### PR TITLE
fix(keeper): clarify queue-head wait diagnostics

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -404,7 +404,7 @@ describe('FleetTelemetryPanel', () => {
     await flushUi()
 
     expect(container.textContent).toContain('부분 텔레메트리')
-    expect(container.textContent).toContain('keepers are blocked in the admission queue')
+    expect(container.textContent).toContain('keepers are blocked in the keeper admission FIFO')
     expect(container.textContent).toContain('Admission queue wait timeout after 45.0s.')
   }, 30_000)
 

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -603,7 +603,7 @@ describe('buildRuntimeWarnings', () => {
     const rows = [makeRow({ runtime_blocker_class: 'admission_queue_wait_timeout' })]
     const warnings = buildRuntimeWarnings(rows)
     expect(warnings.length).toBe(1)
-    expect(warnings[0]).toContain('admission queue')
+    expect(warnings[0]).toContain('keeper admission FIFO')
   })
 
   it('warns about slot blockage', () => {

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -634,7 +634,7 @@ export function buildRuntimeWarnings(rows: FleetRow[]): string[] {
   const admissionBlocked = rows.filter(row => row.runtime_blocker_class === 'admission_queue_wait_timeout')
   if (admissionBlocked.length > 0) {
     warnings.push(
-      `${admissionBlocked.length} keepers are blocked in the admission queue; tool telemetry can look stale because turns never reached tool execution.`,
+      `${admissionBlocked.length} keepers are blocked in the keeper admission FIFO; tool telemetry can look stale because turns never reached tool execution.`,
     )
   }
 

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -203,6 +203,15 @@ describe('keeperRuntimeBlockerHint', () => {
     ).toBe('액션 가능한 신호에 필요한 keeper 도구 호출이 충족되지 않았습니다.')
   })
 
+  it('explains admission queue waits as keeper FIFO waits, not OAS waits', () => {
+    expect(
+      keeperRuntimeBlockerHint(makeKeeper({
+        runtime_blocker_class: 'admission_queue_wait_timeout',
+        runtime_blocker_summary: 'admission_queue_wait_timeout',
+      })),
+    ).toBe('Keeper admission FIFO 대기 시간이 초과되었습니다.')
+  })
+
   const registryBlockerHintCases: Array<[KeeperRuntimeBlockerClass, string]> = [
     [
       'stale_termination_storm',

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -247,7 +247,7 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
     return '자율 턴이 실행 슬롯을 기다리다 타임아웃되었습니다.'
   }
   if (blockerClass === 'admission_queue_wait_timeout') {
-    return 'OAS admission queue 대기 시간이 초과되었습니다.'
+    return 'Keeper admission FIFO 대기 시간이 초과되었습니다.'
   }
   if (blockerClass === 'turn_timeout_after_queue_wait') {
     return '대기 후 실행된 턴이 전체 제한 시간을 초과했습니다.'

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -582,6 +582,74 @@ let run_keeper_cycle_with_slot
     updated
 ;;
 
+let semaphore_wait_timeout_blocker_class
+      (timeout : Keeper_turn_slot.semaphore_wait_timeout)
+  =
+  match timeout.timeout_phase with
+  | Keeper_turn_slot.Autonomous_queue_head -> Keeper_types.Admission_queue_wait_timeout
+  | Keeper_turn_slot.Autonomous_slot -> Keeper_types.Autonomous_slot_wait_timeout
+  | Keeper_turn_slot.Reactive_slot | Keeper_turn_slot.Turn_slot ->
+    Keeper_types.Turn_timeout_after_queue_wait
+;;
+
+let semaphore_wait_timeout_diagnostics
+      ~cascade_name
+      (timeout : Keeper_turn_slot.semaphore_wait_timeout)
+  =
+  let phase_label =
+    Keeper_turn_slot.semaphore_wait_phase_to_string timeout.timeout_phase
+  in
+  let queue_ahead_text =
+    match timeout.timeout_phase, timeout.timeout_queue_ahead with
+    | Keeper_turn_slot.Autonomous_queue_head, Some ahead ->
+      Printf.sprintf " queue_blocker=autonomous_fifo queue_ahead=%d" ahead
+    | Keeper_turn_slot.Autonomous_queue_head, None ->
+      " queue_blocker=autonomous_fifo queue_ahead=unknown"
+    | _, Some ahead -> Printf.sprintf " queue_ahead=%d" ahead
+    | _, None -> ""
+  in
+  let persisted_blocker =
+    Printf.sprintf
+      "skipped: semaphore wait > %.0fs phase=%s (cascade=%s%s queue_depth=%d \
+       autonomous_available=%d reactive_available=%d turn_available=%d)"
+      timeout.timeout_wait_sec
+      phase_label
+      cascade_name
+      queue_ahead_text
+      timeout.timeout_queue_depth
+      timeout.timeout_autonomous_available
+      timeout.timeout_reactive_available
+      timeout.timeout_turn_available
+  in
+  let log_diagnostic =
+    match timeout.timeout_phase with
+    | Keeper_turn_slot.Autonomous_queue_head ->
+      let ahead_text =
+        match timeout.timeout_queue_ahead with
+        | Some ahead -> string_of_int ahead
+        | None -> "unknown"
+      in
+      Printf.sprintf
+        "%s queue_head=[blocker=autonomous_fifo ahead=%s depth=%d]"
+        persisted_blocker
+        ahead_text
+        timeout.timeout_queue_depth
+    | Keeper_turn_slot.Autonomous_slot
+    | Keeper_turn_slot.Reactive_slot
+    | Keeper_turn_slot.Turn_slot ->
+      let holder_text =
+        match timeout.timeout_holders with
+        | [] -> "none"
+        | holders ->
+          holders
+          |> List.map (fun (name, age) -> Printf.sprintf "%s/%.0fs" name age)
+          |> String.concat ", "
+      in
+      Printf.sprintf "%s holders=[%s]" persisted_blocker holder_text
+  in
+  persisted_blocker, log_diagnostic
+;;
+
 (** Handle semaphore wait timeout for legacy path. *)
 let handle_semaphore_wait_timeout
       ~ctx
@@ -599,40 +667,12 @@ let handle_semaphore_wait_timeout
     ~phase_label
     ~kind:Semaphore_wait_timeout
     ();
-  let queue_ahead_text =
-    match timeout.timeout_queue_ahead with
-    | None -> ""
-    | Some ahead -> Printf.sprintf " queue_ahead=%d" ahead
+  let persisted_blocker, log_diagnostic =
+    semaphore_wait_timeout_diagnostics
+      ~cascade_name:(cascade_name_of_meta meta_after_triage)
+      timeout
   in
-  let holder_text =
-    match timeout.timeout_holders with
-    | [] -> "none"
-    | holders ->
-      holders
-      |> List.map (fun (name, age) -> Printf.sprintf "%s/%.0fs" name age)
-      |> String.concat ", "
-  in
-  let persisted_blocker =
-    Printf.sprintf
-      "skipped: semaphore wait > %.0fs phase=%s (cascade=%s%s queue_depth=%d \
-       autonomous_available=%d reactive_available=%d turn_available=%d)"
-      timeout.timeout_wait_sec
-      phase_label
-      (cascade_name_of_meta meta_after_triage)
-      queue_ahead_text
-      timeout.timeout_queue_depth
-      timeout.timeout_autonomous_available
-      timeout.timeout_reactive_available
-      timeout.timeout_turn_available
-  in
-  let log_diagnostic = Printf.sprintf "%s holders=[%s]" persisted_blocker holder_text in
-  let blocker_class =
-    match timeout.timeout_phase with
-    | Keeper_turn_slot.Autonomous_queue_head | Keeper_turn_slot.Autonomous_slot ->
-      Keeper_types.Autonomous_slot_wait_timeout
-    | Keeper_turn_slot.Reactive_slot | Keeper_turn_slot.Turn_slot ->
-      Keeper_types.Turn_timeout_after_queue_wait
-  in
+  let blocker_class = semaphore_wait_timeout_blocker_class timeout in
   Log.Keeper.warn "%s: skipping turn (%s)" meta_after_triage.name log_diagnostic;
   Prometheus.inc_counter
     Keeper_metrics.metric_keeper_semaphore_wait_timeout

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -69,6 +69,12 @@ val record_semaphore_wait_observation :
   unit ->
   unit
 
+val semaphore_wait_timeout_blocker_class :
+  Keeper_turn_slot.semaphore_wait_timeout -> blocker_class
+
+val semaphore_wait_timeout_diagnostics :
+  cascade_name:string -> Keeper_turn_slot.semaphore_wait_timeout -> string * string
+
 val oas_timeout_budget_observation_reasons : string list
 
 val record_oas_timeout_budget_observation :

--- a/test/test_keeper_semaphore_wait_counter.ml
+++ b/test/test_keeper_semaphore_wait_counter.ml
@@ -9,6 +9,10 @@
    is pinned independently of the surrounding Eio + semaphore
    plumbing. *)
 
+module KHL = Masc_mcp.Keeper_heartbeat_loop
+module KTS = Masc_mcp.Keeper_turn_slot
+module KT = Masc_mcp.Keeper_types
+
 let counter_for ~keeper ~channel =
   Masc_mcp.Prometheus.metric_value_or_zero
     Masc_mcp.Keeper_metrics.metric_keeper_semaphore_wait_timeout
@@ -46,6 +50,29 @@ let make_meta name =
   with
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
+
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    if needle_len = 0 then true
+    else if idx + needle_len > haystack_len then false
+    else if String.sub haystack idx needle_len = needle then true
+    else loop (idx + 1)
+  in
+  loop 0
+
+let make_timeout ?queue_ahead ?(holders = []) phase :
+    KTS.semaphore_wait_timeout =
+  { KTS.timeout_wait_sec = 180.0;
+    timeout_phase = phase;
+    timeout_autonomous_available = 6;
+    timeout_reactive_available = 4;
+    timeout_turn_available = 12;
+    timeout_queue_depth = 9;
+    timeout_queue_ahead = queue_ahead;
+    timeout_holders = holders;
+  }
 
 let test_metric_name_stable () =
   Alcotest.(check string)
@@ -205,6 +232,53 @@ let test_wait_observation_reason_labels () =
        ~channel:Masc_mcp.Keeper_world_observation.Scheduled_autonomous
        ())
 
+let test_queue_head_timeout_diagnostic_names_fifo_blocker () =
+  let timeout = make_timeout ~queue_ahead:3 KTS.Autonomous_queue_head in
+  let blocker_class = KHL.semaphore_wait_timeout_blocker_class timeout in
+  Alcotest.(check string)
+    "queue head maps to admission queue blocker"
+    "admission_queue_wait_timeout"
+    (KT.blocker_class_to_string blocker_class);
+  let persisted, log_diagnostic =
+    KHL.semaphore_wait_timeout_diagnostics ~cascade_name:"queue-cascade" timeout
+  in
+  Alcotest.(check bool)
+    "persisted detail names fifo blocker"
+    true
+    (contains_substring persisted "queue_blocker=autonomous_fifo");
+  Alcotest.(check bool)
+    "persisted detail records queue ahead"
+    true
+    (contains_substring persisted "queue_ahead=3");
+  Alcotest.(check bool)
+    "log diagnostic names queue head"
+    true
+    (contains_substring log_diagnostic
+       "queue_head=[blocker=autonomous_fifo ahead=3 depth=9]");
+  Alcotest.(check bool)
+    "queue head diagnostic does not claim missing holders"
+    false
+    (contains_substring log_diagnostic "holders=[none]")
+
+let test_autonomous_slot_timeout_keeps_holder_diagnostic () =
+  let timeout =
+    make_timeout
+      ~holders:[ ("slot-holder-a", 181.4); ("slot-holder-b", 12.0) ]
+      KTS.Autonomous_slot
+  in
+  let blocker_class = KHL.semaphore_wait_timeout_blocker_class timeout in
+  Alcotest.(check string)
+    "slot timeout maps to autonomous slot blocker"
+    "autonomous_slot_wait_timeout"
+    (KT.blocker_class_to_string blocker_class);
+  let _persisted, log_diagnostic =
+    KHL.semaphore_wait_timeout_diagnostics ~cascade_name:"slot-cascade" timeout
+  in
+  Alcotest.(check bool)
+    "slot diagnostic still names holders"
+    true
+    (contains_substring log_diagnostic "holders=[slot-holder-a/181s")
+
 let test_wait_observation_updates_registry_skip_stamp () =
   let base_path =
     Filename.concat (Filename.get_temp_dir_name ())
@@ -303,6 +377,12 @@ let () =
     "watchdog_observation", [
       Alcotest.test_case "reason labels are stable" `Quick
         test_wait_observation_reason_labels;
+      Alcotest.test_case
+        "queue-head timeout names fifo blocker, not empty holders" `Quick
+        test_queue_head_timeout_diagnostic_names_fifo_blocker;
+      Alcotest.test_case
+        "slot timeout keeps holder diagnostic" `Quick
+        test_autonomous_slot_timeout_keeps_holder_diagnostic;
       Alcotest.test_case "registry skip stamp is updated" `Quick
         test_wait_observation_updates_registry_skip_stamp;
       Alcotest.test_case "oas timeout labels are stable" `Quick


### PR DESCRIPTION
## Summary
- classify autonomous FIFO queue-head timeouts as admission queue blockers instead of autonomous slot blockers
- render queue-head waits as `queue_blocker=autonomous_fifo` / `queue_head=[...]` instead of misleading `holders=[none]`
- update dashboard blocker copy to say keeper admission FIFO, not OAS admission queue

## Validation
- `opam exec -- ocamlformat --check lib/keeper/keeper_heartbeat_loop.ml lib/keeper/keeper_heartbeat_loop.mli test/test_keeper_semaphore_wait_counter.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_semaphore_wait_counter.exe`
- `./_build/default/test/test_keeper_semaphore_wait_counter.exe`
- `scripts/dune-local.sh build test/test_keeper_semaphore_wait_queue_head_clock.exe`
- `./_build/default/test/test_keeper_semaphore_wait_queue_head_clock.exe`
- `pnpm install --frozen-lockfile --offline` in `dashboard/`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/lib/keeper-runtime-display.test.ts src/components/fleet-telemetry-utils.test.ts src/components/fleet-telemetry-panel.test.ts`
- `pnpm exec tsc --noEmit --pretty false`