### PR TITLE
refactor(dashboard): clean dead UI noise from cockpit command map

### DIFF
--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -24,7 +24,7 @@ export interface CockpitEntrypoint {
   mode: CockpitMode
   aliases: string[]
   target: CockpitRouteTarget
-  coverage: 'covered' | 'partial' | 'backend-blocked'
+  coverage: 'covered' | 'backend-blocked'
 }
 
 export interface CognitiveModeState {

--- a/dashboard/src/components/cockpit/cockpit.ts
+++ b/dashboard/src/components/cockpit/cockpit.ts
@@ -18,42 +18,58 @@ type CockpitPlane = Extract<CockpitMode, 'work' | 'comms' | 'observe' | 'cogniti
 interface PlaneMeta {
   label: string
   summary: string
-  stat: string
 }
 
-const PLANE_ORDER: CockpitPlane[] = ['work', 'comms', 'observe', 'cognition', 'ide']
+const PLANE_ORDER = ['work', 'comms', 'observe', 'cognition', 'ide'] as const satisfies readonly CockpitPlane[]
 
 const PLANE_META: Record<CockpitPlane, PlaneMeta> = {
   work: {
     label: 'Work',
     summary: 'Goals, tasks, and accountability routes',
-    stat: 'planning',
   },
   comms: {
     label: 'Comms',
     summary: 'Board, message, and composer routes',
-    stat: 'board',
   },
   observe: {
     label: 'Observe',
     summary: 'Runtime, safety, audit, and cost routes',
-    stat: 'runtime',
   },
   cognition: {
     label: 'Cognition',
     summary: 'Keeper, decision, memory, and research routes',
-    stat: 'fleet',
   },
   ide: {
     label: 'IDE',
     summary: 'Source, review, diff, graph, and search routes',
-    stat: 'code',
   },
 }
 
+const ENTRIES_PER_PLANE: ReadonlyMap<CockpitPlane, CockpitEntrypoint[]> = (() => {
+  const map = new Map<CockpitPlane, CockpitEntrypoint[]>()
+  for (const plane of PLANE_ORDER) map.set(plane, [])
+  for (const entrypoint of COCKPIT_ENTRYPOINTS) {
+    if (PLANE_ORDER.includes(entrypoint.mode as CockpitPlane)) {
+      map.get(entrypoint.mode as CockpitPlane)?.push(entrypoint)
+    }
+  }
+  return map
+})()
+
 const COCKPIT_COVERED_ROUTES = COCKPIT_ENTRYPOINTS.filter(entry => entry.coverage === 'covered').length
-const COCKPIT_PARTIAL_ROUTES = COCKPIT_ENTRYPOINTS.filter(entry => entry.coverage === 'partial').length
 const COCKPIT_BLOCKED_ROUTES = COCKPIT_ENTRYPOINTS.filter(entry => entry.coverage === 'backend-blocked').length
+
+const PLANE_WITH_MOST_ENTRIES = PLANE_ORDER.reduce((top, plane) => {
+  const count = ENTRIES_PER_PLANE.get(plane)?.length ?? 0
+  const topCount = ENTRIES_PER_PLANE.get(top)?.length ?? 0
+  return count > topCount ? plane : top
+}, PLANE_ORDER[0])
+
+const PLANE_WITH_MOST_GAPS = PLANE_ORDER.reduce((top, plane) => {
+  const gaps = (ENTRIES_PER_PLANE.get(plane) ?? []).filter(entry => entry.coverage === 'backend-blocked').length
+  const topGaps = (ENTRIES_PER_PLANE.get(top) ?? []).filter(entry => entry.coverage === 'backend-blocked').length
+  return gaps > topGaps ? plane : top
+}, PLANE_ORDER[0])
 
 const COCKPIT_DISCLOSURE_ITEMS: CognitiveDisclosureItem[] = [
   {
@@ -65,22 +81,22 @@ const COCKPIT_DISCLOSURE_ITEMS: CognitiveDisclosureItem[] = [
     detail: html`
       <span class="font-mono text-3xs text-ok">${COCKPIT_COVERED_ROUTES} covered</span>
       <span class="mx-2 text-[var(--color-fg-disabled)]">/</span>
-      <span class="font-mono text-3xs text-warn">${COCKPIT_PARTIAL_ROUTES} partial</span>
-      <span class="mx-2 text-[var(--color-fg-disabled)]">/</span>
       <span class="font-mono text-3xs text-[var(--color-fg-muted)]">${COCKPIT_BLOCKED_ROUTES} backend-blocked</span>
     `,
   },
   {
     level: 'comprehend',
     title: 'Plane grouping',
-    summary: PLANE_ORDER.map(plane => PLANE_META[plane].label).join(', '),
+    summary: `${PLANE_META[PLANE_WITH_MOST_ENTRIES].label} carries the most routes (${ENTRIES_PER_PLANE.get(PLANE_WITH_MOST_ENTRIES)?.length ?? 0})`,
     metric: `${PLANE_ORDER.length} planes`,
   },
   {
     level: 'project',
     title: 'Route gaps',
-    summary: `${COCKPIT_BLOCKED_ROUTES} backend-blocked, ${COCKPIT_PARTIAL_ROUTES} partial`,
-    metric: `${COCKPIT_BLOCKED_ROUTES + COCKPIT_PARTIAL_ROUTES} gaps`,
+    summary: COCKPIT_BLOCKED_ROUTES > 0
+      ? `${COCKPIT_BLOCKED_ROUTES} backend-blocked in ${PLANE_META[PLANE_WITH_MOST_GAPS].label}`
+      : 'No backend-blocked routes',
+    metric: `${COCKPIT_BLOCKED_ROUTES} gaps`,
   },
 ]
 
@@ -122,8 +138,6 @@ function coverageClass(coverage: CockpitEntrypoint['coverage']): string {
   switch (coverage) {
     case 'covered':
       return 'border-ok/30 bg-ok/10 text-ok'
-    case 'partial':
-      return 'border-warn/30 bg-warn/10 text-warn'
     case 'backend-blocked':
       return 'border-[var(--color-border-strong)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)]'
   }
@@ -132,7 +146,6 @@ function coverageClass(coverage: CockpitEntrypoint['coverage']): string {
 function PlaneSection({ plane, entries }: { plane: CockpitPlane; entries: CockpitEntrypoint[] }) {
   const meta = PLANE_META[plane]
   const covered = entries.filter(entry => entry.coverage === 'covered').length
-  const partial = entries.filter(entry => entry.coverage === 'partial').length
   const blocked = entries.filter(entry => entry.coverage === 'backend-blocked').length
 
   return html`
@@ -153,7 +166,6 @@ function PlaneSection({ plane, entries }: { plane: CockpitPlane; entries: Cockpi
         </div>
         <div class="flex shrink-0 flex-wrap justify-end gap-1.5 font-mono text-3xs">
           <span class="rounded-[var(--r-0)] border border-ok/30 bg-ok/10 px-1.5 py-0.5 text-ok">${covered} covered</span>
-          <span class="rounded-[var(--r-0)] border border-warn/30 bg-warn/10 px-1.5 py-0.5 text-warn">${partial} partial</span>
           ${blocked > 0
             ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-1.5 py-0.5 text-[var(--color-fg-muted)]">${blocked} blocked</span>`
             : null}
@@ -181,11 +193,10 @@ function PlaneSection({ plane, entries }: { plane: CockpitPlane; entries: Cockpi
               </span>
               <${ArrowUpRight} class="mt-0.5 shrink-0 text-[var(--color-fg-muted)] transition-colors group-hover:text-[var(--color-fg-primary)]" size=${14} aria-hidden="true" />
             </span>
-            <span class="flex items-center justify-between gap-2">
+            <span class="flex items-center">
               <span class=${`rounded-[var(--r-0)] border px-1.5 py-0.5 font-mono text-3xs ${coverageClass(entrypoint.coverage)}`}>
                 ${entrypoint.coverage}
               </span>
-              <span class="font-mono text-3xs text-[var(--color-fg-disabled)]">${meta.stat}</span>
             </span>
           <//>
         `)}
@@ -195,14 +206,6 @@ function PlaneSection({ plane, entries }: { plane: CockpitPlane; entries: Cockpi
 }
 
 export function Cockpit() {
-  const entriesByPlane = new Map<CockpitPlane, CockpitEntrypoint[]>()
-  for (const plane of PLANE_ORDER) entriesByPlane.set(plane, [])
-  for (const entrypoint of COCKPIT_ENTRYPOINTS) {
-    if (PLANE_ORDER.includes(entrypoint.mode as CockpitPlane)) {
-      entriesByPlane.get(entrypoint.mode as CockpitPlane)?.push(entrypoint)
-    }
-  }
-
   return html`
     <div class="flex h-full w-full flex-col overflow-hidden bg-[var(--color-bg-page)]">
       <div class="grid min-h-0 flex-1 grid-cols-1 xl:grid-cols-[minmax(18rem,26rem)_minmax(0,1fr)]">
@@ -218,14 +221,9 @@ export function Cockpit() {
                   <p class="font-mono text-3xs text-[var(--color-fg-muted)]">MASC Cockpit</p>
                   <h1 class="mt-1 text-lg font-semibold text-[var(--color-fg-primary)]">Command Map</h1>
                 </div>
-                <div class="flex flex-wrap gap-1.5 font-mono text-3xs text-[var(--color-fg-muted)]">
-                  <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-1.5 py-0.5">
-                    ${COCKPIT_ENTRYPOINTS.length} routes
-                  </span>
-                  <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-1.5 py-0.5">
-                    ${PLANE_ORDER.length} planes
-                  </span>
-                </div>
+                <p class="font-mono text-3xs text-[var(--color-fg-muted)]">
+                  ${COCKPIT_ENTRYPOINTS.length} routes across ${PLANE_ORDER.length} planes
+                </p>
               </div>
             </section>
 
@@ -239,7 +237,7 @@ export function Cockpit() {
               <${PlaneSection}
                 key=${plane}
                 plane=${plane}
-                entries=${entriesByPlane.get(plane) ?? []}
+                entries=${ENTRIES_PER_PLANE.get(plane) ?? []}
               />
             `)}
           </div>

--- a/dashboard/src/components/cockpit/cockpit.ts
+++ b/dashboard/src/components/cockpit/cockpit.ts
@@ -59,6 +59,7 @@ const ENTRIES_PER_PLANE: ReadonlyMap<CockpitPlane, CockpitEntrypoint[]> = (() =>
 const COCKPIT_COVERED_ROUTES = COCKPIT_ENTRYPOINTS.filter(entry => entry.coverage === 'covered').length
 const COCKPIT_BLOCKED_ROUTES = COCKPIT_ENTRYPOINTS.filter(entry => entry.coverage === 'backend-blocked').length
 
+// tie-break: strict `>` keeps the initial accumulator, so PLANE_ORDER[0] (first listed plane) wins on equal counts.
 const PLANE_WITH_MOST_ENTRIES = PLANE_ORDER.reduce((top, plane) => {
   const count = ENTRIES_PER_PLANE.get(plane)?.length ?? 0
   const topCount = ENTRIES_PER_PLANE.get(top)?.length ?? 0
@@ -193,10 +194,8 @@ function PlaneSection({ plane, entries }: { plane: CockpitPlane; entries: Cockpi
               </span>
               <${ArrowUpRight} class="mt-0.5 shrink-0 text-[var(--color-fg-muted)] transition-colors group-hover:text-[var(--color-fg-primary)]" size=${14} aria-hidden="true" />
             </span>
-            <span class="flex items-center">
-              <span class=${`rounded-[var(--r-0)] border px-1.5 py-0.5 font-mono text-3xs ${coverageClass(entrypoint.coverage)}`}>
-                ${entrypoint.coverage}
-              </span>
+            <span class=${`rounded-[var(--r-0)] border px-1.5 py-0.5 font-mono text-3xs ${coverageClass(entrypoint.coverage)}`}>
+              ${entrypoint.coverage}
             </span>
           <//>
         `)}


### PR DESCRIPTION
## 목표

Cockpit "Command Map" 페이지(`dashboard/src/components/cockpit/cockpit.ts`)에서 라이브 텔레메트리처럼 보이지만 실제로는 모듈 로드 시점 상수인 UI 노이즈와, type union엔 있지만 데이터엔 0건인 dead variant를 제거합니다.

## 동기 (Why)

진단 조사에서 확인된 사실:

1. **`coverage: 'partial'`은 dead union 멤버**. `cockpit-entrypoints.ts`의 48개 라우트 중 `'partial'`은 0건. git log 추적상 2026-05-01 도입 시 9건이 있었으나 2026-05-12까지 점진적으로 모두 `'covered'`로 승격됨. 그러나 `cockpit.ts:55,68,82`는 여전히 partial 카운터를 계산·렌더링 → "0 partial" 배지가 영구 표시되는 dead UI.
2. **`PLANE_META.stat`은 stat인 척하는 plane 라벨**. `cockpit.ts:188`이 카드 우하단에 모노폰트 stat-like 시각 코드로 표시하지만 plane 단위 고정 라벨이라 같은 plane의 모든 카드에 같은 값. per-route 메트릭이라는 시각적 약속과 실제 동작 불일치.
3. **Progressive Disclosure 3-level이 같은 데이터 재조합**. perceive/comprehend/project 모두 동일한 covered/partial/blocked 카운트에서 파생. 정보 추가 없이 시각적 무게만 증가.
4. **헤더 배지가 정적 값을 라이브처럼 표시**. `${COCKPIT_ENTRYPOINTS.length} routes`는 모듈 로드 시점 상수.

## 변경 사항

- `src/cockpit-entrypoints.ts`: `coverage: 'covered' | 'partial' | 'backend-blocked'` → `coverage: 'covered' | 'backend-blocked'`. typed FSM 좁히기로 tsc가 모든 stale reference를 컴파일 타임에 enumerate (N-of-M 누락 방지).
- `src/components/cockpit/cockpit.ts`:
  - `PlaneMeta.stat` 필드 제거 + 카드 우하단 `<span>${meta.stat}</span>` 제거.
  - `COCKPIT_PARTIAL_ROUTES` 상수 + 'partial' 배지 + `PlaneSection`의 partial 카운트 + `coverageClass`의 'partial' case 제거.
  - `ENTRIES_PER_PLANE` 모듈 레벨 호이스트 (disclosure 데이터 파생 + Cockpit() 재사용).
  - `PLANE_WITH_MOST_ENTRIES`, `PLANE_WITH_MOST_GAPS` 파생 — disclosure comprehend/project items에 실데이터 주입.
  - 헤더 배지를 두 박스에서 한 줄 카탈로그 텍스트("N routes across M planes")로 다운그레이드.
  - `PLANE_ORDER`를 `as const satisfies readonly CockpitPlane[]`로 tuple narrowing (reduce 초기값 type narrowing 보장).

## 검증

- `pnpm typecheck` ✓ (0 error). `'partial'` 제거가 모든 dead reference를 enumerate한 후 정리 완료.
- `pnpm vitest run src/components/cockpit/cockpit.test.ts` ✓ (3/3 pass). 어서션 텍스트 `'1 blocked'`, `'Route coverage'`, `'Plane grouping'`, `'Route gaps'`, `'backend-blocked'`, `'Source'`, `cognitive-level 3개` 모두 보존.
- `pnpm test` ✓ (vitest config 616 files / 7274 tests + solid config 16 files / 178 tests pass).
- `pnpm lint` ✓ (0 errors; 2 pre-existing warnings in `virtual-list.ts`, `fsm-hub.ts` — unrelated).
- `pnpm build` ✓ (9.01s, chunk size warnings pre-existing).
- `rg "'partial'" src/components/cockpit/ src/cockpit-entrypoints.ts` → 0건.

## 관련 컨텍스트

- **RFC 0013 (Cockpit Migration)**: KpiStrip/Lifeline/Ticker 이식 계획 존재. 본 PR은 그 migration이 진행되기 전 현 Command Map의 UI 노이즈만 정리. KpiStrip 이식 자체는 본 PR scope 밖.
- **Follow-up**: cockpit-kit/ ↔ design-system/ui_kits/cockpit/ fork drift (cockpit-kit이 newer superset). 별도 PR로 처리 예정.

## Self-review (Best Programmer 체크리스트)

- [x] 목표 명시
- [x] 변경 파일 명시 (2개)
- [x] 로컬 검증 (typecheck/vitest/lint/build) 통과
- [x] 워크어라운드 거부 기준: typed FSM 좁히기는 string 분류기 *추가*가 아니라 *제거*. counter/dedup/cap 패턴 0건.
- [x] 테스트 fixture 호환성 사전 매핑 완료
- [ ] 시각 회귀: preview 스크린샷 첨부 (필요 시 reviewer 요청 시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)