### PR TITLE
fix(keeper): keep degraded turns on keeper routes

### DIFF
--- a/lib/cascade/cascade_error_classify.ml
+++ b/lib/cascade/cascade_error_classify.ml
@@ -599,6 +599,57 @@ let classify_masc_internal_error (err : Agent_sdk.Error.sdk_error) :
      with Yojson.Json_error _ -> None)
   | _ -> None
 
+let substring_matches_at ~(needle : string) (haystack : string) start_idx =
+  let needle_len = String.length needle in
+  if start_idx < 0 || start_idx + needle_len > String.length haystack
+  then false
+  else
+    let rec loop i =
+      if i >= needle_len then true
+      else if String.unsafe_get needle i <> String.unsafe_get haystack (start_idx + i)
+      then false
+      else loop (i + 1)
+    in
+    loop 0
+
+let string_contains_substring ~(needle : string) (haystack : string) =
+  if String.equal needle "" then true
+  else
+    let max_start = String.length haystack - String.length needle in
+    let rec loop i =
+      if i > max_start then false
+      else if substring_matches_at ~needle haystack i then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let sdk_error_is_server_rejected_parse_error (err : Agent_sdk.Error.sdk_error) =
+  match err with
+  | Agent_sdk.Error.Api (InvalidRequest { message }) ->
+    let lower = String.lowercase_ascii message in
+    (string_contains_substring ~needle:"can't find closing" lower
+     || string_contains_substring ~needle:"find end of" lower)
+    || string_contains_substring ~needle:"unexpected character in json" lower
+    || string_contains_substring ~needle:"unterminated" lower
+    || string_contains_substring ~needle:"parse error" lower
+  | Agent_sdk.Error.Api
+      ( RateLimited _
+      | Overloaded _
+      | ServerError _
+      | AuthError _
+      | NotFound _
+      | ContextOverflow _
+      | NetworkError _
+      | Timeout _ )
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> false
+
 let config_for_label
     ~(name : string)
     ~(model_label : string)

--- a/lib/cascade/cascade_error_classify.mli
+++ b/lib/cascade/cascade_error_classify.mli
@@ -91,6 +91,11 @@ val classify_masc_internal_error_of_string :
     "Internal error: [masc_oas_error] ..." wrapper).  Returns [None]
     when the prefix is absent or the JSON payload is malformed. *)
 
+val sdk_error_is_server_rejected_parse_error :
+  Agent_sdk.Error.sdk_error -> bool
+(** [true] when the provider rejected the request body before processing it
+    because the JSON/request payload could not be parsed. *)
+
 val kind_of_masc_internal_error : masc_internal_error -> string
 (** Short label for each variant, used as the [kind] Prometheus label. *)
 

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -657,6 +657,7 @@ let compute_judgments
       let prompt = prompt_for_facts factual_json in
       Keeper_turn_driver_wrappers.run_named_with_masc_tools ~cascade_name
         ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
+        ~accept:Keeper_tool_disclosure.response_has_text_or_tool_progress
         ~approval:Approval_callbacks.auto_approve
         ()
     )

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -207,6 +207,7 @@ let compute_judgments
       ~caller:Env_config_oas_bridge.Operator_judge (fun () ->
       Keeper_turn_driver_wrappers.run_named_with_masc_tools ~cascade_name
         ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
+        ~accept:Keeper_tool_disclosure.response_has_text_or_tool_progress
         ~approval:Approval_callbacks.auto_approve
         ()
     )

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -25,17 +25,41 @@ module StringSet = Set.Make (String)
 
 let now_iso () = Masc_domain.now_iso ()
 
-let candidate_to_json (c : CC.candidate_info) : Yojson.Safe.t =
-  let string_opt_to_json = function
-    | Some value -> `String value
-    | None -> `Null
+let json_string_option = function
+  | Some value -> `String value
+  | None -> `Null
+;;
+
+let is_ollama_cloud_profile profile_name =
+  String.starts_with ~prefix:"tier.ollama_cloud" profile_name
+  || String.starts_with ~prefix:"ollama_cloud" profile_name
+;;
+
+let is_ollama_cloud_candidate ~profile_name (c : CC.candidate_info) =
+  is_ollama_cloud_profile profile_name
+  ||
+  match c.provider_name with
+  | Some provider_name ->
+    String.equal provider_name "ollama"
+    && (String.ends_with ~suffix:":cloud" c.model_string
+        || List.exists
+             (fun model -> String.ends_with ~suffix:":cloud" model)
+             c.expanded_models)
+  | None -> false
+;;
+
+let candidate_to_json ~profile_name (c : CC.candidate_info) : Yojson.Safe.t =
+  let provider_name, display_provider_name, runtime_kind =
+    if is_ollama_cloud_candidate ~profile_name c
+    then Some "ollama_cloud", Some "Ollama Cloud", Some "direct_api"
+    else c.provider_name, c.display_provider_name, c.runtime_kind
   in
   `Assoc
     [ "model", `String c.model_string
     ; "display_model", `String c.display_model_string
-    ; "provider_name", string_opt_to_json c.provider_name
-    ; "display_provider_name", string_opt_to_json c.display_provider_name
-    ; "runtime_kind", string_opt_to_json c.runtime_kind
+    ; "provider_name", json_string_option provider_name
+    ; "display_provider_name", json_string_option display_provider_name
+    ; "runtime_kind", json_string_option runtime_kind
     ; "expanded_models", `List (List.map (fun value -> `String value) c.expanded_models)
     ; "config_weight", `Int c.config_weight
     ; "effective_weight", `Int c.effective_weight
@@ -188,7 +212,7 @@ let profile_json_of_trace ~keeper_assignable name (trace : CC.selection_trace) =
     [ "name", `String name
     ; "source", `String (source_to_string trace.source)
     ; "keeper_assignable", `Bool keeper_assignable
-    ; "candidates", `List (List.map candidate_to_json trace.candidates)
+    ; "candidates", `List (List.map (candidate_to_json ~profile_name:name) trace.candidates)
     ]
 ;;
 

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -217,7 +217,7 @@ let selected_model_of_meta = function
     (match nonempty_trimmed meta.runtime.usage.last_model_used with
      | Some _ as selected_model -> selected_model
      | None ->
-       (match meta.models with
+       (match Keeper_model_labels.configured_model_labels_of_meta meta with
         | model :: _ -> nonempty_trimmed model
         | [] -> None))
 ;;

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -536,9 +536,12 @@ let run_turn
        tools are bound. *)
        if keeper_oas_context.claude_mcp_config = None
        then (
+         let configured_model_labels =
+           Keeper_model_labels.configured_model_labels_of_meta meta
+         in
          let uses_cli_missing_sync =
            Cascade_runtime_candidate.labels_require_runtime_mcp_header_sync
-             meta.models
+             configured_model_labels
          in
          if uses_cli_missing_sync
          then
@@ -597,7 +600,7 @@ let run_turn
                  ~user_message
              in
              let model_id =
-               match meta.models with
+               match Keeper_model_labels.configured_model_labels_of_meta meta with
                | m :: _ -> m
                | [] -> "auto"
              in

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -685,6 +685,8 @@ let run_turn
                      ~max_tokens
                      ?max_cost_usd
                      ?wait_timeout_sec:admission_wait_timeout_sec
+                     ~accept:
+                       Keeper_tool_disclosure.response_has_text_or_tool_progress
                      ?guardrails
                      ?on_event
                      ?on_yield

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -250,7 +250,7 @@ let preferred_tool_names_for_turn_affordances turn_affordances =
   |> List.filter_map turn_affordance_of_string
   |> List.concat_map (function
        | Board_curation ->
-         [ "keeper_board_curation_submit" ]
+         [ "keeper_board_curation_submit"; "keeper_board_cleanup" ]
        | Board_post_or_comment
        | Message_sweep
        | Reply_in_room

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -250,7 +250,7 @@ let preferred_tool_names_for_turn_affordances turn_affordances =
   |> List.filter_map turn_affordance_of_string
   |> List.concat_map (function
        | Board_curation ->
-         [ "keeper_board_curation_submit"; "keeper_board_cleanup" ]
+         [ "keeper_board_curation_submit" ]
        | Board_post_or_comment
        | Message_sweep
        | Reply_in_room
@@ -364,7 +364,14 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
   else if (not has_current_task)
      && has_task_claim_affordance turn_affordances
      && progress_tool_available "keeper_task_claim"
-  then Agent_sdk.Types.Tool "keeper_task_claim"
+  then
+    (* Runtime MCP transports may report the correct call as
+       [mcp__masc__keeper_task_claim]. OAS exact-tool contracts compare
+       raw provider names before MASC canonicalizes them, so exact
+       [Tool "keeper_task_claim"] can reject a valid claim. Keep the
+       turn tool-required and let MASC validate the canonical observed
+       tool names after execution. *)
+    Agent_sdk.Types.Any
   else if has_turn_affordance Task_audit turn_affordances
           && progress_tool_available "keeper_tasks_audit"
   then Agent_sdk.Types.Tool "keeper_tasks_audit"

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -426,6 +426,35 @@ let normalize_declared_name (raw : string) : string =
     | Some use -> cascade_name_for_use use
     | None -> trimmed
 
+let keeper_runtime_route_uses =
+  [ Keeper_turn; Phase_recovery; Phase_buffer; Tool_required ]
+
+let is_keeper_runtime_route_use use =
+  List.exists (( = ) use) keeper_runtime_route_uses
+
+let route_target_public_name ?config_path use =
+  try Some (cascade_name_for_use ?config_path use |> public_name_of_target)
+  with Failure _ -> None
+
+let normalize_keeper_runtime_declared_name ?config_path raw =
+  let normalized = normalize_declared_name raw in
+  let public_name = public_name_of_target normalized in
+  let keeper_route_targets =
+    keeper_runtime_route_uses
+    |> List.filter_map (route_target_public_name ?config_path)
+    |> List.sort_uniq String.compare
+  in
+  let non_keeper_route_targets =
+    Cascade_routes.all_logical_uses
+    |> List.filter (fun use -> not (is_keeper_runtime_route_use use))
+    |> List.filter_map (route_target_public_name ?config_path)
+    |> List.sort_uniq String.compare
+  in
+  if List.mem public_name non_keeper_route_targets
+     && not (List.mem public_name keeper_route_targets)
+  then cascade_name_for_use ?config_path Keeper_turn
+  else normalized
+
 let resolve_live_with_catalog ~catalog raw =
   let trimmed = String.trim raw in
   let normalized =

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -140,6 +140,11 @@ val normalize_declared_name : string -> string
     Logical route aliases resolve through {!cascade_name_for_use}; otherwise
     the trimmed input is returned. *)
 
+val normalize_keeper_runtime_declared_name : ?config_path:string -> string -> string
+(** Like {!normalize_declared_name}, but ignores stale keeper-local profile
+    assignments that point at a route target reserved for non-keeper logical
+    uses. In that case the active [routes.keeper_turn] target is returned. *)
+
 (** {1 In-memory cascade key helpers} *)
 
 (** First canonicalize, then build the key. *)

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -138,15 +138,7 @@ let compact_if_needed_typed
       tok_count
       trigger_human;
     let model_meta =
-      let model_labels =
-        match
-          dedupe_keep_order (List.filter (fun s -> String.trim s <> "") meta.models)
-        with
-        | _ :: _ as explicit -> explicit
-        | [] ->
-          Cascade_runtime.models_of_cascade_name
-            (Keeper_cascade_profile.Runtime_name (cascade_name_of_meta meta))
-      in
+      let model_labels = Keeper_model_labels.configured_model_labels_of_meta meta in
       Cascade_runtime_candidate.context_window_hint_of_labels model_labels
     in
     let pre_compact_event =

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -445,6 +445,7 @@ let required_tool_rotation_candidate
   && (allow_local_recovery
       || not
            (String.equal normalized Keeper_config.local_recovery_cascade_name))
+  && not (Cascade_capability_profile.is_system_cascade_name normalized)
 
 let legacy_degraded_rotation_candidates
     ~catalog_names

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -1515,12 +1515,22 @@ let pr_work_actions_of_command command =
          | [] -> pr_work_actions_of_git_segment segment
          | actions -> actions)
 
+let is_pr_work_action_tool_name = function
+  | "masc_code_git"
+  | "keeper_pr_create"
+  | "keeper_shell"
+  | "keeper_bash"
+  | "masc_code_shell" -> true
+  | _ -> false
+
 let pr_work_action_metric_events_of_tool_io
     ~route_via_fallback
     ~(tool_name : string)
     ~(input : Yojson.Safe.t)
     ~(output_text : string)
     ~(transport_success : bool) =
+  if not (is_pr_work_action_tool_name tool_name) then []
+  else
   let output_json = output_json_opt ~surface:"pr_work_action" output_text in
   let route_via =
     first_some (Option.bind output_json route_via_of_json)

--- a/lib/keeper/keeper_model_labels.ml
+++ b/lib/keeper/keeper_model_labels.ml
@@ -1,14 +1,8 @@
 open Keeper_types
 
 let configured_model_labels_of_meta (m : keeper_meta) : string list =
-  match dedupe_keep_order (List.filter (fun s -> String.trim s <> "") m.models) with
-  | _ :: _ as explicit -> explicit
-  | [] ->
-      let configured =
-        Cascade_runtime.models_of_cascade_name
-          (Keeper_cascade_profile.Runtime_name (cascade_name_of_meta m))
-      in
-      match Keeper_benchmark_canary.recommended_model_label_for_keeper ~keeper_name:m.name with
-      | Some model_label when String.trim model_label <> "" ->
-          dedupe_keep_order (model_label :: configured)
-      | _ -> configured
+  (* Runtime dispatch must be cascade-catalog authoritative.  Persisted
+     [meta.models] and benchmark-canary labels are legacy hints and can carry
+     stale provider strings across reconfiguration. *)
+  Cascade_runtime.models_of_cascade_name
+    (Keeper_cascade_profile.Runtime_name (cascade_name_of_meta m))

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1204,6 +1204,23 @@ let update_entry ~base_path name f =
   loop ()
 ;;
 
+let update_entry_if_registered ~base_path name f =
+  let key = registry_key ~base_path name in
+  let rec loop () =
+    let current = Atomic.get registry in
+    match StringMap.find_opt key current with
+    | None -> false
+    | Some entry ->
+      let updated = StringMap.add key (f entry) current in
+      if Atomic.compare_and_set registry current updated
+      then (
+        clear_orphan_drop ~base_path name;
+        true)
+      else loop ()
+  in
+  loop ()
+;;
+
 let max_crash_log_entries = 5
 
 let register_with_state
@@ -1600,7 +1617,7 @@ let update_current_turn e f =
 let mark_turn_started ~base_path name =
   let changed = ref false in
   let now = Time_compat.now () in
-  update_entry ~base_path name (fun e ->
+  ignore (update_entry_if_registered ~base_path name (fun e ->
     let turn_id = e.meta.runtime.usage.total_turns + 1 in
     let obs =
       { turn_id
@@ -1617,7 +1634,7 @@ let mark_turn_started ~base_path name =
     { e with
       current_turn_observation = Some obs
     ; compaction_stage = Packed Compaction_accumulating
-    });
+    }));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 
@@ -1633,7 +1650,7 @@ let mark_turn_started ~base_path name =
 let mark_sdk_turn_started ~base_path name =
   let changed = ref false in
   let now = Time_compat.now () in
-  update_entry ~base_path name (fun e ->
+  ignore (update_entry_if_registered ~base_path name (fun e ->
     match e.current_turn_observation with
     | None -> e
     | Some obs ->
@@ -1651,14 +1668,14 @@ let mark_sdk_turn_started ~base_path name =
           ; decision_stage = Packed Decision_undecided
           }
         in
-        { e with current_turn_observation = Some new_obs }));
+        { e with current_turn_observation = Some new_obs })));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 
 let mark_turn_measurement ~base_path name =
   let changed = ref false in
   let now = Time_compat.now () in
-  update_entry ~base_path name (fun e ->
+  ignore (update_entry_if_registered ~base_path name (fun e ->
     match e.current_turn_observation, e.pending_turn_measurement with
     | Some obs, Some measurement ->
       changed := true;
@@ -1671,7 +1688,7 @@ let mark_turn_measurement ~base_path name =
             }
       ; pending_turn_measurement = None
       }
-    | _ -> e);
+    | _ -> e));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 
@@ -1743,13 +1760,13 @@ let set_turn_decision_stage ~base_path name (decision_stage : decision_stage_act
   let target_packed = decision_stage_active_to_packed decision_stage in
   let changed = ref false in
   let now = Time_compat.now () in
-  update_entry ~base_path name (fun e ->
+  ignore (update_entry_if_registered ~base_path name (fun e ->
     update_current_turn e (fun obs ->
       if obs.decision_stage = target_packed
       then obs
       else (
         changed := true;
-        { obs with decision_stage = target_packed })));
+        { obs with decision_stage = target_packed }))));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 
@@ -1780,7 +1797,7 @@ let set_turn_cascade_state ~base_path name (cascade_state : packed_cascade_state
      axis (which also dispatches through its resolver as of Phase 4b). *)
   let changed = ref false in
   let now = Time_compat.now () in
-  update_entry ~base_path name (fun e ->
+  ignore (update_entry_if_registered ~base_path name (fun e ->
     update_current_turn e (fun obs ->
       let new_turn_phase = turn_phase_of_cascade_state cascade_state in
       match resolve_cascade_transition ~from:obs.cascade_state ~target:cascade_state with
@@ -1799,7 +1816,7 @@ let set_turn_cascade_state ~base_path name (cascade_state : packed_cascade_state
                ~from:obs.cascade_state
                ~to_:cascade_state
                ~violation);
-        obs));
+        obs)));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 
@@ -1852,7 +1869,7 @@ let set_turn_phase ~base_path name (turn_phase : packed_turn_phase) =
      arm below. *)
   let changed = ref false in
   let now = Time_compat.now () in
-  update_entry ~base_path name (fun e ->
+  ignore (update_entry_if_registered ~base_path name (fun e ->
     update_current_turn e (fun obs ->
       match resolve_turn_phase_transition ~from:obs.turn_phase ~target:turn_phase with
       | Resolved_turn_idempotent -> obs
@@ -1880,24 +1897,24 @@ let set_turn_phase ~base_path name (turn_phase : packed_turn_phase) =
                ~from:obs.turn_phase
                ~to_:turn_phase
                ~violation);
-        obs));
+        obs)));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 
 let set_turn_selected_model ~base_path name selected_model =
   let changed = ref false in
   let now = Time_compat.now () in
-  update_entry ~base_path name (fun e ->
+  ignore (update_entry_if_registered ~base_path name (fun e ->
     update_current_turn e (fun obs ->
       changed := true;
-      { obs with selected_model }));
+      { obs with selected_model })));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 
 let prepare_turn_retry_after_compaction ~base_path name =
   let changed = ref false in
   let now = Time_compat.now () in
-  update_entry ~base_path name (fun e ->
+  ignore (update_entry_if_registered ~base_path name (fun e ->
     update_current_turn e (fun obs ->
       validate_cascade_transition
         ~from:obs.cascade_state
@@ -1909,7 +1926,7 @@ let prepare_turn_retry_after_compaction ~base_path name =
       ; decision_stage = Packed Decision_guard_ok
       ; cascade_state = Packed Cascade_idle
       ; selected_model = None
-      }));
+      })));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 
@@ -1943,7 +1960,7 @@ let mark_turn_finished ~base_path name =
   let completed_turn_to_record = ref None in
   let changed = ref false in
   let now = Time_compat.now () in
-  update_entry ~base_path name (fun e ->
+  ignore (update_entry_if_registered ~base_path name (fun e ->
     let had_live_turn =
       match e.current_turn_observation with
       | Some _ -> true
@@ -1982,7 +1999,7 @@ let mark_turn_finished ~base_path name =
         }
       else e.meta
     in
-    { e with meta; current_turn_observation = None; last_completed_turn });
+    { e with meta; current_turn_observation = None; last_completed_turn }));
   Option.iter
     (Keeper_transition_audit.record_completed_turn ~keeper_name:name)
     !completed_turn_to_record;

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1434,9 +1434,22 @@ let update_meta ~base_path name meta =
   update_entry ~base_path name (fun e -> { e with meta })
 ;;
 
+let sync_meta_if_registered ~base_path name meta =
+  let key = registry_key ~base_path name in
+  let rec loop () =
+    let current = Atomic.get registry in
+    match StringMap.find_opt key current with
+    | None -> ()
+    | Some entry ->
+      let updated = StringMap.add key { entry with meta } current in
+      if not (Atomic.compare_and_set registry current updated) then loop ()
+  in
+  loop ()
+;;
+
 let () =
   register_runtime_meta_write_sync (fun config meta ->
-    update_meta ~base_path:config.base_path meta.name meta)
+    sync_meta_if_registered ~base_path:config.base_path meta.name meta)
 ;;
 
 let mark_dead ~base_path name ~at =

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -587,27 +587,39 @@ let prepare_agent_setup
           | None -> [])
        | None -> [])
   in
+  let visible_policy_name name =
+    (* Preserve names that are already valid public surface entries.
+       keeper_fs_edit has two public aliases (Edit, Write) with different
+       schemas; round-tripping through public_name_for_internal always
+       picks Edit, so any Write entry would be coerced to Edit and then
+       deduped. Only canonicalize names that are not themselves valid
+       public entries (e.g., internal names like keeper_fs_edit, or
+       unrecognized inputs). *)
+    if Keeper_tool_policy.StringSet.mem name universe_set
+       && Keeper_tool_policy.StringSet.mem name allowed_exec_set
+    then name
+    else (
+      let canonical = Keeper_tool_disclosure.canonical_tool_name name in
+      match Keeper_tool_alias.public_name_for_internal canonical with
+      | Some public
+        when Keeper_tool_policy.StringSet.mem public universe_set
+             && Keeper_tool_policy.StringSet.mem public allowed_exec_set ->
+        public
+      | _ -> name)
+  in
+  let visible_policy_name_opt name =
+    let name = visible_policy_name name in
+    if Keeper_tool_policy.StringSet.mem name universe_set
+       && Keeper_tool_policy.StringSet.mem name allowed_exec_set
+    then Some name
+    else allowed_public_alias_for_internal name
+  in
+  let filter_visible_policy_surface names =
+    names
+    |> List.filter_map visible_policy_name_opt
+    |> Keeper_types.dedupe_keep_order
+  in
   let validate_allow_list ~turn raw =
-    let visible_policy_name name =
-      (* Preserve names that are already valid public surface entries.
-         keeper_fs_edit has two public aliases (Edit, Write) with different
-         schemas; round-tripping through public_name_for_internal always
-         picks Edit, so any Write entry would be coerced to Edit and then
-         deduped. Only canonicalize names that are not themselves valid
-         public entries (e.g., internal names like keeper_fs_edit, or
-         unrecognized inputs). *)
-      if Keeper_tool_policy.StringSet.mem name universe_set
-         && Keeper_tool_policy.StringSet.mem name allowed_exec_set
-      then name
-      else (
-        let canonical = Keeper_tool_disclosure.canonical_tool_name name in
-        match Keeper_tool_alias.public_name_for_internal canonical with
-        | Some public
-          when Keeper_tool_policy.StringSet.mem public universe_set
-               && Keeper_tool_policy.StringSet.mem public allowed_exec_set ->
-          public
-        | _ -> name)
-    in
     let raw = raw |> List.map visible_policy_name |> Keeper_types.dedupe_keep_order in
     let validated, dropped_names =
       List.fold_right
@@ -705,7 +717,10 @@ let prepare_agent_setup
       Keeper_exec_tools.effective_core_tools ()
       |> List.filter (fun name -> Keeper_tool_policy.StringSet.mem name allowed_exec_set)
     in
-    let discovered = Keeper_discovered_tools.active_names acc.discovered ~turn in
+    let discovered =
+      Keeper_discovered_tools.active_names acc.discovered ~turn
+      |> filter_visible_policy_surface
+    in
     let () =
       if decay_discovered then ignore (Keeper_discovered_tools.decay acc.discovered ~turn)
     in
@@ -717,6 +732,7 @@ let prepare_agent_setup
         ~query_text
         ~selection_limit
         ~core
+      |> filter_visible_policy_surface
     in
     let llm_rerank_enabled = Keeper_config.keeper_llm_rerank_enabled () in
     let llm_selected =
@@ -804,7 +820,7 @@ let prepare_agent_setup
                        (List.length selected)
                        (String.length query_text)
                        (List.length preset_tools);
-                   selected
+                   filter_visible_policy_surface selected
                  with
                  | Eio.Cancel.Cancelled _ as e -> raise e
                  | exn ->

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -172,10 +172,11 @@ let effective_declarative_cascade_name
     (meta : keeper_meta) =
   match defaults.cascade_name, defaults.manifest_path with
   | Some cascade_name, _ ->
-      Keeper_cascade_profile.normalize_declared_name cascade_name
+      Keeper_cascade_profile.normalize_keeper_runtime_declared_name cascade_name
   | None, Some _ -> (Keeper_config.default_cascade_name ())
   | None, None ->
-      Keeper_cascade_profile.normalize_declared_name (cascade_name_of_meta meta)
+      Keeper_cascade_profile.normalize_keeper_runtime_declared_name
+        (cascade_name_of_meta meta)
 
 let resynced_tool_access
     (defaults : Keeper_types_profile.keeper_profile_defaults)

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -27,10 +27,12 @@ let effective_declarative_cascade_name
       (meta : keeper_meta)
   =
   match defaults.cascade_name, defaults.manifest_path with
-  | Some cascade_name, _ -> Keeper_cascade_profile.normalize_declared_name cascade_name
+  | Some cascade_name, _ ->
+    Keeper_cascade_profile.normalize_keeper_runtime_declared_name cascade_name
   | None, Some _ -> (Keeper_config.default_cascade_name ())
   | None, None ->
-    Keeper_cascade_profile.normalize_declared_name (cascade_name_of_meta meta)
+    Keeper_cascade_profile.normalize_keeper_runtime_declared_name
+      (cascade_name_of_meta meta)
 ;;
 
 type override_field_detail =

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -71,6 +71,9 @@ let known_internal_names_tbl : (string, unit) Hashtbl.t =
        | Some public -> Hashtbl.replace t public ()
        | None -> ())
     Tool_catalog_surfaces.keeper_internal_tools;
+  List.iter
+    (fun public_mcp -> Hashtbl.replace t public_mcp ())
+    Tool_catalog_surfaces.public_mcp_surface_tools;
   t
 ;;
 

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -167,6 +167,8 @@ let final_keeper_tool_names
   let allowed_tool_names =
     allowed_tool_names |> List.map canonical_name |> Keeper_types.dedupe_keep_order
   in
+  let allowed = Hashtbl.create (List.length allowed_tool_names) in
+  List.iter (fun tool_name -> Hashtbl.replace allowed tool_name ()) allowed_tool_names;
   let reported_tool_names = List.map canonical_name reported_tool_names in
   let observed_tool_names = List.map canonical_name observed_tool_names in
   let tool_names =
@@ -183,7 +185,7 @@ let final_keeper_tool_names
           reported_tool_names
   in
   tool_names
-  |> List.filter (fun tool_name -> List.mem tool_name allowed_tool_names)
+  |> List.filter (fun tool_name -> Hashtbl.mem allowed tool_name)
 ;;
 
 let unexpected_tool_names ~(allowed_tool_names : string list) ~(tool_names : string list)
@@ -194,13 +196,16 @@ let unexpected_tool_names ~(allowed_tool_names : string list) ~(tool_names : str
   in
   let allowed = Hashtbl.create (List.length allowed_tool_names) in
   let seen = Hashtbl.create (List.length tool_names) in
-  List.iter (fun tool_name -> Hashtbl.replace allowed tool_name ()) allowed_tool_names;
+  List.iter
+    (fun tool_name -> Hashtbl.replace allowed (canonical_name tool_name) ())
+    allowed_tool_names;
   tool_names
   |> List.filter (fun tool_name ->
-    if Hashtbl.mem allowed tool_name || Hashtbl.mem seen tool_name
+    let canonical = canonical_name tool_name in
+    if Hashtbl.mem allowed canonical || Hashtbl.mem seen canonical
     then false
     else (
-      Hashtbl.replace seen tool_name ();
+      Hashtbl.replace seen canonical ();
       true))
 ;;
 

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -549,6 +549,23 @@ let normalize_response_text ~(text : string) ~(tool_names : string list) ()
            (String.concat ", " tool_names)))
 ;;
 
+let response_has_text_or_tool_progress (response : Agent_sdk.Types.api_response) =
+  let text = Agent_sdk.Types.text_of_content response.content |> String.trim in
+  text <> ""
+  || List.exists
+       (function
+         | Agent_sdk.Types.ToolUse _ -> true
+         | Agent_sdk.Types.Text _
+         | Agent_sdk.Types.Thinking _
+         | Agent_sdk.Types.RedactedThinking _
+         | Agent_sdk.Types.ToolResult _
+         | Agent_sdk.Types.Image _
+         | Agent_sdk.Types.Document _
+         | Agent_sdk.Types.Audio _ -> false)
+       response.content
+  || response.stop_reason <> Agent_sdk.Types.EndTurn
+;;
+
 let tool_query_text_of_user_message (text : string) : string =
   let allowed_sections =
     [ "### Pending Mentions"

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -200,6 +200,12 @@ val normalize_response_text
   -> unit
   -> (string, string) result
 
+(** [true] when a provider response carries usable keeper progress for
+    cascade accept/reject: non-blank text, ToolUse, or a non-terminal
+    stop reason. Empty [end_turn] responses are rejected so cascade can
+    try the next candidate instead of failing later as "no textual reply". *)
+val response_has_text_or_tool_progress : Agent_sdk.Types.api_response -> bool
+
 (** Project a user-message text to the BM25 query text by keeping
     only the world-state header and a curated set of subsections. *)
 val tool_query_text_of_user_message : string -> string

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -16,30 +16,81 @@ type cascade_execution = {
   max_tokens : int;
 }
 
+let public_profile_name name =
+  let name = String.trim name in
+  let tier_group_prefix = "tier-group." in
+  let tier_prefix = "tier." in
+  if String.starts_with ~prefix:tier_group_prefix name then
+    String.sub name (String.length tier_group_prefix)
+      (String.length name - String.length tier_group_prefix)
+  else if String.starts_with ~prefix:tier_prefix name then
+    String.sub name (String.length tier_prefix)
+      (String.length name - String.length tier_prefix)
+  else name
+
 let fail_open_rotation_cascades_from_catalog
+    ?(excluded_targets : string list = [])
     ~(catalog_names : string list)
-    ~(keeper_assignable : string list) =
+    ~(keeper_assignable : string list)
+    () =
   if catalog_names = [] then None
   else
+    let excluded_targets =
+      excluded_targets |> List.map public_profile_name |> dedupe_keep_order
+    in
     let is_reserved_default name =
       String.equal name (Keeper_config.default_cascade_name ())
     in
     let is_keeper_assignable name =
       List.exists (String.equal name) keeper_assignable
     in
+    let is_excluded name =
+      List.exists (String.equal (public_profile_name name)) excluded_targets
+    in
     match
       catalog_names
       |> List.filter (fun name ->
-             is_reserved_default name || is_keeper_assignable name)
+             (is_reserved_default name || is_keeper_assignable name)
+             && not (is_excluded name))
       |> dedupe_keep_order
     with
     | [] -> None
     | candidates -> Some candidates
 
+let keeper_fail_open_route_uses =
+  [
+    Keeper_cascade_profile.Keeper_turn;
+    Keeper_cascade_profile.Phase_recovery;
+    Keeper_cascade_profile.Phase_buffer;
+    Keeper_cascade_profile.Tool_required;
+  ]
+
+let is_keeper_fail_open_route_use use =
+  List.exists (( = ) use) keeper_fail_open_route_uses
+
+let route_target_for_use use =
+  try Some (Keeper_cascade_profile.cascade_name_for_use use |> public_profile_name)
+  with Failure _ -> None
+
+let active_fail_open_excluded_route_targets () =
+  let keeper_route_targets =
+    keeper_fail_open_route_uses
+    |> List.filter_map route_target_for_use
+    |> dedupe_keep_order
+  in
+  Cascade_routes.all_logical_uses
+  |> List.filter (fun use -> not (is_keeper_fail_open_route_use use))
+  |> List.filter_map route_target_for_use
+  |> List.filter (fun target ->
+         not (List.exists (String.equal target) keeper_route_targets))
+  |> dedupe_keep_order
+
 let active_fail_open_rotation_cascades () =
   fail_open_rotation_cascades_from_catalog
+    ~excluded_targets:(active_fail_open_excluded_route_targets ())
     ~catalog_names:(Keeper_cascade_profile.catalog_names ())
     ~keeper_assignable:(Keeper_cascade_profile.keeper_catalog_names ())
+    ()
 
 let next_fail_open_cascade_for_turn
     ?rotation_cascades

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -17,8 +17,10 @@ type cascade_execution = {
 }
 
 val fail_open_rotation_cascades_from_catalog :
+  ?excluded_targets:string list ->
   catalog_names:string list ->
   keeper_assignable:string list ->
+  unit ->
   string list option
 
 val active_fail_open_rotation_cascades : unit -> string list option

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -868,7 +868,18 @@ let run_named
               Cascade_legacy_runner.record_fallback_event capture
                 ~from_model:runtime_candidate_label ~to_model:runtime_candidate_label
                 ~reason:(class_label ^ Agent_sdk.Error.to_string sdk_err);
-              try_cascade ?resume_checkpoint:next_resume rest new_err
+              let retry_resume_checkpoint =
+                if sdk_error_is_server_rejected_parse_error sdk_err then (
+                  Log.Misc.info
+                    "[cascade-fallback] cascade %s: %s server rejected the \
+                     resumed request body; dropping resume checkpoint for \
+                     next provider"
+                    cascade_name runtime_candidate_label;
+                  None)
+                else
+                  next_resume
+              in
+              try_cascade ?resume_checkpoint:retry_resume_checkpoint rest new_err
             | Cascade_fsm.Exhausted _ ->
               let observation =
                 Cascade_legacy_runner.cascade_observation_with_metrics

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -110,6 +110,7 @@ let run_named_with_masc_tools
     ?max_input_tokens
     ?max_cost_usd
     ?wait_timeout_sec
+    ?(accept = fun (_ : Agent_sdk_response.api_response) -> true)
     ?guardrails
     ?hooks
     ?memory
@@ -142,6 +143,7 @@ let run_named_with_masc_tools
     ?stream_idle_timeout_s ?wait_timeout_sec ?guardrails ?hooks ?memory
     ?tool_retry_policy
     ~required_tool_satisfaction
+    ~accept
     ?compact_ratio
     ?approval
     ?raw_trace ?on_event ?on_yield ?on_resume ?proof_ref

--- a/lib/keeper/keeper_turn_driver_wrappers.mli
+++ b/lib/keeper/keeper_turn_driver_wrappers.mli
@@ -56,6 +56,7 @@ val run_named_with_masc_tools :
   ?max_input_tokens:int ->
   ?max_cost_usd:float ->
   ?wait_timeout_sec:float ->
+  ?accept:(Agent_sdk_response.api_response -> bool) ->
   ?guardrails:Agent_sdk.Guardrails.t ->
   ?hooks:Agent_sdk.Hooks.hooks ->
   ?memory:Agent_sdk.Memory.t ->

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -208,8 +208,10 @@ val fail_open_local_only_when_unavailable
     preserved while retaining only reserved recovery profiles and
     keeper-assignable profiles. *)
 val fail_open_rotation_cascades_from_catalog
-  :  catalog_names:string list
+  :  ?excluded_targets:string list
+  -> catalog_names:string list
   -> keeper_assignable:string list
+  -> unit
   -> string list option
 
 (** Resolve the next cascade to try after an auto-recoverable failure.

--- a/lib/task_sandbox.ml
+++ b/lib/task_sandbox.ml
@@ -48,7 +48,9 @@ let git_exit ~cwd args =
 (* Worktree-message regexes are static — hoist so the DFAs are built
    once at module init instead of per [extract_*] call. *)
 let abs_path_re = Re.Pcre.re {|Path: (/[^ \t\n\r]+)|} |> Re.compile
-let rel_worktree_re = Re.Pcre.re {|\.worktrees/[^ \t\n\r]+|} |> Re.compile
+let rel_worktree_re =
+  Re.Pcre.re {|((?:[^ \t\n\r:]+/)?\.worktrees/[^ \t\n\r]+)|} |> Re.compile
+;;
 let branch_name_re = Re.Pcre.re {|Branch: ([^ \t\n\r]+)|} |> Re.compile
 
 (** Extract absolute worktree path from [Coord_worktree.worktree_create_r]

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -924,6 +924,11 @@ let keeper_persona_audit_item ctx requested_name =
     | None -> defaults.autoboot_enabled
   in
   let paused = runtime_meta |> Option.map (fun meta -> meta.paused) in
+  let dormant_autoboot_disabled =
+    match runtime_meta, autoboot_enabled, paused, registry_entry with
+    | Some _, Some false, (Some false | None), None -> true
+    | _ -> false
+  in
   let issues =
     let add cond issue acc = if cond then issue :: acc else acc in
     []
@@ -933,10 +938,11 @@ let keeper_persona_audit_item ctx requested_name =
          "missing_persona_profile"
     |> add (not live_meta_exists) "missing_runtime_meta"
     |> add (Option.is_some runtime_meta_error) "runtime_meta_error"
-    |> add (Option.is_some runtime_meta && Option.is_none registry_entry)
+    |> add
+         (Option.is_some runtime_meta
+          && Option.is_none registry_entry
+          && not dormant_autoboot_disabled)
          "registry_missing"
-    |> add (match autoboot_enabled with Some false -> true | _ -> false)
-         "autoboot_disabled"
     |> add (match paused with Some true -> true | _ -> false) "keeper_paused"
     |> add (match runtime_meta with Some meta when Stdlib.List.length meta.active_goal_ids = 0 -> true | _ -> false)
          "empty_active_goal_ids"
@@ -980,6 +986,9 @@ let keeper_persona_audit_item ctx requested_name =
       ("phase", Json_util.string_opt_to_json phase);
       ("runtime_status", Json_util.string_opt_to_json runtime_status);
       ("autoboot_enabled", json_bool_opt autoboot_enabled);
+      ("dormant", `Bool dormant_autoboot_disabled);
+      ( "dormant_reason",
+        if dormant_autoboot_disabled then `String "autoboot_disabled" else `Null );
       ("paused", json_bool_opt paused);
       ("keepalive_running", json_bool_opt keepalive_running);
       ("keepalive_started_at", json_float_opt keepalive_started_at);
@@ -999,6 +1008,18 @@ let keeper_persona_audit_summary items =
     List.fold_left (fun acc item -> if pred item then acc + 1 else acc) 0 items
   in
   let count_issue issue = count (has_issue issue) in
+  let count_bool_field field =
+    count (fun item ->
+        match Yojson.Safe.Util.member field item with
+        | `Bool true -> true
+        | _ -> false)
+  in
+  let count_autoboot_disabled =
+    count (fun item ->
+        match Yojson.Safe.Util.member "autoboot_enabled" item with
+        | `Bool false -> true
+        | _ -> false)
+  in
   let ok_count =
     count (fun item ->
         match Yojson.Safe.Util.member "ok" item with
@@ -1017,7 +1038,8 @@ let keeper_persona_audit_summary items =
       ("missing_runtime_meta", `Int (count_issue "missing_runtime_meta"));
       ("runtime_meta_error", `Int (count_issue "runtime_meta_error"));
       ("registry_missing", `Int (count_issue "registry_missing"));
-      ("autoboot_disabled", `Int (count_issue "autoboot_disabled"));
+      ("dormant_autoboot_disabled", `Int (count_bool_field "dormant"));
+      ("autoboot_disabled", `Int count_autoboot_disabled);
       ("keeper_paused", `Int (count_issue "keeper_paused"));
       ("keepalive_not_running", `Int (count_issue "keepalive_not_running"));
       ("empty_active_goal_ids", `Int (count_issue "empty_active_goal_ids"));

--- a/test/test_keeper_benchmark_canary.ml
+++ b/test/test_keeper_benchmark_canary.ml
@@ -45,6 +45,8 @@ let make_meta ?(name = "analyst") ?(models = []) () =
       ("trace_id", `String "trace-keeper-benchmark-canary");
       ("cascade_name", `String Masc_mcp.(Keeper_config.default_cascade_name ()));
       ("last_model_used", `String "");
+      ("sandbox_profile", `String "local");
+      ("network_mode", `String "none");
     ]
   in
   let fields =
@@ -174,16 +176,16 @@ let test_runtime_canary_prepends_recommended_model_only_without_explicit_models 
         let labels =
           KML.configured_model_labels_of_meta (make_meta ~name:"analyst" ())
         in
-        check string "recommended model is prepended"
-          "test-provider:test-model" (List.hd labels);
+        check bool "bench recommendation is not a runtime dispatch override"
+          false (List.mem "test-provider:test-model" labels);
         let explicit_meta =
           { (make_meta ~name:"analyst" ()) with models = [ "explicit:model" ] }
         in
         let explicit_labels =
           KML.configured_model_labels_of_meta explicit_meta
         in
-        check (list string) "explicit models stay untouched"
-          [ "explicit:model" ] explicit_labels)))
+        check bool "legacy explicit models are ignored by runtime labels"
+          false (List.mem "explicit:model" explicit_labels))))
 
 let () =
   run "keeper_benchmark_canary"

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -1190,6 +1190,23 @@ let test_pr_work_action_metric_observes_invalid_output_json () =
     (hook_output_parse_failures "pr_work_action")
 ;;
 
+let test_pr_work_action_metric_ignores_non_pr_tool_output () =
+  let before = hook_output_parse_failures "pr_work_action" in
+  let events =
+    pr_work_events
+      ~tool_name:"keeper_board_cleanup"
+      ~input:(`Assoc [])
+      ~output_text:"cleanup report is not PR telemetry JSON"
+      ()
+  in
+  check (list string) "no pr work actions" [] (work_actions events);
+  check
+    (float 0.001)
+    "non-pr tool output is not parsed as pr_work_action JSON"
+    before
+    (hook_output_parse_failures "pr_work_action")
+;;
+
 let test_pr_work_action_metric_extracts_embedded_output_json () =
   let before = hook_output_parse_failures "pr_work_action" in
   let events =
@@ -1543,6 +1560,10 @@ let () =
             "observes invalid output JSON"
             `Quick
             test_pr_work_action_metric_observes_invalid_output_json
+        ; test_case
+            "ignores non-pr tool output"
+            `Quick
+            test_pr_work_action_metric_ignores_non_pr_tool_output
         ; test_case
             "extracts embedded output JSON"
             `Quick

--- a/test/test_keeper_llama_only.ml
+++ b/test/test_keeper_llama_only.ml
@@ -38,6 +38,8 @@ let make_meta ?(last_model_used = "glm-5.1") ?(models = []) () =
           ("trace_id", `String "trace-keeper-llama-only");
           ("cascade_name", `String Masc_mcp.(Keeper_config.default_cascade_name ()));
           ("last_model_used", `String last_model_used);
+          ("sandbox_profile", `String "local");
+          ("network_mode", `String "none");
         ])
     with
   | Ok meta -> meta
@@ -67,14 +69,15 @@ let test_matching_last_model_is_preserved_when_still_in_cascade () =
     | actual_first :: _ ->
       check string "matching model stays first" first actual_first
 
-let test_explicit_models_override_cascade_resolution () =
+let test_legacy_explicit_models_do_not_override_cascade_resolution () =
   let explicit =
     [ "ollama:qwen3.5:35b-a3b-nvfp4"; "glm-coding:glm-5.1" ]
   in
+  let baseline = labels_for_turn (make_meta ~last_model_used:"" ()) in
   let labels =
     labels_for_turn (make_meta ~last_model_used:"" ~models:explicit ())
   in
-  check (list string) "explicit models are used as configured" explicit labels
+  check (list string) "legacy explicit models do not override cascade" baseline labels
 
 let () =
   run "keeper_llama_only"
@@ -85,7 +88,7 @@ let () =
             test_stale_last_model_is_not_reused_outside_current_cascade;
           test_case "keeps llama pin when still allowed" `Quick
             test_matching_last_model_is_preserved_when_still_in_cascade;
-          test_case "prefers explicit models over cascade defaults" `Quick
-            test_explicit_models_override_cascade_resolution;
+          test_case "ignores legacy explicit models for runtime labels" `Quick
+            test_legacy_explicit_models_do_not_override_cascade_resolution;
         ] );
     ]

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -576,6 +576,65 @@ let test_keeper_persona_audit_reports_durable_live_persona_keeper () =
           check int "no issues" 0
             Yojson.Safe.Util.(item |> member "issues" |> to_list |> List.length))
 
+let test_keeper_persona_audit_reports_dormant_autoboot_disabled_keeper () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  with_clean_base_path_env @@ fun () ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Config_dir_resolver.reset ();
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      write_persona_profile_exn config ~name:"dormant";
+      write_keeper_persona_toml_exn config ~name:"dormant"
+        ~persona_name:"dormant" ~autoboot_enabled:false;
+      write_keeper_meta_exn config ~name:"dormant" ~trace_id:"trace-dormant"
+        ~autoboot_enabled:false;
+      let config_root = Filename.concat (Coord.masc_root_dir config) "config" in
+      write_minimal_cascade_toml config_root;
+      Unix.putenv "MASC_CONFIG_DIR" config_root;
+      Config_dir_resolver.reset ();
+      let ctx = keeper_ctx env sw config "operator" in
+      let ok, body =
+        match
+          Tool_keeper.dispatch ctx ~name:"masc_keeper_persona_audit"
+            ~args:(`Assoc [ ("name", `String "dormant") ])
+        with
+        | Some result -> result
+        | None -> fail "expected masc_keeper_persona_audit dispatch"
+      in
+      check bool "tool audit ok" true ok;
+      let json = parse_json_exn body in
+      check int "summary ok" 1
+        Yojson.Safe.Util.(json |> member "summary" |> member "ok" |> to_int);
+      check int "summary registry missing" 0
+        Yojson.Safe.Util.(
+          json |> member "summary" |> member "registry_missing" |> to_int);
+      check int "summary dormant" 1
+        Yojson.Safe.Util.(
+          json |> member "summary" |> member "dormant_autoboot_disabled"
+          |> to_int);
+      check int "summary autoboot disabled" 1
+        Yojson.Safe.Util.(
+          json |> member "summary" |> member "autoboot_disabled" |> to_int);
+      match audit_item_by_name json "dormant" with
+      | None -> fail "expected dormant audit item"
+      | Some item ->
+          check bool "item ok" true
+            Yojson.Safe.Util.(item |> member "ok" |> to_bool);
+          check bool "dormant flag" true
+            Yojson.Safe.Util.(item |> member "dormant" |> to_bool);
+          check string "dormant reason" "autoboot_disabled"
+            Yojson.Safe.Util.(item |> member "dormant_reason" |> to_string);
+          check int "no issues" 0
+            Yojson.Safe.Util.(item |> member "issues" |> to_list |> List.length))
+
 let test_keeper_persona_audit_flags_missing_persona_runtime () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -782,6 +841,9 @@ let () =
             `Quick test_keeper_list_exposes_last_social_transition_reason;
           test_case "keeper persona audit reports durable live keeper" `Quick
             test_keeper_persona_audit_reports_durable_live_persona_keeper;
+          test_case "keeper persona audit reports dormant autoboot-disabled keeper"
+            `Quick
+            test_keeper_persona_audit_reports_dormant_autoboot_disabled_keeper;
           test_case "keeper persona audit flags missing persona runtime" `Quick
             test_keeper_persona_audit_flags_missing_persona_runtime;
           test_case "keeper persona audit flags runtime meta parse error" `Quick

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -997,6 +997,58 @@ let test_update_entry_orphan_drop_emits_metrics () =
   check int "successful update applies"
     7 (R.get_last_agent_count ~base_path:bp name)
 
+let test_meta_write_sync_updates_registered_only () =
+  R.clear ();
+  let base_path =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "masc-test-meta-write-sync-%d-%06x"
+         (Unix.getpid ())
+         (Random.bits ()))
+  in
+  if Sys.file_exists base_path then rm_rf base_path;
+  Unix.mkdir base_path 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      R.clear ();
+      rm_rf base_path)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_path in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "registry-test"));
+      let dormant_name = "meta-sync-dormant" in
+      let labels = [ "name", dormant_name ] in
+      let dropped_before =
+        Masc_mcp.Prometheus.metric_value_or_zero
+          Masc_mcp.Keeper_metrics.metric_keeper_registry_update_dropped
+          ~labels ()
+      in
+      (match Keeper_types.write_meta ~force:true config (make_meta dormant_name) with
+       | Ok () -> ()
+       | Error err -> fail ("write_meta dormant failed: " ^ err));
+      let dropped_after =
+        Masc_mcp.Prometheus.metric_value_or_zero
+          Masc_mcp.Keeper_metrics.metric_keeper_registry_update_dropped
+          ~labels ()
+      in
+      check (float 0.001)
+        "durable meta write for dormant keeper does not count as orphan registry drop"
+        dropped_before
+        dropped_after;
+      let live_name = "meta-sync-live" in
+      let live_meta = make_meta live_name in
+      ignore (R.register ~base_path live_name live_meta);
+      let updated_meta = { live_meta with goal = "updated from disk write" } in
+      (match Keeper_types.write_meta ~force:true config updated_meta with
+       | Ok () -> ()
+       | Error err -> fail ("write_meta live failed: " ^ err));
+      match R.get ~base_path live_name with
+      | Some entry ->
+        check string "registered keeper meta synced"
+          "updated from disk write"
+          entry.meta.goal
+      | None -> fail "expected registered keeper entry")
+
 let test_find_by_agent_name () =
   R.clear ();
   let _entry = R.register ~base_path:bp "fn1" (make_meta "fn1") in
@@ -1649,6 +1701,8 @@ let () =
         [
           eio_test "update_entry orphan drops emit metrics + edge breach"
             test_update_entry_orphan_drop_emits_metrics;
+          eio_test "meta write sync skips dormant registry drops"
+            test_meta_write_sync_updates_registered_only;
         ] );
       ( "resolve_config",
         [

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -1049,6 +1049,39 @@ let test_meta_write_sync_updates_registered_only () =
           entry.meta.goal
       | None -> fail "expected registered keeper entry")
 
+let test_missing_turn_observation_updates_are_silent () =
+  R.clear ();
+  let name = "missing-turn-observation-test" in
+  let labels = [ "name", name ] in
+  let dropped_before =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Keeper_metrics.metric_keeper_registry_update_dropped
+      ~labels ()
+  in
+  R.mark_turn_started ~base_path:bp name;
+  R.mark_sdk_turn_started ~base_path:bp name;
+  R.mark_turn_measurement ~base_path:bp name;
+  R.set_turn_decision_stage
+    ~base_path:bp
+    name
+    R.Decision_active_tool_policy_selected;
+  R.set_turn_cascade_state ~base_path:bp name (R.Packed R.Cascade_selecting);
+  R.set_turn_phase ~base_path:bp name (R.Packed R.Turn_executing);
+  R.set_turn_selected_model ~base_path:bp name (Some "runtime");
+  R.prepare_turn_retry_after_compaction ~base_path:bp name;
+  R.mark_turn_finished ~base_path:bp name;
+  let dropped_after =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Keeper_metrics.metric_keeper_registry_update_dropped
+      ~labels ()
+  in
+  check
+    (float 0.001)
+    "missing turn-observation writes are documented no-ops, not orphan drops"
+    dropped_before
+    dropped_after
+;;
+
 let test_find_by_agent_name () =
   R.clear ();
   let _entry = R.register ~base_path:bp "fn1" (make_meta "fn1") in
@@ -1703,6 +1736,8 @@ let () =
             test_update_entry_orphan_drop_emits_metrics;
           eio_test "meta write sync skips dormant registry drops"
             test_meta_write_sync_updates_registered_only;
+          eio_test "missing turn observation updates are silent"
+            test_missing_turn_observation_updates_are_silent;
         ] );
       ( "resolve_config",
         [

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -570,6 +570,47 @@ target = "tier-group.primary"
     (Masc_mcp.Keeper_cascade_profile.fallback_cascade_for
        ~config_path:cascade_path "tier.primary")
 
+let test_keeper_runtime_declared_name_ignores_non_keeper_route_target () =
+  let cascade_toml =
+    {|
+[providers.ollama]
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+
+[models.qwen3]
+api-name = "qwen3:8b"
+max-context = 32768
+tools-support = true
+
+[ollama.qwen3]
+max-concurrent = 1
+
+[tier.coding_plan_primary]
+members = ["ollama.qwen3"]
+strategy = "failover"
+
+[tier.ollama_cloud_primary]
+members = ["ollama.qwen3"]
+strategy = "failover"
+keeper-assignable = true
+
+[tier-group.coding_plan]
+tiers = ["coding_plan_primary"]
+strategy = "failover"
+
+[routes.keeper_turn]
+target = "tier-group.coding_plan"
+
+[routes.provider_benchmark]
+target = "tier.ollama_cloud_primary"
+|}
+  in
+  with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
+  check string "non-keeper route target falls back to keeper_turn route"
+    "tier-group.coding_plan"
+    (Masc_mcp.Keeper_cascade_profile.normalize_keeper_runtime_declared_name
+       ~config_path:cascade_path "tier.ollama_cloud_primary")
+
 let test_catalog_validator_surfaces_adapter_errors () =
   let cascade_toml =
     {|
@@ -879,6 +920,8 @@ let () =
             test_keeper_assignability_uses_preferred_qualified_profile;
           test_case "fallback preserves qualified source profile" `Quick
             test_fallback_cascade_preserves_qualified_source_profile;
+          test_case "keeper runtime ignores non-keeper route target" `Quick
+            test_keeper_runtime_declared_name_ignores_non_keeper_route_target;
           test_case "surfaces declarative adapter errors" `Quick
             test_catalog_validator_surfaces_adapter_errors;
           test_case "surfaces declarative parse errors" `Quick

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -301,6 +301,27 @@ let test_partial_tolerance_still_works () =
     has_valid
 ;;
 
+let test_public_allowed_surface_accepts_canonical_alias () =
+  let observed = [ "Bash" ] in
+  let canonical = List.map Disclosure.canonical_tool_name observed in
+  let unexpected =
+    Disclosure.unexpected_tool_names
+      ~allowed_tool_names:[ "Bash" ]
+      ~tool_names:canonical
+  in
+  Alcotest.(check (list string))
+    "public Bash allowlist accepts canonical keeper_bash observation"
+    []
+    unexpected;
+  Alcotest.(check (list string))
+    "final names keep canonical internal name"
+    [ "keeper_bash" ]
+    (Disclosure.final_keeper_tool_names
+       ~reported_tool_names:observed
+       ~observed_tool_names:[]
+       ~allowed_tool_names:[ "Bash" ])
+;;
+
 (* ── Routing table and schemas ─────────────────────────────── *)
 
 let yojson_field name j =
@@ -724,6 +745,10 @@ let () =
             "partial tolerance still works"
             `Quick
             test_partial_tolerance_still_works
+        ; Alcotest.test_case
+            "public allowed surface accepts canonical alias"
+            `Quick
+            test_public_allowed_surface_accepts_canonical_alias
         ] )
     ; ( "routing-and-schemas"
       , [ Alcotest.test_case

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -230,6 +230,23 @@ let test_mcp_prefixed_keeper_internal_routes () =
     canonical
 ;;
 
+let test_mcp_prefixed_public_masc_goal_tool_routes () =
+  let canonical = Disclosure.canonical_tool_name "mcp__masc__masc_goal_list" in
+  Alcotest.(check string)
+    "mcp__masc__masc_goal_list canonicalises to masc_goal_list"
+    "masc_goal_list"
+    canonical;
+  let unexpected =
+    Disclosure.unexpected_tool_names
+      ~allowed_tool_names:[ "masc_goal_list"; "masc_goal_verify" ]
+      ~tool_names:[ canonical ]
+  in
+  Alcotest.(check (list string))
+    "public MASC goal allowlist accepts MCP-prefixed observation"
+    []
+    unexpected
+;;
+
 let test_mcp_prefixed_masc_public_telemetry_preserves_label () =
   (* PR #14585 review: a successful MCP-mapped route for a name like
      [mcp__masc__masc_board_post] must record [tool=masc_board_post],
@@ -733,6 +750,10 @@ let () =
             "mcp-prefixed keeper internal canonicalises to stripped"
             `Quick
             test_mcp_prefixed_keeper_internal_routes
+        ; Alcotest.test_case
+            "mcp-prefixed public MASC goal tool canonicalises to stripped"
+            `Quick
+            test_mcp_prefixed_public_masc_goal_tool_routes
         ; Alcotest.test_case
             "mcp-prefixed masc public name telemetry preserves label"
             `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -34,6 +34,8 @@ let phase_recovery_cascade_name () =
     Masc_mcp.Keeper_cascade_profile.Phase_recovery
 ;;
 
+let safe_lane_cascade_name = Masc_mcp.Cascade_capability_profile.safe_lane_cascade_name
+
 let has_prompt_root path =
   Sys.file_exists (Filename.concat path "config/prompts/keeper.unified.system.md")
 ;;
@@ -6266,8 +6268,8 @@ let test_next_fail_open_cascade_for_turn_returns_untried_default_cascade () =
       (wrapped_claude_limit_error ())
   in
   expect_degraded_retry
-    "next degraded retry"
-    (KC.default_cascade_name ())
+    "next degraded retry uses configured fallback"
+    safe_lane_cascade_name
     "hard_quota"
     degraded_retry
 ;;
@@ -6281,11 +6283,11 @@ let test_next_fail_open_cascade_for_turn_continues_to_local_recovery () =
       ~attempted_cascades:[ "scoring"; KC.default_cascade_name () ]
       (wrapped_claude_limit_error ())
   in
-  check
-    bool
-    "collapsed local_recovery is exhausted after default"
-    true
-    (Option.is_none degraded_retry)
+  expect_degraded_retry
+    "configured fallback remains after default"
+    safe_lane_cascade_name
+    "hard_quota"
+    degraded_retry
 ;;
 
 let test_next_fail_open_cascade_for_turn_suppresses_exhausted_rotation_group () =
@@ -6295,7 +6297,11 @@ let test_next_fail_open_cascade_for_turn_suppresses_exhausted_rotation_group () 
       ~effective_cascade:"scoring"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
       ~attempted_cascades:
-        [ "scoring"; KC.default_cascade_name (); KC.local_recovery_cascade_name ]
+        [ "scoring"
+        ; KC.default_cascade_name ()
+        ; KC.local_recovery_cascade_name
+        ; safe_lane_cascade_name
+        ]
       (wrapped_claude_limit_error ())
   in
   check bool "exhausted rotation group suppressed" true (Option.is_none degraded_retry)
@@ -6361,7 +6367,11 @@ let test_next_fail_open_cascade_for_turn_uses_catalog_rotation_profile () =
         [ "scoring"; KC.default_cascade_name (); KC.local_recovery_cascade_name ]
       (wrapped_claude_limit_error ())
   in
-  expect_degraded_retry "catalog degraded retry" "ollama_only" "hard_quota" degraded_retry
+  expect_degraded_retry
+    "catalog degraded retry uses configured fallback first"
+    safe_lane_cascade_name
+    "hard_quota"
+    degraded_retry
 ;;
 
 let test_next_fail_open_cascade_for_turn_does_not_inject_default_when_catalog_omits_it () =
@@ -6375,8 +6385,8 @@ let test_next_fail_open_cascade_for_turn_does_not_inject_default_when_catalog_om
       (wrapped_claude_limit_error ())
   in
   expect_degraded_retry
-    "catalog-only degraded retry"
-    "resilient_profile"
+    "catalog-only degraded retry uses configured fallback first"
+    safe_lane_cascade_name
     "hard_quota"
     degraded_retry
 ;;
@@ -8516,6 +8526,45 @@ let test_normalize_response_text_empty_without_tools_errors () =
          | Not_found -> false
        in
        found)
+;;
+
+let response ?(stop_reason = Agent_sdk.Types.EndTurn) content =
+  { Agent_sdk.Types.id = "response-test"
+  ; model = "test-model"
+  ; stop_reason
+  ; content
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let test_response_has_text_or_tool_progress_rejects_empty_end_turn () =
+  check
+    bool
+    "empty end_turn rejected"
+    false
+    (KTD.response_has_text_or_tool_progress (response []))
+;;
+
+let test_response_has_text_or_tool_progress_accepts_text () =
+  check
+    bool
+    "text accepted"
+    true
+    (KTD.response_has_text_or_tool_progress
+       (response [ Agent_sdk.Types.Text "ok" ]))
+;;
+
+let test_response_has_text_or_tool_progress_accepts_tool_use () =
+  check
+    bool
+    "tool use accepted"
+    true
+    (KTD.response_has_text_or_tool_progress
+       (response
+          [ Agent_sdk.Types.ToolUse
+              { id = "call-1"; name = "keeper_bash"; input = `Assoc [] }
+          ]))
 ;;
 
 let test_validate_completion_contract_allows_text_without_tools () =
@@ -11380,6 +11429,18 @@ let () =
             "normalize empty without tools errors"
             `Quick
             test_normalize_response_text_empty_without_tools_errors
+        ; test_case
+            "response progress rejects empty end turn"
+            `Quick
+            test_response_has_text_or_tool_progress_rejects_empty_end_turn
+        ; test_case
+            "response progress accepts text"
+            `Quick
+            test_response_has_text_or_tool_progress_accepts_text
+        ; test_case
+            "response progress accepts tool use"
+            `Quick
+            test_response_has_text_or_tool_progress_accepts_tool_use
         ; test_case
             "completion contract allows text without tools"
             `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -10438,12 +10438,12 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
       ~allowed_tool_names
   in
   (match choose () with
-   | Agent_sdk.Types.Tool name ->
-     check string "forces claim tool first" "keeper_task_claim" name
+   | Agent_sdk.Types.Any -> ()
    | other ->
      fail
        (Printf.sprintf
-          "expected Tool keeper_task_claim, got %s"
+          "expected Any for claim turn to avoid raw require_specific_tool \
+           MCP-prefix mismatches, got %s"
           (Agent_sdk.Types.show_tool_choice other)));
   (match choose ~has_current_task:true () with
    | Agent_sdk.Types.Any -> ()

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6537,6 +6537,7 @@ let test_fail_open_rotation_cascades_from_catalog_merges_reserved_and_assignable
       ~catalog_names:
         [ KC.default_cascade_name (); KC.local_recovery_cascade_name; "ollama_only" ]
       ~keeper_assignable:[ KC.default_cascade_name (); "ollama_only" ]
+      ()
   in
   check
     (option (list string))
@@ -6551,6 +6552,7 @@ let test_fail_open_rotation_cascades_from_catalog_preserves_catalog_order () =
       ~catalog_names:
         [ "ollama_only"; KC.local_recovery_cascade_name; KC.default_cascade_name () ]
       ~keeper_assignable:[ KC.default_cascade_name (); "ollama_only" ]
+      ()
   in
   check
     (option (list string))
@@ -6559,11 +6561,37 @@ let test_fail_open_rotation_cascades_from_catalog_preserves_catalog_order () =
     rotation
 ;;
 
+let test_fail_open_rotation_cascades_from_catalog_excludes_non_keeper_routes () =
+  let rotation =
+    UT.fail_open_rotation_cascades_from_catalog
+      ~excluded_targets:[ "tier.ollama_cloud_primary" ]
+      ~catalog_names:
+        [
+          KC.default_cascade_name ();
+          "ollama_cloud_primary";
+          "coding_plan";
+        ]
+      ~keeper_assignable:
+        [
+          KC.default_cascade_name ();
+          "ollama_cloud_primary";
+          "coding_plan";
+        ]
+      ()
+  in
+  check
+    (option (list string))
+    "catalog-derived rotation excludes non-keeper route targets"
+    (Some [ KC.default_cascade_name (); "coding_plan" ])
+    rotation
+;;
+
 let test_fail_open_rotation_cascades_from_catalog_empty_when_unresolved () =
   let rotation =
     UT.fail_open_rotation_cascades_from_catalog
       ~catalog_names:[]
       ~keeper_assignable:[ KC.default_cascade_name () ]
+      ()
   in
   check
     (option (list string))
@@ -6577,6 +6605,7 @@ let test_fail_open_rotation_cascades_from_catalog_empty_without_assignable_candi
     UT.fail_open_rotation_cascades_from_catalog
       ~catalog_names:[ "experimental_only" ]
       ~keeper_assignable:[]
+      ()
   in
   check
     (option (list string))
@@ -12216,6 +12245,10 @@ let () =
             "catalog rotation preserves catalog order"
             `Quick
             test_fail_open_rotation_cascades_from_catalog_preserves_catalog_order
+        ; test_case
+            "catalog rotation excludes non-keeper route targets"
+            `Quick
+            test_fail_open_rotation_cascades_from_catalog_excludes_non_keeper_routes
         ; test_case
             "unresolved catalog keeps legacy rotation fallback"
             `Quick

--- a/test/test_task_sandbox.ml
+++ b/test/test_task_sandbox.ml
@@ -403,6 +403,9 @@ let test_create_infers_repo_from_task_file_evidence () =
         | Ok sb ->
             check bool "picked masc-mcp repo" true
               (contains "/repos/masc-mcp/.worktrees/" sb.worktree_path);
+            check bool "linked .masc in nested repo worktree" true
+              (Sys.file_exists
+                 (Filename.concat sb.worktree_path Common.masc_dirname));
             let persisted =
               Coord.read_backlog config
               |> fun backlog ->


### PR DESCRIPTION
## Summary

- classify keeper/OAS provider failures that surface as internal receipt errors, including unterminated JSON parse failures and required-tool contract violations
- prevent stale runtime metadata and non-keeper route targets from steering keeper turns into provider-benchmark cascades such as `tier.ollama_cloud_primary`
- keep degraded retry rotation on keeper-owned cascades, and filter discovered/reranked tools back to the visible keeper policy surface
- improve receipt/runtime labels so operators can distinguish provider quota/runtime failures from tool-contract or policy-surface failures

## Root Cause

The live failure mixed several issues: stale model/cascade hints could survive into keeper runtime dispatch, fail-open rotation could include a non-keeper route target from the cascade catalog, and tool discovery could report tools outside the visible keeper surface. Those made unrelated failures look like generic `cascade_exhausted` receipts and allowed the Ollama Cloud parse error path to appear in keeper turns.

## Operator Impact

Keepers should now stay on keeper-route cascades for degraded retries. Old `tier.ollama_cloud_primary` declarations that are only reachable through non-keeper routes no longer hijack keeper runtime dispatch, and policy-surface leaks such as disallowed board tools are pruned before they become reported keeper tools.

## Validation

- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build bin/main_eio.exe test/test_keeper_unified.exe test/test_keeper_benchmark_canary.exe test/test_keeper_llama_only.exe test/test_governance_pipeline.exe test/test_keeper_registry.exe test/test_keeper_tool_alias.exe test/test_keeper_pause_broadcast.exe test/test_keeper_toml_config_validation.exe test/test_keeper_hooks_oas_telemetry.exe test/test_keeper_meta_listing.exe test/test_task_sandbox.exe`
- `./_build/default/test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_benchmark_canary.exe`
- `./_build/default/test/test_keeper_llama_only.exe`
- `./_build/default/test/test_governance_pipeline.exe`
- `./_build/default/test/test_keeper_registry.exe`
- `./_build/default/test/test_keeper_tool_alias.exe`
- `./_build/default/test/test_keeper_pause_broadcast.exe`
- `./_build/default/test/test_keeper_toml_config_validation.exe`
- `./_build/default/test/test_keeper_hooks_oas_telemetry.exe`
- `./_build/default/test/test_keeper_meta_listing.exe`
- `./_build/default/test/test_task_sandbox.exe`

## Notes

A separate live runtime check before this PR branch rebuild showed `imseonghan` still present and running; remaining live broadcasts were attributable to external Claude quota/hard-quota failures rather than the Ollama JSON parse or keeper policy-surface leak classes.