### PR TITLE
feat(ide): summarize conversation context

### DIFF
--- a/dashboard/src/components/ide/ide-conversation-rail.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
 import { fireEvent, waitFor } from '@testing-library/preact'
-import { IdeConversationRail, postsToAnchoredThreads, replayRailItems } from './ide-conversation-rail'
+import {
+  conversationContextSummary,
+  IdeConversationRail,
+  postsToAnchoredThreads,
+  replayRailItems,
+} from './ide-conversation-rail'
 import { activeIdeFile, ideContextFocus } from './ide-state'
 import { clearTraces, keeperTraceState } from './keeper-trace-store'
 import { ideReplayUntilMs, setIdeReplayUntilMs } from './ide-replay-state'
@@ -343,6 +348,9 @@ describe('IdeConversationRail', () => {
 
     const decisionCard = container.querySelector<HTMLElement>('[data-replay-source="decision"]')
     expect(decisionCard).not.toBeNull()
+    expect(decisionCard?.querySelector('.ide-conversation-context-badge')?.textContent).toBe('CTX 3')
+    expect(decisionCard?.querySelector('.ide-conversation-context-badge')?.getAttribute('title'))
+      .toBe('Linked context: Code, Telemetry, Keeper')
     const decisionLinks = [...decisionCard!.querySelectorAll<HTMLButtonElement>('.ide-conversation-route-link')]
     expect(decisionLinks.map(link => link.textContent)).toEqual(['Code', 'Telemetry', 'Keeper'])
 
@@ -361,6 +369,9 @@ describe('IdeConversationRail', () => {
 
     const cascadeCard = container.querySelector<HTMLElement>('[data-replay-source="cascade"]')
     expect(cascadeCard).not.toBeNull()
+    expect(cascadeCard?.querySelector('.ide-conversation-context-badge')?.textContent).toBe('CTX 1')
+    expect(cascadeCard?.querySelector('.ide-conversation-context-badge')?.getAttribute('title'))
+      .toBe('Linked context: Telemetry')
     const cascadeLinks = [...cascadeCard!.querySelectorAll<HTMLButtonElement>('.ide-conversation-route-link')]
     expect(cascadeLinks.map(link => link.textContent)).toEqual(['Telemetry'])
 
@@ -454,6 +465,11 @@ describe('IdeConversationRail', () => {
       expect(container.textContent).toContain('comment:comment-1')
     })
 
+    const badge = container.querySelector('.ide-conversation-context-badge')
+    expect(badge?.textContent).toBe('CTX 10')
+    expect(badge?.getAttribute('title'))
+      .toBe('Linked context: Code, Goal, Task, Board, Comment, PR, Git, Log, Telemetry, Keeper')
+
     const links = [...container.querySelectorAll<HTMLButtonElement>('.ide-conversation-route-link')]
     expect(links.map(link => link.textContent)).toEqual([
       'Code',
@@ -482,6 +498,18 @@ describe('IdeConversationRail', () => {
     expect(window.location.hash).toBe('#monitoring?section=agents&view=keepers&keeper=scholar')
 
     render(null, container)
+  })
+
+  it('summarizes conversation route link coverage for card chrome', () => {
+    expect(conversationContextSummary([
+      { id: 'code:a', label: 'Code', tab: 'code', params: {}, evidence: 'Code a' },
+      { id: 'task:t-1', label: 'Task', tab: 'workspace', params: {}, evidence: 'Task t-1' },
+    ])).toEqual({
+      label: 'CTX 2',
+      title: 'Linked context: Code, Task',
+    })
+
+    expect(conversationContextSummary([])).toBeNull()
   })
 })
 

--- a/dashboard/src/components/ide/ide-conversation-rail.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.ts
@@ -62,10 +62,24 @@ const KIND_TOKEN: Record<ThreadKind, string> = {
   note: 'var(--color-fg-muted)',
   suggest: 'var(--color-status-warn)',
 }
+const CONVERSATION_CONTEXT_BADGE_STYLE = {
+  fontSize: 'var(--fs-9)',
+  padding: '0 3px',
+  border: '1px solid var(--color-border-default)',
+  borderRadius: 'var(--r-0)',
+  color: 'var(--color-fg-muted)',
+  background: 'var(--color-bg-surface)',
+  fontFamily: 'var(--font-mono)',
+}
 
 const EMPTY_POSTS: ReadonlyArray<BoardPost> = []
 const EMPTY_DECISIONS: ReadonlyArray<KeeperDecision> = []
 const EMPTY_CASCADE: ReadonlyArray<CascadeStrategyTraceEvent> = []
+
+interface ConversationContextSummary {
+  readonly label: string
+  readonly title: string
+}
 
 type ReplayRailItem =
   | { readonly source: 'thread'; readonly timestamp_ms: number; readonly post: BoardPost }
@@ -432,6 +446,7 @@ function PostCard(
   const thread = postToAnchoredThread(post)
   const anchor = thread?.anchor ?? null
   const routeLinks = conversationRouteLinks(post, anchor, kind, bodyText)
+  const contextSummary = conversationContextSummary(routeLinks)
 
   return html`
     <li class="ide-rail-item">
@@ -483,6 +498,7 @@ function PostCard(
               ${statusDot.label}
             </span>
           ` : null}
+          ${contextSummary ? ConversationContextBadge(contextSummary) : null}
           <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)', marginLeft: 'auto' }}>${formatThreadTime(createdMs)}</span>
         </div>
         ${post.hearth ? html`
@@ -565,6 +581,27 @@ function ConversationRouteLink(link: IdeContextRouteLink) {
   `
 }
 
+export function conversationContextSummary(
+  links: ReadonlyArray<IdeContextRouteLink>,
+): ConversationContextSummary | null {
+  if (links.length === 0) return null
+  return {
+    label: `CTX ${links.length}`,
+    title: `Linked context: ${links.map(link => link.label).join(', ')}`,
+  }
+}
+
+function ConversationContextBadge(summary: ConversationContextSummary) {
+  return html`
+    <span
+      class="ide-conversation-context-badge"
+      title=${summary.title}
+      aria-label=${summary.title}
+      style=${CONVERSATION_CONTEXT_BADGE_STYLE}
+    >${summary.label}</span>
+  `
+}
+
 function DecisionCard(
   item: Extract<ReplayRailItem, { source: 'decision' }>,
   entries: ReadonlyArray<KeeperPresenceEntry>,
@@ -590,6 +627,7 @@ function DecisionCard(
     hasFocus ? cursor.line : undefined,
     summary,
   )
+  const contextSummary = conversationContextSummary(routeLinks)
   return html`
     <li style=${{ display: 'block' }}>
       <div
@@ -631,6 +669,7 @@ function DecisionCard(
               ${statusDot.label}
             </span>
           ` : null}
+          ${contextSummary ? ConversationContextBadge(contextSummary) : null}
           <span style=${{ marginLeft: 'auto', fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${formatThreadTime(item.timestamp_ms)}</span>
         </div>
         <p style=${{ margin: 0, color: 'var(--color-fg-secondary)', fontSize: 'var(--fs-12)' }}>${summary || 'decision event'}</p>
@@ -691,6 +730,7 @@ function decisionTelemetryQuery(decision: KeeperDecision, timestampMs: number): 
 function CascadeCard(item: Extract<ReplayRailItem, { source: 'cascade' }>) {
   const event = item.cascade
   const routeLinks = cascadeRouteLinks(item)
+  const contextSummary = conversationContextSummary(routeLinks)
   return html`
     <li style=${{ display: 'block' }}>
       <div
@@ -708,6 +748,7 @@ function CascadeCard(item: Extract<ReplayRailItem, { source: 'cascade' }>) {
         <div style=${{ display: 'flex', alignItems: 'center', gap: 'var(--sp-2)' }}>
           <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-accent-fg)', letterSpacing: '0.05em' }}>CASCADE</span>
           <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-secondary)' }}>${event.cascade_name}</span>
+          ${contextSummary ? ConversationContextBadge(contextSummary) : null}
           <span style=${{ marginLeft: 'auto', fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${formatThreadTime(item.timestamp_ms)}</span>
         </div>
         <p style=${{ margin: 0, color: 'var(--color-fg-secondary)', fontSize: 'var(--fs-12)' }}>


### PR DESCRIPTION
## Summary

- Adds compact `CTX N` badges to IDE conversation rail cards for board threads, keeper decisions, and cascade replay entries.
- Derives each badge from the card's existing route links so it reflects linked Code, Goal, Task, Board, Comment, PR, Git, Log, Telemetry, and Keeper surfaces without adding new fetches.
- Extends the focused conversation rail tests to assert the visible context counts and badge titles.

## Validation

- `pnpm install --offline`
- `pnpm exec vitest run src/components/ide/ide-conversation-rail.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
  - Passed: 9 tests
  - Note: Vitest still prints sandboxed localhost:3000 `EPERM` noise during setup, but exits 0.
- `pnpm exec eslint src/components/ide/ide-conversation-rail.ts src/components/ide/ide-conversation-rail.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check origin/main...HEAD`
