### PR TITLE
feat(ide): route run progress surface chips

### DIFF
--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -150,6 +150,22 @@ describe('IdeActivityPanel', () => {
       .map(node => node.textContent)
     expect(surfaces).toEqual(['Goal1', 'Task1', 'Board1', 'Comment1', 'PR1', 'Git1', 'Log1', 'Telemetry1'])
 
+    const surfaceLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-run-progress-surface-link')]
+    expect(surfaceLinks.map(link => link.textContent)).toEqual([
+      'Goal1',
+      'Task1',
+      'Board1',
+      'Comment1',
+      'PR1',
+      'Git1',
+      'Log1',
+      'Telemetry1',
+    ])
+    fireEvent.click(surfaceLinks.find(link => link.textContent === 'PR1')!)
+    expect(window.location.hash).toBe('#workspace?section=repositories&view=graph&pr=15000')
+    fireEvent.click(surfaceLinks.find(link => link.textContent === 'Telemetry1')!)
+    expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&session_id=sess-runtime&operation_id=op-runtime&worker_run_id=wr-runtime&q=turn-1')
+
     const activityRouteLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-activity-route-link')]
     expect(activityRouteLinks.map(link => link.textContent)).toEqual([
       'Code',
@@ -686,10 +702,62 @@ describe('IdeActivityPanel', () => {
       ['Log', 1],
       ['Telemetry', 3],
     ])
+    expect(summary.surfaceCounts.find(surface => surface.label === 'PR')?.routeLink).toMatchObject({
+      label: 'PR',
+      params: { section: 'repositories', view: 'graph', pr: '15000' },
+    })
+    expect(summary.surfaceCounts.find(surface => surface.label === 'Telemetry')?.routeLink).toMatchObject({
+      label: 'Telemetry',
+      params: { section: 'fleet-health', view: 'event-log', q: 'turn-1' },
+    })
     expect(summary.keeperCounts).toEqual([
       { keeper_id: 'sangsu', count: 2 },
       { keeper_id: 'analyst', count: 1 },
     ])
+  })
+
+  it('routes run progress surface chips to the latest matching event context', () => {
+    const summary = deriveIdeRunProgressSummary([
+      {
+        id: 'evt-old',
+        run_id: 'run-default',
+        keeper_id: 'analyst',
+        verb: 'noted' as const,
+        target: 'pr',
+        timestamp_ms: 100,
+        context: {
+          pr_id: '14999',
+          log_id: 'turn-old',
+        },
+      },
+      {
+        id: 'evt-latest',
+        run_id: 'run-default',
+        keeper_id: 'sangsu',
+        verb: 'noted' as const,
+        target: 'pr',
+        timestamp_ms: 200,
+        context: {
+          pr_id: '15000',
+          log_id: 'turn-latest',
+          session_id: 'sess-latest',
+        },
+      },
+    ], 'lib/runtime.ml')
+
+    expect(summary.surfaceCounts.find(surface => surface.label === 'PR')?.routeLink).toMatchObject({
+      label: 'PR',
+      params: { section: 'repositories', view: 'graph', pr: '15000' },
+    })
+    expect(summary.surfaceCounts.find(surface => surface.label === 'Telemetry')?.routeLink).toMatchObject({
+      label: 'Telemetry',
+      params: {
+        section: 'fleet-health',
+        view: 'event-log',
+        session_id: 'sess-latest',
+        q: 'turn-latest',
+      },
+    })
   })
 
   it('keeps the run progress keeper total separate from the top keeper list', () => {

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -19,6 +19,7 @@ import {
   IdeContextLens,
   openIdeContextRouteLink,
   routeLinksForContext,
+  type IdeContextRouteContext,
   type IdeContextRouteLink,
 } from './ide-context-lens'
 import {
@@ -109,9 +110,15 @@ export interface IdeRunProgressSummary {
   readonly linkedEvents: number
   readonly keeperTotalCount: number
   readonly latestAgeLabel: string
-  readonly surfaceCounts: ReadonlyArray<{ readonly label: string; readonly count: number }>
+  readonly surfaceCounts: ReadonlyArray<IdeRunProgressSurfaceCount>
   readonly keeperCounts: ReadonlyArray<{ readonly keeper_id: string; readonly count: number }>
   readonly activeGoal: IdeRunProgressGoal | null
+}
+
+export interface IdeRunProgressSurfaceCount {
+  readonly label: string
+  readonly count: number
+  readonly routeLink: IdeContextRouteLink | null
 }
 
 export interface IdeRunProgressGoal {
@@ -463,11 +470,19 @@ export function deriveIdeRunProgressSummary(
       && normalizeIdeContextFilePath(event.context.file_path) === activeFilePath,
     ).length
   const linkedEvents = events.filter(event => event.context !== undefined).length
-  const surfaceCounts: Array<{ readonly label: string; readonly count: number }> = PROGRESS_SURFACES.map(([key, label]) => ({
-    label,
-    count: events.filter(event => event.context?.[key]).length,
-  }))
-  surfaceCounts.push({ label: 'Telemetry', count: events.length })
+  const surfaceCounts: IdeRunProgressSurfaceCount[] = PROGRESS_SURFACES.map(([key, label]) => {
+    const matchingEvents = events.filter(event => event.context?.[key])
+    return {
+      label,
+      count: matchingEvents.length,
+      routeLink: latestSurfaceRouteLink(label, matchingEvents),
+    }
+  })
+  surfaceCounts.push({
+    label: 'Telemetry',
+    count: events.length,
+    routeLink: latestSurfaceRouteLink('Telemetry', events),
+  })
   const keeperEntries = [...events.reduce((acc, event) => {
     acc.set(event.keeper_id, (acc.get(event.keeper_id) ?? 0) + 1)
     return acc
@@ -503,12 +518,7 @@ function RunProgressStrip({ summary }: { readonly summary: IdeRunProgressSummary
       </div>
       ${summary.activeGoal ? RunProgressGoalTrack(summary.activeGoal) : null}
       <div class="ide-run-progress-surfaces" role="list" aria-label="Linked operational surfaces">
-        ${summary.surfaceCounts.map(surface => html`
-          <span role="listitem" data-active=${surface.count > 0 ? 'true' : 'false'}>
-            <span>${surface.label}</span>
-            <span>${surface.count}</span>
-          </span>
-        `)}
+        ${summary.surfaceCounts.map(surface => RunProgressSurfaceChip(surface))}
       </div>
       <div class="ide-run-progress-keepers" aria-label="Top active keepers">
         ${summary.keeperCounts.length === 0
@@ -521,6 +531,31 @@ function RunProgressStrip({ summary }: { readonly summary: IdeRunProgressSummary
           `)}
       </div>
     </section>
+  `
+}
+
+function RunProgressSurfaceChip(surface: IdeRunProgressSurfaceCount) {
+  const routeLink = surface.routeLink
+  return html`
+    <span role="listitem" data-active=${surface.count > 0 ? 'true' : 'false'}>
+      ${routeLink
+        ? html`
+          <button
+            type="button"
+            class="ide-run-progress-surface-link"
+            title=${routeLink.evidence}
+            aria-label=${`Open ${routeLink.evidence}`}
+            onClick=${() => openIdeContextRouteLink(routeLink)}
+          >
+            <span>${surface.label}</span>
+            <span>${surface.count}</span>
+          </button>
+        `
+        : html`
+          <span>${surface.label}</span>
+          <span>${surface.count}</span>
+        `}
+    </span>
   `
 }
 
@@ -639,6 +674,48 @@ function latestAgeLabel(events: ReadonlyArray<RunActivityEvent>): string {
   return `${hours}h ago`
 }
 
+function latestSurfaceRouteLink(
+  label: string,
+  events: ReadonlyArray<RunActivityEvent>,
+): IdeContextRouteLink | null {
+  const latestEvents = [...events].sort((left, right) =>
+    right.timestamp_ms - left.timestamp_ms || right.id.localeCompare(left.id),
+  )
+  for (const event of latestEvents) {
+    const routeLink = activityRouteLinks(event).find(link => link.label === label)
+    if (routeLink) return routeLink
+  }
+  return null
+}
+
+function activityRouteLinks(item: RunActivityEvent): ReadonlyArray<IdeContextRouteLink> {
+  return routeLinksForContext(activityRouteContext(item))
+}
+
+function activityRouteContext(item: RunActivityEvent): IdeContextRouteContext {
+  const eventContextFile = item.context?.file_path
+  const eventFocusFile = eventContextFile === undefined ? null : normalizeIdeContextFilePath(eventContextFile)
+  return {
+    filePath: eventFocusFile ?? undefined,
+    line: normalizeIdeContextLine(item.context?.line),
+    surface: activityContextSurface(item),
+    label: item.detail ?? `${item.verb} ${item.target}`,
+    sourceId: item.id,
+    goalId: item.context?.goal_id,
+    taskId: item.context?.task_id,
+    boardPostId: item.context?.board_post_id,
+    commentId: item.context?.comment_id,
+    prId: item.context?.pr_id,
+    gitRef: item.context?.git_ref,
+    logId: item.context?.log_id,
+    sessionId: item.context?.session_id,
+    operationId: item.context?.operation_id,
+    workerRunId: item.context?.worker_run_id,
+    keeperId: item.keeper_id,
+    telemetry: true,
+  }
+}
+
 function activityRefreshLabel(state: ActivityRefreshState, refreshMs: number | null): string {
   if (state.tone === 'loading') return 'syncing'
   if (state.tone === 'live') return refreshMs === null ? 'loaded' : 'live'
@@ -673,25 +750,7 @@ function ActivityRow(
   const eventFocusFile = eventContextFile === undefined ? null : normalizeIdeContextFilePath(eventContextFile)
   const eventFocusLine = normalizeIdeContextLine(item.context?.line)
   const hasEventContextFocus = eventFocusFile !== null
-  const routeLinks = routeLinksForContext({
-    filePath: eventFocusFile ?? undefined,
-    line: eventFocusLine,
-    surface: activityContextSurface(item),
-    label: item.detail ?? `${item.verb} ${item.target}`,
-    sourceId: item.id,
-    goalId: item.context?.goal_id,
-    taskId: item.context?.task_id,
-    boardPostId: item.context?.board_post_id,
-    commentId: item.context?.comment_id,
-    prId: item.context?.pr_id,
-    gitRef: item.context?.git_ref,
-    logId: item.context?.log_id,
-    sessionId: item.context?.session_id,
-    operationId: item.context?.operation_id,
-    workerRunId: item.context?.worker_run_id,
-    keeperId: item.keeper_id,
-    telemetry: true,
-  })
+  const routeLinks = activityRouteLinks(item)
 
   return html`
     <li

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -1473,6 +1473,38 @@
   color: var(--color-accent-fg);
 }
 
+.ide-run-progress-surface-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.ide-run-progress-surface-link > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-run-progress-surface-link:hover,
+.ide-run-progress-surface-link:focus-visible {
+  color: var(--color-fg-primary);
+}
+
+.ide-run-progress-surface-link:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 1px;
+}
+
 .ide-run-progress-keepers > span {
   flex: 1 1 58px;
 }


### PR DESCRIPTION
## Summary
- make RUN PROGRESS Goal/Task/Board/Comment/PR/Git/Log/Telemetry chips open the latest matching IDE route link
- share Activity row route-link construction with progress summary so chips use the same code/workspace/monitoring routes
- add regression coverage for chip clicks and latest-event selection

## Validation
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/ide-activity-panel.ts src/components/ide/ide-activity-panel.test.ts
- pnpm exec vitest run src/components/ide/ide-activity-panel.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check