### PR TITLE
feat(ide): group focused context route links

### DIFF
--- a/dashboard/src/components/ide/ide-toolbar.test.ts
+++ b/dashboard/src/components/ide/ide-toolbar.test.ts
@@ -2,7 +2,7 @@ import { fireEvent } from '@testing-library/preact'
 import { h } from 'preact'
 import { render } from 'preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { IdeToolbar } from './ide-toolbar'
+import { deriveToolbarContextRouteGroups, IdeToolbar } from './ide-toolbar'
 import { ideContextFocus } from './ide-state'
 
 let container: HTMLDivElement | null = null
@@ -26,11 +26,30 @@ describe('IdeToolbar', () => {
       activated_at_ms: Date.now(),
       route_links: [
         {
+          id: 'code:lib/runtime.ml:42',
+          label: 'Code',
+          tab: 'code',
+          params: {
+            section: 'ide-shell',
+            view: 'source',
+            file: 'lib/runtime.ml',
+            line: '42',
+          },
+          evidence: 'Code lib/runtime.ml:42',
+        },
+        {
           id: 'task:task-runtime',
           label: 'Task',
           tab: 'workspace',
           params: { section: 'planning', view: 'default', task: 'task-runtime' },
           evidence: 'Task task-runtime',
+        },
+        {
+          id: 'pr:15035',
+          label: 'PR',
+          tab: 'workspace',
+          params: { section: 'repositories', view: 'graph', pr: '15035' },
+          evidence: 'PR 15035',
         },
         {
           id: 'telemetry:turn-9',
@@ -52,16 +71,35 @@ describe('IdeToolbar', () => {
 
     const focus = container.querySelector('[data-testid="ide-toolbar-context-focus"]')
     expect(focus?.getAttribute('aria-label'))
-      .toBe('Current IDE context: Task line 42, task task-runtime, keeper sangsu, 2 route links')
+      .toBe('Current IDE context: Task line 42, task task-runtime, keeper sangsu, 4 route links')
     expect(focus?.textContent).toContain('Task')
     expect(focus?.textContent).toContain('L42')
     expect(focus?.textContent).toContain('task task-runtime')
     expect(focus?.textContent).toContain('keeper sangsu')
 
-    const routeLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-toolbar-context-links button')]
-    expect(routeLinks.map(link => link.textContent)).toEqual(['Task', 'Telemetry'])
+    const routeGroups = [...container.querySelectorAll<HTMLSpanElement>('.ide-toolbar-context-route-groups > span')]
+    expect(routeGroups.map(group => group.getAttribute('aria-label'))).toEqual([
+      'Code: 1 route link',
+      'Plan: 1 route link',
+      'Repo: 1 route link',
+      'Runtime: 1 route link',
+    ])
 
-    fireEvent.click(routeLinks.find(link => link.textContent === 'Telemetry')!)
+    const routeLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-toolbar-context-links button')]
+    expect(routeLinks.map(link => link.getAttribute('aria-label'))).toEqual([
+      'Open Code lib/runtime.ml:42',
+      'Open Task task-runtime',
+      'Open PR 15035',
+      'Open Fleet telemetry event log · query turn-9',
+    ])
+    expect(routeLinks[0]?.querySelector('.ide-toolbar-context-link-evidence')?.textContent)
+      .toBe('lib/runtime.ml:42')
+    expect(routeLinks[1]?.querySelector('.ide-toolbar-context-link-evidence')?.textContent)
+      .toBe('task-runtime')
+    expect(routeLinks[3]?.querySelector('.ide-toolbar-context-link-evidence')?.textContent)
+      .toBe('query turn-9')
+
+    fireEvent.click(routeLinks.find(link => link.getAttribute('aria-label')?.includes('telemetry'))!)
     expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&q=turn-9')
   })
 
@@ -95,7 +133,54 @@ describe('IdeToolbar', () => {
     fireEvent.input(input, { target: { value: 'goal-runtime' } })
 
     const command = [...container.querySelectorAll('[role="option"]')]
-      .find(option => option.textContent === 'Open context: Goal')
+      .find(option => option.textContent === 'Open context: Goal · goal-runtime')
     expect(command).toBeTruthy()
+  })
+
+  it('groups focused context links by operational surface', () => {
+    const groups = deriveToolbarContextRouteGroups({
+      file_path: 'lib/runtime.ml',
+      surface: 'Comment',
+      label: 'runtime note',
+      source_id: 'event-1',
+      activated_at_ms: Date.now(),
+      route_links: [
+        {
+          id: 'comment:comment-1',
+          label: 'Comment',
+          tab: 'workspace',
+          params: { section: 'board', comment: 'comment-1' },
+          evidence: 'Comment comment-1',
+        },
+        {
+          id: 'goal:goal-runtime',
+          label: 'Goal',
+          tab: 'workspace',
+          params: { section: 'planning', goal: 'goal-runtime' },
+          evidence: 'Goal goal-runtime',
+        },
+        {
+          id: 'log:turn-9',
+          label: 'Log',
+          tab: 'monitoring',
+          params: { section: 'runtime', view: 'audit', log_id: 'turn-9' },
+          evidence: 'Log turn-9',
+        },
+        {
+          id: 'git:abc123',
+          label: 'Git',
+          tab: 'workspace',
+          params: { section: 'repositories', view: 'graph', ref: 'abc123' },
+          evidence: 'Git abc123',
+        },
+      ],
+    })
+
+    expect(groups).toEqual([
+      { id: 'planning', label: 'Plan', count: 1, evidence: 'Goal goal-runtime' },
+      { id: 'board', label: 'Board', count: 1, evidence: 'Comment comment-1' },
+      { id: 'repo', label: 'Repo', count: 1, evidence: 'Git abc123' },
+      { id: 'runtime', label: 'Runtime', count: 1, evidence: 'Log turn-9' },
+    ])
   })
 })

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -60,6 +60,33 @@ interface IdeToolbarProps {
   readonly onFindOpen?: () => void
 }
 
+export type ToolbarContextRouteGroupId = 'code' | 'planning' | 'board' | 'repo' | 'runtime' | 'other'
+
+export interface ToolbarContextRouteGroup {
+  readonly id: ToolbarContextRouteGroupId
+  readonly label: string
+  readonly count: number
+  readonly evidence: string
+}
+
+const TOOLBAR_ROUTE_GROUP_ORDER: ReadonlyArray<ToolbarContextRouteGroupId> = [
+  'code',
+  'planning',
+  'board',
+  'repo',
+  'runtime',
+  'other',
+]
+
+const TOOLBAR_ROUTE_GROUP_LABELS: Readonly<Record<ToolbarContextRouteGroupId, string>> = {
+  code: 'Code',
+  planning: 'Plan',
+  board: 'Board',
+  repo: 'Repo',
+  runtime: 'Runtime',
+  other: 'Other',
+}
+
 export function IdeToolbar({
   activeView,
   activeLayers,
@@ -244,7 +271,7 @@ function contextCommandActions(focus: IdeContextFocus | null): CommandBarAction[
   if (!focus?.route_links || focus.route_links.length === 0) return []
   return focus.route_links.map(link => ({
     id: `context-${link.id}`,
-    title: `Open context: ${link.label}`,
+    title: `Open context: ${link.label} · ${toolbarContextLinkEvidence(link)}`,
     keywords: [
       'context focus route link',
       focus.surface,
@@ -264,6 +291,7 @@ function ToolbarContextFocus({
   if (!focus) return null
   const lineLabel = focus.line !== undefined ? `L${focus.line}` : null
   const routeLinks = focus.route_links ?? []
+  const routeGroups = deriveToolbarContextRouteGroups(focus)
   return html`
     <div
       class="ide-toolbar-context-focus"
@@ -275,6 +303,20 @@ function ToolbarContextFocus({
       ${lineLabel ? html`<span>${lineLabel}</span>` : null}
       <strong>${focus.label}</strong>
       ${focus.keeper_id ? html`<span>keeper ${focus.keeper_id}</span>` : null}
+      ${routeGroups.length > 0 ? html`
+        <div class="ide-toolbar-context-route-groups" aria-label="Current context surface groups">
+          ${routeGroups.map(group => html`
+            <span
+              key=${group.id}
+              title=${group.evidence}
+              aria-label=${`${group.label}: ${group.count} route ${group.count === 1 ? 'link' : 'links'}`}
+            >
+              <span>${group.label}</span>
+              <span>${group.count}</span>
+            </span>
+          `)}
+        </div>
+      ` : null}
       ${routeLinks.length > 0 ? html`
         <div class="ide-toolbar-context-links" aria-label="Current context route links">
           ${routeLinks.map(link => html`
@@ -284,7 +326,10 @@ function ToolbarContextFocus({
               title=${link.evidence}
               aria-label=${`Open ${link.evidence}`}
               onClick=${() => openToolbarContextRouteLink(link)}
-            >${link.label}</button>
+            >
+              <span class="ide-toolbar-context-link-label">${link.label}</span>
+              <span class="ide-toolbar-context-link-evidence">${toolbarContextLinkEvidence(link)}</span>
+            </button>
           `)}
         </div>
       ` : null}
@@ -303,4 +348,48 @@ function toolbarContextAriaLabel(focus: IdeContextFocus): string {
     ? `, ${focus.route_links.length} route links`
     : ''
   return `Current IDE context: ${focus.surface}${line}, ${focus.label}${keeper}${links}`
+}
+
+export function deriveToolbarContextRouteGroups(
+  focus: IdeContextFocus | null,
+): ReadonlyArray<ToolbarContextRouteGroup> {
+  const links = focus?.route_links ?? []
+  const grouped = new Map<ToolbarContextRouteGroupId, IdeContextFocusRouteLink[]>()
+  for (const link of links) {
+    const groupId = toolbarContextRouteGroupId(link)
+    const current = grouped.get(groupId)
+    if (current) current.push(link)
+    else grouped.set(groupId, [link])
+  }
+  return TOOLBAR_ROUTE_GROUP_ORDER.flatMap(groupId => {
+    const groupLinks = grouped.get(groupId)
+    if (!groupLinks || groupLinks.length === 0) return []
+    return [{
+      id: groupId,
+      label: TOOLBAR_ROUTE_GROUP_LABELS[groupId],
+      count: groupLinks.length,
+      evidence: groupLinks.map(link => link.evidence).join(' / '),
+    }]
+  })
+}
+
+function toolbarContextRouteGroupId(link: IdeContextFocusRouteLink): ToolbarContextRouteGroupId {
+  const section = link.params.section?.toLowerCase()
+  const label = link.label.toLowerCase()
+  if (link.tab === 'code' || label === 'code') return 'code'
+  if (section === 'planning' || label === 'goal' || label === 'task') return 'planning'
+  if (section === 'board' || label === 'board' || label === 'comment') return 'board'
+  if (section === 'repositories' || label === 'pr' || label === 'git') return 'repo'
+  if (link.tab === 'monitoring' || label === 'log' || label === 'telemetry' || label === 'keeper') {
+    return 'runtime'
+  }
+  return 'other'
+}
+
+function toolbarContextLinkEvidence(link: IdeContextFocusRouteLink): string {
+  const evidence = link.evidence.trim()
+  const labelPrefix = `${link.label} `
+  if (evidence.startsWith(labelPrefix)) return evidence.slice(labelPrefix.length)
+  const scoped = evidence.split(' · ').slice(1).join(' · ')
+  return scoped || evidence
 }

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -340,6 +340,38 @@
   font-weight: 600;
 }
 
+.ide-toolbar-context-route-groups {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  min-width: 0;
+}
+
+.ide-toolbar-context-route-groups > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  min-width: 0;
+  height: 18px;
+  padding: 0 5px;
+  border: 1px solid color-mix(in srgb, var(--color-accent-fg) 32%, var(--color-border-default));
+  border-radius: var(--r-1);
+  background: color-mix(in srgb, var(--color-bg-elevated) 88%, var(--color-accent-bg));
+  color: var(--color-accent-fg);
+  overflow: hidden;
+}
+
+.ide-toolbar-context-route-groups > span > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-toolbar-context-route-groups > span > span:last-child {
+  color: var(--color-fg-muted);
+}
+
 .ide-toolbar-context-links {
   display: flex;
   flex-wrap: wrap;
@@ -348,8 +380,11 @@
 }
 
 .ide-toolbar-context-links button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   min-width: 0;
-  max-width: 76px;
+  max-width: 132px;
   height: 18px;
   padding: 0 5px;
   border: 1px solid var(--color-border-default);
@@ -364,9 +399,31 @@
   white-space: nowrap;
 }
 
+.ide-toolbar-context-link-label,
+.ide-toolbar-context-link-evidence {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-toolbar-context-link-label {
+  flex: 0 0 auto;
+  color: var(--color-fg-secondary);
+}
+
+.ide-toolbar-context-link-evidence {
+  color: var(--color-fg-disabled);
+}
+
 .ide-toolbar-context-links button:hover,
 .ide-toolbar-context-links button:focus-visible {
   border-color: var(--color-border-strong);
+  color: var(--color-accent-fg);
+}
+
+.ide-toolbar-context-links button:hover .ide-toolbar-context-link-label,
+.ide-toolbar-context-links button:focus-visible .ide-toolbar-context-link-label {
   color: var(--color-accent-fg);
 }
 


### PR DESCRIPTION
## Summary

- Group focused IDE context route links into Code, Plan, Board, Repo, Runtime, and Other surface chips.
- Show compact evidence values inside toolbar route buttons and command titles, such as task id, PR id, telemetry query, or file line.
- Cover the grouping and evidence rendering in `ide-toolbar` tests.

## Product impact

When a persistent agent focus is selected in the IDE, the toolbar now shows which operational surfaces are connected and what each link points to. This makes task, goal, PR, git, log, telemetry, keeper, and code context visible without requiring the side context lens to stay open.

## Evidence

- `git diff --check`
- `pnpm exec vitest run src/components/ide/ide-toolbar.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/ide/ide-toolbar.ts src/components/ide/ide-toolbar.test.ts`
- `pnpm exec tsc --noEmit --pretty false`

## Review evidence

- Verified the branch is based on current `origin/main` after #15205.
- Scope is limited to `ide-toolbar`, its focused tests, and toolbar context CSS.
- Dashboard dependencies were hydrated in this worktree from the existing pnpm store with `--frozen-lockfile --prefer-offline`; lockfile/package files were unchanged.

## Linked issue

- Follow-up for dashboard IDE visibility work after #15035 review cleanup; no standalone issue.
