### PR TITLE
[codex] Fix scoped keeper idle signals

### DIFF
--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -116,9 +116,16 @@ let no_eligible_action_for_claim_scope claim_goal_scope ~excluded_count =
       claim_goal_scope.Keeper_runtime_contract.mode
       excluded_count
   | None ->
+    let scope_hint =
+      match claim_goal_scope.Keeper_runtime_contract.mode with
+      | "active_goal_ids" ->
+        " Global backlog may be outside this keeper's active_goal_ids or blocked by its tool policy; update the goal scope or create/link an eligible scoped task before retrying."
+      | _ -> ""
+    in
     Printf.sprintf
-      "ACTION: Stop task-checking — blocked/excluded=%d."
+      "ACTION: Stop task-checking — blocked/excluded=%d.%s"
       excluded_count
+      scope_hint
 ;;
 
 let find_task_goal_id config task_id =

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -340,17 +340,12 @@ let read_backlog_counts ~allowed_tool_names ~(config : Coord.config) ~(meta : ke
            unclaimed_tasks)
     in
     let failed =
-      List.length
-        (List.filter
-           (fun (t : Masc_domain.task) ->
-              match t.task_status with
-              | Masc_domain.Cancelled _ -> true
-              | Masc_domain.Todo
-              | Masc_domain.Claimed _
-              | Masc_domain.InProgress _
-              | Masc_domain.AwaitingVerification _
-              | Masc_domain.Done _ -> false)
-           backlog.tasks)
+      (* "Failed" here means still-auditable active work. Terminal Cancelled
+         tasks are historical evidence, not a reason to wake every keeper. *)
+      Coord.audit_orphan_tasks config
+      |> List.map fst
+      |> List.filter claim_scope_filter
+      |> List.length
     in
     let pending_verification =
       List.length

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -1096,7 +1096,12 @@ let test_claim_no_eligible_scoped_reports_scope_truth () =
       bool
       "message preserves active scope"
       true
-      (contains_substring message "within active_goal_ids"))
+      (contains_substring message "within active_goal_ids");
+    check
+      bool
+      "message explains scope repair"
+      true
+      (contains_substring message "update the goal scope"))
 ;;
 
 let test_claim_skips_required_tools_without_access () =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -628,6 +628,69 @@ let test_observe_claimable_backlog_uses_auto_goal_fallback_scope () =
        check int "auto-goal fallback claimable backlog" 1 obs.claimable_task_count)
 ;;
 
+let test_observe_failed_count_ignores_cancelled_tasks () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       ignore
+         (Masc_mcp.Coord.add_task
+            config
+            ~title:"Cancelled stale task"
+            ~priority:1
+            ~description:"desc");
+       (match
+          Masc_mcp.Coord.force_cancel_task_r
+            config
+            ~agent_name:"operator"
+            ~task_id:"task-001"
+            ~reason:"terminal cleanup"
+            ()
+        with
+        | Ok _ -> ()
+        | Error err -> fail (Types.masc_error_to_string err));
+       let obs =
+         WO.observe
+           ~allowed_tool_names:(Some [ "keeper_task_claim"; "keeper_tasks_audit" ])
+           ~pending_board_events:(Some [])
+           ~config
+           ~meta:minimal_meta
+       in
+       check int "cancelled tasks are terminal, not failed actionable work" 0
+         obs.failed_task_count)
+;;
+
+let test_observe_failed_count_counts_orphan_active_tasks () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       ignore
+         (Masc_mcp.Coord.add_task
+            config
+            ~title:"Orphan active task"
+            ~priority:1
+            ~description:"desc");
+       ignore
+         (Masc_mcp.Coord.claim_task
+            config
+            ~agent_name:"missing-agent"
+            ~task_id:"task-001");
+       let obs =
+         WO.observe
+           ~allowed_tool_names:(Some [ "keeper_task_claim"; "keeper_tasks_audit" ])
+           ~pending_board_events:(Some [])
+           ~config
+           ~meta:minimal_meta
+       in
+       check int "orphan active tasks remain auditable failed work" 1
+         obs.failed_task_count)
+;;
+
 let test_durable_signal_present_sees_claimable_backlog_for_smart_hb_gate () =
   let base_dir = temp_dir () in
   Fun.protect
@@ -10863,6 +10926,14 @@ let () =
             "claimable backlog mirrors auto-goal fallback"
             `Quick
             test_observe_claimable_backlog_uses_auto_goal_fallback_scope
+        ; test_case
+            "failed count ignores cancelled terminal tasks"
+            `Quick
+            test_observe_failed_count_ignores_cancelled_tasks
+        ; test_case
+            "failed count keeps orphan active tasks auditable"
+            `Quick
+            test_observe_failed_count_counts_orphan_active_tasks
         ; test_case
             "durable signal sees claimable backlog"
             `Quick


### PR DESCRIPTION
## Summary

- stop counting terminal cancelled tasks as actionable keeper failed-task work
- keep orphan active tasks auditable through the existing task-audit path
- make scoped `keeper_task_claim` failures explain the active-goal scope repair path

## Root Cause

A keeper with persisted `active_goal_ids` could have zero claimable tasks in scope while the room still had unrelated global backlog. At the same time, historical `Cancelled` tasks were counted as failed actionable work, which kept injecting backlog/audit pressure even when there was no scoped work to do.

## Validation

- `scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_task_dispatch.exe`
- `./_build/default/test/test_keeper_unified.exe test world_observation 8 --show-errors`
- `./_build/default/test/test_keeper_unified.exe test world_observation 9 --show-errors`
- `./_build/default/test/test_keeper_task_dispatch.exe test claim 18 --show-errors`
- `git diff --check`