### PR TITLE
feat(ide): route persistence focus chip

### DIFF
--- a/dashboard/src/components/ide/ide-persistence-panel.test.ts
+++ b/dashboard/src/components/ide/ide-persistence-panel.test.ts
@@ -162,6 +162,14 @@ describe('IdePersistencePanel', () => {
     render(html`<${IdePersistencePanel} pollMs=${60_000} />`)
 
     await waitFor(() => expect(fetchKeeperStateDiagramMock).toHaveBeenCalled())
+    const focusChip = screen.getByRole('button', {
+      name: 'Open current persistence focus Code lib/runtime.ml:42',
+    })
+    fireEvent.click(focusChip)
+    expect(window.location.hash).toBe(
+      '#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=42&surface=Persistence&label=sangsu+current+focus&source_id=persistence%3Asangsu&keeper=sangsu',
+    )
+
     const links = Array.from(screen.getByLabelText('Persistence context links')
       .querySelectorAll<HTMLButtonElement>('button'))
     expect(links.map(link => link.textContent)).toEqual(['Code', 'Keeper'])

--- a/dashboard/src/components/ide/ide-persistence-panel.ts
+++ b/dashboard/src/components/ide/ide-persistence-panel.ts
@@ -253,6 +253,10 @@ export function IdePersistencePanel({
   const focusLabel = cursor && cursor.file_path && cursor.line >= 1
     ? `${cursor.file_path.split('/').pop()}:${cursor.line}`
     : null
+  const routeLinks = persistenceRouteLinks(keeperName, cursor)
+  const focusRouteLink = focusLabel
+    ? routeLinks.find(link => link.label === 'Code') ?? null
+    : null
   const [diagram, setDiagram] = useState<KeeperStateDiagramResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
@@ -345,7 +349,11 @@ export function IdePersistencePanel({
           </span>
         ` : null}
         ${focusLabel ? html`
-          <span class="ide-persistence-focus" title=${cursor?.file_path}>↗ ${focusLabel}</span>
+          <${PersistenceFocusChip}
+            label=${focusLabel}
+            filePath=${cursor?.file_path}
+            routeLink=${focusRouteLink}
+          />
         ` : null}
         <span style=${{ marginLeft: 'auto' }}>
           <${PersistenceStatus} status=${persistenceState} lastSaved=${lastSaved} />
@@ -361,7 +369,7 @@ export function IdePersistencePanel({
           <div style=${{ display: 'grid', gap: 'var(--sp-2)' }}>
             <${LifecycleMini} state=${lifecycleState} phase=${phase} />
             <${PersistenceRouteLinks}
-              links=${persistenceRouteLinks(keeperName, cursor)}
+              links=${routeLinks}
             />
 
             <div
@@ -421,6 +429,29 @@ export function IdePersistencePanel({
         `
         : html`<div role="status" style=${{ color: 'var(--color-fg-disabled)', fontSize: 'var(--fs-12)' }}>keeper unavailable</div>`}
     </section>
+  `
+}
+
+function PersistenceFocusChip({
+  label,
+  filePath,
+  routeLink,
+}: {
+  readonly label: string
+  readonly filePath: string | undefined
+  readonly routeLink: IdeContextRouteLink | null
+}) {
+  if (!routeLink) {
+    return html`<span class="ide-persistence-focus" title=${filePath}>↗ ${label}</span>`
+  }
+  return html`
+    <button
+      type="button"
+      class="ide-persistence-focus"
+      title=${routeLink.evidence}
+      aria-label=${`Open current persistence focus ${routeLink.evidence}`}
+      onClick=${() => openIdeContextRouteLink(routeLink)}
+    >↗ ${label}</button>
   `
 }
 

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -1005,13 +1005,34 @@
 }
 
 .ide-persistence-focus {
+  display: inline-flex;
+  align-items: center;
   max-width: 120px;
   overflow: hidden;
+  padding: 0;
+  border: 0;
+  background: transparent;
   color: var(--color-accent-fg);
+  cursor: default;
   font-family: var(--font-mono);
   font-size: var(--fs-10);
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+button.ide-persistence-focus {
+  cursor: pointer;
+}
+
+button.ide-persistence-focus:hover,
+button.ide-persistence-focus:focus-visible {
+  color: var(--color-fg-primary);
+}
+
+button.ide-persistence-focus:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 2px;
+  border-radius: var(--r-1);
 }
 
 .ide-persistence-links {


### PR DESCRIPTION
## Summary
- Make the PERSISTENCE MAP focus chip actionable when a keeper cursor has a code route.
- Reuse the existing persistence route links so the header focus affordance and context links stay consistent.
- Add coverage that the focus chip routes to the current code focus.

## Validation
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/ide-persistence-panel.ts src/components/ide/ide-persistence-panel.test.ts
- pnpm exec vitest run src/components/ide/ide-persistence-panel.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD~1 HEAD