### PR TITLE
fix(dashboard): surface execution trust source health

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   fetchDashboardShell,
+  fetchDashboardExecutionTrust,
   fetchDashboardGovernance,
   fetchDashboardGoalDetail,
   fetchDashboardGoalsTree,
@@ -88,6 +89,58 @@ describe('fetchDashboardShell', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/shell?light=true')
+  })
+})
+
+describe('fetchDashboardExecutionTrust', () => {
+  it('requests the dedicated execution trust surface and preserves coverage gaps', async () => {
+    const rawResponse = {
+      generated_at: '2026-05-14T00:00:00Z',
+      source: 'execution_receipt',
+      producer: 'keeper_agent_run.execution_receipt',
+      durable_store: '.masc/keepers/*/execution-receipts',
+      dashboard_surface: '/api/v1/dashboard/execution-trust',
+      freshness_slo_s: 900,
+      entry_count: 0,
+      total: 0,
+      keepers: [],
+      health: 'coverage_gap',
+      stale_reason: 'execution_receipt_append_failed',
+      coverage_gap_count: 1,
+      coverage_gaps: [
+        {
+          schema: 'masc.telemetry_coverage_gap.v1',
+          source: 'execution_receipt',
+          producer: 'keeper_agent_run.execution_receipt',
+          durable_store: '.masc/keepers/*/execution-receipts',
+          dashboard_surface: '/api/v1/dashboard/execution-trust',
+          stale_reason: 'execution_receipt_append_failed',
+          keeper_name: 'sangsu',
+          trace_id: 'trace-exec-gap',
+        },
+      ],
+    }
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchDashboardExecutionTrust()
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/execution-trust')
+    expect(result.coverage_gap_count).toBe(1)
+    expect(result.coverage_gaps?.[0]).toMatchObject({
+      producer: 'keeper_agent_run.execution_receipt',
+      durable_store: '.masc/keepers/*/execution-receipts',
+      dashboard_surface: '/api/v1/dashboard/execution-trust',
+      stale_reason: 'execution_receipt_append_failed',
+      keeper_name: 'sangsu',
+      trace_id: 'trace-exec-gap',
+    })
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -212,6 +212,27 @@ export function fetchDashboardExecution(opts?: AbortableRequestOptions): Promise
   return get('/api/v1/dashboard/execution', { signal: opts?.signal })
 }
 
+export type DashboardExecutionTrustKeeper = Record<string, unknown> & {
+  name?: string
+  agent_name?: string | null
+  keeper_id?: string | null
+  phase?: string | null
+  pipeline_stage?: string | null
+  status?: string | null
+  trace_id?: string | null
+  trust?: unknown
+}
+
+export type DashboardExecutionTrustResponse = TelemetryFreshnessMetadata & {
+  generated_at?: string
+  total: number
+  keepers: DashboardExecutionTrustKeeper[]
+}
+
+export function fetchDashboardExecutionTrust(opts?: AbortableRequestOptions): Promise<DashboardExecutionTrustResponse> {
+  return get<DashboardExecutionTrustResponse>('/api/v1/dashboard/execution-trust', { signal: opts?.signal })
+}
+
 type ToolQualityToolStat = {
   name: string
   calls: number

--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { TelemetrySummaryResponse, ToolQualityResponse } from '../api/dashboard'
+import type { DashboardExecutionTrustResponse, TelemetrySummaryResponse, ToolQualityResponse } from '../api/dashboard'
 import { normalizeKeepers } from '../keeper-store-normalize'
 import type { DashboardExecutionResponse, DashboardNamespaceTruthResponse } from '../types'
 const executionResponse = {
@@ -53,6 +53,20 @@ const toolQualityResponse: ToolQualityResponse = {
     },
   ],
   hourly_trend: [],
+}
+
+const executionTrustResponse: DashboardExecutionTrustResponse = {
+  generated_at: '2026-04-09T08:10:30Z',
+  source: 'execution_receipt',
+  producer: 'keeper_agent_run.execution_receipt',
+  durable_store: '.masc/keepers/*/execution-receipts',
+  dashboard_surface: '/api/v1/dashboard/execution-trust',
+  freshness_slo_s: 900,
+  latest_age_s: 37,
+  health: 'ok',
+  entry_count: 2,
+  total: 2,
+  keepers: [],
 }
 
 const telemetrySummaryResponse: TelemetrySummaryResponse = {
@@ -182,6 +196,7 @@ function requireResolver<T>(
 
 async function loadPanel(mocks: {
   fetchDashboardExecution: (opts?: { signal?: AbortSignal }) => Promise<DashboardExecutionResponse>
+  fetchDashboardExecutionTrust?: (opts?: { signal?: AbortSignal }) => Promise<DashboardExecutionTrustResponse>
   fetchToolQuality: (opts?: { n?: number; windowHours?: number; signal?: AbortSignal }) => Promise<ToolQualityResponse>
   fetchTelemetrySummary: (opts?: { signal?: AbortSignal }) => Promise<TelemetrySummaryResponse>
   fetchDashboardNamespaceTruth?: (opts?: { signal?: AbortSignal }) => Promise<DashboardNamespaceTruthResponse>
@@ -189,6 +204,9 @@ async function loadPanel(mocks: {
   vi.resetModules()
   vi.doMock('../api/dashboard', () => ({
     fetchDashboardExecution: mocks.fetchDashboardExecution,
+    fetchDashboardExecutionTrust:
+      mocks.fetchDashboardExecutionTrust
+      ?? vi.fn().mockResolvedValue(executionTrustResponse),
     fetchToolQuality: mocks.fetchToolQuality,
     fetchTelemetrySummary: mocks.fetchTelemetrySummary,
     fetchDashboardNamespaceTruth:
@@ -253,9 +271,55 @@ describe('FleetTelemetryPanel', () => {
     expect(container.textContent).toContain('Keeper 턴 로그')
     expect(container.textContent).toContain('실패 분류')
     expect(container.textContent).toContain('함대 통제실')
+    expect(container.textContent).toContain('Execution Trust')
+    expect(container.textContent).toContain('keeper_agent_run.execution_receipt')
+    expect(container.textContent).toContain('/api/v1/dashboard/execution-trust')
     expect(container.textContent).toContain('Telemetry_unified.summary_json')
     expect(container.textContent).toContain('.masc/metrics/keeper.jsonl')
     expect(container.textContent).toContain('/api/v1/dashboard/telemetry/summary')
+  }, 60_000)
+
+  it('renders execution trust coverage gap provenance', async () => {
+    const fetchDashboardExecution = vi.fn().mockResolvedValue(executionResponse)
+    const fetchDashboardExecutionTrust = vi.fn().mockResolvedValue({
+      ...executionTrustResponse,
+      health: 'coverage_gap',
+      stale_reason: 'execution_receipt_append_failed',
+      coverage_gap_count: 1,
+      coverage_gaps: [
+        {
+          schema: 'masc.telemetry_coverage_gap.v1',
+          source: 'execution_receipt',
+          producer: 'keeper_agent_run.execution_receipt',
+          durable_store: '.masc/keepers/*/execution-receipts',
+          dashboard_surface: '/api/v1/dashboard/execution-trust',
+          stale_reason: 'execution_receipt_append_failed',
+          keeper_name: 'sangsu',
+          trace_id: 'trace-exec-gap',
+        },
+      ],
+    } satisfies DashboardExecutionTrustResponse)
+    const fetchToolQuality = vi.fn().mockResolvedValue(toolQualityResponse)
+    const fetchTelemetrySummary = vi.fn().mockResolvedValue(telemetrySummaryResponse)
+    const { FleetTelemetryPanel } = await loadPanel({
+      fetchDashboardExecution,
+      fetchDashboardExecutionTrust,
+      fetchToolQuality,
+      fetchTelemetrySummary,
+    })
+
+    await act(async () => {
+      render(html`<${FleetTelemetryPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(fetchDashboardExecutionTrust).toHaveBeenCalledTimes(1)
+    expect(container.textContent).toContain('coverage gaps 1: execution_receipt_append_failed')
+    expect(container.textContent).toContain('producer keeper_agent_run.execution_receipt')
+    expect(container.textContent).toContain('store .masc/keepers/*/execution-receipts')
+    expect(container.textContent).toContain('surface /api/v1/dashboard/execution-trust')
+    expect(container.textContent).toContain('trace trace-exec-gap')
   }, 60_000)
 
   it('renders readiness cards, attention events, and keeper goal or sandbox badges', async () => {

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -6,9 +6,11 @@ import { LoadingState } from './common/feedback-state'
 import { Eyebrow } from './common/eyebrow'
 import {
   fetchDashboardExecution,
+  fetchDashboardExecutionTrust,
   fetchDashboardNamespaceTruth,
   fetchTelemetrySummary,
   fetchToolQuality,
+  type DashboardExecutionTrustResponse,
   type TelemetrySourceSummary,
   type ToolQualityResponse,
 } from '../api/dashboard'
@@ -23,6 +25,7 @@ import { isAbortError } from '../lib/async-state'
 import { requestConfirm } from './common/confirm-dialog'
 import { Sparkline } from './common/sparkline'
 import { TextInput } from './common/input'
+import { coverageGapDisplay, freshnessText, sourceHealthClass } from './common/source-health'
 import { pushSnapshot, getTrend, type MetricKey, type TrendDirection } from './fleet-trend-store'
 import type { DashboardAttentionEvent, DashboardReadinessPillar } from '../types'
 import {
@@ -558,6 +561,56 @@ function TelemetrySourcesPanel({ sources }: { sources: TelemetrySourceSummary[] 
   `
 }
 
+function ExecutionTrustSourcePanel({ trust }: { trust: DashboardExecutionTrustResponse | null }) {
+  if (!trust) {
+    return html`<div class="text-2xs text-[var(--color-fg-disabled)]">Execution trust source 요약 사용 불가.</div>`
+  }
+
+  const coverageGap = coverageGapDisplay(trust)
+  const provenanceRows = [
+    trust.producer ? ['producer', trust.producer] : null,
+    trust.durable_store ? ['store', trust.durable_store] : null,
+    trust.dashboard_surface ? ['surface', trust.dashboard_surface] : null,
+  ].filter((row): row is [string, string] => row !== null)
+
+  return html`
+    <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
+      <div class="flex items-center justify-between gap-3">
+        <div>
+          <div class="text-2xs font-medium text-[var(--text)]">Execution Trust</div>
+          <div class="mt-1 text-3xs text-[var(--color-fg-disabled)]">
+            <span class="font-mono">${trust.source ?? 'execution_receipt'}</span>
+            <span class="mx-1" aria-hidden="true">·</span>
+            <span class="font-mono ${sourceHealthClass(trust.health)}">${trust.health ?? 'unknown'}</span>
+            <span class="mx-1" aria-hidden="true">·</span>
+            <span>${freshnessText(trust)}</span>
+          </div>
+        </div>
+        <div class="text-right">
+          <div class="font-mono text-sm text-[var(--text)]">${(trust.entry_count ?? 0).toLocaleString()}</div>
+          <div class="text-3xs text-[var(--color-fg-disabled)]">${trust.total.toLocaleString()} keepers</div>
+        </div>
+      </div>
+      ${provenanceRows.length > 0 ? html`
+        <div class="mt-2 grid gap-1 text-3xs text-[var(--color-fg-disabled)]">
+          ${provenanceRows.map(([label, value]) => html`
+            <div class="flex min-w-0 gap-1">
+              <span class="shrink-0">${label}:</span>
+              <span class="min-w-0 break-all font-mono">${value}</span>
+            </div>
+          `)}
+        </div>
+      ` : null}
+      ${coverageGap ? html`
+        <div class="mt-2 grid gap-0.5 text-3xs text-[var(--color-status-warn)]">
+          <span>${coverageGap.summary}</span>
+          ${coverageGap.details.map(detail => html`<span class="font-mono break-all">${detail}</span>`)}
+        </div>
+      ` : null}
+    </div>
+  `
+}
+
 function FailureCategoryPanel({ toolQuality }: { toolQuality: ToolQualityResponse }) {
   if (toolQuality.failure_categories.length === 0) {
     return html`<div class="text-2xs text-[var(--color-fg-disabled)]">최근 실패 카테고리 없음.</div>`
@@ -603,8 +656,9 @@ export function FleetTelemetryPanel() {
     }
 
     try {
-      const [executionResult, toolQualityResult, telemetrySummaryResult, namespaceTruthResult] = await Promise.allSettled([
+      const [executionResult, executionTrustResult, toolQualityResult, telemetrySummaryResult, namespaceTruthResult] = await Promise.allSettled([
         fetchDashboardExecution({ signal: controller.signal }),
+        fetchDashboardExecutionTrust({ signal: controller.signal }),
         fetchToolQuality({ n: 5000, windowHours: 24, signal: controller.signal }),
         fetchTelemetrySummary({ signal: controller.signal }),
         fetchDashboardNamespaceTruth({ signal: controller.signal }),
@@ -620,6 +674,14 @@ export function FleetTelemetryPanel() {
           : []
       if (executionResult.status === 'rejected' && !isAbortError(executionResult.reason)) {
         warnings.push(`실행 스냅샷 사용 불가: ${errorMessage(executionResult.reason)}`)
+      }
+
+      const executionTrust =
+        executionTrustResult.status === 'fulfilled'
+          ? executionTrustResult.value
+          : null
+      if (executionTrustResult.status === 'rejected' && !isAbortError(executionTrustResult.reason)) {
+        warnings.push(`Execution trust 사용 불가: ${errorMessage(executionTrustResult.reason)}`)
       }
 
       const toolQuality =
@@ -651,11 +713,14 @@ export function FleetTelemetryPanel() {
       warnings.push(...buildRuntimeWarnings(rows))
       const updatedAt =
         (executionResult.status === 'fulfilled' ? executionResult.value.generated_at : null)
+        || executionTrust?.generated_at
         || telemetrySummary.generated_at
         || new Date().toISOString()
 
       const hasAnyData =
         rows.length > 0
+        || (executionTrust?.total ?? 0) > 0
+        || (executionTrust?.entry_count ?? 0) > 0
         || toolQuality.total > 0
         || telemetrySummary.total_entries > 0
 
@@ -666,6 +731,7 @@ export function FleetTelemetryPanel() {
         error: hasAnyData ? null : '함대 텔레메트리 데이터가 없습니다.',
         warnings,
         rows,
+        execution_trust: executionTrust,
         tool_quality: toolQuality,
         telemetry_sources: telemetrySummary.sources,
         total_telemetry_entries: telemetrySummary.total_entries,
@@ -804,6 +870,11 @@ export function FleetTelemetryPanel() {
       <div>
         <${Eyebrow} tone="disabled" class="mb-1">함대 통제실</${Eyebrow}>
         <${ControlRoomPanel} state=${value} />
+      </div>
+
+      <div>
+        <${Eyebrow} tone="disabled" class="mb-1">Execution Trust Source</${Eyebrow}>
+        <${ExecutionTrustSourcePanel} trust=${value.execution_trust} />
       </div>
 
       <div>

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -1,4 +1,4 @@
-import type { TelemetrySourceSummary, ToolQualityResponse } from '../api/dashboard'
+import type { DashboardExecutionTrustResponse, TelemetrySourceSummary, ToolQualityResponse } from '../api/dashboard'
 import type { DashboardNamespaceTruthResponse } from '../types'
 import { telemetrySourceLabel } from '../config/telemetry-sources'
 import type { Keeper } from '../types'
@@ -60,6 +60,7 @@ export interface FleetTelemetryState {
   error: string | null
   warnings: string[]
   rows: FleetRow[]
+  execution_trust: DashboardExecutionTrustResponse | null
   tool_quality: ToolQualityResponse
   telemetry_sources: TelemetrySourceSummary[]
   total_telemetry_entries: number
@@ -84,6 +85,7 @@ export function emptyState(): FleetTelemetryState {
     error: null,
     warnings: [],
     rows: [],
+    execution_trust: null,
     tool_quality: EMPTY_TOOL_QUALITY,
     telemetry_sources: [],
     total_telemetry_entries: 0,


### PR DESCRIPTION
## Summary
- Add a dashboard API fetcher for /api/v1/dashboard/execution-trust.
- Load execution trust source metadata in Fleet Telemetry and render health, freshness, provenance, and coverage gap details.
- Add API and Fleet Telemetry regression coverage.

## Verification
- pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/api/dashboard.test.ts src/components/fleet-telemetry-panel.test.ts src/components/common/source-health.test.ts
- pnpm exec tsc --noEmit --pretty
- pnpm exec eslint src/api/dashboard.ts src/api/dashboard.test.ts src/components/fleet-telemetry-panel.ts src/components/fleet-telemetry-panel.test.ts src/components/fleet-telemetry-utils.ts src/components/common/source-health.ts src/components/common/source-health.test.ts
- git diff --check HEAD~1..HEAD