### PR TITLE
Fix docker preflight test application

### DIFF
--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -568,7 +568,6 @@ let test_docker_real_timeout_budgets_are_separated () =
         "preflight keeps short turn-sandbox budget"
         2.0
         (Docker_client_real.session_preflight_timeout_sec ()))
-    (Docker_client_real.session_preflight_timeout_sec ())
 ;;
 
 let () =


### PR DESCRIPTION
## Summary

- Removes the accidental extra application after the `Fun.protect` call in `test_docker_client_real.ml`.
- Restores compilation of the docker client real test target on current `main`.

## Root cause

`Fun.protect ~finally (...) (fun () -> ...)` already returns `unit` in this test. The following `Docker_client_real.session_preflight_timeout_sec ()` expression was parsed as applying that `unit` result as a function, producing the main build error:

```text
This expression has type unit but an expression was expected of type 'a -> 'b
```

## Validation

- `ocamlformat --check test/test_docker_client_real.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_docker_client_real.exe`
- `_build/default/test/test_docker_client_real.exe` (31 tests)
