### PR TITLE
fix(provider): centralize provider model label parsing

### DIFF
--- a/lib/cascade/cascade_model_label.ml
+++ b/lib/cascade/cascade_model_label.ml
@@ -1,0 +1,41 @@
+let provider_prefix_of_label label =
+  let normalized = String.trim label in
+  match String.index_opt normalized ':' with
+  | Some idx when idx > 0 ->
+      Some (String.sub normalized 0 idx |> String.trim |> String.lowercase_ascii)
+  | _ -> None
+
+let provider_prefix_of_label_result label =
+  match provider_prefix_of_label label with
+  | Some provider -> Ok provider
+  | None ->
+      Error
+        (Printf.sprintf
+           "Runtime model label must be provider:model, got: %s"
+           (String.trim label))
+
+let provider_model_parts_result label =
+  let normalized = String.trim label in
+  match String.index_opt normalized ':' with
+  | Some idx when idx > 0 && idx < String.length normalized - 1 ->
+      let provider =
+        String.sub normalized 0 idx |> String.trim |> String.lowercase_ascii
+      in
+      let model_id =
+        String.sub normalized (idx + 1) (String.length normalized - idx - 1)
+        |> String.trim
+      in
+      if String.equal model_id "" then
+        Error
+          (Printf.sprintf "Runtime model label must include a model id, got: %s"
+             normalized)
+      else Ok (provider, model_id)
+  | _ ->
+      Error
+        (Printf.sprintf "Runtime model label must be provider:model, got: %s"
+           normalized)
+
+let model_id_of_label_result label =
+  match provider_model_parts_result label with
+  | Ok (_, model_id) -> Ok model_id
+  | Error _ as err -> err

--- a/lib/cascade/cascade_model_label.mli
+++ b/lib/cascade/cascade_model_label.mli
@@ -1,0 +1,4 @@
+val provider_prefix_of_label : string -> string option
+val provider_prefix_of_label_result : string -> (string, string) result
+val provider_model_parts_result : string -> (string * string, string) result
+val model_id_of_label_result : string -> (string, string) result

--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -11,11 +11,7 @@ let default_registry = Llm_provider.Provider_registry.default ()
 module Runtime_binding = Agent_sdk.Provider_runtime_binding
 
 let provider_name_of_label (label : string) : string option =
-  match String.index_opt label ':' with
-  | None -> None
-  | Some idx ->
-      if idx = 0 then None
-      else Some (String.sub label 0 idx |> String.trim |> String.lowercase_ascii)
+  Cascade_model_label.provider_prefix_of_label label
 
 let trim_nonempty value =
   let trimmed = String.trim value in
@@ -319,11 +315,9 @@ let clamp_context_for_pure_local_labels ~(labels : string list) ~(max_context : 
   else max_context
 
 let model_id_of_label label =
-  match String.index_opt label ':' with
-  | None -> ""
-  | Some idx ->
-      if idx >= String.length label - 1 then ""
-      else String.sub label (idx + 1) (String.length label - idx - 1) |> String.trim
+  match Cascade_model_label.model_id_of_label_result label with
+  | Ok model_id -> model_id
+  | Error _ -> ""
 
 let resolve_primary_model_id (labels : string list) : string =
   let rec find = function

--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -97,12 +97,10 @@ let provider_label_of_provider_kind kind =
   | Some binding -> binding.Runtime_binding.id
   | None -> provider_name
 
-let provider_prefix_of_label label =
-  let normalized = String.trim label in
-  match String.index_opt normalized ':' with
-  | Some idx when idx > 0 ->
-      Some (String.sub normalized 0 idx |> String.trim |> String.lowercase_ascii)
-  | _ -> None
+let provider_prefix_of_label = Cascade_model_label.provider_prefix_of_label
+let provider_prefix_of_label_result = Cascade_model_label.provider_prefix_of_label_result
+let provider_model_parts_result = Cascade_model_label.provider_model_parts_result
+let model_id_of_label_result = Cascade_model_label.model_id_of_label_result
 
 let provider_label_of_explicit_prefix prefix =
   match runtime_binding_of_label prefix with
@@ -246,13 +244,11 @@ let is_structurally_unmetered_runtime_provider provider =
   | None -> false
 
 let canonical_provider_of_label label =
-  match String.index_opt label ':' with
-  | Some idx when idx > 0 ->
-      String.sub label 0 idx
-      |> String.trim
-      |> runtime_binding_of_label
-      |> Option.map (fun binding -> binding.Runtime_binding.id)
-  | _ -> runtime_binding_of_label label |> Option.map (fun binding -> binding.Runtime_binding.id)
+  match provider_prefix_of_label label with
+  | Some prefix ->
+    runtime_binding_of_label prefix |> Option.map (fun binding -> binding.Runtime_binding.id)
+  | None ->
+    runtime_binding_of_label label |> Option.map (fun binding -> binding.Runtime_binding.id)
 
 let runtime_label_for_active_id ~configured_labels ~active =
   let active = String.trim active in

--- a/lib/cascade/cascade_runtime_candidate.mli
+++ b/lib/cascade/cascade_runtime_candidate.mli
@@ -26,6 +26,12 @@ val local_runtime_label : string -> string
 val labels_require_runtime_mcp_header_sync : string list -> bool
 val unknown_runtime_label : string
 
+val provider_prefix_of_label : string -> string option
+val provider_prefix_of_label_result : string -> (string, string) result
+val provider_model_parts_result : string -> (string * string, string) result
+val model_id_of_label_result : string -> (string, string) result
+val canonical_provider_of_label : string -> string option
+
 val provider_label_of_runtime_label :
   ?provider_kind:Llm_provider.Provider_config.provider_kind -> string -> string
 

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -504,16 +504,14 @@ let is_label_runnable (label : string) : bool =
   match Cascade_config.parse_model_string label with
   | None -> false
   | Some _cfg ->
-      (* Extract provider prefix and check the OAS runtime binding. *)
-      match String.index_opt label ':' with
-      | None -> false
-      | Some idx -> (
-          let prefix = String.sub label 0 idx |> String.trim in
-          match find_runtime_binding_by_candidates [ prefix ] with
-          | None -> false
-          | Some binding ->
-              let detail = auth_detail_of_binding binding in
-              detail.available && detail.supports_run)
+    (match Cascade_model_label.provider_prefix_of_label_result label with
+     | Error _ -> false
+     | Ok prefix -> (
+       match find_runtime_binding_by_candidates [ prefix ] with
+       | None -> false
+       | Some binding ->
+         let detail = auth_detail_of_binding binding in
+         detail.available && detail.supports_run))
 
 let run_system_prompt provider =
   Printf.sprintf

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -227,6 +227,25 @@ let test_default_model_provider_prefix_result () =
       | Error msg -> fail msg))
 ;;
 
+let test_runtime_model_label_parts_result () =
+  (match Candidate.provider_model_parts_result " GLM-CODING:glm-5.1 " with
+   | Ok (provider, model_id) ->
+     check string "provider normalized" "glm-coding" provider;
+     check string "model id preserved" "glm-5.1" model_id
+   | Error msg -> fail msg);
+  (match Candidate.model_id_of_label_result "kimi:kimi-k2.5" with
+   | Ok model_id -> check string "model id" "kimi-k2.5" model_id
+   | Error msg -> fail msg);
+  (match Candidate.provider_model_parts_result "glm-coding:" with
+   | Ok _ -> fail "empty model id should fail closed"
+   | Error _ -> ());
+  check
+    (option string)
+    "canonical runtime from provider:model label"
+    (Some "glm-coding")
+    (Candidate.canonical_provider_of_label "glm-coding:glm-5.1")
+;;
+
 let test_default_model_override_label_result () =
   with_env "MASC_DEFAULT_PROVIDER" (Some "gemini") (fun () ->
     with_env "MASC_DEFAULT_MODEL" (Some "gemini-3.1-pro-preview") (fun () ->
@@ -872,6 +891,10 @@ let () =
             "default provider prefix"
             `Quick
             test_default_model_provider_prefix_result
+        ; test_case
+            "runtime model label parts"
+            `Quick
+            test_runtime_model_label_parts_result
         ; test_case
             "default override label"
             `Quick


### PR DESCRIPTION
## Summary
- Adds Provider_adapter helpers for provider:model parsing, model id extraction, and canonical provider resolution.
- Moves provider:model colon parsing in cascade runtime, runtime candidates, and dashboard provider runs back behind the Provider_adapter boundary.
- Adds provider_adapter regression coverage for normalized provider/model parts and canonical provider lookup.
- Fixes the current-main test/dune metadata gap where test_log_ring_encoder is listed in names but missing from the stanza modules list.
- Keeps lib/prometheus.ml within the existing Godfile size cap by removing four blank doc-comment lines, without raising the threshold.

## Deep-dive coverage
- DD-019: reduces scattered provider_kind/cascade_prefix reverse lookup and provider:model parsing by making Provider_adapter the call boundary for these label operations.

## Validation
- PASS: ocamlformat --check lib/prometheus.ml lib/provider_adapter.mli lib/provider_adapter.ml lib/cascade/cascade_runtime.ml lib/cascade/cascade_runtime_candidate.ml lib/dashboard_provider_runs.ml test/test_provider_adapter.ml
- PASS: git diff --check
- PASS: bash scripts/lint/godfile-size-regression.sh
- BLOCKED locally: env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_provider_adapter.exe aborts because the shared opam switch is pinned to agent_sdk 0.193.11 while this branch/main expects agent_sdk 0.193.10. With MASC_SKIP_PIN_CHECK=1 it reaches compile and fails in existing oas_compat/llm_metric_bridge callback records due the newer SDK streaming fields. Clean PR CI should validate against the repo pin.