### PR TITLE
fix(dashboard): surface dropped log rows

### DIFF
--- a/dashboard/src/api/schemas/logs.test.ts
+++ b/dashboard/src/api/schemas/logs.test.ts
@@ -26,6 +26,7 @@ describe('parseLogsResponse', () => {
     const out = parseLogsResponse({ total: 0, entries: [] })
     expect(out.total).toBe(0)
     expect(out.entries).toHaveLength(0)
+    expect(out.dropped_entries).toBe(0)
   })
 
   it('parses a populated response', () => {
@@ -49,6 +50,7 @@ describe('parseLogsResponse', () => {
     })
     expect(out.entries).toHaveLength(1)
     expect(out.entries[0]!.seq).toBe(42)
+    expect(out.dropped_entries).toBe(1)
   })
 
   it('chains raw_level and normalized_level to level when omitted', () => {
@@ -91,6 +93,7 @@ describe('parseLogsResponse', () => {
   it('tolerates a non-array entries field by returning an empty list', () => {
     const out = parseLogsResponse({ total: 0, entries: null })
     expect(out.entries).toHaveLength(0)
+    expect(out.dropped_entries).toBe(0)
   })
 
   it('throws on non-object payload', () => {

--- a/dashboard/src/api/schemas/logs.ts
+++ b/dashboard/src/api/schemas/logs.ts
@@ -5,7 +5,9 @@
 // defaults that match the prior hand-rolled decoder (`decodeLogEntry`).
 // Individual entries that fail validation are dropped from the array
 // (not thrown) to preserve the original lenient-per-entry behavior —
-// one corrupt log row should never blank the entire logs panel.
+// one corrupt log row should never blank the entire logs panel. The
+// computed `dropped_entries` field keeps that leniency visible to
+// operators instead of silently shrinking the log window.
 //
 // The outer response shape is strict: if the top-level `entries` field
 // is missing or the payload is not an object, the parser throws
@@ -65,6 +67,7 @@ const LogsResponseSchema = object({
 export interface LogsResponse {
   total: number
   entries: LogEntry[]
+  dropped_entries: number
 }
 
 export class LogsSchemaDriftError extends Error {
@@ -93,5 +96,9 @@ export function parseLogsResponse(data: unknown): LogsResponse {
     const parsed = safeParse(LogEntrySchema, raw, { abortEarly: true })
     if (parsed.success) entries.push(parsed.output)
   }
-  return { total: outer.output.total, entries }
+  return {
+    total: outer.output.total,
+    entries,
+    dropped_entries: Math.max(0, rawEntries.length - entries.length),
+  }
 }

--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -169,6 +169,31 @@ describe('LogViewer Code links', () => {
     )
   })
 
+  it('surfaces parser-dropped log rows in the summary', async () => {
+    const fetchLogs = vi.fn().mockResolvedValue({
+      total: 2,
+      dropped_entries: 1,
+      entries: [{
+        seq: 1,
+        ts: '2026-05-14T00:00:00Z',
+        level: 'INFO',
+        raw_level: 'INFO',
+        normalized_level: 'INFO',
+        source: 'structured',
+        legacy_classified: false,
+        module: 'keeper_tool',
+        message: 'visible row',
+        details: null,
+      }],
+    })
+    const { LogViewer } = await loadLogs(fetchLogs)
+    const { container } = render(h(LogViewer, {}))
+
+    await waitFor(() => expect(container.textContent).toContain('visible row'))
+    expect(container.textContent).toContain('dropped rows')
+    expect(container.textContent).toContain('1 dropped')
+  })
+
   it('does not render Code links for unsafe absolute log file paths', async () => {
     const fetchLogs = vi.fn().mockResolvedValue({
       total: 1,

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -20,6 +20,7 @@ import {
 interface LogData {
   entries: LogEntry[]
   total: number
+  dropped_entries: number
 }
 
 export interface LogCauseCount {
@@ -431,7 +432,11 @@ async function loadLogs(mode: LoadMode = 'reset') {
       })
       const entries = sortLogEntries(resp.entries).slice(0, Math.max(1, logLimit.value))
       latestSeq.value = latestLogSeq(entries)
-      return { entries, total: resp.total }
+      return {
+        entries,
+        total: resp.total,
+        dropped_entries: resp.dropped_entries ?? 0,
+      }
     })
   }
 
@@ -451,7 +456,12 @@ async function loadLogs(mode: LoadMode = 'reset') {
     const nextEntries = mergeLogEntries(currentEntries, incoming, logLimit.value)
 
     latestSeq.value = latestLogSeq(nextEntries)
-    logResource.state.value = loaded({ entries: nextEntries, total: resp.total })
+    logResource.state.value = loaded({
+      entries: nextEntries,
+      total: resp.total,
+      dropped_entries: (s.status === 'loaded' ? s.data.dropped_entries : 0)
+        + (resp.dropped_entries ?? 0),
+    })
   } catch {
     if (requestId !== latestRequestId) return
     // Delta failures don't overwrite loaded state — keep existing data visible
@@ -583,12 +593,15 @@ function renderSummaryChip(label: string, value: string | number, tone = 'neutra
   `
 }
 
-function renderLogSummary(summary: LogWindowSummary) {
+function renderLogSummary(summary: LogWindowSummary, droppedEntries: number) {
   return html`
     <div class="mx-3 mt-3 flex flex-wrap items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2 text-2xs">
       ${renderSummaryChip('ERROR', summary.errors, summary.errors > 0 ? 'bad' : 'neutral')}
       ${renderSummaryChip('WARN', summary.warnings, summary.warnings > 0 ? 'warn' : 'neutral')}
       ${renderSummaryChip('failure envelope', summary.failureEnvelopes, summary.failureEnvelopes > 0 ? 'info' : 'neutral')}
+      ${droppedEntries > 0
+        ? renderSummaryChip('dropped rows', droppedEntries, 'warn')
+        : null}
       ${summary.topModules.map(item => renderSummaryChip(`module ${item.module}`, item.count))}
       ${summary.topCauses.map(item => renderSummaryChip(`cause ${item.cause}`, item.count, 'info'))}
     </div>
@@ -642,6 +655,7 @@ export function LogViewer() {
   const logData = s.status === 'loaded' ? s.data : undefined
   const logEntries = logData?.entries ?? []
   const logTotal = logData?.total ?? 0
+  const droppedEntries = logData?.dropped_entries ?? 0
   const logLoading = s.status === 'loading'
   const logError = s.status === 'error' ? s.message : null
   const summary = summarizeLogWindow(logEntries)
@@ -698,7 +712,10 @@ export function LogViewer() {
           </div>
 
           <div class="logs-actions flex flex-wrap gap-3 items-center text-2xs text-[color:var(--color-fg-muted)]">
-            <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-1 tabular-nums">${logEntries.length.toLocaleString()} / ${logTotal.toLocaleString()}</span>
+            <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-1 tabular-nums">
+              ${logEntries.length.toLocaleString()} / ${logTotal.toLocaleString()}
+              ${droppedEntries > 0 ? ` · ${droppedEntries.toLocaleString()} dropped` : ''}
+            </span>
             <label class="logs-auto-label flex items-center gap-1.5 cursor-pointer">
               <${Checkbox}
                 name="log-auto-refresh"
@@ -727,7 +744,7 @@ export function LogViewer() {
           <div class="mx-4 mt-4 rounded-[var(--r-1)] border border-solid border-[var(--err-border)] bg-[var(--brick-soft)] px-4 py-3 text-xs text-[var(--err-fg)]">${logError}</div>
         ` : null}
 
-        ${renderLogSummary(summary)}
+        ${renderLogSummary(summary, droppedEntries)}
 
         <div class="px-3 pt-3">
           <div class="grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 px-3 py-2 text-left text-3xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)]">


### PR DESCRIPTION
## Summary
- compute dropped_entries when dashboard log schema parsing skips corrupt individual rows
- show dropped row count in the log toolbar and summary chips so parser loss is operator-visible
- add schema and LogViewer regressions for corrupt-row visibility

## Validation
- git diff --check
- pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/api/schemas/logs.test.ts src/components/logs.test.ts
- pnpm exec tsc --noEmit --pretty false
- pnpm run lint (passes with existing virtual-list unused-disable warning)

## Goal fit
This closes a concrete logging/dashboard gap: the logs panel already tolerated corrupt rows, but that tolerance silently hid missing log data. The dashboard now tells operators when row-level parsing dropped evidence.