### PR TITLE
fix(dashboard): unrot keeper-FSM tests + close CI path-scope blind spot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -867,13 +867,14 @@ jobs:
     timeout-minutes: 10
     needs: [pr-live-gate, changes]
     # PR mode: stay path-scoped (dashboard=true only when dashboard/ changes).
-    # main push / schedule / workflow_dispatch: ignore path scope and always run,
-    # so a dashboard test regression introduced by a non-dashboard-path change
-    # (e.g. a shared-type refactor, or a dashboard-touching Draft merged via
-    # admin-merge fast-track while the dashboard job was red) is detected on the
-    # next main run rather than persisting silently. Mirrors the tla-specs job;
-    # root cause: keeper-fsm-specs.test.ts / keeper-composite.test.ts sat red on
-    # main after #14252/#14380 because no main-push run re-checked them.
+    # Non-PR events (push to main/develop, schedule, workflow_dispatch):
+    # ignore path scope and always run, so a dashboard test regression
+    # introduced by a non-dashboard-path change (e.g. a shared-type refactor,
+    # or a dashboard-touching Draft merged via admin-merge fast-track while
+    # the dashboard job was red) is detected on the next main/develop push
+    # rather than persisting silently. Mirrors the tla-specs job; root cause:
+    # keeper-fsm-specs.test.ts / keeper-composite.test.ts sat red on main
+    # after #14252/#14380 because no main-push run re-checked them.
     if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && (needs.changes.outputs.dashboard == 'true' || needs.pr-live-gate.outputs.live_state == 'NON_PR') }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -866,7 +866,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [pr-live-gate, changes]
-    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && needs.changes.outputs.dashboard == 'true' }}
+    # PR mode: stay path-scoped (dashboard=true only when dashboard/ changes).
+    # main push / schedule / workflow_dispatch: ignore path scope and always run,
+    # so a dashboard test regression introduced by a non-dashboard-path change
+    # (e.g. a shared-type refactor, or a dashboard-touching Draft merged via
+    # admin-merge fast-track while the dashboard job was red) is detected on the
+    # next main run rather than persisting silently. Mirrors the tla-specs job;
+    # root cause: keeper-fsm-specs.test.ts / keeper-composite.test.ts sat red on
+    # main after #14252/#14380 because no main-push run re-checked them.
+    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && (needs.changes.outputs.dashboard == 'true' || needs.pr-live-gate.outputs.live_state == 'NON_PR') }}
 
     steps:
       - name: Checkout

--- a/dashboard/src/api/schemas/keeper-composite.test.ts
+++ b/dashboard/src/api/schemas/keeper-composite.test.ts
@@ -4,6 +4,10 @@ import {
   CompositeSchemaDriftError,
 } from './keeper-composite'
 
+// Minimal snapshot mirroring the required keys of
+// `keeper_composite_observer.ml` `snapshot_to_json`. Optional keys
+// (keeper, collapsed_from, circuit_breaker, phase_diagnosis, execution,
+// runtime_attention, recommended_actions) are added per-test.
 const VALID_SNAPSHOT = {
   correlation_id: 'corr-1',
   run_id: 'run-1',
@@ -21,6 +25,7 @@ const VALID_SNAPSHOT = {
     event_priority_monotone: true,
     phase_derivation_agreement: true,
   },
+  fsm_guard_violations: 0,
   is_live: true,
   last_outcome: null,
 }
@@ -34,6 +39,17 @@ describe('parseKeeperCompositeSnapshot', () => {
     expect(result.is_live).toBe(true)
     expect(result.last_outcome).toBeNull()
     expect(result.recommended_actions).toEqual([])
+    expect(result.fsm_guard_violations).toBe(0)
+  })
+
+  it('parses a non-zero fsm_guard_violations count', () => {
+    const result = parseKeeperCompositeSnapshot({ ...VALID_SNAPSHOT, fsm_guard_violations: 3 })
+    expect(result.fsm_guard_violations).toBe(3)
+  })
+
+  it('throws CompositeSchemaDriftError when fsm_guard_violations is absent', () => {
+    const { fsm_guard_violations: _, ...noViolations } = VALID_SNAPSHOT
+    expect(() => parseKeeperCompositeSnapshot(noViolations)).toThrow(CompositeSchemaDriftError)
   })
 
   it('parses explicit keeper identity when emitted by the backend', () => {

--- a/dashboard/src/api/schemas/keeper-composite.test.ts
+++ b/dashboard/src/api/schemas/keeper-composite.test.ts
@@ -4,15 +4,20 @@ import {
   CompositeSchemaDriftError,
 } from './keeper-composite'
 
-// Minimal snapshot mirroring the required keys of
-// `keeper_composite_observer.ml` `snapshot_to_json`. Optional keys
-// (keeper, collapsed_from, circuit_breaker, phase_diagnosis, execution,
-// runtime_attention, recommended_actions) are added per-test.
+// Minimal snapshot carrying every required key of
+// `KeeperCompositeSnapshotSchema`. Optional keys (keeper, collapsed_from,
+// circuit_breaker, phase_diagnosis, execution, runtime_attention,
+// recommended_actions) are added per-test. Value shapes here mirror what
+// `keeper_composite_observer.ml` `snapshot_to_json` emits: lowercase
+// snake_case phase / turn_phase / decision / cascade / compaction (via
+// `Keeper_state_machine.phase_to_string` etc.). Capitalized variants
+// like `"Stable"` are forward-looking — they appear only in schema-
+// permissiveness tests below, never in real backend payloads today.
 const VALID_SNAPSHOT = {
   correlation_id: 'corr-1',
   run_id: 'run-1',
   ts: 1713398400,
-  phase: 'Stable',
+  phase: 'running',
   turn_phase: 'idle',
   decision: { stage: 'undecided' },
   cascade: { state: 'idle' },
@@ -33,7 +38,7 @@ const VALID_SNAPSHOT = {
 describe('parseKeeperCompositeSnapshot', () => {
   it('parses a valid snapshot', () => {
     const result = parseKeeperCompositeSnapshot(VALID_SNAPSHOT)
-    expect(result.phase).toBe('Stable')
+    expect(result.phase).toBe('running')
     expect(result.collapsed_from).toBeUndefined()
     expect(result.turn_phase).toBe('idle')
     expect(result.is_live).toBe(true)
@@ -60,8 +65,27 @@ describe('parseKeeperCompositeSnapshot', () => {
     expect(result.keeper).toBe('analyst')
   })
 
-  it('parses all valid phase values', () => {
-    for (const phase of ['Running', 'Failing', 'Overflowed', 'Compacting', 'HandingOff', 'Draining', 'Stable']) {
+  // Every phase string the backend can emit, per
+  // `Keeper_state_machine.phase_to_string` (13 ctors, lowercase
+  // snake_case). The schema must round-trip each one verbatim.
+  it('round-trips every phase the backend can emit', () => {
+    for (const phase of [
+      'offline', 'running', 'failing', 'overflowed', 'compacting',
+      'handing_off', 'draining', 'paused', 'stopped', 'crashed',
+      'restarting', 'dead', 'zombie',
+    ]) {
+      const result = parseKeeperCompositeSnapshot({ ...VALID_SNAPSHOT, phase })
+      expect(result.phase).toBe(phase)
+    }
+  })
+
+  // Forward-looking: the schema's `phase` is an open string and tolerates
+  // values that the runtime doesn't emit today (capitalized TLA+ projection
+  // names like "Stable"). Keeping this test pins that openness so a future
+  // `z.enum`-tightening doesn't silently break a planned composite-projection
+  // backend rollout.
+  it('schema is open to non-runtime phase values (e.g. TLA projection "Stable")', () => {
+    for (const phase of ['Stable', 'Running', 'Failing']) {
       const result = parseKeeperCompositeSnapshot({ ...VALID_SNAPSHOT, phase })
       expect(result.phase).toBe(phase)
     }
@@ -217,8 +241,13 @@ describe('parseKeeperCompositeSnapshot', () => {
   })
 
   it('parses collapsed_from when Stable hides a raw keeper phase', () => {
+    // `Stable` is the TLA+ composite projection of seven raw keeper phases
+    // (Offline/Paused/Stopped/Crashed/Restarting/Dead/Zombie). The runtime
+    // observer does not emit it today; the schema supports it for a planned
+    // backend that surfaces the collapse with the raw phase in `collapsed_from`.
     const result = parseKeeperCompositeSnapshot({
       ...VALID_SNAPSHOT,
+      phase: 'Stable',
       collapsed_from: 'paused',
     })
     expect(result.phase).toBe('Stable')

--- a/dashboard/src/components/fsm-hub.integration.test.ts
+++ b/dashboard/src/components/fsm-hub.integration.test.ts
@@ -86,6 +86,7 @@ const REAL_COMPOSITE_PAYLOAD = {
     event_priority_monotone: true,
     phase_derivation_agreement: true,
   },
+  fsm_guard_violations: 0,
   is_live: false,
   last_outcome: null,
 }

--- a/dashboard/src/components/fsm-hub.integration.test.ts
+++ b/dashboard/src/components/fsm-hub.integration.test.ts
@@ -42,7 +42,7 @@ const REAL_COMPOSITE_SHAPE: KeeperCompositeSnapshot = {
   correlation_id: '10510-64f79d602ce6c-60c',
   run_id: 'r-1776233076-0',
   ts: 1776235685.221697,
-  phase: 'Running',
+  phase: 'running',
   turn_phase: 'idle',
   decision: { stage: 'undecided' },
   cascade: { state: 'idle' },
@@ -68,12 +68,17 @@ const REAL_COMPOSITE_SHAPE: KeeperCompositeSnapshot = {
 }
 
 /** Real-world payload observed from `keeper_composite_observer.ml`
-    snapshot_to_json — the schema MUST accept this without transformation. */
+    snapshot_to_json — the schema MUST accept this without transformation.
+    FSM strings are lowercase snake_case because the observer serializes
+    via `Keeper_state_machine.phase_to_string` (and the parallel
+    *_to_string for turn_phase / decision / cascade / compaction).  The
+    capitalized `Stable` form lives in the TLA+ composite projection,
+    not in the runtime JSON. */
 const REAL_COMPOSITE_PAYLOAD = {
   correlation_id: '10510-64f79d602ce6c-60c',
   run_id: 'r-1776233076-0',
   ts: 1776235685.221697,
-  phase: 'Running',
+  phase: 'running',
   turn_phase: 'idle',
   decision: { stage: 'undecided' },
   cascade: { state: 'idle' },
@@ -122,7 +127,7 @@ describe('FSM Hub integration — API response shape', () => {
   describe('composite snapshot schema (valibot pilot)', () => {
     it('accepts the current backend payload shape end-to-end', () => {
       const parsed = parseKeeperCompositeSnapshot(REAL_COMPOSITE_PAYLOAD)
-      expect(parsed.phase).toBe('Running')
+      expect(parsed.phase).toBe('running')
       expect(parsed.collapsed_from).toBeUndefined()
       expect(parsed.invariants.phase_turn_alignment).toBe(true)
       expect(parsed.last_outcome).toBeNull()

--- a/dashboard/src/components/keeper-fsm-specs.test.ts
+++ b/dashboard/src/components/keeper-fsm-specs.test.ts
@@ -8,132 +8,138 @@ import {
   TURN_FSM_STATES,
 } from './keeper-fsm-specs'
 
+// State alphabets the dashboard renders. These must stay in lockstep with
+// the OCaml runtime: KSM ← keeper_state_machine.ml `type phase` (13 ctors),
+// KTC ← keeper_registry.ml `type turn_phase` (7 ctors), KDP/KCL/KMC ← the
+// matching keeper_registry.ml sub-FSM types. If you change one of these
+// arrays you almost certainly need a matching change on the OCaml side and
+// in dashboard/src/api/schemas/keeper-composite.ts.
+const KSM_STATES = [
+  'offline', 'running', 'failing', 'overflowed', 'compacting',
+  'handing_off', 'draining', 'paused', 'stopped', 'crashed',
+  'restarting', 'dead', 'zombie',
+]
+const KTC_STATES = ['idle', 'prompting', 'routing', 'executing', 'compacting', 'finalizing', 'exhausted']
+const KDP_STATES = ['undecided', 'guard_ok', 'gate_rejected', 'tool_policy_selected']
+const KCL_STATES = ['idle', 'selecting', 'trying', 'done', 'exhausted']
+const KMC_STATES = ['accumulating', 'compacting', 'done']
+
 describe('buildCompositeFsmSpec', () => {
   const defaultParams = {
-    phase: 'Running',
+    phase: 'running',
     turnPhase: 'idle',
     decisionStage: 'undecided',
     cascadeState: 'idle',
     compactionStage: 'accumulating',
   }
 
-  it('creates nodes for all 5 clusters with parents', () => {
+  it('creates parent nodes for all 5 sub-FSM clusters', () => {
     const spec = buildCompositeFsmSpec(defaultParams)
-    const parents = spec.nodes.filter(n => !n.parent)
-    const parentIds = parents.map(n => n.id)
+    const parentIds = spec.nodes.filter(n => !n.parent).map(n => n.id)
     expect(parentIds).toEqual(['KSM', 'KTC', 'KDP', 'KCL', 'KMC'])
   })
 
-  it('creates KSM cluster with 7 child states', () => {
+  it('creates the KSM cluster with all 13 keeper-phase states', () => {
     const spec = buildCompositeFsmSpec(defaultParams)
-    const ksmChildren = spec.nodes.filter(n => n.parent === 'KSM')
-    expect(ksmChildren).toHaveLength(7)
-    const ids = ksmChildren.map(n => n.id.split(':')[1])
-    expect(ids).toContain('Running')
-    expect(ids).toContain('Stable')
+    const ids = spec.nodes.filter(n => n.parent === 'KSM').map(n => n.id.split(':')[1])
+    expect(ids).toEqual(KSM_STATES)
   })
 
-  it('creates KTC cluster with 7 child states', () => {
+  it('creates the KTC cluster with all 7 turn-phase states', () => {
     const spec = buildCompositeFsmSpec(defaultParams)
-    const ktcChildren = spec.nodes.filter(n => n.parent === 'KTC')
-    expect(ktcChildren).toHaveLength(7)
+    const ids = spec.nodes.filter(n => n.parent === 'KTC').map(n => n.id.split(':')[1])
+    expect(ids).toEqual(KTC_STATES)
   })
 
-  it('creates KDP cluster with 4 child states', () => {
+  it('creates the KDP cluster with all 4 decision-stage states', () => {
     const spec = buildCompositeFsmSpec(defaultParams)
-    const kdpChildren = spec.nodes.filter(n => n.parent === 'KDP')
-    expect(kdpChildren).toHaveLength(4)
+    const ids = spec.nodes.filter(n => n.parent === 'KDP').map(n => n.id.split(':')[1])
+    expect(ids).toEqual(KDP_STATES)
   })
 
-  it('creates KCL cluster with 5 child states', () => {
+  it('creates the KCL cluster with all 5 cascade states', () => {
     const spec = buildCompositeFsmSpec(defaultParams)
-    const kclChildren = spec.nodes.filter(n => n.parent === 'KCL')
-    expect(kclChildren).toHaveLength(5)
+    const ids = spec.nodes.filter(n => n.parent === 'KCL').map(n => n.id.split(':')[1])
+    expect(ids).toEqual(KCL_STATES)
   })
 
-  it('creates KMC cluster with 3 child states', () => {
+  it('creates the KMC cluster with all 3 compaction stages', () => {
     const spec = buildCompositeFsmSpec(defaultParams)
-    const kmcChildren = spec.nodes.filter(n => n.parent === 'KMC')
-    expect(kmcChildren).toHaveLength(3)
+    const ids = spec.nodes.filter(n => n.parent === 'KMC').map(n => n.id.split(':')[1])
+    expect(ids).toEqual(KMC_STATES)
   })
 
-  it('total node count = 5 parents + 26 children = 31', () => {
+  it('total node count = 5 parents + 32 children = 37', () => {
     const spec = buildCompositeFsmSpec(defaultParams)
-    expect(spec.nodes).toHaveLength(31)
+    const childCount = KSM_STATES.length + KTC_STATES.length + KDP_STATES.length
+      + KCL_STATES.length + KMC_STATES.length
+    expect(childCount).toBe(32)
+    expect(spec.nodes).toHaveLength(5 + childCount)
   })
 
-  it('returns empty edges by design', () => {
+  it('returns empty edges by design (cross-cluster causality lives in the TLA+ spec)', () => {
     const spec = buildCompositeFsmSpec(defaultParams)
     expect(spec.edges).toEqual([])
   })
 
-  it('uses breadthfirst layout', () => {
+  it('uses breadthfirst layout and LR direction', () => {
     const spec = buildCompositeFsmSpec(defaultParams)
     expect(spec.layout).toBe('breadthfirst')
-  })
-
-  it('uses LR direction', () => {
-    const spec = buildCompositeFsmSpec(defaultParams)
     expect(spec.direction).toBe('LR')
   })
 
-  it('marks active phase child as active type when Running', () => {
+  it('marks the active KSM child as active when the phase is running', () => {
     const spec = buildCompositeFsmSpec(defaultParams)
-    const runningChild = spec.nodes.find(n => n.id === 'KSM:Running')
-    expect(runningChild!.type).toBe('active')
+    expect(spec.nodes.find(n => n.id === 'KSM:running')!.type).toBe('active')
   })
 
-  it('marks active phase child as err type when Failing', () => {
-    const spec = buildCompositeFsmSpec({ ...defaultParams, phase: 'Failing' })
-    const failingChild = spec.nodes.find(n => n.id === 'KSM:Failing')
-    expect(failingChild!.type).toBe('err')
+  it('marks the active KSM child as err for failure-class phases', () => {
+    for (const phase of ['failing', 'stopped', 'crashed', 'dead', 'zombie']) {
+      const spec = buildCompositeFsmSpec({ ...defaultParams, phase })
+      expect(spec.nodes.find(n => n.id === `KSM:${phase}`)!.type).toBe('err')
+    }
   })
 
-  it('marks buffer phases as warn type', () => {
-    const spec = buildCompositeFsmSpec({ ...defaultParams, phase: 'Compacting' })
-    const compactingChild = spec.nodes.find(n => n.id === 'KSM:Compacting')
-    expect(compactingChild!.type).toBe('warn')
+  it('marks the active KSM child as warn for buffer-class phases', () => {
+    for (const phase of ['overflowed', 'compacting', 'handing_off', 'draining', 'paused', 'restarting']) {
+      const spec = buildCompositeFsmSpec({ ...defaultParams, phase })
+      expect(spec.nodes.find(n => n.id === `KSM:${phase}`)!.type).toBe('warn')
+    }
   })
 
-  it('marks inactive children as dim', () => {
+  it('marks inactive KSM children as dim', () => {
     const spec = buildCompositeFsmSpec(defaultParams)
-    const stableChild = spec.nodes.find(n => n.id === 'KSM:Stable')
-    expect(stableChild!.type).toBe('dim')
+    expect(spec.nodes.find(n => n.id === 'KSM:dead')!.type).toBe('dim')
   })
 
-  it('marks gate_rejected decision as err type', () => {
+  it('marks a gate_rejected decision as err', () => {
     const spec = buildCompositeFsmSpec({ ...defaultParams, decisionStage: 'gate_rejected' })
-    const rejected = spec.nodes.find(n => n.id === 'KDP:gate_rejected')
-    expect(rejected!.type).toBe('err')
+    expect(spec.nodes.find(n => n.id === 'KDP:gate_rejected')!.type).toBe('err')
   })
 
-  it('marks exhausted cascade as err type', () => {
+  it('marks an exhausted cascade as err', () => {
     const spec = buildCompositeFsmSpec({ ...defaultParams, cascadeState: 'exhausted' })
-    const exhausted = spec.nodes.find(n => n.id === 'KCL:exhausted')
-    expect(exhausted!.type).toBe('err')
+    expect(spec.nodes.find(n => n.id === 'KCL:exhausted')!.type).toBe('err')
   })
 
-  it('marks KMC active child with warn tone', () => {
+  it('marks the active KMC child with a warn tone', () => {
     const spec = buildCompositeFsmSpec(defaultParams)
-    const accumulating = spec.nodes.find(n => n.id === 'KMC:accumulating')
-    expect(accumulating!.type).toBe('warn')
+    expect(spec.nodes.find(n => n.id === 'KMC:accumulating')!.type).toBe('warn')
   })
 
-  it('marks KMC inactive children as dim', () => {
+  it('marks inactive KMC children as dim', () => {
     const spec = buildCompositeFsmSpec(defaultParams)
-    const compacting = spec.nodes.find(n => n.id === 'KMC:compacting')
-    expect(compacting!.type).toBe('dim')
+    expect(spec.nodes.find(n => n.id === 'KMC:compacting')!.type).toBe('dim')
   })
 
-  it('does not set activeNodeId', () => {
+  it('does not set activeNodeId (compound graph, no single active node)', () => {
     const spec = buildCompositeFsmSpec(defaultParams)
     expect(spec.activeNodeId).toBeUndefined()
   })
 
-  it('uses correct node id format cluster:state', () => {
+  it('uses the cluster:state node id format', () => {
     const spec = buildCompositeFsmSpec(defaultParams)
-    const ksmChildren = spec.nodes.filter(n => n.parent === 'KSM')
-    for (const child of ksmChildren) {
+    for (const child of spec.nodes.filter(n => n.parent === 'KSM')) {
       expect(child.id).toMatch(/^KSM:/)
     }
   })
@@ -144,11 +150,9 @@ describe('buildCompositeFsmSpec', () => {
 // ================================================================
 
 describe('buildCompactionSpec', () => {
-  it('returns 3 nodes for KMC states', () => {
+  it('returns 3 nodes for the KMC states', () => {
     const spec = buildCompactionSpec('accumulating')
-    expect(spec.nodes).toHaveLength(3)
-    const ids = spec.nodes.map(n => n.id)
-    expect(ids).toEqual(['accumulating', 'compacting', 'done'])
+    expect(spec.nodes.map(n => n.id)).toEqual(['accumulating', 'compacting', 'done'])
   })
 
   it('returns 3 edges', () => {
@@ -156,160 +160,140 @@ describe('buildCompactionSpec', () => {
     expect(spec.edges).toHaveLength(3)
   })
 
-  it('sets activeNodeId to activeStage', () => {
-    const spec = buildCompactionSpec('compacting')
-    expect(spec.activeNodeId).toBe('compacting')
+  it('sets activeNodeId to the active stage', () => {
+    expect(buildCompactionSpec('compacting').activeNodeId).toBe('compacting')
   })
 
-  it('uses breadthfirst layout', () => {
+  it('uses breadthfirst layout and LR direction', () => {
     const spec = buildCompactionSpec('accumulating')
     expect(spec.layout).toBe('breadthfirst')
-  })
-
-  it('uses LR direction', () => {
-    const spec = buildCompactionSpec('accumulating')
     expect(spec.direction).toBe('LR')
   })
 
-  it('marks compacting active stage as warn', () => {
+  it('marks the compacting active stage as warn', () => {
     const spec = buildCompactionSpec('compacting')
-    const compacting = spec.nodes.find(n => n.id === 'compacting')
-    expect(compacting!.type).toBe('warn')
+    expect(spec.nodes.find(n => n.id === 'compacting')!.type).toBe('warn')
   })
 
-  it('marks accumulating active stage as active with no problematic phase', () => {
-    const spec = buildCompactionSpec('accumulating')
-    const accumulating = spec.nodes.find(n => n.id === 'accumulating')
-    expect(accumulating!.type).toBe('active')
+  it('marks the accumulating active stage as active when the phase is benign', () => {
+    expect(buildCompactionSpec('accumulating').nodes.find(n => n.id === 'accumulating')!.type).toBe('active')
   })
 
-  it('marks done active stage as active', () => {
-    const spec = buildCompactionSpec('done')
-    const done = spec.nodes.find(n => n.id === 'done')
-    expect(done!.type).toBe('active')
+  it('marks the done active stage as active', () => {
+    expect(buildCompactionSpec('done').nodes.find(n => n.id === 'done')!.type).toBe('active')
   })
 
-  it('marks as err when currentPhase is Overflowed', () => {
-    const spec = buildCompactionSpec('accumulating', 'Overflowed')
-    const accumulating = spec.nodes.find(n => n.id === 'accumulating')
-    expect(accumulating!.type).toBe('err')
+  it('marks the active stage as err when currentPhase is overflowed', () => {
+    const spec = buildCompactionSpec('accumulating', 'overflowed')
+    expect(spec.nodes.find(n => n.id === 'accumulating')!.type).toBe('err')
   })
 
-  it('marks as err when currentPhase is Failing', () => {
-    const spec = buildCompactionSpec('accumulating', 'Failing')
-    const accumulating = spec.nodes.find(n => n.id === 'accumulating')
-    expect(accumulating!.type).toBe('err')
+  it('marks the active stage as err when currentPhase is failing', () => {
+    const spec = buildCompactionSpec('accumulating', 'failing')
+    expect(spec.nodes.find(n => n.id === 'accumulating')!.type).toBe('err')
   })
 
-  it('compacting stage takes precedence as warn even with Failing phase', () => {
-    const spec = buildCompactionSpec('compacting', 'Failing')
-    const compacting = spec.nodes.find(n => n.id === 'compacting')
-    expect(compacting!.type).toBe('warn')
+  it('lets the compacting stage take precedence as warn even with a failing phase', () => {
+    const spec = buildCompactionSpec('compacting', 'failing')
+    expect(spec.nodes.find(n => n.id === 'compacting')!.type).toBe('warn')
   })
 
   it('marks inactive states as dim', () => {
     const spec = buildCompactionSpec('accumulating')
-    const compacting = spec.nodes.find(n => n.id === 'compacting')
-    expect(compacting!.type).toBe('dim')
+    expect(spec.nodes.find(n => n.id === 'compacting')!.type).toBe('dim')
   })
 
-  it('handles null currentPhase', () => {
-    const spec = buildCompactionSpec('accumulating', null)
-    const accumulating = spec.nodes.find(n => n.id === 'accumulating')
-    expect(accumulating!.type).toBe('active')
+  it('treats a null currentPhase as benign', () => {
+    expect(buildCompactionSpec('accumulating', null).nodes.find(n => n.id === 'accumulating')!.type).toBe('active')
   })
 
-  it('handles undefined currentPhase', () => {
-    const spec = buildCompactionSpec('accumulating')
-    const accumulating = spec.nodes.find(n => n.id === 'accumulating')
-    expect(accumulating!.type).toBe('active')
+  it('treats an undefined currentPhase as benign', () => {
+    expect(buildCompactionSpec('accumulating').nodes.find(n => n.id === 'accumulating')!.type).toBe('active')
   })
 
-  it('has ratio_gate edge from accumulating to compacting', () => {
+  it('has a ratio_gate edge from accumulating to compacting', () => {
     const spec = buildCompactionSpec('accumulating')
     const edge = spec.edges.find(e => e.source === 'accumulating' && e.target === 'compacting')
-    expect(edge).toBeTruthy()
-    expect(edge!.label).toBe('ratio_gate')
+    expect(edge?.label).toBe('ratio_gate')
   })
 
-  it('has completion edge from compacting to done', () => {
+  it('has a recovery edge from compacting to done', () => {
     const spec = buildCompactionSpec('accumulating')
     const edge = spec.edges.find(e => e.source === 'compacting' && e.target === 'done')
-    expect(edge).toBeTruthy()
-    expect(edge!.type).toBe('recovery')
+    expect(edge?.type).toBe('recovery')
   })
 
-  it('has failure edge from compacting back to accumulating', () => {
+  it('has an error edge from compacting back to accumulating', () => {
     const spec = buildCompactionSpec('accumulating')
     const edge = spec.edges.find(e => e.source === 'compacting' && e.target === 'accumulating')
-    expect(edge).toBeTruthy()
-    expect(edge!.type).toBe('error')
+    expect(edge?.type).toBe('error')
   })
 })
 
 // ================================================================
-// buildTurnFsmSpec
+// buildTurnFsmSpec / normalizeTurnFsmState / turnFsmTlaSymbol
 // ================================================================
 
 describe('buildTurnFsmSpec', () => {
-  it('creates one node per keeper_turn_fsm state', () => {
-    const spec = buildTurnFsmSpec('streaming')
+  it('exposes the 8 UI turn-FSM states (7 backend turn_phase ctors + awaiting_tool_result)', () => {
+    expect(TURN_FSM_STATES).toEqual([
+      'idle', 'prompting', 'routing', 'executing',
+      'awaiting_tool_result', 'compacting', 'finalizing', 'exhausted',
+    ])
+  })
+
+  it('creates one node per turn-FSM state', () => {
+    const spec = buildTurnFsmSpec('executing')
     expect(spec.nodes.map(n => n.id)).toEqual([...TURN_FSM_STATES])
   })
 
-  it('marks the projected current state active', () => {
-    const spec = buildTurnFsmSpec('streaming')
-    const streaming = spec.nodes.find(n => n.id === 'streaming')
-    expect(streaming!.type).toBe('active')
-    expect(spec.activeNodeId).toBe('streaming')
+  it('marks the active state active and sets activeNodeId', () => {
+    const spec = buildTurnFsmSpec('executing')
+    expect(spec.nodes.find(n => n.id === 'executing')!.type).toBe('active')
+    expect(spec.activeNodeId).toBe('executing')
   })
 
-  it('maps legacy prompting to phase_gating', () => {
-    expect(normalizeTurnFsmState('prompting')).toBe('phase_gating')
-    const spec = buildTurnFsmSpec('prompting')
-    expect(spec.activeNodeId).toBe('phase_gating')
+  it('marks the exhausted terminal state as err whether active or not', () => {
+    expect(buildTurnFsmSpec('idle').nodes.find(n => n.id === 'exhausted')!.type).toBe('err')
+    expect(buildTurnFsmSpec('exhausted').nodes.find(n => n.id === 'exhausted')!.type).toBe('err')
   })
 
-  it('maps legacy executing to streaming', () => {
-    expect(normalizeTurnFsmState('executing')).toBe('streaming')
+  it('normalizes the canonical backend turn phases to themselves', () => {
+    for (const s of ['idle', 'prompting', 'routing', 'executing', 'compacting', 'finalizing', 'exhausted']) {
+      expect(normalizeTurnFsmState(s)).toBe(s)
+    }
   })
 
-  it('maps legacy finalizing and compacting to completing', () => {
-    expect(normalizeTurnFsmState('finalizing')).toBe('completing')
-    expect(normalizeTurnFsmState('compacting')).toBe('completing')
+  it('is case-insensitive and trims whitespace', () => {
+    expect(normalizeTurnFsmState('  Executing ')).toBe('executing')
   })
 
-  it('maps the TLA awaiting_tool symbol to the UI awaiting_tool_result state', () => {
+  it('maps the TLA awaiting_tool symbol to the UI awaiting_tool_result state and back', () => {
     expect(normalizeTurnFsmState('awaiting_tool')).toBe('awaiting_tool_result')
     expect(turnFsmTlaSymbol('awaiting_tool_result')).toBe('awaiting_tool')
   })
 
-  it('keeps failed and cancelled terminal states visible', () => {
-    const failedSpec = buildTurnFsmSpec('failed')
-    const failed = failedSpec.nodes.find(n => n.id === 'failed')
-    const cancelled = failedSpec.nodes.find(n => n.id === 'cancelled')
-    expect(failed!.type).toBe('err')
-    expect(cancelled!.type).toBe('warn')
+  it('round-trips every UI state through turnFsmTlaSymbol (only awaiting_tool_result is renamed)', () => {
+    for (const s of TURN_FSM_STATES) {
+      const expected = s === 'awaiting_tool_result' ? 'awaiting_tool' : s
+      expect(turnFsmTlaSymbol(s)).toBe(expected)
+    }
   })
 
-  it('returns no active node for unknown turn phases', () => {
-    const spec = buildTurnFsmSpec('mystery')
-    expect(spec.activeNodeId).toBeNull()
+  it('returns null (no active node) for unknown / legacy turn phases', () => {
+    expect(normalizeTurnFsmState('mystery')).toBeNull()
+    expect(normalizeTurnFsmState('streaming')).toBeNull()
+    expect(normalizeTurnFsmState('phase_gating')).toBeNull()
+    expect(normalizeTurnFsmState('')).toBeNull()
+    expect(normalizeTurnFsmState(null)).toBeNull()
+    expect(normalizeTurnFsmState(undefined)).toBeNull()
+    expect(buildTurnFsmSpec('mystery').activeNodeId).toBeNull()
   })
 
-  it('includes the provider/tool/receipt terminal edges', () => {
-    const spec = buildTurnFsmSpec('streaming')
-    expect(spec.edges).toContainEqual({
-      source: 'streaming',
-      target: 'awaiting_tool_result',
-      label: 'StreamYieldsTool',
-      type: 'cascade',
-    })
-    expect(spec.edges).toContainEqual({
-      source: 'completing',
-      target: 'failed',
-      label: 'ReceiptLost',
-      type: 'error',
-    })
+  it('includes the StartTurn entry edge', () => {
+    const spec = buildTurnFsmSpec('executing')
+    expect(spec.edges).toEqual(expect.arrayContaining([
+      expect.objectContaining({ source: 'idle', target: 'prompting', label: 'StartTurn' }),
+    ]))
   })
 })


### PR DESCRIPTION
## Summary

3-layer audit (TLA+ specs → OCaml runtime → HTTP API → dashboard) of the keeper composite FSM uncovered **30 latent test failures on `main`** plus a CI gap that let them persist. This PR is the surgical cleanup; the deeper RFC-0065 closeout work is flagged below.

## What this PR fixes

### A. `keeper-fsm-specs.test.ts` — 14/46 stale tests
Source was widened by #14252 (KSM 7→13 states, KTC 5→7) and #14380 (close incomplete migration). Test wasn't updated, so it still expected:
- 7-state KSM cluster (`26 children = 31 total nodes`) — now 13-state (`32 children = 37 total`).
- Legacy turn-FSM names (`prompting→phase_gating`, `executing→streaming`, `finalizing→completing`).
- `buildCompactionSpec(..., 'Overflowed')` capitalized phase — source checks lowercase.

Rewrite against current source (which matches OCaml `keeper_state_machine.ml` `type phase` 13 ctors and `keeper_registry.ml` `type turn_phase` 7 ctors). Adds explicit assertions for the `awaiting_tool ↔ awaiting_tool_result` UI/TLA remap and the full failure/buffer-class phase membership of the `ksmTone` selector.

### B. `keeper-composite.test.ts` (16) + `fsm-hub.integration.test.ts` (3) — fixture rot
Schema requires `fsm_guard_violations: number`, fixtures didn't carry it. **The OCaml observer DOES emit `fsm_guard_violations`** (`lib/keeper/keeper_composite_observer.ml:676`), so backend↔schema are aligned — only `VALID_SNAPSHOT` / `REAL_COMPOSITE_PAYLOAD` lagged. Add the field + an explicit drift assertion so a future schema-required addition can't slip through the same way.

### C. `.github/workflows/ci.yml` `dashboard` job — close path-scope blind spot
Mirror the `tla-specs` job's `|| live_state == 'NON_PR'` clause (added after #14668 for the same root cause). Reason A+B sat red for weeks: the `dashboard` job is PR-path-scoped (`needs.changes.outputs.dashboard == 'true'`); a Draft PR with the dashboard job advisory-red was admin-merged, and no subsequent main run re-checked it. With this clause, every main push re-runs the dashboard job regardless of which paths changed.

## Verification

```bash
cd dashboard && corepack pnpm test
# Test Files  2 failed | 611 passed (613)
# Tests       3 failed | 7259 passed (7262)
```

The 3 remaining failures (`cognition-plane.test.ts` ×2 + `runtime-panel.test.ts` ×1) are **pre-existing on `origin/main`** and unrelated to this PR — same path-scope rot, different files. Listing them so they're not lost; will follow up in a separate PR once this one closes the CI gap that hides them.

## Out of scope (flagged, not fixed here)

**D. Observer ↔ composite-spec invariant set drift** (RFC-scoped):
- Observer + dashboard schema expose 5 invariant booleans: `phase_turn_alignment, no_cascade_before_measurement, compaction_atomicity, event_priority_monotone, phase_derivation_agreement`.
- `KeeperCompositeLifecycle.tla` `SafetyInvariant` has 7: 4 overlap + `AttemptFSMRespectsAdmission` / `ToolSurfaceFeedsAttempt` / `PostTurnConsumesAttempt` (the RFC-0065 Phase 5.1.b B1.KCAF / B2.KTS / B3.KPTO joint invariants). Observer's `phase_derivation_agreement` is a KSM-internal check with no composite-spec counterpart.
- Closing the gap requires the runtime to expose B1/B2/B3 state. `KCAF` exists at `lib/cascade/cascade_attempt_fsm.ml` but is per-attempt internal, not keeper-level observable. `KPTO` has no OCaml at all. Stubbing the 3 invariants to `true` would be fake-completeness (Workaround Rejection Bar §1 telemetry-as-fix). Real fix = RFC-0065 runtime closeout.

**E. KCB (circuit breaker) not in composite spec** (design call): observer emits `circuit_breaker.state`, dashboard renders a KCB region, but `KeeperCompositeLifecycle.tla` has no `kcb_*` projection. Documented as "counter-based, not a classical FSM" — keeping as-is.

**F. KSM 13→7 lossy collapse in the composite spec** (deliberate, per spec comment "joint invariants hold for all collapsed-Stable states by construction"). Not a bug.

## Test plan

- [x] `dashboard/src/components/keeper-fsm-specs.test.ts` passes (45/45)
- [x] `dashboard/src/api/schemas/keeper-composite.test.ts` passes (21/21)
- [x] `dashboard/src/components/fsm-hub.integration.test.ts` passes
- [x] `corepack pnpm test` shows only 3 pre-existing unrelated failures
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)