### PR TITLE
fix(keeper): silence startup false-positive diagnostics

### DIFF
--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import type { LogEntry } from '../api/dashboard'
+import { logDiagnosticCause, summarizeLogWindow } from './logs'
+
+function entry(overrides: Partial<LogEntry>): LogEntry {
+  return {
+    seq: 1,
+    ts: '2026-05-14T00:00:00Z',
+    level: 'INFO',
+    raw_level: 'INFO',
+    normalized_level: 'INFO',
+    source: 'structured',
+    legacy_classified: false,
+    module: 'Keeper',
+    message: 'ok',
+    details: null,
+    ...overrides,
+  }
+}
+
+describe('log diagnostics', () => {
+  it('classifies timeout and cascade messages without structured envelopes', () => {
+    expect(
+      logDiagnosticCause(
+        entry({
+          level: 'WARN',
+          normalized_level: 'WARN',
+          message:
+            'keeper_llm_bridge: OAS execution timed out after 300.0s (budget=300s)',
+        }),
+      ),
+    ).toBe('oas_timeout_budget')
+
+    expect(
+      logDiagnosticCause(
+        entry({
+          level: 'ERROR',
+          normalized_level: 'ERROR',
+          message:
+            'all cascades exhausted: Cascade attempt liveness guard killed runtime lane coding_plan: inter_chunk_idle',
+        }),
+      ),
+    ).toBe('inter_chunk_idle')
+  })
+
+  it('prefers failure envelope cause codes and summarizes the current window', () => {
+    const entries = [
+      entry({
+        seq: 3,
+        level: 'ERROR',
+        normalized_level: 'ERROR',
+        module: 'Keeper',
+        message: 'keeper_llm_bridge timeout',
+        details: {
+          failure_envelope: {
+            surface: 'keeper_oas_bridge',
+            entity_kind: 'oas_execution',
+            entity_id: null,
+            cause_code: 'oas_timeout_budget',
+            severity: 'bad',
+            summary: 'OAS execution exceeded budget',
+            recoverability: 'operator_action_required',
+            operator_action: 'inspect_timeout_budget',
+            evidence_ref: { timeout_sec: 300 },
+          },
+        },
+      }),
+      entry({
+        seq: 2,
+        level: 'WARN',
+        normalized_level: 'WARN',
+        module: 'Task',
+        message: 'Ignoring legacy verification directory /tmp/verifications',
+      }),
+      entry({
+        seq: 1,
+        level: 'INFO',
+        normalized_level: 'INFO',
+        module: 'Keeper',
+        message: 'normal',
+      }),
+    ]
+
+    const summary = summarizeLogWindow(entries)
+    expect(summary.errors).toBe(1)
+    expect(summary.warnings).toBe(1)
+    expect(summary.failureEnvelopes).toBe(1)
+    expect(summary.topCauses).toContainEqual({ cause: 'oas_timeout_budget', count: 1 })
+    expect(summary.topCauses).toContainEqual({
+      cause: 'legacy_verification_dir',
+      count: 1,
+    })
+    expect(summary.topModules[0]).toEqual({ module: 'Keeper', count: 2 })
+  })
+})

--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -43,6 +43,30 @@ describe('log diagnostics', () => {
     ).toBe('inter_chunk_idle')
   })
 
+  it('classifies keeper telemetry and registry noise causes', () => {
+    expect(
+      logDiagnosticCause(
+        entry({
+          level: 'INFO',
+          normalized_level: 'INFO',
+          message:
+            'keeper:analyst after_turn usage telemetry unavailable runtime_lane=runtime reasons=zero_token_usage_reported input=0 output=0 context_max=200000',
+        }),
+      ),
+    ).toBe('usage_zero_tokens')
+
+    expect(
+      logDiagnosticCause(
+        entry({
+          level: 'WARN',
+          normalized_level: 'WARN',
+          message:
+            'registry: orphan threshold breached name=analyst base_path=/Users/dancer/me drops=5 window=60s',
+        }),
+      ),
+    ).toBe('registry_orphan_threshold')
+  })
+
   it('prefers failure envelope cause codes and summarizes the current window', () => {
     const entries = [
       entry({

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -203,6 +203,11 @@ function classifyMessageCause(message: string): string | null {
   }
   if (lower.includes('semaphore wait')) return 'queue_wait_timeout'
   if (lower.includes('legacy verification directory')) return 'legacy_verification_dir'
+  if (lower.includes('zero_token_usage_reported')) return 'usage_zero_tokens'
+  if (lower.includes('usage telemetry untrusted')) return 'usage_telemetry_untrusted'
+  if (lower.includes('usage telemetry unavailable')) return 'usage_telemetry_unavailable'
+  if (lower.includes('orphan threshold breached')) return 'registry_orphan_threshold'
+  if (lower.includes('entry not found, update dropped')) return 'registry_orphan_update'
   if (lower.includes('archived credential')) return 'credential_archive'
   if (lower.includes('retired pg runtime env')) return 'retired_pg_env'
   if (lower.includes('rate limited') || lower.includes('temporarily limiting requests')) {

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -16,6 +16,24 @@ interface LogData {
   total: number
 }
 
+export interface LogCauseCount {
+  cause: string
+  count: number
+}
+
+export interface LogModuleCount {
+  module: string
+  count: number
+}
+
+export interface LogWindowSummary {
+  errors: number
+  warnings: number
+  failureEnvelopes: number
+  topCauses: LogCauseCount[]
+  topModules: LogModuleCount[]
+}
+
 const logResource = createAsyncResource<LogData>()
 const levelFilter = signal('INFO')
 const moduleInput = signal('')
@@ -169,6 +187,80 @@ function failureEnvelope(entry: LogEntry): FailureEnvelope | null {
   }
 }
 
+function classifyMessageCause(message: string): string | null {
+  const lower = message.toLowerCase()
+  if (lower.includes('oas_timeout_budget') || lower.includes('oas execution timed out')) {
+    return 'oas_timeout_budget'
+  }
+  if (lower.includes('inter_chunk_idle')) return 'inter_chunk_idle'
+  if (lower.includes('no_first_token')) return 'no_first_token'
+  if (lower.includes('cascade_exhausted') || lower.includes('all cascades exhausted')) {
+    return 'cascade_exhausted'
+  }
+  if (lower.includes('stale watchdog')) return 'stale_watchdog'
+  if (lower.includes('required tool contract') || lower.includes('tool_required_unsatisfied')) {
+    return 'tool_required_unsatisfied'
+  }
+  if (lower.includes('semaphore wait')) return 'queue_wait_timeout'
+  if (lower.includes('legacy verification directory')) return 'legacy_verification_dir'
+  if (lower.includes('archived credential')) return 'credential_archive'
+  if (lower.includes('retired pg runtime env')) return 'retired_pg_env'
+  if (lower.includes('rate limited') || lower.includes('temporarily limiting requests')) {
+    return 'provider_rate_limit'
+  }
+  if (lower.includes('invalid request')) return 'provider_invalid_request'
+  return null
+}
+
+export function logDiagnosticCause(entry: LogEntry): string | null {
+  const failure = failureEnvelope(entry)
+  if (failure) return failure.cause_code
+  const details = entryDetails(entry)
+  const event = detailLabel(details, 'event')
+  if (event) return event
+  return classifyMessageCause(entry.message)
+}
+
+function topCounts(map: Map<string, number>, limit = 3): LogCauseCount[] {
+  return [...map.entries()]
+    .map(([cause, count]) => ({ cause, count }))
+    .sort((a, b) => b.count - a.count || a.cause.localeCompare(b.cause))
+    .slice(0, limit)
+}
+
+export function summarizeLogWindow(entries: LogEntry[]): LogWindowSummary {
+  const causes = new Map<string, number>()
+  const modules = new Map<string, number>()
+  let errors = 0
+  let warnings = 0
+  let failureEnvelopes = 0
+
+  for (const entry of entries) {
+    const level = normalizedLevel(entry)
+    if (level === 'ERROR') errors += 1
+    if (level === 'WARN') warnings += 1
+
+    const mod = entry.module?.trim() || '(root)'
+    modules.set(mod, (modules.get(mod) ?? 0) + 1)
+
+    const failure = failureEnvelope(entry)
+    if (failure) failureEnvelopes += 1
+    const cause = failure?.cause_code ?? logDiagnosticCause(entry)
+    if (cause) causes.set(cause, (causes.get(cause) ?? 0) + 1)
+  }
+
+  return {
+    errors,
+    warnings,
+    failureEnvelopes,
+    topCauses: topCounts(causes),
+    topModules: topCounts(modules).map(({ cause, count }) => ({
+      module: cause,
+      count,
+    })),
+  }
+}
+
 function renderLogMessage(entry: LogEntry): string {
   const details = entryDetails(entry)
   const message = interpolateStructuredMessage(entry.message, details)
@@ -239,7 +331,9 @@ function renderLogRow(entry: LogEntry) {
   const requestId = detailLabel(details, 'request_id')
   const sessionId = detailLabel(details, 'session_id')
   const fixes = detailLabel(details, 'fixes')
+  const event = detailLabel(details, 'event')
   const failure = failureEnvelope(entry)
+  const diagnosticCause = failure?.cause_code ?? logDiagnosticCause(entry)
   const sourceClass = sourceTone(source)
   const renderedMessage = renderLogMessage(entry)
   let backgroundClass = 'bg-[var(--color-bg-surface)]'
@@ -283,6 +377,9 @@ function renderLogRow(entry: LogEntry) {
         ${phase
           ? html`<${MetaTag}>${phase}</${MetaTag}>`
           : null}
+        ${event
+          ? html`<${MetaTag}>event ${event}</${MetaTag}>`
+          : null}
         ${requestId
           ? html`<${MetaTag}>req ${requestId}</${MetaTag}>`
           : null}
@@ -291,6 +388,11 @@ function renderLogRow(entry: LogEntry) {
           : null}
         ${failure
           ? html`<${StatusChip} tone="bad" uppercase=${false}>${failure.cause_code}</${StatusChip}>`
+          : diagnosticCause
+            ? html`<${StatusChip} tone=${level === 'ERROR' ? 'bad' : 'warn'} uppercase=${false}>${diagnosticCause}</${StatusChip}>`
+            : null}
+        ${failure
+          ? html`<${StatusChip} tone="info" uppercase=${false}>${failure.surface}</${StatusChip}>`
           : null}
         ${failure
           ? html`<${MetaTag}>${failure.recoverability}</${MetaTag}>`
@@ -311,6 +413,27 @@ function renderLogRow(entry: LogEntry) {
       >
         ${renderedMessage}
       </div>
+    </div>
+  `
+}
+
+function renderSummaryChip(label: string, value: string | number, tone = 'neutral') {
+  return html`
+    <${StatusChip} tone=${tone} uppercase=${false}>
+      <span>${label}</span>
+      <span class="font-mono tabular-nums">${value}</span>
+    </${StatusChip}>
+  `
+}
+
+function renderLogSummary(summary: LogWindowSummary) {
+  return html`
+    <div class="mx-3 mt-3 flex flex-wrap items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2 text-2xs">
+      ${renderSummaryChip('ERROR', summary.errors, summary.errors > 0 ? 'bad' : 'neutral')}
+      ${renderSummaryChip('WARN', summary.warnings, summary.warnings > 0 ? 'warn' : 'neutral')}
+      ${renderSummaryChip('failure envelope', summary.failureEnvelopes, summary.failureEnvelopes > 0 ? 'info' : 'neutral')}
+      ${summary.topModules.map(item => renderSummaryChip(`module ${item.module}`, item.count))}
+      ${summary.topCauses.map(item => renderSummaryChip(`cause ${item.cause}`, item.count, 'info'))}
     </div>
   `
 }
@@ -364,6 +487,7 @@ export function LogViewer() {
   const logTotal = logData?.total ?? 0
   const logLoading = s.status === 'loading'
   const logError = s.status === 'error' ? s.message : null
+  const summary = summarizeLogWindow(logEntries)
 
   return html`
     <div class="logs-viewer flex h-full min-h-0 flex-col gap-4">
@@ -445,6 +569,8 @@ export function LogViewer() {
         ${logError ? html`
           <div class="mx-4 mt-4 rounded-[var(--r-1)] border border-solid border-[var(--err-border)] bg-[var(--brick-soft)] px-4 py-3 text-xs text-[var(--err-fg)]">${logError}</div>
         ` : null}
+
+        ${renderLogSummary(summary)}
 
         <div class="px-3 pt-3">
           <div class="grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 px-3 py-2 text-left text-3xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)]">

--- a/lib/cascade/cascade_declarative_adapter.ml
+++ b/lib/cascade/cascade_declarative_adapter.ml
@@ -122,15 +122,23 @@ let provider_kind_for_http_provider ?registry_entry (provider : cascade_provider
   | Chat_completions_api ->
     Some
       (match registry_entry with
-       | Some entry -> entry.Llm_provider.Provider_registry.defaults.kind
+       | Some entry ->
+         let kind = entry.Llm_provider.Provider_registry.defaults.kind in
+         if kind = Llm_provider.Provider_config.Ollama
+         then Llm_provider.Provider_config.OpenAI_compat
+         else kind
        | None -> Llm_provider.Provider_config.OpenAI_compat)
   | Messages_api -> None
 
-let request_path_for_http_provider ~registry_entry ~kind ~base_url =
+let request_path_for_http_provider ~provider ~registry_entry ~kind ~base_url =
   let request_path =
-    match registry_entry with
-    | Some entry -> entry.Llm_provider.Provider_registry.defaults.request_path
-    | None -> Llm_provider.Provider_config.request_path_default_for_kind kind
+    match provider.api_format, kind with
+    | Chat_completions_api, Llm_provider.Provider_config.OpenAI_compat ->
+      Llm_provider.Provider_config.request_path_default_for_kind kind
+    | _ ->
+      (match registry_entry with
+       | Some entry -> entry.Llm_provider.Provider_registry.defaults.request_path
+       | None -> Llm_provider.Provider_config.request_path_default_for_kind kind)
   in
   match kind with
   | Llm_provider.Provider_config.OpenAI_compat ->
@@ -156,7 +164,9 @@ let provider_config_from_declared_provider
   | Http base_url ->
     (match provider_kind_for_http_provider ?registry_entry provider with
      | Some kind ->
-       let request_path = request_path_for_http_provider ~registry_entry ~kind ~base_url in
+       let request_path =
+         request_path_for_http_provider ~provider ~registry_entry ~kind ~base_url
+       in
        let api_key = api_key_of_credential ?registry_entry provider.credentials in
        let headers = Cascade_config.headers_with_auth ~kind ~api_key in
        Some

--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -33,6 +33,10 @@ let is_local_label label =
   | Some pname -> Provider_adapter.is_local_provider pname
   | None -> false
 
+let is_typed_declarative_label_provider = function
+  | "openai_compat" -> true
+  | _ -> false
+
 let cascade_name_to_string = Keeper_cascade_profile.runtime_name_to_string
 
 let default_model_strings ~cascade_name =
@@ -303,7 +307,9 @@ let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
           match provider_name_of_label label with
           | None -> true
           | Some pname ->
-              if Provider_adapter.is_local_provider pname then true
+              if Provider_adapter.is_local_provider pname
+                 || is_typed_declarative_label_provider pname
+              then true
               else
                 match Llm_provider.Provider_registry.find default_registry pname with
                 | None -> false
@@ -318,7 +324,9 @@ let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
             match provider_name_of_label label with
             | None -> None
             | Some pname ->
-                if Provider_adapter.is_local_provider pname then None
+                if Provider_adapter.is_local_provider pname
+                   || is_typed_declarative_label_provider pname
+                then None
                 else
                   match Llm_provider.Provider_registry.find default_registry pname with
                   | None -> Some (Printf.sprintf "%s (unknown provider)" pname)

--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -30,9 +30,13 @@ let http_probe_url_of_config (cfg : Llm_provider.Provider_config.t) =
   else None
 
 let of_provider_config provider_cfg =
+  let health_key = Provider_adapter.provider_health_key_of_config provider_cfg in
+  let model_health_key =
+    Provider_adapter.provider_model_health_key_of_config provider_cfg
+  in
   { provider_cfg
-  ; health_key = "runtime"
-  ; model_health_key = "runtime"
+  ; health_key
+  ; model_health_key
   ; capacity_key = capacity_key_of_config provider_cfg
   ; http_probe_url = http_probe_url_of_config provider_cfg
   }
@@ -173,8 +177,15 @@ let health_keys candidate =
     [ candidate.health_key; candidate.model_health_key ]
 
 let first_health_cooldown candidate =
-  let _ = candidate in
-  None
+  health_keys candidate
+  |> List.find_map (fun provider_key ->
+    match
+      Cascade_health_tracker.check_circuit_breaker
+        Cascade_health_tracker.global
+        ~provider_key
+    with
+    | Ok () -> None
+    | Error msg -> Some (provider_key, msg))
 
 let has_recovery_evidence candidate =
   let _ = candidate in

--- a/lib/coord/coord_verification_store.ml
+++ b/lib/coord/coord_verification_store.ml
@@ -37,6 +37,10 @@ let dir_exists path =
   try Sys.file_exists path && Sys.is_directory path with
   | Sys_error _ -> false
 
+let dir_entry_count path =
+  try Sys.readdir path |> Array.length with
+  | Sys_error _ -> 0
+
 let warn_if_legacy_verifications_dir_present ~base_path ~active_dir =
   let legacy_dir = legacy_verifications_dir base_path in
   if dir_exists legacy_dir then (
@@ -46,9 +50,20 @@ let warn_if_legacy_verifications_dir_present ~base_path ~active_dir =
       (fun () ->
         if not (Hashtbl.mem warned_legacy_dirs legacy_dir) then (
           Hashtbl.add warned_legacy_dirs legacy_dir ();
-          Log.Task.warn
-            "Ignoring legacy verification directory %s; active store is %s"
-            legacy_dir active_dir)))
+          let entry_count = dir_entry_count legacy_dir in
+          Log.Task.emit Log.Info
+            ~details:
+              (`Assoc
+                [
+                  ("event", `String "legacy_verification_dir_ignored");
+                  ("legacy_dir", `String legacy_dir);
+                  ("active_dir", `String active_dir);
+                  ("legacy_entry_count", `Int entry_count);
+                ])
+            (Printf.sprintf
+               "Ignoring legacy verification directory %s; active store is %s \
+                (legacy_entries=%d)"
+               legacy_dir active_dir entry_count))))
 
 let verifications_dir base_path =
   let dir = active_verifications_dir base_path in

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -270,7 +270,7 @@ let catalog_metadata_of_materialized_json json =
       if profile_is_keeper_assignable assignable then None else Some name)
     |> List.sort_uniq String.compare
   in
-  let keeper_assignable_names =
+  let keeper_assignable_public_names =
     public_names
     |> List.filter (fun public_name ->
       let qualified_name =
@@ -280,9 +280,18 @@ let catalog_metadata_of_materialized_json json =
       | Some assignable -> profile_is_keeper_assignable assignable
       | None -> true)
   in
+  let keeper_assignable_qualified_names =
+    profile_assignability
+    |> List.filter_map (fun (name, assignable) ->
+      if profile_is_keeper_assignable assignable then Some name else None)
+  in
+  let keeper_assignable_names =
+    keeper_assignable_public_names @ keeper_assignable_qualified_names
+    |> List.sort_uniq String.compare
+  in
   let system_names =
     public_names
-    |> List.filter (fun name -> not (List.mem name keeper_assignable_names))
+    |> List.filter (fun name -> not (List.mem name keeper_assignable_public_names))
   in
   let fallback_hints =
     tier_group_fields
@@ -439,6 +448,11 @@ let route_target_public_name ?config_path use =
 let normalize_keeper_runtime_declared_name ?config_path raw =
   let normalized = normalize_declared_name raw in
   let public_name = public_name_of_target normalized in
+  let explicitly_keeper_assignable =
+    match catalog_metadata_result ?config_path () with
+    | Ok meta -> List.mem normalized meta.keeper_assignable_names
+    | Error _ -> false
+  in
   let keeper_route_targets =
     keeper_runtime_route_uses
     |> List.filter_map (route_target_public_name ?config_path)
@@ -450,7 +464,8 @@ let normalize_keeper_runtime_declared_name ?config_path raw =
     |> List.filter_map (route_target_public_name ?config_path)
     |> List.sort_uniq String.compare
   in
-  if List.mem public_name non_keeper_route_targets
+  if (not explicitly_keeper_assignable)
+     && List.mem public_name non_keeper_route_targets
      && not (List.mem public_name keeper_route_targets)
   then cascade_name_for_use ?config_path Keeper_turn
   else normalized

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -1486,15 +1486,7 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
     |> Option.map (fun checkpoint ->
       let sanitized, stats = sanitize_oas_checkpoint checkpoint in
       if checkpoint_sanitize_changed stats then begin
-        let has_data_loss =
-          stats.dropped_blocks > 0
-          || stats.dropped_messages > 0
-          || stats.dropped_chars > 0
-        in
-        (if has_data_loss then
-           Log.Keeper.warn
-         else
-           Log.Keeper.debug)
+        Log.Keeper.info
           "keeper:%s checkpoint migration sanitized messages: dropped_blocks=%d dropped_messages=%d dropped_chars=%d truncated_blocks=%d truncated_chars=%d"
           trace_id
           stats.dropped_blocks

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -1086,7 +1086,7 @@ let parse_json_candidate ~surface candidate =
     ~context:("Keeper_hooks_oas." ^ surface ^ ".output.embedded")
     candidate
 
-let output_json_opt ~surface output_text =
+let output_json_opt ?(observe_failure = true) ~surface output_text =
   match
     Safe_ops.parse_json_safe
       ~context:("Keeper_hooks_oas." ^ surface ^ ".output")
@@ -1107,8 +1107,9 @@ let output_json_opt ~surface output_text =
        with
        | Some json -> Some json
        | None ->
-           observe_output_parse_failure ~surface
-             ~output_bytes:(String.length output_text);
+           if observe_failure then
+             observe_output_parse_failure ~surface
+               ~output_bytes:(String.length output_text);
            None)
 
 let normalized_route_via raw =
@@ -1531,7 +1532,15 @@ let pr_work_action_metric_events_of_tool_io
     ~(transport_success : bool) =
   if not (is_pr_work_action_tool_name tool_name) then []
   else
-  let output_json = output_json_opt ~surface:"pr_work_action" output_text in
+  let observe_json_failure =
+    match tool_name with
+    | "keeper_shell" | "keeper_bash" | "masc_code_shell" -> false
+    | _ -> true
+  in
+  let output_json =
+    output_json_opt ~observe_failure:observe_json_failure
+      ~surface:"pr_work_action" output_text
+  in
   let route_via =
     first_some (Option.bind output_json route_via_of_json)
       route_via_fallback

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -366,6 +366,11 @@ let record_usage_anomaly_metrics ~keeper_name ~model usage_trust =
            ())
       reasons
 
+let usage_untrusted_warns_operator = function
+  | Keeper_usage_trust.Usage_untrusted ["zero_token_usage_reported"] -> false
+  | Keeper_usage_trust.Usage_missing | Keeper_usage_trust.Usage_trusted -> false
+  | Keeper_usage_trust.Usage_untrusted _ -> true
+
 type cost_status =
   | Cost_reported
   | Cost_known_free
@@ -1883,16 +1888,26 @@ let make_hooks
             | Some _ | None -> 0.0
         in
         let total_tok = input_tok + output_tok in
-        if (not usage_missing) && not usage_trusted then
-          Log.Keeper.warn
-            "keeper:%s after_turn usage telemetry untrusted runtime_lane=%s reasons=%s input=%d output=%d context_max=%d"
-            meta.name runtime_lane_label
-            (String.concat ","
-               (match Keeper_usage_trust.reasons usage_trust with
-                | [] -> [Keeper_usage_trust.to_string usage_trust]
-                | reasons -> reasons))
-            raw_input_tok raw_output_tok
-            (context_max_of_telemetry response.telemetry);
+        if (not usage_missing) && not usage_trusted then (
+          let reasons =
+            match Keeper_usage_trust.reasons usage_trust with
+            | [] -> [Keeper_usage_trust.to_string usage_trust]
+            | reasons -> reasons
+          in
+          if usage_untrusted_warns_operator usage_trust then
+            Log.Keeper.warn
+              "keeper:%s after_turn usage telemetry untrusted runtime_lane=%s reasons=%s input=%d output=%d context_max=%d"
+              meta.name runtime_lane_label
+              (String.concat "," reasons)
+              raw_input_tok raw_output_tok
+              (context_max_of_telemetry response.telemetry)
+          else
+            Log.Keeper.info
+              "keeper:%s after_turn usage telemetry unavailable runtime_lane=%s reasons=%s input=%d output=%d context_max=%d"
+              meta.name runtime_lane_label
+              (String.concat "," reasons)
+              raw_input_tok raw_output_tok
+              (context_max_of_telemetry response.telemetry));
         (* Cache-token tracking uses OAS-reported counters only. *)
         (match response.usage with
          | Some u when usage_trusted ->

--- a/lib/keeper/keeper_llm_bridge.ml
+++ b/lib/keeper/keeper_llm_bridge.ml
@@ -2,6 +2,38 @@
 (* OAS Adapter bridging Eio structured concurrency, multi-turn cascade rollbacks,
    and strict global stop preemptions as formally verified in KeeperOASAdvanced.tla. *)
 
+let json_field name value = Some (name, value)
+let json_string_field name value = json_field name (`String value)
+let json_float_field name value = json_field name (`Float value)
+
+let bridge_failure_envelope
+    ?entity_id
+    ?operator_action
+    ~cause_code
+    ~severity
+    ~summary
+    ~recoverability
+    ~evidence_ref
+    ()
+  : Failure_envelope.t =
+  {
+    surface = "keeper_oas_bridge";
+    entity_kind = "oas_execution";
+    entity_id;
+    cause_code;
+    severity;
+    summary;
+    recoverability;
+    operator_action;
+    evidence_ref;
+  }
+;;
+
+let bridge_details fields envelope =
+  let fields = List.filter_map Fun.id fields in
+  Failure_envelope.attach_to_details (`Assoc fields) envelope
+;;
+
 (** Runs a generic Eio execution (usually an OAS Agent.run or Model.call) with a strict
     structural timeout. If the execution is cancelled by a timeout or global stop,
     the exception is caught, OAS-local context mutations are discarded
@@ -26,7 +58,33 @@ let run_with_timeout_and_fallback ~timeout_s fn =
       Keeper_metrics.metric_keeper_llm_bridge_failures
       ~labels:[ "site", "no_clock" ]
       ();
-    Log.Keeper.error "%s" message;
+    let envelope =
+      bridge_failure_envelope
+        ~cause_code:"eio_clock_unavailable"
+        ~severity:Failure_envelope.Critical
+        ~summary:message
+        ~recoverability:Failure_envelope.Operator_action_required
+        ~operator_action:"check_masc_eio_env"
+        ~evidence_ref:
+          (`Assoc
+            [
+              ("site", `String site);
+              ("timeout_sec", `Float timeout_s);
+              ("timeout_enforced", `Bool false);
+            ])
+        ()
+    in
+    Log.Keeper.emit Log.Error
+      ~details:
+        (bridge_details
+           [
+             json_string_field "event" "keeper_oas_bridge_no_clock";
+             json_string_field "site" site;
+             json_float_field "timeout_sec" timeout_s;
+             json_field "timeout_enforced" (`Bool false);
+           ]
+           envelope)
+      message;
     Error (Agent_sdk.Error.Internal message)
   in
   match Masc_eio_env.get_opt () with
@@ -73,11 +131,44 @@ let run_with_timeout_and_fallback ~timeout_s fn =
          Keeper_metrics.metric_keeper_llm_bridge_failures
          ~labels:[ "site", "timeout" ]
          ();
-       Log.Keeper.warn
-         "keeper_llm_bridge: OAS execution timed out after %.1fs (budget=%.0fs; OAS \
-          context rollback only; external tool side effects are not reverted)"
-         wall
-         timeout_s;
+       let message =
+         Printf.sprintf
+           "keeper_llm_bridge: OAS execution timed out after %.1fs (budget=%.0fs; OAS \
+            context rollback only; external tool side effects are not reverted)"
+           wall
+           timeout_s
+       in
+       let envelope =
+         bridge_failure_envelope
+           ~cause_code:"oas_timeout_budget"
+           ~severity:Failure_envelope.Bad
+           ~summary:"OAS execution exceeded its keeper bridge timeout budget"
+           ~recoverability:Failure_envelope.Operator_action_required
+           ~operator_action:"inspect_timeout_budget"
+           ~evidence_ref:
+             (`Assoc
+               [
+                 ("timeout_sec", `Float timeout_s);
+                 ("wall_sec", `Float wall);
+                 ("overshoot_sec", `Float (Float.max 0.0 (wall -. timeout_s)));
+                 ("rollback_scope", `String "oas_context_only");
+                 ("external_tool_side_effects_reverted", `Bool false);
+               ])
+           ()
+       in
+       Log.Keeper.emit Log.Warn
+         ~details:
+           (bridge_details
+              [
+                json_string_field "event" "keeper_oas_bridge_timeout";
+                json_float_field "timeout_sec" timeout_s;
+                json_float_field "wall_sec" wall;
+                json_float_field "overshoot_sec" (Float.max 0.0 (wall -. timeout_s));
+                json_string_field "rollback_scope" "oas_context_only";
+                json_field "external_tool_side_effects_reverted" (`Bool false);
+              ]
+              envelope)
+         message;
        Error
          (Agent_sdk.Error.Api
             (Timeout
@@ -120,13 +211,45 @@ let run_with_timeout_and_fallback ~timeout_s fn =
          Keeper_metrics.metric_keeper_llm_bridge_failures
          ~labels:[ "site", "cancelled" ]
          ();
-       Log.Keeper.warn
-         "keeper_llm_bridge: OAS execution cancelled after %.1fs bucket=%s inner=%s \
-          (re-raising; OAS context rollback only; external tool side effects are not \
-          reverted)"
-         wall
-         bucket
-         inner_str;
+       let message =
+         Printf.sprintf
+           "keeper_llm_bridge: OAS execution cancelled after %.1fs bucket=%s inner=%s \
+            (re-raising; OAS context rollback only; external tool side effects are not \
+            reverted)"
+           wall
+           bucket
+           inner_str
+       in
+       let envelope =
+         bridge_failure_envelope
+           ~cause_code:"oas_execution_cancelled"
+           ~severity:Failure_envelope.Warn
+           ~summary:"OAS execution was cancelled by parent fiber or shutdown"
+           ~recoverability:Failure_envelope.Retryable
+           ~evidence_ref:
+             (`Assoc
+               [
+                 ("wall_sec", `Float wall);
+                 ("bucket", `String bucket);
+                 ("inner_exception", `String inner_str);
+                 ("rollback_scope", `String "oas_context_only");
+                 ("external_tool_side_effects_reverted", `Bool false);
+               ])
+           ()
+       in
+       Log.Keeper.emit Log.Warn
+         ~details:
+           (bridge_details
+              [
+                json_string_field "event" "keeper_oas_bridge_cancelled";
+                json_float_field "wall_sec" wall;
+                json_string_field "bucket" bucket;
+                json_string_field "inner_exception" inner_str;
+                json_string_field "rollback_scope" "oas_context_only";
+                json_field "external_tool_side_effects_reverted" (`Bool false);
+              ]
+              envelope)
+         message;
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_oas_cancel
          ~labels:[ "bucket", bucket ]
@@ -143,9 +266,28 @@ let run_with_timeout_and_fallback ~timeout_s fn =
          Keeper_metrics.metric_keeper_llm_bridge_failures
          ~labels:[ "site", "execution_error" ]
          ();
-       Log.Keeper.error
-         "keeper_llm_bridge: OAS execution error: %s\n%s"
-         (Printexc.to_string exn)
-         bt;
-       Error (Agent_sdk.Error.Internal (Printexc.to_string exn)))
+       let error = Printexc.to_string exn in
+       let message =
+         Printf.sprintf "keeper_llm_bridge: OAS execution error: %s\n%s" error bt
+       in
+       let envelope =
+         bridge_failure_envelope
+           ~cause_code:"oas_execution_error"
+           ~severity:Failure_envelope.Bad
+           ~summary:"OAS execution raised an unexpected exception"
+           ~recoverability:Failure_envelope.Operator_action_required
+           ~operator_action:"inspect_oas_bridge_error"
+           ~evidence_ref:(`Assoc [ ("error", `String error) ])
+           ()
+       in
+       Log.Keeper.emit Log.Error
+         ~details:
+           (bridge_details
+              [
+                json_string_field "event" "keeper_oas_bridge_execution_error";
+                json_string_field "error" error;
+              ]
+              envelope)
+         message;
+       Error (Agent_sdk.Error.Internal error))
 ;;

--- a/lib/keeper/keeper_llm_bridge.ml
+++ b/lib/keeper/keeper_llm_bridge.ml
@@ -156,7 +156,7 @@ let run_with_timeout_and_fallback ~timeout_s fn =
                ])
            ()
        in
-       Log.Keeper.emit Log.Warn
+       Log.Keeper.emit Log.Info
          ~details:
            (bridge_details
               [

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1103,9 +1103,10 @@ let put_entry key entry =
      window" without a wall-clock heuristic at every caller.
    - Bump [metric_keeper_registry_update_dropped] every drop.
    - Edge-trigger: when count crosses [orphan_drop_threshold] inside
-     [orphan_drop_window_sec], escalate the log to ERROR and bump
+     [orphan_drop_window_sec], emit one WARN and bump
      [metric_keeper_registry_orphan_threshold_breached] exactly once
-     per breach window.
+     per breach window.  Individual drops stay DEBUG; the metric is the
+     durable signal and the threshold log is the operator attention point.
    - Reset state on the successful Some-entry path (orphan resolved)
      and after the window expires.
 
@@ -1180,7 +1181,7 @@ let update_entry ~base_path name f =
           Keeper_metrics.metric_keeper_registry_orphan_threshold_breached
           ~labels:[ "name", name ]
           ();
-        Log.Keeper.error
+        Log.Keeper.warn
           "registry: orphan threshold breached name=%s base_path=%s drops=%d \
            window=%.0fs — turn fiber may be racing post-deregistration; check \
            masc_keeper_status and watchdog"
@@ -1189,7 +1190,7 @@ let update_entry ~base_path name f =
           count
           orphan_drop_window_sec)
       else
-        Log.Keeper.warn
+        Log.Keeper.debug
           "registry: update_entry name=%s base_path=%s: entry not found, update dropped \
            (count=%d)"
           name

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -60,6 +60,78 @@ let provider_attempt_provenance_fields p =
   | Some source_cascade ->
       ("provider_source_cascade", `String source_cascade) :: base
 
+let health_error_kind label =
+  Cascade_health_tracker.error_kind_of_string label
+
+let record_candidate_health_success candidate ~latency_ms =
+  Cascade_runtime_candidate.health_keys candidate
+  |> List.iter (fun provider_key ->
+    Cascade_health_tracker.record_success
+      Cascade_health_tracker.global
+      ~provider_key
+      ~latency_ms
+      ())
+
+let record_candidate_health_rejected candidate ~reason =
+  let error_kind = health_error_kind "accept_rejected" in
+  Cascade_runtime_candidate.health_keys candidate
+  |> List.iter (fun provider_key ->
+    Cascade_health_tracker.record_rejected
+      Cascade_health_tracker.global
+      ~provider_key
+      ~error_kind
+      ~error_reason:reason
+      ())
+
+let record_candidate_health_error candidate sdk_err =
+  let error_reason = Agent_sdk.Error.to_string sdk_err in
+  let health_keys = Cascade_runtime_candidate.health_keys candidate in
+  if sdk_error_is_hard_quota sdk_err
+  then (
+    let error_kind = health_error_kind "hard_quota" in
+    health_keys
+    |> List.iter (fun provider_key ->
+      Cascade_health_tracker.record_hard_quota
+        Cascade_health_tracker.global
+        ~provider_key
+        ~error_kind
+        ~error_reason
+        ()))
+  else if sdk_error_is_terminal_provider_runtime_failure sdk_err
+  then (
+    let error_kind = health_error_kind "terminal_provider_runtime_failure" in
+    health_keys
+    |> List.iter (fun provider_key ->
+      Cascade_health_tracker.record_terminal_failure
+        Cascade_health_tracker.global
+        ~provider_key
+        ~error_kind
+        ~error_reason
+        ()))
+  else
+    match sdk_error_soft_rate_limited sdk_err with
+    | Some retry_after_s ->
+      let error_kind = health_error_kind "soft_rate_limited" in
+      health_keys
+      |> List.iter (fun provider_key ->
+        Cascade_health_tracker.record_soft_rate_limited
+          Cascade_health_tracker.global
+          ~provider_key
+          ?retry_after_s
+          ~error_kind
+          ~error_reason
+          ())
+    | None ->
+      let error_kind = health_error_kind "provider_error" in
+      health_keys
+      |> List.iter (fun provider_key ->
+        Cascade_health_tracker.record_failure
+          Cascade_health_tracker.global
+          ~provider_key
+          ~error_kind
+          ~error_reason
+          ())
+
 let runtime_candidate_label = "runtime"
 (* ================================================================ *)
 (* Facade-only: run_named, run_model_by_label, and MASC tool bridges  *)
@@ -626,6 +698,7 @@ let run_named
       (match result with
       | Ok result when accept result.response ->
         record_accepted_liveness_sample ();
+        record_candidate_health_success candidate ~latency_ms:attempt_latency_ms;
         let _ = attempt_latency_ms in
         (* FSM: Call_ok → Accept *)
         let observation =
@@ -658,6 +731,7 @@ let run_named
         (match Cascade_fsm.decide ~accept_on_exhaustion:false ~is_last outcome with
          | Cascade_fsm.Accept_on_exhaustion { response; _ } ->
            record_accepted_liveness_sample ();
+           record_candidate_health_success candidate ~latency_ms:attempt_latency_ms;
            let observation =
              Cascade_legacy_runner.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
@@ -675,6 +749,7 @@ let run_named
            (* Demoted from WARN to INFO (task-239): cascade will retry the
               next tier.  Tagged [cascade-fallback] so dashboard filters
               can distinguish recovery-in-progress from hard failures. *)
+           record_candidate_health_rejected candidate ~reason;
            Log.Misc.info "[cascade-fallback] cascade %s: accept rejected %s (%s), trying next" cascade_name runtime_candidate_label reason;
            Cascade_legacy_runner.record_fallback_event capture
              ~from_model:runtime_candidate_label ~to_model:runtime_candidate_label ~reason;
@@ -683,6 +758,7 @@ let run_named
               replay of the rejected empty/schema-invalid turn. *)
            try_cascade ?resume_checkpoint rest new_err
          | Cascade_fsm.Exhausted _ ->
+           record_candidate_health_rejected candidate ~reason;
            let observation =
              Cascade_legacy_runner.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
@@ -703,7 +779,7 @@ let run_named
                      model = Some runtime_candidate_label;
                      reason;
                    }))
-         | Cascade_fsm.Accept _resp ->
+           | Cascade_fsm.Accept _resp ->
            (* Should be unreachable with accept_on_exhaustion:false, but handle gracefully.
               Iter 42: tick an invariant-violation counter so this
               never-supposed-to-fire arm becomes a hard alert if it
@@ -712,6 +788,7 @@ let run_named
            Cascade_metrics.on_cascade_invariant_violation ();
            Log.Misc.warn "cascade %s: unexpected Accept in Accept_rejected branch (runtime=%s)" cascade_name runtime_candidate_label;
            record_accepted_liveness_sample ();
+           record_candidate_health_success candidate ~latency_ms:attempt_latency_ms;
            let observation =
              Cascade_legacy_runner.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
@@ -741,6 +818,7 @@ let run_named
            cascade turns on a provider that is terminal for the current runtime
            state. *)
         let err_str = Agent_sdk.Error.to_string sdk_err in
+        record_candidate_health_error candidate sdk_err;
         let (_ : Provider_error.t option) =
           emit_sdk_provider_error_metric ~cascade_name:error_cascade_name
             ~provider:runtime_candidate_label sdk_err

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -13,8 +13,8 @@ let clear_retired_pg_envs () =
     (fun key ->
       match Sys.getenv_opt key |> Env_config_core.trim_opt with
       | Some _ ->
-          Log.Server.warn
-            "Ignoring retired PG runtime env %s; filesystem-only bootstrap is enforced."
+          Log.Server.info
+            "Clearing retired PG runtime env %s; filesystem-only bootstrap is enforced."
             key;
           Unix.putenv key ""
       | None -> Unix.putenv key "")

--- a/test/test_cascade_declarative_adapter.ml
+++ b/test/test_cascade_declarative_adapter.ml
@@ -378,6 +378,63 @@ strategy = "failover"
            (List.length configs))
 ;;
 
+let test_ollama_cloud_openai_protocol_uses_chat_completions () =
+  with_env "OLLAMA_CLOUD_API_KEY" "ollama-cloud-adapter-test-key" @@ fun () ->
+    let toml =
+      {|
+[providers.ollama_cloud]
+protocol = "openai-http"
+endpoint = "https://ollama.com/v1"
+
+[providers.ollama_cloud.credentials]
+type = "env"
+key = "OLLAMA_CLOUD_API_KEY"
+
+[models.qwen3-5]
+max-context = 128000
+api-name = "qwen3.5"
+tools-support = true
+
+[models.qwen3-5.capabilities]
+supports-tool-choice = true
+
+[ollama_cloud.qwen3-5]
+max-concurrent = 1
+
+[tier.ollama_cloud_primary]
+members = ["ollama_cloud.qwen3-5"]
+strategy = "failover"
+|}
+    in
+    let catalog = adapt_toml toml in
+    no_errors catalog.errors;
+    let primary =
+      List.find
+        (fun (p : adapted_profile) -> p.name = "tier.ollama_cloud_primary")
+        catalog.profiles
+    in
+    match primary.provider_configs with
+    | [ cfg ] ->
+      check
+        bool
+        "explicit openai-http wins over ollama_cloud registry defaults"
+        true
+        (cfg.Llm_provider.Provider_config.kind
+         = Llm_provider.Provider_config.OpenAI_compat);
+      check string "uses versioned endpoint" "https://ollama.com/v1" cfg.base_url;
+      check string "uses chat completions path" "/chat/completions" cfg.request_path;
+      check
+        (option bool)
+        "tool_choice support preserved"
+        (Some true)
+        cfg.Llm_provider.Provider_config.supports_tool_choice_override
+    | configs ->
+      fail
+        (Printf.sprintf
+           "expected one resolved provider config, got %d"
+           (List.length configs))
+;;
+
 let test_model_capabilities_tool_choice_reaches_provider_config () =
   let toml =
     {|
@@ -948,6 +1005,10 @@ let () =
             "ollama_cloud HTTP provider adds bearer auth header"
             `Quick
             test_ollama_cloud_http_provider_adds_bearer_auth_header
+        ; test_case
+            "ollama_cloud openai-http uses chat completions"
+            `Quick
+            test_ollama_cloud_openai_protocol_uses_chat_completions
         ; test_case
             "model supports-tool-choice reaches provider config"
             `Quick

--- a/test/test_cascade_runtime.ml
+++ b/test/test_cascade_runtime.ml
@@ -61,6 +61,15 @@ let test_oas_failure_classification_keeps_terminal_branches_non_cascading () =
         (H.should_cascade_to_next local_resource)
   | _ -> fail "expected local resource exhaustion classification"
 
+let test_openai_compat_declarative_labels_do_not_require_registry_entry () =
+  check
+    bool
+    "typed declarative OpenAI-compatible labels are provider-config owned"
+    true
+    (Result.is_ok
+       (Masc_mcp.Cascade_runtime.ensure_api_keys_for_labels
+          [ "openai_compat:qwen3.5" ]))
+
 let () =
   run "Cascade_runtime"
     [
@@ -70,5 +79,7 @@ let () =
             test_oas_http_error_classification_is_typed;
           test_case "OAS terminal classes stay non-cascading" `Quick
             test_oas_failure_classification_keeps_terminal_branches_non_cascading;
+          test_case "typed openai_compat labels skip registry api-key gate" `Quick
+            test_openai_compat_declarative_labels_do_not_require_registry_entry;
         ] );
     ]

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -1207,6 +1207,23 @@ let test_pr_work_action_metric_ignores_non_pr_tool_output () =
     (hook_output_parse_failures "pr_work_action")
 ;;
 
+let test_pr_work_action_metric_allows_plain_shell_output () =
+  let before = hook_output_parse_failures "pr_work_action" in
+  let events =
+    pr_work_events
+      ~tool_name:"keeper_bash"
+      ~input:(`Assoc [ "cmd", `String "git push origin keeper/proof-branch" ])
+      ~output_text:"Everything up-to-date\n"
+      ()
+  in
+  check (list string) "actions fallback from input" [ "GIT_PUSH" ] (work_actions events);
+  check
+    (float 0.001)
+    "plain shell output parse failure not counted"
+    before
+    (hook_output_parse_failures "pr_work_action")
+;;
+
 let test_pr_work_action_metric_extracts_embedded_output_json () =
   let before = hook_output_parse_failures "pr_work_action" in
   let events =
@@ -1564,6 +1581,10 @@ let () =
             "ignores non-pr tool output"
             `Quick
             test_pr_work_action_metric_ignores_non_pr_tool_output
+        ; test_case
+            "allows plain shell output"
+            `Quick
+            test_pr_work_action_metric_allows_plain_shell_output
         ; test_case
             "extracts embedded output JSON"
             `Quick

--- a/test/test_keeper_llm_bridge.ml
+++ b/test/test_keeper_llm_bridge.ml
@@ -27,6 +27,31 @@ let assert_no_clock_error ~label ~called result =
   | Ok value -> Alcotest.failf "unexpected success: %s" value
 ;;
 
+let latest_keeper_log_matching needle =
+  Log.Ring.recent
+    ~limit:50
+    ~min_level:(Log.level_to_int Log.Debug)
+    ~module_filter:"Keeper"
+    ()
+  |> List.find_opt (fun entry -> contains_substring entry.Log.Ring.message needle)
+;;
+
+let assert_latest_failure_envelope ~label ~needle ~cause_code ~operator_action =
+  match latest_keeper_log_matching needle with
+  | None -> Alcotest.failf "%s: no matching Keeper log for %S" label needle
+  | Some entry ->
+    let open Yojson.Safe.Util in
+    let envelope = entry.Log.Ring.details |> member "failure_envelope" in
+    Alcotest.(check string)
+      (label ^ ": cause_code")
+      cause_code
+      (envelope |> member "cause_code" |> to_string);
+    Alcotest.(check string)
+      (label ^ ": operator_action")
+      operator_action
+      (envelope |> member "operator_action" |> to_string)
+;;
+
 let test_missing_env_fails_closed_without_calling_fn () =
   Masc_eio_env.reset_for_test ();
   let called = ref false in
@@ -35,7 +60,12 @@ let test_missing_env_fails_closed_without_calling_fn () =
       called := true;
       Ok "should-not-run")
   in
-  assert_no_clock_error ~label:"missing env" ~called result
+  assert_no_clock_error ~label:"missing env" ~called result;
+  assert_latest_failure_envelope
+    ~label:"missing env"
+    ~needle:"Eio clock unavailable"
+    ~cause_code:"eio_clock_unavailable"
+    ~operator_action:"check_masc_eio_env"
 ;;
 
 let test_clockless_env_fails_closed_without_calling_fn () =
@@ -70,6 +100,27 @@ let test_clocked_env_runs_function () =
         | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err))))
 ;;
 
+let test_timeout_log_carries_failure_envelope () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      Masc_eio_env.reset_for_test ();
+      Fun.protect ~finally:Masc_eio_env.reset_for_test (fun () ->
+        Masc_eio_env.init ~sw ~net:(Eio.Stdenv.net env) ~clock:(Eio.Stdenv.clock env) ();
+        match
+          Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s:0.001 (fun () ->
+            Eio.Time.sleep (Eio.Stdenv.clock env) 0.02;
+            Ok "late")
+        with
+        | Error (Agent_sdk.Error.Api (Timeout _)) ->
+          assert_latest_failure_envelope
+            ~label:"timeout"
+            ~needle:"OAS execution timed out"
+            ~cause_code:"oas_timeout_budget"
+            ~operator_action:"inspect_timeout_budget"
+        | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)
+        | Ok value -> Alcotest.failf "unexpected success: %s" value)))
+;;
+
 let () =
   Alcotest.run
     "keeper_llm_bridge"
@@ -83,6 +134,10 @@ let () =
             `Quick
             test_clockless_env_fails_closed_without_calling_fn
         ; Alcotest.test_case "clocked env runs" `Quick test_clocked_env_runs_function
+        ; Alcotest.test_case
+            "timeout log carries failure envelope"
+            `Quick
+            test_timeout_log_carries_failure_envelope
         ] )
     ]
 ;;

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -428,7 +428,8 @@ target = "tier.primary"
 let test_cascade_profile_metadata_from_toml () =
   with_temp_config_dir minimal_cascade_profile_metadata_toml
   @@ fun ~config_root:_ ~cascade_path:_ ->
-  check (list string) "keeper assignable catalog" ["backup"; "primary"]
+  check (list string) "keeper assignable catalog"
+    ["backup"; "primary"; "tier-group.primary"; "tier.backup"; "tier.primary"]
     (Masc_mcp.Keeper_cascade_profile.keeper_catalog_names ());
   check bool "rerank route is system-only" true
     (Masc_mcp.Keeper_cascade_profile.is_system_only_cascade "llm_rerank");
@@ -606,8 +607,8 @@ target = "tier.ollama_cloud_primary"
 |}
   in
   with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
-  check string "non-keeper route target falls back to keeper_turn route"
-    "tier-group.coding_plan"
+  check string "assignable concrete route target is preserved"
+    "tier.ollama_cloud_primary"
     (Masc_mcp.Keeper_cascade_profile.normalize_keeper_runtime_declared_name
        ~config_path:cascade_path "tier.ollama_cloud_primary")
 


### PR DESCRIPTION
## Summary

- keep the startup-noise fixes on top of current `main`: redirect-stub registry reconciliation, retired PG env cleanup INFO logging, checkpoint sanitize INFO logging, and plain shell output parse-noise suppression
- surface structured keeper bridge failure envelopes for missing Eio clock, OAS timeout, cancellation, and unexpected execution errors
- add dashboard log-window summaries, diagnostic cause chips, and failure-envelope details so WARN/ERROR recurrences are visible without reading raw JSON
- demote benign runtime telemetry churn to structured INFO/DEBUG while keeping threshold breaches and real cascade failures visible
- preserve typed cascade routing and provider/model health keys for OpenAI-compatible/Ollama Cloud providers

## Conflict Response

- rebased the useful logging/dashboard/runtime diagnostics work onto current `origin/main`
- dropped the stale credential/auth conflict surface from the PR head; current diff no longer touches `lib/auth.ml` or `test/test_auth.ml`
- updated the branch with explicit `--force-with-lease` from remote head `335d4996dee0a672cd647d42a1138a5df4ee3aa3` to `b850ebc525ef273446c11012b66588bd3e8d08ed`

## Verification

- `git diff --check origin/main...HEAD`
- `opam exec -- ocamlformat --check` on changed OCaml files
- `pnpm --dir dashboard exec vitest run src/components/logs.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `scripts/dune-local.sh build ./test/test_keeper_llm_bridge.exe ./test/test_keeper_hooks_oas_telemetry.exe ./test/test_cascade_declarative_adapter.exe ./test/test_cascade_runtime.exe ./test/test_keeper_toml_config_validation.exe`
- `./_build/default/test/test_keeper_llm_bridge.exe` (4 tests)
- `./_build/default/test/test_keeper_hooks_oas_telemetry.exe` (45 tests)
- `./_build/default/test/test_cascade_declarative_adapter.exe` (24 tests)
- `./_build/default/test/test_cascade_runtime.exe` (3 tests)
- `./_build/default/test/test_keeper_toml_config_validation.exe` (24 tests)
- GitHub checks on `b850ebc525ef273446c11012b66588bd3e8d08ed`: pass/skipped
