### PR TITLE
feat(ide): route toolbar context groups

### DIFF
--- a/dashboard/src/components/ide/ide-toolbar.test.ts
+++ b/dashboard/src/components/ide/ide-toolbar.test.ts
@@ -84,6 +84,15 @@ describe('IdeToolbar', () => {
       'Repo: 1 route link',
       'Runtime: 1 route link',
     ])
+    const routeGroupButtons = [...container.querySelectorAll<HTMLButtonElement>(
+      '.ide-toolbar-context-route-group-action',
+    )]
+    expect(routeGroupButtons.map(group => group.getAttribute('aria-label'))).toEqual([
+      'Open Code lib/runtime.ml:42',
+      'Open Task task-runtime',
+      'Open PR 15035',
+      'Open Fleet telemetry event log · query turn-9',
+    ])
 
     const routeLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-toolbar-context-links button')]
     expect(routeLinks.map(link => link.getAttribute('aria-label'))).toEqual([
@@ -98,6 +107,9 @@ describe('IdeToolbar', () => {
       .toBe('task-runtime')
     expect(routeLinks[3]?.querySelector('.ide-toolbar-context-link-evidence')?.textContent)
       .toBe('query turn-9')
+
+    fireEvent.click(routeGroupButtons.find(group => group.getAttribute('aria-label')?.includes('telemetry'))!)
+    expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&q=turn-9')
 
     fireEvent.click(routeLinks.find(link => link.getAttribute('aria-label')?.includes('telemetry'))!)
     expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&q=turn-9')
@@ -176,11 +188,17 @@ describe('IdeToolbar', () => {
       ],
     })
 
-    expect(groups).toEqual([
-      { id: 'planning', label: 'Plan', count: 1, evidence: 'Goal goal-runtime' },
-      { id: 'board', label: 'Board', count: 1, evidence: 'Comment comment-1' },
-      { id: 'repo', label: 'Repo', count: 1, evidence: 'Git abc123' },
-      { id: 'runtime', label: 'Runtime', count: 1, evidence: 'Log turn-9' },
+    expect(groups.map(group => ({
+      id: group.id,
+      label: group.label,
+      count: group.count,
+      evidence: group.evidence,
+      routeLinkId: group.routeLink.id,
+    }))).toEqual([
+      { id: 'planning', label: 'Plan', count: 1, evidence: 'Goal goal-runtime', routeLinkId: 'goal:goal-runtime' },
+      { id: 'board', label: 'Board', count: 1, evidence: 'Comment comment-1', routeLinkId: 'comment:comment-1' },
+      { id: 'repo', label: 'Repo', count: 1, evidence: 'Git abc123', routeLinkId: 'git:abc123' },
+      { id: 'runtime', label: 'Runtime', count: 1, evidence: 'Log turn-9', routeLinkId: 'log:turn-9' },
     ])
   })
 })

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -67,6 +67,7 @@ export interface ToolbarContextRouteGroup {
   readonly label: string
   readonly count: number
   readonly evidence: string
+  readonly routeLink: IdeContextFocusRouteLink
 }
 
 const TOOLBAR_ROUTE_GROUP_ORDER: ReadonlyArray<ToolbarContextRouteGroupId> = [
@@ -311,8 +312,16 @@ function ToolbarContextFocus({
               title=${group.evidence}
               aria-label=${`${group.label}: ${group.count} route ${group.count === 1 ? 'link' : 'links'}`}
             >
-              <span>${group.label}</span>
-              <span>${group.count}</span>
+              <button
+                type="button"
+                class="ide-toolbar-context-route-group-action"
+                title=${group.evidence}
+                aria-label=${`Open ${group.evidence}`}
+                onClick=${() => openToolbarContextRouteLink(group.routeLink)}
+              >
+                <span>${group.label}</span>
+                <span>${group.count}</span>
+              </button>
             </span>
           `)}
         </div>
@@ -369,6 +378,7 @@ export function deriveToolbarContextRouteGroups(
       label: TOOLBAR_ROUTE_GROUP_LABELS[groupId],
       count: groupLinks.length,
       evidence: groupLinks.map(link => link.evidence).join(' / '),
+      routeLink: groupLinks[0]!,
     }]
   })
 }

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -373,10 +373,9 @@
 .ide-toolbar-context-route-groups > span {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
   min-width: 0;
   height: 18px;
-  padding: 0 5px;
+  padding: 0;
   border: 1px solid color-mix(in srgb, var(--color-accent-fg) 32%, var(--color-border-default));
   border-radius: var(--r-1);
   background: color-mix(in srgb, var(--color-bg-elevated) 88%, var(--color-accent-bg));
@@ -384,14 +383,39 @@
   overflow: hidden;
 }
 
-.ide-toolbar-context-route-groups > span > span {
+.ide-toolbar-context-route-group-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  min-width: 0;
+  height: 100%;
+  padding: 0 5px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+}
+
+.ide-toolbar-context-route-group-action:hover,
+.ide-toolbar-context-route-group-action:focus-visible {
+  color: var(--color-accent-fg);
+  background: color-mix(in srgb, var(--color-accent-bg) 26%, transparent);
+}
+
+.ide-toolbar-context-route-group-action:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: -1px;
+}
+
+.ide-toolbar-context-route-group-action > span {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.ide-toolbar-context-route-groups > span > span:last-child {
+.ide-toolbar-context-route-group-action > span:last-child {
   color: var(--color-fg-muted);
 }
 


### PR DESCRIPTION
## Summary
- Make toolbar current-context route group chips actionable through their representative route link.
- Preserve existing individual context route links and command bar actions.
- Add coverage for group route navigation and routeLink retention.

## Validation
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/ide-toolbar.ts src/components/ide/ide-toolbar.test.ts
- pnpm exec vitest run src/components/ide/ide-toolbar.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check