### PR TITLE
feat(cascade_decl): enable warning 4 + close 15 fragile sites (RFC-0071 §3.4)

### DIFF
--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -260,7 +260,7 @@ let parse_providers (toml : Otoml.t) : (cascade_provider list, parse_error list)
         (List.filter_map
            (function
              | Ok p -> Some p
-             | _ -> None)
+             | Error _ -> None)
            results)
 ;;
 
@@ -419,7 +419,7 @@ let parse_models (toml : Otoml.t) : (cascade_model_spec list, parse_error list) 
         (List.filter_map
            (function
              | Ok m -> Some m
-             | _ -> None)
+             | Error _ -> None)
            results)
 ;;
 
@@ -436,6 +436,19 @@ let is_reserved (name : string) : bool = List.mem name reserved_namespaces
 type provider_table_entry =
   | Binding_entry of cascade_binding
   | Alias_entry of cascade_alias
+
+(* [Otoml.t] is a 3rd-party closed variant with 12 value constructors;
+   this parser only ever distinguishes "table-shaped" (TomlTable /
+   TomlInlineTable) from everything else. Enumerating the other 10 once
+   here satisfies warning 4 and means an [otoml] version bump that adds a
+   value constructor breaks exactly this site rather than a dozen call
+   sites. *)
+let is_toml_table : Otoml.t -> bool = function
+  | Otoml.TomlTable _ | Otoml.TomlInlineTable _ -> true
+  | Otoml.TomlString _ | Otoml.TomlInteger _ | Otoml.TomlFloat _
+  | Otoml.TomlBoolean _ | Otoml.TomlOffsetDateTime _ | Otoml.TomlLocalDateTime _
+  | Otoml.TomlLocalDate _ | Otoml.TomlLocalTime _ | Otoml.TomlArray _
+  | Otoml.TomlTableArray _ -> false
 
 let parse_binding_fields (provider_id : string) (model_id : string) (tbl : Otoml.t)
   : cascade_binding
@@ -495,22 +508,8 @@ let parse_provider_alias_table (provider_id : string) (tbl : Otoml.t)
     (fun (model_id_or_alias, sub) ->
        match sub with
        | Otoml.TomlTable fields | Otoml.TomlInlineTable fields ->
-         let leaf_fields =
-           List.filter
-             (fun (_, v) ->
-                match v with
-                | Otoml.TomlTable _ | Otoml.TomlInlineTable _ -> false
-                | _ -> true)
-             fields
-         in
-         let sub_tables =
-           List.filter
-             (fun (_, v) ->
-                match v with
-                | Otoml.TomlTable _ | Otoml.TomlInlineTable _ -> true
-                | _ -> false)
-             fields
-         in
+         let leaf_fields = List.filter (fun (_, v) -> not (is_toml_table v)) fields in
+         let sub_tables = List.filter (fun (_, v) -> is_toml_table v) fields in
          let binding =
            let synthetic_tbl = Otoml.TomlTable leaf_fields in
            parse_binding_fields provider_id model_id_or_alias synthetic_tbl
@@ -523,7 +522,11 @@ let parse_provider_alias_table (provider_id : string) (tbl : Otoml.t)
              sub_tables
          in
          Binding_entry binding :: aliases
-       | _ -> [ Binding_entry (parse_binding_fields provider_id model_id_or_alias sub) ])
+       | Otoml.TomlString _ | Otoml.TomlInteger _ | Otoml.TomlFloat _
+       | Otoml.TomlBoolean _ | Otoml.TomlOffsetDateTime _ | Otoml.TomlLocalDateTime _
+       | Otoml.TomlLocalDate _ | Otoml.TomlLocalTime _ | Otoml.TomlArray _
+       | Otoml.TomlTableArray _ ->
+         [ Binding_entry (parse_binding_fields provider_id model_id_or_alias sub) ])
     entries
 ;;
 
@@ -536,12 +539,7 @@ let parse_bindings_and_aliases (toml : Otoml.t)
      [Otoml.get_table] in [parse_provider_alias_table]. *)
   let provider_aliases =
     List.filter
-      (fun (name, value) ->
-         (not (is_reserved name))
-         &&
-         match value with
-         | Otoml.TomlTable _ | Otoml.TomlInlineTable _ -> true
-         | _ -> false)
+      (fun (name, value) -> (not (is_reserved name)) && is_toml_table value)
       top_entries
   in
   let all_entries =
@@ -553,14 +551,14 @@ let parse_bindings_and_aliases (toml : Otoml.t)
     List.filter_map
       (function
         | Binding_entry b -> Some b
-        | _ -> None)
+        | Alias_entry _ -> None)
       all_entries
   in
   let aliases =
     List.filter_map
       (function
         | Alias_entry a -> Some a
-        | _ -> None)
+        | Binding_entry _ -> None)
       all_entries
   in
   bindings, aliases
@@ -667,7 +665,7 @@ let parse_tiers (toml : Otoml.t) : (cascade_tier list, parse_error list) result 
         (List.filter_map
            (function
              | Ok t -> Some t
-             | _ -> None)
+             | Error _ -> None)
            results)
 ;;
 
@@ -716,7 +714,7 @@ let parse_tier_groups (toml : Otoml.t)
         (List.filter_map
            (function
              | Ok g -> Some g
-             | _ -> None)
+             | Error _ -> None)
            results)
 ;;
 
@@ -729,12 +727,11 @@ let parse_routes (toml : Otoml.t) : cascade_route list =
     let entries = Otoml.get_table routes_tbl in
     List.filter_map
       (fun (name, tbl) ->
-         match tbl with
-         | Otoml.TomlTable _ | Otoml.TomlInlineTable _ ->
+         if is_toml_table tbl then
            (match Otoml.find_opt tbl Otoml.get_string [ "target" ] with
             | Some target -> Some { name; target }
             | None -> None)
-         | _ -> None)
+         else None)
       entries
 ;;
 
@@ -747,15 +744,14 @@ let parse_system_targets (toml : Otoml.t) : cascade_route list =
     let entries = Otoml.get_table sys_tbl in
     List.filter_map
       (fun (name, tbl) ->
-         match tbl with
-         | Otoml.TomlTable _ | Otoml.TomlInlineTable _ ->
+         if is_toml_table tbl then
            (match Otoml.find_opt tbl Otoml.get_string [ "target" ] with
             | Some target -> Some { name; target }
             | None ->
               (match Otoml.find_opt tbl Otoml.get_string [ "binding" ] with
                | Some target -> Some { name; target }
                | None -> None))
-         | _ -> None)
+         else None)
       entries
 ;;
 

--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -442,7 +442,10 @@ type provider_table_entry =
    TomlInlineTable) from everything else. Enumerating the other 10 once
    here satisfies warning 4 and means an [otoml] version bump that adds a
    value constructor breaks exactly this site rather than a dozen call
-   sites. *)
+   sites — every "is this a table?" decision in this module goes through
+   [is_toml_table], and the one place that needs the table's contents
+   ([parse_provider_alias_table]) uses [is_toml_table] + [Otoml.get_table]
+   rather than re-matching the constructors. *)
 let is_toml_table : Otoml.t -> bool = function
   | Otoml.TomlTable _ | Otoml.TomlInlineTable _ -> true
   | Otoml.TomlString _ | Otoml.TomlInteger _ | Otoml.TomlFloat _
@@ -506,8 +509,11 @@ let parse_provider_alias_table (provider_id : string) (tbl : Otoml.t)
   let entries = Otoml.get_table tbl in
   List.concat_map
     (fun (model_id_or_alias, sub) ->
-       match sub with
-       | Otoml.TomlTable fields | Otoml.TomlInlineTable fields ->
+       if is_toml_table sub
+       then (
+         (* [sub] is TomlTable/TomlInlineTable (per [is_toml_table]); both
+            unwrap to a (key, value) list via [Otoml.get_table]. *)
+         let fields = Otoml.get_table sub in
          let leaf_fields = List.filter (fun (_, v) -> not (is_toml_table v)) fields in
          let sub_tables = List.filter (fun (_, v) -> is_toml_table v) fields in
          let binding =
@@ -521,12 +527,8 @@ let parse_provider_alias_table (provider_id : string) (tbl : Otoml.t)
                   (parse_alias_fields provider_id model_id_or_alias alias_name alias_tbl))
              sub_tables
          in
-         Binding_entry binding :: aliases
-       | Otoml.TomlString _ | Otoml.TomlInteger _ | Otoml.TomlFloat _
-       | Otoml.TomlBoolean _ | Otoml.TomlOffsetDateTime _ | Otoml.TomlLocalDateTime _
-       | Otoml.TomlLocalDate _ | Otoml.TomlLocalTime _ | Otoml.TomlArray _
-       | Otoml.TomlTableArray _ ->
-         [ Binding_entry (parse_binding_fields provider_id model_id_or_alias sub) ])
+         Binding_entry binding :: aliases)
+       else [ Binding_entry (parse_binding_fields provider_id model_id_or_alias sub) ])
     entries
 ;;
 

--- a/lib/cascade_decl/cascade_declarative_validator.ml
+++ b/lib/cascade_decl/cascade_declarative_validator.ml
@@ -285,22 +285,31 @@ let validate_strategy_fields (cfg : cascade_config) : validation_error list =
               (show_cascade_strategy t.strategy))
        in
        let cycle_errs =
-         match t.cycle_policy, t.strategy with
-         | Some _, Circuit_breaker_cycling -> []
-         | Some _, _ -> mismatch_errors "cycle-policy" "circuit_breaker_cycling"
-         | None, _ -> []
+         match t.cycle_policy with
+         | None -> []
+         | Some _ ->
+           (match t.strategy with
+            | Circuit_breaker_cycling -> []
+            | Failover | Capacity_aware | Weighted_random | Priority_tier | Sticky
+            | Round_robin -> mismatch_errors "cycle-policy" "circuit_breaker_cycling")
        in
        let sticky_errs =
-         match t.sticky_ttl_ms, t.strategy with
-         | Some _, Sticky -> []
-         | Some _, _ -> mismatch_errors "sticky-ttl-ms" "sticky"
-         | None, _ -> []
+         match t.sticky_ttl_ms with
+         | None -> []
+         | Some _ ->
+           (match t.strategy with
+            | Sticky -> []
+            | Failover | Capacity_aware | Weighted_random | Circuit_breaker_cycling
+            | Priority_tier | Round_robin -> mismatch_errors "sticky-ttl-ms" "sticky")
        in
        let scoring_errs =
-         match t.scoring_params, t.strategy with
-         | Some _, Weighted_random -> []
-         | Some _, _ -> mismatch_errors "scoring-params" "weighted_random"
-         | None, _ -> []
+         match t.scoring_params with
+         | None -> []
+         | Some _ ->
+           (match t.strategy with
+            | Weighted_random -> []
+            | Failover | Capacity_aware | Circuit_breaker_cycling | Priority_tier
+            | Sticky | Round_robin -> mismatch_errors "scoring-params" "weighted_random")
        in
        cycle_errs @ sticky_errs @ scoring_errs)
     cfg.tiers

--- a/lib/cascade_decl/dune
+++ b/lib/cascade_decl/dune
@@ -16,6 +16,8 @@
  (name masc_mcp_cascade_decl)
  (public_name masc_mcp.cascade_decl)
  (wrapped false)
+ ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on.
+ (flags (:standard -w +4))
  (libraries
   otoml
   ppx_deriving.runtime


### PR DESCRIPTION
## Summary
RFC-0071 §3.4 Phase 5 ratchet — enable OCaml `-w +4` (fragile-match) on `lib/cascade_decl` and close the 15 sites it surfaces.

- `lib/cascade_decl/dune` ← `(flags (:standard -w +4))`
- **`cascade_declarative_parser.ml` (12 sites)**:
  - 4 `result` matches `| Ok x -> Some x | _ -> None` → `| Error _ -> None`.
  - New `is_toml_table : Otoml.t -> bool` helper enumerates the 3rd-party `Otoml.t` (12 value constructors) **once**; replaces 5 inline `Otoml.TomlTable _ | Otoml.TomlInlineTable _ -> b | _ -> not b` matches with `is_toml_table v` / `not (is_toml_table v)`. An `otoml` bump that adds a constructor now breaks exactly one site.
  - `parse_provider_alias_table` (the one site that needs the table's contents) uses `if is_toml_table sub then Otoml.get_table sub … else …` rather than re-matching the constructors — `Otoml.get_table` unwraps `TomlTable`/`TomlInlineTable` to the same `(key, value)` list the old `match`-arm `fields` binding produced (post-Copilot follow-up `5c23e56f6`).
  - 2 `provider_table_entry` filter_maps `| Binding_entry b -> … | _ -> None` → `| Alias_entry _ -> None` (and mirror).
- **`cascade_declarative_validator.ml` (3 sites)**: the three `match t.X, t.strategy with | Some _, SpecificStrategy -> [] | Some _, _ -> … | None, _ -> []` tuple matches in `validate_strategy_fields` restructured to match the `option` first (`None -> [] | Some _ -> (match t.strategy with …)`) and enumerate all 7 `cascade_strategy` constructors — adding a strategy now triggers warning 8 (non-exhaustive) at these sites.

No behavior change: every wildcard previously covered exactly the constructors now enumerated (or routed through `is_toml_table`).

Cumulative `-w +4` sublibs: **39**.

## Test plan
- [x] `dune build --root . lib/cascade_decl/` — clean (15 warning-4 errors → 0)
- [x] `dune build --root . @check` — no downstream breakage
- [x] `dune exec test/test_cascade_declarative_parser.exe` — 60 tests green
- [x] `dune exec test/test_cascade_declarative_validator.exe` — 29 tests green

RFC-WAIVED: leaf-module compiler-flag ratchet under RFC-0071 §3.4; touches no credential/identity/operator/sandbox/hooks/workflow surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
