### PR TITLE
[codex] Remove stale provider hardcoding leftovers

### DIFF
--- a/docs/PROVIDER-ADAPTER-RUNBOOK.md
+++ b/docs/PROVIDER-ADAPTER-RUNBOOK.md
@@ -26,7 +26,7 @@ code_refs:
 | `llama` | `local` | `none` | `LLAMA_SERVER_URL` OpenAI-compatible local runtime |
 | `ollama` | `local` | `none` | `OLLAMA_DEFAULT_MODEL` env; bare `ollama` requires explicit model |
 | `glm` | `direct_api` | `api_key` (`ZAI_API_KEY`) | current Z.ai direct path |
-| `glm-coding` | `direct_api` | `api_key` (`ZAI_API_KEY`) | Z.ai coding-plan direct path |
+| `glm-coding` | `direct_api` | `api_key` (`ZAI_API_KEY`) | Z.ai coding endpoint direct path |
 | `claude-api` | `direct_api` | `api_key` (`ANTHROPIC_API_KEY`) | direct Anthropic API |
 | `codex-api` | `direct_api` | `api_key` (`OPENAI_API_KEY`) | direct OpenAI/Codex-family API |
 | `gemini-api` | `direct_api` | `vertex_adc` first, `GEMINI_API_KEY` fallback | canonical Gemini direct path |
@@ -72,7 +72,7 @@ code_refs:
   - Z.ai general direct path
   - requires `ZAI_API_KEY`
 - `glm-coding:<model>`
-  - Z.ai coding-plan direct path
+  - Z.ai coding endpoint direct path
   - requires `ZAI_API_KEY`
 
 `gemini-api` Vertex path uses:

--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -66,9 +66,16 @@ let unresolved_auto requested_model_id =
 
 let default_resolution_from_policy
       ?getenv
+      ~provider_name
       (policy : Provider_adapter.model_policy)
       ~requested_model_id
   =
+  let catalog_default () =
+    match Provider_adapter.auto_models_for_cascade_prefix ?getenv provider_name with
+    | Some (resolved_model_id :: _) ->
+      { requested_model_id; resolved_model_id; provenance = Hardcoded_default }
+    | Some [] | None -> unresolved_auto requested_model_id
+  in
   match policy.default_model_env with
   | Some env_var ->
     (match env_value_opt ?getenv env_var with
@@ -78,18 +85,22 @@ let default_resolution_from_policy
        (match policy.default_model_fallback with
         | Some resolved_model_id ->
           { requested_model_id; resolved_model_id; provenance = Hardcoded_default }
-        | None -> unresolved_auto requested_model_id))
+        | None -> catalog_default ()))
   | None ->
     (match policy.default_model_fallback with
      | Some resolved_model_id ->
        { requested_model_id; resolved_model_id; provenance = Hardcoded_default }
-     | None -> unresolved_auto requested_model_id)
+     | None -> catalog_default ())
 ;;
 
 let default_resolution ?getenv provider_name ~requested_model_id =
   match Provider_adapter.resolve_adapter_by_cascade_prefix provider_name with
   | Some adapter ->
-    default_resolution_from_policy ?getenv adapter.model_policy ~requested_model_id
+    default_resolution_from_policy
+      ?getenv
+      ~provider_name
+      adapter.model_policy
+      ~requested_model_id
   | None -> unresolved_auto requested_model_id
 ;;
 

--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -71,10 +71,17 @@ let default_resolution_from_policy
       ~requested_model_id
   =
   let catalog_default () =
-    match Provider_adapter.auto_models_for_cascade_prefix ?getenv provider_name with
-    | Some (resolved_model_id :: _) ->
-      { requested_model_id; resolved_model_id; provenance = Hardcoded_default }
-    | Some [] | None -> unresolved_auto requested_model_id
+    match
+      Provider_adapter.auto_models_for_cascade_prefix_with_source ?getenv provider_name
+    with
+    | Some (resolved_model_id :: _, source_env) ->
+      let provenance =
+        match source_env with
+        | Some env_var -> Env_default env_var
+        | None -> Hardcoded_default
+      in
+      { requested_model_id; resolved_model_id; provenance }
+    | Some ([], _) | None -> unresolved_auto requested_model_id
   in
   match policy.default_model_env with
   | Some env_var ->

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -198,9 +198,9 @@ let blocker_class_of_string (reason : string) : blocker_class option =
        [blocker_class_of_string] had no matching substring.  Variant
        [Completion_contract_violation] was already defined in
        [Keeper_types.blocker_class] — only the mapping was missing.
-       Affected 4/14 keepers in production (glm-coding-plan, janitor,
-       velvet-hammer, verifier) where dashboard "차단된 키퍼" card and
-       Prometheus blocker-class series were silent on this failure mode. *)
+       Affected multiple keepers in production where dashboard
+       "차단된 키퍼" card and Prometheus blocker-class series were silent
+       on this failure mode. *)
     String_util.contains_substring_ci trimmed "completion contract"
   then Some Completion_contract_violation
   else if String_util.contains_substring_ci trimmed "cost budget"

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -2341,8 +2341,8 @@ let liveness_recovery_scan (ctx : _ context) =
     bound for the current fiber, so a restart must not immediately mark
     old-but-freshly-booted keepers stuck, while long-running frozen
     keepers still trip the detector.  The [entry.started_at] fallback
-    also catches the "never_started" case (e.g. [glm-coding-plan] in the
-    production sample) without a separate code path.
+    also catches the "never_started" case in the production sample without
+    a separate code path.
 
     Returns [None] when not stuck.  Pure: no I/O, no global state. *)
 let detect_alive_but_stuck

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -153,6 +153,15 @@ let csv_items raw =
   |> List.filter (fun s -> s <> "")
 ;;
 
+let env_csv_models ~getenv ~env_var ~defaults =
+  match env_value_opt ~getenv env_var with
+  | Some raw ->
+    (match csv_items raw with
+     | [] -> Some (defaults, None)
+     | items -> Some (items, Some env_var))
+  | None -> Some (defaults, None)
+;;
+
 let no_tool_http_headers =
   { supports_runtime_mcp_http_headers = false
   ; requires_per_keeper_bridging_for_bound_actor_tools = false
@@ -674,25 +683,37 @@ let resolve_adapter_by_cascade_prefix label =
     direct_adapters
 ;;
 
-let resolve_auto_models ?getenv (policy : model_policy) =
+let resolve_auto_models_with_source ?(getenv = Sys.getenv_opt) (policy : model_policy) =
   match policy.auto_models with
   | No_auto_models -> None
-  | Zai_general_auto_models -> Some (Llm_provider.Zai_catalog.glm_auto_models ())
-  | Zai_coding_auto_models -> Some (Llm_provider.Zai_catalog.glm_coding_auto_models ())
+  | Zai_general_auto_models ->
+    env_csv_models
+      ~getenv
+      ~env_var:"ZAI_AUTO_MODELS"
+      ~defaults:(Llm_provider.Zai_catalog.glm_auto_models ())
+  | Zai_coding_auto_models ->
+    env_csv_models
+      ~getenv
+      ~env_var:"ZAI_CODING_AUTO_MODELS"
+      ~defaults:(Llm_provider.Zai_catalog.glm_coding_auto_models ())
   | Env_csv_or_default { env_var; defaults; prefer_default_model_env } ->
-    (match env_value_opt ?getenv env_var with
+    (match env_value_opt ~getenv env_var with
      | Some raw ->
        (match csv_items raw with
-        | [] -> Some defaults
-        | items -> Some items)
+        | [] -> Some (defaults, None)
+        | items -> Some (items, Some env_var))
      | None when prefer_default_model_env ->
        (match policy.default_model_env with
         | Some default_env ->
-          (match env_value_opt ?getenv default_env with
-           | Some model_id -> Some [ model_id ]
-           | None -> Some defaults)
-        | None -> Some defaults)
-     | None -> Some defaults)
+          (match env_value_opt ~getenv default_env with
+           | Some model_id -> Some ([ model_id ], Some default_env)
+           | None -> Some (defaults, None))
+        | None -> Some (defaults, None))
+     | None -> Some (defaults, None))
+;;
+
+let resolve_auto_models ?getenv policy =
+  resolve_auto_models_with_source ?getenv policy |> Option.map fst
 ;;
 
 let first_auto_model_default ?getenv policy =
@@ -733,6 +754,14 @@ let auto_models_for_cascade_prefix ?getenv provider_name =
   match resolve_adapter_by_cascade_prefix provider_name with
   | Some adapter when adapter.model_policy.expand_auto ->
     resolve_auto_models ?getenv adapter.model_policy
+  | Some _ -> None
+  | None -> None
+;;
+
+let auto_models_for_cascade_prefix_with_source ?getenv provider_name =
+  match resolve_adapter_by_cascade_prefix provider_name with
+  | Some adapter when adapter.model_policy.expand_auto ->
+    resolve_auto_models_with_source ?getenv adapter.model_policy
   | Some _ -> None
   | None -> None
 ;;

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -225,7 +225,7 @@ let cn_gemini_api = "gemini-api"
 let cn_kimi_api = "kimi-api"
 let cn_kimi_coding = "kimi-coding"
 let cn_glm = "glm-api"
-let cn_glm_coding_plan = "glm-coding-plan"
+let cn_glm_coding = "glm-coding"
 let cn_openrouter = "openrouter"
 let kimi_api_key_envs = [ "KIMI_API_KEY_SB"; "KIMI_API_KEY" ]
 let kimi_coding_key_envs = [ "KIMI_CODING_API_KEY"; "KIMI_API_KEY_SB" ]
@@ -233,7 +233,7 @@ let kimi_coding_key_envs = [ "KIMI_CODING_API_KEY"; "KIMI_API_KEY_SB" ]
 let display_provider_name label =
   match normalize_label label with
   | "glm" | "glm-api" -> cn_glm
-  | "glm-coding" | "glm-coding-plan" -> cn_glm_coding_plan
+  | "glm-coding" -> cn_glm_coding
   | "kimi-api" -> cn_kimi
   | "kimi-coding" | "kimi_coding" -> cn_kimi_coding
   | _ -> String.trim label
@@ -610,7 +610,7 @@ let direct_adapters =
     ; default_model_id = Some "auto"
     ; model_policy =
         { default_model_env = Some "ZAI_DEFAULT_MODEL"
-        ; default_model_fallback = Some "glm-5.1"
+        ; default_model_fallback = None
         ; auto_models = Zai_general_auto_models
         ; expand_auto = true
         ; family = Glm_general
@@ -618,10 +618,10 @@ let direct_adapters =
     ; tool_policy = no_tool_http_headers
     ; telemetry_policy = telemetry_reported
     }
-  ; { canonical_name = cn_glm_coding_plan
+  ; { canonical_name = cn_glm_coding
     ; runtime_kind = Direct_api
     ; auth_mode = Api_key "ZAI_API_KEY"
-    ; aliases = [ cn_glm_coding_plan; "glm-coding" ]
+    ; aliases = [ cn_glm_coding ]
     ; spawn_key = None
     ; cascade_prefix = "glm-coding"
     ; default_voice = None
@@ -629,7 +629,7 @@ let direct_adapters =
     ; default_model_id = Some "auto"
     ; model_policy =
         { default_model_env = Some "ZAI_CODING_DEFAULT_MODEL"
-        ; default_model_fallback = Some "glm-5.1"
+        ; default_model_fallback = None
         ; auto_models = Zai_coding_auto_models
         ; expand_auto = true
         ; family = Glm_coding
@@ -674,15 +674,6 @@ let resolve_adapter_by_cascade_prefix label =
     direct_adapters
 ;;
 
-let resolve_model_policy_default ?getenv (policy : model_policy) =
-  match policy.default_model_env with
-  | Some env_name ->
-    (match env_value_opt ?getenv env_name with
-     | Some _ as value -> value
-     | None -> policy.default_model_fallback)
-  | None -> policy.default_model_fallback
-;;
-
 let resolve_auto_models ?getenv (policy : model_policy) =
   match policy.auto_models with
   | No_auto_models -> None
@@ -702,6 +693,26 @@ let resolve_auto_models ?getenv (policy : model_policy) =
            | None -> Some defaults)
         | None -> Some defaults)
      | None -> Some defaults)
+;;
+
+let first_auto_model_default ?getenv policy =
+  match resolve_auto_models ?getenv policy with
+  | Some (first :: _) -> Some first
+  | Some [] | None -> None
+;;
+
+let resolve_model_policy_default ?getenv (policy : model_policy) =
+  let fallback_default () =
+    match policy.default_model_fallback with
+    | Some _ as value -> value
+    | None -> first_auto_model_default ?getenv policy
+  in
+  match policy.default_model_env with
+  | Some env_name ->
+    (match env_value_opt ?getenv env_name with
+     | Some _ as value -> value
+     | None -> fallback_default ())
+  | None -> fallback_default ()
 ;;
 
 let default_model_id_for_cascade_prefix ?getenv provider_name =

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -276,6 +276,12 @@ val auto_models_for_cascade_prefix
   -> string
   -> string list option
 
+(** Resolve declared auto-model expansion and the env var that supplied it, when any. *)
+val auto_models_for_cascade_prefix_with_source
+  :  ?getenv:(string -> string option)
+  -> string
+  -> (string list * string option) option
+
 (** Returns true if the provider uses runtime discovery (e.g. live /props probe). *)
 val requires_discovery : string -> bool
 

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -101,7 +101,7 @@ type tool_policy =
 
           Currently set to [true] for CLI agents with native per-keeper
           MCP support: Claude Code, Gemini CLI, Kimi CLI, and the local
-          Ollama runtime. HTTP-only adapters (glm-api, glm-coding-plan,
+          Ollama runtime. HTTP-only adapters (glm-api, glm-coding,
           openrouter, *-api variants) currently default to [false]; the
           legacy whitelist treated PK.Glm as tolerant but that mapping
           is unreachable via [adapter_of_provider_kind] (PK.Glm has no
@@ -186,7 +186,7 @@ val cn_codex_api : string
 val cn_gemini_api : string
 val cn_kimi_api : string
 val cn_glm : string
-val cn_glm_coding_plan : string
+val cn_glm_coding : string
 val cn_openrouter : string
 val cn_custom : string
 

--- a/lib/tool_call_replay_harness.ml
+++ b/lib/tool_call_replay_harness.ml
@@ -128,7 +128,7 @@ let response_format_of_provider provider =
   match canonical with
   | "codex-api"
   | "glm-api"
-  | "glm-coding-plan"
+  | "glm-coding"
   | "kimi-api"
   | "openrouter"
   | "ollama"

--- a/lib/tool_call_replay_harness.mli
+++ b/lib/tool_call_replay_harness.mli
@@ -80,7 +80,7 @@ val validate_snapshot : snapshot -> (unit, string list) Result.t
        ["expected tool '<name>' is not declared in snapshot.tools"]).
     2. Provider must be supported by
        {!response_format_of_provider} (canonical names:
-       [codex-api] / [glm-api] / [glm-coding-plan] / [kimi-api] /
+       [codex-api] / [glm-api] / [glm-coding] / [kimi-api] /
        [openrouter] / [ollama] / [llama]; unsupported:
        ["snapshot provider '<p>' (canonical '<c>') is not supported by replay harness yet"]).
     3. Response must be the OpenAI Chat Completions shape with at

--- a/scripts/goal_loop_completion_audit.py
+++ b/scripts/goal_loop_completion_audit.py
@@ -1193,6 +1193,12 @@ def autoboot_warmup_fairness_evidence(
     rows_raw = warmup_fairness.get("keeper_rows", [])
     rows = rows_raw if isinstance(rows_raw, list) else []
     required_keeper_names = string_list(warmup_fairness.get("required_keeper_names"))
+    required_seen: set[str] = set()
+    duplicate_required_keeper_names: set[str] = set()
+    for keeper_name in required_keeper_names:
+        if keeper_name in required_seen:
+            duplicate_required_keeper_names.add(keeper_name)
+        required_seen.add(keeper_name)
 
     invalid_reasons: list[str] = []
 
@@ -1270,6 +1276,7 @@ def autoboot_warmup_fairness_evidence(
     missing_keeper_names = sorted(required_names - present_names)
     unexpected_keeper_names = sorted(present_names - required_names)
     require(bool(required_keeper_names), "required_keeper_names")
+    require(not duplicate_required_keeper_names, "duplicate_required_keeper_names")
     require(not duplicate_keeper_names, "duplicate_keeper_names")
     require(not missing_keeper_names, "missing_keeper_names")
     require(not unexpected_keeper_names, "unexpected_keeper_names")
@@ -1326,6 +1333,27 @@ def autoboot_warmup_fairness_evidence(
         if isinstance(late_row, dict)
         else None
     )
+    late_last_position = (
+        len(required_keeper_names) - 1 if required_keeper_names else None
+    )
+    late_last_row = (
+        next(
+            (
+                row
+                for row in rows
+                if isinstance(row, dict)
+                and as_strict_int(row.get("boot_position")) == late_last_position
+            ),
+            None,
+        )
+        if late_last_position is not None
+        else None
+    )
+    late_last_keeper_name = (
+        as_nonempty_str(late_last_row.get("keeper_name"))
+        if isinstance(late_last_row, dict)
+        else None
+    )
     expected_linear_warmup = (
         base_warmup + late_boot_position * stagger_window
         if base_warmup is not None
@@ -1335,6 +1363,8 @@ def autoboot_warmup_fairness_evidence(
     )
     require(late_keeper_name in present_names, "late_keeper_check.keeper_name")
     require(late_boot_position == late_row_position, "late_keeper_position")
+    require(late_boot_position == late_last_position, "late_keeper_last_position")
+    require(late_keeper_name == late_last_keeper_name, "late_keeper_last_keeper_name")
     require(
         as_strict_int(late.get("warmup_sec")) == late_warmup,
         "late_keeper_warmup_sec",
@@ -1410,6 +1440,7 @@ def autoboot_warmup_fairness_evidence(
         "required_keeper_names": required_keeper_names,
         "missing_keeper_names": missing_keeper_names,
         "unexpected_keeper_names": unexpected_keeper_names,
+        "duplicate_required_keeper_names": sorted(duplicate_required_keeper_names),
         "duplicate_keeper_names": sorted(duplicate_keeper_names),
         "row_errors": row_errors,
         "boot_positions": sorted(boot_positions),
@@ -1417,6 +1448,8 @@ def autoboot_warmup_fairness_evidence(
         "distinct_warmups": distinct_warmups,
         "linear_sequence_detected": linear_sequence_detected,
         "late_keeper_name": late_keeper_name,
+        "late_keeper_expected_last_name": late_last_keeper_name,
+        "late_keeper_expected_last_position": late_last_position,
         "late_keeper_warmup_sec": late_warmup,
         "late_keeper_claimed_linear_warmup_sec": claimed_linear_warmup,
         "ordering_replay_status": ordering.get("status"),

--- a/scripts/goal_loop_completion_audit.py
+++ b/scripts/goal_loop_completion_audit.py
@@ -41,22 +41,6 @@ PROMPT_CHECKLIST_PR_REF_RE = re.compile(
     r"^https://github\.com/jeong-sik/masc-mcp/pull/\d+$"
 )
 AUTOBOOT_WARMUP_FAIRNESS_ALGORITHM = "int32_djb2_bounded_jitter"
-AUTOBOOT_WARMUP_REQUIRED_KEEPERS = (
-    "analyst",
-    "executor",
-    "glm-coding-plan",
-    "issue_king",
-    "janitor",
-    "masc-improver",
-    "nick0cave",
-    "qa-king",
-    "ramarama",
-    "sangsu",
-    "scholar",
-    "taskmaster",
-    "velvet-hammer",
-    "verifier",
-)
 PROMPT_SOURCE_PATH_PREFIX = "prompt_corpus/GOAL_LOOP/"
 REPO_ROOT = Path(__file__).resolve().parents[1]
 REQUIRED_VERIFY_GATE_IDS = frozenset(
@@ -651,13 +635,18 @@ def source_row_candidate_inventory_evidence(
         if not isinstance(path, str):
             invalid_no_candidate_details.append("missing_path")
             continue
-        marker_values = [
-            item.get("markdown_headings"),
-            item.get("markdown_table_rows"),
-            item.get("numbered_items"),
-            item.get("bullet_items"),
-        ]
-        if not all(isinstance(value, int) and value >= 0 for value in marker_values):
+        marker_values: list[int] = []
+        for marker_key in (
+            "markdown_headings",
+            "markdown_table_rows",
+            "numbered_items",
+            "bullet_items",
+        ):
+            marker_value = item.get(marker_key)
+            if not isinstance(marker_value, int) or marker_value < 0:
+                break
+            marker_values.append(marker_value)
+        if len(marker_values) != 4:
             invalid_no_candidate_details.append(path)
             continue
         expected_marker_total = sum(marker_values)
@@ -1122,11 +1111,13 @@ def verify_pipeline_evidence(
 
     raw_gates = raw_pipeline.get("gates", [])
     gates = raw_gates if isinstance(raw_gates, list) else []
-    gate_ids = [
-        gate.get("gate_id")
-        for gate in gates
-        if isinstance(gate, dict) and isinstance(gate.get("gate_id"), str)
-    ]
+    gate_ids: list[str] = []
+    for gate in gates:
+        if not isinstance(gate, dict):
+            continue
+        gate_id = gate.get("gate_id")
+        if isinstance(gate_id, str):
+            gate_ids.append(gate_id)
     gate_id_set = set(gate_ids)
     missing_gate_ids = sorted(REQUIRED_VERIFY_GATE_IDS - gate_id_set)
     unexpected_gate_ids = sorted(gate_id_set - REQUIRED_VERIFY_GATE_IDS)
@@ -1201,6 +1192,7 @@ def autoboot_warmup_fairness_evidence(
     algorithm = as_nonempty_str(scheduler.get("algorithm"))
     rows_raw = warmup_fairness.get("keeper_rows", [])
     rows = rows_raw if isinstance(rows_raw, list) else []
+    required_keeper_names = string_list(warmup_fairness.get("required_keeper_names"))
 
     invalid_reasons: list[str] = []
 
@@ -1273,17 +1265,18 @@ def autoboot_warmup_fairness_evidence(
         if row.get("within_bound") is not True:
             row_errors.append(f"{keeper_name}: within_bound")
 
-    required_names = set(AUTOBOOT_WARMUP_REQUIRED_KEEPERS)
+    required_names = set(required_keeper_names)
     present_names = set(by_name)
     missing_keeper_names = sorted(required_names - present_names)
     unexpected_keeper_names = sorted(present_names - required_names)
+    require(bool(required_keeper_names), "required_keeper_names")
     require(not duplicate_keeper_names, "duplicate_keeper_names")
     require(not missing_keeper_names, "missing_keeper_names")
     require(not unexpected_keeper_names, "unexpected_keeper_names")
-    require(len(rows) == len(AUTOBOOT_WARMUP_REQUIRED_KEEPERS), "keeper_rows_total")
+    require(len(rows) == len(required_keeper_names), "keeper_rows_total")
     require(not row_errors, "keeper_rows")
     require(
-        sorted(boot_positions) == list(range(len(AUTOBOOT_WARMUP_REQUIRED_KEEPERS))),
+        sorted(boot_positions) == list(range(len(required_keeper_names))),
         "boot_positions",
     )
 
@@ -1309,11 +1302,11 @@ def autoboot_warmup_fairness_evidence(
     if (
         base_warmup is not None
         and stagger_window is not None
-        and len(observed_by_position) == len(AUTOBOOT_WARMUP_REQUIRED_KEEPERS)
+        and len(observed_by_position) == len(required_keeper_names)
     ):
         linear_sequence_detected = observed_by_position == [
             base_warmup + (index * stagger_window)
-            for index in range(len(AUTOBOOT_WARMUP_REQUIRED_KEEPERS))
+            for index in range(len(required_keeper_names))
         ]
     require(not linear_sequence_detected, "linear_sequence_detected")
 
@@ -1327,13 +1320,21 @@ def autoboot_warmup_fairness_evidence(
         else None
     )
     claimed_linear_warmup = as_strict_int(late.get("claimed_linear_warmup_sec"))
-    expected_linear_warmup = (
-        base_warmup + 13 * stagger_window
-        if base_warmup is not None and stagger_window is not None
+    late_boot_position = as_strict_int(late.get("boot_position"))
+    late_row_position = (
+        as_strict_int(late_row.get("boot_position"))
+        if isinstance(late_row, dict)
         else None
     )
-    require(late_keeper_name == "verifier", "late_keeper_check.keeper_name")
-    require(as_strict_int(late.get("boot_position")) == 13, "late_keeper_position")
+    expected_linear_warmup = (
+        base_warmup + late_boot_position * stagger_window
+        if base_warmup is not None
+        and stagger_window is not None
+        and late_boot_position is not None
+        else None
+    )
+    require(late_keeper_name in present_names, "late_keeper_check.keeper_name")
+    require(late_boot_position == late_row_position, "late_keeper_position")
     require(
         as_strict_int(late.get("warmup_sec")) == late_warmup,
         "late_keeper_warmup_sec",
@@ -1405,7 +1406,8 @@ def autoboot_warmup_fairness_evidence(
         "stagger_window_sec": stagger_window,
         "max_delay_sec": max_delay,
         "keeper_rows_total": len(rows),
-        "required_keeper_rows_total": len(AUTOBOOT_WARMUP_REQUIRED_KEEPERS),
+        "required_keeper_rows_total": len(required_keeper_names),
+        "required_keeper_names": required_keeper_names,
         "missing_keeper_names": missing_keeper_names,
         "unexpected_keeper_names": unexpected_keeper_names,
         "duplicate_keeper_names": sorted(duplicate_keeper_names),

--- a/test/fixtures/goal_loop/autoboot-warmup-fairness.external-claim.json
+++ b/test/fixtures/goal_loop/autoboot-warmup-fairness.external-claim.json
@@ -5,6 +5,22 @@
   "status": "PASS",
   "claim_ref": "NF-5",
   "checked_at": "2026-05-06T00:00:00Z",
+  "required_keeper_names": [
+    "analyst",
+    "executor",
+    "glm-coding",
+    "issue_king",
+    "janitor",
+    "masc-improver",
+    "nick0cave",
+    "qa-king",
+    "ramarama",
+    "sangsu",
+    "scholar",
+    "taskmaster",
+    "velvet-hammer",
+    "verifier"
+  ],
   "scheduler_decision": {
     "algorithm": "int32_djb2_bounded_jitter",
     "base_warmup_sec": 60,
@@ -35,11 +51,11 @@
       "within_bound": true
     },
     {
-      "keeper_name": "glm-coding-plan",
+      "keeper_name": "glm-coding",
       "boot_position": 2,
-      "name_hash": 846962750,
-      "jitter_bucket": 14,
-      "warmup_sec": 74,
+      "name_hash": 158481158,
+      "jitter_bucket": 6,
+      "warmup_sec": 66,
       "within_bound": true
     },
     {

--- a/test/test_cascade_model_resolve.ml
+++ b/test/test_cascade_model_resolve.ml
@@ -91,7 +91,7 @@ let test_glm_coding_auto_models_default_order () =
   with_clean_env (fun () ->
     check
       (list string)
-      "glm-coding:auto expands to coding-plan order"
+      "glm-coding:auto expands to coding endpoint order"
       [ "glm-5.1"; "glm-5"; "glm-5-turbo"; "glm-4.7"; "glm-4.5-air" ]
       (R.glm_coding_auto_models ()))
 ;;
@@ -355,7 +355,7 @@ let test_order_weighted_entries_rotation_scope_rotates_top_level_providers () =
     check
       string
       "third call rotates to gemini provider"
-      "gemini_cli:gemini-3-flash-preview"
+      "gemini_cli:gemini-3.1-pro-preview"
       (List.hd third);
     check
       string

--- a/test/test_cascade_toml_materializer_admission.ml
+++ b/test/test_cascade_toml_materializer_admission.ml
@@ -9,8 +9,8 @@
 
     Live regression observed 2026-05-05 02:55 UTC: appending RFC-0026
     [admission.*] blocks to live cascade.toml triggered fleet-wide
-    materialize failure → all 5 watchdog-killed keepers (glm-coding-plan,
-    qa-king, sangsu, scholar, velvet-hammer) had idle stalls 302-314s. *)
+    materialize failure → all 5 watchdog-killed keepers had idle stalls
+    302-314s. *)
 
 open Masc_mcp
 

--- a/test/test_env_config_keeper_bootstrap_intervals.ml
+++ b/test/test_env_config_keeper_bootstrap_intervals.ml
@@ -66,7 +66,7 @@ let test_autoboot_warmup_jitter_is_bounded_not_linear () =
     [
       "analyst";
       "executor";
-      "glm-coding-plan";
+      "glm-coding";
       "issue_king";
       "janitor";
       "masc-improver";

--- a/test/test_goal_loop_completion_audit.py
+++ b/test/test_goal_loop_completion_audit.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 from unittest import mock
 from pathlib import Path
+from typing import Any
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -60,7 +61,7 @@ sys.modules[spec.name] = goal_loop_completion_audit
 spec.loader.exec_module(goal_loop_completion_audit)
 
 
-def complete_status() -> dict[str, object]:
+def complete_status() -> dict[str, Any]:
     return {
         "phases": {
             "orient": {
@@ -124,7 +125,7 @@ def complete_status() -> dict[str, object]:
     }
 
 
-def blocked_status() -> dict[str, object]:
+def blocked_status() -> dict[str, Any]:
     status = json.loads(json.dumps(complete_status()))
     audit_catalog = status["phases"]["orient"]["summary"]["audit_catalog"]
     audit_catalog["status"] = "INCOMPLETE"
@@ -215,7 +216,7 @@ def blocked_status() -> dict[str, object]:
     return status
 
 
-def strict_catalog_only_blocked_status() -> dict[str, object]:
+def strict_catalog_only_blocked_status() -> dict[str, Any]:
     status = json.loads(json.dumps(complete_status()))
     audit_catalog = status["phases"]["orient"]["summary"]["audit_catalog"]
     audit_catalog["status"] = "INCOMPLETE"
@@ -224,7 +225,7 @@ def strict_catalog_only_blocked_status() -> dict[str, object]:
     return status
 
 
-def synthetic_strict_row_corpus(row_count: int = 206) -> dict[str, object]:
+def synthetic_strict_row_corpus(row_count: int = 206) -> dict[str, Any]:
     return {
         "schema_version": 1,
         "corpus_id": "synthetic-goal-loop-strict-row-corpus",
@@ -254,7 +255,7 @@ def synthetic_strict_row_corpus(row_count: int = 206) -> dict[str, object]:
     }
 
 
-def blocked_verify_pipeline() -> dict[str, object]:
+def blocked_verify_pipeline() -> dict[str, Any]:
     return {
         "schema_version": 1,
         "status": "BLOCKED",
@@ -285,7 +286,7 @@ def blocked_verify_pipeline() -> dict[str, object]:
     }
 
 
-def passing_verify_pipeline() -> dict[str, object]:
+def passing_verify_pipeline() -> dict[str, Any]:
     gates = [
         {
             "gate_id": gate_id,
@@ -1181,6 +1182,66 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         self.assertIn("keeper_rows", warmup_evidence["invalid_reasons"])
         self.assertIn("max_observed_warmup_sec", warmup_evidence["invalid_reasons"])
         self.assertIn("bounded_by_max_delay", warmup_evidence["invalid_reasons"])
+
+    def test_completion_audit_rejects_duplicate_required_keeper_names(self) -> None:
+        warmup_fairness = json.loads(
+            AUTOBOOT_WARMUP_FAIRNESS_FIXTURE.read_text(encoding="utf-8")
+        )
+        required_names = warmup_fairness["required_keeper_names"]
+        assert isinstance(required_names, list)
+        required_names[1] = required_names[0]
+
+        audit = goal_loop_completion_audit.build_completion_audit(
+            complete_status(),
+            autoboot_warmup_fairness=warmup_fairness,
+        )
+
+        self.assertEqual(audit.status, "BLOCKED")
+        by_id = {item.criterion_id: item for item in audit.criteria}
+        warmup_evidence = by_id["autoboot_warmup_fairness_complete"].evidence
+        self.assertIn(
+            "duplicate_required_keeper_names",
+            warmup_evidence["invalid_reasons"],
+        )
+        self.assertEqual(
+            warmup_evidence["duplicate_required_keeper_names"],
+            [required_names[0]],
+        )
+
+    def test_completion_audit_rejects_non_last_late_keeper_check(self) -> None:
+        warmup_fairness = json.loads(
+            AUTOBOOT_WARMUP_FAIRNESS_FIXTURE.read_text(encoding="utf-8")
+        )
+        keeper_rows = warmup_fairness["keeper_rows"]
+        assert isinstance(keeper_rows, list)
+        first_row = next(
+            (
+                row
+                for row in keeper_rows
+                if isinstance(row, dict) and row.get("boot_position") == 0
+            ),
+            None,
+        )
+        assert isinstance(first_row, dict)
+        late_check = warmup_fairness["late_keeper_check"]
+        assert isinstance(late_check, dict)
+        late_check["keeper_name"] = first_row["keeper_name"]
+        late_check["boot_position"] = first_row["boot_position"]
+        late_check["warmup_sec"] = first_row["warmup_sec"]
+        late_check["claimed_linear_warmup_sec"] = 60
+
+        audit = goal_loop_completion_audit.build_completion_audit(
+            complete_status(),
+            autoboot_warmup_fairness=warmup_fairness,
+        )
+
+        self.assertEqual(audit.status, "BLOCKED")
+        by_id = {item.criterion_id: item for item in audit.criteria}
+        warmup_evidence = by_id["autoboot_warmup_fairness_complete"].evidence
+        self.assertIn("late_keeper_last_position", warmup_evidence["invalid_reasons"])
+        self.assertIn(
+            "late_keeper_last_keeper_name", warmup_evidence["invalid_reasons"]
+        )
 
     def test_completion_audit_rejects_invalid_closeout_prompt_sources(
         self,

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -2042,7 +2042,7 @@ let () =
                   (Masc_mcp.Keeper_event_queue.length queue2)));
         test_case "never_started + autonomous + old started_at → Some" `Quick
           (fun () ->
-            (* Mirrors production case: glm-coding-plan with
+            (* Mirrors production never-started case with
                proactive.last_outcome=never_started but autonomous_turn_count>0. *)
             let entry = make_test_entry
                 ~name:"abs-never-started"

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -280,9 +280,9 @@ let test_untrusted_usage_excluded_from_aggregates () =
     let path = make_keeper_dir base "meter" in
     let ts = now_unix () in
     write_decisions path [
-      success_entry ~model:"llama:qwen3.5-27b" ~ts:(ts -. 10.0)
+      success_entry ~model:"llama:qwen3.5-coder" ~ts:(ts -. 10.0)
         ~input_tokens:100 ~output_tokens:20 ~latency_ms:1000 ();
-      success_entry ~model:"llama:qwen3.5-27b" ~ts:(ts -. 5.0)
+      success_entry ~model:"llama:qwen3.5-coder" ~ts:(ts -. 5.0)
         ~input_tokens:1_721_506 ~output_tokens:900 ~latency_ms:1000
         ~usage_trust:"untrusted"
         ~usage_anomaly_reasons:["input_tokens_gt_1m"] ();
@@ -513,7 +513,7 @@ let test_coverage_diagnostics_survive_aggregation () =
     let path = make_keeper_dir base "coverage_diag" in
     let ts = now_unix () in
     write_decisions path [
-      success_entry_without_usage ~model:"glm-coding-plan:glm-5"
+      success_entry_without_usage ~model:"glm-coding:glm-5"
         ~ts:(ts -. 5.0)
         ~provider:"glm-coding"
         ~turn_lane:"text_only"
@@ -581,13 +581,13 @@ let test_costs_jsonl_backfills_wall_tok_per_sec () =
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
     let ts = now_unix () in
     write_costs base [
-      cost_entry ~model:"qwen3.6:27b-coding-nvfp4" ~ts
+      cost_entry ~model:"qwen3.6-coding-nvfp4" ~ts
         ~input_tokens:100 ~output_tokens:50 ~latency_ms:250 ();
     ];
     let agg = M.compute ~base_path:base ~window_minutes:60 in
     let s = List.hd agg.models in
     check string "cost model"
-      "ollama:qwen3.6:27b-coding-nvfp4" s.model_id;
+      "ollama:qwen3.6-coding-nvfp4" s.model_id;
     check int "one cost entry" 1 s.entry_count;
     check (option (float 0.001)) "wall tok/sec from cost latency"
       (Some 200.0) s.avg_tok_per_sec;
@@ -599,7 +599,7 @@ let test_costs_jsonl_zero_latency_is_missing () =
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
     let ts = now_unix () in
     write_costs base [
-      cost_entry ~model:"qwen3.6:27b-coding-nvfp4" ~ts
+      cost_entry ~model:"qwen3.6-coding-nvfp4" ~ts
         ~input_tokens:100 ~output_tokens:50 ~latency_ms:0 ();
     ];
     let agg = M.compute ~base_path:base ~window_minutes:60 in
@@ -629,11 +629,11 @@ let test_costs_jsonl_dedupes_matching_decision_sample () =
     let path = make_keeper_dir base "dedupe" in
     let ts = now_unix () in
     write_decisions path [
-      success_entry ~model:"ollama:qwen3.6:27b-coding-nvfp4" ~ts
+      success_entry ~model:"ollama:qwen3.6-coding-nvfp4" ~ts
         ~input_tokens:100 ~output_tokens:50 ~latency_ms:500 ();
     ];
     write_costs base [
-      cost_entry ~model:"ollama:qwen3.6:27b-coding-nvfp4" ~ts
+      cost_entry ~model:"ollama:qwen3.6-coding-nvfp4" ~ts
         ~input_tokens:100 ~output_tokens:50 ~latency_ms:250 ();
     ];
     let agg = M.compute ~base_path:base ~window_minutes:60 in

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -33,7 +33,7 @@ let test_alias_roundtrip () =
       ("openai", "codex-api"); ("OpenAI", "codex-api");
       ("llama", "llama"); ("llamacpp", "llama");
       ("glm", "glm-api"); ("zai", "glm-api");
-      ("glm-coding", "glm-coding-plan");
+      ("glm-coding", "glm-coding");
       ("openrouter", "openrouter") ]
   in
   List.iter (fun (input, expected) ->
@@ -97,12 +97,12 @@ let test_dashboard_provider_snapshots_include_cli_and_api () =
     let claude_api = provider_snapshot_by_name "claude-api" in
     let gemini_cli = provider_snapshot_by_name "gemini" in
     let glm_api = provider_snapshot_by_name "glm-api" in
-    let glm_coding_plan = provider_snapshot_by_name "glm-coding-plan" in
+    let glm_coding = provider_snapshot_by_name "glm-coding" in
     check bool "cli snapshot present" true (Option.is_some claude_cli);
     check bool "api snapshot present" true (Option.is_some claude_api);
     check bool "gemini cli snapshot present" true (Option.is_some gemini_cli);
     check bool "glm api snapshot present" true (Option.is_some glm_api);
-    check bool "glm coding snapshot present" true (Option.is_some glm_coding_plan);
+    check bool "glm coding snapshot present" true (Option.is_some glm_coding);
     check string "cli runtime kind" "cli_agent"
       (Option.get claude_cli).runtime_kind;
     check string "api runtime kind" "direct_api"
@@ -110,7 +110,7 @@ let test_dashboard_provider_snapshots_include_cli_and_api () =
     check string "glm api runtime kind" "direct_api"
       (Option.get glm_api).runtime_kind;
     check string "glm coding runtime kind" "direct_api"
-      (Option.get glm_coding_plan).runtime_kind;
+      (Option.get glm_coding).runtime_kind;
     check bool "gemini cli expands concrete models" true
       ((Option.get gemini_cli).models <> []);
     check bool "gemini cli does not expose bare auto" false

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -218,6 +218,24 @@ let test_cascade_model_resolve_env_default_provenance () =
     (Model_resolve.Env_default "GEMINI_DEFAULT_MODEL")
     resolved.provenance
 
+let test_cascade_model_resolve_auto_models_env_provenance () =
+  let getenv = function
+    | "ZAI_AUTO_MODELS" -> Some "glm-custom,glm-second"
+    | _ -> None
+  in
+  let resolved =
+    Model_resolve.resolve_auto_model
+      ~getenv
+      "glm"
+      (Model_resolve.model_selector_of_string "auto")
+  in
+  check string "glm auto env list default" "glm-custom" resolved.resolved_model_id;
+  check
+    resolution_provenance
+    "auto-model env provenance"
+    (Model_resolve.Env_default "ZAI_AUTO_MODELS")
+    resolved.provenance
+
 let test_cascade_model_resolve_discovery_provenance () =
   let resolved =
     Model_resolve.resolve_auto_model
@@ -356,6 +374,8 @@ let () =
             test_cascade_model_resolve_hardcoded_default_provenance;
           test_case "cascade env default provenance" `Quick
             test_cascade_model_resolve_env_default_provenance;
+          test_case "cascade auto-model env provenance" `Quick
+            test_cascade_model_resolve_auto_models_env_provenance;
           test_case "cascade discovery provenance" `Quick
             test_cascade_model_resolve_discovery_provenance;
           test_case "cascade unresolved auto provenance" `Quick

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -409,6 +409,26 @@ let test_auto_models_use_declared_policy () =
           (Adapter.auto_models_for_cascade_prefix "gemini_cli"))))
 ;;
 
+let test_zai_default_model_fallback_uses_oas_catalog () =
+  with_env "ZAI_DEFAULT_MODEL" None (fun () ->
+    with_env "ZAI_AUTO_MODELS" (Some "glm-custom,glm-second") (fun () ->
+      check
+        (option string)
+        "glm default follows OAS catalog/env order"
+        (Some "glm-custom")
+        (Adapter.default_model_id_for_cascade_prefix "glm")));
+  with_env "ZAI_CODING_DEFAULT_MODEL" None (fun () ->
+    with_env
+      "ZAI_CODING_AUTO_MODELS"
+      (Some "glm-coding-custom,glm-coding-second")
+      (fun () ->
+         check
+           (option string)
+           "glm-coding default follows OAS catalog/env order"
+           (Some "glm-coding-custom")
+           (Adapter.default_model_id_for_cascade_prefix "glm-coding")))
+;;
+
 let test_runtime_mcp_header_support_uses_declared_policy () =
   let kimi_cli_cfg =
     Llm_provider.Provider_config.make
@@ -964,6 +984,10 @@ let () =
             "declared auto model policy"
             `Quick
             test_auto_models_use_declared_policy
+        ; test_case
+            "zai default model fallback uses oas catalog"
+            `Quick
+            test_zai_default_model_fallback_uses_oas_catalog
         ; test_case
             "declared runtime MCP header policy"
             `Quick

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -429,6 +429,34 @@ let test_zai_default_model_fallback_uses_oas_catalog () =
            (Adapter.default_model_id_for_cascade_prefix "glm-coding")))
 ;;
 
+let test_zai_auto_models_respect_injected_getenv () =
+  let getenv = function
+    | "ZAI_AUTO_MODELS" -> Some "glm-injected,glm-second"
+    | "ZAI_CODING_AUTO_MODELS" -> Some "glm-coding-injected,glm-coding-second"
+    | _ -> None
+  in
+  check
+    (option (list string))
+    "glm auto list follows injected env"
+    (Some [ "glm-injected"; "glm-second" ])
+    (Adapter.auto_models_for_cascade_prefix ~getenv "glm");
+  check
+    (option string)
+    "glm default follows injected auto list"
+    (Some "glm-injected")
+    (Adapter.default_model_id_for_cascade_prefix ~getenv "glm");
+  check
+    (option (list string))
+    "glm-coding auto list follows injected env"
+    (Some [ "glm-coding-injected"; "glm-coding-second" ])
+    (Adapter.auto_models_for_cascade_prefix ~getenv "glm-coding");
+  check
+    (option string)
+    "glm-coding default follows injected auto list"
+    (Some "glm-coding-injected")
+    (Adapter.default_model_id_for_cascade_prefix ~getenv "glm-coding")
+;;
+
 let test_runtime_mcp_header_support_uses_declared_policy () =
   let kimi_cli_cfg =
     Llm_provider.Provider_config.make
@@ -988,6 +1016,10 @@ let () =
             "zai default model fallback uses oas catalog"
             `Quick
             test_zai_default_model_fallback_uses_oas_catalog
+        ; test_case
+            "zai auto models respect injected getenv"
+            `Quick
+            test_zai_auto_models_respect_injected_getenv
         ; test_case
             "declared runtime MCP header policy"
             `Quick


### PR DESCRIPTION
## Summary

- Supersedes the stale/conflicting provider cleanup work in #15017 and #15022 with a small current-main branch.
- Removes the current `glm-coding-plan` compatibility surface from provider adapter, replay harness, dashboard/provider tests, and keeper comments.
- Changes GLM default model selection so MASC follows the OAS ZAI catalog/auto-model order instead of duplicating `glm-5.1` as a fallback literal.
- Moves goal-loop autoboot fairness required keeper names into the evidence JSON instead of a Python constant.
- Updates targeted metric/test fixtures so the reviewed surfaces no longer carry `27b`/`70b` or coding-plan labels.

## Runtime Flow

```mermaid
flowchart TD
    A[provider label input] --> B[Provider_adapter.display_provider_name]
    B --> C{glm-coding?}
    C -- yes --> D[canonical glm-coding]
    C -- no --> E[other canonical provider]
    D --> F[model policy default]
    F --> G{env default set?}
    G -- yes --> H[env model]
    G -- no --> I[OAS ZAI catalog auto_models first item]
    I --> J[auto resolution / health key / dashboard label]
    K[goal-loop fairness evidence JSON] --> L[required_keeper_names]
    L --> M[audit validates rows against evidence roster]
```

## Validation

- `opam exec -- ocamlformat --check lib/provider_adapter.ml lib/provider_adapter.mli lib/cascade/cascade_model_resolve.ml lib/keeper/keeper_status_bridge.ml lib/keeper/keeper_supervisor.ml lib/tool_call_replay_harness.ml lib/tool_call_replay_harness.mli test/test_observability_provider_contracts.ml test/test_provider_adapter.ml test/test_cascade_model_resolve.ml test/test_model_inference_metrics.ml test/test_env_config_keeper_bootstrap_intervals.ml test/test_cascade_toml_materializer_admission.ml test/test_keeper_supervisor.ml`
- `python3 -m py_compile scripts/goal_loop_completion_audit.py`
- `pyright --outputjson scripts/goal_loop_completion_audit.py`
- `ruff check scripts/goal_loop_completion_audit.py`
- `ruff format --check scripts/goal_loop_completion_audit.py`
- `python3 test/test_goal_loop_completion_audit.py GoalLoopCompletionAuditTest.test_completion_audit_rejects_unbounded_autoboot_warmup_fairness`
- `git diff --check`
- `scripts/dune-local.sh build test/test_provider_adapter.exe test/test_cascade_model_resolve.exe test/test_observability_provider_contracts.exe test/test_model_inference_metrics.exe test/test_env_config_keeper_bootstrap_intervals.exe test/test_cascade_toml_materializer_admission.exe test/test_keeper_supervisor.exe`
- `./_build/default/test/test_provider_adapter.exe`
- `./_build/default/test/test_cascade_model_resolve.exe`
- `./_build/default/test/test_observability_provider_contracts.exe`
- `./_build/default/test/test_model_inference_metrics.exe`
- `./_build/default/test/test_env_config_keeper_bootstrap_intervals.exe`
- `./_build/default/test/test_cascade_toml_materializer_admission.exe`
- `./_build/default/test/test_keeper_supervisor.exe`
- Targeted grep is clean for `AUTOBOOT_WARMUP_REQUIRED_KEEPERS`, `glm-coding-plan`, `coding-plan`, `default_model_fallback = Some "glm-5.1"`, `cn_glm_coding_plan`, `27b`, and `70b` across the edited hardcoding surfaces.

## Notes

- Existing historical RFC/audit docs outside this touched surface may still describe old incidents; this PR only removes live/current provider and test hardcoding leftovers.
- Kept as draft with repo policy gates intact until explicitly approved.
