### PR TITLE
fix(keeper): increment capped-wakeup counter by dropped amount (follow-up #15092)

### DIFF
--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -333,9 +333,13 @@ let wakeup_relevant_keeper_for_board_signal
          wake_meta meta reason;
          Eio_guard.yield_step yield_meter);
   if dropped > 0 then begin
+    (* Counter tracks wakeups dropped by the cap, not capped events; under
+       high fanout [dropped] can be >1 per signal, so add the actual amount
+       (not a fixed 1) to keep BOARD-CAPPED accurate on the compact dashboard. *)
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_board_signal_wakeup_capped_total
       ~labels:[("kind", signal_kind_label)]
+      ~delta:(float_of_int dropped)
       ();
     Log.Keeper.info
       "board signal wakeup capped by configured fanout: dropped=%d post=%s \


### PR DESCRIPTION
## 배경

PR #15092 의 Codex review (P2) 가 unresolved 상태로 main 에 머지되었습니다.

`lib/keeper/keeper_keepalive_signal.ml:336` 의 capped-wakeup 처리 분기:

```ocaml
let selected, dropped = select_board_wakeup_candidates candidates in
...
if dropped > 0 then begin
  Prometheus.inc_counter
    Keeper_metrics.metric_keeper_board_signal_wakeup_capped_total
    ~labels:[("kind", signal_kind_label)]
    ();   (* default ~delta:1.0 *)
  ...
end
```

`masc_keeper_board_signal_wakeup_capped_total` 은 fanout cap 으로 *드롭된 wakeup 수* 를 누적하도록 documented 되어 있지만, 위 호출은 `dropped > 1` 인 경우에도 1 만 증가시켜 *capped events* 수를 기록하는 셈. 고-fanout 상황에서 counter 가 실제 드롭 수 대비 누락 (`dropped - 1` per event) 되고, compact 대시보드의 `BOARD-CAPPED` 값이 실제와 drift.

## 변경

- `lib/keeper/keeper_keepalive_signal.ml`: `inc_counter ... ()` → `inc_counter ... ~delta:(float_of_int dropped) ()`. 인라인 주석으로 의미 (드롭 수 누적) 명시.

## 검증

- `dune build --root . lib/keeper`: 빌드 통과.
- `Prometheus.inc_counter ~delta:N` 의 누적 동작은 `test/test_prometheus_coverage.ml:110` 으로 이미 pinned.
- 통합 경로 (board signal flow → 대시보드 `BOARD-CAPPED` 라벨) 는 `test_generate_compact_surfaces_board_cap_without_failure` 로 회귀 커버.

신규 회귀 테스트는 추가하지 않았습니다: fix 가 단일 call-site 의 한 옵션 인자 변경이고, 두 가지 contract (counter delta 동작 / 대시보드 노출) 모두 기존 테스트에 의해 cover 됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)