### PR TITLE
docs(rfc): RFC-0073~0076 tool readiness package

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -112,6 +112,10 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | 0070 | Keeper Sandbox Runtime — Pure/Edge Separation | Draft | (pending #14714) | depends on RFC-0036 Phase A, extends RFC-0006 Phase B-2 |
 | 0071 | Exhaustive Match Sweep Codemod — Eliminate N-of-M `_ -> false/None` Anti-Pattern | Draft | #14881 2026-05-12 | body written by this PR; lib/core/dune reference (#14888) realized. Related RFC-0042, RFC-0068. |
 | 0072 | Type-encoded keeper sub-FSM transitions (cascade + turn_phase) | Draft | 2026-05-12 | follows PR #14887 + #14893 decision-axis precedent. |
+| 0073 | Tool Readiness Probe — Typed Precondition + Runtime Gap Disclosure | Draft | (this PR) | Tool readiness package — RFC-0073/0074/0075/0076 coordinated. |
+| 0074 | Sandbox & Credential Auto-provision per Keeper Preset | Draft | (this PR) | follows RFC-0073 probe — closes gap that probe diagnoses. |
+| 0075 | Keeper Tools Smoke — Exhaustive Dispatch Coverage Regression Gate | Draft | (this PR) | follows RFC-0071/0072 exhaustive-match precedent for tool dispatch. |
+| 0076 | Tool Readiness Notification Channel — Typed Event Ledger Surface | Draft | (this PR) | follows RFC-0073/0074 — streams readiness state transitions. |
 | 0077 | Write-side silent failure — typed propagation | Draft | 2026-05-14 | symmetric counterpart to RFC-0044 (read-side); covers 20 grandfathered write/create sites in lib/keeper/. Originally claimed 0073, renumbered after #15064 0073-0076 package landed. |
 | 0078 | RFC Number Reservation Ledger + CI Collision Guard | Draft | 2026-05-14 | introduces `docs/rfc/.next-number` ledger + `rfc-number-collision-check` workflow |
 | 0079 | Log row typed encoder + silent-drop removal | Draft | 2026-05-14 | typed `Ring.entry` (level/source closed sums), `Entry_decode_error` raise, drops raw_level/normalized_level/legacy_classified/dropped_entries; supersedes #15170 |

--- a/docs/rfc/RFC-0073-tool-readiness-probe.md
+++ b/docs/rfc/RFC-0073-tool-readiness-probe.md
@@ -65,6 +65,19 @@ and readiness_reason =
   | Sandbox_missing of sandbox_kind
   | Credential_missing of credential_kind
   | Config_invalid of string
+  (* Empirically discovered (2026-05-14 fleet-tool-allocation-proof probe) — see §3.4 *)
+  | Lane_unavailable of {
+      lane_name: string;
+      missing_in_materialize: Tool_name.t list;
+    }
+  | Tool_naming_inconsistency of {
+      requested_name: string;          (* MCP-native name, e.g. "masc_web_search" *)
+      visible_surface_names: string list; (* e.g. Claude Code builtins "WebSearch" *)
+    }
+  | Verifier_blocked_no_open_request of {
+      goal_id: string;
+      goal_phase: string;
+    }
 
 val precondition_of : Tool_name.t -> readiness_precondition
 (* exhaustive match. Tool_name.t 신규 variant 추가 시 컴파일러가 누락 catch. *)
@@ -99,6 +112,22 @@ val probe :
 ```
 
 기존 필드는 변경 없음 (backward-compatible additive change).
+
+### 3.4 Empirically Discovered Variants (2026-05-14 fleet probe evidence)
+
+위 `readiness_reason` 의 3 신규 variant (`Lane_unavailable`, `Tool_naming_inconsistency`, `Verifier_blocked_no_open_request`) 는 *spec 단계의 예상*이 아니라 *런타임 fleet probe 에서 발견된 실증 evidence*다. goal `goal-tool-allocation-proof-fleet-20260514` 의 4 keeper probe 가 다음 typed gap 을 산출:
+
+| variant | Trigger | Evidence ref |
+|---|---|---|
+| `Lane_unavailable` | sangsu keeper (active+keepalive) 의 cascade=tier-group.coding_plan 이 lane=runtime_mcp 로 진입할 때 *materialize 단계*에서 sandbox-요구 도구가 LLM 표면에서 제거. dashboard `resolved_allowlist` 는 통과했으나 materialize 단계 silent strip 으로 `masc_code_git` 미존재 → `required_tool_lane_unavailable` error. | board `p-6502d7dbfaaf89ae24e6ff749a06f914` |
+| `Tool_naming_inconsistency` | tech_glutton keeper 의 cascade 가 lane=runtime_mcp 가 아니라 *local Claude SDK pass-through* 로 routing. `visible_tools` 가 `[Bash, Edit, Grep, WebSearch, Write]` 같은 Claude Code 내장 이름이라 `masc_web_search` 같은 MCP-native 이름과 매칭 실패. 같은 의미, 다른 surface naming. | board `p-15634a8257cd0c1db8092677de5a3ee2` |
+| `Verifier_blocked_no_open_request` | verifier keeper 가 *자율적으로* 발견. goal phase=executing 에서 `active_verification_request_id=null` 이면 verifier 가 reject 조차 vote 불가 — `conflict: goal has no active verification request`. RFC-0074 의 paused-blocked variant 와 *직교*. | board `p-38c3289abd46b765bee74ca765c9c2ea` (verifier 가 직접 post) |
+
+이 variant 들은 *RFC body 변경 자체가 그것의 acceptance test*: probe 가 실패하면서 variant 가 *드러났고*, 그 발견이 본문에 정식화되며, 이후 구현이 *컴파일러로 강제* 된다. 이는 RFC-0073 의 *probe-driven discovery* 패턴이 자기 자신을 검증한 첫 사례.
+
+추가 가능한 후속 variant (직접 probe 없이도 fleet inference 로 예측):
+- `Persona_profile_missing of string` — cascade 시작 자체 실패 (missing persona JSON), masc-improver / nick0cave / qa-king / janitor 의 audit 결과.
+- `Registry_not_present` — keeper toml + persona 는 있으나 runtime registry 에 등록 안 됨 (autoboot 비활성 또는 boot 자체 실패), audit 결과 16/18 keeper 가 해당.
 
 ## 4. Code Changes
 

--- a/docs/rfc/RFC-0073-tool-readiness-probe.md
+++ b/docs/rfc/RFC-0073-tool-readiness-probe.md
@@ -1,0 +1,145 @@
+---
+rfc: "0073"
+title: "Tool Readiness Probe — Typed Precondition + Runtime Gap Disclosure"
+status: Draft
+created: 2026-05-14
+updated: 2026-05-14
+author: vincent
+supersedes: []
+superseded_by: null
+related: ["0005", "0019", "0057", "0062", "0074", "0075", "0076"]
+implementation_prs: []
+---
+
+# Tool Readiness Probe — Typed Precondition + Runtime Gap Disclosure
+
+## 1. Context
+
+`Keeper_exec_tools.execute_keeper_tool_call_with_outcome` (lib/keeper/keeper_exec_tools.ml:281-575) 의 5-gate dispatch 는 Stage 3 에서 policy allowlist 통과를 확인한다. 그러나 Stage 4 의 sandbox/credential precondition 은 *실행 시점에야* fail 한다. dashboard `/api/v1/keepers/:name/tools` (server_dashboard_http_keeper_api.ml:112-128) 의 `resolved_allowlist` 는 policy 통과 사실만 노출하므로, "허용되었으나 호출 불가" 도구를 turn 진입 전에 감지할 수 없다.
+
+대표 케이스 (sangsu keeper, preset=coding, 54 tools):
+- `keeper_fs_*`, `keeper_bash*`, `keeper_shell` — `turn_sandbox_factory=None` 시 error (lines 430-456)
+- `keeper_bash` git 하위 명령 — `turn_sandbox_factory_git` 추가 필요 (line 445)
+- `keeper_pr_*` — GitHub credential 미바인딩 시 fail (lines 480-497)
+
+## 2. Problem
+
+현재 코드의 구조적 결함:
+- "허용 도구" 와 "실행 가능 도구" 가 *같은 set* 으로 노출된다.
+- runtime precondition 은 handler 내부의 ad-hoc `match factory with None -> Error ...` 로 *산재*한다.
+- 새 도구 추가 시 precondition 명세가 *암묵*이다 — 컴파일러가 미선언 도구를 catch 하지 못한다.
+
+이는 CLAUDE.md §워크어라운드 거부 기준 시그니처 #2 (typed variant 가능한 자리에 string/match) + #3 (N-of-M 패치) 의 누적 결과다.
+
+## 3. Proposal — Typed Precondition Registry
+
+각 도구의 precondition 을 *컴파일 타임* 에 declare 한다. `Tool_name.t` exhaustive variant 위에서 fold.
+
+### 3.1 신규 모듈
+
+```ocaml
+(* lib/keeper/tool_capability.mli *)
+type sandbox_kind =
+  | Fs_sandbox
+  | Bash_sandbox
+  | Git_sandbox
+  | No_sandbox_required
+
+type credential_kind =
+  | Github_token
+  | Slack_token
+  | Web_search_key
+  | No_credential_required
+
+type readiness_precondition = {
+  sandbox: sandbox_kind list;        (* AND-list. 모두 충족 필요. *)
+  credentials: credential_kind list;
+  config_keys: string list;          (* cdal config 의 키 존재 여부 *)
+}
+
+type readiness_state =
+  | Ready
+  | Blocked of readiness_reason
+
+and readiness_reason =
+  | Sandbox_missing of sandbox_kind
+  | Credential_missing of credential_kind
+  | Config_invalid of string
+
+val precondition_of : Tool_name.t -> readiness_precondition
+(* exhaustive match. Tool_name.t 신규 variant 추가 시 컴파일러가 누락 catch. *)
+
+val probe :
+  ctx:Tool_exec_ctx.t -> Tool_name.t list -> (Tool_name.t * readiness_state) list
+```
+
+### 3.2 Runtime Probe 통합 지점
+
+`Keeper_run_tools.prepare_agent_setup` (lib/keeper/keeper_run_tools.ml:96-127) 의 `computed_tool_surface` 산출 직후 한 번 호출. 결과를 `agent_setup.readiness_snapshot` 필드에 보관 (신규 필드, 옵셔널).
+
+### 3.3 Dashboard API 응답 확장
+
+`/api/v1/keepers/:name/tools` 응답에 새 객체 추가:
+
+```json
+{
+  "resolved_allowlist": [ ... 54 ... ],
+  "tool_denylist":      [ ... ],
+  "active_masc_tool_count": 17,
+  "runtime_readiness": {
+    "ready":   [ "keeper_time_now", "keeper_memory_search", ... ],
+    "blocked": [
+      { "tool": "keeper_pr_create",
+        "state": "Blocked",
+        "reason_kind": "Credential_missing",
+        "reason_detail": "Github_token not bound to keeper context" }
+    ]
+  }
+}
+```
+
+기존 필드는 변경 없음 (backward-compatible additive change).
+
+## 4. Code Changes
+
+| 파일 | 변경 종류 | 추정 LOC |
+|---|---|---|
+| `lib/keeper/tool_capability.ml` + `.mli` | 신규 | ~110 |
+| `lib/tool_capability_registry.ml` | 신규 (exhaustive match on Tool_name.t) | ~150 |
+| `lib/keeper/keeper_run_tools.ml` | probe 호출 1곳 | ~10 |
+| `lib/server/server_dashboard_http_keeper_api.ml` | JSON 응답 1 객체 추가 | ~30 |
+| `dashboard/src/api/keepers.ts` | 응답 타입 1 필드 | ~5 |
+| `test/test_tool_capability_registry.ml` | exhaustive 가드 + probe 단위 | ~80 |
+
+## 5. Phases
+
+| Phase | 범위 | 머지 조건 |
+|---|---|---|
+| 0 | `tool_capability` + registry skeleton — exhaustive 컴파일 가드만 | dune build 통과 |
+| 1 | `precondition_of` 모든 54 도구에 대해 정의 | RFC-0075 smoke cross-check |
+| 2 | dashboard API JSON 확장 + FE typing | snapshot test 통과 |
+| 3 | (선택) RFC-0076 의 readiness event 와 연결 | RFC-0076 머지 후 |
+
+## 6. Verification
+
+- (a) `dune build` 통과 — exhaustive match 강제. 새 `Tool_name.t` variant 추가 시 컴파일 fail.
+- (b) `dune exec test/test_tool_capability_registry.exe` — registry 모든 variant cover 검증.
+- (c) Local sangsu boot → `curl http://localhost:8935/api/v1/keepers/sangsu/tools | jq '.runtime_readiness.blocked | length'` 가 sandbox 미부착 환경에서 ≥6 (fs_read, fs_edit, bash, bash_output, bash_kill, shell).
+
+## 7. Workaround Rejection Self-Check
+
+- ❌ string `is_ready` 플래그 — typed `readiness_state` variant 사용
+- ❌ metric counter for "blocked tool calls" — `runtime_readiness` 는 *현재 상태* 1회성 응답
+- ❌ N-of-M precondition 산재 — `Tool_name.t` exhaustive 가 모든 사이트 강제
+- ❌ catch-all `_ ->` in `precondition_of` — wildcard 금지
+- ✅ structural: precondition declaration 이 1 모듈에 집중
+
+## 8. Related RFCs
+
+- RFC-0005 Typed Capability Substrate — sandbox 추상의 base layer
+- RFC-0019 Keeper Credential Unification — credential SSOT
+- RFC-0057 Tool Descriptor Codegen — 장기적으로 `[@@deriving tool]` PPX 로 precondition 도 자동 생성 가능
+- RFC-0062 Typed `Tool_result.t` — error channel 의 typed reason 과 통합
+- RFC-0074 Sandbox & Credential Auto-provision — Blocked 도구의 실행 보장 (이 RFC 가 *진단*, 0074 가 *치료*)
+- RFC-0075 Smoke Self-Test — `precondition_of` 의 exhaustive coverage 회귀 가드
+- RFC-0076 Dashboard Notification — readiness 상태 변화의 표면화

--- a/docs/rfc/RFC-0074-sandbox-credential-auto-provision.md
+++ b/docs/rfc/RFC-0074-sandbox-credential-auto-provision.md
@@ -1,0 +1,126 @@
+---
+rfc: "0074"
+title: "Sandbox & Credential Auto-provision per Keeper Preset"
+status: Draft
+created: 2026-05-14
+updated: 2026-05-14
+author: vincent
+supersedes: []
+superseded_by: null
+related: ["0005", "0006", "0019", "0070", "0073"]
+implementation_prs: []
+---
+
+# Sandbox & Credential Auto-provision per Keeper Preset
+
+## 1. Context
+
+`Keeper_run_tools.prepare_agent_setup` (lib/keeper/keeper_run_tools.ml:96-127) 가 turn 시작 시점에 `turn_sandbox_factory`, `turn_sandbox_factory_git`, credential bundle 을 옵셔널 인자로 받는다. 현재 boot path (`lib/keeper/keeper_registry.ml`) 가 이들을 *자동 부착하지 않으므로*, coding preset 의 fs/bash/shell/pr 도구가 turn 시점에 `factory=None` 으로 실행 fail 한다.
+
+RFC-0073 이 *gap 을 진단*한다면 이 RFC 는 *gap 을 닫는다*.
+
+## 2. Problem
+
+- preset (coding/research/social/...) 은 *어떤 자원이 필요한지* 를 implicit 하게만 안다 (`preset_allowlist` 의 tool 목록).
+- sandbox/credential 부착은 caller 측 책임 — `register_keeper` 호출자가 각자 ad-hoc 으로 결정.
+- 결과: dashboard 상 "허용 54" 와 실제 호출 가능한 도구 사이 항구적 gap.
+- credential 부착은 *security surface* — 모든 keeper 에 자동 주입은 부적절. preset-aware 가 필요.
+
+CLAUDE.md §워크어라운드 거부 기준 시그니처 #3 (N-of-M abstraction admission) 의 회피 대상.
+
+## 3. Proposal — `resource_plan` per Preset
+
+preset 마다 *어떤 sandbox 와 credential 이 필요한지* 를 *선언적*으로 declare. boot 시 plan 을 resolve 해서 keeper entry 에 attach.
+
+### 3.1 신규 모듈
+
+```ocaml
+(* lib/keeper/keeper_resource_plan.mli *)
+type resource_plan = {
+  fs_sandbox: [ `Required | `Optional | `Forbidden ];
+  bash_sandbox: [ `Required | `Optional | `Forbidden ];
+  git_sandbox: [ `Required | `Optional | `Forbidden ];
+  credentials: Tool_capability.credential_kind list;  (* RFC-0073 *)
+}
+
+val plan_of_preset : Preset.t -> resource_plan
+(* exhaustive match on Preset.t — 신규 preset 추가 시 컴파일 catch. *)
+
+val attach :
+  base_path:string ->
+  keeper:Keeper_registry.entry ->
+  plan:resource_plan ->
+  auto_provision_credentials:bool ->
+  Keeper_registry.entry
+```
+
+### 3.2 매핑 (예시)
+
+| Preset | fs | bash | git | credentials |
+|---|---|---|---|---|
+| Minimal | Forbidden | Forbidden | Forbidden | [] |
+| Social | Forbidden | Forbidden | Forbidden | [Slack_token] |
+| Coding | Required | Required | Required | [Github_token] |
+| Research | Required | Optional | Forbidden | [Web_search_key] |
+| Delivery | Required | Required | Required | [Github_token; Slack_token] |
+| Full | Required | Required | Required | [Github_token; Slack_token; Web_search_key] |
+
+### 3.3 Boot Path 통합
+
+`Keeper_registry.register_keeper` 호출 직후:
+
+```ocaml
+let plan = Keeper_resource_plan.plan_of_preset meta.preset in
+let auto_creds = Config.bool ~default:false "auto_provision_credentials" in
+let entry = Keeper_resource_plan.attach
+  ~base_path ~keeper:entry ~plan ~auto_provision_credentials:auto_creds
+```
+
+### 3.4 Opt-in Flag
+
+credential 자동 주입은 *default off* (`auto_provision_credentials=false`). 운영자가 `config/tool_policy.toml` 의 `[runtime]` 섹션에서 `auto_provision_credentials = true` 로 활성화. sandbox 자동 부착은 default on (보안 surface 가 없음 — read-only sandbox factory 는 ambient 자원이 아니라 *factory 등록*).
+
+### 3.5 Fail Mode
+
+`Required` 자원이 부착 불가능하면 keeper boot 자체 fail (early & loud). `Optional` 은 미부착 허용 — RFC-0073 의 probe 가 dashboard 에 표시.
+
+## 4. Code Changes
+
+| 파일 | 변경 종류 | 추정 LOC |
+|---|---|---|
+| `lib/keeper/keeper_resource_plan.ml` + `.mli` | 신규 | ~180 |
+| `lib/keeper/keeper_registry.ml` | boot path 통합 1곳 | ~20 |
+| `config/tool_policy.toml` | `[runtime].auto_provision_credentials` 키 1 | ~3 |
+| `test/test_keeper_resource_plan.ml` | preset × 자원 매핑 unit | ~100 |
+
+## 5. Phases
+
+| Phase | 범위 | 머지 조건 |
+|---|---|---|
+| 0 | `resource_plan` skeleton + `plan_of_preset` exhaustive | RFC-0073 Phase 0 머지 후 |
+| 1 | `attach` 구현 (sandbox factory 부착) | 단위 테스트 통과 |
+| 2 | boot path 통합 (default off for credentials) | local sangsu boot 시 fs/bash/git probe Ready 전환 |
+| 3 | credential opt-in 활성화 (운영자 결정) | 보안 검토 통과 |
+
+## 6. Verification
+
+- (a) `dune build` 통과 — `plan_of_preset` exhaustive match 가드.
+- (b) `dune exec test/test_keeper_resource_plan.exe` — preset 8개 × 자원 5개 매트릭스 검증.
+- (c) sangsu (preset=coding) boot 후 `runtime_readiness.blocked` 가 (credential 자동 주입 off 기준) `keeper_pr_*` 만 포함, fs/bash/git 도구는 Ready.
+- (d) `auto_provision_credentials=true` 설정 후 reboot → `runtime_readiness.blocked` 가 빈 배열.
+
+## 7. Workaround Rejection Self-Check
+
+- ❌ "fail 시 fallback dummy sandbox 부착" — Required 자원 부재 시 boot fail, dummy 금지
+- ❌ env var grab-all credential 주입 — `credentials` 가 typed list, source 는 RFC-0019 unification 후 SSOT
+- ❌ preset 매핑 catch-all `_ ->` — exhaustive 강제
+- ❌ "이미 부착되어 있으면 silent skip" — `attach` 가 idempotent 하지만 *이미 부착됨* 사실은 telemetry event 로 ledger 기록
+- ✅ structural: preset 이 자원 요구의 SSOT
+
+## 8. Related RFCs
+
+- RFC-0005 Typed Capability Substrate — sandbox 추상의 base
+- RFC-0006 Keeper Tool Surface Realignment & Symmetric Sandbox — symmetric sandbox 모델의 confirm
+- RFC-0019 Keeper Credential Unification — credential source 의 SSOT (이 RFC 의 선행 의존)
+- RFC-0070 Keeper Sandbox Runtime — Pure/Edge Separation — sandbox lifecycle 추상
+- RFC-0073 Tool Readiness Probe — gap 진단을 통한 boot fail mode 검증

--- a/docs/rfc/RFC-0075-keeper-tools-smoke.md
+++ b/docs/rfc/RFC-0075-keeper-tools-smoke.md
@@ -1,0 +1,125 @@
+---
+rfc: "0075"
+title: "Keeper Tools Smoke — Exhaustive Dispatch Coverage Regression Gate"
+status: Draft
+created: 2026-05-14
+updated: 2026-05-14
+author: vincent
+supersedes: []
+superseded_by: null
+related: ["0042", "0062", "0071", "0072", "0073"]
+implementation_prs: []
+---
+
+# Keeper Tools Smoke — Exhaustive Dispatch Coverage Regression Gate
+
+## 1. Context
+
+`keeper_exec_tools.ml:281-575` 의 dispatch 는 54개 도구를 name-string match 로 라우팅한다. 신규 도구 추가, handler 시그니처 변경, sandbox factory 시그니처 drift 등이 *런타임에야* fail 하며, MEMORY (2026-05-12 `masc-mcp CI Build and Test skips`) 에 따르면 핵심 lib 변경 PR 의 다수가 *Detect Changed Surfaces* gate 뒤에 묶여 test job 이 SKIPPED.
+
+RFC-0071 (exhaustive match codemod) + RFC-0072 (keeper sub-FSM transitions typed) 가 *컴파일 타임 가드*를 도입했지만, tool dispatch table 은 아직 `Tool_name.t` exhaustive 가 enforce 되지 않는다.
+
+## 2. Problem
+
+- dispatch table 의 모든 leaf 가 reachable 한지 *런타임* 보장 없음.
+- `Tool_name.t` 에 variant 추가 시 dispatch 의 누락은 fuzzy `did_you_mean` 분기로 silent fall.
+- 변경된 keeper_exec_tools.ml 가 *Detect Changed Surfaces* gate 뒤에 있어 CI 에서 test SKIPPED.
+- 결과: regression 이 latent 으로 누적 (예: PR #14395 → 1주일 후 #14927 에서야 발견).
+
+CLAUDE.md §워크어라운드 거부 기준 시그니처 #1 (telemetry-as-fix) + #3 (N-of-M) 의 회귀 가드.
+
+## 3. Proposal — Two-layer Smoke
+
+### 3.1 Layer A: 메타 도구 `keeper_tools_smoke`
+
+운영자/keeper 가 호출 가능한 read-only 메타 도구. 모든 54 도구를 dry-run dispatch.
+
+```ocaml
+(* lib/keeper/keeper_tools_smoke.mli *)
+type smoke_outcome =
+  | Dispatched_ok
+  | Skipped of skipped_reason
+  | Dispatch_error of string
+
+and skipped_reason =
+  | Precondition_blocked of Tool_capability.readiness_reason  (* RFC-0073 *)
+  | Side_effect_class                                          (* destructive, run 안 함 *)
+
+val run_smoke :
+  ctx:Tool_exec_ctx.t -> (Tool_name.t * smoke_outcome) list
+(* Tool_name.t 위 exhaustive fold *)
+```
+
+dry-run 의미:
+- `Side_effect_class` (write/git/post) 는 *mock context* 로 dispatch 만 verify, real I/O 안 함.
+- `Precondition_blocked` 는 RFC-0073 probe 결과 활용 — Sandbox/Credential 없으면 Skipped.
+- 나머지 (read/idempotent) 는 real dispatch 후 outcome 분류.
+
+### 3.2 Layer B: alcotest `test_keeper_tools_smoke`
+
+CI 에 강제되는 단위 테스트. `Tool_name.t` variant 위 exhaustive match — 신규 variant 가 smoke 정의에 누락되면 컴파일 fail.
+
+```ocaml
+(* test/test_keeper_tools_smoke.ml *)
+let test_all_tools_have_smoke_definition () =
+  let outcomes = Keeper_tools_smoke.run_smoke ~ctx:Mock_ctx.empty () in
+  let expected = Tool_name.all in   (* 전체 variant 열거 — exhaustive *)
+  Alcotest.(check int) "coverage" (List.length expected) (List.length outcomes);
+  ...
+```
+
+### 3.3 CI Gate 강화
+
+`.github/workflows/ci-build-test.yml` 의 `Detect Changed Surfaces` job 에 다음 path glob 추가:
+
+```yaml
+keeper_dispatch:
+  - 'lib/keeper/keeper_exec_tools.ml'
+  - 'lib/tool_dispatch.ml'
+  - 'lib/keeper/tool_name.ml'
+  - 'lib/keeper/tool_capability_registry.ml'
+```
+
+해당 surface 변경 시 `test_keeper_tools_smoke` *강제 실행* — Build and Test job 의 conditional skip 우회.
+
+## 4. Code Changes
+
+| 파일 | 변경 종류 | 추정 LOC |
+|---|---|---|
+| `lib/keeper/keeper_tools_smoke.ml` + `.mli` | 신규 | ~200 |
+| `test/test_keeper_tools_smoke.ml` | 신규 (exhaustive + outcome 분포) | ~120 |
+| `lib/keeper/keeper_exec_tools.ml` | smoke 메타 도구 dispatch 1 branch | ~10 |
+| `.github/workflows/ci-build-test.yml` | path glob + force-run condition | ~15 |
+| `config/tool_policy.toml` | `keeper_tools_smoke` 를 Minimal 외 모든 preset 에 노출 | ~3 |
+
+## 5. Phases
+
+| Phase | 범위 | 머지 조건 |
+|---|---|---|
+| 0 | Mock_ctx 인프라 + `smoke_outcome` 타입 | 컴파일 |
+| 1 | `run_smoke` 본체 — Tool_name.t exhaustive fold | 단위 테스트 통과 |
+| 2 | alcotest 가드 + CI workflow 통합 | CI green, force-run 검증 |
+| 3 | 메타 도구 `keeper_tools_smoke` dispatch + tool_policy.toml 노출 | RFC-0073 Phase 1 머지 후 (precondition 의존) |
+
+## 6. Verification
+
+- (a) `dune build` 통과 — Tool_name.t 신규 variant 추가 시 smoke 코드 컴파일 fail.
+- (b) `dune exec test/test_keeper_tools_smoke.exe` — 54 도구 모두 outcome 분류됨, `Dispatch_error` 0건.
+- (c) Local sangsu turn 에서 `keeper_tools_smoke` 호출 → 응답 JSON 에 54 entry, Skipped/Dispatched_ok 분포 확인.
+- (d) CI 의 `Build and Test` job 이 keeper_exec_tools.ml 변경 PR 에서 *반드시 실행*되는지 확인 (현재 skip 패턴 close).
+
+## 7. Workaround Rejection Self-Check
+
+- ❌ smoke 결과 *WARN dedup* — 실패는 모두 alert, demote 금지
+- ❌ `Skipped` 의 silent 누적 — `Skipped` 비율 > N% 시 단위 테스트 fail
+- ❌ smoke 도구를 `keeper_internal_list` 에 추가하지 않음 — 사용자/keeper 양쪽 호출 가능
+- ❌ counter-as-fix — smoke 가 *count* 가 아니라 *outcome variant* 반환
+- ✅ structural: Tool_name.t exhaustive 가 N-of-M 회귀 방지
+
+## 8. Related RFCs
+
+- RFC-0042 Closed sum type for keeper turn terminal code — 같은 exhaustive 강제 패턴
+- RFC-0062 Typed `Tool_result.t` — outcome 타입의 reuse 후보
+- RFC-0071 Exhaustive Match Sweep Codemod — N-of-M 안티패턴의 일반 가드
+- RFC-0072 Type-encoded keeper sub-FSM transitions — 같은 typed transitions 가드 패턴
+- RFC-0073 Tool Readiness Probe — `Precondition_blocked` 의 reason source

--- a/docs/rfc/RFC-0076-tool-readiness-notification-channel.md
+++ b/docs/rfc/RFC-0076-tool-readiness-notification-channel.md
@@ -1,0 +1,132 @@
+---
+rfc: "0076"
+title: "Tool Readiness Notification Channel — Typed Event Ledger Surface"
+status: Draft
+created: 2026-05-14
+updated: 2026-05-14
+author: vincent
+supersedes: []
+superseded_by: null
+related: ["0020", "0029", "0033", "0048", "0049", "0073", "0074"]
+implementation_prs: []
+---
+
+# Tool Readiness Notification Channel — Typed Event Ledger Surface
+
+## 1. Context
+
+Dashboard 우상단 알림 영역 (`4 events / 60s` 표시, MASC COCKPIT 헤더) 은 *fleet-wide* 신호만 surface 한다. 특정 keeper 의 *도구 가용성 변화* (sandbox 부착/탈착, credential 만료, config drift) 는 silent. sangsu 의 `keeper_pr_create` 가 turn 도중 GitHub token 만료로 blocked 전환되어도 사용자는 turn 실패 텔레메트리에서야 인지한다.
+
+RFC-0073 이 *현재 상태* 의 snapshot 을 노출한다면, 이 RFC 는 *상태 전이* 를 stream 한다.
+
+## 2. Problem
+
+- readiness 상태 변화가 ledger 에 *typed event* 로 기록되지 않는다.
+- dashboard 알림 채널이 keeper-specific 이벤트를 필터링/표시할 surface 가 없다.
+- 같은 readiness change 의 반복 발화 (예: 매 turn 마다 같은 missing credential) 가 noise 로 알림 영역을 침범할 위험.
+
+이전 사고 (MEMORY `feedback_keeper_hallucinated_audit_cascade`) 의 *fact suppression* 회피 — 우리는 *display* 만 dedup, *fact* 는 모두 보존.
+
+## 3. Proposal — `Tool_readiness_changed` Event Variant + WS Push
+
+### 3.1 Event Variant
+
+```ocaml
+(* lib/events/keeper_event.ml — 기존 type 에 추가 *)
+type event = ...
+  | Tool_readiness_changed of {
+      keeper: string;
+      tool: Tool_name.t;
+      from_state: Tool_capability.readiness_state;  (* RFC-0073 *)
+      to_state: Tool_capability.readiness_state;
+      at: Eio.Time.Instant.t;
+      occurrence_count: int;  (* 같은 (keeper, tool, to_state) 5분 윈도우 내 N번째 *)
+    }
+  | ...
+```
+
+상태 비교 함수 `Tool_capability.readiness_state_equal` 로 `from_state ≠ to_state` 인 경우만 emit.
+
+### 3.2 Emission 지점
+
+- RFC-0073 의 probe 가 매 turn 시작 시점에 호출 — 직전 snapshot 과 diff 해서 change 만 emit.
+- RFC-0074 의 `attach` 성공/실패 — boot 시점에 emit.
+- credential 만료 이벤트 (RFC-0019 의 future work) — 만료 검출 시 emit.
+
+### 3.3 WebSocket 채널
+
+기존 `/api/v1/events/stream` (server_dashboard_ws_*.ml) 에 `keeper-readiness` topic 신설. payload schema:
+
+```json
+{
+  "topic": "keeper-readiness",
+  "event": {
+    "keeper": "sangsu",
+    "tool": "keeper_pr_create",
+    "from_state": "Ready",
+    "to_state": {
+      "kind": "Blocked",
+      "reason_kind": "Credential_missing",
+      "reason_detail": "Github_token expired"
+    },
+    "at": "2026-05-14T03:15:42Z",
+    "occurrence_count": 1
+  }
+}
+```
+
+### 3.4 Dashboard Component
+
+`dashboard/src/components/notification-stream/` 에 `ToolReadinessAlert` 컴포넌트 추가. 메시지 포맷:
+- `Ready → Blocked`: "sangsu: keeper_pr_create blocked (missing Github_token)" — warning tier
+- `Blocked → Ready`: "sangsu: keeper_bash ready (sandbox attached)" — info tier
+- `occurrence_count > 1`: 메시지 우측에 `(×N within 5m)` 첨부, 알림 *개수* 는 1 만 증가
+
+### 3.5 Display Dedup vs Fact Suppression
+
+`occurrence_count` 가 1 초과인 event 도 ledger 에는 *모두 append*. dashboard 만 5분 윈도우 내 같은 (keeper, tool, to_state) 를 1 줄로 합쳐 보여준다. 이는 *display 최적화* 이며 fact 손실 아님.
+
+## 4. Code Changes
+
+| 파일 | 변경 종류 | 추정 LOC |
+|---|---|---|
+| `lib/events/keeper_event.ml` | 신규 event variant 1개 | ~25 |
+| `lib/keeper/keeper_run_tools.ml` | probe 결과 diff + emit | ~40 |
+| `lib/server/server_dashboard_ws_keeper_readiness.ml` | 신규 topic handler | ~80 |
+| `dashboard/src/components/notification-stream/ToolReadinessAlert.tsx` | 신규 | ~120 |
+| `dashboard/src/api/ws/topics.ts` | topic 1 등록 | ~10 |
+| `test/test_keeper_readiness_event.ml` | diff/emit 단위 | ~70 |
+
+## 5. Phases
+
+| Phase | 범위 | 머지 조건 |
+|---|---|---|
+| 0 | event variant + diff 함수 — emission 없이 컴파일 가드만 | dune build |
+| 1 | `Keeper_run_tools` 의 probe diff + emit 통합 | 단위 테스트 통과 |
+| 2 | WS topic handler + schema 문서화 | snapshot test |
+| 3 | dashboard FE 컴포넌트 + 5분 dedup 윈도우 | local sangsu 시연 |
+
+## 6. Verification
+
+- (a) `dune build` 통과 — keeper_event 새 variant 가 ledger consumer 의 exhaustive match 강제.
+- (b) `dune exec test/test_keeper_readiness_event.exe` — diff 함수가 동일 state 에 emit 안 함 / 다른 state 에 emit 함.
+- (c) Local sangsu 환경에서 sandbox factory 부착/탈착을 운영자 명령으로 토글 → dashboard 알림 영역에 transition 표시.
+- (d) 같은 transition 5분 내 5회 발생 시 ledger 에 5건, dashboard 에 1건 (×5 within 5m) 표시.
+
+## 7. Workaround Rejection Self-Check
+
+- ❌ string `reason: string` field — typed `readiness_reason` variant 사용 (RFC-0073 의 typed 강제 유지)
+- ❌ ledger WARN dedup 1h — display 만 5분 dedup, fact ledger 는 모두 보존
+- ❌ "fallback to free-text" reason — variant 가 exhaustive
+- ❌ counter-as-fix — `occurrence_count` 는 *displayable summary* 이지 fact substitute 아님
+- ✅ structural: 결정 결과가 typed event 로 ledger 의 1급 객체
+
+## 8. Related RFCs
+
+- RFC-0020 Keeper heartbeat — Event Layer / Policy Layer separation — 같은 event ledger surface
+- RFC-0029 Dashboard Fiber-Batched Aggregation — WS 채널 capacity
+- RFC-0033 Worktree Status SSE Channel — 같은 streaming 전례
+- RFC-0048 Dashboard Information Architecture Phase 2 — notification 영역 owner
+- RFC-0049 Dashboard Surface Telemetry Foundation — telemetry channel 의 일반화
+- RFC-0073 Tool Readiness Probe — readiness_state 의 source of truth
+- RFC-0074 Sandbox & Credential Auto-provision — `attach` 성공/실패 emission 의 origin


### PR DESCRIPTION
## Summary

sangsu keeper dashboard 의 *허용 도구 54* 표시와 실제 호출 가능성 사이의 항구적 gap 을 4 개의 coordinated RFC 로 정식화합니다.

| RFC | 책임 | 위험 |
|---|---|---|
| 0073 | 진단 — typed precondition registry, `runtime_readiness` API 응답 추가 | 낮음 (read-only signal) |
| 0074 | 치료 — preset → `resource_plan` 매핑, boot 시 자동 부착, credential opt-in | 중간 (security surface) |
| 0075 | 회귀 가드 — `Tool_name.t` exhaustive fold + CI force-run | 낮음 |
| 0076 | 노출 — typed event ledger + dashboard 알림 채널, display-only 5min dedup | 중간 (FE/BE schema 동시) |

## Why

`Keeper_exec_tools.execute_keeper_tool_call_with_outcome` (lib/keeper/keeper_exec_tools.ml:281-575) 의 5-gate dispatch 는 Stage 3 에서 policy allowlist 통과만 확인하고, Stage 4 의 sandbox/credential precondition 은 *실행 시점*에야 fail 합니다. dashboard API (`server_dashboard_http_keeper_api.ml:112-128`) 의 `resolved_allowlist` 는 policy 통과 사실만 노출 — 따라서:

- *허용 54* 와 *실행 가능 54* 가 분리되지 않습니다.
- precondition 검사가 handler 내부 ad-hoc `match factory with None -> Error ...` 로 산재.
- 새 도구 추가 시 precondition 명세가 *암묵*이라 컴파일러가 누락 catch 불가.
- dispatch 회귀가 *Detect Changed Surfaces* gate 뒤로 숨어 latent 으로 누적 (MEMORY 2026-05-12 `masc-mcp CI Build and Test skips`).

## Approach validation

- **3+ files 수정**: RFC 4 + README 1 — 설계 문서, 코드 변경 0.
- **아키텍처 영향**: 있음 — RFC 단계로 escalate (CLAUDE.md §워크어라운드 거부 기준 통과).
- **기존 패턴 재사용**: RFC-0071 (exhaustive match codemod) + RFC-0072 (typed FSM transitions) 의 패턴을 tool dispatch 표면에 확장.

## Workaround Rejection Bar self-check

각 RFC §7 에 명시. 4 RFC 모두 *구조적 해소*:

- ❌ string 분류기 보강 (#2) — `Tool_capability`, `readiness_reason`, `readiness_state` 모두 typed variant
- ❌ telemetry-as-fix (#1) — counter 만 추가하지 않음, *결정 결과* 자체를 typed event ledger 에 append
- ❌ N-of-M 패치 (#3) — `Tool_name.t` exhaustive fold 가 모든 사이트 컴파일 타임 강제
- ❌ catch-all \`_ ->\` — `precondition_of`, `plan_of_preset`, smoke 정의 모두 wildcard 금지

## 산출물 (5 파일, +533 LOC docs)

- `docs/rfc/RFC-0073-tool-readiness-probe.md` (신규)
- `docs/rfc/RFC-0074-sandbox-credential-auto-provision.md` (신규)
- `docs/rfc/RFC-0075-keeper-tools-smoke.md` (신규)
- `docs/rfc/RFC-0076-tool-readiness-notification-channel.md` (신규)
- `docs/rfc/README.md` — index 4 행 추가, 다음 번호 0077 갱신

## Best Programmer Self-Review

- **목표**: 54-tool gap 의 구조적 해소를 RFC 단계로 정식 등록.
- **변경 파일**: docs/rfc/ 5 개. 코드 0.
- **로컬 검증**:
  - frontmatter 8 필드 (rfc / title / status / created / updated / author / supersedes / superseded_by / related / implementation_prs) 모두 명시
  - 4 RFC 사이 cross-reference 양방향 일관 (0073 → 0074/0075/0076; 0074/0075/0076 → 0073)
  - 누락 번호 회피, 0073~0076 reservation race-safe (fetch 후 ls 확인)
- **미검증**:
  - 구현은 후속 PR (Phase 0 부터 시작) — 본 PR 은 spec 만
  - 실제 OCaml 컴파일 가드 효과는 RFC-0073 Phase 0 머지 후 검증

## Test plan

- [ ] frontmatter YAML 파싱 (mental check)
- [ ] README index 행과 본문 RFC 번호 일치
- [ ] cross-reference 양방향 일관

## Related context

- Plan: \`~/me/planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-oas-ticklish-tome.md\`
- 선행 RFC: 0005 (typed capability substrate), 0019 (credential unification), 0042 (closed sum type), 0071 (exhaustive sweep codemod), 0072 (typed FSM transitions)

## Ready 전환

이 PR 은 Draft 로 유지됩니다. Ready 전환은 사용자가 \`human-approved-ready\` 라벨을 부착해야 진행됩니다 (masc-mcp Draft Auto-Merge Guard, 2026-05-13 PR #15036).

🤖 Generated with [Claude Code](https://claude.com/claude-code)