### PR TITLE
refactor(keeper_registry): RFC-0072 Phase 4b — turn_phase dispatch via resolver

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1537,105 +1537,32 @@ let validate_cascade_transition ~from ~to_ =
          (cascade_transition_spec_violation_to_tag v))
 ;;
 
+(* RFC-0072 Phase 4b: collapse the 49-pair turn_phase matrix onto
+   [resolve_turn_phase_transition] (PR #14912).  The transition matrix is
+   now a single source of truth in the resolver — this validator becomes a
+   thin compatibility shim wrapped in [Keeper_fsm_guard_runtime.wrap_unit]
+   so the existing metric / observability instrumentation
+   ([metric_fsm_guard_violation], etc.) keeps firing on forbidden pairs.
+   The typed [turn_phase_transition_spec_violation] tag is folded into the
+   [Invalid_argument] message for diagnostic clarity.  Test surface
+   ([test_keeper_sub_fsm_guards.ml] uses [capture_invalid_arg] +
+   [packed_turn_phase_label] needles) is preserved by keeping the function
+   name and label keywords in the message. *)
 let validate_turn_phase_transition ~from ~to_ =
-  let (_ : packed_turn_phase) = from in
-  let (_ : packed_turn_phase) = to_ in
   Keeper_fsm_guard_runtime.wrap_unit
     ~action:"turn_phase_transition"
     ~stage:"guard"
     (fun () ->
-       let valid =
-         match from, to_ with
-         (* from Turn_idle *)
-         | Packed Turn_idle, Packed Turn_idle -> true
-         | Packed Turn_idle, Packed Turn_prompting ->
-           true (* via turn init / prepare_turn_retry_after_compaction *)
-         | Packed Turn_idle, Packed Turn_routing -> false
-         | Packed Turn_idle, Packed Turn_executing -> false
-         | Packed Turn_idle, Packed Turn_compacting -> false
-         | Packed Turn_idle, Packed Turn_finalizing -> false
-         | Packed Turn_idle, Packed Turn_exhausted -> false
-         (* from Turn_prompting *)
-         | Packed Turn_prompting, Packed Turn_idle ->
-           false (* new turn init is reset, not transition *)
-         | Packed Turn_prompting, Packed Turn_prompting -> true
-         | Packed Turn_prompting, Packed Turn_routing ->
-           true (* via set_turn_cascade_state: Cascade_selecting *)
-         | Packed Turn_prompting, Packed Turn_executing -> true (* via set_turn_phase *)
-         | Packed Turn_prompting, Packed Turn_compacting -> false
-         | Packed Turn_prompting, Packed Turn_finalizing ->
-           true (* via mark_turn_gate_rejected_by_name *)
-         | Packed Turn_prompting, Packed Turn_exhausted -> true
-         (* via set_turn_cascade_state: Cascade_exhausted before any cascade attempt (e.g. all candidates filtered out at admission) *)
-         (* from Turn_routing *)
-         | Packed Turn_routing, Packed Turn_idle ->
-           false (* new turn init is reset, not transition *)
-         | Packed Turn_routing, Packed Turn_prompting ->
-           true (* via set_turn_cascade_state: Cascade_idle on retry *)
-         | Packed Turn_routing, Packed Turn_routing -> true
-         | Packed Turn_routing, Packed Turn_executing ->
-           true (* via set_turn_cascade_state: Cascade_trying *)
-         | Packed Turn_routing, Packed Turn_compacting -> false
-         | Packed Turn_routing, Packed Turn_finalizing -> false
-         | Packed Turn_routing, Packed Turn_exhausted -> true
-         (* via set_turn_cascade_state: Cascade_exhausted during model selection (cascade-fallback exhausted before Cascade_trying) *)
-         (* from Turn_executing *)
-         | Packed Turn_executing, Packed Turn_idle ->
-           false (* new turn init is reset, not transition *)
-         | Packed Turn_executing, Packed Turn_prompting ->
-           true (* via set_turn_cascade_state: Cascade_idle retry *)
-         | Packed Turn_executing, Packed Turn_routing ->
-           true (* via set_turn_cascade_state: Cascade_selecting retry *)
-         | Packed Turn_executing, Packed Turn_executing -> true
-         | Packed Turn_executing, Packed Turn_compacting ->
-           true (* via set_turn_phase: retry plan *)
-         | Packed Turn_executing, Packed Turn_finalizing ->
-           true (* via set_turn_cascade_state: Cascade_done *)
-         | Packed Turn_executing, Packed Turn_exhausted ->
-           true (* via set_turn_cascade_state: Cascade_exhausted *)
-         (* from Turn_compacting *)
-         | Packed Turn_compacting, Packed Turn_idle ->
-           false (* new turn init is reset, not transition *)
-         | Packed Turn_compacting, Packed Turn_prompting ->
-           true (* via prepare_turn_retry_after_compaction *)
-         | Packed Turn_compacting, Packed Turn_routing -> false
-         | Packed Turn_compacting, Packed Turn_executing -> false
-         | Packed Turn_compacting, Packed Turn_compacting -> true
-         | Packed Turn_compacting, Packed Turn_finalizing ->
-           true (* via set_turn_phase: compaction failure *)
-         | Packed Turn_compacting, Packed Turn_exhausted ->
-           true (* via set_turn_cascade_state: Cascade_exhausted on terminal error *)
-         (* from Turn_finalizing *)
-         | Packed Turn_finalizing, Packed Turn_idle -> false (* new turn is reset *)
-         | Packed Turn_finalizing, Packed Turn_prompting ->
-           true (* via set_turn_cascade_state: degraded retry Cascade_idle *)
-         | Packed Turn_finalizing, Packed Turn_routing ->
-           true (* via set_turn_cascade_state: degraded retry Cascade_selecting *)
-         | Packed Turn_finalizing, Packed Turn_executing ->
-           true (* via set_turn_cascade_state: degraded retry Cascade_trying *)
-         | Packed Turn_finalizing, Packed Turn_compacting -> false
-         | Packed Turn_finalizing, Packed Turn_finalizing -> true
-         | Packed Turn_finalizing, Packed Turn_exhausted ->
-           true (* via set_turn_cascade_state: Cascade_exhausted on terminal error *)
-         (* from Turn_exhausted *)
-         | Packed Turn_exhausted, Packed Turn_idle -> false (* new turn is reset *)
-         | Packed Turn_exhausted, Packed Turn_prompting ->
-           true (* via prepare_turn_retry_after_compaction: Cascade_idle *)
-         | Packed Turn_exhausted, Packed Turn_routing ->
-           true (* via set_turn_cascade_state: retry Cascade_selecting *)
-         | Packed Turn_exhausted, Packed Turn_executing ->
-           true (* via set_turn_cascade_state: retry Cascade_trying *)
-         | Packed Turn_exhausted, Packed Turn_compacting -> false
-         | Packed Turn_exhausted, Packed Turn_finalizing -> false
-         | Packed Turn_exhausted, Packed Turn_exhausted -> true
-       in
-       if not valid
-       then
-         invalid_arg
-           (Printf.sprintf
-              "validate_turn_phase_transition: invalid transition %s -> %s"
-              (packed_turn_phase_label from)
-              (packed_turn_phase_label to_)))
+      match resolve_turn_phase_transition ~from ~target:to_ with
+      | Resolved_turn_idempotent | Resolved_turn_transition _ -> ()
+      | Resolved_turn_violation v ->
+        invalid_arg
+          (Printf.sprintf
+             "validate_turn_phase_transition: invalid transition %s -> %s \
+              (spec_violation=%s)"
+             (packed_turn_phase_label from)
+             (packed_turn_phase_label to_)
+             (turn_phase_transition_spec_violation_to_tag v)))
 ;;
 
 let set_turn_decision_stage ~base_path name (decision_stage : decision_stage_active) =
@@ -1705,13 +1632,29 @@ let set_turn_cascade_state ~base_path name (cascade_state : packed_cascade_state
 ;;
 
 let set_turn_phase ~base_path name (turn_phase : packed_turn_phase) =
+  (* RFC-0072 Phase 4b: dispatch via [resolve_turn_phase_transition] (PR #14912)
+     instead of the [validate_turn_phase_transition] call.  Mirrors the
+     cascade-side wiring (PR #14908) — idempotent self-loops no longer flip
+     [changed] or emit a broadcast, and forbidden transitions carry the
+     typed [turn_phase_transition_spec_violation] tag in the
+     [Invalid_argument] message. *)
   let changed = ref false in
   let now = Time_compat.now () in
   update_entry ~base_path name (fun e ->
     update_current_turn e (fun obs ->
-      validate_turn_phase_transition ~from:obs.turn_phase ~to_:turn_phase;
-      changed := true;
-      { obs with turn_phase }));
+      match resolve_turn_phase_transition ~from:obs.turn_phase ~target:turn_phase with
+      | Resolved_turn_idempotent -> obs
+      | Resolved_turn_transition _ ->
+        changed := true;
+        { obs with turn_phase }
+      | Resolved_turn_violation v ->
+        invalid_arg
+          (Printf.sprintf
+             "set_turn_phase: forbidden transition %s -> %s \
+              (spec_violation=%s)"
+             (packed_turn_phase_label obs.turn_phase)
+             (packed_turn_phase_label turn_phase)
+             (turn_phase_transition_spec_violation_to_tag v))));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 


### PR DESCRIPTION
## What

RFC-0072 **Phase 4b** — route `validate_turn_phase_transition` and `set_turn_phase` through `resolve_turn_phase_transition` (introduced in PR #14912). Mirrors the cascade-side wiring (PR #14908) for the turn_phase axis. The 49-arm transition matrix collapses to a single source of truth in the resolver.

| Function | Before | After |
|---|---|---|
| `validate_turn_phase_transition` | 49-arm boolean match (`valid = match ... with true/false`) | 3-arm match on `turn_phase_resolve_outcome` |
| `set_turn_phase` | Called `validate_turn_phase_transition` then unconditionally `changed := true` | Direct resolver dispatch; idempotent self-loop short-circuits `changed`; forbidden raises with typed payload |

## Behavior deltas

### 1. Spurious-broadcast efficiency fix

`set_turn_phase` no longer flips `changed := true` for idempotent self-loops (e.g. `Turn_routing → Turn_routing`). Same fix pattern that PR #14908 applied to `set_turn_cascade_state`.

Side benefit: `set_turn_cascade_state` (which calls `validate_turn_phase_transition` internally on `Resolved_transition`) now also passes its turn_phase through the new short-circuit — when `turn_phase_of_cascade_state` returns an unchanged phase, the validator's resolver path returns `Resolved_turn_idempotent` and the broadcast still fires (because `changed` was already set by the cascade transition); but the inner work is reduced.

### 2. Typed payload in error messages

Both call sites now include:
```
validate_turn_phase_transition: invalid transition Turn_idle -> Turn_routing (spec_violation=idle->routing)
set_turn_phase: forbidden transition Turn_idle -> Turn_routing (spec_violation=idle->routing)
```

Existing test `test_invalid_turn_phase_transitions` and `test_turn_phase_message_includes_labels` in `test_keeper_sub_fsm_guards.ml` use `capture_invalid_arg` + `assert_msg_contains` against function-name and label needles — all preserved.

### 3. Single SoT

Adding a new `turn_phase` variant requires editing `resolve_turn_phase_transition` (PR #14912). Both `validate_*` and `set_turn_*` automatically reflect the change. Warning 8 triggers at the resolver if a new variant is omitted.

### 4. `Keeper_fsm_guard_runtime.wrap_unit` preserved

The wrap_unit wrapper around `validate_turn_phase_transition` is preserved — existing `metric_fsm_guard_violation` instrumentation (action="turn_phase_transition", stage="guard") keeps firing on forbidden pairs. Only the inner body changes.

## Diff

| File | + | - | Net |
|---|---|---|---|
| `lib/keeper/keeper_registry.ml` | 40 | 97 | **-57** |

Net **negative** LOC despite combining 2 RFC sub-phases — the 49-arm matrix collapse far outweighs the spec-violation/idempotent infrastructure cost (the latter already landed in PR #14912 Phase 4a).

## Avoiding the #14893 / #14909 regression

PR #14893 introduced `validate_decision_transition` as a Warning-8 tripwire matching on `(packed_decision_stage * packed_decision_stage)`. The `Packed` wrap existentially hides the witness phantom — compiler couldn't see that `decision_stage_active` omits `Decision_undecided` — Warning 8 demanded the unreachable case and broke `dune @check`. #14909 fixed it by switching to a raw `(decision_stage * decision_stage_active)` match.

**This PR avoids that trap**: both `validate_turn_phase_transition` and `set_turn_phase` dispatch on `turn_phase_resolve_outcome` (a typed 3-constructor sum: `Resolved_turn_transition` / `Resolved_turn_idempotent` / `Resolved_turn_violation`). The 3-arm match is non-GADT and trivially exhaustive — no phantom-witness existential, no Warning 8 false-positive risk.

The 49-pair GADT-vs-typed-violation enumeration **already lives in the resolver itself** (PR #14912), where it's a packed-state pair match over `cascade_state` / `turn_phase` — not a Warning-8 tripwire role, just a value-level dispatch.

## Phase 4 cadence (cascade precedent followed)

| Step | Cascade | Turn_phase |
|---|---|---|
| Additive: GADT + resolver | PR #14903 | PR #14912 |
| Wiring: setter + validator | PR #14908 | **#14916 (this PR)** |

## Self-check (Workaround Rejection Bar)

| # | Check | Result |
|---|---|---|
| 1 | telemetry-as-fix? | no — typed error |
| 2 | string classifier? | no — typed GADT + typed sum |
| 3 | N-of-M? | Phase 4b folds `validate_turn_phase_transition` + `set_turn_phase` over same axis through same resolver. Same justification as cascade Phase 2+3 (#14908): splitting produces transient 2-SoT state. |
| 4 | catch-all added? | no — 3-arm exhaustive match in both bodies |
| 5 | cap/cooldown/dedup? | no |
| 6 | test backdoor? | no — message-keyword + label needles preserved |
| 7 | typo N sites? | no |

## R-1 status

RFC-0072 §7 R-1 for turn_phase axis: still **not yet satisfied** (4 `invalid_arg` raises remain in `lib/keeper/keeper_registry.ml`: `validate_cascade_transition`, `set_turn_cascade_state`, `validate_turn_phase_transition`, `set_turn_phase`). All now carry typed payload, the structural prerequisite for migrating to a typed exception variant in a future phase.

## References

- **RFC-0072**: design SSOT
- **PR #14912**: Phase 4a — turn_phase GADT + resolver
- **PR #14908**: cascade Phase 2+3 — template for this PR's wiring shape
- **PR #14903**: cascade Phase 1 — Phase 4a template
- **PR #14887 / #14893**: decision-axis closure
- **PR #14909**: regression fix that informs the GADT-vs-packed-match risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
