### PR TITLE
feat(ide): summarize explorer git changes

### DIFF
--- a/dashboard/src/components/ide/file-tree-store.test.ts
+++ b/dashboard/src/components/ide/file-tree-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { createFileTreeStore, type FileTreeNode } from './file-tree-store'
+import { createFileTreeStore, summarizeFileTreeDiffs, type FileTreeNode } from './file-tree-store'
 
 const SAMPLE: ReadonlyArray<FileTreeNode> = [
   { path: 'runtime', label: 'runtime', depth: 0, parent: null, hasChildren: true, diff: null, keeperId: null, hueIndex: null },
@@ -90,6 +90,34 @@ describe('createFileTreeStore', () => {
     const s = createFileTreeStore()
     s.seed(SAMPLE)
     expect(s.knownKeepers()).toEqual(['nick0cave', 'sangsu'])
+  })
+
+  it('summarizes changed files from git diff badges across collapsed nodes', () => {
+    const s = createFileTreeStore()
+    s.seed([
+      ...SAMPLE,
+      { path: 'assets/logo.png', label: 'logo.png', depth: 0, parent: null, hasChildren: false, diff: 'bin', keeperId: null, hueIndex: null },
+      { path: 'docs/empty.md', label: 'empty.md', depth: 1, parent: 'docs', hasChildren: false, diff: '+bad -0', keeperId: null, hueIndex: null },
+    ])
+
+    expect(s.diffSummary()).toEqual({
+      changedFiles: 5,
+      additions: 25,
+      deletions: 0,
+      binaryFiles: 1,
+    })
+  })
+
+  it('returns an empty diff summary when no file node carries diff data', () => {
+    expect(summarizeFileTreeDiffs([
+      { path: 'src', label: 'src', depth: 0, parent: null, hasChildren: true, diff: null, keeperId: null, hueIndex: null },
+      { path: 'src/main.ts', label: 'main.ts', depth: 1, parent: 'src', hasChildren: false, diff: null, keeperId: null, hueIndex: null },
+    ])).toEqual({
+      changedFiles: 0,
+      additions: 0,
+      deletions: 0,
+      binaryFiles: 0,
+    })
   })
 
   it('subscribers fire on expansion changes', () => {

--- a/dashboard/src/components/ide/file-tree-store.ts
+++ b/dashboard/src/components/ide/file-tree-store.ts
@@ -3,8 +3,8 @@
  *
  * Mirrors the keeper-state.ts module-level signal pattern. Keeps a
  * flat array of nodes plus an expansion set, derives the visible
- * subset on demand. Seed data is supplied by the consumer (PR-2's
- * mock fixture initially; real keeper artifacts in a follow-up).
+ * subset on demand. Seed data is supplied by the IDE data coordinator
+ * from the workspace tree route.
  *
  * Headless-friendly: the store has zero DOM/render dependencies and
  * its public API is consumable by both Preact (signal.value reads)
@@ -29,9 +29,17 @@ export interface FileTreeNode {
   readonly hueIndex: number | null  // 1..12 (matches RFC 0019 mapping)
 }
 
+export interface FileTreeDiffSummary {
+  readonly changedFiles: number
+  readonly additions: number
+  readonly deletions: number
+  readonly binaryFiles: number
+}
+
 export interface FileTreeStore {
   readonly seed: (nodes: ReadonlyArray<FileTreeNode>) => void
   readonly visibleNodes: () => ReadonlyArray<FileTreeNode>
+  readonly diffSummary: () => FileTreeDiffSummary
   readonly subscribe: (listener: () => void) => () => void
   readonly expand: (path: string) => void
   readonly collapse: (path: string) => void
@@ -45,6 +53,45 @@ export interface FileTreeStore {
 
 function normalizedParent(parent: string | null): string | null {
   return parent === '' ? null : parent
+}
+
+const EMPTY_DIFF_SUMMARY: FileTreeDiffSummary = {
+  changedFiles: 0,
+  additions: 0,
+  deletions: 0,
+  binaryFiles: 0,
+}
+
+export function summarizeFileTreeDiffs(
+  nodes: ReadonlyArray<FileTreeNode>,
+): FileTreeDiffSummary {
+  let changedFiles = 0
+  let additions = 0
+  let deletions = 0
+  let binaryFiles = 0
+
+  for (const node of nodes) {
+    if (node.hasChildren || node.diff === null) continue
+    changedFiles += 1
+    if (node.diff === 'bin') {
+      binaryFiles += 1
+      continue
+    }
+
+    for (const part of node.diff.split(/\s+/)) {
+      if (part.startsWith('+')) additions += parseDiffCount(part)
+      else if (part.startsWith('-')) deletions += parseDiffCount(part)
+    }
+  }
+
+  return changedFiles === 0
+    ? EMPTY_DIFF_SUMMARY
+    : { changedFiles, additions, deletions, binaryFiles }
+}
+
+function parseDiffCount(token: string): number {
+  const parsed = Number.parseInt(token.slice(1), 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
 }
 
 export function createFileTreeStore(): FileTreeStore {
@@ -87,6 +134,7 @@ export function createFileTreeStore(): FileTreeStore {
   })
 
   const visibleNodes = (): ReadonlyArray<FileTreeNode> => visibleNodesSignal.value
+  const diffSummary = (): FileTreeDiffSummary => summarizeFileTreeDiffs(allNodes.value)
 
   const subscribe = (listener: () => void): (() => void) => {
     let sawInitialSnapshot = false
@@ -142,6 +190,7 @@ export function createFileTreeStore(): FileTreeStore {
   return {
     seed,
     visibleNodes,
+    diffSummary,
     subscribe,
     expand,
     collapse,

--- a/dashboard/src/components/ide/ide-explorer.test.ts
+++ b/dashboard/src/components/ide/ide-explorer.test.ts
@@ -96,6 +96,31 @@ describe('IdeExplorer tree row keyboard accessibility', () => {
     expect(keeperOwnedRow?.textContent).toContain('NK')
     expect(keeperOwnedRow?.textContent).toContain('router.ts')
   })
+
+  it('summarizes workspace git changes from file tree diff badges', () => {
+    const store = createFileTreeStore()
+    store.seed(SAMPLE)
+    render(h(IdeExplorer, { fileTreeStore: store }), container)
+
+    const summary = container.querySelector<HTMLElement>('[aria-label="Workspace git changes: 1 changed, +14"]')
+    expect(summary).not.toBeNull()
+    expect(summary?.textContent).toContain('Git changes')
+    expect(summary?.textContent).toContain('1 changed')
+    expect(summary?.textContent).toContain('+14')
+
+    const diffBadge = Array.from(container.querySelectorAll<HTMLElement>('[aria-label="Git diff +14"]'))
+      .find(el => el.textContent === '+14')
+    expect(diffBadge).toBeDefined()
+  })
+
+  it('hides the git changes summary when the workspace tree has no diffs', () => {
+    const store = createFileTreeStore()
+    store.seed(SAMPLE.map(node => ({ ...node, diff: null })))
+    render(h(IdeExplorer, { fileTreeStore: store }), container)
+
+    expect(container.textContent).not.toContain('Git changes')
+  })
+
   it('renders repository source in the explorer header', () => {
     const store = createFileTreeStore()
     store.seed(SAMPLE)

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
 import { Search } from 'lucide-preact'
 import { activeKeeperName } from '../../keeper-state'
-import { type FileTreeStore, type FileTreeNode } from './file-tree-store'
+import { type FileTreeStore, type FileTreeNode, type FileTreeDiffSummary } from './file-tree-store'
 import { activeIdeFile, ideContextFocus, type IdeContextFocus } from './ide-state'
 import type { WorkspaceSource } from '../../api/workspace-source'
 import type { Repository } from '../../api/repositories'
@@ -150,6 +150,7 @@ export function IdeExplorer({
     return visible.filter(n => n.label.toLowerCase().includes(needle))
   }, [visible, filter])
   const fileCount = filtered.filter(n => !n.hasChildren).length
+  const diffSummary = useMemo(() => store.diffSummary(), [store, tick])
   const scopeLabel = explorerScopeLabel(source, keeperName, repoList)
 
   // Reverse map: file_path → keepers currently focused on that file
@@ -190,6 +191,7 @@ export function IdeExplorer({
           >${scopeLabel.label}</span></span>
         <span>${fileCount} FILES</span>
       </header>
+      ${diffSummary.changedFiles > 0 ? ExplorerDiffSummary(diffSummary) : null}
       ${repoList.length > 0 || onRepositoryScan ? html`
         <div
           style=${{
@@ -413,9 +415,53 @@ function TreeRow(
           `)}</span>`
         : null}
       ${node.diff !== null
-        ? html`<span style=${{ color: 'var(--color-fg-muted)', font: 'var(--fs-11)' }}>${node.diff}</span>`
+        ? html`<span
+            aria-label=${`Git diff ${node.diff}`}
+            title=${`Git diff ${node.diff}`}
+            style=${{ color: 'var(--color-fg-muted)', font: 'var(--fs-11)' }}
+          >${node.diff}</span>`
         : null}
     </li>
+  `
+}
+
+function ExplorerDiffSummary(summary: FileTreeDiffSummary) {
+  const parts = [
+    `${summary.changedFiles} changed`,
+    summary.additions > 0 ? `+${summary.additions}` : null,
+    summary.deletions > 0 ? `-${summary.deletions}` : null,
+    summary.binaryFiles > 0 ? `${summary.binaryFiles} bin` : null,
+  ].filter((part): part is string => part !== null)
+  return html`
+    <div
+      role="status"
+      aria-label=${`Workspace git changes: ${parts.join(', ')}`}
+      style=${{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 'var(--sp-2)',
+        minHeight: '24px',
+        padding: 'var(--sp-1) var(--sp-2)',
+        color: 'var(--color-fg-secondary)',
+        background: 'var(--color-bg-muted)',
+        border: '1px solid var(--color-border-default)',
+        borderRadius: 'var(--r-1)',
+        font: 'var(--type-eyebrow)',
+        fontVariantNumeric: 'tabular-nums',
+      }}
+    >
+      <span>Git changes</span>
+      <span
+        style=${{
+          display: 'inline-flex',
+          gap: 'var(--sp-2)',
+          color: 'var(--color-fg-primary)',
+        }}
+      >
+        ${parts.map(part => html`<span key=${part}>${part}</span>`)}
+      </span>
+    </div>
   `
 }
 


### PR DESCRIPTION
## Summary
- add a compact explorer header summary for workspace git changes from file-tree diff badges
- expose a file-tree diff summary helper that counts changed files, additions, deletions, and binary files across collapsed nodes
- add accessible labels for per-file diff badges

## Validation
- pnpm exec vitest run src/components/ide/file-tree-store.test.ts src/components/ide/ide-explorer.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec eslint src/components/ide/file-tree-store.ts src/components/ide/file-tree-store.test.ts src/components/ide/ide-explorer.ts src/components/ide/ide-explorer.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check

## Merge guard note
Published with do-not-merge because #15317 shows the agent PR draft invariant is currently unsafe. Remove that label only after the guard path is checked by a human.
