### PR TITLE
feat(ide): summarize current file signals

### DIFF
--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -6,6 +6,9 @@ import { currentFileFindMatches, IdeEditor } from './ide-editor'
 import { createCodeDocumentStore } from './code-document-store'
 import { createKeeperLineOwnershipStore } from './keeper-line-ownership-store'
 import { activeIdeFile, focusIdeContextAnchor, ideContextFocus } from './ide-state'
+import { ideConversationThreadSnapshot } from './ide-context-bridge'
+import { lspDiagnosticSnapshot } from './ide-lsp-client'
+import { cursorOverlaySignal } from './keeper-cursor-overlay'
 import { clearTraces, pushTrace } from './keeper-trace-store'
 
 describe('IdeEditor', () => {
@@ -22,6 +25,14 @@ describe('IdeEditor', () => {
     render(null, container)
     ideContextFocus.value = null
     clearTraces()
+    lspDiagnosticSnapshot.value = new Map()
+    ideConversationThreadSnapshot.value = { filePath: '', threads: [] }
+    cursorOverlaySignal.value = {
+      cursors: new Map(),
+      heatmap: new Map(),
+      collisions: [],
+      active_file: null,
+    }
     window.location.hash = ''
   })
 
@@ -205,6 +216,101 @@ describe('IdeEditor', () => {
         .toBe('thread scholar')
     })
     expect(container.querySelectorAll('.cm-trace-dot')).toHaveLength(1)
+  })
+
+  it('summarizes current-file operational signals in the editor header', () => {
+    const documentStore = createCodeDocumentStore({
+      file_path: 'runtime.ts',
+      language: 'typescript',
+      content: 'const runtime = 1\nconst other = 2\n',
+    })
+    const ownershipStore = createKeeperLineOwnershipStore('runtime.ts')
+    lspDiagnosticSnapshot.value = new Map([[
+      'runtime.ts',
+      [{
+        file_path: 'runtime.ts',
+        line: 1,
+        severity: 2,
+        source: 'tsserver',
+        message: 'runtime is never reassigned',
+      }],
+    ]])
+    ideConversationThreadSnapshot.value = {
+      filePath: 'runtime.ts',
+      threads: [{
+        id: 'thread-1',
+        kind: 'question',
+        author_keeper_id: 'sangsu',
+        anchor: {
+          file_path: 'runtime.ts',
+          line_start: 2,
+          line_end: 2,
+          symbol_hint: 'runtime',
+        },
+        body: 'Is this task still tied to the active goal?',
+        created_ms: 1,
+        resolved: false,
+        reply_count: 1,
+      }],
+    }
+    cursorOverlaySignal.value = {
+      cursors: new Map([[
+        'sangsu',
+        {
+          keeper_id: 'sangsu',
+          file_path: 'runtime.ts',
+          line: 2,
+          column: 1,
+          focus_mode: 'editing',
+          last_update: Date.now(),
+        },
+      ]]),
+      heatmap: new Map(),
+      collisions: [],
+      active_file: 'runtime.ts',
+    }
+
+    render(
+      h(IdeEditor, {
+        documentStore,
+        ownershipStore,
+        diffRows: () => [
+          { kind: 'add', oldLine: null, newLine: 1, text: '+const runtime = 1' },
+          { kind: 'delete', oldLine: 2, newLine: null, text: '-const old = 1' },
+        ] as const,
+        annotations: [{
+          id: 'ann-1',
+          file_path: 'runtime.ts',
+          line_start: 1,
+          line_end: 1,
+          keeper_id: 'sangsu',
+          kind: 'Comment',
+          content: 'Keep this task linked to the line',
+          goal_id: 'goal-1',
+          task_id: 'task-1',
+          created_at_ms: 1,
+          updated_at_ms: 1,
+        }],
+      }),
+      container,
+    )
+
+    const signals = [...container.querySelectorAll<HTMLLIElement>('.ide-editor-file-signals > li')]
+    expect(signals.map(item => item.textContent)).toEqual([
+      'LSP1',
+      'Notes1',
+      'Threads1',
+      'Diff2',
+      'Keepers1',
+    ])
+    expect(signals.every(item => item.getAttribute('data-active') === 'true')).toBe(true)
+    expect(signals.map(item => item.title)).toEqual([
+      '1 current-file diagnostic',
+      '1 current-file annotation',
+      '1 current-file anchored thread',
+      '2 current-file changed rows',
+      '1 keeper active in this file',
+    ])
   })
 
   it('counts loaded annotations in the notes overlay summary', () => {

--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
 import { fireEvent, waitFor } from '@testing-library/preact'
-import { currentFileFindMatches, IdeEditor } from './ide-editor'
+import { annotationRouteLinks, currentFileFindMatches, IdeEditor } from './ide-editor'
 import { createCodeDocumentStore } from './code-document-store'
 import { createKeeperLineOwnershipStore } from './keeper-line-ownership-store'
 import { activeIdeFile, focusIdeContextAnchor, ideContextFocus } from './ide-state'
@@ -414,6 +414,46 @@ describe('IdeEditor', () => {
     expect(container.querySelectorAll('.cm-masc-annotation-chip')).toHaveLength(1)
     expect(container.querySelector('.cm-masc-annotation-chip')?.getAttribute('aria-label'))
       .toBe('Line 1 annotation context: Comment · goal goal-1 · task task-1 · keeper sangsu · +1')
+  })
+
+  it('maps annotation detail context into operational route links', () => {
+    const links = annotationRouteLinks({
+      id: 'ann-1',
+      file_path: 'runtime.ts',
+      line_start: 7,
+      line_end: 7,
+      keeper_id: 'sangsu',
+      kind: 'Comment',
+      content: 'Keep this task linked to the active goal',
+      goal_id: 'goal-runtime',
+      task_id: 'task-runtime',
+    })
+
+    expect(links.map(link => link.label)).toEqual(['Code', 'Goal', 'Task', 'Keeper'])
+    expect(links.find(link => link.label === 'Code')).toMatchObject({
+      tab: 'code',
+      params: {
+        section: 'ide-shell',
+        view: 'source',
+        file: 'runtime.ts',
+        line: '7',
+        surface: 'Comment',
+        source_id: 'annotation-ann-1',
+        keeper: 'sangsu',
+      },
+    })
+    expect(links.find(link => link.label === 'Goal')?.params).toMatchObject({
+      section: 'planning',
+      goal: 'goal-runtime',
+    })
+    expect(links.find(link => link.label === 'Task')?.params).toMatchObject({
+      section: 'planning',
+      task: 'task-runtime',
+    })
+    expect(links.find(link => link.label === 'Keeper')?.params).toMatchObject({
+      section: 'agents',
+      keeper: 'sangsu',
+    })
   })
 
   it('shows and highlights the focused context line from the shared IDE signal', async () => {

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -47,7 +47,7 @@ import {
   type KeeperPresenceSnapshot,
   type KeeperPresenceStatus,
 } from './keeper-presence-store'
-import { openIdeContextRouteLink, type IdeContextRouteLink } from './ide-context-lens'
+import { openIdeContextRouteLink, routeLinksForContext, type IdeContextRouteLink } from './ide-context-lens'
 import { ideContextFocus, normalizeIdeContextFilePath, type IdeContextFocus } from './ide-state'
 import { ideConversationThreadSnapshot } from './ide-context-bridge'
 
@@ -1153,6 +1153,7 @@ function AnnotationPopover({
 
   const top = coords.bottom - shellRect.top + 4
   const left = Math.max(8, coords.left - shellRect.left)
+  const routeLinks = annotationRouteLinks(annotation)
 
   return html`
     <div
@@ -1207,6 +1208,15 @@ function AnnotationPopover({
       <div style=${{ color: 'var(--color-fg-primary)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
         ${annotation.content}
       </div>
+      ${routeLinks.length > 0 ? html`
+        <div
+          class="ide-editor-context-route-links"
+          aria-label="Annotation operational links"
+          style=${{ marginTop: 'var(--sp-2)' }}
+        >
+          ${routeLinks.map(link => EditorContextRouteLink(link))}
+        </div>
+      ` : null}
       <div style=${{ display: 'flex', gap: 'var(--sp-2)', marginTop: 'var(--sp-2)', flexWrap: 'wrap' }}>
         ${annotation.keeper_id ? html`
           <span style=${{ color: 'var(--color-fg-muted)', fontSize: '11px' }}>
@@ -1226,4 +1236,17 @@ function AnnotationPopover({
       </div>
     </div>
   `
+}
+
+export function annotationRouteLinks(annotation: SelectedAnnotation): ReadonlyArray<IdeContextRouteLink> {
+  return routeLinksForContext({
+    filePath: annotation.file_path,
+    line: annotation.line_start,
+    surface: annotation.kind,
+    label: annotation.content,
+    sourceId: `annotation-${annotation.id}`,
+    goalId: annotation.goal_id ?? undefined,
+    taskId: annotation.task_id ?? undefined,
+    keeperId: annotation.keeper_id,
+  })
 }

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -30,7 +30,13 @@ import {
   internalDocumentSync,
   syntaxHighlightExt,
 } from './ide-editor-extensions'
-import { lspExtension, getSelectedAnnotation, clearSelectedAnnotation, type SelectedAnnotation } from './ide-lsp-client'
+import {
+  lspDiagnosticSnapshot,
+  lspExtension,
+  getSelectedAnnotation,
+  clearSelectedAnnotation,
+  type SelectedAnnotation,
+} from './ide-lsp-client'
 import { SplitDiffView, UnifiedDiffView } from './ide-diff-view'
 import { KeeperBadge } from '../keeper-badge'
 import { keeperCursorExtension } from './keeper-cursor-cm-extension'
@@ -42,7 +48,8 @@ import {
   type KeeperPresenceStatus,
 } from './keeper-presence-store'
 import { openIdeContextRouteLink, type IdeContextRouteLink } from './ide-context-lens'
-import { ideContextFocus, type IdeContextFocus } from './ide-state'
+import { ideContextFocus, normalizeIdeContextFilePath, type IdeContextFocus } from './ide-state'
+import { ideConversationThreadSnapshot } from './ide-context-bridge'
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -62,6 +69,13 @@ interface IdeEditorProps {
   readonly onFindClose?: () => void
   readonly onKeeperLineSelect?: (keeperId: string, line: number) => void
   readonly annotations?: ReadonlyArray<IdeAnnotation>
+}
+
+interface CurrentFileSignal {
+  readonly id: string
+  readonly label: string
+  readonly count: number
+  readonly title: string
 }
 
 export interface FindOptions {
@@ -122,6 +136,14 @@ export function IdeEditor({
     const unsub = ideContextFocus.subscribe(() => forceRender(tick => tick + 1))
     return () => unsub()
   }, [])
+  useEffect(() => {
+    const unsub = ideConversationThreadSnapshot.subscribe(() => forceRender(tick => tick + 1))
+    return () => unsub()
+  }, [])
+  useEffect(() => {
+    const unsub = lspDiagnosticSnapshot.subscribe(() => forceRender(tick => tick + 1))
+    return () => unsub()
+  }, [])
 
   const document = documentStore.document()
   const lines = documentStore.lines()
@@ -134,6 +156,12 @@ export function IdeEditor({
   const activeCursors = keepersWithCursorInFile(overlay.cursors, document.file_path)
   const activeLayerKinds = activeLayersInDisplayOrder(activeLayers)
   const currentDiffRows = diffRows()
+  const currentFileSignals = buildCurrentFileSignals({
+    filePath: document.file_path,
+    annotations,
+    diffRows: currentDiffRows,
+    activeKeeperCount: activeCursors.length,
+  })
   const gridTemplateRows = editorGridRows(activeLayerKinds.length > 0, findOpen)
 
   return html`
@@ -172,6 +200,7 @@ export function IdeEditor({
         <span style=${{ marginLeft: 'auto', flexShrink: 0, whiteSpace: 'nowrap' }}>
           ${lines.length} lines · ownership · ${keepers.length} keepers · ${activeLayerKinds.length} layers
         </span>
+        <${EditorCurrentFileSignals} signals=${currentFileSignals} />
         ${currentFileFocus ? html`
           <div
             role="status"
@@ -255,6 +284,91 @@ export function IdeEditor({
             />`
       }
     </div>
+  `
+}
+
+function buildCurrentFileSignals({
+  filePath,
+  annotations,
+  diffRows,
+  activeKeeperCount,
+}: {
+  readonly filePath: string
+  readonly annotations: ReadonlyArray<IdeAnnotation>
+  readonly diffRows: ReadonlyArray<UnifiedDiffRow>
+  readonly activeKeeperCount: number
+}): ReadonlyArray<CurrentFileSignal> {
+  const normalizedFile = normalizeIdeContextFilePath(filePath)
+  const matchesCurrentFile = (value: string): boolean =>
+    normalizedFile !== null && normalizeIdeContextFilePath(value) === normalizedFile
+  const diagnosticCount = normalizedFile
+    ? lspDiagnosticSnapshot.value.get(normalizedFile)?.length ?? 0
+    : 0
+  const annotationCount = annotations.filter(annotation =>
+    matchesCurrentFile(annotation.file_path),
+  ).length
+  const threadSnapshot = ideConversationThreadSnapshot.value
+  const threadCount = matchesCurrentFile(threadSnapshot.filePath)
+    ? threadSnapshot.threads.length
+    : 0
+  const changedRows = diffRows.filter(row => row.kind === 'add' || row.kind === 'delete')
+  return [
+    {
+      id: 'lsp',
+      label: 'LSP',
+      count: diagnosticCount,
+      title: `${diagnosticCount} current-file diagnostic${diagnosticCount === 1 ? '' : 's'}`,
+    },
+    {
+      id: 'notes',
+      label: 'Notes',
+      count: annotationCount,
+      title: `${annotationCount} current-file annotation${annotationCount === 1 ? '' : 's'}`,
+    },
+    {
+      id: 'threads',
+      label: 'Threads',
+      count: threadCount,
+      title: `${threadCount} current-file anchored thread${threadCount === 1 ? '' : 's'}`,
+    },
+    {
+      id: 'diff',
+      label: 'Diff',
+      count: changedRows.length,
+      title: `${changedRows.length} current-file changed row${changedRows.length === 1 ? '' : 's'}`,
+    },
+    {
+      id: 'keepers',
+      label: 'Keepers',
+      count: activeKeeperCount,
+      title: `${activeKeeperCount} keeper${activeKeeperCount === 1 ? '' : 's'} active in this file`,
+    },
+  ]
+}
+
+function EditorCurrentFileSignals({
+  signals,
+}: {
+  readonly signals: ReadonlyArray<CurrentFileSignal>
+}) {
+  return html`
+    <ul
+      class="ide-editor-file-signals"
+      role="list"
+      aria-label="Current file operational signals"
+    >
+      ${signals.map(signal => html`
+        <li
+          key=${signal.id}
+          role="listitem"
+          data-active=${signal.count > 0 ? 'true' : 'false'}
+          title=${signal.title}
+        >
+          <span>${signal.label}</span>
+          <strong>${signal.count}</strong>
+        </li>
+      `)}
+    </ul>
   `
 }
 

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -1863,6 +1863,52 @@
   white-space: nowrap;
 }
 
+.ide-editor-file-signals {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 3px;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  flex: 0 1 auto;
+}
+
+.ide-editor-file-signals > li {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  height: 18px;
+  padding: 0 5px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-page);
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+}
+
+.ide-editor-file-signals > li[data-active="true"] {
+  border-color: color-mix(in srgb, var(--color-accent-fg) 36%, var(--color-border-default));
+  background: color-mix(in srgb, var(--color-bg-elevated) 82%, var(--color-accent-fg));
+  color: var(--color-accent-fg);
+}
+
+.ide-editor-file-signals span,
+.ide-editor-file-signals strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-editor-file-signals strong {
+  color: var(--color-fg-primary);
+  font-weight: 700;
+}
+
 .ide-editor-context-route-links {
   display: inline-flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Summary:
- add a compact current-file signal strip to the IDE editor header for LSP diagnostics, notes, anchored threads, changed diff rows, and active keepers
- subscribe the editor header to conversation-thread and LSP diagnostic snapshots so the NOW/file view updates without switching rails
- add focused regression coverage for current-file signal counts and accessible chip titles

Validation:
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/ide-editor.ts src/components/ide/ide-editor.test.ts
- pnpm exec vitest run src/components/ide/ide-editor.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check