### PR TITLE
fix(spec): unmask PauseLeadsToBroadcast violation in OperatorPauseBroadcast-buggy.cfg (R-12.a, iter 87 closure)

### DIFF
--- a/specs/keeper-state-machine/OperatorPauseBroadcast-buggy.cfg
+++ b/specs/keeper-state-machine/OperatorPauseBroadcast-buggy.cfg
@@ -1,6 +1,17 @@
 \* Bug model: must violate PauseLeadsToBroadcast.
 \* TLC should report invariant or property violation.
+\*
+\* CHECK_DEADLOCK FALSE: NextBuggy drops WatchdogEmit + Recycle, so keepers
+\* that reach PauseHuman/StaleRunning get stuck (Resolve requires emitted=TRUE).
+\* Without this option TLC reports "Deadlock reached" and exits *before*
+\* checking PROPERTIES, masking the intended PauseLeadsToBroadcast violation.
+\* Precedent: specs/cascade/CascadeAttemptLiveness-buggy.cfg,
+\*            specs/multimodal/MultimodalArtifact-buggy.cfg
+\* (same bug-model-shape: removed action -> stuck phase -> deadlock-not-property).
+\* iter 87 OPB R-12 (#14977) flagged this as a follow-up; iter 97 closes it.
 SPECIFICATION SpecBuggy
+CHECK_DEADLOCK
+  FALSE
 CONSTANTS
   Keepers = {k1, k2}
 INVARIANTS


### PR DESCRIPTION
## Finding (Iteration 97, R-12.a — `OperatorPauseBroadcast-buggy.cfg` deadlock-vs-property fix)

**Spec**: `specs/keeper-state-machine/OperatorPauseBroadcast-buggy.cfg` (cfg only, model body unchanged)
**Aspect**: iter 87 #14977이 명시한 `-buggy.cfg` pre-existing quirk 해소 — `Deadlock reached`가 `PauseLeadsToBroadcast` property violation을 *masking* 하던 문제.
**Risk**: LOW (cfg-only, 1 option line 추가, model body byte-identical, clean cfg 무영향)
**Workaround signature**: N/A — TLC standard option (`CHECK_DEADLOCK FALSE`) 적용

## 순서도 — buggy 실행 경로 (5-step counterexample)

```mermaid
flowchart LR
  S0["Init<br/>k1,k2: Idle<br/>emitted: FALSE"] --> S1
  S1["StartTurn(k2)<br/>k2: Running"] --> S2
  S2["StartTurn(k1)<br/>k1,k2: Running"] --> S3
  S3["EnterStaleRunning(k1)<br/>k1: StaleRunning"] --> S4
  S4["EnterStaleRunning(k2)<br/>k1,k2: StaleRunning"] --> S5
  S5["Stutter forever<br/>(NextBuggy has no<br/>WatchdogEmit/Recycle)"] -.->|"emitted stays FALSE<br/>∴ PauseLeadsToBroadcast<br/>violated"| VIOLATION["TLC exit 13<br/>property violation"]

  classDef bad fill:#fdd,stroke:#a00
  class VIOLATION bad
```

## 문제 진단

`NextBuggy ==  StartTurn ∨ EnterPauseHumanBuggy ∨ EnterStaleRunning ∨ Resolve` — `WatchdogEmit`와 `Recycle`이 제거됨. `Resolve`는 `/\ emitted[k]` precondition을 요구하므로 `emitted=FALSE`인 keeper들은 enabled action 없음.

| | 이전 (CHECK_DEADLOCK 기본 TRUE) | 이후 (CHECK_DEADLOCK FALSE) |
|---|---|---|
| TLC behavior | `Deadlock reached` 즉시 종료 | stuttering 허용, temporal property 검사 진행 |
| Exit code | non-zero (deadlock) | 13 (property violation) |
| Counterexample 형태 | "no action enabled" — bug 의도 misrepresented | `PauseLeadsToBroadcast ~> emitted` violated trace — bug 의도 그대로 |
| 의도하는 bug 의미 | gate verdict이 silent로 사라짐 | 동일 — surface만 정확해짐 |

iter 87 #14977 audit memo가 명시한 "`-buggy.cfg`가 'should report ... property violation'이라 했으나 TLC는 `Deadlock reached`" — 이 PR이 해당 mismatch를 closing.

## Before / After

`specs/keeper-state-machine/OperatorPauseBroadcast-buggy.cfg`:

```diff
  \* Bug model: must violate PauseLeadsToBroadcast.
  \* TLC should report invariant or property violation.
+ \*
+ \* CHECK_DEADLOCK FALSE: NextBuggy drops WatchdogEmit + Recycle, so keepers
+ \* that reach PauseHuman/StaleRunning get stuck (Resolve requires emitted=TRUE).
+ \* Without this option TLC reports "Deadlock reached" and exits *before*
+ \* checking PROPERTIES, masking the intended PauseLeadsToBroadcast violation.
+ \* Precedent: specs/cascade/CascadeAttemptLiveness-buggy.cfg,
+ \*            specs/multimodal/MultimodalArtifact-buggy.cfg
+ \* (same bug-model-shape: removed action -> stuck phase -> deadlock-not-property).
+ \* iter 87 OPB R-12 (#14977) flagged this as a follow-up; iter 97 closes it.
  SPECIFICATION SpecBuggy
+ CHECK_DEADLOCK
+   FALSE
  CONSTANTS
    Keepers = {k1, k2}
  INVARIANTS
    TypeOK
  PROPERTIES
    PauseLeadsToBroadcast
```

(+12/-0 LOC, cfg-only single file)

## 왜 이게 *iteration* 인가

iter 87 OPB first-entry audit (#14977 MERGED)이 명시한 standing follow-up. `OperatorPauseBroadcast-buggy` family pattern (iter 81 `KeeperMemoryLifecycle-buggy` `TypeOK`-first 같은 family — bug 모델이 의도된 violation을 deadlock으로 가리는 *masking pattern*) 의 한 instance 닫기. precedent 두 개 (`CascadeAttemptLiveness-buggy.cfg`, `MultimodalArtifact-buggy.cfg`) 그대로 적용.

## Verification

- [x] **Clean unchanged**: `tlc -config OperatorPauseBroadcast.cfg OperatorPauseBroadcast.tla` → 85 states / 36 distinct / depth 7 / no error / exit 0. 동일 (no regression).
- [x] **Buggy now surfaces property violation**: `tlc -config OperatorPauseBroadcast-buggy.cfg OperatorPauseBroadcast.tla` → 5-step counterexample (k1,k2 모두 StaleRunning에서 stutter, emitted stays FALSE) → `PauseLeadsToBroadcast` violated → exit 13. TLC warning: "stuttering counterexample may be caused by the absence of a fairness constraint in SpecBuggy" — 이게 정확히 bug 모델의 의도 (`SpecBuggy`는 `WF_vars(WatchdogEmit)` 없음).
- [x] **Model body byte-identical**: `git diff specs/keeper-state-machine/OperatorPauseBroadcast.tla` empty. INDEX hash 변경 없음.
- [x] **TLC artifacts cleanup**: `bash scripts/cleanup-tlc-artifacts.sh` 실행, `.bin`/`.fp`/`.st`/`TTrace_*.tla` 잔존물 없음.
- [x] **`bash ~/me/scripts/pr-rfc-check.sh --pr-body /tmp/pr-iter97-body.md`** (rfc-exit=0)

## Trade-off

`CHECK_DEADLOCK FALSE`는 *이 bug spec에서만* 적용 — clean spec은 deadlock check를 유지해야 (Recycle action이 누락되면 catch). bug 모델의 deadlock은 *intentional structural artifact* (action 누락의 부산물)이므로 check를 끄는 게 정확한 의미론.

대안 (검토 후 reject):
- (a) `NextBuggy`에 `EnterPauseHumanBuggy` (no-emit)에 추가로 `Resolve_buggy` (precondition `emitted[k]` 제거)를 추가 → keeper가 진행은 하지만 verdict는 sink — but 그러면 PauseLeadsToBroadcast가 *반드시* 위반된다고 보장하기 어렵고, bug 모델이 spec 본문 변경 유발 (이 PR scope 밖).
- (b) `NextBuggy ∨ UNCHANGED vars` (explicit stutter) — TLA+ semantics에서 stuttering은 항상 가능하므로 redundant; `CHECK_DEADLOCK FALSE`가 더 표준적.

## RFC 참조

`RFC-WAIVED: notification lifecycle (operator broadcast addressability), credential/identity/sandbox/dashboard/hooks/workflow subsystem 미접촉. cfg-only 단일 옵션 추가. precedent 2개 동일 패턴 (CascadeAttemptLiveness-buggy.cfg, MultimodalArtifact-buggy.cfg) 적용.`

## 진행 추적

다음 iteration 시작점: 후보 — KeeperWorkPipeline 모델 버그 fix (KNOWN_FAILURES, exit 13 — iter 88 standing follow-up, clean spec invariant 위반, dormant aspirational spec 우선순위 낮음) OR R-D-2.a+R-D-1.a 번들 (KCAF, MID ~150-300 LOC) OR KSM A-5 (22×19 update_conditions matrix) OR 다음 first-entry spec 탐색.

`buggy-cfg masking pattern` 닫힘 (instance 1: OPB. KMC-buggy `TypeOK`-first도 family 멤버이지만 별개 — `TypeOK` invariant order 문제로 다른 fix shape 필요). 같은 family의 다른 spec 발견되면 동일 fix 적용.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
