### PR TITLE
fix(dashboard): heartbeat websocket sessions

### DIFF
--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -17,6 +17,7 @@ export const MCP_INIT_COOLDOWN_MS = 2_000
 // so a slow first response under Executor_pool contention is not turned into
 // a reconnect by the client side.
 export const DASHBOARD_WS_RPC_TIMEOUT_MS = 30_000
+export const DASHBOARD_WS_HEARTBEAT_INTERVAL_MS = 30_000
 
 // --- Reconnect backoff (shared by SSE and dashboard WS) ---
 // Cap at 60s with plus/minus 1s jitter to break reconnect storms when the server is

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -16,7 +16,10 @@ import {
   parseWebSocketSseFrames,
   subscribeDashboardRoute,
 } from './dashboard-ws'
-import { DASHBOARD_WS_RPC_TIMEOUT_MS } from './config/constants'
+import {
+  DASHBOARD_WS_HEARTBEAT_INTERVAL_MS,
+  DASHBOARD_WS_RPC_TIMEOUT_MS,
+} from './config/constants'
 import {
   dashboardWsConnected,
   dashboardWsLastError,
@@ -140,6 +143,24 @@ function parseRpc(socket: MockWebSocket, index: number): JsonRpcRequest {
 async function flushPromises(): Promise<void> {
   await Promise.resolve()
   await Promise.resolve()
+}
+
+async function connectReadyDashboard(): Promise<MockWebSocket> {
+  await connectDashboardWS({ tab: 'overview', params: {} })
+  const socket = mockSockets[0]!
+  socket.open()
+  const hello = parseRpc(socket, 0)
+  socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+  await flushPromises()
+
+  const subscribe = parseRpc(socket, 1)
+  socket.receive({
+    jsonrpc: '2.0',
+    id: subscribe.id,
+    result: { snapshot: { seq: 1, slices: {} } },
+  })
+  await flushPromises()
+  return socket
 }
 
 beforeEach(() => {
@@ -420,6 +441,57 @@ describe('dashboard websocket route subscriptions', () => {
     expect(dashboardWsLastError.value).toBe(
       'dashboard websocket rpc timed out: dashboard/subscribe',
     )
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    await flushPromises()
+
+    expect(mockSockets).toHaveLength(2)
+    expect(mockSockets[1]!.readyState).toBe(MockWebSocket.CONNECTING)
+  })
+
+  it('sends dashboard heartbeat pings after a route subscription is ready', async () => {
+    vi.useFakeTimers()
+    installWebSocketMocks()
+
+    const socket = await connectReadyDashboard()
+    expect(dashboardWsReady.value).toBe(true)
+    expect(socket.sent).toHaveLength(2)
+
+    await vi.advanceTimersByTimeAsync(DASHBOARD_WS_HEARTBEAT_INTERVAL_MS)
+    await flushPromises()
+
+    const ping = parseRpc(socket, 2)
+    expect(ping.method).toBe('dashboard/ping')
+    expect(ping.params).toEqual({})
+
+    socket.receive({ jsonrpc: '2.0', id: ping.id, result: { ok: true } })
+    await flushPromises()
+
+    expect(dashboardWsConnected.value).toBe(true)
+    expect(dashboardWsReady.value).toBe(true)
+    expect(dashboardWsLastError.value).toBe(null)
+  })
+
+  it('reconnects when a dashboard heartbeat ping never responds', async () => {
+    vi.useFakeTimers()
+    installWebSocketMocks()
+
+    const socket = await connectReadyDashboard()
+    expect(dashboardWsReady.value).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(DASHBOARD_WS_HEARTBEAT_INTERVAL_MS)
+    await flushPromises()
+
+    const ping = parseRpc(socket, 2)
+    expect(ping.method).toBe('dashboard/ping')
+
+    await vi.advanceTimersByTimeAsync(DASHBOARD_WS_RPC_TIMEOUT_MS)
+    await flushPromises()
+
+    expect(socket.readyState).toBe(MockWebSocket.CLOSED)
+    expect(dashboardWsConnected.value).toBe(false)
+    expect(dashboardWsReady.value).toBe(false)
+    expect(dashboardWsLastError.value).toBe('dashboard websocket rpc timed out: dashboard/ping')
 
     await vi.advanceTimersByTimeAsync(1_000)
     await flushPromises()

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -4,6 +4,7 @@ import { hydrateDashboardSlice, routeServerPushEvent } from './sse-store'
 import { batch } from '@preact/signals'
 import { parseWebSocketSseFrames as parseWebSocketSseFramesImpl } from './dashboard-ws-parse'
 import {
+  DASHBOARD_WS_HEARTBEAT_INTERVAL_MS,
   DASHBOARD_WS_RPC_TIMEOUT_MS,
   RECONNECT_JITTER_MS,
   RECONNECT_MAX_MS,
@@ -49,6 +50,8 @@ const DASHBOARD_WS_DISCOVERY_CACHE_KEY = 'masc.dashboard.ws.discovery.v1'
 let socket: WebSocket | null = null
 let rpcId = 0
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+let heartbeatTimer: ReturnType<typeof setInterval> | null = null
+let heartbeatInFlight = false
 let reconnectAttempts = 0
 let lastSubscribeKey = ''
 let desiredRouteState: DashboardRouteState | null = null
@@ -289,6 +292,14 @@ function clearReconnectTimer(): void {
   }
 }
 
+function clearHeartbeatTimer(): void {
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer)
+    heartbeatTimer = null
+  }
+  heartbeatInFlight = false
+}
+
 function rejectPendingRpcs(err: Error): void {
   for (const { reject, timeout } of pending.values()) {
     clearTimeout(timeout)
@@ -327,7 +338,26 @@ function scheduleReconnect(): void {
   }, delay)
 }
 
+function startHeartbeat(ws: WebSocket): void {
+  clearHeartbeatTimer()
+  heartbeatTimer = setInterval(() => {
+    if (socket !== ws || ws.readyState !== WebSocket.OPEN || heartbeatInFlight) {
+      return
+    }
+    heartbeatInFlight = true
+    void sendRpc('dashboard/ping', {})
+      .then(() => {
+        if (socket === ws) heartbeatInFlight = false
+      })
+      .catch(err => {
+        heartbeatInFlight = false
+        reconnectAfterCurrentSocketFailure(ws, err)
+      })
+  }, DASHBOARD_WS_HEARTBEAT_INTERVAL_MS)
+}
+
 function closeSocket(): void {
+  clearHeartbeatTimer()
   if (socket) {
     socket.onopen = null
     socket.onclose = null
@@ -654,7 +684,12 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
         })
         if (desiredRouteState) {
           void subscribeDashboardRoute(desiredRouteState)
+            .then(() => {
+              if (socket === ws) startHeartbeat(ws)
+            })
             .catch(err => reconnectAfterCurrentSocketFailure(ws, err))
+        } else {
+          startHeartbeat(ws)
         }
       })
       .catch(err => reconnectAfterCurrentSocketFailure(ws, err))
@@ -673,6 +708,7 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     if (socket !== ws) return
     const wasReady = dashboardWsReady.value
     const closeError = new Error(formatCloseEventError(event))
+    clearHeartbeatTimer()
     batch(() => {
       dashboardWsConnected.value = false
       dashboardWsReady.value = false

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -478,6 +478,15 @@ let handle_dashboard_unsubscribe_eio id ?mcp_session_id params =
   | Some _, Some _ -> make_error ~id (-32602) "Invalid params: expected object"
 ;;
 
+let handle_dashboard_ping_eio id ?mcp_session_id params =
+  match mcp_session_id, params with
+  | None, _ -> make_error ~id (-32600) "dashboard/ping requires a WebSocket session"
+  | Some session_id, None | Some session_id, Some (`Assoc _) ->
+    Server_mcp_transport_ws.dashboard_ping ~session_id ()
+    |> dashboard_response_or_error id
+  | Some _, Some _ -> make_error ~id (-32602) "Invalid params: expected object"
+;;
+
 let handle_dashboard_ack_eio id ?mcp_session_id params =
   match mcp_session_id, params with
   | None, _ -> make_error ~id (-32600) "dashboard/ack requires a WebSocket session"
@@ -635,6 +644,8 @@ let handle_request
                 handle_dashboard_subscribe_eio state id ?mcp_session_id req.params
               | "dashboard/unsubscribe" ->
                 handle_dashboard_unsubscribe_eio id ?mcp_session_id req.params
+              | "dashboard/ping" ->
+                handle_dashboard_ping_eio id ?mcp_session_id req.params
               | "dashboard/ack" -> handle_dashboard_ack_eio id ?mcp_session_id req.params
               | "prompts/list" ->
                 (match TP.parse_cursor_only_params req.params with

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -416,6 +416,21 @@ let dashboard_unsubscribe ~session_id ?slices () =
         Ok (`Assoc [ ("session", dashboard_session_result session) ])
       end
 
+let dashboard_ping ~session_id () =
+  match find_session session_id with
+  | None -> Error "WebSocket session not found"
+  | Some session ->
+      if not session.dashboard_authenticated then
+        Error "dashboard/ping requires dashboard/hello first"
+      else
+        Ok
+          (`Assoc
+            [
+              ("ok", `Bool true);
+              ("session_id", `String session.id);
+              ("seq", `Int session.dashboard_seq);
+            ])
+
 let dashboard_ack ~session_id ~seq ?buffered_amount () =
   match find_session session_id with
   | None -> Error "WebSocket session not found"

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -3,7 +3,7 @@
     replacing SSE for dashboard / agent connections that
     need full-duplex.
 
-    External surface (16 entries + 3 types):
+    External surface (17 entries + 3 types):
     - {b session record} ({!ws_session}) — concrete because
       [server_ws_standalone] passes session values to
       {!read_inbound_message_frame} /
@@ -24,7 +24,8 @@
       ({!read_inbound_message_frame}).
     - {b dashboard JSON-RPC handlers}
       ({!dashboard_hello}, {!dashboard_subscribe},
-      {!dashboard_unsubscribe}, {!dashboard_ack},
+      {!dashboard_unsubscribe}, {!dashboard_ping},
+      {!dashboard_ack},
       {!set_dashboard_snapshot_provider}).
     - {b outbound delivery}
       ({!send_to_session_result},
@@ -220,6 +221,14 @@ val dashboard_unsubscribe :
 (** Drops [slices] from the subscription set.  When
     [?slices] is [None], unsubscribes from every slice.
     Requires a prior {!dashboard_hello}. *)
+
+val dashboard_ping :
+  session_id:string ->
+  unit ->
+  (Yojson.Safe.t, string) result
+(** Lightweight heartbeat endpoint for browser dashboards.
+    Requires a prior {!dashboard_hello}; stale or unauthenticated sessions
+    fail so the client can reconnect and re-handshake. *)
 
 val dashboard_ack :
   session_id:string ->

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -2946,6 +2946,61 @@ let test_handle_request_resources_subscribe_requires_session () =
    | _ -> Alcotest.fail "response not an object");
   cleanup_dir base_path
 
+let test_handle_request_dashboard_ping_requires_session () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let request =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("jsonrpc", `String "2.0");
+          ("id", `Int 242);
+          ("method", `String "dashboard/ping");
+          ("params", `Assoc []);
+        ])
+  in
+  let response = Mcp_eio.handle_request ~clock ~sw state request in
+  Alcotest.(check bool) "ping requires ws session" true
+    (contains_substring
+       (Yojson.Safe.to_string response)
+       "dashboard/ping requires a WebSocket session");
+  cleanup_dir base_path
+
+let test_handle_request_dashboard_ping_reports_unknown_ws_session () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let request =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("jsonrpc", `String "2.0");
+          ("id", `Int 243);
+          ("method", `String "dashboard/ping");
+          ("params", `Assoc []);
+        ])
+  in
+  let response =
+    Mcp_eio.handle_request
+      ~clock
+      ~sw
+      ~mcp_session_id:"missing-dashboard-ws-session"
+      state
+      request
+  in
+  Alcotest.(check bool) "unknown ws session reported" true
+    (contains_substring
+       (Yojson.Safe.to_string response)
+       "WebSocket session not found");
+  cleanup_dir base_path
+
 let test_handle_request_resources_subscribe_roundtrip () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -3161,6 +3216,10 @@ let eio_tests = [
     test_handle_request_resources_templates_rejects_invalid_cursor;
   "handle resources/subscribe requires session", `Quick,
     test_handle_request_resources_subscribe_requires_session;
+  "handle dashboard/ping requires session", `Quick,
+    test_handle_request_dashboard_ping_requires_session;
+  "handle dashboard/ping reports unknown ws session", `Quick,
+    test_handle_request_dashboard_ping_reports_unknown_ws_session;
   "handle resources/subscribe roundtrip", `Quick,
     test_handle_request_resources_subscribe_roundtrip;
   "execute masc_tool_help", `Quick, test_execute_tool_help_tool;


### PR DESCRIPTION
## Summary
- add authenticated dashboard/ping JSON-RPC handling on the WS server path
- start a browser dashboard heartbeat after hello + initial route subscription succeed
- reconnect the dashboard WS when heartbeat RPCs time out, without overlapping in-flight pings

## Verification
- git diff --check
- pnpm --dir dashboard install --frozen-lockfile --prefer-offline
- pnpm exec tsc --noEmit --pretty
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/dashboard-ws.test.ts
- scripts/dune-local.sh build test/test_mcp_server_eio.exe test/test_ws_transport.exe
- _build/default/test/test_ws_transport.exe --compact
- _build/default/test/test_mcp_server_eio.exe test eio 17,18 --compact

Note: full test_mcp_server_eio alias was not used because the large suite hung locally after test_ws_transport passed; the new dashboard/ping dispatch cases were run directly from the focused test binary.