### PR TITLE
fix(config-doctor): read cascade.toml for catalog diagnostics (RFC-0058 §9 follow-up)

### DIFF
--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -551,7 +551,7 @@ let detect_capability_mismatches (entries : catalog_entry list)
     entries
 ;;
 
-let load_catalog ~config_path =
+let load_catalog_impl ~emit_telemetry ~config_path =
   match load_catalog_source config_path with
   | Error _ as err -> err
   | Ok (`Assoc fields) ->
@@ -568,9 +568,13 @@ let load_catalog ~config_path =
              without the declared profiles registered.  Counter ticks
              so the silent registration gap is observable — downstream
              [resolve_required_capabilities] returns None for these
-             profiles and capability filtering falls back to defaults. *)
-          Cascade_metrics.on_profile_registration_failure ();
-          Log.warn ~ctx:"CascadeConfig" "profiles registration error: %s" msg
+             profiles and capability filtering falls back to defaults.
+             [emit_telemetry] gates both so diagnostic callers do not
+             re-fire the counter every dashboard / doctor poll. *)
+          if emit_telemetry then begin
+            Cascade_metrics.on_profile_registration_failure ();
+            Log.warn ~ctx:"CascadeConfig" "profiles registration error: %s" msg
+          end
         | Ok () -> ())
      | None -> ());
     let builders =
@@ -598,7 +602,8 @@ let load_catalog ~config_path =
            filtered, surface so RFC-0066 Phase 4 migration progress
            is observable.  Only ticks when [has_schema_field] is true
            — empty placeholder builders are not interesting. *)
-        if builder.has_schema_field
+        if emit_telemetry
+           && builder.has_schema_field
            && is_deprecated_logical_profile_name name
         then
           Cascade_metrics.on_deprecated_profile_name_filter ~name;
@@ -641,44 +646,54 @@ let load_catalog ~config_path =
           active_builders
       in
       let cycles = detect_fallback_cycles entries in
-      let key = cycle_set_key cycles in
-      let should_warn =
-        with_cycle_warn_lock (fun () ->
-          match Hashtbl.find_opt cycle_warn_seen config_path with
-          | Some k when String.equal k key -> false
-          | _ ->
-            Hashtbl.replace cycle_warn_seen config_path key;
-            true)
-      in
-      List.iter
-        (fun cycle ->
-           let entry =
-             match cycle with
-             | x :: _ -> x
-             | [] -> "?"
-           in
-           Prometheus.inc_counter
-             Prometheus.metric_cascade_fallback_cycle_detected_total
-             ~labels:[ "cascade", entry ]
-             ();
-           if should_warn
-           then
-             Log.warn
-               ~ctx:"CascadeConfig"
-               "fallback_cascade cycle detected at [%s]: %s — provider stalls in any \
-                participant will silently propagate through the entire loop (no \
-                escape).  Break the cycle by setting at least one fallback_cascade to a \
-                non-participating cascade (e.g. local_recovery) or removing the field."
-               entry
-               (String.concat " → " (cycle @ [ entry ])))
-        cycles;
+      (* Compute the dedup token only inside the telemetry-emitting
+         branch.  Otherwise a diagnostic call would consume the
+         [cycle_warn_seen] token and suppress the next real
+         [load_catalog]'s WARN. *)
+      (if emit_telemetry
+       then (
+         let key = cycle_set_key cycles in
+         let should_warn =
+           with_cycle_warn_lock (fun () ->
+             match Hashtbl.find_opt cycle_warn_seen config_path with
+             | Some k when String.equal k key -> false
+             | _ ->
+               Hashtbl.replace cycle_warn_seen config_path key;
+               true)
+         in
+         List.iter
+           (fun cycle ->
+              let entry =
+                match cycle with
+                | x :: _ -> x
+                | [] -> "?"
+              in
+              Prometheus.inc_counter
+                Prometheus.metric_cascade_fallback_cycle_detected_total
+                ~labels:[ "cascade", entry ]
+                ();
+              if should_warn
+              then
+                Log.warn
+                  ~ctx:"CascadeConfig"
+                  "fallback_cascade cycle detected at [%s]: %s — provider stalls in any \
+                   participant will silently propagate through the entire loop (no \
+                   escape).  Break the cycle by setting at least one fallback_cascade \
+                   to a non-participating cascade (e.g. local_recovery) or removing \
+                   the field."
+                  entry
+                  (String.concat " → " (cycle @ [ entry ])))
+           cycles));
       let mismatches = detect_capability_mismatches entries in
       (* Iter 32: counter complement to the [fallback_cycle_detected]
          counter the cycle detector already emits.  Bumped by the
          number of mismatches in a single load_catalog invocation
          so the iter-5 generic [validation_failed] reason can be
-         attributed to "capability subset violation" vs other faults. *)
-      Cascade_metrics.on_capability_mismatch ~count:(List.length mismatches);
+         attributed to "capability subset violation" vs other faults.
+         [emit_telemetry] gates this so diagnostic callers do not
+         re-fire on every poll for a stable misconfiguration. *)
+      if emit_telemetry then
+        Cascade_metrics.on_capability_mismatch ~count:(List.length mismatches);
       if mismatches <> []
       then
         Error
@@ -690,6 +705,14 @@ let load_catalog ~config_path =
               |> String.concat "; "))
       else Ok entries)
   | Ok _ -> Ok []
+;;
+
+let load_catalog ~config_path =
+  load_catalog_impl ~emit_telemetry:true ~config_path
+;;
+
+let load_catalog_for_diagnostics ~config_path =
+  load_catalog_impl ~emit_telemetry:false ~config_path
 ;;
 
 let load_profile_weighted ~config_path ~name =

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -118,10 +118,30 @@ val is_deprecated_logical_profile_name : string -> bool
 
     On a successful load this also walks the fallback graph and emits
     [masc_cascade_fallback_cycle_detected_total] + a WARN log for each
-    cycle discovered (see {!detect_fallback_cycles}).
+    cycle discovered (see {!detect_fallback_cycles}), plus deprecated-
+    profile-name filter / capability-mismatch / profile-registration
+    counters when those conditions apply.
 
     Returns [Error _] when the file cannot be read or parsed. *)
 val load_catalog :
+  config_path:string ->
+  (catalog_entry list, string) result
+
+(** Same as {!load_catalog} but suppresses every Prometheus / log
+    side-effect — the cycle counter, the cycle WARN, the deprecated-
+    profile-name counter, the capability-mismatch counter, and the
+    profile-registration-failure counter and WARN. The returned
+    [catalog_entry list] is identical to {!load_catalog}.
+
+    Intended for read-only diagnostic callers (e.g.
+    [Config_doctor.diagnose_cascade_catalog]) that re-walk the catalog
+    on every dashboard / doctor poll. Without this, persistent
+    fallback-cycle / capability-mismatch / deprecated-name conditions
+    in a stable catalog would inflate the cycle / mismatch /
+    deprecated-name counters on every poll and re-emit the WARN log
+    even though [load_catalog]'s own [cycle_warn_seen] dedup table
+    already covered the producer side. *)
+val load_catalog_for_diagnostics :
   config_path:string ->
   (catalog_entry list, string) result
 

--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -8,6 +8,12 @@ let cascade_toml_filename = "cascade.toml"
 let tool_policy_toml_filename = "tool_policy.toml"
 let keeper_runtime_toml_filename = "keeper_runtime.toml"
 
+(* SSOT first sentence — see Config_dir_resolver.mli docstring.
+   Callers append their context-specific operator action. *)
+let legacy_cascade_json_warning_prefix =
+  "Found cascade.json but no cascade.toml; cascade.json is no longer \
+   read (RFC-0058 §9)."
+
 type source =
   | Env
   | Local_masc
@@ -403,8 +409,8 @@ let resolve_with inputs =
     if (not cascade_authoring.exists)
        && existing_file (Filename.concat config_root.path cascade_json_filename)
     then
-      [ "Found cascade.json but no cascade.toml; cascade.json is no longer \
-         read (RFC-0058 §9). Rename or convert it to cascade.toml." ]
+      [ legacy_cascade_json_warning_prefix
+        ^ " Rename or convert it to cascade.toml." ]
     else []
   in
   let warnings =

--- a/lib/config_dir_resolver.mli
+++ b/lib/config_dir_resolver.mli
@@ -57,7 +57,13 @@ val cascade_toml_filename : string
 val tool_policy_toml_filename : string
 val keeper_runtime_toml_filename : string
 
-(** {1 Resolution} *)
+val legacy_cascade_json_warning_prefix : string
+(** SSOT first sentence of the "operator left cascade.json behind after
+    migrating to cascade.toml" warning. Both [resolve]'s startup
+    warnings and [Config_doctor.diagnose_cascade_catalog] open with this
+    exact sentence and append a context-specific operator action.
+    Centralizing the prefix keeps the two operator-facing surfaces from
+    drifting on the part that identifies the condition. *)
 
 val inputs_from_env : unit -> inputs
 (** Snapshot current environment (cwd, executable, env vars). *)

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -107,6 +107,26 @@ let option_field name = function
   | Some value -> (name, `String value)
   | None -> (name, `Null)
 
+type cascade_diagnosis = {
+  issues : catalog_issue list;
+  fallback_cycles : string list list;
+  (** Cycles surface as warning issues inside [issues] for the
+      flat warnings list, but we keep the raw list here so
+      {!cascade_catalog_next_actions} can emit a cycle-specific
+      operator action distinct from the degraded-metadata one. *)
+}
+
+let format_fallback_cycle cycle =
+  (* Display the loop with its closing edge so an operator who sees
+     [A -> B -> A] reads "cycle" rather than [A -> B], which looks
+     like a non-cycling chain.  Empty cycles cannot occur here
+     ({!Cascade_config_loader.detect_fallback_cycles} only emits
+     non-empty cycles), so guard defensively with [match] rather
+     than a partial [List.hd]. *)
+  match cycle with
+  | [] -> "(empty cycle)"
+  | first :: _ -> String.concat " -> " (cycle @ [ first ])
+
 let diagnose_cascade_catalog ~active_config_root =
   (* RFC-0058 §9: the on-disk cascade source is [cascade.toml]; the
      legacy [cascade.json] sibling is no longer read.  Probing for
@@ -120,24 +140,29 @@ let diagnose_cascade_catalog ~active_config_root =
   if not (Env_config_core.existing_file config_path) then
     (* No cascade.toml — but if a legacy cascade.json is still lying
        around, the operator forgot to migrate.  Config_dir_resolver
-       already emits this exact warning at startup (see its
-       [degraded_legacy_json_warnings]); mirroring it here makes the
-       same diagnostic visible on the Config Doctor panel so it isn't
-       silent green when the catalog can't be validated. *)
+       already emits a warning at startup (see its
+       [degraded_legacy_json_warnings] using the same
+       [legacy_cascade_json_warning_prefix] SSOT below).  We share
+       the prefix so the two surfaces stay aligned on what they
+       identify; the appended operator action differs by context
+       (startup says "Rename or convert it", doctor says "Migrate ...
+       so catalog diagnostics can run"). *)
     let legacy_json =
       Filename.concat active_config_root Config_dir_resolver.cascade_json_filename
     in
     if Env_config_core.existing_file legacy_json then
-      [ { profile = None
-        ; severity = Catalog_warn
-        ; message =
-            "Found cascade.json but no cascade.toml; cascade.json is no longer \
-             read (RFC-0058 §9). Migrate to cascade.toml so catalog \
-             diagnostics can run."
-        }
-      ]
+      { issues =
+          [ { profile = None
+            ; severity = Catalog_warn
+            ; message =
+                Config_dir_resolver.legacy_cascade_json_warning_prefix
+                ^ " Migrate to cascade.toml so catalog diagnostics can run."
+            }
+          ]
+      ; fallback_cycles = []
+      }
     else
-      []
+      { issues = []; fallback_cycles = [] }
   else
     let profiles = Cascade_catalog_validator.discover_profiles ~config_path in
     let validator_issues = Cascade_catalog_validator.diagnose_catalog ~config_path in
@@ -150,26 +175,37 @@ let diagnose_cascade_catalog ~active_config_root =
        list through the doctor's [issues] makes it land in the same
        warnings/next-actions surface the dashboard renders, so a
        misconfigured [fallback_cascade] chain is visible in the
-       Config Doctor panel without leaving the page. *)
-    let cycle_issues =
-      match Cascade_config_loader.load_catalog ~config_path with
-      | Ok entries ->
-          Cascade_config_loader.detect_fallback_cycles entries
-          |> List.map (fun cycle ->
-            {
-              profile = None;
-              severity = Catalog_warn;
-              message =
-                Printf.sprintf
-                  "Cascade fallback_cascade cycle detected: %s. Rotation cannot \
-                   escape this loop; break the chain or remove the hint."
-                  (String.concat " -> " cycle);
-            })
+       Config Doctor panel without leaving the page.
+
+       Use the diagnostics-only loader variant so the doctor's poll
+       cycle (every dashboard refresh / `masc-mcp doctor config` run)
+       does not re-fire the cycle / mismatch / deprecated-name
+       counters or re-emit the WARN log for the same stable
+       misconfiguration. *)
+    let fallback_cycles =
+      match
+        Cascade_config_loader.load_catalog_for_diagnostics ~config_path
+      with
+      | Ok entries -> Cascade_config_loader.detect_fallback_cycles entries
       | Error _ -> []
+    in
+    let cycle_issues =
+      List.map
+        (fun cycle ->
+          {
+            profile = None;
+            severity = Catalog_warn;
+            message =
+              Printf.sprintf
+                "Cascade fallback_cascade cycle detected: %s. Rotation cannot \
+                 escape this loop; break the chain or remove the hint."
+                (format_fallback_cycle cycle);
+          })
+        fallback_cycles
     in
     let issues = validator_issues @ cycle_issues in
     if issues = [] then
-      []
+      { issues = []; fallback_cycles }
     else
       let error_count =
         issues
@@ -177,7 +213,7 @@ let diagnose_cascade_catalog ~active_config_root =
         |> List.length
       in
       let warn_count = List.length issues - error_count in
-      {
+      let summary = {
         profile = None;
         severity = if error_count > 0 then Catalog_error else Catalog_warn;
         message =
@@ -187,10 +223,11 @@ let diagnose_cascade_catalog ~active_config_root =
             (List.length profiles)
             error_count
             warn_count;
-      }
-      :: issues
+      } in
+      { issues = summary :: issues; fallback_cycles }
 
-let cascade_catalog_next_actions ~config_path issues =
+let cascade_catalog_next_actions ~config_path
+    { issues; fallback_cycles } =
   if issues = [] then
     []
   else
@@ -203,6 +240,19 @@ let cascade_catalog_next_actions ~config_path issues =
           "Fix or disable the broken cascade preset entries in %s before \
            assigning keepers to them."
           config_path
+      else if fallback_cycles <> [] then
+        (* Cycle warnings are a runtime-stalling loop, not degraded
+           metadata.  Give them a distinct primary action so the
+           operator is pointed at the actual hazard (cycle break)
+           rather than at a generic metadata cleanup. *)
+        Printf.sprintf
+          "Break the fallback_cascade cycle(s) in %s: %s. Rotation cannot \
+           escape these loops, so every participant inherits any single \
+           provider stall."
+          config_path
+          (fallback_cycles
+           |> List.map format_fallback_cycle
+           |> String.concat "; ")
       else
         Printf.sprintf
           "Clean up the degraded cascade preset metadata in %s so doctor \
@@ -341,9 +391,10 @@ let analyze_with (inputs : inputs) =
       ~effective_masc_root:runtime_data_root
       ()
   in
-  let cascade_catalog_issues =
+  let cascade_diagnosis =
     diagnose_cascade_catalog ~active_config_root
   in
+  let cascade_catalog_issues = cascade_diagnosis.issues in
   let cascade_config_path =
     Filename.concat active_config_root Config_dir_resolver.cascade_toml_filename
   in
@@ -407,7 +458,7 @@ let analyze_with (inputs : inputs) =
   let cascade_actions =
     cascade_catalog_next_actions
       ~config_path:cascade_config_path
-      cascade_catalog_issues
+      cascade_diagnosis
   in
   let next_actions =
     match init_state with

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -121,7 +121,34 @@ let diagnose_cascade_catalog ~active_config_root =
     []
   else
     let profiles = Cascade_catalog_validator.discover_profiles ~config_path in
-    let issues = Cascade_catalog_validator.diagnose_catalog ~config_path in
+    let validator_issues = Cascade_catalog_validator.diagnose_catalog ~config_path in
+    (* Surface fallback-cycle detection alongside the per-profile
+       validator output.  [Cascade_config_loader.load_catalog]
+       already detects cycles and bumps
+       [masc_cascade_fallback_cycle_detected_total] internally, but a
+       counter only registers a rate — the operator still needs to
+       open Grafana to learn the cycle exists.  Threading the cycle
+       list through the doctor's [issues] makes it land in the same
+       warnings/next-actions surface the dashboard renders, so a
+       misconfigured [fallback_cascade] chain is visible in the
+       Config Doctor panel without leaving the page. *)
+    let cycle_issues =
+      match Cascade_config_loader.load_catalog ~config_path with
+      | Ok entries ->
+          Cascade_config_loader.detect_fallback_cycles entries
+          |> List.map (fun cycle ->
+            {
+              profile = None;
+              severity = Catalog_warn;
+              message =
+                Printf.sprintf
+                  "Cascade fallback_cascade cycle detected: %s. Rotation cannot \
+                   escape this loop; break the chain or remove the hint."
+                  (String.concat " -> " cycle);
+            })
+      | Error _ -> []
+    in
+    let issues = validator_issues @ cycle_issues in
     if issues = [] then
       []
     else

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -108,8 +108,14 @@ let option_field name = function
   | None -> (name, `Null)
 
 let diagnose_cascade_catalog ~active_config_root =
+  (* RFC-0058 §9: the on-disk cascade source is [cascade.toml]; the
+     legacy [cascade.json] sibling is no longer read.  Probing for
+     [cascade.json] here made the catalog diagnostic a no-op in every
+     post-§9 config root (the file is absent), so the dashboard's
+     cascade-health panel showed green without ever validating the
+     catalog. *)
   let config_path =
-    Filename.concat active_config_root Config_dir_resolver.cascade_json_filename
+    Filename.concat active_config_root Config_dir_resolver.cascade_toml_filename
   in
   if not (Env_config_core.existing_file config_path) then
     []
@@ -159,7 +165,7 @@ let cascade_catalog_next_actions ~config_path issues =
     in
     [
       primary_action;
-      "Rerun `masc-mcp doctor config` after editing cascade.json.";
+      "Rerun `masc-mcp doctor config` after editing cascade.toml.";
     ]
 
 let current_inputs ~base_path_input ~default_base_path () =
@@ -293,7 +299,7 @@ let analyze_with (inputs : inputs) =
     diagnose_cascade_catalog ~active_config_root
   in
   let cascade_config_path =
-    Filename.concat active_config_root Config_dir_resolver.cascade_json_filename
+    Filename.concat active_config_root Config_dir_resolver.cascade_toml_filename
   in
   let warnings =
     [

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -118,7 +118,26 @@ let diagnose_cascade_catalog ~active_config_root =
     Filename.concat active_config_root Config_dir_resolver.cascade_toml_filename
   in
   if not (Env_config_core.existing_file config_path) then
-    []
+    (* No cascade.toml — but if a legacy cascade.json is still lying
+       around, the operator forgot to migrate.  Config_dir_resolver
+       already emits this exact warning at startup (see its
+       [degraded_legacy_json_warnings]); mirroring it here makes the
+       same diagnostic visible on the Config Doctor panel so it isn't
+       silent green when the catalog can't be validated. *)
+    let legacy_json =
+      Filename.concat active_config_root Config_dir_resolver.cascade_json_filename
+    in
+    if Env_config_core.existing_file legacy_json then
+      [ { profile = None
+        ; severity = Catalog_warn
+        ; message =
+            "Found cascade.json but no cascade.toml; cascade.json is no longer \
+             read (RFC-0058 §9). Migrate to cascade.toml so catalog \
+             diagnostics can run."
+        }
+      ]
+    else
+      []
   else
     let profiles = Cascade_catalog_validator.discover_profiles ~config_path in
     let validator_issues = Cascade_catalog_validator.diagnose_catalog ~config_path in

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -234,11 +234,12 @@ let bootstrap_base_path_config_root ~base_path =
        | None ->
            ensure_config_root_scaffold config_root;
            (* RFC-0058 §9.3: cascade.toml is the only cascade source.
-              [""] is the smallest valid TOML document (an empty table);
-              the materializer parses it and renders an empty in-memory
-              catalog.  Previously this wrote [cascade.json] with ["{}"]
-              — JSON-shaped, never read post-§9, and a present-but-unread
-              [cascade.json] trips the stale-json warning emitted by
+              [""] is the smallest valid TOML document — a document
+              with no tables and no keys; the materializer parses it
+              and renders an empty in-memory catalog.  Previously this
+              wrote [cascade.json] with ["{}"] — JSON-shaped, never
+              read post-§9, and a present-but-unread [cascade.json]
+              trips the stale-json warning emitted by
               [Config_dir_resolver]. *)
            let cascade_path =
              Filename.concat config_root Config_dir_resolver.cascade_toml_filename

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -233,11 +233,18 @@ let bootstrap_base_path_config_root ~base_path =
              config_root source
        | None ->
            ensure_config_root_scaffold config_root;
+           (* RFC-0058 §9.3: cascade.toml is the only cascade source.
+              [""] is the smallest valid TOML document (an empty table);
+              the materializer parses it and renders an empty in-memory
+              catalog.  Previously this wrote [cascade.json] with ["{}"]
+              — JSON-shaped, never read post-§9, and a present-but-unread
+              [cascade.json] trips the stale-json warning emitted by
+              [Config_dir_resolver]. *)
            let cascade_path =
-             Filename.concat config_root Config_dir_resolver.cascade_json_filename
+             Filename.concat config_root Config_dir_resolver.cascade_toml_filename
            in
            if not (Sys.file_exists cascade_path) then
-             Fs_compat.save_file cascade_path "{}";
+             Fs_compat.save_file cascade_path "";
            Log.Server.warn
              "bootstrapped minimal base-path config root without versioned source: %s"
              config_root);

--- a/test/test_config_doctor.ml
+++ b/test/test_config_doctor.ml
@@ -112,8 +112,12 @@ let make_inputs ?env_config_dir ?env_personas_dir ~cwd ~base_path_input () =
       repo_config_fallback_enabled = false;
     }
 
-let initialize_config_root ?(cascade_json="{}") root =
-  write_file (Filename.concat root "cascade.json") cascade_json;
+(* RFC-0058 §9: cascade.toml is the only on-disk cascade source.  The
+   default [""] is the smallest valid TOML document (an empty table),
+   which the materializer renders to an empty catalog — the "no presets
+   configured" baseline. *)
+let initialize_config_root ?(cascade_toml="") root =
+  write_file (Filename.concat root "cascade.toml") cascade_toml;
   mkdir_p (Filename.concat root "personas")
 
 let test_invalid_explicit_config_dir () =
@@ -186,18 +190,14 @@ let test_broken_cascade_catalog_surfaces_errors () =
   let base_path = Filename.concat dir "base" in
   let config_root = Filename.concat base_path ".masc/config" in
   initialize_config_root
-    ~cascade_json:{|{
-  "bad_provider_models": [
-    "__nonexistent_provider_sentinel__:fake-model"
-  ],
-  "bad_strategy_models": [
-    "claude_code:claude-haiku-4-5-20251001"
-  ],
-  "bad_strategy_strategy": "priority_tier",
-  "bad_strategy_tiers": [
-    ["codex_cli:auto"]
-  ]
-}|}
+    ~cascade_toml:{|[bad_provider]
+models = ["__nonexistent_provider_sentinel__:fake-model"]
+
+[bad_strategy]
+models = ["claude_code:claude-haiku-4-5-20251001"]
+strategy = "priority_tier"
+tiers = [["codex_cli:auto"]]
+|}
     config_root;
   let report =
     Config_doctor.analyze_with
@@ -219,7 +219,7 @@ let test_broken_cascade_catalog_surfaces_errors () =
        report.warnings);
   check bool "next action mentions doctor rerun" true
     (list_contains_substring
-       ~needle:"Rerun `masc-mcp doctor config` after editing cascade.json."
+       ~needle:"Rerun `masc-mcp doctor config` after editing cascade.toml."
        report.next_actions)
 
 let test_non_runtime_required_cascade_catalog_warns () =
@@ -227,19 +227,17 @@ let test_non_runtime_required_cascade_catalog_warns () =
   let base_path = Filename.concat dir "base" in
   let config_root = Filename.concat base_path ".masc/config" in
   initialize_config_root
-    ~cascade_json:{|{
-  "default_models": [
-    "claude_code:claude-haiku-4-5-20251001"
-  ],
-  "default_strategy": "priority_tier",
-  "default_tiers": [
-    ["claude_code:claude-haiku-4-5-20251001"],
-    ["gemini_cli:not-configured-here"]
-  ],
-  "manual_trial_models": [
-    "claude_code:claude-haiku-4-5-20251001"
-  ]
-}|}
+    ~cascade_toml:{|[default]
+models = ["claude_code:claude-haiku-4-5-20251001"]
+strategy = "priority_tier"
+tiers = [
+  ["claude_code:claude-haiku-4-5-20251001"],
+  ["gemini_cli:not-configured-here"],
+]
+
+[manual_trial]
+models = ["claude_code:claude-haiku-4-5-20251001"]
+|}
     config_root;
   let report =
     Config_doctor.analyze_with

--- a/test/test_config_doctor.ml
+++ b/test/test_config_doctor.ml
@@ -113,9 +113,9 @@ let make_inputs ?env_config_dir ?env_personas_dir ~cwd ~base_path_input () =
     }
 
 (* RFC-0058 §9: cascade.toml is the only on-disk cascade source.  The
-   default [""] is the smallest valid TOML document (an empty table),
-   which the materializer renders to an empty catalog — the "no presets
-   configured" baseline. *)
+   default [""] is the smallest valid TOML document — a document with
+   no tables or keys — which the materializer renders to an empty
+   catalog ("no presets configured" baseline). *)
 let initialize_config_root ?(cascade_toml="") root =
   write_file (Filename.concat root "cascade.toml") cascade_toml;
   mkdir_p (Filename.concat root "personas")


### PR DESCRIPTION
## What

RFC-0058 §9 left two vestigial \`cascade.json\` references that quietly broke production behavior.  This PR points them at \`cascade.toml\` (the actual SSOT since §9.3) and migrates the test fixtures accordingly.

## Why — the bugs

1. **\`lib/config_doctor.ml:diagnose_cascade_catalog\`** probed for \`cascade.json\` before running the validator.  Post-§9 that file is absent in every config root, so the existence guard short-circuited and the cascade-catalog diagnostic was a **no-op in production**.  The dashboard's cascade-health panel rendered green without ever validating the catalog.
2. **\`lib/server/server_runtime_bootstrap.ml\`** bootstrap-from-nothing path wrote \`cascade.json\` with \`"{}"\`. That content is JSON-shaped (the TOML reader cannot parse it), it is never read post-§9, *and* a present-but-unread \`cascade.json\` trips the stale-json WARN emitted by \`Config_dir_resolver\` (\`"Found cascade.json but no cascade.toml; cascade.json is no longer read (RFC-0058 §9)."\`).  The bootstrap path was creating the exact footgun the resolver warns about.
3. **\`test/test_config_doctor.ml\`** had not been migrated.  \`initialize_config_root\` wrote \`cascade.json\` with JSON content, and the two cascade fixtures used the flat JSON schema.

## What changed

- \`config_doctor.ml\`: \`Config_dir_resolver.cascade_json_filename\` → \`cascade_toml_filename\` at the two read sites; the next-action message \`"...editing cascade.json."\` → \`"...editing cascade.toml."\`.
- \`server_runtime_bootstrap.ml\`: write an empty \`cascade.toml\` (\`""\` — the smallest valid TOML document, the same seed pattern documented in \`dashboard_cascade.ml:default_raw_source_text\`).
- \`test_config_doctor.ml\`: \`initialize_config_root ?(cascade_toml="")\` writes \`cascade.toml\`; the two cascade fixtures move from flat JSON (\`{"X_models": [...], "X_strategy": "..."}\`) to flat TOML (\`[X]\nmodels = [...]\nstrategy = "..."\`).  The needle \`"...editing cascade.json."\` → \`"cascade.toml."\`.

## Test impact

Before this PR \`test_config_doctor.exe\` had **4 failures**.  After this PR: **1 failure**.

| # | Test | Before | After |
|---|------|--------|-------|
| 0 | invalid explicit config dir | OK | OK |
| 1 | missing init without explicit config | OK | OK |
| 2 | initialized local base config | FAIL | OK |
| 3 | shadowed explicit config dir | OK | OK |
| 4 | broken cascade catalog surfaces errors | FAIL | OK |
| 5 | non-runtime-required cascade catalog warns | FAIL | OK |
| 6 | analyze_live surfaces sandbox preflight | FAIL | **FAIL (orthogonal)** |

Test 6 fails for a reason unrelated to this PR: it calls \`Config_doctor.analyze_live\` without setting \`MASC_BASE_PATH\` / \`MASC_CONFIG_DIR\`, so \`Cascade_catalog_runtime\` cannot resolve the temp config and returns an invalid-catalog \`live_outcome\` → \`status = error\`.  Was already broken on \`origin/main\`; outside the scope of the §9 vestige cleanup.  Will file a follow-up.

## Verification

- \`dune build --root . test/test_config_doctor.exe @check\` green in worktree
- \`test_config_doctor.exe\`: 6/7 pass (test 6 noted above)
- \`test_cascade_config_validity.exe\`, \`test_cascade_toml_materialization.exe\`, \`test_cascade_catalog_runtime.exe\`, \`test_server_runtime_bootstrap.exe\` unaffected (continue to pass)

## Not in scope

- Test 6 sandbox-preflight resolution (orthogonal, pre-existing).
- \`provider_adapter.ml\` hardcoded CLI registry (gap #6, queued for Sprint 2/3 of \`joyful-tumbling-dragon.md\`).
- The \`source_kind = Toml\` single-arm variant retained for compatibility (\`Cascade_toml_materializer.mli\` notes "a future cleanup may drop the type entirely").

🤖 Generated with [Claude Code](https://claude.com/claude-code)