### PR TITLE
fix(keeper): keep shell repos paths sandbox-relative

### DIFF
--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -189,6 +189,15 @@ let keeper_sandbox_repo_names ~(config : Coord.config) ~(meta : keeper_meta) =
       safe_is_dir candidate && safe_file_exists (Filename.concat candidate ".git"))
 ;;
 
+let keeper_playground_relative_root ~(meta : keeper_meta) =
+  Keeper_sandbox.allowed_root_rel_of_meta ~meta
+  |> Keeper_alerting_path.strip_trailing_slashes
+;;
+
+let keeper_playground_relative_path ~(meta : keeper_meta) rel =
+  Filename.concat (keeper_playground_relative_root ~meta) rel
+;;
+
 let relative_path_targets_allowed_root ~(meta : keeper_meta) (raw : string) =
   let boundary prefix =
     let prefix = Keeper_alerting_path.strip_trailing_slashes prefix in
@@ -273,16 +282,12 @@ let rewrite_single_repo_relative_path
     match keeper_sandbox_repo_names ~config ~meta with
     | repo_names when List.mem first_segment repo_names ->
       let sandbox_relative = Filename.concat "repos" raw in
-      let rewritten =
-        Filename.concat (keeper_playground_root ~config ~meta) sandbox_relative
-      in
+      let rewritten = keeper_playground_relative_path ~meta sandbox_relative in
       Log.Keeper.debug "playground_relative: explicit repo rewrite %S → %S" raw rewritten;
       Ok (Some rewritten)
     | [ repo_name ] ->
       let sandbox_relative = Filename.concat ("repos/" ^ repo_name) raw in
-      let rewritten =
-        Filename.concat (keeper_playground_root ~config ~meta) sandbox_relative
-      in
+      let rewritten = keeper_playground_relative_path ~meta sandbox_relative in
       Log.Keeper.debug "playground_relative: single-repo rewrite %S → %S" raw rewritten;
       Ok (Some rewritten)
     | [] -> Ok None
@@ -324,6 +329,20 @@ let host_path_of_own_container_path
     else None)
 ;;
 
+let project_relative_host_path ~(config : Coord.config) (path : string) =
+  let root =
+    Keeper_alerting_path.project_root_of_config config
+    |> Keeper_alerting_path.normalize_path_for_check_stripped
+  in
+  let path_norm = Keeper_alerting_path.normalize_path_for_check_stripped path in
+  if String.equal path_norm root then Some "."
+  else if String.starts_with ~prefix:(root ^ "/") path_norm then
+    Some
+      (String.sub path_norm (String.length root + 1)
+         (String.length path_norm - String.length root - 1))
+  else None
+;;
+
 (* Bare filenames and canonical sandbox lanes default to the keeper sandbox,
    but rooted-looking relative paths (for example
    "workspace/..." or "lib/...") keep project-root/boundary semantics.
@@ -341,15 +360,20 @@ let playground_relative_unless_allowed_root
   : (string, string) result
   =
   let trimmed = String.trim raw in
-  let trimmed =
+  let mapped_from_container, trimmed =
     match host_path_of_own_container_path ~config ~meta trimmed with
     | Some host_path ->
       Log.Keeper.debug
         "playground_relative: mapped container path %S → %S"
         trimmed
         host_path;
-      host_path
-    | None -> trimmed
+      true, host_path
+    | None -> false, trimmed
+  in
+  let trimmed =
+    if mapped_from_container
+    then Option.value ~default:trimmed (project_relative_host_path ~config trimmed)
+    else trimmed
   in
   let trimmed =
     match strip_keeper_playground_prefix ~meta trimmed with
@@ -395,8 +419,7 @@ let playground_relative_unless_allowed_root
       || relative_path_targets_allowed_root ~meta trimmed
     then Ok trimmed
     else (
-      let pg = keeper_playground_root ~config ~meta in
-      Ok (Filename.concat pg trimmed))
+      Ok (keeper_playground_relative_path ~meta trimmed))
 ;;
 
 let resolve_keeper_path

--- a/lib/keeper/keeper_exec_shared.mli
+++ b/lib/keeper/keeper_exec_shared.mli
@@ -74,6 +74,8 @@ val keeper_default_read_root
   -> meta:Keeper_types.keeper_meta
   -> string
 
+val project_relative_host_path : config:Coord.config -> string -> string option
+
 val safe_file_exists : string -> bool
 val safe_is_dir : string -> bool
 

--- a/lib/keeper/keeper_shell_shared.ml
+++ b/lib/keeper/keeper_shell_shared.ml
@@ -554,7 +554,14 @@ let resolve_keeper_shell_read_path
         else
           Filename.concat cwd raw_path
     in
-    resolve_with_autocorrect resolved_raw_path
+    let resolver_path =
+      if raw_path = "" || Filename.is_relative raw_path then
+        Option.value ~default:resolved_raw_path
+          (project_relative_host_path ~config resolved_raw_path)
+      else
+        resolved_raw_path
+    in
+    resolve_with_autocorrect resolver_path
 
 (* Docker/sandbox infrastructure delegated to Keeper_shell_docker.
    Aliases retained for backward compatibility with callers that

--- a/test/test_keeper_shell_containment.ml
+++ b/test/test_keeper_shell_containment.ml
@@ -222,15 +222,16 @@ let blocked_by_symmetric_sandbox raw =
      [Keeper_sandbox_containment.check_read_target] AFTER the resolver
      allowed the host path through.
    - PR-3b (2026-04-28+): the resolver itself rejects out-of-sandbox
-     reads with [path_outside_sandbox], so the symmetric check is not
-     reached for the canonical "outside playground" case.  Both labels
-     observably mean "Docker keeper read blocked by playground
-     boundary".  Use this looser predicate for Docker-keeper tests so
-     the semantic stays "is it blocked" instead of pinning to the
-     1st-stage label.  Legacy [blocked_by_symmetric_sandbox] stays
-     strict so [test_legacy_keeper_unaffected] continues to assert
-     "this code path didn't fire" rather than the broader "blocked or
-     not". *)
+     reads with [path_outside_sandbox].
+   - PR-3b follow-ups reject caller absolute paths even earlier with
+     [path_outside_project_root].
+
+   All three labels observably mean "Docker keeper read blocked by
+   playground boundary".  Use this looser predicate for Docker-keeper
+   tests so the semantic stays "is it blocked" instead of pinning to the
+   1st-stage label.  Legacy [blocked_by_symmetric_sandbox] stays strict so
+   [test_legacy_keeper_unaffected] continues to assert "this code path
+   didn't fire" rather than the broader "blocked or not". *)
 let blocked_by_sandbox_boundary raw =
   match parse_field raw "error" with
   | None -> false
@@ -241,6 +242,7 @@ let blocked_by_sandbox_boundary raw =
       in
       starts_with "symmetric_sandbox_blocked" err
       || starts_with "path_outside_sandbox" err
+      || starts_with "path_outside_project_root" err
 
 let test_legacy_keeper_unaffected () =
   setup ~keeper_name:"alice" ~sandbox:Keeper_types.Local
@@ -353,13 +355,43 @@ let test_docker_keeper_allows_inside_playground () =
   ignore (Fs_compat.save_file_atomic demo "hello inside playground");
   let raw =
     Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
-      ~args:(`Assoc [ ("op", `String "cat"); ("path", `String demo) ])
+      ~args:(`Assoc [ ("op", `String "cat"); ("path", `String "demo.txt") ])
   in
   (* Goal: containment did not block. Whether `cat` succeeds depends on
      /bin/cat availability; we only assert the symmetric_sandbox guard
      is silent. *)
   Alcotest.(check bool) "playground-internal cat not blocked" false
     (blocked_by_sandbox_boundary raw)
+
+let test_docker_relative_repos_path_resolves_inside_playground () =
+  setup ~keeper_name:"glm-coding" ~sandbox:Keeper_types.Docker
+  @@ fun ~base:_ ~config ~meta ~playground ->
+  let repos = Filename.concat playground "repos" in
+  ensure_dir repos;
+  let args = `Assoc [ ("op", `String "ls"); ("path", `String "repos") ] in
+  match Keeper_shell_shared.resolve_keeper_shell_read_path ~config ~meta ~args with
+  | Ok path ->
+    Alcotest.(check string)
+      "bare repos maps to playground repos"
+      (normalize_realpath repos)
+      (normalize_realpath path)
+  | Error e ->
+    Alcotest.fail ("bare repos should stay inside playground: " ^ e)
+
+let test_docker_relative_repos_cwd_resolves_inside_playground () =
+  setup ~keeper_name:"glm-coding" ~sandbox:Keeper_types.Docker
+  @@ fun ~base:_ ~config ~meta ~playground ->
+  let repo = Filename.concat playground "repos/masc-mcp" in
+  ensure_dir repo;
+  let args = `Assoc [ ("cwd", `String "repos/masc-mcp") ] in
+  match Keeper_shell_shared.resolve_keeper_shell_read_cwd ~config ~meta ~args with
+  | Ok cwd ->
+    Alcotest.(check string)
+      "relative repos cwd maps to playground repo"
+      (normalize_realpath repo)
+      (normalize_realpath cwd)
+  | Error e ->
+    Alcotest.fail ("relative repos cwd should stay inside playground: " ^ e)
 
 let test_docker_container_cwd_maps_to_host_worktree () =
   setup ~keeper_name:"executor" ~sandbox:Keeper_types.Docker
@@ -545,6 +577,10 @@ let () =
             test_docker_keeper_blocks_find_outside;
           Alcotest.test_case "docker keeper allows inside playground"
             `Quick test_docker_keeper_allows_inside_playground;
+          Alcotest.test_case "docker relative repos path resolves inside playground"
+            `Quick test_docker_relative_repos_path_resolves_inside_playground;
+          Alcotest.test_case "docker relative repos cwd resolves inside playground"
+            `Quick test_docker_relative_repos_cwd_resolves_inside_playground;
           Alcotest.test_case "docker container cwd maps to host worktree"
             `Quick test_docker_container_cwd_maps_to_host_worktree;
           Alcotest.test_case "docker container file path maps to host worktree"


### PR DESCRIPTION
## Summary
- Keep keeper_shell-generated playground paths sandbox-relative before passing them into the lower path guard.
- Convert only internal host paths derived from Docker container paths or cwd+relative path joins back to project-relative form.
- Add regression coverage for Docker keepers using path="repos" and cwd="repos/<repo>".

## Why
Current runtime logs show relative keeper_shell calls like path=repos being reported as absolute path_outside_project_root because the shell resolver joined them with the host playground root before the security layer saw them. That makes a valid sandbox-relative path look like a forbidden host absolute path and sends keepers into the wrong recovery loop.

## Validation
- ocamlformat --check lib/keeper/keeper_exec_shared.ml lib/keeper/keeper_exec_shared.mli lib/keeper/keeper_shell_shared.ml test/test_keeper_shell_containment.ml
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_shell_containment.exe
- ./_build/default/test/test_keeper_shell_containment.exe