### PR TITLE
feat(activity_graph): enable warning 4 + exhaust is_generic_status (RFC-0071 §3.4)

### DIFF
--- a/lib/activity_graph/activity_graph_reducer.ml
+++ b/lib/activity_graph/activity_graph_reducer.ml
@@ -33,7 +33,10 @@ let payload_string field json =
 
 let is_generic_status = function
   | Unset | Active | Observed -> true
-  | _ -> false
+  | Offline | Spawned | Retired | Compacting | Handoff | Autonomy | Guardrail
+  | Todo | Claimed | In_progress | Done | Cancelled
+  | Posted | Discussed | Open | Resolved | Approved | Denied
+  | Running | Paused | Stopped | Finalized | Coord -> false
 
 (* Semantic weight multiplier by event kind.
    Completion events score high; routine lifecycle events score low. *)

--- a/lib/activity_graph/dune
+++ b/lib/activity_graph/dune
@@ -9,6 +9,8 @@
    activity_graph_registry
    activity_graph_reducer)
  (wrapped false)
+ ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on.
+ (flags (:standard -w +4))
  (libraries
    masc_coord
    masc_core


### PR DESCRIPTION
## 목적

RFC-0071 §3.4 Phase 5 ratchet (#14888 … #14957 후속).

## 변경

### lib/activity_graph — 1 fragile site
`activity_graph_reducer.ml` `is_generic_status` 가 `node_status` (25 ctors) 위에서 `Unset | Active | Observed -> true | _ -> false`. `_ -> false` 가 나머지 22 ctor 흡수 → fragile. 22개 명시:
\`\`\`ocaml
| Offline | Spawned | Retired | Compacting | Handoff | Autonomy | Guardrail
| Todo | Claimed | In_progress | Done | Cancelled
| Posted | Discussed | Open | Resolved | Approved | Denied
| Running | Paused | Stopped | Finalized | Coord -> false
\`\`\`
Behavior-preserving — 새 `node_status` ctor 추가 시 "generic 인가?" 컴파일러가 강제 결정.

## 검증

- \`dune build --root .\` clean (1 warning-4 error → 0)
- activity_graph tests green (11)

## 누적

| | `-w +4` sublibs |
|--|--|
| #14888 … #14957 | 33 |
| **본 PR** | **+1 (activity_graph, +1 fix)** |
| **누계** | **34** |

## Deferred
- `lib/cdal` (adversarial_eval ×4, cdal_friction_projection ×1), `lib/resilience` (confidence ×4, degradation ×2), `lib/autoresearch` (~5)
- `lib/cascade_decl` (12), `lib/coord` (35), `lib/cdal_runtime` (34)
- `lib/repo_manager` (8) — RFC-required
- `lib` (main) — codemod (RFC-0071 Phase 2)