### PR TITLE
fix(dashboard): keep board read models out of post fallback

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -40,6 +40,7 @@ module Types = Masc_domain
 module Tempo = Masc_mcp.Tempo
 module Auth = Masc_mcp.Auth
 module Board = Masc_mcp.Board
+module Board_curation = Masc_mcp.Board_curation
 module Board_dispatch = Masc_mcp.Board_dispatch
 module Task_dispatch = Masc_mcp.Task_dispatch
 module Http_negotiation = Mcp_transport_protocol.Http_negotiation
@@ -314,6 +315,50 @@ let dispatch_route ~routes ~request ~path reqd =
           `Assoc [("name", `String name); ("count", `Int count)]
         ) hearths));
       ] in
+      Http.Response.json (Yojson.Safe.to_string json) reqd
+  | `GET, "/api/v1/board/curation" ->
+      let json =
+        match Board_dispatch.latest_curation_snapshot () with
+        | None -> `Assoc [ ("snapshot", `Null) ]
+        | Some snap ->
+            `Assoc [ ("snapshot", Board_curation.snapshot_to_yojson snap) ]
+      in
+      Http.Response.json (Yojson.Safe.to_string json) reqd
+  | `GET, "/api/v1/board/sub-boards" ->
+      let sub_boards = Board_dispatch.list_sub_boards () in
+      let json =
+        `Assoc
+          [
+            ( "sub_boards",
+              `List (List.map Board.sub_board_to_yojson sub_boards) );
+          ]
+      in
+      Http.Response.json (Yojson.Safe.to_string json) reqd
+  | `GET, "/api/v1/board/karma/ledger" ->
+      let agent = query_param request "agent" in
+      let limit =
+        int_query_param request "limit" ~default:500 |> clamp ~min_v:1 ~max_v:5000
+      in
+      let events = Board_dispatch.get_karma_ledger ?agent ~limit () in
+      let totals =
+        Board_dispatch.get_all_karma ()
+        |> List.sort (fun (_, a) (_, b) -> compare b a)
+      in
+      let json =
+        `Assoc
+          [
+            ("events", `List (List.map Board.karma_event_to_yojson events));
+            ("count", `Int (List.length events));
+            ("scoring_rule", `String "up=+1,down=0");
+            ( "totals",
+              `List
+                (List.map
+                   (fun (agent_name, k) ->
+                     `Assoc
+                       [ ("agent", `String agent_name); ("karma", `Int k) ])
+                   totals) );
+          ]
+      in
       Http.Response.json (Yojson.Safe.to_string json) reqd
   | `POST, "/api/v1/board/reactions" ->
       Http.Request.read_body_async reqd (fun body ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -53,35 +53,14 @@ type metric =
 
 (** {1 Global Metrics Store}
 
-    [metrics] is updated from any fiber on any domain — LLM telemetry,
-    keeper heartbeats, SSE bookkeeping, HTTP handlers. The previous
-    implementation used a bare [Hashtbl.t] with [find_opt] + [add] which
-    has two race windows:
-
-    1. TOCTOU on registration: two fibers call [inc_counter] on a new
-       key, both see [None], both [Hashtbl.add] — duplicate entries in
-       the table.
-    2. Non-atomic float update: [m.value <- m.value +. delta] reads,
-       adds, writes without a memory barrier; two concurrent increments
-       can both observe the same old value.
-
-    We serialise every read and write path through [Stdlib.Mutex].
-    Choice of primitive: operations must work during module
-    initialisation ([let () = init ()] at EOF runs before any Eio
-    scheduler exists), must hold across OCaml 5 domains (Executor_pool
-    workers), and are individually cheap (a Hashtbl op + a float add) so
-   the lock is never held long. [Stdlib.Mutex] fits all three. *)
+    Metrics are shared by fibers/domains, so reads and writes are serialized
+    through [Stdlib.Mutex]. It is available during module initialization and
+    protects both registration and float updates. *)
 let metrics : (string, metric) Hashtbl.t = Hashtbl.create 64
 let metrics_mutex = Stdlib.Mutex.create ()
 
-(* #10682 diagnostic: when EDEADLK fires (PTHREAD_MUTEX_ERRORCHECK
-   detects same-thread re-entry on OCaml 5), lock raises Sys_error with
-   message "Mutex.lock: Resource deadlock avoided". Without a backtrace,
-   the actual re-entrant call site is invisible because [with_lock] is
-   used by ~12 sites in this module and is reachable from every read
-   tool dispatch. We capture the raw backtrace at the point of failure
-   and stash it on a side-channel for the next render so the offending
-   site self-documents. The non-failing path is unchanged. *)
+(* #10682: capture the caller stack for rare EDEADLK re-entry failures so the
+   next diagnostic render can name the offending metric path. *)
 let last_deadlock_backtrace : string option Atomic.t = Atomic.make None
 
 let with_lock f =
@@ -96,8 +75,7 @@ let with_lock f =
   Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock metrics_mutex) f
 ;;
 
-(** Read-only accessor for the most recent EDEADLK backtrace captured
-    by [with_lock]. Used by diagnostic dumps and tests. *)
+(** Read-only EDEADLK diagnostic accessor. *)
 let last_deadlock_backtrace_for_test () = Atomic.get last_deadlock_backtrace
 
 (** {1 Metric Registration} *)
@@ -2743,17 +2721,8 @@ let init () =
       "acquire_flock_retry* wall-clock excluding openfile. Labels: caller, outcome \
        (acquired|timeout)."
     ();
-  (* The keeper turn / cascade / persistence-failure metrics
-     (turn_livelock_blocks .. session_cleanup_failures, plus
-     chat_store_failures and observation_query_failures) are registered
-     earlier in init() — see line ~1171 for turn_livelock_blocks and
-     lines ~1579-1628 for the rest, with detailed help text. Because
-     `add` is no-op when the name already exists, every help string
-     in this duplicate block was silently dropped, while still making
-     the file look like every metric had two declaration sites with
-     conflicting documentation. The original block is removed so
-     edits to help/labels land on the canonical site instead of a
-     dead one. *)
+  (* Duplicate keeper turn / cascade / persistence-failure registrations were
+     removed; the authoritative help text lives at the earlier init() sites. *)
   add
     Keeper_metrics.metric_keeper_stale_termination_total
     "Total stale watchdog terminations (all classes). Labels: keeper."
@@ -2817,20 +2786,13 @@ let init () =
     metric_pricing_catalog_miss
     "Pricing catalog lookups that missed. Labels: model."
     Counter;
-  (* metric_cost_emit_zero_source registered in keeper_hooks_oas.ml with the
-     authoritative help text and `source` label description. Re-registering
-     here would be silently ignored (add is no-op when name exists) and risks
-     diverging help text across edits. *)
+  (* metric_cost_emit_zero_source is registered in keeper_hooks_oas.ml. *)
   add
     metric_cost_ledger_status
     "Cost ledger status transitions per provider/status/reason combination. Labels: \
      provider, status, reason."
     Counter;
-  (* metric_keeper_turn_gate_rejected_terminal registered in keeper_guards.ml
-     with help text and labels keeper, tool, reason, decision.
-     Keeper_metrics.metric_keeper_receipt_unmapped_disposition registered in
-     keeper_execution_receipt.ml without labels (intentional). Avoid
-     re-registering here so the authoritative help/labels stay single-sourced. *)
+  (* Related keeper guard/receipt metrics are registered in their owning modules. *)
   add
     Keeper_metrics.metric_keeper_bash_network_upgrade
     "Bash shell network upgrade events. Labels: keeper, detected_tool."
@@ -2868,10 +2830,7 @@ let init () =
     "Post-turn wire-in failures (autonomous, tool_emission_drain, multimodal, \
      resilience). Labels: keeper, phase."
     Counter;
-  (* metric_keeper_meta_read_failures registered earlier in init() with
-     "labeled by keeper and site" — `add` is no-op when the name exists,
-     so re-registering with a divergent help/label description here was
-     silently dropped. Single registration kept. *)
+  (* metric_keeper_meta_read_failures is registered earlier in init(). *)
   add
     Keeper_metrics.metric_keeper_recurring_failures
     "Recurring task execution/dispatch failures. Labels: task, phase."
@@ -3011,9 +2970,7 @@ let init () =
        singleton."
     ~labels:[ "keeper_name", "__dashboard__" ]
     ();
-  (* PR-0.2.A: generic cache hit/miss counters.  Labels: cache=eio|dashboard.
-     [eio] tracks Cache_eio.get; [dashboard] tracks Dashboard_cache.get_or_compute.
-     Per-label series are auto-created on first inc_counter call. *)
+  (* Generic cache hit/miss counters. Per-label series are created on first use. *)
   add
     metric_cache_hits_total
     "Cache lookup hits. Labels: cache=eio|dashboard. hit_ratio = hits / (hits + misses) \
@@ -3084,9 +3041,7 @@ let init () =
      of grpc_events_delivered; the difference between scanned-lines and replayed-events \
      isolates wasted scan cost."
     Counter;
-  (* RFC-0022 §9 attempt-liveness gate metrics.
-     These constants are referenced by cascade_attempt_liveness_observer.ml
-     but were not registered in init(), causing silent metric loss. *)
+  (* RFC-0022 §9 attempt-liveness gate metrics. *)
   add
     metric_cascade_attempt_liveness_kill
     "Counts would-be (Observe) and actual (Enforce) liveness kills broken down by \

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -102,6 +102,51 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
       h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors;
       true
 
+  | `GET, "/api/v1/board/sub-boards" ->
+      let sub_boards = Board_dispatch.list_sub_boards () in
+      let json =
+        `Assoc
+          [
+            ( "sub_boards",
+              `List (List.map Board.sub_board_to_yojson sub_boards) );
+          ]
+      in
+      h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors;
+      true
+
+  | `GET, "/api/v1/board/karma/ledger" ->
+      (* Karma ledger contract endpoint — attributed karma events.
+         Query params:
+           agent  — filter to a single recipient (case-sensitive)
+           limit  — cap result count (default: 500) *)
+      let agent = query_param httpun_request "agent" in
+      let limit =
+        int_query_param httpun_request "limit" ~default:500
+        |> clamp ~min_v:1 ~max_v:5000
+      in
+      let events = Board_dispatch.get_karma_ledger ?agent ~limit () in
+      let totals =
+        Board_dispatch.get_all_karma ()
+        |> List.sort (fun (_, a) (_, b) -> compare b a)
+      in
+      let json =
+        `Assoc
+          [
+            ("events", `List (List.map Board.karma_event_to_yojson events));
+            ("count", `Int (List.length events));
+            ("scoring_rule", `String "up=+1,down=0");
+            ( "totals",
+              `List
+                (List.map
+                   (fun (agent_name, k) ->
+                     `Assoc
+                       [ ("agent", `String agent_name); ("karma", `Int k) ])
+                   totals) );
+          ]
+      in
+      h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors;
+      true
+
   | `GET, p
     when String.starts_with ~prefix:"/api/v1/board/" p
          && String.length p > 14 ->
@@ -127,33 +172,6 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
           `Assoc [("agent", `String agent); ("karma", `Int k)]
         ) sorted));
       ] in
-      h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors;
-      true
-
-  | `GET, "/api/v1/board/karma/ledger" ->
-      (* Karma ledger contract endpoint — attributed karma events.
-         Query params:
-           agent  — filter to a single recipient (case-sensitive)
-           limit  — cap result count (default: 500) *)
-      let agent = query_param httpun_request "agent" in
-      let limit =
-        int_query_param httpun_request "limit" ~default:500
-        |> clamp ~min_v:1 ~max_v:5000
-      in
-      let events = Board_dispatch.get_karma_ledger ?agent ~limit () in
-      let totals = Board_dispatch.get_all_karma () |> List.sort (fun (_, a) (_, b) -> compare b a) in
-      let json =
-        `Assoc [
-          ("events",
-           `List (List.map Board.karma_event_to_yojson events));
-          ("count", `Int (List.length events));
-          ("scoring_rule", `String "up=+1,down=0");
-          ("totals",
-           `List (List.map (fun (agent_name, k) ->
-               `Assoc [("agent", `String agent_name); ("karma", `Int k)])
-             totals));
-        ]
-      in
       h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors;
       true
 

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -111,6 +111,43 @@ let respond_high_risk_param_blocked request reqd ~param_key ~risk =
                    param_key risk) );
           ]))
 
+let board_curation_json () =
+  match Board_dispatch.latest_curation_snapshot () with
+  | None -> `Assoc [ ("snapshot", `Null) ]
+  | Some snap -> `Assoc [ ("snapshot", Board_curation.snapshot_to_yojson snap) ]
+
+let board_sub_boards_json () =
+  let sub_boards = Board_dispatch.list_sub_boards () in
+  `Assoc
+    [
+      ( "sub_boards",
+        `List (List.map Board.sub_board_to_yojson sub_boards) );
+    ]
+
+let board_karma_ledger_json req =
+  let agent = query_param req "agent" in
+  let limit = int_query_param req "limit" ~default:500 |> clamp ~min_v:1 ~max_v:5000 in
+  let events = Board_dispatch.get_karma_ledger ?agent ~limit () in
+  let totals =
+    Board_dispatch.get_all_karma ()
+    |> List.sort (fun (_, a) (_, b) -> compare b a)
+  in
+  `Assoc
+    [
+      ("events", `List (List.map Board.karma_event_to_yojson events));
+      ("count", `Int (List.length events));
+      ("scoring_rule", `String "up=+1,down=0");
+      ( "totals",
+        `List
+          (List.map
+             (fun (agent_name, k) ->
+               `Assoc [ ("agent", `String agent_name); ("karma", `Int k) ])
+             totals) );
+    ]
+
+let respond_board_json reqd json =
+  Http.Response.json (Yojson.Safe.to_string json) reqd
+
 let add_routes ~sw ~clock router =
   router
   |> Http.Router.get "/api/v1/activity/events" (fun request reqd ->
@@ -293,13 +330,7 @@ let add_routes ~sw ~clock router =
 
   |> Http.Router.get "/api/v1/board/curation" (fun request reqd ->
        with_public_read (fun _state _req reqd ->
-         let json =
-           match Board_dispatch.latest_curation_snapshot () with
-           | None -> `Assoc [ ("snapshot", `Null) ]
-           | Some snap ->
-             `Assoc [ ("snapshot", Board_curation.snapshot_to_yojson snap) ]
-         in
-         Http.Response.json (Yojson.Safe.to_string json) reqd
+         respond_board_json reqd (board_curation_json ())
        ) request reqd)
 
   |> Http.Router.get "/api/v1/board/flairs" (fun _request reqd ->
@@ -308,11 +339,7 @@ let add_routes ~sw ~clock router =
        Http.Response.json (Yojson.Safe.to_string json) reqd)
 
   |> Http.Router.get "/api/v1/board/sub-boards" (fun _request reqd ->
-       let sub_boards = Board_dispatch.list_sub_boards () in
-       let json = `Assoc [
-         ("sub_boards", `List (List.map Board.sub_board_to_yojson sub_boards));
-       ] in
-       Http.Response.json (Yojson.Safe.to_string json) reqd)
+       respond_board_json reqd (board_sub_boards_json ()))
 
   |> Http.Router.post "/api/v1/board/sub-boards" (fun request reqd ->
        with_tool_auth ~tool_name:"board_sub_board_create"
@@ -447,6 +474,12 @@ let add_routes ~sw ~clock router =
               Http.Response.json
                 (Yojson.Safe.to_string (`Assoc [("error", `String "post_id is required")]))
                 ~status:`Bad_request reqd
+          | Some "curation" ->
+              respond_board_json reqd (board_curation_json ())
+          | Some "sub-boards" ->
+              respond_board_json reqd (board_sub_boards_json ())
+          | Some "karma/ledger" ->
+              respond_board_json reqd (board_karma_ledger_json req)
           | Some post_id ->
               let format =
                 query_param req "format" |> Option.value ~default:"nested"
@@ -606,27 +639,7 @@ let add_routes ~sw ~clock router =
 
   |> Http.Router.get "/api/v1/board/karma/ledger" (fun request reqd ->
        with_public_read (fun _state req reqd ->
-         let agent = query_param req "agent" in
-         let limit =
-           int_query_param req "limit" ~default:500
-           |> clamp ~min_v:1 ~max_v:5000
-         in
-         let events = Board_dispatch.get_karma_ledger ?agent ~limit () in
-         let totals =
-           Board_dispatch.get_all_karma ()
-           |> List.sort (fun (_, a) (_, b) -> compare b a)
-         in
-         let json =
-           `Assoc [
-             ("events", `List (List.map Board.karma_event_to_yojson events));
-             ("count", `Int (List.length events));
-             ("scoring_rule", `String "up=+1,down=0");
-             ("totals", `List (List.map (fun (agent_name, k) ->
-               `Assoc [("agent", `String agent_name); ("karma", `Int k)])
-               totals));
-           ]
-         in
-         Http.Response.json (Yojson.Safe.to_string json) reqd
+         respond_board_json reqd (board_karma_ledger_json req)
        ) request reqd)
 
   (* Mention Inbox API *)

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -941,6 +941,40 @@ let require_status label expected result =
          result.body)
 ;;
 
+let json_has_field field body =
+  match Yojson.Safe.from_string body with
+  | `Assoc fields -> List.mem_assoc field fields
+  | _ -> false
+;;
+
+let require_board_read_model label field result =
+  require_status (label ^ " returns 200") 200 result;
+  check
+    bool
+    (label ^ " does not fall through to board post lookup")
+    false
+    (contains_substr "Post_not_found" result.body
+     || contains_substr "Invalid post_id" result.body);
+  check bool (label ^ " exposes " ^ field) true (json_has_field field result.body)
+;;
+
+let test_board_read_model_routes_do_not_fall_through_to_post_lookup () =
+  with_seeded_server
+  @@ fun ~port ~config:_ ~admin_token:_ ~keeper_name:_ ->
+  require_board_read_model
+    "board curation"
+    "snapshot"
+    (run_curl_get ~port ~path:"/api/v1/board/curation" ());
+  require_board_read_model
+    "sub-boards"
+    "sub_boards"
+    (run_curl_get ~port ~path:"/api/v1/board/sub-boards" ());
+  require_board_read_model
+    "karma ledger"
+    "events"
+    (run_curl_get ~port ~path:"/api/v1/board/karma/ledger?limit=1" ())
+;;
+
 let test_keeper_lifecycle_routes_do_not_fall_through_to_generic_404 () =
   with_seeded_server
   @@ fun ~port ~config ~admin_token ~keeper_name ->
@@ -1904,6 +1938,10 @@ let () =
             "lifecycle POST routes do not fall through to generic 404"
             `Slow
             test_keeper_lifecycle_routes_do_not_fall_through_to_generic_404
+        ; test_case
+            "board read models do not fall through to post lookup"
+            `Slow
+            test_board_read_model_routes_do_not_fall_through_to_post_lookup
         ; test_case
             "directive resume updates paused meta"
             `Slow


### PR DESCRIPTION
## Summary

- Fix board read-model routes that were being swallowed by the direct `/api/v1/board/<post_id>` fallback in `main_eio`.
- Keep HTTP/1.1 router and HTTP/2 gateway behavior aligned for board curation, sub-boards, and karma ledger read models.
- Add a server-backed regression test that proves these read models return their expected JSON fields instead of `Post_not_found` / `Invalid post_id`.

## Review Focus

- `bin/main_eio.ml` dispatch order: reserved board read-model routes must be handled before the generic board post detail fallback.
- `server_h2_gateway_routes_extra.ml` keeps the same ordering for H2 traffic.
- `server_routes_http_routes_activity.ml` now has shared JSON helpers and a defensive prefix fallback guard for the same reserved paths.

## Validation

- `ocamlformat --check bin/main_eio.ml lib/server/server_h2_gateway_routes_extra.ml lib/server/server_routes_http_routes_activity.ml test/test_dashboard_keeper_routes.ml`
- `git diff --check`
- `scripts/dune-local.sh build bin/main_eio.exe test/test_dashboard_keeper_routes.exe`
- `MASC_MAIN_EIO_EXE=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-board-readmodel-route-gaps-20260514/_build/default/bin/main_eio.exe ./_build/default/test/test_dashboard_keeper_routes.exe test --color=never 'dashboard_keeper_routes' 2`

## Evidence

- Before the patch, live `scripts/verify-dashboard.sh http://127.0.0.1:8935` reached `92/99` with failures on:
  - `GET /api/v1/board/curation`
  - `GET /api/v1/board/karma/ledger`
  - `GET /api/v1/board/sub-boards`
  - `GET /api/v1/dashboard/planning` JSON shape check after the route failures
- Direct live curls showed the read-model paths falling into board post lookup, e.g. `{"error":"(Board_types.Post_not_found \"curation\")"}`.
- A full verifier run against a second patched server on the same base path is blocked by the runtime ownership guard, as expected, while the current live server owns `/Users/dancer/me`.
