### PR TITLE
[codex] Document ZAI coding plan cascade setup

### DIFF
--- a/docs/CASCADE-COOKBOOK.md
+++ b/docs/CASCADE-COOKBOOK.md
@@ -1,161 +1,226 @@
 # Cascade Cookbook
 
-Copy-paste examples for `config/cascade.toml`.
+Copy-paste examples for `cascade.toml`.
 
 Use this document for local/private live config under:
 
 - `~/.masc/config/cascade.toml`
 - `$MASC_BASE_PATH/.masc/config/cascade.toml`
 
-The runtime will materialize sibling `cascade.json` automatically.
-
-Do not treat these examples as a mandate for checked-in repo defaults. Repo
-defaults must stay limited to providers that the currently pinned OAS runtime
-can execute when selected.
+Do not treat these examples as checked-in repo defaults. Repo defaults live in
+[`config/cascade.toml`](../config/cascade.toml) and use the RFC-0058
+declarative provider/model/tier schema. Operator live configs may stay smaller
+when the goal is to pin one machine to one provider lane.
 
 ## Quick Rules
 
-- Use explicit `provider:model_id` labels in committed defaults when review-stable pinning matters; use `provider:auto` only when the adapter default is the intended contract.
-- A cascade profile is a top-level TOML table such as `[keeper_unified]`.
-- `comment` at the root maps to the runtime `_comment`; `[profile].comment`
-  maps to `_comment_<profile>`.
-- `[default]` acts as fallback for cascades that omit per-profile values.
-- `[profile].keeper_assignable = false` keeps a profile visible in the catalog
-  but hides it from keeper assignment dropdowns.
-- `[profile.api_key_env]` maps provider ids to env var names.
-- `kimi_cli:auto` is the preferred Kimi lane for current live configs when you
-  want the CLI/runtime-MCP tool path.
-- `glm-coding-plan:auto` is the preferred GLM coding-plan lane for current live
-  configs.
-- Direct `kimi:` still exists for Moonshot/OpenAI-compatible routing, but keep
-  it as an explicit choice rather than the default cookbook path.
+- Edit the live file, not the repo seed, for machine-specific routing.
+- Use `glm-coding:<model>` or `glm-coding:auto` for Z.AI GLM Coding Plan.
+- Do not use `glm-coding-plan:<model>` in new configs. The checked-in provider
+  id is `glm-coding`.
+- GLM Coding Plan must use the Z.AI Coding endpoint:
+  `https://api.z.ai/api/coding/paas/v4`.
+- The general Z.AI endpoint is `https://api.z.ai/api/paas/v4`; do not use it
+  for Coding Plan traffic.
+- Put API keys in environment variables or secret loaders. Do not write keys
+  into TOML.
+- Keep personal experiments in the live config. Commit only docs or seed
+  changes that other operators should inherit.
 
-## Example 1: GLM Coding Plan + Kimi CLI + Local Ollama Fallback
+Source checked on 2026-05-12: Z.AI's official API docs say GLM Coding Plan uses
+the dedicated Coding endpoint instead of the general endpoint:
+https://docs.z.ai/api-reference/introduction
 
-Use this when your keepers are primarily coding/text agents and you want:
+## Example 1: Single Z.AI Coding Plan Lane
 
-- `glm-coding-plan` as the main tool-using cloud path
-- `kimi_cli` as the secondary coding cloud path
-- local `ollama` as the cheap fallback/recovery lane
+Use this when the machine should route every keeper/operator use to one GLM
+Coding Plan lane.
+
+This is intentionally small. It is useful for debugging, rate-limit control, or
+temporary operation when you want to remove local 27B/70B-style classification
+from the live config.
 
 ```toml
-comment = "Local/private live config example. Requires valid GLM/Kimi credentials and local fallback runtime health."
+# ~/.masc/config/cascade.toml
+# or $MASC_BASE_PATH/.masc/config/cascade.toml
 
-[default]
-temperature = 0.2
-max_tokens = 8192
+comment = "Single Z.AI Coding Plan cascade. Machine-local live config."
+
+[routes]
+keeper_turn = "coding_plan"
+phase_recovery = "coding_plan"
+phase_buffer = "coding_plan"
+tool_required = "coding_plan"
+governance_judge = "coding_plan"
+operator_judge = "coding_plan"
+cross_verifier = "coding_plan"
+verifier = "coding_plan"
+autoresearch = "coding_plan"
+adversarial_reviewer = "coding_plan"
+auto_responder = "coding_plan"
+routing = "coding_plan"
+openai_compat = "coding_plan"
+persona_generation = "coding_plan"
+provider_benchmark = "coding_plan"
+llm_rerank = "coding_plan"
+simple_task = "coding_plan"
+moderate_task = "coding_plan"
+complex_task = "coding_plan"
+
+[coding_plan]
+comment = "Only active live profile. glm-coding resolves to the Z.AI Coding endpoint."
 models = [
-  { model = "glm-coding-plan:auto", weight = 45 },
-  { model = "kimi_cli:auto", weight = 35 },
-  { model = "ollama:qwen3.5:35b-a3b-nvfp4", weight = 20, supports_tool_choice = true },
+  { model = "glm-coding:auto", weight = 1 },
 ]
+temperature = 0.2
+max_tokens = 16384
+strategy = "failover"
+keeper_assignable = true
 
-[default.api_key_env]
-glm = "ZAI_API_KEY_SB"
-"glm-coding-plan" = "ZAI_API_KEY_SB"
-kimi_cli = "KIMI_API_KEY_SB"
+[coding_plan.api_key_env]
+"glm-coding" = "ZAI_API_KEY"
+```
+
+Expected diagnostic shape:
+
+```bash
+./_build/default/bin/main_eio.exe doctor config \
+  --base-path "$HOME/me" \
+  --json
+```
+
+The important fields are:
+
+- `active_config_root` points at `$MASC_BASE_PATH/.masc/config`.
+- `catalog_validation.status` is `validated`.
+- `catalog_validation.snapshot.profile_count` is `1`.
+- `catalog_validation.snapshot.default_profile_name` is `coding_plan`.
+- Candidate `base_url` values are `https://api.z.ai/api/coding/paas/v4`.
+
+Docker sandbox warnings can make the doctor command exit non-zero while the
+cascade catalog is still valid. Read `catalog_validation` separately from
+`sandbox_preflight`.
+
+## Example 2: Z.AI Coding Plan With Kimi CLI Fallback
+
+Use this when you want GLM Coding Plan as the first cloud lane and Kimi CLI as a
+second lane. Keep this live-only unless the fallback order is meant to become a
+shared default.
+
+```toml
+comment = "GLM Coding Plan primary, Kimi CLI fallback. Machine-local live config."
+
+[routes]
+keeper_turn = "keeper_unified"
+phase_recovery = "keeper_unified"
+phase_buffer = "local_recovery"
+tool_required = "keeper_unified"
+governance_judge = "keeper_unified"
+operator_judge = "keeper_unified"
+cross_verifier = "keeper_unified"
+verifier = "keeper_unified"
+autoresearch = "keeper_unified"
+adversarial_reviewer = "keeper_unified"
+auto_responder = "keeper_unified"
+routing = "keeper_unified"
+openai_compat = "keeper_unified"
+persona_generation = "keeper_unified"
+provider_benchmark = "keeper_unified"
+llm_rerank = "tool_rerank"
+simple_task = "keeper_unified"
+moderate_task = "keeper_unified"
+complex_task = "keeper_unified"
 
 [keeper_unified]
 temperature = 0.2
 max_tokens = 16384
-strategy = "circuit_breaker_cycling"
-max_cycles = 2
-backoff_base_ms = 250
-backoff_cap_ms = 2000
-ollama_max_concurrent = 1
+strategy = "failover"
 models = [
-  { model = "glm-coding-plan:auto", weight = 45 },
-  { model = "kimi_cli:auto", weight = 35 },
-  { model = "ollama:qwen3.5:35b-a3b-nvfp4", weight = 20, supports_tool_choice = true },
+  { model = "glm-coding:auto", weight = 2 },
+  { model = "kimi_cli:auto", weight = 1 },
 ]
+keeper_assignable = true
+
+[keeper_unified.api_key_env]
+"glm-coding" = "ZAI_API_KEY"
+kimi_cli = "MOONSHOT_API_KEY"
 
 [local_recovery]
 temperature = 0.1
 max_tokens = 8192
-models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
+models = ["glm-coding:auto"]
+keeper_assignable = false
+
+[local_recovery.api_key_env]
+"glm-coding" = "ZAI_API_KEY"
 
 [tool_rerank]
 temperature = 0.0
 max_tokens = 200
+models = ["glm-coding:auto"]
 keeper_assignable = false
+
+[tool_rerank.api_key_env]
+"glm-coding" = "ZAI_API_KEY"
 ```
 
 Operational notes:
 
-- Keep `glm-coding-plan` first if you want reliable cloud tool use.
-- Keep `ollama` in `local_recovery_*` even if the main cascade already contains
-  it; recovery profiles should stay deterministic and cheap.
-- `supports_tool_choice` on the local candidate is only a hint for known local
-  models that do obey tool-choice overrides.
+- Keep `glm-coding:auto` first when the subscription is GLM Coding Plan.
+- Use `kimi_cli:auto` only when the CLI runtime and credential are healthy.
+- Use the same `api_key_env` provider id as the model prefix:
+  `"glm-coding" = "ZAI_API_KEY"`.
+- If `ZAI_CODING_DEFAULT_MODEL` is set, `glm-coding:auto` follows that model.
+  Otherwise it follows the adapter default documented in
+  [`docs/spec/14-configuration.md`](./spec/14-configuration.md).
 
-## Example 2: GLM Coding Plan + Kimi CLI + Local MLX-VLM Fallback
+## Keeper Autoboot Example
 
-Use this when the local lane is an OpenAI-compatible MLX-VLM endpoint instead
-of `ollama`.
+Keeper startup is controlled by keeper TOML files, not by `cascade.toml`.
+
+To leave exactly four keepers enabled, make only those files contain
+`autoboot_enabled = true`, and set every other keeper to false.
 
 ```toml
-comment = "Local/private live config example. Requires valid GLM/Kimi credentials and an OpenAI-compatible MLX-VLM endpoint."
-
-[default]
-temperature = 0.2
-max_tokens = 8192
-models = [
-  { model = "glm-coding-plan:auto", weight = 45 },
-  { model = "kimi_cli:auto", weight = 35 },
-  { model = "custom:mlx-community/Huihui-Qwen3.6-35B-A3B-abliterated-4.4bit-msq@http://127.0.0.1:18080/v1", weight = 20 },
-]
-
-[default.api_key_env]
-glm = "ZAI_API_KEY_SB"
-"glm-coding-plan" = "ZAI_API_KEY_SB"
-kimi_cli = "KIMI_API_KEY_SB"
-
-[keeper_unified]
-temperature = 0.2
-max_tokens = 16384
-strategy = "circuit_breaker_cycling"
-max_cycles = 2
-backoff_base_ms = 250
-backoff_cap_ms = 2000
-models = [
-  { model = "glm-coding-plan:auto", weight = 45 },
-  { model = "kimi_cli:auto", weight = 35 },
-  { model = "custom:mlx-community/Huihui-Qwen3.6-35B-A3B-abliterated-4.4bit-msq@http://127.0.0.1:18080/v1", weight = 20 },
-]
-
-[local_mlx_vlm_qwen36]
-temperature = 0.2
-max_tokens = 16384
-models = [
-  "custom:mlx-community/Huihui-Qwen3.6-35B-A3B-abliterated-4.4bit-msq@http://127.0.0.1:18080/v1",
-]
-
-[tool_rerank]
-temperature = 0.0
-max_tokens = 200
-keeper_assignable = false
+# ~/.masc/config/keepers/taskmaster.toml
+[keeper]
+autoboot_enabled = true
+cascade_name = "coding_plan"
 ```
 
-Operational notes:
+```toml
+# ~/.masc/config/keepers/some-other-keeper.toml
+[keeper]
+autoboot_enabled = false
+cascade_name = "coding_plan"
+```
 
-- Keep the `custom:` model on a canonical localhost URL so telemetry and
-  troubleshooting stay stable.
-- If the MLX-VLM lane is only for vision-heavy work, consider assigning it to a
-  separate keeper via `cascade_name` instead of making it your main keeper
-  default.
+Verification:
 
-## Choosing Between Ollama and MLX-VLM
+```bash
+rg -l '^autoboot_enabled\s*=\s*true$' \
+  "$HOME/me/.masc/config/keepers"/*.toml
 
-- Choose `ollama` when the local fallback is mostly text/code and you want the
-  most boring operational path.
-- Choose `mlx-vlm` when the local fallback must accept image-heavy or multimodal
-  turns through an OpenAI-compatible endpoint.
-- Keep `glm-coding-plan` first unless you explicitly want local-first
-  economics and are comfortable with tool-call fallback behavior.
+rg -n 'cascade_name\s*=\s*"(?!coding_plan")' -P \
+  "$HOME/me/.masc/config/keepers"/*.toml
+```
+
+The first command should list only the intended keepers. The second command
+should print nothing when every keeper points at the live profile.
+
+## Choosing A Shape
+
+| Need | Recommended shape |
+| --- | --- |
+| One machine, one provider lane | Example 1 |
+| One primary cloud lane plus a fallback | Example 2 |
+| Shared repo defaults | Edit `config/cascade.toml` declarative provider/model/tier data |
+| Per-keeper startup control | Edit `~/.masc/config/keepers/*.toml` |
 
 ## Where This Connects
 
-- Schema reference: [docs/spec/14-configuration.md](./spec/14-configuration.md)
+- Schema reference: [docs/CASCADE-TOML.md](./CASCADE-TOML.md)
+- Provider/env reference: [docs/spec/14-configuration.md](./spec/14-configuration.md)
 - Checked-in authoring seed: [config/cascade.toml](../config/cascade.toml)
-- Materialized runtime artifact: [config/cascade.json](../config/cascade.json)
-- Reload contract: [README.md](../README.md)
+- Config doctor: [docs/CONFIG-DOCTOR.md](./CONFIG-DOCTOR.md)
+- Reload contract: [docs/TOML-RELOAD-MATRIX.md](./TOML-RELOAD-MATRIX.md)

--- a/docs/CASCADE-COOKBOOK.md
+++ b/docs/CASCADE-COOKBOOK.md
@@ -69,9 +69,7 @@ complex_task = "coding_plan"
 
 [coding_plan]
 comment = "Only active live profile. glm-coding resolves to the Z.AI Coding endpoint."
-models = [
-  { model = "glm-coding:auto", weight = 1 },
-]
+models = ["glm-coding:auto"]
 temperature = 0.2
 max_tokens = 16384
 strategy = "failover"
@@ -85,7 +83,7 @@ Expected diagnostic shape:
 
 ```bash
 ./_build/default/bin/main_eio.exe doctor config \
-  --base-path "$HOME/me" \
+  --base-path "$MASC_BASE_PATH" \
   --json
 ```
 
@@ -136,8 +134,8 @@ temperature = 0.2
 max_tokens = 16384
 strategy = "failover"
 models = [
-  { model = "glm-coding:auto", weight = 2 },
-  { model = "kimi_cli:auto", weight = 1 },
+  "glm-coding:auto",
+  "kimi_cli:auto",
 ]
 keeper_assignable = true
 
@@ -145,13 +143,13 @@ keeper_assignable = true
 "glm-coding" = "ZAI_API_KEY"
 kimi_cli = "MOONSHOT_API_KEY"
 
-[local_recovery]
+[phase_buffer]
 temperature = 0.1
 max_tokens = 8192
 models = ["glm-coding:auto"]
 keeper_assignable = false
 
-[local_recovery.api_key_env]
+[phase_buffer.api_key_env]
 "glm-coding" = "ZAI_API_KEY"
 
 [tool_rerank]
@@ -199,10 +197,10 @@ Verification:
 
 ```bash
 rg -l '^autoboot_enabled\s*=\s*true$' \
-  "$HOME/me/.masc/config/keepers"/*.toml
+  "$MASC_BASE_PATH/.masc/config/keepers"/*.toml
 
 rg -n 'cascade_name\s*=\s*"(?!coding_plan")' -P \
-  "$HOME/me/.masc/config/keepers"/*.toml
+  "$MASC_BASE_PATH/.masc/config/keepers"/*.toml
 ```
 
 The first command should list only the intended keepers. The second command

--- a/docs/CASCADE-TOML.md
+++ b/docs/CASCADE-TOML.md
@@ -14,6 +14,51 @@ written to disk (TOML-only mode, RFC-0058).
 parses TOML and converts to JSON in memory. No sibling `cascade.json` is
 needed or generated.
 
+### Live Config Versus Repo Seed
+
+There are two common authoring contexts:
+
+| Context | Path | Use it for |
+|---------|------|------------|
+| Live operator config | `$MASC_BASE_PATH/.masc/config/cascade.toml` | Machine-specific provider lanes, credentials, temporary failover choices, and local experiments. |
+| Checked-in repo seed | [`config/cascade.toml`](../config/cascade.toml) | Shared defaults that should be inherited by every checkout after review. |
+
+Do not commit a personal live route just because it works on one machine. Commit
+docs or seed changes only when the behavior should be reproducible for other
+operators.
+
+The checked-in seed uses the RFC-0058 declarative provider/model/tier schema.
+Small live configs may still use top-level profile sections when an operator
+needs a compact one-machine override. Use `doctor config` to confirm what the
+runtime actually loaded.
+
+### Z.AI GLM Coding Plan Endpoint
+
+For Z.AI GLM Coding Plan, use the `glm-coding` provider id:
+
+```toml
+models = ["glm-coding:auto"]
+```
+
+`glm-coding` resolves to the dedicated Coding endpoint:
+
+```text
+https://api.z.ai/api/coding/paas/v4
+```
+
+Do not use the general Z.AI endpoint for Coding Plan traffic:
+
+```text
+https://api.z.ai/api/paas/v4
+```
+
+Also do not use the obsolete provider label `glm-coding-plan` in new configs.
+The checked-in provider id is `glm-coding`.
+
+Source checked on 2026-05-12: Z.AI's official API docs say GLM Coding Plan uses
+the dedicated Coding endpoint instead of the general endpoint:
+https://docs.z.ai/api-reference/introduction
+
 ## TOML-Only Mode (RFC-0058)
 
 When `cascade.toml` is present alongside `cascade.json`:
@@ -178,22 +223,88 @@ The repo seed stays intentionally small.
 
 ## Edit Workflow
 
+For repo seed changes:
+
 1. Edit [`config/cascade.toml`](../config/cascade.toml).
 2. Run focused checks:
 
 ```bash
-dune runtest --root . test/test_cascade_toml_materialization.exe
-dune runtest --root . test/test_cascade_phase1_smoke.exe
-dune exec --root . ./test/test_keeper_cascade_profile.exe
+scripts/dune-local.sh build test/test_cascade_toml_materialization.exe
+scripts/dune-local.sh build test/test_cascade_phase1_smoke.exe
+scripts/dune-local.sh build test/test_keeper_cascade_profile.exe
 ```
 
-Optionally verify JSON output:
+`cascade_materialize` is retired. Runtime TOML loading is in-memory, and no
+`cascade.json` file should be generated for normal verification.
+
+For human inspection of the active runtime view, prefer `doctor config`.
+
+For live operator changes:
+
+1. Edit `$MASC_BASE_PATH/.masc/config/cascade.toml`.
+2. Validate the active config root and catalog snapshot:
 
 ```bash
-dune exec --root . ./bin/cascade_materialize.exe -- config/cascade.json
+./_build/default/bin/main_eio.exe doctor config \
+  --base-path "$MASC_BASE_PATH" \
+  --json
 ```
 
+Read these fields first:
+
+- `active_config_root`
+- `catalog_validation.status`
+- `catalog_validation.snapshot.default_profile_name`
+- `catalog_validation.snapshot.profile_count`
+- `catalog_validation.snapshot.profiles[].candidates[].base_url`
+
+`doctor config` also runs sandbox preflight. A Docker warning can make the
+overall doctor status `warn` or the command exit non-zero while
+`catalog_validation.status` is still `validated`.
+
 ## Examples
+
+### Single Z.AI Coding Plan Live Profile
+
+This is the smallest useful live config when every route should go through the
+GLM Coding Plan lane.
+
+```toml
+comment = "Single Z.AI Coding Plan cascade. Machine-local live config."
+
+[routes]
+keeper_turn = "coding_plan"
+phase_recovery = "coding_plan"
+phase_buffer = "coding_plan"
+tool_required = "coding_plan"
+governance_judge = "coding_plan"
+operator_judge = "coding_plan"
+cross_verifier = "coding_plan"
+verifier = "coding_plan"
+autoresearch = "coding_plan"
+adversarial_reviewer = "coding_plan"
+auto_responder = "coding_plan"
+routing = "coding_plan"
+openai_compat = "coding_plan"
+persona_generation = "coding_plan"
+provider_benchmark = "coding_plan"
+llm_rerank = "coding_plan"
+simple_task = "coding_plan"
+moderate_task = "coding_plan"
+complex_task = "coding_plan"
+
+[coding_plan]
+models = [
+  { model = "glm-coding:auto", weight = 1 },
+]
+temperature = 0.2
+max_tokens = 16384
+strategy = "failover"
+keeper_assignable = true
+
+[coding_plan.api_key_env]
+"glm-coding" = "ZAI_API_KEY"
+```
 
 ### Minimal Profile
 

--- a/docs/CASCADE-TOML.md
+++ b/docs/CASCADE-TOML.md
@@ -229,9 +229,9 @@ For repo seed changes:
 2. Run focused checks:
 
 ```bash
-scripts/dune-local.sh build test/test_cascade_toml_materialization.exe
-scripts/dune-local.sh build test/test_cascade_phase1_smoke.exe
-scripts/dune-local.sh build test/test_keeper_cascade_profile.exe
+scripts/dune-local.sh runtest test/test_cascade_toml_materialization.exe
+scripts/dune-local.sh runtest test/test_cascade_phase1_smoke.exe
+scripts/dune-local.sh runtest test/test_keeper_cascade_profile.exe
 ```
 
 `cascade_materialize` is retired. Runtime TOML loading is in-memory, and no
@@ -294,9 +294,7 @@ moderate_task = "coding_plan"
 complex_task = "coding_plan"
 
 [coding_plan]
-models = [
-  { model = "glm-coding:auto", weight = 1 },
-]
+models = ["glm-coding:auto"]
 temperature = 0.2
 max_tokens = 16384
 strategy = "failover"


### PR DESCRIPTION
## Summary

- document the live-config versus repo-seed split for `cascade.toml`
- add a dedicated Z.AI GLM Coding Plan endpoint section using `glm-coding`
- rewrite the cascade cookbook examples so new live configs no longer use the obsolete `glm-coding-plan` provider label
- add copy-paste examples for a single Coding Plan lane, Coding Plan plus Kimi fallback, and keeper autoboot verification

## Why

The live operator config can be valid while still being machine-specific. The docs now make that boundary explicit and show the exact diagnostic fields operators should inspect before calling the setup working.

The Z.AI Coding Plan lane also uses a different endpoint from the general Z.AI API, so the examples need to teach `glm-coding:auto` and `https://api.z.ai/api/coding/paas/v4` directly.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build test/test_cascade_toml_materialization.exe` initially stopped on shared `agent_sdk` pin drift
- `scripts/opam-pin-external-deps.sh --install` refused to downgrade the shared newer `agent_sdk 0.193.2` pin
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_cascade_toml_materialization.exe`
