### PR TITLE
fix(dashboard): keep tablist reachable when current surface is hidden (follow-up #15120)

### DIFF
--- a/dashboard/src/components/dashboard-surface-tabs.test.ts
+++ b/dashboard/src/components/dashboard-surface-tabs.test.ts
@@ -101,4 +101,30 @@ describe('DashboardSurfaceTabs', () => {
 
     expect(await axe(container)).toHaveNoViolations()
   })
+
+  it('keeps the tablist keyboard-reachable when current surface is hidden', () => {
+    // Regression for #15120: VISIBLE_DASHBOARD_NAV_ITEMS hides the cockpit
+    // surface, so when currentTab="cockpit" no item matches and the
+    // previous active-only tabIndex branch left every tab at tabIndex=-1.
+    // The roving-tabindex contract requires exactly one tabIndex=0; fall
+    // back to the first visible item so Tab navigation can still reach
+    // the tablist. aria-selected stays "false" — we must not lie about
+    // selection when nothing in [items] is actually current.
+    render(
+      html`<${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="cockpit" />`,
+      container,
+    )
+
+    const tabs = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'))
+    expect(tabs.length).toBeGreaterThan(0)
+
+    const tabbable = tabs.filter(tab => tab.tabIndex === 0)
+    expect(tabbable).toHaveLength(1)
+    expect(tabbable[0]).toBe(tabs[0])
+
+    for (const tab of tabs) {
+      expect(tab.getAttribute('aria-selected')).toBe('false')
+      expect(tab.hasAttribute('aria-current')).toBe(false)
+    }
+  })
 })

--- a/dashboard/src/components/dashboard-surface-tabs.ts
+++ b/dashboard/src/components/dashboard-surface-tabs.ts
@@ -25,6 +25,16 @@ export function DashboardSurfaceTabs({ items, currentTab }: DashboardSurfaceTabs
       ?.scrollIntoView({ block: 'nearest', inline: 'center' })
   }, [currentTab])
 
+  // Roving-tabindex contract: exactly one tab in the tablist must carry
+  // tabIndex=0 so keyboard users can reach the surface tabs via normal Tab
+  // navigation. When [currentTab] is a hidden surface (e.g. #cockpit, which
+  // VISIBLE_DASHBOARD_NAV_ITEMS filters out), no `item.id === currentTab`
+  // matches and the active-only branch leaves every tab at tabIndex=-1 —
+  // an unreachable tablist. Fall back to the first visible item in that case;
+  // aria-selected stays "false" because nothing in [items] is actually the
+  // current surface, but keyboard reachability is preserved.
+  const hasMatchingTab = items.some(item => item.id === currentTab)
+
   return html`
     <nav class="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] max-[520px]:w-full" aria-label="Dashboard surfaces">
       <div
@@ -32,15 +42,16 @@ export function DashboardSurfaceTabs({ items, currentTab }: DashboardSurfaceTabs
         aria-label="Dashboard surfaces"
         class="inline-flex min-w-max items-center gap-0.5 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-0.5"
       >
-        ${items.map(item => {
+        ${items.map((item, index) => {
           const active = item.id === currentTab
+          const tabbable = active || (!hasMatchingTab && index === 0)
           return html`
             <${RouteLink}
               id=${dashboardSurfaceTabId(item.id)}
               role="tab"
               tab=${item.id}
               params=${item.defaultParams}
-              tabIndex=${active ? 0 : -1}
+              tabIndex=${tabbable ? 0 : -1}
               ariaControls="main-content"
               ariaCurrent=${active ? 'page' : undefined}
               ariaSelected=${active ? 'true' : 'false'}


### PR DESCRIPTION
## 배경

PR #15120 의 Codex review (P2, `dashboard/src/app.ts:278`) 가 unresolved 상태로 main 에 머지되었습니다.

`DashboardSurfaceTabs` 는 `items` 중 `item.id === currentTab` 인 element 에만 `tabIndex=0` 을 부여합니다. 그러나 `VISIBLE_DASHBOARD_NAV_ITEMS` 는 `hidden: true` 인 surface (예: `cockpit`) 를 제외하므로, `currentTab="cockpit"` 인 route 에서는 어떤 item 도 일치하지 않아 *모든* tab 이 `tabIndex=-1`. tablist 전체가 Tab navigation 으로 도달 불가 → 키보드 사용자 a11y 회귀.

## 변경

ARIA roving-tabindex 규약: tablist 안에 정확히 하나의 `tabIndex=0` 이 있어야 함.

- `dashboard/src/components/dashboard-surface-tabs.ts`:
  - `hasMatchingTab = items.some(...)` 검사 추가.
  - 일치 없으면 첫 visible item 이 `tabIndex=0` 으로 fallback.
  - `aria-selected` 는 모든 tab 에서 `"false"`, `aria-current` 는 omit. `items` 안에 실제 current surface 가 없으므로 selection claim 은 assistive tech 에 거짓말이 됨.

- `dashboard/src/components/dashboard-surface-tabs.test.ts`:
  - 회귀 케이스 — `currentTab="cockpit"` 으로 render:
    - 정확히 1 tab 이 `tabIndex=0`, 그 tab 은 첫 visible item,
    - 모든 tab 이 `aria-selected="false"` + `aria-current` 미부착.

## 검증

```
npx vitest run src/components/dashboard-surface-tabs.test.ts
Test Files  1 passed (1)
     Tests  6 passed (6)
```

`tsc --noEmit`: 변경 영역 error 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)