### PR TITLE
fix(dashboard): include filePath in overlay trace row key (follow-up #15162)

### DIFF
--- a/dashboard/src/components/ide/overlay-keeper-trace.test.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.test.ts
@@ -163,6 +163,22 @@ describe('OverlayKeeperTrace — bucket render (RFC-0028 §5)', () => {
     expect(lineLabels.some(t => t.includes('L30'))).toBe(true)
   })
 
+  it('renders sibling rows when same (keeper, line) buckets differ only by filePath', () => {
+    // Regression for PR #15162 P2: bucket key now includes filePath but the
+    // rendered row key did not, so Preact reconciliation could reuse one
+    // bucket's DOM for a sibling whose keeperName + line matched but whose
+    // filePath differed. The render must produce two distinct rows.
+    pushAnchored('a', 'scholar', 12, 1000, 'th-a', 'runtime.ts')
+    pushAnchored('b', 'scholar', 12, 1100, 'th-b', 'worker.ts')
+
+    const container = createContainer()
+    render(html`<${OverlayKeeperTrace} active=${true} />`, container)
+    const buckets = container.querySelectorAll('[role="group"][data-keeper="scholar"][data-line="12"]')
+    expect(buckets.length).toBe(2)
+    const filePaths = Array.from(buckets).map(b => b.getAttribute('data-file')).sort()
+    expect(filePaths).toEqual(['runtime.ts', 'worker.ts'])
+  })
+
   it('caps visible chips to TRACE_CHIP_CAP and renders +N overflow', () => {
     // Push 5 events, all anchored at scholar L12 within retention.
     // None coalesce because each tsMs is > COALESCE_WINDOW_MS apart.

--- a/dashboard/src/components/ide/overlay-keeper-trace.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.ts
@@ -175,7 +175,10 @@ export function OverlayKeeperTrace({ active, keeperFilter }: OverlayKeeperTraceP
       style=${OVERLAY_CONTAINER_STYLE}
     >
       ${buckets.map(bucket => html`
-        <${BucketRow} key=${`${bucket.keeperName}@${bucket.line ?? 'no-line'}`} bucket=${bucket} />
+        <${BucketRow}
+          key=${`${bucket.keeperName}@${bucket.filePath ?? 'no-file'}@${bucket.line ?? 'no-line'}`}
+          bucket=${bucket}
+        />
       `)}
     </div>
   `


### PR DESCRIPTION
## Summary
Follow-up to **#15162** addressing one of two P2 review threads from `chatgpt-codex-connector`.

### Real bug (this PR fixes)
`dashboard/src/components/ide/overlay-keeper-trace.ts:178` — Bucketing was changed to key on (keeperName, filePath, line) so siblings sharing keeperName + line but different filePaths are now distinct buckets. The row key passed to \`<BucketRow key=...>\` was not updated and still keys on (keeperName, line). When two such sibling buckets render, Preact reuses the wrong row, producing stale chips on the survivor.

Fix: add \`bucket.filePath ?? 'no-file'\` to the row key. Adds a render-level regression test asserting two distinct \`role=\"group\"\` rows with the expected \`data-file\` attributes are produced.

### Companion thread (no change — false positive)
The second P2 thread on \`dashboard/src/components/ide/ide-conversation-rail-mock.ts:338\` claims \`postToAnchoredThread\` silently strips valid anchors when \`created_at_iso\` is malformed, because \`bridgePostsToTrace\` \"tolerates via a Date.now() fallback\". Traced to current code:

\`\`\`
\$ rg -n 'Date\\.now' src/components/ide/anchored-thread-trace-bridge.ts src/components/ide/ide-conversation-rail-mock.ts
(no matches)
\`\`\`

\`bridgePostsToTrace\` actually drops malformed-ts posts via \`if (!Number.isFinite(tsMs)) continue\` (anchored-thread-trace-bridge.ts:57-58). The post never reaches \`pushTrace\` — there is no observable no-line-bucket pollution downstream of \`postToTraceInput\`'s null anchor. The Codex finding describes a symptom without observable effect. Leaving the call site unchanged.

## Validation
- \`pnpm vitest run src/components/ide/overlay-keeper-trace.test.ts\` → 16/16 passed including the new regression test.
- AST changes: 1 file +4/-1 (component); 1 file +16/-0 (test). 0 type signature changes.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>