### PR TITLE
chore(ci): shard TLA+ Main into 4-way matrix (22min → ~7-8min)

### DIFF
--- a/.github/workflows/tla-main.yml
+++ b/.github/workflows/tla-main.yml
@@ -13,6 +13,13 @@ name: TLA+ Main Verification
 #
 # This workflow has its own concurrency group keyed by sha, so each commit
 # gets its own slot and runs to completion regardless of subsequent pushes.
+#
+# Sharding (2026-05-13): The monolithic `check-clean` + `check-buggy`
+# pair previously took ~22 min wall-clock on every main push (run
+# 25800347971 sampled 100 specs / 1178s, but 5 specs accounted for 1107s).
+# The matrix below partitions specs across 4 GitHub-hosted runners using
+# Makefile shard targets, dropping wall-clock to ~7-8 min while keeping
+# coverage identical (`check-matrix-coverage` is the gate).
 
 on:
   push:
@@ -29,10 +36,29 @@ permissions:
   contents: read
 
 jobs:
-  tla-specs:
-    name: TLA+ Model Checking (main)
+  coverage:
+    name: TLA+ matrix coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Verify every spec dir is sharded
+        run: make -C specs check-matrix-coverage
+
+  tla-specs:
+    name: TLA+ Model Checking (${{ matrix.shard.name }})
+    needs: coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - { name: keeper-state-machine, target: check-keeper }
+          - { name: masc-ecosystem,       target: check-ecosystem }
+          - { name: social-state,         target: check-social }
+          - { name: others,               target: check-others }
 
     steps:
       - name: Checkout
@@ -49,7 +75,5 @@ jobs:
           curl -fsSL -o specs/keeper-state-machine/tla2tools.jar \
             https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
 
-      - name: Run TLA+ model checking
-        run: |
-          make -C specs check-clean
-          make -C specs check-buggy
+      - name: Run TLA+ model checking (${{ matrix.shard.name }})
+        run: make -C specs ${{ matrix.shard.target }}

--- a/specs/Makefile
+++ b/specs/Makefile
@@ -57,7 +57,7 @@ BUGGY_CFGS := $(shell find . -name '*-buggy*.cfg' | sort)
 clean_cfgs_in = $(shell find $(1) -name '*.cfg' ! -name '*-buggy*.cfg' | sort)
 buggy_cfgs_in = $(shell find $(1) -name '*-buggy*.cfg' | sort)
 
-.PHONY: check-all check-clean check-buggy check-bug-models check-keeper check-ecosystem check-boundary check-closure list clean clean-artefacts
+.PHONY: check-all check-clean check-buggy check-bug-models check-keeper check-ecosystem check-boundary check-closure check-social check-others check-matrix-coverage list clean clean-artefacts
 
 clean: clean-artefacts
 
@@ -135,6 +135,43 @@ check-boundary: check-all
 check-closure: CLEAN_CFGS := $(call clean_cfgs_in,closure/)
 check-closure: BUGGY_CFGS := $(call buggy_cfgs_in,closure/)
 check-closure: check-all
+
+# Sharding groups for CI matrix.  The four targets below partition the same
+# spec set that `check-all` walks; verified by the `check-matrix-coverage`
+# target which fails if anything drifts out of sync.  Tuning:
+#
+#   keeper-state-machine   ~10 min  (51 cfgs, dominated by 3 slow KSM specs)
+#   masc-ecosystem         ~6 min   (MASCEcosystem 352s)
+#   social-and-state-prod  ~3 min   (SocialStateCap 180s top)
+#   others (14 dirs)       ~1 min   (everything not above)
+#
+# Wall-clock fan-out reduces TLA+ Main from ~22 min monolithic to ~10 min.
+
+SOCIAL_DIRS := social-state-cap state-product
+check-social: CLEAN_CFGS := $(foreach d,$(SOCIAL_DIRS),$(call clean_cfgs_in,$(d)/))
+check-social: BUGGY_CFGS := $(foreach d,$(SOCIAL_DIRS),$(call buggy_cfgs_in,$(d)/))
+check-social: check-all
+
+OTHER_DIRS := admission-queue auth autonomous boundary bug-models cascade \
+              checkpoint-trim closure keeper-turn-fsm multimodal resilience \
+              server-state shared task-lifecycle
+check-others: CLEAN_CFGS := $(foreach d,$(OTHER_DIRS),$(call clean_cfgs_in,$(d)/))
+check-others: BUGGY_CFGS := $(foreach d,$(OTHER_DIRS),$(call buggy_cfgs_in,$(d)/))
+check-others: check-all
+
+# Coverage check: every spec directory must appear in exactly one shard.
+# Run in CI before sharded jobs to catch silent drops when new dirs land.
+SHARD_DIRS_ALL := keeper-state-machine masc-ecosystem $(SOCIAL_DIRS) $(OTHER_DIRS)
+check-matrix-coverage: SHELL := /bin/bash
+check-matrix-coverage:
+	@set -euo pipefail; \
+	all_sorted=$$(find . -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort -u); \
+	shard_sorted=$$(printf '%s\n' $(SHARD_DIRS_ALL) | sort -u); \
+	missing=$$(comm -23 <(printf '%s\n' "$$all_sorted") <(printf '%s\n' "$$shard_sorted")); \
+	extra=$$(comm -13 <(printf '%s\n' "$$all_sorted") <(printf '%s\n' "$$shard_sorted")); \
+	if [ -n "$$missing" ]; then echo "::error::Spec dirs missing from CI shards:"; echo "$$missing"; exit 1; fi; \
+	if [ -n "$$extra" ]; then echo "::error::Shard references unknown dirs:"; echo "$$extra"; exit 1; fi; \
+	echo "Matrix coverage OK ($$(printf '%s\n' "$$all_sorted" | wc -l | tr -d ' ') dirs across 4 shards)"
 
 list:
 	@echo "Clean specs ($(words $(CLEAN_CFGS))):"; \

--- a/specs/Makefile
+++ b/specs/Makefile
@@ -140,12 +140,12 @@ check-closure: check-all
 # spec set that `check-all` walks; verified by the `check-matrix-coverage`
 # target which fails if anything drifts out of sync.  Tuning:
 #
-#   keeper-state-machine   ~10 min  (51 cfgs, dominated by 3 slow KSM specs)
+#   keeper-state-machine   ~4 min   (34 cfgs, dominated by KSM specs)
 #   masc-ecosystem         ~6 min   (MASCEcosystem 352s)
 #   social-and-state-prod  ~3 min   (SocialStateCap 180s top)
-#   others (14 dirs)       ~1 min   (everything not above)
+#   others (14 dirs)       ~7 min   (incl. KeeperStaleKilled 182s + MemoryCompaction 181s)
 #
-# Wall-clock fan-out reduces TLA+ Main from ~22 min monolithic to ~10 min.
+# Wall-clock fan-out reduces TLA+ Main from ~22 min monolithic to ~7-8 min.
 
 SOCIAL_DIRS := social-state-cap state-product
 check-social: CLEAN_CFGS := $(foreach d,$(SOCIAL_DIRS),$(call clean_cfgs_in,$(d)/))
@@ -166,6 +166,8 @@ check-matrix-coverage: SHELL := /bin/bash
 check-matrix-coverage:
 	@set -euo pipefail; \
 	all_sorted=$$(find . -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort -u); \
+	dups=$$(printf '%s\n' $(SHARD_DIRS_ALL) | sort | uniq -d); \
+	if [ -n "$$dups" ]; then echo "::error::Dirs listed in more than one shard:"; echo "$$dups"; exit 1; fi; \
 	shard_sorted=$$(printf '%s\n' $(SHARD_DIRS_ALL) | sort -u); \
 	missing=$$(comm -23 <(printf '%s\n' "$$all_sorted") <(printf '%s\n' "$$shard_sorted")); \
 	extra=$$(comm -13 <(printf '%s\n' "$$all_sorted") <(printf '%s\n' "$$shard_sorted")); \


### PR DESCRIPTION
## Why

The single \`Run TLA+ model checking\` step on \`tla-main.yml\` walks every spec on every main push and on every 6h cron sweep — ~22 min wall-clock. Sampling run [25800347971](https://github.com/jeong-sik/masc-mcp/actions/runs/25800347971) found 100 specs / 1178s, with **5 specs accounting for 1107s (94%)**:

| spec | dir | time |
|---|---|---|
| MASCEcosystem | masc-ecosystem | 352s |
| KeeperContextLifecycle | keeper-state-machine | 212s |
| KeeperStaleKilled | boundary | 182s |
| MemoryCompaction | bug-models | 181s |
| SocialStateCap | social-state-cap | 180s |

Critical-path latency matters: main-breakage signal is read first thing every morning (see \`main-nightly-health.yml\` rationale, #14668 incident).

## What

- **\`specs/Makefile\`**: add \`check-social\`, \`check-others\`, \`check-matrix-coverage\` targets. \`check-keeper\` / \`check-ecosystem\` already existed; the four shards partition the 18 spec directories exactly once.
- **\`.github/workflows/tla-main.yml\`**: add a \`coverage\` gate job + a \`tla-specs\` matrix over the four shards with \`fail-fast: false\`. Same Java + tla2tools bootstrap reused on each runner.

| shard | dirs | expected wall-clock |
|---|---|---|
| keeper-state-machine | 1 dir, 34 cfgs | ~4 min |
| masc-ecosystem | 1 dir, 1 cfg | ~6 min |
| social-state | social-state-cap + state-product, 3 cfgs | ~3 min |
| others | 14 dirs, 58 cfgs (incl. KSK 182s + MC 181s) | ~7 min |

Wall-clock max ≈ **~7-8 min**, down from ~22 min.

## Coverage gate

The new \`coverage\` job runs first and calls \`make check-matrix-coverage\`. That target diffs the live \`find specs/*/\` output against \`SHARD_DIRS_ALL\` and fails the run on either *missing* or *extra* directory references. Adding a new spec dir without updating the shard list = CI break, not silent drop.

## Verification (local)

\`\`\`
$ make -C specs check-matrix-coverage
Matrix coverage OK (18 dirs across 4 shards)
\`\`\`

Dry-run for each shard confirmed the expected cfg sets (sum = \`check-all\`).

## Out of scope

- \`tla-scheduled.yml\` stays monolithic. Its hourly cron is latency-tolerant and \`cancel-in-progress: true\` already keeps cumulative runner minutes near zero; sharding it would raise cost without lowering signal latency that matters.
- Further splitting the \`others\` shard (KSK + MC + 56 light specs) is technically possible but a 5th shard buys ~1 min vs. extra bookkeeping. Revisit if a 6th heavy spec lands in a non-keeper dir.
- \`ci.yml\` \`Build and Test\` 50-min monolith is a separate, larger reshape (deferred to its own RFC).

## Risk / rollback

- Each shard reuses the same \`make\` targets that already exist; coverage gate ensures no spec is silently skipped.
- Rollback = revert the workflow change (Makefile additions are inert without the matrix invoker).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>