### PR TITLE
[dashboard/ide] fix: KeeperPresenceSnapshot typed variant — kill FALLBACK_PRESENCE

### DIFF
--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -13,7 +13,7 @@ import {
   type GoalProgress,
 } from '../goals/goal-helpers'
 import { ideConversationThreadSnapshot } from './ide-context-bridge'
-import { globalPresenceSnapshot, PRESENCE_DOT, type KeeperPresenceSnapshot } from './keeper-presence-store'
+import { globalPresenceSnapshot, PRESENCE_DOT, presenceEntries, type KeeperPresenceSnapshot } from './keeper-presence-store'
 import { cursorOverlaySignal, type KeeperCursorOverlay } from './keeper-cursor-overlay'
 import {
   IdeContextLens,
@@ -798,7 +798,7 @@ function ActivityRow(
 ) {
   const hue = keeperHueIndex(item.keeper_id)
   const dot = `var(--color-keeper-${hue}-glow, var(--k-${hue}))`
-  const entry = presence?.entries.find(e => e.keeper_id === item.keeper_id)
+  const entry = presenceEntries(presence).find(e => e.keeper_id === item.keeper_id)
   const statusDot = entry ? PRESENCE_DOT[entry.status] : null
   const cursor = overlay.cursors.get(item.keeper_id)
   // cursor stream normalizes missing line to 0; only render the focus

--- a/dashboard/src/components/ide/ide-branch-context-panel.test.ts
+++ b/dashboard/src/components/ide/ide-branch-context-panel.test.ts
@@ -8,12 +8,12 @@ import {
   buildIdeBranchContextModel,
   IdeBranchContextPanel,
 } from './ide-branch-context-panel'
-import { globalPresenceSnapshot } from './keeper-presence-store'
+import { globalPresenceSnapshot, LOADING_SNAPSHOT } from './keeper-presence-store'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
 
 afterEach(() => {
   window.location.hash = ''
-  globalPresenceSnapshot.value = null
+  globalPresenceSnapshot.value = LOADING_SNAPSHOT
   cursorOverlaySignal.value = {
     cursors: new Map(),
     heatmap: new Map(),
@@ -160,14 +160,13 @@ describe('IdeBranchContextPanel', () => {
 
   it('matches worktree lanes to keeper presence and cursor state by keeper label', async () => {
     globalPresenceSnapshot.value = {
+      kind: 'live',
       runtime_id: 'runtime',
       branch: 'fix/ide-branch',
       supervisor: 'local',
-      connected: true,
       entries: [{
         keeper_id: 'sangsu',
         workspace_label: 'masc-mcp',
-        branch: 'fix/ide-branch',
         role: 'coder',
         status: 'active',
         last_seen_ms: 100,

--- a/dashboard/src/components/ide/ide-branch-context-panel.ts
+++ b/dashboard/src/components/ide/ide-branch-context-panel.ts
@@ -1,7 +1,12 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
 import { fetchGitGraph, type GitGraphResponse } from '../../api/git-graph'
-import { globalPresenceSnapshot, type KeeperPresenceStatus } from './keeper-presence-store'
+import {
+  globalPresenceSnapshot,
+  presenceEntries,
+  type KeeperPresenceSnapshot,
+  type KeeperPresenceStatus,
+} from './keeper-presence-store'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
 import {
   openIdeContextRouteLink,
@@ -376,14 +381,14 @@ const LANE_STATUS_DOT: Record<KeeperPresenceStatus, { color: string; label: stri
 
 function LaneRow(
   lane: IdeWorktreeLane,
-  presence: { readonly entries: ReadonlyArray<{ keeper_id: string; status: KeeperPresenceStatus }> } | null,
+  presence: KeeperPresenceSnapshot | null,
   overlay: { readonly cursors: Map<string, { keeper_id: string; file_path: string; line: number }> },
 ) {
   // Lane.id is the worktree path; presence/cursor stores key on keeper_id.
   // Prefer the explicit keeperId mapping when the snapshot supplies it,
   // otherwise fall back to id and accept that the lookup may miss.
   const presenceKey = lane.keeperId ?? lane.id
-  const entry = presence?.entries.find(e => e.keeper_id === presenceKey)
+  const entry = presenceEntries(presence).find(e => e.keeper_id === presenceKey)
   const status = entry?.status
   const cursor = overlay.cursors.get(presenceKey)
   const focusFile = cursor?.file_path ? cursor.file_path.split('/').pop() : null

--- a/dashboard/src/components/ide/ide-conversation-rail.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.ts
@@ -27,7 +27,7 @@ import { publishIdeConversationThreads } from './ide-context-bridge'
 import { ideReplayUntilMs, setIdeReplayUntilMs } from './ide-replay-state'
 import { activeIdeFile, focusIdeContextAnchor, normalizeIdeContextFilePath } from './ide-state'
 import { activeKeeperName } from '../../keeper-state'
-import { globalPresenceSnapshot, PRESENCE_DOT, type KeeperPresenceEntry } from './keeper-presence-store'
+import { globalPresenceSnapshot, PRESENCE_DOT, presenceEntries, type KeeperPresenceEntry } from './keeper-presence-store'
 import { cursorOverlaySignal, type KeeperCursorOverlay } from './keeper-cursor-overlay'
 
 export interface BoardPost {
@@ -226,7 +226,7 @@ export function IdeConversationRail() {
   )
 
   const presence = globalPresenceSnapshot.value
-  const entries: ReadonlyArray<KeeperPresenceEntry> = presence?.entries ?? []
+  const entries: ReadonlyArray<KeeperPresenceEntry> = presenceEntries(presence)
   const overlay = cursorOverlaySignal.value
 
   return html`

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -46,6 +46,7 @@ import { cursorOverlaySignal, getKeeperColor } from './keeper-cursor-overlay'
 import { filterTraceEventsByReplay, keeperTraceState, type KeeperTraceEvent } from './keeper-trace-store'
 import {
   globalPresenceSnapshot,
+  presenceEntries,
   type KeeperPresenceSnapshot,
   type KeeperPresenceStatus,
 } from './keeper-presence-store'
@@ -1198,7 +1199,7 @@ function EditorKeeperCursorChip(
   key: string,
 ) {
   const color = getKeeperColor(ac.keeper_id)
-  const status: KeeperPresenceStatus | undefined = presence?.entries.find(
+  const status: KeeperPresenceStatus | undefined = presenceEntries(presence).find(
     e => e.keeper_id === ac.keeper_id,
   )?.status
   const isActive = status === 'active'

--- a/dashboard/src/components/ide/ide-interject.ts
+++ b/dashboard/src/components/ide/ide-interject.ts
@@ -13,7 +13,7 @@ import {
   routeLinksForContext,
   type IdeContextRouteLink,
 } from './ide-context-lens'
-import { globalPresenceSnapshot, type KeeperPresenceStatus } from './keeper-presence-store'
+import { globalPresenceSnapshot, presenceEntries, type KeeperPresenceStatus } from './keeper-presence-store'
 import { cursorOverlaySignal, getKeeperColor, type KeeperCursor } from './keeper-cursor-overlay'
 
 // The input and button states flow through the same store/dispatch boundary
@@ -79,7 +79,7 @@ export const IdeInterject: FunctionComponent<IdeInterjectProps> = ({ keeperName 
   // matches the (cased) interject keeper id.
   const keeperIdNorm = keeperId.trim().toLowerCase()
   const presenceEntry = keeperIdNorm
-    ? presence?.entries.find(e => e.keeper_id.trim().toLowerCase() === keeperIdNorm) ?? null
+    ? presenceEntries(presence).find(e => e.keeper_id.trim().toLowerCase() === keeperIdNorm) ?? null
     : null
   const cursor = keeperId
     ? resolveCursor(keeperId, overlay.cursors)

--- a/dashboard/src/components/ide/ide-persistence-panel.ts
+++ b/dashboard/src/components/ide/ide-persistence-panel.ts
@@ -11,7 +11,7 @@ import { keepers } from '../../store'
 import type { Keeper } from '../../types'
 import { MemoryGraph } from '../common/memory-graph'
 import { PersistenceStatus, type PersistenceState } from '../common/persistence-status'
-import { globalPresenceSnapshot, PRESENCE_DOT, type KeeperPresenceEntry } from './keeper-presence-store'
+import { globalPresenceSnapshot, PRESENCE_DOT, presenceEntries, type KeeperPresenceEntry } from './keeper-presence-store'
 import { cursorOverlaySignal, type KeeperCursor } from './keeper-cursor-overlay'
 import {
   openIdeContextRouteLink,
@@ -246,7 +246,7 @@ export function IdePersistencePanel({
   const keeper = findKeeper(keeperRows, keeperName)
   const presence = useSignalValue(globalPresenceSnapshot)
   const overlay = useSignalValue(cursorOverlaySignal)
-  const entries: ReadonlyArray<KeeperPresenceEntry> = presence?.entries ?? []
+  const entries: ReadonlyArray<KeeperPresenceEntry> = presenceEntries(presence)
   const entry = keeperName ? entries.find(e => e.keeper_id === keeperName) : null
   const statusDot = entry ? PRESENCE_DOT[entry.status] : null
   const cursor = keeperName ? overlay.cursors.get(keeperName) : undefined

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -3,21 +3,15 @@ import { useEffect, useMemo, useState } from 'preact/hooks'
 import { KeeperBadge } from '../keeper-badge'
 import {
   createKeeperPresenceStore,
+  disconnectedSnapshot,
   globalPresenceSnapshot,
+  LOADING_SNAPSHOT,
   type KeeperPresenceEntry,
   type KeeperPresenceSnapshot,
 } from './keeper-presence-store'
 import { cursorOverlaySignal, type KeeperCursor } from './keeper-cursor-overlay'
 import { focusIdeContextAnchor, type IdeContextFocus } from './ide-state'
 import { routeLinksForContext } from './ide-context-lens'
-
-const FALLBACK_PRESENCE: KeeperPresenceSnapshot = {
-  runtime_id: 'local',
-  branch: 'main',
-  supervisor: 'local',
-  connected: false,
-  entries: [],
-}
 
 interface ApiAgent {
   readonly name: string
@@ -74,16 +68,19 @@ function agentsToPresence(
   status: ApiStatus,
   worktrees: ReadonlyArray<WorktreeEntry>,
 ): KeeperPresenceSnapshot {
+  if (status.cluster === undefined || status.cluster.trim() === '') {
+    return disconnectedSnapshot('runtime_unknown')
+  }
+  if (agents.length === 0) {
+    return disconnectedSnapshot('no_agents')
+  }
   const now = Date.now()
   return {
-    runtime_id: status.cluster ?? 'local',
-    branch: status.project ?? 'main',
-    supervisor: 'local',
-    connected: agents.length > 0,
+    kind: 'live',
+    runtime_id: status.cluster,
     entries: agents.map((agent, idx) => ({
       keeper_id: agent.name,
       workspace_label: workspaceLabelForAgent(agent.name, worktrees),
-      branch: status.project ?? 'main',
       role: 'agent',
       status: mapAgentStatus(agent.status),
       last_seen_ms: now - idx * 1000,
@@ -144,11 +141,6 @@ interface PresenceData {
   readonly worktrees: ReadonlyArray<WorktreeEntry>
 }
 
-const FALLBACK_DATA: PresenceData = {
-  snapshot: FALLBACK_PRESENCE,
-  worktrees: [],
-}
-
 async function fetchPresence(): Promise<PresenceData> {
   try {
     const [agentsRes, statusRes, worktrees] = await Promise.all([
@@ -156,20 +148,46 @@ async function fetchPresence(): Promise<PresenceData> {
       fetch('/api/v1/status'),
       fetchWorktreeEntries(),
     ])
-    if (!agentsRes.ok || !statusRes.ok) return { snapshot: FALLBACK_PRESENCE, worktrees }
+    if (!agentsRes.ok || !statusRes.ok) {
+      return { snapshot: disconnectedSnapshot('api_unavailable'), worktrees }
+    }
     const agentsData = await agentsRes.json()
     const statusData = await statusRes.json()
     const agents: ApiAgent[] = Array.isArray(agentsData.agents) ? agentsData.agents : []
-    if (agents.length === 0) return { snapshot: FALLBACK_PRESENCE, worktrees }
     const snapshot = agentsToPresence(agents, statusData as ApiStatus, worktrees)
     return { snapshot, worktrees }
   } catch {
-    return FALLBACK_DATA
+    return { snapshot: disconnectedSnapshot('fetch_failed'), worktrees: [] }
   }
 }
 
+function presenceHeader(snap: KeeperPresenceSnapshot) {
+  if (snap.kind === 'loading') {
+    return html`
+      <span style=${{ color: 'var(--color-fg-disabled)' }} aria-label="presence loading">○</span>
+      <span style=${{ fontStyle: 'italic' }}>loading…</span>
+    `
+  }
+  if (snap.kind === 'disconnected') {
+    return html`
+      <span style=${{ color: 'var(--color-status-err)' }} aria-label=${`presence disconnected: ${snap.reason}`}>○</span>
+      <span style=${{ fontStyle: 'italic' }}>disconnected (${snap.reason})</span>
+    `
+  }
+  const segments = [snap.runtime_id]
+  if (snap.branch !== undefined) segments.push(snap.branch)
+  if (snap.supervisor !== undefined) segments.push(snap.supervisor)
+  return html`
+    <span style=${{ color: 'var(--color-status-ok)' }} aria-label="presence live">●</span>
+    ${segments.map((seg, idx) => html`
+      ${idx > 0 ? html`<span>/</span>` : null}
+      <span>${seg}</span>
+    `)}
+  `
+}
+
 export function IdePresenceStrip() {
-  const presenceStore = useMemo(() => createKeeperPresenceStore(FALLBACK_PRESENCE), [])
+  const presenceStore = useMemo(() => createKeeperPresenceStore(LOADING_SNAPSHOT), [])
   const [, forceRender] = useState(0)
   const [worktrees, setWorktrees] = useState<ReadonlyArray<WorktreeEntry>>([])
 
@@ -186,8 +204,7 @@ export function IdePresenceStrip() {
 
   useEffect(() => {
     const unsub = globalPresenceSnapshot.subscribe(() => {
-      const snap = globalPresenceSnapshot.value
-      if (snap !== null) presenceStore.seed(snap)
+      presenceStore.seed(globalPresenceSnapshot.value)
     })
     return unsub
   }, [presenceStore])
@@ -217,12 +234,7 @@ export function IdePresenceStrip() {
         color: 'var(--color-fg-muted)',
       }}
     >
-      <span style=${{ color: current.connected ? 'var(--color-status-ok)' : 'var(--color-fg-disabled)' }}>●</span>
-      <span>${current.runtime_id}</span>
-      <span>/</span>
-      <span>${current.branch}</span>
-      <span>/</span>
-      <span>${current.supervisor}</span>
+      ${presenceHeader(current)}
       <ul
         style=${{
           display: 'inline-flex',

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -617,7 +617,6 @@ describe('IdeShell', () => {
 
     expect(container.textContent).toContain('BRANCH GRAPH')
     await waitFor(() => expect(container.textContent).toContain('masc-mcp'))
-    expect(container.textContent).toContain('main')
   })
 
   it('keeps the right diagnostics bounded above the primary conversation rail', () => {

--- a/dashboard/src/components/ide/inspector-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.ts
@@ -5,7 +5,7 @@ import { activeKeeperName } from '../../keeper-state'
 import { bridgeBdiSnapshotsToTrace } from './bdi-snapshot-trace-bridge'
 import { asBoolean, asNumber, asString, isRecord, toIsoTimestamp } from '../common/normalize'
 import { clearPins, headPinnedKeeper, pinKeeper } from './multi-keeper-pin-store'
-import { globalPresenceSnapshot, PRESENCE_DOT, type KeeperPresenceEntry } from './keeper-presence-store'
+import { globalPresenceSnapshot, PRESENCE_DOT, presenceEntries, type KeeperPresenceEntry } from './keeper-presence-store'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
 // Imported from `./ide-state` rather than `./ide-shell` to avoid the
 // circular dependency `ide-shell -> inspector-keeper-bdi -> ide-shell`
@@ -262,7 +262,7 @@ export function InspectorKeeperBDI({
   const tokenRows = snapshot?.recent_token_spend ?? []
   const lastTool = snapshot?.last_tool_call ?? null
   const presence = globalPresenceSnapshot.value
-  const entries: ReadonlyArray<KeeperPresenceEntry> = presence?.entries ?? []
+  const entries: ReadonlyArray<KeeperPresenceEntry> = presenceEntries(presence)
   const entry = keeperName ? entries.find(e => e.keeper_id === keeperName) : null
   const statusDot = entry ? PRESENCE_DOT[entry.status] : null
 

--- a/dashboard/src/components/ide/inspector-multi-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-multi-keeper-bdi.ts
@@ -5,7 +5,7 @@ import {
   KeeperBdiSnapshot,
   normalizeKeeperBdiSnapshot,
 } from './inspector-keeper-bdi'
-import { globalPresenceSnapshot, PRESENCE_DOT, type KeeperPresenceEntry, type KeeperPresenceSnapshot } from './keeper-presence-store'
+import { globalPresenceSnapshot, PRESENCE_DOT, presenceEntries, type KeeperPresenceEntry, type KeeperPresenceSnapshot } from './keeper-presence-store'
 import { cursorOverlaySignal, type KeeperCursorOverlay } from './keeper-cursor-overlay'
 import { useSignalValue } from './use-signal-value'
 import { activeIdeFile } from './ide-state'
@@ -253,7 +253,7 @@ function KeeperPanel({ entry, slot, compact, focused, dropIdx, presence, overlay
   const lastTool = snapshot?.last_tool_call ?? null
   const dragHandlers = buildDragHandlers(entry.keeperName, dropIdx)
   const cursor = overlay.cursors.get(entry.keeperName)
-  const pEntries: ReadonlyArray<KeeperPresenceEntry> = presence?.entries ?? []
+  const pEntries: ReadonlyArray<KeeperPresenceEntry> = presenceEntries(presence)
   const pEntry = pEntries.find(e => e.keeper_id === entry.keeperName)
   const statusDot = pEntry ? PRESENCE_DOT[pEntry.status] : null
   const focusLabel = cursor && cursor.file_path && cursor.line >= 1
@@ -381,7 +381,7 @@ function KeeperChip({ entry, slot, dropIdx, presence, overlay, onFocus, onUnpin 
   const tokens = slot.snapshot?.recent_token_spend?.[0]?.total_tokens ?? null
   const dragHandlers = buildDragHandlers(entry.keeperName, dropIdx)
   const cursor = overlay.cursors.get(entry.keeperName)
-  const pEntries: ReadonlyArray<KeeperPresenceEntry> = presence?.entries ?? []
+  const pEntries: ReadonlyArray<KeeperPresenceEntry> = presenceEntries(presence)
   const pEntry = pEntries.find(e => e.keeper_id === entry.keeperName)
   const statusDot = pEntry ? PRESENCE_DOT[pEntry.status] : null
   const focusLabel = cursor && cursor.file_path && cursor.line >= 1

--- a/dashboard/src/components/ide/keeper-presence-store.test.ts
+++ b/dashboard/src/components/ide/keeper-presence-store.test.ts
@@ -5,15 +5,14 @@ import {
 } from './keeper-presence-store'
 
 const sample: KeeperPresenceSnapshot = {
+  kind: 'live',
   runtime_id: 'runtime',
   branch: 'main',
   supervisor: 'local',
-  connected: true,
   entries: [
     {
       keeper_id: 'idle-keeper',
       workspace_label: 'wt-idle',
-      branch: 'main',
       role: 'observer',
       status: 'idle',
       last_seen_ms: 1000,
@@ -21,7 +20,6 @@ const sample: KeeperPresenceSnapshot = {
     {
       keeper_id: 'nick0cave',
       workspace_label: 'dkr-a1',
-      branch: 'main',
       role: 'driver',
       status: 'active',
       last_seen_ms: 2000,
@@ -34,10 +32,10 @@ describe('createKeeperPresenceStore', () => {
     const store = createKeeperPresenceStore(sample)
 
     expect(store.snapshot()).toMatchObject({
+      kind: 'live',
       runtime_id: 'runtime',
       branch: 'main',
       supervisor: 'local',
-      connected: true,
     })
     expect(store.entries().map(entry => entry.keeper_id)).toEqual(['nick0cave', 'idle-keeper'])
     expect(store.activeEntries().map(entry => entry.keeper_id)).toEqual(['nick0cave'])

--- a/dashboard/src/components/ide/keeper-presence-store.ts
+++ b/dashboard/src/components/ide/keeper-presence-store.ts
@@ -1,6 +1,33 @@
 import { signal } from '@preact/signals'
 
-export const globalPresenceSnapshot = signal<KeeperPresenceSnapshot | null>(null)
+export type KeeperPresenceStatus = 'active' | 'idle' | 'blocked'
+
+export interface KeeperPresenceEntry {
+  readonly keeper_id: string
+  readonly workspace_label: string
+  readonly role: string
+  readonly status: KeeperPresenceStatus
+  readonly last_seen_ms: number
+}
+
+export type KeeperPresenceSnapshot =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'disconnected'; readonly reason: string }
+  | {
+      readonly kind: 'live'
+      readonly runtime_id: string
+      readonly branch?: string
+      readonly supervisor?: string
+      readonly entries: ReadonlyArray<KeeperPresenceEntry>
+    }
+
+export const LOADING_SNAPSHOT: KeeperPresenceSnapshot = Object.freeze({ kind: 'loading' })
+
+export function disconnectedSnapshot(reason: string): KeeperPresenceSnapshot {
+  return { kind: 'disconnected', reason }
+}
+
+export const globalPresenceSnapshot = signal<KeeperPresenceSnapshot>(LOADING_SNAPSHOT)
 
 export function updateKeeperPresenceFromSSE(snapshot: unknown): boolean {
   const normalized = normalizeSnapshot(snapshot)
@@ -9,23 +36,8 @@ export function updateKeeperPresenceFromSSE(snapshot: unknown): boolean {
   return true
 }
 
-export type KeeperPresenceStatus = 'active' | 'idle' | 'blocked'
-
-export interface KeeperPresenceEntry {
-  readonly keeper_id: string
-  readonly workspace_label: string
-  readonly branch: string
-  readonly role: string
-  readonly status: KeeperPresenceStatus
-  readonly last_seen_ms: number
-}
-
-export interface KeeperPresenceSnapshot {
-  readonly runtime_id: string
-  readonly branch: string
-  readonly supervisor: string
-  readonly connected: boolean
-  readonly entries: ReadonlyArray<KeeperPresenceEntry>
+export function setGlobalPresence(snapshot: KeeperPresenceSnapshot): void {
+  globalPresenceSnapshot.value = snapshot
 }
 
 export interface KeeperPresenceStore {
@@ -37,14 +49,6 @@ export interface KeeperPresenceStore {
   readonly reset: () => void
   readonly subscribe: (listener: () => void) => () => void
 }
-
-const EMPTY_SNAPSHOT: KeeperPresenceSnapshot = Object.freeze({
-  runtime_id: 'runtime',
-  branch: 'main',
-  supervisor: 'local',
-  connected: false,
-  entries: [],
-})
 
 const STATUS_ORDER: Record<KeeperPresenceStatus, number> = {
   active: 0,
@@ -60,12 +64,27 @@ export const PRESENCE_DOT: Record<KeeperPresenceStatus, { readonly color: string
 
 const VALID_STATUS = new Set<string>(['active', 'idle', 'blocked'])
 
+function entriesOf(snap: KeeperPresenceSnapshot): ReadonlyArray<KeeperPresenceEntry> {
+  return snap.kind === 'live' ? snap.entries : []
+}
+
+export function presenceEntries(
+  snap: KeeperPresenceSnapshot | null | undefined,
+): ReadonlyArray<KeeperPresenceEntry> {
+  if (snap === null || snap === undefined) return []
+  return entriesOf(snap)
+}
+
 export function createKeeperPresenceStore(
-  initialSnapshot: unknown = EMPTY_SNAPSHOT,
+  initialSnapshot: KeeperPresenceSnapshot = LOADING_SNAPSHOT,
 ): KeeperPresenceStore {
-  const snapshotSignal = signal<KeeperPresenceSnapshot>(EMPTY_SNAPSHOT)
+  const snapshotSignal = signal<KeeperPresenceSnapshot>(withSortedEntries(initialSnapshot))
 
   const seed = (snapshot: unknown): boolean => {
+    if (isPresenceSnapshot(snapshot)) {
+      snapshotSignal.value = withSortedEntries(snapshot)
+      return true
+    }
     const normalized = normalizeSnapshot(snapshot)
     if (normalized === null) return false
     snapshotSignal.value = normalized
@@ -73,7 +92,7 @@ export function createKeeperPresenceStore(
   }
 
   const reset = (): void => {
-    snapshotSignal.value = EMPTY_SNAPSHOT
+    snapshotSignal.value = LOADING_SNAPSHOT
   }
 
   const subscribe = (listener: () => void): (() => void) => {
@@ -87,15 +106,13 @@ export function createKeeperPresenceStore(
     })
   }
 
-  seed(initialSnapshot)
-
   return {
     seed,
     snapshot: () => snapshotSignal.value,
-    entries: () => snapshotSignal.value.entries,
-    activeEntries: () => snapshotSignal.value.entries.filter(entry => entry.status === 'active'),
+    entries: () => entriesOf(snapshotSignal.value),
+    activeEntries: () => entriesOf(snapshotSignal.value).filter(entry => entry.status === 'active'),
     entryForKeeper: (keeperId: string) =>
-      snapshotSignal.value.entries.find(entry => entry.keeper_id === keeperId) ?? null,
+      entriesOf(snapshotSignal.value).find(entry => entry.keeper_id === keeperId) ?? null,
     reset,
     subscribe,
   }
@@ -103,12 +120,21 @@ export function createKeeperPresenceStore(
 
 type UnknownRecord = Record<string, unknown>
 
+function isPresenceSnapshot(value: unknown): value is KeeperPresenceSnapshot {
+  if (!isRecord(value)) return false
+  const k = value['kind']
+  return k === 'loading' || k === 'disconnected' || k === 'live'
+}
+
+function withSortedEntries(snap: KeeperPresenceSnapshot): KeeperPresenceSnapshot {
+  if (snap.kind !== 'live') return snap
+  const sorted = [...snap.entries].sort(compareEntries)
+  return { ...snap, entries: sorted }
+}
+
 function normalizeSnapshot(value: unknown): KeeperPresenceSnapshot | null {
   if (!isRecord(value)) return null
   if (!hasNonEmptyString(value, 'runtime_id')) return null
-  if (!hasNonEmptyString(value, 'branch')) return null
-  if (!hasNonEmptyString(value, 'supervisor')) return null
-  if (typeof value.connected !== 'boolean') return null
   if (!Array.isArray(value.entries)) return null
 
   const entries = value.entries
@@ -116,31 +142,33 @@ function normalizeSnapshot(value: unknown): KeeperPresenceSnapshot | null {
     .filter((entry): entry is KeeperPresenceEntry => entry !== null)
     .sort(compareEntries)
 
-  return {
-    runtime_id: value.runtime_id as string,
-    branch: value.branch as string,
-    supervisor: value.supervisor as string,
-    connected: value.connected as boolean,
+  const branch = hasNonEmptyString(value, 'branch') ? (value['branch'] as string) : undefined
+  const supervisor = hasNonEmptyString(value, 'supervisor') ? (value['supervisor'] as string) : undefined
+
+  const live: KeeperPresenceSnapshot = {
+    kind: 'live',
+    runtime_id: value['runtime_id'] as string,
     entries,
+    ...(branch !== undefined ? { branch } : {}),
+    ...(supervisor !== undefined ? { supervisor } : {}),
   }
+  return live
 }
 
 function normalizeEntry(value: unknown): KeeperPresenceEntry | null {
   if (!isRecord(value)) return null
   if (!hasNonEmptyString(value, 'keeper_id')) return null
   if (!hasNonEmptyString(value, 'workspace_label')) return null
-  if (!hasNonEmptyString(value, 'branch')) return null
   if (!hasNonEmptyString(value, 'role')) return null
-  if (!isKeeperPresenceStatus(value.status)) return null
-  if (!Number.isFinite(value.last_seen_ms)) return null
+  if (!isKeeperPresenceStatus(value['status'])) return null
+  if (!Number.isFinite(value['last_seen_ms'])) return null
 
   return {
-    keeper_id: value.keeper_id as string,
-    workspace_label: value.workspace_label as string,
-    branch: value.branch as string,
-    role: value.role as string,
-    status: value.status as KeeperPresenceStatus,
-    last_seen_ms: value.last_seen_ms as unknown as number,
+    keeper_id: value['keeper_id'] as string,
+    workspace_label: value['workspace_label'] as string,
+    role: value['role'] as string,
+    status: value['status'] as KeeperPresenceStatus,
+    last_seen_ms: value['last_seen_ms'] as number,
   }
 }
 
@@ -155,7 +183,7 @@ function isRecord(value: unknown): value is UnknownRecord {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-function hasNonEmptyString(record: UnknownRecord, key: string): record is UnknownRecord & Record<typeof key, string> {
+function hasNonEmptyString(record: UnknownRecord, key: string): boolean {
   const value = record[key]
   return typeof value === 'string' && value.trim() !== ''
 }


### PR DESCRIPTION
## Summary

`KeeperPresenceSnapshot`을 discriminated union으로 reshape하여 `FALLBACK_PRESENCE` (`local/main/local`) 하드코딩 박멸 + fallback indistinguishable-from-real 시각적 분리.

Closes #15295.

## 변경 핵심

### Before (silent fallback)
```typescript
interface KeeperPresenceSnapshot {
  runtime_id: string  // status.cluster ?? 'local'
  branch: string      // status.project ?? 'main'  ← project ≠ branch
  supervisor: string  // unconditional 'local'
  connected: boolean
  entries: ...
}
const FALLBACK_PRESENCE = { runtime_id: 'local', branch: 'main', supervisor: 'local', ... }
const EMPTY_SNAPSHOT    = { runtime_id: 'runtime', branch: 'main', supervisor: 'local', ... }
```

### After (typed variant)
```typescript
type KeeperPresenceSnapshot =
  | { kind: 'loading' }
  | { kind: 'disconnected'; reason: string }
  | { kind: 'live'; runtime_id; branch?; supervisor?; entries: ... }
```

- **`FALLBACK_PRESENCE` / `EMPTY_SNAPSHOT` 완전 제거** (transitional 없음, root-fix)
- **`connected: boolean`** dead representation 제거 — `kind === 'live'`가 표현
- **`KeeperPresenceEntry.branch`** caller 0건 → 제거 (legacy 박멸)
- **`branch`/`supervisor`** server 없으면 `undefined` → UI segment skip (가짜 'main'/'local' 미출력)
- **`agentsToPresence`** silent fallback 3건 → 명시적 `disconnected` reason (`no_agents` / `runtime_unknown` / `api_unavailable` / `fetch_failed`)
- **UI render** kind별 분기: `loading…` / `disconnected (reason)` / `runtime_id [/ branch] [/ supervisor]` + 구분 status dot

### Caller 영향 (13 file)

| Surface | Files |
|---|---|
| Types + store | `keeper-presence-store.ts` + test |
| Strip UI (FALLBACK 제거) | `ide-presence-strip.ts` |
| `presence?.entries` → `presenceEntries(presence)` helper | `ide-activity-panel`, `ide-editor`, `ide-conversation-rail`, `ide-interject`, `ide-persistence-panel`, `inspector-keeper-bdi`, `inspector-multi-keeper-bdi` |
| Lane structural type → typed snapshot | `ide-branch-context-panel.ts` + test |
| Test expectation (FALLBACK 'main' 부수효과 제거) | `ide-shell.test.ts` |

### 검증

- `pnpm typecheck`: green
- `pnpm build`: green (12.32s)
- `pnpm test`: **3 pre-existing fails** (origin/main HEAD에서도 동일 fail):
  - `dashboard-shell.test.ts` solo mode 1건
  - `widget-solo.test.ts` 2건
  - 모두 presence 변경과 무관 (baseline 측정 완료, stash → origin/main test → 동일 fail 확인)
- 변경 영역 7474+ test PASS

## Out of scope (별도 issue)

- LSP toggle UI 부재 (`IDE_LAYERS`/`STATUSBAR_LAYER_PRIORITY`에 LSP 누락) — Issue B 예정
- server-side `ApiStatus.branch` 필드 추가 (project ≠ branch 개념 충돌의 server-side 해법) — RFC 영역

## 주의 (사용자 절대 원칙)

- `feedback_hardcoding_and_legacy_zero_tolerance` 준수: 하드코딩 제거 + legacy 동시 삭제, transitional/cleanup PR 분리 거부
- `reference_masc_mcp_draft_auto_merge_guard`: Draft 유지, Ready 전환은 사용자 액션
- agent 자동 PR 생성 금지 (autocoder 등)

RFC-WAIVED: dashboard-only UI refactor, no credential/identity/operator surface touched.

## Test plan

- [ ] CodeRabbit / 사람 리뷰 코멘트 확인 후 대응
- [ ] required CI checks green 확인
- [ ] dashboard 로컬 dev 실행: presence 상태 시각 확인 (loading / disconnected / live 3가지)
- [ ] 사용자 confirm 후 Ready 전환 + `human-approved-ready` 라벨 부착

🤖 Generated with [Claude Code](https://claude.com/claude-code)
