### PR TITLE
Clarify fleet telemetry coverage

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -241,7 +241,7 @@ describe('FleetTelemetryPanel', () => {
     expect(fetchTelemetrySummary).toHaveBeenCalledTimes(1)
     expect(fetchDashboardNamespaceTruth).toHaveBeenCalledTimes(1)
     expect(container.textContent).toContain('키퍼 가동률')
-    expect(container.textContent).toContain('1/2 키퍼가 최근 도구 활동을 보였습니다.')
+    expect(container.textContent).toContain('도구 telemetry 확인 1/2 · 활동 1 · 기록 없음 0 · 미확인 1')
     expect(container.textContent).toContain('keeper-alpha')
     expect(container.textContent).toContain('keeper-beta')
     expect(container.textContent).toContain('Keeper 턴 로그')

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -47,6 +47,7 @@ import {
   summaryCounts,
   toneForPressure,
   toneForToolSuccess,
+  toolTelemetryCoverageDetail,
   toolSummary,
   type FleetRow,
   type FleetTelemetryState,
@@ -135,7 +136,7 @@ function SummaryCard({
     <div class="rounded-[var(--r-1)] border ${toneClass} p-3">
       <${Eyebrow} tone="disabled">${title}</${Eyebrow}>
       <div class="mt-1 text-xl font-semibold text-[var(--text)]">${value}</div>
-      <div class="mt-1 text-2xs leading-relaxed text-[var(--color-fg-disabled)]">${detail}</div>
+      <div class="mt-1 text-2xs leading-relaxed text-[var(--color-fg-muted)]">${detail}</div>
     </div>
   `
 }
@@ -750,7 +751,7 @@ export function FleetTelemetryPanel() {
         <${SummaryCard}
           title="키퍼 가동률"
           value=${`${counts.live}/${value.rows.length || 0}`}
-          detail=${`${counts.toolCovered}/${value.rows.length || 0} 키퍼가 최근 도구 활동을 보였습니다.`}
+          detail=${toolTelemetryCoverageDetail(counts, value.rows.length)}
           tone=${liveTone}
         />
         <${SummaryCard}

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -25,6 +25,7 @@ import {
   toneForPressure,
   toolSummary,
   summaryCounts,
+  toolTelemetryCoverageDetail,
   buildToolQualityMap,
   buildFleetRows,
   buildRuntimeWarnings,
@@ -486,13 +487,40 @@ describe('summaryCounts', () => {
   it('counts live, hot, warn, stale correctly', () => {
     const rows = [
       makeRow({ name: 'a', keepalive_running: true, context_ratio: 0.1, last_activity_ago_s: 60, tool_calls: 1 }),
-      makeRow({ name: 'b', keepalive_running: true, context_ratio: PRESSURE_HOT_RATIO, last_activity_ago_s: 60, tool_calls: 0, recent_tools: [] }),
-      makeRow({ name: 'c', keepalive_running: false, context_ratio: 0.1, last_activity_ago_s: null, tool_calls: 0, recent_tools: [] }),
+      makeRow({ name: 'b', keepalive_running: true, context_ratio: PRESSURE_HOT_RATIO, last_activity_ago_s: 60, tool_calls: 0, recent_tools: [], tool_activity_known: false }),
+      makeRow({ name: 'c', keepalive_running: false, context_ratio: 0.1, last_activity_ago_s: null, tool_calls: 0, recent_tools: [], tool_activity_known: false }),
     ]
     const counts = summaryCounts(rows)
     expect(counts.live).toBe(2)
     expect(counts.hot).toBe(1)
     expect(counts.toolCovered).toBe(1)
+    expect(counts.toolTelemetryCovered).toBe(1)
+    expect(counts.toolActive).toBe(1)
+    expect(counts.toolQuiet).toBe(0)
+    expect(counts.toolUnknown).toBe(2)
+  })
+
+  it('counts known quiet tool telemetry as covered, not active', () => {
+    const counts = summaryCounts([
+      makeRow({ name: 'quiet', tool_calls: 0, recent_tools: [], tool_activity_known: true }),
+      makeRow({ name: 'unknown', tool_calls: 0, recent_tools: [], tool_activity_known: false }),
+    ])
+
+    expect(counts.toolCovered).toBe(1)
+    expect(counts.toolTelemetryCovered).toBe(1)
+    expect(counts.toolActive).toBe(0)
+    expect(counts.toolQuiet).toBe(1)
+    expect(counts.toolUnknown).toBe(1)
+  })
+
+  it('formats tool telemetry coverage detail for operator summaries', () => {
+    const counts = summaryCounts([
+      makeRow({ name: 'active', tool_calls: 2, recent_tools: ['masc_status'], tool_activity_known: true }),
+      makeRow({ name: 'quiet', tool_calls: 0, recent_tools: [], tool_activity_known: true }),
+      makeRow({ name: 'unknown', tool_calls: 0, recent_tools: [], tool_activity_known: false }),
+    ])
+
+    expect(toolTelemetryCoverageDetail(counts, 3)).toBe('도구 telemetry 확인 2/3 · 활동 1 · 기록 없음 1 · 미확인 1')
   })
 })
 

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -690,11 +690,7 @@ export function summaryCounts(rows: FleetRow[]): FleetSummaryCounts {
     && row.tool_calls <= 0
     && row.recent_tools.length === 0,
   ).length
-  const toolTelemetryCovered = rows.filter(row =>
-    row.tool_activity_known
-    || row.tool_calls > 0
-    || row.recent_tools.length > 0,
-  ).length
+  const toolTelemetryCovered = rows.filter(row => row.tool_activity_known).length
   const toolUnknown = Math.max(0, rows.length - toolTelemetryCovered)
   const hot = rows.filter(row => row.keepalive_running && row.context_ratio >= PRESSURE_HOT_RATIO).length
   const warn = rows.filter(row =>

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -669,9 +669,33 @@ export function toolSummary(row: FleetRow): { label: string; title: string } {
   }
 }
 
-export function summaryCounts(rows: FleetRow[]) {
+export interface FleetSummaryCounts {
+  live: number
+  toolCovered: number
+  toolTelemetryCovered: number
+  toolActive: number
+  toolQuiet: number
+  toolUnknown: number
+  hot: number
+  warn: number
+  stale: number
+  blocked: number
+}
+
+export function summaryCounts(rows: FleetRow[]): FleetSummaryCounts {
   const live = rows.filter(row => row.keepalive_running).length
-  const toolCovered = rows.filter(row => row.tool_calls > 0 || row.recent_tools.length > 0).length
+  const toolActive = rows.filter(row => row.tool_calls > 0 || row.recent_tools.length > 0).length
+  const toolQuiet = rows.filter(row =>
+    row.tool_activity_known
+    && row.tool_calls <= 0
+    && row.recent_tools.length === 0,
+  ).length
+  const toolTelemetryCovered = rows.filter(row =>
+    row.tool_activity_known
+    || row.tool_calls > 0
+    || row.recent_tools.length > 0,
+  ).length
+  const toolUnknown = Math.max(0, rows.length - toolTelemetryCovered)
   const hot = rows.filter(row => row.keepalive_running && row.context_ratio >= PRESSURE_HOT_RATIO).length
   const warn = rows.filter(row =>
     row.keepalive_running
@@ -695,5 +719,27 @@ export function summaryCounts(rows: FleetRow[]) {
     && typeof row.runtime_blocker_class === 'string'
     && row.runtime_blocker_class.trim() !== '',
   ).length
-  return { live, toolCovered, hot, warn, stale, blocked }
+  return {
+    live,
+    // Back-compat alias: coverage means "tool telemetry is known", not active usage.
+    toolCovered: toolTelemetryCovered,
+    toolTelemetryCovered,
+    toolActive,
+    toolQuiet,
+    toolUnknown,
+    hot,
+    warn,
+    stale,
+    blocked,
+  }
+}
+
+export function toolTelemetryCoverageDetail(counts: FleetSummaryCounts, totalRows: number): string {
+  const total = Math.max(0, totalRows)
+  return [
+    `도구 telemetry 확인 ${counts.toolTelemetryCovered}/${total}`,
+    `활동 ${counts.toolActive}`,
+    `기록 없음 ${counts.toolQuiet}`,
+    `미확인 ${counts.toolUnknown}`,
+  ].join(' · ')
 }


### PR DESCRIPTION
## Summary

- Distinguishes tool telemetry coverage from nonzero tool activity in Fleet Telemetry summary counts.
- Counts known quiet keepers (`tool_activity_known=true` with zero recent calls/tools) as covered rather than unknown.
- Updates the Fleet comparison summary card to show covered, active, quiet, and unknown tool telemetry states, with slightly stronger detail text contrast.

## Why

The previous summary said keepers "showed recent tool activity" and counted only nonzero tool calls or tool names. That made known quiet telemetry look the same as missing telemetry, which is misleading in an operator dashboard.

## Verification

- `pnpm exec vitest run --config vitest.config.ts src/components/fleet-telemetry-utils.test.ts src/components/fleet-telemetry-panel.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/components/fleet-telemetry-utils.ts src/components/fleet-telemetry-utils.test.ts src/components/fleet-telemetry-panel.ts src/components/fleet-telemetry-panel.test.ts`
- `git diff --check`
- Rendered Fleet Telemetry comparison view with mocked dashboard API data via Playwright fallback; verified the new summary text on desktop and mobile screenshots with no console/page errors.
