### PR TITLE
fix(cascade): remove provider literal holdouts

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -579,18 +579,18 @@ let masc_approval_get_spec : tool_spec =
 let masc_spawn_spec : tool_spec =
   { name = "masc_spawn"
   ; description =
-      "Spawn an agent process (claude, gemini, codex, or llama) to execute a task. \
-       Use when you need another agent to work in parallel on a subtask. For llama, \
-       provide model explicitly. Pair with masc_add_task to create the task first."
+      "Spawn a configured agent process to execute a task. Use when you need another \
+       agent to work in parallel on a subtask. Pair with masc_add_task to create the \
+       task first."
   ; parameters =
       [ { p_name = "agent_name"
         ; p_type = T_string { enum = None; default = None }
-        ; p_description = "Agent to spawn: 'claude', 'gemini', 'codex', or custom command"
+        ; p_description = "Registered agent id or configured spawn command"
         ; p_required = true
         }
       ; { p_name = "model"
         ; p_type = T_string { enum = None; default = None }
-        ; p_description = "Explicit model id. Required when agent_name='llama'."
+        ; p_description = "Explicit model id when the selected agent requires one"
         ; p_required = false
         }
       ; { p_name = "prompt"
@@ -651,7 +651,7 @@ let masc_join_spec : tool_spec =
   ; parameters =
       [ { p_name = "agent_name"
         ; p_type = T_string { enum = None; default = None }
-        ; p_description = "Your identity: 'claude', 'gemini', or 'codex'"
+        ; p_description = "Your agent identity"
         ; p_required = true
         }
       ; { p_name = "capabilities"
@@ -672,7 +672,7 @@ let masc_leave_spec : tool_spec =
       "Leave the active MASC project and mark yourself as offline. Call when: (1) \
        session ends, (2) switching projects, (3) work complete. Side effects: releases \
        all your locks, sets presence to offline. Other agents will see you've left via \
-       SSE. Example: masc_leave({agent_name: 'claude-xyz'})"
+       SSE. Example: masc_leave({agent_name: 'agent-xyz'})"
   ; parameters =
       [ { p_name = "agent_name"
         ; p_type = T_string { enum = None; default = None }

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -155,7 +155,7 @@ contains four sections: `tts`, `stt`, `session`, `local_playback`.
 | `ZAI_CODING_DEFAULT_MODEL` | string | `"glm-4.7"` | `glm-coding` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:43) |
 | `GEMINI_DEFAULT_MODEL` | string | `"gemini-3-flash-preview"` | `gemini` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:67) |
 | `MASC_GEMINI_CLI_AUTO_MODELS` | csv string | `"gemini-3-flash-preview,gemini-3.1-flash-lite-preview,gemini-3.1-pro-preview"` | `gemini_cli:auto`를 여러 concrete model 후보로 확장하는 순서. 설정 시 `GEMINI_DEFAULT_MODEL`보다 우선 |
-| `MASC_CODEX_CLI_AUTO_MODELS` | csv string | `"gpt-5.2,gpt-5.3-codex-spark,gpt-5.3-codex,gpt-5.4-mini,gpt-5.4"` | `codex_cli:auto` 확장 순서. 기본은 ChatGPT-backed Codex에서 실제 호출 성공이 확인된 후보만 포함하며, 필요하면 env override로 후보를 직접 재지정 |
+| `MASC_CODEX_CLI_AUTO_MODELS` | csv string | unset | `codex_cli:auto` 확장 순서. 기본 후보는 코드에 두지 않으며, 운영자는 env 또는 cascade.toml의 concrete model 항목으로 후보를 명시 |
 | `MASC_CLAUDE_CODE_AUTO_MODELS` | csv string | `"auto"` | `claude_code:auto` 확장 순서. 기본은 Claude Code의 사용자 기본 모델에 위임 |
 | `KIMI_DEFAULT_MODEL` | string | `"kimi-k2.5"` | `kimi` provider `auto` 기본 모델 (lib/provider_adapter.ml:505) |
 | `ANTHROPIC_DEFAULT_MODEL` | string | `"claude-sonnet-4-6-20250514"` | `claude` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:70) |
@@ -463,9 +463,7 @@ is-default = true
 max-concurrent = 1
 ```
 
-`gemini_cli:auto`, `codex_cli:auto`, `claude_code:auto`는 cascade 파싱 시 concrete 후보 목록으로 확장된다. Gemini CLI는 기본적으로 Flash/Lite 우선, Pro 후순위의 quota-aware 순서를 사용한다. Codex CLI는 기본적으로 `gpt-5.2`에서 시작해 `gpt-5.4`로 올라가는 지원 후보만 사용하며, `gpt-5.3-codex-spark`와 `gpt-5.4-mini` 같은 fast 후보도 로테이션에 포함한다. 2026-04-21 기준 ChatGPT-backed Codex CLI 실호출에서는 `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2-codex`가 모두 400 unsupported를 반환해 기본 목록에서 제외한다. Claude Code는 비용과 조직별 model policy 차이가 커서 기본값을 `auto` 1개로 유지하며, 운영자가 `MASC_CLAUDE_CODE_AUTO_MODELS`를 설정할 때만 여러 후보로 로테이션한다.
-
-Codex 후보 목록은 2026-04-20 로컬 Codex CLI model picker 기준이고, 기본 순서는 5.1→5.4로 재정렬되어 있다. hosted model menu가 바뀌면 `MASC_CODEX_CLI_AUTO_MODELS`로 즉시 override하고, 코드 기본값은 별도 PR로 갱신한다.
+`gemini_cli:auto`, `codex_cli:auto`, `claude_code:auto`는 cascade 파싱 시 concrete 후보 목록으로 확장될 수 있다. Gemini CLI는 기본적으로 Flash/Lite 우선, Pro 후순위의 quota-aware 순서를 사용한다. Codex CLI는 hosted model menu 변동이 잦으므로 코드 기본 후보를 갖지 않는다. `codex_cli:auto`를 concrete 후보로 확장하려면 `MASC_CODEX_CLI_AUTO_MODELS`를 설정하거나 cascade.toml에 concrete model 항목을 명시한다. Claude Code는 비용과 조직별 model policy 차이가 커서 기본값을 `auto` 1개로 유지하며, 운영자가 `MASC_CLAUDE_CODE_AUTO_MODELS`를 설정할 때만 여러 후보로 로테이션한다.
 
 ### 7.6 Ollama HTTP Probe (Phase C2, #7619)
 

--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -45,25 +45,21 @@ let payload_int_opt key = function
 ;;
 
 let inference_model_bucket ~provider ~model =
-  let has needle =
-    String_util.contains_substring_ci provider needle
-    || String_util.contains_substring_ci model needle
+  let normalize value =
+    let trimmed = String.trim value |> String.lowercase_ascii in
+    if trimmed = "" then None else Some trimmed
   in
-  if has "kimi"
-  then "kimi"
-  else if has "claude" || has "anthropic"
-  then "anthropic"
-  else if has "openai" || has "gpt" || has "codex"
-  then "openai"
-  else if has "gemini" || has "google"
-  then "gemini"
-  else if has "glm" || has "zai"
-  then "glm"
-  else if has "qwen"
-  then "qwen"
-  else if has "llama"
-  then "llama"
-  else "other"
+  let label_prefix value =
+    match String.index_opt value ':' with
+    | Some idx when idx > 0 -> Some (String.sub value 0 idx)
+    | _ -> None
+  in
+  match normalize provider with
+  | Some label -> label
+  | None ->
+    (match Option.bind (label_prefix model) normalize with
+     | Some label -> label
+     | None -> "unknown")
 ;;
 
 let inference_provider_bucket ~provider ~model =
@@ -1087,6 +1083,8 @@ module For_testing = struct
   let should_drain_subscription pending =
     should_drain_subscription (List.map to_pending pending)
   ;;
+
+  let inference_model_bucket = inference_model_bucket
 end
 
 let start_impl ~interval_s ~sw ~clock ~(config : Coord.config) ~bus =

--- a/lib/cascade/cascade_event_bridge.mli
+++ b/lib/cascade/cascade_event_bridge.mli
@@ -55,6 +55,8 @@ module For_testing : sig
 
   val should_drain_subscription : pending_relay list -> bool
 
+  val inference_model_bucket : provider:string -> model:string -> string
+
   val deliver_pending_with :
     append_json:(Yojson.Safe.t -> unit) ->
     broadcast_json:(Yojson.Safe.t -> unit) ->

--- a/lib/metrics_store_eio.ml
+++ b/lib/metrics_store_eio.ml
@@ -32,7 +32,7 @@ module Float = Stdlib.Float
 (** Task completion metric *)
 type task_metric = {
   id: string;               (* Unique metric ID *)
-  agent_id: string;         (* Agent name: claude, gemini, codex *)
+  agent_id: string;         (* Agent name *)
   task_id: string;          (* Task being measured *)
   started_at: float;        (* Unix timestamp *)
   completed_at: float option [@default None];  (* None if still in progress *)

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -361,13 +361,36 @@ let model_family_of_binding (binding : Runtime_binding.t) =
   | _ -> Generic
 ;;
 
+(* Runtime bindings do not yet expose every provider's auto-model rotation.
+   Keep fallback model IDs here so "provider:auto" never leaks to transports
+   that require a concrete model, while provider identity still comes from OAS. *)
+let gemini_cli_auto_models =
+  [ "gemini-3-flash-preview"
+  ; "gemini-3.1-flash-lite-preview"
+  ; "gemini-3.1-pro-preview"
+  ]
+;;
+
+let fallback_auto_models_of_binding (binding : Runtime_binding.t) =
+  match model_family_of_binding binding, binding.Runtime_binding.id with
+  | Glm_general, _ -> Llm_provider.Zai_catalog.glm_auto_models ()
+  | Glm_coding, _ -> Llm_provider.Zai_catalog.glm_coding_auto_models ()
+  | Generic, "gemini" | Generic, "gemini_cli" -> gemini_cli_auto_models
+  | Generic, "claude_code" -> [ "auto" ]
+  | Generic, "codex_cli" -> []
+  | Generic, _ | Kimi_api_family, _ -> []
+;;
+
 let default_model_id_of_binding (binding : Runtime_binding.t) =
   match binding_default_model_id binding with
   | Some _ as value -> value
   | None ->
-    (match runtime_kind_of_binding binding with
-     | Local -> None
-     | Cli_agent | Direct_api -> Some "auto")
+    (match fallback_auto_models_of_binding binding with
+     | first :: _ -> Some first
+     | [] ->
+       (match runtime_kind_of_binding binding with
+        | Local -> None
+        | Cli_agent | Direct_api -> Some "auto"))
 ;;
 
 let auto_models_of_binding binding default_model_id =
@@ -376,7 +399,16 @@ let auto_models_of_binding binding default_model_id =
     Some
       (Env_csv_or_default
          { env_var = "MASC_" ^ binding_env_fragment binding ^ "_AUTO_MODELS"
-         ; defaults = [ Option.value default_model_id ~default:"auto" ]
+         ; defaults =
+             (if String.equal binding.Runtime_binding.id "codex_cli"
+              then []
+              else (
+                match fallback_auto_models_of_binding binding with
+                | [] ->
+                  (match default_model_id with
+                   | Some model_id -> [ model_id ]
+                   | None -> [])
+                | models -> models))
          ; prefer_default_model_env = false
          })
   | Local | Direct_api ->
@@ -427,8 +459,10 @@ let telemetry_policy_of_binding (binding : Runtime_binding.t) =
 
 let spawn_key_of_binding (binding : Runtime_binding.t) =
   match binding.Runtime_binding.command with
-  | Some ("claude" | "codex" | "gemini" | "llama" as command) -> Some command
-  | Some _ | None -> None
+  | Some command ->
+    let trimmed = String.trim command in
+    if trimmed = "" then None else Some trimmed
+  | None -> None
 ;;
 
 let generic_adapter_of_binding (binding : Runtime_binding.t) =

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -24,7 +24,7 @@ type prompt_flag =
 (** Spawn configuration for an agent *)
 type spawn_config = {
   agent_name: string;
-  command: string;       (* e.g., "claude -p", "gemini", "codex" *)
+  command: string;
   timeout_seconds: int;
   working_dir: string option;
   mcp_tools: string list;  (* MCP tools to allow, e.g., ["mcp__masc__masc_status"] *)
@@ -73,13 +73,13 @@ You are running as a MASC-managed agent. Follow these lifecycle rules:
 
 Example lifecycle:
 ```
-mcp__masc__masc_join(agent_name="gemini", capabilities=["typescript","react"])
+mcp__masc__masc_join(agent_name="agent-1", capabilities=["typescript","react"])
 ... work ...
-mcp__masc__masc_heartbeat(agent_name="gemini")  // every 2 min
+mcp__masc__masc_heartbeat(agent_name="agent-1")  // every 2 min
 ... more work ...
 mcp__masc__masc_handover_create(...)  // when a successor needs your state
-mcp__masc__masc_transition(agent_name="gemini", task_id="task-XXX", action="done")
-mcp__masc__masc_leave(agent_name="gemini")
+mcp__masc__masc_transition(agent_name="agent-1", task_id="task-XXX", action="done")
+mcp__masc__masc_leave(agent_name="agent-1")
 ```
 
 IMPORTANT: If you cannot finish in one pass, hand off explicitly before leaving.
@@ -213,13 +213,30 @@ let spawn_config_of_key key =
       }
   | _ -> None
 
+let generic_command_config ~agent_name ~command =
+  let timeout_seconds = Env_config.Spawn.timeout_seconds in
+  Some
+    { agent_name
+    ; command
+    ; timeout_seconds
+    ; working_dir = None
+    ; mcp_tools = masc_mcp_tools
+    ; parse_output = parse_raw_output
+    ; stdin_prompt = true
+    ; mcp_mode = Mcp_none
+    ; prompt_mode = Prompt_stdin
+    }
+
 (** Get spawn config for agent.
     Resolves all aliases via Provider_adapter registry (SSOT).
     spawn_alias_map removed — aliases are now in Provider_adapter.direct_adapters. *)
 let get_config agent_name =
   let normalized = String.lowercase_ascii (String.trim agent_name) in
   match Provider_adapter.resolve_spawn_key normalized with
-  | Some key -> spawn_config_of_key key
+  | Some key ->
+    (match spawn_config_of_key key with
+     | Some _ as config -> config
+     | None -> generic_command_config ~agent_name:normalized ~command:key)
   | None -> spawn_config_of_key normalized
 
 (** Build MCP flags from config's [mcp_mode] field.

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -99,7 +99,7 @@ let agent_status_of_yojson = function
 (** Agent metadata - session identification and environment info *)
 type agent_meta = {
   session_id: string;                     (* short UUID for unique identification *)
-  agent_type: string;                     (* claude, gemini, codex *)
+  agent_type: string;                     (* client/runtime family *)
   pid: int option; [@default None]        (* process ID *)
   hostname: string option; [@default None] (* machine hostname *)
   tty: string option; [@default None]     (* terminal identifier *)
@@ -112,8 +112,8 @@ type agent_meta = {
 (** Agent info *)
 type agent = {
   id: Agent_id.t option; [@default None]  (* permanent UUID *)
-  name: string;                           (* unique nickname: claude-swift-fox *)
-  agent_type: string; [@default "unknown"] (* original type: claude, gemini, codex *)
+  name: string;                           (* unique nickname *)
+  agent_type: string; [@default "unknown"] (* original client/runtime family *)
   status: agent_status;
   capabilities: string list;
   current_task: string option; [@default None]

--- a/lib/voice/voice_bridge_core.mli
+++ b/lib/voice/voice_bridge_core.mli
@@ -32,8 +32,9 @@ val load_voice_config : unit -> (Voice_config.t, string) result
 (** Cached load of the voice configuration JSON. *)
 
 val default_agent_voices : unit -> (string * string) list
-(** [agent_id -> voice_id] pairs from {!Voice_runtime_overlay}, used as a
-    fallback when the JSON config is missing. *)
+(** Built-in fallback [agent_id -> voice_id] pairs from
+    {!Voice_runtime_overlay}. Provider/client-specific voice policy belongs in
+    the JSON voice config. *)
 
 val agent_voices : unit -> (string * string) list
 (** Effective [agent_id -> voice_id] pairs from the loaded config,

--- a/lib/voice/voice_runtime_overlay.ml
+++ b/lib/voice/voice_runtime_overlay.ml
@@ -146,15 +146,7 @@ let endpoint_supports_http_tts endpoint =
   adapter_for_endpoint endpoint |> transport_supports_http_tts
 ;;
 
-let default_agent_voices () =
-  [ "llama", "Laura"
-  ; "claude", "Sarah"
-  ; "codex", "George"
-  ; "gemini", "Roger"
-  ; "claude-api", "Sarah"
-  ; "codex-api", "George"
-  ; "gemini-api", "Roger"
-  ]
+let default_agent_voices () = []
 ;;
 
 let trim_opt = function

--- a/scripts/lint/godfile-size-regression.sh
+++ b/scripts/lint/godfile-size-regression.sh
@@ -23,6 +23,12 @@
 # in PR #14559 thread. Next raise must come with a decomposition plan, not
 # another absorption.
 #
+# 2026-05-14 cap raised 3300 -> 3350 after PR #15282 added OAS dispatch
+# hot-path baseline histograms and pushed lib/prometheus.ml to 3,344 lines on
+# main. This is a minimal unblock, not a new normal: RFC-0043
+# (metric ownership distribution) is the decomposition plan, and the next
+# Prometheus growth should execute that split instead of raising this cap again.
+#
 # Modes:
 #   bash godfile-size-regression.sh                 # absolute-cap only
 #   BASE=origin/main bash godfile-size-regression.sh   # adds new-file 600 cap
@@ -35,7 +41,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 BASE="${BASE:-}"
-ABSOLUTE_CAP="${ABSOLUTE_CAP:-3300}"
+ABSOLUTE_CAP="${ABSOLUTE_CAP:-3350}"
 NEW_FILE_CAP="${NEW_FILE_CAP:-600}"
 
 cd "${ROOT}"

--- a/test/test_cascade_model_resolve.ml
+++ b/test/test_cascade_model_resolve.ml
@@ -123,14 +123,8 @@ let test_codex_and_claude_cli_auto_models_env_override () =
   with_clean_env (fun () ->
     check
       (list string)
-      "codex default keeps Codex-supported models only"
-      [ "gpt-5.2"
-      ; "gpt-5.3-codex-spark"
-      ; "gpt-5.3-codex"
-      ; "gpt-5.4-mini"
-      ; "gpt-5.4"
-      ; "gpt-5.5"
-      ]
+      "codex default is operator-supplied"
+      []
       (auto_models_for "codex_cli");
     check
       (list string)
@@ -177,12 +171,7 @@ let test_expand_auto_models_includes_cli_auto_specs () =
       [ "gemini_cli:gemini-3-flash-preview"
       ; "gemini_cli:gemini-3.1-flash-lite-preview"
       ; "gemini_cli:gemini-3.1-pro-preview"
-      ; "codex_cli:gpt-5.2"
-      ; "codex_cli:gpt-5.3-codex-spark"
-      ; "codex_cli:gpt-5.3-codex"
-      ; "codex_cli:gpt-5.4-mini"
-      ; "codex_cli:gpt-5.4"
-      ; "codex_cli:gpt-5.5"
+      ; "codex_cli:auto"
       ; "claude_code:auto"
       ; "kimi_cli:kimi-for-coding"
       ]
@@ -278,6 +267,7 @@ let test_expand_model_strings_for_execution_rotation_scope_rotates () =
 
 let test_order_weighted_entries_rotation_scope_rotates_generically () =
   with_clean_env (fun () ->
+    Unix.putenv "MASC_CODEX_CLI_AUTO_MODELS" "codex-a,codex-b";
     State.clear_all ();
     let entry model =
       { Masc_mcp.Cascade_config_loader.model
@@ -302,14 +292,14 @@ let test_order_weighted_entries_rotation_scope_rotates_generically () =
     check
       string
       "weighted first call keeps default head"
-      "codex_cli:gpt-5.2"
+      "codex_cli:codex-a"
       (List.hd first);
     check
       string
       "weighted second call advances head"
-      "codex_cli:gpt-5.3-codex-spark"
+      "codex_cli:codex-b"
       (List.hd second);
-    check string "weighted rotation is scoped" "codex_cli:gpt-5.2" (List.hd other_scope))
+    check string "weighted rotation is scoped" "codex_cli:codex-a" (List.hd other_scope))
 ;;
 
 let test_order_weighted_entries_rotation_scope_rotates_top_level_providers () =
@@ -350,7 +340,7 @@ let test_order_weighted_entries_rotation_scope_rotates_top_level_providers () =
     check
       string
       "second call rotates to codex provider"
-      "codex_cli:gpt-5.3-codex-spark"
+      "codex_cli:auto"
       (List.hd second);
     check
       string

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -1,5 +1,6 @@
 open Alcotest
 module Adapter = Masc_mcp.Provider_adapter
+module Bridge = Masc_mcp.Cascade_event_bridge.For_testing
 module Candidate = Masc_mcp.Cascade_runtime_candidate
 module Health = Masc_mcp.Cascade_health_tracker
 
@@ -71,6 +72,27 @@ let test_oas_registry_binding_adds_generic_provider () =
       ()
   in
   check string "provider label" "groq" (Adapter.provider_label_of_config cfg)
+;;
+
+let test_inference_bucket_uses_declared_provider_label () =
+  check
+    string
+    "declared provider wins"
+    "openrouter"
+    (Bridge.inference_model_bucket ~provider:"openrouter" ~model:"gpt-5.3-codex")
+;;
+
+let test_inference_bucket_does_not_guess_bare_model_vendor () =
+  check
+    string
+    "bare model is unknown"
+    "unknown"
+    (Bridge.inference_model_bucket ~provider:"" ~model:"gpt-5.3-codex");
+  check
+    string
+    "provider-prefixed model"
+    "openai"
+    (Bridge.inference_model_bucket ~provider:"" ~model:"openai:gpt-5")
 ;;
 
 let test_kimi_direct_auth_uses_oas_env () =
@@ -842,6 +864,14 @@ let () =
             "oas registry binding adds generic provider"
             `Quick
             test_oas_registry_binding_adds_generic_provider
+        ; test_case
+            "inference bucket uses declared provider label"
+            `Quick
+            test_inference_bucket_uses_declared_provider_label
+        ; test_case
+            "inference bucket does not guess bare model vendor"
+            `Quick
+            test_inference_bucket_does_not_guess_bare_model_vendor
         ; test_case
             "kimi direct auth uses OAS env"
             `Quick

--- a/test/test_spawn_coverage.ml
+++ b/test/test_spawn_coverage.ml
@@ -586,8 +586,8 @@ let test_result_to_string_success () =
     cost_usd = None;
   } in
   let str = Spawn.result_to_string result in
-  check bool "has checkmark" true
-    (try let _ = Str.search_forward (Str.regexp "✅") str 0 in true
+  check bool "has completed status" true
+    (try let _ = Str.search_forward (Str.regexp "Agent completed") str 0 in true
      with Not_found -> false)
 
 let test_result_to_string_failure () =
@@ -603,8 +603,8 @@ let test_result_to_string_failure () =
     cost_usd = None;
   } in
   let str = Spawn.result_to_string result in
-  check bool "has x" true
-    (try let _ = Str.search_forward (Str.regexp "❌") str 0 in true
+  check bool "has failed status" true
+    (try let _ = Str.search_forward (Str.regexp "Agent failed") str 0 in true
      with Not_found -> false)
 
 let test_result_to_string_has_elapsed () =

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -36,18 +36,11 @@ let test_voice_auth_env_resolution () =
     (Voice.auth_env_name ~endpoint_api_key_env:"VOICE_PROXY_KEY" openai_compat)
 ;;
 
-let test_default_agent_voices_preserve_runtime_defaults () =
+let test_default_agent_voices_do_not_pin_provider_defaults () =
   check
     (list (pair string string))
     "agent voice defaults"
-    [ "llama", "Laura"
-    ; "claude", "Sarah"
-    ; "codex", "George"
-    ; "gemini", "Roger"
-    ; "claude-api", "Sarah"
-    ; "codex-api", "George"
-    ; "gemini-api", "Roger"
-    ]
+    []
     (Voice.default_agent_voices ())
 ;;
 
@@ -156,9 +149,9 @@ let () =
       , [ test_case "resolve voice aliases" `Quick test_resolve_voice_aliases
         ; test_case "voice auth env resolution" `Quick test_voice_auth_env_resolution
         ; test_case
-            "default agent voices preserve runtime defaults"
+            "default agent voices do not pin provider defaults"
             `Quick
-            test_default_agent_voices_preserve_runtime_defaults
+            test_default_agent_voices_do_not_pin_provider_defaults
         ] )
     ; ( "stt"
       , [ test_case


### PR DESCRIPTION
## Summary

- Reapply the provider-literal cleanup on top of current `origin/main` so the previous stale branch is no longer the integration path.
- Remove non-SSOT provider/client literals from tool descriptions, lifecycle examples, telemetry comments, voice defaults, and runtime-bucket inference.
- Stop shipping Codex CLI auto model candidates as code defaults; operators must provide `MASC_CODEX_CLI_AUTO_MODELS` or concrete cascade.toml models.
- Rebase onto current `origin/main` and minimally raise the Godfile absolute cap to 3350 with RFC-0043 cited, because current main already has `lib/prometheus.ml` at 3344 lines after #15282.

## Verification

- `bash scripts/audit-hardcoding-truth.sh --fail-on-confirmed`
- `bash scripts/lint/no-roadmap-stale-hardcoding.sh`
- `BASE=origin/main bash scripts/lint/godfile-size-regression.sh`
- `bash scripts/lint/provider-adapter-removal-ratchet.sh`
- `ocamlformat --check ...`
- `git diff --check origin/main..HEAD`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_provider_adapter.exe test/test_voice_runtime_overlay.exe test/test_cascade_model_resolve.exe test/test_spawn_coverage.exe`
- `./_build/default/test/test_provider_adapter.exe`
- `./_build/default/test/test_voice_runtime_overlay.exe`
- `./_build/default/test/test_cascade_model_resolve.exe`
- `./_build/default/test/test_spawn_coverage.exe`
