### PR TITLE
fix(spec): refresh cascade fallback line refs

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-14T01:55:32Z (HEAD: 79cdf290c2)
+Generated: 2026-05-14T02:58:24Z (HEAD: b1f8f26fc4)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -75,7 +75,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | AmbiguousPartialCommitBug.tla | AmbiguousPartialCommitBug | manual | 1 | 1 | buggy={inv:TypeOK, inv:Safety} | 40c4f7406ba8 |
 | AtomicFileWrite.tla | AtomicFileWrite | manual | 2 | 1 | clean={inv:ReaderNeverSeesEmpty} buggy={inv:ReaderNeverSeesEmpty} | 95f772ef7488 |
 | AuthIdentityFSM.tla | AuthIdentityFSM | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 55256576bd84 |
-| CascadeCrossFallback.tla | CascadeCrossFallback | manual | 2 | 1 | clean={inv:TypeOK, inv:AtMostOneCrossCascadePerTurn, inv:PromotionRequiresExhaustion, inv:PromotionFrozenAfterFinish} buggy={inv:TypeOK, inv:AtMostOneCrossCascadePerTurn} | f5ae3d5ddf29 |
+| CascadeCrossFallback.tla | CascadeCrossFallback | manual | 2 | 1 | clean={inv:TypeOK, inv:AtMostOneCrossCascadePerTurn, inv:PromotionRequiresExhaustion, inv:PromotionFrozenAfterFinish} buggy={inv:TypeOK, inv:AtMostOneCrossCascadePerTurn} | b32ff3fbc755 |
 | CascadeExhaustion.tla | CascadeExhaustion | manual | 2 | 1 | clean={inv:TypeOK, inv:ExhaustionSafetyLastOk} buggy={inv:TypeOK, inv:ExhaustionDiagnosticConsistency} | 20f49d7b2536 |
 | CascadeLiveness.tla | CascadeLiveness | manual | 3 | 1 | clean={inv:TypeOK, inv:SlotCapacity, inv:SlotNonNeg, inv:NoPhantomSlots, inv:AdmittedOK} buggy={inv:TypeOK, inv:NoPhantomSlots} liveness={inv:TypeOK, inv:SlotCapacity, inv:SlotNonNeg, inv:NoPhantomSlots, inv:AdmittedOK} | 47df51e8fce8 |
 | CooperativeDrainYield.tla | CooperativeDrainYield | manual | 2 | 1 | clean={inv:TypeOK, inv:NoStarvation} buggy={inv:TypeOK, inv:NoStarvation} | d3828a38e496 |

--- a/specs/bug-models/CascadeCrossFallback.tla
+++ b/specs/bug-models/CascadeCrossFallback.tla
@@ -1,12 +1,14 @@
 ---- MODULE CascadeCrossFallback ----
 \* Bug Model: cross-cascade fallback per-turn budget.
 \*
-\* Models the cross-cascade promotion path that PR4 introduces in
-\* lib/cascade/cascade_inventory.ml + the cross-cascade resolver in
-\* lib/cascade/cascade_oas_runner.ml:resolve_tool_capable_provider_across_cascades
-\* (relocated from lib/oas_worker_named.ml by RFC-0047 Phase 4 rename to
-\* lib/keeper/keeper_turn_driver.ml; the resolver itself now lives in
-\* cascade_oas_runner.ml).
+\* Models the cross-cascade promotion path around strict provider resolution,
+\* tool-support filtering, and keeper cascade execution:
+\*   lib/cascade/cascade_catalog_runtime.ml:resolve_named_providers_strict_with_secondary_resolver
+\*   lib/cascade/cascade_oas_runner.ml:filter_candidate_providers_for_tool_support
+\*   lib/keeper/keeper_turn_driver.ml:run_named
+\* The old resolve_tool_capable_provider_across_cascades helper was removed
+\* when runtime routing fallbacks were purged; the safety obligation now lives
+\* on the strict provider resolution + secondary-resolver path above.
 \*
 \* The intended behavior: when a primary cascade exhausts in a turn, the
 \* runtime is allowed to promote ONE provider from the fleet inventory as
@@ -20,16 +22,18 @@
 \* provider. We model that as PromoteUnbounded — Promote without
 \* updating the guard counter.
 \*
-\* Verified against (2026-04-28):
-\*   lib/cascade/cascade_inventory.ml  — pure scoring + best_runner_among
-\*   lib/cascade/cascade_inventory.mli — single-result API contract
-\*   lib/oas_worker_named.ml           — score_provider plumbed into the
-\*                                       cross-cascade resolver site
+\* Verified against (2026-05-14):
+\*   lib/cascade/cascade_catalog_runtime.ml
+\*       — strict provider resolution + secondary resolver
+\*   lib/cascade/cascade_oas_runner.ml
+\*       — tool-support filtering with secondary_resolver
+\*   lib/keeper/keeper_turn_driver.ml
+\*       — keeper named-cascade execution entry point
 \*
-\* The spec is intentionally narrow: it does not model the *choice* of
-\* provider (that is exercised by Alcotest unit tests on
-\* best_runner_among) — it only enforces the safety property "at most
-\* one cross-cascade promotion per turn".
+\* The spec is intentionally narrow: it does not model provider ranking or
+\* request execution. Those are covered by cascade runtime/unit tests; this
+\* spec only enforces the safety property "at most one cross-cascade
+\* promotion per turn".
 
 EXTENDS Naturals
 


### PR DESCRIPTION
## Summary
- refresh CascadeCrossFallback TLA code references after cascade runtime cleanup
- remove stale cascade_inventory / resolve_tool_capable_provider_across_cascades references
- regenerate specs/INDEX.md so the TLA drift gate matches the updated spec hash

## Validation
- bash scripts/lint/spec-line-refs.sh
- git diff --check origin/main
- scripts/gen-tla-index.sh > /tmp/INDEX.new.md
- diff -u <(grep -v '^Generated: ' specs/INDEX.md) <(grep -v '^Generated: ' /tmp/INDEX.new.md)
- gh pr checks 15154 --repo jeong-sik/masc-mcp --watch --interval 10