### PR TITLE
fix(keeper): cap pre-dispatch resume checkpoints

### DIFF
--- a/docs/compaction/COMPACTION-LIFECYCLE.md
+++ b/docs/compaction/COMPACTION-LIFECYCLE.md
@@ -97,6 +97,9 @@ OAS strategies  →  MASC fold  →  Repair  →  Sync
 Message count is additionally bounded by
 `default_max_checkpoint_messages = 120` and per-message sub-caps
 (text chars ≤16KB, tool result chars ≤8KB, total ≤200KB).
+The same caps are applied to the pre-dispatch resume checkpoint even
+when compaction does not fire, so Agent.run never receives a raw
+between-save checkpoint payload.
 
 ## 4. Observability Surfaces
 

--- a/lib/keeper/keeper_agent_checkpoint_hygiene.ml
+++ b/lib/keeper/keeper_agent_checkpoint_hygiene.ml
@@ -40,7 +40,12 @@ let prepare_resume_checkpoint_for_dispatch
     if not loaded_checkpoint_present
     then None, None
     else if not applied
-    then Some (Keeper_exec_context.checkpoint_of_context compacted_ctx), None
+    then
+      ( Some
+          (Keeper_exec_context.resume_checkpoint_of_context
+             ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
+             compacted_ctx),
+        None )
     else (
       match save_checkpoint compacted_ctx with
       | Ok checkpoint -> Some checkpoint, None

--- a/lib/keeper/keeper_agent_checkpoint_hygiene.mli
+++ b/lib/keeper/keeper_agent_checkpoint_hygiene.mli
@@ -49,8 +49,9 @@ type pre_dispatch_checkpoint_hygiene_result =
        fire, calls [save_checkpoint] to persist the compacted state.
        On save failure the result carries no resume checkpoint, and
        [save_error] surfaces the detail so the caller can block dispatch.
-    5. When no compaction fired, returns the derived checkpoint of
-       the unchanged context. *)
+    5. When no compaction fired, returns a derived resume checkpoint
+       with the same message-count, old-tool-result, per-block, and
+       total-content caps used by checkpoint persistence. *)
 val prepare_resume_checkpoint_for_dispatch
   :  meta:Keeper_types.keeper_meta
   -> now_ts:float

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -101,9 +101,9 @@ type run_result =
 (** Result of pre-dispatch resume checkpoint hygiene.
 
     [resume_checkpoint] is the only checkpoint passed to OAS resume.  It is
-    derived from the sanitized MASC working context, optionally after
-    pre-dispatch compaction, so run_turn does not reload a separate raw
-    checkpoint immediately before dispatch. *)
+    derived from the sanitized and checkpoint-capped MASC working context,
+    optionally after pre-dispatch compaction, so run_turn does not reload a
+    separate raw checkpoint immediately before dispatch. *)
 type pre_dispatch_checkpoint_hygiene_result =
   { context : Keeper_types.working_context
   ; resume_checkpoint : Agent_sdk.Checkpoint.t option

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -1329,6 +1329,47 @@ let sanitize_oas_checkpoint
   in
   ({ cp with messages }, stats)
 
+let capped_checkpoint_messages_of_context
+      ~(max_checkpoint_messages : int)
+      (ctx : working_context)
+  : Agent_sdk.Types.message list
+  =
+  (* Shared by checkpoint persistence and pre-dispatch resume: both paths
+     must honor the load-time message cap plus content-size guards. *)
+  let original_messages = messages_of_context ctx in
+  let capped_messages =
+    trim_messages_preserving_pairs original_messages
+      ~max_count:max_checkpoint_messages
+  in
+  let capped_messages_were_truncated =
+    List.length capped_messages < List.length original_messages
+  in
+  let capped_messages =
+    Agent_sdk.Context_reducer.reduce
+      (Agent_sdk.Context_reducer.stub_tool_results ~keep_recent:1)
+      capped_messages
+  in
+  let capped_messages, sanitize_stats =
+    sanitize_checkpoint_messages capped_messages
+  in
+  if capped_messages_were_truncated || checkpoint_sanitize_changed sanitize_stats
+  then repair_broken_tool_call_pairs capped_messages
+  else capped_messages
+
+let resume_checkpoint_of_context
+      ~(max_checkpoint_messages : int)
+      (ctx : working_context) : Agent_sdk.Checkpoint.t
+  =
+  let checkpoint_context = Agent_sdk.Context.copy (oas_context_of_context ctx) in
+  {
+    ctx.checkpoint with
+    version = Agent_sdk.Checkpoint.checkpoint_version;
+    system_prompt = Some (system_prompt_of_context ctx);
+    messages = capped_checkpoint_messages_of_context ~max_checkpoint_messages ctx;
+    max_total_tokens = Some (max_tokens_of_context ctx);
+    context = checkpoint_context;
+  }
+
 let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
   let open Yojson.Safe.Util in
   match cp.max_total_tokens with
@@ -1337,7 +1378,7 @@ let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int 
       match cp.working_context with
       | Some (`Assoc _ as sidecar) ->
           sidecar |> member "max_tokens" |> to_int_option
-          |> Option.value ~default:fallback
+      |> Option.value ~default:fallback
       | _ -> fallback)
 
 let context_of_oas_checkpoint
@@ -1390,32 +1431,6 @@ let save_oas_checkpoint
   let checkpoint_context = Agent_sdk.Context.copy (oas_context_of_context ctx) in
   Agent_sdk.Context.set_scoped checkpoint_context Agent_sdk.Context.Session
     checkpoint_generation_key (`Int generation);
-  (* Truncate messages at save time to match the load-time cap.
-     Without this, checkpoints grow unbounded between compaction cycles,
-     causing multi-GB transient allocations when loaded by concurrent keepers. *)
-  let original_messages = messages_of_context ctx in
-  let capped_messages =
-    trim_messages_preserving_pairs original_messages
-      ~max_count:max_checkpoint_messages
-  in
-  let capped_messages_were_truncated =
-    List.length capped_messages < List.length original_messages
-  in
-  (* Stub old tool results at save time: keep only the most recent turn's
-     results in full. During Agent.run the reducer uses keep_recent:3, but
-     at checkpoint persistence we are more aggressive — older tool results
-     are unlikely to be useful on resume and bloat disk/memory. *)
-  let capped_messages =
-    Agent_sdk.Context_reducer.reduce
-      (Agent_sdk.Context_reducer.stub_tool_results ~keep_recent:1)
-      capped_messages
-  in
-  let capped_messages, sanitize_stats = sanitize_checkpoint_messages capped_messages in
-  let capped_messages =
-    if capped_messages_were_truncated || checkpoint_sanitize_changed sanitize_stats
-    then repair_broken_tool_call_pairs capped_messages
-    else capped_messages
-  in
   let checkpoint =
     {
       ctx.checkpoint with
@@ -1424,7 +1439,7 @@ let save_oas_checkpoint
       agent_name;
       model;
       system_prompt = Some (system_prompt_of_context ctx);
-      messages = capped_messages;
+      messages = capped_checkpoint_messages_of_context ~max_checkpoint_messages ctx;
       created_at = Time_compat.now ();
       max_total_tokens = Some (max_tokens_of_context ctx);
       context = checkpoint_context;

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -53,6 +53,12 @@ val sync_oas_context : working_context -> working_context
 (** {1 Working-context projections} *)
 
 val checkpoint_of_context : working_context -> Agent_sdk.Checkpoint.t
+val resume_checkpoint_of_context :
+  max_checkpoint_messages:int -> working_context -> Agent_sdk.Checkpoint.t
+(** Project [working_context] to the checkpoint passed to OAS resume,
+    applying the same message count, old-tool-result, per-block, and
+    total-content caps used by {!save_oas_checkpoint}. *)
+
 val oas_context_of_context : working_context -> Agent_sdk.Context.t
 val system_prompt_of_context : working_context -> string
 val messages_of_context : working_context -> Agent_sdk.Types.message list

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -29,6 +29,8 @@ let token_count = Keeper_context_core.token_count
 let message_count = Keeper_context_core.message_count
 let context_ratio = Keeper_context_core.context_ratio
 let checkpoint_of_context = Keeper_context_core.checkpoint_of_context
+let resume_checkpoint_of_context =
+  Keeper_context_core.resume_checkpoint_of_context
 let oas_context_of_context = Keeper_context_core.oas_context_of_context
 let with_max_tokens = Keeper_context_core.with_max_tokens
 let system_prompt_of_context = Keeper_context_core.system_prompt_of_context

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -24,6 +24,8 @@ val token_count : working_context -> int
 val message_count : working_context -> int
 val context_ratio : working_context -> float
 val checkpoint_of_context : working_context -> Agent_sdk.Checkpoint.t
+val resume_checkpoint_of_context :
+  max_checkpoint_messages:int -> working_context -> Agent_sdk.Checkpoint.t
 val oas_context_of_context : working_context -> Agent_sdk.Context.t
 val with_max_tokens : working_context -> int -> working_context
 val system_prompt_of_context : working_context -> string

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -2402,6 +2402,79 @@ let test_pre_dispatch_resume_checkpoint_uses_loaded_working_context () =
   check bool "fresh context does not force Agent.resume" false
     (Option.is_some fresh_result.resume_checkpoint)
 
+let test_pre_dispatch_resume_checkpoint_caps_loaded_context_without_save () =
+  let base_meta = make_keeper_meta () in
+  let meta =
+    {
+      base_meta with
+      compaction =
+        {
+          base_meta.compaction with
+          ratio_gate = 1.0;
+          message_gate = 0;
+          token_gate = 0;
+          max_checkpoint_messages = 120;
+        };
+    }
+  in
+  let large_text =
+    String.make (KCC.default_max_checkpoint_content_chars_total / 8) 'q'
+  in
+  let messages =
+    List.init 40 (fun i ->
+      Agent_sdk.Types.user_msg
+        (Printf.sprintf "resume-bulk-checkpoint-%02d %s" i large_text))
+  in
+  let ctx =
+    KEC.create ~system_prompt:"sp" ~max_tokens:10_000_000
+    |> fun c -> KEC.append_many c messages
+    |> KEC.sync_oas_context
+  in
+  let checkpoint =
+    {
+      (KEC.checkpoint_of_context ctx) with
+      turn_count = 13;
+      messages = KEC.messages_of_context ctx;
+    }
+  in
+  let ctx = { ctx with checkpoint } in
+  let save_called = ref false in
+  let result =
+    KAR.prepare_resume_checkpoint_for_dispatch
+      ~meta
+      ~now_ts:1000.0
+      ~loaded_checkpoint_present:true
+      ~save_checkpoint:(fun _ ->
+        save_called := true;
+        Error "unexpected save without compaction")
+      ctx
+  in
+  check bool "no compaction save for below-threshold bulk context" false
+    !save_called;
+  check bool "bulk context stays below compaction gates" false result.applied;
+  let resume_checkpoint =
+    match result.resume_checkpoint with
+    | Some checkpoint -> checkpoint
+    | None -> Alcotest.fail "expected capped resume checkpoint"
+  in
+  check int "resume turn count is preserved" 13 resume_checkpoint.turn_count;
+  check bool "resume checkpoint enforces total content cap" true
+    (checkpoint_counted_content_chars resume_checkpoint.messages
+     <= KCC.default_max_checkpoint_content_chars_total);
+  check bool "older messages dropped at resume total cap" true
+    (List.length resume_checkpoint.messages < List.length messages);
+  let newest =
+    resume_checkpoint.messages
+    |> List.rev
+    |> List.hd
+    |> Agent_sdk.Types.text_of_message
+  in
+  check bool "newest message retained in resume checkpoint" true
+    (contains_substring newest "resume-bulk-checkpoint-39");
+  check int "context carries capped resume checkpoint"
+    (List.length resume_checkpoint.messages)
+    (List.length result.context.checkpoint.messages)
+
 let test_pre_dispatch_resume_checkpoint_saves_compacted_context () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2821,6 +2894,8 @@ let () =
             test_compact_if_needed_records_saved_tokens_metric;
           test_case "pre-dispatch resume uses loaded working context" `Quick
             test_pre_dispatch_resume_checkpoint_uses_loaded_working_context;
+          test_case "pre-dispatch resume caps loaded context without save" `Quick
+            test_pre_dispatch_resume_checkpoint_caps_loaded_context_without_save;
           test_case "pre-dispatch resume saves compacted context" `Quick
             test_pre_dispatch_resume_checkpoint_saves_compacted_context;
           test_case "pre-dispatch resume blocks unsaved compaction" `Quick


### PR DESCRIPTION
## Summary
- apply the checkpoint persistence caps to pre-dispatch resume checkpoints even when compaction does not fire
- share the message-count, old tool-result, per-block, and total-content cap helper between save and resume projection
- add a regression test for a loaded bulk context that resumes without saving

## Validation
- ocamlformat --check lib/keeper/keeper_context_core.ml lib/keeper/keeper_context_core.mli lib/keeper/keeper_exec_context.ml lib/keeper/keeper_exec_context.mli lib/keeper/keeper_agent_checkpoint_hygiene.ml lib/keeper/keeper_agent_checkpoint_hygiene.mli lib/keeper/keeper_agent_run.mli test/test_keeper_lifecycle.ml
- git diff --check origin/main..HEAD
- env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_lifecycle.exe
- ./_build/default/test/test_keeper_lifecycle.exe