### PR TITLE
feat(ide): route context links back to code

### DIFF
--- a/dashboard/src/components/ide/ide-activity-mock.test.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.test.ts
@@ -127,6 +127,7 @@ describe('IdeActivityMock', () => {
 
     const activityRouteLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-activity-route-link')]
     expect(activityRouteLinks.map(link => link.textContent)).toEqual([
+      'Code',
       'Goal',
       'Task',
       'Board',
@@ -137,6 +138,8 @@ describe('IdeActivityMock', () => {
       'Telemetry',
       'Keeper',
     ])
+    fireEvent.click(activityRouteLinks.find(link => link.textContent === 'Code')!)
+    expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=4&surface=PR&label=telemetry.turn&source_id=evt-1&keeper=sangsu')
     fireEvent.click(activityRouteLinks.find(link => link.textContent === 'Telemetry')!)
     expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&session_id=sess-runtime&operation_id=op-runtime&worker_run_id=wr-runtime&q=turn-1')
 
@@ -153,6 +156,7 @@ describe('IdeActivityMock', () => {
       source_id: 'evt-1',
     })
     expect(ideContextFocus.value?.route_links?.map(link => link.label)).toEqual([
+      'Code',
       'Goal',
       'Task',
       'Board',

--- a/dashboard/src/components/ide/ide-activity-mock.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.ts
@@ -563,6 +563,11 @@ function ActivityRow(
   const eventFocusLine = normalizeIdeContextLine(item.context?.line)
   const hasEventContextFocus = eventFocusFile !== null
   const routeLinks = routeLinksForContext({
+    filePath: eventFocusFile ?? undefined,
+    line: eventFocusLine,
+    surface: activityContextSurface(item),
+    label: item.detail ?? `${item.verb} ${item.target}`,
+    sourceId: item.id,
     goalId: item.context?.goal_id,
     taskId: item.context?.task_id,
     boardPostId: item.context?.board_post_id,

--- a/dashboard/src/components/ide/ide-context-lens.test.ts
+++ b/dashboard/src/components/ide/ide-context-lens.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
 import { fireEvent } from '@testing-library/preact'
-import { deriveIdeContextLens, IdeContextLens } from './ide-context-lens'
+import { deriveIdeContextLens, IdeContextLens, routeLinksForContext } from './ide-context-lens'
 import type { IdeAnnotation } from '../../api/schemas/ide-annotations'
 import type { UnifiedDiffRow } from '../../api/workspace'
 import type { AnchoredThread } from './anchored-thread-rail-store'
@@ -328,14 +328,50 @@ describe('IdeContextLens', () => {
     )
 
     const links = [...container.querySelectorAll<HTMLButtonElement>('.ide-context-route-link')]
-    expect(links.map(link => link.textContent)).toEqual(['Goal', 'Task', 'Keeper'])
+    expect(links.map(link => link.textContent)).toEqual(['Code', 'Goal', 'Task', 'Keeper'])
 
-    fireEvent.click(links[0]!)
+    fireEvent.click(links.find(link => link.textContent === 'Goal')!)
     expect(activated[0]).toMatchObject({
       id: 'goal:goal-ide',
       tab: 'workspace',
       params: { section: 'planning', goal: 'goal-ide' },
     })
+  })
+
+  it('routes file and line context back into the Code IDE shell', () => {
+    const links = routeLinksForContext({
+      filePath: ' lib\\runtime.ml ',
+      line: 42,
+      surface: 'Task',
+      label: 'Runtime task',
+      sourceId: 'task:runtime',
+      keeperId: 'sangsu',
+    })
+
+    expect(links[0]).toMatchObject({
+      id: 'code:lib/runtime.ml:42',
+      label: 'Code',
+      tab: 'code',
+      params: {
+        section: 'ide-shell',
+        view: 'source',
+        file: 'lib/runtime.ml',
+        line: '42',
+        surface: 'Task',
+        label: 'Runtime task',
+        source_id: 'task:runtime',
+        keeper: 'sangsu',
+      },
+      evidence: 'Code lib/runtime.ml:42',
+    })
+  })
+
+  it('does not build Code routes for unsafe file paths', () => {
+    expect(routeLinksForContext({
+      filePath: '/tmp/runtime.ml',
+      line: 42,
+      goalId: 'goal-ide',
+    }).map(link => link.label)).toEqual(['Goal'])
   })
 
   it('links conversation threads into board, comment, keeper, and line context', () => {
@@ -406,6 +442,7 @@ describe('IdeContextLens', () => {
     })
     expect(model.anchors[0]?.meta).toContain('goal goal-ide')
     expect(model.anchors[0]?.route_links?.map(link => link.label)).toEqual([
+      'Code',
       'Goal',
       'Task',
       'Board',
@@ -419,6 +456,18 @@ describe('IdeContextLens', () => {
     expect(model.anchors[0]?.route_links?.find(link => link.label === 'Comment')).toMatchObject({
       tab: 'workspace',
       params: { section: 'board', post: 'post-1', comment: 'comment-1' },
+    })
+    expect(model.anchors[0]?.route_links?.find(link => link.label === 'Code')).toMatchObject({
+      tab: 'code',
+      params: {
+        section: 'ide-shell',
+        view: 'source',
+        file: 'lib/keeper/keeper_exec_ide.ml',
+        line: '27',
+        surface: 'Comment',
+        source_id: 'event-evt-context',
+        keeper: 'sangsu',
+      },
     })
     expect(model.anchors[0]?.route_links?.find(link => link.label === 'Log')).toMatchObject({
       tab: 'monitoring',

--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -8,7 +8,7 @@ import { KeeperBadge } from '../keeper-badge'
 import type { AnchoredThread } from './anchored-thread-rail-store'
 import type { KeeperCursorOverlay } from './keeper-cursor-overlay'
 import type { RunActivityEvent } from './run-activity-store'
-import { focusIdeContextAnchor, normalizeIdeContextFilePath } from './ide-state'
+import { focusIdeContextAnchor, normalizeIdeContextFilePath, normalizeIdeContextLine } from './ide-state'
 
 type SurfaceStatus = 'linked' | 'quiet'
 
@@ -62,6 +62,11 @@ export interface IdeContextRouteLink {
 }
 
 export interface IdeContextRouteContext {
+  readonly filePath?: string
+  readonly line?: number
+  readonly surface?: string
+  readonly label?: string
+  readonly sourceId?: string
   readonly goalId?: string
   readonly taskId?: string
   readonly boardPostId?: string
@@ -131,7 +136,7 @@ const SURFACE_ORDER: ReadonlyArray<IdeContextSurfaceId> = [
   'telemetry',
 ]
 const MAX_CONTEXT_ANCHORS = 6
-const MAX_CONTEXT_ROUTE_LINKS = 9
+const MAX_CONTEXT_ROUTE_LINKS = 10
 
 export function deriveIdeContextLens(input: IdeContextLensInput): IdeContextLensModel {
   const filePath = normalizeIdeContextFilePath(input.filePath)
@@ -517,6 +522,11 @@ function buildAnchors(
       line: positiveLine(annotation.line_start),
       keeper_id: annotation.keeper_id,
       route_links: routeLinksForContext({
+        filePath: annotation.file_path,
+        line: positiveLine(annotation.line_start),
+        surface: annotation.kind,
+        label: truncate(annotation.content || 'annotation', 48),
+        sourceId: `annotation-${annotation.id}`,
         goalId: annotation.goal_id ?? undefined,
         taskId: annotation.task_id ?? undefined,
         keeperId: annotation.keeper_id,
@@ -536,7 +546,14 @@ function buildAnchors(
       ]),
       line: cursor.line,
       keeper_id: cursor.keeper_id,
-      route_links: routeLinksForContext({ keeperId: cursor.keeper_id }),
+      route_links: routeLinksForContext({
+        filePath,
+        line: cursor.line,
+        surface: 'Line',
+        label: cursor.tool_name ?? cursor.focus_mode,
+        sourceId: `cursor-${cursor.keeper_id}-${cursor.line}`,
+        keeperId: cursor.keeper_id,
+      }),
     })
   }
 
@@ -554,6 +571,11 @@ function buildAnchors(
       line: positiveLine(thread.anchor.line_start),
       keeper_id: thread.author_keeper_id,
       route_links: routeLinksForContext({
+        filePath: thread.anchor.file_path,
+        line: positiveLine(thread.anchor.line_start),
+        surface: thread.kind.toUpperCase(),
+        label: truncate(thread.body, 48),
+        sourceId: `thread-${thread.id}`,
         boardPostId: thread.id,
         keeperId: thread.author_keeper_id,
       }),
@@ -570,7 +592,14 @@ function buildAnchors(
       label: `${additions} add / ${deletions} delete`,
       meta: 'working diff for current file',
       line: positiveLine(firstChangedLine(changedRows)),
-      route_links: routeLinksForContext({ gitRef: 'HEAD' }),
+      route_links: routeLinksForContext({
+        filePath,
+        line: positiveLine(firstChangedLine(changedRows)),
+        surface: 'Git',
+        label: 'working diff for current file',
+        sourceId: 'git-diff-summary',
+        gitRef: 'HEAD',
+      }),
     })
   }
 
@@ -585,6 +614,11 @@ function buildAnchors(
       line: eventLineForFile(event, filePath),
       keeper_id: event.keeper_id,
       route_links: routeLinksForContext({
+        filePath: event.context?.file_path ?? filePath,
+        line: eventLineForFile(event, filePath),
+        surface: surfaceFromEvent(event, eventSearchTextByEvent),
+        label: truncate(event.detail || `${event.verb} ${event.target}`, 48),
+        sourceId: `event-${event.id}`,
         goalId: event.context?.goal_id,
         taskId: event.context?.task_id,
         boardPostId: event.context?.board_post_id,
@@ -728,6 +762,31 @@ export function routeLinksForContext(
     if (links.some(existing => existing.id === link.id)) return
     links.push(link)
   }
+  const keeperId = cleanId(context.keeperId)
+  const filePath = context.filePath ? normalizeIdeContextFilePath(context.filePath) : null
+  if (filePath) {
+    const line = normalizeIdeContextLine(context.line)
+    const params: Record<string, string> = {
+      section: 'ide-shell',
+      view: 'source',
+      file: filePath,
+    }
+    if (line !== undefined) params.line = String(line)
+    const surface = cleanId(context.surface)
+    if (surface) params.surface = surface
+    const label = cleanId(context.label)
+    if (label) params.label = label
+    const sourceId = cleanId(context.sourceId)
+    if (sourceId) params.source_id = sourceId
+    if (keeperId && keeperId !== 'system') params.keeper = keeperId
+    add({
+      id: `code:${filePath}${line !== undefined ? `:${line}` : ''}`,
+      label: 'Code',
+      tab: 'code',
+      params,
+      evidence: `Code ${filePath}${line !== undefined ? `:${line}` : ''}`,
+    })
+  }
   const goalId = cleanId(context.goalId)
   if (goalId) {
     add({
@@ -831,7 +890,6 @@ export function routeLinksForContext(
         : 'Fleet telemetry event log',
     })
   }
-  const keeperId = cleanId(context.keeperId)
   if (keeperId && keeperId !== 'system') {
     add({
       id: `keeper:${keeperId}`,

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -403,7 +403,9 @@ export function normalizeRouteParams(tabId: TabId, params: Record<string, string
     next.section = defaultParamsForTab(tabId).section ?? ''
   }
 
-  delete next.surface
+  if (!(tabId === 'code' && next.section === 'ide-shell')) {
+    delete next.surface
+  }
   delete next.operation
   delete next.run_id
 

--- a/dashboard/src/router.test.ts
+++ b/dashboard/src/router.test.ts
@@ -109,6 +109,28 @@ describe('navigate', () => {
     expect(route.value.params.branch).toBe('main')
   })
 
+  it('preserves IDE context surface params on Code routes', () => {
+    navigate('code', {
+      section: 'ide-shell',
+      view: 'source',
+      file: 'lib/runtime.ml',
+      line: '42',
+      surface: 'Task',
+      source_id: 'task:runtime',
+    })
+
+    expect(route.value.tab).toBe('code')
+    expect(route.value.params).toMatchObject({
+      section: 'ide-shell',
+      view: 'source',
+      file: 'lib/runtime.ml',
+      line: '42',
+      surface: 'Task',
+      source_id: 'task:runtime',
+    })
+    expect(window.location.hash).toContain('surface=Task')
+  })
+
   it('keeps explicit production sections stronger than cockpit mode aliases', () => {
     window.location.hash = '#monitoring?section=runtime&mode=Cognition'
     window.dispatchEvent(new HashChangeEvent('hashchange'))


### PR DESCRIPTION
## Summary

- add safe Code route links to IDE context route bundles
- wire activity/context-lens file metadata into those Code links
- preserve IDE route `surface` metadata for Code deep links

## Product impact

IDE activity and context lens links can now route back into the Code IDE when a telemetry/log/keeper record carries safe file/line context. This closes the navigation loop added by the route focus hydrator: operational surfaces can point to the exact IDE file focus instead of only exposing Goal/Task/Board/PR/Git/Log/Telemetry/Keeper links.

## Evidence

- `pnpm install --offline --frozen-lockfile`
- `pnpm exec eslint src/components/ide/ide-context-lens.ts src/components/ide/ide-activity-mock.ts src/components/ide/ide-context-lens.test.ts src/components/ide/ide-activity-mock.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-context-lens.test.ts src/components/ide/ide-activity-mock.test.ts src/router.test.ts`
- `git diff --check`

## Review evidence

- Added regression coverage for safe `Code` route construction from file/line context.
- Added regression coverage that unsafe absolute file paths do not produce Code routes.
- Added route coverage that `code?section=ide-shell` preserves IDE `surface` metadata.
- Added activity coverage that clicking the Code link produces a canonical `#code?section=ide-shell&view=source...` hash.

## Linked issue

Follow-up slice for the persistent-agent IDE progress wiring objective; no standalone GitHub issue was opened for this narrow dashboard polish increment.
