### PR TITLE
Fix inline-envelope lint when rg is unavailable

### DIFF
--- a/scripts/lint/no-inline-error-envelope.sh
+++ b/scripts/lint/no-inline-error-envelope.sh
@@ -30,12 +30,21 @@ cleanup() {
 }
 trap cleanup EXIT
 
-rg_status=0
-rg -nP '"status",\s*`String\s+"error"' lib/ -g '*.ml' >"$matches_file" 2>"$errors_file" || rg_status=$?
-if [[ $rg_status -gt 1 ]]; then
-  echo "ERROR: ripgrep failed while scanning error-envelope literals" >&2
-  cat "$errors_file" >&2
-  exit "$rg_status"
+scan_status=0
+if command -v rg >/dev/null 2>&1; then
+  rg -nP '"status",\s*`String\s+"error"' lib/ -g '*.ml' >"$matches_file" 2>"$errors_file" || scan_status=$?
+  if [[ $scan_status -gt 1 ]]; then
+    echo "ERROR: ripgrep failed while scanning error-envelope literals" >&2
+    cat "$errors_file" >&2
+    exit "$scan_status"
+  fi
+else
+  grep -RInE --include='*.ml' '"status",[[:space:]]*`String[[:space:]]+"error"' lib/ >"$matches_file" 2>"$errors_file" || scan_status=$?
+  if [[ $scan_status -gt 1 ]]; then
+    echo "ERROR: grep failed while scanning error-envelope literals" >&2
+    cat "$errors_file" >&2
+    exit "$scan_status"
+  fi
 fi
 
 while IFS= read -r match; do

--- a/scripts/lint/no-inline-ok-envelope.sh
+++ b/scripts/lint/no-inline-ok-envelope.sh
@@ -62,12 +62,21 @@ cleanup() {
 }
 trap cleanup EXIT
 
-rg_status=0
-rg -nP '\("status",\s*`String\s+"ok"\)' lib/ -g '*.ml' >"$matches_file" 2>"$errors_file" || rg_status=$?
-if [[ $rg_status -gt 1 ]]; then
-  echo "ERROR: ripgrep failed while scanning ok-envelope literals" >&2
-  cat "$errors_file" >&2
-  exit "$rg_status"
+scan_status=0
+if command -v rg >/dev/null 2>&1; then
+  rg -nP '\("status",\s*`String\s+"ok"\)' lib/ -g '*.ml' >"$matches_file" 2>"$errors_file" || scan_status=$?
+  if [[ $scan_status -gt 1 ]]; then
+    echo "ERROR: ripgrep failed while scanning ok-envelope literals" >&2
+    cat "$errors_file" >&2
+    exit "$scan_status"
+  fi
+else
+  grep -RInE --include='*.ml' '\("status",[[:space:]]*`String[[:space:]]+"ok"\)' lib/ >"$matches_file" 2>"$errors_file" || scan_status=$?
+  if [[ $scan_status -gt 1 ]]; then
+    echo "ERROR: grep failed while scanning ok-envelope literals" >&2
+    cat "$errors_file" >&2
+    exit "$scan_status"
+  fi
 fi
 
 while IFS= read -r match; do


### PR DESCRIPTION
## Summary

Follow-up to #14948 after GitHub CI exposed that the hosted runner does not provide `rg`.

The inline envelope lint scripts now:
- keep using `rg -P` when ripgrep is available
- fall back to `grep -RInE --include='*.ml'` with equivalent patterns when `rg` is absent
- still fail on real scanner errors instead of silently passing

## Validation

- `bash scripts/lint/no-inline-error-envelope.sh`
- `bash scripts/lint/no-inline-ok-envelope.sh`
- `env PATH=/usr/bin:/bin bash scripts/lint/no-inline-error-envelope.sh`
- `env PATH=/usr/bin:/bin bash scripts/lint/no-inline-ok-envelope.sh`
- `git diff --check`
