### PR TITLE
feat(ide): show focused context on code lines

### DIFF
--- a/dashboard/src/components/ide/ide-editor-extensions.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.ts
@@ -1,4 +1,4 @@
-import { Decoration, EditorView, GutterMarker, gutter, lineNumbers, type DecorationSet, type ViewUpdate } from '@codemirror/view'
+import { Decoration, EditorView, GutterMarker, WidgetType, gutter, lineNumbers, type DecorationSet, type ViewUpdate } from '@codemirror/view'
 import { Annotation, EditorState, Extension, StateField, StateEffect } from '@codemirror/state'
 import {
   defaultHighlightStyle,
@@ -114,6 +114,26 @@ export function themeExt(): Extension {
     '.cm-line.cm-masc-context-focus': {
       background: 'color-mix(in srgb, var(--color-accent-fg) 12%, transparent)',
       boxShadow: 'inset 2px 0 0 var(--color-accent-fg)',
+    },
+    '.cm-masc-context-focus-chip': {
+      display: 'inline-flex',
+      alignItems: 'center',
+      maxWidth: '36ch',
+      marginLeft: 'var(--sp-2)',
+      padding: '0 var(--sp-2)',
+      border: '1px solid var(--color-border-default)',
+      borderRadius: 'var(--r-0)',
+      background: 'var(--color-bg-elevated)',
+      color: 'var(--color-accent-fg)',
+      fontFamily: 'var(--font-mono)',
+      fontSize: 'var(--fs-10)',
+      lineHeight: '1.4',
+      verticalAlign: 'baseline',
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      pointerEvents: 'none',
+      userSelect: 'none',
     },
   })
 }
@@ -243,7 +263,39 @@ export function keeperLineSelectExt(
 
 // ── Context focus highlight ───────────────────────────────────────
 
-const setContextFocusLine = StateEffect.define<number | null>()
+export interface EditorContextFocusLine {
+  readonly line: number
+  readonly surface?: string
+  readonly label?: string
+  readonly keeperId?: string
+  readonly linkCount?: number
+}
+
+const setContextFocusLine = StateEffect.define<EditorContextFocusLine | null>()
+
+class ContextFocusChip extends WidgetType {
+  constructor(private readonly focus: EditorContextFocusLine) {
+    super()
+  }
+
+  toDOM(): HTMLElement {
+    const el = document.createElement('span')
+    el.className = 'cm-masc-context-focus-chip'
+    const parts = contextFocusChipParts(this.focus)
+    el.textContent = parts.join(' · ')
+    el.title = `Focused ${parts.join(' · ')}`
+    el.setAttribute('aria-label', contextFocusChipAriaLabel(this.focus))
+    return el
+  }
+
+  eq(other: ContextFocusChip): boolean {
+    return this.focus.line === other.focus.line
+      && this.focus.surface === other.focus.surface
+      && this.focus.label === other.focus.label
+      && this.focus.keeperId === other.focus.keeperId
+      && this.focus.linkCount === other.focus.linkCount
+  }
+}
 
 const contextFocusLineField = StateField.define<DecorationSet>({
   create() {
@@ -253,13 +305,17 @@ const contextFocusLineField = StateField.define<DecorationSet>({
     const mapped = value.map(tr.changes)
     for (const effect of tr.effects) {
       if (!effect.is(setContextFocusLine)) continue
-      const lineNumber = effect.value
-      if (lineNumber === null || lineNumber < 1 || lineNumber > tr.state.doc.lines) {
+      const focus = effect.value
+      if (focus === null || focus.line < 1 || focus.line > tr.state.doc.lines) {
         return Decoration.none
       }
-      const line = tr.state.doc.line(lineNumber)
+      const line = tr.state.doc.line(focus.line)
       return Decoration.set([
         Decoration.line({ class: 'cm-masc-context-focus' }).range(line.from),
+        Decoration.widget({
+          widget: new ContextFocusChip(focus),
+          side: 1,
+        }).range(line.to),
       ])
     }
     return mapped
@@ -271,21 +327,39 @@ export function contextFocusLineExt(): Extension {
   return contextFocusLineField
 }
 
-export function focusEditorContextLine(view: EditorView, lineNumber: number | undefined): boolean {
-  if (lineNumber === undefined || lineNumber < 1 || lineNumber > view.state.doc.lines) {
+export function focusEditorContextLine(
+  view: EditorView,
+  focus: number | EditorContextFocusLine | undefined,
+): boolean {
+  const nextFocus = typeof focus === 'number' ? { line: focus } : focus
+  if (nextFocus === undefined || nextFocus.line < 1 || nextFocus.line > view.state.doc.lines) {
     view.dispatch({ effects: [setContextFocusLine.of(null)] })
     return false
   }
-  const line = view.state.doc.line(lineNumber)
+  const line = view.state.doc.line(nextFocus.line)
   view.dispatch({
     selection: { anchor: line.from },
     effects: [
-      setContextFocusLine.of(lineNumber),
+      setContextFocusLine.of(nextFocus),
       EditorView.scrollIntoView(line.from, { y: 'center' }),
     ],
   })
   view.focus()
   return true
+}
+
+function contextFocusChipParts(focus: EditorContextFocusLine): ReadonlyArray<string> {
+  return [
+    focus.surface?.trim() || `L${focus.line}`,
+    focus.label?.trim() || null,
+    focus.keeperId?.trim() ? `keeper ${focus.keeperId.trim()}` : null,
+    focus.linkCount && focus.linkCount > 0 ? `${focus.linkCount} links` : null,
+  ].filter((part): part is string => part !== null)
+}
+
+function contextFocusChipAriaLabel(focus: EditorContextFocusLine): string {
+  const parts = contextFocusChipParts(focus)
+  return `Focused context on line ${focus.line}: ${parts.join(', ')}`
 }
 
 // ── Language support (dynamic import) ─────────────────────────────

--- a/dashboard/src/components/ide/ide-editor-extensions.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.ts
@@ -1,5 +1,5 @@
 import { Decoration, EditorView, GutterMarker, WidgetType, gutter, lineNumbers, type DecorationSet, type ViewUpdate } from '@codemirror/view'
-import { Annotation, EditorState, Extension, StateField, StateEffect } from '@codemirror/state'
+import { Annotation, EditorState, Extension, RangeSetBuilder, StateField, StateEffect, type Text } from '@codemirror/state'
 import {
   defaultHighlightStyle,
   StreamLanguage,
@@ -125,6 +125,26 @@ export function themeExt(): Extension {
       borderRadius: 'var(--r-0)',
       background: 'var(--color-bg-elevated)',
       color: 'var(--color-accent-fg)',
+      fontFamily: 'var(--font-mono)',
+      fontSize: 'var(--fs-10)',
+      lineHeight: '1.4',
+      verticalAlign: 'baseline',
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      pointerEvents: 'none',
+      userSelect: 'none',
+    },
+    '.cm-masc-annotation-chip': {
+      display: 'inline-flex',
+      alignItems: 'center',
+      maxWidth: '34ch',
+      marginLeft: 'var(--sp-2)',
+      padding: '0 var(--sp-2)',
+      border: '1px solid var(--color-border-default)',
+      borderRadius: 'var(--r-0)',
+      background: 'var(--color-bg-surface)',
+      color: 'var(--color-fg-muted)',
       fontFamily: 'var(--font-mono)',
       fontSize: 'var(--fs-10)',
       lineHeight: '1.4',
@@ -360,6 +380,132 @@ function contextFocusChipParts(focus: EditorContextFocusLine): ReadonlyArray<str
 function contextFocusChipAriaLabel(focus: EditorContextFocusLine): string {
   const parts = contextFocusChipParts(focus)
   return `Focused context on line ${focus.line}: ${parts.join(', ')}`
+}
+
+// ── Annotation line chips ─────────────────────────────────────────
+
+export interface EditorAnnotationLine {
+  readonly id: string
+  readonly line: number
+  readonly kind: string
+  readonly keeperId: string
+  readonly goalId?: string | null
+  readonly taskId?: string | null
+}
+
+const setAnnotationLines = StateEffect.define<ReadonlyArray<EditorAnnotationLine>>()
+
+class AnnotationLineChip extends WidgetType {
+  constructor(private readonly annotations: ReadonlyArray<EditorAnnotationLine>) {
+    super()
+  }
+
+  toDOM(): HTMLElement {
+    const el = document.createElement('span')
+    el.className = 'cm-masc-annotation-chip'
+    const text = annotationLineChipText(this.annotations)
+    el.textContent = text
+    el.title = annotationLineChipTitle(this.annotations)
+    el.setAttribute('aria-label', annotationLineChipAriaLabel(this.annotations))
+    return el
+  }
+
+  eq(other: AnnotationLineChip): boolean {
+    return annotationLineKey(this.annotations) === annotationLineKey(other.annotations)
+  }
+}
+
+const annotationLineField = StateField.define<DecorationSet>({
+  create() {
+    return Decoration.none
+  },
+  update(value, tr) {
+    const mapped = value.map(tr.changes)
+    for (const effect of tr.effects) {
+      if (!effect.is(setAnnotationLines)) continue
+      return buildAnnotationLineDecorations(tr.state.doc, effect.value)
+    }
+    return mapped
+  },
+  provide: field => EditorView.decorations.from(field),
+})
+
+export function annotationLineChipExt(): Extension {
+  return annotationLineField
+}
+
+export function pushAnnotationLines(
+  view: EditorView,
+  annotations: ReadonlyArray<EditorAnnotationLine>,
+): void {
+  view.dispatch({ effects: [setAnnotationLines.of(annotations)] })
+}
+
+function buildAnnotationLineDecorations(
+  doc: Text,
+  annotations: ReadonlyArray<EditorAnnotationLine>,
+): DecorationSet {
+  const byLine = new Map<number, EditorAnnotationLine[]>()
+  for (const annotation of annotations) {
+    if (annotation.line < 1 || annotation.line > doc.lines) continue
+    const existing = byLine.get(annotation.line) ?? []
+    existing.push(annotation)
+    byLine.set(annotation.line, existing)
+  }
+  const builder = new RangeSetBuilder<Decoration>()
+  const sortedLines = [...byLine.entries()].sort(([left], [right]) => left - right)
+  for (const [lineNumber, lineAnnotations] of sortedLines) {
+    const line = doc.line(lineNumber)
+    builder.add(
+      line.to,
+      line.to,
+      Decoration.widget({
+        widget: new AnnotationLineChip(lineAnnotations.sort(annotationLineSort)),
+        side: 2,
+      }),
+    )
+  }
+  return builder.finish()
+}
+
+function annotationLineSort(left: EditorAnnotationLine, right: EditorAnnotationLine): number {
+  return left.kind.localeCompare(right.kind)
+    || left.keeperId.localeCompare(right.keeperId)
+    || left.id.localeCompare(right.id)
+}
+
+function annotationLineChipText(annotations: ReadonlyArray<EditorAnnotationLine>): string {
+  const first = annotations[0]
+  if (!first) return 'Annotation'
+  const parts = [
+    first.kind,
+    first.goalId ? `goal ${first.goalId}` : null,
+    first.taskId ? `task ${first.taskId}` : null,
+    `keeper ${first.keeperId}`,
+    annotations.length > 1 ? `+${annotations.length - 1}` : null,
+  ].filter((part): part is string => part !== null)
+  return parts.join(' · ')
+}
+
+function annotationLineChipTitle(annotations: ReadonlyArray<EditorAnnotationLine>): string {
+  return annotations.map(annotation => [
+    annotation.kind,
+    annotation.goalId ? `goal ${annotation.goalId}` : null,
+    annotation.taskId ? `task ${annotation.taskId}` : null,
+    `keeper ${annotation.keeperId}`,
+  ].filter((part): part is string => part !== null).join(' · ')).join('\n')
+}
+
+function annotationLineChipAriaLabel(annotations: ReadonlyArray<EditorAnnotationLine>): string {
+  const first = annotations[0]
+  const line = first?.line ?? 0
+  return `Line ${line} annotation context: ${annotationLineChipText(annotations)}`
+}
+
+function annotationLineKey(annotations: ReadonlyArray<EditorAnnotationLine>): string {
+  return annotations.map(annotation =>
+    `${annotation.id}:${annotation.line}:${annotation.kind}:${annotation.keeperId}:${annotation.goalId ?? ''}:${annotation.taskId ?? ''}`,
+  ).join('|')
 }
 
 // ── Language support (dynamic import) ─────────────────────────────

--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -194,6 +194,74 @@ describe('IdeEditor', () => {
       .toContain('1 note')
   })
 
+  it('renders loaded annotations as compact context chips on code lines', async () => {
+    const documentStore = createCodeDocumentStore({
+      file_path: 'runtime.ts',
+      language: 'typescript',
+      content: 'const runtime = 1\nconst other = 2\n',
+    })
+    const ownershipStore = createKeeperLineOwnershipStore('runtime.ts')
+
+    render(
+      h(IdeEditor, {
+        documentStore,
+        ownershipStore,
+        diffRows: () => [],
+        annotations: [
+          {
+            id: 'ann-1',
+            file_path: 'runtime.ts',
+            line_start: 1,
+            line_end: 1,
+            keeper_id: 'sangsu',
+            kind: 'Comment',
+            content: 'Keep this task linked to the line',
+            goal_id: 'goal-1',
+            task_id: 'task-1',
+            created_at_ms: 1,
+            updated_at_ms: 1,
+          },
+          {
+            id: 'ann-2',
+            file_path: 'runtime.ts',
+            line_start: 1,
+            line_end: 1,
+            keeper_id: 'reviewer',
+            kind: 'Question',
+            content: 'Is this still the active goal?',
+            goal_id: null,
+            task_id: null,
+            created_at_ms: 2,
+            updated_at_ms: 2,
+          },
+          {
+            id: 'ann-other-file',
+            file_path: 'other.ts',
+            line_start: 1,
+            line_end: 1,
+            keeper_id: 'other',
+            kind: 'Comment',
+            content: 'Not this file',
+            goal_id: null,
+            task_id: null,
+            created_at_ms: 3,
+            updated_at_ms: 3,
+          },
+        ],
+      }),
+      container,
+    )
+
+    await waitFor(() => {
+      const chip = container.querySelector('.cm-masc-annotation-chip')
+      expect(chip?.textContent)
+        .toBe('Comment · goal goal-1 · task task-1 · keeper sangsu · +1')
+    })
+    expect(container.querySelectorAll('.cm-masc-annotation-chip')).toHaveLength(1)
+    expect(container.querySelector('.cm-masc-annotation-chip')?.getAttribute('aria-label'))
+      .toBe('Line 1 annotation context: Comment · goal goal-1 · task task-1 · keeper sangsu · +1')
+  })
+
   it('shows and highlights the focused context line from the shared IDE signal', async () => {
     const documentStore = createCodeDocumentStore({
       file_path: 'runtime.ts',

--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -244,7 +244,11 @@ describe('IdeEditor', () => {
       expect(container.querySelector('[data-testid="ide-context-focus-status"]')?.textContent)
         .toContain('Focused L2')
       expect(container.querySelector('.cm-masc-context-focus')).not.toBeNull()
+      expect(container.querySelector('.cm-masc-context-focus-chip')?.textContent)
+        .toContain('Task · task task-runtime · keeper sangsu · 2 links')
     })
+    expect(container.querySelector('.cm-masc-context-focus-chip')?.getAttribute('aria-label'))
+      .toBe('Focused context on line 2: Task, task task-runtime, keeper sangsu, 2 links')
     const focusMeta = [...container.querySelectorAll('.ide-editor-context-focus-meta > span')]
       .map(node => node.textContent)
     expect(focusMeta).toEqual(['Task', 'keeper sangsu', 'source event-1', '2 links'])

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -21,7 +21,9 @@ import {
   keeperLineSelectExt,
   contextFocusLineExt,
   focusEditorContextLine,
+  annotationLineChipExt,
   pushOwnership,
+  pushAnnotationLines,
   internalDocumentSync,
   syntaxHighlightExt,
 } from './ide-editor-extensions'
@@ -244,6 +246,7 @@ export function IdeEditor({
               keepers=${keepers}
               onKeeperLineSelect=${onKeeperLineSelect}
               contextFocus=${currentFileFocus}
+              annotations=${annotations}
             />`
       }
     </div>
@@ -552,6 +555,7 @@ function CodeMirrorEditor({
   showBlame,
   keepers,
   onKeeperLineSelect,
+  annotations = [],
   contextFocus,
 }: {
   readonly documentStore: CodeDocumentStore
@@ -570,6 +574,10 @@ function CodeMirrorEditor({
 
   const document = documentStore.document()
   const ownership = ownershipStore.ownership()
+  const currentFileAnnotations = useMemo(
+    () => annotations.filter(annotation => annotation.file_path === document.file_path),
+    [annotations, document.file_path],
+  )
 
   // Mount CM6 instance
   useEffect(() => {
@@ -595,6 +603,7 @@ function CodeMirrorEditor({
           lspExtension({ filePath: mountDocument.file_path }),
           keeperCursorExtension(),
           contextFocusLineExt(),
+          annotationLineChipExt(),
           EditorView.updateListener.of((update) => {
             const sel = getSelectedAnnotation(update.view)
             if (sel !== prevAnnRef.current) {
@@ -651,6 +660,22 @@ function CodeMirrorEditor({
     if (!view || !ready || !showBlame) return
     pushOwnership(view, ownership)
   }, [ownership, ready, showBlame])
+
+  useEffect(() => {
+    const view = editorRef.current
+    if (!view || !ready) return
+    pushAnnotationLines(view, currentFileAnnotations.map(annotation => ({
+      id: annotation.id,
+      line: annotation.line_start,
+      kind: annotation.kind,
+      keeperId: annotation.keeper_id,
+      goalId: annotation.goal_id,
+      taskId: annotation.task_id,
+    })))
+  }, [
+    currentFileAnnotations,
+    ready,
+  ])
 
   useEffect(() => {
     const view = editorRef.current

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -659,11 +659,21 @@ function CodeMirrorEditor({
       focusEditorContextLine(view, undefined)
       return
     }
-    focusEditorContextLine(view, contextFocus.line)
+    focusEditorContextLine(view, contextFocus.line === undefined ? undefined : {
+      line: contextFocus.line,
+      surface: contextFocus.surface,
+      label: contextFocus.label,
+      keeperId: contextFocus.keeper_id,
+      linkCount: contextFocus.route_links?.length,
+    })
   }, [
     contextFocus?.activated_at_ms,
     contextFocus?.file_path,
     contextFocus?.line,
+    contextFocus?.surface,
+    contextFocus?.label,
+    contextFocus?.keeper_id,
+    contextFocus?.route_links,
     document.file_path,
     documentStore,
     ready,


### PR DESCRIPTION
## Summary

- render the active IDE context focus as a compact CodeMirror line chip next to the highlighted code line
- include surface, label, keeper, and route-link count in the line-local chip
- render loaded Goal/Task/Comment annotations as compact context chips on matching code lines
- collapse multiple annotations on the same line into one stable chip with a `+N` overflow count
- keep the existing editor header focus status and operational route buttons unchanged

## Product impact

Operators no longer need to look away from the code line to understand why the IDE focused there. When telemetry, logs, keeper tool calls, tasks, or comments route into the Code view, the focused line now carries a small context chip that explains the active surface and keeper linkage directly in the line area.

Loaded IDE annotations now also appear directly on the current file's code lines, so Goal/Task/Comment context remains visible before a route focus is selected.

## Evidence

- `pnpm install --offline --frozen-lockfile`
- `pnpm exec eslint src/components/ide/ide-editor.ts src/components/ide/ide-editor-extensions.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-editor.test.ts src/components/ide/ide-editor-extensions.test.ts src/components/ide/ide-context-lens.test.ts src/router.test.ts` (66 tests)
- `git diff --check`

## Review evidence

- Existing focus behavior still highlights and scrolls the focused CodeMirror line.
- Added render coverage for the focused line chip text and aria label.
- Added render coverage for loaded annotation chips, current-file filtering, stable grouping, and aria label.
- Existing route-link test coverage still verifies focused-context route buttons navigate to telemetry.

## Linked issue

Follow-up slice for the persistent-agent IDE progress wiring objective; no standalone issue was opened for this narrow IDE line-context polish.
