### PR TITLE
feat(ide): link diagnostic anchors to routes

### DIFF
--- a/dashboard/src/components/ide/ide-context-lens.test.ts
+++ b/dashboard/src/components/ide/ide-context-lens.test.ts
@@ -268,6 +268,46 @@ describe('IdeContextLens', () => {
       line: 22,
       meta: 'warning / ocamllsp / code type',
     })
+    expect(model.anchors[0]?.route_links?.map(link => link.label)).toEqual(['Code', 'Telemetry'])
+    expect(model.anchors[0]?.route_links?.find(link => link.label === 'Code')).toMatchObject({
+      tab: 'code',
+      params: {
+        section: 'ide-shell',
+        view: 'source',
+        file: 'lib/keeper/keeper_exec_ide.ml',
+        line: '22',
+        surface: 'LSP',
+        label: 'This expression has type string but an int wa...',
+        source_id: 'diagnostic-22-ocamllsp-type-0',
+      },
+    })
+    expect(model.anchors[0]?.route_links?.find(link => link.label === 'Telemetry')).toMatchObject({
+      tab: 'monitoring',
+      params: {
+        section: 'fleet-health',
+        view: 'event-log',
+        q: 'ocamllsp type',
+      },
+      evidence: 'Fleet telemetry event log · query ocamllsp type',
+    })
+  })
+
+  it('keeps diagnostic telemetry routes quiet without source metadata', () => {
+    const model = deriveIdeContextLens({
+      filePath: 'lib/keeper/keeper_exec_ide.ml',
+      annotations: [],
+      diagnostics: [{
+        file_path: 'lib/keeper/keeper_exec_ide.ml',
+        line: 22,
+        severity: 1,
+        message: 'Missing semicolon.',
+      }],
+      diffRows: [],
+      events: [],
+      overlay: { ...overlay, cursors: new Map() },
+    })
+
+    expect(model.anchors[0]?.route_links?.map(link => link.label)).toEqual(['Code'])
   })
 
   it('omits invalid annotation lines from anchors and focus state', () => {

--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -494,17 +494,30 @@ function buildAnchors(
   const anchors: IdeContextAnchor[] = []
 
   for (const [index, diagnostic] of diagnostics.slice(0, 2).entries()) {
+    const line = positiveLine(diagnostic.line)
+    const label = truncate(diagnostic.message || 'diagnostic', 48)
+    const sourceId = `diagnostic-${diagnostic.line}-${diagnostic.source ?? 'lsp'}-${diagnostic.code ?? 'message'}-${index}`
+    const telemetryQuery = diagnosticTelemetryQuery(diagnostic)
     anchors.push({
-      id: `diagnostic-${diagnostic.line}-${diagnostic.source ?? 'lsp'}-${diagnostic.code ?? 'message'}-${index}`,
+      id: sourceId,
       file_path: diagnostic.file_path,
       surface: 'LSP',
-      label: truncate(diagnostic.message || 'diagnostic', 48),
+      label,
       meta: compactMeta([
         diagnosticSeverityLabel(diagnostic.severity),
         diagnostic.source ?? null,
         diagnostic.code !== undefined ? `code ${diagnostic.code}` : null,
       ]),
-      line: positiveLine(diagnostic.line),
+      line,
+      route_links: routeLinksForContext({
+        filePath: diagnostic.file_path,
+        line,
+        surface: 'LSP',
+        label,
+        sourceId,
+        telemetry: telemetryQuery !== undefined,
+        telemetryQuery,
+      }),
     })
   }
 
@@ -725,6 +738,16 @@ function diagnosticSeverityLabel(severity: number | undefined): string {
   if (severity === 3) return 'info'
   if (severity === 4) return 'hint'
   return 'diagnostic'
+}
+
+function diagnosticTelemetryQuery(diagnostic: IdeContextDiagnostic): string | undefined {
+  const parts = [
+    diagnostic.source,
+    diagnostic.code === undefined ? undefined : String(diagnostic.code),
+  ]
+    .map(part => part?.trim())
+    .filter((part): part is string => Boolean(part))
+  return parts.length > 0 ? parts.join(' ') : undefined
 }
 
 function eventContextMeta(event: RunActivityEvent): string {

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -176,7 +176,7 @@ describe('monitoring navigation labels', () => {
     const sections = sectionItemsForTab('monitoring')
     const hiddenIds = sections.filter(item => item.hidden).map(item => item.id)
 
-    expect(hiddenIds).toEqual(['journey', 'observatory', 'cognition'])
+    expect(hiddenIds).toEqual(['journey', 'observatory', 'cognition', 'memory-subsystems'])
   })
 
   it('monitoring sidebar labels are unique (no overloaded term like "런타임")', () => {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -20,6 +20,7 @@ type SurfaceSectionId =
   | 'runtime'
   | 'goal-loop'
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
+  | 'memory-subsystems' // Legacy redirect target (cognition > memory tab)
   // command
   | 'operations'     // Phase 1+6: absorbs intervene + governance + inspector (Phase 7: connectors split out)
   // connectors (Phase 7: top-level surface — sidecar-driven channel bridges)


### PR DESCRIPTION
## Summary
- add Code route links to LSP diagnostic anchors in the IDE context lens
- add telemetry event-log links when diagnostics include source/code metadata
- keep source-less diagnostics Code-only so the panel does not emit noisy telemetry queries

Stacked on #15197 (`fix/memory-subsystems-type-20260514`) so the review diff stays focused while the dashboard baseline fix finishes CI. Retarget to `main` after #15197 lands.

## Verification
- git diff --check origin/fix/memory-subsystems-type-20260514...HEAD
- pnpm exec eslint src/components/ide/ide-context-lens.ts src/components/ide/ide-context-lens.test.ts
- pnpm exec vitest run src/components/ide/ide-context-lens.test.ts
- pnpm exec tsc --noEmit --pretty false