### PR TITLE
perf(server): serve GraphiQL/Playground assets via Fs_compat.load_file

### DIFF
--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -182,8 +182,11 @@ let asset_content_type name =
   else
     "application/octet-stream"
 
+(* Static asset bodies (GraphiQL / Playground) served on the HTTP handler
+   fiber.  [Fs_compat.load_file] is Eio-native when the global fs is wired
+   (prod boot), so the file read no longer blocks the whole domain. *)
 let read_file path =
-  try Ok (In_channel.with_open_bin path In_channel.input_all)
+  try Ok (Fs_compat.load_file path)
   with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
 
 let serve_graphiql_asset name _request reqd =

--- a/test/dune
+++ b/test/dune
@@ -1228,6 +1228,7 @@
 (include stanzas/test_governance_cases_snapshot.inc)
 (include stanzas/test_governance_response_model_empty_9880.inc)
 (include stanzas/test_heartbeat_integration.inc)
+(include stanzas/test_http_pages_asset_read.inc)
 (include stanzas/test_heuristic_metrics_diagnostics.inc)
 (include stanzas/test_cascade_toml_materializer_admission.inc)
 (include stanzas/test_heuristic_metrics_scrub.inc)

--- a/test/stanzas/test_http_pages_asset_read.inc
+++ b/test/stanzas/test_http_pages_asset_read.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_http_pages_asset_read)
+ (modules test_http_pages_asset_read)
+ (libraries masc_test_deps))

--- a/test/test_http_pages_asset_read.ml
+++ b/test/test_http_pages_asset_read.ml
@@ -1,0 +1,61 @@
+(** [Server_routes_http_pages.read_file] coverage.
+
+    [read_file] backs GraphiQL / Playground static-asset serving.  It was
+    migrated from [In_channel.with_open_bin path In_channel.input_all] to
+    [Fs_compat.load_file path] so the read is Eio-native (non-blocking on
+    the HTTP handler's domain) when the global fs is wired.  These tests
+    pin the two invariants that migration must preserve:
+    - byte-exact round-trip (asset bundles include binary PNG / woff2);
+    - missing file maps to [Error _] (the handler turns it into 404). *)
+
+open Alcotest
+
+module Pages = Masc_mcp.Server_routes_http_pages
+
+let with_temp_dir f =
+  let dir = Filename.temp_file "masc_http_pages_test" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      Array.iter (fun n -> try Sys.remove (Filename.concat dir n) with _ -> ()) (Sys.readdir dir);
+      try Unix.rmdir dir with _ -> ())
+    (fun () -> f dir)
+;;
+
+let test_read_file_binary_roundtrip () =
+  with_temp_dir (fun dir ->
+    let path = Filename.concat dir "asset.bin" in
+    let payload = String.init 256 Char.chr in
+    Out_channel.with_open_bin path (fun oc -> Out_channel.output_string oc payload);
+    match Pages.read_file path with
+    | Ok body -> check string "byte-exact round-trip" payload body
+    | Error e -> failf "expected Ok, got Error %s" e)
+;;
+
+let test_read_file_empty () =
+  with_temp_dir (fun dir ->
+    let path = Filename.concat dir "empty.css" in
+    Out_channel.with_open_bin path (fun _ -> ());
+    match Pages.read_file path with
+    | Ok body -> check string "empty file" "" body
+    | Error e -> failf "expected Ok, got Error %s" e)
+;;
+
+let test_read_file_missing () =
+  with_temp_dir (fun dir ->
+    let path = Filename.concat dir "does-not-exist.js" in
+    match Pages.read_file path with
+    | Ok _ -> fail "expected Error for missing file"
+    | Error _ -> ())
+;;
+
+let () =
+  run "http_pages_asset_read"
+    [ ( "read_file"
+      , [ test_case "binary round-trip" `Quick test_read_file_binary_roundtrip
+        ; test_case "empty file" `Quick test_read_file_empty
+        ; test_case "missing file -> Error" `Quick test_read_file_missing
+        ] )
+    ]
+;;


### PR DESCRIPTION
## What

`read_file` in `lib/server/server_routes_http_pages.ml` backs the GraphiQL / Playground static-asset routes. It read files with `In_channel.with_open_bin path In_channel.input_all` — a blocking syscall on the HTTP handler fiber's domain, which stalls every other fiber on that domain (other HTTP requests, SSE drain, keeper heartbeat) for the duration of the read.

This swaps it to `Fs_compat.load_file`, which is Eio-native (`Eio.Path.load`) when the global fs is wired at boot (`server_runtime_bootstrap.ml` calls `Fs_compat.set_fs`), and falls back to `Unix` otherwise (tests, pre-boot).

This is the **last bare `In_channel.*` read on an HTTP route handler** (the sidecar / dashboard-runtime-info / TLA-spec sites were migrated earlier).

## Why it's safe

- Whole-file read → string in both paths; `read_file`'s return type and error contract (`(string, string) result`, `Eio.Cancel.Cancelled` re-raised, everything else → `Error`) are unchanged. `Fs_compat.load_file` raises `Sys_error` on I/O failure (Eio.Io normalized internally), which the existing `with` clause catches.
- On Unix (the only platforms masc-mcp targets) `open_in` == `open_in_bin` — no CRLF translation — so the binary asset bundles (PNG, woff2) round-trip byte-exact.
- Same migration was already done at `server_routes_http_routes_sidecar.ml:165`.

## Test

New `test/test_http_pages_asset_read.ml` (`test_http_pages_asset_read.inc` stanza):
- byte-exact round-trip over a 256-byte payload (all `Char.chr 0..255`)
- empty file
- missing file → `Error _`

```
$ dune exec test/test_http_pages_asset_read.exe
  [OK]  read_file  0   binary round-trip.
  [OK]  read_file  1   empty file.
  [OK]  read_file  2   missing file -> Error.
Test Successful in 0.005s. 3 tests run.
```

`dune build lib/` clean.

RFC-WAIVED: 1-line equivalent-preserving swap on an HTTP static-asset route; no credential/identity/operator/sandbox/dashboard-credential/hooks/workflow surface touched.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>