### PR TITLE
feat(ide): show workspace tree diff badges

### DIFF
--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -42,11 +42,6 @@ let workspace_or_default ?(warn_on_failure = true) ~site ~path ~default f =
       observe_workspace_route_failure ~warn_on_failure ~site ~path exn;
       default
 
-module For_testing = struct
-  let sanitize_log_value = sanitize_log_value
-  let observe_workspace_route_failure = observe_workspace_route_failure
-end
-
 (* Pure classification of the [?keeper=<name>] query param into a
    workspace base directory plus a source tag.
 
@@ -277,13 +272,21 @@ let valid_git_ref s =
 
 (* --- Recursive file tree --- *)
 
-let file_tree_node ~path ~label ~depth ~parent ~has_children =
+let file_tree_node ~diff_by_path ~path ~label ~depth ~parent ~has_children =
+  let diff =
+    match diff_by_path with
+    | Some diff_by_path when not has_children ->
+      (match Hashtbl.find_opt diff_by_path path with
+       | Some badge -> `String badge
+       | None -> `Null)
+    | _ -> `Null
+  in
   `Assoc [ ("path", `String path); ("label", `String label)
          ; ("depth", `Int depth); ("parent", `String parent)
          ; ("hasChildren", `Bool has_children)
-         ; ("diff", `Null); ("keeperId", `Null); ("hueIndex", `Null) ]
+         ; ("diff", diff); ("keeperId", `Null); ("hueIndex", `Null) ]
 
-let rec scan_dir_bounded ~base ~depth ~max_depth ~remaining acc dir =
+let rec scan_dir_bounded ?diff_by_path ~base ~depth ~max_depth ~remaining acc dir =
   if depth > max_depth || remaining <= 0 then (acc, remaining)
   else
     let entries =
@@ -312,13 +315,14 @@ let rec scan_dir_bounded ~base ~depth ~max_depth ~remaining acc dir =
           let rel = rel_under base full in
           let has_children = is_dir && depth < max_depth in
           let parent = if depth = 0 then "" else Filename.dirname rel in
-          let node = file_tree_node
+          let node = file_tree_node ~diff_by_path
               ~path:rel ~label:f ~depth ~parent ~has_children in
           let acc' = node :: acc in
           let remaining' = remaining - 1 in
           let acc'', remaining'' =
             if is_dir && depth < max_depth then
               scan_dir_bounded
+                ?diff_by_path
                 ~base ~depth:(depth + 1) ~max_depth ~remaining:remaining'
                 acc' full
             else (acc', remaining')
@@ -327,8 +331,8 @@ let rec scan_dir_bounded ~base ~depth ~max_depth ~remaining acc dir =
     in
     fold acc remaining entries
 
-let scan_dir ~base ~depth ~max_depth ~max_nodes acc dir =
-  fst (scan_dir_bounded ~base ~depth ~max_depth ~remaining:max_nodes acc dir)
+let scan_dir ?diff_by_path ~base ~depth ~max_depth ~max_nodes acc dir =
+  fst (scan_dir_bounded ?diff_by_path ~base ~depth ~max_depth ~remaining:max_nodes acc dir)
 
 (* --- Git helpers --- *)
 
@@ -363,6 +367,39 @@ let git_run_lines ~cwd args =
     String.split_on_char '\n' out
     |> List.filter (fun l -> l <> "")
 
+let diff_badge_of_numstat ~added ~deleted =
+  match int_of_string_opt added, int_of_string_opt deleted with
+  | Some added, Some deleted ->
+    let parts =
+      (if added > 0 then [Printf.sprintf "+%d" added] else [])
+      @ (if deleted > 0 then [Printf.sprintf "-%d" deleted] else [])
+    in
+    (match parts with
+     | [] -> None
+     | _ -> Some (String.concat " " parts))
+  | _ when String.equal added "-" && String.equal deleted "-" -> Some "bin"
+  | _ -> None
+
+let parse_git_numstat_line line =
+  match String.split_on_char '\t' line with
+  | added :: deleted :: path_parts ->
+    let path = String.concat "\t" path_parts in
+    if path = "" then None
+    else
+      (match diff_badge_of_numstat ~added ~deleted with
+       | Some badge -> Some (path, badge)
+       | None -> None)
+  | _ -> None
+
+let git_diff_badges ~base =
+  let badges = Hashtbl.create 32 in
+  git_run_lines ~cwd:base ["diff"; "--numstat"; "HEAD"; "--"]
+  |> List.iter (fun line ->
+       match parse_git_numstat_line line with
+       | Some (path, badge) -> Hashtbl.replace badges path badge
+       | None -> ());
+  badges
+
 (* Surface git failure to the caller instead of collapsing to []. Lets
    route handlers distinguish "command errored / invalid ref" from
    "command succeeded with no output". *)
@@ -372,6 +409,12 @@ let git_run_lines_or_error ~cwd args =
   | Some out ->
     Ok (String.split_on_char '\n' out
         |> List.filter (fun l -> l <> ""))
+
+module For_testing = struct
+  let sanitize_log_value = sanitize_log_value
+  let observe_workspace_route_failure = observe_workspace_route_failure
+  let parse_git_numstat_line = parse_git_numstat_line
+end
 
 (* --- Blame parsing: collect per-line then group adjacent same-author ranges --- *)
 
@@ -529,7 +572,9 @@ let add_routes router =
            in
            let nodes =
              if not (Sys.file_exists base) then []
-             else scan_dir ~base ~depth:0 ~max_depth:depth ~max_nodes [] base
+             else
+               let diff_by_path = git_diff_badges ~base in
+               scan_dir ~diff_by_path ~base ~depth:0 ~max_depth:depth ~max_nodes [] base
            in
            let json = `List (List.rev nodes) in
            json_response_with_source ~status:`OK ~source request reqd json)

--- a/lib/server/server_routes_http_routes_workspace.mli
+++ b/lib/server/server_routes_http_routes_workspace.mli
@@ -62,8 +62,10 @@ val tree_node_limit_of_query : string option -> int
 (** [scan_dir ~base ~depth ~max_depth ~max_nodes acc dir] returns at most
     [max_nodes] tree nodes. The cap prevents a dashboard file-tree request
     against a large workspace root from monopolizing the server event loop.
-    Exposed for regression testing. *)
+    [diff_by_path], when present, maps relative file paths to compact
+    display badges from git numstat. Exposed for regression testing. *)
 val scan_dir :
+  ?diff_by_path:(string, string) Hashtbl.t ->
   base:string ->
   depth:int ->
   max_depth:int ->
@@ -86,4 +88,6 @@ module For_testing : sig
 
   val observe_workspace_route_failure :
     ?warn_on_failure:bool -> site:string -> path:string -> exn -> unit
+
+  val parse_git_numstat_line : string -> (string * string) option
 end

--- a/test/dune
+++ b/test/dune
@@ -255,6 +255,7 @@
         test_keeper_event_queue
         test_keeper_relevance_check
         test_gh_api_classification
+        test_workspace_routes_keeper
         test_provider_capability_matrix
         test_effect_evidence_source_path
         test_cognitive_gravity

--- a/test/test_workspace_routes_keeper.ml
+++ b/test/test_workspace_routes_keeper.ml
@@ -293,6 +293,22 @@ let touch path =
   let oc = open_out path in
   close_out oc
 
+let json_field name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+
+let node_by_path path nodes =
+  match
+    List.find_opt
+      (fun node ->
+        match json_field "path" node with
+        | Some (`String p) -> p = path
+        | _ -> false)
+      nodes
+  with
+  | Some node -> node
+  | None -> Alcotest.fail ("missing tree node " ^ path)
+
 let test_scan_dir_respects_max_nodes () =
   with_temp_dir "wide-tree" (fun dir ->
     for i = 1 to 80 do
@@ -300,6 +316,58 @@ let test_scan_dir_respects_max_nodes () =
     done;
     let nodes = W.scan_dir ~base:dir ~depth:0 ~max_depth:1 ~max_nodes:25 [] dir in
     Alcotest.(check int) "node cap" 25 (List.length nodes))
+
+let test_scan_dir_attaches_file_diff_badges () =
+  with_temp_dir "diff-tree" (fun dir ->
+    let src = Filename.concat dir "src" in
+    Unix.mkdir src 0o700;
+    touch (Filename.concat src "main.ml");
+    touch (Filename.concat src "unchanged.ml");
+    let diff_by_path = Hashtbl.create 4 in
+    Hashtbl.add diff_by_path "src/main.ml" "+3 -1";
+    let nodes =
+      W.scan_dir ~diff_by_path ~base:dir ~depth:0 ~max_depth:2
+        ~max_nodes:25 [] dir
+    in
+    let src_node = node_by_path "src" nodes in
+    let main_node = node_by_path "src/main.ml" nodes in
+    let unchanged_node = node_by_path "src/unchanged.ml" nodes in
+    (match json_field "diff" src_node with
+     | Some `Null -> ()
+     | _ -> Alcotest.fail "directory diff badge should stay null");
+    (match json_field "diff" main_node with
+     | Some (`String badge) ->
+       Alcotest.(check string) "file diff badge" "+3 -1" badge
+     | _ -> Alcotest.fail "changed file should carry diff badge");
+    (match json_field "diff" unchanged_node with
+     | Some `Null -> ()
+     | _ -> Alcotest.fail "unchanged file diff badge should stay null"))
+
+let test_parse_git_numstat_line_added_deleted () =
+  match W.For_testing.parse_git_numstat_line "3\t1\tsrc/main.ml" with
+  | Some (path, badge) ->
+    Alcotest.(check string) "path" "src/main.ml" path;
+    Alcotest.(check string) "badge" "+3 -1" badge
+  | None -> Alcotest.fail "expected parsed numstat line"
+
+let test_parse_git_numstat_line_deleted_only () =
+  match W.For_testing.parse_git_numstat_line "0\t2\tlib/old.ml" with
+  | Some (path, badge) ->
+    Alcotest.(check string) "path" "lib/old.ml" path;
+    Alcotest.(check string) "badge" "-2" badge
+  | None -> Alcotest.fail "expected deleted-only numstat line"
+
+let test_parse_git_numstat_line_binary () =
+  match W.For_testing.parse_git_numstat_line "-\t-\tassets/logo.png" with
+  | Some (path, badge) ->
+    Alcotest.(check string) "path" "assets/logo.png" path;
+    Alcotest.(check string) "badge" "bin" badge
+  | None -> Alcotest.fail "expected binary numstat line"
+
+let test_parse_git_numstat_line_zero_change_is_ignored () =
+  match W.For_testing.parse_git_numstat_line "0\t0\tREADME.md" with
+  | None -> ()
+  | Some _ -> Alcotest.fail "zero-change numstat line should be ignored"
 
 let test_tree_node_limit_default () =
   Alcotest.(check int) "default" 750 (W.tree_node_limit_of_query None)
@@ -531,6 +599,7 @@ let () =
         ] )
     ; ( "scan_dir"
       , [ Alcotest.test_case "respects max node cap" `Quick test_scan_dir_respects_max_nodes
+        ; Alcotest.test_case "attaches file diff badges" `Quick test_scan_dir_attaches_file_diff_badges
         ; Alcotest.test_case "limit default" `Quick test_tree_node_limit_default
         ; Alcotest.test_case "limit invalid falls back" `Quick test_tree_node_limit_invalid_falls_back
         ; Alcotest.test_case "limit clamps low" `Quick test_tree_node_limit_clamps_low
@@ -555,6 +624,15 @@ let () =
             test_workspace_failure_observer_bounds_site_label
         ; Alcotest.test_case "failure observer re-raises cancel" `Quick
             test_workspace_failure_observer_reraises_cancelled
+        ] )
+    ; ( "git_numstat"
+      , [ Alcotest.test_case "added and deleted" `Quick
+            test_parse_git_numstat_line_added_deleted
+        ; Alcotest.test_case "deleted only" `Quick
+            test_parse_git_numstat_line_deleted_only
+        ; Alcotest.test_case "binary" `Quick test_parse_git_numstat_line_binary
+        ; Alcotest.test_case "zero change ignored" `Quick
+            test_parse_git_numstat_line_zero_change_is_ignored
         ] )
     ; ( "valid_git_ref"
       , [ Alcotest.test_case "main"              `Quick test_valid_ref_main


### PR DESCRIPTION
## Summary
- populate workspace tree file-node diff badges from git numstat
- keep directory and unchanged-file diff fields null
- activate and extend workspace route coverage for scanner badges and numstat parsing

## Validation
- scripts/dune-local.sh build test/test_workspace_routes_keeper.exe
- ./_build/default/test/test_workspace_routes_keeper.exe (61 tests)
- ocamlformat --check lib/server/server_routes_http_routes_workspace.ml lib/server/server_routes_http_routes_workspace.mli test/test_workspace_routes_keeper.ml
- git diff --check origin/main