### PR TITLE
fix(dashboard): prefer OAS TTFRC telemetry

### DIFF
--- a/lib/dashboard/dashboard_oas_bridge.ml
+++ b/lib/dashboard/dashboard_oas_bridge.ml
@@ -161,31 +161,46 @@ let record_with_time ~now (s : sample) =
 
 let record (s : sample) = record_with_time ~now:(Unix.gettimeofday ()) s
 
+let positive_ms = function
+  | Some ms when ms > 0.0 && Float.is_finite ms -> Some ms
+  | _ -> None
+
+let ttfb_from_telemetry (telemetry : Agent_sdk.Types.inference_telemetry) =
+  match positive_ms telemetry.ttfrc_ms with
+  | Some _ as value -> value
+  | None -> (
+      match positive_ms telemetry.prefill_ms with
+      | Some _ as value -> value
+      | None -> (
+          match telemetry.timings with
+          | Some { prompt_ms; _ } -> positive_ms prompt_ms
+          | None -> None))
+
 let duration_from_response ?total_duration_ms
     (response : Agent_sdk.Types.api_response) =
-  let positive = function Some ms when ms > 0.0 -> Some ms | _ -> None in
-  let duration_from_timings = function
-    | Some (timings : Agent_sdk.Types.inference_timings) -> (
-        match (positive timings.prompt_ms, positive timings.predicted_ms) with
-        | Some prompt_ms, Some predicted_ms -> prompt_ms +. predicted_ms
-        | Some prompt_ms, None -> prompt_ms
-        | None, Some predicted_ms -> predicted_ms
-        | None, None -> 0.0)
-    | None -> 0.0
+  let duration_from_telemetry (telemetry : Agent_sdk.Types.inference_telemetry) =
+    let decode_ms =
+      match telemetry.timings with
+      | Some { predicted_ms; _ } -> positive_ms predicted_ms
+      | None -> None
+    in
+    match ttfb_from_telemetry telemetry, decode_ms with
+    | Some ttfb_ms, Some decode_ms -> ttfb_ms +. decode_ms
+    | Some ttfb_ms, None -> ttfb_ms
+    | None, Some decode_ms -> decode_ms
+    | None, None -> 0.0
   in
   match total_duration_ms, response.telemetry with
   | Some ms, _ when ms > 0.0 -> ms
-  | _, Some telemetry -> duration_from_timings telemetry.timings
-      |> fun timings_ms ->
-      (match telemetry.request_latency_ms with
-       | Some ms when ms > 0 -> Float.of_int ms
-       | _ -> timings_ms)
+  | _, Some telemetry -> (
+      match telemetry.request_latency_ms with
+      | Some ms when ms > 0 -> Float.of_int ms
+      | _ -> duration_from_telemetry telemetry)
   | _ -> 0.0
 
 let ttfb_from_response (response : Agent_sdk.Types.api_response) =
   match response.telemetry with
-  | Some { timings = Some { prompt_ms = Some ms; _ }; _ } when ms > 0.0 ->
-      ms
+  | Some telemetry -> Option.value ~default:0.0 (ttfb_from_telemetry telemetry)
   | _ -> 0.0
 
 let cache_hit_from_response ~(usage : Agent_sdk.Types.api_usage option)

--- a/lib/dashboard/dashboard_oas_bridge.mli
+++ b/lib/dashboard/dashboard_oas_bridge.mli
@@ -95,10 +95,15 @@ val sample_of_response :
     twelve-signal bridge sample.
 
     - [usage] fields become token, cost, and cache-hit signals.
+    - [response.telemetry.ttfrc_ms] is preferred for TTFB when OAS reports
+      wall-clock time-to-first-response-chunk. Otherwise positive
+      [prefill_ms] / [prompt_ms] timing is used as the compatibility
+      fallback.
     - [response.telemetry.request_latency_ms] is used as duration when the
-      caller does not provide [total_duration_ms]. If that aggregate
-      latency is missing/zero, positive [prompt_ms] + [predicted_ms]
-      timing components are used as a non-zero duration instead.
+      caller does not provide [total_duration_ms]. If that aggregate latency
+      is missing/zero, positive [ttfrc_ms] + [predicted_ms] timing components
+      are used as a non-zero duration instead, falling back to
+      [prefill_ms] / [prompt_ms] plus decode timing when [ttfrc_ms] is absent.
     - native decode throughput is preferred when OAS telemetry exposes it;
       otherwise wall-clock throughput is derived from output tokens and
       duration.

--- a/test/test_dashboard_oas_bridge.ml
+++ b/test/test_dashboard_oas_bridge.ml
@@ -55,7 +55,7 @@ let make_usage ?cost ?(cache_creation = 0) ?(cache_read = 0) ~input ~output ()
   }
 ;;
 
-let make_telemetry ?timings ?(request_latency_ms = 0) ()
+let make_telemetry ?timings ?(request_latency_ms = 0) ?ttfrc_ms ?prefill_ms ()
   : Agent_sdk.Types.inference_telemetry
   =
   { system_fingerprint = None
@@ -69,8 +69,8 @@ let make_telemetry ?timings ?(request_latency_ms = 0) ()
   ; canonical_model_id = None
   ; effective_context_window = None
   ; provider_internal_action_count = None
-  ; ttfrc_ms = None
-  ; prefill_ms = None
+  ; ttfrc_ms
+  ; prefill_ms
   }
 ;;
 
@@ -469,6 +469,39 @@ let test_sample_of_response_derives_wall_throughput () =
     (sample.throughput_tokens_per_s = Some 200.0)
 ;;
 
+let test_sample_of_response_prefers_ttfrc_for_ttfb () =
+  let usage = make_usage ~input:100 ~output:50 () in
+  let timings : Agent_sdk.Types.inference_timings =
+    { prompt_n = Some 100
+    ; prompt_ms = Some 510.0
+    ; prompt_per_second = Some 196.0
+    ; predicted_n = Some 50
+    ; predicted_ms = Some 100.0
+    ; predicted_per_second = Some 500.0
+    ; cache_n = None
+    }
+  in
+  let telemetry =
+    make_telemetry ~timings ~request_latency_ms:750 ~ttfrc_ms:42.0 ()
+  in
+  let response = make_response ~usage ~telemetry ~model:"kimi-for-coding" () in
+  let sample =
+    DOB.sample_of_response
+      ~provider_id:"kimi_cli"
+      ~model_id:"kimi-for-coding"
+      ~status:DOB.Success
+      response
+  in
+  Alcotest.(check (float 1e-9))
+    "ttfrc drives first response latency"
+    42.0
+    sample.ttfb_ms;
+  Alcotest.(check (float 1e-9))
+    "request latency still drives total duration"
+    750.0
+    sample.total_duration_ms
+;;
+
 let test_sample_of_response_derives_duration_from_timing_components () =
   let usage = make_usage ~input:100 ~output:88 () in
   let timings : Agent_sdk.Types.inference_timings =
@@ -499,6 +532,43 @@ let test_sample_of_response_derives_duration_from_timing_components () =
   | Some throughput ->
     Alcotest.(check (float 1e-9))
       "wall throughput uses derived decode time"
+      100.0
+      throughput
+  | None -> Alcotest.fail "expected derived throughput"
+;;
+
+let test_sample_of_response_uses_ttfrc_for_duration_fallback () =
+  let usage = make_usage ~input:100 ~output:88 () in
+  let timings : Agent_sdk.Types.inference_timings =
+    { prompt_n = None
+    ; prompt_ms = Some 120.0
+    ; prompt_per_second = None
+    ; predicted_n = None
+    ; predicted_ms = Some 880.0
+    ; predicted_per_second = None
+    ; cache_n = None
+    }
+  in
+  let telemetry =
+    make_telemetry ~timings ~request_latency_ms:0 ~ttfrc_ms:450.0 ()
+  in
+  let response = make_response ~usage ~telemetry ~model:"ollama:qwen" () in
+  let sample =
+    DOB.sample_of_response
+      ~provider_id:"ollama"
+      ~model_id:"ollama:qwen"
+      ~status:DOB.Success
+      response
+  in
+  Alcotest.(check (float 1e-9))
+    "duration falls back to ttfrc+decode timings"
+    1330.0
+    sample.total_duration_ms;
+  Alcotest.(check (float 1e-9)) "ttfb uses ttfrc" 450.0 sample.ttfb_ms;
+  match sample.throughput_tokens_per_s with
+  | Some throughput ->
+    Alcotest.(check (float 1e-9))
+      "wall throughput uses decode duration after ttfrc"
       100.0
       throughput
   | None -> Alcotest.fail "expected derived throughput"
@@ -685,9 +755,17 @@ let () =
             `Quick
             test_sample_of_response_derives_wall_throughput
         ; Alcotest.test_case
+            "ttfrc drives ttfb"
+            `Quick
+            test_sample_of_response_prefers_ttfrc_for_ttfb
+        ; Alcotest.test_case
             "timing components avoid zero duration"
             `Quick
             test_sample_of_response_derives_duration_from_timing_components
+        ; Alcotest.test_case
+            "ttfrc duration fallback"
+            `Quick
+            test_sample_of_response_uses_ttfrc_for_duration_fallback
         ; Alcotest.test_case
             "missing usage records unknown sample"
             `Quick


### PR DESCRIPTION
## Summary

- Prefer OAS `response.telemetry.ttfrc_ms` for dashboard OAS bridge TTFB samples when present.
- Fall back through `prefill_ms` / legacy `timings.prompt_ms` so older OAS responses keep the existing behavior.
- When aggregate request latency is missing, derive duration from `ttfrc_ms + predicted_ms` before falling back to the legacy prompt/decode timing sum.
- Add focused regression coverage for `ttfrc_ms`-driven TTFB and duration fallback.

## Why

The old Kimi telemetry gap docs called out provider first-response latency visibility. Current OAS telemetry already carries a wall-clock `ttfrc_ms` signal, but the MASC dashboard bridge was still treating native prompt/prefill timing as TTFB. That makes the dashboard under-report first response latency when queueing, transport, or provider startup delay happens before the first chunk.

## Validation

- `opam exec -- ocamlformat --check lib/dashboard/dashboard_oas_bridge.ml lib/dashboard/dashboard_oas_bridge.mli test/test_dashboard_oas_bridge.ml`
- `scripts/dune-local.sh build @test/runtest-test_dashboard_oas_bridge`
- `git diff --check origin/main...HEAD`

Supersedes #15116, which used an agent-pattern title/branch and tripped the draft guard policy despite carrying this same code diff.