### PR TITLE
[dashboard/api] fix: mark API normalization fallbacks as explicit unknown placeholders

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -316,8 +316,8 @@ describe('fetchDashboardTools', () => {
     const result = await fetchDashboardTools()
 
     const tools = result.tool_inventory.tools
-    expect(tools[0]).toMatchObject({ name: 'tool_a', category: 'uncategorized', tier: 'standard' })
-    expect(tools[1]).toMatchObject({ name: 'tool_b', category: 'keeper', tier: 'standard' })
+    expect(tools[0]).toMatchObject({ name: 'tool_a', category: 'uncategorized', tier: '(unknown tier)' })
+    expect(tools[1]).toMatchObject({ name: 'tool_b', category: 'keeper', tier: '(unknown tier)' })
     expect(tools[2]).toMatchObject({ name: 'tool_c', category: 'uncategorized', tier: 'essential' })
   })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -953,7 +953,7 @@ function decodeKeeperDecision(raw: unknown): KeeperDecision | null {
   return {
     ts_unix: asNumber(raw.ts_unix) ?? null,
     keeper_name: asString(raw.keeper_name) ?? '',
-    event_type: asString(raw.event_type) ?? 'turn',
+    event_type: asString(raw.event_type) ?? '(unknown event_type)',
     outcome: asNullableString(raw.outcome),
     model_used: null,
     latency_ms: asNumber(raw.latency_ms) ?? null,
@@ -1867,7 +1867,7 @@ export async function fetchDashboardTools(opts?: AbortableRequestOptions): Promi
   const normalizedTools = raw.tool_inventory?.tools?.map(t => ({
     ...t,
     category: t.category ?? 'uncategorized',
-    tier: t.tier ?? 'standard',
+    tier: t.tier ?? '(unknown tier)',
   }))
   return {
     ...raw,
@@ -2081,8 +2081,8 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
   return {
     name: asNullableString(data.name) ?? requestedName,
     active_goal_ids: normalizeStringList(data.active_goal_ids),
-    sandbox_profile: asNullableString(data.sandbox_profile) ?? 'local',
-    network_mode: asNullableString(data.network_mode) ?? 'inherit',
+    sandbox_profile: asNullableString(data.sandbox_profile) ?? '(unknown sandbox_profile)',
+    network_mode: asNullableString(data.network_mode) ?? '(unknown network_mode)',
     sandbox_last_error: asNullableString(data.sandbox_last_error),
     effective_sandbox_image: asNullableString(data.effective_sandbox_image),
     private_workspace_root: asNullableString(data.private_workspace_root),
@@ -2124,7 +2124,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
         ?? '',
     },
     compaction: {
-      profile: asNullableString(compaction.profile) ?? 'balanced',
+      profile: asNullableString(compaction.profile) ?? '(unknown compaction profile)',
       ratio_gate: asLooseNumber(compaction.ratio_gate) ?? 0.85,
       message_gate: asInt(compaction.message_gate) ?? 0,
       token_gate: asInt(compaction.token_gate) ?? 0,

--- a/dashboard/src/api/schemas/actions-activity.ts
+++ b/dashboard/src/api/schemas/actions-activity.ts
@@ -97,7 +97,7 @@ function normalizeActivitySubject(
   const type =
     (typeof value.type === 'string' && value.type.trim() !== '' ? value.type.trim() : null)
     ?? (typeof value.kind === 'string' && value.kind.trim() !== '' ? value.kind.trim() : null)
-    ?? 'entity'
+    ?? '(unknown type)'
   return { id, type }
 }
 


### PR DESCRIPTION
## Summary

API normalization layer (\`api/dashboard.ts\` + \`api/schemas/actions-activity.ts\`)가 *null/missing backend fields*를 legitimate-looking string default로 silent 변환. Operator는 *real backend value*인지 *dashboard substitution*인지 구분 불가.

명시적 \`'(unknown ...)'\` placeholder로 교체. Field schema 그대로 non-null string (caller cascade 0).

## 변경 (6 site, 2 file)

### \`api/dashboard.ts\`

| Line | Field | Before | After |
|---|---|---|---|
| 956 | KeeperDecision.event_type | \`?? 'turn'\` | \`?? '(unknown event_type)'\` |
| 1870 | Tool.tier | \`?? 'standard'\` | \`?? '(unknown tier)'\` |
| 2084 | sandbox_profile | \`?? 'local'\` | \`?? '(unknown sandbox_profile)'\` |
| 2085 | network_mode | \`?? 'inherit'\` | \`?? '(unknown network_mode)'\` |
| 2127 | compaction.profile | \`?? 'balanced'\` | \`?? '(unknown compaction profile)'\` |

### \`api/schemas/actions-activity.ts\`

| Line | Field | Before | After |
|---|---|---|---|
| 100 | actor.type | \`?? 'entity'\` | \`?? '(unknown type)'\` |

## Out of scope (false positive — 변경 안 함)

- \`api/core.ts:93 source ?? 'manual'\`: write-side default in setStoredToken(). \`'manual'\`은 *operator-entered token*의 legitimate marker (OAuth/CLI flow와 구분).
- \`api/dashboard.ts:1869 category ?? 'uncategorized'\`: 'uncategorized' 자체가 명시적 placeholder.

## 검증

- \`pnpm typecheck\`: green
- \`pnpm vitest src/api/dashboard.test.ts\`: 34/34 PASS (test expectation 업데이트)

## Goal alignment

\`/goal\`: \"대시보드가 연결 끊긴 정보나 텔레메트리나 로그가 없도록, 하드코딩이 대시보드에서 완전히 제거될 때까지 올바른 정보로 개선\".

PR series:
- PR #15303 (merged \`b2fc1b91c3\`): presence FALLBACK_PRESENCE
- PR #15309 (draft): activeIdeFile null
- PR #15312 (merged \`39715b0628\`): telemetry-unified fallback labels
- PR #15314 (draft): planning-panel fallback labels
- **PR (this)**: API normalization layer

Field schemas remain string non-null (no breaking cascade). Operators
now see explicit '(unknown ...)' markers instead of legitimate-looking
defaults.

RFC-WAIVED: dashboard-only API normalization label refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)