### PR TITLE
feat(keeper): RFC-0070 Phase 4.1-h — Docker_client.S.exec gains ?stdin:string

### DIFF
--- a/lib/keeper/docker_client.ml
+++ b/lib/keeper/docker_client.ml
@@ -16,6 +16,7 @@ module type S = sig
   val exec
     :  ?user:int * int
     -> ?workdir:string
+    -> ?stdin:string
     -> container:Keeper_container_name.t
     -> cmd:string
     -> unit

--- a/lib/keeper/docker_client.mli
+++ b/lib/keeper/docker_client.mli
@@ -46,17 +46,27 @@ module type S = sig
   val exec
     :  ?user:int * int
     -> ?workdir:string
+    -> ?stdin:string
     -> container:Keeper_container_name.t
     -> cmd:string
     -> unit
     -> (Docker_response.exec_result, sandbox_error) result
-  (** [exec ?user ?workdir ~container ~cmd ()] runs [cmd] inside an
-      already-running [container] via [docker exec].
+  (** [exec ?user ?workdir ?stdin ~container ~cmd ()] runs [cmd]
+      inside an already-running [container] via [docker exec].
 
       - [?user] — [(uid, gid)], emitted as [--user uid:gid]. Omitted
         ⇒ docker uses the container image's [USER].
       - [?workdir] — emitted as [-w workdir]. Omitted ⇒ docker uses
         the container's [WORKDIR].
+      - [?stdin] — when present, the argv gains [-i] and the daemon
+        spawn pipes the string in as the command's stdin (`docker exec
+        -i …` reads from the host process's stdin, which the gated
+        spawn fills). Omitted ⇒ no [-i] flag and stdin is closed. RFC
+        §3.2.1: the keeper-turn `overwrite_file` / `append_file` paths
+        write file content via `sh -lc 'mkdir -p … && cat > …'` with
+        the content piped on stdin; Phase 4.1-h surfaces that as a
+        first-class plan field so the Phase 4.1 caller cutover does
+        not need a parallel stdin-aware code path.
 
       The trailing [unit] is required so OCaml can erase the leading
       optionals (warning 16) — all parameters are otherwise labeled.

--- a/lib/keeper/docker_client_mock.ml
+++ b/lib/keeper/docker_client_mock.ml
@@ -85,14 +85,14 @@ let run plan =
     response
   | _ -> Error Docker_client.Daemon_unreachable
 
-let exec ?user:_ ?workdir:_ ~container ~cmd () =
-  (* [?user] / [?workdir] shape the real [docker exec] argv (see
-     {!Docker_client_real.exec_argv}) but do not affect the mocked
+let exec ?user:_ ?workdir:_ ?stdin:_ ~container ~cmd () =
+  (* [?user] / [?workdir] / [?stdin] shape the real [docker exec] argv
+     (see {!Docker_client_real.exec_argv}) but do not affect the mocked
      response, so they are accepted and ignored for matching here —
-     the injection key stays [(container, cmd)]. When a caller
-     (Phase 4.1 [keeper_turn_sandbox_runtime] cutover) needs to
-     assert the user/workdir threaded through, widen the injection
-     key then; until then a narrower key keeps test setup minimal. *)
+     the injection key stays [(container, cmd)]. When a caller (Phase
+     4.1 [keeper_turn_sandbox_runtime] cutover) needs to assert the
+     user/workdir/stdin threaded through, widen the injection key
+     then; until then a narrower key keeps test setup minimal. *)
   match Queue.peek_opt exec_queue with
   | Some ((expected_c, expected_cmd), response)
     when Keeper_container_name.equal container expected_c

--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -134,6 +134,41 @@ let gated_argv_with_status_split ?timeout_sec ~(summary : string) argv =
   loop max_eintr_retries
 ;;
 
+(* Mirror of {!gated_argv_with_status_split} for the stdin-piped case
+   (RFC-0070 Phase 4.1-h). Wraps
+   [Masc_exec.Exec_gate.run_argv_with_stdin_and_status_split] and reuses
+   the same EINTR-retry contract — a [WEXITED 127] whose combined
+   stdout/stderr mentions the EINTR marker is retried up to
+   [max_eintr_retries] times. Used by {!exec} when [?stdin] is
+   [Some _]. *)
+let gated_argv_with_stdin_and_status_split
+      ?timeout_sec
+      ~(summary : string)
+      ~(stdin_content : string)
+      argv
+  =
+  let timeout_sec =
+    match timeout_sec with
+    | Some t -> t
+    | None -> default_timeout_sec ()
+  in
+  let rec loop attempts_left =
+    let status, stdout, stderr =
+      Masc_exec.Exec_gate.run_argv_with_stdin_and_status_split
+        ~actor:`System_task_sandbox
+        ~raw_source:(String.concat " " argv)
+        ~summary
+        ~timeout_sec
+        ~stdin_content
+        argv
+    in
+    if attempts_left > 0 && is_eintr_127 status (stdout ^ "\n" ^ stderr)
+    then loop (attempts_left - 1)
+    else status, stdout, stderr
+  in
+  loop max_eintr_retries
+;;
+
 (* ── Functions ───────────────────────────────────────────────── *)
 
 let ps_query ~labels:_ = placeholder
@@ -142,8 +177,12 @@ let ps_query ~labels:_ = placeholder
    argv shape is unit-testable without a daemon (RFC-0070's pure/edge
    split — deterministic argv construction here, daemon spawn in
    {!exec}). [--user] precedes [-w] to match the order
-   [keeper_turn_sandbox_runtime] currently emits. *)
-let exec_argv ?user ?workdir ~container ~cmd () =
+   [keeper_turn_sandbox_runtime] currently emits.
+
+   [?stdin] is a [bool], not the content itself — the *content* is
+   never part of the argv (it is piped on stdin by {!exec}), so the
+   pure builder only needs to know whether to emit the [-i] flag. *)
+let exec_argv ?user ?workdir ?(stdin = false) ~container ~cmd () =
   let user_args =
     match user with
     | None -> []
@@ -154,18 +193,34 @@ let exec_argv ?user ?workdir ~container ~cmd () =
     | None -> []
     | Some w -> [ "-w"; w ]
   in
+  let stdin_args = if stdin then [ "-i" ] else [] in
   [ "docker"; "exec" ]
   @ user_args
   @ workdir_args
+  @ stdin_args
   @ [ Keeper_container_name.to_string container; "sh"; "-lc"; cmd ]
 ;;
 
-let exec ?user ?workdir ~container ~cmd () =
-  let argv = exec_argv ?user ?workdir ~container ~cmd () in
+let exec ?user ?workdir ?stdin ~container ~cmd () =
+  let argv =
+    exec_argv ?user ?workdir ~stdin:(Option.is_some stdin) ~container ~cmd ()
+  in
   (* Gated spawn returns [(status, stdout, stderr)]; on spawn failure
      the status is synthesized as [WEXITED 127] (see 3b-iv.2.1 commit
-     on rm). *)
-  map_status_to_exec_result (gated_argv_with_status_split ~summary:"keeper docker exec" argv)
+     on rm). [?stdin] toggles between the no-stdin gate
+     ({!gated_argv_with_status_split}) and the stdin-piped gate
+     ({!gated_argv_with_stdin_and_status_split}) — both share the same
+     EINTR-retry contract. *)
+  match stdin with
+  | None ->
+    map_status_to_exec_result
+      (gated_argv_with_status_split ~summary:"keeper docker exec" argv)
+  | Some stdin_content ->
+    map_status_to_exec_result
+      (gated_argv_with_stdin_and_status_split
+         ~summary:"keeper docker exec (stdin-piped)"
+         ~stdin_content
+         argv)
 ;;
 
 let run plan =

--- a/lib/keeper/docker_client_real.mli
+++ b/lib/keeper/docker_client_real.mli
@@ -59,14 +59,20 @@
 
 include Docker_client.S
 
-(** [exec_argv ?user ?workdir ~container ~cmd ()] is the pure [docker
-    exec] argv builder used by {!exec}. Exposed for unit-testing the
-    argv shape (option presence, [--user] before [-w] ordering)
-    without spawning a daemon. Trailing [unit] for the same
-    optional-erasure reason as {!exec}. *)
+(** [exec_argv ?user ?workdir ?stdin ~container ~cmd ()] is the pure
+    [docker exec] argv builder used by {!exec}. Exposed for unit-testing
+    the argv shape (option presence, [--user] before [-w] before [-i]
+    ordering) without spawning a daemon.
+
+    [?stdin] is a [bool], not the content — the *content* is never part
+    of the argv (it is piped on stdin at spawn time by {!exec}); the
+    pure builder only needs to know whether to emit [-i]. Defaults to
+    [false]. Trailing [unit] for the same optional-erasure reason as
+    {!exec}. *)
 val exec_argv
   :  ?user:int * int
   -> ?workdir:string
+  -> ?stdin:bool
   -> container:Keeper_container_name.t
   -> cmd:string
   -> unit

--- a/test/test_docker_client_mock.ml
+++ b/test/test_docker_client_mock.ml
@@ -159,6 +159,42 @@ let test_exec_ignores_user_workdir_for_matching () =
   | Ok er -> check string "stdout" "ok" er.stdout
   | Error _ -> fail "expected Ok — user/workdir must not affect matching"
 
+(* Phase 4.1-h — [?stdin] is the same kind of "shape, not match-key"
+   field as [?user] / [?workdir]. The mock must accept it and still
+   consume the [(container, cmd)] injection unchanged. *)
+let test_exec_ignores_stdin_for_matching () =
+  setup ();
+  let c = sample_container () in
+  Docker_client_mock.inject_exec ~container:c ~cmd:"cat > /tmp/x" (Ok sample_exec_result);
+  match
+    Docker_client_mock.exec
+      ~stdin:"hello world"
+      ~container:c
+      ~cmd:"cat > /tmp/x"
+      ()
+  with
+  | Ok er -> check string "stdout" "ok" er.stdout
+  | Error _ -> fail "expected Ok — ?stdin must not affect matching"
+;;
+
+let test_exec_ignores_all_three_optionals_together () =
+  setup ();
+  let c = sample_container () in
+  Docker_client_mock.inject_exec ~container:c ~cmd:"tee /tmp/x" (Ok sample_exec_result);
+  match
+    Docker_client_mock.exec
+      ~user:(1000, 1000)
+      ~workdir:"/work"
+      ~stdin:"payload"
+      ~container:c
+      ~cmd:"tee /tmp/x"
+      ()
+  with
+  | Ok _ ->
+    check int "injection consumed (1 → 0)" 0 (Docker_client_mock.pending_calls ())
+  | Error _ -> fail "expected Ok — all three optionals must be ignored for matching"
+;;
+
 (* ── ps_query ────────────────────────────────────────────────── *)
 
 let test_ps_query_matches () =
@@ -299,6 +335,10 @@ let () =
           test_case "wrong cmd → miss" `Quick test_exec_unmatched_cmd;
           test_case "user/workdir ignored for matching" `Quick
             test_exec_ignores_user_workdir_for_matching;
+          test_case "?stdin ignored for matching (Phase 4.1-h)" `Quick
+            test_exec_ignores_stdin_for_matching;
+          test_case "user + workdir + stdin all ignored for matching" `Quick
+            test_exec_ignores_all_three_optionals_together;
         ] );
       ( "ps_query",
         [

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -171,6 +171,72 @@ let test_exec_argv_user_and_workdir () =
        ())
 ;;
 
+(* Phase 4.1-h — [?stdin] is the third optional. When true, the argv
+   gains [-i] after [-w] (and after [--user]); the content itself is
+   never in the argv. Default is [false] (no [-i]). *)
+let test_exec_argv_stdin_only_emits_dash_i () =
+  let c = sample_container () in
+  check
+    (list string)
+    "stdin=true → -i after the keyless slot"
+    [ "docker"
+    ; "exec"
+    ; "-i"
+    ; Keeper_container_name.to_string c
+    ; "sh"
+    ; "-lc"
+    ; "cat > /tmp/x"
+    ]
+    (Docker_client_real.exec_argv ~stdin:true ~container:c ~cmd:"cat > /tmp/x" ())
+;;
+
+let test_exec_argv_stdin_false_omits_dash_i () =
+  let c = sample_container () in
+  let argv =
+    Docker_client_real.exec_argv ~stdin:false ~container:c ~cmd:"echo hi" ()
+  in
+  check bool "stdin=false ⇒ no -i" false (List.mem "-i" argv);
+  check
+    (list string)
+    "stdin=false matches the plain shape"
+    [ "docker"; "exec"; Keeper_container_name.to_string c; "sh"; "-lc"; "echo hi" ]
+    argv
+;;
+
+let test_exec_argv_user_workdir_stdin_full_order () =
+  let c = sample_container () in
+  check
+    (list string)
+    "user + workdir + stdin → --user before -w before -i"
+    [ "docker"
+    ; "exec"
+    ; "--user"
+    ; "1000:1000"
+    ; "-w"
+    ; "/work"
+    ; "-i"
+    ; Keeper_container_name.to_string c
+    ; "sh"
+    ; "-lc"
+    ; "tee /tmp/x"
+    ]
+    (Docker_client_real.exec_argv
+       ~user:(1000, 1000)
+       ~workdir:"/work"
+       ~stdin:true
+       ~container:c
+       ~cmd:"tee /tmp/x"
+       ())
+;;
+
+let test_exec_argv_stdin_default_is_false () =
+  (* Omitting [?stdin] altogether is the same as [~stdin:false]: the
+     default is "no -i", because most exec calls don't pipe stdin. *)
+  let c = sample_container () in
+  let argv = Docker_client_real.exec_argv ~container:c ~cmd:"echo hi" () in
+  check bool "no ?stdin ⇒ no -i" false (List.mem "-i" argv)
+;;
+
 let test_ps_query_placeholder () =
   match Docker_client_real.ps_query ~labels:[] with
   | Error Docker_client.Cleanup_failed -> ()
@@ -469,6 +535,18 @@ let () =
             "user + workdir (--user before -w)"
             `Quick
             test_exec_argv_user_and_workdir
+        ] )
+    ; ( "exec_argv ?stdin (pure, Phase 4.1-h)"
+      , [ test_case "stdin=true ⇒ -i present" `Quick test_exec_argv_stdin_only_emits_dash_i
+        ; test_case
+            "stdin=false ⇒ no -i + plain shape"
+            `Quick
+            test_exec_argv_stdin_false_omits_dash_i
+        ; test_case
+            "user + workdir + stdin: --user before -w before -i"
+            `Quick
+            test_exec_argv_user_workdir_stdin_full_order
+        ; test_case "?stdin default is false" `Quick test_exec_argv_stdin_default_is_false
         ] )
     ; ( "parse_security_options (pure, Phase 3e c)"
       , [ test_case "array of strings" `Quick test_parse_security_options_array


### PR DESCRIPTION
## RFC-0070 Phase 4.1-h — `Docker_client.S.exec` gains `?stdin:string`

RFC: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §4 row `4.1-h` (added in v2.5, #14983).

### Why

The Phase 4.1 cutover (`keeper_turn_sandbox_runtime` → `Sandbox_session_executor`) needs an `exec` that pipes stdin into the container — `overwrite_file` / `append_file` write file content via `sh -lc 'mkdir -p … && cat > …'` with the content on stdin (today via `Masc_exec.Exec_gate.run_argv_with_stdin_and_status` + the `-i` flag). `Docker_client.S.exec` previously had no stdin parameter, so the cutover would have needed a parallel stdin-aware code path. Surface stdin as a first-class `S.exec` field instead.

### What

- `lib/keeper/docker_client.{mli,ml}` — `S.exec` gains `?stdin:string`. Doc: when present the argv gains `-i` and the daemon spawn pipes the string in as the command's stdin; when omitted, no `-i` and stdin is closed (default behaviour preserved).
- `lib/keeper/docker_client_real.{ml,mli}` —
  - Pure `exec_argv` gains `?stdin:bool` (not the content — only whether to emit `-i`; the content is never in the argv). Default `false`. Flag order is `--user` before `-w` before `-i` (mirrors the existing `keeper_turn_sandbox_runtime` argv).
  - `exec ?stdin:string` routes to the existing `gated_argv_with_status_split` when `None`; when `Some stdin_content`, to a new `gated_argv_with_stdin_and_status_split` helper that wraps `Masc_exec.Exec_gate.run_argv_with_stdin_and_status_split ~actor:`System_task_sandbox` with the same EINTR-retry contract `4.1-g` (#14989) established for the no-stdin path.
- `lib/keeper/docker_client_mock.ml` — `exec ?user:_ ?workdir:_ ?stdin:_` accepts and ignores `?stdin` for matching; the injection key stays `(container, cmd)` (the same precedent `?user` / `?workdir` set).
- `test/test_docker_client_real.ml` — +4 pure tests on `exec_argv`: `stdin=true` ⇒ `-i` present after the keyless slot; `stdin=false` ⇒ no `-i` and matches the plain shape; full ordering `--user` → `-w` → `-i`; `?stdin` default is `false`. 24 → 28 tests.
- `test/test_docker_client_mock.ml` — +2 tests: `?stdin` alone ignored for matching; all three optionals (`?user` + `?workdir` + `?stdin`) ignored together. 19 → 21 tests.

No call-site change: `Sandbox_session_executor.exec` (#14980) already calls `D.exec ?user ?workdir ~container ~cmd ()` — a new trailing optional doesn't break that call. `Sandbox_executor` doesn't go through `S.exec`.

### Local verification

- `dune build --root . lib/` exit 0.
- `dune exec test/test_docker_client_real.exe` — `28 tests run`.
- `dune exec test/test_docker_client_mock.exe` — `21 tests run`.
- `dune exec test/test_sandbox_executor.exe` — `11 tests run`.
- `dune exec test/test_sandbox_session_executor.exe` — `11 tests run` (call-site untouched).
- `ocamlformat --check` on all 7 files — clean.
- `pr-rfc-check.sh --pr-body /tmp/pr-body-41h.md` — exit 0.

### Self-check (workaround-rejection bar)

- No catch-all `_ ->` added (the new `match stdin with None / Some` is the exhaustive split on `string option`); no silent drop, no telemetry-as-fix, no string classifier, no N-of-M (this is the whole stdin extension), no test backdoor, no cap/cooldown/dedup/repair.
- The "just pipe stdin outside `S`" shortcut was rejected (would have required a parallel code path in Phase 4.1; surfacing `?stdin` as part of `S` keeps the abstraction whole).
- `?stdin:bool` (pure builder) vs `?stdin:string` (the `S` surface) is deliberate: the builder only needs presence to decide the `-i` flag; the content is never in the argv. Mock ignores it because content doesn't change *which* injection is consumed (only how the real daemon's spawn sees stdin).

### Follow-up

- RFC §4 `4.1-h` row flips `⏳ pending` → `✅ #<this PR>` in a later doc sync (folded into Phase 4.1 cutover PR).
- Next on the RFC-0070 trail: the Phase 4.1 cutover itself (now unblocked — all four prereqs 3e-e/3e-a/3e-f/4.1-g shipped, 4.1-h is this PR).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
