### PR TITLE
docs(tla-audit): N-2.e — keeper_approval_queue docstring stale line refs + OCaml-docstring line-ref drift survey (iter 71)

### DIFF
--- a/docs/tla-audit/ocaml-docstring-lineref-drift-class-2026-05-12.md
+++ b/docs/tla-audit/ocaml-docstring-lineref-drift-class-2026-05-12.md
@@ -4,7 +4,7 @@
 **Scope**: `lib/keeper/*.{ml,mli}` "Spec navigation (OCaml -> TLA+)" reverse-citation blocks that cite their own functions/types at `(~line N)`.
 **Verdict**: this is the OCaml-docstring twin of the 8th drift sub-class (TLA-preamble line-reference drift, iter 63 KAQ N-1). iter 64 N-2.a fixed the *spec preamble* side and N-2.c added a guard (`scripts/audit-tla-ml-line-refs.sh`) — but that guard only scans `specs/keeper-state-machine/*.tla`, not OCaml docstrings, and `scripts/audit-ocaml-phase-count.sh` only checks phase counts. So the OCaml-side mirror of the same stale citations has gone uncaught. This PR fixes the clearest case (`keeper_approval_queue.ml`, N-2.e) and catalogues the rest.
 
-## Survey (`rg '\(~?line N\)' lib/keeper/*.ml`)
+## Survey (`rg '\(~?line [0-9]+\)' lib/keeper/*.ml`)
 
 | Module | Cited | Actual | Drift | Status |
 |---|---|---|---|---|

--- a/docs/tla-audit/ocaml-docstring-lineref-drift-class-2026-05-12.md
+++ b/docs/tla-audit/ocaml-docstring-lineref-drift-class-2026-05-12.md
@@ -1,0 +1,44 @@
+# OCaml-docstring line-reference drift class — survey + first fix (N-2.e)
+
+**Date**: 2026-05-12 · **Iteration**: 71 (`/loop` FSM/TLA+/OCaml drift hunt)
+**Scope**: `lib/keeper/*.{ml,mli}` "Spec navigation (OCaml -> TLA+)" reverse-citation blocks that cite their own functions/types at `(~line N)`.
+**Verdict**: this is the OCaml-docstring twin of the 8th drift sub-class (TLA-preamble line-reference drift, iter 63 KAQ N-1). iter 64 N-2.a fixed the *spec preamble* side and N-2.c added a guard (`scripts/audit-tla-ml-line-refs.sh`) — but that guard only scans `specs/keeper-state-machine/*.tla`, not OCaml docstrings, and `scripts/audit-ocaml-phase-count.sh` only checks phase counts. So the OCaml-side mirror of the same stale citations has gone uncaught. This PR fixes the clearest case (`keeper_approval_queue.ml`, N-2.e) and catalogues the rest.
+
+## Survey (`rg '\(~?line N\)' lib/keeper/*.ml`)
+
+| Module | Cited | Actual | Drift | Status |
+|---|---|---|---|---|
+| `keeper_approval_queue.ml` | `[submit_and_await] (~line 751)`, `[submit_pending] (~line 772)`, `[expire_stale] (~line 941)` + quotes the spec's old "at line 751/772/941" | 996 / 1089 / 1335 | +245 / +317 / +394 | **fixed in this PR (N-2.e)** — same numbers iter 64 N-2.a removed from `KeeperApprovalQueue.tla`; the OCaml docstring still carried them *and* quoted the now-removed spec text |
+| `keeper_failure_circuit_breaker.ml` | `[type error_class] (this file, ~line 17)` | 46 | +29 | fixed in iter 70 #14939 (KCB R-1) |
+| `keeper_memory_policy.ml` | `[short_term_horizon] (~line 165)`, `[memory_horizon_of_kind_opt] (~line 171)`, `[memory_horizon_of_kind] (~line 182)` — plus a "Spec line drift correction" block that itself says "actual line is 165 (+10 drift)" | 204 / 210 / 221 | +39 each (and the drift-correction note is itself +39 stale: it claims actual 165, real is 204) | **N-2.f candidate** — the docstring already concludes "function-name citations remain stable", contradicting its own `(~line N)` markers; clean fix = drop all line numbers, keep the semantic notes (mid-term default + #8826) |
+| `keeper_execution_receipt.ml` | `[append] (~line 455)` | 879 | +424 | **N-2.g candidate** |
+| `keeper_heartbeat_loop.ml` | quotes `Spec line 4 cites this function "at line 1815"; the actual current line is 1828 (drift +13)` | spec preamble no longer says "at line 1815" (iter 64 N-2.c removed `run_heartbeat_loop at line 1828` from `KeeperHeartbeat.tla`) | n/a — self-aware about its own drift, but the *quote of the spec* is now stale | **N-2.h candidate** — update to note the spec uses function-name-only refs now |
+
+(Out of scope here: internal cross-references in `keeper_unified_turn.ml`, `keeper_stale_watchdog.ml`, `keeper_supervisor.ml` that cite *other* functions in *other* modules by line — a different concern, harder to validate, lower payoff.)
+
+## The fix in this PR (N-2.e — `keeper_approval_queue.ml`)
+
+Before: the docstring said *"Spec lines 5-6 already cite this module: '[submit_and_await] at line 751, [submit_pending] at line 772, [expire_stale] at line 941'"* and the action-mapping table marked each function `(~line 751/772/941)`. After iter 64 N-2.a, `KeeperApprovalQueue.tla`'s preamble no longer contains those line numbers — so the OCaml quote was doubly wrong (stale numbers + quoting text that no longer exists). After: the docstring says the spec preamble cites by function name, notes that line numbers were removed in iter 64 N-2.a after drift reached +245..+413, and the action-mapping table cites `[submit_and_await]` / `[submit_pending]` / `[expire_stale]` with no line numbers.
+
+## Why this matters
+
+When iter 64 fixed the spec-preamble side of the line-ref drift, the OCaml-side reverse-citation was left holding the same stale numbers — and worse, *quoting the spec text that iter 64 deleted*. A reader following the reverse citation from `keeper_approval_queue.ml` lands at `~line 751` (a `find_pending_id_in_map` lookup utility) or believes the spec still says "at line 751". The asymmetry — fixing one direction of a bidirectional citation but not the other — is exactly the kind of half-finished migration the loop's audit→fix→guard discipline exists to close. N-2.f/g/h finish the OCaml side; R-1.a is the structural guard.
+
+## Follow-up candidates
+
+- **N-2.f (LOW)** — `keeper_memory_policy.ml` docstring: drop the three `(~line N)` markers and the stale "Spec line drift correction" block, keep the `memory_horizon_of_kind` mid-term-default note and the #8826 reference. The docstring already states the right principle ("function-name citations remain stable").
+- **N-2.g (LOW)** — `keeper_execution_receipt.ml`: `[append] (~line 455)` → `[append]` (actual 879, +424).
+- **N-2.h (LOW)** — `keeper_heartbeat_loop.ml`: update the "Spec line 4 cites this function 'at line 1815'" quote — `KeeperHeartbeat.tla` now uses function-name-only references (iter 64 N-2.c).
+- **R-1.a (MED)** — extend `scripts/audit-tla-ml-line-refs.sh` (or add a sibling `audit-ocaml-spec-nav-line-refs.sh`) to scan `lib/keeper/*.{ml,mli}` "Spec navigation" blocks for `\[([a-z_]+)\]\s*\(~?\s*line\s+(\d+)\)` and verify `^let \1` / `^type \1` is within tolerance. The OCaml-docstring twin of R-H-1.f. Would catch all of N-2.{e..h} automatically and any future re-introduction.
+
+## Verification (this audit + fix)
+
+```
+$ rg -n '~line 751|~line 772|~line 941|at line 751' lib/keeper/keeper_approval_queue.ml   # 0 after fix
+$ rg -n '^let submit_and_await|^let submit_pending|^let expire_stale' lib/keeper/keeper_approval_queue.ml   # 996 / 1089 / 1335
+$ dune build test/test_keeper_approval_queue*.exe   # (see PR — comment-only, no behaviour change)
+```
+
+## RFC trail
+
+`keeper_approval_queue.ml` is not in the credential/identity/operator/sandbox/hooks/workflow RFC-required set — RFC-WAIVED for the comment-only docstring fix. Spec lineage: `Cycle 9 / Tier B3, PR #11417`.

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -14,22 +14,23 @@
     [specs/keeper-state-machine/KeeperApprovalQueue.tla] (Cycle 9 /
     Tier B3, PR #11417).
 
-    Spec lines 5-6 already cite this module:
-    "[submit_and_await] at line 751, [submit_pending] at line 772,
-    [expire_stale] at line 941".  This block is the reverse-direction
+    The spec preamble cites this module by function name
+    ([submit_and_await], [submit_pending], [expire_stale]).  It used to
+    carry line numbers (751 / 772 / 941) but iter 64 N-2.a removed them
+    after the OCaml line drift reached +245..+413 — function names are
+    stable, line numbers are not.  This block is the reverse-direction
     citation so code search for "KeeperApprovalQueue" lands here.
 
     Action mapping (TLA+ -> OCaml):
-      Submit                 [submit_and_await] (~line 751) /
-                             [submit_pending] (~line 772) record a
-                             new pending entry and suspend the fiber
-                             on [Eio.Promise.await].
+      Submit                 [submit_and_await] / [submit_pending]
+                             record a new pending entry and suspend
+                             the fiber on [Eio.Promise.await].
       Resolve                operator approves/rejects via the HTTP
                              handler in [server_dashboard_http.ml],
                              which calls [resolve] on the queue and
                              wakes the suspended fiber.
-      ExpireStale            [expire_stale] (~line 941) sweeps
-                             timed-out entries and forces
+      ExpireStale            [expire_stale] sweeps timed-out entries
+                             and forces
                              [Eio.Promise.resolve resolver (Reject ...)]
                              so no fiber is left blocked indefinitely.
       ExpireStaleNoResolve   bug action — entries are removed from


### PR DESCRIPTION
## Finding (Iteration 71, N-2.e — keeper_approval_queue docstring stale line refs + OCaml-docstring line-ref drift class survey)

**OCaml**: `lib/keeper/keeper_approval_queue.ml` (docstring) + `docs/tla-audit/ocaml-docstring-lineref-drift-class-2026-05-12.md` (survey)
**Spec**: `specs/keeper-state-machine/KeeperApprovalQueue.tla` (iter 64 N-2.a fixed the preamble; this PR fixes the OCaml-side mirror)
**Aspect**: half-finished migration — iter 64 fixed one direction of a bidirectional citation (spec preamble) but the OCaml-docstring reverse-citation kept the stale line numbers *and quoted the deleted spec text*
**Risk**: LOW (comment-only docstring + audit memo)
**Workaround signature**: N/A — finishes the OCaml side of iter 64's audit→fix→guard

## 순서도

```mermaid
flowchart LR
  A[iter 63 KAQ N-1 #14919<br/>spec preamble line refs stale<br/>751/772/941 → 996/1089/1335] --> B[iter 64 N-2.a #14925<br/>removed line nums from KeeperApprovalQueue.tla]
  B --> C[iter 64 N-2.c #14925<br/>audit-tla-ml-line-refs.sh guard<br/>BUT: scans *.tla only, not OCaml docstrings]
  C --> D[iter 70 KCB R-1 #14939<br/>found a 2nd OCaml-docstring case<br/>type error_class ~line 17 → 46]
  D --> E[iter 71 this PR N-2.e<br/>fix keeper_approval_queue.ml docstring<br/>+ survey: 4-5 sites in lib/keeper/]
  E --> F[N-2.f/g/h: memory_policy / execution_receipt / heartbeat_loop<br/>R-1.a: OCaml-docstring line-ref validator]
```

## Survey

| Module | Cited | Actual | Drift | Status |
|---|---|---|---|---|
| `keeper_approval_queue.ml` | `[submit_and_await] (~line 751)` / `[submit_pending] (~line 772)` / `[expire_stale] (~line 941)` + quotes spec's old "at line 751/772/941" | 996 / 1089 / 1335 | +245 / +317 / +394 | **fixed here (N-2.e)** |
| `keeper_failure_circuit_breaker.ml` | `[type error_class] (~line 17)` | 46 | +29 | fixed iter 70 #14939 |
| `keeper_memory_policy.ml` | `[short_term_horizon] (~line 165)` / `[memory_horizon_of_kind_opt] (~line 171)` / `[memory_horizon_of_kind] (~line 182)` + a "drift correction" block claiming "actual 165 (+10)" | 204 / 210 / 221 | +39 (and the drift-correction note is itself +39 stale) | N-2.f candidate |
| `keeper_execution_receipt.ml` | `[append] (~line 455)` | 879 | +424 | N-2.g candidate |
| `keeper_heartbeat_loop.ml` | quotes `Spec line 4 cites this function "at line 1815"` | spec no longer says that (iter 64 N-2.c removed it) | n/a — self-aware about magnitude but quotes deleted spec text | N-2.h candidate |

## Before / After (`keeper_approval_queue.ml`)

```diff
-    Spec lines 5-6 already cite this module:
-    "[submit_and_await] at line 751, [submit_pending] at line 772,
-    [expire_stale] at line 941".  This block is the reverse-direction
-    citation so code search for "KeeperApprovalQueue" lands here.
-
-    Action mapping (TLA+ -> OCaml):
-      Submit                 [submit_and_await] (~line 751) /
-                             [submit_pending] (~line 772) record a ...
-      ExpireStale            [expire_stale] (~line 941) sweeps ...
+    The spec preamble cites this module by function name
+    ([submit_and_await], [submit_pending], [expire_stale]).  It used to
+    carry line numbers (751 / 772 / 941) but iter 64 N-2.a removed them
+    after the OCaml line drift reached +245..+413 — function names are
+    stable, line numbers are not.  This block is the reverse-direction ...
+
+    Action mapping (TLA+ -> OCaml):
+      Submit                 [submit_and_await] / [submit_pending] record a ...
+      ExpireStale            [expire_stale] sweeps ...
```

## 왜 톱니처럼 정교하지 않은가

iter 64가 spec-preamble 측 line-ref drift를 고쳤을 때, OCaml 측 reverse-citation은 같은 stale 번호를 그대로 갖고 있었고 — 더 나쁘게 — *iter 64가 삭제한 spec 텍스트를 인용*하고 있었다. `keeper_approval_queue.ml`의 reverse citation을 따라가는 독자는 `~line 751` (= `find_pending_id_in_map` lookup utility)에 도달하거나 "spec이 아직 'at line 751'이라 한다"고 믿는다. 양방향 citation의 한쪽만 고치는 비대칭은 loop의 audit→fix→guard 규율이 닫으려는 바로 그 half-finished migration. N-2.f/g/h가 OCaml 측을 마저 닫고, R-1.a이 구조적 guard.

## Verification

```
$ rg -n '~line 751|~line 772|~line 941|at line 751' lib/keeper/keeper_approval_queue.ml   # empty after fix
$ rg -n '^let submit_and_await|^let submit_pending|^let expire_stale' lib/keeper/keeper_approval_queue.ml   # 996 / 1089 / 1335
$ dune build --root . test/test_hitl_approval.exe   # clean
```

## Trade-off

- 이번 PR은 `keeper_approval_queue.ml`만 (가장 명확, iter 64를 정확히 미러). `keeper_memory_policy.ml` (docstring 재작성 필요 — drift-correction 블록까지 stale) / `keeper_execution_receipt.ml` / `keeper_heartbeat_loop.ml`은 N-2.f/g/h로 분리 (한 PR에 lib/keeper/ 4파일은 과함).
- R-1.a (MED): `scripts/audit-tla-ml-line-refs.sh`에 OCaml-docstring "Spec navigation" 블록 스캔 추가 — `\[([a-z_]+)\]\s*\(~?\s*line\s+(\d+)\)`가 `^let \1` / `^type \1` 근처인지 검증. R-H-1.f의 OCaml-docstring twin. 이 nit들을 자동으로 잡았을 것.

## RFC 참조

`keeper_approval_queue.ml`은 credential/identity/operator/sandbox/hooks/workflow RFC-required set 아님 — RFC-WAIVED (docs/ 메모 + comment-only docstring; `bash ~/me/scripts/pr-rfc-check.sh` 통과). Spec lineage: `Cycle 9 / Tier B3, PR #11417`.

## 진행 추적

다음 iteration 시작점:
1. **N-2.f** (keeper_memory_policy.ml docstring rewrite — drop 3 line refs + stale drift-correction block) / **N-2.g** (keeper_execution_receipt.ml `[append] ~line 455`→name) / **N-2.h** (keeper_heartbeat_loop.ml spec-quote update) OR
2. **R-1.a** (MED — OCaml-docstring line-ref validator, R-H-1.f twin — closes N-2.{e..h} class structurally) OR
3. **Q-2.c·Q-2.d** (KEQ) / **M-2.d** (KOAS TLC) OR
4. **R-D-2.a + R-D-1.a bundle** (MID ~150-300 LOC biggest pending) OR
5. **새 spec entry** (KH 미진입; ~13개 미감사)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
