### PR TITLE
fix(dashboard): add memory-subsystems to SurfaceSectionId type

### DIFF
--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -176,7 +176,7 @@ describe('monitoring navigation labels', () => {
     const sections = sectionItemsForTab('monitoring')
     const hiddenIds = sections.filter(item => item.hidden).map(item => item.id)
 
-    expect(hiddenIds).toEqual(['journey', 'observatory', 'cognition'])
+    expect(hiddenIds).toEqual(['journey', 'observatory', 'cognition', 'memory-subsystems'])
   })
 
   it('monitoring sidebar labels are unique (no overloaded term like "런타임")', () => {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -20,6 +20,7 @@ type SurfaceSectionId =
   | 'runtime'
   | 'goal-loop'
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
+  | 'memory-subsystems' // Legacy redirect target (cognition > memory tab)
   // command
   | 'operations'     // Phase 1+6: absorbs intervene + governance + inspector (Phase 7: connectors split out)
   // connectors (Phase 7: top-level surface — sidecar-driven channel bridges)

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -240,6 +240,7 @@ let make_health_json ?(listener = "http/1.1") request =
     else if keeper_config_unknown_key_count > 0 then "config_unknown_keys"
     else "none"
   in
+  let key_paused_keepers = "paused_keepers" in
   Tool_args.ok_assoc [
     ("server", `String "masc-mcp");
     ("version", `String build.release_version);
@@ -280,7 +281,6 @@ let make_health_json ?(listener = "http/1.1") request =
        but ops still need a quick count without scraping /metrics. List names
        so an operator can correlate with the cause encoded in their
        last_blocker_class. *)
-    let key_paused_keepers = "paused_keepers" in
     (key_paused_keepers, paused_keepers_health_json ());
     ("keeper_config_parse_error_count",
      `Int keeper_config_parse_error_count);


### PR DESCRIPTION
Adds missing `memory-subsystems` to the `SurfaceSectionId` union type to match the existing entry in `DASHBOARD_SECTION_ITEMS`. Prevents TypeScript compilation errors for legacy redirect handling.