### PR TITLE
chore: expose keeper thinking metadata in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ raw `opam exec -- dune ...` 은 의도적인 CI-parity 점검 때만. 평소 개
 | [docs/CASCADE-TOML.md](docs/CASCADE-TOML.md) | cascade.toml 작성 매뉴얼 |
 | [docs/CASCADE-COOKBOOK.md](docs/CASCADE-COOKBOOK.md) | 복붙용 로컬 / 개인 예시 |
 | [docs/OAS-MASC-BOUNDARY.md](docs/OAS-MASC-BOUNDARY.md) | OAS / MASC 소유 경계 |
-| [docs/KEEPER-USER-MANUAL.md](docs/KEEPER-USER-MANUAL.md) | keeper 라이프사이클 / 트러블슈팅 |
+| [docs/KEEPER-USER-MANUAL.md](docs/KEEPER-USER-MANUAL.md) | keeper 라이프사이클, sandbox profile, Docker one-shot/managed 실행, 트러블슈팅 |
 | [docs/SUPERVISOR-MODE.md](docs/SUPERVISOR-MODE.md) | supervisor / operator 워크플로 |
 | [docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md) | dashboard auth, `doctor auth` |
 | [docs/ENV-CONTRACT.md](docs/ENV-CONTRACT.md) | 환경변수 boot 계약 |

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -307,6 +307,17 @@ spawn 시 인자로 직접 설정하는 필드.
 - hard mode runtime preflight는 Docker `SecurityOptions`에서 `rootless`와 `userns`를 모두 요구한다. 현재 Docker Desktop/rootful daemon처럼 둘 중 하나라도 없으면 `doctor`와 keeper startup에서 fail-closed 된다.
 - 기본 sandbox 이미지는 `masc-keeper-sandbox:local`이다. Docker keeper를 올리기 전에 `scripts/build-keeper-sandbox-image.sh`를 실행해 이미지를 만들고, smoke 검증은 `scripts/keeper-sandbox-smoke.sh`를 사용한다.
 - keeper Docker 컨테이너에는 `masc.mcp.component=keeper-sandbox`와 base path hash 라벨이 붙는다. 새 컨테이너 시작 전 같은 base path 범위의 오래된 MASC keeper 컨테이너만 best-effort로 정리한다. 조정값은 `MASC_KEEPER_SANDBOX_CLEANUP_ENABLED`, `MASC_KEEPER_SANDBOX_CLEANUP_STALE_AFTER_SEC`, `MASC_KEEPER_SANDBOX_CLEANUP_INTERVAL_SEC`이다.
+
+#### Docker profile vs one-shot/managed 실행
+
+Docker 사용 여부와 컨테이너 유지 방식은 서로 다른 결정이다.
+
+- `sandbox_profile`은 keeper config/meta에서 정해지는 boot-time policy다. `sandbox_profile=docker` keeper는 sandboxed tool 실행 시 Docker 경로를 사용한다. 이 값은 keeper LLM turn 자체를 Docker 안에서 돌린다는 뜻은 아니다.
+- 실제 컨테이너 route는 tool call 시점에 정해진다. `keeper_bash`, `keeper_shell`, `keeper_fs_read`, `keeper_fs_edit`, git/gh 계열처럼 sandboxed execution이 필요한 tool만 Docker 실행 경로를 탄다. board/task/goal 같은 control-plane tool은 서버 내부 상태 변경이라 컨테이너를 띄우지 않는다.
+- managed container가 없으면 sandboxed tool call은 one-shot Docker container를 만들고 명령 종료 후 사라진다. 그래서 `docker ps`에 계속 보이는 컨테이너가 없어도 Docker가 사용 중일 수 있다.
+- `masc_keeper_sandbox_start`로 visible managed container를 미리 띄우면 이후 sandboxed tool call은 그 container/runtime에 붙을 수 있다. 디버깅, 연속 shell 작업, container 상태 관찰이 필요할 때 쓰는 운영 모드다.
+- `masc_keeper_sandbox_status`에서 `sandbox_profile=docker`, `effective_mode=oneshot_or_managed_inherit`, `container_count=0`이면 "Docker keeper지만 현재 prewarmed container는 없고, sandboxed tool call 때 one-shot Docker를 쓴다"는 뜻이다.
+
 ### 3.1.2 GitHub identity 운영 절차
 
 `github_identity`는 현재 대시보드의 일반 설정 화면에서 수정하는 필드가 아니라 active config root의 `keeper.toml` overlay가 SSOT다. 대시보드에서 찾지 못하면 먼저 active config root를 확인하고 파일을 수정한다.

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -378,6 +378,40 @@ let context_max_of_telemetry
   | Some { effective_context_window = Some n; _ } when n > 0 -> n
   | _ -> 0
 
+type thinking_log_summary =
+  { thinking_present : bool
+  ; thinking_blocks : int
+  ; thinking_chars : int
+  ; redacted_thinking_blocks : int
+  ; thinking_kind : string
+  }
+
+let summarize_thinking_blocks content =
+  let thinking_blocks = ref 0 in
+  let thinking_chars = ref 0 in
+  let redacted_thinking_blocks = ref 0 in
+  List.iter
+    (function
+      | Agent_sdk.Types.Thinking { content; _ } ->
+          incr thinking_blocks;
+          thinking_chars := !thinking_chars + String.length content
+      | Agent_sdk.Types.RedactedThinking _ -> incr redacted_thinking_blocks
+      | _ -> ())
+    content;
+  let thinking_kind =
+    match !thinking_blocks > 0, !redacted_thinking_blocks > 0 with
+    | false, false -> "none"
+    | true, false -> "thinking"
+    | false, true -> "redacted"
+    | true, true -> "mixed"
+  in
+  { thinking_present = !thinking_blocks > 0 || !redacted_thinking_blocks > 0
+  ; thinking_blocks = !thinking_blocks
+  ; thinking_chars = !thinking_chars
+  ; redacted_thinking_blocks = !redacted_thinking_blocks
+  ; thinking_kind
+  }
+
 let classify_usage_trust ?usage ~model ~telemetry () =
   let _ = model in
   let usage_reported, usage =
@@ -2004,10 +2038,16 @@ let make_hooks
         let wall_tok_s = fmt_tok_s wall_tok_s_opt in
         let prompt_tok_s = fmt_tok_s prompt_tok_s_opt in
         let decode_tok_s = fmt_tok_s decode_tok_s_opt in
+        let thinking = summarize_thinking_blocks response.content in
         Log.Keeper.info
-          "keeper:%s turn=%d total_turns=%d runtime_lane=%s tokens=%d wall_tok_s=%s prompt_tok_s=%s decode_tok_s=%s latency_ms=%d"
+          "keeper:%s turn=%d total_turns=%d runtime_lane=%s tokens=%d wall_tok_s=%s prompt_tok_s=%s decode_tok_s=%s latency_ms=%d thinking_present=%b thinking_blocks=%d thinking_chars=%d redacted_thinking_blocks=%d thinking_kind=%s"
           meta.name turn meta.runtime.usage.total_turns model total_tok
-          wall_tok_s prompt_tok_s decode_tok_s latency_ms;
+          wall_tok_s prompt_tok_s decode_tok_s latency_ms
+          thinking.thinking_present
+          thinking.thinking_blocks
+          thinking.thinking_chars
+          thinking.redacted_thinking_blocks
+          thinking.thinking_kind;
         (* Emit per-turn cost event for task attribution.
            cost_usd from OAS Pricing.annotate_response_cost (oas#393 resolved). *)
         (match trajectory_acc with

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -74,6 +74,22 @@ val context_max_of_telemetry :
   Agent_sdk.Types.inference_telemetry option -> int
 (** Provider-reported context window max, or [0] when telemetry omits it. *)
 
+type thinking_log_summary =
+  { thinking_present : bool
+  ; thinking_blocks : int
+  ; thinking_chars : int
+  ; redacted_thinking_blocks : int
+  ; thinking_kind : string
+  }
+(** Redacted metadata for provider thinking blocks.  [thinking_chars] counts
+    only non-redacted [Thinking.content] bytes; raw content is never included
+    in this summary. *)
+
+val summarize_thinking_blocks :
+  Agent_sdk.Types.content_block list -> thinking_log_summary
+(** Summarize thinking block presence for logs/metrics without exposing raw
+    thinking content. *)
+
 val redact_inference_telemetry_json : Yojson.Safe.t -> Yojson.Safe.t
 (** Redact provider/model identity fields from OAS inference telemetry while
     preserving non-identifying runtime counters and timings. *)

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -738,6 +738,36 @@ let test_record_llm_tok_s_metrics_none_telemetry_is_noop () =
     (prompt_count_after -. prompt_count_before)
 ;;
 
+let test_summarize_thinking_blocks_metadata_only () =
+  let summary =
+    Hooks.summarize_thinking_blocks
+      [
+        Agent_sdk.Types.Text "visible";
+        Agent_sdk.Types.Thinking
+          { thinking_type = "extended"; content = "private reasoning" };
+        Agent_sdk.Types.RedactedThinking "opaque-redacted-payload";
+        Agent_sdk.Types.Thinking { thinking_type = "extended"; content = "more" };
+      ]
+  in
+  check bool "thinking present" true summary.thinking_present;
+  check int "thinking blocks" 2 summary.thinking_blocks;
+  check int "thinking chars" 21 summary.thinking_chars;
+  check int "redacted blocks" 1 summary.redacted_thinking_blocks;
+  check string "mixed kind" "mixed" summary.thinking_kind
+;;
+
+let test_summarize_thinking_blocks_none () =
+  let summary =
+    Hooks.summarize_thinking_blocks
+      [ Agent_sdk.Types.Text "visible"; Agent_sdk.Types.Text "" ]
+  in
+  check bool "thinking absent" false summary.thinking_present;
+  check int "no thinking blocks" 0 summary.thinking_blocks;
+  check int "no thinking chars" 0 summary.thinking_chars;
+  check int "no redacted blocks" 0 summary.redacted_thinking_blocks;
+  check string "none kind" "none" summary.thinking_kind
+;;
+
 let inference_latency_labels _model = [ "model", "runtime" ]
 
 let test_record_llm_inference_latency_metric_positive_observes () =
@@ -1568,6 +1598,16 @@ let () =
             "telemetry=None is a safe no-op"
             `Quick
             test_record_llm_tok_s_metrics_none_telemetry_is_noop
+        ] )
+    ; ( "thinking_log_summary"
+      , [ test_case
+            "summarizes thinking metadata only"
+            `Quick
+            test_summarize_thinking_blocks_metadata_only
+        ; test_case
+            "reports none without thinking blocks"
+            `Quick
+            test_summarize_thinking_blocks_none
         ] )
     ; ( "llm_inference_latency"
       , [ test_case


### PR DESCRIPTION
## Summary
- add safe keeper turn log metadata for provider thinking blocks without logging raw thinking content
- document Docker profile vs one-shot/managed sandbox execution and make README document map mention it
- add focused telemetry tests for thinking metadata summaries

## Verification
- git diff --check
- MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe
- ./_build/default/test/test_keeper_hooks_oas_telemetry.exe
- MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build bin/main_eio.exe
- live 8935 restart + /health ok
- live keeper logs showed thinking_present=true with thinking_blocks/thinking_chars metadata only