### PR TITLE
fix(test): replace Unix.unsetenv with masc_test_unsetenv C stub

### DIFF
--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -17,6 +17,12 @@ module Adapter = Masc_mcp.Cascade_declarative_adapter
 module Hotpath = Masc_mcp.Cascade_declarative_hotpath
 module Cascade_strategy = Masc_mcp.Cascade_strategy
 
+(* OCaml stdlib's Unix module does not expose [unsetenv] in 5.4.1; use the
+   shared C stub wired through [masc_test_deps] (test/deps/test_env_stubs.c),
+   following the existing pattern in test_board_moderation.ml and
+   test_cascade_attempt_liveness_config.ml. *)
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
 (* --- Helpers --- *)
 
 let adapt_toml (toml : string) : Adapter.adapted_catalog =
@@ -48,7 +54,7 @@ let with_env name value f =
       (* Unix.putenv name "" would leave [name] present-but-empty, so
          Sys.getenv_opt checks that distinguish unset from empty would
          see a different shape than before with_env ran. *)
-      | None -> Unix.unsetenv name)
+      | None -> unsetenv name)
     f
 
 let with_temp_cascade_config toml f =


### PR DESCRIPTION
## Summary

`test_cascade_declarative_hotpath` 가 main 에서 빌드 실패. \`Unix.unsetenv\` 가 OCaml 5.4.1 stdlib Unix 모듈에 존재하지 않음.

```
File "test/test_cascade_declarative_hotpath.ml", line 51, characters 16-29:
51 |       | None -> Unix.unsetenv name)
                     ^^^^^^^^^^^^^
Error: Unbound value Unix.unsetenv
Hint:   Did you mean Unix.getenv?
```

도입: #15049 (`fix(cascade): keep declarative provider configs on runtime path`).

## Fix

코드베이스에 이미 canonical 패턴 있음:
- C stub: \`test/deps/test_env_stubs.c\` 의 \`masc_test_unsetenv\`
- Library wiring: \`masc_test_deps\` (\`foreign_stubs (names test_env_stubs)\`)
- 기존 사용 사례: \`test_board_moderation.ml:18\`, \`test_cascade_attempt_liveness_config.ml:13\`

해당 파일에 동일 패턴 적용:
```ocaml
external unsetenv : string -> unit = "masc_test_unsetenv"
...
| None -> unsetenv name  (* was: Unix.unsetenv name *)
```

새 패턴 도입 아닌 *기존 패턴 누락 보강*.

## 로컬 검증

```
$ dune build test/test_cascade_declarative_hotpath.exe
(clean, no output)
$ _build/default/test/test_cascade_declarative_hotpath.exe
... 14 tests, all OK in 0.011s
```

## CI 가 놓친 이유

`Detect Changed Surfaces` gate 가 #15049 의 `Build and Test` job 을 SKIPPED 처리. 알려진 CI gap (MEMORY.md `reference_masc_mcp_ci_build_test_skips` — keeper_registry.ml 변경 PR 에서도 동일 패턴 관찰됨). 로컬 빌드도 dune-local lock contention 으로 우회됐을 가능성 (`reference_masc_mcp_dune_local_lock_contention`).

이번 PR 후속으로 *test target 빌드를 \`Detect Changed Surfaces\` gate 와 무관하게 항상 실행* 하는 별도 CI 개선 RFC 가 필요할 수 있음 (out-of-scope).

## Test plan

- [x] 로컬 \`dune build\` 통과
- [x] 로컬 \`test_cascade_declarative_hotpath.exe\` 14/14 통과
- [ ] CI \`Build and Test\` (이 PR 자체가 test 파일을 건드리므로 gate 통과 기대)
- [ ] ocamlformat-check 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 머지 우선순위

**이 PR 최우선 머지** — main 의 `test/test_cascade_declarative_hotpath.exe` 빌드가 *현재* 깨져 있음. 다른 PR 들이 이 fix 머지 후 rebase 필요할 수 있음:

- #15051 (tool-policy fix) — 같은 main 위에 rebase 됨, 머지 시 build verification 신뢰성 회복
- #15054 (RFC-0073 doc) — doc only, 영향 적음
- (이 PR 머지 전까지 어느 PR 도 \`Build and Test\` 신호 신뢰 불가)

머지 후 main 빌드 복구 확인 권장: `dune build test/test_cascade_declarative_hotpath.exe`.

