### PR TITLE
feat(ide): anchor thread traces to lines

### DIFF
--- a/dashboard/src/components/ide/anchored-thread-trace-bridge.test.ts
+++ b/dashboard/src/components/ide/anchored-thread-trace-bridge.test.ts
@@ -13,8 +13,9 @@ function post(
   ts_iso: string,
   keeper: string,
   line?: number | null,
+  filePath?: string | null,
 ): AnchoredThreadProducerInput {
-  return { id, created_at_iso: ts_iso, author_identity: keeper, line }
+  return { id, created_at_iso: ts_iso, author_identity: keeper, line, filePath }
 }
 
 beforeEach(() => {
@@ -82,9 +83,9 @@ describe('bridgePostsToTrace — RFC-0028 PR-δ anchored-thread producer', () =>
     expect(ids).toEqual(['p1'])
   })
 
-  it('maps fields correctly: id, tsMs, keeperName, threadId, source, and line', () => {
+  it('maps fields correctly: id, tsMs, keeperName, threadId, source, filePath, and line', () => {
     bridgePostsToTrace(
-      [post('p1', '2026-05-06T01:00:00Z', 'scholar', 42)],
+      [post('p1', '2026-05-06T01:00:00Z', 'scholar', 42, 'lib/runtime.ml')],
       new Set(),
     )
     const event = keeperTraceState.value.events[0]!
@@ -94,6 +95,7 @@ describe('bridgePostsToTrace — RFC-0028 PR-δ anchored-thread producer', () =>
     expect(event.source).toBe('anchored-thread')
     if (event.source === 'anchored-thread') {
       expect(event.threadId).toBe('p1')
+      expect(event.filePath).toBe('lib/runtime.ml')
       expect(event.line).toBe(42)
     }
   })

--- a/dashboard/src/components/ide/anchored-thread-trace-bridge.test.ts
+++ b/dashboard/src/components/ide/anchored-thread-trace-bridge.test.ts
@@ -12,8 +12,9 @@ function post(
   id: string,
   ts_iso: string,
   keeper: string,
+  line?: number | null,
 ): AnchoredThreadProducerInput {
-  return { id, created_at_iso: ts_iso, author_identity: keeper }
+  return { id, created_at_iso: ts_iso, author_identity: keeper, line }
 }
 
 beforeEach(() => {
@@ -81,9 +82,9 @@ describe('bridgePostsToTrace — RFC-0028 PR-δ anchored-thread producer', () =>
     expect(ids).toEqual(['p1'])
   })
 
-  it('maps fields correctly: id, tsMs, keeperName, threadId, source, line=null', () => {
+  it('maps fields correctly: id, tsMs, keeperName, threadId, source, and line', () => {
     bridgePostsToTrace(
-      [post('p1', '2026-05-06T01:00:00Z', 'scholar')],
+      [post('p1', '2026-05-06T01:00:00Z', 'scholar', 42)],
       new Set(),
     )
     const event = keeperTraceState.value.events[0]!
@@ -93,8 +94,23 @@ describe('bridgePostsToTrace — RFC-0028 PR-δ anchored-thread producer', () =>
     expect(event.source).toBe('anchored-thread')
     if (event.source === 'anchored-thread') {
       expect(event.threadId).toBe('p1')
-      expect(event.line).toBeNull()
+      expect(event.line).toBe(42)
     }
+  })
+
+  it('collapses invalid or missing line values to the keeper-level bucket', () => {
+    bridgePostsToTrace(
+      [
+        post('p0', '2026-05-06T01:00:00Z', 'scholar', 0),
+        post('p1', '2026-05-06T01:00:01Z', 'moth'),
+      ],
+      new Set(),
+    )
+
+    const lines = keeperTraceState.value.events
+      .filter(event => event.source === 'anchored-thread')
+      .map(event => event.line)
+    expect(lines).toEqual([null, null])
   })
 
   it('is idempotent across repeated calls with the returned set', () => {

--- a/dashboard/src/components/ide/anchored-thread-trace-bridge.ts
+++ b/dashboard/src/components/ide/anchored-thread-trace-bridge.ts
@@ -21,6 +21,8 @@ import { pushTrace } from './keeper-trace-store'
  *   tsMs       ← Date.parse(post.created_at_iso) (NaN-guarded)
  *   keeperName ← post.author_identity
  *   threadId   ← post.id (BoardPost is the thread itself for now)
+ *   filePath   ← post.filePath when the caller has already resolved a safe
+ *                board-thread file anchor; otherwise null
  *   line       ← post.line when the caller has already resolved a safe
  *                board-thread file anchor; otherwise null so consumers fall
  *                back to the keeper-level no-line bucket per RFC §5
@@ -34,6 +36,7 @@ export interface AnchoredThreadProducerInput {
   readonly id: string
   readonly created_at_iso: string
   readonly author_identity: string
+  readonly filePath?: string | null
   readonly line?: number | null
 }
 
@@ -58,6 +61,7 @@ export function bridgePostsToTrace(
       keeperName: post.author_identity,
       source: 'anchored-thread',
       threadId: post.id,
+      filePath: post.filePath ?? null,
       line: lineFromPost(post),
     })
     next.add(post.id)

--- a/dashboard/src/components/ide/anchored-thread-trace-bridge.ts
+++ b/dashboard/src/components/ide/anchored-thread-trace-bridge.ts
@@ -21,8 +21,9 @@ import { pushTrace } from './keeper-trace-store'
  *   tsMs       ← Date.parse(post.created_at_iso) (NaN-guarded)
  *   keeperName ← post.author_identity
  *   threadId   ← post.id (BoardPost is the thread itself for now)
- *   line       ← null (BoardPost carries no line anchor; consumers fall
- *                back to the keeper-level no-line bucket per RFC §5)
+ *   line       ← post.line when the caller has already resolved a safe
+ *                board-thread file anchor; otherwise null so consumers fall
+ *                back to the keeper-level no-line bucket per RFC §5
  *
  * NaN-guard rationale: a malformed `created_at_iso` would otherwise
  * propagate `NaN` into the store and break binary-search insertion. We
@@ -33,6 +34,7 @@ export interface AnchoredThreadProducerInput {
   readonly id: string
   readonly created_at_iso: string
   readonly author_identity: string
+  readonly line?: number | null
 }
 
 /**
@@ -56,9 +58,15 @@ export function bridgePostsToTrace(
       keeperName: post.author_identity,
       source: 'anchored-thread',
       threadId: post.id,
-      line: null,
+      line: lineFromPost(post),
     })
     next.add(post.id)
   }
   return next
+}
+
+function lineFromPost(post: AnchoredThreadProducerInput): number | null {
+  return typeof post.line === 'number' && Number.isSafeInteger(post.line) && post.line >= 1
+    ? post.line
+    : null
 }

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.test.ts
@@ -290,6 +290,7 @@ describe('IdeConversationRailMock', () => {
       const trace = keeperTraceState.value.events.find(event => event.id === 'thread-line')
       expect(trace).toMatchObject({
         source: 'anchored-thread',
+        filePath: 'lib/runtime.ml',
         line: 42,
       })
     })

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.test.ts
@@ -1,14 +1,44 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
 import { fireEvent, waitFor } from '@testing-library/preact'
 import { IdeConversationRailMock, postsToAnchoredThreads, replayRailItems } from './ide-conversation-rail-mock'
 import { activeIdeFile, ideContextFocus } from './ide-state'
+import { clearTraces, keeperTraceState } from './keeper-trace-store'
+
+function stubEmptyConversationFetch(): void {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (url.startsWith('/api/v1/board')) {
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    if (url.startsWith('/api/v1/dashboard/keeper-decisions')) {
+      return new Response(JSON.stringify({ events: [], limit: 200, generated_at: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    if (url.startsWith('/api/v1/cascade/strategy_trace')) {
+      return new Response(JSON.stringify({ updated_at: null, total_events: 0, events: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    return new Response('{}', { status: 404 })
+  }))
+}
+
+beforeEach(() => {
+  stubEmptyConversationFetch()
+})
 
 afterEach(() => {
   vi.unstubAllGlobals()
   activeIdeFile.value = 'package.json'
   ideContextFocus.value = null
+  clearTraces()
 })
 
 describe('IdeConversationRailMock', () => {
@@ -255,6 +285,13 @@ describe('IdeConversationRailMock', () => {
 
     await waitFor(() => {
       expect(container.textContent).toContain('question fn:run about this line')
+    })
+    await waitFor(() => {
+      const trace = keeperTraceState.value.events.find(event => event.id === 'thread-line')
+      expect(trace).toMatchObject({
+        source: 'anchored-thread',
+        line: 42,
+      })
     })
 
     const card = container.querySelector<HTMLButtonElement>('.ide-conversation-card')

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.ts
@@ -340,6 +340,7 @@ function postToTraceInput(post: BoardPost) {
     id: post.id,
     created_at_iso: post.created_at_iso,
     author_identity: post.author_identity,
+    filePath: anchor?.file_path ?? null,
     line: anchor?.line_start ?? null,
   }
 }

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.ts
@@ -189,7 +189,7 @@ export function IdeConversationRailMock() {
   // re-render with the same posts is a no-op.
   const knownPostIds = useRef<ReadonlySet<string>>(new Set())
   useEffect(() => {
-    knownPostIds.current = bridgePostsToTrace(posts, knownPostIds.current)
+    knownPostIds.current = bridgePostsToTrace(posts.map(postToTraceInput), knownPostIds.current)
   }, [posts])
 
   // RFC-0028 PR-δ-2 cascade-hop producer: each cascade strategy_trace
@@ -331,6 +331,16 @@ function postToAnchoredThread(post: BoardPost): AnchoredThread | null {
     created_ms: createdMs,
     resolved: false,
     reply_count: Number.isSafeInteger(post.comment_count) ? Math.max(0, post.comment_count) : 0,
+  }
+}
+
+function postToTraceInput(post: BoardPost) {
+  const anchor = postToAnchoredThread(post)?.anchor ?? null
+  return {
+    id: post.id,
+    created_at_iso: post.created_at_iso,
+    author_identity: post.author_identity,
+    line: anchor?.line_start ?? null,
   }
 }
 

--- a/dashboard/src/components/ide/ide-editor-extensions.test.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.test.ts
@@ -9,10 +9,14 @@ import {
   lineNumberExt,
   syntaxHighlightExt,
   blameExtensions,
+  keeperTraceLineGutterExt,
+  keeperTraceLinesForFile,
   pushOwnership,
+  pushKeeperTraceLines,
   setOwnership,
 } from './ide-editor-extensions'
 import type { LineOwnership } from './keeper-line-ownership-store'
+import type { KeeperTraceEvent } from './keeper-trace-store'
 
 function createTestView(extensions: Extension[], doc = 'hello\nworld\n') {
   const container = document.createElement('div')
@@ -155,5 +159,80 @@ describe('pushOwnership + setOwnership effect', () => {
     expect((effect as any).is(setOwnership)).toBe(true)
     expect((effect as any).value).toBe(ownership)
     expect((effect as any).value.get(1)?.keeper_id).toBe('gamma')
+  })
+})
+
+describe('keeperTraceLinesForFile + keeper trace gutter', () => {
+  it('keeps only line-anchored trace events for the current file', () => {
+    const events: KeeperTraceEvent[] = [
+      {
+        id: 'thread-1',
+        tsMs: 2000,
+        keeperName: 'scholar',
+        count: 1,
+        source: 'anchored-thread',
+        threadId: 'thread-1',
+        filePath: 'runtime.ts',
+        line: 2,
+      },
+      {
+        id: 'thread-other',
+        tsMs: 3000,
+        keeperName: 'moth',
+        count: 1,
+        source: 'anchored-thread',
+        threadId: 'thread-other',
+        filePath: 'other.ts',
+        line: 2,
+      },
+      {
+        id: 'thread-unscoped',
+        tsMs: 4000,
+        keeperName: 'luna',
+        count: 1,
+        source: 'anchored-thread',
+        threadId: 'thread-unscoped',
+        line: 3,
+      },
+    ]
+
+    expect(keeperTraceLinesForFile('runtime.ts', events)).toEqual([
+      {
+        line: 2,
+        events: [{
+          source: 'anchored-thread',
+          keeperName: 'scholar',
+          count: 1,
+          tsMs: 2000,
+        }],
+      },
+    ])
+  })
+
+  it('renders file-scoped trace dots in the trace gutter', () => {
+    const exts = [themeExt(), readOnlyExt(), keeperTraceLineGutterExt()]
+    const { view, container } = createTestView(exts, 'one\ntwo\nthree\n')
+
+    pushKeeperTraceLines(view, [
+      {
+        line: 2,
+        events: [
+          { source: 'anchored-thread', keeperName: 'scholar', count: 2, tsMs: 2000 },
+          { source: 'anchored-thread', keeperName: 'moth', count: 1, tsMs: 1000 },
+        ],
+      },
+    ])
+
+    const gutter = container.querySelector('.cm-trace-gutter')
+    expect(gutter).not.toBeNull()
+    const dots = gutter?.querySelectorAll('.cm-trace-dot')
+    expect(dots?.length).toBe(2)
+    expect(dots?.[0]?.getAttribute('data-source')).toBe('anchored-thread')
+    expect(dots?.[0]?.getAttribute('aria-label')).toBe('thread scholar x2')
+    expect(gutter?.querySelector('.cm-trace-stack[role="list"]')?.getAttribute('aria-label'))
+      .toContain('Line 2 keeper trace')
+
+    view.destroy()
+    container.remove()
   })
 })

--- a/dashboard/src/components/ide/ide-editor-extensions.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.ts
@@ -8,6 +8,7 @@ import {
   type StreamParser,
 } from '@codemirror/language'
 import type { LineOwnership } from './keeper-line-ownership-store'
+import type { KeeperTraceEvent, KeeperTraceSource } from './keeper-trace-store'
 import { kSigil } from '../keeper-badge'
 
 // ── Read-only lock ────────────────────────────────────────────────
@@ -101,6 +102,36 @@ export function themeExt(): Extension {
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
+    },
+    '.cm-trace-gutter': {
+      minWidth: '34px',
+      borderRight: '1px solid var(--color-border-default)',
+      background: 'var(--color-bg-page)',
+    },
+    '.cm-trace-gutter .cm-gutterElement': {
+      padding: '0 var(--sp-1)',
+      textAlign: 'left',
+    },
+    '.cm-trace-stack': {
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'flex-start',
+      gap: '2px',
+      minWidth: '28px',
+      height: '100%',
+    },
+    '.cm-trace-dot': {
+      display: 'inline-block',
+      width: '6px',
+      height: '6px',
+      borderRadius: '999px',
+      background: 'var(--cm-trace-color)',
+      boxShadow: '0 0 0 1px var(--color-bg-page)',
+    },
+    '.cm-trace-overflow': {
+      color: 'var(--color-fg-muted)',
+      fontSize: 'var(--fs-9)',
+      lineHeight: '1',
     },
     '&.cm-focused': {
       outline: 'none',
@@ -261,6 +292,187 @@ function blameGutterExt(): Extension {
 
 export function pushOwnership(view: EditorView, ownership: ReadonlyMap<number, LineOwnership>): void {
   view.dispatch({ effects: [setOwnership.of(ownership)] })
+}
+
+// ── Keeper trace gutter ───────────────────────────────────────────
+// File-scoped line trace dots for the `keeper-trace` layer.
+
+const TRACE_DOT_CAP = 3
+
+export interface EditorKeeperTraceLineEvent {
+  readonly source: KeeperTraceSource
+  readonly keeperName: string
+  readonly count: number
+  readonly tsMs: number
+}
+
+export interface EditorKeeperTraceLine {
+  readonly line: number
+  readonly events: ReadonlyArray<EditorKeeperTraceLineEvent>
+}
+
+const setKeeperTraceLines = StateEffect.define<ReadonlyArray<EditorKeeperTraceLine>>()
+
+class TraceLineMarker extends GutterMarker {
+  constructor(
+    private readonly line: number,
+    private readonly events: ReadonlyArray<EditorKeeperTraceLineEvent>,
+  ) {
+    super()
+  }
+
+  toDOM(): HTMLElement {
+    const el = document.createElement('span')
+    el.className = 'cm-trace-stack'
+    if (this.events.length === 0) {
+      el.setAttribute('aria-hidden', 'true')
+      return el
+    }
+    el.setAttribute('role', 'list')
+    el.setAttribute('aria-label', traceLineAriaLabel(this.line, this.events))
+    el.title = traceLineTitle(this.line, this.events)
+    const visible = this.events.slice(0, TRACE_DOT_CAP)
+    for (const event of visible) {
+      const dot = document.createElement('span')
+      dot.className = 'cm-trace-dot'
+      dot.setAttribute('role', 'img')
+      dot.setAttribute('aria-label', traceEventLabel(event))
+      dot.setAttribute('data-source', event.source)
+      dot.style.setProperty('--cm-trace-color', traceSourceColor(event.source))
+      el.append(dot)
+    }
+    const overflow = this.events.length - visible.length
+    if (overflow > 0) {
+      const more = document.createElement('span')
+      more.className = 'cm-trace-overflow'
+      more.textContent = `+${overflow}`
+      more.setAttribute('aria-label', `${overflow} more trace events`)
+      el.append(more)
+    }
+    return el
+  }
+
+  eq(other: TraceLineMarker): boolean {
+    return this.line === other.line && traceLineKey(this.events) === traceLineKey(other.events)
+  }
+}
+
+const TRACE_SPACER = new TraceLineMarker(0, [])
+
+const keeperTraceLineField = StateField.define<ReadonlyMap<number, TraceLineMarker>>({
+  create() {
+    return new Map()
+  },
+  update(markers, tr) {
+    for (const effect of tr.effects) {
+      if (!effect.is(setKeeperTraceLines)) continue
+      const next = new Map<number, TraceLineMarker>()
+      for (const traceLine of effect.value) {
+        if (traceLine.line < 1 || traceLine.line > tr.state.doc.lines || traceLine.events.length === 0) continue
+        next.set(traceLine.line, new TraceLineMarker(traceLine.line, traceLine.events))
+      }
+      return next
+    }
+    return markers
+  },
+})
+
+export function keeperTraceLineGutterExt(): Extension {
+  return [
+    keeperTraceLineField,
+    gutter({
+      class: 'cm-trace-gutter',
+      lineMarkerChange(update: ViewUpdate) {
+        return update.startState.field(keeperTraceLineField, false) !== update.state.field(keeperTraceLineField, false)
+      },
+      lineMarker(view, block) {
+        const line = view.state.doc.lineAt(block.from)
+        const field = view.state.field(keeperTraceLineField, false)
+        return field?.get(line.number) ?? null
+      },
+      initialSpacer: () => TRACE_SPACER,
+    }),
+  ]
+}
+
+export function pushKeeperTraceLines(
+  view: EditorView,
+  traceLines: ReadonlyArray<EditorKeeperTraceLine>,
+): void {
+  view.dispatch({ effects: [setKeeperTraceLines.of(traceLines)] })
+}
+
+export function keeperTraceLinesForFile(
+  filePath: string,
+  events: ReadonlyArray<KeeperTraceEvent>,
+): ReadonlyArray<EditorKeeperTraceLine> {
+  const normalizedFilePath = filePath.trim()
+  if (!normalizedFilePath) return []
+
+  const byLine = new Map<number, EditorKeeperTraceLineEvent[]>()
+  for (const event of events) {
+    if (event.source !== 'anchored-thread') continue
+    if (event.filePath !== normalizedFilePath) continue
+    if (event.line === null || !Number.isSafeInteger(event.line) || event.line < 1) continue
+    const existing = byLine.get(event.line) ?? []
+    existing.push({
+      source: event.source,
+      keeperName: event.keeperName,
+      count: event.count,
+      tsMs: event.tsMs,
+    })
+    byLine.set(event.line, existing)
+  }
+
+  return [...byLine.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([line, eventsForLine]) => ({
+      line,
+      events: eventsForLine.sort((left, right) => right.tsMs - left.tsMs),
+    }))
+}
+
+function traceSourceColor(source: KeeperTraceSource): string {
+  switch (source) {
+    case 'anchored-thread':
+      return 'var(--color-status-info)'
+    case 'cascade-hop':
+      return 'var(--color-accent-fg)'
+    case 'bdi-snapshot':
+      return 'var(--color-status-ok)'
+    case 'decision-log':
+      return 'var(--color-status-warn)'
+  }
+}
+
+function traceSourceLabel(source: KeeperTraceSource): string {
+  switch (source) {
+    case 'anchored-thread':
+      return 'thread'
+    case 'cascade-hop':
+      return 'cascade'
+    case 'bdi-snapshot':
+      return 'BDI'
+    case 'decision-log':
+      return 'decision'
+  }
+}
+
+function traceEventLabel(event: EditorKeeperTraceLineEvent): string {
+  const count = event.count > 1 ? ` x${event.count}` : ''
+  return `${traceSourceLabel(event.source)} ${event.keeperName}${count}`
+}
+
+function traceLineAriaLabel(line: number, events: ReadonlyArray<EditorKeeperTraceLineEvent>): string {
+  return `Line ${line} keeper trace: ${events.map(traceEventLabel).join(', ')}`
+}
+
+function traceLineTitle(line: number, events: ReadonlyArray<EditorKeeperTraceLineEvent>): string {
+  return [`L${line}`, ...events.map(traceEventLabel)].join('\n')
+}
+
+function traceLineKey(events: ReadonlyArray<EditorKeeperTraceLineEvent>): string {
+  return events.map(event => `${event.source}:${event.keeperName}:${event.count}:${event.tsMs}`).join('|')
 }
 
 export function keeperLineSelectExt(

--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -6,6 +6,7 @@ import { currentFileFindMatches, IdeEditor } from './ide-editor'
 import { createCodeDocumentStore } from './code-document-store'
 import { createKeeperLineOwnershipStore } from './keeper-line-ownership-store'
 import { activeIdeFile, focusIdeContextAnchor, ideContextFocus } from './ide-state'
+import { clearTraces, pushTrace } from './keeper-trace-store'
 
 describe('IdeEditor', () => {
   let container: HTMLDivElement
@@ -14,11 +15,13 @@ describe('IdeEditor', () => {
     container = document.createElement('div')
     activeIdeFile.value = 'package.json'
     ideContextFocus.value = null
+    clearTraces()
   })
 
   afterEach(() => {
     render(null, container)
     ideContextFocus.value = null
+    clearTraces()
     window.location.hash = ''
   })
 
@@ -157,6 +160,51 @@ describe('IdeEditor', () => {
     expect(container.textContent).toContain('2 layers')
     expect(container.querySelector('[aria-label="Active IDE overlays"]')?.textContent)
       .toContain('Trace')
+  })
+
+  it('renders keeper trace line dots only for the active file when the trace layer is on', async () => {
+    const documentStore = createCodeDocumentStore({
+      file_path: 'runtime.ts',
+      language: 'typescript',
+      content: 'const runtime = 1\nconst task = runtime + 1\n',
+    })
+    const ownershipStore = createKeeperLineOwnershipStore('runtime.ts')
+
+    pushTrace({
+      id: 'thread-runtime',
+      tsMs: 2000,
+      keeperName: 'scholar',
+      source: 'anchored-thread',
+      threadId: 'thread-runtime',
+      filePath: 'runtime.ts',
+      line: 2,
+    })
+    pushTrace({
+      id: 'thread-other',
+      tsMs: 3000,
+      keeperName: 'moth',
+      source: 'anchored-thread',
+      threadId: 'thread-other',
+      filePath: 'other.ts',
+      line: 1,
+    })
+
+    render(
+      h(IdeEditor, {
+        documentStore,
+        ownershipStore,
+        diffRows: () => [],
+        activeLayers: new Set(['keeper-trace']),
+      }),
+      container,
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('.cm-trace-gutter')).not.toBeNull()
+      expect(container.querySelector('.cm-trace-dot')?.getAttribute('aria-label'))
+        .toBe('thread scholar')
+    })
+    expect(container.querySelectorAll('.cm-trace-dot')).toHaveLength(1)
   })
 
   it('counts loaded annotations in the notes overlay summary', () => {

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -19,10 +19,13 @@ import {
   lineNumberExt,
   blameExtensions,
   keeperLineSelectExt,
+  keeperTraceLineGutterExt,
+  keeperTraceLinesForFile,
   contextFocusLineExt,
   focusEditorContextLine,
   annotationLineChipExt,
   pushOwnership,
+  pushKeeperTraceLines,
   pushAnnotationLines,
   internalDocumentSync,
   syntaxHighlightExt,
@@ -32,6 +35,7 @@ import { SplitDiffView, UnifiedDiffView } from './ide-diff-view'
 import { KeeperBadge } from '../keeper-badge'
 import { keeperCursorExtension } from './keeper-cursor-cm-extension'
 import { cursorOverlaySignal, getKeeperColor } from './keeper-cursor-overlay'
+import { keeperTraceState } from './keeper-trace-store'
 import {
   globalPresenceSnapshot,
   type KeeperPresenceSnapshot,
@@ -246,6 +250,7 @@ export function IdeEditor({
               keepers=${keepers}
               onKeeperLineSelect=${onKeeperLineSelect}
               contextFocus=${currentFileFocus}
+              traceActive=${activeLayers.has('keeper-trace')}
               annotations=${annotations}
             />`
       }
@@ -557,6 +562,7 @@ function CodeMirrorEditor({
   onKeeperLineSelect,
   annotations = [],
   contextFocus,
+  traceActive = false,
 }: {
   readonly documentStore: CodeDocumentStore
   readonly ownershipStore: KeeperLineOwnershipStore
@@ -565,6 +571,7 @@ function CodeMirrorEditor({
   readonly onKeeperLineSelect?: (keeperId: string, line: number) => void
   readonly annotations?: ReadonlyArray<IdeAnnotation>
   readonly contextFocus?: IdeContextFocus | null
+  readonly traceActive?: boolean
 }) {
   const containerRef = useRef<HTMLElement>(null)
   const editorRef = useRef<EditorView | null>(null)
@@ -577,6 +584,11 @@ function CodeMirrorEditor({
   const currentFileAnnotations = useMemo(
     () => annotations.filter(annotation => annotation.file_path === document.file_path),
     [annotations, document.file_path],
+  )
+  const traceEvents = keeperTraceState.value.events
+  const traceLines = useMemo(
+    () => traceActive ? keeperTraceLinesForFile(document.file_path, traceEvents) : [],
+    [document.file_path, traceActive, traceEvents],
   )
 
   // Mount CM6 instance
@@ -614,6 +626,9 @@ function CodeMirrorEditor({
           ...(onKeeperLineSelect
             ? [keeperLineSelectExt(() => ownershipStore.ownership(), onKeeperLineSelect)]
             : []),
+          ...(traceActive
+            ? [keeperTraceLineGutterExt()]
+            : []),
           ...blameExts,
         ],
       })
@@ -627,6 +642,9 @@ function CodeMirrorEditor({
       if (showBlame && ownership.size > 0) {
         pushOwnership(view, ownership)
       }
+      if (traceActive && traceLines.length > 0) {
+        pushKeeperTraceLines(view, traceLines)
+      }
       setReady(true)
     }
 
@@ -638,7 +656,7 @@ function CodeMirrorEditor({
       editorRef.current = null
       setReady(false)
     }
-  }, [document.file_path, documentStore, ownershipStore, onKeeperLineSelect, showBlame])
+  }, [document.file_path, documentStore, ownershipStore, onKeeperLineSelect, showBlame, traceActive])
 
   // Push document updates. The first file response can arrive before
   // the CM6 instance is ready or before this component subscribes, so
@@ -660,6 +678,12 @@ function CodeMirrorEditor({
     if (!view || !ready || !showBlame) return
     pushOwnership(view, ownership)
   }, [ownership, ready, showBlame])
+
+  useEffect(() => {
+    const view = editorRef.current
+    if (!view || !ready || !traceActive) return
+    pushKeeperTraceLines(view, traceLines)
+  }, [ready, traceActive, traceLines])
 
   useEffect(() => {
     const view = editorRef.current
@@ -714,6 +738,11 @@ function CodeMirrorEditor({
     const unsub = ownershipStore.subscribe(() => forceRender(n => n + 1))
     return () => unsub()
   }, [ownershipStore])
+  useEffect(() => {
+    if (!traceActive) return
+    const unsub = keeperTraceState.subscribe(() => forceRender(n => n + 1))
+    return () => unsub()
+  }, [traceActive])
 
   return html`
     <div class="ide-codemirror-shell" data-view=${showBlame ? 'blame' : 'source'}>

--- a/dashboard/src/components/ide/keeper-trace-store.test.ts
+++ b/dashboard/src/components/ide/keeper-trace-store.test.ts
@@ -128,6 +128,39 @@ describe('keeper-trace-store', () => {
     expect(keeperTraceState.value.events.map(e => e.keeperName)).toEqual(['scholar', 'moth'])
   })
 
+  it('does NOT coalesce anchored-thread events for different file lines within the window', () => {
+    pushTrace({
+      id: 'a-1',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'anchored-thread',
+      threadId: 'th-1',
+      filePath: 'runtime.ts',
+      line: 12,
+    })
+    pushTrace({
+      id: 'a-2',
+      tsMs: 1010,
+      keeperName: 'scholar',
+      source: 'anchored-thread',
+      threadId: 'th-2',
+      filePath: 'worker.ts',
+      line: 12,
+    })
+    pushTrace({
+      id: 'a-3',
+      tsMs: 1020,
+      keeperName: 'scholar',
+      source: 'anchored-thread',
+      threadId: 'th-3',
+      filePath: 'runtime.ts',
+      line: 20,
+    })
+
+    expect(keeperTraceState.value.events.map(e => e.id)).toEqual(['a-1', 'a-2', 'a-3'])
+    expect(keeperTraceState.value.events.map(e => e.count)).toEqual([1, 1, 1])
+  })
+
   it('inserts out-of-order events into ascending tsMs position', () => {
     pushTrace({
       id: 'a-1',

--- a/dashboard/src/components/ide/keeper-trace-store.ts
+++ b/dashboard/src/components/ide/keeper-trace-store.ts
@@ -49,6 +49,7 @@ export type KeeperTraceEvent =
   | (KeeperTraceBase & {
       readonly source: 'anchored-thread'
       readonly threadId: string
+      readonly filePath?: string | null
       readonly line: number | null
     })
   | (KeeperTraceBase & {
@@ -86,25 +87,26 @@ export const keeperTraceState = signal<KeeperTraceState>(INITIAL_STATE)
  * a fresh entry with `count: 1`.
  *
  * Coalescing rule (RFC-0028 §4):
- *   if the existing entry with the largest tsMs has the same `source` AND the
- *   same `keeperName` AND `(input.tsMs - existing.tsMs) <= COALESCE_WINDOW_MS`,
+ *   if the existing entry with the largest tsMs has the same trace bucket
+ *   (source + keeperName, and for anchored threads also filePath + line)
+ *   AND `(input.tsMs - existing.tsMs) <= COALESCE_WINDOW_MS`,
  *   then replace it in-array with `{ ...existing, count: existing.count + 1, tsMs: input.tsMs }`.
  *   Otherwise insert at the binary-search position and prune retention.
  *
  * Out-of-order tsMs (a producer with stale clock) is supported — the entry
  * is inserted at the correct ascending position. Coalescing only matches the
- * latest entry by tsMs of the same (source, keeperName) tuple.
+ * latest entry by tsMs of the same trace bucket.
  */
 export function pushTrace(input: KeeperTraceEventInput): void {
   const prev = keeperTraceState.value.events
   const incoming: KeeperTraceEvent = { ...input, count: 1 } as KeeperTraceEvent
 
-  // Find latest entry of same (source, keeperName) — needed for coalescing.
+  // Find latest entry of the same trace bucket — needed for coalescing.
   // Walk backwards because retention prune keeps the array bounded.
   let coalesceIdx = -1
   for (let i = prev.length - 1; i >= 0; i -= 1) {
     const candidate = prev[i]!
-    if (candidate.source === incoming.source && candidate.keeperName === incoming.keeperName) {
+    if (sameTraceBucket(candidate, incoming)) {
       coalesceIdx = i
       break
     }
@@ -188,4 +190,13 @@ function insertSorted(
   const next = arr.slice()
   next.splice(lo, 0, incoming)
   return next
+}
+
+function sameTraceBucket(left: KeeperTraceEvent, right: KeeperTraceEvent): boolean {
+  if (left.source !== right.source || left.keeperName !== right.keeperName) return false
+  if (left.source === 'anchored-thread' && right.source === 'anchored-thread') {
+    return (left.filePath ?? null) === (right.filePath ?? null)
+      && left.line === right.line
+  }
+  return true
 }

--- a/dashboard/src/components/ide/overlay-keeper-trace.test.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.test.ts
@@ -20,13 +20,21 @@ function createContainer(): HTMLElement {
   return container
 }
 
-function pushAnchored(id: string, keeperName: string, line: number | null, tsMs: number, threadId = 'th'): void {
+function pushAnchored(
+  id: string,
+  keeperName: string,
+  line: number | null,
+  tsMs: number,
+  threadId = 'th',
+  filePath: string | null = null,
+): void {
   pushTrace({
     id,
     tsMs,
     keeperName,
     source: 'anchored-thread',
     threadId,
+    filePath,
     line,
   })
 }
@@ -73,6 +81,15 @@ describe('bucketTraceEvents — RFC-0028 §5 grouping', () => {
     const buckets = bucketTraceEvents(keeperTraceState.value.events)
     const keys = buckets.map(b => `${b.keeperName}@${b.line}`).sort()
     expect(keys).toEqual(['moth@12', 'scholar@12', 'scholar@99'])
+  })
+
+  it('keeps same-line trace buckets separate when file paths differ', () => {
+    pushAnchored('a', 'scholar', 12, 1000, 'th-a', 'runtime.ts')
+    pushAnchored('b', 'scholar', 12, 1100, 'th-b', 'worker.ts')
+
+    const buckets = bucketTraceEvents(keeperTraceState.value.events)
+    expect(buckets.map(b => `${b.keeperName}@${b.filePath}@${b.line}`).sort())
+      .toEqual(['scholar@runtime.ts@12', 'scholar@worker.ts@12'])
   })
 
   it('non-anchored sources fall into the keeper-level no-line bucket', () => {

--- a/dashboard/src/components/ide/overlay-keeper-trace.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.ts
@@ -51,6 +51,7 @@ const SOURCE_LABELS: Record<KeeperTraceSource, string> = {
 
 interface TraceBucket {
   readonly keeperName: string
+  readonly filePath: string | null
   readonly line: number | null
   readonly events: ReadonlyArray<KeeperTraceEvent>
 }
@@ -65,7 +66,8 @@ export function bucketTraceEvents(
   const map = new Map<string, KeeperTraceEvent[]>()
   for (const event of events) {
     const lineKey = lineOf(event) ?? 'no-line'
-    const key = `${event.keeperName}@${lineKey}`
+    const fileKey = filePathOf(event) ?? 'no-file'
+    const key = `${event.keeperName}@${fileKey}@${lineKey}`
     let group = map.get(key)
     if (!group) {
       group = []
@@ -79,6 +81,7 @@ export function bucketTraceEvents(
     const head = group[0]!
     buckets.push({
       keeperName: head.keeperName,
+      filePath: filePathOf(head),
       line: lineOf(head),
       events: group,
     })
@@ -90,6 +93,10 @@ export function bucketTraceEvents(
 
 function lineOf(event: KeeperTraceEvent): number | null {
   return event.source === 'anchored-thread' ? event.line : null
+}
+
+function filePathOf(event: KeeperTraceEvent): string | null {
+  return event.source === 'anchored-thread' ? event.filePath ?? null : null
 }
 
 interface OverlayKeeperTraceProps {
@@ -183,6 +190,7 @@ function BucketRow({ bucket }: { readonly bucket: TraceBucket }) {
     <div
       role="group"
       data-keeper=${bucket.keeperName}
+      data-file=${bucket.filePath ?? 'no-file'}
       data-line=${bucket.line ?? 'no-line'}
       style=${{ display: 'flex', alignItems: 'center', gap: 'var(--sp-1)' }}
     >


### PR DESCRIPTION
Summary:
- carry safe board-thread path:line anchors into anchored-thread keeper-trace events
- keep generic/invalid board posts in the keeper-level no-line trace bucket
- add component coverage proving a line-anchored board thread now publishes a line-aware keeper trace before focusing the editor line
- stub conversation rail API calls in tests so focused verification does not attempt localhost fetches

Validation:
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/anchored-thread-trace-bridge.ts src/components/ide/anchored-thread-trace-bridge.test.ts src/components/ide/ide-conversation-rail-mock.ts src/components/ide/ide-conversation-rail-mock.test.ts
- pnpm exec vitest run src/components/ide/anchored-thread-trace-bridge.test.ts src/components/ide/ide-conversation-rail-mock.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check