### PR TITLE
feat(ide): summarize trace context routes

### DIFF
--- a/dashboard/src/components/ide/overlay-keeper-trace.test.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.test.ts
@@ -346,6 +346,13 @@ describe('OverlayKeeperTrace — bucket render (RFC-0028 §5)', () => {
       'Telemetry',
       'Keeper',
     ])
+    const badge = container.querySelector<HTMLElement>('.ide-trace-context-badge')
+    expect(badge?.textContent?.trim()).toBe('CTX 8')
+    expect(badge?.getAttribute('data-context-route-count')).toBe('8')
+    expect(badge?.getAttribute('title'))
+      .toBe('Linked context: Code, Goal, Task, PR, Git, Log, Telemetry, Keeper')
+    expect(badge?.getAttribute('aria-label'))
+      .toBe('scholar trace has 8 linked context routes: Code, Goal, Task, PR, Git, Log, Telemetry, Keeper')
 
     fireEvent.click(links[0]!)
     expect(window.location.hash).toBe(

--- a/dashboard/src/components/ide/overlay-keeper-trace.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.ts
@@ -182,6 +182,20 @@ const ROUTE_LINKS_STYLE = {
   gap: '3px',
 } as const
 
+const CONTEXT_BADGE_STYLE = {
+  minWidth: '34px',
+  height: '17px',
+  padding: '0 5px',
+  border: '1px solid var(--color-border-muted)',
+  borderRadius: 'var(--r-1)',
+  background: 'var(--color-bg-subtle)',
+  color: 'var(--color-fg-muted)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 'var(--fs-9)',
+  lineHeight: '15px',
+  whiteSpace: 'nowrap',
+} as const
+
 const ROUTE_LINK_BUTTON_STYLE = {
   minWidth: 0,
   maxWidth: '58px',
@@ -245,6 +259,7 @@ function BucketRow({ bucket }: { readonly bucket: TraceBucket }) {
   const overflow = bucket.events.length - visible.length
   const lineLabel = bucket.line !== null ? `L${bucket.line}` : '—'
   const routeLinks = traceRouteLinks(bucket.events)
+  const routeSummary = traceRouteSummary(routeLinks)
 
   return html`
     <div
@@ -284,6 +299,15 @@ function BucketRow({ bucket }: { readonly bucket: TraceBucket }) {
         ? html`<span aria-label=${`${overflow} more`} data-overflow=${overflow} style=${OVERFLOW_STYLE}>+${overflow}</span>`
         : null}
       ${routeLinks.length > 0 ? html`
+        <span
+          class="ide-trace-context-badge"
+          data-context-route-count=${routeLinks.length}
+          title=${routeSummary}
+          aria-label=${`${bucket.keeperName} trace has ${routeLinks.length} linked context routes: ${routeLinkLabels(routeLinks)}`}
+          style=${CONTEXT_BADGE_STYLE}
+        >
+          CTX ${routeLinks.length}
+        </span>
         <div class="ide-trace-route-links" aria-label=${`${bucket.keeperName} trace route links`} style=${ROUTE_LINKS_STYLE}>
           ${routeLinks.map(link => html`
             <button
@@ -302,6 +326,14 @@ function BucketRow({ bucket }: { readonly bucket: TraceBucket }) {
       ` : null}
     </div>
   `
+}
+
+function routeLinkLabels(routeLinks: ReadonlyArray<IdeContextRouteLink>): string {
+  return routeLinks.map(link => link.label).join(', ')
+}
+
+function traceRouteSummary(routeLinks: ReadonlyArray<IdeContextRouteLink>): string {
+  return `Linked context: ${routeLinkLabels(routeLinks)}`
 }
 
 function selectTraceEvent(event: KeeperTraceEvent): void {


### PR DESCRIPTION
## Summary
- add a compact CTX badge to keeper trace rows that shows how many operational context routes are linked
- expose the linked surfaces in title/ARIA text so operators can scan trace coverage before opening each route chip
- cover the enriched Goal/Task/PR/Git/Log/Telemetry/Keeper route set in overlay keeper trace tests

## Validation
- pnpm install --offline
- pnpm exec vitest run src/components/ide/overlay-keeper-trace.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec eslint src/components/ide/overlay-keeper-trace.ts src/components/ide/overlay-keeper-trace.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check origin/main...HEAD
