### PR TITLE
fix(dashboard): hide cockpit from primary nav

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -41,7 +41,11 @@ import { ConfirmDialogOverlay } from './components/common/confirm-dialog'
 import { startErrorCleanup, stopErrorCleanup } from './components/common/error-notification-state'
 import { DashboardStatusTray } from './components/status-tray'
 import { DashboardFocusModeToggle, dashboardFocusMode } from './components/focus-mode-toggle'
-import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from './config/navigation'
+import {
+  DASHBOARD_NAV_ITEMS,
+  VISIBLE_DASHBOARD_NAV_ITEMS,
+  currentSectionForRoute,
+} from './config/navigation'
 import { Menu, X } from 'lucide-preact'
 import { useKeyboardShortcutHost } from '../design-system/headless-preact/use-keyboard-shortcut'
 import { globalShortcutManager } from './lib/global-shortcut-manager'
@@ -271,7 +275,7 @@ export function App() {
               </div>
             </div>
 
-            <${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab=${currentTab} />
+            <${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab=${currentTab} />
           </div>
 
           <div class="flex shrink-0 flex-wrap items-center justify-end gap-2 max-[1080px]:justify-between">

--- a/dashboard/src/components/dashboard-surface-tabs.test.ts
+++ b/dashboard/src/components/dashboard-surface-tabs.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { axe } from 'jest-axe'
-import { DASHBOARD_NAV_ITEMS } from '../config/navigation'
+import { VISIBLE_DASHBOARD_NAV_ITEMS } from '../config/navigation'
 import { DashboardSurfaceTabs, dashboardSurfaceTabId } from './dashboard-surface-tabs'
 
 const navigate = vi.fn()
@@ -33,7 +33,7 @@ describe('DashboardSurfaceTabs', () => {
 
   it('renders top-level surfaces as an ARIA tablist', () => {
     render(
-      html`<${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab="code" />`,
+      html`<${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="code" />`,
       container,
     )
 
@@ -42,12 +42,13 @@ describe('DashboardSurfaceTabs', () => {
 
     const tabs = Array.from(container.querySelectorAll('[role="tab"]'))
     expect(tabs.map(tab => tab.textContent?.trim())).toContain('Code')
-    expect(tabs).toHaveLength(DASHBOARD_NAV_ITEMS.length)
+    expect(tabs.map(tab => tab.textContent?.trim())).not.toContain('MASC Cockpit')
+    expect(tabs).toHaveLength(VISIBLE_DASHBOARD_NAV_ITEMS.length)
   })
 
   it('marks the current surface as the selected tab', () => {
     render(
-      html`<${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab="code" />`,
+      html`<${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="code" />`,
       container,
     )
 
@@ -62,7 +63,7 @@ describe('DashboardSurfaceTabs', () => {
 
   it('moves focus and activates the next surface on ArrowRight', () => {
     render(
-      html`<${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab="overview" />`,
+      html`<${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="overview" />`,
       container,
     )
 
@@ -77,7 +78,7 @@ describe('DashboardSurfaceTabs', () => {
 
   it('jumps to the last surface on End', () => {
     render(
-      html`<${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab="overview" />`,
+      html`<${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="overview" />`,
       container,
     )
 
@@ -92,7 +93,7 @@ describe('DashboardSurfaceTabs', () => {
   it('passes axe with route tabs and the controlled main panel target', async () => {
     render(
       html`
-        <${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab="overview" />
+        <${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="overview" />
         <main id="main-content">Overview content</main>
       `,
       container,

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -3,11 +3,22 @@ import { describe, expect, it } from 'vitest'
 import {
   DASHBOARD_SURFACES,
   SECTION_REDIRECTS,
+  VISIBLE_DASHBOARD_NAV_ITEMS,
   defaultParamsForTab,
   normalizeRouteParams,
   sectionItemsForTab,
   visibleSectionItemsForTab,
 } from './navigation'
+
+describe('dashboard surface navigation', () => {
+  it('keeps MASC Cockpit routeable but out of primary navigation', () => {
+    const cockpit = DASHBOARD_SURFACES.find(surface => surface.id === 'cockpit')
+
+    expect(cockpit?.hidden).toBe(true)
+    expect(defaultParamsForTab('cockpit')).toEqual({})
+    expect(VISIBLE_DASHBOARD_NAV_ITEMS.map(item => item.id)).not.toContain('cockpit')
+  })
+})
 
 describe('code (IDE plane) navigation', () => {
   it('exposes the production IDE plane in the sidebar', () => {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -59,6 +59,7 @@ interface DashboardNavItem {
   icon: DashboardSurfaceIcon
   description: string
   defaultParams?: Record<string, string>
+  hidden?: boolean
 }
 
 export interface DashboardSectionNavItem {
@@ -77,6 +78,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     description: 'High-Fidelity MASC Cockpit',
     defaultTab: 'cockpit',
     tabs: ['cockpit'],
+    hidden: true,
   },
 
   {
@@ -157,7 +159,11 @@ export const DASHBOARD_NAV_ITEMS: DashboardNavItem[] = DASHBOARD_SURFACES.map(su
   icon: surface.icon,
   description: surface.description,
   defaultParams: surface.defaultParams,
+  hidden: surface.hidden,
 }))
+
+export const VISIBLE_DASHBOARD_NAV_ITEMS: DashboardNavItem[] =
+  DASHBOARD_NAV_ITEMS.filter(item => item.hidden !== true)
 
 export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavItem[]> = {
   cockpit: [],


### PR DESCRIPTION
## Summary
- hide the legacy MASC Cockpit surface from primary dashboard navigation while keeping #cockpit routeable
- split all nav items from visible nav items so hidden surfaces still resolve labels/deep links
- cover the visible-surface contract in navigation and surface-tab tests

## Verification
- `pnpm exec vitest run --config vitest.config.ts src/config/navigation.test.ts src/components/dashboard-surface-tabs.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check origin/main...HEAD`

## Notes
- ESLint was attempted for the changed files, but the repo eslint config currently ignores these paths and reported only ignored-file warnings.
- Supersedes #15118, which used a `codex/...` branch and tripped the draft guard policy despite carrying this same code diff.