### PR TITLE
[codex] cache dashboard WebSocket discovery

### DIFF
--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -24,6 +24,7 @@ const TARGET_FILES = [
   'src/components/mission.ts',
   'src/components/runtime-monitor.ts',
   'src/components/transport-health.ts',
+  'src/dashboard-ws.ts',
   'src/goal-loop-status.ts',
   'src/lib/async-state.ts',
   'src/components/common/normalize.ts',
@@ -39,6 +40,7 @@ const TEST_FILES = [
   'src/components/goal-loop-panel.test.ts',
   'src/components/keeper-tool-call-inspector.test.ts',
   'src/components/transport-health.test.ts',
+  'src/dashboard-ws.test.ts',
   'src/goal-loop-status.test.ts',
   'src/lib/async-state.test.ts',
 ]

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -8,6 +8,7 @@ const sseStoreMocks = vi.hoisted(() => ({
 vi.mock('./sse-store', () => sseStoreMocks)
 
 import {
+  clearDashboardWsDiscoveryCacheForTests,
   connectDashboardWS,
   dashboardSlicesForRoute,
   disconnectDashboardWS,
@@ -156,6 +157,7 @@ beforeEach(() => {
 
 afterEach(() => {
   disconnectDashboardWS()
+  clearDashboardWsDiscoveryCacheForTests()
   MockParseWorker.holdResponses = false
   dashboardWsConnected.value = false
   dashboardWsLastError.value = null
@@ -280,11 +282,65 @@ describe('dashboard websocket route subscriptions', () => {
     await connectDashboardWS({ tab: 'overview', params: {} })
     expect(mockSockets).toHaveLength(0)
 
-    await vi.advanceTimersByTimeAsync(1_000)
+    await vi.advanceTimersByTimeAsync(60_000)
     await flushPromises()
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(mockSockets).toHaveLength(1)
+  })
+
+  it('reuses cached websocket discovery across reconnects after a ready socket closes', async () => {
+    vi.useFakeTimers()
+    installWebSocketMocks()
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const firstSocket = mockSockets[0]!
+    firstSocket.open()
+    const hello = parseRpc(firstSocket, 0)
+    firstSocket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    await flushPromises()
+
+    const subscribe = parseRpc(firstSocket, 1)
+    firstSocket.receive({
+      jsonrpc: '2.0',
+      id: subscribe.id,
+      result: { snapshot: { seq: 1, slices: {} } },
+    })
+    await flushPromises()
+    expect(dashboardWsReady.value).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    firstSocket.close({ code: 1001, reason: 'server restart', wasClean: true })
+    await vi.advanceTimersByTimeAsync(60_000)
+    await flushPromises()
+
+    expect(mockSockets).toHaveLength(2)
+    expect(mockSockets[1]!.url).toBe('ws://127.0.0.1:8937/')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('invalidates cached discovery when the cached socket closes before it is ready', async () => {
+    vi.useFakeTimers()
+    mockSockets.length = 0
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(wsDiscoveryResponse('ws://127.0.0.1:8937/stale'))
+      .mockResolvedValueOnce(wsDiscoveryResponse('ws://127.0.0.1:8937/fresh'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const staleSocket = mockSockets[0]!
+    expect(staleSocket.url).toBe('ws://127.0.0.1:8937/stale')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    staleSocket.close({ code: 1006, reason: 'connect failed', wasClean: false })
+    await vi.advanceTimersByTimeAsync(60_000)
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(mockSockets).toHaveLength(2)
+    expect(mockSockets[1]!.url).toBe('ws://127.0.0.1:8937/fresh')
   })
 
   it('subscribes the latest route captured while hello is still in flight', async () => {

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -40,9 +40,11 @@ interface DashboardWsDiscovery {
 interface DashboardWsDiscoveryResult {
   wsUrl: string | null
   retry: boolean
+  fromCache: boolean
 }
 
 const DASHBOARD_WS_PARSE_TIMEOUT_MS = 5_000
+const DASHBOARD_WS_DISCOVERY_CACHE_KEY = 'masc.dashboard.ws.discovery.v1'
 
 let socket: WebSocket | null = null
 let rpcId = 0
@@ -53,6 +55,53 @@ let desiredRouteState: DashboardRouteState | null = null
 let shouldReconnect = true
 let connectGeneration = 0
 const pending = new Map<number, PendingRpc>()
+
+function sessionStorageOrNull(): Storage | null {
+  if (typeof sessionStorage === 'undefined') return null
+  try {
+    return sessionStorage
+  } catch {
+    return null
+  }
+}
+
+function readCachedWsUrl(): string | null {
+  const storage = sessionStorageOrNull()
+  if (!storage) return null
+  try {
+    const raw = storage.getItem(DASHBOARD_WS_DISCOVERY_CACHE_KEY)
+    if (!raw) return null
+    const data = JSON.parse(raw) as { ws_url?: unknown }
+    return typeof data.ws_url === 'string' && data.ws_url.length > 0 ? data.ws_url : null
+  } catch {
+    storage.removeItem(DASHBOARD_WS_DISCOVERY_CACHE_KEY)
+    return null
+  }
+}
+
+function writeCachedWsUrl(wsUrl: string): void {
+  const storage = sessionStorageOrNull()
+  if (!storage) return
+  try {
+    storage.setItem(DASHBOARD_WS_DISCOVERY_CACHE_KEY, JSON.stringify({ ws_url: wsUrl }))
+  } catch {
+    // Ignore quota/private-mode failures; discovery still works without cache.
+  }
+}
+
+function clearCachedWsUrl(): void {
+  const storage = sessionStorageOrNull()
+  if (!storage) return
+  try {
+    storage.removeItem(DASHBOARD_WS_DISCOVERY_CACHE_KEY)
+  } catch {
+    // Storage may be disabled; a failed clear is equivalent to no cache control.
+  }
+}
+
+export function clearDashboardWsDiscoveryCacheForTests(): void {
+  clearCachedWsUrl()
+}
 
 // Phase 2 (PR-4.6): rAF accumulator for inbound WS messages.
 // Instead of processing every WS frame immediately (which can trigger
@@ -283,16 +332,19 @@ function closeSocket(): void {
 }
 
 async function discoverWsUrl(): Promise<DashboardWsDiscoveryResult> {
+  const cachedUrl = readCachedWsUrl()
+  if (cachedUrl) return { wsUrl: cachedUrl, retry: false, fromCache: true }
+
   const response = await fetch('/ws', { credentials: 'same-origin' })
-  if (!response.ok) return { wsUrl: null, retry: true }
+  if (!response.ok) return { wsUrl: null, retry: true, fromCache: false }
   const data = await response.json() as DashboardWsDiscovery
   if (data.enabled !== true) {
-    return { wsUrl: null, retry: false }
+    return { wsUrl: null, retry: false, fromCache: false }
   }
   if (data.listening !== true || typeof data.ws_url !== 'string') {
-    return { wsUrl: null, retry: true }
+    return { wsUrl: null, retry: true, fromCache: false }
   }
-  return { wsUrl: data.ws_url, retry: false }
+  return { wsUrl: data.ws_url, retry: false, fromCache: false }
 }
 
 function sendRpc(method: string, params: JsonObject): Promise<unknown> {
@@ -485,11 +537,13 @@ function handleMessage(data: unknown): void {
 
 function reconnectAfterCurrentSocketFailure(ws: WebSocket, err: unknown): void {
   if (socket !== ws) return
+  const wasReady = dashboardWsReady.value
   batch(() => {
     dashboardWsConnected.value = false
     dashboardWsReady.value = false
     dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
   })
+  if (!wasReady) clearCachedWsUrl()
   lastSubscribeKey = ''
   closeSocket()
   scheduleReconnect()
@@ -539,6 +593,7 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
   }
   const wsUrl = discovery.wsUrl
   if (!wsUrl) {
+    if (generation === connectGeneration) clearCachedWsUrl()
     if (generation === connectGeneration && shouldReconnect && discovery.retry) {
       batch(() => {
         dashboardWsLastError.value = 'dashboard websocket unavailable'
@@ -548,9 +603,20 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     return
   }
   if (!shouldReconnect || generation !== connectGeneration) return
+  if (!discovery.fromCache) writeCachedWsUrl(wsUrl)
 
   closeSocket()
-  const ws = new WebSocket(wsUrl)
+  let ws: WebSocket
+  try {
+    ws = new WebSocket(wsUrl)
+  } catch (err) {
+    if (discovery.fromCache) clearCachedWsUrl()
+    batch(() => {
+      dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
+    })
+    scheduleReconnect()
+    return
+  }
   socket = ws
   ws.onopen = () => {
     if (socket !== ws) return
@@ -587,12 +653,14 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
   }
   ws.onclose = (event) => {
     if (socket !== ws) return
+    const wasReady = dashboardWsReady.value
     const closeError = new Error(formatCloseEventError(event))
     batch(() => {
       dashboardWsConnected.value = false
       dashboardWsReady.value = false
       dashboardWsLastError.value = closeError.message
     })
+    if (!wasReady) clearCachedWsUrl()
     lastSubscribeKey = ''
     socket = null
     rejectPendingRpcs(closeError)


### PR DESCRIPTION
## Summary

- Cache successful dashboard WebSocket discovery (`/ws`) in session storage so reconnects do not repeatedly hit the HTTP discovery endpoint.
- Invalidate the cached URL when a cached socket closes before the dashboard handshake reaches ready state, so stale ports self-heal on the next retry.
- Add `dashboard-ws.ts` and its test to the dashboard ESLint allowlist.

## Why

The old performance notes called out reconnect storms where the dashboard repeatedly rediscovered `/ws` before every WebSocket attempt. The reconnect path already has backoff; this change removes redundant discovery fetches from the healthy reconnect case while preserving recovery when the cached URL is stale.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/dashboard-ws.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/dashboard-ws.ts src/dashboard-ws.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check origin/main...HEAD`
