### PR TITLE
Preserve composite tool-surface evidence

### DIFF
--- a/dashboard/src/api/schemas/keeper-composite.test.ts
+++ b/dashboard/src/api/schemas/keeper-composite.test.ts
@@ -158,7 +158,11 @@ describe('parseKeeperCompositeSnapshot', () => {
         },
         tool_surface: {
           tool_requirement: 'required',
+          turn_lane: 'tool_required',
+          tool_surface_class: 'runtime_mcp',
+          visible_tool_count: 2,
           tool_gate_enabled: true,
+          tool_surface_fallback_used: false,
           missing_required_tools: ['keeper_task_claim'],
           required_tools: ['keeper_task_claim'],
         },
@@ -168,6 +172,10 @@ describe('parseKeeperCompositeSnapshot', () => {
     expect(result.execution?.latest_receipt_present).toBe(true)
     expect(result.execution?.terminal_reason_code).toBe('config_error')
     expect(result.execution?.cascade?.fallback_reason).toBe('turn_timeout')
+    expect(result.execution?.tool_surface?.turn_lane).toBe('tool_required')
+    expect(result.execution?.tool_surface?.tool_surface_class).toBe('runtime_mcp')
+    expect(result.execution?.tool_surface?.visible_tool_count).toBe(2)
+    expect(result.execution?.tool_surface?.tool_surface_fallback_used).toBe(false)
     expect(result.execution?.error?.message_preview).toContain('fallback_cascade')
   })
 

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -155,7 +155,11 @@ const KeeperCompositeExecutionSchema = object({
   tool_surface: nullable(
     object({
       tool_requirement: nullable(string()),
+      turn_lane: optional(nullable(string())),
+      tool_surface_class: optional(nullable(string())),
+      visible_tool_count: optional(nullable(number())),
       tool_gate_enabled: nullable(boolean()),
+      tool_surface_fallback_used: optional(nullable(boolean())),
       missing_required_tools: array(string()),
       required_tools: array(string()),
     }),

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -394,7 +394,11 @@ describe('runtimeAttentionForSnapshot', () => {
         tool_contract_result: 'missing_required_tool_use',
         tool_surface: {
           tool_requirement: 'required',
+          turn_lane: 'tool_required',
+          tool_surface_class: 'mixed',
+          visible_tool_count: 0,
           tool_gate_enabled: true,
+          tool_surface_fallback_used: true,
           missing_required_tools: ['keeper_bash'],
           required_tools: ['keeper_bash'],
         },
@@ -404,6 +408,9 @@ describe('runtimeAttentionForSnapshot', () => {
     const attention = runtimeAttentionForSnapshot(snap, generatedAt)
     expect(attention.level).toBe('blocked')
     expect(attention.cause).toContain('missing_required_tool_use (keeper_bash)')
+    expect(attention.reason).toContain('turn_lane=tool_required')
+    expect(attention.reason).toContain('visible_tools=0')
+    expect(attention.reason).toContain('tool_surface_fallback=true')
     expect(attention.nextStep).toContain('keeper_bash')
   })
 
@@ -442,6 +449,16 @@ describe('fleetCellPresentation', () => {
         terminal_reason_code: 'api_error',
         operator_disposition: 'pause_human',
         operator_disposition_reason: 'tool_required_unsatisfied',
+        tool_surface: {
+          tool_requirement: 'required',
+          turn_lane: 'tool_required',
+          tool_surface_class: 'mixed',
+          visible_tool_count: 0,
+          tool_gate_enabled: true,
+          tool_surface_fallback_used: true,
+          missing_required_tools: ['keeper_bash'],
+          required_tools: ['keeper_bash'],
+        },
       }),
     })
     const attention = runtimeAttentionForSnapshot(snap, generatedAt)
@@ -483,6 +500,16 @@ describe('buildRuntimeAssistPrompt', () => {
         terminal_reason_code: 'api_error',
         operator_disposition: 'pause_human',
         operator_disposition_reason: 'tool_required_unsatisfied',
+        tool_surface: {
+          tool_requirement: 'required',
+          turn_lane: 'tool_required',
+          tool_surface_class: 'mixed',
+          visible_tool_count: 0,
+          tool_gate_enabled: true,
+          tool_surface_fallback_used: true,
+          missing_required_tools: ['keeper_bash'],
+          required_tools: ['keeper_bash'],
+        },
       }),
     })
     const attention = runtimeAttentionForSnapshot(snap, generatedAt)
@@ -492,6 +519,9 @@ describe('buildRuntimeAssistPrompt', () => {
     expect(prompt).toContain('cause=')
     expect(prompt).toContain('operator pause: tool_required_unsatisfied')
     expect(prompt).toContain('evidence=')
+    expect(prompt).toContain('"turn_lane":"tool_required"')
+    expect(prompt).toContain('"visible_tool_count":0')
+    expect(prompt).toContain('"tool_surface_fallback_used":true')
     expect(prompt).toContain('KSM=Running')
     expect(prompt).toContain('resolve 후보')
     expect(prompt).toContain('keeper_probe')

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -258,6 +258,7 @@ function isIdleComposite(snapshot: KeeperCompositeSnapshot): boolean {
 
 function executionEvidence(snapshot: KeeperCompositeSnapshot): string[] {
   const execution = snapshot.execution
+  const surface = execution?.tool_surface
   const parts: string[] = []
   if (!snapshot.is_live) parts.push('is_live=false')
   if (execution?.operator_disposition) {
@@ -271,6 +272,24 @@ function executionEvidence(snapshot: KeeperCompositeSnapshot): string[] {
   }
   if (execution?.tool_contract_result) {
     parts.push(`tool=${execution.tool_contract_result}`)
+  }
+  if (surface?.tool_requirement) {
+    parts.push(`tool_requirement=${surface.tool_requirement}`)
+  }
+  if (surface?.turn_lane) {
+    parts.push(`turn_lane=${surface.turn_lane}`)
+  }
+  if (surface?.tool_surface_class) {
+    parts.push(`tool_surface=${surface.tool_surface_class}`)
+  }
+  if (typeof surface?.visible_tool_count === 'number') {
+    parts.push(`visible_tools=${surface.visible_tool_count}`)
+  }
+  if (surface?.tool_surface_fallback_used === true) {
+    parts.push('tool_surface_fallback=true')
+  }
+  if (surface?.tool_gate_enabled === false) {
+    parts.push('tool_gate=false')
   }
   if (execution?.error?.kind) {
     parts.push(`error=${execution.error.kind}`)
@@ -475,6 +494,12 @@ export function buildRuntimeAssistPrompt(
       tool_contract_result: snapshot.execution.tool_contract_result,
       required_tools: snapshot.execution.tool_surface?.required_tools ?? [],
       missing_required_tools: snapshot.execution.tool_surface?.missing_required_tools ?? [],
+      tool_requirement: snapshot.execution.tool_surface?.tool_requirement ?? null,
+      turn_lane: snapshot.execution.tool_surface?.turn_lane ?? null,
+      tool_surface_class: snapshot.execution.tool_surface?.tool_surface_class ?? null,
+      visible_tool_count: snapshot.execution.tool_surface?.visible_tool_count ?? null,
+      tool_gate_enabled: snapshot.execution.tool_surface?.tool_gate_enabled ?? null,
+      tool_surface_fallback_used: snapshot.execution.tool_surface?.tool_surface_fallback_used ?? null,
       error_kind: snapshot.execution.error?.kind ?? null,
       error_preview: snapshot.execution.error?.message_preview ?? null,
     })

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -151,10 +151,16 @@ function executionReceiptLabel(execution: KeeperCompositeExecution | undefined):
 
 function executionReceiptTitle(execution: KeeperCompositeExecution | undefined): string {
   if (!execution?.latest_receipt_present) return '아직 execution receipt가 없습니다.'
+  const surface = execution.tool_surface
   return [
     execution.recorded_at ? `recorded_at: ${execution.recorded_at}` : '',
     execution.operator_disposition ? `operator: ${execution.operator_disposition}` : '',
     execution.operator_disposition_reason ? `reason: ${execution.operator_disposition_reason}` : '',
+    surface?.tool_requirement ? `tool_requirement: ${surface.tool_requirement}` : '',
+    surface?.turn_lane ? `turn_lane: ${surface.turn_lane}` : '',
+    surface?.tool_surface_class ? `tool_surface: ${surface.tool_surface_class}` : '',
+    typeof surface?.visible_tool_count === 'number' ? `visible_tools: ${surface.visible_tool_count}` : '',
+    surface?.tool_surface_fallback_used === true ? 'tool_surface_fallback: true' : '',
     execution.cascade?.fallback_reason ? `fallback: ${execution.cascade.fallback_reason}` : '',
     execution.error?.kind ? `error: ${execution.error.kind}` : '',
     execution.error?.message_preview ? execution.error.message_preview : '',

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -828,10 +828,15 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
           ; ( "tool_requirement"
             , Keeper_agent_tool_surface.tool_requirement_to_yojson
                 receipt.tool_surface.tool_requirement )
+          ; ( "turn_lane"
+            , Keeper_agent_tool_surface.turn_lane_to_yojson
+                receipt.tool_surface.turn_lane )
           ; ( "tool_surface_class"
             , Keeper_agent_tool_surface.tool_surface_class_to_yojson
                 receipt.tool_surface.tool_surface_class )
           ; "tool_gate_enabled", `Bool receipt.tool_surface.tool_gate_enabled
+          ; ( "tool_surface_fallback_used"
+            , `Bool receipt.tool_surface.tool_surface_fallback_used )
           ] )
     ; ( "sandbox"
       , `Assoc

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -685,13 +685,34 @@ let compact_receipt_cascade_json receipt =
 ;;
 
 let compact_receipt_tool_surface_json receipt =
-  match json_member "tool_surface" receipt with
+  let surface =
+    match json_member "tool_surface" receipt with
+    | `Assoc _ as surface -> surface
+    | _ -> json_member "tool_contract" receipt
+  in
+  match surface with
   | `Assoc _ as surface ->
+    let tool_requirement = json_string "tool_requirement" surface in
+    let turn_lane =
+      match json_string "turn_lane" surface, tool_requirement with
+      | Some value, _ -> Some value
+      | None, Some "required" -> Some "tool_required"
+      | None, Some "optional" -> Some "tool_optional"
+      | None, Some "no_tools" -> Some "text_only"
+      | None, _ -> None
+    in
     `Assoc
-      [ ( "tool_requirement"
-        , Json_util.string_opt_to_json (json_string "tool_requirement" surface) )
+      [ "tool_requirement", Json_util.string_opt_to_json tool_requirement
+      ; "turn_lane", Json_util.string_opt_to_json turn_lane
+      ; ( "tool_surface_class"
+        , Json_util.string_opt_to_json (json_string "tool_surface_class" surface) )
+      ; ( "visible_tool_count"
+        , Json_util.int_opt_to_json (json_int "visible_tool_count" surface) )
       ; ( "tool_gate_enabled"
         , Json_util.bool_opt_to_json (json_bool "tool_gate_enabled" surface) )
+      ; ( "tool_surface_fallback_used"
+        , Json_util.bool_opt_to_json
+            (json_bool "tool_surface_fallback_used" surface) )
       ; ( "missing_required_tools"
         , Json_util.json_string_list
             (Json_util.get_string_list surface "missing_required_tools") )

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -1500,6 +1500,17 @@ let test_composite_routes_surface_latest_execution_receipt () =
     (execution |> member "cascade" |> member "fallback_reason" |> to_string);
   check int "composite exposes provider attempt count" 2
     (execution |> member "cascade" |> member "attempt_count" |> to_int);
+  check string "composite exposes tool surface lane" "tool_required"
+    (execution |> member "tool_surface" |> member "turn_lane" |> to_string);
+  check string "composite exposes tool surface class" "mixed"
+    (execution |> member "tool_surface" |> member "tool_surface_class"
+     |> to_string);
+  check int "composite exposes visible tool count" 2
+    (execution |> member "tool_surface" |> member "visible_tool_count"
+     |> to_int);
+  check bool "composite exposes tool surface fallback flag" false
+    (execution |> member "tool_surface" |> member "tool_surface_fallback_used"
+     |> to_bool);
   let fleet = run_curl_get ~port ~path:"/api/v1/keepers/composite" () in
   require_status "fleet composite GET returns 200" 200 fleet;
   let fleet_json = Yojson.Safe.from_string fleet.body in

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -424,6 +424,21 @@ let test_broadcast_payload_carries_turn_diagnostics () =
     "missing required tools"
     [ "keeper_shell" ]
     (string_list_member "missing_required_tools" contract);
+  check
+    string
+    "turn lane"
+    "tool_required"
+    (contract |> U.member "turn_lane" |> U.to_string);
+  check
+    string
+    "tool surface class"
+    "mixed"
+    (contract |> U.member "tool_surface_class" |> U.to_string);
+  check
+    bool
+    "tool surface fallback flag"
+    false
+    (contract |> U.member "tool_surface_fallback_used" |> U.to_bool);
   check string "stop reason" "completed" (payload |> U.member "stop_reason" |> U.to_string);
   check bool "broadcast model_used redacted" true (payload |> U.member "model_used" = `Null)
 ;;


### PR DESCRIPTION
## Summary
- preserve latest execution receipt tool-surface lane/class/visible-count/fallback evidence in keeper composite responses
- carry the same tool-surface evidence into operator broadcast payloads instead of dropping it from runtime logs
- surface the evidence in Fleet FSM attention strings, AI assist payloads, and FSM receipt tooltips

## Verification
- pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/api/schemas/keeper-composite.test.ts src/components/fleet-fsm-matrix.test.ts
- pnpm exec tsc --noEmit --pretty
- pnpm exec eslint src/api/schemas/keeper-composite.ts src/api/schemas/keeper-composite.test.ts src/components/fleet-fsm-matrix.ts src/components/fleet-fsm-matrix.test.ts src/components/fsm-hub.ts
- scripts/dune-local.sh build bin/main_eio.exe test/test_dashboard_keeper_routes.exe test/test_keeper_pause_broadcast.exe
- ./_build/default/test/test_dashboard_keeper_routes.exe test dashboard_keeper_routes 10 --compact --show-errors
- ./_build/default/test/test_keeper_pause_broadcast.exe test needs_operator_broadcast 3 --compact --show-errors
- git diff --check