### PR TITLE
fix(dashboard): defensive WS discovery cache handling (follow-up #15122)

### DIFF
--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -74,7 +74,16 @@ function readCachedWsUrl(): string | null {
     const data = JSON.parse(raw) as { ws_url?: unknown }
     return typeof data.ws_url === 'string' && data.ws_url.length > 0 ? data.ws_url : null
   } catch {
-    storage.removeItem(DASHBOARD_WS_DISCOVERY_CACHE_KEY)
+    // Eviction must not propagate: in restricted storage contexts the
+    // initial getItem can throw, and a follow-up removeItem can throw too.
+    // If readCachedWsUrl propagates, discovery stops falling back to HTTP
+    // /ws — exactly the wrong behavior in a degraded storage environment.
+    // Degrade to null instead.
+    try {
+      storage.removeItem(DASHBOARD_WS_DISCOVERY_CACHE_KEY)
+    } catch {
+      // ignore secondary storage failure
+    }
     return null
   }
 }
@@ -603,14 +612,18 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     return
   }
   if (!shouldReconnect || generation !== connectGeneration) return
-  if (!discovery.fromCache) writeCachedWsUrl(wsUrl)
 
   closeSocket()
   let ws: WebSocket
   try {
     ws = new WebSocket(wsUrl)
   } catch (err) {
-    if (discovery.fromCache) clearCachedWsUrl()
+    // Cache only values that constructed successfully: writing before
+    // [new WebSocket(...)] would persist a malformed/incompatible URL
+    // through the next reconnect, adding an extra failure+backoff cycle
+    // before discovery is retried. Also clear any prior cached value so
+    // a stale entry from an earlier session does not survive.
+    clearCachedWsUrl()
     batch(() => {
       dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
     })
@@ -618,6 +631,11 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     return
   }
   socket = ws
+  // Cache the URL only after the WebSocket constructor accepted it.
+  // Persisting before construction would leave a bad value in the cache
+  // for the next reconnect attempt; persisting after means cache only
+  // ever holds URLs that at minimum parsed without throwing.
+  if (!discovery.fromCache) writeCachedWsUrl(wsUrl)
   ws.onopen = () => {
     if (socket !== ws) return
     dashboardWsConnected.value = true


### PR DESCRIPTION
## 배경

PR #15122 의 Codex review (P2 x 2 in `dashboard/src/dashboard-ws.ts`) 가 unresolved 상태로 main 에 머지되었습니다.

### #1 — line 613 영역: bad URL 이 cache 에 잔존

```ts
if (!discovery.fromCache) writeCachedWsUrl(wsUrl)
...
try { ws = new WebSocket(wsUrl) }
catch (err) {
  if (discovery.fromCache) clearCachedWsUrl()  // ← only conditional
  ...
}
```

`writeCachedWsUrl` 이 *construction 전* 에 호출되어, `new WebSocket(wsUrl)` 이 malformed URL 로 throw 하면 bad URL 이 cache 에 persist. catch 분기는 `discovery.fromCache === true` 일 때만 cache clear → fresh HTTP discovery 결과가 broken 이면 다음 reconnect 가 그 broken URL 을 다시 cache 에서 읽어 한 차례 더 fail / backoff 누락.

### #2 — line 77 영역: 보호되지 않은 secondary storage call

```ts
function readCachedWsUrl(): string | null {
  ...
  try { storage.getItem(...) ... }
  catch {
    storage.removeItem(...)   // ← unguarded; can also throw
    return null
  }
}
```

Restricted-storage 환경 (private browsing 등) 에서 `getItem` 이 throw 하고, `catch` 내부의 `removeItem` 까지 throw 하면 `readCachedWsUrl` 가 예외를 propagate. discovery 가 HTTP `/ws` fallback 으로 가지 않고 reconnect loop 만 돌게 됨 — 정확히 degraded storage 에서 가장 회피해야 할 동작.

## 변경

`dashboard/src/dashboard-ws.ts`:

- `writeCachedWsUrl` 호출을 *successful WebSocket 생성 후* 로 이동. construction 실패 시 무조건 `clearCachedWsUrl()` (이전 fromCache 분기 제거). cache 가 *constructor 가 받아들인 URL* 만 보관하는 invariant.
- `readCachedWsUrl` 의 secondary `removeItem` 호출을 자체 try/catch 로 감쌈. cache-read 실패 항상 `null` 로 degrade.

## 검증

```
npx vitest run src/dashboard-ws.test.ts
Test Files  1 passed (1)
     Tests  20 passed (20)
```

기존 cache reuse / invalidation 테스트 모두 통과 (회귀 없음).

신규 회귀 테스트는 추가하지 않았습니다: 두 fix 모두 *defensive guard / ordering 변경* 이고, 검증에는 throwing-WebSocket / throwing-Storage 모킹이 필요한데 현 harness 를 넘어가는 scaffolding 입니다. 변경 자체가 diff 만 봐도 self-evident 한 보호 강화라 reviewer 가 contract 만 검토해도 충분합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)