### PR TITLE
feat(keeper): RFC-0070 Phase 4.1-g — Docker_client_real spawns via Exec_gate

### DIFF
--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -76,14 +76,30 @@ let is_eintr_127 (status : Unix.process_status) (out : string) =
   | _ -> false
 ;;
 
+(* Sandbox subprocess timeout default.  [Exec_gate.run_argv_with_status*]
+   all carry a hard-coded [?(timeout_sec = 60.0)] default that bypasses
+   the per-caller env override ([MASC_EXEC_TIMEOUT_TURN_SANDBOX_SEC]);
+   routing through [Env_config_exec_timeout] keeps the SSOT live for
+   sites that omit a caller-specific timeout. *)
+let default_timeout_sec () =
+  Env_config_exec_timeout.timeout_sec
+    ~caller:Env_config_exec_timeout.Turn_sandbox
+    ()
+;;
+
 let gated_argv_with_status ?timeout_sec ~(summary : string) argv =
+  let timeout_sec =
+    match timeout_sec with
+    | Some t -> t
+    | None -> default_timeout_sec ()
+  in
   let rec loop attempts_left =
     let status, out =
       Masc_exec.Exec_gate.run_argv_with_status
         ~actor:`System_task_sandbox
         ~raw_source:(String.concat " " argv)
         ~summary
-        ?timeout_sec
+        ~timeout_sec
         argv
     in
     if attempts_left > 0 && is_eintr_127 status out
@@ -94,16 +110,24 @@ let gated_argv_with_status ?timeout_sec ~(summary : string) argv =
 ;;
 
 let gated_argv_with_status_split ?timeout_sec ~(summary : string) argv =
+  let timeout_sec =
+    match timeout_sec with
+    | Some t -> t
+    | None -> default_timeout_sec ()
+  in
   let rec loop attempts_left =
     let status, stdout, stderr =
       Masc_exec.Exec_gate.run_argv_with_status_split
         ~actor:`System_task_sandbox
         ~raw_source:(String.concat " " argv)
         ~summary
-        ?timeout_sec
+        ~timeout_sec
         argv
     in
-    if attempts_left > 0 && is_eintr_127 status (stdout ^ stderr)
+    (* Join with a newline so a marker spanning the stream boundary
+       (stdout ends with "interrupted", stderr begins with "system
+       call") still matches [is_eintr_127]. *)
+    if attempts_left > 0 && is_eintr_127 status (stdout ^ "\n" ^ stderr)
     then loop (attempts_left - 1)
     else status, stdout, stderr
   in
@@ -337,7 +361,10 @@ let run_detached (plan : Keeper_sandbox_session_plan.t) =
            ~started_at:(Unix.gettimeofday ())
        in
        (match
-          gated_argv_with_status_split ~summary:"keeper docker run -d (session)" argv
+          gated_argv_with_status_split
+            ~timeout_sec:ensure_timeout
+            ~summary:"keeper docker run -d (session)"
+            argv
         with
         | Unix.WEXITED 0, _, _ -> Ok (Keeper_sandbox_session_plan.container_name plan)
         | Unix.WEXITED 125, _, _ ->

--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -48,6 +48,68 @@ let map_status_to_exec_result
   | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> Error Docker_client.Daemon_unreachable
 ;;
 
+(* ── Gated spawn (RFC-0070 Phase 4.1-g) ──────────────────────────
+   All docker spawns go through {!Masc_exec.Exec_gate} with
+   [~actor:`System_task_sandbox], the same actor the keeper sandbox
+   subsystem already uses ([keeper_sandbox_runtime], [keeper_docker_read],
+   [keeper_turn_sandbox_runtime]). Before this phase the [Real] client
+   called [Process_eio.run_argv_with_status*] directly, bypassing the
+   gate's actor accounting / approval-policy hook — a regression once a
+   caller like [keeper_turn_sandbox_runtime] (which today gates its own
+   spawns) is cut over to this client. Routing through [Exec_gate] keeps
+   that behaviour; the gate itself delegates to [Process_eio], so the
+   spawn semantics (synthesized [WEXITED 127] on exec failure, etc.) are
+   unchanged.
+
+   EINTR-retry: a [WEXITED 127] whose output mentions "interrupted
+   system call" is a transient EINTR on spawn, not a missing CLI —
+   retry up to [max_eintr_retries] times before letting it fall through
+   to the [WEXITED 127] → [Daemon_unreachable] mapping. Mirrors
+   [keeper_turn_sandbox_runtime.run_argv_with_status_retry_eintr]; the
+   Phase 4.1 cutover deletes that copy in favour of this one. *)
+
+let max_eintr_retries = 8
+
+let is_eintr_127 (status : Unix.process_status) (out : string) =
+  match status with
+  | Unix.WEXITED 127 -> String_util.contains_substring_ci out "interrupted system call"
+  | _ -> false
+;;
+
+let gated_argv_with_status ?timeout_sec ~(summary : string) argv =
+  let rec loop attempts_left =
+    let status, out =
+      Masc_exec.Exec_gate.run_argv_with_status
+        ~actor:`System_task_sandbox
+        ~raw_source:(String.concat " " argv)
+        ~summary
+        ?timeout_sec
+        argv
+    in
+    if attempts_left > 0 && is_eintr_127 status out
+    then loop (attempts_left - 1)
+    else status, out
+  in
+  loop max_eintr_retries
+;;
+
+let gated_argv_with_status_split ?timeout_sec ~(summary : string) argv =
+  let rec loop attempts_left =
+    let status, stdout, stderr =
+      Masc_exec.Exec_gate.run_argv_with_status_split
+        ~actor:`System_task_sandbox
+        ~raw_source:(String.concat " " argv)
+        ~summary
+        ?timeout_sec
+        argv
+    in
+    if attempts_left > 0 && is_eintr_127 status (stdout ^ stderr)
+    then loop (attempts_left - 1)
+    else status, stdout, stderr
+  in
+  loop max_eintr_retries
+;;
+
 (* ── Functions ───────────────────────────────────────────────── *)
 
 let ps_query ~labels:_ = placeholder
@@ -76,10 +138,10 @@ let exec_argv ?user ?workdir ~container ~cmd () =
 
 let exec ?user ?workdir ~container ~cmd () =
   let argv = exec_argv ?user ?workdir ~container ~cmd () in
-  (* [Process_eio.run_argv_with_status_split] returns
-     [(status, stdout, stderr)]; on spawn failure the status is
-     synthesized as [WEXITED 127] (see 3b-iv.2.1 commit on rm). *)
-  map_status_to_exec_result (Process_eio.run_argv_with_status_split argv)
+  (* Gated spawn returns [(status, stdout, stderr)]; on spawn failure
+     the status is synthesized as [WEXITED 127] (see 3b-iv.2.1 commit
+     on rm). *)
+  map_status_to_exec_result (gated_argv_with_status_split ~summary:"keeper docker exec" argv)
 ;;
 
 let run plan =
@@ -98,12 +160,13 @@ let run plan =
   let argv =
     [ "docker"; "run"; "--rm"; "--name"; container_name; image; "sh"; "-lc"; command ]
   in
-  map_status_to_exec_result (Process_eio.run_argv_with_status_split ~timeout_sec argv)
+  map_status_to_exec_result
+    (gated_argv_with_status_split ~timeout_sec ~summary:"keeper docker run (oneshot)" argv)
 ;;
 
 let rm container =
   let argv = [ "docker"; "rm"; "-f"; Keeper_container_name.to_string container ] in
-  let status, _stdout = Process_eio.run_argv_with_status argv in
+  let status, _stdout = gated_argv_with_status ~summary:"keeper docker rm" argv in
   map_exit_status_for_rm status
 ;;
 
@@ -131,7 +194,9 @@ let parse_security_options (raw : string)
 
 let info_security_options () =
   let argv = [ "docker"; "info"; "--format"; "{{json .SecurityOptions}}" ] in
-  match Process_eio.run_argv_with_status_split argv with
+  match
+    gated_argv_with_status_split ~summary:"keeper docker info security-options" argv
+  with
   | Unix.WEXITED 0, out, _ -> parse_security_options out
   | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _, _ ->
     (* Any non-zero exit means the daemon could not answer (not
@@ -156,7 +221,7 @@ let image_present ~image =
      distinguish. [image] is assumed non-empty — the plan layer
      validates that, not this daemon-level call. *)
   let argv = [ "docker"; "image"; "inspect"; image ] in
-  match Process_eio.run_argv_with_status argv with
+  match gated_argv_with_status ~summary:"keeper docker image inspect" argv with
   | Unix.WEXITED 0, _ -> Ok ()
   | Unix.WEXITED 127, _ -> Error Docker_client.Daemon_unreachable
   | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _ ->
@@ -271,7 +336,9 @@ let run_detached (plan : Keeper_sandbox_session_plan.t) =
            ~owner_pid:(Unix.getpid ())
            ~started_at:(Unix.gettimeofday ())
        in
-       (match Process_eio.run_argv_with_status_split argv with
+       (match
+          gated_argv_with_status_split ~summary:"keeper docker run -d (session)" argv
+        with
         | Unix.WEXITED 0, _, _ -> Ok (Keeper_sandbox_session_plan.container_name plan)
         | Unix.WEXITED 125, _, _ ->
           (* [docker run] itself failed — bad flag, image not pullable,

--- a/lib/keeper/docker_client_real.mli
+++ b/lib/keeper/docker_client_real.mli
@@ -94,3 +94,15 @@ val run_detached_argv
   -> owner_pid:int
   -> started_at:float
   -> string list
+
+(** [is_eintr_127 status out] is the EINTR-retry predicate behind the
+    gated-spawn helpers (RFC-0070 Phase 4.1-g): a spawn that exited
+    [WEXITED 127] *and* whose combined stdout/stderr mentions
+    "interrupted system call" (case-insensitive) is a transient EINTR
+    on [fork]/[exec], not a missing docker CLI — so it is retried (up
+    to 8×) instead of being mapped straight to [Daemon_unreachable].
+    Any other status, or [WEXITED 127] without that marker, is [false].
+    Pure; exposed for unit-testing the predicate without a daemon.
+    Mirrors [keeper_turn_sandbox_runtime]'s long-standing EINTR loop
+    (the Phase 4.1 cutover deletes that copy in favour of this one). *)
+val is_eintr_127 : Unix.process_status -> string -> bool

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -391,6 +391,58 @@ let test_executor_with_real_returns_typed_result () =
     fail "executor with Real should only surface Ok or Daemon_unreachable"
 ;;
 
+(* ── is_eintr_127 (pure, Phase 4.1-g) ─────────────────────────── *)
+
+let test_is_eintr_127_true_on_127_with_marker () =
+  (* The marker is matched case-insensitively and as a substring of the
+     combined stdout/stderr the spawn produced. *)
+  check
+    bool
+    "WEXITED 127 + \"interrupted system call\" ⇒ retry"
+    true
+    (Docker_client_real.is_eintr_127
+       (Unix.WEXITED 127)
+       "docker: fork/exec /usr/bin/docker: interrupted system call");
+  check
+    bool
+    "marker is case-insensitive"
+    true
+    (Docker_client_real.is_eintr_127 (Unix.WEXITED 127) "Interrupted System Call")
+;;
+
+let test_is_eintr_127_false_on_127_without_marker () =
+  check
+    bool
+    "WEXITED 127 without the marker (genuine missing CLI) ⇒ no retry"
+    false
+    (Docker_client_real.is_eintr_127
+       (Unix.WEXITED 127)
+       "docker: command not found")
+;;
+
+let test_is_eintr_127_false_on_other_exit_codes () =
+  (* Only 127 — a 125 ("daemon error") that happens to mention the
+     phrase is still a daemon error, not an EINTR. *)
+  check
+    bool
+    "WEXITED 125 + marker ⇒ no retry (only 127 is the EINTR sentinel)"
+    false
+    (Docker_client_real.is_eintr_127 (Unix.WEXITED 125) "interrupted system call");
+  check
+    bool
+    "WEXITED 0 ⇒ no retry"
+    false
+    (Docker_client_real.is_eintr_127 (Unix.WEXITED 0) "interrupted system call")
+;;
+
+let test_is_eintr_127_false_on_signal () =
+  check
+    bool
+    "WSIGNALED ⇒ no retry"
+    false
+    (Docker_client_real.is_eintr_127 (Unix.WSIGNALED 9) "interrupted system call")
+;;
+
 let () =
   run
     "Docker_client_real (Phase 3b-iv.2.3)"
@@ -458,6 +510,21 @@ let () =
             "Sandbox_executor.Make (Real) instantiates + forwards placeholder"
             `Quick
             test_executor_with_real_returns_typed_result
+        ] )
+    ; ( "is_eintr_127 (pure, Phase 4.1-g)"
+      , [ test_case
+            "127 + marker (any case) ⇒ true"
+            `Quick
+            test_is_eintr_127_true_on_127_with_marker
+        ; test_case
+            "127 without marker ⇒ false"
+            `Quick
+            test_is_eintr_127_false_on_127_without_marker
+        ; test_case
+            "non-127 exit codes ⇒ false"
+            `Quick
+            test_is_eintr_127_false_on_other_exit_codes
+        ; test_case "signal ⇒ false" `Quick test_is_eintr_127_false_on_signal
         ] )
     ]
 ;;


### PR DESCRIPTION
## RFC-0070 Phase 4.1-g — `Docker_client_real` spawns via `Masc_exec.Exec_gate`

RFC: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §4 row `4.1-g` (added in v2.5, #14983) — shared prerequisite of all three Phase 4 caller cutovers.

### Why

Before this, `Docker_client_real` called `Process_eio.run_argv_with_status*` *directly*, bypassing `Masc_exec.Exec_gate` — the typed gate (`~actor:Agent_id.t`, approval-policy hook, shadow evidence) that the rest of the keeper sandbox subsystem already routes through (`keeper_sandbox_runtime`, `keeper_docker_read`, `keeper_turn_sandbox_runtime`, all with `~actor:`System_task_sandbox`). Cutting `keeper_turn_sandbox_runtime` over to a `Docker_client_real`-backed executor (Phase 4.1) — or `keeper_shell_docker` / `keeper_sandbox_runtime` over to `Sandbox_executor.Make(Docker_client_real)` (Phase 4.2 / 4.3) — would have silently dropped the gate for those spawns. Routing through `Exec_gate` (which itself delegates to `Process_eio`) keeps the behaviour; spawn semantics (synthesized `WEXITED 127` on exec failure, etc.) are unchanged.

### What

- `lib/keeper/docker_client_real.ml`: two internal helpers
  - `gated_argv_with_status ?timeout_sec ~summary argv : process_status * string`
  - `gated_argv_with_status_split ?timeout_sec ~summary argv : process_status * string * string`
  both wrap `Masc_exec.Exec_gate.run_argv_with_status[_split] ~actor:`System_task_sandbox ~raw_source:(String.concat " " argv) ~summary` with an **EINTR-retry loop** (up to 8×): a `WEXITED 127` whose combined stdout/stderr mentions "interrupted system call" (case-insensitive) is a transient EINTR on `fork`/`exec`, not a missing CLI — retry rather than map straight to `Daemon_unreachable`. Mirrors `keeper_turn_sandbox_runtime.run_argv_with_status_retry_eintr` (the Phase 4.1 cutover deletes that copy in favour of this one). Side effect: this also fixes a latent bug where an EINTR-`127` was misclassified as `Daemon_unreachable`.
  - All 6 spawn sites (`exec`, `run`, `rm`, `info_security_options`, `image_present`, `run_detached`) now go through these helpers. No `Process_eio.*` calls remain (only doc-comment mentions).
- `lib/keeper/docker_client_real.mli`: `val is_eintr_127 : Unix.process_status -> string -> bool` exposed (the EINTR predicate behind the helpers — pure, unit-testable).
- `test/test_docker_client_real.ml`: +4 tests for `is_eintr_127` (127 + marker any case ⇒ true; 127 without marker ⇒ false; 125/0 + marker ⇒ false — only 127 is the sentinel; signal ⇒ false). 20 → 24 tests.

No signature change to `Docker_client.S`. `Docker_client_mock` is untouched (it never used `Process_eio`).

### Local verification

- `dune build --root . lib/` — exit 0; no `Process_eio.*` calls remain in `docker_client_real.ml`.
- `dune exec --root . test/test_docker_client_real.exe` — `Test Successful. 24 tests run.`
- `dune exec --root . test/test_docker_client_mock.exe` — 19 tests run (unchanged).
- `dune exec --root . test/test_sandbox_executor.exe` — 11 tests run; `test/test_sandbox_session_executor.exe` — 11 tests run (both still pass — the spawn-path tests now traverse `Exec_gate` → `Process_eio` and still surface the expected typed errors).
- `ocamlformat --check` on all 3 files — clean.

### Self-check (workaround-rejection bar)

- No catch-all `_ ->` added; the new `match` in the helpers is a 2-arm `if … then loop … else …` over `is_eintr_127`, which itself is an exhaustive `match` on `Unix.process_status` (`WEXITED 127` vs `_`). The EINTR retry is a *retry* (bounded, 8×, then falls through to the existing `127 → Daemon_unreachable` mapping), not a silent swallow.
- No telemetry-as-fix, no string classifier *added as a fix* (the "interrupted system call" substring match is copied verbatim from the existing, battle-tested `keeper_turn_sandbox_runtime` loop — it is the kernel's error string, not a domain classifier), no N-of-M, no test backdoor, no duplicated constant (`max_eintr_retries = 8` is the same value the keeper-turn copy uses; the cutover dedupes).
- The "just bypass the gate" shortcut was rejected deliberately (MANIFEST §workaround-rejection — do not paper over a hurdle for the sake of progress).

### Follow-up

- RFC §4 `4.1-g` row flips `⏳ pending` → `✅ #<this PR>` in the next RFC amendment (folded into 4.1-h or the 4.1 cutover PR).
- The duplicate EINTR loop + `Exec_gate ~actor:`System_task_sandbox` boilerplate in `keeper_turn_sandbox_runtime.ml` is deleted by Phase 4.1.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
