### PR TITLE
Clarify cascade source and tool telemetry visibility

### DIFF
--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -522,6 +522,15 @@ describe('summaryCounts', () => {
 
     expect(toolTelemetryCoverageDetail(counts, 3)).toBe('도구 telemetry 확인 2/3 · 활동 1 · 기록 없음 1 · 미확인 1')
   })
+
+  it('counts explicit zero-tool telemetry as covered', () => {
+    const counts = summaryCounts([
+      makeRow({ recent_tools: [], tool_calls: 0, tool_activity_known: true }),
+      makeRow({ recent_tools: [], tool_calls: 0, tool_activity_known: false }),
+    ])
+
+    expect(counts.toolCovered).toBe(1)
+  })
 })
 
 describe('buildToolQualityMap', () => {

--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -138,6 +138,9 @@ describe('ConfigResolutionPanel', () => {
     expect(container.textContent).toContain('env override')
     expect(container.textContent).toContain('Resolved config child is missing: keepers')
     expect(container.textContent).toContain('cascade.toml')
+    expect(container.textContent).toContain('TOML-only')
+    expect(container.textContent).toContain('authoring=runtime')
+    expect(container.textContent).toContain('repo seed not active')
     expect(container.textContent).toContain('root-relative')
     expect(container.textContent).toContain('under config root')
     expect(container.textContent).not.toContain('/tmp/runtime/config/cascade.toml')
@@ -285,6 +288,27 @@ describe('ConfigResolutionPanel', () => {
 
     expect(container.textContent).toContain('local .masc')
     expect(container.textContent).toContain('/tmp/project/.masc/config')
+  })
+
+  it('calls out repo fallback config roots separately from copied runtime roots', () => {
+    render(
+      html`<${ConfigResolutionPanel}
+        resolution=${{
+          status: 'ready',
+          warnings: [],
+          config_root: { path: '/tmp/project/config', exists: true, source: 'cwd' },
+          cascade_authoring: { path: '/tmp/project/config/cascade.toml', exists: true, source: 'cwd' },
+          cascade: { path: '/tmp/project/config/cascade.toml', exists: true, source: 'cwd' },
+          prompts: { path: '/tmp/project/config/prompts', exists: true, source: 'cwd' },
+          keepers: { path: '/tmp/project/config/keepers', exists: true, source: 'cwd' },
+          personas: { path: '/tmp/project/config/personas', exists: true, source: 'cwd' },
+        }}
+      />`,
+      container,
+    )
+
+    expect(container.textContent).toContain('repo config active')
+    expect(container.textContent).not.toContain('repo seed not active')
   })
 })
 

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -206,6 +206,38 @@ function ConfigRow({
   `
 }
 
+function isRepoFallbackSource(source: string): boolean {
+  return source === 'cwd' || source === 'exe_relative'
+}
+
+function sameResolvedPath(left: DashboardConfigResolutionItem, right: DashboardConfigResolutionItem): boolean {
+  return normalizePath(left.path) === normalizePath(right.path)
+}
+
+function ConfigTopologySummary({
+  resolution,
+}: {
+  resolution: DashboardConfigResolution
+}) {
+  const authoringMatchesRuntime = sameResolvedPath(resolution.cascade_authoring, resolution.cascade)
+  const repoFallbackActive = isRepoFallbackSource(resolution.config_root.source)
+
+  return html`
+    <div class="mb-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-hover)] px-3 py-2">
+      <div class="flex flex-wrap items-center gap-2">
+        <${StatusChip} tone="neutral" uppercase=${false}>TOML-only<//>
+        <${StatusChip} tone=${authoringMatchesRuntime ? 'ok' : 'warn'} uppercase=${false}>
+          ${authoringMatchesRuntime ? 'authoring=runtime' : 'authoring/runtime split'}
+        <//>
+        <${StatusChip} tone=${repoFallbackActive ? 'warn' : 'neutral'} uppercase=${false}>
+          ${repoFallbackActive ? 'repo config active' : 'repo seed not active'}
+        <//>
+        <span class="text-xs text-[var(--color-fg-muted)]">cascade.toml source follows the resolved config root</span>
+      </div>
+    </div>
+  `
+}
+
 function WarningBlock({
   title,
   warnings,
@@ -534,6 +566,8 @@ export function ConfigResolutionPanel({
                 <${StatusChip} tone="neutral" uppercase=${false}>${sourceLabel(resolution.config_root.source)}<//>
                 <span class="text-xs text-[var(--color-fg-muted)]">resolved config root</span>
               </div>
+
+              <${ConfigTopologySummary} resolution=${resolution} />
 
               <div class="mb-4">
                 <${WarningBlock} title="config warnings" warnings=${resolution.warnings} />


### PR DESCRIPTION
Stacked on #15030.\n\nChanges:\n- Add dashboard config topology chips for TOML-only cascade source, authoring/runtime path alignment, and repo seed fallback state.\n- Count explicit zero-tool telemetry as covered in Fleet summary instead of only counting nonzero recent tool activity.\n- Update focused tests for both visibility paths.\n\nVerification:\n- pnpm install --offline --frozen-lockfile\n- pnpm exec vitest run --config vitest.config.ts src/components/tools/config-resolution-panel.test.ts src/components/fleet-telemetry-utils.test.ts src/components/fleet-telemetry-panel.test.ts --no-file-parallelism --maxWorkers=1\n- pnpm exec tsc --noEmit --pretty false\n- pnpm exec eslint src/components/tools/config-resolution-panel.ts src/components/tools/config-resolution-panel.test.ts src/components/fleet-telemetry-utils.ts src/components/fleet-telemetry-utils.test.ts src/components/fleet-telemetry-panel.ts src/components/fleet-telemetry-panel.test.ts