### PR TITLE
feat(ide): focus planning routes from context links

### DIFF
--- a/dashboard/src/components/planning-panel.test.ts
+++ b/dashboard/src/components/planning-panel.test.ts
@@ -1,7 +1,9 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const openTaskDetailMock = vi.hoisted(() => vi.fn())
 
 const routeSignal = signal<{ tab: string; params: Record<string, string>; postId: string | null }>({
   tab: 'workspace',
@@ -35,6 +37,9 @@ vi.mock('./goals', () => ({
 vi.mock('./goals/goal-tree', () => ({
   GoalTree: () => html`<div data-testid="goal-tree">GoalTree</div>`,
 }))
+vi.mock('./goals/task-detail-state', () => ({
+  openTaskDetail: openTaskDetailMock,
+}))
 
 import { PlanningPanel } from './planning-panel'
 
@@ -51,6 +56,7 @@ describe('PlanningPanel', () => {
     coordinationSignal.value = null
     tasksSignal.value = []
     goalsSignal.value = []
+    openTaskDetailMock.mockReset()
   })
   afterEach(() => cleanup())
 
@@ -152,6 +158,101 @@ describe('PlanningPanel', () => {
     expect(screen.getByText('오래된 태스크 점유')).toBeTruthy()
     expect(screen.getByText('Review blocked planning handoff')).toBeTruthy()
     expect(screen.getByText('@sangsu')).toBeTruthy()
+  })
+
+  it('renders route focus for goal route params', () => {
+    routeSignal.value = {
+      tab: 'workspace',
+      params: { section: 'planning', goal: 'goal-runtime' },
+      postId: null,
+    }
+    goalsSignal.value = [
+      {
+        id: 'goal-runtime',
+        horizon: 'short',
+        title: 'Runtime context goal',
+        priority: 1,
+        status: 'active',
+        phase: 'execute',
+        created_at: '2026-05-14T00:00:00Z',
+        updated_at: '2026-05-14T00:00:00Z',
+      },
+    ]
+
+    render(html`<${PlanningPanel} />`)
+
+    expect(screen.getByTestId('planning-route-focus')).toBeTruthy()
+    expect(screen.getByText('goal goal-runtime')).toBeTruthy()
+    expect(screen.getByText('Runtime context goal')).toBeTruthy()
+    expect(screen.getByText('active')).toBeTruthy()
+  })
+
+  it('opens task detail for task route params', async () => {
+    const task = {
+      id: 'task-runtime',
+      title: 'Runtime context task',
+      status: 'claimed',
+      assignee: 'sangsu',
+      goal_id: 'goal-runtime',
+      updated_at: '2026-05-14T00:00:00Z',
+    }
+    routeSignal.value = {
+      tab: 'workspace',
+      params: { section: 'planning', view: 'default', task: 'task-runtime' },
+      postId: null,
+    }
+    tasksSignal.value = [task]
+
+    render(html`<${PlanningPanel} />`)
+
+    expect(screen.getByTestId('planning-route-focus')).toBeTruthy()
+    expect(screen.getByText('task task-runtime')).toBeTruthy()
+    expect(screen.getByText('Runtime context task')).toBeTruthy()
+    expect(screen.getByText('@sangsu')).toBeTruthy()
+    await waitFor(() => {
+      expect(openTaskDetailMock).toHaveBeenCalledWith(task)
+    })
+  })
+
+  it('clears goal and task route focus while preserving other planning params', () => {
+    routeSignal.value = {
+      tab: 'workspace',
+      params: {
+        section: 'planning',
+        view: 'default',
+        focus: 'accountability-ledger',
+        goal: 'goal-runtime',
+        task: 'task-runtime',
+      },
+      postId: null,
+    }
+
+    render(html`<${PlanningPanel} />`)
+    fireEvent.click(screen.getByRole('button', { name: 'clear' }))
+
+    expect(routeSignal.value.params).toEqual({
+      section: 'planning',
+      view: 'default',
+      focus: 'accountability-ledger',
+    })
+  })
+
+  it('preserves route focus params when switching planning views', () => {
+    routeSignal.value = {
+      tab: 'workspace',
+      params: { section: 'planning', goal: 'goal-runtime', task: 'task-runtime' },
+      postId: null,
+    }
+
+    render(html`<${PlanningPanel} />`)
+    fireEvent.click(screen.getByRole('tab', { name: '백로그' }))
+
+    expect(routeSignal.value.params).toEqual({
+      section: 'planning',
+      goal: 'goal-runtime',
+      task: 'task-runtime',
+      view: 'default',
+    })
   })
 
   it('renders accountability ledger focus from route param', () => {

--- a/dashboard/src/components/planning-panel.ts
+++ b/dashboard/src/components/planning-panel.ts
@@ -5,12 +5,14 @@
 
 import { html } from 'htm/preact'
 import { computed } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
 import { replaceRoute, route } from '../router'
-import { coordinationFsmSnapshot } from '../store'
+import { coordinationFsmSnapshot, goals, tasks } from '../store'
 import { FilterChips } from './common/filter-chips'
 import { Planning } from './goals'
 import { GoalTree } from './goals/goal-tree'
 import { PlanningFocusPanel } from './planning-focus-panel'
+import { openTaskDetail } from './goals/task-detail-state'
 import type {
   DashboardCoordinationFsmEvidence,
   DashboardCoordinationFsmRefs,
@@ -37,12 +39,13 @@ const VIEW_CHIPS: Array<{ key: PlanningView; label: string }> = [
 ]
 
 function updateViewParam(view: PlanningView): void {
-  replaceRoute(
-    'workspace',
-    view === 'goal-tree'
-      ? { section: 'planning' }
-      : { section: 'planning', view },
-  )
+  const params: Record<string, string> = { ...route.value.params, section: 'planning' }
+  if (view === 'goal-tree') {
+    delete params.view
+  } else {
+    params.view = view
+  }
+  replaceRoute('workspace', params)
 }
 
 function coordinationCount(
@@ -81,6 +84,75 @@ function evidenceLabel(evidence: DashboardCoordinationFsmEvidence): string {
   const source = evidence.source ?? 'evidence'
   const kind = evidence.kind ? `/${evidence.kind}` : ''
   return `${source}${kind}`
+}
+
+function cleanRouteFocusId(value: string | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed && trimmed.length > 0 ? trimmed : null
+}
+
+function clearPlanningRouteFocus(): void {
+  const params: Record<string, string> = { ...route.value.params, section: 'planning' }
+  delete params.goal
+  delete params.task
+  replaceRoute('workspace', params)
+}
+
+function PlanningRouteFocusPanel() {
+  const params = route.value.params as Record<string, string | undefined>
+  const goalId = cleanRouteFocusId(params.goal)
+  const taskId = cleanRouteFocusId(params.task)
+  const goal = goalId ? goals.value.find(item => item.id === goalId) ?? null : null
+  const task = taskId ? tasks.value.find(item => item.id === taskId) ?? null : null
+
+  useEffect(() => {
+    if (task) openTaskDetail(task)
+  }, [task])
+
+  if (!goalId && !taskId) return null
+
+  return html`
+    <section
+      class="rounded-[var(--r-1)] border border-[var(--color-brass-border)] bg-[var(--color-brass-soft)] px-3 py-2"
+      data-testid="planning-route-focus"
+      aria-label="Planning route focus"
+    >
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div class="min-w-0">
+          <div class="font-mono text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-accent-fg)]">
+            route focus
+          </div>
+          <div class="mt-1 flex min-w-0 flex-wrap items-center gap-2 text-xs text-text-body">
+            ${goalId ? html`
+              <span class="rounded-[var(--r-1)] border border-[var(--color-brass-border)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-[var(--color-accent-fg)]">
+                goal ${goalId}
+              </span>
+              <span class="min-w-0 truncate text-sm font-semibold text-text-strong">
+                ${goal?.title ?? 'goal not loaded'}
+              </span>
+              ${goal?.status ? html`<span class="font-mono text-3xs text-text-muted">${goal.status}</span>` : null}
+            ` : null}
+            ${taskId ? html`
+              <span class="rounded-[var(--r-1)] border border-[var(--color-brass-border)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-[var(--color-accent-fg)]">
+                task ${taskId}
+              </span>
+              <span class="min-w-0 truncate text-sm font-semibold text-text-strong">
+                ${task?.title ?? 'task not loaded'}
+              </span>
+              ${task?.assignee ? html`<span class="font-mono text-3xs text-text-muted">@${task.assignee}</span>` : null}
+            ` : null}
+          </div>
+        </div>
+        <button
+          type="button"
+          class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-text-muted transition-colors hover:border-[var(--color-border-strong)] hover:text-text-strong"
+          onClick=${clearPlanningRouteFocus}
+        >
+          clear
+        </button>
+      </div>
+    </section>
+  `
 }
 
 function CoordinationEvidenceRow({ evidence }: { evidence: DashboardCoordinationFsmEvidence }) {
@@ -198,6 +270,7 @@ export function PlanningPanel() {
         size="sm"
         tone="accent"
       />
+      <${PlanningRouteFocusPanel} />
       <${CoordinationHealthPanel} />
       <${PlanningFocusPanel} />
       ${view === 'goal-tree'


### PR DESCRIPTION
## Summary
- show Goal/Task route params as a planning route-focus receipt
- open the existing task detail overlay when an IDE context link routes to a task
- preserve route-focus params across planning view switches and add a clear action

## Verification
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/planning-panel.ts
- pnpm exec tsc --noEmit --pretty false
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/planning-panel.test.ts
- git diff --check

Follow-up for the merged #15035 IDE context lens review/route polish.