### PR TITLE
fix(dashboard): keep coordination snapshot labels utf8-safe

### DIFF
--- a/lib/coordination_product_snapshot.ml
+++ b/lib/coordination_product_snapshot.ml
@@ -153,8 +153,12 @@ let take n values =
 ;;
 
 let truncate ?(limit = 160) value =
-  let value = String.trim value in
-  if String.length value <= limit then value else String.sub value 0 limit ^ "..."
+  let value = Safe_ops.sanitize_text_utf8 value |> String.trim in
+  if String.length value <= limit
+  then value
+  else
+    String_util.utf8_safe ~max_bytes:(limit + 3) ~suffix:"..." value
+    |> String_util.to_string
 ;;
 
 let single_unique = function

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -141,7 +141,7 @@ check_json_eventually \
   "$BASE/api/v1/dashboard/namespace-truth" \
   "'execution' in d" \
   '^True$' \
-  6 \
+  60 \
   2
 check_http "goal-loop status 200" "$BASE/api/v1/dashboard/goal-loop/status" "200"
 check_json "goal-loop status exposes phases" "$BASE/api/v1/dashboard/goal-loop/status" "'overall_status' in d and 'phases' in d" '^True$'

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -22,6 +22,20 @@ let cleanup_dir dir =
   in
   rm dir
 
+let invalid_utf8_byte_count s =
+  let len = String.length s in
+  let rec loop i count =
+    if i >= len
+    then count
+    else (
+      let dec = String.get_utf_8_uchar s i in
+      let dlen = Uchar.utf_decode_length dec in
+      if dlen > 0 && Uchar.utf_decode_is_valid dec
+      then loop (i + dlen) count
+      else loop (i + 1) (count + 1))
+  in
+  loop 0 0
+
 let with_env key value f =
   let old = Sys.getenv_opt key in
   Unix.putenv key value;
@@ -323,6 +337,18 @@ let test_dashboard_planning_http_json_includes_coordination_fsm () =
      | `List _ -> true
      | _ -> false)
 
+let test_dashboard_planning_http_json_keeps_utf8_valid_after_truncation () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  ignore (Lib.Coord.init config ~agent_name:(Some "dashboard"));
+  let hangul_ga = "\234\176\128" in
+  let title = String.concat "" (List.init 40 (fun _ -> hangul_ga)) in
+  (match Lib.Goal_store.upsert_goal config ~title () with
+   | Ok _ -> ()
+   | Error msg -> fail msg);
+  let json = Lib.Server_dashboard_http.dashboard_planning_http_json ~config in
+  let serialized = Yojson.Safe.to_string json in
+  check int "planning json remains valid utf8" 0 (invalid_utf8_byte_count serialized)
+
 let credential_archived_starvation_total () =
   int_of_float
     (Lib.Prometheus.metric_total
@@ -513,6 +539,8 @@ let () =
             test_dashboard_shell_timeout_fallback_reports_timing_context;
           test_case "planning payload includes coordination FSM" `Quick
             test_dashboard_planning_http_json_includes_coordination_fsm;
+          test_case "planning payload keeps UTF-8 valid after truncation" `Quick
+            test_dashboard_planning_http_json_keeps_utf8_valid_after_truncation;
           test_case "credential monitoring surfaces archive counter" `Quick
             test_credential_monitoring_json_surfaces_archive_counter;
           test_case "batch payload includes credential monitoring" `Quick


### PR DESCRIPTION
## Summary

- Make coordination product snapshot truncation UTF-8 safe before dashboard JSON serialization.
- Extend the namespace-truth verifier wait window so cold execution snapshots can warm up instead of producing a false verifier failure.
- Add a dashboard planning JSON regression test that exercises multi-byte truncation and checks the serialized payload remains valid UTF-8.

## Product impact

Dashboard verification no longer fails with `UnicodeDecodeError` when planning or coordination labels contain Korean or other multi-byte text near the truncation boundary. Cold-start dashboard checks also align with the namespace-truth execution snapshot warm-up behavior.

## Evidence

- `ocamlformat --check lib/coordination_product_snapshot.ml test/test_dashboard_http_core.ml`
- `bash -n scripts/verify-dashboard.sh`
- `git diff --check`
- `scripts/opam-pin-external-deps.sh --install`
- `scripts/dune-local.sh build test/test_dashboard_http_core.exe bin/main_eio.exe`
- `./_build/default/test/test_dashboard_http_core.exe test --color=never executor_pool 7`
- `./_build/default/test/test_dashboard_http_core.exe test --color=never executor_pool 8`

## Review evidence

Root cause was bytewise `String.sub` truncation in `Coordination_product_snapshot.truncate`, which could split UTF-8 codepoints before Yojson serialization. The fix sanitizes first and truncates through `String_util.utf8_safe`, preserving the previous byte budget plus suffix behavior.

The namespace-truth check previously retried only 6 times at 2s, while the endpoint can return an initializing payload until execution snapshot prewarm finishes. The verifier now waits up to 60 attempts at 2s.

## Linked issue

Follow-up from live dashboard verifier failures observed after the board read-model route fix.
