### PR TITLE
feat(cdal): enable warning 4 + close 5 fragile sites (RFC-0071 §3.4)

### DIFF
--- a/lib/cdal/adversarial_eval.ml
+++ b/lib/cdal/adversarial_eval.ml
@@ -204,7 +204,7 @@ let check_missing_interface inputs =
         match input with
         | Changed_file { path; _ } ->
             if Filename.check_suffix path ".ml" then Some path else None
-        | _ -> None)
+        | Diff _ | Type_signature _ | Interface_contract _ -> None)
       inputs
   in
   let mli_files =
@@ -212,7 +212,7 @@ let check_missing_interface inputs =
       (fun input ->
         match input with
         | Interface_contract { path; _ } -> Some path
-        | _ -> None)
+        | Diff _ | Changed_file _ | Type_signature _ -> None)
       inputs
   in
   List.filter_map
@@ -274,7 +274,7 @@ let check_unsafe_patterns inputs =
                   }
               else None)
             unsafe_patterns
-      | _ -> [])
+      | Diff _ | Type_signature _ | Interface_contract _ -> [])
     inputs
 
 (** Check for added files without tests. *)
@@ -284,7 +284,7 @@ let check_untested_additions inputs =
       (fun input ->
         match input with
         | Changed_file { path; _ } -> Some path
-        | _ -> None)
+        | Diff _ | Type_signature _ | Interface_contract _ -> None)
       inputs
   in
   let has_test_file =

--- a/lib/cdal/cdal_friction_projection.ml
+++ b/lib/cdal/cdal_friction_projection.ml
@@ -352,8 +352,8 @@ let project_window
   | Single_run, [ proof ] ->
     project_single_run ~store ~completeness_gaps ~tripwire_threshold proof
   | Single_run, _ -> None (* Single_run requires exactly one proof *)
-  | _, [] -> None
-  | _, _ ->
+  | (Last_n_runs _ | Session _ | Rolling_seconds _), [] -> None
+  | (Last_n_runs _ | Session _ | Rolling_seconds _), (_ :: _) ->
     let per_run =
       List.map
         (fun proof ->

--- a/lib/cdal/dune
+++ b/lib/cdal/dune
@@ -15,6 +15,8 @@
  (name masc_mcp_cdal)
  (public_name masc_mcp.cdal)
  (wrapped false)
+ ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on.
+ (flags (:standard -w +4))
  (libraries
   eio
   yojson


### PR DESCRIPTION
## 목적

RFC-0071 §3.4 Phase 5 ratchet (#14888 … #14961 후속).

## 변경: 5 fragile sites in lib/cdal

### adversarial_eval.ml ×4
`match input with Changed_file {...}\|_ -> ...` (또는 `Interface_contract {...}\|_`) over `allowed_input` (4 ctors: Diff, Changed_file, Type_signature, Interface_contract). `_ ->` 가 나머지 3 ctor 흡수 → fragile. 명시화:
- `check_missing_interface` ×2 (ml_files / mli_files filter)
- `check_unsafe_patterns`
- `check_untested_additions`

### cdal_friction_projection.ml ×1
`match window, proofs with ... | _, _` over `run_window` (Single_run \| Last_n_runs \| Session \| Rolling_seconds). Single_run 은 앞 2 arm 으로 완전 커버; catch-all 을 `(Last_n_runs _ \| Session _ \| Rolling_seconds _), []` + `(Last_n_runs _ \| Session _ \| Rolling_seconds _), (_ :: _)` 로 분리.

모두 behavior-preserving.

## 검증

- \`dune build --root .\` clean (5 warning-4 error → 0)
- adversarial_eval + cdal_friction_projection tests green (38)

## 누적

| | `-w +4` sublibs |
|--|--|
| #14888 … #14961 | 34 |
| **본 PR** | **+1 (cdal, +5 fix)** |
| **누계** | **35** |

## Deferred
- `lib/resilience` (confidence ×4, degradation ×2), `lib/autoresearch` (~5)
- `lib/cascade_decl` (12), `lib/coord` (35), `lib/cdal_runtime` (34)
- `lib/repo_manager` (8) — RFC-required
- `lib` (main) — codemod