### PR TITLE
Fix dashboard keeper cascade qualified ids

### DIFF
--- a/dashboard/src/api/dashboard-cascade.test.ts
+++ b/dashboard/src/api/dashboard-cascade.test.ts
@@ -87,14 +87,14 @@ describe('dashboard cascade split', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const result = await updateKeeperCascade('sojin', 'primary')
+    const result = await updateKeeperCascade('sojin', 'tier.ollama_cloud_primary')
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/keeper/cascade')
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ method: 'POST' })
     expect(fetchMock.mock.calls[0]?.[1]?.body).toBe(JSON.stringify({
       keeper: 'sojin',
-      cascade_name: 'primary',
+      cascade_name: 'tier.ollama_cloud_primary',
     }))
     expect(result.ok).toBe(true)
   })

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -70,8 +70,8 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
       per_provider_timeout_sec: null,
       per_provider_timeout_mode: 'turn_budget_heuristic',
       verify: true,
-      selected_cascade_name: 'keeper_unified',
-      selected_cascade_canonical: 'keeper_unified',
+      selected_cascade_name: 'tier-group.keeper_unified',
+      selected_cascade_canonical: 'tier-group.keeper_unified',
     },
     compaction: {
       profile: 'balanced',
@@ -462,10 +462,10 @@ const mocks = vi.hoisted(() => ({
     },
   })),
   fetchCascadeProfiles: vi.fn(async () => ({
-    profiles: ['keeper_unified', 'resilient_breaker'],
+    profiles: ['tier-group.keeper_unified', 'tier.resilient_breaker'],
     invalid_profiles: [
       {
-        name: 'broken_profile',
+        name: 'tier.broken_profile',
         errors: ['missing models'],
       },
     ],
@@ -519,7 +519,7 @@ describe('KeeperConfigPanel', () => {
     expect(container.textContent).toContain('편집 가능 범위')
     expect(container.textContent).toContain('keeper TOML의 cascade_name')
     expect(container.textContent).toContain('Cascade 선택')
-    expect(container.textContent).toContain('keeper_unified')
+    expect(container.textContent).toContain('tier-group.keeper_unified')
     expect(container.textContent).toContain('broken_profile')
     expect(container.textContent).toContain('/tmp/config/keepers/default.toml')
     expect(container.textContent).toContain('/tmp/config/cascade.toml')
@@ -553,7 +553,7 @@ describe('KeeperConfigPanel', () => {
       (select) => !select.getAttribute('aria-label'),
     ) as HTMLSelectElement | undefined
     expect(cascadeSelect).toBeDefined()
-    expect(cascadeSelect?.value).toBe('keeper_unified')
+    expect(cascadeSelect?.value).toBe('tier-group.keeper_unified')
 
     mocks.fetchKeeperConfig.mockResolvedValueOnce(
       makeKeeperConfig({
@@ -563,20 +563,20 @@ describe('KeeperConfigPanel', () => {
           per_provider_timeout_sec: null,
           per_provider_timeout_mode: 'turn_budget_heuristic',
           verify: true,
-          selected_cascade_name: 'resilient_breaker',
-          selected_cascade_canonical: 'resilient_breaker',
+          selected_cascade_name: 'tier.resilient_breaker',
+          selected_cascade_canonical: 'tier.resilient_breaker',
         },
       }),
     )
 
-    cascadeSelect!.value = 'resilient_breaker'
+    cascadeSelect!.value = 'tier.resilient_breaker'
     cascadeSelect!.dispatchEvent(new Event('change', { bubbles: true }))
     await flush()
     await flush()
 
     expect(mocks.updateKeeperCascade).toHaveBeenCalledWith(
       'keeper-sangsu',
-      'resilient_breaker',
+      'tier.resilient_breaker',
     )
     expect(mocks.fetchKeeperConfig).toHaveBeenCalledTimes(2)
   })

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -70,9 +70,10 @@ val invalid_assignments_for_public_profiles :
   invalid_profiles:(string * string list) list ->
   string list ->
   (string * string list) list
-(** Match public keeper-facing profile names against internal invalid-profile
-    diagnostics using runtime profile preference order.  For an unqualified
-    name such as ["primary"], ["tier-group.primary"] is checked before
+(** Match keeper-facing profile names against internal invalid-profile
+    diagnostics using runtime profile preference order. Qualified names such
+    as ["tier.primary"] are checked exactly. For an unqualified legacy name
+    such as ["primary"], ["tier-group.primary"] is checked before
     ["tier.primary"] so a valid preferred tier-group is not rejected because a
     lower-priority tier with the same public name is invalid. *)
 

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -19,10 +19,12 @@ type cascade_profile_gate = {
 
 let cascade_profile_gate () : cascade_profile_gate =
   let config_path = Cascade_runtime.cascade_config_path () in
-  let keeper_profiles =
+  let keeper_assignable_profiles =
     Keeper_cascade_profile.keeper_catalog_names ?config_path ()
-    |> Dashboard_cascade.public_profile_names
     |> List.sort_uniq String.compare
+  in
+  let keeper_assignable_profile profile =
+    keeper_assignable_profiles = [] || List.mem profile keeper_assignable_profiles
   in
   let fallback_invalid_profiles =
     match config_path with
@@ -34,22 +36,28 @@ let cascade_profile_gate () : cascade_profile_gate =
   match Cascade_catalog_runtime.known_profile_names () with
   | Ok raw_validated_profiles ->
       let validated_profiles =
-        Dashboard_cascade.public_profile_names raw_validated_profiles
+        raw_validated_profiles |> List.sort_uniq String.compare
       in
       let invalid_profiles =
         (Cascade_catalog_runtime.invalid_profile_errors ()
          @ fallback_invalid_profiles)
         |> Dashboard_cascade.invalid_profiles_with_internal_names
       in
+      let keeper_profiles =
+        raw_validated_profiles
+        |> List.filter keeper_assignable_profile
+        |> List.sort_uniq String.compare
+      in
       let candidate_profiles =
         if keeper_profiles = [] then validated_profiles else keeper_profiles
       in
       let known_internal_profiles =
-        match config_path with
-        | None -> raw_validated_profiles
-        | Some path ->
-            Cascade_catalog_validator.discover_profiles_for_diagnostics
-              ~config_path:path
+        (match config_path with
+         | None -> raw_validated_profiles
+         | Some path ->
+             Cascade_catalog_validator.discover_profiles_for_diagnostics
+               ~config_path:path)
+        |> List.sort_uniq String.compare
       in
       let invalid_assignments =
         Dashboard_cascade.invalid_assignments_for_public_profiles
@@ -72,19 +80,28 @@ let cascade_profile_gate () : cascade_profile_gate =
           fallback_invalid_profiles
       in
       let known_internal_profiles =
-        match config_path with
-        | None -> []
-        | Some path ->
-            Cascade_catalog_validator.discover_profiles_for_diagnostics
-              ~config_path:path
+        (match config_path with
+         | None -> []
+         | Some path ->
+             Cascade_catalog_validator.discover_profiles_for_diagnostics
+               ~config_path:path)
+        |> List.sort_uniq String.compare
+      in
+      let keeper_profiles =
+        known_internal_profiles
+        |> List.filter keeper_assignable_profile
+        |> List.sort_uniq String.compare
+      in
+      let candidate_profiles =
+        if keeper_profiles = [] then known_internal_profiles else keeper_profiles
       in
       let invalid_assignments =
         Dashboard_cascade.invalid_assignments_for_public_profiles
-          ~known_internal_profiles ~invalid_profiles keeper_profiles
+          ~known_internal_profiles ~invalid_profiles candidate_profiles
       in
       let invalid_names = List.map fst invalid_assignments in
       let valid_profiles =
-        keeper_profiles
+        candidate_profiles
         |> List.filter (fun profile -> not (List.mem profile invalid_names))
       in
       { valid_profiles; invalid_profiles; invalid_assignments }

--- a/lib/server/server_routes_http_routes_dashboard.mli
+++ b/lib/server/server_routes_http_routes_dashboard.mli
@@ -12,8 +12,9 @@ val add_routes :
   Http_server_eio.Router.t -> Http_server_eio.Router.t
 
 val available_cascade_profiles : unit -> string list
-(** Snapshot of cascade profiles currently considered valid by the
-    runtime gate. Recomputed on each call. *)
+(** Snapshot of qualified cascade profiles currently considered valid by the
+    runtime gate, such as ["tier.primary"] or ["tier-group.primary"].
+    Recomputed on each call. *)
 
 val invalid_cascade_profiles : unit -> (string * string list) list
 (** Snapshot of [(profile_name, violations)] pairs for cascade

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -1211,7 +1211,7 @@ let test_available_cascade_profiles_filter_invalid_catalog_entries () =
   check
     (list string)
     "assignable cascades exclude invalid presets"
-    [ "good" ]
+    [ "tier-group.good"; "tier.good" ]
     (Routes.available_cascade_profiles ());
   let invalid = Routes.invalid_cascade_profiles () in
   check bool "invalid preset is surfaced separately" true
@@ -1251,7 +1251,9 @@ target = "tier-group.primary"
   in
   with_temp_config_root cascade_toml @@ fun config_root ->
   with_config_dir config_root @@ fun () ->
-  check bool "valid tier-group public name remains assignable" true
+  check bool "valid qualified tier-group remains assignable" true
+    (List.mem "tier-group.primary" (Routes.available_cascade_profiles ()));
+  check bool "legacy public alias is not exposed as assignable" false
     (List.mem "primary" (Routes.available_cascade_profiles ()));
   let invalid = Routes.invalid_cascade_profiles () in
   check bool "invalid tier keeps qualified name" true
@@ -1300,17 +1302,35 @@ let test_keeper_cascade_routes_filter_invalid_catalog_entries () =
   require_status "keeper cascades GET returns 200" 200 list_result;
   let profiles = profile_names list_result.body in
   let invalid_profiles = invalid_profile_names list_result.body in
-  check bool "valid profile remains assignable" true (List.mem "good" profiles);
+  check bool "valid profile remains assignable" true
+    (List.mem "tier-group.good" profiles && List.mem "tier.good" profiles);
+  check bool "legacy public alias omitted from assignable list" false
+    (List.mem "good" profiles);
   check bool "invalid profile omitted from assignable list" false
-    (List.mem "broken" profiles);
+    (List.mem "tier.broken" profiles || List.mem "tier-group.broken" profiles);
   check bool "invalid profile is surfaced in payload" true
     (List.mem "tier.broken" invalid_profiles
      || List.mem "tier-group.broken" invalid_profiles);
+  let assign_public_alias_result =
+    run_curl_post
+      ~body:
+        (Printf.sprintf
+           {|{"keeper":"%s","cascade_name":"good"}|}
+           keeper_name)
+      ~token:admin_token
+      ~port
+      ~path:"/api/v1/keeper/cascade"
+      ()
+  in
+  require_status "legacy public alias assignment returns 400" 400
+    assign_public_alias_result;
+  check bool "legacy public alias rejection explains unknown cascade" true
+    (contains_substr "unknown cascade good" assign_public_alias_result.body);
   let assign_invalid_result =
     run_curl_post
       ~body:
         (Printf.sprintf
-           {|{"keeper":"%s","cascade_name":"broken"}|}
+           {|{"keeper":"%s","cascade_name":"tier.broken"}|}
            keeper_name)
       ~token:admin_token
       ~port
@@ -1347,7 +1367,7 @@ let test_keeper_cascade_assignment_updates_dashboard_projection () =
   check string "dashboard starts with seeded meta cascade"
     Masc_mcp.(Keeper_config.default_cascade_name ())
     (keeper_profile_cascade_name before.body keeper_name);
-  let candidate = cascade_profile_first_candidate before.body "primary" in
+  let candidate = cascade_profile_first_candidate before.body "tier-group.primary" in
   check bool "dashboard cascade config keeps candidate model label" true
     (contains_substr "custom:mock@" (candidate_string_field "model" candidate));
   check bool "dashboard cascade config keeps display model label" true
@@ -1359,7 +1379,7 @@ let test_keeper_cascade_assignment_updates_dashboard_projection () =
     run_curl_post
       ~body:
         (Printf.sprintf
-           {|{"keeper":"%s","cascade_name":"alternate"}|}
+           {|{"keeper":"%s","cascade_name":"tier.alternate"}|}
            keeper_name)
       ~token:admin_token
       ~port
@@ -1376,13 +1396,13 @@ let test_keeper_cascade_assignment_updates_dashboard_projection () =
   in
   require_status "cascade config GET after assignment returns 200" 200 after;
   check string "dashboard projection reflects assigned cascade"
-    "alternate"
+    "tier.alternate"
     (keeper_profile_cascade_name after.body keeper_name);
   let keeper_toml_path =
     Filename.concat (Filename.concat config_root "keepers") (keeper_name ^ ".toml")
   in
   check bool "persistent TOML cascade updated" true
-    (contains_substr {|cascade_name = "alternate"|} (read_file keeper_toml_path))
+    (contains_substr {|cascade_name = "tier.alternate"|} (read_file keeper_toml_path))
 ;;
 
 let test_execution_trust_route_surfaces_trust_summary_fields () =


### PR DESCRIPTION
## Summary

- Make keeper cascade assignment APIs use qualified cascade ids (`tier.*` / `tier-group.*`) instead of legacy public aliases.
- Keep invalid-profile diagnostics on internal names so tier and tier-group entries do not collapse together.
- Update dashboard API/component tests and server route tests around the canonical id contract.

## Product impact

Operators can assign keepers to concrete cascade tiers from the dashboard without seeing the contradictory `unknown cascade tier.*` error. Legacy unqualified aliases are no longer advertised by `/api/v1/keeper/cascades` or accepted by the assignment endpoint.

## Evidence

- `ocamlformat -i lib/server/server_routes_http_routes_dashboard.ml lib/server/server_routes_http_routes_dashboard.mli lib/dashboard_cascade.mli test/test_dashboard_keeper_routes.ml`
- `git diff --check`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run --no-file-parallelism --maxWorkers=1 src/api/dashboard-cascade.test.ts src/components/keeper-config-panel.test.ts`

## Review evidence

- Reproduced the live mismatch on `127.0.0.1:8935`: `POST /api/v1/keeper/cascade` rejected `tier.ollama_cloud_primary` while `/api/v1/keeper/cascades` advertised `ollama_cloud_primary`.
- Focused OCaml build was attempted with `scripts/dune-local.sh build test/test_dashboard_keeper_routes.exe`, but the local wrapper stopped at the agent_sdk pin guard. Per operator correction, no opam repair path is included in this PR.

## Linked issue

- None.
