### PR TITLE
fix(keeper): guard lifecycle event origins

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -162,10 +162,15 @@ let apply_post_turn_lifecycle_with_resilience_handles =
 let recover_latest_checkpoint_for_overflow_retry =
   Keeper_post_turn.recover_latest_checkpoint_for_overflow_retry
 
-let dispatch_keeper_phase_event ~(config : Coord.config) ~keeper_name event =
+let dispatch_keeper_phase_event
+    ~(config : Coord.config)
+    ?(origin = Keeper_registry.Generic_dispatch)
+    ~keeper_name
+    event =
   match
     Keeper_registry.dispatch_event
       ~base_path:config.base_path
+      ~origin
       keeper_name
       event
   with
@@ -223,11 +228,15 @@ let record_compaction_outcome ~keeper_name ~before_tokens ~after_tokens =
       saved_tokens before_tokens after_tokens keeper_name
 
 let dispatch_compaction_completed
-    ~(config : Coord.config) ~keeper_name ~before_tokens ~after_tokens =
+    ~(config : Coord.config)
+    ~origin
+    ~keeper_name
+    ~before_tokens
+    ~after_tokens =
   record_compaction_outcome ~keeper_name ~before_tokens ~after_tokens;
   Prometheus.inc_counter Keeper_metrics.metric_keeper_fsm_edge_transitions
     ~labels:[("edge", "kmc_to_ksm_compact_completed")] ();
-  dispatch_keeper_phase_event ~config ~keeper_name
+  dispatch_keeper_phase_event ~config ~origin ~keeper_name
     (Keeper_state_machine.Compaction_completed
        { before_tokens; after_tokens })
 
@@ -237,11 +246,17 @@ let dispatch_post_turn_lifecycle_events
     (lifecycle : post_turn_lifecycle) =
   if lifecycle.compaction.attempted then
     if lifecycle.compaction.applied then
-      dispatch_compaction_completed ~config ~keeper_name
+      dispatch_compaction_completed
+        ~config
+        ~origin:Keeper_registry.Post_turn_lifecycle
+        ~keeper_name
         ~before_tokens:lifecycle.compaction.before_tokens
         ~after_tokens:lifecycle.compaction.after_tokens
     else
-      dispatch_keeper_phase_event ~config ~keeper_name
+      dispatch_keeper_phase_event
+        ~config
+        ~origin:Keeper_registry.Post_turn_lifecycle
+        ~keeper_name
         (Keeper_state_machine.Compaction_failed
            {
              reason =
@@ -252,7 +267,10 @@ let dispatch_post_turn_lifecycle_events
            });
   match lifecycle.handoff_attempted, lifecycle.handoff_json with
   | true, Some _json ->
-      dispatch_keeper_phase_event ~config ~keeper_name
+      dispatch_keeper_phase_event
+        ~config
+        ~origin:Keeper_registry.Post_turn_lifecycle
+        ~keeper_name
         (Keeper_state_machine.Handoff_completed
            {
              generation = lifecycle.updated_meta.runtime.generation;
@@ -261,7 +279,10 @@ let dispatch_post_turn_lifecycle_events
                  lifecycle.updated_meta.runtime.trace_id;
            })
   | true, None ->
-      dispatch_keeper_phase_event ~config ~keeper_name
+      dispatch_keeper_phase_event
+        ~config
+        ~origin:Keeper_registry.Post_turn_lifecycle
+        ~keeper_name
         (Keeper_state_machine.Handoff_failed
            {
              reason =

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -233,6 +233,7 @@ val apply_post_turn_lifecycle_with_resilience_handles
 
 val dispatch_keeper_phase_event
   :  config:Coord.config
+  -> ?origin:Keeper_registry.lifecycle_event_origin
   -> keeper_name:string
   -> Keeper_state_machine.event
   -> unit
@@ -269,6 +270,7 @@ val record_compaction_outcome
     funnel through this helper to keep observability coherent. *)
 val dispatch_compaction_completed
   :  config:Coord.config
+  -> origin:Keeper_registry.lifecycle_event_origin
   -> keeper_name:string
   -> before_tokens:int
   -> after_tokens:int

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -2458,6 +2458,58 @@ let restore_tool_usage ~base_path name =
 
 (* ── RFC-0002 Event Dispatch ───────────────────────────── *)
 
+type lifecycle_event_origin =
+  | Generic_dispatch
+  | Post_turn_lifecycle
+  | Operator_compact
+
+let lifecycle_event_origin_to_string = function
+  | Generic_dispatch -> "generic_dispatch"
+  | Post_turn_lifecycle -> "post_turn_lifecycle"
+  | Operator_compact -> "operator_compact"
+;;
+
+let is_paired_lifecycle_event = function
+  | Keeper_state_machine.Compaction_started
+  | Keeper_state_machine.Compaction_completed _
+  | Keeper_state_machine.Compaction_failed _
+  | Keeper_state_machine.Handoff_started
+  | Keeper_state_machine.Handoff_completed _
+  | Keeper_state_machine.Handoff_failed _ -> true
+  | _ -> false
+;;
+
+let origin_allows_paired_lifecycle_event origin event =
+  match origin, event with
+  | Post_turn_lifecycle, event when is_paired_lifecycle_event event -> true
+  | ( Operator_compact
+    , ( Keeper_state_machine.Compaction_started
+      | Keeper_state_machine.Compaction_completed _
+      | Keeper_state_machine.Compaction_failed _ ) ) -> true
+  | Generic_dispatch, event when is_paired_lifecycle_event event -> false
+  | Operator_compact, event when is_paired_lifecycle_event event -> false
+  | _, _ -> true
+;;
+
+let validate_paired_lifecycle_origin origin event =
+  if origin_allows_paired_lifecycle_event origin event
+  then Ok ()
+  else
+    Error
+      (Keeper_state_machine.Precondition_violation
+         { event = Keeper_state_machine.event_to_string event
+         ; reason =
+             Printf.sprintf
+               "paired lifecycle event requires origin=post_turn_lifecycle%s; got %s"
+               (match event with
+                | Keeper_state_machine.Compaction_started
+                | Keeper_state_machine.Compaction_completed _
+                | Keeper_state_machine.Compaction_failed _ -> " or origin=operator_compact"
+                | _ -> "")
+               (lifecycle_event_origin_to_string origin)
+         })
+;;
+
 let execute_entry_action_observability
       ~(name : string)
       ~(phase : Keeper_state_machine.phase)
@@ -2587,6 +2639,7 @@ let compaction_stage_after_event entry event =
     state is consistent. *)
 let rec dispatch_event_with_audit
           ~base_path
+          ?(origin = Generic_dispatch)
           ?snapshot
           ?events_fired
           ?selected_event
@@ -2613,14 +2666,22 @@ let rec dispatch_event_with_audit
       | Keeper_state_machine.Context_measured { auto_rules; _ } -> Some (now, auto_rules)
       | _ -> entry.last_auto_rules
     in
+    let origin_result = validate_paired_lifecycle_origin origin event in
     let pending_turn_measurement = pending_measurement_after_event now entry event in
-    let compaction_stage = compaction_stage_after_event entry event in
+    let compaction_stage =
+      match origin_result with
+      | Error _ -> entry.compaction_stage
+      | Ok () -> compaction_stage_after_event entry event
+    in
     let result =
-      Keeper_state_machine.apply_event
-        ~current_phase:entry.phase
-        ~conditions:entry.conditions
-        ~event
-        ~now
+      match origin_result with
+      | Error _ as err -> err
+      | Ok () ->
+        Keeper_state_machine.apply_event
+          ~current_phase:entry.phase
+          ~conditions:entry.conditions
+          ~event
+          ~now
     in
     Dashboard_attribution.record
       (Keeper_state_machine.attribution_of_transition ~event result);
@@ -2786,10 +2847,12 @@ let rec dispatch_event_with_audit
        Error e)
 ;;
 
-let dispatch_event ~base_path name event = dispatch_event_with_audit ~base_path name event
+let dispatch_event ~base_path ?(origin = Generic_dispatch) name event =
+  dispatch_event_with_audit ~base_path ~origin name event
+;;
 
-let dispatch_event_and_log ~base_path name event =
-  match dispatch_event ~base_path name event with
+let dispatch_event_and_log ~base_path ?(origin = Generic_dispatch) name event =
+  match dispatch_event ~base_path ~origin name event with
   | Ok tr -> Ok tr
   | Error e ->
     let reason_label =
@@ -2805,8 +2868,8 @@ let dispatch_event_and_log ~base_path name event =
     Error e
 ;;
 
-let dispatch_event_unit ~base_path name event =
-  match dispatch_event_and_log ~base_path name event with
+let dispatch_event_unit ~base_path ?(origin = Generic_dispatch) name event =
+  match dispatch_event_and_log ~base_path ~origin name event with
   | Ok _ -> ()
   | Error e ->
     Log.Keeper.warn
@@ -2817,6 +2880,7 @@ let dispatch_event_unit ~base_path name event =
 
 let dispatch_event_with_audit_and_log
       ~base_path
+      ?(origin = Generic_dispatch)
       ?snapshot
       ?events_fired
       ?selected_event
@@ -2826,6 +2890,7 @@ let dispatch_event_with_audit_and_log
   match
     dispatch_event_with_audit
       ~base_path
+      ~origin
       ?snapshot
       ?events_fired
       ?selected_event

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -897,18 +897,33 @@ val restore_tool_usage : base_path:string -> string -> unit
 
 (** {1 RFC-0002 Event Dispatch} *)
 
+(** Dispatch origin for paired post-turn lifecycle events.
+
+    [Compaction_started]/[Compaction_completed]/[Compaction_failed] and
+    [Handoff_started]/[Handoff_completed]/[Handoff_failed] are same-turn
+    lifecycle pairs. The registry rejects them from [Generic_dispatch] so
+    keepalive/guard/manual callers cannot emit half of a pair outside the
+    owner path. *)
+type lifecycle_event_origin =
+  | Generic_dispatch
+  | Post_turn_lifecycle
+  | Operator_compact
+
 (** Dispatch a typed event through the state machine.
     Updates conditions, derives new phase, syncs legacy state.
     Returns the transition result or an error for invalid transitions.
     Prefer this over [set_state] for new code. *)
 val dispatch_event :
-  base_path:string -> string -> Keeper_state_machine.event ->
+  base_path:string ->
+  ?origin:lifecycle_event_origin ->
+  string -> Keeper_state_machine.event ->
   (Keeper_state_machine.transition_result, Keeper_state_machine.transition_error) result
 
 (** Like [dispatch_event], but preserves richer audit metadata when the event
     causes a phase transition. *)
 val dispatch_event_with_audit :
   base_path:string ->
+  ?origin:lifecycle_event_origin ->
   ?snapshot:Keeper_measurement.measurement_snapshot ->
   ?events_fired:Keeper_state_machine.event list ->
   ?selected_event:Keeper_state_machine.event ->
@@ -919,18 +934,23 @@ val dispatch_event_with_audit :
     [Error] so silent-failure call sites do not lose the signal.
     Same return type — callers that need the result can still match. *)
 val dispatch_event_and_log :
-  base_path:string -> string -> Keeper_state_machine.event ->
+  base_path:string ->
+  ?origin:lifecycle_event_origin ->
+  string -> Keeper_state_machine.event ->
   (Keeper_state_machine.transition_result, Keeper_state_machine.transition_error) result
 
 (** [dispatch_event_unit] wraps [dispatch_event_and_log] and logs a warning
     on [Error] instead of returning the result. Replaces [ignore (...)] call sites
     that previously swallowed transition errors silently. *)
 val dispatch_event_unit :
-  base_path:string -> string -> Keeper_state_machine.event -> unit
+  base_path:string ->
+  ?origin:lifecycle_event_origin ->
+  string -> Keeper_state_machine.event -> unit
 (** Like [dispatch_event_with_audit], but logs and emits a Prometheus
     counter on [Error]. *)
 val dispatch_event_with_audit_and_log :
   base_path:string ->
+  ?origin:lifecycle_event_origin ->
   ?snapshot:Keeper_measurement.measurement_snapshot ->
   ?events_fired:Keeper_state_machine.event list ->
   ?selected_event:Keeper_state_machine.event ->

--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -131,14 +131,15 @@ type auto_rule_summary = {
     These are the ONLY inputs to the deterministic state machine.
     Non-deterministic measurements become typed events at the boundary.
 
-    {2 Post-turn lifecycle contract (implicit invariant)}
+    {2 Paired lifecycle event contract}
 
     [Compaction_started] / [Handoff_started] / their matching
-    [_completed] / [_failed] events MUST be dispatched only from
-    {!Keeper_post_turn.apply_post_turn_lifecycle}, which runs
-    synchronously at the tail of a keeper turn (inside
-    [Keeper_unified_turn.run_unified_turn] or the legacy
-    [Keeper_turn] path).
+    [_completed] / [_failed] events MUST be dispatched with an explicit
+    lifecycle origin through {!Keeper_registry}. Normal turn-owned events
+    use [Post_turn_lifecycle], which runs synchronously at the tail of a
+    keeper turn (inside [Keeper_unified_turn.run_unified_turn] or the
+    legacy [Keeper_turn] path). Manual compaction uses the narrower
+    [Operator_compact] origin for compaction events only.
 
     The keepalive loop ({!Keeper_keepalive.run_heartbeat_loop}) does
     NOT explicitly gate dispatch on [phase]. It relies on the
@@ -155,11 +156,9 @@ type auto_rule_summary = {
     [NoDrainTransition] / [GhostDispatch] actions are the exact
     counterexamples TLC will find.
 
-    If a future change needs to emit these events from outside
-    [apply_post_turn_lifecycle], add an explicit phase gate to the
-    keepalive dispatch site (roughly: [phase_allows_dispatch] reading
-    [Keeper_registry.get] before [run_unified_turn]) and re-verify
-    the TLA+ spec against the new code path. *)
+    If a future change needs another origin for these events, add it to
+    the registry origin guard and re-verify the TLA+ spec against the new
+    code path. *)
 type event =
   | Heartbeat_ok
   | Heartbeat_failed of { consecutive : int; max_allowed : int }
@@ -172,15 +171,15 @@ type event =
       auto_rules : auto_rule_summary;
     }
   | Compaction_started
-    (** Emit ONLY from {!Keeper_post_turn.apply_post_turn_lifecycle}.
-        See the post-turn lifecycle contract above. *)
+    (** Emit only through the registry lifecycle origin guard. See the
+        paired lifecycle contract above. *)
   | Compaction_completed of { before_tokens : int; after_tokens : int }
     (** Must fire in the same turn as the matching [Compaction_started]. *)
   | Compaction_failed of { reason : string }
     (** Must fire in the same turn as the matching [Compaction_started]. *)
   | Handoff_started
-    (** Emit ONLY from {!Keeper_post_turn.apply_post_turn_lifecycle}.
-        See the post-turn lifecycle contract above. *)
+    (** Emit only through the registry lifecycle origin guard. See the
+        paired lifecycle contract above. *)
   | Handoff_completed of { new_trace_id : string; generation : int }
     (** Must fire in the same turn as the matching [Handoff_started]. *)
   | Handoff_failed of { reason : string }

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -518,11 +518,13 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                   ~on_compaction_started:(fun () ->
                     Keeper_exec_context.dispatch_keeper_phase_event
                       ~config:ctx.config
+                      ~origin:Keeper_registry.Post_turn_lifecycle
                       ~keeper_name:meta.name
                       Keeper_state_machine.Compaction_started)
                   ~on_handoff_started:(fun () ->
                     Keeper_exec_context.dispatch_keeper_phase_event
                       ~config:ctx.config
+                      ~origin:Keeper_registry.Post_turn_lifecycle
                       ~keeper_name:meta.name
                       Keeper_state_machine.Handoff_started)
                   ~meta

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -2472,11 +2472,13 @@ let run_keeper_cycle
                       ~on_compaction_started:(fun () ->
                         dispatch_keeper_phase_event
                           ~config
+                          ~origin:Keeper_registry.Post_turn_lifecycle
                           ~keeper_name:meta.name
                           Keeper_state_machine.Compaction_started)
                       ~on_handoff_started:(fun () ->
                         dispatch_keeper_phase_event
                           ~config
+                          ~origin:Keeper_registry.Post_turn_lifecycle
                           ~keeper_name:meta.name
                           Keeper_state_machine.Handoff_started)
                       ~meta

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -1481,6 +1481,7 @@ let handle_keeper_compact ctx args : tool_result =
         let max_tokens = resolve_primary_max_context (Some meta) in
         Keeper_exec_context.dispatch_keeper_phase_event
           ~config:ctx.config ~keeper_name:name
+          ~origin:Keeper_registry.Operator_compact
           Keeper_state_machine.Compaction_started;
         match
           Keeper_exec_context.recover_latest_checkpoint_for_overflow_retry
@@ -1489,6 +1490,7 @@ let handle_keeper_compact ctx args : tool_result =
         | Some recovery ->
           Keeper_exec_context.dispatch_compaction_completed
             ~config:ctx.config ~keeper_name:name
+            ~origin:Keeper_registry.Operator_compact
             ~before_tokens:recovery.compaction.before_tokens
             ~after_tokens:recovery.compaction.after_tokens;
           invalidate_status_cache name;
@@ -1515,6 +1517,7 @@ let handle_keeper_compact ctx args : tool_result =
              signal. *)
           Keeper_exec_context.dispatch_keeper_phase_event
             ~config:ctx.config ~keeper_name:name
+            ~origin:Keeper_registry.Operator_compact
             (Keeper_state_machine.Compaction_failed {
                reason = "no_valid_checkpoint";
             });

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -2606,6 +2606,7 @@ let test_dispatch_keeper_phase_event_uses_room_base_path () =
       ignore (KR.register ~base_path:config.base_path meta.name meta);
       KEC.dispatch_keeper_phase_event
         ~config
+        ~origin:KR.Post_turn_lifecycle
         ~keeper_name:meta.name
         KST.Compaction_started;
       match KR.get ~base_path:config.base_path meta.name with
@@ -2627,6 +2628,7 @@ let test_dispatch_post_turn_lifecycle_events_uses_room_base_path () =
       ignore (KR.register ~base_path:config.base_path meta.name meta);
       KEC.dispatch_keeper_phase_event
         ~config
+        ~origin:KR.Post_turn_lifecycle
         ~keeper_name:meta.name
         KST.Compaction_started;
       let lifecycle =
@@ -2654,6 +2656,45 @@ let test_dispatch_post_turn_lifecycle_events_uses_room_base_path () =
           check string "compaction completion reaches registry" "running"
             (KST.phase_to_string entry.phase)
       | None -> fail "expected registered keeper after lifecycle dispatch")
+
+let test_dispatch_keeper_phase_event_rejects_unscoped_lifecycle_event () =
+  let base_dir = temp_dir "keeper_lifecycle_registry_origin_guard" in
+  Fun.protect
+    ~finally:(fun () ->
+      KR.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      KR.clear ();
+      let config = Masc_mcp.Coord.default_config base_dir in
+      let meta = make_keeper_meta ~name:"keeper-origin-guard" () in
+      ignore (KR.register ~base_path:config.base_path meta.name meta);
+      let labels =
+        [ ("keeper", meta.name); ("event", "compaction_started") ]
+      in
+      let before =
+        Masc_mcp.Prometheus.get_metric_value
+          Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_dispatch_rejections
+          ~labels ()
+        |> Option.value ~default:0.0
+      in
+      KEC.dispatch_keeper_phase_event
+        ~config
+        ~keeper_name:meta.name
+        KST.Compaction_started;
+      let after =
+        Masc_mcp.Prometheus.get_metric_value
+          Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_dispatch_rejections
+          ~labels ()
+        |> Option.value ~default:0.0
+      in
+      check bool "origin guard rejection metric increments" true (after > before);
+      match KR.get ~base_path:config.base_path meta.name with
+      | Some entry ->
+          check string "unscoped compaction start is rejected" "running"
+            (KST.phase_to_string entry.phase)
+      | None -> fail "expected registered keeper after rejected lifecycle dispatch")
 
 let test_dispatch_keeper_phase_event_rejection_increments_metric () =
   let base_dir = temp_dir "keeper_lifecycle_registry_rejection" in
@@ -2907,6 +2948,8 @@ let () =
             test_dispatch_keeper_phase_event_uses_room_base_path;
           test_case "post-turn lifecycle events use room base_path" `Quick
             test_dispatch_post_turn_lifecycle_events_uses_room_base_path;
+          test_case "unscoped lifecycle event is rejected" `Quick
+            test_dispatch_keeper_phase_event_rejects_unscoped_lifecycle_event;
           test_case "phase event rejection increments metric" `Quick
             test_dispatch_keeper_phase_event_rejection_increments_metric;
           test_case "keepalive event rejection increments metric" `Quick

--- a/test/test_keeper_lifecycle_chaos.ml
+++ b/test/test_keeper_lifecycle_chaos.ml
@@ -43,13 +43,22 @@ let get_phase name =
   | None -> Alcotest.fail ("keeper not found: " ^ name)
   | Some e -> e.phase
 
+let paired_lifecycle_origin = function
+  | KSM.Compaction_started
+  | KSM.Compaction_completed _
+  | KSM.Compaction_failed _
+  | KSM.Handoff_started
+  | KSM.Handoff_completed _
+  | KSM.Handoff_failed _ -> R.Post_turn_lifecycle
+  | _ -> R.Generic_dispatch
+
 let dispatch name event =
-  match R.dispatch_event ~base_path:bp name event with
+  match R.dispatch_event ~base_path:bp ~origin:(paired_lifecycle_origin event) name event with
   | Ok tr -> tr
   | Error e -> Alcotest.fail (KSM.transition_error_to_string e)
 
 let dispatch_expect_rejected name event =
-  match R.dispatch_event ~base_path:bp name event with
+  match R.dispatch_event ~base_path:bp ~origin:(paired_lifecycle_origin event) name event with
   | Ok _ -> Alcotest.fail "expected rejected transition"
   (* R.dispatch_event returns a closed transition_error type.  Terminal
      keepers always yield Terminal_state (apply_event guards on


### PR DESCRIPTION
## Summary
- add typed registry origins for paired compaction/handoff lifecycle events
- reject paired lifecycle events from generic dispatch so keepalive/guard paths cannot emit half of a pair
- thread post-turn and operator-compact origins through the existing dispatch helpers
- add regression coverage for rejected unscoped lifecycle dispatch while preserving post-turn/manual compact paths

## Deep Dive
- DD-008: Compaction/Handoff paired-event invariant was documented on the state-machine boundary but not enforced by the registry dispatch API.

## Validation
- ocamlformat --check lib/keeper/keeper_registry.mli lib/keeper/keeper_registry.ml lib/keeper/keeper_exec_context.mli lib/keeper/keeper_exec_context.ml lib/keeper/keeper_turn.ml lib/keeper/keeper_unified_turn.ml lib/tool_keeper.ml lib/keeper/keeper_state_machine.mli test/test_keeper_lifecycle.ml test/test_keeper_lifecycle_chaos.ml
- git diff --check origin/main...HEAD
- bash scripts/lint/godfile-size-regression.sh
- env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_lifecycle.exe test/test_keeper_lifecycle_chaos.exe test/test_keeper_registry.exe
- _build/default/test/test_keeper_lifecycle.exe
- _build/default/test/test_keeper_lifecycle_chaos.exe
- _build/default/test/test_keeper_registry.exe