### PR TITLE
feat(sublibs): enable warning 4 on process + backend (RFC-0071 §3.4 ratchet)

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -684,7 +684,9 @@ module FileSystem = struct
                    | Ok () -> Ok true
                    | Error e -> Error e))
          | Error _ -> Ok false)
-    | Error e -> Error e
+    | Error
+        (( NotFound _ | IOError _ | InvalidKey _ | ConnectionFailed _
+         | BackendNotSupported _ ) as e) -> Error e
 
   let release_lock t ~key ~owner =
     let lock_key = "locks:" ^ key in
@@ -697,7 +699,9 @@ module FileSystem = struct
               | Error _ -> Ok false)
          | _ -> Ok false)  (* Not owner or invalid *)
     | Error (NotFound _) -> Ok true  (* Already released *)
-    | Error e -> Error e
+    | Error
+        (( AlreadyExists _ | IOError _ | InvalidKey _ | ConnectionFailed _
+         | BackendNotSupported _ ) as e) -> Error e
 
   let extend_lock t ~key ~owner ~ttl_seconds =
     let lock_key = "locks:" ^ key in

--- a/lib/backend/dune
+++ b/lib/backend/dune
@@ -7,6 +7,8 @@
   backend_types
   backend_compression
   backend)
+ ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on.
+ (flags (:standard -w +4))
  (libraries
  masc_types
   masc_core

--- a/lib/process/dune
+++ b/lib/process/dune
@@ -4,4 +4,6 @@
  (public_name masc_mcp.masc_process)
  (wrapped false)
  (modules process_eio file_lock_eio exec_tap with_process bg_task)
+ ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on.
+ (flags (:standard -w +4))
  (libraries masc_core masc_log time_compat eio eio.unix unix threads))

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -101,12 +101,17 @@ let default_env = function
   | Some env -> env
   | None -> Unix.environment ()
 
+(* [@@warning "-4"]: scrutinee is [exn] (extensible) — a wildcard arm is
+   mandatory because new exception constructors can never be enumerated.
+   RFC-0071 §3.4.1 sanctioned open-variant exemption, not a lazy
+   catch-all over a closed sum. *)
 let rec should_retry_unix_fallback = function
   | Unix.Unix_error
       ((Unix.EADDRINUSE | Unix.EADDRNOTAVAIL | Unix.EACCES | Unix.EPERM), "bind", _) ->
       true
   | Eio.Cancel.Cancelled exn -> should_retry_unix_fallback exn
   | _ -> false
+[@@warning "-4"]
 
 let close_quietly fd =
   try Unix.close fd with


### PR DESCRIPTION
## 목적

RFC-0071 §3.4 Phase 5 ratchet (#14888/#14894/#14900/#14923/#14930 후속).

> 브랜치명 `warn4-exec` — 원래 lib/exec 목표였으나 exec 는 ~9 fragile site (GADT 포함) 로 별도 PR 로 미루고, process + backend (3 site) 로 scope 축소.

## 변경

### lib/process — 1 fragile site
`process_eio.ml:104` `should_retry_unix_fallback` 가 `exn` (extensible variant) 매칭. wildcard arm 필수 — 모든 예외 enumerate 불가. **RFC-0071 §3.4.1 open-variant exemption**. `[@@warning "-4"]` + WORKAROUND 주석 추가.

### lib/backend — 2 fragile sites
`backend.ml:667` (`acquire_lock`) + `backend.ml:691` (`release_lock`) — `Error e -> Error e` passthrough 가 `Backend_types.error` (6 ctors) 위에서 fragile. 각각 non-special error 5개 명시:
\`\`\`ocaml
| Error ((NotFound _ | IOError _ | InvalidKey _ | ConnectionFailed _ | BackendNotSupported _) as e) -> Error e
\`\`\`
Behavior-preserving — `Error e` 가 이미 passthrough.

## 검증

- \`dune build --root .\` clean (3 warning-4 error → 0)
- backend tests green (72 across 3 files)
- process_eio + file_lock tests green

## 누적

| | `-w +4` sublibs |
|--|--|
| #14888 | 1 (lib/core, +1 fix) |
| #14894 | 5 |
| #14900 | 15 |
| #14923 | +1 (lib/config, +3 fix) |
| #14930 | +2 (autonomous, gate +1 fix) |
| **본 PR** | **+2 (process +1 exempt / backend +2 fix)** |
| **누계** | **26** |

## 다음

`lib/exec` — ~9 fragile sites: exit_code.ml ×4 (category type), approval_policy.ml ×2 (Capability.t GADT scan), output_parse.ml + exec_dispatch.ml (Unix.process_status), exec_gate.ml (Shell_ir_typed GADT). 별도 focused PR — GADT 사이트는 분석 필요.