### PR TITLE
docs(tla-audit): K-2.c.1 correct KAL audit memo — OCaml decision is 3-variant not 4 (iter 66)

### DIFF
--- a/docs/tla-audit/kal-k1-admission-spec-ocaml-mapping-2026-05-12.md
+++ b/docs/tla-audit/kal-k1-admission-spec-ocaml-mapping-2026-05-12.md
@@ -65,9 +65,22 @@ These are call-outs for follow-up PRs, **not** fixes in this audit.
    The spec comment around `Fairness` notes that `TryDispatch` must be *strongly* fair (not just weakly): "TLC 6243-state counter-example confirmed this 2026-05-05". OCaml side has no retry-with-bounded-backoff loop matching SF. Today this is invisible because the dormant path doesn't admit; on activation, a hostile burst of `Refill`/`Complete` interleaving could starve a keeper indefinitely.
    *Suggested fix-PR*: `K-2.b` — define and test a bounded-retry policy in `keeper_admission_router.ml`. Cross-reference TLC counter-example referenced in the spec comment for the test fixture.
 
-3. **Five-state vs seven-state status enumeration (LOW)**
-   Spec uses `{"Idle", "Waiting", "Dispatched", "Working", "Done"}`. OCaml admission policy result type uses a different enumeration: `{ Dispatch_immediate p; Enqueue_overflow; Bypass_admission; Capacity_exhausted }`. The mapping is implicit ("Dispatch_immediate" subsumes both spec `TryDispatch` *and* `StartWork`). This is acceptable as an abstraction but should be documented in the OCaml `.mli`, because today the abstraction relationship is reconstructed only by reading both files in parallel.
-   *Suggested fix-PR*: `K-2.c` — add OCaml `.mli` comment block citing this spec's mapping table. 6th drift class precedent — this is the same shape as `iter 47 KCtxL doc-layer drift`.
+3. **5-element spec state set vs 3-variant OCaml `decision` (LOW)**
+
+   > **Correction (iter 66, K-2.c.1)** — the original wording of this item
+   > said the OCaml result type was a 4-variant enum
+   > `{ Dispatch_immediate p; Enqueue_overflow; Bypass_admission; Capacity_exhausted }`.
+   > That was speculative and wrong: `rg 'Dispatch_immediate|Enqueue_overflow|Bypass_admission' lib/`
+   > returns 0 matches. The actual type is
+   > `lib/keeper/keeper_admission_router.mli` `type decision = Dispatch of {…} | Wait | Surface of surface_reason`
+   > — **three** variants. (`Capacity_exhausted` exists, but as a Prometheus
+   > *event* name in `keeper_admission_policy.mli`, not a decision constructor.)
+   > Discovered while implementing K-2.c in iter 60 #14906; this paragraph
+   > is the K-2.c.1 follow-up that fixes the audit memo's record. The
+   > corrected mapping was already written into the `.mli` by #14906.
+
+   The spec's `keeper_state` is a 5-element set `{"Idle", "Waiting", "Dispatched", "Working", "Done"}` modelling the keeper's lifecycle *position*. The OCaml `type decision` is a different kind of thing — the result of one `schedule` call — with 3 variants `Dispatch | Wait | Surface`. The mapping is one-to-many in time (one `Dispatch` covers the spec's `TryDispatch` *and* `StartWork` transitions) and was implicit until #14906 added the `.mli` block. This is acceptable as an abstraction but needed documenting because the relationship was reconstructed only by reading both files in parallel.
+   *Fix-PR (DONE)*: `K-2.c` — `.mli` comment block citing this spec's mapping table, merged as #14906 (iter 60). 6th drift class precedent — same shape as `iter 47 KCtxL doc-layer drift`.
 
 4. **Dormancy not visible from the spec (LOW)**
    The spec preamble lists invariants I1–I5 with no acknowledgement that the runtime does not yet apply them. A new contributor reading only the spec would assume `MASC_ADMISSION_USE_NEW` is on. Spec comment should add a "Status: design ground, runtime dormant pending `MASC_ADMISSION_USE_NEW=1` activation; see RFC-0026 PR-E-1.6" line.


### PR DESCRIPTION
## Finding (Iteration 66, K-2.c.1 — correct KAL audit memo's fabricated decision-type claim)

**File**: `docs/tla-audit/kal-k1-admission-spec-ocaml-mapping-2026-05-12.md` (item 3 + heading + fix-PR status)
**Aspect**: an audit memo (iter 56 #14895) recorded a *speculative* constructor list as if it were observed; the names don't exist in `lib/`
**Risk**: LOW (docs/tla-audit/ memo only)
**Workaround signature**: N/A — this *removes* a fabricated claim before it propagates

## 순서도

```mermaid
flowchart LR
  A[iter 56 #14895<br/>KAL K-1 audit memo<br/>item 3: claims 4-variant enum<br/>Dispatch_immediate/Enqueue_overflow/...] --> B[iter 60 #14906<br/>K-2.c .mli mapping block<br/>rg verify → actual is 3-variant<br/>Dispatch/Wait/Surface]
  B --> C[K-2.c.1 follow-up queued<br/>in #14906 body]
  C --> D[iter 66 this PR<br/>correct the audit memo record]
```

## Before / After

```diff
-3. **Five-state vs seven-state status enumeration (LOW)**
-   Spec uses `{"Idle", "Waiting", "Dispatched", "Working", "Done"}`. OCaml admission
-   policy result type uses a different enumeration:
-   `{ Dispatch_immediate p; Enqueue_overflow; Bypass_admission; Capacity_exhausted }`. ...
+3. **5-element spec state set vs 3-variant OCaml `decision` (LOW)**
+   > **Correction (iter 66, K-2.c.1)** — the original wording said the OCaml result
+   > type was a 4-variant enum `{ Dispatch_immediate p; ... }`. That was speculative
+   > and wrong: `rg 'Dispatch_immediate|Enqueue_overflow|Bypass_admission' lib/` → 0
+   > matches. The actual type is `type decision = Dispatch of {…} | Wait | Surface of
+   > surface_reason` — three variants. ...
+   The spec's `keeper_state` is a 5-element set ... The OCaml `type decision` is a
+   different kind of thing — the result of one `schedule` call — with 3 variants ...
+   *Fix-PR (DONE)*: `K-2.c` — merged as #14906 (iter 60).
```

## 왜 톱니처럼 정교하지 않은가

Audit memo는 코드의 권위 있는 기록이 아니라 *작성 시점의 관찰*이다. iter 56 memo는 `keeper_admission_router.mli`의 `type decision`을 직접 열어보지 않고 "policy result type uses ... `{ Dispatch_immediate p; Enqueue_overflow; Bypass_admission; Capacity_exhausted }`"라고 적었다 — 이 4개 생성자 이름 중 3개는 `lib/` 전체에 0건 (`Capacity_exhausted`만 Prometheus event 이름으로 존재, decision 생성자 아님). 실제는 `Dispatch | Wait | Surface` **3-variant** (mli 자체가 line 65에서 "the verified count is three"라 명시). memory feedback `feedback_adversarial_reviewer_fabricates_line_refs.md`의 패턴 — line 번호/필드명/생성자명 환각 — 이 audit memo에서 발생한 사례. iter 60 K-2.c가 `.mli` 작성 전 `rg` 검증으로 차단했고, 그 PR body에 "K-2.c.1: audit memo line 정정" 큐를 남겼다. 본 PR이 그 큐 처리.

## 본 PR 수정

1. item 3 heading: "Five-state vs seven-state status enumeration" → "5-element spec state set vs 3-variant OCaml `decision`" (seven-state는 아예 없는 개념).
2. item 3 body에 `**Correction (iter 66, K-2.c.1)**` 블록 추가 — 무엇이 틀렸는지 + `rg` 검증 명령 + 실제 타입 명시. 본문은 spec 5-element set ↔ OCaml 3-variant `decision`의 *서로 다른 종류*임을 설명 (전자는 keeper lifecycle 위치, 후자는 `schedule` 한 번의 결과).
3. *Suggested fix-PR* → *Fix-PR (DONE)*: K-2.c는 #14906(iter 60)으로 머지 완료, 정정된 매핑은 이미 `.mli`에 들어감.

## Verification

```
$ rg 'Dispatch_immediate|Enqueue_overflow|Bypass_admission' lib/
(0 matches)

$ rg -n 'type decision' lib/keeper/keeper_admission_router.mli
97:type decision =
$ sed -n '97,110p' lib/keeper/keeper_admission_router.mli
type decision =
  | Dispatch of { candidate : ...; drift : drift_record; }
  | Wait
  | Surface of surface_reason

$ rg -n 'verified count is three' lib/keeper/keeper_admission_router.mli
65:      verified count is three: [Dispatch | Wait | Surface].  A
```

## Trade-off

- 정정 블록을 inline blockquote로 남김 (memo 삭제·재작성 대신) — audit memo는 시계열 기록이라 "무엇이 틀렸었는지"도 보존 가치가 있음. memory feedback `feedback_adversarial_reviewer_fabricates_line_refs.md`가 정확히 이런 환각 패턴을 다루므로, 정정 사실을 남기면 같은 류 미래 발생 시 참조점이 됨.
- audit memo 외 코드/spec 변경 없음 — `.mli`의 실제 매핑은 #14906에서 이미 올바르게 작성됨.

## RFC 참조

RFC-WAIVED: `docs/tla-audit/` 메모 정정만. credential/identity/operator/sandbox/hooks/workflow-doc 표면 미접촉.

## 진행 추적

다음 iteration 시작점:
1. **M-2.c** (MED — OCaml-side `CancelledNeverAbsorbed` test fixture, KOAS bug-model loop OCaml 측 클로저)
2. **N-2.b** (KAQ Runtime status preamble — runtime-matches-spec flavour) / **N-2.d** (KAQ TLC refresh)
3. **R-D-2.a + R-D-1.a bundle** (MID ~150-300 LOC — KCAF call_err 3-way + Cascade_fsm.Exhausted 2-way split, biggest pending)
4. **새 spec entry** (KWP / KH 미진입) / **KSM A-5 잔여** (22×19 update_conditions matrix)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
