### PR TITLE
fix(keeper): separate noisy runtime diagnostics

### DIFF
--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -604,6 +604,11 @@ let generate_compact ?(scope = All) (config : Coord_utils.config) : string =
       let write_meta_failures =
         Prometheus.metric_total Keeper_metrics.metric_keeper_write_meta_failures |> int_of_float
       in
+      let board_capped =
+        Prometheus.metric_total
+          Keeper_metrics.metric_keeper_board_signal_wakeup_capped_total
+        |> int_of_float
+      in
       let tool_failures =
         (Prometheus.metric_total Keeper_metrics.metric_keeper_tool_selection_failures |> int_of_float)
         + (Prometheus.metric_total Keeper_metrics.metric_keeper_task_load_failures |> int_of_float)
@@ -672,6 +677,19 @@ let generate_compact ?(scope = All) (config : Coord_utils.config) : string =
         then Printf.sprintf " | TOOL-ERR: %d" tool_failures
         else ""
       in
-      Printf.sprintf "KEEPERS: %d running / %d dead / %d other | GUARD: %d | META-WRITE-ERR: %d%s"
-        k_running k_dead k_other guard_violations write_meta_failures tool_suffix;
+      let board_suffix =
+        if board_capped > 0
+        then Printf.sprintf " | BOARD-CAPPED: %d" board_capped
+        else ""
+      in
+      Printf.sprintf
+        "KEEPERS: %d running / %d dead / %d other | GUARD: %d | \
+         META-WRITE-ERR: %d%s%s"
+        k_running
+        k_dead
+        k_other
+        guard_violations
+        write_meta_failures
+        tool_suffix
+        board_suffix;
     ]

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -334,11 +334,12 @@ let wakeup_relevant_keeper_for_board_signal
          Eio_guard.yield_step yield_meter);
   if dropped > 0 then begin
     Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_keepalive_signal_failures
-      ~labels:[("keeper", "aggregate"); ("site", "board_capped")]
+      Keeper_metrics.metric_keeper_board_signal_wakeup_capped_total
+      ~labels:[("kind", signal_kind_label)]
       ();
-    Log.Keeper.warn
-      "board signal wakeup capped: dropped=%d post=%s generic_limit=%d total_limit=%d"
+    Log.Keeper.info
+      "board signal wakeup capped by configured fanout: dropped=%d post=%s \
+       generic_limit=%d total_limit=%d"
       dropped
       signal.post_id
       board_reactive_generic_wakeup_limit

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -376,18 +376,14 @@ let write_meta_with_retry ?(max_retries = 3) config (m : keeper_meta)
     | Error msg when not (is_version_conflict_error msg) -> Error msg
     | Error _ ->
       (* Version conflict: read latest disk state, lift caller's payload
-         onto its version, and try again. *)
+       onto its version, and try again. *)
       (match read_meta_file_path path with
        | Ok (Some latest) ->
-         Prometheus.inc_counter
-           Keeper_metrics.metric_keeper_write_meta_failures
-           ~labels:[("keeper", m.name); ("phase", "cas_retry")]
-           ();
          Prometheus.inc_counter
            Prometheus.metric_write_meta_cas_retry_total
            ~labels:[("keeper_name", m.name)]
            ();
-         Log.Keeper.warn
+         Log.Keeper.info
            "write_meta CAS retry %d/%d for %s (caller had %d, disk %d)"
            (n + 1)
            max_retries
@@ -426,14 +422,10 @@ let write_meta_with_merge
       (match read_meta_file_path path with
        | Ok (Some latest) ->
          Prometheus.inc_counter
-           Keeper_metrics.metric_keeper_write_meta_failures
-           ~labels:[("keeper", caller.name); ("phase", "cas_retry_merge")]
-           ();
-         Prometheus.inc_counter
            Prometheus.metric_write_meta_cas_retry_total
            ~labels:[("keeper_name", caller.name)]
            ();
-         Log.Keeper.warn
+         Log.Keeper.info
            "write_meta CAS retry %d/%d for %s (caller had %d, disk %d; field-level merge)"
            (n + 1)
            max_retries

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -76,6 +76,7 @@ type t =
   | CrashPersistenceFailures
   | GenerationLineageFailures
   | KeepaliveSignalFailures
+  | BoardSignalWakeupCappedTotal
   | BoardSignalNoWakeTotal
   | MetaJsonFailures
   | ToolsOasFailures
@@ -272,6 +273,7 @@ let to_string = function
   | CrashPersistenceFailures -> "masc_keeper_crash_persistence_failures_total"
   | GenerationLineageFailures -> "masc_keeper_generation_lineage_failures_total"
   | KeepaliveSignalFailures -> "masc_keeper_keepalive_signal_failures_total"
+  | BoardSignalWakeupCappedTotal -> "masc_keeper_board_signal_wakeup_capped_total"
   | BoardSignalNoWakeTotal -> "masc_keeper_board_signal_no_wake_total"
   | MetaJsonFailures -> "masc_keeper_meta_json_failures_total"
   | ToolsOasFailures -> "masc_keeper_tools_oas_failures_total"
@@ -537,6 +539,10 @@ let metric_keeper_generation_lineage_failures =
 
 let metric_keeper_keepalive_signal_failures =
   "masc_keeper_keepalive_signal_failures_total"
+;;
+
+let metric_keeper_board_signal_wakeup_capped_total =
+  "masc_keeper_board_signal_wakeup_capped_total"
 ;;
 
 let metric_keeper_board_signal_no_wake_total = "masc_keeper_board_signal_no_wake_total"

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -68,6 +68,7 @@ type t =
   | CrashPersistenceFailures
   | GenerationLineageFailures
   | KeepaliveSignalFailures
+  | BoardSignalWakeupCappedTotal
   | BoardSignalNoWakeTotal
   | MetaJsonFailures
   | ToolsOasFailures
@@ -274,6 +275,7 @@ val metric_keeper_fs_failures : string
 val metric_keeper_crash_persistence_failures : string
 val metric_keeper_generation_lineage_failures : string
 val metric_keeper_keepalive_signal_failures : string
+val metric_keeper_board_signal_wakeup_capped_total : string
 val metric_keeper_board_signal_no_wake_total : string
 val metric_keeper_meta_json_failures : string
 val metric_keeper_tools_oas_failures : string

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -223,15 +223,20 @@ let tool_schema_names schemas =
   List.map (fun (schema : Masc_domain.tool_schema) -> schema.name) schemas
 
 let is_known_policy_tool_name name =
-  Tool_dispatch.is_registered name
-  || List.mem name (Keeper_tool_registry.keeper_internal_candidate_tool_names)
-  || List.mem name (Keeper_tool_registry.effective_core_tools ())
-  || List.mem name Keeper_tool_registry.keeper_admin_dispatched_tools
-  || List.mem name (tool_schema_names Tool_shard.all_keeper_tool_schemas)
-  || Tool_catalog_surfaces.is_on_surface Tool_catalog_surfaces.Public_mcp name
-  || Tool_catalog_surfaces.is_on_surface Tool_catalog_surfaces.Spawned_agent name
-  || Tool_catalog_surfaces.is_on_surface Tool_catalog_surfaces.Local_worker name
-  || Tool_catalog_surfaces.is_on_surface Tool_catalog_surfaces.Admin name
+  let normalized = Keeper_tool_alias.strip_mcp_masc_prefix name in
+  Tool_dispatch.is_registered normalized
+  || Option.is_some (Tool_name.of_string normalized)
+  || Option.is_some (Keeper_tool_alias.route normalized)
+  || Keeper_tool_alias.is_known_internal normalized
+  || Option.is_some (Keeper_tool_alias.public_masc_to_internal normalized)
+  || List.mem normalized (Keeper_tool_registry.keeper_internal_candidate_tool_names)
+  || List.mem normalized (Keeper_tool_registry.effective_core_tools ())
+  || List.mem normalized Keeper_tool_registry.keeper_admin_dispatched_tools
+  || List.mem normalized (tool_schema_names Tool_shard.all_keeper_tool_schemas)
+  || Tool_catalog_surfaces.is_on_surface Tool_catalog_surfaces.Public_mcp normalized
+  || Tool_catalog_surfaces.is_on_surface Tool_catalog_surfaces.Spawned_agent normalized
+  || Tool_catalog_surfaces.is_on_surface Tool_catalog_surfaces.Local_worker normalized
+  || Tool_catalog_surfaces.is_on_surface Tool_catalog_surfaces.Admin normalized
 
 (* Shortcut: if the caller's [base_path] already points at a project root
    that has [base_path/config/tool_policy.toml], prefer that directly.

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1596,8 +1596,12 @@ let init () =
     Counter;
   add
     Keeper_metrics.metric_keeper_keepalive_signal_failures
-    "Total keeper keepalive signal failures (board capped/late-event rejected), labeled \
-     by keeper and site"
+    "Total keeper keepalive signal failures (late-event rejected), labeled by keeper and \
+     site"
+    Counter;
+  add
+    Keeper_metrics.metric_keeper_board_signal_wakeup_capped_total
+    "Total board signal wakeups dropped by configured fanout caps, labeled by kind"
     Counter;
   add
     Keeper_metrics.metric_keeper_board_signal_no_wake_total

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -201,6 +201,23 @@ let test_generate_compact_contains_keepers () =
   Alcotest.(check bool) "contains KEEPERS line" true (contains output "KEEPERS:");
   cleanup_dir dir
 
+let test_generate_compact_surfaces_board_cap_without_failure () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = test_dir () in
+  let config = Coord_utils.default_config dir in
+  setup_room config;
+  Lib.Prometheus.inc_counter
+    Lib.Keeper_metrics.metric_keeper_board_signal_wakeup_capped_total
+    ~labels:[("kind", "task")]
+    ();
+  let output = Lib.Dashboard.generate_compact config in
+  Alcotest.(check bool)
+    "contains board cap diagnostic"
+    true
+    (contains output "BOARD-CAPPED:");
+  cleanup_dir dir
+
 let test_keepers_section_dead_phase () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -274,6 +291,9 @@ let keepers_tests = [
   "keepers section with entry", `Quick, test_keepers_section_with_entry;
   "generate full contains keepers", `Quick, test_generate_full_contains_keepers;
   "generate compact contains keepers", `Quick, test_generate_compact_contains_keepers;
+  ( "generate compact surfaces board cap",
+    `Quick,
+    test_generate_compact_surfaces_board_cap_without_failure );
   "keepers section dead phase", `Quick, test_keepers_section_dead_phase;
   "keepers section with error truncated", `Quick, test_keepers_section_with_error_truncated;
 ]

--- a/test/test_keeper_tool_policy_config.ml
+++ b/test/test_keeper_tool_policy_config.ml
@@ -142,11 +142,27 @@ masc_tools = ["keeper_fs_write", "keeper_fs_delete", "masc_status"]
 let test_policy_validation_knows_static_and_oas_core_tools () =
   check bool "keeper static tag tool is known" true
     (KTPC.is_known_policy_tool_name "keeper_board_post");
+  check bool "keeper shell alias target is known" true
+    (KTPC.is_known_policy_tool_name "keeper_shell");
+  check bool "keeper bash alias target is known" true
+    (KTPC.is_known_policy_tool_name "keeper_bash");
+  check bool "keeper public Bash alias is known" true
+    (KTPC.is_known_policy_tool_name "Bash");
+  check bool "keeper public Read alias is known" true
+    (KTPC.is_known_policy_tool_name "Read");
+  check bool "keeper task done is known" true
+    (KTPC.is_known_policy_tool_name "keeper_task_done");
+  check bool "keeper time tool is known" true
+    (KTPC.is_known_policy_tool_name "keeper_time_now");
   check bool "masc static tag tool is known" true
     (KTPC.is_known_policy_tool_name "masc_status");
+  check bool "mcp-prefixed masc tool is known" true
+    (KTPC.is_known_policy_tool_name "mcp__masc__masc_status");
+  check bool "masc code git tool is known" true
+    (KTPC.is_known_policy_tool_name "masc_code_git");
   check bool "OAS core tool is known" true
     (KTPC.is_known_policy_tool_name "extend_turns");
-  check bool "retired typed tool is not known" false
+  check bool "typed task completion tool is known" true
     (KTPC.is_known_policy_tool_name "masc_complete_task");
   check bool "unknown tool is not known" false
     (KTPC.is_known_policy_tool_name "__missing_tool")

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -413,6 +413,8 @@ let test_new_issue_metrics_registered () =
   check_metric_name Prometheus.metric_cascade_server_error_skip_total;
   check_metric_name Masc_mcp.Keeper_metrics.metric_keeper_passive_loop_detected_total;
   check_metric_name Prometheus.metric_write_meta_cas_retry_total;
+  check_metric_name
+    Masc_mcp.Keeper_metrics.metric_keeper_board_signal_wakeup_capped_total;
   check_metric_name Masc_mcp.Keeper_metrics.metric_keeper_zombie_loop_detected_total
 ;;
 


### PR DESCRIPTION
## Summary
- Normalize keeper policy validation through alias/prefix resolution so static and MCP-prefixed tools do not show as unknown at startup.
- Reclassify expected keeper runtime contention/noise: CAS retry logs become INFO, and board wake fanout caps use a dedicated metric instead of the keepalive failure counter.
- Surface board wake caps in the compact dashboard summary as `BOARD-CAPPED` so operators can distinguish configured fanout limits from real keeper failures.

## Verification
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_tool_policy_config.exe test/test_keeper_meta_cas_retry.exe test/test_keeper_meta_heartbeat_retain_9733.exe test/test_prometheus_coverage.exe test/test_dashboard.exe`
- `env DUNE_BUILD_DIR=_build_prhead DUNE_JOBS=1 dune build --root . test/test_keeper_tool_policy_config.exe test/test_keeper_meta_cas_retry.exe test/test_keeper_meta_heartbeat_retain_9733.exe test/test_prometheus_coverage.exe test/test_dashboard.exe`
- `./_build_prhead/default/test/test_keeper_tool_policy_config.exe`
- `./_build_prhead/default/test/test_keeper_meta_cas_retry.exe`
- `./_build_prhead/default/test/test_keeper_meta_heartbeat_retain_9733.exe`
- `./_build_prhead/default/test/test_prometheus_coverage.exe`
- `./_build_prhead/default/test/test_dashboard.exe`
