### PR TITLE
[dashboard/types] fix: widen PipelineStage with explicit 'unknown' member

### DIFF
--- a/dashboard/src/components/keeper-pipeline-stage.test.ts
+++ b/dashboard/src/components/keeper-pipeline-stage.test.ts
@@ -13,12 +13,12 @@ describe('PipelineStageBadge', () => {
     expect(badge!.classList.contains('stage-thinking')).toBe(true)
   })
 
-  it('renders offline for null stage', () => {
+  it('renders unknown for null stage', () => {
     const container = document.createElement('div')
     render(h(PipelineStageBadge, { stage: null }), container)
-    expect(container.textContent).toContain('offline')
+    expect(container.textContent).toContain('unknown')
     const badge = container.querySelector('.pipeline-stage-badge')
-    expect(badge!.classList.contains('stage-offline')).toBe(true)
+    expect(badge!.classList.contains('stage-unknown')).toBe(true)
   })
 
   it('renders raw value for unknown stage', () => {

--- a/dashboard/src/components/keeper-pipeline-stage.ts
+++ b/dashboard/src/components/keeper-pipeline-stage.ts
@@ -28,7 +28,7 @@ export function PipelineStageBadge({
 }: {
   stage?: PipelineStage | null
 }) {
-  const current = stage ?? 'offline'
+  const current = stage ?? 'unknown'
   const label =
     STAGES.find((s) => s.key === current)?.label ?? current
 

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -508,7 +508,7 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
       return {
         name,
         runtime_class: 'keeper' as const,
-        pipeline_stage: (asString(row.pipeline_stage) ?? 'idle') as PipelineStage,
+        pipeline_stage: (asString(row.pipeline_stage) ?? 'unknown') as PipelineStage,
         phase: toKeeperPhase(asString(row.phase)),
         paused: asBoolean(row.paused),
         registered:

--- a/dashboard/src/live-store.ts
+++ b/dashboard/src/live-store.ts
@@ -175,7 +175,7 @@ export const keeperHealthSummary: ReadonlySignal<KeeperHealthSummary> = computed
     const ratio = k.context_ratio ?? 0
     if (ratio > thresholds.critical) criticalCount++
     else if (ratio > thresholds.warn || stale.has(k.name)) warningCount++
-    return { name: k.name, ratio, stage: (k.pipeline_stage ?? 'idle') as PipelineStage }
+    return { name: k.name, ratio, stage: (k.pipeline_stage ?? 'unknown') as PipelineStage }
   }).sort((a, b) => b.ratio - a.ratio)
 
   return {

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -667,6 +667,7 @@ export type PipelineStage =
   | 'paused'
   | 'crashed'
   | 'restarting'
+  | 'unknown'
 
 // Aggregated metrics computed by the backend over a sliding window.
 // Fields mirror dashboard_http_keeper_detail.ml summary output.


### PR DESCRIPTION
## Summary

`PipelineStage` typed union 확장 — `'unknown'` member 추가하고 3 fallback site (`?? 'idle'` / `?? 'offline'`) 박멸.

Goal hook이 요구한 *typed enum widening* 영역 처리. PR series **완결**.

## 변경 (4 file)

| File | Site | Before | After |
|---|---|---|---|
| `types/core.ts` | union 정의 | 12 members | **13 members** (+ `'unknown'`) |
| `keeper-store-normalize.ts` | 511 | `?? 'idle'` | `?? 'unknown'` |
| `live-store.ts` | 178 | `?? 'idle'` | `?? 'unknown'` |
| `keeper-pipeline-stage.ts` | 31 | `stage ?? 'offline'` | `?? 'unknown'` |

UI 동작: `PipelineStageBadge`의 STAGES lookup 결과 undefined → label fallback `'unknown'` 표시 + `stage-unknown` CSS class.

## Cascade 측정

| Check | 결과 |
|---|---|
| Exhaustive `switch` 사용처 | **없음** — string union으로 사용, discriminator switch 미존재 |
| `as PipelineStage` 캐스트 site | 2 (모두 fallback 영역) |
| `STAGES` constant | 'unknown' 미포함 (intentional — visual stage dot은 legitimate stages만) |
| `pipeline-stage.css` `stage-unknown` class | dashboard CSS가 unknown 가짜 표시 안 함 — 기본 badge style 적용 |

## 검증

- `pnpm typecheck`: green
- `keeper-pipeline-stage.test.ts`: 3/3 PASS (1 expectation 업데이트: null → 'unknown' instead of 'offline')

## Goal 완결

`/goal`: "대시보드가 연결 끊긴 정보나 텔레메트리나 로그가 없도록, 하드코딩이 대시보드에서 완전히 제거될 때까지 올바른 정보로 개선".

PR series 완결 (10 PRs):
1. #15303 (merged): presence FALLBACK_PRESENCE
2. #15309 (draft): activeIdeFile null
3. #15312 (merged): telemetry-unified
4. #15314 (merged): planning-panel
5. #15318 (draft): API normalization
6. #15320 (draft): component layer
7. #15321 (draft): overview ticker
8. #15322 (draft): overlay/goal-tree
9. #15326 (draft): dispersed sweep (13 file)
10. **PR (this)**: PipelineStage typed enum widening

본 PR로 *typed enum widening* 잔존 항목 박멸. *남은 dashboard hardcoded fallback*는 모두 *legit convention markers* (system actor, manual OAuth, text language id, detached git state, router default, form defaults, internal id-suffix, react keys, explicit `'unknown'`/`'none'`/`'-'` placeholders) — false positive로 audit 완료.

RFC-WAIVED: dashboard-only typed enum widening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
