### PR TITLE
docs(specs): KOC R-6 — KeeperOutcomesConservation: third bucket landed, retire stale "r always 0" note

### DIFF
--- a/docs/tla-audit/koc-r6-outcomes-conservation-third-bucket-landed-2026-05-12.md
+++ b/docs/tla-audit/koc-r6-outcomes-conservation-third-bucket-landed-2026-05-12.md
@@ -1,0 +1,38 @@
+# KOC R-6 — KeeperOutcomesConservation.tla: the third bucket landed; preamble "SCOPE DRIFT (r always 0)" note is now stale (first-entry audit, fixed)
+
+**Date**: 2026-05-12 · **Iteration**: 79 (`/loop` FSM/TLA+/OCaml drift hunt) · **Phase**: R (first entry)
+**Spec**: `specs/keeper-state-machine/KeeperOutcomesConservation.tla` (157 LOC, 4 vars, bug-model paired)
+**OCaml**: `lib/dashboard/dashboard_http_keeper.ml` — `compute_outcomes_rollup`
+**Verdict**: **model correct throughout; preamble lags the runtime (sub-class 9: spec-banner-lags-runtime), fixed comment-only**. The spec body (`successes + failures + rejected = observed_turns`, three single-bucket actions, `BuggyDoubleBucket` mutation) was *always* the right model. But the preamble's `OCaml ↔ TLA+ mapping` had drifted line numbers (`:81/:82/:89`), a stale 2-bucket form (`observed_turns = succ_turns + fail_turn`), and — most notably — a "SCOPE DRIFT" note saying *"r is always 0 ... the spec's 3-bucket law holds vacuously ... when `gate_rejected` becomes a live counter the spec invariant becomes load-bearing"*. That has happened: `fail_gate_rejected` is now a live counter, and the OCaml's own doc-comment cites `{!KeeperOutcomesConservation.tla}` with the matching 3-bucket law. Fixed: symbol-anchored the mapping, replaced "SCOPE DRIFT" with a "Runtime status (2026-05-12)" block.
+
+## What the spec is
+
+`KeeperOutcomesConservation.tla` proves `ConservationLaw == successes + failures + rejected = observed_turns` — every observed turn lands in exactly one outcome bucket, so pass-rate percentages (`successes / observed_turns`) shown in the Agent Modal's "결과 / 실패 / 검증" section are truthful. Bug model `BuggyDoubleBucket` categorises one turn into two buckets at once (bumps `successes` and `failures`, `observed_turns` only once) → `ConservationLaw` fails. TLC: clean = no error; buggy = `Invariant ConservationLaw is violated`. (Re-verified this PR — model body untouched.)
+
+## What drifted (sub-class 9: spec-banner-lags-runtime, + sub-class 8 line-refs along the way)
+
+| Preamble claim (as written) | Reality 2026-05-12 (`compute_outcomes_rollup` in `dashboard_http_keeper.ml`) | Fix |
+|---|---|---|
+| `successes` ← `succ_turns` (incr on `Turn_succeeded`) — `dashboard_http_keeper.ml:81` | `succ_turns` ref at line **74**; incr when a `completed_turn_record` has outcome `Keeper_transition_audit.Turn_substantive` (not "`Turn_succeeded`") | symbol anchor; correct outcome variant name |
+| `failures` ← `fail_turn` (incr on `Turn_failed _`) — `:82` | `fail_turn` ref at line **77**; incr on `Turn_failed` | symbol anchor |
+| `rejected` ← `gate_rejected` field — **"currently 0 — see scope drift below"** | `fail_gate_rejected` ref at line **78**; incr on `Turn_gate_rejected` (line 89). **A LIVE COUNTER** — no longer always 0. The json export emits `("gate_rejected", \`Int !fail_gate_rejected)` | symbol anchor; "NO LONGER always 0" |
+| `observed_turns` ← `succ_turns + fail_turn` — `:89` | `let observed_turns = List.length completed_turns` (line **102**) — the size of the `Keeper_transition_audit.recent_completed_turns` 50-entry ring; line 89 is `incr fail_gate_rejected)`. The three counters **partition exactly this list**, so `succ_turns + fail_turn + fail_gate_rejected = observed_turns` by construction | symbol anchor; 3-bucket form |
+| "SCOPE DRIFT ... The OCaml comment above compute_outcomes_rollup (lines 60-64) reads: 'Historical [gate_rejected] counts are not yet persisted ... the field remains 0'" | The *current* OCaml doc-comment (above `compute_outcomes_rollup`) reads: *"Conservation law (spec {!KeeperOutcomesConservation.tla}): successes.substantive_turns + failures.turn_failed + failures.gate_rejected = observed_turns holds by construction because all three turn buckets now come from the same completed-turn ring."* The "remains 0" comment is gone | replaced with "Runtime status (2026-05-12, iter 79 R-6)": the third bucket landed; conservation is load-bearing and OCaml-satisfied by construction |
+
+## Cross-checks (pass)
+
+| Spec element | Runtime | Status |
+|---|---|---|
+| `successes` / `failures` / `rejected` (each turn bumps exactly one + `observed_turns`) | `succ_turns` / `fail_turn` / `fail_gate_rejected` refs, incremented in a single `List.iter` over `completed_turns` via an exhaustive `match turn.outcome with Turn_substantive \| Turn_failed \| Turn_gate_rejected` | ✓ — exhaustive 3-way match = exactly one bucket per turn |
+| `observed_turns` = sum of the three buckets | `List.length completed_turns` — the list the three counters partition | ✓ — conservation by construction |
+| `ConservationLaw` is load-bearing (not vacuous) | `gate_rejected` is a live counter | ✓ as of this PR's preamble |
+| OCaml ↔ spec cross-ref | OCaml doc-comment cites `{!KeeperOutcomesConservation.tla}` + the matching law; spec preamble cites `dashboard_http_keeper.ml:compute_outcomes_rollup` | ✓ bidirectional |
+| `.cfg` / `-buggy.cfg` | both present | ✓ |
+| Bug-Model contract | clean = no error; buggy = `Invariant ConservationLaw is violated` — re-verified this PR | ✓ |
+| Out-of-scope counters (`succ_compactions` / `fail_compaction` / `succ_handoffs` / `fail_handoff` / `keeper_verdicts`) correctly excluded | those refs exist in `compute_outcomes_rollup` but are per-mechanism, not per-turn, and don't feed `observed_turns` | ✓ — preamble's "out-of-scope" note still accurate |
+
+## Sub-class placement & follow-up
+
+- This is **first-entry sub-class 9 (spec-banner-lags-runtime)** — the same shape as iter 68 KEQ Q-1 / iter 69 KEQ Q-2 (the spec preamble framed something as not-yet-true while the runtime had caught up). Inverse of sub-class 7 (runtime-owes-spec, e.g. KOAS M-1). The line-ref drift in the mapping table (sub-class 8) tagged along; both fixed the same way (symbol anchors).
+- No follow-up PR owed. Comment-only spec change — model body byte-identical; `specs/INDEX.md` regenerated (KOC content-hash bump `c53dded69dc1 → 7ac6ec2c5bf3`).
+- The spec is in the `make -C specs check-clean` runner (not `KNOWN_FAILURES`); CI re-checks it. The OCaml's `{!KeeperOutcomesConservation.tla}` doc-comment cross-ref means a future change to `compute_outcomes_rollup` that breaks conservation should be caught at review time *and* by running the spec's buggy cfg — exactly the workflow the old "SCOPE DRIFT" note recommended, now retrospectively confirmed.

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-12T04:13:05Z (HEAD: f0c9c06b4)
+Generated: 2026-05-12T04:25:19Z (HEAD: 3ba0899d6)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -137,7 +137,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperLaunchPending.tla | KeeperLaunchPending | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 29a782dc0677 |
 | KeeperMemoryLifecycle.tla | KeeperMemoryLifecycle | manual | 2 | 1 | clean={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} buggy={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} | 821cd485dadf |
 | KeeperOASAdvanced.tla | KeeperOASAdvanced | manual | 2 | 1 | clean={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:CommittedSideEffectsRequireContinueGate, prop:StrictStopPreemption, prop:EventualTermination} buggy={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:StrictStopPreemption, prop:EventualTermination} | 010a182b7a8b |
-| KeeperOutcomesConservation.tla | KeeperOutcomesConservation | manual | 2 | 1 | clean={inv:Safety} buggy={inv:ConservationLaw} | c53dded69dc1 |
+| KeeperOutcomesConservation.tla | KeeperOutcomesConservation | manual | 2 | 1 | clean={inv:Safety} buggy={inv:ConservationLaw} | 7ac6ec2c5bf3 |
 | KeeperPostTurnOrchestration.tla | KeeperPostTurnOrchestration | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 0c26d77292b4 |
 | KeeperReactionLiveness.tla | KeeperReactionLiveness | manual | 2 | 1 | clean={inv:Safety, prop:BoardEnqueueLeadsToReceipt, prop:VerificationLeadsToReaction, prop:GoalVerificationLeadsToResolution, prop:TaskTransitionLeadsToReceipt, prop:CursorAdvancementRequiresAck} buggy={inv:TypeOK, prop:BoardEnqueueLeadsToReceipt} | 353fe806cd4a |
 | KeeperReconcileLiveness.tla | KeeperReconcileLiveness | manual | 2 | 1 | clean={inv:TypeOK, prop:RunningClearsManualReconcile, prop:DeadIsForever, prop:StoppedIsForever, prop:RunningRequiresFiber, prop:ManualReconcileLiveness, prop:FailingRecoveryLiveness, prop:CompactingResolves, prop:HandoffResolves, prop:DrainingResolves} buggy={inv:TypeOK, prop:RunningClearsManualReconcile, prop:DeadIsForever, prop:StoppedIsForever, prop:RunningRequiresFiber, prop:ManualReconcileLiveness, prop:FailingRecoveryLiveness} | 62638a411215 |

--- a/specs/keeper-state-machine/KeeperOutcomesConservation.tla
+++ b/specs/keeper-state-machine/KeeperOutcomesConservation.tla
@@ -26,31 +26,45 @@
 \*               bumping both but observed_turns only once.
 \*               ConservationLaw MUST be violated.
 \*
-\* OCaml ↔ TLA+ mapping (see #8642 family):
+\* OCaml ↔ TLA+ mapping (see #8642 family).  Symbol-anchored, no line
+\* numbers — iter 64 N-2.a convention; the previous "lines 81/82/89"
+\* anchors had all drifted, and "observed_turns = succ_turns + fail_turn"
+\* was a stale 2-bucket form (the runtime is now 3-bucket).  All three
+\* refs live inside [compute_outcomes_rollup] in
+\* lib/dashboard/dashboard_http_keeper.ml:
 \*
-\*   spec variable     | OCaml ref / counter                         | source
-\*   ------------------+---------------------------------------------+--------
-\*   successes         | `succ_turns` (incr on Turn_succeeded)       | lib/dashboard/dashboard_http_keeper.ml:81
-\*   failures          | `fail_turn`  (incr on Turn_failed _)        | lib/dashboard/dashboard_http_keeper.ml:82
-\*   rejected          | `gate_rejected` field (currently 0 — see    | lib/dashboard/dashboard_http_keeper.ml (compute_outcomes_rollup)
-\*                     | "scope drift" below)                        |
-\*   observed_turns    | succ_turns + fail_turn                      | lib/dashboard/dashboard_http_keeper.ml:89
+\*   spec variable    | OCaml ref / counter (inside compute_outcomes_rollup)
+\*   -----------------+----------------------------------------------------
+\*   successes        | `succ_turns` ref — incr when a completed_turn_record
+\*                    | has outcome [Keeper_transition_audit.Turn_substantive]
+\*   failures         | `fail_turn` ref — incr on [Turn_failed]
+\*   rejected         | `fail_gate_rejected` ref — incr on [Turn_gate_rejected]
+\*                    | (NO LONGER always 0; see "Runtime status" below)
+\*   observed_turns   | `List.length completed_turns` — the size of the
+\*                    | [Keeper_transition_audit.recent_completed_turns]
+\*                    | 50-entry ring; the three buckets partition exactly
+\*                    | this list, so conservation holds by construction
 \*
 \* Aggregation entry point:
-\*   lib/dashboard/dashboard_http_keeper.ml:compute_outcomes_rollup
-\*   — called from the per-keeper detail JSON builder.
+\*   lib/dashboard/dashboard_http_keeper.ml — [compute_outcomes_rollup],
+\*   called from the per-keeper detail JSON builder.  Its doc-comment
+\*   cites {!KeeperOutcomesConservation.tla} and states the same law:
+\*     successes.substantive_turns + failures.turn_failed + failures.gate_rejected
+\*       = observed_turns
+\*   "holds by construction because all three turn buckets now come from
+\*    the same completed-turn ring."
 \*
-\* SCOPE DRIFT (worth knowing, NOT a spec violation):
-\*   The OCaml comment above compute_outcomes_rollup (lines 60-64) reads:
-\*     "Historical [gate_rejected] counts are not yet persisted in the
-\*      same read model, so the field remains 0 until a keeper-turn
-\*      source is added."
-\*   Today the spec's 3-bucket law (s + f + r = observed) holds vacuously
-\*   because r is always 0. When `gate_rejected` becomes a live counter
-\*   the spec invariant becomes load-bearing — the increment site for
-\*   `gate_rejected` must also bump `observed_turns`, otherwise the law
-\*   breaks. Anyone wiring the third bucket should run the spec's clean
-\*   AND buggy cfgs to confirm the wiring honours conservation.
+\* Runtime status (2026-05-12, iter 79 R-6 — supersedes the old "SCOPE
+\* DRIFT" note that said r is always 0):
+\*   The third bucket has landed.  `fail_gate_rejected` is a live counter,
+\*   incremented when a completed-turn record carries the [Turn_gate_rejected]
+\*   outcome, and `observed_turns = List.length completed_turns` counts every
+\*   record — so `gate_rejected` increments inherently bump the denominator
+\*   (they're the same list, not separate sources).  The spec's 3-bucket
+\*   ConservationLaw is therefore load-bearing now, not vacuous, and the
+\*   OCaml satisfies it by construction.  The old advice ("anyone wiring the
+\*   third bucket should run the spec's clean AND buggy cfgs") was followed —
+\*   this entry is the retrospective confirmation.
 \*
 \* Out-of-scope counters (intentionally not modelled here):
 \*   - succ_compactions / fail_compaction / succ_handoffs / fail_handoff


### PR DESCRIPTION
## Finding (Iteration 79, Phase R — first spec entry)

**Spec**: `specs/keeper-state-machine/KeeperOutcomesConservation.tla` (157 LOC, 4 vars, bug-model paired)
**OCaml**: `lib/dashboard/dashboard_http_keeper.ml` — `compute_outcomes_rollup`
**Aspect**: `successes + failures + rejected = observed_turns` — the arithmetic identity behind the Agent Modal "결과 / 실패 / 검증" pass-rate
**Verdict**: **model correct throughout; preamble lags the runtime (sub-class 9: spec-banner-lags-runtime), fixed comment-only** — the "SCOPE DRIFT (r always 0, law vacuous)" note describes a state the runtime has left
**Risk**: LOW — comment-only spec change; model body byte-identical; TLC re-run anyway (clean + buggy as expected)
**Workaround signature**: N/A — *retires* a stale "not yet wired" disclosure and symbol-anchors a drifted mapping; no string classifier / catch-all / cap added

## 순서도

```mermaid
stateDiagram-v2
  [*] --> Init : successes=0, failures=0, rejected=0, observed_turns=0
  Init --> S
  S --> S : SuccessfulTurn — successes++, observed_turns++
  S --> S : FailedTurn — failures++, observed_turns++
  S --> S : RejectedTurn — rejected++, observed_turns++

  state "ConservationLaw\nsuccesses + failures + rejected = observed_turns" as INV
  S --> INV : checked every state

  note right of S
    OCaml: compute_outcomes_rollup iterates recent_completed_turns (50-entry ring);
           match turn.outcome with Turn_substantive→succ_turns | Turn_failed→fail_turn
                                 | Turn_gate_rejected→fail_gate_rejected
           observed_turns = List.length completed_turns ⇒ the three counters partition
           exactly this list ⇒ conservation holds by construction.
           gate_rejected is now a LIVE counter — the spec's 3-bucket law is load-bearing,
           not vacuous (the old "SCOPE DRIFT (r always 0)" note is retired).
    Clean cfg: no error.  Buggy cfg (BuggyDoubleBucket: successes++ ∧ failures++ ∧ observed_turns++):
           Invariant ConservationLaw is violated.
  end note
```

## What drifted (sub-class 9: spec-banner-lags-runtime, + sub-class 8 line-refs)

| Preamble claim (as written) | Reality 2026-05-12 (`compute_outcomes_rollup` in `dashboard_http_keeper.ml`) | Fix |
|---|---|---|
| `successes` ← `succ_turns` (incr on `Turn_succeeded`) — `:81` | `succ_turns` ref at line **74**; incr when a `completed_turn_record` has outcome `Keeper_transition_audit.Turn_substantive` (not "`Turn_succeeded`") | symbol anchor + correct variant name |
| `failures` ← `fail_turn` (incr on `Turn_failed _`) — `:82` | `fail_turn` ref at line **77**; incr on `Turn_failed` | symbol anchor |
| `rejected` ← `gate_rejected` — **"currently 0 — see scope drift below"** | `fail_gate_rejected` ref at line **78**; incr on `Turn_gate_rejected` (line 89). **A LIVE COUNTER** — no longer always 0; json export emits `("gate_rejected", \`Int !fail_gate_rejected)` | symbol anchor + "NO LONGER always 0" |
| `observed_turns` ← `succ_turns + fail_turn` — `:89` | `let observed_turns = List.length completed_turns` (line **102**) — size of the `recent_completed_turns` 50-entry ring; the three counters **partition** that list; line 89 is `incr fail_gate_rejected)` | symbol anchor + 3-bucket form |
| "SCOPE DRIFT ... OCaml comment (lines 60-64): 'Historical [gate_rejected] counts are not yet persisted ... remains 0'" | The *current* OCaml doc-comment above `compute_outcomes_rollup`: *"Conservation law (spec {!KeeperOutcomesConservation.tla}): successes.substantive_turns + failures.turn_failed + failures.gate_rejected = observed_turns holds by construction because all three turn buckets now come from the same completed-turn ring."* | replaced with "Runtime status (2026-05-12, iter 79 R-6)": the third bucket landed; conservation is load-bearing and OCaml-satisfied by construction |

## Before / After (spec preamble)

```diff
-\* OCaml ↔ TLA+ mapping (see #8642 family):
-\*   successes         | `succ_turns` (incr on Turn_succeeded)       | lib/dashboard/dashboard_http_keeper.ml:81
-\*   failures          | `fail_turn`  (incr on Turn_failed _)        | lib/dashboard/dashboard_http_keeper.ml:82
-\*   rejected          | `gate_rejected` field (currently 0 — see ...) | lib/dashboard/dashboard_http_keeper.ml (compute_outcomes_rollup)
-\*   observed_turns    | succ_turns + fail_turn                      | lib/dashboard/dashboard_http_keeper.ml:89
+\* OCaml ↔ TLA+ mapping (see #8642 family).  Symbol-anchored, no line numbers
+\* — ... the previous "lines 81/82/89" anchors had all drifted, and
+\* "observed_turns = succ_turns + fail_turn" was a stale 2-bucket form ...
+\*   successes        | `succ_turns` ref — incr on outcome [Turn_substantive]
+\*   failures         | `fail_turn` ref — incr on [Turn_failed]
+\*   rejected         | `fail_gate_rejected` ref — incr on [Turn_gate_rejected] (NO LONGER always 0)
+\*   observed_turns   | `List.length completed_turns` — the recent_completed_turns 50-entry ring; the three buckets partition it ⇒ conservation by construction
-\* SCOPE DRIFT (worth knowing, NOT a spec violation):
-\*   ... Today the spec's 3-bucket law (s + f + r = observed) holds vacuously
-\*   because r is always 0. When `gate_rejected` becomes a live counter the
-\*   spec invariant becomes load-bearing ...
+\* Runtime status (2026-05-12, iter 79 R-6 — supersedes the old "SCOPE DRIFT" note):
+\*   The third bucket has landed.  `fail_gate_rejected` is a live counter ...
+\*   observed_turns = List.length completed_turns counts every record — so
+\*   gate_rejected increments inherently bump the denominator ... The spec's
+\*   3-bucket ConservationLaw is load-bearing now, not vacuous, and the OCaml
+\*   satisfies it by construction. The old advice ("run the spec's clean AND
+\*   buggy cfgs") was followed — this entry is the retrospective confirmation.
```

`specs/INDEX.md` regenerated: KOC content-hash bump `c53dded69dc1 → 7ac6ec2c5bf3`.

## 왜 톱니처럼 정교하지 않은가

이 spec의 모델 본문(`ConservationLaw == successes + failures + rejected = observed_turns`, 세 single-bucket action, `BuggyDoubleBucket` mutation)은 *처음부터* 정확했다 — 3-bucket 법칙을 이미 모델링. 부정확했던 건 *preamble*뿐: (1) `OCaml ↔ TLA+ mapping`의 line number들(`:81/:82/:89`)이 모두 drift, "observed_turns = succ_turns + fail_turn"이 stale한 2-bucket 형태; (2) "SCOPE DRIFT" 노트가 "r은 항상 0, 법칙은 vacuously 성립, gate_rejected가 live counter가 되면 load-bearing이 됨"이라 했는데 — 그 일이 이미 일어남: `fail_gate_rejected`는 live counter, `observed_turns = List.length completed_turns`가 모든 record를 세므로 gate_rejected 증분이 자동으로 분모를 올림, 그리고 `compute_outcomes_rollup`의 doc-comment가 이미 `{!KeeperOutcomesConservation.tla}`를 인용하며 같은 법칙을 명시. 즉 OCaml은 앞서갔고 spec preamble은 뒤처져 있었음 (sub-class 9: spec-banner-lags-runtime — iter 68/69 KEQ Q-1/Q-2와 같은 모양).

## 본 PR 수정

1. `KeeperOutcomesConservation.tla` preamble: `OCaml ↔ TLA+ mapping`을 symbol-anchored 3-bucket 형태로 재작성 (line number 제거 — iter 64 N-2.a 컨벤션); "SCOPE DRIFT" 블록을 "Runtime status (2026-05-12, iter 79 R-6)" 블록으로 교체 (third bucket landed, 법칙 load-bearing, OCaml이 by-construction 만족). 모델 본문 (`successes`/`failures`/`rejected`/`observed_turns` vars, `Init`, `Next`, 3 actions, `ConservationLaw`, `BuggyDoubleBucket`) byte-identical.
2. `specs/INDEX.md` 재생성 (spec content hash 변경 반영).
3. 새 audit memo `docs/tla-audit/koc-r6-outcomes-conservation-third-bucket-landed-2026-05-12.md`.

영향 범위: spec 1개 (comment-only) + INDEX.md (생성) + 새 memo. OCaml 코드 변화 없음.

## Verification

- [x] `rg "succ_turns|fail_turn|fail_gate_rejected|compute_outcomes_rollup|observed_turns" dashboard_http_keeper.ml` → `succ_turns`@74, `fail_turn`@77, `fail_gate_rejected`@78 (incr on `Turn_gate_rejected`@89), `observed_turns = List.length completed_turns`@102, `compute_outcomes_rollup`@69; json export `("gate_rejected", \`Int !fail_gate_rejected)`@180
- [x] OCaml doc-comment above `compute_outcomes_rollup` cites `{!KeeperOutcomesConservation.tla}` + the 3-bucket law (`successes.substantive_turns + failures.turn_failed + failures.gate_rejected = observed_turns`)
- [x] TLC clean `KeeperOutcomesConservation.cfg` → `Model checking completed. No error has been found.`
- [x] TLC buggy `KeeperOutcomesConservation-buggy.cfg` → `Error: Invariant ConservationLaw is violated.`
- [x] `bash scripts/gen-tla-index.sh > specs/INDEX.md` → only KOC-hash + timestamp/HEAD lines change
- [x] TLC artifacts cleaned; `git status` → only the 3 intended files; `git diff --cached --stat` → 3 files +75/-23

## Trade-off

- 후속 PR 없음. `KeeperOutcomesConservation`은 `make -C specs check-clean` runner에 포함 (KNOWN_FAILURES 아님) — CI `tla-specs` job이 재실행. OCaml↔spec 양방향 cross-ref (`compute_outcomes_rollup` ↔ `{!KeeperOutcomesConservation.tla}`)가 있으므로 향후 `compute_outcomes_rollup` 변경이 conservation을 깨면 리뷰 시 + buggy cfg로 잡힘 — 옛 "SCOPE DRIFT" 노트가 권한 workflow가 이제 retrospective하게 확인됨.
- spec 본문에 `RejectedTurn` action을 더 손볼 게 없음 — 이미 `rejected'` + `observed_turns'`를 lockstep으로 올림 (옛 노트가 우려한 "increment site for gate_rejected must also bump observed_turns"는 OCaml 측에서 `List.length`가 자동 보장; spec 측에선 처음부터 lockstep).

## RFC 참조

`RFC-WAIVED: specs/keeper-state-machine/KeeperOutcomesConservation.tla (comment-only) + specs/INDEX.md (generated) + docs/tla-audit/ memo only. No lib/ or dashboard/ code change. The spec is not in any RFC-gated subsystem (not credential/keeper_gh/host_config, not repo_manager, not operator_control, not keeper_sandbox/shell, not dashboard credential component, not .claude/hooks, not instructions/workflow). dashboard_http_keeper.ml is a read-model JSON builder, not a credential component.`

## 진행 추적

다음 iteration 시작점: 진행 메모리 `project_fsm_tla_loop_progress.md` 의 "Current cursor" 참조. 후보 — 새 spec entry (KeeperLaunchPending / KeeperTurnSlot / KeeperMemoryLifecycle / KeeperSocialModelMagenticLedger / OperatorPauseBroadcast 등 ~8개 미감사) 또는 R-D-2.a+R-D-1.a 번들 (KCAF call_err 3-way + Cascade_fsm.Exhausted 2-way split, MID) 또는 KSM A-5 (22×19 update_conditions matrix).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
