### PR TITLE
Use living candidate liveness budgets

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -20,9 +20,6 @@ is-non-interactive = true
 type = "env"
 key = "ANTHROPIC_API_KEY"
 
-[providers.claude_code.liveness]
-class = "cloud_fast"
-
 # Behavioral capabilities — RFC-0058 §2.4 Phase 5.1.
 # Replaces the OCaml `tool_policy` record and per-kind matches in
 # cascade_transport / provider_tool_support / keeper_usage_trust.
@@ -43,9 +40,6 @@ is-non-interactive = true
 type = "env"
 key = "OPENAI_API_KEY"
 
-[providers.codex_cli.liveness]
-class = "cloud_fast"
-
 [providers.codex_cli.capabilities]
 # Codex CLI's cached login cannot inject arbitrary per-request headers,
 # so keeper-bound actor tools must be bridged via argv (per-keeper auth
@@ -63,9 +57,6 @@ is-non-interactive = true
 [providers.gemini_cli.credentials]
 type = "env"
 key = "GEMINI_API_KEY"
-
-[providers.gemini_cli.liveness]
-class = "cloud_fast"
 
 # Gemini CLI carries one capability — it is intended as a viable
 # bound-actor fallback target for cascades that include Codex CLI
@@ -93,9 +84,6 @@ is-non-interactive = true
 type = "env"
 key = "MOONSHOT_API_KEY"
 
-[providers.kimi_cli.liveness]
-class = "cloud_thinking"
-
 [providers.kimi_cli.capabilities]
 supports-runtime-mcp-http-headers = true
 tolerates-bound-actor-fallback = true
@@ -109,24 +97,14 @@ endpoint = "https://api.z.ai/api/coding/paas/v4"
 type = "env"
 key = "ZAI_API_KEY"
 
-[providers.glm-coding.liveness]
-class = "cloud_thinking"
-
 # glm-coding ships no [capabilities] sub-table — no runtime MCP HTTP
 # headers, no anthropic caching. Parser yields `capabilities = None`;
 # A.3 callers treat `None` as the conservative defaults.
-
-# Provider liveness class (RFC-0058 §3.2.1) feeds attempt-wall budgets
-# in Cascade_attempt_liveness_config. Values: cloud_fast | cloud_thinking
-# | local_27b | local_70b_plus.
 
 [providers.ollama]
 display-name = "Ollama Local"
 protocol = "ollama-http"
 endpoint = "http://localhost:11434"
-
-[providers.ollama.liveness]
-class = "local_27b"
 
 [providers.ollama.capabilities]
 # Local Ollama is a viable bound-actor fallback target in catalogs

--- a/docs/rfc/RFC-0022-cascade-attempt-liveness.md
+++ b/docs/rfc/RFC-0022-cascade-attempt-liveness.md
@@ -143,7 +143,7 @@ because their probable causes differ:
 
 ## 4. Design
 
-### 4.1 Three-tier attempt liveness gate
+### 4.1 Living attempt liveness gate
 
 ```ocaml
 (** Attempt liveness budget. All durations in seconds. *)
@@ -154,17 +154,19 @@ type liveness_budget = {
 }
 ```
 
-Recommended defaults (per cascade profile, override-able):
+The first attempt for a concrete provider/model candidate uses an
+explicit bootstrap budget. After successful streaming attempts exist,
+the runtime derives the budget from recent successful samples for that
+same candidate:
 
-| Profile | TTFT | Inter-chunk | Wall |
+| Source | TTFT | Inter-chunk | Wall |
 |---|---|---|---|
-| `cloud_fast` (codex_cli, claude, gemini) | 30s | 20s | 180s |
-| `cloud_thinking` (any with `thinking=true`) | 60s | 30s | 300s |
-| `local_27b` (ollama_only, llama-server) | 120s | 60s | 900s |
-| `local_70b+` | 240s | 90s | 1800s |
+| bootstrap | conservative fixed floor | conservative fixed floor | conservative fixed floor |
+| observed success | padded P95 successful TTFT | padded P95 successful max gap | padded P95 successful wall |
 
-The values are starting points; final values must be empirically
-calibrated against the 14-keeper diag table after PR-A merge.
+Rejected, killed, errored, or cancelled attempts do not train the
+budget. There is no provider-size taxonomy in this RFC: model labels
+must not imply liveness classes.
 
 ### 4.2 Thinking-aware
 
@@ -374,7 +376,8 @@ need a higher value (60-90s) under load.
 | `lib/cascade/cascade_health_tracker.ml` | classify attempt-liveness failures into `persistent` vs `transient` per §3 table |
 | `lib/cascade/cascade_config.ml` | add `liveness_budget` field per profile |
 | `lib/cascade/cascade_config.mli` | surface `liveness_budget` reader |
-| `config/cascade.toml` | add seed values per profile (cloud_fast / cloud_thinking / local_27b / local_70b+) |
+| `config/cascade.toml` | no liveness class; runtime learns from successful concrete candidates |
+| `lib/cascade/cascade_attempt_liveness_config.ml` | bootstrap budget plus recent successful sample store |
 | `lib/config/env_config_keeper.ml` | env override hooks for the three thresholds (per profile) |
 | `lib/keeper/keeper_hooks_oas.ml` | bridge `Stream_chunk` events to RFC-0012 `record_progress` (Invariant L1) |
 | `test/test_cascade_attempt_liveness.ml` (new) | property tests (§9) |
@@ -397,7 +400,8 @@ The decision table in §4.5 is the source of truth. Tests:
    `Keeper_registry.record_progress` advance at the same monotonic
    time.
 4. **Thinking protection.** A 600s thinking-only stream with chunks
-   every 5s is *not* killed under `cloud_thinking` profile.
+   every 5s is *not* killed when the candidate's observed-success
+   budget allows that stream shape.
 5. **Hung-first-byte.** A provider that holds the connection without
    any chunks is killed at exactly TTFT_MAX (±10ms).
 6. **Mid-stream stall.** A provider that sends 3 chunks then stalls
@@ -416,10 +420,11 @@ Phase A (default-off, observation only) — **wiring landed (PR-2)**:
 - `observe`: liveness clock runs, kills emit `masc_cascade_attempt_liveness_kill_total{mode=observe}` and `masc_cascade_attempt_liveness_observed_total{outcome=...}` but no `Switch.fail`; cascade still advances on real wire errors.
 - 24h on dev base path; compare `diag-keeper-cycle.sh` MAX_S/P95.
 
-Phase B (enforce per profile):
-- Flip per-profile to `enforce`. Start with `cloud_fast` (lowest blast radius — short answers).
+Phase B (enforce with living budgets):
+- Flip liveness to `enforce` after observe-mode samples show the bootstrap and observed-success budgets are not producing false positives.
 - Watch `cascade_attempt_liveness_kill_total{kind=...}` Prometheus counter.
-- Roll up to `cloud_thinking`, then `local_27b`, last `local_70b+`.
+- Inspect budget source labels (`bootstrap` vs `observed_success`) in
+  debug logs and receipts while candidate histories warm up.
 
 Phase C (default `enforce` everywhere):
 - After a 2-week soak with no false-positive reports, default flips
@@ -459,7 +464,8 @@ Phase C (default `enforce` everywhere):
   RFC/test minimum useful post-admission provider run window.
 - Provider-side cost metrics (covered by RFC-0009 Phase 3).
 - Wholesale replacement of OAS HTTP single-bulk-read with chunked. That is `feedback_oas_execution_uncancellable_mid_turn` ("masc-mcp 단독 fix 영역 zero").
-- Per-keeper liveness override (deferred — start with per-profile).
+- Per-keeper liveness override (deferred — start with per-candidate
+  living budgets).
 
 ## 11. Open questions
 
@@ -468,13 +474,13 @@ Phase C (default `enforce` everywhere):
    reasoning), Invariant T1 fires `No_first_token` and we kill what
    was actually a healthy long-think. Mitigation: server-side
    heartbeat is standard on all currently-cascaded providers; if a
-   future provider lacks it, gate it behind a profile that disables
-   TTFT (set `ttft_max = wall_max`).
+   future provider lacks it, it needs a dedicated runtime lane or an
+   explicit bootstrap override that accounts for that transport.
 
 2. **Inter-chunk vs token-rate.** A provider streaming at 0.5 tok/s
-   passes inter-chunk on `local_27b` (60s) but feels dead to a
-   keeper. Token-rate-aware liveness is a follow-up RFC; this RFC
-   uses inter-chunk only to avoid over-engineering Phase A.
+   may pass inter-chunk but still feel dead to a keeper.
+   Token-rate-aware liveness is a follow-up RFC; this RFC uses
+   inter-chunk only to avoid over-engineering Phase A.
 
 3. **Calibration data freshness.** Defaults in §4.1 are starting
    points. Final values come from `diag-keeper-cycle.sh` after Phase
@@ -495,7 +501,7 @@ Phase C (default `enforce` everywhere):
 | Formal (mutation) | TLC on `-buggy.cfg` | invariant violated |
 | Empirical pre | `diag-keeper-cycle.sh` snapshot | recorded as baseline |
 | Empirical post Phase A | `diag-keeper-cycle.sh` 24h | counter `cascade_attempt_liveness_kill_total{mode=observe}` non-zero on at least one provider; no behaviour change |
-| Empirical post Phase B (cloud_fast) | `diag-keeper-cycle.sh` 24h | P95_S for affected keepers drops by ≥30% versus baseline |
+| Empirical post Phase B | `diag-keeper-cycle.sh` 24h | P95_S for affected keepers drops by ≥30% versus baseline without false-positive kills |
 | Soak | 2 weeks Phase B | zero false-positive reports |
 
 ## 13. References

--- a/docs/rfc/RFC-0022-cascade-attempt-liveness.md
+++ b/docs/rfc/RFC-0022-cascade-attempt-liveness.md
@@ -413,10 +413,10 @@ The decision table in §4.5 is the source of truth. Tests:
 
 ## 9. Operational rollout
 
-Phase A (default-off, observation only) — **wiring landed (PR-2)**:
+Phase A (historical observation rollout) — **wiring landed (PR-2)**:
 - FSM module + tests in PR-1 (`lib/cascade/cascade_attempt_liveness.{ml,mli}`).
 - Observer + tick fiber + `oas_worker_named.ml::try_provider` integration in PR-2 (`lib/cascade/cascade_attempt_liveness_observer.{ml,mli}`, `lib/cascade/cascade_attempt_liveness_config.{ml,mli}`).
-- Behind `MASC_CASCADE_ATTEMPT_LIVENESS=off|observe|enforce` (default `observe`).
+- Behind `MASC_CASCADE_ATTEMPT_LIVENESS=off|observe|enforce`. Current runtime default is `enforce` when the env var is unset; an empty or unknown value resolves to `observe`.
 - `observe`: liveness clock runs, kills emit `masc_cascade_attempt_liveness_kill_total{mode=observe}` and `masc_cascade_attempt_liveness_observed_total{outcome=...}` but no `Switch.fail`; cascade still advances on real wire errors.
 - 24h on dev base path; compare `diag-keeper-cycle.sh` MAX_S/P95.
 

--- a/docs/rfc/RFC-0058-declarative-cascade-config.md
+++ b/docs/rfc/RFC-0058-declarative-cascade-config.md
@@ -234,33 +234,14 @@ key = "OPENAI_API_KEY"
 | `key` | string | For `env`: variable name |
 | `path` | string | For `file`: file path |
 
-#### 3.2.1 Liveness sub-table `[providers.<p>.liveness]`
+#### 3.2.1 No provider liveness sub-table
 
-Schema-only at Phase 5.2a: parsed and validated but not yet consumed by
-callers. Intended to replace the cascade-prefix → budget match table in
-`cascade_attempt_liveness_config.budget_for_label` in a follow-up phase.
-When wired, the class will select which `Cascade_attempt_liveness` budget
-the attempt-wall observer applies when no streaming observer is attached.
-
-```toml
-[providers.claude_code.liveness]
-class = "cloud_fast"
-
-[providers.glm-coding.liveness]
-class = "cloud_thinking"
-
-[providers.ollama.liveness]
-class = "local_27b"
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `class` | string | One of `"cloud_fast"`, `"cloud_thinking"`, `"local_27b"`, `"local_70b_plus"` |
-
-`class` is optional. When absent, callers fall back to their pre-Phase-5.2
-default (`cloud_fast`) — this preserves behavior for any provider that
-has not yet been classified. Unknown values emit a parser warning and
-are treated as absent.
+Attempt liveness is deliberately not a provider schema field. The
+runtime starts with an explicit bootstrap budget, then learns from
+recent successful samples for each concrete provider/model candidate.
+Failed, killed, rejected, or cancelled attempts do not train the
+budget. This keeps model-size labels and provider ids out of the
+liveness taxonomy.
 
 ### 3.3 Layer 2: Models
 

--- a/docs/rfc/RFC-0058-phase-5-erase-provider-variant.md
+++ b/docs/rfc/RFC-0058-phase-5-erase-provider-variant.md
@@ -68,32 +68,31 @@ Phased to keep `main` green at every step. Each step is one PR.
 - Caller-site grep: `provider_tool_support`, `runtime_mcp_policy_requires_http_headers`,
   `codex_cli_identity_runtime_mcp_header`. Each becomes a TOML lookup.
 
-### Phase 5.2 — Move liveness tunables to TOML
+### Phase 5.2 — Remove static liveness classes
 
-Split into two PRs to keep the schema migration reversible.
+The provider-level liveness schema was superseded before productization.
+Do not add a provider liveness sub-table or provider liveness class field
+back to declarative cascade config.
 
-**Phase 5.2a (schema only) — this PR**
-- Add `cascade_liveness_class` type + `liveness_class` field on
-  `cascade_provider`.
-- Parser reads `[providers.<p>.liveness] class = "cloud_fast" | …` into
-  the new field. Unknown / missing values are tolerated (parser warns;
-  validator does not flag).
-- `config/cascade.toml` declares a `liveness` sub-table on every shipped
-  provider.
-- Caller (`Cascade_attempt_liveness_config.budget_for_label`) is
-  **unchanged** — keeps its hardcoded match. The TOML data is parsed but
-  not yet consumed. This keeps the schema additive: rolling back means
-  ignoring the new field, no behaviour change.
+Runtime liveness now uses:
 
-**Phase 5.2b (caller migration) — follow-up PR**
-- `budget_for_label` is replaced by `budget_for_provider_id ~cfg`.
-  `keeper_turn_driver_try_provider.ml` passes the provider id (not the
-  cascade label string) and reads the cascade config.
+- an explicit bootstrap budget for candidates with no successful history,
+- recent successful attempt samples keyed by concrete provider/model candidate,
+- no training from failed, killed, rejected, or cancelled attempts.
+
+This keeps provider ids and model-size labels out of liveness policy.
+Follow-up hardening should focus on receipts/debug surfaces that expose
+the candidate key, budget source (`bootstrap` or `observed_success`), and
+resolved budget used for the attempt.
+
+**Former Phase 5.2b caller migration — obsolete**
+- Do not replace the old match with a provider-id keyed budget lookup;
+  that still makes provider identity the budget taxonomy. Keeper dispatch
+  should use a concrete provider/model candidate key.
 - The hardcoded `match cascade_prefix with "codex_cli" | "claude_code" |
-  …` block is deleted.
-- Promote the parser's missing-class tolerance to a validator R-rule
-  (every shipped provider must declare `liveness.class`) so future
-  provider entries cannot regress to the silent fallback.
+  …` block is deleted without replacing it with static provider classes.
+- If validator rules are added, they should ensure no shipped provider
+  declares a liveness class so future entries cannot silently regress.
 
 ### Phase 5.3 — Erase `cascade_prefix` literals from `provider_adapter`
 
@@ -164,8 +163,9 @@ For each Phase 5.N PR:
   fixtures and migration tools excluded).
 - G3: `dune build --root .` and `dune test` pass. Test fixtures may be
   amended in the same PR but production cascade.toml schema does not change.
-- G4: New TOML fields (`[providers.<p>.capabilities]`, `[providers.<p>.liveness]`,
-  provider `aliases`) ship with parser + R-rule validator coverage.
+- G4: New TOML fields (`[providers.<p>.capabilities]`, provider `aliases`)
+  ship with parser + R-rule validator coverage. Provider liveness classes
+  remain absent.
 
 ## 6. Risks
 

--- a/lib/cascade/cascade_attempt_liveness.ml
+++ b/lib/cascade/cascade_attempt_liveness.ml
@@ -13,24 +13,12 @@ type budget = {
   attempt_wall_max : float;
 }
 
-(* §4.1 Recommended starting points. Final values must be empirically
-   calibrated against [scripts/diag-keeper-cycle.sh] output after
-   PR-2 wiring is enabled in [observe] mode. *)
-
-let cloud_fast : budget =
-  { ttft_max = 30.0; inter_chunk_max = 20.0; attempt_wall_max = 180.0 }
-
-let cloud_thinking : budget =
-  { ttft_max = 60.0; inter_chunk_max = 30.0; attempt_wall_max = 300.0 }
-
-(* Calibrated 2026-05-09 against cold-start TTFT for qwen3.6:27b-coding-nvfp4
-   on Apple Silicon: 452s cold vs 31s warm (same prompt). Previous 180s
-   rejected legitimate cold-start turns before first token. *)
-let local_27b : budget =
-  { ttft_max = 600.0; inter_chunk_max = 90.0; attempt_wall_max = 1200.0 }
-
-let local_70b_plus : budget =
-  { ttft_max = 300.0; inter_chunk_max = 120.0; attempt_wall_max = 1800.0 }
+(* Conservative first-attempt budget used before the runtime has observed a
+   successful sample for the concrete provider/model candidate. Later attempts
+   are tuned from successful TTFT/inter-chunk/wall samples in
+   [Cascade_attempt_liveness_config]. *)
+let bootstrap : budget =
+  { ttft_max = 600.0; inter_chunk_max = 120.0; attempt_wall_max = 1800.0 }
 
 module Stream_chunk = struct
   type kind =

--- a/lib/cascade/cascade_attempt_liveness.mli
+++ b/lib/cascade/cascade_attempt_liveness.mli
@@ -46,17 +46,10 @@ type budget = {
   (** Hard backstop on total attempt wall-clock duration. *)
 }
 
-val cloud_fast : budget
-(** [30s / 20s / 180s] — [codex_cli], [claude], [gemini] short answers. *)
-
-val cloud_thinking : budget
-(** [60s / 30s / 300s] — adaptive-reasoning models with thinking deltas. *)
-
-val local_27b : budget
-(** [120s / 60s / 900s] — [ollama_only], [llama-server] mid-size local. *)
-
-val local_70b_plus : budget
-(** [240s / 90s / 1800s] — [70B+] local backstop. *)
+val bootstrap : budget
+(** Conservative first-attempt budget used only until
+    {!Cascade_attempt_liveness_config} has recent successful samples for the
+    concrete provider/model candidate. *)
 
 (** {1 Stream chunk taxonomy}
 

--- a/lib/cascade/cascade_attempt_liveness_config.ml
+++ b/lib/cascade/cascade_attempt_liveness_config.ml
@@ -1,6 +1,6 @@
 (* See cascade_attempt_liveness_config.mli for documentation.
 
-   RFC-0022 PR-2/4 §2 — tri-state env flag + per-label budget map. *)
+   RFC-0022 PR-2/4 §2 — tri-state env flag + living budget map. *)
 
 type mode =
   | Off
@@ -38,39 +38,158 @@ let current_mode () =
 
 let reset_cache_for_test () = mode_cache := None
 
-(* Per-label budget catalog — RFC-0022 PR-2 §2.
+type success_sample =
+  { ttft_ms : float
+  ; max_inter_chunk_ms : float
+  ; wall_ms : float
+  }
 
-   Cloud streaming providers (codex_cli, claude_code, gemini_cli) use
-   [cloud_fast] as a TTFT-strict budget that matches their typical short
-   answer latency. Adaptive-reasoning models (glm-coding which streams
-   thinking deltas, kimi-for-coding) get [cloud_thinking].
+type budget_source =
+  | Bootstrap
+  | Observed_success of { samples : int }
 
-   Local providers stay on the larger [local_27b] / [local_70b_plus]
-   budgets to avoid killing slow local models. *)
+type resolved_budget =
+  { budget : Cascade_attempt_liveness.budget
+  ; source : budget_source
+  }
 
-let budget_for_provider_id ~(provider_id : string) :
-    Cascade_attempt_liveness.budget =
-  let canon = String.lowercase_ascii (String.trim provider_id) in
-  match canon with
-  | "codex_cli" | "claude_code" | "claude" | "gemini_cli" | "gemini" ->
-      Cascade_attempt_liveness.cloud_fast
-  | "glm-coding" | "glm_coding" | "glm" | "kimi_cli" | "kimi-for-coding"
-  | "kimi" ->
-      Cascade_attempt_liveness.cloud_thinking
-  | "ollama_only" | "llama-server" | "llama_server" ->
-      Cascade_attempt_liveness.local_27b
-  | "local_70b" | "local_70b_plus" | "ollama_70b" ->
-      Cascade_attempt_liveness.local_70b_plus
-  | _ -> Cascade_attempt_liveness.cloud_fast
+let budget_source_label = function
+  | Bootstrap -> "bootstrap"
+  | Observed_success _ -> "observed_success"
+
+let success_history : (string, success_sample list) Hashtbl.t = Hashtbl.create 64
+let success_history_mu = Stdlib.Mutex.create ()
+
+let with_success_history_lock f =
+  Stdlib.Mutex.lock success_history_mu;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock success_history_mu) f
+
+let success_history_limit =
+  match Sys.getenv_opt "MASC_CASCADE_LIVENESS_SUCCESS_HISTORY_SIZE" with
+  | None | Some "" -> 32
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | Some n -> max 1 (min 256 n)
+     | None -> 32)
+
+let finite_non_negative v = Float.is_finite v && Float.compare v 0.0 >= 0
+
+let valid_sample (s : success_sample) =
+  finite_non_negative s.ttft_ms
+  && finite_non_negative s.max_inter_chunk_ms
+  && finite_non_negative s.wall_ms
+
+let take limit values =
+  let rec loop n acc = function
+    | [] -> List.rev acc
+    | _ when n <= 0 -> List.rev acc
+    | x :: rest -> loop (n - 1) (x :: acc) rest
+  in
+  loop limit [] values
+
+let record_success_sample ~candidate_key (sample : success_sample) =
+  let key = String.trim candidate_key in
+  if key = "" || not (valid_sample sample) then ()
+  else
+    with_success_history_lock (fun () ->
+        let current =
+          match Hashtbl.find_opt success_history key with
+          | Some samples -> samples
+          | None -> []
+        in
+        Hashtbl.replace success_history key (take success_history_limit (sample :: current)))
+
+let reset_success_history_for_test () =
+  with_success_history_lock (fun () -> Hashtbl.clear success_history)
+
+let success_sample_count_for_test ~candidate_key =
+  let key = String.trim candidate_key in
+  with_success_history_lock (fun () ->
+      match Hashtbl.find_opt success_history key with
+      | Some samples -> List.length samples
+      | None -> 0)
+
+let percentile p values =
+  match List.sort Float.compare values with
+  | [] -> None
+  | sorted ->
+    let len = List.length sorted in
+    let raw_idx = int_of_float (ceil (p *. float_of_int len)) - 1 in
+    let idx = max 0 (min (len - 1) raw_idx) in
+    List.nth_opt sorted idx
+
+let seconds_of_ms ms = ms /. 1000.0
+
+let clamp_float ~floor ~ceiling v =
+  Float.max floor (Float.min ceiling v)
+
+let tuned_seconds ~floor ~ceiling ~multiplier ~add seconds =
+  clamp_float ~floor ~ceiling ((seconds *. multiplier) +. add)
+
+let budget_of_samples samples =
+  let p95 field = percentile 0.95 (List.map field samples) in
+  match p95 (fun s -> s.ttft_ms), p95 (fun s -> s.max_inter_chunk_ms),
+        p95 (fun s -> s.wall_ms) with
+  | Some ttft_ms, Some inter_ms, Some wall_ms ->
+    let ttft_max =
+      tuned_seconds
+        ~floor:30.0
+        ~ceiling:900.0
+        ~multiplier:1.5
+        ~add:5.0
+        (seconds_of_ms ttft_ms)
+    in
+    let inter_chunk_max =
+      tuned_seconds
+        ~floor:20.0
+        ~ceiling:240.0
+        ~multiplier:2.0
+        ~add:5.0
+        (seconds_of_ms inter_ms)
+    in
+    let observed_wall =
+      tuned_seconds
+        ~floor:180.0
+        ~ceiling:3600.0
+        ~multiplier:1.4
+        ~add:30.0
+        (seconds_of_ms wall_ms)
+    in
+    let attempt_wall_max =
+      Float.max observed_wall (ttft_max +. inter_chunk_max)
+    in
+    { Cascade_attempt_liveness.ttft_max = ttft_max
+    ; inter_chunk_max
+    ; attempt_wall_max
+    }
+  | _ -> Cascade_attempt_liveness.bootstrap
+
+let budget_for_candidate ~candidate_key =
+  let key = String.trim candidate_key in
+  let samples =
+    if key = "" then []
+    else
+      with_success_history_lock (fun () ->
+          match Hashtbl.find_opt success_history key with
+          | Some samples -> samples
+          | None -> [])
+  in
+  match samples with
+  | [] -> { budget = Cascade_attempt_liveness.bootstrap; source = Bootstrap }
+  | samples ->
+    { budget = budget_of_samples samples
+    ; source = Observed_success { samples = List.length samples }
+    }
 
 (* RFC-0022 §1 — see .mli for contract. *)
 let outer_wall_for_attempt
-    ~mode ~observer_attached ~per_provider_timeout_s ~provider_id =
+    ~mode ~observer_attached ~per_provider_timeout_s ~candidate_key =
   match mode, observer_attached with
   | Enforce, true -> None
   | _, true ->
+      let resolved = budget_for_candidate ~candidate_key in
       let budget_wall =
-        (budget_for_provider_id ~provider_id).Cascade_attempt_liveness.attempt_wall_max
+        resolved.budget.Cascade_attempt_liveness.attempt_wall_max
       in
       Option.map
         (fun t -> Float.max t budget_wall)

--- a/lib/cascade/cascade_attempt_liveness_config.ml
+++ b/lib/cascade/cascade_attempt_liveness_config.ml
@@ -58,6 +58,7 @@ let budget_source_label = function
   | Observed_success _ -> "observed_success"
 
 let success_history : (string, success_sample list) Hashtbl.t = Hashtbl.create 64
+let success_history_order : string list ref = ref []
 let success_history_mu = Stdlib.Mutex.create ()
 
 let with_success_history_lock f =
@@ -71,6 +72,14 @@ let success_history_limit =
     (match int_of_string_opt (String.trim raw) with
      | Some n -> max 1 (min 256 n)
      | None -> 32)
+
+let success_history_candidate_limit =
+  match Sys.getenv_opt "MASC_CASCADE_LIVENESS_SUCCESS_CANDIDATES" with
+  | None | Some "" -> 128
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | Some n -> max 1 (min 2048 n)
+     | None -> 128)
 
 let finite_non_negative v = Float.is_finite v && Float.compare v 0.0 >= 0
 
@@ -87,11 +96,32 @@ let take limit values =
   in
   loop limit [] values
 
+let take_drop limit values =
+  let rec loop n kept = function
+    | [] -> List.rev kept, []
+    | rest when n <= 0 -> List.rev kept, rest
+    | x :: rest -> loop (n - 1) (x :: kept) rest
+  in
+  loop limit [] values
+
+let remember_candidate_key key =
+  success_history_order
+  := key
+     :: List.filter
+          (fun existing -> not (String.equal existing key))
+          !success_history_order;
+  let kept, evicted =
+    take_drop success_history_candidate_limit !success_history_order
+  in
+  success_history_order := kept;
+  List.iter (Hashtbl.remove success_history) evicted
+
 let record_success_sample ~candidate_key (sample : success_sample) =
   let key = String.trim candidate_key in
   if key = "" || not (valid_sample sample) then ()
   else
     with_success_history_lock (fun () ->
+        remember_candidate_key key;
         let current =
           match Hashtbl.find_opt success_history key with
           | Some samples -> samples
@@ -100,7 +130,9 @@ let record_success_sample ~candidate_key (sample : success_sample) =
         Hashtbl.replace success_history key (take success_history_limit (sample :: current)))
 
 let reset_success_history_for_test () =
-  with_success_history_lock (fun () -> Hashtbl.clear success_history)
+  with_success_history_lock (fun () ->
+      Hashtbl.clear success_history;
+      success_history_order := [])
 
 let success_sample_count_for_test ~candidate_key =
   let key = String.trim candidate_key in

--- a/lib/cascade/cascade_attempt_liveness_config.mli
+++ b/lib/cascade/cascade_attempt_liveness_config.mli
@@ -63,7 +63,9 @@ val budget_for_candidate : candidate_key:string -> resolved_budget
 val record_success_sample :
   candidate_key:string -> success_sample -> unit
 (** Append a successful attempt timing sample for [candidate_key]. Invalid
-    negative/non-finite values are ignored. *)
+    negative/non-finite values are ignored. Each candidate keeps at most
+    [MASC_CASCADE_LIVENESS_SUCCESS_HISTORY_SIZE] samples, and the process keeps
+    at most [MASC_CASCADE_LIVENESS_SUCCESS_CANDIDATES] candidate keys. *)
 
 val reset_cache_for_test : unit -> unit
 (** Test-only: reset the cached flag read so a new value of

--- a/lib/cascade/cascade_attempt_liveness_config.mli
+++ b/lib/cascade/cascade_attempt_liveness_config.mli
@@ -1,4 +1,4 @@
-(** Tri-state env flag + per-label budget lookup for the cascade
+(** Tri-state env flag + living budget selection for the cascade
     attempt-liveness gate (RFC-0022 PR-2/4 §2).
 
     The flag [MASC_CASCADE_ATTEMPT_LIVENESS] selects one of three modes:
@@ -8,7 +8,8 @@
     - [enforce]  — observer raises [Liveness_kill] via [Eio.Switch.fail]
                    on the first {!Cascade_attempt_liveness.Outcome}.
 
-    Default is [observe] (RFC-0022 §9 Phase A).
+    When the env var is absent, current production default is [enforce].
+    Empty or unparseable values resolve to [observe].
 
     The mode is read once and cached on first call (mirrors
     [Keeper_admission_glue.use_new_admission]) so that mid-attempt env
@@ -25,38 +26,61 @@ type mode =
 val current_mode : unit -> mode
 (** Cached env-flag read. First call reads
     [MASC_CASCADE_ATTEMPT_LIVENESS] and caches the result. Subsequent
-    calls return the cached value. Default when unset / unparseable is
-    {!Observe}. *)
+    calls return the cached value. *)
 
 val mode_label : mode -> string
 (** Stable label for telemetry / Prometheus counter values. One of
     [off | observe | enforce]. *)
 
-val budget_for_provider_id :
-  provider_id:string -> Cascade_attempt_liveness.budget
-(** Map a cascade [provider_id] (e.g. [codex_cli], [claude_code],
-    [gemini_cli], [glm-coding], [ollama_only], [llama-server]) to a
-    per-profile budget.
+type success_sample =
+  { ttft_ms : float
+  ; max_inter_chunk_ms : float
+  ; wall_ms : float
+  }
+(** Successful attempt timing sample for one concrete provider/model
+    candidate. Values are milliseconds and are recorded only after the
+    liveness FSM reaches [Success]. Failed, killed, or rejected attempts do not
+    train future budgets. *)
 
-    The argument is the {b provider} dispatch key — not a model id.
-    Callers should pass the value from
-    [Provider_adapter.provider_label_of_config provider_cfg] or an
-    equivalent provider-level identifier.
+type budget_source =
+  | Bootstrap
+  | Observed_success of { samples : int }
 
-    Unknown provider ids fall back to
-    {!Cascade_attempt_liveness.cloud_fast} which is the conservative
-    cloud-streaming default. *)
+type resolved_budget =
+  { budget : Cascade_attempt_liveness.budget
+  ; source : budget_source
+  }
+
+val budget_source_label : budget_source -> string
+(** Stable debug/receipt label: [bootstrap] or [observed_success]. *)
+
+val budget_for_candidate : candidate_key:string -> resolved_budget
+(** Resolve the budget for a concrete provider/model candidate. The key should
+    be derived from [Provider_adapter.provider_model_health_key_of_config] or
+    an equivalent model-scoped runtime key. When no successful samples exist,
+    returns {!Cascade_attempt_liveness.bootstrap} with [source = Bootstrap]. *)
+
+val record_success_sample :
+  candidate_key:string -> success_sample -> unit
+(** Append a successful attempt timing sample for [candidate_key]. Invalid
+    negative/non-finite values are ignored. *)
 
 val reset_cache_for_test : unit -> unit
 (** Test-only: reset the cached flag read so a new value of
     [MASC_CASCADE_ATTEMPT_LIVENESS] takes effect. Production callers
     must not invoke this. *)
 
+val reset_success_history_for_test : unit -> unit
+(** Test-only: clear the in-process success-history budget store. *)
+
+val success_sample_count_for_test : candidate_key:string -> int
+(** Test-only: number of retained samples for [candidate_key]. *)
+
 val outer_wall_for_attempt
   :  mode:mode
   -> observer_attached:bool
   -> per_provider_timeout_s:float option
-  -> provider_id:string
+  -> candidate_key:string
   -> float option
 (** RFC-0022 §1 — backstop wall for the legacy [per_provider_timeout_s]
     knob.
@@ -70,10 +94,10 @@ val outer_wall_for_attempt
       attempt wall budget breach. The legacy outer wall must not
       pre-empt it.
     - [Off] / [Observe] + observer attached: returns
-      [Some (max t (budget_for_provider_id ~provider_id).attempt_wall_max)]
-      when [per_provider_timeout_s = Some t]. Slow-but-legitimate
-      streams (local Ollama 27B / 70B+) get the profile's attempt wall
-      so the legacy 120s knob cannot prematurely fall back the cascade.
+      [Some (max t (budget_for_candidate ~candidate_key).budget.attempt_wall_max)]
+      when [per_provider_timeout_s = Some t]. Successful prior attempts for
+      the same candidate can raise the legacy wall so a slow-but-honest stream
+      is not killed before the liveness observer's own deadline.
     - No observer attached (any mode): returns [per_provider_timeout_s]
       unchanged. Without an observer there is no per-provider budget
       to clamp against, so the caller's legacy knob is honored as-is.

--- a/lib/cascade/cascade_attempt_liveness_observer.ml
+++ b/lib/cascade/cascade_attempt_liveness_observer.ml
@@ -13,6 +13,12 @@ type t = {
   budget : L.budget;
   cascade_label : string;
   provider_label : string;
+  candidate_key : string option;
+  started_at : float;
+  first_chunk_at : float option ref;
+  last_chunk_at : float option ref;
+  max_inter_chunk_s : float ref;
+  success_sample : (string * Cfg.success_sample) option ref;
   state : L.state ref;
   sw_ref : Eio.Switch.t option ref;
   finalized : bool ref;
@@ -20,12 +26,19 @@ type t = {
 
 let mode (t : t) : Cfg.mode = t.mode
 
-let create ~mode ~budget ~cascade_label ~provider_label ~started_at =
+let create ~mode ~budget ~cascade_label ~provider_label ?candidate_key
+    ~started_at () =
   {
     mode;
     budget;
     cascade_label;
     provider_label;
+    candidate_key;
+    started_at;
+    first_chunk_at = ref None;
+    last_chunk_at = ref None;
+    max_inter_chunk_s = ref 0.0;
+    success_sample = ref None;
     state = ref (L.initial ~started_at);
     sw_ref = ref None;
     finalized = ref false;
@@ -128,6 +141,18 @@ let react_to_output (t : t) (output : L.output) : unit =
 
 let now_seconds () = Time_compat.now ()
 
+let observe_chunk_clock (t : t) ~(at : float) : unit =
+  (match !(t.first_chunk_at) with
+   | None -> t.first_chunk_at := Some at
+   | Some _ -> ());
+  (match !(t.last_chunk_at) with
+   | None -> ()
+   | Some prev ->
+     let gap = at -. prev in
+     if Float.is_finite gap && gap > !(t.max_inter_chunk_s)
+     then t.max_inter_chunk_s := gap);
+  t.last_chunk_at := Some at
+
 let prometheus_recorder (t : t) : L.recorder =
   let labels = [ ("cascade", t.cascade_label); ("provider", t.provider_label) ] in
   {
@@ -155,6 +180,9 @@ let step_with_event (t : t) (evt : Agent_sdk.Types.sse_event) : unit =
     match liveness_event with
     | None -> ()
     | Some le ->
+        (match le with
+         | L.Chunk (_, at) -> observe_chunk_clock t ~at
+         | L.Tick _ | L.Provider_wire_error _ -> ());
         let new_state, output =
           L.step ~recorder:(prometheus_recorder t) t.budget !(t.state) le
         in
@@ -257,7 +285,19 @@ let finalize (t : t) : unit =
     | Cfg.Off -> ()
     | Cfg.Observe | Cfg.Enforce ->
         let outcome = outcome_of_state !(t.state) in
+        (match !(t.state), t.candidate_key, !(t.first_chunk_at), !(t.last_chunk_at) with
+         | L.Success, Some candidate_key, Some first_chunk_at, Some last_chunk_at ->
+           t.success_sample :=
+             Some
+               ( candidate_key
+               , { Cfg.ttft_ms = (first_chunk_at -. t.started_at) *. 1000.0
+                 ; max_inter_chunk_ms = !(t.max_inter_chunk_s) *. 1000.0
+                 ; wall_ms = (last_chunk_at -. t.started_at) *. 1000.0
+                 } )
+         | _ -> ());
         Prometheus.inc_counter
           Prometheus.metric_cascade_attempt_liveness_observed
           ~labels:(observed_labels t ~outcome) ()
   end
+
+let success_sample_for_candidate (t : t) = !(t.success_sample)

--- a/lib/cascade/cascade_attempt_liveness_observer.mli
+++ b/lib/cascade/cascade_attempt_liveness_observer.mli
@@ -47,12 +47,18 @@ val create :
   budget:Cascade_attempt_liveness.budget ->
   cascade_label:string ->
   provider_label:string ->
+  ?candidate_key:string ->
   started_at:float ->
+  unit ->
   t
 (** Build an observer for one cascade attempt.
 
-    [started_at] is the monotonic wall-clock the caller already
-    captured for [attempt_started_at] (oas_worker_named.ml:508).
+    [candidate_key], when supplied, is the concrete provider/model key that
+    identifies any successful timing sample exposed by
+    {!success_sample_for_candidate}.
+
+    [started_at] is the monotonic wall-clock the caller already captured for
+    the attempt start.
 
     The observer does not own the switch — see [start_tick_fiber]. *)
 
@@ -108,6 +114,13 @@ val finalize : t -> unit
       cancellation or upstream exception).
 
     Idempotent: calling twice emits the counter once. *)
+
+val success_sample_for_candidate :
+  t -> (string * Cascade_attempt_liveness_config.success_sample) option
+(** Return the successful timing sample captured by {!finalize}, paired
+    with the concrete provider/model candidate key. This function does not
+    mutate the living budget store; callers must record the sample only after
+    their own acceptance gate has accepted the response. *)
 
 val current_state_for_test : t -> Cascade_attempt_liveness.state
 (** Test-only accessor. Production callers must not depend on this. *)

--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -195,28 +195,6 @@ let parse_provider (id : string) (tbl : Otoml.t)
            None)
       | None -> None
     in
-    let liveness_class =
-      match Otoml.find_opt tbl Fun.id [ "liveness" ] with
-      | None -> None
-      | Some live_tbl ->
-        (match Otoml.find_opt live_tbl Otoml.get_string [ "class" ] with
-         | None -> None
-         | Some raw ->
-           (match String.lowercase_ascii (String.trim raw) with
-            | "cloud_fast" -> Some Cloud_fast
-            | "cloud_thinking" -> Some Cloud_thinking
-            | "local_27b" -> Some Local_27b
-            | "local_70b_plus" -> Some Local_70b_plus
-            | other ->
-              Logs.warn (fun m ->
-                m
-                  "cascade_declarative_parser: %s.liveness.class unknown value %S — \
-                   ignoring (expected one of cloud_fast, cloud_thinking, local_27b, \
-                   local_70b_plus)"
-                  path
-                  other);
-              None))
-    in
     let capabilities =
       Otoml.find_opt tbl Fun.id [ "capabilities" ]
       |> Option.map (parse_capabilities ~path)
@@ -234,7 +212,6 @@ let parse_provider (id : string) (tbl : Otoml.t)
       ; transport
       ; is_non_interactive
       ; credentials
-      ; liveness_class
       ; capabilities
       ; headers
       }

--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -25,20 +25,6 @@ type cascade_credential =
   | Inline of string
 [@@deriving show, eq]
 
-(** Per-provider liveness class — RFC-0058 §3.2.1 (Phase 5.2).
-    Schema only at this phase; the field is parsed and validated but
-    not yet consumed. Intended to replace the hardcoded cascade-prefix
-    → budget match table in
-    [Cascade_attempt_liveness_config.budget_for_label] in a follow-up
-    phase. The four classes correspond to existing budget constants in
-    [Cascade_attempt_liveness]. *)
-type cascade_liveness_class =
-  | Cloud_fast
-  | Cloud_thinking
-  | Local_27b
-  | Local_70b_plus
-[@@deriving show, eq]
-
 (** Per-provider runtime + behavioral capabilities — RFC-0058 §2.4 +
     Phase 5.1 (capability fields) + §3.2 Phase 5.6 (tool/event support).
 
@@ -115,7 +101,6 @@ type cascade_provider =
   ; transport : cascade_transport
   ; is_non_interactive : bool
   ; credentials : cascade_credential option
-  ; liveness_class : cascade_liveness_class option
   ; capabilities : cascade_capabilities option
   ; headers : (string * string) list option
   }

--- a/lib/cascade_decl/cascade_declarative_types.mli
+++ b/lib/cascade_decl/cascade_declarative_types.mli
@@ -33,19 +33,6 @@ type cascade_credential =
 
 (** {1 Layer 1: Providers} *)
 
-(** Per-provider liveness class — RFC-0058 §3.2.1 (Phase 5.2).
-    Schema only at this phase; the field is parsed and validated but
-    not yet consumed. Intended to replace the hardcoded cascade-prefix
-    → budget match table in
-    [Cascade_attempt_liveness_config.budget_for_label] in a follow-up
-    phase. *)
-type cascade_liveness_class =
-  | Cloud_fast
-  | Cloud_thinking
-  | Local_27b
-  | Local_70b_plus
-[@@deriving show, eq]
-
 (** Per-provider runtime + behavioral capabilities — RFC-0058 §2.4 +
     Phase 5.1 (caller cutover prep, A.1) + §3.2 Phase 5.6 (tool/event support).
 
@@ -78,7 +65,6 @@ type cascade_provider =
   ; transport : cascade_transport
   ; is_non_interactive : bool
   ; credentials : cascade_credential option
-  ; liveness_class : cascade_liveness_class option
   ; capabilities : cascade_capabilities option
     (** Caller cutover (A.3) replaces:
       - [Llm_provider.Capabilities.*] variant defaults (Phase 5.6, tool/event fields)

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -1007,12 +1007,11 @@ module KeeperRetryBackoff = struct
       @category Timeouts
       @ops_class operator
 
-      Calibrated to match [Cascade_attempt_liveness.local_27b.ttft_max]
-      (180 s) so that slow-but-honest Ollama 27B/70B streams are not
-      denied a degraded retry solely because their first-token latency
-      exceeds the old 60 s floor.  Cloud providers rarely need retries
-      at all; when they do, 180 s is still well within reasonable
-      tail latency. *)
+      Calibrated to the attempt-liveness bootstrap floor so that
+      slow-but-honest streams are not denied a degraded retry solely
+      because their first-token latency exceeds the old 60 s floor.
+      Providers with successful history can learn a wider candidate
+      budget without hard-coding provider or model-size classes. *)
   let degraded_retry_slot_phase_budget_sec =
     Float.max
       5.0

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -425,7 +425,17 @@ let run_named
           provider_cfg
       in
       let attempt_started_at = Unix.gettimeofday () in
-      let (result, checkpoint_after) = try_provider ?resume_checkpoint ?per_provider_timeout_s:pp_timeout provider_cfg in
+      let (result, checkpoint_after, liveness_success_sample) =
+        try_provider ?resume_checkpoint ?per_provider_timeout_s:pp_timeout provider_cfg
+      in
+      let record_accepted_liveness_sample () =
+        match liveness_success_sample with
+        | None -> ()
+        | Some (candidate_key, sample) ->
+          Cascade_attempt_liveness_config.record_success_sample
+            ~candidate_key
+            sample
+      in
       let attempt_latency_ms =
         (Unix.gettimeofday () -. attempt_started_at) *. 1000.0
       in
@@ -451,6 +461,7 @@ let run_named
          a single number, which would mislead strategy ranking. *)
       (match result with
       | Ok result when accept result.response ->
+        record_accepted_liveness_sample ();
         Cascade_health_tracker.(record_success global ~provider_key:provider_health_key
           ~latency_ms:attempt_latency_ms ());
         (* FSM: Call_ok → Accept *)
@@ -485,6 +496,7 @@ let run_named
           { response = result.response; reason } in
         (match Cascade_fsm.decide ~accept_on_exhaustion:false ~is_last outcome with
          | Cascade_fsm.Accept_on_exhaustion { response; _ } ->
+           record_accepted_liveness_sample ();
            let observation =
              Cascade_legacy_runner.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
@@ -538,6 +550,7 @@ let run_named
               real FSM contract violation, not a tunable. *)
            Cascade_metrics.on_cascade_invariant_violation ();
            Log.Misc.warn "cascade %s: unexpected Accept in Accept_rejected branch (model=%s)" cascade_name resp.model;
+           record_accepted_liveness_sample ();
            let observation =
              Cascade_legacy_runner.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -88,7 +88,9 @@ type try_provider_ctx =
     @param resume_checkpoint Checkpoint from a previous failed provider.
     @param per_provider_timeout_s Per-provider wall-clock timeout.
     @param provider_cfg The provider configuration to attempt.
-    @return [(result, checkpoint_after)] tuple. *)
+    @return [(result, checkpoint_after, liveness_success_sample)] tuple. The
+    sample is not recorded here; the caller records it only after the cascade
+    accept predicate accepts the response. *)
 let run_try_provider
       (ctx : try_provider_ctx)
       ?resume_checkpoint
@@ -174,28 +176,41 @@ let run_try_provider
   in
   let local_agent_ref : Agent_sdk.Agent.t option ref = ref None in
   match config_result with
-  | Error err -> Error err, None
+  | Error err -> Error err, None, None
   | Ok config ->
     let liveness_mode = Cascade_attempt_liveness_config.current_mode () in
-    (* Compute provider_id once so the liveness budget lookup and the
-       [outer_wall_for_attempt] dispatch key cannot diverge if
-       [provider_label_of_config] ever changes behavior. *)
-    let provider_id = Provider_adapter.provider_label_of_config provider_cfg in
+    (* Compute the concrete provider/model key once so liveness budget lookup,
+       success-history training, and the [outer_wall_for_attempt] dispatch key
+       cannot diverge. *)
+    let candidate_key =
+      Provider_adapter.provider_model_health_key_of_config provider_cfg
+    in
     let liveness_observer_opt =
       match liveness_mode with
       | Cascade_attempt_liveness_config.Off -> None
       | Cascade_attempt_liveness_config.Observe | Cascade_attempt_liveness_config.Enforce
         ->
-        let budget =
-          Cascade_attempt_liveness_config.budget_for_provider_id ~provider_id
+        let resolved_budget =
+          Cascade_attempt_liveness_config.budget_for_candidate ~candidate_key
         in
+        Log.Misc.debug
+          "cascade_attempt_liveness: candidate=%s budget_source=%s ttft=%.1fs \
+           inter_chunk=%.1fs wall=%.1fs"
+          candidate_key
+          (Cascade_attempt_liveness_config.budget_source_label
+             resolved_budget.source)
+          resolved_budget.budget.Cascade_attempt_liveness.ttft_max
+          resolved_budget.budget.Cascade_attempt_liveness.inter_chunk_max
+          resolved_budget.budget.Cascade_attempt_liveness.attempt_wall_max;
         let obs =
           Cascade_attempt_liveness_observer.create
             ~mode:liveness_mode
-            ~budget
+            ~budget:resolved_budget.budget
             ~cascade_label:ctx.cascade_name
             ~provider_label:provider_cfg.model_id
+            ~candidate_key
             ~started_at:(Time_compat.now ())
+            ()
         in
         Some obs
     in
@@ -203,6 +218,12 @@ let run_try_provider
       match liveness_observer_opt with
       | None -> ()
       | Some obs -> Cascade_attempt_liveness_observer.finalize obs
+    in
+    let liveness_success_sample () =
+      match liveness_observer_opt with
+      | None -> None
+      | Some obs ->
+        Cascade_attempt_liveness_observer.success_sample_for_candidate obs
     in
     let liveness_timeout_error failure =
       let kind = Cascade_attempt_liveness.failure_kind_label failure in
@@ -287,7 +308,7 @@ let run_try_provider
                     ~mode:liveness_mode
                     ~observer_attached:(Option.is_some liveness_observer_opt)
                     ~per_provider_timeout_s
-                    ~provider_id
+                    ~candidate_key
                 in
                 match outer_wall_for_provider with
                 | None -> run_fn ()
@@ -322,9 +343,10 @@ let run_try_provider
      with
      | Error err ->
        finalize_liveness ();
-       Error err, None
+       Error err, None, None
      | Ok result ->
        finalize_liveness ();
+       let liveness_success_sample = liveness_success_sample () in
        let result =
          Result.map_error
            (Cascade_attempt_fsm.enrich_sdk_error
@@ -337,5 +359,5 @@ let run_try_provider
            ?agent_ref:ctx.agent_ref
            !local_agent_ref
        in
-       result, checkpoint_after)
+       result, checkpoint_after, liveness_success_sample)
 ;;

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -185,6 +185,9 @@ let run_try_provider
     let candidate_key =
       Provider_adapter.provider_model_health_key_of_config provider_cfg
     in
+    let provider_label =
+      Provider_adapter.provider_label_of_config provider_cfg
+    in
     let liveness_observer_opt =
       match liveness_mode with
       | Cascade_attempt_liveness_config.Off -> None
@@ -207,7 +210,7 @@ let run_try_provider
             ~mode:liveness_mode
             ~budget:resolved_budget.budget
             ~cascade_label:ctx.cascade_name
-            ~provider_label:provider_cfg.model_id
+            ~provider_label
             ~candidate_key
             ~started_at:(Time_compat.now ())
             ()

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -531,10 +531,9 @@ val metric_cascade_capacity_events : string
     - [mode] ∈ [observe | enforce]
     - [provider] is the cascade label that produced the attempt
 
-    Use the {b observe}-mode counter to calibrate the per-profile
-    budgets (cloud_fast / cloud_thinking / local_27b / local_70b_plus)
-    against [scripts/diag-keeper-cycle.sh] before flipping any profile
-    to {b enforce}. *)
+    Use the {b observe}-mode counter to calibrate bootstrap and
+    observed-success budgets against [scripts/diag-keeper-cycle.sh]
+    before flipping attempt liveness to {b enforce}. *)
 val metric_cascade_attempt_liveness_kill : string
 
 (** RFC-0022 PR-2 §3 — per-attempt finalizer counter regardless of

--- a/test/test_cascade_attempt_liveness.ml
+++ b/test/test_cascade_attempt_liveness.ml
@@ -30,7 +30,8 @@ let check_output =
       | L.Completed -> Format.fprintf fmt "Completed")
     ( = )
 
-let budget = L.cloud_fast (* 30/20/180 *)
+let budget : L.budget =
+  { ttft_max = 30.0; inter_chunk_max = 20.0; attempt_wall_max = 180.0 }
 
 (* ──────────────────────── §4.5 decision table ──────────────────────── *)
 
@@ -135,11 +136,12 @@ let test_success_state_is_absorbing () =
 
 (* ──────────────────────── §8 property tests ──────────────────────── *)
 
-(* §8.4 Thinking protection — adaptive-reasoning model emits thinking
-   tokens every 5s for 600s under cloud_thinking profile (60/30/300).
-   Hits wall at 300s but never inter-chunk. *)
+(* §8.4 Thinking protection — a model emits thinking tokens every 5s
+   under a 60/30/300 budget. Hits wall at 300s but never inter-chunk. *)
 let test_thinking_protection_hits_wall_only () =
-  let b = L.cloud_thinking in
+  let b : L.budget =
+    { ttft_max = 60.0; inter_chunk_max = 30.0; attempt_wall_max = 300.0 }
+  in
   let s = ref (L.initial ~started_at:0.0) in
   let killed_by = ref None in
   let t = ref 0.0 in
@@ -171,7 +173,7 @@ let test_thinking_protection_hits_wall_only () =
 (* §8.5 Hung-first-byte — provider holds connection without any
    chunks. Killed at TTFT_MAX exactly. *)
 let test_hung_first_byte_kills_at_ttft () =
-  let b = L.cloud_fast in (* ttft_max = 30 *)
+  let b = budget in (* ttft_max = 30 *)
   let s = ref (L.initial ~started_at:0.0) in
   let kill_t = ref None in
   let t = ref 0.0 in
@@ -192,7 +194,7 @@ let test_hung_first_byte_kills_at_ttft () =
 (* §8.6 Mid-stream stall — 3 chunks then silence. Killed at
    last_chunk_at + IDLE_MAX. *)
 let test_mid_stream_stall_kills_at_idle () =
-  let b = L.cloud_fast in (* inter_chunk_max = 20 *)
+  let b = budget in (* inter_chunk_max = 20 *)
   let s = ref (L.initial ~started_at:0.0) in
   (* Three chunks at t=1, 2, 3 *)
   List.iter (fun t ->
@@ -220,7 +222,7 @@ let test_mid_stream_stall_kills_at_idle () =
 (* §8.7 Wall backstop — provider streams a token every (idle_max - 1)s
    indefinitely. Killed at WALL_MAX exactly. *)
 let test_wall_backstop_kills_at_wall_max () =
-  let b = L.cloud_fast in (* idle = 20, wall = 180 *)
+  let b = budget in (* idle = 20, wall = 180 *)
   let s = ref (L.initial ~started_at:0.0) in
   let kill_class = ref None in
   let t = ref 0.0 in

--- a/test/test_cascade_attempt_liveness_config.ml
+++ b/test/test_cascade_attempt_liveness_config.ml
@@ -1,8 +1,8 @@
 (** Tests for [Cascade_attempt_liveness_config] (RFC-0022 PR-2/4 §2).
 
-    Covers: env-flag parsing (default Observe, all aliases),
-    cache invalidation via reset_cache_for_test, and living success-history
-    budget selection. *)
+    Covers: env-flag parsing (unset defaults to Enforce; empty/unknown parse
+    as Observe), cache invalidation via reset_cache_for_test, and living
+    success-history budget selection. *)
 
 open Masc_mcp
 module Cfg = Cascade_attempt_liveness_config
@@ -10,15 +10,17 @@ module L = Cascade_attempt_liveness
 
 let env_var = "MASC_CASCADE_ATTEMPT_LIVENESS"
 
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
 let with_env value f =
   let prior = Sys.getenv_opt env_var in
   (match value with
-   | None -> Unix.putenv env_var ""
+   | None -> unsetenv env_var
    | Some v -> Unix.putenv env_var v);
   Cfg.reset_cache_for_test ();
   let restore () =
     (match prior with
-     | None -> Unix.putenv env_var ""
+     | None -> unsetenv env_var
      | Some v -> Unix.putenv env_var v);
     Cfg.reset_cache_for_test ()
   in
@@ -33,17 +35,13 @@ let check_mode label expected actual =
 
 (* -- mode parsing --------------------------------------------------- *)
 
+let test_unset_defaults_enforce () =
+  with_env None (fun () ->
+      check_mode "unset -> Enforce" Enforce (Cfg.current_mode ()))
+
 let test_empty_string_alias () =
-  let prior = Sys.getenv_opt env_var in
-  Unix.putenv env_var "";
-  Cfg.reset_cache_for_test ();
-  (* Empty string parses as Observe by parse_mode contract. *)
-  let m = Cfg.current_mode () in
-  (match prior with
-   | None -> Unix.putenv env_var ""
-   | Some v -> Unix.putenv env_var v);
-  Cfg.reset_cache_for_test ();
-  check_mode "empty string -> Observe" Observe m
+  with_env (Some "") (fun () ->
+      check_mode "empty string -> Observe" Observe (Cfg.current_mode ()))
 
 let test_observe_alias () =
   with_env (Some "observe") (fun () ->
@@ -159,11 +157,29 @@ let test_invalid_success_sample_ignored () =
     0
     (Cfg.success_sample_count_for_test ~candidate_key:"provider:model-a")
 
+let test_success_history_candidate_count_is_bounded () =
+  Cfg.reset_success_history_for_test ();
+  for i = 0 to 2049 do
+    Cfg.record_success_sample
+      ~candidate_key:(Printf.sprintf "provider:model-%03d" i)
+      { Cfg.ttft_ms = 1_000.0; max_inter_chunk_ms = 1_000.0; wall_ms = 2_000.0 }
+  done;
+  Alcotest.(check int)
+    "oldest candidate evicted"
+    0
+    (Cfg.success_sample_count_for_test ~candidate_key:"provider:model-000");
+  Alcotest.(check int)
+    "newest candidate retained"
+    1
+    (Cfg.success_sample_count_for_test ~candidate_key:"provider:model-2049")
+
 let () =
   Alcotest.run "cascade_attempt_liveness_config"
     [
       ( "mode parsing",
         [
+          Alcotest.test_case "unset -> enforce" `Quick
+            test_unset_defaults_enforce;
           Alcotest.test_case "empty string -> observe" `Quick
             test_empty_string_alias;
           Alcotest.test_case "observe" `Quick test_observe_alias;
@@ -193,5 +209,7 @@ let () =
             test_candidate_keys_are_model_scoped;
           Alcotest.test_case "invalid sample ignored" `Quick
             test_invalid_success_sample_ignored;
+          Alcotest.test_case "candidate count bounded" `Quick
+            test_success_history_candidate_count_is_bounded;
         ] );
     ]

--- a/test/test_cascade_attempt_liveness_config.ml
+++ b/test/test_cascade_attempt_liveness_config.ml
@@ -1,7 +1,8 @@
 (** Tests for [Cascade_attempt_liveness_config] (RFC-0022 PR-2/4 §2).
 
     Covers: env-flag parsing (default Observe, all aliases),
-    cache invalidation via reset_cache_for_test, label→budget mapping. *)
+    cache invalidation via reset_cache_for_test, and living success-history
+    budget selection. *)
 
 open Masc_mcp
 module Cfg = Cascade_attempt_liveness_config
@@ -32,7 +33,7 @@ let check_mode label expected actual =
 
 (* -- mode parsing --------------------------------------------------- *)
 
-let test_default_unset () =
+let test_empty_string_alias () =
   let prior = Sys.getenv_opt env_var in
   Unix.putenv env_var "";
   Cfg.reset_cache_for_test ();
@@ -97,7 +98,7 @@ let test_mode_labels () =
   Alcotest.(check string) "observe" "observe" (mode_label Observe);
   Alcotest.(check string) "enforce" "enforce" (mode_label Enforce)
 
-(* -- budget_for_provider_id ---------------------------------------- *)
+(* -- living budget selection --------------------------------------- *)
 
 let budget_eq (a : L.budget) (b : L.budget) =
   Float.equal a.ttft_max b.ttft_max
@@ -107,47 +108,64 @@ let budget_eq (a : L.budget) (b : L.budget) =
 let check_budget label expected actual =
   Alcotest.(check bool) label true (budget_eq expected actual)
 
-let test_budget_codex_cli () =
-  check_budget "codex_cli -> cloud_fast" L.cloud_fast
-    (Cfg.budget_for_provider_id ~provider_id:"codex_cli")
+let test_budget_bootstrap_when_empty () =
+  Cfg.reset_success_history_for_test ();
+  let resolved = Cfg.budget_for_candidate ~candidate_key:"provider:model-a" in
+  check_budget "empty history -> bootstrap" L.bootstrap resolved.budget;
+  Alcotest.(check string)
+    "source" "bootstrap" (Cfg.budget_source_label resolved.source)
 
-let test_budget_claude_code () =
-  check_budget "claude_code -> cloud_fast" L.cloud_fast
-    (Cfg.budget_for_provider_id ~provider_id:"claude_code")
+let test_record_success_sample_updates_candidate_budget () =
+  Cfg.reset_success_history_for_test ();
+  Cfg.record_success_sample
+    ~candidate_key:"provider:model-a"
+    { Cfg.ttft_ms = 42_000.0; max_inter_chunk_ms = 12_000.0; wall_ms = 90_000.0 };
+  let resolved = Cfg.budget_for_candidate ~candidate_key:"provider:model-a" in
+  Alcotest.(check string)
+    "source" "observed_success" (Cfg.budget_source_label resolved.source);
+  Alcotest.(check int)
+    "sample count" 1 (Cfg.success_sample_count_for_test ~candidate_key:"provider:model-a");
+  Alcotest.(check bool)
+    "ttft carries headroom over observed sample"
+    true
+    (resolved.budget.ttft_max > 42.0);
+  Alcotest.(check bool)
+    "wall remains above observed sample"
+    true
+    (resolved.budget.attempt_wall_max > 90.0)
 
-let test_budget_glm_coding () =
-  check_budget "glm-coding -> cloud_thinking" L.cloud_thinking
-    (Cfg.budget_for_provider_id ~provider_id:"glm-coding")
+let test_candidate_keys_are_model_scoped () =
+  Cfg.reset_success_history_for_test ();
+  Cfg.record_success_sample
+    ~candidate_key:"provider:model-fast"
+    { Cfg.ttft_ms = 1_000.0; max_inter_chunk_ms = 500.0; wall_ms = 20_000.0 };
+  Cfg.record_success_sample
+    ~candidate_key:"provider:model-slow"
+    { Cfg.ttft_ms = 120_000.0; max_inter_chunk_ms = 40_000.0; wall_ms = 600_000.0 };
+  let fast = Cfg.budget_for_candidate ~candidate_key:"provider:model-fast" in
+  let slow = Cfg.budget_for_candidate ~candidate_key:"provider:model-slow" in
+  Alcotest.(check bool)
+    "same provider can have different model budgets"
+    true
+    (slow.budget.attempt_wall_max > fast.budget.attempt_wall_max)
 
-let test_budget_kimi () =
-  check_budget "kimi-for-coding -> cloud_thinking" L.cloud_thinking
-    (Cfg.budget_for_provider_id ~provider_id:"kimi-for-coding")
-
-let test_budget_local () =
-  check_budget "ollama_only -> local_27b" L.local_27b
-    (Cfg.budget_for_provider_id ~provider_id:"ollama_only");
-  check_budget "llama-server -> local_27b" L.local_27b
-    (Cfg.budget_for_provider_id ~provider_id:"llama-server")
-
-let test_budget_local_70b () =
-  check_budget "local_70b_plus -> local_70b_plus" L.local_70b_plus
-    (Cfg.budget_for_provider_id ~provider_id:"local_70b_plus")
-
-let test_budget_unknown_default () =
-  check_budget "unknown -> cloud_fast" L.cloud_fast
-    (Cfg.budget_for_provider_id ~provider_id:"weird_provider_xyz")
-
-let test_budget_case_insensitive () =
-  check_budget "GLM-CODING -> cloud_thinking" L.cloud_thinking
-    (Cfg.budget_for_provider_id ~provider_id:"GLM-CODING")
+let test_invalid_success_sample_ignored () =
+  Cfg.reset_success_history_for_test ();
+  Cfg.record_success_sample
+    ~candidate_key:"provider:model-a"
+    { Cfg.ttft_ms = nan; max_inter_chunk_ms = 1.0; wall_ms = 2.0 };
+  Alcotest.(check int)
+    "invalid sample ignored"
+    0
+    (Cfg.success_sample_count_for_test ~candidate_key:"provider:model-a")
 
 let () =
   Alcotest.run "cascade_attempt_liveness_config"
     [
       ( "mode parsing",
         [
-          Alcotest.test_case "default unset -> observe" `Quick
-            test_default_unset;
+          Alcotest.test_case "empty string -> observe" `Quick
+            test_empty_string_alias;
           Alcotest.test_case "observe" `Quick test_observe_alias;
           Alcotest.test_case "off" `Quick test_off_alias;
           Alcotest.test_case "off via 0" `Quick test_off_zero;
@@ -165,17 +183,15 @@ let () =
         ] );
       ( "mode_label",
         [ Alcotest.test_case "stable labels" `Quick test_mode_labels ] );
-      ( "budget_for_provider_id",
+      ( "living budget",
         [
-          Alcotest.test_case "codex_cli" `Quick test_budget_codex_cli;
-          Alcotest.test_case "claude_code" `Quick test_budget_claude_code;
-          Alcotest.test_case "glm-coding" `Quick test_budget_glm_coding;
-          Alcotest.test_case "kimi-for-coding" `Quick test_budget_kimi;
-          Alcotest.test_case "local 27b" `Quick test_budget_local;
-          Alcotest.test_case "local 70b plus" `Quick test_budget_local_70b;
-          Alcotest.test_case "unknown -> cloud_fast" `Quick
-            test_budget_unknown_default;
-          Alcotest.test_case "case insensitive" `Quick
-            test_budget_case_insensitive;
+          Alcotest.test_case "empty history -> bootstrap" `Quick
+            test_budget_bootstrap_when_empty;
+          Alcotest.test_case "success sample updates budget" `Quick
+            test_record_success_sample_updates_candidate_budget;
+          Alcotest.test_case "candidate keys are model scoped" `Quick
+            test_candidate_keys_are_model_scoped;
+          Alcotest.test_case "invalid sample ignored" `Quick
+            test_invalid_success_sample_ignored;
         ] );
     ]

--- a/test/test_cascade_attempt_liveness_observer.ml
+++ b/test/test_cascade_attempt_liveness_observer.ml
@@ -15,11 +15,11 @@ module Obs = Cascade_attempt_liveness_observer
 
 (* -- helpers ------------------------------------------------------- *)
 
-let mk_observer ?(mode = Cfg.Observe) ?(budget = L.cloud_fast)
+let mk_observer ?(mode = Cfg.Observe) ?(budget = L.bootstrap)
     ?(cascade = "test_cascade") ?(provider = "test_provider")
-    ?(started_at = 0.0) () =
+    ?candidate_key ?(started_at = 0.0) () =
   Obs.create ~mode ~budget ~cascade_label:cascade ~provider_label:provider
-    ~started_at
+    ?candidate_key ~started_at ()
 
 let counter_value name labels =
   Prometheus.metric_value_or_zero name ~labels ()
@@ -157,6 +157,32 @@ let test_observe_finalize_emits_outcome () =
   Alcotest.(check (float 1e-6))
     "finalize is idempotent" after after2
 
+let test_success_sample_waits_for_accept_gate () =
+  let candidate_key = "provider:model-a" in
+  Cfg.reset_success_history_for_test ();
+  let obs =
+    mk_observer
+      ~mode:Cfg.Observe
+      ~candidate_key
+      ~started_at:(Time_compat.now ())
+      ()
+  in
+  let wrapped = Obs.wrap_on_event obs None in
+  (match wrapped with
+   | Some f -> f stop
+   | None -> Alcotest.fail "wrapper missing");
+  Obs.finalize obs;
+  Alcotest.(check bool)
+    "finalize exposes a success sample"
+    true
+    (match Obs.success_sample_for_candidate obs with
+     | Some (key, _) -> String.equal key candidate_key
+     | None -> false);
+  Alcotest.(check int)
+    "observer does not train budget before accept"
+    0
+    (Cfg.success_sample_count_for_test ~candidate_key)
+
 let test_observe_finalize_pending_is_wire_error () =
   let cascade = "observe_pending_cascade" in
   let provider = "observe_pending_provider" in
@@ -239,6 +265,8 @@ let () =
             test_observe_done_completes;
           Alcotest.test_case "finalize emits outcome and is idempotent"
             `Quick test_observe_finalize_emits_outcome;
+          Alcotest.test_case "success sample waits for accept gate" `Quick
+            test_success_sample_waits_for_accept_gate;
           Alcotest.test_case "pending finalize -> wire_error" `Quick
             test_observe_finalize_pending_is_wire_error;
         ] );

--- a/test/test_cascade_attempt_outer_wall.ml
+++ b/test/test_cascade_attempt_outer_wall.ml
@@ -1,19 +1,16 @@
-(** RFC-0022 §1 — outer-wall backstop respects the per-profile budget.
+(** RFC-0022 §1 — outer-wall backstop respects living candidate budgets.
 
     The legacy [per_provider_timeout_s] knob (default 120s) used to be
     enforced as a raw [Eio.Time.with_timeout_exn]. That pre-empted
-    attempts before the per-profile attempt-wall ([cloud_fast 180s],
-    [cloud_thinking 300s], [local_27b 900s], [local_70b_plus 1800s])
-    could fire — making slow local LLMs (Ollama) impossible to use.
+    attempts before the liveness observer's attempt-wall could fire.
 
     This module verifies the new contract enforced by
     {!Cascade_attempt_liveness_config.outer_wall_for_attempt}.
 
-    The Ollama scenario (slow streaming past 120s) is exercised at the
-    rule level: with [Enforce + observer] the outer wall returns
-    [None], and the observer drives cancellation. With [Observe /
-    Off + observer] the outer wall is raised to the profile's wall so
-    the legacy 120s knob cannot kill a healthy slow stream. *)
+    With [Enforce + observer] the outer wall returns [None], and the
+    observer drives cancellation. With [Observe / Off + observer] the
+    outer wall is raised to the candidate's living budget so the legacy
+    knob cannot kill a healthy slow stream. *)
 
 open Masc_mcp
 module Cfg = Cascade_attempt_liveness_config
@@ -30,7 +27,7 @@ let test_enforce_with_observer_returns_none () =
       ~mode:Cfg.Enforce
       ~observer_attached:true
       ~per_provider_timeout_s:(Some 120.0)
-      ~provider_id:"codex_cli"
+      ~candidate_key:"provider:model-a"
   in
   Alcotest.(check opt_f) "Enforce + observer → None" None actual
 
@@ -40,79 +37,91 @@ let test_enforce_with_observer_ollama_returns_none () =
       ~mode:Cfg.Enforce
       ~observer_attached:true
       ~per_provider_timeout_s:(Some 120.0)
-      ~provider_id:"ollama_only"
+      ~candidate_key:"provider:model-a"
   in
   Alcotest.(check opt_f)
     "Enforce + observer + ollama → None (observer is authority)"
     None actual
 
-(* ─── Observe / Off + observer: clip outer wall to profile budget ─── *)
+(* ─── Observe / Off + observer: clip outer wall to living budget ─── *)
 
-let test_observe_ollama_clips_to_local_27b_wall () =
+let test_observe_empty_history_clips_to_bootstrap_wall () =
+  Cfg.reset_success_history_for_test ();
   let actual =
     Cfg.outer_wall_for_attempt
       ~mode:Cfg.Observe
       ~observer_attached:true
       ~per_provider_timeout_s:(Some 120.0)
-      ~provider_id:"ollama_only"
+      ~candidate_key:"provider:model-a"
   in
   Alcotest.(check opt_f)
-    "Observe + ollama → local_27b wall 900s (not 120s)"
-    (Some L.local_27b.attempt_wall_max)
+    "Observe + empty history → bootstrap wall (not 120s)"
+    (Some L.bootstrap.attempt_wall_max)
     actual
 
-let test_off_ollama_clips_to_local_27b_wall () =
+let test_off_empty_history_clips_to_bootstrap_wall () =
+  Cfg.reset_success_history_for_test ();
   let actual =
     Cfg.outer_wall_for_attempt
       ~mode:Cfg.Off
       ~observer_attached:true
       ~per_provider_timeout_s:(Some 120.0)
-      ~provider_id:"llama-server"
+      ~candidate_key:"provider:model-a"
   in
   Alcotest.(check opt_f)
-    "Off + llama-server → local_27b wall 900s"
-    (Some L.local_27b.attempt_wall_max)
+    "Off + empty history → bootstrap wall"
+    (Some L.bootstrap.attempt_wall_max)
     actual
 
-let test_observe_ollama_70b_clips_to_local_70b_plus_wall () =
+let test_observed_success_history_clips_to_candidate_wall () =
+  Cfg.reset_success_history_for_test ();
+  Cfg.record_success_sample
+    ~candidate_key:"provider:model-a"
+    { Cfg.ttft_ms = 50_000.0; max_inter_chunk_ms = 10_000.0; wall_ms = 600_000.0 };
+  let expected =
+    let resolved = Cfg.budget_for_candidate ~candidate_key:"provider:model-a" in
+    resolved.budget.attempt_wall_max
+  in
   let actual =
     Cfg.outer_wall_for_attempt
       ~mode:Cfg.Observe
       ~observer_attached:true
       ~per_provider_timeout_s:(Some 120.0)
-      ~provider_id:"ollama_70b"
+      ~candidate_key:"provider:model-a"
   in
   Alcotest.(check opt_f)
-    "Observe + ollama_70b → local_70b_plus wall 1800s"
-    (Some L.local_70b_plus.attempt_wall_max)
+    "Observe + observed success history → candidate wall"
+    (Some expected)
     actual
 
-let test_observe_cloud_fast_keeps_user_t_when_larger () =
-  (* User explicitly set a larger budget than the profile default —
+let test_observe_keeps_user_t_when_larger () =
+  Cfg.reset_success_history_for_test ();
+  (* User explicitly set a larger budget than the bootstrap default —
      respect it. The clip rule is [max user_t profile_wall]. *)
   let actual =
     Cfg.outer_wall_for_attempt
       ~mode:Cfg.Observe
       ~observer_attached:true
-      ~per_provider_timeout_s:(Some 600.0)
-      ~provider_id:"codex_cli"
+      ~per_provider_timeout_s:(Some 3600.0)
+      ~candidate_key:"provider:model-a"
   in
   Alcotest.(check opt_f)
-    "Observe + codex_cli + user 600s → 600s (>cloud_fast 180s)"
-    (Some 600.0) actual
+    "Observe + user 3600s → 3600s (>bootstrap)"
+    (Some 3600.0) actual
 
-let test_observe_cloud_fast_clips_when_user_smaller () =
-  (* The legacy 120s knob is below cloud_fast 180s — clip up. *)
+let test_observe_bootstrap_clips_when_user_smaller () =
+  Cfg.reset_success_history_for_test ();
+  (* The legacy 120s knob is below bootstrap — clip up. *)
   let actual =
     Cfg.outer_wall_for_attempt
       ~mode:Cfg.Observe
       ~observer_attached:true
       ~per_provider_timeout_s:(Some 120.0)
-      ~provider_id:"codex_cli"
+      ~candidate_key:"provider:model-a"
   in
   Alcotest.(check opt_f)
-    "Observe + codex_cli + user 120s → cloud_fast 180s"
-    (Some L.cloud_fast.attempt_wall_max)
+    "Observe + user 120s → bootstrap wall"
+    (Some L.bootstrap.attempt_wall_max)
     actual
 
 (* ─── No observer: pass-through (legacy behaviour preserved) ─── *)
@@ -123,7 +132,7 @@ let test_no_observer_passes_through_user_value () =
       ~mode:Cfg.Off
       ~observer_attached:false
       ~per_provider_timeout_s:(Some 120.0)
-      ~provider_id:"ollama_only"
+      ~candidate_key:"provider:model-a"
   in
   Alcotest.(check opt_f)
     "Off + no observer → unchanged 120s (legacy)"
@@ -138,7 +147,7 @@ let test_enforce_without_observer_passes_through () =
       ~mode:Cfg.Enforce
       ~observer_attached:false
       ~per_provider_timeout_s:(Some 120.0)
-      ~provider_id:"codex_cli"
+      ~candidate_key:"provider:model-a"
   in
   Alcotest.(check opt_f)
     "Enforce + no observer → unchanged 120s (no silent drop)"
@@ -152,7 +161,7 @@ let test_none_input_stays_none_observe_with_observer () =
       ~mode:Cfg.Observe
       ~observer_attached:true
       ~per_provider_timeout_s:None
-      ~provider_id:"ollama_only"
+      ~candidate_key:"provider:model-a"
   in
   Alcotest.(check opt_f) "None input → None output" None actual
 
@@ -162,23 +171,24 @@ let test_none_input_stays_none_off_no_observer () =
       ~mode:Cfg.Off
       ~observer_attached:false
       ~per_provider_timeout_s:None
-      ~provider_id:"codex_cli"
+      ~candidate_key:"provider:model-a"
   in
   Alcotest.(check opt_f) "None + no observer → None" None actual
 
-(* ─── Unknown labels fall back to cloud_fast ─── *)
+(* ─── Unknown candidate keys fall back to explicit bootstrap ─── *)
 
-let test_unknown_label_falls_back_to_cloud_fast () =
+let test_unknown_candidate_uses_bootstrap () =
+  Cfg.reset_success_history_for_test ();
   let actual =
     Cfg.outer_wall_for_attempt
       ~mode:Cfg.Observe
       ~observer_attached:true
       ~per_provider_timeout_s:(Some 60.0)
-      ~provider_id:"some-future-provider"
+      ~candidate_key:"some-future-provider:some-model"
   in
   Alcotest.(check opt_f)
-    "Observe + unknown → cloud_fast 180s"
-    (Some L.cloud_fast.attempt_wall_max)
+    "Observe + unknown candidate → bootstrap"
+    (Some L.bootstrap.attempt_wall_max)
     actual
 
 let () =
@@ -193,16 +203,16 @@ let () =
         ] );
       ( "observe-clips-to-budget",
         [
-          Alcotest.test_case "ollama_only → local_27b wall" `Quick
-            test_observe_ollama_clips_to_local_27b_wall;
-          Alcotest.test_case "llama-server (Off) → local_27b wall" `Quick
-            test_off_ollama_clips_to_local_27b_wall;
-          Alcotest.test_case "ollama_70b → local_70b_plus wall" `Quick
-            test_observe_ollama_70b_clips_to_local_70b_plus_wall;
-          Alcotest.test_case "user 600s > cloud_fast 180s preserved" `Quick
-            test_observe_cloud_fast_keeps_user_t_when_larger;
-          Alcotest.test_case "user 120s < cloud_fast 180s clipped" `Quick
-            test_observe_cloud_fast_clips_when_user_smaller;
+          Alcotest.test_case "empty history → bootstrap wall" `Quick
+            test_observe_empty_history_clips_to_bootstrap_wall;
+          Alcotest.test_case "Off empty history → bootstrap wall" `Quick
+            test_off_empty_history_clips_to_bootstrap_wall;
+          Alcotest.test_case "observed history → candidate wall" `Quick
+            test_observed_success_history_clips_to_candidate_wall;
+          Alcotest.test_case "user 3600s > bootstrap preserved" `Quick
+            test_observe_keeps_user_t_when_larger;
+          Alcotest.test_case "user 120s < bootstrap clipped" `Quick
+            test_observe_bootstrap_clips_when_user_smaller;
         ] );
       ( "no-observer-pass-through",
         [
@@ -220,7 +230,7 @@ let () =
         ] );
       ( "fallback",
         [
-          Alcotest.test_case "unknown label → cloud_fast" `Quick
-            test_unknown_label_falls_back_to_cloud_fast;
+          Alcotest.test_case "unknown candidate → bootstrap" `Quick
+            test_unknown_candidate_uses_bootstrap;
         ] );
     ]

--- a/test/test_cascade_declarative_adapter.ml
+++ b/test/test_cascade_declarative_adapter.ml
@@ -263,7 +263,6 @@ let test_alias_parent_missing () =
           ; transport = Cli "x"
           ; is_non_interactive = false
           ; credentials = None
-          ; liveness_class = None
           ; capabilities = None
           ; headers = None
           }
@@ -529,7 +528,6 @@ let test_duplicate_routes () =
           ; transport = Cli "claude"
           ; is_non_interactive = false
           ; credentials = None
-          ; liveness_class = None
           ; capabilities = None
           ; headers = None
           }

--- a/test/test_cascade_declarative_parser.ml
+++ b/test/test_cascade_declarative_parser.ml
@@ -62,16 +62,10 @@ is-non-interactive = true
 type = "env"
 key = "ANTHROPIC_API_KEY"
 
-[providers.claude-code.liveness]
-class = "cloud_fast"
-
 [providers.ollama]
 provider-name = "Ollama Local"
 protocol = "ollama-http"
 endpoint = "http://localhost:11434"
-
-[providers.ollama.liveness]
-class = "local_27b"
 
 [models.haiku]
 api-name = "claude-haiku-4-5-20251001"
@@ -165,11 +159,6 @@ let test_layer1_providers () =
    | Some p ->
      check string "display_name" "Anthropic Claude Code CLI" p.display_name;
      check bool "non-interactive" true p.is_non_interactive;
-     check
-       (option string)
-       "claude liveness"
-       (Some "Cascade_declarative_types.Cloud_fast")
-       (Option.map show_cascade_liveness_class p.liveness_class);
      (match p.transport with
       | Cli cmd -> check string "cli cmd" "claude" cmd
       | Http _ -> failwith "expected Cli transport")
@@ -179,11 +168,6 @@ let test_layer1_providers () =
   match ollama with
   | Some p ->
     check string "display_name" "Ollama Local" p.display_name;
-    check
-      (option string)
-      "ollama liveness"
-      (Some "Cascade_declarative_types.Local_27b")
-      (Option.map show_cascade_liveness_class p.liveness_class);
     (match p.transport with
      | Http url -> check string "http url" "http://localhost:11434" url
      | Cli _ -> failwith "expected Http transport")
@@ -734,49 +718,6 @@ rate-limit-recency-window-s = 60.0
   match cfg.tiers with
   | [ t ] -> check bool "partial scoring yields None" true (t.scoring_params = None)
   | _ -> failwith "expected exactly one tier"
-;;
-
-(* --- Liveness class tests --- *)
-
-let test_liveness_class_unknown () =
-  let toml =
-    {|
-[providers.p]
-protocol = "anthropic-cli"
-command = "c"
-
-[providers.p.liveness]
-class = "nonexistent_class"
-|}
-  in
-  let cfg = ok_config (parse_string toml) in
-  match cfg.providers with
-  | [ p ] ->
-    check
-      (option string)
-      "unknown liveness yields None"
-      None
-      (Option.map show_cascade_liveness_class p.liveness_class)
-  | _ -> failwith "expected exactly one provider"
-;;
-
-let test_liveness_class_absent () =
-  let toml =
-    {|
-[providers.p]
-protocol = "anthropic-cli"
-command = "c"
-|}
-  in
-  let cfg = ok_config (parse_string toml) in
-  match cfg.providers with
-  | [ p ] ->
-    check
-      (option string)
-      "no liveness sub-table → None"
-      None
-      (Option.map show_cascade_liveness_class p.liveness_class)
-  | _ -> failwith "expected exactly one provider"
 ;;
 
 (* --- Capabilities tests (#14608 tool/event fields + RFC-0058 §2.4 Phase 5.1 dispatch fields) --- *)
@@ -1534,10 +1475,6 @@ let () =
     ; ( "scoring_params"
       , [ test_case "parses all 7 fields" `Quick test_scoring_params
         ; test_case "partial yields None" `Quick test_scoring_params_partial_ignored
-        ] )
-    ; ( "liveness_class"
-      , [ test_case "unknown value yields None" `Quick test_liveness_class_unknown
-        ; test_case "absent yields None" `Quick test_liveness_class_absent
         ] )
     ; ( "capabilities"
       , [ test_case "present parses with defaults" `Quick test_capabilities_present

--- a/test/test_oas_worker_named_liveness_integration.ml
+++ b/test/test_oas_worker_named_liveness_integration.ml
@@ -52,10 +52,10 @@ let test_env_off_short_circuits () =
         "off"
         (Cfg.mode_label (Cfg.current_mode ())))
 
-let test_env_observe_default () =
+let test_env_observe_empty_string_alias () =
   with_env None (fun () ->
       Alcotest.(check string)
-        "default -> Observe (RFC §9 Phase A)"
+        "empty string -> Observe"
         "observe"
         (Cfg.mode_label (Cfg.current_mode ())))
 
@@ -84,10 +84,12 @@ let test_e2e_observe_finalize_emits_observed_total () =
       let cascade = "integ_observe_cascade" in
       let provider = "integ_observe_provider" in
       let mode = Cfg.current_mode () in
-      let budget = Cfg.budget_for_provider_id ~provider_id:provider in
+      let budget =
+        (Cfg.budget_for_candidate ~candidate_key:("test:" ^ provider)).budget
+      in
       let obs =
         Obs.create ~mode ~budget ~cascade_label:cascade
-          ~provider_label:provider ~started_at:0.0
+          ~provider_label:provider ~started_at:0.0 ()
       in
       (* Simulate: provider streamed Done before any chunk -> Success. *)
       let wrapped = Obs.wrap_on_event obs None in
@@ -106,10 +108,12 @@ let test_e2e_off_no_observed_total () =
       let cascade = "integ_off_cascade" in
       let provider = "integ_off_provider" in
       let mode = Cfg.current_mode () in
-      let budget = Cfg.budget_for_provider_id ~provider_id:provider in
+      let budget =
+        (Cfg.budget_for_candidate ~candidate_key:("test:" ^ provider)).budget
+      in
       let obs =
         Obs.create ~mode ~budget ~cascade_label:cascade
-          ~provider_label:provider ~started_at:0.0
+          ~provider_label:provider ~started_at:0.0 ()
       in
       let before = observed_value cascade provider "wire_error" in
       Obs.finalize obs;
@@ -126,10 +130,12 @@ let test_enforce_registered_switch_kills_attempt_without_tick_clock () =
           try
             Eio.Switch.run (fun attempt_sw ->
                 let mode = Cfg.current_mode () in
-                let budget = Cfg.budget_for_provider_id ~provider_id:provider in
+                let budget =
+                  (Cfg.budget_for_candidate ~candidate_key:("test:" ^ provider)).budget
+                in
                 let obs =
                   Obs.create ~mode ~budget ~cascade_label:cascade
-                    ~provider_label:provider ~started_at:0.0
+                    ~provider_label:provider ~started_at:0.0 ()
                 in
                 Obs.register_attempt_switch obs ~sw:attempt_sw;
                 let wrapped = Obs.wrap_on_event obs None in
@@ -154,7 +160,8 @@ let () =
         [
           Alcotest.test_case "off short-circuits" `Quick
             test_env_off_short_circuits;
-          Alcotest.test_case "default observe" `Quick test_env_observe_default;
+          Alcotest.test_case "empty string observe" `Quick
+            test_env_observe_empty_string_alias;
           Alcotest.test_case "enforce alias" `Quick test_env_enforce;
         ] );
       ( "end to end",


### PR DESCRIPTION
## Summary

This PR replaces the static provider/model-size liveness taxonomy with a living budget model keyed by the concrete provider/model candidate.

The important behavior change is that liveness no longer asks whether a provider is a generic fast cloud lane, thinking lane, or local size class. It starts from an explicit bootstrap budget, observes accepted successful attempts for the exact candidate, and derives the next budget from those successful timings.

This is intended to supersede the provider-level liveness-class direction from PR #14905. A provider id or model-size label is not a stable runtime liveness contract.

## Why

The previous plan introduced declarative provider liveness classes such as cloud/thinking/local-size buckets. That is the wrong abstraction boundary for the keeper hot path:

- one provider can host multiple models with very different TTFT/inter-chunk/wall behavior,
- one model can change latency shape under load or transport mode,
- failed, killed, rejected, or schema-invalid attempts must not train future budgets,
- provider-lane resolution happens late enough that static TOML class data can diverge from the resolved attempt reality.

The new rule is narrower and easier to audit: only accepted successful attempts for the same concrete provider/model candidate can widen the future budget for that candidate.

## Runtime Flow

```mermaid
flowchart TD
    A[MASC selects provider/model candidate] --> B[Build candidate_key from resolved provider config]
    B --> C{Success history exists for candidate?}
    C -- no --> D[Use explicit bootstrap budget]
    C -- yes --> E[Compute budget from recent accepted successes]
    E --> E1[P95 TTFT + padding]
    E --> E2[P95 max inter-chunk gap + padding]
    E --> E3[P95 wall time + padding]
    D --> F[Create OAS liveness observer]
    E1 --> F
    E2 --> F
    E3 --> F
    F --> G[OAS provider attempt streams chunks]
    G --> H[Observer tracks first chunk, max gap, final wall]
    H --> I{Attempt result}
    I -- liveness kill/error/cancel --> J[No sample recorded]
    I -- OAS success --> K[Expose timing sample only]
    K --> L{MASC accept predicate passes?}
    L -- no: rejected --> J
    L -- yes: accepted --> M[Record success sample for candidate_key]
    M --> N[Future attempts use observed_success budget]
```

## Decision Sequence

```mermaid
sequenceDiagram
    participant MASC as MASC cascade driver
    participant CFG as Liveness config
    participant OBS as Liveness observer
    participant OAS as OAS Agent.run
    participant ACC as MASC accept gate

    MASC->>CFG: budget_for_candidate(candidate_key)
    alt no accepted samples
      CFG-->>MASC: bootstrap budget
    else accepted samples exist
      CFG-->>MASC: observed_success budget
    end
    MASC->>OBS: create(mode, budget, candidate_key)
    MASC->>OAS: run provider attempt with wrapped on_event
    OAS-->>OBS: stream events / chunks
    OBS-->>OBS: track TTFT, max inter-chunk, wall
    OAS-->>MASC: provider result
    MASC->>OBS: finalize()
    OBS-->>MASC: optional success timing sample
    MASC->>ACC: accept(response)
    alt accepted
      MASC->>CFG: record_success_sample(candidate_key, sample)
    else rejected/error/killed/cancelled
      MASC-->>CFG: no training
    end
```

## What Changed

- Removed provider-level liveness class parsing and types from declarative cascade config.
- Removed liveness sub-tables from `config/cascade.toml`.
- Replaced static budget constants with `bootstrap` plus candidate-keyed observed-success budgets.
- Changed `outer_wall_for_attempt` to use concrete `candidate_key` instead of provider id.
- Changed observer finalization so it exposes a success sample but does not mutate the budget store directly.
- Records success samples only after the cascade accept predicate accepts the response.
- Updated tests and RFC docs to make provider/model-size classes explicitly obsolete.

## Operator Impact

- Unknown or new candidates are conservative but not provider-id hardcoded.
- Accepted successful candidate history can safely widen future walls for slow-but-honest streams.
- Rejected responses cannot poison liveness budgets.
- Debug logs now include `candidate`, `budget_source`, and resolved TTFT/inter-chunk/wall values.

## Validation

Ran after rebasing on current `origin/main`:

- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_cascade_attempt_liveness_config.exe test/test_cascade_attempt_outer_wall.exe test/test_cascade_attempt_liveness_observer.exe test/test_oas_worker_named_liveness_integration.exe test/test_cascade_declarative_parser.exe test/test_cascade_declarative_adapter.exe`
- `_build/default/test/test_cascade_attempt_liveness_config.exe` — 15 tests
- `_build/default/test/test_cascade_attempt_outer_wall.exe` — 12 tests
- `_build/default/test/test_cascade_attempt_liveness_observer.exe` — 10 tests
- `_build/default/test/test_oas_worker_named_liveness_integration.exe` — 6 tests
- `_build/default/test/test_cascade_declarative_parser.exe` — 58 tests
- `_build/default/test/test_cascade_declarative_adapter.exe` — 17 tests
- `opam exec -- ocamlformat --check <touched .ml/.mli files>`
- `git diff --check HEAD~1 HEAD`

Note: `scripts/dune-local.sh` pin guard detected that the shared local `agent_sdk` opam pin is newer than this worktree's lock and refused to downgrade it. The focused build/test run therefore used `MASC_SKIP_PIN_CHECK=1` rather than mutating the shared opam pin backward.