### PR TITLE
fix(dashboard): pick newest coverage gap (follow-up #15099)

### DIFF
--- a/dashboard/src/components/common/source-health.test.ts
+++ b/dashboard/src/components/common/source-health.test.ts
@@ -50,4 +50,45 @@ describe('coverageGapDisplay', () => {
       ],
     })
   })
+
+  it('selects the newest gap (last element) when multiple gaps are present', () => {
+    // Backends emit coverage_gaps in oldest→newest order; the UI must show the
+    // most recent incident, not the first one in the list.
+    const display = coverageGapDisplay({
+      source: 'tool_call_io',
+      coverage_gap_count: 2,
+      coverage_gaps: [
+        {
+          source: 'tool_call_io',
+          producer: 'OLD-producer',
+          durable_store: 'OLD-store',
+          dashboard_surface: 'OLD-surface',
+          stale_reason: 'OLD_reason',
+          trace_id: 'OLD-trace',
+          error: 'OLD-error',
+        },
+        {
+          source: 'tool_call_io',
+          producer: 'NEW-producer',
+          durable_store: 'NEW-store',
+          dashboard_surface: 'NEW-surface',
+          stale_reason: 'NEW_reason',
+          trace_id: 'NEW-trace',
+          error: 'NEW-error',
+        },
+      ],
+    })
+
+    expect(display).toEqual({
+      count: 2,
+      summary: 'coverage gaps 2: NEW_reason',
+      details: [
+        'producer NEW-producer',
+        'store NEW-store',
+        'surface NEW-surface',
+        'trace NEW-trace',
+        'error NEW-error',
+      ],
+    })
+  })
 })

--- a/dashboard/src/components/common/source-health.ts
+++ b/dashboard/src/components/common/source-health.ts
@@ -41,8 +41,15 @@ function nonEmpty(value?: string | null): string | null {
   return trimmed ? trimmed : null
 }
 
+// Backends emit `coverage_gaps` in oldest→newest order (see
+// `lib/dashboard/dashboard_http_keeper.ml`, `lib/dashboard_tool_source_freshness.ml`,
+// `lib/server/server_dashboard_http_keeper_api.ml` — each derives "latest" via
+// `List.rev coverage_gaps |> List.find_opt`). Pick the tail so the UI surfaces
+// provenance for the *current* incident, not a stale one.
 function latestCoverageGap(d: TelemetryFreshnessMetadata): TelemetryCoverageGap | null {
-  return d.coverage_gaps?.[0] ?? null
+  const gaps = d.coverage_gaps
+  if (!gaps || gaps.length === 0) return null
+  return gaps[gaps.length - 1] ?? null
 }
 
 export type CoverageGapDisplay = {


### PR DESCRIPTION
## 배경

PR #15099 의 Codex review 에서 P1 finding 한 건이 unresolved 상태로 main 에 머지되었습니다.

`source-health.ts` 의 `latestCoverageGap` helper 가 `coverage_gaps?.[0]` (= 가장 오래된 항목) 을 선택하지만, 백엔드의 4개 emit 지점 모두 `coverage_gaps` 를 **oldest→newest** 순으로 직렬화합니다:

- `lib/dashboard/dashboard_http_keeper.ml:1319` — `List.rev coverage_gaps |> List.find_opt`
- `lib/dashboard_tool_source_freshness.ml:114` — 동일
- `lib/server/server_dashboard_http_keeper_api.ml:2249, 2345` — 동일

결과적으로 다중 gap 상황에서 UI 는 **현재 outage** 의 provenance (producer/store/trace/error) 대신 **이전 incident** 의 정보를 표시하면서, count 와 stale_reason 은 서버측 latest 와 일치 — 운영자에게 split-view 오방향 신호를 줍니다.

## 변경

- `dashboard/src/components/common/source-health.ts`: `coverage_gaps?.[0]` → `gaps[gaps.length - 1]`. 백엔드 ordering contract 를 inline comment 로 명시.
- `dashboard/src/components/common/source-health.test.ts`: OLD/NEW 필드가 서로 다른 두 gap 을 가진 회귀 테스트 추가. 기존 single-gap 테스트로는 이 버그가 잡히지 않습니다.

## 검증

```
npx vitest run --config vitest.config.ts src/components/common/source-health.test.ts
Test Files  1 passed (1)
     Tests  4 passed (4)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)