### PR TITLE
[dashboard/cascade] fix: extract DEFAULT_CASCADE_CHIP constant

### DIFF
--- a/dashboard/src/components/cascade-inspector.ts
+++ b/dashboard/src/components/cascade-inspector.ts
@@ -20,13 +20,14 @@ export type CascadeInspectorFocus = 'deep-dive' | 'compare'
 type CascadeInspectorChip = 'trace' | CascadeInspectorFocus
 
 const CASCADE_INSPECTOR_FOCUSES: CascadeInspectorFocus[] = ['deep-dive', 'compare']
+const DEFAULT_CASCADE_CHIP: CascadeInspectorChip = 'trace'
 
 export function isCascadeInspectorFocus(v: string | undefined): v is CascadeInspectorFocus {
   return !!v && (CASCADE_INSPECTOR_FOCUSES as string[]).includes(v)
 }
 
 export function cascadeInspectorRouteParams(focus: CascadeInspectorChip): Record<string, string> {
-  return focus === 'trace'
+  return focus === DEFAULT_CASCADE_CHIP
     ? { section: 'runtime', view: 'inspector' }
     : { section: 'runtime', view: 'inspector', focus }
 }
@@ -144,12 +145,12 @@ function CascadeFocusRail({
   focus: CascadeInspectorFocus | null
   traceCount: number
 }) {
-  const active: CascadeInspectorChip = focus ?? 'trace'
+  const active: CascadeInspectorChip = focus ?? DEFAULT_CASCADE_CHIP
   return html`
     <div class="flex flex-col gap-2" aria-label="Cascade inspector focus" data-testid="cascade-focus-rail">
       <${FilterChips}
         chips=${[
-          { key: 'trace', label: 'Trace', count: traceCount, title: 'strategy trace와 runtime health' },
+          { key: DEFAULT_CASCADE_CHIP, label: 'Trace', count: traceCount, title: 'strategy trace와 runtime health' },
           { key: 'deep-dive', label: 'Deep dive', count: traceCount, title: 'latest cascade decision detail' },
           { key: 'compare', label: 'Compare', count: traceCount, title: 'ordered vs filtered/exhausted decisions' },
         ]}


### PR DESCRIPTION
## Summary

`cascade-inspector.ts` 'trace' literal 3 binding 중복 → `DEFAULT_CASCADE_CHIP` constant.

CLAUDE.md "Magic Number 금지" (2곳+ 등장 시 named constant) 정공.

| Site | 이전 | 이후 |
|---|---|---|
| 29 (equality) | `focus === 'trace'` | `focus === DEFAULT_CASCADE_CHIP` |
| 147 (fallback) | `focus ?? 'trace'` | `?? DEFAULT_CASCADE_CHIP` |
| 152 (FilterChips key) | `{ key: 'trace', ... }` | `{ key: DEFAULT_CASCADE_CHIP, ... }` |

Kept (legit):
- type union member 'trace' in `CascadeInspectorChip = 'trace' | ...`

`/goal` series #13. typecheck green, 9/9 PASS.

RFC-WAIVED: dashboard-only constant extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
