### PR TITLE
fix(dashboard): surface telemetry source provenance

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -64,6 +64,12 @@ const telemetrySummaryResponse: TelemetrySummaryResponse = {
       entry_count: 200,
       keeper_count: 2,
       exists: true,
+      producer: 'Telemetry_unified.summary_json',
+      durable_store: '.masc/metrics/keeper.jsonl',
+      dashboard_surface: '/api/v1/dashboard/telemetry/summary',
+      freshness_slo_s: 300,
+      latest_age_s: 42,
+      health: 'ok',
     },
     {
       source: 'tool_metric',
@@ -247,6 +253,9 @@ describe('FleetTelemetryPanel', () => {
     expect(container.textContent).toContain('Keeper 턴 로그')
     expect(container.textContent).toContain('실패 분류')
     expect(container.textContent).toContain('함대 통제실')
+    expect(container.textContent).toContain('Telemetry_unified.summary_json')
+    expect(container.textContent).toContain('.masc/metrics/keeper.jsonl')
+    expect(container.textContent).toContain('/api/v1/dashboard/telemetry/summary')
   }, 60_000)
 
   it('renders readiness cards, attention events, and keeper goal or sandbox badges', async () => {

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -21,6 +21,7 @@ import {
   formatActivity,
   formatActivitySignal,
   numericAge,
+  sourceDetail,
   toneForToolSuccess,
   toneForPressure,
   toolSummary,
@@ -123,6 +124,30 @@ describe('normalizeModelText', () => {
 
   it('returns trimmed text for valid models', () => {
     expect(normalizeModelText(' claude-sonnet-4-6 ')).toBe('claude-sonnet-4-6')
+  })
+})
+
+describe('sourceDetail', () => {
+  it('includes telemetry source provenance and freshness metadata', () => {
+    const detail = sourceDetail({
+      source: 'tool_metric',
+      entry_count: 7,
+      exists: true,
+      latest_age_s: 42,
+      health: 'stale',
+      stale_reason: 'freshness_slo_exceeded',
+      freshness_slo_s: 300,
+      producer: 'Telemetry_unified.summary_json',
+      durable_store: '.masc/tool_metrics/YYYY-MM/DD.jsonl',
+      dashboard_surface: '/api/v1/dashboard/telemetry/summary',
+    })
+
+    expect(detail).toContain('last 42s ago')
+    expect(detail).toContain('stale: freshness_slo_exceeded')
+    expect(detail).toContain('SLO 5m 0s')
+    expect(detail).toContain('producer Telemetry_unified.summary_json')
+    expect(detail).toContain('store .masc/tool_metrics/YYYY-MM/DD.jsonl')
+    expect(detail).toContain('surface /api/v1/dashboard/telemetry/summary')
   })
 })
 

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -575,6 +575,18 @@ export function sourceDetail(source: TelemetrySourceSummary): string {
   if (source.health) {
     parts.push(source.stale_reason ? `${source.health}: ${source.stale_reason}` : source.health)
   }
+  if (typeof source.freshness_slo_s === 'number' && Number.isFinite(source.freshness_slo_s)) {
+    parts.push(`SLO ${formatElapsedCompact(source.freshness_slo_s)}`)
+  }
+  if (source.producer) {
+    parts.push(`producer ${source.producer}`)
+  }
+  if (source.durable_store) {
+    parts.push(`store ${source.durable_store}`)
+  }
+  if (source.dashboard_surface) {
+    parts.push(`surface ${source.dashboard_surface}`)
+  }
 
   return parts.join(' · ')
 }

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -29,6 +29,13 @@ const baseSummary: TelemetrySummaryResponse = {
       entry_count: 1,
       keeper_count: 1,
       exists: true,
+      producer: 'Telemetry_unified.summary_json',
+      durable_store: '.masc/tool_metrics/YYYY-MM/DD.jsonl',
+      dashboard_surface: '/api/v1/dashboard/telemetry/summary',
+      freshness_slo_s: 300,
+      latest_age_s: 45,
+      health: 'stale',
+      stale_reason: 'freshness_slo_exceeded',
     },
   ],
   total_entries: 1,
@@ -206,6 +213,10 @@ describe('TelemetryUnified', () => {
     expect(container.textContent).toContain('Auto-refresh 30s')
     expect(container.textContent).toContain('MASC telemetry store entries')
     expect(container.textContent).toContain('mcp__masc__masc_status')
+    expect(container.textContent).toContain('freshness_slo_exceeded')
+    expect(container.textContent).toContain('Telemetry_unified.summary_json')
+    expect(container.textContent).toContain('.masc/tool_metrics/YYYY-MM/DD.jsonl')
+    expect(container.textContent).toContain('/api/v1/dashboard/telemetry/summary')
 
     // MASC Store Diagnosis cards (live state)
     expect(container.textContent).toContain('키퍼 현황 (실시간)')

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -20,7 +20,7 @@ import {
 import { replaceRoute, route } from '../router'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { TELEMETRY_SOURCE_META, telemetrySourceMeta } from '../config/telemetry-sources'
-import { formatTimeAgo } from '../lib/format-time'
+import { formatElapsedCompact, formatTimeAgo } from '../lib/format-time'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { isAbortError } from '../lib/async-state'
 import { Btn } from './btn'
@@ -588,9 +588,35 @@ function condensedStats(items: readonly TelemetryDisplayItem[]) {
   return { groups, groupedEntries, byCategory }
 }
 
+function telemetrySourceStatusParts(src: TelemetrySourceSummary): string[] {
+  const parts: string[] = []
+  if (src.health) {
+    parts.push(src.stale_reason ? `${src.health}: ${src.stale_reason}` : src.health)
+  } else if (src.stale_reason) {
+    parts.push(src.stale_reason)
+  }
+  if (typeof src.latest_age_s === 'number' && Number.isFinite(src.latest_age_s)) {
+    parts.push(`age ${formatElapsedCompact(src.latest_age_s)}`)
+  }
+  if (typeof src.freshness_slo_s === 'number' && Number.isFinite(src.freshness_slo_s)) {
+    parts.push(`SLO ${formatElapsedCompact(src.freshness_slo_s)}`)
+  }
+  return parts
+}
+
+function telemetrySourceProvenanceRows(src: TelemetrySourceSummary): Array<{ label: string; value: string }> {
+  const rows: Array<{ label: string; value: string }> = []
+  if (src.producer) rows.push({ label: 'producer', value: src.producer })
+  if (src.durable_store) rows.push({ label: 'store', value: src.durable_store })
+  if (src.dashboard_surface) rows.push({ label: 'surface', value: src.dashboard_surface })
+  return rows
+}
+
 function SummaryCard({ src }: { src: TelemetrySourceSummary }) {
   const meta = sourceMeta(src.source)
   const hasData = src.entry_count > 0
+  const statusParts = telemetrySourceStatusParts(src)
+  const provenanceRows = telemetrySourceProvenanceRows(src)
 
   return html`
     <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3 min-w-35">
@@ -607,6 +633,19 @@ function SummaryCard({ src }: { src: TelemetrySourceSummary }) {
       ` : null}
       ${src.exists === false ? html`
         <div class="text-xs text-[var(--color-fg-muted)] italic">store not found</div>
+      ` : null}
+      ${statusParts.length > 0 ? html`
+        <div class="mt-2 text-3xs font-mono text-[var(--color-fg-muted)]">${statusParts.join(' · ')}</div>
+      ` : null}
+      ${provenanceRows.length > 0 ? html`
+        <div class="mt-2 grid gap-1 text-3xs text-[var(--color-fg-disabled)]">
+          ${provenanceRows.map(row => html`
+            <div class="flex min-w-0 gap-1">
+              <span class="shrink-0">${row.label}:</span>
+              <span class="min-w-0 break-all font-mono">${row.value}</span>
+            </div>
+          `)}
+        </div>
       ` : null}
     </div>
   `


### PR DESCRIPTION
## Summary
- show telemetry source health, stale reason, latest age, and SLO on the Runtime Diagnosis summary cards
- include producer, durable store, and dashboard surface provenance in Runtime Diagnosis and Fleet Telemetry source details
- add regression coverage so telemetry summary metadata is not decoded and then hidden from operators

## Verification
- pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/components/telemetry-unified.test.ts src/components/fleet-telemetry-panel.test.ts src/components/fleet-telemetry-utils.test.ts
- pnpm exec tsc --noEmit --pretty
- pnpm exec eslint src/components/telemetry-unified.ts src/components/telemetry-unified.test.ts src/components/fleet-telemetry-utils.ts src/components/fleet-telemetry-utils.test.ts src/components/fleet-telemetry-panel.test.ts
- git diff --check