### PR TITLE
feat(ide): route context lens surface chips

### DIFF
--- a/dashboard/src/components/ide/ide-context-lens.test.ts
+++ b/dashboard/src/components/ide/ide-context-lens.test.ts
@@ -111,6 +111,23 @@ describe('IdeContextLens', () => {
     expect(model.changedLineCount).toBe(2)
     expect(model.anchorTotalCount).toBe(4)
     expect(model.anchors.map(anchor => anchor.surface)).toContain('Git')
+    expect(model.surfaces.find(surface => surface.id === 'line')?.routeLink).toMatchObject({
+      label: 'Code',
+      params: { file: 'lib/keeper/keeper_exec_ide.ml', line: '12' },
+    })
+    expect(model.surfaces.find(surface => surface.id === 'pr')?.routeLink).toMatchObject({
+      label: 'PR',
+      params: { section: 'repositories', view: 'graph', pr: '15000' },
+    })
+    expect(model.surfaces.find(surface => surface.id === 'telemetry')?.routeLink).toMatchObject({
+      label: 'Telemetry',
+      params: { section: 'fleet-health', view: 'event-log' },
+    })
+    expect(model.surfaces.find(surface => surface.id === 'comment')?.routeLink).toBeNull()
+    expect(model.surfaces.find(surface => surface.id === 'comment')?.focusAnchor).toMatchObject({
+      id: 'annotation-ann-1',
+      surface: 'Comment',
+    })
   })
 
   it('does not claim telemetry links from local-only code evidence', () => {
@@ -130,7 +147,9 @@ describe('IdeContextLens', () => {
   })
 
   it('renders a compact context lens panel', () => {
+    const activated: unknown[] = []
     const container = document.createElement('div')
+    ideContextFocus.value = null
 
     render(
       h(IdeContextLens, {
@@ -139,6 +158,7 @@ describe('IdeContextLens', () => {
         diffRows,
         events,
         overlay,
+        onRouteLinkActivate: link => activated.push(link),
       }),
       container,
     )
@@ -149,6 +169,34 @@ describe('IdeContextLens', () => {
     expect(container.textContent).toContain('keeper_exec_ide.ml')
     expect(container.textContent).toContain('4 anchors')
     expect(container.textContent).toContain('goal goal-ide')
+
+    const surfaceButtons = [...container.querySelectorAll<HTMLButtonElement>('.ide-context-surface-action')]
+    expect(surfaceButtons.map(button => button.textContent)).toEqual([
+      'Line1',
+      'Keeper1',
+      'Goal2',
+      'Task2',
+      'Board1',
+      'Git3',
+      'PR1',
+      'Comment1',
+      'Log1',
+      'Telemetry1',
+    ])
+
+    fireEvent.click(surfaceButtons.find(button => button.textContent === 'PR1')!)
+    expect(activated[0]).toMatchObject({
+      label: 'PR',
+      params: { section: 'repositories', view: 'graph', pr: '15000' },
+    })
+
+    fireEvent.click(surfaceButtons.find(button => button.textContent === 'Comment1')!)
+    expect(ideContextFocus.value).toMatchObject({
+      file_path: 'lib/keeper/keeper_exec_ide.ml',
+      line: 12,
+      surface: 'Comment',
+      source_id: 'annotation-ann-1',
+    })
   })
 
   it('reports when the compact anchor list is truncated', () => {

--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -31,6 +31,9 @@ export interface IdeContextSurface {
   readonly status: SurfaceStatus
   readonly count: number
   readonly evidence: string
+  readonly routeLink: IdeContextRouteLink | null
+  readonly focusAnchor: IdeContextAnchor | null
+  readonly actionEvidence: string | null
 }
 
 export interface IdeContextAnchor {
@@ -152,6 +155,19 @@ const CONTEXT_ANCHOR_BUCKET_ORDER = [
   'other',
 ] as const
 type ContextAnchorBucket = (typeof CONTEXT_ANCHOR_BUCKET_ORDER)[number]
+const SURFACE_ROUTE_LABELS: Readonly<Record<IdeContextSurfaceId, ReadonlyArray<string>>> = {
+  lsp: ['Code'],
+  line: ['Code'],
+  keeper: ['Keeper'],
+  goal: ['Goal'],
+  task: ['Task'],
+  board: ['Board'],
+  git: ['Git'],
+  pr: ['PR'],
+  comment: ['Comment', 'Board'],
+  log: ['Log'],
+  telemetry: ['Telemetry'],
+}
 
 export function deriveIdeContextLens(input: IdeContextLensInput): IdeContextLensModel {
   const filePath = normalizeIdeContextFilePath(input.filePath)
@@ -203,6 +219,17 @@ export function deriveIdeContextLens(input: IdeContextLensInput): IdeContextLens
     if (line !== undefined) activeLines.add(line)
   }
 
+  const anchorCandidates = buildAnchors(
+    filePath ?? input.filePath,
+    fileAnnotations,
+    fileDiagnostics,
+    activeCursors,
+    fileThreads,
+    changedRows,
+    fileEvents,
+    eventSearchTextByEvent,
+  )
+
   const surfaces = SURFACE_ORDER.map(id => {
     const count = surfaceCount(id, {
       annotations: fileAnnotations,
@@ -215,31 +242,25 @@ export function deriveIdeContextLens(input: IdeContextLensInput): IdeContextLens
       eventSearchTextByEvent,
     })
     const status: SurfaceStatus = count > 0 ? 'linked' : 'quiet'
+    const action = count > 0 ? contextSurfaceAction(id, anchorCandidates) : null
     return {
       id,
       label: SURFACE_LABELS[id],
       status,
       count,
       evidence: surfaceEvidence(id, count),
+      routeLink: action?.routeLink ?? null,
+      focusAnchor: action?.focusAnchor ?? null,
+      actionEvidence: action?.evidence ?? null,
     }
   })
-
-  const anchors = buildAnchors(
-    filePath ?? input.filePath,
-    fileAnnotations,
-    fileDiagnostics,
-    activeCursors,
-    fileThreads,
-    changedRows,
-    fileEvents,
-    eventSearchTextByEvent,
-  )
+  const anchors = selectVisibleContextAnchors(anchorCandidates, MAX_CONTEXT_ANCHORS)
 
   return {
     linkedCount: surfaces.filter(surface => surface.status === 'linked').length,
     surfaces,
-    anchors: selectVisibleContextAnchors(anchors, MAX_CONTEXT_ANCHORS),
-    anchorTotalCount: anchors.length,
+    anchors,
+    anchorTotalCount: anchorCandidates.length,
     changedLineCount,
     activeLineCount: activeLines.size,
   }
@@ -302,8 +323,29 @@ function contextAnchorBuckets(anchor: IdeContextAnchor): ReadonlySet<ContextAnch
   }
 
   if (anchor.keeper_id) buckets.add('keeper')
+  if (anchor.line !== undefined) buckets.add('line')
+  if (anchor.id.startsWith('event-')) buckets.add('log')
   if (buckets.size === 0) buckets.add('other')
   return buckets
+}
+
+function contextSurfaceAction(
+  id: IdeContextSurfaceId,
+  anchors: ReadonlyArray<IdeContextAnchor>,
+): { readonly routeLink: IdeContextRouteLink | null; readonly focusAnchor: IdeContextAnchor; readonly evidence: string } | null {
+  const matchingAnchors = anchors.filter(anchor => contextAnchorBuckets(anchor).has(id))
+  for (const anchor of matchingAnchors) {
+    for (const label of SURFACE_ROUTE_LABELS[id]) {
+      const routeLink = anchor.route_links?.find(link => link.label === label)
+      if (routeLink) {
+        return { routeLink, focusAnchor: anchor, evidence: routeLink.evidence }
+      }
+    }
+  }
+  const focusAnchor = matchingAnchors[0]
+  return focusAnchor
+    ? { routeLink: null, focusAnchor, evidence: contextAnchorTitle(focusAnchor) }
+    : null
 }
 
 export function IdeContextLens({
@@ -343,17 +385,7 @@ export function IdeContextLens({
         </div>
       </div>
       <div class="ide-context-surface-grid" role="list" aria-label="Linked surfaces">
-        ${model.surfaces.map(surface => html`
-          <span
-            role="listitem"
-            class="ide-context-surface"
-            data-status=${surface.status}
-            title=${surface.evidence}
-          >
-            <span>${surface.label}</span>
-            <span>${surface.count}</span>
-          </span>
-        `)}
+        ${model.surfaces.map(surface => ContextSurfaceChip(surface, activateAnchor, activateRouteLink))}
       </div>
       <ol class="ide-context-anchor-list" aria-label="Current file anchors">
         ${model.anchors.length === 0
@@ -361,6 +393,48 @@ export function IdeContextLens({
           : model.anchors.map(anchor => ContextAnchorRow(anchor, activateAnchor, activateRouteLink))}
       </ol>
     </section>
+  `
+}
+
+function ContextSurfaceChip(
+  surface: IdeContextSurface,
+  onAnchorActivate: (anchor: IdeContextAnchor) => void,
+  onRouteLinkActivate: (link: IdeContextRouteLink) => void,
+) {
+  const actionable = surface.routeLink !== null || surface.focusAnchor !== null
+  const title = surface.actionEvidence ?? surface.evidence
+  const activate = () => {
+    if (surface.routeLink) {
+      onRouteLinkActivate(surface.routeLink)
+    } else if (surface.focusAnchor) {
+      onAnchorActivate(surface.focusAnchor)
+    }
+  }
+  return html`
+    <span
+      role="listitem"
+      class="ide-context-surface"
+      data-status=${surface.status}
+      data-actionable=${actionable ? 'true' : 'false'}
+      title=${title}
+    >
+      ${actionable
+        ? html`
+          <button
+            type="button"
+            class="ide-context-surface-action"
+            aria-label=${`Open ${title}`}
+            onClick=${activate}
+          >
+            <span>${surface.label}</span>
+            <span>${surface.count}</span>
+          </button>
+        `
+        : html`
+          <span>${surface.label}</span>
+          <span>${surface.count}</span>
+        `}
+    </span>
   `
 }
 

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -1749,11 +1749,48 @@
   color: var(--color-accent-fg);
 }
 
+.ide-context-surface[data-actionable="true"] {
+  padding: 0;
+}
+
 .ide-context-surface > span {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.ide-context-surface-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-1);
+  width: 100%;
+  min-width: 0;
+  min-height: 20px;
+  padding: 2px 6px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.ide-context-surface-action > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-context-surface-action:hover,
+.ide-context-surface-action:focus-visible {
+  color: var(--color-fg-primary);
+}
+
+.ide-context-surface-action:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 1px;
 }
 
 .ide-context-anchor-list {


### PR DESCRIPTION
## Summary
- make linked Context Lens surface chips actionable from the summary grid
- route Goal/Task/Board/PR/Git/Log/Telemetry/Keeper surfaces through existing IDE context route links
- fall back to focusing the representative anchor for surfaces without a direct route link, such as comment annotations

## Validation
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/ide-context-lens.ts src/components/ide/ide-context-lens.test.ts
- pnpm exec vitest run src/components/ide/ide-context-lens.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD~1 HEAD