### PR TITLE
fix(dashboard): surface runtime path mismatch

### DIFF
--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -89,7 +89,10 @@ describe('ConfigResolutionPanel', () => {
         }}
         runtimeResolution=${{
           status: 'warn',
-          warnings: ['Runtime build commit (deadbee) differs from server repo HEAD (feedbee).'],
+          warnings: [
+            'Runtime build commit (deadbee) differs from server repo HEAD (feedbee).',
+            'Server binary checkout (/tmp/masc-mcp) differs from dashboard workspace/base path (/tmp/workspace / /tmp/workspace).',
+          ],
           base_path: { path: '/tmp/runtime-input', exists: true, source: 'input' },
           workspace_path: { path: '/tmp/workspace', exists: true, source: 'workspace' },
           resolved_base_path: { path: '/tmp/workspace', exists: true, source: 'resolved_base' },
@@ -100,6 +103,7 @@ describe('ConfigResolutionPanel', () => {
           workspace_git_commit: 'cafef00d',
           resolved_base_git_commit: 'cafef00d',
           source_mismatch: true,
+          server_workspace_mismatch: true,
           diagnostics: [
             {
               ts: '2026-03-27T00:00:00Z',
@@ -152,8 +156,10 @@ describe('ConfigResolutionPanel', () => {
     expect(container.textContent).toContain('server repo head')
     expect(container.textContent).toContain('feedbee')
     expect(container.textContent).toContain('source mismatch')
+    expect(container.textContent).toContain('server/workspace mismatch')
     expect(container.textContent).toContain('SIGTERM')
     expect(container.textContent).toContain('Runtime build commit (deadbee) differs from server repo HEAD (feedbee).')
+    expect(container.textContent).toContain('Server binary checkout (/tmp/masc-mcp) differs from dashboard workspace/base path')
     expect(container.textContent).toContain('ollama warm / kv probe')
     expect(container.textContent).toContain('kv likely reused')
     expect(container.textContent).toContain('qwen3.5:35b-a3b-coding-nvfp4')

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -627,6 +627,11 @@ export function ConfigResolutionPanel({
                       <${StatusChip} tone="bad">source mismatch<//>
                     `
                   : null}
+                ${runtimeResolution.server_workspace_mismatch
+                  ? html`
+                      <${StatusChip} tone="warn">server/workspace mismatch<//>
+                    `
+                  : null}
               </div>
 
               <div class="mb-4">

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -571,6 +571,7 @@ export function normalizeDashboardRuntimeResolution(
     workspace_git_commit: asString(raw.workspace_git_commit) ?? null,
     resolved_base_git_commit: asString(raw.resolved_base_git_commit) ?? null,
     source_mismatch: asBoolean(raw.source_mismatch) ?? false,
+    server_workspace_mismatch: asBoolean(raw.server_workspace_mismatch) ?? false,
     diagnostics: (Array.isArray(raw.diagnostics) ? raw.diagnostics : [])
       .map(normalizeDashboardRuntimeDiagnostic)
       .filter((item): item is DashboardRuntimeDiagnostic => item !== null),

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -112,6 +112,7 @@ export interface DashboardRuntimeResolution {
   workspace_git_commit: string | null
   resolved_base_git_commit: string | null
   source_mismatch: boolean
+  server_workspace_mismatch: boolean
   diagnostics: DashboardRuntimeDiagnostic[]
   build: ServerBuildIdentity
   keeper_runtime: KeeperRuntimeResolved | null

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -254,6 +254,26 @@ let path_item_json ~source path =
     ]
 ;;
 
+let normalized_path_opt path =
+  match trim_to_option path with
+  | None -> None
+  | Some path ->
+    let normalized =
+      if Sys.file_exists path
+      then (
+        try Unix.realpath path with
+        | Unix.Unix_error _ -> path)
+      else path
+    in
+    Some normalized
+;;
+
+let same_normalized_path path expected =
+  match normalized_path_opt expected with
+  | Some expected -> String.equal path expected
+  | None -> false
+;;
+
 let shutdown_signal_of_message message =
   if contains_substring ~needle:"Received SIGTERM" message
   then Some "SIGTERM"
@@ -427,12 +447,17 @@ let runtime_resolution_json (config : Coord.config) =
     | Some runtime, None, Some workspace -> not (String.equal runtime workspace)
     | _ -> false
   in
+  let server_workspace_mismatch =
+    match Option.bind server_repo_path normalized_path_opt with
+    | None -> false
+    | Some server_repo_path ->
+      (not (same_normalized_path server_repo_path config.workspace_path))
+      && not (same_normalized_path server_repo_path config.base_path)
+  in
   let diagnostics, signal_count, repair_count, agent_issue_count =
     runtime_diagnostics_json ()
   in
-  let warnings =
-    []
-    |> fun acc ->
+  let add_source_mismatch_warning acc =
     if source_mismatch
     then (
       let runtime = Option.value ~default:"unknown" runtime_commit in
@@ -448,43 +473,66 @@ let runtime_resolution_json (config : Coord.config) =
         source_label
         source_commit
       :: acc)
-    else
-      acc
-      |> fun acc ->
-      if prompt_dir_mismatch
-      then
-        Printf.sprintf
-          "Prompt markdown dir (%s) differs from resolved config root (%s)."
-          prompt_markdown_dir
-          expected_prompt_dir
-        :: acc
-      else
-        acc
-        |> fun acc ->
-        if signal_count > 0
-        then
-          Printf.sprintf
-            "Recent external shutdown signals detected in server logs (%d). Ephemeral \
-             agents will not auto-rejoin after these restarts."
-            signal_count
-          :: acc
-        else
-          acc
-          |> fun acc ->
-          if repair_count > 0
-          then
-            Printf.sprintf "Recent room-state repair events detected (%d)." repair_count
-            :: acc
-          else
-            acc
-            |> fun acc ->
-            if agent_issue_count > 0
-            then
-              Printf.sprintf
-                "Recent agent-state compatibility warnings detected (%d)."
-                agent_issue_count
-              :: acc
-            else acc |> fun acc -> acc |> List.rev
+    else acc
+  in
+  let add_server_workspace_mismatch_warning acc =
+    if server_workspace_mismatch
+    then (
+      let server_repo =
+        server_repo_path |> Option.value ~default:"unknown server repo"
+      in
+      Printf.sprintf
+        "Server binary checkout (%s) differs from dashboard workspace/base path (%s / \
+         %s). This can be intentional; verify the running worktree when dashboard \
+         data looks stale."
+        server_repo
+        config.workspace_path
+        config.base_path
+      :: acc)
+    else acc
+  in
+  let add_prompt_dir_mismatch_warning acc =
+    if prompt_dir_mismatch
+    then
+      Printf.sprintf
+        "Prompt markdown dir (%s) differs from resolved config root (%s)."
+        prompt_markdown_dir
+        expected_prompt_dir
+      :: acc
+    else acc
+  in
+  let add_signal_warning acc =
+    if signal_count > 0
+    then
+      Printf.sprintf
+        "Recent external shutdown signals detected in server logs (%d). Ephemeral \
+         agents will not auto-rejoin after these restarts."
+        signal_count
+      :: acc
+    else acc
+  in
+  let add_repair_warning acc =
+    if repair_count > 0
+    then Printf.sprintf "Recent room-state repair events detected (%d)." repair_count :: acc
+    else acc
+  in
+  let add_agent_issue_warning acc =
+    if agent_issue_count > 0
+    then
+      Printf.sprintf "Recent agent-state compatibility warnings detected (%d)."
+        agent_issue_count
+      :: acc
+    else acc
+  in
+  let warnings =
+    []
+    |> add_source_mismatch_warning
+    |> add_server_workspace_mismatch_warning
+    |> add_prompt_dir_mismatch_warning
+    |> add_signal_warning
+    |> add_repair_warning
+    |> add_agent_issue_warning
+    |> List.rev
   in
   let status = if warnings = [] then "ready" else "warn" in
   `Assoc
@@ -508,6 +556,7 @@ let runtime_resolution_json (config : Coord.config) =
     ; ( "resolved_base_git_commit"
       , Option.fold ~none:`Null ~some:(fun value -> `String value) resolved_base_commit )
     ; "source_mismatch", `Bool source_mismatch
+    ; "server_workspace_mismatch", `Bool server_workspace_mismatch
     ; "diagnostics", diagnostics
     ; ("keeper_runtime", Keeper_runtime_resolved.(current () |> to_yojson))
     ; "build", Build_identity.to_yojson build

--- a/lib/server/server_dashboard_http_runtime_info.mli
+++ b/lib/server/server_dashboard_http_runtime_info.mli
@@ -54,8 +54,9 @@
 val runtime_resolution_json : Coord.config -> Yojson.Safe.t
 (** Renders the runtime resolution envelope: build
     identity + workspace / base-path commit shas (via
-    {!git_rev_parse_short}) + base-path resolution
-    inputs.  Reached unqualified through the
+    {!git_rev_parse_short}) + server/workspace path
+    mismatch visibility + base-path resolution inputs.
+    Reached unqualified through the
     [Server_dashboard_http_core] cascade consumer. *)
 
 (** {1 Dashboard HTTP routes} *)

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -21,6 +21,21 @@ let cleanup_dir dir =
   in
   rm dir
 
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop index =
+    if needle_len = 0
+    then true
+    else if index + needle_len > haystack_len
+    then false
+    else if String.equal (String.sub haystack index needle_len) needle
+    then true
+    else loop (index + 1)
+  in
+  loop 0
+;;
+
 let test_dashboard_tools_projection () =
   let dir = test_dir () in
   let runtime_probe_calls = Atomic.make 0 in
@@ -77,6 +92,25 @@ let test_dashboard_tools_projection () =
         (match runtime_resolution |> member "source_mismatch" with
          | `Bool _ -> true
          | _ -> false);
+      let server_workspace_mismatch =
+        match runtime_resolution |> member "server_workspace_mismatch" with
+        | `Bool value -> value
+        | _ -> false
+      in
+      check bool "runtime server_workspace_mismatch surfaced" true
+        (match runtime_resolution |> member "server_workspace_mismatch" with
+         | `Bool _ -> true
+         | _ -> false);
+      if server_workspace_mismatch
+      then
+        check bool "runtime server/workspace warning surfaced" true
+          (runtime_resolution
+           |> member "warnings"
+           |> to_list
+           |> List.exists (function
+             | `String warning ->
+               contains_substring ~needle:"Server binary checkout" warning
+             | _ -> false));
       check bool "runtime diagnostics surfaced as list" true
         (match runtime_resolution |> member "diagnostics" with
          | `List _ -> true


### PR DESCRIPTION
## Summary
- add `server_workspace_mismatch` to dashboard runtime resolution so a running server checkout/worktree that differs from the dashboard workspace/base path is visible
- emit a runtime warning for that mismatch and keep all runtime warnings accumulated instead of masking later warnings behind an earlier source mismatch
- show a `server/workspace mismatch` chip in the config resolution panel and normalize the field in the dashboard store

## Verification
- `git diff --check origin/main...HEAD`
- `ocamlformat --check lib/server/server_dashboard_http_runtime_info.ml lib/server/server_dashboard_http_runtime_info.mli test/test_dashboard_tools.ml`
- `scripts/dune-local.sh build ./test/test_dashboard_tools.exe`
- `pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/components/tools/config-resolution-panel.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm run lint` (passes with existing warning in `src/components/common/virtual-list.ts`)

## Notes
- Local execution of `./_build/default/test/test_dashboard_tools.exe test projection 0` hangs after `Coord.init`; tracked separately as #15179.
