### PR TITLE
fix(auth): restore missing-metric coverage in liveness alert (follow-up #15152)

### DIFF
--- a/infrastructure/monitoring/auth-credential-alerts.yml
+++ b/infrastructure/monitoring/auth-credential-alerts.yml
@@ -39,8 +39,20 @@ groups:
         # archive_epochs / archive_pruned_total are boot-time only
         # (not periodic) and do not belong in a fiber-liveness alert;
         # detecting a missing boot signal needs a different rule.
+        #
+        # The disjunction with absent(...) restores missing-metric
+        # coverage that bare rate==0 cannot provide. Specifically:
+        # if the metric series does not exist (an older binary that
+        # predates the heartbeat counter, or a full scrape-side
+        # disappearance), [rate(missing_series[15m])] yields no series
+        # and [no_series == 0] also yields no series — the alert can
+        # never fire. [absent(...)] returns 1 in that case. On a
+        # healthy current binary the metric is pre-registered at
+        # process start (Prometheus.add) so absent() is always false
+        # and only the rate clause governs fiber liveness.
         expr: |
-          rate(masc_auth_bare_alias_audit_ticks_total[15m]) == 0
+          absent(masc_auth_bare_alias_audit_ticks_total)
+          or rate(masc_auth_bare_alias_audit_ticks_total[15m]) == 0
         for: 5m
         labels:
           severity: critical
@@ -49,15 +61,16 @@ groups:
         annotations:
           summary: "Auth bare_alias_audit fiber is not running"
           description: |
-            The periodic bare_alias_audit fiber has not bumped its tick
+            Either the bare_alias_audit fiber has not bumped its tick
             counter (masc_auth_bare_alias_audit_ticks_total) in the
-            last 15 minutes. The audit may have crashed, or the binary
-            in production predates the heartbeat counter introduced as
-            a follow-up to PR #15112. Without a live audit the
+            last 15 minutes, or the metric series does not exist at all
+            (older binary predating the heartbeat counter, or a
+            scrape-side disappearance). Without a live audit the
             ping-pong regression alert
             (AuthBareAliasPingPongRegression) cannot react. Investigate
             the [Auth] bare_alias_audit fiber startup log line and the
-            running binary version.
+            running binary version; the absent() clause specifically
+            flags the missing-instrumentation case.
 
   - name: masc_auth_bare_alias
     interval: 30s


### PR DESCRIPTION
## 배경

PR #15152 (제가 한 이전 fix) 의 Codex review (P1, `infrastructure/monitoring/auth-credential-alerts.yml:43`) 가 unresolved 상태로 main 에 머지되었습니다.

reviewer 지적:

> Changing the rule to only `rate(masc_auth_bare_alias_audit_ticks_total[15m]) == 0` drops the original \"metric absent\" coverage: if this metric does not exist at all (for example, an older binary or full scrape-side disappearance), `rate(...)` returns no series and the comparison also returns no series, so the alert never fires.

**정확함**. 이전 fix 가 fiber-crash 감지는 회복했지만 series 자체 부재 케이스를 잃음.

## 변경

`infrastructure/monitoring/auth-credential-alerts.yml` — 표준 PromQL idiom 적용:

```yaml
expr: |
  absent(masc_auth_bare_alias_audit_ticks_total)
  or rate(masc_auth_bare_alias_audit_ticks_total[15m]) == 0
```

healthy 현재 바이너리에서는 `Prometheus.add` 로 metric 이 pre-register 되어 `absent()` 항상 false → false alarm 없음. 옛 바이너리 / scrape-side 사라짐 케이스에서는 `absent()` 가 1 반환 → 정상 fire.

description annotation 도 두 모드 (no ticks vs no series at all) 명시.

## 메타

iter 18 의 *내 own fix* 가 새 P1 review 받은 케이스 — *parallel agent rename* (`runs_total` → `ticks_total` in #15143) 까지 끼어든 복합 history. cron loop 가 *자기 산출물의 회귀* 까지 detect 하는 self-correcting 사이클로 검증됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)