### PR TITLE
feat(ide): focus telemetry event routes

### DIFF
--- a/dashboard/src/components/ide/ide-activity-mock.test.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.test.ts
@@ -102,8 +102,10 @@ describe('IdeActivityMock', () => {
             goal_id: 'goal-runtime',
             comment_id: 'comment-1',
             pr_number: 15000,
+            session_id: 'sess-runtime',
+            operation_id: 'op-runtime',
           },
-          tags: ['task:task-runtime', 'board:post-1', 'comment:comment-1', 'git:main', 'log:turn-1'],
+          tags: ['task:task-runtime', 'board:post-1', 'comment:comment-1', 'git:main', 'log:turn-1', 'worker:wr-runtime'],
         }],
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
     ))
@@ -136,7 +138,7 @@ describe('IdeActivityMock', () => {
       'Keeper',
     ])
     fireEvent.click(activityRouteLinks.find(link => link.textContent === 'Telemetry')!)
-    expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log')
+    expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&session_id=sess-runtime&operation_id=op-runtime&worker_run_id=wr-runtime&q=turn-1')
 
     const jump = container.querySelector<HTMLButtonElement>('.ide-activity-context-jump')
     expect(jump?.textContent).toContain('runtime.ml:4')
@@ -282,6 +284,8 @@ describe('IdeActivityMock', () => {
     expect(container.querySelector('.ide-activity-context-jump')).toBeNull()
     expect([...container.querySelectorAll<HTMLButtonElement>('.ide-activity-route-link')]
       .map(link => link.textContent)).toEqual(['Log', 'Telemetry', 'Keeper'])
+    fireEvent.click(container.querySelectorAll<HTMLButtonElement>('.ide-activity-route-link')[1]!)
+    expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&q=turn-1')
   })
 
   it('normalizes derived file paths and hides unsafe context jumps', async () => {

--- a/dashboard/src/components/ide/ide-activity-mock.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.ts
@@ -205,6 +205,12 @@ function mergePayloadContext(next: MutableRunActivityContext, payload: unknown):
   if (gitRef) next.git_ref = gitRef
   const logId = stringValue(record.log_id)
   if (logId) next.log_id = logId
+  const sessionId = stringValue(record.session_id)
+  if (sessionId) next.session_id = sessionId
+  const operationId = stringValue(record.operation_id)
+  if (operationId) next.operation_id = operationId
+  const workerRunId = stringValue(record.worker_run_id)
+  if (workerRunId) next.worker_run_id = workerRunId
 }
 
 function mergeTagContext(next: MutableRunActivityContext, rawTag: string): void {
@@ -236,6 +242,9 @@ function mergeTagContext(next: MutableRunActivityContext, rawTag: string): void 
   else if (key === 'pr' || key === 'pull_request' || key === 'review') next.pr_id = value
   else if (key === 'git' || key === 'commit' || key === 'branch') next.git_ref = value
   else if (key === 'log' || key === 'telemetry') next.log_id = value
+  else if (key === 'session' || key === 'session_id') next.session_id = value
+  else if (key === 'operation' || key === 'operation_id' || key === 'op') next.operation_id = value
+  else if (key === 'worker_run' || key === 'worker_run_id' || key === 'worker') next.worker_run_id = value
 }
 
 function stringValue(value: unknown): string | undefined {
@@ -560,6 +569,9 @@ function ActivityRow(
     prId: item.context?.pr_id,
     gitRef: item.context?.git_ref,
     logId: item.context?.log_id,
+    sessionId: item.context?.session_id,
+    operationId: item.context?.operation_id,
+    workerRunId: item.context?.worker_run_id,
     keeperId: item.keeper_id,
     telemetry: true,
   })

--- a/dashboard/src/components/ide/ide-context-lens.test.ts
+++ b/dashboard/src/components/ide/ide-context-lens.test.ts
@@ -300,6 +300,9 @@ describe('IdeContextLens', () => {
           comment_id: 'comment-1',
           git_ref: 'abc123',
           log_id: 'turn-9',
+          session_id: 'sess-9',
+          operation_id: 'op-9',
+          worker_run_id: 'wr-9',
         },
       }],
       overlay: { ...overlay, cursors: new Map() },
@@ -341,7 +344,15 @@ describe('IdeContextLens', () => {
     })
     expect(model.anchors[0]?.route_links?.find(link => link.label === 'Telemetry')).toMatchObject({
       tab: 'monitoring',
-      params: { section: 'fleet-health', view: 'event-log' },
+      params: {
+        section: 'fleet-health',
+        view: 'event-log',
+        session_id: 'sess-9',
+        operation_id: 'op-9',
+        worker_run_id: 'wr-9',
+        q: 'turn-9',
+      },
+      evidence: 'Fleet telemetry event log · session sess-9 · operation op-9 · worker wr-9 · query turn-9',
     })
     expect(model.anchors[0]?.route_links?.find(link => link.label === 'Keeper')).toMatchObject({
       tab: 'monitoring',
@@ -504,5 +515,35 @@ describe('IdeContextLens', () => {
 
     const logRoute = model.anchors[0]?.route_links?.find(link => link.label === 'Log')
     expect(logRoute?.params).toEqual({ section: 'runtime', view: 'audit' })
+  })
+
+  it('routes telemetry-only context into event-log query focus', () => {
+    const model = deriveIdeContextLens({
+      filePath: 'lib/keeper/keeper_exec_ide.ml',
+      annotations: [],
+      diffRows: [],
+      events: [{
+        id: 'evt-telemetry',
+        run_id: 'run-default',
+        keeper_id: 'sangsu',
+        verb: 'noted',
+        target: 'telemetry',
+        timestamp_ms: 400,
+        context: {
+          file_path: 'lib/keeper/keeper_exec_ide.ml',
+          line: 27,
+          log_id: 'turn-9',
+        },
+      }],
+      overlay: { ...overlay, cursors: new Map() },
+    })
+
+    const telemetryRoute = model.anchors[0]?.route_links?.find(link => link.label === 'Telemetry')
+    expect(telemetryRoute).toMatchObject({
+      id: 'telemetry:turn-9',
+      tab: 'monitoring',
+      params: { section: 'fleet-health', view: 'event-log', q: 'turn-9' },
+      evidence: 'Fleet telemetry event log · query turn-9',
+    })
   })
 })

--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -68,6 +68,10 @@ export interface IdeContextRouteContext {
   readonly prId?: string
   readonly gitRef?: string
   readonly logId?: string
+  readonly sessionId?: string
+  readonly operationId?: string
+  readonly workerRunId?: string
+  readonly telemetryQuery?: string
   readonly keeperId?: string
   readonly telemetry?: boolean
 }
@@ -573,6 +577,10 @@ function buildAnchors(
         prId: event.context?.pr_id,
         gitRef: event.context?.git_ref,
         logId: event.context?.log_id,
+        sessionId: event.context?.session_id,
+        operationId: event.context?.operation_id,
+        workerRunId: event.context?.worker_run_id,
+        telemetryQuery: event.context?.log_id,
         keeperId: event.keeper_id,
         telemetry: true,
       }),
@@ -597,6 +605,9 @@ function eventSearchText(event: RunActivityEvent): string {
     event.context?.pr_id ? `pr:${event.context.pr_id}` : undefined,
     event.context?.git_ref ? `git:${event.context.git_ref}` : undefined,
     event.context?.log_id ? `log:${event.context.log_id}` : undefined,
+    event.context?.session_id ? `session:${event.context.session_id}` : undefined,
+    event.context?.operation_id ? `operation:${event.context.operation_id}` : undefined,
+    event.context?.worker_run_id ? `worker_run:${event.context.worker_run_id}` : undefined,
     ...(event.tags ?? []),
   ]
     .filter((part): part is string => typeof part === 'string' && part.trim() !== '')
@@ -678,6 +689,9 @@ function eventContextMeta(event: RunActivityEvent): string {
     context.comment_id ? `comment ${context.comment_id}` : null,
     context.git_ref ? `git ${context.git_ref}` : null,
     context.log_id ? `log ${context.log_id}` : null,
+    context.session_id ? `session ${context.session_id}` : null,
+    context.operation_id ? `operation ${context.operation_id}` : null,
+    context.worker_run_id ? `worker ${context.worker_run_id}` : null,
     context.file_path ?? null,
   ])
 }
@@ -774,12 +788,32 @@ export function routeLinksForContext(
     })
   }
   if (context.telemetry) {
+    const sessionId = cleanId(context.sessionId)
+    const operationId = cleanId(context.operationId)
+    const workerRunId = cleanId(context.workerRunId)
+    const telemetryQuery = cleanId(context.telemetryQuery ?? context.logId)
+    const telemetryParams: Record<string, string> = {
+      section: 'fleet-health',
+      view: 'event-log',
+    }
+    if (sessionId) telemetryParams.session_id = sessionId
+    if (operationId) telemetryParams.operation_id = operationId
+    if (workerRunId) telemetryParams.worker_run_id = workerRunId
+    if (telemetryQuery) telemetryParams.q = telemetryQuery
+    const telemetryScope = [
+      sessionId ? `session ${sessionId}` : null,
+      operationId ? `operation ${operationId}` : null,
+      workerRunId ? `worker ${workerRunId}` : null,
+      telemetryQuery ? `query ${telemetryQuery}` : null,
+    ].filter((value): value is string => value !== null)
     add({
-      id: 'telemetry:event-log',
+      id: `telemetry:${sessionId ?? operationId ?? workerRunId ?? telemetryQuery ?? 'event-log'}`,
       label: 'Telemetry',
       tab: 'monitoring',
-      params: { section: 'fleet-health', view: 'event-log' },
-      evidence: 'Fleet telemetry event log',
+      params: telemetryParams,
+      evidence: telemetryScope.length > 0
+        ? `Fleet telemetry event log · ${telemetryScope.join(' · ')}`
+        : 'Fleet telemetry event log',
     })
   }
   const keeperId = cleanId(context.keeperId)

--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -231,11 +231,11 @@ describe('IdeEditor', () => {
           evidence: 'Task task-runtime',
         },
         {
-          id: 'telemetry:event-log',
+          id: 'telemetry:turn-9',
           label: 'Telemetry',
           tab: 'monitoring',
-          params: { section: 'fleet-health', view: 'event-log' },
-          evidence: 'Fleet telemetry event log',
+          params: { section: 'fleet-health', view: 'event-log', q: 'turn-9' },
+          evidence: 'Fleet telemetry event log · query turn-9',
         },
       ],
     })
@@ -248,6 +248,6 @@ describe('IdeEditor', () => {
     const routeLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-editor-context-route-link')]
     expect(routeLinks.map(link => link.textContent)).toEqual(['Task', 'Telemetry'])
     fireEvent.click(routeLinks.find(link => link.textContent === 'Telemetry')!)
-    expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log')
+    expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&q=turn-9')
   })
 })

--- a/dashboard/src/components/ide/run-activity-store.ts
+++ b/dashboard/src/components/ide/run-activity-store.ts
@@ -34,6 +34,9 @@ export interface RunActivityContext {
   readonly pr_id?: string
   readonly git_ref?: string
   readonly log_id?: string
+  readonly session_id?: string
+  readonly operation_id?: string
+  readonly worker_run_id?: string
 }
 
 export interface RunActivityEvent {
@@ -170,6 +173,9 @@ function isRunActivityContext(value: unknown): value is RunActivityContext {
     && optionalNonEmptyString(value.pr_id)
     && optionalNonEmptyString(value.git_ref)
     && optionalNonEmptyString(value.log_id)
+    && optionalNonEmptyString(value.session_id)
+    && optionalNonEmptyString(value.operation_id)
+    && optionalNonEmptyString(value.worker_run_id)
 }
 
 function optionalNonEmptyString(value: unknown): boolean {

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -90,6 +90,7 @@ describe('TelemetryUnified', () => {
   afterEach(() => {
     render(null, container)
     container.remove()
+    window.location.hash = ''
     vi.clearAllMocks()
     vi.resetModules()
     vi.doUnmock('../api/dashboard')
@@ -214,6 +215,58 @@ describe('TelemetryUnified', () => {
     expect(container.textContent).toContain('1 차단 작업')
     expect(container.textContent).not.toContain('활성 세션')
     expect(container.textContent).toContain('5 public')
+  })
+
+  it('hydrates telemetry scope and entry focus from route params', async () => {
+    window.location.hash = '#monitoring?section=fleet-health&view=event-log&session_id=sess-route&operation_id=op-route&worker_run_id=wr-route&q=turn-9'
+    const fetchTelemetry = vi.fn().mockResolvedValue({
+      ...baseTelemetry,
+      count: 2,
+      entries: [
+        {
+          source: 'tool_metric',
+          ts: 1_775_709_100,
+          session_id: 'sess-route',
+          operation_id: 'op-route',
+          worker_run_id: 'wr-route',
+          tool_name: 'turn-9-evidence',
+          duration_ms: 22,
+          success: true,
+        },
+        {
+          source: 'keeper_metric',
+          ts: 1_775_709_000,
+          session_id: 'sess-route',
+          name: 'keeper-other',
+          channel: 'turn_end',
+          tool_call_count: 1,
+        },
+      ],
+    })
+    const fetchTelemetrySummary = vi.fn().mockResolvedValue(baseSummary)
+    const { TelemetryUnified } = await loadPanel(fetchTelemetry, fetchTelemetrySummary)
+
+    await act(async () => {
+      render(html`<${TelemetryUnified} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(fetchTelemetry).toHaveBeenCalledWith(expect.objectContaining({
+      session_id: 'sess-route',
+      operation_id: 'op-route',
+      worker_run_id: 'wr-route',
+      n: 100,
+    }))
+    expect(container.textContent).toContain('session sess-route')
+    expect(container.textContent).toContain('operation op-route')
+    expect(container.textContent).toContain('worker_run wr-route')
+    expect(container.textContent).toContain('focus turn-9')
+    const searchInput = container.querySelector<HTMLInputElement>('input[aria-label="엔트리 텍스트 검색"]')
+    expect(searchInput?.value).toBe('turn-9')
+    expect(container.textContent).toContain('검색 매치 1건')
+    expect(container.textContent).toContain('turn-9-evidence')
+    expect(container.textContent).not.toContain('keeper-other')
   })
 
   it('renders a telemetry entry raw JSON copy action', async () => {

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -734,16 +734,18 @@ export function TelemetryUnified() {
   const operationFilter = useSignal(params.operation_id ?? '')
   const workerRunFilter = useSignal(params.worker_run_id ?? '')
   const limit = useSignal(100)
-  const entrySearch = useSignal('')
+  const entrySearch = useSignal(params.q ?? '')
 
   useEffect(() => {
     sessionFilter.value = route.value.params.session_id ?? ''
     operationFilter.value = route.value.params.operation_id ?? ''
     workerRunFilter.value = route.value.params.worker_run_id ?? ''
+    entrySearch.value = route.value.params.q ?? ''
   }, [
     route.value.params.session_id,
     route.value.params.operation_id,
     route.value.params.worker_run_id,
+    route.value.params.q,
   ])
 
   async function load() {
@@ -881,6 +883,7 @@ export function TelemetryUnified() {
           ${sessionFilter.value ? html`<span class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs font-mono text-[var(--color-fg-disabled)]">session ${sessionFilter.value}</span>` : null}
           ${operationFilter.value ? html`<span class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs font-mono text-[var(--color-fg-disabled)]">operation ${operationFilter.value}</span>` : null}
           ${workerRunFilter.value ? html`<span class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs font-mono text-[var(--color-fg-disabled)]">worker_run ${workerRunFilter.value}</span>` : null}
+          ${route.value.params.q ? html`<span class="rounded-[var(--r-1)] border border-[var(--color-accent-muted)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs font-mono text-[var(--color-accent-fg)]">focus ${route.value.params.q}</span>` : null}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- carry session_id, operation_id, and worker_run_id through IDE activity context
- route IDE Telemetry links to fleet-health/event-log with scope params and q focus from log_id
- hydrate telemetry event-log search/focus chips from route params

## Validation
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/run-activity-store.ts src/components/ide/ide-activity-mock.ts src/components/ide/ide-context-lens.ts src/components/telemetry-unified.ts
- pnpm exec tsc --noEmit --pretty false
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-context-lens.test.ts src/components/ide/ide-activity-mock.test.ts src/components/ide/ide-editor.test.ts src/components/telemetry-unified.test.ts
- git diff --check

Note: local Vitest still emits existing jsdom localhost :3000 EPERM and --localstorage-file warnings; focused tests pass.