### PR TITLE
feat(ide): show presence context coverage

### DIFF
--- a/dashboard/src/components/ide/ide-presence-strip.test.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   parseWorktreeSSE,
   presenceContextAnchor,
+  presenceContextSummary,
   prLabel,
   workspaceLabelForAgent,
   type WorktreeEntry,
@@ -179,5 +180,30 @@ describe('presenceContextAnchor', () => {
       worktree: sampleWorktrees[0]!,
       cursor: undefined,
     })).toBeNull()
+  })
+
+  it('summarizes visible context coverage for keeper presence chips', () => {
+    const anchor = presenceContextAnchor({
+      entry,
+      worktree: sampleWorktrees[0]!,
+      cursor: {
+        keeper_id: 'nick0cave',
+        file_path: 'lib/runtime.ml',
+        line: 42,
+        column: 7,
+        focus_mode: 'editing',
+        last_update: 123,
+        tool_name: 'ocamllsp',
+      },
+    })
+
+    expect(presenceContextSummary(anchor)).toEqual({
+      label: 'CTX 5',
+      title: 'Linked context: Code, PR, Git, Telemetry, Keeper',
+    })
+  })
+
+  it('omits context coverage when no route links are available', () => {
+    expect(presenceContextSummary(null)).toBeNull()
   })
 })

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -38,6 +38,21 @@ export interface WorktreeEntry {
   readonly keeper_attached: boolean
 }
 
+interface PresenceContextSummary {
+  readonly label: string
+  readonly title: string
+}
+
+const CONTEXT_BADGE_STYLE = {
+  fontSize: 'var(--fs-9)',
+  padding: '0 3px',
+  border: '1px solid var(--color-border-default)',
+  borderRadius: 'var(--r-0)',
+  color: 'var(--color-fg-muted)',
+  background: 'var(--color-bg-elevated)',
+  fontFamily: 'var(--font-mono)',
+}
+
 function mapAgentStatus(status: string): KeeperPresenceEntry['status'] {
   if (status === 'active' || status === 'busy') return 'active'
   if (status === 'listening') return 'idle'
@@ -295,11 +310,23 @@ export function presenceContextAnchor({
   }
 }
 
+export function presenceContextSummary(
+  anchor: Omit<IdeContextFocus, 'activated_at_ms'> | null,
+): PresenceContextSummary | null {
+  const labels = anchor?.route_links?.map(link => link.label) ?? []
+  if (labels.length === 0) return null
+  return {
+    label: `CTX ${labels.length}`,
+    title: `Linked context: ${labels.join(', ')}`,
+  }
+}
+
 function PresenceChip({ entry, worktrees }: PresenceChipProps) {
   const isActive = entry.status === 'active'
   const cursor = cursorOverlaySignal.value.cursors.get(entry.keeper_id)
   const wt = worktrees.find(w => w.branch.startsWith(entry.keeper_id + '/'))
   const contextAnchor = presenceContextAnchor({ entry, worktree: wt ?? null, cursor })
+  const contextSummary = presenceContextSummary(contextAnchor)
 
   const focusLabel = cursor?.file_path
     ? `${cursor.file_path.split('/').pop()}:${cursor.line}`
@@ -351,6 +378,9 @@ function PresenceChip({ entry, worktrees }: PresenceChipProps) {
           overflow: 'hidden',
           textOverflow: 'ellipsis',
         }}>${focusLabel}</span>
+      ` : null}
+      ${contextSummary ? html`
+        <span style=${CONTEXT_BADGE_STYLE} title=${contextSummary.title}>${contextSummary.label}</span>
       ` : null}
       ${prBadge ? html`
         <span style=${{


### PR DESCRIPTION
## Summary

- Adds a compact `CTX N` badge to IDE keeper presence chips when the chip has routeable context.
- Derives the badge from the existing context route links, so the count reflects Code, PR, Git, Telemetry, Keeper, or other linked surfaces already available on click.
- Covers the badge label/title helper in the focused presence-strip test.

## Validation

- `pnpm install --offline`
- `pnpm exec vitest run src/components/ide/ide-presence-strip.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/ide/ide-presence-strip.ts src/components/ide/ide-presence-strip.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`
