### PR TITLE
fix(health): surface log ring summary

### DIFF
--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -534,6 +534,69 @@ module Ring = struct
       ("total", `Int (Atomic.get total));
       ("entries", `List (List.map entry_to_json entries));
     ]
+
+  let latest_metadata_json = function
+    | None -> `Null
+    | Some e ->
+        `Assoc
+          [
+            ("seq", `Int e.seq);
+            ("ts", `String e.ts);
+            ("level", `String (level_to_string e.level));
+            ("source", `String (source_to_string e.source));
+            ("module", `String e.module_name);
+            ( "keeper_name",
+              (match e.keeper_name with
+              | Some name -> `String name
+              | None -> `Null) );
+            ( "turn_id",
+              (match e.turn_id with
+              | Some turn_id -> `Int turn_id
+              | None -> `Null) );
+          ]
+
+  let summary_json () =
+    let total_entries = Atomic.get total in
+    let retained_entries = min total_entries capacity in
+    let recent_window = recent ~limit:200 () in
+    let recent_errors =
+      List.fold_left
+        (fun count e -> if e.level = Error then count + 1 else count)
+        0 recent_window
+    in
+    let recent_warnings =
+      List.fold_left
+        (fun count e -> if e.level = Warn then count + 1 else count)
+        0 recent_window
+    in
+    let file_sink_dir =
+      if String.equal !file_base_dir "" then `Null else `String !file_base_dir
+    in
+    let latest =
+      match recent_window with
+      | latest :: _ -> Some latest
+      | [] -> None
+    in
+    `Assoc
+      [
+        ("status", `String (if total_entries = 0 then "empty" else "active"));
+        ("capacity", `Int capacity);
+        ("total_entries", `Int total_entries);
+        ("retained_entries", `Int retained_entries);
+        ("recent_window", `Int (List.length recent_window));
+        ("recent_errors", `Int recent_errors);
+        ("recent_warnings", `Int recent_warnings);
+        ("latest", latest_metadata_json latest);
+        ( "file_sink",
+          `Assoc
+            [
+              ("enabled", `Bool (!file_channel <> None));
+              ("dir", file_sink_dir);
+              ( "current_date",
+                if String.equal !file_current_date "" then `Null
+                else `String !file_current_date );
+            ] );
+      ]
 end
 
 (** Log a message at given level with optional context *)

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -131,6 +131,10 @@ module Ring : sig
   val entry_to_json : entry -> Yojson.Safe.t
   val entry_of_json : Yojson.Safe.t -> entry
   val to_json : entry list -> Yojson.Safe.t
+  val summary_json : unit -> Yojson.Safe.t
+  (** Cheap operator summary for [/health].  It exposes ring counters,
+      latest metadata, and file-sink state without raw log message text or
+      [details] payloads. *)
 
   val init_file_sink : string -> unit
   (** Initialize file-based log persistence. Loads previous entries from disk

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -261,6 +261,11 @@ let make_health_json ?(listener = "http/1.1") request =
     ("sse_clients", `Int (Sse.client_count ()));
     ("startup", Server_startup_state.to_yojson ());
     ("subsystems", Subsystem_health.to_yojson ());
+    (* Server log visibility belongs on the first health probe too.  Keep the
+       payload cheap and redacted: only ring counters, latest metadata, and
+       file-sink state are exposed here; full log rows stay behind the
+       dashboard logs API. *)
+    ("logs", Log.Ring.summary_json ());
     ("feature_flags", let features = Dashboard_feature_health.get_all_features () in
       Dashboard_feature_health.overview_json features);
     (* Keep /health cheap under live keeper load. [Gc.stat] can force a

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -987,6 +987,33 @@ let test_health_json_surfaces_durable_paused_keepers () =
           Alcotest.(check int) "durable read errors" 0
             (paused |> member "read_error_count" |> to_int)))
 
+let test_health_json_surfaces_log_ring_summary () =
+  Log.set_level Log.Info;
+  Log.emit Log.Warn ~module_name:"HealthTest"
+    "health-log-ring-summary-marker";
+  let request = Httpun.Request.create `GET "/health" in
+  let json = Server_routes_http_runtime.make_health_json request in
+  let open Yojson.Safe.Util in
+  let logs = json |> member "logs" in
+  let latest = logs |> member "latest" in
+  Alcotest.(check string) "log ring active" "active"
+    (logs |> member "status" |> to_string);
+  Alcotest.(check bool) "total entries positive" true
+    (logs |> member "total_entries" |> to_int > 0);
+  Alcotest.(check bool) "retained entries positive" true
+    (logs |> member "retained_entries" |> to_int > 0);
+  Alcotest.(check bool) "recent window positive" true
+    (logs |> member "recent_window" |> to_int > 0);
+  Alcotest.(check string) "latest level" "WARN"
+    (latest |> member "level" |> to_string);
+  Alcotest.(check string) "latest module" "HealthTest"
+    (latest |> member "module" |> to_string);
+  Alcotest.(check bool) "latest excludes message text" true
+    (latest |> member "message" = `Null);
+  Alcotest.(check bool) "latest excludes details payload" true
+    (latest |> member "details" = `Null);
+  ignore (logs |> member "file_sink" |> member "enabled" |> to_bool)
+
 let test_migrate_resident_keeper_dirs_promotes_valid_meta () =
   with_temp_dir "startup-legacy-keepers" (fun dir ->
       let state = Mcp_server.create_state ~base_path:dir in
@@ -2523,6 +2550,8 @@ let () =
           Alcotest.test_case
             "health json surfaces durable paused keepers"
             `Quick test_health_json_surfaces_durable_paused_keepers;
+          Alcotest.test_case "health json surfaces log ring summary" `Quick
+            test_health_json_surfaces_log_ring_summary;
           Alcotest.test_case "readiness false before init" `Quick
             test_startup_state_readiness_before_init;
           Alcotest.test_case "readiness true after init" `Quick


### PR DESCRIPTION
## Summary
- add a redacted `logs` summary to `/health`
- expose log-ring status, total/retained counts, recent warn/error counts, latest metadata, and file-sink state
- keep raw log messages and `details` payloads out of `/health`; full rows remain behind the dashboard logs API

## Why
The live server already has structured dashboard logs, but the first `/health` probe did not show whether the server log ring was active or where the file sink was writing. Operators could see transport/startup state but still had to know a separate logs route to answer "are server logs actually flowing?"

This keeps `/health` cheap by reading the in-memory ring and scanning only a capped recent window.

## Validation
- `scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe bin/main_eio.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 32 --show-errors`
- `ocamlformat --check lib/masc_log/log.mli lib/masc_log/log.ml lib/server/server_routes_http_runtime.ml test/test_server_runtime_bootstrap.ml`
- `git diff --check origin/main...HEAD`
