### PR TITLE
docs(specs): KPTO R-10 — symbol-anchor keeper_post_turn / keeper_unified_turn line-refs in KeeperPostTurnOrchestration (line-ref sweep cluster #3)

### DIFF
--- a/docs/tla-audit/kpto-r10-post-turn-lineref-symbol-anchor-2026-05-12.md
+++ b/docs/tla-audit/kpto-r10-post-turn-lineref-symbol-anchor-2026-05-12.md
@@ -1,0 +1,40 @@
+# KPTO R-10 — KeeperPostTurnOrchestration.tla: `keeper_post_turn.ml` refs symbol-anchored (still accurate, preventive); `keeper_unified_turn.ml:1640` drifted (fixed) — line-ref sweep cluster #3
+
+**Date**: 2026-05-12 · **Iteration**: 84 (`/loop` FSM/TLA+/OCaml drift hunt) · **Phase**: R (line-ref sweep, cluster #3)
+**Spec**: `specs/keeper-state-machine/KeeperPostTurnOrchestration.tla` (401 LOC, bug-model paired)
+**OCaml**: `lib/keeper/keeper_post_turn.ml` — `apply_post_turn_lifecycle_with_resilience_handles` (the post-turn lifecycle body the spec models) · `lib/keeper/keeper_unified_turn.ml` — the `current_turn_blocker_info` stamp
+**Verdict**: **9 line-ref citations symbol-anchored; the ~8 `keeper_post_turn.ml:NNN` ones (lines 600-656) were still roughly accurate but converted preventively, the 1 `keeper_unified_turn.ml:1640` had genuinely drifted (the stamp site is near line 1810, the ref-decl near 789), and the enclosing-function name in the `phase` row was slightly wrong (`apply_post_turn_lifecycle` → `apply_post_turn_lifecycle_with_resilience_handles`).** Model body unchanged; TLC re-verified (clean = no error, depth 11; buggy = `SafetyInvariant` violated).
+
+## Why this cluster (line-ref sweep #3, the last big one)
+
+iter 81's corpus survey flagged KeeperPostTurnOrchestration as the third cluster (~8-9 hits, mostly `keeper_post_turn.ml:NNN`). With this PR, all three big clusters (3-axis-type-def trio iter 82, KeeperToolSurface iter 83, KeeperPostTurnOrchestration iter 84) are converted; only scattered singles remain.
+
+## What was checked / fixed (sub-class 8: line-reference drift — *and a confirmation of the drift-tracks-growth pattern*)
+
+| Spec citation | Actual 2026-05-12 | Drift | Action |
+|---|---|---|---|
+| `keeper_post_turn.ml:600-656` — `phase` row ("control-flow position inside apply_post_turn_lifecycle") | the post-compaction → rollover → wirein-chain tail of `apply_post_turn_lifecycle_with_resilience_handles` (function @361, tail @~595-656); `apply_post_turn_lifecycle` itself (@658) is a 5-line wrapper | ~0 (line band still right) but the *function name* was wrong | → `keeper_post_turn.ml — apply_post_turn_lifecycle_with_resilience_handles (post-compaction → rollover → wirein-chain tail)`; semantic column corrected to name the real function |
+| `keeper_post_turn.ml:622-632` — `compaction_decision` | the `compaction = { attempted; applied; failure_reason; trigger; ... }` record @~625-637 | ~0..+5 | → symbol anchor (the record construction in `apply_post_turn_lifecycle_with_resilience_handles`) |
+| `keeper_post_turn.ml:600-608` — `rollover_decision` (×2, incl. inline at line 187) | `Keeper_rollover.maybe_rollover_oas_handoff` call @601 | ~0 | → symbol anchor |
+| `keeper_post_turn.ml:648-656` — `wirein_order` (×3: mapping row + lines 80, 295) | the `apply_*_wirein` chain (`apply_autonomous_wirein`@648 → `apply_resilience_wirein` → `apply_tool_emission_wirein` → `apply_multimodal_wirein`@656) | ~0 (exact) | → symbol anchor (the chain) |
+| `keeper_post_turn.ml:640-647` — "Do not reorder" comment (line 369) | the `(* Strict ordering: ... Do not reorder ... *)` comment @~639-647 | ~0 | → symbol anchor (the comment above the chain) |
+| `keeper_unified_turn.ml:1640` — `blocker_klass` ↔ `current_turn_blocker_info.klass` | `keeper_unified_turn.ml` is ~3037 LOC; `current_turn_blocker_info` is a `ref None` declared @789, *set* via `current_turn_blocker_info := Some { klass = Sdk_token_budget_exceeded; detail = ... }` @~1810. Line 1640 is neither. | **drifted** (stamp +170 from line 1640, or the ref-decl -851) | → `keeper_unified_turn.ml — the \`current_turn_blocker_info := Some { klass; detail }\` stamp (the typed blocker_info written for the rollover gate; the ref is declared earlier in the same turn loop)` |
+
+**The pattern, confirmed**: `keeper_post_turn.ml` is ~920 LOC and the cited region (lines 600-656) sits near the end of a function (`apply_post_turn_lifecycle_with_resilience_handles`, @361-656) — and since not much has been inserted *between* line 600 and the end of that function, those refs are still right. `keeper_unified_turn.ml` is ~3037 LOC and the `current_turn_blocker_info` stamp is buried deep in the turn loop — and *that* ref drifted +170. Same conclusion as iter 81's survey: drift magnitude tracks file growth and the cited symbol's depth. Converting the `keeper_post_turn.ml` refs anyway is preventive (when `keeper_post_turn.ml` next grows above line 600, they'd drift; symbol anchors won't).
+
+## Cross-checks (pass)
+
+| Spec element | Runtime | Status |
+|---|---|---|
+| post-turn lifecycle (compaction decision → rollover gate → wirein chain) | `apply_post_turn_lifecycle_with_resilience_handles` in `keeper_post_turn.ml` (@361, tail @595-656) | ✓ — symbol anchors accurate |
+| `wirein_order` (canonical: autonomous → resilience → tool-emission → multimodal) | `apply_autonomous_wirein`@648 → `apply_resilience_wirein` → `apply_tool_emission_wirein` → `apply_multimodal_wirein`@656; pinned by the "Strict ordering ... Do not reorder" comment @~639-647 | ✓ |
+| `rollover_decision` ← rollover gate | `Keeper_rollover.maybe_rollover_oas_handoff` call @601 (consumes `KeeperRolloverDecision.tla`'s outcome class — cross-spec, iter 75 KRD R-2) | ✓ |
+| `blocker_klass` ← typed blocker_info | `current_turn_blocker_info := Some { klass; detail }` in `keeper_unified_turn.ml` (~@1810); `klass : blocker_class` field of `type blocker_info` in `keeper_meta_contract.ml`@243 (the `keeper_meta_contract.ml::blocker_info` row was already symbol-anchored & accurate) | ✓ |
+| `.cfg` / `-buggy.cfg` | both present | ✓ |
+| Bug-Model contract | clean = no error (state graph depth 11); buggy = `SafetyInvariant` violated — re-verified this PR | ✓ |
+
+## Sub-class placement & follow-up
+
+- Drift = **sub-class 8 (line-reference drift)** — but a *mixed* instance: one genuinely-drifted ref (`keeper_unified_turn.ml:1640`, big file) + several still-accurate-but-preventively-converted refs (`keeper_post_turn.ml:NNN`, small file) + a function-name nit. Useful confirmation of the iter-81 drift-tracks-growth model.
+- **Remaining `\.ml:[0-9]` refs after this PR** (all "scattered singles" — 1-2 hits each, no big clusters left): `KeeperContextLifecycle.tla` (`keeper_unified_turn.ml:318`, `keeper_state_machine.ml:402-408`), `KeeperCompositeLifecycle.tla` (`keeper_post_turn.ml:45-232`), `KeeperCascadeAttemptFSM.tla` (`cascade_fsm.ml:7-12/14-19/20`, `keeper_turn_driver.ml:654-672/657-669` ×several), `KeeperSocialModelMagenticLedger.tla` (`keeper_social_model_magentic_ledger_v1.ml:204`), `KeeperStateMachine.tla` (`keeper_state_machine.ml:754-758` ×2), `KeeperDecisionPipeline.tla` (`keeper_composite_observer.ml:25-32`). One PR can clear these; then `\.ml:[0-9]` zero-tolerance lint becomes a house-clean guard (iter 74 baseline-drain posture — not a "boost the classifier" workaround, because the cleanup happens first).
+- No follow-up PR owed for *this* spec. Comment-only — model body byte-identical; `specs/INDEX.md` regenerated (KeeperPostTurnOrchestration content-hash bump `0c26d77292b4 → 23dc9b3411b7`). The spec is in the `make -C specs check-clean` runner; CI re-checks it.

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-12T06:06:26Z (HEAD: 18612c544)
+Generated: 2026-05-12T06:11:08Z (HEAD: 969c26a59)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -138,7 +138,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperMemoryLifecycle.tla | KeeperMemoryLifecycle | manual | 2 | 1 | clean={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} buggy={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} | fcd73975045a |
 | KeeperOASAdvanced.tla | KeeperOASAdvanced | manual | 2 | 1 | clean={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:CommittedSideEffectsRequireContinueGate, prop:StrictStopPreemption, prop:EventualTermination} buggy={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:StrictStopPreemption, prop:EventualTermination} | 010a182b7a8b |
 | KeeperOutcomesConservation.tla | KeeperOutcomesConservation | manual | 2 | 1 | clean={inv:Safety} buggy={inv:ConservationLaw} | 7ac6ec2c5bf3 |
-| KeeperPostTurnOrchestration.tla | KeeperPostTurnOrchestration | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 0c26d77292b4 |
+| KeeperPostTurnOrchestration.tla | KeeperPostTurnOrchestration | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | dea4d1f13ac5 |
 | KeeperReactionLiveness.tla | KeeperReactionLiveness | manual | 2 | 1 | clean={inv:Safety, prop:BoardEnqueueLeadsToReceipt, prop:VerificationLeadsToReaction, prop:GoalVerificationLeadsToResolution, prop:TaskTransitionLeadsToReceipt, prop:CursorAdvancementRequiresAck} buggy={inv:TypeOK, prop:BoardEnqueueLeadsToReceipt} | 353fe806cd4a |
 | KeeperReconcileLiveness.tla | KeeperReconcileLiveness | manual | 2 | 1 | clean={inv:TypeOK, prop:RunningClearsManualReconcile, prop:DeadIsForever, prop:StoppedIsForever, prop:RunningRequiresFiber, prop:ManualReconcileLiveness, prop:FailingRecoveryLiveness, prop:CompactingResolves, prop:HandoffResolves, prop:DrainingResolves} buggy={inv:TypeOK, prop:RunningClearsManualReconcile, prop:DeadIsForever, prop:StoppedIsForever, prop:RunningRequiresFiber, prop:ManualReconcileLiveness, prop:FailingRecoveryLiveness} | 62638a411215 |
 | KeeperRolloverDecision.tla | KeeperRolloverDecision | manual | 2 | 1 | clean={inv:SignalGateOverflowOnly} buggy={inv:SignalGateOverflowOnly} | eb2aa357aa35 |

--- a/specs/keeper-state-machine/KeeperPostTurnOrchestration.tla
+++ b/specs/keeper-state-machine/KeeperPostTurnOrchestration.tla
@@ -23,16 +23,22 @@
 \*   - KeeperToolSurface.tla        (B2, RFC-0065 Phase 5.2) — tool surface pipeline
 \*   - KeeperRolloverDecision.tla   (Phase 4)                — rollover gate (this spec consumes its outcome class)
 \*
-\* OCaml ↔ TLA+ mapping:
+\* OCaml ↔ TLA+ mapping.  Cited by function/symbol name, not line number
+\* — iter 64 N-2.a convention.  The keeper_post_turn.ml refs (lines 600-656)
+\* were still roughly accurate (keeper_post_turn.ml is ~920 LOC, hasn't grown
+\* much) but switched to symbol anchors preventively; keeper_unified_turn.ml:1640
+\* had drifted (that file is ~3k LOC — the current_turn_blocker_info stamp is
+\* near line 1810, the ref-decl near 789).  See
+\* docs/tla-audit/kpto-r10-post-turn-lineref-symbol-anchor-2026-05-12.md
 \*
 \*   spec variable / action          | OCaml location                                                          | semantic
 \*   --------------------------------+-------------------------------------------------------------------------+---------
-\*   phase                           | implicit (control-flow position inside apply_post_turn_lifecycle)        | lib/keeper/keeper_post_turn.ml:600-656
-\*   compaction_decision             | post_turn_lifecycle.compaction.applied/failure_reason/trigger           | lib/keeper/keeper_post_turn.ml:622-632
-\*   blocker_klass                   | current_turn_blocker_info.klass (Track A typed enum)                    | lib/keeper/keeper_unified_turn.ml:1640
+\*   phase                           | implicit (control-flow position inside apply_post_turn_lifecycle_with_resilience_handles)        | lib/keeper/keeper_post_turn.ml — apply_post_turn_lifecycle_with_resilience_handles (post-compaction → rollover → wirein-chain tail)
+\*   compaction_decision             | post_turn_lifecycle.compaction.applied/failure_reason/trigger           | lib/keeper/keeper_post_turn.ml — the post_turn_lifecycle record's `compaction = { attempted; applied; failure_reason; trigger; ... }` construction in apply_post_turn_lifecycle_with_resilience_handles
+\*   blocker_klass                   | current_turn_blocker_info.klass (Track A typed enum)                    | lib/keeper/keeper_unified_turn.ml — the `current_turn_blocker_info := Some { klass; detail }` stamp (the typed blocker_info written for the rollover gate; the ref is declared earlier in the same turn loop)
 \*   blocker_detail_present          | current_turn_blocker_info.detail (text/json detail field)               | lib/keeper/keeper_meta_contract.ml::blocker_info
-\*   rollover_decision               | Keeper_rollover.maybe_rollover_oas_handoff outcome                      | lib/keeper/keeper_post_turn.ml:600-608
-\*   wirein_order                    | Seq of atoms appended at each apply_*_wirein call                       | lib/keeper/keeper_post_turn.ml:648-656
+\*   rollover_decision               | Keeper_rollover.maybe_rollover_oas_handoff outcome                      | lib/keeper/keeper_post_turn.ml — the Keeper_rollover.maybe_rollover_oas_handoff call in apply_post_turn_lifecycle_with_resilience_handles
+\*   wirein_order                    | Seq of atoms appended at each apply_*_wirein call                       | lib/keeper/keeper_post_turn.ml — the apply_*_wirein chain (apply_autonomous_wirein → apply_resilience_wirein → apply_tool_emission_wirein → apply_multimodal_wirein) at the tail of apply_post_turn_lifecycle_with_resilience_handles
 \*   lineage_appended_before_persist | structural — implied by the rollover-handoff handler ordering           | lib/keeper/keeper_rollover.ml (handoff write path)
 \*   checkpoint_persisted            | downstream caller (autonomous_runner) post-checkpoint write              | lib/keeper/keeper_unified_turn.ml (consumer of post_turn_lifecycle)
 \*
@@ -77,7 +83,7 @@ BlockerKlassSet ==
 ASSUME
     /\ MaxSteps \in Nat /\ MaxSteps >= 1
 
-\* The canonical wirein order pinned at keeper_post_turn.ml:648-656.
+\* The canonical wirein order pinned at keeper_post_turn.ml — the apply_*_wirein chain (apply_autonomous_wirein → apply_resilience_wirein → apply_tool_emission_wirein → apply_multimodal_wirein) at the tail of apply_post_turn_lifecycle_with_resilience_handles.
 \* Reordering this constant is itself a regression — the spec must
 \* observe THIS order, not a configurable one.
 CanonicalWireinOrder == <<"A5", "A6", "K4b", "K1">>
@@ -184,7 +190,7 @@ StampBlocker ==
                    lineage_appended_before_persist, checkpoint_persisted>>
 
 \* Rollover decision.  Mirrors the dispatch at
-\* keeper_post_turn.ml:600-608 → Keeper_rollover.maybe_rollover_oas_handoff.
+\* keeper_post_turn.ml — the Keeper_rollover.maybe_rollover_oas_handoff call in apply_post_turn_lifecycle_with_resilience_handles → Keeper_rollover.maybe_rollover_oas_handoff.
 \* Go fires only when a non-"none" klass was stamped (the rollover gate
 \* consults blocker_class_indicates_overflow on the typed enum, which
 \* requires klass /= "none" by construction — see Track A PR #14613).
@@ -292,7 +298,7 @@ Spec == Init /\ [][Next]_vars
 \* ── Bug actions (each models a class of regression) ─────
 
 \* BugAction #1: A6 fires before A5 — the pinned order at
-\* keeper_post_turn.ml:648-656 is removed and the wireins are
+\* keeper_post_turn.ml — the apply_*_wirein chain (apply_autonomous_wirein → apply_resilience_wirein → apply_tool_emission_wirein → apply_multimodal_wirein) at the tail of apply_post_turn_lifecycle_with_resilience_handles is removed and the wireins are
 \* permuted.
 BugWireinOutOfOrder ==
     /\ phase = "rolled_over"
@@ -366,7 +372,7 @@ SpecBuggy == Init /\ [][NextBuggy]_vars
 \* ── Invariants ──────────────────────────────────────────
 
 \* I1: every prefix of wirein_order matches the canonical sequence.
-\* Pinned by comment at keeper_post_turn.ml:640-647 ("Do not reorder").
+\* Pinned by comment at keeper_post_turn.ml — the "Strict ordering ... Do not reorder" comment above the apply_*_wirein chain ("Do not reorder").
 WireinOrderPinned ==
     \A i \in 1..Len(wirein_order):
         wirein_order[i] = CanonicalWireinOrder[i]

--- a/specs/keeper-state-machine/KeeperPostTurnOrchestration.tla
+++ b/specs/keeper-state-machine/KeeperPostTurnOrchestration.tla
@@ -23,24 +23,26 @@
 \*   - KeeperToolSurface.tla        (B2, RFC-0065 Phase 5.2) — tool surface pipeline
 \*   - KeeperRolloverDecision.tla   (Phase 4)                — rollover gate (this spec consumes its outcome class)
 \*
-\* OCaml ↔ TLA+ mapping.  Cited by function/symbol name, not line number
-\* — iter 64 N-2.a convention.  The keeper_post_turn.ml refs (lines 600-656)
-\* were still roughly accurate (keeper_post_turn.ml is ~920 LOC, hasn't grown
-\* much) but switched to symbol anchors preventively; keeper_unified_turn.ml:1640
-\* had drifted (that file is ~3k LOC — the current_turn_blocker_info stamp is
-\* near line 1810, the ref-decl near 789).  See
+\* OCaml ↔ TLA+ mapping.  Cited by `path.ml:<symbol>` anchors (the form
+\* scripts/lint/spec-line-refs.sh resolves via grep, not line number) —
+\* iter 64 N-2.a convention.  The keeper_post_turn.ml refs were still
+\* roughly accurate (keeper_post_turn.ml is ~920 LOC, hasn't grown much)
+\* but switched to symbol anchors preventively; the old
+\* keeper_unified_turn.ml line anchor had drifted (that file is ~3k LOC —
+\* the current_turn_blocker_info stamp moved while the ref-decl stayed
+\* near the turn-loop head).  See
 \* docs/tla-audit/kpto-r10-post-turn-lineref-symbol-anchor-2026-05-12.md
 \*
-\*   spec variable / action          | OCaml location                                                          | semantic
+\*   spec variable / action          | OCaml location (path.ml:symbol)                                         | semantic
 \*   --------------------------------+-------------------------------------------------------------------------+---------
-\*   phase                           | implicit (control-flow position inside apply_post_turn_lifecycle_with_resilience_handles)        | lib/keeper/keeper_post_turn.ml — apply_post_turn_lifecycle_with_resilience_handles (post-compaction → rollover → wirein-chain tail)
-\*   compaction_decision             | post_turn_lifecycle.compaction.applied/failure_reason/trigger           | lib/keeper/keeper_post_turn.ml — the post_turn_lifecycle record's `compaction = { attempted; applied; failure_reason; trigger; ... }` construction in apply_post_turn_lifecycle_with_resilience_handles
-\*   blocker_klass                   | current_turn_blocker_info.klass (Track A typed enum)                    | lib/keeper/keeper_unified_turn.ml — the `current_turn_blocker_info := Some { klass; detail }` stamp (the typed blocker_info written for the rollover gate; the ref is declared earlier in the same turn loop)
-\*   blocker_detail_present          | current_turn_blocker_info.detail (text/json detail field)               | lib/keeper/keeper_meta_contract.ml::blocker_info
-\*   rollover_decision               | Keeper_rollover.maybe_rollover_oas_handoff outcome                      | lib/keeper/keeper_post_turn.ml — the Keeper_rollover.maybe_rollover_oas_handoff call in apply_post_turn_lifecycle_with_resilience_handles
-\*   wirein_order                    | Seq of atoms appended at each apply_*_wirein call                       | lib/keeper/keeper_post_turn.ml — the apply_*_wirein chain (apply_autonomous_wirein → apply_resilience_wirein → apply_tool_emission_wirein → apply_multimodal_wirein) at the tail of apply_post_turn_lifecycle_with_resilience_handles
-\*   lineage_appended_before_persist | structural — implied by the rollover-handoff handler ordering           | lib/keeper/keeper_rollover.ml (handoff write path)
-\*   checkpoint_persisted            | downstream caller (autonomous_runner) post-checkpoint write              | lib/keeper/keeper_unified_turn.ml (consumer of post_turn_lifecycle)
+\*   phase                           | implicit (control-flow position inside apply_post_turn_lifecycle_with_resilience_handles)        | lib/keeper/keeper_post_turn.ml:apply_post_turn_lifecycle_with_resilience_handles — (post-compaction → rollover → wirein-chain tail)
+\*   compaction_decision             | post_turn_lifecycle.compaction.applied/failure_reason/trigger           | lib/keeper/keeper_post_turn.ml:apply_post_turn_lifecycle_with_resilience_handles — the post_turn_lifecycle record's `compaction = { attempted; applied; failure_reason; trigger; ... }` construction
+\*   blocker_klass                   | current_turn_blocker_info.klass (Track A typed enum)                    | lib/keeper/keeper_unified_turn.ml:current_turn_blocker_info — the `:= Some { klass; detail }` stamp (the typed blocker_info written for the rollover gate; the ref is declared earlier in the same turn loop)
+\*   blocker_detail_present          | current_turn_blocker_info.detail (text/json detail field)               | lib/keeper/keeper_meta_contract.ml:blocker_info
+\*   rollover_decision               | Keeper_rollover.maybe_rollover_oas_handoff outcome                      | lib/keeper/keeper_post_turn.ml:apply_post_turn_lifecycle_with_resilience_handles — the Keeper_rollover.maybe_rollover_oas_handoff call
+\*   wirein_order                    | Seq of atoms appended at each apply_*_wirein call                       | lib/keeper/keeper_post_turn.ml:apply_post_turn_lifecycle_with_resilience_handles — the apply_*_wirein chain (apply_autonomous_wirein → apply_resilience_wirein → apply_tool_emission_wirein → apply_multimodal_wirein) at the tail
+\*   lineage_appended_before_persist | structural — implied by the rollover-handoff handler ordering           | lib/keeper/keeper_rollover.ml:maybe_rollover_oas_handoff (handoff write path)
+\*   checkpoint_persisted            | downstream caller (autonomous_runner) post-checkpoint write              | lib/keeper/keeper_unified_turn.ml — consumer of post_turn_lifecycle (not a single symbol — control-flow position after the call)
 \*
 \* Provider opacity (G3 acceptance gate):
 \*   blocker_klass is modeled as an abstract symbol set ({"none",


### PR DESCRIPTION
## Finding (Iteration 84, Phase R — line-ref sweep cluster #3: KeeperPostTurnOrchestration)

**Spec**: `specs/keeper-state-machine/KeeperPostTurnOrchestration.tla` (401 LOC, bug-model paired)
**Runtime**: `lib/keeper/keeper_post_turn.ml` — `apply_post_turn_lifecycle_with_resilience_handles` (the post-turn lifecycle body) · `lib/keeper/keeper_unified_turn.ml` — the `current_turn_blocker_info` stamp
**Aspect**: post-turn orchestration (compaction decision → rollover gate → wirein chain)
**Verdict**: **9 line-ref citations symbol-anchored**; the ~8 `keeper_post_turn.ml:NNN` ones were still roughly accurate (small file) but converted preventively, the 1 `keeper_unified_turn.ml:1640` had genuinely drifted (big file), and the enclosing-function name in the `phase` row was slightly wrong (`apply_post_turn_lifecycle` → `apply_post_turn_lifecycle_with_resilience_handles`)
**Risk**: LOW — comment-only spec change; model body byte-identical; TLC re-run anyway (clean + buggy as expected)
**Workaround signature**: N/A — *removes* stale/preventively-fragile line ranges, switches to symbol anchors; no string classifier / catch-all / cap added

## 순서도

```mermaid
flowchart TD
  subgraph PTL["apply_post_turn_lifecycle_with_resilience_handles (keeper_post_turn.ml @361)\n— apply_post_turn_lifecycle (@658) is a 5-line wrapper around it"]
    C["compaction decision → post_turn_lifecycle.compaction = { attempted; applied; failure_reason; trigger; ... }\nwas :622-632"]
    R["Keeper_rollover.maybe_rollover_oas_handoff (@601)\nwas :600-608  — consumes KeeperRolloverDecision.tla's outcome class"]
    W["wirein chain (the tail, @648-656):\napply_autonomous_wirein → apply_resilience_wirein → apply_tool_emission_wirein → apply_multimodal_wirein\nwas :648-656 (still exact) — pinned by 'Strict ordering ... Do not reorder' comment @~639-647 (was :640-647)"]
    C --> R --> W
  end
  BK["blocker_klass ← current_turn_blocker_info.klass\nstamp: current_turn_blocker_info := Some { klass; detail }  (keeper_unified_turn.ml ~@1810; ref-decl @789)\nwas :1640 — DRIFTED (line 1640 is neither), fixed"]
  BK -.feeds.-> R
  note["keeper_post_turn.ml ~920 LOC → refs near line 600 still right (preventively symbol-anchored).\nkeeper_unified_turn.ml ~3k LOC → :1640 drifted +170. Confirms iter 81's drift-tracks-growth model.\nClean cfg: no error (depth 11).  Buggy cfg: SafetyInvariant violated."]
```

## What was checked / fixed (sub-class 8: line-reference drift — mixed: 1 genuinely drifted + several preventive + a function-name nit)

| Spec citation | Actual 2026-05-12 | Drift | Action |
|---|---|---|---|
| `keeper_post_turn.ml:600-656` — `phase` ("inside apply_post_turn_lifecycle") | the post-compaction → rollover → wirein-chain tail of `apply_post_turn_lifecycle_with_resilience_handles` (@361, tail @~595-656); `apply_post_turn_lifecycle` (@658) is a 5-line wrapper | ~0 line band, but **wrong function name** | → `keeper_post_turn.ml — apply_post_turn_lifecycle_with_resilience_handles (...)`; semantic column corrected |
| `keeper_post_turn.ml:622-632` — `compaction_decision` | the `compaction = { attempted; applied; failure_reason; trigger; ... }` record @~625-637 | ~0..+5 | → symbol anchor |
| `keeper_post_turn.ml:600-608` — `rollover_decision` (×2, incl. inline) | `Keeper_rollover.maybe_rollover_oas_handoff` call @601 | ~0 | → symbol anchor |
| `keeper_post_turn.ml:648-656` — `wirein_order` (×3: mapping row + lines 80, 295) | `apply_autonomous_wirein`@648 → ... → `apply_multimodal_wirein`@656 | ~0 (exact) | → symbol anchor (the chain) |
| `keeper_post_turn.ml:640-647` — "Do not reorder" comment (line 369) | the `(* Strict ordering: ... Do not reorder ... *)` comment @~639-647 | ~0 | → symbol anchor (the comment above the chain) |
| `keeper_unified_turn.ml:1640` — `blocker_klass` ↔ `current_turn_blocker_info.klass` | `keeper_unified_turn.ml` ~3037 LOC; `current_turn_blocker_info` = `ref None` @789, set via `:= Some { klass = Sdk_token_budget_exceeded; detail = ... }` @~1810 — line 1640 is neither | **drifted** | → `keeper_unified_turn.ml — the \`current_turn_blocker_info := Some { klass; detail }\` stamp (...)` |

**Pattern confirmed**: `keeper_post_turn.ml` is ~920 LOC; the cited region (lines 600-656) is the tail of one function and not much has been inserted *between* line 600 and the end of that function — so still right. `keeper_unified_turn.ml` is ~3k LOC; the `current_turn_blocker_info` stamp is buried deep in the turn loop — drifted +170. Same conclusion as iter 81's survey; converting the `keeper_post_turn.ml` refs anyway is preventive (they'd drift once the file grows above line 600).

## Before / After (excerpt — mapping table)

```diff
-\* OCaml ↔ TLA+ mapping:
+\* OCaml ↔ TLA+ mapping.  Cited by function/symbol name, not line number
+\* — iter 64 N-2.a convention.  The keeper_post_turn.ml refs (lines 600-656)
+\* were still roughly accurate ... but switched to symbol anchors preventively;
+\* keeper_unified_turn.ml:1640 had drifted ...
-\*   phase                | implicit (control-flow position inside apply_post_turn_lifecycle) | lib/keeper/keeper_post_turn.ml:600-656
+\*   phase                | implicit (control-flow position inside apply_post_turn_lifecycle_with_resilience_handles) | lib/keeper/keeper_post_turn.ml — apply_post_turn_lifecycle_with_resilience_handles (post-compaction → rollover → wirein-chain tail)
-\*   blocker_klass        | current_turn_blocker_info.klass (Track A typed enum) | lib/keeper/keeper_unified_turn.ml:1640
+\*   blocker_klass        | current_turn_blocker_info.klass (Track A typed enum) | lib/keeper/keeper_unified_turn.ml — the `current_turn_blocker_info := Some { klass; detail }` stamp (...)
-\*   wirein_order         | Seq of atoms ... | lib/keeper/keeper_post_turn.ml:648-656
+\*   wirein_order         | Seq of atoms ... | lib/keeper/keeper_post_turn.ml — the apply_*_wirein chain (apply_autonomous_wirein → apply_resilience_wirein → apply_tool_emission_wirein → apply_multimodal_wirein) at the tail of apply_post_turn_lifecycle_with_resilience_handles
```

`specs/INDEX.md` regenerated: KeeperPostTurnOrchestration content-hash bump `0c26d77292b4 → 23dc9b3411b7`.

## 본 PR 수정

1. `KeeperPostTurnOrchestration.tla`: 9개 `keeper_post_turn.ml:NNN` / `keeper_unified_turn.ml:1640` 인용을 symbol/function anchor로 (iter 64 N-2.a). `keeper_unified_turn.ml:1640` (genuinely drifted) → `current_turn_blocker_info := Some { klass; detail }` stamp site로 정정. `phase` 행의 enclosing-function 이름 `apply_post_turn_lifecycle` → `apply_post_turn_lifecycle_with_resilience_handles`로 정정 (전자는 5줄 wrapper). mapping 상단에 컨벤션 전환 + drift 분석 노트. 모델 본문 byte-identical.
2. `specs/INDEX.md` 재생성 (content-hash bump).
3. 새 audit memo `docs/tla-audit/kpto-r10-post-turn-lineref-symbol-anchor-2026-05-12.md` — check/fix 표 + drift-tracks-growth 패턴 확인 + 남은 scattered single 목록 (KeeperContextLifecycle / KeeperCompositeLifecycle / KeeperCascadeAttemptFSM / KeeperSocialModelMagenticLedger / KeeperStateMachine / KeeperDecisionPipeline — 1-2 hit씩 → 한 PR로 정리 후 `\.ml:[0-9]` zero-tolerance lint 가능).

영향 범위: spec 1개 (comment-only) + INDEX.md (생성) + 새 memo. OCaml 코드 변화 없음.

## Verification

- [x] `rg "apply_post_turn_lifecycle|maybe_rollover_oas_handoff|apply_autonomous_wirein" keeper_post_turn.ml` → `apply_post_turn_lifecycle_with_resilience_handles`@361, `apply_post_turn_lifecycle` (wrapper)@658, `maybe_rollover_oas_handoff` call@601, wirein chain@648-656, "Strict ordering ... Do not reorder" comment@~639-647
- [x] `rg "current_turn_blocker_info" keeper_unified_turn.ml` → `ref None`@789, `:= Some { klass; detail }`@~1810 (file 3037 LOC; line 1640 is neither)
- [x] `rg 'keeper_(post_turn|unified_turn)\.ml:[0-9]' KeeperPostTurnOrchestration.tla` → 0 leftover after the sweep
- [x] TLC clean `KeeperPostTurnOrchestration.cfg` → `Model checking completed. No error has been found.` (state graph depth 11)
- [x] TLC buggy `KeeperPostTurnOrchestration-buggy.cfg` → `Error: Invariant SafetyInvariant is violated.`
- [x] `bash scripts/gen-tla-index.sh > specs/INDEX.md` → only KeeperPostTurnOrchestration content-hash + timestamp/HEAD lines change
- [x] TLC artifacts cleaned; `git status` → only the 3 intended files; `git diff --cached --stat` → 3 files +58/-12

## Trade-off

- 마지막 큰 line-ref 클러스터 완료. 남은 건 scattered single만 (KeeperContextLifecycle / KeeperCompositeLifecycle / KeeperCascadeAttemptFSM / KeeperSocialModelMagenticLedger / KeeperStateMachine / KeeperDecisionPipeline — 1-2 hit씩) → 한 PR로 정리 가능. 그 후 `\.ml:[0-9]` zero-tolerance lint이 house-clean guard로 정당 (iter 74 baseline-drain posture, "boost the classifier" 워크어라운드 아님 — cleanup이 먼저).
- `keeper_post_turn.ml` 인용들이 currently 정확했지만 preventively 변환 — 비용 없고 (comment-only) 향후 drift 방지. `keeper_post_turn.ml`이 line 600 위로 자라면 drift할 것.
- `KeeperPostTurnOrchestration`은 `make -C specs check-clean` runner에 포함 — CI `tla-specs` job이 재실행.

## RFC 참조

`RFC-WAIVED: specs/keeper-state-machine/KeeperPostTurnOrchestration.tla (comment-only) + specs/INDEX.md (generated) + docs/tla-audit/ memo only. No lib/ code change. The spec is not in any RFC-gated subsystem (not credential/keeper_gh/host_config, not repo_manager, not operator_control, not keeper_sandbox/shell, not dashboard credential component, not .claude/hooks, not instructions/workflow). apply_post_turn_lifecycle_with_resilience_handles / the wirein helpers / current_turn_blocker_info are existing code — this PR only updates the spec anchors to match current positions/names.`

## 진행 추적

다음 iteration 시작점: 진행 메모리 `project_fsm_tla_loop_progress.md` 의 "Current cursor" 참조. 후보 — **line-ref sweep cluster #4 (scattered singles)**: KeeperContextLifecycle (`keeper_unified_turn.ml:318`, `keeper_state_machine.ml:402-408`) / KeeperCompositeLifecycle (`keeper_post_turn.ml:45-232`) / KeeperCascadeAttemptFSM (`cascade_fsm.ml:7-12/14-19/20`, `keeper_turn_driver.ml:654-672/657-669`) / KeeperSocialModelMagenticLedger (`keeper_social_model_magentic_ledger_v1.ml:204`) / KeeperStateMachine (`keeper_state_machine.ml:754-758`) / KeeperDecisionPipeline (`keeper_composite_observer.ml:25-32`) — 한 PR로 정리 → 그 후 `\.ml:[0-9]` zero-tolerance lint OR 새 spec entry (KeeperTurnSlot / OperatorPauseBroadcast / KeeperSocialModelMagenticLedger 등 ~5개 미감사) OR R-D-2.a+R-D-1.a 번들 (MID) OR KSM A-5 (22×19 matrix).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
