### PR TITLE
fix(test): replace unportable Unix.unsetenv with masc_test_unsetenv stub

### DIFF
--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -38,6 +38,12 @@ let write_file path content =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
 
+(* OCaml's stdlib Unix module does not expose [unsetenv] portably (see e.g.
+   test_keeper_toml.ml). The masc_test_deps library carries a C stub that
+   calls the libc [unsetenv], so we use that here to keep Sys.getenv_opt
+   checks distinguishable between "previously unset" and "set but empty". *)
+external test_unsetenv : string -> unit = "masc_test_unsetenv"
+
 let with_env name value f =
   let previous = Sys.getenv_opt name in
   Unix.putenv name value;
@@ -45,10 +51,7 @@ let with_env name value f =
     ~finally:(fun () ->
       match previous with
       | Some v -> Unix.putenv name v
-      (* Unix.putenv name "" would leave [name] present-but-empty, so
-         Sys.getenv_opt checks that distinguish unset from empty would
-         see a different shape than before with_env ran. *)
-      | None -> Unix.unsetenv name)
+      | None -> test_unsetenv name)
     f
 
 let with_temp_cascade_config toml f =


### PR DESCRIPTION
## Why

PR #15049 landed a `with_env` helper in `test/test_cascade_declarative_hotpath.ml` that restores a previously-unset variable via `Unix.unsetenv name`. The stdlib `Unix` module does not expose that across the platforms this repo targets — `dune build` on main currently fails:

\`\`\`
File "test/test_cascade_declarative_hotpath.ml", line 51, characters 16-29:
51 |       | None -> Unix.unsetenv name)
                     ^^^^^^^^^^^^^
Error: Unbound value Unix.unsetenv
\`\`\`

## What

The repo convention (see `test/deps/test_env_stubs.c` + `external unsetenv` declarations in `test_board_moderation.ml`, `test_cascade_attempt_liveness_config.ml`, `test_keeper_github_pr.ml`, etc., plus the explicit note in `test_keeper_toml.ml`) is the `masc_test_unsetenv` C stub re-exported by the `masc_test_deps` library. That stanza already links `masc_test_deps`, so we just declare the external and use it.

This keeps the original Copilot-review semantics (truly unset, distinguishable from `Sys.getenv_opt = Some ""`) without breaking the build.

## Verification

- `dune build` (local) clears the build break.
- Behavior: when `previous = None`, the C stub calls libc `unsetenv` so `Sys.getenv_opt name` is `None` after the test, matching the pre-test shape.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>