### PR TITLE
fix(keeper_registry): wrap validate_cascade_transition in wrap_unit (follow-up to #14927)

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1610,14 +1610,26 @@ let mark_turn_measurement ~base_path name =
    requires updating [resolve_cascade_transition]; this function reflects
    the change automatically. *)
 let validate_cascade_transition ~from ~to_ =
-  match resolve_cascade_transition ~from ~target:to_ with
-  | Resolved_idempotent | Resolved_transition _ -> ()
-  | Resolved_violation violation ->
-    raise_cascade_transition_violation
-      ~where:"validate_cascade_transition"
-      ~from
-      ~to_
-      ~violation
+  (* Wrapped in [Keeper_fsm_guard_runtime.wrap_unit] for symmetry with
+     [validate_turn_phase_transition] and the setters
+     ([set_turn_cascade_state] / [set_turn_phase]): a forbidden pair
+     reached via this validator bumps [metric_fsm_guard_violation]
+     (action=cascade_transition, stage=guard) before re-raising the typed
+     [Cascade_transition_violation] with its backtrace intact. Without
+     this wrap, a direct call to this validator on a forbidden pair was
+     uninstrumented (RFC-0072 Phase 5 left it as a thin shim). *)
+  Keeper_fsm_guard_runtime.wrap_unit
+    ~action:"cascade_transition"
+    ~stage:"guard"
+    (fun () ->
+       match resolve_cascade_transition ~from ~target:to_ with
+       | Resolved_idempotent | Resolved_transition _ -> ()
+       | Resolved_violation violation ->
+         raise_cascade_transition_violation
+           ~where:"validate_cascade_transition"
+           ~from
+           ~to_
+           ~violation)
 ;;
 
 (* RFC-0072 Phase 4b + Phase 5: collapse the 49-pair turn_phase matrix onto


### PR DESCRIPTION
## What

Follow-up to #14927 (RFC-0072 Phase 5 — typed transition exceptions).

#14927 routed forbidden transitions through `Keeper_fsm_guard_runtime.wrap_unit` for `validate_turn_phase_transition` and both setters (`set_turn_cascade_state` / `set_turn_phase`), so `metric_fsm_guard_violation` (action=…, stage=guard) fires on a forbidden pair. It left the standalone `validate_cascade_transition` unwrapped — a direct call to it on a forbidden pair raised the typed `Cascade_transition_violation` **without** bumping the counter.

This is:
- an asymmetry vs `validate_turn_phase_transition` (wrapped), and
- a mismatch with the test header comment in `test/test_keeper_sub_fsm_guards.ml`, which states forbidden transitions for **both** `cascade_state` and `turn_phase` "bump `masc_fsm_guard_violation_total`".

## Change

Wrap `validate_cascade_transition` in `wrap_unit ~action:"cascade_transition" ~stage:"guard"`, same shape as the turn_phase validator. No behavior change beyond the counter bump + the backtrace-preserving re-raise `wrap_unit` already does.

## Verification

- `dune build --root . lib/keeper` clean
- `dune exec test/test_keeper_sub_fsm_guards.exe` — 11/11 green
- `ocamlformat --check lib/keeper/keeper_registry.ml` clean

Surfaced by the Copilot review thread on #14927.

🤖 Generated with [Claude Code](https://claude.com/claude-code)