### PR TITLE
fix(dashboard): show execution evidence alerts

### DIFF
--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -1,0 +1,48 @@
+import { h } from 'preact'
+import { cleanup, render } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import '@testing-library/jest-dom'
+
+import type { Keeper } from '../types'
+import { KeeperRuntimeAlertStrip } from './keeper-detail-alert-strip'
+
+afterEach(() => {
+  cleanup()
+})
+
+function keeper(overrides: Partial<Keeper> = {}): Keeper {
+  return {
+    name: 'quiet-keeper',
+    status: 'active',
+    ...overrides,
+  }
+}
+
+describe('KeeperRuntimeAlertStrip', () => {
+  it('stays hidden for a quiet keeper without runtime evidence', () => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, { keeper: keeper({ needs_attention: false }) }))
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders execution receipt evidence even when the attention flag is false', () => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, {
+      keeper: keeper({
+        needs_attention: false,
+        trust: {
+          execution_summary: {
+            tool_contract_result: 'missing_required_tool_use',
+            required_tools: ['keeper_task_done'],
+            missing_required_tools: ['keeper_task_done'],
+          },
+        },
+      }),
+    }))
+
+    expect(container.textContent).toContain('증명')
+    expect(container.textContent).toContain('missing_required_tool_use')
+    expect(container.textContent).toContain('필요 도구')
+    expect(container.textContent).toContain('keeper_task_done')
+    expect(container.textContent).toContain('누락')
+  })
+})

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -107,12 +107,22 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
     || typeof observedProviderAttempts === 'number'
     || observedProviderFallback === true
     || (latestCascadeMetric?.fallback_applied === true && Boolean(fallbackReason || fallbackHops > 0))
+  const hasExecutionEvidenceSignal =
+    Boolean(runtimeProofStatus)
+    || requiredTools.length > 0
+    || usedTools.length > 0
+    || missingRequiredTools.length > 0
+    || Boolean(trustSummary)
+    || Boolean(latestTerminalCode)
+    || Boolean(latestNextAction)
+    || shouldShowOperatorDispositionReason
+    || Boolean(trustLatestEvent)
   const renderActivitySignal = () => activity.timestamp
     ? html`${activity.label} <${TimeAgo} timestamp=${activity.timestamp} />`
     : activity.ageSeconds != null
       ? html`${activity.label} ${formatDuration(activity.ageSeconds)} 전`
       : null
-  if (!needsAttention && !hasActivitySignal && !hasRuntimeIdentitySignal) return null
+  if (!needsAttention && !hasActivitySignal && !hasRuntimeIdentitySignal && !hasExecutionEvidenceSignal) return null
 
   const directiveLoading = signal(false)
   const handleDirective = async (action: 'pause' | 'resume' | 'wakeup') => {

--- a/dashboard/src/components/status-tray.test.ts
+++ b/dashboard/src/components/status-tray.test.ts
@@ -97,6 +97,42 @@ describe('summarizeStatusTray', () => {
     })
   })
 
+  it('counts execution receipt evidence even without the top-level attention flag', () => {
+    const summary = summarizeStatusTray({
+      wsOnly: false,
+      sseConnected: true,
+      wsConnected: true,
+      wsReady: true,
+      wsLastEventAt: NOW - 1000,
+      wsEventCount60s: 4,
+      wsLastError: null,
+      reconnectCount: 0,
+      lastDisconnectedAt: 0,
+      keepers: [
+        keeper('gamma', {
+          needs_attention: false,
+          trust: {
+            execution_summary: {
+              tool_contract_result: 'missing_required_tool_use',
+              missing_required_tools: ['keeper_bash'],
+            },
+          },
+        }),
+      ],
+      staleKeeperNames: new Set(),
+      tasks: [],
+      journalEntries: [],
+      unacknowledgedErrors: 0,
+      now: NOW,
+    })
+
+    expect(summary.counts.keeperAttention).toBe(1)
+    expect(summary.items.fleet.tone).toBe('warn')
+    expect(summary.items.fleet.detail).toBe('1 keeper need attention')
+    expect(summary.items.attention.tone).toBe('warn')
+    expect(summary.items.attention.value).toBe('1')
+  })
+
   it('uses the first journal entry for activity state from newest-first snapshots', () => {
     const summary = summarizeStatusTray({
       wsOnly: false,

--- a/dashboard/src/components/status-tray.ts
+++ b/dashboard/src/components/status-tray.ts
@@ -122,9 +122,39 @@ function countPendingVerification(tasksInput: readonly Task[]): number {
   return tasksInput.filter(task => task.status === 'awaiting_verification').length
 }
 
+function isExecutionAttentionCode(value: string | null | undefined): boolean {
+  const normalized = value?.trim().toLowerCase()
+  if (!normalized || normalized === 'unknown') return false
+  if (
+    normalized === 'ok'
+    || normalized === 'pass'
+    || normalized === 'allowed_in_sandbox'
+    || normalized.startsWith('satisfied')
+  ) return false
+  return normalized.includes('violat')
+    || normalized.includes('missing')
+    || normalized.includes('need')
+    || normalized.includes('fail')
+    || normalized.includes('error')
+    || normalized.includes('passive')
+}
+
+function hasExecutionAttentionEvidence(keeper: Keeper): boolean {
+  const trust = keeper.trust
+  if (trust?.needs_attention === true) return true
+  const terminalSeverity = trust?.latest_terminal_reason?.severity?.trim().toLowerCase()
+  if (terminalSeverity === 'bad' || terminalSeverity === 'warn') return true
+  const execution = trust?.execution_summary
+  if (!execution) return false
+  if ((execution.missing_required_tools ?? []).length > 0) return true
+  return isExecutionAttentionCode(execution.runtime_proof_status)
+    || isExecutionAttentionCode(execution.tool_contract_result)
+}
+
 function countKeeperAttention(keeperInput: readonly Keeper[]): number {
   return keeperInput.filter(keeper => {
     if (keeper.needs_attention) return true
+    if (hasExecutionAttentionEvidence(keeper)) return true
     const status = (keeper.status ?? '').toLowerCase()
     return status.includes('crash') || status === 'dead' || status === 'zombie'
   }).length


### PR DESCRIPTION
Summary
- Keep keeper runtime alert strips visible when execution receipt/proof evidence exists even if needs_attention is false.
- Count execution receipt/proof failures in the status tray attention total, so missing required tool evidence is visible from the global dashboard chrome.
- Add regression tests for both the keeper detail alert strip and status tray attention summary.

Verification
- pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/components/keeper-detail-alert-strip.test.ts src/components/status-tray.test.ts
- pnpm exec tsc --noEmit --pretty
- pnpm exec eslint src/components/keeper-detail-alert-strip.ts src/components/status-tray.ts src/components/keeper-detail-alert-strip.test.ts src/components/status-tray.test.ts (test files are ignored by current eslint config; source files pass)
- git diff --check