### PR TITLE
fix(server): match real tool_requirement wire "none" (follow-up #15087)

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -694,11 +694,16 @@ let compact_receipt_tool_surface_json receipt =
   | `Assoc _ as surface ->
     let tool_requirement = json_string "tool_requirement" surface in
     let turn_lane =
+      (* Wire values come from [Keeper_agent_tool_surface.tool_requirement_to_yojson]
+         (lib/keeper/keeper_agent_tool_surface.ml): "required", "optional", "none".
+         The earlier "no_tools" literal never fired because [No_tools] serializes
+         to "none" — leaving turn_lane=null on no-tool receipts that omit an
+         explicit turn_lane. *)
       match json_string "turn_lane" surface, tool_requirement with
       | Some value, _ -> Some value
       | None, Some "required" -> Some "tool_required"
       | None, Some "optional" -> Some "tool_optional"
-      | None, Some "no_tools" -> Some "text_only"
+      | None, Some "none" -> Some "text_only"
       | None, _ -> None
     in
     `Assoc


### PR DESCRIPTION
## 배경

PR #15087 의 Codex review (P2) 가 unresolved 상태로 main 에 머지되었습니다.

`lib/server/server_dashboard_http.ml` 의 `compact_receipt_tool_surface_json` 은 receipt 에 `turn_lane` 이 없을 때 `tool_requirement` 로부터 lane 을 derive 하는데, 그 fallback arm 이 `"no_tools"` literal 을 검사합니다. 그러나 `tool_requirement` 의 실제 wire value 는 `Keeper_agent_tool_surface.tool_requirement_to_yojson` 에서 결정되며 (`lib/keeper/keeper_agent_tool_surface.ml:35-38`):

```ocaml
let tool_requirement_to_yojson = function
  | Required -> `String "required"
  | Optional -> `String "optional"
  | No_tools -> `String "none"
```

`No_tools -> "none"` 입니다. 결과적으로 `"no_tools"` arm 은 dead branch 였고, no-tool 턴의 compact receipt 에서 `turn_lane=null` 이 emit 되어 대시보드 composite payload 의 lane 컨텍스트가 손실되었습니다.

## 변경

- `lib/server/server_dashboard_http.ml`: fallback arm 의 `"no_tools"` → `"none"`. 직렬화 contract 위치 (`keeper_agent_tool_surface.ml`) 를 인라인 주석으로 명시해 다음 reader 가 다시 drift 시키지 않게 함.

## 검증

- `dune build --root . lib/server`: 빌드 통과.
- 단위 테스트는 추가하지 않았습니다. `compact_receipt_tool_surface_json` 은 `.mli` 비공개 파일-로컬 helper 라 직접 호출 테스트를 위해서는 public surface 확장이 필요한데, 단일 literal fix 범위를 넘어섭니다. 자연 발생 receipt fixture 는 항상 `turn_lane` 을 명시하므로 이 fallback 분기는 legacy / partial receipt 에서만 fire 합니다 — 인공 fixture 가 필요한 경계.
- Contract 검증은 `tool_requirement_to_yojson` 정의로 충분히 trace 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)