### PR TITLE
[codex] Expose provider attempt provenance

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -31,6 +31,51 @@ let provider_attempt_status_and_error_of_exception = function
         (Printexc.to_string inner) )
   | exn -> "exception", Printexc.to_string exn
 
+type provider_attempt_provenance =
+  { model_source : string
+  ; resolved_model_source : string
+  ; capability_source : string
+  ; fallback_authority : string
+  ; provider_source_cascade : string option
+  }
+
+let base_provider_attempt_provenance ~uses_direct_model_strings =
+  if uses_direct_model_strings then
+    { model_source = "direct_model_strings"
+    ; resolved_model_source = "direct_model_string"
+    ; capability_source = "provider_config_from_direct_model_string"
+    ; fallback_authority = "direct_model_strings"
+    ; provider_source_cascade = None
+    }
+  else
+    { model_source = "named_cascade"
+    ; resolved_model_source = "cascade_catalog_binding"
+    ; capability_source = "provider_config_from_cascade_catalog"
+    ; fallback_authority = "declared_cascade"
+    ; provider_source_cascade = None
+    }
+
+let cross_cascade_provider_attempt_provenance ~source_cascade =
+  { model_source = "cross_cascade_recovery"
+  ; resolved_model_source = "cross_cascade_catalog_binding"
+  ; capability_source = "provider_config_from_cross_cascade_catalog"
+  ; fallback_authority = "cross_cascade_recovery"
+  ; provider_source_cascade = Some source_cascade
+  }
+
+let provider_attempt_provenance_fields p =
+  let base =
+    [ ("model_source", `String p.model_source)
+    ; ("resolved_model_source", `String p.resolved_model_source)
+    ; ("capability_source", `String p.capability_source)
+    ; ("fallback_authority", `String p.fallback_authority)
+    ]
+  in
+  match p.provider_source_cascade with
+  | None -> base
+  | Some source_cascade ->
+      ("provider_source_cascade", `String source_cascade) :: base
+
 (* ================================================================ *)
 (* Facade-only: run_named, run_model_by_label, and MASC tool bridges  *)
 (* ================================================================ *)
@@ -199,7 +244,10 @@ let run_named
   (* Cross-cascade health-aware fallback: when the current cascade has no
      tool-capable providers after filtering, search all other cascades for
      a healthy tool-capable provider. Depth 1 only (no recursive search). *)
-  let candidate_cfgs =
+  let base_attempt_provenance =
+    base_provider_attempt_provenance ~uses_direct_model_strings
+  in
+  let provider_attempt_provenance, candidate_cfgs =
     match candidate_cfgs with
     | [] ->
         (match resolve_tool_capable_provider_across_cascades
@@ -230,7 +278,8 @@ let run_named
                cascade_name
                (Provider_tool_support.provider_debug_label provider_cfg)
                source_cascade;
-             [provider_cfg]
+             ( cross_cascade_provider_attempt_provenance ~source_cascade
+             , [provider_cfg] )
          | None ->
              Log.Misc.error
                "cascade %s: no callable models available (cross-cascade \
@@ -240,8 +289,8 @@ let run_named
                (String.concat ", " configured_labels)
                require_tool_choice_support
                require_tool_support;
-             [])
-    | _ -> candidate_cfgs
+             (base_attempt_provenance, []))
+    | _ -> (base_attempt_provenance, candidate_cfgs)
   in
   match candidate_cfgs with
   | [] ->
@@ -524,21 +573,23 @@ let run_named
       let provider_kind =
         Llm_provider.Provider_config.string_of_provider_kind provider_cfg.kind
       in
+      let started_decision_fields =
+        provider_attempt_provenance_fields provider_attempt_provenance
+        @ [
+            ("provider_health_key", `String provider_health_key);
+            ("provider_model_health_key", `String provider_model_health_key);
+            ("is_last", `Bool is_last);
+            ( "per_provider_timeout_s",
+              match pp_timeout with
+              | None -> `Null
+              | Some timeout -> `Float timeout );
+          ]
+      in
       emit_runtime_manifest
         ~status:"started"
         ~provider_kind
         ~model_id:provider_cfg.model_id
-        ~decision:
-          (`Assoc
-            [
-              ("provider_health_key", `String provider_health_key);
-              ("provider_model_health_key", `String provider_model_health_key);
-              ("is_last", `Bool is_last);
-              ( "per_provider_timeout_s",
-                match pp_timeout with
-                | None -> `Null
-                | Some timeout -> `Float timeout );
-            ])
+        ~decision:(`Assoc started_decision_fields)
         Keeper_runtime_manifest.Provider_attempt_started;
       let provider_attempt_finished_emitted = ref false in
       let emit_provider_attempt_finished_once
@@ -559,6 +610,10 @@ let run_named
               ("response_model", response_model);
               ("error", error);
             ]
+          in
+          let decision_fields =
+            provider_attempt_provenance_fields provider_attempt_provenance
+            @ decision_fields
           in
           let decision_fields =
             match exception_kind with

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -691,6 +691,7 @@ let memory_summary_json scan =
     ]
 
 let provider_attempt_row_json (row : Keeper_runtime_manifest.t) =
+  let decision_string key = json_string_member_opt key row.decision in
   `Assoc
     [
       ("ts", `String row.ts);
@@ -698,15 +699,26 @@ let provider_attempt_row_json (row : Keeper_runtime_manifest.t) =
       ("cascade_name", json_string_opt row.cascade_name);
       ("provider_kind", json_string_opt row.provider_kind);
       ("model_id", json_string_opt row.model_id);
+      ("model_source", json_string_opt (decision_string "model_source"));
+      ( "resolved_model_source",
+        json_string_opt (decision_string "resolved_model_source") );
+      ("capability_source", json_string_opt (decision_string "capability_source"));
+      ("fallback_authority", json_string_opt (decision_string "fallback_authority"));
+      ( "provider_source_cascade",
+        json_string_opt (decision_string "provider_source_cascade") );
       ("status", `String row.status);
-      ("error", json_string_opt (json_string_member_opt "error" row.decision));
+      ("error", json_string_opt (decision_string "error"));
       ( "exception_kind",
-        json_string_opt (json_string_member_opt "exception_kind" row.decision) );
+        json_string_opt (decision_string "exception_kind") );
     ]
 
 let provider_attempts_summary_json scan =
   let attempt_rows = queue_to_list scan.provider_attempt_rows in
   let terminal = scan.provider_terminal_row in
+  let terminal_decision_string key =
+    Option.bind terminal (fun row ->
+      json_string_member_opt key row.Keeper_runtime_manifest.decision)
+  in
   `Assoc
     [
       ("started_count", `Int scan.provider_started_count);
@@ -722,16 +734,20 @@ let provider_attempts_summary_json scan =
         json_string_opt
           (Option.bind terminal (fun row -> row.Keeper_runtime_manifest.model_id))
       );
+      ( "terminal_model_source",
+        json_string_opt (terminal_decision_string "model_source") );
+      ( "terminal_resolved_model_source",
+        json_string_opt (terminal_decision_string "resolved_model_source") );
+      ( "terminal_capability_source",
+        json_string_opt (terminal_decision_string "capability_source") );
+      ( "terminal_fallback_authority",
+        json_string_opt (terminal_decision_string "fallback_authority") );
+      ( "terminal_provider_source_cascade",
+        json_string_opt (terminal_decision_string "provider_source_cascade") );
       ( "terminal_error",
-        json_string_opt
-          (Option.bind terminal (fun row ->
-             json_string_member_opt "error" row.Keeper_runtime_manifest.decision))
-      );
+        json_string_opt (terminal_decision_string "error") );
       ( "terminal_exception_kind",
-        json_string_opt
-          (Option.bind terminal (fun row ->
-             json_string_member_opt "exception_kind"
-               row.Keeper_runtime_manifest.decision)) );
+        json_string_opt (terminal_decision_string "exception_kind") );
       ("attempts", `List (List.map provider_attempt_row_json attempt_rows));
     ]
 

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -1015,11 +1015,9 @@ let test_provider_attempt_finish_recorded_on_oas_timeout () =
             ~finally:Masc_mcp.Keeper_tool_call_log.reset_for_testing
             (fun () ->
               Masc_mcp.Keeper_tool_call_log.init ~base_path:base_dir ();
-	              let meta =
-	                make_meta ~name:"runtime-manifest-provider-timeout" ()
-	              in
-	              let keeper_turn_id = meta.runtime.usage.total_turns + 1 in
-	              let session_base_dir = Filename.concat base_dir "sessions" in
+              let meta = make_meta ~name:"runtime-manifest-provider-timeout" () in
+              let keeper_turn_id = meta.runtime.usage.total_turns + 1 in
+              let session_base_dir = Filename.concat base_dir "sessions" in
               Fs_compat.mkdir_p session_base_dir;
               let model_string =
                 Printf.sprintf "custom:slow-timeout@%s" base_url
@@ -1071,7 +1069,29 @@ let test_provider_attempt_finish_recorded_on_oas_timeout () =
                 true
                 (Sys.file_exists manifest_path);
               let rows = parsed_manifest_rows manifest_path in
-              ignore (require_manifest_event M.Provider_attempt_started rows);
+              let started_row =
+                require_manifest_event M.Provider_attempt_started rows
+              in
+              Alcotest.(check (option string))
+                "direct model attempt records model source"
+                (Some "direct_model_strings")
+                (json_string_member_opt "model_source" started_row.M.decision);
+              Alcotest.(check (option string))
+                "direct model attempt records resolved model source"
+                (Some "direct_model_string")
+                (json_string_member_opt
+                   "resolved_model_source"
+                   started_row.M.decision);
+              Alcotest.(check (option string))
+                "direct model attempt records capability source"
+                (Some "provider_config_from_direct_model_string")
+                (json_string_member_opt
+                   "capability_source"
+                   started_row.M.decision);
+              Alcotest.(check (option string))
+                "direct model attempt records fallback authority"
+                (Some "direct_model_strings")
+                (json_string_member_opt "fallback_authority" started_row.M.decision);
               let finished_row =
                 require_manifest_event M.Provider_attempt_finished rows
               in
@@ -1079,39 +1099,47 @@ let test_provider_attempt_finish_recorded_on_oas_timeout () =
                 "provider timeout closes attempt"
                 "timeout"
                 finished_row.M.status;
-	              Alcotest.(check (option string))
-	                "provider timeout records exception kind"
-	                (Some "outer_oas_timeout")
-	                (json_string_member_opt "exception_kind" finished_row.M.decision);
-	              Alcotest.(check bool)
-	                "provider timeout records timeout error"
-	                true
-	                (match json_string_member_opt "error" finished_row.M.decision with
-	                 | Some error -> contains_substring error "Timeout after"
-	                 | None -> false);
-	              let status, api_json =
-	                Masc_mcp.Server_dashboard_http_keeper_api.keeper_runtime_trace_json
-	                  config meta.name ~trace_id ~turn_id:keeper_turn_id ()
-	              in
-	              Alcotest.(check string)
-	                "timeout runtime trace status"
-	                "ok"
-	                (match status with `OK -> "ok" | `Not_found -> "not_found");
-	              let provider_attempts =
-	                Yojson.Safe.Util.(api_json |> member "provider_attempts")
-	              in
-	              Alcotest.(check (option string))
-	                "timeout provider attempts summary terminal status"
-	                (Some "timeout")
-	                (json_string_member_opt
-	                   "terminal_status"
-	                   provider_attempts);
-	              Alcotest.(check (option string))
-	                "timeout provider attempts summary exception"
-	                (Some "outer_oas_timeout")
-	                (json_string_member_opt
-	                   "terminal_exception_kind"
-	                   provider_attempts))))
+              Alcotest.(check (option string))
+                "provider timeout records exception kind"
+                (Some "outer_oas_timeout")
+                (json_string_member_opt "exception_kind" finished_row.M.decision);
+              Alcotest.(check bool)
+                "provider timeout records timeout error"
+                true
+                (match json_string_member_opt "error" finished_row.M.decision with
+                 | Some error -> contains_substring error "Timeout after"
+                 | None -> false);
+              let status, api_json =
+                Masc_mcp.Server_dashboard_http_keeper_api.keeper_runtime_trace_json
+                  config meta.name ~trace_id ~turn_id:keeper_turn_id ()
+              in
+              Alcotest.(check string)
+                "timeout runtime trace status"
+                "ok"
+                (match status with `OK -> "ok" | `Not_found -> "not_found");
+              let provider_attempts =
+                Yojson.Safe.Util.(api_json |> member "provider_attempts")
+              in
+              Alcotest.(check (option string))
+                "timeout provider attempts summary terminal status"
+                (Some "timeout")
+                (json_string_member_opt "terminal_status" provider_attempts);
+              Alcotest.(check (option string))
+                "timeout provider attempts summary exception"
+                (Some "outer_oas_timeout")
+                (json_string_member_opt
+                   "terminal_exception_kind"
+                   provider_attempts);
+              Alcotest.(check (option string))
+                "timeout provider attempts summary model source"
+                (Some "direct_model_strings")
+                (json_string_member_opt "terminal_model_source" provider_attempts);
+              Alcotest.(check (option string))
+                "timeout provider attempts summary fallback authority"
+                (Some "direct_model_strings")
+                (json_string_member_opt
+                   "terminal_fallback_authority"
+                   provider_attempts))))
 
 let test_state_sidecar_hydrates_checkpoint_continuity () =
   let module KMP = Masc_mcp.Keeper_memory_policy in


### PR DESCRIPTION
## Summary

- Adds provider/model provenance fields to keeper provider attempt manifest decisions.
- Surfaces those fields through the runtime trace API for both attempt rows and terminal attempt summary.
- Extends the runtime manifest timeout test to assert direct model string provenance in the manifest and dashboard API summary.

## Why

Provider/model routing currently has multiple valid entry points: direct model strings, named cascade bindings, and cross-cascade recovery. Without explicit provenance, operators have to infer why a provider/model was selected from scattered logs and config state. This makes MASC/OAS boundary cleanup harder and obscures whether MASC is using declared cascade intent or a recovery path.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_runtime_manifest.exe`
- `./_build/default/test/test_keeper_runtime_manifest.exe test --show-errors`
