### PR TITLE
Honor TOML persona names in supervisor drift checks

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -652,17 +652,27 @@ let launch_supervised_fiber
    The visibility ERROR is bounded by fleet size (~14 keepers) and
    only fires on first registration — the [is_registered] guard above
    skips repeat calls. *)
+let persona_name_for_drift_check (meta : keeper_meta) =
+  match Keeper_types_profile.load_keeper_profile_defaults_result meta.name with
+  | Ok defaults ->
+    Keeper_types_profile.resolved_persona_name ~keeper_name:meta.name defaults
+  | Error _ -> meta.name
+;;
+
+let persona_path_for_drift_check ~base_path persona_name =
+  match Config_dir_resolver.personas_dir_opt () with
+  | Some dir -> Filename.concat dir persona_name
+  | None ->
+    Filename.concat
+      (Filename.concat (Common.masc_dir_from_base_path ~base_path) "personas")
+      persona_name
+;;
+
 let log_persona_drift_if_missing ~base_path (meta : keeper_meta) =
-  match
-    Keeper_identity.normalize_all_names
-      ~input_agent_name:meta.name
-      ~base_path
-      ~check_persona:true
-      ~check_credential:false
-      ()
-  with
-  | Ok _ -> ()
-  | Error (Keeper_identity.Persona_not_found { resolved; searched; _ }) ->
+  let persona_name = persona_name_for_drift_check meta in
+  let searched = persona_path_for_drift_check ~base_path persona_name in
+  if Sys.file_exists searched then ()
+  else (
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_persona_drift_missing
       ~labels:[ "keeper", meta.name ]
@@ -672,13 +682,8 @@ let log_persona_drift_if_missing ~base_path (meta : keeper_meta) =
        runtime falls through to logging-only RFC P3-a path; operator action: create \
        persona file or remove keeper from registry"
       meta.name
-      resolved
-      searched
-  | Error _ ->
-    (* Other validation errors (Empty_input, Credential_missing — but
-         we passed check_credential:false) are not the silent-drift
-         class this hook is documenting. Stay silent to avoid noise. *)
-    ()
+      persona_name
+      searched)
 ;;
 
 let supervise_keepalive ~proactive_warmup_sec (ctx : _ context) (meta : keeper_meta) =

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -47,6 +47,11 @@ val backoff_delay : int -> float
 val keep_last_n : int -> 'a -> 'a list -> 'a list
 (** [keep_last_n n item lst] prepends [item] and keeps at most [n] entries. *)
 
+val persona_name_for_drift_check : keeper_meta -> string
+(** Resolve the persona handle used by supervisor persona-drift checks.
+    Honors keeper TOML [persona_name] overlays before falling back to
+    the keeper name. *)
+
 val supervision_cohort_size : int
 (** Target keeper count per supervisor cohort.  The first 2-level
     supervision slice groups the 64-keeper fleet as 8 cohorts of 8. *)

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -32,6 +32,37 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let rec mkdir_p path =
+  if path = "" || path = "." || path = "/" then ()
+  else if Sys.file_exists path then ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let write_file path content =
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name ""
+
+let with_config_dir f =
+  let dir = temp_dir () in
+  let config_dir = Filename.concat dir "config" in
+  mkdir_p (Filename.concat config_dir "keepers");
+  mkdir_p (Filename.concat config_dir "personas");
+  let original = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  Fun.protect
+    ~finally:(fun () ->
+      restore_env "MASC_CONFIG_DIR" original;
+      Masc_mcp.Config_dir_resolver.reset ();
+      cleanup_dir dir)
+    (fun () ->
+      Unix.putenv "MASC_CONFIG_DIR" config_dir;
+      Masc_mcp.Config_dir_resolver.reset ();
+      f config_dir)
+
 let contains_substring haystack needle =
   let haystack_len = String.length haystack in
   let needle_len = String.length needle in
@@ -208,6 +239,27 @@ let make_meta name =
   match KT.meta_of_json json with
   | Ok meta -> meta
   | Error err -> fail ("make_meta: " ^ err)
+
+let test_persona_drift_check_uses_toml_persona_name () =
+  with_config_dir @@ fun config_dir ->
+  let keepers_dir = Filename.concat config_dir "keepers" in
+  let executor_persona_dir =
+    Filename.concat (Filename.concat config_dir "personas") "executor"
+  in
+  mkdir_p executor_persona_dir;
+  write_file
+    (Filename.concat executor_persona_dir "profile.json")
+    {|{"name":"Executor","role":"execution"}|};
+  write_file
+    (Filename.concat keepers_dir "glm-coding-plan.toml")
+    {|
+[keeper]
+name = "glm-coding-plan"
+persona_name = "executor"
+goal = "plan coding work"
+|};
+  check string "drift check honors TOML persona_name" "executor"
+    (Sup.persona_name_for_drift_check (make_meta "glm-coding-plan"))
 
 let registered_entries names =
   Reg.clear ();
@@ -1555,6 +1607,10 @@ let () =
       test_case "under limit" `Quick test_keep_last_n_under_limit;
       test_case "at limit" `Quick test_keep_last_n_at_limit;
       test_case "over limit drops oldest" `Quick test_keep_last_n_over_limit;
+    ];
+    "persona_drift", [
+      test_case "drift check honors TOML persona_name" `Quick
+        test_persona_drift_check_uses_toml_persona_name;
     ];
     "fiber_health", [
       test_case "unknown for unregistered" `Quick test_fiber_health_unknown;


### PR DESCRIPTION
## Summary
- make supervisor persona-drift checks resolve keeper TOML persona_name overlays before checking persona directories
- stop false persona_drift errors for keepers like glm-coding-plan and taskmaster that intentionally borrow executor/velvet-hammer personas
- add a focused supervisor regression test

## Verification
- scripts/dune-local.sh build --cache=disabled test/test_keeper_supervisor.exe
- ./_build/default/test/test_keeper_supervisor.exe test persona_drift 0
- scripts/dune-local.sh build --cache=disabled bin/main_eio.exe
- ocamlformat --check lib/keeper/keeper_supervisor.ml lib/keeper/keeper_supervisor.mli test/test_keeper_supervisor.ml
- git diff --check