### PR TITLE
fix(cascade): Ollama IPv6 fix, remove Claude CLI & kimi_cli, add openai_compat cloud providers

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -55,19 +55,6 @@ key = "GEMINI_API_KEY"
 [providers.gemini_cli.capabilities]
 tolerates-bound-actor-fallback = true
 
-[providers.kimi_cli]
-display-name = "Moonshot Kimi CLI"
-protocol = "kimi-cli"
-command = "kimi"
-is-non-interactive = true
-
-[providers.kimi_cli.credentials]
-type = "env"
-key = "MOONSHOT_API_KEY"
-
-[providers.kimi_cli.capabilities]
-supports-runtime-mcp-http-headers = true
-tolerates-bound-actor-fallback = true
 
 [providers.glm-coding]
 display-name = "Zhipu GLM Coding"
@@ -91,6 +78,15 @@ endpoint = "http://127.0.0.1:11434"
 # Local Ollama is a viable bound-actor fallback target in catalogs
 # that include Codex CLI — its HTTP surface accepts per-keeper auth
 # headers natively. All other capability flags default to false.
+
+[providers.openai_compat]
+display-name = "OpenAI-Compatible Cloud"
+protocol = "openai-http"
+endpoint = "https://ollama.com/v1"
+
+[providers.openai_compat.credentials]
+type = "env"
+key = "OLLAMA_CLOUD_API_KEY"
 tolerates-bound-actor-fallback = true
 
 # ── Layer 2: Models ────────────────────────────────────────────
@@ -111,22 +107,6 @@ supports-image-input = true
 supports-native-streaming = true
 supports-caching = true
 supports-response-format-json = true
-
-[models.kimi-coding]
-api-name = "kimi-for-coding"
-max-context = 128000
-tools-support = true
-streaming = true
-
-# Capabilities mirror OAS kimi_capabilities. Only max-output-tokens
-# is overridden from defaults here; other capability fields
-# (supports_parallel_tool_calls, supports_multimodal_input,
-# supports_streaming, supports_prompt_caching) inherit default
-# values from cascade_model_capabilities. M2 cutover preserves this
-# asymmetry — if kimi production actually streams natively this is
-# an OAS bug to rectify upstream, not here.
-[models.kimi-coding.capabilities]
-max-output-tokens = 32768
 
 [models.gemini-flash]
 api-name = "gemini-3-flash-preview"
@@ -585,10 +565,6 @@ supports-native-streaming = true
 is-default = true
 max-concurrent = 1
 
-[kimi_cli.kimi-coding]
-is-default = true
-max-concurrent = 1
-
 
 [gemini_cli.gemini-flash]
 is-default = true
@@ -606,6 +582,18 @@ max-concurrent = 2
 is-default = false
 max-concurrent = 2
 
+[openai_compat.deepseek-v4-pro]
+is-default = true
+max-concurrent = 4
+
+[openai_compat.deepseek-v4-flash]
+is-default = false
+max-concurrent = 4
+
+[openai_compat.qwen3-5]
+is-default = false
+max-concurrent = 4
+
 # ── Layer 4: Aliases (per-use overrides) ───────────────────────
 #
 # Aliases give logical names to (provider, model) pairs with
@@ -622,8 +610,15 @@ temperature = 0.1
 [codex_cli.codex-spark.for-keeper-turn]
 max-output = 32768
 
-[kimi_cli.kimi-coding.for-keeper-turn]
+[openai_compat.deepseek-v4-pro.for-keeper-turn]
 max-output = 32768
+
+[openai_compat.deepseek-v4-flash.for-keeper-turn]
+max-output = 32768
+
+[openai_compat.qwen3-5.for-keeper-turn]
+max-output = 32768
+
 
 # ── Layer 5: Tiers ─────────────────────────────────────────────
 
@@ -631,14 +626,16 @@ max-output = 32768
 # Canonical keeper/workflow tier.
 members = [
   "codex_cli.codex-spark.for-keeper-turn",
-  "kimi_cli.kimi-coding.for-keeper-turn",
+  "glm-coding.glm-flashx",
+  "openai_compat.deepseek-v4-pro.for-keeper-turn",
+  "openai_compat.deepseek-v4-flash.for-keeper-turn",
 ]
 strategy = "failover"
 
 [tier.keeper_diverse]
 # Fallback tier for contract violation retry. Different model
 # composition from primary to break correlated failure.
-members = ["gemini_cli.gemini-flash", "codex_cli.codex-spark"]
+members = ["gemini_cli.gemini-flash", "codex_cli.codex-spark", "openai_compat.qwen3-5.for-keeper-turn"]
 strategy = "failover"
 
 [tier.scoring]
@@ -653,7 +650,7 @@ strategy = "failover"
 [tier.governance]
 # System-only baseline for governance / judge calls.
 keeper-assignable = false
-members = ["kimi_cli.kimi-coding.for-keeper-turn"]
+members = ["glm-coding.glm-flashx", "openai_compat.deepseek-v4-flash.for-keeper-turn"]
 strategy = "failover"
 
 [tier.tier_small]
@@ -664,14 +661,14 @@ strategy = "failover"
 
 [tier.tier_medium]
 # 9B-class cloud-coding models for moderate tasks.
-members = ["glm-coding.glm-flashx"]
+members = ["glm-coding.glm-flashx", "openai_compat.deepseek-v4-flash.for-keeper-turn"]
 strategy = "failover"
 
 [tier.__safe_lane]
 # System-only baseline tier (RFC-0027 PR-4). Last-resort fallback
 # target that satisfies every capability profile. Not keeper-assignable.
 keeper-assignable = false
-members = ["kimi_cli.kimi-coding.for-keeper-turn"]
+members = ["glm-coding.glm-flashx", "openai_compat.deepseek-v4-flash.for-keeper-turn"]
 strategy = "failover"
 
 [tier.local_recovery]

--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -104,7 +104,7 @@ key = "ZAI_API_KEY"
 [providers.ollama]
 display-name = "Ollama Local"
 protocol = "ollama-http"
-endpoint = "http://localhost:11434"
+endpoint = "http://127.0.0.1:11434"
 
 [providers.ollama.capabilities]
 # Local Ollama is a viable bound-actor fallback target in catalogs

--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -10,25 +10,6 @@
 
 # ── Layer 1: Providers ──────────────────────────────────────────
 
-[providers.claude_code]
-display-name = "Anthropic Claude Code CLI"
-protocol = "anthropic-cli"
-command = "claude"
-is-non-interactive = true
-
-[providers.claude_code.credentials]
-type = "env"
-key = "ANTHROPIC_API_KEY"
-
-# Behavioral capabilities — RFC-0058 §2.4 Phase 5.1.
-# Replaces the OCaml `tool_policy` record and per-kind matches in
-# cascade_transport / provider_tool_support / keeper_usage_trust.
-# Field defaults (when omitted) are all false / [] / None.
-[providers.claude_code.capabilities]
-supports-runtime-mcp-http-headers = true
-uses-anthropic-caching = true
-max-turns-per-attempt = 30
-tolerates-bound-actor-fallback = true
 
 [providers.codex_cli]
 display-name = "OpenAI Codex CLI"
@@ -147,39 +128,6 @@ streaming = true
 [models.kimi-coding.capabilities]
 max-output-tokens = 32768
 
-[models.sonnet]
-api-name = "claude-sonnet-4-6"
-max-context = 200000
-tools-support = true
-thinking-support = true
-max-thinking-budget = 16000
-streaming = true
-
-# Capabilities mirror OAS for_model_id_static claude-sonnet-4 family
-# (anthropic_capabilities + max-output override). Anthropic prompt
-# caching is part of the standard Messages API.
-[models.sonnet.capabilities]
-max-output-tokens = 64000
-supports-parallel-tool-calls = true
-supports-image-input = true
-supports-native-streaming = true
-supports-caching = true
-
-[models.haiku]
-api-name = "claude-haiku-4-5-20251001"
-max-context = 200000
-tools-support = true
-streaming = true
-
-# Capabilities mirror OAS for_model_id_static claude-haiku-4 family
-# (anthropic_capabilities + max-output override).
-[models.haiku.capabilities]
-max-output-tokens = 8192
-supports-parallel-tool-calls = true
-supports-image-input = true
-supports-native-streaming = true
-supports-caching = true
-
 [models.gemini-flash]
 api-name = "gemini-3-flash-preview"
 max-context = 128000
@@ -256,29 +204,6 @@ supports-response-format-json = true
 # the responsibility of existing bindings + the 8 production model
 # entries above.
 
-# ── Anthropic family ──────────────────────────────
-
-[models.claude-opus-4]
-api-name = "claude-opus-4"
-match-prefixes = ["claude-opus-4"]
-max-context = 1000000
-tools-support = true
-thinking-support = true
-streaming = true
-
-[models.claude-opus-4.capabilities]
-max-output-tokens = 128000
-supports-parallel-tool-calls = true
-supports-tool-choice = true
-supports-extended-thinking = true
-supports-reasoning-budget = true
-supports-multimodal-inputs = true
-supports-image-input = true
-supports-structured-output = true
-supports-native-streaming = true
-supports-caching = true
-supports-prompt-caching = true
-prompt-cache-alignment = 1024
 supports-top-k = true
 supports-computer-use = true
 
@@ -664,17 +589,6 @@ max-concurrent = 1
 is-default = true
 max-concurrent = 1
 
-[claude_code.sonnet]
-is-default = true
-max-concurrent = 1
-price-input = 3.00
-price-output = 15.00
-
-[claude_code.haiku]
-is-default = false
-max-concurrent = 2
-price-input = 0.80
-price-output = 4.00
 
 [gemini_cli.gemini-flash]
 is-default = true
@@ -699,18 +613,11 @@ max-concurrent = 2
 # rather than raw `<provider>.<model>` pairs — that is how RFC-0058
 # §2.4 keeps vendor/model identifiers out of OCaml source.
 
-[claude_code.haiku.for-scoring]
-max-output = 1024
-temperature = 0.1
 
 [codex_cli.codex-spark.for-scoring]
 max-output = 1024
 temperature = 0.1
 
-[claude_code.haiku.for-governance]
-max-input = 8192
-max-output = 2048
-temperature = 0.1
 
 [codex_cli.codex-spark.for-keeper-turn]
 max-output = 32768
@@ -731,7 +638,7 @@ strategy = "failover"
 [tier.keeper_diverse]
 # Fallback tier for contract violation retry. Different model
 # composition from primary to break correlated failure.
-members = ["claude_code.sonnet", "gemini_cli.gemini-flash", "codex_cli.codex-spark"]
+members = ["gemini_cli.gemini-flash", "codex_cli.codex-spark"]
 strategy = "failover"
 
 [tier.scoring]
@@ -740,14 +647,13 @@ strategy = "failover"
 keeper-assignable = false
 members = [
   "codex_cli.codex-spark.for-scoring",
-  "claude_code.haiku.for-scoring",
 ]
 strategy = "failover"
 
 [tier.governance]
 # System-only baseline for governance / judge calls.
 keeper-assignable = false
-members = ["claude_code.haiku.for-governance"]
+members = ["kimi_cli.kimi-coding.for-keeper-turn"]
 strategy = "failover"
 
 [tier.tier_small]


### PR DESCRIPTION
## Summary

Three fixes in the declarative cascade config (`config/cascade.toml`):

### 1. Ollama endpoint: `localhost` → `127.0.0.1`

macOS resolves `localhost` to `::1` (IPv6 loopback) first in Eio, but Ollama only binds to `127.0.0.1` (IPv4). This caused every Ollama-bound cascade attempt to fail with:

```
Eio.Io Net Connection_failure Refused Unix_error (Connection refused)
connecting to tcp:[::1]:11434
```

### 2. Remove Claude CLI provider and models

Removed `claude_code` provider, `sonnet`/`haiku`/`claude-opus-4` models, and all bindings/aliases. Also removes haiku's `max-output-tokens = 8192` which was capping cascades at 8192 tokens (causing `max_tokens_ceiling_violation` when profiles requested 16384).

### 3. Remove kimi_cli (token exhausted) and add openai_compat cloud providers

Kimi CLI tokens are exhausted. Removed `kimi_cli` provider, model, bindings, and aliases. Added `openai_compat` provider (`https://ollama.com/v1`) with cloud models:
- `deepseek-v4-pro` (primary tier)
- `deepseek-v4-flash` (primary + diverse + governance + safe_lane)
- `qwen3-5` (keeper_diverse tier)

Tier membership updates:
- `tier.primary`: codex_cli → glm-coding → deepseek-v4-pro → deepseek-v4-flash
- `tier.keeper_diverse`: gemini_cli → codex_cli → qwen3-5
- `tier.governance`: glm-coding → deepseek-v4-flash
- `tier.__safe_lane`: glm-coding → deepseek-v4-flash
- `tier.tier_medium`: glm-coding → deepseek-v4-flash

## Test plan

- [ ] Restart MASC server and verify Ollama connects via `127.0.0.1:11434`
- [ ] Confirm no `max_tokens_ceiling_violation` errors
- [ ] Verify cascade fallback with remaining providers (codex_cli, gemini_cli, glm-coding, openai_compat, ollama)
- [ ] Confirm openai_compat cloud models resolve and connect