### PR TITLE
docs(tla-audit): KCB R-1 — KeeperCircuitBreaker spec↔OCaml verified clean + drop stale docstring line ref (iter 70)

### DIFF
--- a/docs/tla-audit/kcb-r1-circuit-breaker-spec-ocaml-verified-2026-05-12.md
+++ b/docs/tla-audit/kcb-r1-circuit-breaker-spec-ocaml-verified-2026-05-12.md
@@ -1,0 +1,55 @@
+# KCB R-1 — KeeperCircuitBreaker.tla ↔ OCaml: mapping verified, one docstring line-ref nit (first-entry audit)
+
+**Date**: 2026-05-12 · **Iteration**: 70 (`/loop` FSM/TLA+/OCaml drift hunt) · **Phase**: R (first entry)
+**Spec**: `specs/keeper-state-machine/KeeperCircuitBreaker.tla` (154 LOC, 6 vars, bug-model paired)
+**OCaml**: `lib/keeper/keeper_failure_circuit_breaker.{ml,mli}` (447 + 142 LOC)
+**Verdict**: **clean** — the spec↔OCaml mapping is bidirectional and accurate, the runtime implements the class-isolation property exactly as modelled, and both `.cfg` / `-buggy.cfg` exist. One trivial drift: the OCaml docstring's reverse-citation cites `[type error_class]` at "`~line 17`" but the declaration is at line 46 (+29). Fixed in this PR by dropping the line number (N-2.a shape, iter 64).
+
+## Cross-checks (all pass)
+
+| Spec element | OCaml | Status |
+|---|---|---|
+| CONSTANT `Threshold` (= 3 in prod) | `keeper_failure_circuit_breaker.ml` `let threshold = 3` | ✓ exact |
+| `count` (0..Threshold) | `mutable consecutive_count : int` | ✓ |
+| `currentClass` | `mutable consecutive_class : error_class` | ✓ |
+| `tripped` (hint injected this step) | `record_failure : ... -> string option` (Some hint when tripped) | ✓ |
+| `ErrorClasses` (spec: 3) | `type error_class = Path_not_found \| Path_not_allowed \| Cwd_not_directory \| Shell_exit_nonzero \| Other` (5) | ✓ — spec preamble explicitly documents the 3↔5 projection as Refinement, not Drift; `Cwd_not_directory` / `Shell_exit_nonzero` fold into the spec's "other" partition for `ClassIsolation` |
+| `RecordFailure(cls)` — same class → `count+1`; `>= Threshold` → trip, `count=0`; **different class → `count=1, currentClass=cls`** | `record_failure`: `if cls = s.consecutive_class then s.consecutive_count <- s.consecutive_count + 1 else (s.consecutive_class <- cls; s.consecutive_count <- 1)`; trip branch sets `s.consecutive_count <- 0` | ✓ — the class-change reset (the safety-critical branch the buggy model removes) is present |
+| `SpecBuggy` (`RecordFailureBuggy`: "no class-change branch — always increment") | not present in OCaml | ✓ — runtime does not exhibit the bug |
+| `.cfg` / `-buggy.cfg` | `KeeperCircuitBreaker.cfg` + `KeeperCircuitBreaker-buggy.cfg` both present | ✓ |
+| Bidirectional cross-ref | spec preamble has an `OCaml ↔ TLA+ mapping` table citing module symbols; OCaml docstring has the reverse "Spec navigation (OCaml -> TLA+)" block citing `KeeperCircuitBreaker.tla (#8642 family)` and quoting spec line ranges 9-13 / 15-22 (both accurate) | ✓ |
+
+## The one nit (fixed here)
+
+`keeper_failure_circuit_breaker.ml` docstring, line ~25:
+
+```
+ErrorClasses  -> [type error_class] (this file, ~line 17)
+```
+
+`type error_class` is declared at **line 46**, not ~17 (drift +29). The "~" hedges it, but 17 vs 46 is not "approximately the same". This is the OCaml-docstring variant of the 8th drift sub-class (line-reference drift, iter 63 KAQ N-1) — and it is *not* caught by `scripts/audit-tla-ml-line-refs.sh` (that validator scans TLA preambles, not OCaml docstrings) nor by `scripts/audit-ocaml-phase-count.sh` (phase counts only). Fixed by dropping the line number entirely and naming the symbol as the stable anchor (N-2.a shape).
+
+The other two line-range citations in the same block — "Spec lines 9-13" (the 5 mapping rows) and "spec lines 15-22" (the scope-projection prose) — were checked against the current `KeeperCircuitBreaker.tla` and are accurate; left unchanged.
+
+## Why this matters (modestly)
+
+The good news first: this is the kind of spec↔OCaml pair the corpus should aim for — small, a typed `error_class` sum on the OCaml side, a CONSTANT-matched `Threshold`, an explicitly-documented projection for the class-count mismatch, a paired bug model, and *bidirectional* cross-references so a search from either side lands at the other. Nothing structural is wrong. The only drift is the one OCaml docstring line number, and that's the same self-limiting class the loop already has a TLA-side validator for — worth fixing for consistency, not because it's load-bearing.
+
+## Possible follow-up (not in scope)
+
+- **R-1.a (LOW)** — extend `scripts/audit-tla-ml-line-refs.sh` (or a sibling) to also scan `lib/keeper/*.{ml,mli}` docstring "Spec navigation" blocks for `(~?line N)` claims and verify the cited symbol is within tolerance. Would have caught this nit automatically. Mirrors R-H-1.f (the OCaml-side twin of R-H-1.c). MED — needs a regex for the OCaml-docstring shape.
+
+## Verification (this audit)
+
+```
+$ wc -l specs/keeper-state-machine/KeeperCircuitBreaker.tla        # 154
+$ wc -l lib/keeper/keeper_failure_circuit_breaker.{ml,mli}         # 447 + 142
+$ rg -n 'type error_class|let threshold|consecutive_count|consecutive_class|record_failure' lib/keeper/keeper_failure_circuit_breaker.ml
+$ ls specs/keeper-state-machine/KeeperCircuitBreaker*.cfg          # .cfg + -buggy.cfg
+```
+
+This PR also drops the stale `~line 17` line number from the OCaml docstring (comment-only). No spec or `.cfg` change.
+
+## RFC trail
+
+`keeper_failure_circuit_breaker.ml` is not in the credential/identity/operator/sandbox/hooks/workflow RFC-required set — RFC-WAIVED for the comment-only docstring fix. Spec lineage: `#8642 family` (per the spec preamble).

--- a/lib/keeper/keeper_failure_circuit_breaker.ml
+++ b/lib/keeper/keeper_failure_circuit_breaker.ml
@@ -22,7 +22,8 @@
       count         -> [mutable consecutive_count : int]
       currentClass  -> [mutable consecutive_class : error_class]
       tripped       -> [record_failure] return value
-      ErrorClasses  -> [type error_class] (this file, ~line 17)
+      ErrorClasses  -> [type error_class] (this file; the name is the
+                       stable anchor — see iter 64 N-2.a, line numbers drift)
 
     This block is the reverse-direction citation so code search for
     "KeeperCircuitBreaker" lands in this module.


### PR DESCRIPTION
## Finding (Iteration 70, KCB R-1 — KeeperCircuitBreaker spec↔OCaml verified clean + one docstring line-ref nit)

**Spec**: `specs/keeper-state-machine/KeeperCircuitBreaker.tla` (154 LOC, 6 vars, bug-model paired) — first entry for a previously-unaudited spec
**OCaml**: `lib/keeper/keeper_failure_circuit_breaker.{ml,mli}` (447 + 142 LOC)
**Aspect**: spec↔OCaml mapping verification — result is **clean** (bidirectional, accurate, runtime matches the modelled class-isolation property, both cfg present); one trivial OCaml-docstring line-ref drift fixed
**Risk**: LOW (audit memo + comment-only docstring fix)
**Workaround signature**: N/A — verification + a 1-line stale-citation cleanup

## 순서도

```mermaid
flowchart LR
  A[iter 1/3 precedent:<br/>'drift 없음 + visualization'<br/>도 valid finding] --> B[iter 70 KCB R-1<br/>first un-audited spec checked]
  B --> C[cross-check 8개 항목<br/>Threshold/count/class/record_failure/<br/>error_class/RecordFailure semantics/<br/>buggy-absent/cfg-pair]
  C --> D[모두 ✓ — runtime matches spec<br/>bidirectional cross-ref healthy]
  C --> E[1 nit: docstring cites<br/>type error_class @ ~line 17<br/>actual line 46 +29]
  E --> F[fix: drop line number<br/>N-2.a shape iter 64]
```

## Cross-checks (all pass)

| Spec element | OCaml | Status |
|---|---|---|
| CONSTANT `Threshold` (3 in prod) | `let threshold = 3` | ✓ exact |
| `count` (0..Threshold) | `mutable consecutive_count : int` | ✓ |
| `currentClass` | `mutable consecutive_class : error_class` | ✓ |
| `tripped` (hint injected this step) | `record_failure : ... -> string option` | ✓ |
| `ErrorClasses` (spec: 3) | `type error_class = Path_not_found \| Path_not_allowed \| Cwd_not_directory \| Shell_exit_nonzero \| Other` (5) | ✓ — spec preamble explicitly documents the 3↔5 projection as Refinement (extra classes fold into "other" for `ClassIsolation`) |
| `RecordFailure(cls)` — same class → `count+1`; trip → `count=0`; **diff class → `count=1, currentClass=cls`** | `if cls = s.consecutive_class then incr else (s.consecutive_class <- cls; s.consecutive_count <- 1)`; trip branch → `consecutive_count <- 0` | ✓ — the class-change reset (the safety-critical branch) is present |
| `SpecBuggy` `RecordFailureBuggy` ("no class-change branch — always increment") | not present | ✓ — runtime doesn't exhibit the bug |
| `.cfg` / `-buggy.cfg` | both present | ✓ |
| bidirectional cross-ref | spec preamble has `OCaml ↔ TLA+ mapping` table; OCaml docstring has reverse "Spec navigation" block citing `#8642 family` + spec line ranges 9-13 / 15-22 (both checked, accurate) | ✓ |

## Before / After (the one nit)

```diff
       tripped       -> [record_failure] return value
-      ErrorClasses  -> [type error_class] (this file, ~line 17)
+      ErrorClasses  -> [type error_class] (this file; the name is the
+                       stable anchor — see iter 64 N-2.a, line numbers drift)
```

`type error_class` is at line **46**, not ~17 (drift +29). Same self-limiting class as the 8th drift sub-class (line-reference drift, iter 63 KAQ N-1) but in an OCaml docstring — *not* caught by `scripts/audit-tla-ml-line-refs.sh` (TLA preambles only) or `scripts/audit-ocaml-phase-count.sh` (phase counts only). Fixed per the N-2.a precedent: drop the line number, name the symbol.

## 왜 톱니처럼 정교한가 (이번엔 거의 정교함)

좋은 소식부터: 이건 corpus가 지향해야 할 모양이다 — 작은 spec, OCaml 측에 typed `error_class` sum, CONSTANT-matched `Threshold`, class-count 불일치에 대한 명시적 projection 문서화, paired bug model, 그리고 *양방향* cross-reference (어느 쪽에서 검색해도 반대쪽에 도달). 구조적으로 잘못된 게 없다. 유일한 drift는 OCaml docstring의 한 line number이고, 그것도 loop이 이미 TLA-side validator를 갖고 있는 self-limiting 클래스다 — load-bearing이라서가 아니라 일관성을 위해 고친다.

## 본 PR

`docs/tla-audit/kcb-r1-circuit-breaker-spec-ocaml-verified-2026-05-12.md` (+~70 LOC) — first-entry 검증 메모. + `keeper_failure_circuit_breaker.ml` docstring 1줄 (stale `~line 17` 제거). spec/.cfg 미변경. Verified: `dune build test/test_circuit_breaker.exe` clean.

## Trade-off

- TLC 미실행 — comment-only 변경, cfg pair 존재만 확인. (`KeeperCircuitBreaker-buggy.cfg`가 실제로 `ClassIsolation` 위반을 보이는지는 다음 TLC-refresh iteration에서.)
- Possible follow-up **R-1.a (MED)**: `scripts/audit-tla-ml-line-refs.sh`의 sibling로 `lib/keeper/*.{ml,mli}` docstring "Spec navigation" 블록의 `(~?line N)` 클레임도 검증 — 이 nit을 자동으로 잡았을 것. R-H-1.f (R-H-1.c의 OCaml-side twin)와 같은 패턴.

## RFC 참조

`keeper_failure_circuit_breaker.ml`은 credential/identity/operator/sandbox/hooks/workflow RFC-required set 아님 — RFC-WAIVED (docs/ 메모 + comment-only docstring; `bash ~/me/scripts/pr-rfc-check.sh` 통과). Spec lineage: `#8642 family`.

## 진행 추적

다음 iteration 시작점:
1. **R-1.a** (MED — OCaml docstring "Spec navigation" line-ref validator, R-H-1.f shape) OR
2. **Q-2.c** (KEQ `EmitMatchesEvidence` pin) / **Q-2.d** (KEQ TLC) / **M-2.d** (KOAS TLC) / **N-2.b·N-2.d** (KAQ) OR
3. **R-D-2.a + R-D-1.a bundle** (MID ~150-300 LOC — biggest pending) OR
4. **새 spec entry** (KH 미진입; KeeperTurnSlot / KeeperLaunchPending / KeeperMemoryLifecycle / KeeperRolloverDecision 등 ~14개 미감사)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
