### PR TITLE
feat(ide): link replay rail route context

### DIFF
--- a/dashboard/src/components/ide/ide-conversation-rail.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.test.ts
@@ -6,6 +6,7 @@ import { IdeConversationRail, postsToAnchoredThreads, replayRailItems } from './
 import { activeIdeFile, ideContextFocus } from './ide-state'
 import { clearTraces, keeperTraceState } from './keeper-trace-store'
 import { ideReplayUntilMs, setIdeReplayUntilMs } from './ide-replay-state'
+import { cursorOverlaySignal } from './keeper-cursor-overlay'
 
 function stubEmptyConversationFetch(): void {
   vi.stubGlobal('fetch', vi.fn(async (url: string) => {
@@ -40,6 +41,12 @@ afterEach(() => {
   activeIdeFile.value = 'package.json'
   ideContextFocus.value = null
   setIdeReplayUntilMs(null)
+  cursorOverlaySignal.value = {
+    cursors: new Map(),
+    heatmap: new Map(),
+    collisions: [],
+    active_file: null,
+  }
   window.location.hash = ''
   clearTraces()
 })
@@ -210,7 +217,7 @@ describe('IdeConversationRail', () => {
             keeper_name: 'scholar',
             event_type: 'turn_completed',
             outcome: 'success',
-            model_used: 'glm:auto',
+            model_used: null,
           }],
           limit: 200,
           generated_at: null,
@@ -258,6 +265,109 @@ describe('IdeConversationRail', () => {
     expect(container.textContent).not.toContain('new thread body')
     expect(container.textContent).not.toContain('turn_completed')
     expect(container.textContent).not.toContain('primary')
+
+    render(null, container)
+  })
+
+  it('renders route links for keeper decision and cascade replay entries', async () => {
+    const decisionTs = Date.UTC(2026, 4, 5, 10, 1, 0) / 1000
+    const cascadeTs = Date.UTC(2026, 4, 5, 10, 2, 0) / 1000
+    cursorOverlaySignal.value = {
+      cursors: new Map([[
+        'scholar',
+        {
+          keeper_id: 'scholar',
+          file_path: 'lib/runtime.ml',
+          line: 42,
+          column: 3,
+          focus_mode: 'reviewing',
+          last_update: Date.UTC(2026, 4, 5, 10, 1, 30),
+        },
+      ]]),
+      heatmap: new Map(),
+      collisions: [],
+      active_file: 'lib/runtime.ml',
+    }
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.startsWith('/api/v1/board')) {
+        return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (url.startsWith('/api/v1/dashboard/keeper-decisions')) {
+        return new Response(JSON.stringify({
+          events: [{
+            ts_unix: decisionTs,
+            keeper_name: 'scholar',
+            event_type: 'turn_completed',
+            outcome: 'success',
+            model_used: 'glm:auto',
+            latency_ms: null,
+            cost_usd: null,
+            input_tokens: null,
+            output_tokens: null,
+            stop_reason: null,
+            error_category: null,
+            tool: 'apply_patch',
+            duration_ms: null,
+            match_count: null,
+          }],
+          limit: 200,
+          generated_at: null,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (url.startsWith('/api/v1/cascade/strategy_trace')) {
+        return new Response(JSON.stringify({
+          updated_at: '2026-05-05T10:04:00Z',
+          total_events: 1,
+          events: [{
+            ts: cascadeTs,
+            cascade_name: 'primary',
+            strategy: 'ranked',
+            cycle: 1,
+            candidates_in: 3,
+            candidates_out: 2,
+            backoff_ms: 0,
+            kind: 'ordered',
+          }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      return new Response('{}', { status: 404 })
+    }))
+
+    const container = document.createElement('div')
+    render(h(IdeConversationRail, {}), container)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('turn_completed')
+      expect(container.textContent).toContain('primary')
+    })
+
+    const decisionCard = container.querySelector<HTMLElement>('[data-replay-source="decision"]')
+    expect(decisionCard).not.toBeNull()
+    const decisionLinks = [...decisionCard!.querySelectorAll<HTMLButtonElement>('.ide-conversation-route-link')]
+    expect(decisionLinks.map(link => link.textContent)).toEqual(['Code', 'Telemetry', 'Keeper'])
+
+    fireEvent.click(decisionLinks.find(link => link.textContent === 'Code')!)
+    expect(window.location.hash.startsWith('#code?')).toBe(true)
+    expect(routeHashParams().get('file')).toBe('lib/runtime.ml')
+    expect(routeHashParams().get('line')).toBe('42')
+
+    fireEvent.click(decisionLinks.find(link => link.textContent === 'Telemetry')!)
+    expect(routeHashParams().get('q')).toBe(
+      `decision keeper:scholar event:turn_completed outcome:success tool:apply_patch ts:${decisionTs}`,
+    )
+
+    fireEvent.click(decisionLinks.find(link => link.textContent === 'Keeper')!)
+    expect(window.location.hash).toBe('#monitoring?section=agents&view=keepers&keeper=scholar')
+
+    const cascadeCard = container.querySelector<HTMLElement>('[data-replay-source="cascade"]')
+    expect(cascadeCard).not.toBeNull()
+    const cascadeLinks = [...cascadeCard!.querySelectorAll<HTMLButtonElement>('.ide-conversation-route-link')]
+    expect(cascadeLinks.map(link => link.textContent)).toEqual(['Telemetry'])
+
+    fireEvent.click(cascadeLinks[0]!)
+    expect(routeHashParams().get('q')).toBe(
+      `cascade primary strategy:ranked cycle:1 kind:ordered ts:${cascadeTs}`,
+    )
 
     render(null, container)
   })
@@ -374,3 +484,7 @@ describe('IdeConversationRail', () => {
     render(null, container)
   })
 })
+
+function routeHashParams(): URLSearchParams {
+  return new URLSearchParams(window.location.hash.split('?')[1] ?? '')
+}

--- a/dashboard/src/components/ide/ide-conversation-rail.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.ts
@@ -584,6 +584,12 @@ function DecisionCard(
   const cursor = overlay.cursors.get(keeper)
   const hasFocus = !!cursor && !!cursor.file_path && cursor.line >= 1
   const focusFile = hasFocus ? cursor.file_path.split('/').pop() : null
+  const routeLinks = decisionRouteLinks(
+    item,
+    hasFocus ? cursor.file_path : undefined,
+    hasFocus ? cursor.line : undefined,
+    summary,
+  )
   return html`
     <li style=${{ display: 'block' }}>
       <div
@@ -640,13 +646,51 @@ function DecisionCard(
           title=${cursor.file_path}
           >↗ ${focusFile}:${cursor.line}</span>
         ` : null}
+        ${routeLinks.length > 0 ? html`
+          <div class="ide-conversation-route-links" aria-label="Decision operational links">
+            ${routeLinks.map(link => ConversationRouteLink(link))}
+          </div>
+        ` : null}
       </div>
     </li>
   `
 }
 
+function decisionRouteLinks(
+  item: Extract<ReplayRailItem, { source: 'decision' }>,
+  filePath: string | undefined,
+  line: number | undefined,
+  summary: string,
+): ReadonlyArray<IdeContextRouteLink> {
+  const decision = item.decision
+  const keeper = decision.keeper_name || 'keeper'
+  return routeLinksForContext({
+    filePath,
+    line,
+    surface: 'Decision',
+    label: summary || decision.event_type || 'decision event',
+    sourceId: `decision-${keeper}-${item.timestamp_ms}-${decision.event_type}`,
+    keeperId: keeper,
+    telemetry: true,
+    telemetryQuery: decisionTelemetryQuery(decision, item.timestamp_ms),
+  })
+}
+
+function decisionTelemetryQuery(decision: KeeperDecision, timestampMs: number): string {
+  return compactRouteQuery([
+    'decision',
+    `keeper:${decision.keeper_name || 'keeper'}`,
+    decision.event_type ? `event:${decision.event_type}` : null,
+    decision.outcome ? `outcome:${decision.outcome}` : null,
+    decision.tool ? `tool:${decision.tool}` : null,
+    decision.model_used ? `model:${decision.model_used}` : null,
+    Number.isFinite(timestampMs) ? `ts:${Math.floor(timestampMs / 1000)}` : null,
+  ])
+}
+
 function CascadeCard(item: Extract<ReplayRailItem, { source: 'cascade' }>) {
   const event = item.cascade
+  const routeLinks = cascadeRouteLinks(item)
   return html`
     <li style=${{ display: 'block' }}>
       <div
@@ -669,9 +713,42 @@ function CascadeCard(item: Extract<ReplayRailItem, { source: 'cascade' }>) {
         <p style=${{ margin: 0, color: 'var(--color-fg-secondary)', fontSize: 'var(--fs-12)' }}>
           ${event.strategy} · ${event.kind} · ${event.candidates_in}->${event.candidates_out}
         </p>
+        ${routeLinks.length > 0 ? html`
+          <div class="ide-conversation-route-links" aria-label="Cascade operational links">
+            ${routeLinks.map(link => ConversationRouteLink(link))}
+          </div>
+        ` : null}
       </div>
     </li>
   `
+}
+
+function cascadeRouteLinks(
+  item: Extract<ReplayRailItem, { source: 'cascade' }>,
+): ReadonlyArray<IdeContextRouteLink> {
+  const event = item.cascade
+  return routeLinksForContext({
+    surface: 'Cascade',
+    label: `${event.cascade_name} ${event.kind}`,
+    sourceId: `cascade-${event.cascade_name}-${event.cycle}-${item.timestamp_ms}`,
+    telemetry: true,
+    telemetryQuery: cascadeTelemetryQuery(event, item.timestamp_ms),
+  })
+}
+
+function cascadeTelemetryQuery(event: CascadeStrategyTraceEvent, timestampMs: number): string {
+  return compactRouteQuery([
+    'cascade',
+    event.cascade_name,
+    `strategy:${event.strategy}`,
+    `cycle:${event.cycle}`,
+    `kind:${event.kind}`,
+    Number.isFinite(timestampMs) ? `ts:${Math.floor(timestampMs / 1000)}` : null,
+  ])
+}
+
+function compactRouteQuery(values: ReadonlyArray<string | null>): string {
+  return values.filter((value): value is string => Boolean(value)).join(' ')
 }
 
 function formatThreadTime(ms: number): string {


### PR DESCRIPTION
## Summary
- add operational route chips to keeper decision replay cards
- add telemetry route chips to cascade replay cards
- route decision cards through keeper cursor code focus when available, plus telemetry and keeper surfaces

## Validation
- pnpm install --offline --frozen-lockfile
- pnpm exec eslint src/components/ide/ide-conversation-rail.ts src/components/ide/ide-conversation-rail.test.ts
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-conversation-rail.test.ts
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-conversation-rail.a11y.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check

Note: the vitest runs pass while printing existing sandbox EPERM noise from attempted localhost:3000 fetches.