### PR TITLE
feat(ide): focus audit ledger from log routes

### DIFF
--- a/dashboard/src/components/cost-dashboard.render.test.ts
+++ b/dashboard/src/components/cost-dashboard.render.test.ts
@@ -59,7 +59,7 @@ function keeperMetrics() {
 }
 
 async function waitFor(assertion: () => boolean, label: string): Promise<void> {
-  for (let i = 0; i < 20; i += 1) {
+  for (let i = 0; i < 100; i += 1) {
     if (assertion()) return
     await new Promise(resolve => setTimeout(resolve, 0))
   }
@@ -228,5 +228,50 @@ describe('CostDashboard route-backed focus behavior', () => {
     expect(window.location.hash).toContain('mode=Observe')
     expect(window.location.hash).toContain('tab=ct-agt')
     await waitFor(() => container.textContent?.includes('sangsu') ?? false, 'keeper metrics')
+  })
+
+  it('pins matching audit ledger rows when the route carries a log id', async () => {
+    apiMocks.fetchAuditLedger.mockResolvedValueOnce({
+      count: 2,
+      entries: [
+        {
+          id: 'audit-unrelated',
+          ts: '2026-05-06T00:00:01Z',
+          actor: 'keeper-alpha',
+          kind: 'tool_call',
+          summary: 'alpha called a tool',
+          severity: 'info',
+        },
+        {
+          id: 'audit-turn-9',
+          ts: '2026-05-06T00:00:02Z',
+          actor: 'keeper-alpha',
+          kind: 'keeper_turn',
+          summary: 'keeper turn completed',
+          severity: 'info',
+          payload: { log_id: 'turn-9' },
+        },
+      ],
+    })
+    window.history.replaceState(null, '', '#monitoring?section=runtime&view=audit&log_id=turn-9')
+    const { route } = await import('../router')
+    const { CostDashboard } = await import('./cost-dashboard')
+    route.value = {
+      tab: 'monitoring',
+      params: { section: 'runtime', view: 'audit', log_id: 'turn-9' },
+      postId: null,
+    }
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+
+    render(h(CostDashboard, { view: 'audit' }), container)
+    await waitFor(
+      () => container.textContent?.includes('log focus · turn-9 · 1 matches pinned') ?? false,
+      'audit log focus banner',
+    )
+
+    const rows = Array.from(container.querySelectorAll('tbody tr'))
+    expect(rows[0]?.textContent).toContain('keeper_turn')
+    expect(rows[1]?.textContent).toContain('tool_call')
+    expect(container.querySelector('[data-testid="audit-log-focus"]')?.textContent).toContain('turn-9')
   })
 })

--- a/dashboard/src/components/cost-dashboard.test.ts
+++ b/dashboard/src/components/cost-dashboard.test.ts
@@ -231,4 +231,36 @@ describe("audit summaries", () => {
       "unrelated",
     ])
   })
+
+  it("does not let `turn-1` match `turn-10` via substring", () => {
+    // Regression for exact log-id focus: `turn-1` must not pin entries that
+    // only mention `turn-10` or similar ids.
+    const collisionEntries: AuditEntry[] = [
+      {
+        id: "audit-turn-10",
+        ts: "2026-05-14T00:00:01Z",
+        actor: "keeper-alpha",
+        kind: "keeper_turn",
+        summary: "failed at turn-10",
+        severity: "warn",
+        payload: { refs: [{ log_id: "turn-10" }] },
+      },
+      {
+        id: "audit-turn-1",
+        ts: "2026-05-14T00:00:02Z",
+        actor: "keeper-alpha",
+        kind: "keeper_turn",
+        summary: "completed turn-1 cleanly",
+        severity: "info",
+        payload: { refs: [{ log_id: "turn-1" }] },
+      },
+    ]
+
+    expect(auditEntryMatchesLogId(collisionEntries[0]!, "turn-1")).toBe(false)
+    expect(auditEntryMatchesLogId(collisionEntries[1]!, "turn-1")).toBe(true)
+    expect(prioritizeAuditEntriesByLogId(collisionEntries, "turn-1").map(entry => entry.id)).toEqual([
+      "audit-turn-1",
+      "audit-turn-10",
+    ])
+  })
 })

--- a/dashboard/src/components/cost-dashboard.test.ts
+++ b/dashboard/src/components/cost-dashboard.test.ts
@@ -2,6 +2,8 @@
 import { describe, expect, it } from "vitest"
 import type { AuditEntry } from "../api/dashboard"
 import {
+  auditEntryMatchesLogId,
+  auditLogRouteParams,
   auditRouteParams,
   formatTokens,
   isAuditFocus,
@@ -9,6 +11,7 @@ import {
   isCostView,
   summarizeAuditActors,
   summarizeAuditKinds,
+  prioritizeAuditEntriesByLogId,
   viewModeForCostFocus,
 } from "./cost-dashboard"
 
@@ -91,6 +94,7 @@ describe("audit focus helpers", () => {
     expect(auditRouteParams("ledger")).toEqual({ section: "runtime", view: "audit" })
     expect(auditRouteParams("actor")).toEqual({ section: "runtime", view: "audit", focus: "actor" })
     expect(auditRouteParams("summary")).toEqual({ section: "runtime", view: "audit", focus: "summary" })
+    expect(auditLogRouteParams("turn-9")).toEqual({ section: "runtime", view: "audit", log_id: "turn-9" })
   })
 })
 
@@ -196,6 +200,35 @@ describe("audit summaries", () => {
         info: 0,
         latest: "2026-05-06T00:02:01Z",
       },
+    ])
+  })
+
+  it("detects and pins audit entries related to a focused log id", () => {
+    const logEntries: AuditEntry[] = [
+      {
+        id: "unrelated",
+        ts: "2026-05-06T00:00:01Z",
+        actor: "keeper-alpha",
+        kind: "tool_call",
+        summary: "alpha called a tool",
+        severity: "info",
+      },
+      {
+        id: "audit-turn-9",
+        ts: "2026-05-06T00:00:02Z",
+        actor: "keeper-alpha",
+        kind: "keeper_turn",
+        summary: "keeper turn completed",
+        severity: "info",
+        payload: { refs: [{ log_id: "turn-9" }] },
+      },
+    ]
+
+    expect(auditEntryMatchesLogId(logEntries[0]!, "turn-9")).toBe(false)
+    expect(auditEntryMatchesLogId(logEntries[1]!, "turn-9")).toBe(true)
+    expect(prioritizeAuditEntriesByLogId(logEntries, "turn-9").map(entry => entry.id)).toEqual([
+      "audit-turn-9",
+      "unrelated",
     ])
   })
 })

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -49,10 +49,13 @@ import {
   viewModeForCostFocus,
   isAuditFocus,
   auditRouteParams,
+  auditLogRouteParams,
 } from './cost/cost-types'
 import { formatTokens, severityClass } from './cost/cost-formatters'
 import {
   severityBuckets,
+  auditEntryMatchesLogId,
+  prioritizeAuditEntriesByLogId,
   summarizeAuditActors,
   summarizeAuditKinds,
 } from './cost/audit-summarizer'
@@ -68,7 +71,10 @@ export {
   viewModeForCostFocus,
   isAuditFocus,
   auditRouteParams,
+  auditLogRouteParams,
   formatTokens,
+  auditEntryMatchesLogId,
+  prioritizeAuditEntriesByLogId,
   summarizeAuditActors,
   summarizeAuditKinds,
 }
@@ -123,6 +129,11 @@ const stressState = signal<StressLoadState>({ status: 'idle' })
 const coverageState = signal<CoverageLoadState>({ status: 'idle' })
 const auditLedgerState = signal<AuditLedgerLoadState>({ status: 'idle' })
 const keeperDecisionsState = signal<KeeperDecisionsLoadState>({ status: 'idle' })
+function cleanRouteParam(value: string | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
 const activeCostFocus = computed<CostFocus | null>(() => {
   const focus = route.value.params.focus
   return isCostFocus(focus) ? focus : null
@@ -131,6 +142,7 @@ const activeAuditFocus = computed<AuditFocus | null>(() => {
   const focus = route.value.params.focus
   return isAuditFocus(focus) ? focus : null
 })
+const activeAuditLogId = computed<string | null>(() => cleanRouteParam(route.value.params.log_id))
 
 const WINDOW_OPTIONS: Array<{ key: number; label: string }> = [
   { key: 30, label: '30분' },
@@ -944,7 +956,8 @@ function AuditSummaryBoard({ entries, count }: { entries: AuditEntry[]; count: n
   `
 }
 
-function AuditLedgerTable({ entries }: { entries: AuditEntry[] }) {
+function AuditLedgerTable({ entries, logId }: { entries: AuditEntry[]; logId: string | null }) {
+  const orderedEntries = prioritizeAuditEntriesByLogId(entries, logId)
   return html`
       <div class="overflow-x-auto rounded-[var(--r-1)] border border-card-border/60 bg-[var(--backdrop-deep)]">
         <table class="w-full" aria-label="Audit ledger entries">
@@ -958,34 +971,44 @@ function AuditLedgerTable({ entries }: { entries: AuditEntry[] }) {
             </tr>
           </thead>
           <tbody>
-            ${entries.map((e, i) => html`
-              <tr key=${i} class="border-b border-[var(--color-border-default)]/50 text-2xs">
+            ${orderedEntries.map((e, i) => {
+              const matched = auditEntryMatchesLogId(e, logId)
+              return html`
+              <tr key=${`${e.id}-${i}`} class=${`border-b text-2xs ${matched ? 'border-[var(--brass-3)] bg-[var(--accent-12)]' : 'border-[var(--color-border-default)]/50'}`}>
                 <td class="px-2 py-1.5 text-left font-mono text-text-muted">${e.ts}</td>
                 <td class="px-2 py-1.5 text-left font-mono text-xs text-[var(--color-accent-fg)]">${e.actor}</td>
                 <td class="px-2 py-1.5 text-left font-mono text-text-strong">${e.kind}</td>
                 <td class="px-2 py-1.5 text-left font-mono text-text-muted max-w-[24ch] truncate" title=${e.summary}>${e.summary}</td>
                 <td class="px-2 py-1.5 text-left font-mono ${severityClass(e.severity)}">${e.severity}</td>
               </tr>
-            `)}
+            `})}
           </tbody>
         </table>
       </div>
   `
 }
 
-function AuditLedgerBoard({ entries, count, focus }: { entries: AuditEntry[]; count: number; focus: AuditFocus | null }) {
+function AuditLedgerBoard({ entries, count, focus, logId }: { entries: AuditEntry[]; count: number; focus: AuditFocus | null; logId: string | null }) {
+  const focusedEntries = logId ? entries.filter(entry => auditEntryMatchesLogId(entry, logId)) : []
   return html`
     <section class="flex flex-col gap-4" aria-label="Audit ledger">
       <div class="flex flex-col items-start gap-2 rounded-[var(--r-1)] border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
-        <span class="font-mono text-2xs uppercase tracking-[var(--track-caps)] text-text-muted">audit ledger · ${count} entries</span>
+        <span class="font-mono text-2xs uppercase tracking-[var(--track-caps)] text-text-muted">audit ledger · ${count} entries${logId ? ` · log ${logId}` : ''}</span>
         <${AuditFocusRail} focus=${focus} count=${count} />
       </div>
+      ${logId ? html`
+        <div class=${`rounded-[var(--r-1)] border px-3 py-2 font-mono text-2xs uppercase tracking-[var(--track-caps)] ${focusedEntries.length > 0 ? 'border-[var(--brass-3)] bg-[var(--accent-12)] text-[var(--brass-1)]' : 'border-card-border/60 bg-[var(--backdrop-deep)] text-text-muted'}`} data-testid="audit-log-focus">
+          ${focusedEntries.length > 0
+            ? `log focus · ${logId} · ${focusedEntries.length} matches pinned`
+            : `log focus miss · ${logId} · showing latest entries`}
+        </div>
+      ` : null}
 
       ${focus === 'actor'
         ? html`<${AuditActorBoard} entries=${entries} />`
         : focus === 'summary'
           ? html`<${AuditSummaryBoard} entries=${entries} count=${count} />`
-          : html`<${AuditLedgerTable} entries=${entries} />`}
+          : html`<${AuditLedgerTable} entries=${entries} logId=${logId} />`}
     </section>
   `
 }
@@ -1305,6 +1328,7 @@ function CostDashboardContent({ view }: { view: CostView }) {
               entries=${auditLedgerState.value.data.entries}
               count=${auditLedgerState.value.data.count}
               focus=${activeAuditFocus.value}
+              logId=${activeAuditLogId.value}
             />`
           : auditLedgerState.value.status === 'error'
             ? html`<${ErrorState}

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -999,7 +999,9 @@ function AuditLedgerBoard({ entries, count, focus, logId }: { entries: AuditEntr
       ${logId ? html`
         <div class=${`rounded-[var(--r-1)] border px-3 py-2 font-mono text-2xs uppercase tracking-[var(--track-caps)] ${focusedEntries.length > 0 ? 'border-[var(--brass-3)] bg-[var(--accent-12)] text-[var(--brass-1)]' : 'border-card-border/60 bg-[var(--backdrop-deep)] text-text-muted'}`} data-testid="audit-log-focus">
           ${focusedEntries.length > 0
-            ? `log focus · ${logId} · ${focusedEntries.length} matches pinned`
+            ? (focus === null
+                ? `log focus · ${logId} · ${focusedEntries.length} matches pinned`
+                : `log focus · ${logId} · ${focusedEntries.length} matches`)
             : `log focus miss · ${logId} · showing latest entries`}
         </div>
       ` : null}

--- a/dashboard/src/components/cost/audit-summarizer.ts
+++ b/dashboard/src/components/cost/audit-summarizer.ts
@@ -86,11 +86,13 @@ export function summarizeAuditKinds(entries: readonly AuditEntry[]): AuditKindSu
 export function auditEntryMatchesLogId(entry: AuditEntry, logId: string | null): boolean {
   const needle = normalizeLogNeedle(logId)
   if (!needle) return false
-  return [
-    entry.id,
-    entry.target,
-    entry.summary,
-  ].some(value => stringContainsLogNeedle(value, needle))
+  // `entry.id` is a structured identifier so demand exact (case-insensitive)
+  // equality — otherwise log id `turn-1` would also match `turn-10`.  For
+  // human-facing free text (`target`, `summary`) and payload contents we
+  // accept token-boundary matches so a sentence like `failed at turn-1`
+  // still pins the row but `failed at turn-10` does not.
+  return stringEqualsLogNeedle(entry.id, needle)
+    || [entry.target, entry.summary].some(value => stringMatchesLogNeedleWithBoundary(value, needle))
     || payloadContainsLogNeedle(entry.payload, needle)
 }
 
@@ -111,13 +113,30 @@ function normalizeLogNeedle(value: string | null | undefined): string | null {
   return trimmed ? trimmed : null
 }
 
-function stringContainsLogNeedle(value: string | undefined, needle: string): boolean {
-  return typeof value === 'string' && value.toLowerCase().includes(needle)
+function stringEqualsLogNeedle(value: string | undefined, needle: string): boolean {
+  return typeof value === 'string' && value.trim().toLowerCase() === needle
+}
+
+// Token boundary = anything that is not `[A-Za-z0-9_-]`.  Log ids commonly
+// contain `-` so the canonical word boundary `\b` is too aggressive
+// (`\bturn-1\b` would still match `turn-10` because `-` is a word boundary
+// for `\b`).  We bracket the needle with explicit non-id-character
+// boundaries (or start/end of string) instead.
+const LOG_NEEDLE_ID_CHARS = /[A-Za-z0-9_-]/
+
+function stringMatchesLogNeedleWithBoundary(value: string | undefined, needle: string): boolean {
+  if (typeof value !== 'string') return false
+  const haystack = value.toLowerCase()
+  const idx = haystack.indexOf(needle)
+  if (idx < 0) return false
+  const before = idx === 0 ? '' : haystack[idx - 1]
+  const after = idx + needle.length >= haystack.length ? '' : haystack[idx + needle.length]
+  return !LOG_NEEDLE_ID_CHARS.test(before) && !LOG_NEEDLE_ID_CHARS.test(after)
 }
 
 function payloadContainsLogNeedle(value: unknown, needle: string, depth = 0): boolean {
   if (depth > 4 || value == null) return false
-  if (typeof value === 'string') return stringContainsLogNeedle(value, needle)
+  if (typeof value === 'string') return stringEqualsLogNeedle(value, needle)
   if (typeof value === 'number' || typeof value === 'boolean') {
     return String(value).toLowerCase() === needle
   }
@@ -126,7 +145,7 @@ function payloadContainsLogNeedle(value: unknown, needle: string, depth = 0): bo
   }
   if (typeof value === 'object') {
     return Object.entries(value).some(([key, item]) =>
-      stringContainsLogNeedle(key, needle) || payloadContainsLogNeedle(item, needle, depth + 1),
+      stringEqualsLogNeedle(key, needle) || payloadContainsLogNeedle(item, needle, depth + 1),
     )
   }
   return false

--- a/dashboard/src/components/cost/audit-summarizer.ts
+++ b/dashboard/src/components/cost/audit-summarizer.ts
@@ -86,11 +86,14 @@ export function summarizeAuditKinds(entries: readonly AuditEntry[]): AuditKindSu
 export function auditEntryMatchesLogId(entry: AuditEntry, logId: string | null): boolean {
   const needle = normalizeLogNeedle(logId)
   if (!needle) return false
-  // `entry.id` is a structured identifier so demand exact (case-insensitive)
-  // equality — otherwise log id `turn-1` would also match `turn-10`.  For
-  // human-facing free text (`target`, `summary`) and payload contents we
-  // accept token-boundary matches so a sentence like `failed at turn-1`
-  // still pins the row but `failed at turn-10` does not.
+  // Match policy:
+  //   - `entry.id`: structured identifier, case-insensitive equality.
+  //   - `entry.target`, `entry.summary`: human-readable text, token-boundary
+  //     match so `failed at turn-1` pins the row, but `failed at turn-10`
+  //     does not.
+  //   - `entry.payload`: structured JSON, with string leaves and keys treated
+  //     as identifier values.
+  // Plain `.includes(needle)` would treat `turn-1` as matching `turn-10`.
   return stringEqualsLogNeedle(entry.id, needle)
     || [entry.target, entry.summary].some(value => stringMatchesLogNeedleWithBoundary(value, needle))
     || payloadContainsLogNeedle(entry.payload, needle)
@@ -124,14 +127,24 @@ function stringEqualsLogNeedle(value: string | undefined, needle: string): boole
 // boundaries (or start/end of string) instead.
 const LOG_NEEDLE_ID_CHARS = /[A-Za-z0-9_-]/
 
+function isIdChar(char: string | undefined): boolean {
+  return typeof char === 'string' && LOG_NEEDLE_ID_CHARS.test(char)
+}
+
 function stringMatchesLogNeedleWithBoundary(value: string | undefined, needle: string): boolean {
-  if (typeof value !== 'string') return false
+  if (typeof value !== 'string' || needle.length === 0) return false
   const haystack = value.toLowerCase()
-  const idx = haystack.indexOf(needle)
-  if (idx < 0) return false
-  const before = idx === 0 ? '' : haystack[idx - 1]
-  const after = idx + needle.length >= haystack.length ? '' : haystack[idx + needle.length]
-  return !LOG_NEEDLE_ID_CHARS.test(before) && !LOG_NEEDLE_ID_CHARS.test(after)
+  // Walk every occurrence — a single match with id-char on either side does
+  // not poison sibling matches that are properly bounded.
+  let idx = haystack.indexOf(needle)
+  while (idx >= 0) {
+    const before = idx === 0 ? undefined : haystack[idx - 1]
+    const afterIdx = idx + needle.length
+    const after = afterIdx >= haystack.length ? undefined : haystack[afterIdx]
+    if (!isIdChar(before) && !isIdChar(after)) return true
+    idx = haystack.indexOf(needle, idx + 1)
+  }
+  return false
 }
 
 function payloadContainsLogNeedle(value: unknown, needle: string, depth = 0): boolean {

--- a/dashboard/src/components/cost/audit-summarizer.ts
+++ b/dashboard/src/components/cost/audit-summarizer.ts
@@ -82,3 +82,52 @@ export function summarizeAuditKinds(entries: readonly AuditEntry[]): AuditKindSu
     }))
     .sort((a, b) => b.count - a.count || a.kind.localeCompare(b.kind))
 }
+
+export function auditEntryMatchesLogId(entry: AuditEntry, logId: string | null): boolean {
+  const needle = normalizeLogNeedle(logId)
+  if (!needle) return false
+  return [
+    entry.id,
+    entry.target,
+    entry.summary,
+  ].some(value => stringContainsLogNeedle(value, needle))
+    || payloadContainsLogNeedle(entry.payload, needle)
+}
+
+export function prioritizeAuditEntriesByLogId(entries: readonly AuditEntry[], logId: string | null): AuditEntry[] {
+  const needle = normalizeLogNeedle(logId)
+  if (!needle) return [...entries]
+  const matched: AuditEntry[] = []
+  const rest: AuditEntry[] = []
+  for (const entry of entries) {
+    if (auditEntryMatchesLogId(entry, needle)) matched.push(entry)
+    else rest.push(entry)
+  }
+  return [...matched, ...rest]
+}
+
+function normalizeLogNeedle(value: string | null | undefined): string | null {
+  const trimmed = value?.trim().toLowerCase()
+  return trimmed ? trimmed : null
+}
+
+function stringContainsLogNeedle(value: string | undefined, needle: string): boolean {
+  return typeof value === 'string' && value.toLowerCase().includes(needle)
+}
+
+function payloadContainsLogNeedle(value: unknown, needle: string, depth = 0): boolean {
+  if (depth > 4 || value == null) return false
+  if (typeof value === 'string') return stringContainsLogNeedle(value, needle)
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value).toLowerCase() === needle
+  }
+  if (Array.isArray(value)) {
+    return value.some(item => payloadContainsLogNeedle(item, needle, depth + 1))
+  }
+  if (typeof value === 'object') {
+    return Object.entries(value).some(([key, item]) =>
+      stringContainsLogNeedle(key, needle) || payloadContainsLogNeedle(item, needle, depth + 1),
+    )
+  }
+  return false
+}

--- a/dashboard/src/components/cost/cost-types.ts
+++ b/dashboard/src/components/cost/cost-types.ts
@@ -32,3 +32,7 @@ export function auditRouteParams(focus: 'ledger' | AuditFocus): Record<string, s
     ? { section: 'runtime', view: 'audit' }
     : { section: 'runtime', view: 'audit', focus }
 }
+
+export function auditLogRouteParams(logId: string): Record<string, string> {
+  return { section: 'runtime', view: 'audit', log_id: logId }
+}

--- a/dashboard/src/components/ide/ide-context-lens.test.ts
+++ b/dashboard/src/components/ide/ide-context-lens.test.ts
@@ -337,7 +337,7 @@ describe('IdeContextLens', () => {
     })
     expect(model.anchors[0]?.route_links?.find(link => link.label === 'Log')).toMatchObject({
       tab: 'monitoring',
-      params: { section: 'runtime', view: 'audit' },
+      params: { section: 'runtime', view: 'audit', log_id: 'turn-9' },
     })
     expect(model.anchors[0]?.route_links?.find(link => link.label === 'Telemetry')).toMatchObject({
       tab: 'monitoring',
@@ -481,7 +481,7 @@ describe('IdeContextLens', () => {
     expect(model.anchors[0]?.line).toBeUndefined()
   })
 
-  it('does not advertise an unsupported log focus route param', () => {
+  it('routes log context into the runtime audit focus', () => {
     const model = deriveIdeContextLens({
       filePath: 'lib/keeper/keeper_exec_ide.ml',
       annotations: [],
@@ -503,6 +503,6 @@ describe('IdeContextLens', () => {
     })
 
     const logRoute = model.anchors[0]?.route_links?.find(link => link.label === 'Log')
-    expect(logRoute?.params).toEqual({ section: 'runtime', view: 'audit' })
+    expect(logRoute?.params).toEqual({ section: 'runtime', view: 'audit', log_id: 'turn-9' })
   })
 })

--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -3,6 +3,7 @@ import type { IdeAnnotation } from '../../api/schemas/ide-annotations'
 import type { UnifiedDiffRow } from '../../api/workspace'
 import { navigate } from '../../router'
 import type { TabId } from '../../types'
+import { auditLogRouteParams } from '../cost/cost-types'
 import { KeeperBadge } from '../keeper-badge'
 import type { AnchoredThread } from './anchored-thread-rail-store'
 import type { KeeperCursorOverlay } from './keeper-cursor-overlay'
@@ -769,7 +770,7 @@ export function routeLinksForContext(
       id: `log:${logId}`,
       label: 'Log',
       tab: 'monitoring',
-      params: { section: 'runtime', view: 'audit' },
+      params: auditLogRouteParams(logId),
       evidence: `Log ${logId}`,
     })
   }


### PR DESCRIPTION
## Summary
- Carry IDE context `log_id` through Log route links into the runtime audit ledger route.
- Add audit ledger log focus rendering: matching entries are pinned first and highlighted, with explicit match/miss copy.
- Add pure matching helpers and regression coverage for route params, prioritization, and rendered audit focus.

## Validation
- `pnpm install --offline --frozen-lockfile`
- `pnpm exec eslint src/components/cost-dashboard.ts src/components/cost/audit-summarizer.ts src/components/cost/cost-types.ts src/components/ide/ide-context-lens.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/cost-dashboard.test.ts src/components/cost-dashboard.render.test.ts src/components/ide/ide-context-lens.test.ts`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/cost-dashboard.test.ts src/components/cost-dashboard.render.test.ts src/components/ide/ide-context-lens.test.ts src/components/ide/ide-activity-mock.test.ts src/components/ide/ide-editor.test.ts`
- `git diff --check`

Note: the broader IDE/component Vitest run emitted existing jsdom localhost:3000 EPERM and `--localstorage-file` warnings, but all selected test files passed.