### PR TITLE
[dashboard/telemetry] fix: mark fallback labels as explicit unknown placeholders

### DIFF
--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -330,12 +330,12 @@ function entryPreview(e: TelemetryEntry): string {
       return `${keeper} -> ${tool}`
     }
     case 'trajectory_tool_call': {
-      const tool = telemetryToolName(e) ?? 'tool'
+      const tool = telemetryToolName(e) ?? '(unknown tool)'
       const keeper =
         normalizeText(e.keeper_name)
         ?? normalizeText(recordField(e.runtime_contract, 'keeper_name'))
         ?? normalizeText(e.keeper)
-        ?? 'unknown'
+        ?? '(unknown keeper)'
       return `${keeper} -> ${tool}`
     }
     case 'tool_usage': {
@@ -344,7 +344,7 @@ function entryPreview(e: TelemetryEntry): string {
       return `${caller || 'unknown'} -> ${tool}`
     }
     case 'oas_event': {
-      const eventType = normalizeText(e.event_type) ?? normalizeText(e.type) ?? 'oas'
+      const eventType = normalizeText(e.event_type) ?? normalizeText(e.type) ?? '(unknown event_type)'
       const agentName = normalizeText(e.agent_name)
       const toolName = normalizeText(e.tool_name)
       const turn = typeof e.turn === 'number' ? e.turn : null
@@ -358,14 +358,14 @@ function entryPreview(e: TelemetryEntry): string {
       return parts.length > 0 ? `${eventType}: ${parts.join(' · ')}` : eventType
     }
     case 'execution_receipt': {
-      const keeper = normalizeText(e.keeper_name) ?? normalizeText(e.agent_name) ?? 'unknown'
-      const outcome = normalizeText(e.outcome) ?? normalizeText(e.operator_disposition) ?? 'recorded'
+      const keeper = normalizeText(e.keeper_name) ?? normalizeText(e.agent_name) ?? '(unknown keeper)'
+      const outcome = normalizeText(e.outcome) ?? normalizeText(e.operator_disposition) ?? '(no outcome)'
       const reason = normalizeText(e.terminal_reason_code)
       return reason ? `${keeper} receipt ${outcome} (${reason})` : `${keeper} receipt ${outcome}`
     }
     case 'goal_event': {
-      const goal = normalizeText(e.goal_id) ?? 'unknown-goal'
-      const eventType = normalizeText(e.event_type) ?? 'goal_event'
+      const goal = normalizeText(e.goal_id) ?? '(unknown goal)'
+      const eventType = normalizeText(e.event_type) ?? '(unknown event_type)'
       return `${goal} ${eventType}`
     }
     case 'tool_metric': {


### PR DESCRIPTION
## Summary

`entryPreview()`의 `?? 'X'` fallback 4건이 *legitimate-looking string label*로 표시되어 operator가 *real data*로 오해 가능. 명시적 placeholder로 교체.

## 변경 (6 site, 4 surface)

| Line | Before (legitimate-looking) | After (explicit) |
|---|---|---|
| 333 | `?? 'tool'` | `?? '(unknown tool)'` |
| 338 | `?? 'unknown'` (keeper) | `?? '(unknown keeper)'` |
| 347 | `?? 'oas'` | `?? '(unknown event_type)'` |
| 361 | `?? 'unknown'` (keeper) | `?? '(unknown keeper)'` |
| 362 | `?? 'recorded'` | `?? '(no outcome)'` |
| 367 | `?? 'unknown-goal'` | `?? '(unknown goal)'` |
| 368 | `?? 'goal_event'` | `?? '(unknown event_type)'` |

## Out of scope (false positive — 변경 안 함)

- Line 293 `?? 'global'`: internal cache-key fallback, 사용자 화면에 *label로 표시되지 않음*.
- Line 305-306 `?? '-'`: dash placeholder, 명시적 missing 표시.
- Line 314 `?? 'unknown'`: tag context에서 명시적 unknown.
- Line 344 `caller || 'unknown'`: 정직.

## 검증

- \`pnpm typecheck\`: green
- \`pnpm vitest run telemetry-unified.test.ts\`: 28/28 PASS

## Goal alignment

\`/goal\`: \"대시보드가 연결 끊긴 정보나 텔레메트리나 로그가 없도록, 하드코딩이 대시보드에서 완전히 제거될 때까지 올바른 정보로 개선\".

본 PR은 telemetry rail의 legitimate-looking fallback label 박멸 (operator가 실제 데이터로 오해 방지).

Stacked on top of PR #15309 (activeIdeFile null) → PR #15303 (presence typed variant, merged \`b2fc1b91c3\`).

RFC-WAIVED: dashboard-only telemetry preview label refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)