### PR TITLE
feat(ide): derive activity links from nested evidence

### DIFF
--- a/dashboard/src/components/ide/ide-activity-mock.test.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.test.ts
@@ -169,6 +169,72 @@ describe('IdeActivityMock', () => {
     ])
   })
 
+  it('maps nested activity context and evidence refs into IDE route links', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({
+        events: [{
+          seq: 1,
+          ts_ms: 100,
+          ts_iso: '2026-05-05T10:00:00Z',
+          room_id: 'run-default',
+          kind: 'telemetry.turn',
+          actor: { kind: 'keeper', id: 'sangsu' },
+          subject: { kind: 'log', id: 'turn-8' },
+          payload: {
+            context: {
+              goal_id: 'goal-runtime',
+              task_id: 'task-runtime',
+              board_post_id: 'post-1',
+              comment_id: 'comment-1',
+            },
+            failure_envelope: {
+              evidence_ref: {
+                file_path: 'lib/runtime.ml',
+                line_start: 8,
+                pr_number: 15008,
+                branch: 'feat/runtime',
+                log_id: 'turn-8',
+                session_id: 'sess-nested',
+                operation_id: 'op-nested',
+                worker_run_id: 'wr-nested',
+              },
+            },
+          },
+          tags: [],
+        }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ))
+
+    const container = document.createElement('div')
+    render(h(IdeActivityMock, { activeFile: 'lib/runtime.ml' }), container)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('goal goal-runtime')
+      expect(container.textContent).toContain('PR 15008')
+      expect(container.textContent).toContain('1 line anchors')
+    })
+
+    const activityRouteLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-activity-route-link')]
+    expect(activityRouteLinks.map(link => link.textContent)).toEqual([
+      'Code',
+      'Goal',
+      'Task',
+      'Board',
+      'Comment',
+      'PR',
+      'Git',
+      'Log',
+      'Telemetry',
+      'Keeper',
+    ])
+
+    fireEvent.click(activityRouteLinks.find(link => link.textContent === 'Code')!)
+    expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=8&surface=PR&label=telemetry.turn&source_id=evt-1&keeper=sangsu')
+
+    fireEvent.click(activityRouteLinks.find(link => link.textContent === 'Telemetry')!)
+    expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&session_id=sess-nested&operation_id=op-nested&worker_run_id=wr-nested&q=turn-8')
+  })
+
   it('renders active run goal progress from activity goal and task links', async () => {
     goals.value = [{
       id: 'goal-runtime',

--- a/dashboard/src/components/ide/ide-activity-mock.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.ts
@@ -176,41 +176,62 @@ function contextFromPayloadAndTags(
 function mergePayloadContext(next: MutableRunActivityContext, payload: unknown): void {
   if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) return
   const record = payload as Record<string, unknown>
+  mergeContextRecord(next, nestedRecord(record.context))
+  mergeContextRecord(next, nestedRecord(record.evidence_ref))
+  const failureEnvelope = nestedRecord(record.failure_envelope)
+  mergeContextRecord(next, nestedRecord(failureEnvelope?.evidence_ref))
+  mergeContextRecord(next, nestedRecord(record.tool_args))
+  mergeContextRecord(next, nestedRecord(record.input))
+  mergeContextRecord(next, record, true)
+}
+
+function mergeContextRecord(
+  next: MutableRunActivityContext,
+  record: Record<string, unknown> | null,
+  overwrite = false,
+): void {
+  if (!record) return
   const filePath = stringValue(record.file_path)
     ?? stringValue(record.path)
     ?? stringValue(record.file)
   const normalizedFilePath = filePath ? normalizeIdeContextFilePath(filePath) : null
-  if (normalizedFilePath) next.file_path = normalizedFilePath
+  if (normalizedFilePath && (overwrite || next.file_path === undefined)) next.file_path = normalizedFilePath
   const line = positiveInteger(record.line)
     ?? positiveInteger(record.line_start)
     ?? positiveInteger(record.lineno)
-  if (line !== undefined) next.line = line
+  if (line !== undefined && (overwrite || next.line === undefined)) next.line = line
   const goalId = stringValue(record.goal_id)
-  if (goalId) next.goal_id = goalId
+  if (goalId && (overwrite || next.goal_id === undefined)) next.goal_id = goalId
   const taskId = stringValue(record.task_id)
-  if (taskId) next.task_id = taskId
+  if (taskId && (overwrite || next.task_id === undefined)) next.task_id = taskId
   const boardPostId = stringValue(record.board_post_id) ?? stringValue(record.post_id)
-  if (boardPostId) next.board_post_id = boardPostId
+  if (boardPostId && (overwrite || next.board_post_id === undefined)) next.board_post_id = boardPostId
   const commentId = stringValue(record.comment_id)
     ?? stringValue(record.reply_id)
     ?? numberString(record.comment_number)
-  if (commentId) next.comment_id = commentId
+  if (commentId && (overwrite || next.comment_id === undefined)) next.comment_id = commentId
   const prId = stringValue(record.pr_id)
     ?? stringValue(record.pull_request)
     ?? numberString(record.pr_number)
-  if (prId) next.pr_id = prId
+  if (prId && (overwrite || next.pr_id === undefined)) next.pr_id = prId
   const gitRef = stringValue(record.git_ref)
     ?? stringValue(record.commit)
     ?? stringValue(record.branch)
-  if (gitRef) next.git_ref = gitRef
+  if (gitRef && (overwrite || next.git_ref === undefined)) next.git_ref = gitRef
   const logId = stringValue(record.log_id)
-  if (logId) next.log_id = logId
+  if (logId && (overwrite || next.log_id === undefined)) next.log_id = logId
   const sessionId = stringValue(record.session_id)
-  if (sessionId) next.session_id = sessionId
+  if (sessionId && (overwrite || next.session_id === undefined)) next.session_id = sessionId
   const operationId = stringValue(record.operation_id)
-  if (operationId) next.operation_id = operationId
+  if (operationId && (overwrite || next.operation_id === undefined)) next.operation_id = operationId
   const workerRunId = stringValue(record.worker_run_id)
-  if (workerRunId) next.worker_run_id = workerRunId
+  if (workerRunId && (overwrite || next.worker_run_id === undefined)) next.worker_run_id = workerRunId
+}
+
+function nestedRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
 }
 
 function mergeTagContext(next: MutableRunActivityContext, rawTag: string): void {


### PR DESCRIPTION
## Summary

- derive IDE activity context from nested `payload.context`, `payload.evidence_ref`, failure-envelope evidence, and common tool input wrappers
- keep flat payload keys as the explicit override and preserve tag-derived context as the final override layer
- add render coverage for nested evidence producing Code, Goal, Task, Board, Comment, PR, Git, Log, Telemetry, and Keeper links

## Product impact

The IDE event timeline now preserves more runtime truth from structured telemetry and failure envelopes. Operators can follow nested evidence from a keeper/runtime activity event into the exact code line, planning item, board thread, PR/git surface, log, and fleet telemetry view instead of losing those links when the backend wraps context under evidence objects.

## Evidence

- `cd dashboard && pnpm install --offline --frozen-lockfile`
- `cd dashboard && pnpm exec eslint src/components/ide/ide-activity-mock.ts src/components/ide/ide-activity-mock.test.ts`
- `cd dashboard && pnpm exec tsc --noEmit --pretty false`
- `cd dashboard && pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-activity-mock.test.ts src/components/ide/ide-context-lens.test.ts src/router.test.ts`
- `git diff --check`

## Review evidence

- The new test pins nested `payload.context` plus `failure_envelope.evidence_ref`.
- The resulting activity row exposes all operational route chips and verifies Code/Telemetry hash output.
- Existing flat payload and tag tests still cover the override path.

## Linked issue

- Follow-up to #15035.
