### PR TITLE
spec(keq): Q-2.a/Q-2.b — KeeperEventQueue preamble + mli reflect implemented runtime (iter 69)

### DIFF
--- a/lib/keeper/keeper_event_queue.mli
+++ b/lib/keeper/keeper_event_queue.mli
@@ -2,19 +2,22 @@
 
     Models the contract verified in
     [specs/keeper-state-machine/KeeperEventQueue.tla]: enqueue is a
-    side-effect-free Event Layer operation, dequeue happens once per
-    Policy Layer turn, and dedup/urgency are bookkeeping concerns
-    that never delay an [enqueue].
+    side-effect-free Event Layer operation, the Policy Layer drains
+    pending stimuli once it gets a turn, and dedup/urgency are
+    bookkeeping concerns that never delay an [enqueue].
 
     This module is data only. The enqueue side is wired:
     [keeper_keepalive_signal.ml] calls [Keeper_registry.enqueue_event]
-    before the wakeup flag flips (RFC-0020 Rule 1), and
-    [keeper_heartbeat_loop.ml] dequeues once per turn (pinning the
-    [Conservation] invariant) and forces [Emit] when the queue is
-    non-empty (pinning [QueueNeverStarvedBySkip]). The remaining
-    follow-up is the consumer-side wiring of
-    [Heartbeat_smart.should_emit] so the Policy Layer reads the queue
-    before answering [Skip]. *)
+    before the wakeup flag flips (RFC-0020 Rule 1). On the dequeue side,
+    [keeper_heartbeat_loop.ml] drains the board-signal batch within the
+    debounce window via [Keeper_registry.drain_board_events] (a CAS loop
+    over [drain_board_window]) and falls back to a single non-board
+    [dequeue_event] when that batch is empty — either path pins the
+    [Conservation] invariant. [run_smart_heartbeat_gate] then snapshots
+    the queue and forces [Emit] when it is non-empty (pinning
+    [QueueNeverStarvedBySkip] — the queue is read before any [Skip]
+    takes effect, though that read currently lives in the gate rather
+    than inside [Heartbeat_smart.should_emit] itself). *)
 
 type urgency =
   | Immediate  (** operator commands and other latency-critical signals *)

--- a/lib/keeper/keeper_event_queue.mli
+++ b/lib/keeper/keeper_event_queue.mli
@@ -6,10 +6,15 @@
     Policy Layer turn, and dedup/urgency are bookkeeping concerns
     that never delay an [enqueue].
 
-    This module is data only. Wiring into
-    [keeper_keepalive_signal.wakeup_keeper] and
-    [Heartbeat_smart.should_emit] lives in a follow-up patch so
-    the queue can be exercised in isolation by tests first. *)
+    This module is data only. The enqueue side is wired:
+    [keeper_keepalive_signal.ml] calls [Keeper_registry.enqueue_event]
+    before the wakeup flag flips (RFC-0020 Rule 1), and
+    [keeper_heartbeat_loop.ml] dequeues once per turn (pinning the
+    [Conservation] invariant) and forces [Emit] when the queue is
+    non-empty (pinning [QueueNeverStarvedBySkip]). The remaining
+    follow-up is the consumer-side wiring of
+    [Heartbeat_smart.should_emit] so the Policy Layer reads the queue
+    before answering [Skip]. *)
 
 type urgency =
   | Immediate  (** operator commands and other latency-critical signals *)

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-12T02:43:01Z (HEAD: f71ee64b1)
+Generated: 2026-05-12T03:07:45Z (HEAD: 44dbd4d08)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -131,7 +131,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperCounterCausality.tla | KeeperCounterCausality | manual | 2 | 1 | clean={inv:Safety} buggy={inv:CausePresentWhenCounted} | 531942a050de |
 | KeeperDecisionPipeline.tla | KeeperDecisionPipeline | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:DecisionBoundaryRequiresMeasurement} | 3476c0518970 |
 | KeeperDwellMonotone.tla | KeeperDwellMonotone | manual | 2 | 1 | clean={inv:Safety} buggy={inv:DwellNonNegative} | 805be4907879 |
-| KeeperEventQueue.tla | KeeperEventQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | b6a4ce692708 |
+| KeeperEventQueue.tla | KeeperEventQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | c2c464472dca |
 | KeeperGenerationLineage.tla | KeeperGenerationLineage | manual | 2 | 1 | clean={inv:TypeOK, inv:CurrentTraceIsolation, inv:GenerationMatchesHistory, inv:CurrentTraceNotInHistory, inv:TraceHistoryUnique, inv:TraceIdsAllocated, inv:IdleCheckpointMatchesCommittedLineage, prop:HandoffEventuallyResolves} buggy={inv:TypeOK, inv:GenerationMatchesHistory, inv:CurrentTraceNotInHistory, inv:TraceHistoryUnique, inv:TraceIdsAllocated, inv:IdleCheckpointMatchesCommittedLineage} | bc957a36caf6 |
 | KeeperHeartbeat.tla | KeeperHeartbeat | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 35344ff2f4be |
 | KeeperLaunchPending.tla | KeeperLaunchPending | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 29a782dc0677 |

--- a/specs/keeper-state-machine/KeeperEventQueue.tla
+++ b/specs/keeper-state-machine/KeeperEventQueue.tla
@@ -15,19 +15,23 @@
 \*     - enqueue wiring: keeper_keepalive_signal.ml calls
 \*       Keeper_registry.enqueue_event before the wakeup flag flips and
 \*       comments "RFC-0020 Rule 1 (enqueue is independent of policy)".
-\*     - dequeue + override: keeper_heartbeat_loop.ml dequeues once per
-\*       turn ("pins the [Conservation] invariant ... in production",
-\*       dequeued_total <= enqueued_total) and forces Emit when the
-\*       queue is non-empty ("Pinned by KeeperEventQueue.tla
-\*       QueueNeverStarvedBySkip invariant").
-\*   Remaining honest gap: the consumer-side wiring of
-\*   Heartbeat_smart.should_emit (so the Policy Layer reads the queue
-\*   before answering Skip) is flagged "follow-up" in keeper_event_queue.mli
-\*   and at keeper_heartbeat_loop.ml. The drift this note closes was
-\*   audited in iter 68 #14933 (docs/tla-audit/keq-q1-event-queue-spec-
-\*   banner-vs-runtime-2026-05-12.md) — the inverse of KOAS M-2.a, where
-\*   the runtime owes the spec; here the spec banner had simply not
-\*   caught up to the runtime.
+\*     - dequeue: keeper_heartbeat_loop.ml drains the board-signal batch
+\*       within the debounce window via Keeper_registry.drain_board_events
+\*       (a CAS loop over Keeper_event_queue.drain_board_window) and
+\*       falls back to a single non-board dequeue_event when that batch
+\*       is empty — either path pins [Conservation]
+\*       (dequeued_total <= enqueued_total) in production.
+\*     - override: run_smart_heartbeat_gate snapshots the queue
+\*       (Keeper_registry.event_queue_snapshot) and forces Emit when it
+\*       is non-empty (metric_keeper_event_queue_override
+\*       reason="event_queue"), pinning QueueNeverStarvedBySkip — the
+\*       queue is read before any Skip takes effect, though that read
+\*       currently lives in the gate rather than inside
+\*       Heartbeat_smart.should_emit itself.
+\*   The drift this note closes was audited in iter 68 #14933
+\*   (docs/tla-audit/keq-q1-event-queue-spec-banner-vs-runtime-2026-05-12.md)
+\*   — the inverse of KOAS M-2.a, where the runtime owes the spec; here
+\*   the spec banner had simply not caught up to the runtime.
 \*
 \* Runtime entities modelled (see [keeper_event_queue.ml],
 \* [keeper_keepalive_signal.ml], [keeper_heartbeat_loop.ml]):

--- a/specs/keeper-state-machine/KeeperEventQueue.tla
+++ b/specs/keeper-state-machine/KeeperEventQueue.tla
@@ -1,17 +1,40 @@
 ---- MODULE KeeperEventQueue ----
 \* Event Layer / Policy Layer separation contract for the keeper
-\* heartbeat loop. Models the design described in
-\* docs/design/keeper-event-queue-layer-separation.md (forthcoming
-\* RFC), itself derived from RUTHLESS_JUDGMENT §3-4.
+\* heartbeat loop. Models the design in
+\* docs/rfc/RFC-0020-keeper-event-queue-layer-separation.md (Draft,
+\* 2026-04-30; RFC-0020 cites this spec as #12386), itself derived
+\* from RUTHLESS_JUDGMENT.md §1 A5 (the starvation-race walkthrough).
 \*
-\* Runtime entities modelled (see [keeper_keepalive_signal.ml] and
-\* [keeper_keepalive.ml]):
+\* Runtime status (2026-05-12, iter 69 Q-2.a):
+\*   The Event Layer this spec models is IMPLEMENTED in main, not
+\*   aspirational:
+\*     - data module: lib/keeper/keeper_event_queue.{ml,mli} — a
+\*       persistent FIFO of stimuli (enqueue / dequeue / dedup_by_post_id
+\*       / sort_by_urgency / classify / drain_board_window). Its .mli
+\*       opens "Models the contract verified in [KeeperEventQueue.tla]".
+\*     - enqueue wiring: keeper_keepalive_signal.ml calls
+\*       Keeper_registry.enqueue_event before the wakeup flag flips and
+\*       comments "RFC-0020 Rule 1 (enqueue is independent of policy)".
+\*     - dequeue + override: keeper_heartbeat_loop.ml dequeues once per
+\*       turn ("pins the [Conservation] invariant ... in production",
+\*       dequeued_total <= enqueued_total) and forces Emit when the
+\*       queue is non-empty ("Pinned by KeeperEventQueue.tla
+\*       QueueNeverStarvedBySkip invariant").
+\*   Remaining honest gap: the consumer-side wiring of
+\*   Heartbeat_smart.should_emit (so the Policy Layer reads the queue
+\*   before answering Skip) is flagged "follow-up" in keeper_event_queue.mli
+\*   and at keeper_heartbeat_loop.ml. The drift this note closes was
+\*   audited in iter 68 #14933 (docs/tla-audit/keq-q1-event-queue-spec-
+\*   banner-vs-runtime-2026-05-12.md) — the inverse of KOAS M-2.a, where
+\*   the runtime owes the spec; here the spec banner had simply not
+\*   caught up to the runtime.
 \*
-\*   event_queue          : the new Event Layer FIFO holding pending
+\* Runtime entities modelled (see [keeper_event_queue.ml],
+\* [keeper_keepalive_signal.ml], [keeper_heartbeat_loop.ml]):
+\*
+\*   event_queue          : the Event Layer FIFO holding pending
 \*                          stimuli (board posts, mentions, operator
-\*                          directives). Today this state lives only
-\*                          implicitly via fiber_wakeup and the
-\*                          interruptible_sleep race window.
+\*                          directives) — Keeper_event_queue.t.
 \*   smart_decision       : the Policy Layer output of
 \*                          Heartbeat_smart.should_emit (Emit/Skip).
 \*


### PR DESCRIPTION
## Finding (Iteration 69, KEQ Q-2.a + Q-2.b — preamble & mli reflect implemented runtime)

**Spec**: `specs/keeper-state-machine/KeeperEventQueue.tla` (preamble) · `lib/keeper/keeper_event_queue.mli` (header)
**Aspect**: fix the 9th first-entry sub-class ("spec banner lags runtime") found in iter 68 #14933 — KEQ's banner framed the Event Layer as aspirational while it's implemented in main
**Risk**: LOW (comment-only; no TLA+ semantics, no OCaml behaviour change)
**Workaround signature**: N/A — honest-doc (15th datapoint, status-disclosure "dormancy ended" flavour)

## 순서도

```mermaid
flowchart LR
  A[iter 68 #14933 KEQ Q-1 audit<br/>preamble: forthcoming RFC<br/>+ lives only implicitly] --> B[iter 69 this PR Q-2.a/Q-2.b]
  B --> C[KeeperEventQueue.tla preamble:<br/>RFC-0020 path + §1 A5<br/>+ dated Runtime status block]
  B --> D[keeper_event_queue.mli header:<br/>'data only, wiring in follow-up'<br/>→ 'enqueue wired, consumer follow-up']
  C & D --> E[banner now matches runtime<br/>inverse of K-2.d/L-2.a/M-2.a trilogy:<br/>'dormancy ended' not 'dormant']
```

## Before / After

**`KeeperEventQueue.tla` preamble:**
```diff
-\* Models the design described in
-\* docs/design/keeper-event-queue-layer-separation.md (forthcoming
-\* RFC), itself derived from RUTHLESS_JUDGMENT §3-4.
+\* Models the design in
+\* docs/rfc/RFC-0020-keeper-event-queue-layer-separation.md (Draft,
+\* 2026-04-30; RFC-0020 cites this spec as #12386), itself derived
+\* from RUTHLESS_JUDGMENT.md §1 A5 (the starvation-race walkthrough).
+\*
+\* Runtime status (2026-05-12, iter 69 Q-2.a):
+\*   The Event Layer this spec models is IMPLEMENTED in main, not
+\*   aspirational:
+\*     - data module: lib/keeper/keeper_event_queue.{ml,mli} ...
+\*     - enqueue wiring: keeper_keepalive_signal.ml ... "RFC-0020 Rule 1"
+\*     - dequeue + override: keeper_heartbeat_loop.ml ... pins Conservation
+\*       / QueueNeverStarvedBySkip
+\*   Remaining honest gap: Heartbeat_smart.should_emit consumer wiring ...
-\*   event_queue : the new Event Layer FIFO ... Today this state lives only
-\*                 implicitly via fiber_wakeup and the interruptible_sleep
-\*                 race window.
+\*   event_queue : the Event Layer FIFO holding pending stimuli ...
+\*                 — Keeper_event_queue.t.
```

**`keeper_event_queue.mli` header:**
```diff
-    This module is data only. Wiring into
-    [keeper_keepalive_signal.wakeup_keeper] and
-    [Heartbeat_smart.should_emit] lives in a follow-up patch so
-    the queue can be exercised in isolation by tests first. *)
+    This module is data only. The enqueue side is wired:
+    [keeper_keepalive_signal.ml] calls [Keeper_registry.enqueue_event]
+    before the wakeup flag flips (RFC-0020 Rule 1), and
+    [keeper_heartbeat_loop.ml] dequeues once per turn (pinning the
+    [Conservation] invariant) and forces [Emit] when the queue is
+    non-empty (pinning [QueueNeverStarvedBySkip]). The remaining
+    follow-up is the consumer-side wiring of
+    [Heartbeat_smart.should_emit] ... *)
```

## 왜 톱니처럼 정교하지 않은가

iter 68 audit가 짚은 대로: spec banner는 독자와의 계약 ("구현 상태는 이렇다"). 런타임이 따라잡았는데 배너가 안 따라가면 독자는 커버리지를 과소평가하거나 스펙을 불신한다. K-2.d/L-2.a/M-2.a status-disclosure trilogy가 *dormancy*를 공개했다면, 이 PR은 그 역 — *dormancy가 끝났음*을 공개. 같은 모양의 dated "Runtime status" 블록.

## 본 PR 수정

1. `KeeperEventQueue.tla` preamble — cited RFC 경로 정정 (`docs/design/...` 부재 → `docs/rfc/RFC-0020-...` Draft 2026-04-30), `§3-4` → `§1 A5`, "lives only implicitly" → dated "Runtime status (2026-05-12)" 블록 (data module / enqueue 배선 RFC-0020 Rule 1 / dequeue+override Conservation+QueueNeverStarvedBySkip / 남은 follow-up = Heartbeat_smart.should_emit consumer), module-reference list 갱신.
2. `keeper_event_queue.mli` header — "data only, wiring in follow-up" → "enqueue 배선 됨 (RFC-0020 Rule 1; Conservation/QueueNeverStarvedBySkip pinned); 남은 follow-up = Heartbeat_smart.should_emit consumer".

## Verification

```
$ bash scripts/audit-tla-phase-count.sh        # phase-count audit clean: SSOT=13
$ bash scripts/audit-tla-ml-line-refs.sh       # line-ref audit clean: 0 citations
$ dune build --root . test/test_keeper_event_queue.exe   # clean (compiles keeper_event_queue.mli)
```

(No TLC re-run — comment-only spec change. 15th honest-doc datapoint.)

## Trade-off

- "consumer-side wiring 완성도"를 깊게 검증하진 않음 — `keeper_event_queue.mli`와 `keeper_heartbeat_loop.ml:670`이 "follow-up"이라 명시하니 그 표기를 신뢰. Q-2.c (`EmitMatchesEvidence` enforcement-site pin)가 정확한 매핑을 만들 때 재확인.
- 이번 worktree는 새로 생성 (이전 `.worktrees/fsm-loop-iter51-rh1b2`가 iteration 사이에 제거됨 — `cd $(git rev-parse --show-toplevel)`가 stale dir에서 `~/me`로 fallback해 잠시 ~/me가 잘못된 브랜치로 checkout됨; 즉시 main 복구 + 브랜치 삭제. iter 64-68 PR은 모두 정상.)

## RFC 참조

RFC-0020 (Draft, 2026-04-30) — `docs/rfc/RFC-0020-keeper-event-queue-layer-separation.md`. 본 PR은 comment-only spec preamble + .mli header — RFC-WAIVED (`bash ~/me/scripts/pr-rfc-check.sh` 통과).

## 진행 추적

다음 iteration 시작점:
1. **Q-2.c** (LOW — `EmitMatchesEvidence`를 enforcement site에 pin 또는 pure-spec property 문서화, K-2.c `.mli` mapping-table 모양) / **Q-2.d** (LOW — KEQ.cfg + -buggy.cfg TLC refresh)
2. **N-2.b** (KAQ Runtime status preamble) / **N-2.d** (KAQ TLC) — #14925 머지 후
3. **M-2.d** (KOAS TLC refresh)
4. **R-D-2.a + R-D-1.a bundle** (MID ~150-300 LOC — biggest pending)
5. **새 spec entry** (KH 미진입 + ~15개 미감사 spec)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
