### PR TITLE
fix(dashboard): add SSE fallback for WS cutover

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -19,6 +19,7 @@ import { cancelPendingSSERefreshes, registerMissionRefresh, setupSSEReaction, st
 import { refreshShell } from './store'
 import { connectDashboardWS, disconnectDashboardWS, subscribeDashboardRoute } from './dashboard-ws'
 import { dashboardWsOnlyEnabled } from './dashboard-ws-cutover'
+import { startDashboardSseFallback } from './dashboard-transport-fallback'
 import { ensureDevToken } from './api/dev-token'
 import { fetchDashboardConfig, parseContextThresholds } from './api/dashboard'
 import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from './config/constants'
@@ -122,6 +123,7 @@ export function App() {
     // the WS external-subscriber path, so turning SSE off is safe when
     // operators have validated the WS channel in their environment.
     const wsOnly = dashboardWsOnlyEnabled()
+    const stopSseFallback = startDashboardSseFallback({ wsOnly })
 
     // Initialize hash router and compatible deep links
     initRouter()
@@ -201,6 +203,7 @@ export function App() {
 
     return () => {
       cancelled = true
+      stopSseFallback()
       disconnectDashboardWS()
       if (!wsOnly) {
         disconnectSSE()

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -6,7 +6,7 @@ import type { RouteState, TabId } from '../types'
 import { hashForRoute, navigate, route } from '../router'
 import { connected, reconnectCount, lastDisconnectedAt } from '../sse'
 import { dashboardWsOnlyEnabled } from '../dashboard-ws-cutover'
-import { dashboardWsConnected } from '../dashboard-ws-state'
+import { dashboardWsConnected, dashboardWsSseFallbackActive } from '../dashboard-ws-state'
 import { dashboardLoading, serverStatus } from '../store'
 import { missionSnapshot, missionLoading } from '../mission-signals'
 import { namespaceTruthInitializing } from '../namespace-truth-store'
@@ -104,7 +104,9 @@ function describeReconnecting(args: {
 
 export function ConnectionStatus() {
   const wsOnly = dashboardWsOnlyEnabled()
-  const isConnected = wsOnly ? dashboardWsConnected.value : connected.value
+  const isConnected = wsOnly
+    ? dashboardWsConnected.value || dashboardWsSseFallbackActive.value
+    : connected.value
   const snap = missionSnapshot.value
   const attentionCount = snap?.attention_queue?.length ?? 0
   const reconn = reconnectCount.value
@@ -366,7 +368,9 @@ function dashboardRouteBoundaryKey(routeState: RouteState): string {
 
 function HealthIndicator({ collapsed }: { collapsed?: boolean }) {
   const wsOnly = dashboardWsOnlyEnabled()
-  const live = wsOnly ? dashboardWsConnected.value : connected.value
+  const live = wsOnly
+    ? dashboardWsConnected.value || dashboardWsSseFallbackActive.value
+    : connected.value
   const snap = missionSnapshot.value
   const sessions = snap?.sessions ?? []
   let blockers = 0

--- a/dashboard/src/components/status-tray.test.ts
+++ b/dashboard/src/components/status-tray.test.ts
@@ -59,6 +59,34 @@ describe('summarizeStatusTray', () => {
     expect(summary.items.transport.detail).toContain('socket closed')
   })
 
+  it('marks WS-only transport as degraded but live when SSE fallback is carrying events', () => {
+    const summary = summarizeStatusTray({
+      wsOnly: true,
+      sseConnected: true,
+      wsConnected: false,
+      wsReady: false,
+      wsLastEventAt: 0,
+      wsEventCount60s: 0,
+      wsLastPongAt: 0,
+      wsLastPongLatencyMs: null,
+      wsSseFallbackActive: true,
+      wsSseFallbackReason: 'dashboard websocket rpc timed out: dashboard/ping',
+      wsLastError: 'dashboard websocket rpc timed out: dashboard/ping',
+      reconnectCount: 0,
+      lastDisconnectedAt: 0,
+      keepers: [],
+      staleKeeperNames: new Set(),
+      tasks: [],
+      journalEntries: [],
+      unacknowledgedErrors: 0,
+      now: NOW,
+    })
+
+    expect(summary.items.transport.tone).toBe('warn')
+    expect(summary.items.transport.value).toBe('SSE fallback')
+    expect(summary.items.transport.detail).toContain('dashboard/ping')
+  })
+
   it('rolls stale keeper, verification, and error counts into tray items', () => {
     const summary = summarizeStatusTray({
       wsOnly: false,

--- a/dashboard/src/components/status-tray.ts
+++ b/dashboard/src/components/status-tray.ts
@@ -11,6 +11,8 @@ import {
   dashboardWsLastPongAt,
   dashboardWsLastPongLatencyMs,
   dashboardWsReady,
+  dashboardWsSseFallbackActive,
+  dashboardWsSseFallbackReason,
 } from '../dashboard-ws-state'
 import { route } from '../router'
 import {
@@ -72,6 +74,8 @@ export interface StatusTrayInput {
   wsEventCount60s: number
   wsLastPongAt: number
   wsLastPongLatencyMs: number | null
+  wsSseFallbackActive?: boolean
+  wsSseFallbackReason?: string | null
   wsLastError: string | null
   reconnectCount: number
   lastDisconnectedAt: number
@@ -186,14 +190,26 @@ export function summarizeStatusTray(input: StatusTrayInput): StatusTraySummary {
   let transport: StatusTrayItem
   if (input.wsOnly) {
     if (!input.wsConnected || !input.wsReady) {
-      transport = {
-        key: 'transport',
-        tone: 'err',
-        label: 'Client',
-        value: 'closed',
-        detail: input.wsLastError
-          ? clip(input.wsLastError)
-          : 'client WS channel is not ready; server transport truth is in Transport Health',
+      if (input.wsSseFallbackActive && input.sseConnected) {
+        transport = {
+          key: 'transport',
+          tone: 'warn',
+          label: 'Client',
+          value: 'SSE fallback',
+          detail: input.wsSseFallbackReason
+            ? `client WS degraded; ${clip(input.wsSseFallbackReason)}`
+            : 'client WS degraded; SSE fallback is live',
+        }
+      } else {
+        transport = {
+          key: 'transport',
+          tone: 'err',
+          label: 'Client',
+          value: 'closed',
+          detail: input.wsLastError
+            ? clip(input.wsLastError)
+            : 'client WS channel is not ready; server transport truth is in Transport Health',
+        }
       }
     } else {
       const silentMs = input.wsLastEventAt === 0
@@ -456,6 +472,8 @@ export function DashboardStatusTray({ sideRailCollapsed = false }: DashboardStat
     wsEventCount60s: dashboardWsEventCount60s.value,
     wsLastPongAt: dashboardWsLastPongAt.value,
     wsLastPongLatencyMs: dashboardWsLastPongLatencyMs.value,
+    wsSseFallbackActive: dashboardWsSseFallbackActive.value,
+    wsSseFallbackReason: dashboardWsSseFallbackReason.value,
     wsLastError: dashboardWsLastError.value,
     reconnectCount: reconnectCount.value,
     lastDisconnectedAt: lastDisconnectedAt.value,

--- a/dashboard/src/components/transport-beacon.test.ts
+++ b/dashboard/src/components/transport-beacon.test.ts
@@ -12,6 +12,8 @@ function beaconInput(overrides: Partial<Parameters<typeof computeBeaconView>[0]>
     eventCount60s: 5,
     lastPongAt: 0,
     lastPongLatencyMs: null,
+    sseFallbackActive: false,
+    sseFallbackReason: null,
     now: NOW,
     ...overrides,
   }
@@ -33,6 +35,18 @@ describe('computeBeaconView', () => {
     }))
     expect(view.state).toBe('red')
     expect(view.label).toContain('disconnected')
+  })
+
+  it('returns yellow SSE fallback when wsOnly but fallback is active', () => {
+    const view = computeBeaconView(beaconInput({
+      connected: false,
+      ready: false,
+      sseFallbackActive: true,
+      sseFallbackReason: 'dashboard websocket rpc timed out: dashboard/ping',
+    }))
+    expect(view.state).toBe('yellow')
+    expect(view.label).toBe('Client SSE fallback')
+    expect(view.title).toContain('dashboard/ping')
   })
 
   it('returns red when wsOnly, socket connected but handshake not ready', () => {

--- a/dashboard/src/components/transport-beacon.ts
+++ b/dashboard/src/components/transport-beacon.ts
@@ -14,6 +14,8 @@ import {
   dashboardWsLastPongAt,
   dashboardWsLastPongLatencyMs,
   dashboardWsReady,
+  dashboardWsSseFallbackActive,
+  dashboardWsSseFallbackReason,
 } from '../dashboard-ws-state'
 import {
   DASHBOARD_WS_HEARTBEAT_INTERVAL_MS,
@@ -47,6 +49,8 @@ export function computeBeaconView(args: {
   eventCount60s: number
   lastPongAt: number
   lastPongLatencyMs: number | null
+  sseFallbackActive: boolean
+  sseFallbackReason: string | null
   now: number
 }): BeaconView {
   if (!args.wsOnly) {
@@ -57,6 +61,15 @@ export function computeBeaconView(args: {
     }
   }
   if (!args.connected || !args.ready) {
+    if (args.sseFallbackActive) {
+      return {
+        state: 'yellow',
+        label: 'Client SSE fallback',
+        title: args.sseFallbackReason
+          ? `Client WS is degraded; SSE fallback is carrying events. Reason: ${args.sseFallbackReason}`
+          : 'Client WS is degraded; SSE fallback is carrying events.',
+      }
+    }
     return {
       state: 'red',
       label: 'Client WS · disconnected',
@@ -109,6 +122,8 @@ const beaconView = computed<BeaconView>(() => computeBeaconView({
   eventCount60s: dashboardWsEventCount60s.value,
   lastPongAt: dashboardWsLastPongAt.value,
   lastPongLatencyMs: dashboardWsLastPongLatencyMs.value,
+  sseFallbackActive: dashboardWsSseFallbackActive.value,
+  sseFallbackReason: dashboardWsSseFallbackReason.value,
   now: Date.now(),
 }))
 

--- a/dashboard/src/dashboard-transport-fallback.test.ts
+++ b/dashboard/src/dashboard-transport-fallback.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  dashboardWsConnected,
+  dashboardWsLastError,
+  dashboardWsReady,
+  dashboardWsSseFallbackActive,
+  dashboardWsSseFallbackReason,
+  _resetDashboardWsCounterForTests,
+} from './dashboard-ws-state'
+import { startDashboardSseFallback } from './dashboard-transport-fallback'
+
+describe('startDashboardSseFallback', () => {
+  beforeEach(() => {
+    dashboardWsConnected.value = false
+    dashboardWsReady.value = false
+    dashboardWsLastError.value = null
+    _resetDashboardWsCounterForTests()
+  })
+
+  afterEach(() => {
+    dashboardWsLastError.value = null
+    _resetDashboardWsCounterForTests()
+  })
+
+  it('connects SSE when WS-only mode observes a websocket error', () => {
+    const connect = vi.fn()
+    const disconnect = vi.fn()
+    const dispose = startDashboardSseFallback({
+      wsOnly: true,
+      connect,
+      disconnect,
+      warn: vi.fn(),
+    })
+
+    dashboardWsLastError.value = 'dashboard websocket rpc timed out: dashboard/ping'
+
+    expect(connect).toHaveBeenCalledTimes(1)
+    expect(disconnect).not.toHaveBeenCalled()
+    expect(dashboardWsSseFallbackActive.value).toBe(true)
+    expect(dashboardWsSseFallbackReason.value).toContain('dashboard/ping')
+
+    dispose()
+    expect(disconnect).toHaveBeenCalledTimes(1)
+    expect(dashboardWsSseFallbackActive.value).toBe(false)
+  })
+
+  it('disconnects fallback SSE when the WS channel becomes ready again', () => {
+    const connect = vi.fn()
+    const disconnect = vi.fn()
+    const dispose = startDashboardSseFallback({
+      wsOnly: true,
+      connect,
+      disconnect,
+      warn: vi.fn(),
+    })
+
+    dashboardWsLastError.value = 'dashboard websocket closed'
+    dashboardWsConnected.value = true
+    dashboardWsReady.value = true
+
+    expect(connect).toHaveBeenCalledTimes(1)
+    expect(disconnect).toHaveBeenCalledTimes(1)
+    expect(dashboardWsSseFallbackActive.value).toBe(false)
+    expect(dashboardWsSseFallbackReason.value).toBe(null)
+
+    dispose()
+    expect(disconnect).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when the dashboard is already in parallel transport mode', () => {
+    const connect = vi.fn()
+    const disconnect = vi.fn()
+    const dispose = startDashboardSseFallback({
+      wsOnly: false,
+      connect,
+      disconnect,
+      warn: vi.fn(),
+    })
+
+    dashboardWsLastError.value = 'dashboard websocket closed'
+
+    expect(connect).not.toHaveBeenCalled()
+    expect(disconnect).not.toHaveBeenCalled()
+    expect(dashboardWsSseFallbackActive.value).toBe(false)
+
+    dispose()
+  })
+})

--- a/dashboard/src/dashboard-transport-fallback.ts
+++ b/dashboard/src/dashboard-transport-fallback.ts
@@ -1,0 +1,73 @@
+import { batch, effect } from '@preact/signals'
+import {
+  dashboardWsConnected,
+  dashboardWsLastError,
+  dashboardWsReady,
+  dashboardWsSseFallbackActive,
+  dashboardWsSseFallbackReason,
+} from './dashboard-ws-state'
+import { connectSSE, disconnectSSE } from './sse'
+
+interface DashboardSseFallbackOptions {
+  wsOnly: boolean
+  connect?: () => void
+  disconnect?: () => void
+  warn?: (message: string, reason: string) => void
+}
+
+export function startDashboardSseFallback(options: DashboardSseFallbackOptions): () => void {
+  const connect = options.connect ?? connectSSE
+  const disconnect = options.disconnect ?? disconnectSSE
+  const warn = options.warn ?? ((message, reason) => console.warn(message, reason))
+  let active = false
+
+  const clearFallbackState = () => {
+    batch(() => {
+      dashboardWsSseFallbackActive.value = false
+      dashboardWsSseFallbackReason.value = null
+    })
+  }
+
+  if (!options.wsOnly) {
+    clearFallbackState()
+    return () => {}
+  }
+
+  const enable = (reason: string) => {
+    if (active) {
+      dashboardWsSseFallbackReason.value = reason
+      return
+    }
+    active = true
+    batch(() => {
+      dashboardWsSseFallbackActive.value = true
+      dashboardWsSseFallbackReason.value = reason
+    })
+    warn('[dashboard] client WS degraded; enabling SSE fallback', reason)
+    connect()
+  }
+
+  const disable = () => {
+    if (!active) return
+    active = false
+    disconnect()
+    clearFallbackState()
+  }
+
+  const dispose = effect(() => {
+    if (dashboardWsConnected.value && dashboardWsReady.value) {
+      disable()
+      return
+    }
+    const reason = dashboardWsLastError.value
+    if (reason) {
+      enable(reason)
+    }
+  })
+
+  return () => {
+    dispose()
+    disable()
+    clearFallbackState()
+  }
+}

--- a/dashboard/src/dashboard-ws-state.ts
+++ b/dashboard/src/dashboard-ws-state.ts
@@ -7,6 +7,8 @@ export const dashboardWsLastSeq = signal(0)
 export const dashboardWsLastPingAt = signal(0)
 export const dashboardWsLastPongAt = signal(0)
 export const dashboardWsLastPongLatencyMs = signal<number | null>(null)
+export const dashboardWsSseFallbackActive = signal(false)
+export const dashboardWsSseFallbackReason = signal<string | null>(null)
 
 // Cutover beacon signals.  The transport beacon (operator-facing UI)
 // reads these to show whether events are actually flowing through the WS
@@ -52,4 +54,6 @@ export function _resetDashboardWsCounterForTests(): void {
   dashboardWsLastPingAt.value = 0
   dashboardWsLastPongAt.value = 0
   dashboardWsLastPongLatencyMs.value = null
+  dashboardWsSseFallbackActive.value = false
+  dashboardWsSseFallbackReason.value = null
 }

--- a/docs/sse-ws-cutover.md
+++ b/docs/sse-ws-cutover.md
@@ -52,10 +52,26 @@ status chip.  States:
 
 | Color | Label | Meaning | Action |
 |-------|-------|---------|--------|
-| Gray | `WS+SSE (legacy)` | Cutover not active in this build | None — this is the safety-net default |
-| Green | `WS-only · open · N events / 60s` | Cutover active, socket open, events arriving | None — the transport is healthy |
-| Yellow | `WS-only · silent` | Cutover active, socket open, but no event for >30s | Verify the workload is genuinely idle.  If you expect events and the gray-mode beacon would have shown them, consider rolling back |
-| Red | `WS-only · disconnected` | Cutover active, but the socket is closed | Wait for auto-reconnect.  If the socket stays closed, roll back |
+| Gray | `Client WS+SSE parallel` | Cutover not active in this build or manually rolled back | Safe but duplicate delivery is expected |
+| Green | `Client WS · open · N events / 60s` / `Client WS · heartbeat · Nms` | Cutover active, socket open, events or heartbeat pongs arriving | None — the transport is healthy |
+| Yellow | `Client WS · silent` | Cutover active, socket open, but no event or fresh heartbeat pong | Verify the workload is genuinely idle. If you expect events and fallback/parallel mode would show them, inspect WS fan-out |
+| Red | `Client WS · disconnected` | Cutover active, but the socket is closed and no fallback is active yet | Wait for auto-reconnect; fallback should engage after the WS layer reports a failure reason |
+| Yellow | `Client SSE fallback` | WS-only build detected a WS close/error/RPC timeout and opened the `/mcp` EventSource safety net | Treat as degraded-but-live; inspect the beacon title / status tray reason, then fix the WS path |
+
+## Automatic SSE fallback
+
+WS-only is the steady-state cutover mode, but the browser no longer lets
+a failed WS channel pause live dashboard events.  When the client sees a
+WS close, connection error, or `dashboard/hello` / `dashboard/ping` /
+`dashboard/subscribe` RPC timeout, it opens the `/mcp` EventSource as a
+runtime safety net while the WS reconnect loop continues.  Once the WS
+channel is connected and ready again, the fallback EventSource is closed
+so steady-state duplicate delivery stays off.
+
+The status tray reports this state as `SSE fallback` and includes the WS
+failure reason.  This is intentionally not a full rollback: it preserves
+operator visibility during WS degradation without changing the tracked
+`VITE_DASHBOARD_WS_ONLY=true` default.
 
 ## Rollback
 


### PR DESCRIPTION
## Summary

- Add a dashboard WS cutover safety controller that opens the /mcp EventSource when WS-only mode observes a WS close/error/RPC timeout.
- Close the fallback EventSource once the WS channel becomes connected and ready again.
- Surface degraded-but-live SSE fallback state in the header connection health, transport beacon, status tray, and cutover docs.

## Product impact

Operators keep live dashboard events during WS-only degradation instead of seeing a hard disconnected state while the WS reconnect loop retries. Steady-state WS-only mode still avoids duplicate SSE+WS delivery once the socket recovers.

## Evidence

- pnpm exec vitest run --config vitest.config.ts src/dashboard-transport-fallback.test.ts src/components/transport-beacon.test.ts src/components/status-tray.test.ts --no-file-parallelism --maxWorkers=1
- pnpm run typecheck
- pnpm run lint (passes with existing warning in src/components/common/virtual-list.ts:87)
- git diff --check

## Review evidence

- New unit coverage verifies fallback SSE connects on WS errors, disconnects when WS is ready, and stays inactive in parallel mode.
- Beacon/status tray tests cover the operator-visible SSE fallback state.

## Linked issue

None. Follow-up from Kimi OCaml server performance docs: WS-only disconnected should degrade to SSE fallback instead of pausing live events.
