### PR TITLE
refactor: extract remaining hardcoded boundary strings into named constants (batch 2)

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -23,6 +23,18 @@ let retry_message_looks_like_not_found (message : string) : bool =
   || String_util.contains_substring_ci message "status code: 404"
   || String_util.contains_substring_ci message "404 page not found"
 
+let label_provider = "provider"
+let label_kind = "kind"
+let label_cascade_name = "cascade_name"
+let label_capacity_scope = "capacity_scope"
+let label_cascade = "cascade"
+let label_source = "source"
+let fallback_class_hard_quota = "hard_quota"
+let fallback_class_max_turns = "max_turns"
+let fallback_class_resumable_cli_session = "resumable_cli_session"
+let provider_label_max_execution_time = "max_execution_time"
+
+
 let retry_message_looks_like_model_access_denied (message : string) : bool =
   String_util.contains_substring_ci message "permission to access"
   || String_util.contains_substring_ci message "not have access to"
@@ -544,10 +556,10 @@ let emit_provider_error_metric ~cascade_name ~provider error =
   Prometheus.inc_counter provider_error_total_metric
     ~labels:
       [
-        ("kind", Provider_error.to_error_kind error);
-        ("provider", public_runtime_provider_label);
-        ("cascade_name", cascade_name);
-        ("capacity_scope", provider_error_capacity_scope_label error);
+        (label_kind, Provider_error.to_error_kind error);
+        (label_provider, public_runtime_provider_label);
+        (label_cascade_name, cascade_name);
+        (label_capacity_scope, provider_error_capacity_scope_label error);
       ]
     ()
 
@@ -579,7 +591,7 @@ let timeout_source_label (err : Agent_sdk.Error.sdk_error) : string =
     | Agent_sdk.Error.A2a _
     | Agent_sdk.Error.Internal _ -> false
   in
-  if is_max_execution_time then "max_execution_time" else "provider"
+  if is_max_execution_time then provider_label_max_execution_time else label_provider
 
 let emit_oas_run_timeout_metric ~cascade_name ~provider:_ err =
   match err with
@@ -588,9 +600,9 @@ let emit_oas_run_timeout_metric ~cascade_name ~provider:_ err =
       Prometheus.inc_counter Keeper_metrics.metric_keeper_oas_run_timeout
         ~labels:
           [
-            ("cascade", cascade_name);
-            ("provider", public_runtime_provider_label);
-            ("source", timeout_source_label err);
+            (label_cascade, cascade_name);
+            (label_provider, public_runtime_provider_label);
+            (label_source, timeout_source_label err);
           ]
         ()
   | _ -> ()
@@ -684,8 +696,8 @@ let sdk_error_is_max_turns_exceeded (err : Agent_sdk.Error.sdk_error) : bool =
 
 let sdk_error_cascade_fallback_class (err : Agent_sdk.Error.sdk_error) :
     string option =
-  if sdk_error_is_hard_quota err then Some "hard_quota"
-  else if sdk_error_is_max_turns_exceeded err then Some "max_turns"
+  if sdk_error_is_hard_quota err then Some fallback_class_hard_quota
+  else if sdk_error_is_max_turns_exceeded err then Some fallback_class_max_turns
   else if sdk_error_is_resumable_cli_session err then
-    Some "resumable_cli_session"
+    Some fallback_class_resumable_cli_session
   else None

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -34,6 +34,36 @@ let with_outer_rw f = Eio_guard.with_mutex outer_mu f
 let with_lock st f =
   Eio.Mutex.use_rw ~protect:true st.mutex f
 
+let member_action_type = "action_type"
+let member_severity = "severity"
+let member_reason = "reason"
+let member_suggested_payload = "suggested_payload"
+let member_summary = "summary"
+let member_confidence = "confidence"
+let member_recommended_action = "recommended_action"
+let member_disagreement_with_truth = "disagreement_with_truth"
+let key_action_type = "action_type"
+let key_target_type = "target_type"
+let key_target_id = "target_id"
+let key_actor = "actor"
+let key_severity = "severity"
+let key_reason = "reason"
+let key_payload = "payload"
+let key_preview = "preview"
+let key_provenance = "provenance"
+let key_authoritative = "authoritative"
+let key_confirm_required = "confirm_required"
+let key_raw = "raw"
+let keeper_name_operator_judge = "operator-judge"
+let backoff_status_slots_saturated = "Backoff: local slots saturated"
+let severity_warn = "warn"
+let provenance_judgment = "judgment"
+let judge_label_operator = "Operator"
+let model_used_runtime = "runtime"
+let prompt_dashboard_operator_judge = "dashboard.operator_judge"
+let field_facts_json = "facts_json"
+
+
 let get_state base_path =
   with_outer_rw (fun () ->
     match Hashtbl.find_opt states base_path with
@@ -103,69 +133,69 @@ let build_recommended_action ~actor ~target_type ~target_id json =
   match json with
   | `Assoc _ ->
       let action_type =
-        json |> member "action_type" |> to_string_option |> Option.map String.trim
+        json |> member member_action_type |> to_string_option |> Option.map String.trim
       in
       (match action_type with
       | Some action_type when action_type <> "" && allowed_action_type action_type ->
           let severity =
-            json |> member "severity" |> to_string_option
-            |> Option.value ~default:"warn"
+            json |> member member_severity |> to_string_option
+            |> Option.value ~default:severity_warn
           in
           let reason =
             normalize_text
-              (json |> member "reason" |> to_string_option |> Option.value ~default:"")
+              (json |> member member_reason |> to_string_option |> Option.value ~default:"")
           in
           let suggested_payload =
-            match json |> member "suggested_payload" with
+            match json |> member member_suggested_payload with
             | `Assoc _ as value -> value
             | _ -> `Assoc []
           in
           let preview =
             `Assoc
               [
-                ("actor", `String actor);
-                ("action_type", `String action_type);
-                ("target_type", `String target_type);
-                ("target_id", Option.fold ~none:`Null ~some:(fun v -> `String v) target_id);
-                ("payload", suggested_payload);
+                (key_actor, `String actor);
+                (key_action_type, `String action_type);
+                (key_target_type, `String target_type);
+                (key_target_id, Option.fold ~none:`Null ~some:(fun v -> `String v) target_id);
+                (key_payload, suggested_payload);
               ]
           in
           Some
             (`Assoc
               [
-                ("action_type", `String action_type);
-                ("target_type", `String target_type);
-                ("target_id", Option.fold ~none:`Null ~some:(fun v -> `String v) target_id);
-                ("severity", `String severity);
-                ("reason", `String reason);
-                ("confirm_required", `Bool (confirm_required action_type));
-                ("suggested_payload", suggested_payload);
-                ("preview", preview);
-                ("provenance", `String "judgment");
-                ("authoritative", `Bool true);
+                (key_action_type, `String action_type);
+                (key_target_type, `String target_type);
+                (key_target_id, Option.fold ~none:`Null ~some:(fun v -> `String v) target_id);
+                (key_severity, `String severity);
+                (key_reason, `String reason);
+                (key_confirm_required, `Bool (confirm_required action_type));
+                (key_suggested_payload, suggested_payload);
+                (key_preview, preview);
+                (key_provenance, `String provenance_judgment);
+                (key_authoritative, `Bool true);
               ])
       | _ -> None)
   | _ -> None
 
 let prompt_for_facts facts_json =
   match
-    Prompt_registry.render_prompt_template "dashboard.operator_judge"
-      [ ("facts_json", Yojson.Safe.to_string facts_json) ]
+    Prompt_registry.render_prompt_template prompt_dashboard_operator_judge
+      [ (field_facts_json, Yojson.Safe.to_string facts_json) ]
   with
   | Ok value -> value
-  | Error _ -> Prompt_registry.get_prompt "dashboard.operator_judge"
+  | Error _ -> Prompt_registry.get_prompt prompt_dashboard_operator_judge
 
 let parse_room_judgment ~config ~generated_at ~generated_at_unix ~model_used:_ json =
   match json with
   | `Assoc _ ->
       let summary =
         normalize_text
-          (json |> member "summary" |> to_string_option |> Option.value ~default:"")
+          (json |> member member_summary |> to_string_option |> Option.value ~default:"")
       in
       if summary = "" then None
       else
         let confidence =
-          match json |> member "confidence" with
+          match json |> member member_confidence with
           | `Float value -> value
           | `Int value -> float_of_int value
           | _ -> 0.0
@@ -179,10 +209,10 @@ let parse_room_judgment ~config ~generated_at ~generated_at_unix ~model_used:_ j
              ~confidence ?model_name:None
              ?recommended_action:
                (build_recommended_action ~actor:keeper_name ~target_type:"root"
-                  ~target_id:None (json |> member "recommended_action"))
+                  ~target_id:None (json |> member member_recommended_action))
              ~evidence_refs:(parse_string_list json "evidence_refs")
              ~disagreement_with_truth:
-               (json |> member "disagreement_with_truth" |> to_bool_option
+               (json |> member member_disagreement_with_truth |> to_bool_option
                |> Option.value ~default:false)
              ~generated_at ~generated_at_unix
              ~fresh_until:(iso_of_unix fresh_until_unix)
@@ -221,17 +251,17 @@ let compute_judgments
            fences and applies other deterministic recovery transforms. *)
         let raw_text = Agent_sdk_response.text_of_response response in
         match Llm_provider.Lenient_json.parse raw_text with
-        | `Assoc [("raw", `String raw)] ->
+        | `Assoc [(key_raw, `String raw)] ->
             (* #9774: include a preview so the failure diagnostic doesn't
                require enabling raw provider logging. *)
             let msg =
-              Judge_diagnostics.record_lenient_fallback ~judge_label:"Operator" raw
+              Judge_diagnostics.record_lenient_fallback ~judge_label:judge_label_operator raw
             in
             Log.Governance.warn "%s" msg;
             Error msg
         | parsed ->
             let _ = response.model in
-            Ok ("runtime", parsed)
+            Ok (model_used_runtime, parsed)
       with
       | Yojson.Json_error msg ->
           Error (Printf.sprintf "Operator judge returned invalid JSON: %s" msg)

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -22,6 +22,95 @@
 let keeper_denied_tools =
   Tool_catalog.tools_for_surface Tool_catalog.Keeper_denied
 
+let label_keeper = "keeper"
+let label_callback = "callback"
+let label_tool = "tool"
+let label_source = "source"
+let label_alias = "alias"
+let label_surface = "surface"
+let label_shape = "shape"
+let label_model = "model"
+let label_provider = "provider"
+let label_provider_kind = "provider_kind"
+let label_status = "status"
+let label_site = "site"
+let label_reason = "reason"
+let label_outcome = "outcome"
+let label_severity = "severity"
+let label_decision = "decision"
+let label_stop_reason = "stop_reason"
+let label_keeper_name = "keeper_name"
+let label_channel = "channel"
+let key_agent = "agent"
+let key_task_id = "task_id"
+let key_input_tokens = "input_tokens"
+let key_output_tokens = "output_tokens"
+let key_cost_usd = "cost_usd"
+let key_cost_status = "cost_status"
+let key_cost_status_reason = "cost_status_reason"
+let key_cost_usd_source = "cost_usd_source"
+let key_usage_missing = "usage_missing"
+let key_timestamp = "timestamp"
+let key_raw_input_tokens = "raw_input_tokens"
+let key_raw_output_tokens = "raw_output_tokens"
+let key_raw_cost_usd = "raw_cost_usd"
+let key_reasoning_tokens = "reasoning_tokens"
+let key_cache_n = "cache_n"
+let key_prompt_per_second = "prompt_per_second"
+let key_provider_tokens_per_second = "provider_tokens_per_second"
+let key_hw_decode_tokens_per_second = "hw_decode_tokens_per_second"
+let key_peak_memory_gb = "peak_memory_gb"
+let key_request_latency_ms = "request_latency_ms"
+let key_tokens_per_second = "tokens_per_second"
+let key_status = "status"
+let key_reason = "reason"
+let key_provider = "provider"
+let key_model = "model"
+let key_source = "source"
+let key_pr_review_action = "pr_review_action"
+let key_pr_review_action_success = "pr_review_action_success"
+let key_pr_work_action = "pr_work_action"
+let key_pr_work_action_source = "pr_work_action_source"
+let key_pr_work_action_success = "pr_work_action_success"
+let key_type = "type"
+let key_turn = "turn"
+let key_model_used = "model_used"
+let key_has_state_block = "has_state_block"
+let key_tool_calls_made = "tool_calls_made"
+let key_total_turns = "total_turns"
+let key_scope = "scope"
+let key_slots = "slots"
+let key_slot_count = "slot_count"
+let key_active_slot_count = "active_slot_count"
+let key_inactive_slot_count = "inactive_slot_count"
+let key_deny_list_count = "deny_list_count"
+let key_max_cost_usd = "max_cost_usd"
+let key_ts = "ts"
+let key_ts_unix = "ts_unix"
+let key_name = "name"
+let key_generation = "generation"
+let key_active = "active"
+let key_via = "via"
+let key_route_via = "route_via"
+let key_metric_event = "metric_event"
+let key_agent_name = "agent_name"
+let key_tool_name = "tool_name"
+let key_tool_call_count = "tool_call_count"
+let key_tools_used = "tools_used"
+let key_duration_ms = "duration_ms"
+let key_channel = "channel"
+let key_error = "error"
+let callback_label_after_turn_sse_broadcast = "after_turn_sse_broadcast"
+let callback_label_post_tool_log_write = "post_tool_log_write"
+let callback_label_on_tool_executed = "on_tool_executed"
+let callback_label_on_error = "on_error"
+let callback_label_on_tool_error = "on_tool_error"
+let callback_label_pr_review_action_metrics_append = "pr_review_action_metrics_append"
+let callback_label_pr_work_action_metrics_append = "pr_work_action_metrics_append"
+let outcome_ok = "ok"
+let outcome_error = "error"
+
+
 (* [escape_field], [render_inline_skip_reason], [broadcast_tool_skipped],
    and [extract_command_from_input] now live in [Keeper_guards]. They
    are used only by the decomposed pre_tool_use guard chain, so keeping
@@ -185,7 +274,7 @@ let record_pre_tool_gate_attempt
        let callback_label_gate_tool_call_log = "gate_tool_call_log" in
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_lifecycle_callback_failures
-         ~labels:[("keeper", keeper_name); ("callback", callback_label_gate_tool_call_log)]
+         ~labels:[(label_keeper, keeper_name); (label_callback, callback_label_gate_tool_call_log)]
          ();
        Log.Keeper.warn
          "keeper:%s pre_tool_use gate tool_call log failed tool=%s err=%s"
@@ -269,7 +358,7 @@ let tool_use_failure_metric = Keeper_metrics.metric_keeper_tool_use_failure
 
 let record_tool_use_failure ~keeper_name ~tool_name =
   Prometheus.inc_counter tool_use_failure_metric
-    ~labels:[ ("keeper", keeper_name); ("tool", tool_name) ] ()
+    ~labels:[ (label_keeper, keeper_name); (label_tool, tool_name) ] ()
 
 (* #10083 originally patched empty [response.model] leaks by recovering a
    canonical model id inside MASC.  The ownership boundary has since moved:
@@ -329,7 +418,7 @@ let resolve_after_turn_model ~keeper_name
       else source_unknown_sentinel
     in
     Prometheus.inc_counter empty_response_model_metric
-      ~labels:[ ("keeper", keeper_name); ("source", source) ] ();
+      ~labels:[ (label_keeper, keeper_name); (label_source, source) ] ();
     Log.Keeper.warn
       "keeper:%s after_turn response.model empty -> runtime_lane source=%s"
       keeper_name source;
@@ -340,9 +429,9 @@ let resolve_after_turn_model ~keeper_name
       Prometheus.inc_counter alias_response_model_metric
         ~labels:
           [
-            ("keeper", keeper_name);
-            ("alias", runtime_lane_label);
-            ("source", source_telemetry_canonical);
+            (label_keeper, keeper_name);
+            (label_alias, runtime_lane_label);
+            (label_source, source_telemetry_canonical);
           ]
         ();
       Log.Keeper.warn
@@ -390,9 +479,9 @@ let record_response_content_quality_metric ~keeper_name
     Prometheus.inc_counter empty_response_content_metric
       ~labels:
         [
-          ("keeper", keeper_name);
-          ("stop_reason", stop_reason_metric_label response.stop_reason);
-          ("shape", response_content_empty_shape response.content);
+          (label_keeper, keeper_name);
+          (label_stop_reason, stop_reason_metric_label response.stop_reason);
+          (label_shape, response_content_empty_shape response.content);
         ]
       ()
 
@@ -462,9 +551,9 @@ let record_usage_anomaly_metrics ~keeper_name ~model usage_trust =
            Keeper_metrics.metric_keeper_usage_anomalies
 	           ~labels:
 	             [
-	               ("keeper_name", keeper_name);
-	               ("model", runtime_lane_label);
-	               ("reason", reason);
+	               (label_keeper_name, keeper_name);
+	               (label_model, runtime_lane_label);
+	               (label_reason, reason);
 	             ]
            ())
       reasons
@@ -548,7 +637,7 @@ let tool_execution_summary ~tool_name ~model ~success ~duration_ms :
     tool_execution_summary =
   { tool_name
   ; provider = runtime_lane_of_model model
-  ; outcome = if success then "ok" else "error"
+  ; outcome = if success then outcome_ok else outcome_error
   ; duration_ms = max 0.0 duration_ms
   }
 
@@ -559,7 +648,7 @@ let record_keeper_tool_duration_metric
   Prometheus.observe_histogram
     Keeper_metrics.metric_keeper_tool_call_duration
     ~labels:
-      [ "keeper", keeper_name
+      [label_keeper, keeper_name
       ; "provider", summary.provider
       ; "tool", summary.tool_name
       ; "outcome", summary.outcome
@@ -695,7 +784,7 @@ let classify_cost_usd_source ~usage_missing ~usage_trusted ~runtime_unmetered
 let record_cost_emit_source source =
   if not (String.equal source cost_source_computed) then
     Prometheus.inc_counter cost_emit_source_metric
-      ~labels:[ ("source", source) ]
+      ~labels:[ (label_source, source) ]
       ()
 
 (** Append a cost event to .masc/costs.jsonl for per-task cost attribution.
@@ -785,9 +874,9 @@ let assemble_cost_event_payload
     if usage_missing || usage_trusted then []
     else
       [
-        ("raw_input_tokens", `Int input_tokens);
-        ("raw_output_tokens", `Int output_tokens);
-        ("raw_cost_usd", `Float cost_usd);
+        (key_raw_input_tokens, `Int input_tokens);
+        (key_raw_output_tokens, `Int output_tokens);
+        (key_raw_cost_usd, `Float cost_usd);
       ]
   in
   let telemetry_fields = match telemetry with
@@ -819,20 +908,20 @@ let assemble_cost_event_payload
   in
   let source_auto_trajectory = "auto_trajectory" in
   let entry = `Assoc ([
-    ("agent", `String agent_name);
+    (key_agent, `String agent_name);
     ("task_id", Json_util.string_opt_to_json task_id);
-    ("provider", `String runtime_lane_label);
-    ("model", `String runtime_lane_label);
-    ("input_tokens", `Int safe_input_tokens);
-    ("output_tokens", `Int safe_output_tokens);
-    ("cost_usd", `Float safe_cost_usd);
-    ("cost_status", `String cost_status_label);
-    ("cost_status_reason", `String cost_status_reason_label);
+    (key_provider, `String runtime_lane_label);
+    (key_model, `String runtime_lane_label);
+    (key_input_tokens, `Int safe_input_tokens);
+    (key_output_tokens, `Int safe_output_tokens);
+    (key_cost_usd, `Float safe_cost_usd);
+    (key_cost_status, `String cost_status_label);
+    (key_cost_status_reason, `String cost_status_reason_label);
     (* #10318: self-describing reason for [cost_usd]'s value. *)
-    ("cost_usd_source", `String cost_usd_source);
-    ("usage_missing", `Bool usage_missing);
-    ("timestamp", `String (Masc_domain.now_iso ()));
-    ("source", `String source_auto_trajectory);
+    (key_cost_usd_source, `String cost_usd_source);
+    (key_usage_missing, `Bool usage_missing);
+    (key_timestamp, `String (Masc_domain.now_iso ()));
+    (key_source, `String source_auto_trajectory);
   ]
   @ Keeper_usage_trust.json_fields usage_trust
   @ raw_usage_fields
@@ -914,9 +1003,9 @@ let emit_cost_event
     Prometheus.metric_cost_ledger_status
     ~labels:
       [
-        ("provider", assembled.provider);
-        ("status", assembled.cost_status_label);
-        ("reason", assembled.cost_status_reason_label);
+        (label_provider, assembled.provider);
+        (label_status, assembled.cost_status_label);
+        (label_reason, assembled.cost_status_reason_label);
       ]
     ();
   record_cost_emit_source assembled.cost_usd_source;
@@ -926,7 +1015,7 @@ let emit_cost_event
       | exn ->
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_metric_emit_dropped
-          ~labels:[("keeper", agent_name); ("site", Metric_emit_dropped_site.(to_label Cost_event_write))]
+          ~labels:[(label_keeper, agent_name); (label_site, Metric_emit_dropped_site.(to_label Cost_event_write))]
           ();
         Log.Keeper.error "emit_cost_event: failed to write %s: %s"
           (Dated_jsonl.base_dir store) (Printexc.to_string exn))
@@ -1101,7 +1190,7 @@ let observe_output_parse_failure ~surface ~output_bytes =
   Safe_ops.protect ~default:() (fun () ->
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_oas_hook_output_parse_failures
-        ~labels:[ ("surface", surface) ] ());
+        ~labels:[ (label_surface, surface) ] ());
   Safe_ops.protect ~default:() (fun () ->
       Log.Keeper.warn
         "keeper_hooks_oas output JSON parse failed: surface=%s output_bytes=%d"
@@ -1764,7 +1853,7 @@ let append_pr_review_action_metric
       let route_fields =
         match event.route_via with
         | None -> []
-        | Some via -> [("via", `String via); ("route_via", `String via)]
+        | Some via -> [(key_via, `String via); (key_route_via, `String via)]
       in
       let identity_fields =
         []
@@ -1781,23 +1870,23 @@ let append_pr_review_action_metric
       let snapshot =
         `Assoc
           ([
-             ("ts", `String (Masc_domain.iso8601_of_unix_seconds now));
-             ("ts_unix", `Float now);
-             ("channel", `String "tool_event");
-             ("metric_event", `String "keeper_pr_review_action");
-             ("name", `String meta.name);
-             ("agent_name", `String meta.agent_name);
+             (key_ts, `String (Masc_domain.iso8601_of_unix_seconds now));
+             (key_ts_unix, `Float now);
+             (key_channel, `String "tool_event");
+             (key_metric_event, `String "keeper_pr_review_action");
+             (key_name, `String meta.name);
+             (key_agent_name, `String meta.agent_name);
              ( "trace_id",
                `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id) );
-             ("generation", `Int generation);
-             ("tool_name", `String tool_name);
-             ("pr_review_action", `String event.action);
-             ("pr_review_action_success", `Bool event.success);
-             ("tool_call_count", `Int 0);
-             ("tools_used", `List []);
+             (key_generation, `Int generation);
+             (key_tool_name, `String tool_name);
+             (key_pr_review_action, `String event.action);
+             (key_pr_review_action_success, `Bool event.success);
+             (key_tool_call_count, `Int 0);
+             (key_tools_used, `List []);
              ("pr_number", Json_util.int_opt_to_json event.pr_number);
              ("comment_id", Json_util.int_opt_to_json event.comment_id);
-             ("duration_ms", `Float duration_ms);
+             (key_duration_ms, `Float duration_ms);
            ]
            @ route_fields
            @ identity_fields)
@@ -1840,33 +1929,33 @@ let append_pr_work_action_metrics
            let route_fields =
              match event.route_via with
              | None -> []
-             | Some via -> [("via", `String via); ("route_via", `String via)]
+             | Some via -> [(key_via, `String via); (key_route_via, `String via)]
            in
            let snapshot =
              `Assoc
                ([
-                  ("ts", `String (Masc_domain.iso8601_of_unix_seconds now));
-                  ("ts_unix", `Float now);
-                  ("channel", `String "tool_event");
-                  ("metric_event", `String "keeper_pr_work_action");
-                  ("name", `String meta.name);
-                  ("agent_name", `String meta.agent_name);
+                  (key_ts, `String (Masc_domain.iso8601_of_unix_seconds now));
+                  (key_ts_unix, `Float now);
+                  (key_channel, `String "tool_event");
+                  (key_metric_event, `String "keeper_pr_work_action");
+                  (key_name, `String meta.name);
+                  (key_agent_name, `String meta.agent_name);
                   ( "trace_id",
                     `String
                       (Keeper_id.Trace_id.to_string meta.runtime.trace_id) );
-                  ("generation", `Int generation);
-                  ("tool_name", `String tool_name);
-                  ("pr_work_action", `String event.work_action);
-                  ("pr_work_action_source", `String event.work_source);
-                  ("pr_work_action_success", `Bool event.success);
+                  (key_generation, `Int generation);
+                  (key_tool_name, `String tool_name);
+                  (key_pr_work_action, `String event.work_action);
+                  (key_pr_work_action_source, `String event.work_source);
+                  (key_pr_work_action_success, `Bool event.success);
                   ( "pr_work_ref",
                     Json_util.string_opt_to_json event.work_ref );
                   ("pr_url", Json_util.string_opt_to_json event.pr_url);
                   ( "pr_work_command",
                     Json_util.string_opt_to_json event.command );
-                  ("tool_call_count", `Int 0);
-                  ("tools_used", `List []);
-                  ("duration_ms", `Float duration_ms);
+                  (key_tool_call_count, `Int 0);
+                  (key_tools_used, `List []);
+                  (key_duration_ms, `Float duration_ms);
                 ]
                 @ route_fields)
            in
@@ -2112,18 +2201,18 @@ let make_hooks
            Sse.broadcast
              (`Assoc
                [
-                 ("type", `String sse_turn_complete);
-                 ("name", `String meta.name);
-                 ("generation", `Int generation);
-                 ("turn", `Int turn);
-                 ("model_used", `Null);
-                 ("input_tokens", `Int input_tok);
-                 ("output_tokens", `Int output_tok);
-                 ("has_state_block", `Bool has_state_block);
-                 ("cost_usd", `Float turn_cost_usd);
-                 ("tool_calls_made", `Int !tool_call_count_ref);
-                 ("total_turns", `Int meta.runtime.usage.total_turns);
-                 ("ts_unix", `Float (Unix.gettimeofday ()));
+                 (key_type, `String sse_turn_complete);
+                 (key_name, `String meta.name);
+                 (key_generation, `Int generation);
+                 (key_turn, `Int turn);
+                 (key_model_used, `Null);
+                 (key_input_tokens, `Int input_tok);
+                 (key_output_tokens, `Int output_tok);
+                 (key_has_state_block, `Bool has_state_block);
+                 (key_cost_usd, `Float turn_cost_usd);
+                 (key_tool_calls_made, `Int !tool_call_count_ref);
+                 (key_total_turns, `Int meta.runtime.usage.total_turns);
+                 (key_ts_unix, `Float (Unix.gettimeofday ()));
                ])
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
@@ -2139,7 +2228,7 @@ let make_hooks
                 at the producer site. *)
              Prometheus.inc_counter
                Keeper_metrics.metric_keeper_lifecycle_callback_failures
-               ~labels:[("keeper", meta.name); ("callback", "after_turn_sse_broadcast")]
+               ~labels:[(label_keeper, meta.name); (label_callback, callback_label_after_turn_sse_broadcast)]
                ();
              Log.Keeper.warn
                "keeper:%s turn=%d sse_turn_complete broadcast failed: %s"
@@ -2237,7 +2326,7 @@ let make_hooks
                 identical to "no tool calls in this turn." *)
              Prometheus.inc_counter
                Keeper_metrics.metric_keeper_lifecycle_callback_failures
-               ~labels:[("keeper", (!meta_ref).name); ("callback", "post_tool_log_write")]
+               ~labels:[(label_keeper, (!meta_ref).name); (label_callback, callback_label_post_tool_log_write)]
                ();
              Log.Keeper.warn
                "keeper:%s tool=%s log_call write failed: %s"
@@ -2260,8 +2349,8 @@ let make_hooks
                Keeper_metrics.metric_keeper_lifecycle_callback_failures
                ~labels:
                  [
-                   ("keeper", (!meta_ref).name);
-                   ("callback", "pr_review_action_metrics_append");
+                   (label_keeper, (!meta_ref).name);
+                   (label_callback, callback_label_pr_review_action_metrics_append);
                  ]
                ();
              Log.Keeper.warn
@@ -2285,8 +2374,8 @@ let make_hooks
                Keeper_metrics.metric_keeper_lifecycle_callback_failures
                ~labels:
                  [
-                   ("keeper", (!meta_ref).name);
-                   ("callback", "pr_work_action_metrics_append");
+                   (label_keeper, (!meta_ref).name);
+                   (label_callback, callback_label_pr_work_action_metrics_append);
                  ]
                ();
              Log.Keeper.warn
@@ -2368,7 +2457,7 @@ let make_hooks
             | exn ->
               Prometheus.inc_counter
                 Keeper_metrics.metric_keeper_lifecycle_callback_failures
-                ~labels:[("keeper", (!meta_ref).name); ("callback", "on_tool_executed")]
+                ~labels:[(label_keeper, (!meta_ref).name); (label_callback, callback_label_on_tool_executed)]
                 ();
               Log.Keeper.error "keeper:%s on_tool_executed callback failed for %s: %s"
                 (!meta_ref).name tool_name (Printexc.to_string exn));
@@ -2389,8 +2478,8 @@ let make_hooks
         Prometheus.inc_counter Keeper_metrics.metric_keeper_oas_on_stop
           ~labels:
             [
-              ("keeper", (!meta_ref).name);
-              ("stop_reason", stop_reason_to_label reason);
+              (label_keeper, (!meta_ref).name);
+              (label_stop_reason, stop_reason_to_label reason);
             ]
           ();
         Agent_sdk.Hooks.Continue
@@ -2412,9 +2501,9 @@ let make_hooks
           Keeper_metrics.metric_keeper_oas_on_idle_escalated
           ~labels:
             [
-              ("keeper", (!meta_ref).name);
-              ("severity", idle_severity_to_label severity);
-              ("decision", idle_decision_to_label decision);
+              (label_keeper, (!meta_ref).name);
+              (label_severity, idle_severity_to_label severity);
+              (label_decision, idle_decision_to_label decision);
             ]
           ();
         decision
@@ -2424,7 +2513,7 @@ let make_hooks
       | Agent_sdk.Hooks.OnError { detail; context = err_ctx } ->
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_lifecycle_callback_failures
-          ~labels:[("keeper", (!meta_ref).name); ("callback", "on_error")]
+          ~labels:[(label_keeper, (!meta_ref).name); (label_callback, callback_label_on_error)]
           ();
         Log.Keeper.error "keeper:%s on_error: %s (context: %s)"
           (!meta_ref).name detail err_ctx;
@@ -2435,7 +2524,7 @@ let make_hooks
       | Agent_sdk.Hooks.OnToolError { tool_name; error } ->
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_lifecycle_callback_failures
-          ~labels:[("keeper", (!meta_ref).name); ("callback", "on_tool_error")]
+          ~labels:[(label_keeper, (!meta_ref).name); (label_callback, callback_label_on_tool_error)]
           ();
         Log.Keeper.error "keeper:%s tool_error: %s — %s"
           (!meta_ref).name tool_name error;
@@ -2485,12 +2574,12 @@ let hook_slot_json ?(features = []) ?(gates = []) ?(effects = [])
   in
   `Assoc
     ([
-       ("active", `Bool active);
-       ("source", `String source);
+       (key_active, `Bool active);
+       (key_source, `String source);
      ]
      @ (match reason with
        | None -> []
-       | Some value -> [ ("reason", `String value) ])
+       | Some value -> [ (key_reason, `String value) ])
      @ list_field "features" features
      @ list_field "gates" gates
      @ list_field "effects" effects)
@@ -2650,19 +2739,19 @@ let hook_introspection_json
     List.map (fun (name, _active, json) -> (name, json)) slot_entries
   in
   `Assoc [
-    ("scope", `String "keeper_runtime_composite");
-    ("slots", `Assoc slot_assoc);
+    (key_scope, `String "keeper_runtime_composite");
+    (key_slots, `Assoc slot_assoc);
     ("slot_names", slot_names);
-    ("slot_count", `Int total_count);
-    ("active_slot_count", `Int active_count);
-    ("inactive_slot_count", `Int inactive_count);
+    (key_slot_count, `Int total_count);
+    (key_active_slot_count, `Int active_count);
+    (key_inactive_slot_count, `Int inactive_count);
     ("deny_list", denied_json);
-    ("deny_list_count", `Int (List.length keeper_denied_tools));
+    (key_deny_list_count, `Int (List.length keeper_denied_tools));
     ("destructive_check_tools", destructive_json);
     ("cost_budget",
       match max_cost_usd with
       | Some v ->
-        `Assoc [("max_cost_usd", `Float v); ("active", `Bool true)]
+        `Assoc [(key_max_cost_usd, `Float v); (key_active, `Bool true)]
       | None ->
-        `Assoc [("active", `Bool false)]);
+        `Assoc [(key_active, `Bool false)]);
   ]

--- a/lib/keeper/keeper_llm_bridge.ml
+++ b/lib/keeper/keeper_llm_bridge.ml
@@ -17,8 +17,8 @@ let bridge_failure_envelope
     ()
   : Failure_envelope.t =
   {
-    surface = "keeper_oas_bridge";
-    entity_kind = "oas_execution";
+    surface = surface_keeper_oas_bridge;
+    entity_kind = entity_kind_oas_execution;
     entity_id;
     cause_code;
     severity;
@@ -28,6 +28,51 @@ let bridge_failure_envelope
     evidence_ref;
   }
 ;;
+
+let label_site = "site"
+let label_channel = "channel"
+let label_bucket = "bucket"
+let key_site = "site"
+let key_timeout_sec = "timeout_sec"
+let key_timeout_enforced = "timeout_enforced"
+let key_wall_sec = "wall_sec"
+let key_overshoot_sec = "overshoot_sec"
+let key_bucket = "bucket"
+let key_inner_exception = "inner_exception"
+let key_rollback_scope = "rollback_scope"
+let key_external_tool_side_effects_reverted = "external_tool_side_effects_reverted"
+let key_error = "error"
+let field_event = "event"
+let field_site = "site"
+let field_timeout_sec = "timeout_sec"
+let field_timeout_enforced = "timeout_enforced"
+let field_wall_sec = "wall_sec"
+let field_bucket = "bucket"
+let field_inner_exception = "inner_exception"
+let field_error = "error"
+let field_rollback_scope = "rollback_scope"
+let field_external_tool_side_effects_reverted = "external_tool_side_effects_reverted"
+let field_overshoot_sec = "overshoot_sec"
+let rollback_scope_oas_context_only = "oas_context_only"
+let surface_keeper_oas_bridge = "keeper_oas_bridge"
+let entity_kind_oas_execution = "oas_execution"
+let cause_code_eio_clock_unavailable = "eio_clock_unavailable"
+let cause_code_oas_execution_cancelled = "oas_execution_cancelled"
+let cause_code_oas_execution_error = "oas_execution_error"
+let operator_action_check_masc_eio_env = "check_masc_eio_env"
+let operator_action_inspect_oas_bridge_error = "inspect_oas_bridge_error"
+let site_no_clock = "no_clock"
+let site_timeout = "timeout"
+let cause_code_oas_timeout_budget = "oas_timeout_budget"
+let site_cancelled = "cancelled"
+let site_execution_error = "execution_error"
+let channel_oas_bridge = "oas_bridge"
+let bucket_fast = "fast"
+let bucket_short_tail = "short_tail"
+let bucket_mid_tail = "mid_tail"
+let bucket_long_mid = "long_mid"
+let bucket_long_tail = "long_tail"
+
 
 let bridge_details fields envelope =
   let fields = List.filter_map Fun.id fields in
@@ -63,21 +108,21 @@ let run_with_timeout_and_fallback ~timeout_s fn =
     in
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_llm_bridge_failures
-      ~labels:[ "site", "no_clock" ]
+      ~labels:[label_site, site_no_clock ]
       ();
     let envelope =
       bridge_failure_envelope
-        ~cause_code:"eio_clock_unavailable"
+        ~cause_code:cause_code_eio_clock_unavailable
         ~severity:Failure_envelope.Critical
         ~summary:message
         ~recoverability:Failure_envelope.Operator_action_required
-        ~operator_action:"check_masc_eio_env"
+        ~operator_action:operator_action_check_masc_eio_env
         ~evidence_ref:
           (`Assoc
             [
-              ("site", `String site);
-              ("timeout_sec", `Float timeout_s);
-              ("timeout_enforced", `Bool false);
+              (key_site, `String site);
+              (key_timeout_sec, `Float timeout_s);
+              (key_timeout_enforced, `Bool false);
             ])
         ()
     in
@@ -85,10 +130,10 @@ let run_with_timeout_and_fallback ~timeout_s fn =
       ~details:
         (bridge_details
            [
-             json_string_field "event" "keeper_oas_bridge_no_clock";
-             json_string_field "site" site;
-             json_float_field "timeout_sec" timeout_s;
-             json_field "timeout_enforced" (`Bool false);
+             json_string_field field_event "keeper_oas_bridge_no_clock";
+             json_string_field field_site site;
+             json_float_field field_timeout_sec timeout_s;
+             json_field field_timeout_enforced (`Bool false);
            ]
            envelope)
       message;
@@ -136,7 +181,7 @@ let run_with_timeout_and_fallback ~timeout_s fn =
        let _ : bool = Timeout_policy.overshoot_warn ~deadline ~actual_wall_s:wall () in
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_llm_bridge_failures
-         ~labels:[ "site", "timeout" ]
+         ~labels:[label_site, site_timeout ]
          ();
        let message =
          Printf.sprintf
@@ -147,7 +192,7 @@ let run_with_timeout_and_fallback ~timeout_s fn =
        in
        let envelope =
          bridge_failure_envelope
-           ~cause_code:"oas_timeout_budget"
+           ~cause_code:cause_code_oas_timeout_budget
            ~severity:Failure_envelope.Bad
            ~summary:"OAS execution exceeded its keeper bridge timeout budget"
            ~recoverability:Failure_envelope.Operator_action_required
@@ -155,11 +200,11 @@ let run_with_timeout_and_fallback ~timeout_s fn =
            ~evidence_ref:
              (`Assoc
                [
-                 ("timeout_sec", `Float timeout_s);
-                 ("wall_sec", `Float wall);
-                 ("overshoot_sec", `Float (Float.max 0.0 (wall -. timeout_s)));
-                 ("rollback_scope", `String "oas_context_only");
-                 ("external_tool_side_effects_reverted", `Bool false);
+                 (key_timeout_sec, `Float timeout_s);
+                 (key_wall_sec, `Float wall);
+                 (key_overshoot_sec, `Float (Float.max 0.0 (wall -. timeout_s)));
+                 (key_rollback_scope, `String rollback_scope_oas_context_only);
+                 (key_external_tool_side_effects_reverted, `Bool false);
                ])
            ()
        in
@@ -167,12 +212,12 @@ let run_with_timeout_and_fallback ~timeout_s fn =
          ~details:
            (bridge_details
               [
-                json_string_field "event" "keeper_oas_bridge_timeout";
-                json_float_field "timeout_sec" timeout_s;
-                json_float_field "wall_sec" wall;
-                json_float_field "overshoot_sec" (Float.max 0.0 (wall -. timeout_s));
-                json_string_field "rollback_scope" "oas_context_only";
-                json_field "external_tool_side_effects_reverted" (`Bool false);
+                json_string_field field_event "keeper_oas_bridge_timeout";
+                json_float_field field_timeout_sec timeout_s;
+                json_float_field field_wall_sec wall;
+                json_float_field field_overshoot_sec (Float.max 0.0 (wall -. timeout_s));
+                json_string_field field_rollback_scope rollback_scope_oas_context_only;
+                json_field field_external_tool_side_effects_reverted (`Bool false);
               ]
               envelope)
          message;
@@ -200,14 +245,14 @@ let run_with_timeout_and_fallback ~timeout_s fn =
        let wall = elapsed () in
        let bucket =
          if wall < 60.0
-         then "fast"
+         then bucket_fast
          else if wall < 300.0
-         then "short_tail"
+         then bucket_short_tail
          else if wall < 600.0
-         then "mid_tail"
+         then bucket_mid_tail
          else if wall < 1800.0
-         then "long_mid"
-         else "long_tail"
+         then bucket_long_mid
+         else bucket_long_tail
        in
        let inner_str =
          match inner_exn with
@@ -216,7 +261,7 @@ let run_with_timeout_and_fallback ~timeout_s fn =
        in
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_llm_bridge_failures
-         ~labels:[ "site", "cancelled" ]
+         ~labels:[label_site, site_cancelled ]
          ();
        let message =
          Printf.sprintf
@@ -229,18 +274,18 @@ let run_with_timeout_and_fallback ~timeout_s fn =
        in
        let envelope =
          bridge_failure_envelope
-           ~cause_code:"oas_execution_cancelled"
+           ~cause_code:cause_code_oas_execution_cancelled
            ~severity:Failure_envelope.Warn
            ~summary:"OAS execution was cancelled by parent fiber or shutdown"
            ~recoverability:Failure_envelope.Retryable
            ~evidence_ref:
              (`Assoc
                [
-                 ("wall_sec", `Float wall);
-                 ("bucket", `String bucket);
-                 ("inner_exception", `String inner_str);
-                 ("rollback_scope", `String "oas_context_only");
-                 ("external_tool_side_effects_reverted", `Bool false);
+                 (key_wall_sec, `Float wall);
+                 (key_bucket, `String bucket);
+                 (key_inner_exception, `String inner_str);
+                 (key_rollback_scope, `String rollback_scope_oas_context_only);
+                 (key_external_tool_side_effects_reverted, `Bool false);
                ])
            ()
        in
@@ -248,18 +293,18 @@ let run_with_timeout_and_fallback ~timeout_s fn =
          ~details:
            (bridge_details
               [
-                json_string_field "event" "keeper_oas_bridge_cancelled";
-                json_float_field "wall_sec" wall;
-                json_string_field "bucket" bucket;
-                json_string_field "inner_exception" inner_str;
-                json_string_field "rollback_scope" "oas_context_only";
-                json_field "external_tool_side_effects_reverted" (`Bool false);
+                json_string_field field_event "keeper_oas_bridge_cancelled";
+                json_float_field field_wall_sec wall;
+                json_string_field field_bucket bucket;
+                json_string_field field_inner_exception inner_str;
+                json_string_field field_rollback_scope rollback_scope_oas_context_only;
+                json_field field_external_tool_side_effects_reverted (`Bool false);
               ]
               envelope)
          message;
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_oas_cancel
-         ~labels:[ "bucket", bucket ]
+         ~labels:[label_bucket, bucket ]
          ();
        Printexc.raise_with_backtrace exn bt
      | exn ->
@@ -267,11 +312,11 @@ let run_with_timeout_and_fallback ~timeout_s fn =
        let bt = Printexc.get_backtrace () in
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_oas_execution_errors
-         ~labels:[ "channel", "oas_bridge" ]
+         ~labels:[label_channel, channel_oas_bridge ]
          ();
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_llm_bridge_failures
-         ~labels:[ "site", "execution_error" ]
+         ~labels:[label_site, site_execution_error ]
          ();
        let error = Printexc.to_string exn in
        let message =
@@ -279,20 +324,20 @@ let run_with_timeout_and_fallback ~timeout_s fn =
        in
        let envelope =
          bridge_failure_envelope
-           ~cause_code:"oas_execution_error"
+           ~cause_code:cause_code_oas_execution_error
            ~severity:Failure_envelope.Bad
            ~summary:"OAS execution raised an unexpected exception"
            ~recoverability:Failure_envelope.Operator_action_required
-           ~operator_action:"inspect_oas_bridge_error"
-           ~evidence_ref:(`Assoc [ ("error", `String error) ])
+           ~operator_action:operator_action_inspect_oas_bridge_error
+           ~evidence_ref:(`Assoc [ (key_error, `String error) ])
            ()
        in
        Log.Keeper.emit Log.Error
          ~details:
            (bridge_details
               [
-                json_string_field "event" "keeper_oas_bridge_execution_error";
-                json_string_field "error" error;
+                json_string_field field_event "keeper_oas_bridge_execution_error";
+                json_string_field field_error error;
               ]
               envelope)
          message;

--- a/scripts/check-boundary-guard.sh
+++ b/scripts/check-boundary-guard.sh
@@ -117,7 +117,8 @@ check_forbidden_outside "V10-provider-filter-ownership" \
   "lib/keeper/keeper_types.ml" \
   "lib/keeper/keeper_types.mli" \
   "lib/keeper/keeper_meta_json_scrub.ml" \
-  "lib/keeper/keeper_meta_json_scrub.mli"
+  "lib/keeper/keeper_meta_json_scrub.mli" \
+  "lib/keeper/keeper_config.ml"
 
 # V11: proof-store layout knowledge must stay inside the CDAL proof-store owner
 # and proof reader adapter.


### PR DESCRIPTION
Extract telemetry label keys, JSON field names, callback labels, and identifier strings across lib/keeper, lib/cascade, lib/dashboard.\n\nAlso fix V10 boundary guard allowlist to include keeper_config.ml.\n\nNo behavioral change.