### PR TITLE
Review follow-up hardening

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -5,6 +5,20 @@
 (private_modules
  plan_action_outcome
  error_event_type
+ alert_persist_kind
+ metrics_sse_failure_kind
+ paused_state_persist_phase
+ bookkeeping_failure_kind
+ checkpoint_failure_operation
+ profile_load_failure_site
+ turn_cleanup_failure_site
+ cascade_sync_failure_site
+ event_bus_drain_site
+ turn_metrics_snapshot_failure_site
+ metric_emit_dropped_site
+ post_turn_wirein_failure_site
+ atomic_orphan_size_class
+ silent_dashboard_actor_outcome
  dashboard_http_keeper_metrics
  dashboard_http_keeper_detail
  dashboard_http_tool_quality

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1796,7 +1796,11 @@ let set_turn_phase ~base_path name (turn_phase : packed_turn_phase) =
      Mirrors the cascade-side wiring (PR #14908) — idempotent self-loops no
      longer flip [changed] or emit a broadcast, and forbidden transitions
      raise the typed [Turn_phase_transition_violation] (Phase 5) carrying
-     the [turn_phase_transition_spec_violation] payload directly. *)
+     the [turn_phase_transition_spec_violation] payload directly.  The
+     violation branch stays wrapped by [Keeper_fsm_guard_runtime.wrap_unit]
+     (PR #14926 pattern) so direct setter rejections keep incrementing
+     [masc_fsm_guard_violation_total] — see the [Resolved_turn_violation]
+     arm below. *)
   let changed = ref false in
   let now = Time_compat.now () in
   update_entry ~base_path name (fun e ->

--- a/lib/tool_args.ml
+++ b/lib/tool_args.ml
@@ -95,8 +95,11 @@ let error_code_to_string = function
     but returning the unserialized [Yojson.Safe.t] node so it can be
     composed into a larger structure or returned as
     [(Yojson.Safe.t, _) result]. *)
+let without_status_field fields =
+  List.filter (fun (key, _) -> not (String.equal key "status")) fields
+
 let error_assoc fields : Yojson.Safe.t =
-  `Assoc (("status", `String "error") :: fields)
+  `Assoc (("status", `String "error") :: without_status_field fields)
 
 (** Build a JSON error response string: [\{"status":"error","message":"..."\}] *)
 let error_response message =
@@ -105,7 +108,9 @@ let error_response message =
 (** Build a JSON error response string with caller-supplied fields.
     Use when the error payload needs more than just [message] (e.g.
     [error]/[agent_id]/[config_path] context).  Field-order semantics:
-    [status] is prepended to the head of the [`Assoc]. *)
+    [status] is prepended to the head of the [`Assoc].  Caller-supplied
+    [status] fields are discarded so the canonical envelope cannot be
+    overridden by duplicate JSON keys. *)
 let error_response_with fields =
   Yojson.Safe.to_string (error_assoc fields)
 
@@ -118,10 +123,6 @@ let error_response_typed ~code message =
       ("message", `String message);
     ]
 
-(** Build a JSON OK response string with additional fields. *)
-let ok_response fields =
-  Yojson.Safe.to_string (`Assoc (("status", `String "ok") :: fields))
-
 (** Build a JSON OK envelope as a [Yojson.Safe.t] (unserialized).  Use
     when the caller needs the envelope as part of a larger composed
     response — for example HTTP body builders that wrap multiple
@@ -129,7 +130,11 @@ let ok_response fields =
     serialize at a later stage.  Same field-order guarantee as
     [ok_response]: status is prepended to the head of the [`Assoc]. *)
 let ok_assoc fields : Yojson.Safe.t =
-  `Assoc (("status", `String "ok") :: fields)
+  `Assoc (("status", `String "ok") :: without_status_field fields)
+
+(** Build a JSON OK response string with additional fields. *)
+let ok_response fields =
+  Yojson.Safe.to_string (ok_assoc fields)
 
 (** {1 Tool_result.t Helpers}
 

--- a/lib/tool_args.mli
+++ b/lib/tool_args.mli
@@ -67,10 +67,12 @@ val error_code_to_string : error_code -> string
     These produce plain JSON strings without [Tool_result.t] wrapping.
     Used by [get_string_required] error paths and other low-level callers. *)
 
-(** [{"status":"error", <fields>}] as a [`Assoc] node.  Counterpart to
-    {!ok_response} / {!ok_result} on the success side, but returns the
-    *unserialized* [Yojson.Safe.t] for embedding in a larger response
-    or returning via [(Yojson.Safe.t, _) result]. *)
+(** [{"status":"error", <fields>}] as a [`Assoc] node.  Caller-supplied
+    [status] fields are discarded so duplicate JSON keys cannot override
+    the canonical envelope status.  Counterpart to {!ok_response} /
+    {!ok_result} on the success side, but returns the *unserialized*
+    [Yojson.Safe.t] for embedding in a larger response or returning via
+    [(Yojson.Safe.t, _) result]. *)
 val error_assoc : (string * Yojson.Safe.t) list -> Yojson.Safe.t
 
 (** [{"status":"error","message":"…"}] as a serialized JSON string. *)
@@ -78,7 +80,8 @@ val error_response : string -> string
 
 (** [{"status":"error", <fields>}] as a serialized JSON string with
     caller-supplied fields.  Use when the payload needs more than just
-    [message] (e.g. [error]/[agent_id]/[config_path] context). *)
+    [message] (e.g. [error]/[agent_id]/[config_path] context).  Any
+    caller-supplied [status] field is discarded. *)
 val error_response_with : (string * Yojson.Safe.t) list -> string
 
 (** [{"status":"error","error_code":"…","message":"…"}] *)
@@ -91,7 +94,8 @@ val ok_response : (string * Yojson.Safe.t) list -> string
     Use when embedding the envelope in a larger composed response — HTTP
     body builders, [(Yojson.Safe.t, string) result] pipelines, etc.
     Identical field-order semantics to {!ok_response}: [status] is
-    prepended to the [`Assoc] head. *)
+    prepended to the [`Assoc] head and caller-supplied [status] fields are
+    discarded. *)
 val ok_assoc : (string * Yojson.Safe.t) list -> Yojson.Safe.t
 
 (** {1 Tool_result.t Helpers}

--- a/scripts/lint/no-inline-error-envelope.sh
+++ b/scripts/lint/no-inline-error-envelope.sh
@@ -23,6 +23,21 @@ ALLOWLIST=(
 )
 
 count=0
+matches_file="$(mktemp)"
+errors_file="$(mktemp)"
+cleanup() {
+  rm -f "$matches_file" "$errors_file"
+}
+trap cleanup EXIT
+
+rg_status=0
+rg -nP '"status",\s*`String\s+"error"' lib/ -g '*.ml' >"$matches_file" 2>"$errors_file" || rg_status=$?
+if [[ $rg_status -gt 1 ]]; then
+  echo "ERROR: ripgrep failed while scanning error-envelope literals" >&2
+  cat "$errors_file" >&2
+  exit "$rg_status"
+fi
+
 while IFS= read -r match; do
   file=${match%%:*}
 
@@ -41,7 +56,7 @@ while IFS= read -r match; do
 
   echo "ERROR: inline error-envelope literal (use Tool_args.error_response / error_response_with / error_assoc / error_result): $match"
   count=$((count + 1))
-done < <(rg -nP '"status",\s*`String\s+"error"' lib/ --type-add 'ocaml:*.ml' -tocaml 2>/dev/null || true)
+done < "$matches_file"
 
 if [[ $count -gt 0 ]]; then
   echo ""

--- a/scripts/lint/no-inline-ok-envelope.sh
+++ b/scripts/lint/no-inline-ok-envelope.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# lint-ok-envelope.sh — Block inline `("status", `String "ok")` literals
+# no-inline-ok-envelope.sh — Block inline `("status", `String "ok")` literals
 # in lib/. Use Tool_args.ok_response / ok_assoc / ok_result instead.
 #
 # Rationale: T27/T28/T29 consolidated 11+ inline ok-envelope sites into
@@ -55,6 +55,21 @@ ALLOWLIST=(
 )
 
 count=0
+matches_file="$(mktemp)"
+errors_file="$(mktemp)"
+cleanup() {
+  rm -f "$matches_file" "$errors_file"
+}
+trap cleanup EXIT
+
+rg_status=0
+rg -nP '\("status",\s*`String\s+"ok"\)' lib/ -g '*.ml' >"$matches_file" 2>"$errors_file" || rg_status=$?
+if [[ $rg_status -gt 1 ]]; then
+  echo "ERROR: ripgrep failed while scanning ok-envelope literals" >&2
+  cat "$errors_file" >&2
+  exit "$rg_status"
+fi
+
 while IFS= read -r match; do
   file=${match%%:*}
 
@@ -75,7 +90,7 @@ while IFS= read -r match; do
   # Strip the line:linenumber prefix for display.
   echo "ERROR: inline ok-envelope literal (use Tool_args.ok_response / ok_assoc / ok_result): $match"
   count=$((count + 1))
-done < <(rg -nP '\("status",\s*`String\s+"ok"\)' lib/ --type-add 'ocaml:*.ml' -tocaml 2>/dev/null || true)
+done < "$matches_file"
 
 if [[ $count -gt 0 ]]; then
   echo ""

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -1488,11 +1488,13 @@ let test_set_turn_phase_rejection_bumps_guard_metric () =
       R.set_turn_phase ~base_path:bp keeper_name R.(Packed Turn_compacting);
       false
     with
-    | Invalid_argument msg ->
-      String.starts_with ~prefix:"set_turn_phase" msg
+    | R.Turn_phase_transition_violation { where; _ } ->
+      String.equal where "set_turn_phase"
   in
   let after = fsm_guard_count () in
-  check bool "forbidden set_turn_phase raises Invalid_argument" true raised;
+  check bool
+    "forbidden set_turn_phase raises Turn_phase_transition_violation from the setter"
+    true raised;
   check (float 0.0001) "guard metric increments" (before +. 1.0) after
 
 let test_effective_keepalive_meta_prefers_disk_when_present () =

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -1471,6 +1471,30 @@ let test_two_sdk_turn_boundaries_no_assert () =
        && obs.R.turn_phase = R.Packed R.Turn_routing)
   | _ -> fail "obs missing after second SDK boundary"
 
+let fsm_guard_count () =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Prometheus.metric_fsm_guard_violation
+    ~labels:[ ("action", "turn_phase_transition"); ("stage", "guard") ]
+    ()
+
+let test_set_turn_phase_rejection_bumps_guard_metric () =
+  R.clear ();
+  let keeper_name = "k-turn-phase-guard-metric" in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  R.mark_turn_started ~base_path:bp keeper_name;
+  let before = fsm_guard_count () in
+  let raised =
+    try
+      R.set_turn_phase ~base_path:bp keeper_name R.(Packed Turn_compacting);
+      false
+    with
+    | Invalid_argument msg ->
+      String.starts_with ~prefix:"set_turn_phase" msg
+  in
+  let after = fsm_guard_count () in
+  check bool "forbidden set_turn_phase raises Invalid_argument" true raised;
+  check (float 0.0001) "guard metric increments" (before +. 1.0) after
+
 let test_effective_keepalive_meta_prefers_disk_when_present () =
   R.clear ();
   let stale = make_meta "loop-meta-disk" in
@@ -1639,5 +1663,7 @@ let () =
             test_mark_sdk_turn_started_no_op_without_obs;
           eio_test "two SDK-turn boundaries inside one keeper-turn"
             test_two_sdk_turn_boundaries_no_assert;
+          eio_test "set_turn_phase rejection bumps guard metric"
+            test_set_turn_phase_rejection_bumps_guard_metric;
         ] );
     ]

--- a/test/test_tool_args_envelope.ml
+++ b/test/test_tool_args_envelope.ml
@@ -1,6 +1,10 @@
 open Alcotest
 open Masc_mcp
 
+let parse_json label payload =
+  try Yojson.Safe.from_string payload with
+  | exn -> failf "%s was not valid JSON: %s; payload=%s" label (Printexc.to_string exn) payload
+
 let test_error_response_matches_error_assoc () =
   let msg = "boom" in
   let expected =
@@ -23,7 +27,7 @@ let test_error_response_with_matches_error_assoc () =
 
 let test_error_response_with_prepends_status_first () =
   let fields = [ ("message", `String "oops") ] in
-  let json = Yojson.Safe.from_string (Tool_args.error_response_with fields) in
+  let json = parse_json "error_response_with" (Tool_args.error_response_with fields) in
   match json with
   | `Assoc ((k, `String v) :: _) ->
     check string "first key is status" "status" k;
@@ -41,8 +45,38 @@ let test_error_response_typed_path () =
   in
   check string "typed error path uses canonical helper" expected actual
 
+let test_error_response_with_drops_caller_status () =
+  let json =
+    parse_json
+      "error_response_with duplicate status"
+      (Tool_args.error_response_with
+         [ ("status", `String "ok"); ("message", `String "boom") ])
+  in
+  match json with
+  | `Assoc fields ->
+    check
+      (list string)
+      "single canonical status key"
+      [ "status"; "message" ]
+      (List.map fst fields);
+    check string "status value" "error"
+      (Yojson.Safe.Util.(json |> member "status" |> to_string))
+  | _ -> fail "expected assoc"
+
+let test_ok_assoc_drops_caller_status () =
+  match Tool_args.ok_assoc [ ("status", `String "error"); ("value", `Int 1) ] with
+  | `Assoc fields ->
+    check
+      (list string)
+      "single canonical status key"
+      [ "status"; "value" ]
+      (List.map fst fields);
+    check string "status value" "ok"
+      (Yojson.Safe.Util.(`Assoc fields |> member "status" |> to_string))
+  | _ -> fail "expected assoc"
+
 let () =
-  run ~and_exit:false "Tool_args_envelope"
+  run "Tool_args_envelope"
     [
       ( "error_envelope",
         [
@@ -54,5 +88,9 @@ let () =
             test_error_response_with_prepends_status_first;
           test_case "typed path keeps canonical shape" `Quick
             test_error_response_typed_path;
+          test_case "caller status cannot override error envelope" `Quick
+            test_error_response_with_drops_caller_status;
+          test_case "caller status cannot override ok envelope" `Quick
+            test_ok_assoc_drops_caller_status;
         ] );
     ]


### PR DESCRIPTION
## Summary

Review-audit follow-up for MASC PRs created in the last 24h window.

Audit window: PRs created since `2026-05-11T02:04:25Z`, checked on `2026-05-12`.

Live scan result:
- `jeong-sik/masc-mcp`: 354 recent PRs scanned
- 185 PRs still had unresolved current review threads
- 444 unresolved current review threads found

This PR does not attempt to replay every stale thread. It groups repeated review findings into root-level hardening:
- make telemetry/label helper modules private so internal support modules do not become public API by accident
- harden the inline JSON-envelope lint scripts so `rg` failures are not silently swallowed
- prevent caller-supplied duplicate `status` fields from overriding canonical tool envelopes
- keep a regression test for direct `set_turn_phase` guard-metric coverage after the runtime wrapper landed on `main`

## Notes

`origin/main` already contains the runtime wrapper for direct `set_turn_phase` rejection metrics. This branch preserves that implementation, adds the missing regression coverage, and updates the local comment to make the direct-setter metric requirement explicit.

## Validation

- `bash scripts/lint/no-inline-error-envelope.sh`
- `bash scripts/lint/no-inline-ok-envelope.sh`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh exec test/test_tool_args_envelope.exe`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh exec test/test_keeper_registry.exe`
- `git diff --check`

Pin note: local MASC verification used `MASC_SKIP_PIN_CHECK=1` because the shared opam switch is already pinned to a newer `agent_sdk` and the repo repair script refused to downgrade the shared pin.
