### PR TITLE
feat(ide): route explorer context links

### DIFF
--- a/dashboard/src/components/ide/ide-explorer.test.ts
+++ b/dashboard/src/components/ide/ide-explorer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { h, render } from 'preact'
+import { fireEvent } from '@testing-library/preact'
 import { explorerScopeLabel, IdeExplorer } from './ide-explorer'
 import { createFileTreeStore, type FileTreeNode } from './file-tree-store'
 import type { Repository } from '../../api/repositories'
@@ -58,6 +59,7 @@ describe('IdeExplorer tree row keyboard accessibility', () => {
 
   afterEach(() => {
     render(null, container)
+    window.location.hash = ''
     activeIdeFile.value = 'package.json'
     ideContextFocus.value = null
   })
@@ -124,7 +126,7 @@ describe('IdeExplorer tree row keyboard accessibility', () => {
     expect(scroller?.contains(container.querySelector('input[type="search"]'))).toBe(false)
   })
 
-  it('marks the file row carrying the current IDE context focus', () => {
+  it('marks the file row carrying the current IDE context focus with route buttons', () => {
     const store = createFileTreeStore()
     store.seed(SAMPLE)
     ideContextFocus.value = {
@@ -161,8 +163,17 @@ describe('IdeExplorer tree row keyboard accessibility', () => {
 
     expect(chip?.textContent).toContain('Task')
     expect(chip?.textContent).toContain('L42')
-    expect(chip?.textContent).toContain('2 links')
+    const routeButtons = [...focusedRow!.querySelectorAll<HTMLButtonElement>('.ide-explorer-context-chip button')]
+    expect(routeButtons.map(button => button.textContent)).toEqual(['Task', 'Telemetry'])
+    expect(routeButtons.map(button => button.getAttribute('aria-label'))).toEqual([
+      'Open Task task-runtime',
+      'Open Fleet telemetry event log · query turn-9',
+    ])
     expect(chip?.getAttribute('aria-label'))
       .toBe('Focused Task line 42: task task-runtime, 2 route links')
+
+    fireEvent.click(routeButtons[1]!)
+    expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&q=turn-9')
+    expect(activeIdeFile.value).toBe('package.json')
   })
 })

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -9,6 +9,7 @@ import type { Repository } from '../../api/repositories'
 import { showToast } from '../common/toast'
 import { KeeperBadge } from '../keeper-badge'
 import { cursorOverlaySignal, getKeeperColor } from './keeper-cursor-overlay'
+import { openIdeContextRouteLink } from './ide-context-lens'
 
 interface IdeExplorerProps {
   readonly fileTreeStore: FileTreeStore
@@ -33,6 +34,8 @@ interface ExplorerScopeLabel {
   readonly label: string
   readonly tone: ExplorerScopeTone
 }
+
+const EXPLORER_CONTEXT_LINK_LIMIT = 3
 
 function repositoryLabel(
   repositories: ReadonlyArray<Repository>,
@@ -418,7 +421,15 @@ function TreeRow(
 
 function ExplorerContextChip(focus: IdeContextFocus) {
   const line = focus.line !== undefined ? `L${focus.line}` : null
-  const linkCount = focus.route_links?.length ?? 0
+  const routeLinks = focus.route_links ?? []
+  const visibleLinks = routeLinks.slice(0, EXPLORER_CONTEXT_LINK_LIMIT)
+  const overflowCount = Math.max(0, routeLinks.length - visibleLinks.length)
+  const stopRouteClick = (event: MouseEvent): void => {
+    event.stopPropagation()
+  }
+  const stopRouteKeyDown = (event: KeyboardEvent): void => {
+    event.stopPropagation()
+  }
   return html`
     <span
       class="ide-explorer-context-chip"
@@ -427,7 +438,20 @@ function ExplorerContextChip(focus: IdeContextFocus) {
     >
       <span>${focus.surface}</span>
       ${line ? html`<span>${line}</span>` : null}
-      ${linkCount > 0 ? html`<span>${linkCount} links</span>` : null}
+      ${visibleLinks.map(link => html`
+        <button
+          key=${link.id}
+          type="button"
+          title=${link.evidence}
+          aria-label=${`Open ${link.evidence}`}
+          onClick=${(event: MouseEvent) => {
+            stopRouteClick(event)
+            openIdeContextRouteLink(link)
+          }}
+          onKeyDown=${stopRouteKeyDown}
+        >${link.label}</button>
+      `)}
+      ${overflowCount > 0 ? html`<span aria-label=${`${overflowCount} more context links`}>+${overflowCount}</span>` : null}
     </span>
   `
 }

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -652,7 +652,7 @@
   align-items: center;
   gap: 3px;
   min-width: 0;
-  max-width: 116px;
+  max-width: 13rem;
   margin-left: auto;
   padding: 1px 5px;
   border: 1px solid var(--color-border-default);
@@ -661,6 +661,25 @@
   color: var(--color-fg-muted);
   font-family: var(--font-mono);
   font-size: var(--fs-9);
+}
+
+.ide-explorer-context-chip button {
+  min-width: 0;
+  max-width: 4rem;
+  padding: 0 3px;
+  overflow: hidden;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-0);
+  background: var(--color-bg-elevated);
+  color: var(--color-accent-fg);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-explorer-context-chip button:hover,
+.ide-explorer-context-chip button:focus-visible {
+  border-color: var(--color-accent-fg);
+  color: var(--color-fg-primary);
 }
 
 .ide-explorer-context-chip > span {


### PR DESCRIPTION
## Summary
- turn the Explorer current-context chip into compact route buttons for the focused operational links
- stop route button clicks from also selecting the file row, preserving current-file state while navigating Task/Telemetry/etc.
- widen and style the chip with semantic tokens only so the tree stays scannable

## Validation
- pnpm exec eslint src/components/ide/ide-explorer.ts src/components/ide/ide-explorer.test.ts
- pnpm exec vitest run src/components/ide/ide-explorer.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD
- rg -n "#[0-9a-fA-F]{3,8}\b" dashboard/src/components/ide/ide-explorer.ts dashboard/src/styles/dashboard.css