### PR TITLE
fix(telemetry): label OAS cost by provider

### DIFF
--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -66,6 +66,13 @@ let inference_model_bucket ~provider ~model =
   else "other"
 ;;
 
+let inference_provider_bucket ~provider ~model =
+  let provider = String.trim provider in
+  if provider = ""
+  then inference_model_bucket ~provider ~model
+  else inference_model_bucket ~provider ~model:""
+;;
+
 let positive_finite value =
   value > 0.0
   &&
@@ -117,11 +124,11 @@ let observe_inference_telemetry
     decode_tok_s
 ;;
 
-let observe_inference_cost ~model_bucket = function
+let observe_inference_cost ~provider ~model_bucket = function
   | Some cost when positive_finite cost ->
     Prometheus.observe_histogram
       Prometheus.metric_oas_inference_cost_usd
-      ~labels:[ "model_bucket", model_bucket ]
+      ~labels:[ "provider", provider; "model_bucket", model_bucket ]
       cost
   | _ -> ()
 ;;
@@ -553,13 +560,16 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
   | Agent_sdk.Event_bus.AgentCompleted { agent_name; task_id; elapsed; result } ->
     (match result with
      | Ok (response : Agent_sdk.Types.api_response) ->
+       let provider =
+         inference_provider_bucket ~provider:"" ~model:response.model
+       in
        let model_bucket = inference_model_bucket ~provider:"" ~model:response.model in
        let cost_usd =
          match response.usage with
          | Some usage -> usage.cost_usd
          | None -> None
        in
-       observe_inference_cost ~model_bucket cost_usd
+       observe_inference_cost ~provider ~model_bucket cost_usd
      | Error _ -> ());
     let payload =
       `Assoc

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1193,8 +1193,9 @@ let init () =
     Histogram;
   add
     metric_oas_inference_cost_usd
-    "OAS AgentCompleted cost_usd histogram. Labelled by bounded model_bucket; enables \
-     per-model cost distribution (P50/P99) and total spend tracking."
+    "OAS AgentCompleted cost_usd histogram. Labelled by bounded provider and \
+     model_bucket; enables provider-level spend tracking plus per-model cost \
+     distribution (P50/P99)."
     Histogram;
   add metric_tasks "Total tasks processed" Counter;
   add metric_errors "Total errors" Counter;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -416,7 +416,7 @@ val metric_oas_inference_prompt_tok_per_sec : string
 val metric_oas_inference_decode_tok_per_sec : string
 
 (** Histogram populated from [AgentCompleted] [usage.cost_usd].
-    Labels: [model_bucket] only. *)
+    Labels: [provider] and [model_bucket]. *)
 val metric_oas_inference_cost_usd : string
 
 val metric_mcp_tool_schema_count : string

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -574,6 +574,17 @@ let test_compact_syncs_oas_context () =
 (* ================================================================ *)
 let test_agent_completed_includes_usage () =
   let open Agent_sdk in
+  let cost_labels =
+    [ ("provider", "openai"); ("model_bucket", "openai") ]
+  in
+  let cost_metric = Prometheus.metric_oas_inference_cost_usd in
+  let before_cost =
+    Prometheus.metric_value_or_zero cost_metric ~labels:cost_labels ()
+  in
+  let before_cost_count =
+    Prometheus.metric_value_or_zero (cost_metric ^ "_count")
+      ~labels:cost_labels ()
+  in
   let usage : Llm_provider.Types.api_usage =
     {
       input_tokens = 500;
@@ -586,7 +597,7 @@ let test_agent_completed_includes_usage () =
   let resp : Llm_provider.Types.api_response =
     {
       id = "msg-test";
-      model = "test-model";
+      model = "gpt-5";
       stop_reason = EndTurn;
       content = [];
       usage = Some usage;
@@ -629,7 +640,7 @@ let test_agent_completed_includes_usage () =
       Alcotest.(check bool) "success" true (bool_field "success");
       Alcotest.(check string) "result" "ok" (string_field "result");
       Alcotest.(check string) "response_id" "msg-test" (string_field "response_id");
-      Alcotest.(check string) "model" "test-model" (string_field "model");
+      Alcotest.(check string) "model" "gpt-5" (string_field "model");
       Alcotest.(check string) "stop_reason" "end_turn" (string_field "stop_reason");
       Alcotest.(check bool) "usage_reported" true (bool_field "usage_reported");
       Alcotest.(check int) "input_tokens" 500 (int_field "input_tokens");
@@ -642,7 +653,16 @@ let test_agent_completed_includes_usage () =
       Alcotest.(check string) "event_type" "agent_completed"
         (match List.assoc_opt "event_type" fields with
          | Some (`String s) -> s
-         | _ -> "")
+         | _ -> "");
+      Alcotest.(check (float 0.0001))
+        "cost histogram labels provider"
+        (before_cost +. 0.003)
+        (Prometheus.metric_value_or_zero cost_metric ~labels:cost_labels ());
+      Alcotest.(check (float 0.0001))
+        "cost histogram count"
+        (before_cost_count +. 1.0)
+        (Prometheus.metric_value_or_zero (cost_metric ^ "_count")
+           ~labels:cost_labels ())
   | Some _ -> Alcotest.fail "expected assoc"
 
 let test_agent_completed_omits_usage_fields_when_success_has_no_usage () =


### PR DESCRIPTION
## Summary
- add a bounded `provider` label to `masc_oas_inference_cost_usd` while preserving the existing `model_bucket` label and metric name
- derive the provider bucket from the same bounded provider/model classifier used by OAS telemetry, avoiding raw provider/model cardinality
- extend the AgentCompleted usage regression to assert the cost histogram sum and count under `provider=openai,model_bucket=openai`

## Context
Old Kimi Agent telemetry gap notes marked provider-level cost tracking as missing/weak. Current MASC already emitted `masc_oas_inference_cost_usd`, but only by `model_bucket`, so operators could not group spend by provider without inferring from model buckets. This keeps the metric stable and adds the missing bounded provider dimension.

## Verification
- `git diff --check origin/main...HEAD`
- `ocamlformat --check lib/cascade/cascade_event_bridge.ml lib/prometheus.ml lib/prometheus.mli test/test_oas_integration.ml`
- `rg -n "Obj\\.magic|Thread\\.delay|Unix\\.sleep|Mutex\\.|failwith|assert false|Sys\\.readdir|Fun\\.protect" lib/cascade/cascade_event_bridge.ml lib/prometheus.ml lib/prometheus.mli test/test_oas_integration.ml` only found pre-existing Prometheus/test harness patterns
- attempted `scripts/dune-local.sh build test/test_oas_integration.exe`; earlier pre-final-rebase run reached an unrelated current-main dependency cycle (`Worker_runtime_docker -> Coord -> Keeper_accountability -> Keeper_identity -> Keeper_config -> Coord`), and final retry was cancelled after waiting on `/tmp/me-dune-local.lock` held by another worktree build
