### PR TITLE
[codex] delegate keeper context overflow retry to OAS

### DIFF
--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -1,11 +1,13 @@
 ---
 status: reference
-last_verified: 2026-05-13
+last_verified: 2026-05-14
 code_refs:
   - lib/masc_oas_bridge.ml
   - lib/worker_oas.ml
   - lib/verifier_oas.ml
   - lib/memory_oas_bridge.ml
+  - lib/keeper/keeper_context_core.ml
+  - lib/keeper/keeper_memory_policy.ml
 ---
 
 # OAS-MASC Boundary Contract
@@ -34,7 +36,7 @@ consumer → MASC-MCP (coordination/orchestration) → OAS (agent runtime)
 | 멀티에이전트 실행 | `Orchestrator`, `Agent_sdk_swarm.Runner` | room, board, workflow, policies, operator surfaces |
 | 도구 실행 | `Tool.t`, hook lifecycle, raw trace | tool schema 정의, tool dispatch, auth/join/policy semantics |
 | 컨텍스트 축약 | `Context_reducer` | 어떤 전략을 언제 적용할지 결정 |
-| ContextOverflow retry | overflow detection, structured error, standalone compact retry | Keeper turn에서 compact+retry 여부와 generation/checkpoint attribution 결정 |
+| ContextOverflow retry | overflow detection, structured error, standalone/keeper compact retry | 최종 overflow 결과를 keeper state, receipt, operator surfaces에 attribution |
 | 이벤트 전달 | `Event_bus` | 어떤 MASC 사건을 custom event로 publish할지 정의, SSE/dashboard에 연결 |
 | 장기 메모리 프리미티브 | `Memory.t` tiers | institutional memory, pg/jsonl backends, room/task/social semantics |
 | 조율 상태 | 없음 | room, tasks, team sessions, governance, social runtime |
@@ -78,11 +80,11 @@ OAS  ──does not know──→ MASC
 | Area | Status | Notes |
 |------|--------|-------|
 | Context compaction | Partial complete | `context_compact_oas.ml`는 OAS `Context_reducer`를 사용한다. MASC 전체 context system이 OAS `Context.t`로 통합된 것은 아니다. |
-| ContextOverflow retry ownership | Complete for keeper hot path | Standalone OAS agents keep `auto_context_overflow_retry=true`. Keeper dispatch sets it to `false`, so OAS returns structured `ContextOverflow` and MASC's `recover_context_overflow_retry` owns the one-per-keeper-turn retry decision. |
+| ContextOverflow retry ownership | Complete for keeper hot path | Keeper dispatch keeps `auto_context_overflow_retry=true`, so OAS owns transcript mutation, emergency compaction, and retry. If OAS still returns structured `ContextOverflow`, MASC records the typed blocker and terminal receipt without compacting checkpoints or re-dispatching the agent turn. |
 | Event bus bridge | Complete for current native/custom flow | `oas_event_bridge.ml` relays both OAS native events and `masc:*` custom events, persists them under `.masc/oas-events/`, and feeds dashboard SSE |
 | Dashboard OAS runtime health | Complete with replay/live split | dashboard health SSOT is `durable oas_event replay + live SSE tail`, not live-only counters |
 | Dashboard runtime counts | Complete with truth split | dashboard `counts` means active runtimes; configured keeper inventory is exposed separately as `configured_keepers` |
-| Checkpoint integration | Partial complete | OAS checkpoint is used in shared worker/runtime paths, and the public OAS worker API now keeps the extra JSON as a neutral checkpoint sidecar. Keeper runtime still persists its own `working_context` / serialized checkpoint path in `lib/keeper/keeper_exec_context.ml` |
+| Checkpoint integration | Mostly complete, sidecar debt remains | OAS checkpoint is used in shared worker/runtime paths. New keeper checkpoint writes keep continuity state out of `working_context`: `patch_checkpoint_last_assistant` strips visible `[STATE]`, stores replay metadata on the assistant message, and clears `Checkpoint.working_context`. Compatibility readers still accept legacy structured sidecars, and feature-flagged autonomous/resilience/multimodal adapters may store neutral sidecar metadata in `working_context`. |
 | Memory bridge | Partial complete | long-term + procedural + institution episodic are bridged; broader memory unification is still separate |
 | Team-session swarm | Removed | `lib/team_session/` module purged; MASC no longer owns a session orchestration surface. OAS Swarm Runner is the sole substrate; consumers drive swarm runs via OAS primitives directly. |
 | Provider/model identity ownership | OAS-owned | MASC resolves logical `cascade_name` / runtime lane intent only; concrete provider/model selection and cost identity are OAS-owned. Legacy `allowed_providers` inputs are ignored |
@@ -94,12 +96,12 @@ OAS  ──does not know──→ MASC
 | `lib/oas_worker*.ml`, `lib/worker_oas.ml`, `lib/verifier_oas.ml` | Correct | OAS is consumed as the runtime contract; MASC chooses prompts, tools, policy, and verification usage |
 | `lib/context_compact_oas.ml` | Acceptable but lossy | Runtime compaction delegates to OAS, but message-importance heuristics still depend on MASC text markers |
 | `lib/memory_oas_bridge.ml` | Acceptable | Consumer-side adapter; imperative seeding removed in RFC-MASC-004 Phase 2, hook-first injection is now the sole path |
-| `lib/keeper/keeper_agent_run.ml` + keeper checkpoint/context path | Boundary violation | Keeper still owns duplicate runtime state via `working_context` and relies on raw text markers such as `[STATE]` |
+| `lib/keeper/keeper_agent_run.ml` + keeper checkpoint/context path | Mostly correct with adapter sidecar debt | Keeper no longer stores continuity runtime state in checkpoint `working_context` on new writes; replay state is assistant-message metadata plus sidecar-file fallback. Remaining debt is limited to MASC adapter sidecars (`autonomous_meta`, `resilience_meta`, `multimodal_artifacts`/`workspace_meta`) and legacy `[STATE]` parse compatibility. |
 
 ## Open Structural Gaps
 
-- keeper runtime still uses a MASC-owned `working_context` wrapper around OAS context/checkpoint primitives
-- keeper continuity still leaks domain semantics through raw message text (`[STATE]`, goal/memory markers)
+- keeper runtime still has a small MASC-owned `working_context` facade around OAS context/checkpoint primitives for token observation, checkpoint loading, and adapter compatibility; this facade must remain read-only with respect to OAS-owned runtime transcript state.
+- keeper continuity no longer writes new `[STATE]` replay state into checkpoint `working_context`, but prompt/fallback paths still understand raw message text markers (`[STATE]`, goal/memory markers) for compatibility and recovery.
 - `memory_oas_bridge.ml` imperative seeding fully removed (RFC-MASC-004 Phase 2-3); hook-first is the sole path
 - runtime-health signaling still relies on a narrow boolean `resource_check` callback instead of a structured probe
 - proof-store and `oas-runtime` filesystem layout must stay behind thin adapters instead of being reconstructed ad hoc
@@ -232,9 +234,9 @@ These stay in MASC:
 ## Priority Order
 
 1. **P1 — keeper runtime state ownership**
-   - shrink the MASC-owned `working_context` role until OAS owns runtime context/checkpoint state
+   - keep new continuity state out of checkpoint `working_context`; reduce or externalize the remaining adapter sidecars when their feature-flagged owners grow stable storage
 2. **P2 — marker/text leakage**
-   - reduce dependence on raw `[STATE]`, `[GOAL]`, and memory-summary markers in runtime-facing paths
+   - reduce remaining prompt/fallback dependence on raw `[STATE]`, `[GOAL]`, and memory-summary markers in runtime-facing paths
 3. **P3 — team-session bridge fidelity** — Resolved (2026-04, team_session module purged; OAS Swarm Runner is sole substrate)
    - MASC team-session surface removed; coordination needs served via board posts + keeper FSM, swarm runs driven through OAS directly
 4. **P4 — memory bridge hardening** — Resolved (2026-04-13, PR #6795 Phase 1 + Phase 2)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -648,7 +648,7 @@ let run_turn
                      ~system_prompt:turn_system_prompt
                      ~tools
                      ~compact_ratio:meta.compaction.ratio_gate
-                     ~oas_auto_context_overflow_retry:false
+                     ~oas_auto_context_overflow_retry:true
                      ~initial_messages:history_messages
                      ~hooks
                      ~context_reducer:reducer

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -1,5 +1,5 @@
 (* Keeper_turn_cascade_budget — cascade execution types, fail-open rotation,
-   OAS timeout budget resolution, context overflow recovery, keeper pause/resume
+   OAS timeout budget resolution, context overflow observation, keeper pause/resume
    sync, partial-commit continue gate, and context budget resolution.
 
    Extracted from keeper_unified_turn.ml (L501-1079) during the god-file split. *)
@@ -7,11 +7,6 @@
 open Keeper_types
 open Keeper_exec_context
 module EC = Keeper_error_classify
-
-(* Absolute floor for context overflow retry when the API does not report
-   the actual token limit.  Prevents retrying with an unreasonably small
-   context window. *)
-let fallback_context_overflow_floor_tokens = 4096
 
 type cascade_execution = {
   cascade_name : Keeper_cascade_profile.runtime_name;
@@ -415,12 +410,6 @@ let next_fail_open_cascade_for_turn_with_budget
       then Degraded_retry_allowed retry
       else Degraded_retry_budget_exhausted retry
 
-type overflow_retry_plan = {
-  retry_max_context : int;
-  retry_generation : int;
-  compaction : compaction_event;
-}
-
 type turn_event_bus_overflow = {
   estimated_tokens : int;
   limit_tokens : int;
@@ -483,66 +472,6 @@ let merge_turn_event_bus_summary
        | Some _ -> right.last_compaction
        | None -> left.last_compaction);
   }
-
-(** Recover from context overflow by compacting and reducing max_context.
-
-    Extracts the token limit directly from the structured [ContextOverflow]
-    error instead of re-parsing stringified error messages.
-    No local token-budget math -- OAS owns context budgeting.
-    MASC only decides whether to compact and retry.
-
-    @boundary-contract
-    - MASC owns: "compact & retry?" decision (at most once per turn),
-      extracting the limit from OAS structured errors, generation tracking.
-    - OAS owns: context overflow detection, ContextOverflow/TokenBudgetExceeded
-      error emission, checkpoint compaction algorithm, token budget enforcement.
-    - Neither may: MASC must not invent token limits or run its own budget
-      math; OAS must not auto-retry on overflow (MASC needs to decide). *)
-let recover_context_overflow_retry
-    ~(meta : keeper_meta)
-    ~(base_dir : string)
-    ~(max_cascade_context : int)
-    ~(error : Agent_sdk.Error.sdk_error) : overflow_retry_plan option =
-  let actual_limit =
-    match error with
-    | Agent_sdk.Error.Api (ContextOverflow { limit = Some limit; _ }) -> limit
-    | Agent_sdk.Error.Agent (TokenBudgetExceeded { limit; _ }) -> limit
-    | _ ->
-      (* Overflow detected but limit not available -- use 80% of cascade max
-         as a conservative fallback, with an absolute floor. *)
-      max fallback_context_overflow_floor_tokens (max_cascade_context * 4 / 5)
-  in
-  let retry_max_context =
-    if max_cascade_context <= 0 then actual_limit
-    else min max_cascade_context actual_limit
-  in
-  let model = Keeper_exec_context.checkpoint_model_of_meta meta in
-  match
-    Keeper_exec_context.recover_latest_checkpoint_for_overflow_retry
-      ~base_dir ~meta ~model
-      ~primary_model_max_tokens:retry_max_context
-  with
-  | Some recovery ->
-      Log.Keeper.warn
-        "%s: context overflow retry -- compacted checkpoint (%d->%d tokens, max_context=%d, generation=%d)"
-        meta.name recovery.compaction.before_tokens
-        recovery.compaction.after_tokens
-        retry_max_context recovery.turn_generation;
-      Some
-        {
-          retry_max_context;
-          retry_generation = recovery.turn_generation;
-          compaction = recovery.compaction;
-        }
-  | None ->
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_checkpoint_failures
-        ~labels:[("keeper", meta.name); ("phase", "overflow_recovery_unavailable")]
-        ();
-      Log.Keeper.warn
-        "%s: context overflow detected but checkpoint recovery unavailable: %s"
-        meta.name (short_preview (Agent_sdk.Error.to_string error));
-      None
 
 let summarize_turn_event_bus
     (events : Agent_sdk.Event_bus.event list) : turn_event_bus_summary =

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -1,5 +1,5 @@
 (* Keeper_turn_cascade_budget — cascade execution types, fail-open rotation,
-   OAS timeout budget resolution, context overflow recovery, keeper pause/resume
+   OAS timeout budget resolution, context overflow observation, keeper pause/resume
    sync, partial-commit continue gate, and context budget resolution.
 
    Public sub-module included by [Keeper_unified_turn]. *)
@@ -147,12 +147,6 @@ val next_fail_open_cascade_for_turn_with_budget :
   Agent_sdk.Error.sdk_error ->
   degraded_retry_budget_decision
 
-type overflow_retry_plan = {
-  retry_max_context : int;
-  retry_generation : int;
-  compaction : compaction_event;
-}
-
 type turn_event_bus_overflow = {
   estimated_tokens : int;
   limit_tokens : int;
@@ -179,13 +173,6 @@ val empty_turn_event_bus_summary : turn_event_bus_summary
 
 val merge_turn_event_bus_summary :
   turn_event_bus_summary -> turn_event_bus_summary -> turn_event_bus_summary
-
-val recover_context_overflow_retry :
-  meta:keeper_meta ->
-  base_dir:string ->
-  max_cascade_context:int ->
-  error:Agent_sdk.Error.sdk_error ->
-  overflow_retry_plan option
 
 val summarize_turn_event_bus :
   Agent_sdk.Event_bus.event list -> turn_event_bus_summary

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -770,12 +770,6 @@ let run_keeper_cycle
                let current_turn_blocker_info = ref None in
                let event_bus_drain_cancel = ref None in
                let turn_event_bus_mu = Eio.Mutex.create () in
-               let mark_paused_after_overflow ~run_meta ~reason =
-                 let paused_meta =
-                   pause_keeper_for_overflow ~config ~meta:run_meta ~reason
-                 in
-                 paused_meta_override := Some paused_meta
-               in
                (* Side-effect tracking is driven by the OAS Event_bus (ToolCalled +
          ToolCompleted) rather than MASC-side observers. Pairing is by
          tool_name order within the per-turn subscription, which is safe
@@ -1172,7 +1166,6 @@ let run_keeper_cycle
                                  ~attempt
                                  ~is_retry
                                  ~allow_degraded_wall_clock_retry_budget
-                                 ~overflow_retry_used
                                  ~attempted_cascades
                          =
                          let execution_cascade_name =
@@ -1605,7 +1598,6 @@ let run_keeper_cycle
                                       ~attempt:1
                                       ~is_retry:true
                                       ~allow_degraded_wall_clock_retry_budget:true
-                                      ~overflow_retry_used
                                       ~attempted_cascades:
                                         (next_execution_cascade_name :: attempted_cascades)
                                   in
@@ -1756,110 +1748,49 @@ let run_keeper_cycle
                                  ~attempt:(attempt + 1)
                                  ~is_retry:true
                                  ~allow_degraded_wall_clock_retry_budget:false
-                                 ~overflow_retry_used
                                  ~attempted_cascades
                              | No_degraded_retry when EC.is_context_overflow err ->
                                let current_turn_event_bus =
                                  drain_turn_event_bus ~site:"context_overflow_capture" ()
                                in
-                               dispatch_keeper_phase_event
-                                 ~config
-                                 ~keeper_name:meta.name
-                                 (context_overflow_event_of_error
-                                    ~fallback_tokens:execution.max_context
-                                    ~turn_event_bus:current_turn_event_bus
-                                    err);
-                               if not overflow_retry_used
-                               then (
-                                 match
-                                   recover_context_overflow_retry
-                                     ~meta:run_meta
-                                     ~base_dir
-                                     ~max_cascade_context:execution.max_context
-                                     ~error:err
-                                 with
-                                 | Some retry_plan ->
-                                   Keeper_registry.set_turn_phase
-                                     ~base_path:config.base_path
-                                     meta.name
-                                     Keeper_registry.(Packed Turn_compacting);
-                                   (* SDK boundary classification: [EC.is_context_overflow err]
-                           was already true above, so the typed klass is fixed.
-                           Stamp the typed [blocker_info] so downstream consumers
-                           (rollover gate) reason over [klass] instead of
-                           substring-matching the [detail] field — keeper layer
-                           treats provider/model as opaque aliases. *)
-                                   current_turn_blocker_info
-                                   := Some
-                                        { klass = Sdk_token_budget_exceeded
-                                        ; detail = Agent_sdk.Error.to_string err
-                                        };
-                                   dispatch_keeper_phase_event
-                                     ~config
-                                     ~keeper_name:meta.name
-                                     Keeper_state_machine.Compaction_started;
-                                   Prometheus.inc_counter
-                                     Keeper_metrics.metric_keeper_fsm_edge_transitions
-                                     ~labels:[ "edge", "kmc_to_ksm_compact_completed" ]
-                                     ();
-                                   dispatch_keeper_phase_event
-                                     ~config
-                                     ~keeper_name:meta.name
-                                     (Keeper_state_machine.Compaction_completed
-                                        { before_tokens =
-                                            retry_plan.compaction.before_tokens
-                                        ; after_tokens =
-                                            retry_plan.compaction.after_tokens
-                                        });
-                                   Keeper_registry.prepare_turn_retry_after_compaction
-                                     ~base_path:config.base_path
-                                     meta.name;
-                                   let retry_meta =
-                                     if
-                                       retry_plan.retry_generation
-                                       = run_meta.runtime.generation
-                                     then run_meta
-                                     else
-                                       map_runtime
-                                         (fun rt ->
-                                            { rt with
-                                              generation = retry_plan.retry_generation
-                                            })
-                                         run_meta
-                                   in
-                                   let retry_execution =
-                                     { execution with
-                                       max_context = retry_plan.retry_max_context
-                                     }
-                                   in
-                                   Eio.Fiber.yield ();
-                                   retry_loop
-                                     ~run_meta:retry_meta
-                                     ~execution:retry_execution
-                                     ~run_generation:retry_plan.retry_generation
-                                     ~attempt:1
-                                     ~is_retry:true
-                                     ~allow_degraded_wall_clock_retry_budget:false
-                                     ~overflow_retry_used:true
-                                     ~attempted_cascades
-                                 | None ->
-                                   mark_paused_after_overflow
-                                     ~run_meta
-                                     ~reason:"auto_compact_recovery_unavailable";
-                                   Keeper_registry.set_turn_phase
-                                     ~base_path:config.base_path
-                                     meta.name
-                                     Keeper_registry.(Packed Turn_finalizing);
-                                   Error err)
-                               else (
-                                 mark_paused_after_overflow
-                                   ~run_meta
-                                   ~reason:"overflow_persisted_after_auto_compact_retry";
-                                 Keeper_registry.set_turn_phase
-                                   ~base_path:config.base_path
-                                   meta.name
-                                   Keeper_registry.(Packed Turn_finalizing);
-                                 Error err)
+                               let overflow_event =
+                                 context_overflow_event_of_error
+                                   ~fallback_tokens:execution.max_context
+                                   ~turn_event_bus:current_turn_event_bus
+                                   err
+                               in
+                               (* OAS owns transcript mutation, emergency compaction,
+                                  and context-overflow retry for the agent run. If
+                                  overflow is still returned here, MASC records the
+                                  typed blocker and lets the normal terminal
+                                  receipt/finalizing path carry the failure; it must
+                                  not compact checkpoints or re-dispatch the agent
+                                  turn from the keeper layer. *)
+                               current_turn_blocker_info
+                               := Some
+                                    { klass = Sdk_token_budget_exceeded
+                                    ; detail =
+                                        Keeper_state_machine.event_to_string
+                                          overflow_event
+                                        ^ ": "
+                                        ^ Agent_sdk.Error.to_string err
+                                    };
+                               Prometheus.inc_counter
+                                 Keeper_metrics.metric_keeper_oas_execution_errors
+                                 ~labels:
+                                   [ "keeper", meta.name
+                                   ; "phase",
+                                     Oas_execution_error_phase.(
+                                       to_label Context_overflow_after_oas_retry)
+                                   ]
+                                 ();
+                               Log.Keeper.warn
+                                 "%s: OAS returned context overflow after its owned retry \
+                                  path; MASC will not compact/retry at keeper layer: %s"
+                                 meta.name
+                                 (short_preview (Agent_sdk.Error.to_string err));
+                               mark_terminal_error err;
+                               Error err
                              | No_degraded_retry ->
                                mark_terminal_error err;
                                Error err)
@@ -1876,7 +1807,6 @@ let run_keeper_cycle
                               ~attempt:1
                               ~is_retry:false
                               ~allow_degraded_wall_clock_retry_budget:false
-                              ~overflow_retry_used:false
                               ~attempted_cascades:
                                 [ KCP.runtime_name_to_string
                                     initial_execution.cascade_name

--- a/lib/keeper/oas_execution_error_phase.ml
+++ b/lib/keeper/oas_execution_error_phase.ml
@@ -7,6 +7,7 @@ type t =
   | Persistent_escalation
   | Resilience_audit_store
   | Overflow_retry_oas_load
+  | Context_overflow_after_oas_retry
 
 let to_label = function
   | Turn_start -> "turn_start"
@@ -17,4 +18,5 @@ let to_label = function
   | Persistent_escalation -> "persistent_escalation"
   | Resilience_audit_store -> "resilience_audit_store"
   | Overflow_retry_oas_load -> "overflow_retry_oas_load"
+  | Context_overflow_after_oas_retry -> "context_overflow_after_oas_retry"
 ;;

--- a/lib/keeper/oas_execution_error_phase.mli
+++ b/lib/keeper/oas_execution_error_phase.mli
@@ -1,12 +1,12 @@
 (** Oas_execution_error_phase — closed sum for the [phase] label on
     two keeper-side metrics:
 
-    - [metric_keeper_oas_execution_errors] (7 phases from
+    - [metric_keeper_oas_execution_errors] (8 phases from
       [keeper_unified_turn], [keeper_turn_cascade_budget],
       [keeper_post_turn])
     - [metric_keeper_write_meta_failures] ([turn_start])
 
-    Replaces 8 hardcoded string literals scattered across 3 files.
+    Replaces hardcoded string literals scattered across 3 files.
     The compiler enforces exhaustive coverage in [to_label] (a missing
     constructor is a compile error there) so adding a new phase
     requires a single edit here and the new wire string surfaces
@@ -21,5 +21,6 @@ type t =
   | Persistent_escalation
   | Resilience_audit_store
   | Overflow_retry_oas_load
+  | Context_overflow_after_oas_retry
 
 val to_label : t -> string

--- a/test/test_approval_callback_wired.ml
+++ b/test/test_approval_callback_wired.ml
@@ -200,13 +200,13 @@ let test_run_named_sites_pass_approval () =
         true (file_matches path "~approval:"))
     run_named_sites
 
-let test_keeper_dispatch_disables_oas_overflow_retry () =
+let test_keeper_dispatch_enables_oas_overflow_retry () =
   let root = repo_root () in
   let rel_path = "lib/keeper/keeper_agent_run.ml" in
   let path = Filename.concat root rel_path in
   let source = read_file path in
   let marker = "Keeper_turn_driver.run_named" in
-  let flag = "~oas_auto_context_overflow_retry:false" in
+  let flag = "~oas_auto_context_overflow_retry:true" in
   let rec search pos =
     try
       let idx = Str.search_forward (Str.regexp_string marker) source pos in
@@ -224,7 +224,7 @@ let test_keeper_dispatch_disables_oas_overflow_retry () =
   in
   Alcotest.(check bool)
     (Printf.sprintf
-       "%s: keeper dispatch must keep OAS overflow auto-retry disabled"
+       "%s: keeper dispatch must keep OAS overflow auto-retry enabled"
        rel_path)
     true (search 0)
 
@@ -249,7 +249,7 @@ let () =
           Alcotest.test_case "run_named call sites pass ~approval"
             `Quick test_run_named_sites_pass_approval;
           Alcotest.test_case
-            "keeper dispatch disables OAS overflow auto-retry"
-            `Quick test_keeper_dispatch_disables_oas_overflow_retry;
+            "keeper dispatch enables OAS overflow auto-retry"
+            `Quick test_keeper_dispatch_enables_oas_overflow_retry;
         ] );
     ]

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -11,6 +11,17 @@
 module KMP = Masc_mcp.Keeper_memory_policy
 module KCC = Masc_mcp.Keeper_context_core
 
+let contains_substring text needle =
+  let text_len = String.length text in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    if needle_len = 0 then true
+    else if idx + needle_len > text_len then false
+    else if String.sub text idx needle_len = needle then true
+    else loop (idx + 1)
+  in
+  loop 0
+
 (* ── Round-trip tests ────────────────────────────────────────────── *)
 
 let make_snapshot
@@ -162,6 +173,54 @@ let test_patch_stores_replay_metadata_and_clears_working_context () =
            Alcotest.(check (option string)) "goal from metadata" (Some "Fix CI") snap.goal;
            Alcotest.(check (option string)) "done from metadata" (Some "All green") snap.done_summary)
 
+let test_patch_drops_legacy_state_working_context_sidecar () =
+  let legacy_sidecar =
+    KMP.structured_working_context_of_snapshot
+      (make_snapshot
+         ~goal:(Some "stale sidecar")
+         ~progress:None
+         ~done_summary:None
+         ~next_summary:None
+         ~next_items:[]
+         ~decisions:[]
+         ~open_questions:[]
+         ~constraints:[]
+         ())
+  in
+  let response_text =
+    "New answer.\n[STATE]\nGoal: fresh metadata\nDONE: Stored in metadata\n[/STATE]"
+  in
+  let cp =
+    make_test_checkpoint
+      ~working_context:(Some legacy_sidecar)
+      ~response_text
+      ()
+  in
+  let patched =
+    KCC.patch_checkpoint_last_assistant cp
+      ~session_id:"new-session"
+      ~response_text
+  in
+  Alcotest.(check bool)
+    "legacy state sidecar cleared from working_context"
+    true
+    (patched.working_context = None);
+  match List.rev patched.messages with
+  | [] -> Alcotest.fail "patched checkpoint has no messages"
+  | last :: _ ->
+      let text = Agent_sdk.Types.text_of_message last in
+      Alcotest.(check bool)
+        "visible checkpoint text is state-free"
+        false
+        (contains_substring text "[STATE]");
+      (match KMP.snapshot_of_message_metadata last with
+       | None -> Alcotest.fail "assistant message metadata missing replay snapshot"
+       | Some snap ->
+           Alcotest.(check (option string))
+             "fresh metadata wins"
+             (Some "fresh metadata")
+             snap.goal)
+
 let test_patch_without_state_block_keeps_text_and_no_metadata () =
   let response_text = "I did some work but no state block." in
   let cp = make_test_checkpoint ~response_text () in
@@ -223,6 +282,7 @@ let () =
       ( "patch_checkpoint",
         [
           Alcotest.test_case "stores replay metadata and clears wc" `Quick test_patch_stores_replay_metadata_and_clears_working_context;
+          Alcotest.test_case "drops legacy state sidecar from wc" `Quick test_patch_drops_legacy_state_working_context_sidecar;
           Alcotest.test_case "no [STATE] keeps text and no metadata" `Quick test_patch_without_state_block_keeps_text_and_no_metadata;
         ] );
       ( "dual_source",

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -1,4 +1,4 @@
-(** Property-based tests for context overflow detection and recovery.
+(** Property-based tests for context overflow detection and boundary handling.
 
     Verifies structural invariants of the compaction-budget fix:
 
@@ -10,19 +10,19 @@
       is_context_overflow(TokenBudgetExceeded {kind≠"Input"}) = false
       for ALL non-"Input" kind strings.
 
-    Property 3 (Recovery consistency):
-      Every error accepted by is_context_overflow yields a positive
-      limit from the recovery path.
+    Property 3 (Limit attribution):
+      Every error accepted by is_context_overflow has a positive
+      structured or fallback limit for blocker attribution.
 
     Property 4 (Structural absence):
       keeper_agent_run source does NOT contain ~max_input_tokens.
 
     Property 5 (Reducer integration):
-      keeper_agent_run source contains cap_message_tokens in the
+      keeper_run_tools source contains cap_message_tokens in the
       keeper reducer chain, ordered before repair_dangling_tool_calls.
 
     Property 6 (Reducer hardening):
-      keeper_agent_run source contains the keeper-local
+      keeper_run_tools source contains the keeper-local
       repair_broken_tool_call_pairs reducer after repair_dangling_tool_calls. *)
 
 module UT = Masc_mcp.Keeper_unified_turn
@@ -83,9 +83,9 @@ let prop_non_input_budget_never_detected =
     (QCheck.make gen_non_input_budget_error)
     (fun err -> not (EC.is_context_overflow err))
 
-let prop_recovery_yields_positive_limit =
+let prop_overflow_attribution_yields_positive_limit =
   QCheck.Test.make ~count:200
-    ~name:"every overflow error yields positive limit in recovery"
+    ~name:"every overflow error yields positive limit for attribution"
     (QCheck.make gen_context_overflow_error)
     (fun err ->
       let limit = match err with
@@ -164,7 +164,7 @@ let test_cap_message_tokens_integration () =
         in
         ascend (Sys.getcwd ())
   in
-  let target = Filename.concat repo_root "lib/keeper/keeper_agent_run.ml" in
+  let target = Filename.concat repo_root "lib/keeper/keeper_run_tools.ml" in
   if not (Sys.file_exists target) then
     ()
   else begin
@@ -184,7 +184,7 @@ let test_cap_message_tokens_integration () =
       find_substring content "Agent_sdk.Context_reducer.repair_dangling_tool_calls"
     in
     Alcotest.(check bool)
-      "keeper_agent_run.ml must integrate cap_message_tokens before repair_dangling_tool_calls"
+      "keeper_run_tools.ml must integrate cap_message_tokens before repair_dangling_tool_calls"
       true
       (match cap_pos, repair_pos with
        | Some cap_pos, Some repair_pos -> cap_pos < repair_pos
@@ -217,7 +217,7 @@ let test_pair_repair_integration () =
         in
         ascend (Sys.getcwd ())
   in
-  let target = Filename.concat repo_root "lib/keeper/keeper_agent_run.ml" in
+  let target = Filename.concat repo_root "lib/keeper/keeper_run_tools.ml" in
   if not (Sys.file_exists target) then
     ()
   else begin
@@ -241,7 +241,7 @@ let test_pair_repair_integration () =
       | None -> None
     in
     Alcotest.(check bool)
-      "keeper_agent_run.ml must integrate local pair repair after repair_dangling_tool_calls"
+      "keeper_run_tools.ml must integrate local pair repair after repair_dangling_tool_calls"
       true
       (match repair_pos, local_pos with
        | Some repair_pos, Some local_pos -> repair_pos < local_pos
@@ -259,15 +259,9 @@ let test_pair_repair_integration () =
          | Agent (TokenBudgetExceeded { kind = "Input"; _ }) -> true
          | _ -> false *)
 
-   val recover_context_overflow_retry :
-     meta:keeper_meta -> base_dir:string ->
-     max_cascade_context:int -> error:Error.sdk_error ->
-     overflow_retry_plan option
-   (*@ plan = recover_context_overflow_retry ~meta ~base_dir ~max_cascade_context ~error
-       requires is_context_overflow error
-       ensures match plan with
-         | Some p -> p.retry_max_context > 0
-         | None -> true *)
+   Keeper turns leave compact+retry to OAS. MASC may classify a structured
+   overflow as a typed blocker, but it must not recover an OAS checkpoint and
+   re-dispatch the same agent turn from the keeper layer.
 *)
 
 (* ── Runner ──────────────────────────────────────────────── *)
@@ -277,7 +271,7 @@ let () =
     List.map QCheck_alcotest.to_alcotest [
       prop_input_budget_always_detected;
       prop_non_input_budget_never_detected;
-      prop_recovery_yields_positive_limit;
+      prop_overflow_attribution_yields_positive_limit;
     ]
   in
   Alcotest.run "pbt_context_overflow" [


### PR DESCRIPTION
## Summary

- Keep keeper dispatch on OAS-owned context overflow retry by passing `~oas_auto_context_overflow_retry:true`.
- Remove the MASC keeper-layer overflow checkpoint compact/retry budget path and replace final overflow handling with typed blocker attribution plus an OAS execution error phase.
- Update the OAS/MASC boundary contract to reflect current ownership, including checkpoint `working_context` sidecar debt.
- Add regression coverage that legacy state `working_context` sidecars are cleared from new checkpoint patches while replay metadata remains on the assistant message.

## Why

OAS owns transcript mutation, emergency compaction, and the retry mechanics for context overflow. MASC should attribute the final failure to keeper/operator surfaces if OAS still returns a structured overflow, but it should not compact the checkpoint and re-dispatch the same keeper turn from the MASC layer.

## Validation

- `scripts/dune-local.sh build test/test_approval_callback_wired.exe test/test_pbt_context_overflow.exe test/test_keeper_state_snapshot_json.exe test/test_keeper_runtime_manifest.exe`
- `./_build/default/test/test_approval_callback_wired.exe`
- `./_build/default/test/test_pbt_context_overflow.exe`
- `./_build/default/test/test_keeper_state_snapshot_json.exe`
- `./_build/default/test/test_keeper_runtime_manifest.exe`
- `git diff --check origin/main..HEAD`

## Review focus

- Confirm the keeper hot path no longer has a MASC-owned context overflow retry path.
- Confirm final overflow attribution still reaches metrics/blocker/operator surfaces.
- Confirm the boundary doc wording matches the implementation and does not overclaim that all `working_context` sidecars are gone.