### PR TITLE
feat(exec): enable warning 4 on masc_exec + close 9 fragile sites (RFC-0071 §3.4)

### DIFF
--- a/lib/exec/approval_policy.ml
+++ b/lib/exec/approval_policy.ml
@@ -11,7 +11,15 @@ type t = {
 
 (* Scan the cap list for a Destructive git op.  Returned first because
    it short-circuits the policy — the approval UI cannot "yes" its way
-   past this one. *)
+   past this one.
+
+   [@warning "-4"]: the [_ :: rest] arm is a find-first scan that
+   *intentionally* skips every non-matching capability — including
+   future [Capability.t] ctors and future [Git_op.t] ctors that are not
+   [Destructive]. Forcing an explicit enumeration over both nested
+   variants adds friction with no safety gain (the answer is always
+   "skip and keep scanning"). RFC-0071 §3.4.1 — nested find-first scan
+   exemption, not a closed-sum dispatch. *)
 let find_destructive_git (caps : Capability.t list) : Git_op.t option =
   let rec scan = function
     | [] -> None
@@ -23,10 +31,16 @@ let find_destructive_git (caps : Capability.t list) : Git_op.t option =
     | _ :: rest -> scan rest
   in
   scan caps
+[@@warning "-4"]
 
 (* Scan for a Write_path that escapes the worktree.  Returned next
    because write-outside is the "is this supposed to touch the host?"
-   smell. *)
+   smell.
+
+   [@warning "-4"]: same find-first-scan rationale as
+   [find_destructive_git] — the [_ :: rest] arm intentionally skips
+   every non-escaping capability, future ctors included.
+   RFC-0071 §3.4.1 nested find-first scan exemption. *)
 let find_write_escape (caps : Capability.t list) : Path_scope.t option =
   let escapes (ps : Path_scope.t) : bool =
     match Path_scope.scope ps with
@@ -43,6 +57,7 @@ let find_write_escape (caps : Capability.t list) : Path_scope.t option =
     | _ :: rest -> scan rest
   in
   scan caps
+[@@warning "-4"]
 
 (* Highest bin risk observed in the full cap tree. *)
 let max_risk (caps : Capability.t list) : Bin.risk_class =

--- a/lib/exec/approval_policy.ml
+++ b/lib/exec/approval_policy.ml
@@ -13,13 +13,13 @@ type t = {
    it short-circuits the policy — the approval UI cannot "yes" its way
    past this one.
 
-   [@warning "-4"]: the [_ :: rest] arm is a find-first scan that
-   *intentionally* skips every non-matching capability — including
-   future [Capability.t] ctors and future [Git_op.t] ctors that are not
-   [Destructive]. Forcing an explicit enumeration over both nested
-   variants adds friction with no safety gain (the answer is always
-   "skip and keep scanning"). RFC-0071 §3.4.1 — nested find-first scan
-   exemption, not a closed-sum dispatch. *)
+   [@@warning "-4"] (on the function below): the [_ :: rest] arm is a
+   find-first scan that *intentionally* skips every non-matching
+   capability — including future [Capability.t] ctors and future
+   [Git_op.t] ctors that are not [Destructive]. Forcing an explicit
+   enumeration over both nested variants adds friction with no safety
+   gain (the answer is always "skip and keep scanning"). RFC-0071
+   §3.4.1 — nested find-first scan exemption, not a closed-sum dispatch. *)
 let find_destructive_git (caps : Capability.t list) : Git_op.t option =
   let rec scan = function
     | [] -> None
@@ -37,10 +37,10 @@ let find_destructive_git (caps : Capability.t list) : Git_op.t option =
    because write-outside is the "is this supposed to touch the host?"
    smell.
 
-   [@warning "-4"]: same find-first-scan rationale as
-   [find_destructive_git] — the [_ :: rest] arm intentionally skips
-   every non-escaping capability, future ctors included.
-   RFC-0071 §3.4.1 nested find-first scan exemption. *)
+   [@@warning "-4"] (on the function below): same find-first-scan
+   rationale as [find_destructive_git] — the [_ :: rest] arm
+   intentionally skips every non-escaping capability, future ctors
+   included. RFC-0071 §3.4.1 nested find-first scan exemption. *)
 let find_write_escape (caps : Capability.t list) : Path_scope.t option =
   let escapes (ps : Path_scope.t) : bool =
     match Path_scope.scope ps with

--- a/lib/exec/dune
+++ b/lib/exec/dune
@@ -5,6 +5,8 @@
  (name masc_exec)
  (public_name masc_mcp.masc_exec)
  (wrapped true)
+ ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on.
+ (flags (:standard -w +4))
  (libraries masc_process masc_core masc_config eio unix yojson re))
 
 ; RFC-0054 PR-3 — auto-generate parallel-verification walkers for

--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -132,7 +132,8 @@ let rec dispatch_pipeline stages =
                 let final_status =
                   match last_status with
                   | Unix.WEXITED 0 -> result.status
-                  | _ -> last_status
+                  | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
+                      last_status
                 in
                 { result with status = final_status })
         | Pipeline _ :: _ ->

--- a/lib/exec/exec_gate.ml
+++ b/lib/exec/exec_gate.ml
@@ -153,12 +153,16 @@ let verdict_for_argv ~actor ~raw_source ~summary ~argv ?env ?cwd () =
     let overlay = Approval_config.lookup rollout_config ~actor in
     let policy : Approval_policy.t = { raw_source; summary } in
     let typed = Shell_ir_typed.of_simple simple in
+    (* [@warning "-4"]: [typed] is a GADT existential (Shell_ir_typed.W).
+       Enumerating every wrapped node type is impractical; the intent is
+       "Generic gets the legacy capability check, everything else gets the
+       typed path". RFC-0071 §3.4.1 GADT-existential exemption. *)
     let caps =
-      match typed with
-      | Shell_ir_typed.W (Shell_ir_typed.Generic _) ->
-        Capability_check.of_simple simple
-      | _ ->
-        Capability_check_typed.of_command typed
+      (match typed with
+       | Shell_ir_typed.W (Shell_ir_typed.Generic _) ->
+         Capability_check.of_simple simple
+       | _ ->
+         Capability_check_typed.of_command typed) [@warning "-4"]
     in
     let verdict = Approval_policy.decide policy ~overlay ~caps ~simple in
     Ok verdict

--- a/lib/exec/exit_code.ml
+++ b/lib/exec/exit_code.ml
@@ -81,7 +81,9 @@ let of_process_status = function
     in
     (* cat is provably one of {Oom_killed, Segfault, Signal _} from the
        [match signum] above; the remaining category ctors are listed
-       explicitly so a new ctor forces a compile error here (warning 4). *)
+       explicitly (no [_ ->] arm) so a new ctor makes this match
+       non-exhaustive — warning 8, which the top-level dune turns into a
+       compile error via [-warn-error +8]. *)
     let lab = match cat with
       | Oom_killed -> "oom_killed"
       | Segfault -> "segfault"

--- a/lib/exec/exit_code.ml
+++ b/lib/exec/exit_code.ml
@@ -79,11 +79,15 @@ let of_process_status = function
       | 11 -> Segfault
       | _ -> Signal signum
     in
+    (* cat is provably one of {Oom_killed, Segfault, Signal _} from the
+       [match signum] above; the remaining category ctors are listed
+       explicitly so a new ctor forces a compile error here (warning 4). *)
     let lab = match cat with
       | Oom_killed -> "oom_killed"
       | Segfault -> "segfault"
       | Signal s -> Printf.sprintf "killed_by_%s" (signal_name s)
-      | _ -> "signal" (* unreachable for this branch *)
+      | Success | General_error | Usage_error | Data_error
+      | Permission_error | Not_found | Timeout | Unknown _ -> "signal"
     in
     let hnt = match cat with
       | Oom_killed ->
@@ -93,7 +97,8 @@ let of_process_status = function
       | Signal s ->
         Printf.sprintf "Process received %s. May have been killed externally."
           (signal_name s)
-      | _ -> ""
+      | Success | General_error | Usage_error | Data_error
+      | Permission_error | Not_found | Timeout | Unknown _ -> ""
     in
     { raw = Unix.WEXITED n; code = n;
       category = cat; label = lab; hint = hnt }
@@ -108,11 +113,13 @@ let of_process_status = function
       | 11 -> Segfault
       | _ -> Signal signum
     in
+    (* Same provable invariant as the WEXITED>=128 branch above. *)
     let lab = match cat with
       | Oom_killed -> "oom_killed"
       | Segfault -> "segfault"
       | Signal s -> Printf.sprintf "killed_by_%s" (signal_name s)
-      | _ -> "signal"
+      | Success | General_error | Usage_error | Data_error
+      | Permission_error | Not_found | Timeout | Unknown _ -> "signal"
     in
     let hnt = match cat with
       | Oom_killed ->
@@ -122,7 +129,8 @@ let of_process_status = function
       | Signal s ->
         Printf.sprintf "Process received %s. May have been killed externally."
           (signal_name s)
-      | _ -> ""
+      | Success | General_error | Usage_error | Data_error
+      | Permission_error | Not_found | Timeout | Unknown _ -> ""
     in
     { raw = Unix.WSIGNALED signum;
       code = 128 + signum;

--- a/lib/exec/output_parse.ml
+++ b/lib/exec/output_parse.ml
@@ -486,7 +486,8 @@ let try_parse ~cmd ~status ~output =
       let may_parse =
         match status with
         | Unix.WEXITED 0 -> true
-        | _ -> parser_allows_nonzero kind
+        | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
+            parser_allows_nonzero kind
       in
       if not may_parse then None
       else


### PR DESCRIPTION
## 목적

RFC-0071 §3.4 Phase 5 ratchet — `lib/exec` (가장 큰 잔여 sublib). #14888/#14894/#14900/#14923/#14930/#14936 후속.

## 변경: 9 fragile-match sites

### Closed-variant enumeration (6)
| 파일 | × | 패턴 | Fix |
|------|---|------|-----|
| `exit_code.ml` | 4 | `match cat with Oom_killed\|Segfault\|Signal s\|_ -> ...` | `cat ∈ {Oom_killed,Segfault,Signal _}` provable; 나머지 8 `category` ctor 명시 |
| `output_parse.ml` | 1 | `match status with WEXITED 0\|_` | `WEXITED _\|WSIGNALED _\|WSTOPPED _` |
| `exec_dispatch.ml` | 1 | 동일 Unix.process_status | 동일 |

### `[@warning "-4"]` exemptions (3) — RFC-0071 §3.4.1
| 파일 | × | 이유 |
|------|---|------|
| `approval_policy.ml` | 2 | `find_destructive_git`/`find_write_escape` 는 `Capability.t list` find-first scan. `_ :: rest` 가 *의도적으로* 모든 non-matching cap (+ nested `Git_op.t` ctor) skip. nested enumeration 강제는 friction만 — 답은 항상 "skip & 계속 scan" |
| `exec_gate.ml` | 1 | `match typed with W (Generic _)\|_` 가 `Shell_ir_typed` GADT existential. wrapped node type 전부 enumerate 비현실적; 의도는 "Generic → legacy check, else → typed path" |

생성 파일 `shell_ir_typed_walkers_gen.ml` 은 clean (generator 가 fragile match 안 emit).

모든 변경 **behavior-preserving**.

## 검증

- \`dune build --root .\` clean (9 warning-4 error → 0)
- \`lib/exec/test\` suite green
- \`test/test_approval_callback_wired.ml\` 의 structural FAIL (lib/oas_worker_exec.ml 검사) 은 **clean origin/main 에서도 재현** — 본 PR 무관

## 누적

| | `-w +4` sublibs |
|--|--|
| #14888 | 1 (lib/core, +1) |
| #14894 | 5 |
| #14900 | 15 |
| #14923 | +1 (config, +3) |
| #14930 | +2 (autonomous, gate +1) |
| #14936 | +2 (process +1 exempt, backend +2) |
| **본 PR** | **+1 (exec, +6 fix +3 exempt)** |
| **누계** | **27** |