### PR TITLE
[dashboard/ide] fix: extract LSP_DEBOUNCE_MS constant (300ms)

### DIFF
--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -78,6 +78,11 @@ export interface SelectedAnnotation {
 
 // ── State Effects ────────────────────────────────────────────────
 
+/** Debounce window for LSP refresh + hover triggers (milliseconds).
+ *  Short enough to feel responsive, long enough to coalesce typing /
+ *  mouse-move bursts. */
+const LSP_DEBOUNCE_MS = 300
+
 const setCodeLenses = StateEffect.define<ReadonlyMap<number, LspCodeLens[]>>()
 const setInlayHints = StateEffect.define<ReadonlyMap<number, LspInlayHint[]>>()
 const setDiagnostics = StateEffect.define<ReadonlyMap<number, LspDiagnostic[]>>()
@@ -738,7 +743,7 @@ const lspViewPlugin = ViewPlugin.fromClass(
 
     private scheduleRefresh(): void {
       if (this.refreshTimer) clearTimeout(this.refreshTimer)
-      this.refreshTimer = setTimeout(() => this.refresh(), 300)
+      this.refreshTimer = setTimeout(() => this.refresh(), LSP_DEBOUNCE_MS)
     }
 
     private async refresh(): Promise<void> {
@@ -768,7 +773,7 @@ const lspViewPlugin = ViewPlugin.fromClass(
       this.hoverClientX = e.clientX
       this.hoverClientY = e.clientY
       if (this.hoverTimer) clearTimeout(this.hoverTimer)
-      this.hoverTimer = setTimeout(() => void this.triggerHover(), 300)
+      this.hoverTimer = setTimeout(() => void this.triggerHover(), LSP_DEBOUNCE_MS)
     }
 
     private onHoverLeave(): void {


### PR DESCRIPTION
## Summary

`ide-lsp-client.ts`의 `300` numeric literal 2 site → `LSP_DEBOUNCE_MS` constant.

| Site | 의미 | Before | After |
|---|---|---|---|
| 741 | scheduleRefresh debounce | `300` | `LSP_DEBOUNCE_MS` |
| 771 | onHoverMove debounce | `300` | `LSP_DEBOUNCE_MS` |

CLAUDE.md "Magic Number 금지" (2곳+ 등장 시 named constant). Numeric literal에도 적용.

## 검증

- `pnpm typecheck`: green
- ide-lsp-client.test.ts: 4/4 PASS

## Goal series 진행 (18 PRs)

`/goal`: numeric magic 룰 충족 후보 박멸.

RFC-WAIVED: dashboard-only constant extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
