### PR TITLE
feat(repo_manager): enable warning 4 + close 16 fragile sites (RFC-0071 §3.4)

### DIFF
--- a/lib/repo_manager/credential_materializer.ml
+++ b/lib/repo_manager/credential_materializer.ml
@@ -87,7 +87,7 @@ let gh_command_ok ~gh_config_dir argv =
   | Some pid -> (
       match snd (waitpid_no_intr [] pid) with
       | Unix.WEXITED 0 -> true
-      | _ -> false)
+      | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> false)
 
 let hosts_yml_has_oauth_token ~gh_config_dir =
   let path = Filename.concat gh_config_dir gh_hosts_yml in
@@ -257,7 +257,7 @@ let read_operator_ambient_token () : string option =
        | Unix.WEXITED 0 ->
            let token = String.trim (Buffer.contents buf) in
            if String.equal token "" then None else Some token
-       | _ -> None)
+       | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> None)
 
 (** RFC-0019 PR-C §3.2 P1 — F-1 gate (permissive).
 
@@ -306,7 +306,7 @@ let ensure (cred : credential) : credential =
         let p =
           match s with
           | Materialized _ -> compute_token_sha256_prefix ~gh_config_dir:dir
-          | _ -> None
+          | Unmaterialized | Stale _ -> None
         in
         s, p
   in

--- a/lib/repo_manager/credential_store.ml
+++ b/lib/repo_manager/credential_store.ml
@@ -159,20 +159,23 @@ let load_all ~base_path =
         | Ok (Otoml.TomlTable fields | Otoml.TomlInlineTable fields) ->
             let rec loop acc = function
               | [] -> Ok (List.rev acc)
-              | (id, value) :: rest -> (
-                  match value with
-                  | Otoml.TomlTable _ | Otoml.TomlInlineTable _ ->
-                      let cred_toml =
-                        Otoml.TomlTable [("credential", Otoml.TomlTable [(id, value)])]
-                      in
-                      (match credential_of_toml cred_toml id with
-                      | Ok cred -> loop (cred :: acc) rest
-                      | Error msg -> Error msg)
-                  | _ ->
-                      Error (Printf.sprintf "credential.%s must be a table" id))
+              | (id, value) :: rest ->
+                  if is_toml_table value then
+                    let cred_toml =
+                      Otoml.TomlTable [("credential", Otoml.TomlTable [(id, value)])]
+                    in
+                    (match credential_of_toml cred_toml id with
+                    | Ok cred -> loop (cred :: acc) rest
+                    | Error msg -> Error msg)
+                  else
+                    Error (Printf.sprintf "credential.%s must be a table" id)
             in
             loop [] fields
-        | Ok _ -> Ok [])
+        | Ok (Otoml.TomlString _ | Otoml.TomlInteger _ | Otoml.TomlFloat _
+             | Otoml.TomlBoolean _ | Otoml.TomlOffsetDateTime _
+             | Otoml.TomlLocalDateTime _ | Otoml.TomlLocalDate _
+             | Otoml.TomlLocalTime _ | Otoml.TomlArray _ | Otoml.TomlTableArray _) ->
+            Ok [])
 
 let save_all ~base_path (creds : credential list) =
   let path = creds_toml_path base_path in

--- a/lib/repo_manager/dune
+++ b/lib/repo_manager/dune
@@ -12,6 +12,8 @@
    keeper_repo_mapping
    repo_sync)
  (wrapped false)
+ ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on.
+ (flags (:standard -w +4))
  (libraries
    masc_mcp.config
    masc_mcp.fs_compat

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -29,7 +29,10 @@ let mapping_of_toml toml keeper_id =
     | Ok (Otoml.TomlString id) ->
         let id = String.trim id in
         Ok (if id = "" then None else Some id)
-    | Ok _ ->
+    | Ok (Otoml.TomlInteger _ | Otoml.TomlFloat _ | Otoml.TomlBoolean _
+         | Otoml.TomlOffsetDateTime _ | Otoml.TomlLocalDateTime _
+         | Otoml.TomlLocalDate _ | Otoml.TomlLocalTime _ | Otoml.TomlArray _
+         | Otoml.TomlTable _ | Otoml.TomlInlineTable _ | Otoml.TomlTableArray _) ->
         Error
           (Printf.sprintf
              "mapping.%s.credential_id must be a string when present" keeper_id)
@@ -71,21 +74,23 @@ let load_all ~base_path =
         | Ok (Otoml.TomlTable fields | Otoml.TomlInlineTable fields) ->
             let rec loop acc = function
               | [] -> Ok (List.rev acc)
-              | (keeper_id, value) :: rest -> (
-                  match value with
-                  | Otoml.TomlTable _ | Otoml.TomlInlineTable _ ->
-                      let mapping_toml =
-                        Otoml.TomlTable [("mapping", Otoml.TomlTable [(keeper_id, value)])]
-                      in
-                      (match mapping_of_toml mapping_toml keeper_id with
-                      | Ok mapping -> loop (mapping :: acc) rest
-                      | Error msg -> Error msg)
-                  | _ ->
-                      Error
-                        (Printf.sprintf "mapping.%s must be a table" keeper_id))
+              | (keeper_id, value) :: rest ->
+                  if is_toml_table value then
+                    let mapping_toml =
+                      Otoml.TomlTable [("mapping", Otoml.TomlTable [(keeper_id, value)])]
+                    in
+                    (match mapping_of_toml mapping_toml keeper_id with
+                    | Ok mapping -> loop (mapping :: acc) rest
+                    | Error msg -> Error msg)
+                  else
+                    Error (Printf.sprintf "mapping.%s must be a table" keeper_id)
             in
             loop [] fields
-        | Ok _ -> Ok [])
+        | Ok (Otoml.TomlString _ | Otoml.TomlInteger _ | Otoml.TomlFloat _
+             | Otoml.TomlBoolean _ | Otoml.TomlOffsetDateTime _
+             | Otoml.TomlLocalDateTime _ | Otoml.TomlLocalDate _
+             | Otoml.TomlLocalTime _ | Otoml.TomlArray _ | Otoml.TomlTableArray _) ->
+            Ok [])
 
 type mapping_lookup =
   | Mapping_found of keeper_repo_mapping
@@ -350,12 +355,18 @@ let safe_file_exists path = Option.is_some (safe_lstat path)
 let safe_is_directory path =
   match safe_lstat path with
   | Some { Unix.st_kind = Unix.S_DIR; _ } -> true
-  | _ -> false
+  | Some { Unix.st_kind =
+             ( Unix.S_REG | Unix.S_CHR | Unix.S_BLK | Unix.S_LNK | Unix.S_FIFO
+             | Unix.S_SOCK ); _ } -> false
+  | None -> false
 
 let safe_is_symlink path =
   match safe_lstat path with
   | Some { Unix.st_kind = Unix.S_LNK; _ } -> true
-  | _ -> false
+  | Some { Unix.st_kind =
+             ( Unix.S_REG | Unix.S_DIR | Unix.S_CHR | Unix.S_BLK | Unix.S_FIFO
+             | Unix.S_SOCK ); _ } -> false
+  | None -> false
 
 let safe_realpath path =
   try Some (Unix.realpath path)
@@ -370,7 +381,10 @@ let read_file_opt path =
           (In_channel.with_open_bin path (fun ic ->
                really_input_string ic st_size))
       with Sys_error _ | End_of_file -> None)
-  | _ -> None
+  | Some { Unix.st_kind =
+             ( Unix.S_REG | Unix.S_DIR | Unix.S_CHR | Unix.S_BLK | Unix.S_LNK
+             | Unix.S_FIFO | Unix.S_SOCK ); _ } -> None
+  | None -> None
 
 let normalize_lexical_path path =
   let absolute = String.starts_with ~prefix:"/" path in

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -66,7 +66,7 @@ let run_git ~cwd ?(env = []) args : (string list, string) result =
   in
   match status with
   | Unix.WEXITED 0 -> Ok (split_lines stdout)
-  | _ ->
+  | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
       let status_text =
         match status with
         | Unix.WEXITED code -> Printf.sprintf "exit %d" code

--- a/lib/repo_manager/repo_manager_types.ml
+++ b/lib/repo_manager/repo_manager_types.ml
@@ -73,3 +73,16 @@ type keeper_repo_mapping = {
   github_credential_id : string option [@default None];
 }
 [@@deriving yojson, show, eq]
+
+(* [Otoml.t] is a 3rd-party closed variant with 12 value constructors;
+   the on-disk config loaders in this library only ever distinguish
+   "table-shaped" (TomlTable / TomlInlineTable) from everything else.
+   Enumerating the other 10 once here satisfies warning 4 and means an
+   [otoml] version bump that adds a value constructor breaks exactly this
+   site instead of several config loaders. *)
+let is_toml_table : Otoml.t -> bool = function
+  | Otoml.TomlTable _ | Otoml.TomlInlineTable _ -> true
+  | Otoml.TomlString _ | Otoml.TomlInteger _ | Otoml.TomlFloat _
+  | Otoml.TomlBoolean _ | Otoml.TomlOffsetDateTime _ | Otoml.TomlLocalDateTime _
+  | Otoml.TomlLocalDate _ | Otoml.TomlLocalTime _ | Otoml.TomlArray _
+  | Otoml.TomlTableArray _ -> false

--- a/lib/repo_manager/repo_manager_types.mli
+++ b/lib/repo_manager/repo_manager_types.mli
@@ -54,3 +54,9 @@ type keeper_repo_mapping = {
   github_credential_id : string option [@default None];
 }
 [@@deriving yojson, show, eq]
+
+(** [is_toml_table v] is [true] iff [v] is [Otoml.TomlTable] or
+    [Otoml.TomlInlineTable].  Shared by the on-disk config loaders so the
+    12-constructor [Otoml.t] enumeration that satisfies warning 4 lives
+    in one place. *)
+val is_toml_table : Otoml.t -> bool

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -73,7 +73,7 @@ let repository_of_toml toml id =
         match Otoml.find_result toml Otoml.get_string (path "status_error") with
         | Ok msg -> Error msg
         | Error _ -> Error "")
-    | other -> other
+    | Active | Paused | Cloning -> status
   in
   let* auto_sync = find_bool_default "auto_sync" false in
   let* sync_interval = find_int64_default "sync_interval" (Int64.of_int 300) in
@@ -117,7 +117,7 @@ let toml_of_repository repo =
     match repo.status with
     | Error msg when String.trim msg <> "" ->
         ("status_error", Otoml.string msg) :: fields
-    | _ -> fields
+    | Error _ | Active | Paused | Cloning -> fields
   in
   Otoml.TomlTable fields
 
@@ -152,22 +152,24 @@ let load_all ~base_path =
         | Ok (Otoml.TomlTable fields | Otoml.TomlInlineTable fields) ->
             let rec loop acc = function
               | [] -> Ok (List.rev acc)
-              | (id, value) :: rest -> (
-                  match value with
-                  | Otoml.TomlTable _ | Otoml.TomlInlineTable _ ->
-                      let repo_toml =
-                        Otoml.TomlTable
-                          [("repository", Otoml.TomlTable [(id, value)])]
-                      in
-                      (match repository_of_toml repo_toml id with
-                      | Ok repo -> loop (repo :: acc) rest
-                      | Error msg -> Error msg)
-                  | _ ->
-                      Error
-                        (Printf.sprintf "repository.%s must be a table" id))
+              | (id, value) :: rest ->
+                  if is_toml_table value then
+                    let repo_toml =
+                      Otoml.TomlTable
+                        [("repository", Otoml.TomlTable [(id, value)])]
+                    in
+                    (match repository_of_toml repo_toml id with
+                    | Ok repo -> loop (repo :: acc) rest
+                    | Error msg -> Error msg)
+                  else
+                    Error (Printf.sprintf "repository.%s must be a table" id)
             in
             loop [] fields
-        | Ok _ -> Ok [])
+        | Ok (Otoml.TomlString _ | Otoml.TomlInteger _ | Otoml.TomlFloat _
+             | Otoml.TomlBoolean _ | Otoml.TomlOffsetDateTime _
+             | Otoml.TomlLocalDateTime _ | Otoml.TomlLocalDate _
+             | Otoml.TomlLocalTime _ | Otoml.TomlArray _ | Otoml.TomlTableArray _) ->
+            Ok [])
 
 let save_all ~base_path (repos : repository list) =
   let path = repos_toml_path base_path in


### PR DESCRIPTION
## Summary
RFC-0071 §3.4 Phase 5 ratchet — enable OCaml `-w +4` (fragile-match) on `lib/repo_manager` and close the 16 sites it surfaces.

**RFC reference (CLAUDE.md §agent_delegation)**: `lib/repo_manager/` credential surface is covered by **RFC-0008 (`CredentialProvider` Trait)** (`docs/rfc/RFC-0008-credential-provider-trait.md`) and **RFC-0019 (keeper-credential-unification)** (`docs/rfc/RFC-0019-keeper-credential-unification.md`). This PR makes **no credential-logic change** — it is a leaf compiler-flag ratchet only (enabling `-w +4` + exhausting closed-variant catch-alls). No credential bundle handling, no F-1 gate, no provisioning flow touched.

- `lib/repo_manager/dune` ← `(flags (:standard -w +4))`
- `repo_manager_types.ml(.mli)`: new shared `is_toml_table : Otoml.t -> bool` — enumerates the 12-constructor 3rd-party `Otoml.t` once; an `otoml` bump that adds a value constructor now breaks exactly this site.
- `repo_git.ml` (1): `run_git` status match `| Unix.WEXITED 0 -> Ok … | _ -> …` → enumerate `Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _`.
- `repo_store.ml` (4): `repository_of_toml` status fixup `| other -> other` → `| Active | Paused | Cloning -> status`; `toml_of_repository` `| _ -> fields` → `| Error _ | Active | Paused | Cloning -> fields`; `load_all` inner `match value with TomlTable|TomlInlineTable -> … | _ -> Error …` → `if is_toml_table value then … else Error …`; `load_all` outer `| Ok _ -> Ok []` → enumerate the 10 non-table `Otoml.t` constructors.
- `credential_store.ml` (2): same `load_all` pattern as `repo_store`.
- `credential_materializer.ml` (3): two `waitpid` `| Unix.WEXITED 0 -> … | _ -> …` → enumerate `process_status`; `ensure` `match s with Materialized _ -> … | _ -> None` → `| Unmaterialized | Stale _ -> None`.
- `keeper_repo_mapping.ml` (6): `mapping_of_toml` credential_id `| Ok _ -> Error …` → enumerate the 11 non-string `Otoml.t` constructors; `load_all` same pattern as `repo_store`; `safe_is_directory` / `safe_is_symlink` / `read_file_opt` — `Some { Unix.st_kind = Unix.S_X; _ } -> … | _ -> …` → enumerate the 7 `Unix.file_kind` constructors + `None`.

No behavior change: every wildcard previously covered exactly the constructors now enumerated (or routed through `is_toml_table`).

Cumulative `-w +4` sublibs: **40**.

## Test plan
- [x] `dune build --root . lib/repo_manager/` — clean (16 warning-4 errors → 0)
- [x] `dune build --root . @check` — no downstream breakage
- [x] `dune exec test/test_credential_store.exe` — 12 green
- [x] `dune exec test/test_credential_materializer.exe` — 23 green
- [x] `dune exec test/test_keeper_repo_mapping.exe` — 36 green
- [x] `dune exec test/test_repo_git.exe` — 6 green
- [ ] `dune exec test/test_repo_store.exe` — **3 PRE-EXISTING failures** (`discover` "finds git repos", `discover` "finds grouped workspace repos", `migration` "register_discovered includes legacy…") — confirmed identical on clean `origin/main` (`local_path` assertion mismatch in the test's temp-dir setup), unrelated to this PR. 24/27 pass. Filed separately for triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
