### PR TITLE
fix(observability): reduce false UTF-8 repair warnings

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -162,11 +162,49 @@ let collect_event_files config =
              None)
     |> List.flatten
 
+let repair_event_file_utf8_once config path =
+  let content = Fs_compat.load_file path in
+  if String.is_valid_utf_8 content then
+    content
+  else
+    Coord_utils.with_file_lock config (lock_path config) (fun () ->
+        let latest = Fs_compat.load_file path in
+        if String.is_valid_utf_8 latest then
+          latest
+        else
+          let repair =
+            Safe_ops.repair_utf8_text_with_stats ~surface:"activity_graph"
+              ~path:("event_file:" ^ path)
+              latest
+          in
+          if not repair.changed then
+            latest
+          else begin
+            (if String.equal path (day_path config) then
+               Log.Misc.warn
+                 "[activity_graph] UTF-8 repaired current event file in memory path=%s \
+                  invalid_bytes=%d action=read_only_current_day"
+                 path repair.invalid_bytes
+             else
+               match Fs_compat.save_file_atomic path repair.text with
+               | Ok () ->
+                   Log.Misc.warn
+                     "[activity_graph] UTF-8 repaired persisted event file path=%s \
+                      invalid_bytes=%d action=rewrite_once"
+                     path repair.invalid_bytes
+               | Error msg ->
+                   Log.Misc.warn
+                     "[activity_graph] UTF-8 repaired event file in memory path=%s \
+                      invalid_bytes=%d action=rewrite_failed error=%s"
+                     path repair.invalid_bytes msg);
+            repair.text
+          end)
+
 let read_all_events config =
   collect_event_files config
   |> List.fold_left
        (fun acc path ->
-         let content = Fs_compat.load_file path in
+         let content = repair_event_file_utf8_once config path in
          let lines = String.split_on_char '\n' content in
          let rows =
            List.filter_map (fun line ->

--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -297,9 +297,15 @@ let count_invalid_utf8_bytes s =
   in
   loop 0 0
 
-let repair_utf8_text ?(surface = "persistence") ?path s =
+type utf8_repair_result =
+  { text : string
+  ; invalid_bytes : int
+  ; changed : bool
+  }
+
+let repair_utf8_text_with_stats ?(surface = "persistence") ?path s =
   let invalid_bytes = count_invalid_utf8_bytes s in
-  if invalid_bytes = 0 then s
+  if invalid_bytes = 0 then { text = s; invalid_bytes = 0; changed = false }
   else
     let len = String.length s in
     let buf = Buffer.create len in
@@ -317,7 +323,10 @@ let repair_utf8_text ?(surface = "persistence") ?path s =
     in
     loop 0;
     record_utf8_repair ~surface ~path ~invalid_bytes;
-    Buffer.contents buf
+    { text = Buffer.contents buf; invalid_bytes; changed = true }
+
+let repair_utf8_text ?surface ?path s =
+  (repair_utf8_text_with_stats ?surface ?path s).text
 
 (** Parse JSON with detailed error reporting *)
 let parse_json_safe ~context str : (Yojson.Safe.t, string) result =

--- a/lib/core/safe_ops.mli
+++ b/lib/core/safe_ops.mli
@@ -32,6 +32,19 @@ type utf8_repair_stats =
   ; path_samples : string list
   }
 
+type utf8_repair_result =
+  { text : string
+  ; invalid_bytes : int
+  ; changed : bool
+  }
+(** Result of repairing malformed UTF-8 text. *)
+
+val repair_utf8_text_with_stats :
+  ?surface:string -> ?path:string -> string -> utf8_repair_result
+(** Replace malformed UTF-8 byte sequences with U+FFFD, record an
+    observable persistence repair when [changed = true], and return the
+    repair metadata needed by callers that can self-heal the backing file. *)
+
 val repair_utf8_text :
   ?surface:string -> ?path:string -> string -> string
 (** Replace malformed UTF-8 byte sequences with U+FFFD and record an

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -322,12 +322,16 @@ let route_text_for_evidence output_text =
   | Tool_output.Inline value -> value
 ;;
 
+let parse_tool_output_json_sanitized text =
+  let text = Safe_ops.sanitize_text_utf8 text in
+  try Ok (Yojson.Safe.from_string text) with
+  | Yojson.Json_error msg -> Error msg
+;;
+
 let route_evidence_json_of_tool_io ~tool_name ~input ~output_text =
   let route_text = route_text_for_evidence output_text in
   let parsed_output =
-    match
-      Safe_ops.parse_json_safe ~context:"Keeper_tool_call_log.route_evidence" route_text
-    with
+    match parse_tool_output_json_sanitized route_text with
     | Ok json -> Some json
     | Error _ -> None
   in
@@ -534,9 +538,7 @@ let blob_aware_output_json (output : string) : Yojson.Safe.t =
 ;;
 
 let semantic_outcome_of_output ~success output =
-  match
-    Safe_ops.parse_json_safe ~context:"Keeper_tool_call_log.semantic_outcome" output
-  with
+  match parse_tool_output_json_sanitized output with
   | Ok json ->
     let ok_field = Safe_ops.json_bool_opt "ok" json in
     let error_field = Safe_ops.json_string_opt "error" json |> Option.map String.trim in

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -268,6 +268,44 @@ let test_emit_sanitizes_invalid_utf8_before_persisting () =
       check int "read path did not repair activity graph row" 0
         stats.repaired_reads)
 
+let test_read_self_heals_historic_invalid_utf8_event_file () =
+  with_config (fun config ->
+      Safe_ops.reset_persistence_utf8_repair_stats_for_tests ();
+      let root = Filename.concat (Coord_utils.masc_dir config) "activity-events" in
+      let month_dir = Filename.concat root "2000-01" in
+      Unix.mkdir root 0o755;
+      Unix.mkdir month_dir 0o755;
+      let event_path = Filename.concat month_dir "01.jsonl" in
+      let raw_line =
+        "{\"seq\":1,\"ts_ms\":1,\"ts_iso\":\"2000-01-01T00:00:00Z\",\
+         \"room_id\":\"default\",\"kind\":\"message.broadcast\",\
+         \"payload\":{\"content\":\"bad\xffpayload\"},\"tags\":[]}\n"
+      in
+      Fs_compat.save_file event_path raw_line;
+      check bool "fixture starts invalid" false
+        (String.is_valid_utf_8 (Fs_compat.load_file event_path));
+      let events = Activity_graph.list_events config ~after_seq:0 ~limit:10 () in
+      let event =
+        match events with
+        | [ event ] -> event
+        | events ->
+            fail
+              (Printf.sprintf "expected one event, got %d"
+                 (List.length events))
+      in
+      let open Yojson.Safe.Util in
+      let replacement = "\xEF\xBF\xBD" in
+      check string "payload repaired on read" ("bad" ^ replacement ^ "payload")
+        (event.payload |> member "content" |> to_string);
+      let stats_after_first = Safe_ops.persistence_utf8_repair_stats () in
+      check int "file repair counted once" 1 stats_after_first.repaired_reads;
+      check bool "backing file rewritten valid" true
+        (String.is_valid_utf_8 (Fs_compat.load_file event_path));
+      ignore (Activity_graph.list_events config ~after_seq:0 ~limit:10 ());
+      let stats_after_second = Safe_ops.persistence_utf8_repair_stats () in
+      check int "second read does not repair again" 1
+        stats_after_second.repaired_reads)
+
 let test_filtered_client_receives_matching_events () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -524,6 +562,8 @@ let () =
             test_events_json_ignores_invalid_derived_pr_number;
           test_case "emit sanitizes invalid utf8 before persisting" `Quick
             test_emit_sanitizes_invalid_utf8_before_persisting;
+          test_case "read self-heals historic invalid utf8 event file" `Quick
+            test_read_self_heals_historic_invalid_utf8_event_file;
           test_case "filtered client receives matching events" `Quick
             test_filtered_client_receives_matching_events;
           test_case "graph summary builds nodes and edges" `Quick

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -703,6 +703,7 @@ let test_dashboard_aggregate_surfaces_coverage_gap () =
    entire JSONL file and silently drop rows. *)
 let test_output_invalid_utf8_sanitized () =
   with_tmp_log_dir (fun dir ->
+    Safe_ops.reset_persistence_utf8_repair_stats_for_tests ();
     let raw_output = "prefix\xecsuffix" in
     Keeper_tool_call_log.log_call
       ~keeper_name:"k" ~tool_name:"tool_bin"
@@ -734,7 +735,12 @@ let test_output_invalid_utf8_sanitized () =
         if dlen > 0 && Uchar.utf_decode_is_valid dec then scan (i + dlen)
         else false
     in
-    Alcotest.(check bool) "persisted file is valid UTF-8" true (scan 0))
+    Alcotest.(check bool) "persisted file is valid UTF-8" true (scan 0);
+    let repair_stats = Safe_ops.persistence_utf8_repair_stats () in
+    Alcotest.(check int)
+      "writer-side tool output parsing does not emit persistence repair"
+      0
+      repair_stats.repaired_reads)
 
 let test_output_valid_utf8_untouched () =
   with_tmp_log (fun () ->

--- a/test/test_safe_ops.ml
+++ b/test/test_safe_ops.ml
@@ -93,6 +93,33 @@ let test_parse_json_safe_rate_limits_repeated_utf8_repair_logs () =
   check int "both repairs counted" 2 stats.repaired_reads;
   check int "duplicate repair warning suppressed" 1 (List.length logs)
 
+let test_repair_utf8_text_with_stats_reports_changed_payload () =
+  let open Safe_ops in
+  reset_persistence_utf8_repair_stats_for_tests ();
+  let replacement = "\xEF\xBF\xBD" in
+  let result =
+    repair_utf8_text_with_stats ~surface:"test" ~path:"with-stats"
+      "left\xffright"
+  in
+  check bool "changed" true result.changed;
+  check int "invalid byte count" 1 result.invalid_bytes;
+  check string "text repaired" ("left" ^ replacement ^ "right") result.text;
+  let stats = persistence_utf8_repair_stats () in
+  check int "repair counted" 1 stats.repaired_reads
+
+let test_repair_utf8_text_with_stats_keeps_clean_payload_unchanged () =
+  let open Safe_ops in
+  reset_persistence_utf8_repair_stats_for_tests ();
+  let input = "already valid" in
+  let result =
+    repair_utf8_text_with_stats ~surface:"test" ~path:"clean" input
+  in
+  check bool "unchanged" false result.changed;
+  check int "no invalid bytes" 0 result.invalid_bytes;
+  check bool "text physically reused" true (result.text == input);
+  let stats = persistence_utf8_repair_stats () in
+  check int "repair not counted" 0 stats.repaired_reads
+
 let test_sanitize_json_utf8_covers_safe_constructors () =
   let open Safe_ops in
   let replacement = "\xEF\xBF\xBD" in
@@ -511,6 +538,10 @@ let () =
         test_parse_json_safe_still_rejects_malformed_json_after_utf8_repair;
       test_case "rate limits repeated utf8 repair logs" `Quick
         test_parse_json_safe_rate_limits_repeated_utf8_repair_logs;
+      test_case "repair with stats reports changed payload" `Quick
+        test_repair_utf8_text_with_stats_reports_changed_payload;
+      test_case "repair with stats keeps clean payload unchanged" `Quick
+        test_repair_utf8_text_with_stats_keeps_clean_payload_unchanged;
       test_case "sanitizes safe constructors" `Quick
         test_sanitize_json_utf8_covers_safe_constructors;
       test_case "sanitizes with raw preserved" `Quick


### PR DESCRIPTION
## Summary
- add Safe_ops repair metadata so read paths can log and self-heal with exact invalid-byte counts
- make activity graph reads repair historical invalid UTF-8 JSONL files once under the stream lock, then persist the repaired file so dashboard polling does not re-emit the same WARN forever
- keep current-day event files read-only on repair to avoid racing append fd cache, while still returning repaired content and logging the action
- stop Keeper tool-call writer-side semantic/route JSON probes from using persistence repair accounting on raw tool output; invalid output is sanitized before parsing without raising false persistence WARNs

## Evidence
- 24h logs had recurring `[json] persistence UTF-8 repaired path=activity_graph:event_line ... suppressed_repeats=81`
- live activity-events corpus had invalid UTF-8 only in historical files, not current 2026-05-13/14 files
- logs also had false writer-side repairs for `Keeper_tool_call_log.semantic_outcome` and `Keeper_tool_call_log.route_evidence`; live `tool_calls` JSONL files were already valid UTF-8
- new regressions prove a historical invalid activity JSONL file is rewritten valid after first read, and invalid tool output no longer increments persistence repair stats during writer-side parsing

## Validation
- `opam exec -- ocamlformat --check lib/keeper_tool_call_log.ml test/test_keeper_tool_call_log.ml lib/core/safe_ops.ml lib/core/safe_ops.mli lib/activity_graph/activity_graph.ml test/test_safe_ops.ml test/test_activity_graph.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_safe_ops.exe`
- `scripts/dune-local.sh build test/test_activity_graph.exe`
- `scripts/dune-local.sh build test/test_keeper_tool_call_log.exe`
- `./_build/default/test/test_safe_ops.exe`
- `./_build/default/test/test_activity_graph.exe`
- `./_build/default/test/test_keeper_tool_call_log.exe`