### PR TITLE
feat(sublibs): enable warning 4 on mcp_transport_protocol + multimodal (RFC-0071 §3.4)

### DIFF
--- a/lib/mcp_transport_protocol/dune
+++ b/lib/mcp_transport_protocol/dune
@@ -5,5 +5,7 @@
  (public_name masc_mcp.mcp_transport_protocol)
  (modules mcp_transport_protocol)
  (wrapped false)
+ ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on.
+ (flags (:standard -w +4))
  (libraries mcp_protocol yojson)
  (preprocess (pps ppx_deriving_yojson)))

--- a/lib/multimodal/dune
+++ b/lib/multimodal/dune
@@ -3,5 +3,7 @@
 (library
  (name multimodal)
  (public_name masc_mcp.multimodal)
+ ; RFC-0071 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries shared_types unix yojson)
  (preprocess (pps ppx_tla)))


### PR DESCRIPTION
## 목적

RFC-0071 §3.4 Phase 5 ratchet (#14888 … #14950 후속).

## 변경

2개 clean sublib 에 `(flags (:standard -w +4))` 추가 (fragile site 0건):
- `lib/mcp_transport_protocol` — 단일 모듈; 7 single-line catch-all 전부 string/Yojson dispatch (open type, warning 4 무시)
- `lib/multimodal` — 10 single-line catch-all 전부 string/Yojson option

## 검증

- \`dune build --root .\` clean
- 각 sublib build clean under `-w +4`

## 누적

| | `-w +4` sublibs |
|--|--|
| #14888 … #14950 | 31 |
| **본 PR** | **+2** |
| **누계** | **33** |

## Deferred (warning 4 fire)

- `lib/cdal` — adversarial_eval ×4, cdal_friction_projection ×1
- `lib/activity_graph` — activity_graph_reducer ×1
- `lib/resilience` — confidence ×4, degradation ×2
- `lib/autoresearch` (~5), `lib/cascade_decl` (12), `lib/coord` (35), `lib/cdal_runtime` (34)
- `lib/repo_manager` (8) — RFC-required subsystem
- `lib` (main, ~1659) — codemod (RFC-0071 Phase 2)