### PR TITLE
feat(ide): focus git graph routes from context links

### DIFF
--- a/dashboard/src/components/git-graph-panel.test.ts
+++ b/dashboard/src/components/git-graph-panel.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import { h, type ComponentChildren } from 'preact'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
+import { signal } from '@preact/signals'
+
+const routeSignal = signal<{ tab: string; params: Record<string, string>; postId: string | null }>({
+  tab: 'workspace',
+  params: { section: 'repositories', view: 'graph' },
+  postId: null,
+})
 
 vi.mock('./git-graph-store', () => {
   const mockState = { value: { data: null, loading: false, error: null } }
@@ -14,6 +21,19 @@ vi.mock('./git-graph-store', () => {
 
 vi.mock('./git-graph-view', () => ({
   GitGraphView: () => h('div', { 'data-testid': 'git-graph-view' }, 'GitGraphView'),
+  findGitGraphRefMatches: (
+    graph: GitGraphResponse,
+    focusRef: string | null | undefined,
+  ) => {
+    const normalized = focusRef?.trim().toLowerCase()
+    if (!normalized) return []
+    return graph.nodes.filter(node => {
+      const sha = node.sha?.trim().toLowerCase()
+      if (sha && (sha === normalized || sha.startsWith(normalized))) return true
+      return [node.branch, node.label, node.detail]
+        .some(value => value?.trim().toLowerCase() === normalized)
+    })
+  },
 }))
 
 vi.mock('../api/repositories', () => ({
@@ -45,6 +65,13 @@ vi.mock('../api/repositories', () => ({
       updated_at: null,
     },
   ])),
+}))
+
+vi.mock('../router', () => ({
+  get route() { return routeSignal },
+  replaceRoute: vi.fn((tab: string, params?: Record<string, string>) => {
+    routeSignal.value = { tab, params: params ?? {}, postId: null }
+  }),
 }))
 
 vi.mock('./common/feedback-state', () => ({
@@ -116,6 +143,11 @@ describe('GitGraphPanel', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     gitGraphResource.state.value = { data: null, loading: false, error: null }
+    routeSignal.value = {
+      tab: 'workspace',
+      params: { section: 'repositories', view: 'graph' },
+      postId: null,
+    }
     vi.clearAllMocks()
   })
 
@@ -250,6 +282,98 @@ describe('GitGraphPanel', () => {
     expect(container.querySelector('[data-testid="git-graph-context-strip"]')).not.toBeNull()
     expect(container.textContent).toContain('Current checkout')
     expect(container.textContent).toContain('main')
+  })
+
+  it('renders git ref route focus with matched graph nodes', () => {
+    gitGraphResource.state.value = {
+      data: makeGraph({
+        repos: [makeRepo()],
+        nodes: [
+          {
+            id: 'commit-1',
+            kind: 'commit',
+            label: 'commit abcdef1234',
+            repo_id: 'repo-1',
+            agent_id: null,
+            color: null,
+            status: 'current',
+            conflict: false,
+            sha: 'abcdef1234567890',
+            branch: null,
+            detail: null,
+          },
+        ],
+        stats: { repo_count: 1, agent_count: 0, branch_count: 0, commit_count: 1, dirty_count: 0, conflict_count: 0 },
+        warnings: [],
+        generated_at: '',
+      }),
+      loading: false,
+      error: null,
+    }
+    routeSignal.value = {
+      tab: 'workspace',
+      params: { section: 'repositories', view: 'graph', ref: 'abcdef' },
+      postId: null,
+    }
+
+    render(h(GitGraphPanel, null), container)
+
+    expect(container.querySelector('[data-testid="git-graph-route-focus"]')).not.toBeNull()
+    expect(container.textContent).toContain('REF abcdef')
+    expect(container.textContent).toContain('1 node match')
+    expect(container.textContent).toContain('commit abcdef1234')
+    expect(container.textContent).toContain('abcdef1234')
+  })
+
+  it('renders PR route focus even when the graph has no PR node', () => {
+    gitGraphResource.state.value = {
+      data: makeGraph({
+        repos: [makeRepo()],
+        stats: { repo_count: 1, agent_count: 0, branch_count: 0, commit_count: 0, dirty_count: 0, conflict_count: 0 },
+        warnings: [],
+        generated_at: '',
+      }),
+      loading: false,
+      error: null,
+    }
+    routeSignal.value = {
+      tab: 'workspace',
+      params: { section: 'repositories', view: 'graph', pr: '15035' },
+      postId: null,
+    }
+
+    render(h(GitGraphPanel, null), container)
+
+    expect(container.querySelector('[data-testid="git-graph-route-focus"]')).not.toBeNull()
+    expect(container.textContent).toContain('PR 15035')
+    expect(container.textContent).toContain('route received')
+  })
+
+  it('clears PR and git ref route focus while preserving graph route params', () => {
+    gitGraphResource.state.value = {
+      data: makeGraph({
+        repos: [makeRepo()],
+        stats: { repo_count: 1, agent_count: 0, branch_count: 0, commit_count: 0, dirty_count: 0, conflict_count: 0 },
+        warnings: [],
+        generated_at: '',
+      }),
+      loading: false,
+      error: null,
+    }
+    routeSignal.value = {
+      tab: 'workspace',
+      params: { section: 'repositories', view: 'graph', pr: '15035', ref: 'abcdef' },
+      postId: null,
+    }
+
+    render(h(GitGraphPanel, null), container)
+    const clearButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      button => button.textContent?.includes('CLEAR'),
+    )
+    expect(clearButton).not.toBeUndefined()
+    clearButton!.click()
+
+    expect(routeSignal.value.params).toEqual({ section: 'repositories', view: 'graph' })
   })
 
   it('renders repository selector from configured repositories', async () => {

--- a/dashboard/src/components/git-graph-panel.ts
+++ b/dashboard/src/components/git-graph-panel.ts
@@ -4,10 +4,11 @@ import { GitBranch, RefreshCw } from 'lucide-preact'
 import { EmptyState, ErrorRecoverable, LoadingState } from './common/feedback-state'
 import { ActionButton } from './common/button'
 import { TimeAgo } from './common/time-ago'
-import { GitGraphView } from './git-graph-view'
+import { GitGraphView, findGitGraphRefMatches } from './git-graph-view'
 import { StatTile } from './common/stat-tile'
 import { fetchRepositoriesList, type Repository } from '../api/repositories'
 import type { GitGraphResponse } from '../api/git-graph'
+import { replaceRoute, route } from '../router'
 import {
   cancelGitGraphRefresh,
   gitGraphResource,
@@ -40,6 +41,22 @@ export interface GitGraphContextModel {
 function shortRef(value: string | null): string {
   if (!value) return 'unknown'
   return value.length > 10 ? value.slice(0, 10) : value
+}
+
+function cleanRouteFocusParam(value: string | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+function clearGitGraphRouteFocus(): void {
+  const params: Record<string, string> = {
+    ...route.value.params,
+    section: 'repositories',
+    view: 'graph',
+  }
+  delete params.pr
+  delete params.ref
+  replaceRoute('workspace', params)
 }
 
 export function compactGitGraphPath(path: string): string {
@@ -155,9 +172,74 @@ function GitGraphContextStrip({ model }: { readonly model: GitGraphContextModel 
   `
 }
 
+function GitGraphRouteFocusPanel({ graph }: { readonly graph: GitGraphResponse }) {
+  const params = route.value.params as Record<string, string | undefined>
+  const prId = cleanRouteFocusParam(params.pr)
+  const gitRef = cleanRouteFocusParam(params.ref)
+  if (!prId && !gitRef) return null
+
+  const matches = gitRef ? findGitGraphRefMatches(graph, gitRef).slice(0, 3) : []
+  const matchLabel = gitRef
+    ? matches.length > 0
+      ? `${matches.length} node match${matches.length === 1 ? '' : 'es'}`
+      : 'no graph node matched'
+    : null
+
+  return html`
+    <section
+      class="rounded-[var(--r-1)] border border-[var(--color-brass-border)] bg-[var(--color-brass-soft)] px-3 py-2"
+      data-testid="git-graph-route-focus"
+      aria-label="Git graph route focus"
+    >
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div class="min-w-0">
+          <div class="font-mono text-3xs font-semibold uppercase tracking-[var(--track-section)] text-[var(--color-accent-fg)]">
+            ROUTE FOCUS
+          </div>
+          <div class="mt-1 flex min-w-0 flex-wrap items-center gap-2 text-xs text-[var(--color-fg-secondary)]">
+            ${prId ? html`
+              <span class="rounded-[var(--r-0)] border border-[var(--color-brass-border)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-[var(--color-accent-fg)]">
+                PR ${prId}
+              </span>
+              <span class="text-2xs text-[var(--color-fg-muted)]">route received</span>
+            ` : null}
+            ${gitRef ? html`
+              <span class="rounded-[var(--r-0)] border border-[var(--color-brass-border)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-[var(--color-accent-fg)]">
+                REF ${gitRef}
+              </span>
+              <span class="font-mono text-3xs text-[var(--color-fg-muted)]">${matchLabel}</span>
+            ` : null}
+          </div>
+          ${matches.length > 0 ? html`
+            <ol class="mt-2 grid gap-1">
+              ${matches.map(node => html`
+                <li key=${node.id} class="grid gap-1 rounded-[var(--r-0)] border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs sm:grid-cols-[minmax(0,1fr)_auto]">
+                  <span class="min-w-0 truncate font-mono text-[var(--color-fg-primary)]">${node.label}</span>
+                  <span class="font-mono uppercase text-[var(--color-fg-muted)]">${node.kind}</span>
+                  ${node.branch ? html`<span class="min-w-0 truncate font-mono text-[var(--color-fg-muted)]">branch ${node.branch}</span>` : null}
+                  ${node.sha ? html`<span class="font-mono text-[var(--color-fg-muted)]">${shortRef(node.sha)}</span>` : null}
+                </li>
+              `)}
+            </ol>
+          ` : null}
+        </div>
+        <button
+          type="button"
+          class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-border-strong)] hover:text-[var(--color-fg-primary)]"
+          onClick=${clearGitGraphRouteFocus}
+        >
+          CLEAR
+        </button>
+      </div>
+    </section>
+  `
+}
+
 export function GitGraphPanel() {
   const state = gitGraphResource.state.value
   const graph = state.data
+  const routeParams = route.value.params as Record<string, string | undefined>
+  const focusedGitRef = cleanRouteFocusParam(routeParams.ref)
   const [repositories, setRepositories] = useState<ReadonlyArray<Repository>>([])
   const [selectedRepoId, setSelectedRepoId] = useState<string | null>(null)
   const [repositoryError, setRepositoryError] = useState<string | null>(null)
@@ -303,6 +385,7 @@ export function GitGraphPanel() {
       </div>
 
       <${GitGraphContextStrip} model=${context} />
+      <${GitGraphRouteFocusPanel} graph=${graph} />
 
       ${graph.warnings.length > 0 ? html`
         <div class="rounded-[var(--r-1)] border border-[var(--warn-20)] bg-[var(--warn-soft)] px-3 py-2 text-sm text-[var(--warn-bright)]">
@@ -310,7 +393,7 @@ export function GitGraphPanel() {
         </div>
       ` : null}
 
-      <${GitGraphView} graph=${graph} />
+      <${GitGraphView} graph=${graph} focusRef=${focusedGitRef} />
     </section>
   `
 }

--- a/dashboard/src/components/git-graph-view.test.ts
+++ b/dashboard/src/components/git-graph-view.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 // @vitest-environment happy-dom
 import { describe, expect, it } from "vitest"
-import { borderForStatus, buildElements, stylesheet } from "./git-graph-view"
+import { borderForStatus, buildElements, findGitGraphRefMatches, stylesheet } from "./git-graph-view"
 import type { GitGraphResponse } from "../api/git-graph"
 
 type StyleBlock = { selector: string; style: Record<string, unknown> }
@@ -138,6 +138,23 @@ describe("buildElements", () => {
     expect(n2!.classes).toBe("commit dirty conflict")
   })
 
+  it("marks nodes that match the route-focused git ref", () => {
+    const elements = buildElements(baseGraph, { focusRef: "abc123" })
+    const focused = elements.find(el => el.data.id === "n1")
+    const other = elements.find(el => el.data.id === "n2")
+
+    expect(focused!.data.routeFocus).toBe(true)
+    expect(focused!.classes).toContain("route-focus")
+    expect(other!.data.routeFocus).toBe(false)
+    expect(other!.classes).not.toContain("route-focus")
+  })
+
+  it("finds git graph nodes by full branch or short sha", () => {
+    expect(findGitGraphRefMatches(baseGraph, "main").map(node => node.id)).toEqual(["n1"])
+    expect(findGitGraphRefMatches(baseGraph, "abc").map(node => node.id)).toEqual(["n1"])
+    expect(findGitGraphRefMatches(baseGraph, "missing")).toEqual([])
+  })
+
   it("filters edges whose source or target is missing from nodes", () => {
     const graph: GitGraphResponse = {
       ...baseGraph,
@@ -226,6 +243,14 @@ describe("stylesheet", () => {
     const conflict = styleBlock(ss, "node.conflict")
     expect(conflict).toBeDefined()
     expect(conflict?.style?.["border-width"]).toBe(4)
+  })
+
+  it("has route focus node style", () => {
+    const ss = stylesheet()
+    const focused = styleBlock(ss, "node.route-focus")
+    expect(focused).toBeDefined()
+    expect(focused?.style?.["border-color"]).toBe("#d4a14a")
+    expect(focused?.style?.["border-width"]).toBe(4)
   })
 
   it("has parent node style", () => {

--- a/dashboard/src/components/git-graph-view.ts
+++ b/dashboard/src/components/git-graph-view.ts
@@ -18,6 +18,7 @@ function getCytoscape(): Promise<typeof cytoscape> {
 // Cytoscape does not resolve CSS variables. Resolve once against :root
 // with fallback to literal hex values.
 const TOKEN_FALLBACKS: Record<string, string> = {
+  '--color-brass-1': '#d4a14a',
   '--color-bg-3': '#211e1a',
   '--color-bg-4': '#2a2621',
   '--color-line-1': '#2a2520',
@@ -31,6 +32,30 @@ const TOKEN_FALLBACKS: Record<string, string> = {
   '--color-emerald': '#22c55e',
   '--color-cyan': '#22d3ee',
   '--color-indigo': '#818cf8',
+}
+
+export interface GitGraphFocusOptions {
+  readonly focusRef?: string | null
+}
+
+function cleanGitGraphFocusValue(value: string | null | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed.toLowerCase() : null
+}
+
+export function gitGraphNodeMatchesRef(node: GitGraphNode, focusRef: string | null | undefined): boolean {
+  const normalizedRef = cleanGitGraphFocusValue(focusRef)
+  if (!normalizedRef) return false
+  const sha = cleanGitGraphFocusValue(node.sha)
+  if (sha && (sha === normalizedRef || sha.startsWith(normalizedRef))) return true
+  return [node.branch, node.label, node.detail].some(value => cleanGitGraphFocusValue(value) === normalizedRef)
+}
+
+export function findGitGraphRefMatches(
+  graph: GitGraphResponse,
+  focusRef: string | null | undefined,
+): ReadonlyArray<GitGraphNode> {
+  return graph.nodes.filter(node => gitGraphNodeMatchesRef(node, focusRef))
 }
 
 function resolveCssVar(token: string): string {
@@ -51,7 +76,10 @@ export function borderForStatus(status: string): string {
   return resolveCssVar('--color-line-2')
 }
 
-export function buildElements(graph: GitGraphResponse): cytoscape.ElementDefinition[] {
+export function buildElements(
+  graph: GitGraphResponse,
+  options: GitGraphFocusOptions = {},
+): cytoscape.ElementDefinition[] {
   const agentParents = graph.agents.map(agent => ({
     data: {
       id: `agent:${agent.id}`,
@@ -62,20 +90,25 @@ export function buildElements(graph: GitGraphResponse): cytoscape.ElementDefinit
     },
   }))
 
-  const nodes = graph.nodes.map(node => ({
-    data: {
-      ...node,
-      parent: node.agent_id ? `agent:${node.agent_id}` : undefined,
-      color: node.color ?? resolveCssVar('--color-fg-3'),
-      borderColor: borderForStatus(node.status),
-      title: node.detail ?? node.branch ?? node.sha ?? node.label,
-    },
-    classes: [
-      node.kind,
-      node.status,
-      node.conflict ? 'conflict' : '',
-    ].filter(Boolean).join(' '),
-  }))
+  const nodes = graph.nodes.map(node => {
+    const routeFocus = gitGraphNodeMatchesRef(node, options.focusRef)
+    return {
+      data: {
+        ...node,
+        parent: node.agent_id ? `agent:${node.agent_id}` : undefined,
+        color: node.color ?? resolveCssVar('--color-fg-3'),
+        borderColor: borderForStatus(node.status),
+        title: node.detail ?? node.branch ?? node.sha ?? node.label,
+        routeFocus,
+      },
+      classes: [
+        node.kind,
+        node.status,
+        node.conflict ? 'conflict' : '',
+        routeFocus ? 'route-focus' : '',
+      ].filter(Boolean).join(' '),
+    }
+  })
 
   const nodeIds = new Set<string>([
     ...agentParents.map(n => n.data.id),
@@ -139,6 +172,15 @@ export function stylesheet(): cytoscape.StylesheetJsonBlock[] {
       },
     },
     {
+      selector: 'node.route-focus',
+      style: {
+        'border-color': resolveCssVar('--color-brass-1'),
+        'border-width': 4,
+        'overlay-color': resolveCssVar('--color-brass-1'),
+        'overlay-opacity': 0.16,
+      },
+    },
+    {
       selector: ':parent',
       style: {
         label: 'data(label)',
@@ -186,9 +228,10 @@ export function stylesheet(): cytoscape.StylesheetJsonBlock[] {
 
 interface GitGraphViewProps {
   graph: GitGraphResponse
+  focusRef?: string | null
 }
 
-export function GitGraphView({ graph }: GitGraphViewProps) {
+export function GitGraphView({ graph, focusRef = null }: GitGraphViewProps) {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const cyRef = useRef<CyCore | null>(null)
   const [loading, setLoading] = useState(true)
@@ -209,7 +252,7 @@ export function GitGraphView({ graph }: GitGraphViewProps) {
 
         const cy = cytoscapeFn({
           container,
-          elements: buildElements(graph),
+          elements: buildElements(graph, { focusRef }),
           style: stylesheet(),
           layout: {
             name: 'breadthfirst',
@@ -245,7 +288,7 @@ export function GitGraphView({ graph }: GitGraphViewProps) {
       cyRef.current?.destroy()
       cyRef.current = null
     }
-  }, [graph.generated_at, graph.nodes.length, graph.edges.length])
+  }, [focusRef, graph.generated_at, graph.nodes.length, graph.edges.length])
 
   return html`
     <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_18rem]">


### PR DESCRIPTION
## Summary
- show PR/ref route-focus receipts when IDE context links land on the repository graph
- highlight git graph nodes matching a routed ref by branch, label, detail, or short/full SHA
- preserve a CLEAR action that removes only the graph focus params

## Verification
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/git-graph-panel.ts src/components/git-graph-view.ts
- pnpm exec tsc --noEmit --pretty false
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/git-graph-panel.test.ts src/components/git-graph-view.test.ts
- git diff --check

Follow-up for IDE context lens PR/Git route polish.