### PR TITLE
fix(telemetry): derive decode rate after first chunk

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -735,9 +735,14 @@ let wall_tokens_per_second
   | Some t when not usage_missing && output_tokens > 0 -> (
       match t.request_latency_ms with
       | Some request_latency_ms when request_latency_ms > 0 ->
-      Some
-        (Float.of_int output_tokens
-         /. (Float.of_int request_latency_ms /. ms_per_second))
+        let request_latency_ms = Float.of_int request_latency_ms in
+        let latency_ms =
+          match t.ttfrc_ms with
+          | Some ttfrc_ms when ttfrc_ms > 0.0 && ttfrc_ms < request_latency_ms ->
+            request_latency_ms -. ttfrc_ms
+          | _ -> request_latency_ms
+        in
+        Some (Float.of_int output_tokens /. (latency_ms /. ms_per_second))
       | _ -> None)
   | _ -> None
 

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -184,8 +184,10 @@ val wall_tokens_per_second :
   usage_missing:bool ->
   output_tokens:int ->
   telemetry:Agent_sdk.Types.inference_telemetry option -> float option
-(** Wall-clock tokens/sec computed from telemetry latency, or [None]
-    when usage / latency is missing. *)
+(** Output tokens/sec computed from telemetry latency, subtracting
+    [ttfrc_ms] when available so the fallback approximates decode
+    throughput instead of first-token wait time. Returns [None] when usage
+    / latency is missing. *)
 
 (** {1 Cost emit source} *)
 

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -318,6 +318,42 @@ let test_emit_cost_event_writes_wall_tok_s_without_provider_timings () =
      | _ -> false)
 ;;
 
+let test_emit_cost_event_derives_wall_tok_s_after_first_chunk () =
+  let root = temp_dir () in
+  let telemetry : Agent_sdk.Types.inference_telemetry =
+    { system_fingerprint = None
+    ; timings = None
+    ; reasoning_tokens = None
+    ; reasoning_tokens_estimated = false
+    ; request_latency_ms = Some 250
+    ; peak_memory_gb = None
+    ; provider_kind = Some Llm_provider.Provider_kind.OpenAI_compat
+    ; reasoning_effort = None
+    ; canonical_model_id = Some "auto"
+    ; effective_context_window = Some 128000
+    ; provider_internal_action_count = None
+    ; ttfrc_ms = Some 50.0
+    ; prefill_ms = None
+    }
+  in
+  Hooks.emit_cost_event
+    ~masc_root:root
+    ~agent_name:"keeper"
+    ~task_id:None
+    ~model:"ollama:qwen3.6:27b-coding-nvfp4"
+    ~input_tokens:100
+    ~output_tokens:50
+    ~cost_usd:0.0
+    ~telemetry
+    ();
+  let json = read_jsonl_line (Filename.concat root "costs.jsonl") in
+  check
+    (float 0.001)
+    "tokens_per_second uses post-first-chunk duration"
+    250.0
+    (json |> member "tokens_per_second" |> to_float)
+;;
+
 let test_emit_cost_event_marks_untrusted_usage () =
   let root = temp_dir () in
   let telemetry : Agent_sdk.Types.inference_telemetry =
@@ -1546,6 +1582,10 @@ let () =
             "emit_cost_event computes wall tok/s without native timings"
             `Quick
             test_emit_cost_event_writes_wall_tok_s_without_provider_timings
+        ; test_case
+            "emit_cost_event computes wall tok/s after first chunk"
+            `Quick
+            test_emit_cost_event_derives_wall_tok_s_after_first_chunk
         ; test_case
             "emit_cost_event marks untrusted usage"
             `Quick


### PR DESCRIPTION
## Summary

Improves the fallback token generation rate calculation when OAS telemetry includes first response chunk timing.

- Uses `request_latency_ms - ttfrc_ms` for fallback `tokens_per_second` when `ttfrc_ms` is present and sane.
- Keeps the existing total-latency fallback when first-chunk timing is absent or invalid.
- Adds a regression test for the post-first-chunk decode-rate path.

## Product impact

Operator cost/telemetry JSON now reports a generation-rate fallback closer to decode throughput instead of diluting it with first-token wait time.

## Evidence

- Kimi telemetry guide calls out Token Generation Rate as `output_tokens / (total_latency - ttft)`.
- Current provider-native `predicted_per_second` is already preserved, but the fallback `tokens_per_second` used total latency even when `ttfrc_ms` existed.

## Review evidence

- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe`
- `./_build/default/test/test_keeper_hooks_oas_telemetry.exe`
- `ocamlformat --check lib/keeper/keeper_hooks_oas.ml lib/keeper/keeper_hooks_oas.mli test/test_keeper_hooks_oas_telemetry.ml`
- `git diff --check`

## Linked issue

None.
