### PR TITLE
fix(dashboard): count coverage-gap telemetry as fleet data (follow-up #15107)

### DIFF
--- a/dashboard/src/components/fleet-telemetry-data-predicate.test.ts
+++ b/dashboard/src/components/fleet-telemetry-data-predicate.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+
+import { hasFleetTelemetryData } from './fleet-telemetry-data-predicate'
+
+const emptyToolQuality = { total: 0 }
+const emptyTelemetrySummary = { total_entries: 0 }
+
+describe('hasFleetTelemetryData', () => {
+  it('returns false when every source reports nothing', () => {
+    expect(
+      hasFleetTelemetryData({
+        rowCount: 0,
+        executionTrust: null,
+        toolQuality: emptyToolQuality,
+        telemetrySummary: emptyTelemetrySummary,
+      }),
+    ).toBe(false)
+  })
+
+  it('returns true when only execution-trust coverage_gap_count > 0', () => {
+    // Regression for #15107: gap-only payloads (total=0, entry_count=0,
+    // coverage_gap_count>0) were misclassified as empty and hid the
+    // Execution Trust panel that exists to surface that gap.
+    expect(
+      hasFleetTelemetryData({
+        rowCount: 0,
+        executionTrust: { total: 0, entry_count: 0, coverage_gap_count: 1 },
+        toolQuality: emptyToolQuality,
+        telemetrySummary: emptyTelemetrySummary,
+      }),
+    ).toBe(true)
+  })
+
+  it('returns true when there are any keeper rows', () => {
+    expect(
+      hasFleetTelemetryData({
+        rowCount: 3,
+        executionTrust: null,
+        toolQuality: emptyToolQuality,
+        telemetrySummary: emptyTelemetrySummary,
+      }),
+    ).toBe(true)
+  })
+
+  it('returns true when execution-trust total > 0', () => {
+    expect(
+      hasFleetTelemetryData({
+        rowCount: 0,
+        executionTrust: { total: 5 },
+        toolQuality: emptyToolQuality,
+        telemetrySummary: emptyTelemetrySummary,
+      }),
+    ).toBe(true)
+  })
+
+  it('returns true when execution-trust entry_count > 0', () => {
+    expect(
+      hasFleetTelemetryData({
+        rowCount: 0,
+        executionTrust: { entry_count: 2 },
+        toolQuality: emptyToolQuality,
+        telemetrySummary: emptyTelemetrySummary,
+      }),
+    ).toBe(true)
+  })
+
+  it('returns true when tool-quality total > 0', () => {
+    expect(
+      hasFleetTelemetryData({
+        rowCount: 0,
+        executionTrust: null,
+        toolQuality: { total: 1 },
+        telemetrySummary: emptyTelemetrySummary,
+      }),
+    ).toBe(true)
+  })
+
+  it('returns true when telemetry-summary entries > 0', () => {
+    expect(
+      hasFleetTelemetryData({
+        rowCount: 0,
+        executionTrust: null,
+        toolQuality: emptyToolQuality,
+        telemetrySummary: { total_entries: 9 },
+      }),
+    ).toBe(true)
+  })
+
+  it('treats null/undefined execution-trust fields as zero', () => {
+    expect(
+      hasFleetTelemetryData({
+        rowCount: 0,
+        executionTrust: { total: null, entry_count: undefined, coverage_gap_count: null },
+        toolQuality: emptyToolQuality,
+        telemetrySummary: emptyTelemetrySummary,
+      }),
+    ).toBe(false)
+  })
+})

--- a/dashboard/src/components/fleet-telemetry-data-predicate.ts
+++ b/dashboard/src/components/fleet-telemetry-data-predicate.ts
@@ -1,0 +1,50 @@
+// Pure predicate split out from FleetTelemetryPanel's data-loading flow so
+// the "do we have anything worth rendering?" decision can be unit-tested
+// without driving the Preact render path.
+
+type ExecutionTrustSnapshot = {
+  total?: number | null
+  entry_count?: number | null
+  coverage_gap_count?: number | null
+}
+
+type ToolQualitySnapshot = {
+  total: number
+}
+
+type TelemetrySummary = {
+  total_entries: number
+}
+
+/**
+ * Returns true when at least one of the fleet-telemetry source-of-truth
+ * signals carries renderable data:
+ *
+ * - any keeper rows,
+ * - execution-trust total / entry count,
+ * - execution-trust coverage gap count (gap-only payloads are still
+ *   actionable — they are the provenance signal the Execution Trust panel
+ *   exists to surface when other sources are empty/unavailable),
+ * - tool-quality total,
+ * - telemetry-summary entry count.
+ *
+ * Mirrors the inline `hasAnyData` expression in `fleet-telemetry-panel.ts`
+ * so the empty-state path stays aligned with what the panel actually
+ * renders.
+ */
+export function hasFleetTelemetryData(input: {
+  rowCount: number
+  executionTrust: ExecutionTrustSnapshot | null | undefined
+  toolQuality: ToolQualitySnapshot
+  telemetrySummary: TelemetrySummary
+}): boolean {
+  const { rowCount, executionTrust, toolQuality, telemetrySummary } = input
+  return (
+    rowCount > 0
+    || (executionTrust?.total ?? 0) > 0
+    || (executionTrust?.entry_count ?? 0) > 0
+    || (executionTrust?.coverage_gap_count ?? 0) > 0
+    || toolQuality.total > 0
+    || telemetrySummary.total_entries > 0
+  )
+}

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -3,6 +3,7 @@ import { useSignal } from '@preact/signals'
 import { useEffect, useMemo, useRef } from 'preact/hooks'
 import { RotateCcw } from 'lucide-preact'
 import { LoadingState } from './common/feedback-state'
+import { hasFleetTelemetryData } from './fleet-telemetry-data-predicate'
 import { Eyebrow } from './common/eyebrow'
 import {
   fetchDashboardExecution,
@@ -717,12 +718,12 @@ export function FleetTelemetryPanel() {
         || telemetrySummary.generated_at
         || new Date().toISOString()
 
-      const hasAnyData =
-        rows.length > 0
-        || (executionTrust?.total ?? 0) > 0
-        || (executionTrust?.entry_count ?? 0) > 0
-        || toolQuality.total > 0
-        || telemetrySummary.total_entries > 0
+      const hasAnyData = hasFleetTelemetryData({
+        rowCount: rows.length,
+        executionTrust,
+        toolQuality,
+        telemetrySummary,
+      })
 
       pushSnapshot(rows)
 


### PR DESCRIPTION
## 배경

PR #15107 의 Codex review (P2) 가 unresolved 상태로 main 에 머지되었습니다.

`fleet-telemetry-panel.ts:720-725` 의 `hasAnyData` 가 fleet-telemetry empty-state 판정 기준으로 4 signal 만 검사 (`rows.length`, `executionTrust.total`, `executionTrust.entry_count`, `toolQuality.total`, `telemetrySummary.total_entries`). 그러나 `executionTrust.coverage_gap_count` 는 빠져 있어, `coverage_gap_count > 0` 인데 `total=0` + `entry_count=0` 인 payload 가 `hasAnyData=false` 로 평가됨.

결과: `value.error` 가 발생하여 component 가 early return, 새 Execution Trust panel 이 렌더링되지 않아 *바로 그 panel 이 surface 하려는 provenance* (gap 의 stale_reason / producer / store 등) 가 hide 됨.

## 변경

iter 4 의 `trust-summary-evidence` 패턴 재사용 — 인라인 OR 체인을 pure helper 로 추출.

- `dashboard/src/components/fleet-telemetry-data-predicate.ts` (신규): `hasFleetTelemetryData({rowCount, executionTrust, toolQuality, telemetrySummary})`. `coverage_gap_count` 를 OR chain 에 포함.
- `dashboard/src/components/fleet-telemetry-panel.ts`: 인라인 `hasAnyData` 표현식 → `hasFleetTelemetryData(...)` 호출. import 추가.
- `dashboard/src/components/fleet-telemetry-data-predicate.test.ts` (신규): 8 vitest 케이스 — empty / gap-only (#15107 회귀) / 각 4 positive signal / null·undefined 처리.

## 검증

```
npx vitest run src/components/fleet-telemetry-data-predicate.test.ts
Test Files  1 passed (1)
     Tests  8 passed (8)
```

`npx tsc --noEmit`: 변경 영역 error 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)