### PR TITLE
docs(tla-audit): KCC R-3 — re-verify KeeperCounterCausality.tla future-design banner

### DIFF
--- a/docs/tla-audit/kcc-r3-counter-causality-dormancy-reverified-2026-05-12.md
+++ b/docs/tla-audit/kcc-r3-counter-causality-dormancy-reverified-2026-05-12.md
@@ -1,0 +1,33 @@
+# KCC R-3 — KeeperCounterCausality.tla: future-design dormancy banner re-verified (first-entry audit)
+
+**Date**: 2026-05-12 · **Iteration**: 76 (`/loop` FSM/TLA+/OCaml drift hunt) · **Phase**: R (first entry)
+**Spec**: `specs/keeper-state-machine/KeeperCounterCausality.tla` (127 LOC, 2 vars, bug-model paired)
+**OCaml**: none — the spec is a **future-design invariant**, not a runtime mirror
+**Verdict**: **clean / dormant** — the spec's `STATUS: FUTURE-DESIGN INVARIANT` banner (written 2026-04-20, see #8795 / #8642 family) is still accurate on every claim it makes. No drift, nothing to implement, nothing to wire. This PR refreshes the banner's "as of" line with a 2026-05-12 re-verification and a brief expansion of each check, plus this memo.
+
+## What the spec is
+
+`KeeperCounterCausality.tla` models a single invariant the redesigned Agent Modal hover tooltip *would* need: every counter increment must be attributable to one causing event (`CausePresentWhenCounted == counter > 0 => last_cause \in CauserEvents`). The redesign (`.claude/plans/curried-moseying-whisper.md`) proposes a per-counter `{last_incremented_at, last_cause_event}` pair serialized from the state-machine handlers so a user hovering `compaction_count` sees "last +1 at 14:22:03, cause: Compaction_completed". The bug model (`BuggyBumpWithoutEvent`) is the "incremented site updated, attribution site not" drift that adding a new event would introduce.
+
+This is **first-entry sub-class 5 (dormancy)** — and it was *already disclosed*: the banner is explicit, names the audit issue (#8795), tells the future implementer exactly what to do ("drop this banner and add the spec to the runner alongside the standard #8642-family OCaml<->TLA+ mapping comment"), and the spec is correctly kept out of `scripts/tla-check.sh`. There is nothing to fix — only to confirm the disclosure hasn't gone stale.
+
+## Re-verification (2026-05-12) — all four checks still hold
+
+| Banner claim (as of 2026-04-20) | 2026-05-12 result | Status |
+|---|---|---|
+| `rg "last_cause\|last_incremented\|last_bumped" lib/ -t ml` → 0 hits | still 0 hits | ✓ unchanged |
+| `.claude/plans/curried-moseying-whisper.md` not wired | repo has **no `.claude/plans/` tree**; `rg "curried-moseying-whisper" .` matches only this spec file | ✓ — the redesign plan is referenced nowhere in the codebase (the `~/.claude/plans/curried-moseying-whisper.md` on the local machine is an unrelated session-plan artifact, not in the repo) |
+| OCaml has the counters but no cause pair | `lib/dashboard/dashboard_http_keeper.ml:keepers_dashboard_json` serializes `("compaction_count", \`Int m.runtime.compaction_rt.count)` (lines 1204, 1771) — a plain int; `compaction_rt : compaction_runtime` (`lib/keeper/keeper_meta_contract.ml:314`) carries no `{last_incremented_at, last_cause_event}` field | ✓ unchanged |
+| NOT in `scripts/tla-check.sh` runner | `rg "KeeperCounterCausality" scripts/*.sh` → no match | ✓ unchanged |
+| `.cfg` / `-buggy.cfg` exist | `KeeperCounterCausality.cfg` + `KeeperCounterCausality-buggy.cfg` present (TTrace files from a past TLC run also present) | ✓ — the spec is self-checkable the moment it's added to a runner |
+
+## Spec internal sanity (bonus — the spec itself is well-formed)
+
+- `BumpFromEvent` is the only clean increment path and it always pairs `counter' = counter + 1` with `last_cause' = e` for `e \in CauserEvents` — exactly the invariant the implementation must preserve.
+- `BuggyBumpWithoutEvent` increments without touching `last_cause`; from `Init` (`last_cause = "none"`) this immediately violates `CausePresentWhenCounted` because `"none" \notin CauserEvents`. So the buggy cfg is guaranteed to catch the modelled drift — the Bug-Model contract (clean OK / buggy violated) holds by construction.
+- `NonCauserEvent` (`UNCHANGED vars` for `e \in EventKind \ CauserEvents`) models the common case where most events flow through the state machine without touching any given counter — important so `Fairness == WF_vars(BumpFromEvent)` doesn't force every event to bump.
+
+## Trade-off / follow-up
+
+- No fix-PR follow-up is owed. The single thing that would change this spec's status is the cause-stamping feature landing in the runtime — at which point the implementer (per the banner's own instruction) drops the `STATUS` banner, adds the `#8642`-family `OCaml ↔ TLA+ mapping` table, and adds `KeeperCounterCausality` to `scripts/tla-check.sh`. This memo + the refreshed banner keep the dormancy disclosure honest until then.
+- This is the second dormancy spec confirmed clean by a first-entry audit (after the implemented-but-clean KCB R-1 iter 70). The corpus's future-design specs are well-disclosed; the audit value here is anti-staleness, not gap-finding.

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-12T04:03:57Z (HEAD: 27dd7b230)
+Generated: 2026-05-12T04:06:03Z (HEAD: 58894f7c8)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -128,7 +128,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperConditionsGovernPhase.tla | KeeperConditionsGovernPhase | manual | 2 | 1 | clean={inv:Safety, prop:HandoffEventuallyAcknowledged} buggy={inv:TypeOK, prop:HandoffEventuallyAcknowledged} | f70bcf64b7d8 |
 | KeeperContextLifecycle.tla | KeeperContextLifecycle | manual | 4 | 2 | clean={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction, prop:CompactionProgress, prop:EventualTurnCompletion, prop:AllKeepersTerminate} buggy={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} ci-buggy={inv:ContextIsolation, inv:ResumeIdentity} ci={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} | d11093191e61 |
 | KeeperCoreTriad.tla | KeeperCoreTriad | manual | 2 | 1 | clean={inv:SafetyInvariant, prop:RunningEventuallyCompletes CapabilityNeverDeadlocks} buggy={inv:SafetyInvariant} | 578800364440 |
-| KeeperCounterCausality.tla | KeeperCounterCausality | manual | 2 | 1 | clean={inv:Safety} buggy={inv:CausePresentWhenCounted} | 531942a050de |
+| KeeperCounterCausality.tla | KeeperCounterCausality | manual | 2 | 1 | clean={inv:Safety} buggy={inv:CausePresentWhenCounted} | 409306c73de0 |
 | KeeperDecisionPipeline.tla | KeeperDecisionPipeline | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:DecisionBoundaryRequiresMeasurement} | 3476c0518970 |
 | KeeperDwellMonotone.tla | KeeperDwellMonotone | manual | 2 | 1 | clean={inv:Safety} buggy={inv:DwellNonNegative} | 805be4907879 |
 | KeeperEventQueue.tla | KeeperEventQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | c2c464472dca |

--- a/specs/keeper-state-machine/KeeperCounterCausality.tla
+++ b/specs/keeper-state-machine/KeeperCounterCausality.tla
@@ -1,13 +1,20 @@
 ---- MODULE KeeperCounterCausality ----
 \* ── STATUS: FUTURE-DESIGN INVARIANT (not yet implemented) ────────────
 \* This spec verifies an invariant a *future* feature must hold, not a
-\* current runtime guarantee. As of 2026-04-20:
+\* current runtime guarantee. As of 2026-04-20, re-verified 2026-05-12
+\* (iter 76 — all four checks below still hold; see
+\*  docs/tla-audit/kcc-r3-counter-causality-dormancy-reverified-2026-05-12.md):
 \*   - rg "last_cause|last_incremented|last_bumped" lib/ -t ml -> 0 hits
-\*   - .claude/plans/curried-moseying-whisper.md (referenced below) -> 0 hits
-\* The OCaml side has the counters themselves
-\* (lib/dashboard/dashboard_http_keeper.ml:keepers_dashboard_json) but no
-\* {last_incremented_at, last_cause_event} pair paired with them; the
-\* Agent Modal hover tooltip described in the redesign is not wired.
+\*   - .claude/plans/curried-moseying-whisper.md (referenced below): the
+\*     repo has no .claude/plans/ tree, and rg "curried-moseying-whisper"
+\*     finds only this spec -> the redesign plan is not wired anywhere
+\*   - the dashboard counters exist (lib/dashboard/dashboard_http_keeper.ml
+\*     keepers_dashboard_json serializes compaction_count from
+\*     m.runtime.compaction_rt.count, a plain int) but compaction_rt
+\*     (type compaction_runtime in lib/keeper/keeper_meta_contract.ml)
+\*     carries no {last_incremented_at, last_cause_event} pair
+\*   - KeeperCounterCausality is in no scripts/*.sh runner
+\* The Agent Modal hover tooltip described in the redesign is not wired.
 \* NOT in scripts/tla-check.sh runner -- this spec records the design
 \* intent for when the cause-stamping extension lands; once the runtime
 \* implements the field, drop this banner and add the spec to the runner


### PR DESCRIPTION
## Finding (Iteration 76, Phase R — first spec entry)

**Spec**: `specs/keeper-state-machine/KeeperCounterCausality.tla` (127 LOC, 2 vars, bug-model paired)
**OCaml**: none — the spec is a **future-design invariant**, not a runtime mirror
**Aspect**: per-counter event-causality invariant for the (unbuilt) Agent Modal hover tooltip
**Verdict**: **clean / dormant** — the `STATUS: FUTURE-DESIGN INVARIANT` banner (written 2026-04-20, #8795 / #8642 family) is still accurate on every claim; re-verified 2026-05-12
**Risk**: LOW (comment/doc-only — no behaviour, no TLC re-run, no implementation owed)
**Workaround signature**: N/A — anti-staleness re-verification of an already-disclosed dormancy spec; no string classifier / catch-all / cap added

## 순서도

```mermaid
stateDiagram-v2
  [*] --> Init : counter=0, last_cause="none"

  Init --> Counted : BumpFromEvent — ∃ e ∈ CauserEvents:\ncounter' = counter+1 ∧ last_cause' = e
  Counted --> Counted : BumpFromEvent (counter < MaxCount)
  Init --> Init : NonCauserEvent — ∃ e ∈ EventKind\CauserEvents: UNCHANGED
  Counted --> Counted : NonCauserEvent

  state "CausePresentWhenCounted\ncounter > 0 ⇒ last_cause ∈ CauserEvents" as INV
  Counted --> INV : checked every state

  note right of Counted
    Clean cfg: Safety (TypeOK ∧ CausePresentWhenCounted) holds.
    Buggy cfg: BuggyBumpWithoutEvent does counter'=counter+1 ∧ UNCHANGED last_cause
               ⇒ from Init (last_cause="none" ∉ CauserEvents) the invariant
               is violated on the first buggy bump. Bug-Model contract holds
               by construction.
    Runtime today: counters serialized as plain ints (compaction_count from
               m.runtime.compaction_rt.count); no {last_incremented_at,
               last_cause_event} pair → spec stays out of the runner until
               the cause-stamping feature lands.
  end note
```

## Re-verification (2026-05-12) — all four banner checks still hold

| Banner claim (as of 2026-04-20) | 2026-05-12 result | Status |
|---|---|---|
| `rg "last_cause\|last_incremented\|last_bumped" lib/ -t ml` → 0 hits | still 0 hits | ✓ unchanged |
| `.claude/plans/curried-moseying-whisper.md` not wired | repo has **no `.claude/plans/` tree**; `rg "curried-moseying-whisper" .` matches only this spec file | ✓ — the redesign plan is referenced nowhere in the codebase (the `~/.claude/plans/curried-moseying-whisper.md` on the local machine is an unrelated session-plan artifact) |
| OCaml has the counters but no cause pair | `keepers_dashboard_json` serializes `("compaction_count", \`Int m.runtime.compaction_rt.count)` (`lib/dashboard/dashboard_http_keeper.ml` lines 1204, 1771) — a plain int; `compaction_rt : compaction_runtime` (`lib/keeper/keeper_meta_contract.ml:314`) has no `{last_incremented_at, last_cause_event}` field | ✓ unchanged |
| NOT in `scripts/tla-check.sh` runner | `rg "KeeperCounterCausality" scripts/*.sh` → no match | ✓ unchanged |
| `.cfg` / `-buggy.cfg` exist | both present (plus past-run TTrace files) | ✓ — the spec is self-checkable the moment it's added to a runner |

## Before / After (spec banner)

```diff
-\* current runtime guarantee. As of 2026-04-20:
-\*   - rg "last_cause|last_incremented|last_bumped" lib/ -t ml -> 0 hits
-\*   - .claude/plans/curried-moseying-whisper.md (referenced below) -> 0 hits
-\* The OCaml side has the counters themselves
-\* (lib/dashboard/dashboard_http_keeper.ml:keepers_dashboard_json) but no
-\* {last_incremented_at, last_cause_event} pair paired with them; the
-\* Agent Modal hover tooltip described in the redesign is not wired.
+\* current runtime guarantee. As of 2026-04-20, re-verified 2026-05-12
+\* (iter 76 — all four checks below still hold; see
+\*  docs/tla-audit/kcc-r3-counter-causality-dormancy-reverified-2026-05-12.md):
+\*   - rg "last_cause|last_incremented|last_bumped" lib/ -t ml -> 0 hits
+\*   - .claude/plans/curried-moseying-whisper.md (referenced below): the
+\*     repo has no .claude/plans/ tree, and rg "curried-moseying-whisper"
+\*     finds only this spec -> the redesign plan is not wired anywhere
+\*   - the dashboard counters exist (... compaction_count from
+\*     m.runtime.compaction_rt.count, a plain int) but compaction_rt
+\*     (type compaction_runtime in lib/keeper/keeper_meta_contract.ml)
+\*     carries no {last_incremented_at, last_cause_event} pair
+\*   - KeeperCounterCausality is in no scripts/*.sh runner
+\* The Agent Modal hover tooltip described in the redesign is not wired.
```

`specs/INDEX.md` regenerated (`scripts/gen-tla-index.sh`): the KCC hash bumps `531942a050de → 409306c73de0` (the banner edit); `KeeperRolloverDecision` hash stays `71d1c2f76746` because #14953 (iter 75) isn't merged yet.

## 왜 톱니처럼 정교하지 않은가

여기서 발견된 "톱니"는 코드↔spec drift가 아니라 **dormancy disclosure의 시간 부패**다. `KeeperCounterCausality.tla`는 미구현 future-design 불변식이고 그 사실을 banner가 명시하지만, banner의 검증 시점("as of 2026-04-20")이 그대로 박혀있어 다음 reader가 "이거 아직도 맞나?"를 매번 손으로 재확인해야 한다. first-entry sub-class 5 (dormancy) — 이미 disclose됐고, drift도 없고, banner도 정확하다. audit value는 gap-finding이 아니라 anti-staleness: 4개 체크를 다시 돌려 "여전히 유효" 도장을 찍고 그 근거를 banner와 memo에 남겼다.

## 본 PR 수정

1. `docs/tla-audit/kcc-r3-counter-causality-dormancy-reverified-2026-05-12.md` 신규 (first-entry 감사 memo: 4 banner check 재검증 표 + spec internal sanity + follow-up 없음).
2. `KeeperCounterCausality.tla` banner의 "as of" 줄에 2026-05-12 재검증 + 각 체크 부연 추가 (comment-only).
3. `specs/INDEX.md` 재생성 (generator가 SSOT — banner 편집으로 KCC 해시 변경 반영).

영향 범위: 코멘트/문서/생성-인덱스만. 런타임·타입·테스트·spec 의미 변화 없음 → TLC 재실행 불필요.

## Verification

- [x] `rg "last_cause|last_incremented|last_bumped" lib/ -t ml` → 0 hits
- [x] `rg "curried-moseying-whisper" .` → only `KeeperCounterCausality.tla`; no `.claude/plans/` tree in repo
- [x] `rg "KeeperCounterCausality" scripts/*.sh` → no match (correctly excluded from runners)
- [x] `bash scripts/gen-tla-index.sh > specs/INDEX.md` → only KCC-hash + timestamp/HEAD lines change (KRD hash untouched, as expected)
- [x] `git diff --cached --stat` → 3 files +48/-8
- [ ] `make -C specs check-clean KeeperCounterCausality` — N/A: spec semantics unchanged (comment-only); the spec is intentionally out of the CI runner until the feature lands.

## Trade-off

- 후속 fix-PR 없음. 이 spec의 상태를 바꿀 유일한 사건은 cause-stamping 기능이 런타임에 들어오는 것 — 그때 구현자가 (banner 지시대로) `STATUS` banner 제거 + `#8642`-family `OCaml ↔ TLA+ mapping` 표 추가 + `scripts/tla-check.sh`에 등록. 이 memo + 갱신된 banner가 그때까지 dormancy disclosure를 정직하게 유지.
- 이는 first-entry 감사로 clean 확인된 2번째 dormancy spec (iter 70 KCB R-1 — implemented-but-clean — 에 이어). corpus의 future-design spec들은 disclosure가 잘 돼있음; 여기 audit value는 anti-staleness.

## RFC 참조

`RFC-WAIVED: comment/doc-only — refreshes the dormancy banner of KeeperCounterCausality.tla, adds a docs/tla-audit/ memo, regenerates specs/INDEX.md (a generated file). No runtime/lib change, no RFC-gated subsystem touched (not credential/keeper_gh/host_config, not repo_manager, not operator_control, not keeper_sandbox/shell, not dashboard credential component, not .claude/hooks, not instructions/workflow).`

## 진행 추적

다음 iteration 시작점: 진행 메모리 `project_fsm_tla_loop_progress.md` 의 "Current cursor" 참조. 후보 — 새 spec entry (KeeperConditionsGovernPhase / KeeperDwellMonotone / KeeperOutcomesConservation / KeeperLaunchPending 등 ~11개 미감사) 또는 R-D-2.a+R-D-1.a 번들 (KCAF call_err 3-way + Cascade_fsm.Exhausted 2-way split, MID ~150-300 LOC) 또는 KSM A-5 (22×19 update_conditions matrix).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
