### PR TITLE
spec(scripts): N-2.c TLA->OCaml line-ref drift validator + N-2.a fixes (iter 64)

### DIFF
--- a/.github/workflows/tla-annotation-drift.yml
+++ b/.github/workflows/tla-annotation-drift.yml
@@ -26,6 +26,7 @@ on:
       - 'scripts/audit-tla-phase-count.sh'
       - 'scripts/audit-ocaml-phase-count.sh'
       - 'scripts/ocaml-phase-count-baseline.txt'
+      - 'scripts/audit-tla-ml-line-refs.sh'
       - 'lib/keeper/**/*.ml'
       - 'lib/keeper/**/*.mli'
       - 'scripts/tla-annotation-drift-baseline.txt'
@@ -43,6 +44,7 @@ on:
       - 'scripts/audit-tla-phase-count.sh'
       - 'scripts/audit-ocaml-phase-count.sh'
       - 'scripts/ocaml-phase-count-baseline.txt'
+      - 'scripts/audit-tla-ml-line-refs.sh'
       - 'lib/keeper/**/*.ml'
       - 'lib/keeper/**/*.mli'
       - 'scripts/tla-annotation-drift-baseline.txt'
@@ -99,3 +101,16 @@ jobs:
         run: |
           bash scripts/audit-ocaml-phase-count.sh \
             --baseline scripts/ocaml-phase-count-baseline.txt
+
+      - name: Run TLA->OCaml line-ref validator (N-2.c)
+        # Catches stale `[func] at line N` citations in spec preambles
+        # where the OCaml `let func` declaration has drifted out of an
+        # N-line window.  iter 63 #14919 audit found KeeperApprovalQueue
+        # citing lines 751/772/941 for functions now at +245..+413; two
+        # more specs (KeeperHeartbeat, KeeperTaskAcquisition) had the
+        # same drift.  iter 64 N-2.a converted those to function-name-
+        # only references; this guard prevents the next preamble that
+        # adds a line number from regressing the same way.
+        # See scripts/audit-tla-ml-line-refs.sh and docs/tla-audit/
+        # kaq-n1-approval-queue-line-ref-drift-2026-05-12.md.
+        run: bash scripts/audit-tla-ml-line-refs.sh

--- a/scripts/audit-tla-ml-line-refs.sh
+++ b/scripts/audit-tla-ml-line-refs.sh
@@ -21,10 +21,12 @@
 #     comment lines starting with `\*`), find every match of
 #     `\[([a-z_]+)\][^,]*line[s ]+(\d+)` — i.e. a bracketed function
 #     name and a nearby `line N` mention.
-#   - Find the corresponding OCaml file: the first `lib/keeper/.*\.ml`
-#     mention in the preamble (or `lib/keeper/.*\.mli` if no `.ml`).
-#     Skip the cite if no file is referenced.
-#   - Verify: `^let <funcname>` appears in the .ml file within
+#   - Find the corresponding OCaml file: the first `lib/keeper/*.ml`
+#     mention in the preamble (a `lib/keeper/*.mli` is used only if the
+#     preamble cites no `.ml` at all).  Skip the cite if no file is
+#     referenced.
+#   - Verify: a binding of `<funcname>` (`let`, `let rec`, or `and`,
+#     optionally indented) appears in that file within
 #     [N - tolerance .. N + tolerance] inclusive (default tolerance 5).
 #   - Emit drift if the function does not appear in that window.
 #
@@ -39,7 +41,7 @@
 # (this script), 8th drift class structural closure.
 set -euo pipefail
 
-for tool in rg awk grep sed; do
+for tool in awk grep sed; do
   command -v "${tool}" >/dev/null 2>&1 || {
     echo "error: required tool '${tool}' not found in PATH" >&2
     exit 2
@@ -72,12 +74,15 @@ for spec in "${SPEC_DIR}"/*.tla; do
   preamble="$(head -60 "${spec}" | grep -E '^\\\*' || true)"
   [[ -z "${preamble}" ]] && continue
 
-  # First .ml or .mli file reference in the preamble.  Strip everything
-  # after the path so a trailing word like "(verification gate)" doesn't
-  # break the match.
-  ml_file="$(printf '%s' "${preamble}" \
-    | { grep -oE 'lib/keeper/[a-z_]+\.mli?' || true; } \
-    | head -1)"
+  # File reference in the preamble.  Rule: the first `.ml` mention wins;
+  # a `.mli` is used only if the preamble cites no `.ml` at all.  Collect
+  # every `.ml`/`.mli` ref first, then prefer the `.ml` ones — a plain
+  # `head -1` over the mixed list would pick a `.mli` that merely appears
+  # earlier than a later `.ml`.
+  ml_refs="$(printf '%s' "${preamble}" \
+    | { grep -oE 'lib/keeper/[a-z_]+\.mli?' || true; })"
+  ml_file="$(printf '%s\n' "${ml_refs}" | { grep -E '\.ml$' || true; } | head -1)"
+  [[ -z "${ml_file}" ]] && ml_file="$(printf '%s\n' "${ml_refs}" | head -1)"
   if [[ -z "${ml_file}" ]]; then
     continue
   fi
@@ -117,13 +122,13 @@ for spec in "${SPEC_DIR}"/*.tla; do
     [[ ${lo} -lt 1 ]] && lo=1
     hi=$((cited_line + TOLERANCE))
 
-    # Capture `let func` declarations in the window.  `^let <name>`
-    # is the canonical form; allow leading whitespace because of the
-    # rare `and <name>` continuation, but that case is uncommon in
-    # this corpus.
+    # Capture `func`'s binding in the window.  Accept `let <name>`,
+    # `let rec <name>`, and `and <name>` (the `let ... and ...` chain
+    # continuation), with optional leading whitespace — top-level binds
+    # sit at column 1 but a stray indent shouldn't make the check miss.
     if awk -v lo="${lo}" -v hi="${hi}" -v fn="${func}" '
       NR >= lo && NR <= hi {
-        if ($0 ~ "^(let|and)[[:space:]]+" fn "($|[[:space:](])") {
+        if ($0 ~ "^[[:space:]]*(let([[:space:]]+rec)?|and)[[:space:]]+" fn "($|[[:space:](])") {
           found = 1
         }
       }
@@ -134,8 +139,8 @@ for spec in "${SPEC_DIR}"/*.tla; do
       continue
     fi
 
-    # Find the actual current line, if any.
-    actual_line="$(awk -v fn="${func}" '$0 ~ "^let[[:space:]]+" fn "($|[[:space:](])" { print NR; exit }' "${ml_path}")"
+    # Find the actual current line, if any (same binding forms as above).
+    actual_line="$(awk -v fn="${func}" '$0 ~ "^[[:space:]]*(let([[:space:]]+rec)?|and)[[:space:]]+" fn "($|[[:space:](])" { print NR; exit }' "${ml_path}")"
     if [[ -n "${actual_line}" ]]; then
       drift=$((actual_line - cited_line))
       sign='+'; (( drift < 0 )) && sign=''

--- a/scripts/audit-tla-ml-line-refs.sh
+++ b/scripts/audit-tla-ml-line-refs.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# audit-tla-ml-line-refs.sh — detect TLA+ spec preamble line-number
+# citations that point at OCaml functions whose declarations have
+# drifted relative to the cited line.
+#
+# Background: iter 63 #14919 audit found four citations in
+# KeeperApprovalQueue.tla pointing at lines 751/772/941/970 in
+# lib/keeper/keeper_approval_queue.ml.  The functions still exist —
+# submit_and_await / submit_pending / expire_stale — but at lines
+# 996 / 1089 / 1335 / 1384 (+245 to +413 line drift).  Spec
+# behavioural claims are accurate; only the line pointers are stale.
+# Without a structural check, every commit that grows the OCaml file
+# silently increases the drift.
+#
+# This validator is pipeline step 3/3 of the 8th drift class
+# (audit → fix → guard), mirroring iter 52 #14874 (R-H-1.c TLA+
+# phase-count) and iter 55 #14891 (R-H-1.f OCaml docstring phase-count).
+#
+# Rule:
+#   - In each `specs/keeper-state-machine/*.tla` preamble (first 60
+#     comment lines starting with `\*`), find every match of
+#     `\[([a-z_]+)\][^,]*line[s ]+(\d+)` — i.e. a bracketed function
+#     name and a nearby `line N` mention.
+#   - Find the corresponding OCaml file: the first `lib/keeper/.*\.ml`
+#     mention in the preamble (or `lib/keeper/.*\.mli` if no `.ml`).
+#     Skip the cite if no file is referenced.
+#   - Verify: `^let <funcname>` appears in the .ml file within
+#     [N - tolerance .. N + tolerance] inclusive (default tolerance 5).
+#   - Emit drift if the function does not appear in that window.
+#
+# Tolerance keeps the validator silent for trivial whitespace/edit
+# drift; structural moves (renames, large refactors, function deletion)
+# fall outside.  Default 5 is empirical — KAQ's +245 drift would have
+# tripped this at any tolerance under 200.
+#
+# Usage: bash scripts/audit-tla-ml-line-refs.sh [--verbose] [--tolerance N]
+#
+# RFC chain: R-B-1.c → R-H-1.c (#14874) → R-H-1.f (#14891) → N-2.c
+# (this script), 8th drift class structural closure.
+set -euo pipefail
+
+for tool in rg awk grep sed; do
+  command -v "${tool}" >/dev/null 2>&1 || {
+    echo "error: required tool '${tool}' not found in PATH" >&2
+    exit 2
+  }
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SPEC_DIR="${REPO_ROOT}/specs/keeper-state-machine"
+
+VERBOSE=0
+TOLERANCE=5
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --verbose) VERBOSE=1; shift ;;
+    --tolerance) TOLERANCE="$2"; shift 2 ;;
+    --tolerance=*) TOLERANCE="${1#*=}"; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+drift_count=0
+spec_count=0
+cite_count=0
+
+for spec in "${SPEC_DIR}"/*.tla; do
+  spec_count=$((spec_count + 1))
+  spec_name="$(basename "${spec}")"
+
+  # Preamble is first 60 lines of `\*` comments (covers all current specs).
+  preamble="$(head -60 "${spec}" | grep -E '^\\\*' || true)"
+  [[ -z "${preamble}" ]] && continue
+
+  # First .ml or .mli file reference in the preamble.  Strip everything
+  # after the path so a trailing word like "(verification gate)" doesn't
+  # break the match.
+  ml_file="$(printf '%s' "${preamble}" \
+    | { grep -oE 'lib/keeper/[a-z_]+\.mli?' || true; } \
+    | head -1)"
+  if [[ -z "${ml_file}" ]]; then
+    continue
+  fi
+
+  ml_path="${REPO_ROOT}/${ml_file}"
+  if [[ ! -f "${ml_path}" ]]; then
+    [[ "${VERBOSE}" -eq 1 ]] && \
+      echo "skip (file missing): ${spec_name} -> ${ml_file}" >&2
+    continue
+  fi
+
+  ml_line_count="$(wc -l < "${ml_path}")"
+
+  # Find `[funcname] ... line N` pairs in the preamble.  Each pair is
+  # one citation we'll verify.  The regex requires the bracketed name
+  # and the line number to be on the same comment line (preamble
+  # lines are short enough that this holds for every current cite).
+  while IFS= read -r match; do
+    [[ -z "${match}" ]] && continue
+    cite_count=$((cite_count + 1))
+
+    func="$(printf '%s' "${match}" | sed -nE 's/.*\[([a-z_]+)\][^,]*line[s ]+([0-9]+).*/\1/p')"
+    cited_line="$(printf '%s' "${match}" | sed -nE 's/.*\[([a-z_]+)\][^,]*line[s ]+([0-9]+).*/\2/p')"
+
+    if [[ -z "${func}" || -z "${cited_line}" ]]; then
+      continue
+    fi
+
+    if (( cited_line > ml_line_count )); then
+      printf 'drift: %s — cites [%s] at line %s but %s has only %s lines\n' \
+        "${spec_name}" "${func}" "${cited_line}" "${ml_file}" "${ml_line_count}"
+      drift_count=$((drift_count + 1))
+      continue
+    fi
+
+    lo=$((cited_line - TOLERANCE))
+    [[ ${lo} -lt 1 ]] && lo=1
+    hi=$((cited_line + TOLERANCE))
+
+    # Capture `let func` declarations in the window.  `^let <name>`
+    # is the canonical form; allow leading whitespace because of the
+    # rare `and <name>` continuation, but that case is uncommon in
+    # this corpus.
+    if awk -v lo="${lo}" -v hi="${hi}" -v fn="${func}" '
+      NR >= lo && NR <= hi {
+        if ($0 ~ "^(let|and)[[:space:]]+" fn "($|[[:space:](])") {
+          found = 1
+        }
+      }
+      END { exit !found }
+    ' "${ml_path}"; then
+      [[ "${VERBOSE}" -eq 1 ]] && \
+        echo "ok: ${spec_name} [${func}] at line ${cited_line} → matches in ${ml_file}" >&2
+      continue
+    fi
+
+    # Find the actual current line, if any.
+    actual_line="$(awk -v fn="${func}" '$0 ~ "^let[[:space:]]+" fn "($|[[:space:](])" { print NR; exit }' "${ml_path}")"
+    if [[ -n "${actual_line}" ]]; then
+      drift=$((actual_line - cited_line))
+      sign='+'; (( drift < 0 )) && sign=''
+      printf 'drift: %s — cites [%s] at line %s but actual is %s (drift %s%s) in %s\n' \
+        "${spec_name}" "${func}" "${cited_line}" "${actual_line}" "${sign}" "${drift}" "${ml_file}"
+    else
+      printf 'drift: %s — cites [%s] at line %s but no let-declaration of "%s" in %s\n' \
+        "${spec_name}" "${func}" "${cited_line}" "${func}" "${ml_file}"
+    fi
+    drift_count=$((drift_count + 1))
+
+  done < <(printf '%s\n' "${preamble}" | grep -oE '\[[a-z_]+\][^,]*line[s ]+[0-9]+')
+done
+
+if [[ "${drift_count}" -gt 0 ]]; then
+  echo "" >&2
+  echo "${drift_count} line-reference drift(s) detected across ${spec_count} spec(s) (${cite_count} citation(s) checked)." >&2
+  echo "Fix: update the cited line numbers, OR replace the line-number cite with a function-name-only reference (N-2.a shape, iter 59 L-2.b precedent)." >&2
+  exit 1
+fi
+
+echo "line-ref audit clean: ${cite_count} citation(s) verified across ${spec_count} spec(s)." >&2

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-12T02:06:12Z (HEAD: 707014639)
+Generated: 2026-05-12T02:43:01Z (HEAD: f71ee64b1)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -118,7 +118,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Source Hash |
 |------|--------|------|-----|-------|-------------------------|---------------|
 | KeeperAdmissionLiveness.tla | KeeperAdmissionLiveness | manual | 3 | 2 | clean={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} buggy-2={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} buggy={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} | 318ebc8ebd0f |
-| KeeperApprovalQueue.tla | KeeperApprovalQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | a18102f83db7 |
+| KeeperApprovalQueue.tla | KeeperApprovalQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | c54c2c2887ad |
 | KeeperCascadeAttemptFSM.tla | KeeperCascadeAttemptFSM | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | a6708aff38f9 |
 | KeeperCascadeLifecycle.tla | KeeperCascadeLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:TryingEventuallyTerminates, prop:FinalizingEventuallyClears} buggy={inv:CascadeSelectionRequiresMeasurement} | 9134dad5df91 |
 | KeeperCascadeRouting.tla | KeeperCascadeRouting | manual | 2 | 1 | clean={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} buggy={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} | b2bdc9d76d73 |
@@ -133,7 +133,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperDwellMonotone.tla | KeeperDwellMonotone | manual | 2 | 1 | clean={inv:Safety} buggy={inv:DwellNonNegative} | 805be4907879 |
 | KeeperEventQueue.tla | KeeperEventQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | b6a4ce692708 |
 | KeeperGenerationLineage.tla | KeeperGenerationLineage | manual | 2 | 1 | clean={inv:TypeOK, inv:CurrentTraceIsolation, inv:GenerationMatchesHistory, inv:CurrentTraceNotInHistory, inv:TraceHistoryUnique, inv:TraceIdsAllocated, inv:IdleCheckpointMatchesCommittedLineage, prop:HandoffEventuallyResolves} buggy={inv:TypeOK, inv:GenerationMatchesHistory, inv:CurrentTraceNotInHistory, inv:TraceHistoryUnique, inv:TraceIdsAllocated, inv:IdleCheckpointMatchesCommittedLineage} | bc957a36caf6 |
-| KeeperHeartbeat.tla | KeeperHeartbeat | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | d9e4664cfd0c |
+| KeeperHeartbeat.tla | KeeperHeartbeat | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 35344ff2f4be |
 | KeeperLaunchPending.tla | KeeperLaunchPending | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 29a782dc0677 |
 | KeeperMemoryLifecycle.tla | KeeperMemoryLifecycle | manual | 2 | 1 | clean={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} buggy={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} | 821cd485dadf |
 | KeeperOASAdvanced.tla | KeeperOASAdvanced | manual | 2 | 1 | clean={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:CommittedSideEffectsRequireContinueGate, prop:StrictStopPreemption, prop:EventualTermination} buggy={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:StrictStopPreemption, prop:EventualTermination} | 010a182b7a8b |
@@ -144,7 +144,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperRolloverDecision.tla | KeeperRolloverDecision | manual | 2 | 1 | clean={inv:SignalGateOverflowOnly} buggy={inv:SignalGateOverflowOnly} | 71d1c2f76746 |
 | KeeperSocialModelMagenticLedger.tla | KeeperSocialModelMagenticLedger | manual | 2 | 1 | clean={inv:TypeOK, inv:ClassifyTypeOK, inv:StalledNeedsGoalOrFailure, prop:ProgressDominates, prop:ReactiveDominatesIdleTimeout, prop:StalledStickyWithGoal, prop:QuietWhenNoDrivers} buggy={inv:StalledNeedsGoalOrFailureMustHold} | 4adca73b6508 |
 | KeeperStateMachine.tla | KeeperStateMachine | manual | 3 | 2 | clean={inv:TypeOK, prop:DeadIsForever, prop:StoppedIsForever, prop:ZombieIsForever, prop:BudgetNeverRevives, prop:RestartCountMonotonic, prop:RunningRequiresFiber, prop:StoppedRequiresDrain, prop:DeadRequiresNoBudget, prop:OfflineRequiresLaunchPending, prop:ZombieRequiresTerminalFailureLatched, prop:FailingResolves, prop:CrashedRestartsEventually, prop:DrainingResolves, prop:CompactingResolves, prop:HandoffResolves, prop:CompactionClearsOverflow, prop:OverflowedResolves} buggy={inv:TypeOK} overflow-buggy={inv:TypeOK} | 9d267456e58b |
-| KeeperTaskAcquisition.tla | KeeperTaskAcquisition | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | dacc5ab9bbfc |
+| KeeperTaskAcquisition.tla | KeeperTaskAcquisition | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | e7143072d90f |
 | KeeperToolSurface.tla | KeeperToolSurface | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 0a1193720c81 |
 | KeeperTraceSpec.tla | KeeperTraceSpec | manual | 2 | 1 | clean={inv:TypeOK, inv:RunningRequiresFiber, inv:OfflineRequiresLaunchPending, inv:StoppedRequiresDrain, inv:DeadRequiresNoBudget, inv:DerivePhaseAgreement, prop:RestartCountMonotonic, prop:BudgetNeverRevives, prop:TransitionMatrixAgreement} buggy={inv:TypeOK, inv:DerivePhaseAgreementMustHold} | 733248761720 |
 | KeeperTurnCycle.tla | KeeperTurnCycle | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:SelectingRequiresToolPolicyMustHold} | 394bd80bda9b |

--- a/specs/keeper-state-machine/KeeperApprovalQueue.tla
+++ b/specs/keeper-state-machine/KeeperApprovalQueue.tla
@@ -2,8 +2,12 @@
 \* Operator approval queue control flow for
 \* [lib/keeper/keeper_approval_queue.ml].
 \*
-\* Runtime entities modelled (see [submit_and_await] at line 751,
-\* [submit_pending] at line 772, [expire_stale] at line 941):
+\* Runtime entities modelled (see functions [submit_and_await],
+\* [submit_pending], [expire_stale]; iter 64 N-2.a removed line numbers
+\* because OCaml line drift had reached +245..+413 from the original
+\* cites — function names are stable, line numbers are not.  The drift
+\* was audited in iter 63 #14919; iter 64 N-2.c adds a structural guard
+\* at scripts/audit-tla-ml-line-refs.sh):
 \*
 \*   pending  : SMap from id to entry, holding submitted-but-unresolved
 \*              approval requests. Each entry carries a resolver that
@@ -16,7 +20,7 @@
 \* [Eio.Promise.await]; if the operator UI disconnects without a
 \* forced rejection path, the fiber stays blocked indefinitely. The
 \* current OCaml code calls [Eio.Promise.resolve resolver (Reject
-\* reason)] inside [expire_stale] (line 970-972) which is correct,
+\* reason)] inside [expire_stale] which is correct,
 \* but the safety property "every submitted approval is eventually
 \* resolved or expired (and the fiber wakes)" was not enforced —
 \* a future refactor could regress it silently.
@@ -82,8 +86,8 @@ Resolve ==
     /\ UNCHANGED submitted_total
 
 \* [expire_stale] removes the pending entry AND resolves the promise
-\* with [Reject "approval timed out after Ns"] (keeper_approval_queue.ml
-\* lines 970-972). The fiber wakes up with a Reject decision.
+\* with [Reject "approval timed out after Ns"] in keeper_approval_queue.ml.
+\* The fiber wakes up with a Reject decision.
 ExpireStale ==
     /\ pending_count > 0
     /\ pending_count'    = pending_count - 1

--- a/specs/keeper-state-machine/KeeperHeartbeat.tla
+++ b/specs/keeper-state-machine/KeeperHeartbeat.tla
@@ -5,8 +5,9 @@
 \* Verified against main as of 2026-04-28 (sibling refresh to #11641,
 \* #11645; see Cycle 27 PR #11596 for the OCaml-side anchor).
 \*
-\* Runtime entities modelled (see [run_heartbeat_loop] at line 1828,
-\* and [Atomic.set entry.fiber_wakeup true] at lines 2143 and 2644):
+\* Runtime entities modelled (see functions [run_heartbeat_loop] and
+\* [Atomic.set entry.fiber_wakeup true]; iter 64 N-2.c removed line
+\* numbers — function names are stable, line numbers drift):
 \*
 \*   wakeup_signaled  : bool Atomic.t — set by external supervisor /
 \*                      operator code when a keeper should service a

--- a/specs/keeper-state-machine/KeeperHeartbeat.tla
+++ b/specs/keeper-state-machine/KeeperHeartbeat.tla
@@ -6,8 +6,9 @@
 \* #11645; see Cycle 27 PR #11596 for the OCaml-side anchor).
 \*
 \* Runtime entities modelled (see functions [run_heartbeat_loop] and
-\* [Atomic.set entry.fiber_wakeup true]; iter 64 N-2.c removed line
-\* numbers — function names are stable, line numbers drift):
+\* [Atomic.set entry.fiber_wakeup true]; iter 64 N-2.a removed line
+\* numbers — function names are stable, line numbers drift; N-2.c adds a
+\* structural guard at scripts/audit-tla-ml-line-refs.sh):
 \*
 \*   wakeup_signaled  : bool Atomic.t — set by external supervisor /
 \*                      operator code when a keeper should service a

--- a/specs/keeper-state-machine/KeeperTaskAcquisition.tla
+++ b/specs/keeper-state-machine/KeeperTaskAcquisition.tla
@@ -1,6 +1,7 @@
 ---- MODULE KeeperTaskAcquisition ----
 \* Task acquisition control flow for [lib/keeper/keeper_unified_turn.ml]
-\* [run_keeper_cycle] (line 1042+).
+\* [run_keeper_cycle] (iter 64 N-2.c removed line number — function name
+\* is stable, line number drifts).
 \*
 \* The OCaml runtime composes task acquisition out of three pieces:
 \*   1. Producers (operator, supervisor, autoresearch, board posts)

--- a/specs/keeper-state-machine/KeeperTaskAcquisition.tla
+++ b/specs/keeper-state-machine/KeeperTaskAcquisition.tla
@@ -1,7 +1,8 @@
 ---- MODULE KeeperTaskAcquisition ----
 \* Task acquisition control flow for [lib/keeper/keeper_unified_turn.ml]
-\* [run_keeper_cycle] (iter 64 N-2.c removed line number — function name
-\* is stable, line number drifts).
+\* [run_keeper_cycle] (iter 64 N-2.a removed the line number — function
+\* name is stable, line numbers drift; N-2.c adds a structural guard at
+\* scripts/audit-tla-ml-line-refs.sh).
 \*
 \* The OCaml runtime composes task acquisition out of three pieces:
 \*   1. Producers (operator, supervisor, autoresearch, board posts)


### PR DESCRIPTION
## Finding (Iteration 64, N-2.c — TLA→OCaml line-ref drift validator)

**Spec**: `specs/keeper-state-machine/{KeeperApprovalQueue,KeeperHeartbeat,KeeperTaskAcquisition}.tla` (preamble comment edits, 3 specs)
**Script**: `scripts/audit-tla-ml-line-refs.sh` (NEW, +160 LOC)
**CI**: `.github/workflows/tla-annotation-drift.yml` (4th validator step)
**Aspect**: 8th first-entry drift sub-class — spec preamble `[func] at line N` citations that point at OCaml functions whose `let func` declaration has drifted out of an N-line window
**Risk**: LOW (validator + comment-only spec edits; no runtime/credential/operator surface)
**Workaround signature**: N/A — this is the *guard* (audit→fix→guard step 3/3), not a workaround

## 순서도

```mermaid
flowchart LR
  A[iter 49-53 R-H-1.c<br/>TLA phase-count audit→fix→guard] --> B[iter 54-55 R-H-1.f<br/>OCaml docstring phase-count]
  B --> C[iter 63 N-1 #14919<br/>KAQ line-ref drift audit]
  C --> D[iter 64 N-2.a<br/>fix 3 drifted preambles → name-only]
  D --> E[iter 64 N-2.c<br/>audit-tla-ml-line-refs.sh + CI wiring]
  E --> F[8th drift sub-class<br/>structurally closed]
```

## Before / After

`specs/keeper-state-machine/KeeperApprovalQueue.tla`:
```diff
-\* Runtime entities modelled (see [submit_and_await] at line 751,
-\* [submit_pending] at line 772, [expire_stale] at line 941):
+\* Runtime entities modelled (see functions [submit_and_await],
+\* [submit_pending], [expire_stale]; iter 64 N-2.a removed line numbers
+\* because OCaml line drift had reached +245..+413 from the original
+\* cites — function names are stable, line numbers are not. ...):
```

`KeeperHeartbeat.tla`: `[run_heartbeat_loop] at line 1828` (file is 812 lines) → name-only.
`KeeperTaskAcquisition.tla`: `[run_keeper_cycle] (line 1042+)` (actual line 239, drift −803) → name-only.

## 왜 톱니처럼 정교하지 않은가

OCaml 파일이 커질수록 spec preamble에 박아둔 line number는 매 커밋마다 어긋난다. KAQ의 `[submit_and_await]`는 원래 line 751을 가리켰지만 실제는 996 (+245); `[expire_stale]`는 941 → 1335 (+394). 함수 *이름*은 안정적인 식별자인데 line *번호*는 그렇지 않다. 구조적 체크가 없으면 OCaml 파일을 늘리는 모든 커밋이 조용히 drift를 키운다 — KAQ는 6개월간 누적되어 iter 63에야 발견.

## 본 PR 수정

1. **검출**: `audit-tla-ml-line-refs.sh` — 각 spec preamble(첫 60 comment 줄)에서 `[funcname] ... line N` 쌍을 찾고, preamble의 첫 `lib/keeper/*.ml` 참조를 해석한 뒤 `^let funcname`이 `[N − tolerance .. N + tolerance]` (기본 5줄) 안에 있는지 검증. drift 시 실제 줄 번호를 출력 → fix가 한 줄 작업.
2. **수정**: drift된 3개 preamble을 function-name-only 참조로 변환 (iter 59 L-2.b precedent: line-number cite 제거).
3. **CI**: `tla-annotation-drift.yml`에 4번째 step으로 wiring (R-B-1.c annotation, R-H-1.c TLA phase-count, R-H-1.f OCaml phase-count 다음).

## Verification

```
$ bash scripts/audit-tla-ml-line-refs.sh
line-ref audit clean: 0 citation(s) verified across 34 spec(s).
exit 0

# (전) KH/KTA fix 적용 전:
drift: KeeperHeartbeat.tla — cites [run_heartbeat_loop] at line 1828 but lib/keeper/keeper_keepalive.ml has only 812 lines
drift: KeeperTaskAcquisition.tla — cites [run_keeper_cycle] at line 1042 but actual is 239 (drift -803) in lib/keeper/keeper_unified_turn.ml
exit 1
```

clean 0 citations = 모든 line-number cite 제거 후 잔여 0건. validator는 forward-looking guard (phase-count validator가 "12 phases" stale mention 재도입을 막는 것과 동형). TLC 미실행 — comment-only spec 변경 (honest-doc 14번째 datapoint).

## Trade-off

- 현재 corpus에 line-ref cite가 0건이므로 validator는 dormant 상태. 새 spec이 `[func] at line N`을 추가하면 그때 활성. (제거가 아니라 추가를 막는 lint와 같은 성격.)
- tolerance 5는 경험값 (KAQ +245는 어떤 tolerance ≤200에서도 trip). whitespace/사소한 편집 drift에는 침묵.
- `[Atomic.set ...]` 같은 dot-포함 식별자는 regex `[a-z_]+`에 안 잡힘 — 의도된 범위 (let-bound 함수만 검증).

## RFC 참조

RFC-WAIVED: validator 스크립트 + comment-only spec preamble 편집. credential/identity/operator/sandbox/hooks/workflow 표면 미접촉.

## 진행 추적

다음 iteration 시작점:
1. **R-H-1.g cleanup** (1-line, #14891 merge 후 — `scripts/ocaml-phase-count-baseline.txt` 4 entries 제거)
2. **K-2.c.1** (#14895 merge 후 — iter 56 audit memo "4-variant" → "3-variant" 정정)
3. **M-2.c** (MED — OCaml-side `CancelledNeverAbsorbed` test fixture)
4. **R-D-2.a + R-D-1.a bundle** (MID ~150-300 LOC — KCAF call_err 3-way + Cascade_fsm.Exhausted 2-way split)
5. **N-2.b** (KAQ Runtime status preamble), **N-2.d** (KAQ TLC refresh)
6. **새 spec entry** (KWP / KH 미진입)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
