### PR TITLE
fix(dashboard): hide duplicate primary nav entries

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -41,7 +41,11 @@ import { ConfirmDialogOverlay } from './components/common/confirm-dialog'
 import { startErrorCleanup, stopErrorCleanup } from './components/common/error-notification-state'
 import { DashboardStatusTray } from './components/status-tray'
 import { DashboardFocusModeToggle, dashboardFocusMode } from './components/focus-mode-toggle'
-import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from './config/navigation'
+import {
+  DASHBOARD_NAV_ITEMS,
+  VISIBLE_DASHBOARD_NAV_ITEMS,
+  currentSectionForRoute,
+} from './config/navigation'
 import { Menu, X } from 'lucide-preact'
 import { useKeyboardShortcutHost } from '../design-system/headless-preact/use-keyboard-shortcut'
 import { globalShortcutManager } from './lib/global-shortcut-manager'
@@ -271,7 +275,7 @@ export function App() {
               </div>
             </div>
 
-            <${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab=${currentTab} />
+            <${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab=${currentTab} />
           </div>
 
           <div class="flex shrink-0 flex-wrap items-center justify-end gap-2 max-[1080px]:justify-between">

--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -202,6 +202,9 @@ describe('cockpit entrypoint registry', () => {
       entrypoint.aliases.map(alias => [alias, entrypoint] as const),
     ))
 
+    expect(COCKPIT_ENTRYPOINTS.every(entrypoint => entrypoint.coverage === 'covered')).toBe(true)
+    expect(byAlias.has('goal-d')).toBe(false)
+    expect(byAlias.has('goal-snapshot')).toBe(false)
     expect(byAlias.get('task-st')?.coverage).toBe('covered')
     expect(byAlias.get('acc-led')?.coverage).toBe('covered')
     expect(byAlias.get('acc-mtx')?.coverage).toBe('covered')

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -24,7 +24,7 @@ export interface CockpitEntrypoint {
   mode: CockpitMode
   aliases: string[]
   target: CockpitRouteTarget
-  coverage: 'covered' | 'backend-blocked'
+  coverage: 'covered'
 }
 
 export interface CognitiveModeState {
@@ -104,7 +104,6 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   // Work Plane: Goal / Task / Accountability.
   { mode: 'work', aliases: ['goal-h', 'goal-horizon'], target: { tab: 'workspace', params: { section: 'planning', view: 'goal-tree' } }, coverage: 'covered' },
   { mode: 'work', aliases: ['goal-t', 'goal-tree'], target: { tab: 'workspace', params: { section: 'planning', view: 'goal-tree' } }, coverage: 'covered' },
-  { mode: 'work', aliases: ['goal-d', 'goal-snapshot', 'goal-snapshot-diff'], target: { tab: 'workspace', params: { section: 'planning', view: 'goal-tree', focus: 'snapshot' } }, coverage: 'backend-blocked' },
   { mode: 'work', aliases: ['task-bl', 'task-backlog'], target: { tab: 'workspace', params: { section: 'planning', view: 'default' } }, coverage: 'covered' },
   { mode: 'work', aliases: ['task-st', 'task-stale'], target: { tab: 'workspace', params: { section: 'planning', view: 'default', focus: 'stale' } }, coverage: 'covered' },
   { mode: 'work', aliases: ['task-w', 'task-wall'], target: { tab: 'workspace', params: { section: 'planning', view: 'default' } }, coverage: 'covered' },
@@ -139,7 +138,7 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'observe', aliases: ['hr-st', 'stress-board'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'stress' } }, coverage: 'covered' },
   { mode: 'observe', aliases: ['hr-mod', 'heuristic-by-module'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'heuristics', focus: 'module' } }, coverage: 'covered' },
 
-  // Cognition Plane: production view tabs show available data and blocked backend gaps.
+  // Cognition Plane: production view tabs show available data.
   { mode: 'cognition', aliases: ['ki-bdi', 'keeper-bdi'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper', focus: 'bdi' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['ki-acc', 'keeper-tool-access'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper', focus: 'tool-access' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['ki-stat', 'keeper-token-stats'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'token-stats' } }, coverage: 'covered' },

--- a/dashboard/src/components/cockpit/cockpit.test.ts
+++ b/dashboard/src/components/cockpit/cockpit.test.ts
@@ -29,7 +29,7 @@ describe('Cockpit command map', () => {
     expect(screen.getByTestId('world-visualizer')).toBeInTheDocument()
     expect(screen.getByTestId('cockpit-disclosure')).toBeInTheDocument()
     expect(document.querySelectorAll('[data-cockpit-plane]')).toHaveLength(5)
-    expect(document.querySelector('[data-cockpit-plane="work"]')).toHaveTextContent('1 blocked')
+    expect(document.querySelector('[data-cockpit-plane="work"]')).not.toHaveTextContent('blocked')
     expect(document.querySelector('[data-cockpit-plane="ide"]')).toHaveTextContent('Source')
   })
 
@@ -42,7 +42,9 @@ describe('Cockpit command map', () => {
     expect(disclosure.querySelector('[data-cognitive-level="perceive"]')).toHaveTextContent('Route coverage')
     expect(disclosure.querySelector('[data-cognitive-level="comprehend"]')).toHaveTextContent('Plane grouping')
     expect(disclosure.querySelector('[data-cognitive-level="project"]')).toHaveTextContent('Route gaps')
-    expect(disclosure).toHaveTextContent('backend-blocked')
+    expect(disclosure).toHaveTextContent('route-backed')
+    expect(disclosure).toHaveTextContent('No blocked route entries')
+    expect(disclosure).not.toHaveTextContent('backend-blocked')
   })
 
   it('links cockpit entries to their canonical production routes', () => {

--- a/dashboard/src/components/cockpit/cockpit.ts
+++ b/dashboard/src/components/cockpit/cockpit.ts
@@ -57,19 +57,12 @@ const ENTRIES_PER_PLANE: ReadonlyMap<CockpitPlane, CockpitEntrypoint[]> = (() =>
 })()
 
 const COCKPIT_COVERED_ROUTES = COCKPIT_ENTRYPOINTS.filter(entry => entry.coverage === 'covered').length
-const COCKPIT_BLOCKED_ROUTES = COCKPIT_ENTRYPOINTS.filter(entry => entry.coverage === 'backend-blocked').length
 
 // tie-break: strict `>` keeps the initial accumulator, so PLANE_ORDER[0] (first listed plane) wins on equal counts.
 const PLANE_WITH_MOST_ENTRIES = PLANE_ORDER.reduce((top, plane) => {
   const count = ENTRIES_PER_PLANE.get(plane)?.length ?? 0
   const topCount = ENTRIES_PER_PLANE.get(top)?.length ?? 0
   return count > topCount ? plane : top
-}, PLANE_ORDER[0])
-
-const PLANE_WITH_MOST_GAPS = PLANE_ORDER.reduce((top, plane) => {
-  const gaps = (ENTRIES_PER_PLANE.get(plane) ?? []).filter(entry => entry.coverage === 'backend-blocked').length
-  const topGaps = (ENTRIES_PER_PLANE.get(top) ?? []).filter(entry => entry.coverage === 'backend-blocked').length
-  return gaps > topGaps ? plane : top
 }, PLANE_ORDER[0])
 
 const COCKPIT_DISCLOSURE_ITEMS: CognitiveDisclosureItem[] = [
@@ -80,9 +73,7 @@ const COCKPIT_DISCLOSURE_ITEMS: CognitiveDisclosureItem[] = [
     metric: `${COCKPIT_ENTRYPOINTS.length} routes`,
     defaultOpen: true,
     detail: html`
-      <span class="font-mono text-3xs text-ok">${COCKPIT_COVERED_ROUTES} covered</span>
-      <span class="mx-2 text-[var(--color-fg-disabled)]">/</span>
-      <span class="font-mono text-3xs text-[var(--color-fg-muted)]">${COCKPIT_BLOCKED_ROUTES} backend-blocked</span>
+      <span class="font-mono text-3xs text-ok">${COCKPIT_COVERED_ROUTES} route-backed</span>
     `,
   },
   {
@@ -94,10 +85,8 @@ const COCKPIT_DISCLOSURE_ITEMS: CognitiveDisclosureItem[] = [
   {
     level: 'project',
     title: 'Route gaps',
-    summary: COCKPIT_BLOCKED_ROUTES > 0
-      ? `${COCKPIT_BLOCKED_ROUTES} backend-blocked in ${PLANE_META[PLANE_WITH_MOST_GAPS].label}`
-      : 'No backend-blocked routes',
-    metric: `${COCKPIT_BLOCKED_ROUTES} gaps`,
+    summary: 'No blocked route entries',
+    metric: '0 gaps',
   },
 ]
 
@@ -135,19 +124,13 @@ function routeCaption(entrypoint: CockpitEntrypoint): string {
   ].filter(Boolean).join(' / ')
 }
 
-function coverageClass(coverage: CockpitEntrypoint['coverage']): string {
-  switch (coverage) {
-    case 'covered':
-      return 'border-ok/30 bg-ok/10 text-ok'
-    case 'backend-blocked':
-      return 'border-[var(--color-border-strong)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)]'
-  }
+function coverageClass(): string {
+  return 'border-ok/30 bg-ok/10 text-ok'
 }
 
 function PlaneSection({ plane, entries }: { plane: CockpitPlane; entries: CockpitEntrypoint[] }) {
   const meta = PLANE_META[plane]
   const covered = entries.filter(entry => entry.coverage === 'covered').length
-  const blocked = entries.filter(entry => entry.coverage === 'backend-blocked').length
 
   return html`
     <section
@@ -167,9 +150,6 @@ function PlaneSection({ plane, entries }: { plane: CockpitPlane; entries: Cockpi
         </div>
         <div class="flex shrink-0 flex-wrap justify-end gap-1.5 font-mono text-3xs">
           <span class="rounded-[var(--r-0)] border border-ok/30 bg-ok/10 px-1.5 py-0.5 text-ok">${covered} covered</span>
-          ${blocked > 0
-            ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-1.5 py-0.5 text-[var(--color-fg-muted)]">${blocked} blocked</span>`
-            : null}
         </div>
       </div>
 
@@ -194,7 +174,7 @@ function PlaneSection({ plane, entries }: { plane: CockpitPlane; entries: Cockpi
               </span>
               <${ArrowUpRight} class="mt-0.5 shrink-0 text-[var(--color-fg-muted)] transition-colors group-hover:text-[var(--color-fg-primary)]" size=${14} aria-hidden="true" />
             </span>
-            <span class=${`rounded-[var(--r-0)] border px-1.5 py-0.5 font-mono text-3xs ${coverageClass(entrypoint.coverage)}`}>
+            <span class=${`rounded-[var(--r-0)] border px-1.5 py-0.5 font-mono text-3xs ${coverageClass()}`}>
               ${entrypoint.coverage}
             </span>
           <//>

--- a/dashboard/src/components/dashboard-surface-tabs.test.ts
+++ b/dashboard/src/components/dashboard-surface-tabs.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { axe } from 'jest-axe'
-import { DASHBOARD_NAV_ITEMS } from '../config/navigation'
+import { VISIBLE_DASHBOARD_NAV_ITEMS } from '../config/navigation'
 import { DashboardSurfaceTabs, dashboardSurfaceTabId } from './dashboard-surface-tabs'
 
 const navigate = vi.fn()
@@ -33,7 +33,7 @@ describe('DashboardSurfaceTabs', () => {
 
   it('renders top-level surfaces as an ARIA tablist', () => {
     render(
-      html`<${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab="code" />`,
+      html`<${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="code" />`,
       container,
     )
 
@@ -42,12 +42,13 @@ describe('DashboardSurfaceTabs', () => {
 
     const tabs = Array.from(container.querySelectorAll('[role="tab"]'))
     expect(tabs.map(tab => tab.textContent?.trim())).toContain('Code')
-    expect(tabs).toHaveLength(DASHBOARD_NAV_ITEMS.length)
+    expect(tabs.map(tab => tab.textContent?.trim())).not.toContain('MASC Cockpit')
+    expect(tabs).toHaveLength(VISIBLE_DASHBOARD_NAV_ITEMS.length)
   })
 
   it('marks the current surface as the selected tab', () => {
     render(
-      html`<${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab="code" />`,
+      html`<${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="code" />`,
       container,
     )
 
@@ -62,7 +63,7 @@ describe('DashboardSurfaceTabs', () => {
 
   it('moves focus and activates the next surface on ArrowRight', () => {
     render(
-      html`<${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab="overview" />`,
+      html`<${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="overview" />`,
       container,
     )
 
@@ -77,7 +78,7 @@ describe('DashboardSurfaceTabs', () => {
 
   it('jumps to the last surface on End', () => {
     render(
-      html`<${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab="overview" />`,
+      html`<${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="overview" />`,
       container,
     )
 
@@ -92,7 +93,7 @@ describe('DashboardSurfaceTabs', () => {
   it('passes axe with route tabs and the controlled main panel target', async () => {
     render(
       html`
-        <${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab="overview" />
+        <${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="overview" />
         <main id="main-content">Overview content</main>
       `,
       container,

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -3,11 +3,22 @@ import { describe, expect, it } from 'vitest'
 import {
   DASHBOARD_SURFACES,
   SECTION_REDIRECTS,
+  VISIBLE_DASHBOARD_NAV_ITEMS,
   defaultParamsForTab,
   normalizeRouteParams,
   sectionItemsForTab,
   visibleSectionItemsForTab,
 } from './navigation'
+
+describe('dashboard surface navigation', () => {
+  it('keeps MASC Cockpit routeable but out of primary navigation', () => {
+    const cockpit = DASHBOARD_SURFACES.find(surface => surface.id === 'cockpit')
+
+    expect(cockpit?.hidden).toBe(true)
+    expect(defaultParamsForTab('cockpit')).toEqual({})
+    expect(VISIBLE_DASHBOARD_NAV_ITEMS.map(item => item.id)).not.toContain('cockpit')
+  })
+})
 
 describe('code (IDE plane) navigation', () => {
   it('exposes the production IDE plane in the sidebar', () => {

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -123,7 +123,6 @@ describe('monitoring navigation labels', () => {
       agents: 'Live runtime-backed roster and process state.',
       cognition: 'Keeper cognition and resource state.',
       runtime: 'Provider routing health and cost.',
-      'goal-loop': 'Runtime progress through the goal loop.',
       'fleet-health': 'Fleet-wide signal aggregation and comparison.',
     })
 
@@ -145,13 +144,13 @@ describe('monitoring navigation labels', () => {
     const sections = visibleSectionItemsForTab('monitoring')
     const ids = sections.map(item => item.id)
 
-    expect(ids).toEqual(['journey', 'agents', 'cognition', 'runtime', 'goal-loop', 'fleet-health'])
+    expect(ids).toEqual(['journey', 'agents', 'cognition', 'runtime', 'fleet-health'])
     expect(ids).toContain('journey')
     expect(ids).toContain('cognition')
     expect(ids).toContain('fleet-health')
     expect(ids).toContain('runtime')
     expect(ids).toContain('agents')
-    expect(ids).toContain('goal-loop')
+    expect(ids).not.toContain('goal-loop')
     // Legacy sections removed in Phase 1
     expect(ids).not.toContain('live')
     expect(ids).not.toContain('observatory')
@@ -174,15 +173,15 @@ describe('monitoring navigation labels', () => {
     expect(sections[1]?.id).toBe('agents')
     expect(sections[2]?.id).toBe('cognition')
     expect(sections[3]?.id).toBe('runtime')
-    expect(sections[4]?.id).toBe('goal-loop')
-    expect(sections[5]?.id).toBe('fleet-health')
+    expect(sections[4]?.id).toBe('fleet-health')
   })
 
   it('keeps diagnostic monitoring routes available but hidden from the sidebar', () => {
     const sections = sectionItemsForTab('monitoring')
     const hiddenIds = sections.filter(item => item.hidden).map(item => item.id)
 
-    expect(hiddenIds).toEqual(['observatory'])
+    expect(hiddenIds).toEqual(['observatory', 'goal-loop'])
+    expect(normalizeRouteParams('monitoring', { section: 'goal-loop' }).section).toBe('goal-loop')
   })
 
   it('monitoring sidebar labels are unique (no overloaded term like "런타임")', () => {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -59,6 +59,7 @@ interface DashboardNavItem {
   icon: DashboardSurfaceIcon
   description: string
   defaultParams?: Record<string, string>
+  hidden?: boolean
 }
 
 export interface DashboardSectionNavItem {
@@ -77,6 +78,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     description: 'High-Fidelity MASC Cockpit',
     defaultTab: 'cockpit',
     tabs: ['cockpit'],
+    hidden: true,
   },
 
   {
@@ -157,7 +159,11 @@ export const DASHBOARD_NAV_ITEMS: DashboardNavItem[] = DASHBOARD_SURFACES.map(su
   icon: surface.icon,
   description: surface.description,
   defaultParams: surface.defaultParams,
+  hidden: surface.hidden,
 }))
+
+export const VISIBLE_DASHBOARD_NAV_ITEMS: DashboardNavItem[] =
+  DASHBOARD_NAV_ITEMS.filter(item => item.hidden !== true)
 
 export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavItem[]> = {
   cockpit: [],

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -207,6 +207,10 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: 'GOAL LOOP',
       description: 'Runtime progress through the goal loop.',
       params: { section: 'goal-loop' },
+      // Planning owns the primary goal/task journey. Keep this as a
+      // direct diagnostic route so existing bookmarks and status links
+      // still work without keeping a duplicate Monitor menu item.
+      hidden: true,
     },
     {
       id: 'fleet-health',


### PR DESCRIPTION
## Summary
- hide the legacy MASC Cockpit surface from primary dashboard navigation while keeping #cockpit routeable
- hide GOAL LOOP from the primary Monitor menu while keeping its direct diagnostic route and status links routeable
- split all nav items from visible nav items so hidden surfaces still resolve labels/deep links
- remove the backend-blocked goal-snapshot COCKPIT entrypoint and blocked-route UI copy
- cover the visible-surface/hidden-route and route-backed cockpit contracts in tests

## Verification
- pnpm exec vitest run --config vitest.config.ts src/config/navigation.test.ts src/components/dashboard-surface-tabs.test.ts src/cockpit-entrypoints.test.ts src/components/cockpit/cockpit.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check
- pnpm exec eslint src/cockpit-entrypoints.ts src/cockpit-entrypoints.test.ts src/components/cockpit/cockpit.ts src/components/cockpit/cockpit.test.ts src/config/navigation.ts src/config/navigation.test.ts src/components/dashboard-surface-tabs.test.ts src/app.ts (0 errors; repo config ignores 6 of these paths with warnings)
