### PR TITLE
fix(provider): split spawn runtime overlay

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -98,7 +98,7 @@ let agent_type_of_mention = Mention.agent_type_of_mention
 
 let is_spawnable mention =
   let base = agent_type_of_mention mention in
-  Option.is_some (Spawn.get_config base)
+  Spawn_runtime_overlay.is_spawnable_agent base
 
 (* --- CLI spawn (Spawn mode) --- *)
 
@@ -126,9 +126,11 @@ let cli_argv_of_agent_type (agent_type : string) : string list =
   | None -> [agent_type]
 
 let run_cli_agent ~agent_type ~prompt =
-  match Spawn.get_config agent_type with
-  | None -> debug_log (Printf.sprintf "SPAWN_SKIP not spawnable: %s" agent_type)
-  | Some _ ->
+  if Spawn_runtime_overlay.is_bare_ollama_label agent_type then
+    debug_log (Spawn_runtime_overlay.bare_ollama_migration_message ())
+  else if not (Spawn_runtime_overlay.is_spawnable_agent agent_type) then
+    debug_log (Printf.sprintf "SPAWN_SKIP not spawnable: %s" agent_type)
+  else
     let base = cli_argv_of_agent_type agent_type in
     let argv = base in
     let raw_source = String.concat " " (List.map Filename.quote argv) in

--- a/lib/dune
+++ b/lib/dune
@@ -112,6 +112,7 @@
   keeper_exec_status
   provider_tool_support
   voice_runtime_overlay
+  spawn_runtime_overlay
   keeper_status_detail
   keeper_exec_persona
   keeper_model_labels

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -584,27 +584,9 @@ let resolve_direct_canonical_name label =
     (resolve_direct_adapter label)
 ;;
 
-(** Resolve spawn_key for an agent label.
-    Returns the key to look up in Spawn.spawn_config_of_key. *)
-let resolve_spawn_key label =
-  match resolve_direct_adapter label with
-  | Some adapter -> adapter.spawn_key
-  | None -> None
-;;
-
 (** Check if a name is a known direct adapter label or alias.
     This includes adapters that do not have a CLI spawn_key (e.g. glm, openrouter). *)
 let is_known_provider name = resolve_direct_adapter name <> None
-
-(** Check if a name is a CLI-spawnable agent (has a spawn_key).
-    For a broader "known provider" predicate, use {!is_known_provider}. *)
-let is_spawnable_agent name = resolve_spawn_key name <> None
-
-let spawnable_canonical_names () =
-  direct_adapters
-  |> List.filter_map (fun a ->
-    if a.spawn_key <> None then Some a.canonical_name else None)
-;;
 
 let normalize_base_url value =
   let trimmed = String.trim value in
@@ -662,16 +644,6 @@ let auth_kind_for_canonical_name name =
   match resolve_direct_adapter name with
   | Some adapter -> string_of_auth_mode adapter.auth_mode
   | None -> "unknown"
-;;
-
-let bare_ollama_migration_message () =
-  "Bare `ollama` without a model requires OLLAMA_DEFAULT_MODEL env var. Use \
-   `ollama:<model>` for explicit selection."
-;;
-
-let is_bare_ollama_label label =
-  let normalized = normalize_label label in
-  String.equal normalized cn_ollama && Env_config_runtime.Ollama.default_model = ""
 ;;
 
 let explicit_llama_model_id_result () =

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -211,17 +211,8 @@ val resolve_adapter_by_cascade_prefix : string -> adapter option
 (** Resolve the canonical name for a provider label. *)
 val resolve_direct_canonical_name : string -> string option
 
-(** Resolve spawn_key for an agent label. *)
-val resolve_spawn_key : string -> string option
-
 (** Check if a name is a known direct adapter label or alias. *)
 val is_known_provider : string -> bool
-
-(** Check if a name is a CLI-spawnable agent (has a spawn_key). *)
-val is_spawnable_agent : string -> bool
-
-(** Return canonical names of all spawnable adapters. *)
-val spawnable_canonical_names : unit -> string list
 
 (** Resolve the declared default model id for a cascade prefix. *)
 val default_model_id_for_cascade_prefix
@@ -316,11 +307,6 @@ val default_model_override_label_result : string -> (string, string) result
 
 val explicit_llama_model_id_result : unit -> (string, string) result
 val explicit_llama_model_label_result : unit -> (string, string) result
-
-(** {1 Ollama} *)
-
-val bare_ollama_migration_message : unit -> string
-val is_bare_ollama_label : string -> bool
 
 (** {1 Auth} *)
 

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -158,7 +158,7 @@ let parse_gemini_output raw =
     parse_raw_output raw
 
 (** Build a spawn config from a canonical spawn key.
-    SSOT for agent names and aliases is [Provider_adapter.direct_adapters];
+    SSOT for agent names and aliases is [Spawn_runtime_overlay.bindings];
     this function only maps resolved keys to their CLI invocation shape. *)
 let spawn_config_of_key key =
   let open Env_config.Spawn in
@@ -202,7 +202,7 @@ let spawn_config_of_key key =
   | "llama" ->
       Some {
         agent_name = "llama";
-        command = Provider_adapter.make_local_label "explicit-model-required";
+        command = Spawn_runtime_overlay.make_local_label "explicit-model-required";
         timeout_seconds;
         working_dir = None;
         mcp_tools = masc_mcp_tools;
@@ -214,11 +214,10 @@ let spawn_config_of_key key =
   | _ -> None
 
 (** Get spawn config for agent.
-    Resolves all aliases via Provider_adapter registry (SSOT).
-    spawn_alias_map removed — aliases are now in Provider_adapter.direct_adapters. *)
+    Resolves all aliases via [Spawn_runtime_overlay] (SSOT). *)
 let get_config agent_name =
   let normalized = String.lowercase_ascii (String.trim agent_name) in
-  match Provider_adapter.resolve_spawn_key normalized with
+  match Spawn_runtime_overlay.resolve_spawn_key normalized with
   | Some key -> spawn_config_of_key key
   | None -> spawn_config_of_key normalized
 
@@ -275,21 +274,16 @@ let fallback_spawn_failure_output ~exit_code =
     exit_code
 
 let add_default_model_arg agent_name argv =
-  match Provider_adapter.resolve_direct_adapter agent_name with
-  | Some adapter when adapter.canonical_name = "llama" -> (
-      match Provider_adapter.explicit_llama_model_id_result () with
-      | Ok model_id -> argv @ [ model_id ]
-      | Error _ -> argv)
-  | _ -> argv
+  Spawn_runtime_overlay.add_default_model_arg ~agent_name argv
 
 (** Spawn an agent with a prompt/task (direct execution, no shell) *)
 let spawn ~agent_name ~prompt ?timeout_seconds ?working_dir () =
   let start_time = Time_compat.now () in
   let normalized_agent = String.lowercase_ascii (String.trim agent_name) in
-  if Provider_adapter.is_bare_ollama_label normalized_agent then
+  if Spawn_runtime_overlay.is_bare_ollama_label normalized_agent then
     {
       success = false;
-      output = Provider_adapter.bare_ollama_migration_message ();
+      output = Spawn_runtime_overlay.bare_ollama_migration_message ();
       exit_code = 2;
       elapsed_ms = int_of_float ((Time_compat.now () -. start_time) *. 1000.0);
       input_tokens = None;

--- a/lib/spawn_runtime_overlay.ml
+++ b/lib/spawn_runtime_overlay.ml
@@ -1,0 +1,84 @@
+(** Spawn runtime overlay. *)
+
+type binding =
+  { canonical_name : string
+  ; spawn_key : string
+  ; aliases : string list
+  }
+
+let normalize_label label = String.trim label |> String.lowercase_ascii
+
+let bindings =
+  [ { canonical_name = "llama"
+    ; spawn_key = "llama"
+    ; aliases = [ "llama"; "llama.cpp"; "llamacpp" ]
+    }
+  ; { canonical_name = "claude"
+    ; spawn_key = "claude"
+    ; aliases = [ "claude"; "claude-code"; "claude_code" ]
+    }
+  ; { canonical_name = "codex"
+    ; spawn_key = "codex"
+    ; aliases = [ "codex"; "codex-cli"; "codex_cli" ]
+    }
+  ; { canonical_name = "gemini"
+    ; spawn_key = "gemini"
+    ; aliases = [ "gemini"; "gemini-cli"; "gemini_cli" ]
+    }
+  ]
+;;
+
+let resolve_binding label =
+  let normalized = normalize_label label in
+  List.find_opt
+    (fun binding ->
+       List.exists
+         (fun alias -> String.equal (normalize_label alias) normalized)
+         binding.aliases)
+    bindings
+;;
+
+let resolve_spawn_key label = Option.map (fun binding -> binding.spawn_key) (resolve_binding label)
+let is_spawnable_agent name = resolve_spawn_key name <> None
+let spawnable_canonical_names () = List.map (fun binding -> binding.canonical_name) bindings
+let make_local_label model_id = "llama:" ^ model_id
+
+let nonempty_env name =
+  match Sys.getenv_opt name with
+  | Some raw ->
+    let trimmed = String.trim raw in
+    if trimmed = "" then None else Some trimmed
+  | None -> None
+;;
+
+let explicit_llama_model_id_result () =
+  match nonempty_env "LLAMA_DEFAULT_MODEL" with
+  | Some model_id -> Ok model_id
+  | None ->
+    (match nonempty_env "MASC_DEFAULT_PROVIDER", nonempty_env "MASC_DEFAULT_MODEL" with
+     | Some provider, Some model_id
+       when String.equal (String.lowercase_ascii provider) "llama" -> Ok model_id
+     | _ ->
+       Error
+         "LLAMA_DEFAULT_MODEL is not set; configure LLAMA_DEFAULT_MODEL or \
+          MASC_DEFAULT_PROVIDER=llama with MASC_DEFAULT_MODEL")
+;;
+
+let add_default_model_arg ~agent_name argv =
+  match resolve_binding agent_name with
+  | Some { canonical_name = "llama"; _ } ->
+    (match explicit_llama_model_id_result () with
+     | Ok model_id -> argv @ [ model_id ]
+     | Error _ -> argv)
+  | Some _ | None -> argv
+;;
+
+let bare_ollama_migration_message () =
+  "Bare `ollama` without a model requires OLLAMA_DEFAULT_MODEL env var. Use \
+   `ollama:<model>` for explicit selection."
+;;
+
+let is_bare_ollama_label label =
+  String.equal (normalize_label label) "ollama"
+  && Env_config_runtime.Ollama.default_model = ""
+;;

--- a/lib/spawn_runtime_overlay.mli
+++ b/lib/spawn_runtime_overlay.mli
@@ -1,0 +1,20 @@
+(** Spawn runtime overlay.
+
+    Spawnable CLI agent aliases and migration guards are MASC spawn runtime
+    concerns. Keep them outside [Provider_adapter] so the provider registry can
+    shrink toward LLM/provider capability projection only. *)
+
+type binding =
+  { canonical_name : string
+  ; spawn_key : string
+  ; aliases : string list
+  }
+
+val bindings : binding list
+val resolve_spawn_key : string -> string option
+val is_spawnable_agent : string -> bool
+val spawnable_canonical_names : unit -> string list
+val make_local_label : string -> string
+val add_default_model_arg : agent_name:string -> string list -> string list
+val bare_ollama_migration_message : unit -> string
+val is_bare_ollama_label : string -> bool

--- a/scripts/ci/check-ssot-spawn-drift.sh
+++ b/scripts/ci/check-ssot-spawn-drift.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# CI gate: SSOT drift detection between Provider_adapter.spawn_key and Spawn.spawn_config_of_key.
+# CI gate: SSOT drift detection between Spawn_runtime_overlay and Spawn.spawn_config_of_key.
 # Meta-issue: #9516
 #
-# CONTRACT: Every spawn_key declared in Provider_adapter.direct_adapters must have a
+# CONTRACT: Every spawn_key declared in Spawn_runtime_overlay.bindings must have a
 # corresponding branch in Spawn.spawn_config_of_key, and vice versa.
 # This prevents runtime "unknown agent" failures when an adapter is added but the
 # spawn mapping is forgotten.
@@ -11,10 +11,9 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-# Extract spawn_key values from Provider_adapter.direct_adapters (Some "...")
-# Filter out None entries, sort, dedupe.
-adapter_keys=$(
-  rg 'spawn_key\s*=\s*Some\s*"([^"]+)"' lib/provider_adapter.ml -o -r '$1' | sort -u
+# Extract spawn_key values from Spawn_runtime_overlay.bindings.
+overlay_keys=$(
+  rg 'spawn_key\s*=\s*"([^"]+)"' lib/spawn_runtime_overlay.ml -o -r '$1' | sort -u
 )
 
 # Extract match arms from Spawn.spawn_config_of_key
@@ -24,25 +23,25 @@ spawn_keys=$(
 )
 
 # Compute symmetric difference
-only_in_adapter=$(comm -23 <(echo "$adapter_keys") <(echo "$spawn_keys"))
-only_in_spawn=$(comm -13 <(echo "$adapter_keys") <(echo "$spawn_keys"))
+only_in_overlay=$(comm -23 <(echo "$overlay_keys") <(echo "$spawn_keys"))
+only_in_spawn=$(comm -13 <(echo "$overlay_keys") <(echo "$spawn_keys"))
 
 exit_code=0
 
-if [ -n "$only_in_adapter" ]; then
-  echo "FAIL: SSOT drift — spawn_key in Provider_adapter but missing in Spawn.spawn_config_of_key:"
-  echo "$only_in_adapter" | sed 's/^/  /'
+if [ -n "$only_in_overlay" ]; then
+  echo "FAIL: SSOT drift — spawn_key in Spawn_runtime_overlay but missing in Spawn.spawn_config_of_key:"
+  echo "$only_in_overlay" | sed 's/^/  /'
   exit_code=1
 fi
 
 if [ -n "$only_in_spawn" ]; then
-  echo "FAIL: SSOT drift — spawn_config_of_key branch in Spawn but no adapter.spawn_key:"
+  echo "FAIL: SSOT drift — spawn_config_of_key branch in Spawn but no Spawn_runtime_overlay binding:"
   echo "$only_in_spawn" | sed 's/^/  /'
   exit_code=1
 fi
 
 if [ "$exit_code" -eq 0 ]; then
-  echo "PASS: Provider_adapter.spawn_key <-> Spawn.spawn_config_of_key are in sync."
+  echo "PASS: Spawn_runtime_overlay.spawn_key <-> Spawn.spawn_config_of_key are in sync."
 fi
 
 exit "$exit_code"

--- a/test/dune
+++ b/test/dune
@@ -616,6 +616,7 @@
         test_process_eio_detached
         test_provider_adapter
         test_voice_runtime_overlay
+        test_spawn_runtime_overlay
         test_worker_container_coverage
         test_resilience
         test_common
@@ -836,6 +837,7 @@
         test_process_eio_detached
         test_provider_adapter
         test_voice_runtime_overlay
+        test_spawn_runtime_overlay
         test_worker_container_coverage
         test_resilience
         test_common

--- a/test/test_auto_responder_coverage.ml
+++ b/test/test_auto_responder_coverage.ml
@@ -148,10 +148,13 @@ let test_extract_nickname_multiline () =
    ============================================================ *)
 
 let test_spawnable_agents_nonempty () =
-  check bool "claude spawnable" true (Auto_responder.is_spawnable "claude")
+  let agents = Masc_mcp.Spawn_runtime_overlay.spawnable_canonical_names () in
+  check bool "nonempty" true (List.length agents > 0)
 
 let test_spawnable_agents_contains_claude () =
-  check bool "contains claude" true (Auto_responder.is_spawnable "claude")
+  let agents = Masc_mcp.Spawn_runtime_overlay.spawnable_canonical_names () in
+  check bool "contains claude" true (List.mem "claude" agents);
+  check bool "auto responder sees claude" true (Auto_responder.is_spawnable "claude")
 
 let test_agent_type_of_mention_claude () =
   let t = Auto_responder.agent_type_of_mention "claude-rare-beaver" in

--- a/test/test_mention_coverage.ml
+++ b/test/test_mention_coverage.ml
@@ -228,7 +228,7 @@ let test_is_spawnable_llama () =
   check bool "llama is spawnable" true (Masc_mcp.Auto_responder.is_spawnable "llama")
 
 let test_is_spawnable_glm () =
-  (* glm has spawn_key=None in Provider_adapter — not CLI-spawnable *)
+  (* glm has no Spawn_runtime_overlay binding — not CLI-spawnable *)
   check bool "glm not spawnable" false (Masc_mcp.Auto_responder.is_spawnable "glm")
 
 let test_is_spawnable_unknown () =
@@ -246,9 +246,16 @@ let test_is_spawnable_empty () =
    ============================================================ *)
 
 let test_spawnable_agents_list () =
-  check bool "contains claude" true (Masc_mcp.Auto_responder.is_spawnable "claude");
-  check bool "contains gemini" true (Masc_mcp.Auto_responder.is_spawnable "gemini");
-  check bool "does not contain bare ollama" false
+  let names = Masc_mcp.Spawn_runtime_overlay.spawnable_canonical_names () in
+  check bool "list not empty" true (List.length names > 0);
+  check bool "contains claude" true (List.mem "claude" names);
+  check bool "contains gemini" true (List.mem "gemini" names);
+  check bool "does not contain bare ollama" false (List.mem "ollama" names);
+  check bool "auto responder contains claude" true
+    (Masc_mcp.Auto_responder.is_spawnable "claude");
+  check bool "auto responder contains gemini" true
+    (Masc_mcp.Auto_responder.is_spawnable "gemini");
+  check bool "auto responder rejects bare ollama" false
     (Masc_mcp.Auto_responder.is_spawnable "ollama")
 
 (* ============================================================

--- a/test/test_spawn.ml
+++ b/test/test_spawn.ml
@@ -152,7 +152,7 @@ let test_masc_mcp_tools () =
   ()
 
 let test_spawn_bare_ollama_rejected () =
-  if Provider_adapter.is_bare_ollama_label "ollama" then (
+  if Spawn_runtime_overlay.is_bare_ollama_label "ollama" then (
     let result = Spawn.spawn ~agent_name:"ollama" ~prompt:"test" () in
     Alcotest.(check bool) "spawn rejected" false result.Spawn.success;
     Alcotest.(check int) "exit code" 2 result.Spawn.exit_code;

--- a/test/test_spawn_coverage.ml
+++ b/test/test_spawn_coverage.ml
@@ -260,7 +260,7 @@ let test_get_config_unknown () =
   | Some _ -> fail "expected None"
 
 let test_spawn_bare_ollama_rejected () =
-  if Masc_mcp.Provider_adapter.is_bare_ollama_label "ollama" then (
+  if Masc_mcp.Spawn_runtime_overlay.is_bare_ollama_label "ollama" then (
     let result = Spawn.spawn ~agent_name:"ollama" ~prompt:"test" () in
     check bool "spawn rejected" false result.Spawn.success;
     check int "exit code" 2 result.Spawn.exit_code;
@@ -586,8 +586,8 @@ let test_result_to_string_success () =
     cost_usd = None;
   } in
   let str = Spawn.result_to_string result in
-  check bool "has checkmark" true
-    (try let _ = Str.search_forward (Str.regexp "✅") str 0 in true
+  check bool "has completed status" true
+    (try let _ = Str.search_forward (Str.regexp_string "Agent completed") str 0 in true
      with Not_found -> false)
 
 let test_result_to_string_failure () =
@@ -603,8 +603,8 @@ let test_result_to_string_failure () =
     cost_usd = None;
   } in
   let str = Spawn.result_to_string result in
-  check bool "has x" true
-    (try let _ = Str.search_forward (Str.regexp "❌") str 0 in true
+  check bool "has failure status" true
+    (try let _ = Str.search_forward (Str.regexp_string "Agent failed") str 0 in true
      with Not_found -> false)
 
 let test_result_to_string_has_elapsed () =

--- a/test/test_spawn_runtime_overlay.ml
+++ b/test/test_spawn_runtime_overlay.ml
@@ -1,0 +1,44 @@
+open Alcotest
+module Spawn_overlay = Masc_mcp.Spawn_runtime_overlay
+
+let test_resolve_spawn_aliases () =
+  check (option string) "claude code alias" (Some "claude")
+    (Spawn_overlay.resolve_spawn_key "claude-code");
+  check (option string) "gemini cli alias" (Some "gemini")
+    (Spawn_overlay.resolve_spawn_key "gemini_cli");
+  check (option string) "glm is not spawnable" None
+    (Spawn_overlay.resolve_spawn_key "glm")
+;;
+
+let test_spawnable_canonical_names () =
+  let names = Spawn_overlay.spawnable_canonical_names () in
+  check bool "contains llama" true (List.mem "llama" names);
+  check bool "contains claude" true (List.mem "claude" names);
+  check bool "contains codex" true (List.mem "codex" names);
+  check bool "contains gemini" true (List.mem "gemini" names);
+  check bool "does not contain ollama" false (List.mem "ollama" names)
+;;
+
+let test_local_label_helper () =
+  check string "local label" "llama:test-model"
+    (Spawn_overlay.make_local_label "test-model")
+;;
+
+let test_bare_ollama_guard () =
+  check bool "explicit ollama model is not bare" false
+    (Spawn_overlay.is_bare_ollama_label "ollama:test-model");
+  if Spawn_overlay.is_bare_ollama_label "ollama" then
+    check bool "migration mentions explicit model label" true
+      (String.contains (Spawn_overlay.bare_ollama_migration_message ()) ':')
+;;
+
+let () =
+  run "spawn_runtime_overlay"
+    [ ( "spawn"
+      , [ test_case "resolve spawn aliases" `Quick test_resolve_spawn_aliases
+        ; test_case "spawnable canonical names" `Quick test_spawnable_canonical_names
+        ; test_case "local label helper" `Quick test_local_label_helper
+        ; test_case "bare ollama guard" `Quick test_bare_ollama_guard
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- Split spawn/autoresponder runtime facts out of `Provider_adapter` into `Spawn_runtime_overlay`.
- Move spawn alias resolution, spawnable agent names, bare-ollama guard text, and local default model labeling to the spawn boundary.
- Remove the corresponding public `Provider_adapter` exports and retarget spawn drift checks/tests to the new overlay.

## Notes

- This PR targets `main` because the prior voice overlay base PR has already merged.
- The local environment refused to downgrade the shared `agent_sdk` floor from the installed newer switch, so focused Dune checks were run with `MASC_SKIP_PIN_CHECK=1`.

## Validation

- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_spawn.exe test/test_spawn_coverage.exe test/test_auto_responder_coverage.exe test/test_mention_coverage.exe test/test_spawn_runtime_overlay.exe test/test_provider_adapter.exe`
- `./_build/default/test/test_spawn_runtime_overlay.exe` - 4 tests
- `./_build/default/test/test_spawn.exe` - 10 tests, 1 skip
- `./_build/default/test/test_spawn_coverage.exe` - 74 tests, 1 skip
- `./_build/default/test/test_auto_responder_coverage.exe` - 29 tests
- `./_build/default/test/test_mention_coverage.exe` - 44 tests
- `./_build/default/test/test_provider_adapter.exe` - 49 tests
- `bash scripts/lint/provider-adapter-removal-ratchet.sh` - callers 36/44, mli exports 92/120
- `bash scripts/ci/check-ssot-spawn-drift.sh`
- `ocamlformat --check lib/spawn_runtime_overlay.ml lib/spawn_runtime_overlay.mli lib/spawn.ml lib/auto_responder.ml lib/provider_adapter.ml lib/provider_adapter.mli test/test_spawn_runtime_overlay.ml test/test_spawn_coverage.ml test/test_auto_responder_coverage.ml test/test_mention_coverage.ml test/test_provider_adapter.ml`
- `git diff --check origin/main...HEAD`
