### PR TITLE
fix(telemetry): label provider latency metrics

### DIFF
--- a/lib/cascade/cascade_legacy_runner.ml
+++ b/lib/cascade/cascade_legacy_runner.ml
@@ -381,7 +381,7 @@ let cascade_metrics_for_candidates ~candidate_count:(_ : int) () =
            per-call metrics object takes precedence. *)
         match latency_ms with
         | Some latency_ms ->
-            Llm_metric_bridge.emit_request_latency ~model_id ~latency_ms
+            Llm_metric_bridge.emit_request_latency ~model_id ~latency_ms ()
         | None -> ())
       ~on_error:(fun ~model_id ~error ->
         ensure_terminal_attempt capture ~model_id ~latency_ms:None

--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -8,10 +8,12 @@
     resolves it at call time for every code path that does not
     explicitly thread [~metrics].
 
-    This module constructs the sink.  Each callback relays into
-    [Prometheus.inc_counter] on a named metric.  No other state —
-    the sink is pure forwarding, so there is no need to guard against
-    concurrent fiber access beyond what Prometheus already provides.
+    This module constructs the sink.  Most callbacks relay directly into
+    [Prometheus.inc_counter] on a named metric.  The exception is request
+    latency: OAS [on_request_end] carries [model_id] but not [provider], so
+    the bridge keeps a tiny model→provider cache from adjacent callbacks
+    ([on_http_status], [on_retry], [on_token_usage]) to label latency
+    histograms without changing the OAS API.
 
     @since 0.4.x (telemetry chain: oas#804 + oas#807) *)
 
@@ -42,6 +44,40 @@ let input_tokens_metric = Prometheus.metric_llm_provider_input_tokens
 let output_tokens_metric = Prometheus.metric_llm_provider_output_tokens
 let circuit_state_metric = Prometheus.metric_llm_provider_circuit_state
 
+let unknown_provider_label = "unknown"
+let provider_cache_max_entries = 256
+let provider_by_model : (string, string) Hashtbl.t = Hashtbl.create 32
+let provider_cache_mutex = Stdlib.Mutex.create ()
+
+let nonempty_or_none value =
+  let value = String.trim value in
+  if value = "" then None else Some value
+
+let remember_provider ~model_id ~provider =
+  match nonempty_or_none model_id, nonempty_or_none provider with
+  | Some model_id, Some provider ->
+    Stdlib.Mutex.protect provider_cache_mutex (fun () ->
+      if Hashtbl.length provider_by_model >= provider_cache_max_entries
+         && not (Hashtbl.mem provider_by_model model_id)
+      then Hashtbl.clear provider_by_model;
+      Hashtbl.replace provider_by_model model_id provider)
+  | _ -> ()
+
+let provider_for_latency ?provider ~model_id () =
+  match Option.bind provider nonempty_or_none with
+  | Some provider ->
+    remember_provider ~model_id ~provider;
+    provider
+  | None ->
+    let model_id = String.trim model_id in
+    if model_id = ""
+    then unknown_provider_label
+    else
+      Stdlib.Mutex.protect provider_cache_mutex (fun () ->
+        Option.value
+          ~default:unknown_provider_label
+          (Hashtbl.find_opt provider_by_model model_id))
+
 (** Emit a single HTTP status observation to the Prometheus counter.
 
     Exposed so that per-call metrics sinks (e.g. the cascade-observation
@@ -49,6 +85,7 @@ let circuit_state_metric = Prometheus.metric_llm_provider_circuit_state
     same counter without duplicating the label shape.  This is the
     single source of truth for the label key names. *)
 let emit_http_status ~provider ~model_id ~status =
+  remember_provider ~model_id ~provider;
   Prometheus.inc_counter http_status_metric
     ~labels:
       [
@@ -109,6 +146,7 @@ let emit_error ~model_id ~error =
     ()
 
 let emit_retry ~provider ~model_id ~attempt =
+  remember_provider ~model_id ~provider;
   Prometheus.inc_counter retry_metric
     ~labels:
       [
@@ -119,6 +157,7 @@ let emit_retry ~provider ~model_id ~attempt =
     ()
 
 let emit_token_usage ~provider ~model_id ~input_tokens ~output_tokens =
+  remember_provider ~model_id ~provider;
   if input_tokens > 0 then
     Prometheus.inc_counter input_tokens_metric
       ~labels:[("provider", provider); ("model", model_id)]
@@ -131,6 +170,7 @@ let emit_token_usage ~provider ~model_id ~input_tokens ~output_tokens =
       ()
 
 let emit_circuit_state ~provider ~model_id ~provider_key ~state =
+  remember_provider ~model_id ~provider;
   let value =
     Float.of_int (Llm_provider.Metrics.circuit_state_to_int state)
   in
@@ -175,9 +215,9 @@ let request_latency_seconds ~latency_ms =
   let latency_ms = Stdlib.max 1 latency_ms in
   Float.of_int latency_ms /. 1000.0
 
-let emit_request_latency_clamped ~model_id ~reason =
+let emit_request_latency_clamped ~provider ~model_id ~reason =
   Prometheus.inc_counter request_latency_clamped_metric
-    ~labels:[("model", model_id); ("reason", reason)]
+    ~labels:[("provider", provider); ("model", model_id); ("reason", reason)]
     ()
 
 (** Emit a single latency observation to the Prometheus histogram.
@@ -186,12 +226,16 @@ let emit_request_latency_clamped ~model_id ~reason =
     capture in [Cascade_legacy_runner]) can forward [on_request_end] to the
     same histogram without duplicating the label shape.  This is the
     single source of truth for the label key names. *)
-let emit_request_latency ~model_id ~latency_ms =
+let emit_request_latency ?provider ~model_id ~latency_ms () =
+  let provider = provider_for_latency ?provider ~model_id () in
   if latency_ms <= 0 then
-    emit_request_latency_clamped ~model_id ~reason:"non_positive_latency_ms";
+    emit_request_latency_clamped
+      ~provider
+      ~model_id
+      ~reason:"non_positive_latency_ms";
   let seconds = request_latency_seconds ~latency_ms in
   Prometheus.observe_histogram request_latency_metric
-    ~labels:[("model", model_id)] seconds
+    ~labels:[("provider", provider); ("model", model_id)] seconds
 
 (** Build the OAS Metrics.t sink.
 
@@ -216,7 +260,7 @@ let make_sink () : Llm_provider.Metrics.t =
     on_request_end =
       (fun ~model_id ~latency_ms ->
         match latency_ms with
-        | Some latency_ms -> emit_request_latency ~model_id ~latency_ms
+        | Some latency_ms -> emit_request_latency ~model_id ~latency_ms ()
         | None -> ());
     on_capability_drop =
       (fun ~model_id ~field ->

--- a/lib/llm_metric_bridge.mli
+++ b/lib/llm_metric_bridge.mli
@@ -25,13 +25,17 @@ val emit_http_status :
     below 1ms are recorded as 1ms so fast calls still produce a non-zero
     histogram sum; non-positive inputs also increment
     [masc_llm_provider_request_latency_clamped_total] so sentinel or missing
-    durations remain visible.
+    durations remain visible.  [?provider] is optional because the OAS
+    [on_request_end] callback currently carries only [model_id]; when omitted,
+    the bridge uses the provider most recently observed for that model from
+    adjacent OAS callbacks such as [on_http_status].
 
     Called by both the global sink built in {!make_sink} and any
     per-call OAS [Metrics.t] literal that wants to forward
     [on_request_end] (e.g. cascade observation captures).  Single
     source of truth for the label shape. *)
-val emit_request_latency : model_id:string -> latency_ms:int -> unit
+val emit_request_latency :
+  ?provider:string -> model_id:string -> latency_ms:int -> unit -> unit
 
 (** Emit a capability drop observation to the Prometheus counter. *)
 val emit_capability_drop : model_id:string -> field:string -> unit

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1556,7 +1556,7 @@ let init () =
   add
     metric_llm_provider_request_latency_clamped
     "Total OAS LLM request latency observations clamped before histogram emission, \
-     labeled by model and reason"
+     labeled by provider, model, and reason"
     Counter;
   add
     metric_llm_provider_retries
@@ -2286,7 +2286,7 @@ let init () =
     ~help:
       "Per-HTTP-request LLM latency from OAS on_request_end callback. Independent from \
        masc_llm_inference_duration_seconds (turn-scope) — this fires per provider HTTP \
-       call regardless of keeper hook health."
+       call regardless of keeper hook health. Labels: provider, model."
     ();
   (* Process-level resource gauges.  Sampled on every /metrics scrape via
      [update_fd_gauges] so a monotonic ramp (fd leak) is visible in the

--- a/test/test_llm_metric_bridge.ml
+++ b/test/test_llm_metric_bridge.ml
@@ -128,7 +128,8 @@ let test_request_latency_clamps_zero_ms () =
   let model_id =
     Printf.sprintf "bridge-latency-zero-%d" (Unix.getpid ())
   in
-  let labels = [ ("model", model_id) ] in
+  let provider = "bridge-latency-provider" in
+  let labels = [ ("provider", provider); ("model", model_id) ] in
   let before_sum =
     metric Prom.metric_llm_provider_request_latency ~labels
   in
@@ -136,13 +137,13 @@ let test_request_latency_clamps_zero_ms () =
     metric (Prom.metric_llm_provider_request_latency ^ "_count") ~labels
   in
   let clamped_labels =
-    [ ("model", model_id); ("reason", "non_positive_latency_ms") ]
+    [ ("provider", provider); ("model", model_id); ("reason", "non_positive_latency_ms") ]
   in
   let before_clamped =
     metric Prom.metric_llm_provider_request_latency_clamped
       ~labels:clamped_labels
   in
-  Bridge.emit_request_latency ~model_id ~latency_ms:0;
+  Bridge.emit_request_latency ~provider ~model_id ~latency_ms:0 ();
   check_metric_delta "latency sum floors to 1ms"
     Prom.metric_llm_provider_request_latency
     ~labels ~before:before_sum ~delta:0.001;
@@ -157,16 +158,34 @@ let test_request_latency_positive_ms_does_not_clamp () =
   let model_id =
     Printf.sprintf "bridge-latency-positive-%d" (Unix.getpid ())
   in
+  let provider = "bridge-positive-provider" in
   let labels =
-    [ ("model", model_id); ("reason", "non_positive_latency_ms") ]
+    [ ("provider", provider); ("model", model_id); ("reason", "non_positive_latency_ms") ]
   in
   let before =
     metric Prom.metric_llm_provider_request_latency_clamped ~labels
   in
-  Bridge.emit_request_latency ~model_id ~latency_ms:42;
+  Bridge.emit_request_latency ~provider ~model_id ~latency_ms:42 ();
   check_metric_delta "positive latency avoids clamp counter"
     Prom.metric_llm_provider_request_latency_clamped
     ~labels ~before ~delta:0.0
+
+let test_request_latency_uses_provider_seen_from_status () =
+  let model_id =
+    Printf.sprintf "bridge-latency-status-provider-%d" (Unix.getpid ())
+  in
+  let provider = "bridge-status-provider" in
+  let labels = [ ("provider", provider); ("model", model_id) ] in
+  let before =
+    metric (Prom.metric_llm_provider_request_latency ^ "_count") ~labels
+  in
+  Bridge.emit_http_status ~provider ~model_id ~status:200;
+  Bridge.emit_request_latency ~model_id ~latency_ms:125 ();
+  check_metric_delta "latency uses provider cached by status"
+    (Prom.metric_llm_provider_request_latency ^ "_count")
+    ~labels
+    ~before
+    ~delta:1.0
 
 let test_error_reason_labels_are_bounded () =
   let model_id =
@@ -205,6 +224,8 @@ let () =
             test_request_latency_clamps_zero_ms;
           Alcotest.test_case "positive request latency does not clamp" `Quick
             test_request_latency_positive_ms_does_not_clamp;
+          Alcotest.test_case "request latency uses provider seen from status" `Quick
+            test_request_latency_uses_provider_seen_from_status;
           Alcotest.test_case "error reason labels are bounded" `Quick
             test_error_reason_labels_are_bounded;
         ] );


### PR DESCRIPTION
## Summary
- add provider labels to masc_llm_provider_request_latency_seconds and the clamped latency counter
- keep OAS API boundary intact by caching the last provider observed for a model from adjacent callbacks
- update cascade forwarding and bridge regression coverage

## Why
Old telemetry gap audit called out provider-level request latency histograms as missing. The metric name already promised provider latency, but the histogram only carried model labels.

## Verification
- git diff --check
- ocamlformat --check lib/llm_metric_bridge.ml lib/llm_metric_bridge.mli lib/prometheus.ml test/test_llm_metric_bridge.ml lib/cascade/cascade_legacy_runner.ml
- scripts/dune-local.sh build test/test_llm_metric_bridge.exe
- _build/default/test/test_llm_metric_bridge.exe --compact
- scripts/dune-local.sh build lib/masc_mcp.cmxa