### PR TITLE
fix(dashboard): close cold-start and proof surface gaps

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -121,6 +121,28 @@ type AbortableRequestOptions = {
   signal?: AbortSignal
 }
 
+export type DashboardFeedRetention = Record<string, unknown> & {
+  scope?: string
+  durable_store?: string
+  durable_replay_surface?: string
+}
+
+export type DashboardFeedMetadata = {
+  generated_at_iso?: string
+  dashboard_surface?: string
+  source?: string
+  retention?: DashboardFeedRetention
+}
+
+function decodeDashboardFeedMetadata(raw: Record<string, unknown>): DashboardFeedMetadata {
+  return {
+    generated_at_iso: asString(raw.generated_at_iso),
+    dashboard_surface: asString(raw.dashboard_surface),
+    source: asString(raw.source),
+    retention: isRecord(raw.retention) ? raw.retention : undefined,
+  }
+}
+
 type DashboardShellRequestOptions = AbortableRequestOptions & {
   light?: boolean
 }
@@ -942,7 +964,7 @@ export interface KeeperDecision {
   match_count: number | null
 }
 
-export interface KeeperDecisionsResponse {
+export interface KeeperDecisionsResponse extends DashboardFeedMetadata {
   events: KeeperDecision[]
   limit: number
   generated_at: number | null
@@ -971,6 +993,7 @@ function decodeKeeperDecision(raw: unknown): KeeperDecision | null {
 function decodeKeeperDecisionsResponse(raw: unknown): KeeperDecisionsResponse | null {
   if (!isRecord(raw)) return null
   return {
+    ...decodeDashboardFeedMetadata(raw),
     events: asRecordArray(raw.events)
       .map(decodeKeeperDecision)
       .filter((d): d is KeeperDecision => d !== null),
@@ -1009,7 +1032,7 @@ export interface HeuristicFiring {
   cooldown_remaining_ms?: number
 }
 
-export interface HeuristicsResponse {
+export interface HeuristicsResponse extends DashboardFeedMetadata {
   limit: number
   count: number
   events: HeuristicEvent[]
@@ -1050,6 +1073,7 @@ function decodeHeuristicFiring(raw: unknown): HeuristicFiring | null {
 function decodeHeuristicsResponse(raw: unknown): HeuristicsResponse | null {
   if (!isRecord(raw)) return null
   return {
+    ...decodeDashboardFeedMetadata(raw),
     limit: asInt(raw.limit) ?? 0,
     count: asInt(raw.count) ?? 0,
     events: asRecordArray(raw.events)
@@ -1088,7 +1112,7 @@ export interface StressEvent {
   timestamp: number
 }
 
-export interface StressResponse {
+export interface StressResponse extends DashboardFeedMetadata {
   limit: number
   count: number
   events: StressEvent[]
@@ -1150,6 +1174,7 @@ function decodeAgentStressRow(raw: unknown): AgentStressRow | null {
 function decodeStressResponse(raw: unknown): StressResponse | null {
   if (!isRecord(raw)) return null
   return {
+    ...decodeDashboardFeedMetadata(raw),
     limit: asInt(raw.limit) ?? 0,
     count: asInt(raw.count) ?? 0,
     events: asRecordArray(raw.events)
@@ -1178,7 +1203,7 @@ export interface CoverageSite {
   triggered_count: number
 }
 
-export interface HeuristicCoverage {
+export interface HeuristicCoverage extends DashboardFeedMetadata {
   total_events: number
   decision_shape_count: number
   mixed_outcome_sites: number
@@ -1200,6 +1225,7 @@ function decodeHeuristicCoverage(raw: unknown): HeuristicCoverage | null {
   if (!isRecord(raw)) return null
   const decisionShapeCount = asInt(raw.decision_shape_count) ?? asInt(raw.unique_decision_tuples) ?? 0
   return {
+    ...decodeDashboardFeedMetadata(raw),
     total_events: asInt(raw.total_events) ?? 0,
     decision_shape_count: decisionShapeCount,
     mixed_outcome_sites: asInt(raw.mixed_outcome_sites) ?? 0,

--- a/dashboard/src/api/schemas/agent-relations.test.ts
+++ b/dashboard/src/api/schemas/agent-relations.test.ts
@@ -37,6 +37,24 @@ describe('parseAgentRelationsResponse', () => {
     expect(out.relations[0]!.participants).toHaveLength(2)
   })
 
+  it('preserves dashboard feed provenance metadata', () => {
+    const out = parseAgentRelationsResponse(
+      validResponse({
+        dashboard_surface: '/api/v1/agent-relations',
+        source: 'second_brain_graphql',
+        generated_at_iso: '2026-04-17T04:00:01Z',
+        retention: {
+          scope: 'external_graphql_query',
+          durable_store: 'Second Brain GraphQL',
+        },
+      }),
+    )
+    expect(out.dashboard_surface).toBe('/api/v1/agent-relations')
+    expect(out.source).toBe('second_brain_graphql')
+    expect(out.retention?.durable_store).toBe('Second Brain GraphQL')
+    expect(out.generated_at_iso).toBe('2026-04-17T04:00:01Z')
+  })
+
   it('accepts empty collections', () => {
     const out = parseAgentRelationsResponse({
       agent_name: 'new-agent',

--- a/dashboard/src/api/schemas/agent-relations.ts
+++ b/dashboard/src/api/schemas/agent-relations.ts
@@ -11,8 +11,11 @@ import {
   nullable,
   number,
   object,
+  optional,
+  record,
   safeParse,
   string,
+  unknown,
   type BaseIssue,
   type InferOutput,
 } from 'valibot'
@@ -37,7 +40,13 @@ const AgentRelationSchema = object({
   participants: array(AgentRelationParticipantSchema),
 })
 
+const DashboardFeedRetentionSchema = record(string(), unknown())
+
 const AgentRelationsResponseSchema = object({
+  dashboard_surface: optional(string()),
+  source: optional(string()),
+  retention: optional(DashboardFeedRetentionSchema),
+  generated_at_iso: optional(string()),
   agent_name: string(),
   collaborators: array(AgentCollaboratorSchema),
   interests: array(string()),

--- a/dashboard/src/api/schemas/agent-timeline.test.ts
+++ b/dashboard/src/api/schemas/agent-timeline.test.ts
@@ -41,6 +41,24 @@ describe('parseAgentTimelineResponse', () => {
     expect(out.summary.tool_calls).toBe(7)
   })
 
+  it('preserves dashboard feed provenance metadata', () => {
+    const out = parseAgentTimelineResponse(
+      validResponse({
+        dashboard_surface: '/api/v1/agent-timeline',
+        source: 'agent_timeline_read_model',
+        generated_at_iso: '2026-04-17T04:00:01Z',
+        retention: {
+          scope: 'multi_source_tail',
+          durable_store: '.masc/activity-events/YYYY-MM/YYYY-MM-DD.jsonl',
+        },
+      }),
+    )
+    expect(out.dashboard_surface).toBe('/api/v1/agent-timeline')
+    expect(out.source).toBe('agent_timeline_read_model')
+    expect(out.retention?.durable_store).toBe('.masc/activity-events/YYYY-MM/YYYY-MM-DD.jsonl')
+    expect(out.generated_at_iso).toBe('2026-04-17T04:00:01Z')
+  })
+
   it('accepts a response with no events', () => {
     const out = parseAgentTimelineResponse(
       validResponse({

--- a/dashboard/src/api/schemas/agent-timeline.ts
+++ b/dashboard/src/api/schemas/agent-timeline.ts
@@ -40,7 +40,13 @@ const AgentTimelineSummarySchema = object({
   total_events: number(),
 })
 
+const DashboardFeedRetentionSchema = record(string(), unknown())
+
 const AgentTimelineResponseSchema = object({
+  dashboard_surface: optional(string()),
+  source: optional(string()),
+  retention: optional(DashboardFeedRetentionSchema),
+  generated_at_iso: optional(string()),
   agent: string(),
   period: AgentTimelinePeriodSchema,
   events: array(AgentTimelineEventSchema),

--- a/dashboard/src/api/schemas/logs.test.ts
+++ b/dashboard/src/api/schemas/logs.test.ts
@@ -36,10 +36,40 @@ describe('parseLogsResponse', () => {
   it('parses a populated response', () => {
     const out = parseLogsResponse({
       total: 2,
+      generated_at_iso: '2026-05-15T01:00:00Z',
+      dashboard_surface: '/api/v1/dashboard/logs',
+      source: 'masc_log_ring',
+      retention: {
+        scope: 'dashboard_logs',
+        coordination_root: '/Users/dancer/me/.masc',
+        buffer: 'Log.Ring',
+        capacity: 50000,
+        durable_store: '/Users/dancer/me/.masc/logs/system_log_2026-05-15.jsonl',
+        file_pattern: 'system_log_YYYY-MM-DD.jsonl',
+        keep_days: 7,
+      },
+      query: {
+        limit: 200,
+        level: 'INFO',
+        applied_level: 'INFO',
+        min_level: 1,
+        module: '',
+        since_seq: null,
+      },
+      returned: 2,
+      latest_seq: 43,
+      oldest_seq: 42,
+      latest_ts_iso: '2026-04-17T00:00:00Z',
       entries: [validEntry(), validEntry({ seq: 43, message: 'booted again' })],
     })
     expect(out.entries).toHaveLength(2)
     expect(out.entries[1]!.seq).toBe(43)
+    expect(out.dashboard_surface).toBe('/api/v1/dashboard/logs')
+    expect(out.source).toBe('masc_log_ring')
+    expect(out.retention?.scope).toBe('dashboard_logs')
+    expect(out.retention?.capacity).toBe(50000)
+    expect(out.query?.applied_level).toBe('INFO')
+    expect(out.latest_seq).toBe(43)
   })
 
   it('throws on a row missing a required field instead of silently dropping it', () => {

--- a/dashboard/src/api/schemas/logs.ts
+++ b/dashboard/src/api/schemas/logs.ts
@@ -44,11 +44,49 @@ export type LogEntry = InferOutput<typeof LogEntrySchema>
 const LogsResponseSchema = object({
   total: number(),
   entries: unknown(),
+  generated_at_iso: optional(string()),
+  dashboard_surface: optional(string()),
+  source: optional(string()),
+  retention: optional(record(string(), unknown())),
+  query: optional(record(string(), unknown())),
+  returned: optional(number()),
+  latest_seq: optional(nullable(number())),
+  oldest_seq: optional(nullable(number())),
+  latest_ts_iso: optional(nullable(string())),
 })
+
+export interface LogsRetention {
+  scope?: string
+  coordination_root?: string
+  buffer?: string
+  capacity?: number
+  durable_store?: string
+  file_pattern?: string
+  keep_days?: number
+  cache_policy?: string
+}
+
+export interface LogsQuery {
+  limit?: number
+  level?: string
+  applied_level?: string
+  min_level?: number
+  module?: string
+  since_seq?: number | null
+}
 
 export interface LogsResponse {
   total: number
   entries: LogEntry[]
+  generated_at_iso?: string
+  dashboard_surface?: string
+  source?: string
+  retention?: LogsRetention
+  query?: LogsQuery
+  returned?: number
+  latest_seq?: number | null
+  oldest_seq?: number | null
+  latest_ts_iso?: string | null
 }
 
 export class LogsSchemaDriftError extends Error {
@@ -83,5 +121,14 @@ export function parseLogsResponse(data: unknown): LogsResponse {
   return {
     total: outer.output.total,
     entries,
+    generated_at_iso: outer.output.generated_at_iso,
+    dashboard_surface: outer.output.dashboard_surface,
+    source: outer.output.source,
+    retention: outer.output.retention as LogsRetention | undefined,
+    query: outer.output.query as LogsQuery | undefined,
+    returned: outer.output.returned,
+    latest_seq: outer.output.latest_seq,
+    oldest_seq: outer.output.oldest_seq,
+    latest_ts_iso: outer.output.latest_ts_iso,
   }
 }

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -8,6 +8,7 @@ import { EmptyState } from './common/empty-state'
 import { TimeAgo } from './common/time-ago'
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
+import { DashboardFeedSourceStrip } from './common/dashboard-feed-source-strip'
 import { agentTimeline } from './agent-detail-state'
 import { trimText } from '../lib/truncate'
 import { toolCategory, durationColor, formatDuration, formatArgs } from './tool-call-shared'
@@ -155,6 +156,7 @@ export function AgentTimelineSection() {
           ${summary.active_duration_minutes > 0 ? html`<${SummaryBadge}>${Math.round(summary.active_duration_minutes)}분 활동<//>` : null}
         </div>
       ` : null}
+      <${DashboardFeedSourceStrip} meta=${timeline} className="mb-2" />
       ${events.length === 0
         ? html`<${EmptyState} message="작업 기록이 아직 없습니다" compact />`
         : html`

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -14,6 +14,7 @@ import { EmptyState } from './common/empty-state'
 import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
 import { StatGrid } from './common/stat-tile'
+import { DashboardFeedSourceStrip } from './common/dashboard-feed-source-strip'
 import { formatTokens } from '../lib/format-number'
 import { findKeeper } from '../lib/keeper-utils'
 import { autonomyHint } from './keeper-detail-ctx-utils'
@@ -384,9 +385,10 @@ export function AgentProfile({ name }: { name: string }) {
           const collabs = rel.collaborators ?? []
           const interests = rel.interests ?? []
           const hasData = collabs.length > 0 || interests.length > 0
-          if (!hasData) return null
           return html`
             <${Card} title="관계 (${collabs.length})" class="ff-card rounded-[var(--r-1)]">
+              <${DashboardFeedSourceStrip} meta=${rel} className="mb-2" />
+              ${!hasData ? html`<${EmptyState} message="관계 데이터 없음" compact />` : null}
               ${collabs.length > 0 ? html`
                 <div class="flex flex-col gap-1">
                   ${collabs.map(c => html`
@@ -419,6 +421,7 @@ export function AgentProfile({ name }: { name: string }) {
         })()}
 
         <${Card} title="타임라인" class="ff-card rounded-[var(--r-1)]">
+          <${DashboardFeedSourceStrip} meta=${timeline} className="mb-2" />
           ${!timeline || (timeline.events ?? []).length === 0
             ? html`<${EmptyState} message="이벤트 없음" compact />`
             : html`<div class="flex flex-col gap-0.5 max-h-75 overflow-y-auto">${(timeline.events ?? []).map((evt: AgentTimelineEvent, idx: number) => {

--- a/dashboard/src/components/common/dashboard-feed-source-strip.ts
+++ b/dashboard/src/components/common/dashboard-feed-source-strip.ts
@@ -1,0 +1,48 @@
+import { html } from 'htm/preact'
+
+export interface DashboardFeedSourceMetadata {
+  dashboard_surface?: string
+  source?: string
+  retention?: Record<string, unknown>
+  generated_at_iso?: string
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value : null
+}
+
+function retentionValue(meta: DashboardFeedSourceMetadata): string | null {
+  const direct = nonEmptyString(meta.retention?.durable_store)
+  if (direct) return direct
+
+  const stores = meta.retention?.durable_stores
+  if (!Array.isArray(stores)) return null
+
+  const names = stores.filter((store): store is string => typeof store === 'string' && store.trim() !== '')
+  if (names.length === 0) return null
+  const visible = names.slice(0, 2).join(', ')
+  return names.length > 2 ? `${visible} +${names.length - 2}` : visible
+}
+
+export function DashboardFeedSourceStrip({
+  meta,
+  className = '',
+}: {
+  meta: DashboardFeedSourceMetadata | null | undefined
+  className?: string
+}) {
+  if (!meta) return null
+  const store = retentionValue(meta)
+  const items = [
+    meta.source ? `source ${meta.source}` : '',
+    meta.dashboard_surface ? `surface ${meta.dashboard_surface}` : '',
+    store ? `store ${store}` : '',
+    meta.generated_at_iso ? `generated ${meta.generated_at_iso}` : '',
+  ].filter(Boolean)
+  if (items.length === 0) return null
+  const cls = [
+    'rounded-[var(--r-1)] border border-card-border/60 bg-[var(--backdrop-deep)] px-2.5 py-1.5 font-mono text-3xs text-[var(--color-fg-muted)]',
+    className,
+  ].filter(Boolean).join(' ')
+  return html`<div class=${cls}>${items.join(' | ')}</div>`
+}

--- a/dashboard/src/components/cost-dashboard.render.test.ts
+++ b/dashboard/src/components/cost-dashboard.render.test.ts
@@ -73,9 +73,16 @@ describe('CostDashboard route-backed focus behavior', () => {
     vi.resetModules()
     apiMocks.fetchRuntimeModelMetrics.mockReset().mockResolvedValue(modelMetrics())
     apiMocks.fetchKeeperCostMetrics.mockReset().mockResolvedValue(keeperMetrics())
-    apiMocks.fetchHeuristics.mockReset().mockResolvedValue({ events: [], limit: 0 })
-    apiMocks.fetchHeuristicCoverage.mockReset().mockResolvedValue({ modules: [], sites: [] })
-    apiMocks.fetchStress.mockReset().mockResolvedValue({ events: [], limit: 0 })
+    apiMocks.fetchHeuristics.mockReset().mockResolvedValue({ events: [], limit: 0, source: 'heuristic_metrics' })
+    apiMocks.fetchHeuristicCoverage.mockReset().mockResolvedValue({
+      total_events: 0,
+      decision_shape_count: 0,
+      mixed_outcome_sites: 0,
+      unique_decision_tuples: 0,
+      sites: [],
+      source: 'heuristic_metrics',
+    })
+    apiMocks.fetchStress.mockReset().mockResolvedValue({ events: [], agent_stress: [], limit: 0, source: 'agent_stress' })
     apiMocks.fetchAuditLedger.mockReset().mockResolvedValue({ entries: [], limit: 0 })
     apiMocks.fetchKeeperDecisions.mockReset().mockResolvedValue({ events: [], limit: 0 })
     window.history.replaceState(null, '', '#overview')
@@ -284,5 +291,42 @@ describe('CostDashboard route-backed focus behavior', () => {
       section: 'runtime',
       view: 'audit',
     })
+  })
+
+  it('renders runtime feed source metadata on heuristic views', async () => {
+    apiMocks.fetchHeuristics.mockResolvedValueOnce({
+      events: [],
+      limit: 25,
+      source: 'heuristic_metrics',
+      dashboard_surface: '/api/v1/dashboard/heuristics',
+      retention: { durable_store: '.masc/heuristic_metrics.jsonl' },
+    })
+    apiMocks.fetchHeuristicCoverage.mockResolvedValueOnce({
+      total_events: 0,
+      decision_shape_count: 0,
+      mixed_outcome_sites: 0,
+      unique_decision_tuples: 0,
+      sites: [],
+      source: 'heuristic_metrics',
+      dashboard_surface: '/api/v1/dashboard/heuristics/coverage',
+      retention: { durable_store: '.masc/heuristic_metrics.jsonl' },
+    })
+    const { route } = await import('../router')
+    const { CostDashboard } = await import('./cost-dashboard')
+    route.value = {
+      tab: 'monitoring',
+      params: { section: 'runtime', view: 'heuristics' },
+      postId: null,
+    }
+
+    render(h(CostDashboard, { view: 'heuristics' }), container)
+    await waitFor(
+      () => container.textContent?.includes('surface /api/v1/dashboard/heuristics') ?? false,
+      'heuristic source metadata',
+    )
+
+    expect(container.textContent).toContain('source heuristic_metrics')
+    expect(container.textContent).toContain('store .masc/heuristic_metrics.jsonl')
+    expect(container.textContent).toContain('surface /api/v1/dashboard/heuristics/coverage')
   })
 })

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -33,6 +33,7 @@ import {
   type AuditLedgerResponse,
   type KeeperDecision,
   type KeeperDecisionsResponse,
+  type DashboardFeedMetadata,
 } from '../api/dashboard'
 import { LoadingState, ErrorState } from './common/feedback-state'
 import { StatTile } from './common/stat-tile'
@@ -94,13 +95,13 @@ type KeeperLoadState =
 type HeuristicLoadState =
   | { status: 'idle' }
   | { status: 'loading' }
-  | { status: 'loaded'; data: HeuristicEvent[]; limit: number }
+  | { status: 'loaded'; data: HeuristicEvent[]; limit: number; meta: DashboardFeedMetadata }
   | { status: 'error'; message: string }
 
 type StressLoadState =
   | { status: 'idle' }
   | { status: 'loading' }
-  | { status: 'loaded'; events: StressEvent[]; board: AgentStressRow[]; limit: number }
+  | { status: 'loaded'; events: StressEvent[]; board: AgentStressRow[]; limit: number; meta: DashboardFeedMetadata }
   | { status: 'error'; message: string }
 
 type CoverageLoadState =
@@ -248,7 +249,7 @@ async function loadHeuristics(limit = 100) {
   heuristicState.value = { status: 'loading' }
   try {
     const resp = await fetchHeuristics(limit)
-    heuristicState.value = { status: 'loaded', data: resp.events, limit: resp.limit }
+    heuristicState.value = { status: 'loaded', data: resp.events, limit: resp.limit, meta: resp }
   } catch (err) {
     const message = err instanceof Error ? err.message : 'heuristic metrics 불러오기 실패'
     heuristicState.value = { status: 'error', message }
@@ -259,7 +260,7 @@ async function loadStress(limit = 100) {
   stressState.value = { status: 'loading' }
   try {
     const resp = await fetchStress(limit)
-    stressState.value = { status: 'loaded', events: resp.events, board: resp.agent_stress, limit: resp.limit }
+    stressState.value = { status: 'loaded', events: resp.events, board: resp.agent_stress, limit: resp.limit, meta: resp }
   } catch (err) {
     const message = err instanceof Error ? err.message : 'stress events 불러오기 실패'
     stressState.value = { status: 'error', message }
@@ -620,7 +621,29 @@ function CostLatency({ buckets, p50, p95 }: {
   `
 }
 
-function HeuristicLog({ events, limit }: { events: HeuristicEvent[]; limit: number }) {
+function feedRetentionValue(meta: DashboardFeedMetadata, key: string): string | null {
+  const value = meta.retention?.[key]
+  return typeof value === 'string' && value.trim() ? value : null
+}
+
+function FeedSourceStrip({ meta }: { meta: DashboardFeedMetadata }) {
+  const durableStore = feedRetentionValue(meta, 'durable_store')
+  const durableReplay = feedRetentionValue(meta, 'durable_replay_surface')
+  const items = [
+    meta.source ? `source ${meta.source}` : '',
+    meta.dashboard_surface ? `surface ${meta.dashboard_surface}` : '',
+    durableStore ? `store ${durableStore}` : '',
+    durableReplay ? `replay ${durableReplay}` : '',
+  ].filter(Boolean)
+  if (items.length === 0) return null
+  return html`
+    <div class="rounded-[var(--r-1)] border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2 font-mono text-2xs text-text-muted">
+      ${items.join(' · ')}
+    </div>
+  `
+}
+
+function HeuristicLog({ events, limit, meta }: { events: HeuristicEvent[]; limit: number; meta: DashboardFeedMetadata }) {
   const fmtTime = (ts: number): string => {
     const d = new Date(ts * 1000)
     return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
@@ -630,6 +653,7 @@ function HeuristicLog({ events, limit }: { events: HeuristicEvent[]; limit: numb
 
   return html`
     <section class="flex flex-col gap-2" aria-label=${`Heuristic log · ${events.length} events`}>
+      <${FeedSourceStrip} meta=${meta} />
       <div class="flex items-center justify-between rounded-[var(--r-1)] border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2">
         <span class="font-mono text-2xs uppercase tracking-[var(--track-caps)] text-text-muted">heuristic log · ${events.length} events · ${triggeredCount} triggered</span>
         <span class="font-mono text-2xs text-text-muted">limit ${limit}</span>
@@ -670,7 +694,7 @@ function HeuristicLog({ events, limit }: { events: HeuristicEvent[]; limit: numb
   `
 }
 
-function StressBoard({ rows, events, limit }: { rows: AgentStressRow[]; events: StressEvent[]; limit: number }) {
+function StressBoard({ rows, events, limit, meta }: { rows: AgentStressRow[]; events: StressEvent[]; limit: number; meta: DashboardFeedMetadata }) {
   const fmtTime = (ts: number): string => {
     const d = new Date(ts * 1000)
     return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
@@ -717,6 +741,7 @@ function StressBoard({ rows, events, limit }: { rows: AgentStressRow[]; events: 
 
   return html`
     <section class="flex flex-col gap-2" aria-label=${`Stress board · ${rows.length} agents · ${events.length} events`}>
+      <${FeedSourceStrip} meta=${meta} />
       <div class="flex items-center justify-between rounded-[var(--r-1)] border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2">
         <span class="font-mono text-2xs uppercase tracking-[var(--track-caps)] text-text-muted">stress board · ${rows.length} agents · ${events.length} events</span>
         <span class="font-mono text-2xs text-text-muted">limit ${limit}</span>
@@ -791,6 +816,7 @@ function HeuristicByModule({ coverage }: { coverage: HeuristicCoverage }) {
 
   return html`
     <section class="flex flex-col gap-2" aria-label="Heuristic by module">
+      <${FeedSourceStrip} meta=${coverage} />
       <div class="flex items-center justify-between rounded-[var(--r-1)] border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2">
         <span class="font-mono text-2xs uppercase tracking-[var(--track-caps)] text-text-muted">heuristic by module · ${coverage.total_events} events · ${coverage.decision_shape_count} decision shapes · ${coverage.mixed_outcome_sites} mixed sites</span>
       </div>
@@ -1046,7 +1072,7 @@ function AuditLedgerBoard({ entries, count, focus, logId }: { entries: AuditEntr
   `
 }
 
-function KeeperDecisionsBoard({ events, limit }: { events: KeeperDecision[]; limit: number }) {
+function KeeperDecisionsBoard({ events, limit, meta }: { events: KeeperDecision[]; limit: number; meta: DashboardFeedMetadata }) {
   const fmtTime = (ts: number | null): string => {
     if (ts == null) return '—'
     const d = new Date(ts * 1000)
@@ -1055,6 +1081,7 @@ function KeeperDecisionsBoard({ events, limit }: { events: KeeperDecision[]; lim
 
   return html`
     <section class="flex flex-col gap-4" aria-label="Keeper decisions">
+      <${FeedSourceStrip} meta=${meta} />
       <div class="flex items-center justify-between rounded-[var(--r-1)] border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2">
         <span class="font-mono text-2xs uppercase tracking-[var(--track-caps)] text-text-muted">keeper decisions · ${events.length} events · limit ${limit}</span>
       </div>
@@ -1316,7 +1343,7 @@ function CostDashboardContent({ view }: { view: CostView }) {
           <h2 class="text-base font-semibold text-text-strong">휴리스틱</h2>
         </header>
         ${heuristicState.value.status === 'loaded'
-          ? html`<${HeuristicLog} events=${heuristicState.value.data} limit=${heuristicState.value.limit} />`
+          ? html`<${HeuristicLog} events=${heuristicState.value.data} limit=${heuristicState.value.limit} meta=${heuristicState.value.meta} />`
           : heuristicState.value.status === 'error'
             ? html`<${ErrorState} message=${heuristicState.value.message} onRetry=${() => void loadHeuristics()} />`
             : html`<${LoadingState} />`}
@@ -1339,7 +1366,7 @@ function CostDashboardContent({ view }: { view: CostView }) {
           <h2 class="text-base font-semibold text-text-strong">스트레스 이벤트</h2>
         </header>
         ${stressState.value.status === 'loaded'
-          ? html`<${StressBoard} rows=${stressState.value.board} events=${stressState.value.events} limit=${stressState.value.limit} />`
+          ? html`<${StressBoard} rows=${stressState.value.board} events=${stressState.value.events} limit=${stressState.value.limit} meta=${stressState.value.meta} />`
           : stressState.value.status === 'error'
             ? html`<${ErrorState} message=${stressState.value.message} onRetry=${() => void loadStress()} />`
             : html`<${LoadingState} />`}
@@ -1386,6 +1413,7 @@ function CostDashboardContent({ view }: { view: CostView }) {
           ? html`<${KeeperDecisionsBoard}
               events=${keeperDecisionsState.value.data.events}
               limit=${keeperDecisionsState.value.data.limit}
+              meta=${keeperDecisionsState.value.data}
             />`
           : keeperDecisionsState.value.status === 'error'
             ? html`<${ErrorState}

--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -141,6 +141,14 @@ describe('LogViewer Code links', () => {
   it('links safe structured log file details back to the Code IDE route', async () => {
     const fetchLogs = vi.fn().mockResolvedValue({
       total: 1,
+      generated_at_iso: '2026-05-15T01:00:00Z',
+      dashboard_surface: '/api/v1/dashboard/logs',
+      source: 'masc_log_ring',
+      retention: {
+        scope: 'dashboard_logs',
+        durable_store: '/Users/dancer/me/.masc/logs/system_log_2026-05-15.jsonl',
+      },
+      latest_seq: 1,
       entries: [{
         seq: 1,
         ts: '2026-05-14T00:00:00Z',
@@ -160,6 +168,10 @@ describe('LogViewer Code links', () => {
     const codeLink = container.querySelector('[data-testid="logs-code-link"]') as HTMLButtonElement
     expect(codeLink.textContent).toBe('Code')
     expect(codeLink.getAttribute('title')).toBe('Code lib/runtime.ml:12')
+    const provenance = container.querySelector('[data-testid="logs-provenance"]') as HTMLElement
+    expect(provenance.textContent).toContain('masc_log_ring')
+    expect(provenance.textContent).toContain('dashboard_logs')
+    expect(provenance.textContent).toContain('system_log_2026-05-15.jsonl')
 
     codeLink.click()
     expect(window.location.hash).toBe(

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -16,11 +16,9 @@ import {
   type IdeContextRouteContext,
   type IdeContextRouteLink,
 } from './ide/ide-context-lens'
+import type { LogsResponse } from '../api/schemas/logs'
 
-interface LogData {
-  entries: LogEntry[]
-  total: number
-}
+type LogData = LogsResponse
 
 export interface LogCauseCount {
   cause: string
@@ -405,6 +403,7 @@ async function loadLogs(mode: LoadMode = 'reset') {
       const entries = sortLogEntries(resp.entries).slice(0, Math.max(1, logLimit.value))
       latestSeq.value = latestLogSeq(entries)
       return {
+        ...resp,
         entries,
         total: resp.total,
       }
@@ -428,6 +427,7 @@ async function loadLogs(mode: LoadMode = 'reset') {
 
     latestSeq.value = latestLogSeq(nextEntries)
     logResource.state.value = loaded({
+      ...resp,
       entries: nextEntries,
       total: resp.total,
     })
@@ -567,6 +567,37 @@ function renderLogSummary(summary: LogWindowSummary) {
   `
 }
 
+function lastPathSegment(path: string | undefined): string | null {
+  if (!path) return null
+  const normalized = path.replace(/\\/g, '/')
+  return normalized.split('/').filter(Boolean).pop() ?? normalized
+}
+
+function renderLogProvenance(data: LogData | undefined) {
+  if (!data) return null
+  const scope = data.retention?.scope
+  const store = lastPathSegment(data.retention?.durable_store)
+  const latestSeq = typeof data.latest_seq === 'number' ? String(data.latest_seq) : null
+  const generatedAt = data.generated_at_iso?.replace('T', ' ').replace('Z', '')
+
+  if (!data.source && !scope && !store && !latestSeq && !generatedAt) return null
+
+  return html`
+    <div class="flex flex-wrap items-center gap-1.5" data-testid="logs-provenance">
+      ${data.source ? renderSummaryChip('source', data.source, 'info') : null}
+      ${scope ? renderSummaryChip('scope', scope) : null}
+      ${latestSeq ? renderSummaryChip('seq', latestSeq) : null}
+      ${store ? html`
+        <${StatusChip}
+          tone="neutral"
+          uppercase=${false}
+        >store ${store}</${StatusChip}>
+      ` : null}
+      ${generatedAt ? renderSummaryChip('at', generatedAt) : null}
+    </div>
+  `
+}
+
 export function LogViewer() {
   useEffect(() => {
     let pollId: ReturnType<typeof setInterval> | null = null
@@ -670,6 +701,7 @@ export function LogViewer() {
           </div>
 
           <div class="logs-actions flex flex-wrap gap-3 items-center text-2xs text-[color:var(--color-fg-muted)]">
+            ${renderLogProvenance(logData)}
             <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-1 tabular-nums">
               ${logEntries.length.toLocaleString()} / ${logTotal.toLocaleString()}
             </span>

--- a/dashboard/src/namespace-truth-normalizers.test.ts
+++ b/dashboard/src/namespace-truth-normalizers.test.ts
@@ -9,6 +9,9 @@ describe('normalizeNamespaceTruth', () => {
   it('returns safe defaults for null input', () => {
     const result = normalizeNamespaceTruth(null)
     expect(result.generated_at).toBeUndefined()
+    expect(result.dashboard_surface).toBeUndefined()
+    expect(result.dashboard_aliases).toEqual([])
+    expect(result.retention).toBeUndefined()
     expect(result.root.status).toBeNull()
     expect(result.root.configured_keepers).toBeUndefined()
     expect(result.execution?.summary).toBeNull()
@@ -36,6 +39,34 @@ describe('normalizeNamespaceTruth', () => {
   it('extracts generated_at from root level', () => {
     const result = normalizeNamespaceTruth({ generated_at: '2026-04-17T10:00:00Z' })
     expect(result.generated_at).toBe('2026-04-17T10:00:00Z')
+  })
+
+  it('preserves top-level provenance for canonical and alias routes', () => {
+    const result = normalizeNamespaceTruth({
+      generated_at_iso: '2026-04-17T10:00:00Z',
+      dashboard_surface: '/api/v1/dashboard/namespace-truth',
+      dashboard_aliases: [
+        '/api/v1/dashboard/project-snapshot',
+        '/api/v1/dashboard/room-truth',
+      ],
+      source: 'namespace_truth_read_model',
+      retention: {
+        scope: 'dashboard_namespace_truth',
+        coordination_root: '/Users/dancer/me',
+        workspace_path: '/Users/dancer/me',
+        shell_input: '/api/v1/dashboard/shell',
+        execution_input: '/api/v1/dashboard/execution',
+        command_input: 'command_summary_json',
+        cache_policy: 'proactive_execution_cache_last_good_shell_fallback',
+      },
+    })
+
+    expect(result.generated_at_iso).toBe('2026-04-17T10:00:00Z')
+    expect(result.dashboard_surface).toBe('/api/v1/dashboard/namespace-truth')
+    expect(result.dashboard_aliases).toContain('/api/v1/dashboard/room-truth')
+    expect(result.source).toBe('namespace_truth_read_model')
+    expect(result.retention?.scope).toBe('dashboard_namespace_truth')
+    expect(result.retention?.execution_input).toBe('/api/v1/dashboard/execution')
   })
 
   // ── root block ──

--- a/dashboard/src/namespace-truth-normalizers.ts
+++ b/dashboard/src/namespace-truth-normalizers.ts
@@ -180,8 +180,24 @@ export function normalizeNamespaceTruth(raw: unknown): DashboardNamespaceTruthRe
   const commandBlock = isRecord(root.command) ? root.command : {}
   const metaCognitionBlock = isRecord(root.meta_cognition) ? root.meta_cognition : {}
   const operatorBlock = isRecord(root.operator) ? root.operator : {}
+  const retentionBlock = isRecord(root.retention) ? root.retention : null
   return {
     generated_at: asString(root.generated_at),
+    generated_at_iso: asString(root.generated_at_iso),
+    dashboard_surface: asString(root.dashboard_surface),
+    dashboard_aliases: asStringArray(root.dashboard_aliases),
+    source: asString(root.source),
+    retention: retentionBlock
+      ? {
+          scope: asString(retentionBlock.scope),
+          coordination_root: asString(retentionBlock.coordination_root),
+          workspace_path: asString(retentionBlock.workspace_path),
+          shell_input: asString(retentionBlock.shell_input),
+          execution_input: asString(retentionBlock.execution_input),
+          command_input: asString(retentionBlock.command_input),
+          cache_policy: asString(retentionBlock.cache_policy),
+        }
+      : undefined,
     root: {
       status: normalizeServerStatus(namespaceBlock.status),
       counts: isRecord(namespaceBlock.counts)

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -226,8 +226,23 @@ export interface DashboardAttentionEvent {
   provenance?: string | null
 }
 
+export interface DashboardNamespaceTruthRetention {
+  scope?: string
+  coordination_root?: string
+  workspace_path?: string
+  shell_input?: string
+  execution_input?: string
+  command_input?: string
+  cache_policy?: string
+}
+
 export interface DashboardNamespaceTruthResponse {
   generated_at?: string
+  generated_at_iso?: string
+  dashboard_surface?: string
+  dashboard_aliases?: string[]
+  source?: string
+  retention?: DashboardNamespaceTruthRetention
   root: {
     status?: ServerStatus | null
     counts?: DashboardShellResponse['counts']

--- a/docs/DASHBOARD-INTEGRATION.md
+++ b/docs/DASHBOARD-INTEGRATION.md
@@ -1,6 +1,6 @@
 ---
 status: reference
-last_verified: 2026-05-01
+last_verified: 2026-05-15
 code_refs:
   - dashboard/src/config/navigation.ts
   - dashboard/src/components/status.ts
@@ -178,6 +178,7 @@ code_refs:
 - `GET /api/v1/dashboard/execution`
 - `GET /api/v1/dashboard/governance`
 - `GET /api/v1/dashboard/proof`
+  - compatibility proof index over verification requests, TLA result refs, keeper feature proof, safe autonomy, execution trust, and surface readiness routes
 - `GET /api/v1/dashboard/goals`
 - `GET /api/v1/dashboard/config`
 - `GET /api/v1/dashboard/feature-health`

--- a/docs/DASHBOARD-INTEGRATION.md
+++ b/docs/DASHBOARD-INTEGRATION.md
@@ -113,8 +113,10 @@ code_refs:
   - goal navigator runtime status
 - `GET /api/v1/activity/graph`
   - observatory investigation graph
-- `GET /api/v1/dashboard/telemetry/summary`
-  - fleet-health summary
+- `GET /api/v1/dashboard/telemetry/summary`, `GET /api/v1/dashboard/telemetry?source=oas_event`
+  - fleet-health summary + durable OAS event replay used by the dashboard OAS runtime monitor
+- `GET /api/v1/dashboard/oas/telemetry/recent`, `GET /api/v1/dashboard/oas/telemetry/summary`
+  - in-process OAS runtime-lane sample cache; payloads expose `dashboard_surface`, `source`, and `retention.durable_replay_surface` so operators can distinguish cache state from durable `oas_event` replay
 - `GET /api/v1/dashboard/memory-subsystems`
   - cognition memory sub-view read model
 - `GET /api/v1/attribution/summary`

--- a/docs/DASHBOARD-INTEGRATION.md
+++ b/docs/DASHBOARD-INTEGRATION.md
@@ -132,6 +132,8 @@ code_refs:
   - read-only CLI equivalent: `masc-keeper-feature-proof --base-path <runtime-root>`
 - `GET /api/v1/models/metrics`, `GET /api/v1/dashboard/keeper-costs`
   - runtime cost/latency view
+- `GET /api/v1/dashboard/keeper-decisions`, `GET /api/v1/dashboard/heuristics`, `GET /api/v1/dashboard/heuristics/coverage`, `GET /api/v1/dashboard/stress`
+  - runtime decision, heuristic, and stress feeds; payloads expose `dashboard_surface`, `source`, and `retention` so the Cost/Runtime subviews can distinguish visible read-model state from the backing JSONL logs
 - `GET /api/v1/providers`
   - runtime provider inventory
 - `GET /api/v1/cascade/config`, `GET /api/v1/cascade/config/raw`

--- a/lib/agent_stress.ml
+++ b/lib/agent_stress.ml
@@ -238,8 +238,21 @@ let board_rows_json ?(agents = []) events =
            String.compare la ra
        | _ -> 0)
 
+let dashboard_source = "agent_stress"
+let dashboard_surface = "/api/v1/dashboard/stress"
+
+let dashboard_retention_json =
+  `Assoc
+    [ ("scope", `String "jsonl_tail")
+    ; ("durable_store", `String ".masc/agent_stress.jsonl")
+    ]
+
 let dashboard_feed_json ~limit ?(agents = []) events =
   `Assoc [
+    ("generated_at_iso", `String (Masc_domain.now_iso ()));
+    ("dashboard_surface", `String dashboard_surface);
+    ("source", `String dashboard_source);
+    ("retention", dashboard_retention_json);
     ("limit", `Int limit);
     ("count", `Int (List.length events));
     ("events", `List events);

--- a/lib/agent_stress.mli
+++ b/lib/agent_stress.mli
@@ -100,4 +100,6 @@ val dashboard_feed_json :
   Yojson.Safe.t list ->
   Yojson.Safe.t
 (** Build the dashboard response carrying both the existing [events] array
-    and the O5 compatibility [agent_stress] board rows. *)
+    and the O5 compatibility [agent_stress] board rows.  The envelope includes
+    [dashboard_surface], [source], and [retention] so operators can tie the
+    board projection back to [.masc/agent_stress.jsonl]. *)

--- a/lib/dashboard/dashboard_agent_relations.ml
+++ b/lib/dashboard/dashboard_agent_relations.ml
@@ -31,6 +31,22 @@ let trusts_query = {|
   }
 |}
 
+let dashboard_surface = "/api/v1/agent-relations"
+let dashboard_source = "second_brain_graphql"
+
+let dashboard_retention_json =
+  `Assoc
+    [
+      ("scope", `String "external_graphql_query");
+      ("durable_store", `String "Second Brain GraphQL");
+      ( "queries",
+        `List
+          [
+            `String "agentCollaborationNetworkByName";
+            `String "agent.relations";
+          ] );
+    ]
+
 (** Build the JSON response for agent relations.
     Combines collaboration network + trust edges + generic relations. *)
 let json ~agent_name () : Yojson.Safe.t =
@@ -92,6 +108,10 @@ let json ~agent_name () : Yojson.Safe.t =
     | None -> []
   in
   `Assoc [
+    ("dashboard_surface", `String dashboard_surface);
+    ("source", `String dashboard_source);
+    ("retention", dashboard_retention_json);
+    ("generated_at_iso", `String (Masc_domain.now_iso ()));
     ("agent_name", `String agent_name);
     ("collaborators", `List collaborators);
     ("interests", `List interests);

--- a/lib/dashboard/dashboard_agent_relations.mli
+++ b/lib/dashboard/dashboard_agent_relations.mli
@@ -11,5 +11,7 @@
     collaborators, interests, and outgoing relations (public-visibility,
     first 20) with an 8-second per-query timeout. On GraphQL error the
     affected section falls back to an empty list and the surrounding
-    payload is still returned. *)
+    payload is still returned. The payload also includes
+    [dashboard_surface], [source], [retention], and [generated_at_iso] so
+    Agent Observatory can show this feed's provenance. *)
 val json : agent_name:string -> unit -> Yojson.Safe.t

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1998,6 +1998,16 @@ let keeper_cost_aggregates_json
   ]
 
 let k2_feed_limit limit = max 1 (min 200 limit)
+let keeper_decisions_dashboard_surface = "/api/v1/dashboard/keeper-decisions"
+
+let keeper_decisions_retention_json ~per_keeper_limit ~keeper_count =
+  `Assoc
+    [
+      ("scope", `String "per_keeper_jsonl_tail");
+      ("durable_store", `String ".masc/keepers/:name.decisions.jsonl");
+      ("per_keeper_tail_lines", `Int per_keeper_limit);
+      ("keeper_count", `Int keeper_count);
+    ]
 
 (** Read per-keeper [.decisions.jsonl] files and return a unified,
     time-sorted stream of recent events (turn telemetry, tool_exec,
@@ -2103,9 +2113,16 @@ let keeper_decisions_json
     ) top
   in
   `Assoc [
+    ("dashboard_surface", `String keeper_decisions_dashboard_surface);
+    ("source", `String "keeper_decision_log");
+    ( "retention",
+      keeper_decisions_retention_json
+        ~per_keeper_limit
+        ~keeper_count:(List.length keepers) );
     ("events", `List items);
     ("limit", `Int limit);
     ("generated_at", `Float (Unix.gettimeofday ()));
+    ("generated_at_iso", `String (Masc_domain.now_iso ()));
   ]
 
 let k2_iso8601_of_unix ts_unix =

--- a/lib/dashboard/dashboard_oas_bridge.ml
+++ b/lib/dashboard/dashboard_oas_bridge.ml
@@ -72,6 +72,16 @@ let float_opt_to_yojson = function Some value -> `Float value | None -> `Null
 let bool_opt_to_yojson = function Some value -> `Bool value | None -> `Null
 let public_runtime_provider_label = "runtime"
 let public_runtime_model_label = "runtime"
+let source_label = "oas_runtime_bridge"
+let durable_replay_surface = "/api/v1/dashboard/telemetry?source=oas_event"
+
+let retention_json =
+  `Assoc
+    [
+      ("scope", `String "in_process_runtime_lane");
+      ("per_provider_cap", `Int per_provider_cap);
+      ("durable_replay_surface", `String durable_replay_surface);
+    ]
 
 let normalize_sample (s : sample) =
   {
@@ -495,6 +505,10 @@ let recent_json ?provider ?limit () =
   let samples = recent ?provider ?limit () in
   `Assoc
     [
+      ("generated_at", `String (Masc_domain.now_iso ()));
+      ("dashboard_surface", `String "/api/v1/dashboard/oas/telemetry/recent");
+      ("source", `String source_label);
+      ("retention", retention_json);
       ("provider", provider_json provider);
       ( "limit",
         match limit with
@@ -508,6 +522,10 @@ let summary_json ?provider ?limit () =
   let summary = summary ?provider ?limit () in
   `Assoc
     [
+      ("generated_at", `String (Masc_domain.now_iso ()));
+      ("dashboard_surface", `String "/api/v1/dashboard/oas/telemetry/summary");
+      ("source", `String source_label);
+      ("retention", retention_json);
       ("provider", provider_json provider);
       ( "limit",
         match limit with

--- a/lib/dashboard/dashboard_oas_bridge.mli
+++ b/lib/dashboard/dashboard_oas_bridge.mli
@@ -209,11 +209,15 @@ val summary_to_yojson : summary -> Yojson.Safe.t
 
 val recent_json : ?provider:string -> ?limit:int -> unit -> Yojson.Safe.t
 (** Dashboard payload for
-    [GET /api/v1/dashboard/oas/telemetry/recent?provider=P&limit=N]. *)
+    [GET /api/v1/dashboard/oas/telemetry/recent?provider=P&limit=N].
+    The envelope includes [dashboard_surface], [source], and [retention] so
+    operators can distinguish this in-process runtime-lane cache from the
+    durable [oas_event] replay surface. *)
 
 val summary_json : ?provider:string -> ?limit:int -> unit -> Yojson.Safe.t
 (** Dashboard payload for
-    [GET /api/v1/dashboard/oas/telemetry/summary?provider=P&limit=N]. *)
+    [GET /api/v1/dashboard/oas/telemetry/summary?provider=P&limit=N].
+    The envelope carries the same provenance metadata as {!recent_json}. *)
 
 val clear : ?provider:string -> unit -> unit
 (** [clear ?provider ()] drops samples and provider-error counts. With

--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -170,8 +170,12 @@ let request_to_json (req : V.verification_request) : Yojson.Safe.t =
     Protected against missing base_path or filesystem errors — failures
     surface as an empty list plus a log line, matching the tolerance
     [Verification.list_requests] already offers on a missing dir. *)
-let load_requests () : V.verification_request list =
-  let base_path = Env_config_core.base_path () in
+let load_requests ?base_path () : V.verification_request list =
+  let base_path =
+    match base_path with
+    | Some value -> value
+    | None -> Env_config_core.base_path ()
+  in
   try V.list_requests base_path
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -206,9 +210,9 @@ let take n lst =
 
 let now_iso () = Masc_domain.now_iso ()
 
-let requests_json ?task_id ?limit () : Yojson.Safe.t =
+let requests_json ?base_path ?task_id ?limit () : Yojson.Safe.t =
   let limit = clamp_limit limit in
-  let all = load_requests () in
+  let all = load_requests ?base_path () in
   let filtered = filter_by_task_id all task_id in
   let sorted = sort_desc filtered in
   let trimmed = take limit sorted in
@@ -257,9 +261,9 @@ let is_rejected (req : V.verification_request) : bool =
 let bucket_of_status (req : V.verification_request) : string =
   req |> status_bucket_of_request |> status_bucket_to_string
 
-let summary_json ?recent () : Yojson.Safe.t =
+let summary_json ?base_path ?recent () : Yojson.Safe.t =
   let recent = clamp_recent recent in
-  let all = load_requests () in
+  let all = load_requests ?base_path () in
   let total = List.length all in
   let pending = ref 0 in
   let approved = ref 0 in

--- a/lib/dashboard/dashboard_verification.mli
+++ b/lib/dashboard/dashboard_verification.mli
@@ -47,12 +47,17 @@
 
 (** Build the JSON snapshot of verification requests.
 
+    - [base_path]: when provided, read that runtime root instead of the
+      process-wide fallback. HTTP routes pass the active server config so a
+      dashboard bound to a non-default base path does not show stale
+      verification state.
     - [task_id]: when [Some id] (non-empty), return only requests whose
       [task_id] equals [id]. When absent or empty, return all tasks.
     - [limit]: clamped into [\[1, 500\]]; defaults to 100. Sort is
       reverse-chronological by [created_at] so the newest request wins
       when the cap trims. *)
 val requests_json :
+  ?base_path:string ->
   ?task_id:string ->
   ?limit:int ->
   unit ->
@@ -60,6 +65,8 @@ val requests_json :
 
 (** Build a one-shot summary snapshot: status bucket counts plus the most
     recent rejections (carriers of verdict_reason / PR / issue refs).
+
+    [base_path] has the same meaning as on {!requests_json}.
 
     The [recent] parameter is clamped into [\[0, 20\]] and defaults to 3.
     When [0], the ["recent_rejections"] array is empty but still present.
@@ -82,4 +89,4 @@ val requests_json :
         ]
       }
     ]} *)
-val summary_json : ?recent:int -> unit -> Yojson.Safe.t
+val summary_json : ?base_path:string -> ?recent:int -> unit -> Yojson.Safe.t

--- a/lib/heuristic_metrics.ml
+++ b/lib/heuristic_metrics.ml
@@ -131,13 +131,33 @@ let dashboard_issue_event_to_json (json : Yojson.Safe.t) : Yojson.Safe.t option 
 
 let dashboard_issue_events events = List.filter_map dashboard_issue_event_to_json events
 
+let dashboard_source = "heuristic_metrics"
+let dashboard_surface = "/api/v1/dashboard/heuristics"
+let coverage_dashboard_surface = "/api/v1/dashboard/heuristics/coverage"
+
+let dashboard_retention_json =
+  `Assoc
+    [ "scope", `String "jsonl_tail"
+    ; "durable_store", `String ".masc/heuristic_metrics.jsonl"
+    ]
+;;
+
+let dashboard_metadata_fields ~surface =
+  [ "generated_at_iso", `String (Masc_domain.now_iso ())
+  ; "dashboard_surface", `String surface
+  ; "source", `String dashboard_source
+  ; "retention", dashboard_retention_json
+  ]
+;;
+
 let dashboard_feed_json ~limit events =
   `Assoc
-    [ "limit", `Int limit
+    (dashboard_metadata_fields ~surface:dashboard_surface
+     @ [ "limit", `Int limit
     ; "count", `Int (List.length events)
     ; "events", `List events
     ; "heuristics", `List (dashboard_issue_events events)
-    ]
+       ])
 ;;
 
 (* ================================================================ *)
@@ -442,10 +462,11 @@ let coverage_site_to_json site =
 
 let coverage_report_to_json report =
   `Assoc
-    [ "total_events", `Int report.total_events
+    (dashboard_metadata_fields ~surface:coverage_dashboard_surface
+     @ [ "total_events", `Int report.total_events
     ; "decision_shape_count", `Int report.decision_shape_count
     ; "mixed_outcome_sites", `Int report.mixed_outcome_sites
     ; "unique_decision_tuples", `Int report.unique_decision_tuples
     ; "sites", `List (List.map coverage_site_to_json report.sites)
-    ]
+       ])
 ;;

--- a/lib/heuristic_metrics.mli
+++ b/lib/heuristic_metrics.mli
@@ -92,7 +92,9 @@ val recent_coverage : int -> coverage_report
 (** Read recent events and summarize their coverage. *)
 
 val coverage_report_to_json : coverage_report -> Yojson.Safe.t
-(** Serialize a coverage report for diagnostics. *)
+(** Serialize a coverage report for diagnostics.  The dashboard envelope
+    includes [dashboard_surface], [source], and [retention] so operators can
+    tie the visible coverage aggregate back to its JSONL store. *)
 
 val event_to_json : event -> Yojson.Safe.t
 (** Serialize an event for external consumption (dashboard, tests). *)
@@ -105,4 +107,5 @@ val dashboard_issue_events : Yojson.Safe.t list -> Yojson.Safe.t list
 
 val dashboard_feed_json : limit:int -> Yojson.Safe.t list -> Yojson.Safe.t
 (** Build the dashboard response carrying both the existing [events] array
-    and the O5 compatibility [heuristics] array. *)
+    and the O5 compatibility [heuristics] array.  The envelope includes
+    [dashboard_surface], [source], and [retention]. *)

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -115,6 +115,9 @@ module Ring : sig
       JSONL files that were written before the typed encoder.  Every
       other call site lets it propagate. *)
 
+  val capacity : int
+  (** Maximum number of entries retained in the in-memory dashboard ring. *)
+
   val source_of_string : string -> source
   (** Inverse of {!source_to_string}.  Raises {!Entry_decode_error} on
       unknown labels. *)

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -382,6 +382,86 @@ let dashboard_governance_tool_events_http_json request : Yojson.Safe.t =
   Dashboard_governance_metrics.governance_tool_events_json ~window_minutes:window ()
 ;;
 
+let dashboard_proof_http_json ~config request : Yojson.Safe.t =
+  let limit = int_query_param request "limit" ~default:25 |> clamp ~min_v:1 ~max_v:100 in
+  let recent =
+    int_query_param request "recent" ~default:5 |> clamp ~min_v:0 ~max_v:20
+  in
+  let base_path = config.Coord.base_path in
+  let verification_summary =
+    Dashboard_verification.summary_json ~base_path ~recent ()
+  in
+  let verification_requests =
+    Dashboard_verification.requests_json ~base_path ~limit ()
+  in
+  let proof_source ~id ~label ~route =
+    `Assoc [ "id", `String id; "label", `String label; "route", `String route ]
+  in
+  let proof_sources =
+    [
+      proof_source ~id:"verification_summary"
+        ~label:"Verification status buckets"
+        ~route:"/api/v1/verification/summary";
+      proof_source ~id:"verification_requests"
+        ~label:"Verification request evidence"
+        ~route:"/api/v1/verification/requests";
+      proof_source ~id:"tlc_results"
+        ~label:"TLA+ verification logs"
+        ~route:"/api/v1/verification/tlc-results";
+      proof_source ~id:"keeper_feature_proof"
+        ~label:"Keeper autonomy feature proof"
+        ~route:"/api/v1/dashboard/keeper-feature-proof";
+      proof_source ~id:"safe_autonomy"
+        ~label:"Autonomy safety evidence"
+        ~route:"/api/v1/dashboard/safe-autonomy";
+      proof_source ~id:"execution_trust"
+        ~label:"Execution trust provenance"
+        ~route:"/api/v1/dashboard/execution-trust";
+      proof_source ~id:"surface_readiness"
+        ~label:"Dashboard surface readiness refs"
+        ~route:"/api/v1/dashboard/surface-readiness";
+    ]
+  in
+  let by_status =
+    match verification_summary with
+    | `Assoc fields -> (
+        match List.assoc_opt "by_status" fields with
+        | Some (`Assoc status_fields) -> status_fields
+        | _ -> [])
+    | _ -> []
+  in
+  let status_int key =
+    match List.assoc_opt key by_status with
+    | Some (`Int n) -> n
+    | _ -> 0
+  in
+  `Assoc
+    [
+      "generated_at", `String (Masc_domain.now_iso ());
+      ( "summary",
+        `Assoc
+          [
+            "verification_total",
+            (match verification_summary with
+             | `Assoc fields -> (
+                 match List.assoc_opt "total" fields with
+                 | Some (`Int n) -> `Int n
+                 | _ -> `Int 0)
+             | _ -> `Int 0);
+            "verification_pending", `Int (status_int "pending");
+            "verification_rejected", `Int (status_int "rejected");
+            "proof_source_count", `Int (List.length proof_sources);
+          ] );
+      ( "verification",
+        `Assoc
+          [
+            "summary", verification_summary;
+            "requests", verification_requests;
+          ] );
+      "proof_sources", `List proof_sources;
+    ]
+;;
+
 type approval_resolve_http_error =
   | Bad_request of string
   | Gone of Keeper_approval_queue.resolve_error

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -78,6 +78,9 @@ val dashboard_governance_http_json :
 val dashboard_governance_tool_events_http_json :
   Httpun.Request.t -> Yojson.Safe.t
 
+val dashboard_proof_http_json :
+  config:Coord.config -> Httpun.Request.t -> Yojson.Safe.t
+
 val dashboard_governance_approval_resolve_http_json :
   base_path:string ->
   args:Yojson.Safe.t ->

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -470,9 +470,11 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
 ;;
 
 let operator_snapshot_http_json ~state ~sw ~clock request =
+  let config = state.Mcp_server.room_config in
+  let proc_mgr = state.Mcp_server.proc_mgr in
   let net, mono_clock = state_dashboard_runtime_caps state in
   let actor =
-    dashboard_actor_for_request ~base_path:state.Mcp_server.room_config.base_path request
+    dashboard_actor_for_request ~base_path:config.base_path request
   in
   let view = query_param request "view" in
   let default_summary_request =
@@ -484,8 +486,48 @@ let operator_snapshot_http_json ~state ~sw ~clock request =
     | None -> true
     | Some raw -> String.equal (String.lowercase_ascii (String.trim raw)) "summary"
   in
+  let compute_default_summary () =
+    let started_at = Unix.gettimeofday () in
+    run_dashboard_compute
+      ~mode:Offloaded_readonly
+      ?net
+      ?mono_clock
+      ~sw
+      ~clock
+      ~config
+      (fun ~config ~sw ->
+         let ctx : _ Operator_control.context =
+           { config
+           ; agent_name = "dashboard"
+           ; sw
+           ; clock
+           ; proc_mgr
+           ; net = None
+           ; mcp_session_id = None
+           }
+         in
+         Operator_control.snapshot_json
+           ~actor:"dashboard"
+           ~view:"summary"
+           ~include_messages:true
+           ~include_keepers:true
+           ~include_summary_fields:false
+           ~lightweight_summary:true
+           ctx)
+    |> with_projection_diagnostics
+         ~surface:"operator_snapshot"
+         ~started_at
+         ~extra:(operator_snapshot_extra ())
+  in
   if default_summary_request
-  then cached_surface_json _operator_snapshot_cache
+  then
+    cached_surface_or_first_success_json
+      _operator_snapshot_cache
+      ~cache_key:(dashboard_cache_key config "operator_snapshot" "default-summary")
+      ~ttl:5.0
+      ~clock
+      ~timeout_sec:dashboard_request_timeout_s
+      compute_default_summary
   else (
     let started_at = Unix.gettimeofday () in
     let include_messages =
@@ -514,14 +556,14 @@ let operator_snapshot_http_json ~state ~sw ~clock request =
                ?mono_clock
                ~sw
                ~clock
-               ~config:state.Mcp_server.room_config
+               ~config
                (fun ~config ~sw ->
                   let ctx : _ Operator_control.context =
                     { config
                     ; agent_name = Option.value ~default:"dashboard" actor
                     ; sw
                     ; clock
-                    ; proc_mgr = state.Mcp_server.proc_mgr
+                    ; proc_mgr
                     ; net = state.Mcp_server.net
                     ; mcp_session_id = None
                     }

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -11,6 +11,7 @@ let float_of_env_default_with_legacy ~canonical ~legacy ~default ~min_v ~max_v =
   | None -> float_of_env_default legacy ~default ~min_v ~max_v
 
 let dashboard_namespace_truth_http_json ~state ~sw:_ ~clock _request =
+  let config = state.Mcp_server.room_config in
   (* Fast-path: if the proactive execution refresh hasn't produced a result
      yet, return "initializing" immediately instead of blocking for 15-20s
      on cold-start on-demand compute. The frontend retries every 3s via
@@ -32,18 +33,11 @@ let dashboard_namespace_truth_http_json ~state ~sw:_ ~clock _request =
         && Option.is_none Execution_surfaces._execution_cache.last_error_unix
   in
   if proactive_first_cycle_pending then
-    `Assoc
-      [
-        ("status", `String "initializing");
-        ("generated_at", `String (Masc_domain.now_iso ()));
-        ( "message",
-          `String
-            "Execution snapshot is still warming up. The dashboard will retry automatically."
-        );
-      ]
+    Namespace_truth_support.compose_namespace_truth_initializing ~config
+      ~message:
+        "Execution snapshot is still warming up. The dashboard will retry automatically."
   else
     with_dashboard_timeout ~clock (fun () ->
-        let config = state.Mcp_server.room_config in
         let started_at = Unix.gettimeofday () in
         let t0 = Time_compat.now () in
         (* Staged fetch: shell may still need a guarded refresh, while execution
@@ -180,7 +174,10 @@ let rec normalize_namespace_truth_snapshot_for_hash (json : Yojson.Safe.t) :
       `Assoc
         (fields
         |> List.filter_map (fun (key, value) ->
-               if String.equal key "generated_at" then None
+               if
+                 String.equal key "generated_at"
+                 || String.equal key "generated_at_iso"
+               then None
                else Some (key, normalize_namespace_truth_snapshot_for_hash value)))
   | `List values ->
       `List (List.map normalize_namespace_truth_snapshot_for_hash values)

--- a/lib/server/server_dashboard_http_namespace_truth.mli
+++ b/lib/server/server_dashboard_http_namespace_truth.mli
@@ -26,6 +26,12 @@ val dashboard_namespace_truth_http_json :
 (** [dashboard_namespace_truth_http_json ~state ~sw ~clock request]
     serves the namespace-truth read model.
 
+    All responses, including cold-start, carry top-level
+    [dashboard_surface], [dashboard_aliases], [source], [retention],
+    and [generated_at_iso] fields so legacy aliases such as
+    [/dashboard/room-truth] remain visibly tied to the canonical
+    namespace-truth read model.
+
     Cold-start fast-path: when the proactive
     {!Server_dashboard_http_execution_surfaces._execution_cache} has
     not produced a successful first cycle and the warm-escape window

--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -365,6 +365,50 @@ let namespace_truth_command_summary_json command_summary_json =
       ("provenance", `String "truth");
     ]
 
+let namespace_truth_dashboard_surface = "/api/v1/dashboard/namespace-truth"
+let namespace_truth_source = "namespace_truth_read_model"
+
+let namespace_truth_aliases =
+  [
+    "/api/v1/dashboard/project-snapshot";
+    "/api/v1/dashboard/room-truth";
+  ]
+
+let namespace_truth_aliases_json () =
+  `List (List.map (fun alias -> `String alias) namespace_truth_aliases)
+
+let namespace_truth_retention_json ~(config : Coord.config) =
+  `Assoc
+    [
+      ("scope", `String "dashboard_namespace_truth");
+      ("coordination_root", `String config.base_path);
+      ("workspace_path", `String config.workspace_path);
+      ("shell_input", `String "/api/v1/dashboard/shell");
+      ("execution_input", `String "/api/v1/dashboard/execution");
+      ("command_input", `String "command_summary_json");
+      ( "cache_policy",
+        `String "proactive_execution_cache_last_good_shell_fallback" );
+    ]
+
+let namespace_truth_metadata_fields ~(config : Coord.config) ~generated_at =
+  [
+    ("dashboard_surface", `String namespace_truth_dashboard_surface);
+    ("dashboard_aliases", namespace_truth_aliases_json ());
+    ("source", `String namespace_truth_source);
+    ("retention", namespace_truth_retention_json ~config);
+    ("generated_at_iso", `String generated_at);
+  ]
+
+let compose_namespace_truth_initializing ~(config : Coord.config) ~message =
+  let generated_at = Masc_domain.now_iso () in
+  `Assoc
+    (namespace_truth_metadata_fields ~config ~generated_at
+     @ [
+         ("status", `String "initializing");
+         ("generated_at", `String generated_at);
+         ("message", `String message);
+       ])
+
 module String_set = Set.Make (String)
 
 let json_bool_field key json ~default =
@@ -793,6 +837,7 @@ let derive_readiness_and_attention ~execution_json ~execution_summary
 
 let compose_namespace_truth_snapshot ~(config : Coord.config) ~initialized ~shell_json
     ~execution_json ~command_summary_json =
+  let generated_at = Masc_domain.now_iso () in
   let meta_cognition_summary = json_assoc_field "meta_cognition" shell_json in
   let meta_summary_input, meta_interpretation =
     match Meta_cognition.parse_summary meta_cognition_summary with
@@ -841,8 +886,9 @@ let compose_namespace_truth_snapshot ~(config : Coord.config) ~initialized ~shel
       ]
   in
   `Assoc
-      [
-        ("generated_at", `String (Masc_domain.now_iso ()));
+    (namespace_truth_metadata_fields ~config ~generated_at
+     @ [
+         ("generated_at", `String generated_at);
         ("root", namespace_block);
         ( "execution",
         `Assoc
@@ -878,4 +924,4 @@ let compose_namespace_truth_snapshot ~(config : Coord.config) ~initialized ~shel
       ("readiness", readiness_json);
       ("attention_events", attention_events_json);
       ("focus", focus_json);
-    ]
+    ])

--- a/lib/server/server_dashboard_http_namespace_truth_support.mli
+++ b/lib/server/server_dashboard_http_namespace_truth_support.mli
@@ -2,13 +2,17 @@
     namespace-truth snapshot composition + focus / queue
     extraction for the dashboard HTTP facade.
 
-    External surface (2 entries) — every dotted caller
+    External surface (3 entries) — every dotted caller
     reaches one of these and nothing else:
     - {!compose_namespace_truth_snapshot} consumed by
       {!Server_dashboard_http_namespace_truth} (also
       reached via the
       [module Namespace_truth_support = ...] alias inside
       that module).
+    - {!compose_namespace_truth_initializing} consumed by
+      {!Server_dashboard_http_namespace_truth} for the cold-start
+      fast path so even the minimal warming response keeps canonical
+      surface/source/retention metadata.
     - {!dashboard_namespace_truth_focus_json} consumed by
       {!Server_dashboard_http} as a one-line
       pass-through (no cascade-include re-export — the
@@ -56,3 +60,10 @@ val compose_namespace_truth_snapshot :
     (TTL'd 10 s, stale-served up to 30 s).  Used by
     {!Server_dashboard_http_namespace_truth} as the
     SSOT producer for the [namespace_truth] HTTP route. *)
+
+val compose_namespace_truth_initializing :
+  config:Coord.config -> message:string -> Yojson.Safe.t
+(** Composes the namespace-truth cold-start response with the same
+    top-level [dashboard_surface], [dashboard_aliases], [source],
+    [retention], and [generated_at_iso] metadata used by the warm
+    read-model. *)

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -753,6 +753,14 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             in
             h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
 
+      | `GET, "/api/v1/dashboard/proof" ->
+          with_h2_public_read h2_reqd (fun state ->
+            let json =
+              dashboard_proof_http_json
+                ~config:state.Mcp_server.room_config httpun_request
+            in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+
       | `GET, "/api/v1/dashboard/planning" ->
           with_h2_public_read h2_reqd (fun state ->
             let json =

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -17,6 +17,70 @@ type cascade_profile_gate = {
   invalid_assignments : (string * string list) list;
 }
 
+let option_int_json = function
+  | Some value -> `Int value
+  | None -> `Null
+
+let option_string_json = function
+  | Some value -> `String value
+  | None -> `Null
+
+let dashboard_logs_store_path ~masc_root =
+  Filename.concat
+    (Filename.concat masc_root "logs")
+    (Printf.sprintf "system_log_%s.jsonl"
+       (Log.format_utc_date_of (Unix.gettimeofday ())))
+
+let dashboard_logs_json ~config ~limit ~level_filter ~min_level ~module_filter
+    ~since_seq entries =
+  let masc_root = Coord.masc_root_dir config in
+  let newest = match entries with [] -> None | entry :: _ -> Some entry in
+  let oldest = List.fold_left (fun _ entry -> Some entry) None entries in
+  let entry_seq_json = Option.map (fun (entry : Log.Ring.entry) -> entry.seq) in
+  let entry_ts_json = Option.map (fun (entry : Log.Ring.entry) -> entry.ts) in
+  match Log.Ring.to_json entries with
+  | `Assoc fields ->
+      `Assoc
+        ([
+           ("generated_at_iso", `String (Masc_domain.now_iso ()));
+           ("dashboard_surface", `String "/api/v1/dashboard/logs");
+           ("source", `String "masc_log_ring");
+           ( "retention",
+             `Assoc
+               [
+                 ("scope", `String "dashboard_logs");
+                 ("coordination_root", `String masc_root);
+                 ("buffer", `String "Log.Ring");
+                 ("capacity", `Int Log.Ring.capacity);
+                 ( "durable_store",
+                   `String (dashboard_logs_store_path ~masc_root) );
+                 ("file_pattern", `String "system_log_YYYY-MM-DD.jsonl");
+                 ("keep_days", `Int 7);
+                 ( "cache_policy",
+                   `String
+                     "uncached; reads in-memory ring backed by daily JSONL sink; delta cursor via since_seq"
+                 );
+               ] );
+           ( "query",
+             `Assoc
+               [
+                 ("limit", `Int limit);
+                 ("level", `String level_filter);
+                 ( "applied_level",
+                   `String (Log.level_to_string (Log.level_of_string level_filter))
+                 );
+                 ("min_level", `Int min_level);
+                 ("module", `String module_filter);
+                 ("since_seq", option_int_json since_seq);
+               ] );
+           ("returned", `Int (List.length entries));
+           ("latest_seq", option_int_json (entry_seq_json newest));
+           ("oldest_seq", option_int_json (entry_seq_json oldest));
+           ("latest_ts_iso", option_string_json (entry_ts_json newest));
+         ]
+        @ fields)
+  | json -> json
+
 let cascade_profile_gate () : cascade_profile_gate =
   let config_path = Cascade_runtime.cascade_config_path () in
   let keeper_assignable_profiles =
@@ -474,14 +538,18 @@ let rec add_routes ~sw ~clock router =
        in
        with_tool_auth ~tool_name:"masc_runtime_ollama_probe" handle request reqd)
   |> Http.Router.get "/api/v1/dashboard/logs" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
+       with_public_read (fun state req reqd ->
          let limit =
            Server_utils.int_query_param req "limit" ~default:200
            |> max 1 |> min 3000
          in
-         let min_level = match Server_utils.query_param req "level" with
-           | Some v -> Log.level_to_int (Log.level_of_string v)
-           | None -> 0
+         let level_filter =
+           match Server_utils.query_param req "level" with
+           | Some v -> v
+           | None -> "DEBUG"
+         in
+         let min_level =
+           Log.level_to_int (Log.level_of_string level_filter)
          in
          let since_seq =
            match Server_utils.query_param req "since_seq" with
@@ -497,7 +565,10 @@ let rec add_routes ~sw ~clock router =
          let entries =
            Log.Ring.recent ~limit ~min_level ~module_filter ?since_seq ()
          in
-         let json = Log.Ring.to_json entries in
+         let json =
+           dashboard_logs_json ~config:state.Mcp_server.room_config ~limit
+             ~level_filter ~min_level ~module_filter ~since_seq entries
+         in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -693,6 +693,14 @@ let rec add_routes ~sw ~clock router =
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/proof" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let json =
+           dashboard_proof_http_json ~config:state.Mcp_server.room_config req
+         in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
   |> Http.Router.post "/api/v1/dashboard/governance/approvals/resolve" (fun request reqd ->
        with_tool_auth ~tool_name:"masc_operator_confirm" (fun state _req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -748,6 +748,41 @@ let append_assoc key value = function
   | json -> json
 ;;
 
+let prepend_assoc fields = function
+  | `Assoc existing -> `Assoc (fields @ existing)
+  | json -> `Assoc (fields @ [ "payload", json ])
+;;
+
+let sidecar_status_dashboard_surface = "/api/v1/sidecar/status"
+let sidecar_status_source = "sidecar_status_file"
+
+let sidecar_status_retention_json ~base_path ~id ~status_path =
+  `Assoc
+    [ "scope", `String "runtime_sidecar_status"
+    ; "status_path", `String status_path
+    ; "default_status_path"
+      , `String (Filename.concat base_path (Printf.sprintf ".gate/runtime/%s/status.json" id))
+    ; "legacy_status_path", `String (Filename.concat base_path (legacy_status_rel id))
+    ; "lifecycle_desired_path", `String (sidecar_desired_path ~base_path id)
+    ; "lifecycle_attempt_path", `String (sidecar_attempt_path ~base_path id)
+    ; "binding_store_path"
+      , `String (Filename.concat base_path (Printf.sprintf ".gate/runtime/%s/bindings.json" id))
+    ; "binding_audit_store_path"
+      , `String
+          (Filename.concat
+             base_path
+             (Printf.sprintf ".gate/runtime/%s/binding_audit.jsonl" id))
+    ]
+;;
+
+let sidecar_status_metadata_fields ~base_path ~id ~status_path =
+  [ "dashboard_surface", `String sidecar_status_dashboard_surface
+  ; "source", `String sidecar_status_source
+  ; "retention", sidecar_status_retention_json ~base_path ~id ~status_path
+  ; "generated_at_iso", `String (isoish_now ())
+  ]
+;;
+
 (** Clamp the [?lines=N] query param to [1, 1000]. Pure so unit tests
     can pin the upper bound without a request mock. *)
 let clamp_lines = function
@@ -802,7 +837,9 @@ let read_status_json ~base_path id =
     else
       `Assoc [ "ok", `Bool true; "available", `Bool false; "status_path", `String path ]
   in
-  append_assoc "sidecar_lifecycle" (lifecycle_json ~base_path id status) status
+  status
+  |> append_assoc "sidecar_lifecycle" (lifecycle_json ~base_path id status)
+  |> prepend_assoc (sidecar_status_metadata_fields ~base_path ~id ~status_path:path)
 ;;
 
 let handle_status state request reqd =

--- a/lib/server/server_routes_http_routes_verification.ml
+++ b/lib/server/server_routes_http_routes_verification.ml
@@ -45,27 +45,29 @@ let verifier_of_request ~base_path request =
 let add_routes router =
   router
   |> Http.Router.get "/api/v1/verification/requests" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
+       with_public_read (fun state req reqd ->
          let task_id = trimmed_query_param req "task_id" in
          let limit =
            match trimmed_query_param req "limit" with
            | Some s -> int_of_string_opt s
            | None -> None
          in
+         let base_path = state.Mcp_server.room_config.base_path in
          let json =
-           Dashboard_verification.requests_json ?task_id ?limit ()
+           Dashboard_verification.requests_json ~base_path ?task_id ?limit ()
          in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/verification/summary" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
+       with_public_read (fun state req reqd ->
          let recent =
            match trimmed_query_param req "recent" with
            | Some s -> int_of_string_opt s
            | None -> None
          in
-         let json = Dashboard_verification.summary_json ?recent () in
+         let base_path = state.Mcp_server.room_config.base_path in
+         let json = Dashboard_verification.summary_json ~base_path ?recent () in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -68,6 +68,36 @@ type timeline_event = {
   detail : Yojson.Safe.t;
 }
 
+let dashboard_surface = "/api/v1/agent-timeline"
+let dashboard_source = "agent_timeline_read_model"
+
+let dashboard_retention_json =
+  `Assoc
+    [
+      ("scope", `String "multi_source_tail");
+      ( "durable_store",
+        `String
+          ".masc/agents/*.json + .masc/tasks/*.json + \
+           .masc/messages/*.json + \
+           .masc/activity-events/YYYY-MM/YYYY-MM-DD.jsonl" );
+      ( "durable_stores",
+        `List
+          [
+            `String ".masc/agents/*.json";
+            `String ".masc/tasks/*.json";
+            `String ".masc/messages/*.json";
+            `String ".masc/activity-events/YYYY-MM/YYYY-MM-DD.jsonl";
+          ] );
+      ( "activity_event_kinds",
+        `List
+          [
+            `String "tool.called";
+            `String "keeper.contract_verdict";
+            `String "keeper.friction";
+            `String "keeper.turn_completed";
+          ] );
+    ]
+
 let event_to_json (e : timeline_event) : Yojson.Safe.t =
   `Assoc
     [
@@ -537,6 +567,10 @@ let build_timeline (config : Coord.config) ~agent_name ~since_hours ~limit
   let now_iso = Masc_domain.now_iso () in
   `Assoc
     [
+      ("dashboard_surface", `String dashboard_surface);
+      ("source", `String dashboard_source);
+      ("retention", dashboard_retention_json);
+      ("generated_at_iso", `String now_iso);
       ("agent", `String agent_name);
       ( "period",
         `Assoc [ ("from", `String since_iso); ("to", `String now_iso) ] );

--- a/lib/tool_agent_timeline.mli
+++ b/lib/tool_agent_timeline.mli
@@ -44,7 +44,10 @@ val build_timeline :
   Yojson.Safe.t
 (** [build_timeline config ~agent_name ~since_hours ~limit
       ~include_tasks ~include_board ~include_tool_calls] returns a
-    JSON object with two keys:
+    JSON object with source metadata plus the timeline payload:
+
+    - [dashboard_surface], [source], [retention], [generated_at_iso]
+      — dashboard provenance for the multi-source read model.
 
     - [events] — the truncated, chronologically-sorted event
       list (most recent [limit] events).

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -167,6 +167,12 @@ check_http "activity swimlane 200" "$BASE/api/v1/activity/swimlane" "200"
 check_json "activity swimlane exposes spans" "$BASE/api/v1/activity/swimlane" "'spans' in d and 'agents' in d" '^True$'
 check_http "telemetry summary 200" "$BASE/api/v1/dashboard/telemetry/summary" "200"
 check_json "telemetry summary has sources" "$BASE/api/v1/dashboard/telemetry/summary" "'sources' in d" '^True$'
+check_http "telemetry entries 200" "$BASE/api/v1/dashboard/telemetry?source=oas_event&n=5" "200"
+check_json "telemetry entries exposes replay envelope" "$BASE/api/v1/dashboard/telemetry?source=oas_event&n=5" "'entries' in d and 'total_matching_entries' in d and 'truncated' in d" '^True$'
+check_http "oas telemetry recent 200" "$BASE/api/v1/dashboard/oas/telemetry/recent?limit=5" "200"
+check_json "oas telemetry recent exposes provenance" "$BASE/api/v1/dashboard/oas/telemetry/recent?limit=5" "'samples' in d and 'dashboard_surface' in d and 'retention' in d" '^True$'
+check_http "oas telemetry summary 200" "$BASE/api/v1/dashboard/oas/telemetry/summary?limit=5" "200"
+check_json "oas telemetry summary exposes provenance" "$BASE/api/v1/dashboard/oas/telemetry/summary?limit=5" "'summary' in d and 'dashboard_surface' in d and 'retention' in d" '^True$'
 check_http "cascade health 200" "$BASE/api/v1/cascade/health" "200"
 check_json "cascade health exposes providers" "$BASE/api/v1/cascade/health" "'providers' in d" '^True$'
 check_http "cascade strategy trace 200" "$BASE/api/v1/cascade/strategy_trace?limit=1" "200"

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -163,6 +163,10 @@ check_http "activity graph 200" "$BASE/api/v1/activity/graph" "200"
 check_json "activity graph has nodes" "$BASE/api/v1/activity/graph" "len(d.get('nodes', [])) >= 0" '^True$'
 check_http "activity events 200" "$BASE/api/v1/activity/events?limit=1" "200"
 check_json "activity events exposes replay window" "$BASE/api/v1/activity/events?limit=1" "'events' in d and 'latest_seq' in d" '^True$'
+check_http "agent timeline 200" "$BASE/api/v1/agent-timeline?agent_name=sangsu&limit=1" "200"
+check_json "agent timeline exposes provenance" "$BASE/api/v1/agent-timeline?agent_name=sangsu&limit=1" "'events' in d and d.get('dashboard_surface') == '/api/v1/agent-timeline' and d.get('source') == 'agent_timeline_read_model' and 'retention' in d" '^True$'
+check_http "agent relations 200" "$BASE/api/v1/agent-relations?agent_name=sangsu" "200"
+check_json "agent relations exposes provenance" "$BASE/api/v1/agent-relations?agent_name=sangsu" "'relations' in d and d.get('dashboard_surface') == '/api/v1/agent-relations' and d.get('source') == 'second_brain_graphql' and 'retention' in d" '^True$'
 check_http "activity swimlane 200" "$BASE/api/v1/activity/swimlane" "200"
 check_json "activity swimlane exposes spans" "$BASE/api/v1/activity/swimlane" "'spans' in d and 'agents' in d" '^True$'
 check_http "telemetry summary 200" "$BASE/api/v1/dashboard/telemetry/summary" "200"

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -279,6 +279,8 @@ check_http "gate status 200" "$BASE/api/v1/gate/status" "200"
 check_json "gate status exposes channel bindings" "$BASE/api/v1/gate/status" "'channels' in d and 'bindings' in d" '^True$'
 check_http "gate connectors 200" "$BASE/api/v1/gate/connectors" "200"
 check_json "gate connectors exposes connectors list" "$BASE/api/v1/gate/connectors" "'connectors' in d" '^True$'
+check_http "sidecar status 200" "$BASE/api/v1/sidecar/status?name=discord" "200"
+check_json "sidecar status exposes provenance" "$BASE/api/v1/sidecar/status?name=discord" "d.get('dashboard_surface') == '/api/v1/sidecar/status' and d.get('source') == 'sidecar_status_file' and d.get('retention', {}).get('scope') == 'runtime_sidecar_status' and 'sidecar_lifecycle' in d" '^True$'
 check_http "dashboard tools 200" "$BASE/api/v1/dashboard/tools" "200"
 check_json "dashboard tools exposes inventory" "$BASE/api/v1/dashboard/tools" "'tool_inventory' in d" '^True$'
 check_http "tool quality 200" "$BASE/api/v1/dashboard/tool-quality?window_hours=24" "200"

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -219,6 +219,14 @@ check_http "dashboard perf 200" "$BASE/api/v1/dashboard/perf" "200"
 check_json "dashboard perf exposes benchmark status" "$BASE/api/v1/dashboard/perf" "'status' in d and 'benchmarks' in d" '^True$'
 check_http "cost latency 200" "$BASE/api/v1/dashboard/cost-latency?window=60" "200"
 check_json "cost latency exposes cost and latency" "$BASE/api/v1/dashboard/cost-latency?window=60" "'total_cost_usd' in d and 'latencyBuckets' in d" '^True$'
+check_http "keeper decisions 200" "$BASE/api/v1/dashboard/keeper-decisions?limit=1" "200"
+check_json "keeper decisions exposes provenance" "$BASE/api/v1/dashboard/keeper-decisions?limit=1" "'events' in d and d.get('dashboard_surface') == '/api/v1/dashboard/keeper-decisions' and d.get('source') == 'keeper_decision_log' and 'retention' in d" '^True$'
+check_http "dashboard heuristics 200" "$BASE/api/v1/dashboard/heuristics?limit=1" "200"
+check_json "dashboard heuristics exposes provenance" "$BASE/api/v1/dashboard/heuristics?limit=1" "'events' in d and d.get('dashboard_surface') == '/api/v1/dashboard/heuristics' and d.get('source') == 'heuristic_metrics' and 'retention' in d" '^True$'
+check_http "heuristic coverage 200" "$BASE/api/v1/dashboard/heuristics/coverage?limit=1" "200"
+check_json "heuristic coverage exposes provenance" "$BASE/api/v1/dashboard/heuristics/coverage?limit=1" "'sites' in d and d.get('dashboard_surface') == '/api/v1/dashboard/heuristics/coverage' and d.get('source') == 'heuristic_metrics' and 'retention' in d" '^True$'
+check_http "dashboard stress 200" "$BASE/api/v1/dashboard/stress?limit=1" "200"
+check_json "dashboard stress exposes provenance" "$BASE/api/v1/dashboard/stress?limit=1" "'agent_stress' in d and d.get('dashboard_surface') == '/api/v1/dashboard/stress' and d.get('source') == 'agent_stress' and 'retention' in d" '^True$'
 
 echo "[4/7] Operations + Workspace"
 check_http "operator digest 200" "$BASE/api/v1/operator/digest" "200"

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -201,6 +201,10 @@ check_http "attribution recent 200" "$BASE/api/v1/attribution/recent?limit=1" "2
 check_json "attribution recent exposes events" "$BASE/api/v1/attribution/recent?limit=1" "'events' in d and 'count' in d" '^True$'
 check_http "safe autonomy 200" "$BASE/api/v1/dashboard/safe-autonomy" "200"
 check_json "safe autonomy exposes scorecard" "$BASE/api/v1/dashboard/safe-autonomy" "'summary' in d and 'domains' in d and 'per_keeper' in d" '^True$'
+check_http "dashboard governance 200" "$BASE/api/v1/dashboard/governance" "200"
+check_json "dashboard governance exposes judge and queue" "$BASE/api/v1/dashboard/governance" "'summary' in d and 'judge' in d and 'approval_queue' in d" '^True$'
+check_http "dashboard proof 200" "$BASE/api/v1/dashboard/proof" "200"
+check_json "dashboard proof exposes verification and sources" "$BASE/api/v1/dashboard/proof" "'summary' in d and 'verification' in d and 'proof_sources' in d" '^True$'
 check_http "keeper feature proof 200" "$BASE/api/v1/dashboard/keeper-feature-proof?window_hours=24" "200"
 check_json "keeper feature proof exposes features" "$BASE/api/v1/dashboard/keeper-feature-proof?window_hours=24" "'summary' in d and 'features' in d and 'evidence_refs' in d" '^True$'
 check_http "feature health 200" "$BASE/api/v1/dashboard/feature-health" "200"

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -319,7 +319,7 @@ check_json "IDE annotations exposes data envelope" "$BASE/api/v1/ide/annotations
 check_http "IDE regions 200" "$BASE/api/v1/ide/regions" "200"
 check_json "IDE regions exposes data envelope" "$BASE/api/v1/ide/regions" "d.get('ok') == True and 'data' in d" '^True$'
 check_http "dashboard logs 200" "$BASE/api/v1/dashboard/logs?limit=3" "200"
-check_json "dashboard logs exposes entries" "$BASE/api/v1/dashboard/logs?limit=3" "'entries' in d" '^True$'
+check_json "dashboard logs exposes provenance" "$BASE/api/v1/dashboard/logs?limit=3" "d.get('dashboard_surface') == '/api/v1/dashboard/logs' and d.get('source') == 'masc_log_ring' and d.get('retention', {}).get('scope') == 'dashboard_logs' and 'generated_at_iso' in d and 'entries' in d" '^True$'
 
 echo "[7/7] SPA"
 check_http "dashboard index 200" "$BASE/dashboard" "200"

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -157,6 +157,17 @@ check_json_eventually \
   '^True$' \
   60 \
   2
+check_json \
+  "namespace-truth exposes provenance" \
+  "$BASE/api/v1/dashboard/namespace-truth" \
+  "d.get('dashboard_surface') == '/api/v1/dashboard/namespace-truth' and d.get('source') == 'namespace_truth_read_model' and '/api/v1/dashboard/room-truth' in d.get('dashboard_aliases', []) and d.get('retention', {}).get('scope') == 'dashboard_namespace_truth'" \
+  '^True$'
+check_http "room-truth 200" "$BASE/api/v1/dashboard/room-truth" "200"
+check_json \
+  "room-truth exposes namespace alias provenance" \
+  "$BASE/api/v1/dashboard/room-truth" \
+  "d.get('dashboard_surface') == '/api/v1/dashboard/namespace-truth' and d.get('source') == 'namespace_truth_read_model' and '/api/v1/dashboard/room-truth' in d.get('dashboard_aliases', []) and d.get('retention', {}).get('scope') == 'dashboard_namespace_truth'" \
+  '^True$'
 check_http "goal-loop status 200" "$BASE/api/v1/dashboard/goal-loop/status" "200"
 check_json "goal-loop status exposes phases" "$BASE/api/v1/dashboard/goal-loop/status" "'overall_status' in d and 'phases' in d" '^True$'
 check_http "activity graph 200" "$BASE/api/v1/activity/graph" "200"

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -364,6 +364,58 @@ let test_dashboard_planning_http_json_includes_coordination_fsm () =
      | `List _ -> true
      | _ -> false)
 
+let test_dashboard_proof_http_json_surfaces_verification_index () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  let module V = Lib.Verification in
+  let output =
+    `Assoc
+      [
+        ("evidence_refs", `List [ `String "artifact://proof-route" ]);
+        ("task_title", `String "Proof route fixture");
+      ]
+  in
+  (match
+     V.create_request
+       ~base_path:config.base_path
+       ~task_id:"task-proof-route"
+       ~output
+       ~criteria:[ V.Custom "proof route must expose verification evidence" ]
+       ~worker:"keeper-proof"
+       ()
+   with
+   | Ok _ -> ()
+   | Error message -> fail message);
+  let json =
+    Lib.Server_dashboard_http.dashboard_proof_http_json
+      ~config
+      (request "/api/v1/dashboard/proof?limit=5&recent=2")
+  in
+  let open Yojson.Safe.Util in
+  check int "verification total" 1
+    (json |> member "summary" |> member "verification_total" |> to_int);
+  check int "pending total" 1
+    (json |> member "summary" |> member "verification_pending" |> to_int);
+  check bool "verification requests exposed" true
+    (match json |> member "verification" |> member "requests" |> member "requests" with
+     | `List [ _ ] -> true
+     | _ -> false);
+  check bool "proof sources include execution trust route" true
+    (json
+     |> member "proof_sources"
+     |> to_list
+     |> List.exists (fun source ->
+       String.equal
+         (source |> member "route" |> to_string)
+         "/api/v1/dashboard/execution-trust"))
+
+let test_dashboard_proof_route_registered_in_http_routers () =
+  let http1 = read_file "lib/server/server_routes_http_routes_dashboard.ml" in
+  let h2 = read_file "lib/server/server_h2_gateway.ml" in
+  check bool "HTTP/1 dashboard proof route registered" true
+    (contains_substring http1 "\"/api/v1/dashboard/proof\"");
+  check bool "HTTP/2 dashboard proof route registered" true
+    (contains_substring h2 "\"/api/v1/dashboard/proof\"")
+
 let test_dashboard_planning_http_json_keeps_utf8_valid_after_truncation () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   ignore (Lib.Coord.init config ~agent_name:(Some "dashboard"));
@@ -568,6 +620,10 @@ let () =
             test_dashboard_shell_timeout_fallback_reports_timing_context;
           test_case "planning payload includes coordination FSM" `Quick
             test_dashboard_planning_http_json_includes_coordination_fsm;
+          test_case "proof payload exposes verification index" `Quick
+            test_dashboard_proof_http_json_surfaces_verification_index;
+          test_case "proof route registered in HTTP routers" `Quick
+            test_dashboard_proof_route_registered_in_http_routers;
           test_case "planning payload keeps UTF-8 valid after truncation" `Quick
             test_dashboard_planning_http_json_keeps_utf8_valid_after_truncation;
           test_case "credential monitoring surfaces archive counter" `Quick

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -36,6 +36,21 @@ let invalid_utf8_byte_count s =
   in
   loop 0 0
 
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop i =
+    i + needle_len <= haystack_len
+    && (String.equal (String.sub haystack i needle_len) needle || loop (i + 1))
+  in
+  needle_len = 0 || loop 0
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
 let with_env key value f =
   let old = Sys.getenv_opt key in
   Unix.putenv key value;
@@ -270,6 +285,18 @@ let test_dashboard_shell_http_json_prefers_last_good_while_prewarming () =
         (json |> member "status" |> member "project" |> to_string);
       check int "last-good counts reused" 7
         (json |> member "counts" |> member "agents" |> to_int))
+
+let test_operator_snapshot_default_route_hydrates_first_success () =
+  let source = read_file "lib/server/server_dashboard_http_core.ml" in
+  check bool "operator snapshot uses first-success cache helper" true
+    (contains_substring source "cached_surface_or_first_success_json"
+     && contains_substring source "_operator_snapshot_cache"
+     && contains_substring source
+          "dashboard_cache_key config \"operator_snapshot\" \"default-summary\"");
+  check bool "operator snapshot no longer serves raw initializing cache" true
+    (not
+       (contains_substring source
+          "then cached_surface_json _operator_snapshot_cache"))
 
 let test_dashboard_shell_timeout_fallback_reports_timing_context () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
@@ -535,6 +562,8 @@ let () =
             test_dashboard_shell_http_json_uses_bootstrap_payload_while_prewarming;
           test_case "shell reuses last good payload while prewarming" `Quick
             test_dashboard_shell_http_json_prefers_last_good_while_prewarming;
+          test_case "operator snapshot hydrates on first default request" `Quick
+            test_operator_snapshot_default_route_hydrates_first_success;
           test_case "shell timeout fallback reports timing context" `Quick
             test_dashboard_shell_timeout_fallback_reports_timing_context;
           test_case "planning payload includes coordination FSM" `Quick

--- a/test/test_dashboard_k2_feeds.ml
+++ b/test/test_dashboard_k2_feeds.ml
@@ -209,6 +209,12 @@ let test_decisions_json_terminal_reason_duration_fallback () =
   let compact =
     Dash.keeper_decisions_json ~config ~keepers:[ meta ] ~limit:10 ()
   in
+  check string "compact dashboard surface" "/api/v1/dashboard/keeper-decisions"
+    Json.(compact |> member "dashboard_surface" |> to_string);
+  check string "compact source" "keeper_decision_log"
+    Json.(compact |> member "source" |> to_string);
+  check string "compact durable store" ".masc/keepers/:name.decisions.jsonl"
+    Json.(compact |> member "retention" |> member "durable_store" |> to_string);
   let compact_event =
     match Json.(compact |> member "events" |> to_list) with
     | event :: _ -> event

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -167,6 +167,25 @@ let test_dashboard_namespace_truth_empty_room () =
         check int "namespace counts expose total runtimes"
           0
           (json |> member "root" |> member "counts" |> member "total_runtimes" |> to_int);
+        check string "canonical dashboard surface"
+          "/api/v1/dashboard/namespace-truth"
+          (json |> member "dashboard_surface" |> to_string);
+        check string "read model source"
+          "namespace_truth_read_model"
+          (json |> member "source" |> to_string);
+        check string "retention scope"
+          "dashboard_namespace_truth"
+          (json |> member "retention" |> member "scope" |> to_string);
+        check bool "generated_at_iso present"
+          true
+          (match json |> member "generated_at_iso" with
+          | `String value -> String.length value > 0
+          | _ -> false);
+        check bool "room-truth alias advertised"
+          true
+          (json |> member "dashboard_aliases" |> to_list
+          |> List.map to_string
+          |> List.mem "/api/v1/dashboard/room-truth");
         check bool "readiness status exposed"
           true
           (String.length (json |> member "readiness" |> member "status" |> to_string) > 0);
@@ -565,6 +584,7 @@ let test_namespace_truth_snapshot_hash_ignores_generated_at () =
         `Assoc
           [
             ("generated_at", `String generated_at);
+            ("generated_at_iso", `String generated_at);
             ( "namespace",
               `Assoc [ ("status", `String "ready"); ("counts", `Assoc [("agents", `Int 1)]) ]
             );

--- a/test/test_dashboard_o5_feeds.ml
+++ b/test/test_dashboard_o5_feeds.ml
@@ -21,6 +21,18 @@ let test_heuristics_feed_exposes_o5_shape () =
   in
   let feed = Heuristic_metrics.dashboard_feed_json ~limit:50 [ event ] in
   let item = first_list_item "heuristics" feed in
+  Alcotest.(check string)
+    "heuristics dashboard surface"
+    "/api/v1/dashboard/heuristics"
+    (feed |> U.member "dashboard_surface" |> U.to_string);
+  Alcotest.(check string)
+    "heuristics source"
+    "heuristic_metrics"
+    (feed |> U.member "source" |> U.to_string);
+  Alcotest.(check string)
+    "heuristics durable store"
+    ".masc/heuristic_metrics.jsonl"
+    (feed |> U.member "retention" |> U.member "durable_store" |> U.to_string);
   Alcotest.(check int) "raw event count" 1 (feed |> U.member "count" |> U.to_int);
   Alcotest.(check string)
     "rule id"
@@ -28,6 +40,36 @@ let test_heuristics_feed_exposes_o5_shape () =
     (item |> U.member "rule_id" |> U.to_string);
   Alcotest.(check string) "action" "triggered" (item |> U.member "action" |> U.to_string);
   Alcotest.(check int) "cooldown" 0 (item |> U.member "cooldown_remaining_ms" |> U.to_int)
+;;
+
+let test_heuristics_coverage_exposes_source_metadata () =
+  let report =
+    { Heuristic_metrics.total_events = 2
+    ; sites =
+        [ { Heuristic_metrics.module_name = "keeper"
+          ; site = "guard"
+          ; count = 2
+          ; triggered_count = 1
+          }
+        ]
+    ; decision_shape_count = 1
+    ; mixed_outcome_sites = 1
+    ; unique_decision_tuples = 1
+    }
+  in
+  let json = Heuristic_metrics.coverage_report_to_json report in
+  Alcotest.(check string)
+    "coverage dashboard surface"
+    "/api/v1/dashboard/heuristics/coverage"
+    (json |> U.member "dashboard_surface" |> U.to_string);
+  Alcotest.(check string)
+    "coverage source"
+    "heuristic_metrics"
+    (json |> U.member "source" |> U.to_string);
+  Alcotest.(check int)
+    "coverage total"
+    2
+    (json |> U.member "total_events" |> U.to_int)
 ;;
 
 let test_agent_stress_feed_exposes_board_rows () =
@@ -57,6 +99,15 @@ let test_agent_stress_feed_exposes_board_rows () =
   in
   let feed = Agent_stress.dashboard_feed_json ~limit:25 ~agents [ event ] in
   let row = first_list_item "agent_stress" feed in
+  Alcotest.(check string)
+    "stress dashboard surface"
+    "/api/v1/dashboard/stress"
+    (feed |> U.member "dashboard_surface" |> U.to_string);
+  Alcotest.(check string) "stress source" "agent_stress" (feed |> U.member "source" |> U.to_string);
+  Alcotest.(check string)
+    "stress durable store"
+    ".masc/agent_stress.jsonl"
+    (feed |> U.member "retention" |> U.member "durable_store" |> U.to_string);
   Alcotest.(check int) "raw event count" 1 (feed |> U.member "count" |> U.to_int);
   Alcotest.(check string) "agent" "sangsu" (row |> U.member "agent" |> U.to_string);
   Alcotest.(check (float 0.001))
@@ -82,6 +133,10 @@ let () =
             "heuristics response carries issue-shape array"
             `Quick
             test_heuristics_feed_exposes_o5_shape
+        ; Alcotest.test_case
+            "heuristics coverage carries source metadata"
+            `Quick
+            test_heuristics_coverage_exposes_source_metadata
         ; Alcotest.test_case
             "stress response carries agent board rows"
             `Quick

--- a/test/test_dashboard_oas_bridge.ml
+++ b/test/test_dashboard_oas_bridge.ml
@@ -240,6 +240,25 @@ let test_recent_json_provider_filter_is_runtime_alias () =
   DOB.record (make_sample ~provider:"anthropic" ());
   DOB.record (make_sample ~provider:"ollama" ~model:"qwen3" ());
   let json = DOB.recent_json ~provider:"ollama" ~limit:5 () in
+  Alcotest.(check bool)
+    "generated_at present"
+    true
+    (json |> Json.member "generated_at" |> Json.to_string |> String.length > 0);
+  Alcotest.(check string)
+    "dashboard surface"
+    "/api/v1/dashboard/oas/telemetry/recent"
+    (json |> Json.member "dashboard_surface" |> Json.to_string);
+  Alcotest.(check string)
+    "source"
+    "oas_runtime_bridge"
+    (json |> Json.member "source" |> Json.to_string);
+  Alcotest.(check string)
+    "durable replay surface"
+    "/api/v1/dashboard/telemetry?source=oas_event"
+    (json
+     |> Json.member "retention"
+     |> Json.member "durable_replay_surface"
+     |> Json.to_string);
   Alcotest.(check string)
     "provider redacted"
     "runtime"
@@ -262,6 +281,14 @@ let test_summary_json_contains_aggregate () =
   DOB.record (make_sample ~cache:true ~status:DOB.Success ());
   DOB.record (make_sample ~cache:false ~status:DOB.Timeout ());
   let json = DOB.summary_json ~provider:"anthropic" ~limit:10 () in
+  Alcotest.(check string)
+    "dashboard surface"
+    "/api/v1/dashboard/oas/telemetry/summary"
+    (json |> Json.member "dashboard_surface" |> Json.to_string);
+  Alcotest.(check int)
+    "retention cap"
+    200
+    (json |> Json.member "retention" |> Json.member "per_provider_cap" |> Json.to_int);
   let summary = json |> Json.member "summary" in
   Alcotest.(check int)
     "sample_count"

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -544,6 +544,42 @@ let test_status_json_includes_lifecycle_shape () =
       (lifecycle |> member "operator_next_action" |> to_string))
 ;;
 
+let test_status_json_exposes_dashboard_provenance () =
+  with_temp_dir "sidecar-status-provenance" (fun base_path ->
+    let json = Routes.read_status_json ~base_path "discord" in
+    let open Yojson.Safe.Util in
+    check
+      string
+      "dashboard_surface"
+      "/api/v1/sidecar/status"
+      (json |> member "dashboard_surface" |> to_string);
+    check string "source" "sidecar_status_file" (json |> member "source" |> to_string);
+    check
+      string
+      "retention scope"
+      "runtime_sidecar_status"
+      (json |> member "retention" |> member "scope" |> to_string);
+    check
+      bool
+      "generated_at_iso present"
+      true
+      (match json |> member "generated_at_iso" with
+       | `String value -> String.length value > 0
+       | _ -> false);
+    check
+      string
+      "default status path"
+      (Filename.concat base_path ".gate/runtime/discord/status.json")
+      (json |> member "retention" |> member "default_status_path" |> to_string);
+    check
+      bool
+      "lifecycle still present"
+      true
+      (match json |> member "sidecar_lifecycle" with
+       | `Assoc _ -> true
+       | _ -> false))
+;;
+
 (* ---- Config write helpers (PUT /api/v1/sidecar/config). ---- *)
 
 let test_escape_quotes_and_backslash () =
@@ -946,6 +982,10 @@ let () =
             "status JSON includes lifecycle shape"
             `Quick
             test_status_json_includes_lifecycle_shape
+        ; test_case
+            "status JSON exposes dashboard provenance"
+            `Quick
+            test_status_json_exposes_dashboard_provenance
         ] )
     ; ( "config_write_helpers"
       , [ test_case "escape: quotes + backslash" `Quick test_escape_quotes_and_backslash


### PR DESCRIPTION
## Summary
- hydrate the default /api/v1/operator snapshot on first request instead of serving the initializing cache shell
- restore the documented /api/v1/dashboard/proof read model as a compatibility proof index over verification requests, TLA result refs, keeper feature proof, safe autonomy, execution trust, and surface readiness routes
- pass the active server base_path into verification dashboard reads so HTTP surfaces do not drift to process-global fallback state
- expose OAS runtime-lane telemetry provenance on recent/summary payloads, including source, dashboard_surface, retention scope, and durable replay surface
- expose runtime feed provenance for keeper decisions, heuristics, heuristic coverage, and stress dashboard feeds so visible Cost/Runtime subviews identify their backing JSONL stores
- expose Agent Observatory timeline/relation feed provenance so per-agent timeline and graph cards identify source, dashboard_surface, retention, and generated_at_iso even when the graph payload is empty
- expose connector sidecar status provenance so /api/v1/sidecar/status identifies dashboard_surface, source, retention paths, generated_at_iso, and lifecycle state for the Connectors surface
- expose canonical namespace-truth provenance on /api/v1/dashboard/namespace-truth and its /api/v1/dashboard/project-snapshot and /api/v1/dashboard/room-truth aliases so duplicate-looking room/Turn surfaces identify the shared read model and retention contract
- expose system Logs tab provenance so /api/v1/dashboard/logs identifies masc_log_ring, retention scope, durable JSONL sink, query metadata, and latest cursor instead of an entries-only payload
- expand dashboard verification coverage for governance, proof, OAS event replay, OAS runtime telemetry, runtime decision/heuristic/stress endpoints, Agent Observatory timeline/relation endpoints, sidecar status, and namespace-truth alias provenance

## Evidence
- ocamlformat --check lib/dashboard/dashboard_verification.ml lib/dashboard/dashboard_verification.mli lib/server/server_dashboard_http.ml lib/server/server_dashboard_http.mli lib/server/server_h2_gateway.ml lib/server/server_routes_http_routes_dashboard.ml lib/server/server_routes_http_routes_verification.ml lib/server/server_dashboard_http_core.ml test/test_dashboard_http_core.ml
- git diff --check
- env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-build-proof-route DUNE_JOBS=1 scripts/dune-local.sh build --display=short test/test_dashboard_http_core.exe test/test_dashboard_verification.exe bin/main_eio.exe
- /private/tmp/masc-mcp-build-proof-route/default/test/test_dashboard_http_core.exe test --color=never => 19 tests passed
- /private/tmp/masc-mcp-build-proof-route/default/test/test_dashboard_verification.exe test --color=never => 9 tests passed
- live /api/v1/dashboard/proof => verification_keys=[requests, summary], proof_source_count=7
- ocamlformat --check lib/dashboard/dashboard_oas_bridge.ml lib/dashboard/dashboard_oas_bridge.mli test/test_dashboard_oas_bridge.ml
- env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-build-oas-telemetry DUNE_JOBS=1 scripts/dune-local.sh build --display=short test/test_dashboard_oas_bridge.exe bin/main_eio.exe
- /private/tmp/masc-mcp-build-oas-telemetry/default/test/test_dashboard_oas_bridge.exe => 24 tests passed
- live /api/v1/dashboard/oas/telemetry/recent?limit=1 => source=oas_runtime_bridge, durable_replay_surface=/api/v1/dashboard/telemetry?source=oas_event
- ocamlformat --check lib/heuristic_metrics.ml lib/heuristic_metrics.mli lib/agent_stress.ml lib/agent_stress.mli lib/dashboard/dashboard_http_keeper.ml test/test_dashboard_o5_feeds.ml test/test_dashboard_k2_feeds.ml
- env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-build-feed-provenance DUNE_JOBS=1 scripts/dune-local.sh build --display=short test/test_dashboard_o5_feeds.exe test/test_dashboard_k2_feeds.exe bin/main_eio.exe
- /private/tmp/masc-mcp-build-feed-provenance/default/test/test_dashboard_o5_feeds.exe => 3 tests passed
- /private/tmp/masc-mcp-build-feed-provenance/default/test/test_dashboard_k2_feeds.exe => 7 tests passed
- pnpm exec tsc --noEmit --pretty
- pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/components/cost-dashboard.render.test.ts => 7 tests passed
- live runtime feed provenance check => keeper-decisions, heuristics, heuristics/coverage, stress all expose dashboard_surface/source/retention
- bash scripts/verify-dashboard.sh http://127.0.0.1:8935 => ALL 167 TESTS PASSED
- env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-build-feed-provenance-commit DUNE_JOBS=1 scripts/dune-local.sh build --display=short bin/main_eio.exe
- post-commit live /health => commit=3b37d1bda3, executable_path=/private/tmp/masc-mcp-build-feed-provenance-commit/default/bin/main_eio.exe, effective_base_path=/Users/dancer/me
- ocamlformat --check lib/tool_agent_timeline.ml lib/tool_agent_timeline.mli lib/dashboard/dashboard_agent_relations.ml lib/dashboard/dashboard_agent_relations.mli
- pnpm exec tsc --noEmit --pretty
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/schemas/agent-timeline.test.ts src/api/schemas/agent-relations.test.ts => 17 tests passed
- env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-build-agent-provenance DUNE_JOBS=1 scripts/dune-local.sh build --display=short bin/main_eio.exe
- live /api/v1/agent-timeline?agent_name=sangsu&limit=1 => source=agent_timeline_read_model, dashboard_surface=/api/v1/agent-timeline, retention.scope=multi_source_tail
- live /api/v1/agent-relations?agent_name=sangsu => source=second_brain_graphql, dashboard_surface=/api/v1/agent-relations, retention.scope=external_graphql_query
- bash scripts/verify-dashboard.sh http://127.0.0.1:8935 => ALL 171 TESTS PASSED
- post-commit live /health => commit=7ff42cbf26, executable_path=/private/tmp/masc-mcp-build-agent-provenance/default/bin/main_eio.exe, effective_base_path=/Users/dancer/me
- ocamlformat --check lib/server/server_routes_http_routes_sidecar.ml test/test_sidecar_lifecycle_routes.ml
- git diff --check
- env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-build-sidecar-status-provenance DUNE_JOBS=1 scripts/dune-local.sh build --display=short test/test_sidecar_lifecycle_routes.exe bin/main_eio.exe
- /private/tmp/masc-mcp-build-sidecar-status-provenance/default/test/test_sidecar_lifecycle_routes.exe => 48 tests passed
- live /api/v1/sidecar/status?name=discord => source=sidecar_status_file, dashboard_surface=/api/v1/sidecar/status, retention.scope=runtime_sidecar_status, sidecar_lifecycle=true
- bash scripts/verify-dashboard.sh http://127.0.0.1:8935 => ALL 173 TESTS PASSED
- post-commit live /health => commit=9909653270, executable_path=/private/tmp/masc-mcp-build-sidecar-status-provenance/default/bin/main_eio.exe, effective_base_path=/Users/dancer/me
- ocamlformat --check lib/server/server_dashboard_http_namespace_truth_support.ml lib/server/server_dashboard_http_namespace_truth.ml lib/server/server_dashboard_http_namespace_truth_support.mli lib/server/server_dashboard_http_namespace_truth.mli test/test_dashboard_namespace_truth.ml
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/namespace-truth-normalizers.test.ts --no-file-parallelism --maxWorkers=1 => 30 tests passed
- pnpm --dir dashboard typecheck
- env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-build-namespace-truth-provenance DUNE_JOBS=1 scripts/dune-local.sh build --display=short test/test_dashboard_namespace_truth.exe bin/main_eio.exe
- /private/tmp/masc-mcp-build-namespace-truth-provenance/default/test/test_dashboard_namespace_truth.exe => 12 tests passed
- live /api/v1/dashboard/room-truth => dashboard_surface=/api/v1/dashboard/namespace-truth, aliases include /api/v1/dashboard/project-snapshot and /api/v1/dashboard/room-truth, source=namespace_truth_read_model, retention.scope=dashboard_namespace_truth, build.commit=0a6064118b
- scripts/verify-dashboard.sh http://127.0.0.1:8935 => ALL 176 TESTS PASSED
- post-commit live /health => commit=0a6064118b, executable_path=/private/tmp/masc-mcp-build-namespace-truth-provenance/default/bin/main_eio.exe, effective_base_path=/Users/dancer/me
- ocamlformat --check lib/server/server_routes_http_routes_dashboard.ml lib/masc_log/log.mli
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/api/schemas/logs.test.ts src/components/logs.test.ts --no-file-parallelism --maxWorkers=1 => 14 tests passed
- pnpm --dir dashboard typecheck
- git diff --check
- env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-build-dashboard-logs-provenance DUNE_JOBS=1 scripts/dune-local.sh build --display=short bin/main_eio.exe
- live /api/v1/dashboard/logs?limit=2 => dashboard_surface=/api/v1/dashboard/logs, source=masc_log_ring, retention.scope=dashboard_logs, durable_store=system_log_2026-05-15.jsonl
- scripts/verify-dashboard.sh http://127.0.0.1:8935 => ALL 176 TESTS PASSED
- post-commit live /health => commit=2055110343, executable_path=/private/tmp/masc-mcp-build-dashboard-logs-provenance/default/bin/main_eio.exe, effective_base_path=/Users/dancer/me
