### PR TITLE
feat(ide): show activity context coverage

### DIFF
--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -54,6 +54,7 @@ describe('IdeActivityPanel', () => {
     expect(container.querySelector('[data-testid="ide-context-lens"]')).not.toBeNull()
     expect(container.textContent).toContain('RUN PROGRESS')
     expect(container.textContent).toContain('0/0 linked')
+    expect(container.querySelector('[role="progressbar"]')?.getAttribute('aria-valuenow')).toBe('0')
     expect(container.textContent).toContain('no keeper activity')
   })
 
@@ -145,6 +146,7 @@ describe('IdeActivityPanel', () => {
       expect(container.textContent).toContain('1 line anchors')
       expect(container.textContent).toContain('1/1 linked')
     })
+    expect(container.querySelector('[role="progressbar"]')?.getAttribute('aria-valuenow')).toBe('100')
 
     const surfaces = [...container.querySelectorAll('.ide-run-progress-surfaces > span')]
       .map(node => node.textContent)
@@ -222,6 +224,52 @@ describe('IdeActivityPanel', () => {
       line: 4,
       surface: 'PR',
     })])
+  })
+
+  it('shows linked context coverage for mixed activity events', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({
+        events: [
+          {
+            seq: 1,
+            ts_ms: 100,
+            ts_iso: '2026-05-05T10:00:00Z',
+            room_id: 'run-default',
+            kind: 'telemetry.turn',
+            actor: { kind: 'keeper', id: 'sangsu' },
+            subject: { kind: 'log', id: 'turn-1' },
+            payload: {
+              log_id: 'turn-1',
+            },
+            tags: [],
+          },
+          {
+            seq: 2,
+            ts_ms: 200,
+            ts_iso: '2026-05-05T10:00:01Z',
+            room_id: 'run-default',
+            kind: 'keeper.note',
+            actor: { kind: 'keeper', id: 'analyst' },
+            subject: { kind: 'note', id: 'note-1' },
+            payload: {
+              summary: 'unlinked note',
+            },
+            tags: [],
+          },
+        ],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ))
+
+    const container = document.createElement('div')
+    render(h(IdeActivityPanel, { activeFile: 'lib/runtime.ml' }), container)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('1/2 linked')
+      expect(container.textContent).toContain('50%')
+    })
+    const coverage = container.querySelector('[role="progressbar"]')
+    expect(coverage?.getAttribute('aria-label')).toBe('Linked context coverage 1 of 2 events')
+    expect(coverage?.getAttribute('aria-valuenow')).toBe('50')
   })
 
   it('maps nested activity context and evidence refs into IDE route links', async () => {
@@ -687,6 +735,8 @@ describe('IdeActivityPanel', () => {
       totalEvents: 3,
       currentFileEvents: 1,
       linkedEvents: 3,
+      linkedCoveragePercent: 100,
+      linkedCoverageLabel: '100%',
       keeperTotalCount: 2,
       latestAgeLabel: '30s ago',
       activeGoal: {

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -108,6 +108,8 @@ export interface IdeRunProgressSummary {
   readonly totalEvents: number
   readonly currentFileEvents: number
   readonly linkedEvents: number
+  readonly linkedCoveragePercent: number
+  readonly linkedCoverageLabel: string
   readonly keeperTotalCount: number
   readonly latestAgeLabel: string
   readonly surfaceCounts: ReadonlyArray<IdeRunProgressSurfaceCount>
@@ -476,6 +478,9 @@ export function deriveIdeRunProgressSummary(
       && normalizeIdeContextFilePath(event.context.file_path) === activeFilePath,
     ).length
   const linkedEvents = events.filter(event => event.context !== undefined).length
+  const linkedCoveragePercent = events.length === 0
+    ? 0
+    : Math.round((linkedEvents / events.length) * 100)
   const surfaceCounts: IdeRunProgressSurfaceCount[] = PROGRESS_SURFACES.map(([key, label]) => {
     const matchingEvents = events.filter(event => event.context?.[key])
     return {
@@ -514,6 +519,8 @@ export function deriveIdeRunProgressSummary(
     totalEvents: events.length,
     currentFileEvents,
     linkedEvents,
+    linkedCoveragePercent,
+    linkedCoverageLabel: `${linkedCoveragePercent}%`,
     keeperTotalCount: keeperEntries.length,
     latestAgeLabel: latestAgeLabel(events),
     surfaceCounts,
@@ -528,6 +535,22 @@ function RunProgressStrip({ summary }: { readonly summary: IdeRunProgressSummary
       <div class="ide-run-progress-head">
         <span>RUN PROGRESS</span>
         <span>${summary.linkedEvents}/${summary.totalEvents} linked</span>
+      </div>
+      <div class="ide-run-progress-coverage">
+        <div class="ide-run-progress-coverage-head">
+          <span>CONTEXT COVERAGE</span>
+          <span>${summary.linkedCoverageLabel}</span>
+        </div>
+        <div
+          class="ide-run-progress-coverage-bar"
+          role="progressbar"
+          aria-label=${`Linked context coverage ${summary.linkedEvents} of ${summary.totalEvents} events`}
+          aria-valuemin="0"
+          aria-valuemax="100"
+          aria-valuenow=${summary.linkedCoveragePercent}
+        >
+          <span style=${{ width: summary.linkedCoverageLabel }} />
+        </div>
       </div>
       <div class="ide-run-progress-stats" role="list" aria-label="Run progress stats">
         <span role="listitem"><strong>${summary.totalEvents}</strong> events</span>

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -1605,6 +1605,7 @@ button.ide-persistence-focus:focus-visible {
 }
 
 .ide-run-progress-head > span,
+.ide-run-progress-coverage-head > span,
 .ide-run-progress-stats > span,
 .ide-run-progress-surfaces > span,
 .ide-run-progress-keepers > span {
@@ -1612,6 +1613,37 @@ button.ide-persistence-focus:focus-visible {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.ide-run-progress-coverage {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.ide-run-progress-coverage-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  color: var(--color-fg-muted);
+  font: var(--type-eyebrow);
+}
+
+.ide-run-progress-coverage-bar {
+  width: 100%;
+  height: 4px;
+  overflow: hidden;
+  border-radius: var(--r-0);
+  background: var(--color-bg-muted);
+}
+
+.ide-run-progress-coverage-bar span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: color-mix(in srgb, var(--color-accent-fg) 76%, var(--color-status-info));
+  transition: width var(--t-fast) ease;
 }
 
 .ide-run-progress-stats,


### PR DESCRIPTION
## Summary

- add a compact context-coverage meter to the IDE Activity Run Progress strip
- derive linked-event coverage alongside existing event, keeper, surface, and active-goal counts
- cover empty, fully linked, and mixed linked/unlinked activity snapshots

## Validation

- `pnpm install --offline`
- `pnpm exec vitest run src/components/ide/ide-activity-panel.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/ide/ide-activity-panel.ts src/components/ide/ide-activity-panel.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`
