### PR TITLE
[dashboard/ide] fix: activeIdeFile string | null — kill 'package.json' hardcoded default

### DIFF
--- a/dashboard/design-system/headless-core/anchored-thread-rail.ts
+++ b/dashboard/design-system/headless-core/anchored-thread-rail.ts
@@ -27,7 +27,7 @@ export interface AnchoredThread {
 }
 
 export interface AnchoredThreadRailController {
-  readonly filePath: () => string
+  readonly filePath: () => string | null
   readonly visibleThreads: () => ReadonlyArray<AnchoredThread>
   readonly threadsForLine: (line: number) => ReadonlyArray<AnchoredThread>
   readonly focusedThreadId: () => string | null
@@ -38,16 +38,17 @@ export interface AnchoredThreadRailController {
 }
 
 export function createAnchoredThreadRail(opts: {
-  readonly filePath: () => string
+  readonly filePath: () => string | null
   readonly threads: () => ReadonlyArray<AnchoredThread>
 }): AnchoredThreadRailController {
   let focusedId: string | null = null
   const listeners = new Set<() => void>()
 
-  const filePath = (): string => opts.filePath()
+  const filePath = (): string | null => opts.filePath()
 
   const visibleThreads = (): ReadonlyArray<AnchoredThread> => {
     const activeFile = opts.filePath()
+    if (activeFile === null) return []
     return opts.threads()
       .filter(thread => validThreadForFile(thread, activeFile))
       .slice()

--- a/dashboard/design-system/headless-core/keeper-line-ownership.ts
+++ b/dashboard/design-system/headless-core/keeper-line-ownership.ts
@@ -28,12 +28,12 @@ export interface LineOwnership {
 }
 
 export interface KeeperLineOwnershipAccumulator {
-  readonly filePath: () => string
+  readonly filePath: () => string | null
   readonly ownership: () => ReadonlyMap<number, LineOwnership>
   readonly eventsForLine: (line: number) => ReadonlyArray<KeeperEdit>
   readonly knownKeepers: () => ReadonlyArray<string>
   readonly ingest: (event: KeeperEdit) => boolean
-  readonly reset: (filePath?: string) => void
+  readonly reset: (filePath?: string | null) => void
 }
 
 export function keeperHueIndex(keeperId: string): AgentColorSlot {
@@ -58,20 +58,21 @@ function shouldReplace(existing: LineOwnership | undefined, event: KeeperEdit): 
 }
 
 export function createKeeperLineOwnershipAccumulator(
-  initialFilePath: string,
+  initialFilePath: string | null,
 ): KeeperLineOwnershipAccumulator {
-  let activeFilePath = initialFilePath
+  let activeFilePath: string | null = initialFilePath
   const ownershipByLine = new Map<number, LineOwnership>()
   const eventsByLine = new Map<number, KeeperEdit[]>()
   const keepers = new Set<string>()
 
-  const filePath = (): string => activeFilePath
+  const filePath = (): string | null => activeFilePath
   const ownership = (): ReadonlyMap<number, LineOwnership> => new Map(ownershipByLine)
   const eventsForLine = (line: number): ReadonlyArray<KeeperEdit> =>
     Number.isSafeInteger(line) ? [...(eventsByLine.get(line) ?? [])] : []
   const knownKeepers = (): ReadonlyArray<string> => [...keepers].sort()
 
   const ingest = (event: KeeperEdit): boolean => {
+    if (activeFilePath === null) return false
     if (event.file_path !== activeFilePath) return false
     if (!validTimestamp(event)) return false
     const range = validLineRange(event)
@@ -97,7 +98,7 @@ export function createKeeperLineOwnershipAccumulator(
     return true
   }
 
-  const reset = (filePath?: string): void => {
+  const reset = (filePath?: string | null): void => {
     if (filePath !== undefined) activeFilePath = filePath
     ownershipByLine.clear()
     eventsByLine.clear()

--- a/dashboard/src/components/ide/anchored-thread-rail-store.ts
+++ b/dashboard/src/components/ide/anchored-thread-rail-store.ts
@@ -14,7 +14,7 @@ import {
 export type { AnchoredThread, ThreadAnchor, ThreadKind } from '../../../design-system/headless-core/anchored-thread-rail'
 
 export interface AnchoredThreadRailStore {
-  readonly filePath: () => string
+  readonly filePath: () => string | null
   readonly seed: (threads: ReadonlyArray<AnchoredThread>) => void
   readonly addThread: (thread: AnchoredThread) => void
   readonly resolveThread: (id: string, resolved?: boolean) => boolean
@@ -26,14 +26,14 @@ export interface AnchoredThreadRailStore {
   readonly focusThread: (id: string) => boolean
   readonly clearFocus: () => void
   readonly knownAuthors: () => ReadonlyArray<string>
-  readonly reset: (filePath?: string) => void
+  readonly reset: (filePath?: string | null) => void
   readonly subscribe: (listener: () => void) => () => void
 }
 
 export function createAnchoredThreadRailStore(
-  initialFilePath: string,
+  initialFilePath: string | null,
 ): AnchoredThreadRailStore {
-  const activeFilePath = signal(initialFilePath)
+  const activeFilePath = signal<string | null>(initialFilePath)
   const allThreads = signal<ReadonlyArray<AnchoredThread>>([])
   const visibleThreadsSignal = signal<ReadonlyArray<AnchoredThread>>([])
   const focusedThreadIdSignal = signal<string | null>(null)
@@ -99,7 +99,7 @@ export function createAnchoredThreadRailStore(
     controller.clearFocus()
   }
 
-  const reset = (filePath?: string): void => {
+  const reset = (filePath?: string | null): void => {
     if (filePath !== undefined) activeFilePath.value = filePath
     allThreads.value = []
     if (focusedThreadIdSignal.value !== null) controller.clearFocus()

--- a/dashboard/src/components/ide/code-document-store.ts
+++ b/dashboard/src/components/ide/code-document-store.ts
@@ -2,7 +2,7 @@ import { signal } from '@preact/signals'
 import { fetchIdeRegions, type IdeCodeRegion } from '../../api/ide'
 
 export interface CodeDocumentSource {
-  readonly file_path: string
+  readonly file_path: string | null
   readonly language: string
   readonly content: string
 }
@@ -29,7 +29,7 @@ export interface CodeDocumentStore {
 }
 
 const EMPTY_DOCUMENT: CodeDocumentSnapshot = {
-  file_path: '(no file)',
+  file_path: null,
   language: 'text',
   content: '',
   lines: [],

--- a/dashboard/src/components/ide/ide-context-bridge.ts
+++ b/dashboard/src/components/ide/ide-context-bridge.ts
@@ -2,17 +2,17 @@ import { signal } from '@preact/signals'
 import type { AnchoredThread } from './anchored-thread-rail-store'
 
 export interface IdeConversationThreadSnapshot {
-  readonly filePath: string
+  readonly filePath: string | null
   readonly threads: ReadonlyArray<AnchoredThread>
 }
 
 export const ideConversationThreadSnapshot = signal<IdeConversationThreadSnapshot>({
-  filePath: '',
+  filePath: null,
   threads: [],
 })
 
 export function publishIdeConversationThreads(
-  filePath: string,
+  filePath: string | null,
   threads: ReadonlyArray<AnchoredThread>,
 ): void {
   ideConversationThreadSnapshot.value = {

--- a/dashboard/src/components/ide/ide-data-coordinator.ts
+++ b/dashboard/src/components/ide/ide-data-coordinator.ts
@@ -156,17 +156,25 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
     const keeperParam = keeper || undefined
     const opts = { keeper: keeperParam, repoId, signal }
 
-    // Load file tree
+    // Load file tree (independent of active file — needed to suggest first file)
     fetchWorkspaceTree(2, opts).then(({ nodes, source }) => {
       if (signal.aborted) return
       fileTreeStore.seed(nodes)
       workspaceSourceSignal.value = source
-      const hasCurrentFile = nodes.some(node => node.path === filePath && !node.hasChildren)
+      const hasCurrentFile =
+        filePath !== null && nodes.some(node => node.path === filePath && !node.hasChildren)
       const nextFile = hasCurrentFile ? null : firstFilePath(nodes)
       if (nextFile && nextFile !== activeIdeFile.value) {
         activeIdeFile.value = nextFile
       }
     }).catch(() => {})
+
+    // File-scoped fetches require an active file path; skip when none is selected.
+    if (filePath === null) {
+      diffRowsSignal.value = []
+      annotationsSignal.value = []
+      return
+    }
 
     // Load file content
     fetchWorkspaceFile(filePath, opts).then(response => {

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -164,19 +164,37 @@ export function IdeEditor({
   }, [])
 
   const document = documentStore.document()
+  if (document.file_path === null) {
+    return html`
+      <div
+        role="region"
+        aria-label="ide editor"
+        data-testid="ide-editor-empty"
+        style=${{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100%',
+          color: 'var(--color-fg-disabled)',
+          fontStyle: 'italic',
+        }}
+      >no active file</div>
+    `
+  }
+  const documentFilePath: string = document.file_path
   const lines = documentStore.lines()
   const ownership = ownershipStore.ownership()
   const keepers = ownershipStore.knownKeepers()
   const overlay = cursorOverlaySignal.value
   const presence = globalPresenceSnapshot.value
   const contextFocus = ideContextFocus.value
-  const currentFileFocus = contextFocus?.file_path === document.file_path ? contextFocus : null
-  const activeCursors = keepersWithCursorInFile(overlay.cursors, document.file_path)
+  const currentFileFocus = contextFocus?.file_path === documentFilePath ? contextFocus : null
+  const activeCursors = keepersWithCursorInFile(overlay.cursors, documentFilePath)
   const activeLayerKinds = activeLayersInDisplayOrder(activeLayers)
   const currentDiffRows = diffRows()
   const replayTraceEvents = filterTraceEventsByReplay(keeperTraceState.value.events, ideReplayUntilMs.value)
   const currentFileSignals = buildCurrentFileSignals({
-    filePath: document.file_path,
+    filePath: documentFilePath,
     annotations,
     diffRows: currentDiffRows,
     activeKeeperCount: activeCursors.length,
@@ -322,8 +340,10 @@ function buildCurrentFileSignals({
   readonly traceEvents: ReadonlyArray<KeeperTraceEvent>
 }): ReadonlyArray<CurrentFileSignal> {
   const normalizedFile = normalizeIdeContextFilePath(filePath)
-  const matchesCurrentFile = (value: string): boolean =>
-    normalizedFile !== null && normalizeIdeContextFilePath(value) === normalizedFile
+  const matchesCurrentFile = (value: string | null): boolean => {
+    if (value === null) return false
+    return normalizedFile !== null && normalizeIdeContextFilePath(value) === normalizedFile
+  }
   const diagnosticCount = normalizedFile
     ? lspDiagnosticSnapshot.value.get(normalizedFile)?.length ?? 0
     : 0
@@ -805,14 +825,19 @@ function CodeMirrorEditor({
   const prevAnnRef = useRef<SelectedAnnotation | null>(null)
 
   const document = documentStore.document()
+  const documentFilePath = document.file_path
   const ownership = ownershipStore.ownership()
   const currentFileAnnotations = useMemo(
-    () => annotations.filter(annotation => annotation.file_path === document.file_path),
-    [annotations, document.file_path],
+    () => documentFilePath === null
+      ? []
+      : annotations.filter(annotation => annotation.file_path === documentFilePath),
+    [annotations, documentFilePath],
   )
   const traceLines = useMemo(
-    () => traceActive ? keeperTraceLinesForFile(document.file_path, traceEvents) : [],
-    [document.file_path, traceActive, traceEvents],
+    () => traceActive && documentFilePath !== null
+      ? keeperTraceLinesForFile(documentFilePath, traceEvents)
+      : [],
+    [documentFilePath, traceActive, traceEvents],
   )
   const traceLinesRef = useRef<ReadonlyArray<EditorKeeperTraceLine>>(traceLines)
 
@@ -829,7 +854,9 @@ function CodeMirrorEditor({
 
     async function mount() {
       const mountDocument = documentStore.document()
-      const lang = await languageExt(mountDocument.file_path)
+      const mountFilePath = mountDocument.file_path
+      if (mountFilePath === null) return
+      const lang = await languageExt(mountFilePath)
       if (destroyed) return
 
       const blameExts = showBlame ? blameExtensions() : []
@@ -841,7 +868,7 @@ function CodeMirrorEditor({
           lineNumberExt(),
           syntaxHighlightExt(),
           lang,
-          lspExtension({ filePath: mountDocument.file_path }),
+          lspExtension({ filePath: mountFilePath }),
           keeperCursorExtension(),
           contextFocusLineExt(),
           annotationLineChipExt(),
@@ -859,11 +886,11 @@ function CodeMirrorEditor({
             ? [
                 keeperTraceLineGutterExt({
                   getTraceLines: () => traceLinesRef.current,
-                  onTraceLineSelect: (event, line) => focusTraceLineContext(
-                    documentStore.document().file_path,
-                    event,
-                    line,
-                  ),
+                  onTraceLineSelect: (event, line) => {
+                    const current = documentStore.document().file_path
+                    if (current === null) return
+                    focusTraceLineContext(current, event, line)
+                  },
                 }),
               ]
             : []),

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -79,7 +79,7 @@ const STATUSBAR_VIEW_LABELS: Readonly<Record<ViewTab, string>> = {
 interface IdeStatusbarInput {
   readonly activeView: ViewTab
   readonly activeLayers: ReadonlySet<string>
-  readonly activeFilePath: string
+  readonly activeFilePath: string | null
   readonly findOpen: boolean
   readonly terminalOpen: boolean
   readonly railsCollapsed: boolean
@@ -276,9 +276,9 @@ export function deriveIdeStatusbarModel({
   addStatusbarChip(
     chips,
     'file',
-    shortStatusbarPath(activeFilePath),
+    activeFilePath === null ? 'no file' : shortStatusbarPath(activeFilePath),
     'ghost',
-    `Active file: ${activeFilePath.trim() || 'no file'}`,
+    `Active file: ${activeFilePath === null ? 'no file' : activeFilePath}`,
   )
 
   const layerLabel = statusbarLayerLabel(activeLayers)
@@ -765,6 +765,14 @@ function IdeBreadcrumb() {
     return () => unsub()
   }, [])
 
+  if (filePath === null) {
+    return html`
+      <nav
+        aria-label="Editor breadcrumb (no file)"
+        style=${{ color: 'var(--color-fg-disabled)', fontStyle: 'italic' }}
+      >no active file</nav>
+    `
+  }
   const segments = filePath.split('/')
   const fileName = segments.at(-1) ?? ""
   const ext = fileName.includes('.') ? fileName.slice(fileName.lastIndexOf('.')) : ''

--- a/dashboard/src/components/ide/ide-state.ts
+++ b/dashboard/src/components/ide/ide-state.ts
@@ -13,7 +13,7 @@
 import { signal } from '@preact/signals'
 import type { TabId } from '../../types'
 
-export const activeIdeFile = signal<string>('package.json')
+export const activeIdeFile = signal<string | null>(null)
 
 export interface IdeContextFocusRouteLink {
   readonly id: string

--- a/dashboard/src/components/ide/keeper-line-ownership-store.ts
+++ b/dashboard/src/components/ide/keeper-line-ownership-store.ts
@@ -17,18 +17,18 @@ import {
 export type { KeeperEdit, LineOwnership }
 
 export interface KeeperLineOwnershipStore {
-  readonly filePath: () => string
+  readonly filePath: () => string | null
   readonly ownership: () => ReadonlyMap<number, LineOwnership>
   readonly eventsForLine: (line: number) => ReadonlyArray<KeeperEdit>
   readonly knownKeepers: () => ReadonlyArray<string>
   readonly ingest: (event: KeeperEdit) => boolean
-  readonly reset: (filePath?: string) => void
+  readonly reset: (filePath?: string | null) => void
   readonly subscribe: (listener: () => void) => () => void
   readonly dispose: () => void
 }
 
 export function createKeeperLineOwnershipStore(
-  initialFilePath: string,
+  initialFilePath: string | null,
 ): KeeperLineOwnershipStore {
   const accumulator = createKeeperLineOwnershipAccumulator(initialFilePath)
   const ownershipSignal = signal<ReadonlyMap<number, LineOwnership>>(new Map())
@@ -45,7 +45,7 @@ export function createKeeperLineOwnershipStore(
     return accepted
   }
 
-  const reset = (filePath?: string): void => {
+  const reset = (filePath?: string | null): void => {
     accumulator.reset(filePath)
     publish()
   }


### PR DESCRIPTION
## Summary

`activeIdeFile = signal<string>('package.json')` 하드코딩 박멸 + `string | null` typed nullable. 사용자가 dashboard 열 때 *real keeper 선택 없이* `package.json`이 active file로 거짓 표시되던 silent fallback family 제거.

Closes #15308.

## 변경 핵심

### Before (silent fallback)
```typescript
// ide-state.ts:16
export const activeIdeFile = signal<string>('package.json')

// code-document-store.ts:32
const EMPTY_DOCUMENT = { file_path: '(no file)', ... }

// ide-context-bridge.ts:9
ideConversationThreadSnapshot = signal({filePath: '', threads: []})
```

### After (typed nullable)
```typescript
export const activeIdeFile = signal<string | null>(null)
// EMPTY_DOCUMENT.file_path = null
// snapshot.filePath: string | null = null
```

### Cascade (10 file)

| Surface | 변경 |
|---|---|
| `ide-state.ts` | signal type `string | null`, 초기값 `null` |
| `keeper-line-ownership.ts` (accumulator) | `string | null` 지원, ingest null 시 reject |
| `keeper-line-ownership-store.ts` | sig propagate |
| `anchored-thread-rail.ts` (controller) | `filePath: () => string | null`, visibleThreads null 시 `[]` |
| `anchored-thread-rail-store.ts` | sig propagate |
| `code-document-store.ts` | `CodeDocumentSource.file_path: string | null`, `EMPTY_DOCUMENT.file_path = null` |
| `ide-context-bridge.ts` | `IdeConversationThreadSnapshot.filePath: string | null` |
| `ide-data-coordinator.ts` | file null → workspace tree fetch만 (auto-jump 유지), file-scoped fetch skip |
| `ide-editor.ts` | `IdeEditor` / `CodeMirrorEditor` / mount() / breadcrumb 모두 null guard, "no active file" placeholder |
| `ide-shell.ts` | `IdeStatusbarInput.activeFilePath: string | null`, chip 'no file' 명시 |

### 검증

- `pnpm typecheck`: green
- `pnpm build`: green (11.56s)
- `pnpm test`: 7485 PASS / 3 fail = **baseline pre-existing** (origin/main HEAD `b2fc1b91c3`에서도 동일 fail — 직접 측정):
  - `dashboard-shell.test.ts` solo mode 1건
  - `widget-solo.test.ts` 2건
  - 모두 active file 변경과 무관

### Out of scope (별도 issue/PR)

- `file-tree-store` / `run-activity-store` / `keeper-line-ownership-store`의 mock seed 박멸
- `ConnectorStatusSnapshot.EMPTY_SNAPSHOT` 박멸 ('— · — · 오프라인' 패턴)
- silent `?? 'X'` / `|| 'X'` fallback 25+ file (top: telemetry-unified, keeper-config-panel, planning-panel 등)

## 주의 (사용자 절대 원칙)

- `feedback_hardcoding_and_legacy_zero_tolerance` 준수: 하드코딩 동시 박멸, transitional 없음
- `reference_masc_mcp_draft_auto_merge_guard`: Draft 유지, Ready 전환은 사용자 액션
- agent 자동 PR 생성 금지

RFC-WAIVED: dashboard-only UI refactor, no credential/identity/operator surface touched.

## Test plan

- [ ] CodeRabbit / 사람 리뷰 코멘트 확인 후 대응
- [ ] required CI checks green
- [ ] dashboard 로컬 dev: 첫 진입 시 'no active file' 명시 표시 확인 + keeper cursor 도착 시 자동 jump 확인
- [ ] 사용자 confirm 후 Ready 전환 + `human-approved-ready` 라벨

🤖 Generated with [Claude Code](https://claude.com/claude-code)
