### PR TITLE
fix(keeper): stop forcing optional board cleanup

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -250,7 +250,7 @@ let preferred_tool_names_for_turn_affordances turn_affordances =
   |> List.filter_map turn_affordance_of_string
   |> List.concat_map (function
        | Board_curation ->
-         [ "keeper_board_curation_submit"; "keeper_board_cleanup" ]
+         [ "keeper_board_curation_submit" ]
        | Board_post_or_comment
        | Message_sweep
        | Reply_in_room

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -10354,8 +10354,8 @@ let test_tools_for_gated_affordance_covers_each_variant () =
           [ "board_curation"; "task_claim"; "board_curation" ]));
   check
     bool
-    "board_curation force-includes cleanup tool"
-    true
+    "board_curation does not force optional cleanup tool"
+    false
     (List.mem
        "keeper_board_cleanup"
        (Surface.preferred_tool_names_for_turn_affordances


### PR DESCRIPTION
## Summary
- stop force-including optional/admin keeper_board_cleanup in Board_curation affordance prompts
- keep cleanup available when a keeper is explicitly allowed to use it, such as janitor
- avoids repeated runtime AllowList pruning for non-admin coding keepers while preserving curation_submit as the preferred curation tool

## Live evidence
- observed repeated logs: keeper:glm-coding AllowList pruned 1 tool(s) outside visible policy surface: keeper_board_cleanup
- local runtime config separately grants glm-coding keeper_board_search, so this PR is only for the code-side cleanup affordance mismatch

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_execution_receipt.ml lib/keeper/keeper_execution_receipt.mli lib/keeper/keeper_agent_tool_surface.ml test/test_keeper_pause_broadcast.ml test/test_keeper_unified.ml
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build --cache=disabled test/test_keeper_unified.exe test/test_keeper_pause_broadcast.exe bin/main_eio.exe
- ./_build/default/test/test_keeper_pause_broadcast.exe
- ./_build/default/test/test_keeper_unified.exe test tool_classification