### PR TITLE
[dashboard] fix: mark component-layer fallback labels as explicit unknown placeholders

### DIFF
--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -27,7 +27,7 @@ export function extractLaneValue(
     case 'decision': return snapshot.decision.stage
     case 'cascade': return snapshot.cascade.state
     case 'compaction': return snapshot.compaction.stage
-    case 'breaker': return snapshot.circuit_breaker?.state ?? 'clean'
+    case 'breaker': return snapshot.circuit_breaker?.state ?? '(no circuit_breaker)'
   }
 }
 

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -269,7 +269,7 @@ function JudgmentsSection() {
             <div class="text-text-muted/90 leading-relaxed">${j.summary ?? ''}</div>
             ${j.recommended_action ? html`
               <div class="mt-2 flex items-center gap-1.5 text-2xs">
-                <span class="rounded-[var(--r-1)] border border-[var(--accent-20)] bg-[var(--accent-8)] px-1.5 py-0.5 font-medium text-accent-fg">${j.recommended_action.action_kind ?? 'action'}</span>
+                <span class="rounded-[var(--r-1)] border border-[var(--accent-20)] bg-[var(--accent-8)] px-1.5 py-0.5 font-medium text-accent-fg">${j.recommended_action.action_kind ?? '(unknown action_kind)'}</span>
                 ${j.recommended_action.resolved_tool ? html`<span class="text-text-dim font-mono">${j.recommended_action.resolved_tool}</span>` : null}
                 ${j.recommended_action.reason ? html`<span class="text-text-muted/80 truncate max-w-[250px]">${j.recommended_action.reason}</span>` : null}
               </div>

--- a/dashboard/src/components/ide/ide-keeper-work-panel.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.ts
@@ -266,7 +266,7 @@ function RuntimeBlock(summary: KeeperWorkSummary) {
   return html`
     <div class="ide-keeper-work-runtime" role="status">
       <div>
-        <span>${summary.terminalCode ?? 'runtime'}</span>
+        <span>${summary.terminalCode ?? '(unknown terminal code)'}</span>
         <strong>${headline ?? action}</strong>
       </div>
       ${action ? html`<span>${action}</span>` : null}

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -210,7 +210,7 @@ function statusbarWorkspaceLabel(
       return `@${workspaceSource.keeper} unknown`
     case 'project':
     case undefined:
-      return statusbarRepositoryLabel(activeStatusbarRepository(repositories, activeRepositoryId)) ?? 'workspace'
+      return statusbarRepositoryLabel(activeStatusbarRepository(repositories, activeRepositoryId)) ?? '(no workspace)'
   }
 }
 

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -30,7 +30,7 @@ function FreshnessLine({ data }: { data: TelemetryFreshnessMetadata }) {
   const gap = coverageGapDisplay(data)
   return html`
     <div class="text-3xs text-[var(--color-fg-disabled)]">
-      <span class="font-mono">${data.source ?? 'tool_call_io'}</span>
+      <span class="font-mono">${data.source ?? '(unknown source)'}</span>
       <span class="mx-1" aria-hidden="true">·</span>
       <span class="font-mono ${sourceHealthClass(data.health)}">${data.health ?? 'unknown'}</span>
       <span class="mx-1" aria-hidden="true">·</span>

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -29,7 +29,7 @@ function FreshnessLine({ data }: { data: TelemetryFreshnessMetadata }) {
   const gap = coverageGapDisplay(data)
   return html`
     <div class="text-3xs text-[var(--color-fg-disabled)]">
-      <span class="font-mono">${data.source ?? 'trajectory_tool_call'}</span>
+      <span class="font-mono">${data.source ?? '(unknown source)'}</span>
       <span class="mx-1" aria-hidden="true">·</span>
       <span class="font-mono ${sourceHealthClass(data.health)}">${data.health ?? 'unknown'}</span>
       <span class="mx-1" aria-hidden="true">·</span>

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -420,7 +420,7 @@ export function RuntimeMonitor() {
                   <div class="flex justify-between gap-3 items-start flex-wrap">
                     <div class="grid gap-1">
                       <strong class="text-sm text-text-strong">${provider.provider}</strong>
-                      <span class="text-xs text-text-muted">${provider.runtime_kind ?? 'runtime'}</span>
+                      <span class="text-xs text-text-muted">${provider.runtime_kind ?? '(unknown runtime_kind)'}</span>
                     </div>
                     <${StatusChip}
                       label=${runtimeStatusLabel(provider)}

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -72,7 +72,7 @@ export function Tools() {
                 등록됨 ${usage.registered_count} (모든 MCP 서버 합산) · 사용된 ${usage.distinct_tools_called} · 미사용 ${usage.never_called_count}
               </div>
               <div class="text-3xs text-[var(--color-fg-muted)] mb-2">
-                <span class="font-mono">${usage.source ?? 'tool_usage'}</span>
+                <span class="font-mono">${usage.source ?? '(unknown source)'}</span>
                 <span class="mx-1">·</span>
                 <span class="font-mono ${sourceHealthClass(usage.health)}">${usage.health ?? 'unknown'}</span>
                 <span class="mx-1">·</span>


### PR DESCRIPTION
## Summary

Component layer 8 site의 \`?? 'legitimate-looking'\` fallback 박멸. Operator surface (governance / runtime monitor / tool telemetry / IDE shell / keeper work panel) 에서 *real backend value*와 *fallback substitution* 구분 가능하도록 명시적 placeholder 적용.

## 변경 (8 site, 8 file)

| File | Line | Before | After |
|---|---|---|---|
| governance.ts | 272 | \`action_kind ?? 'action'\` | \`?? '(unknown action_kind)'\` |
| runtime-monitor.ts | 423 | \`runtime_kind ?? 'runtime'\` | \`?? '(unknown runtime_kind)'\` |
| keeper-tool-telemetry.ts | 32 | \`source ?? 'trajectory_tool_call'\` | \`?? '(unknown source)'\` |
| keeper-tool-call-inspector.ts | 33 | \`source ?? 'tool_call_io'\` | \`?? '(unknown source)'\` |
| tools/tools-main.ts | 75 | \`source ?? 'tool_usage'\` | \`?? '(unknown source)'\` |
| fsm-hub-types.ts | 30 | \`circuit_breaker?.state ?? 'clean'\` | \`?? '(no circuit_breaker)'\` |
| ide/ide-shell.ts | 213 | \`?? 'workspace'\` | \`?? '(no workspace)'\` |
| ide/ide-keeper-work-panel.ts | 269 | \`terminalCode ?? 'runtime'\` | \`?? '(unknown terminal code)'\` |

## Out of scope (false positive — 변경 안 함)

- \`runtime-monitor.ts:58/59 COVERAGE_PRIORITY[coverage_status ?? 'full']\`: 'full'은 *priority lookup key*, user-visible label 아님.
- \`ide-branch-context-panel.ts:110/132 ?? 'detached'\`: 'detached HEAD'는 *real git state*, fallback substitution이 아님.
- \`ide-lsp-client.ts:734 ?? 'text'\`: CodeMirror language id 의 *legitimate plain-text* fallback.

## 검증

- \`pnpm typecheck\`: green
- 8 component test files: 88/88 PASS

## Goal alignment

\`/goal\`: \"대시보드가 연결 끊긴 정보나 텔레메트리나 로그가 없도록, 하드코딩이 대시보드에서 완전히 제거될 때까지 올바른 정보로 개선\".

PR series progress:
- #15303 (merged \`b2fc1b91c3\`): presence FALLBACK_PRESENCE
- #15309 (draft): activeIdeFile null
- #15312 (merged \`39715b0628\`): telemetry-unified fallback labels
- #15314 (merged \`23f15d0fd7\`): planning-panel fallback labels
- #15318 (draft): API normalization layer
- **PR (this)**: component layer (8 site)

RFC-WAIVED: dashboard-only component label refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)