### PR TITLE
feat(ide): route run progress keeper chips

### DIFF
--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -166,6 +166,11 @@ describe('IdeActivityPanel', () => {
     fireEvent.click(surfaceLinks.find(link => link.textContent === 'Telemetry1')!)
     expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&session_id=sess-runtime&operation_id=op-runtime&worker_run_id=wr-runtime&q=turn-1')
 
+    const keeperLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-run-progress-keeper-link')]
+    expect(keeperLinks.map(link => link.getAttribute('aria-label'))).toEqual(['Open Keeper sangsu'])
+    fireEvent.click(keeperLinks[0]!)
+    expect(window.location.hash).toBe('#monitoring?section=agents&view=keepers&keeper=sangsu')
+
     const activityRouteLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-activity-route-link')]
     expect(activityRouteLinks.map(link => link.textContent)).toEqual([
       'Code',
@@ -710,9 +715,24 @@ describe('IdeActivityPanel', () => {
       label: 'Telemetry',
       params: { section: 'fleet-health', view: 'event-log', q: 'turn-1' },
     })
-    expect(summary.keeperCounts).toEqual([
-      { keeper_id: 'sangsu', count: 2 },
-      { keeper_id: 'analyst', count: 1 },
+    expect(summary.keeperCounts.map(entry => ({
+      keeper_id: entry.keeper_id,
+      count: entry.count,
+      routeLink: entry.routeLink && {
+        label: entry.routeLink.label,
+        params: entry.routeLink.params,
+      },
+    }))).toEqual([
+      {
+        keeper_id: 'sangsu',
+        count: 2,
+        routeLink: { label: 'Keeper', params: { section: 'agents', view: 'keepers', keeper: 'sangsu' } },
+      },
+      {
+        keeper_id: 'analyst',
+        count: 1,
+        routeLink: { label: 'Keeper', params: { section: 'agents', view: 'keepers', keeper: 'analyst' } },
+      },
     ])
   })
 
@@ -775,5 +795,6 @@ describe('IdeActivityPanel', () => {
     expect(summary.keeperTotalCount).toBe(4)
     expect(summary.keeperCounts).toHaveLength(3)
     expect(summary.keeperCounts.map(entry => entry.keeper_id)).toEqual(['alpha', 'bravo', 'charlie'])
+    expect(summary.keeperCounts.map(entry => entry.routeLink?.label)).toEqual(['Keeper', 'Keeper', 'Keeper'])
   })
 })

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -111,12 +111,18 @@ export interface IdeRunProgressSummary {
   readonly keeperTotalCount: number
   readonly latestAgeLabel: string
   readonly surfaceCounts: ReadonlyArray<IdeRunProgressSurfaceCount>
-  readonly keeperCounts: ReadonlyArray<{ readonly keeper_id: string; readonly count: number }>
+  readonly keeperCounts: ReadonlyArray<IdeRunProgressKeeperCount>
   readonly activeGoal: IdeRunProgressGoal | null
 }
 
 export interface IdeRunProgressSurfaceCount {
   readonly label: string
+  readonly count: number
+  readonly routeLink: IdeContextRouteLink | null
+}
+
+export interface IdeRunProgressKeeperCount {
+  readonly keeper_id: string
   readonly count: number
   readonly routeLink: IdeContextRouteLink | null
 }
@@ -483,14 +489,27 @@ export function deriveIdeRunProgressSummary(
     count: events.length,
     routeLink: latestSurfaceRouteLink('Telemetry', events),
   })
-  const keeperEntries = [...events.reduce((acc, event) => {
-    acc.set(event.keeper_id, (acc.get(event.keeper_id) ?? 0) + 1)
-    return acc
-  }, new Map<string, number>())]
-    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+  const keeperStats = new Map<string, { count: number; latestEvent: RunActivityEvent }>()
+  for (const event of events) {
+    const current = keeperStats.get(event.keeper_id)
+    if (!current) {
+      keeperStats.set(event.keeper_id, { count: 1, latestEvent: event })
+      continue
+    }
+    keeperStats.set(event.keeper_id, {
+      count: current.count + 1,
+      latestEvent: isLaterRunActivityEvent(event, current.latestEvent) ? event : current.latestEvent,
+    })
+  }
+  const keeperEntries = [...keeperStats.entries()]
+    .sort((left, right) => right[1].count - left[1].count || left[0].localeCompare(right[0]))
   const keeperCounts = keeperEntries
     .slice(0, 3)
-    .map(([keeper_id, count]) => ({ keeper_id, count }))
+    .map(([keeper_id, stat]) => ({
+      keeper_id,
+      count: stat.count,
+      routeLink: keeperProgressRouteLink(stat.latestEvent),
+    }))
   return {
     totalEvents: events.length,
     currentFileEvents,
@@ -523,14 +542,37 @@ function RunProgressStrip({ summary }: { readonly summary: IdeRunProgressSummary
       <div class="ide-run-progress-keepers" aria-label="Top active keepers">
         ${summary.keeperCounts.length === 0
           ? html`<span>no keeper activity</span>`
-          : summary.keeperCounts.map(entry => html`
-            <span title=${`${entry.keeper_id}: ${entry.count} events`}>
-              <${KeeperBadge} id=${entry.keeper_id} variant="sigil" size="sm" />
-              <span>${entry.count}</span>
-            </span>
-          `)}
+          : summary.keeperCounts.map(entry => RunProgressKeeperChip(entry))}
       </div>
     </section>
+  `
+}
+
+function RunProgressKeeperChip(entry: IdeRunProgressKeeperCount) {
+  const routeLink = entry.routeLink
+  return html`
+    <span
+      title=${`${entry.keeper_id}: ${entry.count} events`}
+      data-actionable=${routeLink ? 'true' : 'false'}
+    >
+      ${routeLink
+        ? html`
+          <button
+            type="button"
+            class="ide-run-progress-keeper-link"
+            title=${routeLink.evidence}
+            aria-label=${`Open ${routeLink.evidence}`}
+            onClick=${() => openIdeContextRouteLink(routeLink)}
+          >
+            <${KeeperBadge} id=${entry.keeper_id} variant="sigil" size="sm" />
+            <span>${entry.count}</span>
+          </button>
+        `
+        : html`
+          <${KeeperBadge} id=${entry.keeper_id} variant="sigil" size="sm" />
+          <span>${entry.count}</span>
+        `}
+    </span>
   `
 }
 
@@ -678,14 +720,32 @@ function latestSurfaceRouteLink(
   label: string,
   events: ReadonlyArray<RunActivityEvent>,
 ): IdeContextRouteLink | null {
-  const latestEvents = [...events].sort((left, right) =>
-    right.timestamp_ms - left.timestamp_ms || right.id.localeCompare(left.id),
-  )
-  for (const event of latestEvents) {
-    const routeLink = activityRouteLinks(event).find(link => link.label === label)
-    if (routeLink) return routeLink
+  const latestEvent = latestRunActivityEvent(events)
+  if (!latestEvent) return null
+  return activityRouteLinks(latestEvent).find(link => link.label === label) ?? null
+}
+
+function keeperProgressRouteLink(event: RunActivityEvent): IdeContextRouteLink | null {
+  const links = activityRouteLinks(event)
+  return links.find(link => link.label === 'Keeper')
+    ?? links.find(link => link.label === 'Telemetry')
+    ?? links[0]
+    ?? null
+}
+
+function latestRunActivityEvent(events: ReadonlyArray<RunActivityEvent>): RunActivityEvent | null {
+  let latest: RunActivityEvent | null = null
+  for (const event of events) {
+    if (latest === null || isLaterRunActivityEvent(event, latest)) {
+      latest = event
+    }
   }
-  return null
+  return latest
+}
+
+function isLaterRunActivityEvent(candidate: RunActivityEvent, current: RunActivityEvent): boolean {
+  return candidate.timestamp_ms > current.timestamp_ms
+    || (candidate.timestamp_ms === current.timestamp_ms && candidate.id > current.id)
 }
 
 function activityRouteLinks(item: RunActivityEvent): ReadonlyArray<IdeContextRouteLink> {

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -1578,6 +1578,42 @@
   flex: 1 1 58px;
 }
 
+.ide-run-progress-keepers > span[data-actionable="true"] {
+  padding: 0;
+}
+
+.ide-run-progress-keeper-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  min-width: 0;
+  min-height: 20px;
+  padding: 2px 6px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.ide-run-progress-keeper-link > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-run-progress-keeper-link:hover,
+.ide-run-progress-keeper-link:focus-visible {
+  color: var(--color-fg-primary);
+}
+
+.ide-run-progress-keeper-link:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 1px;
+}
+
 .ide-run-progress-goal {
   display: grid;
   gap: var(--sp-1);


### PR DESCRIPTION
## Summary
- Make RUN PROGRESS top keeper chips actionable through the latest keeper event context.
- Route keeper chips to the keeper monitoring record while preserving existing surface and activity links.
- Keep keeper counts derived in a single pass with latest-event tracking.

## Validation
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/ide-activity-panel.ts src/components/ide/ide-activity-panel.test.ts
- pnpm exec vitest run src/components/ide/ide-activity-panel.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD~1 HEAD