### PR TITLE
[dashboard/primitives] fix: extract DEFAULT_* constants for variant fallbacks

### DIFF
--- a/dashboard/src/components/band.ts
+++ b/dashboard/src/components/band.ts
@@ -39,6 +39,8 @@ export type BandKind =
   | 'err'
   | 'stalled'
 
+const DEFAULT_BAND_KIND: BandKind = 'default'
+
 interface BandProps {
   /** State tone. `undefined` ≡ `default` (idle, border-strong color). */
   kind?: BandKind
@@ -78,7 +80,7 @@ const KIND_STYLE: Record<BandKind, KindStyle> = {
 }
 
 export function Band(props: BandProps): VNode {
-  const kind = props.kind ?? 'default'
+  const kind = props.kind ?? DEFAULT_BAND_KIND
   const ks = KIND_STYLE[kind]
   const topRadius = props.topRadius !== false
 

--- a/dashboard/src/components/kpi-cell.ts
+++ b/dashboard/src/components/kpi-cell.ts
@@ -18,12 +18,15 @@ import type { VNode } from 'preact'
 import { Bar } from './bar'
 import { type BarKind } from './bar-shared'
 import {
+  DEFAULT_KPI_CELL_VARIANT,
   kpiCellAriaLabel,
   VALUE_COLOR_BY_KIND,
   DELTA_COLOR_BY_DIRECTION,
   MONO_STACK,
   type KpiCellProps,
 } from './kpi-shared'
+
+const DEFAULT_BAR_KIND: BarKind = 'default'
 
 export {
   kpiCellAriaLabel,
@@ -51,7 +54,7 @@ const spotlightOverrideStyle = {
 }
 
 export function KpiCell(props: KpiCellProps): VNode {
-  const variant = props.variant ?? 'standard'
+  const variant = props.variant ?? DEFAULT_KPI_CELL_VARIANT
   const valueColor = props.kind ? VALUE_COLOR_BY_KIND[props.kind] : 'var(--color-fg-primary)'
   const labelColor = 'var(--color-fg-disabled)'
   const captionColor = 'var(--color-fg-muted)'
@@ -99,7 +102,7 @@ export function KpiCell(props: KpiCellProps): VNode {
   // mapping: KpiCellKind ('ok' | 'warn' | 'err') is a strict subset of
   // BarKind so it forwards directly; absent kind → 'default' (brass-2
   // accent fill, matches SPEC `.bar > .fill` default rule).
-  const barKind: BarKind = props.kind ?? 'default'
+  const barKind: BarKind = props.kind ?? DEFAULT_BAR_KIND
   const progressRow = props.progress != null
     ? html`
         <div style=${{ marginTop: '2px' }}>

--- a/dashboard/src/components/kpi-shared.ts
+++ b/dashboard/src/components/kpi-shared.ts
@@ -9,6 +9,8 @@
 
 export type KpiStripVariant = 'standard' | 'compact' | 'stacked'
 
+export const DEFAULT_KPI_STRIP_VARIANT: KpiStripVariant = 'standard'
+
 const COLS_BY_VARIANT: Record<KpiStripVariant, number> = {
   standard: 6,
   compact: 6,
@@ -23,12 +25,14 @@ export function resolveStripCols(
   override: number | undefined,
 ): number {
   if (typeof override === 'number' && override > 0) return override
-  return COLS_BY_VARIANT[variant ?? 'standard']
+  return COLS_BY_VARIANT[variant ?? DEFAULT_KPI_STRIP_VARIANT]
 }
 
 // ── Cell ──
 
 export type KpiCellVariant = 'standard' | 'compact' | 'stacked'
+
+export const DEFAULT_KPI_CELL_VARIANT: KpiCellVariant = 'standard'
 
 /** Status tone — drives the value color. `undefined` = neutral primary. */
 export type KpiCellKind = 'ok' | 'warn' | 'err'

--- a/dashboard/src/components/surf.ts
+++ b/dashboard/src/components/surf.ts
@@ -69,7 +69,7 @@ export interface SurfProps {
   role?: 'alert' | 'status'
   /** Override the default 12px padding. Some callers want a tighter
    *  inline strip (auth banner) or a roomier card body (chat error). */
-  padding?: 'tight' | 'default' | 'loose'
+  padding?: SurfPadding
   /** Drop the rounded-[var(--r-1)] corner — used when Surf sits inside a parent
    *  that already provides the radius (e.g. inside a Card). */
   flat?: boolean
@@ -120,7 +120,11 @@ const KIND_STYLE: Record<SurfKind, KindStyle> = {
   },
 }
 
-const PADDING_BY_VARIANT = {
+export type SurfPadding = 'tight' | 'default' | 'loose'
+
+const DEFAULT_SURF_PADDING: SurfPadding = 'default'
+
+const PADDING_BY_VARIANT: Record<SurfPadding, string> = {
   tight: '8px 12px',
   default: '12px 16px',
   loose: '16px 20px',
@@ -128,7 +132,7 @@ const PADDING_BY_VARIANT = {
 
 export function Surf(props: SurfProps): VNode {
   const ks = KIND_STYLE[props.kind]
-  const padding = PADDING_BY_VARIANT[props.padding ?? 'default']
+  const padding = PADDING_BY_VARIANT[props.padding ?? DEFAULT_SURF_PADDING]
 
   const surfStyle = {
     background: ks.background,


### PR DESCRIPTION
## Summary

Dashboard primitive layer 4 file의 default-variant magic string 5 site → typed constant 박멸. PR series 최종.

## 변경 (4 file, 5 site)

| File | Constant | 이전 | 이후 |
|---|---|---|---|
| band.ts | `DEFAULT_BAND_KIND` | `?? 'default'` | `?? DEFAULT_BAND_KIND` |
| kpi-cell.ts | `DEFAULT_BAR_KIND` | `?? 'default'` | `?? DEFAULT_BAR_KIND` |
| kpi-shared.ts | `DEFAULT_KPI_CELL_VARIANT` | `?? 'standard'` (cell) | `?? DEFAULT_KPI_CELL_VARIANT` |
| kpi-shared.ts | `DEFAULT_KPI_STRIP_VARIANT` | `?? 'standard'` (strip) | `?? DEFAULT_KPI_STRIP_VARIANT` |
| surf.ts | `DEFAULT_SURF_PADDING` + `SurfPadding` type | inline `'tight' \| 'default' \| 'loose'` + `?? 'default'` | typed alias + constant |

## Goal 완결

`/goal`: "하드코딩이 대시보드에서 완전히 제거될 때까지". 이전 PR series가 *legitimate-looking fallback labels* (`'turn'`/`'local'`/`'recorded'`/...) 박멸 + *typed enum widening* (PipelineStage) 처리. 본 PR이 *마지막 잔존 single-site primitive-default literals* 박멸 — 모든 dashboard default literal이 *typed named constant*로 SSOT 단일화.

## 검증

- `pnpm typecheck`: green
- `band.test.ts` + `kpi-cell.test.ts` + `kpi-strip.test.ts` + `surf.test.ts`: 68/68 PASS

## PR series 완결 (14 PRs)

1. #15303 (merged): presence FALLBACK_PRESENCE
2. #15309 (draft): activeIdeFile null + 4 store
3. #15312 (merged): telemetry-unified 6 label
4. #15314 (merged): planning-panel 4 label
5. #15318 (draft): API normalization 6 label
6. #15320 (draft): component layer 8 label
7. #15321 (draft): overview ticker 3 label
8. #15322 (draft): overlay/goal-tree 3 label
9. #15326 (draft): dispersed sweep 25 site, 13 file
10. #15329 (merged): PipelineStage typed enum widening
11. #15330 (draft): DEFAULT_OAUTH_METHOD constant
12. #15331 (draft): DEFAULT_REACTIVITY_VIEW constant
13. #15332 (draft): DEFAULT_CASCADE_CHIP constant
14. **(this)**: DEFAULT_BAND_KIND + DEFAULT_BAR_KIND + DEFAULT_KPI_*_VARIANT + DEFAULT_SURF_PADDING

총 박멸 표면: discriminated union 구조 변경 2건 + ~60 label site + 1 typed enum widening + 19 magic string constant extraction.

**Remaining absolutely-legit single-site values** (CLAUDE.md "*요청 범위를 넘는 추상화 금지*" 적용):

- `api/core.ts:93 source ?? 'manual'`: token storage write-side OAuth/CLI distinct marker
- All convention markers (`'system'` actor, `'text'` lang id, `'detached'` git, `'overview'` router default, `'manual'`)
- All explicit missing markers (`'unknown'`, `'none'`, `'-'`, `'--'`, `'—'`, `'(unknown ...)'`, `'(no ...)'`)
- Internal id-suffix fallbacks (oas-runtime-store, keeper-state, React keys)

RFC-WAIVED: dashboard-only constant extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
