### PR TITLE
docs(auth): correct audit_ticks_total growth guidance (follow-up #15183)

### DIFF
--- a/docs/observability/auth-credential-metrics.md
+++ b/docs/observability/auth-credential-metrics.md
@@ -201,7 +201,10 @@ watch -n 5 'curl -fsS -H "Authorization: Bearer $MASC_MCP_TOKEN" \
 ```
 
 Steady state: `dead=0`, `dead_archive=0`, `audit_ticks_total` climbs by
-~5 every 5-second tick (matches the 60s fiber default — 1 tick / 60s).
+about `+1` per minute (the fiber default cadence is `1 tick / 60s`). On
+the `watch -n 5` loop above, most refreshes will show no change and the
+counter will tick up once roughly every 12th refresh — that is normal
+heartbeat, not a fiber stall.
 
 ### Why not the in-app dashboard
 


### PR DESCRIPTION
## 배경

PR #15183 의 Codex review (P2, `docs/observability/auth-credential-metrics.md:204`) 가 unresolved 상태로 main 에 머지되었습니다.

해당 문장:

```
Steady state: `dead=0`, `dead_archive=0`, `audit_ticks_total` climbs by
~5 every 5-second tick (matches the 60s fiber default — 1 tick / 60s).
```

같은 문장 내에서 *상호 모순* — "~5 every 5-second tick" 과 "1 tick / 60s" 가 양립 불가 (1 tick/60s 면 5초당 ~0.083 tick). `watch -n 5` 사용 operator 가 매 refresh 마다 +5 변화 기대 → 실제로는 12 회 refresh 당 +1 → fiber stall 로 *오진* 후 false regression 보고.

## 변경

`docs/observability/auth-credential-metrics.md`: 문장을 fiber cadence 와 정합하게 재작성. "+1 per minute", "most refreshes show no change" 명시. operator 가 정상 heartbeat 를 stall 로 오인하지 않도록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)