### PR TITLE
fix(dashboard): surface route readiness in operations

### DIFF
--- a/dashboard/src/components/operations-panel.test.ts
+++ b/dashboard/src/components/operations-panel.test.ts
@@ -29,6 +29,9 @@ async function loadPanel() {
   vi.doMock('./safe-autonomy', () => ({
     SafeAutonomyPanel: () => html`<div data-testid="safety">Safety</div>`,
   }))
+  vi.doMock('./surface-readiness-panel', () => ({
+    SurfaceReadinessPanel: () => html`<div data-testid="surfaces">Surfaces</div>`,
+  }))
   return import('./operations-panel')
 }
 
@@ -53,9 +56,10 @@ describe('OperationsPanel', () => {
     vi.doUnmock('./connector-status')
     vi.doUnmock('./lab-inspector')
     vi.doUnmock('./safe-autonomy')
+    vi.doUnmock('./surface-readiness-panel')
   })
 
-  it('renders Ops, Governance, and Safety when view is not set (default)', async () => {
+  it('renders Ops, Governance, Safety, and Surfaces when view is not set (default)', async () => {
     const { OperationsPanel } = await loadPanel()
     render(html`<${OperationsPanel} />`, container)
     await flushUi()
@@ -63,6 +67,7 @@ describe('OperationsPanel', () => {
     expect(container.textContent).toContain('Ops')
     expect(container.textContent).toContain('Governance')
     expect(container.textContent).toContain('Safety')
+    expect(container.textContent).toContain('Surfaces')
   })
 
   it('renders only Ops when view is ops', async () => {
@@ -74,6 +79,7 @@ describe('OperationsPanel', () => {
     expect(container.querySelector('[data-testid="ops"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="governance"]')).toBeNull()
     expect(container.querySelector('[data-testid="safety"]')).toBeNull()
+    expect(container.querySelector('[data-testid="surfaces"]')).toBeNull()
   })
 
   it('renders only Governance when view is governance', async () => {
@@ -85,6 +91,19 @@ describe('OperationsPanel', () => {
     expect(container.textContent).not.toContain('Ops')
     expect(container.textContent).toContain('Governance')
     expect(container.querySelector('[data-testid="safety"]')).toBeNull()
+    expect(container.querySelector('[data-testid="surfaces"]')).toBeNull()
+  })
+
+  it('renders only Surface Readiness when view is surfaces', async () => {
+    route.value.params = { section: 'operations', view: 'surfaces' }
+    const { OperationsPanel } = await loadPanel()
+    render(html`<${OperationsPanel} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="ops"]')).toBeNull()
+    expect(container.querySelector('[data-testid="governance"]')).toBeNull()
+    expect(container.querySelector('[data-testid="safety"]')).toBeNull()
+    expect(container.querySelector('[data-testid="surfaces"]')).not.toBeNull()
   })
 
   it('renders FilterChips options without legacy connectors view', async () => {
@@ -94,12 +113,13 @@ describe('OperationsPanel', () => {
 
     const tablist = container.querySelector('[role="tablist"]')
     const buttons = tablist?.querySelectorAll('[role="tab"]') ?? []
-    expect(buttons.length).toBe(5)
+    expect(buttons.length).toBe(6)
     const labels = Array.from(buttons).map(b => b.textContent?.trim())
     expect(labels).toContain('All')
     expect(labels).toContain('Intervene')
     expect(labels).toContain('Governance')
     expect(labels).toContain('Safety')
+    expect(labels).toContain('Surfaces')
     expect(labels).toContain('Inspector')
     expect(labels).not.toContain('Connectors')
   })
@@ -113,6 +133,7 @@ describe('OperationsPanel', () => {
     expect(container.textContent).toContain('Ops')
     expect(container.textContent).toContain('Governance')
     expect(container.querySelector('[data-testid="safety"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="surfaces"]')).not.toBeNull()
   })
 
   it('marks the active chip with aria-selected=true', async () => {

--- a/dashboard/src/components/operations-panel.ts
+++ b/dashboard/src/components/operations-panel.ts
@@ -9,17 +9,19 @@ import { Ops } from './ops'
 import { Governance } from './governance'
 import { LabInspector } from './lab-inspector'
 import { SafeAutonomyPanel } from './safe-autonomy'
+import { SurfaceReadinessPanel } from './surface-readiness-panel'
 import { replaceRoute, route } from '../router'
 
-type OpsView = 'default' | 'ops' | 'governance' | 'safety' | 'inspector'
+type OpsView = 'default' | 'ops' | 'governance' | 'safety' | 'surfaces' | 'inspector'
 
-const VALID_VIEWS: OpsView[] = ['default', 'ops', 'governance', 'safety', 'inspector']
+const VALID_VIEWS: OpsView[] = ['default', 'ops', 'governance', 'safety', 'surfaces', 'inspector']
 
 const VIEW_CHIPS: { key: OpsView; label: string }[] = [
   { key: 'default', label: 'All' },
   { key: 'ops', label: 'Intervene' },
   { key: 'governance', label: 'Governance' },
   { key: 'safety', label: 'Safety' },
+  { key: 'surfaces', label: 'Surfaces' },
   { key: 'inspector', label: 'Inspector' },
 ]
 
@@ -72,6 +74,8 @@ export function OperationsPanel() {
         ? html`<${Governance} />`
       : view === 'safety'
         ? html`<${SafeAutonomyPanel} />`
+      : view === 'surfaces'
+        ? html`<${SurfaceReadinessPanel} />`
       : view === 'inspector'
         ? html`<${LabInspector} />`
       : html`
@@ -81,6 +85,9 @@ export function OperationsPanel() {
             </div>
             <div class="mt-4">
               <${SafeAutonomyPanel} />
+            </div>
+            <div class="mt-4">
+              <${SurfaceReadinessPanel} />
             </div>
           `}
     </div>

--- a/dashboard/src/components/surface-readiness-panel.test.ts
+++ b/dashboard/src/components/surface-readiness-panel.test.ts
@@ -1,0 +1,143 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SurfaceReadinessData, SurfaceReadinessEntry } from './surface-readiness-panel'
+
+const payload: SurfaceReadinessData = {
+  generated_at: '2026-05-14T00:00:00Z',
+  proof_bar: 'fixture+live_spotcheck',
+  surfaces: [
+    {
+      id: 'command.operations',
+      label: 'Operations',
+      exposure_status: 'main',
+      hidden_from_nav: false,
+      meets_main_gate: true,
+      proof_bar: 'fixture+live_spotcheck',
+      rationale: 'Canonical command surface.',
+      route_hash: '#command?section=operations',
+      verification_refs: [
+        { kind: 'script', label: 'live_spotcheck', value: './scripts/harness_dashboard_execution_smoke.sh' },
+        { kind: 'route', label: 'logs', value: '/api/v1/dashboard/logs' },
+        { kind: 'route', label: 'metrics', value: '/metrics' },
+        { kind: 'tool', label: 'tool_name', value: 'masc_operator_digest' },
+      ],
+    },
+    {
+      id: 'lab.harness',
+      label: 'Harness',
+      exposure_status: 'lab',
+      hidden_from_nav: false,
+      meets_main_gate: false,
+      proof_bar: 'fixture+live_spotcheck',
+      rationale: 'Lab safety harness surface.',
+      route_hash: '#lab?section=harness',
+      verification_refs: [
+        { kind: 'route', label: 'live_spotcheck', value: '/api/v1/dashboard/harness-health' },
+        { kind: 'route', label: 'logs', value: '/api/v1/dashboard/logs' },
+        { kind: 'route', label: 'metrics', value: '/metrics' },
+      ],
+    },
+    {
+      id: 'workspace.gap',
+      label: 'Gap Surface',
+      exposure_status: 'main',
+      hidden_from_nav: false,
+      meets_main_gate: true,
+      proof_bar: 'fixture+live_spotcheck',
+      rationale: 'Intentionally missing logs for regression coverage.',
+      route_hash: '#workspace?section=gap',
+      verification_refs: [
+        { kind: 'route', label: 'live_spotcheck', value: '/api/v1/dashboard/gap' },
+        { kind: 'route', label: 'metrics', value: '/metrics' },
+      ],
+    },
+  ],
+}
+
+async function flushUi(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 4; i += 1) {
+      await Promise.resolve()
+    }
+  })
+}
+
+async function loadPanel(getMock = vi.fn().mockResolvedValue(payload)) {
+  vi.resetModules()
+  vi.doMock('../api/core', () => ({
+    get: getMock,
+  }))
+  return {
+    getMock,
+    module: await import('./surface-readiness-panel'),
+  }
+}
+
+describe('SurfaceReadinessPanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.clearAllMocks()
+    vi.resetModules()
+    vi.doUnmock('../api/core')
+  })
+
+  it('loads and renders dashboard surface verification refs', async () => {
+    const { getMock, module } = await loadPanel()
+    const { SurfaceReadinessPanel } = module
+
+    await act(async () => {
+      render(html`<${SurfaceReadinessPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(getMock).toHaveBeenCalledWith('/api/v1/dashboard/surface-readiness')
+    expect(container.textContent).toContain('Surface Readiness')
+    expect(container.textContent).toContain('2 main / 3 total')
+    expect(container.textContent).toContain('command.operations')
+    expect(container.textContent).toContain('#command?section=operations')
+    expect(container.textContent).toContain('live_spotcheck')
+    expect(container.textContent).toContain('/api/v1/dashboard/logs')
+    expect(container.textContent).toContain('missing logs')
+  })
+
+  it('filters gap surfaces by missing proof refs', async () => {
+    const { module } = await loadPanel()
+    const { filterSurfaceReadiness } = module
+
+    const filtered = filterSurfaceReadiness(payload.surfaces, 'gaps')
+
+    expect(filtered.map(surface => surface.id)).toEqual(['workspace.gap'])
+  })
+
+  it('summarizes main, lab, hidden, and gap counts', async () => {
+    const { module } = await loadPanel()
+    const { summarizeSurfaceReadiness } = module
+    const diagnosticHidden: SurfaceReadinessEntry = {
+      ...payload.surfaces[0]!,
+      id: 'monitoring.hidden',
+      exposure_status: 'diagnostic',
+      hidden_from_nav: true,
+      meets_main_gate: false,
+    }
+
+    expect(summarizeSurfaceReadiness([...payload.surfaces, diagnosticHidden])).toMatchObject({
+      total: 4,
+      main: 2,
+      lab: 1,
+      diagnostic: 1,
+      hidden: 1,
+      gaps: 1,
+    })
+  })
+})

--- a/dashboard/src/components/surface-readiness-panel.ts
+++ b/dashboard/src/components/surface-readiness-panel.ts
@@ -1,0 +1,272 @@
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import { get } from '../api/core'
+import { createAsyncResource, type AsyncResource } from '../lib/async-state'
+import { formatTimeAgoEn } from '../lib/format-time'
+import { AsyncContainer } from './common/async-container'
+import { Card } from './common/card'
+import { FilterChips } from './common/filter-chips'
+import { EmptyState } from './common/empty-state'
+import { StatusChip, type StatusChipTone } from './common/status-chip'
+import { KpiStripIsland, type KpiStripIslandData } from './kpi-strip-island'
+import { asBoolean, asRecordArray, asString, isRecord } from './common/normalize'
+
+type SurfaceFilter = 'all' | 'main' | 'lab' | 'diagnostic' | 'gaps'
+
+interface SurfaceVerificationRef {
+  kind: string
+  label: string
+  value: string
+}
+
+export interface SurfaceReadinessEntry {
+  id: string
+  label: string
+  exposure_status: string
+  hidden_from_nav: boolean
+  meets_main_gate: boolean
+  proof_bar: string
+  rationale: string
+  route_hash: string | null
+  verification_refs: SurfaceVerificationRef[]
+}
+
+export interface SurfaceReadinessData {
+  generated_at: string
+  proof_bar: string
+  surfaces: SurfaceReadinessEntry[]
+}
+
+interface SurfaceReadinessSummary {
+  total: number
+  main: number
+  lab: number
+  diagnostic: number
+  hidden: number
+  gaps: number
+}
+
+const surfaceReadiness: AsyncResource<SurfaceReadinessData> = createAsyncResource()
+const activeFilter = signal<SurfaceFilter>('all')
+
+const FILTERS: Array<{ key: SurfaceFilter; label: string }> = [
+  { key: 'all', label: 'All' },
+  { key: 'main', label: 'Main' },
+  { key: 'lab', label: 'Lab' },
+  { key: 'diagnostic', label: 'Diagnostic' },
+  { key: 'gaps', label: 'Gaps' },
+]
+
+function normalizeRef(value: unknown): SurfaceVerificationRef {
+  const ref = isRecord(value) ? value : {}
+  return {
+    kind: asString(ref.kind, 'ref'),
+    label: asString(ref.label, 'ref'),
+    value: asString(ref.value, ''),
+  }
+}
+
+function normalizeSurface(value: unknown): SurfaceReadinessEntry {
+  const item = isRecord(value) ? value : {}
+  return {
+    id: asString(item.id, 'surface'),
+    label: asString(item.label, 'Surface'),
+    exposure_status: asString(item.exposure_status, 'unknown'),
+    hidden_from_nav: asBoolean(item.hidden_from_nav, false),
+    meets_main_gate: asBoolean(item.meets_main_gate, false),
+    proof_bar: asString(item.proof_bar, ''),
+    rationale: asString(item.rationale, ''),
+    route_hash: asString(item.route_hash) ?? null,
+    verification_refs: asRecordArray(item.verification_refs).map(normalizeRef),
+  }
+}
+
+export function normalizeSurfaceReadinessPayload(raw: unknown): SurfaceReadinessData {
+  const data = isRecord(raw) ? raw : {}
+  return {
+    generated_at: asString(data.generated_at, ''),
+    proof_bar: asString(data.proof_bar, ''),
+    surfaces: asRecordArray(data.surfaces).map(normalizeSurface),
+  }
+}
+
+function hasRef(surface: SurfaceReadinessEntry, label: string): boolean {
+  return surface.verification_refs.some(ref => ref.label === label && ref.value.trim() !== '')
+}
+
+export function missingSurfaceProofRefs(surface: SurfaceReadinessEntry): string[] {
+  return ['live_spotcheck', 'logs', 'metrics'].filter(label => !hasRef(surface, label))
+}
+
+function isSurfaceGap(surface: SurfaceReadinessEntry): boolean {
+  const mainGateGap = surface.exposure_status === 'main' && !surface.meets_main_gate
+  return mainGateGap || missingSurfaceProofRefs(surface).length > 0
+}
+
+export function summarizeSurfaceReadiness(surfaces: SurfaceReadinessEntry[]): SurfaceReadinessSummary {
+  return {
+    total: surfaces.length,
+    main: surfaces.filter(surface => surface.exposure_status === 'main').length,
+    lab: surfaces.filter(surface => surface.exposure_status === 'lab').length,
+    diagnostic: surfaces.filter(surface => surface.exposure_status === 'diagnostic').length,
+    hidden: surfaces.filter(surface => surface.hidden_from_nav).length,
+    gaps: surfaces.filter(isSurfaceGap).length,
+  }
+}
+
+export function filterSurfaceReadiness(
+  surfaces: SurfaceReadinessEntry[],
+  filter: SurfaceFilter,
+): SurfaceReadinessEntry[] {
+  if (filter === 'all') return surfaces
+  if (filter === 'gaps') return surfaces.filter(isSurfaceGap)
+  return surfaces.filter(surface => surface.exposure_status === filter)
+}
+
+function loadSurfaceReadiness(): Promise<void> {
+  return surfaceReadiness.load(async () =>
+    normalizeSurfaceReadinessPayload(await get<unknown>('/api/v1/dashboard/surface-readiness')))
+}
+
+export async function refreshSurfaceReadiness(): Promise<void> {
+  await loadSurfaceReadiness()
+}
+
+function exposureTone(surface: SurfaceReadinessEntry): StatusChipTone {
+  if (isSurfaceGap(surface)) return 'bad'
+  if (surface.exposure_status === 'main') return 'ok'
+  if (surface.exposure_status === 'lab') return 'neutral'
+  if (surface.exposure_status === 'diagnostic') return 'warn'
+  return 'neutral'
+}
+
+function SurfaceRefList({ refs }: { refs: SurfaceVerificationRef[] }) {
+  if (refs.length === 0) {
+    return html`<${EmptyState} message="No verification refs." compact />`
+  }
+  return html`
+    <div class="mt-3 grid gap-1.5 text-3xs">
+      ${refs.map(ref => html`
+        <div class="flex min-w-0 flex-wrap items-center gap-1.5">
+          <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-hover)] px-1.5 py-0.5 text-[var(--color-fg-muted)]">
+            ${ref.label}
+          </span>
+          <span class="text-[var(--color-fg-disabled)]">${ref.kind}</span>
+          <code class="min-w-0 break-all text-[var(--color-fg-secondary)]">${ref.value}</code>
+        </div>
+      `)}
+    </div>
+  `
+}
+
+function SurfaceCard({ surface }: { surface: SurfaceReadinessEntry }) {
+  const missingRefs = missingSurfaceProofRefs(surface)
+  return html`
+    <article class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
+      <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+        <div class="min-w-0">
+          <div class="flex flex-wrap items-center gap-2">
+            <div class="text-sm font-medium text-[var(--color-fg-primary)]">${surface.label}</div>
+            <${StatusChip} tone=${exposureTone(surface)}>${surface.exposure_status}<//>
+            ${surface.hidden_from_nav
+              ? html`<${StatusChip} tone="warn">hidden<//>`
+              : html`<${StatusChip} tone="ok">nav<//>`}
+            ${surface.meets_main_gate
+              ? html`<${StatusChip} tone="ok">gate<//>`
+              : html`<${StatusChip} tone="neutral">no gate<//>`}
+          </div>
+          <div class="mt-1 flex flex-wrap items-center gap-1.5 text-3xs text-[var(--color-fg-muted)]">
+            <code>${surface.id}</code>
+            ${surface.route_hash ? html`<span>${surface.route_hash}</span>` : null}
+            ${surface.proof_bar ? html`<span>${surface.proof_bar}</span>` : null}
+          </div>
+          ${surface.rationale
+            ? html`<div class="mt-2 text-2xs leading-relaxed text-[var(--color-fg-secondary)]">${surface.rationale}</div>`
+            : null}
+        </div>
+        ${missingRefs.length > 0
+          ? html`
+            <div class="rounded-[var(--r-1)] border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-1 text-3xs text-[var(--bad-light)]">
+              missing ${missingRefs.join(', ')}
+            </div>
+          `
+          : null}
+      </div>
+      <${SurfaceRefList} refs=${surface.verification_refs} />
+    </article>
+  `
+}
+
+function SurfaceReadinessBody({ data }: { data: SurfaceReadinessData }) {
+  const summary = summarizeSurfaceReadiness(data.surfaces)
+  const filtered = filterSurfaceReadiness(data.surfaces, activeFilter.value)
+  return html`
+    <div class="space-y-4">
+      <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4">
+        <div class="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+          <div class="min-w-0">
+            <div class="text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
+              Surface Readiness
+            </div>
+            <div class="mt-2 text-2xl font-semibold text-[var(--color-fg-primary)]">
+              ${summary.main} main / ${summary.total} total
+            </div>
+            <div class="mt-1 text-3xs text-[var(--color-fg-muted)]">
+              generated ${data.generated_at ? formatTimeAgoEn(data.generated_at) : 'unknown'}
+            </div>
+          </div>
+          <${KpiStripIsland}
+            ariaLabel="Surface readiness summary"
+            cols=${3}
+            cells=${[
+              { variant: 'stacked', label: 'lab', value: summary.lab },
+              { variant: 'stacked', label: 'diagnostic', value: summary.diagnostic },
+              { variant: 'stacked', label: 'hidden', value: summary.hidden },
+              { variant: 'stacked', label: 'gaps', value: summary.gaps },
+              { variant: 'stacked', label: 'proof', value: data.proof_bar || 'n/a' },
+              { variant: 'stacked', label: 'filter', value: activeFilter.value },
+            ] satisfies KpiStripIslandData['cells']}
+          />
+        </div>
+      </div>
+
+      <${FilterChips}
+        chips=${FILTERS.map(filter => ({
+          ...filter,
+          count: filter.key === 'all'
+            ? summary.total
+            : filter.key === 'gaps'
+              ? summary.gaps
+              : summary[filter.key],
+        }))}
+        active=${activeFilter}
+        tone="accent"
+      />
+
+      <div class="grid grid-cols-1 gap-3 xl:grid-cols-2">
+        ${filtered.length === 0
+          ? html`<${EmptyState} message="No surfaces match the filter." compact />`
+          : filtered.map(surface => html`<${SurfaceCard} key=${surface.id} surface=${surface} />`)}
+      </div>
+    </div>
+  `
+}
+
+export function SurfaceReadinessPanel() {
+  useEffect(() => {
+    void loadSurfaceReadiness()
+  }, [])
+
+  return html`
+    <${Card} title="Surface Readiness" class="section">
+      <${AsyncContainer}
+        state=${surfaceReadiness.state}
+        loadingMessage="Loading surface readiness..."
+        emptyWhen=${(data: SurfaceReadinessData) => data.surfaces.length === 0}
+        emptyMessage="No dashboard surfaces are registered."
+        render=${(data: SurfaceReadinessData) => html`<${SurfaceReadinessBody} data=${data} />`}
+      />
+    <//>
+  `
+}

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -32,6 +32,10 @@ vi.mock('./components/server-config', () => ({
   refreshServerConfig: vi.fn(),
 }))
 
+vi.mock('./components/surface-readiness-panel', () => ({
+  refreshSurfaceReadiness: vi.fn(),
+}))
+
 vi.mock('./components/observatory/observatory', () => ({
   refreshObservatorySurface: vi.fn(),
 }))
@@ -49,6 +53,7 @@ import { refreshActivityGraph } from './components/activity-graph-store'
 import { refreshGitGraph } from './components/git-graph-store'
 import { refreshObservatorySurface } from './components/observatory/observatory'
 import { refreshServerConfig } from './components/server-config'
+import { refreshSurfaceReadiness } from './components/surface-readiness-panel'
 import { refreshForRoute, refreshPlanForRoute } from './tab-refresh'
 import { refreshExecution, refreshShell } from './store'
 
@@ -91,6 +96,11 @@ describe('refreshPlanForRoute', () => {
       tab: 'command',
       params: { section: 'operations' },
     })).toEqual(['namespaceTruth', 'operatorSnapshot', 'operatorRoomDigest'])
+
+    expect(refreshPlanForRoute({
+      tab: 'command',
+      params: { section: 'operations', view: 'surfaces' },
+    })).toEqual(['surfaceReadiness'])
   })
 
   it('refreshes the new workspace and lab sections only where store-backed data is needed', () => {
@@ -146,6 +156,17 @@ describe('refreshPlanForRoute', () => {
     await waitFor(() => {
       expect(refreshFeatureHealth).toHaveBeenCalledTimes(1)
       expect(refreshServerConfig).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('refreshes the surface readiness view on route entry', async () => {
+    refreshForRoute({
+      tab: 'command',
+      params: { section: 'operations', view: 'surfaces' },
+    })
+
+    await waitFor(() => {
+      expect(refreshSurfaceReadiness).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -49,6 +49,11 @@ async function refreshDoctorSurface(): Promise<void> {
   await refreshDoctor()
 }
 
+async function refreshSurfaceReadinessSurface(): Promise<void> {
+  const { refreshSurfaceReadiness } = await import('./components/surface-readiness-panel')
+  await refreshSurfaceReadiness()
+}
+
 async function refreshCascadeInspectorSurface(): Promise<void> {
   const { refreshCascadeInspector } = await import('./components/cascade-inspector')
   await refreshCascadeInspector()
@@ -68,6 +73,7 @@ type RefreshTask =
   | 'harness'
   | 'toolQuality'
   | 'inspector'
+  | 'surfaceReadiness'
   | 'cascadeInspector'
   | 'operatorSnapshot'
   | 'operatorRoomDigest'
@@ -105,6 +111,9 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
     case 'command':
       if (routeState.params.view === 'inspector') {
         return ['inspector']
+      }
+      if (routeState.params.view === 'surfaces') {
+        return ['surfaceReadiness']
       }
       return ['namespaceTruth', 'operatorSnapshot', 'operatorRoomDigest']
     case 'workspace':
@@ -156,6 +165,7 @@ const REFRESHERS: Record<RefreshTask, (routeState: Pick<RouteState, 'tab' | 'par
     void refreshServerConfigSurface()
     void refreshDoctorSurface()
   },
+  surfaceReadiness: () => { void refreshSurfaceReadinessSurface() },
   cascadeInspector: () => { void refreshCascadeInspectorSurface() },
   operatorSnapshot: () => { void refreshOperatorSnapshot({ force: true }) },
   operatorRoomDigest: () => { void refreshOperatorRoomDigest({ force: true }) },


### PR DESCRIPTION
## Summary
- Add an Operations > Surfaces view backed by /api/v1/dashboard/surface-readiness.
- Render route readiness, navigation exposure, gate state, and verification refs for every dashboard surface.
- Add route refresh wiring and regression tests for the panel and Operations view selection.

## Verification
- pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/components/surface-readiness-panel.test.ts src/components/operations-panel.test.ts src/tab-refresh.test.ts
- pnpm exec tsc --noEmit --pretty
- pnpm exec eslint src/components/surface-readiness-panel.ts src/components/surface-readiness-panel.test.ts src/components/operations-panel.ts src/components/operations-panel.test.ts src/tab-refresh.ts src/tab-refresh.test.ts
- git diff --check --cached