### PR TITLE
fix(auth): stop bare/canonical credential ping-pong + .archive retention

### DIFF
--- a/docs/observability/auth-credential-metrics.md
+++ b/docs/observability/auth-credential-metrics.md
@@ -1,0 +1,146 @@
+---
+status: reference
+last_verified: 2026-05-14
+code_refs:
+  - lib/auth.ml
+  - lib/auth.mli
+  - lib/server/server_runtime_bootstrap.ml
+  - lib/server/server_bootstrap_loops.ml
+  - lib/prometheus.ml
+  - lib/prometheus.mli
+  - infrastructure/monitoring/auth-credential-alerts.yml
+---
+
+# Auth Credential Surface Metrics
+
+How to read the boot-time and runtime credential state exposed by `/metrics` and the alerting rules that turn them into pages. The surface was introduced by PR #15112 to close the bare-form keeper credential ping-pong between PR-#10440 (`Auth.ensure_credential_alias` writes a short-form alias at every boot) and PR-3b2 #11155 (`Auth.archive_bare_for_canonical` archives any bare-form file unconditionally), which had been accumulating about 20 archive epoch directories per day for 17 days before discovery.
+
+## Background
+
+The credential subsystem exposes its state on **six surfaces**:
+
+| Surface | Location | Use case |
+|---------|----------|----------|
+| 1. API (mli)            | `lib/auth.mli`                                            | Compile-time contract |
+| 2. Tests                | `test/test_auth.ml` (credentials group 22-30)             | CI / pre-merge guards |
+| 3. Boot log             | `[Server] startup bare alias audit: alive_aliases=...`    | Single-shot boot snapshot |
+| 4. Prometheus gauge     | `GET /metrics`                                            | Time-series + alerting (this doc) |
+| 5. Periodic fiber       | `Auth.start_bare_alias_audit_fiber` (60s)                 | Mid-run regression refresh |
+| 6. AlertManager rule    | `infrastructure/monitoring/auth-credential-alerts.yml`    | Operator-facing alarm |
+
+Surfaces 4-6 together form the *reliable observability path* — surface 3 covers boot-time only, and a regression introduced mid-run would otherwise stay invisible until the next server restart.
+
+## γ Classifier (lib/auth.ml)
+
+`classify_bare_for_canonical` is the pure read-only predicate that decides whether a bare-form file is alive or dead. It returns one of three variants:
+
+| Variant | Meaning | Policy |
+|---------|---------|--------|
+| `Bare_absent`     | No file at `agents/<bare>.json`                                                              | No-op |
+| `Bare_alive_alias` | Redirect stub aimed at the *same* UUID file as the canonical credential                     | Keep (PR-#10440 alias) |
+| `Bare_dead`       | Direct credential, orphan redirect, or stub whose canonical is itself a direct credential    | Archive (PR-3b2 policy) |
+
+`archive_bare_for_canonical` dispatches on the variant. `bare_alias_audit` aggregates the variant counts across the entire keeper roster and mirrors them into the Prometheus gauges.
+
+## Gauges
+
+### `masc_auth_bare_alias`
+
+| Label | Values |
+|-------|--------|
+| `state` | `alive`, `dead`, `no_bare` |
+
+Set by `Auth.bare_alias_audit` itself — boot-time via `sync_bootable_keeper_credentials`, then refreshed every `MASC_AUTH_BARE_ALIAS_AUDIT_INTERVAL_S` seconds (default 60) by `start_bare_alias_audit_fiber`. The fiber re-queries the keeper roster on every tick so runtime add/remove is picked up without a fiber restart.
+
+Label cardinality: `3 series`.
+
+#### Steady state (γ fix deployed)
+
+```
+masc_auth_bare_alias{state="alive"}   18    # one per fleet keeper
+masc_auth_bare_alias{state="dead"}     0
+masc_auth_bare_alias{state="no_bare"}  0
+```
+
+#### Regression state (pre-γ ping-pong)
+
+```
+masc_auth_bare_alias{state="alive"}    0
+masc_auth_bare_alias{state="dead"}    18    # every keeper bare flagged for archive
+masc_auth_bare_alias{state="no_bare"}  0
+```
+
+`state="dead" > 0` is the canary alert hook (`AuthBareAliasPingPongRegression`).
+
+### `masc_auth_archive_epochs`
+
+Unlabeled gauge. Set by `startup_prune_auth_archive` to the count of `.archive/<epoch>/` subdirectories remaining after the boot-time retention sweep. Tracks disk inventory.
+
+Retention defaults: `MASC_AUTH_ARCHIVE_RETENTION_DAYS=30`, `MASC_AUTH_ARCHIVE_MIN_KEEP=20`. Operators can tune both via environment variables.
+
+## Counter
+
+### `masc_auth_archive_pruned_total`
+
+Unlabeled counter. Incremented by `Auth.prune_archive` with the count of epoch directories removed in one sweep. A surge (`increase(... [1d]) > 100`) is the secondary regression signal — either a one-time drain after PR #15112 deployment against an already-bloated `.archive/`, or a new regression producing archive events at the historical rate.
+
+## Alert rules
+
+`infrastructure/monitoring/auth-credential-alerts.yml` carries five rules:
+
+| Group | Alert | Severity | Trigger |
+|-------|-------|----------|---------|
+| `masc_auth_credential_contract` | `AuthCredentialSurfaceMetricAbsent` | critical | Any of the three metrics absent for 5m -- fiber crash or binary predates fix |
+| `masc_auth_bare_alias`          | `AuthBareAliasPingPongRegression`  | critical | `state="dead" > 0` for 1m -- the γ guard regression alert |
+| `masc_auth_bare_alias`          | `AuthBareAliasNoBareElevated`      | warning  | `state="no_bare" > 0` for 10m -- alias writer failing |
+| `masc_auth_archive`             | `AuthArchiveEpochsExcessive`       | warning  | `archive_epochs > 100` for 10m -- retention not keeping up |
+| `masc_auth_archive`             | `AuthArchivePruneSurge`            | warning  | `> 100 epochs pruned in 24h` -- one-time drain or regression |
+
+Evaluation interval 30s matches `masc_goal_loop_observe_contract` so the operator cadence stays consistent across surfaces.
+
+## Operator playbook
+
+### Alert: `AuthBareAliasPingPongRegression`
+
+1. Check `masc_auth_archive_pruned_total` rate -- if it is also climbing, the ping-pong is actively producing archive events.
+2. `cat <base_path>/.masc/auth/.archive/` -- recent epoch dirs (sort by mtime) name the regression cycle.
+3. Inspect a representative bare file: `cat <base_path>/.masc/auth/agents/<bare>.json`. A `{"redirect_to": "...json"}` stub whose target differs from the canonical's redirect target is the `Bare_dead` shape.
+4. Confirm the running binary actually has commit `5d9ac2a7` (Prometheus metric definitions) and `2be6f22f` (periodic fiber) -- if `masc_auth_bare_alias` is absent from the scrape, the binary is older than PR #15112.
+
+### Alert: `AuthArchiveEpochsExcessive`
+
+1. Either retention is too generous for this deployment's churn (tune `MASC_AUTH_ARCHIVE_RETENTION_DAYS` down), or `AuthBareAliasPingPongRegression` is also firing -- check the cross-correlation.
+2. Manual sweep: stop the server, `rm -rf` aged epoch dirs, restart -- but only after capturing one representative epoch dir for forensics.
+
+### Verifying the fix locally
+
+```bash
+cd <repo>
+dune build --root . test/test_auth.exe
+_build/default/test/test_auth.exe test credentials '25,26,27,28,29,30'
+# Expected: Test Successful in <50ms. 6 tests run.
+```
+
+Stress reproduction of the original ping-pong:
+
+```bash
+for i in $(seq 1 50); do
+  _build/default/test/test_auth.exe test credentials 26 >/dev/null || echo "fail run $i"
+done
+# Expected: no output (zero failures across 50 outer iterations
+# = 250 internal archive_bare_for_canonical invocations).
+```
+
+## History
+
+- PR-#10440 (2026 earlier) introduced `Auth.ensure_credential_alias` to fix `auth_doctor` and other short-form `load_credential` callers (8/14 keepers failing).
+- PR-3a #11146 archived bare files only when their token differed from the canonical (dual-identity guard).
+- PR-3b1 #11152 starved the runtime caller (`tool_coord.canonicalize_if_keeper`) so all short-form runtime requests resolve through canonical.
+- PR-3b2 #11155 generalised the archive helper to remove any bare-form file regardless of shape -- under the assumption that PR-3b1 had killed every short-form caller. It missed the PR-#10440 alias writer running in the same boot, producing the ping-pong.
+- PR #15112 (2026-05-14) introduced the γ classifier, the retention sweep, the periodic audit fiber, the Prometheus surface, and these alert rules.
+
+## Related
+
+- `docs/observability/cascade-metrics.md` -- same observability pattern for cascade routing decisions.
+- `docs/observability/goal-loop-observe-metrics.md` -- the boot-time exporter contract that this surface plugs into (`metric_config_credential_archived_starvation_total` is part of the GoalLoop contract presence check).
+- `RFC-0019 Keeper Credential Unification` -- the narrower split-brain reconciliation in PR #15112 sits inside the architecture sketched in RFC-0019 §4.

--- a/infrastructure/monitoring/README.md
+++ b/infrastructure/monitoring/README.md
@@ -16,6 +16,7 @@ Prometheus / Grafana files that live alongside the masc-mcp source so deployment
 | `keeper-turn-fsm-alerts.yml` | keeper turn FSM | alerts | `docs/observability/keeper-turn-fsm-metrics.md` |
 | `keeper-turn-fsm-slo.yml` | keeper turn FSM | recording rules | `docs/observability/keeper-turn-fsm-metrics.md` |
 | `grafana-dashboard-surface-dashboard.json` | dashboard IA | Grafana dashboard | `docs/observability/dashboard-surface-metrics.md` |
+| `auth-credential-alerts.yml` | auth credential surface | alerts | PR #15112 (`lib/auth.ml` doc comments + commit messages) |
 
 ## Domains
 
@@ -51,6 +52,14 @@ The two domains overlap *only* at `cascade_routing` — when the keeper FSM ente
 - `masc_cascade_strategy_decisions_total{kind="exhausted",cascade=...}` — cascade view
 
 Both should fire for the same turn; if only one fires the runtime path skipped a layer.
+
+### Auth credential surface
+
+Tracks the boot-time and runtime state of the bare-form keeper alias files written by `Auth.ensure_credential_alias` (PR-#10440) against the archive policy in `Auth.archive_bare_for_canonical` (PR-3b2). After PR #15112 the γ classifier distinguishes alive aliases (redirect stubs aimed at the canonical credential's UUID) from dead bares; the surface is refreshed every 60s by a periodic Eio fiber so mid-run regressions surface within one tick.
+
+Gauges: `masc_auth_bare_alias{state=alive|dead|no_bare}` — classifier counts. `state="dead" > 0` is the ping-pong regression alert hook. `masc_auth_archive_epochs` — current `.archive/<epoch>/` subdir count after the retention sweep. Counter: `masc_auth_archive_pruned_total` — cumulative epoch dirs removed.
+
+Producer code: `lib/auth.ml: classify_bare_for_canonical / bare_alias_audit / prune_archive / start_bare_alias_audit_fiber`, `lib/server/server_runtime_bootstrap.ml: startup_prune_auth_archive`, `lib/server/server_bootstrap_loops.ml` wiring. Alerts: `auth-credential-alerts.yml`.
 
 ## Apply
 

--- a/infrastructure/monitoring/README.md
+++ b/infrastructure/monitoring/README.md
@@ -16,7 +16,7 @@ Prometheus / Grafana files that live alongside the masc-mcp source so deployment
 | `keeper-turn-fsm-alerts.yml` | keeper turn FSM | alerts | `docs/observability/keeper-turn-fsm-metrics.md` |
 | `keeper-turn-fsm-slo.yml` | keeper turn FSM | recording rules | `docs/observability/keeper-turn-fsm-metrics.md` |
 | `grafana-dashboard-surface-dashboard.json` | dashboard IA | Grafana dashboard | `docs/observability/dashboard-surface-metrics.md` |
-| `auth-credential-alerts.yml` | auth credential surface | alerts | PR #15112 (`lib/auth.ml` doc comments + commit messages) |
+| `auth-credential-alerts.yml` | auth credential surface | alerts | `docs/observability/auth-credential-metrics.md` |
 
 ## Domains
 

--- a/infrastructure/monitoring/auth-credential-alerts.yml
+++ b/infrastructure/monitoring/auth-credential-alerts.yml
@@ -1,0 +1,134 @@
+# Prometheus alerting rules for the boot-time + runtime credential
+# surface introduced by PR #15112 (γ guard against PR-#10440 ↔ PR-3b2
+# bare-form ping-pong). Companion code:
+#
+#   - lib/auth.ml: classify_bare_for_canonical, bare_alias_audit,
+#     prune_archive, start_bare_alias_audit_fiber
+#   - lib/server/server_runtime_bootstrap.ml: startup_prune_auth_archive
+#   - lib/server/server_bootstrap_loops.ml: wires the periodic audit
+#     fiber
+#   - lib/prometheus.{ml,mli}: metric definitions
+#
+# These rules turn the gauges from a passive scrape target into an
+# active surface that pages operators within one evaluation interval
+# of a regression, rather than waiting for someone to look at a
+# dashboard.
+
+groups:
+  - name: masc_auth_credential_contract
+    interval: 30s
+    rules:
+      - alert: AuthCredentialSurfaceMetricAbsent
+        expr: |
+          absent(masc_auth_bare_alias)
+          or absent(masc_auth_archive_epochs)
+          or absent(masc_auth_archive_pruned_total)
+        for: 5m
+        labels:
+          severity: critical
+          component: auth
+          subsystem: credential
+        annotations:
+          summary: "Auth credential surface metric is absent"
+          description: |
+            At least one metric introduced by PR #15112 is not being
+            scraped. The periodic bare_alias_audit fiber may have
+            crashed, or the binary in production predates the fix.
+            Without these metrics the ping-pong regression alert
+            cannot fire and the surface stays silent. Investigate
+            the running binary version and the
+            [Auth] bare_alias_audit fiber startup log line.
+
+  - name: masc_auth_bare_alias
+    interval: 30s
+    rules:
+      - alert: AuthBareAliasPingPongRegression
+        expr: |
+          masc_auth_bare_alias{state="dead"} > 0
+        for: 1m
+        labels:
+          severity: critical
+          component: auth
+          subsystem: credential
+        annotations:
+          summary: "Bare-form keeper credential ping-pong regression detected"
+          description: |
+            One or more keepers have a bare-form credential file that
+            the γ classifier (PR #15112) flagged as Bare_dead --
+            i.e. a direct credential, an orphan redirect stub, or a
+            stub aimed at a UUID different from the canonical
+            credential's. Under PR-3b2 the boot sweep archives it,
+            under PR-#10440 the alias writer re-creates it: the same
+            split-brain pattern that accumulated 331 .archive/
+            epochs in 17 days. Either the fix has been reverted, the
+            classifier is missing a new shape, or an operator wrote a
+            bare-form file out of band.
+
+            Investigate:
+              - .masc/auth/.archive/ growth (masc_auth_archive_epochs)
+              - the latest commit on lib/auth.ml around
+                archive_bare_for_canonical / classify_bare_for_canonical
+              - .masc/auth/agents/<bare>.json file shapes for
+                affected keepers
+
+      - alert: AuthBareAliasNoBareElevated
+        expr: |
+          masc_auth_bare_alias{state="no_bare"} > 0
+        for: 10m
+        labels:
+          severity: warning
+          component: auth
+          subsystem: credential
+        annotations:
+          summary: "Keepers without a short-form alias detected"
+          description: |
+            One or more keepers have a canonical credential but no
+            bare-form alias file. PR-#10440 expects every keeper to
+            have one; persistent no_bare means
+            ensure_credential_alias failed (the WARN line
+            "short-form alias write failed" should also have fired).
+            short-form load_credential callers (auth_doctor and
+            similar) will fail to resolve these keepers.
+
+  - name: masc_auth_archive
+    interval: 30s
+    rules:
+      - alert: AuthArchiveEpochsExcessive
+        expr: |
+          masc_auth_archive_epochs > 100
+        for: 10m
+        labels:
+          severity: warning
+          component: auth
+          subsystem: credential
+        annotations:
+          summary: "Auth .archive/ epoch inventory above 100 dirs"
+          description: |
+            The credential .archive/ directory holds more than 100
+            epoch subdirs after the retention sweep. Either the
+            retention defaults (MASC_AUTH_ARCHIVE_RETENTION_DAYS=30,
+            MASC_AUTH_ARCHIVE_MIN_KEEP=20) are too generous for this
+            deployment's churn, or a regression is again producing
+            archive events on every boot (cross-check
+            AuthBareAliasPingPongRegression).
+
+      - alert: AuthArchivePruneSurge
+        expr: |
+          increase(masc_auth_archive_pruned_total[1d]) > 100
+        for: 0m
+        labels:
+          severity: warning
+          component: auth
+          subsystem: credential
+        annotations:
+          summary: "Auth archive prune surge: more than 100 epochs/day"
+          description: |
+            The retention sweep removed more than 100 epoch
+            subdirectories in the last 24h. Likely either a
+            one-time backlog drain after PR #15112 deployed against
+            an already-bloated .archive/ (the 331-epoch state
+            measured 2026-05-14), or a regression that re-introduced
+            the ping-pong and is producing archive events at the
+            historical ~20/day rate. Confirm against
+            masc_auth_archive_epochs trend and
+            AuthBareAliasPingPongRegression.

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -1584,3 +1584,53 @@ let is_auth_enabled config : bool =
   let cfg = load_auth_config config in
   cfg.enabled
 ;;
+
+let bare_alias_audit_interval_default = 60.0
+
+let bare_alias_audit_interval () =
+  match Sys.getenv_opt "MASC_AUTH_BARE_ALIAS_AUDIT_INTERVAL_S" with
+  | Some s ->
+    (match float_of_string_opt s with
+     | Some v when v > 0.0 -> v
+     | _ -> bare_alias_audit_interval_default)
+  | None -> bare_alias_audit_interval_default
+;;
+
+(* Periodic refresh of the bare-alias gauges. Boot-time audit sets
+   the gauge once; this fiber re-runs the audit every
+   [MASC_AUTH_BARE_ALIAS_AUDIT_INTERVAL_S] seconds (default 60) so
+   the surface stays fresh against mid-run regressions -- e.g. an
+   operator-initiated keeper add, a buggy provisioner that writes
+   bare files, or a config reload that broadens the keeper roster.
+   Without this, a regression introduced at runtime would be
+   invisible until the next server restart.
+
+   [canonical_names_fn] is invoked on every tick so a runtime
+   keeper-roster change is reflected in the next sweep without
+   restarting the fiber. *)
+let start_bare_alias_audit_fiber ~sw ~clock ~base_path
+    ~canonical_names_fn =
+  let interval = bare_alias_audit_interval () in
+  Eio.Fiber.fork ~sw (fun () ->
+    Log.Auth.info
+      "bare_alias_audit: periodic fiber started (interval=%.0fs)"
+      interval;
+    let rec loop () =
+      Eio.Time.sleep clock interval;
+      (try
+         let _ : bare_alias_audit_result =
+           bare_alias_audit ~base_path
+             ~canonical_names:(canonical_names_fn ())
+         in
+         ()
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         Log.Auth.warn
+           "bare_alias_audit: periodic tick failed: %s (gauges may be \
+            stale until next tick)"
+           (Printexc.to_string exn));
+      loop ()
+    in
+    loop ())
+;;

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -1139,33 +1139,74 @@ let prune_archive ~base_path ~retention_days ~min_keep : int * int =
     total - !prune_count, !prune_count)
 ;;
 
-let archive_bare_for_canonical config ~canonical_name =
+type bare_alias_state =
+  | Bare_absent
+  | Bare_alive_alias
+  | Bare_dead
+
+(* Inspect the bare-form file at [agents/<bare>.json] without mutating
+   it. Pure read; safe to call from audit paths.
+   - [Bare_absent]      no file at the bare path.
+   - [Bare_alive_alias] redirect stub aimed at the *same* UUID file
+                         as the canonical credential (= PR-#10440
+                         alias, must survive).
+   - [Bare_dead]        any other shape: direct credential, redirect
+                         to a different UUID, redirect with canonical
+                         missing or not stub-shaped. *)
+let classify_bare_for_canonical config ~canonical_name =
   match bare_keeper_name_from_canonical canonical_name with
-  | None -> ()
+  | None -> Bare_absent
   | Some bare_name ->
     let bare_file = credential_file config bare_name in
     if not (file_exists bare_file)
-    then ()
+    then Bare_absent
     else (
       let canonical_file = credential_file config canonical_name in
-      let is_alive_alias =
-        match
-          load_redirect_target config bare_file,
-          load_redirect_target config canonical_file
-        with
-        | Some bare_target, Some canonical_target ->
-          String.equal
-            (Filename.basename bare_target)
-            (Filename.basename canonical_target)
-        | _ -> false
-      in
-      if is_alive_alias
-      then ()
-      else
-        archive_credential_file
-          config
-          ~agent_name:bare_name
-          ~reason:"bare-form keeper credential is dead after PR-3b1 starvation")
+      match
+        load_redirect_target config bare_file,
+        load_redirect_target config canonical_file
+      with
+      | Some bare_target, Some canonical_target
+        when String.equal
+               (Filename.basename bare_target)
+               (Filename.basename canonical_target) -> Bare_alive_alias
+      | _ -> Bare_dead)
+;;
+
+let archive_bare_for_canonical config ~canonical_name =
+  match classify_bare_for_canonical config ~canonical_name with
+  | Bare_absent | Bare_alive_alias -> ()
+  | Bare_dead ->
+    (match bare_keeper_name_from_canonical canonical_name with
+     | None -> ()
+     | Some bare_name ->
+       archive_credential_file
+         config
+         ~agent_name:bare_name
+         ~reason:"bare-form keeper credential is dead after PR-3b1 starvation")
+;;
+
+type bare_alias_audit_result =
+  { alive_aliases : int
+  ; dead_bares : int
+  ; no_bares : int
+  }
+
+let empty_bare_alias_audit_result =
+  { alive_aliases = 0; dead_bares = 0; no_bares = 0 }
+
+let bare_alias_audit ~base_path ~canonical_names =
+  List.fold_left
+    (fun acc canonical_name ->
+       match classify_bare_for_canonical base_path ~canonical_name with
+       | Bare_absent ->
+         { acc with no_bares = acc.no_bares + 1 }
+       | Bare_alive_alias ->
+         { acc with alive_aliases = acc.alive_aliases + 1 }
+       | Bare_dead ->
+         { acc with dead_bares = acc.dead_bares + 1 })
+    empty_bare_alias_audit_result
+    canonical_names
 ;;
 
 let ensure_keeper_credential config ~agent_name

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -1059,33 +1059,113 @@ let archive_credential_file config ~agent_name ~reason =
 
 (* Boot self-heal of bare-form keeper credential files.
 
-   PR-3a (#11146) introduced this as a dual-identity guard, archiving
-   only the case where the bare file's token differed from the
-   canonical's. After PR-3b1 (#11152) starved the runtime caller
-   (lib/tool_coord.ml now asks for the canonical form via
-   Keeper_runtime.canonicalize_if_keeper), every bare-form file is a
-   dead reference at runtime regardless of its shape:
+   Three policies cross this code path:
 
-     - direct credential, different token  -> dual-identity (3a case)
-     - direct credential, same token       -> redundant alias
-     - redirect stub to canonical's UUID   -> unused after starvation
+     PR-3a (#11146)   archive bare when token differs from canonical
+                      (dual-identity guard).
+     PR-3b1 (#11152)  starve runtime callers via canonicalize_if_keeper
+                      in tool_coord.
+     PR-3b2 (#11155)  archive bare unconditionally, on the assumption
+                      that starvation killed every short-form caller.
+     PR-#10440        ensure_credential_alias re-creates a bare-form
+                      redirect stub on every boot so short-form
+                      load_credential callers (auth_doctor, etc.)
+                      resolve directly.
 
-   PR-3b2 generalises the helper to archive any of those without
-   inspecting the token, because none of them can route a request now.
-   The .archive/ destination preserves the file for operator review.
-   Idempotent: once archived, subsequent boots see no bare file and
-   become no-ops. Spec: AuthIdentityFSM.tla I1 IdentityBindsToken. *)
+   PR-3b2 and PR-#10440 contradict: the alias writer puts a stub back
+   on every boot and the archiver moves it on every boot, producing a
+   ping-pong that accumulated 331 .archive/<epoch>/ folders in 17 days
+   (measured 2026-05-14). Spec: AuthIdentityFSM.tla I1 IdentityBindsToken.
+
+   This helper resolves the conflict by recognising a legitimate alias
+   as alive: a bare-form file that is a redirect stub pointing to the
+   *same* UUID file as the canonical credential is the PR-#10440 alias
+   and must not be archived. Every other shape stays subject to PR-3b2:
+
+     - direct credential (no redirect)               -> archive
+     - redirect stub to a different UUID             -> archive (orphan)
+     - redirect stub to the same UUID as canonical   -> KEEP (alias)
+     - canonical missing or itself a direct cred     -> archive
+       (alias semantics need both sides to share a UUID-backed cred). *)
+(* Retention sweep for the .archive/<epoch>/ directories produced by
+   [archive_credential_file]. Each epoch dir is flat (one .json per
+   archived agent_name); this helper does not recurse so a stray
+   nested directory would be left in place instead of being deleted
+   wholesale. Returns [(kept, pruned)] for telemetry.
+
+   Selection rule: sort epochs newest-first, always keep the most
+   recent [min_keep], and among the remainder delete those whose
+   epoch is older than [retention_days * 86400] seconds. *)
+let prune_archive ~base_path ~retention_days ~min_keep : int * int =
+  let archive_dir = Filename.concat (auth_dir base_path) ".archive" in
+  if not (Sys.file_exists archive_dir && Sys.is_directory archive_dir)
+  then 0, 0
+  else (
+    let now = Unix.gettimeofday () in
+    let cutoff = now -. (float_of_int retention_days *. 86400.0) in
+    let entries =
+      try Sys.readdir archive_dir |> Array.to_list with
+      | Sys_error _ -> []
+    in
+    let epoch_entries =
+      List.filter_map
+        (fun name ->
+           match int_of_string_opt name with
+           | Some epoch -> Some (epoch, Filename.concat archive_dir name)
+           | None -> None)
+        entries
+      |> List.sort (fun (a, _) (b, _) -> compare b a)
+    in
+    let total = List.length epoch_entries in
+    let prune_count = ref 0 in
+    List.iteri
+      (fun i (epoch, path) ->
+         if i >= min_keep && float_of_int epoch < cutoff
+         then (
+           let inner =
+             try Sys.readdir path |> Array.to_list with
+             | Sys_error _ -> []
+           in
+           List.iter
+             (fun name ->
+                let file = Filename.concat path name in
+                try Sys.remove file with
+                | Sys_error _ -> ())
+             inner;
+           (try Fs_compat.rmdir path with
+            | Sys_error _ -> ());
+           if not (Sys.file_exists path) then incr prune_count))
+      epoch_entries;
+    total - !prune_count, !prune_count)
+;;
+
 let archive_bare_for_canonical config ~canonical_name =
   match bare_keeper_name_from_canonical canonical_name with
   | None -> ()
   | Some bare_name ->
     let bare_file = credential_file config bare_name in
-    if file_exists bare_file
-    then
-      archive_credential_file
-        config
-        ~agent_name:bare_name
-        ~reason:"bare-form keeper credential is dead after PR-3b1 starvation"
+    if not (file_exists bare_file)
+    then ()
+    else (
+      let canonical_file = credential_file config canonical_name in
+      let is_alive_alias =
+        match
+          load_redirect_target config bare_file,
+          load_redirect_target config canonical_file
+        with
+        | Some bare_target, Some canonical_target ->
+          String.equal
+            (Filename.basename bare_target)
+            (Filename.basename canonical_target)
+        | _ -> false
+      in
+      if is_alive_alias
+      then ()
+      else
+        archive_credential_file
+          config
+          ~agent_name:bare_name
+          ~reason:"bare-form keeper credential is dead after PR-3b1 starvation")
 ;;
 
 let ensure_keeper_credential config ~agent_name

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -1196,17 +1196,35 @@ let empty_bare_alias_audit_result =
   { alive_aliases = 0; dead_bares = 0; no_bares = 0 }
 
 let bare_alias_audit ~base_path ~canonical_names =
-  List.fold_left
-    (fun acc canonical_name ->
-       match classify_bare_for_canonical base_path ~canonical_name with
-       | Bare_absent ->
-         { acc with no_bares = acc.no_bares + 1 }
-       | Bare_alive_alias ->
-         { acc with alive_aliases = acc.alive_aliases + 1 }
-       | Bare_dead ->
-         { acc with dead_bares = acc.dead_bares + 1 })
-    empty_bare_alias_audit_result
-    canonical_names
+  let result =
+    List.fold_left
+      (fun acc canonical_name ->
+         match classify_bare_for_canonical base_path ~canonical_name with
+         | Bare_absent ->
+           { acc with no_bares = acc.no_bares + 1 }
+         | Bare_alive_alias ->
+           { acc with alive_aliases = acc.alive_aliases + 1 }
+         | Bare_dead ->
+           { acc with dead_bares = acc.dead_bares + 1 })
+      empty_bare_alias_audit_result
+      canonical_names
+  in
+  (* Observability sink: gauges idempotently mirror the current
+     classifier state so every Prometheus scrape (post-call) reports
+     the same value, not just the boot-time INFO line. *)
+  Prometheus.set_gauge
+    Prometheus.metric_auth_bare_alias
+    ~labels:[ "state", "alive" ]
+    (float_of_int result.alive_aliases);
+  Prometheus.set_gauge
+    Prometheus.metric_auth_bare_alias
+    ~labels:[ "state", "dead" ]
+    (float_of_int result.dead_bares);
+  Prometheus.set_gauge
+    Prometheus.metric_auth_bare_alias
+    ~labels:[ "state", "no_bare" ]
+    (float_of_int result.no_bares);
+  result
 ;;
 
 let ensure_keeper_credential config ~agent_name

--- a/lib/auth.mli
+++ b/lib/auth.mli
@@ -332,11 +332,13 @@ val bare_alias_audit
   :  base_path:string
   -> canonical_names:string list
   -> bare_alias_audit_result
-(** Read-only audit of bare/canonical alignment for the supplied
-    canonical agent names. Does not mutate state. Intended for boot-
-    time observability so the operator sees ping-pong regressions as
-    a non-zero [dead_bares] count surfacing on every boot, not as the
-    absence of WARN lines. *)
+(** Audit bare/canonical alignment for the supplied canonical agent
+    names. Read-only with respect to credential files. Side effect:
+    mirrors the counts into Prometheus gauges
+    [masc_auth_bare_alias{state=alive|dead|no_bare}] so the values
+    are repeatedly visible on every scrape, not only as a one-shot
+    boot log line. A non-zero [dead_bares] surfaces a ping-pong
+    regression candidate (PR #15112 γ guard). *)
 
 (** {1 Credential Archive Retention} *)
 

--- a/lib/auth.mli
+++ b/lib/auth.mli
@@ -313,3 +313,17 @@ val read_initial_admin : string -> string option
 (** {1 Nickname Helpers} *)
 
 val extract_agent_type_prefix : string -> string option
+
+(** {1 Credential Archive Retention} *)
+
+val prune_archive
+  :  base_path:string
+  -> retention_days:int
+  -> min_keep:int
+  -> int * int
+(** [prune_archive ~base_path ~retention_days ~min_keep] deletes
+    [<base_path>/.masc/auth/.archive/<epoch>/] subdirectories that are
+    older than [retention_days * 86400] seconds, always keeping the
+    most recent [min_keep] epochs regardless of age. Returns
+    [(kept, pruned)]. Non-recursive: each epoch dir is treated as flat
+    (one .json per archived agent_name). *)

--- a/lib/auth.mli
+++ b/lib/auth.mli
@@ -314,6 +314,30 @@ val read_initial_admin : string -> string option
 
 val extract_agent_type_prefix : string -> string option
 
+(** {1 Bare-form Alias Audit} *)
+
+type bare_alias_audit_result =
+  { alive_aliases : int
+  ; dead_bares : int
+  ; no_bares : int
+  }
+(** Aggregate of {!bare_alias_audit}. [alive_aliases] is the count of
+    bare-form files that are legitimate PR-#10440 short-form aliases
+    (redirect stub aimed at the same UUID as the canonical credential).
+    [dead_bares] is the count that would be archived under PR-3b2
+    ([archive_bare_for_canonical] would move them). [no_bares] is the
+    count of canonical names that have no bare-form file at all. *)
+
+val bare_alias_audit
+  :  base_path:string
+  -> canonical_names:string list
+  -> bare_alias_audit_result
+(** Read-only audit of bare/canonical alignment for the supplied
+    canonical agent names. Does not mutate state. Intended for boot-
+    time observability so the operator sees ping-pong regressions as
+    a non-zero [dead_bares] count surfacing on every boot, not as the
+    absence of WARN lines. *)
+
 (** {1 Credential Archive Retention} *)
 
 val prune_archive

--- a/lib/auth.mli
+++ b/lib/auth.mli
@@ -340,6 +340,20 @@ val bare_alias_audit
     boot log line. A non-zero [dead_bares] surfaces a ping-pong
     regression candidate (PR #15112 γ guard). *)
 
+val start_bare_alias_audit_fiber
+  :  sw:Eio.Switch.t
+  -> clock:_ Eio.Time.clock
+  -> base_path:string
+  -> canonical_names_fn:(unit -> string list)
+  -> unit
+(** Fork an Eio fiber that re-runs [bare_alias_audit] every
+    [MASC_AUTH_BARE_ALIAS_AUDIT_INTERVAL_S] seconds (default 60). Each
+    tick refreshes the [masc_auth_bare_alias{state=...}] gauges so
+    mid-run regressions surface within one interval instead of waiting
+    for the next server boot. [canonical_names_fn] is invoked per
+    tick to follow keeper-roster changes. Exceptions inside a tick
+    are logged and absorbed; the loop continues. *)
+
 (** {1 Credential Archive Retention} *)
 
 val prune_archive

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -986,6 +986,30 @@ let metric_config_credential_archived_starvation =
   "masc_config_credential_archived_starvation_total"
 ;;
 
+(* Post-fix observability for PR #15112 (γ guard against PR-#10440 ↔
+   PR-3b2 ping-pong). Each is set by [sync_bootable_keeper_credentials]
+   after the boot sweep so the value is repeatedly visible on every
+   Prometheus scrape, not only as a one-shot boot log line.
+
+   Labels: [state] ∈ {alive, dead, no_bare}.
+   - [alive] count of bare-form files that are PR-#10440 redirect
+     stubs aimed at the canonical credential's UUID (steady-state
+     after γ).
+   - [dead]  ping-pong regression canary; non-zero means the γ
+     classifier let through a bare file that would have been
+     archived under PR-3b2, OR a future code change has reintroduced
+     unconditional archive behavior.
+   - [no_bare] canonical names with no bare-form file at all. *)
+let metric_auth_bare_alias = "masc_auth_bare_alias"
+
+(* Disk inventory + churn for the .archive/<epoch>/ directory.
+   [metric_auth_archive_epochs] is the count of epoch subdirs left
+   after the retention sweep. [metric_auth_archive_pruned_total]
+   increments by the number of epochs removed by [Auth.prune_archive]
+   on each boot. *)
+let metric_auth_archive_epochs = "masc_auth_archive_epochs"
+let metric_auth_archive_pruned_total = "masc_auth_archive_pruned_total"
+
 (* #9786 runtime complement: every [find_credential_by_token]
    lookup that hits N>=2 matches fires this counter.  The
    boot-time audit ({!metric_auth_credential_token_duplicate})
@@ -2420,6 +2444,22 @@ let init () =
     metric_config_credential_archived_starvation
     "Total bare-form keeper credential files archived because they are dead after PR-3b1 \
      starvation. Labels: keeper_name."
+    Counter;
+  add
+    metric_auth_bare_alias
+    "Steady-state count of bare-form keeper alias files per classifier state. \
+     Labels: state=alive|dead|no_bare. Non-zero state=dead is the ping-pong \
+     regression canary for PR #15112 γ guard; alert on it."
+    Gauge;
+  add
+    metric_auth_archive_epochs
+    "Current number of .archive/<epoch>/ subdirectories after the retention \
+     sweep. Tracks disk inventory growth of archived credentials."
+    Gauge;
+  add
+    metric_auth_archive_pruned_total
+    "Total .archive/<epoch>/ subdirectories removed by the boot-time retention \
+     sweep. Increments by the per-boot prune count."
     Counter;
   add
     metric_telemetry_coverage_gap

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -860,6 +860,22 @@ val metric_auth_credential_token_rotated : string
     PR-3b1 starvation. Labels: [keeper_name]. *)
 val metric_config_credential_archived_starvation : string
 
+(** Steady-state count of bare-form keeper alias files per classifier state.
+    Labels: [state] ∈ {alive, dead, no_bare}. Set on every boot by the
+    credential sweep so the value is repeatedly visible on every Prometheus
+    scrape. Non-zero [state=dead] is the ping-pong regression canary for
+    PR #15112 γ guard. *)
+val metric_auth_bare_alias : string
+
+(** Current number of [.archive/<epoch>/] subdirectories after the boot-time
+    retention sweep. Set by [Auth.prune_archive] via the
+    [startup_prune_auth_archive] lazy task. *)
+val metric_auth_archive_epochs : string
+
+(** Total epoch subdirectories removed by [Auth.prune_archive]. Increments
+    by the per-boot prune count. *)
+val metric_auth_archive_pruned_total : string
+
 (** #9786 runtime complement: every [find_credential_by_token]
     lookup that hits N>=2 matches fires this counter.
     Labels: [first_match] = the agent_name that won the

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -979,6 +979,18 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     ~sw
     ~clock
     ~base_path:state.room_config.base_path;
+  (* Bare-alias audit fiber (PR #15112 surface refresh): re-run the
+     classifier every minute so the [masc_auth_bare_alias] gauges
+     reflect mid-run regressions, not only the boot snapshot. The
+     keeper roster is re-queried per tick via the closure so a
+     runtime add/remove is picked up without restarting the fiber. *)
+  Auth.start_bare_alias_audit_fiber
+    ~sw
+    ~clock
+    ~base_path:state.room_config.base_path
+    ~canonical_names_fn:(fun () ->
+      Keeper_runtime.bootable_keeper_names state.room_config
+      |> List.map Keeper_types_profile.keeper_agent_name);
   (* #9876: Hebbian consolidation fiber. Prior to this, the graph was
      write-only — strengthen/weaken populated synapses but decay +
      pruning never ran (zero production callers of [consolidate]).

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1058,6 +1058,24 @@ let sync_bootable_keeper_credentials (state : Mcp_server.server_state) =
               keeper_name agent_name
               (Masc_domain.masc_error_to_string err))
     keeper_names keeper_agent_names;
+  (* Post-sweep audit: surface the ping-pong outcome as a positive
+     boot signal. Before the γ fix (PR #15112) every keeper logged
+     a WARN "archived credential ..." line and operators could only
+     detect regressions by counting WARN lines. Now we emit a single
+     structured INFO so the steady-state ("alive_aliases=N dead=0")
+     is visible on every boot; a non-zero [dead_bares] is the canary
+     for ping-pong regression. *)
+  let audit =
+    Auth.bare_alias_audit ~base_path ~canonical_names:keeper_agent_names
+  in
+  Log.Server.info
+    "startup bare alias audit: alive_aliases=%d dead_bares=%d no_bares=%d"
+    audit.alive_aliases audit.dead_bares audit.no_bares;
+  if audit.dead_bares > 0 then
+    Log.Server.warn
+      "startup bare alias audit: dead_bares=%d (ping-pong regression \
+       candidate; see PR #15112 γ guard)"
+      audit.dead_bares;
   let rotation_outcomes =
     Auth.rotate_shared_tokens_for_agents base_path
       ~agent_names:keeper_agent_names

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1235,6 +1235,37 @@ let startup_prune_keeper_checkpoints (state : Mcp_server.server_state) =
      Log.Misc.warn "startup checkpoint prune failed: %s (next boot retries)"
        (Printexc.to_string exn))
 
+let startup_prune_auth_archive (state : Mcp_server.server_state) =
+  (try
+     let days =
+       Safe_ops.get_env_int_logged
+         "MASC_AUTH_ARCHIVE_RETENTION_DAYS"
+         ~default:30
+     in
+     let min_keep =
+       Safe_ops.get_env_int_logged
+         "MASC_AUTH_ARCHIVE_MIN_KEEP"
+         ~default:20
+     in
+     let kept, pruned =
+       Auth.prune_archive
+         ~base_path:state.room_config.base_path
+         ~retention_days:days
+         ~min_keep
+     in
+     if pruned > 0 then
+       Log.Misc.info
+         "startup auth archive prune: pruned=%d kept=%d (retention=%dd \
+          min_keep=%d)"
+         pruned kept days min_keep
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+     Log.Misc.warn
+       "startup auth archive prune failed: %s (next boot retries; disk \
+        impact bounded by retention)"
+       (Printexc.to_string exn))
+
 let startup_migrate_keeper_histories (state : Mcp_server.server_state) =
   (try
      let traces_dir =
@@ -1571,6 +1602,8 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
           ("jsonl_prune", fun () -> startup_prune_jsonl state);
           ( "keeper_checkpoint_prune",
             fun () -> startup_prune_keeper_checkpoints state );
+          ( "auth_archive_prune",
+            fun () -> startup_prune_auth_archive state );
           (* keeper_bootstrap removed: keeper_autoboot subsystem in
              start_keeper_loops handles this in a dedicated fiber,
              avoiding bootstrap contention with dashboard refresh loops. *)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1065,6 +1065,11 @@ let sync_bootable_keeper_credentials (state : Mcp_server.server_state) =
      structured INFO so the steady-state ("alive_aliases=N dead=0")
      is visible on every boot; a non-zero [dead_bares] is the canary
      for ping-pong regression. *)
+  (* [Auth.bare_alias_audit] mirrors the result into the
+     [masc_auth_bare_alias{state=...}] gauges so the boot signal
+     stays surfaced on every Prometheus scrape. The INFO line below
+     is the one-shot boot log mirror; the WARN that follows is the
+     regression canary. *)
   let audit =
     Auth.bare_alias_audit ~base_path ~canonical_names:keeper_agent_names
   in
@@ -1271,11 +1276,16 @@ let startup_prune_auth_archive (state : Mcp_server.server_state) =
          ~retention_days:days
          ~min_keep
      in
-     if pruned > 0 then
+     Prometheus.set_gauge Prometheus.metric_auth_archive_epochs
+       (float_of_int kept);
+     if pruned > 0 then (
+       Prometheus.inc_counter Prometheus.metric_auth_archive_pruned_total
+         ~delta:(float_of_int pruned)
+         ();
        Log.Misc.info
          "startup auth archive prune: pruned=%d kept=%d (retention=%dd \
           min_keep=%d)"
-         pruned kept days min_keep
+         pruned kept days min_keep)
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -852,6 +852,45 @@ let test_no_ping_pong_across_repeated_boots () =
       check int "audit dead_bares=0" 0 audit.dead_bares;
       check int "audit no_bares=0" 0 audit.no_bares)
 
+(* Surface assertion: [bare_alias_audit] mirrors counts into the
+   Prometheus gauges so every scrape (not only the boot INFO line)
+   exposes the current alive/dead/no_bare split. A regression that
+   stops emitting the gauges fails this test even if the in-process
+   return value is still correct. *)
+let test_bare_alias_audit_emits_prometheus_gauges () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore
+        (Auth.enable_auth dir ~require_token:true
+           ~agent_name:"bootstrap-admin");
+      (match
+         Auth.ensure_keeper_credential dir
+           ~agent_name:"keeper-sangsu-agent"
+       with
+       | Ok _ -> ()
+       | Error e -> fail (Masc_domain.masc_error_to_string e));
+      (match
+         Auth.ensure_credential_alias dir
+           ~canonical_name:"keeper-sangsu-agent" ~alias_name:"sangsu"
+       with
+       | Ok () -> ()
+       | Error e -> fail (Masc_domain.masc_error_to_string e));
+      let _ : Auth.bare_alias_audit_result =
+        Auth.bare_alias_audit ~base_path:dir
+          ~canonical_names:["keeper-sangsu-agent"]
+      in
+      let read state =
+        Masc_mcp.Prometheus.metric_value_or_zero
+          Masc_mcp.Prometheus.metric_auth_bare_alias
+          ~labels:[("state", state)]
+          ()
+      in
+      check (float 0.0001) "alive gauge = 1" 1.0 (read "alive");
+      check (float 0.0001) "dead gauge = 0" 0.0 (read "dead");
+      check (float 0.0001) "no_bare gauge = 0" 0.0 (read "no_bare"))
+
 let test_bare_alias_audit_classifies_states () =
   let dir = setup_test_room () in
   Fun.protect
@@ -1310,6 +1349,8 @@ let () =
         test_no_ping_pong_across_repeated_boots;
       test_case "bare_alias_audit classifies states" `Quick
         test_bare_alias_audit_classifies_states;
+      test_case "bare_alias_audit emits Prometheus gauges" `Quick
+        test_bare_alias_audit_emits_prometheus_gauges;
       test_case "prune_archive drops aged epoch dirs" `Quick
         test_prune_archive_retains_recent_and_drops_old;
       test_case "prune_archive honors min_keep" `Quick

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -810,6 +810,98 @@ let test_prune_archive_retains_recent_and_drops_old () =
       check int "kept count" 1 kept;
       check int "pruned count" 1 pruned)
 
+(* Direct repeatability guard for the 331-epoch ping-pong: simulate
+   five boot cycles (ensure_keeper_credential + ensure_credential_alias)
+   and assert the .archive/ directory never materialises. A regression
+   that re-introduces unconditional archiving would create one epoch
+   dir per loop iteration and fail this test deterministically. *)
+let test_no_ping_pong_across_repeated_boots () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore
+        (Auth.enable_auth dir ~require_token:true
+           ~agent_name:"bootstrap-admin");
+      for _ = 1 to 5 do
+        (match
+           Auth.ensure_keeper_credential dir
+             ~agent_name:"keeper-sangsu-agent"
+         with
+         | Ok _ -> ()
+         | Error e -> fail (Masc_domain.masc_error_to_string e));
+        (match
+           Auth.ensure_credential_alias dir
+             ~canonical_name:"keeper-sangsu-agent"
+             ~alias_name:"sangsu"
+         with
+         | Ok () -> ()
+         | Error e -> fail (Masc_domain.masc_error_to_string e))
+      done;
+      let bare_path = Auth.credential_file dir "sangsu" in
+      check bool "alias survives 5 boot cycles" true
+        (Sys.file_exists bare_path);
+      check bool ".archive/ never created" false
+        (Sys.file_exists (archive_dir_of dir));
+      let audit =
+        Auth.bare_alias_audit
+          ~base_path:dir
+          ~canonical_names:["keeper-sangsu-agent"]
+      in
+      check int "audit alive_aliases=1" 1 audit.alive_aliases;
+      check int "audit dead_bares=0" 0 audit.dead_bares;
+      check int "audit no_bares=0" 0 audit.no_bares)
+
+let test_bare_alias_audit_classifies_states () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore
+        (Auth.enable_auth dir ~require_token:true
+           ~agent_name:"bootstrap-admin");
+      (* alive: canonical minted + alias written *)
+      (match
+         Auth.ensure_keeper_credential dir
+           ~agent_name:"keeper-alive-agent"
+       with
+       | Ok _ -> ()
+       | Error e -> fail (Masc_domain.masc_error_to_string e));
+      (match
+         Auth.ensure_credential_alias dir
+           ~canonical_name:"keeper-alive-agent" ~alias_name:"alive"
+       with
+       | Ok () -> ()
+       | Error e -> fail (Masc_domain.masc_error_to_string e));
+      (* dead: canonical exists but bare points to a stale UUID *)
+      (match
+         Auth.ensure_keeper_credential dir
+           ~agent_name:"keeper-dead-agent"
+       with
+       | Ok _ -> ()
+       | Error e -> fail (Masc_domain.masc_error_to_string e));
+      Auth.save_private_text_file
+        (Auth.credential_file dir "dead")
+        {|{ "redirect_to": "stale-uuid.json" }|};
+      (* no_bare: canonical exists, no bare file written *)
+      (match
+         Auth.ensure_keeper_credential dir
+           ~agent_name:"keeper-orphan-agent"
+       with
+       | Ok _ -> ()
+       | Error e -> fail (Masc_domain.masc_error_to_string e));
+      let audit =
+        Auth.bare_alias_audit ~base_path:dir
+          ~canonical_names:
+            [ "keeper-alive-agent"
+            ; "keeper-dead-agent"
+            ; "keeper-orphan-agent"
+            ]
+      in
+      check int "alive=1" 1 audit.alive_aliases;
+      check int "dead=1" 1 audit.dead_bares;
+      check int "no_bare=1" 1 audit.no_bares)
+
 let test_prune_archive_honors_min_keep () =
   let dir = setup_test_room () in
   Fun.protect
@@ -1214,6 +1306,10 @@ let () =
         test_ensure_keeper_credential_no_archive_when_no_bare;
       test_case "archive_bare skips alive alias (γ)" `Quick
         test_archive_bare_skips_alive_alias;
+      test_case "no ping-pong across repeated boots" `Quick
+        test_no_ping_pong_across_repeated_boots;
+      test_case "bare_alias_audit classifies states" `Quick
+        test_bare_alias_audit_classifies_states;
       test_case "prune_archive drops aged epoch dirs" `Quick
         test_prune_archive_retains_recent_and_drops_old;
       test_case "prune_archive honors min_keep" `Quick

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -695,12 +695,11 @@ let test_ensure_keeper_credential_archives_dual_identity_bare () =
       check bool "canonical credential remains" true
         (Sys.file_exists canonical_path))
 
-(* PR-3b2: bare-form file may also be a redirect stub (PR #10440
-   pattern -- {"redirect_to": "<uuid>.json"}) rather than a direct
-   credential. After PR-3b1 starvation, even redirect stubs are dead
-   references. The generalised archive_bare_for_canonical archives
-   them too. This is the production shape for all 8 keepers in
-   ~/.masc/auth/agents/ as of 2026-04-27. *)
+(* PR-3b2: a bare-form file that is a redirect stub aiming at a UUID
+   *different* from the canonical credential's UUID is an orphan and
+   must be archived. Under γ (ping-pong fix 2026-05-14) this case is
+   still archived; only the alive-alias case
+   (test_archive_bare_skips_alive_alias) survives. *)
 let test_ensure_keeper_credential_archives_redirect_stub_bare () =
   let dir = setup_test_room () in
   Fun.protect
@@ -743,6 +742,99 @@ let test_ensure_keeper_credential_no_archive_when_no_bare () =
       let archive = archive_dir_of dir in
       check bool "no archive directory created on clean state" false
         (Sys.file_exists archive))
+
+(* γ regression guard (ping-pong fix 2026-05-14): when the bare-form
+   file is a legitimate short-form alias written by
+   ensure_credential_alias (#10440) -- i.e. a redirect stub pointing
+   to the *same* UUID file as the canonical credential -- the boot
+   sweep must keep it. Without this, every boot archives the alias
+   and the alias writer immediately re-creates it, producing the
+   331-epoch .archive/ accumulation observed on prod 2026-05-14. *)
+let test_archive_bare_skips_alive_alias () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore
+        (Auth.enable_auth dir ~require_token:true
+           ~agent_name:"bootstrap-admin");
+      (match
+         Auth.ensure_keeper_credential dir
+           ~agent_name:"keeper-sangsu-agent"
+       with
+       | Ok _ -> ()
+       | Error e -> fail (Masc_domain.masc_error_to_string e));
+      (match
+         Auth.ensure_credential_alias dir
+           ~canonical_name:"keeper-sangsu-agent"
+           ~alias_name:"sangsu"
+       with
+       | Ok () -> ()
+       | Error e -> fail (Masc_domain.masc_error_to_string e));
+      let bare_path = Auth.credential_file dir "sangsu" in
+      check bool "alias written by ensure_credential_alias" true
+        (Sys.file_exists bare_path);
+      (match
+         Auth.ensure_keeper_credential dir
+           ~agent_name:"keeper-sangsu-agent"
+       with
+       | Ok _ -> ()
+       | Error e -> fail (Masc_domain.masc_error_to_string e));
+      check bool "alive alias survives second boot" true
+        (Sys.file_exists bare_path);
+      check bool "alive alias NOT archived" false
+        (archive_contains dir "sangsu.json"))
+
+let test_prune_archive_retains_recent_and_drops_old () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      let archive_root = Filename.concat (Auth.auth_dir dir) ".archive" in
+      Fs_compat.mkdir_p archive_root;
+      let now = int_of_float (Unix.gettimeofday ()) in
+      let make_epoch epoch =
+        let path = Filename.concat archive_root (string_of_int epoch) in
+        Fs_compat.mkdir_p path;
+        Auth.save_private_text_file
+          (Filename.concat path "victim.json") "{}";
+        path
+      in
+      let recent = make_epoch (now - (2 * 86400)) in
+      let aged = make_epoch (now - (60 * 86400)) in
+      let kept, pruned =
+        Auth.prune_archive ~base_path:dir ~retention_days:30 ~min_keep:1
+      in
+      check bool "recent epoch dir survives" true (Sys.file_exists recent);
+      check bool "aged epoch dir pruned" false (Sys.file_exists aged);
+      check int "kept count" 1 kept;
+      check int "pruned count" 1 pruned)
+
+let test_prune_archive_honors_min_keep () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      let archive_root = Filename.concat (Auth.auth_dir dir) ".archive" in
+      Fs_compat.mkdir_p archive_root;
+      let now = int_of_float (Unix.gettimeofday ()) in
+      let aged_paths =
+        List.init 3 (fun i ->
+          let epoch = now - (60 * 86400) - i in
+          let path = Filename.concat archive_root (string_of_int epoch) in
+          Fs_compat.mkdir_p path;
+          path)
+      in
+      let kept, pruned =
+        Auth.prune_archive ~base_path:dir ~retention_days:30 ~min_keep:5
+      in
+      List.iter
+        (fun p ->
+          check bool "aged dir retained because of min_keep" true
+            (Sys.file_exists p))
+        aged_paths;
+      check int "all aged kept (under min_keep)" 3 kept;
+      check int "nothing pruned" 0 pruned)
 
 let test_ensure_keeper_credential_reuses_persisted_raw_token_when_env_mismatched () =
   let dir = setup_test_room () in
@@ -1120,6 +1212,12 @@ let () =
         test_ensure_keeper_credential_archives_redirect_stub_bare;
       test_case "ensure_keeper_credential no archive on clean state" `Quick
         test_ensure_keeper_credential_no_archive_when_no_bare;
+      test_case "archive_bare skips alive alias (γ)" `Quick
+        test_archive_bare_skips_alive_alias;
+      test_case "prune_archive drops aged epoch dirs" `Quick
+        test_prune_archive_retains_recent_and_drops_old;
+      test_case "prune_archive honors min_keep" `Quick
+        test_prune_archive_honors_min_keep;
     ];
     "permissions", [
       test_case "worker permissions" `Quick test_worker_permissions;


### PR DESCRIPTION
## 목표

`ensure_credential_alias` (PR-#10440) 와 `archive_bare_for_canonical` (PR-3b2 #11155) 이 매 부팅마다 같은 bare-form 파일을 두고 ping-pong 하던 split-brain 종료. 추가로 `.archive/` retention 정책 신설.

## 측정 (2026-05-14)

`/Users/dancer/me/.masc/auth/.archive/` 상태:
- **331 epoch 폴더 누적** (2026-04-27 ~ 2026-05-14, 17일간)
- 일평균 약 20회 archive cycle
- 매 부팅 18 WARN 라인 (\`archived credential ... reason: bare-form keeper credential is dead\`)
- `.masc/auth/agents/` 현재 59 파일 (bare 18 + canonical 18 + UUID 14 + 기타 9) — 사실상 데이터 leak

## 근본 원인

두 PR 모두 *개별적으로* 정당:
- **PR-#10440** \`fix(auth): write short-form alias for every keeper at bootstrap\` — \`auth_doctor.ml\` 등 short-form \`load_credential\` caller가 fail하던 문제 해결. 8/14 keeper가 영향받았던 prod bug.
- **PR-3b2 #11155** \`fix(auth): archive bare-form keeper credentials regardless of shape\` — PR-3b1 starvation 가정 하에 bare-form은 모두 dead로 간주.

**충돌**: PR-3b2의 가정(*\"bare path는 모두 dead\"*)이 PR-#10440의 의도(*\"bare alias가 live caller에 필요\"*)와 정면 모순. `sync_bootable_keeper_credentials` 한 함수 안에서 line 1025의 \`ensure_keeper_credential\` 끝에 archive, line 1047의 \`ensure_credential_alias\` 가 다시 alias를 씀.

## 변경

**γ (smart archive)** — `lib/auth.ml: archive_bare_for_canonical`:
- bare 파일이 redirect stub 이고 **canonical과 동일 UUID 파일**을 가리키면 → KEEP (PR-#10440 alias).
- 그 외 (direct credential, 다른 UUID, orphan stub, canonical missing) → 기존대로 archive (PR-3b2 유지).

**E (retention)** — `Auth.prune_archive` + `startup_prune_auth_archive` lazy task:
- `MASC_AUTH_ARCHIVE_RETENTION_DAYS` (default 30) 이상 오래된 epoch dir 제거.
- `MASC_AUTH_ARCHIVE_MIN_KEEP` (default 20) — 최소 보존 개수.
- `startup_prune_jsonl` / `startup_prune_keeper_checkpoints` 와 같은 lazy task 그룹에 wiring.

## 변경 파일

- `lib/auth.ml` — γ 로직 + `prune_archive`, doc comment 갱신 (PR-3a/3b1/3b2 + #10440 conflict 명시).
- `lib/auth.mli` — `prune_archive` 노출.
- `lib/server/server_runtime_bootstrap.ml` — `startup_prune_auth_archive` 함수 + lazy task entry.
- `test/test_auth.ml` — 양성 케이스 1 + retention 2 + 기존 redirect_stub 테스트 코멘트 명료화.

## 테스트

| 테스트 | 의도 |
|---|---|
| `test_archive_bare_skips_alive_alias` (new) | γ 양성. PR-#10440 alias 가 두 번째 boot 에서도 살아남음. |
| `test_ensure_keeper_credential_archives_redirect_stub_bare` (수정 코멘트) | γ 음성. canonical 과 다른 UUID 가리키는 orphan stub 은 여전히 archive. |
| `test_ensure_keeper_credential_archives_dual_identity_bare` (unchanged) | PR-3a 회귀 guard. |
| `test_prune_archive_retains_recent_and_drops_old` (new) | retention 양성 + 음성. |
| `test_prune_archive_honors_min_keep` (new) | min_keep override. |

## 로컬 검증

- `pr-rfc-check.sh`: **PASS** (스크립트의 subsystem 패턴이 \`lib/auth.ml\` 을 자동 매칭하지는 않음 — RFC 인용은 본 PR body 의 \"RFC\" 섹션으로 수동 명시).
- dune build: worktree lock contention (6 queued) — GitHub Actions clean 환경 검증 위임. 메모리 \`reference_masc_mcp_dune_local_lock_contention.md\` 참조.

## RFC

- **RFC-0019 Keeper Credential Unification** §2 (\"process root cause\") + §3.2 P9 (\"No agent PR in this subsystem without prior RFC reference\") 명시 인용.
- 본 PR 은 RFC-0019 §4 의 통합 architecture 가 *아님*. **narrow split-brain reconciliation** — PR-#10440 / PR-3b2 의도 둘 다 보존, 한쪽 architecture 선택 X.
- \`.archive/\` retention 은 RFC-0019 의 어느 unification path 에서도 필요한 공통 인프라.

## 미검증 항목

- 컴파일 (CI 의존).
- prod 환경의 \`.archive/\` 331 폴더는 *과거 데이터* 라 retention 이 두 번째 boot 부터 적용. 첫 boot 에 331 모두 prune 되면 ~6초 디스크 I/O — lazy task 라 listen 후 백그라운드.
- canonical 이 *direct credential* (UUID 없음) 인 케이스: bare 가 stub 이어도 alive 판정 불가 → archive. \`auth.mli load_credential\` 문서에 명시된 dual-identity 시나리오와 일치.

🤖 Generated with [Claude Code](https://claude.com/claude-code)