### PR TITLE
fix(cascade): preserve Ollama HTTP provider config

### DIFF
--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -208,6 +208,60 @@ module Kimi_cli_transport_local = Cascade_transport.Kimi_cli_transport_local
 let non_http_transport_of_provider =
   Cascade_transport.non_http_transport_of_provider
 
+let request_runtime_fields_on_base_config
+    ~(base : Llm_provider.Provider_config.t)
+    (req_config : Llm_provider.Provider_config.t)
+  =
+  { base with
+    max_tokens = req_config.max_tokens;
+    temperature = req_config.temperature;
+    top_p = req_config.top_p;
+    top_k = req_config.top_k;
+    min_p = req_config.min_p;
+    system_prompt = req_config.system_prompt;
+    enable_thinking = req_config.enable_thinking;
+    thinking_budget = req_config.thinking_budget;
+    clear_thinking = req_config.clear_thinking;
+    tool_stream = req_config.tool_stream;
+    tool_choice = req_config.tool_choice;
+    disable_parallel_tool_use = req_config.disable_parallel_tool_use;
+    response_format = req_config.response_format;
+    output_schema = req_config.output_schema;
+    cache_system_prompt = req_config.cache_system_prompt;
+    seed = req_config.seed;
+  }
+
+let provider_config_preserving_http_transport
+    ~sw
+    ~net
+    ~(provider_cfg : Llm_provider.Provider_config.t)
+  : Llm_provider.Llm_transport.t =
+  let http_transport = Llm_provider.Complete.make_http_transport ~sw ~net in
+  let patch_request (req : Llm_provider.Llm_transport.completion_request) =
+    { req with
+      config =
+        request_runtime_fields_on_base_config ~base:provider_cfg req.config;
+    }
+  in
+  { complete_sync =
+      (fun req -> http_transport.complete_sync (patch_request req));
+    complete_stream =
+      (fun ?on_telemetry ~on_event req ->
+        http_transport.complete_stream ?on_telemetry ~on_event
+          (patch_request req));
+  }
+
+let transport_for_provider ~sw ~net ~provider_cfg ?runtime_mcp_policy
+    ?cli_transport_overrides () =
+  match provider_cfg.Llm_provider.Provider_config.kind with
+  | Llm_provider.Provider_config.Ollama ->
+      Ok
+        (Some
+           (provider_config_preserving_http_transport ~sw ~net ~provider_cfg))
+  | _ ->
+      non_http_transport_of_provider ~sw ~provider_cfg ?runtime_mcp_policy
+        ?cli_transport_overrides ()
+
 (* ================================================================ *)
 (* Internal: event publishing                                        *)
 (* ================================================================ *)
@@ -238,7 +292,7 @@ let build
     ~(config : config)
   : (Agent_sdk.Agent.t, Agent_sdk.Error.sdk_error) result =
   match
-    non_http_transport_of_provider ~sw ~provider_cfg:config.provider_cfg
+    transport_for_provider ~sw ~net ~provider_cfg:config.provider_cfg
       ?runtime_mcp_policy:config.runtime_mcp_policy
       ?cli_transport_overrides:config.cli_transport_overrides
       ()
@@ -332,7 +386,7 @@ let resume_from_checkpoint
     ~(checkpoint : Agent_sdk.Checkpoint.t)
   : (Agent_sdk.Agent.t, Agent_sdk.Error.sdk_error) result =
   match
-    non_http_transport_of_provider ~sw ~provider_cfg:config.provider_cfg
+    transport_for_provider ~sw ~net ~provider_cfg:config.provider_cfg
       ?runtime_mcp_policy:config.runtime_mcp_policy
       ?cli_transport_overrides:config.cli_transport_overrides
       ()

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2071,6 +2071,35 @@ let test_oas_worker_exec_build_applies_stream_idle_timeout () =
   | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)
 ;;
 
+let test_oas_worker_exec_build_installs_ollama_kind_preserving_transport () =
+  let provider_cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Ollama
+      ~model_id:"glm-5.1:cloud"
+      ~base_url:"https://ollama.com"
+      ~request_path:"/api/chat"
+      ()
+  in
+  let config =
+    Cascade_runner.default_config
+      ~name:"oas-worker-ollama-cloud"
+      ~provider_cfg
+      ~system_prompt:"system"
+      ~tools:[ make_noop_tool () ]
+  in
+  Eio.Switch.run
+  @@ fun sw ->
+  match Cascade_runner.build ~sw ~net:(require_test_net ()) ~config with
+  | Ok agent ->
+    let transport = (Agent_sdk.Agent.options agent).transport in
+    Alcotest.(check bool)
+      "remote ollama installs native HTTP transport"
+      true
+      (Option.is_some transport);
+    Agent_sdk.Agent.close agent
+  | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)
+;;
+
 let test_apply_stream_idle_timeout_default_passes_through_caller_value () =
   let provided = Some 7.5 in
   let result = Keeper_turn_driver.apply_stream_idle_timeout_default provided in
@@ -6443,6 +6472,10 @@ let () =
             "oas_worker applies stream idle timeout"
             `Quick
             test_oas_worker_exec_build_applies_stream_idle_timeout
+        ; Alcotest.test_case
+            "oas_worker installs native Ollama HTTP transport"
+            `Quick
+            test_oas_worker_exec_build_installs_ollama_kind_preserving_transport
         ; Alcotest.test_case
             "apply_stream_idle_timeout_default passes Some through"
             `Quick


### PR DESCRIPTION
## Summary
- Install a native HTTP transport for Ollama provider configs instead of treating them as transport-less default requests.
- Preserve catalog provider config fields such as base_url, request_path, api_key, and headers while carrying per-request runtime fields from OAS.
- Add a regression test that verifies Ollama cloud builds receive an explicit HTTP transport.

## Validation
- env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 DUNE_CACHE=disabled scripts/dune-local.sh build bin/main_eio.exe test/test_oas_worker.exe
- ./_build/default/test/test_oas_worker.exe test '^resume_config$' 5

## Baseline note
- Full ./_build/default/test/test_oas_worker.exe currently fails on origin/main with this diff stashed: cascade_config 42-45 and circuit_breaker_cascade_fallback 0 all report candidates_filtered_after_cycles. I did not fold that unrelated strategy-health cleanup into this PR.