### PR TITLE
docs(keeper): N-2.f/N-2.g — drop stale (~line N) markers from spec-nav docstrings (iter 73)

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -761,8 +761,8 @@ let to_json (receipt : t) =
      OperatorBroadcast event    -> [emit_operator_broadcast]
                                   emits "keeper.operator_broadcast_required.v1"
                                   with structured payload.
-     Eventually-emit liveness   -> [append] (~line 455) calls the
-                                  emit unconditionally when
+     Eventually-emit liveness   -> [append] calls the emit
+                                  unconditionally when
                                   [needs_operator_broadcast] is true,
                                   inside a [try] so a single failure
                                   does not cascade — the spec's clean

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -5,31 +5,28 @@
     Authoritative spec mirror is
     [specs/keeper-state-machine/KeeperMemoryLifecycle.tla] (#8642 family).
 
-    Spec lines 17-35 already cite this module field-by-field:
+    The spec preamble cites this module field-by-field:
       short_mem / mid_mem / long_mem  -> rows with [horizon] in
                                          {"short_term", "mid_term",
                                           "long_term"}, see the
-                                         constants
-                                           [short_term_horizon] (~line 165)
-                                           [mid_term_horizon]   (next)
-                                           [long_term_horizon]  (next)
+                                         constants [short_term_horizon],
+                                         [mid_term_horizon],
+                                         [long_term_horizon].
       provenanced  -> rows with non-empty trace_id / source
                       (lives in keeper_memory_bank, not this file).
-      producer     -> [memory_horizon_of_kind_opt] (~line 171, strict)
-                      and [memory_horizon_of_kind] (~line 182,
-                      back-compat wrapper that defaults unknown kinds
-                      to mid_term with a warn — see #8826 drift note).
+      producer     -> [memory_horizon_of_kind_opt] (strict) and
+                      [memory_horizon_of_kind] (back-compat wrapper that
+                      defaults unknown kinds to mid_term with a warn —
+                      see #8826 drift note).
 
     This block is the reverse-direction citation so code search for
-    "KeeperMemoryLifecycle" lands here.
-
-    Spec line drift correction:
-      Spec line 19-21 cites "ml:155 / ml:156 / ml:157" for the three
-      horizon constants; current actual line is 165 (+10 drift).  The
-      shift is because new `compaction_outcome` record fields were
-      inserted between the spec citation and the constants.  The
-      function-name citations ([memory_horizon_of_kind_opt],
-      [memory_horizon_of_kind]) remain stable.
+    "KeeperMemoryLifecycle" lands here.  Citations are by symbol name,
+    not line number: the spec preamble used to carry "ml:155 / ml:156 /
+    ml:157" for the horizon constants but those drifted (>+30 once
+    `compaction_outcome` fields were inserted between the citation and
+    the constants) and were removed — symbol names are the stable anchor
+    (iter 64 N-2.a; guarded by scripts/audit-ocaml-spec-nav-line-refs.sh,
+    iter 72 R-1.a).
 
     Spec safety goals (line 9-13):
       - every persisted note has provenance


### PR DESCRIPTION
## Finding (Iteration 73, N-2.f + N-2.g — drop stale (~line N) markers from two spec-nav docstrings)

**OCaml**: `lib/keeper/keeper_memory_policy.ml` (N-2.f) + `lib/keeper/keeper_execution_receipt.ml` (N-2.g) — header docstring "Spec navigation" blocks
**Aspect**: finish the OCaml side of the line-ref drift class — two more `[symbol] (~line N)` reverse-citations that have drifted
**Risk**: LOW (comment-only docstrings; no behaviour change)
**Workaround signature**: N/A — N-2.a-shape cleanup; drains 4/7 of the iter 72 baseline

## 순서도

```mermaid
flowchart LR
  A[iter 71 #14943 survey<br/>5 OCaml-docstring sites, drift +29..+424] --> B[iter 70 #14939 keeper_failure_circuit_breaker ✓]
  A --> C[iter 71 #14943 keeper_approval_queue N-2.e ✓]
  A --> D[iter 72 #14944 R-1.a validator + baseline ✓]
  A --> E[iter 73 this PR<br/>N-2.f keeper_memory_policy<br/>N-2.g keeper_execution_receipt]
  E --> F[remaining: N-2.h keeper_heartbeat_loop<br/>R-1.b drain baseline once all land]
```

## Before / After

**N-2.f — `keeper_memory_policy.ml`:**
```diff
-      constants
-        [short_term_horizon] (~line 165)
-        [mid_term_horizon]   (next)
-        [long_term_horizon]  (next)
+      constants [short_term_horizon], [mid_term_horizon], [long_term_horizon].
-      producer  -> [memory_horizon_of_kind_opt] (~line 171, strict)
-                   and [memory_horizon_of_kind] (~line 182, ...)
+      producer  -> [memory_horizon_of_kind_opt] (strict) and [memory_horizon_of_kind] (...)
-    Spec line drift correction:
-      Spec line 19-21 cites "ml:155 / ml:156 / ml:157" ...; current actual line is 165 (+10 drift). ...
-      The function-name citations ... remain stable.
+    Citations are by symbol name, not line number: the spec preamble used
+    to carry "ml:155 / ml:156 / ml:157" ... but those drifted (>+30 once
+    `compaction_outcome` fields were inserted) and were removed — symbol
+    names are the stable anchor (iter 64 N-2.a; guarded by R-1.a).
```
Actual lines: `short_term_horizon` 204, `memory_horizon_of_kind_opt` 210, `memory_horizon_of_kind` 221 — all +39 from the cited 165/171/182. And the "drift correction" block was itself +39 stale (it claimed actual 165) *and* self-contradictory (kept `(~line N)` markers while concluding "function-name citations remain stable"). Kept the #8826 reference and the mid-term-default note.

**N-2.g — `keeper_execution_receipt.ml`:**
```diff
-     Eventually-emit liveness   -> [append] (~line 455) calls the emit ...
+     Eventually-emit liveness   -> [append] calls the emit ...
```
Actual `let append` at line 879 — +424 from the cited 455.

## 왜 톱니처럼 정교하지 않은가

`keeper_memory_policy.ml`의 docstring은 *자기 모순*이었다: "Spec line drift correction" 블록이 "actual line is 165 (+10 drift)"라 적었지만 실제는 204 (+39) — 자기-수정 메커니즘이 그 자체로 stale; 그러면서 "function-name citations remain stable"이라 결론 — 즉 옳은 원칙을 알면서도 `(~line N)` 마커를 유지. iter 64 N-2.a가 spec 측에서, iter 72 R-1.a validator가 OCaml 측에서 이 원칙을 강제하므로, docstring을 그 원칙에 맞게 정리.

## Verification

```
$ rg -n '\[[a-z_]+\][^]]*~?line\s+[0-9]+' lib/keeper/keeper_memory_policy.ml lib/keeper/keeper_execution_receipt.ml   # empty after
$ dune build --root . test/test_keeper_memory_bank_consensus_re_10399.exe   # clean (keeper_memory_policy.ml)
$ dune build --root . test/test_dashboard_goals.exe                          # clean (keeper_execution_receipt.ml)
```

(`scripts/audit-ocaml-spec-nav-line-refs.sh` is in #14944, not yet on main — couldn't run it from this branch. When #14944 lands, these two files no longer trigger it.)

## Trade-off

- Drains 4/7 of the `scripts/ocaml-spec-nav-line-refs-baseline.txt` entries (iter 72 #14944, in flight): `keeper_execution_receipt.ml:append` + `keeper_memory_policy.ml:{short_term_horizon,memory_horizon_of_kind_opt,memory_horizon_of_kind}`. But the baseline file doesn't exist on this PR's base (origin/main), so it can't be edited here — a follow-up **R-1.b** drains those (plus `keeper_approval_queue.ml ×3` from #14943) once #14944 and the fix-PRs all land. Stale-but-absent baseline entries are harmless to CI in the interim.
- **N-2.h** (`keeper_heartbeat_loop.ml`) still pending — that one quotes free text ("Spec line 4 cites this function 'at line 1815'") not the `[symbol] (~line N)` pattern, so it's outside the R-1.a validator's scope; a hand fix.

## RFC 참조

RFC-WAIVED: comment-only docstrings. `keeper_memory_policy.ml` / `keeper_execution_receipt.ml` 둘 다 credential/identity/operator/sandbox/hooks/workflow RFC-required set 아님 (`bash ~/me/scripts/pr-rfc-check.sh` 통과).

## 진행 추적

다음 iteration 시작점:
1. **N-2.h** (keeper_heartbeat_loop.ml — free-text spec quote update, hand fix) OR
2. **R-1.b** (#14944 + #14943 + this 머지 후 — baseline에서 7줄 모두 drain → validator zero-drift enforce) OR
3. **Q-2.c·Q-2.d** (KEQ) / **M-2.d** (KOAS TLC) OR
4. **R-D-2.a + R-D-1.a bundle** (MID ~150-300 LOC biggest pending) OR
5. **새 spec entry** (KH 미진입; ~13개 미감사)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
