### PR TITLE
perf(keeper,coord): non-blocking file reads in keeper/coord hot paths

### DIFF
--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -523,8 +523,7 @@ let keeper_uses_docker_sandbox ~config ~agent_name =
   else
     try
       let lines =
-        In_channel.with_open_text path In_channel.input_all
-        |> String.split_on_char '\n'
+        Fs_compat.load_file path |> String.split_on_char '\n'
       in
       let rec loop in_keeper = function
         | [] -> false

--- a/lib/keeper/keeper_exec_masc.ml
+++ b/lib/keeper/keeper_exec_masc.ml
@@ -112,7 +112,7 @@ let handle_keeper_masc_code_read
                Tool_code.max_file_size)
         else (
           try
-            let content = In_channel.with_open_text target In_channel.input_all in
+            let content = Fs_compat.load_file target in
             let lines = String.split_on_char '\n' content in
             let total_lines = List.length lines in
             let safe_offset = max 0 (min offset total_lines) in

--- a/lib/keeper/keeper_prompt_external.ml
+++ b/lib/keeper/keeper_prompt_external.ml
@@ -40,11 +40,10 @@ let strip_frontmatter (content : string) : string =
 
 let read_file path =
   try
-    let raw = In_channel.with_open_text path In_channel.input_all in
+    let raw = Fs_compat.load_file path in
     Some (strip_frontmatter raw)
   with
   | Sys_error _ -> None
-  | End_of_file -> None
 
 let load_uncached name =
   let path = behavior_path name in

--- a/lib/keeper/keeper_runtime_config.ml
+++ b/lib/keeper/keeper_runtime_config.ml
@@ -132,7 +132,9 @@ let toml_path ~base_path =
     Config_dir_resolver.keeper_runtime_toml_filename
 
 let read_file path =
-  try Ok (In_channel.with_open_text path In_channel.input_all)
+  (* Eio-native read (Fs_compat.load_file) so the keeper-runtime TOML
+     read does not block the whole domain on each refresh. *)
+  try Ok (Fs_compat.load_file path)
   with Sys_error msg -> Error msg
 
 (** Format a TOML scalar back to a string suitable for the boot override store.


### PR DESCRIPTION
## What

Continuation of #14922 (HTTP asset reads). Four more whole-file reads sit on Eio fiber paths but bypass `Fs_compat` and use `In_channel.with_open_text path In_channel.input_all` — a blocking syscall that stalls every other fiber on the domain (other keepers, HTTP/SSE handlers) for the read duration:

| Site | Context |
|---|---|
| `keeper_runtime_config.read_file` | keeper-runtime TOML refresh |
| `keeper_prompt_external.read_file` | keeper prompt-behavior file load |
| `keeper_exec_masc` (masc-tool `read_file` handler) | keeper running a `read` tool call |
| `coord_worktree.keeper_uses_docker_sandbox` | docker-sandbox probe (`[keeper] sandbox_profile`) |

All swap to `Fs_compat.load_file`: Eio-native (`Eio.Path.load`) when the global fs is wired at boot (`server_runtime_bootstrap.set_fs`), Unix fallback otherwise (tests, pre-boot).

Net: **+6 / -6**.

## Why it's safe

- Whole-file read → string is byte-equivalent. `Fs_compat.load_file` raises `Sys_error` on I/O failure (Eio.Io normalized internally) — the only failure exception, same as `In_channel.input_all` on a missing file — so every existing `with Sys_error _` / `with Sys_error msg -> Error msg` clause is unchanged. `keeper_exec_masc`'s clause already re-raises `Eio.Cancel.Cancelled`; the others catch only `Sys_error`, so cancellation propagates correctly.
- Dropped a dead `End_of_file -> None` arm in `keeper_prompt_external.read_file` — neither `input_all` nor `load_file` raises it, and `strip_frontmatter` is pure string ops.

## Test

```
$ dune build lib/                          # clean
$ dune exec test/test_keeper_prompt_external.exe   # 6 OK
$ dune exec test/test_keeper_runtime_toml.exe      # 31 OK
$ dune exec test/test_keeper_masc_bridge.exe       # 2 failures — PRE-EXISTING on origin/main
```

`test_keeper_masc_bridge` `dispatch 1/2` fail identically before and after this change (`{"error":"keeper not found in registry: bridge-test"}` — a registry test-setup issue, unrelated to file IO). Filed mentally as a pre-existing flake; not introduced here.

`coord_worktree.keeper_uses_docker_sandbox` has no direct test (pre-existing gap); the read-path change is byte-equivalent.

RFC-WAIVED: equivalent-preserving file-read swap onto an existing Eio-aware helper; touches `lib/keeper/keeper_*` but no credential/identity/auth/sandbox-containment surface — these are config/prompt/file-read paths only, none in the `keeper_credential_*` / `keeper_sandbox*` / `keeper_shell_*` / `host_config_*` set the agent-delegation rule enumerates.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>