### PR TITLE
fix(dashboard): surface OAS runtime evidence refs

### DIFF
--- a/dashboard/src/components/oas-health-chip.test.ts
+++ b/dashboard/src/components/oas-health-chip.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+import { html } from 'htm/preact'
+import { cleanup, render } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { TelemetryEntry } from '../api/dashboard'
+import { hydrateOasRuntimeFromTelemetryEntries } from '../oas-runtime-store'
+import { OasHealthChip } from './oas-health-chip'
+
+function resetRuntimeState() {
+  hydrateOasRuntimeFromTelemetryEntries([])
+}
+
+describe('OasHealthChip', () => {
+  beforeEach(resetRuntimeState)
+
+  afterEach(() => {
+    cleanup()
+    resetRuntimeState()
+  })
+
+  it('renders OAS runtime evidence refs in the health summary', () => {
+    hydrateOasRuntimeFromTelemetryEntries([
+      {
+        source: 'oas_event',
+        type: 'oas:runtime.artifact_attached',
+        event_type: 'runtime.artifact_attached',
+        ts_unix: 500,
+        correlation_id: 'sess-evidence',
+        run_id: 'run-evidence',
+        payload: {
+          kind: [
+            'Artifact_attached',
+            {
+              artifact_id: 'art-raw',
+              name: 'runtime-raw-trace-json',
+              path: '/tmp/runtime-raw-trace-json.json',
+            },
+          ],
+        },
+      },
+      {
+        source: 'oas_event',
+        type: 'oas:runtime.session_completed',
+        event_type: 'runtime.session_completed',
+        ts_unix: 510,
+        correlation_id: 'sess-evidence',
+        run_id: 'run-evidence',
+        payload: {
+          evidence: {
+            files: [
+              { label: 'report_json', path: '/tmp/report.json' },
+              { label: 'proof_json', path: '/tmp/proof.json' },
+              { label: 'telemetry_json', path: '/tmp/runtime-telemetry-json.json' },
+            ],
+          },
+        },
+      },
+    ] as TelemetryEntry[])
+
+    const { container } = render(html`<${OasHealthChip} />`)
+
+    expect(container.textContent).toContain('OAS 런타임')
+    expect(container.textContent).toContain('증거 참조')
+    expect(container.textContent).toContain('trace')
+    expect(container.textContent).toContain('report')
+    expect(container.textContent).toContain('proof')
+  })
+})

--- a/dashboard/src/components/oas-health-chip.ts
+++ b/dashboard/src/components/oas-health-chip.ts
@@ -88,6 +88,25 @@ function describeSampleWindow(summary: Pick<OasHealthSummary,
   return `sample ${summary.replayLoadedEvents}/${summary.replayTotalMatchingEvents}`
 }
 
+function describeEvidenceDetail(summary: Pick<OasHealthSummary,
+  | 'artifactRefsCount'
+  | 'rawTraceRefsCount'
+  | 'reportRefsCount'
+  | 'proofRefsCount'
+  | 'telemetryRefsCount'
+  | 'runtimeEvidenceRefsCount'
+>): string {
+  const parts = [
+    summary.rawTraceRefsCount > 0 ? `trace ${summary.rawTraceRefsCount}` : null,
+    summary.reportRefsCount > 0 ? `report ${summary.reportRefsCount}` : null,
+    summary.proofRefsCount > 0 ? `proof ${summary.proofRefsCount}` : null,
+    summary.telemetryRefsCount > 0 ? `telemetry ${summary.telemetryRefsCount}` : null,
+    summary.runtimeEvidenceRefsCount > 0 ? `evidence ${summary.runtimeEvidenceRefsCount}` : null,
+    summary.artifactRefsCount > 0 ? `artifact ${summary.artifactRefsCount}` : null,
+  ].filter((part): part is string => part !== null)
+  return parts.length > 0 ? parts.slice(0, 3).join(' · ') : '증거 참조 없음'
+}
+
 export function OasHealthChip() {
   const summary = useComputed(() => oasHealthSummary.value)
   const recentEvents = useComputed(() => oasAgentEvents.value.slice(0, 3))
@@ -114,6 +133,10 @@ export function OasHealthChip() {
     summary.value.lastErrorTs != null
       ? `최근 ${formatLastTick(summary.value.lastErrorTs)}`
       : 'Api/agent 실패'
+  const evidenceDetail =
+    summary.value.lastEvidenceTs != null
+      ? `${describeEvidenceDetail(summary.value)} · 최근 ${formatLastTick(summary.value.lastEvidenceTs)}`
+      : describeEvidenceDetail(summary.value)
 
   return html`
     <${Card} title="OAS 런타임">
@@ -133,6 +156,12 @@ export function OasHealthChip() {
           value=${String(summary.value.totalErrors)}
           status=${summary.value.totalErrors > 0 ? 'crit' : undefined}
           delta=${{ direction: summary.value.totalErrors > 0 ? 'down' as const : 'flat' as const, text: sampleWindow ? `${errorDetail} · ${sampleWindow}` : errorDetail }}
+        />
+        <${StatTile}
+          label="증거 참조"
+          value=${String(summary.value.evidenceRefsCount)}
+          status=${summary.value.evidenceRefsCount > 0 ? 'ok' : 'warn'}
+          delta=${{ direction: summary.value.evidenceRefsCount > 0 ? 'up' as const : 'flat' as const, text: sampleWindow ? `${evidenceDetail} · ${sampleWindow}` : evidenceDetail }}
         />
         <${StatTile}
           label="에이전트 이벤트"

--- a/dashboard/src/oas-runtime-store.test.ts
+++ b/dashboard/src/oas-runtime-store.test.ts
@@ -153,6 +153,101 @@ describe('oas-runtime-store', () => {
     })
   })
 
+  it('hydrates runtime artifact and evidence refs from OAS events', () => {
+    hydrateOasRuntimeFromTelemetryEntries([
+      {
+        source: 'oas_event',
+        type: 'oas:runtime.artifact_attached',
+        event_type: 'runtime.artifact_attached',
+        ts_unix: 500,
+        correlation_id: 'sess-evidence',
+        run_id: 'run-evidence',
+        payload: {
+          seq: 4,
+          ts: 500,
+          kind: [
+            'Artifact_attached',
+            {
+              artifact_id: 'art-raw',
+              name: 'runtime-raw-trace-json',
+              kind: 'json',
+              mime_type: 'application/json',
+              path: '/tmp/runtime-raw-trace-json.json',
+              size_bytes: 512,
+            },
+          ],
+        },
+      },
+      {
+        source: 'oas_event',
+        type: 'oas:runtime.artifact_attached',
+        event_type: 'runtime.artifact_attached',
+        ts_unix: 510,
+        correlation_id: 'sess-evidence',
+        run_id: 'run-evidence',
+        payload: {
+          seq: 5,
+          ts: 510,
+          kind: [
+            'Artifact_attached',
+            {
+              artifact_id: 'art-evidence',
+              name: 'runtime-evidence',
+              kind: 'json',
+              mime_type: 'application/json',
+              path: '/tmp/runtime-evidence.json',
+              size_bytes: 1024,
+            },
+          ],
+        },
+      },
+      {
+        source: 'oas_event',
+        type: 'oas:runtime.session_completed',
+        event_type: 'runtime.session_completed',
+        ts_unix: 520,
+        correlation_id: 'sess-evidence',
+        run_id: 'run-evidence',
+        payload: {
+          evidence: {
+            files: [
+              { label: 'report_json', path: '/tmp/report.json' },
+              { label: 'proof_json', path: '/tmp/proof.json' },
+              { label: 'telemetry_json', path: '/tmp/runtime-telemetry-json.json' },
+            ],
+          },
+        },
+      },
+      {
+        source: 'oas_event',
+        type: 'oas:runtime.agent_completed',
+        event_type: 'runtime.agent_completed',
+        ts_unix: 530,
+        correlation_id: 'sess-evidence',
+        run_id: 'run-evidence',
+        payload: {
+          kind: [
+            'Agent_completed',
+            {
+              participant_name: 'alpha',
+              raw_trace_run_id: 'raw-run-1',
+            },
+          ],
+        },
+      },
+    ] as TelemetryEntry[])
+
+    expect(oasHealthSummary.value.totalEvents).toBe(4)
+    expect(oasHealthSummary.value.evidenceRefsCount).toBeGreaterThan(0)
+    expect(oasHealthSummary.value.artifactRefsCount).toBe(2)
+    expect(oasHealthSummary.value.rawTraceRefsCount).toBeGreaterThanOrEqual(2)
+    expect(oasHealthSummary.value.reportRefsCount).toBeGreaterThanOrEqual(1)
+    expect(oasHealthSummary.value.proofRefsCount).toBeGreaterThanOrEqual(1)
+    expect(oasHealthSummary.value.telemetryRefsCount).toBeGreaterThanOrEqual(1)
+    expect(oasHealthSummary.value.runtimeEvidenceRefsCount).toBeGreaterThanOrEqual(1)
+    expect(oasHealthSummary.value.lastEvidenceTs).toBe(530_000)
+  })
+
   it('dedupes timestamp-less events across replay/live time drift', () => {
     vi.useFakeTimers()
     try {

--- a/dashboard/src/oas-runtime-store.ts
+++ b/dashboard/src/oas-runtime-store.ts
@@ -7,6 +7,7 @@ import {
   noteOasReplayWindow,
   pushOasAgentEvent,
   recordOasError,
+  recordOasEvidenceRefs,
   recordOasLlmCall,
   resetOasRuntimeSignals,
   updateOasKeeperSnapshot,
@@ -26,8 +27,156 @@ type IngestOptions = {
   origin?: 'live' | 'replay'
 }
 
+type EvidenceRefSets = {
+  evidenceRefs: Set<string>
+  artifactRefs: Set<string>
+  rawTraceRefs: Set<string>
+  reportRefs: Set<string>
+  proofRefs: Set<string>
+  telemetryRefs: Set<string>
+  runtimeEvidenceRefs: Set<string>
+}
+
 const seenOasEventKeys = new Set<string>()
 let replayGeneration = 0
+
+function emptyEvidenceRefSets(): EvidenceRefSets {
+  return {
+    evidenceRefs: new Set(),
+    artifactRefs: new Set(),
+    rawTraceRefs: new Set(),
+    reportRefs: new Set(),
+    proofRefs: new Set(),
+    telemetryRefs: new Set(),
+    runtimeEvidenceRefs: new Set(),
+  }
+}
+
+function addEvidenceRef(target: Set<string>, all: Set<string>, ref: string): void {
+  const text = ref.trim()
+  if (!text) return
+  target.add(text)
+  all.add(text)
+}
+
+function classifyEvidenceString(
+  sets: EvidenceRefSets,
+  key: string,
+  value: string,
+): void {
+  const keyText = key.toLowerCase()
+  const valueText = value.trim()
+  if (!valueText) return
+  const combined = `${keyText} ${valueText.toLowerCase()}`
+  const ref = `${keyText || 'value'}:${valueText}`
+  const artifactKey =
+    keyText === 'artifact_id'
+    || keyText === 'artifact_ref'
+    || keyText === 'artifact_path'
+    || keyText === 'artifact_uri'
+    || keyText === 'artifact'
+  if (artifactKey || combined.includes('artifact://')) {
+    addEvidenceRef(sets.artifactRefs, sets.evidenceRefs, ref)
+  }
+  if (
+    keyText.includes('raw_trace')
+    || combined.includes('raw_trace')
+    || combined.includes('raw-trace')
+  ) {
+    addEvidenceRef(sets.rawTraceRefs, sets.evidenceRefs, ref)
+  }
+  if (
+    keyText === 'report'
+    || keyText === 'report_json'
+    || keyText === 'report_md'
+    || keyText === 'report_path'
+    || keyText === 'report_ref'
+    || keyText === 'report_uri'
+    || combined.includes('report_json')
+    || combined.includes('report_md')
+  ) {
+    addEvidenceRef(sets.reportRefs, sets.evidenceRefs, ref)
+  }
+  if (
+    keyText === 'proof'
+    || keyText === 'proof_json'
+    || keyText === 'proof_md'
+    || keyText === 'proof_path'
+    || keyText === 'proof_ref'
+    || keyText === 'proof_uri'
+    || combined.includes('proof_json')
+    || combined.includes('proof_md')
+  ) {
+    addEvidenceRef(sets.proofRefs, sets.evidenceRefs, ref)
+  }
+  if (
+    keyText === 'telemetry'
+    || keyText === 'telemetry_json'
+    || keyText === 'telemetry_md'
+    || keyText === 'telemetry_path'
+    || keyText === 'telemetry_ref'
+    || keyText === 'telemetry_uri'
+    || combined.includes('runtime-telemetry')
+    || combined.includes('telemetry_json')
+    || combined.includes('telemetry_md')
+  ) {
+    addEvidenceRef(sets.telemetryRefs, sets.evidenceRefs, ref)
+  }
+  if (
+    keyText === 'evidence'
+    || keyText === 'evidence_json'
+    || keyText === 'evidence_bundle'
+    || keyText === 'evidence_file'
+    || keyText === 'evidence_path'
+    || keyText === 'evidence_ref'
+    || combined.includes('runtime-evidence')
+  ) {
+    addEvidenceRef(sets.runtimeEvidenceRefs, sets.evidenceRefs, ref)
+  }
+}
+
+function collectEvidenceRefs(
+  value: unknown,
+  sets: EvidenceRefSets,
+  key = '',
+  depth = 0,
+): void {
+  if (depth > 8) return
+  if (typeof value === 'string') {
+    classifyEvidenceString(sets, key, value)
+    return
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectEvidenceRefs(item, sets, key, depth + 1)
+    }
+    return
+  }
+  if (!isRecord(value)) return
+  const artifactId = asString(value.artifact_id)
+  if (artifactId) {
+    addEvidenceRef(sets.artifactRefs, sets.evidenceRefs, `artifact_id:${artifactId}`)
+  }
+  for (const [childKey, childValue] of Object.entries(value)) {
+    collectEvidenceRefs(childValue, sets, childKey, depth + 1)
+  }
+}
+
+function recordEvidenceRefsForEvent(event: OasRuntimeEnvelope): void {
+  const sets = emptyEvidenceRefSets()
+  collectEvidenceRefs(event, sets)
+  if (sets.evidenceRefs.size === 0) return
+  recordOasEvidenceRefs({
+    evidenceRefsCount: sets.evidenceRefs.size,
+    artifactRefsCount: sets.artifactRefs.size,
+    rawTraceRefsCount: sets.rawTraceRefs.size,
+    reportRefsCount: sets.reportRefs.size,
+    proofRefsCount: sets.proofRefs.size,
+    telemetryRefsCount: sets.telemetryRefs.size,
+    runtimeEvidenceRefsCount: sets.runtimeEvidenceRefs.size,
+    tsMs: eventTimestampMs(event),
+  })
+}
 
 function eventPayload(event: OasRuntimeEnvelope): Record<string, unknown> {
   return isRecord(event.payload) ? event.payload : {}
@@ -172,6 +321,7 @@ function ingestRuntimeProjection(
 ): void {
   const payload = eventPayload(event)
   const agentName = agentNameFromEnvelope(event)
+  recordEvidenceRefsForEvent(event)
   switch (event.type) {
     case 'oas:masc:autonomy:agent_selected':
       pushOasAgentEvent({

--- a/dashboard/src/store.test.ts
+++ b/dashboard/src/store.test.ts
@@ -8,6 +8,14 @@ import {
   oasTotalErrors,
   oasLastLlmCallTs,
   oasLastErrorTs,
+  oasEvidenceRefsCount,
+  oasArtifactRefsCount,
+  oasRawTraceRefsCount,
+  oasReportRefsCount,
+  oasProofRefsCount,
+  oasTelemetryRefsCount,
+  oasRuntimeEvidenceRefsCount,
+  oasLastEvidenceTs,
   oasHealthSummary,
   noteOasReplayWindow,
   resetOasRuntimeSignals,
@@ -15,6 +23,7 @@ import {
   updateOasKeeperSnapshot,
   recordOasLlmCall,
   recordOasError,
+  recordOasEvidenceRefs,
 } from './store'
 import type { OasAgentEvent, OasKeeperSnapshot } from './types/oas'
 
@@ -35,6 +44,7 @@ describe('oasHealthSummary', () => {
     expect(oasHealthSummary.value.replayTruncated).toBe(false)
     expect(oasHealthSummary.value.totalLlmCalls).toBe(4)
     expect(oasHealthSummary.value.totalErrors).toBe(2)
+    expect(oasHealthSummary.value.evidenceRefsCount).toBe(0)
   })
 
   it('tracks replay sample size separately from total matching entries', () => {
@@ -130,10 +140,18 @@ describe('oasHealthSummary', () => {
     expect(s.lastKeeperTick).toBeNull()
     expect(s.lastLlmCallTs).toBeNull()
     expect(s.lastErrorTs).toBeNull()
+    expect(s.evidenceRefsCount).toBe(0)
+    expect(s.artifactRefsCount).toBe(0)
+    expect(s.rawTraceRefsCount).toBe(0)
+    expect(s.reportRefsCount).toBe(0)
+    expect(s.proofRefsCount).toBe(0)
+    expect(s.telemetryRefsCount).toBe(0)
+    expect(s.runtimeEvidenceRefsCount).toBe(0)
+    expect(s.lastEvidenceTs).toBeNull()
   })
 })
 
-describe('recordOasLlmCall / recordOasError', () => {
+describe('recordOasLlmCall / recordOasError / recordOasEvidenceRefs', () => {
   beforeEach(resetOasSignals)
 
   it('increments LLM call counter and pins timestamp', () => {
@@ -156,5 +174,37 @@ describe('recordOasLlmCall / recordOasError', () => {
     recordOasError(2)
     expect(oasTotalLlmCalls.value).toBe(1)
     expect(oasTotalErrors.value).toBe(1)
+  })
+
+  it('tracks OAS evidence reference counters independently', () => {
+    recordOasEvidenceRefs({
+      evidenceRefsCount: 6,
+      artifactRefsCount: 2,
+      rawTraceRefsCount: 1,
+      reportRefsCount: 1,
+      proofRefsCount: 1,
+      telemetryRefsCount: 1,
+      runtimeEvidenceRefsCount: 1,
+      tsMs: 1_700_000_000_000,
+    })
+
+    expect(oasEvidenceRefsCount.value).toBe(6)
+    expect(oasArtifactRefsCount.value).toBe(2)
+    expect(oasRawTraceRefsCount.value).toBe(1)
+    expect(oasReportRefsCount.value).toBe(1)
+    expect(oasProofRefsCount.value).toBe(1)
+    expect(oasTelemetryRefsCount.value).toBe(1)
+    expect(oasRuntimeEvidenceRefsCount.value).toBe(1)
+    expect(oasLastEvidenceTs.value).toBe(1_700_000_000_000)
+    expect(oasHealthSummary.value).toMatchObject({
+      evidenceRefsCount: 6,
+      artifactRefsCount: 2,
+      rawTraceRefsCount: 1,
+      reportRefsCount: 1,
+      proofRefsCount: 1,
+      telemetryRefsCount: 1,
+      runtimeEvidenceRefsCount: 1,
+      lastEvidenceTs: 1_700_000_000_000,
+    })
   })
 })

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -175,6 +175,14 @@ export const oasTotalLlmCalls = signal(0)
 export const oasTotalErrors = signal(0)
 export const oasLastLlmCallTs = signal<number | null>(null)
 export const oasLastErrorTs = signal<number | null>(null)
+export const oasEvidenceRefsCount = signal(0)
+export const oasArtifactRefsCount = signal(0)
+export const oasRawTraceRefsCount = signal(0)
+export const oasReportRefsCount = signal(0)
+export const oasProofRefsCount = signal(0)
+export const oasTelemetryRefsCount = signal(0)
+export const oasRuntimeEvidenceRefsCount = signal(0)
+export const oasLastEvidenceTs = signal<number | null>(null)
 
 export function resetOasRuntimeSignals(): void {
   oasAgentEventsRing.clear()
@@ -189,6 +197,14 @@ export function resetOasRuntimeSignals(): void {
   oasTotalErrors.value = 0
   oasLastLlmCallTs.value = null
   oasLastErrorTs.value = null
+  oasEvidenceRefsCount.value = 0
+  oasArtifactRefsCount.value = 0
+  oasRawTraceRefsCount.value = 0
+  oasReportRefsCount.value = 0
+  oasProofRefsCount.value = 0
+  oasTelemetryRefsCount.value = 0
+  oasRuntimeEvidenceRefsCount.value = 0
+  oasLastEvidenceTs.value = null
 }
 
 export function noteOasReplayWindow(input: {
@@ -283,6 +299,46 @@ export function recordOasError(tsMs: number): void {
   oasLastErrorTs.value = Math.max(oasLastErrorTs.value ?? 0, tsMs)
 }
 
+export function recordOasEvidenceRefs(input: {
+  evidenceRefsCount?: number
+  artifactRefsCount?: number
+  rawTraceRefsCount?: number
+  reportRefsCount?: number
+  proofRefsCount?: number
+  telemetryRefsCount?: number
+  runtimeEvidenceRefsCount?: number
+  tsMs?: number | null
+}): void {
+  const evidenceRefsCount = Math.max(0, Math.floor(input.evidenceRefsCount ?? 0))
+  const artifactRefsCount = Math.max(0, Math.floor(input.artifactRefsCount ?? 0))
+  const rawTraceRefsCount = Math.max(0, Math.floor(input.rawTraceRefsCount ?? 0))
+  const reportRefsCount = Math.max(0, Math.floor(input.reportRefsCount ?? 0))
+  const proofRefsCount = Math.max(0, Math.floor(input.proofRefsCount ?? 0))
+  const telemetryRefsCount = Math.max(0, Math.floor(input.telemetryRefsCount ?? 0))
+  const runtimeEvidenceRefsCount = Math.max(0, Math.floor(input.runtimeEvidenceRefsCount ?? 0))
+  if (
+    evidenceRefsCount
+    + artifactRefsCount
+    + rawTraceRefsCount
+    + reportRefsCount
+    + proofRefsCount
+    + telemetryRefsCount
+    + runtimeEvidenceRefsCount === 0
+  ) {
+    return
+  }
+  oasEvidenceRefsCount.value += evidenceRefsCount
+  oasArtifactRefsCount.value += artifactRefsCount
+  oasRawTraceRefsCount.value += rawTraceRefsCount
+  oasReportRefsCount.value += reportRefsCount
+  oasProofRefsCount.value += proofRefsCount
+  oasTelemetryRefsCount.value += telemetryRefsCount
+  oasRuntimeEvidenceRefsCount.value += runtimeEvidenceRefsCount
+  if (typeof input.tsMs === 'number' && Number.isFinite(input.tsMs)) {
+    oasLastEvidenceTs.value = Math.max(oasLastEvidenceTs.value ?? 0, input.tsMs)
+  }
+}
+
 export function updateOasKeeperSnapshot(snapshot: OasKeeperSnapshot): void {
   const next = new Map<string, OasKeeperSnapshot>(oasKeeperSnapshots.value)
   next.set(snapshot.keeper_name, snapshot)
@@ -317,6 +373,14 @@ export const oasHealthSummary: ReadonlySignal<OasHealthSummary> = computed(() =>
   totalErrors: oasTotalErrors.value,
   lastLlmCallTs: oasLastLlmCallTs.value,
   lastErrorTs: oasLastErrorTs.value,
+  evidenceRefsCount: oasEvidenceRefsCount.value,
+  artifactRefsCount: oasArtifactRefsCount.value,
+  rawTraceRefsCount: oasRawTraceRefsCount.value,
+  reportRefsCount: oasReportRefsCount.value,
+  proofRefsCount: oasProofRefsCount.value,
+  telemetryRefsCount: oasTelemetryRefsCount.value,
+  runtimeEvidenceRefsCount: oasRuntimeEvidenceRefsCount.value,
+  lastEvidenceTs: oasLastEvidenceTs.value,
 }))
 
 // --- Loading flags ---

--- a/dashboard/src/types/oas.ts
+++ b/dashboard/src/types/oas.ts
@@ -85,4 +85,12 @@ export interface OasHealthSummary {
   totalErrors: number
   lastLlmCallTs: number | null
   lastErrorTs: number | null
+  evidenceRefsCount: number
+  artifactRefsCount: number
+  rawTraceRefsCount: number
+  reportRefsCount: number
+  proofRefsCount: number
+  telemetryRefsCount: number
+  runtimeEvidenceRefsCount: number
+  lastEvidenceTs: number | null
 }


### PR DESCRIPTION
## Summary
- surface OAS runtime evidence refs in the dashboard OAS runtime summary
- count raw trace, report, proof, telemetry, runtime-evidence, and artifact refs from durable/live oas_event payloads
- add a rendered OasHealthChip regression so the evidence tile remains visible to operators

## Why
OAS already persists runtime proof/report/raw-trace/evidence artifacts, but MASC's OAS runtime dashboard summary only showed event/LLM/error/keeper counters. Operators could see that OAS events existed without seeing whether the evidence chain was present or stale.

## Verification
- git diff --check
- pnpm exec vitest run --config vitest.config.ts src/oas-runtime-store.test.ts src/store.test.ts src/components/oas-health-chip.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false