### PR TITLE
feat(ide): surface keeper active queue

### DIFF
--- a/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
@@ -120,6 +120,55 @@ describe('IdeKeeperWorkPanel', () => {
     expect(window.location.hash).toContain('operation_id=op-151')
     expect(window.location.hash).toContain('q=op-151')
   })
+
+  it('surfaces the rest of the active keeper task queue as routable work', () => {
+    keepers.value = [keeperFixture()]
+    tasks.value = [
+      taskFixture({ goal_id: 'goal-runtime' }),
+      taskFixture({
+        id: 'task-next',
+        title: 'Wire keeper queue context',
+        status: 'in_progress',
+        goal_id: 'goal-next',
+        worktree: {
+          branch: 'feat/keeper-queue',
+          path: '/workspace/.worktrees/keeper-queue',
+          git_root: '/workspace',
+          repo_name: 'masc-mcp',
+        },
+        execution_links: {
+          session_id: 'sess-next',
+        },
+      }),
+      taskFixture({
+        id: 'task-done',
+        title: 'Completed queue item',
+        status: 'done',
+        goal_id: 'goal-next',
+      }),
+    ]
+
+    render(h(IdeKeeperWorkPanel, { keeperName: 'sangsu' }), container)
+
+    const queue = container.querySelector('[aria-label="Keeper active task queue"]')
+    expect(queue?.textContent).toContain('ACTIVE QUEUE')
+    expect(queue?.textContent).toContain('1 queued')
+    expect(queue?.textContent).toContain('task-next')
+    expect(queue?.textContent).toContain('Wire keeper queue context')
+    expect(queue?.textContent).not.toContain('task-done')
+
+    const queueButtons = Array.from(queue?.querySelectorAll('button') ?? [])
+    expect(queueButtons.map(button => button.textContent)).toEqual([
+      'Goal',
+      'Task',
+      'Git',
+      'Telemetry',
+      'Keeper',
+    ])
+
+    fireEvent.click(queueButtons.find(button => button.title === 'Task task-next')!)
+    expect(window.location.hash).toBe('#workspace?section=planning&view=default&task=task-next')
+  })
 })
 
 function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {

--- a/dashboard/src/components/ide/ide-keeper-work-panel.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.ts
@@ -42,6 +42,20 @@ interface KeeperWorkSummary {
 }
 
 const EMPTY_TOOLS: ReadonlyArray<string> = []
+const QUEUED_TASK_STYLE = {
+  display: 'grid',
+  gap: 'var(--sp-1)',
+  minWidth: 0,
+  paddingTop: 'var(--sp-2)',
+  borderTop: '1px solid var(--color-border-divider)',
+}
+const QUEUED_TASK_META_STYLE = {
+  overflow: 'hidden',
+  color: 'var(--color-fg-muted)',
+  fontSize: 'var(--fs-11)',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+}
 
 export function IdeKeeperWorkPanel({ keeperName }: IdeKeeperWorkPanelProps) {
   const summary = keeperWorkSummary(keeperName, keepers.value, tasks.value)
@@ -53,6 +67,7 @@ export function IdeKeeperWorkPanel({ keeperName }: IdeKeeperWorkPanelProps) {
   const currentGoalProgress = summary.currentGoalId
     ? goalProgressFor(summary.currentGoalId)
     : null
+  const queuedTasks = queuedActiveTasks(summary.activeTasks, currentTask)
   const attention = Boolean(
     keeper?.needs_attention
     || keeper?.trust?.needs_attention
@@ -117,6 +132,7 @@ export function IdeKeeperWorkPanel({ keeperName }: IdeKeeperWorkPanelProps) {
               </div>
             `
           : html`<div class="ide-keeper-work-empty">no active keeper task in dashboard state</div>`}
+        ${QueuedTaskCards(queuedTasks, summary.currentGoalId, summary.displayName)}
         ${currentGoal
           ? GoalProgressCard(currentGoal, currentGoalProgress, summary.currentTaskId)
           : summary.currentGoalId
@@ -145,6 +161,40 @@ export function IdeKeeperWorkPanel({ keeperName }: IdeKeeperWorkPanelProps) {
           : null}
       </div>
     </section>
+  `
+}
+
+function QueuedTaskCards(
+  tasks: ReadonlyArray<Task>,
+  fallbackGoalId: string | null,
+  keeperId: string,
+) {
+  if (tasks.length === 0) return null
+  const shownTasks = tasks.slice(0, 3)
+  const hiddenCount = Math.max(0, tasks.length - shownTasks.length)
+  return html`
+    <div class="ide-keeper-work-card" aria-label="Keeper active task queue">
+      <div class="ide-keeper-work-card-top">
+        <span>ACTIVE QUEUE</span>
+        <span>${tasks.length} queued</span>
+      </div>
+      ${shownTasks.map(task => html`
+        <div key=${task.id} style=${QUEUED_TASK_STYLE}>
+          <div class="ide-keeper-work-card-top">
+            <span>${task.id}</span>
+            <span>${task.status ?? 'unknown'}</span>
+          </div>
+          <strong title=${task.title}>${task.title}</strong>
+          ${task.worktree
+            ? html`<span style=${QUEUED_TASK_META_STYLE} title=${task.worktree.path}>${task.worktree.branch} · ${task.worktree.repo_name}</span>`
+            : null}
+          ${TaskRouteLinks(task, fallbackGoalId, keeperId)}
+        </div>
+      `)}
+      ${hiddenCount > 0
+        ? html`<span>${hiddenCount} more active ${hiddenCount === 1 ? 'task' : 'tasks'}</span>`
+        : null}
+    </div>
   `
 }
 
@@ -367,6 +417,14 @@ function uniqTasks(taskList: ReadonlyArray<Task>): Task[] {
     result.push(task)
   }
   return result
+}
+
+function queuedActiveTasks(
+  taskList: ReadonlyArray<Task>,
+  currentTask: Task | null,
+): ReadonlyArray<Task> {
+  if (!currentTask) return taskList
+  return taskList.filter(task => task.id !== currentTask.id)
 }
 
 function normalizedKeeperName(value: string): string {


### PR DESCRIPTION
## Summary

- Adds an active queue section to the IDE keeper work panel so the selected keeper shows the next assigned tasks beyond the current one.
- Reuses the existing IDE context routing for queued tasks, exposing Goal, Task, Git, Telemetry, and Keeper links when those task fields are present.
- Covers the queue behavior with a focused dashboard test, including filtering completed tasks out of the visible queue.

## Validation

- `pnpm install --offline`
- `pnpm exec vitest run src/components/ide/ide-keeper-work-panel.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/ide/ide-keeper-work-panel.ts src/components/ide/ide-keeper-work-panel.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`
