### PR TITLE
refactor(metrics): split OAS hotpath prometheus helpers

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -1041,8 +1041,8 @@ let make_tool_bundle
           Option.iter Keeper_sandbox_factory.cleanup turn_sandbox_factory_git)
     }
   in
-  Prometheus.observe_hotpath
-    ~metric:Prometheus.metric_masc_oas_make_tool_bundle_sec
+  Prometheus_hotpath.observe
+    ~metric:Prometheus_hotpath.metric_oas_make_tool_bundle_sec
     ~start:__t0;
   bundle
 ;;

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -209,38 +209,6 @@ let observe_histogram name ?(labels = []) value =
         })
 ;;
 
-(* Phase B baseline opt-out — read once at module load.  Lets operators
-   diff a run with the histogram observation enabled vs disabled to
-   quantify the histogram's own overhead before drawing conclusions
-   about the hot path. *)
-let hotpath_hist_disabled =
-  Lazy.from_fun (fun () ->
-    match Sys.getenv_opt "MASC_DISABLE_HOTPATH_HIST" with
-    | Some ("1" | "true" | "yes" | "on" | "TRUE" | "YES" | "ON") -> true
-    | _ -> false)
-;;
-
-(* Convenience wrapper for the OAS dispatch baseline: takes the
-   pre-call [Mtime] timestamp and records the elapsed seconds against
-   [metric].  No-op when [MASC_DISABLE_HOTPATH_HIST] is set.  Catches
-   internal exceptions so a metric-emit failure never bubbles into the
-   hot path it is observing. *)
-let observe_hotpath ~metric ~start =
-  if Lazy.force hotpath_hist_disabled
-  then ()
-  else
-    try
-      let elapsed = Mtime.span start (Mtime_clock.now ()) in
-      let ns = Mtime.Span.to_uint64_ns elapsed in
-      let sec = Int64.to_float ns /. 1.0e9 in
-      observe_histogram metric sec
-    with
-    (* Cancellation must propagate (CLAUDE.md feedback —
-       Eio.Cancel.Cancelled 삼킴 버그 사례 회피). *)
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | _ -> ()
-;;
-
 (** {1 Metric Name Constants}
 
     Exported so registration here and [inc_counter] / [set_gauge]
@@ -634,15 +602,6 @@ let metric_oas_context_overflow_ratio = "masc_oas_context_overflow_ratio"
 (* OAS-level context compaction counter — incremented each time
    ContextCompactStarted fires from the event bus. *)
 let metric_oas_context_compaction_total = "masc_oas_context_compaction_total"
-
-(* OAS tool dispatch hot-path latency histograms — Phase B baseline of
-   ~/me/planning/claude-plans/wise-nibbling-lerdorf.md. Wraps the two
-   hot paths called per keeper turn so operators can measure the
-   dispatch share of turn budget before deciding whether memoization is
-   worth the surface-area cost. Observation is gated by
-   [MASC_DISABLE_HOTPATH_HIST=1] for histogram-overhead measurement. *)
-let metric_masc_oas_params_of_schema_sec = "masc_oas_params_of_schema_sec"
-let metric_masc_oas_make_tool_bundle_sec = "masc_oas_make_tool_bundle_sec"
 
 (* MCP tool schema budget (set once at boot from mcp_server_eio.ml
    via [set_tool_schema_stats]). *)
@@ -1513,23 +1472,6 @@ let init () =
     ~help:
       "Keeper tool call latency in seconds, labeled by keeper, provider, tool, and \
        outcome"
-    ();
-  (* Phase B baseline (wise-nibbling-lerdorf plan): measure OAS dispatch
-     hot path before deciding whether memoization is justified.  Disable
-     with [MASC_DISABLE_HOTPATH_HIST=1] to quantify the histogram's own
-     overhead. *)
-  register_histogram
-    ~name:metric_masc_oas_params_of_schema_sec
-    ~help:
-      "OAS [params_of_json_schema] elapsed seconds per call.  Fires from \
-       [Tool_bridge.oas_tool_of_masc] per OAS conversion; hot path target of \
-       wise-nibbling-lerdorf Phase B baseline."
-    ();
-  register_histogram
-    ~name:metric_masc_oas_make_tool_bundle_sec
-    ~help:
-      "OAS [make_tool_bundle] elapsed seconds per call.  Fires once per keeper \
-       turn; hot path target of wise-nibbling-lerdorf Phase B baseline."
     ();
   add
     metric_provider_prefix_cache_creation_tokens

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -577,29 +577,6 @@ val metric_oas_context_overflow_ratio : string
     Labels: [agent_name, trigger]. *)
 val metric_oas_context_compaction_total : string
 
-(** Histogram: elapsed seconds per [Tool_bridge.params_of_json_schema]
-    call.  Phase B baseline of
-    [~/me/planning/claude-plans/wise-nibbling-lerdorf.md] — measures the
-    OAS dispatch hot path before deciding whether memoization is justified.
-    Observation gated by [MASC_DISABLE_HOTPATH_HIST]. *)
-val metric_masc_oas_params_of_schema_sec : string
-
-(** Histogram: elapsed seconds per [Keeper_tools_oas.make_tool_bundle]
-    call.  Fires once per keeper turn.  Phase B baseline. *)
-val metric_masc_oas_make_tool_bundle_sec : string
-
-(** Phase B baseline opt-out: read once at module load from
-    [MASC_DISABLE_HOTPATH_HIST] (truthy = "1"/"true"/"yes"/"on", case-
-    insensitive).  Operators set this for control runs to quantify
-    histogram observation overhead vs the underlying hot path. *)
-val hotpath_hist_disabled : bool Lazy.t
-
-(** Observe a hot-path histogram from a pre-call [Mtime] timestamp.
-    No-op when [hotpath_hist_disabled].  Internal exceptions are
-    swallowed so metric-emit failures never bubble into the observed
-    hot path; cancellation is re-raised. *)
-val observe_hotpath : metric:string -> start:Mtime.t -> unit
-
 (** #12797 Total cascade label-ranking skips triggered by recent server-error
     (5xx) score decay for a provider.  Labels: [provider_key]. *)
 val metric_cascade_server_error_skip_total : string

--- a/lib/prometheus_hotpath.ml
+++ b/lib/prometheus_hotpath.ml
@@ -1,0 +1,46 @@
+(** OAS dispatch hot-path metric helpers.
+
+    Kept outside [Prometheus] so the core registry/export module does not
+    grow whenever a narrow hot-path baseline adds instrumentation. *)
+
+let metric_oas_params_of_schema_sec = "masc_oas_params_of_schema_sec"
+let metric_oas_make_tool_bundle_sec = "masc_oas_make_tool_bundle_sec"
+
+let hist_disabled =
+  Lazy.from_fun (fun () ->
+    match Sys.getenv_opt "MASC_DISABLE_HOTPATH_HIST" with
+    | Some ("1" | "true" | "yes" | "on" | "TRUE" | "YES" | "ON") -> true
+    | _ -> false)
+;;
+
+let observe ~metric ~start =
+  if Lazy.force hist_disabled
+  then ()
+  else
+    try
+      let elapsed = Mtime.span start (Mtime_clock.now ()) in
+      let ns = Mtime.Span.to_uint64_ns elapsed in
+      let sec = Int64.to_float ns /. 1.0e9 in
+      Prometheus.observe_histogram metric sec
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | _ -> ()
+;;
+
+let register () =
+  Prometheus.register_histogram
+    ~name:metric_oas_params_of_schema_sec
+    ~help:
+      "OAS [params_of_json_schema] elapsed seconds per call.  Fires from \
+       [Tool_bridge.oas_tool_of_masc] per OAS conversion; hot path target of \
+       wise-nibbling-lerdorf Phase B baseline."
+    ();
+  Prometheus.register_histogram
+    ~name:metric_oas_make_tool_bundle_sec
+    ~help:
+      "OAS [make_tool_bundle] elapsed seconds per call.  Fires once per keeper \
+       turn; hot path target of wise-nibbling-lerdorf Phase B baseline."
+    ()
+;;
+
+let () = register ()

--- a/lib/prometheus_hotpath.mli
+++ b/lib/prometheus_hotpath.mli
@@ -1,0 +1,18 @@
+(** OAS dispatch hot-path metric helpers. *)
+
+(** Histogram: elapsed seconds per [Tool_bridge.params_of_json_schema]
+    call.  Observation gated by [MASC_DISABLE_HOTPATH_HIST]. *)
+val metric_oas_params_of_schema_sec : string
+
+(** Histogram: elapsed seconds per [Keeper_tools_oas.make_tool_bundle]
+    call.  Fires once per keeper turn. *)
+val metric_oas_make_tool_bundle_sec : string
+
+(** Phase B baseline opt-out, read once at module load. *)
+val hist_disabled : bool Lazy.t
+
+(** Observe a hot-path histogram from a pre-call [Mtime] timestamp.
+    Internal exceptions are swallowed; cancellation is re-raised. *)
+val observe : metric:string -> start:Mtime.t -> unit
+
+val register : unit -> unit

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -218,8 +218,8 @@ let params_of_json_schema schema =
           pairs
     | _ -> []
   in
-  Prometheus.observe_hotpath
-    ~metric:Prometheus.metric_masc_oas_params_of_schema_sec
+  Prometheus_hotpath.observe
+    ~metric:Prometheus_hotpath.metric_oas_params_of_schema_sec
     ~start:__t0;
   result
 

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -14,6 +14,7 @@ open Alcotest
 module Backend = Backend
 module Backend_mutex_metrics = Masc_mcp.Backend_mutex_metrics
 module Prometheus = Masc_mcp.Prometheus
+module Prometheus_hotpath = Masc_mcp.Prometheus_hotpath
 
 (* ============================================================
    type_to_string Tests
@@ -582,6 +583,25 @@ let test_goal_attainment_metrics_registered () =
        ("# TYPE " ^ Prometheus.metric_goal_attainment_measured ^ " gauge"))
 ;;
 
+let test_oas_hotpath_metrics_registered () =
+  Prometheus_hotpath.register ();
+  let text = Prometheus.to_prometheus_text () in
+  check
+    bool
+    "has params_of_schema hotpath TYPE"
+    true
+    (text_has_literal
+       text
+       ("# TYPE " ^ Prometheus_hotpath.metric_oas_params_of_schema_sec ^ " summary"));
+  check
+    bool
+    "has make_tool_bundle hotpath TYPE"
+    true
+    (text_has_literal
+       text
+       ("# TYPE " ^ Prometheus_hotpath.metric_oas_make_tool_bundle_sec ^ " summary"))
+;;
+
 let test_histogram_exported_as_summary () =
   let name = "test_hist_export_fmt" in
   Prometheus.register_histogram ~name ~help:"export format test" ();
@@ -895,6 +915,10 @@ let () =
             "goal attainment metrics registered"
             `Quick
             test_goal_attainment_metrics_registered
+        ; test_case
+            "OAS hotpath metrics registered"
+            `Quick
+            test_oas_hotpath_metrics_registered
         ; test_case
             "histogram exported as summary with _sum/_count"
             `Quick


### PR DESCRIPTION
## Product impact

Restores the Godfile size gate on current `main` without changing the OAS dispatch metric names or dashboard-facing Prometheus series.

## Evidence

- `lib/prometheus.ml` is now 3286 lines, below the 3300 absolute cap.
- OAS hot-path histogram names remain `masc_oas_params_of_schema_sec` and `masc_oas_make_tool_bundle_sec`.
- `MASC_DISABLE_HOTPATH_HIST` still gates observation overhead.

## Review evidence

- `ocamlformat --check lib/prometheus.ml lib/prometheus.mli lib/prometheus_hotpath.ml lib/prometheus_hotpath.mli lib/tool_bridge.ml lib/keeper/keeper_tools_oas.ml test/test_prometheus_coverage.ml`
- `BASE=origin/main bash scripts/lint/godfile-size-regression.sh`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_prometheus_coverage.exe`
- `./_build/default/test/test_prometheus_coverage.exe`

## Linked issue

None. Follow-up to the `Godfile size` CI failure on the current PR merge surface.

## Summary

- Split OAS dispatch hot-path Prometheus helper/metric constants out of `lib/prometheus.ml`.
- Keep metric names and `MASC_DISABLE_HOTPATH_HIST` behavior unchanged.
- Add Prometheus coverage for the extracted hot-path metrics.
