### PR TITLE
fix(dashboard): include pending_first in trust summary visibility (follow-up #15084)

### DIFF
--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -44,6 +44,7 @@ import {
   phaseFilterLabel,
   TaskProgressBar,
 } from './goal-helpers'
+import { trustHasPendingFirstEvidence } from './trust-summary-evidence'
 
 type GoalDetailTab = 'summary' | 'tasks' | 'evidence'
 
@@ -925,6 +926,7 @@ function KeeperCard({ keeper }: { keeper: GoalDetailKeeper }) {
     || Boolean(providerSelectedModel)
     || Boolean(executionCascadeOutcome)
     || Boolean(sandboxRoot)
+    || trustHasPendingFirstEvidence(trust?.approval_state ?? null)
 
   return html`
     <div class="rounded-[var(--r-1)] border border-card-border/60 bg-[var(--backdrop-deep)] p-3">

--- a/dashboard/src/components/goals/trust-summary-evidence.test.ts
+++ b/dashboard/src/components/goals/trust-summary-evidence.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { trustHasPendingFirstEvidence } from './trust-summary-evidence'
+
+describe('trustHasPendingFirstEvidence', () => {
+  it('returns false for nullish approval state', () => {
+    expect(trustHasPendingFirstEvidence(null)).toBe(false)
+    expect(trustHasPendingFirstEvidence(undefined)).toBe(false)
+    expect(trustHasPendingFirstEvidence({})).toBe(false)
+  })
+
+  it('returns false when pending_first has only blank fields', () => {
+    expect(
+      trustHasPendingFirstEvidence({
+        pending_first: { id: '', tool_name: '   ', task_id: null, blocker_class: undefined },
+      }),
+    ).toBe(false)
+  })
+
+  it('returns true when pending_first carries an approval id', () => {
+    expect(
+      trustHasPendingFirstEvidence({
+        pending_first: {
+          id: 'apr_123',
+          tool_name: null,
+          task_id: null,
+          blocker_class: null,
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('returns true when only blocker_class is set', () => {
+    expect(
+      trustHasPendingFirstEvidence({ pending_first: { blocker_class: 'sandbox' } }),
+    ).toBe(true)
+  })
+
+  it('returns true when only tool_name is set', () => {
+    expect(
+      trustHasPendingFirstEvidence({ pending_first: { tool_name: 'keeper_bash' } }),
+    ).toBe(true)
+  })
+
+  it('returns true when only task_id is set', () => {
+    expect(trustHasPendingFirstEvidence({ pending_first: { task_id: 'task-42' } })).toBe(true)
+  })
+})

--- a/dashboard/src/components/goals/trust-summary-evidence.ts
+++ b/dashboard/src/components/goals/trust-summary-evidence.ts
@@ -1,0 +1,35 @@
+// Helpers for deciding whether the keeper trust summary block has any
+// content worth rendering in `goal-tree`. Split out from `KeeperCard` so
+// the predicate can be unit-tested independently of the Preact render
+// path.
+
+type PendingFirst = {
+  id?: string | null
+  tool_name?: string | null
+  task_id?: string | null
+  blocker_class?: string | null
+}
+
+type ApprovalState = {
+  pending_first?: PendingFirst | null
+}
+
+/**
+ * Returns true when `approval_state.pending_first` carries at least one
+ * non-empty identifier/tool/task/blocker field — i.e. there is approval
+ * evidence the operator should be able to see, even when the surrounding
+ * trust fields (`state`, attention/disposition text, execution flags)
+ * are absent.
+ *
+ * Mirrors the trimming/truthy contract used by `KeeperCard` for the
+ * inline `pendingApprovalId/...` locals so the predicate stays aligned
+ * with what the rendered cells actually show.
+ */
+export function trustHasPendingFirstEvidence(
+  approvalState: ApprovalState | null | undefined,
+): boolean {
+  const pending = approvalState?.pending_first
+  if (!pending) return false
+  const fields = [pending.id, pending.tool_name, pending.task_id, pending.blocker_class]
+  return fields.some(value => typeof value === 'string' && value.trim().length > 0)
+}


### PR DESCRIPTION
## 배경

PR #15084 의 Codex review (P2) 가 unresolved 상태로 main 에 머지되었습니다.

`KeeperCard` (`dashboard/src/components/goals/goal-tree.ts:909`) 의 `shouldShowTrustSummary` OR 체인은 17 개 trust/execution 필드를 검사하지만 `pendingApprovalId/Tool/Task/Blocker` 4 개 변수는 포함되어 있지 않습니다. 같은 컴포넌트가 이 4 필드를 렌더링용 셀로 이미 사용하는데도 가시성 결정에는 반영하지 않은 비대칭입니다.

결과: payload 가 `approval_state.pending_first` 만 갖고 다른 trust state / attention reason / disposition / execution flag 가 모두 비어 있으면 검증 요약 블록 전체가 hide 되어, 상위 PR 이 보존한 pending approval evidence 가 UI 에서 사라집니다.

## 변경

- `dashboard/src/components/goals/trust-summary-evidence.ts` (신규): pure helper `trustHasPendingFirstEvidence(approval_state)` 추출. trimming/non-empty 규칙을 `KeeperCard` 의 inline locals 와 정렬.
- `dashboard/src/components/goals/goal-tree.ts`: OR 체인에 `trustHasPendingFirstEvidence(trust?.approval_state ?? null)` 한 줄 추가.
- `dashboard/src/components/goals/trust-summary-evidence.test.ts` (신규): 6 vitest case — nullish, blank-only, id-only, blocker_class-only, tool_name-only, task_id-only.

## 검증

```
npx vitest run --config vitest.config.ts src/components/goals/trust-summary-evidence.test.ts
Test Files  1 passed (1)
     Tests  6 passed (6)
```

별도 TS 타입 에러 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)