### PR TITLE
feat(keeper): RFC-0070 Phase 3e (c) — Docker_client.S.info_security_options

### DIFF
--- a/lib/keeper/docker_client.ml
+++ b/lib/keeper/docker_client.ml
@@ -26,4 +26,6 @@ module type S = sig
     -> (Docker_response.ps_record list, sandbox_error) result
 
   val rm : Keeper_container_name.t -> (unit, sandbox_error) result
+
+  val info_security_options : unit -> (string list, sandbox_error) result
 end

--- a/lib/keeper/docker_client.mli
+++ b/lib/keeper/docker_client.mli
@@ -70,4 +70,17 @@ module type S = sig
     -> (Docker_response.ps_record list, sandbox_error) result
 
   val rm : Keeper_container_name.t -> (unit, sandbox_error) result
+
+  val info_security_options : unit -> (string list, sandbox_error) result
+  (** [info_security_options ()] = the docker daemon's [SecurityOptions]
+      list (from [docker info --format '\{\{json .SecurityOptions\}\}']),
+      lowercased so callers can match tokens like ["seccomp"] /
+      ["apparmor"] / ["no-new-privileges"] case-insensitively.
+
+      [Ok []] when the daemon reports none ([null] / empty array).
+      A daemon-level failure (not running, permission denied, CLI
+      missing) ⇒ [Error Daemon_unreachable]. A payload that is neither
+      a JSON array nor [null], or that fails to parse — i.e. a docker
+      output-format change — ⇒ [Error Probe_format_drift] rather than
+      a silent [Ok []]. *)
 end

--- a/lib/keeper/docker_client_mock.ml
+++ b/lib/keeper/docker_client_mock.ml
@@ -28,6 +28,12 @@ let rm_queue
   : (Keeper_container_name.t * (unit, Docker_client.sandbox_error) result) Queue.t
   = Queue.create ()
 
+(* [info_security_options] takes no input, so the queue holds bare
+   responses (no input key to match on) — strict FIFO consume. *)
+let info_security_options_queue
+  : (string list, Docker_client.sandbox_error) result Queue.t
+  = Queue.create ()
+
 (* ── Injection API ──────────────────────────────────────────── *)
 
 let inject_run plan response = Queue.add (plan, response) run_queue
@@ -41,6 +47,10 @@ let inject_ps_query ~labels response =
 ;;
 
 let inject_rm container response = Queue.add (container, response) rm_queue
+
+let inject_info_security_options response =
+  Queue.add response info_security_options_queue
+;;
 
 (* ── Docker_client.S implementation ─────────────────────────── *)
 
@@ -93,16 +103,27 @@ let rm container =
     response
   | _ -> Error Docker_client.Daemon_unreachable
 
+let info_security_options () =
+  (* No input key — just consume the head. An empty queue fails closed
+     with [Daemon_unreachable], same as an unexpected/out-of-order call
+     on the keyed queues. *)
+  match Queue.take_opt info_security_options_queue with
+  | Some response -> response
+  | None -> Error Docker_client.Daemon_unreachable
+;;
+
 (* ── Fixture lifecycle ──────────────────────────────────────── *)
 
 let reset () =
   Queue.clear run_queue;
   Queue.clear exec_queue;
   Queue.clear ps_query_queue;
-  Queue.clear rm_queue
+  Queue.clear rm_queue;
+  Queue.clear info_security_options_queue
 
 let pending_calls () =
   Queue.length run_queue
   + Queue.length exec_queue
   + Queue.length ps_query_queue
   + Queue.length rm_queue
+  + Queue.length info_security_options_queue

--- a/lib/keeper/docker_client_mock.mli
+++ b/lib/keeper/docker_client_mock.mli
@@ -49,6 +49,14 @@ val inject_rm
   -> (unit, Docker_client.sandbox_error) result
   -> unit
 
+(** [inject_info_security_options response] enqueues [response] to be
+    returned by the next {!info_security_options} call (no input key —
+    it takes [unit]). Strict FIFO, fail-closed: an empty queue returns
+    [Error Daemon_unreachable]. *)
+val inject_info_security_options
+  :  (string list, Docker_client.sandbox_error) result
+  -> unit
+
 (** {1 Fixture lifecycle} *)
 
 (** [reset ()] empties every injection queue. Call between tests so

--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -106,3 +106,38 @@ let rm container =
   let status, _stdout = Process_eio.run_argv_with_status argv in
   map_exit_status_for_rm status
 ;;
+
+(* Pure: parses the stdout of [docker info --format
+   '{{json .SecurityOptions}}'] — a JSON array of strings (or [null] /
+   [] when the daemon reports none). Items are lowercased so callers
+   can match case-insensitively against tokens like ["seccomp"] /
+   ["apparmor"] / ["no-new-privileges"]. Non-string array elements are
+   dropped (they cannot be a security option). Anything that is
+   neither a JSON array nor [null], or that fails to parse, is
+   [Probe_format_drift] — a docker-version output change must surface,
+   not be silently treated as "no options". *)
+let parse_security_options (raw : string)
+  : (string list, Docker_client.sandbox_error) result
+  =
+  match Yojson.Safe.from_string (String.trim raw) with
+  | `List items ->
+    Ok
+      (List.filter_map (function `String s -> Some s | _ -> None) items
+       |> List.map String.lowercase_ascii)
+  | `Null -> Ok []
+  | _ -> Error Docker_client.Probe_format_drift
+  | exception Yojson.Json_error _ -> Error Docker_client.Probe_format_drift
+;;
+
+let info_security_options () =
+  let argv = [ "docker"; "info"; "--format"; "{{json .SecurityOptions}}" ] in
+  match Process_eio.run_argv_with_status_split argv with
+  | Unix.WEXITED 0, out, _ -> parse_security_options out
+  | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _, _ ->
+    (* Any non-zero exit means the daemon could not answer (not
+       running, permission denied, CLI missing → synthesized
+       WEXITED 127). The probe itself is a preflight, not a
+       container command, so there is no in-container exit code to
+       surface as [Ok]. *)
+    Error Docker_client.Daemon_unreachable
+;;

--- a/lib/keeper/docker_client_real.mli
+++ b/lib/keeper/docker_client_real.mli
@@ -71,3 +71,13 @@ val exec_argv
   -> cmd:string
   -> unit
   -> string list
+
+(** [parse_security_options raw] is the pure parser behind
+    {!info_security_options}: it interprets the stdout of
+    [docker info --format '\{\{json .SecurityOptions\}\}'] — a JSON
+    array of strings (or [null] / [] for none), lowercased; non-string
+    elements dropped; anything else ⇒ [Probe_format_drift]. Exposed
+    so the parse is unit-testable without a daemon. *)
+val parse_security_options
+  :  string
+  -> (string list, Docker_client.sandbox_error) result

--- a/test/test_docker_client_mock.ml
+++ b/test/test_docker_client_mock.ml
@@ -178,6 +178,29 @@ let test_rm_error_injection () =
   | Error Docker_client.Cleanup_failed -> ()
   | _ -> fail "expected Cleanup_failed"
 
+(* ── info_security_options (Phase 3e c) ───────────────────────── *)
+
+let test_info_security_options_matches () =
+  setup ();
+  Docker_client_mock.inject_info_security_options (Ok [ "name=seccomp"; "name=apparmor" ]);
+  match Docker_client_mock.info_security_options () with
+  | Ok opts -> check int "2 options + queue drained" 2 (List.length opts);
+    check int "queue drained" 0 (Docker_client_mock.pending_calls ())
+  | Error _ -> fail "expected Ok"
+
+let test_info_security_options_empty_queue () =
+  setup ();
+  match Docker_client_mock.info_security_options () with
+  | Error Docker_client.Daemon_unreachable -> ()
+  | _ -> fail "empty queue must fail closed with Daemon_unreachable"
+
+let test_info_security_options_error_injection () =
+  setup ();
+  Docker_client_mock.inject_info_security_options (Error Docker_client.Probe_format_drift);
+  match Docker_client_mock.info_security_options () with
+  | Error Docker_client.Probe_format_drift -> ()
+  | _ -> fail "expected Probe_format_drift"
+
 (* ── reset / pending_calls ────────────────────────────────────── *)
 
 let test_reset_clears_all_queues () =
@@ -187,7 +210,8 @@ let test_reset_clears_all_queues () =
   Docker_client_mock.inject_exec ~container:c ~cmd:"x" (Ok sample_exec_result);
   Docker_client_mock.inject_ps_query ~labels:[] (Ok []);
   Docker_client_mock.inject_rm c (Ok ());
-  check int "4 queued" 4 (Docker_client_mock.pending_calls ());
+  Docker_client_mock.inject_info_security_options (Ok []);
+  check int "5 queued" 5 (Docker_client_mock.pending_calls ());
   Docker_client_mock.reset ();
   check int "reset clears everything" 0 (Docker_client_mock.pending_calls ())
 
@@ -220,6 +244,14 @@ let () =
         [
           test_case "matches Ok" `Quick test_rm_matches;
           test_case "Error injection round-trip" `Quick test_rm_error_injection;
+        ] );
+      ( "info_security_options",
+        [
+          test_case "matches injection" `Quick test_info_security_options_matches;
+          test_case "empty queue → Daemon_unreachable" `Quick
+            test_info_security_options_empty_queue;
+          test_case "Error injection round-trip" `Quick
+            test_info_security_options_error_injection;
         ] );
       ( "lifecycle",
         [ test_case "reset clears all queues" `Quick test_reset_clears_all_queues ] );

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -170,6 +170,98 @@ let test_rm_returns_typed_error () =
     fail "rm should only surface Daemon_unreachable or Cleanup_failed"
 ;;
 
+(* Phase 3e (c) — [parse_security_options] is the pure parser behind
+   [info_security_options]. Deterministic (no daemon): assert array
+   handling, lowercasing, non-string drop, and that a format drift
+   surfaces as [Probe_format_drift] rather than [Ok []]. *)
+let security_options_result : (string list, Docker_client.sandbox_error) result testable =
+  let pp ppf = function
+    | Ok xs -> Format.fprintf ppf "Ok [%s]" (String.concat "; " xs)
+    | Error e -> Format.fprintf ppf "Error %s" (match e with
+        | Docker_client.Daemon_unreachable -> "Daemon_unreachable"
+        | Docker_client.Image_pull_failed -> "Image_pull_failed"
+        | Docker_client.Container_oom -> "Container_oom"
+        | Docker_client.Exec_timeout -> "Exec_timeout"
+        | Docker_client.Probe_format_drift -> "Probe_format_drift"
+        | Docker_client.Cleanup_failed -> "Cleanup_failed")
+  in
+  testable pp ( = )
+;;
+
+let test_parse_security_options_array () =
+  check
+    security_options_result
+    "array of strings, preserved order"
+    (Ok [ "name=seccomp,profile=builtin"; "name=cgroupns" ])
+    (Docker_client_real.parse_security_options
+       {|["name=seccomp,profile=builtin","name=cgroupns"]|})
+;;
+
+let test_parse_security_options_lowercases () =
+  check
+    security_options_result
+    "items lowercased"
+    (Ok [ "name=apparmor" ])
+    (Docker_client_real.parse_security_options {|["name=AppArmor"]|})
+;;
+
+let test_parse_security_options_null () =
+  check
+    security_options_result
+    "null → Ok []"
+    (Ok [])
+    (Docker_client_real.parse_security_options "null")
+;;
+
+let test_parse_security_options_empty_array () =
+  check
+    security_options_result
+    "[] → Ok []"
+    (Ok [])
+    (Docker_client_real.parse_security_options "[]")
+;;
+
+let test_parse_security_options_drops_non_strings () =
+  check
+    security_options_result
+    "non-string elements dropped"
+    (Ok [ "name=seccomp" ])
+    (Docker_client_real.parse_security_options {|["name=seccomp", 1, true, null]|})
+;;
+
+let test_parse_security_options_bad_json () =
+  check
+    security_options_result
+    "malformed JSON → Probe_format_drift (not silent Ok [])"
+    (Error Docker_client.Probe_format_drift)
+    (Docker_client_real.parse_security_options "not valid json {")
+;;
+
+let test_parse_security_options_object () =
+  check
+    security_options_result
+    "JSON object (not array/null) → Probe_format_drift"
+    (Error Docker_client.Probe_format_drift)
+    (Docker_client_real.parse_security_options {|{"x":1}|})
+;;
+
+(* The edge call: env may or may not have a docker daemon, so only
+   the typed contract is asserted. *)
+let test_info_security_options_returns_typed () =
+  match Docker_client_real.info_security_options () with
+  | Ok _ -> () (* daemon present *)
+  | Error Docker_client.Daemon_unreachable -> () (* no daemon / CLI missing *)
+  | Error Docker_client.Probe_format_drift ->
+    () (* daemon present but unexpected SecurityOptions payload *)
+  | Error Docker_client.Cleanup_failed
+  | Error Docker_client.Image_pull_failed
+  | Error Docker_client.Container_oom
+  | Error Docker_client.Exec_timeout ->
+    fail
+      "info_security_options should only surface Ok | Daemon_unreachable | \
+       Probe_format_drift"
+;;
+
 (* ── Functor instantiation works with Real ───────────────────── *)
 
 (* Phase 3b-iv.2.3 — executor.execute_plan calls Real.run, which is
@@ -212,6 +304,28 @@ let () =
             "user + workdir (--user before -w)"
             `Quick
             test_exec_argv_user_and_workdir
+        ] )
+    ; ( "parse_security_options (pure, Phase 3e c)"
+      , [ test_case "array of strings" `Quick test_parse_security_options_array
+        ; test_case "lowercases items" `Quick test_parse_security_options_lowercases
+        ; test_case "null → Ok []" `Quick test_parse_security_options_null
+        ; test_case "[] → Ok []" `Quick test_parse_security_options_empty_array
+        ; test_case
+            "drops non-string elements"
+            `Quick
+            test_parse_security_options_drops_non_strings
+        ; test_case
+            "malformed JSON → Probe_format_drift"
+            `Quick
+            test_parse_security_options_bad_json
+        ; test_case
+            "object (not array/null) → Probe_format_drift"
+            `Quick
+            test_parse_security_options_object
+        ; test_case
+            "info_security_options → Ok | Daemon_unreachable | Probe_format_drift"
+            `Quick
+            test_info_security_options_returns_typed
         ] )
     ; ( "Functor composition"
       , [ test_case


### PR DESCRIPTION
## Summary

RFC-0070 §3.0.3 + §4 Phase 3e item (c): `Docker_client.S` gains `info_security_options : unit -> (string list, sandbox_error) result`. `keeper_sandbox_runtime.docker_info_security_options` (the Phase 4 cutover target) runs `docker info --format '{{json .SecurityOptions}}'`, parses the JSON, and lowercases — all inlined in one keeper function. This adds the typed `Docker_client.S` member so the keeper can later delegate, and so the parse is mockable + the deterministic part is unit-tested apart from the daemon call.

## What changed

| File | Change |
|------|--------|
| `docker_client.{ml,mli}` | `S` gains `info_security_options : unit -> (string list, sandbox_error) result`. `Ok []` when the daemon reports none (`null` / `[]`); daemon-level failure ⇒ `Error Daemon_unreachable`; a payload neither a JSON array nor `null`, or unparseable — a docker output-format change — ⇒ `Error Probe_format_drift` (not a silent `Ok []`). |
| `docker_client_real.ml` | new pure `parse_security_options : string -> (string list, sandbox_error) result` — interprets the `{{json .SecurityOptions}}` stdout: array of strings → lowercased (so callers match `"seccomp"`/`"apparmor"`/`"no-new-privileges"` case-insensitively); non-string elements dropped (`function `String s -> Some s | _ -> None` — `Yojson.Safe.Util.to_string_option` *raises* `Type_error` on a non-string, it does not return `None`, so a manual match is required); `null`/`[]` → `Ok []`; anything else / parse error → `Probe_format_drift`. `info_security_options ()` spawns `docker info`, delegates to the parser on `WEXITED 0`, else `Daemon_unreachable`. |
| `docker_client_real.mli` | exposes `parse_security_options` for tests |
| `docker_client_mock.ml` / `.mli` | new `info_security_options_queue` (bare responses — no input key), strict-FIFO consume (`Queue.take_opt`; empty queue ⇒ `Daemon_unreachable`), `inject_info_security_options`, wired into `reset` / `pending_calls` |
| `test_docker_client_real.ml` | +8 cases — 7 pure `parse_security_options` (array / lowercasing / `null` / `[]` / non-string drop / malformed JSON / object → `Probe_format_drift`) + 1 typed-contract on the edge call. 9→17 tests. |
| `test_docker_client_mock.ml` | +3 cases — match / empty-queue fail-closed / Error round-trip. 11→14 tests. |

## Verification

```
$ dune build --root . test/test_docker_client_real.exe test/test_docker_client_mock.exe   # exit 0
$ _build/default/test/test_docker_client_real.exe   # Test Successful in 0.909s. 17 tests run.
$ _build/default/test/test_docker_client_mock.exe   # Test Successful in 0.001s. 14 tests run.
```

(First local run caught the `to_string_option`-raises-on-non-string bug; fixed before commit.)

## Scope notes

- Self-contained — `info_security_options` does not expose a new layer, so shipping it ahead of the rest of Phase 3e is safe fragmentation (not the dune-cascade pattern memory warns about).
- RFC §3.0.3 also proposed `image_inspect : image:string -> (image_info, sandbox_error) result`, but the shipped `keeper_sandbox_runtime.docker_image_present` only does a *presence check* (`(unit, _) result`) — nothing consumes inspect data, so Phase 3e (d) should be `image_present`, not a full `image_inspect` + `image_info` type (over-specced). Suggest narrowing RFC §3.0.3 in a doc follow-up.

## RFC reference

RFC-0070 §3.0.3 ("preflight pattern — 4th capability: `docker info --format`, `docker image inspect`") + §4 Phase 3e item (c). RFC-0070 *extends* RFC-0006 (no keeper sandbox containment-policy change) and *depends on* RFC-0036 (no cleanup-hook surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
