### PR TITLE
docs(specs): KML R-8 — symbol-anchor KeeperMemoryLifecycle horizon refs + line-ref drift class survey

### DIFF
--- a/docs/tla-audit/kml-r8-memory-lifecycle-lineref-drift-2026-05-12.md
+++ b/docs/tla-audit/kml-r8-memory-lifecycle-lineref-drift-2026-05-12.md
@@ -1,0 +1,44 @@
+# KML R-8 — KeeperMemoryLifecycle.tla: horizon-constant line-refs drifted +46; symbol-anchored (first-entry audit, fixed) + line-ref drift class survey
+
+**Date**: 2026-05-12 · **Iteration**: 81 (`/loop` FSM/TLA+/OCaml drift hunt) · **Phase**: R (first entry)
+**Spec**: `specs/keeper-state-machine/KeeperMemoryLifecycle.tla` (265 LOC, bug-model paired)
+**OCaml**: `lib/keeper/keeper_memory_policy.ml` (`short_term_horizon` / `mid_term_horizon` / `long_term_horizon` constants) · `keeper_memory_bank.ml` / `keeper_memory_recall.ml` (symbol-anchored already, accurate)
+**Verdict**: **model correct; the 4 `keeper_memory_policy.ml:155-157` citations drifted +46 (the horizon constants are now ~line 201-203), symbol-anchored comment-only**. Everything else in the preamble is already symbol-anchored (`memory_horizon_of_kind_opt`, `memory_horizon_of_kind`, `memory_horizon_of_json_opt`, the persistence sites) and accurate. TLC re-verified (clean = no error; buggy = invariant violated).
+
+## What the spec is
+
+`KeeperMemoryLifecycle.tla` models the short/mid/long memory tiers across note capture, overflow compaction, and generation handoff. Safety goals: provenance on every persisted note, no silent drop on overflow/handoff, handoff clears stale short-term notes, each tier within its bound. Bug model `BuggyCompactOverflow` trims the short tier without promoting to mid → dropped notes accumulate in `lost_notes`. TLC: clean = no error; buggy = invariant violated (`TypeOK` fires first in the buggy cfg's invariant list `{TypeOK, ProvenanceRequired, NoSilentLoss, RecoveryBounded, HandoffLeavesNoStaleShort}` — see "pre-existing observation" below).
+
+## What drifted (sub-class 8: line-reference drift)
+
+| Spec citation (×4 occurrences) | Actual location 2026-05-12 | Drift | Fix |
+|---|---|---|---|
+| `lib/keeper/keeper_memory_policy.ml:155` — `short_mem` ↔ `horizon = "short_term"` (mapping table) | `let short_term_horizon = "short_term"` at line **201** | **+46** | `lib/keeper/keeper_memory_policy.ml — \`short_term_horizon\`` |
+| `lib/keeper/keeper_memory_policy.ml:156` — `mid_mem` | `let mid_term_horizon = "mid_term"` at line **202** | **+46** | `— \`mid_term_horizon\`` |
+| `lib/keeper/keeper_memory_policy.ml:157` — `long_mem` | `let long_term_horizon = "long_term"` at line **203** | **+46** | `— \`long_term_horizon\`` |
+| `lib/keeper/keeper_memory_policy.ml:155-157` — "Tier vocabulary" block header (followed by the three `let ... = "..."` lines verbatim) | constants at lines 201-203 | **+46** | drop the `:155-157`; the block already lists the `let` definitions verbatim, so "the horizon string constants in lib/keeper/keeper_memory_policy.ml" suffices |
+
+The rest of the preamble's OCaml refs were already symbol-anchored and verified accurate:
+- `memory_horizon_of_kind_opt` (strict, line 207), `memory_horizon_of_kind` (back-compat wrapper, line 218 — still has `| None -> mid_term_horizon`), `memory_horizon_of_json_opt` (line 230) — all by name ✓
+- `keeper_memory_bank.ml:append_memory_notes_from_reply`, `keeper_memory_recall.ml:read_recent_memory_texts`, `keeper_compact_policy.ml`, `keeper_compact_audit.ml` — by name/file ✓
+- The "SCOPE DRIFT" note (`memory_horizon_of_kind` routes unknown kinds to `mid_term_horizon` via `| None -> mid_term_horizon`; tracked for the `#8605` strict-`_opt`-plus-warn-wrapper template) — still accurate (the wrapper still defaults; the strict `_opt` exists, the wrapper still doesn't reject) ✓
+
+## Line-ref drift class — survey across the spec corpus (the reason this iteration was a "sweep candidate")
+
+iters 77→80 found four consecutive first-entry audits with stale preamble line numbers (KDM, KCGP, KOC, KLP). A `rg '\.ml:[0-9]' specs/keeper-state-machine/*.tla` shows the citation style appears in **~12 spec files, ~50+ hits**. But not all are drifted:
+
+- **Stable** (top-of-file refs that don't move): `KeeperCompactionLifecycle.tla:18-21` cites `keeper_state_machine.ml:8/10/11/14` for the `type phase` constructors `Running`/`Overflowed`/`Compacting`/`Paused` — and `type phase` *is* at lines 6-19 of `keeper_state_machine.ml`, so `Running` is genuinely at line 8, etc. Refs to a type declaration at the very top of a file don't rot.
+- **Drifted** (refs into functions deep in growing files): the ones the loop has been fixing — `keeper_registry.ml:NNN` (file grew ~1k lines → KLP iter 80 drifts up to +1035), `keeper_memory_policy.ml:155-157` (this PR, +46), `keeper_run_tools.ml:NNN` (KeeperToolSurface — ~15 hits, lines 794-1011 cited — probably drifted), `keeper_post_turn.ml:NNN` (KeeperPostTurnOrchestration — ~8 hits), `keeper_unified_turn.ml:318/1640`, `keeper_state_machine.ml:402-408/754-758`, `keeper_registry.ml:63-68/70-74/76-81` (the 3-axis type defs — cited by 4 specs: KeeperCascadeLifecycle, KeeperDecisionPipeline, KeeperTurnCycle — these are mid-file type defs, likely drifted), `keeper_social_model_magentic_ledger_v1.ml:204`, `keeper_composite_observer.ml:25-32`.
+
+**Recommendation** (not done here — too large for one 10-min PR, and a pure "ban `\.ml:[0-9]`" lint would be the string-classifier workaround pattern):
+1. **Extend the existing validator** `scripts/audit-tla-ml-line-refs.sh` (iter 64 #14925, currently handles `[funcname]...line N`) to also resolve the `<file>:<line>` citation form and warn on drift > tolerance. This *resolves* the ref (the right structural fix — it tells you the true line) rather than banning the syntax. The validator already has the OCaml-file-resolution machinery; the new patterns are `\b\w+\.ml:[0-9]+` and `\b\w+\.ml:[0-9]+-[0-9]+`.
+2. **Per-spec symbol-anchor PRs**, prioritized by drift magnitude — KeeperToolSurface (~15 hits) and the 3-axis-type-def trio (KeeperCascadeLifecycle/KeeperDecisionPipeline/KeeperTurnCycle, shared `keeper_registry.ml:63-81` refs) are the biggest remaining clusters.
+
+## Pre-existing observation (not fixed here — out of scope)
+
+The `KeeperMemoryLifecycle-buggy.cfg` invariant list puts `TypeOK` first, so TLC reports `TypeOK is violated` rather than the *intended* `NoSilentLoss` (the spec preamble says "NoSilentLoss MUST be violated"). A well-formed buggy cfg often omits `TypeOK` so the demonstrated violation is the property the spec exists to defend. This is pre-existing (not introduced by this comment-only PR) and is a candidate follow-up: drop `TypeOK` from the buggy cfg (or confirm the bug action genuinely produces a malformed state, in which case keep it but note why). Out of scope for a line-ref-drift fix.
+
+## Sub-class placement & follow-up
+
+- Drift = **sub-class 8 (line-reference drift)** — fifth consecutive first-entry audit to hit it. Fix: symbol anchors + a top-of-mapping note recording the convention switch and drift magnitude.
+- No follow-up PR owed for *this* spec. The corpus-wide follow-ups are the two recommendations above (extend the validator; per-spec symbol-anchor PRs for the biggest remaining clusters). Comment-only spec change — model body byte-identical; `specs/INDEX.md` regenerated (KML content-hash bump `821cd485dadf → aacf99ece735`). The spec is in the `make -C specs check-clean` runner; CI re-checks it.

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-12T04:38:38Z (HEAD: ca512f313)
+Generated: 2026-05-12T04:43:12Z (HEAD: 6bd158685)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -135,7 +135,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperGenerationLineage.tla | KeeperGenerationLineage | manual | 2 | 1 | clean={inv:TypeOK, inv:CurrentTraceIsolation, inv:GenerationMatchesHistory, inv:CurrentTraceNotInHistory, inv:TraceHistoryUnique, inv:TraceIdsAllocated, inv:IdleCheckpointMatchesCommittedLineage, prop:HandoffEventuallyResolves} buggy={inv:TypeOK, inv:GenerationMatchesHistory, inv:CurrentTraceNotInHistory, inv:TraceHistoryUnique, inv:TraceIdsAllocated, inv:IdleCheckpointMatchesCommittedLineage} | bc957a36caf6 |
 | KeeperHeartbeat.tla | KeeperHeartbeat | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 35344ff2f4be |
 | KeeperLaunchPending.tla | KeeperLaunchPending | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | b40572292792 |
-| KeeperMemoryLifecycle.tla | KeeperMemoryLifecycle | manual | 2 | 1 | clean={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} buggy={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} | 821cd485dadf |
+| KeeperMemoryLifecycle.tla | KeeperMemoryLifecycle | manual | 2 | 1 | clean={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} buggy={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} | aacf99ece735 |
 | KeeperOASAdvanced.tla | KeeperOASAdvanced | manual | 2 | 1 | clean={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:CommittedSideEffectsRequireContinueGate, prop:StrictStopPreemption, prop:EventualTermination} buggy={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:StrictStopPreemption, prop:EventualTermination} | 010a182b7a8b |
 | KeeperOutcomesConservation.tla | KeeperOutcomesConservation | manual | 2 | 1 | clean={inv:Safety} buggy={inv:ConservationLaw} | 7ac6ec2c5bf3 |
 | KeeperPostTurnOrchestration.tla | KeeperPostTurnOrchestration | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 0c26d77292b4 |

--- a/specs/keeper-state-machine/KeeperMemoryLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperMemoryLifecycle.tla
@@ -12,20 +12,23 @@
 \*   - handoff clears stale short-term notes,
 \*   - each tier stays within its configured bound.
 \*
-\* OCaml <-> TLA+ mapping (see #8642 family):
+\* OCaml <-> TLA+ mapping (see #8642 family).  Cited by symbol name, not
+\* line number — iter 64 N-2.a convention; the "lib/keeper/keeper_memory_policy.ml:155-157"
+\* anchors had drifted +46 (the horizon constants are now ~line 201-203).
+\* See docs/tla-audit/kml-r8-memory-lifecycle-lineref-drift-2026-05-12.md
 \*
 \*   spec variable    | OCaml field / source                              | location
 \*   -----------------+--------------------------------------------------+--------
-\*   short_mem        | rows with horizon = "short_term"                 | lib/keeper/keeper_memory_policy.ml:155
-\*   mid_mem          | rows with horizon = "mid_term"                   | lib/keeper/keeper_memory_policy.ml:156
-\*   long_mem         | rows with horizon = "long_term"                  | lib/keeper/keeper_memory_policy.ml:157
+\*   short_mem        | rows with horizon = "short_term"                 | lib/keeper/keeper_memory_policy.ml — `short_term_horizon`
+\*   mid_mem          | rows with horizon = "mid_term"                   | lib/keeper/keeper_memory_policy.ml — `mid_term_horizon`
+\*   long_mem         | rows with horizon = "long_term"                  | lib/keeper/keeper_memory_policy.ml — `long_term_horizon`
 \*   open_short       | unresolved short-term notes (open_question kind) | lib/keeper/keeper_memory_bank.ml
 \*   provenanced      | rows with non-empty trace_id / source            | lib/keeper/keeper_memory_bank.ml
 \*   generation       | snapshot.generation field                        | snapshot record
 \*   overflowed       | derived: short_mem cardinality > MaxShort        | runtime check
 \*
-\* Tier vocabulary (string-typed, intentionally not a variant today):
-\*   lib/keeper/keeper_memory_policy.ml:155-157
+\* Tier vocabulary (string-typed, intentionally not a variant today) —
+\* the horizon string constants in lib/keeper/keeper_memory_policy.ml:
 \*     `let short_term_horizon = "short_term"`
 \*     `let mid_term_horizon   = "mid_term"`
 \*     `let long_term_horizon  = "long_term"`


### PR DESCRIPTION
## Finding (Iteration 81, Phase R — first spec entry + line-ref drift class survey)

**Spec**: `specs/keeper-state-machine/KeeperMemoryLifecycle.tla` (265 LOC, bug-model paired)
**Runtime**: `lib/keeper/keeper_memory_policy.ml` (`short_term_horizon` / `mid_term_horizon` / `long_term_horizon` constants)
**Aspect**: short/mid/long memory tier lifecycle — provenance, no-silent-loss on overflow/handoff, per-tier bounds
**Verdict**: **model correct; the 4 `keeper_memory_policy.ml:155-157` citations drifted +46 (constants now at lines 201-203), symbol-anchored comment-only**. Everything else in the preamble was already symbol-anchored and accurate.
**Risk**: LOW — comment-only spec change; model body byte-identical; TLC re-run anyway (clean + buggy as expected)
**Workaround signature**: N/A — *removes* stale line numbers, switches to symbol anchors; the survey recommends *resolving* validators, not banning the citation syntax (which would be the string-classifier workaround)

## 순서도

```mermaid
stateDiagram-v2
  [*] --> capture : note captured (kind → horizon via memory_horizon_of_kind)
  capture --> short_mem : horizon = "short_term"
  capture --> mid_mem : horizon = "mid_term"
  capture --> long_mem : horizon = "long_term"
  short_mem --> overflowed : |short_mem| > MaxShort
  overflowed --> mid_mem : CompactOverflow — promote trimmed short notes to mid
  short_mem --> short_mem : Handoff clears stale short-term notes

  state "NoSilentLoss\nlost_notes = {}" as INV
  overflowed --> INV : checked every state

  note right of overflowed
    Tier vocab: short_term_horizon / mid_term_horizon / long_term_horizon string constants in keeper_memory_policy.ml.
    Producer: memory_horizon_of_kind_opt (strict) / memory_horizon_of_kind (back-compat wrapper, | None -> mid_term_horizon).
    Clean cfg: no error.  Buggy cfg (BuggyCompactOverflow: trim short WITHOUT promoting to mid → lost_notes grows):
              invariant violated (TypeOK fires first in the buggy cfg's invariant list — see "pre-existing observation").
  end note
```

## What drifted (sub-class 8: line-reference drift)

| Spec citation (×4 occurrences) | Actual location 2026-05-12 | Drift | Fix |
|---|---|---|---|
| `keeper_memory_policy.ml:155` — `short_mem` row (mapping table) | `let short_term_horizon = "short_term"`@**201** | **+46** | `keeper_memory_policy.ml — \`short_term_horizon\`` |
| `keeper_memory_policy.ml:156` — `mid_mem` | `let mid_term_horizon = "mid_term"`@**202** | **+46** | `— \`mid_term_horizon\`` |
| `keeper_memory_policy.ml:157` — `long_mem` | `let long_term_horizon = "long_term"`@**203** | **+46** | `— \`long_term_horizon\`` |
| `keeper_memory_policy.ml:155-157` — "Tier vocabulary" block header (followed by the three `let ... = "..."` lines verbatim) | constants @201-203 | **+46** | drop the `:155-157`; the block already lists the `let` defs verbatim |

Already symbol-anchored & accurate (no change): `memory_horizon_of_kind_opt` (strict, @207), `memory_horizon_of_kind` (back-compat wrapper, @218, still `| None -> mid_term_horizon`), `memory_horizon_of_json_opt` (@230), `keeper_memory_bank.ml:append_memory_notes_from_reply`, `keeper_memory_recall.ml:read_recent_memory_texts`, `keeper_compact_policy.ml`, `keeper_compact_audit.ml`, the "SCOPE DRIFT" `#8605` note.

## Line-ref drift class — corpus survey (the reason this was a "sweep candidate")

iters 77→80 found four consecutive first-entry audits with stale preamble line numbers (KDM #14958, KCGP #14959, KOC #14960, KLP #14963). `rg '\.ml:[0-9]' specs/keeper-state-machine/*.tla` → the citation style appears in **~12 spec files, ~50+ hits**. But not all are drifted:

- **Stable** (top-of-file refs): `KeeperCompactionLifecycle.tla:18-21` cites `keeper_state_machine.ml:8/10/11/14` for `type phase` constructors `Running`/`Overflowed`/`Compacting`/`Paused` — and `type phase` *is* at lines 6-19, so `Running`@8 etc. are still correct. Refs to a top-of-file type decl don't rot.
- **Drifted** (deep-function refs into growing files): `keeper_registry.ml:NNN` (KLP iter 80, up to +1035), `keeper_memory_policy.ml:155-157` (this PR, +46), `keeper_run_tools.ml:NNN` (KeeperToolSurface — ~15 hits, lines 794-1011 cited), `keeper_post_turn.ml:NNN` (KeeperPostTurnOrchestration — ~8 hits), `keeper_registry.ml:63-81` (the 3-axis type defs, cited by KeeperCascadeLifecycle/KeeperDecisionPipeline/KeeperTurnCycle), `keeper_unified_turn.ml:318/1640`, `keeper_state_machine.ml:402-408/754-758`, `keeper_social_model_magentic_ledger_v1.ml:204`, `keeper_composite_observer.ml:25-32`.

**Recommendation** (not done here — a full sweep is too large for one 10-min PR, and a "ban `\.ml:[0-9]`" lint would be the string-classifier workaround pattern):
1. **Extend the existing resolving validator** `scripts/audit-tla-ml-line-refs.sh` (iter 64 #14925; currently handles `[funcname]...line N`) to also resolve the `<file>:<line>` form and warn on drift > tolerance. *Resolving* (telling you the true line) is the right structural fix, not banning the syntax.
2. **Per-spec symbol-anchor PRs**, prioritized by cluster size — KeeperToolSurface (~15 hits) and the `keeper_registry.ml:63-81` 3-axis-type-def trio are the biggest remaining.

## Pre-existing observation (not fixed here — out of scope)

`KeeperMemoryLifecycle-buggy.cfg`'s invariant list is `{TypeOK, ProvenanceRequired, NoSilentLoss, RecoveryBounded, HandoffLeavesNoStaleShort}` — so TLC reports `TypeOK is violated` rather than the *intended* `NoSilentLoss` (the preamble says "NoSilentLoss MUST be violated"). A well-formed buggy cfg often omits `TypeOK` so the demonstrated violation is the spec's actual defense. Pre-existing (not introduced by this comment-only PR); candidate follow-up: drop `TypeOK` from the buggy cfg, or confirm the bug action produces a genuinely malformed state and document why `TypeOK` is kept. Out of scope for a line-ref fix.

## Before / After (spec preamble — excerpt)

```diff
-\* OCaml <-> TLA+ mapping (see #8642 family):
-\*   short_mem        | rows with horizon = "short_term"  | lib/keeper/keeper_memory_policy.ml:155
-\*   mid_mem          | rows with horizon = "mid_term"    | lib/keeper/keeper_memory_policy.ml:156
-\*   long_mem         | rows with horizon = "long_term"   | lib/keeper/keeper_memory_policy.ml:157
+\* OCaml <-> TLA+ mapping (see #8642 family).  Cited by symbol name, not line
+\* number — iter 64 N-2.a convention; the ":155-157" anchors had drifted +46 ...
+\*   short_mem        | rows with horizon = "short_term"  | lib/keeper/keeper_memory_policy.ml — `short_term_horizon`
+\*   mid_mem          | rows with horizon = "mid_term"    | lib/keeper/keeper_memory_policy.ml — `mid_term_horizon`
+\*   long_mem         | rows with horizon = "long_term"   | lib/keeper/keeper_memory_policy.ml — `long_term_horizon`
-\* Tier vocabulary (string-typed, intentionally not a variant today):
-\*   lib/keeper/keeper_memory_policy.ml:155-157
-\*     `let short_term_horizon = "short_term"` ...
+\* Tier vocabulary (string-typed, intentionally not a variant today) —
+\* the horizon string constants in lib/keeper/keeper_memory_policy.ml:
+\*     `let short_term_horizon = "short_term"` ...
```

`specs/INDEX.md` regenerated: KML content-hash bump `821cd485dadf → aacf99ece735`.

## 본 PR 수정

1. `KeeperMemoryLifecycle.tla` preamble: 4개 `keeper_memory_policy.ml:155-157` 인용을 symbol anchor로 (`short_term_horizon` 등) + mapping 상단에 컨벤션 전환 + drift 규모 노트. 모델 본문 byte-identical.
2. `specs/INDEX.md` 재생성.
3. 새 audit memo `docs/tla-audit/kml-r8-memory-lifecycle-lineref-drift-2026-05-12.md` — 이 spec의 drift 표 + **line-ref drift class 코퍼스 서베이** (12 spec, ~50 hit, type-phase top-of-file ref는 stable, deep-function ref만 drift) + 2개 권고 (validator 확장 / 클러스터별 symbol-anchor PR) + buggy.cfg `TypeOK`-우선 pre-existing 관찰.

영향 범위: spec 1개 (comment-only) + INDEX.md (생성) + 새 memo. OCaml 코드 변화 없음.

## Verification

- [x] `rg "let short_term_horizon|let mid_term_horizon|let long_term_horizon|memory_horizon_of_kind" keeper_memory_policy.ml` → constants @201-203, `memory_horizon_of_kind_opt`@207, `memory_horizon_of_kind`@218 (`| None -> mid_term_horizon`), `memory_horizon_of_json_opt`@230
- [x] `rg '\.ml:[0-9]' specs/keeper-state-machine/*.tla` → ~12 files, ~50+ hits (surveyed in memo)
- [x] TLC clean `KeeperMemoryLifecycle.cfg` → `Model checking completed. No error has been found.`
- [x] TLC buggy `KeeperMemoryLifecycle-buggy.cfg` → invariant violated (`TypeOK` — see pre-existing observation)
- [x] `bash scripts/gen-tla-index.sh > specs/INDEX.md` → only KML-hash + timestamp/HEAD lines change
- [x] TLC artifacts cleaned; `git status` → only the 3 intended files; `git diff --cached --stat` → 3 files +55/-8

## Trade-off

- 후속 PR: (a) `scripts/audit-tla-ml-line-refs.sh`에 `<file>:<line>` 형식 resolution 추가 (validator 확장 — *resolving*이지 syntax 금지가 아니라 워크어라운드 아님), (b) 클러스터별 symbol-anchor PR (KeeperToolSurface ~15 hits / `keeper_registry.ml:63-81` 3-axis trio), (c) `KeeperMemoryLifecycle-buggy.cfg`에서 `TypeOK` 제거 검토. 모두 별도 PR — 한 10분 iteration엔 안 들어감.
- `KeeperMemoryLifecycle`은 `make -C specs check-clean` runner에 포함 — CI `tla-specs` job이 재실행.

## RFC 참조

`RFC-WAIVED: specs/keeper-state-machine/KeeperMemoryLifecycle.tla (comment-only) + specs/INDEX.md (generated) + docs/tla-audit/ memo only. No lib/ code change. The spec is not in any RFC-gated subsystem (not credential/keeper_gh/host_config, not repo_manager, not operator_control, not keeper_sandbox/shell, not dashboard credential component, not .claude/hooks, not instructions/workflow).`

## 진행 추적

다음 iteration 시작점: 진행 메모리 `project_fsm_tla_loop_progress.md` 의 "Current cursor" 참조. 후보 — **validator 확장** (`scripts/audit-tla-ml-line-refs.sh`에 `<file>:<line>` resolution — 구조적 fix, 가장 가치 ↑) OR 클러스터별 symbol-anchor PR (KeeperToolSurface ~15 hits 가장 큼) OR 새 spec entry (KeeperTurnSlot / KeeperSocialModelMagenticLedger / OperatorPauseBroadcast 등 ~6개 미감사) OR R-D-2.a+R-D-1.a 번들 (MID) OR KSM A-5 (22×19 matrix).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
