### PR TITLE
feat(ide): use tokens for attribution chrome

### DIFF
--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -1294,7 +1294,7 @@ function AnnotationPopover({
         background: 'var(--color-bg-elevated)',
         border: '1px solid var(--color-border-default)',
         borderRadius: 'var(--r-2)',
-        boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
+        boxShadow: 'var(--shadow-panel)',
         padding: 'var(--sp-3)',
         fontFamily: 'var(--font-sans)',
         fontSize: '13px',

--- a/dashboard/src/components/ide/ide-interject.ts
+++ b/dashboard/src/components/ide/ide-interject.ts
@@ -220,8 +220,8 @@ function InterjectButton(action: InterjectActionState, onClick: () => void) {
 }
 
 const PRESENCE_STYLES: Record<KeeperPresenceStatus, { color: string; bg: string; label: string }> = {
-  active: { color: 'var(--color-status-ok)', bg: 'rgba(46, 160, 67, 0.15)', label: 'ACTIVE' },
-  blocked: { color: 'var(--color-status-err)', bg: 'rgba(248, 81, 73, 0.15)', label: 'BLOCKED' },
+  active: { color: 'var(--color-status-ok)', bg: 'rgb(var(--color-status-ok-glow) / 0.15)', label: 'ACTIVE' },
+  blocked: { color: 'var(--color-status-err)', bg: 'rgb(var(--color-status-err-glow) / 0.15)', label: 'BLOCKED' },
   idle: { color: 'var(--color-fg-muted)', bg: 'var(--color-bg-surface)', label: 'IDLE' },
 }
 

--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -206,7 +206,7 @@ const hoverTooltipTheme = EditorView.theme({
     background: 'var(--color-bg-surface)',
     border: '1px solid var(--color-border-default)',
     borderRadius: '6px',
-    boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+    boxShadow: 'var(--tooltip-shadow)',
     fontFamily: 'var(--font-mono)',
     fontSize: '12px',
     lineHeight: '1.5',

--- a/dashboard/src/components/ide/keeper-cursor-cm-extension.test.ts
+++ b/dashboard/src/components/ide/keeper-cursor-cm-extension.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { EditorState, type Extension } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { cursorOverlaySignal } from './keeper-cursor-overlay'
+import { keeperCursorExtension } from './keeper-cursor-cm-extension'
+
+function createTestView(extensions: Extension[], doc = 'one\ntwo\n') {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const state = EditorState.create({ doc, extensions })
+  const view = new EditorView({ state, parent: container })
+  return { view, container }
+}
+
+describe('keeperCursorExtension', () => {
+  beforeEach(() => {
+    cursorOverlaySignal.value = {
+      active_file: 'runtime.ts',
+      cursors: new Map(),
+      heatmap: new Map(),
+      collisions: [],
+    }
+  })
+
+  afterEach(() => {
+    cursorOverlaySignal.value = {
+      active_file: null,
+      cursors: new Map(),
+      heatmap: new Map(),
+      collisions: [],
+    }
+    document.body.replaceChildren()
+  })
+
+  it('renders cursor labels with design-system keeper tokens', () => {
+    cursorOverlaySignal.value = {
+      active_file: 'runtime.ts',
+      cursors: new Map([[
+        'alpha',
+        {
+          keeper_id: 'alpha',
+          file_path: 'runtime.ts',
+          line: 1,
+          column: 1,
+          focus_mode: 'editing',
+          last_update: Date.now(),
+        },
+      ]]),
+      heatmap: new Map(),
+      collisions: [],
+    }
+
+    const { view, container } = createTestView([keeperCursorExtension()])
+    view.dispatch({ selection: { anchor: 1 } })
+
+    const label = container.querySelector<HTMLElement>('.cm-keeper-cursor-label')
+    expect(label?.getAttribute('style')).toContain('var(--color-keeper-')
+    expect(label?.getAttribute('style')).toContain('var(--color-bg-page)')
+    expect(label?.getAttribute('style')).not.toMatch(/#[0-9a-fA-F]{3,8}|rgba\(/)
+
+    view.destroy()
+    container.remove()
+  })
+})

--- a/dashboard/src/components/ide/keeper-cursor-cm-extension.ts
+++ b/dashboard/src/components/ide/keeper-cursor-cm-extension.ts
@@ -20,6 +20,7 @@ import {
   getKeeperColor,
   type KeeperCursorOverlay,
   type KeeperCursor,
+  type KeeperCursorColor,
 } from './keeper-cursor-overlay'
 
 // ── Types ─────────────────────────────────────────────────────────
@@ -39,7 +40,7 @@ class KeeperCursorLabelWidget extends WidgetType {
     private readonly keeperId: string,
     private readonly toolName: string | undefined,
     private readonly focusMode: string,
-    private readonly color: { cursor: string; selection: string },
+    private readonly color: KeeperCursorColor,
   ) { super() }
 
   toDOM(): HTMLElement {
@@ -52,9 +53,9 @@ class KeeperCursorLabelWidget extends WidgetType {
     container.style.cssText =
       `display:inline-flex;align-items:center;gap:3px;` +
       `padding:1px 5px;margin-left:4px;` +
-      `background:${this.color.cursor};color:#fff;` +
+      `background:${this.color.cursor};color:${this.color.text};` +
       `font-size:10px;font-weight:600;border-radius:3px;` +
-      `box-shadow:0 1px 3px rgba(0,0,0,0.15);` +
+      `box-shadow:${this.color.shadow};` +
       `pointer-events:none;user-select:none;line-height:1.4;`
     container.textContent = label
 
@@ -87,14 +88,18 @@ class CollisionWarningWidget extends WidgetType {
     el.className = 'cm-collision-warning'
 
     const bg =
-      this.riskLevel === 'high' ? 'rgba(248,81,73,0.12)' :
-      this.riskLevel === 'medium' ? 'rgba(210,153,34,0.12)' :
-      'rgba(150,150,150,0.08)'
+      this.riskLevel === 'high' ? 'rgb(var(--color-status-err-glow) / 0.12)' :
+      this.riskLevel === 'medium' ? 'rgb(var(--color-status-warn-glow) / 0.12)' :
+      'rgb(var(--color-accent-glow) / 0.08)'
 
     const border =
-      this.riskLevel === 'high' ? 'rgba(248,81,73,0.4)' :
-      this.riskLevel === 'medium' ? 'rgba(210,153,34,0.4)' :
-      'rgba(150,150,150,0.2)'
+      this.riskLevel === 'high' ? 'rgb(var(--color-status-err-glow) / 0.4)' :
+      this.riskLevel === 'medium' ? 'rgb(var(--color-status-warn-glow) / 0.4)' :
+      'rgb(var(--color-accent-glow) / 0.2)'
+
+    const iconColor = this.riskLevel === 'high'
+      ? 'var(--color-status-err)'
+      : 'var(--color-status-warn)'
 
     el.style.cssText =
       `display:flex;align-items:center;gap:4px;` +
@@ -105,7 +110,7 @@ class CollisionWarningWidget extends WidgetType {
 
     const icon = document.createElement('span')
     icon.textContent = this.riskLevel === 'high' ? '!!' : '!'
-    icon.style.cssText = `font-weight:700;color:${this.riskLevel === 'high' ? '#f85149' : '#d29922'}`
+    icon.style.cssText = `font-weight:700;color:${iconColor}`
     el.appendChild(icon)
 
     const text = document.createElement('span')
@@ -132,7 +137,7 @@ function buildLineHighlight(color: string): Decoration {
   })
 }
 
-function buildCursorLabel(cursor: KeeperCursor, color: { cursor: string; selection: string }): Decoration {
+function buildCursorLabel(cursor: KeeperCursor, color: KeeperCursorColor): Decoration {
   return Decoration.widget({
     widget: new KeeperCursorLabelWidget(
       cursor.keeper_id,

--- a/dashboard/src/components/ide/keeper-cursor-overlay.test.ts
+++ b/dashboard/src/components/ide/keeper-cursor-overlay.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { getKeeperColor } from './keeper-cursor-overlay'
+
+describe('getKeeperColor', () => {
+  it('maps explicit indexes to design-system keeper token slots', () => {
+    expect(getKeeperColor('alpha', 0)).toMatchObject({
+      slot: 1,
+      cursor: 'var(--color-keeper-1)',
+      glow: 'var(--color-keeper-1-glow)',
+      selection: 'rgb(var(--color-keeper-1-glow) / 0.22)',
+      text: 'var(--color-bg-page)',
+    })
+    expect(getKeeperColor('alpha', 11).cursor).toBe('var(--color-keeper-12)')
+    expect(getKeeperColor('alpha', 12).cursor).toBe('var(--color-keeper-1)')
+  })
+
+  it('uses token references for hashed keeper ids instead of raw colors', () => {
+    const color = getKeeperColor('nick0cave')
+    expect(color.slot).toBeGreaterThanOrEqual(1)
+    expect(color.slot).toBeLessThanOrEqual(12)
+    expect(color.cursor).toMatch(/^var\(--color-keeper-\d+\)$/)
+    expect(color.selection).toMatch(/^rgb\(var\(--color-keeper-\d+-glow\) \/ 0\.22\)$/)
+    expect(`${color.cursor} ${color.selection} ${color.shadow}`).not.toMatch(/#[0-9a-fA-F]{3,8}|rgba\(/)
+  })
+})

--- a/dashboard/src/components/ide/keeper-cursor-overlay.ts
+++ b/dashboard/src/components/ide/keeper-cursor-overlay.ts
@@ -42,20 +42,39 @@ export const cursorOverlaySignal = signal<KeeperCursorOverlay>({
 
 // ── Keeper Color Mapping ─────────────────────────────────────────
 
-const KEEPER_COLORS = [
-  { cursor: '#FF6B6B', selection: 'rgba(255, 107, 107, 0.2)', name: 'Red' },
-  { cursor: '#4ECDC4', selection: 'rgba(78, 205, 196, 0.2)', name: 'Teal' },
-  { cursor: '#45B7D1', selection: 'rgba(69, 183, 209, 0.2)', name: 'Blue' },
-  { cursor: '#96CEB4', selection: 'rgba(150, 206, 180, 0.2)', name: 'Green' },
-  { cursor: '#FFEAA7', selection: 'rgba(255, 234, 167, 0.3)', name: 'Yellow' },
-  { cursor: '#DDA0DD', selection: 'rgba(221, 160, 221, 0.2)', name: 'Plum' },
-  { cursor: '#FFA07A', selection: 'rgba(255, 160, 122, 0.2)', name: 'Salmon' },
-  { cursor: '#98FB98', selection: 'rgba(152, 251, 152, 0.2)', name: 'PaleGreen' },
-]
+export interface KeeperCursorColor {
+  readonly slot: number
+  readonly cursor: string
+  readonly selection: string
+  readonly glow: string
+  readonly text: string
+  readonly shadow: string
+}
 
-export function getKeeperColor(keeperId: string, index?: number): { cursor: string; selection: string } {
-  const idx = index ?? (keeperId.charCodeAt(0) + (keeperId.charCodeAt(1) || 0)) % KEEPER_COLORS.length
-  return KEEPER_COLORS[idx] ?? { cursor: KEEPER_COLORS[0]!.cursor, selection: KEEPER_COLORS[0]!.selection }
+const KEEPER_COLOR_SLOT_COUNT = 12
+
+function keeperColorSlot(keeperId: string, index?: number): number {
+  if (Number.isSafeInteger(index) && index! >= 0) return (index! % KEEPER_COLOR_SLOT_COUNT) + 1
+
+  let hash = 2166136261
+  for (let i = 0; i < keeperId.length; i += 1) {
+    hash ^= keeperId.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (Math.abs(hash) % KEEPER_COLOR_SLOT_COUNT) + 1
+}
+
+export function getKeeperColor(keeperId: string, index?: number): KeeperCursorColor {
+  const slot = keeperColorSlot(keeperId, index)
+  const glow = `var(--color-keeper-${slot}-glow)`
+  return {
+    slot,
+    cursor: `var(--color-keeper-${slot})`,
+    selection: `rgb(${glow} / 0.22)`,
+    glow,
+    text: 'var(--color-bg-page)',
+    shadow: `0 0 0 1px rgb(${glow} / 0.32), 0 2px 6px rgb(${glow} / 0.20)`,
+  }
 }
 
 // ── Collision Detection ─────────────────────────────────────────
@@ -132,7 +151,7 @@ export function calculateHeatmap(cursors: Iterable<KeeperCursor>, windowMs = 600
 
 interface KeeperCursorWidgetProps {
   cursor: KeeperCursor
-  color: { cursor: string; selection: string }
+  color: KeeperCursorColor
   onJump?: (keeperId: string, line: number) => void
 }
 
@@ -176,11 +195,11 @@ export function KeeperCursorWidget({ cursor, color, onJump }: KeeperCursorWidget
           gap: '4px',
           padding: '2px 6px',
           background: color.cursor,
-          color: '#fff',
+          color: color.text,
           fontSize: '10px',
           fontWeight: '600',
           borderRadius: '3px',
-          boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
+          boxShadow: color.shadow,
         }}
       >
         <span>${label}</span>
@@ -248,7 +267,7 @@ export function HeatmapRuler({ heatmap, totalLines }: HeatmapRulerProps) {
             key=${line}
             style=${{
               height: '2px',
-              background: `rgba(255, 107, 107, ${opacity})`,
+              background: `rgb(var(--color-accent-glow) / ${opacity})`,
               marginBottom: '4px',
             }}
             title=${`Line ${line}: ${activity} active keepers`}


### PR DESCRIPTION
## Summary
- replace raw multi-keeper cursor colors with the 12-slot design-system keeper token palette
- route cursor labels, selection highlights, heatmap ticks, collision warnings, interject presence fills, annotation popovers, and LSP hover shadows through keeper/status/accent/shadow tokens
- add focused tests that assert cursor overlay styles stay tokenized

## Design-system evidence
- dashboard/design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md requires production IDE code to avoid raw hex and use semantic/role tokens for keeper hues
- command: rg -n "['\":]#[0-9a-fA-F]{3,8}|rgba\(" dashboard/src/components/ide -g '!*.test.ts' -g '!*.test.tsx'
- result: no CSS-color matches

## Validation
- pnpm exec eslint src/components/ide/keeper-cursor-overlay.ts src/components/ide/keeper-cursor-overlay.test.ts src/components/ide/keeper-cursor-cm-extension.ts src/components/ide/keeper-cursor-cm-extension.test.ts src/components/ide/ide-interject.ts src/components/ide/ide-editor.ts src/components/ide/ide-lsp-client.ts
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/keeper-cursor-overlay.test.ts src/components/ide/keeper-cursor-cm-extension.test.ts src/components/ide/ide-interject.test.ts src/components/ide/ide-editor.test.ts src/components/ide/ide-lsp-client.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check