### PR TITLE
feat(ide): show focus context metadata

### DIFF
--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -245,6 +245,9 @@ describe('IdeEditor', () => {
         .toContain('Focused L2')
       expect(container.querySelector('.cm-masc-context-focus')).not.toBeNull()
     })
+    const focusMeta = [...container.querySelectorAll('.ide-editor-context-focus-meta > span')]
+      .map(node => node.textContent)
+    expect(focusMeta).toEqual(['Task', 'keeper sangsu', 'source event-1', '2 links'])
     const routeLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-editor-context-route-link')]
     expect(routeLinks.map(link => link.textContent)).toEqual(['Task', 'Telemetry'])
     fireEvent.click(routeLinks.find(link => link.textContent === 'Telemetry')!)

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -177,6 +177,9 @@ export function IdeEditor({
               Focused ${currentFileFocus.line !== undefined ? `L${currentFileFocus.line}` : currentFileFocus.surface}
               · ${currentFileFocus.label}
             </span>
+            <span class="ide-editor-context-focus-meta" aria-label="Focused context metadata">
+              ${contextFocusMetaParts(currentFileFocus).map(part => html`<span>${part}</span>`)}
+            </span>
             ${currentFileFocus.route_links && currentFileFocus.route_links.length > 0 ? html`
               <span class="ide-editor-context-route-links" aria-label="Focused context operational links">
                 ${currentFileFocus.route_links.map(link => EditorContextRouteLink(link))}
@@ -245,6 +248,16 @@ export function IdeEditor({
       }
     </div>
   `
+}
+
+function contextFocusMetaParts(focus: IdeContextFocus): ReadonlyArray<string> {
+  const routeCount = focus.route_links?.length ?? 0
+  return [
+    focus.surface,
+    focus.keeper_id ? `keeper ${focus.keeper_id}` : null,
+    `source ${focus.source_id}`,
+    routeCount > 0 ? `${routeCount} links` : null,
+  ].filter((part): part is string => part !== null)
 }
 
 function EditorContextRouteLink(link: IdeContextRouteLink) {

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -1455,6 +1455,29 @@
   white-space: nowrap;
 }
 
+.ide-editor-context-focus-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  min-width: 0;
+  flex-wrap: wrap;
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+}
+
+.ide-editor-context-focus-meta > span {
+  min-width: 0;
+  max-width: 86px;
+  padding: 0 4px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-page);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .ide-editor-context-route-links {
   display: inline-flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Follow-up slice for the MASC IDE context work. The editor focus strip now shows compact metadata for the focused context anchor: surface, keeper, source id, and route count, while preserving the existing operational route buttons. This makes line-level focus explain why the current line is linked to Task/Telemetry/Goal/etc instead of only showing the line label.\n\nVerification:\n- pnpm install --offline --frozen-lockfile\n- pnpm exec eslint src/components/ide/ide-editor.ts src/components/ide/ide-editor.test.ts\n- pnpm exec tsc --noEmit --pretty false\n- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-editor.test.ts\n- git diff --check\n- Vite smoke: http://localhost:5174/dashboard/#code?section=ide-shell rendered the Code IDE surface