### PR TITLE
fix(activity): sanitize tool-called payload source

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -102,6 +102,64 @@ let quality_from_result ~success ~message ~attempts =
       ("issues", `List [issue]);
     ]
 
+let activity_preview_string value =
+  value
+  |> Safe_ops.sanitize_text_utf8
+  |> Observability_redact.redact_preview
+  |> Safe_ops.sanitize_text_utf8
+
+let activity_plain_string value = Safe_ops.sanitize_text_utf8 value
+
+let activity_tool_called_payload ~tool_name ~success ~duration_ms ~source
+    ?error_detail ?tool_args_preview arguments =
+  let activity_string_field key =
+    match Safe_ops.json_string_opt key arguments with
+    | Some value ->
+        let preview = activity_preview_string value in
+        if String.trim preview <> "" then Some (key, `String preview) else None
+    | None -> None
+  in
+  let activity_int_field key =
+    match Safe_ops.json_int_opt key arguments with
+    | Some value -> Some (key, `Int value)
+    | None -> None
+  in
+  `Assoc
+    ([
+       ("tool_name", `String (activity_plain_string tool_name));
+       ("success", `Bool success);
+       ("duration_ms", `Int duration_ms);
+       ("source", `String (activity_plain_string source));
+       ( "error",
+         match error_detail with
+         | Some e -> `String (activity_plain_string e)
+         | None -> `Null );
+       ( "tool_args_preview",
+         match tool_args_preview with
+         | Some preview -> `String (activity_plain_string preview)
+         | None -> `Null );
+     ]
+     @ List.filter_map activity_string_field
+         [
+           "cmd";
+           "task_id";
+           "repo";
+           "path";
+           "message";
+           "branch";
+           "branch_name";
+           "title";
+           "session_id";
+           "operation_id";
+           "verification_id";
+         ]
+     @ List.filter_map activity_int_field [ "pr_number"; "issue_number" ])
+  |> Safe_ops.sanitize_json_utf8
+
+module For_testing = struct
+  let activity_tool_called_payload = activity_tool_called_payload
+end
+
 let nonempty_string_opt = function
   | Some value ->
       let trimmed = String.trim value in
@@ -866,48 +924,18 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   Tool_registry.record_call_if_known ~source ?assignment_id:called_assignment_id_opt
     ~tool_name:name ~success ~duration_ms ();
 
-  let tool_args_preview =
-    Observability_redact.redact_tool_input ~tool_name:name arguments
-  in
-  let activity_string_field key =
-    match Safe_ops.json_string_opt key arguments with
-    | Some value when String.trim value <> "" ->
-        Some (key, `String (Observability_redact.redact_preview value))
-    | _ -> None
-  in
-  let activity_int_field key =
-    match Safe_ops.json_int_opt key arguments with
-    | Some value -> Some (key, `Int value)
-    | None -> None
-  in
   let activity_payload =
-    `Assoc
-      ([
-         ("tool_name", `String name);
-         ("success", `Bool success);
-         ("duration_ms", `Int duration_ms);
-         ("source", `String (Tool_registry.string_of_source source));
-         ("error", match error_detail with Some e -> `String e | None -> `Null);
-         ( "tool_args_preview",
-           match tool_args_preview with
-           | Some preview -> `String preview
-           | None -> `Null );
-       ]
-       @ List.filter_map activity_string_field
-           [
-             "cmd";
-             "task_id";
-             "repo";
-             "path";
-             "message";
-             "branch";
-             "branch_name";
-             "title";
-             "session_id";
-             "operation_id";
-             "verification_id";
-           ]
-       @ List.filter_map activity_int_field [ "pr_number"; "issue_number" ])
+    let tool_args_preview =
+      Observability_redact.redact_tool_input ~tool_name:name arguments
+    in
+    activity_tool_called_payload
+      ~tool_name:name
+      ~success
+      ~duration_ms
+      ~source:(Tool_registry.string_of_source source)
+      ?error_detail
+      ?tool_args_preview
+      arguments
   in
 
   (* Emit activity graph event for tool call — enables real-time dashboard tracking *)

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -1,8 +1,9 @@
 (** Mcp_server_eio_call_tool — [tools/call] handler with
     timeout, read-only retry, runtime-MCP keeper tracing.
 
-    The .ml is 959 lines.  External callers reach exactly
-    six symbols — {!handle_call_tool_eio} (the dispatcher
+    The .ml is intentionally kept behind this interface.  External
+    runtime callers reach six operational symbols — {!handle_call_tool_eio}
+    (the dispatcher
     entry point invoked from
     {!Mcp_server_eio_protocol.handle_request}),
     {!contains_casefold} (re-used by the protocol layer
@@ -11,6 +12,9 @@
     {!record_runtime_mcp_keeper_tool_trace},
     {!runtime_mcp_keeper_log_context_of_entry},
     {!tool_timeout_sec_opt}).
+
+    The {!For_testing} module exposes narrow pure helpers for regression
+    tests only.
 
     Internal helpers stay private at this boundary
     ([log_mcp_exn], [int_of_env_default],
@@ -58,6 +62,18 @@ val quality_from_result :
     On failure classifies [message] (timeout / cancellation
     / generic) and emits a single issue entry with
     [severity], [code], [message], [attempts]. *)
+
+module For_testing : sig
+  val activity_tool_called_payload :
+    tool_name:string ->
+    success:bool ->
+    duration_ms:int ->
+    source:string ->
+    ?error_detail:string ->
+    ?tool_args_preview:string ->
+    Yojson.Safe.t ->
+    Yojson.Safe.t
+end
 
 (** {1 Per-tool timeout} *)
 

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -93,6 +93,23 @@ let extract_json_from_text text =
   with Not_found ->
     failf "expected JSON payload in text: %s" text
 
+let rec check_json_strings_valid_utf8 label = function
+  | `String value ->
+      check bool (label ^ " string is valid UTF-8") true
+        (String.is_valid_utf_8 value)
+  | `Assoc fields ->
+      List.iter
+        (fun (key, value) -> check_json_strings_valid_utf8 (label ^ "." ^ key) value)
+        fields
+  | `List values ->
+      List.iteri
+        (fun idx value ->
+           check_json_strings_valid_utf8
+             (Printf.sprintf "%s[%d]" label idx)
+             value)
+        values
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Tuple _ | `Variant _ -> ()
+
 let test_timeout_quality_is_error () =
   let quality =
     Masc_mcp.Mcp_server_eio_call_tool.quality_from_result
@@ -124,6 +141,29 @@ let test_success_quality_has_no_issues () =
   in
   check bool "passed" true (quality |> U.member "passed" |> U.to_bool);
   check int "issue count" 0 (quality |> U.member "issues" |> U.to_list |> List.length)
+
+let test_activity_payload_sanitizes_invalid_utf8 () =
+  let payload =
+    Masc_mcp.Mcp_server_eio_call_tool.For_testing.activity_tool_called_payload
+      ~tool_name:"keeper_bash"
+      ~success:false
+      ~duration_ms:42
+      ~source:"keeper_internal"
+      ~error_detail:"bad\xfferror"
+      ~tool_args_preview:"preview\xfe"
+      (`Assoc
+        [
+          ("cmd", `String "printf '\xff'");
+          ("message", `String "message\xfd");
+          ("title", `String "title\xfc");
+          ("pr_number", `Int 15310);
+        ])
+  in
+  check_json_strings_valid_utf8 "activity_payload" payload;
+  check string "tool name preserved" "keeper_bash"
+    (payload |> U.member "tool_name" |> U.to_string);
+  check int "numeric field preserved" 15310
+    (payload |> U.member "pr_number" |> U.to_int)
 
 let test_contains_casefold_keeps_semantics () =
   let contains = Masc_mcp.Mcp_server_eio_call_tool.contains_casefold in
@@ -490,6 +530,8 @@ let () =
           test_case "timeout is error" `Quick test_timeout_quality_is_error;
           test_case "generic failure is error" `Quick test_generic_failure_quality_is_error;
           test_case "success has no issues" `Quick test_success_quality_has_no_issues;
+          test_case "activity payload sanitizes invalid UTF-8" `Quick
+            test_activity_payload_sanitizes_invalid_utf8;
           test_case "contains casefold keeps semantics" `Quick
             test_contains_casefold_keeps_semantics;
           test_case "transition has no fixed timeout" `Quick test_transition_has_no_fixed_timeout;


### PR DESCRIPTION
## Summary
- Sanitize tool.called activity payload strings at the MCP tool-call emitter before Activity_graph.emit.
- Keep redacted argument previews valid UTF-8 before they reach activity JSONL/SSE persistence.
- Add a regression test that injects invalid UTF-8 into tool-call payload fields and asserts every emitted JSON string is valid UTF-8.

## Evidence
- Recent runtime logs showed `[activity_graph] UTF-8 repaired at emit kind=tool.called actor=keeper-...`, meaning the sink had to repair caller payloads.
- ocamlformat --check lib/mcp_server_eio_call_tool.ml lib/mcp_server_eio_call_tool.mli test/test_mcp_server_eio_call_tool.ml
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_mcp_server_eio_call_tool.exe
- ./_build/default/test/test_mcp_server_eio_call_tool.exe
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_activity_graph.exe
- ./_build/default/test/test_activity_graph.exe