### PR TITLE
refactor(dashboard/ide): drop legacy -mock suffix on real-backend panels

### DIFF
--- a/dashboard/design-system/CHANGELOG.md
+++ b/dashboard/design-system/CHANGELOG.md
@@ -61,7 +61,7 @@ Stage: legacy alias cleanup + KeeperBadge migration completion + token codificat
 
 - **IDE INTERJECT store substrate**
   - `src/components/ide/interject-store.ts` adds typed active-keeper/message state for the INTERJECT rail and explicit availability reasons for Send/Approve/Pause/Drain actions.
-  - `src/components/ide/ide-interject-mock.ts` now consumes the store and `keeper-actions.ts` dispatch boundary instead of rendering a disabled placeholder form.
+  - `src/components/ide/ide-interject.ts` now consumes the store and `keeper-actions.ts` dispatch boundary instead of rendering a disabled placeholder form.
 
 - **IDE code document store substrate**
   - `src/components/ide/code-document-store.ts` adds a typed read-only source document store with file/language metadata, CRLF normalization, line lookup, and bounded line parsing.

--- a/dashboard/design-system/RFC/0022-ide-plane-assembly.md
+++ b/dashboard/design-system/RFC/0022-ide-plane-assembly.md
@@ -24,7 +24,7 @@
 `dashboard/src/components/ide/`에 30+ 파일이 wire-up 되어 있고 IDE plane 의 client-side 는 80%+ 완성 상태다. `ide-shell.ts` 가 root container, `IDE_LAYERS` 가 정의됨, `keeper-presence-store` 의 `workspace_label` 필드 contract 도 있다. 그러나:
 
 1. **server-side gap**: IDE plane 이 필요로 하는 데이터(worktree status, keeper shell ring buffer)를 노출하는 핸들러가 0건. `rg "worktree" lib/dashboard/` 가 0 hit.
-2. **mock fragments**: mockup 이 추가한 4 영역 중 일부는 still mock — `ide-activity-mock.ts`, `ide-conversation-rail-mock.ts`, `ide-interject-mock.ts`.
+2. **mock fragments**: mockup 이 추가한 4 영역 중 일부는 still mock — `ide-activity-mock.ts`, `ide-conversation-rail.ts`, `ide-interject.ts`.
 3. **producer wire-up gap**: RFC-0019/0020/0021 의 store contract 는 정의됐지만 producer-side handler / SSE 가 미작성.
 
 본 RFC 는 이 gap 을 5 sub-RFC (DS 0023–0026 + repo 0033) 로 분할하고, 각 sub-RFC 가 production PR sequence 로 어떻게 매핑되는지 우산으로 묶는다.

--- a/dashboard/src/components/ide/anchored-thread-trace-bridge.ts
+++ b/dashboard/src/components/ide/anchored-thread-trace-bridge.ts
@@ -8,7 +8,7 @@ import { pushTrace } from './keeper-trace-store'
  * new ones and return the updated set.
  *
  * Why a pure function (not a stateful subscription):
- *   - The owning component (`IdeConversationRailMock`) already has the
+ *   - The owning component (`IdeConversationRail`) already has the
  *     fetched `posts` array as a useState value. A pure mapper called
  *     from a `useEffect([posts])` is sufficient and trivially testable.
  *   - Avoids storing per-component state inside the trace store, which

--- a/dashboard/src/components/ide/cascade-hop-trace-bridge.ts
+++ b/dashboard/src/components/ide/cascade-hop-trace-bridge.ts
@@ -33,7 +33,7 @@ import { pushTrace } from './keeper-trace-store'
  *                discriminator and this surfaces it on the chip.)
  *
  * Why a pure function (not a stateful subscription):
- *   - The owning component (`IdeConversationRailMock`) already has the
+ *   - The owning component (`IdeConversationRail`) already has the
  *     fetched `cascadeEvents` array as a useState value. A pure mapper
  *     called from a `useEffect([cascadeEvents])` is sufficient and
  *     trivially testable.

--- a/dashboard/src/components/ide/decision-log-trace-bridge.ts
+++ b/dashboard/src/components/ide/decision-log-trace-bridge.ts
@@ -35,7 +35,7 @@ import { pushTrace } from './keeper-trace-store'
  *                     verbatim, or null for in-flight)
  *
  * Why a pure function (not a stateful subscription):
- *   - The owning component (`IdeConversationRailMock`) already has the
+ *   - The owning component (`IdeConversationRail`) already has the
  *     fetched `decisions` array as a useState value. A pure mapper
  *     called from a `useEffect([decisions])` is sufficient and trivially
  *     testable.

--- a/dashboard/src/components/ide/ide-conversation-rail.a11y.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.a11y.test.ts
@@ -3,9 +3,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { axe } from 'jest-axe'
-import { IdeConversationRailMock } from './ide-conversation-rail-mock'
+import { IdeConversationRail } from './ide-conversation-rail'
 
-describe('IdeConversationRailMock a11y', () => {
+describe('IdeConversationRail a11y', () => {
   let container: HTMLElement
 
   beforeEach(() => {
@@ -19,7 +19,7 @@ describe('IdeConversationRailMock a11y', () => {
   })
 
   it('renders the anchored thread rail mock accessibly', async () => {
-    render(html`<${IdeConversationRailMock} />`, container)
+    render(html`<${IdeConversationRail} />`, container)
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/dashboard/src/components/ide/ide-conversation-rail.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
 import { fireEvent, waitFor } from '@testing-library/preact'
-import { IdeConversationRailMock, postsToAnchoredThreads, replayRailItems } from './ide-conversation-rail-mock'
+import { IdeConversationRail, postsToAnchoredThreads, replayRailItems } from './ide-conversation-rail'
 import { activeIdeFile, ideContextFocus } from './ide-state'
 import { clearTraces, keeperTraceState } from './keeper-trace-store'
 
@@ -41,10 +41,10 @@ afterEach(() => {
   clearTraces()
 })
 
-describe('IdeConversationRailMock', () => {
+describe('IdeConversationRail', () => {
   it('renders the conversation rail with empty state when no API data', () => {
     const container = document.createElement('div')
-    render(h(IdeConversationRailMock, {}), container)
+    render(h(IdeConversationRail, {}), container)
 
     const region = container.querySelector('[role="region"]')
     expect(region?.getAttribute('aria-label')).toBe('REACTION THREAD')
@@ -234,7 +234,7 @@ describe('IdeConversationRailMock', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const container = document.createElement('div')
-    render(h(IdeConversationRailMock, {}), container)
+    render(h(IdeConversationRail, {}), container)
 
     await waitFor(() => {
       expect(container.textContent).toContain('new thread body')
@@ -281,7 +281,7 @@ describe('IdeConversationRailMock', () => {
     }))
 
     const container = document.createElement('div')
-    render(h(IdeConversationRailMock, {}), container)
+    render(h(IdeConversationRail, {}), container)
 
     await waitFor(() => {
       expect(container.textContent).toContain('question fn:run about this line')

--- a/dashboard/src/components/ide/ide-conversation-rail.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.ts
@@ -122,7 +122,7 @@ function boardKindFromPost(post: BoardPost): ThreadKind {
   return 'note'
 }
 
-export function IdeConversationRailMock() {
+export function IdeConversationRail() {
   const threadStore = useMemo(() => createAnchoredThreadRailStore(activeIdeFile.value), [])
   const [posts, setPosts] = useState<ReadonlyArray<BoardPost>>(EMPTY_POSTS)
   const [decisions, setDecisions] = useState<ReadonlyArray<KeeperDecision>>(EMPTY_DECISIONS)

--- a/dashboard/src/components/ide/ide-interject.a11y.test.ts
+++ b/dashboard/src/components/ide/ide-interject.a11y.test.ts
@@ -3,9 +3,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { axe } from 'jest-axe'
-import { IdeInterjectMock } from './ide-interject-mock'
+import { IdeInterject } from './ide-interject'
 
-describe('IdeInterjectMock a11y', () => {
+describe('IdeInterject a11y', () => {
   let container: HTMLElement
 
   beforeEach(() => {
@@ -19,7 +19,7 @@ describe('IdeInterjectMock a11y', () => {
   })
 
   it('renders the interject input and action rail accessibly', async () => {
-    render(html`<${IdeInterjectMock} />`, container)
+    render(html`<${IdeInterject} />`, container)
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/dashboard/src/components/ide/ide-interject.test.ts
+++ b/dashboard/src/components/ide/ide-interject.test.ts
@@ -4,10 +4,10 @@ import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { fireEvent } from '@testing-library/preact'
 import { activeKeeperName } from '../../keeper-state'
-import { IdeInterjectMock, interjectContextRouteLinks } from './ide-interject-mock'
+import { IdeInterject, interjectContextRouteLinks } from './ide-interject'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
 
-describe('IdeInterjectMock', () => {
+describe('IdeInterject', () => {
   beforeEach(() => {
     activeKeeperName.value = 'nick0cave'
   })
@@ -53,7 +53,7 @@ describe('IdeInterjectMock', () => {
   it('renders the interject store backed active keeper controls', async () => {
     const container = document.createElement('div')
     await act(async () => {
-      render(h(IdeInterjectMock, {}), container)
+      render(h(IdeInterject, {}), container)
     })
 
     const region = container.querySelector('[role="region"]')
@@ -78,7 +78,7 @@ describe('IdeInterjectMock', () => {
   it('enables Send after text is entered', async () => {
     const container = document.createElement('div')
     await act(async () => {
-      render(h(IdeInterjectMock, {}), container)
+      render(h(IdeInterject, {}), container)
     })
 
     const input = container.querySelector('input') as HTMLInputElement
@@ -97,7 +97,7 @@ describe('IdeInterjectMock', () => {
     activeKeeperName.value = ''
     const container = document.createElement('div')
     await act(async () => {
-      render(h(IdeInterjectMock, { keeperName: 'tech_glutton' }), container)
+      render(h(IdeInterject, { keeperName: 'tech_glutton' }), container)
     })
 
     expect(container.textContent).toContain('tech_glutton')
@@ -115,7 +115,7 @@ describe('IdeInterjectMock', () => {
   it('preserves typed message when the route keeper changes', async () => {
     const container = document.createElement('div')
     await act(async () => {
-      render(h(IdeInterjectMock, { keeperName: 'keeper-alpha' }), container)
+      render(h(IdeInterject, { keeperName: 'keeper-alpha' }), container)
     })
 
     const input = container.querySelector('input') as HTMLInputElement
@@ -125,7 +125,7 @@ describe('IdeInterjectMock', () => {
     })
 
     await act(async () => {
-      render(h(IdeInterjectMock, { keeperName: 'keeper-beta' }), container)
+      render(h(IdeInterject, { keeperName: 'keeper-beta' }), container)
     })
 
     expect(container.textContent).toContain('keeper-beta')
@@ -150,7 +150,7 @@ describe('IdeInterjectMock', () => {
 
     const container = document.createElement('div')
     await act(async () => {
-      render(h(IdeInterjectMock, { keeperName: 'sangsu' }), container)
+      render(h(IdeInterject, { keeperName: 'sangsu' }), container)
     })
 
     const contextButtons = [...container.querySelectorAll<HTMLButtonElement>('.ide-interject-context-links button')]

--- a/dashboard/src/components/ide/ide-interject.ts
+++ b/dashboard/src/components/ide/ide-interject.ts
@@ -28,7 +28,7 @@ async function dispatchInterject(request: InterjectDispatchRequest): Promise<voi
   })
 }
 
-interface IdeInterjectMockProps {
+interface IdeInterjectProps {
   readonly keeperName?: string | null
 }
 
@@ -37,7 +37,7 @@ function resolveActiveKeeper(keeperName?: string | null): string {
   return routeKeeper || activeKeeperName.value
 }
 
-export const IdeInterjectMock: FunctionComponent<IdeInterjectMockProps> = ({ keeperName = null }) => {
+export const IdeInterject: FunctionComponent<IdeInterjectProps> = ({ keeperName = null }) => {
   const [interjectStore] = useState(() =>
     createInterjectStore({
       initialActiveKeeper: resolveActiveKeeper(keeperName),

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -42,8 +42,8 @@ vi.mock('../../api/repositories', () => ({
   }])),
 }))
 
-vi.mock('./ide-conversation-rail-mock', () => ({
-  IdeConversationRailMock: () => null,
+vi.mock('./ide-conversation-rail', () => ({
+  IdeConversationRail: () => null,
 }))
 
 import { IdeShell } from './ide-shell'

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -4,10 +4,10 @@ import { activeIdeFile, focusIdeContextAnchor } from './ide-state'
 import { createIdeDataCoordinator } from './ide-data-coordinator'
 import { IdeExplorer } from './ide-explorer'
 import { IdeEditor, type IdeEditorView } from './ide-editor'
-import { IdeConversationRailMock } from './ide-conversation-rail-mock'
+import { IdeConversationRail } from './ide-conversation-rail'
 import { IdeActivityPanel } from './ide-activity-panel'
 import { IdeKeeperWorkPanel } from './ide-keeper-work-panel'
-import { IdeInterjectMock } from './ide-interject-mock'
+import { IdeInterject } from './ide-interject'
 import { KeeperShellDrawer } from './keeper-shell-drawer'
 import { IdePresenceStrip } from './ide-presence-strip'
 import { IDE_LAYERS, IdeToolbar } from './ide-toolbar'
@@ -320,7 +320,7 @@ export function IdeShell() {
               <${IdeKeeperWorkPanel} keeperName=${terminalKeeper} />
               <${IdePersistencePanel} keeperName=${terminalKeeper} />
               <${InspectorKeeperBDI} traceActive=${activeLayers.has('keeper-trace')} />
-              <${IdeConversationRailMock} />
+              <${IdeConversationRail} />
             </div>
           `}
         ${railsCollapsed
@@ -339,7 +339,7 @@ export function IdeShell() {
       ${terminalOpen
         ? html`<${KeeperShellDrawer} keeperName=${terminalKeeper} />`
         : null}
-      <${IdeInterjectMock} keeperName=${terminalKeeper} />
+      <${IdeInterject} keeperName=${terminalKeeper} />
     </section>
   `
 }


### PR DESCRIPTION
## Why

`ide-conversation-rail-mock.ts` / `ide-interject-mock.ts` 그리고 동반 클래스 `IdeConversationRailMock` / `IdeInterjectMock` 는 *legacy mockup 단계 명명*이 그대로 남아 있었습니다. 두 컴포넌트는 이미 real backend 와 연결되어 있습니다:

- `IdeConversationRail` → `fetch('/api/v1/board?limit=20&...')`, `fetchKeeperDecisions(200)`, `fetchCascadeStrategyTrace({limit:200})`
- `IdeInterject` → `interject-store` (real keeper-actions dispatch)

이 misleading naming 때문에 사용자가 dashboard 우측 panel 데이터를 *가짜* 로 의심하게 됩니다.

## What

Pure rename — 동작 변경 0:

- 6 file rename (각 컴포넌트의 `*.ts` / `*.test.ts` / `*.a11y.test.ts`)
- Class symbol rename: `IdeConversationRailMock` → `IdeConversationRail`, `IdeInterjectMock` → `IdeInterject`
- ide-shell.ts / ide-shell.test.ts import + JSX usage update
- anchored-thread-trace-bridge / cascade-hop-trace-bridge / decision-log-trace-bridge JSDoc 참조 갱신
- design-system/CHANGELOG.md, RFC/0022-ide-plane-assembly.md path 참조 갱신
- `ide-activity-mock` 은 origin/main 에서 이미 `ide-activity-panel` 로 rename 완료 — 이 PR scope 밖

## Test

- `tsc --noEmit`: changed paths clean (pre-existing `config/navigation.ts` 에러 1건은 origin/main 부터 존재)
- `vitest run` 영향 5 파일: **36/36 pass**
  - ide-conversation-rail.test.ts
  - ide-conversation-rail.a11y.test.ts
  - ide-interject.test.ts
  - ide-interject.a11y.test.ts
  - ide-shell.test.ts

## Diff stat

```
13 files changed, 32 insertions(+), 32 deletions(-)
```

## RFC

이 변경은 dashboard FE 의 순수 naming refactor — backend / credential / keeper subsystem 미터치. RFC discovery: `pr-rfc-check.sh` PASS (exit 0).

🤖 Generated with Claude Code
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>