### PR TITLE
fix(dashboard): bound safe-autonomy read model verification

### DIFF
--- a/docs/DASHBOARD-INTEGRATION.md
+++ b/docs/DASHBOARD-INTEGRATION.md
@@ -121,6 +121,8 @@ code_refs:
   - fleet-health attribution view
 - `GET /api/v1/dashboard/safe-autonomy`
   - operations safety view
+- `GET /api/v1/dashboard/transport-health`
+  - runtime transport health + connection freshness view
 - `GET /api/v1/dashboard/keeper-feature-proof`
   - keeper autonomy feature proof gates, including 24h turn-span and web-search tool evidence
   - tool gates count only calls from known keeper names and expose `keeper_evidence.provenance_scope=known_keeper_tool_call_log`, per-tool successful/failing keepers, sandbox/network modes, task IDs, and goal IDs

--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -716,7 +716,9 @@ let build_keeper_snapshot
     ~(activity_by_keeper : (string, activity_stats) Hashtbl.t)
     (meta : keeper_meta) =
   let sandbox = Keeper_sandbox.of_meta ~config ~meta in
-  let repo_readiness = Keeper_repo_readiness.inspect ~config ~meta () in
+  let repo_readiness =
+    Keeper_repo_readiness.inspect ~workspace_discovery:false ~config ~meta ()
+  in
   let recommendation =
     recommendation_for_keeper bench_manifest ~keeper_name:meta.name
   in
@@ -765,10 +767,10 @@ let build_keeper_snapshot
       @ cascade_findings @ audit_findings;
   }
 
-(* The safe-autonomy screen renders one row per keeper.  This probe is
-   intentionally much shorter than interactive sandbox-status calls; otherwise
-   a slow Docker daemon costs [timeout * keeper_count] before the dashboard can
-   return any bytes.
+(* The safe-autonomy screen renders one row per keeper. Its Docker probe is
+   intentionally much shorter than interactive sandbox-status calls, and the
+   fleet renderer batches the base-path-scoped container listing once per
+   payload before filtering by keeper in memory.
 
    Floor at 1.0s rather than 0.25s: [Process_eio] timeouts surface
    through [Log.warn]-style sites that format duration with [%.0f],
@@ -776,29 +778,41 @@ let build_keeper_snapshot
    reading "command timed out after 0s".  1.0s produces a
    self-explanatory diagnostic when Docker is genuinely slow.
 
-   Worst-case budget bookkeeping (PR #13113 review):
    [Keeper_sandbox_runtime.list_containers] internally runs TWO
    sequential Docker commands (`docker ps` then `docker inspect`),
-   each gated by [~timeout_sec].  The per-row worst case is
-   therefore [2 * timeout_sec], not [timeout_sec].  At 1.0s × 2
-   commands × 50 keepers the screen budget is ~100s in the
-   worst case where every Docker call stalls — well above the
-   typical 15s client deadline, but bounded.  In the common case
-   Docker responds in tens of ms and the screen returns in <1s.
-   Operators who need a tighter overall budget should either
-   reduce keeper count surfaced here, or wait for the upstream
-   "single overall probe budget" follow-up (RFC TBD) that would
-   short-circuit further probes once a wall-clock deadline is hit.
+   each gated by [~timeout_sec]. Because the dashboard calls it once for the
+   fleet rather than once per keeper, a stalled Docker daemon costs about
+   [2 * timeout_sec] per render instead of [2 * timeout_sec * keeper_count].
 *)
 let sandbox_live_probe_timeout_sec = 1.0
 
-let keeper_snapshot_json ~(config : Coord.config) (snapshot : keeper_snapshot) =
+let dashboard_sandbox_containers ~(config : Coord.config) keepers =
+  if
+    List.exists
+      (fun (meta : keeper_meta) -> meta.sandbox_profile = Docker)
+      keepers
+  then
+    Some
+      (Keeper_sandbox_runtime.list_containers
+         ~base_path:config.Coord.base_path
+         ~timeout_sec:sandbox_live_probe_timeout_sec
+         ())
+  else
+    None
+
+let keeper_snapshot_json
+    ?containers_override
+    ~(config : Coord.config)
+    (snapshot : keeper_snapshot)
+  =
   let meta = snapshot.meta in
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   let sandbox = snapshot.sandbox in
   let sandbox_live =
     Keeper_sandbox_control.live_status_json
       ~include_preflight:false
+      ?containers_override
+      ~include_playground_repos:false
       ~config ~meta ~timeout_sec:sandbox_live_probe_timeout_sec ~verbose:false ()
   in
   let domains =
@@ -1168,7 +1182,10 @@ let json ~(config : Coord.config) () =
     ]
   in
   let per_keeper =
-    List.map (keeper_snapshot_json ~config) keeper_snapshots
+    let containers_override = dashboard_sandbox_containers ~config keepers in
+    List.map
+      (keeper_snapshot_json ?containers_override ~config)
+      keeper_snapshots
   in
   let total_active_goals =
     List.fold_left

--- a/lib/keeper/keeper_repo_readiness.ml
+++ b/lib/keeper/keeper_repo_readiness.ml
@@ -90,6 +90,7 @@ let int_opt_field name = function
 let inspect
     ~(config : Coord.config)
     ~(meta : keeper_meta)
+    ?(workspace_discovery = true)
     ?repo_name
     ?(repo = "")
     ?(default_branch = "main")
@@ -130,6 +131,16 @@ let inspect
         "exists", `Bool false;
         "is_git_repo", `Bool false;
         "has_origin", `Bool false;
+      ]
+  else if not (safe_is_dir clone_path) && not workspace_discovery then
+    common_fields "missing_clone" false
+      "Clone the repo into sandbox repos/ first with keeper_shell op=git_clone, then create a worktree."
+      [
+        "exists", `Bool false;
+        "is_git_repo", `Bool false;
+        "has_origin", `Bool false;
+        "workspace_discovery", `String "skipped";
+        "auto_provision_on_worktree_create", `Bool false;
       ]
   else if not (safe_is_dir clone_path) then
     let workspace_matches =

--- a/lib/keeper/keeper_repo_readiness.mli
+++ b/lib/keeper/keeper_repo_readiness.mli
@@ -62,8 +62,13 @@ val int_opt_field :
 val inspect :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
+  ?workspace_discovery:bool ->
   ?repo_name:string ->
   ?repo:string ->
   ?default_branch:string ->
   unit ->
   Yojson.Safe.t
+(** [workspace_discovery] controls whether a missing sandbox clone scans the
+    workspace for a matching source checkout. It defaults to [true] for
+    preflight/actionable flows. Dashboard fleet read models can pass [false]
+    to avoid an expensive recursive workspace scan per keeper row. *)

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -71,6 +71,15 @@ let live_containers ~config ~meta ~timeout_sec =
     ~timeout_sec
     ()
 
+let live_containers_for_keeper ~(meta : keeper_meta) containers =
+  let keeper_label = Keeper_sandbox_runtime.sanitize_label_value meta.name in
+  List.filter
+    (fun (c : Keeper_sandbox_runtime.live_container) ->
+      match c.keeper_name with
+      | Some name -> String.equal name meta.name || String.equal name keeper_label
+      | None -> false)
+    containers
+
 let running_managed_container ~network_label containers =
   List.find_opt
     (fun (c : Keeper_sandbox_runtime.live_container) ->
@@ -503,6 +512,8 @@ let identity_json (meta : keeper_meta) =
 
 let live_status_json ?(include_preflight = true)
     ?preflight_override
+    ?containers_override
+    ?(include_playground_repos = true)
     ~(config : Coord.config)
     ~(meta : keeper_meta)
     ~(timeout_sec : float)
@@ -519,9 +530,14 @@ let live_status_json ?(include_preflight = true)
   in
   let containers, container_error =
     if meta.sandbox_profile = Docker then
-      match live_containers ~config ~meta ~timeout_sec with
-      | Ok containers -> (containers, None)
-      | Error err -> ([], Some err)
+      match containers_override with
+      | Some (Ok containers) ->
+          (live_containers_for_keeper ~meta containers, None)
+      | Some (Error err) -> ([], Some err)
+      | None -> (
+        match live_containers ~config ~meta ~timeout_sec with
+        | Ok containers -> (containers, None)
+        | Error err -> ([], Some err))
     else
       ([], None)
   in
@@ -551,6 +567,14 @@ let live_status_json ?(include_preflight = true)
       ("container_error", Json_util.string_opt_to_json container_error);
       ("why_no_container", Json_util.string_opt_to_json why_no_container);
       ("recommendation", Json_util.string_opt_to_json recommendation);
-      ("playground_repos", playground_repos_json ~config ~meta);
+      ( "playground_repos",
+        if include_playground_repos then
+          playground_repos_json ~config ~meta
+        else
+          `List [] );
+      ( "playground_repos_source",
+        `String
+          (if include_playground_repos then "live"
+           else "skipped_dashboard_hot_path") );
       ("identity", identity_json meta);
     ]

--- a/lib/keeper/keeper_sandbox_control.mli
+++ b/lib/keeper/keeper_sandbox_control.mli
@@ -53,6 +53,8 @@ val playground_repos_json :
 val live_status_json :
   ?include_preflight:bool ->
   ?preflight_override:Yojson.Safe.t option ->
+  ?containers_override:(Keeper_sandbox_runtime.live_container list, string) result ->
+  ?include_playground_repos:bool ->
   config:Coord.config ->
   meta:keeper_meta ->
   timeout_sec:float ->
@@ -64,7 +66,14 @@ val live_status_json :
     the per-keeper render skips its own [docker_preflight] call.
     Pass [Some json] for the cached result, or [None] for "preflight
     was attempted but yielded nothing".  Without this override the
-    render falls back to its own preflight invocation. *)
+    render falls back to its own preflight invocation.
+
+    [containers_override] lets a fleet caller reuse one base-path-scoped
+    Docker listing and filter it by keeper in memory.  Without it the
+    render performs its own keeper-scoped Docker listing.
+
+    [include_playground_repos=false] skips live playground repo enrichment,
+    including per-repo Git metadata probes, for dashboard hot paths. *)
 
 val preflight_status_json :
   timeout_sec:float -> Yojson.Safe.t option

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -175,6 +175,10 @@ check_http "transport health 200" "$BASE/api/v1/dashboard/transport-health" "200
 check_json "transport health has summary" "$BASE/api/v1/dashboard/transport-health" "'summary' in d" '^True$'
 check_http "attribution summary 200" "$BASE/api/v1/attribution/summary" "200"
 check_json "attribution summary has gates" "$BASE/api/v1/attribution/summary" "'gates' in d" '^True$'
+check_http "safe autonomy 200" "$BASE/api/v1/dashboard/safe-autonomy" "200"
+check_json "safe autonomy exposes scorecard" "$BASE/api/v1/dashboard/safe-autonomy" "'summary' in d and 'domains' in d and 'per_keeper' in d" '^True$'
+check_http "keeper feature proof 200" "$BASE/api/v1/dashboard/keeper-feature-proof?window_hours=24" "200"
+check_json "keeper feature proof exposes features" "$BASE/api/v1/dashboard/keeper-feature-proof?window_hours=24" "'summary' in d and 'features' in d and 'evidence_refs' in d" '^True$'
 
 echo "[4/7] Operations + Workspace"
 check_http "operator digest 200" "$BASE/api/v1/operator/digest" "200"

--- a/test/test_dashboard_safe_autonomy.ml
+++ b/test/test_dashboard_safe_autonomy.ml
@@ -239,25 +239,31 @@ let test_history_field_returns_last_15_scores () =
     (List.init 15 (fun idx -> float_of_int (idx + 6)))
     history
 
-let test_sandbox_live_probe_is_bounded_per_keeper () =
+let test_sandbox_live_probe_is_batched_for_dashboard () =
   with_safe_autonomy_store @@ fun config ->
   ignore (persist_docker_keeper config ~name:"docker-a");
   ignore (persist_docker_keeper config ~name:"docker-b");
+  ignore (persist_docker_keeper config ~name:"docker-c");
+  ignore (persist_docker_keeper config ~name:"docker-d");
   let fake_docker = write_slow_fake_docker () in
   with_env "MASC_TEST_FAKE_DOCKER_PATH" (Some fake_docker) (fun () ->
     let started_at = Unix.gettimeofday () in
     let json = Dashboard_safe_autonomy.json ~config () in
     let elapsed_sec = Unix.gettimeofday () -. started_at in
-    (* PR #13113: per-keeper probe timeout is 1.0s (raised from
-       0.25s so [Process_eio]'s [%.0f] log formatter prints "1s"
-       instead of the misleading "0s").  With 2 stalled docker
-       keepers serialised through the screen, the worst-case is
-       roughly 2 * 1.0s + scheduler / I-O overhead.  Bound at 3.5s
-       to keep the regression test alarm narrow without flaking on
-       slow CI runners. *)
-    check bool "slow docker probe is bounded" true (elapsed_sec < 3.5);
+    (* The dashboard should pay the stalled Docker listing timeout once
+       for the fleet, not once per Docker keeper. Four keepers would exceed
+       this bound if the probe were still serialized per row. *)
+    check bool "slow docker probe is batched" true (elapsed_sec < 3.5);
     let per_keeper = Yojson.Safe.Util.(json |> member "per_keeper" |> to_list) in
-    check int "docker keeper count" 2 (List.length per_keeper))
+    check int "docker keeper count" 4 (List.length per_keeper);
+    check bool "playground repo git enrichment skipped" true
+      (List.for_all
+         (fun keeper ->
+           Yojson.Safe.Util.(
+             keeper |> member "sandbox_live" |> member "playground_repos_source"
+             |> to_string)
+           = "skipped_dashboard_hot_path")
+         per_keeper))
 
 let () =
   run "dashboard_safe_autonomy"
@@ -270,7 +276,7 @@ let () =
             test_history_dedupes_identical_payloads;
           test_case "history field returns last 15 scores" `Quick
             test_history_field_returns_last_15_scores;
-          test_case "sandbox live probe is bounded per keeper" `Quick
-            test_sandbox_live_probe_is_bounded_per_keeper;
+          test_case "sandbox live probe is batched for dashboard" `Quick
+            test_sandbox_live_probe_is_batched_for_dashboard;
         ] );
     ]

--- a/test/test_keeper_repo_readiness.ml
+++ b/test/test_keeper_repo_readiness.ml
@@ -174,6 +174,42 @@ let test_auto_provisionable_workspace_repo () =
       Masc_mcp.Tool_code_write.extract_github_org_repo url
       |> Option.value ~default:"")
 
+let test_missing_clone_skips_workspace_discovery () =
+  let base_path = temp_dir "masc-repo-readiness" in
+  write_tool_policy ~base_path;
+  let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
+  let remote = Filename.concat base_path ".remote-masc-mcp.git" in
+  mkdir_p (Filename.dirname repo);
+  run_ok ~cwd:base_path
+    (Printf.sprintf "git init --bare -q --initial-branch=main %s"
+       (Filename.quote remote));
+  run_ok ~cwd:base_path
+    (Printf.sprintf "git clone -q %s %s"
+       (Filename.quote remote) (Filename.quote repo));
+  run_ok ~cwd:repo "git config user.email test@example.com";
+  run_ok ~cwd:repo "git config user.name Test";
+  let readme = Filename.concat repo "README.md" in
+  let oc = open_out readme in
+  output_string oc "# readiness\n";
+  close_out oc;
+  run_ok ~cwd:repo "git add README.md";
+  run_ok ~cwd:repo "git commit -q -m init";
+  run_ok ~cwd:repo "git push -q origin main";
+  set_workspace_origin_to_github ~repo;
+  let config = Masc_mcp.Coord.default_config base_path in
+  let meta = make_meta "keeper-one" in
+  let json =
+    Masc_mcp.Keeper_repo_readiness.inspect ~config ~meta
+      ~repo_name:"masc-mcp" ~workspace_discovery:false ()
+  in
+  check bool "not ok" false (json_bool "ok" json);
+  check string "state" "missing_clone" (json_string "state" json);
+  check string "workspace discovery" "skipped"
+    Yojson.Safe.Util.(json |> member "workspace_discovery" |> to_string);
+  check bool "auto provision disabled" false
+    Yojson.Safe.Util.(
+      json |> member "auto_provision_on_worktree_create" |> to_bool)
+
 let test_auto_provisionable_workspace_repo_after_file_storm () =
   let base_path = temp_dir "masc-repo-readiness" in
   write_tool_policy ~base_path;
@@ -287,6 +323,8 @@ let () =
         test_case "invalid repo_name" `Quick test_invalid_repo_name;
         test_case "auto provisionable workspace repo" `Quick
           test_auto_provisionable_workspace_repo;
+        test_case "missing clone skips workspace discovery" `Quick
+          test_missing_clone_skips_workspace_discovery;
         test_case "auto provisionable workspace repo after file storm" `Quick
           test_auto_provisionable_workspace_repo_after_file_storm;
         test_case "auto provisionable workspace repo before hidden dir storm"


### PR DESCRIPTION
## Summary

- Add verifier coverage for canonical dashboard read models that were documented but not exercised: `safe-autonomy` and `keeper-feature-proof`.
- Document `transport-health` in the canonical dashboard read-model list so the docs and verifier stay aligned.
- Bound the safe-autonomy dashboard hot path by skipping recursive workspace discovery for repo readiness, batching Docker container listing once per fleet render, and skipping live playground repo Git enrichment from the fleet row renderer.
- Add regression coverage for skipped workspace discovery and batched slow Docker probing across multiple Docker keepers.

## Review Focus

- `Dashboard_safe_autonomy.json` should keep fleet-row rendering bounded even when the base path is large or Docker is slow.
- `Keeper_repo_readiness.inspect` still defaults to workspace discovery for actionable/preflight flows; only dashboard callers opt out.
- `Keeper_sandbox_control.live_status_json` keeps existing behavior by default; new optional parameters are only used by fleet callers.

## Validation

- `ocamlformat --check lib/keeper/keeper_repo_readiness.ml lib/keeper/keeper_repo_readiness.mli lib/keeper/keeper_sandbox_control.ml lib/keeper/keeper_sandbox_control.mli lib/dashboard/dashboard_safe_autonomy.ml test/test_keeper_repo_readiness.ml test/test_dashboard_safe_autonomy.ml`
- `git diff --check`
- `bash -n scripts/verify-dashboard.sh`
- dashboard doc/verifier endpoint parity script: `canonical missing from verify: []`, `verify not canonical: []`
- `scripts/dune-local.sh build test/test_keeper_repo_readiness.exe test/test_dashboard_safe_autonomy.exe`
- `./_build/default/test/test_keeper_repo_readiness.exe` (8 tests)
- `./_build/default/test/test_dashboard_safe_autonomy.exe` (4 tests)

## Notes

- Live `http://127.0.0.1:8935/health` recovered to `200` after the earlier wedged endpoint probe, so no local service restart was needed.
