### PR TITLE
fix(dashboard): surface tool usage coverage gaps

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -309,6 +309,55 @@ describe('fetchDashboardTools', () => {
     const result = await fetchDashboardTools()
     expect(result.tool_inventory).toBeDefined()
   })
+
+  it('preserves tool usage coverage gap rows', async () => {
+    const rawResponse = {
+      tool_inventory: { tools: [] },
+      tool_usage: {
+        total_calls: 0,
+        distinct_tools_called: 0,
+        top_20: [],
+        never_called_count: 0,
+        dispatch_v2_enabled: false,
+        registered_count: 0,
+        source: 'tool_usage',
+        health: 'coverage_gap',
+        stale_reason: 'tool_usage_append_failed',
+        coverage_gap_count: 1,
+        coverage_gaps: [
+          {
+            schema: 'masc.telemetry_coverage_gap.v1',
+            source: 'tool_usage',
+            producer: 'tool_usage_log',
+            durable_store: '.masc/tool_usage',
+            dashboard_surface: '/api/v1/dashboard/tools',
+            stale_reason: 'tool_usage_append_failed',
+            error: 'synthetic append failure',
+          },
+        ],
+      },
+    }
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchDashboardTools()
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/tools')
+    expect(result.tool_usage.coverage_gap_count).toBe(1)
+    expect(result.tool_usage.coverage_gaps?.[0]).toMatchObject({
+      producer: 'tool_usage_log',
+      durable_store: '.masc/tool_usage',
+      dashboard_surface: '/api/v1/dashboard/tools',
+      stale_reason: 'tool_usage_append_failed',
+      error: 'synthetic append failure',
+    })
+  })
 })
 
 describe('fetchToolQuality', () => {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1719,19 +1719,7 @@ export interface ToolMetricsTopEntry {
   call_count: number
 }
 
-export interface ToolMetricsResponse {
-  source?: string
-  producer?: string
-  durable_store?: string
-  dashboard_surface?: string
-  freshness_slo_s?: number | null
-  latest_ts_unix?: number | null
-  latest_ts_iso?: string | null
-  latest_age_s?: number | null
-  health?: string
-  stale_reason?: string | null
-  entry_count?: number
-  exists?: boolean
+export interface ToolMetricsResponse extends TelemetryFreshnessMetadata {
   total_calls: number
   distinct_tools_called: number
   top_20: ToolMetricsTopEntry[]

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   loadTools: vi.fn(),
-  toolsData: { value: null as null | { generated_at?: string; tool_inventory: { tools: unknown[] }; tool_usage: { registered_count: number; distinct_tools_called: number; never_called_count: number } } },
+  toolsData: { value: null as null | { generated_at?: string; tool_inventory: { tools: unknown[] }; tool_usage: Record<string, unknown> & { registered_count: number; distinct_tools_called: number; never_called_count: number } } },
   toolsLoading: { value: false },
   toolsError: { value: null as string | null },
 }))
@@ -82,5 +82,41 @@ describe('Tools', () => {
     expect(container.textContent).toContain('도구 사용 현황')
     expect(container.textContent).toContain('ToolMetrics')
     expect(container.textContent).toContain('PromptRegistryPanel')
+  })
+
+  it('renders tool usage coverage gap provenance', async () => {
+    mocks.toolsData.value = {
+      tool_inventory: { tools: [] },
+      tool_usage: {
+        registered_count: 0,
+        distinct_tools_called: 0,
+        never_called_count: 0,
+        source: 'tool_usage',
+        health: 'coverage_gap',
+        stale_reason: 'tool_usage_append_failed',
+        entry_count: 0,
+        coverage_gap_count: 1,
+        coverage_gaps: [
+          {
+            schema: 'masc.telemetry_coverage_gap.v1',
+            source: 'tool_usage',
+            producer: 'tool_usage_log',
+            durable_store: '.masc/tool_usage',
+            dashboard_surface: '/api/v1/dashboard/tools',
+            stale_reason: 'tool_usage_append_failed',
+            error: 'synthetic append failure',
+          },
+        ],
+      },
+    }
+
+    render(html`<${Tools} />`, container)
+    await flush()
+
+    expect(container.textContent).toContain('coverage gaps 1: tool_usage_append_failed')
+    expect(container.textContent).toContain('producer tool_usage_log')
+    expect(container.textContent).toContain('store .masc/tool_usage')
+    expect(container.textContent).toContain('surface /api/v1/dashboard/tools')
+    expect(container.textContent).toContain('error synthetic append failure')
   })
 })

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -17,7 +17,7 @@ import { ConfigResolutionPanel } from './config-resolution-panel'
 import { ActionButton } from '../common/button'
 import { ToolExecutor } from '../tool-executor/tool-executor'
 import { formatElapsedCompact } from '../../lib/format-time'
-import { sourceHealthClass } from '../common/source-health'
+import { sourceHealthClass, coverageGapDisplay } from '../common/source-health'
 
 type ToolsView = 'inventory' | 'executor'
 const activeView = signal<ToolsView>('inventory')
@@ -35,6 +35,7 @@ export function Tools() {
   const error = toolsError.value
   const inventory = data?.tool_inventory.tools ?? []
   const usage = data?.tool_usage ?? null
+  const usageCoverageGap = usage ? coverageGapDisplay(usage) : null
 
   useEffect(() => {
     if (!toolsData.value && !toolsLoading.value) {
@@ -79,6 +80,12 @@ export function Tools() {
                 <span class="mx-1">·</span>
                 <span>${(usage.entry_count ?? 0).toLocaleString()} durable rows</span>
               </div>
+              ${usageCoverageGap ? html`
+                <div class="mb-2 grid gap-0.5 text-3xs text-[var(--color-status-warn)]">
+                  <span>${usageCoverageGap.summary}</span>
+                  ${usageCoverageGap.details.map(detail => html`<span class="font-mono break-all">${detail}</span>`)}
+                </div>
+              ` : null}
             `
           : null}
         <${ToolMetrics} />


### PR DESCRIPTION
## Summary
- Preserve tool_usage coverage_gaps metadata in the dashboard tools API type.
- Render tool usage coverage gap provenance in the Tools surface so operators see producer, store, surface, and error details.
- Add API and Tools component regression coverage.

## Verification
- pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/api/dashboard.test.ts src/components/common/source-health.test.ts src/components/tools/tools-main.test.ts
- pnpm exec tsc --noEmit --pretty
- pnpm exec eslint src/api/dashboard.ts src/api/dashboard.test.ts src/components/common/source-health.ts src/components/common/source-health.test.ts src/components/tools/tools-main.ts src/components/tools/tools-main.test.ts
- git diff --check HEAD~1..HEAD