### PR TITLE
fix(log): align typed ring entry tests

### DIFF
--- a/test/test_autoresearch_codegen.ml
+++ b/test/test_autoresearch_codegen.ml
@@ -20,7 +20,7 @@ let latest_log_seq () =
 let autoresearch_warnings_since seq =
   Log.Ring.recent ~limit:20 ~module_filter:"Autoresearch" ~since_seq:seq ()
   |> List.filter (fun (entry : Log.Ring.entry) ->
-       String.equal entry.normalized_level "WARN")
+       String.equal (Log.level_to_string entry.level) "WARN")
 
 (* ------------------------------------------------------------------ *)
 (* has_background_capacity: fail-safe + noisy contract (#9537)         *)

--- a/test/test_dashboard_tool_host_events.ml
+++ b/test/test_dashboard_tool_host_events.ml
@@ -101,7 +101,8 @@ let test_record_writes_audit_ring_and_telemetry () =
         | row :: _ -> row
         | [] -> fail "expected ring entry"
       in
-      check string "ring source" "client_tool_host" latest.source;
+      check string "ring source" "client_tool_host"
+        (Log.source_to_string latest.source);
       check string "ring module" "ToolHost" latest.module_name;
       check bool "ring details object" true
         (match latest.details with `Assoc _ -> true | _ -> false);

--- a/test/test_grpc_coordination.ml
+++ b/test/test_grpc_coordination.ml
@@ -545,7 +545,7 @@ let test_heartbeat_handler_invalid_bytes_warns_and_continues () =
         true
         (List.exists
            (fun (entry : Log.Ring.entry) ->
-              String.equal entry.normalized_level "WARN"
+              String.equal (Log.level_to_string entry.level) "WARN"
               && String.starts_with ~prefix:"gRPC Heartbeat decode failed:" entry.message)
            logs);
       Alcotest.(check bool)

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -555,7 +555,8 @@ let test_error_result_logs_at_error_level () =
        match entry with
        | None -> fail "expected keeper error log for failing tool result"
        | Some (entry : Mlog.Ring.entry) ->
-         check string "failing tool result logs at ERROR" "ERROR" entry.normalized_level)
+         check string "failing tool result logs at ERROR" "ERROR"
+           (Mlog.level_to_string entry.level))
 ;;
 
 let test_missing_file_error_redacts_directory_suggestions () =

--- a/test/test_masc_log.ml
+++ b/test/test_masc_log.ml
@@ -57,13 +57,13 @@ let test_legacy_traceln_records_metadata () =
   let message =
     Printf.sprintf "[WARN] legacy warning %f" (Unix.gettimeofday ())
   in
-  Log.legacy_traceln ~module_name message;
+  Log.legacy_traceln ~level:Log.Warn ~module_name message;
   match find_entry ~module_name ~message with
   | None -> Alcotest.fail "legacy traceln entry not found"
   | Some (entry : Log.Ring.entry) ->
-      Alcotest.(check string) "source" "legacy_traceln" entry.source;
-      Alcotest.(check string) "normalized level" "WARN" entry.normalized_level;
-      Alcotest.(check bool) "legacy classified" true entry.legacy_classified
+      Alcotest.(check string) "source" "legacy_traceln"
+        (Log.source_to_string entry.source);
+      Alcotest.(check string) "level" "WARN" (Log.level_to_string entry.level)
 
 let test_recent_since_seq_returns_only_new_entries () =
   let module_name = "TestLogDelta" in

--- a/test/test_misc_coverage.ml
+++ b/test/test_misc_coverage.ml
@@ -96,7 +96,7 @@ let test_log_routine_tagged_entry () =
     | [] -> fail "expected routine entry"
     | entry :: _ ->
         check string "module" "Keeper" entry.Log.Ring.module_name;
-        check string "level" "DEBUG" entry.Log.Ring.level;
+        check string "level" "DEBUG" (Log.level_to_string entry.Log.Ring.level);
         check string "message" "routine-test-42" entry.Log.Ring.message;
         let has_routine_class =
           match entry.Log.Ring.details with


### PR DESCRIPTION
## Summary
- Update log-related OCaml tests to compare typed `Log.Ring.entry.level` and `source` through canonical string helpers.
- Replace removed `normalized_level` / `legacy_classified` expectations with the RFC-0079 typed entry contract.
- Pass explicit `~level` to `Log.legacy_traceln`.

## Root Cause
RFC-0079 made `Log.Ring.entry.level` and `source` typed closed sums and removed the legacy classifier fields, but several test files still asserted against the old string fields.

## Validation
- `ocamlformat -i test/test_misc_coverage.ml test/test_autoresearch_codegen.ml test/test_dashboard_tool_host_events.ml test/test_grpc_coordination.ml test/test_keeper_tools_oas.ml test/test_masc_log.ml`
- `scripts/dune-local.sh build test/test_misc_coverage.exe test/test_autoresearch_codegen.exe test/test_dashboard_tool_host_events.exe test/test_grpc_coordination.exe test/test_keeper_tools_oas.exe test/test_masc_log.exe`
- `git diff --check`