### PR TITLE
feat(ide): link conversation rail context routes

### DIFF
--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -904,7 +904,7 @@ function diagnosticTelemetryQuery(diagnostic: IdeContextDiagnostic): string | un
   return parts.length > 0 ? parts.join(' ') : undefined
 }
 
-interface EventRouteRefs {
+export interface IdeContextTextRouteRefs {
   readonly line?: number
   readonly goalId?: string
   readonly taskId?: string
@@ -932,8 +932,11 @@ const EVENT_REF_PATTERNS = {
   workerRunId: new RegExp(`\\b(?:worker_run|worker|wr)[:#/]+${REF_VALUE_PATTERN}`, 'i'),
 } as const
 
-function eventRouteRefs(event: RunActivityEvent): EventRouteRefs {
-  const text = eventRawText(event)
+function eventRouteRefs(event: RunActivityEvent): IdeContextTextRouteRefs {
+  return routeRefsFromText(eventRawText(event))
+}
+
+export function routeRefsFromText(text: string): IdeContextTextRouteRefs {
   return {
     line: eventLineRef(text),
     goalId: firstEventRef(text, EVENT_REF_PATTERNS.goalId),
@@ -976,7 +979,7 @@ function eventLineRef(text: string): number | undefined {
   return compact ? positiveLine(Number(compact)) : undefined
 }
 
-function eventContextMeta(event: RunActivityEvent, refs: EventRouteRefs): string {
+function eventContextMeta(event: RunActivityEvent, refs: IdeContextTextRouteRefs): string {
   const context = event.context
   const goalId = context?.goal_id ?? refs.goalId
   const taskId = context?.task_id ?? refs.taskId

--- a/dashboard/src/components/ide/ide-conversation-rail.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.test.ts
@@ -40,6 +40,7 @@ afterEach(() => {
   activeIdeFile.value = 'package.json'
   ideContextFocus.value = null
   setIdeReplayUntilMs(null)
+  window.location.hash = ''
   clearTraces()
 })
 
@@ -310,6 +311,65 @@ describe('IdeConversationRail', () => {
       source_id: 'thread-thread-line',
       keeper_id: 'scholar',
     })
+
+    render(null, container)
+  })
+
+  it('renders route links for board thread code, planning, review, and keeper context', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.startsWith('/api/v1/board')) {
+        return new Response(JSON.stringify([{
+          id: 'thread-line',
+          title: 'Review lib/runtime.ml:42',
+          body: 'question fn:run comment:comment-1 PR 15035 task:task-runtime goal:goal-runtime branch:feat/ide-routes log:turn-7',
+          author_identity: 'scholar',
+          votes: 0,
+          comment_count: 2,
+          created_at_iso: '2026-05-05T10:00:00Z',
+        }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (url.startsWith('/api/v1/dashboard/keeper-decisions')) {
+        return new Response(JSON.stringify({ events: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (url.startsWith('/api/v1/cascade/strategy_trace')) {
+        return new Response(JSON.stringify({ events: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      return new Response('{}', { status: 404 })
+    }))
+
+    const container = document.createElement('div')
+    render(h(IdeConversationRail, {}), container)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('comment:comment-1')
+    })
+
+    const links = [...container.querySelectorAll<HTMLButtonElement>('.ide-conversation-route-link')]
+    expect(links.map(link => link.textContent)).toEqual([
+      'Code',
+      'Goal',
+      'Task',
+      'Board',
+      'Comment',
+      'PR',
+      'Git',
+      'Log',
+      'Telemetry',
+      'Keeper',
+    ])
+    expect(links.map(link => link.getAttribute('aria-label'))).toContain('Open Comment comment-1')
+
+    fireEvent.click(links.find(link => link.textContent === 'Board')!)
+    expect(window.location.hash).toBe('#workspace?section=board&post=thread-line')
+
+    fireEvent.click(links.find(link => link.textContent === 'Comment')!)
+    expect(window.location.hash).toBe('#workspace?section=board&post=thread-line&comment=comment-1')
+
+    fireEvent.click(links.find(link => link.textContent === 'PR')!)
+    expect(window.location.hash).toBe('#workspace?section=repositories&view=graph&pr=15035')
+
+    fireEvent.click(links.find(link => link.textContent === 'Keeper')!)
+    expect(window.location.hash).toBe('#monitoring?section=agents&view=keepers&keeper=scholar')
 
     render(null, container)
   })

--- a/dashboard/src/components/ide/ide-conversation-rail.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.ts
@@ -29,6 +29,12 @@ import { activeIdeFile, focusIdeContextAnchor, normalizeIdeContextFilePath } fro
 import { activeKeeperName } from '../../keeper-state'
 import { globalPresenceSnapshot, PRESENCE_DOT, type KeeperPresenceEntry } from './keeper-presence-store'
 import { cursorOverlaySignal, type KeeperCursorOverlay } from './keeper-cursor-overlay'
+import {
+  openIdeContextRouteLink,
+  routeLinksForContext,
+  routeRefsFromText,
+  type IdeContextRouteLink,
+} from './ide-context-lens'
 
 export interface BoardPost {
   readonly id: string
@@ -425,6 +431,7 @@ function PostCard(
   const focusFile = hasFocus ? cursor.file_path.split('/').pop() : null
   const thread = postToAnchoredThread(post)
   const anchor = thread?.anchor ?? null
+  const routeLinks = conversationRouteLinks(post, anchor, kind, bodyText)
 
   return html`
     <li class="ide-rail-item">
@@ -501,7 +508,60 @@ function PostCard(
           ${post.comment_count > 0 ? `${post.comment_count} replies · ` : ''}${(post.votes ?? 0) > 0 ? `${post.votes ?? 0} votes` : ''}
         </div>
       </button>
+      ${routeLinks.length > 0 ? html`
+        <div class="ide-conversation-route-links" aria-label="Conversation operational links">
+          ${routeLinks.map(link => ConversationRouteLink(link))}
+        </div>
+      ` : null}
     </li>
+  `
+}
+
+function conversationRouteLinks(
+  post: BoardPost,
+  anchor: AnchoredThread['anchor'] | null,
+  kind: ThreadKind,
+  bodyText: string,
+): ReadonlyArray<IdeContextRouteLink> {
+  const refs = routeRefsFromText(`${post.title ?? ''}\n${post.body ?? ''}\n${post.hearth ?? ''}`)
+  const logId = refs.logId
+  const sessionId = refs.sessionId
+  const operationId = refs.operationId
+  const workerRunId = refs.workerRunId
+  return routeLinksForContext({
+    filePath: anchor?.file_path,
+    line: anchor?.line_start ?? refs.line,
+    surface: KIND_LABEL[kind],
+    label: bodyText || post.title || 'board thread',
+    sourceId: `thread-${post.id}`,
+    goalId: refs.goalId,
+    taskId: refs.taskId,
+    boardPostId: post.id,
+    commentId: refs.commentId,
+    prId: refs.prId,
+    gitRef: refs.gitRef,
+    logId,
+    sessionId,
+    operationId,
+    workerRunId,
+    telemetryQuery: logId ?? sessionId ?? operationId ?? workerRunId,
+    keeperId: post.author_identity || undefined,
+    telemetry: Boolean(logId || sessionId || operationId || workerRunId),
+  })
+}
+
+function ConversationRouteLink(link: IdeContextRouteLink) {
+  return html`
+    <button
+      key=${link.id}
+      type="button"
+      class="ide-conversation-route-link"
+      title=${link.evidence}
+      aria-label=${`Open ${link.evidence}`}
+      onClick=${() => openIdeContextRouteLink(link)}
+    >
+      ${link.label}
+    </button>
   `
 }
 

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -1415,6 +1415,43 @@ button.ide-persistence-focus:focus-visible {
   border-color: var(--color-border-strong);
 }
 
+.ide-conversation-route-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  min-width: 0;
+  margin-top: 3px;
+  padding-left: var(--sp-2);
+}
+
+.ide-conversation-route-link {
+  min-width: 0;
+  max-width: 72px;
+  height: 17px;
+  padding: 0 5px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-muted);
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-conversation-route-link:hover,
+.ide-conversation-route-link:focus-visible {
+  border-color: var(--color-border-strong);
+  color: var(--color-accent-fg);
+}
+
+.ide-conversation-route-link:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 1px;
+}
+
 .ide-conversation-meta {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- add conversation rail route chips through the shared IDE context-route model
- reuse the context text ref parser for goal/task/comment/PR/git/log refs in board-thread text
- cover board/comment/PR/keeper route activation from a line-anchored thread

## Validation
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/ide-conversation-rail.ts src/components/ide/ide-conversation-rail.test.ts src/components/ide/ide-context-lens.ts
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-conversation-rail.test.ts
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-conversation-rail.a11y.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check