### PR TITLE
fix(keeper): keep HITL approval waits out of liveness timeouts

### DIFF
--- a/lib/cascade/cascade_attempt_liveness_observer.ml
+++ b/lib/cascade/cascade_attempt_liveness_observer.ml
@@ -13,6 +13,7 @@ type t = {
   budget : L.budget;
   cascade_label : string;
   candidate_key : string option;
+  external_wait : (unit -> bool) option;
   started_at : float;
   first_chunk_at : float option ref;
   last_chunk_at : float option ref;
@@ -30,13 +31,14 @@ let mode (t : t) : Cfg.mode = t.mode
 
 let public_runtime_provider_label = "runtime"
 
-let create ~mode ~budget ~cascade_label ?candidate_key ~started_at () =
+let create ~mode ~budget ~cascade_label ?external_wait ?candidate_key ~started_at () =
   let stop_tick_p, stop_tick_r = Eio.Promise.create () in
   {
     mode;
     budget;
     cascade_label;
     candidate_key;
+    external_wait;
     started_at;
     first_chunk_at = ref None;
     last_chunk_at = ref None;
@@ -202,6 +204,20 @@ let step_with_event (t : t) (evt : Agent_sdk.Types.sse_event) : unit =
         if L.is_terminal new_state then stop_tick_fiber t;
         react_to_output t output
 
+let external_wait_active (t : t) : bool =
+  match t.external_wait with
+  | None -> false
+  | Some f ->
+    (try f () with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Log.Misc.warn
+         "cascade_attempt_liveness: external_wait predicate raised \
+          (cascade=%s provider=runtime): %s"
+         t.cascade_label
+         (Printexc.to_string exn);
+       false)
+
 let wrap_on_event (t : t)
     (original : (Agent_sdk.Types.sse_event -> unit) option)
     : (Agent_sdk.Types.sse_event -> unit) option =
@@ -271,9 +287,17 @@ let start_tick_fiber (t : t) ~(sw : Eio.Switch.t)
                 if L.is_terminal !(t.state) then ()
                 else begin
                   let now = now_seconds () in
+                  let event =
+                    if external_wait_active t
+                    then L.Chunk (L.Stream_chunk.Heartbeat, now)
+                    else L.Tick now
+                  in
+                  (match event with
+                   | L.Chunk (_, at) -> observe_chunk_clock t ~at
+                   | L.Tick _ | L.Provider_wire_error _ -> ());
                   let new_state, output =
                     L.step ~recorder:(prometheus_recorder t)
-                      t.budget !(t.state) (L.Tick now)
+                      t.budget !(t.state) event
                   in
                   t.state := new_state;
                   (try react_to_output t output

--- a/lib/cascade/cascade_attempt_liveness_observer.mli
+++ b/lib/cascade/cascade_attempt_liveness_observer.mli
@@ -49,6 +49,7 @@ val create :
   mode:Cascade_attempt_liveness_config.mode ->
   budget:Cascade_attempt_liveness.budget ->
   cascade_label:string ->
+  ?external_wait:(unit -> bool) ->
   ?candidate_key:string ->
   started_at:float ->
   unit ->
@@ -59,6 +60,11 @@ val create :
     used only for internal budget history and any successful timing sample
     exposed by {!success_sample_for_candidate}. It is not emitted as a public
     Prometheus label; public observer metrics use a neutral runtime lane.
+
+    [external_wait], when supplied, returns true while the attempt is blocked
+    on a non-provider wait such as MASC HITL approval. During that window the
+    tick fiber feeds liveness heartbeats instead of idle ticks, so operator
+    latency is not classified as provider stream idleness.
 
     [started_at] is the monotonic wall-clock the caller already captured for
     the attempt start.

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -637,7 +637,12 @@ let run_turn
             | Some err -> Error err
             | None ->
               (match
-                 Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s (fun () ->
+                 let bridge_timeout_s =
+                   Keeper_llm_bridge.with_hitl_approval_headroom timeout_s
+                 in
+                 Keeper_llm_bridge.run_with_timeout_and_fallback
+                   ~timeout_s:bridge_timeout_s
+                   (fun () ->
                    Keeper_turn_driver.run_named
                      ~cascade_name:cascade_name_string
                      ~keeper_name:meta.name

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -982,14 +982,17 @@ let sort_entries_by_requested_at entries =
 
 (* ── Submit & await ───────────────────────────────────────── *)
 
+let default_noncritical_approval_timeout_s = 600.0
+
 (** Submit a tool call for approval and suspend the calling fiber.
     Returns the operator's decision when the promise is resolved.
     Called from the OAS approval_callback (inside agent fiber).
 
-    [timeout_s] defaults to 600s for non-[Critical] approvals. This is
-    intentionally longer than the 30s wrapper used by A2 for generic
-    [Eio.Promise.await] sites: a HITL approval is bounded by an
-    operator's response time, not by an SLA on autonomous progress.
+    [timeout_s] defaults to {!default_noncritical_approval_timeout_s}
+    for non-[Critical] approvals. This is intentionally longer than the
+    30s wrapper used by A2 for generic [Eio.Promise.await] sites: a HITL
+    approval is bounded by an operator's response time, not by an SLA on
+    autonomous progress.
     [Critical] approvals are exempt, matching [expire_stale]'s
     operator-must-decide policy. Drop the default only after measuring
     the operator-response distribution — premature shortening turns
@@ -1009,7 +1012,7 @@ let submit_and_await
       ?disposition
       ?disposition_reason
       ?clock
-      ?(timeout_s = 600.0)
+      ?(timeout_s = default_noncritical_approval_timeout_s)
       ()
   : Agent_sdk.Hooks.approval_decision
   =

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -177,6 +177,12 @@ end
 
 (** {1 Submit & await} *)
 
+val default_noncritical_approval_timeout_s : float
+(** Default operator wait used by [submit_and_await] for non-critical
+    approvals. OAS/cascade bridge deadlines that wrap keeper execution must
+    not be shorter than this, otherwise a valid HITL wait is misclassified as
+    provider idleness. *)
+
 (** Submit a tool call for approval and suspend the calling fiber.
     Returns the operator's decision when the promise is resolved.
     Called from the OAS approval_callback (inside the agent fiber). *)

--- a/lib/keeper/keeper_llm_bridge.ml
+++ b/lib/keeper/keeper_llm_bridge.ml
@@ -45,6 +45,13 @@ let bridge_details fields envelope =
     timeout.
     Cancellation (server shutdown / parent fiber cancel) re-raises so the caller
     exits immediately instead of retrying. *)
+
+let with_hitl_approval_headroom timeout_s =
+  Float.max
+    timeout_s
+    (Keeper_approval_queue.default_noncritical_approval_timeout_s +. 30.0)
+;;
+
 let run_with_timeout_and_fallback ~timeout_s fn =
   let fail_without_clock ~site =
     let message =

--- a/lib/keeper/keeper_llm_bridge.mli
+++ b/lib/keeper/keeper_llm_bridge.mli
@@ -1,5 +1,11 @@
 (* lib/keeper/keeper_llm_bridge.mli *)
 
+val with_hitl_approval_headroom : float -> float
+(** Raise an OAS bridge timeout floor above the default non-critical HITL
+    approval wait. This keeps operator approval latency from being surfaced as
+    an OAS/provider timeout before the approval queue itself resolves or
+    expires. *)
+
 (** Runs a generic Eio execution (usually an OAS Agent.run or Model.call) with a strict
     structural timeout.
 

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -295,6 +295,9 @@ let run_try_provider
             ~mode:liveness_mode
             ~budget:resolved_budget.budget
             ~cascade_label:ctx.cascade_name
+            ~external_wait:(fun () ->
+              Keeper_approval_queue.has_pending_for_keeper
+                ~keeper_name:ctx.keeper_name)
             ~candidate_key
             ~started_at:(Time_compat.now ())
             ()

--- a/test/test_cascade_attempt_liveness_observer.ml
+++ b/test/test_cascade_attempt_liveness_observer.ml
@@ -266,6 +266,49 @@ let test_tick_fiber_stops_without_terminal_event () =
   Alcotest.(check bool)
     "pending tick fiber stopped before bootstrap tick" true true
 
+let test_external_wait_heartbeat_prevents_idle_kill () =
+  Eio_main.run (fun env ->
+      let clock = Eio.Stdenv.clock env in
+      let waiting = ref true in
+      let budget =
+        { L.ttft_max = 10.0; inter_chunk_max = 0.05; attempt_wall_max = 10.0 }
+      in
+      Eio.Time.with_timeout_exn clock 1.5 (fun () ->
+          Eio.Switch.run (fun sw ->
+              let obs =
+                Obs.create
+                  ~mode:Cfg.Enforce
+                  ~budget
+                  ~cascade_label:"external_wait_cascade"
+                  ~external_wait:(fun () -> !waiting)
+                  ~started_at:(Time_compat.now ())
+                  ()
+              in
+              Obs.start_tick_fiber obs ~sw ~clock;
+              let wrapped = Obs.wrap_on_event obs None in
+              (match wrapped with
+               | Some f ->
+                 f
+                   (Agent_sdk.Types.ContentBlockStart
+                      { index = 0
+                      ; content_type = "tool_use"
+                      ; tool_id = Some "tool-1"
+                      ; tool_name = Some "keeper_task_create"
+                      })
+               | None -> Alcotest.fail "Enforce wrapper missing");
+              Eio.Time.sleep clock 0.65;
+              waiting := false;
+              Obs.stop_tick_fiber obs;
+              match Obs.current_state_for_test obs with
+              | L.Streaming _ -> ()
+              | L.Failed failure ->
+                Alcotest.failf
+                  "external HITL wait was misclassified as %s"
+                  (L.failure_kind_label failure)
+              | L.Awaiting _ -> Alcotest.fail "expected Streaming state"
+              | L.Success -> Alcotest.fail "unexpected Success state")));
+  Alcotest.(check bool) "external wait did not kill attempt" true true
+
 let () =
   Alcotest.run "cascade_attempt_liveness_observer"
     [
@@ -303,5 +346,9 @@ let () =
             "tick fiber stops without terminal stream event"
             `Quick
             test_tick_fiber_stops_without_terminal_event;
+          Alcotest.test_case
+            "external wait heartbeats prevent idle kill"
+            `Quick
+            test_external_wait_heartbeat_prevents_idle_kill;
         ] );
     ]

--- a/test/test_keeper_llm_bridge.ml
+++ b/test/test_keeper_llm_bridge.ml
@@ -121,6 +121,20 @@ let test_timeout_log_carries_failure_envelope () =
         | Ok value -> Alcotest.failf "unexpected success: %s" value)))
 ;;
 
+let test_hitl_headroom_exceeds_default_approval_wait () =
+  let floor =
+    Keeper_approval_queue.default_noncritical_approval_timeout_s +. 30.0
+  in
+  Alcotest.(check (float 0.001))
+    "short bridge timeout is raised above HITL wait"
+    floor
+    (Keeper_llm_bridge.with_hitl_approval_headroom 292.0);
+  Alcotest.(check (float 0.001))
+    "long bridge timeout is preserved"
+    900.0
+    (Keeper_llm_bridge.with_hitl_approval_headroom 900.0)
+;;
+
 let () =
   Alcotest.run
     "keeper_llm_bridge"
@@ -138,6 +152,10 @@ let () =
             "timeout log carries failure envelope"
             `Quick
             test_timeout_log_carries_failure_envelope
+        ; Alcotest.test_case
+            "HITL approval headroom"
+            `Quick
+            test_hitl_headroom_exceeds_default_approval_wait
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- treat pending keeper HITL approvals as external wait heartbeats for cascade attempt liveness
- raise keeper OAS bridge timeout floor above the default non-critical approval wait
- expose the approval timeout constant so bridge/liveness budgets stay aligned

## Verification
- scripts/dune-local.sh build test/test_cascade_attempt_liveness_observer.exe test/test_keeper_llm_bridge.exe test/test_hitl_approval.exe bin/main_eio.exe
- ./_build/default/test/test_cascade_attempt_liveness_observer.exe
- ./_build/default/test/test_keeper_llm_bridge.exe
- env MASC_BASE_PATH=/private/tmp/masc-hitl-approval-test-base ./_build/default/test/test_hitl_approval.exe test approval_queue 0-12
- ocamlformat --check touched files
- git diff --check HEAD~1..HEAD

## Note
Full test_hitl_approval currently still exposes an existing approval_get/audit-store Eio-context isolation failure outside this patch scope; the approval_queue 0-12 subset covers the submit/await and timeout behavior touched here.