### PR TITLE
[codex] trim dashboard monitoring descriptions

### DIFF
--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -103,6 +103,26 @@ describe('monitoring navigation labels', () => {
     expect(labelFor('cognition')).toBe('Cognition')
   })
 
+  it('keeps monitoring descriptions concise instead of comma-heavy domain lists', () => {
+    const sections = visibleSectionItemsForTab('monitoring')
+    const descriptions = Object.fromEntries(sections.map(item => [item.id, item.description]))
+
+    expect(descriptions).toMatchObject({
+      journey: 'Unified execution flow across lifecycle stages.',
+      agents: 'Live runtime-backed roster and process state.',
+      cognition: 'Keeper cognition and resource state.',
+      runtime: 'Provider routing health and cost.',
+      'goal-loop': 'Runtime progress through the goal loop.',
+      'fleet-health': 'Fleet-wide signal aggregation and comparison.',
+    })
+
+    for (const item of sections) {
+      const wordCount = item.description.split(/\s+/).filter(Boolean).length
+      expect(wordCount).toBeLessThanOrEqual(7)
+      expect(item.description.split(',').length).toBeLessThanOrEqual(2)
+    }
+  })
+
   it('does not expose sessions section (removed in Phase 0 of RFC-MASC-006)', () => {
     const sections = visibleSectionItemsForTab('monitoring')
     const ids = sections.map(item => item.id)

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -91,7 +91,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     id: 'monitoring',
     label: 'Monitor',
     icon: 'monitoring',
-    description: 'Fleet storylines, agents, runtime, and telemetry',
+    description: 'Fleet storylines and runtime telemetry',
     defaultTab: 'monitoring',
     defaultParams: { section: 'journey' },
     tabs: ['monitoring'],
@@ -165,7 +165,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'journey',
       label: 'Journey Map',
-      description: 'Task, run, contract, keeper, thinking, memory, turn, life, and cascade in one flow.',
+      description: 'Unified execution flow across lifecycle stages.',
       params: { section: 'journey' },
     },
     {
@@ -187,25 +187,25 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'cognition',
       label: 'Cognition',
-      description: 'Keeper BDI, token load, memory, decisions, and autoresearch loops.',
+      description: 'Keeper cognition and resource state.',
       params: { section: 'cognition' },
     },
     {
       id: 'runtime',
       label: 'Cascade',
-      description: 'Provider health, capacity, routing, cost, latency, and inspector views.',
+      description: 'Provider routing health and cost.',
       params: { section: 'runtime' },
     },
     {
       id: 'goal-loop',
       label: 'GOAL LOOP',
-      description: 'Observe, Orient, Decide, Act, and Verify runtime status.',
+      description: 'Runtime progress through the goal loop.',
       params: { section: 'goal-loop' },
     },
     {
       id: 'fleet-health',
       label: 'Fleet Telemetry',
-      description: 'Event log, keeper comparison, tool quality, governance, and attribution signals.',
+      description: 'Fleet-wide signal aggregation and comparison.',
       params: { section: 'fleet-health' },
     },
   ],


### PR DESCRIPTION
## Summary
- Trim verbose Monitor surface and monitoring-section descriptions called out by the dashboard IA audit.
- Keep navigation structure, hidden diagnostic routes, and legacy redirects unchanged.
- Add a regression test that pins concise descriptions and blocks comma-heavy domain lists from returning.

## Why
The old dashboard menu audit identified several Monitor descriptions that listed many domains at once, making the sidebar harder to scan. Current main already consolidated the section structure, so this PR only treats the remaining copy-level issue without changing routes.

## Validation
- pnpm exec vitest run --config vitest.config.ts src/config/navigation.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD~1..HEAD