### PR TITLE
docs(specs): KWP R-13 — refresh KeeperWorkPipeline aspirational-design banner (decayed probes + flag KNOWN_FAILURES model bug)

### DIFF
--- a/docs/tla-audit/kwp-r13-work-pipeline-banner-staleness-refresh-2026-05-12.md
+++ b/docs/tla-audit/kwp-r13-work-pipeline-banner-staleness-refresh-2026-05-12.md
@@ -1,0 +1,42 @@
+# KWP R-13 — KeeperWorkPipeline.tla: aspirational-design banner anti-staleness refresh — two of its 2026-04-20 probes had decayed; the clean model still violates an invariant (KNOWN_FAILURES)
+
+**Date**: 2026-05-12 · **Iteration**: 88 (`/loop` FSM/TLA+/OCaml drift hunt) · **Phase**: R (anti-staleness re-verification of an aspirational/dormant spec — sub-class 5)
+**Spec**: `specs/keeper-state-machine/KeeperWorkPipeline.tla` (383 LOC) — ASPIRATIONAL DESIGN spec for a future keeper autonomous-work pipeline (workspace lifecycle / file ops / commit safety / PR creation / review cycles), with a bug-model partner `specs/bug-models/KeeperWorkPipelineBug.tla`
+**Verdict**: **The "ASPIRATIONAL DESIGN INVARIANT" banner's *spirit* still holds — the modeled runtime module (`keeper_exec_github.ml`) still doesn't exist, and the modeled primitives (`force_push_attempted` / `workspace_init` / `workspace_cleaned` / `commit_identity` / `submit_count`) still have 0 hits in `lib/keeper/`. But two of its 2026-04-20 anti-staleness probes have decayed: (a) `find lib -name "*github*"` no longer returns 0 hits — a *different* github-named file (`keeper_tool_github_pr.ml`, a PR-operations tool surface, not the work-pipeline exec module) appeared since; (b) "This spec is NOT in scripts/tla-check.sh (TLC does not run it)" is wrong — `scripts/tla-check.sh` exists, the spec is in `specs/Makefile` + `scripts/ci/check-tla-harness-coverage.sh`, and it has a bug-model partner; the reason it isn't actually checked is that it's in `specs/Makefile`'s `KNOWN_FAILURES` ("clean spec violates invariant (exit 13) — model needs fix, not path issue") — i.e., a *model* bug, distinct from the runtime-not-wired situation.** Banner refreshed comment-only; model body byte-identical; TLC not re-run (the spec is a `KNOWN_FAILURES` entry — its clean model intentionally fails right now; comment-only change, honest-doc posture).
+
+## Why this spec
+
+The iter-81 / iter-85 wrap-ups + iter 86 (KeeperTurnSlot) + iter 87 (OperatorPauseBroadcast) worked through never-first-entry-audited specs. KeeperWorkPipeline is in the "aspirational / dormant" bucket (like KCB iter 70, KCC iter 76, KCounterCausality) — for those the first-entry job is an anti-staleness re-verification of the disclosure banner, not a model↔runtime cross-check (there's no runtime to cross-check against).
+
+## What the 2026-04-20 banner claimed vs. 2026-05-12 reality
+
+| Banner claim (2026-04-20) | 2026-05-12 status | Action |
+|---|---|---|
+| `lib/keeper/keeper_exec_github.ml` does NOT exist | **Still true** — `ls lib/keeper/keeper_exec_github.ml` → no such file | keep, re-dated |
+| `find lib -name "*github*"` returns 0 hits in lib/keeper/ | **Decayed** — `lib/keeper/keeper_tool_github_pr.ml` + `.mli` now exist ("Dedicated GitHub PR keeper tools" — a PR-operations tool surface, NOT the autonomous-work-pipeline exec module the spec models) | replace the probe: the durable signal is `rg 'force_push_attempted\|workspace_init' lib/keeper/` → 0; note the new github-named file is unrelated |
+| The primitives (`force_push_attempted`, `workspace_init`, `workspace_cleaned`, `commit_identity`, `submit_count`) have 0 hits in lib/keeper/ | **Still true** — `rg 'force_push_attempted\|workspace_init\|workspace_cleaned\|commit_identity\|submit_count' lib/keeper/` → 0 | keep — this is the right probe |
+| "This spec is NOT in scripts/tla-check.sh (TLC does not run it)" | **Decayed / misleading** — `scripts/tla-check.sh` exists; the spec is referenced in `specs/Makefile` and `scripts/ci/check-tla-harness-coverage.sh`; `specs/bug-models/KeeperWorkPipelineBug.tla` exists. The reason it isn't *checked* is that it's in `specs/Makefile`'s `KNOWN_FAILURES` (`KeeperWorkPipeline: clean spec violates invariant (exit 13) — model needs fix, not path issue`), so `make -C specs check-clean` skips it | rewrite: it's in the corpus but in `KNOWN_FAILURES` due to a *model* bug (an invariant the clean spec violates) — separate from the runtime-not-wired situation |
+| Actual keeper exec surface: `keeper_exec_board / _context / _fs / _masc / _memory + keeper_tool_pr_review` | Still accurate; add `keeper_tool_github_pr` to the list | append |
+
+## The substantive finding (beyond the stale banner)
+
+`KeeperWorkPipeline.tla`'s **clean** model violates one of its own invariants (exit 13 — that's why it's in `KNOWN_FAILURES`). The "ASPIRATIONAL DESIGN" banner explains why the spec isn't wired to a runtime, but it didn't say the model is *self-inconsistent* — i.e., even as forward-looking design documentation, the safety properties as written are not all simultaneously satisfiable by the model's own actions. The refreshed banner now says so explicitly and notes this strengthens the case for revisiting the #9044 retire/re-target/banner trichotomy: a "banner" (keep as design doc) option is weaker when the design doc has an internal contradiction. Fixing the model bug (discriminating which invariant is violated and either weakening it or adjusting the actions) is out of scope for this comment-only anti-staleness refresh — it's a standing follow-up; the `KNOWN_FAILURES` note ("model needs fix") already tracks it.
+
+## Cross-checks (pass)
+
+| Item | Status |
+|---|---|
+| `keeper_exec_github.ml` exists? | no — `ls` → no such file |
+| modeled primitives in `lib/keeper/`? | 0 hits |
+| `keeper_tool_github_pr.ml` exists & is it the modeled surface? | exists; it's "Dedicated GitHub PR keeper tools" (PR-operations tool surface), not the work-pipeline exec module — banner note added |
+| spec in corpus / harness coverage? | yes — `specs/Makefile`, `scripts/ci/check-tla-harness-coverage.sh`; bug-model `specs/bug-models/KeeperWorkPipelineBug.tla` exists |
+| spec actually checked by `make check-clean`? | no — in `specs/Makefile` `KNOWN_FAILURES` (clean violates invariant, exit 13) |
+| `specs/INDEX.md` | regenerated — only KeeperWorkPipeline content-hash bump (`ab03a79d78e6` → `1b85e3e4ba20`) + timestamp/HEAD |
+| model body | byte-identical (banner comment only) |
+
+## Sub-class placement & follow-up
+
+- Class = **sub-class 5 (dormancy / aspirational — already-disclosed future-design spec; anti-staleness re-verification)** — same pattern as iter 70 (KCB R-1) and iter 76 (KCC R-3). Here the re-verification found *decay in the disclosure probes themselves* (the `find *github*` probe and the "not in tla-check.sh" claim), plus surfaced the standing model-bug status more explicitly.
+- **Follow-up owed (not this PR)**: fix the clean `KeeperWorkPipeline.tla` invariant violation (it's in `KNOWN_FAILURES` — "model needs fix"). That's a model-body change to an aspirational 383-LOC / 13-variable spec — needs a dedicated PR with TLC iteration to identify which invariant fails and why. Low priority (the spec is dormant), but it's the thing standing between this spec and being a clean design doc. Alternatively, the #9044 trichotomy could resolve it (retire the spec, or re-target it to the actual exec surface).
+- This is *not* an RFC-gated subsystem (it models an aspirational autonomous-work pipeline; the actual touched files are none — comment-only spec change; not credential/keeper_gh/host_config, not repo_manager, not operator_control credential handlers, not keeper_sandbox/shell, not dashboard credential component, not .claude/hooks, not instructions/workflow). RFC-WAIVED.
+- No new audit memo follow-up owed beyond the model-bug fix noted above. Comment-only — `specs/INDEX.md` regenerated.

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-12T05:44:03Z (HEAD: 94fdb5078)
+Generated: 2026-05-12T05:53:24Z (HEAD: aa4c2f57c)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -149,7 +149,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperTraceSpec.tla | KeeperTraceSpec | manual | 2 | 1 | clean={inv:TypeOK, inv:RunningRequiresFiber, inv:OfflineRequiresLaunchPending, inv:StoppedRequiresDrain, inv:DeadRequiresNoBudget, inv:DerivePhaseAgreement, prop:RestartCountMonotonic, prop:BudgetNeverRevives, prop:TransitionMatrixAgreement} buggy={inv:TypeOK, inv:DerivePhaseAgreementMustHold} | 733248761720 |
 | KeeperTurnCycle.tla | KeeperTurnCycle | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:SelectingRequiresToolPolicyMustHold} | 1cd52d4f7998 |
 | KeeperTurnSlot.tla | KeeperTurnSlot | manual | 2 | 1 | clean={inv:Safety} buggy={inv:RetryPhaseRequiresReleased} | f75c324a95fe |
-| KeeperWorkPipeline.tla | KeeperWorkPipeline | manual | 1 | 0 | clean={inv:TypeOK, inv:WorkspaceAlwaysBounded, inv:IdentityConsistent, inv:NoForcePush, inv:ReviewBeforeSubmit, prop:EventualCompletion, prop:NoOrphanWorkspace} | ab03a79d78e6 |
+| KeeperWorkPipeline.tla | KeeperWorkPipeline | manual | 1 | 0 | clean={inv:TypeOK, inv:WorkspaceAlwaysBounded, inv:IdentityConsistent, inv:NoForcePush, inv:ReviewBeforeSubmit, prop:EventualCompletion, prop:NoOrphanWorkspace} | 1b85e3e4ba20 |
 | OperatorPauseBroadcast.tla | OperatorPauseBroadcast | manual | 2 | 1 | clean={inv:TypeOK, inv:EmittedBeforeResolved, prop:PauseLeadsToBroadcast, prop:OperatorPauseEverHandled} buggy={inv:TypeOK, prop:PauseLeadsToBroadcast} | 8c678dba2425 |
 
 ### specs/keeper-turn-fsm (1 specs)

--- a/specs/keeper-state-machine/KeeperWorkPipeline.tla
+++ b/specs/keeper-state-machine/KeeperWorkPipeline.tla
@@ -1,19 +1,37 @@
 ---- MODULE KeeperWorkPipeline ----
 \* ── STATUS: ASPIRATIONAL DESIGN INVARIANT (not wired to current runtime) ──
-\* This spec describes a future workspace/PR/commit pipeline. As of
-\* 2026-04-20:
-\*   - lib/keeper/keeper_exec_github.ml does NOT exist
-\*     (`find lib -name "*github*"` returns 0 hits in lib/keeper/)
+\* This spec describes a future workspace/PR/commit pipeline. Re-verified
+\* 2026-05-12 (iter 88 — banner anti-staleness check):
+\*   - lib/keeper/keeper_exec_github.ml STILL does not exist (the module
+\*     this spec models).  NOTE: the 2026-04-20 probe `find lib -name
+\*     "*github*"` is no longer the right signal — a *different*
+\*     github-named file appeared since (lib/keeper/keeper_tool_github_pr.ml,
+\*     "Dedicated GitHub PR keeper tools" — a PR-operations tool surface,
+\*     not the autonomous-work-pipeline exec module).  The durable signal
+\*     is the primitive set below.
 \*   - The primitives this spec models — `force_push_attempted`,
 \*     `workspace_init`, `workspace_cleaned`, `commit_identity`,
-\*     `submit_count` — have 0 hits in lib/keeper/
-\*   - This spec is NOT in scripts/tla-check.sh (TLC does not run it)
+\*     `submit_count` — STILL have 0 hits in lib/keeper/ (this is the
+\*     anti-staleness probe to use: `rg 'force_push_attempted|workspace_init'
+\*     lib/keeper/` → 0).
+\*   - Runner status (was "NOT in scripts/tla-check.sh"): this spec IS in
+\*     the corpus (specs/Makefile, scripts/ci/check-tla-harness-coverage.sh)
+\*     and has a bug-model partner (specs/bug-models/KeeperWorkPipelineBug.tla),
+\*     but it is listed in specs/Makefile's KNOWN_FAILURES — "clean spec
+\*     violates invariant (exit 13) — model needs fix, not path issue" — so
+\*     `make -C specs check-clean` skips it.  That invariant violation is a
+\*     MODEL bug in the clean spec, separate from the runtime-not-wired
+\*     situation; it is a standing follow-up (the aspirational properties
+\*     below are not even self-consistent yet, which strengthens the case
+\*     for revisiting the #9044 trichotomy — see below).
 \* The actual keeper exec surface is keeper_exec_board / _context / _fs /
-\* _masc / _memory + keeper_tool_pr_review, with a different state shape.
+\* _masc / _memory + keeper_tool_pr_review (+ keeper_tool_github_pr), with a
+\* different state shape.
 \* See issue #9044 for the retire / re-target / banner trichotomy.
 \* This banner takes the "banner" option to make the aspirational nature
 \* explicit; treat the safety properties below as forward-looking design
-\* documentation, not runtime invariants.
+\* documentation, not runtime invariants — and note that one of them is
+\* currently violated by the model itself (KNOWN_FAILURES, above).
 \* ──────────────────────────────────────────────────────────────────────
 \*
 \* Keeper Autonomous Work Pipeline — TLA+ Formal Specification (DESIGN)


### PR DESCRIPTION
## Finding (Iteration 88, Phase R — anti-staleness re-verification of KeeperWorkPipeline.tla's aspirational-design banner)

**Spec**: `specs/keeper-state-machine/KeeperWorkPipeline.tla` (383 LOC) — ASPIRATIONAL DESIGN spec for a future keeper autonomous-work pipeline (workspace lifecycle / file ops / commit safety / PR creation / review cycles), with a bug-model partner `specs/bug-models/KeeperWorkPipelineBug.tla`
**Aspect**: the "STATUS: ASPIRATIONAL DESIGN INVARIANT" banner — are its 2026-04-20 anti-staleness probes still valid?
**Verdict**: **banner *spirit* still holds (the modeled `keeper_exec_github.ml` still doesn't exist; the modeled primitives still have 0 hits in `lib/keeper/`), but two probes decayed: (a) `find lib -name "*github*"` no longer returns 0 — `keeper_tool_github_pr.ml` (a PR-operations tool, NOT the work-pipeline exec module) appeared since; (b) "NOT in scripts/tla-check.sh (TLC does not run it)" is wrong — `scripts/tla-check.sh` exists, the spec is in `specs/Makefile` + `scripts/ci/check-tla-harness-coverage.sh` and has a bug-model partner; the real reason it isn't checked is it's in `specs/Makefile`'s `KNOWN_FAILURES` ("clean spec violates invariant (exit 13) — model needs fix") — a *model* bug, distinct from the runtime-not-wired situation.** Banner refreshed comment-only.
**Risk**: LOW — comment-only spec change (banner block only); model body byte-identical; TLC not re-run (the spec is a `KNOWN_FAILURES` entry — its clean model intentionally fails right now; honest-doc posture for a comment-only change to a dormant spec).
**Workaround signature**: N/A — refreshes a disclosure banner; no string classifier / catch-all / cap.

## 순서도 (banner probe decay)

```mermaid
flowchart TD
  b2020["2026-04-20 banner probes"]
  p1["keeper_exec_github.ml does NOT exist<br/>(find lib -name '*github*' → 0)"]
  p2["primitives force_push_attempted/workspace_init/<br/>workspace_cleaned/commit_identity/submit_count → 0 in lib/keeper/"]
  p3["NOT in scripts/tla-check.sh<br/>(TLC does not run it)"]
  b2020 --> p1
  b2020 --> p2
  b2020 --> p3
  s1["2026-05-12: keeper_exec_github.ml STILL absent ✓<br/>BUT keeper_tool_github_pr.ml now exists (PR-ops tool,<br/>not the work-pipeline exec module) → 'find *github*' probe DECAYED"]
  s2["2026-05-12: primitives STILL 0 hits ✓ — this is the durable probe<br/>(`rg 'force_push_attempted|workspace_init' lib/keeper/` → 0)"]
  s3["2026-05-12: scripts/tla-check.sh EXISTS; spec in specs/Makefile +<br/>scripts/ci/check-tla-harness-coverage.sh; KeeperWorkPipelineBug.tla exists.<br/>Real reason it's not checked: in specs/Makefile KNOWN_FAILURES<br/>('clean spec violates invariant exit 13 — model needs fix') → claim DECAYED"]
  p1 --> s1
  p2 --> s2
  p3 --> s3
  note["The model-bug-in-KNOWN_FAILURES is a standing follow-up:<br/>the aspirational properties aren't even self-consistent yet<br/>→ strengthens the #9044 retire/re-target/banner trichotomy"]
  s3 --> note
```

## What the 2026-04-20 banner claimed vs. 2026-05-12 reality

| Banner claim (2026-04-20) | 2026-05-12 status | Action |
|---|---|---|
| `keeper_exec_github.ml` does NOT exist | **Still true** (`ls` → no such file) | keep, re-dated |
| `find lib -name "*github*"` → 0 hits in lib/keeper/ | **Decayed** — `keeper_tool_github_pr.ml` + `.mli` now exist ("Dedicated GitHub PR keeper tools" — a PR-operations tool surface, NOT the autonomous-work-pipeline exec module the spec models) | replace probe with `rg 'force_push_attempted\|workspace_init' lib/keeper/` → 0; note the new github file is unrelated |
| modeled primitives → 0 hits in lib/keeper/ | **Still true** | keep — this IS the right probe |
| "NOT in scripts/tla-check.sh (TLC does not run it)" | **Decayed/misleading** — `scripts/tla-check.sh` exists; spec is in `specs/Makefile` + `scripts/ci/check-tla-harness-coverage.sh`; `specs/bug-models/KeeperWorkPipelineBug.tla` exists. It isn't *checked* because it's in `specs/Makefile`'s `KNOWN_FAILURES` (`clean spec violates invariant (exit 13) — model needs fix, not path issue`) → `make -C specs check-clean` skips it | rewrite: in the corpus but in `KNOWN_FAILURES` due to a *model* bug, separate from the runtime-not-wired situation |
| actual exec surface: `keeper_exec_board / _context / _fs / _masc / _memory + keeper_tool_pr_review` | still accurate; add `keeper_tool_github_pr` | append |

## The substantive bit (beyond the stale banner)

The **clean** `KeeperWorkPipeline.tla` violates one of its own invariants (exit 13 — that's the `KNOWN_FAILURES` entry). The banner explained why the spec isn't wired to a runtime, but not that the model is *self-inconsistent* — even as forward-looking design documentation, the safety properties as written aren't all simultaneously satisfiable by the model's own actions. The refreshed banner now says so and notes it strengthens the #9044 retire/re-target/banner trichotomy (a "banner" / keep-as-design-doc option is weaker when the design doc has an internal contradiction). Fixing that is out of scope for this comment-only refresh — it's a standing follow-up; `KNOWN_FAILURES` already tracks it ("model needs fix").

## Before / After (excerpt)

```diff
- \* This spec describes a future workspace/PR/commit pipeline. As of
- \* 2026-04-20:
- \*   - lib/keeper/keeper_exec_github.ml does NOT exist
- \*     (`find lib -name "*github*"` returns 0 hits in lib/keeper/)
+ \* This spec describes a future workspace/PR/commit pipeline. Re-verified
+ \* 2026-05-12 (iter 88 — banner anti-staleness check):
+ \*   - lib/keeper/keeper_exec_github.ml STILL does not exist (the module
+ \*     this spec models).  NOTE: the 2026-04-20 probe `find lib -name
+ \*     "*github*"` is no longer the right signal — a *different*
+ \*     github-named file appeared since (lib/keeper/keeper_tool_github_pr.ml,
+ \*     "Dedicated GitHub PR keeper tools" ...).  The durable signal is
+ \*     the primitive set below.
...
- \*   - This spec is NOT in scripts/tla-check.sh (TLC does not run it)
+ \*   - Runner status (was "NOT in scripts/tla-check.sh"): this spec IS in
+ \*     the corpus (specs/Makefile, scripts/ci/check-tla-harness-coverage.sh)
+ \*     and has a bug-model partner ... but it is listed in specs/Makefile's
+ \*     KNOWN_FAILURES — "clean spec violates invariant (exit 13) — model
+ \*     needs fix, not path issue" — so `make -C specs check-clean` skips it.
+ \*     That invariant violation is a MODEL bug ... a standing follow-up ...
```

`specs/INDEX.md` regenerated: KeeperWorkPipeline content-hash bump `ab03a79d78e6` → `1b85e3e4ba20`.

## 왜 톱니처럼 정교하지 않은가

KeeperWorkPipeline은 dormant/aspirational spec (banner가 "not wired to current runtime"이라 명시) — 첫 진입 감사는 model↔runtime cross-check가 아니라 disclosure banner의 anti-staleness 재검증 (iter 70 KCB / iter 76 KCC 패턴). 재검증 결과: banner의 *정신*은 유지됨 (`keeper_exec_github.ml` 여전히 없음, 모델 primitive 여전히 0 hit) but 두 probe가 부패함 — (a) `find lib -name "*github*"`가 이제 0이 아님: `keeper_tool_github_pr.ml` ("Dedicated GitHub PR keeper tools" — PR 도구 surface, 이 spec이 모델하는 work-pipeline exec 모듈 아님)이 생김; (b) "NOT in scripts/tla-check.sh (TLC does not run it)"가 틀림: `scripts/tla-check.sh` 존재, spec이 `specs/Makefile` + `scripts/ci/check-tla-harness-coverage.sh`에 있고 bug-model partner도 있음 — 안 돌아가는 *실제 이유*는 `specs/Makefile` `KNOWN_FAILURES`에 있어서 ("clean spec violates invariant (exit 13) — model needs fix") `make check-clean`이 skip함. 즉 clean 모델이 *자기 invariant를 위반*하는 model bug가 따로 있음 — banner는 runtime 미연결만 설명했지 모델 자체가 self-inconsistent하다는 건 안 밝힘. banner refresh로 둘 다 정정 + #9044 trichotomy 재검토 근거 추가.

## 본 PR 수정

1. `KeeperWorkPipeline.tla`의 STATUS 배너 refresh — 2026-04-20 → 2026-05-12 재검증: `keeper_exec_github.ml` 여전히 없음 (유지), `find *github*` probe를 primitive-set probe (`rg 'force_push_attempted|workspace_init' lib/keeper/` → 0)로 교체 + `keeper_tool_github_pr.ml`이 무관한 파일임을 노트, "NOT in scripts/tla-check.sh" 클레임을 "in corpus but in KNOWN_FAILURES (clean violates invariant exit 13 — model bug, runtime 미연결과 별개)"로 재작성, exec surface 목록에 `keeper_tool_github_pr` 추가, #9044 trichotomy 재검토 근거 (모델 self-inconsistency) 추가. 모델 본문 byte-identical.
2. `specs/INDEX.md` 재생성 (content-hash bump).
3. 새 audit memo `docs/tla-audit/kwp-r13-work-pipeline-banner-staleness-refresh-2026-05-12.md`.

영향 범위: spec 1개 (comment-only) + INDEX.md (생성) + 새 memo. OCaml 코드 변화 없음.

## Verification

- [x] `KeeperWorkPipeline.tla` `git diff` → only banner comment lines changed (model body byte-identical)
- [x] `ls lib/keeper/keeper_exec_github.ml` → no such file (banner's modeled module still absent)
- [x] `rg 'force_push_attempted|workspace_init|workspace_cleaned|commit_identity|submit_count' lib/keeper/` → 0 hits (modeled primitives still absent)
- [x] `lib/keeper/keeper_tool_github_pr.ml` exists ("Dedicated GitHub PR keeper tools" — PR-operations tool surface, not the work-pipeline exec module)
- [x] `scripts/tla-check.sh` exists; `KeeperWorkPipeline` in `specs/Makefile` `KNOWN_FAILURES` ("clean spec violates invariant (exit 13) — model needs fix, not path issue"); also in `scripts/ci/check-tla-harness-coverage.sh`; `specs/bug-models/KeeperWorkPipelineBug.tla` exists
- [x] `bash scripts/gen-tla-index.sh > specs/INDEX.md` → only KeeperWorkPipeline content-hash + timestamp/HEAD lines change
- [x] no TLC run (spec is a `KNOWN_FAILURES` entry — clean model intentionally fails; comment-only change); `git status` → 1 modified spec + INDEX.md + 1 new memo only

## Trade-off

- 모델 본문은 손 안 댐. **Standing follow-up (이 PR 밖)**: clean `KeeperWorkPipeline.tla`가 자기 invariant를 위반 (exit 13 — `KNOWN_FAILURES` 엔트리). 그 fix는 aspirational 383-LOC / 13-variable spec의 model-body 변경이라 어느 invariant가 왜 깨지는지 TLC iteration으로 파악해야 함 — 별도 PR. 우선순위 낮음 (spec dormant), 다만 이게 spec을 clean design doc으로 만드는 데 필요. 대안: #9044 trichotomy (retire / re-target to actual exec surface)로 해소.
- `KeeperWorkPipeline.tla`은 `make -C specs check-clean`에서 `KNOWN_FAILURES`로 skip되므로 이 banner 변경이 CI 결과를 바꾸지 않음. INDEX hash bump이 `tla-specs` job을 트리거하긴 함.

## RFC 참조

`RFC-WAIVED: specs/keeper-state-machine/KeeperWorkPipeline.tla (comment-only banner refresh) + specs/INDEX.md (generated) + docs/tla-audit/ memo only. No lib/ code change. The spec models an aspirational autonomous-work pipeline; it is not wired to any runtime, and it is not an RFC-gated subsystem (not credential/keeper_gh/host_config, not repo_manager, not operator_control credential handlers, not keeper_sandbox/shell, not dashboard credential component, not .claude/hooks, not instructions/workflow). This PR only re-dates/corrects the spec's own staleness-disclosure banner.`

## 진행 추적

다음 iteration 시작점: 진행 메모리 `project_fsm_tla_loop_progress.md`의 "Current cursor" 참조. 후보 — **KeeperApprovalQueue.tla first-entry audit** (144 LOC, 미감사) OR `\.ml:[0-9]` zero-tolerance lint (#14971 + #14975 머지 후 — 그 전엔 in-flight false-positive; #14968+#14972+#14977 이미 MERGED) OR **KeeperWorkPipeline 모델 버그 fix** (KNOWN_FAILURES, 별도 PR — clean spec invariant 위반) OR R-D-2.a+R-D-1.a 번들 (KCAF, MID ~150-300 LOC) OR KSM A-5 (22×19 matrix) OR OperatorPauseBroadcast-buggy.cfg deadlock-vs-property follow-up (작은 spec).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
