### PR TITLE
refactor: route 4 hand-rolled CAS retry loops through Lockfree_atomic.update

### DIFF
--- a/lib/cascade/cascade_state.ml
+++ b/lib/cascade/cascade_state.ml
@@ -25,12 +25,7 @@ let record_sticky_choice ~keeper ~cascade ~provider ~ttl_ms ~now =
     let expires_at = now +. (float_of_int ttl_ms /. 1000.) in
     let entry = { provider; expires_at } in
     let key = (keeper, cascade) in
-    let rec loop () =
-      let cur = Atomic.get sticky_table in
-      let next = Sticky_map.add key entry cur in
-      if not (Atomic.compare_and_set sticky_table cur next) then loop ()
-    in
-    loop ()
+    Lockfree_atomic.update sticky_table (fun cur -> Sticky_map.add key entry cur)
 
 let lookup_sticky ~keeper ~cascade ~now =
   let key = (keeper, cascade) in

--- a/lib/cascade/cascade_throttle.ml
+++ b/lib/cascade/cascade_throttle.ml
@@ -64,12 +64,7 @@ let apply_op
 
 let populate (statuses : Llm_provider.Discovery.endpoint_status list) =
   let ops = List.map prepare_op statuses in
-  let rec loop () =
-    let cur = Atomic.get throttle_table in
-    let next = List.fold_left apply_op cur ops in
-    if not (Atomic.compare_and_set throttle_table cur next) then loop ()
-  in
-  loop ()
+  Lockfree_atomic.update throttle_table (fun cur -> List.fold_left apply_op cur ops)
 
 let lookup url = String_map.find_opt url (Atomic.get throttle_table)
 

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -193,12 +193,7 @@ let restart_launch_noop_for_test =
 ;;
 
 let update_restart_launch_noop_state f =
-  let rec loop () =
-    let current = Atomic.get restart_launch_noop_for_test in
-    let next = f current in
-    if not (Atomic.compare_and_set restart_launch_noop_for_test current next) then loop ()
-  in
-  loop ()
+  Lockfree_atomic.update restart_launch_noop_for_test f
 ;;
 
 let set_restart_launch_noop_for_test enabled =

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -67,12 +67,8 @@ let keeper_list_cache_ttl_s () =
   cache_ttl_seconds "MASC_KEEPER_LIST_CACHE_TTL_S" ~default:2.0
 
 let invalidate_text_cache cache_ref =
-  let rec loop () =
-    let current = Atomic.get cache_ref in
-    let next = empty_text_cache ~generation:(current.generation + 1) in
-    if not (Atomic.compare_and_set cache_ref current next) then loop ()
-  in
-  loop ()
+  Lockfree_atomic.update cache_ref (fun current ->
+    empty_text_cache ~generation:(current.generation + 1))
 
 let invalidate_keeper_list_cache () = invalidate_text_cache _keeper_list_cache
 


### PR DESCRIPTION
## What

Follow-up to #14890 (which converted `cache_eio.decrement_cached_entry_count`). `Lockfree_atomic.update` already exists and is well-tested (`test_lockfree_atomic.ml` covers contention replay + never-loses-work), and its module doc states its purpose is to consolidate the `read → transform → compare_and_set → retry` pattern duplicated across lock-free refactors.

Four more call sites still hand-rolled the identical loop:

| Site | Was | Now |
|---|---|---|
| `tool_keeper.invalidate_text_cache` | `let rec loop () = let cur = Atomic.get … in let next = … in if not (CAS …) then loop ()` | `Lockfree_atomic.update cache_ref (fun cur -> empty_text_cache ~generation:(cur.generation + 1))` |
| `cascade_throttle.populate` | ″ | `Lockfree_atomic.update throttle_table (fun cur -> List.fold_left apply_op cur ops)` |
| `cascade_state.record_sticky_choice` | ″ | `Lockfree_atomic.update sticky_table (fun cur -> Sticky_map.add key entry cur)` |
| `keeper_supervisor.update_restart_launch_noop_state` | ″ | `Lockfree_atomic.update restart_launch_noop_for_test f` |

Net: **+5 / -24**.

## Why it's safe

Each conversion is byte-equivalent: the hand-rolled loop and `Lockfree_atomic.update` both do `read → pure transform → CAS → retry-on-failure` with no side effects in the transform. Behavior is exercised by the existing suites:

```
$ dune exec test/test_keeper_supervisor.exe   # 70 tests OK
$ dune exec test/test_cascade_strategy.exe    # 69 tests OK
```

`dune build lib/` clean.

## Deliberately not touched

- `config_boot_overrides.set` / `clear` use the same pattern, but `lib/config/` is a separate dune library that `masc_mcp` depends on; referencing `Lockfree_atomic` (a `lib/`-root module) from there would create a dependency cycle.
- `tool_keeper.cached_text_by_key` also retries via recursion, but it runs `compute ()` inside the loop body — converting it to `update_with_commit` would change re-execution semantics under contention.

RFC-WAIVED: behavior-preserving call-site consolidation onto an existing tested helper; no credential/identity/operator/sandbox/dashboard-credential/hooks/workflow surface touched.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>