### PR TITLE
docs: index operator schema surfaces

### DIFF
--- a/docs/OPERATOR-SCHEMA-SURFACE-INDEX.md
+++ b/docs/OPERATOR-SCHEMA-SURFACE-INDEX.md
@@ -1,0 +1,28 @@
+# Operator Schema Surface Index
+
+This is the operator-facing map for MASC runtime output, dashboard response,
+SSE, JSONL, and OAS bridge surfaces. It answers where the schema or type truth
+lives, who produces it, who consumes it, and which test should catch obvious
+path drift.
+
+Machine-readable catalog: `docs/schema-surfaces/operator-output-surfaces.v1.json`.
+
+## Current Surfaces
+
+| Surface | Output | Schema/type truth | Validation |
+| --- | --- | --- | --- |
+| `masc.keeper_composite.http.v1` | `/api/v1/keepers/:name/composite` | `lib/keeper/keeper_composite_observer.mli`, `dashboard/src/api/schemas/keeper-composite.ts` | Dashboard schema and composite observer tests |
+| `masc.dashboard_sse.v1` | Dashboard SSE event envelope | `dashboard/src/schemas/sse.ts`, `dashboard/src/types/sse.ts`, event inventory doc | SSE parser tests |
+| `masc.keeper_runtime_manifest.jsonl.v1` | Per-turn runtime manifest JSONL | `lib/keeper/keeper_runtime_manifest.mli` | Manifest JSON roundtrip tests |
+| `masc.keeper_execution_receipt.jsonl.v1` | Terminal keeper execution receipt JSONL | `lib/keeper/keeper_execution_receipt.mli` | Receipt invariant tests |
+| `masc.keeper_tool_call_log.jsonl.v1` | Keeper tool-call I/O JSONL | `lib/keeper_tool_call_log.mli` | Tool-call log tests |
+| `masc.runtime_contract_projection.v1` | Runtime contract JSON projection | `lib/keeper/keeper_runtime_contract.mli` | Tool-call/runtime contract tests |
+| `masc.mcp_openapi_tool_schema.v1` | MCP tool schemas and generated OpenAPI | `lib/keeper/keeper_schema.mli`, `lib/tool_schema_dsl.mli` | Tool matrix and OpenAPI smoke tests |
+| `masc.oas_bridge_events.v1` | OAS custom events bridged into MASC | `lib/cascade/cascade_event_bridge.mli`, event inventory doc | OAS integration tests |
+
+## Boundary Rules
+
+- Dashboard HTTP response shapes must be parsed through `dashboard/src/api/schemas/`.
+- SSE is a freshness transport. Authoritative read models live behind HTTP or durable JSONL artifacts.
+- MASC does not duplicate OAS runtime schemas. OAS-owned surfaces are linked by catalog id in `external_refs`.
+- If a schema source or test file moves, update the machine-readable catalog in the same change.

--- a/docs/schema-surfaces/operator-output-surfaces.v1.json
+++ b/docs/schema-surfaces/operator-output-surfaces.v1.json
@@ -1,0 +1,149 @@
+{
+  "version": 1,
+  "updated_at": "2026-05-14",
+  "description": "Operator-facing index of MASC runtime output, dashboard, and OAS bridge schema surfaces.",
+  "surfaces": [
+    {
+      "id": "masc.keeper_composite.http.v1",
+      "kind": "http_response",
+      "owner": "MASC",
+      "producer": "Keeper_composite_observer snapshot_to_json",
+      "consumer": ["dashboard FSM Hub", "fleet/operator views"],
+      "wire_or_artifact": "/api/v1/keepers/:name/composite response",
+      "schema_source": [
+        "lib/keeper/keeper_composite_observer.mli",
+        "dashboard/src/api/schemas/keeper-composite.ts",
+        "dashboard/docs/API_CONTRACT.md"
+      ],
+      "validator": "Valibot dashboard parser plus OCaml projection tests",
+      "tests": [
+        "dashboard/src/api/schemas/keeper-composite.test.ts",
+        "test/test_keeper_composite_observer.ml"
+      ],
+      "stability": "operator_internal",
+      "version_field": null,
+      "external_refs": [],
+      "notes": "Dashboard schema is the runtime boundary for response parsing; OCaml projection remains the producer truth."
+    },
+    {
+      "id": "masc.dashboard_sse.v1",
+      "kind": "sse_event",
+      "owner": "MASC",
+      "producer": "Server SSE publishers",
+      "consumer": ["dashboard SSE/WebSocket clients"],
+      "wire_or_artifact": "Dashboard SSE event envelope",
+      "schema_source": [
+        "dashboard/src/schemas/sse.ts",
+        "dashboard/src/types/sse.ts",
+        "docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md"
+      ],
+      "validator": "Dashboard SSE parser",
+      "tests": ["dashboard/src/schemas/sse.test.ts", "test/test_sse.ml"],
+      "stability": "operator_internal",
+      "version_field": null,
+      "external_refs": ["oas.event_bus.v1"],
+      "notes": "SSE freshness signals are not authoritative read models; consumers re-fetch authoritative snapshots."
+    },
+    {
+      "id": "masc.keeper_runtime_manifest.jsonl.v1",
+      "kind": "jsonl_artifact",
+      "owner": "MASC",
+      "producer": "Keeper_runtime_manifest",
+      "consumer": ["runtime lens", "keeper diagnostics"],
+      "wire_or_artifact": ".masc/keepers/<keeper>/runtime-manifests/<trace_id>.jsonl",
+      "schema_source": ["lib/keeper/keeper_runtime_manifest.mli"],
+      "validator": "Keeper_runtime_manifest.of_json",
+      "tests": ["test/test_keeper_runtime_manifest.ml"],
+      "stability": "operator_internal",
+      "version_field": "schema_version",
+      "external_refs": ["oas.runtime_protocol.v1", "oas.event_bus.v1"],
+      "notes": "Records decision context before and during provider attempts; narrower than execution receipts."
+    },
+    {
+      "id": "masc.keeper_execution_receipt.jsonl.v1",
+      "kind": "jsonl_artifact",
+      "owner": "MASC",
+      "producer": "Keeper_execution_receipt",
+      "consumer": ["execution dashboard", "operator trust surfaces"],
+      "wire_or_artifact": ".masc/keepers/<keeper>/execution-receipts/*.jsonl",
+      "schema_source": ["lib/keeper/keeper_execution_receipt.mli"],
+      "validator": "Keeper_execution_receipt.to_json and receipt invariant tests",
+      "tests": [
+        "test/test_keeper_receipt_authoritative.ml",
+        "test/test_keeper_receipt_authoritative_matrix.ml",
+        "test/test_keeper_receipt_outcome_tla_parity.ml"
+      ],
+      "stability": "operator_internal",
+      "version_field": "schema",
+      "external_refs": ["oas.raw_trace_record.v1"],
+      "notes": "Terminal keeper turn receipt, including tool contract and cascade outcome summary."
+    },
+    {
+      "id": "masc.keeper_tool_call_log.jsonl.v1",
+      "kind": "jsonl_artifact",
+      "owner": "MASC",
+      "producer": "Keeper_tool_call_log",
+      "consumer": ["dashboard tool-call inspector", "runtime trust summaries"],
+      "wire_or_artifact": ".masc/tool_calls/YYYY-MM/DD.jsonl",
+      "schema_source": ["lib/keeper_tool_call_log.mli"],
+      "validator": "Tool-call log read_recent and redaction tests",
+      "tests": ["test/test_keeper_tool_call_log.ml"],
+      "stability": "operator_internal",
+      "version_field": null,
+      "external_refs": ["oas.raw_trace_record.v1"],
+      "notes": "Persists redacted full I/O and effective turn policy context for keeper tool calls."
+    },
+    {
+      "id": "masc.runtime_contract_projection.v1",
+      "kind": "json_schema",
+      "owner": "MASC",
+      "producer": "Keeper_runtime_contract",
+      "consumer": ["execution receipt", "tool-call log", "runtime trust"],
+      "wire_or_artifact": "Runtime contract JSON projection",
+      "schema_source": ["lib/keeper/keeper_runtime_contract.mli"],
+      "validator": "Runtime contract projection tests through tool-call logging",
+      "tests": ["test/test_keeper_tool_call_log.ml"],
+      "stability": "operator_internal",
+      "version_field": null,
+      "external_refs": [],
+      "notes": "Redacts provider/model to the neutral runtime lane while preserving operator policy context."
+    },
+    {
+      "id": "masc.mcp_openapi_tool_schema.v1",
+      "kind": "tool_schema",
+      "owner": "MASC",
+      "producer": "MCP tool schema registry and OpenAPI generator",
+      "consumer": ["MCP clients", "REST/OpenAPI clients", "dashboard authoring tools"],
+      "wire_or_artifact": "MCP tools/list and /api/v1/openapi.json",
+      "schema_source": [
+        "lib/keeper/keeper_schema.mli",
+        "lib/tool_schema_dsl.mli",
+        "docs/spec/09-server-transport.md"
+      ],
+      "validator": "Tool inventory and OpenAPI smoke tests",
+      "tests": ["test/test_mcp_tool_matrix.ml", "test/test_openapi_api_e2e.ml"],
+      "stability": "evolving",
+      "version_field": "MCP protocolVersion",
+      "external_refs": [],
+      "notes": "OpenAPI is generated from REST-bound MCP tools; per-tool output schemas are not uniformly versioned in v1."
+    },
+    {
+      "id": "masc.oas_bridge_events.v1",
+      "kind": "event_bus",
+      "owner": "MASC",
+      "producer": "Cascade/OAS event bridge",
+      "consumer": ["dashboard SSE bridge", "OAS event subscribers"],
+      "wire_or_artifact": "OAS Custom events relayed into MASC surfaces",
+      "schema_source": [
+        "lib/cascade/cascade_event_bridge.mli",
+        "docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md"
+      ],
+      "validator": "OAS integration bridge tests",
+      "tests": ["test/test_oas_integration.ml"],
+      "stability": "operator_internal",
+      "version_field": null,
+      "external_refs": ["oas.event_bus.v1", "oas.runtime_protocol.v1"],
+      "notes": "MASC domain events stay MASC-owned and correlate with OAS via bridge payloads."
+    }
+  ]
+}

--- a/test/dune
+++ b/test/dune
@@ -89,6 +89,7 @@
         test_keeper_chat_store
         test_keeper_runtime_trust_snapshot
         test_keeper_runtime_manifest
+        test_schema_surface_index
         test_keeper_accountability
         test_reputation_ledger_v2
         test_reputation_multi_dim
@@ -321,6 +322,7 @@
           test_keeper_chat_store
           test_keeper_runtime_trust_snapshot
           test_keeper_runtime_manifest
+          test_schema_surface_index
           test_keeper_accountability
           test_reputation_ledger_v2
           test_reputation_multi_dim

--- a/test/test_schema_surface_index.ml
+++ b/test/test_schema_surface_index.ml
@@ -1,0 +1,132 @@
+open Alcotest
+
+let catalog_rel = "docs/schema-surfaces/operator-output-surfaces.v1.json"
+
+let rec find_repo_root dir =
+  if Sys.file_exists (Filename.concat dir "dune-project")
+  then dir
+  else (
+    let parent = Filename.dirname dir in
+    if String.equal parent dir then fail "could not locate dune-project" else find_repo_root parent)
+;;
+
+let source_path rel = Filename.concat (find_repo_root (Sys.getcwd ())) rel
+
+let member name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+;;
+
+let require_string field json =
+  match member field json with
+  | Some (`String value) -> value
+  | _ -> failf "missing string field: %s" field
+;;
+
+let require_int field json =
+  match member field json with
+  | Some (`Int value) -> value
+  | _ -> failf "missing int field: %s" field
+;;
+
+let require_list field json =
+  match member field json with
+  | Some (`List values) -> values
+  | _ -> failf "missing list field: %s" field
+;;
+
+let require_string_list field json =
+  require_list field json
+  |> List.map (function
+    | `String value -> value
+    | _ -> failf "field %s must be a string list" field)
+;;
+
+let catalog () = Yojson.Safe.from_file (source_path catalog_rel)
+let surfaces json = require_list "surfaces" json
+
+let allowed_kinds =
+  [ "event_bus"
+  ; "http_response"
+  ; "json_schema"
+  ; "jsonl_artifact"
+  ; "ocaml_interface"
+  ; "runtime_protocol"
+  ; "sse_event"
+  ; "tool_schema"
+  ; "typescript_schema"
+  ]
+;;
+
+let allowed_stability = [ "stable"; "evolving"; "internal"; "operator_internal" ]
+
+let test_catalog_shape () =
+  let json = catalog () in
+  check int "version" 1 (require_int "version" json);
+  let rows = surfaces json in
+  check bool "has surfaces" true (List.length rows >= 8);
+  let ids = List.map (require_string "id") rows in
+  check (list string) "ids unique" (List.sort String.compare ids) (List.sort_uniq String.compare ids);
+  List.iter
+    (fun row ->
+      let id = require_string "id" row in
+      check bool (id ^ " kind allowed") true (List.mem (require_string "kind" row) allowed_kinds);
+      check
+        bool
+        (id ^ " stability allowed")
+        true
+        (List.mem (require_string "stability" row) allowed_stability);
+      check bool (id ^ " owner present") true (String.length (require_string "owner" row) > 0);
+      check bool (id ^ " sources present") true (require_string_list "schema_source" row <> []);
+      check bool (id ^ " tests present") true (require_string_list "tests" row <> []);
+      ignore (require_string_list "external_refs" row))
+    rows
+;;
+
+let test_required_surfaces_present () =
+  let ids = catalog () |> surfaces |> List.map (require_string "id") in
+  List.iter
+    (fun id -> check bool ("required surface: " ^ id) true (List.mem id ids))
+    [ "masc.keeper_composite.http.v1"
+    ; "masc.dashboard_sse.v1"
+    ; "masc.keeper_runtime_manifest.jsonl.v1"
+    ; "masc.keeper_execution_receipt.jsonl.v1"
+    ; "masc.keeper_tool_call_log.jsonl.v1"
+    ; "masc.runtime_contract_projection.v1"
+    ; "masc.mcp_openapi_tool_schema.v1"
+    ; "masc.oas_bridge_events.v1"
+    ]
+;;
+
+let test_local_paths_exist () =
+  catalog ()
+  |> surfaces
+  |> List.iter (fun row ->
+    let id = require_string "id" row in
+    let paths = require_string_list "schema_source" row @ require_string_list "tests" row in
+    List.iter
+      (fun rel -> check bool (id ^ " path exists: " ^ rel) true (Sys.file_exists (source_path rel)))
+      paths)
+;;
+
+let test_oas_refs_are_external () =
+  catalog ()
+  |> surfaces
+  |> List.iter (fun row ->
+    let id = require_string "id" row in
+    require_string_list "external_refs" row
+    |> List.iter (fun ref_id ->
+      check bool (id ^ " external ref is OAS: " ^ ref_id) true (String.starts_with ~prefix:"oas." ref_id)))
+;;
+
+let () =
+  run
+    "Schema_surface_index"
+    [ ( "catalog"
+      , [ test_case "shape" `Quick test_catalog_shape
+        ; test_case "required surfaces" `Quick test_required_surfaces_present
+        ; test_case "local paths exist" `Quick test_local_paths_exist
+        ; test_case "OAS refs are external" `Quick test_oas_refs_are_external
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- Add an operator-facing schema surface index for MASC runtime, dashboard, JSONL, tool schema, and OAS bridge outputs.
- Add a machine-readable v1 catalog with explicit external_refs for OAS-owned runtime surfaces.
- Add a focused catalog drift test for required ids, local schema/test path existence, and OAS external ref shape.

## Verification
- jq -e '.version == 1 and (.surfaces | length >= 8)' docs/schema-surfaces/operator-output-surfaces.v1.json
- opam exec -- ocamlformat --check test/test_schema_surface_index.ml
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build ./test/test_schema_surface_index.exe ./test/test_keeper_runtime_manifest.exe ./test/test_keeper_tool_call_log.exe
- scripts/dune-local.sh exec ./test/test_schema_surface_index.exe
- ./_build/default/test/test_keeper_runtime_manifest.exe
- ./_build/default/test/test_keeper_tool_call_log.exe

## Rebase note
- Rebased onto current origin/main so local validation uses the active OAS pin d5037d2346e7e13f5488a13495e65722b0a0a268.
