### PR TITLE
fix(provider): project timeout policy from runtime overlay

### DIFF
--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -224,22 +224,22 @@ let has_recovery_evidence candidate =
       && info.success_rate > 0.0)
 
 let provider_attempt_timeout_constraints candidate =
-  Provider_adapter.timeout_bounds_of_kind candidate.provider_cfg.kind
+  Provider_runtime_overlay.timeout_bounds_of_kind candidate.provider_cfg.kind
 
 let apply_provider_attempt_timeout_constraints constraints timeout_s =
   let timeout_s =
-    match constraints.Provider_adapter.min_timeout_s with
+    match constraints.Provider_runtime_overlay.min_timeout_s with
     | Some min_s -> Float.max timeout_s min_s
     | None -> timeout_s
   in
-  match constraints.Provider_adapter.max_timeout_s with
+  match constraints.Provider_runtime_overlay.max_timeout_s with
   | Some max_s -> Float.min timeout_s max_s
   | None -> timeout_s
 
 let provider_default_attempt_timeout_s constraints =
   match
-    ( constraints.Provider_adapter.min_timeout_s
-    , constraints.Provider_adapter.max_timeout_s )
+    ( constraints.Provider_runtime_overlay.min_timeout_s
+    , constraints.Provider_runtime_overlay.max_timeout_s )
   with
   | Some min_s, Some max_s -> Some (Float.min max_s min_s)
   | Some min_s, None -> Some min_s
@@ -254,8 +254,8 @@ let effective_attempt_timeout_s ~is_last ~configured_timeout_s candidate =
         apply_provider_attempt_timeout_constraints constraints configured
       in
       if is_last
-         && Option.is_none constraints.Provider_adapter.min_timeout_s
-         && Option.is_none constraints.Provider_adapter.max_timeout_s
+         && Option.is_none constraints.Provider_runtime_overlay.min_timeout_s
+         && Option.is_none constraints.Provider_runtime_overlay.max_timeout_s
       then None
       else Some bounded
   | None -> provider_default_attempt_timeout_s constraints

--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -22,28 +22,18 @@ type cli_transport_overrides =
      to honour this field there. *)
   }
 
-(* SSOT for the Claude Code subprocess hard cap lives in
-   [Provider_adapter] (claude adapter's [tool_policy.max_turns_per_attempt]).
-   The constant below is a backward-compat re-export for the existing test
-   suite; new code reads the cap via [provider_effective_max_turns] or
-   [Provider_adapter.adapter_of_provider_kind]. *)
+(* SSOT for provider subprocess hard caps lives in OAS
+   [Provider_config.max_turns_hard_cap], projected through
+   [Provider_runtime_overlay]. The constant below is a backward-compat
+   re-export for the existing test suite. *)
 let claude_code_max_turns_hard_cap =
-  match
-    Provider_adapter.adapter_of_provider_kind
-      Llm_provider.Provider_config.Claude_code
-  with
-  | Some adapter ->
-    Option.value ~default:30 adapter.tool_policy.max_turns_per_attempt
-  | None -> 30
+  Provider_runtime_overlay.max_turns_hard_cap
+    Llm_provider.Provider_config.Claude_code
+  |> Option.value ~default:30
 ;;
 
 let provider_effective_max_turns kind requested =
-  match Provider_adapter.adapter_of_provider_kind kind with
-  | Some adapter ->
-    (match adapter.tool_policy.max_turns_per_attempt with
-     | Some cap -> min requested cap
-     | None -> requested)
-  | None -> requested
+  Provider_runtime_overlay.clamp_max_turns kind requested
 ;;
 
 (* #10097: codex_cli can only expose keeper-bound runtime MCP tools when the

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -364,7 +364,6 @@ let legacy_direct_adapters =
     ; tool_policy =
         { runtime_mcp_http_headers with
           uses_anthropic_caching = true
-        ; max_turns_per_attempt = Some 30
         ; tolerates_bound_actor_fallback = true
         }
     ; telemetry_policy = telemetry_usage_missing_runtime_reported
@@ -843,41 +842,6 @@ let is_http_probe_capable_kind (kind : Llm_provider.Provider_config.provider_kin
   | Llm_provider.Provider_config.Ollama -> true
   | Anthropic | Claude_code | OpenAI_compat | Glm | DashScope | Codex_cli
   | Gemini | Gemini_cli | Kimi | Kimi_cli -> false
-;;
-
-(** Per-provider per-attempt timeout bounds.
-
-    [min_timeout_s] is the floor below which an attempt timeout is
-    never set (e.g. ollama needs 300s to load a cold model — anything
-    lower means the keeper turn fails before the model finishes
-    initialising).
-
-    [max_timeout_s] is the ceiling above which an attempt cannot
-    block (e.g. claude_code's 120s subprocess budget — exceeding it
-    means the CLI has hung and the supervisor must intervene). *)
-type timeout_bounds =
-  { min_timeout_s : float option
-  ; max_timeout_s : float option
-  }
-
-(** [timeout_bounds_of_kind kind] is the per-provider attempt timeout
-    policy.  Encapsulates the only [match provider_cfg.kind] site that
-    used to live in keeper-layer driver helpers; new providers add an
-    arm here, not at the call site.
-
-    RFC-0058 Phase 5.6: vendor-specific operational tunables live
-    inside the adapter boundary, not the keeper turn-driver. *)
-let timeout_bounds_of_kind (kind : Llm_provider.Provider_config.provider_kind)
-  : timeout_bounds
-  =
-  match kind with
-  | Llm_provider.Provider_config.Ollama ->
-    { min_timeout_s = Some 300.0; max_timeout_s = None }
-  | Claude_code -> { min_timeout_s = None; max_timeout_s = Some 120.0 }
-  | Gemini | Gemini_cli -> { min_timeout_s = None; max_timeout_s = Some 180.0 }
-  | Kimi_cli -> { min_timeout_s = None; max_timeout_s = Some 60.0 }
-  | Anthropic | Kimi | OpenAI_compat | Glm | DashScope | Codex_cli ->
-    { min_timeout_s = None; max_timeout_s = None }
 ;;
 
 (** Default fallback label for local runtime when no other preferred

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -269,26 +269,6 @@ val is_local_provider : string -> bool
 val is_http_probe_capable_kind :
   Llm_provider.Provider_config.provider_kind -> bool
 
-(** Per-provider per-attempt timeout bounds.
-
-    [min_timeout_s] is the floor below which an attempt timeout is
-    never set; [max_timeout_s] is the ceiling above which an attempt
-    cannot block. *)
-type timeout_bounds =
-  { min_timeout_s : float option
-  ; max_timeout_s : float option
-  }
-
-(** [timeout_bounds_of_kind kind] is the per-provider attempt timeout
-    policy.  Encapsulates the only [match provider_cfg.kind] site
-    that used to live in keeper-layer driver helpers; new providers
-    add an arm here, not at the call site.
-
-    RFC-0058 Phase 5.6: vendor-specific operational tunables live
-    inside the adapter boundary, not the keeper turn-driver. *)
-val timeout_bounds_of_kind :
-  Llm_provider.Provider_config.provider_kind -> timeout_bounds
-
 (** {1 Model Label Resolution} *)
 
 (** Default fallback label for local runtime when no preferred models exist. *)

--- a/lib/provider_runtime_overlay.ml
+++ b/lib/provider_runtime_overlay.ml
@@ -127,3 +127,35 @@ let usage_missing_by_design (binding : binding) =
 ;;
 
 let provider_config ?model binding = Binding.to_provider_config ?model binding
+
+type timeout_bounds =
+  { min_timeout_s : float option
+  ; max_timeout_s : float option
+  }
+
+let timeout_bounds_of_kind (kind : PConfig.provider_kind) =
+  match kind, PConfig.default_attempt_timeout_s kind with
+  | PConfig.Ollama, timeout_s -> { min_timeout_s = timeout_s; max_timeout_s = None }
+  | PConfig.Gemini, Some timeout_s
+  | PConfig.Gemini_cli, Some timeout_s
+  | PConfig.Claude_code, Some timeout_s
+  | PConfig.Kimi_cli, Some timeout_s ->
+    { min_timeout_s = None; max_timeout_s = Some timeout_s }
+  | PConfig.Gemini, None ->
+    { min_timeout_s = None; max_timeout_s = Some 180.0 }
+  | PConfig.Gemini_cli, None ->
+    { min_timeout_s = None; max_timeout_s = Some 180.0 }
+  | PConfig.Claude_code, None ->
+    { min_timeout_s = None; max_timeout_s = Some 120.0 }
+  | PConfig.Kimi_cli, None -> { min_timeout_s = None; max_timeout_s = Some 60.0 }
+  | ( PConfig.Anthropic
+    | PConfig.Kimi
+    | PConfig.OpenAI_compat
+    | PConfig.Glm
+    | PConfig.DashScope
+    | PConfig.Codex_cli )
+    , _ -> { min_timeout_s = None; max_timeout_s = None }
+;;
+
+let max_turns_hard_cap = PConfig.max_turns_hard_cap
+let clamp_max_turns = PConfig.clamp_max_turns

--- a/lib/provider_runtime_overlay.mli
+++ b/lib/provider_runtime_overlay.mli
@@ -21,3 +21,20 @@ val supports_runtime_mcp_http_headers : binding -> bool
 val uses_prompt_caching : binding -> bool
 val usage_missing_by_design : binding -> bool
 val provider_config : ?model:string -> binding -> Llm_provider.Provider_config.t
+
+(** Per-provider per-attempt timeout bounds projected from OAS
+    [Provider_config] defaults plus local compatibility semantics.
+
+    [min_timeout_s] floors too-short caller budgets for cold local runtimes.
+    [max_timeout_s] caps providers that should not block past a known hard
+    ceiling. *)
+type timeout_bounds =
+  { min_timeout_s : float option
+  ; max_timeout_s : float option
+  }
+
+val timeout_bounds_of_kind :
+  Llm_provider.Provider_config.provider_kind -> timeout_bounds
+
+val max_turns_hard_cap : Llm_provider.Provider_config.provider_kind -> int option
+val clamp_max_turns : Llm_provider.Provider_config.provider_kind -> int -> int

--- a/test/dune
+++ b/test/dune
@@ -613,6 +613,7 @@
         test_bg_task_stub
         test_process_eio_detached
         test_provider_adapter
+        test_provider_runtime_overlay
         test_voice_runtime_overlay
         test_worker_container_coverage
         test_resilience
@@ -833,6 +834,7 @@
         test_bg_task_stub
         test_process_eio_detached
         test_provider_adapter
+        test_provider_runtime_overlay
         test_voice_runtime_overlay
         test_worker_container_coverage
         test_resilience

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -629,62 +629,6 @@ let test_unmetered_provider_uses_declared_telemetry_policy () =
     (Adapter.is_structurally_unmetered_provider "unknown")
 ;;
 
-(* RFC-0058 Phase 5.6 boundary helper: timeout_bounds_of_kind.
-
-   These tests seal the per-provider attempt timeout policy inside
-   the adapter boundary. The previous [match provider_cfg.kind] site
-   lived in [Keeper_turn_driver_helpers]; the helper now lives here
-   so adding vLLM/lmstudio means editing this site, not the keeper
-   layer. *)
-
-let test_timeout_bounds_ollama_has_300s_floor () =
-  let b = Adapter.timeout_bounds_of_kind Llm_provider.Provider_config.Ollama in
-  check (option (float 0.001)) "ollama min 300s" (Some 300.0) b.min_timeout_s;
-  check (option (float 0.001)) "ollama no max"    None         b.max_timeout_s
-
-let test_timeout_bounds_claude_code_has_120s_ceiling () =
-  let b =
-    Adapter.timeout_bounds_of_kind Llm_provider.Provider_config.Claude_code
-  in
-  check (option (float 0.001)) "claude_code no min" None         b.min_timeout_s;
-  check (option (float 0.001)) "claude_code max 120s" (Some 120.0) b.max_timeout_s
-
-let test_timeout_bounds_gemini_variants_share_ceiling () =
-  let b_api =
-    Adapter.timeout_bounds_of_kind Llm_provider.Provider_config.Gemini
-  in
-  let b_cli =
-    Adapter.timeout_bounds_of_kind Llm_provider.Provider_config.Gemini_cli
-  in
-  check (option (float 0.001)) "Gemini max 180s" (Some 180.0) b_api.max_timeout_s;
-  check (option (float 0.001)) "Gemini_cli max 180s" (Some 180.0)
-    b_cli.max_timeout_s
-
-let test_timeout_bounds_kimi_cli_has_60s_ceiling () =
-  let b =
-    Adapter.timeout_bounds_of_kind Llm_provider.Provider_config.Kimi_cli
-  in
-  check (option (float 0.001)) "kimi_cli max 60s" (Some 60.0) b.max_timeout_s
-
-let test_timeout_bounds_unconstrained_kinds_have_no_bounds () =
-  let unconstrained =
-    [ Llm_provider.Provider_config.Anthropic
-    ; Llm_provider.Provider_config.Kimi
-    ; Llm_provider.Provider_config.OpenAI_compat
-    ; Llm_provider.Provider_config.Glm
-    ; Llm_provider.Provider_config.DashScope
-    ; Llm_provider.Provider_config.Codex_cli
-    ]
-  in
-  List.iter
-    (fun kind ->
-       let b = Adapter.timeout_bounds_of_kind kind in
-       check (option (float 0.001))
-         "unconstrained min = None" None b.min_timeout_s;
-       check (option (float 0.001))
-         "unconstrained max = None" None b.max_timeout_s)
-    unconstrained
-
 (* RFC-0058 Phase 5.6 boundary helper: apply_wire_overlay.
 
    These tests seal the invariant that the keeper layer no longer
@@ -1048,28 +992,6 @@ let () =
             "default_local_fallback_label"
             `Quick
             test_default_local_fallback_label
-        ] )
-    ; ( "timeout_bounds_of_kind"
-      , [ test_case
-            "ollama floors at 300s"
-            `Quick
-            test_timeout_bounds_ollama_has_300s_floor
-        ; test_case
-            "claude_code ceiling 120s"
-            `Quick
-            test_timeout_bounds_claude_code_has_120s_ceiling
-        ; test_case
-            "gemini variants share 180s ceiling"
-            `Quick
-            test_timeout_bounds_gemini_variants_share_ceiling
-        ; test_case
-            "kimi_cli ceiling 60s"
-            `Quick
-            test_timeout_bounds_kimi_cli_has_60s_ceiling
-        ; test_case
-            "unconstrained kinds report no bounds"
-            `Quick
-            test_timeout_bounds_unconstrained_kinds_have_no_bounds
         ] )
     ; ( "apply_wire_overlay"
       , [ test_case

--- a/test/test_provider_runtime_overlay.ml
+++ b/test/test_provider_runtime_overlay.ml
@@ -1,0 +1,96 @@
+open Alcotest
+module Overlay = Masc_mcp.Provider_runtime_overlay
+
+let test_timeout_bounds_ollama_has_300s_floor () =
+  let b = Overlay.timeout_bounds_of_kind Llm_provider.Provider_config.Ollama in
+  check (option (float 0.001)) "ollama min 300s" (Some 300.0) b.min_timeout_s;
+  check (option (float 0.001)) "ollama no max" None b.max_timeout_s
+;;
+
+let test_timeout_bounds_claude_code_has_120s_ceiling () =
+  let b = Overlay.timeout_bounds_of_kind Llm_provider.Provider_config.Claude_code in
+  check (option (float 0.001)) "claude_code no min" None b.min_timeout_s;
+  check (option (float 0.001)) "claude_code max 120s" (Some 120.0) b.max_timeout_s
+;;
+
+let test_timeout_bounds_gemini_variants_share_ceiling () =
+  let b_api = Overlay.timeout_bounds_of_kind Llm_provider.Provider_config.Gemini in
+  let b_cli = Overlay.timeout_bounds_of_kind Llm_provider.Provider_config.Gemini_cli in
+  check (option (float 0.001)) "Gemini max 180s" (Some 180.0) b_api.max_timeout_s;
+  check (option (float 0.001)) "Gemini_cli max 180s" (Some 180.0) b_cli.max_timeout_s
+;;
+
+let test_timeout_bounds_kimi_cli_has_60s_ceiling () =
+  let b = Overlay.timeout_bounds_of_kind Llm_provider.Provider_config.Kimi_cli in
+  check (option (float 0.001)) "kimi_cli max 60s" (Some 60.0) b.max_timeout_s
+;;
+
+let test_timeout_bounds_unconstrained_kinds_have_no_bounds () =
+  let unconstrained =
+    [ Llm_provider.Provider_config.Anthropic
+    ; Llm_provider.Provider_config.Kimi
+    ; Llm_provider.Provider_config.OpenAI_compat
+    ; Llm_provider.Provider_config.Glm
+    ; Llm_provider.Provider_config.DashScope
+    ; Llm_provider.Provider_config.Codex_cli
+    ]
+  in
+  List.iter
+    (fun kind ->
+       let b = Overlay.timeout_bounds_of_kind kind in
+       check (option (float 0.001)) "unconstrained min = None" None b.min_timeout_s;
+       check (option (float 0.001)) "unconstrained max = None" None b.max_timeout_s)
+    unconstrained
+;;
+
+let test_max_turns_hard_cap_uses_oas_provider_config () =
+  check
+    (option int)
+    "claude_code hard cap"
+    (Some 30)
+    (Overlay.max_turns_hard_cap Llm_provider.Provider_config.Claude_code);
+  check
+    int
+    "claude_code clamps requested turns"
+    30
+    (Overlay.clamp_max_turns Llm_provider.Provider_config.Claude_code 99);
+  check
+    int
+    "ollama has no hard cap"
+    99
+    (Overlay.clamp_max_turns Llm_provider.Provider_config.Ollama 99)
+;;
+
+let () =
+  run
+    "provider_runtime_overlay"
+    [ ( "timeout_bounds_of_kind"
+      , [ test_case
+            "ollama floors at 300s"
+            `Quick
+            test_timeout_bounds_ollama_has_300s_floor
+        ; test_case
+            "claude_code ceiling 120s"
+            `Quick
+            test_timeout_bounds_claude_code_has_120s_ceiling
+        ; test_case
+            "gemini variants share 180s ceiling"
+            `Quick
+            test_timeout_bounds_gemini_variants_share_ceiling
+        ; test_case
+            "kimi_cli ceiling 60s"
+            `Quick
+            test_timeout_bounds_kimi_cli_has_60s_ceiling
+        ; test_case
+            "unconstrained kinds report no bounds"
+            `Quick
+            test_timeout_bounds_unconstrained_kinds_have_no_bounds
+        ] )
+    ; ( "max_turns"
+      , [ test_case
+            "uses OAS Provider_config hard cap"
+            `Quick
+            test_max_turns_hard_cap_uses_oas_provider_config
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- Move per-provider attempt timeout bounds out of `Provider_adapter` and into `Provider_runtime_overlay`.
- Route cascade attempt-timeout and max-turn hard-cap logic through the runtime overlay / OAS `Provider_config` APIs.
- Remove the hardcoded Claude max-turn cap from the LLM adapter record and keep focused regression coverage in a dedicated runtime overlay test.

## Validation

- `scripts/dune-local.sh build lib/masc_mcp.a test/test_provider_adapter.exe test/test_provider_runtime_overlay.exe test/test_oas_worker.exe`
- `_build/default/test/test_provider_adapter.exe` - 44 tests
- `_build/default/test/test_provider_runtime_overlay.exe` - 6 tests
- `_build/default/test/test_oas_worker.exe test cascade_config` - 43 tests
- `ocamlformat --check lib/provider_runtime_overlay.ml lib/provider_runtime_overlay.mli lib/provider_adapter.ml lib/provider_adapter.mli lib/cascade/cascade_runtime_candidate.ml lib/cascade/cascade_transport.ml test/test_provider_adapter.ml test/test_provider_runtime_overlay.ml test/dune`
