### PR TITLE
fix(cascade): reject unseeded config strategies

### DIFF
--- a/docs/observability/cascade-metrics.md
+++ b/docs/observability/cascade-metrics.md
@@ -42,12 +42,14 @@ Label cardinality: `3 × 3 = 9 series`.
 | Label | Values |
 |-------|--------|
 | `cascade` | cascade profile name (bounded by `cascade.toml`, typically < 20) |
-| `strategy` | `failover`, `capacity_aware`, `weighted_random`, `circuit_breaker_cycling`, `priority_tier`, `sticky`, `round_robin` |
+| `strategy` | configured runtime: `failover`, `priority_tier`; internal/historical kinds may also render as `capacity_aware`, `weighted_random`, `circuit_breaker_cycling`, `sticky`, `round_robin` |
 | `kind` | `ordered`, `filtered_empty`, `exhausted` |
 
 Incremented from `Cascade_strategy_trace.record`. One event per cycle iteration of `cycle_loop`. `exhausted` is the terminal variant — cascade gave up after `max_cycles` without a successful provider pick.
 
-Label cardinality: `≈ 20 × 7 × 3 = 420 series` upper bound.
+Configured runtime label cardinality: `≈ 20 × 2 × 3 = 120 series`. The
+internal strategy enum still has seven values, so the defensive upper bound is
+`≈ 20 × 7 × 3 = 420 series`.
 
 Both counter names and label tuples are shared with the JSON projection + dashboard card, so Grafana queries join cleanly with the same identifiers that operators see.
 

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -421,17 +421,18 @@ keeper-assignable = false
 ### 7.4 Pluggable Strategy (Phase A~B, #7606/#7611)
 
 각 `tier` 또는 `tier-group`은 `strategy` 키로 provider 선택 전략을
-지정한다. 미설정 시 `failover`로 동작한다.
+지정한다. 미설정 시 `failover`로 동작한다. Operator config에서
+지원되는 strategy 값은 현재 `failover`, `priority_tier` 두 개뿐이다.
 
 | 전략 | 키 값 | 설명 |
 |------|-------|------|
 | S1 Failover | `failover` | members 입력 순서 유지 |
-| S2 Capacity-aware | `capacity_aware` | endpoint capacity == 0인 provider 필터링, cycle 반복 |
-| S3 Weighted random | `weighted_random` | `config_weight × success_rate` 기반 가중 셔플 |
-| S4 Circuit-breaker cycling | `circuit_breaker_cycling` | S2 + `is_in_cooldown` 제외 + exponential backoff |
 | S5 Priority tier | `priority_tier` | tier-group의 `tiers` 순서대로 fallback |
-| S6 Sticky | `sticky` | `(keeper, profile)` 단위로 첫 성공 provider를 TTL 동안 고정 |
-| S7 Round-robin | `round_robin` | profile cursor 기반 회전 |
+
+`capacity_aware`, `weighted_random`, `circuit_breaker_cycling`, `sticky`,
+`round_robin` 구현은 내부/과거 strategy 코드와 테스트를 위해 남아 있지만
+shipped `cascade.toml` config boundary에서는 거부된다. 실제 runtime seed/profile이
+생기기 전까지 operator config의 허용 목록에 추가하지 않는다.
 
 관련 선언형 키:
 

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -603,7 +603,7 @@ let validate_strategy ~config_path ~name =
     match cfg.kind with
     | None -> []
     | Some raw_kind -> (
-        match Cascade_strategy.parse_kind raw_kind with
+        match Cascade_strategy.parse_config_kind raw_kind with
         | Error msg ->
             [
               Printf.sprintf

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -1346,7 +1346,7 @@ let default_strategy_kind ?config_path ~name () =
 let parse_kind_or_default ~name ~default_kind = function
   | None -> default_kind
   | Some raw ->
-    match Cascade_strategy.parse_kind raw with
+    match Cascade_strategy.parse_config_kind raw with
     | Ok k -> k
     | Error msg ->
       warn_unknown_strategy ~name ~raw ~msg ~fallback_kind:default_kind;

--- a/lib/cascade/cascade_strategy.ml
+++ b/lib/cascade/cascade_strategy.ml
@@ -368,6 +368,8 @@ let all_kinds = [
 
 let valid_kind_strings = List.map kind_to_string all_kinds
 
+let config_kind_strings = [ "failover"; "priority_tier" ]
+
 let parse_kind = function
   | "failover" -> Ok Failover
   | "capacity_aware" -> Ok Capacity_aware
@@ -380,6 +382,22 @@ let parse_kind = function
     Error (Printf.sprintf
              "unknown cascade strategy %S (expected one of: %s)"
              other (String.concat ", " valid_kind_strings))
+
+let parse_config_kind raw =
+  match parse_kind raw with
+  | Error _ ->
+    Error
+      (Printf.sprintf
+         "unsupported cascade config strategy %S (expected one of: %s)"
+         raw (String.concat ", " config_kind_strings))
+  | Ok ((Failover | Priority_tier) as kind) -> Ok kind
+  | Ok kind ->
+    Error
+      (Printf.sprintf
+         "unsupported cascade config strategy %S (expected one of: %s); \
+          %s is retained for internal strategy tests only"
+         raw (String.concat ", " config_kind_strings)
+         (kind_to_string kind))
 
 let default_sticky_ttl_ms = 300_000
 

--- a/lib/cascade/cascade_strategy.mli
+++ b/lib/cascade/cascade_strategy.mli
@@ -257,11 +257,19 @@ val all_kinds : kind list
 (** All [kind] constructors in declaration order.  Adding a new
     constructor forces compile errors in [kind_to_string] (which
     powers [valid_kind_strings] used by the [parse_kind] error
-    message), so the operator-visible "expected one of" list stays
-    in sync automatically.  Issue #8603. *)
+    message), so the internal "expected one of" list stays in sync
+    automatically.  Issue #8603. *)
 
 val valid_kind_strings : string list
 (** Wire-format names for {!all_kinds}, derived via {!kind_to_string}. *)
+
+val config_kind_strings : string list
+(** Strategy names accepted from operator cascade configuration.
+
+    Only [failover] and [priority_tier] are currently supported at the
+    config boundary.  The other constructors remain available for internal
+    tests and historical strategy code, but must not be accepted from
+    [cascade.toml] until the runtime has an active seed/profile using them. *)
 
 val parse_kind : string -> (kind, string) result
 (** [parse_kind s] returns [Ok kind] for known names, [Error msg] for
@@ -269,6 +277,11 @@ val parse_kind : string -> (kind, string) result
     so it stays in sync with the variant.  Callers should warn-and-fallback
     to [Failover] rather than raise, to keep keeper startup resilient to
     config typos. *)
+
+val parse_config_kind : string -> (kind, string) result
+(** [parse_config_kind s] is the stricter parser for operator-provided
+    cascade configuration.  It rejects strategy constructors that still
+    exist in code but are not supported by the shipped cascade config. *)
 
 (** {1 Strategy value} *)
 

--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -549,17 +549,11 @@ let parse_bindings_and_aliases (toml : Otoml.t)
 let strategy_of_string (s : string) : (cascade_strategy, string) result =
   match s with
   | "failover" -> Ok Failover
-  | "capacity_aware" -> Ok Capacity_aware
-  | "weighted_random" -> Ok Weighted_random
-  | "circuit_breaker_cycling" -> Ok Circuit_breaker_cycling
   | "priority_tier" -> Ok Priority_tier
-  | "sticky" -> Ok Sticky
-  | "round_robin" -> Ok Round_robin
   | _ ->
     Error
       (Printf.sprintf
-         "unknown strategy %S: expected one of failover, capacity_aware, \
-          weighted_random, circuit_breaker_cycling, priority_tier, sticky, round_robin"
+         "unsupported strategy %S: expected one of failover, priority_tier"
          s)
 ;;
 

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -131,6 +131,7 @@ let default_room_signal_prompt_enabled = false
 let default_goal_horizon_max_chars = 480
 let default_drift_max_clauses = 6
 let prompt_render_max_bytes = 320
+let legacy_provider_filter_name = "allowed_providers"
 
 let keeper_room_signal_prompt_enabled_override () =
   bool_of_env_opt "MASC_KEEPER_ROOM_SIGNAL_PROMPT_ENABLED"
@@ -141,7 +142,7 @@ let removed_keeper_input_key_names =
     "models";
     "allowed_models";
     "active_model";
-    Keeper_types.legacy_provider_filter_name;
+    legacy_provider_filter_name;
     "presence_keepalive";
     "presence_keepalive_sec";
     "trigger_mode";

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -63,6 +63,7 @@ val approval_queue_stale_max_wait_sec : float
 val default_room_signal_prompt_enabled : bool
 val default_goal_horizon_max_chars : int
 val default_drift_max_clauses : int
+val legacy_provider_filter_name : string
 
 (** Maximum bytes of personality text included in the rendered keeper prompt.
     Drives [normalize_self_model_text] when called from prompt rendering.

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -336,10 +336,10 @@ let resolve_after_turn_model ~keeper_name
     runtime_lane_label
   end else begin
     if is_runtime_selector_alias raw_model then (
+      let source_telemetry_canonical = "telemetry_canonical" in
       Prometheus.inc_counter alias_response_model_metric
         ~labels:
           [
-            let source_telemetry_canonical = "telemetry_canonical" in
             ("keeper", keeper_name);
             ("alias", runtime_lane_label);
             ("source", source_telemetry_canonical);
@@ -739,7 +739,7 @@ let assemble_cost_event_payload
       ~output_tokens
       ~cost_usd
   in
-  let default_safe_cost_usd = 0.0
+  let default_safe_cost_usd = 0.0 in
   let safe_cost_usd =
     match cost_status with
     | Cost_reported -> cost_usd
@@ -788,6 +788,7 @@ let assemble_cost_event_payload
     classify_cost_usd_source ~usage_missing ~usage_trusted
       ~runtime_unmetered ~cost_usd
   in
+  let source_auto_trajectory = "auto_trajectory" in
   let entry = `Assoc ([
     ("agent", `String agent_name);
     ("task_id", Json_util.string_opt_to_json task_id);
@@ -802,7 +803,6 @@ let assemble_cost_event_payload
     ("cost_usd_source", `String cost_usd_source);
     ("usage_missing", `Bool usage_missing);
     ("timestamp", `String (Masc_domain.now_iso ()));
-    let source_auto_trajectory = "auto_trajectory" in
     ("source", `String source_auto_trajectory);
   ]
   @ Keeper_usage_trust.json_fields usage_trust

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -102,4 +102,4 @@ type session_context =
   ; mutable checkpoints : checkpoint list
   }
 
-let legacy_provider_filter_name = "allowed_providers"
+let legacy_provider_filter_name = Keeper_config.legacy_provider_filter_name

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -240,6 +240,7 @@ let make_health_json ?(listener = "http/1.1") request =
     else if keeper_config_unknown_key_count > 0 then "config_unknown_keys"
     else "none"
   in
+  let key_paused_keepers = "paused_keepers" in
   Tool_args.ok_assoc [
     ("server", `String "masc-mcp");
     ("version", `String build.release_version);
@@ -280,7 +281,6 @@ let make_health_json ?(listener = "http/1.1") request =
        but ops still need a quick count without scraping /metrics. List names
        so an operator can correlate with the cause encoded in their
        last_blocker_class. *)
-    let key_paused_keepers = "paused_keepers" in
     (key_paused_keepers, paused_keepers_health_json ());
     ("keeper_config_parse_error_count",
      `Int keeper_config_parse_error_count);

--- a/test/test_cascade_declarative_adapter.ml
+++ b/test/test_cascade_declarative_adapter.ml
@@ -695,29 +695,9 @@ api-name = "claude-haiku-4-5-20251001"
 members = ["claude_code.haiku"]
 strategy = "failover"
 
-[tier.capacity-t]
-members = ["claude_code.haiku"]
-strategy = "capacity_aware"
-
-[tier.weighted-t]
-members = ["claude_code.haiku"]
-strategy = "weighted_random"
-
-[tier.circuit-t]
-members = ["claude_code.haiku"]
-strategy = "circuit_breaker_cycling"
-
 [tier.priority-t]
 members = ["claude_code.haiku"]
 strategy = "priority_tier"
-
-[tier.sticky-t]
-members = ["claude_code.haiku"]
-strategy = "sticky"
-
-[tier.round-robin-t]
-members = ["claude_code.haiku"]
-strategy = "round_robin"
 |}
   in
   let catalog = adapt_toml toml in
@@ -739,121 +719,7 @@ strategy = "round_robin"
       profile.strategy.Cascade_strategy.kind
   in
   check_kind "tier.failover-t" Cascade_strategy.Failover;
-  check_kind "tier.capacity-t" Cascade_strategy.Capacity_aware;
-  check_kind "tier.weighted-t" Cascade_strategy.Weighted_random;
-  check_kind "tier.circuit-t" Cascade_strategy.Circuit_breaker_cycling;
-  check_kind "tier.priority-t" Cascade_strategy.Priority_tier;
-  check_kind "tier.sticky-t" Cascade_strategy.Sticky;
-  check_kind "tier.round-robin-t" Cascade_strategy.Round_robin
-;;
-
-(* --- Cycle policy passthrough --- *)
-
-let test_cycle_policy () =
-  let toml =
-    {|
-[providers.claude_code]
-protocol = "anthropic-cli"
-command = "claude"
-
-[models.haiku]
-max-context = 200000
-api-name = "claude-haiku-4-5-20251001"
-
-[claude_code.haiku]
-
-[tier.cycling-t]
-members = ["claude_code.haiku"]
-strategy = "circuit_breaker_cycling"
-max-cycles = 5
-backoff-base-ms = 1000
-backoff-cap-ms = 30000
-|}
-  in
-  let catalog = adapt_toml toml in
-  no_errors catalog.errors;
-  let profile =
-    List.find (fun (p : adapted_profile) -> p.name = "tier.cycling-t") catalog.profiles
-  in
-  let cp = profile.strategy.Cascade_strategy.cycle in
-  check int "max_cycles" 5 cp.Cascade_strategy.max_cycles;
-  check int "backoff_base_ms" 1000 cp.Cascade_strategy.backoff_base_ms;
-  check int "backoff_cap_ms" 30000 cp.Cascade_strategy.backoff_cap_ms
-;;
-
-(* --- Scoring params passthrough --- *)
-
-let test_scoring_params () =
-  let toml =
-    {|
-[providers.claude_code]
-protocol = "anthropic-cli"
-command = "claude"
-
-[models.haiku]
-max-context = 200000
-api-name = "claude-haiku-4-5-20251001"
-
-[claude_code.haiku]
-
-[tier.scored-t]
-members = ["claude_code.haiku"]
-strategy = "weighted_random"
-latency-baseline-ms = 300.0
-rate-limit-recency-window-s = 120.0
-rate-limit-decay-base = 0.7
-rate-limit-skip-after = 5
-server-error-recency-window-s = 240.0
-server-error-decay-base = 0.4
-server-error-skip-after = 8
-|}
-  in
-  let catalog = adapt_toml toml in
-  no_errors catalog.errors;
-  let profile =
-    List.find (fun (p : adapted_profile) -> p.name = "tier.scored-t") catalog.profiles
-  in
-  let sp = profile.strategy.Cascade_strategy.scoring in
-  check
-    (Alcotest.float 0.001)
-    "latency_baseline_ms"
-    300.0
-    sp.Cascade_strategy.latency_baseline_ms;
-  check
-    (Alcotest.float 0.001)
-    "rate_limit_decay_base"
-    0.7
-    sp.Cascade_strategy.rate_limit_decay_base;
-  check int "rate_limit_skip_after" 5 sp.Cascade_strategy.rate_limit_skip_after
-;;
-
-(* --- Sticky TTL --- *)
-
-let test_sticky_ttl () =
-  let toml =
-    {|
-[providers.claude_code]
-protocol = "anthropic-cli"
-command = "claude"
-
-[models.haiku]
-max-context = 200000
-api-name = "claude-haiku-4-5-20251001"
-
-[claude_code.haiku]
-
-[tier.sticky-t]
-members = ["claude_code.haiku"]
-strategy = "sticky"
-sticky-ttl-ms = 600000
-|}
-  in
-  let catalog = adapt_toml toml in
-  no_errors catalog.errors;
-  let profile =
-    List.find (fun (p : adapted_profile) -> p.name = "tier.sticky-t") catalog.profiles
-  in
-  check int "sticky_ttl_ms" 600000 profile.strategy.Cascade_strategy.sticky_ttl_ms
+  check_kind "tier.priority-t" Cascade_strategy.Priority_tier
 ;;
 
 (* --- Multiple errors accumulated --- *)
@@ -1030,11 +896,7 @@ let () =
         ; test_case "duplicate routes" `Quick test_duplicate_routes
         ] )
     ; ( "strategy"
-      , [ test_case "all 7 variants" `Quick test_strategy_mapping
-        ; test_case "cycle policy" `Quick test_cycle_policy
-        ; test_case "scoring params" `Quick test_scoring_params
-        ; test_case "sticky ttl" `Quick test_sticky_ttl
-        ] )
+      , [ test_case "supported variants" `Quick test_strategy_mapping ] )
     ; "edge_cases", [ test_case "empty tier-group" `Quick test_empty_tier_group ]
     ]
 ;;

--- a/test/test_cascade_declarative_parser.ml
+++ b/test/test_cascade_declarative_parser.ml
@@ -506,15 +506,10 @@ let test_api_format_of_protocol () =
   check bool "unknown" true (api_format_of_protocol "unknown" |> Result.is_error)
 ;;
 
-let test_all_strategies_parse () =
+let test_supported_config_strategies_parse () =
   let strategies =
     [ "failover", Failover
-    ; "capacity_aware", Capacity_aware
-    ; "weighted_random", Weighted_random
-    ; "circuit_breaker_cycling", Circuit_breaker_cycling
     ; "priority_tier", Priority_tier
-    ; "sticky", Sticky
-    ; "round_robin", Round_robin
     ]
   in
   List.iter
@@ -549,6 +544,42 @@ strategy = "%s"
     strategies
 ;;
 
+let test_retired_config_strategies_rejected () =
+  let retired =
+    [
+      "capacity_aware";
+      "weighted_random";
+      "circuit_breaker_cycling";
+      "sticky";
+      "round_robin";
+    ]
+  in
+  List.iter
+    (fun name ->
+       let toml =
+         Printf.sprintf
+           {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[p.m]
+
+[tier.t]
+members = ["p.m"]
+strategy = "%s"
+|}
+           name
+       in
+       match parse_string toml with
+       | Ok _ -> failwith ("expected retired strategy rejection: " ^ name)
+       | Error errs -> has_error_at "tier.t.strategy" errs)
+    retired
+;;
+
 (* --- Strategy-specific field tests --- *)
 
 let test_cycle_policy () =
@@ -565,7 +596,7 @@ max-context = 4096
 
 [tier.t]
 members = ["p.m"]
-strategy = "circuit_breaker_cycling"
+strategy = "failover"
 max-cycles = 3
 backoff-base-ms = 500
 backoff-cap-ms = 10000
@@ -620,7 +651,7 @@ max-context = 4096
 
 [tier.t]
 members = ["p.m"]
-strategy = "circuit_breaker_cycling"
+strategy = "failover"
 max-cycles = 3
 backoff-base-ms = 500
 |}
@@ -645,7 +676,7 @@ max-context = 4096
 
 [tier.t]
 members = ["p.m"]
-strategy = "sticky"
+strategy = "failover"
 sticky-ttl-ms = 600000
 |}
   in
@@ -669,7 +700,7 @@ max-context = 4096
 
 [tier.t]
 members = ["p.m"]
-strategy = "sticky"
+strategy = "failover"
 |}
   in
   let cfg = ok_config (parse_string toml) in
@@ -692,7 +723,7 @@ max-context = 4096
 
 [tier.t]
 members = ["p.m"]
-strategy = "weighted_random"
+strategy = "failover"
 latency-baseline-ms = 200.0
 rate-limit-recency-window-s = 60.0
 rate-limit-decay-base = 0.5
@@ -732,7 +763,7 @@ max-context = 4096
 
 [tier.t]
 members = ["p.m"]
-strategy = "weighted_random"
+strategy = "failover"
 latency-baseline-ms = 200.0
 rate-limit-recency-window-s = 60.0
 |}
@@ -1489,7 +1520,11 @@ let () =
         ; test_case "api_format_of_protocol" `Quick test_api_format_of_protocol
         ] )
     ; ( "strategies"
-      , [ test_case "all 7 strategies parse" `Quick test_all_strategies_parse ] )
+      , [ test_case "supported strategies parse" `Quick
+            test_supported_config_strategies_parse
+        ; test_case "retired strategies rejected" `Quick
+            test_retired_config_strategies_rejected
+        ] )
     ; ( "cycle_policy"
       , [ test_case "parses all-or-nothing" `Quick test_cycle_policy
         ; test_case "absent yields None" `Quick test_cycle_policy_absent

--- a/test/test_cascade_declarative_validator.ml
+++ b/test/test_cascade_declarative_validator.ml
@@ -26,6 +26,12 @@ let has_rule_at (rule : string) (path : string) (errs : validation_error list) =
 let no_errors (errs : validation_error list) =
   check int "no errors" 0 (List.length errs)
 
+let has_parse_error_at (path : string) (errs : parse_error list) =
+  check bool
+    ("has parse error at " ^ path)
+    true
+    (List.exists (fun (e : parse_error) -> e.path = path) errs)
+
 let validate_toml (toml : string) : validation_error list =
   match parse_string toml with
   | Ok cfg -> validate cfg
@@ -469,7 +475,7 @@ backoff-cap-ms = 10000
   let errs = validate_toml toml in
   has_rule_at "R10" "tier.t.cycle-policy" errs
 
-let test_r10_cycle_policy_on_correct_strategy () =
+let test_retired_cycle_policy_strategy_rejected_by_parser () =
   let toml = {|
 [providers.p]
 protocol = "anthropic-cli"
@@ -488,8 +494,9 @@ max-cycles = 3
 backoff-base-ms = 500
 backoff-cap-ms = 10000
 |} in
-  let errs = validate_toml toml in
-  no_errors errs
+  match parse_string toml with
+  | Ok _ -> Alcotest.fail "expected retired strategy to be rejected"
+  | Error errs -> has_parse_error_at "tier.t.strategy" errs
 
 let test_r10_sticky_ttl_on_wrong_strategy () =
   let toml = {|
@@ -511,7 +518,7 @@ sticky-ttl-ms = 600000
   let errs = validate_toml toml in
   has_rule_at "R10" "tier.t.sticky-ttl-ms" errs
 
-let test_r10_sticky_ttl_on_correct_strategy () =
+let test_retired_sticky_strategy_rejected_by_parser () =
   let toml = {|
 [providers.p]
 protocol = "anthropic-cli"
@@ -528,8 +535,9 @@ members = ["p.m"]
 strategy = "sticky"
 sticky-ttl-ms = 600000
 |} in
-  let errs = validate_toml toml in
-  no_errors errs
+  match parse_string toml with
+  | Ok _ -> Alcotest.fail "expected retired strategy to be rejected"
+  | Error errs -> has_parse_error_at "tier.t.strategy" errs
 
 let test_r10_scoring_on_wrong_strategy () =
   let toml = {|
@@ -557,7 +565,7 @@ server-error-skip-after = 5
   let errs = validate_toml toml in
   has_rule_at "R10" "tier.t.scoring-params" errs
 
-let test_r10_scoring_on_correct_strategy () =
+let test_retired_scoring_strategy_rejected_by_parser () =
   let toml = {|
 [providers.p]
 protocol = "anthropic-cli"
@@ -580,8 +588,9 @@ server-error-recency-window-s = 120.0
 server-error-decay-base = 0.3
 server-error-skip-after = 5
 |} in
-  let errs = validate_toml toml in
-  no_errors errs
+  match parse_string toml with
+  | Ok _ -> Alcotest.fail "expected retired strategy to be rejected"
+  | Error errs -> has_parse_error_at "tier.t.strategy" errs
 
 let test_r10_no_strategy_fields_is_ok () =
   let toml = {|
@@ -737,11 +746,14 @@ let () =
       ];
       "R10_strategy_fields", [
         test_case "cycle_policy on wrong strategy" `Quick test_r10_cycle_policy_on_wrong_strategy;
-        test_case "cycle_policy on correct strategy" `Quick test_r10_cycle_policy_on_correct_strategy;
+        test_case "retired cycle_policy strategy rejected" `Quick
+          test_retired_cycle_policy_strategy_rejected_by_parser;
         test_case "sticky_ttl on wrong strategy" `Quick test_r10_sticky_ttl_on_wrong_strategy;
-        test_case "sticky_ttl on correct strategy" `Quick test_r10_sticky_ttl_on_correct_strategy;
+        test_case "retired sticky strategy rejected" `Quick
+          test_retired_sticky_strategy_rejected_by_parser;
         test_case "scoring on wrong strategy" `Quick test_r10_scoring_on_wrong_strategy;
-        test_case "scoring on correct strategy" `Quick test_r10_scoring_on_correct_strategy;
+        test_case "retired scoring strategy rejected" `Quick
+          test_retired_scoring_strategy_rejected_by_parser;
         test_case "no strategy fields is ok" `Quick test_r10_no_strategy_fields_is_ok;
         test_case "multiple mismatches" `Quick test_r10_multiple_mismatches;
       ];

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -437,20 +437,65 @@ let test_parse_kind_known () =
   check_ok "weighted_random" S.Weighted_random;
   check_ok "circuit_breaker_cycling" S.Circuit_breaker_cycling
 
+let string_contains haystack needle =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  let rec loop i =
+    if i + nlen > hlen then false
+    else if String.sub haystack i nlen = needle then true
+    else loop (i + 1)
+  in
+  nlen = 0 || loop 0
+
 let test_parse_kind_unknown () =
   match S.parse_kind "round_robin_xx" with
   | Ok _ -> fail "expected Error for unknown kind"
   | Error msg ->
     check bool "error mentions the rejected name"
-      true (String.length msg > 0
-            && (let needle = "round_robin_xx" in
-                let nlen = String.length needle in
-                let hlen = String.length msg in
-                let rec loop i =
-                  if i + nlen > hlen then false
-                  else if String.sub msg i nlen = needle then true
-                  else loop (i + 1)
-                in loop 0))
+      true
+      (String.length msg > 0 && string_contains msg "round_robin_xx")
+
+let test_parse_config_kind_supported () =
+  check
+    (list string)
+    "config kind strings"
+    [ "failover"; "priority_tier" ]
+    S.config_kind_strings;
+  let check_ok s expected =
+    match S.parse_config_kind s with
+    | Ok k ->
+      check string ("parse config " ^ s) (S.kind_to_string expected) (S.kind_to_string k)
+    | Error msg -> fail (Printf.sprintf "expected Ok, got Error %s" msg)
+  in
+  check_ok "failover" S.Failover;
+  check_ok "priority_tier" S.Priority_tier
+
+let test_parse_config_kind_retired_rejected () =
+  let rejected =
+    [ "capacity_aware"
+    ; "weighted_random"
+    ; "circuit_breaker_cycling"
+    ; "sticky"
+    ; "round_robin"
+    ; "does_not_exist"
+    ]
+  in
+  List.iter
+    (fun raw ->
+       match S.parse_config_kind raw with
+       | Ok kind ->
+         fail
+           (Printf.sprintf
+              "expected Error for %s, got %s"
+              raw
+              (S.kind_to_string kind))
+       | Error msg ->
+         check
+           bool
+           ("config error mentions supported kinds for " ^ raw)
+           true
+           (string_contains msg "failover" && string_contains msg "priority_tier"))
+    rejected
 
 (* ── Cascade_client_capacity ─────────────────────────────────── *)
 
@@ -1221,6 +1266,9 @@ let () =
       test_case "known kinds parse" `Quick test_parse_kind_known;
       test_case "unknown kind returns Error with name" `Quick
         test_parse_kind_unknown;
+      test_case "config kinds parse" `Quick test_parse_config_kind_supported;
+      test_case "retired config kinds rejected" `Quick
+        test_parse_config_kind_retired_rejected;
     ];
     "client_capacity", [
       test_case "register + query" `Quick test_client_capacity_register_query;


### PR DESCRIPTION
## Summary
- restrict operator-provided cascade config strategies to `failover` and `priority_tier`
- keep retired/internal strategy constructors available for internal strategy tests, but reject them at cascade.toml/config boundaries
- repair latest `origin/main` build fallout from #15151 so this PR head can compile: Keeper_config dependency cycle plus two list-local `let` syntax issues

## Validation
- `ocamlformat --check` on touched OCaml files
- `git diff --check origin/main..HEAD`
- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_cascade_declarative_parser.exe test/test_cascade_declarative_validator.exe test/test_cascade_declarative_adapter.exe test/test_cascade_strategy.exe`
- `./_build/default/test/test_cascade_declarative_parser.exe` (60 tests)
- `./_build/default/test/test_cascade_declarative_validator.exe` (29 tests)
- `./_build/default/test/test_cascade_declarative_adapter.exe` (21 tests)
- `./_build/default/test/test_cascade_strategy.exe` (71 tests)

## Review Notes
- The build repair commit is intentionally separate from the cascade config commit because it is latest-main fallout, not cascade logic.