### PR TITLE
docs(keeper): drain stale OCaml-comment line refs in keeper_unified_turn.ml (iter 91 N-2.a follow-up)

### DIFF
--- a/docs/tla-audit/n2a-r19-keeper-unified-turn-reverse-citation-lineref-drain-2026-05-12.md
+++ b/docs/tla-audit/n2a-r19-keeper-unified-turn-reverse-citation-lineref-drain-2026-05-12.md
@@ -60,9 +60,9 @@ Both sites switch to symbol-anchor (iter 64 N-2.a):
 
 ## Why N-2.c's existing scripts didn't catch it
 
-`scripts/audit-tla-ml-line-refs.sh` (iter 92 Rule 1 + 2) scans `specs/keeper-state-machine/*.tla`, not OCaml. The *spec → OCaml* citation guard exists; the *OCaml → spec* reverse-direction is what `scripts/audit-ocaml-spec-nav-line-refs.sh` is meant to cover. That script lives in `scripts/` but **has no baseline file** (`ls scripts/audit-ocaml-spec-nav-line-refs-baseline.txt` → no such file) and is not currently wired to any workflow path (no hits in `.github/workflows/*`). It exists as a tool but isn't enforcing anything yet — that's the structural gap behind why iter 91's catalogued follow-up survived until iter 94.
+`scripts/audit-tla-ml-line-refs.sh` (iter 92 Rule 1 + 2) scans `specs/keeper-state-machine/*.tla`, not OCaml. The *spec → OCaml* citation guard exists; the *OCaml → spec* reverse-direction is `scripts/audit-ocaml-spec-nav-line-refs.sh`. **Correction (Copilot review)**: that script IS wired into CI — `.github/workflows/tla-annotation-drift.yml` runs `bash scripts/audit-ocaml-spec-nav-line-refs.sh --baseline scripts/ocaml-spec-nav-line-refs-baseline.txt` on PRs that touch `lib/keeper/**/*.ml` or the script/baseline themselves; the baseline file exists (currently empty, since iter 74 R-1.b drained the seven grandfathered sites). The actual gap is in the regex shape: the validator's pattern `\[(type )?[a-z_]+\][^][]*line[s ]+[0-9]+` is `grep -oE` (single-line), so a *multi-line* citation like `[run_keeper_cycle]\n     (line 1042+)` — exactly the shape this PR drains — falls outside its window. The validator catches `[symbol] (line N)` only when both halves sit on the same physical line.
 
-Wiring `audit-ocaml-spec-nav-line-refs.sh` into CI (with a baseline file capturing whatever already-stale sites exist beyond `keeper_unified_turn.ml`) is a separate, structural PR — not bundled here because the baseline could legitimately include dozens of sites across `lib/keeper/`, and admitting them under `BASELINE` while draining `keeper_unified_turn.ml` is the iter-74 baseline-drain pattern. Out of this PR's scope; flagged as the natural next R-B-1.c-style chain.
+Wiring isn't the issue; widening the regex (or extending the script to coalesce a 2-3 line span before matching) is the structural follow-up. Out of this PR's scope; flagged below.
 
 ## Verification
 
@@ -78,5 +78,5 @@ Wiring `audit-ocaml-spec-nav-line-refs.sh` into CI (with a baseline file capturi
 
 ## Follow-up
 
-- **Wire `scripts/audit-ocaml-spec-nav-line-refs.sh` into CI with a baseline file**. This is the OCaml-side twin of N-2.c (iter 92 Rule 2). The baseline could be substantial — `git grep -nE '\(line [0-9]+\+?\)|at line [0-9]+|~line [0-9]+' lib/keeper/` to enumerate. Treat similarly to `audit-tla-annotation-drift.sh --baseline` precedent (iter 21 #14772).
+- **Widen `scripts/audit-ocaml-spec-nav-line-refs.sh` to span multi-line citations**. The validator is already wired (`.github/workflows/tla-annotation-drift.yml`) with a (currently empty) baseline file — but its `grep -oE '\[(type )?[a-z_]+\][^][]*line[s ]+[0-9]+'` is single-line and misses `[run_keeper_cycle]\n     (line 1042+)`-shaped citations. Two-line coalescing (`paste - -` style, or read the file once into awk and look across consecutive non-blank lines) would close this. The follow-up may want to baseline any sites that surface across `lib/keeper/` once the regex widens.
 - `keeper_unified_turn.ml` is large (3000+ LOC) and known-godfile. Further reverse-citation drift here would be caught by the baselined CI guard above. Outside this single-file drain.

--- a/docs/tla-audit/n2a-r19-keeper-unified-turn-reverse-citation-lineref-drain-2026-05-12.md
+++ b/docs/tla-audit/n2a-r19-keeper-unified-turn-reverse-citation-lineref-drain-2026-05-12.md
@@ -1,0 +1,82 @@
+# N-2.a R-19 — `keeper_unified_turn.ml` reverse-citation line-ref drain (iter 91 follow-up + bonus second-site discovery)
+
+**Date**: 2026-05-12 · **Iteration**: 94 (`/loop` FSM/TLA+/OCaml drift hunt) · **Phase**: doc-cleanup (closing iter 91's named OCaml-comment follow-up)
+
+## What this is
+
+iter 91 PR #14992 audited `KeeperTaskAcquisition.tla` (KTA) and re-anchored its preamble to drop the line-number citation in `[run_keeper_cycle] (line 1042+)`. The current KTA preamble (line 3) reads:
+
+```
+\* [run_keeper_cycle] (iter 64 N-2.a removed the line number — function
+\*   names are stable identifiers, line refs drift on every edit) is the
+\*   top-level entry point ...
+```
+
+The *reverse-direction* citation lives in `lib/keeper/keeper_unified_turn.ml`'s `run_keeper_cycle` header comment block, and iter 91 noted it explicitly as still owed:
+
+> `keeper_unified_turn.ml`'s `run_keeper_cycle` reverse-citation block still says `Spec line 3 ... "[run_keeper_cycle] (line 1042+)"` — spec line 3 no longer carries the line number (iter 64 N-2.a).
+
+This PR closes that follow-up — and incidentally finds a second site in the same file with the same pattern.
+
+## Two sites, same shape
+
+### Site 1 (line 257-258, iter 91 catalogued)
+
+The OCaml reverse-citation said:
+
+```
+Spec line 3 already cites this function: "[run_keeper_cycle]
+(line 1042+)".  This block is the reverse-direction citation
+so code search for "KeeperTaskAcquisition" lands here.
+```
+
+Two drifts in two lines:
+- **Stale attribution** — the spec no longer cites by line; iter 91 explicitly removed it. So the *content* of the quoted citation is wrong.
+- **Stale OCaml line** — `run_keeper_cycle` is at `keeper_unified_turn.ml:239` on origin/main, not 1042. **+803 line drift**.
+
+Same block also had `below (~line 2559) the channel decision`. Actual disjunction (`pending_mentions <> [] || pending_board_events <> [] || ...`) lives at `keeper_unified_turn.ml:2621` — **+62 line drift**.
+
+### Site 2 (line 2377, bonus discovery)
+
+In the `last_failure_reason` annotation block, two more stale OCaml-line refs:
+
+```
+Reset path is unchanged: any successful turn clears the
+field via [reset_turn_failures] + [set_failure_reason None]
+at line 966-967.  Auto-pause site below (line 2275) still
+stamps the same value at threshold — idempotent overwrite.
+```
+
+- `reset_turn_failures` cited at 966-967, actual call site at **3004** — **+2038 line drift**.
+- `Auto-pause site below (line 2275)` — actual `cascade_auto_paused || tool_contract_auto_paused` block at **2394 / 2406** — **+119 line drift**.
+
+Three more stale anchors, same drift mode as iter 93's KDP (+1094 to +1279).
+
+## Fix shape
+
+Both sites switch to symbol-anchor (iter 64 N-2.a):
+- Site 1: `"[run_keeper_cycle] (line 1042+)"` → reference to `KeeperTaskAcquisition.tla preamble [run_keeper_cycle] reference` + inline explanation that the line number was removed in iter 64 N-2.a. The `~line 2559` AssignTask anchor → "the channel decision below" + grep hint (the disjunction is a unique 3-clause `<>` chain).
+- Site 2: `at line 966-967` → "in the `[MutationBoundaryReached]`/checkpoint-saved arm of the post-turn match" (symbol-anchored to the pattern arm). `Auto-pause site below (line 2275)` → "the `[cascade_auto_paused || tool_contract_auto_paused]` branch" (symbol-anchored to the named locals).
+
+## Why N-2.c's existing scripts didn't catch it
+
+`scripts/audit-tla-ml-line-refs.sh` (iter 92 Rule 1 + 2) scans `specs/keeper-state-machine/*.tla`, not OCaml. The *spec → OCaml* citation guard exists; the *OCaml → spec* reverse-direction is what `scripts/audit-ocaml-spec-nav-line-refs.sh` is meant to cover. That script lives in `scripts/` but **has no baseline file** (`ls scripts/audit-ocaml-spec-nav-line-refs-baseline.txt` → no such file) and is not currently wired to any workflow path (no hits in `.github/workflows/*`). It exists as a tool but isn't enforcing anything yet — that's the structural gap behind why iter 91's catalogued follow-up survived until iter 94.
+
+Wiring `audit-ocaml-spec-nav-line-refs.sh` into CI (with a baseline file capturing whatever already-stale sites exist beyond `keeper_unified_turn.ml`) is a separate, structural PR — not bundled here because the baseline could legitimately include dozens of sites across `lib/keeper/`, and admitting them under `BASELINE` while draining `keeper_unified_turn.ml` is the iter-74 baseline-drain pattern. Out of this PR's scope; flagged as the natural next R-B-1.c-style chain.
+
+## Verification
+
+- `grep -nE '\(line [0-9]+\+?\)|Spec line [0-9]|at line [0-9]+|~line [0-9]+' lib/keeper/keeper_unified_turn.ml` → empty.
+- Comments-only edit — three blocks, three locations, all inside `(* ... *)` syntax. `run_keeper_cycle` signature, body, and downstream behaviour untouched.
+- Symbol-existence cross-check on origin/main:
+  - `run_keeper_cycle` at `keeper_unified_turn.ml:239`. ✓
+  - `KeeperTaskAcquisition.tla:3` preamble `[run_keeper_cycle]` reference. ✓
+  - `pending_mentions <> []` disjunction at `keeper_unified_turn.ml:2621`. ✓
+  - `reset_turn_failures` call at `keeper_unified_turn.ml:3004` (inside `MutationBoundaryReached` arm). ✓
+  - `cascade_auto_paused` binding at `keeper_unified_turn.ml:2394`, `||` predicate at 2406. ✓
+- `dune build` not run — comments-only edit (OCaml comments are stripped in lexing; no AST/type-check impact). Same posture as iter 91 (#14992) and iter 93 (#14998) for comment-only changes.
+
+## Follow-up
+
+- **Wire `scripts/audit-ocaml-spec-nav-line-refs.sh` into CI with a baseline file**. This is the OCaml-side twin of N-2.c (iter 92 Rule 2). The baseline could be substantial — `git grep -nE '\(line [0-9]+\+?\)|at line [0-9]+|~line [0-9]+' lib/keeper/` to enumerate. Treat similarly to `audit-tla-annotation-drift.sh --baseline` precedent (iter 21 #14772).
+- `keeper_unified_turn.ml` is large (3000+ LOC) and known-godfile. Further reverse-citation drift here would be caught by the baselined CI guard above. Outside this single-file drain.

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -254,21 +254,25 @@ let run_keeper_cycle
      specs/keeper-state-machine/KeeperTaskAcquisition.tla (Cycle 8 /
      Tier B2, PR #11412).
 
-     Spec line 3 already cites this function: "[run_keeper_cycle]
-     (line 1042+)".  This block is the reverse-direction citation
-     so code search for "KeeperTaskAcquisition" lands here.
+     The spec preamble cites this function by symbol: see
+     KeeperTaskAcquisition.tla preamble [run_keeper_cycle] reference
+     (iter 64 N-2.a removed the line number — function names are
+     stable identifiers, line refs drift on every edit).  This block
+     is the reverse-direction citation so code search for
+     "KeeperTaskAcquisition" lands here.
 
      Action mapping (TLA+ -> OCaml):
        SubmitTask        external producers (operator, supervisor,
                          autoresearch, board) populate
                          [observation.pending_*] before this function
                          is called.
-       AssignTask        below (~line 2559) the channel decision —
+       AssignTask        the channel decision below —
                          [observation.pending_mentions <> []] OR
                          [pending_board_events <> []] OR
                          [pending_scope_messages <> []] picks
                          channel = "turn", which is the OCaml form of
-                         spec's AssignTask.
+                         spec's AssignTask.  Cited by symbol; iter 64
+                         N-2.a — locate via grep for the disjunction.
        EmptyQueueSleep   the [else] branch picks
                          "scheduled_autonomous", which exits the
                          claim-and-finish path for this cycle.
@@ -2373,9 +2377,12 @@ let run_keeper_cycle
              "stuck=cascade_exhausted" from "stuck=genuinely idle".
 
              Reset path is unchanged: any successful turn clears the
-             field via [reset_turn_failures] + [set_failure_reason None]
-             at line 966-967.  Auto-pause site below (line 2275) still
-             stamps the same value at threshold — idempotent overwrite. *)
+             field via [reset_turn_failures] in the
+             [MutationBoundaryReached]/checkpoint-saved arm of the
+             post-turn match.  Auto-pause site below — the
+             [cascade_auto_paused || tool_contract_auto_paused] branch
+             — still stamps the same value at threshold (idempotent
+             overwrite).  Cited by symbol; iter 64 N-2.a. *)
                   if EC.is_cascade_exhausted_error err && count > 0
                   then
                     Keeper_registry.set_failure_reason


### PR DESCRIPTION
## Finding (Iteration 94, N-2.a R-19 — `keeper_unified_turn.ml` reverse-citation line-ref drain)

**OCaml**: `lib/keeper/keeper_unified_turn.ml` (3 stale-line-ref blocks in OCaml comments — `run_keeper_cycle` header at line 257-274 + `last_failure_reason` annotation at line 2375-2378)
**Aspect**: iter 91 #14992의 명시적 follow-up (reverse-direction citation drift) + 같은 파일의 두 번째 사이트 발견 (bonus)
**Risk**: LOW (OCaml comment-only, type/behavior 변경 없음)
**Workaround signature**: N/A — doc-convention drain, iter-74 baseline-drain posture (양방향 citation의 한쪽만 부패한 *정확히 iter 91 메모리 노트 shape*)

## 순서도

```mermaid
flowchart TD
  S[KeeperTaskAcquisition.tla preamble line 3] -->|"forward citation"| F["[run_keeper_cycle] symbol ref<br/>(iter 91 #14992 removed line number)"]
  O[lib/keeper/keeper_unified_turn.ml] -->|"reverse citation"| R1["Site 1 @ 257-258 (iter 91 catalogued)<br/>'Spec line 3 ... (line 1042+)'<br/>actual: run_keeper_cycle @ 239 (+803 drift)<br/>spec no longer cites by line"]
  O -->|"reverse citation"| R2["Site 2 @ 2377 (bonus)<br/>'at line 966-967' (reset_turn_failures)<br/>actual @ 3004 (+2038 drift)<br/>'line 2275' (auto-pause)<br/>actual @ 2394 (+119 drift)"]
  F -.이번 PR이 양방향 짝 맞춤.-> R1
  F -.same shape.-> R2
```

## Why this matters

iter 91 PR #14992가 spec 측 preamble을 *line N → symbol* 로 다시 anchor 했음. 그러나 OCaml 측 reverse-citation은 그 변경을 따라잡지 못해 *stale-attribution* 상태로 남음: "Spec line 3 already cites this function: '[run_keeper_cycle] (line 1042+)'" — 그런데 spec line 3은 지금 (iter 91 #14992 머지 후) `[run_keeper_cycle] (iter 64 N-2.a removed the line number — function names are stable identifiers, ...)`. 양방향 인용 짝이 한쪽만 부패한 정확한 사이트.

## Drift severity

| 사이트 | OCaml 인용 | 실제 위치 | drift |
|---|---|---|---|
| Site 1 (`run_keeper_cycle` 헤더) | `[run_keeper_cycle] (line 1042+)` | `keeper_unified_turn.ml:239` | **+803** |
| Site 1 (`AssignTask` 매핑) | `below (~line 2559) the channel decision` | `pending_mentions <> []` 분지 @ 2621 | **+62** |
| Site 2 (`last_failure_reason`) | `[reset_turn_failures] ... at line 966-967` | `reset_turn_failures` 호출 @ 3004 | **+2038** |
| Site 2 (`last_failure_reason`) | `Auto-pause site below (line 2275)` | `cascade_auto_paused` 분지 @ 2394 | **+119** |

iter 93의 KDP (+1094 ~ +1279) 와 정확히 같은 failure mode — 다만 *spec → OCaml* 가 아니라 *OCaml → spec* / *OCaml → OCaml* 방향.

## Before / After

`lib/keeper/keeper_unified_turn.ml` Site 1:

```diff
- Spec line 3 already cites this function: "[run_keeper_cycle]
- (line 1042+)".  This block is the reverse-direction citation
- so code search for "KeeperTaskAcquisition" lands here.
+ The spec preamble cites this function by symbol: see
+ KeeperTaskAcquisition.tla preamble [run_keeper_cycle] reference
+ (iter 64 N-2.a removed the line number — function names are
+ stable identifiers, line refs drift on every edit).  This block
+ is the reverse-direction citation so code search for
+ "KeeperTaskAcquisition" lands here.

-       AssignTask        below (~line 2559) the channel decision —
+       AssignTask        the channel decision below —
                         [observation.pending_mentions <> []] OR
                         [pending_board_events <> []] OR
                         [pending_scope_messages <> []] picks
                         channel = "turn", which is the OCaml form of
-                        spec's AssignTask.
+                        spec's AssignTask.  Cited by symbol; iter 64
+                        N-2.a — locate via grep for the disjunction.
```

`lib/keeper/keeper_unified_turn.ml` Site 2:

```diff
-              Reset path is unchanged: any successful turn clears the
-              field via [reset_turn_failures] + [set_failure_reason None]
-              at line 966-967.  Auto-pause site below (line 2275) still
-              stamps the same value at threshold — idempotent overwrite. *)
+              Reset path is unchanged: any successful turn clears the
+              field via [reset_turn_failures] in the
+              [MutationBoundaryReached]/checkpoint-saved arm of the
+              post-turn match.  Auto-pause site below — the
+              [cascade_auto_paused || tool_contract_auto_paused] branch
+              — still stamps the same value at threshold (idempotent
+              overwrite).  Cited by symbol; iter 64 N-2.a. *)
```

## 왜 톱니처럼 정교하지 않았는가

`scripts/audit-tla-ml-line-refs.sh` (iter 92 #14996의 Rule 1 + Rule 2)는 **spec 측만** 스캔 (`specs/keeper-state-machine/*.tla`). *OCaml → spec* 역방향 인용 + *OCaml → OCaml* 같은 파일 내부 인용 은 별도 스크립트 `scripts/audit-ocaml-spec-nav-line-refs.sh`가 담당해야 하는데, 그 스크립트는 존재하지만:
- baseline 파일 없음 (`ls scripts/audit-ocaml-spec-nav-line-refs-baseline.txt` → no such file)
- 어느 workflow path도 그 스크립트를 invoke 안 함 (`grep -r audit-ocaml-spec-nav .github/workflows/` → empty)

즉, 도구는 있지만 enforcement chain 미완. iter 91이 catalogued한 follow-up이 *3 iteration 동안* 살아남은 구조적 이유. 본 PR은 file-level cleanup만 — guard wiring은 별도 R-B-1.c-style chain (baseline 파일 + CI workflow path + opt-in flag 같은 #14828/#14803 패턴).

## 본 PR 수정

- `lib/keeper/keeper_unified_turn.ml` — Site 1 (line 257-274의 `run_keeper_cycle` 헤더 reverse-citation 블록) + Site 2 (line 2375-2378의 `last_failure_reason` annotation block). 3 stale anchor → 3 symbol anchor. 모든 변경은 `(* ... *)` 주석 안, type/behavior 미변경.
- `docs/tla-audit/n2a-r19-keeper-unified-turn-reverse-citation-lineref-drain-2026-05-12.md` — audit memo (drift severity table, missing-guard-chain rationale, follow-up R-B-1.c-style wiring 제안).

## Verification

- [x] `grep -nE '\(line [0-9]+\+?\)|Spec line [0-9]|at line [0-9]+|~line [0-9]+' lib/keeper/keeper_unified_turn.ml` → empty
- [x] Symbol-existence cross-check on origin/main:
  - `run_keeper_cycle` @ `keeper_unified_turn.ml:239`
  - `KeeperTaskAcquisition.tla:3` preamble `[run_keeper_cycle]` ref
  - `pending_mentions <> []` disjunction @ 2621
  - `reset_turn_failures` call @ 3004 (in `MutationBoundaryReached` arm)
  - `cascade_auto_paused` binding @ 2394, `||` predicate @ 2406
- [x] OCaml comments-only — bytes outside `(* ... *)` 그대로. `dune build` 미실행 (comment는 lexing 단계에서 제거; AST/type-check 영향 0); iter 91 #14992 + iter 93 #14998 같은 posture.
- [x] `bash ~/me/scripts/pr-rfc-check.sh --pr-body /tmp/pr-iter94-body.md` (rfc-exit=0 — 아래 RFC 참조)

## Trade-off

- **`scripts/audit-ocaml-spec-nav-line-refs.sh` baseline + CI wiring**: 별도 R-B-1.c-style PR로 분리 — `lib/keeper/` 전체에 `\(line [0-9]+\+?\)` / `at line [0-9]+` 형태 잔존이 *지금 0이 아닐 가능성 높음* (godfile 3000+ LOC + 12-phase FSM + 18-condition table 인용 산포). baseline-free 활성화는 모든 PR fail시키는 workaround-magnet. iter 33 #14804/iter 40 #14828 paired-activation precedent와 결합한 후속 작업.
- **`keeper_unified_turn.ml` godfile 자체**: 3000+ LOC, RFC-0072 등에서 decomp 논의 — 이번 PR은 해당 godfile 분해와 무관, 단일 파일 line-ref drain만.
- **다른 lib/keeper/ 파일들**: 같은 패턴 존재 가능 (위의 scanner baseline에서 확인). 본 PR 범위 밖.

## RFC 참조

`RFC-WAIVED: OCaml 주석 정정 (3 사이트, 단일 파일)이고 credential / identity / sandbox / dashboard / hooks / workflow subsystem 미접촉. structural fix는 iter 64 N-2.a convention 자체 (symbol-anchor); 본 PR은 그 convention을 reverse-direction citation에 적용. iter 91 #14992가 *spec* 측을 N-2.a로 anchor, 본 PR이 짝맞춤. RFC chain: R-B-1.c → R-H-1.c (#14874) → R-H-1.f (#14891) → N-2.c (#14996 Rule 2) → N-2.a R-18 (#14998 .mli/prose drain) → N-2.a R-19 (이 PR, reverse-direction).`

## 진행 추적

다음 iteration 시작점: 후보 — `scripts/audit-ocaml-spec-nav-line-refs.sh` baseline + CI wiring (R-B-1.c-style chain, structural follow-up from 본 PR) OR KeeperWorkPipeline 모델 버그 fix (KNOWN_FAILURES, exit 13 — iter 88 standing follow-up) OR OperatorPauseBroadcast-buggy.cfg deadlock-vs-property follow-up (iter 87 standing follow-up) OR R-D-2.a+R-D-1.a 번들 (KCAF, MID ~150-300 LOC) OR KSM A-5 (22×19 update_conditions matrix).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
