### PR TITLE
docs(tla-audit): KRD R-2 — verify KeeperRolloverDecision.tla ↔ keeper_rollover.ml + 2 doc nits

### DIFF
--- a/docs/tla-audit/krd-r2-rollover-decision-spec-ocaml-verified-2026-05-12.md
+++ b/docs/tla-audit/krd-r2-rollover-decision-spec-ocaml-verified-2026-05-12.md
@@ -1,0 +1,57 @@
+# KRD R-2 — KeeperRolloverDecision.tla ↔ OCaml: mapping verified, one scope gap + one missing reverse-citation (first-entry audit)
+
+**Date**: 2026-05-12 · **Iteration**: 75 (`/loop` FSM/TLA+/OCaml drift hunt) · **Phase**: R (first entry)
+**Spec**: `specs/keeper-state-machine/KeeperRolloverDecision.tla` (165 LOC, 7 vars, bug-model paired)
+**OCaml**: `lib/keeper/keeper_rollover.ml` (349 LOC) · `lib/keeper/keeper_rollover.mli` (78 LOC)
+**Verdict**: **clean** — the spec's `OCaml ↔ TLA+ mapping` table is accurate, the decision CASE matches `classify_rollover_gate` arm-for-arm, the provider-opacity property is enforced by a purely-typed predicate (zero substring matches in the file), and both `.cfg` / `-buggy.cfg` exist. Two doc/model-completeness nits, both fixed in this PR:
+
+1. **Scope gap** — the OCaml `signal_gate` is a *disjunction of two* overflow signals; the spec models only one (the historical `last_blocker_info`+`Proactive_error` path). Fixed by adding a "Spec scope" note to the spec preamble (R-2.a — 16th honest-doc datapoint: comment-only, TLC not re-run).
+2. **One-directional cross-ref** — the spec cites `keeper_rollover.ml:classify_rollover_gate`, but `keeper_rollover.ml`'s "Spec navigation" block cites only `KeeperGenerationLineage.tla` (a different aspect of the same module); code search for `KeeperRolloverDecision` lands nowhere in `lib/`. Fixed by extending the `classify_rollover_gate` doc comment with a reverse-citation.
+
+## Cross-checks (all pass)
+
+| Spec element | OCaml | Status |
+|---|---|---|
+| `autoHandoff` / `cooldownElapsed` (BOOLEAN) | `classify_rollover_gate ~auto_handoff ~cooldown_elapsed` | ✓ exact named args |
+| `ratioGate` (BOOLEAN) | `let ratio_gate = ratio >= handoff_threshold` | ✓ — spec's "ratio >= handoff_threshold" semantic note matches |
+| `lastOutcome` ∈ {`proactive_error`,`proactive_silent`,`proactive_text`} | `last_outcome : proactive_cycle_outcome` (`Proactive_text_response \| Proactive_silent \| Proactive_error` — 3 inhabited; the runtime type also carries `Proactive_text_*` variants the spec folds into `proactive_text`) | ✓ — abstract symbol set, no provider semantics |
+| `lastBlockerClass` ∈ `BlockerClasses ∪ {"none"}` (abstract `"overflow"` / `"non_overflow"`) | `last_blocker_info : blocker_info option` → `blocker_class_indicates_overflow klass` | ✓ — spec deliberately models the typed class as opaque symbols to enforce opacity at the model-checking level |
+| `SignalFires(o,k) == o = "proactive_error" /\ k = "overflow"` | `last_outcome = Proactive_error && info_indicates_overflow last_blocker_info` | ✓ for the modelled disjunct (see scope gap below) |
+| `ComputeDecision`: `~ah→skip_disabled`; `~ce→skip_cooldown`; `rg/\sig→go_both`; `rg/\~sig→go_ratio`; `~rg/\sig→go_signal`; OTHER→`skip_below` | `if not auto_handoff then Skip "auto_handoff_disabled" else if not cooldown_elapsed then Skip "cooldown" else match ratio_gate, signal_gate with \| true,true -> Go "ratio+signal" \| false,true -> Go "persistent_overflow_blocker" \| true,false -> Go "ratio" \| false,false -> Skip "below_thresholds"` | ✓ — arm-for-arm; spec's `decision` symbols ↔ OCaml's `Skip`/`Go` reason strings (semantic, not literal — mapping table line 13 says `Skip(reason) \| Go(reason)`) |
+| `blocker_class_indicates_overflow` is **purely typed** — "substring matching at this layer is forbidden" (preamble §Architectural invariant) | `let blocker_class_indicates_overflow (klass : blocker_class) : bool = match klass with \| Sdk_token_budget_exceeded -> true \| ... -> false` — exhaustive variant match, no `String.starts_with` / `contains` / `is_substring` / `"overflow"` literal anywhere in the file (`rg` → 0 matches) | ✓ — the SDK boundary (`Keeper_status_bridge`) is the sole wire→typed adapter, exactly as the preamble asserts |
+| `SignalGateOverflowOnly` invariant (signal half fires only on `"overflow"`) | holds for **both** OCaml disjuncts — they call the same `info_indicates_overflow` ⇒ `blocker_class_indicates_overflow`; no class-specific bypass | ✓ — invariant is a faithful model of the architectural property even though it only names one disjunct |
+| `SpecBuggy` / `ComputeDecisionBuggy` (signal fires on `outcome="proactive_error" /\ klass /= "none"` — any non-none class, mirroring the historical substring drift) | not present in OCaml — the runtime gate is class-typed, never "any non-empty class" | ✓ — runtime does not exhibit the modelled bug |
+| `.cfg` / `-buggy.cfg` | `KeeperRolloverDecision.cfg` + `KeeperRolloverDecision-buggy.cfg` both present | ✓ |
+
+## The scope gap (LOW — model completeness, not a safety hole)
+
+`classify_rollover_gate` (lines 137-162) computes:
+
+```ocaml
+let current_turn_signal = info_indicates_overflow current_turn_blocker_info in
+let signal_gate =
+  current_turn_signal
+  || (last_outcome = Proactive_error && info_indicates_overflow last_blocker_info)
+in
+```
+
+That is **two** overflow signals OR'd together:
+
+- **(a)** `?current_turn_blocker_info` — the *in-flight* turn's blocker. Fires regardless of `last_outcome`. Optional named arg, defaults to `None`.
+- **(b)** `last_blocker_info` — the *previous* turn's blocker, gated on `last_outcome = Proactive_error`.
+
+`KeeperRolloverDecision.tla` models only **(b)**: `SignalFires(outcome, klass) == outcome = "proactive_error" /\ klass = "overflow"`, and the `Next` action picks fresh `(lastOutcome, lastBlockerClass)` only — there is no `currentTurnBlockerClass` variable, and the `OCaml ↔ TLA+ mapping` table doesn't mention `current_turn_blocker_info`.
+
+**Why this is benign**: both disjuncts route through the *same* typed predicate `blocker_class_indicates_overflow` over the *same* `blocker_class` set. There is no class-specific behaviour on path (a) that (b) lacks. So `SignalGateOverflowOnly` — "the signal half fires only when the class is `overflow`" — is true of the real runtime even though the spec only names one of the two ways the signal half can fire. The spec is a *partial but sound* model: it under-approximates the trigger conditions, never over-approximates the safety guarantee.
+
+**Fix-PR (DONE — this PR, R-2.a)**: added to the spec preamble (after the mapping table) a "Spec scope" note documenting the two-disjunct shape and stating the invariant covers (a) by construction; flagged that if (a) ever grows class-specific behaviour it must be added as a second `SignalFires` disjunct. Comment-only — TLC not re-run (16th honest-doc datapoint; same handling as iters 64/67/69 honest-doc spec edits).
+
+## The missing reverse-citation (LOW — navigability)
+
+The spec preamble cites the OCaml three times (`classify_rollover_gate`, `blocker_class_indicates_overflow`, `rollover_gate_decision`). The OCaml file *does* have a "Spec navigation (OCaml -> TLA+)" block — but it points at `KeeperGenerationLineage.tla` (the *handoff-lineage* aspect of `keeper_rollover.ml`), not at `KeeperRolloverDecision.tla` (the *gate-decision* aspect). So a `grep KeeperRolloverDecision lib/` returns nothing — the reverse leg of the bidirectional cross-ref is absent.
+
+**Fix-PR (DONE — this PR)**: extended the `classify_rollover_gate` doc comment with a localized reverse-citation (`Spec mirror: [specs/keeper-state-machine/KeeperRolloverDecision.tla] models this gate; SignalGateOverflowOnly is the safety invariant; ...; reverse-citation so code search for "KeeperRolloverDecision" lands here.`). Localized rather than in the file header because the gate-decision concern is distinct from the lineage concern the header block already covers.
+
+## Sub-class placement
+
+This is **first-entry sub-class 1 (coverage gap)** in the mild form — the spec is sound and the cross-checks pass, the "gap" is that the spec's `Next` action under-models the OCaml's two-source signal disjunction. It is *not* sub-class 2 (drift — nothing has drifted), not 3 (cross-spec staleness), not 9 (spec-banner-lags-runtime — the banner here is accurate for what it models). Both fixes are doc-only; no behaviour, no TLC re-run, no new test (the architectural invariant is already exercised by the spec's own `SpecBuggy` / `SignalGateOverflowOnly` pair, which TLC checks in CI).

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -133,7 +133,18 @@ let append_lineage_artifacts_best_effort
     the *actual* LLM response for the last turn: when a proactive turn errored
     with an overflow-class blocker, rollover is triggered regardless of the
     checkpoint ratio — the ratio gate structurally cannot fire once compaction
-    shrinks the checkpoint below the threshold (umbrella #7036). *)
+    shrinks the checkpoint below the threshold (umbrella #7036).
+
+    Spec mirror: [specs/keeper-state-machine/KeeperRolloverDecision.tla] models
+    this gate (vars autoHandoff / cooldownElapsed / ratioGate / lastOutcome /
+    blockerClass / decision); [SignalGateOverflowOnly] is the safety invariant
+    that the signal half fires only on an overflow-class blocker, and the
+    bug-model cfg checks that the historical "any non-empty class" substring
+    drift would violate it.  The spec models the [last_blocker_info] +
+    [Proactive_error] disjunct only; the [?current_turn_blocker_info] disjunct
+    uses the same typed [blocker_class_indicates_overflow] predicate so it is
+    covered by construction.  Reverse-citation so code search for
+    "KeeperRolloverDecision" lands here. *)
 let classify_rollover_gate
     ~(auto_handoff : bool) ~(cooldown_elapsed : bool)
     ~(ratio : float) ~(handoff_threshold : float)

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-12T03:07:45Z (HEAD: 44dbd4d08)
+Generated: 2026-05-12T04:03:57Z (HEAD: 27dd7b230)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -141,7 +141,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperPostTurnOrchestration.tla | KeeperPostTurnOrchestration | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 0c26d77292b4 |
 | KeeperReactionLiveness.tla | KeeperReactionLiveness | manual | 2 | 1 | clean={inv:Safety, prop:BoardEnqueueLeadsToReceipt, prop:VerificationLeadsToReaction, prop:GoalVerificationLeadsToResolution, prop:TaskTransitionLeadsToReceipt, prop:CursorAdvancementRequiresAck} buggy={inv:TypeOK, prop:BoardEnqueueLeadsToReceipt} | 353fe806cd4a |
 | KeeperReconcileLiveness.tla | KeeperReconcileLiveness | manual | 2 | 1 | clean={inv:TypeOK, prop:RunningClearsManualReconcile, prop:DeadIsForever, prop:StoppedIsForever, prop:RunningRequiresFiber, prop:ManualReconcileLiveness, prop:FailingRecoveryLiveness, prop:CompactingResolves, prop:HandoffResolves, prop:DrainingResolves} buggy={inv:TypeOK, prop:RunningClearsManualReconcile, prop:DeadIsForever, prop:StoppedIsForever, prop:RunningRequiresFiber, prop:ManualReconcileLiveness, prop:FailingRecoveryLiveness} | 62638a411215 |
-| KeeperRolloverDecision.tla | KeeperRolloverDecision | manual | 2 | 1 | clean={inv:SignalGateOverflowOnly} buggy={inv:SignalGateOverflowOnly} | 71d1c2f76746 |
+| KeeperRolloverDecision.tla | KeeperRolloverDecision | manual | 2 | 1 | clean={inv:SignalGateOverflowOnly} buggy={inv:SignalGateOverflowOnly} | eb2aa357aa35 |
 | KeeperSocialModelMagenticLedger.tla | KeeperSocialModelMagenticLedger | manual | 2 | 1 | clean={inv:TypeOK, inv:ClassifyTypeOK, inv:StalledNeedsGoalOrFailure, prop:ProgressDominates, prop:ReactiveDominatesIdleTimeout, prop:StalledStickyWithGoal, prop:QuietWhenNoDrivers} buggy={inv:StalledNeedsGoalOrFailureMustHold} | 4adca73b6508 |
 | KeeperStateMachine.tla | KeeperStateMachine | manual | 3 | 2 | clean={inv:TypeOK, prop:DeadIsForever, prop:StoppedIsForever, prop:ZombieIsForever, prop:BudgetNeverRevives, prop:RestartCountMonotonic, prop:RunningRequiresFiber, prop:StoppedRequiresDrain, prop:DeadRequiresNoBudget, prop:OfflineRequiresLaunchPending, prop:ZombieRequiresTerminalFailureLatched, prop:FailingResolves, prop:CrashedRestartsEventually, prop:DrainingResolves, prop:CompactingResolves, prop:HandoffResolves, prop:CompactionClearsOverflow, prop:OverflowedResolves} buggy={inv:TypeOK} overflow-buggy={inv:TypeOK} | 9d267456e58b |
 | KeeperTaskAcquisition.tla | KeeperTaskAcquisition | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | e7143072d90f |

--- a/specs/keeper-state-machine/KeeperRolloverDecision.tla
+++ b/specs/keeper-state-machine/KeeperRolloverDecision.tla
@@ -12,6 +12,18 @@
 \*   blockerClass     | lib/keeper/keeper_rollover.ml:blocker_class_indicates_overflow | typed Keeper_types.blocker_class
 \*   decision         | lib/keeper/keeper_rollover.ml:rollover_gate_decision    | Skip(reason) | Go(reason)
 \*
+\* Spec scope (2026-05-12, iter 75 R-2.a — see docs/tla-audit/krd-r2-rollover-decision-spec-ocaml-verified-2026-05-12.md):
+\*   The OCaml signal gate is a disjunction of TWO overflow signals:
+\*     (a) ?current_turn_blocker_info — the in-flight turn's blocker (fires
+\*         regardless of last_outcome), and
+\*     (b) last_blocker_info gated on last_outcome = Proactive_error.
+\*   This spec models only (b) via SignalFires.  (a) is intentionally omitted:
+\*   it exercises the same typed predicate blocker_class_indicates_overflow on
+\*   the same blocker_class set, so SignalGateOverflowOnly already covers it by
+\*   construction (the spec under-approximates the trigger conditions, never
+\*   over-approximates the safety guarantee).  If (a) ever grows class-specific
+\*   behaviour, add it here as a second SignalFires disjunct + a Next variable.
+\*
 \* Architectural invariant:
 \*   OAS/MASC treat provider/model as opaque aliases.  The keeper layer
 \*   reasons only over typed blocker_class — substring matching at this


### PR DESCRIPTION
## Finding (Iteration 75, Phase R — first spec entry)

**Spec**: `specs/keeper-state-machine/KeeperRolloverDecision.tla` (165 LOC, 7 vars, bug-model paired)
**OCaml**: `lib/keeper/keeper_rollover.ml` (349 LOC) · `lib/keeper/keeper_rollover.mli` (78 LOC)
**Aspect**: provider-opaque, typed-class-driven rollover gate decision (`classify_rollover_gate`)
**Verdict**: **clean** — first-entry audit, mapping verified; two doc/model-completeness nits fixed
**Risk**: LOW (doc-only — no behaviour change, no TLC re-run; 16th honest-doc datapoint)
**Workaround signature**: N/A — this PR *documents an existing sound model* and adds a missing cross-reference; no string classifier / catch-all / cap added

## 순서도

```mermaid
stateDiagram-v2
  [*] --> EvalGate : classify_rollover_gate (~auto_handoff, ~cooldown_elapsed,\n~ratio, ~handoff_threshold, ~last_outcome,\n~last_blocker_info, ?current_turn_blocker_info)
  EvalGate --> SkipDisabled : not auto_handoff
  EvalGate --> SkipCooldown : auto_handoff /\ not cooldown_elapsed
  EvalGate --> ComputeRG : auto_handoff /\ cooldown_elapsed

  state ComputeRG {
    [*] --> ratio_gate : ratio >= handoff_threshold ?
    [*] --> signal_gate : (a) current_turn_blocker overflow?\n  OR (b) last_outcome=Proactive_error /\ last_blocker overflow?
  }

  ComputeRG --> GoBoth      : ratio_gate /\ signal_gate          → Go "ratio+signal"
  ComputeRG --> GoSignal    : ~ratio_gate /\ signal_gate         → Go "persistent_overflow_blocker"
  ComputeRG --> GoRatio     : ratio_gate /\ ~signal_gate         → Go "ratio"
  ComputeRG --> SkipBelow   : ~ratio_gate /\ ~signal_gate        → Skip "below_thresholds"

  SkipDisabled --> [*]
  SkipCooldown --> [*]
  GoBoth --> [*]
  GoSignal --> [*]
  GoRatio --> [*]
  SkipBelow --> [*]

  note right of ComputeRG
    Spec models disjunct (b) only via SignalFires(o,k) == o="proactive_error" /\ k="overflow".
    Disjunct (a) uses the same typed predicate blocker_class_indicates_overflow ⇒
    SignalGateOverflowOnly covers it by construction. R-2.a documents this in the preamble.
    Bug model: ComputeDecisionBuggy fires signal on k /= "none" (any class) → invariant violated.
  end note
```

## Cross-checks (all pass)

| Spec element | OCaml | Status |
|---|---|---|
| `autoHandoff` / `cooldownElapsed` | `~auto_handoff` / `~cooldown_elapsed` named args | ✓ |
| `ratioGate` | `let ratio_gate = ratio >= handoff_threshold` | ✓ |
| `lastOutcome` ∈ {`proactive_error`,`proactive_silent`,`proactive_text`} | `last_outcome : proactive_cycle_outcome` (`Proactive_text_response \| Proactive_silent \| Proactive_error`) | ✓ — abstract symbols, no provider semantics |
| `lastBlockerClass` ∈ `BlockerClasses ∪ {"none"}` (abstract `"overflow"`/`"non_overflow"`) | `last_blocker_info option` → `blocker_class_indicates_overflow` | ✓ — typed class modelled as opaque symbols by design |
| `ComputeDecision` CASE (6 arms incl. `~ah`/`~ce` guards) | `if not auto_handoff … else if not cooldown_elapsed … else match ratio_gate, signal_gate with …` | ✓ — arm-for-arm |
| "substring matching at this layer is forbidden" | `blocker_class_indicates_overflow` = exhaustive variant match; `rg 'String.starts_with\|is_substring\|is_prefix\|contains.*overflow\|"overflow"' keeper_rollover.ml` → 0 matches | ✓ |
| `SignalGateOverflowOnly` invariant | holds for **both** OCaml disjuncts (same `info_indicates_overflow` ⇒ `blocker_class_indicates_overflow`) | ✓ — faithful model of the architectural property |
| `SpecBuggy` / `ComputeDecisionBuggy` (signal on any non-`"none"` class) | not present in OCaml | ✓ — runtime doesn't exhibit the modelled bug |
| `.cfg` / `-buggy.cfg` | both present | ✓ |

## Before / After

**Spec preamble** — added after the `OCaml ↔ TLA+ mapping` table:
```diff
+\* Spec scope (2026-05-12, iter 75 R-2.a — see docs/tla-audit/krd-r2-...md):
+\*   The OCaml signal gate is a disjunction of TWO overflow signals:
+\*     (a) ?current_turn_blocker_info — the in-flight turn's blocker (fires
+\*         regardless of last_outcome), and
+\*     (b) last_blocker_info gated on last_outcome = Proactive_error.
+\*   This spec models only (b) via SignalFires.  (a) is intentionally omitted:
+\*   ... SignalGateOverflowOnly already covers it by construction ...
+\*   If (a) ever grows class-specific behaviour, add it here as a second
+\*   SignalFires disjunct + a Next variable.
```

**`keeper_rollover.ml` `classify_rollover_gate` doc comment** — appended:
```diff
+    Spec mirror: [specs/keeper-state-machine/KeeperRolloverDecision.tla] models
+    this gate (vars autoHandoff / cooldownElapsed / ratioGate / lastOutcome /
+    blockerClass / decision); [SignalGateOverflowOnly] is the safety invariant
+    ... Reverse-citation so code search for "KeeperRolloverDecision" lands here.
```

## 왜 톱니처럼 정교하지 않은가

두 가지 — 둘 다 LOW, 안전 구멍 아님:
1. **Scope gap**: OCaml `signal_gate`는 두 overflow 신호의 OR (`?current_turn_blocker_info` | `last_blocker_info` + `Proactive_error`). spec은 후자만 `SignalFires`로 모델링. 양쪽 모두 같은 typed predicate `blocker_class_indicates_overflow`를 거치므로 `SignalGateOverflowOnly` 불변식은 (a)를 구성적으로 커버 — spec은 trigger 조건을 under-approximate할 뿐 안전 보장을 over-approximate하지 않음. 단 preamble에 그 사실이 적혀있지 않아 다음 reader가 "왜 in-flight blocker는 안 모델링했지?"를 매번 재발견해야 함.
2. **One-directional cross-ref**: spec은 `keeper_rollover.ml:classify_rollover_gate`를 3회 인용하지만 `keeper_rollover.ml`의 "Spec navigation" 헤더는 `KeeperGenerationLineage.tla`(handoff-lineage 측면)만 가리킴 — `grep KeeperRolloverDecision lib/`는 0 hit. bidirectional cross-ref의 reverse leg 부재.

## 본 PR 수정

1. `docs/tla-audit/krd-r2-rollover-decision-spec-ocaml-verified-2026-05-12.md` 신규 (감사 메모, 9 cross-check + 2 nit).
2. `KeeperRolloverDecision.tla` preamble에 "Spec scope" 블록 추가 (comment-only).
3. `keeper_rollover.ml` `classify_rollover_gate` doc 코멘트에 reverse-citation 추가 (localized — lineage 헤더와 별개 concern이므로).

영향 범위: 코멘트/문서만. 런타임·타입·테스트 변화 없음. spec 의미 불변 → TLC 재실행 불필요.

## Verification

- [x] `rg` substring-match check on `keeper_rollover.ml` → 0 matches (architectural invariant verified)
- [x] `git diff --cached --stat` → 3 files, +81/-1 (audit memo + 2 comment-only edits)
- [ ] `dune build` — skipped (doc/comment-only change; global dune-local lock contention, see memory; CI verifies on clean env). Verified the OCaml comment introduces no `*)` premature terminator by inspection.
- [ ] `make -C specs check-clean KeeperRolloverDecision` — N/A: spec semantics unchanged (comment-only); CI `tla-specs` job re-runs TLC anyway.

## Trade-off

- 후속 후보 **R-2.b** (선택): `current_turn_blocker_info`를 spec에 실제로 추가 (`currentTurnBlockerClass` 변수 + `SignalFires`에 두 번째 disjunct). 현재는 architecturally redundant이므로 미루지만, 만약 in-flight blocker에 class별 분기가 생기면 그때 필수가 됨. preamble note가 그 trigger 조건을 명시함.
- 이 PR은 새 테스트를 추가하지 않음 — 해당 architectural invariant는 이미 spec의 `SpecBuggy`/`SignalGateOverflowOnly` 쌍이 CI `tla-specs` job에서 검증 중. OCaml 측은 doc 변경뿐이라 추가 regression guard 불필요.

## RFC 참조

`RFC-WAIVED: doc/comment-only changes to keeper_rollover.ml + KeeperRolloverDecision.tla preamble + a new docs/tla-audit/ memo. keeper_rollover.ml is not in any RFC-gated subsystem (not credential/keeper_gh/host_config, not repo_manager, not operator_control, not keeper_sandbox/shell, not dashboard credential component, not .claude/hooks, not instructions/workflow). No behaviour change.`

## 진행 추적

다음 iteration 시작점: 진행 메모리 `project_fsm_tla_loop_progress.md` 의 "Current cursor" 참조. 후보 — 새 spec entry (KeeperConditionsGovernPhase / KeeperCounterCausality / KeeperDwellMonotone / …) 또는 R-D-2.a+R-D-1.a 번들 (KCAF call_err 3-way + Cascade_fsm.Exhausted 2-way split, MID ~150-300 LOC, >10min 가능성).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
