### PR TITLE
docs(board): clarify SubBoard slug and routes

### DIFF
--- a/docs/spec/11-board.md
+++ b/docs/spec/11-board.md
@@ -447,6 +447,8 @@ type sub_board = {
 | GET | `/api/v1/board/sub-boards` | 전체 SubBoard 목록 (`{sub_boards: [...]}`) |
 | POST | `/api/v1/board/sub-boards` | SubBoard 생성 (`slug`, `name`, `description`, `access?` 필요) |
 | GET | `/api/v1/board/sub-boards/<id_or_slug>` | 단일 SubBoard 조회 (ID 또는 slug로 검색) |
+| PUT | `/api/v1/board/sub-boards/<id_or_slug>` | SubBoard 수정 (name?, description?, access?, members?) |
+| DELETE | `/api/v1/board/sub-boards/<id_or_slug>` | SubBoard 삭제 (소속 게시물의 hearth는 orphan 정책으로 클리어됨) |
 
 POST 요청은 `with_tool_auth` (`tool_name: "board_sub_board_create"`)로 인증.
 

--- a/lib/tool_board_schemas.ml
+++ b/lib/tool_board_schemas.ml
@@ -102,7 +102,7 @@ let tool_post_create : Masc_domain.tool_schema =
                 , `Assoc
                     [ "type", `String "string"
                     ; ( "description"
-                      , `String "Topic hearth name (e.g. webrtc, code-review)" )
+                      , `String "SubBoard slug or topic hearth name (e.g. ops, research). When a SubBoard with this slug exists, the post is bound to that SubBoard and its access policy." )
                     ] )
               ; ( "thread_id"
                 , `Assoc
@@ -157,7 +157,7 @@ let tool_post_list : Masc_domain.tool_schema =
                     [ "type", `String "string"
                     ; "maxLength", `Int 100
                     ; ( "description"
-                      , `String "Filter by hearth topic (e.g. webrtc, code-review)" )
+                      , `String "Filter by SubBoard slug or hearth topic (e.g. ops, research)" )
                     ] )
               ; ( "random"
                 , `Assoc


### PR DESCRIPTION
## Summary

<!-- What changed? Keep this short and factual. -->

## Product impact

- User-visible change:

## Evidence

<!-- Tests, harness runs, screenshots, logs, or other proof. -->
- If tool-call behavior or provider tool support changed: include replay-harness or `ToolCallContract` evidence.

## GOAL LOOP ACT checklist

<!-- Complete this section for operational/runtime fixes. Leave unchecked items with a brief N/A reason. -->

- [ ] Observe — metric/log/trace evidence for the failure or drift is linked or pasted above
- [ ] Orient — mapped to a finding, live-log pattern, audit item, or explicit new finding
- [ ] Decide — priority/risk rationale is stated, including why this scope is the next action
- [ ] Act — code/config/docs changed in the smallest bounded scope; rollback path is clear
- [ ] Verify — regression test, focused local command, CI job, or production-log check proves PASS/FAIL
- [ ] Loop — remaining follow-up is linked as an issue/PR/handoff, or explicitly marked none

## Review evidence

<!-- Cross-model review result, reviewer model, and fallback reason if any. -->

## Linked issue

- Closes #
- Relates #

## Variant addition checklist

<!-- Complete this section if you added, removed, or renamed any OCaml variant,
     TypeScript union member, TLA+ domain literal, or JSON schema enum value.
     Leave unchecked boxes with a brief justification comment if not applicable. -->

- [ ] **OCaml** — variant added/removed in `.ml`/`.mli` and exhaustive `match` updated (no silent `_` wildcard without justification comment)
- [ ] **TypeScript** — corresponding union type in `dashboard/src/types/core.ts` updated (e.g. `KeeperPhase`, `KeeperHealth`, etc.)
- [ ] **TLA+ spec** — matching domain literal or `DOMAIN` set in the relevant `.tla` file updated
- [ ] **Event / JSON schema** — event type string, JSON schema enum, or `canonical_keeper_toml_key_names` updated if applicable
- [ ] **`make check-variants` passes** — run `bash scripts/check-variants.sh` locally and confirm PASS
