### PR TITLE
feat(ide): polish context lens anchor counts

### DIFF
--- a/dashboard/src/components/ide/ide-context-lens.test.ts
+++ b/dashboard/src/components/ide/ide-context-lens.test.ts
@@ -109,7 +109,24 @@ describe('IdeContextLens', () => {
     ]))
     expect(model.activeLineCount).toBe(1)
     expect(model.changedLineCount).toBe(2)
+    expect(model.anchorTotalCount).toBe(4)
     expect(model.anchors.map(anchor => anchor.surface)).toContain('Git')
+  })
+
+  it('does not claim telemetry links from local-only code evidence', () => {
+    const model = deriveIdeContextLens({
+      filePath: 'lib/keeper/keeper_exec_ide.ml',
+      annotations: [annotation],
+      diffRows,
+      events: [],
+      overlay: { ...overlay, cursors: new Map() },
+    })
+
+    const counts = new Map(model.surfaces.map(surface => [surface.id, surface.count]))
+    expect(counts.get('lsp')).toBe(1)
+    expect(counts.get('git')).toBe(2)
+    expect(counts.get('log')).toBe(0)
+    expect(counts.get('telemetry')).toBe(0)
   })
 
   it('renders a compact context lens panel', () => {
@@ -130,7 +147,72 @@ describe('IdeContextLens', () => {
     expect(container.textContent).toContain('CONTEXT LENS')
     expect(container.textContent).toContain('11/11 linked')
     expect(container.textContent).toContain('keeper_exec_ide.ml')
+    expect(container.textContent).toContain('4 anchors')
     expect(container.textContent).toContain('goal goal-ide')
+  })
+
+  it('reports when the compact anchor list is truncated', () => {
+    const container = document.createElement('div')
+    const extraAnnotations = [
+      annotation,
+      { ...annotation, id: 'ann-2', line_start: 15, content: 'Second note' },
+      { ...annotation, id: 'ann-3', line_start: 16, content: 'Third note' },
+    ]
+    const secondThread: AnchoredThread = {
+      ...thread,
+      id: 'thread-2',
+      body: 'Second anchored thread',
+      anchor: { ...thread.anchor, line_start: 20, line_end: 20 },
+    }
+    const busyOverlay: KeeperCursorOverlay = {
+      ...overlay,
+      cursors: new Map([
+        ...overlay.cursors,
+        ['analyst', {
+          keeper_id: 'analyst',
+          file_path: 'lib/keeper/keeper_exec_ide.ml',
+          line: 17,
+          column: 2,
+          focus_mode: 'reviewing',
+          last_update: 101,
+          tool_name: 'review',
+          turn: 8,
+        }],
+      ]),
+    }
+
+    render(
+      h(IdeContextLens, {
+        filePath: 'lib/keeper/keeper_exec_ide.ml',
+        annotations: extraAnnotations,
+        diagnostics: [
+          {
+            file_path: 'lib/keeper/keeper_exec_ide.ml',
+            line: 21,
+            severity: 1,
+            source: 'ocamllsp',
+            message: 'First diagnostic',
+          },
+          {
+            file_path: 'lib/keeper/keeper_exec_ide.ml',
+            line: 22,
+            severity: 2,
+            source: 'ocamllsp',
+            message: 'Second diagnostic',
+          },
+        ],
+        diffRows,
+        events: [],
+        threads: [thread, secondThread],
+        overlay: busyOverlay,
+      }),
+      container,
+    )
+
+    const panel = container.querySelector('[data-testid="ide-context-lens"]')
+    expect(panel?.getAttribute('data-visible-anchors')).toBe('6')
+    expect(panel?.getAttribute('data-total-anchors')).toBe('10')
+    expect(container.textContent).toContain('6/10 anchors')
   })
 
   it('publishes focused file and line when an anchor is clicked', () => {

--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -81,6 +81,7 @@ export interface IdeContextLensModel {
   readonly linkedCount: number
   readonly surfaces: ReadonlyArray<IdeContextSurface>
   readonly anchors: ReadonlyArray<IdeContextAnchor>
+  readonly anchorTotalCount: number
   readonly changedLineCount: number
   readonly activeLineCount: number
 }
@@ -129,6 +130,7 @@ const SURFACE_ORDER: ReadonlyArray<IdeContextSurfaceId> = [
   'log',
   'telemetry',
 ]
+const MAX_CONTEXT_ANCHORS = 6
 const MAX_CONTEXT_ROUTE_LINKS = 9
 
 export function deriveIdeContextLens(input: IdeContextLensInput): IdeContextLensModel {
@@ -201,19 +203,22 @@ export function deriveIdeContextLens(input: IdeContextLensInput): IdeContextLens
     }
   })
 
+  const anchors = buildAnchors(
+    filePath ?? input.filePath,
+    fileAnnotations,
+    fileDiagnostics,
+    activeCursors,
+    fileThreads,
+    changedRows,
+    fileEvents,
+    eventSearchTextByEvent,
+  )
+
   return {
     linkedCount: surfaces.filter(surface => surface.status === 'linked').length,
     surfaces,
-    anchors: buildAnchors(
-      filePath ?? input.filePath,
-      fileAnnotations,
-      fileDiagnostics,
-      activeCursors,
-      fileThreads,
-      changedRows,
-      fileEvents,
-      eventSearchTextByEvent,
-    ),
+    anchors: anchors.slice(0, MAX_CONTEXT_ANCHORS),
+    anchorTotalCount: anchors.length,
     changedLineCount,
     activeLineCount: activeLines.size,
   }
@@ -239,6 +244,8 @@ export function IdeContextLens({
     <section
       class="ide-context-lens"
       data-testid="ide-context-lens"
+      data-visible-anchors=${model.anchors.length}
+      data-total-anchors=${model.anchorTotalCount}
       aria-label="IDE context lens"
     >
       <div class="ide-context-lens-summary">
@@ -249,6 +256,7 @@ export function IdeContextLens({
         <div class="ide-context-lens-meta">
           <span title=${filePath}>${fileLabel}</span>
           <span>${model.activeLineCount} line anchors</span>
+          <span>${anchorCountLabel(model)}</span>
           <span>${model.changedLineCount} changed rows</span>
         </div>
       </div>
@@ -433,7 +441,7 @@ function surfaceCount(
   if (id === 'log') {
     return state.events.length
   }
-  if (id === 'telemetry') return state.events.length + state.changedLineCount + state.annotations.length + state.diagnostics.length
+  if (id === 'telemetry') return state.events.length
   return 0
 }
 
@@ -454,6 +462,12 @@ function surfaceEvidence(id: IdeContextSurfaceId, count: number): string {
 
 function plural(count: number): string {
   return count === 1 ? '' : 's'
+}
+
+function anchorCountLabel(model: IdeContextLensModel): string {
+  return model.anchorTotalCount > model.anchors.length
+    ? `${model.anchors.length}/${model.anchorTotalCount} anchors`
+    : `${model.anchorTotalCount} anchor${plural(model.anchorTotalCount)}`
 }
 
 function buildAnchors(
@@ -588,7 +602,7 @@ function buildAnchors(
     })
   }
 
-  return anchors.slice(0, 6)
+  return anchors
 }
 
 function eventSearchText(event: RunActivityEvent): string {


### PR DESCRIPTION
## Summary

- Add explicit Context Lens anchor coverage metadata so compact rails show when the visible anchor list is truncated.
- Keep the Telemetry surface truthful by counting only current-file activity events, not local-only annotations, diagnostics, or diff rows.

## Product impact

Operators can now distinguish "all anchors are visible" from "more context is hidden below the compact rail cap", and the IDE no longer claims telemetry linkage when the current file only has local code evidence.

## Evidence

- `pnpm install --offline --frozen-lockfile`
- `pnpm exec eslint src/components/ide/ide-context-lens.ts src/components/ide/ide-context-lens.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-context-lens.test.ts src/components/ide/ide-activity-mock.test.ts`
- `git diff --check`

## Review evidence

- Added regression coverage for local-only code evidence not lighting up Telemetry.
- Added DOM proof for compact anchor truncation via `data-visible-anchors`, `data-total-anchors`, and the visible `6/10 anchors` summary.
- No raw hex colors were added in the changed IDE files.

## Linked issue

- Follow-up toward IDE progress visibility and context-linking polish.
