### PR TITLE
fix(dashboard): verify cognition readiness read model

### DIFF
--- a/lib/dashboard/dashboard_surface_readiness.ml
+++ b/lib/dashboard/dashboard_surface_readiness.ml
@@ -233,8 +233,7 @@ let all_entries =
       ~meets_main_gate:false
       ~rationale:"Hidden keeper cognition and memory drill-down."
       ~route_hash:"#monitoring?section=cognition"
-      ~live_spotcheck:"/api/v1/dashboard/shell"
-      ~tool_name:"masc_operator_snapshot"
+      ~live_spotcheck:"/api/v1/dashboard/memory-subsystems"
       ()
   ; entry
       ~id:"command.operations"

--- a/test/test_dashboard_surface_readiness.ml
+++ b/test/test_dashboard_surface_readiness.ml
@@ -146,6 +146,29 @@ let test_live_spotcheck_keeps_script_values_as_scripts () =
            check string "live_spotcheck kind" "script"
              Yojson.Safe.Util.(ref_json |> member "kind" |> to_string))
 
+let test_cognition_readiness_uses_cognition_read_model () =
+  let json = Dashboard_surface_readiness.json ~surface_id:"monitoring.cognition" () in
+  let surfaces = Yojson.Safe.Util.(json |> member "surfaces" |> to_list) in
+  match List.find_opt
+          (fun surface ->
+            Yojson.Safe.Util.(surface |> member "id" |> to_string = "monitoring.cognition"))
+          surfaces
+  with
+  | None -> fail "monitoring.cognition missing"
+  | Some surface ->
+      (match find_verification_ref surface "live_spotcheck" with
+       | None -> fail "monitoring.cognition live_spotcheck missing"
+       | Some ref_json ->
+           let open Yojson.Safe.Util in
+           check string "live_spotcheck kind" "route"
+             (ref_json |> member "kind" |> to_string);
+           check string "live_spotcheck value"
+             "/api/v1/dashboard/memory-subsystems"
+             (ref_json |> member "value" |> to_string);
+           check string "surface verification ref labels"
+             "live_spotcheck+logs+metrics"
+             (surface |> member "verification_ref_bar" |> to_string))
+
 let test_verification_ref_bar_reflects_declared_refs () =
   let overview_json = Dashboard_surface_readiness.json ~surface_id:"overview" () in
   let open Yojson.Safe.Util in
@@ -235,6 +258,8 @@ let () =
             test_live_spotcheck_serializes_route_values_as_routes;
           test_case "script live spotchecks stay scripts" `Quick
             test_live_spotcheck_keeps_script_values_as_scripts;
+          test_case "cognition readiness uses cognition read model" `Quick
+            test_cognition_readiness_uses_cognition_read_model;
           test_case "verification ref bar reflects declared refs" `Quick
             test_verification_ref_bar_reflects_declared_refs;
           test_case "legacy surfaces removed from readiness inventory" `Quick


### PR DESCRIPTION
## Summary
- point monitoring.cognition surface readiness at its actual cognition/memory read model
- add a regression test that verifies the live spotcheck route and ref bar labels

## Why
The hidden Cognition surface renders memory/cognition data, but readiness was still proving the generic dashboard shell. That made the surface look covered while not checking the menu-specific read model.

## Verification
- git diff --check origin/main...HEAD
- bash scripts/check-dashboard-surface-parity.sh --check
- bash scripts/check-dashboard-nav-event-parity.sh --check
- ocamlformat --check lib/dashboard/dashboard_surface_readiness.ml test/test_dashboard_surface_readiness.ml
- scripts/dune-local.sh build test/test_dashboard_surface_readiness.exe
- ./_build/default/test/test_dashboard_surface_readiness.exe