### PR TITLE
chore(server): remove dead recover_running_sessions lazy task

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1546,18 +1546,6 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         [
           ("restore_sessions", fun () -> restore_persisted_sessions state);
           ("reconcile_active_agents", fun () -> reconcile_active_agents_gauge state);
-          ( "recover_running_sessions",
-            fun () ->
-              match state.Mcp_server.proc_mgr, state.Mcp_server.net with
-              | None, _ ->
-                  Log.Server.warn
-                    "skipping session recovery: process_mgr not available"
-              | Some _process_mgr, None ->
-                  Log.Server.warn
-                    "skipping session recovery: net not available"
-              | Some _process_mgr, Some _net ->
-                  (* Team_session_engine_eio removed — skip recovery *)
-                  ignore (sw, clock, state.Mcp_server.room_config) );
           ("prompt_bootstrap", fun () -> bootstrap_prompt_state state);
           ("telemetry_warmup", fun () -> warm_tool_registry_from_telemetry state);
           ("tool_metrics_restore", fun () -> restore_tool_metrics_from_disk state);


### PR DESCRIPTION
## 목표
부팅 로그의 dead lazy task entry 제거. `Team_session_engine_eio` 가 제거된 이후 `recover_running_sessions` 의 본체는 `ignore (sw, clock, state.Mcp_server.room_config)` 만 수행하는 no-op. 5개 사이트에 이미 `Team_session_engine_eio removed` tombstone 코멘트가 남아 있는데 이 lazy task entry 만 함께 정리되지 않았음.

## 변경 파일
- `lib/server/server_runtime_bootstrap.ml`: lazy task list 에서 `recover_running_sessions` entry 12 줄 삭제.

## 측정 근거
부팅 직후 로그에서 다음 두 줄이 출력되지만 본체 작업은 0:
```
[Server] lazy_task: starting recover_running_sessions
[Server] lazy_task: finished recover_running_sessions
```
관련 dead tombstone 사이트 (`rg "Team_session_engine_eio removed"`):
- `lib/server/server_runtime_bootstrap.ml:1559` (이 PR 에서 제거)
- `lib/tool_inline_dispatch_comm.ml:86`
- `lib/dashboard/dashboard_mission.ml:736`
- `test/test_operator_control_keeper.ml:3462`

## 로컬 검증
- `git diff --stat`: 1 file, -12.
- `pr-rfc-check.sh`: PASS (subsystem 매칭 없음).
- dune build: worktree lock contention (4+ 큐 대기) 으로 GitHub Actions clean 환경 검증에 위임.

## 미검증 항목
- 변경 후 컴파일 (CI 의존). closure entry 한 줄 list 삭제이므로 API/타입 변경 0.
- Server_startup_state pending list 에서 task 이름이 한 줄 사라짐 — 외부 monitoring/dashboard 가 hard-coded `"recover_running_sessions"` 를 기대하지 않는지는 `rg '"recover_running_sessions"'` 로 사전 확인 (0 hit).

## 후속 (별 PR)
- Lazy task 의존 그래프 명시화 + 독립 task `Eio.Fiber.all` 병렬화 (B 항목, 본 PR 범위 밖).
- `.archive/` 디렉토리 누적 (331 epoch) cleanup 정책 — credential ping-pong 종료 RFC 와 함께.

🤖 Generated with [Claude Code](https://claude.com/claude-code)