### PR TITLE
test(keeper): M-2.c OCaml-side CancelledNeverAbsorbed regression guard (iter 67)

### DIFF
--- a/lib/keeper/keeper_oas_checkpoint.ml
+++ b/lib/keeper/keeper_oas_checkpoint.ml
@@ -35,6 +35,12 @@ let persist_checkpoint ~dir ~session_id (ckpt : Agent_sdk.Checkpoint.t)
          Printf.sprintf "checkpoint persist failed for %s: %s" session_id err)
       (Fs_compat.save_file_atomic path (Agent_sdk.Checkpoint.to_string ckpt))
   with
+  (* CancelledNeverAbsorbed (KeeperOASAdvanced.tla): re-raise [Cancelled]
+     before the catch-all so a cancelled checkpoint fiber propagates the
+     cancel to its parent switch instead of returning a normal [Error]
+     result.  Absorbing it would create the spec's "zombie" — the parent
+     believes the child completed cleanly while the cancel signal is lost.
+     Regression guard: test/test_oas_checkpoint_cancelled_never_absorbed.ml *)
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
     Error (Printf.sprintf "checkpoint persist failed for %s: %s"

--- a/test/dune
+++ b/test/dune
@@ -1311,6 +1311,7 @@
 (include stanzas/test_normalized_actor.inc)
 (include stanzas/test_oas_bridge_judge_callers_9629.inc)
 (include stanzas/test_oas_bridge_timeout_ssot_10094.inc)
+(include stanzas/test_oas_checkpoint_cancelled_never_absorbed.inc)
 (include stanzas/test_oas_timeout_budget_strike.inc)
 (include stanzas/test_oas_worker.inc)
 (include stanzas/test_oas_worker_exec_close_cancel_source.inc)

--- a/test/stanzas/test_oas_checkpoint_cancelled_never_absorbed.inc
+++ b/test/stanzas/test_oas_checkpoint_cancelled_never_absorbed.inc
@@ -1,0 +1,8 @@
+; iter 67 M-2.c — OCaml-side CancelledNeverAbsorbed regression guard
+; (KeeperOASAdvanced.tla bug-model loop closer).
+; Pure source-text inspection; no MASC_BASE_PATH, no project libs.
+
+(test
+ (name test_oas_checkpoint_cancelled_never_absorbed)
+ (modules test_oas_checkpoint_cancelled_never_absorbed)
+ (deps ../lib/keeper/keeper_oas_checkpoint.ml))

--- a/test/test_oas_checkpoint_cancelled_never_absorbed.ml
+++ b/test/test_oas_checkpoint_cancelled_never_absorbed.ml
@@ -1,0 +1,91 @@
+(* test/test_oas_checkpoint_cancelled_never_absorbed.ml
+
+   OCaml-side regression guard for the [CancelledNeverAbsorbed]
+   invariant in [specs/keeper-state-machine/KeeperOASAdvanced.tla].
+
+   The spec's [CancelledAbsorbed] bug action models a catch-all that
+   swallows [Eio.Cancel.Cancelled] — a cancelled fiber returns a normal
+   [Error] result instead of letting the cancel propagate to its parent
+   switch.  The parent then believes the child completed cleanly while
+   the cancel signal is lost ("zombie").  The spec's bug model is
+   paired and verified on the TLA+ side; this test pins the OCaml
+   runtime's compliance.
+
+   [Keeper_oas_checkpoint.persist_checkpoint] is in the modelled OAS
+   bridge surface (called from {!Cascade_runner}).  Its [try/with]
+   returns [(unit, string) result] but re-raises [Cancelled] via a
+   dedicated arm placed *before* the [| exn ->] catch-all.  This test
+   asserts, by source inspection, that:
+
+     1. the dedicated [| Eio.Cancel.Cancelled _ as e -> raise e] arm
+        exists in [keeper_oas_checkpoint.ml], and
+     2. it precedes the [| exn ->] catch-all in the same function (so a
+        future reorder/removal can't silently funnel [Cancelled] into
+        the [Error] branch).
+
+   Source inspection rather than a runtime test because forcing
+   [Fs_compat.save_file_atomic] to raise [Cancelled] would require
+   mocking the filesystem module; the anchored-substring approach
+   mirrors [test_keeper_supervisor_finally_cancel_swallow.ml] (the
+   complementary case where re-raising from a [Fun.protect ~finally] is
+   itself the regression). *)
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> In_channel.input_all ic)
+
+let index_of haystack needle =
+  let n = String.length needle and h = String.length haystack in
+  let rec scan i =
+    if i + n > h then None
+    else if String.sub haystack i n = needle then Some i
+    else scan (i + 1)
+  in
+  scan 0
+
+let require ~label cond =
+  if not cond then
+    failwith
+      (Printf.sprintf
+         "[%s] keeper_oas_checkpoint.ml violates CancelledNeverAbsorbed \
+          (KeeperOASAdvanced.tla): see lib/keeper/keeper_oas_checkpoint.ml \
+          persist_checkpoint and iter 67 M-2.c"
+         label)
+
+let () =
+  let parent p = Filename.dirname p in
+  let exe = Sys.executable_name in
+  let project_root = parent (parent (parent (parent exe))) in
+  let candidates =
+    [ Filename.concat project_root "lib/keeper/keeper_oas_checkpoint.ml"
+    ; "lib/keeper/keeper_oas_checkpoint.ml"
+    ; "../lib/keeper/keeper_oas_checkpoint.ml"
+    ]
+  in
+  let src =
+    match List.find_opt Sys.file_exists candidates with
+    | Some p -> read_file p
+    | None ->
+      failwith
+        (Printf.sprintf
+           "no candidate source path resolved (cwd=%s, exe=%s)"
+           (Sys.getcwd ()) exe)
+  in
+  (* Anchor 1: the dedicated re-raise arm exists. *)
+  let reraise_arm = "| Eio.Cancel.Cancelled _ as e -> raise e" in
+  require ~label:"cancelled re-raise arm present"
+    (index_of src reraise_arm <> None);
+  (* Anchor 2: it precedes the catch-all in the same with-block. *)
+  (match index_of src reraise_arm, index_of src "| exn ->" with
+   | Some i_reraise, Some i_catchall ->
+     require ~label:"re-raise arm precedes catch-all"
+       (i_reraise < i_catchall)
+   | _ ->
+     failwith "[order] expected both a Cancelled arm and an | exn -> catch-all");
+  (* Anchor 3: the spec name is cited in the source comment so a future
+     refactor that drops the arm also has to delete the rationale. *)
+  require ~label:"spec invariant name cited"
+    (index_of src "CancelledNeverAbsorbed" <> None);
+  print_endline "test_oas_checkpoint_cancelled_never_absorbed: OK"


### PR DESCRIPTION
## Finding (Iteration 67, M-2.c — OCaml-side CancelledNeverAbsorbed regression guard)

**Spec**: `specs/keeper-state-machine/KeeperOASAdvanced.tla` (`CancelledAbsorbed` action + `CancelledNeverAbsorbed` invariant — already paired & verified on the TLA+ side)
**OCaml**: `lib/keeper/keeper_oas_checkpoint.ml` `persist_checkpoint` (already correct; +1 comment) + new `test/test_oas_checkpoint_cancelled_never_absorbed.ml`
**Aspect**: closing the bug-model loop on the OCaml side — the spec's "don't swallow Cancelled" invariant gets a runtime-side regression guard
**Risk**: LOW (comment + test only; no behaviour change)
**Workaround signature**: N/A — this is a *regression guard for an already-correct* property (not a suppression)

## 순서도

```mermaid
flowchart LR
  A[iter 61 #14911<br/>KOAS M-1 audit:<br/>bug-model paired/verified,<br/>0 spec concepts in lib/] --> B[iter 62 #14913<br/>M-2.a preamble: runtime owes spec]
  B --> C[iter 67 this PR M-2.c<br/>found persist_checkpoint<br/>ALREADY does the right thing]
  C --> D[+comment citing spec invariant<br/>+source-inspection regression test]
  D --> E[OCaml-side bug-model loop closed<br/>without runtime change]
```

## Before / After

`lib/keeper/keeper_oas_checkpoint.ml` `persist_checkpoint`:
```diff
   with
+  (* CancelledNeverAbsorbed (KeeperOASAdvanced.tla): re-raise [Cancelled]
+     before the catch-all so a cancelled checkpoint fiber propagates the
+     cancel to its parent switch instead of returning a normal [Error]
+     result.  Absorbing it would create the spec's "zombie" — the parent
+     believes the child completed cleanly while the cancel signal is lost.
+     Regression guard: test/test_oas_checkpoint_cancelled_never_absorbed.ml *)
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> Error (Printf.sprintf "checkpoint persist failed for %s: %s" ...)
```

New `test/test_oas_checkpoint_cancelled_never_absorbed.ml` — source-inspection guard asserting:
1. `| Eio.Cancel.Cancelled _ as e -> raise e` arm exists,
2. it precedes `| exn ->` in the same `with`-block (so a reorder can't funnel `Cancelled` into `Error`),
3. `CancelledNeverAbsorbed` is cited in the source comment (a refactor dropping the arm must also delete the rationale).

## 왜 톱니처럼 정교하지 않은가

`KeeperOASAdvanced.tla`는 `CancelledAbsorbed`/`CancelledNeverAbsorbed` bug-model이 paired + verified (memory: "Clean 56 states / Buggy 3 steps")인데, OCaml 측엔 *대응하는 회귀 가드가 없었다*. `persist_checkpoint`는 우연히 올바른 패턴(`| Eio.Cancel.Cancelled _ as e -> raise e` before `| exn -> Error`)을 갖고 있지만 — 그 한 줄에 *왜* 그래야 하는지 주석이 없어, 미래 refactor가 "쓸데없는 arm이네" 하고 제거하면 silently 회귀한다 (cancelled fiber가 zombie가 됨). FSM Sparse Match 안티패턴(`instructions/software-development.md`)의 친척 — exhaustive match가 강제하지 못하는 invariant는 테스트로 못박아야 한다. 보완: `test_keeper_supervisor_finally_cancel_swallow.ml`은 *반대* 케이스 (`Fun.protect ~finally`에서 Cancelled re-raise는 *버그*) — 이 둘이 합쳐서 "어디서 swallow하고 어디서 re-raise하는지"를 코드에 고정.

## 본 PR 수정

1. `keeper_oas_checkpoint.ml`의 `Cancelled` arm에 spec invariant를 인용하는 6줄 주석 (WHY가 non-obvious — CLAUDE.md "WHY 주석" 규칙).
2. `test/test_oas_checkpoint_cancelled_never_absorbed.ml` 신규 — anchored-substring 회귀 가드 (`test_keeper_supervisor_finally_cancel_swallow.ml` 패턴 미러; runtime 테스트 대신 source inspection — `Fs_compat.save_file_atomic`가 `Cancelled`를 raise하게 만들려면 fs 모듈 mocking 필요).
3. `test/stanzas/test_oas_checkpoint_cancelled_never_absorbed.inc` + `test/dune`에 알파벳 순 include 1줄.

## Verification

```
$ dune build --root . test/test_oas_checkpoint_cancelled_never_absorbed.exe   # clean
$ dune exec --root . test/test_oas_checkpoint_cancelled_never_absorbed.exe
test_oas_checkpoint_cancelled_never_absorbed: OK
$ dune build --root . test/test_oas_worker_exec_checkpoint.exe                 # compiles keeper_oas_checkpoint.ml → clean
```

## Trade-off

- Source-inspection 테스트는 runtime 테스트보다 약하다 — 실제 cancellation propagation을 검증하지 않고 *코드 형태*만 본다. 그러나 `persist_checkpoint`를 cancellation point에서 raise시키려면 `Fs_compat` mocking이 필요하고, 그건 별도 작업. anchored-substring 패턴은 이미 `test_keeper_supervisor_finally_cancel_swallow.ml`로 선례가 있음.
- `persist_checkpoint`가 유일한 OAS-surface `try/with → result` 후보였음 (`oas_execution_error_phase.ml`은 Prometheus label만, `oas_compat.ml`은 cancel 핸들링 없음). 더 넓은 OAS bridge cancellation 검증은 M-2.b (runtime `external_commit_witness` type, RFC 필요) 범위.

## RFC 참조

RFC-WAIVED: 주석 + 테스트만. `keeper_oas_checkpoint`는 RFC-required subsystem (credential/identity/operator/sandbox/hooks/workflow) 아님 — `bash ~/me/scripts/pr-rfc-check.sh` 통과.

## 진행 추적

다음 iteration 시작점:
1. **N-2.b** (KAQ Runtime status preamble — runtime-matches-spec flavour, status-disclosure 4번째 변종 완성) / **N-2.d** (KAQ TLC refresh)
2. **M-2.d** (LOW — KOAS clean+buggy cfg TLC refresh)
3. **R-D-2.a + R-D-1.a bundle** (MID ~150-300 LOC — KCAF call_err 3-way + Cascade_fsm.Exhausted 2-way split, biggest pending)
4. **새 spec entry** (KWP / KH 미진입) / **KSM A-5 잔여** (22×19 update_conditions matrix)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
