### PR TITLE
fix(keeper): preflight git cwd path flags

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -680,7 +680,10 @@ let run_docker_shell_command_with_status
          else
            "sandbox_profile=docker blocks nested container runtimes and host socket \
             references")
-    else (
+    else
+      match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd with
+      | Error err -> sandbox_error err
+      | Ok () ->
       let _cleanup =
         Keeper_sandbox_runtime.maybe_cleanup_stale_containers
           ~base_path:config.base_path
@@ -888,7 +891,7 @@ let run_docker_shell_command_with_status
                             meta.name);
                         Ok { status; output; image; network_label }
                       with
-                      | Failure err -> sandbox_error err)))))))
+                      | Failure err -> sandbox_error err))))))
 ;;
 
 let run_docker_with_git_bash
@@ -926,44 +929,49 @@ let run_docker_with_git_bash
     match check_egress ~config ~meta ~cmd with
     | Some blocked_json -> blocked_json
     | None ->
-      let cwd, sandbox_root_git_blocker =
-        resolve_sandbox_root_git_cwd ~config ~meta ~cwd ~cmd
-      in
-      (match sandbox_root_git_blocker with
-       | Some message -> sandbox_error_json message
-       | None ->
-         let _ = turn_sandbox_runtime in
-         (match
-            run_docker_shell_command_with_status
-              ~config
-              ~meta
-              ~cwd
-              ~timeout_sec
-              ~cmd
-              ~git_creds_enabled:true
-              ~network_mode:Network_inherit
-          with
-          | Error message -> error_json message
-          | Ok result ->
-            let cwd_response =
-              Keeper_cwd_response.docker
-                ~host_cwd:cwd
-                ~container_cwd:(docker_private_workspace_cwd ~config ~meta cwd)
-            in
-            Yojson.Safe.to_string
-              (`Assoc
-                  ([ "ok", `Bool (result.status = Unix.WEXITED 0)
-                   ; "via", `String "docker"
-                   ; "cwd", Keeper_cwd_response.to_yojson_response cwd_response
-                   ; "sandbox_profile", `String "docker"
-                   ; "git_creds_enabled", `Bool true
-                   ; "network_mode", `String result.network_label
-                   ; "effective_sandbox_image", `String result.image
-                   ; "status", Keeper_alerting_path.process_status_to_json result.status
-                   ; "output", `String result.output
-                   ]
-                   @ gh_exit_class_field ~cmd ~status:result.status ~output:result.output
-                  )))))
+      (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd with
+       | Error err -> sandbox_error_json err
+       | Ok () ->
+         let cwd, sandbox_root_git_blocker =
+           resolve_sandbox_root_git_cwd ~config ~meta ~cwd ~cmd
+         in
+         match sandbox_root_git_blocker with
+         | Some message -> sandbox_error_json message
+         | None ->
+           let _ = turn_sandbox_runtime in
+           (match
+              run_docker_shell_command_with_status
+                ~config
+                ~meta
+                ~cwd
+                ~timeout_sec
+                ~cmd
+                ~git_creds_enabled:true
+                ~network_mode:Network_inherit
+            with
+            | Error message -> error_json message
+            | Ok result ->
+              let cwd_response =
+                Keeper_cwd_response.docker
+                  ~host_cwd:cwd
+                  ~container_cwd:(docker_private_workspace_cwd ~config ~meta cwd)
+              in
+              Yojson.Safe.to_string
+                (`Assoc
+                    ([ "ok", `Bool (result.status = Unix.WEXITED 0)
+                     ; "via", `String "docker"
+                     ; "cwd", Keeper_cwd_response.to_yojson_response cwd_response
+                     ; "sandbox_profile", `String "docker"
+                     ; "git_creds_enabled", `Bool true
+                     ; "network_mode", `String result.network_label
+                     ; "effective_sandbox_image", `String result.image
+                     ; "status", Keeper_alerting_path.process_status_to_json result.status
+                     ; "output", `String result.output
+                     ]
+                     @ gh_exit_class_field
+                         ~cmd
+                         ~status:result.status
+                         ~output:result.output)))))
 ;;
 
 let run_docker_hardened_bash
@@ -991,12 +999,15 @@ let run_docker_hardened_bash
     sandbox_error_json
       "sandbox_profile=docker blocks nested container runtimes and host socket references"
   else (
-    let cwd, sandbox_root_git_blocker =
-      resolve_sandbox_root_git_cwd ~config ~meta ~cwd ~cmd
-    in
-    match sandbox_root_git_blocker with
-    | Some message -> sandbox_error_json message
-    | None ->
+    match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd with
+    | Error err -> sandbox_error_json err
+    | Ok () ->
+      let cwd, sandbox_root_git_blocker =
+        resolve_sandbox_root_git_cwd ~config ~meta ~cwd ~cmd
+      in
+      (match sandbox_root_git_blocker with
+       | Some message -> sandbox_error_json message
+       | None ->
       (match turn_sandbox_runtime, network_mode with
        | Some runtime, Network_none ->
          (match
@@ -1082,5 +1093,5 @@ let run_docker_hardened_bash
                       @ gh_exit_class_field
                           ~cmd
                           ~status:result.status
-                          ~output:result.output))))))
+                          ~output:result.output)))))))
 ;;

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -497,6 +497,12 @@ let is_path_flag token =
   | _ -> false
 ;;
 
+let path_flag_requires_existing_dir token =
+  match strip_wrapping_quotes token with
+  | "-C" | "--work-tree" -> true
+  | _ -> false
+;;
+
 let path_value_of_flagged_token token =
   let token = strip_wrapping_quotes token in
   let prefixes = [ "--git-dir="; "--work-tree="; "--exec-path=" ] in
@@ -511,6 +517,17 @@ let path_value_of_flagged_token token =
               (String.length token - String.length prefix))
        else None)
     prefixes
+;;
+
+let inline_path_flag_requires_existing_dir token =
+  let token = strip_wrapping_quotes token in
+  String.starts_with ~prefix:"--work-tree=" token
+;;
+
+let path_is_existing_dir ?workdir path =
+  let resolved = resolve_path ?base_dir:workdir path in
+  try Sys.file_exists resolved && Sys.is_directory resolved with
+  | Sys_error _ -> false
 ;;
 
 let looks_like_path_token token =
@@ -577,43 +594,50 @@ let validate_command_paths ?workdir cmd =
           paths and explicit cwd."
          ^ path_rewrite_redirect_hint cmd)
     else (
-      let rec loop expect_path_value = function
+      let validate_path_value ~requires_existing_dir token =
+        if not (validate_path ?workdir token)
+        then
+          Error
+            (Printf.sprintf
+               "Path blocked: %s (outside allowed directories for this keeper \
+                command)"
+               token)
+        else if requires_existing_dir && not (path_is_existing_dir ?workdir token)
+        then
+          Error
+            (Printf.sprintf
+               "cwd_not_directory: %s (directory does not exist under cwd; create \
+                or repair the sandbox repo/worktree first)"
+               token)
+        else Ok ()
+      in
+      let rec loop expect_existing_dir = function
         | [] -> Ok ()
         | token :: rest ->
           let token = strip_wrapping_quotes token in
           if token = ""
-          then loop expect_path_value rest
-          else if expect_path_value
+          then loop expect_existing_dir rest
+          else if expect_existing_dir
           then
-            if validate_path ?workdir token
-            then loop false rest
-            else
-              Error
-                (Printf.sprintf
-                   "Path blocked: %s (outside allowed directories for this keeper \
-                    command)"
-                   token)
+            (match validate_path_value ~requires_existing_dir:true token with
+             | Ok () -> loop false rest
+             | Error _ as err -> err)
           else (
             match path_value_of_flagged_token token with
             | Some value ->
-              if validate_path ?workdir value
-              then loop false rest
-              else
-                Error
-                  (Printf.sprintf
-                     "Path blocked: %s (outside allowed directories for this keeper \
-                      command)"
-                     value)
-            | None when is_path_flag token -> loop true rest
+              (match
+                 validate_path_value
+                   ~requires_existing_dir:(inline_path_flag_requires_existing_dir token)
+                   value
+               with
+               | Ok () -> loop false rest
+               | Error _ as err -> err)
+            | None when is_path_flag token ->
+              loop (path_flag_requires_existing_dir token) rest
             | None when looks_like_path_token token ->
-              if validate_path ?workdir token
-              then loop false rest
-              else
-                Error
-                  (Printf.sprintf
-                     "Path blocked: %s (outside allowed directories for this keeper \
-                      command)"
-                     token)
+              (match validate_path_value ~requires_existing_dir:false token with
+               | Ok () -> loop false rest
+               | Error _ as err -> err)
             | None -> loop false rest)
       in
       cmd |> split_shell_tokens |> loop false)

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -584,6 +584,31 @@ let test_bash_git_creds_uses_oneshot_with_turn_runtime () =
   Alcotest.(check bool) "one-shot run mounted GH identity bundle" true
     (contains_substring log (root_gh_dir ^ ":/tmp/keeper-creds/.config/gh:ro"))
 
+let test_bash_git_c_option_missing_dir_blocks_before_docker () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  let log_path = Filename.concat config.Coord.base_path "docker.log" in
+  with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ( "cmd",
+              `String
+                "git -C repos/masc-mcp/.worktrees/missing status" );
+            ("cwd", `String playground);
+          ])
+      ()
+  in
+  Alcotest.(check bool) "typed cwd error" true
+    (response_mentions raw "error" "cwd_not_directory");
+  Alcotest.(check bool) "docker was not invoked" false
+    (Sys.file_exists log_path)
+
 let test_bash_git_push_requires_write_preset_before_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
@@ -1215,6 +1240,9 @@ let () =
           Alcotest.test_case
             "docker keeper bash git creds bypass warm turn runtime"
             `Quick test_bash_git_creds_uses_oneshot_with_turn_runtime;
+          Alcotest.test_case
+            "docker keeper git -C missing dir blocks before docker"
+            `Quick test_bash_git_c_option_missing_dir_blocks_before_docker;
           Alcotest.test_case
             "docker keeper git push requires write preset"
             `Quick test_bash_git_push_requires_write_preset_before_docker;

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -915,6 +915,61 @@ let () =
           | Ok () -> ()
           | Error msg ->
             Alcotest.fail ("plain path unexpectedly rejected: " ^ msg));
+      Alcotest.test_case "git -C missing worktree is cwd_not_directory"
+        `Quick (fun () ->
+          let workdir = Filename.temp_file "wdt_git_c_" "" in
+          Sys.remove workdir;
+          Unix.mkdir workdir 0o755;
+          Fun.protect
+            ~finally:(fun () -> try Unix.rmdir workdir with _ -> ())
+            (fun () ->
+              match
+                Worker_dev_tools.validate_command_paths
+                  ~workdir
+                  "git -C repos/masc-mcp/.worktrees/missing status"
+              with
+              | Error msg ->
+                Alcotest.(check bool)
+                  "typed cwd error"
+                  true
+                  (contains_substring msg "cwd_not_directory")
+              | Ok () -> Alcotest.fail "missing git -C directory must be blocked"));
+      Alcotest.test_case "git -C existing worktree is allowed" `Quick
+        (fun () ->
+          let workdir = Filename.temp_file "wdt_git_c_ok_" "" in
+          Sys.remove workdir;
+          let target =
+            Filename.concat workdir "repos/masc-mcp/.worktrees/task"
+          in
+          let rec mkdir_p path =
+            if path = "" || path = "." || path = "/" then ()
+            else if Sys.file_exists path then ()
+            else (
+              mkdir_p (Filename.dirname path);
+              Unix.mkdir path 0o755)
+          in
+          mkdir_p target;
+          let rec cleanup path =
+            if Sys.file_exists path then
+              match Unix.lstat path with
+              | { Unix.st_kind = Unix.S_DIR; _ } ->
+                Array.iter
+                  (fun name -> cleanup (Filename.concat path name))
+                  (Sys.readdir path);
+                Unix.rmdir path
+              | _ -> Sys.remove path
+          in
+          Fun.protect
+            ~finally:(fun () -> try cleanup workdir with _ -> ())
+            (fun () ->
+              match
+                Worker_dev_tools.validate_command_paths
+                  ~workdir
+                  "git -C repos/masc-mcp/.worktrees/task status"
+              with
+              | Ok () -> ()
+              | Error msg ->
+                Alcotest.fail ("existing git -C directory rejected: " ^ msg)));
     ];
     "command_blocked_hint_redirects", [
       (* Field evidence (2026-04-17/18): keeper_bash rejected `gh`, `docker`,


### PR DESCRIPTION
## Summary
- classify git -C/--work-tree path flags as cwd-bearing directory inputs
- preflight missing repo/worktree dirs before Docker git dispatch so logs surface cwd_not_directory instead of late git fatal
- cover worker path validation and Docker keeper_bash route

## Validation
- ocamlformat --check lib/worker_dev_tools.ml lib/keeper/keeper_shell_docker.ml test/test_worker_dev_tools.ml test/test_keeper_shell_docker_route.ml
- git diff --check HEAD~1..HEAD
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_worker_dev_tools.exe test/test_keeper_shell_docker_route.exe
- ./_build/default/test/test_worker_dev_tools.exe
- ./_build/default/test/test_keeper_shell_docker_route.exe test docker_route_fires 4 --show-errors