### PR TITLE
feat(ide): focus keeper breadcrumb context

### DIFF
--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -58,6 +58,7 @@ import { deriveIdeStatusbarModel, IdeShell } from './ide-shell'
 import { navigate, route } from '../../router'
 import { clearTraces, pushTrace } from './keeper-trace-store'
 import { activeIdeFile, ideContextFocus } from './ide-state'
+import { cursorOverlaySignal } from './keeper-cursor-overlay'
 
 function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
   const button = Array.from(container.querySelectorAll('button'))
@@ -127,6 +128,7 @@ describe('IdeShell', () => {
     route.value = { tab: 'overview', params: {}, postId: null }
     activeIdeFile.value = 'package.json'
     ideContextFocus.value = null
+    cursorOverlaySignal.value = { cursors: new Map(), heatmap: new Map(), collisions: [], active_file: null }
     clearTraces()
   })
 
@@ -354,6 +356,59 @@ describe('IdeShell', () => {
       'Telemetry turn-42',
       'Keeper sangsu',
     ])
+  })
+
+  it('focuses active keeper breadcrumb chips into routeable code and keeper context', async () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+      postId: null,
+    }
+    activeIdeFile.value = 'lib/runtime.ml'
+    cursorOverlaySignal.value = {
+      cursors: new Map([[
+        'sangsu',
+        {
+          keeper_id: 'sangsu',
+          file_path: 'lib/runtime.ml',
+          line: 42,
+          column: 7,
+          focus_mode: 'editing',
+          last_update: Date.parse('2026-05-06T00:00:00Z'),
+          tool_name: 'ocamllsp',
+          turn: 9,
+        },
+      ]]),
+      heatmap: new Map(),
+      collisions: [],
+      active_file: 'lib/runtime.ml',
+    }
+
+    render(h(IdeShell, {}), container)
+
+    const keeperButton = await waitFor(() => {
+      const button = container.querySelector<HTMLButtonElement>('.ide-breadcrumb-keeper')
+      expect(button?.getAttribute('aria-label')).toBe('Focus sangsu keeper context at line 42')
+      return button!
+    })
+
+    fireEvent.click(keeperButton)
+
+    expect(ideContextFocus.value).toMatchObject({
+      file_path: 'lib/runtime.ml',
+      line: 42,
+      surface: 'Keeper',
+      label: 'ocamllsp',
+      source_id: 'breadcrumb:sangsu:42',
+      keeper_id: 'sangsu',
+    })
+    expect(ideContextFocus.value?.route_links?.map(link => link.label)).toEqual(['Code', 'Keeper'])
+    await waitFor(() => expect(container.querySelector('[data-testid="ide-toolbar-context-focus"]')?.textContent)
+      .toContain('ocamllsp'))
+    const routeGroups = [...container.querySelectorAll<HTMLButtonElement>('.ide-toolbar-context-route-group-action')]
+    expect(routeGroups.map(button => button.textContent)).toEqual(['Code1', 'Runtime1'])
+    fireEvent.click(routeGroups[1]!)
+    expect(window.location.hash).toBe('#monitoring?section=agents&view=keepers&keeper=sangsu')
   })
 
   it('rejects unsafe IDE route file focus params', async () => {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -785,6 +785,7 @@ function IdeBreadcrumb() {
     readonly focusMode: KeeperCursor['focus_mode']
     readonly toolName: string | undefined
     readonly turn: number | undefined
+    readonly line: number
   }> = []
   for (const [keeperId, cursor] of overlay.cursors) {
     if (cursor.file_path === filePath) {
@@ -794,8 +795,28 @@ function IdeBreadcrumb() {
         focusMode: cursor.focus_mode,
         toolName: cursor.tool_name,
         turn: cursor.turn,
+        line: cursor.line,
       })
     }
+  }
+
+  const activateKeeperBreadcrumb = (keeper: (typeof activeOnFile)[number]) => {
+    focusIdeContextAnchor({
+      file_path: filePath,
+      line: keeper.line,
+      surface: 'Keeper',
+      label: keeper.toolName ?? keeper.focusMode,
+      source_id: `breadcrumb:${keeper.keeperId}:${keeper.line}`,
+      keeper_id: keeper.keeperId,
+      route_links: routeLinksForContext({
+        filePath,
+        line: keeper.line,
+        surface: 'Keeper',
+        label: keeper.toolName ?? keeper.focusMode,
+        sourceId: `breadcrumb:${keeper.keeperId}:${keeper.line}`,
+        keeperId: keeper.keeperId,
+      }),
+    })
   }
 
   return html`
@@ -822,10 +843,13 @@ function IdeBreadcrumb() {
         ? html`
           <span class="flex items-center gap-1 ml-auto shrink-0">
             ${activeOnFile.map(k => html`
-              <span
+              <button
                 key=${k.keeperId}
-                class="flex items-center gap-1"
+                type="button"
+                class="ide-breadcrumb-keeper"
                 title=${`${k.keeperId} · ${k.focusMode}${k.toolName ? ` · ${k.toolName}` : ''}${k.turn != null ? ` · turn ${k.turn}` : ''}`}
+                aria-label=${`Focus ${k.keeperId} keeper context at line ${k.line}`}
+                onClick=${() => activateKeeperBreadcrumb(k)}
                 style=${{ color: 'var(--color-fg-muted)' }}
               >
                 <span
@@ -842,7 +866,7 @@ function IdeBreadcrumb() {
                 <span>${k.keeperId}</span>
                 ${k.toolName ? html`<span class="text-[var(--color-fg-disabled)]" style=${{ fontSize: '10px' }}>${k.toolName}</span>` : null}
                 ${k.turn != null ? html`<span style=${{ fontSize: '10px', color: 'var(--color-accent-fg)' }}>T${k.turn}</span>` : null}
-              </span>
+              </button>
             `)}
           </span>
         `

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -498,6 +498,41 @@
   min-height: 2.25rem;
 }
 
+.ide-breadcrumb-keeper {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  min-width: 0;
+  max-width: 14rem;
+  min-height: 18px;
+  padding: 0 3px;
+  border: 1px solid transparent;
+  border-radius: var(--r-1);
+  background: transparent;
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  font: inherit;
+}
+
+.ide-breadcrumb-keeper > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-breadcrumb-keeper:hover,
+.ide-breadcrumb-keeper:focus-visible {
+  border-color: var(--color-border-default);
+  background: var(--color-bg-page);
+  color: var(--color-accent-fg);
+}
+
+.ide-breadcrumb-keeper:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 1px;
+}
+
 .ide-view-tabs,
 .ide-layer-picker {
   display: flex;


### PR DESCRIPTION
## Summary

- make active keeper chips in the IDE breadcrumb clickable
- focus the clicked keeper into code-line context with Code and Keeper route links
- keep the focused context visible in the toolbar route groups

## Validation

- `pnpm install --offline`
- `pnpm exec vitest run src/components/ide/ide-shell.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/ide/ide-shell.ts src/components/ide/ide-shell.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check origin/main...HEAD`
