### PR TITLE
fix(dashboard): surface cascade label for tool quality

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -262,6 +262,7 @@ export type ToolQualityResponse = {
   success_rate: number
   by_tool: ToolQualityToolStat[]
   by_keeper: ToolQualityKeeperStat[]
+  by_cascade?: ToolQualityKeeperStat[]
   failure_categories: ToolQualityFailureCategory[]
   hourly_trend?: ToolQualityHourlyPoint[]
 }

--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -37,6 +37,17 @@ const payloadWithMissingToolMetrics = {
   ],
 }
 
+const payloadWithCascadeBuckets = {
+  ...payload,
+  by_cascade: [
+    {
+      name: 'local_qwen3_27b_only',
+      calls: 7,
+      success_pct: 100,
+    },
+  ],
+}
+
 function okJson<T>(body: T) {
   return {
     ok: true,
@@ -136,6 +147,21 @@ describe('ToolQualityPanel', () => {
     expect(container.textContent).toContain('m:example')
     expect(container.textContent).toContain('0.0k')
     expect(container.textContent).not.toContain('오류:')
+  })
+
+  it('renders cascade buckets separately from the redacted runtime model lane', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okJson(payloadWithCascadeBuckets))
+    vi.stubGlobal('fetch', fetchMock)
+    const { ToolQualityPanel } = await import('./tool-quality-panel')
+
+    await act(async () => {
+      render(html`<${ToolQualityPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(container.textContent).toContain('캐스케이드별')
+    expect(container.textContent).toContain('local_qwen3_27b_only')
   })
 
   it('replaces a stale in-flight request with the newest refresh', async () => {

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -55,6 +55,7 @@ type ToolQualityData = Omit<
   sampling_mode: string
   sample_limit: number
   window_hours: number | null
+  by_cascade: KeeperStat[]
   by_tool: ToolStat[]
 }
 
@@ -65,6 +66,7 @@ function normalizeToolQualityData(json: ToolQualityResponse): ToolQualityData {
     sampling_mode: json.sampling_mode ?? 'recent_n',
     sample_limit: json.sample_limit ?? json.total,
     window_hours: json.window_hours ?? null,
+    by_cascade: json.by_cascade ?? [],
     by_tool: json.by_tool.map(t => ({
       ...t,
       output_truncated_count: t.output_truncated_count ?? 0,
@@ -349,6 +351,13 @@ export function ToolQualityPanel() {
 
       ${d.hourly_trend && d.hourly_trend.length >= 2 ? html`
         <${TrendSparkline} points=${d.hourly_trend} />
+      ` : null}
+
+      ${d.by_cascade.length > 0 ? html`
+        <div>
+          <div class="text-3xs text-[var(--color-fg-disabled)] uppercase tracking-wider mb-1">캐스케이드별</div>
+          <${KeeperRateBars} keepers=${d.by_cascade} />
+        </div>
       ` : null}
 
       <div>

--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -91,6 +91,15 @@ let classify_failure_output (output : string) : string =
 let bucket_key record field ~default =
   Safe_ops.json_string_opt field record |> Option.value ~default
 
+let cascade_bucket_key record =
+  match Safe_ops.json_string_opt "cascade_profile" record with
+  | Some value when String.trim value <> "" -> value
+  | _ ->
+    let runtime_contract = Yojson.Safe.Util.member "runtime_contract" record in
+    (match Safe_ops.json_string_opt "cascade_profile" runtime_contract with
+     | Some value when String.trim value <> "" -> value
+     | _ -> "runtime")
+
 let thinking_mode_of_record record =
   match record with
   | `Assoc fields ->
@@ -196,6 +205,7 @@ let empty_summary ~window_hours ~n ~sampling_mode =
     ; ("success_rate", `Float 0.0)
     ; ("by_tool", `List [])
     ; ("by_keeper", `List [])
+    ; ("by_cascade", `List [])
     ; ("by_model", `List [])
     ; ("by_lane", `List [])
     ; ("by_thinking_mode", `List [])
@@ -231,6 +241,9 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
     Hashtbl.create 16
   in
   (* model/lane/thinking/tool_choice -> (calls, successes) *)
+  let cascade_stats : (string, int ref * int ref) Hashtbl.t =
+    Hashtbl.create 16
+  in
   let model_stats : (string, int ref * int ref) Hashtbl.t =
     Hashtbl.create 16
   in
@@ -322,6 +335,7 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
         Hashtbl.replace keeper_stats keeper v; v
     in
     incr kc; if ok then incr ks;
+    update_rate_table cascade_stats (cascade_bucket_key record) ok;
     update_rate_table model_stats (bucket_key record "model" ~default:"unknown") ok;
     update_rate_table lane_stats (bucket_key record "lane" ~default:"unknown") ok;
     update_rate_table thinking_mode_stats (thinking_mode_of_record record) ok;
@@ -392,6 +406,7 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
   let by_keeper =
     render_rate_table ~field:"name" keeper_stats
   in
+  let by_cascade = render_rate_table ~field:"name" cascade_stats in
   let by_model = render_rate_table ~field:"name" model_stats in
   let by_lane = render_rate_table ~field:"name" lane_stats in
   let by_thinking_mode =
@@ -447,6 +462,7 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
     ("success_rate", `Float (Float.round (rate *. 100.0) /. 100.0));
     ("by_tool", `List by_tool);
     ("by_keeper", `List by_keeper);
+    ("by_cascade", `List by_cascade);
     ("by_model", `List by_model);
     ("by_lane", `List by_lane);
     ("by_thinking_mode", `List by_thinking_mode);

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -789,6 +789,11 @@ let log_call
       let model_field =
         if model = "" then [] else [ "model", `String "runtime" ]
       in
+      let cascade_profile_field =
+        match cascade_profile with
+        | Some value when String.trim value <> "" -> [ "cascade_profile", `String value ]
+        | _ -> []
+      in
       let result_bytes_field =
         match result_bytes with
         | Some n -> [ "result_bytes", `Int n ]
@@ -936,6 +941,7 @@ let log_call
            ]
            @ route_evidence_field
            @ model_field
+           @ cascade_profile_field
            @ lane_field
            @ tool_choice_field
            @ thinking_enabled_field

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -149,7 +149,8 @@ val log_call :
   unit
 (** [log_call ...] persists a single tool call record with full I/O.
     Output is truncated to 4000 bytes. [model] is a compatibility input only;
-    non-empty values are redacted to the neutral runtime lane. Turn-policy fields ([lane], [tool_choice],
+    non-empty values are redacted to the neutral runtime lane. [cascade_profile]
+    is persisted separately as the operator-facing runtime selector. Turn-policy fields ([lane], [tool_choice],
     [thinking_enabled], [thinking_budget]) capture the effective tool
     selection context. [result_bytes] is the original output size before
     any truncation. [truncated_to] is present when Tool_output_validation

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -132,7 +132,9 @@ let test_model_field_stored () =
       ~keeper_name:"k" ~tool_name:"masc_status"
       ~input:(`Assoc []) ~output_text:"ok"
       ~success:true ~duration_ms:2.0
-      ~model:"glm-4-9b" ();
+      ~model:"glm-4-9b"
+      ~cascade_profile:"local_qwen3_27b_only"
+      ();
     let entries = Keeper_tool_call_log.read_recent () in
     Alcotest.(check int) "one entry" 1 (List.length entries);
     let entry_str = Yojson.Safe.to_string (List.hd entries) in
@@ -140,7 +142,10 @@ let test_model_field_stored () =
       (Observability_redact.contains_substring ~sub:"glm-4-9b" entry_str);
     Alcotest.(check (option string)) "model redacted to runtime"
       (Some "runtime")
-      (Safe_ops.json_string_opt "model" (List.hd entries)))
+      (Safe_ops.json_string_opt "model" (List.hd entries));
+    Alcotest.(check (option string)) "cascade profile stored"
+      (Some "local_qwen3_27b_only")
+      (Safe_ops.json_string_opt "cascade_profile" (List.hd entries)))
 
 let test_policy_denied_structured_error_gets_semantic_failure () =
   with_tmp_log (fun () ->
@@ -236,6 +241,9 @@ let test_turn_context_fields_stored () =
       (Safe_ops.json_int ~default:0 "turn" entry);
     Alcotest.(check int) "keeper_turn_id field" 7
       (Safe_ops.json_int ~default:0 "keeper_turn_id" entry);
+    Alcotest.(check (option string)) "cascade_profile field"
+      (Some "tool_use_strict")
+      (Safe_ops.json_string_opt "cascade_profile" entry);
     Alcotest.(check (option string)) "task_id field"
       (Some "task-runtime-trust")
       (Safe_ops.json_string_opt "task_id" entry);
@@ -275,6 +283,9 @@ let test_turn_context_fields_stored () =
       Yojson.Safe.Util.(
         runtime_contract |> member "missing_required_tools" |> to_list
         |> List.map to_string);
+    Alcotest.(check (option string)) "runtime_contract cascade_profile"
+      (Some "tool_use_strict")
+      (Safe_ops.json_string_opt "cascade_profile" runtime_contract);
     let action_radius = Yojson.Safe.Util.member "action_radius" entry in
     Alcotest.(check (option string)) "action_radius tool"
       (Some "masc_status")
@@ -492,14 +503,16 @@ let test_dashboard_aggregate_groups_runtime_fields () =
       ~success:true ~duration_ms:2.0
       ~model:"glm-5.1" ~lane:"tool_required"
       ~tool_choice:"required"
-      ~thinking_enabled:false ~thinking_budget:1024 ();
+      ~thinking_enabled:false ~thinking_budget:1024
+      ~cascade_profile:"primary" ();
     Keeper_tool_call_log.log_call
       ~keeper_name:"k2" ~tool_name:"masc_status"
       ~input:(`Assoc []) ~output_text:"error: {\"ok\":false,\"error\":\"boom\"}"
       ~success:false ~duration_ms:3.0
       ~model:"qwen3.5-27b-unified" ~lane:"retry"
       ~tool_choice:"auto"
-      ~thinking_enabled:true ~thinking_budget:4096 ();
+      ~thinking_enabled:true ~thinking_budget:4096
+      ~cascade_profile:"local_qwen3_27b_only" ();
     let summary = Dashboard_http_tool_quality.aggregate ~n:10 () in
     Alcotest.(check (option string)) "sampling mode present"
       (Some "recent_n")
@@ -527,15 +540,22 @@ let test_dashboard_aggregate_groups_runtime_fields () =
     Alcotest.(check bool) "latest age present" true
       (Safe_ops.json_float_opt "latest_age_s" summary |> Option.is_some);
     let by_model = Yojson.Safe.Util.member "by_model" summary in
+    let by_cascade = Yojson.Safe.Util.member "by_cascade" summary in
     let by_lane = Yojson.Safe.Util.member "by_lane" summary in
     let by_thinking = Yojson.Safe.Util.member "by_thinking_mode" summary in
     let by_tool_choice = Yojson.Safe.Util.member "by_tool_choice" summary in
     let runtime_bucket = find_bucket "runtime" by_model in
+    let primary_cascade_bucket = find_bucket "primary" by_cascade in
+    let local_cascade_bucket = find_bucket "local_qwen3_27b_only" by_cascade in
     let retry_bucket = find_bucket "retry" by_lane in
     let enabled_bucket = find_bucket "enabled" by_thinking in
     let auto_bucket = find_bucket "auto" by_tool_choice in
     Alcotest.(check int) "runtime bucket calls" 2
       (Safe_ops.json_int ~default:0 "calls" runtime_bucket);
+    Alcotest.(check int) "primary cascade bucket calls" 1
+      (Safe_ops.json_int ~default:0 "calls" primary_cascade_bucket);
+    Alcotest.(check int) "local cascade bucket calls" 1
+      (Safe_ops.json_int ~default:0 "calls" local_cascade_bucket);
     Alcotest.(check int) "retry bucket calls" 1
       (Safe_ops.json_int ~default:0 "calls" retry_bucket);
     Alcotest.(check int) "enabled thinking calls" 1


### PR DESCRIPTION
## Summary

- keep provider/model identity redacted as `runtime` in keeper tool-call telemetry
- persist the effective `cascade_profile` as a separate tool-call log field
- add `by_cascade` to `/api/v1/dashboard/tool-quality` and render it in the dashboard tool-quality panel

## Product impact

Operators no longer see only an undifferentiated `runtime` bucket when inspecting tool-call quality. The dashboard now shows the effective cascade selector, while concrete provider/model names remain hidden at the MASC boundary.

## Evidence

- `ocamlformat --check lib/keeper_tool_call_log.ml lib/keeper_tool_call_log.mli lib/dashboard/dashboard_http_tool_quality.ml test/test_keeper_tool_call_log.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_tool_call_log.exe`
- `./_build/default/test/test_keeper_tool_call_log.exe`
- `pnpm typecheck`
- `pnpm exec vitest run src/components/tool-quality-panel.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`

## Review evidence

- Regression coverage asserts raw model strings are still absent, the `model` field remains `runtime`, and `cascade_profile` is stored separately.
- Dashboard aggregate coverage asserts `by_model` stays `runtime` while `by_cascade` contains the effective cascade names.
- Frontend coverage asserts the tool-quality panel renders the cascade bucket.

## Linked issue

- Follow-up from the runtime-label operator feedback in the current OAS/MASC execution stream.
