### PR TITLE
feat(tool-descriptor): typed behavior_contract on tool_spec (#15257 C-axis)

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -65,6 +65,7 @@ let masc_config_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -91,6 +92,7 @@ let masc_code_read_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -107,6 +109,7 @@ let masc_tool_help_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -132,6 +135,7 @@ let masc_dashboard_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -148,6 +152,7 @@ let masc_gc_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -171,6 +176,7 @@ let masc_web_search_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -194,6 +200,7 @@ let masc_web_fetch_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -215,6 +222,7 @@ let masc_tool_admin_snapshot_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -231,6 +239,7 @@ let masc_tool_stats_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -240,6 +249,7 @@ let masc_cleanup_zombies_spec : tool_spec =
       "Remove zombie agents (no heartbeat for 5+ min) and release their file locks."
   ; parameters = []
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -267,6 +277,7 @@ let masc_webrtc_offer_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -294,6 +305,7 @@ let masc_webrtc_answer_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -342,6 +354,7 @@ let masc_tool_admin_update_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -359,6 +372,7 @@ let masc_pause_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -369,6 +383,7 @@ let masc_resume_spec : tool_spec =
        Broadcasts notification to all agents."
   ; parameters = []
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -389,6 +404,7 @@ let masc_plan_init_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -411,6 +427,7 @@ let masc_plan_update_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -429,6 +446,7 @@ let masc_plan_get_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -446,6 +464,7 @@ let masc_plan_set_task_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -457,6 +476,7 @@ let masc_plan_get_task_spec : tool_spec =
        masc_plan_set_task. Auto-cleared on masc_leave."
   ; parameters = []
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -469,6 +489,7 @@ let masc_plan_clear_task_spec : tool_spec =
        on masc_leave."
   ; parameters = []
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -490,6 +511,7 @@ let masc_note_add_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -513,6 +535,7 @@ let masc_deliver_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -529,6 +552,7 @@ let masc_approval_pending_spec : tool_spec =
        admin-only detail/resolve path."
   ; parameters = []
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -548,6 +572,7 @@ let masc_approval_get_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -585,6 +610,7 @@ let masc_spawn_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -612,6 +638,7 @@ let masc_start_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -635,6 +662,7 @@ let masc_join_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -653,15 +681,14 @@ let masc_leave_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
 let masc_broadcast_spec : tool_spec =
   { name = "masc_broadcast"
   ; description =
-      "Send a message visible to ALL agents via SSE push. Use for: status updates \
-       ('Starting task X'), help requests ('@gemini can you review this?'), \
-       completions. Use @agent_name to ping specific agent."
+      "Send a message visible to ALL agents via SSE push."
   ; parameters =
       [ { p_name = "agent_name"
         ; p_type = T_string { enum = None; default = None }
@@ -675,6 +702,12 @@ let masc_broadcast_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract =
+      [ Precede_with [ "masc_status" ]
+      ; Hint Mention_specific_agent
+      ; Hint Update_status
+      ; Hint Help_request
+      ]
   }
 ;;
 
@@ -698,6 +731,7 @@ let masc_messages_spec : tool_spec =
         }
       ]
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -711,6 +745,7 @@ let masc_who_spec : tool_spec =
        Use capabilities to find the right agent for @mentions."
   ; parameters = []
   ; additional_properties = false
+  ; behavior_contract = []
   }
 ;;
 
@@ -850,10 +885,37 @@ let emit_required buf params =
     Buffer.add_string buf "]);\n"
 ;;
 
+(* Issue #15257 C축 — typed behavior rules를 description 본문 자연어로 inline.
+   Claude Code BashTool/prompt.ts 패턴과 동일 (행동 규칙은 description에).
+   exhaustive match라 새 variant 추가 시 컴파일러가 prose 표현도 강제. *)
+let format_behavior_rule = function
+  | Precede_with [ t ] ->
+    Printf.sprintf "Call `%s` first to verify state before invoking this tool." t
+  | Precede_with tools ->
+    let names = String.concat ", " (List.map (Printf.sprintf "`%s`") tools) in
+    Printf.sprintf "Call one of %s first to verify state." names
+  | Hint Mention_specific_agent ->
+    "Use `@agent_name` syntax to ping a specific agent."
+  | Hint Update_status ->
+    "Use for status updates (e.g. starting/done/blocker)."
+  | Hint Help_request ->
+    "Use to request help or review from another agent."
+;;
+
+let format_behavior_contract = function
+  | [] -> ""
+  | rules ->
+    let bullets = List.map (Printf.sprintf "- %s") (List.map format_behavior_rule rules) in
+    "\n\nUsage rules:\n" ^ String.concat "\n" bullets
+;;
+
 let emit_tool_schema buf spec =
   Buffer.add_string buf "  {\n";
   buf_addf buf "    name = %S;\n" spec.name;
-  buf_addf buf "    description = %S;\n" spec.description;
+  buf_addf
+    buf
+    "    description = %S;\n"
+    (spec.description ^ format_behavior_contract spec.behavior_contract);
   Buffer.add_string buf "    input_schema = `Assoc [\n";
   Buffer.add_string buf "      (\"type\", `String \"object\");\n";
   (match spec.parameters with

--- a/lib/tool_schemas_specs/tool_schemas_specs_types.ml
+++ b/lib/tool_schemas_specs/tool_schemas_specs_types.ml
@@ -29,9 +29,33 @@ type param =
   ; p_required : bool
   }
 
+(* Behavior contract — Issue #15257 C축 (description 표준 부재 해소).
+   Tool descriptor에 행동 규칙을 typed로 박아 작성자 직관 의존 제거.
+   Closed sum + non-option list로 모든 spec 작성자에게 명시적 표명 강제.
+
+   tool_name_ref rationale: 본 lib은 Tool_name sublib에 의존 불가
+   (역방향 cycle). boundary alias로 string 유지, 검증은 codegen 측의
+   Tool_name.of_string에서 수행 (JSON serialization과 동일 정신).
+
+   PoC는 2 variant (Precede_with, Hint)로 시작 — minimum + audit 원칙.
+   future variants (Avoid_after, Mutually_exclusive_with, ...)는 사용처
+   증거가 누적된 시점에 추가. *)
+
+type tool_name_ref = string
+
+type usage_hint =
+  | Mention_specific_agent
+  | Update_status
+  | Help_request
+
+type behavior_rule =
+  | Precede_with of tool_name_ref list
+  | Hint of usage_hint
+
 type tool_spec =
   { name : string
   ; description : string
   ; parameters : param list
   ; additional_properties : bool
+  ; behavior_contract : behavior_rule list
   }

--- a/lib/tool_schemas_specs/tool_schemas_specs_types.mli
+++ b/lib/tool_schemas_specs/tool_schemas_specs_types.mli
@@ -21,9 +21,23 @@ type param =
   ; p_required : bool
   }
 
+(** Behavior contract — Issue #15257 C축. 자세한 rationale은 .ml 참조. *)
+
+type tool_name_ref = string
+
+type usage_hint =
+  | Mention_specific_agent
+  | Update_status
+  | Help_request
+
+type behavior_rule =
+  | Precede_with of tool_name_ref list
+  | Hint of usage_hint
+
 type tool_spec =
   { name : string
   ; description : string
   ; parameters : param list
   ; additional_properties : bool
+  ; behavior_contract : behavior_rule list
   }


### PR DESCRIPTION
## Summary

Issue #15257 C축(description 표준 부재) root-fix. typed `behavior_rule` closed sum + `tool_spec.behavior_contract : behavior_rule list` (non-option) 도입, codegen이 자연어 prose로 description에 inline (Claude Code BashTool prompt 패턴).

## What

- `tool_schemas_specs_types`에 `behavior_rule` (`Precede_with | Hint`) + `usage_hint` (`Mention_specific_agent | Update_status | Help_request`) 추가
- `tool_spec.behavior_contract`: **non-option list** — 32 phase-6 spec 모두 명시적 표명 (`[]` 포함)
- `masc_broadcast` PoC: `Precede_with [masc_status]` + `Hint × 3` 적용
- `masc_broadcast.description`에서 **legacy 행동 규칙 prose 제거** (typed로 옮긴 내용이 prose에도 중복으로 남지 않게)
- `gen_tool_descriptors`에 `format_behavior_rule` + `format_behavior_contract` exhaustive formatter — 새 variant 추가 시 컴파일러가 prose 표현 강제

## Why

- *option 아님* → 모든 spec 작성자에게 명시적 표명 강제 (사용자 절대 원칙: transitional 거부)
- *closed sum* → 작성자 직관 의존 제거 (작성자별 격차 = Issue #15257 측정값 12%의 root cause)
- *description = 기능, behavior_contract = 규칙*: SSOT 분리 (Claude Code BashTool/prompt.ts 패턴)
- `tool_name_ref = string` boundary alias — 본 lib은 `Tool_name` sublib 의존 불가 (역방향 cycle, `project_keeper_sublib_extraction_analysis` 유사 패턴)

## Generated output (masc_broadcast)

Before (origin/main):
```
description = "Send a message visible to ALL agents via SSE push. Use for: status updates ('Starting task X'), help requests ('@gemini can you review this?'), completions. Use @agent_name to ping specific agent.";
```

After (this PR):
```
description = "Send a message visible to ALL agents via SSE push.

Usage rules:
- Call `masc_status` first to verify state before invoking this tool.
- Use `@agent_name` syntax to ping a specific agent.
- Use for status updates (e.g. starting/done/blocker).
- Use to request help or review from another agent.";
```

## Verified

- `dune build --root .` 전체 빌드 통과
- **156 tests PASS** across 7 schema/registration test files:
  - `test_tool_descriptors_gen` (39/39)
  - `test_tool_surface_ssot` (25/25)
  - `test_tool_registration_consistency` (14/14)
  - `test_tool_library_coverage` (18/18)
  - `test_tool_diversity` (9/9)
  - `test_tool_input_validation` (29/29)
  - `test_tool_prefilter` (22/22)
- 직접 `./_build/default/bin/gen_tool_descriptors.exe` 출력 확인

### Pre-existing failures (본 PR 책임 0)

- `test_keeper_masc_bridge` 3건 (`meta_json[1]`, `dispatch[1]`, `dispatch[2]`)
- `test_tools_coverage` 1건 (`schema_structure[3] unique_names`: expected 119, received 109)

`git stash` 후 `origin/main`에서 동일 test 실행 시 동일 4건 FAIL 확인 — *latent regression*. 별도 issue로 분리 (`reference_masc_mcp_ci_build_test_skips` 패턴).

## Out of scope (follow-up tracks)

- Pre-existing test regression 4건 — 별도 issue
- 나머지 31 spec에 `behavior_contract` 적용 — *evidence-based* codemod, 사용처 증거 누적 후
- `Avoid_after` 등 추가 variant — PoC 2 variant로 시작, audit 후 *증거 기반* 추가
- hand-written schema (gen 밖) → RFC-0057 후속 phase

## Status

- **Draft.** human-approved-ready 라벨 필요 (DraftAutoMergeGuard).
- ocamlformat-check는 advisory — style follow-up은 별도 (`style(): apply ocamlformat`).

## Related

- Issue #15257 (measurement + plan)
- RFC-0057 §9 phase ledger (이 PR을 phase 5 또는 신규 number로 카운트할지는 review 합의)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
