### PR TITLE
Expose runtime-trace linked artifacts

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -152,6 +152,27 @@ describe('keeper runtime trace', () => {
         memory_flush_success_count: 1,
         episodes_flushed: 2,
       },
+      linked_artifacts: {
+        receipts: [
+          {
+            kind: 'execution_receipt',
+            path: '/tmp/receipt.jsonl',
+            present: true,
+            file_stat: { size: 120 },
+          },
+        ],
+        checkpoints: [
+          {
+            kind: 'oas_checkpoint',
+            path: '/tmp/checkpoint.json',
+            present: false,
+            file_stat: null,
+          },
+        ],
+        tool_call_logs: [],
+      },
+      manifest_rows: [{ event: 'Turn_started', trace_id: 'trace-1' }],
+      receipts: [{ terminal_reason_code: 'completed' }],
       health: 'ok',
       stale_reason: null,
     })
@@ -164,6 +185,10 @@ describe('keeper runtime trace', () => {
 	    expect(result.event_bus.correlation_ids).toEqual(['corr-1'])
     expect(result.memory.memory_flushed_count).toBe(0)
     expect(result.memory.episodes_flushed).toBe(2)
+    expect(result.linked_artifacts.receipts[0]?.path).toBe('/tmp/receipt.jsonl')
+    expect(result.linked_artifacts.checkpoints[0]?.present).toBe(false)
+    expect(result.manifest_rows[0]?.event).toBe('Turn_started')
+    expect(result.receipts[0]?.terminal_reason_code).toBe('completed')
     expect(result.health).toBe('ok')
   })
 

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -767,6 +767,19 @@ export interface KeeperRuntimeLens {
   gaps: KeeperRuntimeLensGap[]
 }
 
+export interface KeeperRuntimeTraceLinkedArtifact {
+  kind: string
+  path: string
+  present: boolean
+  file_stat: Record<string, unknown> | null
+}
+
+export interface KeeperRuntimeTraceLinkedArtifacts {
+  receipts: KeeperRuntimeTraceLinkedArtifact[]
+  checkpoints: KeeperRuntimeTraceLinkedArtifact[]
+  tool_call_logs: KeeperRuntimeTraceLinkedArtifact[]
+}
+
 export interface KeeperRuntimeTraceResponse {
   keeper: string
   trace_id: string
@@ -781,6 +794,9 @@ export interface KeeperRuntimeTraceResponse {
   event_bus: KeeperRuntimeTraceEventBusSummary
   memory: KeeperRuntimeTraceMemorySummary
   runtime_lens: KeeperRuntimeLens
+  linked_artifacts: KeeperRuntimeTraceLinkedArtifacts
+  manifest_rows: Record<string, unknown>[]
+  receipts: Record<string, unknown>[]
   health: string
   stale_reason: string | null
 }
@@ -820,6 +836,35 @@ function stringListField(raw: Record<string, unknown>, key: string): string[] {
   const value = raw[key]
   if (!Array.isArray(value)) return []
   return value.filter((item): item is string => typeof item === 'string')
+}
+
+function recordListField(raw: Record<string, unknown>, key: string): Record<string, unknown>[] {
+  const value = raw[key]
+  if (!Array.isArray(value)) return []
+  return value.filter(isRecord)
+}
+
+function parseRuntimeTraceLinkedArtifact(raw: unknown): KeeperRuntimeTraceLinkedArtifact {
+  const obj = isRecord(raw) ? raw : {}
+  return {
+    kind: stringField(obj, 'kind'),
+    path: stringField(obj, 'path'),
+    present: obj.present === true,
+    file_stat: isRecord(obj.file_stat) ? obj.file_stat : null,
+  }
+}
+
+function parseRuntimeTraceLinkedArtifacts(raw: unknown): KeeperRuntimeTraceLinkedArtifacts {
+  const obj = isRecord(raw) ? raw : {}
+  const parseList = (key: string) => {
+    const value = obj[key]
+    return Array.isArray(value) ? value.map(parseRuntimeTraceLinkedArtifact) : []
+  }
+  return {
+    receipts: parseList('receipts'),
+    checkpoints: parseList('checkpoints'),
+    tool_call_logs: parseList('tool_call_logs'),
+  }
 }
 
 function parseRuntimeTraceTurnIdentity(raw: unknown): KeeperRuntimeTraceTurnIdentity {
@@ -1058,6 +1103,9 @@ export function parseKeeperRuntimeTrace(raw: unknown): KeeperRuntimeTraceRespons
     event_bus: parseRuntimeTraceEventBus(raw.event_bus),
     memory: parseRuntimeTraceMemory(raw.memory),
     runtime_lens: parseRuntimeLens(raw.runtime_lens, traceId),
+    linked_artifacts: parseRuntimeTraceLinkedArtifacts(raw.linked_artifacts),
+    manifest_rows: recordListField(raw, 'manifest_rows'),
+    receipts: recordListField(raw, 'receipts'),
     health: stringField(raw, 'health') || 'unknown',
     stale_reason: nullableStringField(raw, 'stale_reason'),
   }

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -530,6 +530,34 @@ describe('RuntimeLensSection', () => {
         ],
       },
       health: 'partial',
+      linked_artifacts: {
+        receipts: [
+          {
+            kind: 'execution_receipt',
+            path: '/tmp/receipt.jsonl',
+            present: true,
+            file_stat: { size: 120 },
+          },
+        ],
+        checkpoints: [
+          {
+            kind: 'oas_checkpoint',
+            path: '/tmp/checkpoint.json',
+            present: false,
+            file_stat: null,
+          },
+        ],
+        tool_call_logs: [
+          {
+            kind: 'tool_call_log',
+            path: '/tmp/tool-calls.jsonl',
+            present: true,
+            file_stat: { size: 80 },
+          },
+        ],
+      },
+      manifest_rows: [{ event: 'Turn_started', trace_id: 'trace-lens' }],
+      receipts: [{ terminal_reason_code: 'completed' }],
       stale_reason: null,
     }
   }
@@ -631,6 +659,14 @@ describe('RuntimeLensSection', () => {
     expect(screen.getByText('manifest rows')).toBeInTheDocument()
     expect(screen.getByText('6/6')).toBeInTheDocument()
     expect(screen.getByText('receipt rows')).toBeInTheDocument()
+    expect(screen.getByText('manifest file')).toBeInTheDocument()
+    expect(screen.getByText('manifest raw rows')).toBeInTheDocument()
+    expect(screen.getByText('receipt raw rows')).toBeInTheDocument()
+    expect(screen.getByText('receipt artifacts')).toBeInTheDocument()
+    expect(screen.getByText('checkpoint artifacts')).toBeInTheDocument()
+    expect(screen.getByText('tool log artifacts')).toBeInTheDocument()
+    expect(screen.getAllByText('1/1').length).toBeGreaterThan(1)
+    expect(screen.getByText('0/1')).toBeInTheDocument()
     expect(screen.getByText('provider attempts')).toBeInTheDocument()
     expect(screen.getAllByText('1/1').length).toBeGreaterThan(0)
     expect(screen.getByText('provider terminal')).toBeInTheDocument()

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -932,6 +932,19 @@ function runtimeTraceMemoryEvidence(trace: KeeperRuntimeTraceResponse): string {
   ].join(' · ')
 }
 
+function artifactEvidenceLabel(artifacts: readonly { present: boolean }[]): string {
+  if (artifacts.length === 0) return '0/0'
+  const present = artifacts.filter(item => item.present).length
+  return `${present}/${artifacts.length}`
+}
+
+function artifactEvidenceTitle(artifacts: readonly { kind: string; path: string; present: boolean }[]): string {
+  if (artifacts.length === 0) return 'no linked artifacts'
+  return artifacts
+    .map(item => `${item.present ? 'present' : 'missing'} ${item.kind}: ${item.path || '-'}`)
+    .join('\n')
+}
+
 function lensGapTone(severity: string): StatusChipTone {
   switch (severity) {
     case 'bad':
@@ -995,6 +1008,7 @@ export function RuntimeLensSection({
   const context = lens.axes.context
   const memory = lens.axes.memory
   const clock = lens.turn_clock
+  const artifacts = trace.linked_artifacts
   const swimlanes = [
     lens.swimlanes.keeper,
     lens.swimlanes.masc_policy_cascade,
@@ -1016,8 +1030,30 @@ export function RuntimeLensSection({
         <${SignalRow} label="context compaction" value=${`${context.context_compacted_count}/${context.context_compact_started_count}`} />
         <${SignalRow} label="memory flush" value=${`${memory.memory_flush_success_count}/${memory.memory_flush_error_count}`} />
         <${SignalRow} label="trace id" value=${compactToken(trace.trace_id)} />
+        <${SignalRow}
+          label="manifest file"
+          value=${trace.manifest_path_present ? 'present' : 'missing'}
+          title=${trace.manifest_path}
+        />
         <${SignalRow} label="manifest rows" value=${`${trace.manifest_returned_rows}/${trace.manifest_total_rows}`} />
         <${SignalRow} label="receipt rows" value=${trace.receipt_returned_rows} />
+        <${SignalRow} label="manifest raw rows" value=${trace.manifest_rows.length} />
+        <${SignalRow} label="receipt raw rows" value=${trace.receipts.length} />
+        <${SignalRow}
+          label="receipt artifacts"
+          value=${artifactEvidenceLabel(artifacts.receipts)}
+          title=${artifactEvidenceTitle(artifacts.receipts)}
+        />
+        <${SignalRow}
+          label="checkpoint artifacts"
+          value=${artifactEvidenceLabel(artifacts.checkpoints)}
+          title=${artifactEvidenceTitle(artifacts.checkpoints)}
+        />
+        <${SignalRow}
+          label="tool log artifacts"
+          value=${artifactEvidenceLabel(artifacts.tool_call_logs)}
+          title=${artifactEvidenceTitle(artifacts.tool_call_logs)}
+        />
         <${SignalRow} label="provider attempts" value=${`${trace.provider_attempts.started_count}/${trace.provider_attempts.finished_count}`} />
         <${SignalRow} label="provider terminal" value=${runtimeTraceProviderTerminal(trace)} />
         <${SignalRow} label="event ids" value=${runtimeTraceEventIds(trace)} />


### PR DESCRIPTION
## Summary
- preserve runtime-trace linked artifacts, raw manifest rows, and raw receipt rows in the dashboard parser
- show manifest file presence plus receipt/checkpoint/tool-call-log artifact counts in the Runtime Lens panel
- add focused parser and UI regression coverage so backend evidence is not silently dropped

## Verification
- pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/api/keeper.test.ts src/components/keeper-detail-runtime.test.ts
- pnpm exec tsc --noEmit --pretty
- pnpm exec eslint src/api/keeper.ts src/api/keeper.test.ts src/components/keeper-detail-runtime.ts src/components/keeper-detail-runtime.test.ts
- git diff --check