### PR TITLE
spec(scripts): document phase-validator false-negative class (follow-up #14891)

### DIFF
--- a/scripts/audit-ocaml-phase-count.sh
+++ b/scripts/audit-ocaml-phase-count.sh
@@ -146,6 +146,22 @@ while IFS= read -r entry; do
   # `(*` / `*` nor contain `*)`.  This is more reliable than the prior
   # left-anchored keyword filter, which let prefixed-whitespace code
   # through and could flag string literals.
+  #
+  # KNOWN LIMITATION (false negative class):
+  # Block comments whose continuation lines lack a leading `*` are not
+  # detected as in-comment by this heuristic.  Example that *would* be
+  # missed:
+  #
+  #     (* The keeper has
+  #        12-phase lifecycle *)
+  #
+  # The middle line ("12-phase lifecycle") does not start with `(*`/`*`
+  # and does not contain `*)`.  Deliberate trade-off — proper detection
+  # requires lexing the full file's comment-span state (this is shell,
+  # not ocaml).  Mitigations: (1) ocamlformat's default prefixes every
+  # continuation line with `*`, which this filter accepts; (2) for
+  # high-stakes audits use the OCaml-side companion validator backed by
+  # `compiler-libs` typed comments (zero false negatives).
   stripped="${content#"${content%%[![:space:]]*}"}"
   case "${stripped}" in
     '(*'*|'(**'*|'*'*) : ;;          # comment open or continuation


### PR DESCRIPTION
## 목적

#14891 (merged) 의 Copilot 리뷰 thread 대응. \`scripts/audit-ocaml-phase-count.sh\` 의 comment-context heuristic 이 block-comment continuation line (leading \`*\` 없는) 을 in-comment 로 인식 못 함 → 그 line 의 phase-count mention 이 silent skip.

스크립트 docstring 이 이미 "intentionally avoids a full OCaml comment-span parser" 라고 명시했으나, *어떤 false-negative class* 인지 명확하지 않았음.

## 변경

\`scripts/audit-ocaml-phase-count.sh\` docstring 에 KNOWN LIMITATION 블록 추가 (comment-only, 로직 변경 0):

- false-negative 예시 명시:
  \`\`\`ocaml
  (* The keeper has
     12-phase lifecycle *)
  \`\`\`
  중간 line ("12-phase lifecycle") 이 \`(*\`/\`*\` 로 시작 안 하고 \`*)\` 도 없어 skip.
- 두 가지 mitigation:
  1. ocamlformat default 가 모든 continuation line 에 \`*\` prefix → 이 filter 가 수용.
  2. high-stakes audit 은 OCaml-side companion validator (compiler-libs typed comments, false negative 0) 사용.

## 검증

- \`bash -n scripts/audit-ocaml-phase-count.sh\` — syntax ok
- comment-only diff, +16/-0

## 왜 별도 PR 인가

#14891 이 squash-merge 후 branch 삭제됨. 메모리 \`feedback_stacked_pr_auto_close_recovery\` — 머지된 PR branch 에 push 금지. origin/main 기준 fresh PR.