### PR TITLE
feat(dashboard): make telemetry event-log timestamps reactive

### DIFF
--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -20,7 +20,7 @@ import {
 import { replaceRoute, route } from '../router'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { TELEMETRY_SOURCE_META, telemetrySourceMeta } from '../config/telemetry-sources'
-import { formatElapsedCompact, formatTimeAgo } from '../lib/format-time'
+import { formatElapsedCompact } from '../lib/format-time'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { isAbortError } from '../lib/async-state'
 import { Btn } from './btn'
@@ -29,6 +29,7 @@ import { CopyIdButton } from './common/copy-id-button'
 import { ringFocusClasses } from './common/ring'
 import { StatTile } from './common/stat-tile'
 import { coverageGapDisplay } from './common/source-health'
+import { TimeAgo } from './common/time-ago'
 
 interface StoreSnapshot {
   keepers: number
@@ -134,10 +135,6 @@ function formatTs(ts: number): string {
     month: '2-digit', day: '2-digit',
     hour: '2-digit', minute: '2-digit', second: '2-digit',
   })
-}
-
-function timeAgoSafe(ts: number): string {
-  return ts === 0 ? '' : formatTimeAgo(ts)
 }
 
 function normalizeText(value: unknown): string | null {
@@ -693,8 +690,10 @@ function EntryRow({ entry, routeFocused = false }: { entry: TelemetryEntry; rout
           aria-expanded=${expanded.value}
         >
           <span class="font-mono font-bold ${meta.color} w-4 text-center flex-shrink-0">${meta.icon}</span>
-          <span class="font-mono text-[var(--color-fg-muted)] w-28 flex-shrink-0" title=${formatTs(ts)}>
-            ${timeAgoSafe(ts)}
+          <span class="w-56 flex-shrink-0">
+            ${ts === 0
+              ? html`<span class="font-mono text-[var(--color-fg-muted)]">-</span>`
+              : html`<${TimeAgo} timestamp=${ts} mode="both" class="font-mono text-[var(--color-fg-muted)]"/>`}
           </span>
           ${success != null ? html`
             <span class="flex-shrink-0 w-4 ${success ? 'text-[var(--color-status-ok)]' : 'text-[var(--bad-light)]'}">
@@ -772,8 +771,10 @@ function GroupRow({ item, routeFocused = false }: { item: Extract<TelemetryDispl
           onClick=${() => { expanded.value = !expanded.value }}
         >
           <span class="font-mono font-bold ${meta.color} w-4 text-center flex-shrink-0">${meta.icon}</span>
-          <span class="font-mono text-[var(--color-fg-muted)] w-28 flex-shrink-0" title=${`${formatTs(item.oldestTs)} → ${formatTs(item.latestTs)}`}>
-            ${timeAgoSafe(item.latestTs)}
+          <span class="w-56 flex-shrink-0" title=${`${formatTs(item.oldestTs)} → ${formatTs(item.latestTs)}`}>
+            ${item.latestTs === 0
+              ? html`<span class="font-mono text-[var(--color-fg-muted)]">-</span>`
+              : html`<${TimeAgo} timestamp=${item.latestTs} mode="both" class="font-mono text-[var(--color-fg-muted)]"/>`}
           </span>
           <span class="flex-shrink-0 w-4 text-[var(--color-fg-disabled)]">~</span>
           <span class="font-mono text-[var(--color-fg-primary)] truncate flex-1" title=${`${meta.label} · ${item.label} · ${item.count} events`}>
@@ -811,7 +812,11 @@ function GroupRow({ item, routeFocused = false }: { item: Extract<TelemetryDispl
             return html`
               <div class="flex items-center gap-2 rounded-[var(--r-1)] bg-[var(--black-20)] px-2 py-1.5 text-3xs" key=${`${item.key}:${index}`}>
                 <span class="font-mono font-bold ${entryMeta.color} w-4 text-center flex-shrink-0">${entryMeta.icon}</span>
-                <span class="font-mono text-[var(--color-fg-disabled)] w-24 flex-shrink-0" title=${formatTs(ts)}>${timeAgoSafe(ts)}</span>
+                <span class="w-48 flex-shrink-0">
+                  ${ts === 0
+                    ? html`<span class="font-mono text-[var(--color-fg-disabled)]">-</span>`
+                    : html`<${TimeAgo} timestamp=${ts} mode="both" class="font-mono text-[var(--color-fg-disabled)]"/>`}
+                </span>
                 <span class="font-mono text-[var(--color-fg-primary)] truncate flex-1" title=${entryPreview(entry)}>${entryPreview(entry)}</span>
               </div>
             `


### PR DESCRIPTION
## 목표
대시보드 Fleet Telemetry 이벤트 로그의 시간 셀이 "정말 갱신되는 중인지" 한눈에 보이지 않아서 정체 상태 진단이 어렵다는 문제를 해결합니다.

## 변경
`dashboard/src/components/telemetry-unified.ts` 의 세 시간 셀 (EntryRow, GroupRow 헤더, GroupRow expanded sub-entry) 을 정적 `timeAgoSafe(ts)` 텍스트에서 `TimeAgo` 컴포넌트 호출로 교체.

`TimeAgo` 는 이미 다음을 갖추고 있습니다 (`dashboard/src/components/common/time-ago.ts`):
- 30 초 shared ticker → 부모 re-render 없이 상대 라벨이 자기 자신 갱신
- `<time datetime=...>` semantic + ISO 속성
- ko-KR 절대시간을 `title` (호버) + `aria-label` (스크린리더) 에 모두 노출
- `mode="both"` 옵션 — `"5분 전 · 05. 14. 13:46"` 처럼 상대+절대 동시 표시

본 PR 은 `mode="both"` 를 채택해 셀 안에 두 표현을 동시에 보입니다. 폭은 w-28 → w-56 (sub-entry는 w-24 → w-48) 로 확장.

`timeAgoSafe` 헬퍼와 이제 미사용 `formatTimeAgo` import 는 제거. `formatTs` 는 GroupRow tooltip 의 oldest→latest 범위 표시에서 여전히 쓰이므로 유지.

## 스코프 외 (Follow-up)
ExecutionTrust 등 source 카드의 `age 4m 18s · SLO 5m 0s` 라벨은 *서버 snapshot 시점* 정보가 응답에 빠져 있어 클라이언트만 reactive 화 해도 의미가 적습니다. 별도 RFC/PR 로 분리합니다.

## 로컬 검증
- `pnpm typecheck` ✅
- `pnpm exec vitest run -- src/components/telemetry-unified.test.ts src/components/common/time-ago.test.ts` ✅ 51/51
- `pnpm exec eslint src/components/telemetry-unified.ts` ✅
- 화면 검증은 미수행 (head 가 main 기준 0 diff 였고, 본 PR 만 dashboard build 안에서 cherry-picked). reviewer 검증 시 `pnpm dev` 후 `?section=fleet-health&view=event-log` 의 시간 셀 라벨이 30 초 마다 카운트 증가하는지 확인.

## 미검증
- vitest "common" 외 일부 cockpit 통합 테스트는 main 의 변경과 무관해서 돌리지 않음 (force-push 안전상 별 risk 없음).
- TimeAgo class prop 가 기존 셀 폭에서 잘리지 않는지의 시각 검증.

## RFC
RFC-WAIVED: 변경 영역 (`dashboard/src/components/telemetry-unified.ts`) 은 RFC 필수 subsystem (credential / identity / repo_manager / operator_control* / keeper sandbox / dashboard credential / .claude hooks / instructions workflow*) 에 포함되지 않음. 순수 presentational 리팩토링.

🤖 Generated with [Claude Code](https://claude.com/claude-code)