### PR TITLE
docs(specs): OPB R-12 — fix stale stale-watchdog anchor in OperatorPauseBroadcast (supervisor → keeper_stale_watchdog after PR #10670) (first-entry audit)

### DIFF
--- a/docs/tla-audit/opb-r12-operator-pause-broadcast-firstentry-stale-watchdog-anchor-2026-05-12.md
+++ b/docs/tla-audit/opb-r12-operator-pause-broadcast-firstentry-stale-watchdog-anchor-2026-05-12.md
@@ -1,0 +1,51 @@
+# OPB R-12 — OperatorPauseBroadcast.tla: first-entry audit — model accurate; the `keeper_supervisor.ml … emit_stale_keeper_broadcast` anchor drifted (watchdog extracted to `keeper_stale_watchdog.ml` in PR #10670; the OCaml side already flags it) — sub-class 2
+
+**Date**: 2026-05-12 · **Iteration**: 87 (`/loop` FSM/TLA+/OCaml drift hunt) · **Phase**: R (first-entry audit of a previously-unaudited spec)
+**Spec**: `specs/keeper-state-machine/OperatorPauseBroadcast.tla` (135 LOC, bug-model paired) — guarantees gate verdicts (`pause_human` / silent stall) are *addressable* (an `OperatorBroadcast` event eventually reaches operators)
+**OCaml**: `keeper_execution_receipt.ml` (`needs_operator_broadcast` + `emit_operator_broadcast` called from `append`; `operator_disposition`; `emit_stale_keeper_broadcast`), `keeper_stale_watchdog.ml` (`fork_stale_watchdog` — the watchdog fiber-fork under `ctx.sw`), `keeper_supervisor.ml` (now only `let fork_stale_watchdog = Keeper_stale_watchdog.fork_stale_watchdog`)
+**Verdict**: **Model body accurate (FSM `Idle → Running → {PauseHuman, StaleRunning} → Resolved → Idle`, emit at `EnterPauseHuman`, separate `WatchdogEmit` after `StaleRunning`; matches the runtime — receipt `append` emits a broadcast for PauseHuman/StaleRunning dispositions, the stale watchdog emits independently). One anchor in the "Anchors (OCaml runtime)" block drifted: it cites `lib/keeper/keeper_supervisor.ml: stale watchdog fiber forks under ctx.sw and calls emit_stale_keeper_broadcast` — but PR #10670 extracted the watchdog into `keeper_stale_watchdog.ml` (`fork_stale_watchdog`), `keeper_supervisor.ml` only forwards it, and `emit_stale_keeper_broadcast` is defined in `keeper_execution_receipt.ml` (called from the watchdog's inner `emit_watchdog_broadcast`). The OCaml side already noticed — `keeper_stale_watchdog.ml`'s header comment says "That citation pre-dates PR 10670". Also dropped two stale "this PR's Step 2/3" self-references.** Comment-only fix; model body byte-identical; TLC re-verified (clean = no error, 85 states / 36 distinct, temporal props pass; buggy = error — `Deadlock reached`, see quirk below).
+
+## Why this spec
+
+The iter-81 / iter-85 wrap-ups left a tail of never-first-entry-audited specs; iter 86 took KeeperTurnSlot, this iteration takes OperatorPauseBroadcast (the second-smallest unaudited spec). It models the #10670 fix (gate verdicts were a dead-end display field) — a good audit target because the fix relocated code (supervisor → dedicated watchdog module), which is exactly where anchors drift.
+
+## What was checked
+
+| Spec element | Runtime | Status |
+|---|---|---|
+| `EnterPauseHuman(k)` emits at the phase transition | `keeper_execution_receipt.ml` — `append` calls `if needs_operator_broadcast disposition then ... emit_operator_broadcast` (`needs_operator_broadcast` true for PauseHuman/StaleRunning-class dispositions) | ✓ accurate |
+| `EnterStaleRunning(k)` — no emit (stalled keeper produces no receipt) | matches: a heartbeat-fiber stall produces no receipt → no `append` → no broadcast on its own | ✓ |
+| `WatchdogEmit(k)` — separate action that rescues `StaleRunning` from silence | `keeper_stale_watchdog.ml` — `fork_stale_watchdog` forks the watchdog fiber under `ctx.sw`; on stall detection its inner `emit_watchdog_broadcast` calls `Keeper_execution_receipt.emit_stale_keeper_broadcast` | ✓ — **but the anchor pointed at `keeper_supervisor.ml`, which now only forwards (`fork_stale_watchdog = Keeper_stale_watchdog.fork_stale_watchdog`)** |
+| `operator_disposition` "was a derived display field with no transition out" | `keeper_execution_receipt.ml` — `operator_disposition` still computes the kind/reason; the #10670 fix added the broadcast wiring around it | ✓ (the spec's past-tense framing is historically accurate) |
+| `Resolve` / `Recycle` (terminal sink + return to pool) | `keeper_supervisor.ml` flips a keeper back to Idle after the broadcast is acknowledged | ✓ |
+| `.cfg` / `-buggy.cfg` | both present | ✓ |
+| Bug-Model contract | clean = no error (85 states, 36 distinct; `PauseLeadsToBroadcast` + `OperatorPauseEverHandled` temporal props pass); buggy = error (`Deadlock reached`) — re-verified this PR | ✓ — non-zero exit (buggy fails as required), **though the failure mode is a deadlock, not the intended `PauseLeadsToBroadcast` violation** (see follow-up) |
+| line-ref drift | none — spec already cites by symbol name | ✓ (only the *file* in one anchor was wrong) |
+
+## The drift (sub-class 2: code relocated, comment/anchor lags)
+
+The "Anchors (OCaml runtime)" block cited:
+
+> `- lib/keeper/keeper_supervisor.ml: stale watchdog fiber forks under ctx.sw and calls emit_stale_keeper_broadcast (this PR's Step 3).`
+
+Two things wrong:
+1. **The watchdog fiber-fork moved.** PR #10670 extracted the stale-turn watchdog out of `keeper_supervisor.ml` into a dedicated `keeper_stale_watchdog.ml`. `fork_stale_watchdog` (which does `Eio.Fiber.fork ~sw:ctx.sw …`) lives there now. `keeper_supervisor.ml` only does `let fork_stale_watchdog = Keeper_stale_watchdog.fork_stale_watchdog` and invokes it once per keeper at boot.
+2. **`emit_stale_keeper_broadcast` is in `keeper_execution_receipt.ml`, not `keeper_supervisor.ml`.** The watchdog's inner `emit_watchdog_broadcast` calls `Keeper_execution_receipt.emit_stale_keeper_broadcast`.
+
+This drift is *already documented on the OCaml side*: `keeper_stale_watchdog.ml`'s module header comment reads "watchdog fiber forks under ctx.sw and calls emit_stale_keeper_broadcast. That citation pre-dates PR 10670" — i.e., the OCaml author noticed the spec's anchor was stale and left a note, but the spec itself wasn't updated. This audit closes the loop: the spec anchor now points at `keeper_stale_watchdog.ml: fork_stale_watchdog` (the fiber fork) and notes `emit_stale_keeper_broadcast` is in `keeper_execution_receipt.ml`, with `keeper_supervisor.ml` only forwarding.
+
+Also dropped the two stale "this PR's Step 2 / Step 3" self-references (they referred to the PR that introduced the spec — meaningless now).
+
+**Fix (comment-only)**: rewrote the "Anchors (OCaml runtime)" block — `keeper_execution_receipt.ml` anchor unchanged (still accurate), `keeper_supervisor.ml` anchor replaced with the `keeper_stale_watchdog.ml: fork_stale_watchdog` + `Keeper_execution_receipt.emit_stale_keeper_broadcast` chain + a note on the `keeper_supervisor.ml` forwarding shim + the PR #10670 extraction history; added the iter-64 N-2.a header note.
+
+## Pre-existing follow-up (not fixed here — comment-only PR)
+
+The `-buggy.cfg` says "TLC should report invariant or property violation" but TLC actually reports **`Deadlock reached`**: `SpecBuggy`'s `NextBuggy` drops `WatchdogEmit` *and* `Recycle` and uses `EnterPauseHumanBuggy` (no emit), so every keeper that reaches `PauseHuman`/`StaleRunning` is permanently stuck (`Resolve` needs `emitted[k]`, which never becomes true), and no `NextBuggy` action is enabled → deadlock. That's still a non-zero exit (the buggy spec correctly fails the clean contract), but a cleaner buggy model would keep `Recycle` so the *liveness property* (`PauseLeadsToBroadcast`) violation surfaces directly rather than a deadlock masking it. Same family as the iter-81 observation about `KeeperMemoryLifecycle-buggy.cfg` reporting `TypeOK` instead of the intended `NoSilentLoss`. Candidate for a small spec follow-up (add `Recycle` to `NextBuggy`, or accept the deadlock and reword the cfg comment).
+
+## Sub-class placement & follow-up
+
+- Drift = **sub-class 2 (drift: code relocated, comment/anchor lags)** — confirmed by the OCaml side's own "pre-dates PR 10670" note. Comment-only fix.
+- No follow-up PR owed for the anchor fix. Comment-only — model body byte-identical; `specs/INDEX.md` regenerated (OperatorPauseBroadcast content-hash bump `2ef619cbcd73` → `8c678dba2425`). The spec is in the `make -C specs check-clean` runner; CI re-checks it.
+- Pre-existing buggy-cfg quirk (deadlock masks the property check) noted above — small spec follow-up candidate, not blocking.
+- This is *not* an RFC-gated subsystem (it models the operator-pause-broadcast lifecycle, not credential/keeper_gh/host_config, not repo_manager, not operator_control *credential* handlers — the broadcast is a notification, not an identity/credential action; not keeper_sandbox/shell, not dashboard credential component, not .claude/hooks, not instructions/workflow). RFC-WAIVED.
+- **Remaining never-first-entry-audited specs after this**: a handful (KeeperEventQueue, KeeperHeartbeat, KeeperWorkPipeline, KeeperTaskAcquisition, KeeperApprovalQueue — depending on how "audited" is counted; several had partial entries in earlier iterations). Next first-entry candidate: KeeperWorkPipeline or KeeperApprovalQueue.

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-12T05:30:13Z (HEAD: 65c84903a)
+Generated: 2026-05-12T05:44:03Z (HEAD: 94fdb5078)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -150,7 +150,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperTurnCycle.tla | KeeperTurnCycle | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:SelectingRequiresToolPolicyMustHold} | 1cd52d4f7998 |
 | KeeperTurnSlot.tla | KeeperTurnSlot | manual | 2 | 1 | clean={inv:Safety} buggy={inv:RetryPhaseRequiresReleased} | f75c324a95fe |
 | KeeperWorkPipeline.tla | KeeperWorkPipeline | manual | 1 | 0 | clean={inv:TypeOK, inv:WorkspaceAlwaysBounded, inv:IdentityConsistent, inv:NoForcePush, inv:ReviewBeforeSubmit, prop:EventualCompletion, prop:NoOrphanWorkspace} | ab03a79d78e6 |
-| OperatorPauseBroadcast.tla | OperatorPauseBroadcast | manual | 2 | 1 | clean={inv:TypeOK, inv:EmittedBeforeResolved, prop:PauseLeadsToBroadcast, prop:OperatorPauseEverHandled} buggy={inv:TypeOK, prop:PauseLeadsToBroadcast} | 2ef619cbcd73 |
+| OperatorPauseBroadcast.tla | OperatorPauseBroadcast | manual | 2 | 1 | clean={inv:TypeOK, inv:EmittedBeforeResolved, prop:PauseLeadsToBroadcast, prop:OperatorPauseEverHandled} buggy={inv:TypeOK, prop:PauseLeadsToBroadcast} | 8c678dba2425 |
 
 ### specs/keeper-turn-fsm (1 specs)
 

--- a/specs/keeper-state-machine/OperatorPauseBroadcast.tla
+++ b/specs/keeper-state-machine/OperatorPauseBroadcast.tla
@@ -14,11 +14,23 @@
 \*   model satisfies this; the bug model (where emit is silently dropped)
 \*   must violate it.
 \*
-\* Anchors (OCaml runtime)
-\*   - lib/keeper/keeper_execution_receipt.ml: needs_operator_broadcast +
-\*     emit_operator_broadcast called from append (this PR's Step 2).
-\*   - lib/keeper/keeper_supervisor.ml: stale watchdog fiber forks under
-\*     ctx.sw and calls emit_stale_keeper_broadcast (this PR's Step 3).
+\* Anchors (OCaml runtime — cited by symbol/function name, not line
+\* number; iter 64 N-2.a convention)
+\*   - keeper_execution_receipt.ml: [needs_operator_broadcast] +
+\*     [emit_operator_broadcast], called from [append]
+\*     (`if needs_operator_broadcast disposition then ... emit_operator_broadcast`).
+\*     This is the EnterPauseHuman emit path.
+\*   - keeper_stale_watchdog.ml: [fork_stale_watchdog] forks the
+\*     stale-turn watchdog fiber under [ctx.sw] and (via its inner
+\*     [emit_watchdog_broadcast]) calls
+\*     [Keeper_execution_receipt.emit_stale_keeper_broadcast].  This is
+\*     the WatchdogEmit path.  keeper_supervisor.ml only *forwards*:
+\*     `let fork_stale_watchdog = Keeper_stale_watchdog.fork_stale_watchdog`,
+\*     invoked once per keeper at supervisor boot.  (The watchdog logic
+\*     was extracted out of keeper_supervisor.ml into keeper_stale_watchdog.ml
+\*     in PR #10670; the OCaml module's own header comment already flags
+\*     that the old "keeper_supervisor.ml ... emit_stale_keeper_broadcast"
+\*     citation here was stale — this updates the spec side to match.)
 
 EXTENDS Naturals, FiniteSets, TLC
 


### PR DESCRIPTION
## Finding (Iteration 87, Phase R — first-entry audit of OperatorPauseBroadcast.tla)

**Spec**: `specs/keeper-state-machine/OperatorPauseBroadcast.tla` (135 LOC, bug-model paired) — guarantees gate verdicts (`pause_human` / silent stall) are *addressable* (an `OperatorBroadcast` event eventually reaches operators)
**OCaml**: `keeper_execution_receipt.ml` (`needs_operator_broadcast` + `emit_operator_broadcast` called from `append`; `operator_disposition`; `emit_stale_keeper_broadcast`), `keeper_stale_watchdog.ml` (`fork_stale_watchdog` — the watchdog fiber-fork under `ctx.sw`), `keeper_supervisor.ml` (now only `let fork_stale_watchdog = Keeper_stale_watchdog.fork_stale_watchdog`)
**Aspect**: the "Anchors (OCaml runtime)" block — whether the cited symbols/files still match the runtime
**Verdict**: **model body accurate; one anchor drifted — it cited `keeper_supervisor.ml` for the stale-watchdog fiber-fork + `emit_stale_keeper_broadcast`, but PR #10670 extracted the watchdog into `keeper_stale_watchdog.ml` (`fork_stale_watchdog`), `keeper_supervisor.ml` only forwards, and `emit_stale_keeper_broadcast` is in `keeper_execution_receipt.ml`. The OCaml side already flagged this (`keeper_stale_watchdog.ml` header: "That citation pre-dates PR 10670"). Also dropped two stale "this PR's Step 2/3" self-references.** Comment-only fix.
**Risk**: LOW — comment-only spec change; model body byte-identical; TLC re-run (clean = no error 85 states / 36 distinct, temporal props pass; buggy = error — deadlock, see note).
**Workaround signature**: N/A — corrects a stale file/symbol anchor; no string classifier / catch-all / cap.

## 순서도 (OperatorPauseBroadcast FSM + corrected anchors)

```mermaid
stateDiagram-v2
  [*] --> Idle
  Idle --> Running: StartTurn
  Running --> PauseHuman: EnterPauseHuman (emitted := TRUE)<br/>↳ keeper_execution_receipt.ml: append →<br/>if needs_operator_broadcast disposition then emit_operator_broadcast
  Running --> StaleRunning: EnterStaleRunning (no emit — stalled keeper produces no receipt)
  StaleRunning --> StaleRunning: WatchdogEmit (emitted := TRUE)<br/>↳ keeper_stale_watchdog.ml: fork_stale_watchdog (fiber under ctx.sw) →<br/>emit_watchdog_broadcast → Keeper_execution_receipt.emit_stale_keeper_broadcast
  PauseHuman --> Resolved: Resolve [needs emitted]
  StaleRunning --> Resolved: Resolve [needs emitted]
  Resolved --> Idle: Recycle (emitted := FALSE)
  note right of StaleRunning
    OLD anchor said "keeper_supervisor.ml: stale watchdog fiber forks ... emit_stale_keeper_broadcast"
    — drifted: PR #10670 moved the watchdog into keeper_stale_watchdog.ml;
    keeper_supervisor.ml only does `let fork_stale_watchdog = Keeper_stale_watchdog.fork_stale_watchdog`.
    The OCaml module header already says "That citation pre-dates PR 10670".
  end note
  note left of Resolved
    Clean: PauseLeadsToBroadcast (phase ∈ {PauseHuman,StaleRunning}) ~> emitted holds.
    Buggy (EnterPauseHumanBuggy no emit, no WatchdogEmit, no Recycle): keepers stuck
    ~emitted forever → TLC reports "Deadlock reached" (non-zero exit; buggy fails as required,
    though a cleaner buggy model would keep Recycle so the liveness violation surfaces directly).
  end note
```

## What was checked (cross-check pass)

| Spec element | Runtime | Status |
|---|---|---|
| `EnterPauseHuman` emits at the phase transition | `keeper_execution_receipt.ml` — `append` does `if needs_operator_broadcast disposition then ... emit_operator_broadcast` (true for PauseHuman/StaleRunning-class dispositions) | ✓ accurate |
| `EnterStaleRunning` — no emit | stalled heartbeat fiber → no receipt → no `append` → no broadcast on its own | ✓ |
| `WatchdogEmit` — rescues `StaleRunning` from silence | `keeper_stale_watchdog.ml` — `fork_stale_watchdog` forks the watchdog fiber under `ctx.sw`; on stall its `emit_watchdog_broadcast` calls `Keeper_execution_receipt.emit_stale_keeper_broadcast` | ✓ — **anchor pointed at `keeper_supervisor.ml` (now only forwards); fixed** |
| `operator_disposition` "was a derived display field with no transition out" | `keeper_execution_receipt.ml` — `operator_disposition` still computes kind/reason; #10670 added the broadcast wiring around it | ✓ (past-tense framing is historically accurate) |
| `Resolve` / `Recycle` | `keeper_supervisor.ml` flips a keeper back to Idle after the broadcast is acknowledged | ✓ |
| `.cfg` / `-buggy.cfg` | both present | ✓ |
| Bug-Model contract | clean = no error (85 states, 36 distinct; `PauseLeadsToBroadcast` + `OperatorPauseEverHandled` pass); buggy = error (`Deadlock reached`) — re-verified | ✓ — non-zero exit (buggy fails the clean contract); failure mode is a deadlock, not the intended `PauseLeadsToBroadcast` violation (pre-existing — see Trade-off) |
| line-ref drift | none — spec already cites by symbol | ✓ (only the *file* in one anchor was wrong) |

## Before / After (excerpt)

```diff
- \* Anchors (OCaml runtime)
- \*   - lib/keeper/keeper_execution_receipt.ml: needs_operator_broadcast +
- \*     emit_operator_broadcast called from append (this PR's Step 2).
- \*   - lib/keeper/keeper_supervisor.ml: stale watchdog fiber forks under
- \*     ctx.sw and calls emit_stale_keeper_broadcast (this PR's Step 3).
+ \* Anchors (OCaml runtime — cited by symbol/function name, not line
+ \* number; iter 64 N-2.a convention)
+ \*   - keeper_execution_receipt.ml: [needs_operator_broadcast] +
+ \*     [emit_operator_broadcast], called from [append] ... EnterPauseHuman emit path.
+ \*   - keeper_stale_watchdog.ml: [fork_stale_watchdog] forks the
+ \*     stale-turn watchdog fiber under [ctx.sw] and (via [emit_watchdog_broadcast])
+ \*     calls [Keeper_execution_receipt.emit_stale_keeper_broadcast]. ... WatchdogEmit path.
+ \*     keeper_supervisor.ml only *forwards*: `let fork_stale_watchdog = Keeper_stale_watchdog.fork_stale_watchdog`.
+ \*     (Extracted out of keeper_supervisor.ml in PR #10670; the OCaml module's own
+ \*     header comment already flags the old citation here was stale.)
```

`specs/INDEX.md` regenerated: OperatorPauseBroadcast content-hash bump `2ef619cbcd73` → `8c678dba2425`.

## 왜 톱니처럼 정교하지 않은가

OperatorPauseBroadcast 모델 본문은 정확함 (FSM `Idle→Running→{PauseHuman,StaleRunning}→Resolved→Idle`, `EnterPauseHuman`에서 emit, `StaleRunning` 후 별도 `WatchdogEmit` — runtime의 receipt `append`가 PauseHuman/StaleRunning disposition에 broadcast emit + stale watchdog가 독립적으로 emit하는 것과 일치). 부족했던 건 "Anchors" 블록의 한 줄: `keeper_supervisor.ml: stale watchdog fiber forks ... emit_stale_keeper_broadcast`라고 했는데 PR #10670이 watchdog을 `keeper_stale_watchdog.ml`로 추출 (`fork_stale_watchdog`), `keeper_supervisor.ml`은 `let fork_stale_watchdog = Keeper_stale_watchdog.fork_stale_watchdog`로 forward만 하고, `emit_stale_keeper_broadcast`는 `keeper_execution_receipt.ml`에 있음. 흥미롭게도 OCaml 측이 *이미* 알고 있음 — `keeper_stale_watchdog.ml` 헤더 코멘트에 "That citation pre-dates PR 10670"라고 적혀 있음. 즉 OCaml 작성자는 spec 인용이 stale한 걸 보고 노트만 남기고 spec은 안 고침. 이 PR이 loop을 닫음 (spec 측을 runtime에 맞춤). sub-class 2 (code relocated, comment lags) — OCaml 측 노트가 cross-check 역할.

## 본 PR 수정

1. `OperatorPauseBroadcast.tla`의 "Anchors (OCaml runtime)" 블록 재작성 — `keeper_execution_receipt.ml` 앵커는 그대로 (정확), `keeper_supervisor.ml` 앵커를 `keeper_stale_watchdog.ml: fork_stale_watchdog` (fiber fork) + `Keeper_execution_receipt.emit_stale_keeper_broadcast` 체인 + `keeper_supervisor.ml` forwarding shim 노트 + PR #10670 추출 이력으로 교체. 2개 stale "this PR's Step 2/3" self-reference 제거. iter 64 N-2.a 헤더 노트. 모델 본문 byte-identical.
2. `specs/INDEX.md` 재생성 (content-hash bump).
3. 새 audit memo `docs/tla-audit/opb-r12-operator-pause-broadcast-firstentry-stale-watchdog-anchor-2026-05-12.md`.

영향 범위: spec 1개 (comment-only) + INDEX.md (생성) + 새 memo. OCaml 코드 변화 없음.

## Verification

- [x] `OperatorPauseBroadcast.tla` `git diff` → only comment lines changed (model body byte-identical)
- [x] runtime symbols verified: `needs_operator_broadcast`@777 / `emit_operator_broadcast`@861 / `append`@879 (`if needs_operator_broadcast disposition then ... emit_operator_broadcast`@885-887) / `operator_disposition`@438 / `emit_stale_keeper_broadcast` in `keeper_execution_receipt.ml`; `fork_stale_watchdog`@383 (forks `Eio.Fiber.fork ~sw:ctx.sw`@405, inner `emit_watchdog_broadcast`@510 → `Keeper_execution_receipt.emit_stale_keeper_broadcast`@512) in `keeper_stale_watchdog.ml`; `let fork_stale_watchdog = Keeper_stale_watchdog.fork_stale_watchdog`@181 in `keeper_supervisor.ml`; `keeper_stale_watchdog.ml`@32-33 header already says the old citation "pre-dates PR 10670"
- [x] `rg '\.ml:[0-9]' specs/keeper-state-machine/OperatorPauseBroadcast.tla` → none (spec was already symbol-anchored)
- [x] TLC clean `OperatorPauseBroadcast.cfg` → `Model checking completed. No error has been found.` (85 states, 36 distinct; temporal properties checked)
- [x] TLC buggy `OperatorPauseBroadcast-buggy.cfg` → `Error: Deadlock reached.` (non-zero exit — buggy spec fails the clean contract)
- [x] `bash scripts/gen-tla-index.sh > specs/INDEX.md` → only OperatorPauseBroadcast content-hash + timestamp/HEAD lines change
- [x] TLC artifacts (`*_TTrace_*`, `states/`) cleaned; `git status` → 1 modified spec + INDEX.md + 1 new memo only

## Trade-off

- 모델 본문은 손 안 댐. **Pre-existing buggy-cfg quirk** (이 PR에서 고치지 않음 — comment-only): `-buggy.cfg`가 "should report invariant or property violation"이라 했으나 TLC는 `Deadlock reached`를 보고함 — `SpecBuggy`의 `NextBuggy`가 `WatchdogEmit` *와* `Recycle`을 빼고 `EnterPauseHumanBuggy`(no emit)를 쓰니 PauseHuman/StaleRunning에 들어간 keeper가 영구히 stuck (`Resolve`는 `emitted[k]` 필요) → deadlock. 여전히 non-zero exit (buggy가 clean contract를 깨므로 OK)이지만, 더 깔끔한 buggy model은 `Recycle`을 유지해서 liveness property (`PauseLeadsToBroadcast`) violation이 직접 드러나게 할 것. iter 81의 `KeeperMemoryLifecycle-buggy.cfg`가 `TypeOK`를 먼저 보고한 것과 같은 family. 작은 spec follow-up 후보 (`NextBuggy`에 `Recycle` 추가, 또는 deadlock 받아들이고 cfg 코멘트 리워딩).
- `OperatorPauseBroadcast`은 `make -C specs check-clean` runner에 포함 — CI `tla-specs` job이 재실행.
- (별건) 이 loop의 in-flight PR 중 #14971 (KeeperPostTurnOrchestration line-ref sweep, iter 84) + #14975 (KeeperTurnSlot, iter 86)이 origin/main과 CONFLICTING (`specs/INDEX.md` content-hash 테이블 충돌 — 그 사이 #14972가 머지됨). #14971은 사용자가 추가 커밋 (`6c1d427d8` "switch mapping table to path.ml:symbol anchors (lint-checkable)")을 push한 상태라 loop이 건드리지 않음 — 사용자 또는 admin이 rebase. 번호 순 (#14971 → #14975 → #14976) 머지 또는 INDEX.md 재생성으로 해소.

## RFC 참조

`RFC-WAIVED: specs/keeper-state-machine/OperatorPauseBroadcast.tla (comment-only) + specs/INDEX.md (generated) + docs/tla-audit/ memo only. No lib/ code change. The spec models the operator-pause-broadcast notification lifecycle, not an RFC-gated subsystem (not credential/keeper_gh/host_config, not repo_manager, not operator_control credential/identity action handlers — the broadcast is a notification event, not a credential action; not keeper_sandbox/shell, not dashboard credential component, not .claude/hooks, not instructions/workflow). All cited OCaml symbols (needs_operator_broadcast, emit_operator_broadcast, append, operator_disposition, emit_stale_keeper_broadcast, fork_stale_watchdog) are existing — this PR only corrects a stale file/symbol anchor in the spec preamble.`

## 진행 추적

다음 iteration 시작점: 진행 메모리 `project_fsm_tla_loop_progress.md`의 "Current cursor" 참조. 후보 — **KeeperWorkPipeline.tla / KeeperApprovalQueue.tla first-entry audit** (미감사 잔여) OR `\.ml:[0-9]` zero-tolerance lint (#14971 + #14975 + #14976 머지 후 — 그 전엔 in-flight false-positive) OR R-D-2.a+R-D-1.a 번들 (KCAF `call_err` 3-way + `Cascade_fsm.Exhausted` 2-way split, MID ~150-300 LOC) OR KSM A-5 (22×19 update_conditions matrix) OR OperatorPauseBroadcast-buggy.cfg deadlock-vs-property follow-up (small).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
