### PR TITLE
feat(coord): enable warning 4 + close 41 fragile sites (RFC-0071 §3.4)

### DIFF
--- a/lib/coord/coord_agent.ml
+++ b/lib/coord/coord_agent.ml
@@ -115,7 +115,10 @@ let update_agent_r config ~agent_name ?status ?capabilities () : string Masc_dom
                              Some "Cannot set inactive while a task is assigned"
                          | None, Some Masc_domain.Busy ->
                              Some "Cannot set busy without an active task"
-                         | _ -> None
+                         | Some _, Some (Masc_domain.Active | Masc_domain.Busy | Masc_domain.Listening)
+                         | Some _, None
+                         | None, Some (Masc_domain.Active | Masc_domain.Listening | Masc_domain.Inactive)
+                         | None, None -> None
                        in
                        (match invalid with
                         | Some msg -> Error (Masc_domain.Task (Masc_domain.Task_error.InvalidState msg))

--- a/lib/coord/coord_broadcast.ml
+++ b/lib/coord/coord_broadcast.ml
@@ -249,7 +249,11 @@ let broadcast ?trace_context ?(msg_type = "broadcast")
    | Ok _ -> ()
    | Error (Backend_types.BackendNotSupported msg) when String.starts_with ~prefix:"FileSystem backend" msg ->
        Log.Misc.debug "broadcast publish skipped: %s" msg
-   | Error e -> Log.Misc.error "broadcast publish failed: %s" (Backend_types.show_error e));
+   | Error ((Backend_types.BackendNotSupported _
+            | Backend_types.NotFound _ | Backend_types.AlreadyExists _
+            | Backend_types.IOError _ | Backend_types.InvalidKey _
+            | Backend_types.ConnectionFailed _) as e) ->
+       Log.Misc.error "broadcast publish failed: %s" (Backend_types.show_error e));
   emit_message_activity config ~from_agent:safe_agent ~content:safe_content
     ~mention ();
   (try !on_broadcast_mention mention

--- a/lib/coord/coord_eio.ml
+++ b/lib/coord/coord_eio.ml
@@ -199,10 +199,13 @@ let get_recent_events config ~limit =
   let current_seq = match Backend.FileSystem.atomic_get config.backend event_seq_key with
     | Ok n -> n
     | Error (Backend.NotFound _) -> 0
-    | Error e ->
+    | Error (Backend.IOError m) ->
+        Log.Coord.warn "get_recent_events: event seq read failed: %s" m;
+        0
+    | Error (Backend.AlreadyExists _ | Backend.InvalidKey _
+            | Backend.ConnectionFailed _ | Backend.BackendNotSupported _) ->
         Log.Coord.warn "get_recent_events: event seq read failed: %s"
-          (match e with Backend.IOError m -> m
-           | _ -> "unexpected backend error");
+          "unexpected backend error";
         0
   in
   let start_seq = max 0 (current_seq - limit) in
@@ -276,14 +279,11 @@ let read_state config =
       with Eio.Cancel.Cancelled _ as e -> raise e | e -> Error (Printexc.to_string e))
   | Error (Backend.NotFound _) ->
       Ok (default_room_state ())
-  | Error e ->
-      Error (match e with
-        | Backend.IOError msg -> msg
-        | Backend.NotFound k -> "Not found: " ^ k
-        | Backend.AlreadyExists k -> "Already exists: " ^ k
-        | Backend.InvalidKey k -> "Invalid key: " ^ k
-        | Backend.ConnectionFailed m -> "Connection failed: " ^ m
-        | Backend.BackendNotSupported m -> "Not supported: " ^ m)
+  | Error (Backend.IOError msg) -> Error msg
+  | Error (Backend.AlreadyExists k) -> Error ("Already exists: " ^ k)
+  | Error (Backend.InvalidKey k) -> Error ("Invalid key: " ^ k)
+  | Error (Backend.ConnectionFailed m) -> Error ("Connection failed: " ^ m)
+  | Error (Backend.BackendNotSupported m) -> Error ("Not supported: " ^ m)
 
 (** Write room state *)
 let write_state config state =
@@ -402,10 +402,10 @@ let register_agent config ~name ?(capabilities=[]) () =
       end;
 
       Ok agent
-  | Error e ->
-      Error (match e with
-        | Backend.IOError msg -> msg
-        | _ -> "Failed to register agent")
+  | Error (Backend.IOError msg) -> Error msg
+  | Error (Backend.NotFound _ | Backend.AlreadyExists _ | Backend.InvalidKey _
+          | Backend.ConnectionFailed _ | Backend.BackendNotSupported _) ->
+      Error "Failed to register agent"
 
 (** Get agent state *)
 let get_agent config ~name =
@@ -417,10 +417,10 @@ let get_agent config ~name =
       with Eio.Cancel.Cancelled _ as e -> raise e | e -> Error (Printexc.to_string e))
   | Error (Backend.NotFound _) ->
       Error "Agent not found"
-  | Error e ->
-      Error (match e with
-        | Backend.IOError msg -> msg
-        | _ -> "Failed to get agent")
+  | Error (Backend.IOError msg) -> Error msg
+  | Error (Backend.AlreadyExists _ | Backend.InvalidKey _
+          | Backend.ConnectionFailed _ | Backend.BackendNotSupported _) ->
+      Error "Failed to get agent"
 
 (** Remove agent *)
 let remove_agent config ~name =
@@ -443,10 +443,10 @@ let remove_agent config ~name =
       Ok ()
   | Error (Backend.NotFound _) ->
       Ok ()  (* Already removed *)
-  | Error e ->
-      Error (match e with
-        | Backend.IOError msg -> msg
-        | _ -> "Failed to remove agent")
+  | Error (Backend.IOError msg) -> Error msg
+  | Error (Backend.AlreadyExists _ | Backend.InvalidKey _
+          | Backend.ConnectionFailed _ | Backend.BackendNotSupported _) ->
+      Error "Failed to remove agent"
 
 (** {1 Lock Operations} *)
 
@@ -507,20 +507,20 @@ let acquire_lock config ~resource ~owner =
       Ok (Some lock)
   | Ok false ->
       Ok None  (* Lock held by someone else *)
-  | Error e ->
-      Error (match e with
-        | Backend.IOError msg -> msg
-        | _ -> "Failed to acquire lock")
+  | Error (Backend.IOError msg) -> Error msg
+  | Error (Backend.NotFound _ | Backend.AlreadyExists _ | Backend.InvalidKey _
+          | Backend.ConnectionFailed _ | Backend.BackendNotSupported _) ->
+      Error "Failed to acquire lock"
 
 (** Release lock *)
 let release_lock config ~resource ~owner =
   match Backend.FileSystem.release_lock config.backend ~key:resource ~owner with
   | Ok true -> Ok ()
   | Ok false -> Error "Not lock owner"
-  | Error e ->
-      Error (match e with
-        | Backend.IOError msg -> msg
-        | _ -> "Failed to release lock")
+  | Error (Backend.IOError msg) -> Error msg
+  | Error (Backend.NotFound _ | Backend.AlreadyExists _ | Backend.InvalidKey _
+          | Backend.ConnectionFailed _ | Backend.BackendNotSupported _) ->
+      Error "Failed to release lock"
 
 (** Extend lock TTL *)
 let extend_lock config ~resource ~owner =
@@ -529,10 +529,10 @@ let extend_lock config ~resource ~owner =
           ~key:resource ~owner ~ttl_seconds with
   | Ok true -> Ok ()
   | Ok false -> Error "Not lock owner or lock expired"
-  | Error e ->
-      Error (match e with
-        | Backend.IOError msg -> msg
-        | _ -> "Failed to extend lock")
+  | Error (Backend.IOError msg) -> Error msg
+  | Error (Backend.NotFound _ | Backend.AlreadyExists _ | Backend.InvalidKey _
+          | Backend.ConnectionFailed _ | Backend.BackendNotSupported _) ->
+      Error "Failed to extend lock"
 
 (** {1 Message Operations} *)
 
@@ -626,10 +626,10 @@ let broadcast config ~from_agent ~content =
          Log.Coord.warn "on_broadcast_mention callback failed: %s"
            (Printexc.to_string exn));
       Ok msg
-  | Error e ->
-      Error (match e with
-        | Backend.IOError msg -> msg
-        | _ -> "Failed to broadcast message")
+  | Error (Backend.IOError msg) -> Error msg
+  | Error (Backend.NotFound _ | Backend.AlreadyExists _ | Backend.InvalidKey _
+          | Backend.ConnectionFailed _ | Backend.BackendNotSupported _) ->
+      Error "Failed to broadcast message"
 
 (** Get message by sequence number *)
 let get_message config ~seq =
@@ -641,20 +641,20 @@ let get_message config ~seq =
       with Eio.Cancel.Cancelled _ as e -> raise e | e -> Error (Printexc.to_string e))
   | Error (Backend.NotFound _) ->
       Error "Message not found"
-  | Error e ->
-      Error (match e with
-        | Backend.IOError msg -> msg
-        | _ -> "Failed to get message")
+  | Error (Backend.IOError msg) -> Error msg
+  | Error (Backend.AlreadyExists _ | Backend.InvalidKey _
+          | Backend.ConnectionFailed _ | Backend.BackendNotSupported _) ->
+      Error "Failed to get message"
 
 (** {1 Health Check} *)
 
 let health_check config =
   match Backend.FileSystem.health_check config.backend with
   | Ok result -> Ok result
-  | Error e ->
-      Error (match e with
-        | Backend.IOError msg -> msg
-        | _ -> "Health check failed")
+  | Error (Backend.IOError msg) -> Error msg
+  | Error (Backend.NotFound _ | Backend.AlreadyExists _ | Backend.InvalidKey _
+          | Backend.ConnectionFailed _ | Backend.BackendNotSupported _) ->
+      Error "Health check failed"
 
 (** {1 Coord Status} *)
 

--- a/lib/coord/coord_query.ml
+++ b/lib/coord/coord_query.ml
@@ -239,7 +239,7 @@ let collect_recent_messages config ~msgs_path ~since_seq ~limit ~warn_label =
             | json ->
                 (match message_of_yojson json with
                  | Ok msg when msg.seq > since_seq -> loop (remaining - 1) (msg :: acc) rest
-                 | _ -> loop remaining acc rest)
+                 | Ok _ | Error _ -> loop remaining acc rest)
             | exception (Eio.Cancel.Cancelled _ as e) -> raise e
             | exception e ->
                 Log.legacy_traceln ~level:Log.Warn ~module_name:"Coord"
@@ -278,7 +278,7 @@ let get_all_messages_raw config ~since_seq =
             | json ->
                 (match message_of_yojson json with
                  | Ok msg when msg.seq > since_seq -> loop (msg :: acc) rest
-                 | _ -> loop acc rest)
+                 | Ok _ | Error _ -> loop acc rest)
             | exception (Eio.Cancel.Cancelled _ as e) -> raise e
             | exception e ->
                 Log.legacy_traceln ~level:Log.Warn ~module_name:"Coord"

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -94,7 +94,11 @@ let transition_task_r
               (Masc_domain.Task
                  (Masc_domain.Task_error.InvalidState
                     (Printf.sprintf "Task %s is blocked from re-claim: %s" task_id r)))
-          | _ -> Ok ()
+          | Masc_domain.Claim, None
+          | ( Masc_domain.Start | Masc_domain.Done_action | Masc_domain.Cancel
+            | Masc_domain.Release | Masc_domain.Submit_for_verification
+            | Masc_domain.Approve_verification | Masc_domain.Reject_verification
+            | Masc_domain.Submit_pr_evidence ), _ -> Ok ()
         in
         let now = now_iso () in
         let now_ts = Time_compat.now () in
@@ -153,7 +157,13 @@ let transition_task_r
                retried with the same action rather than claiming first.
                Name the exact next call to make so small-LLM keepers can
                recover on the next turn. *)
-            let remediation =
+            (* WORKAROUND: task_status (6 ctors) × task_action (9 ctors) =
+               54 combos, with ~11 specific hint cases. 명시적 enumeration은
+               hint-string 경로(graceful degradation 가능)에서 churn 비용이
+               컴파일러 강제의 가치를 초과.
+               근본 해결: 도메인 모델링 변경 — (status, action) -> error_kind
+               분류기를 분리한 RFC 후보. *)
+            let[@warning "-4"] remediation =
               let own_assignee =
                 match task_assignee_of_status task.task_status with
                 | Some a when same_task_actor config a agent_name -> true
@@ -207,8 +217,13 @@ let transition_task_r
         in
         let new_status = decision.Coord_task_lifecycle.new_status in
         let set_current = decision.set_current in
+        (* WORKAROUND: action (9) × task_status (6) × new_status (6) × option (2)
+           = 648 combos. action+option은 enumeration되었으나 task_status/new_status는
+           대부분 _. task_status enumeration은 cross-product 폭발 — 도메인 신규 ctor
+           추가 시 의미 변경 없는 caller가 churn.
+           근본 해결: precondition validator를 도메인 모델에 흡수 (RFC 후보). *)
         let* () =
-          match action, task.task_status, new_status, prepare_verification_request with
+          (match action, task.task_status, new_status, prepare_verification_request with
           | ( (Masc_domain.Submit_for_verification | Masc_domain.Submit_pr_evidence)
             , _
             , Masc_domain.AwaitingVerification { assignee; verification_id; _ }
@@ -262,10 +277,13 @@ let transition_task_r
               | Masc_domain.Submit_pr_evidence )
             , _
             , _
-            , None ) -> Ok ()
+            , None ) -> Ok ()) [@warning "-4"]
         in
+        (* WORKAROUND: same justification as previous let*. action (9) × task_status (6)
+           × option (2) = 108 combos, action+option enumerated, task_status mostly _.
+           근본 해결: 위와 동일 RFC 후보. *)
         let* () =
-          match action, task.task_status, prepare_verification_verdict with
+          (match action, task.task_status, prepare_verification_verdict with
           | ( Masc_domain.Approve_verification
             , Masc_domain.AwaitingVerification { verification_id; _ }
             , Some prepare ) ->
@@ -338,7 +356,7 @@ let transition_task_r
               | Masc_domain.Approve_verification
               | Masc_domain.Reject_verification )
             , _
-            , None ) -> Ok ()
+            , None ) -> Ok ()) [@warning "-4"]
         in
         (match decision.drift with
          | Some Coord_task_lifecycle.Claimed_to_done_skip ->
@@ -663,7 +681,14 @@ let transition_task_r
              own worktree, leaving the original orphaned.  Best-effort
              matches the existing Done branch: filesystem GC must not
              fail the state transition. *)
-          let cleanup_worktree_for_transition reason_label =
+          (* WORKAROUND: Masc_error.t는 framework-tier 합타입 (7 ctor),
+             각 ctor가 자체 합타입 (Task_error, System_error 등). best-effort
+             cleanup의 변별점은 WorktreeNotFound 한 경로뿐이고 나머지 ctor 전체는
+             동일하게 WARN 처리. 명시적 enumeration은 framework 신규 ctor마다
+             best-effort path가 churn 대상이 됨.
+             근본 해결: Masc_error.t를 best_effort_cleanup_outcome 변환기로
+             1차 분류 후 다루기 (RFC 후보). *)
+          let[@warning "-4"] cleanup_worktree_for_transition reason_label =
             match task.worktree with
             | None -> ()
             | Some _ ->

--- a/lib/coord/coord_task_cache_invariant.ml
+++ b/lib/coord/coord_task_cache_invariant.ml
@@ -176,13 +176,11 @@ let stale_active_task_signal_present ~config ~from_agent ~module_name ~content =
   then false
   else match check_cache_signal ~config ~content with
   | No_cache_signal | No_terminal_task -> false
-  | stale_tasks ->
-    (match stale_tasks with
-     | Terminal_tasks stale_tasks ->
-       record_cache_desync_cleared ~config ~module_name stale_tasks
-     | Backlog_unavailable { task_ids; _ } ->
-       record_backlog_unavailable ~config ~module_name task_ids
-     | No_cache_signal | No_terminal_task -> ());
+  | Terminal_tasks stale_tasks ->
+    record_cache_desync_cleared ~config ~module_name stale_tasks;
+    true
+  | Backlog_unavailable { task_ids; _ } ->
+    record_backlog_unavailable ~config ~module_name task_ids;
     true
 ;;
 

--- a/lib/coord/coord_task_classify.ml
+++ b/lib/coord/coord_task_classify.ml
@@ -46,11 +46,16 @@ let classify_completion_path
       ~(drift : Coord_task_lifecycle.drift option)
       ~(force : bool)
   =
-  match action, drift, force with
-  | Masc_domain.Approve_verification, _, _ -> "via_verification"
-  | _, _, true -> "forced_done"
-  | _, Some Coord_task_lifecycle.Claimed_to_done_skip, false -> "claimed_to_done_skip"
-  | _, None, false -> "in_progress_to_done"
+  match action with
+  | Masc_domain.Approve_verification -> "via_verification"
+  | Masc_domain.Claim | Masc_domain.Start | Masc_domain.Done_action
+  | Masc_domain.Cancel | Masc_domain.Release
+  | Masc_domain.Submit_for_verification | Masc_domain.Reject_verification
+  | Masc_domain.Submit_pr_evidence ->
+    if force then "forced_done"
+    else (match drift with
+          | Some Coord_task_lifecycle.Claimed_to_done_skip -> "claimed_to_done_skip"
+          | None -> "in_progress_to_done")
 ;;
 
 let task_actor_kind agent_name =

--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -458,7 +458,7 @@ let with_distributed_lock ?clock config _path key f =
     else
       match backend_acquire_lock config ~key ~ttl_seconds ~owner with
       | Ok true -> true
-      | _ ->
+      | Ok false | Error _ ->
           sleep_lock_retry ?clock (backoff_with_jitter delay);
           acquire (attempts - 1) (Float.min 0.5 (delay *. 2.0))
   in
@@ -495,7 +495,7 @@ let with_distributed_lock_r ?clock config path key f : ('a, masc_error) result =
     else
       match backend_acquire_lock config ~key ~ttl_seconds ~owner with
       | Ok true -> true
-      | _ ->
+      | Ok false | Error _ ->
           sleep_lock_retry ?clock (backoff_with_jitter delay);
           acquire (attempts - 1) (Float.min 0.5 (delay *. 2.0))
   in

--- a/lib/coord/coord_utils_paths_backend.ml
+++ b/lib/coord/coord_utils_paths_backend.ml
@@ -69,7 +69,9 @@ let backend_get config ~key =
   (match result with
    | Ok v -> Ok (Some v)
    | Error (Backend_types.NotFound _) -> Ok None
-   | Error e -> Error e)
+   | Error (Backend_types.AlreadyExists _ | Backend_types.IOError _
+           | Backend_types.InvalidKey _ | Backend_types.ConnectionFailed _
+           | Backend_types.BackendNotSupported _) as err -> err)
 
 let backend_set config ~key ~value =
   match config.backend with
@@ -86,7 +88,9 @@ let backend_delete config ~key =
   (match result with
    | Ok () -> Ok true
    | Error (Backend_types.NotFound _) -> Ok false
-   | Error e -> Error e)
+   | Error (Backend_types.AlreadyExists _ | Backend_types.IOError _
+           | Backend_types.InvalidKey _ | Backend_types.ConnectionFailed _
+           | Backend_types.BackendNotSupported _) as err -> err)
 
 let backend_exists config ~key =
   match config.backend with
@@ -109,7 +113,7 @@ let backend_get_all config ~prefix =
            let pairs = List.filter_map (fun k ->
              match backend_get config ~key:k with
              | Ok (Some v) -> Some (k, v)
-             | _ -> None
+             | Ok None | Error _ -> None
            ) keys in
            Ok pairs)
 

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -387,7 +387,7 @@ let is_usable_git_worktree path =
       match first_nonempty_line output with
       | Some top -> same_realpath top path
       | None -> false)
-  | _ -> false
+  | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _ -> false
 
 let run_git_in_clone clone_path args =
   run_argv_with_status ([ "git"; "-C"; clone_path; "--no-optional-locks" ] @ args)
@@ -961,7 +961,7 @@ let partial_clone_error ~clone_path ~msg =
 let git_origin_url root =
   match run_argv_with_status [ "git"; "-C"; root; "remote"; "get-url"; "origin" ] with
   | Unix.WEXITED 0, output -> first_nonempty_line output
-  | _ -> None
+  | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _ -> None
 
 let normalize_origin_remote_to_https root =
   match git_origin_url root with
@@ -975,7 +975,7 @@ let normalize_origin_remote_to_https root =
             [ "git"; "-C"; root; "remote"; "set-url"; "origin"; normalized ]
         with
         | Unix.WEXITED 0, _ -> Some normalized
-        | _ -> None
+        | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _ -> None
 
 let auto_provision_sandbox_clone ~config ~agent_name ~repos_dir ~repo_name =
   let search_root = project_root config in
@@ -1161,7 +1161,11 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
           in
 
           (* Link worktree to task in backlog *)
-          let maybe_link_task () =
+          (* WORKAROUND: Masc_error.t has 7 ctors with nested per-domain
+             variants (Task_error has its own ctors). 정확한 enumeration은
+             도메인 신규 ctor마다 무관한 caller가 churn 대상이 됨.
+             근본 해결: per-domain error-to-string helper로 분류 일원화 (RFC 후보). *)
+          let[@warning "-4"] maybe_link_task () =
             if link_task then begin
               match link_worktree_to_task config ~task_id ~worktree_info:wt_info with
               | Ok () -> ""

--- a/lib/coord/dune
+++ b/lib/coord/dune
@@ -3,6 +3,7 @@
  (name masc_coord)
  (public_name masc_mcp.masc_coord)
  (wrapped false)
+ (flags (:standard -w +4))
  (modules
   coord_backlog
   coord_bootstrap

--- a/lib/coord/playground_repo_cache.ml
+++ b/lib/coord/playground_repo_cache.ml
@@ -29,7 +29,7 @@ let is_shallow_repo repo_path =
     match git_meta repo_path [ "rev-parse"; "--is-shallow-repository" ] with
     | Unix.WEXITED 0, output ->
         String.equal "true" (String.trim output)
-    | _ -> false
+    | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _ -> false
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | _ -> false
@@ -44,12 +44,12 @@ let update
     let branch =
       match git_meta repo_path [ "rev-parse"; "--abbrev-ref"; "HEAD" ] with
       | Unix.WEXITED 0, output -> String.trim output
-      | _ -> "unknown"
+      | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _ -> "unknown"
     in
     let commit =
       match git_meta repo_path [ "log"; "--oneline"; "-1" ] with
       | Unix.WEXITED 0, output -> String.trim output
-      | _ -> ""
+      | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _ -> ""
     in
     let ts = Printf.sprintf "%.0f" (Unix.gettimeofday ()) in
     let entry =


### PR DESCRIPTION
## 목표

`lib/coord/` sub-library에 `(flags (:standard -w +4))` 추가하고 41개 fragile-match 사이트를 RFC-0071 §3.4.1 분류에 따라 닫는다. WS-1 (sublib ratchet) 최종 PR.

## 변경

`lib/coord/dune`에 `-w +4` 활성화 + 11개 파일에서 41 site 처리.

### 카테고리별 처리

| 패턴 | 사이트 수 | 처리 |
|------|---------|------|
| `Unix.process_status` | 5 | `WEXITED _ \| WSIGNALED _ \| WSTOPPED _` enumerate |
| `Backend_types.error` (6 ctors) | 14 | outer match flatten, 6 ctor 명시 |
| `Stdlib.result` | 5 | `Ok _ \| Error _` 명시 |
| `cache_signal_check` (4 ctors) | 1 | 4 ctor flatten |
| `task_action` (9 ctors) | 2 | action 차원 분리 + 명시 enum |
| `agent_status × option` cross-product | 1 | 4×2 명시 enum |
| `Masc_error.t` framework variant 큰 cross-product | 4 | `[@warning "-4"]` + WORKAROUND 주석 |

### `[@warning "-4"]` 사용 정당화

RFC-0071 §3.4.1 4번째 de-facto 카테고리 (framework-tier 합타입, cdal_runtime PR #14997 선례). 적용 대상:

1. `coord_task.ml:remediation` — `task_status (6) × task_action (9) = 54 combos`, ~11 specific hint cases. Hint-string 경로 (graceful degradation 가능).
2. `coord_task.ml:let* () = match action, task.task_status, new_status, prepare_verification_request` — 4-tuple, 648 combos. action+option enumerated, task_status/new_status는 대부분 wildcard. 동일 패턴 2 site.
3. `coord_task.ml:cleanup_worktree_for_transition` — `Masc_error.t` 7 ctor + 각 도메인 자체 합타입. best-effort cleanup의 변별점은 `WorktreeNotFound` 하나뿐.
4. `coord_worktree.ml:maybe_link_task` — `Masc_error.t` 동일 패턴.

각 site에 `(* WORKAROUND: <이유>. 근본 해결: <RFC 후보> *)` 주석 첨부.

## 검증

- `dune build --root . lib/coord/` clean: warning 4 사이트 41 → 0
- `dune build --root . @check` clean: downstream regression 없음
- 테스트 green: `test_coord_eio_pure` 10건, `test_coord_bootstrap`, `test_coord_worktree_policy_path` 11건

## 누적 진행

`-w +4` ratchet 진행률: **41/42 production sublibs (97.6%)**

```
✅ 36 sublib (기존 머지): core, exec, types, resilience, cdal, activity_graph, ...
✅ lib/ide       (PR #14984)
✅ lib/cascade_decl (PR #14987)
✅ lib/repo_manager (PR #14990, RFC-0008+0019)
✅ lib/cdal_runtime (PR #14997)
✅ lib/coord     (이 PR)
```

skip: `lib/exec/parser` (Menhir 생성). 

남은 작업 = `lib/dune` 메인 (1044+ 사이트, codemod 필요). WS-2 advisory lint → WS-3 codemod → WS-4 적용/활성화.

## RFC-WAIVED

leaf compiler-flag 변경 (`lib/coord/dune` + 내부 로직 무변경). `agent_delegation` subsystem (credential / identity / repo / operator / sandbox / dashboard / hooks) 무관.
