### PR TITLE
fix(gate): scope timestamp coverage to sampled turns (follow-up #15161)

### DIFF
--- a/scripts/keeper-production-readiness-gate.py
+++ b/scripts/keeper-production-readiness-gate.py
@@ -378,9 +378,6 @@ def evaluate(
         keeper_metrics(manifest_keeper).manifest_files += 1
         for row in iter_jsonl(manifest):
             metrics.manifest_rows += 1
-            metrics.timestamp_rows += 1
-            if parse_ts(row.get("ts")) is not None:
-                metrics.parseable_timestamp_rows += 1
             keeper = str(row.get("keeper_name") or manifest.parent.parent.name)
             trace = str(row.get("trace_id") or manifest.stem)
             generation_value = row.get("generation")
@@ -413,6 +410,10 @@ def evaluate(
         }
 
     for (keeper, _trace, _generation, _turn), rows in selected_rows_by_turn.items():
+        for row in rows:
+            metrics.timestamp_rows += 1
+            if parse_ts(row.get("ts")) is not None:
+                metrics.parseable_timestamp_rows += 1
         if not event_rows(rows, "turn_finished"):
             continue
         keeper_metric = keeper_metrics(keeper)


### PR DESCRIPTION
## Summary
Follow-up to **#15161** addressing the P1 review thread from `chatgpt-codex-connector` on `scripts/keeper-production-readiness-gate.py:383`.

### Bug
When `max_turns_per_keeper > 0`, `evaluate` samples the latest N terminal turns per keeper into `selected_rows_by_turn`, but `metrics.timestamp_rows` and `metrics.parseable_timestamp_rows` were already accumulated for **all** manifest rows during the discovery loop (`metrics.timestamp_rows += 1` on every iter_jsonl row). A single bad `ts` in a stale historical turn would drop `timestamp_coverage_pct` below threshold even when every sampled turn was clean — false negative in the 3-turn fleet workflow that `scripts/harness/workload/agent_swarm_live.sh` defaults to.

### Fix
Move the timestamp counter into the iteration over `selected_rows_by_turn`. Coverage is now computed against the same row set the gate's turn-level judgements use. 4 lines changed; no API surface or threshold change.

## Validation
- AST parse OK
- Standalone smoke (`/tmp/test_15161_smoke.py`): manifest with 1 stale garbage-ts row + 3 parseable recent turns, `max_turns_per_keeper=3` → `timestamp_rows=3`, `parseable_timestamp_rows=3`, `terminal_turns=3`. Stale row excluded as expected.

## Trade-offs
- Counters now reflect *what the gate actually graded*, not raw input volume. If an operator wants raw-input coverage as a separate signal, that's a new metric, not a re-merge of the two semantics.
- No new metric added; no telemetry-as-fix.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>