### PR TITLE
fix(keeper): harden cascade exhaustion and tool routing

### DIFF
--- a/lib/cascade/cascade_declarative_adapter.ml
+++ b/lib/cascade/cascade_declarative_adapter.ml
@@ -130,12 +130,21 @@ let request_path_for_http_provider ~registry_entry ~kind ~base_url =
     Cascade_config.normalize_openai_compat_request_path ~base_url ~request_path
   | _ -> request_path
 
+let supports_tool_choice_override_of_model_spec (spec : cascade_model_spec) =
+  match spec.capabilities with
+  | Some capabilities -> Some capabilities.supports_tool_choice
+  | None -> None
+;;
+
 let provider_config_from_declared_provider
     (provider : cascade_provider)
     (spec : cascade_model_spec)
     ~(max_tokens : int option)
     : Llm_provider.Provider_config.t option =
   let registry_entry = find_registry_entry provider.id in
+  let supports_tool_choice_override =
+    supports_tool_choice_override_of_model_spec spec
+  in
   match provider.transport with
   | Http base_url ->
     (match provider_kind_for_http_provider ?registry_entry provider with
@@ -149,6 +158,7 @@ let provider_config_from_declared_provider
             ~api_key:(api_key_of_credential ?registry_entry provider.credentials)
             ~request_path
             ~max_context:spec.max_context
+            ?supports_tool_choice_override
             ?max_tokens
             ())
      | None -> None)
@@ -163,6 +173,7 @@ let provider_config_from_declared_provider
             ~api_key:(api_key_of_credential ?registry_entry provider.credentials)
             ~headers:[]
             ~max_context:spec.max_context
+            ?supports_tool_choice_override
             ?max_tokens
             ())
      | None -> None)

--- a/lib/cascade/cascade_declarative_adapter.ml
+++ b/lib/cascade/cascade_declarative_adapter.ml
@@ -201,6 +201,9 @@ let resolve_binding_config (cfg : cascade_config)
       | Some input_cost, Some _ when input_cost > 0.0 -> Some spec.max_context
       | _ -> None
     in
+    let supports_tool_choice_override =
+      supports_tool_choice_override_of_model_spec spec
+    in
     let parse_registered_provider () =
       match resolve_provider_prefix binding.provider_id with
       | None ->
@@ -208,7 +211,10 @@ let resolve_binding_config (cfg : cascade_config)
         None
       | Some cascade_prefix ->
         let model_string = Printf.sprintf "%s:%s" cascade_prefix spec.api_name in
-        Cascade_config.parse_model_string ?max_tokens model_string
+        Cascade_config.parse_model_string
+          ?max_tokens
+          ?supports_tool_choice_override
+          model_string
     in
     let result =
       match find_provider cfg binding.provider_id with

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -121,6 +121,7 @@ let set_keeper_paused_state ~agent_name paused =
           else Keeper_state_machine.Operator_resume);
        if not paused
        then (
+         Keeper_turn_livelock.reset_keeper_livelock ~keeper:entry.name;
          (* tla-lint: allow-mutation: fiber signal — Atomic flag wakes the keeper from Eio.Promise.await *)
          Atomic.set entry.fiber_wakeup true;
          (* Cycle 43: KeeperHeartbeat.tla WakeupSignal post-condition.

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -182,7 +182,12 @@ let process_directive ~agent_name directive =
        [meta.paused = true]. Without this branch, wakeup signals fiber_wakeup
        but the heartbeat loop honors paused state and skips — user clicks
        "깨우기" with no observable effect. Treat wakeup as a superset of
-       resume so paused keepers re-enter the run loop. *)
+       resume so paused keepers re-enter the run loop.
+       Also clear any persisted livelock attempt counter regardless of which
+       branch runs: turn-livelock blocks record only a `pause_human` receipt
+       and do not persist [meta.paused], so the wakeup directive on those
+       keepers takes the non-paused branch and the stale attempt counter
+       would otherwise survive into the next dispatch. *)
     let entry_paused =
       match Keeper_registry.find_by_agent_name agent_name with
       | Some e -> e.meta.paused
@@ -194,6 +199,7 @@ let process_directive ~agent_name directive =
          | Some meta -> meta.paused
          | None -> false)
     in
+    Keeper_turn_livelock.reset_keeper_livelock ~keeper:agent_name;
     if entry_paused
     then (
       Log.Keeper.info "directive: waking up %s (was paused — auto-resuming)" agent_name;

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1790,6 +1790,42 @@ let set_turn_cascade_state ~base_path name (cascade_state : packed_cascade_state
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 
+let mark_turn_cascade_exhausted ~base_path name =
+  let set_cascade_state cascade_state =
+    set_turn_cascade_state
+      ~base_path
+      name
+      (Packed cascade_state : packed_cascade_state)
+  in
+  match get ~base_path name with
+  | None | Some { current_turn_observation = None; _ } -> ()
+  | Some { current_turn_observation = Some obs; _ } ->
+    (match obs.cascade_state with
+     | Packed Cascade_idle ->
+       set_turn_decision_stage
+         ~base_path
+         name
+         Decision_active_tool_policy_selected;
+       set_cascade_state Cascade_selecting;
+       set_cascade_state Cascade_trying;
+       set_cascade_state Cascade_exhausted
+     | Packed Cascade_selecting ->
+       set_turn_decision_stage
+         ~base_path
+         name
+         Decision_active_tool_policy_selected;
+       set_cascade_state Cascade_trying;
+       set_cascade_state Cascade_exhausted
+     | Packed Cascade_trying -> set_cascade_state Cascade_exhausted
+     | Packed Cascade_exhausted -> set_cascade_state Cascade_exhausted
+     | Packed Cascade_done ->
+       Log.Keeper.warn
+         "registry: ignoring cascade exhaustion after Cascade_done name=%s \
+          base_path=%s"
+         name
+         base_path)
+;;
+
 let set_turn_phase ~base_path name (turn_phase : packed_turn_phase) =
   (* RFC-0072 Phase 4b + Phase 5: dispatch via [resolve_turn_phase_transition]
      (PR #14912) instead of the [validate_turn_phase_transition] call.

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -707,6 +707,15 @@ val set_turn_decision_stage :
 val set_turn_cascade_state :
   base_path:string -> string -> packed_cascade_state -> unit
 
+(** Mark cascade exhaustion on the live turn.
+
+    When provider selection fails before the tool-disclosure hook runs, the
+    live cascade axis can still be [Cascade_idle]. This helper materializes the
+    spec-valid pre-terminal path ([idle -> selecting -> trying -> exhausted])
+    instead of allowing callers to jump directly to [Cascade_exhausted]. No-op
+    when no turn is active. *)
+val mark_turn_cascade_exhausted : base_path:string -> string -> unit
+
 (** Update the live turn's phase directly. No-op if idle. *)
 val set_turn_phase :
   base_path:string -> string -> packed_turn_phase -> unit

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -799,6 +799,7 @@ let resume_keeper_after_reconcile_gate (ctx : _ context) (meta : keeper_meta) =
     resumed_meta.name
     None;
   Keeper_registry.reset_turn_failures ~base_path:ctx.config.base_path resumed_meta.name;
+  Keeper_turn_livelock.reset_keeper_livelock ~keeper:resumed_meta.name;
   Keeper_registry.dispatch_event_unit
     ~base_path:ctx.config.base_path
     resumed_meta.name

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -221,7 +221,8 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     Log.Keeper.warn
       "update_keeper resumed paused keeper %s; clearing \
        auto_resume_after_sec=%s last_blocker.klass=%s last_blocker.detail=%S"
-      old.name auto_resume_after_sec blocker_class blocker_detail);
+      old.name auto_resume_after_sec blocker_class blocker_detail;
+    Keeper_turn_livelock.reset_keeper_livelock ~keeper:old.name);
   if old.paused && not resume_paused_keeper then
     Log.Keeper.warn
       "update_keeper kept %s paused because an approval/reconcile gate is pending"

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -221,8 +221,13 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     Log.Keeper.warn
       "update_keeper resumed paused keeper %s; clearing \
        auto_resume_after_sec=%s last_blocker.klass=%s last_blocker.detail=%S"
-      old.name auto_resume_after_sec blocker_class blocker_detail;
-    Keeper_turn_livelock.reset_keeper_livelock ~keeper:old.name);
+      old.name auto_resume_after_sec blocker_class blocker_detail);
+  (* Clear any persisted livelock attempt counter on every update_keeper run,
+     not only the resume-paused branch.  Turn-livelock guards record a
+     `pause_human` receipt without setting [meta.paused], so a follow-up
+     `masc_keeper_up` for that keeper would otherwise leave the stale
+     counter in memory and the next dispatch would still be blocked. *)
+  Keeper_turn_livelock.reset_keeper_livelock ~keeper:old.name;
   if old.paused && not resume_paused_keeper then
     Log.Keeper.warn
       "update_keeper kept %s paused because an approval/reconcile gate is pending"

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1181,11 +1181,9 @@ let run_keeper_cycle
                          let mark_terminal_error err =
                            if EC.is_cascade_exhausted_error err
                            then (
-                             Keeper_registry.set_turn_cascade_state
+                             Keeper_registry.mark_turn_cascade_exhausted
                                ~base_path:config.base_path
-                               meta.name
-                               (Keeper_registry.Packed Cascade_exhausted
-                                : Keeper_registry.packed_cascade_state);
+                               meta.name;
                              Prometheus.inc_counter
                                Keeper_metrics.metric_keeper_fsm_edge_transitions
                                ~labels:[ "edge", "kcl_to_ktc_exhaustion" ]

--- a/test/test_cascade_declarative_adapter.ml
+++ b/test/test_cascade_declarative_adapter.ml
@@ -317,6 +317,55 @@ strategy = "failover"
            (List.length configs)))
 ;;
 
+let test_model_capabilities_tool_choice_reaches_provider_config () =
+  let toml =
+    {|
+[providers.glm-coding]
+protocol = "openai-http"
+endpoint = "https://api.z.ai/api/coding/paas/v4"
+
+[models.glm-5-1]
+max-context = 128000
+api-name = "glm-5.1"
+tools-support = true
+
+[models.glm-5-1.capabilities]
+supports-tool-choice = true
+
+[glm-coding.glm-5-1]
+max-concurrent = 1
+
+[tier.coding_plan_primary]
+members = ["glm-coding.glm-5-1"]
+strategy = "failover"
+|}
+  in
+  let catalog = adapt_toml toml in
+  no_errors catalog.errors;
+  let tier =
+    List.find
+      (fun (p : adapted_profile) -> p.name = "tier.coding_plan_primary")
+      catalog.profiles
+  in
+  match tier.provider_configs with
+  | [ cfg ] ->
+    check
+      (option bool)
+      "supports-tool-choice override is preserved"
+      (Some true)
+      cfg.Llm_provider.Provider_config.supports_tool_choice_override;
+    check bool "tool-choice gate accepts declared model capability" true
+      (Masc_mcp.Provider_tool_support.supports_required_tool_use
+         ~require_tool_choice_support:true
+         ~require_tool_support:true
+         cfg)
+  | configs ->
+    fail
+      (Printf.sprintf
+         "expected one resolved provider config, got %d"
+         (List.length configs))
+;;
+
 let test_declared_http_provider_v1_endpoint_dedupes_request_path () =
   let toml =
     {|
@@ -838,6 +887,10 @@ let () =
             "registered HTTP provider uses registry api_key_env fallback"
             `Quick
             test_registered_http_provider_without_credentials_uses_registry_api_key_env
+        ; test_case
+            "model supports-tool-choice reaches provider config"
+            `Quick
+            test_model_capabilities_tool_choice_reaches_provider_config
         ; test_case
             "declared HTTP provider dedupes request path"
             `Quick

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -1070,11 +1070,22 @@ let test_directive_pause () =
 
 let test_directive_resume () =
   R.clear ();
+  Masc_mcp.Keeper_turn_livelock.reset_for_tests ();
   let _entry = R.register ~base_path:bp "dr1" (make_meta "dr1") in
+  ignore
+    (Masc_mcp.Keeper_turn_livelock.guard_and_record_turn_start
+       ~keeper:"dr1"
+       ~turn_id:7
+       ~max_attempts:3
+       ~stuck_after_sec:1800.0
+       ());
   KK.process_directive ~agent_name:"agent-dr1" "pause";
   KK.process_directive ~agent_name:"agent-dr1" "resume";
   match R.get ~base_path:bp "dr1" with
-  | Some e -> check bool "resumed after directive" false e.meta.paused
+  | Some e ->
+    check bool "resumed after directive" false e.meta.paused;
+    check bool "resume clears livelock attempt state" true
+      (Option.is_none (Masc_mcp.Keeper_turn_livelock.current_state ~keeper:"dr1"))
   | None -> fail "expected dr1"
 
 let test_directive_keeper_name_alias () =
@@ -1447,6 +1458,24 @@ let test_mark_sdk_turn_started_no_op_without_obs () =
     fail "mark_sdk_turn_started installed observation without keeper-turn"
   | None -> fail "entry missing"
 
+let test_mark_turn_cascade_exhausted_materializes_pre_disclosure_path () =
+  R.clear ();
+  let keeper_name = "k-cascade-exhausted-pre-disclosure" in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  R.mark_turn_started ~base_path:bp keeper_name;
+  R.mark_turn_cascade_exhausted ~base_path:bp keeper_name;
+  match R.get ~base_path:bp keeper_name with
+  | Some { current_turn_observation = Some obs; _ } ->
+    check bool "cascade_state lands on Cascade_exhausted" true
+      (obs.R.cascade_state = R.Packed R.Cascade_exhausted);
+    check bool "turn_phase lands on Turn_exhausted" true
+      (obs.R.turn_phase = R.Packed R.Turn_exhausted);
+    check bool "decision_stage records tool policy boundary" true
+      (obs.R.decision_stage = R.Packed R.Decision_tool_policy_selected)
+  | Some { current_turn_observation = None; _ } ->
+    fail "mark_turn_cascade_exhausted cleared observation"
+  | None -> fail "entry missing"
+
 (* The production [Assert_failure] at keeper_registry.ml:775 was triggered
    when the SDK fired [before_turn_params] for a second time inside one
    keeper-turn.  This test reproduces the same shape: two
@@ -1663,6 +1692,8 @@ let () =
             test_mark_sdk_turn_started_preserves_keeper_scope;
           eio_test "mark_sdk_turn_started no-op without observation"
             test_mark_sdk_turn_started_no_op_without_obs;
+          eio_test "mark_turn_cascade_exhausted materializes pre-disclosure path"
+            test_mark_turn_cascade_exhausted_materializes_pre_disclosure_path;
           eio_test "two SDK-turn boundaries inside one keeper-turn"
             test_two_sdk_turn_boundaries_no_assert;
           eio_test "set_turn_phase rejection bumps guard metric"

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -479,6 +479,7 @@ let test_playground_repo_status_refreshes_cached_git_metadata () =
     ~finally:(fun () ->
       Keeper_keepalive.stop_keepalive keeper_name;
       Keeper_registry.clear ();
+      Masc_mcp.Keeper_turn_livelock.reset_for_tests ();
       Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
     (fun () ->
@@ -1377,6 +1378,13 @@ let test_keeper_up_resumes_auto_paused_keeper () =
       (match Keeper_types.write_meta config paused_meta with
        | Ok () -> ()
        | Error err -> Alcotest.fail ("paused meta write failed: " ^ err));
+      ignore
+        (Masc_mcp.Keeper_turn_livelock.guard_and_record_turn_start
+           ~keeper:keeper_name
+           ~turn_id:11
+           ~max_attempts:3
+           ~stuck_after_sec:1800.0
+           ());
       let ok, body =
         dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
           ~args:
@@ -1396,7 +1404,10 @@ let test_keeper_up_resumes_auto_paused_keeper () =
       Alcotest.(check bool) "auto resume delay cleared" true
         (Option.is_none resumed.auto_resume_after_sec);
       Alcotest.(check bool) "runtime blocker cleared" true
-        (Option.is_none resumed.runtime.last_blocker))
+        (Option.is_none resumed.runtime.last_blocker);
+      Alcotest.(check bool) "keeper_up resume clears livelock state" true
+        (Option.is_none
+           (Masc_mcp.Keeper_turn_livelock.current_state ~keeper:keeper_name)))
 
 let test_keeper_up_keeps_paused_keeper_with_continue_gate_blocker () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary
- Materialize the valid cascade terminal path when provider/cascade exhaustion happens before the provider-disclosure hook has moved the turn out of Cascade_idle.
- Propagate declarative supports-tool-choice from cascade.toml model capabilities into Provider_config so required-tool gates match the TOML truth.
- Clear the turn livelock guard on keeper resume / keeper up after operator intervention, so stale attempts=3 does not keep blocking dispatch after the underlying issue is fixed.

## Validation
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build --cache=disabled test/test_keeper_registry.exe test/test_cascade_declarative_adapter.exe test/test_operator_control.exe test/test_keeper_unified.exe bin/main_eio.exe
- ./_build/default/test/test_keeper_registry.exe
- ./_build/default/test/test_cascade_declarative_adapter.exe
- ./_build/default/test/test_operator_control.exe test operator 31
- ./_build/default/test/test_keeper_unified.exe test phase_gate 1
- opam exec -- ocamlformat --check <touched OCaml files>
- git diff --check
- live /health on the patched worktree binary is ok; post-restart log scan found no Rate limited / livelock / invalid cascade transition / no callable models signatures

## Operator note
The live local /Users/dancer/me/.masc/config/cascade.toml was updated separately with an Ollama Cloud coding_plan fallback. That runtime config change is intentionally not included in this repo commit.