### PR TITLE
fix(keeper): harden long-run keeper durability

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -712,11 +712,20 @@ max-input = 8192
 max-output = 2048
 temperature = 0.1
 
+[codex_cli.codex-spark.for-keeper-turn]
+max-output = 32768
+
+[kimi_cli.kimi-coding.for-keeper-turn]
+max-output = 32768
+
 # ── Layer 5: Tiers ─────────────────────────────────────────────
 
 [tier.primary]
 # Canonical keeper/workflow tier.
-members = ["codex_cli.codex-spark", "kimi_cli.kimi-coding"]
+members = [
+  "codex_cli.codex-spark.for-keeper-turn",
+  "kimi_cli.kimi-coding.for-keeper-turn",
+]
 strategy = "failover"
 
 [tier.keeper_diverse]
@@ -756,12 +765,12 @@ strategy = "failover"
 # System-only baseline tier (RFC-0027 PR-4). Last-resort fallback
 # target that satisfies every capability profile. Not keeper-assignable.
 keeper-assignable = false
-members = ["kimi_cli.kimi-coding"]
+members = ["kimi_cli.kimi-coding.for-keeper-turn"]
 strategy = "failover"
 
 [tier.local_recovery]
 # Recovery tier for fallback_cascade = "local_recovery".
-members = ["codex_cli.codex-spark"]
+members = ["codex_cli.codex-spark.for-keeper-turn"]
 strategy = "failover"
 
 # ── Tier-Groups (fallback chains) ──────────────────────────────

--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -742,6 +742,7 @@ let review
                   | Keeper_turn_driver.Admission_queue_rejected _
                   | Keeper_turn_driver.Turn_timeout _
                   | Keeper_turn_driver.Oas_timeout_budget _
+                  | Keeper_turn_driver.Max_tokens_ceiling_violation _
                   | Keeper_turn_driver.Ambiguous_post_commit _ )
               | None ->
                 false

--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -51,6 +51,7 @@ let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
   | Some (Cascade_error_classify.Admission_queue_rejected _)
   | Some (Cascade_error_classify.Turn_timeout _)
   | Some (Cascade_error_classify.Oas_timeout_budget _)
+  | Some (Cascade_error_classify.Max_tokens_ceiling_violation _)
   | Some (Cascade_error_classify.Ambiguous_post_commit _)
   | None -> (
   match err with
@@ -658,6 +659,7 @@ let sdk_error_is_max_turns_exceeded (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Cascade_error_classify.Admission_queue_rejected _)
   | Some (Cascade_error_classify.Turn_timeout _)
   | Some (Cascade_error_classify.Oas_timeout_budget _)
+  | Some (Cascade_error_classify.Max_tokens_ceiling_violation _)
   | Some (Cascade_error_classify.Ambiguous_post_commit _) ->
       false
   | None -> (

--- a/lib/cascade/cascade_error_classify.ml
+++ b/lib/cascade/cascade_error_classify.ml
@@ -60,6 +60,12 @@ type masc_internal_error =
       min_required_sec : float;
       phase : string;
     }
+  | Max_tokens_ceiling_violation of {
+      cascade_name : cascade_name;
+      requested_max_tokens : int;
+      provider_ceiling : int;
+      reason : string;
+    }
   | Ambiguous_post_commit of {
       is_timeout : bool;
       tools : string list;
@@ -207,6 +213,17 @@ let masc_internal_error_to_json = function
         ("min_required_sec", `Float min_required_sec);
         ("phase", `String phase);
       ]
+  | Max_tokens_ceiling_violation
+      { cascade_name; requested_max_tokens; provider_ceiling; reason } ->
+    let cascade_name = cascade_name_to_string cascade_name in
+    `Assoc
+      [
+        ("kind", `String "max_tokens_ceiling_violation");
+        ("cascade_name", `String cascade_name);
+        ("requested_max_tokens", `Int requested_max_tokens);
+        ("provider_ceiling", `Int provider_ceiling);
+        ("reason", `String reason);
+      ]
   | Ambiguous_post_commit { is_timeout; tools; original_error } ->
     `Assoc
       [
@@ -263,6 +280,15 @@ let summary_of_masc_internal_error = function
            "OAS timeout budget exhausted; phase=%s; source=%s; budget=%.1fs; remaining=%s; min_required=%.1fs; estimated_input_tokens=%d; keeper_turn_timeout=%.1fs"
            phase source budget_sec remaining min_required_sec
            estimated_input_tokens keeper_turn_timeout_sec)
+  | Max_tokens_ceiling_violation
+      { cascade_name; requested_max_tokens; provider_ceiling; reason } ->
+    Some
+      (Printf.sprintf
+         "Invalid max_tokens budget for cascade %s; requested_max_tokens=%d; provider_ceiling=%d; reason=%s"
+         (cascade_name_to_string cascade_name)
+         requested_max_tokens
+         provider_ceiling
+         reason)
   (* Variants without a custom long-form summary: callers fall back to
      [kind_of_masc_internal_error] / the JSON payload.  Enumerated
      explicitly so adding a new [masc_internal_error] variant forces
@@ -300,7 +326,8 @@ let () =
        kind (cascade_exhausted | resumable_cli_session | \
        no_tool_capable_provider | accept_rejected | \
        admission_queue_timeout | admission_queue_rejected | \
-       turn_timeout | oas_timeout_budget | ambiguous_post_commit), \
+       turn_timeout | oas_timeout_budget | max_tokens_ceiling_violation | \
+       ambiguous_post_commit), \
        cascade_name (originating cascade or \"unknown\" for \
        cascade-less variants)."
     ()
@@ -314,6 +341,7 @@ let kind_of_masc_internal_error = function
   | Admission_queue_rejected _ -> "admission_queue_rejected"
   | Turn_timeout _ -> "turn_timeout"
   | Oas_timeout_budget _ -> "oas_timeout_budget"
+  | Max_tokens_ceiling_violation _ -> "max_tokens_ceiling_violation"
   | Ambiguous_post_commit _ -> "ambiguous_post_commit"
 
 (** #10285: which cascade emitted this error.
@@ -340,7 +368,8 @@ let cascade_name_of_masc_internal_error = function
   | Cascade_exhausted { cascade_name; _ }
   | Resumable_cli_session { cascade_name; _ }
   | No_tool_capable_provider { cascade_name; _ }
-  | Admission_queue_timeout { cascade_name; _ } ->
+  | Admission_queue_timeout { cascade_name; _ }
+  | Max_tokens_ceiling_violation { cascade_name; _ } ->
       let cascade_name = cascade_name_to_string cascade_name in
       if String.equal (String.trim cascade_name) "" then "unknown"
       else cascade_name
@@ -530,6 +559,24 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                              (string_opt_of_assoc "phase" json);
                        })
               | _ -> None)
+          | _ -> None)
+      | Some (`String "max_tokens_ceiling_violation") -> (
+          match
+            string_opt_of_assoc "cascade_name" json,
+            int_opt_of_assoc "requested_max_tokens" json,
+            int_opt_of_assoc "provider_ceiling" json
+          with
+          | Some cascade_name, Some requested_max_tokens, Some provider_ceiling ->
+            Some
+              (Max_tokens_ceiling_violation
+                 {
+                   cascade_name = cascade_name_of_string cascade_name;
+                   requested_max_tokens;
+                   provider_ceiling;
+                   reason =
+                     Option.value ~default:"unknown"
+                       (string_opt_of_assoc "reason" json);
+                 })
           | _ -> None)
       | Some (`String "ambiguous_post_commit") -> (
           match string_opt_of_assoc "original_error" json with

--- a/lib/cascade/cascade_error_classify.mli
+++ b/lib/cascade/cascade_error_classify.mli
@@ -61,6 +61,12 @@ type masc_internal_error =
       min_required_sec : float;
       phase : string;
     }
+  | Max_tokens_ceiling_violation of {
+      cascade_name : cascade_name;
+      requested_max_tokens : int;
+      provider_ceiling : int;
+      reason : string;
+    }
   | Ambiguous_post_commit of {
       is_timeout : bool;
       tools : string list;

--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -335,6 +335,14 @@ type error_kind = Error_kind of string
 let error_kind_of_string value = Error_kind value
 let error_kind_to_string (Error_kind value) = value
 
+type provider_restore = {
+  restore_provider_key : string;
+  restore_consecutive_failures : int;
+  restore_cooldown_until : float option;
+  restore_last_failure_at : float option;
+  restore_top_fingerprints : (string * int) list;
+}
+
 (* ── Constructor ──────────────────────────────── *)
 
 let create () : t = {
@@ -390,6 +398,40 @@ let get_or_create_state t key =
     } in
     Hashtbl.replace t.providers key s;
     s
+
+let finite_positive = function
+  | Some value when Float.is_finite value && value > 0.0 -> Some value
+  | _ -> None
+
+let restore_providers t providers =
+  with_lock t (fun () ->
+    let now = Unix.gettimeofday () in
+    List.fold_left
+      (fun restored row ->
+        let provider_key = String.trim row.restore_provider_key in
+        if String.equal provider_key ""
+        then restored
+        else (
+          let state = get_or_create_state t provider_key in
+          state.consecutive_failures <- max 0 row.restore_consecutive_failures;
+          state.cooldown_until
+          <- (match finite_positive row.restore_cooldown_until with
+              | Some ts when ts > now -> ts
+              | _ -> 0.0);
+          state.last_failure_at
+          <- (match finite_positive row.restore_last_failure_at with
+              | Some ts -> ts
+              | None -> 0.0);
+          Hashtbl.reset state.fingerprint_counts;
+          List.iter
+            (fun (fp, count) ->
+              let fp = String.trim fp in
+              if (not (String.equal fp "")) && count > 0
+              then Hashtbl.replace state.fingerprint_counts fp count)
+            row.restore_top_fingerprints;
+          restored + 1))
+      0
+      providers)
 
 (* Append [latency_ms] to the per-provider ring buffer.  Allocates the
    array lazily on first valid sample so providers that never report

--- a/lib/cascade/cascade_health_tracker.mli
+++ b/lib/cascade/cascade_health_tracker.mli
@@ -104,6 +104,24 @@ val error_kind_to_string : error_kind -> string
 (** Create a new empty tracker. *)
 val create : unit -> t
 
+(** Durable provider state that can be restored after process restart.
+
+    This intentionally excludes rolling-window events and latency/cost rings:
+    those are short-lived routing signals. Cooldown, failure count, and error
+    fingerprints are enough to prevent a restart from immediately retrying a
+    provider that was just circuit-broken. *)
+type provider_restore = {
+  restore_provider_key : string;
+  restore_consecutive_failures : int;
+  restore_cooldown_until : float option;
+  restore_last_failure_at : float option;
+  restore_top_fingerprints : (string * int) list;
+}
+
+(** Restore durable provider state into a tracker.
+    Returns the number of non-empty provider rows applied. *)
+val restore_providers : t -> provider_restore list -> int
+
 (** Record a successful provider call. Clears cooldown and resets
     consecutive failure counter.
 

--- a/lib/cascade/cascade_metrics.ml
+++ b/lib/cascade/cascade_metrics.ml
@@ -912,16 +912,10 @@ let metric_cascade_metrics_eviction =
 let on_cascade_metrics_eviction () =
   Prometheus.inc_counter metric_cascade_metrics_eviction ()
 
-(* [Cascade_inference.clamp_max_tokens_to_ceiling] silently reduces
-   an operator-supplied [max_tokens] to the provider's
-   [provider_ceiling] when the operator's value exceeds it.  The
-   policy is intentional ("smaller response is better than no
-   response" per the docstring) but the silent reduction means
-   operators who configured [max_tokens=16384] for a long-form
-   response in cascade.toml and got a 4096-token truncation had no
-   signal that the budget was clipped.  Pair with iter 26
-   [max_context_fallback] for the symmetric context-window
-   side. *)
+(* Legacy iter-46 counter retained for metric compatibility.  DD-020
+   replaced runtime max_tokens clipping with a structured
+   [max_tokens_ceiling_violation] pre-dispatch error, so this counter
+   should stay at zero on current code paths. *)
 let metric_max_tokens_clamped = "masc_cascade_max_tokens_clamped_total"
 
 let on_max_tokens_clamped () =
@@ -959,7 +953,7 @@ let on_cascade_audit_failure ~stage =
    [max_context=128_000] for a cascade that happens to be
    local-only got an unexpectedly small window with no signal.
 
-   Companion to iter 46 [max_tokens_clamped] (response-budget
+   Companion to DD-020 [max_tokens_ceiling_violation] (response-budget
    side) and iter 26 [max_context_fallback] (no-resolved-value
    side); together they form the complete inference-budget
    coverage:
@@ -968,7 +962,7 @@ let on_cascade_audit_failure ~stage =
      resolved but suspicious   iter 27 discovered_context_below_floor
      resolved but disagreement iter 28 context_capability_drift
      local-only clamp          iter 49 local_context_clamped  (this)
-     response budget clip      iter 46 max_tokens_clamped *)
+     response budget invalid   DD-020 max_tokens_ceiling_violation *)
 let metric_local_context_clamped =
   "masc_cascade_local_context_clamped_total"
 

--- a/lib/cascade/cascade_metrics.mli
+++ b/lib/cascade/cascade_metrics.mli
@@ -291,11 +291,10 @@ val on_cascade_metrics_eviction : unit -> unit
     [cascade_max_keys] or canonicalize synthesized names. *)
 
 val on_max_tokens_clamped : unit -> unit
-(** Tick the max_tokens-clamped counter at
-    [Cascade_inference.clamp_max_tokens_to_ceiling] when the
-    operator-supplied [max_tokens] exceeds the provider ceiling
-    and is silently reduced.  Symmetric to iter-26
-    [max_context_fallback] (context-window side). *)
+(** Legacy iter-46 counter retained for metric compatibility. DD-020
+    replaced runtime max_tokens clipping with the structured
+    [max_tokens_ceiling_violation] pre-dispatch error, so current code
+    paths should not emit this counter. *)
 
 val on_cascade_audit_failure : stage:string -> unit
 (** Tick the cascade-audit subsystem failure counter at
@@ -310,8 +309,8 @@ val on_local_context_clamped : unit -> unit
     [Cascade_runtime.clamp_context_for_pure_local_labels] when a
     cascade with only local-provider labels has its
     [max_context] silently reduced to [small_local_floor].
-    Symmetric to iter 46 [max_tokens_clamped] (response-budget
-    side). *)
+    Symmetric to DD-020 [max_tokens_ceiling_violation]
+    (response-budget side). *)
 
 val all_cascade_counters : (string * string) list
 (** SSOT list of every cascade counter in this module, paired with

--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -241,10 +241,9 @@ let clamp_context_for_pure_local_labels ~(labels : string list) ~(max_context : 
   then begin
     let clamped = min max_context Env_config.ContextCompact.small_local_floor in
     (* Iter 49: tick a counter when the clamp actually reduces the
-       window (max_context > floor).  Same shape as iter 46
-       max_tokens_clamped — the policy stays (local providers
-       have tiny context windows) but the rate is observable so
-       operators can spot cascade.toml settings being silently
+       window (max_context > floor).  Same family as DD-020
+       max_tokens_ceiling_violation: local context clamps remain
+       observable so operators can spot cascade.toml settings being
        clipped on local-only cascades. *)
     if clamped < max_context then
       Cascade_metrics.on_local_context_clamped ();

--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -368,6 +368,174 @@ let models_of_cascade_name cascade_name =
         normalized detail;
       []
 
+let min_positive_int_options values =
+  values
+  |> List.filter_map (function Some value when value > 0 -> Some value | _ -> None)
+  |> function
+  | [] -> None
+  | value :: rest -> Some (List.fold_left min value rest)
+
+let strip_prefix ~prefix value =
+  let prefix_len = String.length prefix in
+  if String.length value >= prefix_len
+     && String.equal (String.sub value 0 prefix_len) prefix
+  then Some (String.sub value prefix_len (String.length value - prefix_len))
+  else None
+
+let declarative_model_max_output_tokens
+    (cfg : Cascade_declarative_types.cascade_config)
+    model_id =
+  let open Cascade_declarative_types in
+  match
+    cfg.models
+    |> List.find_opt
+         (fun (model : cascade_model_spec) -> String.equal model.id model_id)
+  with
+  | None -> None
+  | Some model -> (
+      match model.capabilities with
+      | Some caps -> caps.max_output_tokens
+      | None -> None)
+
+let declarative_member_max_output_tokens
+    (cfg : Cascade_declarative_types.cascade_config)
+    member =
+  let open Cascade_declarative_types in
+  let alias =
+    cfg.aliases
+    |> List.find_opt (fun (alias : cascade_alias) ->
+         String.equal
+           (Printf.sprintf "%s.%s.%s" alias.provider_id alias.model_id alias.name)
+           member)
+  in
+  match alias with
+  | Some alias ->
+      min_positive_int_options
+        [
+          alias.max_output;
+          declarative_model_max_output_tokens cfg alias.model_id;
+        ]
+  | None ->
+      (match
+         cfg.bindings
+         |> List.find_opt
+              (fun (binding : cascade_binding) ->
+                 String.equal
+                   (Printf.sprintf "%s.%s" binding.provider_id binding.model_id)
+                   member)
+       with
+       | None -> None
+       | Some binding -> declarative_model_max_output_tokens cfg binding.model_id)
+
+let declarative_member_exists (cfg : Cascade_declarative_types.cascade_config) member
+    =
+  let open Cascade_declarative_types in
+  List.exists
+    (fun (alias : cascade_alias) ->
+       String.equal
+         (Printf.sprintf "%s.%s.%s" alias.provider_id alias.model_id alias.name)
+         member)
+    cfg.aliases
+  || List.exists
+       (fun (binding : cascade_binding) ->
+          String.equal
+            (Printf.sprintf "%s.%s" binding.provider_id binding.model_id)
+            member)
+       cfg.bindings
+
+let declarative_tier_members (cfg : Cascade_declarative_types.cascade_config)
+    tier_name =
+  let open Cascade_declarative_types in
+  match
+    cfg.tiers
+    |> List.find_opt (fun (tier : cascade_tier) ->
+         String.equal tier.name tier_name)
+  with
+  | Some tier -> tier.members
+  | None -> []
+
+let declarative_tier_group_members
+    (cfg : Cascade_declarative_types.cascade_config)
+    group_name =
+  let open Cascade_declarative_types in
+  let tiers_by_name = Hashtbl.create (List.length cfg.tiers) in
+  List.iter
+    (fun (tier : cascade_tier) -> Hashtbl.replace tiers_by_name tier.name tier)
+    cfg.tiers;
+  match
+    cfg.tier_groups
+    |> List.find_opt (fun (group : cascade_tier_group) ->
+         String.equal group.name group_name)
+  with
+  | None -> []
+  | Some group ->
+      group.tiers
+      |> List.filter_map (Hashtbl.find_opt tiers_by_name)
+      |> List.concat_map (fun (tier : cascade_tier) -> tier.members)
+
+let declarative_members_for_profile
+    (cfg : Cascade_declarative_types.cascade_config)
+    profile_name =
+  match strip_prefix ~prefix:"tier." profile_name with
+  | Some tier_name -> declarative_tier_members cfg tier_name
+  | None -> (
+      match strip_prefix ~prefix:"tier-group." profile_name with
+      | Some group_name -> declarative_tier_group_members cfg group_name
+      | None ->
+          let group_members = declarative_tier_group_members cfg profile_name in
+          if group_members <> [] then group_members
+          else
+            let tier_members = declarative_tier_members cfg profile_name in
+            if tier_members <> [] then tier_members
+            else if declarative_member_exists cfg profile_name then [ profile_name ]
+            else [])
+
+let declarative_route_target
+    (cfg : Cascade_declarative_types.cascade_config)
+    raw_name =
+  let open Cascade_declarative_types in
+  let trimmed = String.trim raw_name in
+  let candidate_keys =
+    (match Cascade_routes.logical_use_of_string_opt trimmed with
+     | Some use -> [ trimmed; Cascade_routes.logical_use_key use ]
+     | None -> [ trimmed ])
+    |> List.filter (fun key -> not (String.equal key ""))
+  in
+  let routes = cfg.routes @ cfg.system_targets in
+  candidate_keys
+  |> List.find_map (fun key ->
+       routes
+       |> List.find_opt (fun (route : cascade_route) -> String.equal route.name key)
+       |> Option.map (fun route -> route.target))
+
+let first_nonempty_members cfg candidates =
+  candidates
+  |> List.find_map (fun profile_name ->
+       let members = declarative_members_for_profile cfg profile_name in
+       if members = [] then None else Some members)
+
+let max_output_tokens_ceiling_of_cascade_name cascade_name =
+  match cascade_config_path () with
+  | None -> None
+  | Some path -> (
+      match Cascade_declarative_parser.parse_file path with
+      | Error _ -> None
+      | Ok cfg ->
+          let raw_name = cascade_name_to_string cascade_name in
+          let resolved_name =
+            match Cascade_catalog_runtime.resolve_declared_name ~raw_name () with
+            | Ok resolved -> Some resolved
+            | Error _ -> None
+          in
+          [ resolved_name; declarative_route_target cfg raw_name; Some raw_name ]
+          |> List.filter_map Fun.id
+          |> first_nonempty_members cfg
+          |> Option.map (fun members ->
+               members
+               |> List.map (declarative_member_max_output_tokens cfg)
+               |> min_positive_int_options)
+          |> Option.join)
+
 let resolve_named_providers_result ?provider_filter
     ?(require_tool_choice_support = false)
     ?(require_tool_support = false)

--- a/lib/cascade/cascade_runtime.mli
+++ b/lib/cascade/cascade_runtime.mli
@@ -36,6 +36,8 @@ val models_of_cascade_name_result :
   Keeper_cascade_profile.runtime_name -> (string list, string) result
 val models_of_cascade_name :
   Keeper_cascade_profile.runtime_name -> string list
+val max_output_tokens_ceiling_of_cascade_name :
+  Keeper_cascade_profile.runtime_name -> int option
 val resolve_named_providers_result :
   ?provider_filter:string list ->
   ?require_tool_choice_support:bool ->

--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -147,12 +147,28 @@ let runtime_label_for_active_id ~configured_labels ~active =
          | None -> active)
 
 let runtime_health_key_of_label label =
-  let _ = label in
-  None
+  let cfg_of_kind ~kind ~model_id ~base_url =
+    Llm_provider.Provider_config.make ~kind ~model_id ~base_url ()
+  in
+  let cfg =
+    match Provider_kind_resolver.resolve label with
+    | Registered { provider_name; model_id; kind } ->
+      let base_url = registry_default_base_url provider_name in
+      Some (cfg_of_kind ~kind ~model_id ~base_url)
+    | Custom_url { model_id; base_url } ->
+      Some
+        (cfg_of_kind
+           ~kind:Llm_provider.Provider_config.OpenAI_compat
+           ~model_id
+           ~base_url)
+    | Unknown _ -> None
+  in
+  Option.map Provider_adapter.provider_health_key_of_config cfg
 
 let runtime_health_keys_of_labels labels =
-  let _ = labels in
-  []
+  labels
+  |> List.filter_map runtime_health_key_of_label
+  |> List.sort_uniq String.compare
 
 let resolve_reported_runtime_id ~labels ~reported_runtime_id =
   let _ = labels in
@@ -188,8 +204,18 @@ let first_health_cooldown candidate =
     | Error msg -> Some (provider_key, msg))
 
 let has_recovery_evidence candidate =
-  let _ = candidate in
-  false
+  health_keys candidate
+  |> List.exists (fun provider_key ->
+    match
+      Cascade_health_tracker.provider_info
+        Cascade_health_tracker.global
+        ~provider_key
+    with
+    | None -> false
+    | Some info ->
+      (not info.in_cooldown)
+      && (info.events_in_window > 0 || info.latency_samples > 0)
+      && info.success_rate > 0.0)
 
 let provider_attempt_timeout_constraints candidate =
   Provider_adapter.timeout_bounds_of_kind candidate.provider_cfg.kind

--- a/lib/cascade/cascade_trust_persist.ml
+++ b/lib/cascade/cascade_trust_persist.ml
@@ -77,6 +77,51 @@ let snapshot_to_json ~ts (infos : H.provider_info list) : Yojson.Safe.t =
     ; ("providers", `List (List.map provider_info_to_json infos))
     ]
 
+let float_opt = function
+  | `Float v when Float.is_finite v -> Some v
+  | `Int v -> Some (float_of_int v)
+  | `Intlit raw ->
+    (match Safe_ops.float_of_string_safe raw with
+     | Some v when Float.is_finite v -> Some v
+     | _ -> None)
+  | _ -> None
+
+let int_opt = function
+  | `Int v -> Some v
+  | `Intlit raw -> Safe_ops.int_of_string_safe raw
+  | _ -> None
+
+let restore_provider_of_json json =
+  let open Yojson.Safe.Util in
+  match json |> member "provider_key" with
+  | `String provider_key when String.trim provider_key <> "" ->
+    let restore_consecutive_failures =
+      json |> member "consecutive_failures" |> int_opt |> Option.value ~default:0
+    in
+    let restore_cooldown_until = json |> member "cooldown_expires_at" |> float_opt in
+    let restore_last_failure_at = json |> member "last_failure_at" |> float_opt in
+    let restore_top_fingerprints =
+      match json |> member "top_fingerprints" with
+      | `List rows ->
+        List.filter_map
+          (fun row ->
+            match row |> member "fingerprint", row |> member "count" |> int_opt with
+            | `String fp, Some count when String.trim fp <> "" && count > 0 ->
+              Some (fp, count)
+            | _ -> None)
+          rows
+      | _ -> []
+    in
+    Some
+      H.
+        { restore_provider_key = provider_key
+        ; restore_consecutive_failures
+        ; restore_cooldown_until
+        ; restore_last_failure_at
+        ; restore_top_fingerprints
+        }
+  | _ -> None
+
 (* ── Public API ─────────────────────────────────────── *)
 
 let snapshot_now ~base_path =
@@ -91,7 +136,33 @@ let snapshot_now ~base_path =
     Log.Misc.warn "cascade_trust_persist: snapshot_now failed: %s"
       (Printexc.to_string exn)
 
+let hydrate_latest ~base_path =
+  try
+    let store = get_or_create_store ~base_path in
+    match Dated_jsonl.read_recent store 1 with
+    | [] -> 0
+    | latest :: _ ->
+      (match Yojson.Safe.Util.member "providers" latest with
+       | `List providers ->
+         let restored =
+           List.filter_map restore_provider_of_json providers
+           |> H.restore_providers H.global
+         in
+         if restored > 0 then
+           Log.Misc.info
+             "cascade_trust_persist: hydrated %d provider health row(s)"
+             restored;
+         restored
+       | _ -> 0)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Misc.warn "cascade_trust_persist: hydrate_latest failed: %s"
+      (Printexc.to_string exn);
+    0
+
 let start_snapshot_fiber ~sw ~clock ~base_path =
+  let _hydrated = hydrate_latest ~base_path in
   let _store = get_or_create_store ~base_path in
   Eio.Fiber.fork ~sw (fun () ->
     Log.Misc.info

--- a/lib/cascade/cascade_trust_persist.mli
+++ b/lib/cascade/cascade_trust_persist.mli
@@ -28,11 +28,16 @@ val snapshot_now : base_path:string -> unit
     {!Cascade_health_tracker.global} via {!Cascade_health_tracker.all_providers}.
     Used by the tick fiber and shutdown hook. *)
 
+val hydrate_latest : base_path:string -> int
+(** Restore provider cooldown/failure state from the latest JSONL snapshot.
+    Returns the number of provider rows applied. Best-effort: malformed or
+    missing snapshots return [0]. *)
+
 val start_snapshot_fiber :
   sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> base_path:string -> unit
 (** Spawn a background fiber that calls {!snapshot_now} every
-    [snapshot_interval_s].  Registers a shutdown hook for one final
-    snapshot. *)
+    [snapshot_interval_s].  Hydrates from the latest snapshot before the
+    fiber starts and registers a shutdown hook for one final snapshot. *)
 
 val reset_for_testing : unit -> unit
 (** Clear cached store state.  Does not cancel any fiber started via

--- a/lib/cascade_inference.ml
+++ b/lib/cascade_inference.ml
@@ -99,17 +99,35 @@ let resolve_max_tokens
   | Some t -> t
   | None -> fallback ()
 
-(** Clamp max_tokens to provider ceiling.
-    Clamping > rejection: a smaller response is better than no response.
-    Mirrors TLA+ KeeperCoreTriad.CapabilityGate action. *)
-let clamp_max_tokens_to_ceiling ~(provider_ceiling : int option) (max_tokens : int) : int =
+(** Validate max_tokens against provider ceilings before dispatch. *)
+let validate_max_tokens_within_ceiling
+    ~(cascade_name : Keeper_cascade_profile.runtime_name)
+    ~(provider_ceiling : int option)
+    (max_tokens : int)
+  : (int, Cascade_error_classify.masc_internal_error) result =
+  let violation ~reason ~provider_ceiling =
+    Error
+      (Cascade_error_classify.Max_tokens_ceiling_violation
+         {
+           cascade_name;
+           requested_max_tokens = max_tokens;
+           provider_ceiling;
+           reason;
+         })
+  in
   match provider_ceiling with
-  | Some ceiling when max_tokens > ceiling ->
-    (* Iter 46: tick a counter so operators can alert on
-       cascade.toml [max_tokens] settings being silently clipped
-       by provider ceilings.  The clamp policy itself stays — a
-       smaller response beats none — but the rate is now
-       observable for budget tuning / docs alignment. *)
-    Cascade_metrics.on_max_tokens_clamped ();
-    max 1 ceiling
-  | _ -> max_tokens
+  | None ->
+    if max_tokens <= 0
+    then violation ~reason:"max_tokens_not_positive" ~provider_ceiling:0
+    else Ok max_tokens
+  | Some ceiling ->
+    if max_tokens <= 0
+    then violation ~reason:"max_tokens_not_positive" ~provider_ceiling:ceiling
+    else if ceiling <= 0
+    then violation ~reason:"provider_ceiling_not_positive" ~provider_ceiling:ceiling
+    else if max_tokens > ceiling
+    then
+      violation
+        ~reason:"requested_exceeds_provider_ceiling"
+        ~provider_ceiling:ceiling
+    else Ok max_tokens

--- a/lib/cascade_inference.mli
+++ b/lib/cascade_inference.mli
@@ -46,13 +46,16 @@ val resolve_max_tokens :
   fallback:(unit -> int) ->
   int
 
-(** Clamp max_tokens to provider ceiling.
+(** Validate max_tokens against the provider ceiling before dispatch.
 
     If [provider_ceiling] is [Some ceiling] and [max_tokens > ceiling],
-    returns [ceiling]. Otherwise returns [max_tokens] unchanged.
+    returns [Error _] instead of silently reducing the operator-supplied
+    budget. Also rejects non-positive [max_tokens] and non-positive
+    provider ceilings.
 
-    Clamping strategy: a smaller response is better than no response.
-    Mirrors TLA+ KeeperCoreTriad.CapabilityGate action.
-
-    @since Core Triad *)
-val clamp_max_tokens_to_ceiling : provider_ceiling:int option -> int -> int
+    @since DD-020 *)
+val validate_max_tokens_within_ceiling :
+  cascade_name:Keeper_cascade_profile.runtime_name ->
+  provider_ceiling:int option ->
+  int ->
+  (int, Cascade_error_classify.masc_internal_error) result

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -180,6 +180,23 @@ let run_turn
   in
   let temperature = ctx.temperature in
   let max_tokens = ctx.max_tokens in
+  let pre_dispatch_max_tokens_error =
+    match
+      Cascade_inference.validate_max_tokens_within_ceiling
+        ~cascade_name
+        ~provider_ceiling:(Some max_context)
+        max_tokens
+    with
+    | Ok _ -> None
+    | Error internal_error ->
+      let detail =
+        Option.value
+          ~default:(Cascade_error_classify.kind_of_masc_internal_error internal_error)
+          (Cascade_error_classify.summary_of_masc_internal_error internal_error)
+      in
+      Log.Keeper.error "%s: %s" meta.name detail;
+      Some (Cascade_error_classify.sdk_error_of_masc_internal_error internal_error)
+  in
   let context_injector = ctx.context_injector in
   let shared_context = ctx.shared_context in
   let session_dir = ctx.session_dir in
@@ -633,7 +650,10 @@ let run_turn
          match pre_dispatch_checkpoint_error with
          | Some err -> Error err
          | None ->
-           (match !initial_tool_surface_blocker_ref with
+           (match pre_dispatch_max_tokens_error with
+            | Some err -> Error err
+            | None ->
+             (match !initial_tool_surface_blocker_ref with
             | Some err -> Error err
             | None ->
               (match
@@ -719,7 +739,7 @@ let run_turn
                      ?event_bus
                      ?per_provider_timeout_s
                      ())
-               with
+             with
                | Error e -> Error e
                | Ok result ->
                  let post_turn_t0 = Time_compat.now () in
@@ -1674,7 +1694,7 @@ let run_turn
                           ()
                       with
                       | Error e -> Error (Agent_sdk.Error.Internal e)
-                      | Ok response_text -> finalize_response_text response_text))))
+                      | Ok response_text -> finalize_response_text response_text)))))
 	       in
 	       (match turn_result with
 	        | Ok _ -> ()

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -180,11 +180,14 @@ let run_turn
   in
   let temperature = ctx.temperature in
   let max_tokens = ctx.max_tokens in
+  let max_output_ceiling =
+    Cascade_runtime.max_output_tokens_ceiling_of_cascade_name cascade_name
+  in
   let pre_dispatch_max_tokens_error =
     match
       Cascade_inference.validate_max_tokens_within_ceiling
         ~cascade_name
-        ~provider_ceiling:(Some max_context)
+        ~provider_ceiling:max_output_ceiling
         max_tokens
     with
     | Ok _ -> None

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -28,6 +28,7 @@ let default_max_checkpoint_messages = 120
     accumulates hundreds of text blocks or multi-MB synthetic context. *)
 let default_max_checkpoint_text_blocks_per_message = 32
 let default_max_checkpoint_text_chars_per_message = 16 * 1024
+let default_max_checkpoint_content_chars_total = 512 * 1024
 let checkpoint_text_cap_marker = "\n[capped]"
 
 (** ToolResult block caps — analogous to text block caps above.
@@ -1177,23 +1178,145 @@ let sanitize_checkpoint_message
         { empty_checkpoint_sanitize_stats with dropped_messages = 1 } )
   else (Some { msg with content = kept }, stats)
 
+let checkpoint_content_chars_of_block = function
+  | Agent_sdk.Types.Text text -> String.length text
+  | Agent_sdk.Types.Thinking { content; _ } -> String.length content
+  | Agent_sdk.Types.RedactedThinking text -> String.length text
+  | Agent_sdk.Types.ToolResult { content; _ } -> String.length content
+  | _ -> 0
+
+let checkpoint_content_chars_of_message (msg : Agent_sdk.Types.message) : int =
+  List.fold_left
+    (fun total block -> total + checkpoint_content_chars_of_block block)
+    0
+    msg.content
+
+let cap_checkpoint_message_to_remaining_content
+    ~(remaining : int)
+    (msg : Agent_sdk.Types.message)
+  : Agent_sdk.Types.message option * int * checkpoint_sanitize_stats =
+  let message_chars = checkpoint_content_chars_of_message msg in
+  if message_chars = 0 then (Some msg, 0, empty_checkpoint_sanitize_stats)
+  else if remaining <= 0 then
+    ( None,
+      0,
+      {
+        empty_checkpoint_sanitize_stats with
+        dropped_messages = 1;
+        dropped_chars = message_chars;
+      } )
+  else if message_chars <= remaining then
+    (Some msg, message_chars, empty_checkpoint_sanitize_stats)
+  else
+    let remaining_ref = ref remaining in
+    let used_ref = ref 0 in
+    let kept_rev, stats =
+      List.fold_left
+        (fun (kept_rev, stats) block ->
+           let cap_content rebuild content =
+             let len = String.length content in
+             if len = 0 then
+               (rebuild content :: kept_rev, stats)
+             else if !remaining_ref <= 0 then
+               ( kept_rev,
+                 add_checkpoint_sanitize_stats stats
+                   {
+                     empty_checkpoint_sanitize_stats with
+                     dropped_blocks = 1;
+                     dropped_chars = len;
+                   } )
+             else if len <= !remaining_ref then (
+               remaining_ref := !remaining_ref - len;
+               used_ref := !used_ref + len;
+               (rebuild content :: kept_rev, stats))
+             else
+               let capped, truncated_chars =
+                 truncate_checkpoint_text ~max_chars:!remaining_ref content
+               in
+               let capped_len = String.length capped in
+               remaining_ref := 0;
+               used_ref := !used_ref + capped_len;
+               ( rebuild capped :: kept_rev,
+                 add_checkpoint_sanitize_stats stats
+                   {
+                     empty_checkpoint_sanitize_stats with
+                     truncated_blocks = 1;
+                     truncated_chars;
+                   } )
+           in
+           match block with
+           | Agent_sdk.Types.Text text ->
+               cap_content (fun text -> Agent_sdk.Types.Text text) text
+           | Agent_sdk.Types.ToolResult { tool_use_id; content; is_error; _ } ->
+               cap_content
+                 (fun content ->
+                   Agent_sdk.Types.ToolResult
+                     { tool_use_id; content; is_error; json = None })
+                 content
+           | Agent_sdk.Types.Thinking { content; _ } ->
+               cap_content (fun text -> Agent_sdk.Types.Text text) content
+           | Agent_sdk.Types.RedactedThinking text ->
+               cap_content (fun text -> Agent_sdk.Types.Text text) text
+           | _ -> (block :: kept_rev, stats))
+        ([], empty_checkpoint_sanitize_stats)
+        msg.content
+    in
+    let kept = List.rev kept_rev in
+    if kept = [] then
+      ( None,
+        !used_ref,
+        add_checkpoint_sanitize_stats stats
+          { empty_checkpoint_sanitize_stats with dropped_messages = 1 } )
+    else (Some { msg with content = kept }, !used_ref, stats)
+
+let cap_checkpoint_messages_total_content
+    (messages : Agent_sdk.Types.message list)
+  : Agent_sdk.Types.message list * checkpoint_sanitize_stats =
+  let rec loop kept remaining stats = function
+    | [] -> (kept, stats)
+    | msg :: older ->
+        let sanitized, used, msg_stats =
+          cap_checkpoint_message_to_remaining_content ~remaining msg
+        in
+        let kept =
+          match sanitized with
+          | Some msg -> msg :: kept
+          | None -> kept
+        in
+        let remaining = max 0 (remaining - used) in
+        loop
+          kept
+          remaining
+          (add_checkpoint_sanitize_stats stats msg_stats)
+          older
+  in
+  loop
+    []
+    default_max_checkpoint_content_chars_total
+    empty_checkpoint_sanitize_stats
+    (List.rev messages)
+
 let sanitize_checkpoint_messages
     (messages : Agent_sdk.Types.message list)
   : Agent_sdk.Types.message list * checkpoint_sanitize_stats =
-  List.fold_right
-    (fun msg (acc, stats) ->
-       let sanitized_opt, msg_stats = sanitize_checkpoint_message msg in
-       let acc =
-         match sanitized_opt with
-         | Some sanitized -> sanitized :: acc
-         | None -> acc
-       in
-       let stats =
-         add_checkpoint_sanitize_stats stats msg_stats
-       in
-       (acc, stats))
-    messages
-    ([], empty_checkpoint_sanitize_stats)
+  let messages, stats =
+    List.fold_right
+      (fun msg (acc, stats) ->
+         let sanitized_opt, msg_stats = sanitize_checkpoint_message msg in
+         let acc =
+           match sanitized_opt with
+           | Some sanitized -> sanitized :: acc
+           | None -> acc
+         in
+         let stats =
+           add_checkpoint_sanitize_stats stats msg_stats
+         in
+         (acc, stats))
+      messages
+      ([], empty_checkpoint_sanitize_stats)
+  in
+  let messages, total_stats = cap_checkpoint_messages_total_content messages in
+  (messages, add_checkpoint_sanitize_stats stats total_stats)
 
 let sanitize_oas_checkpoint
     ?(repair_orphans = true)
@@ -1287,9 +1410,9 @@ let save_oas_checkpoint
       (Agent_sdk.Context_reducer.stub_tool_results ~keep_recent:1)
       capped_messages
   in
-  let capped_messages, _ = sanitize_checkpoint_messages capped_messages in
+  let capped_messages, sanitize_stats = sanitize_checkpoint_messages capped_messages in
   let capped_messages =
-    if capped_messages_were_truncated
+    if capped_messages_were_truncated || checkpoint_sanitize_changed sanitize_stats
     then repair_broken_tool_call_pairs capped_messages
     else capped_messages
   in

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -204,6 +204,11 @@ val default_max_checkpoint_tool_result_chars : int
     threshold the payload collapses to a stub so a single
     orphan-repair pass cannot inflate one block to multi-MB. *)
 
+val default_max_checkpoint_content_chars_total : int
+(** Total persisted Text/tool_result content budget across the retained
+    checkpoint message list. The newest messages are kept first; older
+    messages are truncated or dropped once this budget is exhausted. *)
+
 val tool_result_text_of_block :
   tool_use_id:string ->
   content:string ->

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -170,6 +170,7 @@ let is_auto_recoverable_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Turn_timeout _)
   | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)
   | None ->
       false
@@ -184,6 +185,7 @@ let is_resumable_cli_session_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
   | Some (Keeper_turn_driver.Turn_timeout _)
   | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)
   | None ->
       false
@@ -312,6 +314,7 @@ let degraded_retry_after_recoverable_error
     | Some (Keeper_turn_driver.No_tool_capable_provider _)
     | Some (Keeper_turn_driver.Accept_rejected _)
     | Some (Keeper_turn_driver.Admission_queue_rejected _)
+    | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
     | Some (Keeper_turn_driver.Ambiguous_post_commit _)
     | None ->
         None
@@ -358,6 +361,7 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
     | Some (Keeper_turn_driver.No_tool_capable_provider _)
     | Some (Keeper_turn_driver.Accept_rejected _)
     | Some (Keeper_turn_driver.Admission_queue_rejected _)
+    | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
     | Some (Keeper_turn_driver.Ambiguous_post_commit _) ->
         None
     | None ->
@@ -586,7 +590,8 @@ let is_ambiguous_side_effect_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Turn_timeout _)
-  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> false
+  | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _) -> false
 
 let reclassify_error_after_side_effect
     ~(tool_names : string list)
@@ -750,6 +755,7 @@ let is_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
   | Some (Keeper_turn_driver.Oas_timeout_budget _)
   | Some (Keeper_turn_driver.Turn_timeout _)
+  | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _) -> false
   | None -> false
 

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -418,6 +418,7 @@ let is_oas_timeout_budget_error (err : Agent_sdk.Error.sdk_error) =
       | Keeper_turn_driver.Admission_queue_timeout _
       | Keeper_turn_driver.Admission_queue_rejected _
       | Keeper_turn_driver.Turn_timeout _
+      | Keeper_turn_driver.Max_tokens_ceiling_violation _
       | Keeper_turn_driver.Ambiguous_post_commit _ )
   | None ->
     false

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -2118,14 +2118,6 @@ let make_hooks
             ~keeper_name:(!meta_ref).name ()
         in
         let result_bytes = if original_bytes > 0 then original_bytes else out_len in
-        let handler_logged =
-          Keeper_tool_call_log.consume_handler_logged
-            ~keeper_name:(!meta_ref).name
-            ~tool_name
-            ~output_text
-            ~success:(outcome = "ok")
-            ()
-        in
         let ( lane
             , tool_choice
             , thinking_enabled
@@ -2143,33 +2135,32 @@ let make_hooks
           Keeper_tool_call_log.get_turn_context
             ~keeper_name:(!meta_ref).name ()
         in
-        if not handler_logged then
-          (try
-             Keeper_tool_call_log.log_call
-               ~keeper_name:(!meta_ref).name
-               ~tool_name ~input ~output_text
-               ~success:(outcome = "ok") ~duration_ms
-               ~model:(current_keeper_model !meta_ref)
-               ?lane ?tool_choice ?thinking_enabled ?thinking_budget
-               ?prompt_fingerprint
-               ?trace_id ?session_id ?turn ?keeper_turn_id ?task_id ?goal_ids
-               ?sandbox_profile ?network_mode ?approval_mode
-               ~result_bytes ?truncated_to ()
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-               (* P2 silent-failure fix (same pattern as the broadcast site
-                  above at line ~1098): tool-call audit log write failures
-                  were dropped without trace.  Loss of these rows leaves
-                  downstream replay / debugging tools with gaps that look
-                  identical to "no tool calls in this turn." *)
-               Prometheus.inc_counter
-                 Keeper_metrics.metric_keeper_lifecycle_callback_failures
-                 ~labels:[("keeper", (!meta_ref).name); ("callback", "post_tool_log_write")]
-                 ();
-               Log.Keeper.warn
-                 "keeper:%s tool=%s log_call write failed: %s"
-                 (!meta_ref).name tool_name (Printexc.to_string exn));
+        (try
+           Keeper_tool_call_log.log_call
+             ~keeper_name:(!meta_ref).name
+             ~tool_name ~input ~output_text
+             ~success:(outcome = "ok") ~duration_ms
+             ~model:(current_keeper_model !meta_ref)
+             ?lane ?tool_choice ?thinking_enabled ?thinking_budget
+             ?prompt_fingerprint
+             ?trace_id ?session_id ?turn ?keeper_turn_id ?task_id ?goal_ids
+             ?sandbox_profile ?network_mode ?approval_mode
+             ~result_bytes ?truncated_to ()
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+             (* P2 silent-failure fix (same pattern as the broadcast site
+                above at line ~1098): tool-call audit log write failures
+                were dropped without trace.  Loss of these rows leaves
+                downstream replay / debugging tools with gaps that look
+                identical to "no tool calls in this turn." *)
+             Prometheus.inc_counter
+               Keeper_metrics.metric_keeper_lifecycle_callback_failures
+               ~labels:[("keeper", (!meta_ref).name); ("callback", "post_tool_log_write")]
+               ();
+             Log.Keeper.warn
+               "keeper:%s tool=%s log_call write failed: %s"
+               (!meta_ref).name tool_name (Printexc.to_string exn));
         (try
            append_pr_review_action_metric
              ~config

--- a/lib/keeper/keeper_lifecycle_hooks.mli
+++ b/lib/keeper/keeper_lifecycle_hooks.mli
@@ -3,14 +3,16 @@
     Foundation for the lifecycle_cleanup_hook plumbing described in
     [docs/rfc/RFC-0036-multi-keeper-docker-orchestration.md].
 
-    This PR wires the first call site:
-    [Keeper_supervisor.sweep_and_recover] fires [Tombstone_reaped] after
-    a dead-keeper unregister succeeds (see [Keeper_lifecycle_hooks.run]
-    invocation in keeper_supervisor.ml). [Phase_transition] is
-    declared but not yet emitted from any call site — Phase A.2
-    follow-up wires it; until that PR lands no hook will receive a
-    Phase_transition event. Phase B/C uses the same registration API
-    to attach the [Docker_runtime] bridge.
+    The two production call sites are:
+    - [Keeper_registry.dispatch_event_with_audit] fires [Phase_transition]
+      after the state machine accepts a phase change and before the
+      registry write commits.
+    - [Keeper_supervisor.sweep_and_recover] fires [Tombstone_reaped] after
+      a dead-keeper unregister succeeds (see [Keeper_lifecycle_hooks.run]
+      invocation in keeper_supervisor.ml).
+
+    Phase B/C uses the same registration API to attach the
+    [Docker_runtime] bridge.
 
     Contract:
     - Hooks are best-effort, synchronous, and exception-safe. The runner
@@ -31,13 +33,9 @@ type event =
       from_phase : Keeper_state_machine.phase;
       to_phase   : Keeper_state_machine.phase;
     }
-      (** Reserved for the Phase A.2 follow-up: a future supervisor
-          phase-transition call site will fire this before the
-          registry write commits. No call site emits it in this PR;
-          [Keeper_lifecycle_hooks.run] is currently invoked only with
-          [Tombstone_reaped] (from [Keeper_supervisor.sweep_and_recover]).
-          Hooks will observe the intent of the transition; they cannot
-          veto. *)
+      (** Fired from [Keeper_registry.dispatch_event_with_audit] for real
+          phase changes before the registry write commits. Hooks observe
+          the intent of the transition; they cannot veto. *)
   | Tombstone_reaped
       (** Fired by [Keeper_supervisor.cleanup_dead_tombstone] after the
           registry unregister completes. The keeper is fully gone from

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -438,6 +438,7 @@ let keeper_state_snapshot_to_summary_text (snapshot : keeper_state_snapshot) : s
 let default_max_string_chars = 400
 let default_max_list_items = 5
 let default_max_item_chars = 200
+let default_continuity_summary_max_chars = 5_600
 
 let cap_string ~max_chars = function
   | None -> None
@@ -474,6 +475,15 @@ let cap_snapshot
     constraints =
       cap_list ~max_items:max_list_items ~max_item_chars snapshot.constraints;
   }
+
+let cap_continuity_summary_text
+    ?(max_chars = default_continuity_summary_max_chars)
+    (text : string) : string =
+  let trimmed = String.trim text in
+  if trimmed = "" then ""
+  else
+    String_util.utf8_safe ~max_bytes:(max_chars + 3) ~suffix:"…" trimmed
+    |> String_util.to_string
 
 (* RFC-MASC-001 Phase 1 post-mortem (Gen3 2026-04-17):
    [keeper_state_snapshot_to_summary_text] renders every field for audit/persistence.
@@ -716,6 +726,7 @@ let continuity_fallback_summary_text
   if trimmed = "" then
     "No continuity snapshot available."
   else
+    let bounded = cap_continuity_summary_text trimmed in
     let freshness_line =
       if last_continuity_update_ts > 0.0 then
         let age_s = max 0.0 (Time_compat.now () -. last_continuity_update_ts) in
@@ -729,7 +740,7 @@ let continuity_fallback_summary_text
         freshness_line;
         "Checkpoint note: latest checkpoint [STATE] snapshot unavailable.";
         "Treat the following as prior context only and re-verify blockers, constraints, and repo state against the live world state before acting.";
-        trimmed;
+        bounded;
       ]
 
 let keeper_state_snapshot_to_json (snapshot : keeper_state_snapshot) : Yojson.Safe.t =

--- a/lib/keeper/keeper_memory_policy.mli
+++ b/lib/keeper/keeper_memory_policy.mli
@@ -210,6 +210,7 @@ val keeper_state_snapshot_to_summary_text : keeper_state_snapshot -> string
 val default_max_string_chars : int
 val default_max_list_items : int
 val default_max_item_chars : int
+val default_continuity_summary_max_chars : int
 
 val cap_string : max_chars:int -> string option -> string option
 (** Truncate to [max_chars]; [None] passes through. *)
@@ -224,6 +225,11 @@ val cap_snapshot :
   ?max_item_chars:int -> keeper_state_snapshot -> keeper_state_snapshot
 (** Apply per-field caps using the [default_max_*] values when none
     are supplied. *)
+
+val cap_continuity_summary_text : ?max_chars:int -> string -> string
+(** Trim and truncate rendered [continuity_summary] text. This final
+    shared cap is used by production and fallback consumption paths, so
+    legacy oversized summaries cannot bypass {!cap_snapshot}. *)
 
 (** {1 Prompt rendering} *)
 

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -437,7 +437,9 @@ let apply_post_turn_lifecycle_with_resilience_handles
                ());
         {
           meta with
-          continuity_summary = keeper_state_snapshot_to_summary_text snapshot;
+          continuity_summary =
+            keeper_state_snapshot_to_summary_text snapshot
+            |> Keeper_memory_policy.cap_continuity_summary_text;
           runtime =
             {
               meta.runtime with

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -2643,6 +2643,12 @@ let rec dispatch_event_with_audit
          ; transition_outcome = "applied"
          ; wall_clock_at_decision = now
          };
+       Keeper_lifecycle_hooks.run
+         ~base_dir:base_path
+         ~meta:entry.meta
+         ~keeper_id:name
+         (Keeper_lifecycle_hooks.Phase_transition
+            { from_phase = tr.prev_phase; to_phase = tr.new_phase });
        (* Broadcast phase transition to SSE subscribers *)
        (try
           Sse.broadcast

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -222,6 +222,7 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
     Some Admission_queue_wait_timeout
   | Some (Keeper_turn_driver.Admission_queue_rejected _) -> None
   | Some (Keeper_turn_driver.Oas_timeout_budget _) -> Some Oas_timeout_budget
+  | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _) -> None
   | Some (Keeper_turn_driver.Turn_timeout _) -> Some Turn_timeout
   | Some (Keeper_turn_driver.Ambiguous_post_commit { is_timeout; _ }) ->
     Some

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -194,54 +194,6 @@ let transient_mutex_contention_tool_error
         ])
 ;;
 
-let current_keeper_model (meta : Keeper_types.keeper_meta) =
-  let _ = meta in
-  "runtime"
-;;
-
-let persist_tool_call_io_from_handler
-      ~(meta : Keeper_types.keeper_meta)
-      ~(tool_name : string)
-      ~(input : Yojson.Safe.t)
-      ~(output_text : string)
-      ~(success : bool)
-      ~(duration_ms : float)
-      ?result_bytes
-      ?truncated_to
-      ()
-  =
-  try
-    Keeper_tool_call_log.log_call
-      ~keeper_name:meta.name
-      ~tool_name
-      ~input
-      ~output_text
-      ~success
-      ~duration_ms
-      ~model:(current_keeper_model meta)
-      ?result_bytes
-      ?truncated_to
-      ();
-    Keeper_tool_call_log.remember_handler_logged
-      ~keeper_name:meta.name
-      ~tool_name
-      ~output_text
-      ~success
-      ()
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_lifecycle_callback_failures
-      ~labels:[ "keeper", meta.name; "callback", "handler_tool_log_write" ]
-      ();
-    Log.Keeper.warn
-      "keeper:%s tool=%s handler-side tool_call log failed: %s"
-      meta.name
-      tool_name
-      (Printexc.to_string exn)
-;;
-
 (** Max chars for SSE error preview. Short enough for dashboard display,
     long enough to include the actionable portion of the error. *)
 let sse_error_preview_max_chars = 300
@@ -543,15 +495,6 @@ let make_keeper_tool_handler
             ; "ok", `Bool false
             ; "error", `String error_text
             ]);
-      persist_tool_call_io_from_handler
-        ~meta
-        ~tool_name:name
-        ~input
-        ~output_text
-        ~success:false
-        ~duration_ms:0.0
-        ~result_bytes:(String.length output_text)
-        ();
       Tool_result.error ~tool_name:name ~start_time:t0 output_text
     | Ok input ->
       let key = args_key input in
@@ -573,15 +516,6 @@ let make_keeper_tool_handler
             prior_fails
         in
         let output_text = normalize_tool_result ~success:false msg in
-        persist_tool_call_io_from_handler
-          ~meta
-          ~tool_name:name
-          ~input
-          ~output_text
-          ~success:false
-          ~duration_ms:0.0
-          ~result_bytes:(String.length output_text)
-          ();
         Tool_result.error ~tool_name:name ~start_time:t0 output_text)
       else (
         let t0 = Time_compat.now () in
@@ -682,15 +616,6 @@ let make_keeper_tool_handler
               ~original_bytes:(String.length normalized_error)
               ();
             let output_text = Tool_output_validation.cap normalized_error in
-            persist_tool_call_io_from_handler
-              ~meta
-              ~tool_name:name
-              ~input
-              ~output_text
-              ~success:false
-              ~duration_ms:(Float.of_int duration_ms)
-              ~result_bytes:(String.length normalized_error)
-              ();
             Tool_result.error ~tool_name:name ~start_time:t0 output_text)
           else (
             failure_count_reset failure_counts key;
@@ -797,17 +722,6 @@ let make_keeper_tool_handler
             Keeper_tool_call_log.set_truncation_info
               ~keeper_name:meta.name
               ~original_bytes:original_len
-              ?truncated_to:
-                (if was_truncated then Some (String.length truncated_result) else None)
-              ();
-            persist_tool_call_io_from_handler
-              ~meta
-              ~tool_name:name
-              ~input
-              ~output_text:truncated_result
-              ~success:true
-              ~duration_ms:(Float.of_int duration_ms)
-              ~result_bytes:original_len
               ?truncated_to:
                 (if was_truncated then Some (String.length truncated_result) else None)
               ();
@@ -932,15 +846,6 @@ let make_keeper_tool_handler
             ~original_bytes:(String.length normalized_exn)
             ();
           let output_text = Tool_output_validation.cap normalized_exn in
-          persist_tool_call_io_from_handler
-            ~meta
-            ~tool_name:name
-            ~input
-            ~output_text
-            ~success:false
-            ~duration_ms:(Float.of_int duration_ms)
-            ~result_bytes:(String.length normalized_exn)
-            ();
           Tool_result.error ~tool_name:name ~start_time:t0 output_text)
 ;;
 

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -372,6 +372,7 @@ let degraded_retry_bypasses_slot_phase_guard
       | Keeper_turn_driver.Admission_queue_timeout _
       | Keeper_turn_driver.Admission_queue_rejected _
       | Keeper_turn_driver.Turn_timeout _
+      | Keeper_turn_driver.Max_tokens_ceiling_violation _
       | Keeper_turn_driver.Ambiguous_post_commit _ )
   | None ->
     false

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -462,6 +462,98 @@ let run_named
       ?per_provider_timeout_s
       candidate
   in
+  let positive_finite_float = function
+    | value when Float.is_finite value && value > 0.0 -> Some value
+    | _ -> None
+  in
+  let health_error_kind label =
+    Cascade_health_tracker.error_kind_of_string label
+  in
+  let health_keys candidate =
+    Cascade_runtime_candidate.health_keys candidate
+    |> List.sort_uniq String.compare
+  in
+  let cost_usd_of_response (response : Agent_sdk.Types.api_response) =
+    match response.usage with
+    | Some usage -> usage.cost_usd
+    | None -> None
+  in
+  let record_candidate_success candidate ~latency_ms
+      (result : Cascade_runner.run_result) =
+    let latency_ms = positive_finite_float latency_ms in
+    let cost_usd = cost_usd_of_response result.response in
+    List.iter
+      (fun provider_key ->
+         Cascade_health_tracker.record_success
+           Cascade_health_tracker.global
+           ~provider_key
+           ?latency_ms
+           ?cost_usd
+           ())
+      (health_keys candidate)
+  in
+  let record_candidate_rejected candidate ~reason =
+    let error_kind = health_error_kind "accept_rejected" in
+    List.iter
+      (fun provider_key ->
+         Cascade_health_tracker.record_rejected
+           Cascade_health_tracker.global
+           ~provider_key
+           ~error_kind
+           ~error_reason:reason
+           ())
+      (health_keys candidate)
+  in
+  let record_candidate_error candidate (sdk_err : Agent_sdk.Error.sdk_error) =
+    let error_reason = Agent_sdk.Error.to_string sdk_err in
+    let error_kind =
+      sdk_error_cascade_fallback_class sdk_err
+      |> Option.value ~default:"provider_error"
+      |> health_error_kind
+    in
+    let provider_key = Cascade_runtime_candidate.health_key candidate in
+    let model_key = Cascade_runtime_candidate.model_health_key candidate in
+    if sdk_error_is_hard_quota sdk_err then
+      Cascade_health_tracker.record_hard_quota
+        Cascade_health_tracker.global
+        ~provider_key
+        ~error_kind
+        ~error_reason
+        ()
+    else if sdk_error_is_model_access_denied sdk_err then
+      Cascade_health_tracker.record_terminal_failure
+        Cascade_health_tracker.global
+        ~provider_key:model_key
+        ~error_kind
+        ~error_reason
+        ()
+    else if sdk_error_is_resumable_cli_session sdk_err
+            || sdk_error_is_terminal_provider_runtime_failure sdk_err
+    then
+      Cascade_health_tracker.record_terminal_failure
+        Cascade_health_tracker.global
+        ~provider_key
+        ~error_kind
+        ~error_reason
+        ()
+    else
+      match sdk_error_soft_rate_limited sdk_err with
+      | Some retry_after_s ->
+        Cascade_health_tracker.record_soft_rate_limited
+          Cascade_health_tracker.global
+          ~provider_key
+          ?retry_after_s
+          ~error_kind
+          ~error_reason
+          ()
+      | None ->
+        Cascade_health_tracker.record_failure
+          Cascade_health_tracker.global
+          ~provider_key
+          ~error_kind
+          ~error_reason
+          ()
+  in
   let rec try_cascade
       ?(on_success = fun ~provider_key:_ -> ())
       ?resume_checkpoint ?per_provider_timeout_s remaining last_err =
@@ -698,8 +790,7 @@ let run_named
       (match result with
       | Ok result when accept result.response ->
         record_accepted_liveness_sample ();
-        record_candidate_health_success candidate ~latency_ms:attempt_latency_ms;
-        let _ = attempt_latency_ms in
+        record_candidate_success candidate ~latency_ms:attempt_latency_ms result;
         (* FSM: Call_ok → Accept *)
         let observation =
           Cascade_legacy_runner.cascade_observation_with_metrics
@@ -723,15 +814,15 @@ let run_named
            [record_rejected] behaves like a failure for cooldown /
            weight but keeps the [Rejected] tag so the dashboard can
            distinguish it from hard errors. *)
-        let () = () in
         (* FSM: Accept_rejected → decide *)
         let reason = "response rejected by accept" in
+        record_candidate_rejected candidate ~reason;
         let outcome = Cascade_fsm.Accept_rejected
           { response = result.response; reason } in
         (match Cascade_fsm.decide ~accept_on_exhaustion:false ~is_last outcome with
-         | Cascade_fsm.Accept_on_exhaustion { response; _ } ->
+           | Cascade_fsm.Accept_on_exhaustion { response; _ } ->
            record_accepted_liveness_sample ();
-           record_candidate_health_success candidate ~latency_ms:attempt_latency_ms;
+           record_candidate_success candidate ~latency_ms:attempt_latency_ms result;
            let observation =
              Cascade_legacy_runner.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
@@ -788,7 +879,7 @@ let run_named
            Cascade_metrics.on_cascade_invariant_violation ();
            Log.Misc.warn "cascade %s: unexpected Accept in Accept_rejected branch (runtime=%s)" cascade_name runtime_candidate_label;
            record_accepted_liveness_sample ();
-           record_candidate_health_success candidate ~latency_ms:attempt_latency_ms;
+           record_candidate_success candidate ~latency_ms:attempt_latency_ms result;
            let observation =
              Cascade_legacy_runner.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
@@ -824,6 +915,10 @@ let run_named
             ~provider:runtime_candidate_label sdk_err
         in
         let _ = err_str in
+        let cascade_outcome = sdk_error_to_cascade_outcome sdk_err in
+        Option.iter
+          (fun _ -> record_candidate_error candidate sdk_err)
+          cascade_outcome;
         (* FSM: Call_err → decide.
            Hard-quota fast-path: a hard quota is permanent for this turn —
            every remaining tier in this declared cascade will hit the same
@@ -834,7 +929,7 @@ let run_named
            above (line ~1760) keeps this provider deselected for future
            turns; the fast-path only short-circuits the within-turn
            retry. *)
-        (match sdk_error_to_cascade_outcome sdk_err with
+        (match cascade_outcome with
          | Some outcome ->
            let decision =
              if sdk_error_is_hard_quota sdk_err then
@@ -973,7 +1068,7 @@ let run_named
   let _ = sw, net in
   let adapter = Cascade_runtime_candidate.strategy_adapter in
   let signal_ctx : Cascade_strategy.signal_ctx = {
-    health = Cascade_health_tracker.create ();
+    health = Cascade_health_tracker.global;
     capacity = (fun _ -> None);
     now = Unix.gettimeofday ();
     rand_int = Random.int;

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -61,6 +61,12 @@ type masc_internal_error =
       min_required_sec : float;
       phase : string;
     }
+  | Max_tokens_ceiling_violation of {
+      cascade_name : cascade_name;
+      requested_max_tokens : int;
+      provider_ceiling : int;
+      reason : string;
+    }
   | Ambiguous_post_commit of {
       is_timeout : bool;
       tools : string list;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -596,10 +596,14 @@ let run_keeper_cycle
                     ~cascade_name
                     ~fallback:Keeper_config.keeper_unified_max_tokens
                 in
+                let max_output_ceiling =
+                  Cascade_runtime.max_output_tokens_ceiling_of_cascade_name
+                    cascade_name
+                in
                 (match
                    Cascade_inference.validate_max_tokens_within_ceiling
                      ~cascade_name
-                     ~provider_ceiling:(Some max_context)
+                     ~provider_ceiling:max_output_ceiling
                      raw_max_tokens
                  with
                  | Error err ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -591,24 +591,27 @@ let run_keeper_cycle
                     ~cascade_name
                     ~fallback:Keeper_config.keeper_unified_temperature
                 in
-                let max_tokens =
-                  let raw =
-                    Cascade_inference.resolve_max_tokens
-                      ~cascade_name
-                      ~fallback:Keeper_config.keeper_unified_max_tokens
-                  in
-                  (* Capability gate: clamp to provider ceiling (TLA+ S3) *)
-                  Cascade_inference.clamp_max_tokens_to_ceiling
-                    ~provider_ceiling:(Some max_context)
-                    raw
+                let raw_max_tokens =
+                  Cascade_inference.resolve_max_tokens
+                    ~cascade_name
+                    ~fallback:Keeper_config.keeper_unified_max_tokens
                 in
-                Ok
-                  { cascade_name
-                  ; max_context_resolution
-                  ; max_context
-                  ; temperature
-                  ; max_tokens
-                  })
+                (match
+                   Cascade_inference.validate_max_tokens_within_ceiling
+                     ~cascade_name
+                     ~provider_ceiling:(Some max_context)
+                     raw_max_tokens
+                 with
+                 | Error err ->
+                   Error (Cascade_error_classify.sdk_error_of_masc_internal_error err)
+                 | Ok max_tokens ->
+                   Ok
+                     { cascade_name
+                     ; max_context_resolution
+                     ; max_context
+                     ; temperature
+                     ; max_tokens
+                     }))
          in
          let effective_cascade_runtime_name = KCP.Runtime_name effective_cascade_name in
          (match build_cascade_execution ~cascade_name:effective_cascade_runtime_name with

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -22,10 +22,6 @@ let max_output_len = 4000
     sequential so set→consume ordering is guaranteed. *)
 let pending_truncation : (string, int * int option) Hashtbl.t = Hashtbl.create 8
 
-let handler_logged_mutex = Stdlib.Mutex.create ()
-let handler_logged_recent : (string, float) Hashtbl.t = Hashtbl.create 32
-let handler_logged_ttl_sec = 300.0
-
 type turn_context =
   { agent_name : string option
   ; lane : string option
@@ -80,48 +76,6 @@ let empty_turn_context =
 ;;
 
 let pending_turn_context : (string, turn_context) Hashtbl.t = Hashtbl.create 8
-
-let handler_logged_key ~keeper_name ~tool_name ~output_text ~success =
-  let canonical_tool_name =
-    match Keeper_tool_alias.route tool_name with
-    | Some r -> r.internal_name
-    | None -> tool_name
-  in
-  Printf.sprintf
-    "%s\000%s\000%b\000%d"
-    keeper_name
-    canonical_tool_name
-    success
-    (Hashtbl.hash output_text)
-;;
-
-let remember_handler_logged ~keeper_name ~tool_name ~output_text ~success () =
-  let key = handler_logged_key ~keeper_name ~tool_name ~output_text ~success in
-  let now = Time_compat.now () in
-  Stdlib.Mutex.protect handler_logged_mutex (fun () ->
-    let stale =
-      Hashtbl.fold
-        (fun key ts acc -> if now -. ts > handler_logged_ttl_sec then key :: acc else acc)
-        handler_logged_recent
-        []
-    in
-    List.iter (Hashtbl.remove handler_logged_recent) stale;
-    Hashtbl.replace handler_logged_recent key now)
-;;
-
-let consume_handler_logged ~keeper_name ~tool_name ~output_text ~success () =
-  let key = handler_logged_key ~keeper_name ~tool_name ~output_text ~success in
-  let now = Time_compat.now () in
-  Stdlib.Mutex.protect handler_logged_mutex (fun () ->
-    match Hashtbl.find_opt handler_logged_recent key with
-    | Some ts when now -. ts <= handler_logged_ttl_sec ->
-      Hashtbl.remove handler_logged_recent key;
-      true
-    | Some _ ->
-      Hashtbl.remove handler_logged_recent key;
-      false
-    | None -> false)
-;;
 
 let set_truncation_info ~keeper_name ~original_bytes ?truncated_to () =
   Hashtbl.replace pending_truncation keeper_name (original_bytes, truncated_to)
@@ -476,9 +430,7 @@ let reset_for_testing () =
   store_ref := None;
   configured_store_ref := None;
   Hashtbl.reset pending_truncation;
-  Hashtbl.reset pending_turn_context;
-  Stdlib.Mutex.protect handler_logged_mutex (fun () ->
-    Hashtbl.reset handler_logged_recent)
+  Hashtbl.reset pending_turn_context
 ;;
 
 let store_dir () =

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -156,28 +156,6 @@ val log_call :
     any truncation. [truncated_to] is present when Tool_output_validation
     truncated the output. Best-effort (failures logged). *)
 
-val remember_handler_logged :
-  keeper_name:string ->
-  tool_name:string ->
-  output_text:string ->
-  success:bool ->
-  unit ->
-  unit
-(** [remember_handler_logged ...] records that the keeper tool handler has
-    already persisted the full I/O for this just-completed tool execution.
-    Agent SDK post-tool hooks consume this marker to avoid duplicate rows
-    when a provider emits both handler-side and hook-side signals. *)
-
-val consume_handler_logged :
-  keeper_name:string ->
-  tool_name:string ->
-  output_text:string ->
-  success:bool ->
-  unit ->
-  bool
-(** [consume_handler_logged ...] returns [true] once when a recent
-    handler-side log marker matches the post-tool hook event. *)
-
 val read_recent :
   ?keeper_name:string ->
   ?n:int ->

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -55,6 +55,69 @@ type context = Tool_inline_dispatch_types.context = {
     Coord.config -> Mcp_server_eio_governance.mcp_session_record list -> unit;
 }
 
+let tool_index_entry_of_schema (schema : Masc_domain.tool_schema)
+  : Agent_sdk.Tool_index.entry =
+  let group =
+    Tool_catalog.tool_group schema.name
+    |> Option.map Tool_catalog.tool_group_to_string
+  in
+  Agent_sdk.Tool_index.
+    { name = schema.name; description = schema.description; group; aliases = [] }
+
+let discover_tool_matches ~(query : string) ~(limit : int)
+    (schemas : Masc_domain.tool_schema list) =
+  let query = String.lowercase_ascii (String.trim query) in
+  let limit = max 0 limit in
+  if String.equal query "" || limit = 0 then []
+  else
+    let schema_by_name = Hashtbl.create (List.length schemas) in
+    List.iter
+      (fun (schema : Masc_domain.tool_schema) ->
+         Hashtbl.replace schema_by_name schema.name schema)
+      schemas;
+    let index_config = { Agent_sdk.Tool_index.default_config with top_k = limit } in
+    let index =
+      schemas
+      |> List.map tool_index_entry_of_schema
+      |> Agent_sdk.Tool_index.build ~config:index_config
+    in
+    Agent_sdk.Tool_index.retrieve index query
+    |> List.filter_map (fun (name, score) ->
+      match Hashtbl.find_opt schema_by_name name with
+      | Some schema -> Some (schema, score)
+      | None -> None)
+
+let discover_tools_json ~(query : string) ~(limit : int)
+    (schemas : Masc_domain.tool_schema list) : Yojson.Safe.t =
+  let query = String.lowercase_ascii (String.trim query) in
+  let matches = discover_tool_matches ~query ~limit schemas in
+  let results =
+    List.map
+      (fun ((schema : Masc_domain.tool_schema), score) ->
+         `Assoc
+           [
+             ("name", `String schema.name);
+             ("description", `String schema.description);
+             ("score", `Float score);
+           ])
+      matches
+  in
+  `Assoc
+    [
+      ("query", `String query);
+      ("count", `Int (List.length results));
+      ("tools", `List results);
+      ("scoring", `String "bm25");
+      ( "hint",
+        `String
+          "These tools are callable via tools/call even if not in the default tools/list."
+      );
+    ]
+
+module For_testing = struct
+  let discover_tools_json = discover_tools_json
+end
+
 (** Dispatch a tool call.
     Returns [Some (Tool_result.t)] if the tool name is handled,
     [None] if the tool name is not recognized by this module. *)
@@ -266,35 +329,14 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.t option =
 
   (* ── Tool discovery ─────────────────────────────────────────── *)
   | "masc_discover_tools" ->
-      let query = String.lowercase_ascii (arg_get_string "query" "") in
+      let query = arg_get_string "query" "" in
       let limit = arg_get_int "limit" 20 in
-      if String.equal query "" then
+      if String.equal (String.trim query) "" then
         Some (Tool_result.error ~tool_name:name ~start_time:start "query is required")
       else
         let all_schemas = Config.visible_tool_schemas ~include_hidden:true ~include_deprecated:false () in
-        let words = String.split_on_char ' ' query |> List.filter (fun w -> String.length w > 0) in
-        let matches =
-          all_schemas
-          |> List.filter (fun (schema : Masc_domain.tool_schema) ->
-                 let name_l = String.lowercase_ascii schema.name in
-                 let desc_l = String.lowercase_ascii schema.description in
-                 let haystack = name_l ^ " " ^ desc_l in
-                 words |> List.exists (fun w ->
-                   String_util.contains_substring haystack w))
-          |> List.filteri (fun i _ -> i < limit)
-        in
-        let results = List.map (fun (schema : Masc_domain.tool_schema) ->
-          `Assoc [
-            ("name", `String schema.name);
-            ("description", `String schema.description);
-          ]
-        ) matches in
-        Some (Tool_result.ok ~tool_name:name ~start_time:start (Yojson.Safe.to_string (`Assoc [
-          ("query", `String query);
-          ("count", `Int (List.length results));
-          ("tools", `List results);
-          ("hint", `String "These tools are callable via tools/call even if not in the default tools/list.");
-        ])))
+        let payload = discover_tools_json ~query ~limit all_schemas in
+        Some (Tool_result.ok ~tool_name:name ~start_time:start (Yojson.Safe.to_string payload))
 
   (* ── Fallthrough to extra dispatch ──────────────────────────── *)
   | _ ->

--- a/lib/tool_inline_dispatch.mli
+++ b/lib/tool_inline_dispatch.mli
@@ -37,3 +37,11 @@ type context = Tool_inline_dispatch_types.context = {
 (** {1 Dispatch} *)
 
 val dispatch : context -> name:string -> Tool_result.t option
+
+module For_testing : sig
+  val discover_tools_json :
+       query:string
+    -> limit:int
+    -> Masc_domain.tool_schema list
+    -> Yojson.Safe.t
+end

--- a/test/dune
+++ b/test/dune
@@ -1321,6 +1321,7 @@
 (include stanzas/test_tool_call_replay_harness.inc)
 (include stanzas/test_tool_diversity.inc)
 (include stanzas/test_tool_help_registry_shard_coverage_10101.inc)
+(include stanzas/test_tool_inline_dispatch.inc)
 (include stanzas/test_tool_name.inc)
 (include stanzas/test_tool_task_completion_example.inc)
 (include stanzas/test_transport_bridge_seal.inc)

--- a/test/stanzas/test_tool_inline_dispatch.inc
+++ b/test/stanzas/test_tool_inline_dispatch.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_tool_inline_dispatch)
+ (modules test_tool_inline_dispatch)
+ (libraries masc_test_deps))

--- a/test/test_cascade_capability_gate.ml
+++ b/test/test_cascade_capability_gate.ml
@@ -1,39 +1,89 @@
-(** test_cascade_capability_gate — Provider ceiling clamping.
+(** test_cascade_capability_gate — Provider ceiling validation.
 
     Verifies TLA+ KeeperCoreTriad.CapabilityGate (S3 invariant):
-    requested_max_tokens never exceeds provider ceiling after clamping. *)
+    requested_max_tokens never exceeds provider ceiling before dispatch. *)
 
 open Alcotest
 
-let clamp = Masc_mcp.Cascade_inference.clamp_max_tokens_to_ceiling
+module CI = Masc_mcp.Cascade_inference
+module CE = Masc_mcp.Cascade_error_classify
 
-let test_clamp_above_ceiling () =
-  let result = clamp ~provider_ceiling:(Some 40960) 65536 in
-  check int "65536 clamped to 40960" 40960 result
+let cascade_name = Masc_mcp.Keeper_cascade_profile.Runtime_name "keeper_unified"
 
-let test_clamp_below_ceiling () =
-  let result = clamp ~provider_ceiling:(Some 131072) 32768 in
-  check int "32768 unchanged (below ceiling)" 32768 result
+let validate ?(provider_ceiling = Some 40960) max_tokens =
+  CI.validate_max_tokens_within_ceiling
+    ~cascade_name
+    ~provider_ceiling
+    max_tokens
 
-let test_clamp_equal_ceiling () =
-  let result = clamp ~provider_ceiling:(Some 32768) 32768 in
-  check int "equal to ceiling stays" 32768 result
+let check_violation expected_reason expected_requested expected_ceiling = function
+  | Error
+      (CE.Max_tokens_ceiling_violation
+         { cascade_name; requested_max_tokens; provider_ceiling; reason }) ->
+    check
+      string
+      "cascade_name"
+      "keeper_unified"
+      (CE.cascade_name_to_string cascade_name);
+    check int "requested_max_tokens" expected_requested requested_max_tokens;
+    check int "provider_ceiling" expected_ceiling provider_ceiling;
+    check string "reason" expected_reason reason
+  | Error _ -> fail "expected max_tokens ceiling violation"
+  | Ok value -> failf "expected validation error, got Ok %d" value
 
-let test_clamp_no_ceiling () =
-  let result = clamp ~provider_ceiling:None 65536 in
-  check int "None ceiling -> unchanged" 65536 result
+let check_ok label expected = function
+  | Ok actual -> check int label expected actual
+  | Error _ -> failf "expected Ok %d" expected
 
-let test_clamp_zero_ceiling () =
-  let result = clamp ~provider_ceiling:(Some 0) 1024 in
-  check int "zero ceiling floors to 1" 1 result
+let test_reject_above_ceiling () =
+  validate 65536
+  |> check_violation "requested_exceeds_provider_ceiling" 65536 40960
+
+let test_allow_below_ceiling () =
+  let result = validate ~provider_ceiling:(Some 131072) 32768 in
+  check_ok "32768 accepted (below ceiling)" 32768 result
+
+let test_allow_equal_ceiling () =
+  let result = validate ~provider_ceiling:(Some 32768) 32768 in
+  check_ok "equal to ceiling accepted" 32768 result
+
+let test_allow_no_ceiling () =
+  let result = validate ~provider_ceiling:None 65536 in
+  check_ok "None ceiling accepted" 65536 result
+
+let test_reject_zero_ceiling () =
+  validate ~provider_ceiling:(Some 0) 1024
+  |> check_violation "provider_ceiling_not_positive" 1024 0
+
+let test_reject_nonpositive_max_tokens () =
+  validate 0 |> check_violation "max_tokens_not_positive" 0 40960
+
+let test_sdk_error_round_trip_preserves_structured_violation () =
+  match validate 65536 with
+  | Ok _ -> fail "expected validation error"
+  | Error internal_error ->
+    let err = CE.sdk_error_of_masc_internal_error internal_error in
+    (match CE.classify_masc_internal_error err with
+     | Some
+         (CE.Max_tokens_ceiling_violation
+            { requested_max_tokens; provider_ceiling; reason; _ }) ->
+       check int "requested round trip" 65536 requested_max_tokens;
+       check int "ceiling round trip" 40960 provider_ceiling;
+       check string "reason round trip" "requested_exceeds_provider_ceiling" reason
+     | _ -> fail "expected structured violation round trip")
 
 let () =
   run "cascade_capability_gate" [
-    "clamp_max_tokens", [
-      test_case "above ceiling -> clamped"    `Quick test_clamp_above_ceiling;
-      test_case "below ceiling -> unchanged"  `Quick test_clamp_below_ceiling;
-      test_case "equal ceiling -> unchanged"  `Quick test_clamp_equal_ceiling;
-      test_case "no ceiling -> unchanged"     `Quick test_clamp_no_ceiling;
-      test_case "zero ceiling -> clamped to 0" `Quick test_clamp_zero_ceiling;
+    "max_tokens_ceiling_validation", [
+      test_case "above ceiling -> rejected" `Quick test_reject_above_ceiling;
+      test_case "below ceiling -> accepted" `Quick test_allow_below_ceiling;
+      test_case "equal ceiling -> accepted" `Quick test_allow_equal_ceiling;
+      test_case "no ceiling -> accepted" `Quick test_allow_no_ceiling;
+      test_case "zero ceiling -> rejected" `Quick test_reject_zero_ceiling;
+      test_case "nonpositive max_tokens -> rejected" `Quick test_reject_nonpositive_max_tokens;
+      test_case
+        "structured error round trip"
+        `Quick
+        test_sdk_error_round_trip_preserves_structured_violation;
     ];
   ]

--- a/test/test_cascade_capability_gate.ml
+++ b/test/test_cascade_capability_gate.ml
@@ -7,6 +7,7 @@ open Alcotest
 
 module CI = Masc_mcp.Cascade_inference
 module CE = Masc_mcp.Cascade_error_classify
+module CR = Masc_mcp.Cascade_runtime
 
 let cascade_name = Masc_mcp.Keeper_cascade_profile.Runtime_name "keeper_unified"
 
@@ -72,6 +73,67 @@ let test_sdk_error_round_trip_preserves_structured_violation () =
        check string "reason round trip" "requested_exceeds_provider_ceiling" reason
      | _ -> fail "expected structured violation round trip")
 
+let write_file path body =
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc body)
+
+let with_temp_cascade_toml body f =
+  let dir = Filename.temp_file "cascade-capability-gate-" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let config_path = Filename.concat dir "cascade.toml" in
+  write_file config_path body;
+  let saved_config_dir = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  let restore_env () =
+    match saved_config_dir with
+    | Some value -> Unix.putenv "MASC_CONFIG_DIR" value
+    | None -> Unix.putenv "MASC_CONFIG_DIR" ""
+  in
+  Unix.putenv "MASC_CONFIG_DIR" dir;
+  Masc_mcp.Config_dir_resolver.reset ();
+  Masc_mcp.Cascade_catalog_runtime.reset_cache_for_tests ();
+  Fun.protect
+    ~finally:(fun () ->
+      restore_env ();
+      Masc_mcp.Config_dir_resolver.reset ();
+      Masc_mcp.Cascade_catalog_runtime.reset_cache_for_tests ();
+      Sys.remove config_path;
+      Unix.rmdir dir)
+    f
+
+let test_cascade_output_cap_not_context_window () =
+  with_temp_cascade_toml
+    {|
+[providers.remote]
+protocol = "openai-http"
+endpoint = "https://example.test/v1"
+
+[models.long]
+api-name = "remote-long"
+max-context = 200000
+tools-support = true
+
+[models.long.capabilities]
+max-output-tokens = 8192
+
+[remote.long]
+max-concurrent = 1
+
+[tier.primary]
+members = ["remote.long"]
+
+[routes.keeper_unified]
+target = "tier.primary"
+|}
+    (fun () ->
+      let ceiling = CR.max_output_tokens_ceiling_of_cascade_name cascade_name in
+      check (option int) "output ceiling" (Some 8192) ceiling;
+      CI.validate_max_tokens_within_ceiling ~cascade_name
+        ~provider_ceiling:ceiling 65536
+      |> check_violation "requested_exceeds_provider_ceiling" 65536 8192)
+
 let () =
   run "cascade_capability_gate" [
     "max_tokens_ceiling_validation", [
@@ -85,5 +147,9 @@ let () =
         "structured error round trip"
         `Quick
         test_sdk_error_round_trip_preserves_structured_violation;
+      test_case
+        "cascade output cap, not context window, gates max_tokens"
+        `Quick
+        test_cascade_output_cap_not_context_window;
     ];
   ]

--- a/test/test_cascade_health_tracker.ml
+++ b/test/test_cascade_health_tracker.ml
@@ -757,6 +757,46 @@ let test_recent_outcome_count_success_separate () =
          ~outcome:H.Outcome_soft_rate_limited
          ~window_s:60.0)
 
+let test_restore_providers_reinstates_active_cooldown () =
+  let t = H.create () in
+  let until = Unix.gettimeofday () +. 60.0 in
+  let restored =
+    H.restore_providers
+      t
+      [ { restore_provider_key = "restored-provider"
+        ; restore_consecutive_failures = 4
+        ; restore_cooldown_until = Some until
+        ; restore_last_failure_at = Some (until -. 10.0)
+        ; restore_top_fingerprints = [ "timeout|abc12345", 2 ]
+        }
+      ]
+  in
+  check int "one provider restored" 1 restored;
+  check bool "restored cooldown blocks provider" true
+    (H.is_in_cooldown t ~provider_key:"restored-provider");
+  match H.provider_info t ~provider_key:"restored-provider" with
+  | None -> fail "expected restored provider_info"
+  | Some info ->
+    check int "consecutive failures restored" 4 info.consecutive_failures;
+    check (list (pair string int)) "fingerprints restored"
+      [ "timeout|abc12345", 2 ]
+      info.top_fingerprints
+
+let test_restore_providers_ignores_blank_provider_key () =
+  let t = H.create () in
+  let restored =
+    H.restore_providers
+      t
+      [ { restore_provider_key = " "
+        ; restore_consecutive_failures = 3
+        ; restore_cooldown_until = Some (Unix.gettimeofday () +. 60.0)
+        ; restore_last_failure_at = None
+        ; restore_top_fingerprints = []
+        }
+      ]
+  in
+  check int "blank key ignored" 0 restored
+
 let () =
   run "cascade_health_tracker" [
     "record", [
@@ -892,5 +932,11 @@ let () =
         test_recent_outcome_count_filters_by_outcome;
       test_case "success counts independently" `Quick
         test_recent_outcome_count_success_separate;
+    ];
+    "restore", [
+      test_case "reinstates active cooldown" `Quick
+        test_restore_providers_reinstates_active_cooldown;
+      test_case "ignores blank provider key" `Quick
+        test_restore_providers_ignores_blank_provider_key;
     ];
   ]

--- a/test/test_cascade_trust_persist.ml
+++ b/test/test_cascade_trust_persist.ml
@@ -187,6 +187,35 @@ let test_snapshot_does_not_throw_on_empty_tracker () =
     | [] -> fail "expected at least one record"
     | _ -> ())
 
+let test_hydrate_latest_restores_cooldown_from_snapshot () =
+  with_temp_base (fun dir ->
+    let key = "test_hydrate:" ^ string_of_int (Random.bits ()) in
+    H.record_failure H.global ~provider_key:key
+      ~error_kind:(kind "timeout") ~error_reason:"deadline" ();
+    H.record_failure H.global ~provider_key:key
+      ~error_kind:(kind "timeout") ~error_reason:"deadline" ();
+    H.record_failure H.global ~provider_key:key
+      ~error_kind:(kind "timeout") ~error_reason:"deadline" ();
+    check bool "provider entered cooldown before snapshot" true
+      (H.is_in_cooldown H.global ~provider_key:key);
+    P.snapshot_now ~base_path:dir;
+    H.record_success H.global ~provider_key:key ();
+    check bool "success clears cooldown before hydrate" false
+      (H.is_in_cooldown H.global ~provider_key:key);
+    let restored = P.hydrate_latest ~base_path:dir in
+    check bool "hydrate applied at least one row" true (restored > 0);
+    check bool "hydrate reinstates cooldown" true
+      (H.is_in_cooldown H.global ~provider_key:key);
+    match H.provider_info H.global ~provider_key:key with
+    | None -> fail "missing hydrated provider"
+    | Some info ->
+      check int "restored failure count" 3 info.consecutive_failures;
+      check bool "fingerprint survives hydrate" true
+        (List.exists
+           (fun (fp, count) ->
+             String.starts_with ~prefix:"timeout" fp && count = 3)
+           info.top_fingerprints))
+
 let () =
   Random.self_init ();
   run "cascade_trust_persist"
@@ -203,5 +232,7 @@ let () =
             test_two_snapshots_produce_two_records
         ; test_case "no throw on empty tracker" `Quick
             test_snapshot_does_not_throw_on_empty_tracker
+        ; test_case "hydrate restores cooldown from snapshot" `Quick
+            test_hydrate_latest_restores_cooldown_from_snapshot
         ] )
     ]

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -1379,6 +1379,24 @@ let oversized_user_message ?(prompt = "긴 텍스트도 저장되면 안 돼") (
       metadata = [];
   }
 
+let checkpoint_counted_content_chars messages =
+  List.fold_left
+    (fun total (msg : Agent_sdk.Types.message) ->
+      List.fold_left
+        (fun total block ->
+          match block with
+          | Agent_sdk.Types.Text text -> total + String.length text
+          | Agent_sdk.Types.ToolResult { content; _ } ->
+              total + String.length content
+          | Agent_sdk.Types.Thinking { content; _ } ->
+              total + String.length content
+          | Agent_sdk.Types.RedactedThinking text -> total + String.length text
+          | _ -> total)
+        total
+        msg.content)
+    0
+    messages
+
 let summarized_contaminated_text =
   "[Summary of 2 earlier messages]\n\
    [User] ## Current World State\n\n\
@@ -1559,6 +1577,54 @@ let test_save_oas_checkpoint_caps_oversized_text () =
             (contains_substring text "[capped]");
           check bool "text was compacted" true
             (String.length text < String.length oversized_checkpoint_text))
+
+let test_save_oas_checkpoint_caps_total_content () =
+  let base_dir = temp_dir "keeper_lifecycle_save_total_cap" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let session =
+        KEC.create_session ~session_id:"trace-save-total-cap" ~base_dir
+      in
+      let large_text =
+        String.make (KCC.default_max_checkpoint_content_chars_total / 8) 'q'
+      in
+      let messages =
+        List.init 40 (fun i ->
+            Agent_sdk.Types.user_msg
+              (Printf.sprintf "bulk-checkpoint-%02d %s" i large_text))
+      in
+      let ctx =
+        KEC.create ~system_prompt:"keeper lifecycle" ~max_tokens:64_000
+        |> fun ctx -> KEC.append_many ctx messages
+        |> KEC.sync_oas_context
+      in
+      match
+        KEC.save_oas_checkpoint
+          ~max_checkpoint_messages:120
+          ~session
+          ~agent_name:"keeper-lifecycle"
+          ~model:"glm:glm-5.1"
+          ~ctx
+          ~generation:1
+      with
+      | Error e ->
+          Alcotest.fail
+            (Printf.sprintf "save_oas_checkpoint failed: %s" e)
+      | Ok checkpoint ->
+          check bool "global content cap enforced" true
+            (checkpoint_counted_content_chars checkpoint.messages
+             <= KCC.default_max_checkpoint_content_chars_total);
+          check bool "older messages dropped at total cap" true
+            (List.length checkpoint.messages < List.length messages);
+          let newest =
+            checkpoint.messages
+            |> List.rev
+            |> List.hd
+            |> Agent_sdk.Types.text_of_message
+          in
+          check bool "newest message retained" true
+            (contains_substring newest "bulk-checkpoint-39"))
 
 let test_sanitize_checkpoint_message_caps_oversized_tool_result () =
   let oversized =
@@ -2706,6 +2772,8 @@ let () =
             test_save_oas_checkpoint_strips_ephemeral_world_state;
           test_case "save caps oversized text" `Quick
             test_save_oas_checkpoint_caps_oversized_text;
+          test_case "save caps total checkpoint content" `Quick
+            test_save_oas_checkpoint_caps_total_content;
           test_case "save caps oversized tool result" `Quick
             test_sanitize_checkpoint_message_caps_oversized_tool_result;
           test_case "save caps aggregate tool result budget" `Quick

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -4,6 +4,7 @@ module R = Masc_mcp.Keeper_registry
 module Keeper_types = Masc_mcp.Keeper_types
 module KSM = Masc_mcp.Keeper_state_machine
 module Audit = Masc_mcp.Keeper_transition_audit
+module Hooks = Masc_mcp.Keeper_lifecycle_hooks
 module Meas = Masc_mcp.Keeper_measurement
 module Pages = Masc_mcp.Server_routes_http_pages
 module Json = Yojson.Safe.Util
@@ -510,6 +511,30 @@ let test_dispatch_event_emits_lifecycle_transition_metric_only_on_phase_change (
   in
   check (float 0.001) "phase-change transition metric incremented"
     (changed_before +. 1.0) changed_after
+
+let test_dispatch_event_runs_phase_transition_hook () =
+  R.clear ();
+  Hooks.reset_for_testing ();
+  let keeper_name = "k4-lifecycle-hook" in
+  let seen = ref [] in
+  Fun.protect
+    ~finally:Hooks.reset_for_testing
+    (fun () ->
+      Hooks.register (fun ~keeper_id event ->
+          match event with
+          | Hooks.Phase_transition { from_phase; to_phase } ->
+            seen := (keeper_id, from_phase, to_phase) :: !seen
+          | Hooks.Tombstone_reaped -> ());
+      ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+      ignore (R.dispatch_event ~base_path:bp keeper_name KSM.Fiber_started);
+      check int "same-phase event does not run hook" 0 (List.length !seen);
+      ignore (R.dispatch_event ~base_path:bp keeper_name KSM.Operator_pause);
+      match !seen with
+      | [ (seen_keeper, from_phase, to_phase) ] ->
+        check string "keeper" keeper_name seen_keeper;
+        check string "from" "running" (KSM.phase_to_string from_phase);
+        check string "to" "paused" (KSM.phase_to_string to_phase)
+      | _ -> fail "expected exactly one phase transition hook event")
 
 let test_dispatch_event_observes_phase_sse_broadcast_failure () =
   R.clear ();
@@ -1680,6 +1705,8 @@ let () =
             test_dispatch_event_emits_phase_sse;
           eio_test "dispatch event emits lifecycle metric only on phase change"
             test_dispatch_event_emits_lifecycle_transition_metric_only_on_phase_change;
+          eio_test "dispatch event runs phase transition hook"
+            test_dispatch_event_runs_phase_transition_hook;
           eio_test "dispatch event observes phase SSE broadcast failure"
             test_dispatch_event_observes_phase_sse_broadcast_failure;
           eio_test "extended states" test_extended_states;

--- a/test/test_keeper_terminal_reason.ml
+++ b/test/test_keeper_terminal_reason.ml
@@ -401,6 +401,27 @@ let test_structured_oas_timeout_budget () =
     (terminal_next_action terminal)
 ;;
 
+let test_structured_max_tokens_ceiling_violation () =
+  let err =
+    Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Masc_mcp.Keeper_turn_driver.Max_tokens_ceiling_violation
+         { cascade_name =
+             Masc_mcp.Keeper_turn_driver.cascade_name_of_string "keeper_unified"
+         ; requested_max_tokens = 65_536
+         ; provider_ceiling = 40_960
+         ; reason = "requested_exceeds_provider_ceiling"
+         })
+  in
+  let terminal = KT.of_failure ~raw_error:(Agent_sdk.Error.to_string err) err in
+  check string "code" "max_tokens_ceiling_violation" (terminal_code terminal);
+  check string "severity" "bad" (KT.severity_to_string (terminal_severity terminal));
+  check
+    (option string)
+    "next action"
+    (Some "inspect_latest_error")
+    (terminal_next_action terminal)
+;;
+
 let test_structured_turn_wall_clock_timeout () =
   let err =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
@@ -517,6 +538,10 @@ let () =
             `Quick
             test_structured_required_tool_no_tool_call
         ; test_case "oas timeout budget" `Quick test_structured_oas_timeout_budget
+        ; test_case
+            "max_tokens ceiling violation"
+            `Quick
+            test_structured_max_tokens_ceiling_violation
         ; test_case
             "turn wall-clock timeout"
             `Quick

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -277,7 +277,7 @@ let test_tool_side_effect_failures_are_observed () =
             ()))
 ;;
 
-let test_handler_persists_tool_call_io_without_post_hook () =
+let test_handler_does_not_write_tool_call_io_without_post_hook () =
   let meta = make_test_meta ~name:"test-keeper-direct-tool-io" () in
   let ctx_snapshot = make_test_ctx () in
   let dir = Filename.temp_file "test_keeper_tools_direct_io_" "" in
@@ -306,22 +306,11 @@ let test_handler_persists_tool_call_io_without_post_hook () =
         | Error { Agent_sdk.Types.message; _ } ->
           fail ("keeper_time_now should succeed: " ^ message));
        let entries = Keeper_tool_call_log.read_recent ~keeper_name:meta.name ~n:10 () in
-       check int "handler wrote one tool_call row" 1 (List.length entries);
-       let row = List.hd entries in
-       check
-         string
-         "tool"
-         "keeper_time_now"
-         Yojson.Safe.Util.(row |> member "tool" |> to_string);
-       check
-         string
-         "trace id"
-         "trace-direct-tool-io"
-         Yojson.Safe.Util.(row |> member "trace_id" |> to_string))
+       check int "handler does not write tool_call rows directly" 0 (List.length entries))
 ;;
 
-let test_post_hook_does_not_duplicate_handler_logged_io () =
-  let meta = make_test_meta ~name:"test-keeper-direct-tool-dedupe" () in
+let test_post_hook_is_single_tool_call_log_writer () =
+  let meta = make_test_meta ~name:"test-keeper-direct-tool-hook-writer" () in
   let meta_ref = ref meta in
   let ctx_snapshot = make_test_ctx () in
   let dir = Filename.temp_file "test_keeper_tools_direct_dedupe_" "" in
@@ -338,6 +327,11 @@ let test_post_hook_does_not_duplicate_handler_logged_io () =
        let config = Coord.default_config dir in
        Keeper_tool_call_log.reset_for_testing ();
        Keeper_tool_call_log.init ~base_path:dir ();
+       Keeper_tool_call_log.set_turn_context
+         ~keeper_name:meta.name
+         ~trace_id:"trace-hook-tool-io"
+         ~turn:1
+         ();
        let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
        let tool = find_tool "keeper_time_now" tools in
        let output_text =
@@ -365,9 +359,20 @@ let test_post_hook_does_not_duplicate_handler_logged_io () =
                ; result_bytes = String.length output_text
                ; duration_ms = 2.0
                ; schedule = dummy_schedule
-               }));
+           }));
        let entries = Keeper_tool_call_log.read_recent ~keeper_name:meta.name ~n:10 () in
-       check int "post hook did not duplicate handler row" 1 (List.length entries))
+       check int "post hook wrote one tool_call row" 1 (List.length entries);
+       let row = List.hd entries in
+       check
+         string
+         "tool"
+         "keeper_time_now"
+         Yojson.Safe.Util.(row |> member "tool" |> to_string);
+       check
+         string
+         "trace id"
+         "trace-hook-tool-io"
+         Yojson.Safe.Util.(row |> member "trace_id" |> to_string))
 ;;
 
 let test_oas_wrapper_records_keeper_internal_tool_call () =
@@ -1225,13 +1230,13 @@ let () =
             `Quick
             test_tool_side_effect_failures_are_observed
         ; test_case
-            "handler persists tool-call I/O without post hook"
+            "handler does not write tool-call I/O without post hook"
             `Quick
-            test_handler_persists_tool_call_io_without_post_hook
+            test_handler_does_not_write_tool_call_io_without_post_hook
         ; test_case
-            "post hook skips handler-logged tool-call I/O"
+            "post hook is the single tool-call I/O writer"
             `Quick
-            test_post_hook_does_not_duplicate_handler_logged_io
+            test_post_hook_is_single_tool_call_log_writer
         ; test_case
             "wrapper records keeper-internal calls"
             `Quick

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -1,5 +1,7 @@
 open Alcotest
 module Adapter = Masc_mcp.Provider_adapter
+module Candidate = Masc_mcp.Cascade_runtime_candidate
+module Health = Masc_mcp.Cascade_health_tracker
 
 let with_env name value f =
   let previous = Sys.getenv_opt name in
@@ -610,6 +612,68 @@ let test_provider_of_model_label_uses_typed_boundaries () =
     (Adapter.provider_of_model_label "private-provider:model-x")
 ;;
 
+let provider_cfg label =
+  match Masc_mcp.Cascade_config.parse_model_string label with
+  | Some cfg -> cfg
+  | None -> fail ("expected model label to parse: " ^ label)
+;;
+
+let test_runtime_candidate_uses_internal_health_keys () =
+  let cfg =
+    provider_cfg "custom:candidate-health@http://127.0.0.1:15123"
+  in
+  let candidate = Candidate.of_provider_config cfg in
+  check
+    string
+    "provider health key is internal"
+    (Adapter.provider_health_key_of_config cfg)
+    (Candidate.health_key candidate);
+  check
+    string
+    "model health key is internal"
+    (Adapter.provider_model_health_key_of_config cfg)
+    (Candidate.model_health_key candidate);
+  check
+    (list string)
+    "runtime labels resolve to internal provider health keys"
+    [ Adapter.provider_health_key_of_config cfg ]
+    (Candidate.runtime_health_keys_of_labels
+       [ "custom:candidate-health@http://127.0.0.1:15123" ])
+;;
+
+let test_runtime_candidate_cooldown_reads_global_health () =
+  let cfg =
+    provider_cfg "custom:cooldown-health@http://127.0.0.1:15124"
+  in
+  let candidate = Candidate.of_provider_config cfg in
+  let model_key = Adapter.provider_model_health_key_of_config cfg in
+  for _ = 1 to Health.cooldown_threshold do
+    Health.record_failure Health.global ~provider_key:model_key ()
+  done;
+  match Candidate.first_health_cooldown candidate with
+  | Some (blocked_key, _msg) ->
+    check string "model-level cooldown is observed" model_key blocked_key
+  | None -> fail "expected candidate to observe global model-level cooldown"
+;;
+
+let test_runtime_candidate_recovery_evidence_reads_global_health () =
+  let cfg =
+    provider_cfg "custom:recovery-health@http://127.0.0.1:15125"
+  in
+  let candidate = Candidate.of_provider_config cfg in
+  let provider_key = Adapter.provider_health_key_of_config cfg in
+  Health.record_success
+    Health.global
+    ~provider_key
+    ~latency_ms:42.0
+    ();
+  check
+    bool
+    "global success is recovery evidence"
+    true
+    (Candidate.has_recovery_evidence candidate)
+;;
+
 let test_unmetered_provider_uses_declared_telemetry_policy () =
   check
     bool
@@ -1015,6 +1079,18 @@ let () =
             "provider model label uses typed boundaries"
             `Quick
             test_provider_of_model_label_uses_typed_boundaries
+        ; test_case
+            "runtime candidate uses internal health keys"
+            `Quick
+            test_runtime_candidate_uses_internal_health_keys
+        ; test_case
+            "runtime candidate observes global cooldown"
+            `Quick
+            test_runtime_candidate_cooldown_reads_global_health
+        ; test_case
+            "runtime candidate observes recovery evidence"
+            `Quick
+            test_runtime_candidate_recovery_evidence_reads_global_health
         ; test_case
             "unmetered provider uses telemetry policy"
             `Quick

--- a/test/test_snapshot_size_cap.ml
+++ b/test/test_snapshot_size_cap.ml
@@ -80,6 +80,35 @@ let test_idempotence () =
   Alcotest.(check (list string)) "decisions idempotent"
     c1.decisions c2.decisions
 
+let test_continuity_summary_text_capped () =
+  let capped =
+    KMP.cap_continuity_summary_text ~max_chars:80 (long_string 500 'c')
+  in
+  Alcotest.(check bool) "summary length near cap"
+    true (String.length capped <= 80 + 3);
+  Alcotest.(check bool) "ellipsis appended"
+    true (Astring.String.is_suffix ~affix:"…" capped)
+
+let test_continuity_fallback_caps_legacy_summary () =
+  let rendered =
+    KMP.continuity_fallback_summary_text
+      ~continuity_summary:(long_string 10_000 'f')
+      ~last_continuity_update_ts:0.0
+  in
+  Alcotest.(check bool) "freshness retained"
+    true (Astring.String.is_infix ~affix:"Freshness:" rendered);
+  let payload =
+    rendered
+    |> String.split_on_char '\n'
+    |> List.rev
+    |> List.find_opt (fun line -> String.trim line <> "")
+  in
+  let payload = Option.value payload ~default:"" in
+  Alcotest.(check bool) "legacy payload capped"
+    true (String.length payload <= KMP.default_continuity_summary_max_chars + 3);
+  Alcotest.(check bool) "legacy payload has ellipsis"
+    true (Astring.String.is_suffix ~affix:"…" payload)
+
 let () =
   Alcotest.run "snapshot_size_cap"
     [ ( "cap_snapshot",
@@ -95,5 +124,9 @@ let () =
             test_none_fields_stay_none;
           Alcotest.test_case "cap is idempotent" `Quick
             test_idempotence;
+          Alcotest.test_case "continuity summary text capped" `Quick
+            test_continuity_summary_text_capped;
+          Alcotest.test_case "fallback caps legacy summary" `Quick
+            test_continuity_fallback_caps_legacy_summary;
         ] );
     ]

--- a/test/test_tool_inline_dispatch.ml
+++ b/test/test_tool_inline_dispatch.ml
@@ -1,0 +1,80 @@
+open Alcotest
+
+let schema name description : Masc_domain.tool_schema =
+  { name; description; input_schema = `Assoc [] }
+
+let tool_names json =
+  Yojson.Safe.Util.(
+    json
+    |> member "tools"
+    |> to_list
+    |> List.map (fun item -> item |> member "name" |> to_string))
+
+let test_discover_tools_uses_bm25_ranking_not_substring_or () =
+  let schemas =
+    [
+      schema "masc_room_read" "Read room messages and channel activity";
+      schema "masc_file_read" "Read file contents from the workspace";
+      schema "masc_worktree_create" "Create an isolated git branch workspace";
+    ]
+  in
+  let json =
+    Masc_mcp.Tool_inline_dispatch.For_testing.discover_tools_json
+      ~query:"read file contents"
+      ~limit:2
+      schemas
+  in
+  match tool_names json with
+  | first :: _ -> check string "best match" "masc_file_read" first
+  | [] -> fail "expected at least one tool"
+
+let test_discover_tools_returns_empty_for_unmatched_query () =
+  let schemas =
+    [
+      schema "masc_room_read" "Read room messages and channel activity";
+      schema "masc_file_read" "Read file contents from the workspace";
+    ]
+  in
+  let json =
+    Masc_mcp.Tool_inline_dispatch.For_testing.discover_tools_json
+      ~query:"zzzzzzzz"
+      ~limit:5
+      schemas
+  in
+  check int "unmatched count" 0 (List.length (tool_names json))
+
+let test_discover_tools_marks_bm25_scoring () =
+  let schemas = [ schema "masc_file_read" "Read file contents" ] in
+  let json =
+    Masc_mcp.Tool_inline_dispatch.For_testing.discover_tools_json
+      ~query:"file"
+      ~limit:5
+      schemas
+  in
+  check
+    string
+    "scoring"
+    "bm25"
+    Yojson.Safe.Util.(json |> member "scoring" |> to_string)
+
+let () =
+  run
+    "tool_inline_dispatch"
+    [
+      ( "discover_tools",
+        [
+          test_case
+            "BM25 ranks specific tool above substring hit"
+            `Quick
+            test_discover_tools_uses_bm25_ranking_not_substring_or;
+          test_case
+            "unmatched query returns empty"
+            `Quick
+            test_discover_tools_returns_empty_for_unmatched_query;
+          test_case
+            "response marks bm25 scoring"
+            `Quick
+            test_discover_tools_marks_bm25_scoring;
+        ] );
+    ]
+;;


### PR DESCRIPTION
## Summary

This patch closes nine durability, lifecycle, dispatch, and pre-dispatch correctness gaps from the MASC/OAS deep-dive for long-running keeper fleets.

- hydrates cascade provider health/cooldown state from the latest durable JSONL snapshot on startup
- restores real internal cascade candidate health keys, feeds keeper routing from the hydrated global health tracker, and records accepted/rejected/error provider outcomes back into that tracker while preserving external Runtime Lens redaction
- removes the `handler_logged_recent` TTL dedup workaround and makes the OAS post-tool hook the single durable tool-call I/O writer
- adds a global checkpoint content cap so 120 retained messages cannot still serialize into a multi-MB checkpoint
- replaces silent `max_tokens` ceiling clipping with a structured pre-dispatch `max_tokens_ceiling_violation`
- validates keeper `max_tokens` against declarative model `max-output-tokens` rather than context window size, and pins keeper-turn tiers to 32k output aliases so fallback candidates remain runnable under that gate
- replaces substring-OR inline tool discovery with BM25 ranking from `Agent_sdk.Tool_index`
- emits `Keeper_lifecycle_hooks.Phase_transition` from real registry phase changes instead of leaving the hook variant dead
- applies one shared `continuity_summary` text cap to both production and fallback consumption paths

## Why

The deep-dive called out provider-health reset, dashboard-only routing signals, TTL log-dedup masking, checkpoint size growth, silent `max_tokens` clipping, weak substring tool discovery, a dead lifecycle transition hook, and reactive continuity-summary caps as unhealthy for 18+ keeper runs.

Together these affect whether keepers retry LLM providers sanely, whether cooldowns and latency/error feedback survive restarts and influence routing, whether tool-call history has a single truthful writer, whether restart/resume remains bounded under long work sessions, whether invalid cascade budgets fail visibly before an LLM call, whether inline tool lookup returns the most relevant tool instead of the first broad substring match, whether lifecycle cleanup hooks can react to phase transitions, and whether legacy continuity text can bypass the snapshot cap.

## Validation

- `scripts/opam-pin-external-deps.sh --install`
- `scripts/dune-local.sh build test/test_provider_adapter.exe test/test_oas_worker.exe test/test_cascade_strategy.exe test/test_cascade_health_tracker.exe`
- `./_build/default/test/test_provider_adapter.exe`
- `./_build/default/test/test_oas_worker.exe` (155 tests run; socket-backed run_named cases skipped by the local sandbox, now covered by deterministic candidate-health unit tests)
- `./_build/default/test/test_cascade_strategy.exe`
- `./_build/default/test/test_cascade_health_tracker.exe`
- `scripts/dune-local.sh build test/test_keeper_lifecycle.exe test/test_keeper_tools_oas.exe test/test_cascade_health_tracker.exe test/test_cascade_trust_persist.exe`
- `./_build/default/test/test_keeper_lifecycle.exe`
- `./_build/default/test/test_keeper_tools_oas.exe`
- `./_build/default/test/test_cascade_trust_persist.exe`
- `scripts/dune-local.sh build test/test_cascade_capability_gate.exe test/test_keeper_terminal_reason.exe test/test_keeper_lifecycle.exe test/test_keeper_tools_oas.exe`
- `./_build/default/test/test_cascade_capability_gate.exe`
- `./_build/default/test/test_keeper_terminal_reason.exe`
- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe`
- `scripts/dune-local.sh build test/test_tool_inline_dispatch.exe`
- `./_build/default/test/test_tool_inline_dispatch.exe`
- `scripts/dune-local.sh build test/test_keeper_registry.exe`
- `./_build/default/test/test_keeper_registry.exe`
- `scripts/dune-local.sh build test/test_snapshot_size_cap.exe test/test_keeper_lifecycle.exe`
- `./_build/default/test/test_snapshot_size_cap.exe`
- `ocamlformat --check lib/cascade/cascade_runtime_candidate.ml lib/keeper/keeper_turn_driver.ml test/test_provider_adapter.ml`
- `opam exec -- ocamlformat --check lib/tool_inline_dispatch.ml lib/tool_inline_dispatch.mli test/test_tool_inline_dispatch.ml`
- `opam exec -- ocamlformat --check lib/keeper/keeper_lifecycle_hooks.mli lib/keeper/keeper_registry.ml test/test_keeper_registry.ml`
- `opam exec -- ocamlformat --check lib/keeper/keeper_memory_policy.ml lib/keeper/keeper_memory_policy.mli lib/keeper/keeper_post_turn.ml test/test_snapshot_size_cap.ml`
- `opam exec -- ocamlformat --check lib/cascade_inference.ml lib/cascade_inference.mli lib/cascade/cascade_error_classify.ml lib/cascade/cascade_error_classify.mli lib/cascade/cascade_metrics.ml lib/cascade/cascade_metrics.mli lib/cascade/cascade_runtime.ml lib/keeper/keeper_agent_run.ml lib/keeper/keeper_unified_turn.ml lib/keeper/keeper_turn_driver.mli lib/keeper/keeper_error_classify.ml lib/keeper/keeper_heartbeat_loop.ml lib/keeper/keeper_status_bridge.ml lib/keeper/keeper_turn_cascade_budget.ml lib/cascade/cascade_attempt_fsm.ml lib/anti_rationalization.ml test/test_cascade_capability_gate.ml test/test_keeper_terminal_reason.ml`
- `ocamlformat --check lib/cascade/cascade_runtime.ml lib/cascade/cascade_runtime.mli lib/keeper/keeper_agent_run.ml lib/keeper/keeper_unified_turn.ml test/test_cascade_capability_gate.ml`
- `git diff --check`
