### PR TITLE
feat(ide): show activity context in trace gutter

### DIFF
--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -5,6 +5,7 @@ import { fireEvent, waitFor } from '@testing-library/preact'
 import { deriveIdeRunProgressSummary, IdeActivityPanel } from './ide-activity-panel'
 import { activeIdeFile, ideContextFocus } from './ide-state'
 import { lspDiagnosticSnapshot } from './ide-lsp-client'
+import { clearTraces, keeperTraceState } from './keeper-trace-store'
 import { goals, tasks } from '../../store'
 
 const renderedContainers = new Set<Parameters<typeof preactRender>[1]>()
@@ -25,6 +26,7 @@ function stubEmptyActivityFetch(): void {
 
 beforeEach(() => {
   stubEmptyActivityFetch()
+  clearTraces()
 })
 
 afterEach(() => {
@@ -38,6 +40,7 @@ afterEach(() => {
   goals.value = []
   tasks.value = []
   window.location.hash = ''
+  clearTraces()
 })
 
 describe('IdeActivityPanel', () => {
@@ -189,6 +192,15 @@ describe('IdeActivityPanel', () => {
       'Telemetry',
       'Keeper',
     ])
+    expect(keeperTraceState.value.events).toEqual([expect.objectContaining({
+      id: 'activity:run-default:evt-1',
+      keeperName: 'sangsu',
+      source: 'activity-event',
+      eventId: 'evt-1',
+      filePath: 'lib/runtime.ml',
+      line: 4,
+      surface: 'PR',
+    })])
   })
 
   it('maps nested activity context and evidence refs into IDE route links', async () => {

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { useEffect, useMemo, useState } from 'preact/hooks'
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
 import type { IdeAnnotation } from '../../api/schemas/ide-annotations'
 import type { UnifiedDiffRow } from '../../api/workspace'
@@ -36,6 +36,7 @@ import {
   type RunActivityEvent,
   type RunActivityVerb,
 } from './run-activity-store'
+import { bridgeRunActivityEventsToTrace } from './run-activity-trace-bridge'
 
 const FALLBACK_VERB_MAP: Readonly<Record<string, RunActivityVerb>> = {
   approved: 'approved',
@@ -326,6 +327,7 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
   }, [])
   const [, forceRender] = useState(0)
   const [refreshState, setRefreshState] = useState<ActivityRefreshState>(INITIAL_REFRESH_STATE)
+  const emittedTraceIds = useRef<ReadonlySet<string>>(new Set())
   const refreshMs = normalizedPollMs(pollMs)
 
   useEffect(() => {
@@ -398,6 +400,10 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
     ? EMPTY_DIAGNOSTICS
     : lspDiagnosticSnapshot.value.get(activeFilePath) ?? EMPTY_DIAGNOSTICS
   const progress = deriveIdeRunProgressSummary(events, activeFile, goals.value, tasks.value)
+
+  useEffect(() => {
+    emittedTraceIds.current = bridgeRunActivityEventsToTrace(events, emittedTraceIds.current)
+  }, [events])
 
   return html`
     <div

--- a/dashboard/src/components/ide/ide-editor-extensions.test.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.test.ts
@@ -194,17 +194,36 @@ describe('keeperTraceLinesForFile + keeper trace gutter', () => {
         threadId: 'thread-unscoped',
         line: 3,
       },
+      {
+        id: 'activity-1',
+        tsMs: 5000,
+        keeperName: 'sangsu',
+        count: 1,
+        source: 'activity-event',
+        eventId: 'evt-1',
+        filePath: 'runtime.ts',
+        line: 2,
+        surface: 'Goal',
+      },
     ]
 
     expect(keeperTraceLinesForFile('runtime.ts', events)).toEqual([
       {
         line: 2,
-        events: [{
-          source: 'anchored-thread',
-          keeperName: 'scholar',
-          count: 1,
-          tsMs: 2000,
-        }],
+        events: [
+          {
+            source: 'activity-event',
+            keeperName: 'sangsu',
+            count: 1,
+            tsMs: 5000,
+          },
+          {
+            source: 'anchored-thread',
+            keeperName: 'scholar',
+            count: 1,
+            tsMs: 2000,
+          },
+        ],
       },
     ])
   })
@@ -218,6 +237,7 @@ describe('keeperTraceLinesForFile + keeper trace gutter', () => {
         line: 2,
         events: [
           { source: 'anchored-thread', keeperName: 'scholar', count: 2, tsMs: 2000 },
+          { source: 'activity-event', keeperName: 'sangsu', count: 1, tsMs: 1500 },
           { source: 'anchored-thread', keeperName: 'moth', count: 1, tsMs: 1000 },
         ],
       },
@@ -226,9 +246,11 @@ describe('keeperTraceLinesForFile + keeper trace gutter', () => {
     const gutter = container.querySelector('.cm-trace-gutter')
     expect(gutter).not.toBeNull()
     const dots = gutter?.querySelectorAll('.cm-trace-dot')
-    expect(dots?.length).toBe(2)
+    expect(dots?.length).toBe(3)
     expect(dots?.[0]?.getAttribute('data-source')).toBe('anchored-thread')
     expect(dots?.[0]?.getAttribute('aria-label')).toBe('thread scholar x2')
+    expect(dots?.[1]?.getAttribute('data-source')).toBe('activity-event')
+    expect(dots?.[1]?.getAttribute('aria-label')).toBe('activity sangsu')
     expect(gutter?.querySelector('.cm-trace-stack[role="list"]')?.getAttribute('aria-label'))
       .toContain('Line 2 keeper trace')
 

--- a/dashboard/src/components/ide/ide-editor-extensions.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.ts
@@ -411,17 +411,18 @@ export function keeperTraceLinesForFile(
 
   const byLine = new Map<number, EditorKeeperTraceLineEvent[]>()
   for (const event of events) {
-    if (event.source !== 'anchored-thread') continue
-    if (event.filePath !== normalizedFilePath) continue
-    if (event.line === null || !Number.isSafeInteger(event.line) || event.line < 1) continue
-    const existing = byLine.get(event.line) ?? []
+    const filePath = traceEventFilePath(event)
+    const line = traceEventLine(event)
+    if (filePath !== normalizedFilePath) continue
+    if (line === null) continue
+    const existing = byLine.get(line) ?? []
     existing.push({
       source: event.source,
       keeperName: event.keeperName,
       count: event.count,
       tsMs: event.tsMs,
     })
-    byLine.set(event.line, existing)
+    byLine.set(line, existing)
   }
 
   return [...byLine.entries()]
@@ -436,6 +437,8 @@ function traceSourceColor(source: KeeperTraceSource): string {
   switch (source) {
     case 'anchored-thread':
       return 'var(--color-status-info)'
+    case 'activity-event':
+      return 'var(--color-status-info)'
     case 'cascade-hop':
       return 'var(--color-accent-fg)'
     case 'bdi-snapshot':
@@ -449,6 +452,8 @@ function traceSourceLabel(source: KeeperTraceSource): string {
   switch (source) {
     case 'anchored-thread':
       return 'thread'
+    case 'activity-event':
+      return 'activity'
     case 'cascade-hop':
       return 'cascade'
     case 'bdi-snapshot':
@@ -456,6 +461,26 @@ function traceSourceLabel(source: KeeperTraceSource): string {
     case 'decision-log':
       return 'decision'
   }
+}
+
+function traceEventFilePath(event: KeeperTraceEvent): string | null {
+  if (event.source === 'anchored-thread') return event.filePath ?? null
+  if (event.source === 'activity-event') return event.filePath
+  return null
+}
+
+function traceEventLine(event: KeeperTraceEvent): number | null {
+  if (event.source === 'anchored-thread') {
+    return event.line !== null && Number.isSafeInteger(event.line) && event.line >= 1
+      ? event.line
+      : null
+  }
+  if (event.source === 'activity-event') {
+    return Number.isSafeInteger(event.line) && event.line >= 1
+      ? event.line
+      : null
+  }
+  return null
 }
 
 function traceEventLabel(event: EditorKeeperTraceLineEvent): string {

--- a/dashboard/src/components/ide/keeper-trace-store.test.ts
+++ b/dashboard/src/components/ide/keeper-trace-store.test.ts
@@ -161,6 +161,42 @@ describe('keeper-trace-store', () => {
     expect(keeperTraceState.value.events.map(e => e.count)).toEqual([1, 1, 1])
   })
 
+  it('does NOT coalesce activity events for different file lines within the window', () => {
+    pushTrace({
+      id: 'activity-1',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'activity-event',
+      eventId: 'evt-1',
+      filePath: 'runtime.ts',
+      line: 12,
+      surface: 'Goal',
+    })
+    pushTrace({
+      id: 'activity-2',
+      tsMs: 1010,
+      keeperName: 'scholar',
+      source: 'activity-event',
+      eventId: 'evt-2',
+      filePath: 'worker.ts',
+      line: 12,
+      surface: 'Task',
+    })
+    pushTrace({
+      id: 'activity-3',
+      tsMs: 1020,
+      keeperName: 'scholar',
+      source: 'activity-event',
+      eventId: 'evt-3',
+      filePath: 'runtime.ts',
+      line: 20,
+      surface: 'Log',
+    })
+
+    expect(keeperTraceState.value.events.map(e => e.id)).toEqual(['activity-1', 'activity-2', 'activity-3'])
+    expect(keeperTraceState.value.events.map(e => e.count)).toEqual([1, 1, 1])
+  })
+
   it('inserts out-of-order events into ascending tsMs position', () => {
     pushTrace({
       id: 'a-1',
@@ -393,6 +429,16 @@ describe('keeper-trace-store', () => {
       decisionId: 'dec-1',
       semanticOutcome: 'success',
     })
+    pushTrace({
+      id: 'e-1',
+      tsMs: 1400,
+      keeperName: 'scholar',
+      source: 'activity-event',
+      eventId: 'evt-1',
+      filePath: 'runtime.ts',
+      line: 9,
+      surface: 'Goal',
+    })
 
     for (const event of keeperTraceState.value.events) {
       // Compile-time exhaustive narrowing.
@@ -411,6 +457,12 @@ describe('keeper-trace-store', () => {
         case 'decision-log':
           expect(event.decisionId).toBe('dec-1')
           expect(event.semanticOutcome).toBe('success')
+          break
+        case 'activity-event':
+          expect(event.eventId).toBe('evt-1')
+          expect(event.filePath).toBe('runtime.ts')
+          expect(event.line).toBe(9)
+          expect(event.surface).toBe('Goal')
           break
       }
     }

--- a/dashboard/src/components/ide/keeper-trace-store.ts
+++ b/dashboard/src/components/ide/keeper-trace-store.ts
@@ -3,11 +3,12 @@ import { signal } from '@preact/signals'
 /**
  * RFC-0028 PR-α: keeper-trace store.
  *
- * Stitched read-side projection over 4 existing layer surfaces:
+ * Stitched read-side projection over existing IDE/runtime surfaces:
  *  - anchored-thread (RFC-0021)
  *  - cascade-hop     (RFC-0023)
  *  - bdi-snapshot    (RFC-0024)
  *  - decision-log    (RFC-0026)
+ *  - activity-event  (/api/v1/activity/events normalized context)
  *
  * The store is *append-only* from the producer's perspective. It enforces
  * three invariants on every `pushTrace` call:
@@ -36,6 +37,7 @@ export type KeeperTraceSource =
   | 'cascade-hop'
   | 'bdi-snapshot'
   | 'decision-log'
+  | 'activity-event'
 
 interface KeeperTraceBase {
   readonly id: string
@@ -66,12 +68,20 @@ export type KeeperTraceEvent =
       readonly decisionId: string
       readonly semanticOutcome: string | null
     })
+  | (KeeperTraceBase & {
+      readonly source: 'activity-event'
+      readonly eventId: string
+      readonly filePath: string
+      readonly line: number
+      readonly surface: string
+    })
 
 export type KeeperTraceEventInput =
   | Omit<Extract<KeeperTraceEvent, { source: 'anchored-thread' }>, 'count'>
   | Omit<Extract<KeeperTraceEvent, { source: 'cascade-hop' }>, 'count'>
   | Omit<Extract<KeeperTraceEvent, { source: 'bdi-snapshot' }>, 'count'>
   | Omit<Extract<KeeperTraceEvent, { source: 'decision-log' }>, 'count'>
+  | Omit<Extract<KeeperTraceEvent, { source: 'activity-event' }>, 'count'>
 
 export interface KeeperTraceState {
   readonly events: ReadonlyArray<KeeperTraceEvent>
@@ -88,7 +98,7 @@ export const keeperTraceState = signal<KeeperTraceState>(INITIAL_STATE)
  *
  * Coalescing rule (RFC-0028 §4):
  *   if the existing entry with the largest tsMs has the same trace bucket
- *   (source + keeperName, and for anchored threads also filePath + line)
+ *   (source + keeperName, and for line-anchored sources also filePath + line)
  *   AND `(input.tsMs - existing.tsMs) <= COALESCE_WINDOW_MS`,
  *   then replace it in-array with `{ ...existing, count: existing.count + 1, tsMs: input.tsMs }`.
  *   Otherwise insert at the binary-search position and prune retention.
@@ -197,6 +207,9 @@ function sameTraceBucket(left: KeeperTraceEvent, right: KeeperTraceEvent): boole
   if (left.source === 'anchored-thread' && right.source === 'anchored-thread') {
     return (left.filePath ?? null) === (right.filePath ?? null)
       && left.line === right.line
+  }
+  if (left.source === 'activity-event' && right.source === 'activity-event') {
+    return left.filePath === right.filePath && left.line === right.line
   }
   return true
 }

--- a/dashboard/src/components/ide/overlay-keeper-trace.test.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.test.ts
@@ -60,6 +60,25 @@ function pushDecision(id: string, keeperName: string, tsMs: number): void {
   })
 }
 
+function pushActivity(
+  id: string,
+  keeperName: string,
+  line: number,
+  tsMs: number,
+  filePath = 'runtime.ts',
+): void {
+  pushTrace({
+    id,
+    tsMs,
+    keeperName,
+    source: 'activity-event',
+    eventId: `evt-${id}`,
+    filePath,
+    line,
+    surface: 'Goal',
+  })
+}
+
 beforeEach(() => {
   clearTraces()
 })
@@ -95,13 +114,16 @@ describe('bucketTraceEvents — RFC-0028 §5 grouping', () => {
   it('non-anchored sources fall into the keeper-level no-line bucket', () => {
     pushBdi('a', 'scholar', 1000)
     pushDecision('b', 'scholar', 1100)
-    pushAnchored('c', 'scholar', 12, 1200)
+    pushAnchored('c', 'scholar', 12, 1200, 'th-c', 'runtime.ts')
+    pushActivity('d', 'scholar', 12, 1300)
 
     const buckets = bucketTraceEvents(keeperTraceState.value.events)
     const noLineBucket = buckets.find(b => b.line === null)
     expect(noLineBucket).toBeDefined()
     expect(noLineBucket?.events.length).toBe(2)
     expect(noLineBucket?.events.map(e => e.source).sort()).toEqual(['bdi-snapshot', 'decision-log'])
+    const lineBucket = buckets.find(b => b.filePath === 'runtime.ts' && b.line === 12)
+    expect(lineBucket?.events.map(e => e.source).sort()).toEqual(['activity-event', 'anchored-thread'])
   })
 
   it('sorts events newest-first within each bucket', () => {
@@ -215,13 +237,16 @@ describe('OverlayKeeperTrace — bucket render (RFC-0028 §5)', () => {
     pushAnchored('a', 'scholar', null, 1000) // no line → no-line bucket
     pushBdi('b', 'scholar', 1100)
     pushDecision('c', 'scholar', 1200)
+    pushActivity('d', 'scholar', 4, 1300)
 
     const container = createContainer()
     render(html`<${OverlayKeeperTrace} active=${true} />`, container)
-    const bucket = container.querySelector('[role="group"][data-keeper="scholar"]')
+    const bucket = container.querySelector('[role="group"][data-keeper="scholar"][data-line="no-line"]')
     const chips = Array.from(bucket?.querySelectorAll('li[role="img"]') ?? [])
     const sources = chips.map(c => c.getAttribute('data-source'))
     expect(sources).toEqual(expect.arrayContaining(['anchored-thread', 'bdi-snapshot', 'decision-log']))
+    const lineBucket = container.querySelector('[role="group"][data-keeper="scholar"][data-line="4"]')
+    expect(lineBucket?.querySelector('li[role="img"]')?.getAttribute('data-source')).toBe('activity-event')
   })
 
   it('chip aria-label includes source + line + count', () => {

--- a/dashboard/src/components/ide/overlay-keeper-trace.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.ts
@@ -9,12 +9,12 @@ import {
 /**
  * RFC-0028 PR-β: keeper-trace gutter chip overlay.
  *
- * Reads `keeperTraceState` (the 4-source stitched store from PR-α) and
+ * Reads `keeperTraceState` (the stitched trace store) and
  * renders a stacked gutter chip per RFC §5: cap=3 visible chips per
  * (keeperName, line) bucket plus a `+N` overflow indicator. Each chip is
  * colored by source (anchored-thread / cascade-hop / bdi-snapshot /
- * decision-log) and exposes a hover tooltip with the underlying event
- * details.
+ * decision-log / activity-event) and exposes a hover tooltip with the
+ * underlying event details.
  *
  * Bucket key (RFC §5 + §11 #3):
  *   `${keeperName}@${line ?? 'no-line'}`
@@ -39,6 +39,7 @@ const SOURCE_COLORS: Record<KeeperTraceSource, string> = {
   'cascade-hop': 'var(--color-accent-fg, #8b5cf6)',
   'bdi-snapshot': 'var(--color-status-ok, #2dba4e)',
   'decision-log': 'var(--color-status-warn, #d97706)',
+  'activity-event': 'var(--color-status-info, #4a90e2)',
 }
 
 /** Source → label glyph for tooltip + ARIA. */
@@ -47,6 +48,7 @@ const SOURCE_LABELS: Record<KeeperTraceSource, string> = {
   'cascade-hop': 'cascade',
   'bdi-snapshot': 'BDI',
   'decision-log': 'decision',
+  'activity-event': 'activity',
 }
 
 interface TraceBucket {
@@ -92,11 +94,15 @@ export function bucketTraceEvents(
 }
 
 function lineOf(event: KeeperTraceEvent): number | null {
-  return event.source === 'anchored-thread' ? event.line : null
+  if (event.source === 'anchored-thread') return event.line
+  if (event.source === 'activity-event') return event.line
+  return null
 }
 
 function filePathOf(event: KeeperTraceEvent): string | null {
-  return event.source === 'anchored-thread' ? event.filePath ?? null : null
+  if (event.source === 'anchored-thread') return event.filePath ?? null
+  if (event.source === 'activity-event') return event.filePath
+  return null
 }
 
 interface OverlayKeeperTraceProps {
@@ -148,8 +154,9 @@ const OVERFLOW_STYLE = {
 
 function formatTooltip(event: KeeperTraceEvent): string {
   const sourceLabel = SOURCE_LABELS[event.source]
-  const lineSuffix = event.source === 'anchored-thread' && event.line !== null
-    ? ` L${event.line}`
+  const line = lineOf(event)
+  const lineSuffix = line !== null
+    ? ` L${line}`
     : ''
   const countSuffix = event.count > 1 ? ` ×${event.count}` : ''
   return `${sourceLabel}${lineSuffix}${countSuffix}`

--- a/dashboard/src/components/ide/run-activity-trace-bridge.test.ts
+++ b/dashboard/src/components/ide/run-activity-trace-bridge.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearTraces,
+  keeperTraceState,
+} from './keeper-trace-store'
+import { bridgeRunActivityEventsToTrace } from './run-activity-trace-bridge'
+import type { RunActivityEvent } from './run-activity-store'
+
+beforeEach(() => {
+  clearTraces()
+})
+
+afterEach(() => {
+  clearTraces()
+})
+
+describe('bridgeRunActivityEventsToTrace', () => {
+  it('pushes file-line activity context into the keeper trace store', () => {
+    const emitted = bridgeRunActivityEventsToTrace([
+      activity({
+        id: 'evt-1',
+        keeper_id: 'sangsu',
+        context: {
+          file_path: ' lib\\runtime.ml ',
+          line: 7,
+          goal_id: 'goal-runtime',
+          task_id: 'task-runtime',
+          log_id: 'turn-7',
+        },
+      }),
+    ], new Set())
+
+    expect([...emitted]).toEqual(['activity:run-default:evt-1'])
+    expect(keeperTraceState.value.events).toEqual([{
+      id: 'activity:run-default:evt-1',
+      tsMs: 1000,
+      keeperName: 'sangsu',
+      source: 'activity-event',
+      count: 1,
+      eventId: 'evt-1',
+      filePath: 'lib/runtime.ml',
+      line: 7,
+      surface: 'Goal',
+    }])
+  })
+
+  it('deduplicates already emitted activity events across refreshes', () => {
+    const event = activity({
+      id: 'evt-1',
+      context: {
+        file_path: 'lib/runtime.ml',
+        line: 4,
+        log_id: 'turn-4',
+      },
+    })
+
+    const emitted = bridgeRunActivityEventsToTrace([event], new Set())
+    const emittedAgain = bridgeRunActivityEventsToTrace([event], emitted)
+
+    expect(emittedAgain).toBeInstanceOf(Set)
+    expect(keeperTraceState.value.events).toHaveLength(1)
+    expect(keeperTraceState.value.events[0]?.count).toBe(1)
+  })
+
+  it('skips unscoped lines and unsafe file paths without poisoning later enrichment', () => {
+    const unscoped = activity({
+      id: 'evt-1',
+      context: { line: 4, log_id: 'turn-1' },
+    })
+    const unsafe = activity({
+      id: 'evt-2',
+      context: { file_path: '/tmp/runtime.ml', line: 5, log_id: 'turn-2' },
+    })
+
+    const first = bridgeRunActivityEventsToTrace([unscoped, unsafe], new Set())
+    expect([...first]).toEqual([])
+    expect(keeperTraceState.value.events).toEqual([])
+
+    const enriched = bridgeRunActivityEventsToTrace([
+      activity({
+        id: 'evt-1',
+        context: { file_path: 'lib/runtime.ml', line: 4, log_id: 'turn-1' },
+      }),
+    ], first)
+
+    expect([...enriched]).toEqual(['activity:run-default:evt-1'])
+    expect(keeperTraceState.value.events[0]).toMatchObject({
+      source: 'activity-event',
+      filePath: 'lib/runtime.ml',
+      line: 4,
+      surface: 'Log',
+    })
+  })
+})
+
+function activity(overrides: Partial<RunActivityEvent>): RunActivityEvent {
+  return {
+    id: 'evt-default',
+    run_id: 'run-default',
+    keeper_id: 'keeper-a',
+    verb: 'noted',
+    target: 'telemetry',
+    timestamp_ms: 1000,
+    ...overrides,
+  }
+}

--- a/dashboard/src/components/ide/run-activity-trace-bridge.ts
+++ b/dashboard/src/components/ide/run-activity-trace-bridge.ts
@@ -1,0 +1,50 @@
+import { pushTrace } from './keeper-trace-store'
+import { normalizeIdeContextFilePath, normalizeIdeContextLine } from './ide-state'
+import type { RunActivityEvent } from './run-activity-store'
+
+/**
+ * Bridge normalized run activity into the keeper-trace store so activity
+ * events with trusted file+line context become visible in the IDE line gutter.
+ *
+ * The caller owns `alreadyEmitted`; keeping the set outside this module avoids
+ * leaking component lifecycle across remounts while still deduping refreshes.
+ */
+export function bridgeRunActivityEventsToTrace(
+  events: ReadonlyArray<RunActivityEvent>,
+  alreadyEmitted: ReadonlySet<string>,
+): ReadonlySet<string> {
+  if (events.length === 0) return alreadyEmitted
+  const next = new Set(alreadyEmitted)
+  for (const event of events) {
+    const key = `activity:${event.run_id}:${event.id}`
+    if (next.has(key)) continue
+    const filePath = event.context?.file_path
+      ? normalizeIdeContextFilePath(event.context.file_path)
+      : null
+    const line = normalizeIdeContextLine(event.context?.line)
+    if (filePath === null || line === undefined) continue
+    if (!Number.isFinite(event.timestamp_ms)) continue
+    pushTrace({
+      id: key,
+      tsMs: event.timestamp_ms,
+      keeperName: event.keeper_id,
+      source: 'activity-event',
+      eventId: event.id,
+      filePath,
+      line,
+      surface: activityTraceSurface(event),
+    })
+    next.add(key)
+  }
+  return next
+}
+
+function activityTraceSurface(event: RunActivityEvent): string {
+  if (event.context?.pr_id) return 'PR'
+  if (event.context?.board_post_id) return 'Board'
+  if (event.context?.goal_id) return 'Goal'
+  if (event.context?.task_id) return 'Task'
+  if (event.context?.git_ref) return 'Git'
+  if (event.context?.log_id) return 'Log'
+  return event.kind?.trim() || 'Activity'
+}


### PR DESCRIPTION
## Summary

- add an activity-event keeper trace source for file+line activity context
- bridge normalized run activity into the keeper trace store
- render activity trace dots in the IDE line gutter and trace overlay

## Product impact

The IDE keeper-trace layer now makes normalized activity/log/telemetry context visible directly in the code line area. When an activity event carries file+line context, the editor gutter can show the same operational progress signal alongside anchored-thread trace dots instead of hiding it only in the activity rail.

## Evidence

- Adds `activity-event` to the keeper trace store with file/line/surface payload.
- Adds `run-activity-trace-bridge.ts` to map safe normalized run activity context into trace events.
- Keeps unsafe absolute paths and line-only activity out of the gutter.
- Extends editor gutter and overlay rendering to include `activity-event`.

## Review evidence

- `git diff --check HEAD~1..HEAD`
- `pnpm exec vitest run src/components/ide/keeper-trace-store.test.ts src/components/ide/run-activity-trace-bridge.test.ts src/components/ide/ide-editor-extensions.test.ts src/components/ide/overlay-keeper-trace.test.ts src/components/ide/ide-activity-panel.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/ide/keeper-trace-store.ts src/components/ide/run-activity-trace-bridge.ts src/components/ide/ide-activity-panel.ts src/components/ide/ide-editor-extensions.ts src/components/ide/overlay-keeper-trace.ts src/components/ide/keeper-trace-store.test.ts src/components/ide/run-activity-trace-bridge.test.ts src/components/ide/ide-editor-extensions.test.ts src/components/ide/overlay-keeper-trace.test.ts src/components/ide/ide-activity-panel.test.ts`
- `pnpm exec tsc --noEmit --pretty false`

## Linked issue

Follow-up slice for the active IDE visibility workstream; no standalone issue.
