### PR TITLE
[codex] reap stale WebRTC peers

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1047,8 +1047,12 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
          if Server_webrtc_transport.is_enabled ()
          then (
            let webrtc_expired = Server_webrtc_transport.cleanup_expired_offers () in
-           if webrtc_expired > 0
-           then Log.Server.info "WebRTC: cleaned %d expired offers" webrtc_expired);
+           let webrtc_stale_peers = Server_webrtc_transport.cleanup_stale_peers () in
+           if webrtc_expired > 0 || webrtc_stale_peers > 0
+           then
+             Log.Server.info "WebRTC: cleaned %d expired offers, %d stale peers"
+               webrtc_expired
+               webrtc_stale_peers);
          (* Rate-limit buckets: evict keys unused for
              [MASC_RATE_LIMIT_BUCKET_TTL_SEC] (default 5 minutes) *)
          let rl = Eio.Lazy.force Rate_limit.global in

--- a/lib/server/server_webrtc_transport.ml
+++ b/lib/server/server_webrtc_transport.ml
@@ -456,3 +456,18 @@ let cleanup_expired_offers ?(max_age_s = 60.0) () =
     with_registry (fun () -> Hashtbl.remove pending_offers id)
   ) expired;
   List.length expired
+
+(** Clean up active peers that stopped producing lifecycle or datachannel
+    activity.  Collect ids under the registry lock, then remove peers outside
+    that critical section because [remove_peer] takes the same lock and closes
+    the WebRTC stack. *)
+let cleanup_stale_peers ?(max_idle_s = 300.0) () =
+  let now = Unix.gettimeofday () in
+  let stale =
+    with_registry (fun () ->
+      Hashtbl.fold (fun peer_id conn acc ->
+        if now -. conn.last_activity > max_idle_s then peer_id :: acc else acc
+      ) active_peers [])
+  in
+  List.iter remove_peer stale;
+  List.length stale

--- a/lib/server/server_webrtc_transport.mli
+++ b/lib/server/server_webrtc_transport.mli
@@ -9,7 +9,7 @@
     Masc_mcp.Server_webrtc_transport] alias from the WS
     + signaling regression tests.
 
-    External surface (19 entries + 2 records):
+    External surface (20 entries + 2 records):
     - {b records} ({!pending_offer}, {!peer_conn})
       reached by record-pattern access from the
       regression test suite.
@@ -29,7 +29,8 @@
       {!active_peer_count},
       {!live_webrtc_count},
       {!connected_channel_count}).
-    - {b janitor} ({!cleanup_expired_offers}).
+    - {b janitor}
+      ({!cleanup_expired_offers}, {!cleanup_stale_peers}).
     - {b callback registration}
       ({!set_message_handler},
       {!set_connection_starter}).
@@ -171,6 +172,13 @@ val cleanup_expired_offers : ?max_age_s:float -> unit -> int
     from the pending registry.  Returns the number of
     offers expired.  Used by the periodic janitor in
     the bootstrap loops. *)
+
+val cleanup_stale_peers : ?max_idle_s:float -> unit -> int
+(** Drops active peers idle longer than [?max_idle_s]
+    (default 300.0) from every WebRTC registry and closes
+    their WebRTC stack.  Returns the number of peers
+    removed.  Used by the periodic janitor in the
+    bootstrap loops. *)
 
 (** {1 Callback registration} *)
 

--- a/test/test_webrtc_signaling.ml
+++ b/test/test_webrtc_signaling.ml
@@ -104,6 +104,32 @@ let test_cleanup_expired () =
     let cleaned = Wrtc.cleanup_expired_offers ~max_age_s:0.0 () in
     Alcotest.(check bool) "cleaned >= 1" true (cleaned >= 1))
 
+let test_cleanup_stale_peers () =
+  Eio_main.run (fun _env ->
+    let make_peer from_agent answerer_agent =
+      let offer_id =
+        Wrtc.create_offer ~from_agent ~ice_candidates:["c1"]
+          ~dtls_fingerprint:"fp"
+      in
+      let result = Wrtc.accept_offer ~offer_id ~answerer_agent in
+      Alcotest.(check bool) "accept ok" true (Result.is_ok result);
+      Result.get_ok result
+    in
+    ignore (Wrtc.cleanup_stale_peers ~max_idle_s:(-1.0) ());
+    let fresh = make_peer "fresh-a" "fresh-b" in
+    let fresh_cleaned = Wrtc.cleanup_stale_peers ~max_idle_s:3600.0 () in
+    Alcotest.(check int) "fresh peer not cleaned" 0 fresh_cleaned;
+    Alcotest.(check bool) "fresh peer still active"
+      true (Wrtc.active_peer_count () > 0);
+    Wrtc.remove_peer fresh.peer_id;
+    let _stale = make_peer "stale-a" "stale-b" in
+    let stale_cleaned = Wrtc.cleanup_stale_peers ~max_idle_s:(-1.0) () in
+    Alcotest.(check bool) "stale peer cleaned" true (stale_cleaned >= 1);
+    Alcotest.(check int) "no active peers after stale cleanup"
+      0 (Wrtc.active_peer_count ());
+    Alcotest.(check int) "no live webrtc after stale cleanup"
+      0 (Wrtc.live_webrtc_count ()))
+
 (* ====== Transport Enum ====== *)
 
 let test_transport_webrtc_variant () =
@@ -221,6 +247,7 @@ let () =
     ]);
     ("cleanup", [
       Alcotest.test_case "expired offers" `Quick test_cleanup_expired;
+      Alcotest.test_case "stale peers" `Quick test_cleanup_stale_peers;
     ]);
     ("transport_enum", [
       Alcotest.test_case "webrtc variant" `Quick test_transport_webrtc_variant;


### PR DESCRIPTION
Summary
- add `Server_webrtc_transport.cleanup_stale_peers` to evict idle active WebRTC peers from all registries and close their WebRTC stack
- wire the periodic maintenance janitor to reap both expired offers and stale peers
- add WebRTC signaling regression coverage for fresh-peer preservation and stale-peer cleanup

Why
- the existing janitor only removed expired signaling offers; accepted peers could remain in `active_peers` / `peer_webrtc_map` after activity stopped without a lifecycle close event

Validation
- `ocamlformat --check lib/server/server_webrtc_transport.ml lib/server/server_webrtc_transport.mli lib/server/server_bootstrap_loops.ml test/test_webrtc_signaling.ml`
- `scripts/dune-local.sh build @test/runtest-test_webrtc_signaling @test/runtest-test_transport_integration`
- `git diff --check`

Notes
- Draft PR intentionally; MASC merge policy still requires human review/labels before ready/merge.