### PR TITLE
fix(keeper): purge legacy model metadata parse

### DIFF
--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -140,7 +140,8 @@ OAS  ──does not know──→ MASC
   dashboard rows, audit rows, and resolution broadcasts keep `selected_model`
   as a compatibility key only and emit `null`. Autoresearch cycle JSON and
   attribution evidence keep `model_used` as a compatibility key only and emit
-  `null`, while legacy persisted strings decode to a neutral runtime label.
+  `null`. Legacy keeper `models` inputs are rejected at TOML/meta parse
+  boundaries rather than decoded into a neutral runtime label.
   Channel Gate turn stats follow the same rule: keeper response parsing keeps
   duration/token counts and collapses the legacy model slot to `runtime`, while
   outbound wire JSON emits `model_used: null`.

--- a/docs/design/keeper-runtime-truth-unification-goal.md
+++ b/docs/design/keeper-runtime-truth-unification-goal.md
@@ -449,7 +449,9 @@ Boundary follow-up:
   inferring concrete provider/model identities. Older unified-turn token,
   cache, context-window, latency-bucket, and usage-anomaly metric labels also
   emit the neutral runtime lane instead of concrete `model_used` /
-  `resolved_model_id` values.
+  `resolved_model_id` values. Legacy keeper `models` inputs are now rejected
+  or ignored at parse/reconcile boundaries; runtime label selection must flow
+  through the named TOML cascade.
 - Residual work remains: pricing/telemetry labels, auth/display helpers,
   runtime-MCP quirks, local-default labels, dashboard debug fixtures, and
   broader cascade config/catalog/transport surfaces still know concrete

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -1165,7 +1165,7 @@ let merge_keeper_profile_defaults
     always_approve = prefer overlay.always_approve base.always_approve;
     social_model = prefer overlay.social_model base.social_model;
     cascade_name = prefer overlay.cascade_name base.cascade_name;
-    models = prefer overlay.models base.models;
+    models = None;
     max_turns_per_call = prefer overlay.max_turns_per_call base.max_turns_per_call;
     max_turns_per_call_scheduled_autonomous =
       prefer overlay.max_turns_per_call_scheduled_autonomous

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -141,11 +141,6 @@ let parse_keeper_chat_stream_request body_str =
         channel <> "" || channel_user_id <> ""
         || channel_user_name <> "" || channel_room_id <> ""
       in
-      let legacy_models_present =
-        match json |> member "models" with
-        | `Null -> false
-        | _ -> true
-      in
       let timeout_sec =
         match json |> member "timeout_sec" with
         | `Null -> Ok None
@@ -164,23 +159,25 @@ let parse_keeper_chat_stream_request body_str =
       then
         Error
           "channel, channel_user_id, and channel_room_id are required when connector context is supplied"
-      else if legacy_models_present then
-        Error
-          "legacy keeper model args removed for masc_keeper_msg: models. Use cascade_name; concrete provider/model identity is OAS-owned."
       else
-        match timeout_sec with
-        | Ok timeout_sec ->
-            Ok
-              {
-                name;
-                message;
-                timeout_sec;
-                channel;
-                channel_user_id;
-                channel_user_name;
-                channel_room_id;
-              }
+        match
+          Keeper_types.reject_legacy_model_args ~tool_name:"masc_keeper_msg" json
+        with
         | Error err -> Error err
+        | Ok () -> (
+          match timeout_sec with
+          | Ok timeout_sec ->
+              Ok
+                {
+                  name;
+                  message;
+                  timeout_sec;
+                  channel;
+                  channel_user_id;
+                  channel_user_name;
+                  channel_room_id;
+                }
+          | Error err -> Error err )
   with Yojson.Json_error e ->
     Error ("invalid json: " ^ e)
 

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -35,8 +35,8 @@
     (~10 internal lets — [contains_casefold],
     [get_origin] / [cors_headers] adapter helpers,
     [keeper_chat_stream_*] sub-renderers + per-event
-    framing, [legacy_models_present] /
-    [has_connector_context] payload guards). *)
+    framing, connector-context and legacy model-argument
+    payload guards). *)
 
 (** {1 Request record} *)
 

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -85,6 +85,29 @@ let test_parse_keeper_chat_stream_request_rejects_partial_connector_context () =
         "channel, channel_user_id, and channel_room_id are required when connector context is supplied"
         err
 
+let test_parse_keeper_chat_stream_request_rejects_legacy_model_args () =
+  let cases =
+    [
+      ( "models",
+        {|{"name":"luna","message":"hello","models":["glm:legacy"]}|} );
+      ( "allowed_models",
+        {|{"name":"luna","message":"hello","allowed_models":["glm:legacy"]}|} );
+      ( "active_model",
+        {|{"name":"luna","message":"hello","active_model":"glm:legacy"}|} );
+    ]
+  in
+  List.iter
+    (fun (field, body) ->
+      match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+      | Ok _ -> fail ("expected legacy field to be rejected: " ^ field)
+      | Error err ->
+          check string ("legacy field rejected: " ^ field)
+            (Printf.sprintf
+               "legacy keeper model args removed for masc_keeper_msg: %s. Use cascade_name; concrete provider/model identity is OAS-owned."
+               field)
+            err)
+    cases
+
 (* ── Filesystem-safe sanitizer ──────────────────────────────────────── *)
 
 let test_filesystem_safe_normal () =
@@ -214,6 +237,8 @@ let () =
             test_parse_keeper_chat_stream_request_accepts_connector_context;
           test_case "stream request rejects partial connector context" `Quick
             test_parse_keeper_chat_stream_request_rejects_partial_connector_context;
+          test_case "stream request rejects legacy model args" `Quick
+            test_parse_keeper_chat_stream_request_rejects_legacy_model_args;
         ] );
       ( "filesystem_safe",
         [

--- a/test/test_keeper_llama_only.ml
+++ b/test/test_keeper_llama_only.ml
@@ -7,6 +7,17 @@ let restore_env name = function
   | Some value -> Unix.putenv name value
   | None -> Unix.putenv name ""
 
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    if needle_len = 0 then true
+    else if idx + needle_len > haystack_len then false
+    else if String.sub haystack idx needle_len = needle then true
+    else loop (idx + 1)
+  in
+  loop 0
+
 let with_worktree_config_root f =
   let cwd = Sys.getcwd () in
   let config_dir = Filename.concat cwd "config" in
@@ -79,6 +90,24 @@ let test_legacy_explicit_models_do_not_override_cascade_resolution () =
   in
   check (list string) "legacy explicit models do not override cascade" baseline labels
 
+let test_meta_of_json_rejects_legacy_models () =
+  match
+    KT.meta_of_json
+      (`Assoc
+        [
+          ("name", `String "keeper-llama-only-test");
+          ("agent_name", `String "keeper-llama-only-test");
+          ("trace_id", `String "trace-keeper-llama-models-drop");
+          ("models", `List [ `String "glm:glm-5.1" ]);
+          ("sandbox_profile", `String "local");
+          ("network_mode", `String "none");
+        ])
+  with
+  | Ok _ -> fail "meta_of_json should reject legacy models"
+  | Error err ->
+    check bool "legacy models rejected" true
+      (contains_substring err "models")
+
 let () =
   run "keeper_llama_only"
     [
@@ -90,5 +119,7 @@ let () =
             test_matching_last_model_is_preserved_when_still_in_cascade;
           test_case "ignores legacy explicit models for runtime labels" `Quick
             test_legacy_explicit_models_do_not_override_cascade_resolution;
+          test_case "rejects legacy models while parsing keeper meta" `Quick
+            test_meta_of_json_rejects_legacy_models;
         ] );
     ]

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -2092,6 +2092,9 @@ let test_runtime_manifest_contract_omits_provider_model_fields () =
   check_source_omits
     "lib/keeper/keeper_types_profile.ml"
     "json_string_list \"models\" keeper_json";
+  check_source_omits
+    "lib/server/server_routes_http_keeper_stream.ml"
+    "legacy_models_present";
   check_source_missing "lib/keeper/keeper_agent_context.ml";
   check_source_missing "lib/keeper/keeper_agent_context.mli";
   check_source_omits

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -2076,6 +2076,22 @@ let test_runtime_manifest_contract_omits_provider_model_fields () =
   check_source_omits "lib/cascade/cascade_runtime.ml" "direct_model_strings";
   check_source_omits "lib/cascade/cascade_config.ml" "let parse_model_strings";
   check_source_omits "lib/cascade/cascade_config.mli" "val parse_model_strings";
+  check_source_omits "lib/keeper/keeper_meta_json_parse.ml" "pk_models";
+  check_source_omits
+    "lib/keeper/keeper_meta_json_parse.mli"
+    "pk_models";
+  check_source_omits
+    "lib/keeper/keeper_runtime.ml"
+    "models_changed";
+  check_source_omits
+    "lib/keeper/keeper_runtime.ml"
+    "models = target_models";
+  check_source_omits
+    "lib/keeper/keeper_turn_up_create.ml"
+    "profile_defaults.models";
+  check_source_omits
+    "lib/keeper/keeper_types_profile.ml"
+    "json_string_list \"models\" keeper_json";
   check_source_missing "lib/keeper/keeper_agent_context.ml";
   check_source_missing "lib/keeper/keeper_agent_context.mli";
   check_source_omits


### PR DESCRIPTION
## Summary
- remove the dead persisted keeper `models` parser and keep parsed keeper meta `models = []`
- stop `ensure_keeper_meta` and keeper creation from resyncing legacy profile/default model lists into runtime meta
- stop persona profile JSON from carrying `models` through overlays; named TOML cascade remains the runtime source of truth
- update boundary/runtime-truth docs and pin tests so legacy `models` is rejected, not silently decoded

## Verification
- `scripts/dune-local.sh build --cache=disabled test/test_keeper_llama_only.exe test/test_keeper_runtime_manifest.exe bin/main_eio.exe`
- `./_build/default/test/test_keeper_llama_only.exe`
- `./_build/default/test/test_keeper_runtime_manifest.exe`
- `ocamlformat --check lib/keeper/keeper_meta_json_parse.ml lib/keeper/keeper_meta_json_parse.mli lib/keeper/keeper_runtime.ml lib/keeper/keeper_turn_up_create.ml lib/keeper/keeper_types_profile.ml test/test_keeper_llama_only.ml test/test_keeper_runtime_manifest.ml`
- `git diff --check`

Note: local validation initially exposed opam `agent_sdk` pin drift; repaired with `scripts/opam-pin-external-deps.sh --install` before the final successful build.