### PR TITLE
fix(keeper): preserve keeper turn ids in runtime manifests

### DIFF
--- a/lib/keeper/keeper_agent_memory_episode.ml
+++ b/lib/keeper/keeper_agent_memory_episode.ml
@@ -29,6 +29,7 @@ let emit_flush_activity
     ~(config : Coord_utils.config)
     ~(keeper_name : string)
     ~(turn : int)
+    ?(oas_turn_count : int option)
     ~(episodes : int)
     ~(procedures : int)
     ?outcome
@@ -41,10 +42,12 @@ let emit_flush_activity
       ; ("procedures", `Int procedures)
       ; ("turn", `Int turn)
       ]
-      @
-      match outcome with
-      | None -> []
-      | Some value -> [ ("outcome", `String value) ]
+      @ (match oas_turn_count with
+         | None -> []
+         | Some count -> [ ("oas_turn_count", `Int count) ])
+      @ (match outcome with
+         | None -> []
+         | Some value -> [ ("outcome", `String value) ])
     in
     try
       (Atomic.get Coord_hooks.activity_emit_fn) config
@@ -76,12 +79,13 @@ let record_success
     ~(keeper_name : string)
     ~(memory : Agent_sdk.Memory.t)
     ~(turn : int)
+    ?(oas_turn_count : int option)
     ~(trace_id : string)
     ~(snapshot : Keeper_memory_policy.keeper_state_snapshot)
     () : unit =
   try
     Memory_oas_bridge.store_episode_from_snapshot ~memory
-      ~keeper_name ~turn ~trace_id snapshot;
+      ~keeper_name ~turn ?oas_turn_count ~trace_id snapshot;
     let episodes, procedures =
       Memory_oas_bridge.flush_incremental ~memory ~agent_name:keeper_name
     in
@@ -89,7 +93,7 @@ let record_success
       Log.Keeper.debug
         "keeper:%s post-run flush episodes=%d procedures=%d"
         keeper_name episodes procedures;
-      emit_flush_activity ~config ~keeper_name ~turn
+      emit_flush_activity ~config ~keeper_name ~turn ?oas_turn_count
         ~episodes ~procedures
         ~tags:[ "memory"; "episode"; "flush" ]
         ()
@@ -151,13 +155,14 @@ let record_failure
     ~(keeper_name : string)
     ~(memory : Agent_sdk.Memory.t)
     ~(turn : int)
+    ?(oas_turn_count : int option)
     ~(trace_id : string)
     ~(error_kind : Memory_oas_bridge.error_kind)
     ~(error_message : string)
     () : unit =
   try
     Memory_oas_bridge.store_failed_turn_episode ~memory
-      ~keeper_name ~turn ~trace_id ~error_kind ~error_message ();
+      ~keeper_name ~turn ?oas_turn_count ~trace_id ~error_kind ~error_message ();
     (* #10341: surface non-keepalive failure modes (timeout, parse) into
        the Agent_stress ledger so the stress dimensions defined in
        agent_stress.mli stop being write-only-for-Failure_streak. *)
@@ -178,7 +183,7 @@ let record_failure
       Log.Keeper.debug
         "keeper:%s post-run failure flush episodes=%d procedures=%d"
         keeper_name episodes procedures;
-      emit_flush_activity ~config ~keeper_name ~turn
+      emit_flush_activity ~config ~keeper_name ~turn ?oas_turn_count
         ~episodes ~procedures ~outcome:"failure"
         ~tags:[ "memory"; "episode"; "flush"; "failure" ]
         ()

--- a/lib/keeper/keeper_agent_memory_episode.mli
+++ b/lib/keeper/keeper_agent_memory_episode.mli
@@ -11,6 +11,7 @@ val emit_flush_activity :
   config:Coord_utils.config ->
   keeper_name:string ->
   turn:int ->
+  ?oas_turn_count:int ->
   episodes:int ->
   procedures:int ->
   ?outcome:string ->
@@ -25,6 +26,7 @@ val record_success :
   keeper_name:string ->
   memory:Agent_sdk.Memory.t ->
   turn:int ->
+  ?oas_turn_count:int ->
   trace_id:string ->
   snapshot:Keeper_memory_policy.keeper_state_snapshot ->
   unit ->
@@ -44,6 +46,7 @@ val record_failure :
   keeper_name:string ->
   memory:Agent_sdk.Memory.t ->
   turn:int ->
+  ?oas_turn_count:int ->
   trace_id:string ->
   error_kind:Memory_oas_bridge.error_kind ->
   error_message:string ->

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1219,7 +1219,7 @@ let run_turn
                     let state_snapshot_sidecar_path =
                       Filename.concat
                         (Filename.concat session.session_dir "state-snapshots")
-                        (Printf.sprintf "turn-%06d.json" result.turns)
+                        (Printf.sprintf "turn-%06d.json" manifest_keeper_turn_id)
                     in
                     let latest_state_snapshot_sidecar_path =
                       Filename.concat session.session_dir "state-snapshot.latest.json"
@@ -1233,6 +1233,7 @@ let run_turn
                           ("agent_name", `String meta.agent_name);
                           ("trace_id", `String trace_id);
                           ("generation", `Int generation);
+                          ("keeper_turn_id", `Int manifest_keeper_turn_id);
                           ("oas_turn_count", `Int result.turns);
                           ( "state_snapshot",
                             Keeper_memory_policy.keeper_state_snapshot_to_json
@@ -1492,7 +1493,7 @@ let run_turn
                               config
                               meta
                               ~snapshot:state_snapshot
-                              ~turn:result.turns
+                              ~turn:manifest_keeper_turn_id
                               ~reply:response_text
                               ()
                           in
@@ -1506,7 +1507,7 @@ let run_turn
                               Keeper_memory_bank.append_memory_notes_from_tool_results
                                 config
                                 meta
-                                ~turn:result.turns
+                                ~turn:manifest_keeper_turn_id
                                 ~results:tool_results)
                             else 0
                           in
@@ -1542,7 +1543,8 @@ let run_turn
                          ~config
                          ~keeper_name:meta.name
                          ~memory
-                         ~turn:result.turns
+                         ~turn:manifest_keeper_turn_id
+                         ~oas_turn_count:result.turns
                          ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
                          ~snapshot:state_snapshot
                          ();
@@ -1628,7 +1630,8 @@ let run_turn
                               ([ "ts_unix", `Float (Time_compat.now ())
                                ; "event", `String "post_turn_eval"
                                ; "keeper_name", `String meta.name
-                               ; "turn", `Int result.turns
+                               ; "turn", `Int manifest_keeper_turn_id
+                               ; "oas_turn_count", `Int result.turns
                                ; "goal_alignment", `Float goal_score
                                ; ( "tools_used_count"
                                  , `Int (List.length actual_keeper_tool_names) )
@@ -1721,16 +1724,13 @@ let run_turn
 	       (match turn_result with
 	        | Ok _ -> ()
 	        | Error err ->
-          let turn =
-            match !receipt_turn_count_ref with
-            | Some turns -> turns
-            | None -> start_turn_count + 1
-          in
+          let oas_turn_count = !receipt_turn_count_ref in
           Keeper_agent_memory_episode.record_failure
             ~config
             ~keeper_name:meta.name
             ~memory
-            ~turn
+            ~turn:manifest_keeper_turn_id
+            ?oas_turn_count
             ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
             ~error_kind:(Memory_oas_bridge.error_kind_of_string (sdk_error_kind err))
             ~error_message:(Agent_sdk.Error.to_string err)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1867,11 +1867,12 @@ let run_turn
                | None -> `Null
                | Some ok -> `Bool ok );
            ]
-       in
-       let append_receipt_manifest ?status ?decision ~site event =
-         let status =
-           match status with
-           | Some status -> status
+         in
+         let append_receipt_manifest ?status ?decision ~site event =
+           let oas_turn_count = receipt.turn_count in
+           let status =
+             match status with
+             | Some status -> status
            | None ->
              Keeper_execution_receipt.outcome_kind_to_string receipt.outcome
          in
@@ -1889,6 +1890,7 @@ let run_turn
            ~keeper_name:receipt.keeper_name ~agent_name:receipt.agent_name
            ~trace_id:receipt.trace_id ~generation:receipt.generation
            ~keeper_turn_id:manifest_keeper_turn_id ~event
+           ?oas_turn_count
            ~cascade_name:
              (Keeper_execution_receipt.cascade_name_to_string receipt.cascade_name)
            ~status ~decision ~receipt_path ?tool_call_log_path ()

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -217,12 +217,13 @@ let run_turn
   let approval_mode_derived = ctx.approval_mode_derived in
   let keeper_oas_context = ctx.keeper_oas_context in
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+  let manifest_keeper_turn_id = meta.runtime.usage.total_turns + 1 in
   let runtime_manifest_context : Keeper_runtime_manifest.turn_context =
     { manifest_keeper_name = meta.name
     ; manifest_agent_name = Some meta.agent_name
     ; manifest_trace_id = trace_id
     ; manifest_generation = Some generation
-    ; manifest_keeper_turn_id = Some (start_turn_count + 1)
+    ; manifest_keeper_turn_id = Some manifest_keeper_turn_id
     }
   in
   let checkpoint_path =
@@ -253,7 +254,7 @@ let run_turn
     Hash.(to_hex (get (loop empty messages)))
   in
   append_manifest ~site:"checkpoint_loaded"
-    ~keeper_turn_id:(start_turn_count + 1)
+    ~keeper_turn_id:manifest_keeper_turn_id
     ~checkpoint_path
     ~decision:
       (`Assoc
@@ -267,7 +268,7 @@ let run_turn
         ])
     Keeper_runtime_manifest.Checkpoint_loaded;
   append_manifest ~site:"context_compacted"
-    ~keeper_turn_id:(start_turn_count + 1)
+    ~keeper_turn_id:manifest_keeper_turn_id
     ~status:(if pre_dispatch_compacted then "compacted" else "skipped")
     ~decision:
       (`Assoc
@@ -303,7 +304,7 @@ let run_turn
   let ctx_work = prompt_ctx.Keeper_run_prompt.ctx_work in
   let history_messages_digest = digest_message_texts_as_joined history_messages in
   append_manifest ~site:"context_injected"
-    ~keeper_turn_id:(start_turn_count + 1)
+    ~keeper_turn_id:manifest_keeper_turn_id
     ~decision:
       (`Assoc
         [
@@ -401,7 +402,7 @@ let run_turn
     let memory = s.Keeper_run_tools.memory in
     let acc = s.Keeper_run_tools.acc in
     append_manifest ~site:"tool_surface_selected"
-      ~keeper_turn_id:(start_turn_count + 1)
+      ~keeper_turn_id:manifest_keeper_turn_id
       ~decision:
         (`Assoc
           [
@@ -1280,7 +1281,7 @@ let run_turn
                         false
                     in
                     append_manifest ~site:"state_snapshot_sidecar"
-                      ~keeper_turn_id:(start_turn_count + 1)
+                      ~keeper_turn_id:manifest_keeper_turn_id
                       ~oas_turn_count:result.turns
                       ~status:
                         (if state_snapshot_sidecar_saved then "saved" else "error")
@@ -1337,7 +1338,7 @@ let run_turn
                           with
                           | Ok () ->
                             append_manifest ~site:"checkpoint_saved"
-                              ~keeper_turn_id:(start_turn_count + 1)
+                              ~keeper_turn_id:manifest_keeper_turn_id
                               ~oas_turn_count:result.turns
                               ~checkpoint_path:
                                 (Keeper_checkpoint_store.oas_checkpoint_path
@@ -1887,7 +1888,7 @@ let run_turn
          Keeper_runtime_manifest.make ~ts:receipt.ended_at
            ~keeper_name:receipt.keeper_name ~agent_name:receipt.agent_name
            ~trace_id:receipt.trace_id ~generation:receipt.generation
-           ~keeper_turn_id:(start_turn_count + 1) ~event
+           ~keeper_turn_id:manifest_keeper_turn_id ~event
            ~cascade_name:
              (Keeper_execution_receipt.cascade_name_to_string receipt.cascade_name)
            ~status ~decision ~receipt_path ?tool_call_log_path ()

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -171,6 +171,11 @@ let prepare_agent_setup
   : (agent_setup, Agent_sdk.Error.sdk_error) result
   =
   let cascade_name_string = Keeper_cascade_profile.runtime_name_to_string cascade_name in
+  let manifest_keeper_turn_id =
+    match runtime_manifest_context with
+    | Some ctx -> ctx.Keeper_runtime_manifest.manifest_keeper_turn_id
+    | None -> None
+  in
   let ctx_snapshot = ctx_work in
   let agent_name = meta.agent_name in
   let acc : hook_accumulator =
@@ -1604,7 +1609,7 @@ let prepare_agent_setup
                   ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
                   ~generation
                   ~turn
-                  ~keeper_turn_id:turn
+                  ?keeper_turn_id:manifest_keeper_turn_id
                   ?task_id:
                     (Option.map Keeper_id.Task_id.to_string acc.meta.current_task_id)
                   ~goal_ids:meta.active_goal_ids

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -411,6 +411,7 @@ let store_episode_from_snapshot
     ~(memory : Agent_sdk.Memory.t)
     ~(keeper_name : string)
     ~(turn : int)
+    ?(oas_turn_count : int option)
     ~(trace_id : string)
     (snapshot : Keeper_memory_policy.keeper_state_snapshot) : unit =
   let parts =
@@ -441,6 +442,15 @@ let store_episode_from_snapshot
       (int_of_float (ts *. 1000.0) mod 1_000_000)
   in
   let episode : Agent_sdk.Memory.episode =
+    let context =
+      [
+        ("trace_id", `String trace_id);
+        ("turn", `String (string_of_int turn));
+      ]
+      @ (match oas_turn_count with
+         | None -> []
+         | Some count -> [ ("oas_turn_count", `String (string_of_int count)) ])
+    in
     {
       id = episode_id;
       timestamp = ts;
@@ -455,12 +465,7 @@ let store_episode_from_snapshot
           ("institution_outcome", `String outcome_str);
           ( "learnings",
             `List (List.map (fun l -> `String l) learnings) );
-          ( "context",
-            `Assoc
-              [
-                ("trace_id", `String trace_id);
-                ("turn", `String (string_of_int turn));
-              ] );
+          ("context", `Assoc context);
         ];
     }
   in
@@ -537,6 +542,7 @@ let store_failed_turn_episode
     ~(memory : Agent_sdk.Memory.t)
     ~(keeper_name : string)
     ~(turn : int)
+    ?(oas_turn_count : int option)
     ~(trace_id : string)
     ~(error_kind : error_kind)
     ~(error_message : string)
@@ -567,6 +573,19 @@ let store_failed_turn_episode
     failure_learnings ~error_kind ~error_preview
   in
   let episode : Agent_sdk.Memory.episode =
+    let context =
+      [
+        ("trace_id", `String trace_id);
+        ("turn", `String (string_of_int turn));
+      ]
+      @ (match oas_turn_count with
+         | None -> []
+         | Some count -> [ ("oas_turn_count", `String (string_of_int count)) ])
+      @ [
+          ("error_kind", `String error_kind_label);
+          ("error_message", `String error_context);
+        ]
+    in
     {
       id = episode_id;
       timestamp = ts;
@@ -589,14 +608,7 @@ let store_failed_turn_episode
              readers can distinguish absent data from a placeholder. *)
           ( "learnings",
             `List (List.map (fun s -> `String s) learnings) );
-          ( "context",
-            `Assoc
-              [
-                ("trace_id", `String trace_id);
-                ("turn", `String (string_of_int turn));
-                ("error_kind", `String error_kind_label);
-                ("error_message", `String error_context);
-              ] );
+          ("context", `Assoc context);
         ];
     }
   in

--- a/lib/memory_oas_bridge.mli
+++ b/lib/memory_oas_bridge.mli
@@ -61,14 +61,16 @@ val store_episode_from_snapshot :
   memory:Agent_sdk.Memory.t ->
   keeper_name:string ->
   turn:int ->
+  ?oas_turn_count:int ->
   trace_id:string ->
   Keeper_memory_policy.keeper_state_snapshot ->
   unit
 (** Captures a successful keeper turn into the OAS memory
     store: serialises the [goal] / [progress] /
     [done_summary] tuple from the snapshot, attaches
-    [keeper_name] / [turn] / [trace_id] metadata, and
-    writes via [Agent_sdk.Memory.store_episode]. *)
+    [keeper_name] / keeper [turn] / [trace_id] metadata, optionally
+    preserves the per-call OAS turn count, and writes via
+    [Agent_sdk.Memory.store_episode]. *)
 
 (** Typed wrapper for failed-turn error-kind labels. JSON/status/metric
     surfaces continue to render the stable string label. *)
@@ -81,6 +83,7 @@ val store_failed_turn_episode :
   memory:Agent_sdk.Memory.t ->
   keeper_name:string ->
   turn:int ->
+  ?oas_turn_count:int ->
   trace_id:string ->
   error_kind:error_kind ->
   error_message:string ->

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -1361,6 +1361,19 @@ let test_successful_provider_turn_links_runtime_artifacts () =
             "state sidecar exists"
             true
             (Sys.file_exists state_path);
+          Alcotest.(check string)
+            "state sidecar uses keeper turn filename"
+            (Printf.sprintf "turn-%06d.json" keeper_turn_id)
+            (Filename.basename state_path);
+          let state_json = Yojson.Safe.from_file state_path in
+          Alcotest.(check int)
+            "state sidecar keeper turn id"
+            keeper_turn_id
+            (json_int_member "keeper_turn_id" state_json);
+          Alcotest.(check int)
+            "state sidecar OAS turn count"
+            result.turn_count
+            (json_int_member "oas_turn_count" state_json);
           Alcotest.(check bool)
             "latest state sidecar exists"
             true
@@ -1698,6 +1711,7 @@ let test_state_sidecar_hydrates_checkpoint_continuity () =
             ("agent_name", `String "runtime-manifest-sidecar-agent");
             ("trace_id", `String trace_id);
             ("generation", `Int 1);
+            ("keeper_turn_id", `Int 8);
             ("oas_turn_count", `Int 1);
             ("state_snapshot", KMP.keeper_state_snapshot_to_json snapshot);
           ]

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -1252,6 +1252,10 @@ let test_successful_provider_turn_links_runtime_artifacts () =
             "latest tool name"
             "keeper_tool_search"
             Yojson.Safe.Util.(latest_tool |> member "tool" |> to_string);
+          Alcotest.(check int)
+            "tool-call log uses keeper turn id"
+            keeper_turn_id
+            (json_int_member "keeper_turn_id" latest_tool);
           let trace_id =
             Masc_mcp.Keeper_id.Trace_id.to_string meta.runtime.trace_id
           in
@@ -1322,6 +1326,10 @@ let test_successful_provider_turn_links_runtime_artifacts () =
           let receipt_path =
             require_some "receipt manifest link" receipt_row.M.links.receipt_path
           in
+          Alcotest.(check (option int))
+            "receipt manifest preserves OAS turn count"
+            (Some result.turn_count)
+            receipt_row.M.oas_turn_count;
           Alcotest.(check bool)
             "receipt file exists"
             true

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -1191,7 +1191,18 @@ let test_successful_provider_turn_links_runtime_artifacts () =
         ~finally:Masc_mcp.Keeper_tool_call_log.reset_for_testing
         (fun () ->
           Masc_mcp.Keeper_tool_call_log.init ~base_path:base_dir ();
-          let meta = make_meta ~name:"runtime-manifest-success" () in
+          let meta =
+            make_meta ~name:"runtime-manifest-success" ()
+            |> fun meta ->
+            {
+              meta with
+              runtime =
+                {
+                  meta.runtime with
+                  usage = { meta.runtime.usage with total_turns = 23 };
+                };
+            }
+          in
           let keeper_turn_id = meta.runtime.usage.total_turns + 1 in
           let session_base_dir = Filename.concat base_dir "sessions" in
           Fs_compat.mkdir_p session_base_dir;
@@ -1269,9 +1280,18 @@ let test_successful_provider_turn_links_runtime_artifacts () =
               M.Receipt_appended;
               M.Turn_finished;
             ];
-          let provider_lane_row =
-            require_manifest_event M.Provider_lane_resolved rows
+          let provider_started_row =
+            require_manifest_event M.Provider_attempt_started rows
           in
+          Alcotest.(check (option int))
+            "provider start uses keeper turn id"
+            (Some keeper_turn_id)
+            provider_started_row.M.keeper_turn_id;
+          let provider_lane_row = require_manifest_event M.Provider_lane_resolved rows in
+          Alcotest.(check (option int))
+            "provider lane uses keeper turn id"
+            (Some keeper_turn_id)
+            provider_lane_row.M.keeper_turn_id;
           Alcotest.(check (option string))
             "provider lane records keeper cascade engine"
             (Some
@@ -1463,7 +1483,18 @@ let test_provider_attempt_finish_recorded_on_oas_timeout () =
             ~finally:Masc_mcp.Keeper_tool_call_log.reset_for_testing
             (fun () ->
               Masc_mcp.Keeper_tool_call_log.init ~base_path:base_dir ();
-              let meta = make_meta ~name:"runtime-manifest-provider-timeout" () in
+              let meta =
+                make_meta ~name:"runtime-manifest-provider-timeout" ()
+                |> fun meta ->
+                {
+                  meta with
+                  runtime =
+                    {
+                      meta.runtime with
+                      usage = { meta.runtime.usage with total_turns = 17 };
+                    };
+                }
+              in
               let keeper_turn_id = meta.runtime.usage.total_turns + 1 in
               let session_base_dir = Filename.concat base_dir "sessions" in
               Fs_compat.mkdir_p session_base_dir;
@@ -1517,6 +1548,10 @@ let test_provider_attempt_finish_recorded_on_oas_timeout () =
               let started_row =
                 require_manifest_event M.Provider_attempt_started rows
               in
+              Alcotest.(check (option int))
+                "timeout provider start uses keeper turn id"
+                (Some keeper_turn_id)
+                started_row.M.keeper_turn_id;
               Alcotest.(check (option string))
                 "declared cascade attempt records model source"
                 (Some "named_cascade")
@@ -1540,6 +1575,10 @@ let test_provider_attempt_finish_recorded_on_oas_timeout () =
               let finished_row =
                 require_manifest_event M.Provider_attempt_finished rows
               in
+              Alcotest.(check (option int))
+                "timeout provider finish uses keeper turn id"
+                (Some keeper_turn_id)
+                finished_row.M.keeper_turn_id;
               Alcotest.(check string)
                 "provider timeout closes attempt"
                 "timeout"

--- a/test/test_memory_oas_5tier.ml
+++ b/test/test_memory_oas_5tier.ml
@@ -476,6 +476,52 @@ let test_flush_episodes_appends_only_new_records () =
   Alcotest.(check bool) "new record appended" true (List.mem "new-episode-id" ids);
   cleanup_tmp_dir dir
 
+let test_success_episode_preserves_oas_turn_count () =
+  let dir = setup_tmp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tmp_dir dir)
+    (fun () ->
+      let memory =
+        Memory_oas_bridge.create_memory ~agent_name:"test-success-turn" ()
+      in
+      let snapshot =
+        {
+          Keeper_memory_policy.empty_keeper_state_snapshot with
+          goal = Some "preserve turn clocks";
+          done_summary = Some "keeper turn completed";
+        }
+      in
+      Memory_oas_bridge.store_episode_from_snapshot
+        ~memory
+        ~keeper_name:"test-success-turn"
+        ~turn:24
+        ~oas_turn_count:1
+        ~trace_id:"trace-success-turn"
+        snapshot;
+      let flushed =
+        Memory_oas_bridge.flush_episodes
+          ~memory
+          ~agent_name:"test-success-turn"
+      in
+      Alcotest.(check int) "success episode flushed" 1 flushed;
+      let persisted = Institution_eio.load_recent_episodes_jsonl ~limit:10 in
+      let episode =
+        List.find_opt
+          (fun (episode : Institution_eio.episode) ->
+            String.equal episode.event_type "keeper_turn"
+            && List.mem "test-success-turn" episode.participants)
+          persisted
+      in
+      match episode with
+      | None -> Alcotest.fail "expected successful keeper_turn episode"
+      | Some episode ->
+        Alcotest.(check string) "trace_id preserved" "trace-success-turn"
+          (List.assoc "trace_id" episode.context);
+        Alcotest.(check string) "keeper turn preserved" "24"
+          (List.assoc "turn" episode.context);
+        Alcotest.(check string) "oas turn count preserved" "1"
+          (List.assoc "oas_turn_count" episode.context))
+
 let test_failed_turn_episode_flushes_failure_outcome () =
   let dir = setup_tmp_dir () in
   Fun.protect
@@ -488,6 +534,7 @@ let test_failed_turn_episode_flushes_failure_outcome () =
         ~memory
         ~keeper_name:"test-failed-turn"
         ~turn:7
+        ~oas_turn_count:2
         ~trace_id:"trace-failed-turn"
         ~error_kind:(Memory_oas_bridge.error_kind_of_string "provider_timeout")
         ~error_message:"provider timed out before producing a tool-using turn"
@@ -517,6 +564,8 @@ let test_failed_turn_episode_flushes_failure_outcome () =
           (List.assoc "trace_id" episode.context);
         Alcotest.(check string) "turn preserved" "7"
           (List.assoc "turn" episode.context);
+        Alcotest.(check string) "oas turn count preserved" "2"
+          (List.assoc "oas_turn_count" episode.context);
         Alcotest.(check string) "error kind preserved" "provider_timeout"
           (List.assoc "error_kind" episode.context);
         Alcotest.(check string) "error message preserved"
@@ -566,6 +615,8 @@ let () =
         test_jsonl_backend_uses_explicit_base_dir;
       Alcotest.test_case "flush_episodes appends only new" `Quick
         test_flush_episodes_appends_only_new_records;
+      Alcotest.test_case "successful keeper turn preserves OAS turn count" `Quick
+        test_success_episode_preserves_oas_turn_count;
       Alcotest.test_case "failed keeper turn flushes failure outcome" `Quick
         test_failed_turn_episode_flushes_failure_outcome;
     ]);


### PR DESCRIPTION
## Summary
- stamp runtime manifest provider/receipt rows with the keeper runtime turn id instead of the OAS session turn count
- use the keeper runtime turn id for durable keeper history sinks: state sidecar filenames/payloads, memory-bank note turns, institution episodes, tool-call log context, and post-turn eval rows
- keep OAS per-call counts in `oas_turn_count`/receipt fields so the two clocks stay separate
- add nonzero keeper-turn regression coverage for runtime artifacts, tool-call logs, receipt manifest rows, and OAS memory episode context

## Evidence
- Live janitor manifest showed `Turn_started` rows at keeper turns 23/24 while provider, receipt, and terminal rows from the same run were stamped `keeper_turn_id=1`.
- State sidecars, memory episodes, and tool-call log context also used OAS per-call turns as primary keeper identity, so a long-running keeper could repeatedly write `turn-000001.json` or group tool evidence under the wrong keeper turn even when the keeper runtime turn was 24+.
- This made runtime-trace grouping collapse distinct keeper turns and produced false dangling provider attempts/evidence-span failures in the fleet readiness gate.

## Verification
- `ocamlformat --check lib/memory_oas_bridge.ml lib/memory_oas_bridge.mli lib/keeper/keeper_agent_memory_episode.ml lib/keeper/keeper_agent_memory_episode.mli lib/keeper/keeper_agent_run.ml lib/keeper/keeper_run_tools.ml test/test_memory_oas_5tier.ml test/test_keeper_runtime_manifest.ml`
- `git diff --check`
- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_runtime_manifest.exe test/test_memory_oas_5tier.exe`
- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_runtime_manifest.exe`
- `./_build/default/test/test_keeper_runtime_manifest.exe` (24 tests)
- `./_build/default/test/test_memory_oas_5tier.exe` (20 tests)
- risk pattern scan on touched files: no new matches; only existing test cleanup helpers use `Sys.readdir`/`Sys.command`