### PR TITLE
fix(keeper): restore fsm_guard_violation counter on set_turn_phase reject

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1650,13 +1650,30 @@ let set_turn_phase ~base_path name (turn_phase : packed_turn_phase) =
         changed := true;
         { obs with turn_phase }
       | Resolved_turn_violation v ->
-        invalid_arg
-          (Printf.sprintf
-             "set_turn_phase: forbidden transition %s -> %s \
-              (spec_violation=%s)"
-             (packed_turn_phase_label obs.turn_phase)
-             (packed_turn_phase_label turn_phase)
-             (turn_phase_transition_spec_violation_to_tag v))));
+        (* Route the [invalid_arg] through [wrap_unit] so the guard's
+           Prometheus counter [metric_fsm_guard_violation]
+           (action=turn_phase_transition, stage=guard) keeps firing for
+           forbidden transitions reached via this setter.  Prior to
+           RFC-0072 Phase 4b (#14918), [set_turn_phase] called
+           [validate_turn_phase_transition] — itself wrapped — so the
+           instrumentation was transitive; the resolver swap dropped it.
+           wrap_unit bumps the counter and re-raises the same
+           [Invalid_argument], preserving the
+           [packed_turn_phase_label] / [spec_violation] message format.
+           The trailing [obs] is unreachable (and a no-op transition is
+           the correct fallback should wrap_unit ever return). *)
+        Keeper_fsm_guard_runtime.wrap_unit
+          ~action:"turn_phase_transition"
+          ~stage:"guard"
+          (fun () ->
+            invalid_arg
+              (Printf.sprintf
+                 "set_turn_phase: forbidden transition %s -> %s \
+                  (spec_violation=%s)"
+                 (packed_turn_phase_label obs.turn_phase)
+                 (packed_turn_phase_label turn_phase)
+                 (turn_phase_transition_spec_violation_to_tag v)));
+        obs));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 


### PR DESCRIPTION
## Summary

Follow-up to merged #14918 (RFC-0072 Phase 4b). A Copilot review finding on that PR was valid but landed after merge.

`set_turn_phase` was swapped from `validate_turn_phase_transition` to `resolve_turn_phase_transition`. The validator is wrapped in `Keeper_fsm_guard_runtime.wrap_unit` — forbidden transitions reached via this setter incremented `metric_fsm_guard_violation` (`action=turn_phase_transition`, `stage=guard`) transitively. The resolver swap dropped that: `Invalid_argument` from `set_turn_phase` is now uninstrumented.

## Change

`lib/keeper/keeper_registry.ml` — wrap the resolver's `Resolved_turn_violation` branch in `wrap_unit`:
- counter fires on forbidden transitions again
- same `Invalid_argument` re-raises with the unchanged `packed_turn_phase_label` / `spec_violation` message format (test needles preserved)
- trailing `obs` is unreachable (no-op transition is the correct fallback should `wrap_unit` ever return)

Diff: 1 file, +24 / -7.

## Verification

- Local `dune build --root . @check` (running; will report)
- No wire/schema change. The `Invalid_argument` message string is byte-identical.
- The only behavioural delta: `metric_fsm_guard_violation{action="turn_phase_transition",stage="guard"}` increments on `set_turn_phase` rejections, matching pre-#14918 behaviour.

RFC-WAIVED: instrumentation restore for an already-RFC'd subsystem (RFC-0072 Phase 4b); no new design surface.