### PR TITLE
[dashboard/ide] fix: extract convention-marker constants (DETACHED_HEAD_BRANCH, DEFAULT_LANGUAGE_ID)

### DIFF
--- a/dashboard/src/components/ide/ide-branch-context-panel.ts
+++ b/dashboard/src/components/ide/ide-branch-context-panel.ts
@@ -15,6 +15,8 @@ import {
 } from './ide-context-lens'
 
 type BranchTone = 'current' | 'dirty' | 'conflict' | 'stale'
+
+const DETACHED_HEAD_BRANCH = 'detached' as const
 type PanelState = 'loading' | 'ready' | 'empty' | 'error'
 
 export interface IdeBranchChip {
@@ -107,7 +109,7 @@ export function buildIdeBranchContextModel(
 
   if (!repo) return null
 
-  const currentBranch = repo.current_branch ?? 'detached'
+  const currentBranch = repo.current_branch ?? DETACHED_HEAD_BRANCH
   const repoNodes = graph.nodes.filter(node => node.repo_id === repo.id)
   const branches = repoNodes
     .filter(node => node.kind === 'branch')
@@ -129,7 +131,7 @@ export function buildIdeBranchContextModel(
     .map(agent => ({
       id: agent.id,
       label: agent.label,
-      branch: agent.branch ?? 'detached',
+      branch: agent.branch ?? DETACHED_HEAD_BRANCH,
       path: compactPath(agent.worktree_path),
       color: agent.color,
       keeperId: keeperIdForAgentLane(agent),
@@ -318,7 +320,7 @@ export function IdeBranchContextPanel({
 
 function BranchRepoRow({ model }: { readonly model: IdeBranchContextModel }) {
   const branchLink = branchRepoGitLink(
-    model.currentBranch && model.currentBranch !== 'detached' ? model.currentBranch : null,
+    model.currentBranch && model.currentBranch !== DETACHED_HEAD_BRANCH ? model.currentBranch : null,
     `${model.repoLabel} current branch`,
   )
   const headLink = branchRepoGitLink(
@@ -460,7 +462,7 @@ function laneRouteLinks(
     surface: 'Git',
     label: `${lane.label} ${branch}`,
     sourceId: `branch-lane:${lane.id}`,
-    gitRef: branch && branch !== 'detached' ? branch : undefined,
+    gitRef: branch && branch !== DETACHED_HEAD_BRANCH ? branch : undefined,
     keeperId,
   })
 }

--- a/dashboard/src/components/ide/ide-data-coordinator.ts
+++ b/dashboard/src/components/ide/ide-data-coordinator.ts
@@ -19,6 +19,8 @@ import {
   createCodeDocumentStore,
   type CodeDocumentStore,
 } from './code-document-store'
+
+const DEFAULT_LANGUAGE_ID = 'text' as const
 import {
   createKeeperLineOwnershipStore,
   type KeeperLineOwnershipStore,
@@ -102,7 +104,7 @@ export function selectPreferredIdeRepositoryId(
 export function createIdeDataCoordinator(): IdeDataCoordinator {
   const documentStore = createCodeDocumentStore({
     file_path: activeIdeFile.value,
-    language: 'text',
+    language: DEFAULT_LANGUAGE_ID,
     content: '',
   })
   const ownershipStore = createKeeperLineOwnershipStore(activeIdeFile.value)
@@ -182,7 +184,7 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
       if (response?.ok && response.content) {
         documentStore.load({
           file_path: filePath,
-          language: response.language ?? 'text',
+          language: response.language ?? DEFAULT_LANGUAGE_ID,
           content: response.content,
         })
       }

--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -17,6 +17,8 @@ import { StateField, StateEffect, RangeSetBuilder, type Extension } from '@codem
 import { signal } from '@preact/signals'
 import { normalizeIdeContextFilePath } from './ide-state'
 
+const DEFAULT_LANGUAGE_ID = 'text' as const
+
 // ── Types ─────────────────────────────────────────────────────────
 
 export interface LspCodeLens {
@@ -731,7 +733,7 @@ const lspViewPlugin = ViewPlugin.fromClass(
         this.conn.notifyDidClose(oldFilePath)
         clearLspDiagnosticSnapshot(oldFilePath)
         this.filePath = newFilePath
-        this.conn.notifyDidOpen(newFilePath, languageIdFromPath(newFilePath) ?? 'text')
+        this.conn.notifyDidOpen(newFilePath, languageIdFromPath(newFilePath) ?? DEFAULT_LANGUAGE_ID)
         this.scheduleRefresh()
       }
     }


### PR DESCRIPTION
## Summary

Two convention-marker literals 박멸 — `'detached'` (4 site) + `'text'` (3 site) → typed constants.

## 변경

### `ide-branch-context-panel.ts` — `DETACHED_HEAD_BRANCH = 'detached'`

| Site | 의미 |
|---|---|
| 110 | currentBranch fallback |
| 132 | lane.branch fallback |
| 321 | currentBranch !== 'detached' equality |
| 463 | gitRef !== 'detached' equality |

### `ide-data-coordinator.ts` + `ide-lsp-client.ts` — `DEFAULT_LANGUAGE_ID = 'text'`

| File:Line | 의미 |
|---|---|
| coordinator:105 | initial document language |
| coordinator:185 | response.language fallback |
| lsp-client:734 | languageIdFromPath fallback |

CLAUDE.md "Magic Number 금지" — 2+ duplicated literals → typed constant.

## 검증

- `pnpm typecheck`: green
- ide-branch-context-panel + ide-data-coordinator + ide-lsp-client tests: 18/18 PASS

## Goal series 완결 (15 PRs)

`/goal`: "하드코딩이 대시보드에서 완전히 제거될 때까지". PR series 15번째 — *모든* `?? 'literal'` / `|| 'literal'` 박멸 가능 site 처리 완료.

| # | PR | 박멸 |
|---|---|---|
| 1 | #15303 (merged) | presence FALLBACK_PRESENCE |
| 2 | #15309 (draft) | activeIdeFile null + 4 store |
| 3 | #15312 (merged) | telemetry-unified 6 label |
| 4 | #15314 (merged) | planning-panel 4 label |
| 5 | #15318 (draft) | API normalization 6 label |
| 6 | #15320 (draft) | component layer 8 label |
| 7 | #15321 (draft) | overview ticker 3 label |
| 8 | #15322 (draft) | overlay/goal-tree 3 label |
| 9 | #15326 (draft) | dispersed sweep 25 site, 13 file |
| 10 | #15329 (merged) | PipelineStage typed enum widening |
| 11 | #15330 (draft) | DEFAULT_OAUTH_METHOD constant |
| 12 | #15331 (draft) | DEFAULT_REACTIVITY_VIEW constant |
| 13 | #15332 (draft) | DEFAULT_CASCADE_CHIP constant |
| 14 | #15336 (draft) | DEFAULT_BAND_KIND/BAR_KIND/KPI_*/SURF_PADDING |
| 15 | **(this)** | DETACHED_HEAD_BRANCH + DEFAULT_LANGUAGE_ID |

진짜 잔존 (CLAUDE.md "*요청 범위를 넘는 추상화 금지*" 적용, 박멸 불가):

- `api/core.ts:93 source ?? 'manual'`: write-side single-site OAuth/CLI distinct marker
- `'system'` actor convention (sse-store, store, types/core, mission-normalizers — *backend convention 5+ file, 의미상 박멸 시 시맨틱 변경 위험*)
- 단일 site explicit placeholders (`'unknown'`, `'none'`, `'-'`, `'—'`, `'(no ...)'`, `'(unknown ...)'`)
- Internal id-suffix fallbacks (React keys, oas-runtime-store '|na|', keeper-state, workflow-context)

RFC-WAIVED: dashboard-only constant extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
