### PR TITLE
feat(scripts): audit-ocaml-spec-nav-line-refs.sh multi-line scan (R-1.c)

### DIFF
--- a/docs/tla-audit/r1c-ocaml-spec-nav-multiline-scan-2026-05-12.md
+++ b/docs/tla-audit/r1c-ocaml-spec-nav-multiline-scan-2026-05-12.md
@@ -1,0 +1,58 @@
+# R-1.c — `audit-ocaml-spec-nav-line-refs.sh` multi-line scan + comment-boundary filter (closing iter 94's "single-line regex" structural gap)
+
+**Date**: 2026-05-12 · **Iteration**: 95 (`/loop` FSM/TLA+/OCaml drift hunt) · **Phase**: guard (closing the structural follow-up surfaced by iter 94 #15002)
+
+## What this is
+
+iter 94 audit memo (post-Copilot-review correction) identified the real structural gap behind iter 91's surviving follow-up: the OCaml-side validator `scripts/audit-ocaml-spec-nav-line-refs.sh` *was* wired into CI (`.github/workflows/tla-annotation-drift.yml:134`) with a baseline file (`scripts/ocaml-spec-nav-line-refs-baseline.txt`, currently empty after iter 74's drain). The gap was the **regex shape**: the scan loop used `grep -oE` (line-oriented), so a citation like
+
+```
+[run_keeper_cycle]
+(line 1042+)
+```
+
+— bracketed symbol and `line N` on *adjacent* lines — fell outside the window and survived three iterations.
+
+This PR closes the regex gap. Two changes to the scanner:
+
+1. **`grep -oE` → awk whole-file scan**. Same regex (`\[(type )?[a-z_]+\][^][\n]*(\n[[:space:]]*[^][\n]*)?line[s ]+[0-9]+`) operates on the whole file via `RS="\0"`. Allows AT MOST one intervening newline between `[sym]` and `line N` (no paragraph-spanning).
+
+2. **Comment-boundary filter** to suppress false positives that splice across two unrelated comment blocks (`*) ... (*`). Without this filter, `[source]` (a record-field name in one comment) plus `KeeperTurnCycle.tla lines 189` (a *spec* line ref in the next comment block) of `keeper_guards.ml` matched as a single drift — the bracketed symbol and the line number were in *separate* comments, so dropping matches that contain `*)` or `(*` (a guaranteed comment terminator/opener) is sound.
+
+## What the widened scan immediately surfaces
+
+Running the new scanner on origin/main (503e92ad6):
+
+```
+drift: lib/keeper/keeper_unified_turn.ml — cites [run_keeper_cycle] at line 1042 but actual is 239 (drift -803)
+```
+
+Exactly the iter 91 catalogued site that iter 94 PR #15002 is currently in flight to fix. The scanner couldn't see it before this PR; now it does. **Baselined here** (`lib/keeper/keeper_unified_turn.ml:run_keeper_cycle`) while #15002 is OPEN; the baseline line drains when that PR merges.
+
+## Why the false-positive filter is sound
+
+Inside a single OCaml comment block `(* ... *)`, the substrings `(*` and `*)` never appear (they'd terminate the comment). So *any* match that spans `*) ... (*` necessarily crosses two distinct comment blocks and is not a single coherent citation. The filter is conservative — it discards potential matches that *could* legitimately span comments (rare in practice; none in the current `lib/keeper/` tree), but those are exactly the cases where the symbol-vs-line-number coupling is ambiguous and should not be flagged.
+
+Manual sanity-check on origin/main: only one false-positive shape exists today (`keeper_guards.ml` `[source]` + `KeeperTurnCycle.tla lines 189`); the filter drops it. Post-iter-94 cleanup of `keeper_unified_turn.ml` will not produce a new false positive (the cleanup edits are entirely within `(* ... *)` blocks).
+
+## Verification
+
+- `bash -n scripts/audit-ocaml-spec-nav-line-refs.sh` → syntax OK.
+- `bash scripts/audit-ocaml-spec-nav-line-refs.sh --baseline scripts/ocaml-spec-nav-line-refs-baseline.txt` → `ocaml-spec-nav line-ref audit clean: 1 citation(s) verified across 504 file(s) (1 baselined).` (exit 0).
+- Negative test: append `(* [test_negative_sym]\n   (line 9999) negative test *)` to any `lib/keeper/*.ml` → scanner reports `drift: lib/keeper/keeper_guards.ml — cites [test_negative_sym] at line 9999 but file has only 689 lines` (exit 1); revert → exit 0.
+- False-positive guard: `keeper_guards.ml`'s `[source]` field reference no longer drifts (filtered out by the `*)` / `(*` exclusion).
+- CI: `.github/workflows/tla-annotation-drift.yml:134` already invokes this script with the existing baseline path — no workflow edit needed; new scan capability picks up automatically.
+
+## Paired-activation rationale
+
+iter 33 #14804 precedent — activate scanner improvements together with paired baseline lines for any existing sites the widened scan surfaces. Here, exactly one new site (`keeper_unified_turn.ml:run_keeper_cycle`), which iter 94 #15002 is already in flight to drain. When #15002 merges, the `run_keeper_cycle` reverse-citation no longer has `(line 1042+)` in it; the scanner reports zero citations; the baseline line becomes stale and the next iteration drains it.
+
+## Not a workaround
+
+CLAUDE.md §워크어라운드 거부 기준 #2 ("string/substring 분류기 보강") targets *runtime* string classifiers added where a typed variant is possible. This is a *static lint regex widening* — making an existing guard see a citation shape it was structurally blind to. The structural fix is the iter 64 N-2.a convention; the lint enforces it; this PR closes a previously open window in the lint's coverage.
+
+## Follow-up
+
+- Drain `lib/keeper/keeper_unified_turn.ml:run_keeper_cycle` from the baseline when iter 94 #15002 merges.
+- The third drift class (prose form `at line N` / `(line N)` without a bracketed symbol, e.g. iter 94 Site 2's `at line 966-967` after `[reset_turn_failures]` in a separate adjacent line — actually caught by this PR's multi-line scan because `[reset_turn_failures]` is in the same comment) is structurally covered now. If a *purely* prose citation like `the function at line 2275` (no bracketed symbol anywhere in the multi-line window) appears, it remains uncaught; no current `lib/keeper/*.ml` sites have that shape, so deferred until one shows up.
+- Standing follow-ups from earlier iterations (KWP model bug, OPB-buggy deadlock, R-D-2.a+R-D-1.a bundle, KSM A-5) unchanged.

--- a/scripts/audit-ocaml-spec-nav-line-refs.sh
+++ b/scripts/audit-ocaml-spec-nav-line-refs.sh
@@ -153,7 +153,31 @@ for ml in "${KEEPER_DIR}"/*.ml "${KEEPER_DIR}"/*.mli; do
     fi
     drift_count=$((drift_count + 1))
 
-  done < <(grep -oE '\[(type )?[a-z_]+\][^][]*line[s ]+[0-9]+' "${ml}" || true)
+    # Multi-line scan (iter 95 R-1.c): a citation like
+    #   "[run_keeper_cycle]
+    #    (line 1042+)"
+    # where the bracketed symbol and the `line N` mention sit on adjacent
+    # lines was previously invisible — `grep -oE` is single-line.  This awk
+    # pass reads the whole file and walks all matches of the same shape
+    # bounded to AT MOST ONE intervening newline (no over-spanning across
+    # paragraphs).  Newlines inside the match are collapsed to spaces
+    # before sed extracts `sym` / `cited_line`, so the existing extractors
+    # keep working.  Same regex; awk operates on the whole file via RS.
+  done < <(awk 'BEGIN{RS="\0"} {
+    s = $0
+    while (match(s, /\[(type )?[a-z_]+\][^][\n]*(\n[[:space:]]*[^][\n]*)?line[s ]+[0-9]+/)) {
+      hit = substr(s, RSTART, RLENGTH)
+      # Reject matches that span OCaml comment boundaries `*) ... (*`
+      # (e.g. `[source]` in one comment followed by an unrelated
+      # `KeeperTurnCycle.tla lines 189` in the next comment).
+      if (hit !~ /\*\)/ && hit !~ /\(\*/) {
+        gsub(/\n/, " ", hit)
+        gsub(/[[:space:]]+/, " ", hit)
+        print hit
+      }
+      s = substr(s, RSTART + RLENGTH)
+    }
+  }' "${ml}")
 done
 
 if [[ "${drift_count}" -gt 0 ]]; then

--- a/scripts/ocaml-spec-nav-line-refs-baseline.txt
+++ b/scripts/ocaml-spec-nav-line-refs-baseline.txt
@@ -15,3 +15,13 @@
 # any future transient grandfathering — add a "<path>:<symbol>" line
 # here, reference the fix-PR in this comment, and remove it once that
 # PR merges (same convention as the ocaml-phase-count baseline).
+#
+# iter 95 R-1.c (this PR): scanner gained multi-line scan capability
+# (the single-line `grep -oE` regex couldn't match `[sym]` and `line N`
+# split across adjacent comment lines).  The widened scan immediately
+# surfaced one drift hidden from the previous regex; baselined here
+# while its fix-PR is in flight:
+#   keeper_unified_turn.ml:run_keeper_cycle — iter 94 #15002 (drains
+#     the `[run_keeper_cycle] (line 1042+)` reverse-citation in the
+#     run_keeper_cycle header; remove this line once #15002 merges).
+lib/keeper/keeper_unified_turn.ml:run_keeper_cycle


### PR DESCRIPTION
## Finding (Iteration 95, R-1.c — `audit-ocaml-spec-nav-line-refs.sh` multi-line scan)

**Script**: `scripts/audit-ocaml-spec-nav-line-refs.sh` (single-line `grep -oE` → whole-file awk + bounded multi-line regex + comment-boundary filter)
**Baseline**: `scripts/ocaml-spec-nav-line-refs-baseline.txt` (1 line added — paired-activation with iter 94 #15002 fix-PR)
**Wired into**: `.github/workflows/tla-annotation-drift.yml:134` (이미 존재 — workflow 편집 불필요)
**Aspect**: iter 94 audit memo (post-Copilot-review correction)이 명시한 진짜 structural gap closure
**Risk**: LOW (스크립트 + baseline only; CI는 zero-finding으로 통과; comment-boundary filter가 회귀 차단)
**Workaround signature**: N/A — static lint regex widening, runtime classifier 아님; iter-74 baseline-drain posture로 pre-cleared

## 순서도

```mermaid
flowchart TD
  iter94["iter 94 audit memo (Copilot review 정정)"] -->|"진짜 gap 식별"| GAP["regex single-line — multi-line citation invisible"]
  GAP --> FIX["iter 95 (이 PR): awk whole-file scan + 1-newline span"]
  FIX --> CATCH["[run_keeper_cycle]\n(line 1042+) — actual @239, drift -803"]
  CATCH --> BASELINE["baseline 1 line (iter 94 #15002 pending drain)"]
  FIX --> FP["[source] (one comment) + KeeperTurnCycle.tla lines 189 (other comment)"]
  FP --> FILTER["comment-boundary filter: drop *) ... (* spans"]
  FILTER --> CLEAN["clean: 1 citation verified, 1 baselined"]
```

## What the widened scan immediately surfaces

origin/main (503e92ad6)에서 새 scanner 실행:

```
drift: lib/keeper/keeper_unified_turn.ml — cites [run_keeper_cycle] at line 1042 but actual is 239 (drift -803)
```

iter 91 catalogued + iter 94 PR #15002가 fix 중인 *바로 그 사이트*. iter 91→94 (4 iteration) 살아남은 *구조적 이유*가 정확히 single-line regex였음. 본 PR이 그 가시성 gap을 닫음. paired baseline (#15002 OPEN 동안만, 머지 시 drain).

## Before / After

`scripts/audit-ocaml-spec-nav-line-refs.sh` 1 hunk:

```diff
-  done < <(grep -oE '\[(type )?[a-z_]+\][^][]*line[s ]+[0-9]+' "${ml}" || true)
+    # Multi-line scan (iter 95 R-1.c): a citation like
+    #   "[run_keeper_cycle]
+    #    (line 1042+)"
+    # where the bracketed symbol and the `line N` mention sit on adjacent
+    # lines was previously invisible — `grep -oE` is single-line.  This awk
+    # pass reads the whole file and walks all matches of the same shape
+    # bounded to AT MOST ONE intervening newline (no over-spanning across
+    # paragraphs).  Newlines inside the match are collapsed to spaces
+    # before sed extracts `sym` / `cited_line`, so the existing extractors
+    # keep working.  Same regex; awk operates on the whole file via RS.
+  done < <(awk 'BEGIN{RS="\0"} {
+    s = $0
+    while (match(s, /\[(type )?[a-z_]+\][^][\n]*(\n[[:space:]]*[^][\n]*)?line[s ]+[0-9]+/)) {
+      hit = substr(s, RSTART, RLENGTH)
+      # Reject matches that span OCaml comment boundaries `*) ... (*`
+      # (e.g. `[source]` in one comment followed by an unrelated
+      # `KeeperTurnCycle.tla lines 189` in the next comment).
+      if (hit !~ /\*\)/ && hit !~ /\(\*/) {
+        gsub(/\n/, " ", hit)
+        gsub(/[[:space:]]+/, " ", hit)
+        print hit
+      }
+      s = substr(s, RSTART + RLENGTH)
+    }
+  }' "${ml}")
```

`scripts/ocaml-spec-nav-line-refs-baseline.txt` — 1 line + iter 95 transient comment block.

## 왜 톱니처럼 정교하지 않았는가

**8-class drift pipeline의 OCaml-side validator** (`audit-ocaml-spec-nav-line-refs.sh`, iter 72 #14944)는 *line-oriented*. `grep -oE`가 unix tradition — file 1줄 1매치. 그러나 OCaml comments는 textual paragraph 형태로 line break가 *데이터 구조의 일부*가 아닌 *형식의 일부*: `[run_keeper_cycle]\n(line 1042+)` 같은 형태는 *single citation*이다.

이 미세한 gap이 iter 91 follow-up이 *3 iteration* (#14992 → #14998 → #15002) 살아남은 정확한 이유. 사용자가 iter 94 audit memo를 정정 (Copilot review): 원래 클레임 "no baseline, no workflow wiring"은 *틀렸다*, 실제는 둘 다 존재. 진짜 gap = regex shape.

본 PR의 가설: scanner를 multi-line으로 확장하면, 정확히 iter 94가 fix하려는 사이트를 *자동으로* 발견할 수 있다. 검증 결과: yes — `[run_keeper_cycle]` -803 drift drift 감지 ✓.

추가 false positive 1건 (`keeper_guards.ml` `[source]` field name + `KeeperTurnCycle.tla lines 189` 다른 comment block) — comment-boundary filter (`*)` / `(*` 매칭 거부)로 차단. OCaml comment 내부에는 `(*`/`*)` 가 등장 불가능하므로 conservative하고 sound.

## 본 PR 수정

- `scripts/audit-ocaml-spec-nav-line-refs.sh` — 1 hunk, `grep -oE` → awk whole-file scan + 1-newline-span regex + comment-boundary filter. +18/-1 LOC.
- `scripts/ocaml-spec-nav-line-refs-baseline.txt` — 1 transient baseline line (`lib/keeper/keeper_unified_turn.ml:run_keeper_cycle`) + iter 95 comment 블록 (drain trigger = #15002 merge). +9/-0 LOC.
- `docs/tla-audit/r1c-ocaml-spec-nav-multiline-scan-2026-05-12.md` — audit memo (gap rationale, filter soundness argument, paired-activation precedent).

## Verification

- [x] `bash -n scripts/audit-ocaml-spec-nav-line-refs.sh` → syntax OK
- [x] `bash scripts/audit-ocaml-spec-nav-line-refs.sh --baseline scripts/ocaml-spec-nav-line-refs-baseline.txt` → `ocaml-spec-nav line-ref audit clean: 1 citation(s) verified across 504 file(s) (1 baselined).` (exit 0)
- [x] Negative test: inject `(* [test_negative_sym]\n   (line 9999) negative test *)\nlet test_negative_sym = ()` into `keeper_guards.ml` → scanner emits `drift: ... cites [test_negative_sym] at line 9999 but file has only 689 lines` (exit 1); revert → exit 0
- [x] False-positive 회귀 차단: `keeper_guards.ml` `[source]` + adjacent-comment `KeeperTurnCycle.tla lines 189` → 새 filter가 차단 (origin/main pre-PR scanner는 false report)
- [x] CI: `.github/workflows/tla-annotation-drift.yml:134`가 이미 invoke — 워크플로 편집 불필요
- [x] `bash ~/me/scripts/pr-rfc-check.sh --pr-body /tmp/pr-iter95-body.md` (rfc-exit=0 — 아래 RFC 참조)

## Trade-off

- **paired-activation dependency**: baseline 1줄이 iter 94 #15002 merge에 의존. #15002는 작은 OCaml-comment doc fix라 머지 가능성 high; 그러나 만약 #15002 거부되거나 long-stale 되면 baseline 라인 영구화 → 따라야 할 새 fix-PR. iter 33 #14804 paired-activation precedent와 동일 risk profile.
- **comment-boundary filter는 *conservative***: `[sym]`과 `line N` 사이에 *정상적으로* `*)` 가 나오는 multi-comment block citation은 누락. 현재 `lib/keeper/`에 0 사이트, 실용 영향 없음. 미래 이런 사이트가 나오면 별도 RFC.
- **`grep -oE`의 더 깊은 한계**: regex 자체는 `[^][\n]*`로 newline 1개 span만 허용 — 3+ line 전체 paragraph spanning은 못 잡음. 현재 0 사이트, 필요 시 widening.

## RFC 참조

`RFC-WAIVED: scripts/.sh + scripts/.txt baseline + audit memo 변경이고 credential / identity / sandbox / dashboard / hooks / workflow subsystem 미접촉. structural fix는 iter 64 N-2.a convention 자체 (symbol-anchor); 본 PR은 N-2.c-style 가드의 regex 확장 (single-line → bounded multi-line) — 가드를 그 convention에 더 정렬. iter-74 baseline-drain posture로 pre-cleared. RFC chain: R-B-1.c → R-H-1.c (#14874) → R-H-1.f (#14891) → N-2.c (#14996 Rule 2) → R-1.a (#14944, single-line) → R-1.b (#14946, drain) → R-1.c (이 PR, multi-line + filter).`

## 진행 추적

다음 iteration 시작점: 후보 — iter 94 PR #15002 머지 모니터링 + baseline drain (R-1.c chain의 자연 closure) OR KeeperWorkPipeline 모델 버그 fix (KNOWN_FAILURES, exit 13 — iter 88 standing follow-up) OR OperatorPauseBroadcast-buggy.cfg deadlock-vs-property follow-up (iter 87 standing follow-up) OR R-D-2.a+R-D-1.a 번들 (KCAF, MID ~150-300 LOC) OR KSM A-5 (22×19 update_conditions matrix).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
