### PR TITLE
feat(ide): route branch graph repo refs

### DIFF
--- a/dashboard/src/components/ide/ide-branch-context-panel.test.ts
+++ b/dashboard/src/components/ide/ide-branch-context-panel.test.ts
@@ -97,6 +97,7 @@ describe('buildIdeBranchContextModel', () => {
     expect(model?.repoLabel).toBe('masc-mcp')
     expect(model?.currentBranch).toBe('fix/ide-branch')
     expect(model?.head).toBe('abcdef1234')
+    expect(model?.headRef).toBe('abcdef1234567890')
     expect(model?.status).toBe('dirty')
     expect(model?.branches[0]?.tone).toBe('current')
     expect(model?.lanes[0]?.path).toBe('.worktrees/fix-ide-branch')
@@ -145,6 +146,16 @@ describe('IdeBranchContextPanel', () => {
     expect(container.textContent).toContain('fix/ide-branch')
     expect(container.textContent).toContain('abcdef1234')
     expect(container.querySelector('svg[aria-label="Branch graph for masc-mcp"]')).not.toBeNull()
+
+    const repoLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-branch-repo-row button')]
+    expect(repoLinks.map(link => link.getAttribute('aria-label'))).toEqual([
+      'Open Git fix/ide-branch',
+      'Open Git abcdef1234567890',
+    ])
+    fireEvent.click(repoLinks[0]!)
+    expect(window.location.hash).toBe('#workspace?section=repositories&view=graph&ref=fix%2Fide-branch')
+    fireEvent.click(repoLinks[1]!)
+    expect(window.location.hash).toBe('#workspace?section=repositories&view=graph&ref=abcdef1234567890')
   })
 
   it('matches worktree lanes to keeper presence and cursor state by keeper label', async () => {

--- a/dashboard/src/components/ide/ide-branch-context-panel.ts
+++ b/dashboard/src/components/ide/ide-branch-context-panel.ts
@@ -39,6 +39,7 @@ export interface IdeBranchContextModel {
   readonly repoRoot: string
   readonly currentBranch: string
   readonly head: string
+  readonly headRef: string | null
   readonly status: 'clean' | 'dirty' | 'conflict'
   readonly stats: {
     readonly branchCount: number
@@ -140,6 +141,7 @@ export function buildIdeBranchContextModel(
     repoRoot: repo.root,
     currentBranch,
     head: shortSha(repo.head),
+    headRef: repo.head,
     status,
     stats: {
       branchCount: repo.branch_count,
@@ -276,11 +278,7 @@ export function IdeBranchContextPanel({
       </header>
 
       ${model ? html`
-        <div class="ide-branch-repo-row">
-          <span class="ide-branch-repo">${model.repoLabel}</span>
-          <span class="ide-branch-current">${model.currentBranch}</span>
-          <span class="ide-branch-head">${model.head}</span>
-        </div>
+        <${BranchRepoRow} model=${model} />
         <${MiniBranchGraph} model=${model} />
         <div class="ide-branch-stat-row" aria-label=${branchSummary}>
           <span>${model.stats.branchCount} br</span>
@@ -310,6 +308,63 @@ export function IdeBranchContextPanel({
         </div>
       `}
     </section>
+  `
+}
+
+function BranchRepoRow({ model }: { readonly model: IdeBranchContextModel }) {
+  const branchLink = branchRepoGitLink(
+    model.currentBranch && model.currentBranch !== 'detached' ? model.currentBranch : null,
+    `${model.repoLabel} current branch`,
+  )
+  const headLink = branchRepoGitLink(
+    model.headRef ?? (model.head !== 'unknown' ? model.head : null),
+    `${model.repoLabel} HEAD`,
+  )
+  return html`
+    <div class="ide-branch-repo-row">
+      <span class="ide-branch-repo">${model.repoLabel}</span>
+      <${BranchRepoRouteChip}
+        className="ide-branch-current"
+        label=${model.currentBranch}
+        routeLink=${branchLink}
+      />
+      <${BranchRepoRouteChip}
+        className="ide-branch-head"
+        label=${model.head}
+        routeLink=${headLink}
+      />
+    </div>
+  `
+}
+
+function branchRepoGitLink(ref: string | null, label: string): IdeContextRouteLink | null {
+  if (!ref) return null
+  return routeLinksForContext({
+    surface: 'Git',
+    label,
+    sourceId: `branch-context:${ref}`,
+    gitRef: ref,
+  }).find(link => link.label === 'Git') ?? null
+}
+
+function BranchRepoRouteChip({
+  className,
+  label,
+  routeLink,
+}: {
+  readonly className: string
+  readonly label: string
+  readonly routeLink: IdeContextRouteLink | null
+}) {
+  if (!routeLink) return html`<span class=${className}>${label}</span>`
+  return html`
+    <button
+      type="button"
+      class=${`${className} ide-branch-repo-route`}
+      title=${routeLink.evidence}
+      aria-label=${`Open ${routeLink.evidence}`}
+      onClick=${() => openIdeContextRouteLink(routeLink)}
+    >${label}</button>
   `
 }
 

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -1140,6 +1140,25 @@ button.ide-persistence-focus:focus-visible {
   color: var(--color-fg-disabled);
 }
 
+.ide-branch-repo-route {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+}
+
+.ide-branch-repo-route:hover,
+.ide-branch-repo-route:focus-visible {
+  color: var(--color-fg-primary);
+}
+
+.ide-branch-repo-route:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 2px;
+  border-radius: var(--r-1);
+}
+
 .ide-branch-mini-graph {
   width: 100%;
   height: 5.375rem;


### PR DESCRIPTION
## Summary
- Make BRANCH GRAPH current branch and HEAD chips route to repository graph refs.
- Preserve short HEAD display while storing full headRef for navigation.
- Reuse existing IDE context route helpers instead of introducing new route rules.

## Validation
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/ide-branch-context-panel.ts src/components/ide/ide-branch-context-panel.test.ts
- pnpm exec vitest run src/components/ide/ide-branch-context-panel.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD~1 HEAD