### PR TITLE
fix(keeper): validate policy tools against static routes

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -432,7 +432,10 @@ let preferred_tool_choice_for_required_tool_names
       let canonical = Keeper_tool_disclosure.canonical_tool_name name in
       if List.mem canonical allowed_tool_names then Some canonical
       else if List.mem name allowed_tool_names then Some name
-      else None)
+      else (
+        match Keeper_tool_alias.public_name_for_internal canonical with
+        | Some public when List.mem public allowed_tool_names -> Some public
+        | _ -> None))
     |> Keeper_types.dedupe_keep_order
   in
   match visible_required with

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -588,6 +588,27 @@ let prepare_agent_setup
        | None -> [])
   in
   let validate_allow_list ~turn raw =
+    let visible_policy_name name =
+      (* Preserve names that are already valid public surface entries.
+         keeper_fs_edit has two public aliases (Edit, Write) with different
+         schemas; round-tripping through public_name_for_internal always
+         picks Edit, so any Write entry would be coerced to Edit and then
+         deduped. Only canonicalize names that are not themselves valid
+         public entries (e.g., internal names like keeper_fs_edit, or
+         unrecognized inputs). *)
+      if Keeper_tool_policy.StringSet.mem name universe_set
+         && Keeper_tool_policy.StringSet.mem name allowed_exec_set
+      then name
+      else (
+        let canonical = Keeper_tool_disclosure.canonical_tool_name name in
+        match Keeper_tool_alias.public_name_for_internal canonical with
+        | Some public
+          when Keeper_tool_policy.StringSet.mem public universe_set
+               && Keeper_tool_policy.StringSet.mem public allowed_exec_set ->
+          public
+        | _ -> name)
+    in
+    let raw = raw |> List.map visible_policy_name |> Keeper_types.dedupe_keep_order in
     let validated, dropped_names =
       List.fold_right
         (fun n (validated, dropped_names) ->
@@ -613,7 +634,7 @@ let prepare_agent_setup
         if omitted > 0 then Printf.sprintf " (+%d more)" omitted else ""
       in
       Log.Keeper.warn
-        "keeper:%s turn:%d AllowList pruned %d tool(s) outside dispatch universe: %s%s"
+        "keeper:%s turn:%d AllowList pruned %d tool(s) outside visible policy surface: %s%s"
         meta.name
         turn
         dropped

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -114,6 +114,14 @@ let route name =
     to allowlists — they should now add these names directly. *)
 let public_names () = [ "Bash"; "Edit"; "Grep"; "Read"; "WebFetch"; "WebSearch"; "Write" ]
 
+let public_name_for_internal internal_name =
+  public_names ()
+  |> List.find_opt (fun public ->
+    match route public with
+    | Some r -> String.equal r.internal_name internal_name
+    | None -> false)
+;;
+
 (* ── MCP surface routing (separate concern) ──────────────────────── *)
 
 let public_masc_to_internal_tbl =

--- a/lib/keeper/keeper_tool_alias.mli
+++ b/lib/keeper/keeper_tool_alias.mli
@@ -38,6 +38,12 @@ val is_known_internal : string -> bool
     to allowlists at construction time. *)
 val public_names : unit -> string list
 
+(** [public_name_for_internal internal_name] returns the preferred
+    LLM-native public name for an internal routed tool, when one exists.
+    The result follows [public_names] order, so ambiguous internals such
+    as [keeper_fs_edit] pick a stable primary public surface. *)
+val public_name_for_internal : string -> string option
+
 (** {1 Result-based telemetry} *)
 
 (** [record_route_outcome ~tool ~routed_to ~result] increments the

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -322,7 +322,7 @@ let load ~base_path : (t, string) result =
             Hashtbl.fold (fun group_name tools acc ->
               List.filter (fun t -> not (is_known_policy_tool_name t)) tools
               |> List.rev_map (fun t ->
-                Printf.sprintf "masc_groups.%s: tool '%s' is not a known policy tool" group_name t)
+                Printf.sprintf "masc.%s: tool '%s' is not a known policy tool" group_name t)
               |> List.rev_append acc
             ) masc_groups []
           in

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -222,7 +222,7 @@ let parse_git_clone (doc : Keeper_toml_loader.toml_doc) : git_clone_config =
 let tool_schema_names schemas =
   List.map (fun (schema : Masc_domain.tool_schema) -> schema.name) schemas
 
-let is_known_runtime_policy_tool name =
+let is_known_policy_tool_name name =
   Tool_dispatch.is_registered name
   || List.mem name (Keeper_tool_registry.keeper_internal_candidate_tool_names)
   || List.mem name (Keeper_tool_registry.effective_core_tools ())
@@ -304,22 +304,37 @@ let load ~base_path : (t, string) result =
         (match all_errors with
         | _ :: _ -> Error (Printf.sprintf "in %s: %s" path (String.concat "; " all_errors))
         | [] ->
-          (* Validate static tool groups against the keeper-facing runtime
-             universe, not only [Tool_dispatch].  Keeper-local tools, shard
-             schemas, injected MASC tools, and SDK-provided helpers such as
-             [extend_turns] are materialized outside the public dispatch table. *)
+          (* Validate tool names against the keeper-facing policy surface.
+             Skip shard-backed groups because their members resolve from
+             [Tool_shard] at runtime. *)
           let unknown_tools =
             Hashtbl.fold (fun group_name (group : group_source) acc ->
               match group with
               | Static tools ->
-                  List.filter (fun t -> not (is_known_runtime_policy_tool t)) tools
+                  List.filter (fun t -> not (is_known_policy_tool_name t)) tools
                   |> List.rev_map (fun t ->
-                    Printf.sprintf "groups.%s: tool '%s' is not registered" group_name t)
+                    Printf.sprintf "groups.%s: tool '%s' is not a known policy tool" group_name t)
                   |> List.rev_append acc
               | Shard_ref _ -> acc
             ) groups []
           in
-          let all_tool_errors = unknown_tools in
+          let unknown_masc_tools =
+            Hashtbl.fold (fun group_name tools acc ->
+              List.filter (fun t -> not (is_known_policy_tool_name t)) tools
+              |> List.rev_map (fun t ->
+                Printf.sprintf "masc_groups.%s: tool '%s' is not a known policy tool" group_name t)
+              |> List.rev_append acc
+            ) masc_groups []
+          in
+          let unknown_preset_tools =
+            Hashtbl.fold (fun preset_name (def : preset_def) acc ->
+              List.filter (fun t -> not (is_known_policy_tool_name t)) def.masc_tools
+              |> List.rev_map (fun t ->
+                Printf.sprintf "presets.%s.masc_tools: tool '%s' is not a known policy tool" preset_name t)
+              |> List.rev_append acc
+            ) presets []
+          in
+          let all_tool_errors = unknown_tools @ unknown_masc_tools @ unknown_preset_tools in
           (match all_tool_errors with
           | _ :: _ ->
               Log.Keeper.warn "tool_policy_config: %d unknown tools in %s" (List.length all_tool_errors) path;

--- a/lib/keeper/keeper_tool_policy_config.mli
+++ b/lib/keeper/keeper_tool_policy_config.mli
@@ -19,6 +19,12 @@ type preset_resolution =
     Returns [Error msg] if the file is missing or malformed. *)
 val load : base_path:string -> (t, string) result
 
+(** True when [name] is valid in [tool_policy.toml]. This checks the full
+    keeper-facing policy surface, including static tag-dispatch tools and OAS
+    core tools that are not direct handler-registry entries. Exposed for
+    policy-validation tests. *)
+val is_known_policy_tool_name : string -> bool
+
 (** Resolve a preset name to its tool name list.
     Shard-backed groups are resolved via [Tool_shard] at call time.
     MASC tools are filtered through [masc_filter] if provided.

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -40,6 +40,25 @@ let test_known_aliases_resolve () =
     (route_internal "WebSearch")
 ;;
 
+let test_internal_names_resolve_to_preferred_public_alias () =
+  Alcotest.(check (option string))
+    "keeper_bash -> Bash"
+    (Some "Bash")
+    (Alias.public_name_for_internal "keeper_bash");
+  Alcotest.(check (option string))
+    "keeper_shell -> Grep"
+    (Some "Grep")
+    (Alias.public_name_for_internal "keeper_shell");
+  Alcotest.(check (option string))
+    "keeper_fs_edit primary public alias is Edit"
+    (Some "Edit")
+    (Alias.public_name_for_internal "keeper_fs_edit");
+  Alcotest.(check (option string))
+    "unaliased internal has no public alias"
+    None
+    (Alias.public_name_for_internal "keeper_board_post")
+;;
+
 let test_unknown_returns_none () =
   Alcotest.(check (option string)) "Skill has no cognate" None (route_internal "Skill");
   Alcotest.(check (option string))
@@ -656,6 +675,10 @@ let () =
     "Keeper_tool_alias"
     [ ( "routing-table"
       , [ Alcotest.test_case "known aliases resolve" `Quick test_known_aliases_resolve
+        ; Alcotest.test_case
+            "internal names resolve to preferred public alias"
+            `Quick
+            test_internal_names_resolve_to_preferred_public_alias
         ; Alcotest.test_case "unknown returns None" `Quick test_unknown_returns_none
         ; Alcotest.test_case "route round-trip" `Quick test_route_round_trip
         ; Alcotest.test_case

--- a/test/test_keeper_tool_policy_config.ml
+++ b/test/test_keeper_tool_policy_config.ml
@@ -139,6 +139,18 @@ masc_tools = ["keeper_fs_write", "keeper_fs_delete", "masc_status"]
       | Some KTPC.All_candidates -> fail "legacy preset should be explicit subset"
       | None -> fail "legacy preset missing")
 
+let test_policy_validation_knows_static_and_oas_core_tools () =
+  check bool "keeper static tag tool is known" true
+    (KTPC.is_known_policy_tool_name "keeper_board_post");
+  check bool "masc static tag tool is known" true
+    (KTPC.is_known_policy_tool_name "masc_status");
+  check bool "OAS core tool is known" true
+    (KTPC.is_known_policy_tool_name "extend_turns");
+  check bool "retired typed tool is not known" false
+    (KTPC.is_known_policy_tool_name "masc_complete_task");
+  check bool "unknown tool is not known" false
+    (KTPC.is_known_policy_tool_name "__missing_tool")
+
 (* ── preset_can_satisfy tests ───────────────────────────────── *)
 
 let load_config () =
@@ -222,6 +234,8 @@ let () =
             test_load_anchors_resolution_to_base_path_over_cwd_candidate;
           test_case "normalizes legacy fs tool names" `Quick
             test_load_normalizes_legacy_fs_tool_names;
+          test_case "policy validation accepts static and OAS core tools" `Quick
+            test_policy_validation_knows_static_and_oas_core_tools;
         ] );
       ( "preset_can_satisfy",
         [

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -10549,6 +10549,30 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
           (Agent_sdk.Types.show_tool_choice other)));
   (match
      Surface.preferred_tool_choice_for_required_tool_names
+       ~required_tool_names:[ "keeper_shell"; "keeper_bash"; "keeper_board_post" ]
+       ~allowed_tool_names:[ "Grep"; "Bash"; "keeper_board_post" ]
+   with
+   | Agent_sdk.Types.Any -> ()
+   | other ->
+     fail
+       (Printf.sprintf
+          "expected Any when internal required tools are exposed via public aliases, got \
+           %s"
+          (Agent_sdk.Types.show_tool_choice other)));
+  (match
+     Surface.preferred_tool_choice_for_required_tool_names
+       ~required_tool_names:[ "keeper_shell" ]
+       ~allowed_tool_names:[ "Grep" ]
+   with
+   | Agent_sdk.Types.Any -> ()
+   | other ->
+     fail
+       (Printf.sprintf
+          "expected Any for internal keeper_shell required tool exposed as public alias, \
+           got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
+  (match
+     Surface.preferred_tool_choice_for_required_tool_names
        ~required_tool_names:[ "keeper_tasks_audit" ]
        ~allowed_tool_names:[ "keeper_tasks_audit"; "keeper_board_post" ]
    with


### PR DESCRIPTION
## Summary
- validate tool_policy.toml names against the full keeper-facing tool surface, not only direct handler registrations
- accept static tag-dispatch keeper/masc tools and OAS core extend_turns as valid policy entries
- map internal required/allowlist names such as `keeper_bash` and `keeper_shell` back to their public LLM aliases (`Bash`, `Grep`) before visible-surface pruning
- preserve already-visible public aliases such as `Write` so reverse canonicalization does not collapse them into a sibling alias like `Edit`
- add focused coverage for keeper_board_post, masc_status, extend_turns, alias reverse lookup, required-tool alias selection, and retired/unknown names

## Operator impact
- fixes noisy startup/runtime warnings like `tool_policy_config: 135 unknown tools` when the active config contains valid keeper/masc tool policy entries
- fixes follow-on tool-surface noise where internal required tools were logged as pruned after RFC-0064 alias cleanup even though their public aliases were valid
- live servers using an older binary will keep logging until this lands, the binary is rebuilt, and the server is restarted

## Verification
- `scripts/dune-local.sh build test/test_keeper_tool_alias.exe test/test_keeper_unified.exe test/test_keeper_tool_policy_config.exe bin/main_eio.exe`
- `_build/default/test/test_keeper_tool_alias.exe` (33 tests)
- `_build/default/test/test_keeper_tool_policy_config.exe` (12 tests)
- `_build/default/test/test_keeper_unified.exe test tool_classification 3 --show-errors`
- startup smoke with `MASC_CONFIG_DIR=/Users/dancer/me/.masc/config` and temp base path: no `tool_policy_config` unknown-tools warning; only `loaded 18 groups, 7 masc_groups, 8 presets`
- local TLA drift workflow scripts: annotation drift, TLA phase-count, OCaml phase-count, TLA->OCaml line refs, OCaml spec-nav line refs all pass
- GitHub checks: rerunning for rebased head `5a6215ea8a0f5ba477a2647c7daa6b57f6729e56`


---

## 머지 의존성

머지 순서: **#15059 (build fix) → 이 PR → 후속 RFC**

- 이 PR 의 base (rebase 후 d7e8567db6 ~) 가 `Unix.unsetenv` 빌드 fail 을 포함. #15059 가 main 머지되면 이 PR rebase 필요. rebase 후 push 시 `--force-with-lease=<branch>:<expected-sha>` explicit form 사용 권장 (MEMORY \`feedback_force_with_lease_silent_overwrite_in_long_worktree\`).
- 본 PR 의 모든 review thread 는 resolved 상태 (`PRRT_kwDOQ7_DYc6Bzd5Z`, `PRRT_kwDOQ7_DYc6Bzd6A`, `PRRT_kwDOQ7_DYc6Bz_IP`). Ready 전환 후 머지 가능.

