### PR TITLE
fix(provider): split voice runtime overlay

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -107,6 +107,7 @@
   keeper_exec_status
   provider_tool_support
   provider_runtime_overlay
+  voice_runtime_overlay
   keeper_status_detail
   keeper_exec_persona
   keeper_model_labels

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -57,11 +57,6 @@ type telemetry_policy =
   ; runtime_reporting : reporting_policy
   }
 
-type voice_transport =
-  | Voice_openai_compat
-  | Voice_elevenlabs_direct
-  | Voice_mcp
-
 type adapter =
   { canonical_name : string
   ; runtime_kind : runtime_kind
@@ -75,33 +70,11 @@ type adapter =
                                        [Cascade_config] parser and Provider_registry-compatible
                                        model labels. This is the primary naming boundary between
                                        MASC routing and OAS provider configs. *)
-  ; default_voice : string option
-    (** Default TTS voice name. None = no voice assignment. *)
   ; endpoint_url : string option (** Base URL for the provider API. *)
   ; default_model_id : string option (** Default model ID for the provider. *)
   ; model_policy : model_policy
   ; tool_policy : tool_policy
   ; telemetry_policy : telemetry_policy
-  }
-
-type voice_adapter =
-  { canonical_name : string
-  ; transport : voice_transport
-  ; auth_mode : auth_mode
-  ; aliases : string list
-  }
-
-type voice_http_request =
-  { url : string
-  ; headers : (string * string) list
-  ; body_json : Yojson.Safe.t
-  }
-
-type voice_stt_request =
-  { url : string
-  ; headers : (string * string) list
-  ; form_fields : (string * string) list
-  ; file_field : string * string (** (field_name, file_path) *)
   }
 
 type gemini_direct_auth =
@@ -128,12 +101,6 @@ let string_of_auth_mode = function
   | Api_key env_name -> "api_key:" ^ env_name
   | Vertex_adc { project_env; location_env } ->
     "vertex_adc:" ^ project_env ^ ":" ^ location_env
-;;
-
-let string_of_voice_transport = function
-  | Voice_openai_compat -> "openai_compat"
-  | Voice_elevenlabs_direct -> "elevenlabs_direct"
-  | Voice_mcp -> "voice_mcp"
 ;;
 
 let normalize_label label = String.trim label |> String.lowercase_ascii
@@ -340,7 +307,6 @@ let legacy_direct_adapters =
     ; aliases = [ cn_llama; "llama.cpp"; "llamacpp" ]
     ; spawn_key = Some "llama"
     ; cascade_prefix = "llama"
-    ; default_voice = Some "Laura"
     ; endpoint_url = Some Env_config_runtime.Llama.server_url
     ; default_model_id =
         (let m = Env_config_runtime.Llama.default_model in
@@ -361,7 +327,6 @@ let legacy_direct_adapters =
     ; aliases = [ cn_ollama; "ollama-local" ]
     ; spawn_key = None
     ; cascade_prefix = "ollama"
-    ; default_voice = None
     ; endpoint_url = Some Env_config_runtime.Ollama.server_url
     ; default_model_id =
         (let m = Env_config_runtime.Ollama.default_model in
@@ -382,7 +347,6 @@ let legacy_direct_adapters =
     ; aliases = [ cn_claude; "claude-code"; "claude_code" ]
     ; spawn_key = Some "claude"
     ; cascade_prefix = "claude_code"
-    ; default_voice = Some "Sarah"
     ; endpoint_url = None
     ; default_model_id = Some "auto"
     ; model_policy =
@@ -411,7 +375,6 @@ let legacy_direct_adapters =
     ; aliases = [ cn_codex; "codex-cli"; "codex_cli" ]
     ; spawn_key = Some "codex"
     ; cascade_prefix = "codex_cli"
-    ; default_voice = Some "George"
     ; endpoint_url = None
     ; default_model_id = Some "auto"
     ; model_policy =
@@ -442,7 +405,6 @@ let legacy_direct_adapters =
     ; aliases = [ cn_gemini; "gemini-cli"; "gemini_cli" ]
     ; spawn_key = Some "gemini"
     ; cascade_prefix = "gemini_cli"
-    ; default_voice = Some "Roger"
     ; endpoint_url = None
     ; default_model_id = Some "auto"
     ; model_policy =
@@ -482,7 +444,6 @@ let legacy_direct_adapters =
     ; aliases = [ cn_kimi; "kimi-cli"; "kimi_cli" ]
     ; spawn_key = None
     ; cascade_prefix = "kimi_cli"
-    ; default_voice = None
     ; endpoint_url = None
     ; default_model_id = Some "auto"
     ; model_policy =
@@ -507,7 +468,6 @@ let legacy_direct_adapters =
     ; aliases = [ cn_claude_api; "anthropic" ]
     ; spawn_key = None
     ; cascade_prefix = "claude"
-    ; default_voice = Some "Sarah"
     ; endpoint_url = Some (anthropic_api_url ())
     ; default_model_id = Some "auto"
     ; model_policy =
@@ -526,7 +486,6 @@ let legacy_direct_adapters =
     ; aliases = [ cn_codex_api; "openai" ]
     ; spawn_key = None
     ; cascade_prefix = "openai"
-    ; default_voice = Some "George"
     ; endpoint_url = Some (openai_api_url ())
     ; default_model_id = Some "auto"
     ; model_policy =
@@ -549,7 +508,6 @@ let legacy_direct_adapters =
     ; aliases = [ cn_gemini_api; "google" ]
     ; spawn_key = None
     ; cascade_prefix = "gemini"
-    ; default_voice = Some "Roger"
     ; endpoint_url = None
     ; (* Resolved dynamically for Gemini *)
       default_model_id = Some "auto"
@@ -569,7 +527,6 @@ let legacy_direct_adapters =
     ; aliases = [ cn_kimi_api; "moonshot" ]
     ; spawn_key = None
     ; cascade_prefix = "kimi"
-    ; default_voice = None
     ; endpoint_url = Some (kimi_api_url ())
     ; default_model_id = Some "auto"
     ; model_policy =
@@ -588,7 +545,6 @@ let legacy_direct_adapters =
     ; aliases = [ cn_kimi_coding; "kimi_coding" ]
     ; spawn_key = None
     ; cascade_prefix = "kimi_coding"
-    ; default_voice = None
     ; endpoint_url = Some (kimi_coding_api_url ())
     ; default_model_id = Some "auto"
     ; model_policy =
@@ -607,7 +563,6 @@ let legacy_direct_adapters =
     ; aliases = [ cn_glm; "glm"; "glm_cloud"; "zai" ]
     ; spawn_key = None
     ; cascade_prefix = "glm"
-    ; default_voice = None
     ; endpoint_url = Some (glm_api_url ())
     ; default_model_id = Some "auto"
     ; model_policy =
@@ -626,7 +581,6 @@ let legacy_direct_adapters =
     ; aliases = [ cn_glm_coding_plan; "glm-coding" ]
     ; spawn_key = None
     ; cascade_prefix = "glm-coding"
-    ; default_voice = None
     ; endpoint_url = Some (glm_coding_api_url ())
     ; default_model_id = Some "auto"
     ; model_policy =
@@ -645,7 +599,6 @@ let legacy_direct_adapters =
     ; aliases = [ cn_openrouter ]
     ; spawn_key = None
     ; cascade_prefix = "openrouter"
-    ; default_voice = None
     ; endpoint_url = Some (openrouter_api_url ())
     ; default_model_id = None
     ; model_policy =
@@ -738,7 +691,6 @@ let generic_adapter_of_binding (binding : Provider_runtime_overlay.binding) =
   ; aliases = Provider_runtime_overlay.labels binding
   ; spawn_key = spawn_key_of_binding binding
   ; cascade_prefix = Provider_runtime_overlay.id binding
-  ; default_voice = None
   ; endpoint_url = Provider_runtime_overlay.endpoint_url binding
   ; default_model_id
   ; model_policy =
@@ -846,35 +798,6 @@ let auto_models_for_cascade_prefix ?getenv provider_name =
     resolve_auto_models ?getenv adapter.model_policy
   | Some _ -> None
   | None -> None
-;;
-
-let voice_openai_compat_adapter =
-  { canonical_name = "voice-openai-compat"
-  ; transport = Voice_openai_compat
-  ; auth_mode = No_auth
-  ; aliases =
-      [ "voice-openai-compat"; "openai_compat"; "openai"; "railway-elevenlabs-proxy" ]
-  }
-;;
-
-let voice_elevenlabs_direct_adapter =
-  { canonical_name = "elevenlabs-direct"
-  ; transport = Voice_elevenlabs_direct
-  ; auth_mode = Api_key "ELEVENLABS_API_KEY"
-  ; aliases = [ "elevenlabs-direct"; "elevenlabs"; "tts-elevenlabs" ]
-  }
-;;
-
-let voice_mcp_adapter =
-  { canonical_name = "voice-mcp"
-  ; transport = Voice_mcp
-  ; auth_mode = No_auth
-  ; aliases = [ "voice-mcp"; "voice_mcp"; "mcp"; "local-voice-mcp" ]
-  }
-;;
-
-let voice_adapters =
-  [ voice_openai_compat_adapter; voice_elevenlabs_direct_adapter; voice_mcp_adapter ]
 ;;
 
 (** The "custom" provider prefix represents user-provided self-hosted
@@ -1000,351 +923,11 @@ let spawnable_canonical_names () =
     if a.spawn_key <> None then Some a.canonical_name else None)
 ;;
 
-(** All agent voices as (canonical_name, voice_name) pairs.
-    For backward compatibility with voice_bridge_core. *)
-let all_agent_voices () =
-  direct_adapters
-  |> List.filter_map (fun a ->
-    match a.default_voice with
-    | Some v -> Some (a.canonical_name, v)
-    | None -> None)
-;;
-
-let resolve_voice_adapter label =
-  let normalized = normalize_label label in
-  List.find_opt
-    (fun (adapter : voice_adapter) ->
-       List.exists (fun alias -> normalize_label alias = normalized) adapter.aliases)
-    voice_adapters
-;;
-
-let voice_adapter_labels (adapter : voice_adapter) =
-  adapter.canonical_name :: string_of_voice_transport adapter.transport :: adapter.aliases
-;;
-
-let voice_adapter_for_endpoint_kind = function
-  | Voice_config.Openai_compat -> voice_openai_compat_adapter
-  | Voice_config.Elevenlabs_direct -> voice_elevenlabs_direct_adapter
-  | Voice_config.Voice_mcp -> voice_mcp_adapter
-;;
-
-let voice_adapter_for_endpoint (endpoint : Voice_config.endpoint) =
-  match resolve_voice_adapter endpoint.id with
-  | Some adapter -> adapter
-  | None -> voice_adapter_for_endpoint_kind endpoint.kind
-;;
-
-let voice_endpoint_matches_provider_label label (endpoint : Voice_config.endpoint) =
-  let normalized = normalize_label label in
-  let adapter = voice_adapter_for_endpoint endpoint in
-  let candidates =
-    endpoint.id
-    :: Voice_config.string_of_endpoint_kind endpoint.kind
-    :: voice_adapter_labels adapter
-  in
-  List.exists
-    (fun candidate -> String.equal (normalize_label candidate) normalized)
-    candidates
-;;
-
-let select_voice_endpoints ?provider (endpoints : Voice_config.endpoint list) =
-  let endpoints =
-    List.filter (fun (endpoint : Voice_config.endpoint) -> endpoint.enabled) endpoints
-  in
-  match provider with
-  | Some label when String.trim label <> "" ->
-    List.filter (voice_endpoint_matches_provider_label label) endpoints
-  | _ -> endpoints
-;;
-
-let voice_auth_env_name ?endpoint_api_key_env (adapter : voice_adapter) =
-  match endpoint_api_key_env with
-  | Some raw ->
-    let trimmed = String.trim raw in
-    if trimmed <> ""
-    then Some trimmed
-    else (
-      match adapter.auth_mode with
-      | Api_key env_name -> Some env_name
-      | _ -> None)
-  | None ->
-    (match adapter.auth_mode with
-     | Api_key env_name -> Some env_name
-     | _ -> None)
-;;
-
-let voice_endpoint_auth_env_name (endpoint : Voice_config.endpoint) =
-  let adapter = voice_adapter_for_endpoint endpoint in
-  voice_auth_env_name ?endpoint_api_key_env:endpoint.api_key_env adapter
-;;
-
-let trim_opt = function
-  | Some raw ->
-    let trimmed = String.trim raw in
-    if trimmed = "" then None else Some trimmed
-  | None -> None
-;;
-
 let normalize_base_url value =
   let trimmed = String.trim value in
   if String.length trimmed > 1 && String.ends_with ~suffix:"/" trimmed
   then String.sub trimmed 0 (String.length trimmed - 1)
   else trimmed
-;;
-
-let legacy_voice_env_warning_emitted = Atomic.make false
-
-let warn_legacy_voice_env_once () =
-  if not (Atomic.get legacy_voice_env_warning_emitted)
-  then (
-    Atomic.set legacy_voice_env_warning_emitted true;
-    Log.Misc.warn
-      "VOICE_MCP_HOST/PORT fallback is deprecated; prefer .masc/voice_config.json \
-       session.endpoints or MASC_HTTP_* listener settings.")
-;;
-
-let legacy_voice_base_url_opt () =
-  let host_opt = Sys.getenv_opt "VOICE_MCP_HOST" |> trim_opt in
-  let port_opt = Sys.getenv_opt "VOICE_MCP_PORT" |> trim_opt in
-  match host_opt, port_opt with
-  | None, None -> None
-  | _ ->
-    warn_legacy_voice_env_once ();
-    let host = Option.value host_opt ~default:Env_config.Voice.default_host in
-    let port =
-      Option.value port_opt ~default:(string_of_int Env_config.Voice.default_port)
-    in
-    Some (Printf.sprintf "http://%s:%s" host port)
-;;
-
-let http_listener_env_explicit () =
-  Option.is_some (Sys.getenv_opt Env_config_core.http_base_url_env_key |> trim_opt)
-  || Option.is_some (Sys.getenv_opt Env_config_core.host_env_key |> trim_opt)
-  || Option.is_some (Sys.getenv_opt Env_config_core.http_port_env_key |> trim_opt)
-;;
-
-let default_voice_session_base_url () =
-  match Sys.getenv_opt Env_config_core.http_base_url_env_key |> trim_opt with
-  | Some base_url -> normalize_base_url base_url
-  | None ->
-    if http_listener_env_explicit ()
-    then
-      Printf.sprintf
-        "http://%s:%s"
-        (Env_config_core.masc_host ())
-        (Env_config_core.masc_http_port ())
-    else (
-      match legacy_voice_base_url_opt () with
-      | Some legacy_base_url -> normalize_base_url legacy_base_url
-      | None ->
-        Printf.sprintf
-          "http://%s:%s"
-          (Env_config_core.masc_host ())
-          (Env_config_core.masc_http_port ()))
-;;
-
-let compose_voice_endpoint_url ~base_url ~path =
-  let base_uri = Uri.of_string base_url in
-  let base_path = Uri.path base_uri in
-  let base_path =
-    if base_path = ""
-    then "/"
-    else if String.ends_with ~suffix:"/" base_path && String.length base_path > 1
-    then String.sub base_path 0 (String.length base_path - 1)
-    else base_path
-  in
-  let final_path =
-    if path = "/mcp"
-    then
-      if String.ends_with ~suffix:"/mcp" base_path
-      then base_path
-      else if base_path = "/"
-      then "/mcp"
-      else base_path ^ "/mcp"
-    else if path = "/health"
-    then
-      if String.ends_with ~suffix:"/health" base_path
-      then base_path
-      else if String.ends_with ~suffix:"/mcp" base_path
-      then String.sub base_path 0 (String.length base_path - 4) ^ "/health"
-      else if base_path = "/"
-      then "/health"
-      else base_path ^ "/health"
-    else if base_path = "/"
-    then path
-    else base_path ^ path
-  in
-  Uri.with_path base_uri final_path |> Uri.to_string
-;;
-
-let default_voice_session_url ~path =
-  compose_voice_endpoint_url ~base_url:(default_voice_session_base_url ()) ~path
-;;
-
-let voice_session_endpoint_result (config : Voice_config.t) =
-  match Voice_config.select_endpoint config.session.endpoints with
-  | Some endpoint ->
-    let adapter = voice_adapter_for_endpoint endpoint in
-    if adapter.transport = Voice_mcp
-    then Ok endpoint
-    else Error (Printf.sprintf "session endpoint %s must use kind=voice_mcp" endpoint.id)
-  | None -> Error "no configured session endpoint"
-;;
-
-let voice_session_mcp_url_of_endpoint (endpoint : Voice_config.endpoint) =
-  let adapter = voice_adapter_for_endpoint endpoint in
-  if adapter.transport <> Voice_mcp
-  then
-    Error (Printf.sprintf "session endpoint %s must use voice_mcp transport" endpoint.id)
-  else (
-    match endpoint.mcp_url with
-    | Some url -> Ok url
-    | None ->
-      (match endpoint.base_url with
-       | Some base_url -> Ok (compose_voice_endpoint_url ~base_url ~path:"/mcp")
-       | None -> Ok (default_voice_session_url ~path:"/mcp")))
-;;
-
-let voice_session_health_url_of_endpoint (endpoint : Voice_config.endpoint) =
-  let adapter = voice_adapter_for_endpoint endpoint in
-  if adapter.transport <> Voice_mcp
-  then
-    Error (Printf.sprintf "session endpoint %s must use voice_mcp transport" endpoint.id)
-  else (
-    match endpoint.health_url with
-    | Some url -> Ok url
-    | None ->
-      (match endpoint.base_url with
-       | Some base_url -> Ok (compose_voice_endpoint_url ~base_url ~path:"/health")
-       | None -> Ok (default_voice_session_url ~path:"/health")))
-;;
-
-let voice_transport_supports_http_tts (adapter : voice_adapter) =
-  match adapter.transport with
-  | Voice_openai_compat | Voice_elevenlabs_direct -> true
-  | Voice_mcp -> false
-;;
-
-let voice_endpoint_supports_http_tts (endpoint : Voice_config.endpoint) =
-  voice_adapter_for_endpoint endpoint |> voice_transport_supports_http_tts
-;;
-
-(** ElevenLabs base URL — SSOT is [Voice_config.default_elevenlabs_base_url]. *)
-let default_elevenlabs_base_url = Voice_config.default_elevenlabs_base_url
-
-let voice_endpoint_base_url (endpoint : Voice_config.endpoint) =
-  match voice_adapter_for_endpoint endpoint with
-  | { transport = Voice_elevenlabs_direct; _ } ->
-    (match endpoint.base_url with
-     | Some value -> Some (normalize_base_url value)
-     | None -> Some default_elevenlabs_base_url)
-  | _ -> Option.map normalize_base_url endpoint.base_url
-;;
-
-let elevenlabs_voice_id voice =
-  match String.trim voice with
-  | "Sarah" -> "EXAVITQu4vr4xnSDxMaL"
-  | "Roger" -> "CwhRBWXzGAHq8TQ4Fs17"
-  | "George" -> "JBFqnCBsd6RMkjVDRZzb"
-  | "Laura" -> "FGY2WhTYpPnrIDTdsKH5"
-  | "" -> "21m00Tcm4TlvDq8ikWAM"
-  | value -> value
-;;
-
-let voice_http_request_for_tts
-      (endpoint : Voice_config.endpoint)
-      ~api_key
-      ~message
-      ~voice
-      ~model
-      ~(tuning : Voice_config.voice_tuning)
-  =
-  let adapter = voice_adapter_for_endpoint endpoint in
-  match voice_endpoint_base_url endpoint, adapter.transport with
-  | None, _ ->
-    Error (Printf.sprintf "voice config endpoint %s missing base_url" endpoint.id)
-  | Some _, Voice_mcp ->
-    Error
-      (Printf.sprintf
-         "voice config endpoint %s uses voice_mcp and cannot build HTTP TTS request"
-         endpoint.id)
-  | Some base_url, Voice_openai_compat ->
-    let headers =
-      [ "Content-Type", "application/json"; "Accept", "audio/mpeg" ]
-      @ if api_key = "" then [] else [ "Authorization", "Bearer " ^ api_key ]
-    in
-    let body_json =
-      `Assoc
-        [ "input", `String message
-        ; "voice", `String voice
-        ; "model", `String model
-        ; "response_format", `String "mp3"
-        ; ( "voice_settings"
-          , `Assoc
-              [ "stability", `Float tuning.stability
-              ; "similarity_boost", `Float tuning.similarity_boost
-              ; "style", `Float tuning.style
-              ] )
-        ]
-    in
-    Ok { url = base_url ^ "/audio/speech"; headers; body_json }
-  | Some base_url, Voice_elevenlabs_direct ->
-    let headers =
-      [ "xi-api-key", api_key
-      ; "Content-Type", "application/json"
-      ; "Accept", "audio/mpeg"
-      ]
-    in
-    let body_json =
-      `Assoc
-        [ "text", `String message
-        ; "model_id", `String model
-        ; ( "voice_settings"
-          , `Assoc
-              [ "stability", `Float tuning.stability
-              ; "similarity_boost", `Float tuning.similarity_boost
-              ; "style", `Float tuning.style
-              ] )
-        ]
-    in
-    Ok
-      { url = Printf.sprintf "%s/text-to-speech/%s" base_url (elevenlabs_voice_id voice)
-      ; headers
-      ; body_json
-      }
-;;
-
-let voice_stt_request_for_endpoint
-      (endpoint : Voice_config.endpoint)
-      ~api_key
-      ~audio_file
-      ~model
-  =
-  let adapter = voice_adapter_for_endpoint endpoint in
-  match voice_endpoint_base_url endpoint, adapter.transport with
-  | None, _ ->
-    Error (Printf.sprintf "voice config endpoint %s missing base_url" endpoint.id)
-  | Some _, Voice_mcp ->
-    Error
-      (Printf.sprintf
-         "voice config endpoint %s uses voice_mcp and cannot build HTTP STT request"
-         endpoint.id)
-  | Some base_url, Voice_openai_compat ->
-    let headers = if api_key = "" then [] else [ "Authorization", "Bearer " ^ api_key ] in
-    Ok
-      { url = base_url ^ "/audio/transcriptions"
-      ; headers
-      ; form_fields = [ "model", model ]
-      ; file_field = "file", audio_file
-      }
-  | Some base_url, Voice_elevenlabs_direct ->
-    let headers = [ "xi-api-key", api_key ] in
-    Ok
-      { url = base_url ^ "/speech-to-text"
-      ; headers
-      ; form_fields = [ "model_id", model ]
-      ; file_field = "file", audio_file
-      }
 ;;
 
 let default_cli_agent_name () = Env_config_runtime.Cli.default_agent

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -1,7 +1,8 @@
-(** Provider_adapter — provider registry, auth resolution, voice bridge,
-    and cascade label construction.
+(** Provider_adapter — provider registry, auth resolution, and cascade label
+    construction.
 
-    MASC owns local runtime policy, voice routing, and cascade labels.
+    MASC owns local runtime policy and cascade labels. Voice runtime
+    policy lives in [Voice_runtime_overlay].
     OAS owns provider identity and transport defaults through
     [Agent_sdk.Provider_runtime_binding]. Adding a new plain provider
     should normally happen in OAS; MASC only needs an explicit adapter
@@ -118,11 +119,6 @@ type telemetry_policy =
   ; runtime_reporting : reporting_policy
   }
 
-type voice_transport =
-  | Voice_openai_compat
-  | Voice_elevenlabs_direct
-  | Voice_mcp
-
 type adapter =
   { canonical_name : string
   ; runtime_kind : runtime_kind
@@ -130,32 +126,11 @@ type adapter =
   ; aliases : string list
   ; spawn_key : string option
   ; cascade_prefix : string
-  ; default_voice : string option
   ; endpoint_url : string option
   ; default_model_id : string option
   ; model_policy : model_policy
   ; tool_policy : tool_policy
   ; telemetry_policy : telemetry_policy
-  }
-
-type voice_adapter =
-  { canonical_name : string
-  ; transport : voice_transport
-  ; auth_mode : auth_mode
-  ; aliases : string list
-  }
-
-type voice_http_request =
-  { url : string
-  ; headers : (string * string) list
-  ; body_json : Yojson.Safe.t
-  }
-
-type voice_stt_request =
-  { url : string
-  ; headers : (string * string) list
-  ; form_fields : (string * string) list
-  ; file_field : string * string
   }
 
 type gemini_direct_auth =
@@ -197,15 +172,11 @@ val cn_custom : string
 
 val string_of_runtime_kind : runtime_kind -> string
 val string_of_auth_mode : auth_mode -> string
-val string_of_voice_transport : voice_transport -> string
 
 (** {1 Adapter Registry} *)
 
 (** All registered LLM provider/runtime adapters. *)
 val direct_adapters : adapter list
-
-(** All registered voice provider adapters. *)
-val voice_adapters : voice_adapter list
 
 (** {1 Label and Provider Resolution} *)
 
@@ -317,61 +288,6 @@ type timeout_bounds =
     inside the adapter boundary, not the keeper turn-driver. *)
 val timeout_bounds_of_kind :
   Llm_provider.Provider_config.provider_kind -> timeout_bounds
-
-(** {1 Voice Adapter Resolution} *)
-
-val resolve_voice_adapter : string -> voice_adapter option
-val voice_adapter_for_endpoint : Voice_config.endpoint -> voice_adapter
-val voice_adapter_for_endpoint_kind : Voice_config.endpoint_kind -> voice_adapter
-val voice_adapter_labels : voice_adapter -> string list
-val voice_endpoint_matches_provider_label : string -> Voice_config.endpoint -> bool
-
-val select_voice_endpoints
-  :  ?provider:string
-  -> Voice_config.endpoint list
-  -> Voice_config.endpoint list
-
-(** Resolve auth env var name for a voice adapter, with optional endpoint override. *)
-val voice_auth_env_name : ?endpoint_api_key_env:string -> voice_adapter -> string option
-
-val voice_endpoint_auth_env_name : Voice_config.endpoint -> string option
-val voice_transport_supports_http_tts : voice_adapter -> bool
-val voice_endpoint_supports_http_tts : Voice_config.endpoint -> bool
-
-(** All agent voices as [(canonical_name, voice_name)] pairs. *)
-val all_agent_voices : unit -> (string * string) list
-
-(** {1 Voice Session URLs} *)
-
-val default_voice_session_url : path:string -> string
-
-val voice_session_endpoint_result
-  :  Voice_config.t
-  -> (Voice_config.endpoint, string) result
-
-val voice_session_mcp_url_of_endpoint : Voice_config.endpoint -> (string, string) result
-
-val voice_session_health_url_of_endpoint
-  :  Voice_config.endpoint
-  -> (string, string) result
-
-(** {1 Voice HTTP Requests} *)
-
-val voice_http_request_for_tts
-  :  Voice_config.endpoint
-  -> api_key:string
-  -> message:string
-  -> voice:string
-  -> model:string
-  -> tuning:Voice_config.voice_tuning
-  -> (voice_http_request, string) result
-
-val voice_stt_request_for_endpoint
-  :  Voice_config.endpoint
-  -> api_key:string
-  -> audio_file:string
-  -> model:string
-  -> (voice_stt_request, string) result
 
 (** {1 Model Label Resolution} *)
 

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -29,8 +29,8 @@ let write_text path content = Fs_compat.save_file path content
 let read_file path = Fs_compat.load_file path
 
 let resolve_api_key endpoint =
-  let adapter = Provider_adapter.voice_adapter_for_endpoint endpoint in
-  match Provider_adapter.voice_endpoint_auth_env_name endpoint with
+  let adapter = Voice_runtime_overlay.adapter_for_endpoint endpoint in
+  match Voice_runtime_overlay.endpoint_auth_env_name endpoint with
   | Some env_name ->
     (match Sys.getenv_opt env_name with
      | Some value ->
@@ -128,7 +128,7 @@ let speak_via_http_tts_to_file endpoint ~agent_id ~message ~voice ~model ~output
   let* api_key = resolve_api_key endpoint in
   let tuning = tuning_for_agent agent_id in
   let* request =
-    Provider_adapter.voice_http_request_for_tts
+    Voice_runtime_overlay.http_request_for_tts
       endpoint
       ~api_key
       ~message
@@ -143,7 +143,7 @@ let speak_via_http_tts_to_file endpoint ~agent_id ~message ~voice ~model ~output
     ~output_file
 ;;
 
-let run_stt_multipart_request (req : Provider_adapter.voice_stt_request) =
+let run_stt_multipart_request (req : Voice_runtime_overlay.stt_request) =
   let header_args =
     List.concat_map
       (fun (key, value) -> [ "-H"; Printf.sprintf "%s: %s" key value ])
@@ -184,7 +184,7 @@ let run_stt_multipart_request (req : Provider_adapter.voice_stt_request) =
 let transcribe_via_http_stt endpoint ~audio_file ~model =
   let* api_key = resolve_api_key endpoint in
   let* request =
-    Provider_adapter.voice_stt_request_for_endpoint endpoint ~api_key ~audio_file ~model
+    Voice_runtime_overlay.stt_request_for_endpoint endpoint ~api_key ~audio_file ~model
   in
   run_stt_multipart_request request
 ;;
@@ -238,7 +238,7 @@ let transcribe_audio ~audio_file ?language_code () =
 let available_tts_endpoints ?provider () =
   match load_voice_config () with
   | Error _ -> []
-  | Ok config -> Provider_adapter.select_voice_endpoints ?provider config.tts.endpoints
+  | Ok config -> Voice_runtime_overlay.select_endpoints ?provider config.tts.endpoints
 ;;
 
 let public_config_json () =
@@ -303,8 +303,8 @@ let tts_preview_bytes_from_request_json json =
       in
       Error detail
     | endpoint :: rest ->
-      let adapter = Provider_adapter.voice_adapter_for_endpoint endpoint in
-      if not (Provider_adapter.voice_transport_supports_http_tts adapter)
+      let adapter = Voice_runtime_overlay.adapter_for_endpoint endpoint in
+      if not (Voice_runtime_overlay.transport_supports_http_tts adapter)
       then (
         let note = Printf.sprintf "%s: preview unsupported for voice_mcp" endpoint.id in
         try_endpoints (note :: attempted) rest)
@@ -498,7 +498,7 @@ let extract_mcp_result json =
 
 let call_voice_mcp_endpoint ~sw ~clock ~net ~endpoint ~tool_name ~arguments =
   let uri =
-    match Provider_adapter.voice_session_mcp_url_of_endpoint endpoint with
+    match Voice_runtime_overlay.session_mcp_url_of_endpoint endpoint with
     | Ok url -> Uri.of_string url
     | Error _ -> voice_mcp_uri ()
   in
@@ -544,9 +544,9 @@ let attempt_tts_endpoint
       ~priority
       endpoint
   =
-  let adapter = Provider_adapter.voice_adapter_for_endpoint endpoint in
+  let adapter = Voice_runtime_overlay.adapter_for_endpoint endpoint in
   match adapter.transport with
-  | Provider_adapter.Voice_openai_compat | Provider_adapter.Voice_elevenlabs_direct ->
+  | Voice_runtime_overlay.Openai_compat | Voice_runtime_overlay.Elevenlabs_direct ->
     let audio_file = make_audio_file ~agent_id in
     (match
        speak_via_http_tts_to_file
@@ -594,7 +594,7 @@ let attempt_tts_endpoint
        (try Sys.remove audio_file with
         | Sys_error _ -> ());
        Error error)
-  | Provider_adapter.Voice_mcp ->
+  | Voice_runtime_overlay.Voice_mcp ->
     let args =
       `Assoc
         [ "agent_id", `String agent_id
@@ -641,7 +641,7 @@ let cache_duration () =
 let session_endpoint_result () =
   match load_voice_config () with
   | Error message -> Error message
-  | Ok config -> Provider_adapter.voice_session_endpoint_result config
+  | Ok config -> Voice_runtime_overlay.session_endpoint_result config
 ;;
 
 let is_voice_server_available ~sw:_ ~clock ~net =
@@ -651,7 +651,7 @@ let is_voice_server_available ~sw:_ ~clock ~net =
     false
   | Ok endpoint ->
     let health_target =
-      match Provider_adapter.voice_session_health_url_of_endpoint endpoint with
+      match Voice_runtime_overlay.session_health_url_of_endpoint endpoint with
       | Ok url -> url
       | Error _ -> Uri.to_string (voice_health_uri ())
     in
@@ -670,7 +670,7 @@ let is_voice_server_available ~sw:_ ~clock ~net =
           Eio.Switch.run
           @@ fun inner_sw ->
           let uri =
-            match Provider_adapter.voice_session_health_url_of_endpoint endpoint with
+            match Voice_runtime_overlay.session_health_url_of_endpoint endpoint with
             | Ok url -> Uri.of_string url
             | Error _ -> voice_health_uri ()
           in
@@ -956,7 +956,7 @@ let health_check ~sw:_ ~clock:_ ~net () =
   | Error error -> Error error
   | Ok endpoint ->
     let uri =
-      match Provider_adapter.voice_session_health_url_of_endpoint endpoint with
+      match Voice_runtime_overlay.session_health_url_of_endpoint endpoint with
       | Ok url -> Uri.of_string url
       | Error _ -> voice_health_uri ()
     in

--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -46,9 +46,8 @@ let record_playback ~agent_id ~message =
   Atomic.set last_playback_ref
     (Some { agent_id; message_hash = Hashtbl.hash message; finished_at = Unix.gettimeofday () })
 
-(** Default agent voices from Provider_adapter registry (SSOT).
-    Hardcoded list removed — voices defined in Provider_adapter.direct_adapters. *)
-let default_agent_voices () = Provider_adapter.all_agent_voices ()
+(** Default agent voices from the voice runtime overlay. *)
+let default_agent_voices () = Voice_runtime_overlay.default_agent_voices ()
 
 let load_voice_config () = Voice_config.load ()
 
@@ -74,14 +73,14 @@ let local_playback_enabled_for_agent agent_id =
   | Error _ -> false
 
 let default_voice_uri path =
-  Uri.of_string (Provider_adapter.default_voice_session_url ~path)
+  Uri.of_string (Voice_runtime_overlay.default_session_url ~path)
 
 let voice_mcp_uri () =
   match load_voice_config () with
   | Ok config -> (
-      match Provider_adapter.voice_session_endpoint_result config with
+      match Voice_runtime_overlay.session_endpoint_result config with
       | Ok endpoint -> (
-          match Provider_adapter.voice_session_mcp_url_of_endpoint endpoint with
+          match Voice_runtime_overlay.session_mcp_url_of_endpoint endpoint with
           | Ok url -> Uri.of_string url
           | Error _ -> default_voice_uri "/mcp" )
       | Error _ -> default_voice_uri "/mcp")
@@ -90,9 +89,9 @@ let voice_mcp_uri () =
 let voice_health_uri () =
   match load_voice_config () with
   | Ok config -> (
-      match Provider_adapter.voice_session_endpoint_result config with
+      match Voice_runtime_overlay.session_endpoint_result config with
       | Ok endpoint -> (
-          match Provider_adapter.voice_session_health_url_of_endpoint endpoint with
+          match Voice_runtime_overlay.session_health_url_of_endpoint endpoint with
           | Ok url -> Uri.of_string url
           | Error _ -> default_voice_uri "/health" )
       | Error _ -> default_voice_uri "/health")

--- a/lib/voice/voice_bridge_core.mli
+++ b/lib/voice/voice_bridge_core.mli
@@ -32,8 +32,8 @@ val load_voice_config : unit -> (Voice_config.t, string) result
 (** Cached load of the voice configuration JSON. *)
 
 val default_agent_voices : unit -> (string * string) list
-(** [agent_id -> voice_id] pairs from the {!Provider_adapter}
-    registry, used as a fallback when the JSON config is missing. *)
+(** [agent_id -> voice_id] pairs from {!Voice_runtime_overlay}, used as a
+    fallback when the JSON config is missing. *)
 
 val agent_voices : unit -> (string * string) list
 (** Effective [agent_id -> voice_id] pairs from the loaded config,

--- a/lib/voice/voice_runtime_overlay.ml
+++ b/lib/voice/voice_runtime_overlay.ml
@@ -1,0 +1,411 @@
+(** Voice runtime overlay.
+
+    This module owns voice-only runtime resolution so the LLM
+    [Provider_adapter] boundary no longer needs to export TTS/STT/session
+    helpers. *)
+
+type transport =
+  | Openai_compat
+  | Elevenlabs_direct
+  | Voice_mcp
+
+type auth_mode =
+  | No_auth
+  | Api_key of string
+
+type adapter =
+  { canonical_name : string
+  ; transport : transport
+  ; auth_mode : auth_mode
+  ; aliases : string list
+  }
+
+type http_request =
+  { url : string
+  ; headers : (string * string) list
+  ; body_json : Yojson.Safe.t
+  }
+
+type stt_request =
+  { url : string
+  ; headers : (string * string) list
+  ; form_fields : (string * string) list
+  ; file_field : string * string
+  }
+
+let normalize_label label = String.trim label |> String.lowercase_ascii
+
+let string_of_transport = function
+  | Openai_compat -> "openai_compat"
+  | Elevenlabs_direct -> "elevenlabs_direct"
+  | Voice_mcp -> "voice_mcp"
+;;
+
+let openai_compat_adapter =
+  { canonical_name = "voice-openai-compat"
+  ; transport = Openai_compat
+  ; auth_mode = No_auth
+  ; aliases =
+      [ "voice-openai-compat"; "openai_compat"; "openai"; "railway-elevenlabs-proxy" ]
+  }
+;;
+
+let elevenlabs_direct_adapter =
+  { canonical_name = "elevenlabs-direct"
+  ; transport = Elevenlabs_direct
+  ; auth_mode = Api_key "ELEVENLABS_API_KEY"
+  ; aliases = [ "elevenlabs-direct"; "elevenlabs"; "tts-elevenlabs" ]
+  }
+;;
+
+let voice_mcp_adapter =
+  { canonical_name = "voice-mcp"
+  ; transport = Voice_mcp
+  ; auth_mode = No_auth
+  ; aliases = [ "voice-mcp"; "voice_mcp"; "mcp"; "local-voice-mcp" ]
+  }
+;;
+
+let adapters = [ openai_compat_adapter; elevenlabs_direct_adapter; voice_mcp_adapter ]
+
+let resolve_adapter label =
+  let normalized = normalize_label label in
+  List.find_opt
+    (fun (adapter : adapter) ->
+       List.exists (fun alias -> normalize_label alias = normalized) adapter.aliases)
+    adapters
+;;
+
+let adapter_labels (adapter : adapter) =
+  adapter.canonical_name :: string_of_transport adapter.transport :: adapter.aliases
+;;
+
+let adapter_for_endpoint_kind = function
+  | Voice_config.Openai_compat -> openai_compat_adapter
+  | Voice_config.Elevenlabs_direct -> elevenlabs_direct_adapter
+  | Voice_config.Voice_mcp -> voice_mcp_adapter
+;;
+
+let adapter_for_endpoint (endpoint : Voice_config.endpoint) =
+  match resolve_adapter endpoint.id with
+  | Some adapter -> adapter
+  | None -> adapter_for_endpoint_kind endpoint.kind
+;;
+
+let endpoint_matches_provider_label label (endpoint : Voice_config.endpoint) =
+  let normalized = normalize_label label in
+  let adapter = adapter_for_endpoint endpoint in
+  let candidates =
+    endpoint.id
+    :: Voice_config.string_of_endpoint_kind endpoint.kind
+    :: adapter_labels adapter
+  in
+  List.exists
+    (fun candidate -> String.equal (normalize_label candidate) normalized)
+    candidates
+;;
+
+let select_endpoints ?provider (endpoints : Voice_config.endpoint list) =
+  let endpoints =
+    List.filter (fun (endpoint : Voice_config.endpoint) -> endpoint.enabled) endpoints
+  in
+  match provider with
+  | Some label when String.trim label <> "" ->
+    List.filter (endpoint_matches_provider_label label) endpoints
+  | _ -> endpoints
+;;
+
+let auth_env_name ?endpoint_api_key_env (adapter : adapter) =
+  match endpoint_api_key_env with
+  | Some raw ->
+    let trimmed = String.trim raw in
+    if trimmed <> ""
+    then Some trimmed
+    else (
+      match adapter.auth_mode with
+      | Api_key env_name -> Some env_name
+      | No_auth -> None)
+  | None ->
+    (match adapter.auth_mode with
+     | Api_key env_name -> Some env_name
+     | No_auth -> None)
+;;
+
+let endpoint_auth_env_name (endpoint : Voice_config.endpoint) =
+  let adapter = adapter_for_endpoint endpoint in
+  auth_env_name ?endpoint_api_key_env:endpoint.api_key_env adapter
+;;
+
+let transport_supports_http_tts (adapter : adapter) =
+  match adapter.transport with
+  | Openai_compat | Elevenlabs_direct -> true
+  | Voice_mcp -> false
+;;
+
+let endpoint_supports_http_tts endpoint =
+  adapter_for_endpoint endpoint |> transport_supports_http_tts
+;;
+
+let default_agent_voices () =
+  [ "llama", "Laura"
+  ; "claude", "Sarah"
+  ; "codex", "George"
+  ; "gemini", "Roger"
+  ; "claude-api", "Sarah"
+  ; "codex-api", "George"
+  ; "gemini-api", "Roger"
+  ]
+;;
+
+let trim_opt = function
+  | Some raw ->
+    let trimmed = String.trim raw in
+    if trimmed = "" then None else Some trimmed
+  | None -> None
+;;
+
+let normalize_base_url value =
+  let trimmed = String.trim value in
+  if String.length trimmed > 1 && String.ends_with ~suffix:"/" trimmed
+  then String.sub trimmed 0 (String.length trimmed - 1)
+  else trimmed
+;;
+
+let legacy_voice_env_warning_emitted = Atomic.make false
+
+let warn_legacy_voice_env_once () =
+  if not (Atomic.get legacy_voice_env_warning_emitted)
+  then (
+    Atomic.set legacy_voice_env_warning_emitted true;
+    Log.Misc.warn
+      "VOICE_MCP_HOST/PORT fallback is deprecated; prefer .masc/voice_config.json \
+       session.endpoints or MASC_HTTP_* listener settings.")
+;;
+
+let legacy_voice_base_url_opt () =
+  let host_opt = Sys.getenv_opt "VOICE_MCP_HOST" |> trim_opt in
+  let port_opt = Sys.getenv_opt "VOICE_MCP_PORT" |> trim_opt in
+  match host_opt, port_opt with
+  | None, None -> None
+  | _ ->
+    warn_legacy_voice_env_once ();
+    let host = Option.value host_opt ~default:Env_config.Voice.default_host in
+    let port =
+      Option.value port_opt ~default:(string_of_int Env_config.Voice.default_port)
+    in
+    Some (Printf.sprintf "http://%s:%s" host port)
+;;
+
+let http_listener_env_explicit () =
+  Option.is_some (Sys.getenv_opt Env_config_core.http_base_url_env_key |> trim_opt)
+  || Option.is_some (Sys.getenv_opt Env_config_core.host_env_key |> trim_opt)
+  || Option.is_some (Sys.getenv_opt Env_config_core.http_port_env_key |> trim_opt)
+;;
+
+let default_session_base_url () =
+  match Sys.getenv_opt Env_config_core.http_base_url_env_key |> trim_opt with
+  | Some base_url -> normalize_base_url base_url
+  | None ->
+    if http_listener_env_explicit ()
+    then
+      Printf.sprintf
+        "http://%s:%s"
+        (Env_config_core.masc_host ())
+        (Env_config_core.masc_http_port ())
+    else (
+      match legacy_voice_base_url_opt () with
+      | Some legacy_base_url -> normalize_base_url legacy_base_url
+      | None ->
+        Printf.sprintf
+          "http://%s:%s"
+          (Env_config_core.masc_host ())
+          (Env_config_core.masc_http_port ()))
+;;
+
+let compose_endpoint_url ~base_url ~path =
+  let base_uri = Uri.of_string base_url in
+  let base_path = Uri.path base_uri in
+  let base_path =
+    if base_path = ""
+    then "/"
+    else if String.ends_with ~suffix:"/" base_path && String.length base_path > 1
+    then String.sub base_path 0 (String.length base_path - 1)
+    else base_path
+  in
+  let final_path =
+    if path = "/mcp"
+    then
+      if String.ends_with ~suffix:"/mcp" base_path
+      then base_path
+      else if base_path = "/"
+      then "/mcp"
+      else base_path ^ "/mcp"
+    else if path = "/health"
+    then
+      if String.ends_with ~suffix:"/health" base_path
+      then base_path
+      else if String.ends_with ~suffix:"/mcp" base_path
+      then String.sub base_path 0 (String.length base_path - 4) ^ "/health"
+      else if base_path = "/"
+      then "/health"
+      else base_path ^ "/health"
+    else if base_path = "/"
+    then path
+    else base_path ^ path
+  in
+  Uri.with_path base_uri final_path |> Uri.to_string
+;;
+
+let default_session_url ~path =
+  compose_endpoint_url ~base_url:(default_session_base_url ()) ~path
+;;
+
+let session_endpoint_result (config : Voice_config.t) =
+  match Voice_config.select_endpoint config.session.endpoints with
+  | Some endpoint ->
+    let adapter = adapter_for_endpoint endpoint in
+    if adapter.transport = Voice_mcp
+    then Ok endpoint
+    else Error (Printf.sprintf "session endpoint %s must use kind=voice_mcp" endpoint.id)
+  | None -> Error "no configured session endpoint"
+;;
+
+let session_mcp_url_of_endpoint (endpoint : Voice_config.endpoint) =
+  let adapter = adapter_for_endpoint endpoint in
+  if adapter.transport <> Voice_mcp
+  then
+    Error (Printf.sprintf "session endpoint %s must use voice_mcp transport" endpoint.id)
+  else (
+    match endpoint.mcp_url with
+    | Some url -> Ok url
+    | None ->
+      (match endpoint.base_url with
+       | Some base_url -> Ok (compose_endpoint_url ~base_url ~path:"/mcp")
+       | None -> Ok (default_session_url ~path:"/mcp")))
+;;
+
+let session_health_url_of_endpoint (endpoint : Voice_config.endpoint) =
+  let adapter = adapter_for_endpoint endpoint in
+  if adapter.transport <> Voice_mcp
+  then
+    Error (Printf.sprintf "session endpoint %s must use voice_mcp transport" endpoint.id)
+  else (
+    match endpoint.health_url with
+    | Some url -> Ok url
+    | None ->
+      (match endpoint.base_url with
+       | Some base_url -> Ok (compose_endpoint_url ~base_url ~path:"/health")
+       | None -> Ok (default_session_url ~path:"/health")))
+;;
+
+let default_elevenlabs_base_url = Voice_config.default_elevenlabs_base_url
+
+let endpoint_base_url (endpoint : Voice_config.endpoint) =
+  match adapter_for_endpoint endpoint with
+  | { transport = Elevenlabs_direct; _ } ->
+    (match endpoint.base_url with
+     | Some value -> Some (normalize_base_url value)
+     | None -> Some default_elevenlabs_base_url)
+  | _ -> Option.map normalize_base_url endpoint.base_url
+;;
+
+let elevenlabs_voice_id voice =
+  match String.trim voice with
+  | "Sarah" -> "EXAVITQu4vr4xnSDxMaL"
+  | "Roger" -> "CwhRBWXzGAHq8TQ4Fs17"
+  | "George" -> "JBFqnCBsd6RMkjVDRZzb"
+  | "Laura" -> "FGY2WhTYpPnrIDTdsKH5"
+  | "" -> "21m00Tcm4TlvDq8ikWAM"
+  | value -> value
+;;
+
+let http_request_for_tts
+      (endpoint : Voice_config.endpoint)
+      ~api_key
+      ~message
+      ~voice
+      ~model
+      ~(tuning : Voice_config.voice_tuning)
+  =
+  let adapter = adapter_for_endpoint endpoint in
+  match endpoint_base_url endpoint, adapter.transport with
+  | None, _ ->
+    Error (Printf.sprintf "voice config endpoint %s missing base_url" endpoint.id)
+  | Some _, Voice_mcp ->
+    Error
+      (Printf.sprintf
+         "voice config endpoint %s uses voice_mcp and cannot build HTTP TTS request"
+         endpoint.id)
+  | Some base_url, Openai_compat ->
+    let headers =
+      [ "Content-Type", "application/json"; "Accept", "audio/mpeg" ]
+      @ if api_key = "" then [] else [ "Authorization", "Bearer " ^ api_key ]
+    in
+    let body_json =
+      `Assoc
+        [ "input", `String message
+        ; "voice", `String voice
+        ; "model", `String model
+        ; "response_format", `String "mp3"
+        ; ( "voice_settings"
+          , `Assoc
+              [ "stability", `Float tuning.stability
+              ; "similarity_boost", `Float tuning.similarity_boost
+              ; "style", `Float tuning.style
+              ] )
+        ]
+    in
+    Ok { url = base_url ^ "/audio/speech"; headers; body_json }
+  | Some base_url, Elevenlabs_direct ->
+    let headers =
+      [ "xi-api-key", api_key
+      ; "Content-Type", "application/json"
+      ; "Accept", "audio/mpeg"
+      ]
+    in
+    let body_json =
+      `Assoc
+        [ "text", `String message
+        ; "model_id", `String model
+        ; ( "voice_settings"
+          , `Assoc
+              [ "stability", `Float tuning.stability
+              ; "similarity_boost", `Float tuning.similarity_boost
+              ; "style", `Float tuning.style
+              ] )
+        ]
+    in
+    Ok
+      { url = Printf.sprintf "%s/text-to-speech/%s" base_url (elevenlabs_voice_id voice)
+      ; headers
+      ; body_json
+      }
+;;
+
+let stt_request_for_endpoint (endpoint : Voice_config.endpoint) ~api_key ~audio_file ~model =
+  let adapter = adapter_for_endpoint endpoint in
+  match endpoint_base_url endpoint, adapter.transport with
+  | None, _ ->
+    Error (Printf.sprintf "voice config endpoint %s missing base_url" endpoint.id)
+  | Some _, Voice_mcp ->
+    Error
+      (Printf.sprintf
+         "voice config endpoint %s uses voice_mcp and cannot build HTTP STT request"
+         endpoint.id)
+  | Some base_url, Openai_compat ->
+    let headers = if api_key = "" then [] else [ "Authorization", "Bearer " ^ api_key ] in
+    Ok
+      { url = base_url ^ "/audio/transcriptions"
+      ; headers
+      ; form_fields = [ "model", model ]
+      ; file_field = "file", audio_file
+      }
+  | Some base_url, Elevenlabs_direct ->
+    let headers = [ "xi-api-key", api_key ] in
+    Ok
+      { url = base_url ^ "/speech-to-text"
+      ; headers
+      ; form_fields = [ "model_id", model ]
+      ; file_field = "file", audio_file
+      }
+;;

--- a/lib/voice/voice_runtime_overlay.mli
+++ b/lib/voice/voice_runtime_overlay.mli
@@ -1,0 +1,68 @@
+(** Voice runtime overlay.
+
+    Voice TTS/STT/session endpoint rules are local MASC runtime concerns. They
+    intentionally live outside [Provider_adapter], whose remaining boundary is
+    LLM provider routing and capability projection. *)
+
+type transport =
+  | Openai_compat
+  | Elevenlabs_direct
+  | Voice_mcp
+
+type auth_mode =
+  | No_auth
+  | Api_key of string
+
+type adapter =
+  { canonical_name : string
+  ; transport : transport
+  ; auth_mode : auth_mode
+  ; aliases : string list
+  }
+
+type http_request =
+  { url : string
+  ; headers : (string * string) list
+  ; body_json : Yojson.Safe.t
+  }
+
+type stt_request =
+  { url : string
+  ; headers : (string * string) list
+  ; form_fields : (string * string) list
+  ; file_field : string * string
+  }
+
+val string_of_transport : transport -> string
+val adapters : adapter list
+val resolve_adapter : string -> adapter option
+val adapter_for_endpoint : Voice_config.endpoint -> adapter
+val adapter_for_endpoint_kind : Voice_config.endpoint_kind -> adapter
+val adapter_labels : adapter -> string list
+val endpoint_matches_provider_label : string -> Voice_config.endpoint -> bool
+val select_endpoints : ?provider:string -> Voice_config.endpoint list -> Voice_config.endpoint list
+val auth_env_name : ?endpoint_api_key_env:string -> adapter -> string option
+val endpoint_auth_env_name : Voice_config.endpoint -> string option
+val transport_supports_http_tts : adapter -> bool
+val endpoint_supports_http_tts : Voice_config.endpoint -> bool
+val default_agent_voices : unit -> (string * string) list
+val default_session_url : path:string -> string
+val session_endpoint_result : Voice_config.t -> (Voice_config.endpoint, string) result
+val session_mcp_url_of_endpoint : Voice_config.endpoint -> (string, string) result
+val session_health_url_of_endpoint : Voice_config.endpoint -> (string, string) result
+
+val http_request_for_tts
+  :  Voice_config.endpoint
+  -> api_key:string
+  -> message:string
+  -> voice:string
+  -> model:string
+  -> tuning:Voice_config.voice_tuning
+  -> (http_request, string) result
+
+val stt_request_for_endpoint
+  :  Voice_config.endpoint
+  -> api_key:string
+  -> audio_file:string
+  -> model:string
+  -> (stt_request, string) result

--- a/test/dune
+++ b/test/dune
@@ -611,6 +611,7 @@
         test_bg_task_stub
         test_process_eio_detached
         test_provider_adapter
+        test_voice_runtime_overlay
         test_worker_container_coverage
         test_resilience
         test_common
@@ -830,6 +831,7 @@
         test_bg_task_stub
         test_process_eio_detached
         test_provider_adapter
+        test_voice_runtime_overlay
         test_worker_container_coverage
         test_resilience
         test_common

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -259,102 +259,6 @@ let test_default_model_override_label_result () =
       | Error msg -> fail msg))
 ;;
 
-let test_resolve_voice_aliases () =
-  let elevenlabs = Option.get (Adapter.resolve_voice_adapter "elevenlabs") in
-  check string "elevenlabs alias" "elevenlabs-direct" elevenlabs.canonical_name;
-  let openai_compat = Option.get (Adapter.resolve_voice_adapter "openai_compat") in
-  check string "openai compat alias" "voice-openai-compat" openai_compat.canonical_name
-;;
-
-let test_voice_auth_env_resolution () =
-  let elevenlabs = Option.get (Adapter.resolve_voice_adapter "elevenlabs-direct") in
-  check
-    (option string)
-    "elevenlabs auth env"
-    (Some "ELEVENLABS_API_KEY")
-    (Adapter.voice_auth_env_name elevenlabs);
-  let openai_compat = Option.get (Adapter.resolve_voice_adapter "voice-openai-compat") in
-  check
-    (option string)
-    "endpoint override auth env"
-    (Some "VOICE_PROXY_KEY")
-    (Adapter.voice_auth_env_name ~endpoint_api_key_env:"VOICE_PROXY_KEY" openai_compat)
-;;
-
-let test_stt_request_elevenlabs_direct () =
-  let endpoint : Masc_mcp.Voice_config.endpoint =
-    { id = "test-stt"
-    ; kind = Elevenlabs_direct
-    ; base_url = Some "https://api.elevenlabs.io/v1"
-    ; mcp_url = None
-    ; health_url = None
-    ; api_key_env = Some "ELEVENLABS_API_KEY"
-    ; enabled = true
-    ; timeout_seconds = Some 30.0
-    ; max_retries = Some 2
-    }
-  in
-  with_env "ELEVENLABS_API_KEY" (Some "test-key-123") (fun () ->
-    match
-      Adapter.voice_stt_request_for_endpoint
-        endpoint
-        ~api_key:"test-key-123"
-        ~audio_file:"/tmp/test.wav"
-        ~model:"scribe_v2"
-    with
-    | Ok req ->
-      check string "url" "https://api.elevenlabs.io/v1/speech-to-text" req.url;
-      check
-        bool
-        "has xi-api-key header"
-        true
-        (List.exists (fun (k, _) -> k = "xi-api-key") req.headers);
-      check
-        bool
-        "model_id in form_fields"
-        true
-        (List.exists (fun (k, v) -> k = "model_id" && v = "scribe_v2") req.form_fields);
-      let field_name, file_path = req.file_field in
-      check string "file field name" "file" field_name;
-      check string "file path" "/tmp/test.wav" file_path
-    | Error err -> fail (Printf.sprintf "expected Ok, got Error: %s" err))
-;;
-
-let test_stt_request_openai_compat () =
-  let endpoint : Masc_mcp.Voice_config.endpoint =
-    { id = "test-openai-stt"
-    ; kind = Openai_compat
-    ; base_url = Some "https://api.openai.com/v1"
-    ; mcp_url = None
-    ; health_url = None
-    ; api_key_env = Some "OPENAI_API_KEY"
-    ; enabled = true
-    ; timeout_seconds = Some 30.0
-    ; max_retries = Some 2
-    }
-  in
-  match
-    Adapter.voice_stt_request_for_endpoint
-      endpoint
-      ~api_key:"sk-test"
-      ~audio_file:"/tmp/test.wav"
-      ~model:"whisper-1"
-  with
-  | Ok req ->
-    check string "url" "https://api.openai.com/v1/audio/transcriptions" req.url;
-    check
-      bool
-      "has Authorization header"
-      true
-      (List.exists (fun (k, _) -> k = "Authorization") req.headers);
-    check
-      bool
-      "model in form_fields"
-      true
-      (List.exists (fun (k, v) -> k = "model" && v = "whisper-1") req.form_fields)
-  | Error err -> fail (Printf.sprintf "expected Ok, got Error: %s" err)
-;;
-
 let test_requires_discovery_llama () =
   check bool "llama requires discovery" true (Adapter.requires_discovery "llama");
   check bool "llamacpp requires discovery" true (Adapter.requires_discovery "llamacpp");
@@ -421,30 +325,6 @@ let test_default_local_fallback_label () =
      let slen = String.length label in
      let plen = String.length suffix in
      slen >= plen && String.sub label (slen - plen) plen = suffix)
-;;
-
-let test_stt_request_mcp_rejected () =
-  let endpoint : Masc_mcp.Voice_config.endpoint =
-    { id = "test-mcp-stt"
-    ; kind = Voice_mcp
-    ; base_url = None
-    ; mcp_url = Some "http://localhost:8936"
-    ; health_url = None
-    ; api_key_env = None
-    ; enabled = true
-    ; timeout_seconds = Some 5.0
-    ; max_retries = Some 1
-    }
-  in
-  match
-    Adapter.voice_stt_request_for_endpoint
-      endpoint
-      ~api_key:""
-      ~audio_file:"/tmp/test.wav"
-      ~model:"scribe_v2"
-  with
-  | Ok _ -> fail "expected Error for voice_mcp endpoint"
-  | Error _ -> ()
 ;;
 
 let test_auto_models_use_declared_policy () =
@@ -1144,8 +1024,6 @@ let () =
             "openai compat identity uses endpoint metadata"
             `Quick
             test_openai_compat_provider_identity_uses_endpoint_metadata
-        ; test_case "resolve voice aliases" `Quick test_resolve_voice_aliases
-        ; test_case "voice auth env resolution" `Quick test_voice_auth_env_resolution
         ; test_case
             "tool_policy_of_cascade_capabilities None is conservative"
             `Quick
@@ -1170,14 +1048,6 @@ let () =
             "default_local_fallback_label"
             `Quick
             test_default_local_fallback_label
-        ] )
-    ; ( "stt"
-      , [ test_case
-            "stt request elevenlabs direct"
-            `Quick
-            test_stt_request_elevenlabs_direct
-        ; test_case "stt request openai compat" `Quick test_stt_request_openai_compat
-        ; test_case "stt request mcp rejected" `Quick test_stt_request_mcp_rejected
         ] )
     ; ( "timeout_bounds_of_kind"
       , [ test_case

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -1,0 +1,172 @@
+open Alcotest
+module Voice = Masc_mcp.Voice_runtime_overlay
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+;;
+
+let test_resolve_voice_aliases () =
+  let elevenlabs = Option.get (Voice.resolve_adapter "elevenlabs") in
+  check string "elevenlabs alias" "elevenlabs-direct" elevenlabs.canonical_name;
+  let openai_compat = Option.get (Voice.resolve_adapter "openai_compat") in
+  check string "openai compat alias" "voice-openai-compat" openai_compat.canonical_name
+;;
+
+let test_voice_auth_env_resolution () =
+  let elevenlabs = Option.get (Voice.resolve_adapter "elevenlabs-direct") in
+  check
+    (option string)
+    "elevenlabs auth env"
+    (Some "ELEVENLABS_API_KEY")
+    (Voice.auth_env_name elevenlabs);
+  let openai_compat = Option.get (Voice.resolve_adapter "voice-openai-compat") in
+  check
+    (option string)
+    "endpoint override auth env"
+    (Some "VOICE_PROXY_KEY")
+    (Voice.auth_env_name ~endpoint_api_key_env:"VOICE_PROXY_KEY" openai_compat)
+;;
+
+let test_default_agent_voices_preserve_runtime_defaults () =
+  check
+    (list (pair string string))
+    "agent voice defaults"
+    [ "llama", "Laura"
+    ; "claude", "Sarah"
+    ; "codex", "George"
+    ; "gemini", "Roger"
+    ; "claude-api", "Sarah"
+    ; "codex-api", "George"
+    ; "gemini-api", "Roger"
+    ]
+    (Voice.default_agent_voices ())
+;;
+
+let test_stt_request_elevenlabs_direct () =
+  let endpoint : Masc_mcp.Voice_config.endpoint =
+    { id = "test-stt"
+    ; kind = Elevenlabs_direct
+    ; base_url = Some "https://api.elevenlabs.io/v1"
+    ; mcp_url = None
+    ; health_url = None
+    ; api_key_env = Some "ELEVENLABS_API_KEY"
+    ; enabled = true
+    ; timeout_seconds = Some 30.0
+    ; max_retries = Some 2
+    }
+  in
+  with_env "ELEVENLABS_API_KEY" (Some "test-key-123") (fun () ->
+    match
+      Voice.stt_request_for_endpoint
+        endpoint
+        ~api_key:"test-key-123"
+        ~audio_file:"/tmp/test.wav"
+        ~model:"scribe_v2"
+    with
+    | Ok req ->
+      check string "url" "https://api.elevenlabs.io/v1/speech-to-text" req.url;
+      check
+        bool
+        "has xi-api-key header"
+        true
+        (List.exists (fun (k, _) -> k = "xi-api-key") req.headers);
+      check
+        bool
+        "model_id in form_fields"
+        true
+        (List.exists (fun (k, v) -> k = "model_id" && v = "scribe_v2") req.form_fields);
+      let field_name, file_path = req.file_field in
+      check string "file field name" "file" field_name;
+      check string "file path" "/tmp/test.wav" file_path
+    | Error err -> fail (Printf.sprintf "expected Ok, got Error: %s" err))
+;;
+
+let test_stt_request_openai_compat () =
+  let endpoint : Masc_mcp.Voice_config.endpoint =
+    { id = "test-openai-stt"
+    ; kind = Openai_compat
+    ; base_url = Some "https://api.openai.com/v1"
+    ; mcp_url = None
+    ; health_url = None
+    ; api_key_env = Some "OPENAI_API_KEY"
+    ; enabled = true
+    ; timeout_seconds = Some 30.0
+    ; max_retries = Some 2
+    }
+  in
+  match
+    Voice.stt_request_for_endpoint
+      endpoint
+      ~api_key:"sk-test"
+      ~audio_file:"/tmp/test.wav"
+      ~model:"whisper-1"
+  with
+  | Ok req ->
+    check string "url" "https://api.openai.com/v1/audio/transcriptions" req.url;
+    check
+      bool
+      "has Authorization header"
+      true
+      (List.exists (fun (k, _) -> k = "Authorization") req.headers);
+    check
+      bool
+      "model in form_fields"
+      true
+      (List.exists (fun (k, v) -> k = "model" && v = "whisper-1") req.form_fields)
+  | Error err -> fail (Printf.sprintf "expected Ok, got Error: %s" err)
+;;
+
+let test_stt_request_mcp_rejected () =
+  let endpoint : Masc_mcp.Voice_config.endpoint =
+    { id = "test-mcp-stt"
+    ; kind = Voice_mcp
+    ; base_url = None
+    ; mcp_url = Some "http://localhost:8936"
+    ; health_url = None
+    ; api_key_env = None
+    ; enabled = true
+    ; timeout_seconds = Some 5.0
+    ; max_retries = Some 1
+    }
+  in
+  match
+    Voice.stt_request_for_endpoint
+      endpoint
+      ~api_key:""
+      ~audio_file:"/tmp/test.wav"
+      ~model:"scribe_v2"
+  with
+  | Ok _ -> fail "expected Error for voice_mcp endpoint"
+  | Error _ -> ()
+;;
+
+let () =
+  run
+    "voice_runtime_overlay"
+    [ ( "adapter"
+      , [ test_case "resolve voice aliases" `Quick test_resolve_voice_aliases
+        ; test_case "voice auth env resolution" `Quick test_voice_auth_env_resolution
+        ; test_case
+            "default agent voices preserve runtime defaults"
+            `Quick
+            test_default_agent_voices_preserve_runtime_defaults
+        ] )
+    ; ( "stt"
+      , [ test_case
+            "stt request elevenlabs direct"
+            `Quick
+            test_stt_request_elevenlabs_direct
+        ; test_case "stt request openai compat" `Quick test_stt_request_openai_compat
+        ; test_case "stt request mcp rejected" `Quick test_stt_request_mcp_rejected
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- Move voice-only adapter/auth/session/TTS/STT projection out of `Provider_adapter` into `Voice_runtime_overlay`.
- Route `Voice_bridge` and `Voice_bridge_core` through the voice overlay.
- Remove voice fields and voice tests from the LLM provider adapter surface, with dedicated voice overlay coverage.

## Validation

- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_provider_adapter.exe test/test_voice_runtime_overlay.exe`
- `./_build/default/test/test_provider_adapter.exe` - 49 tests
- `./_build/default/test/test_voice_runtime_overlay.exe` - 6 tests
- `ocamlformat --check lib/voice/voice_runtime_overlay.mli lib/voice/voice_runtime_overlay.ml lib/voice/voice_bridge_core.mli lib/voice/voice_bridge_core.ml lib/voice/voice_bridge.ml lib/provider_adapter.mli lib/provider_adapter.ml test/test_provider_adapter.ml test/test_voice_runtime_overlay.ml`
- `git diff --check origin/main...HEAD`
- `bash scripts/lint/provider-adapter-removal-ratchet.sh --print` - callers 42/44, exports 97/120

## Notes

- Local pin repair refused to downgrade the shared `agent_sdk` floor from `0.193.12` to this branchs recorded pin floor, so the focused build used the currently installed newer `agent_sdk` with `MASC_SKIP_PIN_CHECK=1`.
