### PR TITLE
fix(keeper): reject legacy runtime manifest identity fields

### DIFF
--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -203,6 +203,23 @@ let redacts_provider_model_key key =
    || string_contains_substring key "model"
    || String.equal key "configured_labels")
 
+let rec retired_provider_model_key_path ?(prefix = "decision") = function
+  | `Assoc fields ->
+      List.find_map
+        (fun (key, value) ->
+          let path = prefix ^ "." ^ key in
+          if redacts_provider_model_key key then Some path
+          else retired_provider_model_key_path ~prefix:path value)
+        fields
+  | `List values ->
+      values
+      |> List.mapi (fun idx value -> idx, value)
+      |> List.find_map (fun (idx, value) ->
+        retired_provider_model_key_path
+          ~prefix:(Printf.sprintf "%s[%d]" prefix idx)
+          value)
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ -> None
+
 let rec redact_provider_model_json = function
   | `Assoc fields ->
       `Assoc
@@ -275,8 +292,29 @@ let links_of_json = function
                   Ok { receipt_path; checkpoint_path; tool_call_log_path })))
   | _ -> Error "field \"links\" must be an object"
 
+let reject_retired_manifest_fields fields =
+  match List.find_opt (fun (key, _) -> redacts_provider_model_key key) fields with
+  | Some (key, _) ->
+      Error
+        (Printf.sprintf
+           "retired runtime manifest field %S is no longer accepted" key)
+  | None -> Ok ()
+
+let reject_retired_decision_fields decision =
+  match retired_provider_model_key_path decision with
+  | Some path ->
+      Error
+        (Printf.sprintf
+           "retired runtime manifest decision field %S is no longer accepted"
+           path)
+  | None -> Ok ()
+
 let of_json = function
   | `Assoc fields -> (
+      let ( >>= ) result f =
+        match result with Ok value -> f value | Error _ as err -> err
+      in
+      reject_retired_manifest_fields fields >>= fun () ->
       match required_int "schema_version" fields with
       | Error _ as err -> err
       | Ok parsed_schema_version ->
@@ -285,7 +323,6 @@ let of_json = function
               (Printf.sprintf "unsupported schema_version: %d"
                  parsed_schema_version)
           else
-            let ( >>= ) result f = match result with Ok value -> f value | Error _ as err -> err in
             required_string "ts" fields >>= fun ts ->
             required_string "keeper_name" fields >>= fun keeper_name ->
             optional_string "agent_name" fields >>= fun agent_name ->
@@ -301,6 +338,7 @@ let of_json = function
             optional_string "cascade_name" fields >>= fun cascade_name ->
             required_string "status" fields >>= fun status ->
             field "decision" fields >>= fun decision ->
+            reject_retired_decision_fields decision >>= fun () ->
             field "links" fields >>= fun links_json ->
             links_of_json links_json >>= fun links ->
             Ok

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -359,7 +359,7 @@ let test_json_roundtrip () =
         "manifest decision omits response model"
         false
         (json_has_key "response_model" emitted_decision);
-      let legacy_json =
+      let retired_top_level_json =
         `Assoc
           [
             ("schema_version", `Int 1);
@@ -379,22 +379,38 @@ let test_json_roundtrip () =
             ("links", `Assoc []);
           ]
       in
-      match M.of_json legacy_json with
-      | Error msg -> Alcotest.fail ("legacy manifest parse failed: " ^ msg)
-      | Ok legacy ->
-          Alcotest.(check string)
-            "legacy trace parses"
-            "trace-legacy"
-            legacy.trace_id;
-          let legacy_emitted = M.to_json legacy in
-          Alcotest.(check bool)
-            "legacy manifest JSON omits provider kind"
-            false
-            (json_has_key "provider_kind" legacy_emitted);
-          Alcotest.(check bool)
-            "legacy manifest JSON omits model id"
-            false
-            (json_has_key "model_id" legacy_emitted)
+      (match M.of_json retired_top_level_json with
+       | Ok _ -> Alcotest.fail "retired top-level provider/model fields parsed"
+       | Error msg ->
+         Alcotest.(check bool)
+           "retired top-level provider/model fields rejected"
+           true
+           (contains_substring msg "retired runtime manifest field"));
+      let retired_decision_json =
+        `Assoc
+          [
+            ("schema_version", `Int 1);
+            ("ts", `String "2026-05-12T00:00:00Z");
+            ("keeper_name", `String "sangsu");
+            ("agent_name", `Null);
+            ("trace_id", `String "trace-retired-decision");
+            ("generation", `Null);
+            ("keeper_turn_id", `Null);
+            ("oas_turn_count", `Null);
+            ("event", `String "provider_attempt_started");
+            ("cascade_name", `String "default");
+            ("status", `String "started");
+            ("decision", `Assoc [ ("response_model", `String "gpt-test") ]);
+            ("links", `Assoc []);
+          ]
+      in
+      match M.of_json retired_decision_json with
+      | Ok _ -> Alcotest.fail "retired decision provider/model fields parsed"
+      | Error msg ->
+        Alcotest.(check bool)
+          "retired decision provider/model fields rejected"
+          true
+          (contains_substring msg "retired runtime manifest decision field")
 
 let test_of_json_rejects_unknown_event () =
   let json =


### PR DESCRIPTION
## Summary
- reject retired runtime manifest provider/model identity fields during JSON decode
- reject provider/model identity keys nested in manifest decision payloads
- update runtime manifest coverage to prove legacy rows no longer parse while current rows/lens still pass

## Verification
- scripts/dune-local.sh build test/test_keeper_runtime_manifest.exe
- ./_build/default/test/test_keeper_runtime_manifest.exe
- ocamlformat --check lib/keeper/keeper_runtime_manifest.ml test/test_keeper_runtime_manifest.ml
- git diff --check HEAD~1..HEAD