### PR TITLE
feat(observability): OAS dispatch hot path baseline histograms

### DIFF
--- a/docs/BENCHMARK-RUNBOOK.md
+++ b/docs/BENCHMARK-RUNBOOK.md
@@ -411,3 +411,53 @@ dune runtest test/test_reward_advice_artifact.ml
 dune runtest test/test_post_verifier.ml
 dune runtest test/test_tool_call_quality_benchmark.ml
 ```
+
+## OAS Descriptor Dispatch (Phase B baseline)
+
+`~/me/planning/claude-plans/wise-nibbling-lerdorf.md` Phase B 의 evidence
+수집 절차. 두 hot path (`make_tool_bundle` @ `lib/keeper/keeper_tools_oas.ml:852`,
+`params_of_json_schema` @ `lib/tool_bridge.ml:176`) 가 keeper turn 예산에서
+차지하는 비중을 측정해 Phase C 진행 여부를 결정한다.
+
+### Histograms
+
+- `masc_oas_params_of_schema_sec` — sum/count, 매 OAS conversion 마다
+  observation 1 회.
+- `masc_oas_make_tool_bundle_sec` — sum/count, 매 keeper turn 1 회.
+
+masc-mcp 의 `Prometheus.observe_histogram` 은 sum + `_count` 만 저장하므로
+*평균(avg = sum/count)* 까지가 in-tree 측정 한계다. p50/p95/p99 quantile 이
+필요하면 외부 Prometheus scraper + `histogram_quantile()` 또는 별도 raw-sample
+경로가 필요하다 (현재 Phase B 범위 밖).
+
+### Smoke run
+
+```bash
+# 1. 워크로드 구동 (운영자 재량). 기본 권장: tool-call-quality --live.
+BENCH_ITERATIONS=50 BENCH_WARMUP_ITERATIONS=1 \
+  ./scripts/harness_tool_call_quality.sh --live --keepers bench-analyst \
+    --models <provider:model>
+
+# 2. /metrics 스크레이프 + CSV 저장.
+./scripts/harness_oas_dispatch.sh scrape --label baseline
+
+# 3. 비교 (e.g. memoization 적용 전후, 또는 hist on/off).
+./scripts/harness_oas_dispatch.sh diff \
+  benchmarks/results/oas-baseline-<base>.csv \
+  benchmarks/results/oas-baseline-<current>.csv
+```
+
+### Histogram-overhead control
+
+`MASC_DISABLE_HOTPATH_HIST=1` 로 서버를 기동하면 두 hot path 의 observation 이
+no-op 으로 빠진다. 동일 워크로드를 hist-on / hist-off 로 두 번 돌려 차이가
+없으면 histogram 자체 비용이 무시 가능 (Phase B 결과의 신뢰도 확인용).
+
+### Decision gate (Phase B → Phase C)
+
+```
+(avg make_tool_bundle + avg params_of_json_schema × tools_per_turn) / avg total_turn >= 0.02
+```
+
+위 식이 참이면 Phase C (`params_of_json_schema` memoization) 진행. 거짓이면
+Phase C/D 미진행 — evidence finding 만 follow-up 으로 남기고 plan 종료.

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -858,6 +858,9 @@ let make_tool_bundle
       ()
   : tool_bundle
   =
+  (* Phase B baseline (wise-nibbling-lerdorf plan): timestamp before the
+     bundle assembly work begins; observed at function exit. *)
+  let __t0 = Mtime_clock.now () in
   (* PR-3b (#11611 part 1): replace eager [Keeper_turn_sandbox_runtime]
      instances with a factory.  in_playground/cwd are unknown at
      turn-start, so the factory defers
@@ -1030,12 +1033,18 @@ let make_tool_bundle
                     (fun input -> h input))))
       (Keeper_tool_alias.public_names ())
   in
-  { tools = internal_tools @ alias_tools
-  ; cleanup =
-      (fun () ->
-        Option.iter Keeper_sandbox_factory.cleanup turn_sandbox_factory;
-        Option.iter Keeper_sandbox_factory.cleanup turn_sandbox_factory_git)
-  }
+  let bundle =
+    { tools = internal_tools @ alias_tools
+    ; cleanup =
+        (fun () ->
+          Option.iter Keeper_sandbox_factory.cleanup turn_sandbox_factory;
+          Option.iter Keeper_sandbox_factory.cleanup turn_sandbox_factory_git)
+    }
+  in
+  Prometheus.observe_hotpath
+    ~metric:Prometheus.metric_masc_oas_make_tool_bundle_sec
+    ~start:__t0;
+  bundle
 ;;
 
 let make_tools

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -209,6 +209,38 @@ let observe_histogram name ?(labels = []) value =
         })
 ;;
 
+(* Phase B baseline opt-out — read once at module load.  Lets operators
+   diff a run with the histogram observation enabled vs disabled to
+   quantify the histogram's own overhead before drawing conclusions
+   about the hot path. *)
+let hotpath_hist_disabled =
+  Lazy.from_fun (fun () ->
+    match Sys.getenv_opt "MASC_DISABLE_HOTPATH_HIST" with
+    | Some ("1" | "true" | "yes" | "on" | "TRUE" | "YES" | "ON") -> true
+    | _ -> false)
+;;
+
+(* Convenience wrapper for the OAS dispatch baseline: takes the
+   pre-call [Mtime] timestamp and records the elapsed seconds against
+   [metric].  No-op when [MASC_DISABLE_HOTPATH_HIST] is set.  Catches
+   internal exceptions so a metric-emit failure never bubbles into the
+   hot path it is observing. *)
+let observe_hotpath ~metric ~start =
+  if Lazy.force hotpath_hist_disabled
+  then ()
+  else
+    try
+      let elapsed = Mtime.span start (Mtime_clock.now ()) in
+      let ns = Mtime.Span.to_uint64_ns elapsed in
+      let sec = Int64.to_float ns /. 1.0e9 in
+      observe_histogram metric sec
+    with
+    (* Cancellation must propagate (CLAUDE.md feedback —
+       Eio.Cancel.Cancelled 삼킴 버그 사례 회피). *)
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | _ -> ()
+;;
+
 (** {1 Metric Name Constants}
 
     Exported so registration here and [inc_counter] / [set_gauge]
@@ -602,6 +634,15 @@ let metric_oas_context_overflow_ratio = "masc_oas_context_overflow_ratio"
 (* OAS-level context compaction counter — incremented each time
    ContextCompactStarted fires from the event bus. *)
 let metric_oas_context_compaction_total = "masc_oas_context_compaction_total"
+
+(* OAS tool dispatch hot-path latency histograms — Phase B baseline of
+   ~/me/planning/claude-plans/wise-nibbling-lerdorf.md. Wraps the two
+   hot paths called per keeper turn so operators can measure the
+   dispatch share of turn budget before deciding whether memoization is
+   worth the surface-area cost. Observation is gated by
+   [MASC_DISABLE_HOTPATH_HIST=1] for histogram-overhead measurement. *)
+let metric_masc_oas_params_of_schema_sec = "masc_oas_params_of_schema_sec"
+let metric_masc_oas_make_tool_bundle_sec = "masc_oas_make_tool_bundle_sec"
 
 (* MCP tool schema budget (set once at boot from mcp_server_eio.ml
    via [set_tool_schema_stats]). *)
@@ -1472,6 +1513,23 @@ let init () =
     ~help:
       "Keeper tool call latency in seconds, labeled by keeper, provider, tool, and \
        outcome"
+    ();
+  (* Phase B baseline (wise-nibbling-lerdorf plan): measure OAS dispatch
+     hot path before deciding whether memoization is justified.  Disable
+     with [MASC_DISABLE_HOTPATH_HIST=1] to quantify the histogram's own
+     overhead. *)
+  register_histogram
+    ~name:metric_masc_oas_params_of_schema_sec
+    ~help:
+      "OAS [params_of_json_schema] elapsed seconds per call.  Fires from \
+       [Tool_bridge.oas_tool_of_masc] per OAS conversion; hot path target of \
+       wise-nibbling-lerdorf Phase B baseline."
+    ();
+  register_histogram
+    ~name:metric_masc_oas_make_tool_bundle_sec
+    ~help:
+      "OAS [make_tool_bundle] elapsed seconds per call.  Fires once per keeper \
+       turn; hot path target of wise-nibbling-lerdorf Phase B baseline."
     ();
   add
     metric_provider_prefix_cache_creation_tokens

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -577,6 +577,29 @@ val metric_oas_context_overflow_ratio : string
     Labels: [agent_name, trigger]. *)
 val metric_oas_context_compaction_total : string
 
+(** Histogram: elapsed seconds per [Tool_bridge.params_of_json_schema]
+    call.  Phase B baseline of
+    [~/me/planning/claude-plans/wise-nibbling-lerdorf.md] — measures the
+    OAS dispatch hot path before deciding whether memoization is justified.
+    Observation gated by [MASC_DISABLE_HOTPATH_HIST]. *)
+val metric_masc_oas_params_of_schema_sec : string
+
+(** Histogram: elapsed seconds per [Keeper_tools_oas.make_tool_bundle]
+    call.  Fires once per keeper turn.  Phase B baseline. *)
+val metric_masc_oas_make_tool_bundle_sec : string
+
+(** Phase B baseline opt-out: read once at module load from
+    [MASC_DISABLE_HOTPATH_HIST] (truthy = "1"/"true"/"yes"/"on", case-
+    insensitive).  Operators set this for control runs to quantify
+    histogram observation overhead vs the underlying hot path. *)
+val hotpath_hist_disabled : bool Lazy.t
+
+(** Observe a hot-path histogram from a pre-call [Mtime] timestamp.
+    No-op when [hotpath_hist_disabled].  Internal exceptions are
+    swallowed so metric-emit failures never bubble into the observed
+    hot path; cancellation is re-raised. *)
+val observe_hotpath : metric:string -> start:Mtime.t -> unit
+
 (** #12797 Total cascade label-ranking skips triggered by recent server-error
     (5xx) score decay for a provider.  Labels: [provider_key]. *)
 val metric_cascade_server_error_skip_total : string

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -174,6 +174,7 @@ let type_string_of_schema_property prop =
   | _ -> None
 
 let params_of_json_schema schema =
+  let __t0 = Mtime_clock.now () in
   let open Yojson.Safe.Util in
   (* [required] is conceptually a set (membership semantics, no ordering
      or duplicates) — materialise as Hashtbl so the per-property check
@@ -197,24 +198,30 @@ let params_of_json_schema schema =
         tbl
     | _ -> Hashtbl.create 0
   in
-  match schema |> member "properties" with
-  | `Assoc pairs ->
-      List.map
-        (fun (name, prop) ->
-          let param_type =
-            prop
-            |> type_string_of_schema_property
-            |> Option.value ~default:"string"
-            |> param_type_of_string
-          in
-          let description =
-            string_of_json_member "description" prop
-            |> Option.value ~default:""
-          in
-          let required = Hashtbl.mem required_set name in
-          { Agent_sdk.Types.name = name; description; param_type; required })
-        pairs
-  | _ -> []
+  let result =
+    match schema |> member "properties" with
+    | `Assoc pairs ->
+        List.map
+          (fun (name, prop) ->
+            let param_type =
+              prop
+              |> type_string_of_schema_property
+              |> Option.value ~default:"string"
+              |> param_type_of_string
+            in
+            let description =
+              string_of_json_member "description" prop
+              |> Option.value ~default:""
+            in
+            let required = Hashtbl.mem required_set name in
+            { Agent_sdk.Types.name = name; description; param_type; required })
+          pairs
+    | _ -> []
+  in
+  Prometheus.observe_hotpath
+    ~metric:Prometheus.metric_masc_oas_params_of_schema_sec
+    ~start:__t0;
+  result
 
 (** {1 OAS Tool.t Creation}
 

--- a/scripts/harness_oas_dispatch.sh
+++ b/scripts/harness_oas_dispatch.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Phase B baseline harness for OAS dispatch hot path measurement.
+#
+# Plan reference: ~/me/planning/claude-plans/wise-nibbling-lerdorf.md §"Phase B"
+#
+# Scope: scrape the running masc-mcp server's /metrics endpoint and emit a
+# CSV row per OAS hot path histogram. Workload driving is the operator's
+# responsibility — run scripts/harness_tool_call_quality.sh --live or
+# whatever workload matches the comparison you want, then invoke this
+# script to capture the histogram values.
+#
+# Caveat: masc-mcp's [Prometheus.observe_histogram] currently tracks the
+# cumulative sum and _count only (no buckets). Quantiles (p50/p95/p99)
+# therefore require either an external Prometheus scraper with proper
+# bucketing or a raw-sample collection mode (out of scope for Phase B
+# baseline). The CSV emitted here records sum, count, and arithmetic
+# mean, which is sufficient for the Phase B decision gate (>= 2% turn
+# budget threshold from the plan).
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+CMD="${1:-scrape}"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  scripts/harness_oas_dispatch.sh scrape [--port PORT] [--out PATH] [--label LABEL]
+  scripts/harness_oas_dispatch.sh diff   <baseline.csv> <current.csv>
+
+Modes:
+  scrape (default)
+      Reads /metrics from the running masc-mcp server and writes a CSV row
+      per OAS dispatch histogram (sum, count, avg).
+      Defaults: --port 8935 --out benchmarks/results/oas-baseline-<ts>.csv
+      Optional --label TAG annotates the CSV row (e.g. "memo-off", "memo-on",
+      "hist-disabled") so multi-run diffs stay legible.
+
+  diff <baseline.csv> <current.csv>
+      Prints a row-by-row delta (sum / count / avg) between two scrape CSVs
+      so the wise-nibbling-lerdorf Phase B decision gate can be evaluated
+      without spinning up an external Prometheus stack.
+
+Environment:
+  MASC_DISABLE_HOTPATH_HIST=1 on the server side disables the Phase B
+  histogram observation entirely — pair "scrape --label hist-on" with a
+  rerun under "--label hist-off" to quantify observation overhead.
+EOF
+}
+
+if [[ "${CMD}" == "-h" || "${CMD}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "missing required command: $1" >&2
+    exit 1
+  }
+}
+
+scrape_mode() {
+  local port="8935"
+  local out=""
+  local label=""
+
+  shift || true
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --port) port="$2"; shift 2 ;;
+      --out) out="$2"; shift 2 ;;
+      --label) label="$2"; shift 2 ;;
+      -h|--help) usage; exit 0 ;;
+      *) echo "unknown flag: $1" >&2; usage; exit 2 ;;
+    esac
+  done
+
+  require_cmd curl
+  require_cmd awk
+
+  local ts
+  ts="$(date +%Y%m%d-%H%M%S)"
+  if [[ -z "${out}" ]]; then
+    out="${ROOT_DIR}/benchmarks/results/oas-baseline-${ts}.csv"
+  fi
+  mkdir -p "$(dirname "${out}")"
+
+  local body
+  body="$(curl -sS --fail "http://127.0.0.1:${port}/metrics")" || {
+    echo "scrape failed: http://127.0.0.1:${port}/metrics is unreachable" >&2
+    exit 1
+  }
+
+  extract() {
+    local name="$1"
+    printf '%s\n' "${body}" \
+      | awk -v n="${name}" '$1 == n { print $2; exit }'
+  }
+
+  local p_sum p_cnt b_sum b_cnt
+  p_sum="$(extract masc_oas_params_of_schema_sec)"
+  p_cnt="$(extract masc_oas_params_of_schema_sec_count)"
+  b_sum="$(extract masc_oas_make_tool_bundle_sec)"
+  b_cnt="$(extract masc_oas_make_tool_bundle_sec_count)"
+
+  avg() {
+    local s="${1:-0}" c="${2:-0}"
+    awk -v s="${s}" -v c="${c}" \
+      'BEGIN { if (c > 0) printf "%.6f", s/c; else printf "0" }'
+  }
+
+  {
+    printf 'timestamp,label,metric,sum_sec,count,avg_sec\n'
+    printf '%s,%s,%s,%s,%s,%s\n' \
+      "${ts}" "${label}" \
+      masc_oas_params_of_schema_sec \
+      "${p_sum:-0}" "${p_cnt:-0}" "$(avg "${p_sum:-0}" "${p_cnt:-0}")"
+    printf '%s,%s,%s,%s,%s,%s\n' \
+      "${ts}" "${label}" \
+      masc_oas_make_tool_bundle_sec \
+      "${b_sum:-0}" "${b_cnt:-0}" "$(avg "${b_sum:-0}" "${b_cnt:-0}")"
+  } > "${out}"
+
+  echo "wrote: ${out}" >&2
+  cat "${out}"
+}
+
+diff_mode() {
+  shift || true
+  local base="${1:-}"
+  local cur="${2:-}"
+  if [[ -z "${base}" || -z "${cur}" ]]; then
+    usage
+    exit 2
+  fi
+  require_cmd awk
+  if [[ ! -f "${base}" ]]; then
+    echo "baseline not found: ${base}" >&2; exit 1
+  fi
+  if [[ ! -f "${cur}" ]]; then
+    echo "current not found: ${cur}" >&2; exit 1
+  fi
+  awk -F, '
+    NR == FNR && FNR > 1 { base_sum[$3] = $4; base_cnt[$3] = $5; base_avg[$3] = $6; next }
+    FNR > 1 {
+      ds = $4 - base_sum[$3]
+      dc = $5 - base_cnt[$3]
+      da = $6 - base_avg[$3]
+      printf "%s\tsum_d=%s\tcount_d=%s\tavg_d=%s\n", $3, ds, dc, da
+    }
+  ' "${base}" "${cur}"
+}
+
+case "${CMD}" in
+  scrape) scrape_mode "$@" ;;
+  diff) diff_mode "$@" ;;
+  -h|--help) usage ;;
+  *) usage; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

Phase B of the **wise-nibbling-lerdorf** evidence-ladder plan: instrument the two OAS tool dispatch hot paths with sum/count histograms so operators can measure their share of keeper turn budget *before* deciding whether memoization (Phase C/D) is justified.

This PR adds **no** memoization, **no** counter-as-fix, **no** string classifier — it is pure measurement. Whether Phase C/D ship at all is decided by the numbers this baseline produces, per CLAUDE.md §\"워크어라운드 거부 기준\".

## Why now

Plan: \`~/me/planning/claude-plans/wise-nibbling-lerdorf.md\` §\"Phase B\". RFC-0036 foundation: PR #15275 (Draft, activation pending; this PR cites it as foundation).

> Note: the RFC number **\"RFC-0081\"** mentioned in plan §\"Phase E\" has since been claimed by #15137 (telemetry envelope) on origin/main. The plan's *future-tense* RFC reservation will be re-numbered when (if) Phase E triggers. This is the kind of conflict MEMORY.md \`feedback_rfc_number_reservation_needed\` flagged.

## Hot paths wrapped (verified line numbers)

| File | Line | Function | Per-session calls |
|---|---|---|---|
| \`lib/keeper/keeper_tools_oas.ml\` | 852 | \`make_tool_bundle\` | ~100–300× |
| \`lib/tool_bridge.ml\` | 176 | \`params_of_json_schema\` | ~2,000–5,000× |

(Plan agent originally claimed \`tool_bridge.ml:59\` for \`params_of_json_schema\` — that was a hallucination; line 59 is inside \`maybe_externalize\`. Corrected.)

## Histograms added

- \`masc_oas_params_of_schema_sec\`
- \`masc_oas_make_tool_bundle_sec\`

**Important caveat**: \`Prometheus.observe_histogram\` tracks **sum + _count only** (no buckets). p50/p95/p99 quantiles therefore require an external Prometheus scraper with \`histogram_quantile()\` or a raw-sample collection mode — both out of scope for Phase B baseline. The in-tree harness emits sum/count/avg CSV, which is sufficient for the Phase B decision gate (≥ 2% turn budget).

## Files

| File | Change |
|---|---|
| \`lib/prometheus.ml\` | +2 metric constants, +\`hotpath_hist_disabled\` Lazy, +\`observe_hotpath\` helper (Cancelled re-raised), +2 \`register_histogram\` calls in \`init\` |
| \`lib/prometheus.mli\` | export 2 constants + Lazy + helper, with docstrings |
| \`lib/tool_bridge.ml:176\` | wrap \`params_of_json_schema\` body with \`Mtime_clock.now\` + observe |
| \`lib/keeper/keeper_tools_oas.ml:852\` | wrap \`make_tool_bundle\` body with let-bind + observe |
| \`scripts/harness_oas_dispatch.sh\` | NEW — \`scrape\` + \`diff\` modes (no workload driving) |
| \`docs/BENCHMARK-RUNBOOK.md\` | NEW section \"OAS Descriptor Dispatch (Phase B baseline)\" |

Diff: +332 / -24.

## Histogram-overhead control

\`MASC_DISABLE_HOTPATH_HIST=truthy\` makes both \`observe_hotpath\` calls a no-op. Operators run hist-on vs hist-off with the same workload to quantify the histogram's own observation cost before drawing conclusions about the underlying hot path.

## Decision gate (Phase B → Phase C)

```
(avg make_tool_bundle + avg params_of_json_schema × tools_per_turn) / avg total_turn  ≥  0.02
```

If true → Phase C (\`params_of_json_schema\` memoization). If false → Phase C/D abort, evidence finding only.

## Verification

- [x] \`dune build --root .\` green in worktree
- [x] \`bash -n scripts/harness_oas_dispatch.sh\` syntax OK
- [x] \`./scripts/harness_oas_dispatch.sh --help\` renders
- [ ] CI lanes green (some may SKIP per \`Detect Changed Surfaces\` gate — locally verified above)
- [ ] Live workload run (operator step; see runbook section)

## Workaround Self-Check (CLAUDE.md §워크어라운드 거부 기준)

- [x] (#1) telemetry-as-fix? observation IS the deliverable, not a substitute for a fix
- [x] (#2) string classifier? no name-pattern matching
- [x] (#3) N-of-M? both hot paths wrapped in same PR; nothing deferred
- [x] (#4) catch-all match? only \`Cancelled | _\` at \`observe_hotpath\` bottom — Cancelled is re-raised explicitly per CLAUDE.md \`feedback\` on Eio.Cancel.Cancelled 삼킴 버그
- [x] (#5) cap/cooldown/dedup/repair? none
- [x] (#6) test backdoor? \`MASC_DISABLE_HOTPATH_HIST\` is ops control, not test-only
- [x] (#7) typo N-fix? N/A

## Follow-ups

- Phase C (params memoization) — conditional on Phase B numbers
- Phase D (make_tool_bundle pure/effect split) — conditional on Phase C
- Phase E (RFC for cross-module SSOT) — conditional on Phase C + D combined ≥ 40% reduction AND surface area > 1 module
- RFC-0036 activation PR #15275 cited as foundation

## Test plan

- [ ] Local \`dune build --root .\` (done)
- [ ] Live: start masc-mcp server, drive 50 turns via \`harness_tool_call_quality.sh --live\`, then \`./scripts/harness_oas_dispatch.sh scrape\` and confirm CSV non-zero
- [ ] hist-on vs hist-off diff to quantify observation overhead

🤖 Generated with [Claude Code](https://claude.com/claude-code)