### PR TITLE
feat(ide): route tagged activity context links

### DIFF
--- a/dashboard/src/components/ide/ide-context-lens.test.ts
+++ b/dashboard/src/components/ide/ide-context-lens.test.ts
@@ -531,6 +531,109 @@ describe('IdeContextLens', () => {
     })
   })
 
+  it('promotes tagged activity references into routeable IDE context links', () => {
+    const model = deriveIdeContextLens({
+      filePath: 'lib/keeper/keeper_exec_ide.ml',
+      annotations: [],
+      diffRows: [],
+      events: [{
+        id: 'evt-tagged-context',
+        run_id: 'run-default',
+        keeper_id: 'sangsu',
+        verb: 'noted',
+        target: 'PR #15000',
+        timestamp_ms: 400,
+        detail: [
+          'goal:goal-ide',
+          'task:task-42',
+          'board:post-1',
+          'comment:comment-1',
+          'git:abc123',
+          'log:turn-9',
+          'session:sess-9',
+          'op:op-9',
+          'wr:wr-9',
+          'line:27',
+        ].join(' '),
+        tags: ['pr:15000'],
+      }],
+      overlay: { ...overlay, cursors: new Map() },
+    })
+
+    expect(model.activeLineCount).toBe(1)
+    expect(model.anchors[0]).toMatchObject({
+      surface: 'PR',
+      line: 27,
+      keeper_id: 'sangsu',
+    })
+    expect(model.anchors[0]?.meta).toContain('goal goal-ide')
+    expect(model.anchors[0]?.route_links?.map(link => link.label)).toEqual([
+      'Code',
+      'Goal',
+      'Task',
+      'Board',
+      'Comment',
+      'PR',
+      'Git',
+      'Log',
+      'Telemetry',
+      'Keeper',
+    ])
+    expect(model.anchors[0]?.route_links?.find(link => link.label === 'Code')).toMatchObject({
+      tab: 'code',
+      params: {
+        section: 'ide-shell',
+        view: 'source',
+        file: 'lib/keeper/keeper_exec_ide.ml',
+        line: '27',
+        surface: 'PR',
+      },
+    })
+    expect(model.anchors[0]?.route_links?.find(link => link.label === 'Telemetry')).toMatchObject({
+      tab: 'monitoring',
+      params: {
+        section: 'fleet-health',
+        view: 'event-log',
+        session_id: 'sess-9',
+        operation_id: 'op-9',
+        worker_run_id: 'wr-9',
+        q: 'turn-9',
+      },
+    })
+  })
+
+  it('prefers structured activity context over tagged fallback references', () => {
+    const model = deriveIdeContextLens({
+      filePath: 'lib/keeper/keeper_exec_ide.ml',
+      annotations: [],
+      diffRows: [],
+      events: [{
+        id: 'evt-structured-wins',
+        run_id: 'run-default',
+        keeper_id: 'sangsu',
+        verb: 'noted',
+        target: 'PR #99999',
+        timestamp_ms: 400,
+        detail: 'pr:99999 log:turn-999',
+        context: {
+          file_path: 'lib/keeper/keeper_exec_ide.ml',
+          pr_id: '15000',
+          log_id: 'turn-9',
+        },
+      }],
+      overlay: { ...overlay, cursors: new Map() },
+    })
+
+    expect(model.anchors[0]?.route_links?.find(link => link.label === 'PR')).toMatchObject({
+      id: 'pr:15000',
+      evidence: 'PR 15000',
+    })
+    expect(model.anchors[0]?.route_links?.find(link => link.label === 'Log')).toMatchObject({
+      id: 'log:turn-9',
+      evidence: 'Log turn-9',
+    })
+  })
+
   it('keeps other-file activity out of the current-file lens', () => {
     const model = deriveIdeContextLens({
       filePath: 'lib/keeper/keeper_exec_ide.ml',

--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -184,6 +184,7 @@ export function deriveIdeContextLens(input: IdeContextLensInput): IdeContextLens
   }
   for (const event of fileEvents) {
     const line = eventLineForFile(event, filePath ?? input.filePath)
+      ?? eventRouteRefs(event).line
     if (line !== undefined) activeLines.add(line)
   }
 
@@ -617,32 +618,35 @@ function buildAnchors(
   }
 
   for (const event of events.slice(0, 3)) {
-    const contextMeta = eventContextMeta(event)
+    const refs = eventRouteRefs(event)
+    const contextMeta = eventContextMeta(event, refs)
+    const eventLine = eventLineForFile(event, filePath) ?? refs.line
+    const eventSurface = surfaceFromEvent(event, eventSearchTextByEvent)
     anchors.push({
       id: `event-${event.id}`,
       file_path: event.context?.file_path ?? filePath,
-      surface: surfaceFromEvent(event, eventSearchTextByEvent),
+      surface: eventSurface,
       label: truncate(`${event.verb} ${event.target}`, 48),
       meta: truncate(contextMeta || event.detail || `keeper ${event.keeper_id}`, 60),
-      line: eventLineForFile(event, filePath),
+      line: eventLine,
       keeper_id: event.keeper_id,
       route_links: routeLinksForContext({
         filePath: event.context?.file_path ?? filePath,
-        line: eventLineForFile(event, filePath),
-        surface: surfaceFromEvent(event, eventSearchTextByEvent),
+        line: eventLine,
+        surface: eventSurface,
         label: truncate(event.detail || `${event.verb} ${event.target}`, 48),
         sourceId: `event-${event.id}`,
-        goalId: event.context?.goal_id,
-        taskId: event.context?.task_id,
-        boardPostId: event.context?.board_post_id,
-        commentId: event.context?.comment_id,
-        prId: event.context?.pr_id,
-        gitRef: event.context?.git_ref,
-        logId: event.context?.log_id,
-        sessionId: event.context?.session_id,
-        operationId: event.context?.operation_id,
-        workerRunId: event.context?.worker_run_id,
-        telemetryQuery: event.context?.log_id,
+        goalId: event.context?.goal_id ?? refs.goalId,
+        taskId: event.context?.task_id ?? refs.taskId,
+        boardPostId: event.context?.board_post_id ?? refs.boardPostId,
+        commentId: event.context?.comment_id ?? refs.commentId,
+        prId: event.context?.pr_id ?? refs.prId,
+        gitRef: event.context?.git_ref ?? refs.gitRef,
+        logId: event.context?.log_id ?? refs.logId,
+        sessionId: event.context?.session_id ?? refs.sessionId,
+        operationId: event.context?.operation_id ?? refs.operationId,
+        workerRunId: event.context?.worker_run_id ?? refs.workerRunId,
+        telemetryQuery: event.context?.log_id ?? refs.logId,
         keeperId: event.keeper_id,
         telemetry: true,
       }),
@@ -750,21 +754,102 @@ function diagnosticTelemetryQuery(diagnostic: IdeContextDiagnostic): string | un
   return parts.length > 0 ? parts.join(' ') : undefined
 }
 
-function eventContextMeta(event: RunActivityEvent): string {
+interface EventRouteRefs {
+  readonly line?: number
+  readonly goalId?: string
+  readonly taskId?: string
+  readonly boardPostId?: string
+  readonly commentId?: string
+  readonly prId?: string
+  readonly gitRef?: string
+  readonly logId?: string
+  readonly sessionId?: string
+  readonly operationId?: string
+  readonly workerRunId?: string
+}
+
+const REF_VALUE_PATTERN = '([A-Za-z0-9][A-Za-z0-9._/@:-]*)'
+const EVENT_REF_PATTERNS = {
+  goalId: new RegExp(`\\bgoal[:#/]+${REF_VALUE_PATTERN}`, 'i'),
+  taskId: new RegExp(`\\btask[:#/]+${REF_VALUE_PATTERN}`, 'i'),
+  boardPostId: new RegExp(`\\b(?:board|post)[:#/]+${REF_VALUE_PATTERN}`, 'i'),
+  commentId: new RegExp(`\\bcomment[:#/]+${REF_VALUE_PATTERN}`, 'i'),
+  prId: /\b(?:pr|pull[_\s-]?request)\s*[:#/]?\s*#?(\d{1,10})\b/i,
+  gitRef: new RegExp(`\\b(?:git|commit|branch|ref)[:#/]+${REF_VALUE_PATTERN}`, 'i'),
+  logId: new RegExp(`\\b(?:log|turn)[:#/]+${REF_VALUE_PATTERN}`, 'i'),
+  sessionId: new RegExp(`\\bsession[:#/]+${REF_VALUE_PATTERN}`, 'i'),
+  operationId: new RegExp(`\\b(?:operation|op)[:#/]+${REF_VALUE_PATTERN}`, 'i'),
+  workerRunId: new RegExp(`\\b(?:worker_run|worker|wr)[:#/]+${REF_VALUE_PATTERN}`, 'i'),
+} as const
+
+function eventRouteRefs(event: RunActivityEvent): EventRouteRefs {
+  const text = eventRawText(event)
+  return {
+    line: eventLineRef(text),
+    goalId: firstEventRef(text, EVENT_REF_PATTERNS.goalId),
+    taskId: firstEventRef(text, EVENT_REF_PATTERNS.taskId),
+    boardPostId: firstEventRef(text, EVENT_REF_PATTERNS.boardPostId),
+    commentId: firstEventRef(text, EVENT_REF_PATTERNS.commentId),
+    prId: firstEventRef(text, EVENT_REF_PATTERNS.prId),
+    gitRef: firstEventRef(text, EVENT_REF_PATTERNS.gitRef),
+    logId: firstEventRef(text, EVENT_REF_PATTERNS.logId),
+    sessionId: firstEventRef(text, EVENT_REF_PATTERNS.sessionId),
+    operationId: firstEventRef(text, EVENT_REF_PATTERNS.operationId),
+    workerRunId: firstEventRef(text, EVENT_REF_PATTERNS.workerRunId),
+  }
+}
+
+function eventRawText(event: RunActivityEvent): string {
+  return [
+    event.kind,
+    event.verb,
+    event.target,
+    event.detail,
+    ...(event.tags ?? []),
+  ]
+    .filter((part): part is string => typeof part === 'string' && part.trim() !== '')
+    .join(' ')
+}
+
+function firstEventRef(text: string, pattern: RegExp): string | undefined {
+  return cleanParsedRef(pattern.exec(text)?.[1])
+}
+
+function cleanParsedRef(value: string | undefined): string | undefined {
+  const cleaned = value?.trim().replace(/[),.;\]}]+$/u, '')
+  return cleaned ? cleaned : undefined
+}
+
+function eventLineRef(text: string): number | undefined {
+  const explicit = /\b(?:line|l)[:#]+(\d{1,7})\b/i.exec(text)?.[1]
+  const compact = explicit ?? /\bL(\d{1,7})\b/.exec(text)?.[1]
+  return compact ? positiveLine(Number(compact)) : undefined
+}
+
+function eventContextMeta(event: RunActivityEvent, refs: EventRouteRefs): string {
   const context = event.context
-  if (!context) return ''
+  const goalId = context?.goal_id ?? refs.goalId
+  const taskId = context?.task_id ?? refs.taskId
+  const prId = context?.pr_id ?? refs.prId
+  const boardPostId = context?.board_post_id ?? refs.boardPostId
+  const commentId = context?.comment_id ?? refs.commentId
+  const gitRef = context?.git_ref ?? refs.gitRef
+  const logId = context?.log_id ?? refs.logId
+  const sessionId = context?.session_id ?? refs.sessionId
+  const operationId = context?.operation_id ?? refs.operationId
+  const workerRunId = context?.worker_run_id ?? refs.workerRunId
   return compactMeta([
-    context.goal_id ? `goal ${context.goal_id}` : null,
-    context.task_id ? `task ${context.task_id}` : null,
-    context.pr_id ? `PR ${context.pr_id}` : null,
-    context.board_post_id ? `board ${context.board_post_id}` : null,
-    context.comment_id ? `comment ${context.comment_id}` : null,
-    context.git_ref ? `git ${context.git_ref}` : null,
-    context.log_id ? `log ${context.log_id}` : null,
-    context.session_id ? `session ${context.session_id}` : null,
-    context.operation_id ? `operation ${context.operation_id}` : null,
-    context.worker_run_id ? `worker ${context.worker_run_id}` : null,
-    context.file_path ?? null,
+    goalId ? `goal ${goalId}` : null,
+    taskId ? `task ${taskId}` : null,
+    prId ? `PR ${prId}` : null,
+    boardPostId ? `board ${boardPostId}` : null,
+    commentId ? `comment ${commentId}` : null,
+    gitRef ? `git ${gitRef}` : null,
+    logId ? `log ${logId}` : null,
+    sessionId ? `session ${sessionId}` : null,
+    operationId ? `operation ${operationId}` : null,
+    workerRunId ? `worker ${workerRunId}` : null,
+    context?.file_path ?? null,
   ])
 }
 


### PR DESCRIPTION
## Summary

- Promote explicit tagged activity references like `goal:...`, `task:...`, `pr #...`, `log:...`, `session:...`, and `line:...` into IDE Context Lens route links.
- Preserve structured activity context as the source of truth when both structured and tagged references are present.
- Add focused Context Lens coverage for tagged fallback links and structured-context precedence.

## Verification

- `pnpm exec vitest run src/components/ide/ide-context-lens.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/ide/ide-context-lens.ts src/components/ide/ide-context-lens.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`
