### PR TITLE
feat(ide): link keeper shell to context

### DIFF
--- a/dashboard/src/components/ide/keeper-shell-drawer.test.ts
+++ b/dashboard/src/components/ide/keeper-shell-drawer.test.ts
@@ -1,9 +1,12 @@
 import { h } from 'preact'
 import { render } from 'preact'
-import { waitFor } from '@testing-library/preact'
+import { fireEvent, waitFor } from '@testing-library/preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { tasks } from '../../store'
+import { cursorOverlaySignal } from './keeper-cursor-overlay'
 import {
   KeeperShellDrawer,
+  keeperShellRouteLinks,
   linesFromShellEvent,
   summarizeShellLines,
 } from './keeper-shell-drawer'
@@ -13,6 +16,14 @@ let mounted: HTMLDivElement | null = null
 afterEach(() => {
   if (mounted) render(null, mounted)
   mounted = null
+  tasks.value = []
+  cursorOverlaySignal.value = {
+    cursors: new Map(),
+    heatmap: new Map(),
+    collisions: [],
+    active_file: null,
+  }
+  window.location.hash = ''
   vi.unstubAllGlobals()
 })
 
@@ -61,6 +72,59 @@ describe('KeeperShellDrawer event mapping', () => {
     })
   })
 
+  it('builds operational routes from shell task, goal, git branch, cursor, and keeper', () => {
+    const links = keeperShellRouteLinks({
+      keeperName: 'sangsu',
+      taskId: 'task-123',
+      taskList: [{
+        id: 'task-123',
+        title: 'Runtime task',
+        goal_id: 'goal-ide',
+        worktree: {
+          branch: 'feat/runtime',
+          path: '/tmp/runtime',
+          git_root: '/tmp/runtime',
+          repo_name: 'masc-mcp',
+        },
+      }],
+      cursor: {
+        keeper_id: 'sangsu',
+        file_path: 'lib/runtime.ml',
+        line: 42,
+        column: 3,
+        focus_mode: 'editing',
+        last_update: Date.now(),
+        tool_name: 'ocamllsp',
+      },
+    })
+
+    expect(links.map(link => link.label)).toEqual([
+      'Code',
+      'Goal',
+      'Task',
+      'Git',
+      'Telemetry',
+      'Keeper',
+    ])
+    expect(links.find(link => link.label === 'Code')).toMatchObject({
+      params: {
+        section: 'ide-shell',
+        view: 'source',
+        file: 'lib/runtime.ml',
+        line: '42',
+        surface: 'Terminal',
+        label: 'keeper shell task-123',
+        source_id: 'keeper-shell:sangsu:task-123',
+        keeper: 'sangsu',
+      },
+      evidence: 'Code lib/runtime.ml:42',
+    })
+    expect(links.find(link => link.label === 'Telemetry')).toMatchObject({
+      params: { section: 'fleet-health', view: 'event-log', q: 'task-123' },
+      evidence: 'Fleet telemetry event log · query task-123',
+    })
+  })
+
   it('renders shell output through the shared terminal molecule', async () => {
     mounted = document.createElement('div')
     render(h(KeeperShellDrawer, { keeperName: '' }), mounted)
@@ -102,6 +166,68 @@ describe('KeeperShellDrawer event mapping', () => {
     expect(summary?.textContent).toContain('dropped 15B')
     expect(mounted.querySelector('[data-status-chip-tone="info"]')?.textContent).toContain('streaming')
     expect(mounted.querySelector('[data-status-chip-tone="bad"]')?.textContent).toContain('stderr 1')
+  })
+
+  it('renders shell context links and routes back into code and task context', async () => {
+    tasks.value = [{
+      id: 'task-123',
+      title: 'Runtime task',
+      goal_id: 'goal-ide',
+      status: 'in_progress',
+      worktree: {
+        branch: 'feat/runtime',
+        path: '/tmp/runtime',
+        git_root: '/tmp/runtime',
+        repo_name: 'masc-mcp',
+      },
+    }]
+    cursorOverlaySignal.value = {
+      cursors: new Map([['sangsu', {
+        keeper_id: 'sangsu',
+        file_path: 'lib/runtime.ml',
+        line: 42,
+        column: 3,
+        focus_mode: 'editing',
+        last_update: Date.now(),
+        tool_name: 'ocamllsp',
+      }]]),
+      heatmap: new Map(),
+      collisions: [],
+      active_file: 'lib/runtime.ml',
+    }
+    let resolveFetch: (value: Response) => void = () => undefined
+    const fetchPromise = new Promise<Response>(resolve => {
+      resolveFetch = resolve
+    })
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(fetchPromise))
+
+    mounted = document.createElement('div')
+    render(h(KeeperShellDrawer, { keeperName: 'sangsu' }), mounted)
+
+    resolveFetch(new Response(
+      'event: shell\ndata: {"type":"snapshot","keeper":"sangsu","task_id":"task-123","stdout_since":"one\\n","stderr_since":"","closed":false}\n\n',
+      {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      },
+    ))
+
+    await waitFor(() => expect(mounted?.textContent).toContain('task-123'))
+    const routeLinks = [...mounted.querySelectorAll<HTMLButtonElement>('.keeper-shell-context-links button')]
+    expect(routeLinks.map(link => link.textContent)).toEqual([
+      'Code',
+      'Goal',
+      'Task',
+      'Git',
+      'Telemetry',
+      'Keeper',
+    ])
+
+    fireEvent.click(routeLinks.find(link => link.textContent === 'Code')!)
+    expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=42&surface=Terminal&label=keeper+shell+task-123&source_id=keeper-shell%3Asangsu%3Atask-123&keeper=sangsu')
+
+    fireEvent.click(routeLinks.find(link => link.textContent === 'Task')!)
+    expect(window.location.hash).toBe('#workspace?section=planning&view=default&task=task-123')
   })
 
   it('does not auto-scroll when reduced motion is preferred', async () => {

--- a/dashboard/src/components/ide/keeper-shell-drawer.ts
+++ b/dashboard/src/components/ide/keeper-shell-drawer.ts
@@ -4,8 +4,16 @@ import {
   streamKeeperShell,
   type KeeperShellStreamEvent,
 } from '../../api/keeper-shell'
+import { tasks } from '../../store'
+import type { Task } from '../../types'
 import { StatusChip, type StatusChipTone } from '../common/status-chip'
 import { Terminal, type TerminalLine } from '../common/terminal'
+import {
+  openIdeContextRouteLink,
+  routeLinksForContext,
+  type IdeContextRouteLink,
+} from './ide-context-lens'
+import { cursorOverlaySignal, type KeeperCursor } from './keeper-cursor-overlay'
 
 const MAX_TERMINAL_LINES = 5000
 
@@ -27,6 +35,13 @@ export interface KeeperShellSummary {
   readonly meta: number
   readonly droppedBytes: number
   readonly lastStream: ShellLine['stream'] | null
+}
+
+export interface KeeperShellRouteLinkInput {
+  readonly keeperName: string
+  readonly taskId: string | null
+  readonly taskList: ReadonlyArray<Task>
+  readonly cursor: KeeperCursor | null
 }
 
 function splitChunkLines(chunk: string): string[] {
@@ -119,6 +134,55 @@ function shellSummaryLabel(summary: KeeperShellSummary, status: KeeperShellStatu
   return `Keeper shell ${status}: ${lineCountLabel(summary.total)}, ${summary.stdout} stdout, ${summary.stderr} stderr, ${summary.meta} meta, last ${last}${dropped}`
 }
 
+export function keeperShellRouteLinks({
+  keeperName,
+  taskId,
+  taskList,
+  cursor,
+}: KeeperShellRouteLinkInput): ReadonlyArray<IdeContextRouteLink> {
+  const keeperId = nonEmpty(keeperName)
+  if (!keeperId) return []
+  const task = taskId
+    ? taskList.find(candidate => candidate.id === taskId) ?? null
+    : null
+  const sourceParts = ['keeper-shell', keeperId, taskId].filter((part): part is string =>
+    typeof part === 'string' && part.trim() !== '')
+  return routeLinksForContext({
+    filePath: cursor?.file_path,
+    line: cursor?.line,
+    surface: 'Terminal',
+    label: taskId ? `keeper shell ${taskId}` : 'keeper shell',
+    sourceId: sourceParts.join(':'),
+    goalId: task?.goal_id ?? undefined,
+    taskId: taskId ?? undefined,
+    gitRef: task?.worktree?.branch,
+    keeperId,
+    telemetry: true,
+    telemetryQuery: taskId ?? keeperId,
+  })
+}
+
+function KeeperShellContextLinks({
+  links,
+}: {
+  readonly links: ReadonlyArray<IdeContextRouteLink>
+}) {
+  if (links.length === 0) return null
+  return html`
+    <div class="keeper-shell-context-links" aria-label="Keeper shell operational links">
+      ${links.map(link => html`
+        <button
+          key=${link.id}
+          type="button"
+          title=${link.evidence}
+          aria-label=${`Open ${link.evidence}`}
+          onClick=${() => openIdeContextRouteLink(link)}
+        >${link.label}</button>
+      `)}
+    </div>
+  `
+}
+
 function KeeperShellSummaryStrip({
   summary,
   status,
@@ -148,9 +212,17 @@ export function KeeperShellDrawer({ keeperName }: KeeperShellDrawerProps) {
   const [lines, setLines] = useState<ShellLine[]>([])
   const [status, setStatus] = useState<KeeperShellStatus>('idle')
   const [taskId, setTaskId] = useState<string | null>(null)
+  const [overlay, setOverlay] = useState(cursorOverlaySignal.value)
   const viewportRef = useRef<HTMLDivElement | null>(null)
   const terminalLines = useMemo(() => lines.map(toTerminalLine), [lines])
   const summary = useMemo(() => summarizeShellLines(lines), [lines])
+  const cursor = resolveKeeperCursor(keeper, overlay.cursors)
+  const routeLinks = keeperShellRouteLinks({
+    keeperName: keeper,
+    taskId,
+    taskList: tasks.value,
+    cursor,
+  })
 
   const prefersReducedMotion = useMemo(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
@@ -200,6 +272,11 @@ export function KeeperShellDrawer({ keeperName }: KeeperShellDrawerProps) {
     el.scrollTop = el.scrollHeight
   }, [lines, prefersReducedMotion])
 
+  useEffect(() => {
+    const unsub = cursorOverlaySignal.subscribe(v => setOverlay(v))
+    return () => unsub()
+  }, [])
+
   return html`
     <aside
       class="border-t border-solid border-[var(--color-border-divider)] bg-[var(--color-bg-page)]"
@@ -216,6 +293,7 @@ export function KeeperShellDrawer({ keeperName }: KeeperShellDrawerProps) {
           ? html`<span class="truncate text-[var(--color-fg-disabled)]">${taskId}</span>`
           : null}
         <${StatusChip} tone=${statusTone(status)} uppercase=${false} class="font-mono">${status}</${StatusChip}>
+        <${KeeperShellContextLinks} links=${routeLinks} />
         <div class="ml-auto min-w-0">
           <${KeeperShellSummaryStrip} summary=${summary} status=${status} />
         </div>
@@ -231,4 +309,22 @@ export function KeeperShellDrawer({ keeperName }: KeeperShellDrawerProps) {
       />
     </aside>
   `
+}
+
+function resolveKeeperCursor(
+  keeperName: string,
+  cursors: ReadonlyMap<string, KeeperCursor>,
+): KeeperCursor | null {
+  const target = keeperName.toLowerCase().trim()
+  if (!target) return null
+  for (const [id, cursor] of cursors) {
+    if (id.toLowerCase() === target) return cursor
+    if (cursor.keeper_id.toLowerCase() === target) return cursor
+  }
+  return null
+}
+
+function nonEmpty(value: string | null | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
 }

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -1146,6 +1146,42 @@
   outline-offset: 1px;
 }
 
+.keeper-shell-context-links {
+  display: flex;
+  flex: 1 1 12rem;
+  flex-wrap: wrap;
+  gap: 3px;
+  min-width: 8rem;
+}
+
+.keeper-shell-context-links button {
+  min-width: 0;
+  max-width: 84px;
+  height: 18px;
+  padding: 0 5px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-page);
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.keeper-shell-context-links button:hover,
+.keeper-shell-context-links button:focus-visible {
+  border-color: var(--color-border-strong);
+  color: var(--color-accent-fg);
+}
+
+.keeper-shell-context-links button:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 1px;
+}
+
 .ide-context-lens {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Summary:
- add keeper shell operational links for Code, Goal, Task, Git, Telemetry, and Keeper context
- derive shell context from SSE task_id, dashboard task store, worktree branch, and keeper cursor overlay
- cover route derivation and click navigation in keeper shell tests

Validation:
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/keeper-shell-drawer.ts src/components/ide/keeper-shell-drawer.test.ts
- pnpm exec vitest run src/components/ide/keeper-shell-drawer.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check