### PR TITLE
fix(keeper): count empty after-turn responses

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -268,6 +268,9 @@ let empty_response_model_metric =
 let alias_response_model_metric =
   Prometheus.metric_after_turn_response_model_alias
 
+let empty_response_content_metric =
+  Prometheus.metric_after_turn_response_content_empty
+
 let zero_usage : Agent_sdk.Types.api_usage =
   {
     input_tokens = 0;
@@ -327,6 +330,47 @@ let resolve_after_turn_model ~keeper_name
         keeper_name "telemetry_canonical");
     runtime_lane_label
   end
+
+let stop_reason_metric_label = function
+  | Agent_sdk.Types.EndTurn -> "end_turn"
+  | Agent_sdk.Types.StopToolUse -> "tool_use"
+  | Agent_sdk.Types.MaxTokens -> "max_tokens"
+  | Agent_sdk.Types.StopSequence -> "stop_sequence"
+  | Agent_sdk.Types.Unknown _ -> "unknown"
+
+let content_block_has_visible_or_tool_progress = function
+  | Agent_sdk.Types.Text text -> String.trim text <> ""
+  | Agent_sdk.Types.ToolResult { content; json; _ } ->
+      String.trim content <> "" || Option.is_some json
+  | Agent_sdk.Types.ToolUse _
+  | Agent_sdk.Types.Image _
+  | Agent_sdk.Types.Document _
+  | Agent_sdk.Types.Audio _ -> true
+  | Agent_sdk.Types.Thinking _ | Agent_sdk.Types.RedactedThinking _ -> false
+
+let response_content_empty_shape content =
+  if content = [] then "empty"
+  else if
+    List.exists
+      (function
+        | Agent_sdk.Types.Thinking _ | Agent_sdk.Types.RedactedThinking _ -> true
+        | _ -> false)
+      content
+  then "thinking_only"
+  else "blank_text"
+
+let record_response_content_quality_metric ~keeper_name
+    (response : Agent_sdk.Types.api_response) =
+  if not (List.exists content_block_has_visible_or_tool_progress response.content)
+  then
+    Prometheus.inc_counter empty_response_content_metric
+      ~labels:
+        [
+          ("keeper", keeper_name);
+          ("stop_reason", stop_reason_metric_label response.stop_reason);
+          ("shape", response_content_empty_shape response.content);
+        ]
+      ()
 
 let context_max_of_telemetry
     (telemetry : Agent_sdk.Types.inference_telemetry option) =
@@ -1904,6 +1948,7 @@ let make_hooks
            histogram still proves the hook ran. *)
         record_llm_inference_latency_metric ~model
           ~telemetry:response.telemetry;
+        record_response_content_quality_metric ~keeper_name:meta.name response;
         let fmt_tok_s = function
           | Some v -> Printf.sprintf "%.1f" v
           | None -> "-"

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -64,6 +64,12 @@ val resolve_after_turn_model :
     metrics when OAS omits [response.model] or returns a selector alias,
     without exposing concrete model identity. *)
 
+val record_response_content_quality_metric :
+  keeper_name:string -> Agent_sdk.Types.api_response -> unit
+(** Count after-turn responses that contain no visible assistant text and no
+    tool progress.  Tool-use responses are progress, even when textual content
+    is empty. *)
+
 val context_max_of_telemetry :
   Agent_sdk.Types.inference_telemetry option -> int
 (** Provider-reported context window max, or [0] when telemetry omits it. *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -739,6 +739,8 @@ let metric_cascade_ttfb_seconds = "masc_cascade_ttfb_seconds"
 let metric_cascade_inter_chunk_seconds = "masc_cascade_inter_chunk_seconds"
 let metric_after_turn_hook = "masc_after_turn_hook_total"
 let metric_after_turn_telemetry_missing = "masc_after_turn_telemetry_missing_total"
+let metric_after_turn_response_content_empty =
+  "masc_after_turn_response_content_empty_total"
 
 let metric_after_turn_telemetry_zero_latency =
   "masc_after_turn_telemetry_zero_latency_total"
@@ -1124,6 +1126,11 @@ let init () =
   add
     metric_after_turn_telemetry_zero_latency
     "AfterTurn responses where telemetry was present but request_latency_ms was 0."
+    Counter;
+  add
+    metric_after_turn_response_content_empty
+    "AfterTurn responses that completed without visible assistant text or tool \
+     progress. Labels: keeper, stop_reason, shape."
     Counter;
   add
     metric_oas_inference_telemetry_tokens

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -441,6 +441,7 @@ val metric_llm_decode_tok_per_sec : string
 
 val metric_after_turn_hook : string
 val metric_after_turn_telemetry_missing : string
+val metric_after_turn_response_content_empty : string
 val metric_after_turn_telemetry_zero_latency : string
 val metric_tasks : string
 val metric_errors : string

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -599,11 +599,15 @@ let make_telemetry
   }
 ;;
 
-let make_response ?(stop_reason = Agent_sdk.Types.EndTurn) ?telemetry () =
+let make_response
+    ?(stop_reason = Agent_sdk.Types.EndTurn)
+    ?(content = [])
+    ?telemetry
+    () =
   { Agent_sdk.Types.id = "response-test"
   ; model = "test-model"
   ; stop_reason
-  ; content = []
+  ; content
   ; usage = None
   ; telemetry
   }
@@ -816,6 +820,69 @@ let test_record_llm_inference_latency_metric_none_counts_missing () =
   in
   check (float 0.0001) "missing counter +1" 1.0 (missing_after -. missing_before);
   check (float 0.0001) "latency histogram unchanged" 0.0 (count_after -. count_before)
+;;
+
+let empty_content_labels ~keeper ~stop_reason ~shape =
+  [ "keeper", keeper; "stop_reason", stop_reason; "shape", shape ]
+;;
+
+let empty_content_counter ~keeper ~stop_reason ~shape =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Prometheus.metric_after_turn_response_content_empty
+    ~labels:(empty_content_labels ~keeper ~stop_reason ~shape)
+    ()
+;;
+
+let test_record_response_content_quality_metric_empty_end_turn_counts () =
+  let keeper = "response-content-empty-keeper" in
+  let before =
+    empty_content_counter ~keeper ~stop_reason:"end_turn" ~shape:"empty"
+  in
+  Hooks.record_response_content_quality_metric
+    ~keeper_name:keeper
+    (make_response ());
+  let after =
+    empty_content_counter ~keeper ~stop_reason:"end_turn" ~shape:"empty"
+  in
+  check (float 0.0001) "empty end_turn counter +1" 1.0 (after -. before)
+;;
+
+let test_record_response_content_quality_metric_blank_text_counts () =
+  let keeper = "response-content-blank-text-keeper" in
+  let before =
+    empty_content_counter ~keeper ~stop_reason:"max_tokens" ~shape:"blank_text"
+  in
+  Hooks.record_response_content_quality_metric
+    ~keeper_name:keeper
+    (make_response
+       ~stop_reason:Agent_sdk.Types.MaxTokens
+       ~content:[ Agent_sdk.Types.Text " \n\t " ]
+       ());
+  let after =
+    empty_content_counter ~keeper ~stop_reason:"max_tokens" ~shape:"blank_text"
+  in
+  check (float 0.0001) "blank text counter +1" 1.0 (after -. before)
+;;
+
+let test_record_response_content_quality_metric_tool_use_is_progress () =
+  let keeper = "response-content-tool-use-keeper" in
+  let before =
+    empty_content_counter ~keeper ~stop_reason:"tool_use" ~shape:"blank_text"
+  in
+  Hooks.record_response_content_quality_metric
+    ~keeper_name:keeper
+    (make_response
+       ~stop_reason:Agent_sdk.Types.StopToolUse
+       ~content:
+         [
+           Agent_sdk.Types.ToolUse
+             { id = "toolu-test"; name = "keeper_bash"; input = `Assoc [] };
+         ]
+       ());
+  let after =
+    empty_content_counter ~keeper ~stop_reason:"tool_use" ~shape:"blank_text"
+  in
+  check (float 0.0001) "tool use is not empty content" 0.0 (after -. before)
 ;;
 
 let slot json name = json |> member "slots" |> member name
@@ -1498,6 +1565,20 @@ let () =
             "missing telemetry increments missing counter"
             `Quick
             test_record_llm_inference_latency_metric_none_counts_missing
+        ] )
+    ; ( "response_content_quality"
+      , [ test_case
+            "empty end_turn response content counts"
+            `Quick
+            test_record_response_content_quality_metric_empty_end_turn_counts
+        ; test_case
+            "blank text response content counts"
+            `Quick
+            test_record_response_content_quality_metric_blank_text_counts
+        ; test_case
+            "tool-use-only response is progress"
+            `Quick
+            test_record_response_content_quality_metric_tool_use_is_progress
         ] )
     ; ( "hook_introspection"
       , [ test_case


### PR DESCRIPTION
## Summary
- Add `masc_after_turn_response_content_empty_total` for after-turn responses that complete without visible assistant text or tool progress.
- Wire the counter into `Keeper_hooks_oas.after_turn` with bounded labels: `keeper`, `stop_reason`, `shape`.
- Treat tool-use, media, non-empty tool results, and structured tool-result JSON as progress so tool-only turns do not false-positive.

## Verification
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe`
- `./_build/default/test/test_keeper_hooks_oas_telemetry.exe` (47 tests)

## Review Notes
- Draft PR only. Do not add `human-approved-ready` until human review is complete.
- Expected policy reds while draft/unapproved: Draft Auto-Merge Guard and CI Gate.