### PR TITLE
fix(ide): address post-merge context review comments

### DIFF
--- a/dashboard/src/components/ide/ide-lsp-client.test.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.test.ts
@@ -36,6 +36,13 @@ describe('resolveLspDiagnosticFilePath', () => {
     )).toBeNull()
   })
 
+})
+
+describe('clearLspDiagnosticSnapshot', () => {
+  afterEach(() => {
+    lspDiagnosticSnapshot.value = new Map()
+  })
+
   it('clears only the normalized diagnostic snapshot for the previous file', () => {
     lspDiagnosticSnapshot.value = new Map([
       [

--- a/dashboard/src/components/ide/ide-lsp-client.test.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it } from 'vitest'
-import { resolveLspDiagnosticFilePath } from './ide-lsp-client'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  clearLspDiagnosticSnapshot,
+  lspDiagnosticSnapshot,
+  resolveLspDiagnosticFilePath,
+} from './ide-lsp-client'
 
 describe('resolveLspDiagnosticFilePath', () => {
+  afterEach(() => {
+    lspDiagnosticSnapshot.value = new Map()
+  })
+
   it('keeps safe relative diagnostic URIs as IDE file paths', () => {
     expect(resolveLspDiagnosticFilePath(
       'file://lib/keeper/runtime.ml',
@@ -26,5 +34,37 @@ describe('resolveLspDiagnosticFilePath', () => {
       'file:///tmp/current.ml',
       'lib/keeper/current.ml',
     )).toBeNull()
+  })
+
+  it('clears only the normalized diagnostic snapshot for the previous file', () => {
+    lspDiagnosticSnapshot.value = new Map([
+      [
+        'lib/keeper/old.ml',
+        [
+          {
+            file_path: 'lib/keeper/old.ml',
+            line: 7,
+            severity: 1,
+            message: 'old diagnostic',
+          },
+        ],
+      ],
+      [
+        'lib/keeper/current.ml',
+        [
+          {
+            file_path: 'lib/keeper/current.ml',
+            line: 3,
+            severity: 2,
+            message: 'current diagnostic',
+          },
+        ],
+      ],
+    ])
+
+    clearLspDiagnosticSnapshot('lib\\keeper\\old.ml')
+
+    expect(lspDiagnosticSnapshot.value.has('lib/keeper/old.ml')).toBe(false)
+    expect(lspDiagnosticSnapshot.value.get('lib/keeper/current.ml')).toHaveLength(1)
   })
 })

--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -638,7 +638,7 @@ function publishLspDiagnosticSnapshot(
   lspDiagnosticSnapshot.value = next
 }
 
-function clearLspDiagnosticSnapshot(filePath: string): void {
+export function clearLspDiagnosticSnapshot(filePath: string): void {
   const normalizedFilePath = normalizeIdeContextFilePath(filePath)
   if (normalizedFilePath === null) return
   const next = new Map(lspDiagnosticSnapshot.value)
@@ -727,7 +727,9 @@ const lspViewPlugin = ViewPlugin.fromClass(
       if (update.docChanged) this.hideTooltip()
       const newFilePath = update.state.field(lspConfigField).filePath
       if (newFilePath !== this.filePath) {
-        this.conn.notifyDidClose(this.filePath)
+        const oldFilePath = this.filePath
+        this.conn.notifyDidClose(oldFilePath)
+        clearLspDiagnosticSnapshot(oldFilePath)
         this.filePath = newFilePath
         this.conn.notifyDidOpen(newFilePath, languageIdFromPath(newFilePath) ?? 'text')
         this.scheduleRefresh()
@@ -751,6 +753,7 @@ const lspViewPlugin = ViewPlugin.fromClass(
       ])
 
       if (!view.dom.isConnected) return
+      if (fp !== this.filePath) return
       const effects: StateEffect<unknown>[] = []
       if (lenses.status === 'fulfilled') effects.push(setCodeLenses.of(lenses.value))
       if (hints.status === 'fulfilled') effects.push(setInlayHints.of(hints.value))

--- a/lib/activity_graph/activity_graph_types.ml
+++ b/lib/activity_graph/activity_graph_types.ml
@@ -299,9 +299,12 @@ let derive_context_from_tag fields raw =
   | None -> fields
   | Some ("file", value) ->
     let file_path, line = tag_file_value value in
-    fields
-    |> assoc_replace_string_opt "file_path" file_path
-    |> assoc_replace_int_opt "line" line
+    (match file_path with
+     | Some file_path ->
+       fields
+       |> assoc_replace "file_path" (`String file_path)
+       |> assoc_replace_int_opt "line" line
+     | None -> fields)
   | Some ("line", value) ->
     (match int_of_string_opt value with
      | Some line when line >= 1 -> assoc_replace "line" (`Int line) fields

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -168,23 +168,43 @@ let test_events_json_omits_unsafe_ide_context_file_paths () =
            ~tags:[ "file:lib/../tag.ml:31" ]
            ~payload:(`Assoc [])
            ());
+      ignore
+        (Activity_graph.emit config ~kind:"keeper.turn_completed"
+           ~actor:(Activity_graph.entity ~kind:"keeper" "sangsu")
+           ~subject:(Activity_graph.entity ~kind:"log" "turn-mismatch")
+           ~tags:[ "file:/workspace/lib/tag.ml:99" ]
+           ~payload:
+             (`Assoc
+                [
+                  ("file_path", `String "lib/payload.ml");
+                  ("line", `Int 12);
+                ])
+           ());
       let json = Activity_graph.json_response config ~after_seq:0 ~limit:10 () in
       let open Yojson.Safe.Util in
       match json |> member "events" |> to_list with
-      | [ payload_event; drive_event; traversal_event ] ->
+      | [ payload_event; drive_event; traversal_event; mismatch_event ] ->
+        let file_path_omitted event =
+          match event |> member "context" with
+          | `Null -> true
+          | context -> context |> member "file_path" = `Null
+        in
         List.iter
           (fun event ->
-            check bool "unsafe file path omitted" true
-              (event |> member "context" |> member "file_path" |> fun value ->
-               value = `Null))
+            check bool "unsafe file path omitted" true (file_path_omitted event))
           [ payload_event; drive_event; traversal_event ];
         check int "line survives without unsafe payload file path" 12
           (payload_event |> member "context" |> member "line" |> to_int);
-        check int "line survives without unsafe tag file path" 27
-          (drive_event |> member "context" |> member "line" |> to_int)
+        check bool "unsafe tag file line omitted" true
+          (drive_event |> member "context" = `Null);
+        let mismatch_context = mismatch_event |> member "context" in
+        check string "unsafe tag keeps payload file path" "lib/payload.ml"
+          (mismatch_context |> member "file_path" |> to_string);
+        check int "unsafe tag keeps payload line" 12
+          (mismatch_context |> member "line" |> to_int)
       | events ->
         fail
-          (Printf.sprintf "expected three events, got %d" (List.length events)))
+          (Printf.sprintf "expected four events, got %d" (List.length events)))
 
 let test_events_json_ignores_invalid_derived_pr_number () =
   with_config (fun config ->


### PR DESCRIPTION
## Summary
- Handle post-merge #15035 review comments in a follow-up draft PR.
- Reject unsafe `file:` tags as an atomic file/line pair so rejected tags cannot overwrite safe payload lines.
- Clear stale LSP diagnostic snapshots when the editor switches files, and discard in-flight refresh results for old files.
- Add regression coverage for both unsafe file-tag line mismatch and stale diagnostic snapshot clearing.

## Validation
- `ocamlformat --check lib/activity_graph/activity_graph_types.ml test/test_activity_graph.ml`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_activity_graph.exe`
- `./_build/default/test/test_activity_graph.exe`
- `pnpm install --offline --frozen-lockfile`
- `pnpm exec eslint src/components/ide/ide-lsp-client.ts src/components/ide/ide-lsp-client.test.ts`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-lsp-client.test.ts`
- `pnpm exec tsc --noEmit --pretty false`

Note: the first focused Dune build without `MASC_SKIP_PIN_CHECK=1` was blocked by unrelated shared opam `agent_sdk` pin drift, so I did not repin the global switch from this review-fix worktree.