### PR TITLE
feat(sublibs): enable warning 4 on autonomous + gate (RFC-0071 §3.4 ratchet)

### DIFF
--- a/lib/autonomous/dune
+++ b/lib/autonomous/dune
@@ -3,6 +3,8 @@
 (library
  (name autonomous)
  (public_name masc_mcp.autonomous)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries shared_types multimodal yojson)
  (preprocess
   (pps ppx_tla)))

--- a/lib/gate/channel_gate.ml
+++ b/lib/gate/channel_gate.ml
@@ -166,7 +166,11 @@ let handle_inbound ~dispatch (msg : inbound_message) =
         ~duration_ms:0
         (match e with
          | Duplicate_message _ -> Channel_gate_metrics.Duplicate
-         | _ ->
+         | Empty_content
+         | Content_too_long _
+         | Empty_keeper_name
+         | Empty_channel_user_id
+         | Empty_idempotency_key ->
              Channel_gate_metrics.Validation_error
                (validation_error_to_string e));
       Error (Validation e)

--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -13,6 +13,8 @@
    channel_gate_metrics
    gate_protocol
    gate_time_util)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries
    yojson
    unix


### PR DESCRIPTION
## 목적

RFC-0071 §3.4 Phase 5 ratchet (#14888/#14894/#14900/#14923 후속).

## 변경

| Sublib | catch-all 상태 | 조치 |
|--------|---------------|------|
| `lib/autonomous` | clean (0 fragile site) | `-w +4` 활성화만 |
| `lib/gate` | 1 closed-variant fragile site | fix + 활성화 |

`lib/gate/channel_gate.ml:167` — `Gate_protocol.validation_error` (6 ctors). `Duplicate_message _ \| _ -> ...` → 6 ctor 전부 명시:
\`\`\`ocaml
| Duplicate_message _ -> Channel_gate_metrics.Duplicate
| Empty_content | Content_too_long _ | Empty_keeper_name
| Empty_channel_user_id | Empty_idempotency_key ->
    Channel_gate_metrics.Validation_error (validation_error_to_string e)
\`\`\`
Behavior-preserving — `_ ->` arm 이 5개 non-Duplicate 에 동일 동작.

## 검증

- \`dune build --root .\` clean
- channel_gate / gate_protocol tests green (14 across 3 files)

## 누적

| | `-w +4` sublibs |
|--|--|
| #14888 | 1 (lib/core, +1 fix) |
| #14894 | 5 |
| #14900 | 15 |
| #14923 | +1 (lib/config, +3 fix) |
| **본 PR** | **+2 (autonomous clean / gate +1 fix)** |
| **누계** | **24** |

## 다음 ratchet 후보 (deferred)

- `lib/exec` — ~10 fragile sites (exit_code.ml, output_parse.ml, exec_dispatch.ml, approval_policy.ml, exec_gate.ml). 별도 PR — 한 batch 로 너무 큼.
- `lib/process` — 1 site (process_eio.ml:104, `exn` extensible variant → `[@warning "-4"]` + WORKAROUND 주석 필요).
- `lib/backend` — 1 site (backend.ml:667, `Error e` passthrough → `[@warning "-4"]` 또는 enumerate).