### PR TITLE
feat(config): enable warning 4 on masc_config + close 3 fragile sites (RFC-0071 §3.4)

### DIFF
--- a/lib/config/dune
+++ b/lib/config/dune
@@ -19,4 +19,10 @@
    masc_time_constants
    playground_paths)
  (wrapped false)
+ ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on.
+ ; The one closed-variant fragile site (env_config_oas_bridge.ml's
+ ; legacy_per_caller_env_var) is closed in this PR; the remaining
+ ; catch-all (env_config_runtime.ml string scrutinee) is open-type and
+ ; warning 4 ignores it.
+ (flags (:standard -w +4))
  (libraries masc_core masc_log yojson uri ipaddr unix))

--- a/lib/config/dune
+++ b/lib/config/dune
@@ -20,9 +20,10 @@
    playground_paths)
  (wrapped false)
  ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on.
- ; The one closed-variant fragile site (env_config_oas_bridge.ml's
- ; legacy_per_caller_env_var) is closed in this PR; the remaining
- ; catch-all (env_config_runtime.ml string scrutinee) is open-type and
- ; warning 4 ignores it.
+ ; Closed-variant fragile sites fixed in this PR: env_config_oas_bridge.ml's
+ ; legacy_per_caller_env_var, plus the two Shell_timeout.bucket matches in
+ ; env_config_sandbox.ml (now routed through Shell_timeout.is_floor_bucket,
+ ; itself an exhaustive match). The remaining catch-all (env_config_runtime.ml
+ ; string scrutinee) is open-type and warning 4 ignores it.
  (flags (:standard -w +4))
  (libraries masc_core masc_log yojson uri ipaddr unix))

--- a/lib/config/env_config_oas_bridge.ml
+++ b/lib/config/env_config_oas_bridge.ml
@@ -123,7 +123,14 @@ let per_caller_env_var ~caller =
 let legacy_per_caller_env_var = function
   | Operator_judge -> Some "MASC_OPERATOR_JUDGE_TIMEOUT_SEC"
   | Governance_judge -> Some "MASC_DASHBOARD_GOVERNANCE_JUDGE_TIMEOUT_SEC"
-  | _ -> None
+  | Auto_responder
+  | Dashboard_provider_runs
+  | Autoresearch_codegen
+  | Keeper_persona_authoring
+  | Server_openai_compat
+  | Tool_deep_review
+  | Anti_rationalization -> None
+  | Unknown _ -> None
 ;;
 
 let global_env_var = "MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC"

--- a/lib/config/env_config_sandbox.ml
+++ b/lib/config/env_config_sandbox.ml
@@ -150,6 +150,15 @@ module Shell_timeout = struct
   let known_buckets () =
     [ Io; Read; Git_meta; Gh_min; User_max; Cleanup_rm ]
 
+  (* [Gh_min] is the only read-only floor bucket — see .mli: operators
+     MUST NOT lower it via env (doing so cascades 401 retries, #8688).
+     Exhaustive match (warning 4) so a new bucket forces a deliberate
+     floor/non-floor classification here, once, rather than at every
+     call site that branches on it. *)
+  let is_floor_bucket : bucket -> bool = function
+    | Gh_min -> true
+    | Io | Read | Git_meta | User_max | Cleanup_rm | Unknown _ -> false
+
   let known_default_sec = function
     | Io -> Some 30.0
     | Read -> Some 15.0
@@ -183,12 +192,11 @@ module Shell_timeout = struct
     | None -> None
 
   let timeout_sec ~bucket () =
-    match bucket with
-    | Gh_min ->
+    if is_floor_bucket bucket then
       (* Read-only floor — see .mli.  Operators MUST NOT lower this
          via env; doing so cascades 401 retries (#8688). *)
       15.0
-    | Io | Read | Git_meta | User_max | Cleanup_rm | Unknown _ ->
+    else
       let per_bucket_env = per_bucket_env_var ~bucket in
       match trimmed_value_opt per_bucket_env with
       | Some v ->
@@ -325,9 +333,8 @@ let raw_shell_timeout () : Yojson.Safe.t =
     let key = Shell_timeout.bucket_key b in
     let value = float_v (Shell_timeout.timeout_sec ~bucket:b ()) in
     let entry =
-      match b with
-      | Gh_min -> entry_floor value
-      | Io | Read | Git_meta | User_max | Cleanup_rm | Unknown _ ->
+      if Shell_timeout.is_floor_bucket b then entry_floor value
+      else
         entry_env_overridable
           ~env_var:(Shell_timeout.per_bucket_env_var ~bucket:b)
           value

--- a/lib/config/env_config_sandbox.ml
+++ b/lib/config/env_config_sandbox.ml
@@ -188,7 +188,7 @@ module Shell_timeout = struct
       (* Read-only floor — see .mli.  Operators MUST NOT lower this
          via env; doing so cascades 401 retries (#8688). *)
       15.0
-    | _ ->
+    | Io | Read | Git_meta | User_max | Cleanup_rm | Unknown _ ->
       let per_bucket_env = per_bucket_env_var ~bucket in
       match trimmed_value_opt per_bucket_env with
       | Some v ->
@@ -327,7 +327,7 @@ let raw_shell_timeout () : Yojson.Safe.t =
     let entry =
       match b with
       | Gh_min -> entry_floor value
-      | _ ->
+      | Io | Read | Git_meta | User_max | Cleanup_rm | Unknown _ ->
         entry_env_overridable
           ~env_var:(Shell_timeout.per_bucket_env_var ~bucket:b)
           value


### PR DESCRIPTION
## 목적

RFC-0071 §3.4 Phase 5 ratchet 확장 (#14888/#14894/#14900 후속). `lib/config` sublib 에 `-w +4` 활성화.

## 발견: inventory 가 놓친 fragile site

`-w +4` 켜자 **§1.2 single-line inventory regex 가 못 잡은** closed-variant fragile site 3개가 컴파일러에 의해 노출. 이들은 `| _ ->` 다음에 multi-line 식이 와서 `_ -> false/None/()` 패턴이 아님:

| # | 위치 | scrutinee 타입 | Before | After |
|---|------|---------------|--------|-------|
| 1 | `env_config_oas_bridge.ml:126` | `caller` (10 ctors) | `Operator_judge \| Governance_judge \| _ -> None` | 10 ctor 전부 명시 |
| 2 | `env_config_sandbox.ml:328` | `Shell_timeout.bucket` (7 ctors) | `Gh_min \| _ -> ...` | `Gh_min \| Io \| Read \| Git_meta \| User_max \| Cleanup_rm \| Unknown _` |
| 3 | `env_config_sandbox.ml:191` | 같은 `bucket` | `Gh_min \| _ -> ...` | 동일 fix |

3건 모두 **behavior-preserving** — `_ ->` arm 이 모든 흡수 ctor 에 대해 동일 동작. 명시화로 새 ctor 추가 시 compile error 강제.

`env_config_runtime.ml:343` (string scrutinee) 는 open-type — warning 4 무시.

## 검증

- `dune build --root .` — 3 warning-4 error → 0
- `test_oas_bridge_judge_callers_9629` + `test_masc_oas_bridge_timeout_guard` green
- `env_config_sandbox` 관련 30 tests green

## 시사점

§1.2 의 **1043 count 는 lower bound**. warning 4 는 regex 가 건너뛰는 multi-line `_ ->` arm 도 검출. RFC-0071 §2.1 codemod (.cmt typed AST 읽음) 가 authoritative enumeration.

## 누적

| | sublibs with `-w +4` |
|--|--|
| #14888 | 1 (lib/core, +1 fix) |
| #14894 | 5 |
| #14900 | 15 |
| **본 PR** | **+1 (lib/config, +3 fix)** |
| **누계** | **22** |