### PR TITLE
feat(ide): polish planning route focus receipt

### DIFF
--- a/dashboard/src/components/planning-panel.test.ts
+++ b/dashboard/src/components/planning-panel.test.ts
@@ -181,8 +181,11 @@ describe('PlanningPanel', () => {
 
     render(html`<${PlanningPanel} />`)
 
-    expect(screen.getByTestId('planning-route-focus')).toBeTruthy()
-    expect(screen.getByText('goal goal-runtime')).toBeTruthy()
+    const focus = screen.getByTestId('planning-route-focus')
+    expect(focus).toBeTruthy()
+    expect(focus.getAttribute('data-route-focused-goal')).toBe('goal-runtime')
+    expect(focus.textContent).toContain('ROUTE FOCUS')
+    expect(screen.getByText('GOAL goal-runtime')).toBeTruthy()
     expect(screen.getByText('Runtime context goal')).toBeTruthy()
     expect(screen.getByText('active')).toBeTruthy()
   })
@@ -205,8 +208,11 @@ describe('PlanningPanel', () => {
 
     render(html`<${PlanningPanel} />`)
 
-    expect(screen.getByTestId('planning-route-focus')).toBeTruthy()
-    expect(screen.getByText('task task-runtime')).toBeTruthy()
+    const focus = screen.getByTestId('planning-route-focus')
+    expect(focus).toBeTruthy()
+    expect(focus.getAttribute('data-route-focused-task')).toBe('task-runtime')
+    expect(focus.textContent).toContain('ROUTE FOCUS')
+    expect(screen.getByText('TASK task-runtime')).toBeTruthy()
     expect(screen.getByText('Runtime context task')).toBeTruthy()
     expect(screen.getByText('@sangsu')).toBeTruthy()
     await waitFor(() => {
@@ -228,7 +234,7 @@ describe('PlanningPanel', () => {
     }
 
     render(html`<${PlanningPanel} />`)
-    fireEvent.click(screen.getByRole('button', { name: 'clear' }))
+    fireEvent.click(screen.getByRole('button', { name: 'CLEAR' }))
 
     expect(routeSignal.value.params).toEqual({
       section: 'planning',

--- a/dashboard/src/components/planning-panel.ts
+++ b/dashboard/src/components/planning-panel.ts
@@ -115,17 +115,19 @@ function PlanningRouteFocusPanel() {
     <section
       class="rounded-[var(--r-1)] border border-[var(--color-brass-border)] bg-[var(--color-brass-soft)] px-3 py-2"
       data-testid="planning-route-focus"
+      data-route-focused-goal=${goalId ?? undefined}
+      data-route-focused-task=${taskId ?? undefined}
       aria-label="Planning route focus"
     >
       <div class="flex flex-wrap items-start justify-between gap-3">
         <div class="min-w-0">
-          <div class="font-mono text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-accent-fg)]">
-            route focus
+          <div class="font-mono text-3xs font-semibold uppercase tracking-[var(--track-section)] text-[var(--color-accent-fg)]">
+            ROUTE FOCUS
           </div>
           <div class="mt-1 flex min-w-0 flex-wrap items-center gap-2 text-xs text-text-body">
             ${goalId ? html`
-              <span class="rounded-[var(--r-1)] border border-[var(--color-brass-border)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-[var(--color-accent-fg)]">
-                goal ${goalId}
+              <span class="rounded-[var(--r-0)] border border-[var(--color-brass-border)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-[var(--color-accent-fg)]">
+                GOAL ${goalId}
               </span>
               <span class="min-w-0 truncate text-sm font-semibold text-text-strong">
                 ${goal?.title ?? 'goal not loaded'}
@@ -133,8 +135,8 @@ function PlanningRouteFocusPanel() {
               ${goal?.status ? html`<span class="font-mono text-3xs text-text-muted">${goal.status}</span>` : null}
             ` : null}
             ${taskId ? html`
-              <span class="rounded-[var(--r-1)] border border-[var(--color-brass-border)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-[var(--color-accent-fg)]">
-                task ${taskId}
+              <span class="rounded-[var(--r-0)] border border-[var(--color-brass-border)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-[var(--color-accent-fg)]">
+                TASK ${taskId}
               </span>
               <span class="min-w-0 truncate text-sm font-semibold text-text-strong">
                 ${task?.title ?? 'task not loaded'}
@@ -148,7 +150,7 @@ function PlanningRouteFocusPanel() {
           class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-text-muted transition-colors hover:border-[var(--color-border-strong)] hover:text-text-strong"
           onClick=${clearPlanningRouteFocus}
         >
-          clear
+          CLEAR
         </button>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- align planning goal/task route focus receipt with the IDE route-focus visual pattern
- expose `data-route-focused-goal` and `data-route-focused-task` for landing verification
- keep CLEAR behavior preserving unrelated planning params

## Validation
- `pnpm install --offline --frozen-lockfile`
- `pnpm exec eslint src/components/planning-panel.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/planning-panel.test.ts src/components/ide/ide-context-lens.test.ts`
- `git diff --check`