### PR TITLE
feat(ide): route branch lane context links

### DIFF
--- a/dashboard/src/components/ide/ide-branch-context-panel.test.ts
+++ b/dashboard/src/components/ide/ide-branch-context-panel.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
-import { waitFor } from '@testing-library/preact'
+import { fireEvent, waitFor } from '@testing-library/preact'
 import type { GitGraphResponse } from '../../api/git-graph'
 import {
   buildIdeBranchContextModel,
@@ -12,6 +12,7 @@ import { globalPresenceSnapshot } from './keeper-presence-store'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
 
 afterEach(() => {
+  window.location.hash = ''
   globalPresenceSnapshot.value = null
   cursorOverlaySignal.value = {
     cursors: new Map(),
@@ -192,6 +193,20 @@ describe('IdeBranchContextPanel', () => {
     await waitFor(() => expect(container.textContent).toContain('runtime.ml:42'))
     const status = container.querySelector('[role="status"][aria-label="Keeper sangsu: ACTIVE"]')
     expect(status).not.toBeNull()
+
+    const links = [...container.querySelectorAll<HTMLButtonElement>('.ide-branch-lane-links button')]
+    expect(links.map(link => link.textContent)).toEqual(['Code', 'Git', 'Keeper'])
+
+    fireEvent.click(links[0]!)
+    expect(window.location.hash).toBe(
+      '#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=42&surface=Git&label=sangsu+fix%2Fide-branch&source_id=branch-lane%3Alane-1&keeper=sangsu',
+    )
+
+    fireEvent.click(links[1]!)
+    expect(window.location.hash).toBe('#workspace?section=repositories&view=graph&ref=fix%2Fide-branch')
+
+    fireEvent.click(links[2]!)
+    expect(window.location.hash).toBe('#monitoring?section=agents&view=keepers&keeper=sangsu')
   })
 
   it('waits for an active repository before fetching branch graph data', async () => {

--- a/dashboard/src/components/ide/ide-branch-context-panel.ts
+++ b/dashboard/src/components/ide/ide-branch-context-panel.ts
@@ -3,6 +3,11 @@ import { useEffect, useMemo, useState } from 'preact/hooks'
 import { fetchGitGraph, type GitGraphResponse } from '../../api/git-graph'
 import { globalPresenceSnapshot, type KeeperPresenceStatus } from './keeper-presence-store'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
+import {
+  openIdeContextRouteLink,
+  routeLinksForContext,
+  type IdeContextRouteLink,
+} from './ide-context-lens'
 
 type BranchTone = 'current' | 'dirty' | 'conflict' | 'stale'
 type PanelState = 'loading' | 'ready' | 'empty' | 'error'
@@ -328,9 +333,10 @@ function LaneRow(
   const cursor = overlay.cursors.get(presenceKey)
   const focusFile = cursor?.file_path ? cursor.file_path.split('/').pop() : null
   const dotStyle = status ? LANE_STATUS_DOT[status] : null
+  const routeLinks = laneRouteLinks(lane, presenceKey, cursor)
 
   return html`
-    <li key=${lane.id} style=${{ display: 'grid', gridTemplateColumns: '6px 1fr auto', alignItems: 'center', gap: 'var(--sp-1)', padding: '2px 0' }}>
+    <li key=${lane.id} style=${{ display: 'grid', gridTemplateColumns: '6px minmax(0, 1fr) auto auto', alignItems: 'center', gap: 'var(--sp-1)', padding: '2px 0' }}>
       <span
         aria-hidden="true"
         style=${{
@@ -360,6 +366,11 @@ function LaneRow(
           >${focusFile}:${cursor?.line}</span>
         ` : null}
       </div>
+      ${routeLinks.length > 0 ? html`
+        <div class="ide-branch-lane-links" aria-label=${`${lane.label} operational links`}>
+          ${routeLinks.map(link => BranchLaneRouteLink(link))}
+        </div>
+      ` : null}
       ${dotStyle ? html`
         <span
           role="status"
@@ -374,5 +385,36 @@ function LaneRow(
         >${dotStyle.label}</span>
       ` : null}
     </li>
+  `
+}
+
+function laneRouteLinks(
+  lane: IdeWorktreeLane,
+  keeperId: string,
+  cursor: { readonly file_path: string; readonly line: number } | undefined,
+): ReadonlyArray<IdeContextRouteLink> {
+  const branch = lane.branch.trim()
+  return routeLinksForContext({
+    filePath: cursor?.file_path,
+    line: cursor?.line,
+    surface: 'Git',
+    label: `${lane.label} ${branch}`,
+    sourceId: `branch-lane:${lane.id}`,
+    gitRef: branch && branch !== 'detached' ? branch : undefined,
+    keeperId,
+  })
+}
+
+function BranchLaneRouteLink(link: IdeContextRouteLink) {
+  return html`
+    <button
+      key=${link.id}
+      type="button"
+      title=${link.evidence}
+      aria-label=${`Open ${link.evidence}`}
+      onClick=${() => openIdeContextRouteLink(link)}
+    >
+      ${link.label}
+    </button>
   `
 }

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -1112,6 +1112,42 @@
   color: var(--color-fg-disabled);
 }
 
+.ide-branch-lane-links {
+  display: inline-flex;
+  min-width: 0;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 3px;
+}
+
+.ide-branch-lane-links button {
+  min-width: 0;
+  max-width: 52px;
+  height: 17px;
+  padding: 0 5px;
+  overflow: hidden;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-page);
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-branch-lane-links button:hover,
+.ide-branch-lane-links button:focus-visible {
+  border-color: var(--color-border-strong);
+  color: var(--color-accent-fg);
+}
+
+.ide-branch-lane-links button:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 1px;
+}
+
 .ide-branch-warning,
 .ide-branch-empty {
   min-width: 0;


### PR DESCRIPTION
## Summary
- add compact Code/Git/Keeper route chips to IDE branch/worktree lanes
- reuse the existing IDE context route-link contract for source, git graph, and keeper navigation
- cover lane route clicks in the branch context panel test

## Verification
- pnpm exec eslint src/components/ide/ide-branch-context-panel.ts src/components/ide/ide-branch-context-panel.test.ts
- pnpm exec vitest run src/components/ide/ide-branch-context-panel.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD~1..HEAD