### PR TITLE
feat(dashboard): link log code context to IDE

### DIFF
--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -191,4 +191,63 @@ describe('LogViewer Code links', () => {
     await waitFor(() => expect(container.textContent).toContain('read file'))
     expect(container.querySelector('[data-testid="logs-code-link"]')).toBeNull()
   })
+
+  it('links nested log evidence into operational IDE routes', async () => {
+    const fetchLogs = vi.fn().mockResolvedValue({
+      total: 1,
+      entries: [{
+        seq: 3,
+        ts: '2026-05-14T00:00:00Z',
+        level: 'WARN',
+        raw_level: 'WARN',
+        normalized_level: 'WARN',
+        source: 'structured',
+        legacy_classified: false,
+        module: 'keeper_tool',
+        message: 'tool warning',
+        details: {
+          context: {
+            goal_id: 'goal-runtime',
+            task_id: 'task-runtime',
+            board_post_id: 'post-1',
+            comment_id: 'comment-1',
+          },
+          failure_envelope: {
+            evidence_ref: {
+              file_path: 'lib/runtime.ml',
+              line_start: 8,
+              pr_number: 15008,
+              branch: 'feat/runtime',
+              log_id: 'turn-8',
+              session_id: 'sess-nested',
+              operation_id: 'op-nested',
+              worker_run_id: 'wr-nested',
+            },
+          },
+        },
+      }],
+    })
+    const { LogViewer } = await loadLogs(fetchLogs)
+    const { container } = render(h(LogViewer, {}))
+
+    await waitFor(() => expect(container.textContent).toContain('tool warning'))
+    const routeLinks = [...container.querySelectorAll<HTMLButtonElement>('.logs-route-link')]
+    expect(routeLinks.map(link => link.textContent)).toEqual([
+      'Code',
+      'Goal',
+      'Task',
+      'Board',
+      'Comment',
+      'PR',
+      'Git',
+      'Log',
+      'Telemetry',
+    ])
+
+    routeLinks.find(link => link.textContent === 'Code')?.click()
+    expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=8&surface=Log&label=keeper_tool&source_id=log%3A3')
+
+    routeLinks.find(link => link.textContent === 'Telemetry')?.click()
+    expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&session_id=sess-nested&operation_id=op-nested&worker_run_id=wr-nested&q=turn-8')
+  })
 })

--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { h } from 'preact'
+import { cleanup, render, waitFor } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { LogEntry } from '../api/dashboard'
 import { logDiagnosticCause, summarizeLogWindow } from './logs'
 
@@ -16,6 +18,14 @@ function entry(overrides: Partial<LogEntry>): LogEntry {
     details: null,
     ...overrides,
   }
+}
+
+async function loadLogs(fetchLogs: ReturnType<typeof vi.fn>) {
+  vi.resetModules()
+  vi.doMock('../api/dashboard.js', () => ({
+    fetchLogs,
+  }))
+  return import('./logs')
 }
 
 describe('log diagnostics', () => {
@@ -115,5 +125,70 @@ describe('log diagnostics', () => {
       count: 1,
     })
     expect(summary.topModules[0]).toEqual({ module: 'Keeper', count: 2 })
+  })
+})
+
+describe('LogViewer Code links', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    vi.resetModules()
+    vi.doUnmock('../api/dashboard.js')
+    window.location.hash = ''
+  })
+
+  it('links safe structured log file details back to the Code IDE route', async () => {
+    const fetchLogs = vi.fn().mockResolvedValue({
+      total: 1,
+      entries: [{
+        seq: 1,
+        ts: '2026-05-14T00:00:00Z',
+        level: 'INFO',
+        raw_level: 'INFO',
+        normalized_level: 'INFO',
+        source: 'structured',
+        legacy_classified: false,
+        module: 'keeper_tool',
+        message: 'read file',
+        details: { file_path: 'lib/runtime.ml', line: 12 },
+      }],
+    })
+    const { LogViewer } = await loadLogs(fetchLogs)
+    const { container } = render(h(LogViewer, {}))
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-testid="logs-code-link"]')).not.toBeNull(),
+    )
+    const codeLink = container.querySelector('[data-testid="logs-code-link"]') as HTMLButtonElement
+    expect(codeLink.textContent).toBe('Code')
+    expect(codeLink.getAttribute('title')).toBe('Code lib/runtime.ml:12')
+
+    codeLink.click()
+    expect(window.location.hash).toBe(
+      '#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=12&surface=Log&label=keeper_tool&source_id=log%3A1',
+    )
+  })
+
+  it('does not render Code links for unsafe absolute log file paths', async () => {
+    const fetchLogs = vi.fn().mockResolvedValue({
+      total: 1,
+      entries: [{
+        seq: 2,
+        ts: '2026-05-14T00:00:00Z',
+        level: 'INFO',
+        raw_level: 'INFO',
+        normalized_level: 'INFO',
+        source: 'structured',
+        legacy_classified: false,
+        module: 'keeper_tool',
+        message: 'read file',
+        details: { file_path: '/tmp/runtime.ml', line: 12 },
+      }],
+    })
+    const { LogViewer } = await loadLogs(fetchLogs)
+    const { container } = render(h(LogViewer, {}))
+
+    await waitFor(() => expect(container.textContent).toContain('read file'))
+    expect(container.querySelector('[data-testid="logs-code-link"]')).toBeNull()
   })
 })

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -10,7 +10,12 @@ import { Checkbox } from './common/checkbox'
 import { createAsyncResource, loaded } from '../lib/async-state'
 import { toolCategory } from './tool-call-shared'
 import { StatusChip } from './common/status-chip'
-import { openIdeContextRouteLink, routeLinksForContext, type IdeContextRouteLink } from './ide/ide-context-lens'
+import {
+  openIdeContextRouteLink,
+  routeLinksForContext,
+  type IdeContextRouteContext,
+  type IdeContextRouteLink,
+} from './ide/ide-context-lens'
 
 interface LogData {
   entries: LogEntry[]
@@ -84,6 +89,25 @@ type FailureEnvelope = {
 interface LogCodeLocation {
   readonly filePath: string
   readonly line?: number
+}
+
+type LogRouteContextFields = Pick<
+  IdeContextRouteContext,
+  | 'filePath'
+  | 'line'
+  | 'goalId'
+  | 'taskId'
+  | 'boardPostId'
+  | 'commentId'
+  | 'prId'
+  | 'gitRef'
+  | 'logId'
+  | 'sessionId'
+  | 'operationId'
+  | 'workerRunId'
+>
+type MutableLogRouteContext = {
+  -readonly [K in keyof LogRouteContextFields]?: LogRouteContextFields[K]
 }
 
 function normalizedLevel(entry: LogEntry): string {
@@ -171,6 +195,14 @@ function positiveLine(value: unknown): number | undefined {
   return /^[1-9]\d*$/.test(trimmed) ? Number.parseInt(trimmed, 10) : undefined
 }
 
+function idString(value: unknown): string | undefined {
+  const text = nestedString(value)
+  if (text) return text
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 1
+    ? String(value)
+    : undefined
+}
+
 function codeLocationFromRecord(record: Record<string, unknown> | null): LogCodeLocation | null {
   if (!record) return null
   const filePath =
@@ -184,6 +216,52 @@ function codeLocationFromRecord(record: Record<string, unknown> | null): LogCode
     }
   }
   return null
+}
+
+function mergeLogRouteRecord(
+  context: MutableLogRouteContext,
+  record: Record<string, unknown> | null,
+  overwrite = false,
+): void {
+  if (!record) return
+  const location = codeLocationFromRecord(record)
+  if (location && (overwrite || context.filePath === undefined)) context.filePath = location.filePath
+  if (location?.line !== undefined && (overwrite || context.line === undefined)) context.line = location.line
+
+  const goalId = idString(record.goal_id)
+  if (goalId && (overwrite || context.goalId === undefined)) context.goalId = goalId
+  const taskId = idString(record.task_id)
+  if (taskId && (overwrite || context.taskId === undefined)) context.taskId = taskId
+  const boardPostId = idString(record.board_post_id) ?? idString(record.post_id)
+  if (boardPostId && (overwrite || context.boardPostId === undefined)) context.boardPostId = boardPostId
+  const commentId = idString(record.comment_id) ?? idString(record.reply_id) ?? idString(record.comment_number)
+  if (commentId && (overwrite || context.commentId === undefined)) context.commentId = commentId
+  const prId = idString(record.pr_id) ?? idString(record.pull_request) ?? idString(record.pr_number)
+  if (prId && (overwrite || context.prId === undefined)) context.prId = prId
+  const gitRef = idString(record.git_ref) ?? idString(record.commit) ?? idString(record.branch)
+  if (gitRef && (overwrite || context.gitRef === undefined)) context.gitRef = gitRef
+  const logId = idString(record.log_id)
+  if (logId && (overwrite || context.logId === undefined)) context.logId = logId
+  const sessionId = idString(record.session_id)
+  if (sessionId && (overwrite || context.sessionId === undefined)) context.sessionId = sessionId
+  const operationId = idString(record.operation_id)
+  if (operationId && (overwrite || context.operationId === undefined)) context.operationId = operationId
+  const workerRunId = idString(record.worker_run_id)
+  if (workerRunId && (overwrite || context.workerRunId === undefined)) context.workerRunId = workerRunId
+}
+
+function hasLogRouteContext(context: MutableLogRouteContext): boolean {
+  return context.filePath !== undefined
+    || context.goalId !== undefined
+    || context.taskId !== undefined
+    || context.boardPostId !== undefined
+    || context.commentId !== undefined
+    || context.prId !== undefined
+    || context.gitRef !== undefined
+    || context.logId !== undefined
+    || context.sessionId !== undefined
+    || context.operationId !== undefined
+    || context.workerRunId !== undefined
 }
 
 function failureEnvelope(entry: LogEntry): FailureEnvelope | null {
@@ -294,22 +372,31 @@ export function summarizeLogWindow(entries: LogEntry[]): LogWindowSummary {
   }
 }
 
-export function logCodeRouteLink(entry: LogEntry): IdeContextRouteLink | null {
+export function logRouteLinks(entry: LogEntry): ReadonlyArray<IdeContextRouteLink> {
   const details = entryDetails(entry)
-  const failure = failureEnvelope(entry)
-  const location =
-    codeLocationFromRecord(details)
-    ?? codeLocationFromRecord(nestedRecord(details?.evidence_ref))
-    ?? codeLocationFromRecord(failure?.evidence_ref ?? null)
-  if (!location) return null
+  const failureEnvelopeRecord = nestedRecord(details?.failure_envelope)
+  const context: MutableLogRouteContext = {}
+  mergeLogRouteRecord(context, nestedRecord(details?.context))
+  mergeLogRouteRecord(context, nestedRecord(details?.evidence_ref))
+  mergeLogRouteRecord(context, nestedRecord(failureEnvelopeRecord?.evidence_ref))
+  mergeLogRouteRecord(context, nestedRecord(details?.tool_args))
+  mergeLogRouteRecord(context, nestedRecord(details?.input))
+  mergeLogRouteRecord(context, details, true)
+  if (!hasLogRouteContext(context)) return []
   return routeLinksForContext({
-    filePath: location.filePath,
-    line: location.line,
+    ...context,
     surface: 'Log',
     label: entry.module || entry.message,
     sourceId: `log:${entry.seq}`,
-    logId: String(entry.seq),
-  }).find(link => link.label === 'Code') ?? null
+    telemetry: context.logId !== undefined
+      || context.sessionId !== undefined
+      || context.operationId !== undefined
+      || context.workerRunId !== undefined,
+  })
+}
+
+export function logCodeRouteLink(entry: LogEntry): IdeContextRouteLink | null {
+  return logRouteLinks(entry).find(link => link.label === 'Code') ?? null
 }
 
 function renderLogMessage(entry: LogEntry): string {
@@ -387,7 +474,13 @@ function renderLogRow(entry: LogEntry) {
   const diagnosticCause = failure?.cause_code ?? logDiagnosticCause(entry)
   const sourceClass = sourceTone(source)
   const renderedMessage = renderLogMessage(entry)
-  const codeRouteLink = logCodeRouteLink(entry)
+  const routeLinks = logRouteLinks(entry)
+  const diagnosticChip = failure
+    ? html`<${StatusChip} tone="bad" uppercase=${false}>${failure.cause_code}</${StatusChip}>`
+    : null
+  const fallbackDiagnosticChip = !failure && diagnosticCause
+    ? html`<${StatusChip} tone=${level === 'ERROR' ? 'bad' : 'warn'} uppercase=${false}>${diagnosticCause}</${StatusChip}>`
+    : null
   let backgroundClass = 'bg-[var(--color-bg-surface)]'
   if (level === 'ERROR') {
     backgroundClass = 'bg-[var(--bad-6)]'
@@ -438,11 +531,8 @@ function renderLogRow(entry: LogEntry) {
         ${sessionId
           ? html`<${MetaTag}>session ${sessionId}</${MetaTag}>`
           : null}
-        ${failure
-          ? html`<${StatusChip} tone="bad" uppercase=${false}>${failure.cause_code}</${StatusChip}>`
-          : diagnosticCause
-            ? html`<${StatusChip} tone=${level === 'ERROR' ? 'bad' : 'warn'} uppercase=${false}>${diagnosticCause}</${StatusChip}>`
-            : null}
+        ${diagnosticChip}
+        ${fallbackDiagnosticChip}
         ${failure
           ? html`<${StatusChip} tone="info" uppercase=${false}>${failure.surface}</${StatusChip}>`
           : null}
@@ -452,16 +542,19 @@ function renderLogRow(entry: LogEntry) {
         ${failure?.operator_action
           ? html`<${StatusChip} tone="info" uppercase=${false}>next ${failure.operator_action}</${StatusChip}>`
           : null}
-        ${codeRouteLink
+        ${routeLinks.length > 0
           ? html`
-            <button
-              type="button"
-              data-testid="logs-code-link"
-              class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs font-semibold text-[var(--color-accent-fg)] hover:border-[var(--color-accent-border)] hover:bg-[var(--color-bg-hover)]"
-              title=${codeRouteLink.evidence}
-              aria-label=${`Open ${codeRouteLink.evidence}`}
-              onClick=${() => openIdeContextRouteLink(codeRouteLink)}
-            >Code</button>
+            ${routeLinks.map(link => html`
+              <button
+                key=${link.id}
+                type="button"
+                data-testid=${link.label === 'Code' ? 'logs-code-link' : undefined}
+                class="logs-route-link rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs font-semibold text-[var(--color-accent-fg)] hover:border-[var(--color-accent-border)] hover:bg-[var(--color-bg-hover)]"
+                title=${link.evidence}
+                aria-label=${`Open ${link.evidence}`}
+                onClick=${() => openIdeContextRouteLink(link)}
+              >${link.label}</button>
+            `)}
           `
           : null}
       </div>

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -10,6 +10,7 @@ import { Checkbox } from './common/checkbox'
 import { createAsyncResource, loaded } from '../lib/async-state'
 import { toolCategory } from './tool-call-shared'
 import { StatusChip } from './common/status-chip'
+import { openIdeContextRouteLink, routeLinksForContext, type IdeContextRouteLink } from './ide/ide-context-lens'
 
 interface LogData {
   entries: LogEntry[]
@@ -78,6 +79,11 @@ type FailureEnvelope = {
   recoverability: string
   operator_action: string | null
   evidence_ref: Record<string, unknown> | null
+}
+
+interface LogCodeLocation {
+  readonly filePath: string
+  readonly line?: number
 }
 
 function normalizedLevel(entry: LogEntry): string {
@@ -156,6 +162,28 @@ function nestedString(value: unknown): string | null {
   if (typeof value !== 'string') return null
   const trimmed = value.trim()
   return trimmed === '' ? null : trimmed
+}
+
+function positiveLine(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 1) return value
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return /^[1-9]\d*$/.test(trimmed) ? Number.parseInt(trimmed, 10) : undefined
+}
+
+function codeLocationFromRecord(record: Record<string, unknown> | null): LogCodeLocation | null {
+  if (!record) return null
+  const filePath =
+    nestedString(record.file_path)
+    ?? nestedString(record.path)
+    ?? nestedString(record.file)
+  if (filePath) {
+    return {
+      filePath,
+      line: positiveLine(record.line) ?? positiveLine(record.line_start) ?? positiveLine(record.lineno),
+    }
+  }
+  return null
 }
 
 function failureEnvelope(entry: LogEntry): FailureEnvelope | null {
@@ -266,6 +294,24 @@ export function summarizeLogWindow(entries: LogEntry[]): LogWindowSummary {
   }
 }
 
+export function logCodeRouteLink(entry: LogEntry): IdeContextRouteLink | null {
+  const details = entryDetails(entry)
+  const failure = failureEnvelope(entry)
+  const location =
+    codeLocationFromRecord(details)
+    ?? codeLocationFromRecord(nestedRecord(details?.evidence_ref))
+    ?? codeLocationFromRecord(failure?.evidence_ref ?? null)
+  if (!location) return null
+  return routeLinksForContext({
+    filePath: location.filePath,
+    line: location.line,
+    surface: 'Log',
+    label: entry.module || entry.message,
+    sourceId: `log:${entry.seq}`,
+    logId: String(entry.seq),
+  }).find(link => link.label === 'Code') ?? null
+}
+
 function renderLogMessage(entry: LogEntry): string {
   const details = entryDetails(entry)
   const message = interpolateStructuredMessage(entry.message, details)
@@ -341,6 +387,7 @@ function renderLogRow(entry: LogEntry) {
   const diagnosticCause = failure?.cause_code ?? logDiagnosticCause(entry)
   const sourceClass = sourceTone(source)
   const renderedMessage = renderLogMessage(entry)
+  const codeRouteLink = logCodeRouteLink(entry)
   let backgroundClass = 'bg-[var(--color-bg-surface)]'
   if (level === 'ERROR') {
     backgroundClass = 'bg-[var(--bad-6)]'
@@ -404,6 +451,18 @@ function renderLogRow(entry: LogEntry) {
           : null}
         ${failure?.operator_action
           ? html`<${StatusChip} tone="info" uppercase=${false}>next ${failure.operator_action}</${StatusChip}>`
+          : null}
+        ${codeRouteLink
+          ? html`
+            <button
+              type="button"
+              data-testid="logs-code-link"
+              class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs font-semibold text-[var(--color-accent-fg)] hover:border-[var(--color-accent-border)] hover:bg-[var(--color-bg-hover)]"
+              title=${codeRouteLink.evidence}
+              aria-label=${`Open ${codeRouteLink.evidence}`}
+              onClick=${() => openIdeContextRouteLink(codeRouteLink)}
+            >Code</button>
+          `
           : null}
       </div>
       <div


### PR DESCRIPTION
## Summary

- add compact operational route chips to structured log rows when details or nested evidence include IDE context
- reuse the shared IDE context route builder for Code, Goal, Task, Board, Comment, PR, Git, Log, and Telemetry routes
- keep unsafe absolute paths hidden while preserving non-code operational links

## Product impact

Operators can move from log evidence directly into the IDE source view, planning item, board/comment thread, PR/git view, runtime audit log, or fleet telemetry query without copying IDs out of JSON. Nested failure-envelope evidence now stays connected to the same dashboard surfaces as activity and keeper tool-call context.

## Evidence

- `cd dashboard && pnpm exec eslint src/components/logs.ts`
- `cd dashboard && pnpm exec tsc --noEmit --pretty false`
- `cd dashboard && pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/logs.test.ts src/components/ide/ide-context-lens.test.ts src/router.test.ts` (3 files, 50 tests)
- `git diff --check`

## Review evidence

- Focused follow-up from PR #15035 review sweep.
- Existing coverage pins safe relative `file_path` to Code and absolute `/tmp/...` to no Code link.
- New coverage pins nested `details.context` plus `failure_envelope.evidence_ref` into Code, Goal, Task, Board, Comment, PR, Git, Log, and Telemetry route chips.

## Replacement note

Supersedes #15124. This replacement carries the log-code diff on `fix/dashboard-log-code-link-20260514` without the stale `agent-pr` label gate; it remains draft-only.

## Linked issue

- Follow-up to #15035.
