### PR TITLE
feat(types): enable warning 4 on masc_types + exhaust masc_error.code (RFC-0071 §3.4)

### DIFF
--- a/lib/types/dune
+++ b/lib/types/dune
@@ -4,5 +4,7 @@
  (public_name masc_mcp.masc_types)
  (wrapped false)
  (modules rate_limit_types masc_error ids types_core types_auth masc_domain task_stage severity)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries yojson unix time_compat masc_core base64 uuidm)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving.ord ppx_deriving_yojson)))

--- a/lib/types/masc_error.ml
+++ b/lib/types/masc_error.ml
@@ -223,12 +223,31 @@ let to_yojson err =
 
 let code = function
   | Auth (Auth_error.Forbidden _) -> 403
-  | Auth _ -> 401
+  | Auth (Auth_error.Unauthorized _
+         | Auth_error.TokenExpired _
+         | Auth_error.InvalidToken _) -> 401
   | Task (Task_error.NotFound _) -> 404
   | Agent (Agent_error.NotFound _) -> 404
-  | Task _ | Agent _ | Portal _ | System _ -> 400
+  | Task (Task_error.AlreadyClaimed _
+         | Task_error.NotClaimed _
+         | Task_error.InvalidState _
+         | Task_error.InvalidId _) -> 400
+  | Agent (Agent_error.NotJoined _
+          | Agent_error.AlreadyJoined _
+          | Agent_error.InvalidName _) -> 400
+  | Portal (Portal_error.NotOpen _
+           | Portal_error.AlreadyOpen _
+           | Portal_error.Closed _) -> 400
+  | System (System_error.NotInitialized
+           | System_error.AlreadyInitialized
+           | System_error.InvalidJson _
+           | System_error.IoError _
+           | System_error.InvalidFilePath _
+           | System_error.StorageError _
+           | System_error.ValidationError _
+           | System_error.WorktreeNotFound _) -> 400
   | RateLimitExceeded _ -> 429
-  | _ -> 500
+  | CacheError _ -> 500
 
 (* [is_retryable] mirrors [Error.is_retryable] in OAS so MASC-side
    callers don't have to fall back on an OAS-only predicate when


### PR DESCRIPTION
## 목적

RFC-0071 §3.4 Phase 5 ratchet (#14888 … #14945 후속).

## 변경

### lib/types — 1 fragile site (nested)
`masc_error.ml` `code : t -> int` (HTTP status mapper). per-family `_` defaults 가 nested concrete `Foo_error.t` 타입의 새 sub-ctor 를 silent 흡수 → warning 4. 모든 sub-ctor 명시:

| Family | ctors | code |
|--------|-------|------|
| `Auth_error.t` | Forbidden | 403 |
| | Unauthorized \| TokenExpired \| InvalidToken | 401 |
| `Task_error.t` | NotFound | 404 |
| | AlreadyClaimed \| NotClaimed \| InvalidState \| InvalidId | 400 |
| `Agent_error.t` | NotFound | 404 |
| | NotJoined \| AlreadyJoined \| InvalidName | 400 |
| `Portal_error.t` | NotOpen \| AlreadyOpen \| Closed | 400 |
| `System_error.t` | 8 ctors | 400 |
| top-level | RateLimitExceeded | 429 |
| | CacheError | 500 |

Behavior-preserving — 동일 status code, `_` arm 만 제거. 새 error ctor 추가 시 HTTP status 결정을 컴파일러가 강제.

## 검증

- \`dune build --root .\` clean (전체)

## 누적

| | `-w +4` sublibs |
|--|--|
| #14888 … #14945 | 30 |
| **본 PR** | **+1 (types, +1 fix)** |
| **누계** | **31** |

## Deferred

- `lib/autoresearch` (~5 sites: autoresearch_metric, autoresearch_git)
- `lib/multimodal` (10), `lib/cascade_decl` (12), `lib/coord` (35), `lib/cdal_runtime` (34), `lib/cdal` (7), `lib/activity_graph` (7), `lib/resilience` (8), `lib/mcp_transport_protocol` (7)
- `lib/repo_manager` (8) — RFC-required subsystem, needs RFC
- `lib` (main, ~1659) — codemod (RFC-0071 Phase 2)