### PR TITLE
fix(dashboard): record refresh timeout details

### DIFF
--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -41,6 +41,22 @@ let should_reraise_cancel exn =
   | Eio.Cancel.Cancelled _ -> not (is_internal_race_cancel exn)
   | _ -> false
 
+let timeout_failure_message ~label ~phase ~timeout_s ~elapsed_s =
+  Printf.sprintf
+    "refresh_timeout label=%s phase=%s timeout_s=%.1f elapsed_s=%.1f"
+    label
+    phase
+    timeout_s
+    elapsed_s
+
+let timeout_exception ~config ~phase ~elapsed_s =
+  Failure
+    (timeout_failure_message
+       ~label:config.label
+       ~phase
+       ~timeout_s:config.timeout_s
+       ~elapsed_s)
+
 let log_refresh_failure ~config ~consecutive_failures ~current_interval ~dt exn =
   incr consecutive_failures;
   if !consecutive_failures >= config.failure_threshold then
@@ -85,9 +101,11 @@ let start ~sw ~clock ~config:raw_config ~compute ~on_result =
          Log.Dashboard.info "%s warm cache done (%.1fs)" config.label
            (Time_compat.now () -. t0)
        | Error `Timeout ->
-         notify_error config (Failure "timeout");
-         Log.Dashboard.warn "%s warm cache skipped (%.1fs timeout)" config.label
-           (Time_compat.now () -. t0)
+         let dt = Time_compat.now () -. t0 in
+         let timeout_exn = timeout_exception ~config ~phase:"warm_cache" ~elapsed_s:dt in
+         notify_error config timeout_exn;
+         Log.Dashboard.warn "%s warm cache skipped (%.1fs timeout=%.1fs): %s"
+           config.label dt config.timeout_s (Printexc.to_string timeout_exn)
      with
      | exn ->
        if should_reraise_cancel exn then
@@ -146,7 +164,7 @@ let start ~sw ~clock ~config:raw_config ~compute ~on_result =
            Log.Dashboard.debug "%s refreshed (%.1fs)" config.label dt
          | Error `Timeout ->
              let dt = Time_compat.now () -. t0 in
-             let timeout_exn = Failure "timeout" in
+             let timeout_exn = timeout_exception ~config ~phase:"refresh" ~elapsed_s:dt in
              notify_error config timeout_exn;
              log_refresh_failure ~config ~consecutive_failures ~current_interval
                ~dt timeout_exn
@@ -159,3 +177,7 @@ let start ~sw ~clock ~config:raw_config ~compute ~on_result =
       loop ()
     in
     loop ())
+
+module For_testing = struct
+  let timeout_failure_message = timeout_failure_message
+end

--- a/lib/server/proactive_refresh.mli
+++ b/lib/server/proactive_refresh.mli
@@ -18,6 +18,11 @@ val default_config : label:string -> interval_s:float -> config
 (** [default_config ~label ~interval_s] returns a config with
     [max_backoff_s = 120.0], [failure_threshold = 5], [timeout_s = 10.0]. *)
 
+module For_testing : sig
+  val timeout_failure_message :
+    label:string -> phase:string -> timeout_s:float -> elapsed_s:float -> string
+end
+
 val start :
   sw:Eio.Switch.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -399,6 +399,7 @@ let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
            ~interval_s:_operator_refresh_interval_s)
         with
         timeout_s = _operator_refresh_interval_s *. 0.8
+      ; on_error = Some (mark_cached_surface_error _operator_snapshot_cache)
       ; warm_delay_s = 120.0
       }
     ~compute
@@ -459,6 +460,7 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
            ~interval_s:_operator_refresh_interval_s)
         with
         timeout_s = _operator_refresh_interval_s *. 0.8
+      ; on_error = Some (mark_cached_surface_error _operator_digest_cache)
       ; warm_delay_s = 150.0
       }
     ~compute
@@ -736,6 +738,7 @@ let start_mission_refresh_loop ~state ~sw ~clock =
     ~config:
       { (Proactive_refresh.default_config ~label:"mission" ~interval_s:120.0) with
         timeout_s = mission_refresh_timeout_s
+      ; on_error = Some (mark_cached_surface_error _mission_cache)
       ; warm_delay_s = 90.0
       }
     ~compute

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -431,6 +431,7 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
     ~config:
       { (Proactive_refresh.default_config ~label:"execution" ~interval_s:60.0) with
         timeout_s = execution_refresh_timeout_s
+      ; on_error = Some (mark_cached_surface_error _execution_cache)
       ; warm_delay_s = 0.0
       }
     ~compute
@@ -463,6 +464,7 @@ let start_transport_health_refresh_loop ~state ~sw ~clock =
     ~config:
       { (Proactive_refresh.default_config ~label:"transport_health" ~interval_s) with
         timeout_s
+      ; on_error = Some (mark_cached_surface_error _transport_health_cache)
       ; warm_delay_s = 0.0
       }
     ~compute

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -15,6 +15,20 @@ let check_json msg expected actual =
 let timeout_kind json =
   Yojson.Safe.Util.(member "timeout_kind" json |> to_string)
 
+let test_proactive_refresh_timeout_message_names_phase () =
+  let msg =
+    Proactive_refresh.For_testing.timeout_failure_message
+      ~label:"operator_snapshot"
+      ~phase:"refresh"
+      ~timeout_s:24.0
+      ~elapsed_s:33.2
+  in
+  Alcotest.(check string)
+    "typed proactive refresh timeout"
+    "refresh_timeout label=operator_snapshot phase=refresh timeout_s=24.0 \
+     elapsed_s=33.2"
+    msg
+
 (* -- 1. Nested get_or_compute must not deadlock ----------------------------- *)
 
 let test_nested_no_deadlock () =
@@ -517,6 +531,8 @@ let () =
         ] );
       ( "timeout",
         [
+          test_case "proactive refresh timeout names phase" `Quick
+            test_proactive_refresh_timeout_message_names_phase;
           test_case "stale preserved on timeout" `Quick
             (fun () ->
                Eio.Switch.run @@ fun sw ->


### PR DESCRIPTION
## Summary
- Replace opaque proactive refresh timeout errors like Failure("timeout") with typed timeout context: label, phase, timeout_s, elapsed_s.
- Record outer proactive-refresh timeout failures into cached surface diagnostics via on_error, so stale_reason/last_error reflect refresh-loop timeouts for operator snapshot, digest, mission, execution, and transport health.
- Add a regression test pinning the timeout message shape.

## Evidence
- 24h log sweep: recent Dashboard warnings showed operator_snapshot/operator_digest/execution refresh failed with only Failure("timeout").
- ocamlformat --check lib/server/proactive_refresh.ml lib/server/proactive_refresh.mli lib/server/server_dashboard_http_core.ml lib/server/server_dashboard_http_execution_surfaces.ml test/test_dashboard_cache.ml
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_dashboard_cache.exe
- ./_build/default/test/test_dashboard_cache.exe
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_dashboard_execution.exe
- ./_build/default/test/test_dashboard_execution.exe