### PR TITLE
fix(keeper): reduce duplicate runtime error logs

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -872,7 +872,7 @@ let emit_operator_broadcast config (receipt : t) ~disposition ~reason =
       ~payload
       ()
   in
-  Log.Keeper.error
+  Log.Keeper.warn
     "%s: operator_broadcast_required emitted disposition=%s reason=%s seq=%d"
     receipt.keeper_name
     (operator_disposition_kind_to_string disposition)
@@ -1024,7 +1024,7 @@ let emit_stale_keeper_broadcast
     Keeper_metrics.metric_keeper_execution_receipt_failures
     ~labels:[ "keeper", keeper_name; "site", Execution_receipt_failure_site.(to_label Stale_broadcast) ]
     ();
-  Log.Keeper.error
+  Log.Keeper.warn
     "%s: stale_keeper_broadcast emitted last_turn=%.0fs ago cascade=%s seq=%d"
     keeper_name
     stale_seconds

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -659,31 +659,70 @@ let persona_name_for_drift_check (meta : keeper_meta) =
   | Error _ -> meta.name
 ;;
 
-let persona_path_for_drift_check ~base_path persona_name =
+let persona_profile_path_for_drift_check ~base_path persona_name =
   match Config_dir_resolver.personas_dir_opt () with
-  | Some dir -> Filename.concat dir persona_name
+  | Some dir ->
+    Filename.concat (Filename.concat dir persona_name) "profile.json"
   | None ->
     Filename.concat
-      (Filename.concat (Common.masc_dir_from_base_path ~base_path) "personas")
-      persona_name
+      (Filename.concat
+         (Filename.concat (Common.masc_dir_from_base_path ~base_path) "personas")
+         persona_name)
+      "profile.json"
+;;
+
+type persona_drift_log_level =
+  | Persona_drift_warn
+  | Persona_drift_error
+
+let keeper_defaults_have_inline_identity
+    (defaults : Keeper_types_profile.keeper_profile_defaults)
+  =
+  Option.is_some defaults.goal
+  || Option.is_some defaults.short_goal
+  || Option.is_some defaults.mid_goal
+  || Option.is_some defaults.long_goal
+  || Option.is_some defaults.will
+  || Option.is_some defaults.needs
+  || Option.is_some defaults.desires
+  || Option.is_some defaults.instructions
+  || defaults.mention_targets <> []
+;;
+
+let persona_drift_log_level_for_missing_profile (meta : keeper_meta) =
+  match Keeper_types_profile.load_keeper_profile_defaults_result meta.name with
+  | Ok defaults when keeper_defaults_have_inline_identity defaults ->
+    Persona_drift_warn
+  | Ok _ | Error _ -> Persona_drift_error
 ;;
 
 let log_persona_drift_if_missing ~base_path (meta : keeper_meta) =
   let persona_name = persona_name_for_drift_check meta in
-  let searched = persona_path_for_drift_check ~base_path persona_name in
+  let searched = persona_profile_path_for_drift_check ~base_path persona_name in
   if Sys.file_exists searched then ()
   else (
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_persona_drift_missing
       ~labels:[ "keeper", meta.name ]
       ();
-    Log.Keeper.error
-      "[#10993][persona_drift] keeper=%s resolved=%s persona file missing at %s — \
-       runtime falls through to logging-only RFC P3-a path; operator action: create \
-       persona file or remove keeper from registry"
-      meta.name
-      persona_name
-      searched)
+    let msg =
+      Printf.sprintf
+        "[#10993][persona_drift] keeper=%s resolved=%s persona profile missing at %s"
+        meta.name
+        persona_name
+        searched
+    in
+    match persona_drift_log_level_for_missing_profile meta with
+    | Persona_drift_warn ->
+      Log.Keeper.warn
+        "%s — using keeper TOML metadata; operator action: add persona profile if \
+         persona assets are required"
+        msg
+    | Persona_drift_error ->
+      Log.Keeper.error
+        "%s — runtime falls through to logging-only RFC P3-a path; operator action: \
+         create persona profile or remove keeper from registry"
+        msg)
 ;;
 
 let supervise_keepalive ~proactive_warmup_sec (ctx : _ context) (meta : keeper_meta) =

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -52,6 +52,21 @@ val persona_name_for_drift_check : keeper_meta -> string
     Honors keeper TOML [persona_name] overlays before falling back to
     the keeper name. *)
 
+val persona_profile_path_for_drift_check :
+  base_path:string -> string -> string
+(** Return the concrete persona [profile.json] path reported by supervisor
+    drift diagnostics. *)
+
+type persona_drift_log_level =
+  | Persona_drift_warn
+  | Persona_drift_error
+
+val persona_drift_log_level_for_missing_profile :
+  keeper_meta -> persona_drift_log_level
+(** Classify a missing persona profile.  Keeper TOML with enough inline
+    identity remains operational and is WARN; keepers without TOML/persona
+    identity are ERROR. *)
+
 val supervision_cohort_size : int
 (** Target keeper count per supervisor cohort.  The first 2-level
     supervision slice groups the 64-keeper fleet as 8 cohorts of 8. *)

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -261,6 +261,54 @@ goal = "plan coding work"
   check string "drift check honors TOML persona_name" "executor"
     (Sup.persona_name_for_drift_check (make_meta "glm-coding-plan"))
 
+let test_persona_drift_path_points_to_profile_json () =
+  with_config_dir @@ fun config_dir ->
+  let expected =
+    Filename.concat
+      (Filename.concat (Filename.concat config_dir "personas") "executor")
+      "profile.json"
+  in
+  check
+    string
+    "profile path"
+    expected
+    (Sup.persona_profile_path_for_drift_check
+       ~base_path:(Filename.dirname (Filename.dirname config_dir))
+       "executor")
+
+let test_missing_persona_with_inline_toml_is_warn () =
+  with_config_dir @@ fun config_dir ->
+  let keepers_dir = Filename.concat config_dir "keepers" in
+  write_file
+    (Filename.concat keepers_dir "inline-only.toml")
+    {|
+[keeper]
+name = "inline-only"
+persona_name = "missing-profile"
+goal = "inline keeper metadata is enough to run"
+|};
+  check
+    bool
+    "inline TOML missing profile is warn"
+    true
+    (match Sup.persona_drift_log_level_for_missing_profile
+             (make_meta "inline-only")
+     with
+     | Sup.Persona_drift_warn -> true
+     | Sup.Persona_drift_error -> false)
+
+let test_missing_persona_without_profile_or_toml_is_error () =
+  with_config_dir @@ fun _config_dir ->
+  check
+    bool
+    "missing profile without TOML is error"
+    true
+    (match Sup.persona_drift_log_level_for_missing_profile
+             (make_meta "missing-everywhere")
+     with
+     | Sup.Persona_drift_error -> true
+     | Sup.Persona_drift_warn -> false)
+
 let registered_entries names =
   Reg.clear ();
   List.map
@@ -1611,6 +1659,12 @@ let () =
     "persona_drift", [
       test_case "drift check honors TOML persona_name" `Quick
         test_persona_drift_check_uses_toml_persona_name;
+      test_case "drift path points to profile.json" `Quick
+        test_persona_drift_path_points_to_profile_json;
+      test_case "missing persona with inline TOML is WARN" `Quick
+        test_missing_persona_with_inline_toml_is_warn;
+      test_case "missing persona without TOML is ERROR" `Quick
+        test_missing_persona_without_profile_or_toml_is_error;
     ];
     "fiber_health", [
       test_case "unknown for unregistered" `Quick test_fiber_health_unknown;


### PR DESCRIPTION
## Summary
- demote successful operator broadcast emission logs from ERROR to WARN while preserving structured activity events and failure receipts
- report persona drift against the concrete profile.json path
- keep missing persona profiles as ERROR only when no TOML/persona identity is available; inline keeper TOML metadata now logs WARN

## Validation
- opam exec -- ocamlformat --check lib/keeper/keeper_supervisor.ml lib/keeper/keeper_supervisor.mli lib/keeper/keeper_execution_receipt.ml test/test_keeper_supervisor.ml
- scripts/dune-local.sh build test/test_keeper_supervisor.exe test/test_keeper_pause_broadcast.exe
- ./_build/default/test/test_keeper_supervisor.exe
- ./_build/default/test/test_keeper_pause_broadcast.exe
- git diff --check