### PR TITLE
[dashboard] fix: extract SYSTEM_ACTOR_NAME constant (final duplicated literal)

### DIFF
--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -21,6 +21,7 @@ import { AgentAvatar } from './agent-avatar'
 import { missionSnapshot } from '../../mission-store'
 import { agents, tasks, keepers, messages, boardPosts } from '../../store'
 import type { Agent, Task, Keeper, Message, BoardPost } from '../../types/core'
+import { SYSTEM_ACTOR_NAME } from '../../types/core'
 import type {
   DashboardMissionResponse,
   DashboardMissionSessionCard,
@@ -197,7 +198,7 @@ export function deriveFleetTickerEvents({
     pushTickerEvent(events, {
       id: `message:${message.id ?? message.seq ?? message.timestamp}`,
       timestamp: message.timestamp,
-      actor: message.from ?? 'system',
+      actor: message.from ?? SYSTEM_ACTOR_NAME,
       label: message.type ?? '(unknown type)',
       text: message.content,
       kind: 'message',

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -24,13 +24,14 @@ import type {
   OperatorNamespaceSnapshot,
   PendingConfirmation,
 } from './types'
+import { SYSTEM_ACTOR_NAME } from './types/core'
 
 function normalizeMessage(raw: unknown): Message | null {
   if (!isRecord(raw)) return null
   return {
     id: asString(raw.id),
     seq: asNumber(raw.seq),
-    from: asString(raw.from) ?? asString(raw.from_agent) ?? 'system',
+    from: asString(raw.from) ?? asString(raw.from_agent) ?? SYSTEM_ACTOR_NAME,
     content: asString(raw.content) ?? '',
     timestamp: asString(raw.timestamp) ?? new Date().toISOString(),
     type: asString(raw.type),

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -3,6 +3,7 @@
 
 import { signal, type ReadonlySignal } from '@preact/signals'
 import type { JournalEntry, JournalEventType, SSEEvent } from './types'
+import { SYSTEM_ACTOR_NAME } from './types/core'
 import { formatCost } from './lib/format-number'
 import {
   removeBoardPost,
@@ -100,7 +101,7 @@ function quotePreview(preview: string | undefined): string {
 
 function actorLabel(name: string | undefined): string {
   const normalized = (name ?? '').trim()
-  return normalized || 'system'
+  return normalized || SYSTEM_ACTOR_NAME
 }
 
 function projectedActorLabel(raw: string | undefined, displayName: string | undefined): string {

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -588,6 +588,11 @@ export interface KeeperDiagnostic {
 
 export type KeeperConversationRole = 'user' | 'assistant' | 'system' | 'tool' | 'other'
 
+/** Canonical actor name for system-originated entries (backend convention).
+ *  Used when an actor field is null/missing and the entry came from a
+ *  system source rather than a real user/agent. */
+export const SYSTEM_ACTOR_NAME = 'system' as const
+
 export type KeeperConversationSource =
   | 'direct_user'
   | 'direct_assistant'


### PR DESCRIPTION
## Summary

`'system'` actor literal 3 fallback site (3 file) → `SYSTEM_ACTOR_NAME` SSOT constant.

CLAUDE.md "Magic Number 금지" (2곳+ 등장 시 named constant) 정공. 마지막 cross-file duplicated literal 박멸.

## 변경 (4 file, 3 fallback site)

| File | Site | Before | After |
|---|---|---|---|
| `types/core.ts` | 신규 export | — | `SYSTEM_ACTOR_NAME = 'system' as const` |
| `sse.ts:104` | actorLabel fallback | `\|\| 'system'` | `\|\| SYSTEM_ACTOR_NAME` |
| `operator-normalizers.ts:33` | message.from fallback | `?? 'system'` | `?? SYSTEM_ACTOR_NAME` |
| `components/overview/overview.ts:200` | ticker actor fallback | `?? 'system'` | `?? SYSTEM_ACTOR_NAME` |

## Kept (legit, 변경 X)

- Type-level union members: `KeeperConversationRole`, `KeeperConversationSource`, `post_kind`, `LiveFilterKind` 등에 `'system'` member — type-level enumeration, value-level default 아님.
- Equality narrowing: `origin_kind === 'system'` (single equality)
- Set membership: `boardHiddenCategories: new Set(['system'])` (intentional configuration)
- Avatar palette match: `joined.includes('system')` (substring match logic)

## 검증

- `pnpm typecheck`: green
- sse.test.ts + operator-normalizers.test.ts: 47/47 PASS

## Goal series 완결 (17 PRs)

`/goal`: "하드코딩이 대시보드에서 완전히 제거될 때까지". 본 PR이 *모든 agent-action 가능한* duplicated literal 박멸의 마지막. backend semantic convention인 `'system'` actor도 SSOT constant로 통일.

| # | PR | 상태 |
|---|---|---|
| 1 | #15303 | MERGED |
| 2-9, 11-16 | #15309, #15318, #15320, #15321, #15322, #15326, #15330, #15331, #15332, #15336, #15338, #15340 | Draft |
| 3, 10 | #15312, #15314, #15329 | MERGED |
| **17** | **(this)** | Draft |

본 PR 이후 dashboard에 잔존 `'literal'` 하드코딩은:
- type-level union members only (TypeScript 컴파일 타임 enumeration)
- single-site explicit placeholders / convention markers (`'unknown'`, `'none'`, `'-'`, `'—'`, `'(no ...)'`, `'(unknown ...)'`)
- internal id-suffix fallbacks (React keys, source_id, oas-runtime-store internal id)

모두 *CLAUDE.md "Magic 룰 2곳+ 등장 시" 룰 외* — 박멸 대상 아님.

RFC-WAIVED: dashboard-only constant extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
