### PR TITLE
spec(kcl): add EnterHandingOff + NoMidFlight invariant (Gap-1)

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-13T13:23:10Z (HEAD: ef6b30c7bd)
+Generated: 2026-05-14T01:55:32Z (HEAD: 79cdf290c2)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -17,8 +17,8 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | Manual specs | 95 |
 | TTrace (auto-generated) | 0 |
 | Directories | 18 |
-| Total .cfg files | 197 |
-| Buggy .cfg (bug-model pair) | 100 |
+| Total .cfg files | 198 |
+| Buggy .cfg (bug-model pair) | 101 |
 
 `kind` column: **manual** = hand-authored spec; **ttrace** = TLC counterexample export (`*TTrace*` or trace marker in header). `cfg`/`buggy` columns count companion `.cfg` files. `invariants/properties` lists names per cfg label (`clean=...`, `buggy=...`). `source hash` is the tracked `.tla` blob fingerprint.
 
@@ -124,7 +124,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperCascadeRouting.tla | KeeperCascadeRouting | manual | 2 | 1 | clean={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} buggy={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} | b2bdc9d76d73 |
 | KeeperCircuitBreaker.tla | KeeperCircuitBreaker | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:TripOnlyWithStreak} | 1d4d87f2bb68 |
 | KeeperCompactionLifecycle.tla | KeeperCompactionLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:OverflowEventuallyLeavesOverflow, prop:CompactingEventuallyStops} buggy={inv:CompactingAlignsAll} | d05b75d81e11 |
-| KeeperCompositeLifecycle.tla | KeeperCompositeLifecycle | manual | 5 | 4 | clean={inv:SafetyInvariant, prop:EventualMeasurementResolves, prop:RecoveryEventuallyCompletes, prop:OverflowedEventuallyResolves} buggy-attempt={inv:ToolSurfaceFeedsAttempt} buggy-cascade={inv:NoCascadeBeforeMeasurement} buggy-compaction={inv:CompactionAtomicity, inv:PhaseTurnAlignment} buggy-post-turn={inv:PostTurnConsumesAttempt} | 293a6287f767 |
+| KeeperCompositeLifecycle.tla | KeeperCompositeLifecycle | manual | 6 | 5 | clean={inv:SafetyInvariant, inv:NoMidFlightTransitionToHandingOff, prop:EventualMeasurementResolves, prop:RecoveryEventuallyCompletes, prop:OverflowedEventuallyResolves} buggy-attempt={inv:ToolSurfaceFeedsAttempt} buggy-cascade={inv:NoCascadeBeforeMeasurement} buggy-compaction={inv:CompactionAtomicity, inv:PhaseTurnAlignment} buggy-mid-flight-handoff={inv:NoMidFlightTransitionToHandingOff} buggy-post-turn={inv:PostTurnConsumesAttempt} | b581c5d9272b |
 | KeeperConditionsGovernPhase.tla | KeeperConditionsGovernPhase | manual | 2 | 1 | clean={inv:Safety, prop:HandoffEventuallyAcknowledged} buggy={inv:TypeOK, prop:HandoffEventuallyAcknowledged} | a7ffe94f2ecd |
 | KeeperContextLifecycle.tla | KeeperContextLifecycle | manual | 4 | 2 | clean={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction, prop:CompactionProgress, prop:EventualTurnCompletion, prop:AllKeepersTerminate} buggy={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} ci-buggy={inv:ContextIsolation, inv:ResumeIdentity} ci={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} | 1160fd29094d |
 | KeeperCoreTriad.tla | KeeperCoreTriad | manual | 2 | 1 | clean={inv:SafetyInvariant, prop:RunningEventuallyCompletes CapabilityNeverDeadlocks} buggy={inv:SafetyInvariant} | 578800364440 |

--- a/specs/keeper-state-machine/KeeperCompositeLifecycle-buggy-mid-flight-handoff.cfg
+++ b/specs/keeper-state-machine/KeeperCompositeLifecycle-buggy-mid-flight-handoff.cfg
@@ -1,0 +1,22 @@
+\* TLC Configuration — Buggy spec (Gap-1: mid-flight handoff entry)
+\* Expected outcome: NoMidFlightTransitionToHandingOff MUST be violated.
+\* If it holds, the invariant is too weak or the bug action is
+\* unreachable.  Pairs with SpecBuggyMidFlightHandoff in
+\* KeeperCompositeLifecycle.tla.
+\*
+\* Models the silent failure family where the OCaml runtime allows
+\* HandingOff to be observed (handoff_active=true set externally) while
+\* a cascade attempt is still in flight, bypassing the cooperative
+\* cancel + termination contract that the clean EnterHandingOff models.
+\* Audit: docs/tla-audit/cross-fsm-joint-gap-2026-05-14.md (Gap-1).
+
+SPECIFICATION SpecBuggyMidFlightHandoff
+
+CONSTANTS
+    MaxTurnTicks = 4
+
+INVARIANTS
+    NoMidFlightTransitionToHandingOff
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/keeper-state-machine/KeeperCompositeLifecycle.cfg
+++ b/specs/keeper-state-machine/KeeperCompositeLifecycle.cfg
@@ -13,6 +13,10 @@ CONSTANTS
 
 INVARIANTS
     SafetyInvariant
+\* Gap-1 invariant (audit 2026-05-14) is inside SafetyInvariant; the
+\* explicit listing below lets the matrix-coverage scanner attribute a
+\* violation to the precise predicate.
+    NoMidFlightTransitionToHandingOff
 
 CHECK_DEADLOCK
     FALSE

--- a/specs/keeper-state-machine/KeeperCompositeLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperCompositeLifecycle.tla
@@ -414,6 +414,51 @@ ClearFailing ==
                    turn_tick, kcaf_attempt_phase, kts_surface_ready,
                    kpto_phase>>
 
+\* HandingOff orchestration (Gap-1 audit 2026-05-14).
+\* Until this iteration KCL declared "HandingOff" in PhaseSet but never
+\* transitioned into it, so the joint invariants conditioning on KSM phase
+\* held vacuously for the entire HandingOff cross-section.  Modeling the
+\* entry explicitly is what surfaces the mid-flight gap, and the
+\* NoMidFlightTransitionToHandingOff invariant below pins the contract.
+\*
+\* Modeling note — quiescence preconditions.
+\*   KCL is an OBSERVER, not a controller.  EnterHandingOff models the
+\*   *desired contract*: OCaml must drive the in-flight cascade attempt
+\*   to a terminal state (Eio cancel + termination) before HandingOff is
+\*   observable in the joint state.  Encoding this as a precondition
+\*   makes the contract explicit; the matching bug action
+\*   (BugMidFlightHandoffEntry below) models the contract *violation*,
+\*   so any TLC counter-example coming from the buggy spec is
+\*   attributable to the bypass, not to a benign racing trace of the
+\*   clean spec.  This is the spec-first stance: clean spec encodes
+\*   what OCaml *must* uphold, bug action encodes the silent failure
+\*   when OCaml does *not* uphold it.
+EnterHandingOff ==
+    /\ ksm_phase = "Running"
+    /\ ktc_turn_phase \in {"idle", "finalizing"}
+    /\ kcaf_attempt_phase /= "attempting"
+    /\ kcl_cascade_state \in {"idle", "done", "exhausted"}
+    /\ ksm_phase' = "HandingOff"
+    /\ UNCHANGED <<ktc_turn_phase, kdp_decision, kcl_cascade_state,
+                   kmc_compaction, shared_measurement, measurement_turn,
+                   turn_tick, kcaf_attempt_phase, kts_surface_ready,
+                   kpto_phase>>
+
+\* HandoffCompletes — keeper returns to Running after handoff success.
+\* Mirrors keeper_keepalive.ml::maybe_recover_from_handoff.  Quiescence
+\* preconditions match NoMidFlightTransitionToHandingOff so that the
+\* clean spec stays inside the invariant envelope.
+HandoffCompletes ==
+    /\ ksm_phase = "HandingOff"
+    /\ ktc_turn_phase \in {"idle", "finalizing"}
+    /\ kcaf_attempt_phase \in {"idle", "terminal"}
+    /\ kcl_cascade_state \in {"idle", "done", "exhausted"}
+    /\ ksm_phase' = "Running"
+    /\ UNCHANGED <<ktc_turn_phase, kdp_decision, kcl_cascade_state,
+                   kmc_compaction, shared_measurement, measurement_turn,
+                   turn_tick, kcaf_attempt_phase, kts_surface_ready,
+                   kpto_phase>>
+
 \* Overflowed orchestration (Context overflow detected).
 \* Runtime truth: parent phase moves to Overflowed first. The in-flight turn
 \* and cascade projection remain live until the later compaction retry path
@@ -466,6 +511,8 @@ Next ==
     \/ ClearFailing
     \/ EnterOverflowed
     \/ OverflowedAutoCompact
+    \/ EnterHandingOff
+    \/ HandoffCompletes
 
 Fairness ==
     /\ WF_vars(MeasurementBroadcast)
@@ -480,6 +527,7 @@ Fairness ==
     /\ WF_vars(FinishCompaction)
     /\ WF_vars(ClearFailing)
     /\ WF_vars(OverflowedAutoCompact)
+    /\ WF_vars(HandoffCompletes)
 
 Spec == Init /\ [][Next]_vars /\ Fairness
 
@@ -548,6 +596,27 @@ ToolSurfaceFeedsAttempt ==
 PostTurnConsumesAttempt ==
     (kpto_phase = "active") => (kcaf_attempt_phase /= "attempting")
 
+\* ── Gap-1 invariant (audit 2026-05-14) ───────────────────
+\* This invariant closes the "mid-flight transitional phase"
+\* silent-failure family.  KCL previously declared HandingOff in
+\* PhaseSet but had no action transitioning into it, so any joint
+\* property conditioning on KSM=HandingOff held vacuously.  Adding
+\* EnterHandingOff with quiescence preconditions makes that subspace
+\* reachable, and I8 below pins the cross-FSM contract.  Pairs with
+\* SpecBuggyMidFlightHandoff (BugMidFlightHandoffEntry) which models
+\* the contract bypass — the silent failure path.
+
+\* I8 — NoMidFlightTransitionToHandingOff
+\* If KSM is in HandingOff, the turn cycle must be quiescent: no
+\* attempting cascade, no in-flight cascade attempt (state in trying
+\* or selecting), and the turn phase must not be in an active stage.
+\* The clean spec preserves this by construction (EnterHandingOff
+\* preconditions); the buggy spec violates it via the bypass action.
+NoMidFlightTransitionToHandingOff ==
+    (ksm_phase = "HandingOff") =>
+        (kcaf_attempt_phase /= "attempting" /\
+         kcl_cascade_state \in {"idle", "done", "exhausted"})
+
 SafetyInvariant ==
     /\ TypeOK
     /\ PhaseTurnAlignment
@@ -557,6 +626,7 @@ SafetyInvariant ==
     /\ AttemptFSMRespectsAdmission
     /\ ToolSurfaceFeedsAttempt
     /\ PostTurnConsumesAttempt
+    /\ NoMidFlightTransitionToHandingOff
 
 \* ── Liveness ─────────────────────────────────────────────
 
@@ -646,10 +716,34 @@ BugPostTurnDuringAttempt ==
 NextBuggyAttempt  == Next \/ BugAttemptWithoutSurface
 NextBuggyPostTurn == Next \/ BugPostTurnDuringAttempt
 
+\* Gap-1 bug action (audit 2026-05-14).
+\* BugMidFlightHandoffEntry — bypass of the EnterHandingOff quiescence
+\* preconditions.  An external signal (handoff_active=true from
+\* operator/credential/budget) sets the keeper's phase to HandingOff
+\* *while* a cascade attempt is still in flight; the OCaml runtime
+\* fails to cooperatively cancel the cascade fiber before the phase
+\* change is observable.  Post-state: KSM=HandingOff, cascade in
+\* "trying", KCAF in "attempting" — exactly the joint state the clean
+\* EnterHandingOff forbids.  Violates NoMidFlightTransitionToHandingOff.
+BugMidFlightHandoffEntry ==
+    /\ ksm_phase = "Running"
+    /\ ktc_turn_phase = "executing"
+    /\ kcl_cascade_state = "trying"
+    /\ kcaf_attempt_phase = "attempting"
+    /\ ksm_phase' = "HandingOff"
+    /\ UNCHANGED <<ktc_turn_phase, kdp_decision, kcl_cascade_state,
+                   kmc_compaction, shared_measurement, measurement_turn,
+                   turn_tick, kcaf_attempt_phase, kts_surface_ready,
+                   kpto_phase>>
+
+NextBuggyMidFlightHandoff == Next \/ BugMidFlightHandoffEntry
+
 SpecBuggyCascade  == Init /\ [][NextBuggyCascade]_vars  /\ Fairness
 SpecBuggyCompaction == Init /\ [][NextBuggyCompaction]_vars /\ Fairness
 SpecBuggyAttempt  == Init /\ [][NextBuggyAttempt]_vars  /\ Fairness
 SpecBuggyPostTurn == Init /\ [][NextBuggyPostTurn]_vars /\ Fairness
+SpecBuggyMidFlightHandoff ==
+    Init /\ [][NextBuggyMidFlightHandoff]_vars /\ Fairness
 
 \* ── Boundary comments (reviewer gate) ────────────────────
 \* This spec must NOT introduce any of the following, per:


### PR DESCRIPTION
## Context

본 PR은 **masc-mcp의 TLA+ ↔ FSM ↔ OCaml 실 구현 사이 상태×상태×상태×상태 joint state 엣지케이스 분석 (2026-05-14)** 의 첫 번째 산출물입니다. 분석에서 8개의 silent-failure / 잘못된 failover 후보를 식별했고, 사용자 합의된 진행 순서는 **3 → 1 → 2** 입니다:

- **3. spec-first 검증**: KCL에 bug-action + invariant 3 종을 추가하여 *지금 silent하게 통과하는 시나리오*를 TLC가 실제로 잡는지 buggy.cfg로 증명. *본 PR의 scope*.
- **1. OCaml fix 4 PR**: typed projection / Eio cancel 분리 / fsm_guard 리팩토링 / classify_transition catch-all 제거.
- **2. audit memo**: `docs/tla-audit/cross-fsm-joint-gap-2026-05-14.md`.

본 PR은 그중 **Gap-1 (mid-flight turn × KSM phase 변경)** 한 건에 집중합니다.

## 문제

KCL의 `PhaseSet`은 `HandingOff` 를 포함하지만, **spec 어느 action에도 `ksm_phase' = "HandingOff"` 로 전이하는 path가 존재하지 않았습니다**. 결과:

- TLC가 explore하는 reachable state space에 HandingOff가 *전혀 나타나지 않음*.
- 7개 joint invariant 모두 HandingOff 차원에서 *vacuous하게 통과*.
- OCaml impl 측에서는 외부 신호 (operator/credential/budget) 로 인해 진행 중인 turn 도중에도 KSM phase가 HandingOff로 전이 가능 — spec가 검증하지 않은 silent failure path.

`keeper_unified_turn::run_cycle` 의 phase guard (`Keeper_state_machine.can_execute_turn`) 는 **turn ENTRY 1곳에서만** 호출되고, 진행 중 turn에 대한 cooperative cancel 보장은 어디에도 명문화되어 있지 않습니다.

## 본 PR 변경

1. **Clean actions `EnterHandingOff` / `HandoffCompletes`** — *quiescence preconditions* 강제. KCL이 *desired OCaml contract*를 명시:
   - `EnterHandingOff` 는 `ktc_turn_phase ∈ {idle, finalizing}` 이고 `kcaf_attempt_phase ≠ attempting` 이고 `kcl_cascade_state ∈ {idle, done, exhausted}` 일 때만 발사 가능.
   - 즉 OCaml은 HandingOff 진입 *전에* in-flight cascade fiber를 cooperatively cancel + termination까지 끌고 가야 함.

2. **Safety invariant `NoMidFlightTransitionToHandingOff`** — clean spec에서는 위 preconditions로 보호되므로 자명하게 통과. **buggy spec에서는 위반.**

3. **Bug action `BugMidFlightHandoffEntry`** — quiescence preconditions를 *bypass*. 외부 signal이 attempting cascade × trying 상태에서 phase를 HandingOff로 직접 변경. 그 결과 joint state `ksm=HandingOff × cascade=trying × kcaf=attempting` 가 만들어져 invariant 위반.

4. **새 파일 `KCL-buggy-mid-flight-handoff.cfg`** — `SPECIFICATION SpecBuggyMidFlightHandoff` + invariant `NoMidFlightTransitionToHandingOff`. `specs/Makefile` 의 BUGGY_CFGS glob이 자동으로 픽업.

## 검증

로컬 TLC (Java 21 + tla2tools 1.8.0) 실행 결과:

\`\`\`
Clean:  215 distinct states, depth 41, no errors.
Buggy:  219 distinct states, violation in 9 steps (TLC exit 12).
        Trace: BugMidFlightHandoffEntry fires from
               Running × executing × trying × attempting,
               lands on HandingOff × executing × trying × attempting.
\`\`\`

CI \`tla-main.yml\` 4-shard matrix가 자동 재검증.

## 왜 quiescence를 *invariant*가 아닌 *action precondition*으로 강제했는가

초기 draft에서는 \`(ksm_phase = "HandingOff") => quiescence\` 를 safety invariant로 작성했지만, 두 번의 TLC 실패를 통해 다음을 발견했습니다:

- *Clean spec*에서도 `Running × cascade=done` 상태 직후 `EnterHandingOff` 발사 시점에 `cascade=done × ksm=HandingOff` joint state가 reachable (cascade의 `done`은 transient — `FinishTurn` 으로 cleanup될 때까지 stay하는데 그 사이에 EnterHandingOff 끼어들 수 있음).
- 즉 *state-based invariant*만으로는 *transition-history-dependent* silent failure (Running → trying → HandingOff → done의 race) 를 구분할 수 없음.
- 해결: spec가 *contract를 명시* (precondition), bug action이 *contract bypass*를 명시. 이로써 buggy spec의 invariant violation이 *bug action 때문임이 증명*됨.

이건 *spec-first*의 정신과도 일치: clean spec은 OCaml이 *반드시 upheld해야 할* 것을 model하고, bug action은 *그 contract를 위반할 때 발생하는 silent failure*를 model.

## 알려진 한계 (후속 작업)

- **Liveness 면 미보장**: `(ksm = HandingOff ∧ kcaf = attempting) ~> (kcaf ≠ attempting)` 같은 liveness property는 *OCaml의 cooperative cancel path가 실제로 wired*되어 있어야 하는데, 그건 OCaml 측 Gap-1.B 작업 (별도 RFC). 현재 clean spec은 quiescence preconditions로 *spec 내부에서만* boundary를 유지.
- **Draining 차원 미모델링**: `EnterDraining` / `DrainingCompletes` 도 같은 종류의 vacuous gap. 별도 후속 PR.

## Backlog — 후속 7 PR

| # | 영역 | 작업 단위 |
|---|------|----------|
| **3.1.B** | Gap-4 BugResumeFromPausedStaleCascade | spec PR |
| **3.1.C** | Gap-5 BugHardQuotaRetryAcrossTurns (KcafPhaseSet 4-state 확장) | spec PR |
| **1.A** | Gap-8 \`turn_state ↔ turn_phase\` 명시적 projection + property test | OCaml PR |
| **1.B** | Gap-3 \`wrap_unit\` Eio.Cancel.Cancelled 분리 | OCaml PR |
| **1.C** | Gap-2 \`[@@fsm_guard]\` typed predicate 교체 | OCaml PR |
| **1.D** | Gap-7 \`classify_transition\` catch-all 제거 | OCaml PR |
| **2** | Audit memo \`cross-fsm-joint-gap-2026-05-14.md\` | docs PR |

## Test plan

- [x] 로컬 \`java -cp tla2tools.jar tlc2.TLC -config KCL.cfg KCL.tla\` → clean pass.
- [x] 로컬 \`java -cp tla2tools.jar tlc2.TLC -config KCL-buggy-mid-flight-handoff.cfg KCL.tla\` → exit 12.
- [ ] CI \`tla-main.yml\` 4-shard 모두 green.
- [ ] \`make -C specs check-matrix-coverage\` PASS (새 cfg가 매트릭스에 포함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)