### PR TITLE
fix(telemetry): record tool input validation outcomes

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -784,6 +784,7 @@ let metric_provider_prefix_cache_read_tokens =
 
 let metric_tool_call = "masc_tool_call_total"
 let metric_tool_call_duration = "masc_tool_call_duration_seconds"
+let metric_tool_input_validation = "masc_tool_input_validation_total"
 let metric_llm_provider_http_status = "masc_llm_provider_http_status_total"
 let metric_llm_provider_request_latency = "masc_llm_provider_request_latency_seconds"
 let metric_llm_provider_request_latency_clamped = "masc_llm_provider_request_latency_clamped_total"
@@ -1483,6 +1484,10 @@ let init () =
   add
     metric_tool_call
     "Total keeper tool calls labeled by provider, tool, and outcome"
+    Counter;
+  add
+    metric_tool_input_validation
+    "Total tool input validation outcomes labeled by tool, result, and reason"
     Counter;
   (* PR-0.2.C: pre-register cold/warm phase rows so /metrics shows a
      zero-value baseline before the first observation. The phase label

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -470,6 +470,7 @@ val metric_provider_prefix_cache_creation_tokens : string
 val metric_provider_prefix_cache_read_tokens : string
 val metric_tool_call : string
 val metric_tool_call_duration : string
+val metric_tool_input_validation : string
 val metric_llm_provider_http_status : string
 val metric_llm_provider_request_latency : string
 val metric_llm_provider_request_latency_clamped : string

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -121,6 +121,42 @@ let prepare_args ?schema ~name args =
   normalize_blank_optional_enum_args ?schema args
 ;;
 
+let schema_has_properties = function
+  | `Assoc fields ->
+    (match List.assoc_opt "properties" fields with
+     | Some (`Assoc (_ :: _)) -> true
+     | _ -> false)
+  | _ -> false
+;;
+
+let emit_validation_telemetry ~tool ~result ~reason =
+  Prometheus.inc_counter
+    Prometheus.metric_tool_input_validation
+    ~labels:[ "tool", tool; "result", result; "reason", reason ]
+    ();
+  Otel_spans.add_event
+    ~name:"tool.param.validation"
+    ~attrs:
+      [ "tool.name", `String tool
+      ; "tool.param.validation.result", `String result
+      ; "tool.param.validation.reason", `String reason
+      ]
+    ()
+;;
+
+let pass_reason ~schema ~args ~prepared_args =
+  match schema with
+  | None -> "missing_schema"
+  | Some schema when not (schema_has_properties schema) -> "empty_schema"
+  | Some _ when not (Yojson.Safe.equal prepared_args args) -> "normalized"
+  | Some _ -> "valid"
+;;
+
+let pass_result = function
+  | "missing_schema" | "empty_schema" -> "bypass"
+  | _ -> "pass"
+;;
+
 let validation_action ?schema ~name ~args () : Tool_dispatch.pre_hook_action =
   let lookup name =
     let schema =
@@ -139,13 +175,22 @@ let validation_action ?schema ~name ~args () : Tool_dispatch.pre_hook_action =
   let prepared_args = prepare_args ?schema ~name args in
   match hook ~name ~args:prepared_args with
   | Agent_sdk.Tool_middleware.Pass when not (Yojson.Safe.equal prepared_args args) ->
+    let reason = pass_reason ~schema ~args ~prepared_args in
+    let result = pass_result reason in
+    emit_validation_telemetry ~tool:name ~result ~reason;
     Log.debug "tool_input_validation normalized args for %s" name;
     Proceed prepared_args
-  | Agent_sdk.Tool_middleware.Pass -> Pass
+  | Agent_sdk.Tool_middleware.Pass ->
+    let reason = pass_reason ~schema ~args ~prepared_args in
+    let result = pass_result reason in
+    emit_validation_telemetry ~tool:name ~result ~reason;
+    Pass
   | Agent_sdk.Tool_middleware.Proceed coerced ->
+    emit_validation_telemetry ~tool:name ~result:"pass" ~reason:"coerced";
     Log.debug "tool_input_validation coerced args for %s" name;
     Proceed coerced
   | Agent_sdk.Tool_middleware.Reject { message; _ } ->
+    emit_validation_telemetry ~tool:name ~result:"fail" ~reason:"invalid_args";
     Log.info "tool_input_validation rejected %s: %s" name message;
     Reject
       { Tool_result.success = false

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -443,6 +443,7 @@ let test_review_blocker_metrics_registered () =
   check_registered Prometheus.metric_telemetry_coverage_gap;
   check_registered Prometheus.metric_telemetry_unified_source_read_failures;
   check_registered Prometheus.metric_tool_assignment_telemetry_failures;
+  check_registered Prometheus.metric_tool_input_validation;
   check_registered Masc_mcp.Keeper_metrics.metric_keeper_oas_hook_output_parse_failures;
   check_registered Prometheus.metric_inference_queue_rejected;
   check_registered Prometheus.metric_telemetry_observe_failures;

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -380,6 +380,197 @@ let assoc_string key json =
   | `String value -> value
   | _ -> failwith ("expected string field: " ^ key)
 
+let validation_labels ~tool ~result ~reason =
+  [ "tool", tool; "result", result; "reason", reason ]
+
+let validation_metric_value ~tool ~result ~reason =
+  Prometheus.metric_value_or_zero
+    Prometheus.metric_tool_input_validation
+    ~labels:(validation_labels ~tool ~result ~reason)
+    ()
+
+let check_validation_metric_increment ~tool ~result ~reason f =
+  let before = validation_metric_value ~tool ~result ~reason in
+  f ();
+  let after = validation_metric_value ~tool ~result ~reason in
+  Alcotest.(check (float 0.0001))
+    (Printf.sprintf "metric %s/%s/%s increments" tool result reason)
+    (before +. 1.0)
+    after
+
+let attr_string key attrs =
+  match List.assoc_opt key attrs with
+  | Some (`String value) -> Some value
+  | _ -> None
+
+let test_validation_telemetry_records_pass_fail_and_bypass () =
+  let valid_tool = "__tool_input_validation_metric_valid" in
+  let valid_schema = make_schema [ "count", "integer" ] in
+  check_validation_metric_increment
+    ~tool:valid_tool
+    ~result:"pass"
+    ~reason:"valid"
+    (fun () ->
+       match
+         Tool_input_validation.validate_args
+           ~schema:valid_schema
+           ~name:valid_tool
+           ~args:(`Assoc [ "count", `Int 42 ])
+           ()
+       with
+       | Ok _ -> ()
+       | Error result ->
+         Alcotest.fail
+           (Printf.sprintf
+              "expected valid input, got %s"
+              (Yojson.Safe.to_string result.Tool_result.data)));
+  let coerced_tool = "__tool_input_validation_metric_coerced" in
+  check_validation_metric_increment
+    ~tool:coerced_tool
+    ~result:"pass"
+    ~reason:"coerced"
+    (fun () ->
+       match
+         Tool_input_validation.validate_args
+           ~schema:valid_schema
+           ~name:coerced_tool
+           ~args:(`Assoc [ "count", `String "42" ])
+           ()
+       with
+       | Ok coerced ->
+         (match Yojson.Safe.Util.member "count" coerced with
+          | `Int 42 -> ()
+          | _ -> Alcotest.fail "expected coerced integer")
+       | Error result ->
+         Alcotest.fail
+           (Printf.sprintf
+              "expected coerced input, got %s"
+              (Yojson.Safe.to_string result.Tool_result.data)));
+  let fail_tool = "__tool_input_validation_metric_fail" in
+  check_validation_metric_increment
+    ~tool:fail_tool
+    ~result:"fail"
+    ~reason:"invalid_args"
+    (fun () ->
+       match
+         Tool_input_validation.validate_args
+           ~schema:valid_schema
+           ~name:fail_tool
+           ~args:(`Assoc [ "count", `String "not-an-int" ])
+           ()
+       with
+       | Error _ -> ()
+       | Ok _ -> Alcotest.fail "expected invalid args failure");
+  let missing_tool = "__tool_input_validation_metric_missing_schema" in
+  check_validation_metric_increment
+    ~tool:missing_tool
+    ~result:"bypass"
+    ~reason:"missing_schema"
+    (fun () ->
+       match
+         Tool_input_validation.validate_args
+           ~name:missing_tool
+           ~args:(`Assoc [ "count", `String "not-validated" ])
+           ()
+       with
+       | Ok _ -> ()
+       | Error result ->
+         Alcotest.fail
+           (Printf.sprintf
+              "expected missing schema bypass, got %s"
+              (Yojson.Safe.to_string result.Tool_result.data)));
+  let empty_tool = "__tool_input_validation_metric_empty_schema" in
+  check_validation_metric_increment
+    ~tool:empty_tool
+    ~result:"bypass"
+    ~reason:"empty_schema"
+    (fun () ->
+       match
+         Tool_input_validation.validate_args
+           ~schema:(`Assoc [])
+           ~name:empty_tool
+           ~args:(`Assoc [ "anything", `String "goes" ])
+           ()
+       with
+       | Ok _ -> ()
+       | Error result ->
+         Alcotest.fail
+           (Printf.sprintf
+              "expected empty schema bypass, got %s"
+              (Yojson.Safe.to_string result.Tool_result.data)))
+
+let test_validation_telemetry_records_normalized_transition () =
+  check_validation_metric_increment
+    ~tool:"masc_transition"
+    ~result:"pass"
+    ~reason:"normalized"
+    (fun () ->
+       match
+         Tool_input_validation.validate_args
+           ~schema:masc_transition_schema
+           ~name:"masc_transition"
+           ~args:
+             (`Assoc
+                [
+                  "agent_name", `String "codex-local-admin";
+                  "task_id", `String "task-239";
+                  "to", `String "claimed";
+                  "note", `String "PR #8308 Draft";
+                ])
+           ()
+       with
+       | Ok forwarded ->
+         Alcotest.(check string)
+           "to normalized to action"
+           "claimed"
+           (assoc_string "action" forwarded);
+         Alcotest.(check string)
+           "note normalized to notes"
+           "PR #8308 Draft"
+           (assoc_string "notes" forwarded)
+       | Error result ->
+         Alcotest.fail
+           (Printf.sprintf
+              "expected normalized transition, got %s"
+              (Yojson.Safe.to_string result.Tool_result.data)))
+
+let test_validation_telemetry_emits_otel_event () =
+  let tool = "__tool_input_validation_otel_event" in
+  let schema = make_schema ~required:[ "path" ] [ "path", "string" ] in
+  let events = ref [] in
+  Otel_spans.with_test_event_emitter
+    ~enabled:true
+    ~emit_event:(fun ~name ~attrs -> events := (name, attrs) :: !events)
+    (fun () ->
+       match
+         Tool_input_validation.validate_args
+           ~schema
+           ~name:tool
+           ~args:(`Assoc [])
+           ()
+       with
+       | Error _ -> ()
+       | Ok _ -> Alcotest.fail "expected validation failure");
+  match !events with
+  | [ event_name, attrs ] ->
+    Alcotest.(check string)
+      "event name"
+      "tool.param.validation"
+      event_name;
+    Alcotest.(check (option string))
+      "tool attr"
+      (Some tool)
+      (attr_string "tool.name" attrs);
+    Alcotest.(check (option string))
+      "validation result attr"
+      (Some "fail")
+      (attr_string "tool.param.validation.result" attrs);
+    Alcotest.(check (option string))
+      "validation reason attr"
+      (Some "invalid_args")
+      (attr_string "tool.param.validation.reason" attrs)
+  | _ -> Alcotest.fail "expected exactly one validation event"
+
 let test_registered_hook_transition_compat_to_and_note () =
   let args =
     `Assoc
@@ -549,6 +740,14 @@ let () =
       Alcotest.test_case "empty schema passes" `Quick test_empty_schema_passes;
       Alcotest.test_case "schema union type does not raise" `Quick
         test_schema_union_type_does_not_raise;
+    ]);
+    ("telemetry", [
+      Alcotest.test_case "records pass, fail, and bypass counters" `Quick
+        test_validation_telemetry_records_pass_fail_and_bypass;
+      Alcotest.test_case "records normalized transition counter" `Quick
+        test_validation_telemetry_records_normalized_transition;
+      Alcotest.test_case "emits OTel validation event" `Quick
+        test_validation_telemetry_emits_otel_event;
     ]);
     ("registered_hook", [
       Alcotest.test_case "coercion flows through registered hook" `Quick


### PR DESCRIPTION
## Summary

Adds telemetry for tool input validation outcomes from the OAS-backed pre-dispatch validator.

- Adds `masc_tool_input_validation_total` with bounded `result` and `reason` labels.
- Emits an OTel `tool.param.validation` event with `tool.param.validation.result`.
- Covers pass, coerced, normalized, failed, missing-schema bypass, and empty-schema bypass paths.

## Product impact

Operators can now distinguish "tool call failed" from "LLM produced invalid tool parameters" and can track validation pass/fail/bypass rates without scraping logs.

## Evidence

- Kimi telemetry gap doc calls out Tool Parameter validity as `tool.param.validation.result`.
- Current code only counted keeper OAS failures on rejected keeper tool input; pass/coerce/bypass paths had no direct validation outcome signal.

## Review evidence

- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_tool_input_validation.exe test/test_prometheus_coverage.exe`
- `./_build/default/test/test_tool_input_validation.exe`
- `./_build/default/test/test_prometheus_coverage.exe`
- `ocamlformat --check lib/tool_input_validation.ml test/test_tool_input_validation.ml lib/prometheus.ml lib/prometheus.mli test/test_prometheus_coverage.ml`
- `git diff origin/main --check`

## Linked issue

None.
