### PR TITLE
feat(dashboard): surface keeper live truth

### DIFF
--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -218,6 +218,8 @@ export const KeeperCompositeSnapshotSchema = object({
   phase_diagnosis: optional(KeeperPhaseDiagnosisSchema),
   is_live: boolean(),
   last_outcome: nullable(KeeperLastOutcomeSchema),
+  idle_seconds: optional(number()),
+  last_turn_ts: optional(number()),
   execution: optional(KeeperCompositeExecutionSchema),
   runtime_attention: optional(KeeperRuntimeAttentionSchema),
   recommended_actions: fallback(array(OperatorRecommendedActionSchema), []),

--- a/dashboard/src/components/keeper-detail-body.ts
+++ b/dashboard/src/components/keeper-detail-body.ts
@@ -17,6 +17,7 @@ import {
   TraitsList,
 } from './keeper-detail-panels'
 import {
+  KeeperLiveTruthPanel,
   RuntimeLensSection,
   RuntimeSignals,
   TurnBudgetSection,
@@ -54,6 +55,7 @@ import type { keeperActivityDisplay } from '../lib/keeper-runtime-display'
 import { KeeperRuntimeAlertStrip } from './keeper-detail-alert-strip'
 import { KeeperCommsPanel, PlaygroundReposPanel } from './keeper-detail-comms'
 import { KeeperClearContextDialog } from './keeper-detail-lifecycle'
+import type { KeeperDetailEvidenceState } from './keeper-detail-hooks'
 
 export interface KeeperDetailBodyProps {
   keeper: Keeper
@@ -64,6 +66,8 @@ export interface KeeperDetailBodyProps {
   activityDisplay: ReturnType<typeof keeperActivityDisplay>
   compositeSnapshot: KeeperCompositeSnapshot | null
   runtimeTrace: KeeperRuntimeTraceResponse | null
+  compositeEvidence: KeeperDetailEvidenceState<KeeperCompositeSnapshot>
+  runtimeTraceEvidence: KeeperDetailEvidenceState<KeeperRuntimeTraceResponse>
   diagOpen: boolean
   onDiagToggle: (open: boolean) => void
   checkpointRefreshToken: number
@@ -87,6 +91,8 @@ export function KeeperDetailBody({
   activityDisplay,
   compositeSnapshot,
   runtimeTrace,
+  compositeEvidence,
+  runtimeTraceEvidence,
   diagOpen,
   onDiagToggle,
   checkpointRefreshToken,
@@ -118,6 +124,14 @@ export function KeeperDetailBody({
           eyebrow="상태 개요"
           title="운영 상태 개요"
         >
+      <${KeeperLiveTruthPanel}
+        keeper=${keeper}
+        compositeSnapshot=${compositeSnapshot}
+        runtimeTrace=${runtimeTrace}
+        compositeEvidence=${compositeEvidence}
+        runtimeTraceEvidence=${runtimeTraceEvidence}
+      />
+
       ${'' /* RFC-0046: 6-axis composite snapshot (KSM/KTC/KDP/KCL/KMC/breaker) — SSOT for keeper FSM state */}
       ${'' /* RFC-0046 §7 #2: share useKeeperComposite with FsmHub to dedup the /composite poll */}
       <${FsmHub}

--- a/dashboard/src/components/keeper-detail-hooks.ts
+++ b/dashboard/src/components/keeper-detail-hooks.ts
@@ -6,6 +6,24 @@ import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
 const COMPOSITE_REFRESH_MS = 30_000
 const RUNTIME_TRACE_REFRESH_MS = 30_000
 
+export interface KeeperDetailEvidenceState<T> {
+  data: T | null
+  refreshedAtMs: number | null
+  error: string | null
+  loading: boolean
+}
+
+const emptyEvidence = <T,>(): KeeperDetailEvidenceState<T> => ({
+  data: null,
+  refreshedAtMs: null,
+  error: null,
+  loading: true,
+})
+
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback
+}
+
 /**
  * RFC-0046 §7 follow-up #1: single composite snapshot fetch shared
  * across the detail surface. Before this hook KeeperStateDiagramPanel
@@ -16,17 +34,31 @@ const RUNTIME_TRACE_REFRESH_MS = 30_000
  * FsmHub still has its own polling/reducer loop — see RFC §7 for the
  * remaining dedup work. This hook handles only the two derived panels.
  */
-export function useKeeperComposite(keeperName: string): KeeperCompositeSnapshot | null {
-  const [snapshot, setSnapshot] = useState<KeeperCompositeSnapshot | null>(null)
+export function useKeeperCompositeEvidence(keeperName: string): KeeperDetailEvidenceState<KeeperCompositeSnapshot> {
+  const [evidence, setEvidence] = useState<KeeperDetailEvidenceState<KeeperCompositeSnapshot>>(() => emptyEvidence())
   useEffect(() => {
     const controller = new AbortController()
     let cancelled = false
+    setEvidence(emptyEvidence())
     const refresh = async () => {
       try {
         const result = await fetchKeeperComposite(keeperName, { signal: controller.signal })
-        if (!cancelled && !controller.signal.aborted) setSnapshot(result)
-      } catch {
-        // best-effort polling — leave the previous snapshot in place
+        if (!cancelled && !controller.signal.aborted) {
+          setEvidence({
+            data: result,
+            refreshedAtMs: Date.now(),
+            error: null,
+            loading: false,
+          })
+        }
+      } catch (err) {
+        if (!cancelled && !controller.signal.aborted) {
+          setEvidence((current) => ({
+            ...current,
+            error: errorMessage(err, 'composite fetch failed'),
+            loading: false,
+          }))
+        }
       }
     }
     void refresh()
@@ -37,23 +69,41 @@ export function useKeeperComposite(keeperName: string): KeeperCompositeSnapshot 
       cleanup()
     }
   }, [keeperName])
-  return snapshot
+  return evidence
 }
 
-export function useKeeperRuntimeTrace(keeperName: string): KeeperRuntimeTraceResponse | null {
-  const [trace, setTrace] = useState<KeeperRuntimeTraceResponse | null>(null)
+export function useKeeperComposite(keeperName: string): KeeperCompositeSnapshot | null {
+  return useKeeperCompositeEvidence(keeperName).data
+}
+
+export function useKeeperRuntimeTraceEvidence(keeperName: string): KeeperDetailEvidenceState<KeeperRuntimeTraceResponse> {
+  const [evidence, setEvidence] = useState<KeeperDetailEvidenceState<KeeperRuntimeTraceResponse>>(() => emptyEvidence())
   useEffect(() => {
     const controller = new AbortController()
     let cancelled = false
+    setEvidence(emptyEvidence())
     const refresh = async () => {
       try {
         const result = await fetchKeeperRuntimeTrace(keeperName, {
           limit: 200,
           signal: controller.signal,
         })
-        if (!cancelled && !controller.signal.aborted) setTrace(result)
-      } catch {
-        // best-effort polling — leave the previous evidence in place
+        if (!cancelled && !controller.signal.aborted) {
+          setEvidence({
+            data: result,
+            refreshedAtMs: Date.now(),
+            error: null,
+            loading: false,
+          })
+        }
+      } catch (err) {
+        if (!cancelled && !controller.signal.aborted) {
+          setEvidence((current) => ({
+            ...current,
+            error: errorMessage(err, 'runtime trace fetch failed'),
+            loading: false,
+          }))
+        }
       }
     }
     void refresh()
@@ -64,5 +114,9 @@ export function useKeeperRuntimeTrace(keeperName: string): KeeperRuntimeTraceRes
       cleanup()
     }
   }, [keeperName])
-  return trace
+  return evidence
+}
+
+export function useKeeperRuntimeTrace(keeperName: string): KeeperRuntimeTraceResponse | null {
+  return useKeeperRuntimeTraceEvidence(keeperName).data
 }

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -24,7 +24,10 @@ import {
   keeperNeedsDiagnosticAttention,
   runSocialSweep,
 } from './keeper-detail-helpers'
-import { useKeeperComposite, useKeeperRuntimeTrace } from './keeper-detail-hooks'
+import {
+  useKeeperCompositeEvidence,
+  useKeeperRuntimeTraceEvidence,
+} from './keeper-detail-hooks'
 import { KeeperLifecycleButtons } from './keeper-detail-lifecycle'
 import {
   KeeperDetailHeaderInfo,
@@ -74,8 +77,10 @@ export function KeeperDetailPage() {
   const [phaseEnteredAtSec, setPhaseEnteredAtSec] = useState<number | null>(null)
   // RFC-0046 §7 #1: single composite snapshot shared with the two
   // derived panels (state-diagram + memory-tier).
-  const compositeSnapshot = useKeeperComposite(keeper.name)
-  const runtimeTrace = useKeeperRuntimeTrace(keeper.name)
+  const compositeEvidence = useKeeperCompositeEvidence(keeper.name)
+  const runtimeTraceEvidence = useKeeperRuntimeTraceEvidence(keeper.name)
+  const compositeSnapshot = compositeEvidence.data
+  const runtimeTrace = runtimeTraceEvidence.data
   const prevKeeperRef = useRef(keeper.name)
   if (prevKeeperRef.current !== keeper.name) {
     prevKeeperRef.current = keeper.name
@@ -179,14 +184,14 @@ export function KeeperDetailPage() {
   return html`
     <div class="mx-auto flex w-full max-w-[1600px] flex-col gap-5 pb-8">
       <div class="sticky top-0 z-20 overflow-hidden rounded-[var(--r-6)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shadow-[var(--shadow-raised)] backdrop-blur-xl">
-        <div class="flex items-center justify-between gap-4 border-b border-[var(--color-border-default)] px-5 py-4 sm:px-6">
+        <div class="flex flex-col items-stretch justify-between gap-4 border-b border-[var(--color-border-default)] px-5 py-4 sm:flex-row sm:items-center sm:px-6">
           <${KeeperDetailHeaderInfo}
             keeper=${keeper}
             titleId=${titleId}
             phaseEnteredAtSec=${phaseEnteredAtSec}
             onClose=${closeKeeperDetail}
           />
-          <div class="flex items-center gap-2">
+          <div class="flex flex-wrap items-center justify-start gap-2 sm:justify-end">
             <button
               type="button"
               class="py-1 px-3 rounded-[var(--r-1)] text-2xs font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--rose-light)] hover:bg-[var(--bad-soft)] transition-colors"
@@ -220,6 +225,8 @@ export function KeeperDetailPage() {
         activityDisplay=${activityDisplay}
         compositeSnapshot=${compositeSnapshot}
         runtimeTrace=${runtimeTrace}
+        compositeEvidence=${compositeEvidence}
+        runtimeTraceEvidence=${runtimeTraceEvidence}
         diagOpen=${diagOpen}
         onDiagToggle=${setDiagOpen}
         checkpointRefreshToken=${checkpointRefreshToken}

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import '@testing-library/jest-dom'
 
 import type { DashboardMissionKeeperBrief, Keeper, KeeperConfig } from '../types'
-import type { KeeperRuntimeTraceResponse } from '../api/keeper'
+import type { KeeperCompositeSnapshot, KeeperRuntimeTraceResponse } from '../api/keeper'
 import {
   AllowlistPreview,
   BudgetSourceBadge,
@@ -13,6 +13,7 @@ import {
   budgetSourceLabel,
   budgetSourceTone,
   filterSignalGroups,
+  deriveKeeperLiveTruth,
   resolveAllowlistPreview,
   resolveKeeperCurrentTaskLabel,
 } from './keeper-detail-runtime'
@@ -533,6 +534,92 @@ describe('RuntimeLensSection', () => {
     }
   }
 
+  function compositeFixture(overrides: Partial<KeeperCompositeSnapshot> = {}): KeeperCompositeSnapshot {
+    const base: KeeperCompositeSnapshot = {
+      keeper: 'sangsu',
+      correlation_id: 'keeper:sangsu:1',
+      run_id: 'run-1',
+      ts: 1_778_688_700,
+      phase: 'running',
+      turn_phase: 'idle',
+      decision: { stage: 'undecided' },
+      cascade: { state: 'idle' },
+      compaction: { stage: 'accumulating' },
+      circuit_breaker: { state: 'clean' },
+      measurement: { captured: false },
+      invariants: {
+        phase_turn_alignment: true,
+        no_cascade_before_measurement: true,
+        compaction_atomicity: true,
+        event_priority_monotone: true,
+        phase_derivation_agreement: true,
+      },
+      phase_diagnosis: {
+        current_phase: 'running',
+        derived_phase: 'running',
+        can_execute_turn: true,
+        conditions: {
+          launch_pending: false,
+          fiber_alive: true,
+          heartbeat_healthy: true,
+          turn_healthy: true,
+          context_within_budget: true,
+          context_handoff_needed: false,
+          compaction_active: false,
+          handoff_active: false,
+          operator_paused: false,
+          stop_requested: false,
+          restart_budget_remaining: true,
+          backoff_elapsed: false,
+          guardrail_triggered: false,
+          drain_complete: false,
+          context_overflow: false,
+          compact_retry_exhausted: false,
+          terminal_failure_latched: false,
+        },
+        determining_condition: 'running_fiber_alive',
+        rows: [],
+      },
+      is_live: false,
+      idle_seconds: 117,
+      last_turn_ts: 1_778_688_606,
+      last_outcome: null,
+      execution: {
+        latest_receipt_present: true,
+        recorded_at: '2026-05-13T16:10:14Z',
+        outcome: 'receipt_done',
+        terminal_reason_code: 'completed',
+        operator_disposition: 'pass',
+        operator_disposition_reason: 'healthy',
+        model_used: null,
+        stop_reason: 'completed',
+        tool_contract_result: 'needs_execution_progress',
+        duration_ms: 16000,
+        error: null,
+        cascade: null,
+        tool_surface: {
+          tool_requirement: 'optional',
+          tool_gate_enabled: false,
+          missing_required_tools: [],
+          required_tools: [],
+        },
+      },
+      runtime_attention: {
+        state: 'blocked',
+        needs_attention: true,
+        blocked: true,
+        fiber_stop_requested: false,
+        reason: 'healthy',
+        raw_phase: 'running',
+        is_live: false,
+        source: 'execution_receipt',
+      },
+      recommended_actions: [],
+      fsm_guard_violations: 0,
+    }
+    return { ...base, ...overrides }
+  }
+
   it('renders axis summary, swimlanes, and gap badges', () => {
     render(h(RuntimeLensSection, { trace: runtimeTraceFixture() }))
 
@@ -549,6 +636,61 @@ describe('RuntimeLensSection', () => {
     render(h(RuntimeLensSection, { trace: null }))
 
     expect(screen.getByText('runtime_trace_unavailable')).toBeInTheDocument()
+  })
+
+  it('derives visible live-truth rows from composite and runtime trace evidence', () => {
+    const summary = deriveKeeperLiveTruth({
+      keeper: {
+        name: 'sangsu',
+        status: 'active',
+        keepalive_running: true,
+      },
+      compositeSnapshot: compositeFixture(),
+      runtimeTrace: runtimeTraceFixture(),
+      runtimeResolution: null,
+    })
+
+    expect(summary.headline).toBe('조치 필요')
+    expect(summary.rows.find(row => row.label === '런타임')?.value).toBe('fiber alive')
+    expect(summary.rows.find(row => row.label === '현재 턴')?.value).toBe('no live turn')
+    expect(summary.rows.find(row => row.label === '최신 증거')?.value).toBe('turn #7 finished')
+    expect(summary.rows.find(row => row.label === 'FSM')?.value).toBe('KSM running / KTC idle')
+    expect(summary.rows.find(row => row.label === '차단')?.detail).toContain('needs_execution_progress')
+  })
+
+  it('surfaces runtime resolution warnings in the live-truth summary', () => {
+    const summary = deriveKeeperLiveTruth({
+      keeper: {
+        name: 'sangsu',
+        status: 'active',
+        keepalive_running: true,
+      },
+      compositeSnapshot: compositeFixture({
+        runtime_attention: {
+          state: 'healthy',
+          needs_attention: false,
+          blocked: false,
+          reason: null,
+          raw_phase: 'running',
+          is_live: false,
+          source: 'execution_receipt',
+        },
+      }),
+      runtimeTrace: runtimeTraceFixture(),
+      runtimeResolution: {
+        status: 'warn',
+        warnings: ['Runtime build commit differs from server repo HEAD.'],
+        source_mismatch: true,
+        server_repo_git_commit: '386514c1f9',
+        workspace_git_commit: 'd0add960d7',
+        server_repo_path: { path: '/repo/.worktrees/stale-server' },
+      },
+    })
+
+    expect(summary.tone).toBe('warn')
+    expect(summary.runtimeWarnings).toEqual(['Runtime build commit differs from server repo HEAD.'])
+    expect(summary.runtimeBuildLabel).toBe('386514c1f9 vs workspace d0add960d7')
+    expect(summary.runtimeRepoLabel).toBe('.worktrees/stale-server')
   })
 })
 

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -5,6 +5,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import { formatPct1 } from '../lib/format-number'
+import { formatDuration } from '../lib/format-time'
 import { ActionButton } from './common/button'
 import { CollapsibleSection } from './common/collapsible'
 import { DistributionBars, type DistributionItem } from './common/distribution-bars'
@@ -15,11 +16,13 @@ import { StatusChip, type StatusChipTone } from './common/status-chip'
 import { toolCategory } from './tool-call-shared'
 import type { Keeper } from '../types'
 import type {
+  KeeperCompositeSnapshot,
   KeeperRuntimeLensLane,
   KeeperRuntimeTraceResponse,
 } from '../api/keeper'
-import { serverStatus } from '../store'
+import { serverStatus, shellRuntimeResolution } from '../store'
 import { operatorSnapshot } from '../operator-store'
+import type { KeeperDetailEvidenceState } from './keeper-detail-hooks'
 import {
   allowlistEmptyState,
   auditMetadataState,
@@ -63,6 +66,338 @@ function SignalRow({ label, value }: { label: string; value: string | number }) 
     <div class="flex items-center justify-between py-2 px-3 rounded-[var(--r-1)] bg-[var(--color-bg-surface)]">
       <span class="text-xs text-[var(--color-fg-muted)]">${label}</span>
       <span class="text-xs font-medium text-[var(--color-fg-secondary)]">${value}</span>
+    </div>
+  `
+}
+
+interface KeeperLiveTruthRuntimeInput {
+  status?: string | null
+  warnings?: string[]
+  source_mismatch?: boolean
+  server_repo_path?: { path?: string | null } | null
+  server_repo_git_commit?: string | null
+  workspace_git_commit?: string | null
+  build?: {
+    commit?: string | null
+    started_at?: string | null
+  } | null
+}
+
+export interface KeeperLiveTruthRow {
+  label: string
+  value: string
+  detail: string
+  tone: StatusChipTone
+}
+
+export interface KeeperLiveTruthSummary {
+  headline: string
+  headlineDetail: string
+  tone: StatusChipTone
+  rows: KeeperLiveTruthRow[]
+  runtimeWarnings: string[]
+  runtimeBuildLabel: string | null
+  runtimeRepoLabel: string | null
+}
+
+function compactToken(value: string | null | undefined, fallback = 'unknown'): string {
+  const text = value?.trim()
+  return text ? text : fallback
+}
+
+function shortCommit(value: string | null | undefined): string | null {
+  const text = value?.trim()
+  return text ? text.slice(0, 10) : null
+}
+
+function isIdleTurnPhase(value: string | null | undefined): boolean {
+  const normalized = value?.trim().toLowerCase()
+  return !normalized || normalized === 'idle' || normalized === 'stable' || normalized === 'offline'
+}
+
+function runtimeWarningList(runtimeResolution: KeeperLiveTruthRuntimeInput | null | undefined): string[] {
+  if (!runtimeResolution) return []
+  const warnings = Array.isArray(runtimeResolution.warnings)
+    ? runtimeResolution.warnings.filter((warning): warning is string => warning.trim() !== '')
+    : []
+  if (runtimeResolution.source_mismatch && warnings.length === 0) {
+    return ['Runtime source mismatch detected.']
+  }
+  return warnings
+}
+
+function terminalEventLabel(trace: KeeperRuntimeTraceResponse | null): {
+  value: string
+  detail: string
+  tone: StatusChipTone
+} {
+  if (!trace) {
+    return {
+      value: 'trace unavailable',
+      detail: 'runtime_trace evidence not loaded',
+      tone: 'neutral',
+    }
+  }
+  const clock = trace.runtime_lens.turn_clock
+  const keeperTurn = clock.keeper_turn_id ?? trace.turn_identity.requested_keeper_turn_id ?? trace.turn_id
+  const turnLabel = keeperTurn == null ? 'turn unknown' : `turn #${keeperTurn}`
+  const terminal = clock.terminal_event_present ? compactToken(clock.terminal_event, 'terminal present') : 'terminal missing'
+  const gapCount = trace.runtime_lens.gaps.length
+  const terminalTone: StatusChipTone =
+    gapCount > 0
+      ? 'warn'
+      : !clock.terminal_event_present
+        ? 'warn'
+        : terminal === 'turn_finished'
+          ? 'ok'
+          : 'info'
+  const detailParts = [
+    `oas ${clock.max_oas_turn_count ?? '-'}`,
+    `manifest ${clock.manifest_total_rows}`,
+    `health ${compactToken(trace.health)}`,
+    gapCount > 0 ? `${gapCount} lens gap${gapCount === 1 ? '' : 's'}` : 'no lens gaps',
+  ]
+  return {
+    value: `${turnLabel} ${terminal === 'turn_finished' ? 'finished' : terminal}`,
+    detail: detailParts.join(' · '),
+    tone: terminalTone,
+  }
+}
+
+export function deriveKeeperLiveTruth({
+  keeper,
+  compositeSnapshot,
+  runtimeTrace,
+  runtimeResolution,
+}: {
+  keeper: Keeper
+  compositeSnapshot: KeeperCompositeSnapshot | null
+  runtimeTrace: KeeperRuntimeTraceResponse | null
+  runtimeResolution?: KeeperLiveTruthRuntimeInput | null
+}): KeeperLiveTruthSummary {
+  const linkedState = linkedRuntimeState(keeper)
+  const phase = compactToken(compositeSnapshot?.phase ?? keeper.phase ?? keeper.status)
+  const turnPhase = compactToken(compositeSnapshot?.turn_phase ?? keeper.pipeline_stage)
+  const fiberAlive =
+    compositeSnapshot?.phase_diagnosis?.conditions.fiber_alive
+    ?? keeper.keepalive_running
+    ?? keeper.presence_keepalive
+    ?? (linkedState !== 'offline')
+  const activeTurn = compositeSnapshot?.is_live === true || !isIdleTurnPhase(compositeSnapshot?.turn_phase)
+  const blocked =
+    compositeSnapshot?.runtime_attention?.blocked === true
+    || compositeSnapshot?.runtime_attention?.needs_attention === true
+    || Boolean(keeper.runtime_blocker_class)
+  const stopRequested =
+    compositeSnapshot?.runtime_attention?.fiber_stop_requested === true
+    || compositeSnapshot?.phase_diagnosis?.conditions.stop_requested === true
+  const traceEvidence = terminalEventLabel(runtimeTrace)
+  const warnings = runtimeWarningList(runtimeResolution)
+  const headline =
+    stopRequested
+      ? '종료 신호'
+      : blocked
+        ? '조치 필요'
+        : fiberAlive && activeTurn
+          ? '턴 진행 중'
+          : fiberAlive
+            ? '대기 중'
+            : runtimeTrace
+              ? '실행 미확인'
+              : '증거 부족'
+  const tone: StatusChipTone =
+    stopRequested
+      ? 'bad'
+      : blocked || warnings.length > 0
+        ? 'warn'
+        : fiberAlive && activeTurn
+          ? 'ok'
+          : fiberAlive
+            ? 'neutral'
+            : runtimeTrace
+              ? 'warn'
+              : 'neutral'
+
+  const idleLabel =
+    typeof compositeSnapshot?.idle_seconds === 'number'
+      ? `${formatDuration(compositeSnapshot.idle_seconds)} idle`
+      : typeof keeper.last_turn_ago_s === 'number'
+        ? `${formatDuration(keeper.last_turn_ago_s)} since turn`
+        : 'idle age unknown'
+  const runtimeReason =
+    compactToken(
+      compositeSnapshot?.runtime_attention?.reason
+      ?? keeper.runtime_blocker_summary
+      ?? keeper.attention_reason
+      ?? null,
+      'no blocker reason',
+    )
+  const toolContract = compactToken(compositeSnapshot?.execution?.tool_contract_result ?? null, 'tool contract unknown')
+  const guardCount = compositeSnapshot?.fsm_guard_violations ?? 0
+  const invariantFailed = compositeSnapshot
+    ? Object.values(compositeSnapshot.invariants).some(value => value === false)
+    : false
+  const runtimeCommit =
+    shortCommit(runtimeResolution?.server_repo_git_commit)
+    ?? shortCommit(runtimeResolution?.build?.commit)
+  const workspaceCommit = shortCommit(runtimeResolution?.workspace_git_commit)
+  const runtimeBuildLabel = runtimeCommit
+    ? workspaceCommit && workspaceCommit !== runtimeCommit
+      ? `${runtimeCommit} vs workspace ${workspaceCommit}`
+      : runtimeCommit
+    : null
+  const runtimeRepoLabel = runtimeResolution?.server_repo_path?.path
+    ? runtimeResolution.server_repo_path.path.split('/').slice(-2).join('/')
+    : null
+
+  return {
+    headline,
+    headlineDetail: [
+      `phase ${phase}`,
+      `turn ${turnPhase}`,
+      fiberAlive ? 'fiber alive' : 'fiber not proven',
+      activeTurn ? 'live turn' : 'no live turn',
+    ].join(' · '),
+    tone,
+    runtimeWarnings: warnings,
+    runtimeBuildLabel,
+    runtimeRepoLabel,
+    rows: [
+      {
+        label: '런타임',
+        value: fiberAlive ? 'fiber alive' : 'fiber not proven',
+        detail: `roster ${keeper.status} · linked ${linkedState}`,
+        tone: fiberAlive ? 'ok' : 'warn',
+      },
+      {
+        label: '현재 턴',
+        value: activeTurn ? `${turnPhase} live` : 'no live turn',
+        detail: `${compositeSnapshot ? (compositeSnapshot.is_live === true ? 'is_live=true' : 'is_live=false') : 'is_live=unknown'} · ${turnPhase} · ${idleLabel}`,
+        tone: activeTurn ? 'ok' : 'neutral',
+      },
+      {
+        label: '최신 증거',
+        value: traceEvidence.value,
+        detail: traceEvidence.detail,
+        tone: traceEvidence.tone,
+      },
+      {
+        label: 'FSM',
+        value: `KSM ${phase} / KTC ${turnPhase}`,
+        detail: `${guardCount} guard violations · ${invariantFailed ? 'invariant fail' : 'invariants ok'}`,
+        tone: guardCount > 0 || invariantFailed ? 'bad' : 'ok',
+      },
+      {
+        label: '차단',
+        value: blocked ? compactToken(compositeSnapshot?.runtime_attention?.state, 'blocked') : 'none',
+        detail: `${runtimeReason} · ${toolContract}`,
+        tone: blocked ? 'warn' : 'ok',
+      },
+    ],
+  }
+}
+
+function EvidenceStamp({
+  label,
+  evidence,
+}: {
+  label: string
+  evidence: Pick<KeeperDetailEvidenceState<unknown>, 'refreshedAtMs' | 'error' | 'loading'>
+}) {
+  const state = evidence.error
+    ? 'error'
+    : evidence.refreshedAtMs
+      ? 'fresh'
+      : evidence.loading
+        ? 'loading'
+        : 'missing'
+  const tone: StatusChipTone =
+    state === 'fresh' ? 'ok' : state === 'error' ? 'warn' : 'neutral'
+  return html`
+    <span class="inline-flex min-w-0 items-center gap-1.5 text-3xs text-[var(--color-fg-muted)]">
+      <${StatusChip} tone=${tone} uppercase=${false}>${label}<//>
+      ${evidence.refreshedAtMs
+        ? html`<${TimeAgo} timestamp=${evidence.refreshedAtMs} />`
+        : html`<span>${state}</span>`}
+      ${evidence.error ? html`<span class="truncate text-[var(--color-status-warn)]">${evidence.error}</span>` : null}
+    </span>
+  `
+}
+
+export function KeeperLiveTruthPanel({
+  keeper,
+  compositeSnapshot,
+  runtimeTrace,
+  compositeEvidence,
+  runtimeTraceEvidence,
+}: {
+  keeper: Keeper
+  compositeSnapshot: KeeperCompositeSnapshot | null
+  runtimeTrace: KeeperRuntimeTraceResponse | null
+  compositeEvidence: KeeperDetailEvidenceState<KeeperCompositeSnapshot>
+  runtimeTraceEvidence: KeeperDetailEvidenceState<KeeperRuntimeTraceResponse>
+}) {
+  const runtimeResolution = shellRuntimeResolution.value
+  const summary = deriveKeeperLiveTruth({
+    keeper,
+    compositeSnapshot,
+    runtimeTrace,
+    runtimeResolution,
+  })
+  const headlineParts = summary.headlineDetail.split(' · ').filter(Boolean)
+  const firstWarning = summary.runtimeWarnings[0] ?? null
+  const extraWarningCount = Math.max(0, summary.runtimeWarnings.length - 1)
+
+  return html`
+    <div
+      class="w-full max-w-[calc(100vw-3rem)] rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-4 lg:max-w-none"
+      data-testid="keeper-live-truth"
+    >
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div class="min-w-0">
+          <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Live truth</div>
+          <div class="mt-1 flex flex-wrap items-center gap-2">
+            <${StatusChip} tone=${summary.tone} uppercase=${false}>${summary.headline}<//>
+            ${headlineParts.map(part => html`
+              <span class="inline-flex max-w-full rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-3xs font-mono text-[var(--color-fg-secondary)]">
+                ${part}
+              </span>
+            `)}
+          </div>
+        </div>
+        <div class="flex min-w-0 flex-wrap justify-start gap-2 sm:justify-end">
+          <${EvidenceStamp} label="composite" evidence=${compositeEvidence} />
+          <${EvidenceStamp} label="trace" evidence=${runtimeTraceEvidence} />
+        </div>
+      </div>
+
+      ${firstWarning ? html`
+        <div class="mt-3 flex min-w-0 flex-wrap items-center gap-2 rounded-[var(--r-1)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-xs text-[var(--color-fg-secondary)]">
+          <${StatusChip} tone="warn" uppercase=${false}>runtime warning<//>
+          <span class="min-w-0 flex-1 truncate">${firstWarning}</span>
+          ${extraWarningCount > 0 ? html`<span class="text-3xs text-[var(--color-fg-muted)]">+${extraWarningCount}</span>` : null}
+        </div>
+      ` : null}
+
+      <div class="mt-3 grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-5">
+        ${summary.rows.map(row => html`
+          <div class="min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
+            <div class="flex items-center justify-between gap-2">
+              <span class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${row.label}</span>
+              <${StatusChip} tone=${row.tone} uppercase=${false}>${row.tone}<//>
+            </div>
+            <div class="mt-1 truncate text-sm font-medium text-[var(--color-fg-primary)]" title=${row.value}>${row.value}</div>
+            <div class="mt-1 truncate text-3xs text-[var(--color-fg-muted)]" title=${row.detail}>${row.detail}</div>
+          </div>
+        `)}
+      </div>
+
+      ${(summary.runtimeBuildLabel || summary.runtimeRepoLabel) ? html`
+        <div class="mt-3 flex flex-wrap gap-2 text-3xs text-[var(--color-fg-muted)]">
+          ${summary.runtimeBuildLabel ? html`<span class="font-mono">build ${summary.runtimeBuildLabel}</span>` : null}
+          ${summary.runtimeRepoLabel ? html`<span class="font-mono">repo ${summary.runtimeRepoLabel}</span>` : null}
+        </div>
+      ` : null}
     </div>
   `
 }

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -74,10 +74,10 @@ function KeeperCascadeSelector({ keeper }: { keeper: Keeper }) {
   ])
 
   return html`
-    <div class="flex items-center gap-1.5">
+    <div class="flex min-w-0 items-center gap-1.5">
       <select
         aria-label="Cascade 프로필 선택"
-        class="py-0.5 px-1 rounded-[var(--r-1)] text-3xs font-mono bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)] border border-[var(--color-border-default)] cursor-pointer"
+        class="min-w-0 max-w-full py-0.5 px-1 rounded-[var(--r-1)] text-3xs font-mono bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)] border border-[var(--color-border-default)] cursor-pointer"
         title=${invalidProfiles.length > 0
           ? `Cascade 프로필\n\n비활성화된 잘못된 프로필:\n${invalidSummary}`
           : 'Cascade 프로필'}
@@ -176,7 +176,7 @@ export function KeeperDetailHeaderInfo({
   onClose: () => void
 }) {
   return html`
-    <div class="flex min-w-0 items-start gap-4">
+    <div class="flex min-w-0 flex-wrap items-start gap-4">
       <button
         type="button"
         onClick=${onClose}
@@ -186,7 +186,7 @@ export function KeeperDetailHeaderInfo({
         목록
       </button>
       <div class="size-12 shrink-0 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] border border-[var(--color-border-default)] flex items-center justify-center text-2xl">${keeper.emoji}</div>
-      <div class="flex flex-col gap-0.5">
+      <div class="flex min-w-[12rem] flex-1 flex-col gap-0.5">
         <${SectionLabel}>모니터링 / 에이전트 / 키퍼 상세</${SectionLabel}>
         <div class="mt-1 flex flex-wrap items-center gap-2.5">
           <h2 id=${titleId} class="m-0 text-lg font-semibold text-[var(--color-fg-primary)]">${keeper.name}</h2>


### PR DESCRIPTION
## Summary
- Add a first-screen Live Truth panel to keeper detail pages so operators can separate fiber liveness, current turn state, latest runtime trace evidence, FSM guard state, and blocker state.
- Preserve composite/runtime-trace fetch freshness and errors instead of silently keeping stale evidence.
- Extend the composite schema for idle_seconds/last_turn_ts and fix keeper detail header wrapping on narrow screens.

## Verification
- pnpm typecheck
- pnpm exec vitest run --config vitest.config.ts src/components/keeper-detail-runtime.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec eslint src/components/keeper-detail-runtime.ts src/components/keeper-detail-body.ts src/components/keeper-detail-page.ts src/components/keeper-detail-shell.ts src/components/keeper-detail-hooks.ts src/api/schemas/keeper-composite.ts src/components/keeper-detail-runtime.test.ts (0 errors; schema/test ignored by current eslint config)
- Playwright screenshots: /tmp/keeper-detail-live-truth-final-desktop-2.png and /tmp/keeper-detail-live-truth-final-mobile-3.png