### PR TITLE
[dashboard/api] fix: extract DEFAULT_STORED_TOKEN_SOURCE + STORED_TOKEN_SOURCES tuple

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -26,6 +26,10 @@ const TOKEN_META_STORAGE_KEY = 'masc_bearer_token_meta'
 
 type StoredTokenSource = 'dev' | 'manual' | 'url'
 
+const STORED_TOKEN_SOURCES = ['dev', 'manual', 'url'] as const
+
+const DEFAULT_STORED_TOKEN_SOURCE: StoredTokenSource = 'manual'
+
 export interface StoredTokenMeta {
   source: StoredTokenSource
   actor?: string | null
@@ -36,7 +40,7 @@ function normalizeStoredTokenMeta(value: unknown): StoredTokenMeta | null {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
   const record = value as Record<string, unknown>
   const source = typeof record.source === 'string' ? record.source : null
-  if (source !== 'dev' && source !== 'manual' && source !== 'url') return null
+  if (source === null || !(STORED_TOKEN_SOURCES as readonly string[]).includes(source)) return null
   const actor = sanitizeDashboardActorName(
     typeof record.actor === 'string' ? record.actor : null,
   )
@@ -44,7 +48,7 @@ function normalizeStoredTokenMeta(value: unknown): StoredTokenMeta | null {
     typeof record.scope === 'string' && record.scope.trim() !== ''
       ? record.scope.trim()
       : null
-  return { source, actor, scope }
+  return { source: source as StoredTokenSource, actor, scope }
 }
 
 function initTokenFromUrl(): void {
@@ -90,7 +94,7 @@ export function setStoredToken(
     return
   }
   const nextMeta = normalizeStoredTokenMeta({
-    source: meta.source ?? 'manual',
+    source: meta.source ?? DEFAULT_STORED_TOKEN_SOURCE,
     actor: meta.actor ?? null,
     scope: meta.scope ?? null,
   })


### PR DESCRIPTION
## Summary

`api/core.ts`의 `'manual'` literal 3 binding 중복 → `DEFAULT_STORED_TOKEN_SOURCE` + `STORED_TOKEN_SOURCES` 추출.

CLAUDE.md "Magic Number 금지" (2곳+ 등장 시 named constant) 정공. 동시에 `source !== 'dev' && source !== 'manual' && source !== 'url'` 하드코딩된 validation chain을 tuple-based membership check로 변경 (validation drift 방지).

## 변경 (1 file, 3 site)

| Site | Before | After |
|---|---|---|
| 27 (type union) | `'dev' \| 'manual' \| 'url'` | 유지 (type-level enumeration) |
| 39 (validation) | `source !== 'dev' && ... !== 'url'` | `(STORED_TOKEN_SOURCES as readonly string[]).includes(source)` |
| 93 (fallback) | `meta.source ?? 'manual'` | `?? DEFAULT_STORED_TOKEN_SOURCE` |

추가 신규:
- `STORED_TOKEN_SOURCES = ['dev', 'manual', 'url'] as const` — runtime tuple
- `DEFAULT_STORED_TOKEN_SOURCE: StoredTokenSource = 'manual'`

## 검증

- `pnpm typecheck`: green
- core.test.ts + mcp.test.ts: 48/48 PASS

## Goal series 완결 (16 PRs)

`/goal`: "하드코딩이 대시보드에서 완전히 제거될 때까지". 본 PR이 *agent action 가능한 모든* duplicated literal 박멸의 마지막 진입.

진짜 잔존 (agent action 불가):
- `'system'` actor convention (sse-store, store, types/core, mission-normalizers 등 5+ file): **backend semantic convention** — system message actor 의미. 박멸 시 시맨틱 변경 위험 (RFC scope, agent 권한 외).
- Single-site explicit placeholders / internal id-suffix / typed enum union members: CLAUDE.md "*요청 범위를 넘는 추상화 금지*" 적용.

RFC-WAIVED: dashboard-only constant extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
