### PR TITLE
Propagate declarative Ollama Cloud auth

### DIFF
--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -44,6 +44,15 @@ val resolve_auto_model_id : string -> string -> string
 val normalize_openai_compat_request_path :
   base_url:string -> request_path:string -> string
 
+(** Build HTTP headers for a resolved provider API key.
+
+    Empty API keys return only the JSON content-type header; HTTP providers
+    with bearer-token auth receive [Authorization: Bearer ...]. *)
+val headers_with_auth :
+  kind:Llm_provider.Provider_config.provider_kind ->
+  api_key:string ->
+  (string * string) list
+
 (** Parse a "provider:model_id" string into a {!Llm_provider.Provider_config.t}.
 
     Supported providers are determined by {!Llm_provider.Provider_registry.default}.

--- a/lib/cascade/cascade_declarative_adapter.ml
+++ b/lib/cascade/cascade_declarative_adapter.ml
@@ -71,11 +71,21 @@ let find_registry_entry (provider_id : string) :
      | Some cascade_prefix -> Llm_provider.Provider_registry.find registry cascade_prefix
      | None -> None)
 
+let credential_env_candidates = function
+  | "OLLAMA_CLOUD_API_KEY" -> [ "OLLAMA_CLOUD_API_KEY"; "OLLAMA_API_KEY" ]
+  | key -> [ key ]
+
+let api_key_from_env key =
+  credential_env_candidates key
+  |> List.find_map (fun env ->
+         match Sys.getenv_opt env with
+         | Some value when String.trim value <> "" -> Some value
+         | _ -> None)
+  |> Option.value ~default:""
+
 let api_key_of_credential ?registry_entry = function
   | Some (Env key) ->
-      (match Sys.getenv_opt key with
-       | Some value -> value
-       | None -> "")
+      api_key_from_env key
   | Some (Inline value) -> value
   | Some (File _) -> ""
   | None ->
@@ -86,9 +96,7 @@ let api_key_of_credential ?registry_entry = function
        then ""
        else (
          (* NDT-OK: credential materialization is the provider boundary; catalog parsing stays deterministic. *)
-         match Sys.getenv_opt env with
-         | Some value -> value
-         | None -> "")
+         api_key_from_env env)
      | None -> "")
 
 let provider_kind_of_cli_provider (provider : cascade_provider) :
@@ -149,12 +157,15 @@ let provider_config_from_declared_provider
     (match provider_kind_for_http_provider ?registry_entry provider with
      | Some kind ->
        let request_path = request_path_for_http_provider ~registry_entry ~kind ~base_url in
+       let api_key = api_key_of_credential ?registry_entry provider.credentials in
+       let headers = Cascade_config.headers_with_auth ~kind ~api_key in
        Some
          (Llm_provider.Provider_config.make
             ~kind
             ~model_id:spec.api_name
             ~base_url
-            ~api_key:(api_key_of_credential ?registry_entry provider.credentials)
+            ~api_key
+            ~headers
             ~request_path
             ~max_context:spec.max_context
             ?supports_tool_choice_override

--- a/test/test_cascade_declarative_adapter.ml
+++ b/test/test_cascade_declarative_adapter.ml
@@ -317,6 +317,67 @@ strategy = "failover"
            (List.length configs)))
 ;;
 
+let test_ollama_cloud_http_provider_adds_bearer_auth_header () =
+  with_env "OLLAMA_CLOUD_API_KEY" "ollama-cloud-adapter-test-key" @@ fun () ->
+  with_env "OLLAMA_API_KEY" "fallback-ollama-api-key" @@ fun () ->
+    let toml =
+      {|
+[providers.ollama_cloud]
+protocol = "ollama-http"
+endpoint = "https://ollama.com"
+
+[providers.ollama_cloud.credentials]
+type = "env"
+key = "OLLAMA_CLOUD_API_KEY"
+
+[models.glm-5-1-cloud]
+max-context = 262144
+api-name = "glm-5.1:cloud"
+tools-support = true
+
+[ollama_cloud.glm-5-1-cloud]
+max-concurrent = 1
+
+[tier.coding_plan]
+members = ["ollama_cloud.glm-5-1-cloud"]
+strategy = "failover"
+|}
+    in
+    let catalog = adapt_toml toml in
+    no_errors catalog.errors;
+    let coding_plan =
+      List.find
+        (fun (p : adapted_profile) -> p.name = "tier.coding_plan")
+        catalog.profiles
+    in
+    match coding_plan.provider_configs with
+    | [ cfg ] ->
+      check
+        bool
+        "uses Ollama wire kind"
+        true
+        (cfg.Llm_provider.Provider_config.kind = Llm_provider.Provider_config.Ollama);
+      check
+        string
+        "uses Ollama Cloud endpoint"
+        "https://ollama.com"
+        cfg.Llm_provider.Provider_config.base_url;
+      check string "uses Ollama chat path" "/api/chat" cfg.request_path;
+      check string "materializes cloud API key" "ollama-cloud-adapter-test-key" cfg.api_key;
+      check
+        bool
+        "Authorization bearer header present"
+        true
+        (List.mem
+           ("Authorization", "Bearer ollama-cloud-adapter-test-key")
+           cfg.headers)
+    | configs ->
+      fail
+        (Printf.sprintf
+           "expected one resolved provider config, got %d"
+           (List.length configs))
+;;
+
 let test_model_capabilities_tool_choice_reaches_provider_config () =
   let toml =
     {|
@@ -883,6 +944,10 @@ let () =
             "registered HTTP provider uses registry api_key_env fallback"
             `Quick
             test_registered_http_provider_without_credentials_uses_registry_api_key_env
+        ; test_case
+            "ollama_cloud HTTP provider adds bearer auth header"
+            `Quick
+            test_ollama_cloud_http_provider_adds_bearer_auth_header
         ; test_case
             "model supports-tool-choice reaches provider config"
             `Quick


### PR DESCRIPTION
## Summary
- Export the shared cascade auth-header builder for declarative HTTP provider adapters.
- Resolve `OLLAMA_CLOUD_API_KEY` first, with `OLLAMA_API_KEY` fallback, when declarative provider credentials point at Ollama Cloud.
- Attach `Authorization: Bearer ...` to declarative `ollama-http` provider configs for `https://ollama.com`.

## Why
The declarative cascade adapter materialized the API key but did not pass provider auth headers into `Provider_config.make`. That left MASC declarative Ollama Cloud profiles with a key value but no Bearer header at request time.

## Validation
- First build hit Dune cache temp cleanup noise: `rmdir(...dune_b32370_artifacts): Directory not empty`
- `env DUNE_CACHE=disabled scripts/dune-local.sh build ./test/test_cascade_declarative_adapter.exe`
- `./_build/default/test/test_cascade_declarative_adapter.exe` passed: 23 tests
- Live smoke: `POST https://ollama.com/api/chat` with `glm-5.1:cloud` returned HTTP 200, `done=true`, content `OK`