### PR TITLE
fix(dashboard): surface keeper tool coverage gaps

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -15,6 +15,7 @@ import {
   fetchMemorySubsystems,
   fetchRuntimeProviders,
   fetchRuntimeModelMetrics,
+  fetchTelemetrySummary,
   fetchTlcResults,
   fetchToolQuality,
 } from './dashboard'
@@ -370,6 +371,107 @@ describe('fetchToolQuality', () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/tool-quality?window_hours=24')
     expect(result.window_hours).toBe(24)
     expect(result.sampling_mode).toBe('window_hours')
+  })
+
+  it('preserves tool-quality coverage gap rows', async () => {
+    const rawResponse = {
+      generated_at: '2026-05-14T00:00:00Z',
+      sampling_mode: 'window_hours',
+      sample_limit: null,
+      window_hours: 24,
+      total: 2,
+      success: 1,
+      failure: 1,
+      success_rate: 50,
+      source: 'tool_call_io',
+      health: 'coverage_gap',
+      stale_reason: 'append_failed',
+      coverage_gap_count: 1,
+      coverage_gaps: [
+        {
+          schema: 'masc.telemetry_coverage_gap.v1',
+          source: 'tool_call_io',
+          producer: 'keeper_tool_call_log.append',
+          durable_store: '.masc/tool_calls',
+          dashboard_surface: '/api/v1/dashboard/tool-quality',
+          stale_reason: 'append_failed',
+          trace_id: 'trace-quality-gap',
+          error: 'disk full',
+        },
+      ],
+      by_tool: [],
+      by_keeper: [],
+      failure_categories: [],
+    }
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchToolQuality({ windowHours: 24 })
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/tool-quality?window_hours=24')
+    expect(result.coverage_gap_count).toBe(1)
+    expect(result.coverage_gaps?.[0]).toMatchObject({
+      producer: 'keeper_tool_call_log.append',
+      durable_store: '.masc/tool_calls',
+      dashboard_surface: '/api/v1/dashboard/tool-quality',
+      stale_reason: 'append_failed',
+      trace_id: 'trace-quality-gap',
+      error: 'disk full',
+    })
+  })
+})
+
+describe('fetchTelemetrySummary', () => {
+  it('preserves per-source coverage gap rows', async () => {
+    const rawResponse = {
+      generated_at: '2026-05-14T00:00:00Z',
+      total_entries: 0,
+      sources: [
+        {
+          source: 'agent_event',
+          entry_count: 0,
+          health: 'coverage_gap',
+          stale_reason: 'append_failed',
+          coverage_gaps: [
+            {
+              schema: 'masc.telemetry_coverage_gap.v1',
+              source: 'agent_event',
+              producer: 'telemetry_eio',
+              durable_store: '.masc/telemetry',
+              dashboard_surface: '/api/v1/dashboard/telemetry/summary',
+              stale_reason: 'append_failed',
+              error: 'disk full',
+            },
+          ],
+        },
+      ],
+    }
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchTelemetrySummary()
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/telemetry/summary')
+    expect(result.sources[0]?.coverage_gap_count).toBe(1)
+    expect(result.sources[0]?.coverage_gaps?.[0]).toMatchObject({
+      producer: 'telemetry_eio',
+      durable_store: '.masc/telemetry',
+      dashboard_surface: '/api/v1/dashboard/telemetry/summary',
+      stale_reason: 'append_failed',
+      error: 'disk full',
+    })
   })
 })
 

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -5,6 +5,8 @@ import {
   fetchDashboardGoalDetail,
   fetchDashboardGoalsTree,
   fetchDashboardTools,
+  fetchKeeperToolCalls,
+  fetchKeeperToolStats,
   fetchDashboardMemory,
   fetchCostLatency,
   fetchKeeperConfig,
@@ -85,6 +87,96 @@ describe('fetchDashboardShell', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/shell?light=true')
+  })
+})
+
+describe('keeper tool telemetry fetchers', () => {
+  it('preserves tool-stats coverage gap rows', async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(
+      new Response(JSON.stringify({
+        keeper: 'keeper-alpha',
+        window_hours: 24,
+        total_entries: 0,
+        source: 'trajectory_tool_call',
+        health: 'coverage_gap',
+        stale_reason: 'trajectory_append_failed',
+        coverage_gaps: [
+          {
+            schema: 'masc.telemetry_coverage_gap.v1',
+            ts: 1_777_100_000,
+            ts_iso: '2026-05-14T00:00:00Z',
+            source: 'trajectory_tool_call',
+            producer: 'keeper_hooks_oas.post_tool_use',
+            durable_store: '.masc/keepers/keeper-alpha/trajectories',
+            dashboard_surface: '/api/v1/keepers/:name/tool-stats',
+            stale_reason: 'trajectory_append_failed',
+            keeper_name: 'keeper-alpha',
+            trace_id: 'trace-tool-stats-gap',
+            error: 'append denied',
+          },
+        ],
+        tools: [],
+        timeline: [],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperToolStats('keeper-alpha')
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/keepers/keeper-alpha/tool-stats')
+    expect(result.coverage_gap_count).toBe(1)
+    expect(result.coverage_gaps?.[0]).toMatchObject({
+      producer: 'keeper_hooks_oas.post_tool_use',
+      durable_store: '.masc/keepers/keeper-alpha/trajectories',
+      dashboard_surface: '/api/v1/keepers/:name/tool-stats',
+      stale_reason: 'trajectory_append_failed',
+      trace_id: 'trace-tool-stats-gap',
+      error: 'append denied',
+    })
+  })
+
+  it('preserves tool-call coverage gap rows', async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(
+      new Response(JSON.stringify({
+        keeper: 'keeper-alpha',
+        count: 0,
+        source: 'tool_call_io',
+        health: 'coverage_gap',
+        stale_reason: 'tool_call_io_append_failed',
+        coverage_gaps: [
+          {
+            schema: 'masc.telemetry_coverage_gap.v1',
+            source: 'tool_call_io',
+            producer: 'keeper_tool_call_log.append',
+            durable_store: '.masc/tool_calls',
+            dashboard_surface: '/api/v1/keepers/:name/tool-calls',
+            stale_reason: 'tool_call_io_append_failed',
+            keeper_name: 'keeper-alpha',
+            trace_id: 'trace-tool-call-gap',
+          },
+        ],
+        entries: [],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperToolCalls('keeper-alpha')
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/keepers/keeper-alpha/tool-calls')
+    expect(result.coverage_gap_count).toBe(1)
+    expect(result.coverage_gaps?.[0]).toMatchObject({
+      producer: 'keeper_tool_call_log.append',
+      durable_store: '.masc/tool_calls',
+      dashboard_surface: '/api/v1/keepers/:name/tool-calls',
+      stale_reason: 'tool_call_io_append_failed',
+      trace_id: 'trace-tool-call-gap',
+    })
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2376,9 +2376,45 @@ export type TelemetryFreshnessMetadata = {
   stale_reason?: string | null
   entry_count?: number
   exists?: boolean
+  coverage_gaps?: TelemetryCoverageGap[]
+  coverage_gap_count?: number
+}
+
+export type TelemetryCoverageGap = {
+  schema?: string
+  ts?: number
+  ts_iso?: string | null
+  source?: string
+  producer?: string
+  durable_store?: string
+  dashboard_surface?: string
+  stale_reason?: string
+  keeper_name?: string | null
+  trace_id?: string | null
+  error?: string | null
+}
+
+function decodeTelemetryCoverageGap(raw: unknown): TelemetryCoverageGap | null {
+  if (!isRecord(raw)) return null
+  return {
+    schema: asString(raw.schema),
+    ts: asNumber(raw.ts),
+    ts_iso: asNullableString(raw.ts_iso),
+    source: asString(raw.source),
+    producer: asString(raw.producer),
+    durable_store: asString(raw.durable_store),
+    dashboard_surface: asString(raw.dashboard_surface),
+    stale_reason: asString(raw.stale_reason),
+    keeper_name: asNullableString(raw.keeper_name),
+    trace_id: asNullableString(raw.trace_id),
+    error: asNullableString(raw.error),
+  }
 }
 
 function decodeTelemetryFreshnessMetadata(raw: Record<string, unknown>): TelemetryFreshnessMetadata {
+  const coverageGaps = asRecordArray(raw.coverage_gaps)
+    .map(decodeTelemetryCoverageGap)
+    .filter((gap): gap is TelemetryCoverageGap => gap !== null)
   return {
     source: asString(raw.source),
     producer: asString(raw.producer),
@@ -2392,6 +2428,8 @@ function decodeTelemetryFreshnessMetadata(raw: Record<string, unknown>): Telemet
     stale_reason: asNullableString(raw.stale_reason),
     entry_count: asNumber(raw.entry_count),
     exists: asBoolean(raw.exists),
+    coverage_gaps: coverageGaps,
+    coverage_gap_count: asNumber(raw.coverage_gap_count, coverageGaps.length),
   }
 }
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -239,19 +239,7 @@ export type ToolQualityHourlyPoint = {
   success_rate: number
 }
 
-export type ToolQualityResponse = {
-  source?: string
-  producer?: string
-  durable_store?: string
-  dashboard_surface?: string
-  freshness_slo_s?: number
-  latest_ts_unix?: number | null
-  latest_ts_iso?: string | null
-  latest_age_s?: number | null
-  health?: string
-  stale_reason?: string | null
-  entry_count?: number
-  exists?: boolean
+export type ToolQualityResponse = TelemetryFreshnessMetadata & {
   generated_at?: string
   sampling_mode?: 'recent_n' | 'window_hours' | string
   sample_limit?: number | null
@@ -2644,22 +2632,12 @@ export type TelemetryResponse = {
   entries: TelemetryEntry[]
 }
 
-export type TelemetrySourceSummary = {
+export type TelemetrySourceSummary = TelemetryFreshnessMetadata & {
   source: string
   path?: string
-  exists?: boolean
   entry_count: number
   keepers?: Array<{ name: string; path: string }>
   keeper_count?: number
-  freshness_slo_s?: number | null
-  producer?: string
-  durable_store?: string
-  dashboard_surface?: string
-  latest_ts_unix?: number | null
-  latest_ts_iso?: string | null
-  latest_age_s?: number | null
-  health?: string
-  stale_reason?: string | null
 }
 
 export type TelemetrySummaryResponse = {
@@ -2719,6 +2697,7 @@ function decodeTelemetrySourceSummary(raw: unknown): TelemetrySourceSummary | nu
   const source = asString(raw.source)
   if (!source) return null
   return {
+    ...decodeTelemetryFreshnessMetadata(raw),
     source,
     path: asString(raw.path),
     exists: asBoolean(raw.exists),
@@ -2731,15 +2710,6 @@ function decodeTelemetrySourceSummary(raw: unknown): TelemetrySourceSummary | nu
       })
       .filter((keeper): keeper is { name: string; path: string } => keeper !== null),
     keeper_count: asNumber(raw.keeper_count),
-    freshness_slo_s: asNumber(raw.freshness_slo_s),
-    producer: asString(raw.producer),
-    durable_store: asString(raw.durable_store),
-    dashboard_surface: asString(raw.dashboard_surface),
-    latest_ts_unix: asNumber(raw.latest_ts_unix),
-    latest_ts_iso: asString(raw.latest_ts_iso),
-    latest_age_s: asNumber(raw.latest_age_s),
-    health: asString(raw.health),
-    stale_reason: asNullableString(raw.stale_reason),
   }
 }
 

--- a/dashboard/src/components/common/source-health.test.ts
+++ b/dashboard/src/components/common/source-health.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { coverageGapDisplay, freshnessText, sourceHealthClass } from './source-health'
+
+describe('sourceHealthClass', () => {
+  it('maps coverage_gap to warning tone', () => {
+    expect(sourceHealthClass('coverage_gap')).toBe('text-[var(--color-status-warn)]')
+  })
+})
+
+describe('freshnessText', () => {
+  it('prefers stale reason over latest age', () => {
+    expect(freshnessText({ stale_reason: 'tool_call_io_append_failed', latest_age_s: 4 })).toBe(
+      'tool_call_io_append_failed',
+    )
+  })
+})
+
+describe('coverageGapDisplay', () => {
+  it('summarizes latest coverage gap provenance for freshness lines', () => {
+    const display = coverageGapDisplay({
+      source: 'tool_call_io',
+      producer: 'fallback-producer',
+      durable_store: 'fallback-store',
+      dashboard_surface: 'fallback-surface',
+      stale_reason: 'fallback_reason',
+      coverage_gap_count: 2,
+      coverage_gaps: [
+        {
+          source: 'tool_call_io',
+          producer: 'keeper_tool_call_log.append',
+          durable_store: '.masc/tool_calls',
+          dashboard_surface: '/api/v1/keepers/:name/tool-calls',
+          stale_reason: 'tool_call_io_append_failed',
+          trace_id: 'trace-tool-call-gap',
+          error: 'append denied',
+        },
+      ],
+    })
+
+    expect(display).toEqual({
+      count: 2,
+      summary: 'coverage gaps 2: tool_call_io_append_failed',
+      details: [
+        'producer keeper_tool_call_log.append',
+        'store .masc/tool_calls',
+        'surface /api/v1/keepers/:name/tool-calls',
+        'trace trace-tool-call-gap',
+        'error append denied',
+      ],
+    })
+  })
+})

--- a/dashboard/src/components/common/source-health.ts
+++ b/dashboard/src/components/common/source-health.ts
@@ -9,7 +9,7 @@
 // everything else → disabled neutral tone.
 
 import { formatElapsedCompact } from '../../lib/format-time'
-import type { TelemetryFreshnessMetadata } from '../../api/dashboard'
+import type { TelemetryCoverageGap, TelemetryFreshnessMetadata } from '../../api/dashboard'
 
 /** Map a source health string to a Tailwind text color class. */
 export function sourceHealthClass(health?: string | null): string {
@@ -34,4 +34,44 @@ export function freshnessText(d: TelemetryFreshnessMetadata): string {
     return 'latest n/a'
   }
   return `latest ${formatElapsedCompact(d.latest_age_s)}`
+}
+
+function nonEmpty(value?: string | null): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+function latestCoverageGap(d: TelemetryFreshnessMetadata): TelemetryCoverageGap | null {
+  return d.coverage_gaps?.[0] ?? null
+}
+
+export type CoverageGapDisplay = {
+  count: number
+  summary: string
+  details: string[]
+}
+
+/** Build compact operator-visible coverage-gap details for freshness lines. */
+export function coverageGapDisplay(d: TelemetryFreshnessMetadata): CoverageGapDisplay | null {
+  const count = d.coverage_gap_count ?? d.coverage_gaps?.length ?? 0
+  if (count <= 0) return null
+
+  const gap = latestCoverageGap(d)
+  const reason = nonEmpty(gap?.stale_reason) ?? nonEmpty(d.stale_reason) ?? 'coverage_gap'
+  const rawDetails: Array<[string, string | null]> = [
+    ['producer', nonEmpty(gap?.producer) ?? nonEmpty(d.producer)],
+    ['store', nonEmpty(gap?.durable_store) ?? nonEmpty(d.durable_store)],
+    ['surface', nonEmpty(gap?.dashboard_surface) ?? nonEmpty(d.dashboard_surface)],
+    ['trace', nonEmpty(gap?.trace_id)],
+    ['error', nonEmpty(gap?.error)],
+  ]
+  const details = rawDetails
+    .filter((entry): entry is [string, string] => entry[1] != null)
+    .map(([label, value]) => `${label} ${value}`)
+
+  return {
+    count,
+    summary: `coverage gaps ${count}: ${reason}`,
+    details,
+  }
 }

--- a/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
@@ -83,4 +83,41 @@ describe('KeeperToolCallInspector render', () => {
     expect(inputCopy?.getAttribute('title')).toBe('도구 호출 입력 복사')
     expect(outputCopy?.getAttribute('title')).toBe('도구 호출 출력 복사')
   })
+
+  it('surfaces coverage gap provenance when tool-call IO is stale', async () => {
+    const fetchKeeperToolCalls = vi.fn().mockResolvedValue({
+      keeper: 'analyst',
+      count: 0,
+      source: 'tool_call_io',
+      health: 'coverage_gap',
+      stale_reason: 'tool_call_io_append_failed',
+      coverage_gap_count: 1,
+      coverage_gaps: [
+        {
+          source: 'tool_call_io',
+          producer: 'keeper_tool_call_log.append',
+          durable_store: '.masc/tool_calls',
+          dashboard_surface: '/api/v1/keepers/:name/tool-calls',
+          stale_reason: 'tool_call_io_append_failed',
+          trace_id: 'trace-tool-call-gap',
+          error: 'append denied',
+        },
+      ],
+      entries: [],
+    })
+
+    const { KeeperToolCallInspector } = await loadInspector(fetchKeeperToolCalls)
+    await act(async () => {
+      render(html`<${KeeperToolCallInspector} keeperName="analyst" />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(container.textContent).toContain('coverage gaps 1: tool_call_io_append_failed')
+    expect(container.textContent).toContain('producer keeper_tool_call_log.append')
+    expect(container.textContent).toContain('store .masc/tool_calls')
+    expect(container.textContent).toContain('surface /api/v1/keepers/:name/tool-calls')
+    expect(container.textContent).toContain('trace trace-tool-call-gap')
+    expect(container.textContent).toContain('error append denied')
+  })
 })

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -15,12 +15,13 @@ import { parseToolBlobMarker } from '../lib/tool-blob-marker'
 import { CopyIdButton } from './common/copy-id-button'
 import { TextInput } from './common/input'
 import { ringFocusClasses } from './common/ring'
-import { sourceHealthClass, freshnessText } from './common/source-health'
+import { coverageGapDisplay, sourceHealthClass, freshnessText } from './common/source-health'
 
 // Delegated to lib/format-time (SSOT)
 const formatTimestamp = formatTimeHms
 
 function FreshnessLine({ data }: { data: TelemetryFreshnessMetadata }) {
+  const gap = coverageGapDisplay(data)
   return html`
     <div class="text-3xs text-[var(--color-fg-disabled)]">
       <span class="font-mono">${data.source ?? 'tool_call_io'}</span>
@@ -31,6 +32,12 @@ function FreshnessLine({ data }: { data: TelemetryFreshnessMetadata }) {
       ${typeof data.entry_count === 'number' ? html`
         <span class="mx-1" aria-hidden="true">·</span>
         <span>${data.entry_count.toLocaleString()} rows</span>
+      ` : null}
+      ${gap ? html`
+        <div class="mt-1 font-mono text-[var(--color-status-warn)]">${gap.summary}</div>
+        ${gap.details.length > 0 ? html`
+          <div class="mt-0.5 break-all font-mono text-[var(--color-fg-muted)]">${gap.details.join(' · ')}</div>
+        ` : null}
       ` : null}
     </div>
   `

--- a/dashboard/src/components/keeper-tool-telemetry.test.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { filterToolStats } from './keeper-tool-telemetry'
 import type { ToolStat } from '../api/dashboard'
 
@@ -90,5 +93,80 @@ describe('filterToolStats', () => {
     const empty: readonly ToolStat[] = []
     expect(filterToolStats(empty, 'masc')).toEqual([])
     expect(filterToolStats(empty, '')).toBe(empty)
+  })
+})
+
+async function flushUi(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 4; i += 1) {
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(0)
+    }
+  })
+}
+
+async function loadTelemetry(fetchKeeperToolStats: ReturnType<typeof vi.fn>) {
+  vi.resetModules()
+  vi.doMock('../api/dashboard', () => ({
+    fetchKeeperToolStats,
+  }))
+  return import('./keeper-tool-telemetry')
+}
+
+describe('KeeperToolTelemetry render', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.clearAllMocks()
+    vi.resetModules()
+    vi.doUnmock('../api/dashboard')
+    vi.useRealTimers()
+  })
+
+  it('surfaces trajectory coverage gap provenance', async () => {
+    const fetchKeeperToolStats = vi.fn().mockResolvedValue({
+      keeper: 'analyst',
+      window_hours: 24,
+      total_entries: 0,
+      source: 'trajectory_tool_call',
+      health: 'coverage_gap',
+      stale_reason: 'trajectory_append_failed',
+      coverage_gap_count: 1,
+      coverage_gaps: [
+        {
+          source: 'trajectory_tool_call',
+          producer: 'keeper_hooks_oas.post_tool_use',
+          durable_store: '.masc/keepers/analyst/trajectories',
+          dashboard_surface: '/api/v1/keepers/:name/tool-stats',
+          stale_reason: 'trajectory_append_failed',
+          trace_id: 'trace-tool-stats-gap',
+          error: 'append denied',
+        },
+      ],
+      tools: [],
+      timeline: [],
+    })
+
+    const { KeeperToolTelemetry } = await loadTelemetry(fetchKeeperToolStats)
+    await act(async () => {
+      render(html`<${KeeperToolTelemetry} keeperName="analyst" />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(container.textContent).toContain('coverage gaps 1: trajectory_append_failed')
+    expect(container.textContent).toContain('producer keeper_hooks_oas.post_tool_use')
+    expect(container.textContent).toContain('store .masc/keepers/analyst/trajectories')
+    expect(container.textContent).toContain('surface /api/v1/keepers/:name/tool-stats')
+    expect(container.textContent).toContain('trace trace-tool-stats-gap')
+    expect(container.textContent).toContain('error append denied')
   })
 })

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -13,7 +13,7 @@ import { TextInput } from './common/input'
 import { SectionCap } from './common/section-cap'
 import { PanelCard } from './common/panel-card'
 import { ProgressBar } from './common/progress-bar'
-import { sourceHealthClass, freshnessText } from './common/source-health'
+import { coverageGapDisplay, sourceHealthClass, freshnessText } from './common/source-health'
 import { StatusChip } from './common/status-chip'
 
 // ── Types ─────────────────────────────────────────────
@@ -26,6 +26,7 @@ interface TelemetryState extends TelemetryFreshnessMetadata {
 }
 
 function FreshnessLine({ data }: { data: TelemetryFreshnessMetadata }) {
+  const gap = coverageGapDisplay(data)
   return html`
     <div class="text-3xs text-[var(--color-fg-disabled)]">
       <span class="font-mono">${data.source ?? 'trajectory_tool_call'}</span>
@@ -36,6 +37,12 @@ function FreshnessLine({ data }: { data: TelemetryFreshnessMetadata }) {
       ${typeof data.entry_count === 'number' ? html`
         <span class="mx-1" aria-hidden="true">·</span>
         <span>${data.entry_count.toLocaleString()} rows</span>
+      ` : null}
+      ${gap ? html`
+        <div class="mt-1 font-mono text-[var(--color-status-warn)]">${gap.summary}</div>
+        ${gap.details.length > 0 ? html`
+          <div class="mt-0.5 break-all font-mono text-[var(--color-fg-muted)]">${gap.details.join(' · ')}</div>
+        ` : null}
       ` : null}
     </div>
   `
@@ -171,6 +178,8 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
         stale_reason: data.stale_reason,
         entry_count: data.entry_count,
         exists: data.exists,
+        coverage_gaps: data.coverage_gaps,
+        coverage_gap_count: data.coverage_gap_count,
         tools: data.tools,
         timeline: data.timeline,
         totalEntries: data.total_entries,

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -228,6 +228,52 @@ describe('TelemetryUnified', () => {
     expect(container.textContent).toContain('5 public')
   })
 
+  it('renders telemetry summary coverage gap provenance', async () => {
+    const fetchTelemetry = vi.fn().mockResolvedValue(baseTelemetry)
+    const fetchTelemetrySummary = vi.fn().mockResolvedValue({
+      ...baseSummary,
+      sources: [
+        {
+          ...baseSummary.sources[0],
+          health: 'coverage_gap',
+          stale_reason: 'append_failed',
+          coverage_gap_count: 1,
+          coverage_gaps: [
+            {
+              schema: 'masc.telemetry_coverage_gap.v1',
+              source: 'tool_metric',
+              producer: 'telemetry_eio',
+              durable_store: '.masc/telemetry',
+              dashboard_surface: '/api/v1/dashboard/telemetry/summary',
+              stale_reason: 'append_failed',
+              trace_id: 'trace-summary-gap',
+              error: 'disk full',
+            },
+          ],
+        },
+      ],
+    })
+    const { TelemetryUnified } = await loadPanel(fetchTelemetry, fetchTelemetrySummary)
+
+    await act(async () => {
+      render(html`<${TelemetryUnified} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(container.textContent).toContain('coverage gaps 1: append_failed')
+    expect(container.textContent).toContain('gap producer')
+    expect(container.textContent).toContain('telemetry_eio')
+    expect(container.textContent).toContain('gap store')
+    expect(container.textContent).toContain('.masc/telemetry')
+    expect(container.textContent).toContain('gap surface')
+    expect(container.textContent).toContain('/api/v1/dashboard/telemetry/summary')
+    expect(container.textContent).toContain('gap trace')
+    expect(container.textContent).toContain('trace-summary-gap')
+    expect(container.textContent).toContain('gap error')
+    expect(container.textContent).toContain('disk full')
+  })
+
   it('hydrates telemetry scope and entry focus from route params', async () => {
     window.location.hash = '#monitoring?section=fleet-health&view=event-log&session_id=sess-route&operation_id=op-route&worker_run_id=wr-route&q=turn-9'
     const fetchTelemetry = vi.fn().mockResolvedValue({

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -28,6 +28,7 @@ import { OasHealthChip } from './oas-health-chip'
 import { CopyIdButton } from './common/copy-id-button'
 import { ringFocusClasses } from './common/ring'
 import { StatTile } from './common/stat-tile'
+import { coverageGapDisplay } from './common/source-health'
 
 interface StoreSnapshot {
   keepers: number
@@ -590,10 +591,14 @@ function condensedStats(items: readonly TelemetryDisplayItem[]) {
 
 function telemetrySourceStatusParts(src: TelemetrySourceSummary): string[] {
   const parts: string[] = []
+  const coverageGap = coverageGapDisplay(src)
   if (src.health) {
     parts.push(src.stale_reason ? `${src.health}: ${src.stale_reason}` : src.health)
   } else if (src.stale_reason) {
     parts.push(src.stale_reason)
+  }
+  if (coverageGap) {
+    parts.push(coverageGap.summary)
   }
   if (typeof src.latest_age_s === 'number' && Number.isFinite(src.latest_age_s)) {
     parts.push(`age ${formatElapsedCompact(src.latest_age_s)}`)
@@ -609,6 +614,18 @@ function telemetrySourceProvenanceRows(src: TelemetrySourceSummary): Array<{ lab
   if (src.producer) rows.push({ label: 'producer', value: src.producer })
   if (src.durable_store) rows.push({ label: 'store', value: src.durable_store })
   if (src.dashboard_surface) rows.push({ label: 'surface', value: src.dashboard_surface })
+  const coverageGap = coverageGapDisplay(src)
+  for (const detail of coverageGap?.details ?? []) {
+    const separator = detail.indexOf(' ')
+    if (separator <= 0) {
+      rows.push({ label: 'gap', value: detail })
+    } else {
+      rows.push({
+        label: `gap ${detail.slice(0, separator)}`,
+        value: detail.slice(separator + 1),
+      })
+    }
+  }
   return rows
 }
 

--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -48,6 +48,26 @@ const payloadWithCascadeBuckets = {
   ],
 }
 
+const payloadWithCoverageGap = {
+  ...payload,
+  source: 'tool_call_io',
+  health: 'coverage_gap',
+  stale_reason: 'append_failed',
+  coverage_gap_count: 1,
+  coverage_gaps: [
+    {
+      schema: 'masc.telemetry_coverage_gap.v1',
+      source: 'tool_call_io',
+      producer: 'keeper_tool_call_log.append',
+      durable_store: '.masc/tool_calls',
+      dashboard_surface: '/api/v1/dashboard/tool-quality',
+      stale_reason: 'append_failed',
+      trace_id: 'trace-quality-gap',
+      error: 'disk full',
+    },
+  ],
+}
+
 function okJson<T>(body: T) {
   return {
     ok: true,
@@ -162,6 +182,25 @@ describe('ToolQualityPanel', () => {
 
     expect(container.textContent).toContain('캐스케이드별')
     expect(container.textContent).toContain('local_qwen3_27b_only')
+  })
+
+  it('renders tool-quality coverage gap provenance', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okJson(payloadWithCoverageGap))
+    vi.stubGlobal('fetch', fetchMock)
+    const { ToolQualityPanel } = await import('./tool-quality-panel')
+
+    await act(async () => {
+      render(html`<${ToolQualityPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(container.textContent).toContain('coverage gaps 1: append_failed')
+    expect(container.textContent).toContain('producer keeper_tool_call_log.append')
+    expect(container.textContent).toContain('store .masc/tool_calls')
+    expect(container.textContent).toContain('surface /api/v1/dashboard/tool-quality')
+    expect(container.textContent).toContain('trace trace-quality-gap')
+    expect(container.textContent).toContain('error disk full')
   })
 
   it('replaces a stale in-flight request with the newest refresh', async () => {

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -16,7 +16,7 @@ import {
   sharedToolQualityLoading,
 } from './fleet-data-core'
 import { route } from '../router'
-import { sourceHealthClass, freshnessText } from './common/source-health'
+import { sourceHealthClass, freshnessText, coverageGapDisplay } from './common/source-health'
 
 const TOOL_QUALITY_WINDOW_HOURS = 24
 
@@ -301,6 +301,7 @@ export function ToolQualityPanel() {
   if (loading.value && !d) return html`<${LoadingState}>도구 품질 불러오는 중...<//>`
   if (error.value) return html`<${ErrorState} message=${error.value} class="m-4" />`
   if (!d || d.total === 0) return html`<div class="p-4 text-2xs text-[var(--color-fg-disabled)]">도구 호출 데이터 없음</div>`
+  const coverageGap = coverageGapDisplay(d)
 
   return html`
     <div class="flex flex-col gap-4 p-4">
@@ -321,6 +322,12 @@ export function ToolQualityPanel() {
             <span class="mx-1" aria-hidden="true">·</span>
             <span>${(d.entry_count ?? d.total).toLocaleString()} rows</span>
           </div>
+          ${coverageGap ? html`
+            <div class="mt-1 grid gap-0.5 text-3xs text-[var(--color-status-warn)]">
+              <span>${coverageGap.summary}</span>
+              ${coverageGap.details.map(detail => html`<span class="font-mono break-all">${detail}</span>`)}
+            </div>
+          ` : null}
         </div>
         <button
           class="text-3xs px-2 py-0.5 rounded-[var(--r-1)] bg-[var(--bg-subtle)] text-[var(--color-fg-disabled)] hover:text-[var(--text)]"

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -1692,7 +1692,44 @@ let test_tool_calls_route_surfaces_coverage_gap_health () =
     (json |> member "health" |> to_string);
   check string "route surfaces coverage gap stale reason"
     "tool_call_io_append_failed"
-    (json |> member "stale_reason" |> to_string)
+    (json |> member "stale_reason" |> to_string);
+  check int "route surfaces coverage gap rows" 1
+    (json |> member "coverage_gaps" |> to_list |> List.length)
+;;
+
+let test_tool_stats_route_surfaces_coverage_gap_rows () =
+  with_seeded_server
+  @@ fun ~port ~config ~admin_token:_ ~keeper_name ->
+  let masc_root = Masc_mcp.Coord.masc_root_dir config in
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Masc_mcp.Telemetry_coverage_gap.record
+    ~masc_root
+    ~source:"trajectory_tool_call"
+    ~producer:"keeper_hooks_oas.post_tool_use"
+    ~durable_store:(Filename.concat masc_root "trajectories")
+    ~dashboard_surface:"/api/v1/keepers/:name/tool-stats"
+    ~stale_reason:"trajectory_append_failed"
+    ~keeper_name
+    ~trace_id:"trace-tool-stats-gap"
+    ();
+  let result =
+    run_curl_get ~port
+      ~path:(Printf.sprintf "/api/v1/keepers/%s/tool-stats" keeper_name)
+      ()
+  in
+  require_status "tool stats GET returns 200" 200 result;
+  let open Yojson.Safe.Util in
+  let json = Yojson.Safe.from_string result.body in
+  check string "route surfaces trajectory source" "trajectory_tool_call"
+    (json |> member "source" |> to_string);
+  check string "route surfaces tool stats coverage gap health" "coverage_gap"
+    (json |> member "health" |> to_string);
+  check string "route surfaces tool stats stale reason"
+    "trajectory_append_failed"
+    (json |> member "stale_reason" |> to_string);
+  check int "route surfaces tool stats coverage gap rows" 1
+    (json |> member "coverage_gaps" |> to_list |> List.length)
 ;;
 
 let test_merge_keeper_trace_lines_includes_internal_history () =
@@ -1899,6 +1936,10 @@ let () =
             "tool calls route surfaces coverage gap health"
             `Slow
             test_tool_calls_route_surfaces_coverage_gap_health
+        ; test_case
+            "tool stats route surfaces coverage gap rows"
+            `Slow
+            test_tool_stats_route_surfaces_coverage_gap_rows
         ; test_case
             "dashboard dev token rotates legacy dashboard-dev owner"
             `Quick


### PR DESCRIPTION
## Summary
- preserve telemetry coverage gap rows in keeper tool-stats/tool-calls API decoders
- show coverage gap reason plus producer/store/surface/trace/error in keeper tool telemetry freshness lines
- add frontend and route regression coverage so stale tool telemetry does not lose the durable coverage-gap evidence

## Verification
- pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/api/dashboard.test.ts src/components/common/source-health.test.ts src/components/keeper-tool-call-inspector-render.test.ts src/components/keeper-tool-telemetry.test.ts
- pnpm exec tsc --noEmit --pretty
- pnpm exec eslint src/api/dashboard.ts src/api/dashboard.test.ts src/components/common/source-health.ts src/components/common/source-health.test.ts src/components/keeper-tool-call-inspector.ts src/components/keeper-tool-call-inspector-render.test.ts src/components/keeper-tool-telemetry.ts src/components/keeper-tool-telemetry.test.ts
- scripts/dune-local.sh build test/test_dashboard_keeper_routes.exe
- ./_build/default/test/test_dashboard_keeper_routes.exe test dashboard_keeper_routes 14,15 --compact --show-errors
- ocamlformat --check test/test_dashboard_keeper_routes.ml
- git diff --check