### PR TITLE
fix(telemetry): emit streaming OTel span events

### DIFF
--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -182,16 +182,32 @@ let emit_streaming_first_chunk ~provider ~model_id ~ttfrc_ms =
   remember_provider ~model_id ~provider;
   match seconds_of_ms ttfrc_ms with
   | Some seconds ->
+    Otel_spans.add_event
+      ~name:"ttfrc.received"
+      ~attrs:
+        [ "gen_ai.provider.name", `String provider
+        ; "gen_ai.request.model", `String model_id
+        ; "masc.gen_ai.streaming.ttfrc_ms", `Float ttfrc_ms
+        ]
+      ();
     Prometheus.observe_histogram streaming_first_chunk_metric
       ~labels:[("provider", provider); ("model", model_id)]
       seconds
   | None -> ()
 
 let emit_streaming_chunk ~provider ~model_id ~chunk_index ~inter_chunk_ms =
-  let _ = chunk_index in
   remember_provider ~model_id ~provider;
   match seconds_of_ms inter_chunk_ms with
   | Some seconds ->
+    Otel_spans.add_event
+      ~name:"streaming.chunk"
+      ~attrs:
+        [ "gen_ai.provider.name", `String provider
+        ; "gen_ai.request.model", `String model_id
+        ; "masc.gen_ai.streaming.chunk_index", `Int chunk_index
+        ; "masc.gen_ai.streaming.inter_chunk_ms", `Float inter_chunk_ms
+        ]
+      ();
     Prometheus.observe_histogram streaming_inter_chunk_metric
       ~labels:[("provider", provider); ("model", model_id)]
       seconds

--- a/lib/otel/otel_spans.ml
+++ b/lib/otel/otel_spans.ml
@@ -9,6 +9,19 @@ module OT = Opentelemetry
 
 let initialized = Atomic.make false
 let exporter_active = Atomic.make false
+let enabled_override : bool option ref = ref None
+
+let event_emitter_override
+      : (name:string -> attrs:OT.key_value list -> unit) option ref
+  =
+  ref None
+;;
+
+let enabled () =
+  match !enabled_override with
+  | Some value -> value
+  | None -> Otel_config.enabled
+;;
 
 let init () =
   if Otel_config.enabled && not (Atomic.get initialized) then begin
@@ -70,6 +83,32 @@ let with_span ~name ?(attrs = []) f =
       f (fun () ->
         let ctx = OT.Scope.to_span_ctx scope in
         Some (OT.Trace_id.to_hex (OT.Span_ctx.trace_id ctx))))
+
+(** Add an event to the active OTel span. No-op when disabled or when no
+    ambient span exists. *)
+let add_event ~name ?(attrs = []) () =
+  if enabled ()
+  then
+    match !event_emitter_override with
+    | Some emit -> emit ~name ~attrs
+    | None ->
+      (match OT.Scope.get_ambient_scope () with
+       | Some scope ->
+         OT.Scope.add_event scope (fun () -> OT.Event.make ~attrs name)
+       | None -> ())
+;;
+
+let with_test_event_emitter ~enabled:enabled_value ~emit_event f =
+  let prev_enabled = !enabled_override in
+  let prev_emitter = !event_emitter_override in
+  enabled_override := Some enabled_value;
+  event_emitter_override := Some emit_event;
+  Eio_guard.protect
+    ~finally:(fun () ->
+      enabled_override := prev_enabled;
+      event_emitter_override := prev_emitter)
+    f
+;;
 
 (** Get the current OTel trace ID as a hex string, or None if disabled / no active span. *)
 let current_trace_id () =

--- a/lib/otel/otel_spans.mli
+++ b/lib/otel/otel_spans.mli
@@ -36,5 +36,17 @@ val with_span :
   ((unit -> string option) -> 'a) ->
   'a
 
+(** [add_event ~name ~attrs ()] appends an event to the active OTel span.
+    No-op when OTel is disabled or when no ambient span exists. *)
+val add_event :
+  name:string -> ?attrs:Opentelemetry.key_value list -> unit -> unit
+
+(** Temporarily override event emission for focused tests. *)
+val with_test_event_emitter :
+  enabled:bool ->
+  emit_event:(name:string -> attrs:Opentelemetry.key_value list -> unit) ->
+  (unit -> 'a) ->
+  'a
+
 (** [current_trace_id ()] returns the active OTel trace ID as hex, or [None]. *)
 val current_trace_id : unit -> string option

--- a/test/test_llm_metric_bridge.ml
+++ b/test/test_llm_metric_bridge.ml
@@ -1,4 +1,5 @@
 module Bridge = Masc_mcp.Llm_metric_bridge
+module Otel_spans = Masc_mcp.Otel_spans
 module Prom = Masc_mcp.Prometheus
 
 let metric name ~labels =
@@ -172,6 +173,70 @@ let test_streaming_metrics_ignore_invalid_ms () =
     (Prom.metric_llm_provider_streaming_inter_chunk ^ "_count")
     ~labels ~before:inter_before ~delta:0.0
 
+let assoc_string key attrs =
+  match List.assoc_opt key attrs with
+  | Some (`String value) -> value
+  | Some _ -> Alcotest.failf "expected string attr %s" key
+  | None -> Alcotest.failf "missing attr %s" key
+
+let assoc_float key attrs =
+  match List.assoc_opt key attrs with
+  | Some (`Float value) -> value
+  | Some _ -> Alcotest.failf "expected float attr %s" key
+  | None -> Alcotest.failf "missing attr %s" key
+
+let assoc_int key attrs =
+  match List.assoc_opt key attrs with
+  | Some (`Int value) -> value
+  | Some _ -> Alcotest.failf "expected int attr %s" key
+  | None -> Alcotest.failf "missing attr %s" key
+
+let test_streaming_callbacks_emit_otel_events () =
+  let events = ref [] in
+  let provider = "bridge-otel-provider" in
+  let model_id = Printf.sprintf "bridge-otel-model-%d" (Unix.getpid ()) in
+  Otel_spans.with_test_event_emitter ~enabled:true
+    ~emit_event:(fun ~name ~attrs -> events := (name, attrs) :: !events)
+    (fun () ->
+       Bridge.emit_streaming_first_chunk ~provider ~model_id ~ttfrc_ms:25.0;
+       Bridge.emit_streaming_chunk
+         ~provider ~model_id ~chunk_index:3 ~inter_chunk_ms:7.5);
+  match List.rev !events with
+  | [ first_name, first_attrs; chunk_name, chunk_attrs ] ->
+    Alcotest.(check string) "first chunk event" "ttfrc.received" first_name;
+    Alcotest.(check string) "chunk event" "streaming.chunk" chunk_name;
+    Alcotest.(check string)
+      "first provider"
+      provider
+      (assoc_string "gen_ai.provider.name" first_attrs);
+    Alcotest.(check string)
+      "first model"
+      model_id
+      (assoc_string "gen_ai.request.model" first_attrs);
+    Alcotest.(check (float 0.0001))
+      "ttfrc ms"
+      25.0
+      (assoc_float "masc.gen_ai.streaming.ttfrc_ms" first_attrs);
+    Alcotest.(check int)
+      "chunk index"
+      3
+      (assoc_int "masc.gen_ai.streaming.chunk_index" chunk_attrs);
+    Alcotest.(check string)
+      "chunk provider"
+      provider
+      (assoc_string "gen_ai.provider.name" chunk_attrs);
+    Alcotest.(check string)
+      "chunk model"
+      model_id
+      (assoc_string "gen_ai.request.model" chunk_attrs);
+    Alcotest.(check (float 0.0001))
+      "inter chunk ms"
+      7.5
+      (assoc_float "masc.gen_ai.streaming.inter_chunk_ms" chunk_attrs)
+  | other ->
+    Alcotest.failf "expected two OTel streaming events, got %d"
+      (List.length other)
+
 let test_request_latency_clamps_zero_ms () =
   let model_id =
     Printf.sprintf "bridge-latency-zero-%d" (Unix.getpid ())
@@ -270,6 +335,8 @@ let () =
             test_sink_records_oas_callbacks;
           Alcotest.test_case "streaming metrics ignore invalid ms" `Quick
             test_streaming_metrics_ignore_invalid_ms;
+          Alcotest.test_case "streaming callbacks emit OTel events" `Quick
+            test_streaming_callbacks_emit_otel_events;
           Alcotest.test_case "request latency floors zero ms" `Quick
             test_request_latency_clamps_zero_ms;
           Alcotest.test_case "positive request latency does not clamp" `Quick


### PR DESCRIPTION
## Summary

- emit OTel span events for OAS streaming first-chunk and inter-chunk callbacks
- expose a guarded OTel span-event helper with a focused test emitter override
- add regression coverage for event order and provider/model/timing attrs

## Product impact

- User-visible change: no UI/API surface change. Operators get trace-level streaming evidence (`ttfrc.received`, `streaming.chunk`) in addition to existing Prometheus histograms, which makes slow-response vs no-response diagnosis sharper.

## Evidence

- Source finding: old Kimi telemetry audit asked for trace-level streaming evidence, not only aggregate histograms. Current main had streaming Prometheus metrics but no active-span OTel event emission for these callbacks.
- `ocamlformat --check lib/otel/otel_spans.ml lib/otel/otel_spans.mli lib/llm_metric_bridge.ml test/test_llm_metric_bridge.ml`
- `git diff --check`
- `scripts/check-oas-pin.sh`
- `scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_llm_metric_bridge.exe`
- `scripts/dune-local.sh build test/test_llm_metric_bridge.exe`
- `./_build/default/test/test_llm_metric_bridge.exe`

## GOAL LOOP ACT checklist

- [x] Observe — audit gap was Prometheus-only streaming telemetry without trace-level streaming span events.
- [x] Orient — maps to the Kimi telemetry document's remaining TTFC/chunk ordering diagnosis target.
- [x] Decide — bounded to the OAS metrics bridge and OTel span helper; no provider or dashboard contract change.
- [x] Act — added active-span event emission and focused regression coverage.
- [x] Verify — focused Dune build and `test_llm_metric_bridge` passed locally.
- [x] Loop — no additional follow-up for this specific trace-event gap.

## Review evidence

- Cross-model review: not run; this is a bounded telemetry bridge patch with local regression coverage. Draft PR is left for normal reviewer/CI scrutiny.

## Linked issue

- Closes # N/A
- Relates # N/A; derived from local Kimi telemetry audit docs.

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant added/removed.
- [ ] **TypeScript** — N/A: no dashboard union member changed.
- [ ] **TLA+ spec** — N/A: no spec domain literal changed.
- [ ] **Event / JSON schema** — N/A: no JSON schema enum changed; OTel span-event names are runtime telemetry labels.
- [ ] **`make check-variants` passes** — N/A: no variant/schema enum surface changed.
