### PR TITLE
fix(dashboard): stabilize IDE rail status

### DIFF
--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -38,7 +38,15 @@ vi.mock('../../api/repositories', () => ({
   fetchRepositoriesList: vi.fn(() => Promise.resolve([{
     id: 'masc-mcp',
     name: 'masc-mcp',
+    url: '',
     local_path: '/workspace/masc-mcp',
+    default_branch: 'main',
+    status: 'active',
+    auto_sync: false,
+    sync_interval: 300,
+    credential_id: null,
+    created_at: null,
+    updated_at: null,
   }])),
 }))
 
@@ -264,10 +272,27 @@ describe('IdeShell', () => {
         session_id: 'sess-runtime',
         keeper: 'sangsu',
       },
+      repositories: [{
+        id: 'masc-mcp',
+        name: 'masc-mcp',
+        url: '',
+        local_path: '/workspace/masc-mcp',
+        default_branch: 'main',
+        status: 'active',
+        auto_sync: false,
+        sync_interval: 300,
+        credential_id: null,
+        created_at: null,
+        updated_at: null,
+      }],
+      activeRepositoryId: 'masc-mcp',
+      workspaceSource: { kind: 'repository', repoId: 'masc-mcp' },
+      dashboardConnected: true,
     })
 
-    expect(model.workspaceLabel).toBe('LIVE WORKSPACE')
-    expect(model.connectionLabel).toBe('mcp · connected')
+    expect(model.workspaceLabel).toBe('masc-mcp')
+    expect(model.connectionLabel).toBe('runtime · live')
+    expect(model.connectionTone).toBe('ok')
     expect(model.chips.map(chip => chip.label)).toEqual([
       'SPLIT DIFF',
       'ide/ide-shell.ts',
@@ -310,9 +335,11 @@ describe('IdeShell', () => {
     render(h(IdeShell, {}), container)
 
     await waitFor(() => expect(activeIdeFile.value).toBe('lib/runtime.ml'))
+    await waitFor(() => expect(container.querySelector('[data-testid="ide-statusbar-workspace"]')?.textContent).toBe('masc-mcp'))
 
     const statusbar = container.querySelector('[data-testid="ide-statusbar"]')
     expect(statusbar?.getAttribute('aria-label')).toBe('IDE operational status')
+    expect(statusbar?.textContent).not.toContain('LIVE WORKSPACE')
     const chipLabels = [
       ...container.querySelectorAll<HTMLElement>('[data-testid^="ide-statusbar-chip-"]'),
     ].map(chip => chip.textContent)
@@ -591,6 +618,28 @@ describe('IdeShell', () => {
     expect(container.textContent).toContain('BRANCH GRAPH')
     await waitFor(() => expect(container.textContent).toContain('masc-mcp'))
     expect(container.textContent).toContain('main')
+  })
+
+  it('keeps the right diagnostics bounded above the primary conversation rail', () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    const rail = container.querySelector('[data-testid="ide-right-rail"]')
+    const contextStack = container.querySelector('[data-testid="ide-right-context-stack"]')
+    const primaryRail = container.querySelector('[data-testid="ide-primary-conversation-rail"]')
+    expect(rail).not.toBeNull()
+    expect(contextStack).not.toBeNull()
+    expect(primaryRail).not.toBeNull()
+    expect(Array.from(rail?.children ?? []).map(child => child.className)).toEqual([
+      'ide-plane-context-stack',
+      'ide-plane-primary-rail',
+    ])
+    expect(container.querySelector('.ide-plane-activity')).not.toBeNull()
   })
 
   it('hydrates collapsed IDE rails from the route', () => {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -20,6 +20,11 @@ import { routeLinksForContext } from './ide-context-lens'
 import { navigate, route } from '../../router'
 import { activeKeeperName } from '../../keeper-state'
 import { keepers } from '../../store'
+import { connected } from '../../sse'
+import { dashboardWsOnlyEnabled } from '../../dashboard-ws-cutover'
+import { dashboardWsConnected, dashboardWsSseFallbackActive } from '../../dashboard-ws-state'
+import type { Repository } from '../../api/repositories'
+import type { WorkspaceSource } from '../../api/workspace-source'
 import {
   parseActive,
   serializeActive,
@@ -32,6 +37,7 @@ export { activeIdeFile }
 type ViewTab = IdeEditorView
 type IdeFocus = 'review'
 type IdeStatusbarChipTone = 'brass' | 'ghost' | 'info' | 'ok'
+type IdeConnectionTone = 'ok' | 'warn'
 
 export interface IdeStatusbarChip {
   readonly id: string
@@ -44,6 +50,7 @@ export interface IdeStatusbarModel {
   readonly workspaceLabel: string
   readonly chips: ReadonlyArray<IdeStatusbarChip>
   readonly connectionLabel: string
+  readonly connectionTone: IdeConnectionTone
 }
 
 const IDE_LAYER_KINDS = new Set(IDE_LAYERS.map(layer => layer.kind))
@@ -78,6 +85,10 @@ interface IdeStatusbarInput {
   readonly railsCollapsed: boolean
   readonly reviewFocusActive: boolean
   readonly routeParams: Record<string, string>
+  readonly repositories?: ReadonlyArray<Repository>
+  readonly activeRepositoryId?: string | null
+  readonly workspaceSource?: WorkspaceSource
+  readonly dashboardConnected?: boolean
 }
 
 function viewFromRoute(raw: string | null | undefined): ViewTab {
@@ -151,6 +162,65 @@ function shortStatusbarPath(path: string): string {
   return `${parts.at(-2)}/${parts.at(-1)}`
 }
 
+function compactStatusbarPath(path: string): string | undefined {
+  const normalized = path.trim().replace(/\\/g, '/')
+  if (!normalized) return undefined
+  const parts = normalized.split('/').filter(Boolean)
+  if (parts.length === 0) return undefined
+  if (parts.length === 1) return parts[0]
+  return `${parts.at(-2)}/${parts.at(-1)}`
+}
+
+function statusbarRepositoryLabel(repository: Repository | undefined): string | undefined {
+  const name = repository?.name?.trim()
+  if (name) return name
+  return compactStatusbarPath(repository?.local_path ?? '') ?? repository?.id?.trim()
+}
+
+function activeStatusbarRepository(
+  repositories: ReadonlyArray<Repository> | undefined,
+  activeRepositoryId: string | null | undefined,
+): Repository | undefined {
+  if (!repositories || repositories.length === 0) return undefined
+  return repositories.find(repository => activeRepositoryId && repository.id === activeRepositoryId)
+    ?? repositories[0]
+}
+
+function statusbarWorkspaceLabel(
+  repositories: ReadonlyArray<Repository> | undefined,
+  activeRepositoryId: string | null | undefined,
+  workspaceSource: WorkspaceSource | undefined,
+): string {
+  const repositoryForId = (repoId: string): string =>
+    statusbarRepositoryLabel(repositories?.find(repository => repository.id === repoId))
+    ?? repoId
+
+  switch (workspaceSource?.kind) {
+    case 'repository':
+      return repositoryForId(workspaceSource.repoId)
+    case 'repository_missing':
+      return `${repositoryForId(workspaceSource.repoId)} fallback`
+    case 'repository_unknown':
+      return `${workspaceSource.repoId} unknown`
+    case 'playground':
+      return `@${workspaceSource.keeper}`
+    case 'playground_missing':
+      return `@${workspaceSource.keeper} fallback`
+    case 'keeper_unknown':
+      return `@${workspaceSource.keeper} unknown`
+    case 'project':
+    case undefined:
+      return statusbarRepositoryLabel(activeStatusbarRepository(repositories, activeRepositoryId)) ?? 'workspace'
+  }
+}
+
+function dashboardRuntimeConnected(): boolean {
+  if (dashboardWsOnlyEnabled()) {
+    return dashboardWsConnected.value || dashboardWsSseFallbackActive.value
+  }
+  return connected.value
+}
+
 function statusbarLayerLabel(activeLayers: ReadonlySet<string>): string | null {
   if (activeLayers.size === 0) return null
   const labels = STATUSBAR_LAYER_PRIORITY
@@ -195,6 +265,10 @@ export function deriveIdeStatusbarModel({
   railsCollapsed,
   reviewFocusActive,
   routeParams,
+  repositories,
+  activeRepositoryId,
+  workspaceSource,
+  dashboardConnected = false,
 }: IdeStatusbarInput): IdeStatusbarModel {
   const chips: IdeStatusbarChip[] = []
   const viewLabel = STATUSBAR_VIEW_LABELS[activeView]
@@ -250,9 +324,10 @@ export function deriveIdeStatusbarModel({
   addStatusbarChip(chips, 'keeper', keeper ? `Keeper ${keeper}` : undefined, 'ok', 'Focused keeper')
 
   return {
-    workspaceLabel: 'LIVE WORKSPACE',
+    workspaceLabel: statusbarWorkspaceLabel(repositories, activeRepositoryId, workspaceSource),
     chips,
-    connectionLabel: 'mcp · connected',
+    connectionLabel: dashboardConnected ? 'runtime · live' : 'runtime · reconnecting',
+    connectionTone: dashboardConnected ? 'ok' : 'warn',
   }
 }
 
@@ -298,6 +373,18 @@ export function IdeShell() {
   const diffRows = useSubscribedSnapshot(
     coordinator.diffRows,
     coordinator.subscribeDiffRows,
+  )
+  const repositories = useSubscribedValue(
+    coordinator.repositories,
+    coordinator.subscribeRepositories,
+  )
+  const activeRepositoryId = useSubscribedValue(
+    coordinator.activeRepositoryId,
+    coordinator.subscribeActiveRepositoryId,
+  )
+  const workspaceSource = useSubscribedValue(
+    coordinator.workspaceSource,
+    coordinator.subscribeWorkspaceSource,
   )
   const [activeFilePath, setActiveFilePath] = useState(activeIdeFile.value)
 
@@ -401,6 +488,10 @@ export function IdeShell() {
     railsCollapsed,
     reviewFocusActive,
     routeParams: route.value.params,
+    repositories,
+    activeRepositoryId,
+    workspaceSource,
+    dashboardConnected: dashboardRuntimeConnected(),
   })
 
   useEffect(() => {
@@ -474,6 +565,7 @@ export function IdeShell() {
         <span
           class="chip sm is-brass"
           style=${{ flexShrink: 0 }}
+          data-testid="ide-statusbar-workspace"
         >${statusbar.workspaceLabel}</span>
         <div
           class="ide-plane-statusbar-meta"
@@ -489,7 +581,10 @@ export function IdeShell() {
           `)}
         </div>
         <${IdePresenceStrip} />
-        <span class="ide-plane-connection">● ${statusbar.connectionLabel}</span>
+        <span
+          class="ide-plane-connection"
+          data-state=${statusbar.connectionTone}
+        >● ${statusbar.connectionLabel}</span>
       </header>
       <${IdeToolbar}
         activeView=${activeView}
@@ -542,21 +637,26 @@ export function IdeShell() {
           : html`
             <div
               class="ide-plane-conversation"
-              style=${{
-                display: 'grid',
-                gridTemplateRows: 'auto auto auto auto 1fr',
-                minHeight: 0,
-                overflow: 'auto',
-              }}
+              data-testid="ide-right-rail"
             >
-              <${IdeBranchContextPanel}
-                activeRepositoryId=${coordinator.activeRepositoryId}
-                subscribeActiveRepositoryId=${coordinator.subscribeActiveRepositoryId}
-              />
-              <${IdeKeeperWorkPanel} keeperName=${terminalKeeper} />
-              <${IdePersistencePanel} keeperName=${terminalKeeper} />
-              <${InspectorKeeperBDI} traceActive=${activeLayers.has('keeper-trace')} />
-              <${IdeConversationRail} />
+              <div
+                class="ide-plane-context-stack"
+                data-testid="ide-right-context-stack"
+              >
+                <${IdeBranchContextPanel}
+                  activeRepositoryId=${coordinator.activeRepositoryId}
+                  subscribeActiveRepositoryId=${coordinator.subscribeActiveRepositoryId}
+                />
+                <${IdeKeeperWorkPanel} keeperName=${terminalKeeper} />
+                <${IdePersistencePanel} keeperName=${terminalKeeper} />
+                <${InspectorKeeperBDI} traceActive=${activeLayers.has('keeper-trace')} />
+              </div>
+              <div
+                class="ide-plane-primary-rail"
+                data-testid="ide-primary-conversation-rail"
+              >
+                <${IdeConversationRail} />
+              </div>
             </div>
           `}
         ${railsCollapsed
@@ -599,6 +699,22 @@ function useSubscribedSnapshot<T>(
       }
       current = next
       setValue(previous => previous === next ? previous : next)
+    })
+  }, [read, subscribe])
+
+  return value
+}
+
+function useSubscribedValue<T>(
+  read: () => T,
+  subscribe: (listener: () => void) => () => void,
+): T {
+  const [value, setValue] = useState<T>(() => read())
+
+  useEffect(() => {
+    setValue(read())
+    return subscribe(() => {
+      setValue(read())
     })
   }, [read, subscribe])
 

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -299,8 +299,15 @@
 
 .ide-plane-connection {
   margin-left: auto;
-  color: var(--color-status-ok);
   white-space: nowrap;
+}
+
+.ide-plane-connection[data-state="ok"] {
+  color: var(--color-status-ok);
+}
+
+.ide-plane-connection[data-state="warn"] {
+  color: var(--color-status-warn);
 }
 
 .ide-toolbar {
@@ -572,11 +579,14 @@
   min-height: 0;
   min-width: 0;
   overflow: hidden;
+  isolation: isolate;
 }
 
 .ide-plane-tree {
   grid-column: 1;
   grid-row: 1 / span 2;
+  position: relative;
+  z-index: var(--z-base);
   min-width: 0;
   min-height: 0;
   overflow: hidden;
@@ -692,6 +702,8 @@
 .ide-plane-editor {
   grid-column: 2;
   grid-row: 1 / span 2;
+  position: relative;
+  z-index: var(--z-base);
   display: grid;
   grid-template-rows: minmax(0, 1fr);
   min-width: 0;
@@ -703,18 +715,51 @@
 .ide-plane-conversation {
   grid-column: 3;
   grid-row: 1;
+  position: relative;
+  z-index: var(--z-base);
+  display: grid;
+  grid-template-rows: minmax(0, 42%) minmax(0, 1fr);
   min-width: 0;
   min-height: 0;
   overflow: hidden;
+  isolation: isolate;
 }
 
 .ide-plane-activity {
   grid-column: 3;
   grid-row: 2;
+  position: relative;
+  z-index: var(--z-base);
   min-width: 0;
   min-height: 0;
   overflow: hidden;
   border-top: 1px solid var(--color-border-divider);
+  isolation: isolate;
+}
+
+.ide-plane-context-stack,
+.ide-plane-primary-rail {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.ide-plane-context-stack {
+  display: grid;
+  grid-auto-rows: max-content;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border-bottom: 1px solid var(--color-border-divider);
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border-default) transparent;
+}
+
+.ide-plane-primary-rail {
+  display: grid;
+}
+
+.ide-plane-primary-rail > .ide-rail-panel {
+  min-height: 0;
 }
 
 .ide-plane-shell[data-rails-collapsed="true"] .ide-plane-grid {
@@ -1205,7 +1250,7 @@
 .ide-rail-head {
   position: sticky;
   top: 0;
-  z-index: var(--z-sticky);
+  z-index: var(--z-base);
   display: flex;
   justify-content: space-between;
   gap: var(--sp-3);
@@ -2163,7 +2208,7 @@
 
   .ide-plane-conversation {
     max-height: none;
-    overflow: visible;
+    overflow: hidden;
   }
 
   .ide-plane-editor {


### PR DESCRIPTION
## Summary
- Replace the IDE statusbar hardcoded workspace/connection labels with coordinator-backed workspace source and dashboard transport state.
- Split the right IDE rail into a bounded diagnostics stack and primary conversation rail so diagnostic panels cannot hide the production reaction rail.
- Add focused shell coverage for the statusbar model and right-rail layout contract.

## Root Cause
The IDE shell statusbar always rendered static `LIVE WORKSPACE` / `mcp · connected` text, and the right rail mixed diagnostic panels with the primary conversation rail in one scroll stack. That made the rail sensitive to z-index/sticky header interactions and allowed diagnostic content to crowd out the surface operators actually need.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/ide/ide-shell.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- Playwright browser spot check of `/dashboard/#code?section=ide-shell&view=source` confirmed the right rail reserves separate context, primary rail, and activity regions without overlap.