### PR TITLE
fix(dashboard): hydrate startup from bootstrap

### DIFF
--- a/dashboard/src/api/dashboard-hot.ts
+++ b/dashboard/src/api/dashboard-hot.ts
@@ -1,5 +1,6 @@
 import { get, NAMESPACE_TRUTH_GET_TIMEOUT_MS } from './core'
 import type {
+  DashboardBootstrapResponse,
   DashboardNamespaceTruthResponse,
   DashboardShellResponse,
 } from '../types'
@@ -15,6 +16,10 @@ type DashboardShellRequestOptions = AbortableRequestOptions & {
 export function fetchDashboardShell(opts?: DashboardShellRequestOptions): Promise<DashboardShellResponse> {
   const qs = opts?.light ? '?light=true' : ''
   return get(`/api/v1/dashboard/shell${qs}`, { signal: opts?.signal })
+}
+
+export function fetchDashboardBootstrap(opts?: AbortableRequestOptions): Promise<DashboardBootstrapResponse> {
+  return get('/api/v1/dashboard/bootstrap', { signal: opts?.signal })
 }
 
 export function fetchDashboardNamespaceTruth(

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -113,6 +113,7 @@ export type {
   CascadeValidationStatus,
 } from './dashboard-cascade'
 export { reportToolHostFailure } from './tool-host-failure'
+export { fetchDashboardBootstrap } from './dashboard-hot'
 
 // --- Dashboard projections ---
 

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -49,8 +49,6 @@ import {
   boardHearthsError,
   subBoardOptions,
   subBoardOptionsLoading,
-  subBoardOptionsError,
-  loadSubBoardOptionsForPost,
   boardExcludeAutomation,
   boardLoading,
   boardLoadingMore,

--- a/dashboard/src/components/board/sub-board-surface.ts
+++ b/dashboard/src/components/board/sub-board-surface.ts
@@ -61,7 +61,7 @@ function SubBoardRow({ board, onEdit, onDelete, deleting }: SubBoardRowProps) {
             </span>
             <div class="min-w-0 cursor-pointer" onClick=${() => {
               boardHearthFilter.value = board.slug
-              navigate('board')
+              navigate('workspace', { section: 'board' })
             }}>
               <h3 class="truncate text-sm font-semibold text-[var(--color-fg-primary)] hover:underline">${board.name || board.slug}</h3>
               <div class="truncate font-mono text-2xs text-[var(--color-fg-muted)]">/${board.slug}</div>

--- a/dashboard/src/store-dashboard-bootstrap.test.ts
+++ b/dashboard/src/store-dashboard-bootstrap.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  fetchDashboardBootstrap: vi.fn(),
+  fetchDashboardShell: vi.fn(),
+  fetchDashboardExecution: vi.fn(),
+  fetchDashboardPlanning: vi.fn(),
+}))
+
+const toastMocks = vi.hoisted(() => ({
+  showToast: vi.fn(),
+}))
+
+vi.mock('./api/dashboard-hot', () => ({
+  fetchDashboardBootstrap: apiMocks.fetchDashboardBootstrap,
+  fetchDashboardShell: apiMocks.fetchDashboardShell,
+}))
+
+vi.mock('./api/dashboard', () => ({
+  fetchDashboardExecution: apiMocks.fetchDashboardExecution,
+  fetchDashboardPlanning: apiMocks.fetchDashboardPlanning,
+}))
+
+vi.mock('./sse', () => ({
+  journal: {
+    log: vi.fn(),
+  },
+}))
+
+vi.mock('./components/common/toast', () => ({
+  showToast: toastMocks.showToast,
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.resetModules()
+})
+
+describe('refreshDashboard bootstrap', () => {
+  it('hydrates startup dashboard slices from the bootstrap aggregator', async () => {
+    apiMocks.fetchDashboardBootstrap.mockResolvedValue({
+      served_at: '2026-05-14T06:00:00Z',
+      milestone: 1,
+      shell: {
+        generated_at: '2026-05-14T06:00:00Z',
+        status: { project: 'default' },
+        counts: { agents: 1, tasks: 2, keepers: 3, total_runtimes: 4 },
+        configured_keepers: 5,
+        providers: {},
+        meta_cognition: null,
+        auth: null,
+        config_resolution: null,
+        runtime_resolution: null,
+      },
+      execution: {
+        generated_at: '2026-05-14T06:00:00Z',
+        status: { project: 'default' },
+        agents: [],
+        tasks: [],
+        messages: [],
+        keepers: [],
+        execution_queue: [],
+        worker_support_briefs: [],
+        continuity_briefs: [],
+      },
+      planning: {
+        generated_at: '2026-05-14T06:00:01Z',
+        goals: [],
+        rollup: {},
+        coordination_fsm: null,
+      },
+      namespace_truth: {
+        generated_at: '2026-05-14T06:00:02Z',
+        root: {
+          status: { project: 'default', version: '2.200.0' },
+          counts: { agents: 1, tasks: 2, keepers: 3 },
+          configured_keepers: 5,
+          provenance: 'bootstrap',
+        },
+      },
+      goals: {
+        generated_at: '2026-05-14T06:00:03Z',
+        tree: [],
+        summary: { total_goals: 0 },
+      },
+    })
+
+    const store = await import('./store')
+    const namespaceStore = await import('./namespace-truth-store')
+    const goalTreeState = await import('./goal-tree-state')
+
+    await store.refreshDashboard({ force: true })
+
+    expect(apiMocks.fetchDashboardBootstrap).toHaveBeenCalledTimes(1)
+    expect(apiMocks.fetchDashboardShell).not.toHaveBeenCalled()
+    expect(apiMocks.fetchDashboardExecution).not.toHaveBeenCalled()
+    expect(store.shellCounts.value).toEqual({
+      agents: 1,
+      tasks: 2,
+      keepers: 3,
+      total_runtimes: 4,
+      configured_keepers: 5,
+    })
+    expect(store.executionLoaded.value).toBe(true)
+    expect(store.lastGoalsRefreshAt.value).toBe('2026-05-14T06:00:01Z')
+    expect(namespaceStore.namespaceTruth.value?.root.provenance).toBe('bootstrap')
+    expect(store.serverStatus.value?.version).toBe('2.200.0')
+    expect(goalTreeState.goalTreeData.value?.summary.total_goals).toBe(0)
+  })
+
+  it('falls back to legacy shell and execution fetches when a required bootstrap slice is unavailable', async () => {
+    apiMocks.fetchDashboardBootstrap.mockResolvedValue({
+      served_at: '2026-05-14T06:00:00Z',
+      milestone: 1,
+      shell: { error: 'slice_unavailable', slice: 'shell' },
+      execution: { error: 'slice_unavailable', slice: 'execution' },
+    })
+    apiMocks.fetchDashboardShell.mockResolvedValue({
+      generated_at: '2026-05-14T06:01:00Z',
+      status: { project: 'fallback' },
+      counts: { agents: 0, tasks: 1, keepers: 0 },
+      providers: {},
+      meta_cognition: null,
+      auth: null,
+      config_resolution: null,
+      runtime_resolution: null,
+    })
+    apiMocks.fetchDashboardExecution.mockResolvedValue({
+      generated_at: '2026-05-14T06:01:00Z',
+      status: { project: 'fallback' },
+      agents: [],
+      tasks: [],
+      messages: [],
+      keepers: [],
+      execution_queue: [],
+      worker_support_briefs: [],
+      continuity_briefs: [],
+    })
+
+    const store = await import('./store')
+
+    await store.refreshDashboard({ force: true })
+
+    expect(apiMocks.fetchDashboardBootstrap).toHaveBeenCalledTimes(1)
+    expect(apiMocks.fetchDashboardShell).toHaveBeenCalledWith({ light: false })
+    expect(apiMocks.fetchDashboardExecution).toHaveBeenCalledTimes(1)
+    expect(store.serverStatus.value?.project).toBe('fallback')
+    expect(store.executionLoaded.value).toBe(true)
+  })
+})

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -17,6 +17,8 @@ import type {
   DashboardExecutionWorkerSupportBrief,
   DashboardExecutionContinuityBrief,
   DashboardExecutionResponse,
+  DashboardBootstrapResponse,
+  DashboardBootstrapSliceError,
   DashboardMemoryResponse,
   DashboardPlanningResponse,
   DashboardConfigResolution,
@@ -30,7 +32,7 @@ import type {
   DashboardCoordinationFsmSnapshot,
   DashboardCoordinationFsmViolation,
 } from './types'
-import { fetchDashboardShell } from './api/dashboard-hot'
+import { fetchDashboardBootstrap, fetchDashboardShell } from './api/dashboard-hot'
 import { journal } from './sse'
 import { showToast } from './components/common/toast'
 import {
@@ -49,6 +51,9 @@ import { FetchScheduler } from './lib/fetch-scheduler'
 import { isRecord, asString, asNumber } from './components/common/normalize'
 import { setCanonicalDashboardActor } from './lib/dashboard-session-actor'
 import { timeBoardRequest } from './board-metrics'
+import { namespaceTruth, namespaceTruthError, namespaceTruthInitializing } from './namespace-truth-signals'
+import { normalizeNamespaceTruth } from './namespace-truth-normalizers'
+import { hydrateGoalTreeSnapshot } from './goal-tree-state'
 import {
   normalizeAgent, normalizeTask, normalizeMessage,
   normalizeExecutionQueueItem,
@@ -520,12 +525,58 @@ export function invalidateDashboardCache(): void {
   // Projection endpoints are intentionally fresh-first after the operator-console rewrite.
 }
 
+function bootstrapSliceError(slice: unknown): slice is DashboardBootstrapSliceError {
+  return isRecord(slice) && typeof slice.error === 'string'
+}
+
+async function refreshDashboardFallback(opts?: RefreshOptions): Promise<void> {
+  await Promise.all([refreshShell(opts), refreshExecution(opts)])
+}
+
+function hydrateDashboardBootstrap(data: DashboardBootstrapResponse): void {
+  if (!data.shell || bootstrapSliceError(data.shell)) {
+    throw new Error('dashboard bootstrap shell slice unavailable')
+  }
+  if (!data.execution || bootstrapSliceError(data.execution)) {
+    throw new Error('dashboard bootstrap execution slice unavailable')
+  }
+
+  hydrateShellSnapshot(data.shell, { light: true })
+  hydrateExecutionSnapshot(data.execution)
+
+  if (data.planning && !bootstrapSliceError(data.planning)) {
+    hydratePlanningSnapshot(data.planning)
+  }
+  if (data.namespace_truth && !bootstrapSliceError(data.namespace_truth)) {
+    const normalized = normalizeNamespaceTruth(data.namespace_truth)
+    namespaceTruth.value = normalized
+    namespaceTruthError.value = null
+    namespaceTruthInitializing.value = false
+    serverStatus.value = mergeServerStatus(
+      serverStatus.value,
+      normalized.root.status ?? null,
+    )
+  }
+  if (data.goals && !bootstrapSliceError(data.goals)) {
+    hydrateGoalTreeSnapshot(data.goals)
+  }
+}
+
 export async function refreshDashboard(opts?: RefreshOptions): Promise<void> {
   if (inflightDashboardRefresh) return inflightDashboardRefresh
   dashboardLoading.value = true
   inflightDashboardRefresh = (async () => {
     try {
-      await Promise.all([refreshShell(opts), refreshExecution(opts)])
+      executionLoading.value = true
+      executionError.value = null
+      try {
+        hydrateDashboardBootstrap(await fetchDashboardBootstrap())
+      } catch (bootstrapErr) {
+        console.warn('[Dashboard] bootstrap refresh failed, falling back:', bootstrapErr)
+        await refreshDashboardFallback(opts)
+      } finally {
+        executionLoading.value = false
+      }
     } catch (err) {
       console.warn('[Dashboard] refresh error:', err)
     } finally {

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -135,6 +135,24 @@ export interface DashboardShellResponse {
   runtime_resolution?: DashboardRuntimeResolution | null
 }
 
+export interface DashboardBootstrapSliceError {
+  error: string
+  slice?: string
+}
+
+export type DashboardBootstrapSlice<T> = T | DashboardBootstrapSliceError
+
+export interface DashboardBootstrapResponse {
+  served_at?: string
+  milestone?: number
+  shell?: DashboardBootstrapSlice<DashboardShellResponse>
+  execution?: DashboardBootstrapSlice<DashboardExecutionResponse>
+  planning?: DashboardBootstrapSlice<DashboardPlanningResponse>
+  namespace_truth?: DashboardBootstrapSlice<DashboardNamespaceTruthResponse>
+  goals?: DashboardBootstrapSlice<DashboardGoalsTreeResponse>
+  goal_loop_status?: DashboardBootstrapSlice<Record<string, unknown>>
+}
+
 export interface DashboardNamespaceTruthAttentionSummary {
   count: number
   bad_count: number


### PR DESCRIPTION
## Summary
- Hydrate the initial dashboard refresh from `/api/v1/dashboard/bootstrap` instead of fanning out to separate shell and execution requests.
- Apply bootstrap slices into shell, execution, planning, namespace truth, and goal tree stores, while falling back to the legacy shell/execution fetch path if required slices are unavailable.
- Fix existing dashboard typecheck blockers in the board surface: remove dead sub-board option imports and route sub-board clicks through the workspace board tab.

## Product impact
- Reduces cold-start dashboard request fan-out on operator consoles and reuses the server-side bootstrap aggregator that was already designed to avoid Executor_pool contention.
- Keeps degraded startup behavior safe: if the bootstrap route or a required slice fails, operators still get the existing shell/execution refresh behavior.
- Restores dashboard TypeScript health for this branch.

## Evidence
- `pnpm vitest run --config vitest.config.ts src/store-dashboard-bootstrap.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm typecheck`
- `git diff --cached --check`

## Review evidence
- New unit coverage verifies successful bootstrap hydration avoids legacy shell/execution calls.
- New unit coverage verifies required bootstrap slice failure falls back to legacy fetches.
- Board route/type fixes were included because they blocked `pnpm typecheck` before this PR could be validated.

## Linked issue
- Follow-up from Kimi dashboard performance improvement plan; no dedicated GitHub issue.
