### PR TITLE
chore(ci): skip odoc build when Pages deploy var is disabled

### DIFF
--- a/.github/workflows/odoc.yml
+++ b/.github/workflows/odoc.yml
@@ -21,6 +21,13 @@ concurrency:
 jobs:
   build-doc:
     name: Build odoc
+    # Skip the ~25-minute OCaml build when GitHub Pages deploy is not enabled.
+    # Upload + deploy steps are already gated on vars.ODOC_PAGES_DEPLOY == 'true',
+    # so without the var the build job produced artifacts that were immediately
+    # discarded (152 successful main-push runs / 30d * ~25min = ~63h/month of
+    # dead CI minutes). workflow_dispatch still runs so operators can verify
+    # @doc builds cleanly before flipping the deploy variable.
+    if: ${{ vars.ODOC_PAGES_DEPLOY == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
## Why

Audit of every workflow's 30-day run stats (`gh api .../actions/workflows/<id>/runs`) found:

| workflow | runs/30d | dead? | action |
|----|----|----|----|
| odoc.yml | 1176 (152 succ, 933 cancel, 91 fail) | **yes** — 152 successful builds × ~25 min = **~63 h/month** discarded | this PR |
| deploy-railway / perf-baseline / dashboard-lighthouse / dashboard-ws-load / webrtc-live-interop | 0–4 manual-only | intentional dormant (header comments confirm) | keep |
| ocamlformat | 96 succ / 4 fail (last 100) | normal advisory | keep |
| main-nightly-health | 7 fail / 9 runs | needs investigation; separate PR | defer |
| TLA+ Main 22 min, ci.yml Build-and-Test 50 min | hot critical paths | matrix/split = separate RFC | defer |

odoc upload + deploy were already gated on `vars.ODOC_PAGES_DEPLOY == 'true'`, but the build job itself wasn't, so every main push (~5/day) ran a ~25 min OCaml build whose artifact was discarded immediately. The new job-level `if` matches the existing gate plus a `workflow_dispatch` escape hatch.

## What

- `.github/workflows/odoc.yml`: add `if: ${{ vars.ODOC_PAGES_DEPLOY == 'true' || github.event_name == 'workflow_dispatch' }}` to `build-doc` job. No other trigger / concurrency / permission changes.

## Verification

- Existing `deploy` job already had the same guard — semantically consistent.
- `workflow_dispatch` path preserved so operators can verify `@doc` builds cleanly before flipping the variable.
- No test or production code touched; rollback = revert the 7-line addition.

## Why not delete the workflow entirely

The workflow is the deploy path for `vars.ODOC_PAGES_DEPLOY`. Deleting it would force a re-add when Pages is enabled. Gating is reversible; deletion is one-way.

## Out of scope

- ocamlformat / odoc fail-rate root cause (separate triage)
- TLA+ Main matrix split (~22 min → ~5 min, separate RFC)
- ci.yml Build-and-Test split (~50 min → ~15-20 min, separate RFC)
- main-nightly-health 78% failure (separate diagnostic)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>