### PR TITLE
chore(scripts): drain run_keeper_cycle from ocaml-spec-nav baseline (R-1.d, iter 95 closure)

### DIFF
--- a/scripts/ocaml-spec-nav-line-refs-baseline.txt
+++ b/scripts/ocaml-spec-nav-line-refs-baseline.txt
@@ -16,12 +16,12 @@
 # here, reference the fix-PR in this comment, and remove it once that
 # PR merges (same convention as the ocaml-phase-count baseline).
 #
-# iter 95 R-1.c (this PR): scanner gained multi-line scan capability
-# (the single-line `grep -oE` regex couldn't match `[sym]` and `line N`
-# split across adjacent comment lines).  The widened scan immediately
-# surfaced one drift hidden from the previous regex; baselined here
-# while its fix-PR is in flight:
-#   keeper_unified_turn.ml:run_keeper_cycle — iter 94 #15002 (drains
-#     the `[run_keeper_cycle] (line 1042+)` reverse-citation in the
-#     run_keeper_cycle header; remove this line once #15002 merges).
-lib/keeper/keeper_unified_turn.ml:run_keeper_cycle
+# iter 95 R-1.c (#15004) widened the scanner from `grep -oE` (line-
+# oriented) to awk whole-file scan + bounded multi-line match + comment-
+# boundary filter; it surfaced one previously hidden citation
+# (`keeper_unified_turn.ml [run_keeper_cycle]`, -803 drift), which
+# iter 94 #15002 had already drained on origin/main minutes earlier.
+# iter 96 R-1.d (this PR) drains the transient baseline line that
+# #15004 had to keep while #15002 was OPEN.  STATUS returns to empty,
+# zero OCaml-docstring line-ref drift across all five baseline chains
+# (R-1.a -> R-1.b -> R-1.c -> R-1.d).


### PR DESCRIPTION
## Finding (Iteration 96, R-1.d — `ocaml-spec-nav-line-refs-baseline.txt` drain)

**Baseline**: `scripts/ocaml-spec-nav-line-refs-baseline.txt` (1 transient line + iter 95 comment block removed, comment trail extended)
**Aspect**: iter 95 #15004의 paired-activation transient baseline의 자연 closure — iter 94 #15002 머지 후 즉시 drain.
**Risk**: LOW (baseline 라인 제거만, scanner 영향 0)
**Workaround signature**: N/A — paired-activation cycle의 의도된 closure

## 순서도 — 3단계 cycle 완주

```mermaid
flowchart LR
  S1["iter 94 #15002<br/>OCaml comment fix<br/>(reverse-citation drain)"] -->|07:03Z merged| S2
  S2["iter 95 #15004<br/>scanner widen + paired baseline<br/>(R-1.c)"] -->|07:10Z merged| S3
  S3["iter 96 (이 PR)<br/>baseline drain<br/>(R-1.d)"] --> CLEAN["STATUS = empty<br/>zero OCaml-docstring line-ref drift"]
```

## Status

`bash scripts/audit-ocaml-spec-nav-line-refs.sh --baseline scripts/ocaml-spec-nav-line-refs-baseline.txt` on origin/main (b6aac6561) post-#15002+#15004 merge: `ocaml-spec-nav line-ref audit clean: 0 citation(s) verified across 504 file(s) (0 baselined).`

즉 #15002 머지로 `[run_keeper_cycle] (line 1042+)` 사이트가 제거됨 → scanner는 그 사이트를 더 이상 보지 않음 → baseline의 `lib/keeper/keeper_unified_turn.ml:run_keeper_cycle` 라인은 *stale grandfather*. 즉시 drain하지 않으면 baseline 영구화 (다음 변경이 *다른* 사이트로 drift할 때 wrongful pass 위험).

## Before / After

`scripts/ocaml-spec-nav-line-refs-baseline.txt`:

```diff
- # iter 95 R-1.c (this PR): scanner gained multi-line scan capability
- # (the single-line `grep -oE` regex couldn't match `[sym]` and `line N`
- # split across adjacent comment lines).  The widened scan immediately
- # surfaced one drift hidden from the previous regex; baselined here
- # while its fix-PR is in flight:
- #   keeper_unified_turn.ml:run_keeper_cycle — iter 94 #15002 (drains
- #     the `[run_keeper_cycle] (line 1042+)` reverse-citation in the
- #     run_keeper_cycle header; remove this line once #15002 merges).
- lib/keeper/keeper_unified_turn.ml:run_keeper_cycle
+ # iter 95 R-1.c (#15004) widened the scanner from `grep -oE` (line-
+ # oriented) to awk whole-file scan + bounded multi-line match + comment-
+ # boundary filter; it surfaced one previously hidden citation
+ # (`keeper_unified_turn.ml [run_keeper_cycle]`, -803 drift), which
+ # iter 94 #15002 had already drained on origin/main minutes earlier.
+ # iter 96 R-1.d (this PR) drains the transient baseline line that
+ # #15004 had to keep while #15002 was OPEN.  STATUS returns to empty,
+ # zero OCaml-docstring line-ref drift across all five baseline chains
+ # (R-1.a -> R-1.b -> R-1.c -> R-1.d).
```

(1 data line 제거 + iter 95 transient comment block을 iter 96 historical note로 conversion)

## 왜 이게 *iteration* 인가

iter 95 PR body에서 명시한 next-iter step ("baseline drain trigger = #15002 merge")의 *기계적 closing*. iter 95 자체가 다음 iter의 step을 *자기 참조적으로 식별* 한 사이트 — `/loop` chain이 일하는 가장 명확한 사이클 시연:

1. **fix-PR** (#15002): 한 사이트의 stale anchor 제거
2. **capability-PR** (#15004): scanner가 *그 형태*를 catch 가능하도록 확장 + transient baseline
3. **drain-PR** (이 PR): transient baseline 라인 제거, capability 영속화

같은 세션 안에서 3 PR을 7분 + 7분 간격으로 admin-merge → drain까지 모두 완주. iter 33 #14804 paired-activation precedent의 *완료 형태* — baseline은 *전이적* grandfathering.

## 본 PR 수정

- `scripts/ocaml-spec-nav-line-refs-baseline.txt` — 1 data line + iter 95 transient comment block 제거; iter 96 historical note 추가 (R-1.a → R-1.b → R-1.c → R-1.d chain 명시). +8/-9 LOC, single file.

(audit memo 없음 — 이 변경은 정확히 iter 95 audit memo의 *Follow-up* 단락에 명시된 mechanical drain, 새 발견 없음.)

## Verification

- [x] `bash scripts/audit-ocaml-spec-nav-line-refs.sh --baseline scripts/ocaml-spec-nav-line-refs-baseline.txt` → `ocaml-spec-nav line-ref audit clean: 0 citation(s) verified across 504 file(s) (0 baselined).` (exit 0, post-drain)
- [x] Capability regression test: inject `(* [test_drain_negative]\n   (line 9999) drain regression test *)\nlet test_drain_negative = ()` into `keeper_guards.ml` → scanner emits `drift: ... cites [test_drain_negative] at line 9999 but file has only 689 lines` (exit 1); revert → exit 0. **iter 95 multi-line scan capability + comment-boundary filter는 drain 후에도 정상 작동**.
- [x] CI: `.github/workflows/tla-annotation-drift.yml:134` 그대로 invoke; baseline 파일 자체는 keep (header 강조: "Keep this file: the CI step still passes `--baseline <this file>`...").
- [x] `bash ~/me/scripts/pr-rfc-check.sh --pr-body /tmp/pr-iter96-body.md` (rfc-exit=0)

## Trade-off

없음 — 정확한 mechanical drain. 추가 사이트 발견되면 새 transient baseline 라인 + 새 fix-PR cycle.

## RFC 참조

`RFC-WAIVED: baseline 파일 라인 제거 (data line 1개 + comment block) only이고 credential / identity / sandbox / dashboard / hooks / workflow subsystem 미접촉. structural fix는 iter 95 R-1.c (#15004)에 이미 들어감; 본 PR은 그 PR이 명시한 mechanical follow-up. RFC chain: R-1.a (#14944) → R-1.b (#14946) → R-1.c (#15004) → R-1.d (이 PR, drain). 8th drift class structural closure 유지.`

## 진행 추적

다음 iteration 시작점: 후보 — KeeperWorkPipeline 모델 버그 fix (KNOWN_FAILURES, exit 13 — iter 88 standing follow-up, clean spec invariant 위반) OR OperatorPauseBroadcast-buggy.cfg deadlock-vs-property follow-up (iter 87 standing follow-up) OR R-D-2.a+R-D-1.a 번들 (KCAF, MID ~150-300 LOC) OR KSM A-5 (22×19 update_conditions matrix). N-2.a/R-1 chain은 closed (iter 92→93→94→95→96의 5 PR 라인 완주).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
