### PR TITLE
fix(keeper): demote zero-token usage telemetry noise

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -410,11 +410,6 @@ let record_usage_anomaly_metrics ~keeper_name ~model usage_trust =
            ())
       reasons
 
-let usage_untrusted_warns_operator = function
-  | Keeper_usage_trust.Usage_untrusted ["zero_token_usage_reported"] -> false
-  | Keeper_usage_trust.Usage_missing | Keeper_usage_trust.Usage_trusted -> false
-  | Keeper_usage_trust.Usage_untrusted _ -> true
-
 type cost_status =
   | Cost_reported
   | Cost_known_free
@@ -1938,7 +1933,7 @@ let make_hooks
             | [] -> [Keeper_usage_trust.to_string usage_trust]
             | reasons -> reasons
           in
-          if usage_untrusted_warns_operator usage_trust then
+          if Keeper_usage_trust.warns_operator usage_trust then
             Log.Keeper.warn
               "keeper:%s after_turn usage telemetry untrusted runtime_lane=%s reasons=%s input=%d output=%d context_max=%d"
               meta.name runtime_lane_label

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -277,11 +277,17 @@ let record_usage_trust ~keeper_name ~(trust : usage_trust) =
         Prometheus.inc_counter usage_anomaly_reason_metric
           ~labels:[ ("keeper", keeper_name); ("reason", reason) ] ())
       reasons;
-    Log.Keeper.warn
-      "#9959 usage_anomaly keeper=%s reasons=[%s] — upstream fix \
-       tracked in jeong-sik/oas#1181; cost accounting is suppressed \
+    let warns_operator = Keeper_usage_trust.warns_operator trust in
+    let log_usage =
+      if warns_operator then Log.Keeper.warn else Log.Keeper.info
+    in
+    log_usage
+      "#9959 usage_anomaly keeper=%s reasons=[%s] severity=%s — upstream \
+       fix tracked in jeong-sik/oas#1181; cost accounting is suppressed \
        to 0.0 for this turn by [usage_trust_is_trusted] gate."
-      keeper_name (String.concat "," reasons)
+      keeper_name
+      (String.concat "," reasons)
+      (if warns_operator then "warn" else "info")
   | Usage_missing | Usage_trusted -> ()
 
 let record_keeper_total_cost_usd ~keeper_name ~total_cost_usd =

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -2847,10 +2847,17 @@ let run_keeper_cycle
                              ]
                            ())
                       reasons;
-                    Log.Keeper.warn
-                      "%s: keeper usage telemetry untrusted runtime_lane=%s \
-                       reasons=%s input=%d output=%d context_max=%d"
+                    let warns_operator =
+                      Keeper_usage_trust.warns_operator usage_trust
+                    in
+                    let log_usage =
+                      if warns_operator then Log.Keeper.warn else Log.Keeper.info
+                    in
+                    log_usage
+                      "%s: keeper usage telemetry %s runtime_lane=%s reasons=%s \
+                       input=%d output=%d context_max=%d"
                       updated_meta.name
+                      (if warns_operator then "untrusted" else "unavailable")
                       runtime_lane_label
                       (String.concat "," reasons)
                       result.usage.input_tokens

--- a/lib/keeper/keeper_usage_trust.ml
+++ b/lib/keeper/keeper_usage_trust.ml
@@ -24,6 +24,11 @@ let reasons = function
   | Usage_untrusted reasons -> reasons
   | Usage_missing | Usage_trusted -> []
 
+let warns_operator = function
+  | Usage_untrusted [ "zero_token_usage_reported" ] -> false
+  | Usage_missing | Usage_trusted -> false
+  | Usage_untrusted _ -> true
+
 let json_fields trust =
   [
     ("usage_trust", `String (to_string trust));

--- a/lib/keeper/keeper_usage_trust.mli
+++ b/lib/keeper/keeper_usage_trust.mli
@@ -19,4 +19,12 @@ val to_string : t -> string
 
 val reasons : t -> string list
 
+val warns_operator : t -> bool
+(** [true] when the trust anomaly should be operator-visible as WARN.
+
+    A pure zero-token report is an untrusted usage shape, but several
+    CLI/runtime lanes legitimately cannot report token usage. It remains
+    counted and serialized as untrusted, but should not page operators via
+    WARN unless another anomaly reason is present. *)
+
 val json_fields : t -> (string * Yojson.Safe.t) list

--- a/test/test_keeper_usage_trust_counter.ml
+++ b/test/test_keeper_usage_trust_counter.ml
@@ -10,6 +10,7 @@
    while that fix is in-flight. *)
 
 module UM = Masc_mcp.Keeper_unified_metrics
+module UT = Masc_mcp.Keeper_usage_trust
 module Prom = Masc_mcp.Prometheus
 
 let outcome_for ~keeper ~outcome =
@@ -107,6 +108,20 @@ let test_per_keeper_isolation () =
     "B untrusted unchanged" b_before
     (outcome_for ~keeper:b ~outcome:"untrusted")
 
+let test_zero_token_usage_is_info_severity () =
+  Alcotest.(check bool)
+    "zero-token-only remains non-WARN"
+    false
+    (UT.warns_operator (UT.Usage_untrusted [ "zero_token_usage_reported" ]))
+
+let test_compound_usage_anomaly_warns_operator () =
+  Alcotest.(check bool)
+    "compound anomaly remains WARN"
+    true
+    (UT.warns_operator
+       (UT.Usage_untrusted
+          [ "zero_token_usage_reported"; "input_tokens_gt_1m" ]))
+
 let () =
   Alcotest.run "keeper_usage_trust_counter_9959"
     [
@@ -128,5 +143,12 @@ let () =
         [
           Alcotest.test_case "per-keeper independent" `Quick
             test_per_keeper_isolation;
+        ] );
+      ( "severity",
+        [
+          Alcotest.test_case "zero-token-only is info" `Quick
+            test_zero_token_usage_is_info_severity;
+          Alcotest.test_case "compound anomaly warns" `Quick
+            test_compound_usage_anomaly_warns_operator;
         ] );
     ]


### PR DESCRIPTION
## Summary
- centralize usage telemetry WARN severity in Keeper_usage_trust.warns_operator
- keep zero-token-only usage reports counted and serialized as untrusted, but log them at INFO instead of WARN
- reuse the same severity decision in keeper hooks, unified turn logging, and usage trust metrics

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_usage_trust.ml lib/keeper/keeper_usage_trust.mli lib/keeper/keeper_hooks_oas.ml lib/keeper/keeper_unified_turn.ml lib/keeper/keeper_unified_metrics.ml test/test_keeper_usage_trust_counter.ml
- git diff --check
- scripts/dune-local.sh build test/test_keeper_usage_trust_counter.exe
- ./_build/default/test/test_keeper_usage_trust_counter.exe