### PR TITLE
feat(ide): route keeper presence context

### DIFF
--- a/dashboard/src/components/ide/ide-presence-strip.test.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   parseWorktreeSSE,
+  presenceContextAnchor,
   prLabel,
   workspaceLabelForAgent,
   type WorktreeEntry,
@@ -113,5 +114,70 @@ describe('prLabel', () => {
 
   it('falls back to plain "#N" when state is null', () => {
     expect(prLabel(7, null)).toBe('#7')
+  })
+})
+
+describe('presenceContextAnchor', () => {
+  const entry = {
+    keeper_id: 'nick0cave',
+    workspace_label: 'wt-run-47',
+    branch: 'main',
+    role: 'agent',
+    status: 'active',
+    last_seen_ms: 123,
+  } as const
+
+  it('builds code, PR, Git, telemetry, and keeper route links from a focused keeper chip', () => {
+    const anchor = presenceContextAnchor({
+      entry,
+      worktree: sampleWorktrees[0]!,
+      cursor: {
+        keeper_id: 'nick0cave',
+        file_path: 'lib/runtime.ml',
+        line: 42,
+        column: 7,
+        focus_mode: 'editing',
+        last_update: 123,
+        tool_name: 'ocamllsp',
+      },
+    })
+
+    expect(anchor).toMatchObject({
+      file_path: 'lib/runtime.ml',
+      line: 42,
+      surface: 'Keeper',
+      label: 'nick0cave@wt-run-47',
+      source_id: 'presence:nick0cave',
+      keeper_id: 'nick0cave',
+    })
+    expect(anchor?.route_links?.map(link => link.label)).toEqual([
+      'Code',
+      'PR',
+      'Git',
+      'Telemetry',
+      'Keeper',
+    ])
+    expect(anchor?.route_links?.find(link => link.label === 'PR')?.params).toMatchObject({
+      section: 'repositories',
+      view: 'graph',
+      pr: '88',
+    })
+    expect(anchor?.route_links?.find(link => link.label === 'Git')?.params).toMatchObject({
+      section: 'repositories',
+      ref: 'nick0cave/wt-run-47',
+    })
+    expect(anchor?.route_links?.find(link => link.label === 'Telemetry')?.params).toMatchObject({
+      section: 'fleet-health',
+      view: 'event-log',
+      q: 'nick0cave',
+    })
+  })
+
+  it('does not create a focus anchor for keepers without cursor file context', () => {
+    expect(presenceContextAnchor({
+      entry,
+      worktree: sampleWorktrees[0]!,
+      cursor: undefined,
+    })).toBeNull()
   })
 })

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -7,8 +7,9 @@ import {
   type KeeperPresenceEntry,
   type KeeperPresenceSnapshot,
 } from './keeper-presence-store'
-import { cursorOverlaySignal } from './keeper-cursor-overlay'
-import { activeIdeFile } from './ide-state'
+import { cursorOverlaySignal, type KeeperCursor } from './keeper-cursor-overlay'
+import { focusIdeContextAnchor, type IdeContextFocus } from './ide-state'
+import { routeLinksForContext } from './ide-context-lens'
 
 const FALLBACK_PRESENCE: KeeperPresenceSnapshot = {
   runtime_id: 'local',
@@ -245,10 +246,48 @@ interface PresenceChipProps {
   readonly worktrees: ReadonlyArray<WorktreeEntry>
 }
 
+interface PresenceContextAnchorInput {
+  readonly entry: KeeperPresenceEntry
+  readonly worktree: WorktreeEntry | null
+  readonly cursor: KeeperCursor | undefined
+}
+
+export function presenceContextAnchor({
+  entry,
+  worktree,
+  cursor,
+}: PresenceContextAnchorInput): Omit<IdeContextFocus, 'activated_at_ms'> | null {
+  if (!cursor?.file_path) return null
+  const prId = worktree?.pr_number != null ? String(worktree.pr_number) : undefined
+  const label = `${entry.keeper_id}@${entry.workspace_label}`
+  const sourceId = `presence:${entry.keeper_id}`
+  return {
+    file_path: cursor.file_path,
+    line: cursor.line,
+    surface: 'Keeper',
+    label,
+    source_id: sourceId,
+    keeper_id: entry.keeper_id,
+    route_links: routeLinksForContext({
+      filePath: cursor.file_path,
+      line: cursor.line,
+      surface: 'Keeper',
+      label,
+      sourceId,
+      prId,
+      gitRef: worktree?.branch,
+      telemetry: true,
+      telemetryQuery: entry.keeper_id,
+      keeperId: entry.keeper_id,
+    }),
+  }
+}
+
 function PresenceChip({ entry, worktrees }: PresenceChipProps) {
   const isActive = entry.status === 'active'
   const cursor = cursorOverlaySignal.value.cursors.get(entry.keeper_id)
   const wt = worktrees.find(w => w.branch.startsWith(entry.keeper_id + '/'))
+  const contextAnchor = presenceContextAnchor({ entry, worktree: wt ?? null, cursor })
 
   const focusLabel = cursor?.file_path
     ? `${cursor.file_path.split('/').pop()}:${cursor.line}`
@@ -258,9 +297,9 @@ function PresenceChip({ entry, worktrees }: PresenceChipProps) {
     ? prLabel(wt.pr_number, wt.pr_state)
     : null
 
-  const canNavigate = cursor?.file_path != null
+  const canNavigate = contextAnchor !== null
   const navigate = (): void => {
-    if (cursor?.file_path) activeIdeFile.value = cursor.file_path
+    if (contextAnchor) focusIdeContextAnchor(contextAnchor)
   }
   const onKeyDown = canNavigate
     ? (e: KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigate() } }
@@ -307,7 +346,7 @@ function PresenceChip({ entry, worktrees }: PresenceChipProps) {
           padding: '0 3px',
           borderRadius: 'var(--r-0)',
           background: wt?.pr_state === 'open' ? 'var(--color-status-ok)' : 'var(--color-bg-muted)',
-          color: wt?.pr_state === 'open' ? '#fff' : 'var(--color-fg-muted)',
+          color: wt?.pr_state === 'open' ? 'var(--color-bg-page)' : 'var(--color-fg-muted)',
         }}>${prBadge}</span>
       ` : null}
       <span


### PR DESCRIPTION
## Summary
- route keeper presence chip clicks through the shared IDE context focus path instead of only switching activeIdeFile
- derive Code/PR/Git/Telemetry/Keeper links from the focused keeper cursor and matching worktree/PR metadata
- remove the touched presence PR badge raw foreground color in favor of a semantic token

## Validation
- pnpm exec eslint src/components/ide/ide-presence-strip.ts src/components/ide/ide-presence-strip.test.ts
- pnpm exec vitest run src/components/ide/ide-presence-strip.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD
- rg -n "#[0-9a-fA-F]{3,8}\b" dashboard/src/components/ide/ide-presence-strip.ts