### PR TITLE
feat(ide): focus keeper routes from context links

### DIFF
--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useState, useRef, useEffect } from 'preact/hooks'
-import { route } from '../router'
+import { replaceRoute, route } from '../router'
 import { keepers } from '../store'
 import { selectKeeper } from '../keeper-runtime'
 import { loadKeeperConfig } from './keeper-config-panel'
@@ -42,6 +42,55 @@ const CLOSE_BUTTON_FOCUS_CLASS = ringFocusClasses({
   offset: 2,
   offsetSurface: 'page',
 })
+
+function clearKeeperRouteFocus(): void {
+  const params: Record<string, string> = { ...route.value.params, section: 'agents' }
+  delete params.agent
+  delete params.keeper
+  replaceRoute('monitoring', params)
+}
+
+function KeeperRouteFocusPanel({
+  keeperName,
+  status,
+  agentName,
+}: {
+  keeperName: string
+  status: string
+  agentName?: string | null
+}) {
+  return html`
+    <section
+      class="rounded-[var(--r-1)] border border-[var(--color-brass-border)] bg-[var(--color-brass-soft)] px-3 py-2"
+      data-testid="keeper-route-focus"
+      aria-label="Keeper route focus"
+    >
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div class="min-w-0">
+          <div class="font-mono text-3xs font-semibold uppercase tracking-[var(--track-section)] text-[var(--color-accent-fg)]">
+            ROUTE FOCUS
+          </div>
+          <div class="mt-1 flex min-w-0 flex-wrap items-center gap-2 text-xs text-[var(--color-fg-secondary)]">
+            <span class="rounded-[var(--r-0)] border border-[var(--color-brass-border)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-[var(--color-accent-fg)]">
+              KEEPER ${keeperName}
+            </span>
+            <span class="font-mono text-3xs text-[var(--color-fg-muted)]">status ${status}</span>
+            ${agentName ? html`
+              <span class="font-mono text-3xs text-[var(--color-fg-muted)]">agent ${agentName}</span>
+            ` : null}
+          </div>
+        </div>
+        <button
+          type="button"
+          class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-border-strong)] hover:text-[var(--color-fg-primary)]"
+          onClick=${clearKeeperRouteFocus}
+        >
+          CLEAR
+        </button>
+      </div>
+    </section>
+  `
+}
 
 export function KeeperDetailPage() {
   const keeperName =
@@ -182,7 +231,7 @@ export function KeeperDetailPage() {
   }
 
   return html`
-    <div class="mx-auto flex w-full max-w-[1600px] flex-col gap-5 pb-8">
+    <div class="mx-auto flex w-full max-w-[1600px] flex-col gap-5 pb-8" data-route-focused-keeper=${keeper.name}>
       <div class="sticky top-0 z-20 overflow-hidden rounded-[var(--r-6)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shadow-[var(--shadow-raised)] backdrop-blur-xl">
         <div class="flex flex-col items-stretch justify-between gap-4 border-b border-[var(--color-border-default)] px-5 py-4 sm:flex-row sm:items-center sm:px-6">
           <${KeeperDetailHeaderInfo}
@@ -215,6 +264,12 @@ export function KeeperDetailPage() {
           </div>
         </div>
       </div>
+
+      <${KeeperRouteFocusPanel}
+        keeperName=${keeper.name}
+        status=${effectiveStatus}
+        agentName=${keeper.agent_name ?? keeper.agent?.name ?? null}
+      />
 
       <${KeeperDetailBody}
         keeper=${keeper}

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render, screen } from '@testing-library/preact'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
 import { html } from 'htm/preact'
 
 import type { Keeper } from '../types'
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   resetKeeperConfig: vi.fn(),
   selectKeeper: vi.fn(),
   navigate: vi.fn(),
+  replaceRoute: vi.fn(),
   route: {
     value: {
       tab: 'monitoring',
@@ -116,6 +117,7 @@ vi.mock('../keeper-runtime', async () => {
 
 vi.mock('../router', () => ({
   navigate: mocks.navigate,
+  replaceRoute: mocks.replaceRoute,
   route: mocks.route,
 }))
 
@@ -145,6 +147,7 @@ describe('openKeeperDetail', () => {
     mocks.resetKeeperConfig.mockClear()
     mocks.selectKeeper.mockClear()
     mocks.navigate.mockClear()
+    mocks.replaceRoute.mockClear()
     mocks.route.value = {
       tab: 'monitoring',
       params: { section: 'agents', view: 'keepers' },
@@ -312,6 +315,39 @@ describe('KeeperDetailPage', () => {
     render(html`<${KeeperDetailPage} />`)
     expect(screen.getByText('analyst')).toBeTruthy()
     expect(mocks.selectKeeper).toHaveBeenCalledWith('analyst')
+  })
+
+  it('surfaces and clears keeper route focus without dropping the keepers view', () => {
+    const analyst = {
+      name: 'analyst',
+      status: 'active',
+      phase: 'Running',
+      pipeline_stage: 'idle',
+      agent_name: 'keeper-analyst-agent',
+      runtime_class: 'keeper',
+      agent: {
+        exists: true,
+        name: 'keeper-analyst-agent',
+        agent_type: 'agent',
+        status: 'active',
+      },
+    } as unknown as Keeper
+    keepers.value = [analyst]
+
+    render(html`<${KeeperDetailPage} />`)
+
+    const focus = screen.getByTestId('keeper-route-focus')
+    expect(focus.textContent).toContain('ROUTE FOCUS')
+    expect(focus.textContent).toContain('KEEPER analyst')
+    expect(focus.textContent).toContain('agent keeper-analyst-agent')
+    expect(document.querySelector('[data-route-focused-keeper="analyst"]')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'CLEAR' }))
+
+    expect(mocks.replaceRoute).toHaveBeenCalledWith('monitoring', {
+      section: 'agents',
+      view: 'keepers',
+    })
   })
 })
 


### PR DESCRIPTION
## Summary
- add a brass route-focus receipt on keeper detail pages reached through `keeper` route params
- mark the focused keeper detail surface with `data-route-focused-keeper` for route-link verification
- clear only keeper/agent focus params while preserving the agents/keepers route context

## Validation
- `pnpm install --offline --frozen-lockfile`
- `pnpm exec eslint src/components/keeper-detail-page.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/keeper-detail.test.ts src/components/agents-unified.test.ts`
- `git diff --check`