### PR TITLE
fix(provider): route dashboard runs through OAS bindings

### DIFF
--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -126,8 +126,7 @@ type cascade_thinking_control_format =
     so the cascade.toml [\[models.<id>.capabilities\]] sub-table becomes
     the SSOT for per-model feature flags. Currently OAS derives these
     via [for_model_id_static] substring match on the upstream *API model
-    identifier* — e.g. [starts_with "claude-opus-4"], [starts_with
-    "gpt-5"]. That input is the api-name (cascade_model_spec.api_name /
+    identifier*. That input is the api-name (cascade_model_spec.api_name /
     Provider_config.model_id), not the cascade [\[models.<id>\]] key.
     M2 replaces that derivation with a cascade.toml lookup keyed on the
     cascade [<id>] (the cascade key) so OAS no longer needs to "know

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -151,52 +151,64 @@ let make_run_id () =
   let hash = Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFFFF in
   Printf.sprintf "run-%d-%06x" ts_ms hash
 
-let model_id_of_label label =
-  match String.index_opt label ':' with
-  | Some idx when idx < String.length label - 1 ->
-      let model =
-        String.sub label (idx + 1) (String.length label - idx - 1)
-        |> String.trim
-      in
-      if String.equal model "" then None else Some model
-  | _ -> None
+type provider_auth_detail = {
+  auth_kind : string;
+  status : string;
+  available : bool;
+  supports_run : bool;
+  endpoint_url : string option;
+  note : string option;
+}
 
-(* auth_kind_for_provider and endpoint_url_for_provider removed.
-   Use Provider_adapter.auth_detail_of_provider instead. *)
+let auth_detail_of_binding binding =
+  let available = Provider_runtime_overlay.available binding in
+  let note =
+    match Provider_runtime_overlay.runtime_kind binding with
+    | `Cli_agent ->
+        Some "Cached CLI login is assumed; final validation happens at execution time."
+    | `Local | `Direct_api -> None
+  in
+  {
+    auth_kind = Provider_runtime_overlay.auth_kind binding;
+    status = (if available then "configured" else "missing_auth");
+    available;
+    supports_run = available;
+    endpoint_url = Provider_runtime_overlay.endpoint_url binding;
+    note;
+  }
 
-let catalog_models_for_provider provider =
-  match Provider_adapter.resolve_direct_adapter provider with
-  | Some { canonical_name; _ } when String.equal canonical_name Provider_adapter.cn_llama -> []
-  | Some _ -> (
-      match Provider_adapter.auto_models_for_provider provider with
-      | Some models -> models
-      | None -> [ "auto" ])
-  | None -> []
+let models_for_binding binding =
+  let default_model = Provider_runtime_overlay.default_model_id binding in
+  match Provider_runtime_overlay.supported_models binding with
+  | [] -> Option.to_list default_model
+  | models -> models
 
-let default_model_for_provider provider =
-  match Provider_adapter.resolve_direct_adapter provider with
-  | Some { canonical_name; _ } when String.equal canonical_name Provider_adapter.cn_llama -> (
-      match Provider_adapter.explicit_llama_model_id_result () with
-      | Ok model_id -> trim_nonempty model_id
-      | Error _ -> None)
-  | Some { default_model_id; _ } -> (
-      match catalog_models_for_provider provider with
-      | first :: _ when not (String.equal (String.trim first) "") && not (String.equal first "auto") -> Some first
-      | _ -> default_model_id)
-  | None -> None
+let runtime_kind_string binding =
+  match Provider_runtime_overlay.runtime_kind binding with
+  | `Local -> "local"
+  | `Cli_agent -> "cli_agent"
+  | `Direct_api -> "direct_api"
 
-let candidate_models_for_provider provider =
-  catalog_models_for_provider provider
+let dashboard_kind_string binding =
+  match Provider_runtime_overlay.runtime_kind binding with
+  | `Local -> "local"
+  | `Cli_agent -> "cli"
+  | `Direct_api -> "cloud"
 
-let llama_snapshot () =
+let llama_snapshot binding =
   let discovered_models, status, available, note =
-    match Tool_local_runtime_core.fetch_models_at Env_config_runtime.Llama.server_url with
+    let endpoint =
+      Provider_runtime_overlay.endpoint_url binding
+      |> Option.value ~default:Env_config_runtime.Llama.server_url
+    in
+    match Tool_local_runtime_core.fetch_models_at endpoint with
     | Ok (_url, models) -> (models, "online", true, None)
     | Error message -> ([], "offline", false, Some message)
   in
+  let default_model = Provider_runtime_overlay.default_model_id binding in
   let models =
     dedupe_keep_order
-      (discovered_models @ Option.to_list (default_model_for_provider "llama"))
+      (discovered_models @ Option.to_list default_model)
   in
   (* Merge OAS Discovery probe data for richer observability.
      Discovery_cache.get_cached_or_refresh is TTL-gated (30s),
@@ -220,60 +232,51 @@ let llama_snapshot () =
         healthy = ep.healthy;
       }
   in
+  let detail = auth_detail_of_binding binding in
   {
-    provider = "llama";
+    provider = Provider_runtime_overlay.id binding;
     kind = "local";
     runtime_kind = "local";
-    auth_kind = "none";
+    auth_kind = detail.auth_kind;
     status;
     available;
     supports_single_agent_run = available && Stdlib.List.length models > 0;
-    default_model = default_model_for_provider "llama";
+    default_model;
     models;
-    source = "masc/local-runtime";
-    endpoint_url = (Provider_adapter.auth_detail_of_provider "llama").endpoint_url;
+    source = "oas/provider-runtime-binding";
+    endpoint_url = detail.endpoint_url;
     note;
     discovery;
   }
 
-(** Build snapshot for any direct-API provider.
-    Vendor-specific logic (Gemini Vertex ADC, etc.) is encapsulated
-    inside Provider_adapter.auth_detail_of_provider. *)
-let provider_snapshot_of_adapter (adapter : Provider_adapter.adapter) =
-  let provider = adapter.canonical_name in
-  let detail = Provider_adapter.auth_detail_of_provider provider in
-  let default_model = default_model_for_provider provider in
-  let kind =
-    match adapter.runtime_kind with
-    | Provider_adapter.Local -> "local"
-    | Provider_adapter.Cli_agent -> "cli"
-    | Provider_adapter.Direct_api -> "cloud"
-  in
+let provider_snapshot_of_binding binding =
+  let provider = Provider_runtime_overlay.id binding in
+  let detail = auth_detail_of_binding binding in
+  let default_model = Provider_runtime_overlay.default_model_id binding in
+  let models = models_for_binding binding in
   {
     provider;
-    kind;
-    runtime_kind = Provider_adapter.string_of_runtime_kind adapter.runtime_kind;
+    kind = dashboard_kind_string binding;
+    runtime_kind = runtime_kind_string binding;
     auth_kind = detail.auth_kind;
     status = detail.status;
     available = detail.available;
-    supports_single_agent_run = detail.supports_run && Option.is_some default_model;
+    supports_single_agent_run =
+      detail.supports_run && (Option.is_some default_model || models <> []);
     default_model;
-    models = candidate_models_for_provider provider;
-    source = "masc/provider-adapter";
+    models;
+    source = "oas/provider-runtime-binding";
     endpoint_url = detail.endpoint_url;
     note = detail.note;
     discovery = None;
   }
 
 let provider_snapshots () : provider_snapshot list =
-  let managed =
-    Provider_adapter.direct_adapters
-    |> List.filter (fun (a : Provider_adapter.adapter) ->
-         not ((=) a.runtime_kind Provider_adapter.Local)
-         && Option.is_some a.default_model_id)
-    |> List.map provider_snapshot_of_adapter
-  in
-  llama_snapshot () :: managed
+  Provider_runtime_overlay.all ()
+  |> List.map (fun binding ->
+         if String.equal (Provider_runtime_overlay.id binding) "llama" then
+           llama_snapshot binding
+         else provider_snapshot_of_binding binding)
 
 let provider_snapshot_by_name name =
   provider_snapshots ()
@@ -360,21 +363,20 @@ let response_text_of_api_response (response : Agent_sdk.Types.api_response) =
   Agent_sdk.Types.text_of_content response.content |> String.trim
 
 let provider_label_for_model provider model =
-  match Provider_adapter.resolve_direct_adapter provider with
-  | Some adapter ->
-    let prefix = Provider_adapter.cascade_prefix_of_adapter adapter in
-    (match Provider_adapter.provider_model_label prefix model with
-     | Some label -> Ok label
-     | None ->
-       Error
-         (Printf.sprintf
-            "Missing model for dashboard single-agent provider '%s'"
-            provider))
+  match Provider_runtime_overlay.find_by_candidates [ provider ] with
+  | Some binding ->
+      let model = String.trim model in
+      if String.equal model "" then
+        Error
+          (Printf.sprintf
+             "Missing model for dashboard single-agent provider '%s'"
+             provider)
+      else Ok (Printf.sprintf "%s:%s" (Provider_runtime_overlay.id binding) model)
   | None ->
-    Error
-      (Printf.sprintf
-         "Unsupported provider '%s' for dashboard single-agent runs"
-         provider)
+      Error
+        (Printf.sprintf
+           "Unsupported provider '%s' for dashboard single-agent runs"
+           provider)
 
 let resolve_provider_run_request ~provider ~model_opt ~prompt =
   match provider_snapshot_by_name provider with
@@ -416,13 +418,16 @@ let is_label_runnable (label : string) : bool =
   match Cascade_config.parse_model_string label with
   | None -> false
   | Some _cfg ->
-    (* Extract provider prefix from label and check auth detail *)
-    match String.index_opt label ':' with
-    | None -> false
-    | Some idx ->
-      let prefix = String.sub label 0 idx |> String.trim in
-      let detail = Provider_adapter.auth_detail_of_provider prefix in
-      detail.available && detail.supports_run
+      (* Extract provider prefix and check the OAS runtime binding. *)
+      match String.index_opt label ':' with
+      | None -> false
+      | Some idx -> (
+          let prefix = String.sub label 0 idx |> String.trim in
+          match Provider_runtime_overlay.find_by_candidates [ prefix ] with
+          | None -> false
+          | Some binding ->
+              let detail = auth_detail_of_binding binding in
+              detail.available && detail.supports_run)
 
 let run_system_prompt provider =
   Printf.sprintf

--- a/lib/dashboard_provider_runs.mli
+++ b/lib/dashboard_provider_runs.mli
@@ -23,11 +23,10 @@
     ([discovery_info_to_json], [provider_snapshot_to_json],
     [run_record_to_json]), Hashtbl mutators
     ([set_run_record], [update_run_record], [find_run_record]),
-    [make_run_id], model-list resolvers
-    ([model_id_of_label], [catalog_models_for_provider],
-    [default_model_for_provider],
-    [candidate_models_for_provider]), [llama_snapshot] +
-    [provider_snapshot_of_adapter] + [provider_snapshots] +
+    [make_run_id], OAS binding projection helpers
+    ([auth_detail_of_binding], [models_for_binding],
+    [runtime_kind_string], [dashboard_kind_string]),
+    [llama_snapshot] + [provider_snapshot_of_binding] + [provider_snapshots] +
     [provider_snapshot_by_name],
     [response_text_of_api_response],
     [provider_label_for_model],

--- a/lib/dune
+++ b/lib/dune
@@ -4,6 +4,7 @@
  (public_name masc_mcp)
 (private_modules
  plan_action_outcome
+ prometheus_text
  error_event_type
  alert_persist_kind
  metrics_sse_failure_kind

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -3024,14 +3024,13 @@ let set_tool_schema_stats ~count ~approx_tokens =
   set_gauge metric_mcp_tool_schema_tokens_approx (float_of_int approx_tokens)
 ;;
 
-(** {1 Prometheus Export} *)
-
-let type_to_string = function
-  | Counter -> "counter"
-  | Gauge -> "gauge"
-  | Histogram -> "histogram"
+let text_metric_type = function
+  | Counter -> Prometheus_text.Counter
+  | Gauge -> Prometheus_text.Gauge
+  | Histogram -> Prometheus_text.Histogram
 ;;
 
+let type_to_string metric_type = Prometheus_text.type_to_string (text_metric_type metric_type)
 let labels_to_string = Prometheus_format.labels_to_string
 
 let to_prometheus_text () =
@@ -3045,112 +3044,17 @@ let to_prometheus_text () =
     with_lock (fun () ->
       Hashtbl.fold
         (fun _ (m : metric) acc ->
-           { name = m.name
-           ; help = m.help
-           ; metric_type = m.metric_type
-           ; value = m.value
-           ; labels = m.labels
-           }
+           Prometheus_text.metric
+             ~name:m.name
+             ~help:m.help
+             ~metric_type:(text_metric_type m.metric_type)
+             ~value:m.value
+             ~labels:m.labels
            :: acc)
         metrics
         [])
   in
-  let buf = Buffer.create 1024 in
-  let by_name = Hashtbl.create 32 in
-  List.iter
-    (fun (m : metric) ->
-       let existing = Hashtbl.find_opt by_name m.name |> Option.value ~default:[] in
-       Hashtbl.replace by_name m.name (m :: existing))
-    snapshot;
-  (* Collect histogram parent names.  observe_histogram stores the
-     cumulative sum under the original name and the observation count
-     under "<name>_count".  We suppress standalone export of the
-     _count companion and instead emit it inline as part of the
-     summary stanza for the parent. *)
-  let histogram_parents = Hashtbl.create 8 in
-  Hashtbl.iter
-    (fun name ms ->
-       List.iter
-         (fun (m : metric) ->
-            if m.metric_type = Histogram then Hashtbl.replace histogram_parents name true)
-         ms)
-    by_name;
-  Hashtbl.iter
-    (fun name ms ->
-       let is_histogram_count =
-         let suf = "_count" in
-         let slen = String.length suf in
-         String.length name > slen
-         && String.sub name (String.length name - slen) slen = suf
-         && Hashtbl.mem histogram_parents (String.sub name 0 (String.length name - slen))
-       in
-       if is_histogram_count
-       then ()
-       else (
-         match ms with
-         | [] -> ()
-         | head_metric :: _ as ms ->
-           (* Pick HELP deterministically from the unlabeled parent row that
-         [register_histogram] created at startup; without this, the
-         exported HELP becomes nondeterministically either the real
-         description or the raw metric name once any labelled phase row
-         is added by [observe_histogram] (which fills [help = name]
-         when no entry exists yet).  Fall back to the first entry's
-         [help] when no unlabeled parent exists, then to the metric
-         name. *)
-           let chosen_help =
-             let unlabeled = List.find_opt (fun (m : metric) -> m.labels = []) ms in
-             match unlabeled with
-             | Some m when m.help <> "" && m.help <> m.name -> m.help
-             | _ ->
-               let descriptive =
-                 List.find_opt (fun (m : metric) -> m.help <> "" && m.help <> m.name) ms
-               in
-               (match descriptive with
-                | Some m -> m.help
-                | None -> name)
-           in
-           Printf.bprintf buf "# HELP %s %s\n" name chosen_help;
-           (match head_metric.metric_type with
-            | Histogram ->
-              (* No bucket distribution is tracked, so emit as summary
-            (sum + count) which is the closest valid Prometheus type. *)
-              Printf.bprintf buf "# TYPE %s summary\n" name;
-              List.iter
-                (fun (metric : metric) ->
-                   let ls = labels_to_string metric.labels in
-                   Buffer.add_string
-                     buf
-                     (Printf.sprintf "%s_sum%s %g\n" name ls metric.value);
-                   let count_key = metric_key (name ^ "_count") metric.labels in
-                   let count_val =
-                     with_lock (fun () ->
-                       match Hashtbl.find_opt metrics count_key with
-                       | Some cm -> cm.value
-                       | None -> 0.0)
-                   in
-                   Buffer.add_string
-                     buf
-                     (Printf.sprintf "%s_count%s %g\n" name ls count_val))
-                ms
-            | _ ->
-              Buffer.add_string
-                buf
-                (Printf.sprintf
-                   "# TYPE %s %s\n"
-                   name
-                   (type_to_string head_metric.metric_type));
-              List.iter
-                (fun (metric : metric) ->
-                   Printf.bprintf
-                     buf
-                     "%s%s %g\n"
-                     metric.name
-                     (labels_to_string metric.labels)
-                     metric.value)
-                ms)))
-    by_name;
-  Buffer.contents buf
+  Prometheus_text.render snapshot
 ;;
 
 (** {1 Convenience Functions} *)

--- a/lib/prometheus_text.ml
+++ b/lib/prometheus_text.ml
@@ -1,0 +1,135 @@
+type label = string * string
+
+type metric_type =
+  | Counter
+  | Gauge
+  | Histogram
+
+type metric =
+  { name : string
+  ; help : string
+  ; metric_type : metric_type
+  ; value : float
+  ; labels : label list
+  }
+
+let metric ~name ~help ~metric_type ~value ~labels =
+  { name; help; metric_type; value; labels }
+;;
+
+let add_key_segment buf s =
+  Buffer.add_string buf (string_of_int (String.length s));
+  Buffer.add_char buf ':';
+  Buffer.add_string buf s
+;;
+
+let labels_key labels =
+  let buf = Buffer.create 32 in
+  List.iter
+    (fun (k, v) ->
+       add_key_segment buf k;
+       add_key_segment buf v)
+    labels;
+  Buffer.contents buf
+;;
+
+let metric_key name labels =
+  let encoded_labels = labels_key labels in
+  let buf = Buffer.create (String.length name + String.length encoded_labels + 16) in
+  add_key_segment buf name;
+  Buffer.add_string buf encoded_labels;
+  Buffer.contents buf
+;;
+
+let type_to_string = function
+  | Counter -> "counter"
+  | Gauge -> "gauge"
+  | Histogram -> "histogram"
+;;
+
+let labels_to_string = function
+  | [] -> ""
+  | labels ->
+    let pairs =
+      List.map (fun (k, v) -> Printf.sprintf "%s=\"%s\"" k (String.escaped v)) labels
+    in
+    "{" ^ String.concat "," pairs ^ "}"
+;;
+
+let has_metric_type metric_type (m : metric) = m.metric_type = metric_type
+
+let choose_help name ms =
+  let unlabeled = List.find_opt (fun (m : metric) -> m.labels = []) ms in
+  match unlabeled with
+  | Some m when m.help <> "" && m.help <> m.name -> m.help
+  | _ ->
+    let descriptive =
+      List.find_opt (fun (m : metric) -> m.help <> "" && m.help <> m.name) ms
+    in
+    (match descriptive with
+     | Some m -> m.help
+     | None -> name)
+;;
+
+let is_histogram_count ~histogram_parents name =
+  let suffix = "_count" in
+  let suffix_len = String.length suffix in
+  String.length name > suffix_len
+  && String.sub name (String.length name - suffix_len) suffix_len = suffix
+  &&
+  let parent = String.sub name 0 (String.length name - suffix_len) in
+  Hashtbl.mem histogram_parents parent
+;;
+
+let render snapshot =
+  let buf = Buffer.create 1024 in
+  let by_name = Hashtbl.create 32 in
+  let values_by_key = Hashtbl.create 64 in
+  List.iter
+    (fun (m : metric) ->
+       let existing = Hashtbl.find_opt by_name m.name |> Option.value ~default:[] in
+       Hashtbl.replace by_name m.name (m :: existing);
+       Hashtbl.replace values_by_key (metric_key m.name m.labels) m.value)
+    snapshot;
+  let histogram_parents = Hashtbl.create 8 in
+  Hashtbl.iter
+    (fun name ms ->
+       if List.exists (has_metric_type Histogram) ms
+       then Hashtbl.replace histogram_parents name true)
+    by_name;
+  Hashtbl.iter
+    (fun name ms ->
+       if is_histogram_count ~histogram_parents name
+       then ()
+       else (
+         match ms with
+         | [] -> ()
+         | head_metric :: _ ->
+           Printf.bprintf buf "# HELP %s %s\n" name (choose_help name ms);
+           (match head_metric.metric_type with
+            | Histogram ->
+              Printf.bprintf buf "# TYPE %s summary\n" name;
+              List.iter
+                (fun (metric : metric) ->
+                   let labels = labels_to_string metric.labels in
+                   Printf.bprintf buf "%s_sum%s %g\n" name labels metric.value;
+                   let count_key = metric_key (name ^ "_count") metric.labels in
+                   let count_value =
+                     Hashtbl.find_opt values_by_key count_key |> Option.value ~default:0.0
+                   in
+                   Printf.bprintf buf "%s_count%s %g\n" name labels count_value)
+                ms
+            | _ ->
+              Printf.bprintf buf "# TYPE %s %s\n" name (type_to_string head_metric.metric_type);
+              List.iter
+                (fun (metric : metric) ->
+                   Printf.bprintf
+                     buf
+                     "%s%s %g\n"
+                     metric.name
+                     (labels_to_string metric.labels)
+                     metric.value)
+                ms)))
+    by_name;
+  Buffer.contents buf
+;;

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -237,10 +237,6 @@ let openrouter_api_url () =
   env_url_or ~env:"OPENROUTER_API_URL" ~default:(registry_default_base_url "openrouter")
 ;;
 
-let gemini_generative_api_url () =
-  env_url_or ~env:"GEMINI_API_URL" ~default:(registry_default_base_url "gemini")
-;;
-
 let glm_api_url () =
   env_url_or ~env:"ZAI_BASE_URL" ~default:Llm_provider.Zai_catalog.general_base_url
 ;;
@@ -780,14 +776,6 @@ let resolve_auto_models ?getenv (policy : model_policy) =
 let default_model_id_for_cascade_prefix ?getenv provider_name =
   match resolve_adapter_by_cascade_prefix provider_name with
   | Some adapter -> resolve_model_policy_default ?getenv adapter.model_policy
-  | None -> None
-;;
-
-let auto_models_for_provider ?getenv provider_name =
-  match find_direct_adapter_by_alias provider_name with
-  | Some adapter when adapter.model_policy.expand_auto ->
-    resolve_auto_models ?getenv adapter.model_policy
-  | Some _ -> None
   | None -> None
 ;;
 
@@ -1485,20 +1473,6 @@ let oas_capabilities_of_config (cfg : Llm_provider.Provider_config.t) =
   | Codex_cli -> Llm_provider.Capabilities.codex_cli_capabilities
 ;;
 
-(* ── Generic provider auth detail ─────────────────────────────── *)
-
-(** Provider-agnostic auth detail for dashboard display.
-    Encapsulates vendor-specific auth logic (e.g. Gemini Vertex/API key)
-    so consumers do not branch on vendor names. *)
-type auth_detail =
-  { auth_kind : string
-  ; status : string
-  ; available : bool
-  ; supports_run : bool
-  ; endpoint_url : string option
-  ; note : string option
-  }
-
 (** Cascade config prefix from adapter record. No match needed. *)
 let cascade_prefix_of_adapter (adapter : adapter) = adapter.cascade_prefix
 
@@ -1540,76 +1514,6 @@ let provider_kind_of_declarative_protocol raw =
 let cascade_prefix_of_declarative_protocol raw =
   provider_kind_of_declarative_protocol raw
   |> Option.map cascade_prefix_of_provider_kind
-;;
-
-(** Resolve auth detail for any provider by canonical name or alias.
-    Gemini-specific Vertex ADC vs API Key logic is internal. *)
-let auth_detail_of_provider provider =
-  match resolve_direct_adapter provider with
-  | None ->
-    { auth_kind = "unknown"
-    ; status = "unsupported"
-    ; available = false
-    ; supports_run = false
-    ; endpoint_url = None
-    ; note = Some "Unsupported provider"
-    }
-  | Some adapter ->
-    let auth_kind_base =
-      if adapter.canonical_name = cn_kimi_api
-      then "api_key:KIMI_API_KEY"
-      else string_of_auth_mode adapter.auth_mode
-    in
-    if adapter.canonical_name = cn_gemini_api
-    then (
-      match resolve_gemini_direct_auth () with
-      | Gemini_api_key ->
-        { auth_kind = "api_key:GEMINI_API_KEY"
-        ; status = "configured"
-        ; available = true
-        ; supports_run = true
-        ; endpoint_url = Some (gemini_generative_api_url ())
-        ; note = None
-        }
-      | Gemini_vertex_adc { project; location } ->
-        { auth_kind = Printf.sprintf "vertex_adc:%s:%s" project location
-        ; status = "vertex_adc"
-        ; available = true
-        ; supports_run = false
-        ; endpoint_url = Some (gemini_vertex_openai_base_url ~project ~location)
-        ; note =
-            Some
-              "Dashboard run MVP only supports Gemini via GEMINI_API_KEY. Vertex ADC \
-               inventory is visible but run is disabled."
-        }
-      | Gemini_auth_missing message ->
-        { auth_kind = auth_kind_base
-        ; status = "missing_auth"
-        ; available = false
-        ; supports_run = false
-        ; endpoint_url = None
-        ; note = Some message
-        })
-    else if adapter.runtime_kind = Cli_agent
-    then (
-      let available = provider_auth_available provider in
-      { auth_kind = auth_kind_base
-      ; status = (if available then "configured" else "missing_auth")
-      ; available
-      ; supports_run = available
-      ; endpoint_url = None
-      ; note =
-          Some "Cached CLI login is assumed; final validation happens at execution time."
-      })
-    else (
-      let available = provider_auth_available provider in
-      { auth_kind = auth_kind_base
-      ; status = (if available then "configured" else "missing_auth")
-      ; available
-      ; supports_run = available
-      ; endpoint_url = endpoint_url_of_adapter adapter
-      ; note = None
-      })
 ;;
 
 let auth_env_keys_of_provider_kind (kind : Llm_provider.Provider_config.provider_kind)

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -141,15 +141,6 @@ type gemini_direct_auth =
   | Gemini_api_key
   | Gemini_auth_missing of string
 
-type auth_detail =
-  { auth_kind : string
-  ; status : string
-  ; available : bool
-  ; supports_run : bool
-  ; endpoint_url : string option
-  ; note : string option
-  }
-
 (** {1 Canonical Provider Names} *)
 
 val cn_llama : string
@@ -237,12 +228,6 @@ val default_model_id_for_cascade_prefix
   :  ?getenv:(string -> string option)
   -> string
   -> string option
-
-(** Resolve declared auto-model expansion for a provider canonical name/alias. *)
-val auto_models_for_provider
-  :  ?getenv:(string -> string option)
-  -> string
-  -> string list option
 
 (** Resolve declared auto-model expansion for a cascade prefix. *)
 val auto_models_for_cascade_prefix
@@ -344,9 +329,6 @@ val provider_auth_available : string -> bool
 
 (** Derive auth_kind string for a provider canonical name. *)
 val auth_kind_for_canonical_name : string -> string
-
-(** Provider-agnostic auth detail for dashboard display. *)
-val auth_detail_of_provider : string -> auth_detail
 
 (** Cascade prefix from adapter record. *)
 val cascade_prefix_of_adapter : adapter -> string

--- a/lib/provider_runtime_overlay.ml
+++ b/lib/provider_runtime_overlay.ml
@@ -46,6 +46,25 @@ let find_unique_by_kind kind =
 let endpoint_url (binding : binding) = trim_nonempty binding.Binding.base_url
 let default_model_id (binding : binding) = Option.bind binding.Binding.default_model trim_nonempty
 
+let supported_models (binding : binding) =
+  match binding.Binding.capabilities.supported_models with
+  | Some models -> models |> List.filter_map trim_nonempty |> Json_util.dedupe_keep_order
+  | None -> []
+;;
+
+let available (binding : binding) = binding.Binding.available
+
+let auth_kind (binding : binding) =
+  match binding.Binding.auth with
+  | Binding.No_auth -> "none"
+  | Binding.Api_key_env env -> "api_key:" ^ env
+  | Binding.Cli_cached_login -> "cli_cached_login"
+  | Binding.Oauth_cached_login -> "oauth_cached_login"
+  | Binding.Setup_token_env env -> "setup_token:" ^ env
+  | Binding.File path -> "file:" ^ path
+  | Binding.Exec command -> "exec:" ^ command
+;;
+
 let auth_env_keys (binding : binding) =
   let auth_env =
     match binding.Binding.auth with
@@ -126,6 +145,7 @@ let usage_missing_by_design (binding : binding) =
   not binding.Binding.capabilities.emits_usage_tokens
 ;;
 
+let resolve_model ?requested_model binding = Binding.resolve_model binding ~requested_model
 let provider_config ?model binding = Binding.to_provider_config ?model binding
 
 type timeout_bounds =

--- a/lib/provider_runtime_overlay.mli
+++ b/lib/provider_runtime_overlay.mli
@@ -14,12 +14,16 @@ val find_by_candidates : string list -> binding option
 val find_unique_by_kind : Llm_provider.Provider_config.provider_kind -> binding option
 val endpoint_url : binding -> string option
 val default_model_id : binding -> string option
+val supported_models : binding -> string list
+val available : binding -> bool
+val auth_kind : binding -> string
 val primary_api_key_env : binding -> string option
 val auth_env_keys : binding -> string list
 val runtime_kind : binding -> [ `Local | `Cli_agent | `Direct_api ]
 val supports_runtime_mcp_http_headers : binding -> bool
 val uses_prompt_caching : binding -> bool
 val usage_missing_by_design : binding -> bool
+val resolve_model : ?requested_model:string -> binding -> string
 val provider_config : ?model:string -> binding -> Llm_provider.Provider_config.t
 
 (** Per-provider per-attempt timeout bounds projected from OAS

--- a/scripts/lint/no-roadmap-stale-hardcoding.allowlist
+++ b/scripts/lint/no-roadmap-stale-hardcoding.allowlist
@@ -16,12 +16,10 @@
 lib/keeper/keeper_hooks_oas.mli:22
 
 # lib/provider_adapter.ml model list — gap #6, queued for Sprint 2/3
-lib/provider_adapter.ml:365
-lib/provider_adapter.ml:366
-lib/provider_adapter.ml:367
-lib/provider_adapter.ml:368
-lib/provider_adapter.ml:369
-lib/provider_adapter.ml:370
-lib/provider_adapter.ml:402
-lib/provider_adapter.ml:403
-lib/provider_adapter.ml:405
+lib/provider_adapter.ml:382
+lib/provider_adapter.ml:383
+lib/provider_adapter.ml:384
+lib/provider_adapter.ml:385
+lib/provider_adapter.ml:386
+lib/provider_adapter.ml:387
+lib/provider_adapter.ml:407

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -93,16 +93,22 @@ let test_resolve_canonical_wraps_adapter () =
 let test_dashboard_provider_snapshots_include_cli_and_api () =
   Eio_main.run (fun _env ->
     let open Masc_mcp.Dashboard_provider_runs in
-    let claude_cli = provider_snapshot_by_name "claude" in
-    let claude_api = provider_snapshot_by_name "claude-api" in
-    let gemini_cli = provider_snapshot_by_name "gemini" in
-    let glm_api = provider_snapshot_by_name "glm-api" in
-    let glm_coding_plan = provider_snapshot_by_name "glm-coding-plan" in
+    let claude_cli = provider_snapshot_by_name "claude_code" in
+    let claude_api = provider_snapshot_by_name "claude" in
+    let gemini_cli = provider_snapshot_by_name "gemini_cli" in
+    let glm_api = provider_snapshot_by_name "glm" in
+    let glm_coding_plan = provider_snapshot_by_name "glm-coding" in
+    let legacy_claude_api = provider_snapshot_by_name "claude-api" in
+    let legacy_glm_api = provider_snapshot_by_name "glm-api" in
     check bool "cli snapshot present" true (Option.is_some claude_cli);
     check bool "api snapshot present" true (Option.is_some claude_api);
     check bool "gemini cli snapshot present" true (Option.is_some gemini_cli);
     check bool "glm api snapshot present" true (Option.is_some glm_api);
     check bool "glm coding snapshot present" true (Option.is_some glm_coding_plan);
+    check bool "legacy claude-api snapshot removed" false
+      (Option.is_some legacy_claude_api);
+    check bool "legacy glm-api snapshot removed" false
+      (Option.is_some legacy_glm_api);
     check string "cli runtime kind" "cli_agent"
       (Option.get claude_cli).runtime_kind;
     check string "api runtime kind" "direct_api"
@@ -111,10 +117,10 @@ let test_dashboard_provider_snapshots_include_cli_and_api () =
       (Option.get glm_api).runtime_kind;
     check string "glm coding runtime kind" "direct_api"
       (Option.get glm_coding_plan).runtime_kind;
-    check bool "gemini cli expands concrete models" true
-      ((Option.get gemini_cli).models <> []);
-    check bool "gemini cli does not expose bare auto" false
-      (List.mem "auto" (Option.get gemini_cli).models))
+    check string "cli source" "oas/provider-runtime-binding"
+      (Option.get claude_cli).source;
+    check string "api source" "oas/provider-runtime-binding"
+      (Option.get claude_api).source)
 
 let test_default_registry_populated () =
   (* Verify default_registry is usable by resolving a known provider.


### PR DESCRIPTION
## Summary

- Route dashboard provider inventory and single-agent run validation through OAS `Provider_runtime_binding` projection.
- Remove the dashboard-only `Provider_adapter` exports: `auth_detail`, `auth_detail_of_provider`, and `auto_models_for_provider`.
- Keep llama runtime discovery as live local runtime observability, but stop rebuilding provider/model catalogs in the dashboard layer.
- Split Prometheus text rendering into a private helper to satisfy the current Godfile size cap without raising the cap.
- Update the hardcoded-prefix gate drift so this PR does not carry stale line-number debt forward.

## Validation

- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_prometheus_coverage.exe test/test_observability_provider_contracts.exe test/test_provider_adapter.exe`
- `./_build/default/test/test_prometheus_coverage.exe` - 62 tests
- `./_build/default/test/test_observability_provider_contracts.exe` - 25 tests
- `./_build/default/test/test_provider_adapter.exe` - 44 tests
- `ocamlformat --check lib/prometheus.ml lib/prometheus_text.ml lib/dune`
- `bash scripts/lint/godfile-size-regression.sh`
- `bash scripts/lint/provider-adapter-removal-ratchet.sh` - callers 41/44, mli exports 92/120
- `bash scripts/lint/no-roadmap-stale-hardcoding.sh`
- `git diff --check`

## Note

`test/test_ci_hardening_source.exe` was attempted locally but is not listed as validation: it currently fails source-guard assertions unrelated to this provider binding slice.
