### PR TITLE
fix(keeper): separate tool-route errors from provider availability

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -581,7 +581,7 @@ let run_turn
            "keeper %s (cascade=%s): cli-backed providers selected but \
             effective claude_mcp_config is None; MCP tool catalog will not \
             be visible to the subprocess (token missing, flag disabled, or \
-            auto-construction failed)"
+           auto-construction failed)"
            meta.name
            cascade_name_string;
        let cli_transport_overrides =

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -513,11 +513,28 @@ let operator_disposition (receipt : t)
     | Some _ | None -> false
   then Disp_pause_human, Reason_internal_error
   else if
+    let canonical_names names =
+      names
+      |> List.map Keeper_tool_disclosure.canonical_tool_name
+      |> Keeper_types.dedupe_keep_order
+    in
+    let used_tool_names =
+      canonical_names
+        (receipt.canonical_tools @ receipt.observed_tools @ receipt.tools_used)
+    in
+    let required_tool_names = canonical_names receipt.tool_surface.required_tools in
+    let required_tools_satisfied =
+      required_tool_names <> []
+      && receipt.tool_surface.missing_required_tools = []
+      && List.for_all
+           (fun required -> List.mem required used_tool_names)
+           required_tool_names
+    in
     let ok_followup_progress =
       receipt.outcome = `Ok
       && receipt.cascade_outcome = Cascade_completed
       && receipt.tool_contract_result = Contract_needs_execution_progress
-      && receipt.tools_used <> []
+      && required_tools_satisfied
     in
     receipt.tool_surface.tool_requirement = Required
     && (List.mem

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -513,6 +513,12 @@ let operator_disposition (receipt : t)
     | Some _ | None -> false
   then Disp_pause_human, Reason_internal_error
   else if
+    let ok_followup_progress =
+      receipt.outcome = `Ok
+      && receipt.cascade_outcome = Cascade_completed
+      && receipt.tool_contract_result = Contract_needs_execution_progress
+      && receipt.tools_used <> []
+    in
     receipt.tool_surface.tool_requirement = Required
     && (List.mem
           receipt.tool_contract_result
@@ -526,6 +532,7 @@ let operator_disposition (receipt : t)
           ; Contract_no_tool_capable_provider
           ]
         || receipt.tools_used = [])
+    && not ok_followup_progress
   then Disp_pause_human, Reason_tool_required_unsatisfied
   else if receipt.degraded_retry_applied || Option.is_some receipt.degraded_retry_cascade
   then Disp_fail_open_next_cascade, Reason_degraded_retry

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -97,6 +97,11 @@ let shell_interpreter_names = [ "bash"; "sh"; "zsh" ]
 
 let command_name text = Filename.basename text
 
+let is_direct_masc_tool_command_name name =
+  String.starts_with ~prefix:"keeper_" name
+  || String.starts_with ~prefix:"masc_" name
+  || String.equal name "extend_turns"
+
 let shell_c_payload words =
   match words with
   | shell :: rest when
@@ -141,6 +146,34 @@ and strip_env_args = function
   | word :: rest when is_env_assignment word.text ->
     strip_env_args rest
   | words -> strip_command_wrappers words
+
+let direct_tool_command_name ~meta cmd =
+  let allowed =
+    Keeper_tool_policy.keeper_universe_tool_names meta
+    |> List.map String.lowercase_ascii
+  in
+  let rec first_command_name cmd =
+    let words = shell_words_with_boundaries cmd in
+    let first_from_words =
+      let rec loop = function
+        | word :: rest when word.starts_command ->
+          (match strip_command_wrappers (word :: rest) with
+           | first :: _ -> Some (command_name first.text)
+           | [] -> None)
+        | _ :: rest -> loop rest
+        | [] -> None
+      in
+      loop words
+    in
+    match shell_c_payload words with
+    | Some payload -> first_command_name payload
+    | None -> first_from_words
+  in
+  match first_command_name cmd with
+  | Some name when is_direct_masc_tool_command_name name ->
+    let normalized = String.lowercase_ascii name in
+    Some (name, List.mem normalized allowed)
+  | _ -> None
 
 let gh_pr_create_sequence = function
   | gh :: pr :: create :: _ ->
@@ -211,6 +244,40 @@ let handle_keeper_bash
          ; "cmd", `String cmd_for_log
          ])
   in
+  let direct_tool_command_block ~tool_policy_visible tool_name =
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_shell_bash_failures
+      ~labels:[("keeper", meta.name); ("site", "tool_invoked_as_shell")]
+      ();
+    Log.Keeper.warn
+      "keeper_bash direct tool command blocked: keeper=%s tool=%s cmd=%s"
+      meta.name tool_name cmd_for_log;
+    Yojson.Safe.to_string
+      (`Assoc
+         [ "ok", `Bool false
+         ; "error", `String "tool_invoked_as_shell_command"
+         ; "tool", `String tool_name
+         ; "cmd", `String cmd_for_log
+         ; "hint",
+           `String
+             (if tool_policy_visible
+              then
+                Printf.sprintf
+                  "%s is a MASC tool, not a shell command. Call the %s \
+                   tool directly with JSON arguments instead of using Bash."
+                  tool_name tool_name
+              else
+                Printf.sprintf
+                  "%s looks like a MASC tool, not a shell command, but it \
+                   is not visible in this keeper's tool policy. Do not run \
+                   it through Bash; pick a visible tool or update the keeper \
+                   tool policy."
+                  tool_name)
+         ; "suggested_tool", `String tool_name
+         ; "tool_policy_visible", `Bool tool_policy_visible
+         ; "retryable", `Bool true
+         ])
+  in
   if cmd = ""
   then error_json "cmd is required. Good: cmd='ls -la lib/'. Bad: cmd=''."
   else if Env_config_keeper.KeeperSandbox.hard_mode ()
@@ -218,10 +285,12 @@ let handle_keeper_bash
   then
     error_json
       "MASC_KEEPER_SANDBOX_HARD_MODE requires sandbox_profile=docker"
-  else if cmd_contains_gh_pr_create cmd
-  then gh_pr_create_block ()
-
-  else begin
+  else (
+    match direct_tool_command_name ~meta cmd with
+    | Some (tool_name, tool_policy_visible) ->
+      direct_tool_command_block ~tool_policy_visible tool_name
+    | None when cmd_contains_gh_pr_create cmd -> gh_pr_create_block ()
+    | None -> begin
     (* Tick 22: dark-launch shadow logger.  Runs
        [Worker_dev_tools.diff_command] side-by-side with the
        live gate and emits a structured line for every non-[Agree]
@@ -951,5 +1020,5 @@ let handle_keeper_bash
                        | None -> run_uncached ())
                     | None -> run_uncached ())
                end))
-  end
+  end)
 ;;

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -258,7 +258,7 @@ let run_named
   let original_candidates =
     Cascade_runtime_candidate.of_provider_configs original_candidate_cfgs
   in
-  let candidate_cfgs =
+  let tool_filtered_candidate_cfgs =
     filter_candidate_providers_for_tool_support
       ~keeper_name
       ?runtime_mcp_policy
@@ -270,7 +270,7 @@ let run_named
       candidate_cfgs
   in
   let candidates =
-    candidate_cfgs
+    tool_filtered_candidate_cfgs
     |> Cascade_runtime_candidate.of_provider_configs
     |> List.filter
          (fun candidate ->
@@ -303,7 +303,14 @@ let run_named
           original_candidates
       in
       let internal_error =
-        if require_tool_choice_support || require_tool_support then
+        match
+          classify_empty_candidates
+            ~require_tool_choice_support
+            ~require_tool_support
+            ~tool_filtered_candidate_count:
+              (List.length tool_filtered_candidate_cfgs)
+        with
+        | Tool_capability_empty ->
           No_tool_capable_provider
             {
               cascade_name = error_cascade_name;
@@ -311,7 +318,7 @@ let run_named
               required_tool_names;
               provider_rejections;
             }
-        else
+        | Provider_unavailable ->
           Cascade_exhausted
             {
               cascade_name = error_cascade_name;
@@ -341,6 +348,9 @@ let run_named
                            (fun tool_name -> `String tool_name)
                            required_tool_names) );
                     ("candidate_count", `Int (List.length original_candidate_cfgs));
+                    ( "tool_filtered_candidate_count",
+                      `Int (List.length tool_filtered_candidate_cfgs) );
+                    ("health_filtered_candidate_count", `Int (List.length candidates));
                     ( "rejected_candidate_count",
                       `Int (List.length provider_rejections) );
                     ( "rejection_reasons",

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -87,6 +87,18 @@ let required_tool_lane_unavailable_error ~lane ~missing_required_tools
              (String.concat ", " materialized_tools);
        })
 
+type empty_candidate_classification =
+  | Tool_capability_empty
+  | Provider_unavailable
+
+let classify_empty_candidates ~require_tool_choice_support ~require_tool_support
+    ~tool_filtered_candidate_count =
+  if
+    (require_tool_choice_support || require_tool_support)
+    && tool_filtered_candidate_count = 0
+  then Tool_capability_empty
+  else Provider_unavailable
+
 let provider_rejections_for_no_tool_error
     ~keeper_name ?runtime_mcp_policy ~tools
     ~require_tool_choice_support ~require_tool_support candidates =

--- a/lib/keeper/keeper_turn_driver_helpers.mli
+++ b/lib/keeper/keeper_turn_driver_helpers.mli
@@ -35,6 +35,16 @@ val required_tool_lane_unavailable_error :
   materialized_tools:string list ->
   Agent_sdk.Error.sdk_error
 
+type empty_candidate_classification =
+  | Tool_capability_empty
+  | Provider_unavailable
+
+val classify_empty_candidates :
+  require_tool_choice_support:bool ->
+  require_tool_support:bool ->
+  tool_filtered_candidate_count:int ->
+  empty_candidate_classification
+
 val provider_rejections_for_no_tool_error :
   keeper_name:string ->
   ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -874,6 +874,51 @@ let test_bash_missing_cmd_field () =
   | None ->
       Alcotest.fail ("expected error json for missing cmd field, got: " ^ raw)
 
+let test_bash_blocks_direct_masc_tool_command () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_docker_meta "direct-tool-command" in
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None
+      ~config ~meta
+      ~args:(`Assoc [ ("cmd", `String "keeper_tasks_list") ]) ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check (option string))
+    "error"
+    (Some "tool_invoked_as_shell_command")
+    (Json.member "error" json |> Json.to_string_option);
+  Alcotest.(check (option string))
+    "suggested tool"
+    (Some "keeper_tasks_list")
+    (Json.member "suggested_tool" json |> Json.to_string_option);
+  Alcotest.(check bool)
+    "hint says direct tool call"
+    true
+    (String_util.contains_substring
+       (Json.member "hint" json |> Json.to_string)
+       "keeper_tasks_list tool");
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None
+      ~config ~meta
+      ~args:(`Assoc [ ("cmd", `String "keeper_missing_from_policy") ]) ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check (option string))
+    "tool-like command error"
+    (Some "tool_invoked_as_shell_command")
+    (Json.member "error" json |> Json.to_string_option);
+  Alcotest.(check bool)
+    "non-visible tool-like command still blocked"
+    false
+    (Json.member "tool_policy_visible" json |> Json.to_bool)
+
 let test_shell_missing_op_field () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
@@ -993,6 +1038,8 @@ let () =
     ]);
     ("negative_path", [
       Alcotest.test_case "missing cmd field" `Quick test_bash_missing_cmd_field;
+      Alcotest.test_case "direct MASC tool command blocked" `Quick
+        test_bash_blocks_direct_masc_tool_command;
       Alcotest.test_case "missing op field" `Quick test_shell_missing_op_field;
       Alcotest.test_case "unsupported op" `Quick test_shell_unsupported_op;
     ]);

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -271,10 +271,29 @@ let test_pass_for_completed_claim_progress () =
       ~cascade_outcome:R.Cascade_completed
       ~tool_contract_result:Contract_needs_execution_progress
       ~tools_used:[ "keeper_task_claim" ]
+      ~required_tools:[ "keeper_task_claim" ]
       ~terminal_reason_code:"completed"
       ()
   in
   check_disp "completed claim progress" r "pass" "healthy"
+;;
+
+let test_pause_when_unrelated_tool_used_for_required_progress () =
+  let r =
+    mk_receipt
+      ~outcome:`Ok
+      ~cascade_outcome:R.Cascade_completed
+      ~tool_contract_result:Contract_needs_execution_progress
+      ~tools_used:[ "keeper_task_claim" ]
+      ~required_tools:[ "keeper_task_done" ]
+      ~terminal_reason_code:"completed"
+      ()
+  in
+  check_disp
+    "unrelated tool does not satisfy required progress"
+    r
+    "pause_human"
+    "tool_required_unsatisfied"
 ;;
 
 let test_pass_next_for_cascade_fallback () =
@@ -666,6 +685,10 @@ let () =
             "ok+completed claim progress -> pass"
             `Quick
             test_pass_for_completed_claim_progress
+        ; test_case
+            "unrelated tool does not satisfy required progress"
+            `Quick
+            test_pause_when_unrelated_tool_used_for_required_progress
         ; test_case
             "fallback -> pass_next_model"
             `Quick

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -264,6 +264,19 @@ let test_pass_for_healthy () =
   check_disp "healthy" r "pass" "healthy"
 ;;
 
+let test_pass_for_completed_claim_progress () =
+  let r =
+    mk_receipt
+      ~outcome:`Ok
+      ~cascade_outcome:R.Cascade_completed
+      ~tool_contract_result:Contract_needs_execution_progress
+      ~tools_used:[ "keeper_task_claim" ]
+      ~terminal_reason_code:"completed"
+      ()
+  in
+  check_disp "completed claim progress" r "pass" "healthy"
+;;
+
 let test_pass_next_for_cascade_fallback () =
   let r =
     mk_receipt
@@ -649,6 +662,10 @@ let () =
             test_alert_for_cascade_exhausted
         ; test_case "unmapped -> unknown" `Quick test_unknown_when_unmapped
         ; test_case "ok+completed -> pass" `Quick test_pass_for_healthy
+        ; test_case
+            "ok+completed claim progress -> pass"
+            `Quick
+            test_pass_for_completed_claim_progress
         ; test_case
             "fallback -> pass_next_model"
             `Quick

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -1997,6 +1997,30 @@ let test_required_tool_lane_unavailable_is_tool_support_config_error () =
       "expected tool_support InvalidConfig, got %s"
       (Agent_sdk.Error.to_string err)
 
+let test_empty_candidate_classification_separates_tool_filter_from_availability () =
+  let module FT = Masc_mcp.Keeper_turn_driver_helpers in
+  let check label expected actual =
+    Alcotest.(check bool) label true (actual = expected)
+  in
+  check "required tools and no tool-capable candidates"
+    FT.Tool_capability_empty
+    (FT.classify_empty_candidates
+       ~require_tool_choice_support:true
+       ~require_tool_support:true
+       ~tool_filtered_candidate_count:0);
+  check "required tools but candidates were only unavailable"
+    FT.Provider_unavailable
+    (FT.classify_empty_candidates
+       ~require_tool_choice_support:true
+       ~require_tool_support:true
+       ~tool_filtered_candidate_count:2);
+  check "optional tools and no providers"
+    FT.Provider_unavailable
+    (FT.classify_empty_candidates
+       ~require_tool_choice_support:false
+       ~require_tool_support:false
+       ~tool_filtered_candidate_count:0)
+
 let test_keeper_cascade_engine_boundary () =
   let module E = Masc_mcp.Keeper_cascade_engine in
   let engine = E.keeper_managed in
@@ -2306,6 +2330,10 @@ let () =
           Alcotest.test_case
             "required tool lane mismatch is cascade-recoverable"
             `Quick test_required_tool_lane_unavailable_is_tool_support_config_error;
+          Alcotest.test_case
+            "empty candidate classification keeps availability separate"
+            `Quick
+            test_empty_candidate_classification_separates_tool_filter_from_availability;
           Alcotest.test_case "keeper cascade engine boundary is typed"
             `Quick test_keeper_cascade_engine_boundary;
           Alcotest.test_case "keeper hot path avoids OAS Complete_cascade"


### PR DESCRIPTION
## Summary
- block direct MASC tool invocations through keeper Bash with structured retry hints
- keep provider availability failures separate from tool-capability filtering in cascade routing diagnostics
- stop treating successful claim-progress receipts as human-paused tool_required_unsatisfied broadcasts
- move the CLI MCP visibility WARN after auto-construction, so successful runtime-MCP CLI turns no longer emit false tool-catalog-invisible warnings

## Verification
- ocamlformat --check lib/keeper/keeper_agent_run.ml lib/keeper/keeper_execution_receipt.ml test/test_keeper_pause_broadcast.ml lib/keeper/keeper_shell_bash.ml test/test_keeper_bash_safety.ml
- scripts/opam-pin-external-deps.sh --install
- scripts/dune-local.sh build test/test_keeper_bash_safety.exe test/test_keeper_runtime_manifest.exe test/test_keeper_pause_broadcast.exe test/test_keeper_cli_mcp_config.exe bin/main_eio.exe
- ./_build/default/test/test_keeper_bash_safety.exe test negative_path 1-1
- ./_build/default/test/test_keeper_runtime_manifest.exe test wiring 4-4
- ./_build/default/test/test_keeper_pause_broadcast.exe test operator_disposition 10-10
- ./_build/default/test/test_keeper_pause_broadcast.exe
- ./_build/default/test/test_keeper_cli_mcp_config.exe
- git diff --check

## Live evidence
- restarted local 8935 server from this worktree with /Users/dancer/me base path
- before the live config mitigation, executor recovered through strict_tool_candidates after inter_chunk_idle and produced a non-human-pause completed receipt
- after moving executor and then all keeper TOMLs to tier-group.strict_tool_candidates, executor produced two completed receipts without inter_chunk_idle:
  - 2026-05-14T04:19:20Z: outcome=receipt_done, operator_disposition=pass, operator_disposition_reason=healthy, duration_ms=13000
  - 2026-05-14T04:22:40Z: outcome=receipt_done, operator_disposition=pass, operator_disposition_reason=healthy, duration_ms=12000
- after the WARN ordering fix, the strict-tool live run no longer emitted the false "claude_mcp_config is None; MCP tool catalog will not be visible" warning before successful keeper_task_claim

## CI
- Draft Auto-Merge Guard: pass
- check: pass
- TLA+ annotation drift check: pass
- ocamlformat-check: pass

Depends on #15153.