### PR TITLE
[dashboard/credential] fix: extract DEFAULT_OAUTH_METHOD constant (kill 'web' magic string)

### DIFF
--- a/dashboard/src/components/credential-settings.ts
+++ b/dashboard/src/components/credential-settings.ts
@@ -9,9 +9,12 @@ import {
   normalizeCredentialsResponse,
   type Credential,
   type CredentialCreatePayload,
+  type CredentialOauthMethod,
   type CredentialState,
   type CredentialType,
 } from '../api/credentials'
+
+const DEFAULT_OAUTH_METHOD: CredentialOauthMethod = 'web'
 import { createAsyncResource } from '../lib/async-state'
 import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
@@ -45,7 +48,7 @@ const addDraft = signal<CredentialCreatePayload>({
   name: '',
   username: '',
   type: 'github',
-  oauth_method: 'web',
+  oauth_method: DEFAULT_OAUTH_METHOD,
   description: '',
 })
 
@@ -154,7 +157,7 @@ export function buildCredentialCreateRequest(payload: CredentialCreatePayload): 
 }
 
 function resetAddDraft() {
-  addDraft.value = { id: '', name: '', username: '', type: 'github', oauth_method: 'web', description: '' }
+  addDraft.value = { id: '', name: '', username: '', type: 'github', oauth_method: DEFAULT_OAUTH_METHOD, description: '' }
   saveError.value = null
 }
 
@@ -255,7 +258,7 @@ export function CredentialSettings() {
         gh_config_dir: sanitizeOptionalString(draft.gh_config_dir),
         ssh_key_path: sanitizeOptionalString(draft.ssh_key_path),
         gpg_key_id: sanitizeOptionalString(draft.gpg_key_id),
-        oauth_method: draft.oauth_method ?? 'web',
+        oauth_method: draft.oauth_method ?? DEFAULT_OAUTH_METHOD,
         token: sanitizeOptionalString(draft.token),
         description: draft.description?.trim() || undefined,
       })
@@ -351,7 +354,7 @@ export function CredentialSettings() {
                   addDraft.value = {
                     ...draft,
                     type: nextType,
-                    oauth_method: nextType === 'github' ? draft.oauth_method ?? 'web' : 'web',
+                    oauth_method: nextType === 'github' ? draft.oauth_method ?? DEFAULT_OAUTH_METHOD : DEFAULT_OAUTH_METHOD,
                     token: nextType === 'github' ? draft.token ?? '' : '',
                   }
                 }}
@@ -366,11 +369,11 @@ export function CredentialSettings() {
                 <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">gh login</label>
                 <select
                   class="${fieldStyle}"
-                  value=${draft.oauth_method ?? 'web'}
+                  value=${draft.oauth_method ?? DEFAULT_OAUTH_METHOD}
                   onChange=${(e: Event) => {
                     addDraft.value = {
                       ...draft,
-                      oauth_method: (e.target as HTMLSelectElement).value === 'with_token' ? 'with_token' : 'web',
+                      oauth_method: (e.target as HTMLSelectElement).value === 'with_token' ? 'with_token' : DEFAULT_OAUTH_METHOD,
                     }
                   }}
                 >


### PR DESCRIPTION
## Summary

`credential-settings.ts`의 7 site에 분산된 `'web'` magic string을 `DEFAULT_OAUTH_METHOD` named constant로 추출. CLAUDE.md "Magic Number 금지" §"같은 리터럴이 2곳 이상 등장하면 반드시 named constant로 교체" 정공.

## 변경 (1 file, 7 site)

| Site | 의미 | Before | After |
|---|---|---|---|
| 48 | addDraft initial | `'web'` | `DEFAULT_OAUTH_METHOD` |
| 161 | resetAddDraft | `'web'` | `DEFAULT_OAUTH_METHOD` |
| 262 | form submit fallback | `?? 'web'` | `?? DEFAULT_OAUTH_METHOD` |
| 358 | type=github branch | `?? 'web' : 'web'` | `?? DEFAULT_OAUTH_METHOD : DEFAULT_OAUTH_METHOD` |
| 373 | select value | `?? 'web'` | `?? DEFAULT_OAUTH_METHOD` |
| 377 | select onChange | `: 'web'` | `: DEFAULT_OAUTH_METHOD` |

```typescript
const DEFAULT_OAUTH_METHOD: CredentialOauthMethod = 'web'
```

## Goal 충족 의미

`/goal`: "하드코딩이 대시보드에서 완전히 제거될 때까지". `'web'`은 *legitimate OAuth method value*이지만 7 site에 *duplicated magic string*으로 박혀 있어 "dashboard default vs backend-supplied value" 의도 불분명. SSOT constant로 명시.

## PR series 완결 (11 PRs)

| # | PR | 박멸 영역 |
|---|---|---|
| 1 | #15303 (merged) | presence FALLBACK_PRESENCE |
| 2 | #15309 (draft) | activeIdeFile null + 4 store |
| 3 | #15312 (merged) | telemetry-unified 6 label |
| 4 | #15314 (merged) | planning-panel 4 label |
| 5 | #15318 (draft) | API normalization 6 label |
| 6 | #15320 (draft) | component layer 8 label |
| 7 | #15321 (draft) | overview ticker 3 label |
| 8 | #15322 (draft) | overlay/goal-tree 3 label |
| 9 | #15326 (draft) | dispersed sweep 25+ site, 13 file |
| 10 | #15329 (draft) | PipelineStage typed enum widening |
| 11 | **(this)** | DEFAULT_OAUTH_METHOD constant |

## 검증

- `pnpm typecheck`: green
- CredentialOauthMethod type 미변경 (literal 'web'을 typed constant로 binding만)

RFC-WAIVED: dashboard-only constant extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
