### PR TITLE
feat(ide): highlight focused diff context rows

### DIFF
--- a/dashboard/src/components/ide/ide-diff-view.test.ts
+++ b/dashboard/src/components/ide/ide-diff-view.test.ts
@@ -215,12 +215,34 @@ describe('diff preview chrome', () => {
       .toBe('Diff context: Task line 4, task task-runtime, 2 route links')
     expect(focus?.textContent).toContain('Task')
     expect(focus?.textContent).toContain('L4')
-    expect(container.querySelectorAll('[data-context-focus="true"]')).toHaveLength(2)
+    const focusedRows = container.querySelectorAll<HTMLElement>('[data-context-focus="true"]')
+    expect(focusedRows).toHaveLength(2)
+    expect(focusedRows[0]?.getAttribute('style')).toContain('inset 3px 0 0 var(--color-accent-fg)')
 
     const telemetry = [...container.querySelectorAll<HTMLButtonElement>('.ide-diff-context-links button')]
       .find(button => button.textContent === 'Telemetry')
     fireEvent.click(telemetry!)
     expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&q=turn-9')
+  })
+
+  it('renders the focused split diff row with the same visible rail', () => {
+    render(SplitDiffView([
+      row('delete', 4, null, 'old value'),
+      row('add', null, 4, 'new value'),
+      row('context', 5, 5, 'same value'),
+    ], {
+      file_path: 'lib/runtime.ml',
+      line: 4,
+      surface: 'PR',
+      label: 'PR 15035',
+      source_id: 'event-2',
+      activated_at_ms: Date.now(),
+      route_links: [],
+    }), container)
+
+    const focusedRows = container.querySelectorAll<HTMLElement>('[data-context-focus="true"]')
+    expect(focusedRows).toHaveLength(1)
+    expect(focusedRows[0]?.getAttribute('style')).toContain('inset 3px 0 0 var(--color-accent-fg)')
   })
 
   it('renders split empty state instead of a blank pane', () => {

--- a/dashboard/src/components/ide/ide-diff-view.ts
+++ b/dashboard/src/components/ide/ide-diff-view.ts
@@ -69,9 +69,11 @@ export function UnifiedDiffView(
               overflow: 'auto',
             }}
           >
-            ${rows.map(row => html`
+            ${rows.map(row => {
+              const focused = diffRowMatchesFocus(row, diffFocus)
+              return html`
               <li
-                data-context-focus=${diffRowMatchesFocus(row, diffFocus) ? 'true' : 'false'}
+                data-context-focus=${focused ? 'true' : 'false'}
                 style=${{
                   display: 'grid',
                   gridTemplateColumns: '32px 40px 40px minmax(0, 1fr)',
@@ -80,6 +82,7 @@ export function UnifiedDiffView(
                   padding: '0 var(--sp-3)',
                   background: diffBackground(row.kind),
                   color: row.kind === 'delete' ? 'var(--color-status-danger, var(--color-fg-secondary))' : 'var(--color-fg-secondary)',
+                  ...diffFocusRailStyle(focused),
                 }}
               >
                 <span style=${{ color: diffMarkerColor(row.kind), textAlign: 'center' }}>${diffMarker(row.kind)}</span>
@@ -87,7 +90,7 @@ export function UnifiedDiffView(
                 <span style=${{ color: 'var(--color-fg-disabled)', fontSize: 'var(--fs-11)', textAlign: 'right' }}>${row.newLine ?? ''}</span>
                 <span style=${{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', minWidth: 0 }}>${row.text}</span>
               </li>
-            `)}
+            `})}
           </ol>
         `}
     </div>
@@ -245,18 +248,21 @@ export function SplitDiffView(
       <div style=${{ overflow: 'auto' }}>
         ${splitRows.length === 0
           ? DiffEmptyState('No split diff rows for the selected file.')
-          : splitRows.map(row => html`
+          : splitRows.map(row => {
+            const focused = splitDiffRowMatchesFocus(row, diffFocus)
+            return html`
             <div
-              data-context-focus=${splitDiffRowMatchesFocus(row, diffFocus) ? 'true' : 'false'}
+              data-context-focus=${focused ? 'true' : 'false'}
               style=${{
                 display: 'grid',
                 gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
+                ...diffFocusRailStyle(focused),
               }}
             >
               <${SplitDiffCellView} cell=${row.before} />
               <${SplitDiffCellView} cell=${row.after} framed=${true} />
             </div>
-          `)}
+          `})}
       </div>
     </div>
   `
@@ -345,6 +351,16 @@ function diffMarkerColor(kind: string): string {
   if (kind === 'add') return 'var(--color-status-ok, var(--ok))'
   if (kind === 'delete') return 'var(--color-status-danger, var(--danger))'
   return 'var(--color-fg-disabled)'
+}
+
+function diffFocusRailStyle(focused: boolean): Record<string, string> {
+  return focused
+    ? {
+        boxShadow: 'inset 3px 0 0 var(--color-accent-fg)',
+        outline: '1px solid color-mix(in srgb, var(--color-accent-fg) 36%, transparent)',
+        outlineOffset: '-1px',
+      }
+    : {}
 }
 
 // ── Summary helpers ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- add a visible accent rail to focused rows in unified and split diff previews
- keep the existing diff context route links intact
- cover the visible focus state for both unified and split diff rendering

## Validation

- `pnpm install --offline`
- `pnpm exec vitest run src/components/ide/ide-diff-view.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/ide/ide-diff-view.ts src/components/ide/ide-diff-view.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`
