### PR TITLE
feat(keeper): RFC-0070 Phase 3e (d) — Docker_client.S.image_present

### DIFF
--- a/lib/keeper/docker_client.ml
+++ b/lib/keeper/docker_client.ml
@@ -28,4 +28,6 @@ module type S = sig
   val rm : Keeper_container_name.t -> (unit, sandbox_error) result
 
   val info_security_options : unit -> (string list, sandbox_error) result
+
+  val image_present : image:string -> (unit, sandbox_error) result
 end

--- a/lib/keeper/docker_client.mli
+++ b/lib/keeper/docker_client.mli
@@ -83,4 +83,19 @@ module type S = sig
       a JSON array nor [null], or that fails to parse — i.e. a docker
       output-format change — ⇒ [Error Probe_format_drift] rather than
       a silent [Ok []]. *)
+
+  val image_present : image:string -> (unit, sandbox_error) result
+  (** [image_present ~image] runs [docker image inspect <image>].
+      [Ok ()] when the image exists locally.
+
+      A non-zero exit conflates "image not found locally" (exit 1 — the
+      common case; the caller may then pull) with "daemon down" (also
+      exit 1, with a connection-error message), so it surfaces as
+      [Error Image_pull_failed] — the single "image is not available
+      for this run" signal. The one disambiguated case is a docker CLI
+      that is missing entirely ⇒ [Error Daemon_unreachable]. [image] is
+      assumed non-empty; the plan layer validates that, not this
+      daemon-level call. (RFC §3.0.3 sketched a richer
+      [image_inspect → image_info]; nothing consumes inspect data, so
+      this is the presence-check it actually needs.) *)
 end

--- a/lib/keeper/docker_client_mock.ml
+++ b/lib/keeper/docker_client_mock.ml
@@ -34,6 +34,10 @@ let info_security_options_queue
   : (string list, Docker_client.sandbox_error) result Queue.t
   = Queue.create ()
 
+let image_present_queue
+  : (string * (unit, Docker_client.sandbox_error) result) Queue.t
+  = Queue.create ()
+
 (* ── Injection API ──────────────────────────────────────────── *)
 
 let inject_run plan response = Queue.add (plan, response) run_queue
@@ -50,6 +54,10 @@ let inject_rm container response = Queue.add (container, response) rm_queue
 
 let inject_info_security_options response =
   Queue.add response info_security_options_queue
+;;
+
+let inject_image_present ~image response =
+  Queue.add (image, response) image_present_queue
 ;;
 
 (* ── Docker_client.S implementation ─────────────────────────── *)
@@ -112,6 +120,13 @@ let info_security_options () =
   | None -> Error Docker_client.Daemon_unreachable
 ;;
 
+let image_present ~image =
+  match Queue.peek_opt image_present_queue with
+  | Some (expected, response) when String.equal image expected ->
+    ignore (Queue.pop image_present_queue);
+    response
+  | _ -> Error Docker_client.Daemon_unreachable
+
 (* ── Fixture lifecycle ──────────────────────────────────────── *)
 
 let reset () =
@@ -119,7 +134,8 @@ let reset () =
   Queue.clear exec_queue;
   Queue.clear ps_query_queue;
   Queue.clear rm_queue;
-  Queue.clear info_security_options_queue
+  Queue.clear info_security_options_queue;
+  Queue.clear image_present_queue
 
 let pending_calls () =
   Queue.length run_queue
@@ -127,3 +143,4 @@ let pending_calls () =
   + Queue.length ps_query_queue
   + Queue.length rm_queue
   + Queue.length info_security_options_queue
+  + Queue.length image_present_queue

--- a/lib/keeper/docker_client_mock.mli
+++ b/lib/keeper/docker_client_mock.mli
@@ -57,6 +57,14 @@ val inject_info_security_options
   :  (string list, Docker_client.sandbox_error) result
   -> unit
 
+(** [inject_image_present ~image response] enqueues [response] to be
+    returned when {!image_present} is called with that [image] string
+    (exact match). Strict FIFO, fail-closed on mismatch. *)
+val inject_image_present
+  :  image:string
+  -> (unit, Docker_client.sandbox_error) result
+  -> unit
+
 (** {1 Fixture lifecycle} *)
 
 (** [reset ()] empties every injection queue. Call between tests so

--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -141,3 +141,24 @@ let info_security_options () =
        surface as [Ok]. *)
     Error Docker_client.Daemon_unreachable
 ;;
+
+let image_present ~image =
+  (* [docker image inspect <image>] — exit 0 ⇒ present locally. A
+     non-zero exit conflates "image not found locally" (exit 1 — the
+     common case, the caller may then pull) with "daemon down" (also
+     exit 1, with a connection-error message). The shipped
+     [keeper_sandbox_runtime.docker_image_present] makes the same
+     conflation. We surface [Image_pull_failed] as the single "image
+     is not available for this run" signal, except a synthesized
+     [WEXITED 127] (docker CLI itself missing), which is unambiguously
+     [Daemon_unreachable]. A future RFC could split this into
+     [Image_not_found | Daemon_unreachable] if the preflight needs to
+     distinguish. [image] is assumed non-empty — the plan layer
+     validates that, not this daemon-level call. *)
+  let argv = [ "docker"; "image"; "inspect"; image ] in
+  match Process_eio.run_argv_with_status argv with
+  | Unix.WEXITED 0, _ -> Ok ()
+  | Unix.WEXITED 127, _ -> Error Docker_client.Daemon_unreachable
+  | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _ ->
+    Error Docker_client.Image_pull_failed
+;;

--- a/test/test_docker_client_mock.ml
+++ b/test/test_docker_client_mock.ml
@@ -201,6 +201,30 @@ let test_info_security_options_error_injection () =
   | Error Docker_client.Probe_format_drift -> ()
   | _ -> fail "expected Probe_format_drift"
 
+(* ── image_present (Phase 3e d) ───────────────────────────────── *)
+
+let test_image_present_matches () =
+  setup ();
+  Docker_client_mock.inject_image_present ~image:"alpine:3.20" (Ok ());
+  match Docker_client_mock.image_present ~image:"alpine:3.20" with
+  | Ok () -> check int "queue drained" 0 (Docker_client_mock.pending_calls ())
+  | Error _ -> fail "expected Ok"
+
+let test_image_present_wrong_image_miss () =
+  setup ();
+  Docker_client_mock.inject_image_present ~image:"alpine:3.20" (Ok ());
+  match Docker_client_mock.image_present ~image:"ubuntu:24.04" with
+  | Error Docker_client.Daemon_unreachable ->
+    check int "queue intact on miss" 1 (Docker_client_mock.pending_calls ())
+  | _ -> fail "expected miss on different image"
+
+let test_image_present_error_injection () =
+  setup ();
+  Docker_client_mock.inject_image_present ~image:"missing:img" (Error Docker_client.Image_pull_failed);
+  match Docker_client_mock.image_present ~image:"missing:img" with
+  | Error Docker_client.Image_pull_failed -> ()
+  | _ -> fail "expected Image_pull_failed"
+
 (* ── reset / pending_calls ────────────────────────────────────── *)
 
 let test_reset_clears_all_queues () =
@@ -211,7 +235,8 @@ let test_reset_clears_all_queues () =
   Docker_client_mock.inject_ps_query ~labels:[] (Ok []);
   Docker_client_mock.inject_rm c (Ok ());
   Docker_client_mock.inject_info_security_options (Ok []);
-  check int "5 queued" 5 (Docker_client_mock.pending_calls ());
+  Docker_client_mock.inject_image_present ~image:"a:b" (Ok ());
+  check int "6 queued" 6 (Docker_client_mock.pending_calls ());
   Docker_client_mock.reset ();
   check int "reset clears everything" 0 (Docker_client_mock.pending_calls ())
 
@@ -252,6 +277,14 @@ let () =
             test_info_security_options_empty_queue;
           test_case "Error injection round-trip" `Quick
             test_info_security_options_error_injection;
+        ] );
+      ( "image_present",
+        [
+          test_case "matches injection" `Quick test_image_present_matches;
+          test_case "wrong image → miss; queue intact" `Quick
+            test_image_present_wrong_image_miss;
+          test_case "Error injection round-trip" `Quick
+            test_image_present_error_injection;
         ] );
       ( "lifecycle",
         [ test_case "reset clears all queues" `Quick test_reset_clears_all_queues ] );

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -262,6 +262,24 @@ let test_info_security_options_returns_typed () =
        Probe_format_drift"
 ;;
 
+(* Phase 3e (d) — [image_present] runs [docker image inspect <image>].
+   Env-dependent: a present image ⇒ [Ok ()], an absent one ⇒
+   [Image_pull_failed] (or [Daemon_unreachable] if docker is missing).
+   Only the typed contract is asserted; a random-looking image name
+   means [Ok] is unlikely on a clean host but not impossible, so it is
+   accepted. The forbidden variants would indicate a mapping bug. *)
+let test_image_present_returns_typed () =
+  match Docker_client_real.image_present ~image:"definitely-not-a-real-image:0xnope" with
+  | Ok () -> () (* extremely unlikely, but a real local image with this name is legal *)
+  | Error Docker_client.Image_pull_failed -> () (* not present locally / daemon down *)
+  | Error Docker_client.Daemon_unreachable -> () (* docker CLI missing *)
+  | Error Docker_client.Cleanup_failed
+  | Error Docker_client.Container_oom
+  | Error Docker_client.Exec_timeout
+  | Error Docker_client.Probe_format_drift ->
+    fail "image_present should only surface Ok | Image_pull_failed | Daemon_unreachable"
+;;
+
 (* ── Functor instantiation works with Real ───────────────────── *)
 
 (* Phase 3b-iv.2.3 — executor.execute_plan calls Real.run, which is
@@ -326,6 +344,12 @@ let () =
             "info_security_options → Ok | Daemon_unreachable | Probe_format_drift"
             `Quick
             test_info_security_options_returns_typed
+        ] )
+    ; ( "image_present (Phase 3e d)"
+      , [ test_case
+            "image_present → Ok | Image_pull_failed | Daemon_unreachable"
+            `Quick
+            test_image_present_returns_typed
         ] )
     ; ( "Functor composition"
       , [ test_case


### PR DESCRIPTION
## Summary

RFC-0070 §3.0.3 + §4 Phase 3e item (d): `Docker_client.S` gains `image_present : image:string -> (unit, sandbox_error) result`. `keeper_sandbox_runtime.docker_image_present` (the Phase 4 cutover target) runs `docker image inspect <image>` and returns `Ok ()`/`Error <string>` — this adds the typed `Docker_client.S` member so the keeper can later delegate, and so the call is mockable.

**Scope correction vs RFC §3.0.3**: that section sketched `image_inspect : image:string -> (image_info, sandbox_error) result` with a new `image_info` type. Nothing consumes inspect data — the keeper only checks presence — so an `image_info` type would be over-specced. This ships `image_present`, the presence-check actually needed. RFC §3.0.3 should be narrowed (doc follow-up).

## What changed

| File | Change |
|------|--------|
| `docker_client.{ml,mli}` | `S` gains `image_present : image:string -> (unit, sandbox_error) result`. Exit 0 ⇒ `Ok ()`. Non-zero exit conflates "not found locally" (exit 1, common — caller may then pull) with "daemon down" (also exit 1) ⇒ `Error Image_pull_failed` (the single "image unavailable for this run" signal — same conflation the existing keeper function makes). Synthesized `WEXITED 127` (CLI missing) ⇒ `Error Daemon_unreachable`. `image` assumed non-empty (plan layer validates). |
| `docker_client_real.ml` | `image_present ~image` spawns `docker image inspect`, maps exit status as above. |
| `docker_client_mock.ml` / `.mli` | new `image_present_queue` keyed on `image`, strict-FIFO consume (mismatch ⇒ `Daemon_unreachable`, queue intact), `inject_image_present ~image`, wired into `reset` / `pending_calls`. |
| `test_docker_client_real.ml` | +1 typed-contract case (`Ok | Image_pull_failed | Daemon_unreachable`). 17→18 tests. |
| `test_docker_client_mock.ml` | +3 cases — match / wrong-image miss (queue intact) / Error round-trip. 14→17 tests. |

## Verification

```
$ dune build --root . test/test_docker_client_real.exe test/test_docker_client_mock.exe   # exit 0
$ _build/default/test/test_docker_client_real.exe   # Test Successful in 1.559s. 18 tests run.
$ _build/default/test/test_docker_client_mock.exe   # Test Successful in 0.001s. 17 tests run.
```

## Phase 3e progress

(b) `exec ?user/?workdir` (#14947 merged), (c) `info_security_options` (#14951 merged), (d) `image_present` (this) — the three self-contained edge primitives. Remaining: (e) `Keeper_sandbox_session_plan` (needs a direction call on the 4 §3.1.2 paper-design issues — labels composer vs list, mounts/identity integration, `env_passthrough` naming, ulimits soft:hard), then (a) `run_detached` + (f) `Sandbox_session_executor.Make`. None of (b)/(c)/(d) expose a new layer, so this fragmentation is safe (not the dune-cascade pattern).

## RFC reference

RFC-0070 §3.0.3 ("preflight pattern — `docker info --format`, `docker image inspect`") + §4 Phase 3e item (d). RFC-0070 *extends* RFC-0006 (no keeper sandbox containment-policy change) and *depends on* RFC-0036 (no cleanup-hook surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
