### PR TITLE
feat(ide): balance context lens anchors

### DIFF
--- a/dashboard/src/components/ide/ide-context-lens.test.ts
+++ b/dashboard/src/components/ide/ide-context-lens.test.ts
@@ -215,6 +215,88 @@ describe('IdeContextLens', () => {
     expect(container.textContent).toContain('6/10 anchors')
   })
 
+  it('keeps operational PR, Git, and planning anchors visible when the current file is busy', () => {
+    const extraAnnotations = [
+      annotation,
+      { ...annotation, id: 'ann-2', line_start: 15, content: 'Second task note' },
+      { ...annotation, id: 'ann-3', line_start: 16, content: 'Third task note' },
+    ]
+    const busyOverlay: KeeperCursorOverlay = {
+      ...overlay,
+      cursors: new Map([
+        ...overlay.cursors,
+        ['analyst', {
+          keeper_id: 'analyst',
+          file_path: 'lib/keeper/keeper_exec_ide.ml',
+          line: 17,
+          column: 2,
+          focus_mode: 'reviewing',
+          last_update: 101,
+          tool_name: 'review',
+          turn: 8,
+        }],
+      ]),
+    }
+
+    const model = deriveIdeContextLens({
+      filePath: 'lib/keeper/keeper_exec_ide.ml',
+      annotations: extraAnnotations,
+      diagnostics: [
+        {
+          file_path: 'lib/keeper/keeper_exec_ide.ml',
+          line: 21,
+          severity: 1,
+          source: 'ocamllsp',
+          code: 'type',
+          message: 'First diagnostic',
+        },
+        {
+          file_path: 'lib/keeper/keeper_exec_ide.ml',
+          line: 22,
+          severity: 2,
+          source: 'ocamllsp',
+          message: 'Second diagnostic',
+        },
+      ],
+      diffRows,
+      events: [{
+        id: 'evt-rich',
+        run_id: 'run-default',
+        keeper_id: 'sangsu',
+        verb: 'noted',
+        target: 'PR #15000',
+        timestamp_ms: 400,
+        context: {
+          file_path: 'lib/keeper/keeper_exec_ide.ml',
+          line: 27,
+          goal_id: 'goal-ide',
+          task_id: 'task-42',
+          pr_id: '15000',
+          board_post_id: 'post-1',
+          comment_id: 'comment-1',
+          git_ref: 'abc123',
+          log_id: 'turn-9',
+        },
+      }],
+      threads: [thread],
+      overlay: busyOverlay,
+    })
+
+    expect(model.anchorTotalCount).toBeGreaterThan(6)
+    expect(model.anchors).toHaveLength(6)
+    expect(model.anchors.map(anchor => anchor.id)).toEqual([
+      'diagnostic-21-ocamllsp-type-0',
+      'event-evt-rich',
+      'git-diff-summary',
+      'annotation-ann-1',
+      'thread-thread-1',
+      'annotation-ann-2',
+    ])
+    expect(model.anchors[1]?.route_links?.map(link => link.label)).toContain('PR')
+    expect(model.anchors[2]?.surface).toBe('Git')
+    expect(model.anchors[3]?.route_links?.map(link => link.label)).toEqual(['Code', 'Goal', 'Task', 'Keeper'])
+  })
+
   it('publishes focused file and line when an anchor is clicked', () => {
     const container = document.createElement('div')
     ideContextFocus.value = null

--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -137,6 +137,21 @@ const SURFACE_ORDER: ReadonlyArray<IdeContextSurfaceId> = [
 ]
 const MAX_CONTEXT_ANCHORS = 6
 const MAX_CONTEXT_ROUTE_LINKS = 10
+const CONTEXT_ANCHOR_BUCKET_ORDER = [
+  'lsp',
+  'pr',
+  'git',
+  'task',
+  'board',
+  'log',
+  'goal',
+  'comment',
+  'telemetry',
+  'line',
+  'keeper',
+  'other',
+] as const
+type ContextAnchorBucket = (typeof CONTEXT_ANCHOR_BUCKET_ORDER)[number]
 
 export function deriveIdeContextLens(input: IdeContextLensInput): IdeContextLensModel {
   const filePath = normalizeIdeContextFilePath(input.filePath)
@@ -223,11 +238,72 @@ export function deriveIdeContextLens(input: IdeContextLensInput): IdeContextLens
   return {
     linkedCount: surfaces.filter(surface => surface.status === 'linked').length,
     surfaces,
-    anchors: anchors.slice(0, MAX_CONTEXT_ANCHORS),
+    anchors: selectVisibleContextAnchors(anchors, MAX_CONTEXT_ANCHORS),
     anchorTotalCount: anchors.length,
     changedLineCount,
     activeLineCount: activeLines.size,
   }
+}
+
+function selectVisibleContextAnchors(
+  anchors: ReadonlyArray<IdeContextAnchor>,
+  limit: number,
+): ReadonlyArray<IdeContextAnchor> {
+  if (anchors.length <= limit) return anchors
+  const selected: IdeContextAnchor[] = []
+  const selectedIds = new Set<string>()
+  const add = (anchor: IdeContextAnchor): boolean => {
+    if (selectedIds.has(anchor.id)) return false
+    selected.push(anchor)
+    selectedIds.add(anchor.id)
+    return selected.length >= limit
+  }
+
+  for (const bucket of CONTEXT_ANCHOR_BUCKET_ORDER) {
+    const anchor = anchors.find(candidate =>
+      !selectedIds.has(candidate.id)
+      && contextAnchorBuckets(candidate).has(bucket),
+    )
+    if (anchor && add(anchor)) return selected
+  }
+  for (const anchor of anchors) {
+    if (add(anchor)) return selected
+  }
+  return selected
+}
+
+function contextAnchorBuckets(anchor: IdeContextAnchor): ReadonlySet<ContextAnchorBucket> {
+  const buckets = new Set<ContextAnchorBucket>()
+  for (const link of anchor.route_links ?? []) {
+    const label = link.label.trim().toLowerCase()
+    if (label === 'goal') buckets.add('goal')
+    else if (label === 'task') buckets.add('task')
+    else if (label === 'board') buckets.add('board')
+    else if (label === 'comment') buckets.add('comment')
+    else if (label === 'pr') buckets.add('pr')
+    else if (label === 'git') buckets.add('git')
+    else if (label === 'log') buckets.add('log')
+    else if (label === 'telemetry') buckets.add('telemetry')
+    else if (label === 'keeper') buckets.add('keeper')
+  }
+
+  const surface = anchor.surface.trim().toLowerCase()
+  if (surface === 'lsp') buckets.add('lsp')
+  else if (surface === 'line') buckets.add('line')
+  else if (surface === 'goal') buckets.add('goal')
+  else if (surface === 'task') buckets.add('task')
+  else if (surface === 'board') buckets.add('board')
+  else if (surface === 'git') buckets.add('git')
+  else if (surface === 'pr') buckets.add('pr')
+  else if (surface === 'log') buckets.add('log')
+  else if (surface === 'telemetry') buckets.add('telemetry')
+  else if (surface === 'comment' || surface === 'question' || surface === 'note' || surface === 'suggest') {
+    buckets.add('comment')
+  }
+
+  if (anchor.keeper_id) buckets.add('keeper')
+  if (buckets.size === 0) buckets.add('other')
+  return buckets
 }
 
 export function IdeContextLens({


### PR DESCRIPTION
## Summary
- select compact context-lens anchors by operational surface bucket instead of taking the first six blindly
- keep LSP, PR/activity, Git/diff, planning, board/comment, and runtime evidence visible in busy files
- add regression coverage for a crowded current-file lens where PR/Git anchors previously would be hidden by diagnostics/notes/cursors

## Validation
- pnpm exec eslint src/components/ide/ide-context-lens.ts src/components/ide/ide-context-lens.test.ts
- pnpm exec vitest run src/components/ide/ide-context-lens.test.ts src/components/ide/ide-activity-panel.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD~1..HEAD
- rg -n "#[0-9a-fA-F]{3,8}\b" dashboard/src/components/ide/ide-context-lens.ts