### PR TITLE
docs(auth): operator view (terminal-as-dashboard) section

### DIFF
--- a/docs/observability/auth-credential-metrics.md
+++ b/docs/observability/auth-credential-metrics.md
@@ -152,6 +152,67 @@ done
 # = 250 internal archive_bare_for_canonical invocations).
 ```
 
+## Operator view (without Grafana)
+
+Operators who don't want to spin up Grafana can read the same surface
+directly off the `/metrics` endpoint. The four credential-domain metrics
+filter down to a self-contained block in the scrape output.
+
+### One-shot
+
+```bash
+TOKEN="$MASC_MCP_TOKEN"   # bearer token; see ~/.zshenv / keychain
+PORT="${MASC_MCP_PORT:-8935}"
+curl -fsS -H "Authorization: Bearer $TOKEN" \
+  "http://127.0.0.1:$PORT/metrics" \
+  | grep -E '^masc_auth_(bare_alias|archive)'
+```
+
+Expected steady-state output (post-PR #15112 + #15143):
+
+```
+masc_auth_bare_alias{state="alive"} 18
+masc_auth_bare_alias{state="dead"} 0
+masc_auth_bare_alias{state="no_bare"} 0
+masc_auth_archive_epochs 21
+masc_auth_archive_pruned_total 310
+masc_auth_bare_alias_outcome_total{outcome="alive_skip"} 18
+masc_auth_bare_alias_outcome_total{outcome="dead_archive"} 0
+masc_auth_bare_alias_outcome_total{outcome="absent"} 0
+masc_auth_bare_alias_audit_ticks_total 123
+```
+
+Regression signature — any of:
+
+- `bare_alias{state="dead"} > 0`
+- `bare_alias_outcome_total{outcome="dead_archive"}` climbing between scrapes
+- `bare_alias_audit_ticks_total` flat between scrapes
+
+### Repeated polling (terminal dashboard)
+
+`watch` formats the surface as a single refreshing pane — the simplest
+"dashboard" without any UI layer:
+
+```bash
+watch -n 5 'curl -fsS -H "Authorization: Bearer $MASC_MCP_TOKEN" \
+  "http://127.0.0.1:${MASC_MCP_PORT:-8935}/metrics" \
+  | grep -E "^masc_auth_(bare_alias|archive)" \
+  | column -t'
+```
+
+Steady state: `dead=0`, `dead_archive=0`, `audit_ticks_total` climbs by
+~5 every 5-second tick (matches the 60s fiber default — 1 tick / 60s).
+
+### Why not the in-app dashboard
+
+`dashboard/src/` does not consume `/metrics`. Cascade, keeper turn FSM,
+and all other Prometheus domains share the same gap — none surface in
+the in-app dashboard. Adding only auth-credential there would be an
+N-of-M patch (CLAUDE.md software-development §workaround #3). The
+correct unblock is a separate RFC for in-app metric viz across all
+domains; this section gives operators the same data via the terminal
+in the meantime.
+
 ## History
 
 - PR-#10440 (2026 earlier) introduced `Auth.ensure_credential_alias` to fix `auth_doctor` and other short-form `load_credential` callers (8/14 keepers failing).


### PR DESCRIPTION
## Goal

PR #15112/#15143 후속 — operator view section (terminal-as-dashboard) 을 observability doc 에 추가. 사용자 *"대시보드로 나올수있나"* 질문에 대한 *답변 + light 영구 자산*.

## 배경

사용자가 in-app dashboard 노출 가능성 질문. 조사 결과:

- `dashboard/src/` 가 Prometheus `/metrics` 직접 fetch 안 함
- cascade / keeper turn FSM 등 **모든** Prometheus 도메인이 같은 상태
- auth-credential 만 in-app 노출 = N-of-M 패턴 (CLAUDE.md §workaround #3)

→ in-app dashboard 단순 추가 거부. 대안 = *terminal-as-dashboard* (curl + watch). 즉시 *영구 사용 가능 surface*.

## 변경

`docs/observability/auth-credential-metrics.md` 에 "Operator view (without Grafana)" 섹션 추가 (Operator playbook ↔ History 사이).

| 부분 | 내용 |
|---|---|
| One-shot | `curl ... \| grep masc_auth_(bare_alias\|archive)` — 8 라인 credential block |
| Repeated polling | `watch -n 5 'curl ... \| column -t'` — terminal dashboard, 60s fiber tick rate 매칭 |
| Steady-state sample | dead=0, dead_archive=0, audit_ticks 누적 |
| Regression signature | 3 가지 신호 명시 |
| Why no in-app widget | N-of-M 회피 + 별도 RFC 권고 |

## Self-referential meta-note

이 PR 자체가 *PR #1122 (~/me pre-push PR state guard)* 의 *self-referential 증거*. 이전 commit `bb04a8783a` 가 *MERGED 브랜치 (#15143)* 에 push 됐고 (main 미도달), hook 이 install 안 됐기 때문에 차단 못 함. PR #1122 머지 + install 후 active. **두 번 회수 → hook 의 필요성 결정적 확인**.

## Verification

- doc only — code/build/test 무관
- markdown linter: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)