### PR TITLE
fix(provider): read tool capabilities from OAS bindings

### DIFF
--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -11,9 +11,7 @@ type capabilities =
     tool-delivery projection after OAS has resolved provider/model
     capabilities. *)
 let is_cli_agent_provider (provider_cfg : Llm_provider.Provider_config.t) =
-  match Provider_adapter.adapter_of_provider_config provider_cfg with
-  | Some adapter -> adapter.runtime_kind = Provider_adapter.Cli_agent
-  | None -> false
+  Llm_provider.Provider_config.is_subprocess_cli provider_cfg.kind
 ;;
 
 (** [normalize_cli_caps_when ~is_cli caps] overrides CLI runtime caps when
@@ -36,7 +34,9 @@ let normalize_cli_caps_when ~is_cli (caps : Llm_provider.Capabilities.capabiliti
     capability truth stays in OAS. *)
 let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
   let is_cli = is_cli_agent_provider provider_cfg in
-  let caps = Provider_adapter.oas_capabilities_of_config provider_cfg in
+  let caps =
+    Agent_sdk.Provider_runtime_binding.capabilities_for_provider_config provider_cfg
+  in
   if is_cli
   then
     let runtime_mcp_lane =


### PR DESCRIPTION
## Summary
- replace Provider_adapter-based CLI detection with OAS Provider_config.is_subprocess_cli
- read Provider_tool_support OAS capabilities directly from Agent_sdk.Provider_runtime_binding
- intentionally leave runtime MCP header and per-keeper bridging policy on Provider_adapter for this slice

## Validation
- MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_provider_capability_matrix.exe test/test_filter_rejection_10474.exe test/test_oas_worker.exe
- MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_per_keeper_token_fallback.exe test/test_provider_adapter.exe
- ./_build/default/test/test_provider_capability_matrix.exe
- ./_build/default/test/test_filter_rejection_10474.exe
- ./_build/default/test/test_oas_worker.exe
- ./_build/default/test/test_per_keeper_token_fallback.exe
- ./_build/default/test/test_provider_adapter.exe
- bash scripts/lint/provider-adapter-removal-ratchet.sh
- ocamlformat --check lib/provider_tool_support.ml
- git diff --check

## Review focus
- This is the safe Provider_tool_support slice only: capability truth moves to OAS binding, while header acceptance and Codex/Kimi bridging semantics remain unchanged.