### PR TITLE
feat(ide): restore route focus links

### DIFF
--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -175,6 +175,72 @@ describe('IdeShell', () => {
     })
   })
 
+  it('hydrates operational route links from IDE route params', async () => {
+    route.value = {
+      tab: 'code',
+      params: {
+        section: 'ide-shell',
+        view: 'source',
+        file: 'lib/runtime.ml',
+        line: '42',
+        surface: 'PR',
+        label: 'Runtime review',
+        source_id: 'trace:evt-42',
+        keeper: 'sangsu',
+        goal: 'goal-runtime',
+        task: 'task-runtime',
+        post: 'post-runtime',
+        comment: 'comment-runtime',
+        pr: '15035',
+        ref: 'main',
+        log_id: 'turn-42',
+        session_id: 'sess-runtime',
+        operation_id: 'op-runtime',
+        worker_run_id: 'wr-runtime',
+      },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    await waitFor(() => expect(ideContextFocus.value?.route_links?.map(link => link.label)).toEqual([
+      'Code',
+      'Goal',
+      'Task',
+      'Board',
+      'Comment',
+      'PR',
+      'Git',
+      'Log',
+      'Telemetry',
+      'Keeper',
+    ]))
+
+    const toolbarFocus = container.querySelector('[data-testid="ide-toolbar-context-focus"]')
+    expect(toolbarFocus?.getAttribute('aria-label')).toBe(
+      'Current IDE context: PR line 42, Runtime review, keeper sangsu, 10 route links',
+    )
+
+    const routeButtons = [...container.querySelectorAll<HTMLButtonElement>('.ide-toolbar-context-links button')]
+    expect(routeButtons.map(button => button.getAttribute('aria-label'))).toEqual([
+      'Open Code lib/runtime.ml:42',
+      'Open Goal goal-runtime',
+      'Open Task task-runtime',
+      'Open Board post post-runtime',
+      'Open Comment comment-runtime',
+      'Open PR 15035',
+      'Open Git main',
+      'Open Log turn-42',
+      'Open Fleet telemetry event log · session sess-runtime · operation op-runtime · worker wr-runtime · query turn-42',
+      'Open Keeper sangsu',
+    ])
+
+    fireEvent.click(routeButtons[8]!)
+    expect(window.location.hash).toBe(
+      '#monitoring?section=fleet-health&view=event-log&session_id=sess-runtime&operation_id=op-runtime&worker_run_id=wr-runtime&q=turn-42',
+    )
+  })
+
   it('rejects unsafe IDE route file focus params', async () => {
     route.value = {
       tab: 'code',

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -16,6 +16,7 @@ import { OverlayKeeperTrace } from './overlay-keeper-trace'
 import { IdePersistencePanel } from './ide-persistence-panel'
 import { IdeBranchContextPanel } from './ide-branch-context-panel'
 import { cursorOverlaySignal, getKeeperColor, type KeeperCursor } from './keeper-cursor-overlay'
+import { routeLinksForContext } from './ide-context-lens'
 import { navigate, route } from '../../router'
 import { activeKeeperName } from '../../keeper-state'
 import { keepers } from '../../store'
@@ -93,6 +94,14 @@ function routeFocusSourceId(params: Record<string, string>, filePath: string, li
   return line !== undefined ? `route:${filePath}:${line}` : `route:${filePath}`
 }
 
+function routeParam(params: Record<string, string>, ...keys: ReadonlyArray<string>): string | undefined {
+  for (const key of keys) {
+    const value = params[key]?.trim()
+    if (value) return value
+  }
+  return undefined
+}
+
 function paramsWithLayers(
   params: Record<string, string>,
   view: ViewTab,
@@ -151,9 +160,26 @@ export function IdeShell() {
     ? routeFocusSourceId(route.value.params, routeFileFocus, routeLineFocus)
     : ''
   const routeKeeperFocus = route.value.params.keeper?.trim() || undefined
+  const routeGoalFocus = routeParam(route.value.params, 'goal_id', 'goal')
+  const routeTaskFocus = routeParam(route.value.params, 'task_id', 'task')
+  const routeBoardPostFocus = routeParam(route.value.params, 'board_post_id', 'post')
+  const routeCommentFocus = routeParam(route.value.params, 'comment_id', 'comment')
+  const routePrFocus = routeParam(route.value.params, 'pr_id', 'pr')
+  const routeGitFocus = routeParam(route.value.params, 'git_ref', 'ref')
+  const routeLogFocus = routeParam(route.value.params, 'log_id', 'log')
+  const routeSessionFocus = routeParam(route.value.params, 'session_id')
+  const routeOperationFocus = routeParam(route.value.params, 'operation_id', 'op')
+  const routeWorkerRunFocus = routeParam(route.value.params, 'worker_run_id', 'worker')
+  const routeTelemetryFocus = routeParam(route.value.params, 'telemetry_q', 'q') ?? routeLogFocus
 
   useEffect(() => {
     if (!routeFileFocus) return
+    const telemetry = Boolean(
+      routeTelemetryFocus
+      || routeSessionFocus
+      || routeOperationFocus
+      || routeWorkerRunFocus,
+    )
     focusIdeContextAnchor({
       file_path: routeFileFocus,
       line: routeLineFocus,
@@ -161,6 +187,26 @@ export function IdeShell() {
       label: routeLabelFocus,
       source_id: routeSourceFocus,
       keeper_id: routeKeeperFocus,
+      route_links: routeLinksForContext({
+        filePath: routeFileFocus,
+        line: routeLineFocus,
+        surface: routeSurfaceFocus,
+        label: routeLabelFocus,
+        sourceId: routeSourceFocus,
+        goalId: routeGoalFocus,
+        taskId: routeTaskFocus,
+        boardPostId: routeBoardPostFocus,
+        commentId: routeCommentFocus,
+        prId: routePrFocus,
+        gitRef: routeGitFocus,
+        logId: routeLogFocus,
+        sessionId: routeSessionFocus,
+        operationId: routeOperationFocus,
+        workerRunId: routeWorkerRunFocus,
+        telemetryQuery: routeTelemetryFocus,
+        keeperId: routeKeeperFocus,
+        telemetry,
+      }),
     })
   }, [
     routeFileFocus,
@@ -169,6 +215,17 @@ export function IdeShell() {
     routeLabelFocus,
     routeSourceFocus,
     routeKeeperFocus,
+    routeGoalFocus,
+    routeTaskFocus,
+    routeBoardPostFocus,
+    routeCommentFocus,
+    routePrFocus,
+    routeGitFocus,
+    routeLogFocus,
+    routeSessionFocus,
+    routeOperationFocus,
+    routeWorkerRunFocus,
+    routeTelemetryFocus,
   ])
 
   const activeFocus = focusFromRoute(route.value.params.focus)


### PR DESCRIPTION
## Summary
- reconstruct IDE context route links from deep-link route params during shell hydration
- keep Code / Goal / Task / Board / Comment / PR / Git / Log / Telemetry / Keeper actions available in the toolbar after URL entry
- cover the restored toolbar route links with an IDE shell regression test

## Verification
- pnpm exec eslint src/components/ide/ide-shell.ts src/components/ide/ide-shell.test.ts
- pnpm exec vitest run src/components/ide/ide-shell.test.ts src/components/ide/ide-toolbar.test.ts src/components/ide/ide-context-lens.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD~1..HEAD