### PR TITLE
[dashboard/planning] fix: mark fallback labels as explicit unknown placeholders

### DIFF
--- a/dashboard/src/components/planning-panel.ts
+++ b/dashboard/src/components/planning-panel.ts
@@ -81,7 +81,7 @@ function refsLabel(refs: DashboardCoordinationFsmRefs | undefined): string {
 }
 
 function evidenceLabel(evidence: DashboardCoordinationFsmEvidence): string {
-  const source = evidence.source ?? 'evidence'
+  const source = evidence.source ?? '(unknown source)'
   const kind = evidence.kind ? `/${evidence.kind}` : ''
   return `${source}${kind}`
 }
@@ -165,7 +165,7 @@ function CoordinationEvidenceRow({ evidence }: { evidence: DashboardCoordination
           ${evidenceLabel(evidence)}
         </span>
         <span class="min-w-0 truncate text-2xs font-medium text-text-strong">
-          ${evidence.label ?? evidence.id ?? 'evidence'}
+          ${evidence.label ?? evidence.id ?? '(unlabeled evidence)'}
         </span>
       </div>
       ${evidence.detail ? html`
@@ -181,9 +181,9 @@ function CoordinationViolationRow({ violation }: { violation: DashboardCoordinat
     <li class="rounded-[var(--r-1)] border border-card-border/60 bg-black/10 p-2">
       <div class="flex flex-wrap items-center gap-2 text-xs">
         <span class="rounded-[var(--r-1)] border px-2 py-0.5 text-3xs font-semibold uppercase ${severityToneClass(violation.severity)}">
-          ${violation.severity ?? 'info'}
+          ${violation.severity ?? '(unknown severity)'}
         </span>
-        <span class="font-mono text-2xs text-text-strong">${violation.code ?? violation.axis ?? 'coordination'}</span>
+        <span class="font-mono text-2xs text-text-strong">${violation.code ?? violation.axis ?? '(unknown violation)'}</span>
         ${violation.axis ? html`<span class="text-3xs text-text-dim">${violation.axis}</span>` : null}
       </div>
       <div class="mt-1 text-xs leading-relaxed text-text-body">${violation.message ?? 'coordination invariant 검토 필요.'}</div>


### PR DESCRIPTION
## Summary

`PlanningPanel`이 coordination FSM evidence/violation row에 *legitimate-looking string fallback* 4건 표시. Operator가 *real telemetry*로 오해 가능. 명시적 placeholder 교체.

## 변경 (4 site)

| Line | Before (legitimate-looking) | After (explicit) |
|---|---|---|
| 84 | \`evidence.source ?? 'evidence'\` | \`?? '(unknown source)'\` |
| 168 | \`?? evidence.id ?? 'evidence'\` | \`?? '(unlabeled evidence)'\` |
| 184 | \`violation.severity ?? 'info'\` | \`?? '(unknown severity)'\` |
| 186 | \`?? violation.axis ?? 'coordination'\` | \`?? '(unknown violation)'\` |

## Out of scope (false positive)

- React key fallbacks (line 194, 245, 254): internal React reconciliation, *user-visible label 아님*.
- Line 189 \`?? 'coordination invariant 검토 필요.'\`: 명시적 한국어 message guidance, *real data로 오해 불가*.

## 검증

- \`pnpm typecheck\`: green
- \`pnpm vitest planning-panel.test.ts\`: 15/15 PASS

## Goal alignment

\`/goal\`: \"대시보드가 연결 끊긴 정보나 텔레메트리나 로그가 없도록, 하드코딩이 대시보드에서 완전히 제거될 때까지 올바른 정보로 개선\".

본 PR은 PR #15312 (telemetry-unified fallback labels merged) 와 동일 패턴 — legitimate-looking fallback 박멸.

RFC-WAIVED: dashboard-only planning panel label refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)