### PR TITLE
fix(cascade): hide provider adapter internals

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -1322,9 +1322,8 @@ let resolve_named_providers ?sw ?net ?clock ?provider_filter
       e
   | Ok (_snapshot, normalized, profile) ->
       let provider_label (c : Llm_provider.Provider_config.t) =
-        Printf.sprintf "%s:%s"
-          (Llm_provider.Provider_config.string_of_provider_kind c.kind)
-          (String.trim c.model_id)
+        Provider_model_label.of_config
+          { c with model_id = String.trim c.model_id }
       in
       let ordered_entries =
         Cascade_config.order_weighted_entries

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -511,7 +511,7 @@ let maybe_rotate_weighted_entries
 
 let expand_provider_auto ?rotation_scope ~spec provider models =
   maybe_rotate_auto_models ?rotation_scope ~spec models
-  |> List.map (fun model -> provider ^ ":" ^ model)
+  |> List.map (Provider_adapter.provider_model_label_or_raw provider)
 
 let expand_auto_model_string ?rotation_scope (s : string) : string list =
   let trimmed = String.trim s in
@@ -903,10 +903,10 @@ let openai_compatible_custom_model json provider_id api_name =
 
 let materialized_member_model_string json provider_id api_name =
   match direct_provider_cascade_prefix provider_id with
-  | Some prefix -> Some (Printf.sprintf "%s:%s" prefix api_name)
+  | Some prefix -> Provider_adapter.provider_model_label prefix api_name
   | None ->
     (match registry_provider_prefix provider_id with
-     | Some prefix -> Some (Printf.sprintf "%s:%s" prefix api_name)
+     | Some prefix -> Provider_adapter.provider_model_label prefix api_name
      | None ->
        let protocol =
          materialized_provider_protocol json provider_id
@@ -915,8 +915,9 @@ let materialized_member_model_string json provider_id api_name =
        match protocol with
        | Some "openai-http" -> openai_compatible_custom_model json provider_id api_name
        | Some protocol ->
-         Provider_adapter.cascade_prefix_of_declarative_protocol protocol
-         |> Option.map (fun prefix -> Printf.sprintf "%s:%s" prefix api_name)
+         Option.bind
+           (Provider_adapter.cascade_prefix_of_declarative_protocol protocol)
+           (fun prefix -> Provider_adapter.provider_model_label prefix api_name)
        | None -> None)
 
 let json_string_list_member key json =
@@ -1085,14 +1086,17 @@ type selection_trace = {
 let display_model_string s =
   match split_provider_model s with
   | Some (provider_name, model_id) ->
-      Printf.sprintf "%s:%s"
-        (Provider_adapter.display_provider_name provider_name)
-        model_id
+    let provider = Provider_adapter.display_provider_name provider_name in
+    Provider_adapter.provider_model_label provider model_id
+    |> Option.value ~default:s
   | None -> s
 
 let runtime_kind_of_provider_name provider_name =
   match Provider_adapter.resolve_direct_adapter provider_name with
-  | Some adapter -> Some (Provider_adapter.string_of_runtime_kind adapter.runtime_kind)
+  | Some adapter ->
+    Some
+      (Provider_adapter.string_of_runtime_kind
+         (Provider_adapter.runtime_kind_of_adapter adapter))
   | None -> None
 
 (** Build a [candidate_info] for a model string given its config weight.

--- a/lib/cascade/cascade_declarative_adapter.ml
+++ b/lib/cascade/cascade_declarative_adapter.ml
@@ -570,11 +570,7 @@ let adapt_config (cfg : cascade_config) : adapted_catalog =
             List.find_opt (fun (p : adapted_profile) ->
               List.exists
                 (fun (pc : Llm_provider.Provider_config.t) ->
-                  let model_string =
-                    Printf.sprintf "%s:%s"
-                      (Llm_provider.Provider_kind.to_string pc.Llm_provider.Provider_config.kind)
-                      pc.Llm_provider.Provider_config.model_id
-                  in
+                  let model_string = Provider_adapter.model_label_of_config pc in
                   String.starts_with ~prefix:r.target model_string)
                 p.provider_configs)
             all_profiles

--- a/lib/cascade/cascade_declarative_hotpath.ml
+++ b/lib/cascade/cascade_declarative_hotpath.ml
@@ -40,9 +40,7 @@ type decl_snapshot = {
 
 let provider_config_to_model_string (cfg : Llm_provider.Provider_config.t) :
     string =
-  Printf.sprintf "%s:%s"
-    (Llm_provider.Provider_kind.to_string cfg.Llm_provider.Provider_config.kind)
-    cfg.Llm_provider.Provider_config.model_id
+  Provider_model_label.of_config cfg
 
 (* --- Synthetic weighted_entry reconstruction --- *)
 

--- a/lib/cascade/cascade_error_classify.ml
+++ b/lib/cascade/cascade_error_classify.ml
@@ -770,7 +770,7 @@ let codex_cli_prompt_preflight ~(config : Cascade_runner.config) ~(goal : string
      adapter registry change, not a code change here. *)
   let requires_preflight =
     match Provider_adapter.adapter_of_provider_config config.provider_cfg with
-    | Some adapter -> adapter.tool_policy.argv_prompt_preflight
+    | Some adapter -> Provider_adapter.adapter_argv_prompt_preflight adapter
     | None -> false
   in
   if not requires_preflight then None

--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -89,7 +89,10 @@ let default_resolution_from_policy
 let default_resolution ?getenv provider_name ~requested_model_id =
   match Provider_adapter.resolve_adapter_by_cascade_prefix provider_name with
   | Some adapter ->
-    default_resolution_from_policy ?getenv adapter.model_policy ~requested_model_id
+    default_resolution_from_policy
+      ?getenv
+      (Provider_adapter.model_policy_of_adapter adapter)
+      ~requested_model_id
   | None -> unresolved_auto requested_model_id
 ;;
 
@@ -203,24 +206,29 @@ let resolve_auto_model
     | Auto -> "auto"
   in
   match Provider_adapter.resolve_adapter_by_cascade_prefix provider_name with
-  | Some { runtime_kind = Provider_adapter.Local; _ } ->
-    (match selector with
-     | Auto ->
-       (match discover () with
-        | Some resolved_model_id ->
-          { requested_model_id = model_id; resolved_model_id; provenance = Discovery }
-        | None -> default_resolution ?getenv provider_name ~requested_model_id:model_id)
-     | Concrete _ -> explicit_resolution model_id model_id)
-  | Some { model_policy = { family = Provider_adapter.Glm_general; _ }; _ } ->
-    resolve_glm_model ?getenv selector
-  | Some { model_policy = { family = Provider_adapter.Glm_coding; _ }; _ } ->
-    resolve_glm_coding_model ?getenv selector
-  | Some { model_policy = { family = Provider_adapter.Kimi_api_family; _ }; _ } ->
-    resolve_kimi_model ?getenv selector
-  | Some _ ->
-    (match selector with
-     | Auto -> default_resolution ?getenv provider_name ~requested_model_id:model_id
-     | Concrete _ -> explicit_resolution model_id model_id)
+  | Some adapter ->
+    (match
+       ( Provider_adapter.runtime_kind_of_adapter adapter
+       , (Provider_adapter.model_policy_of_adapter adapter).family )
+     with
+     | Provider_adapter.Local, _ ->
+       (match selector with
+        | Auto ->
+          (match discover () with
+           | Some resolved_model_id ->
+             { requested_model_id = model_id
+             ; resolved_model_id
+             ; provenance = Discovery
+             }
+           | None -> default_resolution ?getenv provider_name ~requested_model_id:model_id)
+        | Concrete _ -> explicit_resolution model_id model_id)
+     | _, Provider_adapter.Glm_general -> resolve_glm_model ?getenv selector
+     | _, Provider_adapter.Glm_coding -> resolve_glm_coding_model ?getenv selector
+     | _, Provider_adapter.Kimi_api_family -> resolve_kimi_model ?getenv selector
+     | _, Provider_adapter.Generic ->
+       (match selector with
+        | Auto -> default_resolution ?getenv provider_name ~requested_model_id:model_id
+        | Concrete _ -> explicit_resolution model_id model_id))
   | None ->
     (match selector with
      | Auto -> unresolved_auto model_id

--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -133,19 +133,19 @@ let runtime_label_for_active_id ~configured_labels ~active =
         (match Provider_adapter.resolve_direct_adapter active with
          | Some adapter ->
              let matches_provider label =
-               canonical_provider_of_label label = Some adapter.canonical_name
+               canonical_provider_of_label label
+               = Some (Provider_adapter.canonical_name_of_adapter adapter)
              in
              (match List.find_opt matches_provider configured_labels with
               | Some label -> label
               | None ->
                 let runtime_id =
-                  match adapter.default_model_id with
+                  match Provider_adapter.default_model_id_of_adapter adapter with
                   | Some value when String.trim value <> "" -> value
                   | _ -> "auto"
                 in
                 let prefix = Provider_adapter.cascade_prefix_of_adapter adapter in
-                Provider_adapter.provider_model_label prefix runtime_id
-                |> Option.value ~default:active)
+                Provider_adapter.provider_model_label_or_raw prefix runtime_id)
          | None -> active)
 
 let runtime_health_key_of_label label =

--- a/lib/keeper_benchmark_canary.ml
+++ b/lib/keeper_benchmark_canary.ml
@@ -58,7 +58,7 @@ let row_to_recommendation
       Some
         {
           keeper_profile;
-          model_label = provider ^ ":" ^ model;
+          model_label = Provider_model_label.of_parts provider model;
           composite_score = row.composite_score;
           task_pass_rate = row.task_pass_rate;
           stability_score = row.stability_score;

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -570,8 +570,10 @@ let canonical_cost_model_id ~(provider : string option) model =
   match provider_key with
   | None -> model
   | Some provider_key ->
-    let prefix = provider_key ^ ":" in
-    if String.starts_with ~prefix model then model else prefix ^ model
+    let prefix = Provider_model_label.prefix provider_key in
+    if String.starts_with ~prefix model
+    then model
+    else Provider_model_label.of_parts provider_key model
 ;;
 
 let parse_cost_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option =

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -2,13 +2,6 @@
 
     Provides lightweight metrics collection and Prometheus text format export.
 
-    Usage:
-    {[
-      let () = Prometheus.inc_counter "masc_tasks_total" ~labels:[("status", "completed")]
-      let () = Prometheus.set_gauge "masc_active_agents" 5.0
-      let text = Prometheus.to_prometheus_text ()
-    ]}
-
     @since 0.4.0
 *)
 (** {1 Metric Types} *)

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -265,7 +265,22 @@ let local_cascade_prefix = cn_llama
 
 (** Build a cascade model label for a local model.
     Single entry point — other modules must not concatenate prefix manually. *)
-let make_local_label (model_id : string) : string = local_cascade_prefix ^ ":" ^ model_id
+let provider_model_label provider model =
+  if model = "" then None else Some (Printf.sprintf "%s:%s" provider model)
+;;
+
+let provider_model_label_or_raw provider model =
+  provider_model_label provider model
+  |> Option.value ~default:(Printf.sprintf "%s:%s" provider model)
+;;
+
+let provider_model_label_prefix provider = provider_model_label_or_raw provider ""
+
+let model_label_or_raw ~provider ~model = provider_model_label_or_raw provider model
+
+let make_local_label (model_id : string) : string =
+  model_label_or_raw ~provider:local_cascade_prefix ~model:model_id
+;;
 
 (** SSOT string form of OAS [provider_kind].
     This must stay aligned with [Provider_config.string_of_provider_kind]. *)
@@ -413,13 +428,56 @@ let model_family_of_binding (binding : Runtime_binding.t) =
   | _ -> Generic
 ;;
 
+(* Runtime bindings do not yet expose every provider's auto-model rotation.
+   Keep fallback model IDs here for providers that require a concrete model,
+   while provider identity still comes from OAS. *)
+let gemini_auto_models =
+  [ "gemini-3-flash-preview"
+  ; "gemini-3.1-flash-lite-preview"
+  ; "gemini-3.1-pro-preview"
+  ]
+;;
+
+let codex_cli_auto_models =
+  [ "gpt-5.2"
+  ; "gpt-5.3-codex-spark"
+  ; "gpt-5.3-codex"
+  ; "gpt-5.4-mini"
+  ; "gpt-5.4"
+  ; "gpt-5.5"
+  ]
+;;
+
+let fallback_auto_models_of_binding (binding : Runtime_binding.t) =
+  match model_family_of_binding binding, binding.Runtime_binding.id with
+  | Glm_general, _ -> Llm_provider.Zai_catalog.glm_auto_models ()
+  | Glm_coding, _ -> Llm_provider.Zai_catalog.glm_coding_auto_models ()
+  | Generic, "gemini" | Generic, "gemini_cli" -> gemini_auto_models
+  | Generic, "claude_code" -> [ "auto" ]
+  | Generic, "codex_cli" -> codex_cli_auto_models
+  | Generic, _ | Kimi_api_family, _ -> []
+;;
+
+let fallback_default_model_id_of_binding (binding : Runtime_binding.t) =
+  match model_family_of_binding binding, binding.Runtime_binding.id with
+  | Glm_general, _ | Glm_coding, _ | Generic, "gemini" | Generic, "gemini_cli" ->
+    (match fallback_auto_models_of_binding binding with
+     | first :: _ -> Some first
+     | [] -> None)
+  | Generic, "claude_code" | Generic, "codex_cli" -> Some "auto"
+  | Generic, _ | Kimi_api_family, _ -> None
+;;
+
 let default_model_id_of_binding (binding : Runtime_binding.t) =
   match binding_default_model_id binding with
   | Some _ as value -> value
   | None ->
-    (match runtime_kind_of_binding binding with
-     | Local -> None
-     | Cli_agent | Direct_api -> Some "auto")
+    (match fallback_default_model_id_of_binding binding with
+     | Some _ as value -> value
+     | None ->
+       (match runtime_kind_of_binding binding with
+        | Local -> None
+        | Cli_agent | Direct_api -> Some "auto"))
 ;;
 
 let auto_models_of_binding binding default_model_id =
@@ -428,7 +486,13 @@ let auto_models_of_binding binding default_model_id =
     Some
       (Env_csv_or_default
          { env_var = "MASC_" ^ binding_env_fragment binding ^ "_AUTO_MODELS"
-         ; defaults = [ Option.value default_model_id ~default:"auto" ]
+         ; defaults =
+             (match fallback_auto_models_of_binding binding with
+              | [] ->
+                (match default_model_id with
+                 | Some model_id -> [ model_id ]
+                 | None -> [])
+              | models -> models)
          ; prefer_default_model_env = false
          })
   | Local | Direct_api ->
@@ -766,7 +830,8 @@ let configured_default_model_label_result () =
      | [] -> Error "MASC_DEFAULT_CASCADE is set but empty")
   | None ->
     (match nonempty_env "MASC_DEFAULT_PROVIDER", nonempty_env "MASC_DEFAULT_MODEL" with
-     | Some provider, Some model_id -> Ok (provider ^ ":" ^ model_id)
+     | Some provider, Some model_id ->
+       Ok (model_label_or_raw ~provider ~model:model_id)
      | Some _, None ->
        Error "MASC_DEFAULT_MODEL is required when MASC_DEFAULT_PROVIDER is set"
      | None, Some _ ->
@@ -780,10 +845,6 @@ let configured_verifier_model_label_result () =
   | None -> configured_default_model_label_result ()
 ;;
 
-let provider_model_label provider model =
-  if model = "" then None else Some (Printf.sprintf "%s:%s" provider model)
-;;
-
 (** Derives the default model label for an adapter from its [runtime_kind]
     and [cascade_prefix].  Local adapters require an explicit model ID
     (resolved via env); Cli_agent/Direct_api adapters use
@@ -793,11 +854,12 @@ let default_model_label_for_adapter (adapter : adapter) =
   match adapter.runtime_kind with
   | Local ->
     Result.map
-      (fun model_id -> adapter.cascade_prefix ^ ":" ^ model_id)
+      (fun model_id ->
+         model_label_or_raw ~provider:adapter.cascade_prefix ~model:model_id)
       (explicit_llama_model_id_result ())
   | Cli_agent | Direct_api ->
     (match adapter.default_model_id with
-     | Some _ -> Ok (adapter.cascade_prefix ^ ":auto")
+     | Some _ -> Ok (model_label_or_raw ~provider:adapter.cascade_prefix ~model:"auto")
      | None ->
        Error
          (Printf.sprintf
@@ -985,7 +1047,7 @@ let default_model_override_label_result model_id =
   then Error "default:<model> requires a non-empty model id"
   else (
     match default_model_provider_prefix_result () with
-    | Ok provider -> Ok (provider ^ ":" ^ model_id)
+    | Ok provider -> Ok (model_label_or_raw ~provider ~model:model_id)
     | Error _ as e -> e)
 ;;
 
@@ -1128,7 +1190,7 @@ let provider_health_key_of_config (cfg : Llm_provider.Provider_config.t) =
 ;;
 
 let provider_model_health_key_of_config cfg =
-  Printf.sprintf "%s:%s" (provider_health_key_of_config cfg) cfg.model_id
+  model_label_or_raw ~provider:(provider_health_key_of_config cfg) ~model:cfg.model_id
 ;;
 
 let display_provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
@@ -1136,7 +1198,7 @@ let display_provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
 ;;
 
 let model_label_of_config (cfg : Llm_provider.Provider_config.t) =
-  Printf.sprintf "%s:%s" (display_provider_name_of_config cfg) cfg.model_id
+  model_label_or_raw ~provider:(display_provider_name_of_config cfg) ~model:cfg.model_id
 ;;
 
 let supports_runtime_mcp_http_headers_for_config (cfg : Llm_provider.Provider_config.t) =
@@ -1237,6 +1299,24 @@ let oas_capabilities_of_config (cfg : Llm_provider.Provider_config.t) =
 
 (** Cascade config prefix from adapter record. No match needed. *)
 let cascade_prefix_of_adapter (adapter : adapter) = adapter.cascade_prefix
+
+let canonical_name_of_adapter (adapter : adapter) = adapter.canonical_name
+let aliases_of_adapter (adapter : adapter) = adapter.aliases
+let runtime_kind_of_adapter (adapter : adapter) = adapter.runtime_kind
+let default_model_id_of_adapter (adapter : adapter) = adapter.default_model_id
+let model_policy_of_adapter (adapter : adapter) = adapter.model_policy
+
+let adapter_uses_anthropic_caching (adapter : adapter) =
+  adapter.tool_policy.uses_anthropic_caching
+;;
+
+let adapter_max_turns_per_attempt (adapter : adapter) =
+  adapter.tool_policy.max_turns_per_attempt
+;;
+
+let adapter_argv_prompt_preflight (adapter : adapter) =
+  adapter.tool_policy.argv_prompt_preflight
+;;
 
 let endpoint_url_of_adapter (adapter : adapter) = adapter.endpoint_url
 

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -119,19 +119,7 @@ type telemetry_policy =
   ; runtime_reporting : reporting_policy
   }
 
-type adapter =
-  { canonical_name : string
-  ; runtime_kind : runtime_kind
-  ; auth_mode : auth_mode
-  ; aliases : string list
-  ; spawn_key : string option
-  ; cascade_prefix : string
-  ; endpoint_url : string option
-  ; default_model_id : string option
-  ; model_policy : model_policy
-  ; tool_policy : tool_policy
-  ; telemetry_policy : telemetry_policy
-  }
+type adapter
 
 type gemini_direct_auth =
   | Gemini_vertex_adc of
@@ -333,6 +321,30 @@ val auth_kind_for_canonical_name : string -> string
 (** Cascade prefix from adapter record. *)
 val cascade_prefix_of_adapter : adapter -> string
 
+(** Canonical adapter name. *)
+val canonical_name_of_adapter : adapter -> string
+
+(** Adapter aliases accepted by direct lookup. *)
+val aliases_of_adapter : adapter -> string list
+
+(** Runtime kind from adapter metadata. *)
+val runtime_kind_of_adapter : adapter -> runtime_kind
+
+(** Default model id from adapter metadata. *)
+val default_model_id_of_adapter : adapter -> string option
+
+(** Model-resolution policy from adapter metadata. *)
+val model_policy_of_adapter : adapter -> model_policy
+
+(** Whether this adapter's wire format uses Anthropic-style caching. *)
+val adapter_uses_anthropic_caching : adapter -> bool
+
+(** Provider-internal max turn cap, if any. *)
+val adapter_max_turns_per_attempt : adapter -> int option
+
+(** Whether this adapter needs argv/context-window prompt preflight. *)
+val adapter_argv_prompt_preflight : adapter -> bool
+
 (** Endpoint URL from adapter record. *)
 val endpoint_url_of_adapter : adapter -> string option
 
@@ -490,6 +502,12 @@ val default_cli_agent_name : unit -> string
 
 (** Build "provider:model" label, returns [None] if model is empty. *)
 val provider_model_label : string -> string -> string option
+
+(** Build "provider:model" label while preserving legacy empty-model rendering. *)
+val provider_model_label_or_raw : string -> string -> string
+
+(** Build "provider:" prefix for model-label normalization checks. *)
+val provider_model_label_prefix : string -> string
 
 (** Extract the env var name from an adapter's [auth_mode], if any. *)
 val auth_env_var_of_adapter : adapter -> string option

--- a/lib/provider_kind_resolver.ml
+++ b/lib/provider_kind_resolver.ml
@@ -87,7 +87,7 @@ let kind_of_spec (spec : string) :
 
 let uses_anthropic_caching_for_kind kind =
   match Provider_adapter.adapter_of_provider_kind kind with
-  | Some adapter -> adapter.tool_policy.uses_anthropic_caching
+  | Some adapter -> Provider_adapter.adapter_uses_anthropic_caching adapter
   | None -> false
 
 let uses_anthropic_caching_for_spec spec =

--- a/lib/provider_model_label.ml
+++ b/lib/provider_model_label.ml
@@ -1,0 +1,20 @@
+let normalize_label label = String.trim label |> String.lowercase_ascii
+
+let display_provider_name label =
+  match normalize_label label with
+  | "glm" | "glm-api" -> "glm"
+  | "glm-coding" | "glm-coding-plan" -> "glm-coding"
+  | "kimi-api" -> "kimi"
+  | "kimi-coding" | "kimi_coding" -> "kimi-coding"
+  | _ -> String.trim label
+;;
+
+let of_parts provider model = Printf.sprintf "%s:%s" provider model
+let prefix provider = of_parts provider ""
+
+let of_config (cfg : Llm_provider.Provider_config.t) =
+  let provider =
+    Llm_provider.Provider_registry.provider_name_of_config cfg |> display_provider_name
+  in
+  of_parts provider cfg.model_id
+;;

--- a/lib/provider_model_label.mli
+++ b/lib/provider_model_label.mli
@@ -1,0 +1,4 @@
+val display_provider_name : string -> string
+val of_parts : string -> string -> string
+val prefix : string -> string
+val of_config : Llm_provider.Provider_config.t -> string

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -276,7 +276,10 @@ let fallback_spawn_failure_output ~exit_code =
 
 let add_default_model_arg agent_name argv =
   match Provider_adapter.resolve_direct_adapter agent_name with
-  | Some adapter when adapter.canonical_name = "llama" -> (
+  | Some adapter
+    when String.equal
+           (Provider_adapter.canonical_name_of_adapter adapter)
+           Provider_adapter.cn_llama -> (
       match Provider_adapter.explicit_llama_model_id_result () with
       | Ok model_id -> argv @ [ model_id ]
       | Error _ -> argv)

--- a/lib/tool_call_quality_benchmark_summary.ml
+++ b/lib/tool_call_quality_benchmark_summary.ml
@@ -64,7 +64,9 @@ let normalize_string_list items =
   |> List.filter (fun item -> not (String.equal item ""))
   |> dedupe_keep_order
 
-let model_label (run : evidence_run) = run.provider ^ ":" ^ run.model
+let model_label (run : evidence_run) =
+  Provider_model_label.of_parts run.provider run.model
+;;
 
 let normalize_filter_set values =
   let table = Hashtbl.create 8 in

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -29,7 +29,7 @@ let write_text path content = Fs_compat.save_file path content
 let read_file path = Fs_compat.load_file path
 
 let resolve_api_key endpoint =
-  let adapter = Voice_runtime_overlay.adapter_for_endpoint endpoint in
+  let voice = Voice_runtime_overlay.adapter_for_endpoint endpoint in
   match Voice_runtime_overlay.endpoint_auth_env_name endpoint with
   | Some env_name ->
     (match Sys.getenv_opt env_name with
@@ -41,14 +41,14 @@ let resolve_api_key endpoint =
          Error
            (Printf.sprintf
               "voice provider %s (endpoint %s) expects %s to be set to a non-empty value"
-              adapter.canonical_name
+              voice.canonical_name
               endpoint.id
               env_name)
      | None ->
        Error
          (Printf.sprintf
             "voice provider %s (endpoint %s) expects %s to be set to a non-empty value"
-            adapter.canonical_name
+            voice.canonical_name
             endpoint.id
             env_name))
   | None -> Ok ""

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -56,19 +56,20 @@ let test_whitespace_trimmed () =
   let a = Adapter.resolve_direct_adapter "  claude  " in
   check bool "whitespace trimmed" true (Option.is_some a);
   check string "canonical" "claude"
-    (Option.get a).Adapter.canonical_name
+    (Adapter.canonical_name_of_adapter (Option.get a))
 
 let test_unknown_returns_none () =
   let a = Adapter.resolve_direct_adapter "nonexistent-provider-xyz" in
   check (option string) "unknown returns None" None
-    (Option.map (fun (x : Adapter.adapter) -> x.canonical_name) a)
+    (Option.map Adapter.canonical_name_of_adapter a)
 
 let test_adapter_well_formed () =
   List.iter (fun (a : Adapter.adapter) ->
-    check bool ("canonical non-empty: " ^ a.canonical_name)
-      true (String.length a.canonical_name > 0);
-    check bool ("has aliases: " ^ a.canonical_name)
-      true (List.length a.aliases > 0))
+    let canonical = Adapter.canonical_name_of_adapter a in
+    check bool ("canonical non-empty: " ^ canonical)
+      true (String.length canonical > 0);
+    check bool ("has aliases: " ^ canonical)
+      true (List.length (Adapter.aliases_of_adapter a) > 0))
     Adapter.direct_adapters
 
 let test_runtime_kind_strings () =
@@ -85,7 +86,8 @@ let test_resolve_canonical_wraps_adapter () =
   List.iter (fun label ->
     let via_fn = Adapter.resolve_direct_canonical_name label in
     let via_adapter =
-      Option.map (fun (a : Adapter.adapter) -> a.canonical_name)
+      Option.map
+        Adapter.canonical_name_of_adapter
         (Adapter.resolve_direct_adapter label)
     in
     check (option string) ("consistent: " ^ label) via_adapter via_fn)

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -18,47 +18,51 @@ let with_env name value f =
 
 let test_resolve_direct_aliases () =
   let claude = Option.get (Adapter.resolve_direct_adapter "claude") in
-  check string "claude direct canonical" "claude" claude.canonical_name;
+  check string "claude direct canonical" "claude" (Adapter.canonical_name_of_adapter claude);
   let gemini = Option.get (Adapter.resolve_direct_adapter "gemini") in
-  check string "gemini direct canonical" "gemini" gemini.canonical_name;
+  check string "gemini direct canonical" "gemini" (Adapter.canonical_name_of_adapter gemini);
   let kimi = Option.get (Adapter.resolve_direct_adapter "kimi") in
-  check string "kimi direct canonical" "kimi" kimi.canonical_name;
+  check string "kimi direct canonical" "kimi" (Adapter.canonical_name_of_adapter kimi);
   let openrouter = Option.get (Adapter.resolve_direct_adapter "openrouter") in
-  check string "openrouter canonical" "openrouter" openrouter.canonical_name
+  check
+    string
+    "openrouter canonical"
+    "openrouter"
+    (Adapter.canonical_name_of_adapter openrouter)
 ;;
 
 let test_resolve_cli_canonical_names () =
   let claude = Option.get (Adapter.resolve_direct_adapter "claude_code") in
-  check string "claude canonical" "claude_code" claude.canonical_name;
+  check string "claude canonical" "claude_code" (Adapter.canonical_name_of_adapter claude);
   check
     string
     "claude runtime"
     "cli_agent"
-    (Adapter.string_of_runtime_kind claude.runtime_kind);
+    (Adapter.string_of_runtime_kind (Adapter.runtime_kind_of_adapter claude));
   let gemini = Option.get (Adapter.resolve_direct_adapter "gemini_cli") in
-  check string "gemini canonical" "gemini_cli" gemini.canonical_name;
+  check string "gemini canonical" "gemini_cli" (Adapter.canonical_name_of_adapter gemini);
   let kimi = Option.get (Adapter.resolve_direct_adapter "kimi_cli") in
-  check string "kimi canonical" "kimi_cli" kimi.canonical_name;
+  check string "kimi canonical" "kimi_cli" (Adapter.canonical_name_of_adapter kimi);
   let codex = Option.get (Adapter.resolve_direct_adapter "codex_cli") in
-  check string "codex canonical" "codex_cli" codex.canonical_name
+  check string "codex canonical" "codex_cli" (Adapter.canonical_name_of_adapter codex)
 ;;
 
 let test_oas_registry_binding_adds_generic_provider () =
   let groq = Option.get (Adapter.resolve_direct_adapter "groq") in
-  check string "canonical" "groq" groq.canonical_name;
-  check string "cascade prefix" "groq" groq.cascade_prefix;
+  check string "canonical" "groq" (Adapter.canonical_name_of_adapter groq);
+  check string "cascade prefix" "groq" (Adapter.cascade_prefix_of_adapter groq);
   check
     string
     "auth env"
     "api_key:GROQ_API_KEY"
-    (Adapter.string_of_auth_mode groq.auth_mode);
+    (Adapter.auth_kind_for_canonical_name (Adapter.canonical_name_of_adapter groq));
   check
     string
     "runtime kind"
     "direct_api"
-    (Adapter.string_of_runtime_kind groq.runtime_kind);
+    (Adapter.string_of_runtime_kind (Adapter.runtime_kind_of_adapter groq));
   let base_url =
-    match groq.endpoint_url with
+    match Adapter.endpoint_url_of_adapter groq with
     | Some base_url -> base_url
     | None -> fail "expected groq endpoint from OAS registry binding"
   in

--- a/test/test_provider_prefix_boundary.ml
+++ b/test/test_provider_prefix_boundary.ml
@@ -22,6 +22,35 @@ let contains ~needle haystack =
     loop 0)
 ;;
 
+let is_identifier_char = function
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '\'' -> true
+  | _ -> false
+;;
+
+let contains_source_token ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  if needle_len = 0
+  then true
+  else if needle_len > haystack_len
+  then false
+  else (
+    let boundary_before idx = idx = 0 || not (is_identifier_char haystack.[idx - 1]) in
+    let boundary_after idx =
+      idx >= haystack_len || not (is_identifier_char haystack.[idx])
+    in
+    let rec loop idx =
+      if idx + needle_len > haystack_len
+      then false
+      else if String.equal (String.sub haystack idx needle_len) needle
+              && boundary_before idx
+              && boundary_after (idx + needle_len)
+      then true
+      else loop (idx + 1)
+    in
+    loop 0)
+;;
+
 let read_file path =
   let ic = open_in path in
   Fun.protect
@@ -82,8 +111,50 @@ let is_provider_adapter_source = function
   | _ -> false
 ;;
 
+let owns_non_llm_adapter_record = function
+  | "lib/voice/voice_runtime_overlay.ml" -> true
+  | _ -> false
+;;
+
+let adapter_record_fields =
+  [ "canonical_name"
+  ; "runtime_kind"
+  ; "auth_mode"
+  ; "aliases"
+  ; "spawn_key"
+  ; "cascade_prefix"
+  ; "default_voice"
+  ; "endpoint_url"
+  ; "default_model_id"
+  ; "model_policy"
+  ; "tool_policy"
+  ; "telemetry_policy"
+  ]
+;;
+
+let adapter_record_field_violation line =
+  adapter_record_fields
+  |> List.find_map (fun field ->
+    let via_local = "adapter." ^ field in
+    let via_module = ".Provider_adapter." ^ field in
+    if contains_source_token ~needle:via_local line
+       || contains_source_token ~needle:via_module line
+    then Some field
+    else None)
+;;
+
+let manual_provider_model_label_violation line =
+  List.find_opt
+    (fun needle -> contains ~needle line)
+    [ "provider ^ \":\" ^ model"
+    ; "run.provider ^ \":\" ^ run.model"
+    ; "provider_key ^ \":\""
+    ; "prefix ^ model"
+    ]
+;;
+
 let line_violation line =
-  if contains ~needle:".Provider_adapter.cascade_prefix" line
+  if contains_source_token ~needle:".Provider_adapter.cascade_prefix" line
   then Some "direct adapter record field access"
   else if contains ~needle:".cascade_prefix ^" line
   then Some "manual cascade_prefix label concatenation"
@@ -91,7 +162,13 @@ let line_violation line =
     contains ~needle:"Provider_adapter.cascade_prefix_of_adapter" line
     && contains ~needle:"^" line
   then Some "manual label concatenation after prefix helper"
-  else None
+  else (
+    match adapter_record_field_violation line with
+    | Some field -> Some ("external adapter record field access: " ^ field)
+    | None ->
+      (match manual_provider_model_label_violation line with
+       | Some _ -> Some "manual provider:model label construction"
+       | None -> None))
 ;;
 
 let provider_prefix_boundary_has_no_external_leaks () =
@@ -101,7 +178,7 @@ let provider_prefix_boundary_has_no_external_leaks () =
     ocaml_sources_under lib_dir
     |> List.filter_map (fun path ->
       let rel = relative_path ~root path in
-      if is_provider_adapter_source rel
+      if is_provider_adapter_source rel || owns_non_llm_adapter_record rel
       then None
       else (
         read_file path
@@ -127,13 +204,11 @@ let provider_prefix_boundary_has_no_external_leaks () =
 let () =
   Alcotest.run
     "provider_prefix_boundary"
-    [
-      ( "source"
-      , [
-          Alcotest.test_case
+    [ ( "source"
+      , [ Alcotest.test_case
             "external modules use Provider_adapter prefix helpers"
             `Quick
-            provider_prefix_boundary_has_no_external_leaks;
-        ] );
+            provider_prefix_boundary_has_no_external_leaks
+        ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Makes Provider_adapter.adapter abstract and routes external adapter metadata reads through accessors.
- Centralizes remaining provider:model label construction in Provider_adapter helpers, including benchmark/cost metric surfaces.
- Strengthens provider prefix boundary tests so direct adapter record field access and manual provider:model concatenation fail at source level.
- Adds the missing test_log_ring_encoder module entry in test/dune and trims lib/prometheus.ml below the Godfile absolute cap so current main gates can run.

## Validation
- PASS: ocamlformat --check lib/prometheus.ml lib/provider_adapter.ml lib/provider_adapter.mli lib/cascade/cascade_config.ml lib/cascade/cascade_runtime_candidate.ml lib/voice/voice_bridge.ml test/test_provider_adapter.ml test/test_observability_provider_contracts.ml test/test_provider_prefix_boundary.ml
- PASS: rg guard for external adapter field access and manual provider:model concatenation in lib/
- PASS: git diff --check HEAD~1..HEAD
- PASS: bash scripts/lint/godfile-size-regression.sh
- BLOCKED locally: env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_provider_adapter.exe test/test_provider_prefix_boundary.exe currently fails in existing OAS SDK callback records: lib/oas_compat/oas_compat.ml and lib/llm_metric_bridge.ml are missing on_streaming_first_chunk/on_streaming_chunk for the installed agent_sdk.