### PR TITLE
fix(dashboard): track ws hello latency

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -644,6 +644,7 @@ let metric_ws_parse_cache_hits = "masc_ws_parse_cache_hits_total"
 let metric_ws_parse_cache_misses = "masc_ws_parse_cache_misses_total"
 let metric_ws_bytes_cache_hits = "masc_ws_bytes_cache_hits_total"
 let metric_ws_bytes_cache_misses = "masc_ws_bytes_cache_misses_total"
+let metric_ws_dashboard_hello_latency_seconds = "masc_ws_dashboard_hello_latency_seconds"
 
 let metric_dashboard_execution_render_phase_sec =
   "masc_dashboard_execution_render_phase_seconds"
@@ -2901,6 +2902,20 @@ let init () =
     metric_ws_bytes_cache_misses
     "WS raw-SSE-forward Bytes cache misses (fresh allocation required)"
     Counter;
+  register_histogram
+    ~name:metric_ws_dashboard_hello_latency_seconds
+    ~help:
+      "dashboard/hello JSON-RPC processing latency in seconds. Labels: \
+       outcome=success|error."
+    ~labels:[ "outcome", "success" ]
+    ();
+  register_histogram
+    ~name:metric_ws_dashboard_hello_latency_seconds
+    ~help:
+      "dashboard/hello JSON-RPC processing latency in seconds. Labels: \
+       outcome=success|error."
+    ~labels:[ "outcome", "error" ]
+    ();
   add
     metric_http_accepts
     "TCP connections accepted by the primary HTTP listener. Labels: mode (h1|h2|auto)."

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -971,6 +971,10 @@ val metric_ws_parse_cache_misses : string
 val metric_ws_bytes_cache_hits : string
 val metric_ws_bytes_cache_misses : string
 
+(** Histogram of dashboard/hello JSON-RPC processing latency in seconds.
+    Labels: [outcome = success | error]. *)
+val metric_ws_dashboard_hello_latency_seconds : string
+
 (** Dashboard execution render phase latency histogram. Labels:
     [phase] = total | snapshot | operations | enrich | enrich_per_keeper
             | data_load | assemble.

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -333,15 +333,22 @@ let verify_dashboard_token ~base_path token =
             | Error err -> Error (Masc_domain.masc_error_to_string err)))
 
 let dashboard_hello ~base_path ~session_id ?token () =
-  match find_session session_id with
-  | None -> Error "WebSocket session not found"
-  | Some session -> (
-      match verify_dashboard_token ~base_path token with
-      | Error msg -> Error msg
-      | Ok agent ->
-          session.dashboard_authenticated <- true;
-          session.dashboard_agent <- agent;
-          Ok (dashboard_auth_success_payload session))
+  let start_time = Unix.gettimeofday () in
+  let result =
+    match find_session session_id with
+    | None -> Error "WebSocket session not found"
+    | Some session -> (
+        match verify_dashboard_token ~base_path token with
+        | Error msg -> Error msg
+        | Ok agent ->
+            session.dashboard_authenticated <- true;
+            session.dashboard_agent <- agent;
+            Ok (dashboard_auth_success_payload session))
+  in
+  Transport_metrics.observe_ws_dashboard_hello_latency
+    ~success:(match result with Ok _ -> true | Error _ -> false)
+    (Unix.gettimeofday () -. start_time);
+  result
 
 let dashboard_snapshot session =
   let slices =

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -151,6 +151,14 @@ let inc_ws_bytes_cache_miss () =
   Prometheus.inc_counter Prometheus.metric_ws_bytes_cache_misses ()
 ;;
 
+let observe_ws_dashboard_hello_latency ~success seconds =
+  let outcome = if success then "success" else "error" in
+  Prometheus.observe_histogram
+    Prometheus.metric_ws_dashboard_hello_latency_seconds
+    ~labels:[ "outcome", outcome ]
+    (max 0.0 seconds)
+;;
+
 let observe_ws_client_buffered_bytes n =
   let bytes = float_of_int (max 0 n) in
   Prometheus.observe_histogram Prometheus.metric_ws_client_buffered_bytes bytes;
@@ -459,6 +467,8 @@ type ws_delivery_metric_names =
   ; throttled_deliveries : string
   ; client_buffered_bytes : string
   ; client_buffered_bytes_count : string
+  ; hello_latency : string
+  ; hello_latency_count : string
   }
 
 let ws_delivery_metric_names =
@@ -470,6 +480,8 @@ let ws_delivery_metric_names =
   ; throttled_deliveries = "masc_ws_throttled_deliveries_total"
   ; client_buffered_bytes = "masc_ws_client_buffered_bytes"
   ; client_buffered_bytes_count = "masc_ws_client_buffered_bytes_count"
+  ; hello_latency = Prometheus.metric_ws_dashboard_hello_latency_seconds
+  ; hello_latency_count = Prometheus.metric_ws_dashboard_hello_latency_seconds ^ "_count"
   }
 ;;
 
@@ -657,6 +669,13 @@ let transport_health_json ~config =
                   , `Int
                       (int_of_float
                          (v ws_delivery_metrics.client_buffered_bytes_count ())) )
+                ; ( "hello_latency_sum_seconds"
+                  , `Float (Prometheus.metric_total ws_delivery_metrics.hello_latency) )
+                ; ( "hello_latency_count"
+                  , `Int
+                      (int_of_float
+                         (Prometheus.metric_total ws_delivery_metrics.hello_latency_count))
+                  )
                 ] )
           ] )
     ; ( "webrtc"

--- a/lib/transport_metrics.mli
+++ b/lib/transport_metrics.mli
@@ -193,6 +193,10 @@ val inc_ws_bytes_cache_hit : unit -> unit
 (** Increments [masc_ws_bytes_cache_misses_total]. *)
 val inc_ws_bytes_cache_miss : unit -> unit
 
+(** Records [dashboard/hello] processing latency in seconds.
+    [success] is encoded as bounded [outcome=success|error]. *)
+val observe_ws_dashboard_hello_latency : success:bool -> float -> unit
+
 (** [observe_ws_client_buffered_bytes n] records
     [masc_ws_client_buffered_bytes] (clamped to [max 0 n]) AND
     increments [masc_ws_client_acks_total].  Paired observation

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -67,6 +67,12 @@ let test_init () =
        let _ = Str.search_forward
          (Str.regexp_string "masc_http_accepts_total") text 0 in
        true
+     with Not_found -> false);
+  check bool "ws hello latency metric registered" true
+    (try
+       let _ = Str.search_forward
+         (Str.regexp_string "masc_ws_dashboard_hello_latency_seconds") text 0 in
+       true
      with Not_found -> false)
 
 (* ============================================================
@@ -187,6 +193,41 @@ let test_ws_sessions () =
     "masc_ws_sessions_total" () in
   check (float 0.01) "ws sessions" 4.0 v
 
+let test_ws_dashboard_hello_latency () =
+  let metric = Prometheus.metric_ws_dashboard_hello_latency_seconds in
+  let success_labels = [ ("outcome", "success") ] in
+  let error_labels = [ ("outcome", "error") ] in
+  let success_before = Prometheus.metric_value_or_zero metric ~labels:success_labels () in
+  let success_count_before =
+    Prometheus.metric_value_or_zero (metric ^ "_count") ~labels:success_labels ()
+  in
+  let error_before = Prometheus.metric_value_or_zero metric ~labels:error_labels () in
+  let error_count_before =
+    Prometheus.metric_value_or_zero (metric ^ "_count") ~labels:error_labels ()
+  in
+  TM.observe_ws_dashboard_hello_latency ~success:true 0.25;
+  TM.observe_ws_dashboard_hello_latency ~success:false (-1.0);
+  let success_after = Prometheus.metric_value_or_zero metric ~labels:success_labels () in
+  let success_count_after =
+    Prometheus.metric_value_or_zero (metric ^ "_count") ~labels:success_labels ()
+  in
+  let error_after = Prometheus.metric_value_or_zero metric ~labels:error_labels () in
+  let error_count_after =
+    Prometheus.metric_value_or_zero (metric ^ "_count") ~labels:error_labels ()
+  in
+  check (float 0.001) "success latency sum delta" 0.25 (success_after -. success_before);
+  check
+    (float 0.001)
+    "success latency count delta"
+    1.0
+    (success_count_after -. success_count_before);
+  check (float 0.001) "negative error latency clamped" 0.0 (error_after -. error_before);
+  check
+    (float 0.001)
+    "error latency count delta"
+    1.0
+    (error_count_after -. error_count_before)
+
 let test_ws_enabled_blank_env_matches_runtime () =
   with_env "MASC_WS_ENABLED" (Some "") (fun () ->
     check bool "transport metrics treats blank as enabled" true
@@ -300,6 +341,14 @@ let test_transport_health_json () =
     ~labels:[ ("stage", "append") ] ~delta:1.0 ();
   Prometheus.inc_counter Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_dispatch_rejections
     ~labels:[ ("event", "compaction_started") ] ~delta:2.0 ();
+  let hello_latency_sum_before =
+    Prometheus.metric_total Prometheus.metric_ws_dashboard_hello_latency_seconds
+  in
+  let hello_latency_count_before =
+    Prometheus.metric_total
+      (Prometheus.metric_ws_dashboard_hello_latency_seconds ^ "_count")
+  in
+  TM.observe_ws_dashboard_hello_latency ~success:true 0.125;
   Masc_mcp.Sse.broadcast (`Assoc [ ("type", `String "transport-test") ]);
   let json = TM.transport_health_json ~config in
   let sse_json = json |> U.member "sse" in
@@ -408,10 +457,23 @@ let test_transport_health_json () =
     ; "client_acks", "client_acks"
     ; "throttled_deliveries", "throttled_deliveries"
     ; "client_buffered_bytes_count", "client_buffered_bytes_count"
+    ; "hello_latency_count", "hello_latency_count"
     ];
   check bool "client_buffered_bytes_sum field present (float)" true
     (match delivery_json |> U.member "client_buffered_bytes_sum" with
      | `Float _ | `Int _ -> true | _ -> false);
+  check bool "hello_latency_sum_seconds field present (float)" true
+    (match delivery_json |> U.member "hello_latency_sum_seconds" with
+     | `Float _ | `Int _ -> true | _ -> false);
+  check bool "hello latency count is aggregated into health json" true
+    (float_of_int (delivery_json |> U.member "hello_latency_count" |> U.to_int)
+     >= hello_latency_count_before +. 1.0);
+  check bool "hello latency sum is aggregated into health json" true
+    ((match delivery_json |> U.member "hello_latency_sum_seconds" with
+      | `Float f -> f
+      | `Int i -> float_of_int i
+      | _ -> 0.0)
+     >= hello_latency_sum_before +. 0.125);
   ignore (Masc_mcp.Sse.close_all_clients ());
   cleanup_dir base_dir
 
@@ -494,6 +556,8 @@ let () =
     ]);
     ("websocket", [
       test_case "set_ws_sessions" `Quick test_ws_sessions;
+      test_case "observe dashboard hello latency" `Quick
+        test_ws_dashboard_hello_latency;
       test_case "blank env stays enabled" `Quick
         test_ws_enabled_blank_env_matches_runtime;
       test_case "normalized env matches runtime" `Quick


### PR DESCRIPTION
## Summary
- Add a Prometheus histogram for dashboard/hello JSON-RPC processing latency, labelled by success/error outcome.
- Record the metric in the WebSocket dashboard hello path without changing auth/session behavior.
- Surface aggregated hello latency sum/count in transport health JSON for dashboard consumption.

## Verification
- git diff --check
- scripts/dune-local.sh build test/test_transport_metrics.exe test/test_ws_transport.exe
- scripts/dune-local.sh build @runtest-test_transport_metrics @runtest-test_ws_transport

## Notes
- Addresses the old OCaml server performance monitoring gap for dashboard/hello processing time.