### PR TITLE
fix(cascade): remove vestigial config_path from local_capacity (follow-up #15127)

### DIFF
--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -459,8 +459,17 @@ let local_urls_of_named_selection ~sw ~net selection =
              if base_url = "" then None else Some base_url
            else None)
 
-let local_capacity_for_selections ~sw ~net ?config_path selections =
-  let (_ : string option) = config_path in
+(* [?config_path] was previously exposed but discarded — the downstream
+   [Cascade_catalog_runtime.resolve_named_providers] resolves against the
+   process-global active catalog ([lookup_active_profile]) and has no
+   path-override entry point, so a non-default argument silently routed
+   capacity probes to the wrong catalog. No caller actually passes the
+   override (see grep across lib/ — autoresearch_codegen / dashboard
+   judges all omit it). Removing the parameter eliminates the footgun
+   instead of preserving a misleading shim. If catalog-path override
+   becomes a real requirement, plumb it through [resolve_named_providers]
+   and [lookup_active_profile] under an RFC. *)
+let local_capacity_for_selections ~sw ~net selections =
   let local_urls =
     selections
     |> List.concat_map (fun selection ->

--- a/lib/cascade/cascade_runtime.mli
+++ b/lib/cascade/cascade_runtime.mli
@@ -79,10 +79,15 @@ type local_capacity = {
 val local_capacity_for_selections :
   sw:Eio.Switch.t ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
-  ?config_path:string ->
   string list ->
   local_capacity
 (** Query local endpoint capacity for named cascade selections.
 
     Selections are resolved through the TOML catalog into typed provider
-    candidates. Direct model-string parsing is intentionally not a fallback. *)
+    candidates. Direct model-string parsing is intentionally not a fallback.
+
+    Resolution always uses the process-global active catalog (via
+    [Cascade_catalog_runtime.resolve_named_providers] →
+    [lookup_active_profile]); path-scoped override is not supported here.
+    A previous [?config_path] argument was silently discarded — removed
+    to avoid the footgun of an override that pretended to apply. *)


### PR DESCRIPTION
## 배경

PR #15127 의 Codex review (P2, `lib/cascade/cascade_runtime.ml:463`) 가 unresolved 상태로 main 에 머지되었습니다. 리뷰 요지:

> `local_capacity_for_selections` 가 `?config_path` 를 노출하지만 즉시 discard. 다른 catalog 를 가리키는 호출자가 silently 잘못된 catalog 에 대해 capacity probe 를 수행 가능.

## 평가와 결정

reviewer 는 `config_path` 를 named-provider / fallback-route resolution 까지 thread 하라고 권고. 그러나 downstream `Cascade_catalog_runtime.resolve_named_providers` 는 `lookup_active_profile` 을 통해 **process-global active catalog** 만 사용 — path-override entry point 자체가 없음. threading 은 multi-module API 추가 필요.

`lib/` grep 결과 **`~config_path` 를 실제로 넘기는 caller 가 0건** (autoresearch_codegen / dashboard governance_judge / dashboard operator_judge 모두 omit). threading 은 "아무도 요청하지 않은 use case 를 위한 plumbing".

→ **reviewer 권고와 다른 결정**: 오해 유발 파라미터를 제거 (Option A, 정직한 root). footgun (override 인 척하지만 실제로 안 작동) 자체를 없앰. 진짜 catalog-path override 가 필요해지면 `resolve_named_providers` + `lookup_active_profile` 에 RFC 로 적절히 설계 (nesting / threads / discovery cache 의미를 함께).

## 변경

- `lib/cascade/cascade_runtime.ml`: `?config_path` 파라미터 + `let (_ : ...) = config_path in` discard 제거. 인라인 주석으로 history + RFC 후보 명시.
- `lib/cascade/cascade_runtime.mli`: 파라미터 제거 + doc note 추가 — "resolution 은 process-global active catalog 사용; path-override 미지원".

## 검증

```
dune build --root . lib    # 통과 (caller 0건이라 fallout 없음)
```

기존 `test_ci_hardening_source` 가 12 failure 보이지만 pristine `origin/main` 에서도 동일 — 본 PR 변경과 무관 (확인: stash + 재실행 결과 동일).

## 후속

- (Optional RFC) `Cascade_catalog_runtime.resolve_named_providers` 에 `?config_path` 진짜 threading 이 필요해지면 `lookup_active_profile` 까지 명시적 plumbing. 본 PR 의 doc note 가 그 RFC 의 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)