### PR TITLE
feat(ide): enable warning 4 on masc_ide (RFC-0071 §3.4)

### DIFF
--- a/lib/ide/dune
+++ b/lib/ide/dune
@@ -4,6 +4,8 @@
  (name masc_ide)
  (public_name masc_mcp.ide)
  (wrapped false)
+ ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on.
+ (flags (:standard -w +4))
  (modules
   ide_annotation_types
   ide_annotations


### PR DESCRIPTION
## Summary
RFC-0071 §3.4 Phase 5 ratchet — enable OCaml `-w +4` (fragile-match) on `lib/ide`.

- `lib/ide/dune` ← `(flags (:standard -w +4))`
- No source changes: every `| _ ->` arm in this sublib matches on `option` / `string` / `list` (Yojson parsing fallbacks), which warning 4 does not flag.

Cumulative `-w +4` sublibs: **38** (37 incl. `lib/autoresearch` #14974 + this).

## Test plan
- [x] `dune build --root . lib/ide/` — clean
- [x] `dune build --root . @check` — no downstream breakage

RFC-WAIVED: leaf-module compiler-flag ratchet under RFC-0071 §3.4; touches no credential/identity/operator/sandbox/hooks/workflow surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)