### PR TITLE
fix(keeper): classify internal receipt errors

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -415,6 +415,7 @@ type operator_disposition_reason =
   | Reason_degraded_retry
   | Reason_cascade_fallback
   | Reason_provider_runtime_error
+  | Reason_internal_error
   | Reason_tool_required_unsatisfied
   | Reason_turn_livelock_blocked
   | Reason_cancelled
@@ -428,6 +429,7 @@ let operator_disposition_reason_to_string = function
   | Reason_degraded_retry -> "degraded_retry"
   | Reason_cascade_fallback -> "cascade_fallback"
   | Reason_provider_runtime_error -> "provider_runtime_error"
+  | Reason_internal_error -> "internal_error"
   | Reason_tool_required_unsatisfied -> "tool_required_unsatisfied"
   | Reason_turn_livelock_blocked -> "turn_livelock_blocked"
   | Reason_cancelled -> "cancelled"
@@ -503,6 +505,13 @@ let operator_disposition (receipt : t)
     | Some "turn_livelock_blocked" -> true
     | Some _ | None -> false
   then Disp_pause_human, Reason_turn_livelock_blocked
+  else if
+    String.equal terminal_reason "internal_error"
+    ||
+    match error_kind with
+    | Some "internal" -> true
+    | Some _ | None -> false
+  then Disp_pause_human, Reason_internal_error
   else if
     receipt.tool_surface.tool_requirement = Required
     && (List.mem

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -243,6 +243,7 @@ type operator_disposition_reason =
   | Reason_degraded_retry
   | Reason_cascade_fallback
   | Reason_provider_runtime_error
+  | Reason_internal_error
   | Reason_tool_required_unsatisfied
   | Reason_turn_livelock_blocked
   | Reason_cancelled

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -193,6 +193,19 @@ let test_provider_failure_not_reported_as_tool_unsatisfied () =
   check_disp "provider failure before tool use" r "pause_human" "provider_runtime_error"
 ;;
 
+let test_internal_error_not_unmapped () =
+  let r =
+    mk_receipt
+      ~outcome:`Error
+      ~cascade_outcome:Cascade_completed
+      ~terminal_reason_code:"internal_error"
+      ~tool_contract_result:Contract_satisfied_completion
+      ~error_kind:(Some (R.error_kind_of_string "internal"))
+      ()
+  in
+  check_disp "internal error" r "pause_human" "internal_error"
+;;
+
 let test_preflight_config_failure_not_reported_as_tool_unsatisfied () =
   let r =
     mk_receipt
@@ -607,6 +620,10 @@ let () =
             "provider failure before tool use -> provider_runtime_error"
             `Quick
             test_provider_failure_not_reported_as_tool_unsatisfied
+        ; test_case
+            "internal error -> pause_human"
+            `Quick
+            test_internal_error_not_unmapped
         ; test_case
             "config failure before tool use -> preflight_config_error"
             `Quick


### PR DESCRIPTION
## Summary
- classify receipt `terminal_reason_code=internal_error` / `error_kind=internal` as `pause_human/internal_error`
- prevent this live log shape from falling through to `unknown/unmapped_cascade_state`
- stop force-adding optional/admin `keeper_board_cleanup` to board-curation preferred tools; janitor can still see cleanup via explicit allow-list

## Live log evidence
Observed in `/Users/dancer/me/.masc/logs/masc-mcp-8935.log` on 2026-05-14 KST:
- `operator_disposition: unmapped (outcome=error cascade_outcome=completed terminal_reason=internal_error tool_contract_result=satisfied_completion error_kind=internal)`
- `operator_broadcast_required emitted disposition=unknown reason=unmapped_cascade_state`
- repeated `AllowList pruned 1 tool(s) outside visible policy surface: keeper_board_cleanup`

Runtime config note:
- local `~/.masc/config/keepers/glm-coding.toml` was also narrowed to allow `keeper_board_search`, because the live keeper attempted it and `preset = "coding"` intentionally omits `board_extended`.

## Verification
- `opam exec -- ocamlformat --check lib/keeper/keeper_execution_receipt.ml lib/keeper/keeper_execution_receipt.mli lib/keeper/keeper_agent_tool_surface.ml test/test_keeper_pause_broadcast.ml test/test_keeper_unified.ml`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build --cache=disabled test/test_keeper_unified.exe test/test_keeper_pause_broadcast.exe bin/main_eio.exe`
- `./_build/default/test/test_keeper_pause_broadcast.exe`
- `./_build/default/test/test_keeper_unified.exe test tool_classification`
- `git diff --check`