### PR TITLE
spec(scripts): R-1.a OCaml-docstring spec-nav line-ref validator + CI wiring (iter 72)

### DIFF
--- a/.github/workflows/tla-annotation-drift.yml
+++ b/.github/workflows/tla-annotation-drift.yml
@@ -27,6 +27,8 @@ on:
       - 'scripts/audit-ocaml-phase-count.sh'
       - 'scripts/ocaml-phase-count-baseline.txt'
       - 'scripts/audit-tla-ml-line-refs.sh'
+      - 'scripts/audit-ocaml-spec-nav-line-refs.sh'
+      - 'scripts/ocaml-spec-nav-line-refs-baseline.txt'
       - 'lib/keeper/**/*.ml'
       - 'lib/keeper/**/*.mli'
       - 'scripts/tla-annotation-drift-baseline.txt'
@@ -45,6 +47,8 @@ on:
       - 'scripts/audit-ocaml-phase-count.sh'
       - 'scripts/ocaml-phase-count-baseline.txt'
       - 'scripts/audit-tla-ml-line-refs.sh'
+      - 'scripts/audit-ocaml-spec-nav-line-refs.sh'
+      - 'scripts/ocaml-spec-nav-line-refs-baseline.txt'
       - 'lib/keeper/**/*.ml'
       - 'lib/keeper/**/*.mli'
       - 'scripts/tla-annotation-drift-baseline.txt'
@@ -114,3 +118,18 @@ jobs:
         # See scripts/audit-tla-ml-line-refs.sh and docs/tla-audit/
         # kaq-n1-approval-queue-line-ref-drift-2026-05-12.md.
         run: bash scripts/audit-tla-ml-line-refs.sh
+
+      - name: Run OCaml-docstring spec-nav line-ref validator (R-1.a)
+        # OCaml-docstring twin of N-2.c.  iter 70 #14939 / iter 71 #14943
+        # found `[symbol] (~line N)` reverse-citations in lib/keeper/*.{ml,mli}
+        # header docstrings whose line numbers had drifted +29 .. +424
+        # (keeper_approval_queue, keeper_failure_circuit_breaker,
+        # keeper_memory_policy, keeper_execution_receipt).  The TLA-side
+        # guard (audit-tla-ml-line-refs.sh) only scans *.tla preambles, so
+        # the OCaml side went uncaught.  Baseline grandfathers the sites
+        # in flight (N-2.e #14943 + N-2.f/g TBD); drain a line when its
+        # fix-PR merges — see the baseline file header and docs/tla-audit/
+        # ocaml-docstring-lineref-drift-class-2026-05-12.md.
+        run: |
+          bash scripts/audit-ocaml-spec-nav-line-refs.sh \
+            --baseline scripts/ocaml-spec-nav-line-refs-baseline.txt

--- a/scripts/audit-ocaml-spec-nav-line-refs.sh
+++ b/scripts/audit-ocaml-spec-nav-line-refs.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# audit-ocaml-spec-nav-line-refs.sh — detect stale `[symbol] (~line N)`
+# citations inside OCaml "Spec navigation (OCaml -> TLA+)" reverse-citation
+# blocks in lib/keeper/*.{ml,mli}.
+#
+# Background: this is the OCaml-docstring twin of the TLA-side validator
+# scripts/audit-tla-ml-line-refs.sh (iter 64 N-2.c, the 8th drift class's
+# audit→fix→guard step 3).  That validator only scans
+# specs/keeper-state-machine/*.tla preambles.  But the same drift exists
+# on the OCaml side: a module's header docstring carries a reverse
+# citation like
+#
+#     ExpireStale  [expire_stale] (~line 941) sweeps timed-out entries
+#
+# and the OCaml line drifts away from 941 as the file grows.  iter 70/71
+# (#14939 keeper_failure_circuit_breaker, #14943 keeper_approval_queue)
+# found four such sites with drift +29 .. +424; iter 71's survey memo is
+# docs/tla-audit/ocaml-docstring-lineref-drift-class-2026-05-12.md.
+#
+# Rule:
+#   - In each lib/keeper/*.{ml,mli}, find every match of
+#     `\[(type )?<sym>\] ... line N` on a single line — i.e. a bracketed
+#     symbol name (optionally prefixed with `type `) and a nearby
+#     `line N` mention, with no bracket between them.
+#   - Verify: `^let <sym>` / `^and <sym>` / `^type <sym>` / `^  type <sym>`
+#     appears in the SAME file within [N - tolerance .. N + tolerance]
+#     inclusive (default tolerance 5).
+#   - Emit drift if the symbol does not appear in that window.
+#
+# Baseline: scripts/ocaml-spec-nav-line-refs-baseline.txt grandfathers the
+# four sites in flight as of iter 72; each line "<repo-relative-path>:<sym>".
+# Drain a line when its fix-PR merges (same convention as the
+# ocaml-phase-count baseline header).
+#
+# Usage: bash scripts/audit-ocaml-spec-nav-line-refs.sh [--verbose] \
+#          [--tolerance N] [--baseline FILE]
+#
+# RFC chain: R-B-1.c → R-H-1.c (#14874) → R-H-1.f (#14891) → N-2.c (#14925)
+# → R-1.a (this script).  OCaml-docstring corner of the line-ref drift class.
+set -euo pipefail
+
+for tool in rg awk grep sed; do
+  command -v "${tool}" >/dev/null 2>&1 || {
+    echo "error: required tool '${tool}' not found in PATH" >&2
+    exit 2
+  }
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+KEEPER_DIR="${REPO_ROOT}/lib/keeper"
+
+VERBOSE=0
+TOLERANCE=5
+BASELINE_FILE=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --verbose) VERBOSE=1; shift ;;
+    --tolerance) TOLERANCE="$2"; shift 2 ;;
+    --tolerance=*) TOLERANCE="${1#*=}"; shift ;;
+    --baseline) BASELINE_FILE="$2"; shift 2 ;;
+    --baseline=*) BASELINE_FILE="${1#*=}"; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+declare -a BASELINE_KEYS=()
+if [[ -n "${BASELINE_FILE}" ]]; then
+  if [[ ! -f "${BASELINE_FILE}" ]]; then
+    echo "error: baseline file not found: ${BASELINE_FILE}" >&2
+    exit 2
+  fi
+  while IFS= read -r raw; do
+    raw="${raw%%#*}"
+    raw="$(printf '%s' "${raw}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    [[ -z "${raw}" ]] && continue
+    BASELINE_KEYS+=("${raw}")
+  done < "${BASELINE_FILE}"
+fi
+
+in_baseline() {
+  local key="$1" b
+  for b in "${BASELINE_KEYS[@]:-}"; do
+    [[ "${b}" == "${key}" ]] && return 0
+  done
+  return 1
+}
+
+drift_count=0
+file_count=0
+cite_count=0
+baseline_hit=0
+
+shopt -s nullglob
+for ml in "${KEEPER_DIR}"/*.ml "${KEEPER_DIR}"/*.mli; do
+  file_count=$((file_count + 1))
+  rel="lib/keeper/$(basename "${ml}")"
+  ml_line_count="$(wc -l < "${ml}")"
+
+  # Each `[sym] ... line N` pair (sym optionally `type `-prefixed; no
+  # bracket between the symbol and the line number).
+  while IFS= read -r match; do
+    [[ -z "${match}" ]] && continue
+
+    sym="$(printf '%s' "${match}" | sed -nE 's/.*\[(type )?([a-z_]+)\][^][]*line[s ]+([0-9]+).*/\2/p')"
+    cited_line="$(printf '%s' "${match}" | sed -nE 's/.*\[(type )?([a-z_]+)\][^][]*line[s ]+([0-9]+).*/\3/p')"
+    [[ -z "${sym}" || -z "${cited_line}" ]] && continue
+
+    cite_count=$((cite_count + 1))
+    key="${rel}:${sym}"
+
+    if in_baseline "${key}"; then
+      baseline_hit=$((baseline_hit + 1))
+      [[ "${VERBOSE}" -eq 1 ]] && \
+        echo "ok (baseline): ${key} cites line ${cited_line} (pending fix-PR)" >&2
+      continue
+    fi
+
+    if (( cited_line > ml_line_count )); then
+      printf 'drift: %s — cites [%s] at line %s but file has only %s lines\n' \
+        "${rel}" "${sym}" "${cited_line}" "${ml_line_count}"
+      drift_count=$((drift_count + 1))
+      continue
+    fi
+
+    lo=$((cited_line - TOLERANCE)); [[ ${lo} -lt 1 ]] && lo=1
+    hi=$((cited_line + TOLERANCE))
+
+    if awk -v lo="${lo}" -v hi="${hi}" -v sym="${sym}" '
+      NR >= lo && NR <= hi {
+        if ($0 ~ "^(let|and)[[:space:]]+" sym "($|[[:space:](:])" ||
+            $0 ~ "^[[:space:]]*type[[:space:]]+" sym "($|[[:space:]=])") {
+          found = 1
+        }
+      }
+      END { exit !found }
+    ' "${ml}"; then
+      [[ "${VERBOSE}" -eq 1 ]] && \
+        echo "ok: ${key} at line ${cited_line} → matches in ${rel}" >&2
+      continue
+    fi
+
+    actual_line="$(awk -v sym="${sym}" '
+      $0 ~ "^(let|and)[[:space:]]+" sym "($|[[:space:](:])" ||
+      $0 ~ "^[[:space:]]*type[[:space:]]+" sym "($|[[:space:]=])" { print NR; exit }
+    ' "${ml}")"
+    if [[ -n "${actual_line}" ]]; then
+      drift=$((actual_line - cited_line)); sign='+'; (( drift < 0 )) && sign=''
+      printf 'drift: %s — cites [%s] at line %s but actual is %s (drift %s%s)\n' \
+        "${rel}" "${sym}" "${cited_line}" "${actual_line}" "${sign}" "${drift}"
+    else
+      printf 'drift: %s — cites [%s] at line %s but no let/and/type-declaration of "%s"\n' \
+        "${rel}" "${sym}" "${cited_line}" "${sym}"
+    fi
+    drift_count=$((drift_count + 1))
+
+  done < <(grep -oE '\[(type )?[a-z_]+\][^][]*line[s ]+[0-9]+' "${ml}" || true)
+done
+
+if [[ "${drift_count}" -gt 0 ]]; then
+  echo "" >&2
+  echo "${drift_count} OCaml-docstring line-reference drift(s) across ${file_count} file(s) (${cite_count} citation(s) checked, ${baseline_hit} baselined)." >&2
+  echo "Fix: drop the line number and name the symbol (N-2.a shape), OR — if it must stay — re-anchor it.  See docs/tla-audit/ocaml-docstring-lineref-drift-class-2026-05-12.md." >&2
+  exit 1
+fi
+
+echo "ocaml-spec-nav line-ref audit clean: ${cite_count} citation(s) verified across ${file_count} file(s) (${baseline_hit} baselined)." >&2

--- a/scripts/ocaml-spec-nav-line-refs-baseline.txt
+++ b/scripts/ocaml-spec-nav-line-refs-baseline.txt
@@ -1,0 +1,24 @@
+# OCaml "Spec navigation" line-ref baseline — transient grandfather list
+# for scripts/audit-ocaml-spec-nav-line-refs.sh.  Each non-comment line:
+# "<repo-relative-path>:<symbol>".
+#
+# These are the `[symbol] (~line N)` citations in lib/keeper/*.{ml,mli}
+# header docstrings whose line numbers had already drifted when the
+# validator was introduced (iter 72 R-1.a).  Survey + drift figures:
+# docs/tla-audit/ocaml-docstring-lineref-drift-class-2026-05-12.md (iter 71).
+#
+# Drain a line when its fix-PR merges (same convention as the
+# ocaml-phase-count baseline):
+#   - keeper_approval_queue.ml:*           — drained by N-2.e (#14943)
+#   - keeper_execution_receipt.ml:append   — drained by N-2.g (TBD)
+#   - keeper_memory_policy.ml:*            — drained by N-2.f (TBD)
+# Once all are drained the validator enforces zero OCaml-docstring
+# line-ref drift; the `--baseline` flag stays for future transients.
+
+lib/keeper/keeper_approval_queue.ml:submit_and_await
+lib/keeper/keeper_approval_queue.ml:submit_pending
+lib/keeper/keeper_approval_queue.ml:expire_stale
+lib/keeper/keeper_execution_receipt.ml:append
+lib/keeper/keeper_memory_policy.ml:short_term_horizon
+lib/keeper/keeper_memory_policy.ml:memory_horizon_of_kind_opt
+lib/keeper/keeper_memory_policy.ml:memory_horizon_of_kind


### PR DESCRIPTION
## Finding (Iteration 72, R-1.a — OCaml-docstring spec-nav line-ref validator)

**Script**: `scripts/audit-ocaml-spec-nav-line-refs.sh` (NEW, +~160 LOC) · `scripts/ocaml-spec-nav-line-refs-baseline.txt` (NEW, 7 keys) · `.github/workflows/tla-annotation-drift.yml` (5th validator step)
**Aspect**: audit→fix→guard step 3 for the OCaml-docstring corner of the 8th drift sub-class (line-reference drift)
**Risk**: LOW (validator + baseline + CI comment; no runtime surface)
**Workaround signature**: N/A — this is the *guard*, with a transient baseline (R-H-1.f precedent)

## 순서도

```mermaid
flowchart LR
  A[iter 63 KAQ N-1 #14919<br/>spec preamble line refs stale] --> B[iter 64 N-2.a/c #14925<br/>fix + audit-tla-ml-line-refs.sh<br/>scans *.tla only]
  B --> C[iter 70 KCB R-1 #14939<br/>found OCaml docstring drift<br/>type error_class ~17 → 46]
  C --> D[iter 71 N-2.e #14943<br/>fix keeper_approval_queue + survey<br/>4 sites, drift +29..+424]
  D --> E[iter 72 this PR R-1.a<br/>audit-ocaml-spec-nav-line-refs.sh<br/>+ baseline + CI step]
  E --> F[OCaml-docstring line-ref drift<br/>structurally guarded; baseline drains<br/>as N-2.e/f/g land]
```

## What was added

1. **`scripts/audit-ocaml-spec-nav-line-refs.sh`** — for each `lib/keeper/*.{ml,mli}`, finds `[(type )?<sym>] ... line N` on a line (the `[symbol] (~line N)` reverse-citation shape, allowing `[type error_class] (this file, ~line 17)`-style prefixes/suffixes between `]` and `line N`) and verifies `^let <sym>` / `^and <sym>` / `^type <sym>` appears in the same file within `±tolerance` (default 5) of N. Emits the actual line on drift. Same shape as `audit-tla-ml-line-refs.sh` (iter 64) but resolves *within the same file* — no cross-file resolution.
2. **`scripts/ocaml-spec-nav-line-refs-baseline.txt`** — grandfathers the 7 keys in flight: `keeper_approval_queue.ml:{submit_and_await,submit_pending,expire_stale}` (drained by N-2.e #14943), `keeper_execution_receipt.ml:append` (N-2.g TBD), `keeper_memory_policy.ml:{short_term_horizon,memory_horizon_of_kind_opt,memory_horizon_of_kind}` (N-2.f TBD). Drain-on-merge convention (same as the ocaml-phase-count baseline). `keeper_failure_circuit_breaker.ml` is already fixed in main (#14939 merged) so it's not in the baseline.
3. **CI** — 5th validator step in `tla-annotation-drift.yml` (after R-B-1.c annotation, R-H-1.c TLA phase-count, R-H-1.f OCaml phase-count, N-2.c TLA line-ref).

## Verification

```
$ bash scripts/audit-ocaml-spec-nav-line-refs.sh          # no baseline
drift: lib/keeper/keeper_approval_queue.ml — cites [submit_and_await] at line 751 but actual is 996 (drift +245)
drift: lib/keeper/keeper_approval_queue.ml — cites [submit_pending] at line 772 but actual is 1089 (drift +317)
drift: lib/keeper/keeper_approval_queue.ml — cites [expire_stale] at line 941 but actual is 1335 (drift +394)
   ... (×2 — each appears in both the "Spec lines 5-6 already cite" quote and the action-mapping table)
drift: lib/keeper/keeper_execution_receipt.ml — cites [append] at line 455 but actual is 879 (drift +424)
drift: lib/keeper/keeper_memory_policy.ml — cites [short_term_horizon] at line 165 but actual is 204 (drift +39)
drift: lib/keeper/keeper_memory_policy.ml — cites [memory_horizon_of_kind_opt] at line 171 but actual is 210 (drift +39)
drift: lib/keeper/keeper_memory_policy.ml — cites [memory_horizon_of_kind] at line 182 but actual is 221 (drift +39)
10 OCaml-docstring line-reference drift(s) ... ; exit 1

$ bash scripts/audit-ocaml-spec-nav-line-refs.sh --baseline scripts/ocaml-spec-nav-line-refs-baseline.txt
ocaml-spec-nav line-ref audit clean: 10 citation(s) verified across 500 file(s) (10 baselined). ; exit 0

$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tla-annotation-drift.yml'))"   # yaml ok
```

## 왜 톱니처럼 정교하지 않은가

iter 64가 line-ref drift의 *spec-preamble* 측을 닫고 guard까지 달았지만, 같은 drift가 *OCaml docstring*의 reverse-citation에도 존재했고 — 그 guard는 `*.tla`만 스캔하므로 — 사각지대였다. iter 70/71에서 4개 사이트가 +29~+424 drift로 발견됐다. 이건 분류 자체의 한쪽 끝(OCaml)을 막지 않으면 다른 쪽(spec)을 막아도 새는, audit→fix→guard 규율이 닫으려는 정확한 패턴. baseline은 transient — N-2.e (#14943) + N-2.f/g가 land하면 비워지고, validator가 OCaml-docstring zero-drift를 enforce.

## Trade-off

- baseline에 7개 키 — `keeper_approval_queue` 3개는 #14943(in flight)이 drain하므로, #14943이 먼저 머지되면 그 3줄이 stale-on-merge가 됨 (drain follow-up 필요). #14939(keeper_failure_circuit_breaker)는 이미 머지돼서 baseline에 안 넣음. 머지 순서 무관, drain은 mechanical (R-H-1.f 선례).
- validator는 `lib/keeper/`만 스캔 — 다른 디렉토리의 OCaml docstring은 범위 밖 (현재 corpus에서 "Spec navigation" 블록은 keeper 모듈에만 있음). 필요 시 디렉토리 추가.
- "Spec lines 5-6 already cite ... 'at line 751'" 같은 *spec 텍스트 인용*은 N-2.e가 손으로 고침 — validator는 `[symbol] line N` 패턴만 잡고 자유텍스트 인용은 안 잡음. 그건 R-1.a 범위 밖.

## RFC 참조

RFC-WAIVED: validator 스크립트 + baseline data + CI 주석. credential/identity/operator/sandbox/hooks/workflow 표면 미접촉 (`bash ~/me/scripts/pr-rfc-check.sh` 통과). RFC chain: R-B-1.c → R-H-1.c (#14874) → R-H-1.f (#14891) → N-2.c (#14925) → R-1.a (this).

## 진행 추적

다음 iteration 시작점:
1. **N-2.f** (keeper_memory_policy.ml docstring rewrite — 3 line refs + stale "drift correction" 블록 제거 → baseline 3줄 drain) / **N-2.g** (keeper_execution_receipt.ml `[append] ~line 455`→name → baseline 1줄 drain) / **N-2.h** (keeper_heartbeat_loop.ml spec-quote update — validator 범위 밖이라 손으로) OR
2. **R-1.b cleanup** (#14943 머지 후 baseline에서 keeper_approval_queue 3줄 drain) OR
3. **Q-2.c·Q-2.d** (KEQ) / **M-2.d** (KOAS TLC) OR
4. **R-D-2.a + R-D-1.a bundle** (MID ~150-300 LOC biggest pending) OR
5. **새 spec entry** (KH 미진입; ~13개 미감사)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
