### PR TITLE
[dashboard] sweep: mark legitimate-looking fallback labels as explicit unknown (13 file)

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -1046,7 +1046,7 @@ function parseRuntimeLensClaimScopeAxis(raw: unknown): KeeperRuntimeLensClaimSco
   const obj = isRecord(raw) ? raw : {}
   return {
     present: obj.present === true,
-    source: stringField(obj, 'source') || 'keeper_task_claim_tool_call',
+    source: stringField(obj, 'source') || '(unknown source)',
     status: stringField(obj, 'status') || 'not_observed',
     result: nullableStringField(obj, 'result'),
     mode: nullableStringField(obj, 'mode'),
@@ -1147,7 +1147,7 @@ function parseRuntimeLensGap(raw: unknown): KeeperRuntimeLensGap {
   const obj = isRecord(raw) ? raw : {}
   return {
     code: stringField(obj, 'code') || 'unknown_gap',
-    severity: stringField(obj, 'severity') || 'warn',
+    severity: stringField(obj, 'severity') || '(unknown severity)',
     lane: stringField(obj, 'lane') || 'unknown',
     detail: nullableStringField(obj, 'detail'),
   }

--- a/dashboard/src/components/git-graph-panel.ts
+++ b/dashboard/src/components/git-graph-panel.ts
@@ -62,7 +62,7 @@ function clearGitGraphRouteFocus(): void {
 export function compactGitGraphPath(path: string): string {
   const normalized = path.replace(/\\/g, '/')
   const parts = normalized.split('/').filter(Boolean)
-  if (parts.length <= 2) return normalized || 'workspace'
+  if (parts.length <= 2) return normalized || '(no path)'
   return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`
 }
 

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -70,7 +70,7 @@ function degradedReasonLabel(reason?: string | null): string {
     case 'backoff':
       return 'backoff'
     default:
-      return reason?.trim() || 'degraded'
+      return reason?.trim() || '(unknown reason)'
   }
 }
 

--- a/dashboard/src/components/harness-health-sections.test.ts
+++ b/dashboard/src/components/harness-health-sections.test.ts
@@ -355,12 +355,12 @@ describe('verdictSummary', () => {
     expect(verdictSummary('reject:  too long  ')).toBe('too long')
   })
 
-  it('returns reject for empty reason', () => {
-    expect(verdictSummary('reject:')).toBe('reject')
+  it('returns explicit placeholder for empty reason', () => {
+    expect(verdictSummary('reject:')).toBe('(no reject reason)')
   })
 
-  it('returns reject for whitespace-only reason', () => {
-    expect(verdictSummary('reject:   ')).toBe('reject')
+  it('returns explicit placeholder for whitespace-only reason', () => {
+    expect(verdictSummary('reject:   ')).toBe('(no reject reason)')
   })
 })
 

--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -171,7 +171,7 @@ export function verdictTone(verdict: string): string {
 
 export function verdictSummary(verdict: string): string {
   if (!verdict.startsWith('reject:')) return verdict
-  return verdict.slice('reject:'.length).trim() || 'reject'
+  return verdict.slice('reject:'.length).trim() || '(no reject reason)'
 }
 
 export function heroTitle(data: HarnessHealthData): string {
@@ -385,7 +385,7 @@ export function RecentVerdictsList({ items }: { items: HarnessVerdictItem[] }) {
               <div>
                 <${ItemTitle}>${item.task_title || item.task_id}</${ItemTitle}>
                 <div class="mt-1 text-xs text-[var(--color-fg-muted)]">
-                  ${item.agent_name || 'agent'} · ${item.gate || 'gate'} · ${item.evaluator_cascade || 'cascade'} · ${formatTimestamp(item.timestamp)}
+                  ${item.agent_name || '(unknown agent)'} · ${item.gate || '(unknown gate)'} · ${item.evaluator_cascade || '(unknown cascade)'} · ${formatTimestamp(item.timestamp)}
                 </div>
               </div>
               <${StatusDot} size="md" class=${verdictTone(item.verdict)} />

--- a/dashboard/src/components/ide/ide-branch-context-panel.ts
+++ b/dashboard/src/components/ide/ide-branch-context-panel.ts
@@ -75,7 +75,7 @@ function shortSha(raw: string | null): string {
 function compactPath(path: string): string {
   const normalized = path.replace(/\\/g, '/')
   const parts = normalized.split('/').filter(Boolean)
-  if (parts.length <= 2) return normalized || 'workspace'
+  if (parts.length <= 2) return normalized || '(no path)'
   return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`
 }
 

--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -360,7 +360,7 @@ export function IdeContextLens({
   onRouteLinkActivate,
 }: IdeContextLensProps) {
   const model = deriveIdeContextLens({ filePath, annotations, diffRows, events, threads, diagnostics, overlay })
-  const fileLabel = filePath.split('/').pop() || filePath || 'workspace'
+  const fileLabel = filePath.split('/').pop() || filePath || '(no file)'
   const activateAnchor = onAnchorActivate ?? activateIdeContextAnchor
   const activateRouteLink = onRouteLinkActivate ?? openIdeContextRouteLink
 
@@ -646,7 +646,7 @@ function buildAnchors(
 
   for (const [index, diagnostic] of diagnostics.slice(0, 2).entries()) {
     const line = positiveLine(diagnostic.line)
-    const label = truncate(diagnostic.message || 'diagnostic', 48)
+    const label = truncate(diagnostic.message || '(no message)', 48)
     const sourceId = `diagnostic-${diagnostic.line}-${diagnostic.source ?? 'lsp'}-${diagnostic.code ?? 'message'}-${index}`
     const telemetryQuery = diagnosticTelemetryQuery(diagnostic)
     anchors.push({
@@ -677,7 +677,7 @@ function buildAnchors(
       id: `annotation-${annotation.id}`,
       file_path: annotation.file_path,
       surface: annotation.kind,
-      label: truncate(annotation.content || 'annotation', 48),
+      label: truncate(annotation.content || '(no content)', 48),
       meta: compactMeta([
         annotation.goal_id ? `goal ${annotation.goal_id}` : null,
         annotation.task_id ? `task ${annotation.task_id}` : null,
@@ -689,7 +689,7 @@ function buildAnchors(
         filePath: annotation.file_path,
         line: positiveLine(annotation.line_start),
         surface: annotation.kind,
-        label: truncate(annotation.content || 'annotation', 48),
+        label: truncate(annotation.content || '(no content)', 48),
         sourceId: `annotation-${annotation.id}`,
         goalId: annotation.goal_id ?? undefined,
         taskId: annotation.task_id ?? undefined,

--- a/dashboard/src/components/ide/ide-conversation-rail.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.ts
@@ -336,7 +336,7 @@ function postToAnchoredThread(post: BoardPost): AnchoredThread | null {
   return {
     id: post.id,
     kind: boardKindFromPost(post),
-    author_keeper_id: post.author_identity || 'keeper',
+    author_keeper_id: post.author_identity || '(unknown author)',
     anchor,
     body: post.body || post.title || 'board thread',
     created_ms: createdMs,
@@ -571,7 +571,7 @@ function DecisionCard(
   overlay: KeeperCursorOverlay,
 ) {
   const decision = item.decision
-  const keeper = decision.keeper_name || 'keeper'
+  const keeper = decision.keeper_name || '(unknown keeper)'
   const hue = keeperHueIndex(keeper)
   const color = `var(--color-keeper-${hue}-glow, var(--k-${hue}))`
   const summary = [
@@ -663,12 +663,12 @@ function decisionRouteLinks(
   summary: string,
 ): ReadonlyArray<IdeContextRouteLink> {
   const decision = item.decision
-  const keeper = decision.keeper_name || 'keeper'
+  const keeper = decision.keeper_name || '(unknown keeper)'
   return routeLinksForContext({
     filePath,
     line,
     surface: 'Decision',
-    label: summary || decision.event_type || 'decision event',
+    label: summary || decision.event_type || '(unknown decision event)',
     sourceId: `decision-${keeper}-${item.timestamp_ms}-${decision.event_type}`,
     keeperId: keeper,
     telemetry: true,
@@ -679,7 +679,7 @@ function decisionRouteLinks(
 function decisionTelemetryQuery(decision: KeeperDecision, timestampMs: number): string {
   return compactRouteQuery([
     'decision',
-    `keeper:${decision.keeper_name || 'keeper'}`,
+    `keeper:${decision.keeper_name || '(unknown keeper)'}`,
     decision.event_type ? `event:${decision.event_type}` : null,
     decision.outcome ? `outcome:${decision.outcome}` : null,
     decision.tool ? `tool:${decision.tool}` : null,

--- a/dashboard/src/components/ide/keeper-cursor-overlay.ts
+++ b/dashboard/src/components/ide/keeper-cursor-overlay.ts
@@ -333,7 +333,7 @@ export function connectKeeperCursorStream(
           file_path: filePath,
           line: entry.line || 0,
           column: entry.column || 0,
-          focus_mode: entry.focus_mode || 'reading',
+          focus_mode: entry.focus_mode || '(unknown focus_mode)',
           last_update: entry.last_seen_ms,
           tool_name: entry.tool_name,
           turn: entry.turn,

--- a/dashboard/src/components/ide/keeper-shell-drawer.ts
+++ b/dashboard/src/components/ide/keeper-shell-drawer.ts
@@ -300,7 +300,7 @@ export function KeeperShellDrawer({ keeperName }: KeeperShellDrawerProps) {
       </div>
       <${Terminal}
         lines=${terminalLines}
-        prompt=${status === 'streaming' ? `${keeper || 'keeper'}:$ ` : ''}
+        prompt=${status === 'streaming' ? `${keeper || '(no keeper)'}:$ ` : ''}
         testId="keeper-shell-terminal"
         ariaLabel="Keeper shell terminal"
         emptyText="waiting for keeper shell output"

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -57,7 +57,7 @@ function KeeperCascadeSelector({ keeper }: { keeper: Keeper }) {
     }
   }, [])
 
-  const fallbackCascade = keeper.cascade_name || 'default'
+  const fallbackCascade = keeper.cascade_name || '(no cascade)'
   const currentCascade = draftCascade?.keeperName === keeper.name && draftCascade.from === fallbackCascade
     ? draftCascade.cascade
     : fallbackCascade

--- a/dashboard/src/components/keeper-tool-access.ts
+++ b/dashboard/src/components/keeper-tool-access.ts
@@ -37,8 +37,8 @@ function mentionsLabel(targets: readonly string[]): string {
 
 export function KeeperToolAccessSummary({ config }: { config: KeeperConfig }) {
   const cascade = config.execution.selected_cascade_name || '—'
-  const sandbox = config.sandbox_profile ?? 'local'
-  const network = config.network_mode ?? 'inherit'
+  const sandbox = config.sandbox_profile ?? '(unknown sandbox_profile)'
+  const network = config.network_mode ?? '(unknown network_mode)'
   const handoff = `${config.handoff.auto ? 'on' : 'off'} · threshold ${config.handoff.threshold}`
   const idle = `${config.proactive.idle_sec}s${config.proactive.enabled ? '' : ' (disabled)'}`
   const mentions = mentionsLabel(config.coordination.mention_targets)

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -140,7 +140,7 @@ function mergeLogEntries(
 }
 
 function sourceLabel(source: string): string {
-  return SOURCE_LABELS[source] ?? (source || 'structured')
+  return SOURCE_LABELS[source] ?? (source || '(unknown source)')
 }
 
 function entryDetails(entry: LogEntry): Record<string, unknown> | null {
@@ -439,7 +439,7 @@ async function loadLogs(mode: LoadMode = 'reset') {
 
 function renderLogRow(entry: LogEntry) {
   const level = normalizedLevel(entry)
-  const source = entry.source || 'structured'
+  const source = entry.source || '(unknown source)'
   const details = entryDetails(entry)
   const clientName = detailLabel(details, 'client_name')
   const toolName = detailLabel(details, 'tool_name') ?? detailLabel(details, 'tool')

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -528,13 +528,13 @@ function handleEvent(event: SSEEvent): void {
     case 'keeper_guardrail':
       addTypedJournalEntry(
         event.name ?? agent,
-        `Guardrail: ${event.reason ?? 'stopped'}`,
+        `Guardrail: ${event.reason ?? '(unknown reason)'}`,
         'keepers',
         'keeper_guardrail',
         {
-          severity: event.severity ?? 'error',
+          severity: event.severity ?? '(unknown severity)',
           source: event.source,
-          narrativeText: `${actorLabel(event.name ?? agent)}가 guardrail에 의해 중단되었습니다: ${event.reason ?? 'stopped'}`,
+          narrativeText: `${actorLabel(event.name ?? agent)}가 guardrail에 의해 중단되었습니다: ${event.reason ?? '(unknown reason)'}`,
         },
       )
       break
@@ -902,7 +902,7 @@ function handleEvent(event: SSEEvent): void {
       const auditKind = (event.audit_kind ?? (p.kind as string)) ?? type
       const auditTarget = event.audit_target ?? (p.target as string | undefined)
       const auditSummary = (event.audit_summary ?? (p.summary as string)) ?? auditKind
-      const auditSeverity = (event.audit_severity ?? (p.severity as string)) ?? 'info'
+      const auditSeverity = (event.audit_severity ?? (p.severity as string)) ?? '(unknown severity)'
       appendAuditEntry({
         id: auditId,
         ts: auditTs,


### PR DESCRIPTION
## Summary

Dashboard 전체 sweep — 13 file에 걸친 25+ legitimate-looking fallback label 박멸. PR series의 *남은 dispersed candidates* 일괄 처리.

## 변경 분포 (13 file)

| File | Site | Pattern |
|---|---|---|
| api/keeper.ts | 2 | source / severity |
| components/governance.ts | 1 | reason |
| components/harness-health-sections.ts | 5 | reject / agent / gate / cascade |
| components/keeper-detail-shell.ts | 1 | cascade |
| components/keeper-tool-access.ts | 2 | sandbox_profile / network_mode |
| components/ide/ide-context-lens.ts | 4 | workspace / diagnostic / annotation |
| components/ide/ide-branch-context-panel.ts | 1 | workspace |
| components/ide/ide-conversation-rail.ts | 5 | keeper / decision event |
| components/ide/keeper-cursor-overlay.ts | 1 | focus_mode |
| components/ide/keeper-shell-drawer.ts | 1 | keeper |
| components/git-graph-panel.ts | 1 | workspace |
| components/logs.ts | 2 | source |
| sse.ts | 4 | reason / severity |

All replacements: legitimate-looking string → `'(unknown ...)'` / `'(no ...)'` explicit marker.

## Out of scope (false positive, kept)

- **typed enum defaults**: PipelineStage 'idle'/'offline', style enum 'default'/'standard'/'reading' (caller cascade)
- **convention markers**: 'system' (actor), 'manual' (token source), 'text' (CodeMirror lang), 'detached' (git HEAD), 'root' (entity), 'overview' (router default)
- **internal id-suffix fallbacks**: oas-runtime-store, keeper-state, workflow-context

## 검증

- `pnpm typecheck`: green
- Variant-affected tests: PASS (harness-health-sections.test.ts 86/86 — 2 expectation 업데이트)
- 전체 test: 7488 / 7481 PASS (남은 7 fail = 3 pre-existing dashboard-shell/widget-solo + 4 다른 file pre-existing, 변경 무관)

## Goal alignment

`/goal`: "대시보드가 연결 끊긴 정보나 텔레메트리나 로그가 없도록, 하드코딩이 대시보드에서 완전히 제거될 때까지 올바른 정보로 개선".

PR series progression:
- #15303 (merged): presence FALLBACK_PRESENCE
- #15309 (draft): activeIdeFile null
- #15312 (merged): telemetry-unified
- #15314 (merged): planning-panel
- #15318 (draft): API normalization
- #15320 (draft): component layer
- #15321 (draft): overview ticker
- #15322 (draft): overlay/goal-tree
- **PR (this)**: dispersed sweep — 25+ site, 13 file

RFC-WAIVED: dashboard-only fallback label refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
