### PR TITLE
fix(specs): KDM R-4 — add missing "Zombie" to KeeperDwellMonotone PhaseSet; refresh stale impl-mapping refs

### DIFF
--- a/docs/tla-audit/kdm-r4-dwell-monotone-phaseset-and-mapping-drift-2026-05-12.md
+++ b/docs/tla-audit/kdm-r4-dwell-monotone-phaseset-and-mapping-drift-2026-05-12.md
@@ -1,0 +1,48 @@
+# KDM R-4 — KeeperDwellMonotone.tla: PhaseSet missing "Zombie" + Implementation-mapping line-refs stale (first-entry audit, fixed)
+
+**Date**: 2026-05-12 · **Iteration**: 77 (`/loop` FSM/TLA+/OCaml drift hunt) · **Phase**: R (first entry)
+**Spec**: `specs/keeper-state-machine/KeeperDwellMonotone.tla` (159 LOC, 3 vars, bug-model paired)
+**OCaml/TS**: `lib/keeper/keeper_registry.ml` (producer) · `dashboard/src/components/keeper-detail-page.ts` + `keeper-detail-shell.ts` + `keeper-phase-indicator.ts` (consumer) · `dashboard/src/api/keeper.ts` (`fetchKeeperTransitions`)
+**Verdict**: **two real drifts, both fixed in this PR** — (1) `PhaseSet` listed only 12 of the 13 `type phase` constructors (`"Zombie"` missing) despite the spec's own comment saying it was present; (2) the `Implementation mapping` block cited `keeper_registry.ml:919` (drifted +1658 — the `wall_clock_at_decision = now` stamp is at ~line 2577; line 919 is `packed_compaction_stage_label`, unrelated) and three dashboard files that had been refactored away (`keeper-detail.ts` is now a 15-line shim; the `phaseEnteredAtSec` `useState` moved to `keeper-detail-page.ts`). Core safety (`DwellNonNegative`) was correct throughout — both drifts are model-completeness / navigability, not a logic bug.
+
+## What the spec is
+
+`KeeperDwellMonotone.tla` models the minimal clock + phase-entry-stamp relationship behind the Agent Modal's "Running for 2h 20m" dwell indicator: `DwellNonNegative == entered_at <= now`. Discipline points: (1) the clock is monotonic; (2) every phase transition does `entered_at := now` (no stale carry-over, no future stamp). Bug model `BuggyEntryInFuture` does `entered_at' = now + 1` — TLC catches it (counterexample `now=1, phase="Running", entered_at=2`).
+
+## Drift 1 — `PhaseSet` missing `"Zombie"` (sub-class 2: drift)
+
+The OCaml `keeper_state_machine.ml:6-19` has **13** `type phase` constructors: `Offline | Running | Failing | Overflowed | Compacting | HandingOff | Draining | Paused | Stopped | Crashed | Restarting | Dead | Zombie`. The spec's `PhaseSet` literal listed only the first **12** — `"Zombie"` absent — even though the comment directly above it said *"13-phase FSM ... Zombie added iter 4 #14707, terminal-terminal — see PhaseSet below"*. The comment was right; the set was stale.
+
+**Effect**: `DwellNonNegative` is phase-agnostic (it constrains `entered_at`/`now` only), so the safety result is unaffected. But `TypeOK` excluded `phase = "Zombie"` and the `Transition` action never explored transitions into/out of Zombie — the spec silently under-modelled a terminal phase. **Fix**: added `"Zombie"` to `PhaseSet`; updated the comment to record the iter 77 R-4 correction.
+
+**TLC re-run (this PR)** — verified the Bug-Model contract still holds with the 13th phase:
+- Clean (`KeeperDwellMonotone.cfg`): `Model checking completed. No error has been found.` — 3472 states generated, 273 distinct, depth 8, max outdegree 13 (= 12 other phases + 1 tick — consistent with the 13-phase set). ✓
+- Buggy (`KeeperDwellMonotone-buggy.cfg`): `DwellNonNegative` violated, counterexample trace `now=1, phase="Running", entered_at=2` (≈ depth 2-3). ✓
+
+## Drift 2 — `Implementation mapping` block stale on all three sites (sub-class 8: line-reference drift)
+
+| Spec citation (as written) | Reality on 2026-05-12 | Fix |
+|---|---|---|
+| `lib/keeper/keeper_registry.ml:919` — `Keeper_transition_audit.record_transition { ...; wall_clock_at_decision = now; ... }` | `wall_clock_at_decision = now` is at **~line 2577**; line 919 is `let packed_compaction_stage_label` (compaction-stage diagnostics, unrelated). Drift **+1658**. | Cite by symbol: "the `Keeper_transition_audit.record_transition { ...; wall_clock_at_decision = now; ... }` record built at each transition apply" — no line number (iter 64 N-2.a convention) |
+| `dashboard/src/components/keeper-detail.ts:1167-1168` — `const [phaseEnteredAtSec, ...] = useState<number \| null>(null)` from `fetchKeeperTransitions(...).transitions[0].wall_clock_at_decision` | `keeper-detail.ts` is now a **15-line file** (re-export shim). The `phaseEnteredAtSec` `useState` lives in **`dashboard/src/components/keeper-detail-page.ts`** (`const [phaseEnteredAtSec, setPhaseEnteredAtSec] = useState<number \| null>(null)`), sourced from `fetchKeeperTransitions` in **`dashboard/src/api/keeper.ts`**, threaded through `keeper-detail-shell.ts` into `KeeperPhaseAndStage` | Re-pointed to `keeper-detail-page.ts` / `keeper-detail-shell.ts` / `dashboard/src/api/keeper.ts`; no line numbers |
+| `dashboard/src/components/keeper-phase-indicator.ts:113` — `formatDuration(Math.max(0, Date.now()/1000 - phaseEnteredAtSec))` | Now at **line 114**, restructured into a `dwellText` const guarded by `typeof phaseEnteredAtSec === 'number' && Number.isFinite(phaseEnteredAtSec)`; clamp body unchanged (`formatDuration(Math.max(0, Date.now() / 1000 - phaseEnteredAtSec))`) | Cite the `dwellText` expression in `keeper-phase-indicator.ts`; no line number |
+
+The clamp's *behaviour* is intact (the defense-in-depth `Math.max(0, ...)` still guards a misbehaving clock); only the file/line citations had rotted. The spec's claim "this is independent of the spec — the spec ensures the producer side is correct so the clamp should never fire" remains accurate.
+
+## Cross-checks (pass)
+
+| Spec element | Runtime | Status |
+|---|---|---|
+| `PhaseSet` (now 13) | `type phase` in `keeper_state_machine.ml` (13 constructors) | ✓ after this PR |
+| producer stamps `entered_at := now` | `Keeper_transition_audit.record_transition { ...; wall_clock_at_decision = now; ... }` in `keeper_registry.ml` — `now` from `Time_compat.now ()` | ✓ |
+| consumer reads latest transition's stamp | `keeper-detail-page.ts` `phaseEnteredAtSec` ← `fetchKeeperTransitions` (`dashboard/src/api/keeper.ts`) ← `wall_clock_at_decision` | ✓ |
+| frontend never shows negative dwell | `keeper-phase-indicator.ts` `formatDuration(Math.max(0, Date.now()/1000 - phaseEnteredAtSec))` | ✓ |
+| `.cfg` / `-buggy.cfg` | both present (+ a past-run TTrace file) | ✓ |
+| Bug-Model contract | clean = no error, buggy = `DwellNonNegative` violated — re-verified this PR | ✓ |
+
+## Sub-class placement & follow-up
+
+- Drift 1 = **sub-class 2 (drift)** — the literal `PhaseSet` lagged its own comment and the OCaml `type phase`.
+- Drift 2 = **sub-class 8 (line-reference drift)** — the producer ref drifted +1658, the consumer refs survived a multi-file dashboard refactor pointing at a now-15-line shim.
+- No follow-up PR owed. `specs/INDEX.md` regenerated (KDM content-hash bump `805be4907879 → 69416fba4415`).
+- This is the first audited spec where a *frontend* refactor (component split into `*-page.ts` / `*-shell.ts`) had silently invalidated a spec citation — worth noting that the line-ref drift class isn't OCaml-only; TS component renames hit it too. The fix (symbol/file anchors, no line numbers) is the same.

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-12T04:06:03Z (HEAD: 58894f7c8)
+Generated: 2026-05-12T04:13:05Z (HEAD: f0c9c06b4)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -130,7 +130,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperCoreTriad.tla | KeeperCoreTriad | manual | 2 | 1 | clean={inv:SafetyInvariant, prop:RunningEventuallyCompletes CapabilityNeverDeadlocks} buggy={inv:SafetyInvariant} | 578800364440 |
 | KeeperCounterCausality.tla | KeeperCounterCausality | manual | 2 | 1 | clean={inv:Safety} buggy={inv:CausePresentWhenCounted} | 409306c73de0 |
 | KeeperDecisionPipeline.tla | KeeperDecisionPipeline | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:DecisionBoundaryRequiresMeasurement} | 3476c0518970 |
-| KeeperDwellMonotone.tla | KeeperDwellMonotone | manual | 2 | 1 | clean={inv:Safety} buggy={inv:DwellNonNegative} | 805be4907879 |
+| KeeperDwellMonotone.tla | KeeperDwellMonotone | manual | 2 | 1 | clean={inv:Safety} buggy={inv:DwellNonNegative} | 69416fba4415 |
 | KeeperEventQueue.tla | KeeperEventQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | c2c464472dca |
 | KeeperGenerationLineage.tla | KeeperGenerationLineage | manual | 2 | 1 | clean={inv:TypeOK, inv:CurrentTraceIsolation, inv:GenerationMatchesHistory, inv:CurrentTraceNotInHistory, inv:TraceHistoryUnique, inv:TraceIdsAllocated, inv:IdleCheckpointMatchesCommittedLineage, prop:HandoffEventuallyResolves} buggy={inv:TypeOK, inv:GenerationMatchesHistory, inv:CurrentTraceNotInHistory, inv:TraceHistoryUnique, inv:TraceIdsAllocated, inv:IdleCheckpointMatchesCommittedLineage} | bc957a36caf6 |
 | KeeperHeartbeat.tla | KeeperHeartbeat | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 35344ff2f4be |

--- a/specs/keeper-state-machine/KeeperDwellMonotone.tla
+++ b/specs/keeper-state-machine/KeeperDwellMonotone.tla
@@ -26,27 +26,34 @@
 \*               DwellNonNegative MUST be violated.  If it passes, the
 \*               invariant is too weak and must be strengthened.
 \*
-\* Implementation mapping (spec ↔ runtime, see #8642 family):
+\* Implementation mapping (spec ↔ runtime, see #8642 family).
+\* Cited by symbol/file anchor, not line number — line numbers drift
+\* (iter 64 N-2.a convention; the producer ref below had drifted +1658 and
+\* the dashboard consumer had been split across three new files by iter 77,
+\* see docs/tla-audit/kdm-r4-dwell-monotone-phaseset-and-mapping-drift-2026-05-12.md):
 \*
 \*   Producer side — phase transition stamps entry timestamp:
-\*     lib/keeper/keeper_registry.ml:919
-\*       Keeper_transition_audit.record_transition {
-\*         ...; wall_clock_at_decision = now; ... }
-\*     The OCaml side stamps [wall_clock_at_decision = now] at the moment
-\*     of each transition apply, satisfying the spec discipline that
-\*     entry_at := now (not future, not stale).  [now] comes from
-\*     [Time_compat.now ()] which is wall-clock monotonic in practice
-\*     (system clock).
+\*     lib/keeper/keeper_registry.ml — the
+\*       Keeper_transition_audit.record_transition { ...;
+\*         wall_clock_at_decision = now; ... }
+\*     record built at each transition apply.  The OCaml side stamps
+\*     [wall_clock_at_decision = now] at the moment of the apply,
+\*     satisfying the spec discipline that entry_at := now (not future,
+\*     not stale).  [now] comes from [Time_compat.now ()] which is
+\*     wall-clock monotonic in practice (system clock).
 \*
 \*   Consumer side — dashboard derives dwell from the latest transition:
-\*     dashboard/src/components/keeper-detail.ts:1167-1168
-\*       const [phaseEnteredAtSec, ...] = useState<number | null>(null)
-\*       // sourced from fetchKeeperTransitions(...).transitions[0]
-\*       //   .wall_clock_at_decision
+\*     dashboard/src/components/keeper-detail-page.ts holds
+\*       const [phaseEnteredAtSec, setPhaseEnteredAtSec] = useState<number | null>(null)
+\*     sourced from fetchKeeperTransitions(...) (dashboard/src/api/keeper.ts) —
+\*     the latest KeeperTransition's wall_clock_at_decision — and threads it
+\*     through keeper-detail-shell.ts into KeeperPhaseAndStage.
 \*
 \*   Defense in depth — frontend clamp guards a misbehaving clock:
-\*     dashboard/src/components/keeper-phase-indicator.ts:113
-\*       formatDuration(Math.max(0, Date.now()/1000 - phaseEnteredAtSec))
+\*     dashboard/src/components/keeper-phase-indicator.ts computes
+\*       const dwellText = (typeof phaseEnteredAtSec === 'number' && Number.isFinite(phaseEnteredAtSec))
+\*         ? formatDuration(Math.max(0, Date.now() / 1000 - phaseEnteredAtSec))
+\*         : null
 \*     Even if [phaseEnteredAtSec > Date.now()/1000] (clock skew between
 \*     server and client, or a missed clamp on the producer), the dwell
 \*     UI never shows a negative duration.  This is independent of the
@@ -69,7 +76,12 @@ VARIABLES
 vars == << phase, entered_at, now >>
 
 \* RFC-0002 13-phase FSM (keeper_state_machine.ml: type phase, 13 constructors;
-\* Zombie added iter 4 #14707, terminal-terminal — see PhaseSet below).
+\* Zombie added iter 4 #14707, terminal-terminal).  The set below is the full
+\* 13 — iter 77 R-4 added the missing "Zombie" (the comment had claimed it was
+\* present but the literal set listed only 12); the dwell invariant is phase-
+\* agnostic so adding it is structurally transparent, but keeping the set in
+\* sync with [type phase] prevents the spec from silently under-modelling a
+\* terminal phase.
 PhaseSet == {
     "Offline",
     "Running",
@@ -82,7 +94,8 @@ PhaseSet == {
     "Stopped",
     "Crashed",
     "Restarting",
-    "Dead"
+    "Dead",
+    "Zombie"
 }
 
 TypeOK ==


### PR DESCRIPTION
## Finding (Iteration 77, Phase R — first spec entry)

**Spec**: `specs/keeper-state-machine/KeeperDwellMonotone.tla` (159 LOC, 3 vars, bug-model paired)
**Runtime**: `lib/keeper/keeper_registry.ml` (producer — `Keeper_transition_audit.record_transition`) · `dashboard/src/components/keeper-detail-page.ts` + `keeper-detail-shell.ts` + `keeper-phase-indicator.ts` (consumer) · `dashboard/src/api/keeper.ts` (`fetchKeeperTransitions`)
**Aspect**: phase-dwell-time monotonicity invariant behind the Agent Modal "Running for 2h 20m" indicator
**Verdict**: **two real drifts, both fixed** — core `DwellNonNegative` invariant was correct throughout; the drifts are model-completeness + navigability
**Risk**: LOW-MID — drift 1 (PhaseSet) is a real spec change (TLC re-run, contract re-verified); drift 2 (impl-mapping refs) is comment-only
**Workaround signature**: N/A — this PR *removes* stale line numbers and *fills in* a missing phase; no string classifier / catch-all / cap added

## 순서도

```mermaid
stateDiagram-v2
  [*] --> Init : phase="Running", entered_at=0, now=0
  Init --> S : Tick (now' = now+1) — UNCHANGED phase, entered_at
  S --> S : Tick
  S --> S : Transition — ∃ p ∈ PhaseSet\{phase}: phase'=p ∧ entered_at'=now (UNCHANGED now)

  state "DwellNonNegative\nentered_at ≤ now" as INV
  S --> INV : checked every state

  note right of S
    PhaseSet now = 13 (iter 77 R-4 added "Zombie" — matches keeper_state_machine.ml type phase).
    Clean cfg: no error (273 distinct states, depth 8, max outdegree 13 = 12 other phases + 1 tick).
    Buggy cfg (BuggyEntryInFuture: entered_at' = now+1): DwellNonNegative violated,
              counterexample now=1, phase="Running", entered_at=2.
    Producer: keeper_registry.ml — Keeper_transition_audit.record_transition { ...; wall_clock_at_decision = now; ... }
    Consumer: keeper-detail-page.ts phaseEnteredAtSec ← fetchKeeperTransitions (dashboard/src/api/keeper.ts)
              → keeper-detail-shell.ts → KeeperPhaseAndStage
    Defense:  keeper-phase-indicator.ts dwellText = ... formatDuration(Math.max(0, Date.now()/1000 - phaseEnteredAtSec))
  end note
```

## Drift 1 — `PhaseSet` missing `"Zombie"` (sub-class 2: drift)

`keeper_state_machine.ml:6-19` has **13** `type phase` constructors (`... | Dead | Zombie`). The spec's `PhaseSet` literal listed only the first **12** — `"Zombie"` absent — despite the comment above it saying *"13-phase FSM ... Zombie added iter 4 #14707, terminal-terminal — see PhaseSet below"*. The comment was right; the set was stale. `DwellNonNegative` is phase-agnostic so the safety result is unaffected, but `TypeOK` excluded `phase = "Zombie"` and `Transition` never explored it — the spec silently under-modelled a terminal phase.

**Fix**: added `"Zombie"` to `PhaseSet`; updated the comment to record the iter 77 R-4 correction. **TLC re-run** (this PR):
- Clean `KeeperDwellMonotone.cfg`: `Model checking completed. No error has been found.` — 3472 states / 273 distinct / depth 8 / max outdegree **13** (= 12 other phases + tick). ✓
- Buggy `KeeperDwellMonotone-buggy.cfg`: `DwellNonNegative` violated — counterexample `now=1, phase="Running", entered_at=2`. ✓

## Drift 2 — `Implementation mapping` block stale on all three sites (sub-class 8: line-reference drift)

| Spec citation (as written) | Reality 2026-05-12 | Fix |
|---|---|---|
| `keeper_registry.ml:919` — `Keeper_transition_audit.record_transition { ...; wall_clock_at_decision = now; ... }` | `wall_clock_at_decision = now` is at **~line 2577**; line 919 is `let packed_compaction_stage_label` (unrelated). Drift **+1658** | symbol anchor, no line number |
| `keeper-detail.ts:1167-1168` — `useState<number\|null>(null)` for `phaseEnteredAtSec` from `fetchKeeperTransitions(...).transitions[0].wall_clock_at_decision` | `keeper-detail.ts` is now a **15-line shim**; the `useState` moved to **`keeper-detail-page.ts`**, sourced from `fetchKeeperTransitions` in **`dashboard/src/api/keeper.ts`**, threaded via `keeper-detail-shell.ts` into `KeeperPhaseAndStage` | re-pointed to the three current files, no line numbers |
| `keeper-phase-indicator.ts:113` — `formatDuration(Math.max(0, Date.now()/1000 - phaseEnteredAtSec))` | now line **114**, restructured into a `dwellText` const guarded by `typeof phaseEnteredAtSec === 'number' && Number.isFinite(...)`; clamp body unchanged | cite the `dwellText` expression, no line number |

The clamp *behaviour* is intact; only the citations rotted. (This is the first audited spec where a *frontend* component refactor — split into `*-page.ts` / `*-shell.ts` — invalidated a spec citation; the line-ref drift class isn't OCaml-only.)

## Before / After (spec)

```diff
 \* RFC-0002 13-phase FSM (keeper_state_machine.ml: type phase, 13 constructors;
-\* Zombie added iter 4 #14707, terminal-terminal — see PhaseSet below).
+\* Zombie added iter 4 #14707, terminal-terminal).  The set below is the full
+\* 13 — iter 77 R-4 added the missing "Zombie" (the comment had claimed it was
+\* present but the literal set listed only 12); ...
 PhaseSet == {
     "Offline", ..., "Restarting",
-    "Dead"
+    "Dead",
+    "Zombie"
 }
```
```diff
-\*   Producer side ...
-\*     lib/keeper/keeper_registry.ml:919
-\*       Keeper_transition_audit.record_transition { ...; wall_clock_at_decision = now; ... }
+\*   Producer side ...
+\*     lib/keeper/keeper_registry.ml — the
+\*       Keeper_transition_audit.record_transition { ...; wall_clock_at_decision = now; ... }
+\*     record built at each transition apply. ...
-\*   Consumer side ...
-\*     dashboard/src/components/keeper-detail.ts:1167-1168
-\*       const [phaseEnteredAtSec, ...] = useState<number | null>(null)
+\*   Consumer side ...
+\*     dashboard/src/components/keeper-detail-page.ts holds
+\*       const [phaseEnteredAtSec, setPhaseEnteredAtSec] = useState<number | null>(null)
+\*     sourced from fetchKeeperTransitions(...) (dashboard/src/api/keeper.ts) ... threads it
+\*     through keeper-detail-shell.ts into KeeperPhaseAndStage.
-\*   Defense in depth ...
-\*     dashboard/src/components/keeper-phase-indicator.ts:113
-\*       formatDuration(Math.max(0, Date.now()/1000 - phaseEnteredAtSec))
+\*   Defense in depth ...
+\*     dashboard/src/components/keeper-phase-indicator.ts computes
+\*       const dwellText = (typeof phaseEnteredAtSec === 'number' && Number.isFinite(phaseEnteredAtSec))
+\*         ? formatDuration(Math.max(0, Date.now() / 1000 - phaseEnteredAtSec)) : null
```

`specs/INDEX.md` regenerated (`scripts/gen-tla-index.sh`): KDM content-hash bump `805be4907879 → 69416fba4415`.

## 왜 톱니처럼 정교하지 않은가

두 가지:
1. `PhaseSet`가 자기 위 주석("13-phase ... see PhaseSet below")과 OCaml `type phase`(13개)에 뒤처져 12개만 나열 — terminal phase 하나(`Zombie`)를 TLC가 탐색 안 함. drift가 *주석과 본문 사이*에 끼어있어 reader가 "주석이 거짓말이네"로만 넘기기 쉬움.
2. `Implementation mapping` 블록의 3개 인용 모두 부패: producer는 +1658 drift (line 919는 무관한 `packed_compaction_stage_label`), consumer 2개는 dashboard component 리팩터(`keeper-detail.ts` → 15줄 shim, `useState`는 `keeper-detail-page.ts`로 이동)로 무효화. spec ↔ 코드 양방향 navigability가 끊겨있었음.

## 본 PR 수정

1. `KeeperDwellMonotone.tla` `PhaseSet`에 `"Zombie"` 추가 + 주석 갱신 (R-4 correction 기록). 의미 변경 → TLC clean/buggy 재실행해 Bug-Model contract 재확인.
2. `Implementation mapping` 블록 3개 인용 모두 현재 파일로 재지정 (symbol/file anchor, line number 제거 — iter 64 N-2.a 컨벤션) + dashboard 리팩터 사실 명시.
3. `specs/INDEX.md` 재생성 (generator SSOT — spec content hash 변경 반영).
4. 새 audit memo `docs/tla-audit/kdm-r4-dwell-monotone-phaseset-and-mapping-drift-2026-05-12.md`.

영향 범위: spec 1개 (의미 변경 — `PhaseSet` 13개 + 주석) + INDEX.md (생성) + 새 memo. OCaml/TS 코드 변화 없음.

## Verification

- [x] `rg "^  | [A-Z]" lib/keeper/keeper_state_machine.ml` → `type phase` has 13 constructors incl. `Zombie`
- [x] TLC clean `KeeperDwellMonotone.cfg` → `Model checking completed. No error has been found.` (273 distinct states, depth 8, max outdegree 13)
- [x] TLC buggy `KeeperDwellMonotone-buggy.cfg` → `DwellNonNegative` violated (counterexample `now=1, phase="Running", entered_at=2`)
- [x] `rg "wall_clock_at_decision" lib/keeper/keeper_registry.ml` → at line 2577 (not 919); `rg "phaseEnteredAtSec" dashboard/src/` → in `keeper-detail-page.ts:67` (`keeper-detail.ts` is a 15-line shim); `keeper-phase-indicator.ts:114` has the `Math.max(0, ...)` clamp
- [x] `bash scripts/gen-tla-index.sh > specs/INDEX.md` → only KDM-hash + timestamp/HEAD lines change
- [x] TLC artifacts cleaned (`*_TTrace_*` is gitignored; `states/` removed); `git status` → only the 3 intended files
- [x] `git diff --cached --stat` → 3 files +80/-19

## Trade-off

- 후속 PR 없음. `KeeperDwellMonotone`은 `make -C specs check-clean` runner에 이미 포함 (KNOWN_FAILURES 아님) — CI `tla-specs` job이 이 변경에 대해 TLC 재실행.
- `PhaseSet`를 다른 sibling spec들 (KeeperConditionsGovernPhase, KeeperStateMachine 등)이 어떻게 다루는지 별도 cross-spec 점검은 안 함 — iter 41 #14830이 이미 cross-spec PhaseSet 정렬 (`--check-cross-spec`)을 한 차례 했으나 그 시점 이후 `Zombie` 추가가 KDM에는 반영 안 됐던 것. 다음 새 spec entry 때 다른 spec들의 PhaseSet도 13개인지 spot-check 권장 (별도 finding).

## RFC 참조

`RFC-WAIVED: specs/keeper-state-machine/*.tla + specs/INDEX.md (generated) + docs/tla-audit/ memo only. No lib/ or dashboard/ code change. KeeperDwellMonotone.tla is not in any RFC-gated subsystem (not credential/keeper_gh/host_config, not repo_manager, not operator_control, not keeper_sandbox/shell, not dashboard credential component, not .claude/hooks, not instructions/workflow). The "Zombie" phase itself traces to RFC-0002's 13-phase FSM (already established; this PR only syncs the spec set to it).`

## 진행 추적

다음 iteration 시작점: 진행 메모리 `project_fsm_tla_loop_progress.md` 의 "Current cursor" 참조. 후보 — 새 spec entry (KeeperConditionsGovernPhase / KeeperOutcomesConservation / KeeperLaunchPending / KeeperTurnSlot 등 ~10개 미감사; KeeperConditionsGovernPhase는 PhaseSet도 가지고 있을 가능성 — Zombie 동기화 spot-check 겸) 또는 R-D-2.a+R-D-1.a 번들 (KCAF call_err 3-way + Cascade_fsm.Exhausted 2-way split, MID) 또는 KSM A-5 (22×19 update_conditions matrix).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
