### PR TITLE
docs(keeper): N-2.h + R-1.b — close out OCaml-docstring line-ref drift class (iter 74)

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -1558,9 +1558,12 @@ let record_keepalive_stage_timing
 
    The spec preamble cites this module by function name
    ([run_heartbeat_loop]); it used to carry a line number but iter 64
-   N-2.c removed it (function names are stable, line numbers drift —
-   guarded by scripts/audit-ocaml-spec-nav-line-refs.sh, iter 72 R-1.a).
-   This comment is the authoritative reverse-direction citation.
+   N-2.a removed it — function names are stable, line numbers drift, and
+   spec-preamble line refs are now guarded by
+   scripts/audit-tla-ml-line-refs.sh (iter 64 N-2.c).  This comment is
+   the authoritative reverse-direction citation; the OCaml-docstring
+   side is guarded by scripts/audit-ocaml-spec-nav-line-refs.sh
+   (iter 72 R-1.a).
 
    Action mapping (TLA+ -> OCaml):
      WakeupSignal     external code sets [wakeup] Atomic to true

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -1556,18 +1556,19 @@ let record_keepalive_stage_timing
    specs/keeper-state-machine/KeeperHeartbeat.tla (Cycle 7 / Tier B1,
    PR #11408).
 
-   Spec line 4 cites this function "at line 1815"; the actual current
-   line is 1828 (drift of +13 since spec was authored, due to upstream
-   changes in this module).  Future spec PRs may re-anchor; until
-   then this comment is the authoritative reverse-direction citation.
+   The spec preamble cites this module by function name
+   ([run_heartbeat_loop]); it used to carry a line number but iter 64
+   N-2.c removed it (function names are stable, line numbers drift —
+   guarded by scripts/audit-ocaml-spec-nav-line-refs.sh, iter 72 R-1.a).
+   This comment is the authoritative reverse-direction citation.
 
    Action mapping (TLA+ -> OCaml):
      WakeupSignal     external code sets [wakeup] Atomic to true
                       (e.g., wakeup_keeper / operator_resume).
-     HeartbeatTick    [interruptible_sleep] consumes the wakeup via
-                      [Atomic.compare_and_set wakeup true false] at
-                      this file line 589, then the loop body services
-                      the pending event.
+     HeartbeatTick    [Keeper_keepalive_signal.interruptible_sleep]
+                      consumes the wakeup via
+                      [Atomic.compare_and_set wakeup true false], then
+                      the loop body services the pending event.
      TurnComplete     turn body finishes; loop returns to next sleep
                       cycle.
      MissedWakeup     bug action — the wakeup is observed and cleared

--- a/scripts/ocaml-spec-nav-line-refs-baseline.txt
+++ b/scripts/ocaml-spec-nav-line-refs-baseline.txt
@@ -2,23 +2,16 @@
 # for scripts/audit-ocaml-spec-nav-line-refs.sh.  Each non-comment line:
 # "<repo-relative-path>:<symbol>".
 #
-# These are the `[symbol] (~line N)` citations in lib/keeper/*.{ml,mli}
-# header docstrings whose line numbers had already drifted when the
-# validator was introduced (iter 72 R-1.a).  Survey + drift figures:
-# docs/tla-audit/ocaml-docstring-lineref-drift-class-2026-05-12.md (iter 71).
-#
-# Drain a line when its fix-PR merges (same convention as the
-# ocaml-phase-count baseline):
-#   - keeper_approval_queue.ml:*           — drained by N-2.e (#14943)
-#   - keeper_execution_receipt.ml:append   — drained by N-2.g (TBD)
-#   - keeper_memory_policy.ml:*            — drained by N-2.f (TBD)
-# Once all are drained the validator enforces zero OCaml-docstring
-# line-ref drift; the `--baseline` flag stays for future transients.
-
-lib/keeper/keeper_approval_queue.ml:submit_and_await
-lib/keeper/keeper_approval_queue.ml:submit_pending
-lib/keeper/keeper_approval_queue.ml:expire_stale
-lib/keeper/keeper_execution_receipt.ml:append
-lib/keeper/keeper_memory_policy.ml:short_term_horizon
-lib/keeper/keeper_memory_policy.ml:memory_horizon_of_kind_opt
-lib/keeper/keeper_memory_policy.ml:memory_horizon_of_kind
+# STATUS: empty.  iter 72 R-1.a (#14944) introduced the validator with
+# seven grandfathered `[symbol] (~line N)` citations whose line numbers
+# had drifted +29 .. +424; their fix-PRs merged:
+#   keeper_failure_circuit_breaker.ml  — iter 70 #14939 (predates this file)
+#   keeper_approval_queue.ml ×3        — iter 71 N-2.e #14943
+#   keeper_execution_receipt.ml:append — iter 73 N-2.g #14946
+#   keeper_memory_policy.ml ×3         — iter 73 N-2.f #14946
+# iter 74 R-1.b drained the lines, so the validator now enforces zero
+# OCaml-docstring line-ref drift.  Keep this file: the CI step still
+# passes `--baseline <this file>` and the `--baseline` flag works for
+# any future transient grandfathering — add a "<path>:<symbol>" line
+# here, reference the fix-PR in this comment, and remove it once that
+# PR merges (same convention as the ocaml-phase-count baseline).


### PR DESCRIPTION
## Finding (Iteration 74, N-2.h + R-1.b — close out the OCaml-docstring line-ref drift class)

**OCaml**: `lib/keeper/keeper_heartbeat_loop.ml` (N-2.h, spec-nav comment block) + `scripts/ocaml-spec-nav-line-refs-baseline.txt` (R-1.b, drained)
**Aspect**: finish the last OCaml-docstring line-ref site + drain the iter-72 baseline now that all fix-PRs merged
**Risk**: LOW (comment-only + baseline-data-only)
**Workaround signature**: N/A — closes audit→fix→guard for this corner

## 순서도

```mermaid
flowchart LR
  A[iter 63 KAQ N-1: spec preamble line refs] --> B[iter 64 N-2.a/c: fix + audit-tla-ml-line-refs.sh]
  B --> C[iter 70 KCB R-1: found OCaml docstring drift]
  C --> D[iter 71 N-2.e + survey: 5 sites]
  D --> E[iter 72 R-1.a: validator + 7-key baseline]
  D --> F[iter 73 N-2.f/g: keeper_memory_policy + keeper_execution_receipt]
  E & F --> G[iter 74 this PR: N-2.h keeper_heartbeat_loop<br/>+ R-1.b drain baseline → empty]
  G --> H[8th drift class — OCaml corner closed:<br/>audit → fix → guard → baseline drained]
```

## Before / After

**N-2.h — `keeper_heartbeat_loop.ml` (lines 1554-1582 "Spec navigation" block):**
```diff
-   Spec line 4 cites this function "at line 1815"; the actual current
-   line is 1828 (drift of +13 since spec was authored, ...).  Future
-   spec PRs may re-anchor; until then this comment is the authoritative
-   reverse-direction citation.
+   The spec preamble cites this module by function name
+   ([run_heartbeat_loop]); it used to carry a line number but iter 64
+   N-2.c removed it (function names are stable, line numbers drift —
+   guarded by scripts/audit-ocaml-spec-nav-line-refs.sh, iter 72 R-1.a).
+   This comment is the authoritative reverse-direction citation.
   ...
-     HeartbeatTick    [interruptible_sleep] consumes the wakeup via
-                      [Atomic.compare_and_set wakeup true false] at
-                      this file line 589, then the loop body services ...
+     HeartbeatTick    [Keeper_keepalive_signal.interruptible_sleep]
+                      consumes the wakeup via
+                      [Atomic.compare_and_set wakeup true false], then
+                      the loop body services ...
```
- "at line 1815" / "actual current line is 1828" — both stale. `run_heartbeat_loop` is at line **1584** now, and `KeeperHeartbeat.tla`'s preamble no longer says "at line 1815/1828" (iter 64 N-2.c).
- "at this file line 589" — line 589 is `handle_semaphore_wait_timeout` (unrelated). The `compare_and_set wakeup` is inside `Keeper_keepalive_signal.interruptible_sleep` (a *different* module), not this file.

**R-1.b — `scripts/ocaml-spec-nav-line-refs-baseline.txt`:** drained all 7 keys (their fix-PRs all merged: #14939 keeper_failure_circuit_breaker, #14943 keeper_approval_queue ×3, #14946 keeper_execution_receipt:append + keeper_memory_policy ×3). File kept empty with an updated header — same drain-on-merge convention as `ocaml-phase-count-baseline.txt` (iter 65 R-H-1.g).

## 왜 톱니처럼 정교하지 않은가

`keeper_heartbeat_loop.ml`의 코멘트는 *self-aware* — "actual current line is 1828 (drift +13)"라 적으며 drift를 인정했지만, 그 인정 자체가 stale (actual은 1584, 그리고 spec은 더 이상 "at line 1815"이라 안 함). self-aware-but-stale는 stale의 한 종류. 그리고 "at this file line 589"는 아예 틀린 파일을 가리킴 (그 함수는 다른 모듈에 있음). symbol 이름으로 고정하면 둘 다 사라진다 — iter 64 N-2.a/N-2.c가 spec 측에서, iter 72 R-1.a validator가 OCaml 측에서 강제하는 원칙.

## Verification

```
$ bash scripts/audit-ocaml-spec-nav-line-refs.sh --baseline scripts/ocaml-spec-nav-line-refs-baseline.txt
ocaml-spec-nav line-ref audit clean: 0 citation(s) verified across 500 file(s) (0 baselined). ; exit 0
$ sed -n '1554,1582p' lib/keeper/keeper_heartbeat_loop.ml | rg 'line [0-9]+|at line'   # empty after
$ dune build --root . test/test_keeper_semaphore_wait_counter.exe   # clean
```

## Trade-off

- Worktree note: this iteration's worktree ended up nested (`.worktrees/fsm-loop-iter73/.worktrees/fsm-loop-iter74`) because the persistent shell cwd was inside iter 73's worktree when `git worktree add .worktrees/...` ran. Functional but cosmetically ugly; harmless (registered with the main repo's worktree list). Future: cd to the main-repo absolute path before `git worktree add`.
- The "Spec navigation" comment in `keeper_heartbeat_loop.ml` still has *one* stale "this file line 589" elsewhere? No — checked: only the two sites above. The block is now line-number-free.

## RFC 참조

RFC-WAIVED: comment + baseline data. `keeper_heartbeat_loop.ml`은 credential/identity/operator/sandbox/hooks/workflow RFC-required set 아님 (`bash ~/me/scripts/pr-rfc-check.sh` 통과).

## 진행 추적

OCaml-docstring line-ref drift class 완전 종료 (audit iter 70/71 → fix N-2.e/f/g/h → guard R-1.a → baseline drained R-1.b). 다음 iteration 시작점:
1. **Q-2.c** (KEQ `EmitMatchesEvidence` enforcement-site pin / pure-spec doc) / **Q-2.d** (KEQ cfg TLC refresh) / **M-2.d** (KOAS cfg TLC refresh) OR
2. **R-D-2.a + R-D-1.a bundle** (MID ~150-300 LOC — KCAF call_err 3-way + Cascade_fsm.Exhausted 2-way split, biggest pending) OR
3. **새 spec entry** (KH 미진입; KeeperTurnSlot / KeeperLaunchPending / KeeperMemoryLifecycle / KeeperRolloverDecision 등 ~13개 미감사) OR
4. **KSM A-5 잔여** (22×19 update_conditions matrix)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
