### PR TITLE
fix(cascade): shrink declarative strategy surface

### DIFF
--- a/lib/cascade/cascade_declarative_adapter.ml
+++ b/lib/cascade/cascade_declarative_adapter.ml
@@ -299,12 +299,7 @@ let apply_alias_overrides (base : Llm_provider.Provider_config.t)
 let map_strategy_kind (decl : cascade_strategy) : Cascade_strategy.kind =
   match decl with
   | Failover -> Cascade_strategy.Failover
-  | Capacity_aware -> Cascade_strategy.Capacity_aware
-  | Weighted_random -> Cascade_strategy.Weighted_random
-  | Circuit_breaker_cycling -> Cascade_strategy.Circuit_breaker_cycling
   | Priority_tier -> Cascade_strategy.Priority_tier
-  | Sticky -> Cascade_strategy.Sticky
-  | Round_robin -> Cascade_strategy.Round_robin
 
 let map_cycle_policy (cp : cascade_cycle_policy) :
     Cascade_strategy.cycle_policy =

--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -289,12 +289,7 @@ type cascade_alias =
 
 type cascade_strategy =
   | Failover
-  | Capacity_aware
-  | Weighted_random
-  | Circuit_breaker_cycling
   | Priority_tier
-  | Sticky
-  | Round_robin
 [@@deriving show, eq]
 
 type cascade_cycle_policy =

--- a/lib/cascade_decl/cascade_declarative_types.mli
+++ b/lib/cascade_decl/cascade_declarative_types.mli
@@ -222,12 +222,7 @@ type cascade_alias =
 
 type cascade_strategy =
   | Failover
-  | Capacity_aware
-  | Weighted_random
-  | Circuit_breaker_cycling
   | Priority_tier
-  | Sticky
-  | Round_robin
 [@@deriving show, eq]
 
 (** {1 Strategy-specific parameter types} *)

--- a/lib/cascade_decl/cascade_declarative_validator.ml
+++ b/lib/cascade_decl/cascade_declarative_validator.ml
@@ -274,42 +274,31 @@ let validate_strategy_fields (cfg : cascade_config) : validation_error list =
   List.concat_map
     (fun (t : cascade_tier) ->
        let path = Printf.sprintf "tier.%s" t.name in
-       let mismatch_errors field_name expected_strategy =
+       let retired_field_errors field_name retired_strategy =
          err
            "R10"
            (Printf.sprintf "%s.%s" path field_name)
            (Printf.sprintf
-              "%s is only valid with strategy %S, but tier uses %s"
+              "%s belongs to retired internal strategy %S and is not \
+               supported by cascade.toml strategy %s"
               field_name
-              expected_strategy
+              retired_strategy
               (show_cascade_strategy t.strategy))
        in
        let cycle_errs =
          match t.cycle_policy with
          | None -> []
-         | Some _ ->
-           (match t.strategy with
-            | Circuit_breaker_cycling -> []
-            | Failover | Capacity_aware | Weighted_random | Priority_tier | Sticky
-            | Round_robin -> mismatch_errors "cycle-policy" "circuit_breaker_cycling")
+         | Some _ -> retired_field_errors "cycle-policy" "circuit_breaker_cycling"
        in
        let sticky_errs =
          match t.sticky_ttl_ms with
          | None -> []
-         | Some _ ->
-           (match t.strategy with
-            | Sticky -> []
-            | Failover | Capacity_aware | Weighted_random | Circuit_breaker_cycling
-            | Priority_tier | Round_robin -> mismatch_errors "sticky-ttl-ms" "sticky")
+         | Some _ -> retired_field_errors "sticky-ttl-ms" "sticky"
        in
        let scoring_errs =
          match t.scoring_params with
          | None -> []
-         | Some _ ->
-           (match t.strategy with
-            | Weighted_random -> []
-            | Failover | Capacity_aware | Circuit_breaker_cycling | Priority_tier
-            | Sticky | Round_robin -> mismatch_errors "scoring-params" "weighted_random")
+         | Some _ -> retired_field_errors "scoring-params" "weighted_random"
        in
        cycle_errs @ sticky_errs @ scoring_errs)
     cfg.tiers


### PR DESCRIPTION
## Summary

- Shrinks the declarative cascade strategy type to the two supported cascade.toml strategies: `failover` and `priority_tier`.
- Removes unreachable retired strategy mappings from the declarative adapter.
- Rewords R10 validation for retired strategy-only fields so operator errors no longer imply unsupported strategies are configurable.

## Product impact

This closes the DD-002a drift on the operator-facing declarative config surface: parser, type, adapter, and validator now agree that retired/internal cascade strategies are not part of cascade.toml.

## Evidence

- `ocamlformat --check lib/cascade_decl/cascade_declarative_types.mli lib/cascade_decl/cascade_declarative_types.ml lib/cascade/cascade_declarative_adapter.ml lib/cascade_decl/cascade_declarative_validator.ml`
- `git diff --check`
- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_cascade_declarative_parser.exe test/test_cascade_declarative_validator.exe test/test_cascade_declarative_adapter.exe test/test_cascade_catalog_runtime_yojson.exe`
- `_build/default/test/test_cascade_declarative_parser.exe`
- `_build/default/test/test_cascade_declarative_validator.exe`
- `_build/default/test/test_cascade_declarative_adapter.exe`
- `_build/default/test/test_cascade_catalog_runtime_yojson.exe`
- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_cascade_declarative_hotpath.exe`
- `_build/default/test/test_cascade_declarative_hotpath.exe`

## Review evidence

Review focus: this is intentionally scoped to the declarative config surface. Internal `Cascade_strategy` variants remain available for legacy/internal strategy tests; cascade.toml stays restricted to the two supported runtime strategies.

## Linked issue

Deep-dive DD-002a / DD-016: remove five dead cascade config strategies from the operator-facing surface.
