### PR TITLE
feat(ide): link BDI inspector route context

### DIFF
--- a/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
@@ -11,7 +11,7 @@ import {
 import { clearPins } from './multi-keeper-pin-store'
 import { clearTraces, pushTrace } from './keeper-trace-store'
 import { cursorOverlaySignal, type KeeperCursor } from './keeper-cursor-overlay'
-import { activeIdeFile } from './ide-state'
+import { activeIdeFile, ideContextFocus } from './ide-state'
 
 const snapshot = {
   keeper: 'scholar',
@@ -64,6 +64,8 @@ afterEach(() => {
     active_file: null,
   }
   activeIdeFile.value = 'package.json'
+  ideContextFocus.value = null
+  window.location.hash = ''
   void inspectorKeeperPin.value
 })
 
@@ -305,6 +307,43 @@ describe('InspectorKeeperBDI', () => {
 
     focusButton!.click()
     expect(activeIdeFile.value).toBe('src/components/ide/inspector-keeper-bdi.ts')
+    expect(ideContextFocus.value).toMatchObject({
+      file_path: 'src/components/ide/inspector-keeper-bdi.ts',
+      line: 42,
+      surface: 'BDI',
+      keeper_id: 'scholar',
+    })
+
+    render(null, container)
+  })
+
+  it('renders BDI operational route links for code, telemetry, and keeper context', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(snapshot)))
+    vi.stubGlobal('fetch', fetchMock)
+    activeKeeperName.value = 'scholar'
+    setCursorFor('scholar', { file_path: 'src/components/ide/inspector-keeper-bdi.ts', line: 42 })
+
+    const container = createContainer()
+    render(html`<${InspectorKeeperBDI} pollMs=${60_000} />`, container)
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/keepers/scholar/bdi-snapshot', expect.any(Object))
+    })
+
+    const links = [...container.querySelectorAll<HTMLButtonElement>('.ide-bdi-route-link')]
+    expect(links.map(link => link.textContent)).toEqual(['Code', 'Telemetry', 'Keeper'])
+
+    links.find(link => link.textContent === 'Code')!.click()
+    expect(window.location.hash.startsWith('#code?')).toBe(true)
+    expect(routeHashParams().get('file')).toBe('src/components/ide/inspector-keeper-bdi.ts')
+    expect(routeHashParams().get('line')).toBe('42')
+
+    links.find(link => link.textContent === 'Telemetry')!.click()
+    expect(routeHashParams().get('q')).toBe(
+      'bdi keeper:scholar generated:2026-05-05T13:00:00Z tool:keeper_bash',
+    )
+
+    links.find(link => link.textContent === 'Keeper')!.click()
+    expect(window.location.hash).toBe('#monitoring?section=agents&view=keepers&keeper=scholar')
 
     render(null, container)
   })
@@ -332,3 +371,7 @@ describe('InspectorKeeperBDI', () => {
     render(null, container)
   })
 })
+
+function routeHashParams(): URLSearchParams {
+  return new URLSearchParams(window.location.hash.split('?')[1] ?? '')
+}

--- a/dashboard/src/components/ide/inspector-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.ts
@@ -11,7 +11,12 @@ import { cursorOverlaySignal } from './keeper-cursor-overlay'
 // circular dependency `ide-shell -> inspector-keeper-bdi -> ide-shell`
 // (which also drags `router` and other window-touching side effects
 // into this module's tests).
-import { activeIdeFile } from './ide-state'
+import { focusIdeContextAnchor } from './ide-state'
+import {
+  openIdeContextRouteLink,
+  routeLinksForContext,
+  type IdeContextRouteLink,
+} from './ide-context-lens'
 import { OverlayKeeperTrace } from './overlay-keeper-trace'
 
 export interface KeeperBdiTokenSpend {
@@ -181,6 +186,66 @@ function BdiRow({ label, value }: { readonly label: string, readonly value: stri
   `
 }
 
+export function bdiRouteLinks({
+  keeperName,
+  snapshot,
+  filePath,
+  line,
+}: {
+  readonly keeperName: string
+  readonly snapshot: KeeperBdiSnapshot | null
+  readonly filePath?: string
+  readonly line?: number
+}): ReadonlyArray<IdeContextRouteLink> {
+  const keeper = keeperName.trim()
+  if (!keeper) return []
+  return routeLinksForContext({
+    filePath,
+    line,
+    surface: 'BDI',
+    label: snapshot?.intention ?? `keeper BDI ${keeper}`,
+    sourceId: `bdi-${keeper}-${snapshot?.generated_at ?? 'live'}`,
+    keeperId: keeper,
+    telemetry: true,
+    telemetryQuery: bdiTelemetryQuery(keeper, snapshot),
+  })
+}
+
+function bdiTelemetryQuery(keeperName: string, snapshot: KeeperBdiSnapshot | null): string {
+  return [
+    'bdi',
+    `keeper:${keeperName}`,
+    snapshot?.generated_at ? `generated:${snapshot.generated_at}` : null,
+    snapshot?.last_tool_call?.tool ? `tool:${snapshot.last_tool_call.tool}` : null,
+  ].filter((value): value is string => value !== null).join(' ')
+}
+
+export function BdiRouteLinks({
+  links,
+  ariaLabel,
+}: {
+  readonly links: ReadonlyArray<IdeContextRouteLink>
+  readonly ariaLabel: string
+}) {
+  if (links.length === 0) return null
+  return html`
+    <div class="ide-bdi-route-links" aria-label=${ariaLabel}>
+      ${links.map(link => html`
+        <button
+          key=${link.id}
+          type="button"
+          class="ide-bdi-route-link"
+          title=${link.evidence}
+          aria-label=${`Open ${link.evidence}`}
+          onClick=${() => openIdeContextRouteLink(link)}
+        >
+          ${link.label}
+        </button>
+      `)}
+    </div>
+  `
+}
+
 export function InspectorKeeperBDI({
   pollMs = 5000,
   traceActive = false,
@@ -265,9 +330,24 @@ export function InspectorKeeperBDI({
   const entries: ReadonlyArray<KeeperPresenceEntry> = presence?.entries ?? []
   const entry = keeperName ? entries.find(e => e.keeper_id === keeperName) : null
   const statusDot = entry ? PRESENCE_DOT[entry.status] : null
+  const routeLinks = bdiRouteLinks({
+    keeperName,
+    snapshot,
+    filePath: hasValidFocus ? cursor?.file_path : undefined,
+    line: hasValidFocus ? cursor?.line : undefined,
+  })
 
   const navigateToFocus = (): void => {
-    if (hasValidFocus && cursor) activeIdeFile.value = cursor.file_path
+    if (!hasValidFocus || !cursor) return
+    focusIdeContextAnchor({
+      file_path: cursor.file_path,
+      line: cursor.line,
+      surface: 'BDI',
+      label: snapshot?.intention ?? `keeper BDI ${keeperName}`,
+      source_id: `bdi-${keeperName}-${snapshot?.generated_at ?? 'live'}`,
+      keeper_id: keeperName,
+      route_links: routeLinks,
+    })
   }
 
   return html`
@@ -339,6 +419,7 @@ export function InspectorKeeperBDI({
             }}
           >${focusLabel}</button>
         ` : null}
+        <${BdiRouteLinks} links=${routeLinks} ariaLabel="BDI operational links" />
         ${pin?.line
           ? html`<span style=${{ marginLeft: 'auto', color: 'var(--color-fg-muted)', fontSize: 'var(--fs-11)' }}>L${pin.line}</span>`
           : null}

--- a/dashboard/src/components/ide/inspector-multi-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-multi-keeper-bdi.test.ts
@@ -15,6 +15,7 @@ import {
 } from './multi-keeper-pin-store'
 import { cursorOverlaySignal, type KeeperCursor } from './keeper-cursor-overlay'
 import { activeIdeFile } from './ide-shell'
+import { ideContextFocus } from './ide-state'
 
 function setKeeperCursor(keeperId: string, filePath: string, line: number): void {
   const cursors = new Map(cursorOverlaySignal.value.cursors)
@@ -132,6 +133,8 @@ beforeEach(() => {
   activeKeeperName.value = ''
   clearKeeperCursors()
   activeIdeFile.value = 'package.json'
+  ideContextFocus.value = null
+  window.location.hash = ''
 })
 
 afterEach(() => {
@@ -143,6 +146,8 @@ afterEach(() => {
   activeKeeperName.value = ''
   clearKeeperCursors()
   activeIdeFile.value = 'package.json'
+  ideContextFocus.value = null
+  window.location.hash = ''
 })
 
 describe('InspectorMultiKeeperBDI — single-pin fallback (RFC-0027 §10)', () => {
@@ -665,6 +670,12 @@ describe('InspectorMultiKeeperBDI — file focus label (cursor overlay → IDE j
     fileBtn?.click()
     // activeIdeFile jumped …
     expect(activeIdeFile.value).toBe('lib/keeper/keeper_registry.ml')
+    expect(ideContextFocus.value).toMatchObject({
+      file_path: 'lib/keeper/keeper_registry.ml',
+      line: 555,
+      surface: 'BDI',
+      keeper_id: 'scholar',
+    })
     // … but pin order untouched (focus-promote did NOT fire because the focus
     // label is now a sibling button, not nested inside the focus chip button).
     expect(pinnedKeepers.value.entries[0]?.keeperName).toBe(headBefore)
@@ -690,4 +701,44 @@ describe('InspectorMultiKeeperBDI — file focus label (cursor overlay → IDE j
     expect(focusBtn.querySelector('button[aria-label^="focus file "]')).toBeNull()
     expect(chip.querySelector('button[aria-label^="focus file "]')).not.toBeNull()
   })
+
+  it('renders BDI route links on keeper panels and focus-mode chips', async () => {
+    vi.stubGlobal('fetch', makeFetchMock())
+    pinKeeper('scholar', 1)
+    pinKeeper('moth', 2)
+    pinKeeper('luna', 3)
+    pinKeeper('ash', 4)
+    setKeeperCursor('ash', 'src/runtime/ash.ts', 9)
+    setKeeperCursor('scholar', 'lib/keeper/keeper_registry.ml', 555)
+
+    const container = createContainer()
+    render(html`<${InspectorMultiKeeperBDI} pollMs=${60_000} />`, container)
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-layout="focus-mode"]')).not.toBeNull()
+    })
+
+    const ashPanel = container.querySelector('article[data-keeper="ash"]')
+    expect(ashPanel).not.toBeNull()
+    const ashLinks = [...ashPanel!.querySelectorAll<HTMLButtonElement>('.ide-bdi-route-link')]
+    expect(ashLinks.map(link => link.textContent)).toEqual(['Code', 'Telemetry', 'Keeper'])
+
+    ashLinks.find(link => link.textContent === 'Code')!.click()
+    expect(routeHashParams().get('file')).toBe('src/runtime/ash.ts')
+    expect(routeHashParams().get('line')).toBe('9')
+
+    const scholarChip = container.querySelector('span[role="listitem"][data-keeper="scholar"]')
+    expect(scholarChip).not.toBeNull()
+    const scholarLinks = [...scholarChip!.querySelectorAll<HTMLButtonElement>('.ide-bdi-route-link')]
+    expect(scholarLinks.map(link => link.textContent)).toEqual(['Code', 'Telemetry', 'Keeper'])
+
+    scholarLinks.find(link => link.textContent === 'Telemetry')!.click()
+    expect(routeHashParams().get('q')).toContain('bdi keeper:scholar')
+
+    scholarLinks.find(link => link.textContent === 'Keeper')!.click()
+    expect(window.location.hash).toBe('#monitoring?section=agents&view=keepers&keeper=scholar')
+  })
 })
+
+function routeHashParams(): URLSearchParams {
+  return new URLSearchParams(window.location.hash.split('?')[1] ?? '')
+}

--- a/dashboard/src/components/ide/inspector-multi-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-multi-keeper-bdi.ts
@@ -1,14 +1,16 @@
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import {
+  BdiRouteLinks,
   InspectorKeeperBDI,
   KeeperBdiSnapshot,
+  bdiRouteLinks,
   normalizeKeeperBdiSnapshot,
 } from './inspector-keeper-bdi'
 import { globalPresenceSnapshot, PRESENCE_DOT, type KeeperPresenceEntry, type KeeperPresenceSnapshot } from './keeper-presence-store'
 import { cursorOverlaySignal, type KeeperCursorOverlay } from './keeper-cursor-overlay'
 import { useSignalValue } from './use-signal-value'
-import { activeIdeFile } from './ide-state'
+import { focusIdeContextAnchor } from './ide-state'
 import {
   pinKeeper,
   pinnedKeepers,
@@ -259,8 +261,23 @@ function KeeperPanel({ entry, slot, compact, focused, dropIdx, presence, overlay
   const focusLabel = cursor && cursor.file_path && cursor.line >= 1
     ? `${cursor.file_path.split('/').pop()}:${cursor.line}`
     : null
+  const routeLinks = bdiRouteLinks({
+    keeperName: entry.keeperName,
+    snapshot,
+    filePath: cursor && cursor.file_path && cursor.line >= 1 ? cursor.file_path : undefined,
+    line: cursor && cursor.file_path && cursor.line >= 1 ? cursor.line : undefined,
+  })
   const navigateToFocus = (): void => {
-    if (cursor?.file_path) activeIdeFile.value = cursor.file_path
+    if (!cursor?.file_path || cursor.line < 1) return
+    focusIdeContextAnchor({
+      file_path: cursor.file_path,
+      line: cursor.line,
+      surface: 'BDI',
+      label: snapshot?.intention ?? `keeper BDI ${entry.keeperName}`,
+      source_id: `bdi-${entry.keeperName}-${snapshot?.generated_at ?? 'live'}`,
+      keeper_id: entry.keeperName,
+      route_links: routeLinks,
+    })
   }
 
   return html`
@@ -328,6 +345,10 @@ function KeeperPanel({ entry, slot, compact, focused, dropIdx, presence, overlay
             }}
           >${focusLabel}</button>
         ` : null}
+        <${BdiRouteLinks}
+          links=${routeLinks}
+          ariaLabel=${`${entry.keeperName} BDI operational links`}
+        />
         <button
           type="button"
           aria-label=${`unpin ${entry.keeperName}`}
@@ -387,8 +408,23 @@ function KeeperChip({ entry, slot, dropIdx, presence, overlay, onFocus, onUnpin 
   const focusLabel = cursor && cursor.file_path && cursor.line >= 1
     ? `${cursor.file_path.split('/').pop()}:${cursor.line}`
     : null
+  const routeLinks = bdiRouteLinks({
+    keeperName: entry.keeperName,
+    snapshot: slot.snapshot,
+    filePath: cursor && cursor.file_path && cursor.line >= 1 ? cursor.file_path : undefined,
+    line: cursor && cursor.file_path && cursor.line >= 1 ? cursor.line : undefined,
+  })
   const navigateToFocus = (): void => {
-    if (cursor?.file_path) activeIdeFile.value = cursor.file_path
+    if (!cursor?.file_path || cursor.line < 1) return
+    focusIdeContextAnchor({
+      file_path: cursor.file_path,
+      line: cursor.line,
+      surface: 'BDI',
+      label: slot.snapshot?.intention ?? `keeper BDI ${entry.keeperName}`,
+      source_id: `bdi-${entry.keeperName}-${slot.snapshot?.generated_at ?? 'live'}`,
+      keeper_id: entry.keeperName,
+      route_links: routeLinks,
+    })
   }
   return html`
     <span
@@ -442,6 +478,10 @@ function KeeperChip({ entry, slot, dropIdx, presence, overlay, onFocus, onUnpin 
           }}
         >${focusLabel}</button>
       ` : null}
+      <${BdiRouteLinks}
+        links=${routeLinks}
+        ariaLabel=${`${entry.keeperName} BDI operational links`}
+      />
       <button
         type="button"
         aria-label=${`unpin ${entry.keeperName}`}

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -1468,6 +1468,41 @@ button.ide-persistence-focus:focus-visible {
   overflow-wrap: anywhere;
 }
 
+.ide-bdi-route-links {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  min-width: 0;
+}
+
+.ide-bdi-route-link {
+  min-width: 0;
+  max-width: 72px;
+  height: 17px;
+  padding: 0 5px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-muted);
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-bdi-route-link:hover,
+.ide-bdi-route-link:focus-visible {
+  border-color: var(--color-border-strong);
+  color: var(--color-accent-fg);
+}
+
+.ide-bdi-route-link:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 1px;
+}
+
 .ide-interject-context-links {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- add Code, Telemetry, and Keeper route chips to the single-keeper BDI inspector
- reuse the same BDI route context links from the multi-keeper inspector panels and focus chips
- publish BDI focus context through the IDE route bridge so drill-downs land in code, telemetry, and keeper views

## Validation
- pnpm exec eslint src/components/ide/inspector-keeper-bdi.ts src/components/ide/inspector-keeper-bdi.test.ts src/components/ide/inspector-multi-keeper-bdi.ts src/components/ide/inspector-multi-keeper-bdi.test.ts
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/inspector-keeper-bdi.test.ts src/components/ide/inspector-multi-keeper-bdi.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD~1 HEAD