### PR TITLE
feat(ide): jump replay from keeper trace chips

### DIFF
--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -10,7 +10,7 @@ import { ideConversationThreadSnapshot } from './ide-context-bridge'
 import { lspDiagnosticSnapshot } from './ide-lsp-client'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
 import { clearTraces, pushTrace } from './keeper-trace-store'
-import { setIdeReplayUntilMs } from './ide-replay-state'
+import { ideReplayUntilMs, setIdeReplayUntilMs } from './ide-replay-state'
 
 describe('IdeEditor', () => {
   let container: HTMLDivElement
@@ -580,6 +580,7 @@ describe('IdeEditor', () => {
     })
     fireEvent.click(container.querySelector<HTMLButtonElement>('button.cm-trace-stack')!)
 
+    expect(ideReplayUntilMs.value).toBe(3000)
     expect(ideContextFocus.value).toMatchObject({
       file_path: 'runtime.ts',
       line: 2,

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -57,7 +57,7 @@ import {
   type IdeContextFocus,
 } from './ide-state'
 import { ideConversationThreadSnapshot } from './ide-context-bridge'
-import { ideReplayUntilMs } from './ide-replay-state'
+import { ideReplayUntilMs, setIdeReplayUntilMs } from './ide-replay-state'
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -401,6 +401,7 @@ function focusTraceLineContext(
   event: EditorKeeperTraceLineEvent,
   line: number,
 ): void {
+  setIdeReplayUntilMs(event.tsMs)
   const surface = traceLineFocusSurface(event)
   const label = traceLineFocusLabel(event)
   const sourceId = event.id ? `trace:${event.id}` : `trace:${event.source}:${line}:${event.tsMs}`

--- a/dashboard/src/components/ide/overlay-keeper-trace.test.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.test.ts
@@ -12,7 +12,8 @@ import {
   keeperTraceState,
   pushTrace,
 } from './keeper-trace-store'
-import { setIdeReplayUntilMs } from './ide-replay-state'
+import { ideReplayUntilMs, setIdeReplayUntilMs } from './ide-replay-state'
+import { ideContextFocus } from './ide-state'
 
 const mountedContainers: HTMLElement[] = []
 
@@ -87,6 +88,7 @@ type KeeperTraceEventForTest = Parameters<typeof pushTrace>[0]
 
 beforeEach(() => {
   clearTraces()
+  ideContextFocus.value = null
 })
 
 afterEach(() => {
@@ -95,6 +97,7 @@ afterEach(() => {
     render(null, container)
   }
   setIdeReplayUntilMs(null)
+  ideContextFocus.value = null
   clearTraces()
 })
 
@@ -232,7 +235,7 @@ describe('OverlayKeeperTrace — bucket render (RFC-0028 §5)', () => {
     render(html`<${OverlayKeeperTrace} active=${true} />`, container)
 
     const bucket = container.querySelector('[role="group"][data-keeper="scholar"][data-line="12"]')
-    const chips = bucket?.querySelectorAll('li[role="img"]')
+    const chips = bucket?.querySelectorAll('.ide-trace-chip')
     expect(chips?.length).toBe(TRACE_CHIP_CAP)
 
     const overflow = bucket?.querySelector('[data-overflow]')
@@ -248,7 +251,7 @@ describe('OverlayKeeperTrace — bucket render (RFC-0028 §5)', () => {
     const container = createContainer()
     render(html`<${OverlayKeeperTrace} active=${true} />`, container)
     const bucket = container.querySelector('[role="group"][data-keeper="scholar"]')
-    const chips = bucket?.querySelectorAll('li[role="img"]')
+    const chips = bucket?.querySelectorAll('.ide-trace-chip')
     expect(chips?.length).toBe(3)
     expect(bucket?.querySelector('[data-overflow]')).toBeNull()
   })
@@ -262,11 +265,11 @@ describe('OverlayKeeperTrace — bucket render (RFC-0028 §5)', () => {
     const container = createContainer()
     render(html`<${OverlayKeeperTrace} active=${true} />`, container)
     const bucket = container.querySelector('[role="group"][data-keeper="scholar"][data-line="no-line"]')
-    const chips = Array.from(bucket?.querySelectorAll('li[role="img"]') ?? [])
+    const chips = Array.from(bucket?.querySelectorAll('.ide-trace-chip') ?? [])
     const sources = chips.map(c => c.getAttribute('data-source'))
     expect(sources).toEqual(expect.arrayContaining(['anchored-thread', 'bdi-snapshot', 'decision-log']))
     const lineBucket = container.querySelector('[role="group"][data-keeper="scholar"][data-line="4"]')
-    expect(lineBucket?.querySelector('li[role="img"]')?.getAttribute('data-source')).toBe('activity-event')
+    expect(lineBucket?.querySelector('.ide-trace-chip')?.getAttribute('data-source')).toBe('activity-event')
   })
 
   it('chip aria-label includes source + line + count', () => {
@@ -275,11 +278,45 @@ describe('OverlayKeeperTrace — bucket render (RFC-0028 §5)', () => {
 
     const container = createContainer()
     render(html`<${OverlayKeeperTrace} active=${true} />`, container)
-    const chip = container.querySelector('li[role="img"]')
+    const chip = container.querySelector('.ide-trace-chip')
     // The single coalesced chip should have count 2.
     expect(chip?.getAttribute('aria-label')).toContain('thread')
     expect(chip?.getAttribute('aria-label')).toContain('L42')
     expect(chip?.getAttribute('aria-label')).toContain('×2')
+  })
+
+  it('clicking a trace chip jumps the shared replay cursor and focuses IDE context', () => {
+    pushActivity('a', 'scholar', 12, 2000, 'runtime.ts', {
+      eventId: 'evt-a',
+      goalId: 'goal-runtime',
+      taskId: 'task-runtime',
+      logId: 'turn-12',
+    })
+
+    const container = createContainer()
+    render(html`<${OverlayKeeperTrace} active=${true} />`, container)
+
+    const chip = container.querySelector<HTMLButtonElement>('.ide-trace-chip[data-event-id="a"]')
+    expect(chip).not.toBeNull()
+    fireEvent.click(chip!)
+
+    expect(ideReplayUntilMs.value).toBe(2000)
+    expect(ideContextFocus.value).toMatchObject({
+      file_path: 'runtime.ts',
+      line: 12,
+      surface: 'Goal',
+      label: 'Goal activity evt-a',
+      source_id: 'trace:a',
+      keeper_id: 'scholar',
+    })
+    expect(ideContextFocus.value?.route_links?.map(link => link.label)).toEqual([
+      'Code',
+      'Goal',
+      'Task',
+      'Log',
+      'Telemetry',
+      'Keeper',
+    ])
   })
 
   it('renders operational route links for enriched activity traces', () => {

--- a/dashboard/src/components/ide/overlay-keeper-trace.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.ts
@@ -6,13 +6,14 @@ import {
   KeeperTraceSource,
   keeperTraceState,
 } from './keeper-trace-store'
-import { ideReplayUntilMs } from './ide-replay-state'
+import { ideReplayUntilMs, setIdeReplayUntilMs } from './ide-replay-state'
 import {
   openIdeContextRouteLink,
   routeLinksForContext,
   type IdeContextRouteContext,
   type IdeContextRouteLink,
 } from './ide-context-lens'
+import { focusIdeContextAnchor } from './ide-state'
 
 /**
  * RFC-0028 PR-β: keeper-trace gutter chip overlay.
@@ -151,14 +152,20 @@ const STACK_STYLE = {
   display: 'inline-flex',
   alignItems: 'center',
   gap: '2px',
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
 } as const
 
 const CHIP_STYLE = {
   display: 'inline-block',
   width: '8px',
   height: '8px',
+  padding: 0,
   borderRadius: '50%',
   border: '1px solid var(--color-bg-surface)',
+  appearance: 'none',
+  cursor: 'pointer',
 } as const
 
 const OVERFLOW_STYLE = {
@@ -254,13 +261,23 @@ function BucketRow({ bucket }: { readonly bucket: TraceBucket }) {
       <ul role="list" aria-label=${`${bucket.keeperName} trace events`} style=${STACK_STYLE}>
         ${visible.map(event => html`
           <li
-            role="img"
+            role="listitem"
             data-source=${event.source}
             data-count=${event.count}
-            aria-label=${formatTooltip(event)}
-            title=${formatTooltip(event)}
-            style=${{ ...CHIP_STYLE, background: SOURCE_COLORS[event.source] }}
-          />
+            style=${{ display: 'inline-flex' }}
+          >
+            <button
+              type="button"
+              class="ide-trace-chip"
+              data-source=${event.source}
+              data-count=${event.count}
+              data-event-id=${event.id}
+              aria-label=${`${formatTooltip(event)}; jump replay to event`}
+              title=${formatTooltip(event)}
+              onClick=${() => selectTraceEvent(event)}
+              style=${{ ...CHIP_STYLE, background: SOURCE_COLORS[event.source] }}
+            />
+          </li>
         `)}
       </ul>
       ${overflow > 0
@@ -285,6 +302,21 @@ function BucketRow({ bucket }: { readonly bucket: TraceBucket }) {
       ` : null}
     </div>
   `
+}
+
+function selectTraceEvent(event: KeeperTraceEvent): void {
+  setIdeReplayUntilMs(event.tsMs)
+  const context = traceRouteContext(event)
+  if (!context.filePath) return
+  focusIdeContextAnchor({
+    file_path: context.filePath,
+    line: context.line,
+    surface: context.surface ?? SOURCE_LABELS[event.source],
+    label: context.label ?? formatTooltip(event),
+    source_id: context.sourceId ?? `trace:${event.id}`,
+    keeper_id: context.keeperId,
+    route_links: routeLinksForContext(context),
+  })
 }
 
 function traceRouteLinks(events: ReadonlyArray<KeeperTraceEvent>): ReadonlyArray<IdeContextRouteLink> {


### PR DESCRIPTION
Summary:
- Trace chip clicks set the shared audit replay cursor to the selected event timestamp.
- Overlay trace chips also focus the IDE context and preserve operational route links.
- CodeMirror keeper-trace gutter clicks now drive replay and context together.

Validation:
- pnpm exec eslint src/components/ide/overlay-keeper-trace.ts src/components/ide/overlay-keeper-trace.test.ts src/components/ide/ide-editor.ts src/components/ide/ide-editor.test.ts
- pnpm exec vitest run src/components/ide/overlay-keeper-trace.test.ts src/components/ide/ide-editor.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check