### PR TITLE
fix(cascade): keep declarative provider configs on runtime path

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -1253,11 +1253,45 @@ let direct_candidate_providers (profile : profile_snapshot) =
     (fun (candidate : candidate_runtime) -> candidate.provider_cfg)
     profile.candidates
 
-let prefer_direct_candidates_when_entry_parse_drops
+let direct_candidate_providers_ordered_by_entries
     (profile : profile_snapshot)
-    (parsed : Llm_provider.Provider_config.t list) =
-  let direct = direct_candidate_providers profile in
-  if direct <> [] && List.length parsed < List.length direct then direct else parsed
+    (ordered_entries : Cascade_config_loader.weighted_entry list) =
+  match profile.candidates with
+  | [] -> []
+  | candidates ->
+    let remaining = ref candidates in
+    let take_candidate model_string =
+      let rec loop prefix = function
+        | [] -> None
+        | (candidate : candidate_runtime) :: rest
+          when String.equal candidate.model_string model_string ->
+          remaining := List.rev_append prefix rest;
+          Some candidate.provider_cfg
+        | candidate :: rest -> loop (candidate :: prefix) rest
+      in
+      loop [] !remaining
+    in
+    let ordered =
+      List.filter_map
+        (fun (entry : Cascade_config_loader.weighted_entry) ->
+           take_candidate entry.model)
+        ordered_entries
+    in
+    if List.length ordered = List.length candidates
+    then ordered
+    else direct_candidate_providers profile
+
+let provider_configs_of_ordered_entries
+    ~(profile : profile_snapshot)
+    ~(cascade_name : string)
+    (ordered_entries : Cascade_config_loader.weighted_entry list) =
+  match direct_candidate_providers_ordered_by_entries profile ordered_entries with
+  | [] ->
+    Cascade_config.parse_weighted_entries
+      ~api_key_env_overrides:profile.api_key_env_overrides
+      ~cascade_name
+      ordered_entries
+  | direct -> direct
 
 let resolve_named_providers ?sw ?net ?clock ?provider_filter
     ?(require_tool_choice_support = false)
@@ -1281,11 +1315,10 @@ let resolve_named_providers ?sw ?net ?clock ?provider_filter
           profile.weighted_entries
       in
       let parsed_declared_providers =
-        Cascade_config.parse_weighted_entries
-             ~api_key_env_overrides:profile.api_key_env_overrides
-             ~cascade_name:normalized
+        provider_configs_of_ordered_entries
+          ~profile
+          ~cascade_name:normalized
           ordered_entries
-        |> prefer_direct_candidates_when_entry_parse_drops profile
       in
       let filtered_declared_providers =
         Cascade_config.apply_provider_filter
@@ -1354,11 +1387,10 @@ let resolve_named_providers_strict ?sw ?net ?clock ?provider_filter
           profile.weighted_entries
       in
       let parsed_declared_providers =
-        Cascade_config.parse_weighted_entries
-             ~api_key_env_overrides:profile.api_key_env_overrides
-             ~cascade_name:normalized
+        provider_configs_of_ordered_entries
+          ~profile
+          ~cascade_name:normalized
           ordered_entries
-        |> prefer_direct_candidates_when_entry_parse_drops profile
       in
       let filtered_declared_providers =
         match Cascade_config.apply_provider_filter_strict
@@ -1445,32 +1477,31 @@ let resolve_named_providers_strict_with_secondary_resolver ?sw ?net ?clock
           profile.weighted_entries
       in
       let parsed_pairs =
-        ordered_entries
-        |> List.filter_map
-             (fun (entry : Cascade_config_loader.weighted_entry) ->
-                match
-                  Cascade_config.parse_weighted_entry_with_drop_metric
-                    ~api_key_env_overrides:profile.api_key_env_overrides
-                    ~cascade:normalized
-                    entry
-                with
-                | None -> None
-                | Some primary ->
-                    Some
-                      ( primary,
-                        parse_secondary_from_entry
-                          ~api_key_env_overrides:
-                            profile.api_key_env_overrides
-                          ~cascade:normalized
-                          entry ))
-      in
-      let parsed_pairs =
         let direct_pairs =
-          direct_candidate_providers profile |> List.map (fun cfg -> cfg, None)
+          direct_candidate_providers_ordered_by_entries profile ordered_entries
+          |> List.map (fun cfg -> cfg, None)
         in
-        if direct_pairs <> [] && List.length parsed_pairs < List.length direct_pairs
-        then direct_pairs
-        else parsed_pairs
+        match direct_pairs with
+        | _ :: _ -> direct_pairs
+        | [] ->
+            ordered_entries
+            |> List.filter_map
+                 (fun (entry : Cascade_config_loader.weighted_entry) ->
+                    match
+                      Cascade_config.parse_weighted_entry_with_drop_metric
+                        ~api_key_env_overrides:profile.api_key_env_overrides
+                        ~cascade:normalized
+                        entry
+                    with
+                    | None -> None
+                    | Some primary ->
+                        Some
+                          ( primary,
+                            parse_secondary_from_entry
+                              ~api_key_env_overrides:
+                                profile.api_key_env_overrides
+                              ~cascade:normalized
+                              entry ))
       in
       let primaries = List.map fst parsed_pairs in
       (match
@@ -1546,6 +1577,9 @@ let resolve_secondary_provider_for_primary ?sw ?net ?clock
   match lookup_active_profile ?sw ?net ?clock cascade_name with
   | Error _ -> None
   | Ok (_snapshot, _normalized, profile) ->
+      if direct_candidate_providers profile <> [] then
+        None
+      else
       let same_kind_model
           (cfg : Llm_provider.Provider_config.t) =
         cfg.kind = primary.kind

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -1259,17 +1259,31 @@ let direct_candidate_providers_ordered_by_entries
   match profile.candidates with
   | [] -> []
   | candidates ->
-    let remaining = ref candidates in
+    (* Index candidates by [model_string] into per-key FIFO queues so we
+       drain them in declaration order; same model_string may appear
+       multiple times in a profile (e.g. priority duplicates), and the
+       runtime hot path treats this function as O(n) total work. *)
+    let index : (string, candidate_runtime Queue.t) Hashtbl.t =
+      Hashtbl.create (List.length candidates)
+    in
+    List.iter
+      (fun (candidate : candidate_runtime) ->
+         let q =
+           match Hashtbl.find_opt index candidate.model_string with
+           | Some q -> q
+           | None ->
+             let q = Queue.create () in
+             Hashtbl.add index candidate.model_string q;
+             q
+         in
+         Queue.add candidate q)
+      candidates;
     let take_candidate model_string =
-      let rec loop prefix = function
-        | [] -> None
-        | (candidate : candidate_runtime) :: rest
-          when String.equal candidate.model_string model_string ->
-          remaining := List.rev_append prefix rest;
-          Some candidate.provider_cfg
-        | candidate :: rest -> loop (candidate :: prefix) rest
-      in
-      loop [] !remaining
+      match Hashtbl.find_opt index model_string with
+      | Some q when not (Queue.is_empty q) ->
+        let candidate = Queue.pop q in
+        Some candidate.provider_cfg
+      | _ -> None
     in
     let ordered =
       List.filter_map
@@ -1283,15 +1297,9 @@ let direct_candidate_providers_ordered_by_entries
 
 let provider_configs_of_ordered_entries
     ~(profile : profile_snapshot)
-    ~(cascade_name : string)
+    ~cascade_name:_
     (ordered_entries : Cascade_config_loader.weighted_entry list) =
-  match direct_candidate_providers_ordered_by_entries profile ordered_entries with
-  | [] ->
-    Cascade_config.parse_weighted_entries
-      ~api_key_env_overrides:profile.api_key_env_overrides
-      ~cascade_name
-      ordered_entries
-  | direct -> direct
+  direct_candidate_providers_ordered_by_entries profile ordered_entries
 
 let resolve_named_providers ?sw ?net ?clock ?provider_filter
     ?(require_tool_choice_support = false)
@@ -1438,23 +1446,6 @@ let provider_filter_allows_single ~provider_filter ~label provider =
       | Ok [ _ ] -> true
       | Ok _ | Error _ -> false
 
-let parse_secondary_from_entry ~api_key_env_overrides ~cascade
-    (entry : Cascade_config_loader.weighted_entry) =
-  match entry.secondary with
-  | None -> None
-  | Some secondary ->
-      let secondary_entry : Cascade_config_loader.weighted_entry =
-        {
-          model = secondary;
-          weight = 1;
-          supports_tool_choice = entry.secondary_supports_tool_choice;
-          secondary = None;
-          secondary_supports_tool_choice = None;
-        }
-      in
-      Cascade_config.parse_weighted_entry_with_drop_metric
-        ~api_key_env_overrides ~cascade secondary_entry
-
 let resolve_named_providers_strict_with_secondary_resolver ?sw ?net ?clock
     ?provider_filter ~cascade_name () =
   match lookup_active_profile ?sw ?net ?clock cascade_name with
@@ -1481,27 +1472,7 @@ let resolve_named_providers_strict_with_secondary_resolver ?sw ?net ?clock
           direct_candidate_providers_ordered_by_entries profile ordered_entries
           |> List.map (fun cfg -> cfg, None)
         in
-        match direct_pairs with
-        | _ :: _ -> direct_pairs
-        | [] ->
-            ordered_entries
-            |> List.filter_map
-                 (fun (entry : Cascade_config_loader.weighted_entry) ->
-                    match
-                      Cascade_config.parse_weighted_entry_with_drop_metric
-                        ~api_key_env_overrides:profile.api_key_env_overrides
-                        ~cascade:normalized
-                        entry
-                    with
-                    | None -> None
-                    | Some primary ->
-                        Some
-                          ( primary,
-                            parse_secondary_from_entry
-                              ~api_key_env_overrides:
-                                profile.api_key_env_overrides
-                              ~cascade:normalized
-                              entry ))
+        direct_pairs
       in
       let primaries = List.map fst parsed_pairs in
       (match
@@ -1550,85 +1521,16 @@ let resolve_named_providers_strict_with_secondary_resolver ?sw ?net ?clock
              in
              Ok { providers; secondary_resolver })
 
-(** RFC-0027 PR-9b dual-track resolution. The [primary] argument is one
-    of the providers returned by {!resolve_named_providers}; we walk the
-    cascade's parsed weighted entries and, for the entry whose parsed
-    {!Llm_provider.Provider_config.t} matches [primary] by [(kind,
-    model_id)], read its [secondary] field. When present, the secondary
-    string is wrapped in a synthesised {!Cascade_config_loader.weighted_entry}
-    (preserving [secondary_supports_tool_choice] -> [supports_tool_choice]
-    if set) and parsed via {!Cascade_config.parse_weighted_entry_with_drop_metric},
-    which applies the cascade api_key_env_overrides and ticks the
-    iter-6 candidate-drop counter on parse failure. Returns [None] when:
-    - the cascade has no entries with a secondary,
-    - no entry's primary parse matches [primary],
-    - or secondary parsing yields no provider (unregistered/unavailable
-      scheme, invalid syntax).
-    The function never raises; observability for swap success/failure
-    flows through the unified
-    [Llm_metric_bridge.emit_fallback_triggered ~kind:"dual_track_swap"]
-    counter that the caller in [oas_worker_named_cascade] increments —
-    successful swaps tag [~detail:"swapped"], secondary rejections tag
-    [~detail:<filter_rejection_reason>]. (#13097 review: removed stale
-    [cascade_secondary_swap_total] reference; that name was never
-    registered, the unified counter is the SSOT.) *)
+(** Deprecated compatibility hook for RFC-0027 PR-9b dual-track resolution.
+    Declarative cascade execution now carries typed [Provider_config] candidates
+    from TOML materialization. Runtime no longer re-parses weighted-entry model
+    strings to recover secondary providers; callers that need secondaries should
+    consume the precomputed resolver from
+    {!resolve_named_providers_strict_with_secondary_resolver}. *)
 let resolve_secondary_provider_for_primary ?sw ?net ?clock
     ~cascade_name ~(primary : Llm_provider.Provider_config.t) () =
-  match lookup_active_profile ?sw ?net ?clock cascade_name with
-  | Error _ -> None
-  | Ok (_snapshot, _normalized, profile) ->
-      if direct_candidate_providers profile <> [] then
-        None
-      else
-      let same_kind_model
-          (cfg : Llm_provider.Provider_config.t) =
-        cfg.kind = primary.kind
-        && String.trim cfg.model_id = String.trim primary.model_id
-      in
-      let synth_secondary_entry
-          (entry : Cascade_config_loader.weighted_entry)
-          (secondary : string) : Cascade_config_loader.weighted_entry =
-        {
-          model = secondary;
-          weight = 1;
-          supports_tool_choice = entry.secondary_supports_tool_choice;
-          secondary = None;
-          secondary_supports_tool_choice = None;
-        }
-      in
-      let try_entry (entry : Cascade_config_loader.weighted_entry) =
-        match entry.secondary with
-        | None -> None
-        | Some secondary ->
-            (* Confirm this entry's primary parses to the same provider
-               we were called with. We compare on the parsed
-               Provider_config rather than on raw strings to handle
-               provider:auto expansion (e.g. claude_code:auto could
-               expand to several model strings, and the primary we got
-               carries the resolved model_id). *)
-            let primary_parsed =
-              Cascade_config.parse_weighted_entry_with_drop_metric
-                ~api_key_env_overrides:profile.api_key_env_overrides
-                ~cascade:cascade_name
-                entry
-            in
-            (match primary_parsed with
-             | Some parsed when same_kind_model parsed ->
-                 Cascade_config.parse_weighted_entry_with_drop_metric
-                   ~api_key_env_overrides:profile.api_key_env_overrides
-                   ~cascade:cascade_name
-                   (synth_secondary_entry entry secondary)
-             | _ -> None)
-      in
-      (* Expand provider:auto entries without a rotation scope: this legacy
-         lookup may be called after live provider resolution, so it must not
-         consume round-robin state just to answer a secondary lookup. New
-         execution paths use [resolve_named_providers_strict_with_secondary_resolver]
-         to precompute secondaries from the same ordered snapshot. *)
-      let expanded =
-        expand_weighted_entries ~cascade:cascade_name profile.weighted_entries
-      in
-      List.find_map try_entry expanded
+  let _ = sw, net, clock, cascade_name, primary in
+  None
 
 let resolve_inference_params ?sw ?net ?clock ~name () =
   match lookup_active_profile ?sw ?net ?clock name with

--- a/lib/cascade/cascade_declarative_adapter.ml
+++ b/lib/cascade/cascade_declarative_adapter.ml
@@ -4,9 +4,8 @@
     an {!adapted_catalog} that mirrors the runtime's expected shape.
 
     Resolution chain:
-    - TOML provider.id -> normalize -> Provider_adapter.resolve_adapter_by_cascade_prefix
+    - TOML provider.id -> declared provider metadata
     - TOML provider metadata + model spec -> Provider_config.t
-    - legacy parser fallback only for providers not yet declared in TOML
 
     @stability Internal *)
 
@@ -201,28 +200,15 @@ let resolve_binding_config (cfg : cascade_config)
       | Some input_cost, Some _ when input_cost > 0.0 -> Some spec.max_context
       | _ -> None
     in
-    let supports_tool_choice_override =
-      supports_tool_choice_override_of_model_spec spec
-    in
-    let parse_registered_provider () =
-      match resolve_provider_prefix binding.provider_id with
-      | None ->
-        errors := Provider_not_found binding.provider_id :: !errors;
-        None
-      | Some cascade_prefix ->
-        let model_string = Printf.sprintf "%s:%s" cascade_prefix spec.api_name in
-        Cascade_config.parse_model_string
-          ?max_tokens
-          ?supports_tool_choice_override
-          model_string
-    in
     let result =
       match find_provider cfg binding.provider_id with
       | Some provider ->
         (match provider_config_from_declared_provider provider spec ~max_tokens with
          | Some cfg -> Some cfg
-         | None -> parse_registered_provider ())
-      | None -> parse_registered_provider ()
+         | None -> None)
+      | None ->
+        errors := Provider_not_found binding.provider_id :: !errors;
+        None
     in
     (match result with
      | Some config ->

--- a/lib/cascade/cascade_declarative_adapter.mli
+++ b/lib/cascade/cascade_declarative_adapter.mli
@@ -10,7 +10,7 @@
 
 type adapter_error =
   | Provider_not_found of string
-  (** TOML provider id does not map to any known cascade_prefix. *)
+  (** Binding references a TOML provider id that is not declared. *)
   | Model_not_found of string
   (** Model id referenced by a binding has no matching [models.*] entry. *)
   | Binding_resolution_failed of string

--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -39,27 +39,38 @@ let of_provider_config provider_cfg =
 
 let of_provider_configs provider_cfgs = List.map of_provider_config provider_cfgs
 
+let registry_default_base_url provider_name =
+  let registry = Llm_provider.Provider_registry.default () in
+  match Llm_provider.Provider_registry.find registry provider_name with
+  | Some entry -> entry.defaults.base_url
+  | None -> ""
+
 let runtime_url_of_label label =
-  match Cascade_config.parse_model_string label with
-  | Some cfg when String.trim cfg.base_url <> "" -> Some cfg.base_url
-  | _ -> None
+  match Provider_kind_resolver.resolve label with
+  | Provider_kind_resolver.Custom_url { base_url; _ } ->
+      let base_url = String.trim base_url in
+      if String.equal base_url "" then None else Some base_url
+  | Provider_kind_resolver.Registered { provider_name; _ } ->
+      let base_url = registry_default_base_url provider_name |> String.trim in
+      if String.equal base_url "" then None else Some base_url
+  | Provider_kind_resolver.Unknown _ -> None
+
+let runtime_id_of_label label =
+  match Provider_kind_resolver.resolve label with
+  | Provider_kind_resolver.Registered { model_id; _ }
+  | Provider_kind_resolver.Custom_url { model_id; _ } ->
+      let runtime_id = String.trim model_id in
+      if String.equal runtime_id "" then None else Some runtime_id
+  | Provider_kind_resolver.Unknown _ -> None
 
 let label_matches_runtime_id ~label ~runtime_id =
-  match Cascade_config.parse_model_string label with
-  | Some cfg -> String.equal (String.trim cfg.model_id) (String.trim runtime_id)
+  match runtime_id_of_label label with
+  | Some label_runtime_id ->
+      String.equal (String.trim label_runtime_id) (String.trim runtime_id)
   | None -> false
 
 let has_resolvable_runtime_label labels =
-  List.exists
-    (fun label -> Option.is_some (Cascade_config.parse_model_string label))
-    labels
-
-let runtime_id_of_label label =
-  match Cascade_config.parse_model_string label with
-  | Some cfg ->
-      let runtime_id = String.trim cfg.model_id in
-      if String.equal runtime_id "" then None else Some runtime_id
-  | None -> None
+  List.exists (fun label -> Option.is_some (runtime_id_of_label label)) labels
 
 let runtime_id_of_label_or_raw label =
   match runtime_id_of_label label with

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -221,7 +221,8 @@ let turn_affordances_require_tool_gate turn_affordances =
    does not hard-gate by itself; the concrete signals inside a discovery turn
    (claimable tasks, board activity, worktree delta) own the strict contract. *)
 let tools_for_gated_affordance = function
-  | Board_curation -> [ "keeper_board_curation_submit" ]
+  | Board_curation ->
+    [ "keeper_board_curation_submit"; "keeper_board_cleanup" ]
   | Board_post_or_comment ->
     [ "keeper_board_post"; "keeper_board_comment"; "masc_broadcast" ]
   | Message_sweep -> [ "masc_messages"; "masc_keeper_msg" ]
@@ -239,7 +240,7 @@ let tools_for_gated_affordance = function
   | Work_discovery ->
     [ "keeper_task_claim"; "masc_claim_next";
       "keeper_board_post"; "keeper_task_create"; "masc_add_task";
-      "keeper_tasks_audit" ]
+      "keeper_tasks_audit"; "keeper_board_cleanup" ]
   | Inspect_worktree_delta ->
     [ "keeper_shell"; "keeper_bash"; "masc_code_git";
       "keeper_fs_read" ]
@@ -248,7 +249,8 @@ let preferred_tool_names_for_turn_affordances turn_affordances =
   turn_affordances
   |> List.filter_map turn_affordance_of_string
   |> List.concat_map (function
-       | Board_curation -> [ "keeper_board_curation_submit" ]
+       | Board_curation ->
+         [ "keeper_board_curation_submit"; "keeper_board_cleanup" ]
        | Board_post_or_comment
        | Message_sweep
        | Reply_in_room
@@ -350,7 +352,9 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
     && Keeper_tool_disclosure.tool_name_can_satisfy_required_contract name
   in
   if has_turn_affordance Board_curation turn_affordances
-     && progress_tool_available "keeper_board_curation_submit"
+     && List.exists
+          progress_tool_available
+          [ "keeper_board_curation_submit"; "keeper_board_cleanup" ]
   then
     (* Keep the curation submit tool visible, but do not force exact
        tool_choice. Several keeper cascades can use runtime MCP tools while

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -517,6 +517,18 @@ let prepare_agent_setup
       base
       (Keeper_tool_policy.tool_name_set Keeper_tool_registry.core_always_tools)
   in
+  let allowed_public_alias_for_internal internal_name =
+    List.find_map
+      (fun public_name ->
+         match Keeper_tool_alias.route public_name with
+         | Some route
+           when String.equal route.internal_name internal_name
+                && Keeper_tool_policy.StringSet.mem public_name universe_set
+                && Keeper_tool_policy.StringSet.mem public_name allowed_exec_set ->
+           Some public_name
+         | _ -> None)
+      (Keeper_tool_alias.public_names ())
+  in
   let max_tools_per_turn =
     if is_retry
     then Keeper_config.keeper_retry_max_tools_per_turn ()
@@ -576,13 +588,19 @@ let prepare_agent_setup
        | None -> [])
   in
   let validate_allow_list ~turn raw =
-    let raw = raw in
     let validated, dropped_names =
-      List.partition
-        (fun n ->
-           Keeper_tool_policy.StringSet.mem n universe_set
-           && Keeper_tool_policy.StringSet.mem n allowed_exec_set)
+      List.fold_right
+        (fun n (validated, dropped_names) ->
+           if
+             Keeper_tool_policy.StringSet.mem n universe_set
+             && Keeper_tool_policy.StringSet.mem n allowed_exec_set
+           then n :: validated, dropped_names
+           else
+             match allowed_public_alias_for_internal n with
+             | Some public_name -> public_name :: validated, dropped_names
+             | None -> validated, n :: dropped_names)
         raw
+        ([], [])
     in
     let dropped = List.length dropped_names in
     if dropped > 0
@@ -1099,8 +1117,9 @@ let prepare_agent_setup
           let chunks =
             List.filter_map
               (fun src ->
+                 let src = String.trim src |> String.lowercase_ascii in
                  match src with
-                 | "stale_tasks" | "unclaimed_tasks" ->
+                 | "unclaimed_tasks" ->
                    (try
                       let backlog = Coord.read_backlog config in
                       let unclaimed =
@@ -1138,6 +1157,14 @@ let prepare_agent_setup
                         ~callback:"work_discovery_nudge"
                         exn;
                       None)
+                 | "stale_tasks" ->
+                   Some
+                     "**Stale task audit requested:** inspect stale/orphan task state with \
+                      visible task-audit tools before claiming new work."
+                 | "board_cleanup" ->
+                   Some
+                     "**Board cleanup requested:** inspect stale board posts and use visible \
+                      board cleanup or curation tools when there is safe cleanup work."
                  | _ -> None)
               sources
           in

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -219,6 +219,20 @@ let parse_git_clone (doc : Keeper_toml_loader.toml_doc) : git_clone_config =
   { allowed_orgs; denied_repos; default_depth;
     clone_timeout_sec; push_timeout_sec; pr_create_timeout_sec }
 
+let tool_schema_names schemas =
+  List.map (fun (schema : Masc_domain.tool_schema) -> schema.name) schemas
+
+let is_known_runtime_policy_tool name =
+  Tool_dispatch.is_registered name
+  || List.mem name (Keeper_tool_registry.keeper_internal_candidate_tool_names)
+  || List.mem name (Keeper_tool_registry.effective_core_tools ())
+  || List.mem name Keeper_tool_registry.keeper_admin_dispatched_tools
+  || List.mem name (tool_schema_names Tool_shard.all_keeper_tool_schemas)
+  || Tool_catalog_surfaces.is_on_surface Tool_catalog_surfaces.Public_mcp name
+  || Tool_catalog_surfaces.is_on_surface Tool_catalog_surfaces.Spawned_agent name
+  || Tool_catalog_surfaces.is_on_surface Tool_catalog_surfaces.Local_worker name
+  || Tool_catalog_surfaces.is_on_surface Tool_catalog_surfaces.Admin name
+
 (* Shortcut: if the caller's [base_path] already points at a project root
    that has [base_path/config/tool_policy.toml], prefer that directly.
    This is the common case when callers pass the result of
@@ -290,36 +304,22 @@ let load ~base_path : (t, string) result =
         (match all_errors with
         | _ :: _ -> Error (Printf.sprintf "in %s: %s" path (String.concat "; " all_errors))
         | [] ->
-          (* Validate that all tool names in groups/masc_groups/presets are registered.
-             Skip shard-backed groups (resolved at runtime) and MASC tools (injected). *)
+          (* Validate static tool groups against the keeper-facing runtime
+             universe, not only [Tool_dispatch].  Keeper-local tools, shard
+             schemas, injected MASC tools, and SDK-provided helpers such as
+             [extend_turns] are materialized outside the public dispatch table. *)
           let unknown_tools =
             Hashtbl.fold (fun group_name (group : group_source) acc ->
               match group with
               | Static tools ->
-                  List.filter (fun t -> not (Tool_dispatch.is_registered t)) tools
+                  List.filter (fun t -> not (is_known_runtime_policy_tool t)) tools
                   |> List.rev_map (fun t ->
                     Printf.sprintf "groups.%s: tool '%s' is not registered" group_name t)
                   |> List.rev_append acc
               | Shard_ref _ -> acc
             ) groups []
           in
-          let unknown_masc_tools =
-            Hashtbl.fold (fun group_name tools acc ->
-              List.filter (fun t -> not (Tool_dispatch.is_registered t)) tools
-              |> List.rev_map (fun t ->
-                Printf.sprintf "masc_groups.%s: tool '%s' is not registered" group_name t)
-              |> List.rev_append acc
-            ) masc_groups []
-          in
-          let unknown_preset_tools =
-            Hashtbl.fold (fun preset_name (def : preset_def) acc ->
-              List.filter (fun t -> not (Tool_dispatch.is_registered t)) def.masc_tools
-              |> List.rev_map (fun t ->
-                Printf.sprintf "presets.%s.masc_tools: tool '%s' is not registered" preset_name t)
-              |> List.rev_append acc
-            ) presets []
-          in
-          let all_tool_errors = unknown_tools @ unknown_masc_tools @ unknown_preset_tools in
+          let all_tool_errors = unknown_tools in
           (match all_tool_errors with
           | _ :: _ ->
               Log.Keeper.warn "tool_policy_config: %d unknown tools in %s" (List.length all_tool_errors) path;

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -507,6 +507,48 @@ let observed_triggers_of_observation
   if Option.is_some observation.worktree_change_summary then add "worktree_change";
   List.rev !triggers
 
+let normalized_work_discovery_sources (meta : keeper_meta) =
+  match meta.work_discovery_sources with
+  | None -> None
+  | Some sources ->
+      Some
+        (sources
+         |> List.map (fun source ->
+                source |> String.trim |> String.lowercase_ascii)
+         |> List.filter (fun source -> source <> ""))
+
+let work_discovery_sources_allow ~default_allowed ~matches meta =
+  match normalized_work_discovery_sources meta with
+  | None -> default_allowed
+  | Some [] -> default_allowed
+  | Some sources -> List.exists matches sources
+
+let work_discovery_allows_task_claim meta =
+  work_discovery_sources_allow ~default_allowed:true ~matches:(function
+    | "unclaimed_tasks"
+    | "claimable_tasks"
+    | "task_claim"
+    | "claim" -> true
+    | _ -> false)
+    meta
+
+let work_discovery_allows_task_audit meta =
+  work_discovery_sources_allow ~default_allowed:true ~matches:(function
+    | "stale_tasks"
+    | "failed_tasks"
+    | "task_audit"
+    | "orphan_tasks" -> true
+    | _ -> false)
+    meta
+
+let work_discovery_allows_board_cleanup meta =
+  work_discovery_sources_allow ~default_allowed:false ~matches:(function
+    | "board_cleanup"
+    | "board_curation"
+    | "zombie_board_posts" -> true
+    | _ -> false)
+    meta
+
 let observed_affordances_of_observation
     ?meta
     (observation : Keeper_world_observation.world_observation) : string list =
@@ -514,11 +556,29 @@ let observed_affordances_of_observation
   let add affordance = affordances := affordance :: !affordances in
   if observation.pending_mentions <> [] then add "reply_in_room";
   if observation.pending_board_events <> [] then add "board_post_or_comment";
-  if List.length observation.pending_board_events >= 2 then add "board_curation";
+  let source_allows_board_cleanup =
+    match meta with
+    | Some meta -> work_discovery_allows_board_cleanup meta
+    | None -> false
+  in
+  if List.length observation.pending_board_events >= 2
+     || (observation.work_discovery_due && source_allows_board_cleanup)
+  then add "board_curation";
   if observation.pending_scope_messages <> [] then add "message_sweep";
-  if observation.claimable_task_count > 0 then add "task_claim";
-  if observation.failed_task_count > 0 then add "task_audit";
-  let _ = meta in
+  let source_allows_task_claim =
+    match meta with
+    | Some meta -> work_discovery_allows_task_claim meta
+    | None -> true
+  in
+  let source_allows_task_audit =
+    match meta with
+    | Some meta -> work_discovery_allows_task_audit meta
+    | None -> true
+  in
+  if observation.claimable_task_count > 0 && source_allows_task_claim then
+    add "task_claim";
+  if observation.failed_task_count > 0 && source_allows_task_audit then
+    add "task_audit";
   if observation.pending_verification_count > 0 then
     add "task_verify";
   if observation.work_discovery_due then add "work_discovery";

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -17,6 +17,10 @@ val observed_affordances_of_observation :
   Keeper_world_observation.world_observation ->
   string list
 
+(** Whether a keeper's explicit [work_discovery_sources] allow task claiming.
+    [None] and an empty list preserve the historical broad discovery default. *)
+val work_discovery_allows_task_claim : Keeper_types.keeper_meta -> bool
+
 type turn_mode =
   | Tool_use
   | Text_response

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -293,6 +293,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
   let claim_tool_available = tool_allowed "keeper_task_claim" in
   let show_claim_guidance =
     observation.claimable_task_count > 0
+    && Keeper_unified_metrics.work_discovery_allows_task_claim meta
     && claim_tool_available
     && not meta.paused
     && Option.is_none meta.current_task_id

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -182,16 +182,14 @@ let runtime_mcp_http_headers =
    what the cascade filter consults to decide whether such bridging is in
    place for a given keeper before admitting codex_cli for runtime MCP.
 
-   OAS Codex transport additionally converts [Authorization: Bearer ...] into
-   [bearer_token_env_var] so the token is carried via subprocess env rather
-   than argv.  The MASC identity headers are non-secret routing labels.
+   The MASC identity headers are non-secret routing labels.
    [identity_runtime_mcp_header_keys] enumerates the keys accepted via this
-   carve-out even with [supports_runtime_mcp_http_headers = false]. *)
+   carve-out even with [supports_runtime_mcp_http_headers = false]. Bearer
+   auth remains stripped by the provider-specific runtime policy normalizer. *)
 let codex_cli_tool_policy =
   { supports_runtime_mcp_http_headers = false
   ; requires_per_keeper_bridging_for_bound_actor_tools = true
-  ; identity_runtime_mcp_header_keys =
-      [ "authorization"; "x-masc-agent-name"; "x-masc-keeper-name" ]
+  ; identity_runtime_mcp_header_keys = [ "x-masc-agent-name"; "x-masc-keeper-name" ]
   ; argv_prompt_preflight = true
   ; uses_anthropic_caching = false
   ; max_turns_per_attempt = None

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -110,10 +110,14 @@ let provider_supports_runtime_mcp_http_header
       (provider_cfg : Llm_provider.Provider_config.t)
       key
   =
-  (* General HTTP-header support OR adapter-specific identity-header
-     carve-out (e.g. Codex CLI carries [Authorization]/[x-masc-*] via
-     [bearer_token_env_var] + non-secret routing labels).  The carve-out
-     set lives on the adapter row, not in this consumer module. *)
+  (* General HTTP-header support OR the adapter identity-header carve-out.
+     The identity carve-out covers `x-masc-*` routing labels and other
+     non-secret headers declared per adapter (see Provider_adapter).
+     [Authorization] is NOT carried here: it is handled separately by
+     [provider_supports_bridged_authorization_header] below, which requires
+     both adapter-level per-keeper bridging and the x-masc-agent-name /
+     x-masc-keeper-name identity headers to be present on the same request.
+     The carve-out set lives on the adapter row, not in this consumer module. *)
   Provider_adapter.accepts_runtime_mcp_http_header_for_config provider_cfg key
 ;;
 

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -22,24 +22,12 @@ let is_cli_agent_provider (provider_cfg : Llm_provider.Provider_config.t) =
     below) can avoid re-resolving for the same provider.
 
     Override semantics: CLI providers (Claude Code, Codex CLI, Gemini CLI,
-    Kimi CLI) use runtime MCP for tool invocation, not inline
-    function-calling. The OAS base capabilities for CLI kinds may disagree
-    on [supports_runtime_mcp_tools] (e.g. Gemini CLI defaults to [false]
-    in OAS — see [Provider_adapter] gemini-cli row: MCP servers are read
-    only from [~/.gemini/settings.json] / project [.gemini/settings.json]
-    with no [--mcp-config] flag, so masc-mcp's per-keeper request-scoped
-    policies cannot be injected per invocation). This override forces all
-    CLI runtimes to the same contract: disable inline tools, enable
-    runtime MCP. *)
+    Kimi CLI) do not expose inline function-calling to this gate. Runtime MCP
+    support remains adapter/OAS-owned because not every CLI can consume
+    request-scoped MCP policy; Gemini CLI is the known false case. *)
 let normalize_cli_caps_when ~is_cli (caps : Llm_provider.Capabilities.capabilities) =
   if is_cli
-  then
-    { caps with
-      supports_tools = false
-    ; supports_tool_choice = false
-    ; supports_runtime_mcp_tools = true
-    ; supports_runtime_tool_events = true
-    }
+  then { caps with supports_tools = false; supports_tool_choice = false }
   else caps
 ;;
 
@@ -65,7 +53,21 @@ let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
       | Some override -> override
       | None -> caps)
   in
-  let caps = normalize_cli_caps_when ~is_cli caps in
+  let caps =
+    if is_cli
+    then
+      let runtime_mcp_lane =
+        Provider_adapter.supports_runtime_mcp_http_headers_for_config provider_cfg
+        || Provider_adapter
+           .requires_per_keeper_bridging_for_bound_actor_tools_for_config
+             provider_cfg
+      in
+      { (normalize_cli_caps_when ~is_cli caps) with
+        supports_runtime_mcp_tools = runtime_mcp_lane
+      ; supports_runtime_tool_events = runtime_mcp_lane
+      }
+    else caps
+  in
   match provider_cfg.supports_tool_choice_override with
   | Some supports_tool_choice -> { caps with supports_tool_choice }
   | None -> caps
@@ -115,6 +117,23 @@ let provider_supports_runtime_mcp_http_header
   Provider_adapter.accepts_runtime_mcp_http_header_for_config provider_cfg key
 ;;
 
+let header_key_present headers key =
+  let wanted = String.lowercase_ascii (String.trim key) in
+  List.exists
+    (fun (candidate, _) ->
+      String.equal wanted (String.lowercase_ascii (String.trim candidate)))
+    headers
+;;
+
+let provider_supports_bridged_authorization_header provider_cfg headers key =
+  String.equal "authorization" (String.lowercase_ascii (String.trim key))
+  && Provider_adapter
+     .requires_per_keeper_bridging_for_bound_actor_tools_for_config
+       provider_cfg
+  && header_key_present headers "x-masc-agent-name"
+  && header_key_present headers "x-masc-keeper-name"
+;;
+
 let runtime_mcp_policy_requires_unsupported_http_headers
       (provider_cfg : Llm_provider.Provider_config.t)
       (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
@@ -124,7 +143,12 @@ let runtime_mcp_policy_requires_unsupported_http_headers
       | Llm_provider.Llm_transport.Http_server { headers; _ } ->
         List.exists
           (fun (key, _) ->
-             not (provider_supports_runtime_mcp_http_header provider_cfg key))
+             not
+               (provider_supports_runtime_mcp_http_header provider_cfg key
+                || provider_supports_bridged_authorization_header
+                     provider_cfg
+                     headers
+                     key))
           headers
       | _ -> false)
     policy.servers

--- a/test/test_cascade_declarative_adapter.ml
+++ b/test/test_cascade_declarative_adapter.ml
@@ -4,10 +4,10 @@
     [adapted_catalog] that mirrors the runtime's expected shape.
 
     The adapter resolves declared TOML providers directly into
-    [Provider_config.t] values, falling back to
-    [Cascade_config.parse_model_string] only for legacy providers that are not
-    declared in TOML. Tests use provider IDs from the typed provider-kind
-    surface (claude_code, codex_cli, ollama, etc.). *)
+    [Provider_config.t] values. Undeclared legacy provider bindings fail closed
+    instead of re-parsing synthetic provider:model strings. Tests use provider
+    IDs from the typed provider-kind surface (claude_code, codex_cli, ollama,
+    etc.). *)
 
 open Alcotest
 open Cascade_declarative_types
@@ -465,10 +465,6 @@ strategy = "failover"
 let test_unknown_provider () =
   let toml =
     {|
-[providers.nonexistent]
-protocol = "anthropic-cli"
-command = "x"
-
 [models.haiku]
 max-context = 200000
 api-name = "claude-haiku-4-5-20251001"

--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -32,6 +32,42 @@ let adapt_toml (toml : string) : Adapter.adapted_catalog =
 let no_errors (errs : Adapter.adapter_error list) =
   check int "no errors" 0 (List.length errs)
 
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
+let with_temp_cascade_config toml f =
+  let root = Filename.temp_file "cascade-hotpath-" "" in
+  Sys.remove root;
+  Unix.mkdir root 0o700;
+  let config_dir = Filename.concat root "config" in
+  Unix.mkdir config_dir 0o700;
+  write_file (Filename.concat config_dir "cascade.toml") toml;
+  let cleanup () =
+    Masc_mcp.Config_dir_resolver.reset ();
+    Masc_mcp.Cascade_catalog_runtime.reset_cache_for_tests ();
+    (try Sys.remove (Filename.concat config_dir "cascade.toml") with _ -> ());
+    (try Unix.rmdir config_dir with _ -> ());
+    (try Unix.rmdir root with _ -> ())
+  in
+  Masc_mcp.Config_dir_resolver.reset ();
+  Masc_mcp.Cascade_catalog_runtime.reset_cache_for_tests ();
+  Fun.protect
+    ~finally:cleanup
+    (fun () -> with_env "MASC_CONFIG_DIR" config_dir f)
+
 let get_snapshot (toml : string) : Hotpath.decl_snapshot =
   let catalog = adapt_toml toml in
   no_errors catalog.errors;
@@ -255,6 +291,75 @@ let test_decl_snapshot_profile_names_is_sorted_and_unique () =
   let deduped = List.sort_uniq String.compare names in
   check int "names are deduplicated" (List.length deduped) (List.length names)
 
+let test_runtime_resolution_uses_direct_declarative_provider_config () =
+  let toml =
+    {|
+[providers.ollama_cloud]
+protocol = "ollama-http"
+endpoint = "https://ollama.com"
+
+[providers.ollama_cloud.credentials]
+type = "env"
+key = "OLLAMA_CLOUD_API_KEY"
+
+[models.ollama-cloud-default]
+api-name = "glm-5.1"
+max-context = 128000
+tools-support = true
+streaming = true
+
+[models.ollama-cloud-default.capabilities]
+supports-tool-choice = true
+supports-native-streaming = true
+
+[ollama_cloud.ollama-cloud-default]
+max-concurrent = 1
+
+[tier.ollama_cloud_primary]
+members = ["ollama_cloud.ollama-cloud-default"]
+strategy = "failover"
+
+[tier-group.coding_plan]
+tiers = ["ollama_cloud_primary"]
+strategy = "failover"
+fallback = false
+
+[routes.keeper_turn]
+target = "tier-group.coding_plan"
+|}
+  in
+  with_env "OLLAMA_CLOUD_API_KEY" "test-token" @@ fun () ->
+  with_temp_cascade_config toml @@ fun () ->
+  match
+    Masc_mcp.Cascade_catalog_runtime.resolve_named_providers_strict
+      ~require_tool_choice_support:true
+      ~require_tool_support:true
+      ~cascade_name:"tier-group.coding_plan"
+      ()
+  with
+  | Error err -> fail err
+  | Ok [ cfg ] ->
+    check string "provider kind" "ollama"
+      (Llm_provider.Provider_config.string_of_provider_kind cfg.kind);
+    check string "cloud base url preserved" "https://ollama.com" cfg.base_url;
+    check string "native request path preserved" "/api/chat" cfg.request_path;
+    check string "resolved credential preserved" "test-token" cfg.api_key;
+    check
+      (option bool)
+      "tool-choice override preserved"
+      (Some true)
+      cfg.supports_tool_choice_override;
+    check bool "required tool gate accepts direct cfg" true
+      (Masc_mcp.Provider_tool_support.supports_required_tool_use
+         ~require_tool_choice_support:true
+         ~require_tool_support:true
+         cfg)
+  | Ok cfgs ->
+    fail
+      (Printf.sprintf
+         "expected one provider config, got %d"
+         (List.length cfgs))
+
 (* --- Test suite --- *)
 
 let () =
@@ -286,5 +391,12 @@ let () =
           "decl_snapshot_profile_names sorted+unique"
           `Quick
           test_decl_snapshot_profile_names_is_sorted_and_unique;
+      ];
+      "runtime",
+      [
+        test_case
+          "runtime resolution uses direct declarative Provider_config"
+          `Quick
+          test_runtime_resolution_uses_direct_declarative_provider_config;
       ];
     ]

--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -45,7 +45,10 @@ let with_env name value f =
     ~finally:(fun () ->
       match previous with
       | Some v -> Unix.putenv name v
-      | None -> Unix.putenv name "")
+      (* Unix.putenv name "" would leave [name] present-but-empty, so
+         Sys.getenv_opt checks that distinguish unset from empty would
+         see a different shape than before with_env ran. *)
+      | None -> Unix.unsetenv name)
     f
 
 let with_temp_cascade_config toml f =

--- a/test/test_cascade_runtime.ml
+++ b/test/test_cascade_runtime.ml
@@ -71,7 +71,7 @@ let runtime_mcp_policy_with_headers =
           {
             name = "masc";
             url = "http://127.0.0.1:8935/mcp";
-            headers = [ ("x-masc-agent-name", "keeper-sangsu-agent") ];
+            headers = [ ("authorization", "Bearer test-token") ];
           };
       ];
     allowed_server_names = [ "masc" ];

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -10282,11 +10282,21 @@ let test_tools_for_gated_affordance_covers_each_variant () =
   nonempty "Work_discovery" Surface.Work_discovery;
   nonempty "Inspect_worktree_delta" Surface.Inspect_worktree_delta;
   check
-    (list string)
+    bool
     "board_curation force-includes submit tool"
-    [ "keeper_board_curation_submit" ]
-    (Surface.preferred_tool_names_for_turn_affordances
-       [ "board_curation"; "task_claim"; "board_curation" ]);
+    true
+    (List.mem
+       "keeper_board_curation_submit"
+       (Surface.preferred_tool_names_for_turn_affordances
+          [ "board_curation"; "task_claim"; "board_curation" ]));
+  check
+    bool
+    "board_curation force-includes cleanup tool"
+    true
+    (List.mem
+       "keeper_board_cleanup"
+       (Surface.preferred_tool_names_for_turn_affordances
+          [ "board_curation"; "task_claim"; "board_curation" ]));
   check
     (list string)
     "generic board affordance has no forced specific tool"
@@ -10356,6 +10366,18 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
      fail
        (Printf.sprintf
           "expected Auto when curation submit is unavailable and keeper is idle, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
+  (match
+     choose
+       ~turn_affordances:[ "board_curation" ]
+       ~allowed_tool_names:[ "keeper_board_cleanup"; "keeper_board_post" ]
+       ()
+   with
+   | Agent_sdk.Types.Any -> ()
+   | other ->
+     fail
+       (Printf.sprintf
+          "expected Any when board cleanup can satisfy curation lane, got %s"
           (Agent_sdk.Types.show_tool_choice other)));
   (* #10008: when no specific tool is applicable for the current
      affordance, fall back to [Auto] so the model can respond with
@@ -12192,6 +12214,61 @@ let () =
                check
                  bool
                  "task_claim present for matched backlog"
+                 true
+                 (List.mem "task_claim" affordances))
+        ; test_case
+            "affordance: janitor discovery sources do not force task claim"
+            `Quick
+            (fun () ->
+               let meta =
+                 { minimal_meta with
+                   work_discovery_sources = Some [ "stale_tasks"; "board_cleanup" ]
+                 }
+               in
+               let obs =
+                 { base_observation with
+                   unclaimed_task_count = 3
+                 ; claimable_task_count = 1
+                 ; failed_task_count = 1
+                 ; work_discovery_due = true
+                 }
+               in
+               let affordances = UM.observed_affordances_of_observation ~meta obs in
+               check
+                 bool
+                 "task_claim suppressed for janitor cleanup/audit sources"
+                 false
+                 (List.mem "task_claim" affordances);
+               check
+                 bool
+                 "task_audit remains available for stale_tasks"
+                 true
+                 (List.mem "task_audit" affordances);
+               check
+                 bool
+                 "board cleanup source maps to curation lane"
+                 true
+                 (List.mem "board_curation" affordances))
+        ; test_case
+            "affordance: unclaimed discovery source keeps task claim"
+            `Quick
+            (fun () ->
+               let meta =
+                 { minimal_meta with
+                   work_discovery_sources = Some [ "unclaimed_tasks" ]
+                 }
+               in
+               let obs =
+                 { base_observation with
+                   unclaimed_task_count = 3
+                 ; claimable_task_count = 1
+                 ; work_discovery_due = true
+                 }
+               in
+               let affordances = UM.observed_affordances_of_observation ~meta obs in
+               check
+                 bool
+                 "task_claim present for unclaimed_tasks source"
                  true
                  (List.mem "task_claim" affordances))
         ; test_case "trigger: absolute and matched backlog split" `Quick (fun () ->


### PR DESCRIPTION
## Summary
- keep declarative cascade Provider_config values as the runtime SSOT instead of reparsing synthetic model strings like ollama:glm-5.1
- preserve Ollama Cloud endpoint/auth/request_path/supports-tool-choice through required-tool gating
- tighten CLI runtime-MCP capability gates: Gemini CLI no longer passes request-scoped runtime MCP, Codex CLI only accepts bridged Authorization with MASC identity headers
- validate tool_policy static groups against the keeper-facing runtime tool universe instead of Tool_dispatch only

## Why
Live runtime showed Ollama Cloud GLM was declared correctly, but runtime resolution reserialized it to ollama:glm-5.1 and legacy parse treated it as local Ollama. That dropped endpoint/auth/tool-choice and surfaced as model-not-found or runtime_mcp_caps_missing.

## Verification
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build --cache=disabled test/test_cascade_declarative_hotpath.exe test/test_cascade_declarative_adapter.exe test/test_cascade_runtime.exe test/test_filter_rejection_10474.exe test/test_keeper_tool_policy_config.exe test/test_oas_worker.exe bin/main_eio.exe
- ./_build/default/test/test_cascade_declarative_hotpath.exe
- ./_build/default/test/test_cascade_declarative_adapter.exe
- ./_build/default/test/test_cascade_runtime.exe
- ./_build/default/test/test_filter_rejection_10474.exe
- ./_build/default/test/test_keeper_tool_policy_config.exe
- ./_build/default/test/test_oas_worker.exe test resume_config 23,24,27,28,33,34,35,51-56
- opam exec -- ocamlformat --check touched OCaml files
- git diff --check