### PR TITLE
docs(specs): KLP R-7 — symbol-anchor KeeperLaunchPending preamble (line-refs drifted +100..+1000)

### DIFF
--- a/docs/tla-audit/klp-r7-launch-pending-lineref-drift-2026-05-12.md
+++ b/docs/tla-audit/klp-r7-launch-pending-lineref-drift-2026-05-12.md
@@ -1,0 +1,44 @@
+# KLP R-7 — KeeperLaunchPending.tla: preamble line-refs drifted +100..+1000 lines; symbol-anchored (first-entry audit, fixed)
+
+**Date**: 2026-05-12 · **Iteration**: 80 (`/loop` FSM/TLA+/OCaml drift hunt) · **Phase**: R (first entry)
+**Spec**: `specs/keeper-state-machine/KeeperLaunchPending.tla` (149 LOC, 3 vars, bug-model paired)
+**OCaml**: `lib/keeper/keeper_state_machine.ml` (`derive_phase`, `update_conditions` `Fiber_started` arm, conditions json export) · `lib/keeper/keeper_registry.ml` (`register_offline`, `mark_dead`)
+**Verdict**: **model correct; preamble's ~8 line-number citations all stale (drift +100 to +1000), fixed comment-only**. The spec body (`launch_pending`/`fiber_alive`/`phase` vars, `Init`, `FiberStart`/`MarkDead`/`Done`, `FiberStartedWithoutClearing` bug action, `LaunchPendingExclusive`/`PhaseConsistent` invariants) is byte-identical and matches the runtime; TLC re-verified (clean = no error, buggy = `SafetyInvariant` violated). Only the preamble's OCaml citations had rotted — and `keeper_registry.ml` has grown ~1000 lines since they were written, so the `keeper_registry.ml:340`/`:407` anchors now point ~950-1040 lines off.
+
+## What the spec is
+
+`KeeperLaunchPending.tla` models the `launch_pending : bool` lifecycle for the 3-phase fragment `{Offline, Running, Dead}` — the `derive_phase` Offline branch (`else if c.launch_pending && not c.fiber_alive then Offline`) was the only branch without a phase-derivation spec. Key invariant: `LaunchPendingExclusive == ~(launch_pending /\ fiber_alive)` — the pre-launch flag and the alive flag are never both set. Bug action `FiberStartedWithoutClearing` sets `fiber_alive' = TRUE` but leaves `launch_pending' = TRUE` (drift: a future `update_conditions` refactor omitting the `launch_pending = false` field). The phase still resolves to Running (the Offline branch demands `~fiber_alive`), so the drift is invisible to phase consumers but visible in the conditions JSON — exactly the kind of silent observability drift the spec defends against. TLC: clean = no error; buggy = `Invariant SafetyInvariant is violated`. (Re-verified this PR.)
+
+## What drifted (sub-class 8: line-reference drift — large scale)
+
+| Spec citation (as written) | Actual location 2026-05-12 | Drift | Fix |
+|---|---|---|---|
+| `keeper_state_machine.ml:393-394` — `else if c.launch_pending && not c.fiber_alive then Offline` | line **501** (inside `derive_phase`, which starts at line 473) | **+108** | cite `derive_phase`'s `else if c.launch_pending && not c.fiber_alive then Offline` branch by name |
+| `KeeperReconcileLiveness:88-101` (sibling spec line range) | `KeeperReconcileLiveness.tla`'s `DerivePhase` is at ~lines 88-101 (still roughly there — least drifted) | ~0 | cite `KeeperReconcileLiveness's DerivePhase` by name |
+| `keeper_registry.ml:340` — `register_offline` (set `launch_pending = true`) | `let register_offline` at line **1288**, `launch_pending = true` at line **1291** | **+948** | cite `keeper_registry.ml — register_offline` by name |
+| `keeper_state_machine.ml:520` / `:518-532` — `Fiber_started` event handler | the `Fiber_started ->` arm of `update_conditions` at line **613**; the `{ c with launch_pending = false; fiber_alive = true; ... }` record at ~**627-629** | **+93..+97** | cite `update_conditions`' `Fiber_started` arm by name |
+| `keeper_registry.ml:407` / `:400-413` — Dead transition (reset both flags) | `let mark_dead` at line **1442**; `launch_pending = false` / `fiber_alive = false` at ~**1472-1473** | **+1035..+1042** | cite `keeper_registry.ml — mark_dead` by name |
+| `keeper_state_machine.ml:709` — json export of `launch_pending` | `[ "launch_pending", \`Bool c.launch_pending` at line **1204** | **+495** | cite the conditions json export `"launch_pending"` field by name |
+| `keeper_registry.ml:337-344` — `register_offline` (Init mirror) | `let register_offline` at **1288** | **+944** | symbol anchor |
+| "derive_phase priority 9 (Running)" | the Running branch is `else if fiber_alive` near the bottom of `derive_phase` — "priority 9" is approximate and brittle | n/a | cite `derive_phase`'s `fiber_alive` branch by name, no priority number |
+
+## Cross-checks (pass)
+
+| Spec element | Runtime | Status |
+|---|---|---|
+| `Init` (launch_pending=TRUE, fiber_alive=FALSE, phase=Offline) | `register_offline` builds `default_conditions` with `launch_pending = true; restart_budget_remaining = true`; `derive_phase` → `Offline` (the `launch_pending && ~fiber_alive` branch at line 501) | ✓ |
+| `FiberStart` (launch_pending'=FALSE, fiber_alive'=TRUE, phase'=Running) | `update_conditions`' `Fiber_started` arm: `{ c with launch_pending = false; fiber_alive = true; ... }`; `derive_phase` → `Running` (the `fiber_alive` branch) | ✓ |
+| `MarkDead` (launch_pending'=FALSE, fiber_alive'=FALSE, phase'=Dead) | `keeper_registry.ml`'s `mark_dead`: resets `launch_pending = false; fiber_alive = false`, phase → `Dead` | ✓ |
+| `LaunchPendingExclusive` (the two flags never both TRUE) | `update_conditions`' `Fiber_started` arm sets `launch_pending = false` *in the same record* as `fiber_alive = true` — atomic, so they're never both TRUE | ✓ — the bug action's exact failure mode is "this record drops the `launch_pending = false` field" |
+| `FiberStartedWithoutClearing` not present in runtime | the `Fiber_started` arm does set `launch_pending = false` | ✓ — runtime doesn't exhibit the modelled drift |
+| conditions JSON surfaces `launch_pending` | `[ "launch_pending", \`Bool c.launch_pending` in `keeper_state_machine.ml` (line 1204) — so the drift *would* be observable | ✓ — matches the spec's "visible to anyone reading conditions" claim |
+| `PhaseSet == {"Offline","Running","Dead"}` (3-phase projection) | disclosed in the preamble ("the full 13-phase variant is out of scope") | ✓ — like KCGP (iter 78), this is a deliberate projection, not a stale full set; no Zombie-sync needed |
+| `.cfg` / `-buggy.cfg` | both present | ✓ |
+| Bug-Model contract | clean = no error; buggy = `Invariant SafetyInvariant is violated` — re-verified this PR | ✓ |
+
+## Sub-class placement & follow-up
+
+- Drift = **sub-class 8 (line-reference drift)** — the most-drifted instance the loop has found so far (`keeper_registry.ml:407 → mark_dead@1442` is +1035 lines). Cause: `keeper_registry.ml` is one of the repo's largest files and has roughly doubled since this spec's preamble was written. Fix: every OCaml ref now cited by function/arm name (iter 64 N-2.a convention), with a top-of-preamble note recording the convention switch + drift magnitude.
+- `PhaseSet` spot-check: **clean** (3-phase projection, disclosed) — second sibling after KCGP iter 78 that came back clean. Pattern holding: only full-13-phase `PhaseSet`s need the `type phase` cross-check (KeeperDwellMonotone was the one that needed it, fixed iter 77).
+- No follow-up PR owed. Comment-only spec change — model body byte-identical; `specs/INDEX.md` regenerated (KLP content-hash bump `29a782dc0677 → b40572292792`). The spec is in the `make -C specs check-clean` runner (not `KNOWN_FAILURES`); CI re-checks it.
+- **Note on the line-ref drift class going forward**: KeeperLaunchPending, KeeperDwellMonotone (iter 77), KeeperConditionsGovernPhase (iter 78), KeeperOutcomesConservation (iter 79) — four consecutive first-entry audits, all found stale line numbers in the preamble. The pattern is now empirically: *any spec preamble older than ~iter 64 that cites `keeper_state_machine.ml:NNN` or `keeper_registry.ml:NNN` should be assumed drifted.* A bulk sweep (grep `specs/keeper-state-machine/*.tla` for `\.ml:[0-9]` and symbol-anchor all hits in one PR) is a candidate follow-up if the per-spec rate stays this high.

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-12T04:36:12Z (HEAD: 01445195f)
+Generated: 2026-05-12T04:38:38Z (HEAD: ca512f313)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -134,7 +134,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperEventQueue.tla | KeeperEventQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | c2c464472dca |
 | KeeperGenerationLineage.tla | KeeperGenerationLineage | manual | 2 | 1 | clean={inv:TypeOK, inv:CurrentTraceIsolation, inv:GenerationMatchesHistory, inv:CurrentTraceNotInHistory, inv:TraceHistoryUnique, inv:TraceIdsAllocated, inv:IdleCheckpointMatchesCommittedLineage, prop:HandoffEventuallyResolves} buggy={inv:TypeOK, inv:GenerationMatchesHistory, inv:CurrentTraceNotInHistory, inv:TraceHistoryUnique, inv:TraceIdsAllocated, inv:IdleCheckpointMatchesCommittedLineage} | bc957a36caf6 |
 | KeeperHeartbeat.tla | KeeperHeartbeat | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 35344ff2f4be |
-| KeeperLaunchPending.tla | KeeperLaunchPending | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 29a782dc0677 |
+| KeeperLaunchPending.tla | KeeperLaunchPending | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | b40572292792 |
 | KeeperMemoryLifecycle.tla | KeeperMemoryLifecycle | manual | 2 | 1 | clean={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} buggy={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} | 821cd485dadf |
 | KeeperOASAdvanced.tla | KeeperOASAdvanced | manual | 2 | 1 | clean={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:CommittedSideEffectsRequireContinueGate, prop:StrictStopPreemption, prop:EventualTermination} buggy={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:StrictStopPreemption, prop:EventualTermination} | 010a182b7a8b |
 | KeeperOutcomesConservation.tla | KeeperOutcomesConservation | manual | 2 | 1 | clean={inv:Safety} buggy={inv:ConservationLaw} | 7ac6ec2c5bf3 |

--- a/specs/keeper-state-machine/KeeperLaunchPending.tla
+++ b/specs/keeper-state-machine/KeeperLaunchPending.tla
@@ -1,28 +1,36 @@
 ---- MODULE KeeperLaunchPending ----
-\* Pre-launch lifecycle for `lib/keeper/keeper_state_machine.ml` priority 2
-\* (Offline branch).  This spec closes Note A drift identified during
-\* Cycle 24 / Tier C1 Phase 0:
+\* Pre-launch lifecycle for `lib/keeper/keeper_state_machine.ml`'s Offline
+\* branch.  This spec closes Note A drift identified during Cycle 24 /
+\* Tier C1 Phase 0:
 \*
-\*   keeper_state_machine.ml:393-394
+\*   keeper_state_machine.ml — derive_phase's
 \*     `else if c.launch_pending && not c.fiber_alive then Offline`
+\*     branch (the Offline branch, low priority — it only fires when
+\*     no higher-priority condition holds)
 \*
 \*   was the only `derive_phase` branch lacking a phase-derivation
-\*   spec.  Sibling specs (KeeperReconcileLiveness:88-101,
+\*   spec.  Sibling specs (KeeperReconcileLiveness's DerivePhase,
 \*   KeeperConditionsGovernPhase, KeeperCompactionLifecycle, ...)
 \*   together cover every other priority.  This spec fills that gap.
 \*
+\* All OCaml refs below are cited by function/arm name, not line number
+\* — iter 64 N-2.a convention; the preamble's previous line anchors had
+\* drifted by +100..+1000 lines (keeper_registry.ml had grown ~1k lines).
+\* See docs/tla-audit/klp-r7-launch-pending-lineref-drift-2026-05-12.md
+\*
 \* Runtime entities modelled (lifecycle of `launch_pending : bool`):
 \*
-\*   Set TRUE  : keeper_registry.ml:340 (register_offline)
-\*               — invoked at keeper registration *before* the fiber
-\*                 has been spawned.  Pairs with
-\*                 restart_budget_remaining = TRUE.
+\*   Set TRUE  : keeper_registry.ml — register_offline (the
+\*               default_conditions record with launch_pending = true).
+\*               Invoked at keeper registration *before* the fiber has
+\*               been spawned.  Pairs with restart_budget_remaining = TRUE.
 \*   Clear FALSE
-\*     in FSM  : keeper_state_machine.ml:520 (Fiber_started event)
-\*               — fiber has actually started; pre-launch is no longer
-\*                 pending.
-\*     on death: keeper_registry.ml:407 (Dead transition)
-\*               — keeper is permanently dead, all flags reset.
+\*     in FSM  : keeper_state_machine.ml — update_conditions' Fiber_started
+\*               arm (`{ c with launch_pending = false; fiber_alive = true; ... }`).
+\*               Fiber has actually started; pre-launch is no longer pending.
+\*     on death: keeper_registry.ml — mark_dead (resets
+\*               launch_pending = false; fiber_alive = false).  Keeper is
+\*               permanently dead, all flags reset.
 \*
 \* Scope projection: this spec models only the launch_pending /
 \* fiber_alive / phase relationship for the 3-phase fragment
@@ -37,10 +45,11 @@
 \*   `update_conditions` for the `Fiber_started` event omits the
 \*   `launch_pending = false` field.  The visible symptom is a
 \*   keeper that runs *and* reports launch_pending=true in JSON,
-\*   confusing supervisors (per keeper_registry.ml polls).  Phase
-\*   would still resolve to Running because priority 2 only fires
-\*   when fiber_alive=FALSE — so the drift is silent unless caught
-\*   here.
+\*   confusing supervisors (per keeper_registry.ml polls; the
+\*   conditions json export `"launch_pending", \`Bool c.launch_pending`
+\*   in keeper_state_machine.ml surfaces it).  Phase would still
+\*   resolve to Running because the Offline branch only fires when
+\*   fiber_alive=FALSE — so the drift is silent unless caught here.
 \*
 \* Bug-Model contract (CLAUDE.md software-development.md):
 \*   Spec      under KeeperLaunchPending.cfg       => TLC: no error.
@@ -64,7 +73,7 @@ TypeOK ==
     /\ fiber_alive    \in BOOLEAN
     /\ phase          \in PhaseSet
 
-\* Init mirrors keeper_registry.ml:337-344 register_offline:
+\* Init mirrors keeper_registry.ml's register_offline:
 \*   default_conditions {launch_pending = true; restart_budget_remaining = true}
 \*   derive_phase -> Offline.
 Init ==
@@ -74,10 +83,10 @@ Init ==
 
 \* ── Honest actions ─────────────────────────────────────────────
 
-\* keeper_state_machine.ml:518-532 Fiber_started event handler.
+\* keeper_state_machine.ml's update_conditions Fiber_started arm.
 \* Resets launch_pending and sets fiber_alive simultaneously.
-\* derive_phase priority 9 (Running) fires once both flags are
-\* updated.
+\* derive_phase's `fiber_alive` branch (Running) fires once both
+\* flags are updated.
 FiberStart ==
     /\ launch_pending = TRUE
     /\ fiber_alive    = FALSE
@@ -85,8 +94,8 @@ FiberStart ==
     /\ fiber_alive'    = TRUE
     /\ phase'          = "Running"
 
-\* keeper_registry.ml:400-413 Dead transition.  Resets both flags
-\* and lands phase on Dead.  Modelled from any non-terminal state.
+\* keeper_registry.ml's mark_dead.  Resets both flags and lands
+\* phase on Dead.  Modelled from any non-terminal state.
 MarkDead ==
     /\ phase /= "Dead"
     /\ launch_pending' = FALSE
@@ -104,11 +113,12 @@ Done ==
 
 \* The fiber starts but the launch_pending flag is forgotten.
 \* Keeper would now report fiber_alive=TRUE *and* launch_pending=TRUE
-\* — a drift the json export at keeper_state_machine.ml:709 would
-\* surface as a confusing observability signal.  Critically,
-\* derive_phase still routes to Running (priority 9) because
-\* priority 2 demands ~fiber_alive — so the drift is invisible to
-\* phase consumers but visible to anyone reading conditions.
+\* — a drift the conditions json export
+\* (`"launch_pending", \`Bool c.launch_pending` in keeper_state_machine.ml)
+\* would surface as a confusing observability signal.  Critically,
+\* derive_phase still routes to Running (its `fiber_alive` branch)
+\* because the Offline branch demands ~fiber_alive — so the drift is
+\* invisible to phase consumers but visible to anyone reading conditions.
 FiberStartedWithoutClearing ==
     /\ launch_pending = TRUE
     /\ fiber_alive    = FALSE


### PR DESCRIPTION
## Finding (Iteration 80, Phase R — first spec entry)

**Spec**: `specs/keeper-state-machine/KeeperLaunchPending.tla` (149 LOC, 3 vars, bug-model paired)
**Runtime**: `lib/keeper/keeper_state_machine.ml` (`derive_phase` Offline branch, `update_conditions` `Fiber_started` arm, conditions json export) · `lib/keeper/keeper_registry.ml` (`register_offline`, `mark_dead`)
**Aspect**: `launch_pending : bool` lifecycle — `~(launch_pending /\ fiber_alive)`, the pre-launch/alive exclusivity behind the `derive_phase` Offline branch
**Verdict**: **model correct; preamble's ~8 line-number citations all stale (drift +100 to +1000), fixed comment-only** — `keeper_registry.ml` has grown ~1k lines since the preamble was written
**Risk**: LOW — comment-only spec change; model body byte-identical; TLC re-run anyway (clean + buggy as expected)
**Workaround signature**: N/A — *removes* stale line numbers, switches to symbol anchors; no string classifier / catch-all / cap added

## 순서도

```mermaid
stateDiagram-v2
  [*] --> Offline : launch_pending=TRUE, fiber_alive=FALSE  (register_offline default_conditions)
  Offline --> Running : FiberStart — launch_pending'=FALSE ∧ fiber_alive'=TRUE  (update_conditions Fiber_started arm)
  Offline --> Dead : MarkDead — launch_pending'=FALSE ∧ fiber_alive'=FALSE  (mark_dead)
  Running --> Dead : MarkDead
  Running --> Running : Done (stutter)
  Dead --> Dead : Done (stutter)

  state "LaunchPendingExclusive\n~(launch_pending ∧ fiber_alive)" as INV
  Running --> INV : checked every state

  note right of Running
    Bug action (SpecBuggy only) FiberStartedWithoutClearing:
      launch_pending'=TRUE (drift — should be FALSE) ∧ fiber_alive'=TRUE ∧ phase'=Running
    → LaunchPendingExclusive violated. Phase still resolves to Running (the derive_phase
      Offline branch demands ~fiber_alive) — drift invisible to phase consumers, visible in
      the conditions json export `"launch_pending", `Bool c.launch_pending`.
    Clean cfg: no error.  Buggy cfg: Invariant SafetyInvariant is violated.
  end note
```

## What drifted (sub-class 8: line-reference drift — largest instance the loop has found)

| Spec citation (as written) | Actual location 2026-05-12 | Drift | Fix |
|---|---|---|---|
| `keeper_state_machine.ml:393-394` — `else if c.launch_pending && not c.fiber_alive then Offline` | line **501** (in `derive_phase`, which starts at line 473) | **+108** | cite `derive_phase`'s Offline branch by name |
| `KeeperReconcileLiveness:88-101` (sibling line range) | `KeeperReconcileLiveness.tla`'s `DerivePhase` ~lines 88-101 (least drifted) | ~0 | cite `KeeperReconcileLiveness's DerivePhase` by name |
| `keeper_registry.ml:340` — `register_offline` (set `launch_pending = true`) | `let register_offline`@**1288**, `launch_pending = true`@**1291** | **+948** | symbol anchor |
| `keeper_state_machine.ml:520` / `:518-532` — `Fiber_started` handler | the `Fiber_started ->` arm of `update_conditions`@**613**, the `{ c with launch_pending = false; fiber_alive = true; ... }` record ~**627-629** | **+93..+97** | cite `update_conditions`' `Fiber_started` arm by name |
| `keeper_registry.ml:407` / `:400-413` — Dead transition | `let mark_dead`@**1442**, flag resets ~**1472-1473** | **+1035..+1042** | cite `keeper_registry.ml — mark_dead` by name |
| `keeper_state_machine.ml:709` — `launch_pending` json export | `[ "launch_pending", \`Bool c.launch_pending`@**1204** | **+495** | cite the conditions json export `"launch_pending"` field by name |
| `keeper_registry.ml:337-344` — `register_offline` (Init mirror) | `let register_offline`@**1288** | **+944** | symbol anchor |
| "derive_phase priority 9 (Running)" | the Running branch (`else if fiber_alive`) near the bottom of `derive_phase` — priority number is brittle | n/a | cite `derive_phase`'s `fiber_alive` branch by name, no number |

## Before / After (spec preamble — excerpt)

```diff
-\* Pre-launch lifecycle for `lib/keeper/keeper_state_machine.ml` priority 2
-\* (Offline branch). ...
-\*   keeper_state_machine.ml:393-394
-\*     `else if c.launch_pending && not c.fiber_alive then Offline`
+\* Pre-launch lifecycle for `lib/keeper/keeper_state_machine.ml`'s Offline branch. ...
+\*   keeper_state_machine.ml — derive_phase's
+\*     `else if c.launch_pending && not c.fiber_alive then Offline`
+\*     branch (the Offline branch, low priority ...)
+\* All OCaml refs below are cited by function/arm name, not line number
+\* — iter 64 N-2.a convention; the preamble's previous line anchors had
+\* drifted by +100..+1000 lines (keeper_registry.ml had grown ~1k lines).
-\*   Set TRUE  : keeper_registry.ml:340 (register_offline) ...
-\*     in FSM  : keeper_state_machine.ml:520 (Fiber_started event) ...
-\*     on death: keeper_registry.ml:407 (Dead transition) ...
+\*   Set TRUE  : keeper_registry.ml — register_offline (the default_conditions
+\*               record with launch_pending = true). ...
+\*     in FSM  : keeper_state_machine.ml — update_conditions' Fiber_started arm
+\*               (`{ c with launch_pending = false; fiber_alive = true; ... }`). ...
+\*     on death: keeper_registry.ml — mark_dead (resets launch_pending = false; fiber_alive = false). ...
```
(Plus the inline action-comment refs: `Init` "mirrors keeper_registry.ml:337-344" → "mirrors keeper_registry.ml's register_offline"; `FiberStart` "keeper_state_machine.ml:518-532 Fiber_started event handler" → "keeper_state_machine.ml's update_conditions Fiber_started arm"; `MarkDead` "keeper_registry.ml:400-413 Dead transition" → "keeper_registry.ml's mark_dead"; `FiberStartedWithoutClearing` "json export at keeper_state_machine.ml:709" → "the conditions json export `\"launch_pending\", `Bool c.launch_pending` in keeper_state_machine.ml".)

`specs/INDEX.md` regenerated: KLP content-hash bump `29a782dc0677 → b40572292792`.

## 왜 톱니처럼 정교하지 않은가

`KeeperLaunchPending.tla`의 모델 본문 (`launch_pending`/`fiber_alive`/`phase` vars, `Init`, `FiberStart`/`MarkDead`/`Done`, `FiberStartedWithoutClearing` bug action, `LaunchPendingExclusive`/`PhaseConsistent` invariants) 은 byte-identical하고 런타임과 일치 — TLC clean = no error, buggy = `SafetyInvariant` violated. 부패한 건 preamble의 line-number 인용 ~8개뿐: `keeper_state_machine.ml:393-394` (실제 501, +108), `keeper_registry.ml:340` (실제 1288, +948), `keeper_registry.ml:407` (실제 mark_dead@1442, +1035), `keeper_state_machine.ml:709` (실제 1204, +495) 등. 원인은 `keeper_registry.ml`이 이 preamble 작성 후 ~1000줄 늘어난 것 — 한 번 박은 line number는 파일이 자라면 그만큼 부패한다. 이번 iter 77~80 연속 4번의 first-entry 감사 모두 같은 패턴 (preamble line-ref drift) 발견. 해결: 모든 OCaml ref를 function/arm 이름으로 인용 (iter 64 N-2.a 컨벤션) + preamble 상단에 컨벤션 전환 + drift 규모 노트.

## 본 PR 수정

1. `KeeperLaunchPending.tla` preamble: header / "Runtime entities modelled" / `Init`·`FiberStart`·`MarkDead`·`FiberStartedWithoutClearing` action 코멘트의 모든 line-ref를 symbol/function anchor로 재작성 + 상단에 컨벤션 전환 노트. "derive_phase priority 9" 같은 brittle priority number도 제거 (branch 이름으로). 모델 본문 (vars/Init/actions/invariants/Spec/SpecBuggy) byte-identical.
2. `specs/INDEX.md` 재생성 (spec content hash 변경 반영).
3. 새 audit memo `docs/tla-audit/klp-r7-launch-pending-lineref-drift-2026-05-12.md` (8개 drift 표 + cross-check + line-ref drift class 누적 관찰 + bulk-sweep 후보 제안).

영향 범위: spec 1개 (comment-only) + INDEX.md (생성) + 새 memo. OCaml 코드 변화 없음.

## Verification

- [x] `rg "launch_pending.*fiber_alive.*Offline" keeper_state_machine.ml` → line 501 (`derive_phase`@473); `rg "register_offline|mark_dead" keeper_registry.ml` → `register_offline`@1288 (`launch_pending = true`@1291), `mark_dead`@1442 (flag resets ~1472-73); `Fiber_started ->` arm of `update_conditions`@613 (`{ c with launch_pending = false; fiber_alive = true; ... }`@627-29); `[ "launch_pending", \`Bool c.launch_pending`@1204
- [x] TLC clean `KeeperLaunchPending.cfg` → `Model checking completed. No error has been found.`
- [x] TLC buggy `KeeperLaunchPending-buggy.cfg` → `Error: Invariant SafetyInvariant is violated.`
- [x] `bash scripts/gen-tla-index.sh > specs/INDEX.md` → only KLP-hash + timestamp/HEAD lines change
- [x] TLC artifacts cleaned; `git status` → only the 3 intended files; `git diff --cached --stat` → 3 files +85/-31

## Trade-off

- 후속 PR 없음 직접적으로는. 단 **bulk-sweep 후보** 제안: iter 77~80 연속 4번의 first-entry 감사 모두 preamble line-ref drift 발견 — `specs/keeper-state-machine/*.tla`에서 `\.ml:[0-9]` grep해 남은 hit들을 한 PR에서 symbol-anchor하는 게 per-spec rate가 이대로면 효율적 (memo에 기록).
- `KeeperLaunchPending`은 `make -C specs check-clean` runner에 포함 (KNOWN_FAILURES 아님) — CI `tla-specs` job이 재실행.
- `PhaseSet == {"Offline","Running","Dead"}` spot-check: clean (3-phase projection, disclosed — KCGP iter 78에 이어 2번째 clean projection). 13-phase full set spec만 `type phase` cross-check 필요.

## RFC 참조

`RFC-WAIVED: specs/keeper-state-machine/KeeperLaunchPending.tla (comment-only) + specs/INDEX.md (generated) + docs/tla-audit/ memo only. No lib/ code change. The spec is not in any RFC-gated subsystem (not credential/keeper_gh/host_config, not repo_manager, not operator_control, not keeper_sandbox/shell, not dashboard credential component, not .claude/hooks, not instructions/workflow).`

## 진행 추적

다음 iteration 시작점: 진행 메모리 `project_fsm_tla_loop_progress.md` 의 "Current cursor" 참조. 후보 — 새 spec entry (KeeperTurnSlot / KeeperMemoryLifecycle / KeeperSocialModelMagenticLedger / OperatorPauseBroadcast 등 ~7개 미감사) 또는 **bulk line-ref sweep** (`*.tla`의 `\.ml:[0-9]` 일괄 symbol-anchor — iter 77~80이 4연속 같은 drift 발견했으므로 검토 가치 ↑) 또는 R-D-2.a+R-D-1.a 번들 (KCAF call_err 3-way + Cascade_fsm.Exhausted 2-way split, MID) 또는 KSM A-5 (22×19 update_conditions matrix).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
