### PR TITLE
[codex] Show cascade candidate telemetry labels

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -1,6 +1,5 @@
 // CascadeConfigPanel — renders cascade.toml profiles + health tracker state
-// side-by-side so operators can inspect routing order without exposing concrete
-// provider/model identity.
+// side-by-side so operators can inspect routing order and candidate labels.
 //
 // Consumes:
 //   GET /api/v1/cascade/config  — profiles + per-candidate weight/health
@@ -138,7 +137,7 @@ function rawConfigModeSummary(
     primary:
       `현재 active source는 ${sourcePath} 입니다. 원본 cascade.toml 내용은 dashboard API에서 redaction됩니다.`,
     secondary:
-      '프로필, weight, health, validation 상태만 노출되고 provider/model 원문은 OAS-owned runtime data로 남깁니다.',
+      '프로필, 후보 label, weight, health, validation 상태만 노출됩니다.',
     saveLabel: '저장 비활성',
   }
 }
@@ -224,11 +223,33 @@ function validationDescription(status: CascadeValidationStatus): string {
 
 function runtimeKindLabel(kind: string | null | undefined): string | null {
   switch (kind) {
-    case 'cli_agent': return 'CLI(non-interactive)'
-    case 'direct_api': return 'Direct API'
-    case 'local': return '로컬'
+    case 'cli_agent': return 'cli-agent'
+    case 'direct_api': return 'direct-api'
+    case 'local': return 'local'
     default: return null
   }
+}
+
+function candidateWeightLabel(c: CascadeCandidate): string {
+  return c.effective_weight === c.config_weight
+    ? String(c.config_weight)
+    : `${c.config_weight} -> ${c.effective_weight}`
+}
+
+function uniqueNonEmpty(values: readonly string[]): string[] {
+  return Array.from(new Set(values.map(value => value.trim()).filter(Boolean)))
+}
+
+function candidateExpandedSummary(
+  c: CascadeCandidate,
+  displayModel: string,
+): string | null {
+  const expandedModels = uniqueNonEmpty(c.expanded_models ?? [])
+  if (expandedModels.length === 0) return null
+  if (expandedModels.length === 1 && expandedModels[0] === displayModel) return null
+  const visible = expandedModels.slice(0, 3).join(', ')
+  const hidden = expandedModels.length - 3
+  return hidden > 0 ? `${visible} +${hidden}` : visible
 }
 
 function fmtCooldownExpiry(expiresAt: number | null): string {
@@ -349,7 +370,7 @@ function ProfileCard({
   }
 
   return html`
-    <article class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] p-3">
+    <article class="min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] p-3">
       <header class="flex items-center gap-2 mb-2 flex-wrap">
         <span class="font-semibold text-[var(--color-fg-primary)]">${profile.name}</span>
         <${StatusChip} tone=${sourceTone(profile.source)}>
@@ -434,27 +455,56 @@ function ProfileCard({
       ${profile.candidates.length === 0
         ? html`<div class="text-xs text-[var(--color-fg-muted)]">no candidates resolved</div>`
         : html`
-          <ol class="flex flex-col gap-1 text-xs">
+          <ol class="min-w-0 flex flex-col gap-1 text-xs">
             ${profile.candidates.map((c, idx) => {
-              const displayModel = 'runtime'
+              const displayModel = c.display_model ?? c.model
+              const providerLabel = c.display_provider_name ?? c.provider_name
               const runtimeLabel = runtimeKindLabel(c.runtime_kind)
+              const expandedSummary = candidateExpandedSummary(c, displayModel)
               return html`
-              <li class="flex items-start gap-2 py-1 border-b border-[var(--color-border-default)] last:border-b-0">
-                <span class="tabular-nums text-[var(--color-fg-muted)] w-5">${idx + 1}.</span>
-                <${StatusChip} tone=${candidateTone(c)}>
-                  ${c.in_cooldown ? 'cooldown' : formatPct1(c.success_rate)}
-                <//>
-                <div class="flex-1 min-w-0">
-                  <div class="flex items-center gap-2 flex-wrap">
-                    <code class="text-[var(--color-fg-primary)]">${displayModel}</code>
+              <li class="grid grid-cols-1 gap-x-2 gap-y-1 py-2 border-b border-[var(--color-border-default)] last:border-b-0 sm:grid-cols-[auto_minmax(0,1fr)_auto]">
+                <div class="flex items-center gap-1.5 self-start">
+                  <span class="tabular-nums text-[var(--color-fg-muted)] w-5">${idx + 1}.</span>
+                  <${StatusChip} tone=${candidateTone(c)} class="shrink-0">
+                    ${c.in_cooldown ? 'cooldown' : formatPct1(c.success_rate)}
+                  <//>
+                </div>
+                <div class="min-w-0 grid gap-1">
+                  <div class="flex min-w-0 items-baseline gap-1.5 flex-wrap">
+                    <span class="text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]">model</span>
+                    <code class="min-w-0 max-w-full break-all text-[var(--color-fg-primary)]">${displayModel}</code>
+                  </div>
+                  <div class="flex min-w-0 gap-x-3 gap-y-1 flex-wrap text-[var(--color-fg-muted)]">
+                    ${providerLabel
+                      ? html`
+                        <span class="min-w-0">
+                          <span class="text-3xs uppercase tracking-wider">provider</span>
+                          <code class="ml-1 break-all text-[var(--color-fg-primary)]">${providerLabel}</code>
+                        </span>
+                      `
+                      : null}
                     ${runtimeLabel
-                      ? html`<span class="text-[var(--color-fg-muted)]">${runtimeLabel}</span>`
+                      ? html`
+                        <span>
+                          <span class="text-3xs uppercase tracking-wider">runtime</span>
+                          <code class="ml-1 text-[var(--color-fg-primary)]">${runtimeLabel}</code>
+                        </span>
+                      `
+                      : null}
+                    ${expandedSummary
+                      ? html`
+                        <span class="min-w-0">
+                          <span class="text-3xs uppercase tracking-wider">expanded</span>
+                          <code class="ml-1 break-all text-[var(--color-fg-primary)]">${expandedSummary}</code>
+                        </span>
+                      `
                       : null}
                   </div>
                 </div>
-                <span class="tabular-nums text-[var(--color-fg-muted)]">
-                  w ${c.config_weight}${c.effective_weight === c.config_weight ? '' : ` → ${c.effective_weight}`}
-                </span>
+                <div class="flex items-baseline gap-1.5 text-[var(--color-fg-muted)] sm:justify-end sm:text-right">
+                  <span class="text-3xs uppercase tracking-wider">weight</span>
+                  <code class="tabular-nums text-[var(--color-fg-primary)]">${candidateWeightLabel(c)}</code>
+                </div>
               </li>
             `})}
           </ol>
@@ -1152,7 +1202,7 @@ export function CascadeConfigPanel() {
   const slo = current.data?.slo ?? null
 
   return html`
-    <div class="flex flex-col gap-4">
+    <div class="min-w-0 flex flex-col gap-4">
       <div class="flex items-center gap-3 flex-wrap">
         <${Btn} onClick=${() => void loadCascadeData(resource)}>
           새로고침
@@ -1184,7 +1234,7 @@ export function CascadeConfigPanel() {
               )
               return html`
                 <${CascadeValidationBanner} config=${config} />
-                <div class="grid grid-cols-1 gap-3 md:grid-cols-2 mb-3">
+                <div class="grid min-w-0 grid-cols-1 gap-3 md:grid-cols-2 mb-3">
                   <${StatCell}
                     label="프로파일"
                     value=${config.profiles.length}
@@ -1204,7 +1254,7 @@ export function CascadeConfigPanel() {
                 ${config.profiles.length === 0
                   ? html`<${EmptyState}>표시할 유효 cascade profile 이 없습니다.<//>`
                   : html`
-                    <div class="grid gap-3 md:grid-cols-2 mb-3">
+                    <div class="grid min-w-0 gap-3 md:grid-cols-2 mb-3">
                       ${config.profiles.map(p => html`
                         <${ProfileCard}
                           profile=${p}

--- a/dashboard/src/components/common/stat-cell.ts
+++ b/dashboard/src/components/common/stat-cell.ts
@@ -26,10 +26,10 @@ const VALUE_SIZE = {
 
 export function StatCell({ label, value, detail, tone, size = 'md', bg = 'white-4', class: className }: StatCellProps) {
   return html`
-    <div class="p-4 rounded-[var(--r-1)] ${BG[bg]} border border-[var(--color-border-default)] grid gap-1.5 ${tone ?? ''} ${className ?? ''}" role="group" aria-label="${label}: ${value}${detail != null ? ` (${detail})` : ''}">
+    <div class="min-w-0 p-4 rounded-[var(--r-1)] ${BG[bg]} border border-[var(--color-border-default)] grid gap-1.5 ${tone ?? ''} ${className ?? ''}" role="group" aria-label="${label}: ${value}${detail != null ? ` (${detail})` : ''}">
       <span class="text-3xs text-[var(--color-fg-muted)] tracking-wider uppercase font-medium">${label}</span>
-      <strong class="text-[var(--color-fg-secondary)] ${VALUE_SIZE[size]} leading-tight tabular-nums">${value}</strong>
-      ${detail != null ? html`<small class="text-[var(--color-fg-muted)] text-3xs leading-relaxed">${detail}</small>` : null}
+      <strong class="min-w-0 break-words text-[var(--color-fg-secondary)] ${VALUE_SIZE[size]} leading-tight tabular-nums">${value}</strong>
+      ${detail != null ? html`<small class="min-w-0 break-all text-[var(--color-fg-muted)] text-3xs leading-relaxed">${detail}</small>` : null}
     </div>
   `
 }

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -361,6 +361,13 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
     return html`<div class="text-2xs text-[var(--color-fg-disabled)]">Keeper 데이터 없음.</div>`
   }
 
+  const runtimeModelLabel = (model: string): string =>
+    model === 'runtime' ? 'runtime lane' : model
+  const runtimeModelTitle = (model: string): string =>
+    model === 'runtime'
+      ? 'provider/model identity is redacted; use cascade and attempts details below'
+      : model
+
   return html`
     <div class="overflow-x-auto">
       <table class="w-full text-2xs" aria-label="키퍼 텔레메트리 현황">
@@ -484,7 +491,12 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                 valueClass="text-[var(--color-fg-disabled)]"
               />
               <td class="py-1.5 text-right text-3xs text-[var(--color-fg-disabled)]">
-                <div class="font-mono text-[var(--color-fg-secondary)]">${row.model}</div>
+                <div
+                  class="font-mono text-[var(--color-fg-secondary)]"
+                  title=${runtimeModelTitle(row.model)}
+                >
+                  ${runtimeModelLabel(row.model)}
+                </div>
                 ${row.cascade_label
                   ? html`<div class="max-w-56 truncate" title=${row.cascade_label}>cascade ${row.cascade_label}</div>`
                   : null}

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -26,13 +26,17 @@ module StringSet = Set.Make (String)
 let now_iso () = Masc_domain.now_iso ()
 
 let candidate_to_json (c : CC.candidate_info) : Yojson.Safe.t =
+  let string_opt_to_json = function
+    | Some value -> `String value
+    | None -> `Null
+  in
   `Assoc
-    [ "model", `String "runtime"
-    ; "display_model", `Null
-    ; "provider_name", `Null
-    ; "display_provider_name", `Null
-    ; "runtime_kind", `String "runtime"
-    ; "expanded_models", `List []
+    [ "model", `String c.model_string
+    ; "display_model", `String c.display_model_string
+    ; "provider_name", string_opt_to_json c.provider_name
+    ; "display_provider_name", string_opt_to_json c.display_provider_name
+    ; "runtime_kind", string_opt_to_json c.runtime_kind
+    ; "expanded_models", `List (List.map (fun value -> `String value) c.expanded_models)
     ; "config_weight", `Int c.config_weight
     ; "effective_weight", `Int c.effective_weight
     ; "success_rate", `Float c.success_rate

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -584,6 +584,29 @@ let keeper_profile_cascade_name body keeper_name =
   | None -> fail ("keeper profile missing from cascade config: " ^ keeper_name)
 ;;
 
+let cascade_profile_first_candidate body profile_name =
+  let open Yojson.Safe.Util in
+  let json = Yojson.Safe.from_string body in
+  let rows = json |> member "profiles" |> to_list in
+  match
+    List.find_opt
+      (fun row -> row |> member "name" |> to_string = profile_name)
+      rows
+  with
+  | None -> fail ("cascade profile missing from config: " ^ profile_name)
+  | Some row -> (
+      match row |> member "candidates" |> to_list with
+      | candidate :: _ -> candidate
+      | [] -> fail ("cascade profile has no candidates: " ^ profile_name))
+;;
+
+let candidate_string_field field candidate =
+  let open Yojson.Safe.Util in
+  match candidate |> member field with
+  | `String value -> value
+  | _ -> fail ("candidate string field missing: " ^ field)
+;;
+
 let make_keeper_meta_json ?(name = "route_shadow_demo") ?(paused = true) () =
   match
     Masc_test_deps.meta_of_json_fixture
@@ -1324,6 +1347,14 @@ let test_keeper_cascade_assignment_updates_dashboard_projection () =
   check string "dashboard starts with seeded meta cascade"
     Masc_mcp.(Keeper_config.default_cascade_name ())
     (keeper_profile_cascade_name before.body keeper_name);
+  let candidate = cascade_profile_first_candidate before.body "primary" in
+  check bool "dashboard cascade config keeps candidate model label" true
+    (contains_substr "custom:mock@" (candidate_string_field "model" candidate));
+  check bool "dashboard cascade config keeps display model label" true
+    (contains_substr "custom:mock@" (candidate_string_field "display_model" candidate));
+  check string "dashboard cascade config keeps provider label"
+    "custom"
+    (candidate_string_field "provider_name" candidate);
   let assign_result =
     run_curl_post
       ~body:


### PR DESCRIPTION
## Summary

- Stop redacting `/api/v1/cascade/config` candidates to the generic `runtime` placeholder; the dashboard API now emits the resolved candidate model label, display label, provider label, runtime kind, and expanded model list.
- Render cascade profile candidates as labeled operational telemetry rows: model, provider, runtime, expanded, weight, and health status.
- Keep long source paths and model labels from widening/clipping the dashboard on narrow viewports.
- Clarify Fleet Telemetry runtime rows by rendering the redacted `runtime` placeholder as `runtime lane`, with cascade/attempt/fallback details remaining visible below it.

## Root Cause

The backend projection had the candidate data available in `Cascade_config.candidate_info`, but `Dashboard_cascade.candidate_to_json` replaced it with static `runtime` values. The frontend then rendered that placeholder, so operators could see a candidate count and health status but not what the candidate actually represented.

Fleet Telemetry also used the same word, `runtime`, as a display value. That value is intentional redaction, but the UI made it read like a model name rather than a runtime lane bucket.

## Validation

- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/components/cascade-config-panel.ts src/components/common/stat-cell.ts src/components/fleet-telemetry-panel.ts src/api/schemas/cascade.ts src/api/schemas/cascade.test.ts`
- `pnpm exec vitest run src/components/fleet-telemetry-panel.test.ts src/components/fleet-telemetry-utils.test.ts`
- `scripts/dune-local.sh build bin/main_eio.exe test/test_dashboard_keeper_routes.exe`
- `env MASC_MAIN_EIO_EXE=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/cascade-telemetry-candidate-labels-20260514/_build/default/bin/main_eio.exe ./_build/default/test/test_dashboard_keeper_routes.exe test --show-errors --color=never dashboard_keeper_routes 7`
- Rendered dashboard smoke via Playwright on `1440x1100` and `390x844`; verified `MODEL`, `PROVIDER`, `RUNTIME`, `WEIGHT`, `ollama:deepseek-v4-pro:cloud`, and `ollama:deepseek-v4-flash:cloud` are visible with no relevant console errors.