### PR TITLE
feat(ide): surface operational trace context

### DIFF
--- a/dashboard/src/components/ide/ide-editor-extensions.test.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.test.ts
@@ -216,6 +216,7 @@ describe('keeperTraceLinesForFile + keeper trace gutter', () => {
             keeperName: 'sangsu',
             count: 1,
             tsMs: 5000,
+            surface: 'Goal',
           },
           {
             source: 'anchored-thread',
@@ -237,7 +238,7 @@ describe('keeperTraceLinesForFile + keeper trace gutter', () => {
         line: 2,
         events: [
           { source: 'anchored-thread', keeperName: 'scholar', count: 2, tsMs: 2000 },
-          { source: 'activity-event', keeperName: 'sangsu', count: 1, tsMs: 1500 },
+          { source: 'activity-event', keeperName: 'sangsu', count: 1, tsMs: 1500, surface: 'PR' },
           { source: 'anchored-thread', keeperName: 'moth', count: 1, tsMs: 1000 },
         ],
       },
@@ -250,7 +251,7 @@ describe('keeperTraceLinesForFile + keeper trace gutter', () => {
     expect(dots?.[0]?.getAttribute('data-source')).toBe('anchored-thread')
     expect(dots?.[0]?.getAttribute('aria-label')).toBe('thread scholar x2')
     expect(dots?.[1]?.getAttribute('data-source')).toBe('activity-event')
-    expect(dots?.[1]?.getAttribute('aria-label')).toBe('activity sangsu')
+    expect(dots?.[1]?.getAttribute('aria-label')).toBe('activity PR sangsu')
     expect(gutter?.querySelector('.cm-trace-stack[role="list"]')?.getAttribute('aria-label'))
       .toContain('Line 2 keeper trace')
 

--- a/dashboard/src/components/ide/ide-editor-extensions.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.ts
@@ -304,6 +304,7 @@ export interface EditorKeeperTraceLineEvent {
   readonly keeperName: string
   readonly count: number
   readonly tsMs: number
+  readonly surface?: string
 }
 
 export interface EditorKeeperTraceLine {
@@ -421,6 +422,7 @@ export function keeperTraceLinesForFile(
       keeperName: event.keeperName,
       count: event.count,
       tsMs: event.tsMs,
+      surface: traceEventSurface(event),
     })
     byLine.set(line, existing)
   }
@@ -483,9 +485,19 @@ function traceEventLine(event: KeeperTraceEvent): number | null {
   return null
 }
 
+function traceEventSurface(event: KeeperTraceEvent): string | undefined {
+  return event.source === 'activity-event' ? event.surface : undefined
+}
+
 function traceEventLabel(event: EditorKeeperTraceLineEvent): string {
   const count = event.count > 1 ? ` x${event.count}` : ''
-  return `${traceSourceLabel(event.source)} ${event.keeperName}${count}`
+  const rawSurface = event.surface?.trim()
+  const surface = event.source === 'activity-event'
+    && rawSurface
+    && rawSurface.toLowerCase() !== 'activity'
+    ? ` ${rawSurface}`
+    : ''
+  return `${traceSourceLabel(event.source)}${surface} ${event.keeperName}${count}`
 }
 
 function traceLineAriaLabel(line: number, events: ReadonlyArray<EditorKeeperTraceLineEvent>): string {
@@ -497,7 +509,7 @@ function traceLineTitle(line: number, events: ReadonlyArray<EditorKeeperTraceLin
 }
 
 function traceLineKey(events: ReadonlyArray<EditorKeeperTraceLineEvent>): string {
-  return events.map(event => `${event.source}:${event.keeperName}:${event.count}:${event.tsMs}`).join('|')
+  return events.map(event => `${event.source}:${event.surface ?? ''}:${event.keeperName}:${event.count}:${event.tsMs}`).join('|')
 }
 
 export function keeperLineSelectExt(

--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -269,6 +269,35 @@ describe('IdeEditor', () => {
       collisions: [],
       active_file: 'runtime.ts',
     }
+    pushTrace({
+      id: 'activity-runtime',
+      tsMs: 3000,
+      keeperName: 'sangsu',
+      source: 'activity-event',
+      eventId: 'evt-1',
+      filePath: 'runtime.ts',
+      line: 1,
+      surface: 'PR',
+    })
+    pushTrace({
+      id: 'thread-runtime',
+      tsMs: 2000,
+      keeperName: 'sangsu',
+      source: 'anchored-thread',
+      threadId: 'thread-1',
+      filePath: 'runtime.ts',
+      line: 2,
+    })
+    pushTrace({
+      id: 'activity-other',
+      tsMs: 4000,
+      keeperName: 'moth',
+      source: 'activity-event',
+      eventId: 'evt-other',
+      filePath: 'other.ts',
+      line: 1,
+      surface: 'Task',
+    })
 
     render(
       h(IdeEditor, {
@@ -300,6 +329,8 @@ describe('IdeEditor', () => {
       'LSP1',
       'Notes1',
       'Threads1',
+      'Trace2',
+      'Ops1',
       'Diff2',
       'Keepers1',
     ])
@@ -308,6 +339,8 @@ describe('IdeEditor', () => {
       '1 current-file diagnostic',
       '1 current-file annotation',
       '1 current-file anchored thread',
+      '2 current-file trace events',
+      '1 current-file operational surface link',
       '2 current-file changed rows',
       '1 keeper active in this file',
     ])

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -41,7 +41,7 @@ import { SplitDiffView, UnifiedDiffView } from './ide-diff-view'
 import { KeeperBadge } from '../keeper-badge'
 import { keeperCursorExtension } from './keeper-cursor-cm-extension'
 import { cursorOverlaySignal, getKeeperColor } from './keeper-cursor-overlay'
-import { keeperTraceState } from './keeper-trace-store'
+import { keeperTraceState, type KeeperTraceEvent } from './keeper-trace-store'
 import {
   globalPresenceSnapshot,
   type KeeperPresenceSnapshot,
@@ -144,6 +144,10 @@ export function IdeEditor({
     const unsub = lspDiagnosticSnapshot.subscribe(() => forceRender(tick => tick + 1))
     return () => unsub()
   }, [])
+  useEffect(() => {
+    const unsub = keeperTraceState.subscribe(() => forceRender(tick => tick + 1))
+    return () => unsub()
+  }, [])
 
   const document = documentStore.document()
   const lines = documentStore.lines()
@@ -161,6 +165,7 @@ export function IdeEditor({
     annotations,
     diffRows: currentDiffRows,
     activeKeeperCount: activeCursors.length,
+    traceEvents: keeperTraceState.value.events,
   })
   const gridTemplateRows = editorGridRows(activeLayerKinds.length > 0, findOpen)
 
@@ -292,11 +297,13 @@ function buildCurrentFileSignals({
   annotations,
   diffRows,
   activeKeeperCount,
+  traceEvents,
 }: {
   readonly filePath: string
   readonly annotations: ReadonlyArray<IdeAnnotation>
   readonly diffRows: ReadonlyArray<UnifiedDiffRow>
   readonly activeKeeperCount: number
+  readonly traceEvents: ReadonlyArray<KeeperTraceEvent>
 }): ReadonlyArray<CurrentFileSignal> {
   const normalizedFile = normalizeIdeContextFilePath(filePath)
   const matchesCurrentFile = (value: string): boolean =>
@@ -312,6 +319,16 @@ function buildCurrentFileSignals({
     ? threadSnapshot.threads.length
     : 0
   const changedRows = diffRows.filter(row => row.kind === 'add' || row.kind === 'delete')
+  const fileTraceEvents = traceEvents.filter(event => {
+    const traceFilePath = traceEventFilePath(event)
+    return traceFilePath !== null && matchesCurrentFile(traceFilePath)
+  })
+  const traceHitCount = fileTraceEvents.reduce((sum, event) => sum + event.count, 0)
+  const operationalTraceCount = fileTraceEvents.reduce((sum, event) => {
+    if (event.source !== 'activity-event') return sum
+    const surface = event.surface.trim().toLowerCase()
+    return surface !== '' && surface !== 'activity' ? sum + event.count : sum
+  }, 0)
   return [
     {
       id: 'lsp',
@@ -332,6 +349,18 @@ function buildCurrentFileSignals({
       title: `${threadCount} current-file anchored thread${threadCount === 1 ? '' : 's'}`,
     },
     {
+      id: 'trace',
+      label: 'Trace',
+      count: traceHitCount,
+      title: `${traceHitCount} current-file trace event${traceHitCount === 1 ? '' : 's'}`,
+    },
+    {
+      id: 'ops',
+      label: 'Ops',
+      count: operationalTraceCount,
+      title: `${operationalTraceCount} current-file operational surface link${operationalTraceCount === 1 ? '' : 's'}`,
+    },
+    {
       id: 'diff',
       label: 'Diff',
       count: changedRows.length,
@@ -344,6 +373,12 @@ function buildCurrentFileSignals({
       title: `${activeKeeperCount} keeper${activeKeeperCount === 1 ? '' : 's'} active in this file`,
     },
   ]
+}
+
+function traceEventFilePath(event: KeeperTraceEvent): string | null {
+  if (event.source === 'anchored-thread') return event.filePath ?? null
+  if (event.source === 'activity-event') return event.filePath
+  return null
 }
 
 function EditorCurrentFileSignals({


### PR DESCRIPTION
## Summary
- carry activity-event surface labels (PR/Goal/Task/Log/etc.) into the CodeMirror keeper trace gutter labels
- add current-file Trace and Ops chips to the IDE editor header so operators can see line-scoped activity without opening the rail
- cover surface propagation and current-file trace counting in IDE tests

## Validation
- pnpm exec eslint src/components/ide/ide-editor.ts src/components/ide/ide-editor-extensions.ts src/components/ide/ide-editor.test.ts src/components/ide/ide-editor-extensions.test.ts
- pnpm exec vitest run src/components/ide/ide-editor.test.ts src/components/ide/ide-editor-extensions.test.ts src/components/ide/ide-activity-panel.test.ts src/components/ide/run-activity-trace-bridge.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check