### PR TITLE
feat(keeper): RFC-0070 Phase 3e (b) — Docker_client.S.exec gains ?user + ?workdir

### DIFF
--- a/lib/keeper/docker_client.ml
+++ b/lib/keeper/docker_client.ml
@@ -14,8 +14,11 @@ module type S = sig
     -> (Docker_response.exec_result, sandbox_error) result
 
   val exec
-    :  container:Keeper_container_name.t
+    :  ?user:int * int
+    -> ?workdir:string
+    -> container:Keeper_container_name.t
     -> cmd:string
+    -> unit
     -> (Docker_response.exec_result, sandbox_error) result
 
   val ps_query

--- a/lib/keeper/docker_client.mli
+++ b/lib/keeper/docker_client.mli
@@ -44,9 +44,26 @@ module type S = sig
     -> (Docker_response.exec_result, sandbox_error) result
 
   val exec
-    :  container:Keeper_container_name.t
+    :  ?user:int * int
+    -> ?workdir:string
+    -> container:Keeper_container_name.t
     -> cmd:string
+    -> unit
     -> (Docker_response.exec_result, sandbox_error) result
+  (** [exec ?user ?workdir ~container ~cmd ()] runs [cmd] inside an
+      already-running [container] via [docker exec].
+
+      - [?user] — [(uid, gid)], emitted as [--user uid:gid]. Omitted
+        ⇒ docker uses the container image's [USER].
+      - [?workdir] — emitted as [-w workdir]. Omitted ⇒ docker uses
+        the container's [WORKDIR].
+
+      The trailing [unit] is required so OCaml can erase the leading
+      optionals (warning 16) — all parameters are otherwise labeled.
+
+      A non-zero exit *inside the container* is the command's result
+      ([Ok { exit_code = n; ... }]), not a daemon error; only
+      daemon-level statuses become [Error Daemon_unreachable]. *)
 
   val ps_query
     :  labels:(string * string) list

--- a/lib/keeper/docker_client_mock.ml
+++ b/lib/keeper/docker_client_mock.ml
@@ -55,7 +55,14 @@ let run plan =
     response
   | _ -> Error Docker_client.Daemon_unreachable
 
-let exec ~container ~cmd =
+let exec ?user:_ ?workdir:_ ~container ~cmd () =
+  (* [?user] / [?workdir] shape the real [docker exec] argv (see
+     {!Docker_client_real.exec_argv}) but do not affect the mocked
+     response, so they are accepted and ignored for matching here —
+     the injection key stays [(container, cmd)]. When a caller
+     (Phase 4.1 [keeper_turn_sandbox_runtime] cutover) needs to
+     assert the user/workdir threaded through, widen the injection
+     key then; until then a narrower key keeps test setup minimal. *)
   match Queue.peek_opt exec_queue with
   | Some ((expected_c, expected_cmd), response)
     when Keeper_container_name.equal container expected_c

--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -52,10 +52,30 @@ let map_status_to_exec_result
 
 let ps_query ~labels:_ = placeholder
 
-let exec ~container ~cmd =
-  let argv =
-    [ "docker"; "exec"; Keeper_container_name.to_string container; "sh"; "-lc"; cmd ]
+(* Pure: builds the [docker exec] argv. Separated from {!exec} so the
+   argv shape is unit-testable without a daemon (RFC-0070's pure/edge
+   split — deterministic argv construction here, daemon spawn in
+   {!exec}). [--user] precedes [-w] to match the order
+   [keeper_turn_sandbox_runtime] currently emits. *)
+let exec_argv ?user ?workdir ~container ~cmd () =
+  let user_args =
+    match user with
+    | None -> []
+    | Some (uid, gid) -> [ "--user"; Printf.sprintf "%d:%d" uid gid ]
   in
+  let workdir_args =
+    match workdir with
+    | None -> []
+    | Some w -> [ "-w"; w ]
+  in
+  [ "docker"; "exec" ]
+  @ user_args
+  @ workdir_args
+  @ [ Keeper_container_name.to_string container; "sh"; "-lc"; cmd ]
+;;
+
+let exec ?user ?workdir ~container ~cmd () =
+  let argv = exec_argv ?user ?workdir ~container ~cmd () in
   (* [Process_eio.run_argv_with_status_split] returns
      [(status, stdout, stderr)]; on spawn failure the status is
      synthesized as [WEXITED 127] (see 3b-iv.2.1 commit on rm). *)

--- a/lib/keeper/docker_client_real.mli
+++ b/lib/keeper/docker_client_real.mli
@@ -58,3 +58,16 @@
     leak" contract is preserved. *)
 
 include Docker_client.S
+
+(** [exec_argv ?user ?workdir ~container ~cmd ()] is the pure [docker
+    exec] argv builder used by {!exec}. Exposed for unit-testing the
+    argv shape (option presence, [--user] before [-w] ordering)
+    without spawning a daemon. Trailing [unit] for the same
+    optional-erasure reason as {!exec}. *)
+val exec_argv
+  :  ?user:int * int
+  -> ?workdir:string
+  -> container:Keeper_container_name.t
+  -> cmd:string
+  -> unit
+  -> string list

--- a/test/test_docker_client_mock.ml
+++ b/test/test_docker_client_mock.ml
@@ -114,7 +114,7 @@ let test_exec_matches_injection () =
   let c = sample_container () in
   Docker_client_mock.inject_exec ~container:c ~cmd:"ls -la"
     (Ok sample_exec_result);
-  match Docker_client_mock.exec ~container:c ~cmd:"ls -la" with
+  match Docker_client_mock.exec ~container:c ~cmd:"ls -la" () with
   | Ok er -> check string "stdout" "ok" er.stdout
   | Error _ -> fail "expected Ok"
 
@@ -123,9 +123,22 @@ let test_exec_unmatched_cmd () =
   let c = sample_container () in
   Docker_client_mock.inject_exec ~container:c ~cmd:"ls -la"
     (Ok sample_exec_result);
-  match Docker_client_mock.exec ~container:c ~cmd:"different cmd" with
+  match Docker_client_mock.exec ~container:c ~cmd:"different cmd" () with
   | Error Docker_client.Daemon_unreachable -> ()
   | _ -> fail "expected miss on different cmd"
+
+(* Phase 3e (b) — [exec] now takes [?user] / [?workdir]; the mock
+   ignores them for matching (key stays [(container, cmd)]). Passing
+   them must not change which injection is consumed. *)
+let test_exec_ignores_user_workdir_for_matching () =
+  setup ();
+  let c = sample_container () in
+  Docker_client_mock.inject_exec ~container:c ~cmd:"id" (Ok sample_exec_result);
+  match
+    Docker_client_mock.exec ~user:(1000, 1000) ~workdir:"/work" ~container:c ~cmd:"id" ()
+  with
+  | Ok er -> check string "stdout" "ok" er.stdout
+  | Error _ -> fail "expected Ok — user/workdir must not affect matching"
 
 (* ── ps_query ────────────────────────────────────────────────── *)
 
@@ -195,6 +208,8 @@ let () =
         [
           test_case "matches" `Quick test_exec_matches_injection;
           test_case "wrong cmd → miss" `Quick test_exec_unmatched_cmd;
+          test_case "user/workdir ignored for matching" `Quick
+            test_exec_ignores_user_workdir_for_matching;
         ] );
       ( "ps_query",
         [

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -73,7 +73,7 @@ let test_run_returns_typed_result () =
    (no daemon / CLI missing). Other [sandbox_error] variants are
    semantically out of scope for [exec] and must NOT surface. *)
 let test_exec_returns_typed_result () =
-  match Docker_client_real.exec ~container:(sample_container ()) ~cmd:"echo hi" with
+  match Docker_client_real.exec ~container:(sample_container ()) ~cmd:"echo hi" () with
   | Ok _ -> () (* daemon present *)
   | Error Docker_client.Daemon_unreachable -> () (* daemon / CLI missing *)
   | Error Docker_client.Cleanup_failed
@@ -82,6 +82,70 @@ let test_exec_returns_typed_result () =
   | Error Docker_client.Exec_timeout
   | Error Docker_client.Probe_format_drift ->
     fail "exec should only surface Ok exec_result or Error Daemon_unreachable"
+;;
+
+(* Phase 3e (b) — [exec_argv] is the pure argv builder behind [exec].
+   Deterministic (no daemon needed): assert option presence and the
+   [--user]-before-[-w] ordering. The container suffix is PID+nonce so
+   its string form is unique per invocation; the test only checks it
+   lands in the right position. *)
+let test_exec_argv_plain () =
+  let c = sample_container () in
+  check
+    (list string)
+    "no user, no workdir"
+    [ "docker"; "exec"; Keeper_container_name.to_string c; "sh"; "-lc"; "ls -la" ]
+    (Docker_client_real.exec_argv ~container:c ~cmd:"ls -la" ())
+;;
+
+let test_exec_argv_user_only () =
+  let c = sample_container () in
+  check
+    (list string)
+    "user only → --user uid:gid"
+    [ "docker"
+    ; "exec"
+    ; "--user"
+    ; "1000:1000"
+    ; Keeper_container_name.to_string c
+    ; "sh"
+    ; "-lc"
+    ; "id"
+    ]
+    (Docker_client_real.exec_argv ~user:(1000, 1000) ~container:c ~cmd:"id" ())
+;;
+
+let test_exec_argv_workdir_only () =
+  let c = sample_container () in
+  check
+    (list string)
+    "workdir only → -w <dir>"
+    [ "docker"; "exec"; "-w"; "/work"; Keeper_container_name.to_string c; "sh"; "-lc"; "pwd" ]
+    (Docker_client_real.exec_argv ~workdir:"/work" ~container:c ~cmd:"pwd" ())
+;;
+
+let test_exec_argv_user_and_workdir () =
+  let c = sample_container () in
+  check
+    (list string)
+    "user + workdir → --user before -w"
+    [ "docker"
+    ; "exec"
+    ; "--user"
+    ; "1000:1000"
+    ; "-w"
+    ; "/work"
+    ; Keeper_container_name.to_string c
+    ; "sh"
+    ; "-lc"
+    ; "whoami"
+    ]
+    (Docker_client_real.exec_argv
+       ~user:(1000, 1000)
+       ~workdir:"/work"
+       ~container:c
+       ~cmd:"whoami"
+       ())
 ;;
 
 let test_ps_query_placeholder () =
@@ -139,6 +203,15 @@ let () =
             "rm → typed error (Daemon_unreachable | Cleanup_failed)"
             `Quick
             test_rm_returns_typed_error
+        ] )
+    ; ( "exec_argv (pure, Phase 3e b)"
+      , [ test_case "plain (no user/workdir)" `Quick test_exec_argv_plain
+        ; test_case "user only" `Quick test_exec_argv_user_only
+        ; test_case "workdir only" `Quick test_exec_argv_workdir_only
+        ; test_case
+            "user + workdir (--user before -w)"
+            `Quick
+            test_exec_argv_user_and_workdir
         ] )
     ; ( "Functor composition"
       , [ test_case


### PR DESCRIPTION
## Summary

RFC-0070 §3.0.4 + §4 Phase 3e item (b): `Docker_client.S.exec` gains `?user` + `?workdir`. The keeper turn-sandbox runtime invokes `docker exec --user uid:gid -w cwd <container> sh -lc <cmd>` (the Phase 4.1 cutover target), but `exec` only had `~container ~cmd` — this lets the typed plan carry user/workdir instead of the caller hand-building argv.

## What changed

| File | Change |
|------|--------|
| `docker_client.{ml,mli}` | `S.exec` → `?user:(int * int) -> ?workdir:string -> container:... -> cmd:... -> unit -> result`. `?user` = `(uid, gid)` → `--user uid:gid`; `?workdir` → `-w workdir`. Trailing `unit` so OCaml can erase the leading optionals (warning 16 — all params labeled). |
| `docker_client_real.ml` | new pure `exec_argv ?user ?workdir ~container ~cmd ()` (builds the argv; `--user` precedes `-w` to match what `keeper_turn_sandbox_runtime` emits today); `exec` delegates to it then spawns. Splitting the deterministic argv construction from the daemon spawn keeps it unit-testable without a daemon — RFC-0070's pure/edge thesis applied to one more edge. |
| `docker_client_real.mli` | exposes `exec_argv` for tests |
| `docker_client_mock.ml` | `exec` accepts + ignores `?user`/`?workdir` for matching (injection key stays `(container, cmd)` — they shape the real argv, not the mocked response). Comment: when Phase 4.1 needs to assert the threaded-through user/workdir, the injection key widens then. Documented, not silently dropped. |
| `test_docker_client_real.ml` | +4 `exec_argv` cases (plain / user-only / workdir-only / both — asserts `--user` before `-w`). 5→9 tests. |
| `test_docker_client_mock.ml` | +1 case: user/workdir do not affect matching. 10→11 tests. |

## Verification

```
$ dune build --root . test/test_docker_client_real.exe test/test_docker_client_mock.exe   # exit 0
$ _build/default/test/test_docker_client_real.exe   # Test Successful in 0.888s. 9 tests run.
$ _build/default/test/test_docker_client_mock.exe   # Test Successful in 0.001s. 11 tests run.
```

Existing `exec ~container ~cmd ()` call sites add the `()`; no behavior change with the optionals omitted. No production caller of `D.exec` exists yet (Phase 4 not done) — only the two test files + the two impls.

## Scope

- `?user:int * int` is a `(uid, gid)` pair to mirror the existing keeper code; a typed `posix_user` record could be a follow-up if the Phase 4.1 cutover wants it.
- The remaining Phase 3e items — `run_detached` (a), `info_security_options` (c), `image_inspect` (d), `Keeper_sandbox_session_plan`, `Sandbox_session_executor.Make` — are not in this PR. (b) is self-contained and does not expose a new layer, so shipping it alone is safe fragmentation (not the dune-cascade pattern memory warns about).

## RFC reference

RFC-0070 §3.0.4 ("`exec` flag completeness fix") + §4 Phase 3e item (b). RFC-0070 *extends* RFC-0006 (no keeper sandbox containment-policy change here) and *depends on* RFC-0036 (no cleanup-hook surface change here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
