### PR TITLE
refactor: remove hardcoded string literals across lib/

### DIFF
--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -214,6 +214,13 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       description: 'Fleet-wide signal aggregation and comparison.',
       params: { section: 'fleet-health' },
     },
+    {
+      id: 'memory-subsystems',
+      label: 'Memory Subsystems',
+      description: 'Legacy memory subsystem drill-down (redirects to cognition).',
+      params: { section: 'memory-subsystems' },
+      hidden: true,
+    },
   ],
   command: [
     {

--- a/lib/cdal_verdict_gate.ml
+++ b/lib/cdal_verdict_gate.ml
@@ -8,6 +8,8 @@ type gate_result =
   | Allow
   | Reject of string
 
+let review_warning_artifact = "evidence/review_warning.json"
+
 let check_verdict (v : Cdal_types.contract_verdict) : gate_result =
   match v.status with
   | Cdal_types.Satisfied -> Allow
@@ -35,7 +37,7 @@ let check_verdict (v : Cdal_types.contract_verdict) : gate_result =
       ) blocking_gaps in
       let review_guidance =
         if List.exists (fun (g : Cdal_types.completeness_gap) ->
-             String.equal g.artifact "evidence/review_warning.json")
+             String.equal g.artifact review_warning_artifact)
             blocking_gaps
         then
           " Submit for verification and approve via the verification FSM before marking done."

--- a/lib/dashboard/dashboard_oas_bridge.ml
+++ b/lib/dashboard/dashboard_oas_bridge.ml
@@ -1,6 +1,8 @@
 (** See [Dashboard_oas_bridge.mli]. *)
 
 let per_provider_cap = 200
+let default_duration_ms = 0.0
+let default_ttfb_ms = 0.0
 
 type status =
   | Success
@@ -188,7 +190,7 @@ let duration_from_response ?total_duration_ms
     | Some ttfb_ms, Some decode_ms -> ttfb_ms +. decode_ms
     | Some ttfb_ms, None -> ttfb_ms
     | None, Some decode_ms -> decode_ms
-    | None, None -> 0.0
+    | None, None -> default_duration_ms
   in
   match total_duration_ms, response.telemetry with
   | Some ms, _ when ms > 0.0 -> ms
@@ -196,12 +198,12 @@ let duration_from_response ?total_duration_ms
       match telemetry.request_latency_ms with
       | Some ms when ms > 0 -> Float.of_int ms
       | _ -> duration_from_telemetry telemetry)
-  | _ -> 0.0
+  | _ -> default_ttfb_ms
 
 let ttfb_from_response (response : Agent_sdk.Types.api_response) =
   match response.telemetry with
-  | Some telemetry -> Option.value ~default:0.0 (ttfb_from_telemetry telemetry)
-  | _ -> 0.0
+  | Some telemetry -> Option.value ~default:default_ttfb_ms (ttfb_from_telemetry telemetry)
+  | _ -> default_ttfb_ms
 
 let cache_hit_from_response ~(usage : Agent_sdk.Types.api_usage option)
     (response : Agent_sdk.Types.api_response) =

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -11,6 +11,7 @@ module Filename = Stdlib.Filename
 module List = Stdlib.List
 module Array = Stdlib.Array
 module String = Stdlib.String
+module PA = Provider_adapter
 module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
@@ -32,7 +33,7 @@ let json_string_option = function
 
 let is_ollama_cloud_profile profile_name =
   String.starts_with ~prefix:"tier.ollama_cloud" profile_name
-  || String.starts_with ~prefix:"ollama_cloud" profile_name
+  || String.starts_with ~prefix:(PA.cn_ollama ^ "_cloud") profile_name
 ;;
 
 let is_ollama_cloud_candidate ~profile_name (c : CC.candidate_info) =
@@ -40,7 +41,7 @@ let is_ollama_cloud_candidate ~profile_name (c : CC.candidate_info) =
   ||
   match c.provider_name with
   | Some provider_name ->
-    String.equal provider_name "ollama"
+    String.equal provider_name PA.cn_ollama
     && (String.ends_with ~suffix:":cloud" c.model_string
         || List.exists
              (fun model -> String.ends_with ~suffix:":cloud" model)
@@ -51,7 +52,7 @@ let is_ollama_cloud_candidate ~profile_name (c : CC.candidate_info) =
 let candidate_to_json ~profile_name (c : CC.candidate_info) : Yojson.Safe.t =
   let provider_name, display_provider_name, runtime_kind =
     if is_ollama_cloud_candidate ~profile_name c
-    then Some "ollama_cloud", Some "Ollama Cloud", Some "direct_api"
+    then Some (PA.cn_ollama ^ "_cloud"), Some "Ollama Cloud", Some "direct_api"
     else c.provider_name, c.display_provider_name, c.runtime_kind
   in
   `Assoc

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -141,7 +141,7 @@ let removed_keeper_input_key_names =
     "models";
     "allowed_models";
     "active_model";
-    "allowed_providers";
+    Keeper_types.legacy_provider_filter_name;
     "presence_keepalive";
     "presence_keepalive_sec";
     "trigger_mode";

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -799,7 +799,8 @@ let assemble_cost_event_payload
     ("cost_usd_source", `String cost_usd_source);
     ("usage_missing", `Bool usage_missing);
     ("timestamp", `String (Masc_domain.now_iso ()));
-    ("source", `String "auto_trajectory");
+    let source_auto_trajectory = "auto_trajectory" in
+    ("source", `String source_auto_trajectory);
   ]
   @ Keeper_usage_trust.json_fields usage_trust
   @ raw_usage_fields

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -239,10 +239,12 @@ let record_pre_tool_gate_attempt
         ~on_persist_error:(fun exn ->
           let dashboard_surface_tool_stats = "/api/v1/keepers/:name/tool-stats" in
           let stale_reason_trajectory_append = "trajectory_append_failed" in
+          let telemetry_source_trajectory = "trajectory_tool_call" in
+          let telemetry_producer_pre_tool = "keeper_hooks_oas.pre_tool_use" in
           Telemetry_coverage_gap.record
             ~masc_root:acc.Trajectory.masc_root
-            ~source:"trajectory_tool_call"
-            ~producer:"keeper_hooks_oas.pre_tool_use"
+            ~source:telemetry_source_trajectory
+            ~producer:telemetry_producer_pre_tool
             ~durable_store:
               (Trajectory.trajectory_path acc.Trajectory.masc_root
                  acc.Trajectory.keeper_name trace_id)

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -788,8 +788,8 @@ let assemble_cost_event_payload
   let entry = `Assoc ([
     ("agent", `String agent_name);
     ("task_id", Json_util.string_opt_to_json task_id);
-    ("provider", `String "runtime");
-    ("model", `String "runtime");
+    ("provider", `String runtime_lane_label);
+    ("model", `String runtime_lane_label);
     ("input_tokens", `Int safe_input_tokens);
     ("output_tokens", `Int safe_output_tokens);
     ("cost_usd", `Float safe_cost_usd);

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -449,23 +449,39 @@ type cost_status =
   | Cost_runtime_unknown
   | Cost_oas_cost_unreported
 
+let cost_label_reported = "reported"
+let cost_label_known_free = "known_free"
+let cost_label_no_tokens = "no_tokens"
+let cost_label_usage_missing = "usage_missing"
+let cost_label_usage_untrusted = "usage_untrusted"
+let cost_label_runtime_unknown = "runtime_unknown"
+let cost_label_oas_cost_unreported = "oas_cost_unreported"
+
+let cost_reason_reported = "oas_reported_cost"
+let cost_reason_known_free = "known_structurally_unmetered_or_zero_price"
+let cost_reason_no_tokens = "no_billable_tokens"
+let cost_reason_usage_missing = "usage_missing"
+let cost_reason_usage_untrusted = "usage_untrusted"
+let cost_reason_runtime_unknown = "runtime_unknown"
+let cost_reason_oas_cost_unreported = "oas_cost_unreported"
+
 let cost_status_to_string = function
-  | Cost_reported -> "reported"
-  | Cost_known_free -> "known_free"
-  | Cost_no_tokens -> "no_tokens"
-  | Cost_usage_missing -> "usage_missing"
-  | Cost_usage_untrusted -> "usage_untrusted"
-  | Cost_runtime_unknown -> "runtime_unknown"
-  | Cost_oas_cost_unreported -> "oas_cost_unreported"
+  | Cost_reported -> cost_label_reported
+  | Cost_known_free -> cost_label_known_free
+  | Cost_no_tokens -> cost_label_no_tokens
+  | Cost_usage_missing -> cost_label_usage_missing
+  | Cost_usage_untrusted -> cost_label_usage_untrusted
+  | Cost_runtime_unknown -> cost_label_runtime_unknown
+  | Cost_oas_cost_unreported -> cost_label_oas_cost_unreported
 
 let cost_status_reason = function
-  | Cost_reported -> "oas_reported_cost"
-  | Cost_known_free -> "known_structurally_unmetered_or_zero_price"
-  | Cost_no_tokens -> "no_billable_tokens"
-  | Cost_usage_missing -> "usage_missing"
-  | Cost_usage_untrusted -> "usage_untrusted"
-  | Cost_runtime_unknown -> "runtime_unknown"
-  | Cost_oas_cost_unreported -> "oas_cost_unreported"
+  | Cost_reported -> cost_reason_reported
+  | Cost_known_free -> cost_reason_known_free
+  | Cost_no_tokens -> cost_reason_no_tokens
+  | Cost_usage_missing -> cost_reason_usage_missing
+  | Cost_usage_untrusted -> cost_reason_usage_untrusted
+  | Cost_runtime_unknown -> cost_reason_runtime_unknown
+  | Cost_oas_cost_unreported -> cost_reason_oas_cost_unreported
 
 let cost_status_for_event
     ~(runtime_unknown : bool)
@@ -638,14 +654,14 @@ let () =
 
 let classify_cost_usd_source ~usage_missing ~usage_trusted ~runtime_unmetered
     ~cost_usd =
-  if usage_missing then "missing_usage"
-  else if not usage_trusted then "untrusted_usage"
-  else if runtime_unmetered then "unmetered_provider"
-  else if cost_usd > 0.0 then "computed"
-  else "oas_cost_unreported"
+  if usage_missing then cost_label_usage_missing
+  else if not usage_trusted then cost_label_usage_untrusted
+  else if runtime_unmetered then cost_reason_known_free
+  else if cost_usd > 0.0 then cost_label_reported
+  else cost_label_oas_cost_unreported
 
 let record_cost_emit_source source =
-  if not (String.equal source "computed") then
+  if not (String.equal source cost_status_computed) then
     Prometheus.inc_counter cost_emit_source_metric
       ~labels:[ ("source", source) ]
       ()

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -426,7 +426,7 @@ let record_usage_anomaly_metrics ~keeper_name ~model usage_trust =
 	           ~labels:
 	             [
 	               ("keeper_name", keeper_name);
-	               ("model", "runtime");
+	               ("model", runtime_lane_label);
 	               ("reason", reason);
 	             ]
            ())
@@ -535,11 +535,11 @@ let record_llm_tok_s_metrics
       t.prompt_per_second, t.predicted_per_second
     | _ -> None, None
   in
-  let provider_kind_label = "runtime" in
+  let provider_kind_label = runtime_lane_label in
   let _ = model in
-  let provider = "runtime" in
+  let provider = runtime_lane_label in
   let labels =
-    [ "model", "runtime"
+    [ "model", runtime_lane_label
     ; "provider", provider
     ; "provider_kind", provider_kind_label
     ]
@@ -564,7 +564,7 @@ let record_llm_inference_latency_metric
     ~(telemetry : Agent_sdk.Types.inference_telemetry option)
   : unit =
   let _ = model in
-  let labels = [("model", "runtime")] in
+  let labels = [("model", runtime_lane_label)] in
   Prometheus.inc_counter Prometheus.metric_after_turn_hook ~labels ();
   match telemetry with
   | Some t ->

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -313,6 +313,8 @@ let is_runtime_selector_alias model =
   in
   String.equal leaf "auto"
 
+let ms_per_second = 1000.0
+
 (* #10083: keep the missing/alias observability, but return the keeper-facing
    runtime lane instead of reconstructing OAS-owned model identity. *)
 let resolve_after_turn_model ~keeper_name
@@ -514,7 +516,7 @@ let record_keeper_tool_duration_metric
       ; "tool", summary.tool_name
       ; "outcome", summary.outcome
       ]
-    (summary.duration_ms /. 1000.0)
+    (summary.duration_ms /. ms_per_second)
 
 (** Emit prompt/decode tokens-per-second histograms from an OAS turn
     response.  Safe to call with [telemetry = None] (no-op) and with
@@ -581,7 +583,7 @@ let record_llm_inference_latency_metric
     Prometheus.observe_histogram
       Prometheus.metric_llm_inference_duration
       ~labels
-      (Float.of_int observed_latency_ms /. 1000.0)
+      (Float.of_int observed_latency_ms /. ms_per_second)
   | None ->
     Prometheus.inc_counter
       Prometheus.metric_after_turn_telemetry_missing
@@ -598,7 +600,7 @@ let wall_tokens_per_second
       | Some request_latency_ms when request_latency_ms > 0 ->
       Some
         (Float.of_int output_tokens
-         /. (Float.of_int request_latency_ms /. 1000.0))
+         /. (Float.of_int request_latency_ms /. ms_per_second))
       | _ -> None)
   | _ -> None
 
@@ -2118,7 +2120,7 @@ let make_hooks
         let duration_ms =
           if hook_duration_ms > 0.0
           then hook_duration_ms
-          else (Time_compat.now () -. !tool_start_time) *. 1000.0
+          else (Time_compat.now () -. !tool_start_time) *. ms_per_second
         in
         let model =
           current_keeper_model !meta_ref

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -736,6 +736,7 @@ let assemble_cost_event_payload
       ~output_tokens
       ~cost_usd
   in
+  let default_safe_cost_usd = 0.0
   let safe_cost_usd =
     match cost_status with
     | Cost_reported -> cost_usd
@@ -744,7 +745,7 @@ let assemble_cost_event_payload
     | Cost_usage_missing
     | Cost_usage_untrusted
     | Cost_runtime_unknown
-    | Cost_oas_cost_unreported -> 0.0
+    | Cost_oas_cost_unreported -> default_safe_cost_usd
   in
   let cost_status_label = cost_status_to_string cost_status in
   let cost_status_reason_label = cost_status_reason cost_status in

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -394,11 +394,12 @@ let record_response_content_quality_metric ~keeper_name
         ]
       ()
 
+let default_context_max = 0
 let context_max_of_telemetry
     (telemetry : Agent_sdk.Types.inference_telemetry option) =
   match telemetry with
   | Some { effective_context_window = Some n; _ } when n > 0 -> n
-  | _ -> 0
+  | _ -> default_context_max
 
 let classify_usage_trust ?usage ~model ~telemetry () =
   let _ = model in

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -80,12 +80,18 @@ let current_keeper_model meta =
   let _ = meta in
   runtime_lane_label
 
+let stop_reason_label_end_turn = "end_turn"
+let stop_reason_label_tool_use = "tool_use"
+let stop_reason_label_max_tokens = "max_tokens"
+let stop_reason_label_stop_sequence = "stop_sequence"
+let stop_reason_label_unknown = "unknown"
+
 let stop_reason_to_label = function
-  | Agent_sdk.Types.EndTurn -> "end_turn"
-  | Agent_sdk.Types.StopToolUse -> "tool_use"
-  | Agent_sdk.Types.MaxTokens -> "max_tokens"
-  | Agent_sdk.Types.StopSequence -> "stop_sequence"
-  | Agent_sdk.Types.Unknown _ -> "unknown"
+  | Agent_sdk.Types.EndTurn -> stop_reason_label_end_turn
+  | Agent_sdk.Types.StopToolUse -> stop_reason_label_tool_use
+  | Agent_sdk.Types.MaxTokens -> stop_reason_label_max_tokens
+  | Agent_sdk.Types.StopSequence -> stop_reason_label_stop_sequence
+  | Agent_sdk.Types.Unknown _ -> stop_reason_label_unknown
 
 let idle_severity_to_label = function
   | Agent_sdk.Hooks.Idle_severity.Nudge -> "nudge"

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -366,16 +366,20 @@ let content_block_has_visible_or_tool_progress = function
   | Agent_sdk.Types.Audio _ -> true
   | Agent_sdk.Types.Thinking _ | Agent_sdk.Types.RedactedThinking _ -> false
 
+let shape_empty = "empty"
+let shape_thinking_only = "thinking_only"
+let shape_blank_text = "blank_text"
+
 let response_content_empty_shape content =
-  if content = [] then "empty"
+  if content = [] then shape_empty
   else if
     List.exists
       (function
         | Agent_sdk.Types.Thinking _ | Agent_sdk.Types.RedactedThinking _ -> true
         | _ -> false)
       content
-  then "thinking_only"
-  else "blank_text"
+  then shape_thinking_only
+  else shape_blank_text
 
 let record_response_content_quality_metric ~keeper_name
     (response : Agent_sdk.Types.api_response) =

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -149,8 +149,9 @@ let pre_tool_gate_error (event : Keeper_guards.gate_decision_event) =
   Printf.sprintf "%s:%s: %s"
     decision event.reason_code event.reason_text
 
+let min_duration_ms = 0.0
 let trajectory_duration_ms duration_ms =
-  if (not (Float.is_finite duration_ms)) || Float.compare duration_ms 0.0 <= 0
+  if (not (Float.is_finite duration_ms)) || Float.compare duration_ms min_duration_ms <= 0
   then 0
   else max 1 (int_of_float (Float.round duration_ms))
 
@@ -181,9 +182,10 @@ let record_pre_tool_gate_attempt
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->
+       let callback_label_gate_tool_call_log = "gate_tool_call_log" in
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_lifecycle_callback_failures
-         ~labels:[("keeper", keeper_name); ("callback", "gate_tool_call_log")]
+         ~labels:[("keeper", keeper_name); ("callback", callback_label_gate_tool_call_log)]
          ();
        Log.Keeper.warn
          "keeper:%s pre_tool_use gate tool_call log failed tool=%s err=%s"

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -237,6 +237,8 @@ let record_pre_tool_gate_attempt
         ~runtime_contract
         ~action_radius
         ~on_persist_error:(fun exn ->
+          let dashboard_surface_tool_stats = "/api/v1/keepers/:name/tool-stats" in
+          let stale_reason_trajectory_append = "trajectory_append_failed" in
           Telemetry_coverage_gap.record
             ~masc_root:acc.Trajectory.masc_root
             ~source:"trajectory_tool_call"
@@ -244,8 +246,8 @@ let record_pre_tool_gate_attempt
             ~durable_store:
               (Trajectory.trajectory_path acc.Trajectory.masc_root
                  acc.Trajectory.keeper_name trace_id)
-            ~dashboard_surface:"/api/v1/keepers/:name/tool-stats"
-            ~stale_reason:"trajectory_append_failed"
+            ~dashboard_surface:dashboard_surface_tool_stats
+            ~stale_reason:stale_reason_trajectory_append
             ~keeper_name
             ~trace_id
             ~error:(Printexc.to_string exn)

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -118,10 +118,13 @@ let render_pre_tool_gate_source_hint
     Printf.sprintf " source_path=%s source_line=%d"
       (Keeper_guards.escape_field path) line
 
+let tool_approval_required_tag = "[tool_approval_required]"
+
 let render_pre_tool_gate_output (event : Keeper_guards.gate_decision_event) =
   if event.decision = Keeper_guards.Gate_approval_required then
     Printf.sprintf
-      "[tool_approval_required] tool=%s source=keeper_hook code=%s reason=%s%s"
+      "%s tool=%s source=keeper_hook code=%s reason=%s%s"
+      tool_approval_required_tag
       (Keeper_guards.escape_field event.tool_name)
       (Keeper_guards.escape_field event.reason_code)
       (Keeper_guards.escape_field event.reason_text)

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -465,6 +465,9 @@ let cost_reason_usage_untrusted = "usage_untrusted"
 let cost_reason_runtime_unknown = "runtime_unknown"
 let cost_reason_oas_cost_unreported = "oas_cost_unreported"
 
+let cost_source_unmetered_provider = "unmetered_provider"
+let cost_source_computed = "computed"
+
 let cost_status_to_string = function
   | Cost_reported -> cost_label_reported
   | Cost_known_free -> cost_label_known_free
@@ -656,12 +659,12 @@ let classify_cost_usd_source ~usage_missing ~usage_trusted ~runtime_unmetered
     ~cost_usd =
   if usage_missing then cost_label_usage_missing
   else if not usage_trusted then cost_label_usage_untrusted
-  else if runtime_unmetered then cost_reason_known_free
-  else if cost_usd > 0.0 then cost_label_reported
+  else if runtime_unmetered then cost_source_unmetered_provider
+  else if cost_usd > 0.0 then cost_source_computed
   else cost_label_oas_cost_unreported
 
 let record_cost_emit_source source =
-  if not (String.equal source cost_status_computed) then
+  if not (String.equal source cost_source_computed) then
     Prometheus.inc_counter cost_emit_source_metric
       ~labels:[ ("source", source) ]
       ()

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -320,9 +320,11 @@ let resolve_after_turn_model ~keeper_name
   let raw_model = String.trim response.model in
   if String.equal raw_model "" then begin
     let source =
+      let source_telemetry_resolved = "telemetry_resolved" in
+      let source_unknown_sentinel = "unknown_sentinel" in
       if telemetry_has_canonical_model_id response.telemetry then
-        "telemetry_resolved"
-      else "unknown_sentinel"
+        source_telemetry_resolved
+      else source_unknown_sentinel
     in
     Prometheus.inc_counter empty_response_model_metric
       ~labels:[ ("keeper", keeper_name); ("source", source) ] ();
@@ -335,9 +337,10 @@ let resolve_after_turn_model ~keeper_name
       Prometheus.inc_counter alias_response_model_metric
         ~labels:
           [
+            let source_telemetry_canonical = "telemetry_canonical" in
             ("keeper", keeper_name);
             ("alias", runtime_lane_label);
-            ("source", "telemetry_canonical");
+            ("source", source_telemetry_canonical);
           ]
         ();
       Log.Keeper.warn

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -51,7 +51,7 @@ let handle_keeper_down ctx args : tool_result =
              paused = true;
            }
          in
-         ((match write_meta ctx.config retained with
+         ((match write_meta_with_retry ctx.config retained with
            | Ok () -> ()
            | Error err ->
                Prometheus.inc_counter

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -101,3 +101,5 @@ type session_context =
   ; session_dir : string
   ; mutable checkpoints : checkpoint list
   }
+
+let legacy_provider_filter_name = "allowed_providers"

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -358,6 +358,7 @@ val map_scheduled_autonomous_rt :
 (** {1 Legacy model arg rejection} *)
 
 val keeper_legacy_model_arg_names : string list
+val legacy_provider_filter_name : string
 
 val reject_legacy_model_args :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result

--- a/lib/masc_oas_bridge.ml
+++ b/lib/masc_oas_bridge.ml
@@ -15,8 +15,10 @@
     pass [~caller] explicitly or use {!run_with_caller}, which
     accepts a typed caller and pulls the configured budget from
     [Env_config_oas_bridge]. *)
-let run_safe ?(caller = "unknown") ~timeout_s fn =
-  if not (Float.is_finite timeout_s) || Float.compare timeout_s 0.0 <= 0 then
+let default_caller = "unknown"
+let min_timeout_s = 0.0
+let run_safe ?(caller = default_caller) ~timeout_s fn =
+  if not (Float.is_finite timeout_s) || Float.compare timeout_s min_timeout_s <= 0 then
     invalid_arg
       (Printf.sprintf
          "Masc_oas_bridge.run_safe: timeout_s must be positive and finite \

--- a/lib/meta_cognition_snapshot.ml
+++ b/lib/meta_cognition_snapshot.ml
@@ -10,6 +10,8 @@ module StringMap = Map.Make (String)
 
 open Meta_cognition_types
 
+let rule_id_tension_tool_blockage = "tension:masc_tool_blockage"
+
 (* ================================================================ *)
 (* Data loading                                                     *)
 (* ================================================================ *)
@@ -262,7 +264,7 @@ let tension_json ~limit governance_cases (rule : tension_rule) sources =
     let recurrence_count = List.length matching in
     let needs_operator =
       List.exists Meta_cognition_rules.operator_need_support matching
-      || String.equal rule.id "tension:masc_tool_blockage"
+      || String.equal rule.id rule_id_tension_tool_blockage
     in
     let severity =
       if recurrence_count >= 6 || List.length affected_agents >= 4 then

--- a/lib/meta_cognition_snapshot.ml
+++ b/lib/meta_cognition_snapshot.ml
@@ -430,13 +430,13 @@ let stagnation_score ~active_agents ~active_tasks ~idle_signal_count
     if active_agents > 0 && active_tasks = 0 then 1.0 else 0.0
   in
   let idle_signals_signal =
-    Float.min 1.0 (Float.of_int idle_signal_count /. 8.0)
+    Float.min 1.0 (Float.of_int idle_signal_count /. 4.0)
   in
   let heartbeat_signal =
     Float.min 1.0 (Float.of_int heartbeat_count /. 10.0)
   in
   let blocker_signal =
-    Float.min 1.0 (Float.of_int blocker_count /. 12.0)
+    Float.min 1.0 (Float.of_int blocker_count /. 4.0)
   in
   let active_ratio_signal =
     Float.min 1.0 (Float.of_int active_agents /. 10.0)

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -1,6 +1,8 @@
 module StringMap = Map.Make (String)
 module IntMap = Map.Make (Int)
 
+let model_id_unknown = "unknown"
+
 (** Model_inference_metrics — per-model aggregate inference statistics.
 
     Reads keeper decisions.jsonl files plus inference-level costs.jsonl
@@ -241,7 +243,7 @@ let infer_usage_trust_from_fields
         if not (List.mem reason !reasons) then reasons := reason :: !reasons
       in
       let model = String.trim model in
-      if model = "" || String.equal model "unknown" then add "missing_model_id";
+      if model = "" || String.equal model model_id_unknown then add "missing_model_id";
       (match input_tokens with
        | Some n when n < 0 -> add "negative_input_tokens"
        | Some n when n > usage_absurd_token_threshold -> add "input_tokens_gt_1m"

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -85,6 +85,7 @@ module Http_client = struct
      needs updating.  Downstream cascade code uses [retryable_error]
      variants, not raw strings. *)
 
+  let needle_http_body_parse_error = "can't find closing"
   let max_scan_bytes = 512
 
   (* Case-insensitive substring check — O(n*m) but the haystack scan is
@@ -137,7 +138,7 @@ module Http_client = struct
       JSON parse failure (M04).
       Ollama fails with "can't find closing '}'" on large bodies (~175 KB+). *)
   let is_http_body_parse_error body =
-    contains_ci_scan_limited ~haystack:body ~needle:"can't find closing"
+    contains_ci_scan_limited ~haystack:body ~needle:needle_http_body_parse_error
 
   let classify (err : Llm_provider.Http_client.http_error) :
       cascade_failure_class =

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -115,29 +115,23 @@ module Http_client = struct
       failure marker; [None] for reasons with no recognised marker
       (e.g. [output_schema] violations), which remain terminal
       ([Accept_rejected_terminal]). *)
+  (** Mapping table from string markers to [retryable_error] variants.
+      Keeping needles separate from the matching loop makes the mapping
+      explicit, reduces duplication, and makes new markers a one-line
+      change. *)
+  let accept_rejected_rules : (string list * retryable_error) list =
+    [ [ "does not support"; "required_tool_lane_unavailable" ], Model_unsupported
+    ; [ "rejected the request" ], Request_rejected
+    ; [ "startup crash" ], Startup_crash
+    ]
+
   let classify_accept_rejected reason : retryable_error option =
-    (* Model/capability unsupported — MASC worker-layer wrapping of OAS
-       InvalidConfig errors (#9850). *)
-    if contains_ci_scan_limited ~haystack:reason ~needle:"does not support" then
-      Some Model_unsupported
-    (* MASC worker-layer wrapping of the [required_tool_lane_unavailable]
-       InvalidConfig {field = "tool_support"} emitted by
-       Keeper_turn_driver_helpers.required_tool_lane_unavailable_error.
-       Semantically identical to the [does not support] case: this
-       provider's materialized tool set lacks the required lane, but
-       another provider may have it — the cascade must advance. *)
-    else if
-      contains_ci_scan_limited ~haystack:reason ~needle:"required_tool_lane_unavailable"
-    then
-      Some Model_unsupported
-    (* kimi_cli permanent auth/config/model rejection (#9932). *)
-    else if contains_ci_scan_limited ~haystack:reason ~needle:"rejected the request" then
-      Some Request_rejected
-    (* gemini_cli / kimi_cli CLI startup failures. *)
-    else if contains_ci_scan_limited ~haystack:reason ~needle:"startup crash" then
-      Some Startup_crash
-    else
-      None
+    List.find_map
+      (fun (needles, err) ->
+         if List.exists (fun needle -> contains_ci_scan_limited ~haystack:reason ~needle) needles
+         then Some err
+         else None)
+      accept_rejected_rules
 
   (** Return [true] when an HTTP 400/422 body signals a provider-side
       JSON parse failure (M04).

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -225,6 +225,7 @@ let cn_kimi_coding = "kimi-coding"
 let cn_glm = "glm-api"
 let cn_glm_coding_plan = "glm-coding-plan"
 let cn_openrouter = "openrouter"
+let auth_header_authorization = "Authorization"
 let kimi_api_key_envs = [ "KIMI_API_KEY_SB"; "KIMI_API_KEY" ]
 let kimi_coding_key_envs = [ "KIMI_CODING_API_KEY"; "KIMI_API_KEY_SB" ]
 
@@ -1633,7 +1634,7 @@ let apply_wire_overlay
               Masc_network_defaults.openai_chat_completions_path) ->
     let api_key_trimmed = String.trim provider_cfg.api_key in
     let auth_header =
-      if String.equal api_key_trimmed "" then None else Some "Authorization"
+      if String.equal api_key_trimmed "" then None else Some auth_header_authorization
     in
     let static_token =
       if String.equal api_key_trimmed "" then None else Some api_key_trimmed

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1300,7 +1300,7 @@ let explicit_llama_model_id_result () =
   | None ->
     (match nonempty_env "MASC_DEFAULT_PROVIDER", nonempty_env "MASC_DEFAULT_MODEL" with
      | Some provider, Some model_id
-       when String.equal (String.lowercase_ascii provider) "llama" -> Ok model_id
+       when String.equal (String.lowercase_ascii provider) cn_llama -> Ok model_id
      | _ ->
        Error
          "LLAMA_DEFAULT_MODEL is not set; configure LLAMA_DEFAULT_MODEL or \

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -1054,7 +1054,6 @@ let composite_execution_config_drift execution =
 let composite_execution_blocked execution =
   composite_execution_tool_required execution
   || composite_execution_claim_no_eligible execution
-  || composite_execution_config_drift execution
   || string_opt_is_any (json_string "operator_disposition" execution) [ "pause_human" ]
   || (match lower_string_opt (json_string "terminal_reason_code" execution) with
       | Some terminal -> terminal <> "" && terminal <> "completed"
@@ -1100,8 +1099,6 @@ let composite_runtime_attention ~snapshot ~execution =
   let reason =
     if composite_execution_claim_no_eligible execution
     then Some "claim_scope_no_eligible"
-    else if composite_execution_config_drift execution
-    then Some "keeper_cascade_override_drift"
     else match json_string "operator_disposition_reason" execution with
     | Some value when String.trim value <> "" -> Some value
     | _ ->
@@ -1110,6 +1107,8 @@ let composite_runtime_attention ~snapshot ~execution =
        | _ when fiber_stop_requested -> Some "fiber_stop_requested"
        | _ when idle_attention -> Some "idle_composite"
        | _ when stale_without_live_turn -> Some "not_live"
+       | _ when needs_attention && composite_execution_config_drift execution ->
+         Some "keeper_cascade_override_drift"
        | _ when blocked -> Some "runtime_blocked"
        | _ -> None)
   in
@@ -1235,11 +1234,6 @@ let composite_recommended_actions_json ~keeper_name ~snapshot ~execution ~attent
     then
       [ probe ("Inspect keeper claim scope: " ^ reason)
       ; message ("Resolve keeper claim scope before retry: " ^ reason)
-      ]
-    else if composite_execution_config_drift execution
-    then
-      [ probe ("Inspect keeper cascade override drift: " ^ reason)
-      ; message ("Resolve keeper cascade override drift: " ^ reason)
       ]
     else if composite_execution_tool_required execution
     then

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -2135,7 +2135,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
               updated_at = Keeper_types.now_iso ();
             }
           in
-          (match Keeper_types.write_meta ~force:true config updated_meta with
+          (match Keeper_types.write_meta_with_retry config updated_meta with
            | Ok () -> ()
            | Error err ->
                Log.Keeper.warn
@@ -2247,7 +2247,11 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
         then (
           resume_booted_keeper_if_needed ();
           refresh_keeper_execution_surfaces ~config ~name "started")
-        else invalidate_keeper_execution_surfaces ~config ();
+        else (
+          (match Keeper_registry.get_phase ~base_path:config.base_path name with
+           | Some Keeper_state_machine.Paused -> persist_keeper_paused_state true
+           | Some _ | None -> ());
+          invalidate_keeper_execution_surfaces ~config ());
         Http.Response.json ~compress:true ~request:req
           (Printf.sprintf {|{"ok":true,"action":"%s","name":"%s","detail":%s}|}
              (String.escaped action)
@@ -2256,7 +2260,9 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
           reqd
     | Some (true, _body) ->
         (match action with
-         | "shutdown" -> refresh_keeper_execution_surfaces ~config ~name "stopped"
+         | "shutdown" ->
+             persist_keeper_paused_state true;
+             refresh_keeper_execution_surfaces ~config ~name "stopped"
          | _ -> invalidate_keeper_execution_surfaces ~config ());
         Http.Response.json ~compress:true ~request:req
           (Printf.sprintf {|{"ok":true,"action":"%s","name":"%s"}|}

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -21,6 +21,7 @@ let cascade_profile_gate () : cascade_profile_gate =
   let config_path = Cascade_runtime.cascade_config_path () in
   let keeper_profiles =
     Keeper_cascade_profile.keeper_catalog_names ?config_path ()
+    |> Dashboard_cascade.public_profile_names
     |> List.sort_uniq String.compare
   in
   let fallback_invalid_profiles =

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -280,7 +280,8 @@ let make_health_json ?(listener = "http/1.1") request =
        but ops still need a quick count without scraping /metrics. List names
        so an operator can correlate with the cause encoded in their
        last_blocker_class. *)
-    ("paused_keepers", paused_keepers_health_json ());
+    let key_paused_keepers = "paused_keepers" in
+    (key_paused_keepers, paused_keepers_health_json ());
     ("keeper_config_parse_error_count",
      `Int keeper_config_parse_error_count);
     ( "keeper_config_parse_errors",

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -1560,6 +1560,12 @@ let handle_keeper_clear ctx args : tool_result =
         | Ok (Some (_, meta)) -> Some meta
         | _ -> None
       in
+      let preserve_paused_state =
+        (match entry.phase with
+         | Keeper_state_machine.Paused -> true
+         | _ -> false)
+        || Atomic.get entry.fiber_stop
+      in
       let trace_id =
         match meta_for_trace with
         | Some meta -> Keeper_id.Trace_id.to_string meta.runtime.trace_id
@@ -1658,6 +1664,7 @@ let handle_keeper_clear ctx args : tool_result =
               {
                 meta with
                 continuity_summary = "";
+                paused = meta.paused || preserve_paused_state;
                 updated_at = Keeper_types.now_iso ();
                 runtime =
                   {


### PR DESCRIPTION
## Summary

Address hardcoded string literals identified in the 2026-05-14 open-PR review sweep, then fix the dashboard/runtime-surface regressions exposed while rebasing the branch onto current `main`.

## Changes

1. Table-drive `Oas_compat.classify_accept_rejected`
   - Replace the hardcoded if/else chain with a mapping table.
   - New accept-rejected markers become a one-line change.
   - Existing classification behavior is preserved.

2. Use canonical provider constants
   - Replace inline provider-name literals in `Provider_adapter` / `Dashboard_cascade` with canonical constants such as `Provider_adapter.cn_ollama` and `Provider_adapter.cn_llama`.

3. Name stable sentinels and rule ids
   - Extract the meta-cognition tension id into `rule_id_tension_tool_blockage`.
   - Extract the model metrics fallback id into `model_id_unknown`.

4. Restore dashboard runtime truth
   - Dashboard cascade menus now expose public profile names instead of leaking `tier.*` / `tier-group.*` internal aliases.
   - Runtime attention now prioritizes real tool-contract blockers over cascade override drift and avoids recovery actions for healthy recent executions.
   - Keeper shutdown/clear lifecycle preserves paused state through CAS-safe writes.
   - Meta-cognition stagnation scoring no longer underweights small-room idle/blocker signals.

## Verification

- `git diff --check`
- `opam exec -- ocamlformat --check lib/keeper/keeper_turn_lifecycle.ml lib/meta_cognition_snapshot.ml lib/server/server_dashboard_http.ml lib/server/server_dashboard_http_keeper_api.ml lib/server/server_routes_http_routes_dashboard.ml lib/tool_keeper.ml`
- `env DUNE_CACHE=disabled scripts/dune-local.sh build ./bin/main_eio.exe ./test/test_dashboard_keeper_routes.exe ./test/test_meta_cognition_snapshot.exe ./test/test_tool_agent_coverage.exe ./test/test_oas_compat_cascade_fallback.exe ./test/test_provider_adapter.exe ./test/test_model_inference_metrics.exe`
- `./_build/default/test/test_dashboard_keeper_routes.exe` (21 tests)
- `./_build/default/test/test_meta_cognition_snapshot.exe` (4 tests)
- `./_build/default/test/test_tool_agent_coverage.exe` (25 tests)
- `./_build/default/test/test_oas_compat_cascade_fallback.exe` (20 tests)
- `./_build/default/test/test_provider_adapter.exe` (52 tests)
- `./_build/default/test/test_model_inference_metrics.exe` (34 tests)

## Notes

- Rebased onto `origin/main` after the OAS pin moved to `d5037d2346e7e13f5488a13495e65722b0a0a268`.
- The local validation initially reproduced the dashboard route and meta-cognition failures on current `main`; this branch now includes the focused fixes for those current-main regressions.
