### PR TITLE
feat(ide): surface toolbar context focus

### DIFF
--- a/dashboard/src/components/ide/ide-toolbar.test.ts
+++ b/dashboard/src/components/ide/ide-toolbar.test.ts
@@ -1,0 +1,101 @@
+import { fireEvent } from '@testing-library/preact'
+import { h } from 'preact'
+import { render } from 'preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { IdeToolbar } from './ide-toolbar'
+import { ideContextFocus } from './ide-state'
+
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  if (container) render(null, container)
+  container = null
+  ideContextFocus.value = null
+  window.location.hash = ''
+})
+
+describe('IdeToolbar', () => {
+  it('renders current IDE context focus and routes through its operational links', () => {
+    ideContextFocus.value = {
+      file_path: 'lib/runtime.ml',
+      line: 42,
+      surface: 'Task',
+      label: 'task task-runtime',
+      source_id: 'event-1',
+      keeper_id: 'sangsu',
+      activated_at_ms: Date.now(),
+      route_links: [
+        {
+          id: 'task:task-runtime',
+          label: 'Task',
+          tab: 'workspace',
+          params: { section: 'planning', view: 'default', task: 'task-runtime' },
+          evidence: 'Task task-runtime',
+        },
+        {
+          id: 'telemetry:turn-9',
+          label: 'Telemetry',
+          tab: 'monitoring',
+          params: { section: 'fleet-health', view: 'event-log', q: 'turn-9' },
+          evidence: 'Fleet telemetry event log · query turn-9',
+        },
+      ],
+    }
+    container = document.createElement('div')
+
+    render(h(IdeToolbar, {
+      activeView: 'source',
+      activeLayers: new Set<string>(),
+      onViewChange: vi.fn(),
+      onLayersChange: vi.fn(),
+    }), container)
+
+    const focus = container.querySelector('[data-testid="ide-toolbar-context-focus"]')
+    expect(focus?.getAttribute('aria-label'))
+      .toBe('Current IDE context: Task line 42, task task-runtime, keeper sangsu, 2 route links')
+    expect(focus?.textContent).toContain('Task')
+    expect(focus?.textContent).toContain('L42')
+    expect(focus?.textContent).toContain('task task-runtime')
+    expect(focus?.textContent).toContain('keeper sangsu')
+
+    const routeLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-toolbar-context-links button')]
+    expect(routeLinks.map(link => link.textContent)).toEqual(['Task', 'Telemetry'])
+
+    fireEvent.click(routeLinks.find(link => link.textContent === 'Telemetry')!)
+    expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&q=turn-9')
+  })
+
+  it('adds current context route links to the command bar', () => {
+    ideContextFocus.value = {
+      file_path: 'lib/runtime.ml',
+      line: 12,
+      surface: 'Goal',
+      label: 'Runtime goal',
+      source_id: 'event-2',
+      activated_at_ms: Date.now(),
+      route_links: [{
+        id: 'goal:goal-runtime',
+        label: 'Goal',
+        tab: 'workspace',
+        params: { section: 'planning', goal: 'goal-runtime' },
+        evidence: 'Goal goal-runtime',
+      }],
+    }
+    container = document.createElement('div')
+
+    render(h(IdeToolbar, {
+      activeView: 'source',
+      activeLayers: new Set<string>(),
+      onViewChange: vi.fn(),
+      onLayersChange: vi.fn(),
+    }), container)
+
+    const input = container.querySelector('[data-testid="ide-command-bar"] input') as HTMLInputElement
+    fireEvent.focus(input)
+    fireEvent.input(input, { target: { value: 'goal-runtime' } })
+
+    const command = [...container.querySelectorAll('[role="option"]')]
+      .find(option => option.textContent === 'Open context: Goal')
+    expect(command).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -1,12 +1,18 @@
 import { html } from 'htm/preact'
-import { useEffect, useMemo } from 'preact/hooks'
+import { useEffect, useMemo, useState } from 'preact/hooks'
 import { PanelRightClose, PanelRightOpen } from 'lucide-preact'
 import {
   createLayeredOverlay,
   type OverlayLayer,
 } from '../../../design-system/headless-core/layered-overlay'
 import { useLayeredOverlay } from '../../../design-system/headless-preact/use-layered-overlay'
+import { navigate } from '../../router'
 import { CommandBar, type CommandBarAction } from '../common/command-bar'
+import {
+  ideContextFocus,
+  type IdeContextFocus,
+  type IdeContextFocusRouteLink,
+} from './ide-state'
 
 // Phase 1 PR-3: IDE editor toolbar — view tabs + LAYERS toggle.
 // View tabs (SOURCE / SPLIT DIFF / UNIFIED / BLAME) are local UI state
@@ -70,10 +76,16 @@ export function IdeToolbar({
     return next
   }, [])
   const { active, isActive } = useLayeredOverlay(controller)
+  const [contextFocus, setContextFocus] = useState(ideContextFocus.value)
 
   useEffect(() => {
     controller.setActive(activeLayers)
   }, [controller, activeLayers])
+
+  useEffect(() => {
+    const unsub = ideContextFocus.subscribe(focus => setContextFocus(focus))
+    return () => unsub()
+  }, [])
 
   const handleLayerToggle = (kind: string) => {
     controller.toggle(kind)
@@ -117,6 +129,7 @@ export function IdeToolbar({
           handler: onFindOpen,
         }]
       : []),
+    ...contextCommandActions(contextFocus),
   ]
 
   return html`
@@ -150,13 +163,16 @@ export function IdeToolbar({
           >${tab.label}</button>
         `)}
       </div>
-      <${CommandBar}
-        actions=${commandActions}
-        placeholder="Run IDE command..."
-        testId="ide-command-bar"
-        className="min-w-0"
-        inputClassName="h-7 w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 font-mono text-2xs text-[var(--color-fg-primary)] outline-none transition-colors placeholder:text-[var(--color-fg-disabled)] focus:border-[var(--color-accent)] focus:ring-1 focus:ring-[var(--color-accent)]"
-      />
+      <div class="ide-toolbar-command-cluster">
+        <${CommandBar}
+          actions=${commandActions}
+          placeholder="Run IDE command..."
+          testId="ide-command-bar"
+          className="min-w-0"
+          inputClassName="h-7 w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 font-mono text-2xs text-[var(--color-fg-primary)] outline-none transition-colors placeholder:text-[var(--color-fg-disabled)] focus:border-[var(--color-accent)] focus:ring-1 focus:ring-[var(--color-accent)]"
+        />
+        <${ToolbarContextFocus} focus=${contextFocus} />
+      </div>
       ${onRailsToggle ? html`
         <button
           type="button"
@@ -222,4 +238,69 @@ export function IdeToolbar({
       </div>
     </div>
   `
+}
+
+function contextCommandActions(focus: IdeContextFocus | null): CommandBarAction[] {
+  if (!focus?.route_links || focus.route_links.length === 0) return []
+  return focus.route_links.map(link => ({
+    id: `context-${link.id}`,
+    title: `Open context: ${link.label}`,
+    keywords: [
+      'context focus route link',
+      focus.surface,
+      focus.label,
+      focus.keeper_id ?? '',
+      link.evidence,
+    ].join(' '),
+    handler: () => openToolbarContextRouteLink(link),
+  }))
+}
+
+function ToolbarContextFocus({
+  focus,
+}: {
+  readonly focus: IdeContextFocus | null
+}) {
+  if (!focus) return null
+  const lineLabel = focus.line !== undefined ? `L${focus.line}` : null
+  const routeLinks = focus.route_links ?? []
+  return html`
+    <div
+      class="ide-toolbar-context-focus"
+      data-testid="ide-toolbar-context-focus"
+      aria-label=${toolbarContextAriaLabel(focus)}
+      title=${`${focus.file_path}${focus.line !== undefined ? `:${focus.line}` : ''}`}
+    >
+      <span>${focus.surface}</span>
+      ${lineLabel ? html`<span>${lineLabel}</span>` : null}
+      <strong>${focus.label}</strong>
+      ${focus.keeper_id ? html`<span>keeper ${focus.keeper_id}</span>` : null}
+      ${routeLinks.length > 0 ? html`
+        <div class="ide-toolbar-context-links" aria-label="Current context route links">
+          ${routeLinks.map(link => html`
+            <button
+              key=${link.id}
+              type="button"
+              title=${link.evidence}
+              aria-label=${`Open ${link.evidence}`}
+              onClick=${() => openToolbarContextRouteLink(link)}
+            >${link.label}</button>
+          `)}
+        </div>
+      ` : null}
+    </div>
+  `
+}
+
+function openToolbarContextRouteLink(link: IdeContextFocusRouteLink): void {
+  navigate(link.tab, link.params)
+}
+
+function toolbarContextAriaLabel(focus: IdeContextFocus): string {
+  const line = focus.line !== undefined ? ` line ${focus.line}` : ''
+  const keeper = focus.keeper_id ? `, keeper ${focus.keeper_id}` : ''
+  const links = focus.route_links?.length
+    ? `, ${focus.route_links.length} route links`
+    : ''
+  return `Current IDE context: ${focus.surface}${line}, ${focus.label}${keeper}${links}`
 }

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -303,6 +303,78 @@
   grid-template-columns: max-content minmax(1rem, 1fr) max-content max-content;
 }
 
+.ide-toolbar-command-cluster {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.ide-toolbar-context-focus {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+}
+
+.ide-toolbar-context-focus > span,
+.ide-toolbar-context-focus > strong {
+  min-width: 0;
+  max-width: 9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-toolbar-context-focus > span {
+  padding: 1px 5px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-page);
+}
+
+.ide-toolbar-context-focus > strong {
+  color: var(--color-fg-primary);
+  font-weight: 600;
+}
+
+.ide-toolbar-context-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  min-width: 0;
+}
+
+.ide-toolbar-context-links button {
+  min-width: 0;
+  max-width: 76px;
+  height: 18px;
+  padding: 0 5px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-page);
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-toolbar-context-links button:hover,
+.ide-toolbar-context-links button:focus-visible {
+  border-color: var(--color-border-strong);
+  color: var(--color-accent-fg);
+}
+
+.ide-toolbar-context-links button:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 1px;
+}
+
 .ide-toolbar-tabs,
 .ide-toolbar-layers {
   min-width: 0;


### PR DESCRIPTION
Summary:
- show the current IDE context focus inside the toolbar command cluster
- expose focused context route links as visible toolbar buttons and command bar actions
- cover Task/Telemetry link routing and command search visibility in a focused toolbar test

Validation:
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/ide-toolbar.ts src/components/ide/ide-toolbar.test.ts
- pnpm exec vitest run src/components/ide/ide-toolbar.test.ts src/components/ide/ide-shell.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD~1..HEAD