### PR TITLE
[codex] Fix required tool lane mismatch recovery

### DIFF
--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -72,6 +72,21 @@ let missing_required_tool_names_after_lane ~required_tool_names ~effective_tools
   missing_required_tool_names_after_lane_by_name ~required_tool_names
     ~materialized_tool_names
 
+let required_tool_lane_unavailable_error ~lane ~missing_required_tools
+    ~materialized_tools =
+  Agent_sdk.Error.Config
+    (Agent_sdk.Error.InvalidConfig
+       {
+         field = "tool_support";
+         detail =
+           Printf.sprintf
+             "required_tool_lane_unavailable: lane=%s missing_required_tools=[%s] \
+              materialized_tools=[%s]"
+             lane
+             (String.concat ", " missing_required_tools)
+             (String.concat ", " materialized_tools);
+       })
+
 let provider_rejections_for_no_tool_error
     ~keeper_name ?runtime_mcp_policy ~tools
     ~require_tool_choice_support ~require_tool_support candidates =

--- a/lib/keeper/keeper_turn_driver_helpers.mli
+++ b/lib/keeper/keeper_turn_driver_helpers.mli
@@ -29,6 +29,12 @@ val missing_required_tool_names_after_lane_by_name :
   materialized_tool_names:string list ->
   string list
 
+val required_tool_lane_unavailable_error :
+  lane:string ->
+  missing_required_tools:string list ->
+  materialized_tools:string list ->
+  Agent_sdk.Error.sdk_error
+
 val provider_rejections_for_no_tool_error :
   keeper_name:string ->
   ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -200,13 +200,10 @@ let run_try_provider
         Keeper_runtime_manifest.Provider_lane_resolved;
       if missing_required_tool_names <> [] then
         Error
-          (Agent_sdk.Error.Internal
-             (Printf.sprintf
-                "required_tool_lane_unavailable: lane=%s \
-                 missing_required_tools=[%s] materialized_tools=[%s]"
-                resolved_lane
-                (String.concat ", " missing_required_tool_names)
-                (String.concat ", " materialized_tool_names)))
+          (Keeper_turn_driver_helpers.required_tool_lane_unavailable_error
+             ~lane:resolved_lane
+             ~missing_required_tools:missing_required_tool_names
+             ~materialized_tools:materialized_tool_names)
       else
         Ok
           { (Cascade_runtime_candidate.default_config

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -1888,6 +1888,28 @@ let test_required_tool_lane_matrix_materialization () =
            ~effective_tools ~runtime_mcp_policy))
     cases
 
+let test_required_tool_lane_unavailable_is_tool_support_config_error () =
+  let module FT = Masc_mcp.Keeper_turn_driver_helpers in
+  match
+    FT.required_tool_lane_unavailable_error ~lane:"runtime_mcp"
+      ~missing_required_tools:[ "masc_code_git" ]
+      ~materialized_tools:[ "keeper_pr_list"; "keeper_board_post" ]
+  with
+  | Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field; detail }) ->
+    Alcotest.(check string) "field" "tool_support" field;
+    Alcotest.(check bool)
+      "detail includes lane"
+      true
+      (contains_substring detail "lane=runtime_mcp");
+    Alcotest.(check bool)
+      "detail includes missing tool"
+      true
+      (contains_substring detail "missing_required_tools=[masc_code_git]")
+  | err ->
+    Alcotest.failf
+      "expected tool_support InvalidConfig, got %s"
+      (Agent_sdk.Error.to_string err)
+
 let test_keeper_cascade_engine_boundary () =
   let module E = Masc_mcp.Keeper_cascade_engine in
   let engine = E.keeper_managed in
@@ -2158,6 +2180,9 @@ let () =
             test_required_tool_lane_missing_names;
           Alcotest.test_case "required tool lane matrix materializes tools"
             `Quick test_required_tool_lane_matrix_materialization;
+          Alcotest.test_case
+            "required tool lane mismatch is cascade-recoverable"
+            `Quick test_required_tool_lane_unavailable_is_tool_support_config_error;
           Alcotest.test_case "keeper cascade engine boundary is typed"
             `Quick test_keeper_cascade_engine_boundary;
           Alcotest.test_case "keeper hot path avoids OAS Complete_cascade"


### PR DESCRIPTION
## Summary

- Reclassify keeper required-tool lane mismatches as `tool_support` `InvalidConfig`.
- Preserve the existing diagnostic detail for missing/materialized tools.
- Add a focused regression for the cascade-recoverable error shape.

## Root Cause

Sangsu receipts showed `required_tool_lane_unavailable` after a provider lane resolved to `runtime_mcp` while the turn still required `masc_code_git`. `runtime_mcp` could materialize public/keeper tools such as `keeper_pr_list` and `keeper_board_post`, but not spawned-agent-only tools like `masc_code_git`.

The driver reported that mismatch as an internal keeper error, so the selected candidate produced a hard tool failure instead of being rejected as a provider/tool-support mismatch.

## Behavior Change

When lane resolution cannot materialize explicitly required tools, the provider attempt now returns `InvalidConfig { field = "tool_support" }`. The cascade FSM already maps this field to `AcceptRejected`, allowing provider/cascade fallback instead of a terminal `internal_error`.

Closes #15076.

## Validation

- `opam exec -- ocamlformat --check lib/keeper/keeper_turn_driver_helpers.ml lib/keeper/keeper_turn_driver_helpers.mli lib/keeper/keeper_turn_driver_try_provider.ml test/test_keeper_runtime_manifest.ml`
- `scripts/dune-local.sh build test/test_keeper_runtime_manifest.exe`
- `./_build/default/test/test_keeper_runtime_manifest.exe test wiring 1 --show-errors`
- `./_build/default/test/test_keeper_runtime_manifest.exe test wiring 2 --show-errors`
- `./_build/default/test/test_keeper_runtime_manifest.exe test wiring 3 --show-errors`
- `git diff --check`

Note: the first local build attempt hit the known transient Dune cache cleanup race (`rmdir ... Directory not empty`); the exact same focused build passed on retry.
