### PR TITLE
feat(ide): link interject bar to context

### DIFF
--- a/dashboard/src/components/ide/ide-interject-mock.test.ts
+++ b/dashboard/src/components/ide/ide-interject-mock.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
+import { fireEvent } from '@testing-library/preact'
 import { activeKeeperName } from '../../keeper-state'
-import { IdeInterjectMock } from './ide-interject-mock'
+import { IdeInterjectMock, interjectContextRouteLinks } from './ide-interject-mock'
+import { cursorOverlaySignal } from './keeper-cursor-overlay'
 
 describe('IdeInterjectMock', () => {
   beforeEach(() => {
@@ -12,6 +14,40 @@ describe('IdeInterjectMock', () => {
 
   afterEach(() => {
     activeKeeperName.value = ''
+    cursorOverlaySignal.value = {
+      cursors: new Map(),
+      heatmap: new Map(),
+      collisions: [],
+      active_file: null,
+    }
+    window.location.hash = ''
+  })
+
+  it('builds code and keeper context routes for the active interject target', () => {
+    const links = interjectContextRouteLinks('sangsu', {
+      keeper_id: 'sangsu',
+      file_path: 'lib/runtime.ml',
+      line: 42,
+      column: 2,
+      focus_mode: 'reviewing',
+      last_update: Date.now(),
+      tool_name: 'ocamllsp',
+    })
+
+    expect(links.map(link => link.label)).toEqual(['Code', 'Keeper'])
+    expect(links.find(link => link.label === 'Code')).toMatchObject({
+      params: {
+        section: 'ide-shell',
+        view: 'source',
+        file: 'lib/runtime.ml',
+        line: '42',
+        surface: 'Interject',
+        label: 'ocamllsp',
+        source_id: 'interject:sangsu',
+        keeper: 'sangsu',
+      },
+      evidence: 'Code lib/runtime.ml:42',
+    })
   })
 
   it('renders the interject store backed active keeper controls', async () => {
@@ -29,7 +65,10 @@ describe('IdeInterjectMock', () => {
     expect(input?.readOnly).toBe(false)
     expect(input?.getAttribute('aria-label')).toBe('Interject input')
 
-    const buttons = [...container.querySelectorAll('button')]
+    const contextButtons = [...container.querySelectorAll('.ide-interject-context-links button')]
+    expect(contextButtons.map(button => button.textContent)).toEqual(['Keeper'])
+
+    const buttons = [...container.querySelectorAll<HTMLButtonElement>('.ide-interject-actions button')]
     expect(buttons.map(button => button.textContent)).toEqual(['Send', 'Approve', 'Pause', 'Drain'])
     expect(buttons[0]?.disabled).toBe(true)
     expect(buttons[1]?.disabled).toBe(true)
@@ -43,7 +82,7 @@ describe('IdeInterjectMock', () => {
     })
 
     const input = container.querySelector('input') as HTMLInputElement
-    const send = container.querySelector('button') as HTMLButtonElement
+    const send = container.querySelector('.ide-interject-actions button') as HTMLButtonElement
     expect(send.disabled).toBe(true)
 
     await act(async () => {
@@ -63,7 +102,7 @@ describe('IdeInterjectMock', () => {
 
     expect(container.textContent).toContain('tech_glutton')
     const input = container.querySelector('input') as HTMLInputElement
-    const send = container.querySelector('button') as HTMLButtonElement
+    const send = container.querySelector('.ide-interject-actions button') as HTMLButtonElement
 
     await act(async () => {
       input.value = 'inspect the current IDE context'
@@ -91,5 +130,33 @@ describe('IdeInterjectMock', () => {
 
     expect(container.textContent).toContain('keeper-beta')
     expect((container.querySelector('input') as HTMLInputElement).value).toBe('keep this draft')
+  })
+
+  it('renders cursor context links and routes back to the IDE code surface', async () => {
+    cursorOverlaySignal.value = {
+      cursors: new Map([['sangsu', {
+        keeper_id: 'sangsu',
+        file_path: 'lib/runtime.ml',
+        line: 42,
+        column: 2,
+        focus_mode: 'reviewing',
+        last_update: Date.now(),
+        tool_name: 'ocamllsp',
+      }]]),
+      heatmap: new Map(),
+      collisions: [],
+      active_file: 'lib/runtime.ml',
+    }
+
+    const container = document.createElement('div')
+    await act(async () => {
+      render(h(IdeInterjectMock, { keeperName: 'sangsu' }), container)
+    })
+
+    const contextButtons = [...container.querySelectorAll<HTMLButtonElement>('.ide-interject-context-links button')]
+    expect(contextButtons.map(button => button.textContent)).toEqual(['Code', 'Keeper'])
+
+    fireEvent.click(contextButtons.find(button => button.textContent === 'Code')!)
+    expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=42&surface=Interject&label=ocamllsp&source_id=interject%3Asangsu&keeper=sangsu')
   })
 })

--- a/dashboard/src/components/ide/ide-interject-mock.ts
+++ b/dashboard/src/components/ide/ide-interject-mock.ts
@@ -8,8 +8,13 @@ import {
   type InterjectActionState,
   type InterjectDispatchRequest,
 } from './interject-store'
+import {
+  openIdeContextRouteLink,
+  routeLinksForContext,
+  type IdeContextRouteLink,
+} from './ide-context-lens'
 import { globalPresenceSnapshot, type KeeperPresenceStatus } from './keeper-presence-store'
-import { cursorOverlaySignal, getKeeperColor } from './keeper-cursor-overlay'
+import { cursorOverlaySignal, getKeeperColor, type KeeperCursor } from './keeper-cursor-overlay'
 
 // The input and button states flow through the same store/dispatch boundary
 // that live active-keeper wiring uses. Send remains disabled until a concrete
@@ -79,6 +84,7 @@ export const IdeInterjectMock: FunctionComponent<IdeInterjectMockProps> = ({ kee
   const cursor = keeperId
     ? resolveCursor(keeperId, overlay.cursors)
     : null
+  const contextLinks = interjectContextRouteLinks(keeperId, cursor)
 
   return html`
     <div
@@ -112,6 +118,7 @@ export const IdeInterjectMock: FunctionComponent<IdeInterjectMockProps> = ({ kee
           ${presenceEntry ? KeeperPresencePill(presenceEntry.status) : null}
         </div>
         ${cursor ? CursorLocation(cursor) : null}
+        <${InterjectContextLinks} links=${contextLinks} />
       </div>
       <input
         class="ide-interject-input"
@@ -147,6 +154,43 @@ export const IdeInterjectMock: FunctionComponent<IdeInterjectMockProps> = ({ kee
             }}
           >${snapshot.error}</span>`
         : null}
+    </div>
+  `
+}
+
+export function interjectContextRouteLinks(
+  keeperId: string,
+  cursor: KeeperCursor | null,
+): ReadonlyArray<IdeContextRouteLink> {
+  const keeper = keeperId.trim()
+  if (!keeper) return []
+  return routeLinksForContext({
+    filePath: cursor?.file_path,
+    line: cursor?.line,
+    surface: 'Interject',
+    label: cursor?.tool_name ?? cursor?.focus_mode ?? 'active keeper',
+    sourceId: `interject:${keeper}`,
+    keeperId: keeper,
+  })
+}
+
+function InterjectContextLinks({
+  links,
+}: {
+  readonly links: ReadonlyArray<IdeContextRouteLink>
+}) {
+  if (links.length === 0) return null
+  return html`
+    <div class="ide-interject-context-links" aria-label="Interject context links">
+      ${links.map(link => html`
+        <button
+          key=${link.id}
+          type="button"
+          title=${link.evidence}
+          aria-label=${`Open ${link.evidence}`}
+          onClick=${() => openIdeContextRouteLink(link)}
+        >${link.label}</button>
+      `)}
     </div>
   `
 }
@@ -261,8 +305,8 @@ function CursorLocation(cursor: {
 
 function resolveCursor(
   keeperId: string,
-  cursors: Map<string, { keeper_id: string; file_path: string; line: number; focus_mode: string; tool_name?: string }>,
-) {
+  cursors: Map<string, KeeperCursor>,
+): KeeperCursor | null {
   const target = keeperId.toLowerCase().trim()
   for (const [id, cursor] of cursors) {
     if (id.toLowerCase() === target) return cursor

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -982,6 +982,41 @@
   overflow-wrap: anywhere;
 }
 
+.ide-interject-context-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  min-width: 0;
+}
+
+.ide-interject-context-links button {
+  min-width: 0;
+  max-width: 76px;
+  height: 18px;
+  padding: 0 5px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-page);
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-interject-context-links button:hover,
+.ide-interject-context-links button:focus-visible {
+  border-color: var(--color-border-strong);
+  color: var(--color-accent-fg);
+}
+
+.ide-interject-context-links button:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 1px;
+}
+
 .ide-activity-list {
   gap: var(--sp-1);
 }


### PR DESCRIPTION
Summary:
- add Code/Keeper operational links to the IDE interject bar from the active keeper cursor
- route interject focus back into the IDE code surface with surface/source/keeper context
- keep action buttons scoped separately from context route buttons in tests

Validation:
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/ide-interject-mock.ts src/components/ide/ide-interject-mock.test.ts src/components/ide/ide-interject-mock.a11y.test.ts
- pnpm exec vitest run src/components/ide/ide-interject-mock.test.ts src/components/ide/ide-interject-mock.a11y.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check