### PR TITLE
chore(scripts): audit-tla-ml-line-refs Rule 2 — zero-tolerance `file.ml:NNN` colon-form guard (iter-74 baseline-drain close)

### DIFF
--- a/docs/tla-audit/n2c-r17-tla-ml-colon-lineref-strict-guard-2026-05-12.md
+++ b/docs/tla-audit/n2c-r17-tla-ml-colon-lineref-strict-guard-2026-05-12.md
@@ -1,0 +1,36 @@
+# N-2.c R-17 — `audit-tla-ml-line-refs.sh` Rule 2: zero-tolerance guard against the compact `file.ml:NNN` colon-form line reference in `specs/keeper-state-machine/*.tla` (the iter-74-flagged "`\.ml:[0-9]` lint" — now landable, subdir is clean)
+
+**Date**: 2026-05-12 · **Iteration**: 92 (`/loop` FSM/TLA+/OCaml drift hunt) · **Phase**: guard (closing a long-standing follow-up)
+
+## What this is
+
+The iter-64 N-2.a convention for `specs/keeper-state-machine/*.tla` is "no line numbers — cite OCaml by symbol" (e.g. `keeper_foo.ml:my_function` or `keeper_foo.ml — my_function`), because the OCaml files grow and line numbers drift on every edit while symbols don't. The drift class had a 3-step pipeline (audit → fix → guard); N-2.c is the guard, `scripts/audit-tla-ml-line-refs.sh`, wired into `.github/workflows/tla-annotation-drift.yml`.
+
+But that guard's regex only matched the **prose** form — `\[([a-z_]+)\][^,]*line[s ]+(\d+)` (a bracketed function name and a nearby `line N` mention). It missed the **compact** form — `lib/keeper/keeper_post_turn.ml:648-656` (filename, colon, digit). The iter-84 #14971 line-ref sweep + the follow-up symbol-anchor commit (`6c1d427d8` — "switch mapping table to path.ml:symbol anchors (lint-checkable)") drained `KeeperPostTurnOrchestration.tla`'s mapping table of the last compact-form offenders, but nothing prevented the next preamble from re-introducing one.
+
+This PR adds **Rule 2** to the existing script: a whole-file scan of each `specs/keeper-state-machine/*.tla` for `[A-Za-z0-9_]+\.ml:[0-9]` — any hit is an N-2.a violation. Zero new script, zero new CI step (the workflow already runs `audit-tla-ml-line-refs.sh`), zero baseline file (the subdir is now clean: `0 prose-form citation(s) verified + 0 colon-form line-ref(s) across 34 spec(s)`).
+
+## Why it was "blocked" until now (and why iter 91's note was wrong)
+
+iter 91's audit memo said the lint was "still blocked — KeeperPostTurnOrchestration.tla has 9 line-range refs even after #14971 merged". That was a **stale-local-checkout artifact**: the loop's repo-root `main` checkout predated #14971's merge (`773bf985c`), so a `grep` over the working tree still saw the pre-merge file. `git show origin/main:specs/keeper-state-machine/KeeperPostTurnOrchestration.tla | grep '\.ml:[0-9]'` returns nothing — the user's `6c1d427d8` symbol-anchored the whole mapping table (`keeper_post_turn.ml:apply_post_turn_lifecycle_with_resilience_handles — ...`). So the subdir has been clean since #14971 merged; the lint is landable now.
+
+## Scope decisions
+
+- **`.ml` only, not `.mli`.** Interface files are small and don't grow, so they're not subject to the growth-driven drift this guard targets; Rule 1 already treats `.mli` as a fallback (used only if the preamble cites no `.ml` at all). Two `.mli:NNN` refs remain — `KeeperCompositeLifecycle.tla`'s `Keeper_state_machine.mli:139-144` (a 5-line line-number-heavy block; the surrounding text already self-documents "lines 131-136 reference ... [type event] declaration that starts at line 139 with [Context_measured] at line 144") and `KeeperDecisionPipeline.tla`'s `(mli mirror at keeper_registry.mli:49-53)`. Left for a separate cleanup if wanted (a `.mli`-converting PR would also want to drain `KeeperDecisionPipeline`'s prose `line 493 / 515 / 535 / 575` "Authoritative write points" block, which Rule 1 also misses because those entries use bare `mark_turn_started` not bracketed `[mark_turn_started]`).
+- **Scoped to `specs/keeper-state-machine/`.** The script already iterates only that directory (`SPEC_DIR`). The other spec trees (`specs/boundary/`, `specs/bug-models/`, `specs/auth/`, `specs/admission-queue/`, `specs/keeper-turn-fsm/`, `specs/task-lifecycle/`) never adopted the N-2.a convention and still use the `file.ml:NNN` form freely (~40 sites); widening the rule to them would need a baseline file (the `audit-tla-annotation-drift.sh --baseline` / `audit-ocaml-phase-count.sh --baseline` precedent). Out of scope here — this is the guard for the subdir that already follows the convention.
+
+## Not a workaround
+
+CLAUDE.md §워크어라운드 거부 기준 #2 ("string/substring 분류기 보강") targets *runtime* string classifiers added where a typed variant is possible — `String.starts_with ~prefix:"completion_contract_violation:"` and the like, where the compiler can't catch a missing reader. This is a *documentation-convention lint*: the structural fix is the symbol-anchor convention itself (symbols are stable identifiers the OCaml compiler keeps honest; line numbers aren't), and the lint just enforces it — same category as a "no hex literals" / "no trailing whitespace" CI check. It was pre-cleared as the iter-74 baseline-drain posture, and the user's `6c1d427d8` ("lint-checkable") explicitly anticipates it.
+
+## Verification
+
+- `bash -n scripts/audit-tla-ml-line-refs.sh` — syntax OK.
+- `bash scripts/audit-tla-ml-line-refs.sh` — `line-ref audit clean: 0 prose-form citation(s) verified + 0 colon-form line-ref(s) across 34 spec(s).` (exit 0).
+- Negative test: append `\* negative-test: keeper_foo.ml:42 ...` to a spec → `colon-ref: KeeperHeartbeat.tla:NNN — N-2.a: cite by symbol, not line — ...` (exit 1); revert → exit 0.
+- CI: `.github/workflows/tla-annotation-drift.yml` already runs this script on `specs/keeper-state-machine/**` and `scripts/audit-tla-ml-line-refs.sh` path changes — no workflow edit needed.
+
+## Follow-up
+
+- `.mli:NNN` cleanup (KeeperCompositeLifecycle / KeeperDecisionPipeline) + `KeeperDecisionPipeline`'s prose `line 493/515/535/575` block — a small spec-comment PR; not urgent (`.mli` files don't drift).
+- `keeper_unified_turn.ml`'s `run_keeper_cycle` reverse-citation block still says `Spec line 3 ... "[run_keeper_cycle] (line 1042+)"` — spec line 3 no longer carries the line number (iter 64 N-2.a). The `scripts/audit-ocaml-spec-nav-line-refs.sh` guard (the OCaml-docstring twin) covers reverse-citations but with a baseline; check whether this site is baselined and, if so, drain it when fixed. (iter 91 follow-up, still owed.)

--- a/scripts/audit-tla-ml-line-refs.sh
+++ b/scripts/audit-tla-ml-line-refs.sh
@@ -198,12 +198,13 @@ if [[ "${drift_count}" -gt 0 || "${colon_ref_count}" -gt 0 ]]; then
   echo "" >&2
   if [[ "${drift_count}" -gt 0 ]]; then
     echo "${drift_count} line-reference drift(s) detected across ${spec_count} spec(s) (${cite_count} citation(s) checked)." >&2
+    echo "Fix (Rule 1, drift): update the cited line numbers, OR replace the line-number cite with a symbol reference (N-2.a shape — e.g. \`keeper_foo.ml:my_function\` or \`keeper_foo.ml — my_function\`; iter 59 L-2.b precedent)." >&2
   fi
   if [[ "${colon_ref_count}" -gt 0 ]]; then
     echo "${colon_ref_count} colon-form line-ref(s) (\`file.ml:NNN\`) detected in specs/keeper-state-machine/*.tla — N-2.a requires symbol anchors." >&2
+    echo "Fix (Rule 2, colon-form forbidden): replace each \`file.ml:NNN\` with a symbol anchor (\`file.ml:symbol\`) or a prose mention; line-number cites are not allowed under N-2.a." >&2
   fi
-  echo "Fix: update the cited line numbers, OR replace the line-number cite with a symbol reference (N-2.a shape — e.g. \`keeper_foo.ml:my_function\` or \`keeper_foo.ml — my_function\`; iter 59 L-2.b precedent)." >&2
   exit 1
 fi
 
-echo "line-ref audit clean: ${cite_count} prose-form citation(s) verified + 0 colon-form line-ref(s) across ${spec_count} spec(s)." >&2
+echo "line-ref audit clean: ${cite_count} prose-form citation(s) verified + ${colon_ref_count} colon-form line-ref(s) across ${spec_count} spec(s)." >&2

--- a/scripts/audit-tla-ml-line-refs.sh
+++ b/scripts/audit-tla-ml-line-refs.sh
@@ -16,7 +16,7 @@
 # (audit → fix → guard), mirroring iter 52 #14874 (R-H-1.c TLA+
 # phase-count) and iter 55 #14891 (R-H-1.f OCaml docstring phase-count).
 #
-# Rule:
+# Rule 1 (drift check — prose `[func] ... line N` form):
 #   - In each `specs/keeper-state-machine/*.tla` preamble (first 60
 #     comment lines starting with `\*`), find every match of
 #     `\[([a-z_]+)\][^,]*line[s ]+(\d+)` — i.e. a bracketed function
@@ -35,10 +35,32 @@
 # fall outside.  Default 5 is empirical — KAQ's +245 drift would have
 # tripped this at any tolerance under 200.
 #
+# Rule 2 (strict check — compact `file.ml:NNN` colon form):
+#   - In each `specs/keeper-state-machine/*.tla` (whole file, not just
+#     the preamble), reject any `<ident>.ml:<digit>` — the compact
+#     `lib/keeper/keeper_foo.ml:648-656` form.  The iter-64 N-2.a
+#     convention for this subdir is "no line numbers — cite OCaml by
+#     symbol" (`keeper_foo.ml:my_function` or `keeper_foo.ml — my_function`);
+#     line numbers drift on every edit to the OCaml file, symbols do not.
+#   - Rule 1's prose-form regex (`[func] ... line N`) misses this compact
+#     form entirely, so iter 84 #14971's mapping-table sweep + the
+#     follow-up symbol-anchor commit left no automated guard against the
+#     next preamble re-introducing it.  This rule closes that gap.
+#   - `.ml` only — `.mli` interface files are small and don't grow, so
+#     they're not subject to the growth-driven drift this guard targets,
+#     and Rule 1 already de-prioritises `.mli` (it's only a fallback
+#     there).  Two `.mli:NNN` refs remain (KeeperCompositeLifecycle's
+#     `Keeper_state_machine.mli:139-144`, KeeperDecisionPipeline's
+#     `keeper_registry.mli:49-53`); left for a separate cleanup if wanted.
+#   - Scoped to keeper-state-machine because the other spec trees
+#     (boundary/, bug-models/, auth/, ...) never adopted N-2.a and still
+#     use the colon form freely; widening would need a baseline file.
+#
 # Usage: bash scripts/audit-tla-ml-line-refs.sh [--verbose] [--tolerance N]
 #
 # RFC chain: R-B-1.c → R-H-1.c (#14874) → R-H-1.f (#14891) → N-2.c
-# (this script), 8th drift class structural closure.
+# (this script — Rule 1; iter 92 adds Rule 2), 8th drift class
+# structural closure.
 set -euo pipefail
 
 for tool in awk grep sed; do
@@ -155,11 +177,33 @@ for spec in "${SPEC_DIR}"/*.tla; do
   done < <(printf '%s\n' "${preamble}" | grep -oE '\[[a-z_]+\][^,]*line[s ]+[0-9]+')
 done
 
-if [[ "${drift_count}" -gt 0 ]]; then
+# ── Rule 2: strict colon-form `file.ml:NNN` check ──────────────────
+# Whole-file scan (the colon form shows up in mapping tables and
+# inline `\*` comments, not just the preamble).  Any hit is an N-2.a
+# violation — line numbers must be symbols in this subdir.
+colon_ref_count=0
+for spec in "${SPEC_DIR}"/*.tla; do
+  spec_name="$(basename "${spec}")"
+  while IFS= read -r hit; do
+    [[ -z "${hit}" ]] && continue
+    colon_ref_count=$((colon_ref_count + 1))
+    line_no="${hit%%:*}"
+    line_txt="$(printf '%s' "${hit#*:}" | sed -E 's/^[[:space:]]+//' | cut -c1-100)"
+    printf 'colon-ref: %s:%s — N-2.a: cite by symbol, not line — %s\n' \
+      "${spec_name}" "${line_no}" "${line_txt}"
+  done < <(grep -nE '[A-Za-z0-9_]+\.ml:[0-9]' "${spec}" || true)
+done
+
+if [[ "${drift_count}" -gt 0 || "${colon_ref_count}" -gt 0 ]]; then
   echo "" >&2
-  echo "${drift_count} line-reference drift(s) detected across ${spec_count} spec(s) (${cite_count} citation(s) checked)." >&2
-  echo "Fix: update the cited line numbers, OR replace the line-number cite with a function-name-only reference (N-2.a shape, iter 59 L-2.b precedent)." >&2
+  if [[ "${drift_count}" -gt 0 ]]; then
+    echo "${drift_count} line-reference drift(s) detected across ${spec_count} spec(s) (${cite_count} citation(s) checked)." >&2
+  fi
+  if [[ "${colon_ref_count}" -gt 0 ]]; then
+    echo "${colon_ref_count} colon-form line-ref(s) (\`file.ml:NNN\`) detected in specs/keeper-state-machine/*.tla — N-2.a requires symbol anchors." >&2
+  fi
+  echo "Fix: update the cited line numbers, OR replace the line-number cite with a symbol reference (N-2.a shape — e.g. \`keeper_foo.ml:my_function\` or \`keeper_foo.ml — my_function\`; iter 59 L-2.b precedent)." >&2
   exit 1
 fi
 
-echo "line-ref audit clean: ${cite_count} citation(s) verified across ${spec_count} spec(s)." >&2
+echo "line-ref audit clean: ${cite_count} prose-form citation(s) verified + 0 colon-form line-ref(s) across ${spec_count} spec(s)." >&2


### PR DESCRIPTION
## Finding (Iteration 92, N-2.c R-17 — `\.ml:[0-9]` zero-tolerance guard)

**Script**: `scripts/audit-tla-ml-line-refs.sh` (Rule 2 added — whole-file scan of each `specs/keeper-state-machine/*.tla` for `[A-Za-z0-9_]+\.ml:[0-9]`; any hit = N-2.a violation)
**Wired into**: `.github/workflows/tla-annotation-drift.yml` "Run TLA->OCaml line-ref validator (N-2.c)" step (existing — no workflow edit needed)
**Aspect**: iter-74-flagged baseline-drain guard — finally landable now that the subdir is clean
**Risk**: LOW (script-only; lint runs zero-finding on current main; existing Rule 1 unchanged)
**Workaround signature**: N/A — pre-cleared as a doc-convention guard, not a string classifier; structural fix *is* the symbol-anchor convention, lint just enforces

## 순서도

```mermaid
flowchart TD
  A["audit-tla-ml-line-refs.sh<br/>(N-2.c, in tla-annotation-drift CI)"] --> R1["Rule 1: prose [func] ... line N<br/>(in preamble, tolerance ±5)"]
  A --> R2["Rule 2 (iter 92, NEW): compact file.ml:NNN<br/>(whole file, zero tolerance)"]
  R1 --> M["misses compact form<br/>(keeper_post_turn.ml:648-656)"]
  R2 --> N["catches compact form<br/>(N-2.a: cite by symbol)"]
  M -.-> H["iter 84 #14971 fixed it manually<br/>+ user 6c1d427d8 = 'lint-checkable'"]
  H --> R2
```

## Why it was 'blocked' until iter 92

iter 91 audit memo claimed `KeeperPostTurnOrchestration.tla`에 `\.ml:[0-9]` ref 9개 남음 → 사실은 **stale-local-checkout 오판**. `git show origin/main:specs/keeper-state-machine/KeeperPostTurnOrchestration.tla | grep '\.ml:[0-9]'` → empty. 사용자의 `6c1d427d8` ("switch mapping table to path.ml:symbol anchors (lint-checkable)") 이미 머지된 #14971에서 mapping table 전체 symbol-anchor 완료. **subdir은 #14971 머지 시점부터 clean**.

## Before / After

`scripts/audit-tla-ml-line-refs.sh` 1파일, +50/-6 LOC.

- **Before**: 정규식 `\[([a-z_]+)\][^,]*line[s ]+(\d+)` (prose form `[func] ... line N`) 만 catch. compact form `file.ml:NNN`은 완전히 miss. `0 citation(s) verified across 34 spec(s)` (subdir이 이미 깨끗하지만 guard가 닫혀 있지 않음).
- **After**: Rule 2 추가 — 별도 loop가 `${SPEC_DIR}/*.tla` 전체 파일을 `grep -nE '[A-Za-z0-9_]+\.ml:[0-9]'`로 스캔, 매치 시 `colon-ref: <spec>:<line> — N-2.a: cite by symbol, not line — <excerpt>` 출력 + `colon_ref_count++`. exit 조건이 `drift_count > 0 || colon_ref_count > 0`. 헤더에 "Rule 1 / Rule 2" 구분 + `.ml`-only 스코프 결정 근거 + `.mli:NNN` 2개 잔존 사이트 명시 + scoping rationale (다른 spec tree는 N-2.a 미채택). 최종 메시지가 "0 prose-form citation(s) verified + 0 colon-form line-ref(s) across 34 spec(s)."

```diff
+# Rule 2 (strict check — compact `file.ml:NNN` colon form):
+#   - In each `specs/keeper-state-machine/*.tla` (whole file, not just
+#     the preamble), reject any `<ident>.ml:<digit>` ...
...
+colon_ref_count=0
+for spec in "${SPEC_DIR}"/*.tla; do
+  spec_name="$(basename "${spec}")"
+  while IFS= read -r hit; do
+    [[ -z "${hit}" ]] && continue
+    colon_ref_count=$((colon_ref_count + 1))
+    line_no="${hit%%:*}"
+    line_txt="$(printf '%s' "${hit#*:}" | sed -E 's/^[[:space:]]+//' | cut -c1-100)"
+    printf 'colon-ref: %s:%s — N-2.a: cite by symbol, not line — %s\n' \
+      "${spec_name}" "${line_no}" "${line_txt}"
+  done < <(grep -nE '[A-Za-z0-9_]+\.ml:[0-9]' "${spec}" || true)
+done
+
+if [[ "${drift_count}" -gt 0 || "${colon_ref_count}" -gt 0 ]]; then
+  ...
```

## 왜 톱니처럼 정교하지 않은가

N-2.a 규약(symbol-anchor)과 이를 지키는 guard(N-2.c)가 **세트로 설계됐는데 guard의 정규식이 한 form만 catch**했다 — `[func] ... line N` 산문형은 잡지만 `file.ml:NNN` 압축형은 통째로 miss. iter-84 #14971의 sweep + 사용자의 `6c1d427d8` 후속 ("lint-checkable") 이 subdir의 마지막 압축형 ref를 손으로 비웠는데, 그 후 다음 PR이 압축형을 다시 도입해도 자동으로 잡힐 방법이 없었다. 즉 *규약*과 *guard* 사이의 톱니가 한 쪽 면만 맞물려 있었음 — 이 PR이 반대 면을 추가한다.

## 본 PR 수정

- `scripts/audit-tla-ml-line-refs.sh` — Rule 2 추가 (whole-file `[A-Za-z0-9_]+\.ml:[0-9]` 스캔), 헤더 재구성 (Rule 1 / Rule 2 / 스코핑 결정 근거), exit/report 블록 합산, 최종 메시지 갱신. +50/-6 LOC, 단일 파일.
- `docs/tla-audit/n2c-r17-tla-ml-colon-lineref-strict-guard-2026-05-12.md` — audit memo (스코프 결정, workaround 거부 기준 클리어 근거, follow-up).

## Verification

- [x] `bash -n scripts/audit-tla-ml-line-refs.sh` → syntax OK
- [x] `bash scripts/audit-tla-ml-line-refs.sh` → `line-ref audit clean: 0 prose-form citation(s) verified + 0 colon-form line-ref(s) across 34 spec(s).` (exit 0)
- [x] Negative test: spec에 `\* keeper_foo.ml:42` 한 줄 append → `colon-ref: KeeperHeartbeat.tla:NNN — N-2.a: cite by symbol, not line — \* negative-test: keeper_foo.ml:42 should trip Rule 2` (exit 1); revert → exit 0
- [x] CI: `.github/workflows/tla-annotation-drift.yml`가 이미 `audit-tla-ml-line-refs.sh`와 `specs/keeper-state-machine/**`를 path에 포함 — 자동 enforce
- [x] `bash ~/me/scripts/pr-rfc-check.sh --pr-body /tmp/pr-iter92-body.md` (rfc-exit=0 — 아래 RFC 참조)

## Trade-off

- **`.ml`만, `.mli` 제외**: interface 파일은 작고 안 자라므로 growth-driven drift 대상이 아님 (Rule 1도 `.mli`는 fallback으로만 처리). `.mli:NNN` 2건 잔존 — `KeeperCompositeLifecycle.tla`의 `Keeper_state_machine.mli:139-144` (5줄짜리 line-number-heavy 블록), `KeeperDecisionPipeline.tla`의 `(mli mirror at keeper_registry.mli:49-53)` — 별도 cleanup이 원하면 (`.mli` 변환 PR은 `KeeperDecisionPipeline`의 prose `line 493/515/535/575` "Authoritative write points" 블록도 함께 drain 권장 — Rule 1도 못 잡는 형태 [bare `mark_turn_started`이지 `[mark_turn_started]` 아님]).
- **keeper-state-machine 스코프만**: 다른 spec tree (`specs/boundary/`, `specs/bug-models/`, `specs/auth/`, ...)는 N-2.a 미채택, `\.ml:[0-9]` ref ~40개 자유롭게 사용 중. 확장하려면 baseline 파일 필요 (`audit-tla-annotation-drift.sh --baseline` 선례). 본 PR 범위 밖.
- iter 91 follow-up (`keeper_unified_turn.ml` `(line 1042+)` reverse-ref) 미해소 — `scripts/audit-ocaml-spec-nav-line-refs.sh`가 이미 baseline 가진 OCaml-docstring twin guard. 별도 OCaml-touching PR에 번들.

## RFC 참조

`RFC-WAIVED: documentation-convention lint이지 credential/identity/sandbox/dashboard/hooks/workflow subsystem 아님. structural fix는 symbol-anchor 규약 자체이고 (symbols는 OCaml 컴파일러가 stable identifier로 유지) lint는 그 규약을 enforce. CLAUDE.md §워크어라운드 거부 기준 #2 (string/substring 분류기) 미해당 — runtime classifier 아닌 doc-convention guard. iter-74 baseline-drain posture로 progress memory에서 pre-cleared. RFC chain: R-B-1.c → R-H-1.c (#14874) → R-H-1.f (#14891) → N-2.c (이 스크립트, Rule 1; iter 92가 Rule 2 추가).`

## 진행 추적

다음 iteration 시작점: 후보 — KeeperWorkPipeline 모델 버그 fix (KNOWN_FAILURES, exit 13) OR OperatorPauseBroadcast-buggy deadlock-vs-property follow-up OR `keeper_unified_turn.ml` `(line 1042+)` reverse-ref fix (OCaml-touching PR에 번들) OR `.mli:NNN` cleanup (KCL + KDP) OR R-D-2.a+R-D-1.a 번들 (KCAF) OR KSM A-5 (22×19 matrix).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
