### PR TITLE
fix(oas_compat): route required_tool_lane_unavailable to cascade (follow-up #15091)

### DIFF
--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -120,6 +120,16 @@ module Http_client = struct
        InvalidConfig errors (#9850). *)
     if contains_ci_scan_limited ~haystack:reason ~needle:"does not support" then
       Some Model_unsupported
+    (* MASC worker-layer wrapping of the [required_tool_lane_unavailable]
+       InvalidConfig {field = "tool_support"} emitted by
+       Keeper_turn_driver_helpers.required_tool_lane_unavailable_error.
+       Semantically identical to the [does not support] case: this
+       provider's materialized tool set lacks the required lane, but
+       another provider may have it — the cascade must advance. *)
+    else if
+      contains_ci_scan_limited ~haystack:reason ~needle:"required_tool_lane_unavailable"
+    then
+      Some Model_unsupported
     (* kimi_cli permanent auth/config/model rejection (#9932). *)
     else if contains_ci_scan_limited ~haystack:reason ~needle:"rejected the request" then
       Some Request_rejected

--- a/test/test_oas_compat_cascade_fallback.ml
+++ b/test/test_oas_compat_cascade_fallback.ml
@@ -274,6 +274,24 @@ let test_classify_accept_rejected_startup_crash () =
          "expected Startup_crash, got %s"
          (retryable_error_to_string other))
 
+let test_classify_accept_rejected_required_tool_lane_unavailable () =
+  (* Regression for #15091: the [required_tool_lane_unavailable_error]
+     wrapper emits an [InvalidConfig {field = "tool_support"; detail}]
+     whose detail begins with [required_tool_lane_unavailable: ...].
+     Without a matching marker the cascade stayed terminal; with the
+     marker it must route to [Model_unsupported] so the next provider
+     in the cascade gets a chance. *)
+  let reason =
+    "required_tool_lane_unavailable: lane=text_only \
+     missing_required_tools=[edit] materialized_tools=[read,bash]"
+  in
+  match Oas_compat.Http_client.classify_accept_rejected reason with
+  | Some Oas_compat.Http_client.Model_unsupported -> ()
+  | other ->
+    Alcotest.failf
+      "expected Model_unsupported for required_tool_lane_unavailable, got %s"
+      (retryable_error_to_string other)
+
 let test_classify_accept_rejected_unknown_returns_none () =
   let reason = "output_schema violation: value is not a string" in
   (match Oas_compat.Http_client.classify_accept_rejected reason with
@@ -359,6 +377,8 @@ let () =
             `Quick test_classify_accept_rejected_request_rejected;
           Alcotest.test_case "startup crash → Startup_crash"
             `Quick test_classify_accept_rejected_startup_crash;
+          Alcotest.test_case "required_tool_lane_unavailable → Model_unsupported"
+            `Quick test_classify_accept_rejected_required_tool_lane_unavailable;
           Alcotest.test_case "unrecognised reason → None"
             `Quick test_classify_accept_rejected_unknown_returns_none;
         ] );


### PR DESCRIPTION
## 배경

PR #15091 의 Codex review (P1) 가 unresolved 상태로 main 에 머지되었습니다.

`Keeper_turn_driver_helpers.required_tool_lane_unavailable_error` 는 다음 에러를 emit 합니다:

```ocaml
Agent_sdk.Error.Config
  (Agent_sdk.Error.InvalidConfig
     { field = "tool_support";
       detail = Printf.sprintf
         "required_tool_lane_unavailable: lane=%s missing_required_tools=[%s] \
          materialized_tools=[%s]" ... })
```

`Cascade_attempt_fsm.sdk_error_to_cascade_outcome` 가 이를 `AcceptRejected {reason = detail}` 로 매핑하면, `Oas_compat.Http_client.classify_accept_rejected` (lib/oas_compat/oas_compat.ml:118) 가 cascade advance 여부를 결정합니다. 이 classifier 는 3 개 marker 만 인식:

- `"does not support"` → `Model_unsupported`
- `"rejected the request"` → `Request_rejected`
- `"startup crash"` → `Startup_crash`

`"required_tool_lane_unavailable:"` detail 은 어느 marker 도 포함하지 않아 `None` 반환 → `Accept_rejected_terminal` → **cascade 가 다음 provider 로 fallback 하지 않음**. 의도는 정반대 (이 provider 의 tool 라인업 부족, 다른 provider 시도해야 함).

## 변경

- `lib/oas_compat/oas_compat.ml`: `classify_accept_rejected` 에 `"required_tool_lane_unavailable"` matcher 추가. 의미적으로 동일한 `Model_unsupported` 로 라우팅. 기존 doc 이 이미 `tool_support InvalidConfig wrapper` 케이스를 `Model_unsupported` 의 일종이라 명시하고 있어 variant 추가 없이 정확히 fit.
- `test/test_oas_compat_cascade_fallback.ml`: 신규 회귀 케이스 `required_tool_lane_unavailable → Model_unsupported` 추가. 기존 3 marker 테스트와 동일 구조.

## 검증

```
_build/default/test/test_oas_compat_cascade_fallback.exe
20 tests run, all OK (기존 19 + 회귀 1)
```

## 후속

substring matcher 패턴은 `workaround rejection bar §2 (string/substring classifier 보강)` 에 해당합니다. 본 PR 은 *기존 3-marker 같은 sibling 추가* 라 즉시 대응 가치가 높지만, root fix 는 `InvalidConfig` 가 typed `failure_reason` variant 를 carry 하도록 worker 측 에러 표현을 closed sum type 으로 옮기는 것 — 별도 RFC 후보로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)