### PR TITLE
fix(keeper): demote routine OAS bridge cancels

### DIFF
--- a/lib/keeper/keeper_llm_bridge.ml
+++ b/lib/keeper/keeper_llm_bridge.ml
@@ -41,6 +41,7 @@ let key_wall_sec = "wall_sec"
 let key_overshoot_sec = "overshoot_sec"
 let key_bucket = "bucket"
 let key_inner_exception = "inner_exception"
+let key_cancel_classification = "cancel_classification"
 let key_rollback_scope = "rollback_scope"
 let key_external_tool_side_effects_reverted = "external_tool_side_effects_reverted"
 let key_error = "error"
@@ -51,6 +52,8 @@ let field_timeout_enforced = "timeout_enforced"
 let field_wall_sec = "wall_sec"
 let field_bucket = "bucket"
 let field_inner_exception = "inner_exception"
+let field_log_class = "log_class"
+let field_cancel_classification = "cancel_classification"
 let field_error = "error"
 let field_rollback_scope = "rollback_scope"
 let field_external_tool_side_effects_reverted = "external_tool_side_effects_reverted"
@@ -97,7 +100,42 @@ let with_hitl_approval_headroom timeout_s =
     (Keeper_approval_queue.default_noncritical_approval_timeout_s +. 30.0)
 ;;
 
-let run_with_timeout_and_fallback ~timeout_s fn =
+let cancel_bucket_of_wall wall =
+  if wall < 60.0
+  then bucket_fast
+  else if wall < 300.0
+  then bucket_short_tail
+  else if wall < 600.0
+  then bucket_mid_tail
+  else if wall < 1800.0
+  then bucket_long_mid
+  else bucket_long_tail
+;;
+
+type cancel_classification =
+  | Unknown_cancel
+  | Routine_parent_cancel
+
+let string_of_cancel_classification = function
+  | Unknown_cancel -> "unknown_cancel"
+  | Routine_parent_cancel -> "routine_parent_cancel"
+;;
+
+let cancel_log_level = function
+  | Routine_parent_cancel -> Log.Info
+  | Unknown_cancel -> Log.Warn
+;;
+
+let log_class_of_cancel_classification = function
+  | Routine_parent_cancel -> "routine_parent_cancel"
+  | Unknown_cancel -> "warn_cancel"
+;;
+
+let run_with_timeout_and_fallback
+    ?(cancel_classification = Unknown_cancel)
+    ~timeout_s
+    fn
+  =
   let fail_without_clock ~site =
     let message =
       Printf.sprintf
@@ -240,25 +278,22 @@ let run_with_timeout_and_fallback ~timeout_s fn =
           Categorize wall duration into a discrete bucket and surface the
           inner cancel exception so operators can split short_tail / mid_tail
           / long_tail in PromQL and the inner reason ([Eio.Cancel.Cancel_hook]
-          payload, parent-fiber Cancelled, etc.) appears in the log. *)
+          payload, parent-fiber Cancelled, etc.) appears in the log. Severity
+          comes from the caller's explicit [cancel_classification], not the
+          internal exception name or wall-clock bucket. *)
        let bt = Printexc.get_raw_backtrace () in
        let wall = elapsed () in
-       let bucket =
-         if wall < 60.0
-         then bucket_fast
-         else if wall < 300.0
-         then bucket_short_tail
-         else if wall < 600.0
-         then bucket_mid_tail
-         else if wall < 1800.0
-         then bucket_long_mid
-         else bucket_long_tail
-       in
+       let bucket = cancel_bucket_of_wall wall in
        let inner_str =
          match inner_exn with
          | Failure msg -> "Failure(" ^ msg ^ ")"
          | _ -> Printexc.to_string inner_exn
        in
+       let log_level = cancel_log_level cancel_classification in
+       let cancel_classification_label =
+         string_of_cancel_classification cancel_classification
+       in
+       let log_class = log_class_of_cancel_classification cancel_classification in
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_llm_bridge_failures
          ~labels:[label_site, site_cancelled ]
@@ -284,19 +319,22 @@ let run_with_timeout_and_fallback ~timeout_s fn =
                  (key_wall_sec, `Float wall);
                  (key_bucket, `String bucket);
                  (key_inner_exception, `String inner_str);
+                 (key_cancel_classification, `String cancel_classification_label);
                  (key_rollback_scope, `String rollback_scope_oas_context_only);
                  (key_external_tool_side_effects_reverted, `Bool false);
                ])
            ()
        in
-       Log.Keeper.emit Log.Warn
+       Log.Keeper.emit log_level
          ~details:
            (bridge_details
               [
                 json_string_field field_event "keeper_oas_bridge_cancelled";
+                json_string_field field_log_class log_class;
                 json_float_field field_wall_sec wall;
                 json_string_field field_bucket bucket;
                 json_string_field field_inner_exception inner_str;
+                json_string_field field_cancel_classification cancel_classification_label;
                 json_string_field field_rollback_scope rollback_scope_oas_context_only;
                 json_field field_external_tool_side_effects_reverted (`Bool false);
               ]

--- a/lib/keeper/keeper_llm_bridge.mli
+++ b/lib/keeper/keeper_llm_bridge.mli
@@ -6,6 +6,13 @@ val with_hitl_approval_headroom : float -> float
     an OAS/provider timeout before the approval queue itself resolves or
     expires. *)
 
+type cancel_classification =
+  | Unknown_cancel
+  | Routine_parent_cancel
+(** Caller-provided cancellation context.  [Routine_parent_cancel] is only for
+    explicit parent/supervisor cancellation paths that are expected to re-raise;
+    provider or bridge timeouts must keep the default [Unknown_cancel]. *)
+
 (** Runs a generic Eio execution (usually an OAS Agent.run or Model.call) with a strict
     structural timeout.
 
@@ -18,6 +25,7 @@ val with_hitl_approval_headroom : float -> float
 
     @raises Eio.Cancel.Cancelled when the parent fiber/switch is cancelled. *)
 val run_with_timeout_and_fallback
-  :  timeout_s:float
+  :  ?cancel_classification:cancel_classification
+  -> timeout_s:float
   -> (unit -> ('a, Agent_sdk.Error.sdk_error) result)
   -> ('a, Agent_sdk.Error.sdk_error) result

--- a/test/test_keeper_llm_bridge.ml
+++ b/test/test_keeper_llm_bridge.ml
@@ -130,7 +130,9 @@ let test_parent_timeout_cancel_logs_info () =
         let cancelled =
           try
             ignore
-              (Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s:1.0
+              (Keeper_llm_bridge.run_with_timeout_and_fallback
+                 ~cancel_classification:Keeper_llm_bridge.Routine_parent_cancel
+                 ~timeout_s:1.0
                  (fun () -> raise (Eio.Cancel.Cancelled Eio.Time.Timeout)));
             false
           with
@@ -144,11 +146,45 @@ let test_parent_timeout_cancel_logs_info () =
           Alcotest.(check string)
             "routine parent timeout cancel is info"
             "INFO"
-            entry.Log.Ring.normalized_level;
+            (Log.level_to_string entry.Log.Ring.level);
           Alcotest.(check string)
             "log class"
             "routine_parent_cancel"
             (entry.Log.Ring.details |> member "log_class" |> to_string))))
+;;
+
+let test_default_parent_timeout_cancel_stays_warn () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      Masc_eio_env.reset_for_test ();
+      Fun.protect ~finally:Masc_eio_env.reset_for_test (fun () ->
+        Masc_eio_env.init ~sw ~net:(Eio.Stdenv.net env) ~clock:(Eio.Stdenv.clock env) ();
+        let cancelled =
+          try
+            ignore
+              (Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s:1.0
+                 (fun () -> raise (Eio.Cancel.Cancelled Eio.Time.Timeout)));
+            false
+          with
+          | Eio.Cancel.Cancelled _ -> true
+        in
+        Alcotest.(check bool) "cancel re-raised" true cancelled;
+        match latest_keeper_log_matching "bucket=fast inner=Eio__Time.Timeout" with
+        | None -> Alcotest.fail "missing default timeout cancel log"
+        | Some entry ->
+          let open Yojson.Safe.Util in
+          Alcotest.(check string)
+            "default parent timeout cancel stays warn"
+            "WARN"
+            (Log.level_to_string entry.Log.Ring.level);
+          Alcotest.(check string)
+            "log class"
+            "warn_cancel"
+            (entry.Log.Ring.details |> member "log_class" |> to_string);
+          Alcotest.(check string)
+            "cancel classification"
+            "unknown_cancel"
+            (entry.Log.Ring.details |> member "cancel_classification" |> to_string))))
 ;;
 
 let test_unknown_cancel_stays_warn () =
@@ -174,7 +210,7 @@ let test_unknown_cancel_stays_warn () =
           Alcotest.(check string)
             "unknown cancel stays warn"
             "WARN"
-            entry.Log.Ring.normalized_level;
+            (Log.level_to_string entry.Log.Ring.level);
           Alcotest.(check string)
             "log class"
             "warn_cancel"
@@ -216,6 +252,10 @@ let () =
             "parent timeout cancel logs info"
             `Quick
             test_parent_timeout_cancel_logs_info
+        ; Alcotest.test_case
+            "default timeout cancel stays warn"
+            `Quick
+            test_default_parent_timeout_cancel_stays_warn
         ; Alcotest.test_case
             "unknown cancel stays warn"
             `Quick

--- a/test/test_keeper_llm_bridge.ml
+++ b/test/test_keeper_llm_bridge.ml
@@ -121,6 +121,66 @@ let test_timeout_log_carries_failure_envelope () =
         | Ok value -> Alcotest.failf "unexpected success: %s" value)))
 ;;
 
+let test_parent_timeout_cancel_logs_info () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      Masc_eio_env.reset_for_test ();
+      Fun.protect ~finally:Masc_eio_env.reset_for_test (fun () ->
+        Masc_eio_env.init ~sw ~net:(Eio.Stdenv.net env) ~clock:(Eio.Stdenv.clock env) ();
+        let cancelled =
+          try
+            ignore
+              (Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s:1.0
+                 (fun () -> raise (Eio.Cancel.Cancelled Eio.Time.Timeout)));
+            false
+          with
+          | Eio.Cancel.Cancelled _ -> true
+        in
+        Alcotest.(check bool) "cancel re-raised" true cancelled;
+        match latest_keeper_log_matching "bucket=fast inner=Eio__Time.Timeout" with
+        | None -> Alcotest.fail "missing parent timeout cancel log"
+        | Some entry ->
+          let open Yojson.Safe.Util in
+          Alcotest.(check string)
+            "routine parent timeout cancel is info"
+            "INFO"
+            entry.Log.Ring.normalized_level;
+          Alcotest.(check string)
+            "log class"
+            "routine_parent_cancel"
+            (entry.Log.Ring.details |> member "log_class" |> to_string))))
+;;
+
+let test_unknown_cancel_stays_warn () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      Masc_eio_env.reset_for_test ();
+      Fun.protect ~finally:Masc_eio_env.reset_for_test (fun () ->
+        Masc_eio_env.init ~sw ~net:(Eio.Stdenv.net env) ~clock:(Eio.Stdenv.clock env) ();
+        let cancelled =
+          try
+            ignore
+              (Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s:1.0
+                 (fun () -> raise (Eio.Cancel.Cancelled (Failure "operator-stop-test"))));
+            false
+          with
+          | Eio.Cancel.Cancelled _ -> true
+        in
+        Alcotest.(check bool) "cancel re-raised" true cancelled;
+        match latest_keeper_log_matching "inner=Failure(operator-stop-test)" with
+        | None -> Alcotest.fail "missing unknown cancel log"
+        | Some entry ->
+          let open Yojson.Safe.Util in
+          Alcotest.(check string)
+            "unknown cancel stays warn"
+            "WARN"
+            entry.Log.Ring.normalized_level;
+          Alcotest.(check string)
+            "log class"
+            "warn_cancel"
+            (entry.Log.Ring.details |> member "log_class" |> to_string))))
+;;
+
 let test_hitl_headroom_exceeds_default_approval_wait () =
   let floor =
     Keeper_approval_queue.default_noncritical_approval_timeout_s +. 30.0
@@ -152,6 +212,14 @@ let () =
             "timeout log carries failure envelope"
             `Quick
             test_timeout_log_carries_failure_envelope
+        ; Alcotest.test_case
+            "parent timeout cancel logs info"
+            `Quick
+            test_parent_timeout_cancel_logs_info
+        ; Alcotest.test_case
+            "unknown cancel stays warn"
+            `Quick
+            test_unknown_cancel_stays_warn
         ; Alcotest.test_case
             "HITL approval headroom"
             `Quick


### PR DESCRIPTION
## Summary
- classify routine parent-cancel cases in keeper_llm_bridge (Eio timeout / Not_first within fast-mid buckets)
- emit those routine bridge cancellations at INFO while keeping long or unknown cancellations at WARN
- add log_class details so operators can still split routine_parent_cancel vs warn_cancel

## Validation
- `opam exec -- ocamlformat --check lib/keeper/keeper_llm_bridge.ml test/test_keeper_llm_bridge.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_llm_bridge.exe`
- `./_build/default/test/test_keeper_llm_bridge.exe`