### PR TITLE
fix(cascade): keep provider prefixes behind adapter helpers

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -886,7 +886,7 @@ let materialized_provider_endpoint json provider_id =
 
 let direct_provider_cascade_prefix provider_id =
   match Provider_adapter.resolve_adapter_by_cascade_prefix provider_id with
-  | Some adapter -> Some adapter.Provider_adapter.cascade_prefix
+  | Some adapter -> Some (Provider_adapter.cascade_prefix_of_adapter adapter)
   | None ->
     Provider_adapter.resolve_adapter_by_cascade_prefix
       (normalize_decl_provider_id provider_id)

--- a/lib/cascade/cascade_declarative_adapter.ml
+++ b/lib/cascade/cascade_declarative_adapter.ml
@@ -50,11 +50,11 @@ let err (e : adapter_error) : adapter_error list = [ e ]
 
 let resolve_provider_prefix (provider_id : string) : string option =
   match Provider_adapter.resolve_adapter_by_cascade_prefix provider_id with
-  | Some adapter -> Some adapter.Provider_adapter.cascade_prefix
+  | Some adapter -> Some (Provider_adapter.cascade_prefix_of_adapter adapter)
   | None ->
     let normalized = normalize_id provider_id in
     match Provider_adapter.resolve_adapter_by_cascade_prefix normalized with
-    | Some adapter -> Some adapter.Provider_adapter.cascade_prefix
+    | Some adapter -> Some (Provider_adapter.cascade_prefix_of_adapter adapter)
     | None -> None
 
 let find_provider (cfg : cascade_config) (provider_id : string) :

--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -93,6 +93,12 @@ let default_resolution ?getenv provider_name ~requested_model_id =
   | None -> unresolved_auto requested_model_id
 ;;
 
+let cascade_prefix_of_canonical_provider canonical_name =
+  Provider_adapter.resolve_direct_adapter canonical_name
+  |> Option.map Provider_adapter.cascade_prefix_of_adapter
+  |> Option.value ~default:canonical_name
+;;
+
 (** Default GLM auto-cascade order: quality-first, then speed.
     glm-5.1 = best quality (reasoning), glm-5-turbo = fast tool calling,
     glm-4.7 = stable general, glm-4.7-flashx = fastest/cheapest.
@@ -107,7 +113,12 @@ let resolve_glm_model ?getenv selector =
     | Concrete s -> s
     | Auto -> "auto"
   in
-  let default_model = default_resolution ?getenv "glm" ~requested_model_id:model_id in
+  let default_model =
+    default_resolution
+      ?getenv
+      (cascade_prefix_of_canonical_provider Provider_adapter.cn_glm)
+      ~requested_model_id:model_id
+  in
   let resolved_model_id =
     Llm_provider.Zai_catalog.resolve_glm_alias
       ~default_model:default_model.resolved_model_id
@@ -128,7 +139,10 @@ let resolve_glm_coding_model ?getenv selector =
     | Auto -> "auto"
   in
   let default_model =
-    default_resolution ?getenv "glm-coding" ~requested_model_id:model_id
+    default_resolution
+      ?getenv
+      (cascade_prefix_of_canonical_provider Provider_adapter.cn_glm_coding_plan)
+      ~requested_model_id:model_id
   in
   let resolved_model_id =
     Llm_provider.Zai_catalog.resolve_glm_coding_alias

--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -138,12 +138,14 @@ let runtime_label_for_active_id ~configured_labels ~active =
              (match List.find_opt matches_provider configured_labels with
               | Some label -> label
               | None ->
-                  let runtime_id =
-                    match adapter.default_model_id with
-                    | Some value when String.trim value <> "" -> value
-                    | _ -> "auto"
-                  in
-                  adapter.cascade_prefix ^ ":" ^ runtime_id)
+                let runtime_id =
+                  match adapter.default_model_id with
+                  | Some value when String.trim value <> "" -> value
+                  | _ -> "auto"
+                in
+                let prefix = Provider_adapter.cascade_prefix_of_adapter adapter in
+                Provider_adapter.provider_model_label prefix runtime_id
+                |> Option.value ~default:active)
          | None -> active)
 
 let runtime_health_key_of_label label =

--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -101,6 +101,9 @@ let record_codex_cli_omission_for_agent
       ~(tools : string list)
   : unit
   =
+  let provider_label =
+    Provider_adapter.cascade_prefix_of_provider_kind Llm_provider.Provider_config.Codex_cli
+  in
   match tools with
   | [] -> ()
   | _ ->
@@ -108,7 +111,7 @@ let record_codex_cli_omission_for_agent
       (fun tool ->
          Prometheus.inc_counter
            Prometheus.metric_provider_mcp_tool_omission
-           ~labels:[ "provider", "codex_cli"; "tool", tool ]
+           ~labels:[ "provider", provider_label; "tool", tool ]
            ())
       tools;
     let tool_fingerprint = codex_cli_omission_fingerprint tools in
@@ -120,9 +123,10 @@ let record_codex_cli_omission_for_agent
         "codex_cli omitting keeper-bound runtime MCP tool(s) that require request-scoped \
          auth headers: %s (no per-keeper bearer-token lane available for %s; subsequent \
          omissions of this same set are counted in \
-         masc_provider_mcp_tool_omission_total{provider=\"codex_cli\"} and not re-logged)"
+         masc_provider_mcp_tool_omission_total{provider=\"%s\"} and not re-logged)"
         (String.concat ", " (List.sort String.compare tools))
         agent_name_key
+        provider_label
 ;;
 
 let record_codex_cli_omission ~(tools : string list) : unit =

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -362,7 +362,14 @@ let response_text_of_api_response (response : Agent_sdk.Types.api_response) =
 let provider_label_for_model provider model =
   match Provider_adapter.resolve_direct_adapter provider with
   | Some adapter ->
-    Ok (Provider_adapter.cascade_prefix_of_adapter adapter ^ ":" ^ model)
+    let prefix = Provider_adapter.cascade_prefix_of_adapter adapter in
+    (match Provider_adapter.provider_model_label prefix model with
+     | Some label -> Ok label
+     | None ->
+       Error
+         (Printf.sprintf
+            "Missing model for dashboard single-agent provider '%s'"
+            provider))
   | None ->
     Error
       (Printf.sprintf

--- a/test/dune
+++ b/test/dune
@@ -1371,3 +1371,8 @@
  (name test_tool_descriptors_gen)
  (modules test_tool_descriptors_gen)
  (libraries masc_test_deps))
+
+(test
+ (name test_provider_prefix_boundary)
+ (modules test_provider_prefix_boundary)
+ (libraries alcotest))

--- a/test/test_provider_prefix_boundary.ml
+++ b/test/test_provider_prefix_boundary.ml
@@ -1,0 +1,139 @@
+(** Source-level guard for provider cascade-prefix ownership.
+
+    [Provider_adapter] is the boundary that owns provider prefix fields and
+    provider:model label construction. Other library modules should call its
+    helpers instead of reaching into the adapter record or rebuilding labels. *)
+
+let contains ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  if needle_len = 0
+  then true
+  else if needle_len > haystack_len
+  then false
+  else (
+    let rec loop idx =
+      if idx + needle_len > haystack_len
+      then false
+      else if String.equal (String.sub haystack idx needle_len) needle
+      then true
+      else loop (idx + 1)
+    in
+    loop 0)
+;;
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+;;
+
+let repo_root () =
+  let marker path = Filename.concat path "lib/provider_adapter.ml" in
+  let has_marker path = Sys.file_exists (marker path) in
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when has_marker root -> root
+  | _ ->
+    let rec ascend path =
+      if has_marker path
+      then path
+      else (
+        let parent = Filename.dirname path in
+        if String.equal parent path then path else ascend parent)
+    in
+    ascend (Sys.getcwd ())
+;;
+
+let is_directory path =
+  try Sys.is_directory path with
+  | Sys_error _ -> false
+;;
+
+let is_ocaml_source path =
+  Filename.check_suffix path ".ml" || Filename.check_suffix path ".mli"
+;;
+
+let rec ocaml_sources_under dir =
+  Sys.readdir dir
+  |> Array.to_list
+  |> List.concat_map (fun name ->
+    let path = Filename.concat dir name in
+    if is_directory path
+    then ocaml_sources_under path
+    else if is_ocaml_source path
+    then [ path ]
+    else [])
+;;
+
+let source_path root relative = Filename.concat root relative
+
+let relative_path ~root path =
+  let root_prefix = root ^ Filename.dir_sep in
+  let root_len = String.length root_prefix in
+  if String.length path >= root_len
+     && String.equal (String.sub path 0 root_len) root_prefix
+  then String.sub path root_len (String.length path - root_len)
+  else path
+;;
+
+let is_provider_adapter_source = function
+  | "lib/provider_adapter.ml" | "lib/provider_adapter.mli" -> true
+  | _ -> false
+;;
+
+let line_violation line =
+  if contains ~needle:".Provider_adapter.cascade_prefix" line
+  then Some "direct adapter record field access"
+  else if contains ~needle:".cascade_prefix ^" line
+  then Some "manual cascade_prefix label concatenation"
+  else if
+    contains ~needle:"Provider_adapter.cascade_prefix_of_adapter" line
+    && contains ~needle:"^" line
+  then Some "manual label concatenation after prefix helper"
+  else None
+;;
+
+let provider_prefix_boundary_has_no_external_leaks () =
+  let root = repo_root () in
+  let lib_dir = source_path root "lib" in
+  let violations =
+    ocaml_sources_under lib_dir
+    |> List.filter_map (fun path ->
+      let rel = relative_path ~root path in
+      if is_provider_adapter_source rel
+      then None
+      else (
+        read_file path
+        |> String.split_on_char '\n'
+        |> List.mapi (fun idx line ->
+          match line_violation line with
+          | Some reason -> Some (Printf.sprintf "%s:%d %s" rel (idx + 1) reason)
+          | None -> None)
+        |> List.filter_map Fun.id
+        |> function
+        | [] -> None
+        | xs -> Some xs))
+    |> List.concat
+  in
+  match violations with
+  | [] -> ()
+  | xs ->
+    Alcotest.failf
+      "provider prefix boundary leaks:\n%s"
+      (String.concat "\n" xs)
+;;
+
+let () =
+  Alcotest.run
+    "provider_prefix_boundary"
+    [
+      ( "source"
+      , [
+          Alcotest.test_case
+            "external modules use Provider_adapter prefix helpers"
+            `Quick
+            provider_prefix_boundary_has_no_external_leaks;
+        ] );
+    ]
+;;


### PR DESCRIPTION
## Summary
- route cascade prefix reads through Provider_adapter helpers outside the adapter SSOT
- stop rebuilding provider:model labels in cascade/dashboard call sites
- remove the glm/glm-coding model default lookup literals from cascade_model_resolve
- add a source-level guard that fails if lib/ modules reach into adapter.cascade_prefix or concatenate provider labels outside Provider_adapter

## Validation
- git diff --check origin/main...HEAD
- rg '\.Provider_adapter\.cascade_prefix|\.cascade_prefix \^|Provider_adapter\.cascade_prefix_of_adapter [^\n]*\^' lib -g '*.ml' -g '*.mli' (only Provider_adapter internals remain)
- ./_build/default/test/test_provider_prefix_boundary.exe
- GitHub Actions: check, ocamlformat-check, Hardcoded model prefix, PR Sync Check, PR Live Gate all passed; CI Gate still pending at last local check
