### PR TITLE
feat(ide): link keeper work to execution context

### DIFF
--- a/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
@@ -87,6 +87,39 @@ describe('IdeKeeperWorkPanel', () => {
     fireEvent.click(buttonByText(container, 'Task'))
     expect(window.location.hash).toBe('#workspace?section=planning&view=default&task=task-151')
   })
+
+  it('links the current task to git, telemetry, and keeper context', () => {
+    keepers.value = [keeperFixture()]
+    tasks.value = [taskFixture({
+      goal_id: 'goal-runtime',
+      execution_links: {
+        session_id: 'sess-151',
+        operation_id: 'op-151',
+      },
+    })]
+
+    render(h(IdeKeeperWorkPanel, { keeperName: 'sangsu' }), container)
+
+    const taskLinks = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('.ide-keeper-work-card .ide-keeper-work-links button'),
+    )
+    expect(taskLinks.map(link => link.textContent)).toEqual([
+      'Goal',
+      'Task',
+      'Git',
+      'Telemetry',
+      'Keeper',
+    ])
+    expect(buttonByText(container, 'Git').title).toBe('Git fix/cascade')
+    expect(buttonByText(container, 'Telemetry').title)
+      .toBe('Fleet telemetry event log · session sess-151 · operation op-151 · query op-151')
+
+    fireEvent.click(buttonByText(container, 'Telemetry'))
+    expect(window.location.hash).toContain('#monitoring?section=fleet-health&view=event-log')
+    expect(window.location.hash).toContain('session_id=sess-151')
+    expect(window.location.hash).toContain('operation_id=op-151')
+    expect(window.location.hash).toContain('q=op-151')
+  })
 })
 
 function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {

--- a/dashboard/src/components/ide/ide-keeper-work-panel.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.ts
@@ -14,7 +14,11 @@ import {
   canonicalKeeperName,
   keeperIdentityKeys,
 } from '../common/keeper-identity'
-import { openIdeContextRouteLink, routeLinksForContext } from './ide-context-lens'
+import {
+  openIdeContextRouteLink,
+  routeLinksForContext,
+  type IdeContextRouteLink,
+} from './ide-context-lens'
 import { cursorOverlaySignal, getKeeperColor, type KeeperCursor } from './keeper-cursor-overlay'
 
 interface IdeKeeperWorkPanelProps {
@@ -97,6 +101,7 @@ export function IdeKeeperWorkPanel({ keeperName }: IdeKeeperWorkPanelProps) {
               ${currentTask.worktree
                 ? html`<span title=${currentTask.worktree.path}>${currentTask.worktree.branch} · ${currentTask.worktree.repo_name}</span>`
                 : null}
+              ${TaskRouteLinks(currentTask, summary.currentGoalId, summary.displayName)}
             </div>
           `
           : summary.currentTaskId
@@ -108,6 +113,7 @@ export function IdeKeeperWorkPanel({ keeperName }: IdeKeeperWorkPanelProps) {
                 </div>
                 <strong>keeper runtime current task</strong>
                 <span>task row not present in execution projection</span>
+                ${RuntimeTaskRouteLinks(summary.currentTaskId, summary.currentGoalId, summary.displayName)}
               </div>
             `
           : html`<div class="ide-keeper-work-empty">no active keeper task in dashboard state</div>`}
@@ -171,12 +177,41 @@ function GoalProgressCard(
 }
 
 function GoalRouteLinks(goalId: string, taskId: string | null) {
-  const links = routeLinksForContext({
+  return KeeperWorkRouteLinks(routeLinksForContext({
     goalId,
     taskId: taskId ?? undefined,
-  })
+  }), 'Keeper work planning links')
+}
+
+function TaskRouteLinks(task: Task, fallbackGoalId: string | null, keeperId: string) {
+  const execution = taskExecutionRouteContext(task)
+  return KeeperWorkRouteLinks(routeLinksForContext({
+    goalId: task.goal_id ?? fallbackGoalId ?? undefined,
+    taskId: task.id,
+    gitRef: task.worktree?.branch,
+    sessionId: execution.sessionId ?? undefined,
+    operationId: execution.operationId ?? undefined,
+    telemetryQuery: execution.telemetryQuery ?? undefined,
+    telemetry: execution.hasTelemetry,
+    keeperId,
+  }), 'Keeper task operational links')
+}
+
+function RuntimeTaskRouteLinks(taskId: string, goalId: string | null, keeperId: string) {
+  return KeeperWorkRouteLinks(routeLinksForContext({
+    goalId: goalId ?? undefined,
+    taskId,
+    keeperId,
+  }), 'Keeper runtime task links')
+}
+
+function KeeperWorkRouteLinks(
+  links: ReadonlyArray<IdeContextRouteLink>,
+  label: string,
+) {
+  if (links.length === 0) return null
   return html`
-    <div class="ide-keeper-work-links" aria-label="Keeper work planning links">
+    <div class="ide-keeper-work-links" aria-label=${label}>
       ${links.map(link => html`
         <button
           key=${link.id}
@@ -187,6 +222,32 @@ function GoalRouteLinks(goalId: string, taskId: string | null) {
       `)}
     </div>
   `
+}
+
+function taskExecutionRouteContext(task: Task): {
+  readonly sessionId: string | null
+  readonly operationId: string | null
+  readonly telemetryQuery: string | null
+  readonly hasTelemetry: boolean
+} {
+  const sessionId = firstNonEmpty(
+    task.execution_links?.session_id,
+    task.contract?.links?.session_id,
+  )
+  const operationId = firstNonEmpty(
+    task.execution_links?.operation_id,
+    task.contract?.links?.operation_id,
+  )
+  const autoresearchLoopId = firstNonEmpty(
+    task.execution_links?.autoresearch_loop_id,
+    task.contract?.links?.autoresearch_loop_id,
+  )
+  return {
+    sessionId,
+    operationId,
+    telemetryQuery: firstNonEmpty(operationId, sessionId, autoresearchLoopId),
+    hasTelemetry: Boolean(sessionId || operationId || autoresearchLoopId),
+  }
 }
 
 function WorkMetric(label: string, value: string) {


### PR DESCRIPTION
Summary:
- add operational route links to the IDE keeper work task card, connecting the current task to Goal, Task, Git, Telemetry, and Keeper surfaces when evidence is available
- keep runtime-only current_task rows linkable back to planning/keeper context even when the task row is missing from the projection
- add regression coverage proving task execution links expose Git and telemetry navigation from the IDE rail

Validation:
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/ide-keeper-work-panel.ts src/components/ide/ide-keeper-work-panel.test.ts
- pnpm exec vitest run src/components/ide/ide-keeper-work-panel.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check