### PR TITLE
feat(dashboard): link log code context to IDE

### DIFF
--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -1,0 +1,72 @@
+import { h } from 'preact'
+import { cleanup, render, waitFor } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+async function loadLogs(fetchLogs: ReturnType<typeof vi.fn>) {
+  vi.resetModules()
+  vi.doMock('../api/dashboard.js', () => ({
+    fetchLogs,
+  }))
+  return import('./logs')
+}
+
+describe('LogViewer Code links', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    vi.resetModules()
+    vi.doUnmock('../api/dashboard.js')
+    window.location.hash = ''
+  })
+
+  it('links safe structured log file details back to the Code IDE route', async () => {
+    const fetchLogs = vi.fn().mockResolvedValue({
+      total: 1,
+      entries: [{
+        seq: 1,
+        ts: '2026-05-14T00:00:00Z',
+        level: 'INFO',
+        raw_level: 'INFO',
+        normalized_level: 'INFO',
+        source: 'structured',
+        legacy_classified: false,
+        module: 'keeper_tool',
+        message: 'read file',
+        details: { file_path: 'lib/runtime.ml', line: 12 },
+      }],
+    })
+    const { LogViewer } = await loadLogs(fetchLogs)
+    const { container } = render(h(LogViewer, {}))
+
+    await waitFor(() => expect(container.querySelector('[data-testid="logs-code-link"]')).not.toBeNull())
+    const codeLink = container.querySelector('[data-testid="logs-code-link"]') as HTMLButtonElement
+    expect(codeLink.textContent).toBe('Code')
+    expect(codeLink.getAttribute('title')).toBe('Code lib/runtime.ml:12')
+
+    codeLink.click()
+    expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=12&surface=Log&label=keeper_tool&source_id=log%3A1')
+  })
+
+  it('does not render Code links for unsafe absolute log file paths', async () => {
+    const fetchLogs = vi.fn().mockResolvedValue({
+      total: 1,
+      entries: [{
+        seq: 2,
+        ts: '2026-05-14T00:00:00Z',
+        level: 'INFO',
+        raw_level: 'INFO',
+        normalized_level: 'INFO',
+        source: 'structured',
+        legacy_classified: false,
+        module: 'keeper_tool',
+        message: 'read file',
+        details: { file_path: '/tmp/runtime.ml', line: 12 },
+      }],
+    })
+    const { LogViewer } = await loadLogs(fetchLogs)
+    const { container } = render(h(LogViewer, {}))
+
+    await waitFor(() => expect(container.textContent).toContain('read file'))
+    expect(container.querySelector('[data-testid="logs-code-link"]')).toBeNull()
+  })
+})

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -10,6 +10,7 @@ import { Checkbox } from './common/checkbox'
 import { createAsyncResource, loaded } from '../lib/async-state'
 import { toolCategory } from './tool-call-shared'
 import { StatusChip } from './common/status-chip'
+import { openIdeContextRouteLink, routeLinksForContext, type IdeContextRouteLink } from './ide/ide-context-lens'
 
 interface LogData {
   entries: LogEntry[]
@@ -60,6 +61,11 @@ type FailureEnvelope = {
   recoverability: string
   operator_action: string | null
   evidence_ref: Record<string, unknown> | null
+}
+
+interface LogCodeLocation {
+  readonly filePath: string
+  readonly line?: number
 }
 
 function normalizedLevel(entry: LogEntry): string {
@@ -140,6 +146,28 @@ function nestedString(value: unknown): string | null {
   return trimmed === '' ? null : trimmed
 }
 
+function positiveLine(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 1) return value
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return /^[1-9]\d*$/.test(trimmed) ? Number.parseInt(trimmed, 10) : undefined
+}
+
+function codeLocationFromRecord(record: Record<string, unknown> | null): LogCodeLocation | null {
+  if (!record) return null
+  const filePath =
+    nestedString(record.file_path)
+    ?? nestedString(record.path)
+    ?? nestedString(record.file)
+  if (filePath) {
+    return {
+      filePath,
+      line: positiveLine(record.line) ?? positiveLine(record.line_start) ?? positiveLine(record.lineno),
+    }
+  }
+  return null
+}
+
 function failureEnvelope(entry: LogEntry): FailureEnvelope | null {
   const details = entryDetails(entry)
   const envelope = nestedRecord(details?.failure_envelope)
@@ -167,6 +195,24 @@ function failureEnvelope(entry: LogEntry): FailureEnvelope | null {
     operator_action: nestedString(envelope.operator_action),
     evidence_ref: nestedRecord(envelope.evidence_ref),
   }
+}
+
+export function logCodeRouteLink(entry: LogEntry): IdeContextRouteLink | null {
+  const details = entryDetails(entry)
+  const failure = failureEnvelope(entry)
+  const location =
+    codeLocationFromRecord(details)
+    ?? codeLocationFromRecord(nestedRecord(details?.evidence_ref))
+    ?? codeLocationFromRecord(failure?.evidence_ref ?? null)
+  if (!location) return null
+  return routeLinksForContext({
+    filePath: location.filePath,
+    line: location.line,
+    surface: 'Log',
+    label: entry.module || entry.message,
+    sourceId: `log:${entry.seq}`,
+    logId: String(entry.seq),
+  }).find(link => link.label === 'Code') ?? null
 }
 
 function renderLogMessage(entry: LogEntry): string {
@@ -242,6 +288,7 @@ function renderLogRow(entry: LogEntry) {
   const failure = failureEnvelope(entry)
   const sourceClass = sourceTone(source)
   const renderedMessage = renderLogMessage(entry)
+  const codeRouteLink = logCodeRouteLink(entry)
   let backgroundClass = 'bg-[var(--color-bg-surface)]'
   if (level === 'ERROR') {
     backgroundClass = 'bg-[var(--bad-6)]'
@@ -297,6 +344,18 @@ function renderLogRow(entry: LogEntry) {
           : null}
         ${failure?.operator_action
           ? html`<${StatusChip} tone="info" uppercase=${false}>next ${failure.operator_action}</${StatusChip}>`
+          : null}
+        ${codeRouteLink
+          ? html`
+            <button
+              type="button"
+              data-testid="logs-code-link"
+              class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs font-semibold text-[var(--color-accent-fg)] hover:border-[var(--color-accent-border)] hover:bg-[var(--color-bg-hover)]"
+              title=${codeRouteLink.evidence}
+              aria-label=${`Open ${codeRouteLink.evidence}`}
+              onClick=${() => openIdeContextRouteLink(codeRouteLink)}
+            >Code</button>
+          `
           : null}
       </div>
       <div


### PR DESCRIPTION
## Summary

- add a Code route chip to structured log rows when details or failure evidence include safe file/line context
- reuse the shared IDE context route builder so unsafe absolute paths stay hidden
- cover both relative and absolute log path behavior with focused dashboard tests

## Product impact

Operators can move from log evidence directly into the IDE source view without copying paths, while the existing path guard prevents host-local absolute paths from becoming dashboard links.

## Evidence

- `cd dashboard && pnpm exec eslint src/components/logs.ts`
- `cd dashboard && pnpm exec tsc --noEmit --pretty false`
- `cd dashboard && pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/logs.test.ts src/components/ide/ide-context-lens.test.ts src/router.test.ts`
- `git diff --check`

## Review evidence

- Focused follow-up from PR #15035 review sweep.
- Route output is covered for `lib/runtime.ml:12` and absolute `/tmp/runtime.ml` is covered as no-link.

## Linked issue

- Follow-up to #15035.
