### PR TITLE
feat(ide): sync replay cursor with keeper trace

### DIFF
--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -49,8 +49,6 @@ import {
   boardHearthsError,
   subBoardOptions,
   subBoardOptionsLoading,
-  subBoardOptionsError,
-  loadSubBoardOptionsForPost,
   boardExcludeAutomation,
   boardLoading,
   boardLoadingMore,
@@ -254,6 +252,13 @@ function NewPostForm() {
     `
   }
 
+  const subBoardSelectOptions = subBoardOptions.value.map(sb => ({ value: sb.slug, label: sb.name }))
+  const activeHearth = newPostHearth.value.trim()
+  const selectedSubBoardOptions = activeHearth
+    && !subBoardSelectOptions.some(option => option.value === activeHearth)
+    ? [{ value: activeHearth, label: activeHearth }, ...subBoardSelectOptions]
+    : subBoardSelectOptions
+
   return html`
     <div class="p-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] grid gap-3">
       <${TextInput}
@@ -274,10 +279,10 @@ function NewPostForm() {
       />
       <${Select}
         value=${newPostHearth.value}
-        options=${subBoardOptions.value.map(sb => ({ value: sb.slug, label: sb.name }))}
+        options=${selectedSubBoardOptions}
         placeholder="Sub-board (hearth) 선택"
         disabled=${newPostSubmitting.value || subBoardOptionsLoading.value}
-        ariaLabel="새 글 Sub-board"
+        ariaLabel="새 글 hearth"
         onInput=${(value: string) => { newPostHearth.value = value }}
       />
       <div class="flex gap-2 justify-end">

--- a/dashboard/src/components/board/sub-board-surface.ts
+++ b/dashboard/src/components/board/sub-board-surface.ts
@@ -61,7 +61,7 @@ function SubBoardRow({ board, onEdit, onDelete, deleting }: SubBoardRowProps) {
             </span>
             <div class="min-w-0 cursor-pointer" onClick=${() => {
               boardHearthFilter.value = board.slug
-              navigate('board')
+              navigate('workspace', { section: 'board' })
             }}>
               <h3 class="truncate text-sm font-semibold text-[var(--color-fg-primary)] hover:underline">${board.name || board.slug}</h3>
               <div class="truncate font-mono text-2xs text-[var(--color-fg-muted)]">/${board.slug}</div>

--- a/dashboard/src/components/ide/ide-conversation-rail.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.test.ts
@@ -5,6 +5,7 @@ import { fireEvent, waitFor } from '@testing-library/preact'
 import { IdeConversationRail, postsToAnchoredThreads, replayRailItems } from './ide-conversation-rail'
 import { activeIdeFile, ideContextFocus } from './ide-state'
 import { clearTraces, keeperTraceState } from './keeper-trace-store'
+import { ideReplayUntilMs, setIdeReplayUntilMs } from './ide-replay-state'
 
 function stubEmptyConversationFetch(): void {
   vi.stubGlobal('fetch', vi.fn(async (url: string) => {
@@ -38,6 +39,7 @@ afterEach(() => {
   vi.unstubAllGlobals()
   activeIdeFile.value = 'package.json'
   ideContextFocus.value = null
+  setIdeReplayUntilMs(null)
   clearTraces()
 })
 
@@ -246,6 +248,7 @@ describe('IdeConversationRail', () => {
     slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }))
 
     await waitFor(() => {
+      expect(ideReplayUntilMs.value).toBe(Date.UTC(2026, 4, 5, 10, 0, 0))
       expect(container.textContent).toContain('old thread body')
       expect(container.textContent).toContain('1/2 threads')
       expect(container.textContent).toContain('0/1 decisions')

--- a/dashboard/src/components/ide/ide-conversation-rail.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.ts
@@ -24,6 +24,7 @@ import {
   type AuditReplayEvent,
 } from './audit-replay-slider'
 import { publishIdeConversationThreads } from './ide-context-bridge'
+import { ideReplayUntilMs, setIdeReplayUntilMs } from './ide-replay-state'
 import { activeIdeFile, focusIdeContextAnchor, normalizeIdeContextFilePath } from './ide-state'
 import { activeKeeperName } from '../../keeper-state'
 import { globalPresenceSnapshot, PRESENCE_DOT, type KeeperPresenceEntry } from './keeper-presence-store'
@@ -128,7 +129,7 @@ export function IdeConversationRail() {
   const [decisions, setDecisions] = useState<ReadonlyArray<KeeperDecision>>(EMPTY_DECISIONS)
   const [cascadeEvents, setCascadeEvents] = useState<ReadonlyArray<CascadeStrategyTraceEvent>>(EMPTY_CASCADE)
   const [focusedId, setFocusedId] = useState<string | null>(null)
-  const [replayUntilMs, setReplayUntilMs] = useState<number | null>(null)
+  const [replayUntilMs, setReplayUntilMs] = useState<number | null>(ideReplayUntilMs.value)
   const [activeFile, setActiveFile] = useState(activeIdeFile.value)
   const [keeperName, setKeeperName] = useState(activeKeeperName.value)
   const [, forceRender] = useState(0)
@@ -139,6 +140,10 @@ export function IdeConversationRail() {
   }, [])
   useEffect(() => {
     const unsub = cursorOverlaySignal.subscribe(() => forceRender((t: number) => t + 1))
+    return () => unsub()
+  }, [])
+  useEffect(() => {
+    const unsub = ideReplayUntilMs.subscribe(value => setReplayUntilMs(value))
     return () => unsub()
   }, [])
 
@@ -251,7 +256,7 @@ export function IdeConversationRail() {
       <${AuditReplaySlider}
         events=${replayEvents}
         value=${replayUntilMs}
-        onChange=${setReplayUntilMs}
+        onChange=${setIdeReplayUntilMs}
       />
       <ol
         class="ide-rail-list"

--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -10,6 +10,7 @@ import { ideConversationThreadSnapshot } from './ide-context-bridge'
 import { lspDiagnosticSnapshot } from './ide-lsp-client'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
 import { clearTraces, pushTrace } from './keeper-trace-store'
+import { setIdeReplayUntilMs } from './ide-replay-state'
 
 describe('IdeEditor', () => {
   let container: HTMLDivElement
@@ -18,12 +19,14 @@ describe('IdeEditor', () => {
     container = document.createElement('div')
     activeIdeFile.value = 'package.json'
     ideContextFocus.value = null
+    setIdeReplayUntilMs(null)
     clearTraces()
   })
 
   afterEach(() => {
     render(null, container)
     ideContextFocus.value = null
+    setIdeReplayUntilMs(null)
     clearTraces()
     lspDiagnosticSnapshot.value = new Map()
     ideConversationThreadSnapshot.value = { filePath: '', threads: [] }
@@ -215,6 +218,50 @@ describe('IdeEditor', () => {
       expect(container.querySelector('.cm-trace-dot')?.getAttribute('aria-label'))
         .toBe('thread scholar')
     })
+    expect(container.querySelectorAll('.cm-trace-dot')).toHaveLength(1)
+  })
+
+  it('filters keeper trace gutter dots through the shared replay cursor', async () => {
+    const documentStore = createCodeDocumentStore({
+      file_path: 'runtime.ts',
+      language: 'typescript',
+      content: 'const oldTrace = 1\nconst replayTrace = oldTrace + 1\n',
+    })
+    const ownershipStore = createKeeperLineOwnershipStore('runtime.ts')
+    pushTrace({
+      id: 'thread-old',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'anchored-thread',
+      threadId: 'thread-old',
+      filePath: 'runtime.ts',
+      line: 2,
+    })
+    pushTrace({
+      id: 'thread-future',
+      tsMs: 3000,
+      keeperName: 'moth',
+      source: 'anchored-thread',
+      threadId: 'thread-future',
+      filePath: 'runtime.ts',
+      line: 1,
+    })
+    setIdeReplayUntilMs(1500)
+
+    render(
+      h(IdeEditor, {
+        documentStore,
+        ownershipStore,
+        diffRows: () => [],
+        activeLayers: new Set(['keeper-trace']),
+      }),
+      container,
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('button.cm-trace-stack[data-line="2"]')).not.toBeNull()
+    })
+    expect(container.querySelector('button.cm-trace-stack[data-line="1"]')).toBeNull()
     expect(container.querySelectorAll('.cm-trace-dot')).toHaveLength(1)
   })
 

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -43,7 +43,7 @@ import { SplitDiffView, UnifiedDiffView } from './ide-diff-view'
 import { KeeperBadge } from '../keeper-badge'
 import { keeperCursorExtension } from './keeper-cursor-cm-extension'
 import { cursorOverlaySignal, getKeeperColor } from './keeper-cursor-overlay'
-import { keeperTraceState, type KeeperTraceEvent } from './keeper-trace-store'
+import { filterTraceEventsByReplay, keeperTraceState, type KeeperTraceEvent } from './keeper-trace-store'
 import {
   globalPresenceSnapshot,
   type KeeperPresenceSnapshot,
@@ -57,6 +57,7 @@ import {
   type IdeContextFocus,
 } from './ide-state'
 import { ideConversationThreadSnapshot } from './ide-context-bridge'
+import { ideReplayUntilMs } from './ide-replay-state'
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -99,6 +100,7 @@ export interface FindMatch {
 }
 
 const EMPTY_ACTIVE_LAYERS: ReadonlySet<string> = new Set()
+const EMPTY_TRACE_EVENTS: ReadonlyArray<KeeperTraceEvent> = []
 
 const VIEW_LABEL: Record<IdeEditorView, string> = {
   source: 'SOURCE',
@@ -155,6 +157,10 @@ export function IdeEditor({
     const unsub = keeperTraceState.subscribe(() => forceRender(tick => tick + 1))
     return () => unsub()
   }, [])
+  useEffect(() => {
+    const unsub = ideReplayUntilMs.subscribe(() => forceRender(tick => tick + 1))
+    return () => unsub()
+  }, [])
 
   const document = documentStore.document()
   const lines = documentStore.lines()
@@ -167,12 +173,13 @@ export function IdeEditor({
   const activeCursors = keepersWithCursorInFile(overlay.cursors, document.file_path)
   const activeLayerKinds = activeLayersInDisplayOrder(activeLayers)
   const currentDiffRows = diffRows()
+  const replayTraceEvents = filterTraceEventsByReplay(keeperTraceState.value.events, ideReplayUntilMs.value)
   const currentFileSignals = buildCurrentFileSignals({
     filePath: document.file_path,
     annotations,
     diffRows: currentDiffRows,
     activeKeeperCount: activeCursors.length,
-    traceEvents: keeperTraceState.value.events,
+    traceEvents: replayTraceEvents,
   })
   const gridTemplateRows = editorGridRows(activeLayerKinds.length > 0, findOpen)
 
@@ -292,6 +299,7 @@ export function IdeEditor({
               onKeeperLineSelect=${onKeeperLineSelect}
               contextFocus=${currentFileFocus}
               traceActive=${activeLayers.has('keeper-trace')}
+              traceEvents=${replayTraceEvents}
               annotations=${annotations}
             />`
       }
@@ -776,6 +784,7 @@ function CodeMirrorEditor({
   annotations = [],
   contextFocus,
   traceActive = false,
+  traceEvents = EMPTY_TRACE_EVENTS,
 }: {
   readonly documentStore: CodeDocumentStore
   readonly ownershipStore: KeeperLineOwnershipStore
@@ -785,6 +794,7 @@ function CodeMirrorEditor({
   readonly annotations?: ReadonlyArray<IdeAnnotation>
   readonly contextFocus?: IdeContextFocus | null
   readonly traceActive?: boolean
+  readonly traceEvents?: ReadonlyArray<KeeperTraceEvent>
 }) {
   const containerRef = useRef<HTMLElement>(null)
   const editorRef = useRef<EditorView | null>(null)
@@ -798,7 +808,6 @@ function CodeMirrorEditor({
     () => annotations.filter(annotation => annotation.file_path === document.file_path),
     [annotations, document.file_path],
   )
-  const traceEvents = keeperTraceState.value.events
   const traceLines = useMemo(
     () => traceActive ? keeperTraceLinesForFile(document.file_path, traceEvents) : [],
     [document.file_path, traceActive, traceEvents],

--- a/dashboard/src/components/ide/ide-replay-state.ts
+++ b/dashboard/src/components/ide/ide-replay-state.ts
@@ -1,0 +1,9 @@
+import { signal } from '@preact/signals'
+
+export const ideReplayUntilMs = signal<number | null>(null)
+
+export function setIdeReplayUntilMs(value: number | null): void {
+  const next = value === null || !Number.isFinite(value) ? null : value
+  if (ideReplayUntilMs.value === next) return
+  ideReplayUntilMs.value = next
+}

--- a/dashboard/src/components/ide/keeper-trace-store.test.ts
+++ b/dashboard/src/components/ide/keeper-trace-store.test.ts
@@ -3,6 +3,7 @@ import {
   COALESCE_WINDOW_MS,
   RETENTION_MS,
   clearTraces,
+  filterTraceEventsByReplay,
   keeperTraceState,
   pushTrace,
   tracesByKeeper,
@@ -20,6 +21,30 @@ afterEach(() => {
 describe('keeper-trace-store', () => {
   it('starts empty', () => {
     expect(keeperTraceState.value.events).toHaveLength(0)
+  })
+
+  it('filters trace events at the replay cursor', () => {
+    pushTrace({
+      id: 'old',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'anchored-thread',
+      threadId: 'old-thread',
+      line: 12,
+    })
+    pushTrace({
+      id: 'new',
+      tsMs: 2000,
+      keeperName: 'scholar',
+      source: 'anchored-thread',
+      threadId: 'new-thread',
+      line: 13,
+    })
+
+    expect(filterTraceEventsByReplay(keeperTraceState.value.events, null).map(e => e.id))
+      .toEqual(['old', 'new'])
+    expect(filterTraceEventsByReplay(keeperTraceState.value.events, 1500).map(e => e.id))
+      .toEqual(['old'])
   })
 
   it('appends a single event with count=1', () => {

--- a/dashboard/src/components/ide/keeper-trace-store.ts
+++ b/dashboard/src/components/ide/keeper-trace-store.ts
@@ -171,6 +171,14 @@ export function tracesBySource(source: KeeperTraceSource): ReadonlyArray<KeeperT
   return keeperTraceState.value.events.filter(e => e.source === source)
 }
 
+export function filterTraceEventsByReplay<T extends { readonly tsMs: number }>(
+  events: ReadonlyArray<T>,
+  untilMs: number | null,
+): ReadonlyArray<T> {
+  if (untilMs === null || !Number.isFinite(untilMs)) return events
+  return events.filter(event => Number.isFinite(event.tsMs) && event.tsMs <= untilMs)
+}
+
 function replaceAt(
   arr: ReadonlyArray<KeeperTraceEvent>,
   idx: number,

--- a/dashboard/src/components/ide/overlay-keeper-trace.test.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.test.ts
@@ -12,6 +12,7 @@ import {
   keeperTraceState,
   pushTrace,
 } from './keeper-trace-store'
+import { setIdeReplayUntilMs } from './ide-replay-state'
 
 const mountedContainers: HTMLElement[] = []
 
@@ -93,6 +94,7 @@ afterEach(() => {
   for (const container of mountedContainers.splice(0)) {
     render(null, container)
   }
+  setIdeReplayUntilMs(null)
   clearTraces()
 })
 
@@ -174,6 +176,18 @@ describe('OverlayKeeperTrace — render gating', () => {
     const region = container.querySelector('[role="region"][aria-label="Keeper trace overlay"]')
     expect(region).not.toBeNull()
     expect(region?.getAttribute('data-overlay')).toBe('keeper-trace')
+  })
+
+  it('projects buckets through the shared audit replay cursor', () => {
+    pushAnchored('old', 'scholar', 12, 1000, 'old-thread', 'runtime.ts')
+    pushAnchored('future', 'scholar', 99, 3000, 'future-thread', 'runtime.ts')
+    setIdeReplayUntilMs(1500)
+
+    const container = createContainer()
+    render(html`<${OverlayKeeperTrace} active=${true} />`, container)
+
+    expect(container.querySelector('[data-line="12"]')).not.toBeNull()
+    expect(container.querySelector('[data-line="99"]')).toBeNull()
   })
 })
 

--- a/dashboard/src/components/ide/overlay-keeper-trace.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.ts
@@ -1,10 +1,12 @@
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import {
+  filterTraceEventsByReplay,
   KeeperTraceEvent,
   KeeperTraceSource,
   keeperTraceState,
 } from './keeper-trace-store'
+import { ideReplayUntilMs } from './ide-replay-state'
 import {
   openIdeContextRouteLink,
   routeLinksForContext,
@@ -133,6 +135,12 @@ function useTraceEvents(): ReadonlyArray<KeeperTraceEvent> {
   return snapshot.events
 }
 
+function useReplayUntilMs(): number | null {
+  const [untilMs, setUntilMs] = useState(ideReplayUntilMs.value)
+  useEffect(() => ideReplayUntilMs.subscribe(value => setUntilMs(value)), [])
+  return untilMs
+}
+
 const OVERLAY_CONTAINER_STYLE = {
   display: 'grid',
   gap: 'var(--sp-1)',
@@ -196,11 +204,13 @@ function formatTooltip(event: KeeperTraceEvent): string {
 
 export function OverlayKeeperTrace({ active, keeperFilter }: OverlayKeeperTraceProps) {
   const events = useTraceEvents()
+  const replayUntilMs = useReplayUntilMs()
   if (!active) return null
 
+  const replayFiltered = filterTraceEventsByReplay(events, replayUntilMs)
   const filtered = keeperFilter
-    ? events.filter(e => e.keeperName === keeperFilter)
-    : events
+    ? replayFiltered.filter(e => e.keeperName === keeperFilter)
+    : replayFiltered
   if (filtered.length === 0) return null
 
   const buckets = bucketTraceEvents(filtered)


### PR DESCRIPTION
Summary:
- Add a shared IDE replay cursor so the conversation scrubber can drive other IDE surfaces.
- Filter keeper trace overlay, editor gutter dots, and current-file trace counts through the replay cursor.
- Restore board typecheck after #15260 by preserving active hearth options and using the workspace board route.

Validation:
- pnpm exec eslint on touched board and IDE files
- pnpm exec vitest run focused IDE plus board tests: 6 files, 89 tests
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD~2..HEAD