### PR TITLE
feat(ide): link persistence context to code

### DIFF
--- a/dashboard/src/components/ide/ide-persistence-panel.test.ts
+++ b/dashboard/src/components/ide/ide-persistence-panel.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { cleanup, render, screen, waitFor } from '@testing-library/preact'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
 import { html } from 'htm/preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -16,6 +16,7 @@ import {
   lifecycleStateFromKeeperPhase,
   persistenceStateFromKeeperPhase,
 } from './ide-persistence-panel'
+import { cursorOverlaySignal } from './keeper-cursor-overlay'
 
 vi.mock('../../api/keeper', async () => {
   const actual = await vi.importActual<typeof import('../../api/keeper')>('../../api/keeper')
@@ -38,6 +39,13 @@ afterEach(() => {
   vi.clearAllMocks()
   activeKeeperName.value = ''
   keepers.value = []
+  cursorOverlaySignal.value = {
+    cursors: new Map(),
+    heatmap: new Map(),
+    collisions: [],
+    active_file: null,
+  }
+  window.location.hash = ''
 })
 
 describe('ide persistence helpers', () => {
@@ -119,5 +127,50 @@ describe('IdePersistencePanel', () => {
     ))
     expect(screen.getByText('keeper-2')).toBeTruthy()
     expect(screen.getByText('memory bank data unavailable')).toBeTruthy()
+  })
+
+  it('links persistence state back to code focus and keeper runtime context', async () => {
+    activeKeeperName.value = 'sangsu'
+    keepers.value = [{
+      name: 'sangsu',
+      status: 'online',
+      phase: 'Running',
+    }]
+    cursorOverlaySignal.value = {
+      cursors: new Map([[
+        'sangsu',
+        {
+          keeper_id: 'sangsu',
+          file_path: 'lib/runtime.ml',
+          line: 42,
+          column: 1,
+          focus_mode: 'editing',
+          last_update: 100,
+        },
+      ]]),
+      heatmap: new Map(),
+      collisions: [],
+      active_file: 'lib/runtime.ml',
+    }
+    fetchKeeperStateDiagramMock.mockResolvedValue({
+      keeper: 'sangsu',
+      current_phase: 'Running',
+      mermaid: 'graph TD',
+      memory_kind_usage: [],
+    } satisfies KeeperStateDiagramResponse)
+
+    render(html`<${IdePersistencePanel} pollMs=${60_000} />`)
+
+    await waitFor(() => expect(fetchKeeperStateDiagramMock).toHaveBeenCalled())
+    const links = Array.from(screen.getByLabelText('Persistence context links')
+      .querySelectorAll<HTMLButtonElement>('button'))
+    expect(links.map(link => link.textContent)).toEqual(['Code', 'Keeper'])
+    expect(links[0]?.title).toBe('Code lib/runtime.ml:42')
+    expect(links[1]?.title).toBe('Keeper sangsu')
+
+    fireEvent.click(links[0]!)
+    expect(window.location.hash).toBe(
+      '#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=42&surface=Persistence&label=sangsu+current+focus&source_id=persistence%3Asangsu&keeper=sangsu',
+    )
   })
 })

--- a/dashboard/src/components/ide/ide-persistence-panel.ts
+++ b/dashboard/src/components/ide/ide-persistence-panel.ts
@@ -12,7 +12,12 @@ import type { Keeper } from '../../types'
 import { MemoryGraph } from '../common/memory-graph'
 import { PersistenceStatus, type PersistenceState } from '../common/persistence-status'
 import { globalPresenceSnapshot, PRESENCE_DOT, type KeeperPresenceEntry } from './keeper-presence-store'
-import { cursorOverlaySignal } from './keeper-cursor-overlay'
+import { cursorOverlaySignal, type KeeperCursor } from './keeper-cursor-overlay'
+import {
+  openIdeContextRouteLink,
+  routeLinksForContext,
+  type IdeContextRouteLink,
+} from './ide-context-lens'
 import { useSignalValue } from './use-signal-value'
 
 const REFRESH_MS = 30_000
@@ -340,17 +345,7 @@ export function IdePersistencePanel({
           </span>
         ` : null}
         ${focusLabel ? html`
-          <span style=${{
-            fontSize: 'var(--fs-10)',
-            fontFamily: 'var(--font-mono)',
-            color: 'var(--color-accent-fg)',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-            maxWidth: '120px',
-          }}
-          title=${cursor?.file_path}
-          >↗ ${focusLabel}</span>
+          <span class="ide-persistence-focus" title=${cursor?.file_path}>↗ ${focusLabel}</span>
         ` : null}
         <span style=${{ marginLeft: 'auto' }}>
           <${PersistenceStatus} status=${persistenceState} lastSaved=${lastSaved} />
@@ -365,6 +360,9 @@ export function IdePersistencePanel({
         ? html`
           <div style=${{ display: 'grid', gap: 'var(--sp-2)' }}>
             <${LifecycleMini} state=${lifecycleState} phase=${phase} />
+            <${PersistenceRouteLinks}
+              links=${persistenceRouteLinks(keeperName, cursor)}
+            />
 
             <div
               style=${{
@@ -423,5 +421,41 @@ export function IdePersistencePanel({
         `
         : html`<div role="status" style=${{ color: 'var(--color-fg-disabled)', fontSize: 'var(--fs-12)' }}>keeper unavailable</div>`}
     </section>
+  `
+}
+
+function persistenceRouteLinks(
+  keeperName: string,
+  cursor: KeeperCursor | undefined,
+): ReadonlyArray<IdeContextRouteLink> {
+  const keeperId = keeperName.trim()
+  return routeLinksForContext({
+    filePath: cursor?.file_path,
+    line: cursor?.line,
+    surface: 'Persistence',
+    label: keeperId ? `${keeperId} current focus` : 'keeper current focus',
+    sourceId: keeperId ? `persistence:${keeperId}` : 'persistence',
+    keeperId,
+  })
+}
+
+function PersistenceRouteLinks({
+  links,
+}: {
+  readonly links: ReadonlyArray<IdeContextRouteLink>
+}) {
+  if (links.length === 0) return null
+  return html`
+    <div class="ide-persistence-links" aria-label="Persistence context links">
+      ${links.map(link => html`
+        <button
+          key=${link.id}
+          type="button"
+          title=${link.evidence}
+          aria-label=${`Open ${link.evidence}`}
+          onClick=${() => openIdeContextRouteLink(link)}
+        >${link.label}</button>
+      `)}
+    </div>
   `
 }

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -677,6 +677,52 @@
   font-size: var(--fs-10);
 }
 
+.ide-persistence-focus {
+  max-width: 120px;
+  overflow: hidden;
+  color: var(--color-accent-fg);
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-persistence-links {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 3px;
+  min-width: 0;
+}
+
+.ide-persistence-links button {
+  min-width: 0;
+  max-width: 80px;
+  height: 18px;
+  padding: 0 5px;
+  overflow: hidden;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-page);
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-persistence-links button:hover,
+.ide-persistence-links button:focus-visible {
+  border-color: var(--color-border-strong);
+  color: var(--color-accent-fg);
+}
+
+.ide-persistence-links button:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 1px;
+}
+
 .ide-branch-context-head,
 .ide-branch-repo-row,
 .ide-branch-stat-row,


### PR DESCRIPTION
Summary:
- add Code/Keeper operational links to the IDE persistence map when the selected keeper has a live cursor focus
- make the persistence focus chip reusable CSS instead of an inline-only text hint
- add regression coverage proving persistence state can route back to the exact file/line and keeper runtime context

Validation:
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/ide-persistence-panel.ts src/components/ide/ide-persistence-panel.test.ts src/components/ide/ide-persistence-panel.a11y.test.ts
- pnpm exec vitest run src/components/ide/ide-persistence-panel.test.ts src/components/ide/ide-persistence-panel.a11y.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check