### PR TITLE
fix: address recent post-merge review follow-ups

### DIFF
--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -99,7 +99,7 @@ let read_json_file path =
    [Cascade_metrics.on_toml_read_race] so operators can alert on
    pathological reload churn (e.g. a writer that fsyncs in a tight
    loop). *)
-let load_toml_in_memory config_path =
+let load_toml_in_memory ~emit_telemetry config_path =
   let source_state =
     Cascade_toml_materializer.source_state ~config_path
   in
@@ -137,36 +137,41 @@ let load_toml_in_memory config_path =
            | Some mp when Float.equal mp mtime_pre ->
              with_cache_lock (fun () ->
                Hashtbl.replace config_cache cache_key (mp, json));
-             Eio.traceln
-               "[CascadeConfig] loaded TOML %s mtime=%.0f (in-memory)"
-               cache_key
-               mp;
-             Ok json
+            if emit_telemetry then
+              Eio.traceln
+                "[CascadeConfig] loaded TOML %s mtime=%.0f (in-memory)"
+                cache_key
+                mp;
+            Ok json
            | Some mp ->
              (* mtime moved between the pre-stat and the post-stat.
                 The rendered content is fresh-as-of mp but we cannot
                 prove it matches either sample, so we don't cache —
                 next call will re-stat and converge. *)
-             Cascade_metrics.on_toml_read_race ();
-             Log.warn
-               ~ctx:"CascadeConfig"
-               "TOML changed mid-read (mtime %.0f -> %.0f) for %s; \
-                serving fresh content but skipping cache update to \
-                force re-stat on next call"
-               mtime_pre
-               mp
-               cache_key;
+             if emit_telemetry then begin
+               Cascade_metrics.on_toml_read_race ();
+               Log.warn
+                 ~ctx:"CascadeConfig"
+                 "TOML changed mid-read (mtime %.0f -> %.0f) for %s; \
+                  serving fresh content but skipping cache update to \
+                  force re-stat on next call"
+                 mtime_pre
+                 mp
+                 cache_key
+             end;
              Ok json
            | None ->
              (* Post-stat failed (file vanished mid-read).  Treat
                 like a race so the caller re-converges next time. *)
-             Cascade_metrics.on_toml_read_race ();
-             Log.warn
-               ~ctx:"CascadeConfig"
-               "TOML disappeared mid-read after mtime=%.0f for %s; \
-                returning in-memory render but skipping cache update"
-               mtime_pre
-               cache_key;
+             if emit_telemetry then begin
+               Cascade_metrics.on_toml_read_race ();
+               Log.warn
+                 ~ctx:"CascadeConfig"
+                 "TOML disappeared mid-read after mtime=%.0f for %s; \
+                  returning in-memory render but skipping cache update"
+                 mtime_pre
+                 cache_key
+             end;
              Ok json)))
 ;;
 
@@ -180,8 +185,8 @@ let load_toml_in_memory config_path =
    on-disk JSON is read: a sibling [cascade.toml] is parsed and
    rendered to an in-memory [Yojson.Safe.t] view that legacy
    JSON-shaped consumers walk via [Yojson.Safe.Util]. *)
-let load_catalog_source path =
-  try load_toml_in_memory path with
+let load_catalog_source_impl ~emit_telemetry path =
+  try load_toml_in_memory ~emit_telemetry path with
   | Sys_error msg -> Error msg
   | Unix.Unix_error (err, fn, arg) ->
     Error (Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err))
@@ -193,6 +198,14 @@ let load_catalog_source path =
        second call raises [End_of_file]. Surface as an [Error] instead
        of crashing the loader. *)
     Error (Printf.sprintf "cascade source truncated mid-read: %s" path)
+;;
+
+let load_catalog_source path =
+  load_catalog_source_impl ~emit_telemetry:true path
+;;
+
+let load_catalog_source_for_diagnostics path =
+  load_catalog_source_impl ~emit_telemetry:false path
 ;;
 
 (** A model entry with an optional weight for weighted cascade selection.
@@ -552,7 +565,7 @@ let detect_capability_mismatches (entries : catalog_entry list)
 ;;
 
 let load_catalog_impl ~emit_telemetry ~config_path =
-  match load_catalog_source config_path with
+  match load_catalog_source_impl ~emit_telemetry config_path with
   | Error _ as err -> err
   | Ok (`Assoc fields) ->
     (* RFC-0058: register TOML-declared profiles before catalog parsing
@@ -715,9 +728,9 @@ let load_catalog_for_diagnostics ~config_path =
   load_catalog_impl ~emit_telemetry:false ~config_path
 ;;
 
-let load_profile_weighted ~config_path ~name =
+let load_profile_weighted_impl ~emit_telemetry ~config_path ~name =
   let key = name ^ "_models" in
-  match load_catalog_source config_path with
+  match load_catalog_source_impl ~emit_telemetry config_path with
   | Error msg ->
     (* Surface the load failure on the standard logging channel so
          operators see it without tailing stderr. Returning the empty
@@ -737,6 +750,14 @@ let load_profile_weighted ~config_path ~name =
     (match json |> member key with
      | `List items -> List.filter_map parse_weighted_item items
      | _ -> [])
+;;
+
+let load_profile_weighted ~config_path ~name =
+  load_profile_weighted_impl ~emit_telemetry:true ~config_path ~name
+;;
+
+let load_profile_weighted_for_diagnostics ~config_path ~name =
+  load_profile_weighted_impl ~emit_telemetry:false ~config_path ~name
 ;;
 
 let load_profile ~config_path ~name =
@@ -985,8 +1006,8 @@ let empty_strategy_config =
   }
 ;;
 
-let resolve_strategy_config ~config_path ~name =
-  match load_catalog_source config_path with
+let resolve_strategy_config_impl ~emit_telemetry ~config_path ~name =
+  match load_catalog_source_impl ~emit_telemetry config_path with
   | Error msg ->
     Log.Misc.warn
       "[CascadeConfig] resolve_strategy_config: %s (name=%s, path=%s)"
@@ -1013,6 +1034,14 @@ let resolve_strategy_config ~config_path ~name =
     ; server_error_decay_base = read_float_field json (name ^ "_server_error_decay_base")
     ; server_error_skip_after = read_int_field json (name ^ "_server_error_skip_after")
     }
+;;
+
+let resolve_strategy_config ~config_path ~name =
+  resolve_strategy_config_impl ~emit_telemetry:true ~config_path ~name
+;;
+
+let resolve_strategy_config_for_diagnostics ~config_path ~name =
+  resolve_strategy_config_impl ~emit_telemetry:false ~config_path ~name
 ;;
 
 (* ── RFC-0041: cascade_profile loader ──────────────────────────────── *)

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -20,6 +20,10 @@
     JSON is read or written. *)
 val load_catalog_source : string -> (Yojson.Safe.t, string) result
 
+(** Same as {!load_catalog_source}, but suppresses TOML source-read
+    trace / race telemetry for high-frequency diagnostic polling. *)
+val load_catalog_source_for_diagnostics : string -> (Yojson.Safe.t, string) result
+
 (** Drop the cached entry for one cascade source path.
 
     Intended for in-process editors/tests that overwrite the file and need
@@ -184,6 +188,13 @@ val load_profile_weighted :
   name:string ->
   weighted_entry list
 
+(** Diagnostics-only variant of {!load_profile_weighted}; suppresses
+    TOML source-read trace / race telemetry. *)
+val load_profile_weighted_for_diagnostics :
+  config_path:string ->
+  name:string ->
+  weighted_entry list
+
 (** Per-cascade inference parameter overrides. *)
 type inference_params = {
   temperature: float option;
@@ -317,6 +328,9 @@ type strategy_config = {
 }
 
 val resolve_strategy_config :
+  config_path:string -> name:string -> strategy_config
+
+val resolve_strategy_config_for_diagnostics :
   config_path:string -> name:string -> strategy_config
 
 (** {1 RFC-0041 cascade_profile bridge} *)

--- a/lib/cascade_catalog_validator.ml
+++ b/lib/cascade_catalog_validator.ml
@@ -52,10 +52,21 @@ let discover_profiles_in_json = function
       |> List.sort_uniq String.compare
   | _ -> []
 
-let discover_profiles ~config_path =
-  match Cascade_config_loader.load_catalog_source config_path with
+let discover_profiles_impl ~emit_telemetry ~config_path =
+  let load_catalog_source =
+    if emit_telemetry
+    then Cascade_config_loader.load_catalog_source
+    else Cascade_config_loader.load_catalog_source_for_diagnostics
+  in
+  match load_catalog_source config_path with
   | Ok json -> discover_profiles_in_json json
   | Error _ -> []
+
+let discover_profiles ~config_path =
+  discover_profiles_impl ~emit_telemetry:true ~config_path
+
+let discover_profiles_for_diagnostics ~config_path =
+  discover_profiles_impl ~emit_telemetry:false ~config_path
 
 let model_ids_of_specs (specs : string list) : string list =
   specs
@@ -251,7 +262,7 @@ let snapshot_profile_for ~config_path ~profile =
          snapshot.profiles
      | _ -> None)
 
-let diagnose_profile ~config_path ~profile =
+let diagnose_profile ~emit_telemetry ~config_path ~profile =
   let snapshot_profile = snapshot_profile_for ~config_path ~profile in
   let model_specs =
     match snapshot_profile with
@@ -260,7 +271,12 @@ let diagnose_profile ~config_path ~profile =
         (fun (entry : Cascade_config_loader.weighted_entry) -> entry.model)
         p.weighted_entries
     | None ->
-      Cascade_config_loader.load_profile_weighted ~config_path ~name:profile
+      (if emit_telemetry
+       then Cascade_config_loader.load_profile_weighted ~config_path ~name:profile
+       else
+         Cascade_config_loader.load_profile_weighted_for_diagnostics
+           ~config_path
+           ~name:profile)
       |> List.map (fun (entry : Cascade_config_loader.weighted_entry) ->
              entry.model)
   in
@@ -269,7 +285,11 @@ let diagnose_profile ~config_path ~profile =
     | Some (p : Cascade_catalog_runtime.profile_build) ->
       p.required_capability_profile
     | None ->
-      (match Cascade_config_loader.load_catalog ~config_path with
+      (match
+         if emit_telemetry
+         then Cascade_config_loader.load_catalog ~config_path
+         else Cascade_config_loader.load_catalog_for_diagnostics ~config_path
+       with
        | Error _ -> None
        | Ok entries ->
            List.find_map
@@ -312,7 +332,12 @@ let diagnose_profile ~config_path ~profile =
         }
   in
   let strategy_cfg =
-    Cascade_config_loader.resolve_strategy_config ~config_path ~name:profile
+    (if emit_telemetry
+     then Cascade_config_loader.resolve_strategy_config ~config_path ~name:profile
+     else
+       Cascade_config_loader.resolve_strategy_config_for_diagnostics
+         ~config_path
+         ~name:profile)
   in
   let strategy_issue =
     match strategy_cfg.kind with
@@ -355,8 +380,13 @@ let diagnose_profile ~config_path ~profile =
   in
   issues @ capability_issues
 
-let diagnose_catalog ~config_path =
-  match Cascade_config_loader.load_catalog_source config_path with
+let diagnose_catalog_impl ~emit_telemetry ~config_path =
+  let load_catalog_source =
+    if emit_telemetry
+    then Cascade_config_loader.load_catalog_source
+    else Cascade_config_loader.load_catalog_source_for_diagnostics
+  in
+  match load_catalog_source config_path with
   | Error msg ->
       [
         {
@@ -370,7 +400,14 @@ let diagnose_catalog ~config_path =
       ]
   | Ok json ->
       discover_profiles_in_json json
-      |> List.concat_map (fun profile -> diagnose_profile ~config_path ~profile)
+      |> List.concat_map (fun profile ->
+        diagnose_profile ~emit_telemetry ~config_path ~profile)
+
+let diagnose_catalog ~config_path =
+  diagnose_catalog_impl ~emit_telemetry:true ~config_path
+
+let diagnose_catalog_for_diagnostics ~config_path =
+  diagnose_catalog_impl ~emit_telemetry:false ~config_path
 
 let dedupe_keep_order values =
   let seen = Hashtbl.create (List.length values) in

--- a/lib/cascade_catalog_validator.mli
+++ b/lib/cascade_catalog_validator.mli
@@ -18,6 +18,10 @@ val discover_profiles : config_path:string -> string list
 (** Discover named cascade presets from ["{name}_models"] keys. Returns
     [[]] when the config cannot be loaded. *)
 
+val discover_profiles_for_diagnostics : config_path:string -> string list
+(** Diagnostics-only variant of {!discover_profiles}; suppresses TOML
+    source-read trace / race telemetry. *)
+
 val diagnose_catalog : config_path:string -> issue list
 (** Validate every discovered preset in [config_path].
 
@@ -28,6 +32,10 @@ val diagnose_catalog : config_path:string -> issue list
     Provider-unavailable entries are not treated as hard failures here:
     the validator is intended to catch broken catalog structure, not
     environment-specific credential state. *)
+
+val diagnose_catalog_for_diagnostics : config_path:string -> issue list
+(** Diagnostics-only variant of {!diagnose_catalog}; suppresses catalog
+    validation telemetry and TOML source-read trace / race telemetry. *)
 
 val error_messages_by_profile :
   config_path:string ->

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -110,6 +110,7 @@ let option_field name = function
 type cascade_diagnosis = {
   issues : catalog_issue list;
   fallback_cycles : string list list;
+  missing_toml_with_legacy_json : bool;
   (** Cycles surface as warning issues inside [issues] for the
       flat warnings list, but we keep the raw list here so
       {!cascade_catalog_next_actions} can emit a cycle-specific
@@ -160,12 +161,17 @@ let diagnose_cascade_catalog ~active_config_root =
             }
           ]
       ; fallback_cycles = []
+      ; missing_toml_with_legacy_json = true
       }
     else
-      { issues = []; fallback_cycles = [] }
+      { issues = []; fallback_cycles = []; missing_toml_with_legacy_json = false }
   else
-    let profiles = Cascade_catalog_validator.discover_profiles ~config_path in
-    let validator_issues = Cascade_catalog_validator.diagnose_catalog ~config_path in
+    let profiles =
+      Cascade_catalog_validator.discover_profiles_for_diagnostics ~config_path
+    in
+    let validator_issues =
+      Cascade_catalog_validator.diagnose_catalog_for_diagnostics ~config_path
+    in
     (* Surface fallback-cycle detection alongside the per-profile
        validator output.  [Cascade_config_loader.load_catalog]
        already detects cycles and bumps
@@ -205,7 +211,7 @@ let diagnose_cascade_catalog ~active_config_root =
     in
     let issues = validator_issues @ cycle_issues in
     if issues = [] then
-      { issues = []; fallback_cycles }
+      { issues = []; fallback_cycles; missing_toml_with_legacy_json = false }
     else
       let error_count =
         issues
@@ -224,10 +230,10 @@ let diagnose_cascade_catalog ~active_config_root =
             error_count
             warn_count;
       } in
-      { issues = summary :: issues; fallback_cycles }
+      { issues = summary :: issues; fallback_cycles; missing_toml_with_legacy_json = false }
 
 let cascade_catalog_next_actions ~config_path
-    { issues; fallback_cycles } =
+    { issues; fallback_cycles; missing_toml_with_legacy_json } =
   if issues = [] then
     []
   else
@@ -239,6 +245,16 @@ let cascade_catalog_next_actions ~config_path
         Printf.sprintf
           "Fix or disable the broken cascade preset entries in %s before \
            assigning keepers to them."
+          config_path
+      else if missing_toml_with_legacy_json then
+        let legacy_json =
+          Filename.concat
+            (Filename.dirname config_path)
+            Config_dir_resolver.cascade_json_filename
+        in
+        Printf.sprintf
+          "Migrate or rename %s to %s before relying on catalog diagnostics."
+          legacy_json
           config_path
       else if fallback_cycles <> [] then
         (* Cycle warnings are a runtime-stalling loop, not degraded

--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -43,6 +43,9 @@ let map_status_to_exec_result
       ((status, stdout, stderr) : Unix.process_status * string * string)
   =
   match status with
+  | Unix.WEXITED 126
+    when String_util.contains_substring_ci (stdout ^ "\n" ^ stderr) "exec_gate_blocked:"
+    -> Error Docker_client.Daemon_unreachable
   | Unix.WEXITED 125 | Unix.WEXITED 127 -> Error Docker_client.Daemon_unreachable
   | Unix.WEXITED code -> Ok Docker_response.{ exit_code = code; stdout; stderr }
   | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> Error Docker_client.Daemon_unreachable
@@ -76,15 +79,35 @@ let is_eintr_127 (status : Unix.process_status) (out : string) =
   | _ -> false
 ;;
 
-(* Sandbox subprocess timeout default.  [Exec_gate.run_argv_with_status*]
+let is_exec_gate_blocked (status : Unix.process_status) (out : string) =
+  match status with
+  | Unix.WEXITED 126 -> String_util.contains_substring_ci out "exec_gate_blocked:"
+  | _ -> false
+;;
+
+let docker_probe_timeout_sec () =
+  Env_config_exec_timeout.timeout_sec ~caller:Env_config_exec_timeout.Sandbox ()
+;;
+
+let session_exec_timeout_sec () =
+  Env_config_exec_timeout.timeout_sec ~caller:Env_config_exec_timeout.Shell ()
+;;
+
+let session_start_timeout_sec () =
+  Env_config_exec_timeout.timeout_sec ~caller:Env_config_exec_timeout.Turn_up ()
+;;
+
+let session_preflight_timeout_sec () =
+  Env_config_exec_timeout.timeout_sec ~caller:Env_config_exec_timeout.Turn_sandbox ()
+;;
+
+(* Docker probe timeout default.  [Exec_gate.run_argv_with_status*]
    all carry a hard-coded [?(timeout_sec = 60.0)] default that bypasses
-   the per-caller env override ([MASC_EXEC_TIMEOUT_TURN_SANDBOX_SEC]);
-   routing through [Env_config_exec_timeout] keeps the SSOT live for
-   sites that omit a caller-specific timeout. *)
+   the per-caller env override ([MASC_EXEC_TIMEOUT_SANDBOX_SEC]); routing
+   through [Env_config_exec_timeout] keeps the SSOT live for short
+   daemon probes that omit a caller-specific timeout. *)
 let default_timeout_sec () =
-  Env_config_exec_timeout.timeout_sec
-    ~caller:Env_config_exec_timeout.Turn_sandbox
-    ()
+  docker_probe_timeout_sec ()
 ;;
 
 let gated_argv_with_status ?timeout_sec ~(summary : string) argv =
@@ -214,10 +237,14 @@ let exec ?user ?workdir ?stdin ~container ~cmd () =
   match stdin with
   | None ->
     map_status_to_exec_result
-      (gated_argv_with_status_split ~summary:"keeper docker exec" argv)
+      (gated_argv_with_status_split
+         ~timeout_sec:(session_exec_timeout_sec ())
+         ~summary:"keeper docker exec"
+         argv)
   | Some stdin_content ->
     map_status_to_exec_result
       (gated_argv_with_stdin_and_status_split
+         ~timeout_sec:(session_exec_timeout_sec ())
          ~summary:"keeper docker exec (stdin-piped)"
          ~stdin_content
          argv)
@@ -245,8 +272,10 @@ let run plan =
 
 let rm container =
   let argv = [ "docker"; "rm"; "-f"; Keeper_container_name.to_string container ] in
-  let status, _stdout = gated_argv_with_status ~summary:"keeper docker rm" argv in
-  map_exit_status_for_rm status
+  let status, stdout = gated_argv_with_status ~summary:"keeper docker rm" argv in
+  if is_exec_gate_blocked status stdout
+  then Error Docker_client.Daemon_unreachable
+  else map_exit_status_for_rm status
 ;;
 
 (* Pure: parses the stdout of [docker info --format
@@ -277,6 +306,8 @@ let info_security_options () =
     gated_argv_with_status_split ~summary:"keeper docker info security-options" argv
   with
   | Unix.WEXITED 0, out, _ -> parse_security_options out
+  | status, out, err when is_exec_gate_blocked status (out ^ "\n" ^ err) ->
+    Error Docker_client.Daemon_unreachable
   | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _, _ ->
     (* Any non-zero exit means the daemon could not answer (not
        running, permission denied, CLI missing → synthesized
@@ -302,6 +333,8 @@ let image_present ~image =
   let argv = [ "docker"; "image"; "inspect"; image ] in
   match gated_argv_with_status ~summary:"keeper docker image inspect" argv with
   | Unix.WEXITED 0, _ -> Ok ()
+  | status, out when is_exec_gate_blocked status out ->
+    Error Docker_client.Daemon_unreachable
   | Unix.WEXITED 127, _ -> Error Docker_client.Daemon_unreachable
   | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _ ->
     Error Docker_client.Image_pull_failed
@@ -400,9 +433,8 @@ let run_detached (plan : Keeper_sandbox_session_plan.t) =
   match write_identity_files plan with
   | Error _ as err -> err
   | Ok () ->
-    let ensure_timeout =
-      Env_config_exec_timeout.timeout_sec ~caller:Env_config_exec_timeout.Turn_sandbox ()
-    in
+    let ensure_timeout = session_preflight_timeout_sec () in
+    let start_timeout = session_start_timeout_sec () in
     (match Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec:ensure_timeout with
      | Error _ ->
        (* docker runtime could not be ensured — daemon-level. *)
@@ -416,8 +448,8 @@ let run_detached (plan : Keeper_sandbox_session_plan.t) =
            ~started_at:(Unix.gettimeofday ())
        in
        (match
-          gated_argv_with_status_split
-            ~timeout_sec:ensure_timeout
+         gated_argv_with_status_split
+            ~timeout_sec:start_timeout
             ~summary:"keeper docker run -d (session)"
             argv
         with

--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -272,8 +272,8 @@ let run plan =
 
 let rm container =
   let argv = [ "docker"; "rm"; "-f"; Keeper_container_name.to_string container ] in
-  let status, stdout = gated_argv_with_status ~summary:"keeper docker rm" argv in
-  if is_exec_gate_blocked status stdout
+  let status, combined_out = gated_argv_with_status ~summary:"keeper docker rm" argv in
+  if is_exec_gate_blocked status combined_out
   then Error Docker_client.Daemon_unreachable
   else map_exit_status_for_rm status
 ;;

--- a/lib/keeper/docker_client_real.mli
+++ b/lib/keeper/docker_client_real.mli
@@ -119,17 +119,17 @@ val is_eintr_127 : Unix.process_status -> string -> bool
     in-container command result. *)
 val is_exec_gate_blocked : Unix.process_status -> string -> bool
 
-val docker_probe_timeout_sec : unit -> float
 (** Timeout used by short Docker daemon probes such as [rm],
     [image_present], and [info_security_options]. *)
+val docker_probe_timeout_sec : unit -> float
 
-val session_exec_timeout_sec : unit -> float
 (** Timeout used by [exec] session commands. Preserves the 60s shell
     command budget instead of the short sandbox-preflight budget. *)
+val session_exec_timeout_sec : unit -> float
 
-val session_start_timeout_sec : unit -> float
 (** Timeout used by the actual [docker run -d] session start. *)
+val session_start_timeout_sec : unit -> float
 
-val session_preflight_timeout_sec : unit -> float
 (** Timeout used by the short seccomp/runtime preflight before detached
     session start. *)
+val session_preflight_timeout_sec : unit -> float

--- a/lib/keeper/docker_client_real.mli
+++ b/lib/keeper/docker_client_real.mli
@@ -112,3 +112,24 @@ val run_detached_argv
     Mirrors [keeper_turn_sandbox_runtime]'s long-standing EINTR loop
     (the Phase 4.1 cutover deletes that copy in favour of this one). *)
 val is_eintr_127 : Unix.process_status -> string -> bool
+
+(** [is_exec_gate_blocked status out] detects the Exec_gate deny/ask
+    sentinel. The real Docker client maps that host-side gate result to
+    [Daemon_unreachable] rather than treating exit 126 as an
+    in-container command result. *)
+val is_exec_gate_blocked : Unix.process_status -> string -> bool
+
+val docker_probe_timeout_sec : unit -> float
+(** Timeout used by short Docker daemon probes such as [rm],
+    [image_present], and [info_security_options]. *)
+
+val session_exec_timeout_sec : unit -> float
+(** Timeout used by [exec] session commands. Preserves the 60s shell
+    command budget instead of the short sandbox-preflight budget. *)
+
+val session_start_timeout_sec : unit -> float
+(** Timeout used by the actual [docker run -d] session start. *)
+
+val session_preflight_timeout_sec : unit -> float
+(** Timeout used by the short seccomp/runtime preflight before detached
+    session start. *)

--- a/test/test_config_doctor.ml
+++ b/test/test_config_doctor.ml
@@ -120,6 +120,10 @@ let initialize_config_root ?(cascade_toml="") root =
   write_file (Filename.concat root "cascade.toml") cascade_toml;
   mkdir_p (Filename.concat root "personas")
 
+let initialize_legacy_json_only_config_root root =
+  write_file (Filename.concat root "cascade.json") "{}";
+  mkdir_p (Filename.concat root "personas")
+
 let test_invalid_explicit_config_dir () =
   with_temp_dir "config-doctor-invalid" @@ fun dir ->
   let base_path = Filename.concat dir "base" in
@@ -253,6 +257,29 @@ models = ["claude_code:claude-haiku-4-5-20251001"]
        ~needle:"uses priority_tier, but 1/2 tier(s) collapse after model-id normalization"
        report.warnings)
 
+let test_legacy_json_without_toml_next_action_migrates () =
+  with_temp_dir "config-doctor-legacy-json" @@ fun dir ->
+  let base_path = Filename.concat dir "base" in
+  let config_root = Filename.concat base_path ".masc/config" in
+  initialize_legacy_json_only_config_root config_root;
+  let report =
+    Config_doctor.analyze_with
+      (make_inputs ~cwd:dir ~base_path_input:base_path ())
+  in
+  check string "status downgrades to warn" "warn" (status report.status);
+  check bool "legacy json warning present" true
+    (list_contains_substring
+       ~needle:"cascade.json but no cascade.toml"
+       report.warnings);
+  check bool "next action points at migration" true
+    (list_contains_substring
+       ~needle:"Migrate or rename"
+       report.next_actions);
+  check bool "next action names cascade.toml" true
+    (list_contains_substring
+       ~needle:"cascade.toml"
+       report.next_actions)
+
 let fake_docker_missing_image_script =
   "#!/bin/sh\n\
 case \"$1\" in\n\
@@ -329,6 +356,8 @@ let () =
              test_broken_cascade_catalog_surfaces_errors;
            test_case "non-runtime-required cascade catalog warns" `Quick
              test_non_runtime_required_cascade_catalog_warns;
+           test_case "legacy cascade.json without toml gets migration action"
+             `Quick test_legacy_json_without_toml_next_action_migrates;
            test_case "analyze_live surfaces sandbox preflight failure"
              `Quick test_analyze_live_surfaces_sandbox_preflight_failure;
          ]);

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -528,25 +528,46 @@ let test_exec_gate_blocked_rejects_plain_126 () =
 ;;
 
 let test_docker_real_timeout_budgets_are_separated () =
-  check
-    (float 0.001)
-    "exec keeps shell budget"
-    60.0
-    (Docker_client_real.session_exec_timeout_sec ());
-  check
-    (float 0.001)
-    "probe keeps sandbox budget"
-    10.0
-    (Docker_client_real.docker_probe_timeout_sec ());
-  check
-    (float 0.001)
-    "start keeps turn-up budget"
-    15.0
-    (Docker_client_real.session_start_timeout_sec ());
-  check
-    (float 0.001)
-    "preflight keeps short turn-sandbox budget"
-    2.0
+  (* Pin env vars to sentinels so assertions are deterministic regardless
+     of the host environment. Restore originals on exit. *)
+  let pin key value = Unix.putenv key (string_of_float value) in
+  let snap key = try Some (key, Unix.getenv key) with Not_found -> None in
+  let saved =
+    List.filter_map snap
+      [ "MASC_EXEC_TIMEOUT_SHELL_SEC"
+      ; "MASC_EXEC_TIMEOUT_SANDBOX_SEC"
+      ; "MASC_EXEC_TIMEOUT_TURN_UP_SEC"
+      ; "MASC_EXEC_TIMEOUT_TURN_SANDBOX_SEC"
+      ]
+  in
+  pin "MASC_EXEC_TIMEOUT_SHELL_SEC" 60.0;
+  pin "MASC_EXEC_TIMEOUT_SANDBOX_SEC" 10.0;
+  pin "MASC_EXEC_TIMEOUT_TURN_UP_SEC" 15.0;
+  pin "MASC_EXEC_TIMEOUT_TURN_SANDBOX_SEC" 2.0;
+  Fun.protect
+    ~finally:(fun () ->
+      List.iter (function k, v -> Unix.putenv k v) saved)
+    (fun () ->
+      check
+        (float 0.001)
+        "exec keeps shell budget"
+        60.0
+        (Docker_client_real.session_exec_timeout_sec ());
+      check
+        (float 0.001)
+        "probe keeps sandbox budget"
+        10.0
+        (Docker_client_real.docker_probe_timeout_sec ());
+      check
+        (float 0.001)
+        "start keeps turn-up budget"
+        15.0
+        (Docker_client_real.session_start_timeout_sec ());
+      check
+        (float 0.001)
+        "preflight keeps short turn-sandbox budget"
+        2.0
+        (Docker_client_real.session_preflight_timeout_sec ()))
     (Docker_client_real.session_preflight_timeout_sec ())
 ;;
 

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -509,6 +509,47 @@ let test_is_eintr_127_false_on_signal () =
     (Docker_client_real.is_eintr_127 (Unix.WSIGNALED 9) "interrupted system call")
 ;;
 
+let test_exec_gate_blocked_detects_126_sentinel () =
+  check
+    bool
+    "blocked"
+    true
+    (Docker_client_real.is_exec_gate_blocked
+       (Unix.WEXITED 126)
+       "exec_gate_blocked: policy denied")
+;;
+
+let test_exec_gate_blocked_rejects_plain_126 () =
+  check
+    bool
+    "plain 126"
+    false
+    (Docker_client_real.is_exec_gate_blocked (Unix.WEXITED 126) "permission denied")
+;;
+
+let test_docker_real_timeout_budgets_are_separated () =
+  check
+    (float 0.001)
+    "exec keeps shell budget"
+    60.0
+    (Docker_client_real.session_exec_timeout_sec ());
+  check
+    (float 0.001)
+    "probe keeps sandbox budget"
+    10.0
+    (Docker_client_real.docker_probe_timeout_sec ());
+  check
+    (float 0.001)
+    "start keeps turn-up budget"
+    15.0
+    (Docker_client_real.session_start_timeout_sec ());
+  check
+    (float 0.001)
+    "preflight keeps short turn-sandbox budget"
+    2.0
+    (Docker_client_real.session_preflight_timeout_sec ())
+;;
+
 let () =
   run
     "Docker_client_real (Phase 3b-iv.2.3)"
@@ -603,6 +644,20 @@ let () =
             `Quick
             test_is_eintr_127_false_on_other_exit_codes
         ; test_case "signal ⇒ false" `Quick test_is_eintr_127_false_on_signal
+        ] )
+    ; ( "exec gate / timeout policy (pure, Phase 4.1-g)"
+      , [ test_case
+            "126 + exec_gate_blocked marker ⇒ true"
+            `Quick
+            test_exec_gate_blocked_detects_126_sentinel
+        ; test_case
+            "plain 126 ⇒ false"
+            `Quick
+            test_exec_gate_blocked_rejects_plain_126
+        ; test_case
+            "Docker real timeout callers stay separated"
+            `Quick
+            test_docker_real_timeout_budgets_are_separated
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- make config-doctor catalog diagnostics use side-effect-suppressed loader paths, including validator fallback paths and TOML read-race telemetry
- make legacy `cascade.json` without `cascade.toml` tell operators to migrate or rename to `cascade.toml`
- restore Docker real session exec/start timeout budgets and classify the `exec_gate_blocked:` sentinel as daemon-level failure

## Audit

- audited merged PRs from `2026-05-10T07:27:47Z` to `2026-05-12T07:27:47Z`: 548 exact 48h PRs
- post-merge branch candidates found: 58
- unresolved review threads found: 662
- applied current-main-valid high-impact review findings from https://github.com/jeong-sik/masc-mcp/pull/14995 and https://github.com/jeong-sik/masc-mcp/pull/14989
- skipped stale/reused branch stacks and doc/style-only backlog outside this focused runtime follow-up

## Verification

- `git diff --check`
- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_config_doctor.exe test/test_docker_client_real.exe`
- `./_build/default/test/test_config_doctor.exe test doctor 0-6 --show-errors`
- `./_build/default/test/test_docker_client_real.exe`

## Known Local Test Gap

- Full `./_build/default/test/test_config_doctor.exe --show-errors` still fails in the existing `analyze_live surfaces sandbox preflight failure` case: expected `warn`, got `error`. The new config-doctor regression subset passes.
