### PR TITLE
feat(ide): route keeper trace context

### DIFF
--- a/dashboard/src/components/ide/keeper-trace-store.ts
+++ b/dashboard/src/components/ide/keeper-trace-store.ts
@@ -74,6 +74,16 @@ export type KeeperTraceEvent =
       readonly filePath: string
       readonly line: number
       readonly surface: string
+      readonly goalId?: string
+      readonly taskId?: string
+      readonly boardPostId?: string
+      readonly commentId?: string
+      readonly prId?: string
+      readonly gitRef?: string
+      readonly logId?: string
+      readonly sessionId?: string
+      readonly operationId?: string
+      readonly workerRunId?: string
     })
 
 export type KeeperTraceEventInput =

--- a/dashboard/src/components/ide/overlay-keeper-trace.test.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
+import { fireEvent } from '@testing-library/preact'
 import {
   OverlayKeeperTrace,
   TRACE_CHIP_CAP,
@@ -66,6 +67,7 @@ function pushActivity(
   line: number,
   tsMs: number,
   filePath = 'runtime.ts',
+  refs: Partial<Extract<KeeperTraceEventForTest, { source: 'activity-event' }>> = {},
 ): void {
   pushTrace({
     id,
@@ -76,14 +78,18 @@ function pushActivity(
     filePath,
     line,
     surface: 'Goal',
+    ...refs,
   })
 }
+
+type KeeperTraceEventForTest = Parameters<typeof pushTrace>[0]
 
 beforeEach(() => {
   clearTraces()
 })
 
 afterEach(() => {
+  window.location.hash = ''
   for (const container of mountedContainers.splice(0)) {
     render(null, container)
   }
@@ -260,6 +266,51 @@ describe('OverlayKeeperTrace — bucket render (RFC-0028 §5)', () => {
     expect(chip?.getAttribute('aria-label')).toContain('thread')
     expect(chip?.getAttribute('aria-label')).toContain('L42')
     expect(chip?.getAttribute('aria-label')).toContain('×2')
+  })
+
+  it('renders operational route links for enriched activity traces', () => {
+    pushActivity('a', 'scholar', 12, 1000, 'runtime.ts', {
+      eventId: 'evt-a',
+      goalId: 'goal-runtime',
+      taskId: 'task-runtime',
+      prId: '15035',
+      gitRef: 'main',
+      logId: 'turn-12',
+      sessionId: 'sess-runtime',
+      operationId: 'op-runtime',
+      workerRunId: 'wr-runtime',
+    })
+
+    const container = createContainer()
+    render(html`<${OverlayKeeperTrace} active=${true} />`, container)
+
+    const links = [...container.querySelectorAll<HTMLButtonElement>('.ide-trace-route-link')]
+    expect(links.map(link => link.textContent)).toEqual([
+      'Code',
+      'Goal',
+      'Task',
+      'PR',
+      'Git',
+      'Log',
+      'Telemetry',
+      'Keeper',
+    ])
+
+    fireEvent.click(links[0]!)
+    expect(window.location.hash).toBe(
+      '#code?section=ide-shell&view=source&file=runtime.ts&line=12&surface=Goal&label=Goal+activity+evt-a&source_id=trace%3Aa&keeper=scholar',
+    )
+
+    fireEvent.click(links[5]!)
+    expect(window.location.hash).toBe('#monitoring?section=runtime&view=audit&log_id=turn-12')
+
+    fireEvent.click(links[6]!)
+    expect(window.location.hash).toBe(
+      '#monitoring?section=fleet-health&view=event-log&session_id=sess-runtime&operation_id=op-runtime&worker_run_id=wr-runtime&q=turn-12',
+    )
+
+    fireEvent.click(links[7]!)
+    expect(window.location.hash).toBe('#monitoring?section=agents&view=keepers&keeper=scholar')
   })
 })
 

--- a/dashboard/src/components/ide/overlay-keeper-trace.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.ts
@@ -5,6 +5,12 @@ import {
   KeeperTraceSource,
   keeperTraceState,
 } from './keeper-trace-store'
+import {
+  openIdeContextRouteLink,
+  routeLinksForContext,
+  type IdeContextRouteContext,
+  type IdeContextRouteLink,
+} from './ide-context-lens'
 
 /**
  * RFC-0028 PR-β: keeper-trace gutter chip overlay.
@@ -32,14 +38,15 @@ import {
  */
 
 export const TRACE_CHIP_CAP = 3
+const TRACE_ROUTE_LINK_CAP = 10
 
 /** Source → chip background color (semantic, not literal). */
 const SOURCE_COLORS: Record<KeeperTraceSource, string> = {
-  'anchored-thread': 'var(--color-status-info, #4a90e2)',
-  'cascade-hop': 'var(--color-accent-fg, #8b5cf6)',
-  'bdi-snapshot': 'var(--color-status-ok, #2dba4e)',
-  'decision-log': 'var(--color-status-warn, #d97706)',
-  'activity-event': 'var(--color-status-info, #4a90e2)',
+  'anchored-thread': 'var(--color-status-info)',
+  'cascade-hop': 'var(--color-accent-fg)',
+  'bdi-snapshot': 'var(--color-status-ok)',
+  'decision-log': 'var(--color-status-warn)',
+  'activity-event': 'var(--color-status-info)',
 }
 
 /** Source → label glyph for tooltip + ARIA. */
@@ -152,6 +159,31 @@ const OVERFLOW_STYLE = {
   fontSize: 'var(--fs-11)',
 } as const
 
+const ROUTE_LINKS_STYLE = {
+  display: 'inline-flex',
+  minWidth: 0,
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  gap: '3px',
+} as const
+
+const ROUTE_LINK_BUTTON_STYLE = {
+  minWidth: 0,
+  maxWidth: '58px',
+  height: '17px',
+  padding: '0 5px',
+  overflow: 'hidden',
+  border: '1px solid var(--color-border-default)',
+  borderRadius: 'var(--r-1)',
+  background: 'var(--color-bg-page)',
+  color: 'var(--color-fg-muted)',
+  cursor: 'pointer',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 'var(--fs-9)',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+} as const
+
 function formatTooltip(event: KeeperTraceEvent): string {
   const sourceLabel = SOURCE_LABELS[event.source]
   const line = lineOf(event)
@@ -195,6 +227,7 @@ function BucketRow({ bucket }: { readonly bucket: TraceBucket }) {
   const visible = bucket.events.slice(0, TRACE_CHIP_CAP)
   const overflow = bucket.events.length - visible.length
   const lineLabel = bucket.line !== null ? `L${bucket.line}` : '—'
+  const routeLinks = traceRouteLinks(bucket.events)
 
   return html`
     <div
@@ -223,6 +256,104 @@ function BucketRow({ bucket }: { readonly bucket: TraceBucket }) {
       ${overflow > 0
         ? html`<span aria-label=${`${overflow} more`} data-overflow=${overflow} style=${OVERFLOW_STYLE}>+${overflow}</span>`
         : null}
+      ${routeLinks.length > 0 ? html`
+        <div class="ide-trace-route-links" aria-label=${`${bucket.keeperName} trace route links`} style=${ROUTE_LINKS_STYLE}>
+          ${routeLinks.map(link => html`
+            <button
+              key=${link.id}
+              type="button"
+              class="ide-trace-route-link"
+              title=${link.evidence}
+              aria-label=${`Open ${link.evidence}`}
+              onClick=${() => openIdeContextRouteLink(link)}
+              style=${ROUTE_LINK_BUTTON_STYLE}
+            >
+              ${link.label}
+            </button>
+          `)}
+        </div>
+      ` : null}
     </div>
   `
+}
+
+function traceRouteLinks(events: ReadonlyArray<KeeperTraceEvent>): ReadonlyArray<IdeContextRouteLink> {
+  const links: IdeContextRouteLink[] = []
+  const seen = new Set<string>()
+  for (const event of events) {
+    for (const link of routeLinksForContext(traceRouteContext(event))) {
+      if (seen.has(link.id)) continue
+      seen.add(link.id)
+      links.push(link)
+      if (links.length >= TRACE_ROUTE_LINK_CAP) return links
+    }
+  }
+  return links
+}
+
+function traceRouteContext(event: KeeperTraceEvent): IdeContextRouteContext {
+  if (event.source === 'activity-event') {
+    return {
+      filePath: event.filePath,
+      line: event.line,
+      surface: event.surface,
+      label: `${event.surface} activity ${event.eventId}`,
+      sourceId: `trace:${event.id}`,
+      goalId: event.goalId,
+      taskId: event.taskId,
+      boardPostId: event.boardPostId,
+      commentId: event.commentId,
+      prId: event.prId,
+      gitRef: event.gitRef,
+      logId: event.logId,
+      sessionId: event.sessionId,
+      operationId: event.operationId,
+      workerRunId: event.workerRunId,
+      telemetryQuery: event.logId ?? event.eventId,
+      keeperId: event.keeperName,
+      telemetry: true,
+    }
+  }
+
+  if (event.source === 'anchored-thread') {
+    return {
+      filePath: event.filePath ?? undefined,
+      line: event.line ?? undefined,
+      surface: 'Thread',
+      label: `thread ${event.threadId}`,
+      sourceId: `trace:${event.id}`,
+      boardPostId: event.threadId,
+      keeperId: event.keeperName,
+    }
+  }
+
+  if (event.source === 'bdi-snapshot') {
+    return {
+      surface: 'BDI',
+      label: event.intention ?? 'BDI snapshot',
+      sourceId: `trace:${event.id}`,
+      keeperId: event.keeperName,
+      telemetryQuery: event.id,
+      telemetry: true,
+    }
+  }
+
+  if (event.source === 'decision-log') {
+    return {
+      surface: 'Decision',
+      label: event.semanticOutcome ?? 'decision',
+      sourceId: `trace:${event.id}`,
+      keeperId: event.keeperName,
+      telemetryQuery: event.decisionId,
+      telemetry: true,
+    }
+  }
+
+  return {
+    surface: 'Cascade',
+    label: event.provider,
+    sourceId: `trace:${event.id}`,
+    telemetryQuery: event.hopId,
+    telemetry: true,
+  }
 }

--- a/dashboard/src/components/ide/run-activity-trace-bridge.test.ts
+++ b/dashboard/src/components/ide/run-activity-trace-bridge.test.ts
@@ -25,7 +25,14 @@ describe('bridgeRunActivityEventsToTrace', () => {
           line: 7,
           goal_id: 'goal-runtime',
           task_id: 'task-runtime',
+          board_post_id: 'post-runtime',
+          comment_id: 'comment-runtime',
+          pr_id: '15035',
+          git_ref: 'main',
           log_id: 'turn-7',
+          session_id: 'sess-runtime',
+          operation_id: 'op-runtime',
+          worker_run_id: 'wr-runtime',
         },
       }),
     ], new Set())
@@ -40,7 +47,17 @@ describe('bridgeRunActivityEventsToTrace', () => {
       eventId: 'evt-1',
       filePath: 'lib/runtime.ml',
       line: 7,
-      surface: 'Goal',
+      surface: 'PR',
+      goalId: 'goal-runtime',
+      taskId: 'task-runtime',
+      boardPostId: 'post-runtime',
+      commentId: 'comment-runtime',
+      prId: '15035',
+      gitRef: 'main',
+      logId: 'turn-7',
+      sessionId: 'sess-runtime',
+      operationId: 'op-runtime',
+      workerRunId: 'wr-runtime',
     }])
   })
 

--- a/dashboard/src/components/ide/run-activity-trace-bridge.ts
+++ b/dashboard/src/components/ide/run-activity-trace-bridge.ts
@@ -33,6 +33,16 @@ export function bridgeRunActivityEventsToTrace(
       filePath,
       line,
       surface: activityTraceSurface(event),
+      goalId: event.context?.goal_id,
+      taskId: event.context?.task_id,
+      boardPostId: event.context?.board_post_id,
+      commentId: event.context?.comment_id,
+      prId: event.context?.pr_id,
+      gitRef: event.context?.git_ref,
+      logId: event.context?.log_id,
+      sessionId: event.context?.session_id,
+      operationId: event.context?.operation_id,
+      workerRunId: event.context?.worker_run_id,
     })
     next.add(key)
   }


### PR DESCRIPTION
## Summary
- preserve structured activity refs when bridging activity events into keeper trace events
- add compact operational route links to keeper trace overlay buckets
- route trace buckets to Code, planning, repo, runtime log, telemetry, and keeper views using the existing context route contract
- remove raw color fallbacks from trace source colors so the overlay stays on semantic design tokens

## Verification
- pnpm exec eslint src/components/ide/keeper-trace-store.ts src/components/ide/run-activity-trace-bridge.ts src/components/ide/run-activity-trace-bridge.test.ts src/components/ide/overlay-keeper-trace.ts src/components/ide/overlay-keeper-trace.test.ts
- pnpm exec vitest run src/components/ide/keeper-trace-store.test.ts src/components/ide/run-activity-trace-bridge.test.ts src/components/ide/overlay-keeper-trace.test.ts src/components/ide/ide-editor-extensions.test.ts src/components/ide/ide-editor.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD~1..HEAD
- rg -n "#[0-9a-fA-F]{3,8}" dashboard/src/components/ide/overlay-keeper-trace.ts dashboard/src/components/ide/run-activity-trace-bridge.ts dashboard/src/components/ide/keeper-trace-store.ts