### PR TITLE
fix(dashboard): reduce visible cockpit entrypoints

### DIFF
--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -5,6 +5,7 @@ import {
   COGNITIVE_MODE_STATES,
   COGNITIVE_MODE_TARGETS,
   COCKPIT_ENTRYPOINTS,
+  COCKPIT_LEGACY_ENTRYPOINTS,
   COCKPIT_MODE_TARGETS,
   cognitiveModeForCockpitMode,
   cognitiveModeForRoute,
@@ -15,8 +16,8 @@ import {
 import { sectionItemsForTab } from './config/navigation'
 
 describe('cockpit entrypoint registry', () => {
-  const coverageForAlias = (alias: string) =>
-    COCKPIT_ENTRYPOINTS.find(entrypoint => entrypoint.aliases.includes(alias))?.coverage
+  const visibleAliases = () => COCKPIT_ENTRYPOINTS.flatMap(entrypoint => entrypoint.aliases)
+  const legacyAliases = () => COCKPIT_LEGACY_ENTRYPOINTS.flatMap(entrypoint => entrypoint.aliases)
 
   it('keeps every prototype plane mode mapped to a production route', () => {
     expect(Object.keys(COCKPIT_MODE_TARGETS)).toEqual([
@@ -59,6 +60,38 @@ describe('cockpit entrypoint registry', () => {
     })
   })
 
+  it('keeps the visible cockpit command map to ten primary aliases', () => {
+    const aliases = visibleAliases()
+
+    expect(COCKPIT_ENTRYPOINTS).toHaveLength(10)
+    expect(aliases).toEqual([
+      'goal-horizon',
+      'task-board',
+      'board-feed',
+      'composer',
+      'cascade',
+      'audit',
+      'safety',
+      'cost',
+      'keeper-cognition',
+      'source',
+    ])
+    expect(new Set(aliases).size).toBe(10)
+    expect(aliases).not.toContain('ct-lat')
+    expect(aliases).not.toContain('cs-deep')
+    expect(aliases).not.toContain('pr-thread')
+  })
+
+  it('keeps old prototype aliases as legacy redirects instead of visible commands', () => {
+    const visible = new Set(visibleAliases())
+    const legacy = legacyAliases()
+
+    for (const alias of ['ct-lat', 'cs-deep', 'pr-thread', 'dc-mem', 'acc-led']) {
+      expect(visible.has(alias)).toBe(false)
+      expect(legacy).toContain(alias)
+    }
+  })
+
   it('normalizes cognitive mode aliases from cockpit routes', () => {
     expect(normalizeCognitiveMode(' CODE ')).toBe('code')
     expect(cognitiveModeForCockpitMode('Work')).toBe('cockpit')
@@ -82,8 +115,8 @@ describe('cockpit entrypoint registry', () => {
     expect(normalizeCockpitEntrypoint('Keeper / Tool Access')).toBe('keeper-tool-access')
   })
 
-  it('targets registered dashboard sections for every cockpit sub-entrypoint', () => {
-    for (const entrypoint of COCKPIT_ENTRYPOINTS) {
+  it('targets registered dashboard sections for primary and legacy entrypoints', () => {
+    for (const entrypoint of [...COCKPIT_ENTRYPOINTS, ...COCKPIT_LEGACY_ENTRYPOINTS]) {
       const section = entrypoint.target.params?.section
       if (!section) continue
       const knownSections = sectionItemsForTab(entrypoint.target.tab).map(item => item.params.section)
@@ -91,7 +124,30 @@ describe('cockpit entrypoint registry', () => {
     }
   })
 
-  it('resolves prototype subtabs to explicit live route homes', () => {
+  it('resolves primary cockpit aliases to canonical production routes', () => {
+    expect(cockpitTargetForParams({ mode: 'Work', tab: 'goal-horizon' })).toEqual({
+      tab: 'workspace',
+      params: { section: 'planning', view: 'goal-tree' },
+    })
+    expect(cockpitTargetForParams({ mode: 'Comms', tab: 'composer' })).toEqual({
+      tab: 'command',
+      params: { section: 'operations', view: 'ops' },
+    })
+    expect(cockpitTargetForParams({ mode: 'Observe', tab: 'cost' })).toEqual({
+      tab: 'monitoring',
+      params: { section: 'runtime', view: 'cost' },
+    })
+    expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'keeper-cognition' })).toEqual({
+      tab: 'monitoring',
+      params: { section: 'cognition', view: 'keeper' },
+    })
+    expect(cockpitTargetForParams({ mode: 'IDE', tab: 'source' })).toEqual({
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+    })
+  })
+
+  it('keeps legacy prototype subtabs routeable without re-exposing them in the command map', () => {
     expect(cockpitTargetForParams({ mode: 'IDE', tab: 'edit' })).toEqual({
       tab: 'code',
       params: { section: 'ide-shell', view: 'source' },
@@ -152,125 +208,25 @@ describe('cockpit entrypoint registry', () => {
       tab: 'monitoring',
       params: { section: 'runtime', view: 'audit', focus: 'summary' },
     })
-  })
-  it('routes the covered IDE search entrypoint directly to the find panel', () => {
-    const entrypoint = COCKPIT_ENTRYPOINTS.find(entry => entry.aliases.includes('find'))
-
-    expect(entrypoint?.coverage).toBe('covered')
-    expect(cockpitTargetForParams({ mode: 'IDE', tab: 'search' })).toEqual({
+    expect(cockpitTargetForParams({ mode: 'IDE', tab: 'find' })).toEqual({
       tab: 'code',
       params: { section: 'ide-shell', view: 'source', find: 'open' },
     })
-    expect(cockpitTargetForParams({ mode: 'CODE', tab: 'find' })).toEqual({
-      tab: 'code',
-      params: { section: 'ide-shell', view: 'source', find: 'open' },
+    expect(cockpitTargetForParams({ mode: 'Comms', tab: 'cm-bc' })).toEqual({
+      tab: 'command',
+      params: { section: 'operations', view: 'ops', focus: 'broadcast' },
     })
-  })
-  it('routes covered C3 composer variants to focused quick intervention modes', () => {
-    const variants = [
-      ['cm-bc', 'broadcast'],
-      ['cm-mn', 'mention'],
-      ['cm-st', 'state'],
-    ] as const
-
-    for (const [alias, focus] of variants) {
-      const entrypoint = COCKPIT_ENTRYPOINTS.find(entry => entry.aliases.includes(alias))
-      expect(entrypoint?.coverage).toBe('covered')
-      expect(cockpitTargetForParams({ mode: 'Comms', tab: alias })).toEqual({
-        tab: 'command',
-        params: { section: 'operations', view: 'ops', focus },
-      })
-    }
-  })
-  it('marks IDE review entrypoints as covered review focus routes', () => {
-    const byAlias = new Map(COCKPIT_ENTRYPOINTS.flatMap(entrypoint =>
-      entrypoint.aliases.map(alias => [alias, entrypoint] as const),
-    ))
-
-    expect(byAlias.get('review')).toMatchObject({
-      coverage: 'covered',
-      target: { tab: 'code', params: { section: 'ide-shell', view: 'unified', focus: 'review' } },
-    })
-    expect(byAlias.get('pr-thread')).toMatchObject({
-      coverage: 'covered',
-      target: { tab: 'code', params: { section: 'ide-shell', view: 'unified', focus: 'review' } },
-    })
-  })
-
-  it('marks planning focus cockpit entries as route-covered', () => {
-    const byAlias = new Map(COCKPIT_ENTRYPOINTS.flatMap(entrypoint =>
-      entrypoint.aliases.map(alias => [alias, entrypoint] as const),
-    ))
-
-    expect(byAlias.get('task-st')?.coverage).toBe('covered')
-    expect(byAlias.get('acc-led')?.coverage).toBe('covered')
-    expect(byAlias.get('acc-mtx')?.coverage).toBe('covered')
     expect(cockpitTargetForParams({ mode: 'Work', tab: 'acc-led' })).toEqual({
       tab: 'workspace',
       params: { section: 'planning', focus: 'accountability-ledger' },
-    })
-    expect(cockpitTargetForParams({ mode: 'Work', tab: 'acc-mtx' })).toEqual({
-      tab: 'workspace',
-      params: { section: 'planning', focus: 'accountability-matrix' },
-    })
-  })
-
-  it('marks cost cockpit entries as route-covered focus surfaces', () => {
-    const byAlias = new Map(COCKPIT_ENTRYPOINTS.flatMap(entrypoint =>
-      entrypoint.aliases.map(alias => [alias, entrypoint] as const),
-    ))
-
-    expect(byAlias.get('ct-agt')?.coverage).toBe('covered')
-    expect(byAlias.get('ct-mtx')?.coverage).toBe('covered')
-    expect(byAlias.get('ct-lat')?.coverage).toBe('covered')
-    expect(cockpitTargetForParams({ mode: 'Observe', tab: 'ct-agt' })).toEqual({
-      tab: 'monitoring',
-      params: { section: 'runtime', view: 'cost', focus: 'agent' },
-    })
-    expect(cockpitTargetForParams({ mode: 'Observe', tab: 'ct-mtx' })).toEqual({
-      tab: 'monitoring',
-      params: { section: 'runtime', view: 'cost', focus: 'matrix' },
     })
     expect(cockpitTargetForParams({ mode: 'Observe', tab: 'ct-lat' })).toEqual({
       tab: 'monitoring',
       params: { section: 'runtime', view: 'cost', focus: 'latency' },
     })
-  })
-
-  it('marks cascade cockpit entries as route-covered inspector focus surfaces', () => {
-    const byAlias = new Map(COCKPIT_ENTRYPOINTS.flatMap(entrypoint =>
-      entrypoint.aliases.map(alias => [alias, entrypoint] as const),
-    ))
-
-    expect(byAlias.get('cs-deep')?.coverage).toBe('covered')
-    expect(byAlias.get('cs-cmp')?.coverage).toBe('covered')
-    expect(cockpitTargetForParams({ mode: 'Observe', tab: 'cs-deep' })).toEqual({
-      tab: 'monitoring',
-      params: { section: 'runtime', view: 'inspector', focus: 'deep-dive' },
-    })
     expect(cockpitTargetForParams({ mode: 'Observe', tab: 'cascade-compare' })).toEqual({
       tab: 'monitoring',
       params: { section: 'runtime', view: 'inspector', focus: 'compare' },
     })
-  })
-  it('marks audit actor and summary entrypoints as covered runtime routes', () => {
-    const byAlias = new Map(COCKPIT_ENTRYPOINTS.flatMap(entrypoint =>
-      entrypoint.aliases.map(alias => [alias, entrypoint] as const),
-    ))
-
-    expect(byAlias.get('au-act')).toMatchObject({
-      coverage: 'covered',
-      target: { tab: 'monitoring', params: { section: 'runtime', view: 'audit', focus: 'actor' } },
-    })
-    expect(byAlias.get('au-sum')).toMatchObject({
-      coverage: 'covered',
-      target: { tab: 'monitoring', params: { section: 'runtime', view: 'audit', focus: 'summary' } },
-    })
-  })
-
-  it('marks existing IDE source, split, and graph surfaces covered', () => {
-    expect(coverageForAlias('edit')).toBe('covered')
-    expect(coverageForAlias('split-diff')).toBe('covered')
-    expect(coverageForAlias('git-graph')).toBe('covered')
   })
 })

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -101,9 +101,71 @@ export const COCKPIT_MODE_TARGETS: Record<CockpitMode, CockpitRouteTarget> = {
 }
 
 export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
-  // Work Plane: Goal / Task / Accountability.
-  { mode: 'work', aliases: ['goal-h', 'goal-horizon'], target: { tab: 'workspace', params: { section: 'planning', view: 'goal-tree' } }, coverage: 'covered' },
-  { mode: 'work', aliases: ['goal-t', 'goal-tree'], target: { tab: 'workspace', params: { section: 'planning', view: 'goal-tree' } }, coverage: 'covered' },
+  {
+    mode: 'work',
+    aliases: ['goal-horizon'],
+    target: { tab: 'workspace', params: { section: 'planning', view: 'goal-tree' } },
+    coverage: 'covered',
+  },
+  {
+    mode: 'work',
+    aliases: ['task-board'],
+    target: { tab: 'workspace', params: { section: 'planning', view: 'default' } },
+    coverage: 'covered',
+  },
+  {
+    mode: 'comms',
+    aliases: ['board-feed'],
+    target: { tab: 'workspace', params: { section: 'board' } },
+    coverage: 'covered',
+  },
+  {
+    mode: 'comms',
+    aliases: ['composer'],
+    target: { tab: 'command', params: { section: 'operations', view: 'ops' } },
+    coverage: 'covered',
+  },
+  {
+    mode: 'observe',
+    aliases: ['cascade'],
+    target: { tab: 'monitoring', params: { section: 'runtime', view: 'cascade' } },
+    coverage: 'covered',
+  },
+  {
+    mode: 'observe',
+    aliases: ['audit'],
+    target: { tab: 'monitoring', params: { section: 'runtime', view: 'audit' } },
+    coverage: 'covered',
+  },
+  {
+    mode: 'observe',
+    aliases: ['safety'],
+    target: { tab: 'command', params: { section: 'operations', view: 'safety' } },
+    coverage: 'covered',
+  },
+  {
+    mode: 'observe',
+    aliases: ['cost'],
+    target: { tab: 'monitoring', params: { section: 'runtime', view: 'cost' } },
+    coverage: 'covered',
+  },
+  {
+    mode: 'cognition',
+    aliases: ['keeper-cognition'],
+    target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper' } },
+    coverage: 'covered',
+  },
+  {
+    mode: 'ide',
+    aliases: ['source'],
+    target: { tab: 'code', params: { section: 'ide-shell', view: 'source' } },
+    coverage: 'covered',
+  },
+]
+
+export const COCKPIT_LEGACY_ENTRYPOINTS: CockpitEntrypoint[] = [
+  // Work Plane legacy design subtabs.
+  { mode: 'work', aliases: ['goal-h', 'goal-t', 'goal-tree'], target: { tab: 'workspace', params: { section: 'planning', view: 'goal-tree' } }, coverage: 'covered' },
   { mode: 'work', aliases: ['goal-d', 'goal-snapshot', 'goal-snapshot-diff'], target: { tab: 'workspace', params: { section: 'planning', view: 'goal-tree', focus: 'snapshot' } }, coverage: 'backend-blocked' },
   { mode: 'work', aliases: ['task-bl', 'task-backlog'], target: { tab: 'workspace', params: { section: 'planning', view: 'default' } }, coverage: 'covered' },
   { mode: 'work', aliases: ['task-st', 'task-stale'], target: { tab: 'workspace', params: { section: 'planning', view: 'default', focus: 'stale' } }, coverage: 'covered' },
@@ -111,8 +173,8 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'work', aliases: ['acc-led', 'accountability-ledger'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-ledger' } }, coverage: 'covered' },
   { mode: 'work', aliases: ['acc-mtx', 'accountability-matrix'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-matrix' } }, coverage: 'covered' },
 
-  // Comms Plane: board, message focus, and composer surfaces have production coverage.
-  { mode: 'comms', aliases: ['bd-feed', 'board-feed'], target: { tab: 'workspace', params: { section: 'board' } }, coverage: 'covered' },
+  // Comms Plane legacy design subtabs.
+  { mode: 'comms', aliases: ['bd-feed'], target: { tab: 'workspace', params: { section: 'board' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['bd-thr', 'board-thread'], target: { tab: 'workspace', params: { section: 'board', focus: 'thread' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['bd-tog', 'board-direct-automation'], target: { tab: 'workspace', params: { section: 'board', focus: 'automation' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['ms-rm', 'messages-room'], target: { tab: 'workspace', params: { section: 'board', focus: 'messages-room' } }, coverage: 'covered' },
@@ -122,7 +184,7 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'comms', aliases: ['cm-mn', 'composer-mention'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'mention' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['cm-st', 'composer-state'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'state' } }, coverage: 'covered' },
 
-  // Observe Plane: split prototype tabs across the consolidated production surfaces.
+  // Observe Plane legacy design subtabs.
   { mode: 'observe', aliases: ['cs-list', 'cascade-list'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'cascade' } }, coverage: 'covered' },
   { mode: 'observe', aliases: ['cs-deep', 'cascade-deep-dive'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'inspector', focus: 'deep-dive' } }, coverage: 'covered' },
   { mode: 'observe', aliases: ['cs-cmp', 'cascade-compare'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'inspector', focus: 'compare' } }, coverage: 'covered' },
@@ -139,7 +201,7 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'observe', aliases: ['hr-st', 'stress-board'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'stress' } }, coverage: 'covered' },
   { mode: 'observe', aliases: ['hr-mod', 'heuristic-by-module'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'heuristics', focus: 'module' } }, coverage: 'covered' },
 
-  // Cognition Plane: production view tabs show available data and blocked backend gaps.
+  // Cognition Plane legacy design subtabs.
   { mode: 'cognition', aliases: ['ki-bdi', 'keeper-bdi'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper', focus: 'bdi' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['ki-acc', 'keeper-tool-access'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper', focus: 'tool-access' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['ki-stat', 'keeper-token-stats'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'token-stats' } }, coverage: 'covered' },
@@ -151,8 +213,8 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'cognition', aliases: ['ar-fnd', 'ar-finding-card'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'autoresearch', focus: 'finding' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['ar-flw', 'ar-flow'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'autoresearch', focus: 'flow' } }, coverage: 'covered' },
 
-  // IDE Plane.
-  { mode: 'ide', aliases: ['edit', 'source'], target: { tab: 'code', params: { section: 'ide-shell', view: 'source' } }, coverage: 'covered' },
+  // IDE Plane legacy design subtabs.
+  { mode: 'ide', aliases: ['edit'], target: { tab: 'code', params: { section: 'ide-shell', view: 'source' } }, coverage: 'covered' },
   { mode: 'ide', aliases: ['review', 'pr-thread'], target: { tab: 'code', params: { section: 'ide-shell', view: 'unified', focus: 'review' } }, coverage: 'covered' },
   { mode: 'ide', aliases: ['merge', 'split', 'split-diff'], target: { tab: 'code', params: { section: 'ide-shell', view: 'split-diff' } }, coverage: 'covered' },
   { mode: 'ide', aliases: ['graph', 'git-graph'], target: { tab: 'workspace', params: { section: 'repositories', view: 'graph' } }, coverage: 'covered' },
@@ -161,7 +223,7 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
 
 const ENTRYPOINT_TARGETS = new Map<string, CockpitRouteTarget>()
 
-for (const entrypoint of COCKPIT_ENTRYPOINTS) {
+for (const entrypoint of [...COCKPIT_ENTRYPOINTS, ...COCKPIT_LEGACY_ENTRYPOINTS]) {
   for (const alias of entrypoint.aliases) {
     ENTRYPOINT_TARGETS.set(`${entrypoint.mode}:${normalizeCockpitEntrypoint(alias)}`, entrypoint.target)
   }

--- a/dashboard/src/components/cockpit/cockpit.test.ts
+++ b/dashboard/src/components/cockpit/cockpit.test.ts
@@ -29,7 +29,7 @@ describe('Cockpit command map', () => {
     expect(screen.getByTestId('world-visualizer')).toBeInTheDocument()
     expect(screen.getByTestId('cockpit-disclosure')).toBeInTheDocument()
     expect(document.querySelectorAll('[data-cockpit-plane]')).toHaveLength(5)
-    expect(document.querySelector('[data-cockpit-plane="work"]')).toHaveTextContent('1 blocked')
+    expect(document.querySelector('[data-cockpit-plane="work"]')).toHaveTextContent('2 covered')
     expect(document.querySelector('[data-cockpit-plane="ide"]')).toHaveTextContent('Source')
   })
 
@@ -42,13 +42,14 @@ describe('Cockpit command map', () => {
     expect(disclosure.querySelector('[data-cognitive-level="perceive"]')).toHaveTextContent('Route coverage')
     expect(disclosure.querySelector('[data-cognitive-level="comprehend"]')).toHaveTextContent('Plane grouping')
     expect(disclosure.querySelector('[data-cognitive-level="project"]')).toHaveTextContent('Route gaps')
-    expect(disclosure).toHaveTextContent('backend-blocked')
+    expect(disclosure).toHaveTextContent('10 routes')
+    expect(disclosure).toHaveTextContent('No backend-blocked routes')
   })
 
   it('links cockpit entries to their canonical production routes', () => {
     render(h(Cockpit, null))
 
-    const goalTree = screen.getByRole('link', { name: /Open Goal Tree in #workspace \/ planning \/ goal-tree/ })
+    const goalTree = screen.getByRole('link', { name: /Open Goal Horizon in #workspace \/ planning \/ goal-tree/ })
     expect(goalTree).toHaveAttribute('href', '#workspace?section=planning&view=goal-tree')
 
     fireEvent.click(goalTree)


### PR DESCRIPTION
## Summary
- Reduce the visible Cockpit command map to 10 primary aliases.
- Move old prototype subtabs into a legacy redirect registry so deep links still resolve without re-expanding the UI.
- Update cockpit routing and component tests to pin the primary-vs-legacy boundary.

## Verification
- git diff --check
- pnpm --dir dashboard install --frozen-lockfile --prefer-offline
- pnpm exec tsc --noEmit --pretty (from dashboard/)
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/cockpit-entrypoints.test.ts src/router.test.ts src/components/cockpit/cockpit.test.ts
- pnpm exec eslint src/cockpit-entrypoints.ts src/cockpit-entrypoints.test.ts src/components/cockpit/cockpit.test.ts (exit 0; repo config reports direct TS files ignored)

## Notes
- Addresses the old dashboard IA P0 item: Cockpit aliases 20+ -> 10 while preserving legacy URL compatibility.