### PR TITLE
fix(dashboard): preserve trust provider model

### DIFF
--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -449,6 +449,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
             missing_required_tools: ['masc_board_post'],
             provider_attempt_count: 2,
             provider_fallback_applied: true,
+            provider_selected_model: 'provider:runtime-lane',
           },
           latest_terminal_reason: {
             code: 'required_tool_use_unsatisfied',
@@ -478,6 +479,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
         missing_required_tools: ['masc_board_post'],
         provider_attempt_count: 2,
         provider_fallback_applied: true,
+        provider_selected_model: 'provider:runtime-lane',
       },
       latest_terminal_reason: {
         code: 'required_tool_use_unsatisfied',

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -239,7 +239,7 @@ export function normalizeKeeperTrust(raw: unknown): Keeper['trust'] {
             asNumber(executionRaw.provider_attempt_count) ?? null,
           provider_fallback_applied:
             asBoolean(executionRaw.provider_fallback_applied) ?? null,
-          provider_selected_model: null,
+          provider_selected_model: asString(executionRaw.provider_selected_model) ?? null,
           cascade_outcome: asString(executionRaw.cascade_outcome) ?? null,
           sandbox_summary: asString(executionRaw.sandbox_summary) ?? null,
           sandbox_root: asString(executionRaw.sandbox_root) ?? null,

--- a/dashboard/src/operator-normalizers.test.ts
+++ b/dashboard/src/operator-normalizers.test.ts
@@ -253,6 +253,7 @@ describe('normalizeOperatorSnapshot', () => {
             execution: {
               tool_contract_result: 'violated',
               missing_required_tools: ['masc_board_post'],
+              provider_selected_model: 'provider:runtime-lane',
             },
             latest_terminal_reason: {
               code: 'required_tool_use_unsatisfied',
@@ -271,6 +272,7 @@ describe('normalizeOperatorSnapshot', () => {
       execution_summary: {
         tool_contract_result: 'violated',
         missing_required_tools: ['masc_board_post'],
+        provider_selected_model: 'provider:runtime-lane',
       },
       latest_terminal_reason: {
         code: 'required_tool_use_unsatisfied',


### PR DESCRIPTION
Summary
- Preserve runtime_trust.execution.provider_selected_model in the shared keeper trust normalizer instead of forcing it to null.
- Add regression coverage for both dashboard keeper store normalization and operator snapshot normalization.

Verification
- pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/keeper-store-normalize.test.ts src/operator-normalizers.test.ts
- pnpm exec tsc --noEmit --pretty
- pnpm exec eslint src/keeper-store-normalize.ts src/keeper-store-normalize.test.ts src/operator-normalizers.test.ts (ignored by current eslint config)
- git diff --check