### PR TITLE
fix(cascade): cap inferred max tokens to output ceiling

### DIFF
--- a/lib/cascade_inference.ml
+++ b/lib/cascade_inference.ml
@@ -91,9 +91,8 @@ let resolve_temperature
   | None -> fallback ()
 
 (** Cap an automatically-derived max_tokens value to the narrowest output
-    ceiling in the resolved cascade. Explicit caller-provided overrides do not
-    pass through [resolve_max_tokens]; those stay hard rejected by the
-    pre-dispatch validator. *)
+    ceiling in the resolved cascade. Explicit caller-provided overrides and
+    cascade.toml values stay hard rejected by the pre-dispatch validator. *)
 let cap_auto_resolved_max_tokens ~cascade_name ~source max_tokens =
   match Cascade_runtime.max_output_tokens_ceiling_of_cascade_name cascade_name with
   | Some ceiling when ceiling > 0 && max_tokens > ceiling ->
@@ -105,19 +104,17 @@ let cap_auto_resolved_max_tokens ~cascade_name ~source max_tokens =
     ceiling
   | _ -> max_tokens
 
-(** Resolve a max_tokens value: cascade config -> fallback. *)
+(** Resolve a max_tokens value: cascade config -> capped fallback. *)
 let resolve_max_tokens
     ~(cascade_name : Keeper_cascade_profile.runtime_name)
     ~(fallback : unit -> int) : int =
   let cascade_name_string =
     Keeper_cascade_profile.runtime_name_to_string cascade_name
   in
-  let max_tokens, source =
-    match (for_cascade ~name:cascade_name_string).max_tokens with
-    | Some t -> t, "cascade_config"
-    | None -> fallback (), "fallback"
-  in
-  cap_auto_resolved_max_tokens ~cascade_name ~source max_tokens
+  match (for_cascade ~name:cascade_name_string).max_tokens with
+  | Some t -> t
+  | None ->
+    cap_auto_resolved_max_tokens ~cascade_name ~source:"fallback" (fallback ())
 
 (** Validate max_tokens against provider ceilings before dispatch. *)
 let validate_max_tokens_within_ceiling

--- a/lib/cascade_inference.ml
+++ b/lib/cascade_inference.ml
@@ -90,14 +90,34 @@ let resolve_temperature
   | Some t -> t
   | None -> fallback ()
 
+(** Cap an automatically-derived max_tokens value to the narrowest output
+    ceiling in the resolved cascade. Explicit caller-provided overrides do not
+    pass through [resolve_max_tokens]; those stay hard rejected by the
+    pre-dispatch validator. *)
+let cap_auto_resolved_max_tokens ~cascade_name ~source max_tokens =
+  match Cascade_runtime.max_output_tokens_ceiling_of_cascade_name cascade_name with
+  | Some ceiling when ceiling > 0 && max_tokens > ceiling ->
+    Log.warn ~ctx:"cascade"
+      "%s: auto-resolved max_tokens=%d from %s exceeds output ceiling=%d; \
+       using ceiling"
+      (Keeper_cascade_profile.runtime_name_to_string cascade_name)
+      max_tokens source ceiling;
+    ceiling
+  | _ -> max_tokens
+
 (** Resolve a max_tokens value: cascade config -> fallback. *)
 let resolve_max_tokens
     ~(cascade_name : Keeper_cascade_profile.runtime_name)
     ~(fallback : unit -> int) : int =
-  let cascade_name = Keeper_cascade_profile.runtime_name_to_string cascade_name in
-  match (for_cascade ~name:cascade_name).max_tokens with
-  | Some t -> t
-  | None -> fallback ()
+  let cascade_name_string =
+    Keeper_cascade_profile.runtime_name_to_string cascade_name
+  in
+  let max_tokens, source =
+    match (for_cascade ~name:cascade_name_string).max_tokens with
+    | Some t -> t, "cascade_config"
+    | None -> fallback (), "fallback"
+  in
+  cap_auto_resolved_max_tokens ~cascade_name ~source max_tokens
 
 (** Validate max_tokens against provider ceilings before dispatch. *)
 let validate_max_tokens_within_ceiling

--- a/lib/cascade_inference.mli
+++ b/lib/cascade_inference.mli
@@ -40,7 +40,10 @@ val resolve_temperature :
   float
 
 (** Resolve a max_tokens value with cascade config priority.
-    Returns cascade config value if present, otherwise calls [fallback]. *)
+    Returns cascade config value if present, otherwise calls [fallback].
+    Automatic values are bounded to the resolved cascade's output ceiling when
+    one is available; explicit caller overrides are validated outside this
+    helper and are not silently reduced. *)
 val resolve_max_tokens :
   cascade_name:Keeper_cascade_profile.runtime_name ->
   fallback:(unit -> int) ->

--- a/lib/cascade_inference.mli
+++ b/lib/cascade_inference.mli
@@ -41,9 +41,9 @@ val resolve_temperature :
 
 (** Resolve a max_tokens value with cascade config priority.
     Returns cascade config value if present, otherwise calls [fallback].
-    Automatic values are bounded to the resolved cascade's output ceiling when
-    one is available; explicit caller overrides are validated outside this
-    helper and are not silently reduced. *)
+    Fallback values are bounded to the resolved cascade's output ceiling when
+    one is available; cascade config values and explicit caller overrides are
+    validated outside this helper and are not silently reduced. *)
 val resolve_max_tokens :
   cascade_name:Keeper_cascade_profile.runtime_name ->
   fallback:(unit -> int) ->

--- a/test/test_cascade_capability_gate.ml
+++ b/test/test_cascade_capability_gate.ml
@@ -199,6 +199,73 @@ target = "tier-group.strict_tool_candidates"
         ~provider_ceiling:ceiling resolved
       |> check_ok "capped value accepted" 16384)
 
+let test_resolve_max_tokens_preserves_cascade_config_for_validator () =
+  with_temp_cascade_toml
+    {|
+keeper_unified_max_tokens = 65536
+
+[providers.claude_code]
+protocol = "anthropic-cli"
+command = "claude"
+is-non-interactive = true
+
+[providers.kimi_cli]
+protocol = "kimi-cli"
+command = "kimi"
+is-non-interactive = true
+
+[models.claude-auto]
+api-name = "auto"
+max-context = 200000
+tools-support = true
+
+[models.claude-auto.capabilities]
+max-output-tokens = 64000
+
+[models.kimi-cli-coding]
+api-name = "kimi-for-coding"
+max-context = 128000
+tools-support = true
+
+[models.kimi-cli-coding.capabilities]
+max-output-tokens = 16384
+
+[claude_code.claude-auto]
+max-concurrent = 1
+
+[kimi_cli.kimi-cli-coding]
+max-concurrent = 1
+
+[claude_code.claude-auto.tool_candidate]
+max-output = 64000
+temperature = 0.2
+
+[kimi_cli.kimi-cli-coding.tool_candidate]
+max-output = 16384
+temperature = 0.2
+
+[tier.strict_tool_candidates]
+members = ["claude_code.claude-auto.tool_candidate", "kimi_cli.kimi-cli-coding.tool_candidate"]
+strategy = "failover"
+
+[tier-group.strict_tool_candidates]
+tiers = ["strict_tool_candidates"]
+strategy = "failover"
+
+[routes.keeper_unified]
+target = "tier-group.strict_tool_candidates"
+|}
+    (fun () ->
+      let ceiling = CR.max_output_tokens_ceiling_of_cascade_name cascade_name in
+      check (option int) "mixed cascade output ceiling" (Some 16384) ceiling;
+      let resolved =
+        CI.resolve_max_tokens ~cascade_name ~fallback:(fun () -> 8192)
+      in
+      check int "cascade config max_tokens is not silently capped" 65536 resolved;
+      CI.validate_max_tokens_within_ceiling ~cascade_name
+        ~provider_ceiling:ceiling resolved
+      |> check_violation "requested_exceeds_provider_ceiling" 65536 16384)
+
 let () =
   run "cascade_capability_gate" [
     "max_tokens_ceiling_validation", [
@@ -220,5 +287,9 @@ let () =
         "automatic max_tokens respects mixed failover ceiling"
         `Quick
         test_resolve_max_tokens_caps_automatic_value_to_cascade_ceiling;
+      test_case
+        "cascade config max_tokens reaches validator"
+        `Quick
+        test_resolve_max_tokens_preserves_cascade_config_for_validator;
     ];
   ]

--- a/test/test_cascade_capability_gate.ml
+++ b/test/test_cascade_capability_gate.ml
@@ -134,6 +134,71 @@ target = "tier.primary"
         ~provider_ceiling:ceiling 65536
       |> check_violation "requested_exceeds_provider_ceiling" 65536 8192)
 
+let test_resolve_max_tokens_caps_automatic_value_to_cascade_ceiling () =
+  with_temp_cascade_toml
+    {|
+[providers.claude_code]
+protocol = "anthropic-cli"
+command = "claude"
+is-non-interactive = true
+
+[providers.kimi_cli]
+protocol = "kimi-cli"
+command = "kimi"
+is-non-interactive = true
+
+[models.claude-auto]
+api-name = "auto"
+max-context = 200000
+tools-support = true
+
+[models.claude-auto.capabilities]
+max-output-tokens = 64000
+
+[models.kimi-cli-coding]
+api-name = "kimi-for-coding"
+max-context = 128000
+tools-support = true
+
+[models.kimi-cli-coding.capabilities]
+max-output-tokens = 16384
+
+[claude_code.claude-auto]
+max-concurrent = 1
+
+[kimi_cli.kimi-cli-coding]
+max-concurrent = 1
+
+[claude_code.claude-auto.tool_candidate]
+max-output = 64000
+temperature = 0.2
+
+[kimi_cli.kimi-cli-coding.tool_candidate]
+max-output = 16384
+temperature = 0.2
+
+[tier.strict_tool_candidates]
+members = ["claude_code.claude-auto.tool_candidate", "kimi_cli.kimi-cli-coding.tool_candidate"]
+strategy = "failover"
+
+[tier-group.strict_tool_candidates]
+tiers = ["strict_tool_candidates"]
+strategy = "failover"
+
+[routes.keeper_unified]
+target = "tier-group.strict_tool_candidates"
+|}
+    (fun () ->
+      let ceiling = CR.max_output_tokens_ceiling_of_cascade_name cascade_name in
+      check (option int) "mixed cascade output ceiling" (Some 16384) ceiling;
+      let resolved =
+        CI.resolve_max_tokens ~cascade_name ~fallback:(fun () -> 65536)
+      in
+      check int "automatic max_tokens capped to ceiling" 16384 resolved;
+      CI.validate_max_tokens_within_ceiling ~cascade_name
+        ~provider_ceiling:ceiling resolved
+      |> check_ok "capped value accepted" 16384)
+
 let () =
   run "cascade_capability_gate" [
     "max_tokens_ceiling_validation", [
@@ -151,5 +216,9 @@ let () =
         "cascade output cap, not context window, gates max_tokens"
         `Quick
         test_cascade_output_cap_not_context_window;
+      test_case
+        "automatic max_tokens respects mixed failover ceiling"
+        `Quick
+        test_resolve_max_tokens_caps_automatic_value_to_cascade_ceiling;
     ];
   ]


### PR DESCRIPTION
## Summary

- Cap automatically resolved cascade `max_tokens` to the resolved cascade output ceiling.
- Keep explicit caller-provided `max_tokens` on the existing strict pre-dispatch rejection path.
- Add a regression fixture for mixed failover members where one alias resolves to 64000 output tokens and another is capped at 16384.

## Live Failure

Observed live keeper turns blocked before dispatch with:

`pre_dispatch_max_tokens_ceiling_violation`: `tier-group.strict_tool_candidates` requested `64000` while the resolved provider ceiling was `16384`.

That config is live-only under `~/me/.masc/config/cascade.toml`, but the failure class is code-level: an automatic inferred budget can exceed the minimum output ceiling for a failover tier/group. This patch normalizes automatic inference before validation while preserving hard rejection for explicit overrides.

## Verification

- `ocamlformat --check lib/cascade_inference.ml lib/cascade_inference.mli test/test_cascade_capability_gate.ml`
- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_cascade_capability_gate.exe`
- `./_build/default/test/test_cascade_capability_gate.exe`
- `git diff --check`
