### PR TITLE
[codex] Fix keeper public tool alias validation

### DIFF
--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -164,14 +164,34 @@ let final_keeper_tool_names
       ~(allowed_tool_names : string list)
   : string list
   =
-  merge_reported_and_observed_tool_names ~reported_tool_names ~observed_tool_names
-  |> List.map canonical_name
+  let allowed_tool_names =
+    allowed_tool_names |> List.map canonical_name |> Keeper_types.dedupe_keep_order
+  in
+  let reported_tool_names = List.map canonical_name reported_tool_names in
+  let observed_tool_names = List.map canonical_name observed_tool_names in
+  let tool_names =
+    match observed_tool_names with
+    | [] -> reported_tool_names
+    | _ :: _ ->
+      let observed = Hashtbl.create (List.length observed_tool_names) in
+      List.iter
+        (fun tool_name -> Hashtbl.replace observed tool_name ())
+        observed_tool_names;
+      observed_tool_names
+      @ List.filter
+          (fun tool_name -> not (Hashtbl.mem observed tool_name))
+          reported_tool_names
+  in
+  tool_names
   |> List.filter (fun tool_name -> List.mem tool_name allowed_tool_names)
 ;;
 
 let unexpected_tool_names ~(allowed_tool_names : string list) ~(tool_names : string list)
   : string list
   =
+  let allowed_tool_names =
+    allowed_tool_names |> List.map canonical_name |> Keeper_types.dedupe_keep_order
+  in
   let allowed = Hashtbl.create (List.length allowed_tool_names) in
   let seen = Hashtbl.create (List.length tool_names) in
   List.iter (fun tool_name -> Hashtbl.replace allowed tool_name ()) allowed_tool_names;

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -39,9 +39,10 @@ val merge_reported_and_observed_tool_names
   -> observed_tool_names:string list
   -> string list
 
-(** Compose [merge_reported_and_observed_tool_names] with public-name
-    canonicalization (via [Keeper_tool_alias.route]) and filter to the
-    keeper's [allowed_tool_names]. *)
+(** Merge reported/observed tool names after public-name canonicalization
+    (via [Keeper_tool_alias.route]) and filter to the keeper's canonical
+    [allowed_tool_names]. The allowlist may contain either LLM-visible
+    aliases (e.g. [Bash]) or internal handler names (e.g. [keeper_bash]). *)
 val final_keeper_tool_names
   :  reported_tool_names:string list
   -> observed_tool_names:string list
@@ -49,7 +50,9 @@ val final_keeper_tool_names
   -> string list
 
 (** Names called by the model that are NOT on the keeper's allowed
-    surface (deduped, order preserving). *)
+    surface (deduped, order preserving). [allowed_tool_names] is
+    canonicalized before comparison so runtime-reported internal
+    handler names can satisfy a public alias surface. *)
 val unexpected_tool_names
   :  allowed_tool_names:string list
   -> tool_names:string list

--- a/test/test_keeper_tool_surface_guard.ml
+++ b/test/test_keeper_tool_surface_guard.ml
@@ -21,6 +21,27 @@ let test_unexpected_tool_names_reports_foreign_surface () =
        ~tool_names:[ "keeper_task_claim"; "Skill"; "Bash"; "Skill"; "Agent" ])
 ;;
 
+let test_unexpected_tool_names_accepts_public_alias_surface () =
+  check
+    (list string)
+    "public alias accepts internal handler"
+    []
+    (KTD.unexpected_tool_names
+       ~allowed_tool_names:[ "Bash"; "Read"; "masc_board_post" ]
+       ~tool_names:[ "keeper_bash"; "keeper_fs_read"; "keeper_board_post" ])
+;;
+
+let test_final_keeper_tool_names_accepts_public_alias_surface () =
+  check
+    (list string)
+    "public alias keeps canonical internal tool"
+    [ "keeper_bash" ]
+    (KTD.final_keeper_tool_names
+       ~reported_tool_names:[ "mcp__masc__Bash" ]
+       ~observed_tool_names:[ "keeper_bash" ]
+       ~allowed_tool_names:[ "Bash" ])
+;;
+
 (* #8471 partial tolerance: mixed turn (valid + unexpected) must not
    hard-fail — the valid tool call is real work and should survive. *)
 let test_has_valid_tool_call_true_when_mixed () =
@@ -151,6 +172,14 @@ let () =
             "reports foreign surface"
             `Quick
             test_unexpected_tool_names_reports_foreign_surface
+        ; test_case
+            "accepts public alias surface"
+            `Quick
+            test_unexpected_tool_names_accepts_public_alias_surface
+        ; test_case
+            "final names accept public alias surface"
+            `Quick
+            test_final_keeper_tool_names_accepts_public_alias_surface
         ] )
     ; ( "partial_tolerance"
       , [ test_case


### PR DESCRIPTION
## Summary

- Canonicalize keeper allowlists before unexpected-tool checks.
- Merge reported and observed keeper tool names after canonicalization.
- Add regressions for public alias surfaces such as `Bash` mapping to `keeper_bash`.

## Root cause

Live Sangsu receipts showed a false `tool_surface_mismatch`: the model-visible surface allowed public aliases like `Bash`, while runtime telemetry reported internal handler names like `keeper_bash`. The disclosure guard canonicalized called tool names, but compared them against the uncanonicalized allowlist, so an allowed tool was rejected as unexpected.

The same path could double-count one physical call when reported tool names used MCP alias form and observed tool names used internal handler form. This patch canonicalizes both sides before filtering and de-dupes reported names already seen in observed telemetry.

## Validation

- `opam exec -- ocamlformat --check lib/keeper/keeper_tool_disclosure.ml lib/keeper/keeper_tool_disclosure.mli test/test_keeper_tool_surface_guard.ml`
- `scripts/dune-local.sh build test/test_keeper_tool_surface_guard.exe`
- `./_build/default/test/test_keeper_tool_surface_guard.exe`
- `scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_tool_alias.exe test/test_keeper_tool_surface_guard.exe`
- `./_build/default/test/test_keeper_tool_alias.exe`
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 41 --show-errors`
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 42 --show-errors`
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 61 --show-errors`
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 62 --show-errors`
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 63 --show-errors`
- `git diff --check`
