### PR TITLE
feat(ide): mark explorer context focus

### DIFF
--- a/dashboard/src/components/ide/ide-explorer.test.ts
+++ b/dashboard/src/components/ide/ide-explorer.test.ts
@@ -3,6 +3,7 @@ import { h, render } from 'preact'
 import { explorerScopeLabel, IdeExplorer } from './ide-explorer'
 import { createFileTreeStore, type FileTreeNode } from './file-tree-store'
 import type { Repository } from '../../api/repositories'
+import { activeIdeFile, ideContextFocus } from './ide-state'
 
 const SAMPLE: ReadonlyArray<FileTreeNode> = [
   { path: 'runtime', label: 'runtime', depth: 0, parent: null, hasChildren: true, diff: null, keeperId: null, hueIndex: null },
@@ -57,6 +58,8 @@ describe('IdeExplorer tree row keyboard accessibility', () => {
 
   afterEach(() => {
     render(null, container)
+    activeIdeFile.value = 'package.json'
+    ideContextFocus.value = null
   })
 
   it('makes every treeitem keyboard-focusable, not just directories', () => {
@@ -119,5 +122,47 @@ describe('IdeExplorer tree row keyboard accessibility', () => {
     expect(scroller?.contains(tree)).toBe(true)
     expect(scroller?.contains(container.querySelector('header'))).toBe(false)
     expect(scroller?.contains(container.querySelector('input[type="search"]'))).toBe(false)
+  })
+
+  it('marks the file row carrying the current IDE context focus', () => {
+    const store = createFileTreeStore()
+    store.seed(SAMPLE)
+    ideContextFocus.value = {
+      file_path: 'runtime/router.ts',
+      line: 42,
+      surface: 'Task',
+      label: 'task task-runtime',
+      source_id: 'event-1',
+      activated_at_ms: Date.now(),
+      route_links: [
+        {
+          id: 'task:task-runtime',
+          label: 'Task',
+          tab: 'workspace',
+          params: { section: 'planning', view: 'default', task: 'task-runtime' },
+          evidence: 'Task task-runtime',
+        },
+        {
+          id: 'telemetry:turn-9',
+          label: 'Telemetry',
+          tab: 'monitoring',
+          params: { section: 'fleet-health', view: 'event-log', q: 'turn-9' },
+          evidence: 'Fleet telemetry event log · query turn-9',
+        },
+      ],
+    }
+
+    render(h(IdeExplorer, { fileTreeStore: store }), container)
+
+    const focusedRow = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="treeitem"]'),
+    ).find(el => el.textContent?.includes('router.ts'))
+    const chip = focusedRow?.querySelector('.ide-explorer-context-chip')
+
+    expect(chip?.textContent).toContain('Task')
+    expect(chip?.textContent).toContain('L42')
+    expect(chip?.textContent).toContain('2 links')
+    expect(chip?.getAttribute('aria-label'))
+      .toBe('Focused Task line 42: task task-runtime, 2 route links')
   })
 })

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from 'preact/hooks'
 import { Search } from 'lucide-preact'
 import { activeKeeperName } from '../../keeper-state'
 import { type FileTreeStore, type FileTreeNode } from './file-tree-store'
-import { activeIdeFile } from './ide-state'
+import { activeIdeFile, ideContextFocus, type IdeContextFocus } from './ide-state'
 import type { WorkspaceSource } from '../../api/workspace-source'
 import type { Repository } from '../../api/repositories'
 import { showToast } from '../common/toast'
@@ -111,6 +111,9 @@ export function IdeExplorer({
   const [isScanningRepositories, setIsScanningRepositories] = useState(false)
   const [activeFile, setActiveFile] = useState(activeIdeFile.value)
   useEffect(() => activeIdeFile.subscribe(file => setActiveFile(file)), [])
+
+  const [contextFocus, setContextFocus] = useState(ideContextFocus.value)
+  useEffect(() => ideContextFocus.subscribe(focus => setContextFocus(focus)), [])
 
   const [cursorOverlay, setCursorOverlay] = useState(cursorOverlaySignal.value)
   useEffect(() => cursorOverlaySignal.subscribe(v => setCursorOverlay(v)), [])
@@ -302,6 +305,7 @@ export function IdeExplorer({
               if (node.hasChildren) store.toggle(node.path)
               else activeIdeFile.value = node.path
             },
+            contextFocus?.file_path === node.path ? contextFocus : null,
             keepersByFile.get(node.path),
           ))}
         </ul>
@@ -357,6 +361,7 @@ function TreeRow(
   expanded: boolean,
   selected: boolean,
   onClick: () => void,
+  contextFocus: IdeContextFocus | null,
   activeKeepers?: ReadonlyArray<{ readonly keeperId: string; readonly color: string; readonly focusMode: string }>,
 ) {
   const indent = node.depth * 12
@@ -385,6 +390,7 @@ function TreeRow(
         ? html`<${KeeperBadge} id=${node.keeperId} variant="sigil" size="sm" />`
         : html`<span aria-hidden="true" style=${{ width: '14px', height: '14px', textAlign: 'center', fontSize: '12px', lineHeight: '14px' }}>${fileIcon(node, expanded)}</span>`}
       <span class="ide-explorer-row-label">${node.label}</span>
+      ${contextFocus ? ExplorerContextChip(contextFocus) : null}
       ${activeKeepers && activeKeepers.length > 0
         ? html`<span
             aria-label=${`${activeKeepers.map(k => k.keeperId).join(', ')} focusing`}
@@ -408,4 +414,28 @@ function TreeRow(
         : null}
     </li>
   `
+}
+
+function ExplorerContextChip(focus: IdeContextFocus) {
+  const line = focus.line !== undefined ? `L${focus.line}` : null
+  const linkCount = focus.route_links?.length ?? 0
+  return html`
+    <span
+      class="ide-explorer-context-chip"
+      aria-label=${explorerContextChipLabel(focus)}
+      title=${`${focus.surface} · ${focus.label}`}
+    >
+      <span>${focus.surface}</span>
+      ${line ? html`<span>${line}</span>` : null}
+      ${linkCount > 0 ? html`<span>${linkCount} links</span>` : null}
+    </span>
+  `
+}
+
+function explorerContextChipLabel(focus: IdeContextFocus): string {
+  const line = focus.line !== undefined ? ` line ${focus.line}` : ''
+  const links = focus.route_links?.length
+    ? `, ${focus.route_links.length} route links`
+    : ''
+  return `Focused ${focus.surface}${line}: ${focus.label}${links}`
 }

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -431,6 +431,29 @@
   white-space: nowrap;
 }
 
+.ide-explorer-context-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  min-width: 0;
+  max-width: 116px;
+  margin-left: auto;
+  padding: 1px 5px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-page);
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+}
+
+.ide-explorer-context-chip > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .ide-plane-editor {
   grid-column: 2;
   grid-row: 1 / span 2;


### PR DESCRIPTION
Summary:
- mark the file tree row that carries the current IDE context focus
- surface context surface, line, and route-link count directly in the explorer
- add coverage for focused Task context chips on file rows

Validation:
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/ide-explorer.ts src/components/ide/ide-explorer.test.ts
- pnpm exec vitest run src/components/ide/ide-explorer.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check