### PR TITLE
style(cascade_model_resolve): align to janestreet ocamlformat profile

### DIFF
--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -21,11 +21,15 @@
 
     All text/vision models support function calling.
     glm-5.1 supports reasoning (reasoning_content field). *)
-type model_selector = Concrete of string | Auto
+type model_selector =
+  | Concrete of string
+  | Auto
 
 let model_selector_of_string s =
-  if String.equal (String.lowercase_ascii (String.trim s)) "auto" then Auto
+  if String.equal (String.lowercase_ascii (String.trim s)) "auto"
+  then Auto
   else Concrete s
+;;
 
 type model_resolution_provenance =
   | Explicit_input
@@ -35,64 +39,74 @@ type model_resolution_provenance =
   | Discovery
   | Unresolved_auto
 
-type model_resolution = {
-  requested_model_id : string;
-  resolved_model_id : string;
-  provenance : model_resolution_provenance;
-}
+type model_resolution =
+  { requested_model_id : string
+  ; resolved_model_id : string
+  ; provenance : model_resolution_provenance
+  }
 
 let env_value_opt ?(getenv = Sys.getenv_opt) var =
   match getenv var with
   | Some v ->
-      let trimmed = String.trim v in
-      if String.equal trimmed "" then None else Some trimmed
+    let trimmed = String.trim v in
+    if String.equal trimmed "" then None else Some trimmed
   | None -> None
+;;
 
 let explicit_resolution requested_model_id resolved_model_id =
   { requested_model_id; resolved_model_id; provenance = Explicit_input }
+;;
 
 let unresolved_auto requested_model_id =
-  {
-    requested_model_id;
-    resolved_model_id = requested_model_id;
-    provenance = Unresolved_auto;
+  { requested_model_id
+  ; resolved_model_id = requested_model_id
+  ; provenance = Unresolved_auto
   }
+;;
 
 let default_resolution_from_policy
-    ?getenv
-    (policy : Provider_adapter.model_policy)
-    ~requested_model_id =
+      ?getenv
+      (policy : Provider_adapter.model_policy)
+      ~requested_model_id
+  =
   match policy.default_model_env with
-  | Some env_var -> (
-      match env_value_opt ?getenv env_var with
-      | Some resolved_model_id ->
-          { requested_model_id; resolved_model_id; provenance = Env_default env_var }
-      | None -> (
-          match policy.default_model_fallback with
-          | Some resolved_model_id ->
-              { requested_model_id; resolved_model_id; provenance = Hardcoded_default }
-          | None -> unresolved_auto requested_model_id))
-  | None -> (
-      match policy.default_model_fallback with
-      | Some resolved_model_id ->
+  | Some env_var ->
+    (match env_value_opt ?getenv env_var with
+     | Some resolved_model_id ->
+       { requested_model_id; resolved_model_id; provenance = Env_default env_var }
+     | None ->
+       (match policy.default_model_fallback with
+        | Some resolved_model_id ->
           { requested_model_id; resolved_model_id; provenance = Hardcoded_default }
-      | None -> unresolved_auto requested_model_id)
+        | None -> unresolved_auto requested_model_id))
+  | None ->
+    (match policy.default_model_fallback with
+     | Some resolved_model_id ->
+       { requested_model_id; resolved_model_id; provenance = Hardcoded_default }
+     | None -> unresolved_auto requested_model_id)
+;;
 
 let default_resolution ?getenv provider_name ~requested_model_id =
   match Provider_adapter.resolve_adapter_by_cascade_prefix provider_name with
   | Some adapter ->
-      default_resolution_from_policy ?getenv adapter.model_policy ~requested_model_id
+    default_resolution_from_policy ?getenv adapter.model_policy ~requested_model_id
   | None -> unresolved_auto requested_model_id
+;;
 
 (** Default GLM auto-cascade order: quality-first, then speed.
     glm-5.1 = best quality (reasoning), glm-5-turbo = fast tool calling,
     glm-4.7 = stable general, glm-4.7-flashx = fastest/cheapest.
     Configurable via ZAI_AUTO_MODELS env var (comma-separated). *)
 let glm_auto_models = Llm_provider.Zai_catalog.glm_auto_models
+
 let glm_coding_auto_models = Llm_provider.Zai_catalog.glm_coding_auto_models
 
 let resolve_glm_model ?getenv selector =
-  let model_id = match selector with Concrete s -> s | Auto -> "auto" in
+  let model_id =
+    match selector with
+    | Concrete s -> s
+    | Auto -> "auto"
+  in
   let default_model = default_resolution ?getenv "glm" ~requested_model_id:model_id in
   let resolved_model_id =
     Llm_provider.Zai_catalog.resolve_glm_alias
@@ -102,13 +116,17 @@ let resolve_glm_model ?getenv selector =
   match selector with
   | Auto -> { default_model with resolved_model_id }
   | Concrete _ ->
-      if String.equal resolved_model_id model_id then
-        explicit_resolution model_id resolved_model_id
-      else
-        { requested_model_id = model_id; resolved_model_id; provenance = Alias model_id }
+    if String.equal resolved_model_id model_id
+    then explicit_resolution model_id resolved_model_id
+    else { requested_model_id = model_id; resolved_model_id; provenance = Alias model_id }
+;;
 
 let resolve_glm_coding_model ?getenv selector =
-  let model_id = match selector with Concrete s -> s | Auto -> "auto" in
+  let model_id =
+    match selector with
+    | Concrete s -> s
+    | Auto -> "auto"
+  in
   let default_model =
     default_resolution ?getenv "glm-coding" ~requested_model_id:model_id
   in
@@ -120,31 +138,36 @@ let resolve_glm_coding_model ?getenv selector =
   match selector with
   | Auto -> { default_model with resolved_model_id }
   | Concrete _ ->
-      if String.equal resolved_model_id model_id then
-        explicit_resolution model_id resolved_model_id
-      else
-        { requested_model_id = model_id; resolved_model_id; provenance = Alias model_id }
+    if String.equal resolved_model_id model_id
+    then explicit_resolution model_id resolved_model_id
+    else { requested_model_id = model_id; resolved_model_id; provenance = Alias model_id }
+;;
 
 let resolve_kimi_model ?getenv selector =
-  let model_id = match selector with Concrete s -> s | Auto -> "auto" in
+  let model_id =
+    match selector with
+    | Concrete s -> s
+    | Auto -> "auto"
+  in
   let trimmed = String.trim model_id in
   match String.lowercase_ascii trimmed with
-  | "auto" ->
-      default_resolution ?getenv "kimi" ~requested_model_id:model_id
+  | "auto" -> default_resolution ?getenv "kimi" ~requested_model_id:model_id
   | "kimi-for-coding" ->
-      let default_model = default_resolution ?getenv "kimi" ~requested_model_id:model_id in
-      {
-        requested_model_id = model_id;
-        resolved_model_id = default_model.resolved_model_id;
-        provenance = Alias model_id;
-      }
+    let default_model = default_resolution ?getenv "kimi" ~requested_model_id:model_id in
+    { requested_model_id = model_id
+    ; resolved_model_id = default_model.resolved_model_id
+    ; provenance = Alias model_id
+    }
   | _ -> explicit_resolution model_id trimmed
+;;
 
 let resolve_glm_model_id model_id =
   (resolve_glm_model (model_selector_of_string model_id)).resolved_model_id
+;;
 
 let resolve_glm_coding_model_id model_id =
   (resolve_glm_coding_model (model_selector_of_string model_id)).resolved_model_id
+;;
 
 (** Resolve "auto" and aliases to concrete model IDs.
     Cloud APIs generally require concrete model names, and local
@@ -155,49 +178,56 @@ let resolve_glm_coding_model_id model_id =
     resolve the model_id before invoking [Llm_provider.Discovery.endpoint_for_model]
     to avoid routing mismatches. *)
 let resolve_auto_model
-    ?getenv
-    ?(discover = Llm_provider.Discovery.first_discovered_model_id)
-    provider_name selector =
-  let model_id = match selector with Concrete s -> s | Auto -> "auto" in
+      ?getenv
+      ?(discover = Llm_provider.Discovery.first_discovered_model_id)
+      provider_name
+      selector
+  =
+  let model_id =
+    match selector with
+    | Concrete s -> s
+    | Auto -> "auto"
+  in
   match Provider_adapter.resolve_adapter_by_cascade_prefix provider_name with
   | Some { runtime_kind = Provider_adapter.Local; _ } ->
-      (match selector with
-       | Auto ->
-           (match discover () with
-            | Some resolved_model_id ->
-                { requested_model_id = model_id; resolved_model_id; provenance = Discovery }
-            | None -> default_resolution ?getenv provider_name ~requested_model_id:model_id)
-       | Concrete _ -> explicit_resolution model_id model_id)
+    (match selector with
+     | Auto ->
+       (match discover () with
+        | Some resolved_model_id ->
+          { requested_model_id = model_id; resolved_model_id; provenance = Discovery }
+        | None -> default_resolution ?getenv provider_name ~requested_model_id:model_id)
+     | Concrete _ -> explicit_resolution model_id model_id)
   | Some { model_policy = { family = Provider_adapter.Glm_general; _ }; _ } ->
-      resolve_glm_model ?getenv selector
+    resolve_glm_model ?getenv selector
   | Some { model_policy = { family = Provider_adapter.Glm_coding; _ }; _ } ->
-      resolve_glm_coding_model ?getenv selector
+    resolve_glm_coding_model ?getenv selector
   | Some { model_policy = { family = Provider_adapter.Kimi_api_family; _ }; _ } ->
-      resolve_kimi_model ?getenv selector
+    resolve_kimi_model ?getenv selector
   | Some _ ->
-      (match selector with
-       | Auto -> default_resolution ?getenv provider_name ~requested_model_id:model_id
-       | Concrete _ -> explicit_resolution model_id model_id)
+    (match selector with
+     | Auto -> default_resolution ?getenv provider_name ~requested_model_id:model_id
+     | Concrete _ -> explicit_resolution model_id model_id)
   | None ->
-      (match selector with
-       | Auto -> unresolved_auto model_id
-       | Concrete _ -> explicit_resolution model_id model_id)
+    (match selector with
+     | Auto -> unresolved_auto model_id
+     | Concrete _ -> explicit_resolution model_id model_id)
+;;
 
 let resolve_auto_model_id provider_name model_id =
   (resolve_auto_model provider_name (model_selector_of_string model_id)).resolved_model_id
+;;
 
 let parse_custom_model model_id =
   match String.index_opt model_id '@' with
   | Some at_idx ->
-      let model = String.sub model_id 0 at_idx in
-      let url =
-        String.sub model_id (at_idx + 1) (String.length model_id - at_idx - 1)
-      in
-      (model, url)
+    let model = String.sub model_id 0 at_idx in
+    let url = String.sub model_id (at_idx + 1) (String.length model_id - at_idx - 1) in
+    model, url
   | None ->
-      let url =
-        match env_value_opt "CUSTOM_LLM_BASE_URL" with
-        | Some u -> u
-        | None -> Llm_provider.Discovery.default_endpoint
-      in
-      (model_id, url)
+    let url =
+      match env_value_opt "CUSTOM_LLM_BASE_URL" with
+      | Some u -> u
+      | None -> Llm_provider.Discovery.default_endpoint
+    in
+    model_id, url
+;;

--- a/lib/cascade/cascade_model_resolve.mli
+++ b/lib/cascade/cascade_model_resolve.mli
@@ -12,6 +12,7 @@
     Configurable via [ZAI_AUTO_MODELS] env var (comma-separated).
     Default: [\["glm-5.1"; "glm-5-turbo"; "glm-4.7"; "glm-4.7-flashx"\]]. *)
 val glm_auto_models : unit -> string list
+
 val glm_coding_auto_models : unit -> string list
 
 (** {2 Removed in RFC-0058 Phase 5.3a}
@@ -26,7 +27,9 @@ val glm_coding_auto_models : unit -> string list
     ([MASC_<PROVIDER>_AUTO_MODELS]) remains intact and is now exercised
     against the generic path in [test/test_cascade_model_resolve.ml]. *)
 
-type model_selector = Concrete of string | Auto
+type model_selector =
+  | Concrete of string
+  | Auto
 
 val model_selector_of_string : string -> model_selector
 
@@ -38,16 +41,21 @@ type model_resolution_provenance =
   | Discovery
   | Unresolved_auto
 
-type model_resolution = {
-  requested_model_id : string;
-  resolved_model_id : string;
-  provenance : model_resolution_provenance;
-}
+type model_resolution =
+  { requested_model_id : string
+  ; resolved_model_id : string
+  ; provenance : model_resolution_provenance
+  }
 
-val resolve_glm_model :
-  ?getenv:(string -> string option) -> model_selector -> model_resolution
-val resolve_glm_coding_model :
-  ?getenv:(string -> string option) -> model_selector -> model_resolution
+val resolve_glm_model
+  :  ?getenv:(string -> string option)
+  -> model_selector
+  -> model_resolution
+
+val resolve_glm_coding_model
+  :  ?getenv:(string -> string option)
+  -> model_selector
+  -> model_resolution
 
 (** Resolve a GLM model alias to the concrete API model ID.
     - ["auto"] -> env var [ZAI_DEFAULT_MODEL] or ["glm-5.1"]
@@ -56,17 +64,19 @@ val resolve_glm_coding_model :
     - ["vision"] -> ["glm-4.6v"]
     - Concrete IDs pass through unchanged. *)
 val resolve_glm_model_id : string -> string
+
 val resolve_glm_coding_model_id : string -> string
 
 (** Resolve "auto" and aliases to concrete model IDs for any provider.
     Cloud providers resolve aliases; local providers (llama, ollama) resolve
     "auto" via {!Llm_provider.Discovery.first_discovered_model_id}. *)
-val resolve_auto_model :
-  ?getenv:(string -> string option) ->
-  ?discover:(unit -> string option) ->
-  string ->
-  model_selector ->
-  model_resolution
+val resolve_auto_model
+  :  ?getenv:(string -> string option)
+  -> ?discover:(unit -> string option)
+  -> string
+  -> model_selector
+  -> model_resolution
+
 val resolve_auto_model_id : string -> string -> string
 
 (** Parse a "model@url" custom model spec.

--- a/test/test_cascade_model_resolve.ml
+++ b/test/test_cascade_model_resolve.ml
@@ -21,130 +21,149 @@ module PA = Masc_mcp.Provider_adapter
    the provider id is the test's pin, not a production literal. *)
 let auto_models_for pid =
   PA.auto_models_for_cascade_prefix pid |> Option.value ~default:[]
+;;
 
 let unset_env k =
-  try Unix.putenv k "" with _ -> ()
+  try Unix.putenv k "" with
+  | _ -> ()
+;;
 
 let with_clean_env f =
-  List.iter unset_env [
-    "ZAI_CODING_DEFAULT_MODEL";
-    "ZAI_CODING_AUTO_MODELS";
-    "GEMINI_DEFAULT_MODEL";
-    "ANTHROPIC_DEFAULT_MODEL";
-    "OPENAI_DEFAULT_MODEL";
-    "OPENROUTER_DEFAULT_MODEL";
-    "OLLAMA_DEFAULT_MODEL";
-    "MASC_GEMINI_CLI_AUTO_MODELS";
-    "MASC_CODEX_CLI_AUTO_MODELS";
-    "MASC_CLAUDE_CODE_AUTO_MODELS";
-    "MASC_KIMI_CLI_AUTO_MODELS";
-  ];
+  List.iter
+    unset_env
+    [ "ZAI_CODING_DEFAULT_MODEL"
+    ; "ZAI_CODING_AUTO_MODELS"
+    ; "GEMINI_DEFAULT_MODEL"
+    ; "ANTHROPIC_DEFAULT_MODEL"
+    ; "OPENAI_DEFAULT_MODEL"
+    ; "OPENROUTER_DEFAULT_MODEL"
+    ; "OLLAMA_DEFAULT_MODEL"
+    ; "MASC_GEMINI_CLI_AUTO_MODELS"
+    ; "MASC_CODEX_CLI_AUTO_MODELS"
+    ; "MASC_CLAUDE_CODE_AUTO_MODELS"
+    ; "MASC_KIMI_CLI_AUTO_MODELS"
+    ];
   f ()
+;;
 
 let test_gemini_auto_maps_to_flash_preview () =
   with_clean_env (fun () ->
     let resolved = R.resolve_auto_model_id "gemini" "auto" in
-    check string "gemini:auto → gemini-3-flash-preview"
-      "gemini-3-flash-preview" resolved)
+    check string "gemini:auto → gemini-3-flash-preview" "gemini-3-flash-preview" resolved)
+;;
 
 let test_gemini_cli_auto_maps_to_flash_preview () =
   with_clean_env (fun () ->
     let resolved = R.resolve_auto_model_id "gemini_cli" "auto" in
-    check string "gemini_cli:auto → gemini-3-flash-preview"
-      "gemini-3-flash-preview" resolved)
+    check
+      string
+      "gemini_cli:auto → gemini-3-flash-preview"
+      "gemini-3-flash-preview"
+      resolved)
+;;
 
 let test_gemini_cli_explicit_model_passthrough () =
   with_clean_env (fun () ->
-    let resolved =
-      R.resolve_auto_model_id "gemini_cli" "gemini-3-flash-preview"
-    in
-    check string "explicit model untouched"
-      "gemini-3-flash-preview" resolved)
+    let resolved = R.resolve_auto_model_id "gemini_cli" "gemini-3-flash-preview" in
+    check string "explicit model untouched" "gemini-3-flash-preview" resolved)
+;;
 
 let test_gemini_env_override () =
   Unix.putenv "GEMINI_DEFAULT_MODEL" "gemini-3-flash-preview";
   let resolved_gemini = R.resolve_auto_model_id "gemini" "auto" in
   let resolved_cli = R.resolve_auto_model_id "gemini_cli" "auto" in
   Unix.putenv "GEMINI_DEFAULT_MODEL" "";
-  check string "gemini respects env override"
-    "gemini-3-flash-preview" resolved_gemini;
-    check string "gemini_cli respects same env override"
-    "gemini-3-flash-preview" resolved_cli
+  check string "gemini respects env override" "gemini-3-flash-preview" resolved_gemini;
+  check
+    string
+    "gemini_cli respects same env override"
+    "gemini-3-flash-preview"
+    resolved_cli
+;;
 
 let test_glm_coding_auto_maps_to_glm_5_1 () =
   with_clean_env (fun () ->
     let resolved = R.resolve_auto_model_id "glm-coding" "auto" in
-    check string "glm-coding:auto → glm-5.1"
-      "glm-5.1" resolved)
+    check string "glm-coding:auto → glm-5.1" "glm-5.1" resolved)
+;;
 
 let test_glm_coding_auto_models_default_order () =
   with_clean_env (fun () ->
-    check (list string) "glm-coding:auto expands to coding-plan order"
-      [
-        "glm-5.1";
-        "glm-5";
-        "glm-5-turbo";
-        "glm-4.7";
-        "glm-4.5-air";
-      ]
+    check
+      (list string)
+      "glm-coding:auto expands to coding-plan order"
+      [ "glm-5.1"; "glm-5"; "glm-5-turbo"; "glm-4.7"; "glm-4.5-air" ]
       (R.glm_coding_auto_models ()))
+;;
 
 let test_gemini_cli_auto_models_default_rotation_order () =
   with_clean_env (fun () ->
-    check (list string) "gemini_cli:auto expands to quota-aware rotation"
-      [
-        "gemini-3-flash-preview";
-        "gemini-3.1-flash-lite-preview";
-        "gemini-3.1-pro-preview";
+    check
+      (list string)
+      "gemini_cli:auto expands to quota-aware rotation"
+      [ "gemini-3-flash-preview"
+      ; "gemini-3.1-flash-lite-preview"
+      ; "gemini-3.1-pro-preview"
       ]
       (auto_models_for "gemini_cli"))
+;;
 
 let test_gemini_cli_auto_models_env_override () =
-  Unix.putenv "MASC_GEMINI_CLI_AUTO_MODELS"
-    "gemini-a, gemini-b,, gemini-c ";
+  Unix.putenv "MASC_GEMINI_CLI_AUTO_MODELS" "gemini-a, gemini-b,, gemini-c ";
   let models = auto_models_for "gemini_cli" in
   Unix.putenv "MASC_GEMINI_CLI_AUTO_MODELS" "";
-  check (list string) "operator override trims blanks"
-    [ "gemini-a"; "gemini-b"; "gemini-c" ] models
+  check
+    (list string)
+    "operator override trims blanks"
+    [ "gemini-a"; "gemini-b"; "gemini-c" ]
+    models
+;;
 
 let test_codex_and_claude_cli_auto_models_env_override () =
   with_clean_env (fun () ->
-    check (list string) "codex default keeps Codex-supported models only"
-      [
-        "gpt-5.2";
-        "gpt-5.3-codex-spark";
-        "gpt-5.3-codex";
-        "gpt-5.4-mini";
-        "gpt-5.4";
-        "gpt-5.5";
+    check
+      (list string)
+      "codex default keeps Codex-supported models only"
+      [ "gpt-5.2"
+      ; "gpt-5.3-codex-spark"
+      ; "gpt-5.3-codex"
+      ; "gpt-5.4-mini"
+      ; "gpt-5.4"
+      ; "gpt-5.5"
       ]
       (auto_models_for "codex_cli");
-    check (list string) "claude default delegates to CLI"
-      [ "auto" ] (auto_models_for "claude_code");
+    check
+      (list string)
+      "claude default delegates to CLI"
+      [ "auto" ]
+      (auto_models_for "claude_code");
     Unix.putenv "MASC_CODEX_CLI_AUTO_MODELS" "gpt-a,gpt-b";
     Unix.putenv "MASC_CLAUDE_CODE_AUTO_MODELS" "sonnet,opus";
     let codex = auto_models_for "codex_cli" in
     let claude = auto_models_for "claude_code" in
     Unix.putenv "MASC_CODEX_CLI_AUTO_MODELS" "";
     Unix.putenv "MASC_CLAUDE_CODE_AUTO_MODELS" "";
-    check (list string) "codex operator rotation"
-      [ "gpt-a"; "gpt-b" ] codex;
-    check (list string) "claude operator rotation"
-      [ "sonnet"; "opus" ] claude)
+    check (list string) "codex operator rotation" [ "gpt-a"; "gpt-b" ] codex;
+    check (list string) "claude operator rotation" [ "sonnet"; "opus" ] claude)
+;;
 
 let test_kimi_cli_auto_model_policy () =
   with_clean_env (fun () ->
-    check string "kimi_cli:auto resolves to concrete CLI default"
+    check
+      string
+      "kimi_cli:auto resolves to concrete CLI default"
       "kimi-for-coding"
       (R.resolve_auto_model_id "kimi_cli" "auto");
-    check (list string) "kimi_cli:auto expands to declared default"
+    check
+      (list string)
+      "kimi_cli:auto expands to declared default"
       [ "kimi-for-coding" ]
       (auto_models_for "kimi_cli");
     Unix.putenv "MASC_KIMI_CLI_AUTO_MODELS" "kimi-a,kimi-b";
     let models = auto_models_for "kimi_cli" in
     Unix.putenv "MASC_KIMI_CLI_AUTO_MODELS" "";
-    check (list string) "kimi cli operator rotation"
-      [ "kimi-a"; "kimi-b" ] models)
+    check (list string) "kimi cli operator rotation" [ "kimi-a"; "kimi-b" ] models)
+;;
 
 let test_expand_auto_models_includes_cli_auto_specs () =
   with_clean_env (fun () ->
@@ -152,28 +171,33 @@ let test_expand_auto_models_includes_cli_auto_specs () =
       C.expand_auto_models
         [ "gemini_cli:auto"; "codex_cli:auto"; "claude_code:auto"; "kimi_cli:auto" ]
     in
-    check (list string) "CLI auto specs expand in-place"
-      [
-        "gemini_cli:gemini-3-flash-preview";
-        "gemini_cli:gemini-3.1-flash-lite-preview";
-        "gemini_cli:gemini-3.1-pro-preview";
-        "codex_cli:gpt-5.2";
-        "codex_cli:gpt-5.3-codex-spark";
-        "codex_cli:gpt-5.3-codex";
-        "codex_cli:gpt-5.4-mini";
-        "codex_cli:gpt-5.4";
-        "codex_cli:gpt-5.5";
-        "claude_code:auto";
-        "kimi_cli:kimi-for-coding";
+    check
+      (list string)
+      "CLI auto specs expand in-place"
+      [ "gemini_cli:gemini-3-flash-preview"
+      ; "gemini_cli:gemini-3.1-flash-lite-preview"
+      ; "gemini_cli:gemini-3.1-pro-preview"
+      ; "codex_cli:gpt-5.2"
+      ; "codex_cli:gpt-5.3-codex-spark"
+      ; "codex_cli:gpt-5.3-codex"
+      ; "codex_cli:gpt-5.4-mini"
+      ; "codex_cli:gpt-5.4"
+      ; "codex_cli:gpt-5.5"
+      ; "claude_code:auto"
+      ; "kimi_cli:kimi-for-coding"
       ]
       expanded)
+;;
 
 let test_expand_model_strings_for_execution_matches_auto_expansion () =
   with_clean_env (fun () ->
     let items = [ "glm-coding:auto"; "gemini_cli:auto" ] in
-    check (list string) "execution expansion matches auto expansion"
+    check
+      (list string)
+      "execution expansion matches auto expansion"
       (C.expand_auto_models items)
       (C.expand_model_strings_for_execution items))
+;;
 
 let test_expand_model_strings_for_execution_dedupe_stable_repeated_inputs () =
   with_clean_env (fun () ->
@@ -187,9 +211,12 @@ let test_expand_model_strings_for_execution_dedupe_stable_repeated_inputs () =
       ; "codex_cli:gpt-5.2"
       ]
     in
-    check (list string) "first occurrence wins, order preserved"
+    check
+      (list string)
+      "first occurrence wins, order preserved"
       [ "codex_cli:gpt-5.2"; "kimi_cli:kimi-for-coding" ]
       (C.expand_model_strings_for_execution items))
+;;
 
 let test_expand_model_strings_for_execution_dedupe_explicit_and_auto () =
   with_clean_env (fun () ->
@@ -200,18 +227,19 @@ let test_expand_model_strings_for_execution_dedupe_explicit_and_auto () =
     let items = [ "codex_cli:gpt-5.2"; "codex_cli:auto" ] in
     let expanded = C.expand_model_strings_for_execution items in
     (* (a) head is the explicit declaration *)
-    check string "explicit first occurrence retained at head"
+    check
+      string
+      "explicit first occurrence retained at head"
       "codex_cli:gpt-5.2"
       (List.hd expanded);
     (* (b) duplicate of the explicit name does not reappear *)
     let occurrences =
-      List.filter (String.equal "codex_cli:gpt-5.2") expanded
-      |> List.length
+      List.filter (String.equal "codex_cli:gpt-5.2") expanded |> List.length
     in
     check int "no duplicate of explicit name" 1 occurrences;
     (* (c) auto-expansion of other entries still present (sanity) *)
-    check bool "auto-expanded siblings present" true
-      (List.length expanded > 1))
+    check bool "auto-expanded siblings present" true (List.length expanded > 1))
+;;
 
 let test_expand_model_strings_for_execution_rotation_scope_rotates () =
   with_clean_env (fun () ->
@@ -231,176 +259,201 @@ let test_expand_model_strings_for_execution_rotation_scope_rotates () =
         ~rotation_scope:"tool_rerank"
         [ "gemini_cli:auto" ]
     in
-    check string "first scoped call starts at default head"
+    check
+      string
+      "first scoped call starts at default head"
       "gemini_cli:gemini-3-flash-preview"
       (List.hd first);
-    check string "second scoped call advances head"
+    check
+      string
+      "second scoped call advances head"
       "gemini_cli:gemini-3.1-flash-lite-preview"
       (List.hd second);
-    check string "different scope has its own cursor"
+    check
+      string
+      "different scope has its own cursor"
       "gemini_cli:gemini-3-flash-preview"
       (List.hd other_scope))
+;;
 
 let test_order_weighted_entries_rotation_scope_rotates_generically () =
   with_clean_env (fun () ->
     State.clear_all ();
     let entry model =
-      {
-        Masc_mcp.Cascade_config_loader.model = model;
-        weight = 1;
-        supports_tool_choice = None;
-        secondary = None;
-        secondary_supports_tool_choice = None;
+      { Masc_mcp.Cascade_config_loader.model
+      ; weight = 1
+      ; supports_tool_choice = None
+      ; secondary = None
+      ; secondary_supports_tool_choice = None
       }
     in
     let first =
-      C.order_weighted_entries
-        ~rotation_scope:"big_three"
-        [ entry "codex_cli:auto" ]
-      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
-             e.model)
+      C.order_weighted_entries ~rotation_scope:"big_three" [ entry "codex_cli:auto" ]
+      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) -> e.model)
     in
     let second =
-      C.order_weighted_entries
-        ~rotation_scope:"big_three"
-        [ entry "codex_cli:auto" ]
-      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
-             e.model)
+      C.order_weighted_entries ~rotation_scope:"big_three" [ entry "codex_cli:auto" ]
+      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) -> e.model)
     in
     let other_scope =
-      C.order_weighted_entries
-        ~rotation_scope:"tool_rerank"
-        [ entry "codex_cli:auto" ]
-      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
-             e.model)
+      C.order_weighted_entries ~rotation_scope:"tool_rerank" [ entry "codex_cli:auto" ]
+      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) -> e.model)
     in
-    check string "weighted first call keeps default head"
+    check
+      string
+      "weighted first call keeps default head"
       "codex_cli:gpt-5.2"
       (List.hd first);
-    check string "weighted second call advances head"
+    check
+      string
+      "weighted second call advances head"
       "codex_cli:gpt-5.3-codex-spark"
       (List.hd second);
-    check string "weighted rotation is scoped"
-      "codex_cli:gpt-5.2"
-      (List.hd other_scope))
+    check string "weighted rotation is scoped" "codex_cli:gpt-5.2" (List.hd other_scope))
+;;
 
 let test_order_weighted_entries_rotation_scope_rotates_top_level_providers () =
   with_clean_env (fun () ->
     State.clear_all ();
     let entry model =
-      {
-        Masc_mcp.Cascade_config_loader.model = model;
-        weight = 1;
-        supports_tool_choice = None;
-        secondary = None;
-        secondary_supports_tool_choice = None;
+      { Masc_mcp.Cascade_config_loader.model
+      ; weight = 1
+      ; supports_tool_choice = None
+      ; secondary = None
+      ; secondary_supports_tool_choice = None
       }
     in
     let entries =
-      [
-        entry "claude_code:auto";
-        entry "codex_cli:auto";
-        entry "gemini_cli:auto";
-      ]
+      [ entry "claude_code:auto"; entry "codex_cli:auto"; entry "gemini_cli:auto" ]
     in
     let first =
       C.order_weighted_entries ~rotation_scope:"big_three" entries
-      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
-             e.model)
+      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) -> e.model)
     in
     let second =
       C.order_weighted_entries ~rotation_scope:"big_three" entries
-      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
-             e.model)
+      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) -> e.model)
     in
     let third =
       C.order_weighted_entries ~rotation_scope:"big_three" entries
-      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
-             e.model)
+      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) -> e.model)
     in
     let other_scope =
       C.order_weighted_entries ~rotation_scope:"tool_rerank" entries
-      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
-             e.model)
+      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) -> e.model)
     in
-    check string "first call starts with declared provider"
+    check
+      string
+      "first call starts with declared provider"
       "claude_code:auto"
       (List.hd first);
-    check string "second call rotates to codex provider"
+    check
+      string
+      "second call rotates to codex provider"
       "codex_cli:gpt-5.3-codex-spark"
       (List.hd second);
-    check string "third call rotates to gemini provider"
+    check
+      string
+      "third call rotates to gemini provider"
       "gemini_cli:gemini-3-flash-preview"
       (List.hd third);
-    check string "different scope restarts top-level provider order"
+    check
+      string
+      "different scope restarts top-level provider order"
       "claude_code:auto"
       (List.hd other_scope))
+;;
 
 let test_order_weighted_entries_cooldown_is_provider_scoped () =
   with_clean_env (fun () ->
     let entry model =
-      {
-        Masc_mcp.Cascade_config_loader.model = model;
-        weight = 100;
-        supports_tool_choice = None;
-        secondary = None;
-        secondary_supports_tool_choice = None;
+      { Masc_mcp.Cascade_config_loader.model
+      ; weight = 100
+      ; supports_tool_choice = None
+      ; secondary = None
+      ; secondary_supports_tool_choice = None
       }
     in
     H.record_failure H.global ~provider_key:"test-provider" ();
     H.record_failure H.global ~provider_key:"test-provider" ();
     H.record_failure H.global ~provider_key:"test-provider" ();
     let ordered =
-      C.order_weighted_entries ~rand_int:(fun _ -> 0)
-        [
-          entry "test-provider:model-a";
-          entry "other-provider:model-a";
-        ]
-      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
-             e.model)
+      C.order_weighted_entries
+        ~rand_int:(fun _ -> 0)
+        [ entry "test-provider:model-a"; entry "other-provider:model-a" ]
+      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) -> e.model)
     in
-    check string "cooled provider model is skipped"
-      "other-provider:model-a" (List.hd ordered))
+    check
+      string
+      "cooled provider model is skipped"
+      "other-provider:model-a"
+      (List.hd ordered))
+;;
 
 let () =
-  run "Cascade_model_resolve" [
-    "gemini auto", [
-      test_case "glm-coding:auto"
-        `Quick test_glm_coding_auto_maps_to_glm_5_1;
-      test_case "glm-coding:auto model list"
-        `Quick test_glm_coding_auto_models_default_order;
-      test_case "gemini:auto"
-        `Quick test_gemini_auto_maps_to_flash_preview;
-      test_case "gemini_cli:auto (regression 2026-04-20)"
-        `Quick test_gemini_cli_auto_maps_to_flash_preview;
-      test_case "gemini_cli explicit"
-        `Quick test_gemini_cli_explicit_model_passthrough;
-      test_case "GEMINI_DEFAULT_MODEL env override"
-        `Quick test_gemini_env_override;
-      test_case "gemini_cli:auto model list"
-        `Quick test_gemini_cli_auto_models_default_rotation_order;
-      test_case "gemini_cli:auto env list override"
-        `Quick test_gemini_cli_auto_models_env_override;
-      test_case "codex/claude cli auto env list override"
-        `Quick test_codex_and_claude_cli_auto_models_env_override;
-      test_case "kimi_cli:auto policy"
-        `Quick test_kimi_cli_auto_model_policy;
-      test_case "expand_auto_models covers CLI auto"
-        `Quick test_expand_auto_models_includes_cli_auto_specs;
-      test_case "execution expansion matches auto expansion"
-        `Quick test_expand_model_strings_for_execution_matches_auto_expansion;
-      test_case "dedupe_stable: first wins on repeats"
-        `Quick test_expand_model_strings_for_execution_dedupe_stable_repeated_inputs;
-      test_case "dedupe_stable: explicit beats auto-expansion"
-        `Quick test_expand_model_strings_for_execution_dedupe_explicit_and_auto;
-      test_case "execution expansion can rotate by scope"
-        `Quick test_expand_model_strings_for_execution_rotation_scope_rotates;
-      test_case "weighted ordering rotates auto by scope"
-        `Quick test_order_weighted_entries_rotation_scope_rotates_generically;
-      test_case "weighted ordering rotates provider order by scope"
-        `Quick
-        test_order_weighted_entries_rotation_scope_rotates_top_level_providers;
-      test_case "weighted ordering cooldown is provider scoped" `Quick
-        test_order_weighted_entries_cooldown_is_provider_scoped;
-    ];
-  ]
+  run
+    "Cascade_model_resolve"
+    [ ( "gemini auto"
+      , [ test_case "glm-coding:auto" `Quick test_glm_coding_auto_maps_to_glm_5_1
+        ; test_case
+            "glm-coding:auto model list"
+            `Quick
+            test_glm_coding_auto_models_default_order
+        ; test_case "gemini:auto" `Quick test_gemini_auto_maps_to_flash_preview
+        ; test_case
+            "gemini_cli:auto (regression 2026-04-20)"
+            `Quick
+            test_gemini_cli_auto_maps_to_flash_preview
+        ; test_case
+            "gemini_cli explicit"
+            `Quick
+            test_gemini_cli_explicit_model_passthrough
+        ; test_case "GEMINI_DEFAULT_MODEL env override" `Quick test_gemini_env_override
+        ; test_case
+            "gemini_cli:auto model list"
+            `Quick
+            test_gemini_cli_auto_models_default_rotation_order
+        ; test_case
+            "gemini_cli:auto env list override"
+            `Quick
+            test_gemini_cli_auto_models_env_override
+        ; test_case
+            "codex/claude cli auto env list override"
+            `Quick
+            test_codex_and_claude_cli_auto_models_env_override
+        ; test_case "kimi_cli:auto policy" `Quick test_kimi_cli_auto_model_policy
+        ; test_case
+            "expand_auto_models covers CLI auto"
+            `Quick
+            test_expand_auto_models_includes_cli_auto_specs
+        ; test_case
+            "execution expansion matches auto expansion"
+            `Quick
+            test_expand_model_strings_for_execution_matches_auto_expansion
+        ; test_case
+            "dedupe_stable: first wins on repeats"
+            `Quick
+            test_expand_model_strings_for_execution_dedupe_stable_repeated_inputs
+        ; test_case
+            "dedupe_stable: explicit beats auto-expansion"
+            `Quick
+            test_expand_model_strings_for_execution_dedupe_explicit_and_auto
+        ; test_case
+            "execution expansion can rotate by scope"
+            `Quick
+            test_expand_model_strings_for_execution_rotation_scope_rotates
+        ; test_case
+            "weighted ordering rotates auto by scope"
+            `Quick
+            test_order_weighted_entries_rotation_scope_rotates_generically
+        ; test_case
+            "weighted ordering rotates provider order by scope"
+            `Quick
+            test_order_weighted_entries_rotation_scope_rotates_top_level_providers
+        ; test_case
+            "weighted ordering cooldown is provider scoped"
+            `Quick
+            test_order_weighted_entries_cooldown_is_provider_scoped
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

`lib/cascade/cascade_model_resolve.{ml,mli}` and
`test/test_cascade_model_resolve.ml` predate the repo's `.ocamlformat`
janestreet-profile pin (introduced in `bf06f07b`) and were never
reformatted. The `ocamlformat-check` CI job only runs on files changed
by a PR, so the drift stayed invisible until #14914 (RFC-0058 Phase 5.3a)
touched these files — that PR was admin-merged with `ocamlformat-check`
failing as advisory. This PR clears the backlog.

## What changed

Pure `ocamlformat -i` output on three files — **no semantic change**.
`git show` on the single commit shows only layout churn from the
default→janestreet profile switch:

- multi-line variant declarations (`Concrete of string | Auto` → one per line)
- `;;` terminators after top-level `let`
- record fields with leading `;`
- 2-space match-arm indentation

## Verification

```
$ ocamlformat --check lib/cascade/cascade_model_resolve.ml \
    lib/cascade/cascade_model_resolve.mli test/test_cascade_model_resolve.ml
(exit 0 — clean)

$ MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build --root . test/test_cascade_model_resolve.exe
(pass)

$ _build/default/test/test_cascade_model_resolve.exe
1 failure! in 0.002s. 18 tests run.
```

The one failure is `test_order_weighted_entries_rotation_scope_rotates_top_level_providers`
— pre-existing on `origin/main`, unrelated to formatting (it concerns
provider rotation order, not layout). Out of scope.

## Notes

- Follow-up to #14914, mirroring the `style: apply ocamlformat` pattern
  used on the Phase 5.2b branch.
- No `.ml` logic is touched; the diff is mechanically reproducible by
  running `ocamlformat -i` on the three files at `origin/main` HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
