### PR TITLE
fix(cascade): bound hotpath max tokens by failover ceiling

### DIFF
--- a/lib/cascade/cascade_declarative_hotpath.ml
+++ b/lib/cascade/cascade_declarative_hotpath.ml
@@ -58,6 +58,16 @@ let make_weighted_entry (cfg : Llm_provider.Provider_config.t) :
 
 (* --- Inference params extraction --- *)
 
+let min_positive_max_tokens (configs : Llm_provider.Provider_config.t list) =
+  configs
+  |> List.filter_map (fun cfg ->
+    match cfg.Llm_provider.Provider_config.max_tokens with
+    | Some n when n > 0 -> Some n
+    | _ -> None)
+  |> function
+  | [] -> None
+  | first :: rest -> Some (List.fold_left min first rest)
+
 let extract_inference_params (configs : Llm_provider.Provider_config.t list) :
     Loader.inference_params =
   match configs with
@@ -66,7 +76,7 @@ let extract_inference_params (configs : Llm_provider.Provider_config.t list) :
       num_ctx = None; thinking_enabled = None; thinking_budget = None }
   | first :: _ ->
     { Loader.temperature = first.Llm_provider.Provider_config.temperature;
-      max_tokens = first.Llm_provider.Provider_config.max_tokens;
+      max_tokens = min_positive_max_tokens configs;
       keep_alive = None;
       num_ctx = None;
       thinking_enabled = first.Llm_provider.Provider_config.enable_thinking;

--- a/test/test_cascade_capability_gate.ml
+++ b/test/test_cascade_capability_gate.ml
@@ -199,11 +199,9 @@ target = "tier-group.strict_tool_candidates"
         ~provider_ceiling:ceiling resolved
       |> check_ok "capped value accepted" 16384)
 
-let test_resolve_max_tokens_preserves_cascade_config_for_validator () =
+let test_resolve_provider_derived_max_tokens_matches_failover_ceiling () =
   with_temp_cascade_toml
     {|
-keeper_unified_max_tokens = 65536
-
 [providers.claude_code]
 protocol = "anthropic-cli"
 command = "claude"
@@ -213,6 +211,10 @@ is-non-interactive = true
 protocol = "kimi-cli"
 command = "kimi"
 is-non-interactive = true
+
+[providers.ollama]
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
 
 [models.claude-auto]
 api-name = "auto"
@@ -230,10 +232,21 @@ tools-support = true
 [models.kimi-cli-coding.capabilities]
 max-output-tokens = 16384
 
+[models.local-recovery]
+api-name = "local"
+max-context = 32768
+tools-support = true
+
+[models.local-recovery.capabilities]
+max-output-tokens = 8192
+
 [claude_code.claude-auto]
 max-concurrent = 1
 
 [kimi_cli.kimi-cli-coding]
+max-concurrent = 1
+
+[ollama.local-recovery]
 max-concurrent = 1
 
 [claude_code.claude-auto.tool_candidate]
@@ -244,12 +257,20 @@ temperature = 0.2
 max-output = 16384
 temperature = 0.2
 
+[ollama.local-recovery.recovery]
+max-output = 8192
+temperature = 0.2
+
 [tier.strict_tool_candidates]
 members = ["claude_code.claude-auto.tool_candidate", "kimi_cli.kimi-cli-coding.tool_candidate"]
 strategy = "failover"
 
+[tier.local_recovery]
+members = ["ollama.local-recovery.recovery"]
+strategy = "failover"
+
 [tier-group.strict_tool_candidates]
-tiers = ["strict_tool_candidates"]
+tiers = ["strict_tool_candidates", "local_recovery"]
 strategy = "failover"
 
 [routes.keeper_unified]
@@ -257,14 +278,16 @@ target = "tier-group.strict_tool_candidates"
 |}
     (fun () ->
       let ceiling = CR.max_output_tokens_ceiling_of_cascade_name cascade_name in
-      check (option int) "mixed cascade output ceiling" (Some 16384) ceiling;
+      check (option int) "mixed cascade output ceiling" (Some 8192) ceiling;
       let resolved =
-        CI.resolve_max_tokens ~cascade_name ~fallback:(fun () -> 8192)
+        CI.resolve_max_tokens ~cascade_name ~fallback:(fun () -> 65536)
       in
-      check int "cascade config max_tokens is not silently capped" 65536 resolved;
+      check int "provider-derived max_tokens follows narrowest failover ceiling"
+        8192
+        resolved;
       CI.validate_max_tokens_within_ceiling ~cascade_name
         ~provider_ceiling:ceiling resolved
-      |> check_violation "requested_exceeds_provider_ceiling" 65536 16384)
+      |> check_ok "narrowest failover value accepted" 8192)
 
 let () =
   run "cascade_capability_gate" [
@@ -288,8 +311,8 @@ let () =
         `Quick
         test_resolve_max_tokens_caps_automatic_value_to_cascade_ceiling;
       test_case
-        "cascade config max_tokens reaches validator"
+        "provider-derived max_tokens matches failover ceiling"
         `Quick
-        test_resolve_max_tokens_preserves_cascade_config_for_validator;
+        test_resolve_provider_derived_max_tokens_matches_failover_ceiling;
     ];
   ]

--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -178,6 +178,53 @@ let test_candidates () =
   check int "primary has 3 candidates" 3
     (List.length primary.Hotpath.candidates)
 
+let test_failover_inference_max_tokens_uses_narrowest_candidate () =
+  let toml =
+    {|
+[providers.claude_code]
+protocol = "anthropic-cli"
+command = "claude"
+
+[models.wide]
+max-context = 200000
+api-name = "wide"
+tools-support = true
+
+[models.narrow]
+max-context = 32768
+api-name = "narrow"
+tools-support = true
+
+[claude_code.wide.tool]
+max-output = 64000
+temperature = 0.2
+
+[claude_code.narrow.recovery]
+max-output = 8192
+temperature = 0.2
+
+[tier.mixed]
+members = ["claude_code.wide.tool", "claude_code.narrow.recovery"]
+strategy = "failover"
+|}
+  in
+  let snapshot = get_snapshot toml in
+  let mixed = find_profile snapshot "tier.mixed" in
+  check (option int) "profile max_tokens follows narrowest failover candidate"
+    (Some 8192)
+    mixed.Hotpath.inference_params.max_tokens;
+  match mixed.Hotpath.candidates with
+  | wide :: narrow :: _ ->
+    check (option int) "wide candidate keeps own cap" (Some 64000)
+      wide.Hotpath.provider_cfg.Llm_provider.Provider_config.max_tokens;
+    check (option int) "narrow candidate keeps own cap" (Some 8192)
+      narrow.Hotpath.provider_cfg.Llm_provider.Provider_config.max_tokens
+  | candidates ->
+    fail
+      (Printf.sprintf
+         "expected at least two candidates, got %d"
+         (List.length candidates))
+
 let test_model_string_format () =
   let snapshot = get_snapshot valid_toml in
   let local = find_profile snapshot "tier.local" in
@@ -379,6 +426,10 @@ let () =
         test_case "candidates" `Quick test_candidates;
         test_case "model_string format" `Quick test_model_string_format;
         test_case "weighted_entries count" `Quick test_weighted_entries_count;
+        test_case
+          "failover inference max_tokens uses narrowest candidate"
+          `Quick
+          test_failover_inference_max_tokens_uses_narrowest_candidate;
         test_case "strategy preserved" `Quick test_strategy_preserved;
         test_case "probes field absent" `Quick test_probes_field_absent;
         test_case "ollama_max_concurrent" `Quick test_ollama_max_concurrent;


### PR DESCRIPTION
## Summary
- derive declarative hotpath inference max_tokens from the narrowest positive failover candidate instead of the first candidate
- update capability-gate coverage to remove the stale flat legacy max_tokens expectation
- add regression coverage for 64K/8K failover groups resolving to the safe 8K request budget

## Evidence
- ocamlformat --check lib/cascade/cascade_declarative_hotpath.ml test/test_cascade_declarative_hotpath.ml test/test_cascade_capability_gate.ml
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_cascade_declarative_hotpath.exe test/test_cascade_capability_gate.exe test/test_cascade_runtime.exe
- ./_build/default/test/test_cascade_declarative_hotpath.exe
- ./_build/default/test/test_cascade_capability_gate.exe
- ./_build/default/test/test_cascade_runtime.exe
- git diff --check origin/main..HEAD

Runtime signal addressed: 2026-05-14 keeper receipts showed fleet-wide pre_dispatch_max_tokens_ceiling_violation for tier-group.strict_tool_candidates with requested_max_tokens=64000 and provider_ceiling=16384, plus follow-up local_recovery/tier-group.coding_plan 16384 vs 8192 ceiling failures.