### PR TITLE
feat(ide): show diff context focus

### DIFF
--- a/dashboard/src/components/ide/ide-diff-view.test.ts
+++ b/dashboard/src/components/ide/ide-diff-view.test.ts
@@ -1,9 +1,11 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { fireEvent } from '@testing-library/preact'
 import { render } from 'preact'
 import type { UnifiedDiffRow } from '../../api/workspace'
 import {
   buildSplitDiff,
+  diffContextFocusForRows,
   formatDiffLineRange,
   formatDiffSummaryAria,
   SplitDiffView,
@@ -112,6 +114,29 @@ describe('summarizeDiffRows', () => {
     expect(formatDiffLineRange(summary.oldRange)).toBe('n/a')
     expect(formatDiffLineRange(summary.newRange)).toBe('n/a')
   })
+
+  it('matches current context focus against old or new diff lines', () => {
+    const rows = [
+      row('delete', 4, null, 'old'),
+      row('add', null, 5, 'new'),
+    ]
+    expect(diffContextFocusForRows(rows, {
+      file_path: 'lib/runtime.ml',
+      line: 5,
+      surface: 'Task',
+      label: 'task task-runtime',
+      source_id: 'event-1',
+      activated_at_ms: Date.now(),
+    })?.line).toBe(5)
+    expect(diffContextFocusForRows(rows, {
+      file_path: 'lib/runtime.ml',
+      line: 9,
+      surface: 'Task',
+      label: 'task task-runtime',
+      source_id: 'event-1',
+      activated_at_ms: Date.now(),
+    })).toBeNull()
+  })
 })
 
 describe('formatDiffSummaryAria', () => {
@@ -138,6 +163,7 @@ describe('diff preview chrome', () => {
   afterEach(() => {
     render(null, container)
     document.body.removeChild(container)
+    window.location.hash = ''
   })
 
   it('renders unified summary chips before diff rows', () => {
@@ -152,6 +178,49 @@ describe('diff preview chrome', () => {
     expect(container.querySelector('[data-status-chip-tone="bad"]')?.textContent).toBe('-1')
     expect(container.querySelector('[data-status-chip-tone="info"]')?.textContent).toBe('old 4-5 -> new 4-5')
     expect(container.querySelector('[aria-label="Unified diff rows"]')?.textContent).toContain('new value')
+  })
+
+  it('renders focused diff context and routes through its links', () => {
+    render(UnifiedDiffView([
+      row('delete', 4, null, 'old value'),
+      row('add', null, 4, 'new value'),
+      row('context', 5, 5, 'same value'),
+    ], {
+      file_path: 'lib/runtime.ml',
+      line: 4,
+      surface: 'Task',
+      label: 'task task-runtime',
+      source_id: 'event-1',
+      activated_at_ms: Date.now(),
+      route_links: [
+        {
+          id: 'task:task-runtime',
+          label: 'Task',
+          tab: 'workspace',
+          params: { section: 'planning', view: 'default', task: 'task-runtime' },
+          evidence: 'Task task-runtime',
+        },
+        {
+          id: 'telemetry:turn-9',
+          label: 'Telemetry',
+          tab: 'monitoring',
+          params: { section: 'fleet-health', view: 'event-log', q: 'turn-9' },
+          evidence: 'Fleet telemetry event log · query turn-9',
+        },
+      ],
+    }), container)
+
+    const focus = container.querySelector('[data-testid="ide-diff-context-focus"]')
+    expect(focus?.getAttribute('aria-label'))
+      .toBe('Diff context: Task line 4, task task-runtime, 2 route links')
+    expect(focus?.textContent).toContain('Task')
+    expect(focus?.textContent).toContain('L4')
+    expect(container.querySelectorAll('[data-context-focus="true"]')).toHaveLength(2)
+
+    const telemetry = [...container.querySelectorAll<HTMLButtonElement>('.ide-diff-context-links button')]
+      .find(button => button.textContent === 'Telemetry')
+    fireEvent.click(telemetry!)
+    expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&q=turn-9')
   })
 
   it('renders split empty state instead of a blank pane', () => {

--- a/dashboard/src/components/ide/ide-diff-view.ts
+++ b/dashboard/src/components/ide/ide-diff-view.ts
@@ -1,6 +1,8 @@
 import { html } from 'htm/preact'
 import type { UnifiedDiffRow } from '../../api/workspace'
+import { navigate } from '../../router'
 import { StatusChip } from '../common/status-chip'
+import type { IdeContextFocus, IdeContextFocusRouteLink } from './ide-state'
 
 // ── Shared diff types ─────────────────────────────────────────────
 
@@ -34,8 +36,12 @@ export interface DiffSummary {
 
 // ── Unified diff view ─────────────────────────────────────────────
 
-export function UnifiedDiffView(rows: ReadonlyArray<UnifiedDiffRow>) {
+export function UnifiedDiffView(
+  rows: ReadonlyArray<UnifiedDiffRow>,
+  contextFocus: IdeContextFocus | null = null,
+) {
   const summary = summarizeDiffRows(rows)
+  const diffFocus = diffContextFocusForRows(rows, contextFocus)
   return html`
     <div
       role="region"
@@ -50,7 +56,7 @@ export function UnifiedDiffView(rows: ReadonlyArray<UnifiedDiffRow>) {
         lineHeight: 1.6,
       }}
     >
-      <${DiffSummaryStrip} summary=${summary} mode="Unified" />
+      <${DiffSummaryStrip} summary=${summary} mode="Unified" contextFocus=${diffFocus} />
       ${summary.total === 0
         ? DiffEmptyState('No diff rows for the selected file.')
         : html`
@@ -65,6 +71,7 @@ export function UnifiedDiffView(rows: ReadonlyArray<UnifiedDiffRow>) {
           >
             ${rows.map(row => html`
               <li
+                data-context-focus=${diffRowMatchesFocus(row, diffFocus) ? 'true' : 'false'}
                 style=${{
                   display: 'grid',
                   gridTemplateColumns: '32px 40px 40px minmax(0, 1fr)',
@@ -92,9 +99,11 @@ export function UnifiedDiffView(rows: ReadonlyArray<UnifiedDiffRow>) {
 function DiffSummaryStrip({
   summary,
   mode,
+  contextFocus = null,
 }: {
   readonly summary: DiffSummary
   readonly mode: 'Unified' | 'Split'
+  readonly contextFocus?: IdeContextFocus | null
 }) {
   // In Split mode buildSplitDiff visually pairs each delete with its add on
   // the same row, so additions+deletions over-counts the visible "changed
@@ -136,7 +145,42 @@ function DiffSummaryStrip({
         <${StatusChip} tone="neutral" uppercase=${false}>${summary.context} context</${StatusChip}>
         <${StatusChip} tone="info" uppercase=${false}>old ${formatDiffLineRange(summary.oldRange)} -> new ${formatDiffLineRange(summary.newRange)}</${StatusChip}>
       </span>
+      ${contextFocus ? html`<${DiffContextFocus} focus=${contextFocus} />` : null}
     </div>
+  `
+}
+
+function DiffContextFocus({
+  focus,
+}: {
+  readonly focus: IdeContextFocus
+}) {
+  const line = focus.line !== undefined ? `L${focus.line}` : null
+  const links = focus.route_links ?? []
+  return html`
+    <span
+      class="ide-diff-context-focus"
+      data-testid="ide-diff-context-focus"
+      aria-label=${diffContextFocusLabel(focus)}
+      title=${`${focus.file_path}${focus.line !== undefined ? `:${focus.line}` : ''}`}
+    >
+      <span>${focus.surface}</span>
+      ${line ? html`<span>${line}</span>` : null}
+      <strong>${focus.label}</strong>
+      ${links.length > 0 ? html`
+        <span class="ide-diff-context-links" aria-label="Diff context route links">
+          ${links.map(link => html`
+            <button
+              key=${link.id}
+              type="button"
+              title=${link.evidence}
+              aria-label=${`Open ${link.evidence}`}
+              onClick=${() => openDiffContextRouteLink(link)}
+            >${link.label}</button>
+          `)}
+        </span>
+      ` : null}
+    </span>
   `
 }
 
@@ -163,9 +207,13 @@ function DiffEmptyState(label: string) {
 
 // ── Split diff view ───────────────────────────────────────────────
 
-export function SplitDiffView(rows: ReadonlyArray<UnifiedDiffRow>) {
+export function SplitDiffView(
+  rows: ReadonlyArray<UnifiedDiffRow>,
+  contextFocus: IdeContextFocus | null = null,
+) {
   const summary = summarizeDiffRows(rows)
   const splitRows: SplitDiffRow[] = buildSplitDiff(rows)
+  const diffFocus = diffContextFocusForRows(rows, contextFocus)
   return html`
     <div
       role="region"
@@ -180,7 +228,7 @@ export function SplitDiffView(rows: ReadonlyArray<UnifiedDiffRow>) {
         lineHeight: 1.6,
       }}
     >
-      <${DiffSummaryStrip} summary=${summary} mode="Split" />
+      <${DiffSummaryStrip} summary=${summary} mode="Split" contextFocus=${diffFocus} />
       <div
         style=${{
           display: 'grid',
@@ -199,6 +247,7 @@ export function SplitDiffView(rows: ReadonlyArray<UnifiedDiffRow>) {
           ? DiffEmptyState('No split diff rows for the selected file.')
           : splitRows.map(row => html`
             <div
+              data-context-focus=${splitDiffRowMatchesFocus(row, diffFocus) ? 'true' : 'false'}
               style=${{
                 display: 'grid',
                 gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
@@ -240,6 +289,42 @@ function SplitDiffCellView({
       <span style=${{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', minWidth: 0 }}>${cell?.text ?? ''}</span>
     </div>
   `
+}
+
+export function diffContextFocusForRows(
+  rows: ReadonlyArray<UnifiedDiffRow>,
+  focus: IdeContextFocus | null,
+): IdeContextFocus | null {
+  if (!focus || focus.line === undefined) return null
+  return rows.some(row => diffRowMatchesFocus(row, focus)) ? focus : null
+}
+
+function diffRowMatchesFocus(
+  row: UnifiedDiffRow,
+  focus: IdeContextFocus | null,
+): boolean {
+  if (!focus || focus.line === undefined) return false
+  return row.newLine === focus.line || row.oldLine === focus.line
+}
+
+function splitDiffRowMatchesFocus(
+  row: SplitDiffRow,
+  focus: IdeContextFocus | null,
+): boolean {
+  if (!focus || focus.line === undefined) return false
+  return row.before?.line === focus.line || row.after?.line === focus.line
+}
+
+function diffContextFocusLabel(focus: IdeContextFocus): string {
+  const line = focus.line !== undefined ? ` line ${focus.line}` : ''
+  const links = focus.route_links?.length
+    ? `, ${focus.route_links.length} route links`
+    : ''
+  return `Diff context: ${focus.surface}${line}, ${focus.label}${links}`
+}
+
+function openDiffContextRouteLink(link: IdeContextFocusRouteLink): void {
+  navigate(link.tab, link.params)
 }
 
 // ── Diff helpers ──────────────────────────────────────────────────

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -236,9 +236,9 @@ export function IdeEditor({
           />`
         : null}
       ${activeView === 'split-diff'
-        ? SplitDiffView(currentDiffRows)
+        ? SplitDiffView(currentDiffRows, currentFileFocus)
         : activeView === 'unified'
-          ? UnifiedDiffView(currentDiffRows)
+          ? UnifiedDiffView(currentDiffRows, currentFileFocus)
           : html`<${CodeMirrorEditor}
               documentStore=${documentStore}
               ownershipStore=${ownershipStore}

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -347,6 +347,77 @@
   font: var(--type-eyebrow);
 }
 
+.ide-diff-context-focus {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  min-width: 0;
+  margin-left: auto;
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+}
+
+.ide-diff-context-focus > span,
+.ide-diff-context-focus > strong {
+  min-width: 0;
+  max-width: 10rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-diff-context-focus > span:not(.ide-diff-context-links) {
+  padding: 1px 5px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-page);
+}
+
+.ide-diff-context-focus > strong {
+  color: var(--color-fg-primary);
+  font-weight: 600;
+}
+
+.ide-diff-context-links {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  min-width: 0;
+}
+
+.ide-diff-context-links button {
+  min-width: 0;
+  max-width: 76px;
+  height: 18px;
+  padding: 0 5px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-page);
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-diff-context-links button:hover,
+.ide-diff-context-links button:focus-visible {
+  border-color: var(--color-border-strong);
+  color: var(--color-accent-fg);
+}
+
+.ide-diff-context-links button:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 1px;
+}
+
+[data-context-focus="true"] {
+  box-shadow: inset 2px 0 0 var(--color-accent-fg);
+}
 
 .ide-plane-grid {
   display: grid;


### PR DESCRIPTION
Summary:
- pass current IDE file context into split/unified diff previews
- show focused surface/line/label and operational route links in diff summary chrome
- mark diff rows that overlap the current context focus line

Validation:
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/ide-diff-view.ts src/components/ide/ide-diff-view.test.ts src/components/ide/ide-editor.ts
- pnpm exec vitest run src/components/ide/ide-diff-view.test.ts src/components/ide/ide-editor.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check