### PR TITLE
fix: surface stale keeper goal scopes

### DIFF
--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -812,6 +812,68 @@ let keeper_persona_audit_status ctx (meta : keeper_meta) =
   in
   Keeper_exec_status.keeper_surface_status ~agent_status ~diagnostic
 
+type keeper_active_goal_scope_audit = {
+  active_goal_ids : string list;
+  scoped_task_count : int;
+  scoped_open_task_count : int;
+  scoped_terminal_task_count : int;
+  global_open_task_count : int;
+  stale : bool;
+}
+
+let keeper_active_goal_scope_audit ctx (meta : keeper_meta) =
+  let active_goal_ids = meta.active_goal_ids in
+  let task_is_open (task : Masc_domain.task) =
+    not (Masc_domain.task_status_is_terminal task.task_status)
+  in
+  let tasks = Coord.get_tasks_safe ctx.config in
+  let count_open tasks =
+    List.fold_left
+      (fun acc task -> if task_is_open task then acc + 1 else acc)
+      0 tasks
+  in
+  let scoped_tasks =
+    if active_goal_ids = [] then []
+    else
+      List.filter
+        (Keeper_runtime_contract.task_is_linked_to_keeper_goals active_goal_ids)
+        tasks
+  in
+  let scoped_task_count = List.length scoped_tasks in
+  let scoped_open_task_count = count_open scoped_tasks in
+  let scoped_terminal_task_count = scoped_task_count - scoped_open_task_count in
+  let global_open_task_count = count_open tasks in
+  let stale =
+    active_goal_ids <> [] && scoped_open_task_count = 0
+    && global_open_task_count > 0
+  in
+  {
+    active_goal_ids;
+    scoped_task_count;
+    scoped_open_task_count;
+    scoped_terminal_task_count;
+    global_open_task_count;
+    stale;
+  }
+
+let keeper_active_goal_scope_audit_to_json audit =
+  `Assoc
+    [
+      ( "active_goal_ids",
+        `List (List.map (fun goal_id -> `String goal_id) audit.active_goal_ids)
+      );
+      ("scoped_task_count", `Int audit.scoped_task_count);
+      ("scoped_open_task_count", `Int audit.scoped_open_task_count);
+      ("scoped_terminal_task_count", `Int audit.scoped_terminal_task_count);
+      ("global_open_task_count", `Int audit.global_open_task_count);
+      ("stale", `Bool audit.stale);
+      ( "next_action",
+        if audit.stale then
+          `String
+            "update keeper active_goal_ids or create/link an eligible scoped task"
+        else `Null );
+    ]
+
 let keeper_persona_profile_candidates persona_name =
   let resolution = Config_dir_resolver.resolve () in
   (resolution.personas.path :: Config_dir_resolver.personas_dirs ())
@@ -918,6 +980,9 @@ let keeper_persona_audit_item ctx requested_name =
   let runtime_status =
     runtime_meta |> Option.map (keeper_persona_audit_status ctx)
   in
+  let active_goal_scope =
+    runtime_meta |> Option.map (keeper_active_goal_scope_audit ctx)
+  in
   let autoboot_enabled =
     match runtime_meta with
     | Some meta -> Some meta.autoboot_enabled
@@ -946,6 +1011,11 @@ let keeper_persona_audit_item ctx requested_name =
     |> add (match paused with Some true -> true | _ -> false) "keeper_paused"
     |> add (match runtime_meta with Some meta when Stdlib.List.length meta.active_goal_ids = 0 -> true | _ -> false)
          "empty_active_goal_ids"
+    |> add
+         (match active_goal_scope with
+          | Some scope when scope.stale -> true
+          | _ -> false)
+         "stale_active_goal_ids"
     |> add
          (match runtime_meta, autoboot_enabled, paused, keepalive_running with
           | Some _, (Some true | None), (Some false | None), Some false -> true
@@ -985,6 +1055,10 @@ let keeper_persona_audit_item ctx requested_name =
       ("registry_present", `Bool (Option.is_some registry_entry));
       ("phase", Json_util.string_opt_to_json phase);
       ("runtime_status", Json_util.string_opt_to_json runtime_status);
+      ( "active_goal_scope",
+        match active_goal_scope with
+        | Some scope -> keeper_active_goal_scope_audit_to_json scope
+        | None -> `Null );
       ("autoboot_enabled", json_bool_opt autoboot_enabled);
       ("dormant", `Bool dormant_autoboot_disabled);
       ( "dormant_reason",
@@ -1043,6 +1117,8 @@ let keeper_persona_audit_summary items =
       ("keeper_paused", `Int (count_issue "keeper_paused"));
       ("keepalive_not_running", `Int (count_issue "keepalive_not_running"));
       ("empty_active_goal_ids", `Int (count_issue "empty_active_goal_ids"));
+      ( "stale_active_goal_ids",
+        `Int (count_issue "stale_active_goal_ids") );
     ]
 
 let handle_keeper_persona_audit ctx args : tool_result =

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -144,7 +144,13 @@ let write_corrupt_keeper_meta_exn config ~name =
 
 let write_keeper_meta_exn ?(autoboot_enabled = true)
     ?(social_model = "bdi_speech_v1")
-    ?(last_social_transition_reason = "") config ~name ~trace_id =
+    ?(last_social_transition_reason = "")
+    ?active_goal_ids config ~name ~trace_id =
+  let active_goal_ids =
+    match active_goal_ids with
+    | Some goal_ids -> goal_ids
+    | None -> [ "goal-" ^ name ]
+  in
   let json =
     `Assoc
       [
@@ -155,7 +161,8 @@ let write_keeper_meta_exn ?(autoboot_enabled = true)
         ("social_model", `String social_model);
         ("last_social_transition_reason", `String last_social_transition_reason);
         ("autoboot_enabled", `Bool autoboot_enabled);
-        ("active_goal_ids", `List [ `String ("goal-" ^ name) ]);
+        ( "active_goal_ids",
+          `List (List.map (fun goal_id -> `String goal_id) active_goal_ids) );
       ]
   in
   let meta =
@@ -174,6 +181,30 @@ let register_keeper_offline_exn config ~name =
         (Keeper_registry.register_offline ~base_path:config.base_path name meta)
   | Ok None -> fail ("expected keeper meta for " ^ name)
   | Error e -> fail ("read_meta failed: " ^ e)
+
+let mark_task_done_by_title config ~title ~agent_name =
+  let backlog = Coord.read_backlog config in
+  let seen = ref false in
+  let tasks =
+    List.map
+      (fun (task : Masc_domain.task) ->
+        if String.equal task.title title then (
+          seen := true;
+          {
+            task with
+            task_status =
+              Masc_domain.Done
+                {
+                  assignee = agent_name;
+                  completed_at = Masc_domain.now_iso ();
+                  notes = Some "done";
+                };
+          })
+        else task)
+      backlog.tasks
+  in
+  if not !seen then fail ("expected task to mark done: " ^ title);
+  Coord.write_backlog config { backlog with tasks; version = backlog.version + 1 }
 
 let parse_json_exn body =
   try Yojson.Safe.from_string body
@@ -635,6 +666,92 @@ let test_keeper_persona_audit_reports_dormant_autoboot_disabled_keeper () =
           check int "no issues" 0
             Yojson.Safe.Util.(item |> member "issues" |> to_list |> List.length))
 
+let test_keeper_persona_audit_flags_stale_active_goal_ids () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  with_clean_base_path_env @@ fun () ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Config_dir_resolver.reset ();
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      write_persona_profile_exn config ~name:"analyst";
+      write_keeper_persona_toml_exn config ~name:"analyst"
+        ~persona_name:"analyst";
+      let stale_goal, _ =
+        match Goal_store.upsert_goal config ~title:"Finished scoped goal" () with
+        | Ok payload -> payload
+        | Error msg -> fail msg
+      in
+      let other_goal, _ =
+        match Goal_store.upsert_goal config ~title:"Open global goal" () with
+        | Ok payload -> payload
+        | Error msg -> fail msg
+      in
+      write_keeper_meta_exn config ~name:"analyst" ~trace_id:"trace-analyst"
+        ~active_goal_ids:[ stale_goal.id ];
+      ignore
+        (Coord_task.add_task ~goal_id:stale_goal.id config
+           ~title:"Done scoped task" ~priority:3 ~description:"desc");
+      ignore
+        (Coord_task.add_task ~goal_id:other_goal.id config
+           ~title:"Open global task" ~priority:1 ~description:"desc");
+      mark_task_done_by_title config ~title:"Done scoped task"
+        ~agent_name:"keeper-analyst-agent";
+      let config_root = Filename.concat (Coord.masc_root_dir config) "config" in
+      write_minimal_cascade_toml config_root;
+      Unix.putenv "MASC_CONFIG_DIR" config_root;
+      Config_dir_resolver.reset ();
+      (match Keeper_types.read_meta config "analyst" with
+       | Ok (Some meta) ->
+           ignore
+             (Keeper_registry.register ~base_path:config.base_path "analyst"
+                meta)
+       | Ok None -> fail "expected analyst meta"
+       | Error e -> fail ("read_meta failed: " ^ e));
+      let ctx = keeper_ctx env sw config "operator" in
+      let ok, body =
+        match
+          Tool_keeper.dispatch ctx ~name:"masc_keeper_persona_audit"
+            ~args:(`Assoc [ ("name", `String "analyst") ])
+        with
+        | Some result -> result
+        | None -> fail "expected masc_keeper_persona_audit dispatch"
+      in
+      check bool "tool audit ok" true ok;
+      let json = parse_json_exn body in
+      check int "summary stale active goal ids" 1
+        Yojson.Safe.Util.(
+          json |> member "summary" |> member "stale_active_goal_ids" |> to_int);
+      match audit_item_by_name json "analyst" with
+      | None -> fail "expected analyst audit item"
+      | Some item ->
+          let issues =
+            Yojson.Safe.Util.(item |> member "issues") |> string_list_of_json
+          in
+          let scope = Yojson.Safe.Util.(item |> member "active_goal_scope") in
+          check bool "flags stale active goals" true
+            (List.mem "stale_active_goal_ids" issues);
+          check bool "item not ok" false
+            Yojson.Safe.Util.(item |> member "ok" |> to_bool);
+          check int "scoped tasks counted" 1
+            Yojson.Safe.Util.(scope |> member "scoped_task_count" |> to_int);
+          check int "scoped open tasks counted" 0
+            Yojson.Safe.Util.(scope |> member "scoped_open_task_count" |> to_int);
+          check int "scoped terminal tasks counted" 1
+            Yojson.Safe.Util.(
+              scope |> member "scoped_terminal_task_count" |> to_int);
+          check int "global open tasks counted" 1
+            Yojson.Safe.Util.(scope |> member "global_open_task_count" |> to_int);
+          check bool "scope marked stale" true
+            Yojson.Safe.Util.(scope |> member "stale" |> to_bool))
+
 let test_keeper_persona_audit_flags_missing_persona_runtime () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -844,6 +961,8 @@ let () =
           test_case "keeper persona audit reports dormant autoboot-disabled keeper"
             `Quick
             test_keeper_persona_audit_reports_dormant_autoboot_disabled_keeper;
+          test_case "keeper persona audit flags stale active goal ids" `Quick
+            test_keeper_persona_audit_flags_stale_active_goal_ids;
           test_case "keeper persona audit flags missing persona runtime" `Quick
             test_keeper_persona_audit_flags_missing_persona_runtime;
           test_case "keeper persona audit flags runtime meta parse error" `Quick


### PR DESCRIPTION
## Summary
- add stale active-goal scope detection to masc_keeper_persona_audit
- surface scoped/open/global task counts plus next_action for stale keeper goal scopes
- add a regression test where a keeper has only terminal scoped tasks while global backlog still has open work

## Why
A keeper can look healthy but keep returning no eligible scoped tasks when its persisted active_goal_ids point at goals with zero open scoped work. Operators need this surfaced in the audit path instead of inferring it from claim failures and delivery_surface=silent state.

Closes #15065

## Validation
- scripts/dune-local.sh build test/test_keeper_meta_listing.exe
- ./_build/default/test/test_keeper_meta_listing.exe
- opam exec -- ocamlformat --check lib/tool_keeper.ml test/test_keeper_meta_listing.ml
- git diff --check