### PR TITLE
docs(oas): define provider-free boundary contract

### DIFF
--- a/docs/CASCADE-TOML.md
+++ b/docs/CASCADE-TOML.md
@@ -27,6 +27,39 @@ When `cascade.toml` is present alongside `cascade.json`:
 
 Legacy `cascade.json`-only mode remains supported for backward compatibility.
 
+## Provider/Model-Free Contract
+
+`models = ["provider:model"]` entries are **configuration data**, not permission
+for MASC code to branch on provider or model literals.
+
+The runtime contract is:
+
+- MASC owns routes, profile selection, fallback, admission, health cooldown,
+  receipt, dashboard, and keeper-facing assignment policy.
+- OAS owns the generic single-provider runtime contract: provider catalog,
+  model/capability/pricing manifests, request/response adapters, and
+  non-interactive transport metadata.
+- MASC bridge/adapter code may parse provider/model labels and project
+  `cascade.toml` facts into OAS generic provider/capability contracts.
+- MASC core code must not hardcode vendor/model names for routing decisions.
+  It should route by logical use, declared capability, profile order, health,
+  and capacity.
+
+In practical terms, adding a cloud API provider that already follows an
+existing OAS wire protocol should be:
+
+1. Add or override an OAS provider catalog entry (`OAS_PROVIDER_CATALOG` or
+   embedding-time catalog install).
+2. Add the provider id/model label to `cascade.toml`.
+3. Add capability/pricing facts through OAS manifests when the defaults are not
+   enough.
+4. Run the cascade materialization and OAS boundary checks.
+
+Adding a subscription-backed CLI runtime is the same shape: the provider
+catalog declares `transport = "cli"`, cached-login auth, non-interactive
+readiness, and daemon safety; `cascade.toml` only references the opaque
+provider id selected by the operator.
+
 ## TOML Schema Reference
 
 ### Top-Level Comment
@@ -164,6 +197,11 @@ models = [
   { model = "glm-coding:auto", supports_tool_choice = true, weight = 2 },
 ]
 ```
+
+Provider ids in the examples above are repo seed examples only. Operators may
+use catalog-defined ids such as `"acme-cloud:acme-large"` or
+`"subscriber-codex:auto"` without requiring MASC code changes, provided the
+corresponding OAS provider/catalog capability contract exists.
 
 ## Checked-In Seed Policy
 

--- a/docs/CASCADE-TOML.md
+++ b/docs/CASCADE-TOML.md
@@ -53,7 +53,7 @@ existing OAS wire protocol should be:
 2. Add the provider id/model label to `cascade.toml`.
 3. Add capability/pricing facts through OAS manifests when the defaults are not
    enough.
-4. Run the cascade materialization and OAS boundary checks.
+4. Run `masc-mcp doctor` (or the dashboard raw_config endpoint) to validate the TOML parse and verify OAS boundary compliance.
 
 Adding a subscription-backed CLI runtime is the same shape: the provider
 catalog declares `transport = "cli"`, cached-login auth, non-interactive

--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -51,8 +51,8 @@ OAS  ──does not know──→ MASC
 
 ## Config Ownership
 
-- `config/cascade.toml`은 **MASC runtime contract**다. Legacy
-  `cascade.json`은 compatibility/fallback input일 뿐이며 새 authoring SSOT가 아니다.
+- `config/cascade.toml`은 **MASC runtime contract**다. On-disk
+  `cascade.json`은 legacy compatibility/fallback input일 뿐이며 새 authoring SSOT가 아니다. (MASC는 TOML에서 in-memory JSON representation을 렌더해 dashboard 등 소비자에게 제공한다.)
 - cascade schema, parsing, label semantics, selection policy의 owner는 MASC다.
 - MASC는 repo-level default와 keeper별 `cascade_name` override를 해석해 concrete provider/model 후보를 고른다.
 - OAS는 MASC가 선택한 concrete provider/model config를 실행하는 단일-provider runtime으로 남는다.

--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -51,10 +51,19 @@ OAS  ──does not know──→ MASC
 
 ## Config Ownership
 
-- `config/cascade.json`은 **MASC runtime contract**다.
+- `config/cascade.toml`은 **MASC runtime contract**다. Legacy
+  `cascade.json`은 compatibility/fallback input일 뿐이며 새 authoring SSOT가 아니다.
 - cascade schema, parsing, label semantics, selection policy의 owner는 MASC다.
 - MASC는 repo-level default와 keeper별 `cascade_name` override를 해석해 concrete provider/model 후보를 고른다.
 - OAS는 MASC가 선택한 concrete provider/model config를 실행하는 단일-provider runtime으로 남는다.
+- OAS provider catalog / capability manifest / pricing override는 generic
+  provider runtime contract다. MASC may project `cascade.toml` provider/model
+  facts into those OAS contracts, but OAS must not learn MASC routes,
+  keeper phases, tier-groups, board/governance semantics, or dashboard policy.
+- `provider/model-free` in MASC means MASC policy code routes by logical use,
+  declared capability, profile order, health, capacity, and receipt state; it
+  does not branch on vendor/model literals. Provider/model ids remain operator
+  configuration data.
 - 따라서 checked-in repo defaults는 review-stable pinning이 중요할 때 explicit `provider:model_id`를 쓰고, adapter default 자체를 계약으로 삼을 때만 `provider:auto`를 쓴다.
 - legacy `allowed_providers` keeper TOML/meta fields는 compatibility input일 뿐이며, active runtime policy로 취급하지 않는다.
 - persisted legacy keeper meta tool-policy fields are scrubbed into canonical `tool_access` on read; direct `meta_of_json` callers must use canonical keeper meta keys.
@@ -99,6 +108,8 @@ OAS  ──does not know──→ MASC
 
 These are the next changes that are generic enough to propose upstream:
 
+- generic provider catalog / model capability / pricing manifest contracts for
+  broad cloud APIs and non-interactive CLI/subscriber runtimes
 - harness case/result/verdict/repair-directive primitives that MASC evaluators can reuse
 - richer swarm `agent_entry` metadata so `planned_worker` routing and telemetry survive end to end
 - structured runtime-health probe callback to replace the current boolean `resource_check`
@@ -137,7 +148,8 @@ Use this checklist when reviewing boundary-touching PRs:
 1. **OAS가 MASC를 새로 알게 되는가?**
    - generic runtime/harness primitive가 아니라 room/task/governance/session semantics가 OAS public contract로 새어 나오면 안 된다.
 2. **MASC core가 provider/model 세부를 새로 배우는가?**
-   - model ID, vendor, token/cost detail은 OAS-facing adapter/bridge에 머물러야 한다.
+   - model ID, vendor, token/cost detail은 config 또는 OAS-facing adapter/bridge에 머물러야 한다.
+   - routing/policy code가 vendor/model literal로 분기하면 provider/model-free 위반이다.
 3. **문서 truth가 코드 truth와 일치하는가?**
    - 특히 cascade labels, runtime-health semantics, boundary-audit snapshot은 구현과 SSOT 문서가 함께 갱신되어야 한다.
 4. **Checked-in cascade labels are explicit enough for stable review**

--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -230,15 +230,24 @@ MASC Types.tool_schema
 
 ### 6.1 Cascade Name Resolution
 
-MASC는 직접 model_spec을 관리하지 않는다. `cascade_name`을 OAS에 넘기고, OAS `Cascade_config`가 실제 provider 선택을 수행한다.
+MASC owns cascade name resolution. The keeper path resolves `cascade_name`
+through the active MASC catalog and then calls OAS as a single-provider runtime
+for each selected attempt. OAS provider catalog and capability manifests are
+generic execution contracts; they are not the MASC cascade plane.
 
 ```
 cascade_name (e.g. "keeper", "verifier", "context_router")
-  -> config/cascade.json 에서 "{name}_models" 목록 조회
-  -> OAS Cascade_config.resolve_model_strings
-  -> OAS Cascade_config.parse_model_strings
-  -> Provider_config.t list (ordered by priority)
+  -> config/cascade.toml [routes] / profile lookup
+  -> MASC catalog model labels
+  -> MASC/OAS adapter resolves labels against OAS Provider_registry/catalog
+  -> Provider_config.t list (ordered by MASC policy)
+  -> OAS Agent.run single provider per attempt
 ```
+
+Provider/model-free here means MASC policy code does not branch on vendor or
+model literals. Provider/model ids remain operator-authored config data and may
+come from an OAS provider catalog for cloud APIs, local OpenAI-compatible
+servers, or non-interactive subscription CLI runtimes.
 
 ### 6.2 Cascade Inference Parameters
 
@@ -432,7 +441,7 @@ Static pre-filtering은 OAS Guardrails가, stateful per-call checks는 Eval_gate
 | Checkpoint | Partial | shared worker/runtime paths는 OAS Checkpoint를 사용한다. Public `Oas_worker` surface의 extra checkpoint JSON은 neutral `checkpoint_sidecar` 이름을 쓰지만 keeper 경로는 여전히 `lib/keeper/keeper_exec_context.ml`의 wrapper + serialized context를 유지 |
 | Memory bridge | Partial | Long_term + Episodic + Procedural bridged. Working/Scratchpad는 OAS 내부. 전체 통합은 미완 |
 | Team-session swarm | Partial | OAS Swarm runner 활성, bridge fidelity 불완전 |
-| Cascade config | Complete | cascade_name -> OAS Provider_registry -> Provider_config.t |
+| Cascade config | Complete | cascade_name -> MASC catalog/profile -> OAS Provider_registry/catalog -> Provider_config.t |
 | Verifier | Complete | PreToolUse hook + Guardrails adapter |
 | Model resolution | Complete | oas_model_resolve.ml이 Provider_Registry SSOT 사용 |
 | Tool bridge | Complete | MASC tool_schema -> OAS Tool.t 변환 |
@@ -498,7 +507,7 @@ Detailed implementation checklist lives in
 1. **의존 방향은 단방향이다**: MASC -> OAS. OAS 코드에 MASC import가 존재하면 설계 위반이다.
 2. **MASC는 OAS Agent.run을 사용한다**: 에이전트 생명주기를 자체 재구현하지 않는다. `Cascade.call` 직접 사용은 금지.
 3. **Message 타입은 공유한다**: `Agent_sdk.Types.message`가 MASC와 OAS 모두의 메시지 타입이다. 변환 레이어 없음.
-4. **Cascade name이 model을 추상화한다**: MASC 코드에 구체적 모델 이름이 하드코딩되지 않는다. cascade_name -> cascade.json -> Provider_Registry 체인.
+4. **Cascade name이 model을 추상화한다**: MASC policy code에 구체적 provider/model 이름이 하드코딩되지 않는다. cascade_name -> cascade.toml/catalog -> Provider_Registry/catalog 체인.
 5. **Event_bus prefix는 `masc:`이다**: MASC 이벤트는 반드시 이 prefix를 사용한다. SSE bridge가 이 prefix로 필터링한다.
 6. **Verifier는 read-only를 건너뛴다**: read/grep/search/status 류 도구는 MODEL 호출 없이 Pass를 반환한다.
 7. **Checkpoint는 session_id로 네임스페이스된다**: 동일 agent의 다른 세션 checkpoint와 충돌하지 않는다.

--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -507,7 +507,7 @@ Detailed implementation checklist lives in
 1. **의존 방향은 단방향이다**: MASC -> OAS. OAS 코드에 MASC import가 존재하면 설계 위반이다.
 2. **MASC는 OAS Agent.run을 사용한다**: 에이전트 생명주기를 자체 재구현하지 않는다. `Cascade.call` 직접 사용은 금지.
 3. **Message 타입은 공유한다**: `Agent_sdk.Types.message`가 MASC와 OAS 모두의 메시지 타입이다. 변환 레이어 없음.
-4. **Cascade name이 model을 추상화한다**: MASC policy code에 구체적 provider/model 이름이 하드코딩되지 않는다. cascade_name -> cascade.toml/catalog -> Provider_Registry/catalog 체인.
+4. **Cascade name이 model을 추상화한다**: MASC policy code에 구체적 provider/model 이름이 하드코딩되지 않는다. cascade_name -> cascade.toml/catalog -> Provider_registry/catalog 체인.
 5. **Event_bus prefix는 `masc:`이다**: MASC 이벤트는 반드시 이 prefix를 사용한다. SSE bridge가 이 prefix로 필터링한다.
 6. **Verifier는 read-only를 건너뛴다**: read/grep/search/status 류 도구는 MODEL 호출 없이 Pass를 반환한다.
 7. **Checkpoint는 session_id로 네임스페이스된다**: 동일 agent의 다른 세션 checkpoint와 충돌하지 않는다.


### PR DESCRIPTION
## Summary

Documents the MASC side of the provider-free/model-free boundary now that OAS exposes a generic provider catalog contract.

- defines the `cascade.toml` Provider/Model-Free Contract
- clarifies that MASC policy code routes by logical use, capability, profile order, health, and capacity rather than vendor/model literals
- records that OAS owns generic provider catalog, capability manifest, pricing, request/response adapter, and non-interactive transport metadata
- updates the OAS integration spec so MASC remains a downstream coordinator and OAS remains a generic single-provider runtime contract

## Operator impact

Adding a cloud API provider or subscriber CLI runtime should be done by adding an OAS provider catalog entry plus MASC `cascade.toml` references to opaque provider/model labels. The boundary docs now reject embedding vendor/model-specific routing logic in MASC core policy code.

## Validation

- `git diff --check origin/main...HEAD`

Known pre-existing environment/doc drift observed while checking broader gates:

- `scripts/check-oas-pin.sh --local-only` fails because the shared opam switch is pinned to newer local OAS `f7134446...`, while current MASC main expects `188efa67...`.
- `bash scripts/check-doc-truth.sh` fails on existing `ROADMAP` 0.19.17 vs `PRODUCT-OPERATING-PLAN` 0.19.11 version drift.
