### PR TITLE
fix(keeper): relax runtime MCP inline tool_choice

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -22,6 +22,11 @@ let provider_attempt_status_of_result = function
   | Error (Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _)) -> "timeout"
   | Error _ -> "error"
 
+let provider_attempt_exception_kind_of_result = function
+  | Error (Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _)) ->
+    Some "outer_oas_timeout"
+  | Ok _ | Error _ -> None
+
 let provider_attempt_status_and_error_of_exception = function
   | Eio.Time.Timeout -> "timeout", "Eio.Time.Timeout"
   | Eio.Cancel.Cancelled inner ->
@@ -752,6 +757,7 @@ let run_named
                 (match result with
                  | Ok _ -> `Null
                  | Error sdk_err -> `String (Agent_sdk.Error.to_string sdk_err))
+              ?exception_kind:(provider_attempt_exception_kind_of_result result)
               attempt_latency_ms;
             result, checkpoint_after, liveness_success_sample, attempt_latency_ms
           | exception exn ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -109,6 +109,46 @@ let emit_runtime_manifest
     |> append
   | _ -> ()
 
+let sanitize_runtime_mcp_external_tool_choice
+      ~runtime_mcp_external_tools
+      (params : Agent_sdk.Hooks.turn_params)
+  =
+  if not runtime_mcp_external_tools then params
+  else
+    match params.tool_choice with
+    | Some (Agent_sdk.Types.Any | Agent_sdk.Types.Tool _) ->
+      { params with tool_choice = Some Agent_sdk.Types.Auto }
+    | Some (Agent_sdk.Types.Auto | Agent_sdk.Types.None_) | None -> params
+
+let sanitize_runtime_mcp_external_tool_decision
+      ~runtime_mcp_external_tools
+      (decision : Agent_sdk.Hooks.hook_decision)
+  =
+  match decision with
+  | Agent_sdk.Hooks.AdjustParams params ->
+    Agent_sdk.Hooks.AdjustParams
+      (sanitize_runtime_mcp_external_tool_choice
+         ~runtime_mcp_external_tools
+         params)
+  | _ -> decision
+
+let wrap_runtime_mcp_external_tool_hooks
+      ~runtime_mcp_external_tools
+      (hooks : Agent_sdk.Hooks.hooks option)
+  =
+  match hooks, runtime_mcp_external_tools with
+  | None, _ | Some _, false -> hooks
+  | Some hooks, true ->
+    let before_turn_params =
+      Option.map
+        (fun hook event ->
+           hook event
+           |> sanitize_runtime_mcp_external_tool_decision
+                ~runtime_mcp_external_tools:true)
+        hooks.before_turn_params
+    in
+    Some { hooks with before_turn_params }
+
 (** Run a single provider attempt within the cascade.
 
     This is the extracted body of the [try_provider] closure that was
@@ -167,6 +207,14 @@ let run_try_provider
       let resolved_lane =
         Keeper_turn_driver_helpers.resolved_tool_lane_label ~effective_tools
           ~runtime_mcp_policy
+      in
+      let runtime_mcp_external_tools =
+        effective_tools = [] && Option.is_some runtime_mcp_policy
+      in
+      let hooks =
+        wrap_runtime_mcp_external_tool_hooks
+          ~runtime_mcp_external_tools
+          ctx.hooks
       in
       emit_runtime_manifest ctx
         ~status:(if missing_required_tool_names = [] then "resolved" else "error")
@@ -233,7 +281,7 @@ let run_try_provider
           ; temperature = ctx.temperature
           ; max_idle_turns = ctx.max_idle_turns
           ; guardrails = ctx.guardrails
-          ; hooks = ctx.hooks
+          ; hooks
           ; context_reducer = ctx.context_reducer
           ; memory = ctx.memory
           ; tool_retry_policy = ctx.tool_retry_policy
@@ -465,3 +513,8 @@ let run_try_provider
        in
        result, checkpoint_after, liveness_success_sample)
 ;;
+
+module For_testing = struct
+  let sanitize_runtime_mcp_external_tool_choice =
+    sanitize_runtime_mcp_external_tool_choice
+end

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -70,3 +70,10 @@ val run_try_provider :
   (Cascade_runner.run_result, Agent_sdk.Error.sdk_error) result
   * Agent_sdk.Checkpoint.t option
   * (string * Cascade_attempt_liveness_config.success_sample) option
+
+module For_testing : sig
+  val sanitize_runtime_mcp_external_tool_choice :
+    runtime_mcp_external_tools:bool ->
+    Agent_sdk.Hooks.turn_params ->
+    Agent_sdk.Hooks.turn_params
+end

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -1561,12 +1561,12 @@ let test_provider_attempt_finish_recorded_on_oas_timeout () =
               (match result with
                | Ok _ -> Alcotest.fail "expected OAS bridge timeout"
                | Error err ->
+                 let error_text = Agent_sdk.Error.to_string err in
                  Alcotest.(check bool)
                    "timeout surfaced to keeper turn"
                    true
-                   (contains_substring
-                      (Agent_sdk.Error.to_string err)
-                      "Timeout after"));
+                   (contains_substring error_text "Timeout after"
+                    || contains_substring error_text "Per-provider timeout after"));
               Alcotest.(check bool)
                 "provider request was attempted"
                 true
@@ -1628,7 +1628,9 @@ let test_provider_attempt_finish_recorded_on_oas_timeout () =
                 "provider timeout records timeout error"
                 true
                 (match json_string_member_opt "error" finished_row.M.decision with
-                 | Some error -> contains_substring error "Timeout after"
+                 | Some error ->
+                   contains_substring error "Timeout after"
+                   || contains_substring error "Per-provider timeout after"
                  | None -> false);
               let status, api_json =
                 Masc_mcp.Server_dashboard_http_keeper_api.keeper_runtime_trace_json
@@ -2261,6 +2263,50 @@ let test_runtime_manifest_contract_omits_provider_model_fields () =
       "lib/keeper/keeper_turn_driver_try_provider.ml";
     ]
 
+let test_runtime_mcp_external_lane_demotes_inline_tool_choice () =
+  let module TP = Masc_mcp.Keeper_turn_driver_try_provider.For_testing in
+  let params =
+    { Agent_sdk.Hooks.default_turn_params with
+      tool_choice = Some Agent_sdk.Types.Any
+    }
+  in
+  let sanitized =
+    TP.sanitize_runtime_mcp_external_tool_choice
+      ~runtime_mcp_external_tools:true
+      params
+  in
+  Alcotest.(check bool)
+    "Any is demoted to Auto"
+    true
+    (match sanitized.Agent_sdk.Hooks.tool_choice with
+     | Some Agent_sdk.Types.Auto -> true
+     | _ -> false);
+  let exact_tool =
+    { params with tool_choice = Some (Agent_sdk.Types.Tool "keeper_task_claim") }
+  in
+  let sanitized_exact =
+    TP.sanitize_runtime_mcp_external_tool_choice
+      ~runtime_mcp_external_tools:true
+      exact_tool
+  in
+  Alcotest.(check bool)
+    "exact tool_choice is demoted to Auto"
+    true
+    (match sanitized_exact.Agent_sdk.Hooks.tool_choice with
+     | Some Agent_sdk.Types.Auto -> true
+     | _ -> false);
+  let inline_lane =
+    TP.sanitize_runtime_mcp_external_tool_choice
+      ~runtime_mcp_external_tools:false
+      exact_tool
+  in
+  Alcotest.(check bool)
+    "inline lane keeps exact tool_choice"
+    true
+    (match inline_lane.Agent_sdk.Hooks.tool_choice with
+     | Some (Agent_sdk.Types.Tool "keeper_task_claim") -> true
+     | _ -> false)
+
 let () =
   Alcotest.run "keeper_runtime_manifest"
     [
@@ -2342,5 +2388,9 @@ let () =
             "runtime manifest contract omits provider/model fields"
             `Quick
             test_runtime_manifest_contract_omits_provider_model_fields;
+          Alcotest.test_case
+            "runtime MCP external lane demotes inline tool_choice"
+            `Quick
+            test_runtime_mcp_external_lane_demotes_inline_tool_choice;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Demote inline Agent SDK tool_choice to Auto when a keeper provider lane resolves tools through runtime MCP policy instead of inline tools.
- Preserve MASC-side required-tool receipt/contract enforcement while avoiding the preflight "no tools are visible" failure.
- Tag provider-attempt timeout results with exception_kind=outer_oas_timeout for runtime trace/dashboard grouping.

## Evidence
- Runtime logs showed keeper surface visible_tool_count=20, but strict/runtime-MCP provider attempts failed with "tool_choice requires tool use, but no tools are visible".
- ocamlformat --check lib/keeper/keeper_turn_driver.ml lib/keeper/keeper_turn_driver_try_provider.mli lib/keeper/keeper_turn_driver_try_provider.ml test/test_keeper_runtime_manifest.ml
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_runtime_manifest.exe test/test_oas_integration.exe
- ./_build/default/test/test_keeper_runtime_manifest.exe
- ./_build/default/test/test_oas_integration.exe