### PR TITLE
fix(keeper): clarify empty cascade diagnostics

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -274,6 +274,9 @@ let run_named
       ~label:cascade_name
       candidate_cfgs
   in
+  let configured_label_count = List.length configured_labels in
+  let original_candidate_count = List.length original_candidate_cfgs in
+  let tool_filtered_candidate_count = List.length tool_filtered_candidate_cfgs in
   let candidates =
     tool_filtered_candidate_cfgs
     |> Cascade_runtime_candidate.of_provider_configs
@@ -287,15 +290,8 @@ let run_named
                   cascade_name runtime_candidate_label runtime_candidate_label msg;
                 false)
   in
+  let health_filtered_candidate_count = List.length candidates in
   let provider_attempt_provenance = base_provider_attempt_provenance in
-  if candidates = [] then
-    Log.Misc.error
-      "cascade %s: no callable models available in declared cascade — \
-       candidate_count=%d require_tool_choice_support=%b require_tool_support=%b"
-      cascade_name
-      (List.length configured_labels)
-      require_tool_choice_support
-      require_tool_support;
   match candidates with
   | [] ->
       let required_tool_names =
@@ -307,14 +303,38 @@ let run_named
           ~require_tool_choice_support ~require_tool_support
           original_candidates
       in
+      let empty_candidate_classification =
+        classify_empty_candidates
+          ~require_tool_choice_support
+          ~require_tool_support
+          ~tool_filtered_candidate_count
+      in
+      let classification_code =
+        empty_candidate_classification_code empty_candidate_classification
+      in
+      let exhaustion_summary =
+        match empty_candidate_classification with
+        | Tool_capability_empty ->
+          "no tool-capable providers after capability filter"
+        | Provider_unavailable ->
+          "providers unavailable after health/cooldown filter"
+      in
+      Log.Misc.error
+        "cascade %s: %s; classification=%s configured_label_count=%d \
+         original_candidate_count=%d tool_filtered_candidate_count=%d \
+         health_filtered_candidate_count=%d require_tool_choice_support=%b \
+         require_tool_support=%b"
+        cascade_name
+        exhaustion_summary
+        classification_code
+        configured_label_count
+        original_candidate_count
+        tool_filtered_candidate_count
+        health_filtered_candidate_count
+        require_tool_choice_support
+        require_tool_support;
       let internal_error =
-        match
-          classify_empty_candidates
-            ~require_tool_choice_support
-            ~require_tool_support
-            ~tool_filtered_candidate_count:
-              (List.length tool_filtered_candidate_cfgs)
-        with
+        match empty_candidate_classification with
         | Tool_capability_empty ->
           No_tool_capable_provider
             {
@@ -352,10 +372,14 @@ let run_named
                         (List.map
                            (fun tool_name -> `String tool_name)
                            required_tool_names) );
-                    ("candidate_count", `Int (List.length original_candidate_cfgs));
+                    ( "empty_candidate_classification",
+                      `String classification_code );
+                    ("configured_label_count", `Int configured_label_count);
+                    ("candidate_count", `Int original_candidate_count);
                     ( "tool_filtered_candidate_count",
-                      `Int (List.length tool_filtered_candidate_cfgs) );
-                    ("health_filtered_candidate_count", `Int (List.length candidates));
+                      `Int tool_filtered_candidate_count );
+                    ( "health_filtered_candidate_count",
+                      `Int health_filtered_candidate_count );
                     ( "rejected_candidate_count",
                       `Int (List.length provider_rejections) );
                     ( "rejection_reasons",

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -99,6 +99,10 @@ let classify_empty_candidates ~require_tool_choice_support ~require_tool_support
   then Tool_capability_empty
   else Provider_unavailable
 
+let empty_candidate_classification_code = function
+  | Tool_capability_empty -> "tool_capability_empty"
+  | Provider_unavailable -> "provider_unavailable"
+
 let provider_rejections_for_no_tool_error
     ~keeper_name ?runtime_mcp_policy ~tools
     ~require_tool_choice_support ~require_tool_support candidates =

--- a/lib/keeper/keeper_turn_driver_helpers.mli
+++ b/lib/keeper/keeper_turn_driver_helpers.mli
@@ -45,6 +45,9 @@ val classify_empty_candidates :
   tool_filtered_candidate_count:int ->
   empty_candidate_classification
 
+val empty_candidate_classification_code :
+  empty_candidate_classification -> string
+
 val provider_rejections_for_no_tool_error :
   keeper_name:string ->
   ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -2021,7 +2021,15 @@ let test_empty_candidate_classification_separates_tool_filter_from_availability 
     (FT.classify_empty_candidates
        ~require_tool_choice_support:false
        ~require_tool_support:false
-       ~tool_filtered_candidate_count:0)
+       ~tool_filtered_candidate_count:0);
+  Alcotest.(check string)
+    "tool capability code"
+    "tool_capability_empty"
+    (FT.empty_candidate_classification_code FT.Tool_capability_empty);
+  Alcotest.(check string)
+    "provider unavailable code"
+    "provider_unavailable"
+    (FT.empty_candidate_classification_code FT.Provider_unavailable)
 
 let test_keeper_cascade_engine_boundary () =
   let module E = Masc_mcp.Keeper_cascade_engine in


### PR DESCRIPTION
## Summary
- Replace the ambiguous empty-cascade log with separate tool capability vs provider availability diagnostics.
- Add configured/original/tool-filtered/health-filtered counts to the error log.
- Persist empty_candidate_classification and configured_label_count in the pre-dispatch manifest for dashboard/runtime trace consumers.

## Why
Recent runtime logs showed cascades with declared candidates being reported as no callable models. The underlying cause can be tool capability filtering or provider health/cooldown/local fallback exhaustion, and the old message made those cases look identical.

## Validation
- ocamlformat --check lib/keeper/keeper_turn_driver.ml lib/keeper/keeper_turn_driver_helpers.ml lib/keeper/keeper_turn_driver_helpers.mli test/test_keeper_runtime_manifest.ml
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_runtime_manifest.exe
- ./_build/default/test/test_keeper_runtime_manifest.exe