### PR TITLE
fix(cascade): show real provider identity in boot-log catalog snapshot

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -432,13 +432,23 @@ let record_probe_metrics (profiles : profile_snapshot list) =
         profile.probes)
     profiles
 
+(* JSON serialization for the boot-log snapshot. This is an internal
+   observability surface (server_runtime_bootstrap.ml's "Validated active
+   cascade catalog: ..." log line), NOT an external API or dashboard
+   surface. The Runtime Lens redaction (#15040) intentionally erases
+   provider identity at external boundaries — Prometheus labels via
+   [record_probe_metrics] are still redacted and pinned by
+   test_keeper_hooks_oas_telemetry.ml. But the boot log needs real values
+   so operators can verify which providers/models were loaded into the
+   catalog at startup; without that, a misconfigured cascade.toml is
+   indistinguishable from a healthy one in the log. *)
 let candidate_probe_to_yojson (probe : candidate_probe) =
   `Assoc
     [
-      ("model_string", `String public_runtime_model_label);
-      ("provider_kind", `String public_runtime_provider_label);
-      ("model_id", `String public_runtime_model_label);
-      ("base_url", `String "");
+      ("model_string", `String probe.model_string);
+      ("provider_kind", `String probe.provider_kind);
+      ("model_id", `String probe.model_id);
+      ("base_url", `String probe.base_url);
       ( "status",
         match probe.status with
         | Probe_ok -> `String "ok"

--- a/lib/cascade/cascade_legacy_runner.ml
+++ b/lib/cascade/cascade_legacy_runner.ml
@@ -221,12 +221,23 @@ type cascade_metrics_capture = {
   mutable fallback_events_rev : cascade_fallback_event list;
 }
 
+(* Non-redacted JSON encoders for the internal audit log
+   (cascade_observation_to_json → record_cascade_audit). Sibling fields
+   in the same observation envelope (selected_model, primary_model,
+   candidate_models) are already emitted as real strings; the per-attempt
+   and per-fallback model_id were the only fields collapsed to the
+   [public_runtime] placeholder by #15040. Sibling parity restored.
+
+   The redacted variants for external boundaries (keeper metrics consumed
+   by dashboard/OAS) live in lib/keeper/keeper_unified_metrics.ml as
+   [redacted_cascade_attempt_to_json] etc. and intentionally omit
+   model_id/model_label entirely. Those are not touched here. *)
 let cascade_attempt_to_json (attempt : cascade_attempt) : Yojson.Safe.t =
   `Assoc
     [
       ("attempt_index", `Int attempt.attempt_index);
-      ("model_id", `String public_runtime_model_label);
-      ("model_label", `Null);
+      ("model_id", `String attempt.model_id);
+      ("model_label", Json_util.string_opt_to_json attempt.model_label);
       ("latency_ms", Json_util.int_opt_to_json attempt.latency_ms);
       ("error", Json_util.string_opt_to_json attempt.error);
     ]
@@ -235,10 +246,10 @@ let cascade_fallback_event_to_json (event : cascade_fallback_event) :
     Yojson.Safe.t =
   `Assoc
     [
-      ("from_model_id", `String public_runtime_model_label);
-      ("from_model_label", `Null);
-      ("to_model_id", `String public_runtime_model_label);
-      ("to_model_label", `Null);
+      ("from_model_id", `String event.from_model_id);
+      ("from_model_label", Json_util.string_opt_to_json event.from_model_label);
+      ("to_model_id", `String event.to_model_id);
+      ("to_model_label", Json_util.string_opt_to_json event.to_model_label);
       ("reason", `String event.reason);
     ]
 


### PR DESCRIPTION
## Summary

\`Validated active cascade catalog: ...\` 서버 boot log 가 모든 candidate 의 identity 필드를 하드코드된 \`"runtime"\` placeholder 로 출력. operator 가 boot log 에서 *어떤 provider/model 이 catalog 에 로드됐는지* 분간 불가.

## 증상

`.masc/config/cascade.toml` 에 3개 provider, 5개 model, 4개 profile (claude_tool_primary / coding_plan_primary / ollama_cloud_primary / tier-group.coding_plan) 정상 등록된 상태에서 boot log:

```json
{
  "profile_count": 4,
  "profiles": [
    {
      "name": "tier-group.coding_plan",
      "candidates": [
        {
          "model_string": "runtime",
          "provider_kind": "runtime",
          "model_id": "runtime",
          "base_url": "",
          "status": "not_applicable",
          "error": "cloud provider live health is not an auth-free bootstrap probe; credential/config validation is handled before execution"
        },
        { /* 동일 placeholder 반복 */ }
      ]
    },
    ...
  ]
}
```

모든 N×M candidate 가 동일 placeholder. ollama_cloud 의 어느 모델이 등록됐는지, claude_code 의 어느 모델이 routing 되는지 *boot 시점에서 확인 불가*.

## 원인

#15040 (Runtime Lens) 가 \`candidate_probe_to_yojson\` (lib/cascade/cascade_catalog_runtime.ml:435-454) 에서 4개 identity 필드를 하드코드 \`public_runtime_model_label\` / \`public_runtime_provider_label\` / \`""\` 로 치환. 그러나 \`candidate_probe\` 레코드 (line 9-15) 는 *진짜 값을 그대로 가지고 있음* (\`candidate_probe_not_applicable\` 등이 \`candidate.model_string\`, \`candidate.provider_cfg.model_id\` 등을 채워줌, line 264-302).

즉 *데이터는 있으나 serializer 가 버리는* 회귀.

## 의도된 redaction 은 그대로

Runtime Lens 의 redaction 의도는 *external surface* (Prometheus 라벨 / OAS API / dashboard) 에 적용. 본 fix 는 그것들 *건드리지 않음*:

- \`record_probe_metrics\` (line 423-430) — Prometheus 라벨 \`provider_name="runtime"\` / \`model_id="runtime"\` 유지. \`test_keeper_hooks_oas_telemetry.ml:627, 658, 698, 722\` 에서 pin 됨, 43/43 통과 확인.
- \`lib/dashboard/dashboard_oas_bridge.ml\`, \`lib/core/provider_error.ml\` 의 \`public_runtime_*_label\` 사용 — 무변경.

Lens 패턴 정석: redact at *boundary*, not at *every serializer*. Boot log 는 internal observability, external boundary 아님.

## Fix

\`candidate_probe_to_yojson\` 의 4개 필드 emit 을 \`probe.model_string\` / \`probe.provider_kind\` / \`probe.model_id\` / \`probe.base_url\` (레코드 진짜 값) 로 변경. status / error 필드는 redaction 무관, 변경 없음.

```diff
- ("model_string", `String public_runtime_model_label);
- ("provider_kind", `String public_runtime_provider_label);
- ("model_id", `String public_runtime_model_label);
- ("base_url", `String "");
+ ("model_string", `String probe.model_string);
+ ("provider_kind", `String probe.provider_kind);
+ ("model_id", `String probe.model_id);
+ ("base_url", `String probe.base_url);
```

도입 commit 코드 주석에 lens 패턴 의도 명시 — 미래 reviewer 가 redaction 을 *다시* 끼워넣지 않도록 가드.

## Test plan

- [x] \`dune build lib/cascade/\` clean
- [x] \`dune build test/test_keeper_hooks_oas_telemetry.exe\` clean
- [x] 해당 telemetry test 43/43 통과 (Prometheus redaction 회귀 없음)
- [x] \`ocamlformat --check\` clean
- [ ] CI \`Build and Test\` (이 PR 이 lib/cascade/ 만 건드리므로 \`Detect Changed Surfaces\` gate 통과 기대)
- [ ] 서버 boot log 에서 진짜 provider/model identity 확인 (사용자 환경에서)

## 머지 의존성

독립 PR. main 빌드는 #15059 (test_cascade_declarative_hotpath build fix) 머지 후 안정. 본 PR 은 #15059 와 *별개 파일* 이므로 머지 순서 강제 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Scope 확장 (iter 2, 2026-05-14)

`/loop`로 regression hunt 자동 수행 중 동일 패턴 *추가 site* 발견. 동일 commit (`#15040` Runtime Lens) 가 *2개 internal serializer*에 over-redaction 도입:

### 추가 fix: `lib/cascade/cascade_legacy_runner.ml`

| 함수 | 라인 | 패턴 |
|------|------|------|
| `cascade_attempt_to_json` | 228-229 | `model_id` → `public_runtime_model_label`, `model_label` → `Null` |
| `cascade_fallback_event_to_json` | 238-241 | `from_model_id`/`to_model_id` 동일 placeholder |

이들은 **internal audit log** (`cascade_observation_to_json` → `record_cascade_audit`) 의 base serializer. *Redacted 변종*은 별도 함수 (`redacted_cascade_attempt_to_json` in `lib/keeper/keeper_unified_metrics.ml:636`) 로 *명시적으로 존재* — model_id/model_label *전체 omit*. 즉 redaction은 external boundary 별도 라우팅이 의도. base가 redact 되면 두 boundary 동일 출력 — variant 분리 의미 상실.

### 증거: 같은 JSON envelope 내부 *sibling inconsistency*

`cascade_observation_to_json` (line 417) 출력에서:
- 외부 필드: `selected_model`/`primary_model`/`candidate_models` — *real strings*
- 내부 필드: `attempts[*].model_id`/`fallback_events[*].from_model_id` — *placeholder "runtime"*

같은 envelope 내 *동일 의미*의 model identity가 *layer에 따라 redact/non-redact*. operator가 audit 기록 inspect 시 "어떤 attempt가 어떤 모델 사용했는지" *동일 record 안에서* 분간 불가.

### 통합 fix 후 동작

| Boundary | Serializer | Redaction |
|----------|-----------|-----------|
| **Boot log** (`server_runtime_bootstrap.ml`) | `candidate_probe_to_yojson` | **real values** (1차 fix) |
| **Audit log** (`record_cascade_audit`) | `cascade_attempt_to_json` / `cascade_fallback_event_to_json` | **real values** (2차 fix) |
| **Dashboard/OAS** | `dashboard_oas_bridge.ml`, `dashboard_harness_health.ml` | placeholder *유지* (intentional boundary) |
| **Keeper unified metrics** | `redacted_cascade_attempt_to_json` etc. | placeholder *유지* (intentional boundary) |
| **Prometheus labels** | `record_probe_metrics` | placeholder *유지* (test-pinned: `test_keeper_hooks_oas_telemetry.ml`) |
| **Provider error responses** | `provider_error.ml` | placeholder *유지* (external API) |

Lens 패턴 정석 회복: redact at *boundary*, real data at *internal layer*.

### 검증

- `dune build lib/cascade/`: clean
- `dune build test/test_keeper_hooks_oas_telemetry.exe`: clean
- Test 43/43 통과 (Prometheus redaction 회귀 없음)
- ocamlformat: clean
- regression hunt 결과 cascade/ 외 더 이상 internal serializer 에 `public_runtime_*` 패턴 없음 (dashboard/provider_error는 외부 boundary)

