### PR TITLE
docs(rfc-0036): activate OAS cognitive mapping manifest

### DIFF
--- a/docs/rfc/RFC-0036-oas-cognitive-mapping.md
+++ b/docs/rfc/RFC-0036-oas-cognitive-mapping.md
@@ -1,8 +1,10 @@
 # RFC-0036: oas Cognitive Mapping (companion to RFC-0035)
 
-- **Status**: Draft
+- **Status**: Active
 - **Author**: Claude (autonomous, /loop iteration 5)
 - **Created**: 2026-05-07
+- **Activated**: 2026-05-14 (cite-able foundation for downstream OAS-touching RFCs; manifest table at §"Problem" is the working contract)
+- **Implementation state**: manifest accepted as the working host ↔ oas pairing; PR-A1 / PR-A2 / PR-B (Extensions A and B) **not yet implemented** — those proposals retain their `not started` status in §"Implementation plan (this RFC stack)" and ship under separate PRs when scheduled. Activation here does **not** imply Extensions are merged.
 - **Companion to**: RFC-0035 (Cognitive IDE Master Plan Integration)
 - **Repos affected**: `jeong-sik/oas` (agent_sdk) and the masc-mcp ↔ oas
   contract surface


### PR DESCRIPTION
## Summary

Activates **RFC-0036 (Draft → Active)** so downstream OAS-touching RFCs and PRs can cite it as the working host ↔ oas pairing contract.

The manifest table at §"Problem" — 7 host/oas surface pairs across cognitive dimensions — is what becomes cite-able. No new claims, no code change, no CI delta.

**Extensions A/B remain `not started`**: `Cognitive_op` variant, `Cognitive_event` type, and the PR-A1/PR-A2/PR-B sequence in §"Implementation plan (this RFC stack)" are *not* implemented by this PR and ship separately when scheduled.

## Why now

Required as Phase A foundation in `~/me/planning/claude-plans/wise-nibbling-lerdorf.md` — an evidence-ladder plan for OAS tool dispatch hot path caching (Phase B baseline → Phase C/D conditional caching → Phase E conditional RFC-0081). Phase B and beyond cite RFC-0036 in PR-RFC check.

## Files

- `docs/rfc/RFC-0036-oas-cognitive-mapping.md` — Status `Draft → Active`, add `Activated:` line, add `Implementation state:` line clarifying Extensions are not in scope here.

Diff: +3/-1 line.

## Verification gates (RFC-0036 §"Verification gates")

- [x] Mapping table reflects actual files (verified in original Draft PR, unchanged here)
- [x] No code change
- [x] No build change / no CI change
- [x] Self-review per `~/me/agents/best-programmer/AGENT.md` (see commit body)

## Workaround Self-Check (CLAUDE.md §워크어라운드 거부 기준)

- [x] (#1) telemetry-as-fix? N/A — docs-only
- [x] (#2) string classifier? N/A
- [x] (#3) N-of-M patch? N/A — single docs PR
- [x] (#4) catch-all match? N/A
- [x] (#5) cap/cooldown/dedup/repair? N/A
- [x] (#6) test backdoor? N/A
- [x] (#7) typo N-fix? N/A

## Test plan

- [ ] CI green (docs-only, expect lint pass only)
- [ ] No additional CI lanes touched

## Follow-ups

- Phase B PR (separate worktree, `feat/oas-dispatch-hotpath-baseline-20260514`) will cite this RFC after merge.
- Extensions A/B (Cognitive_op variant, Cognitive_event type) — separate PRs, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)