### PR TITLE
fix(dashboard): verify workspace read models

### DIFF
--- a/docs/DASHBOARD-INTEGRATION.md
+++ b/docs/DASHBOARD-INTEGRATION.md
@@ -142,6 +142,8 @@ code_refs:
   - connectors descriptor + live state
 - `GET /api/v1/dashboard/board`
   - workspace board
+- `GET /api/v1/board/hearths`, `GET /api/v1/board/curation`, `GET /api/v1/board/karma/ledger`
+  - workspace board filters, curation, and karma ledger
 - `GET /api/v1/board/sub-boards`
   - workspace named board spaces
 - `GET /api/v1/dashboard/planning`

--- a/docs/DASHBOARD-INTEGRATION.md
+++ b/docs/DASHBOARD-INTEGRATION.md
@@ -150,8 +150,10 @@ code_refs:
   - planning + goal tree
 - `GET /api/v1/git/graph`
   - workspace repository graph view
-- `GET /api/v1/verification/requests`
-  - workspace verification table
+- `GET /api/v1/verification/requests`, `GET /api/v1/verification/summary`
+  - workspace verification table and status rollup
+- `GET /api/v1/verification/specs`, `GET /api/v1/verification/tlc-results`
+  - TLA+ spec index and TLC result panels
 - `GET /api/v1/dashboard/tools`
   - lab tools inventory
 - `GET /api/v1/autoresearch/loops`

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -291,6 +291,17 @@ let add_routes ~sw ~clock router =
          Http.Response.json (Yojson.Safe.to_string json) reqd
        ) request reqd)
 
+  |> Http.Router.get "/api/v1/board/curation" (fun request reqd ->
+       with_public_read (fun _state _req reqd ->
+         let json =
+           match Board_dispatch.latest_curation_snapshot () with
+           | None -> `Assoc [ ("snapshot", `Null) ]
+           | Some snap ->
+             `Assoc [ ("snapshot", Board_curation.snapshot_to_yojson snap) ]
+         in
+         Http.Response.json (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+
   |> Http.Router.get "/api/v1/board/flairs" (fun _request reqd ->
        let flairs = List.map Board.flair_to_yojson Board.available_flairs in
        let json = `Assoc [("flairs", `List flairs)] in

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -197,6 +197,10 @@ check_http "verification requests 200" "$BASE/api/v1/verification/requests" "200
 check_json "verification requests exposes list" "$BASE/api/v1/verification/requests" "'requests' in d" '^True$'
 check_http "verification summary 200" "$BASE/api/v1/verification/summary" "200"
 check_json "verification summary exposes status buckets" "$BASE/api/v1/verification/summary" "'by_status' in d" '^True$'
+check_http "verification specs 200" "$BASE/api/v1/verification/specs" "200"
+check_json "verification specs exposes index" "$BASE/api/v1/verification/specs" "'entries' in d and 'count' in d" '^True$'
+check_http "verification tlc results 200" "$BASE/api/v1/verification/tlc-results" "200"
+check_json "verification tlc results exposes entries" "$BASE/api/v1/verification/tlc-results" "'entries' in d and 'count' in d" '^True$'
 
 echo "[5/7] Connectors + Lab"
 check_http "gate connectors 200" "$BASE/api/v1/gate/connectors" "200"

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -181,6 +181,12 @@ check_http "operator digest 200" "$BASE/api/v1/operator/digest" "200"
 check_json "operator digest has health block" "$BASE/api/v1/operator/digest" "'health' in d" '^True$'
 check_http "board 200" "$BASE/api/v1/dashboard/board" "200"
 check_json "board exposes posts" "$BASE/api/v1/dashboard/board" "'posts' in d" '^True$'
+check_http "board hearths 200" "$BASE/api/v1/board/hearths" "200"
+check_json "board hearths exposes list" "$BASE/api/v1/board/hearths" "'hearths' in d" '^True$'
+check_http "board curation 200" "$BASE/api/v1/board/curation" "200"
+check_json "board curation exposes snapshot slot" "$BASE/api/v1/board/curation" "'snapshot' in d" '^True$'
+check_http "board karma ledger 200" "$BASE/api/v1/board/karma/ledger?limit=1" "200"
+check_json "board karma ledger exposes events and totals" "$BASE/api/v1/board/karma/ledger?limit=1" "'events' in d and 'totals' in d" '^True$'
 check_http "sub-boards 200" "$BASE/api/v1/board/sub-boards" "200"
 check_json "sub-boards exposes list" "$BASE/api/v1/board/sub-boards" "'sub_boards' in d" '^True$'
 check_http "planning 200" "$BASE/api/v1/dashboard/planning" "200"


### PR DESCRIPTION
Summary:
- Add the missing HTTP route for `/api/v1/board/curation` to match the existing H2 gateway and Board curation UI fetcher.
- Add live verifier coverage for board hearths, curation, and karma ledger read models.
- Add live verifier coverage for verification specs and TLC result read models.
- Document the board and verification auxiliary read models in the dashboard integration spec.

Validation:
- `ocamlformat --check lib/server/server_routes_http_routes_activity.ml`
- `bash -n scripts/verify-dashboard.sh`
- `git diff --check`
- `bash scripts/check-dashboard-surface-parity.sh --check`
- `bash scripts/check-dashboard-nav-event-parity.sh --check`
- `scripts/dune-local.sh build test/test_ci_hardening_source.exe`

Note:
- Full `./_build/default/test/test_ci_hardening_source.exe` currently fails on existing unrelated source-guard drift; the added route compiled and I did not keep a new assertion in that failing test case.
