### PR TITLE
feat(ide): link keeper tool calls to code

### DIFF
--- a/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
@@ -84,6 +84,87 @@ describe('KeeperToolCallInspector render', () => {
     expect(outputCopy?.getAttribute('title')).toBe('도구 호출 출력 복사')
   })
 
+  it('links safe tool-call file inputs back to the Code IDE route', async () => {
+    const fetchKeeperToolCalls = vi.fn().mockResolvedValue({
+      keeper: 'analyst',
+      count: 1,
+      source: 'tool_call_io',
+      health: 'ok',
+      entries: [
+        {
+          ts: 1_777_100_000,
+          keeper: 'analyst',
+          tool: 'keeper_fs_read',
+          input: { file_path: 'lib/runtime.ml', line: 12 },
+          output: 'file contents',
+          success: true,
+          duration_ms: 42,
+        },
+      ],
+    })
+
+    const { KeeperToolCallInspector } = await loadInspector(fetchKeeperToolCalls)
+    await act(async () => {
+      render(html`<${KeeperToolCallInspector} keeperName="analyst" />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const rowToggle = container.querySelector('button[aria-expanded="false"]') as HTMLButtonElement | null
+    await act(async () => {
+      rowToggle?.click()
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const codeLink = container.querySelector('[data-testid="keeper-tool-code-link"]') as HTMLButtonElement | null
+    expect(codeLink).not.toBeNull()
+    expect(codeLink?.textContent).toBe('Code')
+    expect(codeLink?.getAttribute('title')).toBe('Code lib/runtime.ml:12')
+
+    await act(async () => {
+      codeLink?.click()
+      await Promise.resolve()
+    })
+    expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=12&surface=Tool&label=keeper_fs_read&source_id=tool%3Aanalyst%3A1777100000%3Akeeper_fs_read&keeper=analyst')
+  })
+
+  it('does not render Code links for unsafe absolute tool-call file inputs', async () => {
+    const fetchKeeperToolCalls = vi.fn().mockResolvedValue({
+      keeper: 'analyst',
+      count: 1,
+      source: 'tool_call_io',
+      health: 'ok',
+      entries: [
+        {
+          ts: 1_777_100_000,
+          keeper: 'analyst',
+          tool: 'keeper_fs_read',
+          input: { file_path: '/tmp/runtime.ml', line: 12 },
+          output: 'file contents',
+          success: true,
+          duration_ms: 42,
+        },
+      ],
+    })
+
+    const { KeeperToolCallInspector } = await loadInspector(fetchKeeperToolCalls)
+    await act(async () => {
+      render(html`<${KeeperToolCallInspector} keeperName="analyst" />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const rowToggle = container.querySelector('button[aria-expanded="false"]') as HTMLButtonElement | null
+    await act(async () => {
+      rowToggle?.click()
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="keeper-tool-code-link"]')).toBeNull()
+  })
+
   it('surfaces coverage gap provenance when tool-call IO is stale', async () => {
     const fetchKeeperToolCalls = vi.fn().mockResolvedValue({
       keeper: 'analyst',

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -16,6 +16,7 @@ import { CopyIdButton } from './common/copy-id-button'
 import { TextInput } from './common/input'
 import { ringFocusClasses } from './common/ring'
 import { coverageGapDisplay, sourceHealthClass, freshnessText } from './common/source-health'
+import { openIdeContextRouteLink, routeLinksForContext, type IdeContextRouteLink } from './ide/ide-context-lens'
 
 // Delegated to lib/format-time (SSOT)
 const formatTimestamp = formatTimeHms
@@ -59,6 +60,59 @@ function tryPrettyJson(s: string): string | null {
   } catch {
     return null
   }
+}
+
+interface ToolCodeLocation {
+  readonly filePath: string
+  readonly line?: number
+}
+
+function stringField(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
+}
+
+function positiveLine(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 1
+    ? value
+    : undefined
+}
+
+function inputCodeLocation(input: unknown): ToolCodeLocation | null {
+  if (typeof input === 'string') {
+    const parsed = tryPrettyJson(input)
+    if (!parsed) return null
+    try {
+      return inputCodeLocation(JSON.parse(input))
+    } catch {
+      return null
+    }
+  }
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) return null
+  const record = input as Record<string, unknown>
+  const filePath =
+    stringField(record.file_path)
+    ?? stringField(record.path)
+    ?? stringField(record.file)
+  if (filePath) {
+    return {
+      filePath,
+      line: positiveLine(record.line) ?? positiveLine(record.line_start) ?? positiveLine(record.lineno),
+    }
+  }
+  return inputCodeLocation(record.input)
+}
+
+function toolCallCodeRouteLink(entry: ToolCallEntry): IdeContextRouteLink | null {
+  const location = inputCodeLocation(entry.input)
+  if (!location) return null
+  return routeLinksForContext({
+    filePath: location.filePath,
+    line: location.line,
+    surface: 'Tool',
+    label: entry.tool,
+    sourceId: `tool:${entry.keeper}:${entry.ts}:${entry.tool}`,
+    keeperId: entry.keeper,
+  }).find(link => link.label === 'Code') ?? null
 }
 
 // Tool output may be (a) a raw string, (b) a JSON blob we logged as a string,
@@ -119,6 +173,7 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
   const cat = toolCategory(entry.tool)
   const formattedInput = formatInput(entry.input)
   const formattedOutput = formatOutput(entry.output)
+  const codeRouteLink = toolCallCodeRouteLink(entry)
 
   return html`
     <div
@@ -148,6 +203,23 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
         <div class="px-3 pb-3 space-y-2">
           ${entry.model ? html`
             <div class="text-3xs text-[var(--color-fg-muted)]">model: <span class="text-[var(--color-fg-secondary)] font-mono">${entry.model}</span></div>
+          ` : null}
+          ${codeRouteLink ? html`
+            <div class="flex items-center justify-between gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-2">
+              <span class="min-w-0 truncate text-3xs font-mono text-[var(--color-fg-muted)]" title=${codeRouteLink.evidence}>
+                ${codeRouteLink.evidence}
+              </span>
+              <button
+                type="button"
+                data-testid="keeper-tool-code-link"
+                class=${`shrink-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 text-3xs font-semibold text-[var(--color-accent-fg)] hover:border-[var(--color-accent-border)] hover:bg-[var(--color-bg-hover)] ${ringFocusClasses()}`}
+                title=${codeRouteLink.evidence}
+                aria-label=${`Open ${codeRouteLink.evidence}`}
+                onClick=${() => openIdeContextRouteLink(codeRouteLink)}
+              >
+                Code
+              </button>
+            </div>
           ` : null}
           <${CopyableToolCallBlock}
             title="입력"


### PR DESCRIPTION
## Summary

- add a Code deep-link row to expanded keeper tool-call inspector rows when input carries safe file context
- reuse `routeLinksForContext` so the inspector lands on `code?section=ide-shell&view=source`
- keep unsafe absolute paths hidden from Code routing

## Product impact

Keeper tool-call IO now connects directly back to the IDE when a tool input includes relative `file_path`/`path`/`file` metadata. Operators can inspect the exact code location from the keeper tool inspector without manually copying file paths out of JSON.

## Evidence

- `pnpm install --offline --frozen-lockfile`
- `pnpm exec eslint src/components/keeper-tool-call-inspector.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/keeper-tool-call-inspector-render.test.ts src/components/ide/ide-context-lens.test.ts src/router.test.ts`
- `git diff --check`

## Review evidence

- Added render coverage that relative `file_path` + `line` in keeper tool input produces a canonical Code IDE hash.
- Added render coverage that absolute `/tmp/...` tool input does not show a Code route.
- Reused the shared IDE route helper so path validation stays aligned with context-lens and activity routing.

## Linked issue

Follow-up slice for the persistent-agent IDE progress wiring objective; no standalone GitHub issue was opened for this narrow keeper-tool inspector increment.
