### PR TITLE
Surface durable paused keepers in health

### DIFF
--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -137,6 +137,60 @@ let health_path_diagnostics () =
         ?env_masc_base_path:(Env_config_core.base_path_raw_opt ())
         ~effective_base_path ~effective_masc_root ()
 
+type paused_keeper_scan = {
+  names : string list;
+  read_errors : (string * string) list;
+}
+
+let sorted_unique_strings values = List.sort_uniq String.compare values
+
+let running_paused_keeper_names () =
+  Keeper_registry.all ()
+  |> List.filter_map (fun (e : Keeper_registry.registry_entry) ->
+       if e.meta.paused then Some e.name else None)
+  |> sorted_unique_strings
+
+let durable_paused_keeper_scan config =
+  Keeper_types.keeper_names config
+  |> List.fold_left
+       (fun acc name ->
+         match Keeper_types.read_meta config name with
+         | Ok (Some meta) when meta.paused ->
+             { acc with names = meta.name :: acc.names }
+         | Ok (Some _) | Ok None -> acc
+         | Error err ->
+             { acc with read_errors = (name, err) :: acc.read_errors })
+       { names = []; read_errors = [] }
+  |> fun scan ->
+  {
+    names = sorted_unique_strings scan.names;
+    read_errors = List.sort (fun (a, _) (b, _) -> String.compare a b) scan.read_errors;
+  }
+
+let paused_keepers_health_json () =
+  let running_names = running_paused_keeper_names () in
+  let durable_scan =
+    match current_server_state_opt () with
+    | Some state -> durable_paused_keeper_scan state.Mcp_server.room_config
+    | None -> { names = []; read_errors = [] }
+  in
+  let names = sorted_unique_strings (running_names @ durable_scan.names) in
+  `Assoc [
+    ("count", `Int (List.length names));
+    ("names", `List (List.map (fun name -> `String name) names));
+    ("running_count", `Int (List.length running_names));
+    ("running_names", `List (List.map (fun name -> `String name) running_names));
+    ("durable_count", `Int (List.length durable_scan.names));
+    ("durable_names", `List (List.map (fun name -> `String name) durable_scan.names));
+    ("read_error_count", `Int (List.length durable_scan.read_errors));
+    ( "read_errors",
+      `List
+        (List.map
+           (fun (keeper, error) ->
+             `Assoc [ ("keeper", `String keeper); ("error", `String error) ])
+           durable_scan.read_errors) );
+  ]
+
 let make_health_json ?(listener = "http/1.1") request =
   let uptime_secs = int_of_float (Unix.gettimeofday () -. server_start_time) in
   let uptime_str =
@@ -221,20 +275,12 @@ let make_health_json ?(listener = "http/1.1") request =
     ]);
     ("keeper_fibers", `Int (Keeper_registry.count_running ()));
     (* Paused-keeper visibility: a keeper with [meta.paused = true] does not
-       run turns even if its fiber is alive. The dashboard "깨우기" button
-       now auto-resumes paused keepers, but ops still need a quick count
-       without scraping /metrics. List names so an operator can correlate
-       with the cause encoded in their last_blocker_class. *)
-    ("paused_keepers",
-     let paused =
-       Keeper_registry.all ()
-       |> List.filter_map (fun (e : Keeper_registry.registry_entry) ->
-            if e.meta.paused then Some (`String e.name) else None)
-     in
-     `Assoc [
-       ("count", `Int (List.length paused));
-       ("names", `List paused);
-     ]);
+       run turns, and auto-paused keepers may no longer have a live registry
+       entry. The dashboard "깨우기" button now auto-resumes paused keepers,
+       but ops still need a quick count without scraping /metrics. List names
+       so an operator can correlate with the cause encoded in their
+       last_blocker_class. *)
+    ("paused_keepers", paused_keepers_health_json ());
     ("keeper_config_parse_error_count",
      `Int keeper_config_parse_error_count);
     ( "keeper_config_parse_errors",

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -117,13 +117,23 @@ val make_health_json :
     [build] / [protocol] (default + listener + supported list) /
     [transport] / [paths] / [uptime] / [sse_clients] /
     [startup] / [subsystems] / [feature_flags] / [gc] /
-    [keeper_fibers] / [keeper_config_parse_error_count] /
-    [keeper_config_parse_errors] / [keeper_config_unknown_key_count] /
-    [keeper_config_unknown_keys] / [keeper_config_schema_status] /
-    [keeper_config_schema_blocking] /
+    [keeper_fibers] / [paused_keepers] /
+    [keeper_config_parse_error_count] / [keeper_config_parse_errors] /
+    [keeper_config_unknown_key_count] / [keeper_config_unknown_keys] /
+    [keeper_config_schema_status] / [keeper_config_schema_blocking] /
     [keeper_config_schema_terminal_reason] /
     [keeper_config_operator_action_required] /
     [lazy_task_boot_guard_fires_total].
+
+    {2 paused_keepers contract}
+
+    [paused_keepers.count] and [paused_keepers.names] are the union of
+    registry-visible paused keepers and durable [.masc/keepers/*.json]
+    metas with [paused = true].  The nested [running_*] and
+    [durable_*] fields keep the two sources inspectable so a keeper
+    that has been auto-paused and removed from the live keepalive set
+    does not disappear from [/health].  [read_error_count] surfaces
+    corrupt durable meta instead of silently reporting a clean zero.
 
     {2 lazy_task_boot_guard_fires_total contract (P2 silent-
     failure fix)}

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -919,6 +919,74 @@ let make_keeper_meta_json ?(name = "sangsu")
   | Ok meta -> Keeper_types.meta_to_json meta |> Yojson.Safe.pretty_to_string
   | Error err -> Alcotest.fail ("meta_of_json failed: " ^ err)
 
+let make_keeper_meta ?(paused = false) ?(name = "sangsu")
+    ?(trace_id = "trace-sangsu-live")
+    ?(updated_at = "2026-03-29T10:36:57Z") () =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
+          ("trace_id", `String trace_id);
+          ("goal", `String ("goal-" ^ name));
+          ("cascade_name", `String Masc_mcp.(Keeper_config.default_cascade_name ()));
+          ("updated_at", `String updated_at);
+          ("last_model_used", `String "llama:auto");
+        ])
+  with
+  | Ok meta ->
+      {
+        meta with
+        paused;
+        auto_resume_after_sec = (if paused then Some 3600.0 else None);
+      }
+  | Error err -> Alcotest.fail ("meta_of_json failed: " ^ err)
+
+let write_keeper_meta_exn config meta =
+  match Keeper_types.write_meta config meta with
+  | Ok () -> ()
+  | Error err -> Alcotest.fail ("keeper meta write failed: " ^ err)
+
+let test_health_json_surfaces_durable_paused_keepers () =
+  with_temp_dir "health-durable-paused-keepers" (fun dir ->
+      let config_root = make_config_root dir in
+      with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
+      let previous_state = !Server_auth.server_state in
+      Config_dir_resolver.reset ();
+      Fun.protect
+        ~finally:(fun () ->
+          Server_auth.server_state := previous_state;
+          Config_dir_resolver.reset ())
+        (fun () ->
+          let state = Mcp_server.create_state ~base_path:dir in
+          Server_auth.server_state := Some state;
+          let config = state.Mcp_server.room_config in
+          write_keeper_meta_exn config
+            (make_keeper_meta ~name:"durable-paused" ~trace_id:"trace-paused"
+               ~paused:true ());
+          write_keeper_meta_exn config
+            (make_keeper_meta ~name:"durable-active" ~trace_id:"trace-active"
+               ~paused:false ());
+          let request = Httpun.Request.create `GET "/health" in
+          let json = Server_routes_http_runtime.make_health_json request in
+          let open Yojson.Safe.Util in
+          let paused = json |> member "paused_keepers" in
+          let durable_names =
+            paused |> member "durable_names" |> to_list |> List.map to_string
+          in
+          let names = paused |> member "names" |> to_list |> List.map to_string in
+          Alcotest.(check int) "durable paused count" 1
+            (paused |> member "durable_count" |> to_int);
+          Alcotest.(check (list string)) "durable paused names"
+            [ "durable-paused" ] durable_names;
+          Alcotest.(check bool) "union includes durable paused keeper" true
+            (List.exists (( = ) "durable-paused") names);
+          Alcotest.(check bool) "union excludes active durable keeper" false
+            (List.exists (( = ) "durable-active") names);
+          Alcotest.(check int) "durable read errors" 0
+            (paused |> member "read_error_count" |> to_int)))
+
 let test_migrate_resident_keeper_dirs_promotes_valid_meta () =
   with_temp_dir "startup-legacy-keepers" (fun dir ->
       let state = Mcp_server.create_state ~base_path:dir in
@@ -2452,6 +2520,9 @@ let () =
             test_startup_state_catalog_degraded_survives_lazy_activation;
           Alcotest.test_case "liveness probe is always true" `Quick
             test_startup_state_liveness;
+          Alcotest.test_case
+            "health json surfaces durable paused keepers"
+            `Quick test_health_json_surfaces_durable_paused_keepers;
           Alcotest.test_case "readiness false before init" `Quick
             test_startup_state_readiness_before_init;
           Alcotest.test_case "readiness true after init" `Quick


### PR DESCRIPTION
## Summary
- make /health.paused_keepers count the union of live registry paused keepers and durable paused keeper meta
- expose running_* vs durable_* fields plus read_error_count/read_errors for operator diagnosis
- add a bootstrap health regression test for a durable paused keeper with no live registry entry

## Verification
- scripts/dune-local.sh build --cache=disabled test/test_server_runtime_bootstrap.exe
- ./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 31
- scripts/dune-local.sh build --cache=disabled bin/main_eio.exe
- ocamlformat --check lib/server/server_routes_http_runtime.ml lib/server/server_routes_http_runtime.mli test/test_server_runtime_bootstrap.ml
- git diff --check