### PR TITLE
fix(ide): preserve payload line on unsafe file tags

### DIFF
--- a/dashboard/src/components/ide/ide-activity-mock.test.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.test.ts
@@ -332,6 +332,21 @@ describe('IdeActivityMock', () => {
             },
             tags: [],
           },
+          {
+            seq: 4,
+            ts_ms: 70,
+            ts_iso: '2026-05-05T10:00:03Z',
+            room_id: 'run-default',
+            kind: 'telemetry.turn',
+            actor: { kind: 'keeper', id: 'sangsu' },
+            subject: { kind: 'log', id: 'turn-4' },
+            payload: {
+              file_path: 'lib/payload.ml',
+              line: 4,
+              log_id: 'turn-4',
+            },
+            tags: ['file:/workspace/lib/other.ml:99'],
+          },
         ],
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
     ))
@@ -340,11 +355,15 @@ describe('IdeActivityMock', () => {
     render(h(IdeActivityMock, { activeFile: 'lib/runtime.ml' }), container)
 
     await waitFor(() => {
-      expect(container.textContent).toContain('3 events')
+      expect(container.textContent).toContain('4 events')
     })
 
     const jumps = [...container.querySelectorAll<HTMLButtonElement>('.ide-activity-context-jump')]
-    expect(jumps.map(jump => jump.textContent)).toEqual(['↗ runtime.ml:4', '↗ runtime.ml:7'])
+    expect(jumps.map(jump => jump.textContent)).toEqual([
+      '↗ runtime.ml:4',
+      '↗ runtime.ml:7',
+      '↗ payload.ml:4',
+    ])
 
     fireEvent.click(jumps[0]!)
     expect(activeIdeFile.value).toBe('lib/runtime.ml')

--- a/dashboard/src/components/ide/ide-activity-mock.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.ts
@@ -220,7 +220,8 @@ function mergeTagContext(next: MutableRunActivityContext, rawTag: string): void 
     const match = value.match(/^(.+?)(?::([1-9][0-9]*))?$/)
     const path = match?.[1]
     const normalizedPath = path ? normalizeIdeContextFilePath(path) : null
-    if (normalizedPath) next.file_path = normalizedPath
+    if (!normalizedPath) return
+    next.file_path = normalizedPath
     if (match?.[2]) next.line = Number.parseInt(match[2], 10)
     return
   }


### PR DESCRIPTION
Follow-up for PR #15035 review. When an activity event has a safe payload file/line and an unsafe file: tag, the dashboard now ignores the unsafe tag entirely instead of pairing the payload file with the rejected tag line. Verification: pnpm install --offline --frozen-lockfile; pnpm exec eslint src/components/ide/ide-activity-mock.ts src/components/ide/ide-activity-mock.test.ts; pnpm exec tsc --noEmit --pretty false; pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-activity-mock.test.ts; git diff --check.