### PR TITLE
test(keeper): guard summarizer dispatch wiring

### DIFF
--- a/test/test_keeper_summarizer.ml
+++ b/test/test_keeper_summarizer.ml
@@ -7,6 +7,26 @@
 
 module KS = Masc_mcp.Keeper_summarizer
 
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+let repo_root () =
+  let marker path = Filename.concat path "lib/keeper/keeper_agent_run.ml" in
+  let has_marker path = Sys.file_exists (marker path) in
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when has_marker root -> root
+  | _ ->
+      let rec ascend path =
+        if has_marker path then path
+        else
+          let parent = Filename.dirname path in
+          if String.equal parent path then path else ascend parent
+      in
+      ascend (Sys.getcwd ())
+
 let msg ~role ~text : Agent_sdk.Types.message =
   { role; content = [ Agent_sdk.Types.Text text ]; name = None; tool_call_id = None; metadata = [] }
 
@@ -67,6 +87,27 @@ let test_empty_messages () =
   Alcotest.(check string) "empty → No prior context marker"
     "[No prior context]" summary
 
+let test_keeper_dispatch_passes_keeper_summarizer () =
+  let root = repo_root () in
+  let rel_path = "lib/keeper/keeper_agent_run.ml" in
+  let source = read_file (Filename.concat root rel_path) in
+  let marker = "Keeper_turn_driver.run_named" in
+  let required = "~summarizer:Keeper_summarizer.keeper_summarizer" in
+  let rec search pos =
+    match Astring.String.find_sub ~start:pos ~sub:marker source with
+    | None -> false
+    | Some idx ->
+        let len = min 3000 (String.length source - idx) in
+        let dispatch_block = String.sub source idx len in
+        Astring.String.is_infix ~affix:required dispatch_block
+        || search (idx + String.length marker)
+  in
+  Alcotest.(check bool)
+    (Printf.sprintf
+       "%s: keeper dispatch must pass Keeper_summarizer into OAS compaction"
+       rel_path)
+    true (search 0)
+
 let () =
   Alcotest.run "keeper_summarizer"
     [ ( "scrub + summarize",
@@ -78,5 +119,7 @@ let () =
             test_non_text_blocks_untouched;
           Alcotest.test_case "empty messages" `Quick
             test_empty_messages;
+          Alcotest.test_case "keeper dispatch passes summarizer" `Quick
+            test_keeper_dispatch_passes_keeper_summarizer;
         ] );
     ]


### PR DESCRIPTION
## Summary
- add a regression guard that every Keeper_turn_driver.run_named dispatch in keeper_agent_run.ml passes Keeper_summarizer.keeper_summarizer
- protects MASC [STATE] scrubbing before OAS budget compaction for long-running keeper history

## Validation
- ocamlformat --check test/test_keeper_summarizer.ml
- scripts/dune-local.sh build test/test_keeper_summarizer.exe
- scripts/dune-local.sh exec test/test_keeper_summarizer.exe
- git diff --check