### PR TITLE
fix(dashboard): verify code ide presence surface

### DIFF
--- a/docs/DASHBOARD-INTEGRATION.md
+++ b/docs/DASHBOARD-INTEGRATION.md
@@ -146,6 +146,8 @@ code_refs:
   - lab autoresearch loops
 - `GET /api/v1/dashboard/harness-health`
   - lab harness health
+- `GET /api/v1/ide/presence`
+  - code IDE live collaboration presence
 - `GET /api/v1/dashboard/logs`
   - log viewer
 - `GET /api/v1/dashboard/surface-readiness`

--- a/lib/dashboard/dashboard_surface_readiness.ml
+++ b/lib/dashboard/dashboard_surface_readiness.ml
@@ -352,7 +352,7 @@ let all_entries =
       ~meets_main_gate:true
       ~rationale:"Keeper collaboration IDE shell."
       ~route_hash:"#code?section=ide-shell"
-      ~live_spotcheck:"/api/v1/dashboard/shell"
+      ~live_spotcheck:"/api/v1/ide/presence"
       ()
   ; entry
       ~id:"logs"

--- a/lib/server/server_ide_http.mli
+++ b/lib/server/server_ide_http.mli
@@ -6,6 +6,8 @@
     - POST /api/v1/ide/annotations
     - DELETE /api/v1/ide/annotations/:id
     - GET  /api/v1/ide/regions
+    - GET  /api/v1/ide/presence
+    - GET  /api/v1/ide/presence/stream
 
     All routes use the workspace base resolution from
     {!Server_routes_http_routes_workspace} so the IDE reads/writes

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -176,7 +176,9 @@ check_json "autoresearch loops exposes loops" "$BASE/api/v1/autoresearch/loops" 
 check_http "harness health 200" "$BASE/api/v1/dashboard/harness-health" "200"
 check_json "harness health exposes overview" "$BASE/api/v1/dashboard/harness-health" "'overview' in d" '^True$'
 
-echo "[6/7] Logs"
+echo "[6/7] Code + Logs"
+check_http "IDE presence 200" "$BASE/api/v1/ide/presence" "200"
+check_json "IDE presence exposes connected state" "$BASE/api/v1/ide/presence" "d.get('data', {}).get('connected')" '^True$'
 check_http "dashboard logs 200" "$BASE/api/v1/dashboard/logs?limit=3" "200"
 check_json "dashboard logs exposes entries" "$BASE/api/v1/dashboard/logs?limit=3" "'entries' in d" '^True$'
 

--- a/test/test_dashboard_surface_readiness.ml
+++ b/test/test_dashboard_surface_readiness.ml
@@ -169,6 +169,29 @@ let test_cognition_readiness_uses_cognition_read_model () =
              "live_spotcheck+logs+metrics"
              (surface |> member "verification_ref_bar" |> to_string))
 
+let test_code_ide_readiness_uses_ide_presence_read_model () =
+  let json = Dashboard_surface_readiness.json ~surface_id:"code.ide-shell" () in
+  let surfaces = Yojson.Safe.Util.(json |> member "surfaces" |> to_list) in
+  match List.find_opt
+          (fun surface ->
+            Yojson.Safe.Util.(surface |> member "id" |> to_string = "code.ide-shell"))
+          surfaces
+  with
+  | None -> fail "code.ide-shell missing"
+  | Some surface ->
+      (match find_verification_ref surface "live_spotcheck" with
+       | None -> fail "code.ide-shell live_spotcheck missing"
+       | Some ref_json ->
+           let open Yojson.Safe.Util in
+           check string "live_spotcheck kind" "route"
+             (ref_json |> member "kind" |> to_string);
+           check string "live_spotcheck value"
+             "/api/v1/ide/presence"
+             (ref_json |> member "value" |> to_string);
+           check string "surface verification ref labels"
+             "live_spotcheck+logs+metrics"
+             (surface |> member "verification_ref_bar" |> to_string))
+
 let test_verification_ref_bar_reflects_declared_refs () =
   let overview_json = Dashboard_surface_readiness.json ~surface_id:"overview" () in
   let open Yojson.Safe.Util in
@@ -260,6 +283,8 @@ let () =
             test_live_spotcheck_keeps_script_values_as_scripts;
           test_case "cognition readiness uses cognition read model" `Quick
             test_cognition_readiness_uses_cognition_read_model;
+          test_case "code ide readiness uses ide presence read model" `Quick
+            test_code_ide_readiness_uses_ide_presence_read_model;
           test_case "verification ref bar reflects declared refs" `Quick
             test_verification_ref_bar_reflects_declared_refs;
           test_case "legacy surfaces removed from readiness inventory" `Quick


### PR DESCRIPTION
## Summary
- point code.ide-shell surface readiness at the IDE presence read model instead of the generic dashboard shell
- add the IDE presence endpoint to the dashboard integration spec and verify-dashboard smoke suite
- add a regression test for the Code IDE readiness live spotcheck route

## Why
The Code IDE surface loads workspace, git, annotation, region, and presence data. Readiness only proving /api/v1/dashboard/shell left the surface looking covered without checking an IDE-owned read model.

## Verification
- git diff --check origin/main...HEAD
- bash -n scripts/verify-dashboard.sh
- bash scripts/check-dashboard-surface-parity.sh --check
- bash scripts/check-dashboard-nav-event-parity.sh --check
- ocamlformat --check lib/dashboard/dashboard_surface_readiness.ml test/test_dashboard_surface_readiness.ml lib/server/server_ide_http.mli
- scripts/dune-local.sh build test/test_dashboard_surface_readiness.exe
- ./_build/default/test/test_dashboard_surface_readiness.exe