### PR TITLE
refactor(keeper_registry): RFC-0072 Phase 6 — typed compaction transition exception

### DIFF
--- a/docs/rfc/RFC-0072-keeper-sub-fsm-transitions-typed.md
+++ b/docs/rfc/RFC-0072-keeper-sub-fsm-transitions-typed.md
@@ -221,9 +221,18 @@ exception Turn_phase_transition_violation of
 - Tests (`test_keeper_sub_fsm_guards.ml`): `capture_invalid_arg` + substring-needle assertions replaced by pattern-matching the typed `violation` payload + a single `Printexc.to_string` render check per axis. (Bonus: this rewrite also fixes a latent broken test — `test_turn_phase_message_includes_labels` asserted `Turn_routing -> Turn_exhausted` is rejected, but PR #14395 made that pair *valid*; the heavy `dune test` CI step skips on most PRs so it went unnoticed.)
 - LOC: ~+130 / -55. Risk: low (typed payload + printer; no behaviour change on the success path; failure path message text preserved).
 
-### Phase 6 — Compaction axis audit (separate amendment)
+### Phase 6 — Compaction axis: typed exception, no GADT/resolver
 
-Inventory `compaction_stage` variants + transition matrix (currently an `assert`-based `@@fsm_guard` shim raising `Assert_failure`). Decide whether the resolver + typed-exception pattern applies.
+Inventory: `compaction_stage` has **3 states** (`accumulating`, `compacting`, `done`) → a 3×3 matrix = 3 idempotent + 3 valid cross-state + 3 forbidden. The pre-Phase-6 `validate_compaction_transition` was a bare `assert (match (from, to) with … -> true | … -> false)` inside `wrap_unit` — exhaustive (Warning-8 tripwire intact) but its `Assert_failure` carried only a file/line, not the rejected pair.
+
+Decision: apply the **typed-exception + diagnostic-label** half of the pattern (mirroring what #14389 gave the other axes' messages, going straight to typed since this axis never had an `invalid_arg` string phase), but **not** the GADT/resolver half — with 3 states and a single consumer (`validate_compaction_transition` ← `compaction_stage_after_event`), a `Compaction_transition` GADT (3 cross-state constructors) and a `resolve_compaction_transition` indirection would be premature abstraction.
+
+What ships:
+- `compaction_transition_spec_violation` (3 constructors: `Accumulating_to_done` / `Done_to_accumulating` / `Done_to_compacting`) + `_to_tag`.
+- `exception Compaction_transition_violation of { where; from; to_; violation }` + `Printexc.register_printer` + `raise_*` helper + `packed_compaction_stage_label` (constructor-name label, mirrors `packed_cascade_state_label`).
+- `validate_compaction_transition` body: `assert (match … -> bool)` → `match … with <6 valid> -> () | <3 forbidden> -> raise_compaction_transition_violation …`, still inside `wrap_unit` (`metric_fsm_guard_violation` action=`compaction_transition`, stage=`guard` still fires). Match stays exhaustive.
+- Tests: `test_invalid_compaction_transitions` catches `Compaction_transition_violation _` (was `Assert_failure _`) + checks payload endpoints; new `test_compaction_violation_payload` (typed `violation` tag + `Printexc.to_string` render).
+- LOC: ~+95 / -25. Risk: low (success path unchanged; failure path gains labels).
 
 ## 6. Risks
 
@@ -249,8 +258,10 @@ The audit in §2.4 counted explicit `set_turn_cascade_state` calls. There may be
 - **R-2**: `turn_phase` axis has 0 `invalid_arg` sites in `lib/` — **met by Phase 5** (the 2 turn_phase sites raise `Turn_phase_transition_violation` instead).
 - **R-3**: All `cascade_state` valid transitions are first-class GADT constructors — met by Phase 1.
 - **R-4**: Adding a new `cascade_state` (or `turn_phase`) variant requires editing the resolver and triggers Warning 8 at all match sites — met by Phase 1 / Phase 4a.
-- **R-5**: Existing test coverage is preserved or replaced by compile-time / typed-payload enforcement (no behavior regression) — met by Phase 3 / 4b / 5.
-- **R-6**: Phase 1, 2, 3, 4 (a/b), and 5 each ship in independent PRs, each <150 LOC impl.
+- **R-5**: Existing test coverage is preserved or replaced by compile-time / typed-payload enforcement (no behavior regression) — met by Phase 3 / 4b / 5 / 6.
+- **R-6**: Phase 1, 2, 3, 4 (a/b), 5, and 6 each ship in independent PRs, each <150 LOC impl.
+- **R-7**: `compaction_stage` forbidden transitions raise a typed exception (not `Assert_failure`), carrying the rejected pair + violation tag — met by Phase 6. (No GADT for this axis: deliberate, see §5 Phase 6.)
+- **R-8**: All 4 keeper sub-FSM axes (decision / cascade / turn_phase / compaction) are closed — decision via input refinement (#14887/#14893), cascade + turn_phase via resolver + typed exception (#14903→#14935), compaction via typed exception (Phase 6). No `_ -> false` catch-all and no untyped runtime rejection (`invalid_arg` / bare `Assert_failure`) remains on any axis's validator.
 
 ## 8. Open questions
 

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -907,6 +907,67 @@ let witness_to_compaction_stage : packed_compaction_stage -> compaction_stage = 
   | Packed Compaction_done -> Compaction_done
 ;;
 
+(* Diagnostic label using the constructor name (e.g. ["Compaction_done"]).
+   Used by the [Compaction_transition_violation] [Printexc] printer.
+   Distinct from [Keeper_composite_observer.compaction_stage_to_string]
+   which emits a snake_case form for dashboards. *)
+let packed_compaction_stage_label : packed_compaction_stage -> string = function
+  | Packed Compaction_accumulating -> "Compaction_accumulating"
+  | Packed Compaction_compacting -> "Compaction_compacting"
+  | Packed Compaction_done -> "Compaction_done"
+;;
+
+(* RFC-0072 Phase 6: typed error for forbidden compaction-stage transitions.
+   One constructor per of the 3 forbidden pairs in the compaction matrix
+   (3 idempotent + 3 valid cross-state + 3 forbidden = 9 = 3×3).  Mirrors
+   [cascade_transition_spec_violation] / [turn_phase_transition_spec_violation];
+   smaller because the compaction axis has only 3 states. *)
+type compaction_transition_spec_violation =
+  | Accumulating_to_done
+  | Done_to_accumulating
+  | Done_to_compacting
+
+let compaction_transition_spec_violation_to_tag = function
+  | Accumulating_to_done -> "accumulating->done"
+  | Done_to_accumulating -> "done->accumulating"
+  | Done_to_compacting -> "done->compacting"
+;;
+
+(* RFC-0072 Phase 6: typed exception for forbidden compaction transitions.
+   Replaces the prior bare [assert (match ... -> bool)] inside
+   [validate_compaction_transition], whose [Assert_failure] carried only a
+   file/line — not the rejected (from, to) pair.  Mirrors
+   [Cascade_transition_violation] / [Turn_phase_transition_violation]:
+   the typed [compaction_transition_spec_violation] payload travels on the
+   exception, and a [Printexc] printer renders the labelled message. *)
+exception
+  Compaction_transition_violation of
+    { where : string
+    ; from : packed_compaction_stage
+    ; to_ : packed_compaction_stage
+    ; violation : compaction_transition_spec_violation
+    }
+
+let compaction_transition_violation_message ~where ~from ~to_ ~violation =
+  Printf.sprintf
+    "%s: invalid compaction transition %s -> %s (spec_violation=%s)"
+    where
+    (packed_compaction_stage_label from)
+    (packed_compaction_stage_label to_)
+    (compaction_transition_spec_violation_to_tag violation)
+;;
+
+let raise_compaction_transition_violation ~where ~from ~to_ ~violation =
+  raise (Compaction_transition_violation { where; from; to_; violation })
+;;
+
+let () =
+  Printexc.register_printer (function
+    | Compaction_transition_violation { where; from; to_; violation } ->
+      Some (compaction_transition_violation_message ~where ~from ~to_ ~violation)
+    | _ -> None)
+;;
+
 type turn_measurement =
   { tm_captured_at : float
   ; tm_auto_rules : Keeper_state_machine.auto_rule_summary
@@ -2393,29 +2454,53 @@ let compaction_stage_of_event entry event =
   | _ -> entry.compaction_stage
 ;;
 
+(* RFC-0072 Phase 6: the 3×3 compaction matrix dispatched as an exhaustive
+   match — the 3 valid pairs (incl. idempotent self-loops) return [()], the
+   3 forbidden pairs raise the typed [Compaction_transition_violation]
+   (replacing the prior bare [assert], whose [Assert_failure] carried no
+   labels).  Still wrapped in [Keeper_fsm_guard_runtime.wrap_unit] so
+   [metric_fsm_guard_violation] (action=compaction_transition, stage=guard)
+   fires on a forbidden pair; the match stays exhaustive so adding a
+   [compaction_stage] variant triggers Warning 8 here.  No
+   [Compaction_transition] GADT / [resolve_*] helper: with 3 states and a
+   single consumer the resolver indirection would be premature. *)
 let validate_compaction_transition ~from ~to_ =
   Keeper_fsm_guard_runtime.wrap_unit
     ~action:"compaction_transition"
     ~stage:"guard"
     (fun () ->
-       assert (
-         match from, to_ with
-         (* from Compaction_accumulating *)
-         | Packed Compaction_accumulating, Packed Compaction_accumulating -> true
-         | Packed Compaction_accumulating, Packed Compaction_compacting ->
-           true (* via set_compaction_stage *)
-         | Packed Compaction_accumulating, Packed Compaction_done -> false
-         (* from Compaction_compacting *)
-         | Packed Compaction_compacting, Packed Compaction_accumulating ->
-           true (* via set_compaction_stage: retry *)
-         | Packed Compaction_compacting, Packed Compaction_compacting -> true
-         | Packed Compaction_compacting, Packed Compaction_done ->
-           true (* via set_compaction_stage *)
-         (* from Compaction_done — terminal *)
-         | Packed Compaction_done, Packed Compaction_accumulating ->
-           false (* terminal; new compaction is reset *)
-         | Packed Compaction_done, Packed Compaction_compacting -> false (* terminal *)
-         | Packed Compaction_done, Packed Compaction_done -> true))
+       match from, to_ with
+       (* Idempotent self-loops + valid cross-state transitions (6). *)
+       | Packed Compaction_accumulating, Packed Compaction_accumulating
+       | Packed Compaction_accumulating, Packed Compaction_compacting
+       (* via set_compaction_stage *)
+       | Packed Compaction_compacting, Packed Compaction_accumulating
+       (* via set_compaction_stage: retry after a failed compaction *)
+       | Packed Compaction_compacting, Packed Compaction_compacting
+       | Packed Compaction_compacting, Packed Compaction_done
+       (* via set_compaction_stage *)
+       | Packed Compaction_done, Packed Compaction_done -> ()
+       (* Forbidden transitions (3). *)
+       | Packed Compaction_accumulating, Packed Compaction_done ->
+         raise_compaction_transition_violation
+           ~where:"validate_compaction_transition"
+           ~from
+           ~to_
+           ~violation:Accumulating_to_done
+       | Packed Compaction_done, Packed Compaction_accumulating ->
+         (* terminal; a fresh compaction is a reset, not a transition *)
+         raise_compaction_transition_violation
+           ~where:"validate_compaction_transition"
+           ~from
+           ~to_
+           ~violation:Done_to_accumulating
+       | Packed Compaction_done, Packed Compaction_compacting ->
+         (* terminal *)
+         raise_compaction_transition_violation
+           ~where:"validate_compaction_transition"
+           ~from
+           ~to_
+           ~violation:Done_to_compacting)
 ;;
 
 let compaction_stage_after_event entry event =

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -441,6 +441,35 @@ type packed_compaction_stage =
 val compaction_stage_to_witness : compaction_stage -> packed_compaction_stage
 val witness_to_compaction_stage : packed_compaction_stage -> compaction_stage
 
+(** Diagnostic label using the constructor name (e.g. ["Compaction_done"]).
+    Used by the [Compaction_transition_violation] [Printexc] printer. *)
+val packed_compaction_stage_label : packed_compaction_stage -> string
+
+(** RFC-0072 Phase 6: typed error for the 3 forbidden compaction-stage
+    transitions (3 idempotent + 3 valid + 3 forbidden = 9 = 3×3). *)
+type compaction_transition_spec_violation =
+  | Accumulating_to_done
+  | Done_to_accumulating
+  | Done_to_compacting
+
+val compaction_transition_spec_violation_to_tag
+  :  compaction_transition_spec_violation
+  -> string
+
+(** RFC-0072 Phase 6: raised by [validate_compaction_transition] on a
+    forbidden compaction transition, carrying the typed
+    [compaction_transition_spec_violation] payload (replaces the prior bare
+    [assert] / [Assert_failure]).  [where] is a diagnostic label naming the
+    raising function.  A [Printexc] printer is registered so
+    [Printexc.to_string] renders the labelled message. *)
+exception
+  Compaction_transition_violation of
+    { where : string
+    ; from : packed_compaction_stage
+    ; to_ : packed_compaction_stage
+    ; violation : compaction_transition_spec_violation
+    }
+
 type turn_measurement = {
   tm_captured_at : float;
   tm_auto_rules : Keeper_state_machine.auto_rule_summary;
@@ -686,11 +715,12 @@ val set_turn_phase :
     [validate_turn_phase_transition] dispatches through
     [resolve_turn_phase_transition] and raises the typed
     [Turn_phase_transition_violation] on a forbidden pair (RFC-0072
-    Phase 4b + 5).  [validate_compaction_transition] is still the
-    [@@fsm_guard]-style [assert]-based shim (raises [Assert_failure]);
-    extending the resolver pattern to the compaction axis is a future
-    RFC-0072 phase.  Both bump [Prometheus.metric_fsm_guard_violation]
-    via [Keeper_fsm_guard_runtime.wrap_unit]. *)
+    Phase 4b + 5).  [validate_compaction_transition] is an exhaustive
+    3×3 match raising the typed [Compaction_transition_violation] on a
+    forbidden pair (RFC-0072 Phase 6 — no GADT/resolver indirection,
+    the axis has 3 states and a single consumer).  Both bump
+    [Prometheus.metric_fsm_guard_violation] via
+    [Keeper_fsm_guard_runtime.wrap_unit]. *)
 val validate_turn_phase_transition :
   from:packed_turn_phase -> to_:packed_turn_phase -> unit
 

--- a/test/test_keeper_sub_fsm_guards.ml
+++ b/test/test_keeper_sub_fsm_guards.ml
@@ -6,8 +6,9 @@
     spec-violation payload, and bump [masc_fsm_guard_violation_total].
     [decision_stage] forbidden transitions are unrepresentable at the
     call site ([decision_stage_active] [to_] type) — a compile-time
-    invariant, not a runtime check.  [compaction_stage] still raises
-    [Assert_failure] (the resolver pattern has not reached that axis). *)
+    invariant, not a runtime check.  [compaction_stage] forbidden
+    transitions raise the typed [Compaction_transition_violation]
+    (RFC-0072 Phase 6 — exhaustive 3×3 match, no GADT/resolver). *)
 
 open Masc_mcp.Keeper_registry
 module Obs = Masc_mcp.Keeper_composite_observer
@@ -301,7 +302,7 @@ let test_valid_compaction_transitions () =
   List.iter
     (fun (from, to_) ->
        try validate_compaction_transition ~from ~to_ with
-       | Assert_failure _ ->
+       | Assert_failure _ | Compaction_transition_violation _ ->
          Alcotest.fail
            (Printf.sprintf
               "valid compaction %s -> %s rejected"
@@ -327,7 +328,17 @@ let test_invalid_compaction_transitions () =
               (Obs.compaction_stage_to_string from)
               (Obs.compaction_stage_to_string to_))
        with
-       | Assert_failure _ -> ())
+       (* RFC-0072 Phase 6: forbidden pairs raise the typed exception, not
+          a bare [Assert_failure].  The payload's endpoints must match. *)
+       | Compaction_transition_violation { from = ef; to_ = et; _ } ->
+         Alcotest.(check string)
+           "violation.from matches"
+           (packed_compaction_stage_label from)
+           (packed_compaction_stage_label ef);
+         Alcotest.(check string)
+           "violation.to_ matches"
+           (packed_compaction_stage_label to_)
+           (packed_compaction_stage_label et))
     cases
 ;;
 
@@ -428,6 +439,37 @@ let test_cascade_violation_payload () =
     assert_str_contains ~haystack:rendered ~needle:(packed_cascade_state_label to_)
 ;;
 
+let test_compaction_violation_payload () =
+  let from : packed_compaction_stage = Packed Compaction_done in
+  let to_ : packed_compaction_stage = Packed Compaction_compacting in
+  match validate_compaction_transition ~from ~to_ with
+  | () -> Alcotest.fail "validator should have raised Compaction_transition_violation"
+  | exception Compaction_transition_violation { where; from = ef; to_ = et; violation } ->
+    Alcotest.(check string)
+      "where names the validator"
+      "validate_compaction_transition"
+      where;
+    Alcotest.(check string)
+      "violation.from"
+      (packed_compaction_stage_label from)
+      (packed_compaction_stage_label ef);
+    Alcotest.(check string)
+      "violation.to_"
+      (packed_compaction_stage_label to_)
+      (packed_compaction_stage_label et);
+    Alcotest.(check string)
+      "violation tag"
+      "done->compacting"
+      (compaction_transition_spec_violation_to_tag violation);
+    let rendered =
+      Printexc.to_string
+        (Compaction_transition_violation { where; from = ef; to_ = et; violation })
+    in
+    assert_str_contains ~haystack:rendered ~needle:"validate_compaction_transition";
+    assert_str_contains ~haystack:rendered ~needle:(packed_compaction_stage_label from);
+    assert_str_contains ~haystack:rendered ~needle:(packed_compaction_stage_label to_)
+;;
+
 (* ── Test runner ────────────────────────────────────────── *)
 
 let () =
@@ -474,6 +516,10 @@ let () =
             "cascade violation carries typed payload + Printexc text"
             `Quick
             test_cascade_violation_payload
+        ; Alcotest.test_case
+            "compaction violation carries typed payload + Printexc text"
+            `Quick
+            test_compaction_violation_payload
         ] )
     ]
 ;;


### PR DESCRIPTION
## What

RFC-0072 **Phase 6** — closes the last keeper sub-FSM axis. The compaction axis had a bare `assert (match (from, to) with … -> true | … -> false)` inside `Keeper_fsm_guard_runtime.wrap_unit` — exhaustive (Warning-8 tripwire intact) but its `Assert_failure` carried only a file/line, not the rejected pair, unlike the cascade / turn_phase / decision axes.

## Inventory + decision

`compaction_stage` has **3 states** (`accumulating`, `compacting`, `done`) → a 3×3 matrix = 3 idempotent + 3 valid cross-state + 3 forbidden:

| | → accumulating | → compacting | → done |
|---|---|---|---|
| **accumulating** | idempotent ✓ | valid ✓ | **forbidden** (`Accumulating_to_done`) |
| **compacting** | valid ✓ (retry after fail) | idempotent ✓ | valid ✓ |
| **done** (terminal) | **forbidden** (`Done_to_accumulating`) | **forbidden** (`Done_to_compacting`) | idempotent ✓ |

**Decision**: apply the typed-exception + diagnostic-label half of the RFC-0072 pattern (mirroring what #14389 gave the other axes' messages, going straight to typed since this axis never had an `invalid_arg` string phase). **Not** the GADT/resolver half — with 3 states and a single consumer (`validate_compaction_transition` ← `compaction_stage_after_event`), a `Compaction_transition` GADT (3 cross-state constructors) and a `resolve_compaction_transition` indirection would be premature abstraction. The RFC §5 Phase 6 section is rewritten to record this.

## Changes

| File | Change |
|---|---|
| `keeper_registry.ml/.mli` | `type compaction_transition_spec_violation` (3 ctors) + `_to_tag`; `exception Compaction_transition_violation of { where; from; to_; violation }` + `Printexc.register_printer` + `raise_*` helper + `packed_compaction_stage_label` (constructor-name label, distinct from `Keeper_composite_observer.compaction_stage_to_string`'s snake_case). `validate_compaction_transition` body: `assert (match … -> bool)` → `match … with <6 valid> -> () \| <3 forbidden> -> raise_compaction_transition_violation …`, still inside `wrap_unit` (`metric_fsm_guard_violation` action=`compaction_transition`, stage=`guard` still fires). Match stays exhaustive — adding a `compaction_stage` variant triggers Warning 8. |
| `test/test_keeper_sub_fsm_guards.ml` | `test_invalid_compaction_transitions` catches `Compaction_transition_violation _` (was `Assert_failure _`) + checks payload endpoints; new `test_compaction_violation_payload` (typed `violation` tag + `Printexc.to_string` render — mirrors the turn_phase / cascade payload tests from Phase 5). Header comment updated. |
| `docs/rfc/RFC-0072` | §5 Phase 6 rewritten from "audit" to the realised decision (typed exception, no GADT — with rationale); §7 adds R-7 + R-8. |

## Backward compatibility

`Printexc.register_printer` reproduces a labelled message:
```
validate_compaction_transition: invalid compaction transition Compaction_done -> Compaction_compacting (spec_violation=done->compacting)
```
No `Assert_failure` catchers near this validator exist in `lib/` (grep), so switching the exception type is lib-safe. `wrap_unit`'s catch is already widened to all exceptions (Phase 5), so the counter + backtrace-preserving re-raise apply unchanged.

## Verification

Heavy CI build runs in the clean GitHub Actions env. Local (worktree):
```
dune build lib/ test/test_keeper_sub_fsm_guards.exe  → clean
dune exec test/test_keeper_sub_fsm_guards.exe        → 12/12 OK
ocamlformat --check (changed files)                  → clean
```

## Status after this PR — RFC-0072 complete

All 4 keeper sub-FSM axes closed:
- **decision** — input refinement (`decision_stage_active` excludes the forbidden targets) — #14887 / #14893
- **cascade** — GADT + resolver + typed exception, all violation paths instrumented via `wrap_unit` — #14903 → #14908 → #14927 → #14935
- **turn_phase** — same — #14912 → #14918 → #14926 → #14927
- **compaction** — typed exception (no GADT) — **this PR**

No `_ -> false` catch-all and no untyped runtime rejection (`invalid_arg` / bare `Assert_failure`) remains on any axis's validator. (`rg "invalid_arg" lib/keeper/keeper_registry.ml` → 1 hit: the FSM-unrelated `keeper name contains unit separator` check.)

Remaining RFC-0072 housekeeping (out of scope): RFC-0072 number collision (`RFC-0072-keeper-sub-fsm-transitions-typed.md` ↔ `RFC-0072-provider-adapter-sublib-extraction.md` coexist on main) — renumber touches the other RFC + its referencing PRs, separate cleanup.

## Self-check (Workaround Rejection Bar)

| # | Check | Result |
|---|---|---|
| 1 | telemetry-as-fix? | no — metric counter preserved (still fires via `wrap_unit`), not added as the fix; fix is the typed payload + labels |
| 2 | string classifier? | no — typed sum, no substring matching anywhere |
| 3 | N-of-M? | no — compaction is the last axis; all 4 now closed (R-8) |
| 4 | catch-all added? | no — the match was already exhaustive (the prior `assert` enumerated all 9 pairs); this PR keeps it exhaustive and removes the `assert` wrapper |
| 5 | cap/cooldown/dedup? | no |
| 6 | test backdoor? | no — no `set_X_for_test`; tests use the public validator + typed exception |
| 7 | typo N sites? | no |

## References

- **RFC-0072** §5 Phase 6 (realised decision), §7 R-7 / R-8
- **PR #14927** Phase 5 — typed cascade/turn_phase exceptions (this PR mirrors the pattern, minus the GADT)
- **PR #14935** follow-up — wrapped `validate_cascade_transition` in `wrap_unit` (the symmetry this PR continues for compaction)
- **PR #14389** — "include from/to labels in FSM transition rejection messages" (the diagnostic-label pattern this PR brings to the compaction axis, going straight to typed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
