### PR TITLE
fix(dashboard): close runtime verifier gaps

### DIFF
--- a/docs/DASHBOARD-INTEGRATION.md
+++ b/docs/DASHBOARD-INTEGRATION.md
@@ -109,6 +109,8 @@ code_refs:
   - overview + runtime shell metadata
 - `GET /api/v1/dashboard/namespace-truth`
   - journey / agents / shared namespace truth
+- `GET /api/v1/dashboard/goal-loop/status`
+  - goal navigator runtime status
 - `GET /api/v1/activity/graph`
   - observatory investigation graph
 - `GET /api/v1/dashboard/telemetry/summary`
@@ -126,7 +128,7 @@ code_refs:
   - read-only CLI equivalent: `masc-keeper-feature-proof --base-path <runtime-root>`
 - `GET /api/v1/models/metrics`, `GET /api/v1/dashboard/keeper-costs`
   - runtime cost/latency view
-- `GET /api/v1/cascade/strategy-trace`, `GET /api/v1/cascade/health`
+- `GET /api/v1/cascade/strategy_trace`, `GET /api/v1/cascade/health`
   - runtime inspector view
 - `GET /api/v1/operator/digest`
   - operations read model
@@ -134,6 +136,8 @@ code_refs:
   - connectors descriptor + live state
 - `GET /api/v1/dashboard/board`
   - workspace board
+- `GET /api/v1/board/sub-boards`
+  - workspace named board spaces
 - `GET /api/v1/dashboard/planning`
   - planning + goal tree
 - `GET /api/v1/git/graph`

--- a/lib/dashboard/dashboard_surface_readiness.ml
+++ b/lib/dashboard/dashboard_surface_readiness.ml
@@ -165,7 +165,7 @@ let all_entries =
       ~meets_main_gate:true
       ~rationale:"Canonical runtime surface for cascade routing and provider health."
       ~route_hash:"#monitoring?section=runtime"
-      ~live_spotcheck:"/api/v1/dashboard/shell"
+      ~live_spotcheck:"/api/v1/cascade/health"
       ~tool_name:"masc_operator_snapshot"
       ()
   ; entry

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -143,10 +143,16 @@ check_json_eventually \
   '^True$' \
   6 \
   2
+check_http "goal-loop status 200" "$BASE/api/v1/dashboard/goal-loop/status" "200"
+check_json "goal-loop status exposes phases" "$BASE/api/v1/dashboard/goal-loop/status" "'overall_status' in d and 'phases' in d" '^True$'
 check_http "activity graph 200" "$BASE/api/v1/activity/graph" "200"
 check_json "activity graph has nodes" "$BASE/api/v1/activity/graph" "len(d.get('nodes', [])) >= 0" '^True$'
 check_http "telemetry summary 200" "$BASE/api/v1/dashboard/telemetry/summary" "200"
 check_json "telemetry summary has sources" "$BASE/api/v1/dashboard/telemetry/summary" "'sources' in d" '^True$'
+check_http "cascade health 200" "$BASE/api/v1/cascade/health" "200"
+check_json "cascade health exposes providers" "$BASE/api/v1/cascade/health" "'providers' in d" '^True$'
+check_http "cascade strategy trace 200" "$BASE/api/v1/cascade/strategy_trace?limit=1" "200"
+check_json "cascade strategy trace exposes events" "$BASE/api/v1/cascade/strategy_trace?limit=1" "'events' in d" '^True$'
 check_http "memory subsystems 200" "$BASE/api/v1/dashboard/memory-subsystems" "200"
 check_json "memory subsystems has hebbian block" "$BASE/api/v1/dashboard/memory-subsystems" "'hebbian' in d" '^True$'
 check_http "transport health 200" "$BASE/api/v1/dashboard/transport-health" "200"
@@ -159,8 +165,12 @@ check_http "operator digest 200" "$BASE/api/v1/operator/digest" "200"
 check_json "operator digest has health block" "$BASE/api/v1/operator/digest" "'health' in d" '^True$'
 check_http "board 200" "$BASE/api/v1/dashboard/board" "200"
 check_json "board exposes posts" "$BASE/api/v1/dashboard/board" "'posts' in d" '^True$'
+check_http "sub-boards 200" "$BASE/api/v1/board/sub-boards" "200"
+check_json "sub-boards exposes list" "$BASE/api/v1/board/sub-boards" "'sub_boards' in d" '^True$'
 check_http "planning 200" "$BASE/api/v1/dashboard/planning" "200"
 check_json "planning exposes rollup" "$BASE/api/v1/dashboard/planning" "'rollup' in d" '^True$'
+check_http "git graph 200" "$BASE/api/v1/git/graph?n=20" "200"
+check_json "git graph exposes stats and nodes" "$BASE/api/v1/git/graph?n=20" "'stats' in d and 'nodes' in d" '^True$'
 check_http "verification requests 200" "$BASE/api/v1/verification/requests" "200"
 check_json "verification requests exposes list" "$BASE/api/v1/verification/requests" "'requests' in d" '^True$'
 check_http "verification summary 200" "$BASE/api/v1/verification/summary" "200"

--- a/test/test_dashboard_surface_readiness.ml
+++ b/test/test_dashboard_surface_readiness.ml
@@ -169,6 +169,28 @@ let test_cognition_readiness_uses_cognition_read_model () =
              "live_spotcheck+logs+metrics"
              (surface |> member "verification_ref_bar" |> to_string))
 
+let test_runtime_readiness_uses_cascade_health_read_model () =
+  let json = Dashboard_surface_readiness.json ~surface_id:"monitoring.runtime" () in
+  let surfaces = Yojson.Safe.Util.(json |> member "surfaces" |> to_list) in
+  match List.find_opt
+          (fun surface ->
+            Yojson.Safe.Util.(surface |> member "id" |> to_string = "monitoring.runtime"))
+          surfaces
+  with
+  | None -> fail "monitoring.runtime missing"
+  | Some surface ->
+      (match find_verification_ref surface "live_spotcheck" with
+       | None -> fail "monitoring.runtime live_spotcheck missing"
+       | Some ref_json ->
+           let open Yojson.Safe.Util in
+           check string "live_spotcheck kind" "route"
+             (ref_json |> member "kind" |> to_string);
+           check string "live_spotcheck value" "/api/v1/cascade/health"
+             (ref_json |> member "value" |> to_string);
+           check string "surface verification ref labels"
+             "live_spotcheck+logs+metrics+tool"
+             (surface |> member "verification_ref_bar" |> to_string))
+
 let test_code_ide_readiness_uses_ide_presence_read_model () =
   let json = Dashboard_surface_readiness.json ~surface_id:"code.ide-shell" () in
   let surfaces = Yojson.Safe.Util.(json |> member "surfaces" |> to_list) in
@@ -283,6 +305,8 @@ let () =
             test_live_spotcheck_keeps_script_values_as_scripts;
           test_case "cognition readiness uses cognition read model" `Quick
             test_cognition_readiness_uses_cognition_read_model;
+          test_case "runtime readiness uses cascade health read model" `Quick
+            test_runtime_readiness_uses_cascade_health_read_model;
           test_case "code ide readiness uses ide presence read model" `Quick
             test_code_ide_readiness_uses_ide_presence_read_model;
           test_case "verification ref bar reflects declared refs" `Quick


### PR DESCRIPTION
Summary:
- Point monitoring.runtime surface readiness at the cascade health read model instead of generic dashboard shell.
- Add dashboard verifier coverage for cascade health, cascade strategy trace, goal-loop status, sub-boards, and git graph live routes.
- Fix stale or missing dashboard integration route docs and cover the runtime readiness contract with a regression test.

Validation:
- git diff --check
- bash -n scripts/verify-dashboard.sh
- python route coverage check: readiness live routes are mentioned in verify-dashboard.sh and DASHBOARD-INTEGRATION.md
- bash scripts/check-dashboard-surface-parity.sh --check
- bash scripts/check-dashboard-nav-event-parity.sh --check
- ocamlformat --check lib/dashboard/dashboard_surface_readiness.ml test/test_dashboard_surface_readiness.ml
- scripts/dune-local.sh build test/test_dashboard_surface_readiness.exe
- ./_build/default/test/test_dashboard_surface_readiness.exe