### PR TITLE
fix(dashboard): purge memory subsystem legacy route

### DIFF
--- a/dashboard/src/components/status.test.ts
+++ b/dashboard/src/components/status.test.ts
@@ -16,11 +16,8 @@ describe("sectionLabel", () => {
 })
 
 describe("normalizeStatusSection", () => {
-  it("maps retired memory-subsystems links to cognition", () => {
-    expect(normalizeStatusSection("memory-subsystems")).toBe("cognition")
-  })
-
   it("falls back to the monitoring default section", () => {
+    expect(normalizeStatusSection("memory-subsystems")).toBe("runtime")
     expect(normalizeStatusSection("unknown")).toBe("runtime")
     expect(normalizeStatusSection(undefined)).toBe("runtime")
   })

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -74,7 +74,6 @@ function renderSection(section: StatusSection) {
 }
 
 export function normalizeStatusSection(section: string | undefined): StatusSection {
-  if (section === 'memory-subsystems') return 'cognition'
   if (
     section === 'observatory'
     || section === 'journey'

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -176,7 +176,7 @@ describe('monitoring navigation labels', () => {
     const sections = sectionItemsForTab('monitoring')
     const hiddenIds = sections.filter(item => item.hidden).map(item => item.id)
 
-    expect(hiddenIds).toEqual(['journey', 'observatory', 'cognition', 'memory-subsystems'])
+    expect(hiddenIds).toEqual(['journey', 'observatory', 'cognition'])
   })
 
   it('monitoring sidebar labels are unique (no overloaded term like "런타임")', () => {
@@ -236,16 +236,6 @@ describe('normalizeRouteParams backward compat (RFC-MASC-006 Phase 0)', () => {
     expect(result.view).toBe('live')
   })
 
-  it('redirects legacy memory-subsystems links to cognition memory view', () => {
-    const result = normalizeRouteParams('monitoring', {
-      section: 'memory-subsystems',
-      keeper: 'nova',
-    })
-    expect(result.section).toBe('cognition')
-    expect(result.view).toBe('memory')
-    expect(result.keeper).toBe('nova')
-  })
-
   it('redirects standalone runtime diagnostics into runtime views', () => {
     expect(normalizeRouteParams('monitoring', { section: 'cascade-inspector' })).toMatchObject({
       section: 'runtime',
@@ -281,13 +271,6 @@ describe('SECTION_REDIRECTS table (consolidation Phase -1)', () => {
 
   it('exposes the activity → observatory redirect as reference contract', () => {
     expect(SECTION_REDIRECTS['monitoring:activity']).toEqual({ section: 'observatory' })
-  })
-
-  it('keeps legacy memory-subsystems redirect as reference contract', () => {
-    expect(SECTION_REDIRECTS['monitoring:memory-subsystems']).toEqual({
-      section: 'cognition',
-      params: { view: 'memory' },
-    })
   })
 
   it('is the single source of truth for legacy section remaps', () => {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -20,7 +20,6 @@ type SurfaceSectionId =
   | 'runtime'
   | 'goal-loop'
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
-  | 'memory-subsystems' // Legacy redirect target (cognition > memory tab)
   // command
   | 'operations'     // Phase 1+6: absorbs intervene + governance + inspector (Phase 7: connectors split out)
   // connectors (Phase 7: top-level surface — sidecar-driven channel bridges)
@@ -217,13 +216,6 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       params: { section: 'cognition' },
       hidden: true,
     },
-    {
-      id: 'memory-subsystems',
-      label: 'Memory Subsystems',
-      description: 'Legacy memory subsystem drill-down (redirects to cognition).',
-      params: { section: 'memory-subsystems' },
-      hidden: true,
-    },
   ],
   command: [
     {
@@ -367,9 +359,6 @@ export const SECTION_REDIRECTS: Record<TabSectionKey, SectionRedirect> = {
   'command:governance':   { section: 'operations' },
   'command:connectors':   { section: 'operations', view: 'connectors' },
   'command:inspector':    { section: 'operations', view: 'inspector' },
-
-  // Cognition UX cleanup: memory-subsystems merged into cognition > memory tab
-  'monitoring:memory-subsystems': { section: 'cognition', params: { view: 'memory' } },
 
   // Dashboard consolidation Phase 1: workspace surface
   'workspace:goals': { section: 'planning' },

--- a/docs/DASHBOARD-INTEGRATION.md
+++ b/docs/DASHBOARD-INTEGRATION.md
@@ -96,7 +96,6 @@ code_refs:
 - `command:governance -> command:operations`
 - `command:connectors -> command:operations&view=connectors`
 - `command:inspector -> command:operations&view=inspector`
-- `monitoring:memory-subsystems -> monitoring:cognition&view=memory`
 - `connectors:connector-discord -> connectors:connector-status&connector=discord`
 - `connectors:connector-imessage -> connectors:connector-status&connector=imessage`
 - `connectors:connector-slack -> connectors:connector-status&connector=slack`


### PR DESCRIPTION
## Summary
- remove the hidden monitoring memory-subsystems navigation entry
- remove the monitoring:memory-subsystems redirect contract
- stop normalizing direct memory-subsystems status links into cognition
- keep the real /api/v1/dashboard/memory-subsystems read model for the cognition memory view

## Verification
- pnpm install --frozen-lockfile --offline
- pnpm exec vitest run --config vitest.config.ts src/config/navigation.test.ts src/components/status.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check
- rg -n "monitoring:memory-subsystems|monitoring\.memory-subsystems|monitoring\?section=memory-subsystems|Legacy redirect target|redirects legacy memory-subsystems|retired memory-subsystems links|memory-subsystems.*redirect|redirect.*memory-subsystems|maps retired memory-subsystems" dashboard/src lib test docs scripts