### PR TITLE
[codex] label BDI telemetry units

### DIFF
--- a/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
@@ -121,6 +121,7 @@ describe('InspectorKeeperBDI', () => {
     expect(container.textContent).toContain('line ownership needs inspection')
     expect(container.textContent).toContain('165 tok')
     expect(container.textContent).toContain('keeper_bash')
+    expect(container.textContent).toContain('42ms')
 
     render(null, container)
   })

--- a/dashboard/src/components/ide/inspector-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.ts
@@ -159,6 +159,12 @@ function formatTokens(value: number | null): string {
   return value === null ? '—' : value.toLocaleString()
 }
 
+function formatDurationMs(value: number | null): string {
+  if (value === null || !Number.isFinite(value) || value < 0) return '—'
+  if (value < 1000) return `${Math.round(value).toLocaleString()}ms`
+  return `${(value / 1000).toFixed(1)}s`
+}
+
 function formatAge(value: string | null): string {
   if (!value) return '—'
   return value.slice(11, 19)
@@ -374,6 +380,9 @@ export function InspectorKeeperBDI({
         </span>
         ${lastTool?.semantic_outcome
           ? html`<span style=${{ color: lastTool.success === false ? 'var(--color-status-warn)' : 'var(--color-status-ok)' }}>${lastTool.semantic_outcome}</span>`
+          : null}
+        ${lastTool?.duration_ms !== null && lastTool?.duration_ms !== undefined
+          ? html`<span style=${{ color: 'var(--color-fg-secondary)', fontFamily: 'var(--font-mono)' }}>${formatDurationMs(lastTool.duration_ms)}</span>`
           : null}
       </div>
 

--- a/dashboard/src/components/ide/inspector-multi-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-multi-keeper-bdi.test.ts
@@ -312,6 +312,10 @@ describe('InspectorMultiKeeperBDI — focus-mode layout (RFC-0027 §5, exactly P
     expect(chips.length).toBe(3)
     const chipNames = Array.from(chips).map(c => c.getAttribute('data-keeper'))
     expect(chipNames).toEqual(['luna', 'moth', 'scholar'])
+    await vi.waitFor(() => {
+      const chipText = Array.from(chips).map(c => c.textContent ?? '').join(' ')
+      expect(chipText).toContain('165 tok')
+    })
   })
 
   it('clicking a chip promotes that keeper to the focused slot', async () => {

--- a/dashboard/src/components/ide/inspector-multi-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-multi-keeper-bdi.ts
@@ -423,7 +423,7 @@ function KeeperChip({ entry, slot, dropIdx, presence, overlay, onFocus, onUnpin 
           />
         ` : null}
         ${entry.line !== null ? html`<span style=${{ color: 'var(--color-fg-muted)' }}>L${entry.line}</span>` : null}
-        ${tokens !== null ? html`<span style=${{ color: 'var(--color-fg-muted)' }}>${tokens.toLocaleString()}</span>` : null}
+        ${tokens !== null ? html`<span style=${{ color: 'var(--color-fg-muted)' }}>${formatTokenCount(tokens)}</span>` : null}
       </button>
       ${focusLabel ? html`
         <button


### PR DESCRIPTION
## Summary

- Show Keeper BDI `duration_ms` in the Last Tool row with explicit `ms`/`s` units.
- Reuse the existing multi-keeper token formatter so focus-mode keeper chips show `tok` instead of bare numbers.

## Why

The dashboard audit called out BDI telemetry values that had lost semantic units in the UI. The telemetry was already present in the payload; this change makes the existing values reviewable without guessing the unit.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/components/ide/inspector-keeper-bdi.test.ts src/components/ide/inspector-multi-keeper-bdi.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/ide/inspector-keeper-bdi.ts src/components/ide/inspector-multi-keeper-bdi.ts src/components/ide/inspector-keeper-bdi.test.ts src/components/ide/inspector-multi-keeper-bdi.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`
