### PR TITLE
fix(dashboard): validate cascade and config responses

### DIFF
--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -3,8 +3,11 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import tseslint from 'typescript-eslint'
 
 const TARGET_FILES = [
+  'src/api/dashboard-cascade.ts',
   'src/api/gate.ts',
   'src/api/goal-loop.ts',
+  'src/api/schemas/cascade.ts',
+  'src/api/schemas/dashboard-config.ts',
   'src/api/transport-health.ts',
   'src/components/common/async-container.ts',
   'src/components/common/empty-state.ts',
@@ -27,6 +30,8 @@ const TARGET_FILES = [
 ]
 
 const TEST_FILES = [
+  'src/api/schemas/cascade.test.ts',
+  'src/api/schemas/dashboard-config.test.ts',
   'src/cb-shared-telemetry-source.test.ts',
   'src/components/common/markdown.test.ts',
   'src/components/connector-status.test.ts',

--- a/dashboard/src/api/dashboard-cascade.ts
+++ b/dashboard/src/api/dashboard-cascade.ts
@@ -1,11 +1,30 @@
 import { get, post } from './core'
+import {
+  parseCascadeConfigResponse,
+  parseCascadeHealthResponse,
+  parseCascadeRawConfigResponse,
+} from './schemas/cascade'
+import type {
+  CascadeConfigResponse,
+  CascadeHealthResponse,
+  CascadeInvalidProfile,
+  CascadeRawConfigResponse,
+} from './schemas/cascade'
+export { CascadeSchemaDriftError } from './schemas/cascade'
+export type {
+  CascadeCandidate,
+  CascadeConfigResponse,
+  CascadeHealthProvider,
+  CascadeHealthResponse,
+  CascadeInvalidProfile,
+  CascadeKeeperProfile,
+  CascadeProfile,
+  CascadeProviderStatus,
+  CascadeRawConfigResponse,
+  CascadeValidationStatus,
+} from './schemas/cascade'
 
 // --- Keeper Cascade Config ---
-
-export interface CascadeInvalidProfile {
-  name: string
-  errors: string[]
-}
 
 export function fetchCascadeProfiles(): Promise<{
   profiles: string[]
@@ -23,153 +42,31 @@ export function updateKeeperCascade(keeper: string, cascade_name: string): Promi
 
 // --- Cascade config + health (observability) ---
 
-export interface CascadeCandidate {
-  model: string
-  display_model?: string | null
-  provider_name?: string | null
-  display_provider_name?: string | null
-  runtime_kind?: string | null
-  expanded_models?: string[] | null
-  config_weight: number
-  effective_weight: number
-  success_rate: number
-  in_cooldown: boolean
-}
-
-export interface CascadeProfile {
-  name: string
-  /** [load_failed] is emitted when the cascade.toml/json file failed
-   *  to load (parse / IO / unknown field).  Distinguishes a fault
-   *  from operator-intended absence of a profile, so the UI can render
-   *  a `bad`-tone badge instead of the `warn` chip used for the
-   *  benign hardcoded_defaults path. */
-  source: 'named' | 'default_fallback' | 'hardcoded_defaults' | 'load_failed'
-  keeper_assignable: boolean
-  candidates: CascadeCandidate[]
-}
-
-export interface CascadeKeeperProfile {
-  keeper: string
-  cascade_name: string
-  canonical: string
-}
-
-export type CascadeValidationStatus =
-  | 'validated'
-  | 'serving_valid_subset'
-  | 'serving_last_known_good'
-  | 'invalid'
-
-export interface CascadeConfigResponse {
-  updated_at: string
-  source_path: string
-  validation_status: CascadeValidationStatus
-  validation_errors: string[]
-  invalid_profiles: CascadeInvalidProfile[]
-  profiles: CascadeProfile[]
-  keeper_profiles: CascadeKeeperProfile[]
-}
-
-export interface CascadeRawConfigResponse {
-  updated_at: string
-  source_path: string
-  source_editable: boolean
-  source_text: string
-}
-
-/** Operational state reported next to [provider_key] on the dashboard.
- *  - `active`: tracker recorded at least one event in the current window.
- *  - `cooldown`: tracker opened a cooldown window.
- *  - `configured`: declared in `cascade.json` but zero traffic in the
- *    current window (either untouched since startup or expired out).
- *  @since 0.173.0 */
-export type CascadeProviderStatus = 'active' | 'cooldown' | 'configured'
-
-export interface CascadeHealthProvider {
-  provider_key: string
-  success_rate: number
-  consecutive_failures: number
-  in_cooldown: boolean
-  cooldown_expires_at: number | null
-  events_in_window: number
-  /** Subset of [events_in_window] with outcome "rejected" — response
-   *  arrived but was rejected by the cascade's accept predicate. Split
-   *  so the dashboard can tell "provider down" from "provider returns
-   *  unusable output".
-   *  @since 0.160.0 — optional for backward compat with older servers. */
-  rejected_in_window?: number
-  /** `true` iff any `cascade.json` profile lists a model whose scheme
-   *  prefix matches `provider_key`. `false` surfaces providers that
-   *  were tracked but are no longer referenced by config (e.g. after
-   *  a cascade rename).
-   *  @since 0.173.0 — optional for backward compat with older servers. */
-  declared?: boolean
-  /** @since 0.173.0 — optional for backward compat with older servers. */
-  status?: CascadeProviderStatus
-  /** Entry-weighted mean prefill throughput across all models that
-   *  share this provider scheme, over the last `perf_window_minutes`
-   *  of keeper decisions.jsonl. `null` when no contributing model
-   *  reported inference_timings (Anthropic/Gemini path).
-   *  @since 0.173.1 — optional; backend returns only when `base_path`
-   *  is wired (always in production, never in test harnesses). */
-  avg_prompt_tok_per_sec?: number | null
-  /** @since 0.173.1 */
-  avg_decode_tok_per_sec?: number | null
-  /** @since 0.173.1 */
-  avg_tok_per_sec?: number | null
-  /** @since 0.173.1 */
-  avg_latency_ms?: number | null
-  /** Approximation: entry-weighted mean of per-model p50.  Not a true
-   *  cross-model percentile; fine for dashboard sparklines.  When
-   *  exact values are needed, compute from recent_entries in
-   *  `/api/v1/runtime/model-metrics`.
-   *  @since 0.173.1 */
-  p50_latency_ms?: number | null
-  /** @since 0.173.1 — see `p50_latency_ms`. */
-  p95_latency_ms?: number | null
-  /** Number of keeper turns attributed to this provider in the perf
-   *  window.  `null` when the backend was unable to run the aggregate
-   *  (missing `base_path`); `0` when it ran and found none.
-   *  @since 0.173.1 */
-  request_count?: number | null
-}
-
-export interface CascadeHealthResponse {
-  updated_at: string
-  window_sec: number
-  cooldown_threshold: number
-  cooldown_sec: number
-  hard_quota_cooldown_sec: number
-  providers: CascadeHealthProvider[]
-  /** Window used by the per-provider perf aggregate.  `null` when the
-   *  backend did not compute perf (no `base_path`, matches every
-   *  provider having null perf fields).
-   *  @since 0.173.1 — optional for backward compat with older servers. */
-  perf_window_minutes?: number | null
-}
-
 export function fetchCascadeConfig(
   opts?: { signal?: AbortSignal },
 ): Promise<CascadeConfigResponse> {
-  return get<CascadeConfigResponse>('/api/v1/cascade/config', { signal: opts?.signal })
+  return get<unknown>('/api/v1/cascade/config', { signal: opts?.signal })
+    .then(parseCascadeConfigResponse)
 }
 
 export function fetchCascadeConfigRaw(
   opts?: { signal?: AbortSignal },
 ): Promise<CascadeRawConfigResponse> {
-  return get<CascadeRawConfigResponse>('/api/v1/cascade/config/raw', {
+  return get<unknown>('/api/v1/cascade/config/raw', {
     signal: opts?.signal,
-  })
+  }).then(parseCascadeRawConfigResponse)
 }
 
 export function updateCascadeConfigRaw(source_text: string): Promise<CascadeConfigResponse> {
-  return post<CascadeConfigResponse>('/api/v1/cascade/config/raw', { source_text })
+  return post<unknown>('/api/v1/cascade/config/raw', { source_text })
+    .then(parseCascadeConfigResponse)
 }
 
 export function fetchCascadeHealth(
   opts?: { signal?: AbortSignal },
 ): Promise<CascadeHealthResponse> {
-  return get<CascadeHealthResponse>('/api/v1/cascade/health', { signal: opts?.signal })
+  return get<unknown>('/api/v1/cascade/health', { signal: opts?.signal })
+    .then(parseCascadeHealthResponse)
 }
 
 type CascadeCapacityKind = 'cli' | 'ollama' | 'other'

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -21,6 +21,10 @@ import {
   type AgentTimelineEvent,
   type AgentTimelineResponse,
 } from './schemas/agent-timeline'
+import {
+  parseDashboardConfigResponse,
+  type DashboardConfigResponse,
+} from './schemas/dashboard-config'
 import { parseLogsResponse, type LogEntry, type LogsResponse } from './schemas/logs'
 import { asKeeperRuntimeBlockerClass } from '../lib/runtime-blocker-class'
 import type {
@@ -62,6 +66,13 @@ import type {
   DashboardConfigResolution,
   DashboardRuntimeResolution,
 } from '../types'
+export { DashboardConfigSchemaDriftError } from './schemas/dashboard-config'
+export type {
+  ConfigEntry,
+  ConfigEntryProvenance,
+  ConfigEntrySource,
+  DashboardConfigResponse,
+} from './schemas/dashboard-config'
 export {
   fetchCascadeAuditRuns,
   fetchCascadeClientCapacity,
@@ -166,39 +177,8 @@ export async function fetchAgentRelations(agentName: string): Promise<AgentRelat
   return parseAgentRelationsResponse(raw)
 }
 
-export type ConfigEntrySource = 'env' | 'default' | 'derived' | 'runtime'
-
-export interface ConfigEntryProvenance {
-  kind: ConfigEntrySource
-  detail: string
-  derived_from?: string[]
-}
-
-export interface ConfigEntry {
-  env: string
-  description: string
-  value: string | null
-  default: string
-  source: ConfigEntrySource
-  source_detail?: string
-  provenance?: ConfigEntryProvenance
-  sensitive: boolean
-}
-
-export interface DashboardConfigResponse {
-  generated_at: string
-  server: {
-    version: string
-    git_commit: string | null
-    ocaml_version: string
-    uptime_seconds: number
-    pid: number
-  }
-  categories: Record<string, ConfigEntry[]>
-}
-
 export function fetchDashboardConfig(): Promise<DashboardConfigResponse> {
-  return get('/api/v1/dashboard/config')
+  return get<unknown>('/api/v1/dashboard/config').then(parseDashboardConfigResponse)
 }
 
 /** Parse runtime context-ratio thresholds from the dashboard config response.

--- a/dashboard/src/api/schemas/cascade.test.ts
+++ b/dashboard/src/api/schemas/cascade.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CascadeSchemaDriftError,
+  parseCascadeConfigResponse,
+  parseCascadeHealthResponse,
+  parseCascadeRawConfigResponse,
+} from './cascade'
+
+const validConfig = {
+  updated_at: '2026-05-12T00:00:00Z',
+  source_path: '/tmp/masc/cascade.toml',
+  validation_status: 'validated',
+  validation_errors: [],
+  invalid_profiles: [{ name: 'broken', errors: ['missing model'] }],
+  profiles: [
+    {
+      name: 'keeper_unified',
+      source: 'named',
+      keeper_assignable: true,
+      candidates: [
+        {
+          model: 'glm-coding:auto',
+          display_model: 'glm-coding',
+          provider_name: 'glm',
+          display_provider_name: 'GLM',
+          runtime_kind: 'cli',
+          expanded_models: ['glm-coding:auto'],
+          config_weight: 1,
+          effective_weight: 1,
+          success_rate: 0.98,
+          in_cooldown: false,
+        },
+      ],
+    },
+  ],
+  keeper_profiles: [
+    {
+      keeper: 'sangsu',
+      cascade_name: 'keeper_unified',
+      canonical: 'keeper_unified',
+    },
+  ],
+}
+
+describe('cascade API schemas', () => {
+  it('parses valid cascade config payloads', () => {
+    const parsed = parseCascadeConfigResponse(validConfig)
+
+    expect(parsed.validation_status).toBe('validated')
+    expect(parsed.profiles[0]?.candidates[0]?.model).toBe('glm-coding:auto')
+  })
+
+  it('throws typed drift errors when a required config field is missing', () => {
+    const drifted: Record<string, unknown> = { ...validConfig }
+    delete drifted.validation_status
+
+    expect(() => parseCascadeConfigResponse(drifted)).toThrow(CascadeSchemaDriftError)
+  })
+
+  it('parses raw cascade config payloads', () => {
+    const parsed = parseCascadeRawConfigResponse({
+      updated_at: '2026-05-12T00:00:00Z',
+      source_path: '/tmp/masc/cascade.toml',
+      source_editable: true,
+      source_text: '[profiles.keeper_unified]\n',
+    })
+
+    expect(parsed.source_editable).toBe(true)
+    expect(parsed.source_text).toContain('keeper_unified')
+  })
+
+  it('parses valid cascade health payloads', () => {
+    const parsed = parseCascadeHealthResponse({
+      updated_at: '2026-05-12T00:00:00Z',
+      window_sec: 300,
+      cooldown_threshold: 3,
+      cooldown_sec: 120,
+      hard_quota_cooldown_sec: 900,
+      perf_window_minutes: null,
+      providers: [
+        {
+          provider_key: 'glm',
+          success_rate: 1,
+          consecutive_failures: 0,
+          in_cooldown: false,
+          cooldown_expires_at: null,
+          events_in_window: 4,
+          rejected_in_window: 0,
+          declared: true,
+          status: 'active',
+          request_count: null,
+        },
+      ],
+    })
+
+    expect(parsed.providers[0]?.status).toBe('active')
+  })
+})

--- a/dashboard/src/api/schemas/cascade.ts
+++ b/dashboard/src/api/schemas/cascade.ts
@@ -1,0 +1,153 @@
+// Cascade dashboard schemas — schema-at-boundary for
+// `/api/v1/cascade/{config,config/raw,health}`.
+//
+// These endpoints drive operational UI state, so missing required
+// fields are treated as backend/frontend contract drift. Optional
+// additive fields stay optional to preserve compatibility with older
+// servers.
+
+import {
+  array,
+  boolean,
+  nullable,
+  number,
+  object,
+  optional,
+  picklist,
+  string,
+  type BaseIssue,
+  type InferOutput,
+} from 'valibot'
+
+import { SchemaDriftError, parseOrThrow } from './drift-error'
+
+const CascadeInvalidProfileSchema = object({
+  name: string(),
+  errors: array(string()),
+})
+
+export type CascadeInvalidProfile = InferOutput<typeof CascadeInvalidProfileSchema>
+
+const CascadeCandidateSchema = object({
+  model: string(),
+  display_model: optional(nullable(string())),
+  provider_name: optional(nullable(string())),
+  display_provider_name: optional(nullable(string())),
+  runtime_kind: optional(nullable(string())),
+  expanded_models: optional(nullable(array(string()))),
+  config_weight: number(),
+  effective_weight: number(),
+  success_rate: number(),
+  in_cooldown: boolean(),
+})
+
+export type CascadeCandidate = InferOutput<typeof CascadeCandidateSchema>
+
+const CascadeProfileSourceSchema = picklist([
+  'named',
+  'default_fallback',
+  'hardcoded_defaults',
+  'load_failed',
+])
+
+const CascadeProfileSchema = object({
+  name: string(),
+  source: CascadeProfileSourceSchema,
+  keeper_assignable: boolean(),
+  candidates: array(CascadeCandidateSchema),
+})
+
+export type CascadeProfile = InferOutput<typeof CascadeProfileSchema>
+
+const CascadeKeeperProfileSchema = object({
+  keeper: string(),
+  cascade_name: string(),
+  canonical: string(),
+})
+
+export type CascadeKeeperProfile = InferOutput<typeof CascadeKeeperProfileSchema>
+
+const CascadeValidationStatusSchema = picklist([
+  'validated',
+  'serving_valid_subset',
+  'serving_last_known_good',
+  'invalid',
+])
+
+export type CascadeValidationStatus = InferOutput<typeof CascadeValidationStatusSchema>
+
+const CascadeConfigResponseSchema = object({
+  updated_at: string(),
+  source_path: string(),
+  validation_status: CascadeValidationStatusSchema,
+  validation_errors: array(string()),
+  invalid_profiles: array(CascadeInvalidProfileSchema),
+  profiles: array(CascadeProfileSchema),
+  keeper_profiles: array(CascadeKeeperProfileSchema),
+})
+
+export type CascadeConfigResponse = InferOutput<typeof CascadeConfigResponseSchema>
+
+const CascadeRawConfigResponseSchema = object({
+  updated_at: string(),
+  source_path: string(),
+  source_editable: boolean(),
+  source_text: string(),
+})
+
+export type CascadeRawConfigResponse = InferOutput<typeof CascadeRawConfigResponseSchema>
+
+const CascadeProviderStatusSchema = picklist(['active', 'cooldown', 'configured'])
+
+export type CascadeProviderStatus = InferOutput<typeof CascadeProviderStatusSchema>
+
+const CascadeHealthProviderSchema = object({
+  provider_key: string(),
+  success_rate: number(),
+  consecutive_failures: number(),
+  in_cooldown: boolean(),
+  cooldown_expires_at: nullable(number()),
+  events_in_window: number(),
+  rejected_in_window: optional(number()),
+  declared: optional(boolean()),
+  status: optional(CascadeProviderStatusSchema),
+  avg_prompt_tok_per_sec: optional(nullable(number())),
+  avg_decode_tok_per_sec: optional(nullable(number())),
+  avg_tok_per_sec: optional(nullable(number())),
+  avg_latency_ms: optional(nullable(number())),
+  p50_latency_ms: optional(nullable(number())),
+  p95_latency_ms: optional(nullable(number())),
+  request_count: optional(nullable(number())),
+})
+
+export type CascadeHealthProvider = InferOutput<typeof CascadeHealthProviderSchema>
+
+const CascadeHealthResponseSchema = object({
+  updated_at: string(),
+  window_sec: number(),
+  cooldown_threshold: number(),
+  cooldown_sec: number(),
+  hard_quota_cooldown_sec: number(),
+  providers: array(CascadeHealthProviderSchema),
+  perf_window_minutes: optional(nullable(number())),
+})
+
+export type CascadeHealthResponse = InferOutput<typeof CascadeHealthResponseSchema>
+
+export class CascadeSchemaDriftError extends SchemaDriftError {
+  constructor(issues: readonly BaseIssue<unknown>[]) {
+    super('cascade', issues)
+  }
+}
+
+export function parseCascadeConfigResponse(data: unknown): CascadeConfigResponse {
+  return parseOrThrow(CascadeSchemaDriftError, CascadeConfigResponseSchema, data)
+}
+
+export function parseCascadeRawConfigResponse(data: unknown): CascadeRawConfigResponse {
+  return parseOrThrow(CascadeSchemaDriftError, CascadeRawConfigResponseSchema, data)
+}
+
+export function parseCascadeHealthResponse(data: unknown): CascadeHealthResponse {
+  return parseOrThrow(CascadeSchemaDriftError, CascadeHealthResponseSchema, data)
+}

--- a/dashboard/src/api/schemas/dashboard-config.test.ts
+++ b/dashboard/src/api/schemas/dashboard-config.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DashboardConfigSchemaDriftError,
+  parseDashboardConfigResponse,
+} from './dashboard-config'
+
+const validDashboardConfig = {
+  generated_at: '2026-05-12T00:00:00Z',
+  server: {
+    version: '0.19.17',
+    git_commit: null,
+    ocaml_version: '5.4.0',
+    uptime_seconds: 42,
+    pid: 12345,
+  },
+  categories: {
+    dashboard: [
+      {
+        env: 'MASC_DASHBOARD_CTX_PREPARING',
+        description: 'Warn threshold',
+        value: '0.72',
+        default: '0.70',
+        source: 'env',
+        source_detail: 'process env',
+        provenance: {
+          kind: 'runtime',
+          detail: 'derived at boot',
+          derived_from: ['MASC_DASHBOARD_CTX_PREPARING'],
+        },
+        sensitive: false,
+      },
+    ],
+  },
+}
+
+describe('dashboard config schema', () => {
+  it('parses valid dashboard config payloads', () => {
+    const parsed = parseDashboardConfigResponse(validDashboardConfig)
+
+    expect(parsed.server.version).toBe('0.19.17')
+    expect(parsed.categories.dashboard?.[0]?.env).toBe('MASC_DASHBOARD_CTX_PREPARING')
+  })
+
+  it('throws typed drift errors when required server fields are missing', () => {
+    const drifted = {
+      ...validDashboardConfig,
+      server: {
+        version: '0.19.17',
+        git_commit: null,
+        ocaml_version: '5.4.0',
+        uptime_seconds: 42,
+      },
+    }
+
+    expect(() => parseDashboardConfigResponse(drifted)).toThrow(DashboardConfigSchemaDriftError)
+  })
+})

--- a/dashboard/src/api/schemas/dashboard-config.ts
+++ b/dashboard/src/api/schemas/dashboard-config.ts
@@ -1,0 +1,73 @@
+// Dashboard config schema — schema-at-boundary for
+// `GET /api/v1/dashboard/config`.
+//
+// The config panel renders operational truth from env/default/runtime
+// provenance. Missing required fields indicate backend/frontend
+// contract drift rather than a display-only absence.
+
+import {
+  array,
+  boolean,
+  nullable,
+  number,
+  object,
+  optional,
+  picklist,
+  record,
+  string,
+  type BaseIssue,
+  type InferOutput,
+} from 'valibot'
+
+import { SchemaDriftError, parseOrThrow } from './drift-error'
+
+const ConfigEntrySourceSchema = picklist(['env', 'default', 'derived', 'runtime'])
+
+export type ConfigEntrySource = InferOutput<typeof ConfigEntrySourceSchema>
+
+const ConfigEntryProvenanceSchema = object({
+  kind: ConfigEntrySourceSchema,
+  detail: string(),
+  derived_from: optional(array(string())),
+})
+
+export type ConfigEntryProvenance = InferOutput<typeof ConfigEntryProvenanceSchema>
+
+const ConfigEntrySchema = object({
+  env: string(),
+  description: string(),
+  value: nullable(string()),
+  default: string(),
+  source: ConfigEntrySourceSchema,
+  source_detail: optional(string()),
+  provenance: optional(ConfigEntryProvenanceSchema),
+  sensitive: boolean(),
+})
+
+export type ConfigEntry = InferOutput<typeof ConfigEntrySchema>
+
+const DashboardConfigServerSchema = object({
+  version: string(),
+  git_commit: nullable(string()),
+  ocaml_version: string(),
+  uptime_seconds: number(),
+  pid: number(),
+})
+
+const DashboardConfigResponseSchema = object({
+  generated_at: string(),
+  server: DashboardConfigServerSchema,
+  categories: record(string(), array(ConfigEntrySchema)),
+})
+
+export type DashboardConfigResponse = InferOutput<typeof DashboardConfigResponseSchema>
+
+export class DashboardConfigSchemaDriftError extends SchemaDriftError {
+  constructor(issues: readonly BaseIssue<unknown>[]) {
+    super('dashboard-config', issues)
+  }
+}
+
+export function parseDashboardConfigResponse(data: unknown): DashboardConfigResponse {
+  return parseOrThrow(DashboardConfigSchemaDriftError, DashboardConfigResponseSchema, data)
+}


### PR DESCRIPTION
## Summary
- Add valibot schema boundaries for dashboard cascade and dashboard config responses.
- Parse unknown API responses before UI consumption and throw explicit drift errors on invalid payloads.
- Cover cascade/config schemas with focused tests and lint scope.

## Validation
- pnpm --dir dashboard install --offline
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/schemas/cascade.test.ts src/api/schemas/dashboard-config.test.ts src/api/dashboard-cascade.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty
- pnpm exec eslint src/api/dashboard-cascade.ts src/api/schemas/cascade.ts src/api/schemas/dashboard-config.ts src/api/schemas/cascade.test.ts src/api/schemas/dashboard-config.test.ts
- git diff --check