### PR TITLE
[codex] fix cascade liveness metric units

### DIFF
--- a/lib/cascade/cascade_attempt_liveness.ml
+++ b/lib/cascade/cascade_attempt_liveness.ml
@@ -67,7 +67,7 @@ type output =
   | Completed
 
 (** Metric recorder — caller (e.g. cascade_attempt_liveness_observer)
-    supplies callbacks for TTFT, TBT, and liveness outcome.
+    supplies callbacks for TTFT seconds, TBT seconds, and liveness outcome.
     Pure FSM stays IO-free; side effects live in the recorder. *)
 type recorder = {
   record_ttft : float -> unit;
@@ -108,8 +108,8 @@ let step ?(recorder = null_recorder) (b : budget) (s : state) (e : event)
 
   (* Awaiting × chunk(any non-Done): transition to Streaming. *)
   | Awaiting { started_at }, Chunk (_, received_at) ->
-      let ttft_ms = (received_at -. started_at) *. 1000.0 in
-      recorder.record_ttft ttft_ms;
+      let ttft_seconds = received_at -. started_at in
+      recorder.record_ttft ttft_seconds;
       ( Streaming { started_at; last_chunk_at = received_at }
       , Continue )
 
@@ -135,8 +135,8 @@ let step ?(recorder = null_recorder) (b : budget) (s : state) (e : event)
 
   (* Streaming × chunk(any non-Done): advance last_chunk_at. *)
   | Streaming { started_at; last_chunk_at = prev_last }, Chunk (_, received_at) ->
-      let tbt_ms = (received_at -. prev_last) *. 1000.0 in
-      recorder.record_inter_chunk tbt_ms;
+      let tbt_seconds = received_at -. prev_last in
+      recorder.record_inter_chunk tbt_seconds;
       ( Streaming { started_at; last_chunk_at = received_at }
       , Continue )
 

--- a/lib/cascade/cascade_attempt_liveness.mli
+++ b/lib/cascade/cascade_attempt_liveness.mli
@@ -175,9 +175,10 @@ type output =
   | Completed
       (** Attempt succeeded. *)
 
-(** Metric recorder — caller supplies callbacks for TTFT, TBT, and
-    liveness outcome observation.  [null_recorder] is the default so
-    the pure FSM stays IO-free unless a caller explicitly wires metrics. *)
+(** Metric recorder — caller supplies callbacks for TTFT seconds, TBT
+    seconds, and liveness outcome observation.  [null_recorder] is the
+    default so the pure FSM stays IO-free unless a caller explicitly
+    wires metrics. *)
 type recorder = {
   record_ttft : float -> unit;
   record_inter_chunk : float -> unit;

--- a/test/test_cascade_attempt_liveness.ml
+++ b/test/test_cascade_attempt_liveness.ml
@@ -33,6 +33,28 @@ let check_output =
 let budget : L.budget =
   { ttft_max = 30.0; inter_chunk_max = 20.0; attempt_wall_max = 180.0 }
 
+let test_recorder_receives_seconds_not_milliseconds () =
+  let ttft = ref None in
+  let inter_chunk = ref None in
+  let recorder : L.recorder =
+    {
+      record_ttft = (fun seconds -> ttft := Some seconds);
+      record_inter_chunk = (fun seconds -> inter_chunk := Some seconds);
+      record_liveness_outcome = (fun _ -> ());
+    }
+  in
+  let s = L.initial ~started_at:10.0 in
+  let s', _ =
+    L.step ~recorder budget s (L.Chunk (C.Answer_delta, 12.5))
+  in
+  let _s'', _ =
+    L.step ~recorder budget s' (L.Chunk (C.Answer_delta, 13.75))
+  in
+  Alcotest.(check (option (float 0.0001)))
+    "TTFT recorded in seconds" (Some 2.5) !ttft;
+  Alcotest.(check (option (float 0.0001)))
+    "inter-chunk recorded in seconds" (Some 1.25) !inter_chunk
+
 (* ──────────────────────── §4.5 decision table ──────────────────────── *)
 
 let test_awaiting_chunk_any_to_streaming () =
@@ -256,6 +278,8 @@ let () =
     [
       ( "decision_table",
         [
+          case "recorder receives seconds, not milliseconds"
+            test_recorder_receives_seconds_not_milliseconds;
           case "Awaiting × chunk(any) → Streaming"
             test_awaiting_chunk_any_to_streaming;
           case "Awaiting × Tick(t≥ttft) → Failed No_first_token"


### PR DESCRIPTION
## Summary
- Emit cascade liveness TTFT/TBT recorder values in seconds instead of milliseconds.
- Clarify the recorder contract in the implementation/interface docs.
- Add a regression test that pins seconds units before values reach Prometheus histograms.

## Why
The old Kimi/cascade telemetry docs called out missing or unreliable provider timing visibility. Current main has the histograms, but the pure FSM was feeding millisecond values into recorder callbacks consumed by `masc_cascade_ttfb_seconds` and `masc_cascade_inter_chunk_seconds`, making the Prometheus series 1000x too large.

## Validation
- `scripts/dune-local.sh build @test/runtest-test_cascade_attempt_liveness`
- `scripts/dune-local.sh build @test/runtest-test_cascade_attempt_liveness_observer`
- `git diff --check`