### PR TITLE
fix(keeper): hide autoresearch from default discovery

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -14,8 +14,7 @@ let dedupe_schemas (schemas : Masc_domain.tool_schema list) =
   List.rev unique
 
 let retired_front_door_schema_names =
-  [
-  ]
+  Tool_autoresearch.schemas |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
 
 let filter_retired_front_door_schemas (schemas : Masc_domain.tool_schema list) =
   List.filter
@@ -24,30 +23,32 @@ let filter_retired_front_door_schemas (schemas : Masc_domain.tool_schema list) =
     schemas
 
 let raw_all_tool_schemas : Masc_domain.tool_schema list =
-  filter_retired_front_door_schemas
-    (dedupe_schemas
-       (Tools.raw_schemas
-       @ Tool_schemas_misc.schemas
-       @ Tool_board.tools
-       @ Keeper_types.schemas
-       @ Tool_local_runtime.schemas
-       @ Tool_autoresearch.schemas
-       @ Tool_agent_timeline.schemas
-       @ Tool_shard.schemas
-       (* #9912 / #10101: every keeper-facing shard tool must reach the
-          authoritative registry consumed by
-          [Tool_help_registry.find_entry], or keepers that request
-          help on the tool receive "unknown tool" despite the
-          dispatcher handling it correctly.  #9912 plugged only
-          [Tool_shard.base_tools] (5 always-present tools); #10101
-          observed 11 other shard categories still missing
-          (keeper_task_claim, keeper_fs_edit, keeper_board_*, ...).
-          [Tool_shard.all_keeper_tool_schemas] is the SSOT that
-          pulls from [all_shards] plus the non-shard
-          [keeper_preflight_tools] / [keeper_pr_review_tools]
-          lists, so future shard categories flow through without
-          another patch-local fix. *)
-       @ Tool_shard.all_keeper_tool_schemas))
+  dedupe_schemas
+    (Tools.raw_schemas
+     @ Tool_schemas_misc.schemas
+     @ Tool_board.tools
+     @ Keeper_types.schemas
+     @ Tool_local_runtime.schemas
+     @ Tool_autoresearch.schemas
+     @ Tool_agent_timeline.schemas
+     @ Tool_shard.schemas
+     (* #9912 / #10101: every keeper-facing shard tool must reach the
+        authoritative registry consumed by
+        [Tool_help_registry.find_entry], or keepers that request
+        help on the tool receive "unknown tool" despite the
+        dispatcher handling it correctly.  #9912 plugged only
+        [Tool_shard.base_tools] (5 always-present tools); #10101
+        observed 11 other shard categories still missing
+        (keeper_task_claim, keeper_fs_edit, keeper_board_*, ...).
+        [Tool_shard.all_keeper_tool_schemas] is the SSOT that
+        pulls from [all_shards] plus the non-shard
+        [keeper_preflight_tools] / [keeper_pr_review_tools]
+        lists, so future shard categories flow through without
+        another patch-local fix. *)
+     @ Tool_shard.all_keeper_tool_schemas)
+
+let front_door_tool_schemas : Masc_domain.tool_schema list =
+  filter_retired_front_door_schemas raw_all_tool_schemas
 
 (** Validate tool schemas at module initialization time.
     Logs warnings for: duplicate names, empty names/descriptions,
@@ -90,7 +91,7 @@ let validate_schemas (schemas : Masc_domain.tool_schema list) =
 
 let all_tool_schemas : Masc_domain.tool_schema list =
   let schemas =
-    Capability_registry.public_tool_schemas_from raw_all_tool_schemas
+    Capability_registry.public_tool_schemas_from front_door_tool_schemas
   in
   validate_schemas schemas;
   schemas
@@ -119,7 +120,7 @@ let is_raw_tool_name name = Hashtbl.mem raw_tool_name_set name
 let visible_tool_schemas ?(include_hidden = false) ?(include_deprecated = false) () :
     Masc_domain.tool_schema list =
   Capability_registry.visible_public_tool_schemas_from ~include_hidden
-    ~include_deprecated raw_all_tool_schemas
+    ~include_deprecated front_door_tool_schemas
 
 let surface_tool_schemas ?(include_hidden = false) ?(include_deprecated = false) () :
     Masc_domain.tool_schema list =

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -79,6 +79,8 @@ let dedupe_tool_search_schemas schemas =
 let default_tool_search_schemas () =
   Tool_shard.all_keeper_tool_schemas @ [ keeper_tool_search_schema ]
   |> List.filter (fun (schema : Masc_domain.tool_schema) ->
+    not (String.starts_with ~prefix:"masc_autoresearch_" schema.name))
+  |> List.filter (fun (schema : Masc_domain.tool_schema) ->
     not (is_keeper_denied schema.name))
   |> dedupe_tool_search_schemas
 ;;

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -492,6 +492,9 @@ let keeper_default_model_tools (_meta : keeper_meta) : Masc_domain.tool_schema l
   keeper_model_tools @ keeper_voice_tool_schemas
   @ [ keeper_tool_search_schema ]
 
+let is_autoresearch_tool_name name =
+  String.starts_with ~prefix:"masc_autoresearch_" name
+
 (** Recovery minimum tools: non-removable shards only.
     Used in Failing phase to guarantee minimum tool availability.
     Phase B2: TLA+ RecoveryFloorMaintained invariant.
@@ -585,13 +588,20 @@ let keeper_preset_universe_tool_names (meta : keeper_meta) : string list =
   in
   dedupe_tool_names (from_preset @ from_core)
 
+let autoresearch_keeper_tools_for_meta (meta : keeper_meta) =
+  let scoped = keeper_preset_universe_tool_names meta in
+  if List.exists is_autoresearch_tool_name scoped then
+    Tool_shard.autoresearch_keeper_tools
+  else
+    []
+
 (** Shared schema assembly: computes the full tool schema list once.
     [masc_schemas_fn] selects policy-filtered or universe-filtered MASC schemas
     depending on the caller's access scope. *)
 let all_keeper_schemas ~(masc_schemas_fn : keeper_meta -> Masc_domain.tool_schema list)
     (meta : keeper_meta) : Masc_domain.tool_schema list =
   (keeper_default_model_tools meta)
-  @ Tool_shard.autoresearch_keeper_tools
+  @ autoresearch_keeper_tools_for_meta meta
   @ Tool_shard.coding_tools
   @ Tool_code_write.schemas
   @ Tool_shard.keeper_preflight_tools

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -1837,8 +1837,8 @@ let agent_shards : string list StringMap.t ref = ref StringMap.empty
 let agent_shards_mutex = Stdlib.Mutex.create ()
 
 (** Default shards for a new keeper.
-    All keepers get all shards unconditionally. Safety is handled by
-    eval_gate deny lists, not by shard membership. *)
+    Autoresearch is intentionally opt-in through the explicit shard or
+    a preset/tool policy group. *)
 let default_shard_names : string list =
   [ "base"
   ; "board"
@@ -1847,7 +1847,6 @@ let default_shard_names : string list =
   ; "library"
   ; "taskboard"
   ; "coding"
-  ; "autoresearch"
   ]
 ;;
 

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -79,7 +79,7 @@ val get_shard : string -> shard option
 
 val default_shard_names : string list
 (** Default shards for a new keeper: base, board, filesystem, shell,
-    library, taskboard, coding, autoresearch. *)
+    library, taskboard, coding. Autoresearch is opt-in. *)
 
 val tools_of_shards : string list -> Masc_domain.tool_schema list
 (** Combine tools from multiple shard names. *)

--- a/test/test_config_coverage.ml
+++ b/test/test_config_coverage.ml
@@ -80,6 +80,22 @@ let test_all_tool_names_omit_removed_mode_tools () =
     [ "masc_switch_mode"; "masc_get_config"; "masc_tool_enable";
       "masc_tool_disable" ]
 
+let test_front_door_omits_autoresearch_tools () =
+  let has_autoresearch schemas =
+    List.exists
+      (fun (schema : Masc_domain.tool_schema) ->
+         String.starts_with ~prefix:"masc_autoresearch_" schema.name)
+      schemas
+  in
+  check bool "raw registry keeps autoresearch dispatchable" true
+    (has_autoresearch Config.raw_all_tool_schemas);
+  check bool "public front door hides autoresearch" false
+    (has_autoresearch Config.all_tool_schemas);
+  check bool "visible discovery hides autoresearch" false
+    (has_autoresearch
+       (Config.visible_tool_schemas ~include_hidden:true
+          ~include_deprecated:true ()))
+
 let test_visible_tool_schemas_subset_of_all () =
   let visible = Config.visible_tool_schemas () in
   check bool "visible <= all" true
@@ -114,6 +130,8 @@ let () =
             test_approval_get_requires_admin_permission;
           test_case "removed mode tools omitted" `Quick
             test_all_tool_names_omit_removed_mode_tools;
+          test_case "front door omits autoresearch" `Quick
+            test_front_door_omits_autoresearch_tools;
           test_case "visible is subset of all" `Quick
             test_visible_tool_schemas_subset_of_all;
           test_case "pause visible" `Quick test_is_tool_visible_pause;

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -124,10 +124,10 @@ let test_default_has_no_legacy_governance_tools () =
   check bool "case brief submit removed" false (has_tool "masc_case_brief_submit" tools)
 ;;
 
-let test_default_has_research_tools () =
-  let meta = make_meta () in
+let test_coding_preset_hides_autoresearch_tools () =
+  let meta = make_meta ~preset:Keeper_types.Coding () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
-  check bool "has autoresearch" true (has_any_prefix "masc_autoresearch_" tools)
+  check bool "hides autoresearch" false (has_any_prefix "masc_autoresearch_" tools)
 ;;
 
 let test_custom_empty_blocks_all_tools () =
@@ -293,10 +293,10 @@ let test_legacy_pr_schemas_removed () =
 ;;
 
 (* ============================================================
-   6. All keepers get autoresearch tools (mode removed)
+   6. Autoresearch tools are opt-in through research-capable presets
    ============================================================ *)
 
-let test_all_keepers_have_autoresearch () =
+let test_research_preset_has_autoresearch () =
   let meta = make_meta ~preset:Keeper_types.Research () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
   check bool "has autoresearch" true (has_any_prefix "masc_autoresearch_" tools)
@@ -1196,7 +1196,10 @@ let () =
             "legacy governance tools removed"
             `Quick
             test_default_has_no_legacy_governance_tools
-        ; test_case "has research tools" `Quick test_default_has_research_tools
+        ; test_case
+            "coding preset hides autoresearch tools"
+            `Quick
+            test_coding_preset_hides_autoresearch_tools
         ; test_case
             "custom empty blocks all tools"
             `Quick
@@ -1256,9 +1259,9 @@ let () =
         ] )
     ; ( "autoresearch_tools"
       , [ test_case
-            "all keepers have autoresearch"
+            "research preset has autoresearch"
             `Quick
-            test_all_keepers_have_autoresearch
+            test_research_preset_has_autoresearch
         ] )
     ; ( "mode_free_access"
       , [ test_case

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -18,6 +18,7 @@ let make_test_meta
       ?(name = "test-keeper")
       ?(preset = Keeper_types.Full)
       ?(also_allow = [])
+      ?(allowed_paths = [ "*" ])
       ?tool_access
       ()
   : Keeper_types.keeper_meta
@@ -33,7 +34,7 @@ let make_test_meta
           [ "name", `String name
           ; "agent_name", `String name
           ; "trace_id", `String "test-trace-001"
-          ; "allowed_paths", `List [ `String "*" ]
+          ; "allowed_paths", `List (List.map (fun path -> `String path) allowed_paths)
           ; "tool_access", Keeper_types.tool_access_to_json tool_access
           ])
   with
@@ -154,6 +155,27 @@ let find_tool name tools =
   List.find (fun (tool : Tool.t) -> String.equal tool.schema.name name) tools
 ;;
 
+let find_read_tool tools = find_tool "Read" tools
+
+let read_repo_dir meta =
+  Filename.concat "repos" meta.Keeper_types.name
+;;
+
+let read_path meta path = Filename.concat (read_repo_dir meta) path
+
+let read_args meta path = `Assoc [ "file_path", `String (read_path meta path) ]
+
+let ensure_read_repo_dir config meta =
+  let root = Keeper_alerting_path.project_root_of_config config in
+  Fs_compat.mkdir_p (Filename.concat root (read_repo_dir meta))
+;;
+
+let make_registered_tools ~config ~meta ~ctx_snapshot () =
+  let keeper_name = meta.Keeper_types.name in
+  ignore (Keeper_registry.register ~base_path:config.Coord.base_path keeper_name meta);
+  Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot ()
+;;
+
 let dummy_schedule : Agent_sdk.Hooks.tool_schedule =
   { planned_index = 0
   ; batch_index = 0
@@ -188,7 +210,9 @@ let rec rm_rf path =
 ;;
 
 let test_tool_side_effect_failures_are_observed () =
-  let meta = make_test_meta ~name:"test-keeper-side-effects" () in
+  let meta =
+    make_test_meta ~name:"test-keeper-side-effects" ~allowed_paths:[ "repos" ] ()
+  in
   let ctx_snapshot = make_test_ctx () in
   let dir = Filename.temp_file "test_keeper_tools_side_effects_" "" in
   Sys.remove dir;
@@ -200,13 +224,14 @@ let test_tool_side_effect_failures_are_observed () =
        @@ fun env ->
        Fs_compat.set_fs (Eio.Stdenv.fs env);
        let config = Coord.default_config dir in
+       ensure_read_repo_dir config meta;
        let decision_path =
          Keeper_types_support.keeper_decision_log_path config meta.name
        in
        Fs_compat.mkdir_p (Filename.dirname decision_path);
        Unix.mkdir decision_path 0o755;
-       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-       let tool = find_tool "keeper_fs_read" tools in
+       let tools = make_registered_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_read_tool tools in
        let keeper_labels = [ "keeper", meta.name ] in
        let sse_before =
          Prometheus.metric_value_or_zero
@@ -230,7 +255,7 @@ let test_tool_side_effect_failures_are_observed () =
             match
               Tool.execute
                 tool
-                (`Assoc [ "path", `String "missing-side-effect-file.txt" ])
+                (read_args meta "missing-side-effect-file.txt")
             with
             | Error _ -> ()
             | Ok _ -> fail "missing file should be surfaced as tool error");
@@ -382,7 +407,9 @@ let is_guardrail_message message =
 ;;
 
 let test_error_json_is_returned_as_tool_error () =
-  let meta = make_test_meta () in
+  let meta =
+    make_test_meta ~name:"test-keeper-error-json" ~allowed_paths:[ "repos" ] ()
+  in
   let ctx_snapshot = make_test_ctx () in
   let dir =
     Filename.concat
@@ -403,12 +430,13 @@ let test_error_json_is_returned_as_tool_error () =
        @@ fun env ->
        Fs_compat.set_fs (Eio.Stdenv.fs env);
        let config = Coord.default_config dir in
-       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-       let tool = find_tool "keeper_fs_read" tools in
+       ensure_read_repo_dir config meta;
+       let tools = make_registered_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_read_tool tools in
        match
          Tool.execute
            tool
-           (`Assoc [ "path", `String "missing-file-for-keeper-tools-oas.txt" ])
+           (read_args meta "missing-file-for-keeper-tools-oas.txt")
        with
        | Error { Agent_sdk.Types.message; _ } ->
          let json = Yojson.Safe.from_string message in
@@ -429,7 +457,9 @@ let test_error_json_is_returned_as_tool_error () =
 ;;
 
 let test_oas_handler_rejects_missing_required_args () =
-  let meta = make_test_meta () in
+  let meta =
+    make_test_meta ~name:"test-keeper-validation" ~allowed_paths:[ "repos" ] ()
+  in
   let ctx_snapshot = make_test_ctx () in
   let dir =
     Filename.concat
@@ -450,8 +480,9 @@ let test_oas_handler_rejects_missing_required_args () =
        @@ fun env ->
        Fs_compat.set_fs (Eio.Stdenv.fs env);
        let config = Coord.default_config dir in
-       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-       let tool = find_tool "keeper_fs_read" tools in
+       ensure_read_repo_dir config meta;
+       let tools = make_registered_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_read_tool tools in
        match Tool.execute tool (`Assoc []) with
        | Error { Agent_sdk.Types.message; _ } ->
          let json = Yojson.Safe.from_string message in
@@ -477,7 +508,9 @@ let latest_log_seq () =
 ;;
 
 let test_error_result_logs_at_error_level () =
-  let meta = make_test_meta () in
+  let meta =
+    make_test_meta ~name:"test-keeper-log-level" ~allowed_paths:[ "repos" ] ()
+  in
   let ctx_snapshot = make_test_ctx () in
   let dir =
     Filename.concat
@@ -498,13 +531,14 @@ let test_error_result_logs_at_error_level () =
        @@ fun env ->
        Fs_compat.set_fs (Eio.Stdenv.fs env);
        let config = Coord.default_config dir in
-       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-       let tool = find_tool "keeper_fs_read" tools in
+       ensure_read_repo_dir config meta;
+       let tools = make_registered_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_read_tool tools in
        let baseline = latest_log_seq () in
        (match
-          Tool.execute
-            tool
-            (`Assoc [ "path", `String "missing-file-for-keeper-tools-oas.txt" ])
+         Tool.execute
+           tool
+            (read_args meta "missing-file-for-keeper-tools-oas.txt")
         with
         | Error _ -> ()
         | Ok _ -> fail "missing file should be surfaced as tool error");
@@ -519,8 +553,10 @@ let test_error_result_logs_at_error_level () =
          check string "failing tool result logs at ERROR" "ERROR" entry.normalized_level)
 ;;
 
-let test_missing_file_error_includes_directory_suggestions () =
-  let meta = make_test_meta () in
+let test_missing_file_error_redacts_directory_suggestions () =
+  let meta =
+    make_test_meta ~name:"test-keeper-suggestions" ~allowed_paths:[ "repos" ] ()
+  in
   let ctx_snapshot = make_test_ctx () in
   let dir =
     Filename.concat
@@ -541,37 +577,39 @@ let test_missing_file_error_includes_directory_suggestions () =
        @@ fun env ->
        Fs_compat.set_fs (Eio.Stdenv.fs env);
        let config = Coord.default_config dir in
-       let pg_dir =
-         Filename.concat
-           (Keeper_alerting_path.project_root_of_config config)
-           (Keeper_alerting_path.playground_path_of_keeper meta.name)
+       let read_dir =
+         Filename.concat (Keeper_alerting_path.project_root_of_config config)
+           (read_repo_dir meta)
        in
-       Fs_compat.mkdir_p pg_dir;
-       let existing = Filename.concat pg_dir "known.txt" in
+       Fs_compat.mkdir_p read_dir;
+       let existing = Filename.concat read_dir "known.txt" in
        Out_channel.with_open_text existing (fun oc ->
          Out_channel.output_string oc "known");
-       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-       let tool = find_tool "keeper_fs_read" tools in
-       match Tool.execute tool (`Assoc [ "path", `String "missing.txt" ]) with
+       let tools = make_registered_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_read_tool tools in
+       match Tool.execute tool (read_args meta "missing.txt") with
        | Error { Agent_sdk.Types.message; _ } ->
          let json = Yojson.Safe.from_string message in
          let detail = Yojson.Safe.Util.member "detail" json in
-         let suggestions =
-           match Yojson.Safe.Util.member "suggested_entries" detail with
-           | `List entries ->
-             List.filter_map
-               (function
-                 | `String value -> Some value
-                 | _ -> None)
-               entries
-           | _ -> []
-         in
-         check bool "known file suggested" true (List.mem "known.txt" suggestions)
+         check
+           bool
+           "detail preserves path"
+           true
+           (Option.is_some (Safe_ops.json_string_opt "path" detail));
+         check
+           bool
+           "directory entries are not leaked"
+           true
+           (match Yojson.Safe.Util.member "suggested_entries" detail with
+            | `Null | `List [] -> true
+            | _ -> false)
        | Ok _ -> fail "missing file should be surfaced as tool error")
 ;;
 
 let test_repeated_error_results_are_blocked () =
-  let meta = make_test_meta () in
+  let meta =
+    make_test_meta ~name:"test-keeper-guardrail" ~allowed_paths:[ "repos" ] ()
+  in
   let ctx_snapshot = make_test_ctx () in
   let dir =
     Filename.concat
@@ -592,9 +630,10 @@ let test_repeated_error_results_are_blocked () =
        @@ fun env ->
        Fs_compat.set_fs (Eio.Stdenv.fs env);
        let config = Coord.default_config dir in
-       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-       let tool = find_tool "keeper_fs_read" tools in
-       let args = `Assoc [ "path", `String "missing-file-for-keeper-tools-oas.txt" ] in
+       ensure_read_repo_dir config meta;
+       let tools = make_registered_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_read_tool tools in
+       let args = read_args meta "missing-file-for-keeper-tools-oas.txt" in
        for _ = 1 to Keeper_tools_oas.max_consecutive_failures do
          match Tool.execute tool args with
          | Error _ -> ()
@@ -611,7 +650,9 @@ let test_repeated_error_results_are_blocked () =
 ;;
 
 let test_failure_count_resets_after_success () =
-  let meta = make_test_meta () in
+  let meta =
+    make_test_meta ~name:"test-keeper-reset" ~allowed_paths:[ "repos" ] ()
+  in
   let ctx_snapshot = make_test_ctx () in
   let dir =
     Filename.concat
@@ -635,22 +676,21 @@ let test_failure_count_resets_after_success () =
        @@ fun env ->
        Fs_compat.set_fs (Eio.Stdenv.fs env);
        let config = Coord.default_config dir in
-       let pg_dir =
-         Filename.concat
-           (Keeper_alerting_path.project_root_of_config config)
-           (Keeper_alerting_path.playground_path_of_keeper meta.name)
+       let read_dir =
+         Filename.concat (Keeper_alerting_path.project_root_of_config config)
+           (read_repo_dir meta)
        in
-       Fs_compat.mkdir_p pg_dir;
-       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-       let tool = find_tool "keeper_fs_read" tools in
+       Fs_compat.mkdir_p read_dir;
+       let tools = make_registered_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_read_tool tools in
        let path = "reset-after-success.txt" in
-       let args = `Assoc [ "path", `String path ] in
+       let args = read_args meta path in
        for _ = 1 to Keeper_tools_oas.max_consecutive_failures - 1 do
          match Tool.execute tool args with
          | Error _ -> ()
          | Ok _ -> fail "missing file should fail before reset"
        done;
-       let abs_path = Filename.concat pg_dir path in
+       let abs_path = Filename.concat read_dir path in
        Out_channel.with_open_text abs_path (fun oc -> Out_channel.output_string oc "ok");
        (match Tool.execute tool args with
         | Ok _ -> ()
@@ -674,7 +714,9 @@ let test_failure_count_resets_after_success () =
 ;;
 
 let test_failure_tracking_is_independent_per_args () =
-  let meta = make_test_meta () in
+  let meta =
+    make_test_meta ~name:"test-keeper-independent" ~allowed_paths:[ "repos" ] ()
+  in
   let ctx_snapshot = make_test_ctx () in
   let dir =
     Filename.concat
@@ -695,10 +737,11 @@ let test_failure_tracking_is_independent_per_args () =
        @@ fun env ->
        Fs_compat.set_fs (Eio.Stdenv.fs env);
        let config = Coord.default_config dir in
-       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-       let tool = find_tool "keeper_fs_read" tools in
-       let args_a = `Assoc [ "path", `String "missing-a.txt" ] in
-       let args_b = `Assoc [ "path", `String "missing-b.txt" ] in
+       ensure_read_repo_dir config meta;
+       let tools = make_registered_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_read_tool tools in
+       let args_a = read_args meta "missing-a.txt" in
+       let args_b = read_args meta "missing-b.txt" in
        for _ = 1 to Keeper_tools_oas.max_consecutive_failures do
          match Tool.execute tool args_a with
          | Error _ -> ()
@@ -760,6 +803,18 @@ let test_non_research_keeper_has_autoresearch () =
       allowed
   in
   check bool "has autoresearch tools" true has_any
+;;
+
+let test_minimal_model_tools_hide_autoresearch_by_default () =
+  let meta = make_test_meta ~preset:Keeper_types.Minimal () in
+  let tools = Keeper_exec_tools.keeper_allowed_model_tools meta in
+  let has_any =
+    List.exists
+      (fun (t : Types_core.tool_schema) ->
+         String.starts_with ~prefix:"masc_autoresearch_" t.name)
+      tools
+  in
+  check bool "minimal model tools hide autoresearch" false has_any
 ;;
 
 let test_research_model_tools_include_autoresearch () =
@@ -1150,9 +1205,9 @@ let () =
             `Quick
             test_error_result_logs_at_error_level
         ; test_case
-            "missing file error includes suggestions"
+            "missing file error redacts suggestions"
             `Quick
-            test_missing_file_error_includes_directory_suggestions
+            test_missing_file_error_redacts_directory_suggestions
         ; test_case
             "repeated errors are blocked"
             `Quick
@@ -1248,6 +1303,10 @@ let () =
             "allowlisted non-research has autoresearch"
             `Quick
             test_non_research_keeper_has_autoresearch
+        ; test_case
+            "minimal model tools hide autoresearch"
+            `Quick
+            test_minimal_model_tools_hide_autoresearch_by_default
         ; test_case
             "allowlisted model tools include autoresearch"
             `Quick

--- a/test/test_tool_help_registry_shard_coverage_10101.ml
+++ b/test/test_tool_help_registry_shard_coverage_10101.ml
@@ -9,7 +9,7 @@ module Types = Masc_domain
    [masc_tool_help(keeper_task_claim)] returned "unknown tool"
    despite the dispatcher handling the tool correctly.
 
-   This test asserts the full invariant: every schema exported
+   This test asserts the registry invariant: every schema exported
    by [Tool_shard.all_keeper_tool_schemas] is resolvable from
    [Config.raw_all_tool_schemas].  If a new shard category is
    introduced and forgotten at the aggregation site, or if a
@@ -38,17 +38,17 @@ module Registry = Masc_mcp.Tool_help_registry
 let registry_has name =
   Option.is_some (Registry.find_entry Config.raw_all_tool_schemas name)
 
-(* Full coverage check: every tool schema exposed by
+(* Registry coverage check: every tool schema exposed by
    [Tool_shard.all_keeper_tool_schemas] must be resolvable via
-   [Config.raw_all_tool_schemas].  This is the structural
-   invariant — if it fails, aggregation has drifted. *)
+   [Config.raw_all_tool_schemas].  This is the structural invariant for
+   help lookup and dispatch-supporting metadata — if it fails,
+   aggregation has drifted. *)
 let test_every_shard_tool_is_in_authoritative_registry () =
-  let shard_schemas = Shard.all_keeper_tool_schemas in
   let missing =
     List.filter_map
       (fun (s : Masc_domain.tool_schema) ->
         if registry_has s.name then None else Some s.name)
-      shard_schemas
+      Shard.all_keeper_tool_schemas
     |> List.sort_uniq String.compare
   in
   match missing with

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -106,7 +106,7 @@ let test_default_shard_names () =
     (List.mem "governance" defaults);
   Alcotest.(check bool) "coding in defaults" true
     (List.mem "coding" defaults);
-  Alcotest.(check bool) "autoresearch in defaults" true
+  Alcotest.(check bool) "autoresearch opt-in" false
     (List.mem "autoresearch" defaults);
   Alcotest.(check bool) "weather removed from defaults" false
     (List.mem "weather" defaults);
@@ -578,8 +578,8 @@ let () =
         Alcotest.(check bool) "has search findings" true has_search);
       Alcotest.test_case "in defaults" `Quick (fun () ->
         let defaults = Tool_shard.default_shard_names in
-        Alcotest.(check bool) "autoresearch in defaults"
-          true (List.mem "autoresearch" defaults));
+        Alcotest.(check bool) "autoresearch opt-in"
+          false (List.mem "autoresearch" defaults));
     ]);
     ("default_shard_names", [
       Alcotest.test_case "defaults" `Quick test_default_shard_names;


### PR DESCRIPTION
## Summary
- Hide experimental masc_autoresearch tools from public/front-door and default keeper discovery.
- Keep autoresearch in the raw registry so dispatch, help lookup, and explicit research-capable presets continue to work.
- Make the autoresearch shard opt-in and update keeper/tool coverage tests.

## Validation
- ocamlformat -i on touched OCaml files
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_config_coverage.exe test/test_keeper_tools_oas.exe test/test_keeper_tool_exposure.exe test/test_tool_shard_coverage.exe test/test_tool_help_registry_shard_coverage_10101.exe
- ./_build/default/test/test_config_coverage.exe
- ./_build/default/test/test_keeper_tools_oas.exe
- ./_build/default/test/test_keeper_tool_exposure.exe
- ./_build/default/test/test_tool_shard_coverage.exe
- ./_build/default/test/test_tool_help_registry_shard_coverage_10101.exe
- git diff --check

Note: local OAS agent_sdk pin check was bypassed because the installed agent_sdk package is newer than the expected pin and scripts/opam-pin-external-deps.sh refused to downgrade it.