### PR TITLE
fix(keeper): warn on effective CLI MCP config

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -549,44 +549,41 @@ let run_turn
            (Keeper_runtime_resolved.stream_idle_timeout_for_total_timeout
               ~total_timeout_s:timeout_s)
        in
-       (* Observability for issue #10049: providers that declare runtime MCP
-       HTTP header support need claude_mcp_config to reach the masc-mcp
-       HTTP MCP endpoint; otherwise the MCP tool catalog is invisible to
-       the subprocess and the model will correctly report that no shell
-       tools are bound. *)
-       if keeper_oas_context.claude_mcp_config = None
-       then (
-         let configured_model_labels =
-           Keeper_model_labels.configured_model_labels_of_meta meta
-         in
-         let uses_cli_missing_sync =
-           Cascade_runtime_candidate.labels_require_runtime_mcp_header_sync
-             configured_model_labels
-         in
-         if uses_cli_missing_sync
-         then
-           Log.Keeper.warn
-             "keeper %s (cascade=%s): cli-backed providers selected but \
-              claude_mcp_config is None; MCP tool catalog will not be visible to the \
-              subprocess (see issue #10049 for fix plan)"
-             meta.name
-             cascade_name_string);
+       let claude_mcp_config =
+         (* #10049 Option C: auto-construct from the keeper bearer token +
+            server host/port when env is unset. Gated behind
+            MASC_AUTO_CONSTRUCT_CLAUDE_MCP (default true). The existing
+            explicit-env path still wins, and operators can opt out by setting
+            the flag false. *)
+         Keeper_cli_mcp_config.effective_for_keeper
+           ~base_path:config.base_path
+           ~agent_name:meta.agent_name
+           ~configured:keeper_oas_context.claude_mcp_config
+       in
+       (* Observability for issue #10049: warn only when the effective config
+          is still missing after the auto-construction fallback. Otherwise the
+          log incorrectly says the subprocess cannot see MCP even though the
+          transport override is about to provide the generated config. *)
+       let configured_model_labels =
+         Keeper_model_labels.configured_model_labels_of_meta meta
+       in
+       let requires_runtime_mcp_header_sync =
+         Cascade_runtime_candidate.labels_require_runtime_mcp_header_sync
+           configured_model_labels
+       in
+       if
+         Keeper_cli_mcp_config.missing_catalog_warning_required_for_effective
+           ~requires_runtime_mcp_header_sync
+           ~effective_claude_mcp_config:claude_mcp_config
+       then
+         Log.Keeper.warn
+           "keeper %s (cascade=%s): cli-backed providers selected but \
+            effective claude_mcp_config is None; MCP tool catalog will not \
+            be visible to the subprocess (token missing, flag disabled, or \
+            auto-construction failed)"
+           meta.name
+           cascade_name_string;
        let cli_transport_overrides =
-         let claude_mcp_config =
-           match keeper_oas_context.claude_mcp_config with
-           | Some _ as cfg -> cfg
-           | None ->
-             (* #10049 Option C: auto-construct from the keeper bearer
-               token + server host/port when env is unset. Gated
-               behind MASC_AUTO_CONSTRUCT_CLAUDE_MCP (default true). The
-               existing explicit-env path still wins, and operators can opt
-               out by setting the flag false. Returns [None] when the flag
-               is off or the token file is missing — the Log.Keeper.warn
-               above (iter 10052) still fires for visibility. *)
-             Keeper_cli_mcp_config.try_construct_for_keeper
-               ~base_path:config.base_path
-               ~agent_name:meta.agent_name
-         in
          let cli_subprocess_idle_sec =
            Some (Keeper_runtime_resolved.cli_subprocess_idle_sec ())
          in

--- a/lib/keeper/keeper_cli_mcp_config.ml
+++ b/lib/keeper/keeper_cli_mcp_config.ml
@@ -62,3 +62,14 @@ let try_construct_for_keeper ~base_path ~agent_name =
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | _ -> None
+
+let effective_for_keeper ~base_path ~agent_name ~(configured : string option) =
+  match configured with
+  | Some _ as cfg -> cfg
+  | None -> try_construct_for_keeper ~base_path ~agent_name
+
+let missing_catalog_warning_required_for_effective
+      ~requires_runtime_mcp_header_sync
+      ~(effective_claude_mcp_config : string option)
+  =
+  requires_runtime_mcp_header_sync && Option.is_none effective_claude_mcp_config

--- a/lib/keeper/keeper_cli_mcp_config.mli
+++ b/lib/keeper/keeper_cli_mcp_config.mli
@@ -14,3 +14,14 @@ val try_construct_for_keeper :
 (** Returns [Some json] if the feature flag is on AND the token file
     exists, non-empty, and host/port are resolvable. [None] otherwise;
     the caller falls through to the existing behaviour unchanged. *)
+
+val effective_for_keeper :
+  base_path:string -> agent_name:string -> configured:string option -> string option
+(** Explicit config wins; otherwise attempts {!try_construct_for_keeper}. *)
+
+val missing_catalog_warning_required_for_effective :
+  requires_runtime_mcp_header_sync:bool ->
+  effective_claude_mcp_config:string option ->
+  bool
+(** [true] only when CLI runtime MCP header sync is needed and the effective
+    config is still absent. *)

--- a/test/test_keeper_cli_mcp_config.ml
+++ b/test/test_keeper_cli_mcp_config.ml
@@ -4,6 +4,41 @@ open Alcotest
 
 module K = Masc_mcp.Keeper_cli_mcp_config
 
+let mkdir_p path =
+  let rec loop dir =
+    if String.equal dir "" || String.equal dir "." || Sys.file_exists dir
+    then ()
+    else (
+      loop (Filename.dirname dir);
+      Unix.mkdir dir 0o755)
+  in
+  loop path
+;;
+
+let write_file path contents =
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc contents)
+;;
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Array.iter (fun name -> rm_rf (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path)
+    else Unix.unlink path
+;;
+
+let with_temp_base f =
+  let base = Filename.temp_file "keeper-cli-mcp-config-" "" in
+  Unix.unlink base;
+  Unix.mkdir base 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf base) (fun () -> f base)
+;;
+
 let test_build_json_shape () =
   let out = K.build_json ~url:"http://127.0.0.1:8935/mcp" ~bearer_token:"tok" in
   let json = Yojson.Safe.from_string out in
@@ -39,6 +74,59 @@ let test_try_construct_default_true_no_token () =
   let out = K.try_construct_for_keeper ~base_path:base ~agent_name:"nobody" in
   check (option string) "missing token returns None" None out
 
+let test_effective_config_prefers_explicit () =
+  Unix.putenv K.feature_flag_env "false";
+  with_temp_base (fun base ->
+    let explicit = {|{"mcpServers":{"masc":{"type":"http"}}}|} in
+    let out =
+      K.effective_for_keeper
+        ~base_path:base
+        ~agent_name:"keeper"
+        ~configured:(Some explicit)
+    in
+    check (option string) "explicit config wins" (Some explicit) out)
+;;
+
+let test_warning_not_required_when_auto_construct_succeeds () =
+  Unix.putenv K.feature_flag_env "";
+  with_temp_base (fun base ->
+    let auth_dir = Masc_mcp.Auth.auth_dir base in
+    mkdir_p auth_dir;
+    write_file (Filename.concat auth_dir "keeper.token") "token-for-test\n";
+    let effective =
+      K.effective_for_keeper ~base_path:base ~agent_name:"keeper" ~configured:None
+    in
+    let required =
+      K.missing_catalog_warning_required_for_effective
+        ~requires_runtime_mcp_header_sync:true
+        ~effective_claude_mcp_config:effective
+    in
+    check bool "auto-constructed config suppresses warning" false required)
+;;
+
+let test_warning_required_when_auto_construct_fails () =
+  Unix.putenv K.feature_flag_env "";
+  with_temp_base (fun base ->
+    let effective =
+      K.effective_for_keeper ~base_path:base ~agent_name:"keeper" ~configured:None
+    in
+    let required =
+      K.missing_catalog_warning_required_for_effective
+        ~requires_runtime_mcp_header_sync:true
+        ~effective_claude_mcp_config:effective
+    in
+    check bool "missing token keeps warning" true required)
+;;
+
+let test_warning_not_required_without_runtime_mcp_sync () =
+  let required =
+    K.missing_catalog_warning_required_for_effective
+      ~requires_runtime_mcp_header_sync:false
+      ~effective_claude_mcp_config:None
+  in
+  check bool "non-cli labels do not warn" false required
+;;
+
 let () =
   run "keeper_cli_mcp_config" [
     "build_json", [
@@ -50,5 +138,14 @@ let () =
       test_case "explicit false → None" `Quick test_try_construct_disabled_by_default;
       test_case "default true + no token → None" `Quick
         test_try_construct_default_true_no_token;
+    ];
+    "effective", [
+      test_case "explicit config wins" `Quick test_effective_config_prefers_explicit;
+      test_case "auto-construct suppresses warning" `Quick
+        test_warning_not_required_when_auto_construct_succeeds;
+      test_case "missing token keeps warning" `Quick
+        test_warning_required_when_auto_construct_fails;
+      test_case "runtime MCP sync not needed" `Quick
+        test_warning_not_required_without_runtime_mcp_sync;
     ]
   ]


### PR DESCRIPTION
## Summary
- resolve the effective Claude CLI MCP config before warning or building transport overrides
- keep explicit OAS_CLAUDE_MCP_CONFIG precedence, then use keeper-token auto-construction fallback
- add regression coverage for explicit config, successful auto-construction, missing-token warning, and non-CLI no-warning cases

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_agent_run.ml lib/keeper/keeper_cli_mcp_config.ml lib/keeper/keeper_cli_mcp_config.mli test/test_keeper_cli_mcp_config.ml
- git diff --check
- scripts/dune-local.sh build test/test_keeper_cli_mcp_config.exe
- ./_build/default/test/test_keeper_cli_mcp_config.exe