### PR TITLE
feat(ide): hydrate file focus from route

### DIFF
--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -49,6 +49,7 @@ vi.mock('./ide-conversation-rail-mock', () => ({
 import { IdeShell } from './ide-shell'
 import { navigate, route } from '../../router'
 import { clearTraces, pushTrace } from './keeper-trace-store'
+import { activeIdeFile, ideContextFocus } from './ide-state'
 
 function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
   const button = Array.from(container.querySelectorAll('button'))
@@ -116,6 +117,8 @@ describe('IdeShell', () => {
     vi.unstubAllGlobals()
     window.location.hash = ''
     route.value = { tab: 'overview', params: {}, postId: null }
+    activeIdeFile.value = 'package.json'
+    ideContextFocus.value = null
     clearTraces()
   })
 
@@ -141,6 +144,54 @@ describe('IdeShell', () => {
     expect(container.textContent).toContain('Active overlays')
     expect(container.textContent).toContain('Time')
     expect(container.textContent).toContain('Approve')
+  })
+
+  it('hydrates current file and line focus from IDE route params', async () => {
+    route.value = {
+      tab: 'code',
+      params: {
+        section: 'ide-shell',
+        view: 'source',
+        file: 'lib\\runtime.ml',
+        line: '42',
+        surface: 'Task',
+        label: 'Runtime task',
+        source_id: 'task:runtime',
+        keeper: 'sangsu',
+      },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    await waitFor(() => expect(activeIdeFile.value).toBe('lib/runtime.ml'))
+    expect(ideContextFocus.value).toMatchObject({
+      file_path: 'lib/runtime.ml',
+      line: 42,
+      surface: 'Task',
+      label: 'Runtime task',
+      source_id: 'task:runtime',
+      keeper_id: 'sangsu',
+    })
+  })
+
+  it('rejects unsafe IDE route file focus params', async () => {
+    route.value = {
+      tab: 'code',
+      params: {
+        section: 'ide-shell',
+        view: 'source',
+        file: '/workspace/lib/runtime.ml',
+        line: '42',
+      },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(activeIdeFile.value).toBe('package.json')
+    expect(ideContextFocus.value).toBeNull()
   })
 
   it('renders toolbar lanes that can collapse independently on narrow screens', () => {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
-import { activeIdeFile } from './ide-state'
+import { activeIdeFile, focusIdeContextAnchor } from './ide-state'
 import { createIdeDataCoordinator } from './ide-data-coordinator'
 import { IdeExplorer } from './ide-explorer'
 import { IdeEditor, type IdeEditorView } from './ide-editor'
@@ -68,6 +68,30 @@ function keeperFromRoute(): string {
   return keepers.value[0]?.name?.trim() ?? ''
 }
 
+function routeFocusFile(params: Record<string, string>): string | undefined {
+  return params.file?.trim() || params.file_path?.trim() || params.path?.trim() || undefined
+}
+
+function routeFocusLine(params: Record<string, string>): number | undefined {
+  const raw = params.line?.trim() || params.lineno?.trim()
+  if (!raw) return undefined
+  if (!/^[1-9]\d*$/.test(raw)) return undefined
+  const value = Number.parseInt(raw, 10)
+  return Number.isSafeInteger(value) && value >= 1 ? value : undefined
+}
+
+function routeFocusLabel(params: Record<string, string>, filePath: string): string {
+  const label = params.label?.trim()
+  if (label) return label
+  return filePath.split('/').pop() || filePath
+}
+
+function routeFocusSourceId(params: Record<string, string>, filePath: string, line?: number): string {
+  const sourceId = params.source_id?.trim() || params.source?.trim()
+  if (sourceId) return sourceId
+  return line !== undefined ? `route:${filePath}:${line}` : `route:${filePath}`
+}
+
 function paramsWithLayers(
   params: Record<string, string>,
   view: ViewTab,
@@ -117,6 +141,34 @@ export function IdeShell() {
     const unsubscribe = activeIdeFile.subscribe(setActiveFilePath)
     return () => unsubscribe()
   }, [])
+
+  const routeFileFocus = routeFocusFile(route.value.params)
+  const routeLineFocus = routeFocusLine(route.value.params)
+  const routeSurfaceFocus = route.value.params.surface?.trim() || 'Route'
+  const routeLabelFocus = routeFileFocus ? routeFocusLabel(route.value.params, routeFileFocus) : ''
+  const routeSourceFocus = routeFileFocus
+    ? routeFocusSourceId(route.value.params, routeFileFocus, routeLineFocus)
+    : ''
+  const routeKeeperFocus = route.value.params.keeper?.trim() || undefined
+
+  useEffect(() => {
+    if (!routeFileFocus) return
+    focusIdeContextAnchor({
+      file_path: routeFileFocus,
+      line: routeLineFocus,
+      surface: routeSurfaceFocus,
+      label: routeLabelFocus,
+      source_id: routeSourceFocus,
+      keeper_id: routeKeeperFocus,
+    })
+  }, [
+    routeFileFocus,
+    routeLineFocus,
+    routeSurfaceFocus,
+    routeLabelFocus,
+    routeSourceFocus,
+    routeKeeperFocus,
+  ])
 
   const activeFocus = focusFromRoute(route.value.params.focus)
   const [activeView, setActiveView] = useState<ViewTab>(() => viewFromRoute(route.value.params.view))


### PR DESCRIPTION
## Summary

- Teach the IDE shell to consume `file` / `file_path` / `path` plus `line` route params and hydrate the active IDE file/focus state.
- Reuse the existing IDE context focus sanitizer so unsafe absolute/traversal paths are ignored instead of changing editor state.

## Product impact

Other dashboard surfaces can now deep-link back into the IDE at a concrete file and line, closing the reverse path for Goal/Task/PR/Board/Log/Telemetry context to land on code instead of only letting the IDE link outward.

## Evidence

- `pnpm install --offline --frozen-lockfile`
- `pnpm exec eslint src/components/ide/ide-shell.ts src/components/ide/ide-shell.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-shell.test.ts src/components/ide/ide-state.test.ts`
- `git diff --check`

## Review evidence

- Added regression coverage for route-driven file/line hydration.
- Added regression coverage that unsafe route file paths do not mutate IDE focus state.
- No raw hex colors were added in the changed IDE files.

## Linked issue

- Follow-up toward bidirectional IDE progress visibility and context linking.
