### PR TITLE
[dashboard] fix: mark approval/trace label fallbacks as explicit unknown placeholders

### DIFF
--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -1282,8 +1282,8 @@ function GoalDetailPanel({
                       ${detail.approvals.map((approval, index) => html`
                         <div key=${String(approval.id ?? index)} class="rounded-[var(--r-1)] border border-warn/20 bg-warn/6 p-3 text-xs">
                           <div class="flex flex-wrap items-center justify-between gap-2">
-                            <strong class="text-text-strong">${String(approval.tool_name ?? 'tool')}</strong>
-                            <span class="text-text-dim">${String(approval.risk_level ?? 'risk')}</span>
+                            <strong class="text-text-strong">${String(approval.tool_name ?? '(unknown tool)')}</strong>
+                            <span class="text-text-dim">${String(approval.risk_level ?? '(unknown risk_level)')}</span>
                           </div>
                           <div class="mt-2 text-text-muted">${String(approval.input_preview ?? 'pending operator decision')}</div>
                         </div>

--- a/dashboard/src/components/ide/overlay-keeper-trace.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.ts
@@ -383,7 +383,7 @@ function traceRouteContext(event: KeeperTraceEvent): IdeContextRouteContext {
   if (event.source === 'decision-log') {
     return {
       surface: 'Decision',
-      label: event.semanticOutcome ?? 'decision',
+      label: event.semanticOutcome ?? '(unknown outcome)',
       sourceId: `trace:${event.id}`,
       keeperId: event.keeperName,
       telemetryQuery: event.decisionId,


### PR DESCRIPTION
3 site (overlay-keeper-trace + goal-tree) legitimate-looking fallback 박멸. Goal series continuation.

| Site | Before | After |
|---|---|---|
| overlay-keeper-trace.ts:386 | `semanticOutcome ?? 'decision'` | `?? '(unknown outcome)'` |
| goal-tree.ts:1285 | `tool_name ?? 'tool'` | `?? '(unknown tool)'` |
| goal-tree.ts:1286 | `risk_level ?? 'risk'` | `?? '(unknown risk_level)'` |

Tests: typecheck green, 110/110 PASS.

Goal: `/goal` dashboard hardcoded fallback removal. PR series — #15303, #15309, #15312, #15314, #15318, #15320, #15321, **(this)**.

RFC-WAIVED: dashboard-only label refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
