### PR TITLE
feat(ide): focus trace gutter context

### DIFF
--- a/dashboard/src/components/ide/ide-editor-extensions.test.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest'
+import { fireEvent } from '@testing-library/preact'
+import { describe, it, expect, vi } from 'vitest'
 import { EditorState, type Extension } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import {
@@ -207,26 +208,31 @@ describe('keeperTraceLinesForFile + keeper trace gutter', () => {
       },
     ]
 
-    expect(keeperTraceLinesForFile('runtime.ts', events)).toEqual([
-      {
-        line: 2,
-        events: [
-          {
-            source: 'activity-event',
-            keeperName: 'sangsu',
-            count: 1,
-            tsMs: 5000,
-            surface: 'Goal',
-          },
-          {
-            source: 'anchored-thread',
-            keeperName: 'scholar',
-            count: 1,
-            tsMs: 2000,
-          },
-        ],
-      },
-    ])
+    const traceLines = keeperTraceLinesForFile('runtime.ts', events)
+    expect(traceLines).toHaveLength(1)
+    expect(traceLines[0]?.line).toBe(2)
+    expect(traceLines[0]?.events).toHaveLength(2)
+    expect(traceLines[0]?.events[0]).toMatchObject({
+      id: 'activity-1',
+      source: 'activity-event',
+      keeperName: 'sangsu',
+      count: 1,
+      tsMs: 5000,
+      filePath: 'runtime.ts',
+      line: 2,
+      eventId: 'evt-1',
+      surface: 'Goal',
+    })
+    expect(traceLines[0]?.events[1]).toMatchObject({
+      id: 'thread-1',
+      source: 'anchored-thread',
+      keeperName: 'scholar',
+      count: 1,
+      tsMs: 2000,
+      filePath: 'runtime.ts',
+      line: 2,
+      threadId: 'thread-1',
+    })
   })
 
   it('renders file-scoped trace dots in the trace gutter', () => {
@@ -252,8 +258,58 @@ describe('keeperTraceLinesForFile + keeper trace gutter', () => {
     expect(dots?.[0]?.getAttribute('aria-label')).toBe('thread scholar x2')
     expect(dots?.[1]?.getAttribute('data-source')).toBe('activity-event')
     expect(dots?.[1]?.getAttribute('aria-label')).toBe('activity PR sangsu')
-    expect(gutter?.querySelector('.cm-trace-stack[role="list"]')?.getAttribute('aria-label'))
-      .toContain('Line 2 keeper trace')
+    const stack = gutter?.querySelector<HTMLButtonElement>('button.cm-trace-stack')
+    expect(stack?.getAttribute('aria-label')).toContain('Line 2 keeper trace')
+    expect(stack?.dataset.line).toBe('2')
+
+    view.destroy()
+    container.remove()
+  })
+
+  it('selects the top trace event when a trace gutter stack is clicked', () => {
+    const onSelect = vi.fn()
+    const traceLines = [
+      {
+        line: 2,
+        events: [
+          {
+            id: 'activity-1',
+            source: 'activity-event' as const,
+            keeperName: 'sangsu',
+            count: 1,
+            tsMs: 3000,
+            surface: 'PR',
+            eventId: 'evt-1',
+            goalId: 'goal-1',
+          },
+          {
+            id: 'thread-1',
+            source: 'anchored-thread' as const,
+            keeperName: 'scholar',
+            count: 1,
+            tsMs: 2000,
+            threadId: 'thread-1',
+          },
+        ],
+      },
+    ]
+    const exts = [
+      themeExt(),
+      readOnlyExt(),
+      keeperTraceLineGutterExt({
+        getTraceLines: () => traceLines,
+        onTraceLineSelect: onSelect,
+      }),
+    ]
+    const { view, container } = createTestView(exts, 'one\ntwo\nthree\n')
+
+    pushKeeperTraceLines(view, traceLines)
+
+    const stack = container.querySelector<HTMLButtonElement>('button.cm-trace-stack')
+    expect(stack).not.toBeNull()
+    fireEvent.click(stack!)
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect).toHaveBeenCalledWith(traceLines[0]!.events[0], 2)
 
     view.destroy()
     container.remove()

--- a/dashboard/src/components/ide/ide-editor-extensions.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.ts
@@ -119,6 +119,15 @@ export function themeExt(): Extension {
       gap: '2px',
       minWidth: '28px',
       height: '100%',
+      padding: '0',
+      border: '0',
+      background: 'transparent',
+      color: 'inherit',
+      cursor: 'pointer',
+    },
+    '.cm-trace-stack:focus-visible': {
+      outline: '1px solid var(--color-accent-fg)',
+      outlineOffset: '1px',
     },
     '.cm-trace-dot': {
       display: 'inline-block',
@@ -300,16 +309,36 @@ export function pushOwnership(view: EditorView, ownership: ReadonlyMap<number, L
 const TRACE_DOT_CAP = 3
 
 export interface EditorKeeperTraceLineEvent {
+  readonly id?: string
   readonly source: KeeperTraceSource
   readonly keeperName: string
   readonly count: number
   readonly tsMs: number
+  readonly filePath?: string
+  readonly line?: number
+  readonly eventId?: string
+  readonly threadId?: string
   readonly surface?: string
+  readonly goalId?: string
+  readonly taskId?: string
+  readonly boardPostId?: string
+  readonly commentId?: string
+  readonly prId?: string
+  readonly gitRef?: string
+  readonly logId?: string
+  readonly sessionId?: string
+  readonly operationId?: string
+  readonly workerRunId?: string
 }
 
 export interface EditorKeeperTraceLine {
   readonly line: number
   readonly events: ReadonlyArray<EditorKeeperTraceLineEvent>
+}
+
+export interface KeeperTraceLineGutterOptions {
+  readonly getTraceLines?: () => ReadonlyArray<EditorKeeperTraceLine>
+  readonly onTraceLineSelect?: (event: EditorKeeperTraceLineEvent, line: number) => void
 }
 
 const setKeeperTraceLines = StateEffect.define<ReadonlyArray<EditorKeeperTraceLine>>()
@@ -323,13 +352,16 @@ class TraceLineMarker extends GutterMarker {
   }
 
   toDOM(): HTMLElement {
-    const el = document.createElement('span')
-    el.className = 'cm-trace-stack'
     if (this.events.length === 0) {
+      const el = document.createElement('span')
+      el.className = 'cm-trace-stack'
       el.setAttribute('aria-hidden', 'true')
       return el
     }
-    el.setAttribute('role', 'list')
+    const el = document.createElement('button')
+    el.type = 'button'
+    el.className = 'cm-trace-stack'
+    el.dataset.line = String(this.line)
     el.setAttribute('aria-label', traceLineAriaLabel(this.line, this.events))
     el.title = traceLineTitle(this.line, this.events)
     const visible = this.events.slice(0, TRACE_DOT_CAP)
@@ -378,7 +410,8 @@ const keeperTraceLineField = StateField.define<ReadonlyMap<number, TraceLineMark
   },
 })
 
-export function keeperTraceLineGutterExt(): Extension {
+export function keeperTraceLineGutterExt(options: KeeperTraceLineGutterOptions = {}): Extension {
+  const canSelect = options.getTraceLines && options.onTraceLineSelect
   return [
     keeperTraceLineField,
     gutter({
@@ -391,9 +424,44 @@ export function keeperTraceLineGutterExt(): Extension {
         const field = view.state.field(keeperTraceLineField, false)
         return field?.get(line.number) ?? null
       },
+      ...(canSelect
+        ? {
+            domEventHandlers: {
+              click: (view, block, event) => selectTraceLineFromGutterClick(
+                view.state.doc.lineAt(block.from).number,
+                event,
+                options.getTraceLines!,
+                options.onTraceLineSelect!,
+              ),
+            },
+          }
+        : {}),
       initialSpacer: () => TRACE_SPACER,
     }),
   ]
+}
+
+function selectTraceLineFromGutterClick(
+  blockLine: number,
+  event: Event,
+  getTraceLines: () => ReadonlyArray<EditorKeeperTraceLine>,
+  onTraceLineSelect: (event: EditorKeeperTraceLineEvent, line: number) => void,
+): boolean {
+  if (!(event instanceof MouseEvent) || event.button !== 0) return false
+  const target = event.target
+  if (!(target instanceof Element)) return false
+  const stack = target.closest('.cm-trace-stack')
+  if (!(stack instanceof HTMLElement) || stack.getAttribute('aria-hidden') === 'true') return false
+  const lineFromMarker = Number(stack.dataset.line)
+  const line = Number.isSafeInteger(lineFromMarker) && lineFromMarker >= 1
+    ? lineFromMarker
+    : blockLine
+  const traceLine = getTraceLines().find(candidate => candidate.line === line)
+  const topEvent = traceLine?.events[0]
+  if (!topEvent) return false
+  event.stopPropagation()
+  onTraceLineSelect(topEvent, line)
+  return true
 }
 
 export function pushKeeperTraceLines(
@@ -418,11 +486,26 @@ export function keeperTraceLinesForFile(
     if (line === null) continue
     const existing = byLine.get(line) ?? []
     existing.push({
+      id: event.id,
       source: event.source,
       keeperName: event.keeperName,
       count: event.count,
       tsMs: event.tsMs,
+      filePath,
+      line,
+      eventId: event.source === 'activity-event' ? event.eventId : undefined,
+      threadId: event.source === 'anchored-thread' ? event.threadId : undefined,
       surface: traceEventSurface(event),
+      goalId: event.source === 'activity-event' ? event.goalId : undefined,
+      taskId: event.source === 'activity-event' ? event.taskId : undefined,
+      boardPostId: event.source === 'activity-event' ? event.boardPostId : undefined,
+      commentId: event.source === 'activity-event' ? event.commentId : undefined,
+      prId: event.source === 'activity-event' ? event.prId : undefined,
+      gitRef: event.source === 'activity-event' ? event.gitRef : undefined,
+      logId: event.source === 'activity-event' ? event.logId : undefined,
+      sessionId: event.source === 'activity-event' ? event.sessionId : undefined,
+      operationId: event.source === 'activity-event' ? event.operationId : undefined,
+      workerRunId: event.source === 'activity-event' ? event.workerRunId : undefined,
     })
     byLine.set(line, existing)
   }
@@ -509,7 +592,20 @@ function traceLineTitle(line: number, events: ReadonlyArray<EditorKeeperTraceLin
 }
 
 function traceLineKey(events: ReadonlyArray<EditorKeeperTraceLineEvent>): string {
-  return events.map(event => `${event.source}:${event.surface ?? ''}:${event.keeperName}:${event.count}:${event.tsMs}`).join('|')
+  return events
+    .map(event => [
+      event.id ?? '',
+      event.source,
+      event.surface ?? '',
+      event.keeperName,
+      event.count,
+      event.tsMs,
+      event.goalId ?? '',
+      event.taskId ?? '',
+      event.prId ?? '',
+      event.logId ?? '',
+    ].join(':'))
+    .join('|')
 }
 
 export function keeperLineSelectExt(

--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -489,6 +489,86 @@ describe('IdeEditor', () => {
     })
   })
 
+  it('focuses operational route context when a keeper trace gutter stack is clicked', async () => {
+    const documentStore = createCodeDocumentStore({
+      file_path: 'runtime.ts',
+      language: 'typescript',
+      content: 'const runtime = 1\nconst task = runtime + 1\n',
+    })
+    const ownershipStore = createKeeperLineOwnershipStore('runtime.ts')
+
+    pushTrace({
+      id: 'activity-runtime',
+      tsMs: 3000,
+      keeperName: 'sangsu',
+      source: 'activity-event',
+      eventId: 'evt-1',
+      filePath: 'runtime.ts',
+      line: 2,
+      surface: 'PR',
+      goalId: 'goal-runtime',
+      taskId: 'task-runtime',
+      boardPostId: 'post-runtime',
+      commentId: 'comment-runtime',
+      prId: '15035',
+      gitRef: 'refs/heads/review-response',
+      logId: 'turn-2',
+      sessionId: 'sess-runtime',
+      operationId: 'op-runtime',
+      workerRunId: 'worker-runtime',
+    })
+
+    render(
+      h(IdeEditor, {
+        documentStore,
+        ownershipStore,
+        diffRows: () => [],
+        activeLayers: new Set(['keeper-trace']),
+      }),
+      container,
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('button.cm-trace-stack')).not.toBeNull()
+    })
+    fireEvent.click(container.querySelector<HTMLButtonElement>('button.cm-trace-stack')!)
+
+    expect(ideContextFocus.value).toMatchObject({
+      file_path: 'runtime.ts',
+      line: 2,
+      surface: 'PR',
+      label: 'PR activity evt-1',
+      source_id: 'trace:activity-runtime',
+      keeper_id: 'sangsu',
+    })
+    expect(ideContextFocus.value?.route_links?.map(link => link.label)).toEqual([
+      'Code',
+      'Goal',
+      'Task',
+      'Board',
+      'Comment',
+      'PR',
+      'Git',
+      'Log',
+      'Telemetry',
+      'Keeper',
+    ])
+    expect(ideContextFocus.value?.route_links?.find(link => link.label === 'Telemetry')?.params)
+      .toMatchObject({
+        section: 'fleet-health',
+        view: 'event-log',
+        session_id: 'sess-runtime',
+        operation_id: 'op-runtime',
+        worker_run_id: 'worker-runtime',
+        q: 'turn-2',
+      })
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="ide-context-focus-status"]')?.textContent)
+        .toContain('Focused L2')
+      expect(container.querySelectorAll('.ide-editor-context-route-link')).toHaveLength(10)
+    })
+  })
+
   it('shows and highlights the focused context line from the shared IDE signal', async () => {
     const documentStore = createCodeDocumentStore({
       file_path: 'runtime.ts',

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -29,6 +29,8 @@ import {
   pushAnnotationLines,
   internalDocumentSync,
   syntaxHighlightExt,
+  type EditorKeeperTraceLine,
+  type EditorKeeperTraceLineEvent,
 } from './ide-editor-extensions'
 import {
   lspDiagnosticSnapshot,
@@ -48,7 +50,12 @@ import {
   type KeeperPresenceStatus,
 } from './keeper-presence-store'
 import { openIdeContextRouteLink, routeLinksForContext, type IdeContextRouteLink } from './ide-context-lens'
-import { ideContextFocus, normalizeIdeContextFilePath, type IdeContextFocus } from './ide-state'
+import {
+  focusIdeContextAnchor,
+  ideContextFocus,
+  normalizeIdeContextFilePath,
+  type IdeContextFocus,
+} from './ide-state'
 import { ideConversationThreadSnapshot } from './ide-context-bridge'
 
 // ── Types ─────────────────────────────────────────────────────────
@@ -379,6 +386,63 @@ function traceEventFilePath(event: KeeperTraceEvent): string | null {
   if (event.source === 'anchored-thread') return event.filePath ?? null
   if (event.source === 'activity-event') return event.filePath
   return null
+}
+
+function focusTraceLineContext(
+  filePath: string,
+  event: EditorKeeperTraceLineEvent,
+  line: number,
+): void {
+  const surface = traceLineFocusSurface(event)
+  const label = traceLineFocusLabel(event)
+  const sourceId = event.id ? `trace:${event.id}` : `trace:${event.source}:${line}:${event.tsMs}`
+  focusIdeContextAnchor({
+    file_path: filePath,
+    line,
+    surface,
+    label,
+    source_id: sourceId,
+    keeper_id: event.keeperName,
+    route_links: routeLinksForContext({
+      filePath,
+      line,
+      surface,
+      label,
+      sourceId,
+      goalId: event.goalId,
+      taskId: event.taskId,
+      boardPostId: event.boardPostId ?? event.threadId,
+      commentId: event.commentId,
+      prId: event.prId,
+      gitRef: event.gitRef,
+      logId: event.logId,
+      sessionId: event.sessionId,
+      operationId: event.operationId,
+      workerRunId: event.workerRunId,
+      telemetryQuery: event.logId ?? event.eventId,
+      keeperId: event.keeperName,
+      telemetry: Boolean(event.logId || event.sessionId || event.operationId || event.workerRunId),
+    }),
+  })
+}
+
+function traceLineFocusSurface(event: EditorKeeperTraceLineEvent): string {
+  if (event.source === 'activity-event') return event.surface?.trim() || 'Activity'
+  if (event.source === 'anchored-thread') return 'Thread'
+  if (event.source === 'cascade-hop') return 'Cascade'
+  if (event.source === 'bdi-snapshot') return 'BDI'
+  return 'Decision'
+}
+
+function traceLineFocusLabel(event: EditorKeeperTraceLineEvent): string {
+  if (event.source === 'activity-event') {
+    const surface = traceLineFocusSurface(event)
+    return event.eventId ? `${surface} activity ${event.eventId}` : surface
+  }
+  if (event.source === 'anchored-thread') {
+    return event.threadId ? `thread ${event.threadId}` : 'thread'
+  }
+  return traceLineFocusSurface(event)
 }
 
 function EditorCurrentFileSignals({
@@ -739,6 +803,11 @@ function CodeMirrorEditor({
     () => traceActive ? keeperTraceLinesForFile(document.file_path, traceEvents) : [],
     [document.file_path, traceActive, traceEvents],
   )
+  const traceLinesRef = useRef<ReadonlyArray<EditorKeeperTraceLine>>(traceLines)
+
+  useEffect(() => {
+    traceLinesRef.current = traceLines
+  }, [traceLines])
 
   // Mount CM6 instance
   useEffect(() => {
@@ -776,7 +845,16 @@ function CodeMirrorEditor({
             ? [keeperLineSelectExt(() => ownershipStore.ownership(), onKeeperLineSelect)]
             : []),
           ...(traceActive
-            ? [keeperTraceLineGutterExt()]
+            ? [
+                keeperTraceLineGutterExt({
+                  getTraceLines: () => traceLinesRef.current,
+                  onTraceLineSelect: (event, line) => focusTraceLineContext(
+                    documentStore.document().file_path,
+                    event,
+                    line,
+                  ),
+                }),
+              ]
             : []),
           ...blameExts,
         ],


### PR DESCRIPTION
## Summary
- make keeper trace gutter stacks clickable buttons with gutter-level CodeMirror event handling
- preserve trace event refs on line events and focus the shared IDE context with Code/Goal/Task/Board/Comment/PR/Git/Log/Telemetry/Keeper links
- add focused extension/editor tests for trace selection and route-link projection

## Validation
- pnpm exec eslint src/components/ide/ide-editor.ts src/components/ide/ide-editor.test.ts src/components/ide/ide-editor-extensions.ts src/components/ide/ide-editor-extensions.test.ts
- pnpm exec vitest run src/components/ide/ide-editor.test.ts src/components/ide/ide-editor-extensions.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD~1..HEAD