### PR TITLE
feat(ide): summarize branch lane context

### DIFF
--- a/dashboard/src/components/ide/ide-branch-context-panel.test.ts
+++ b/dashboard/src/components/ide/ide-branch-context-panel.test.ts
@@ -206,6 +206,12 @@ describe('IdeBranchContextPanel', () => {
 
     const links = [...container.querySelectorAll<HTMLButtonElement>('.ide-branch-lane-links button')]
     expect(links.map(link => link.textContent)).toEqual(['Code', 'Git', 'Keeper'])
+    const badge = container.querySelector<HTMLElement>('.ide-branch-lane-context-badge')
+    expect(badge?.textContent?.trim()).toBe('CTX 3')
+    expect(badge?.getAttribute('data-context-route-count')).toBe('3')
+    expect(badge?.getAttribute('title')).toBe('Linked context: Code, Git, Keeper')
+    expect(badge?.getAttribute('aria-label'))
+      .toBe('sangsu lane has 3 linked context routes: Code, Git, Keeper')
 
     fireEvent.click(links[0]!)
     expect(window.location.hash).toBe(

--- a/dashboard/src/components/ide/ide-branch-context-panel.ts
+++ b/dashboard/src/components/ide/ide-branch-context-panel.ts
@@ -379,6 +379,20 @@ const LANE_STATUS_DOT: Record<KeeperPresenceStatus, { color: string; label: stri
   idle: { color: 'var(--color-fg-muted)', label: 'IDLE' },
 }
 
+const LANE_CONTEXT_BADGE_STYLE = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  height: '17px',
+  padding: '0 5px',
+  border: '1px solid var(--color-border-muted)',
+  borderRadius: 'var(--r-1)',
+  background: 'var(--color-bg-subtle)',
+  color: 'var(--color-fg-muted)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 'var(--fs-9)',
+  whiteSpace: 'nowrap',
+} as const
+
 function LaneRow(
   lane: IdeWorktreeLane,
   presence: KeeperPresenceSnapshot | null,
@@ -394,6 +408,7 @@ function LaneRow(
   const focusFile = cursor?.file_path ? cursor.file_path.split('/').pop() : null
   const dotStyle = status ? LANE_STATUS_DOT[status] : null
   const routeLinks = laneRouteLinks(lane, presenceKey, cursor)
+  const routeLabels = routeLinkLabels(routeLinks)
 
   return html`
     <li key=${lane.id} style=${{ display: 'grid', gridTemplateColumns: '6px minmax(0, 1fr) auto auto', alignItems: 'center', gap: 'var(--sp-1)', padding: '2px 0' }}>
@@ -428,6 +443,15 @@ function LaneRow(
       </div>
       ${routeLinks.length > 0 ? html`
         <div class="ide-branch-lane-links" aria-label=${`${lane.label} operational links`}>
+          <span
+            class="ide-branch-lane-context-badge"
+            data-context-route-count=${routeLinks.length}
+            title=${`Linked context: ${routeLabels}`}
+            aria-label=${`${lane.label} lane has ${routeLinks.length} linked context routes: ${routeLabels}`}
+            style=${LANE_CONTEXT_BADGE_STYLE}
+          >
+            CTX ${routeLinks.length}
+          </span>
           ${routeLinks.map(link => BranchLaneRouteLink(link))}
         </div>
       ` : null}
@@ -463,6 +487,10 @@ function laneRouteLinks(
     gitRef: branch && branch !== 'detached' ? branch : undefined,
     keeperId,
   })
+}
+
+function routeLinkLabels(routeLinks: ReadonlyArray<IdeContextRouteLink>): string {
+  return routeLinks.map(link => link.label).join(', ')
 }
 
 function BranchLaneRouteLink(link: IdeContextRouteLink) {


### PR DESCRIPTION
## Summary
- add a compact CTX badge to IDE branch worktree lanes so operators can see how many linked context routes a keeper lane exposes
- include the linked Code/Git/Keeper surfaces in title and ARIA text while preserving the existing route buttons
- cover the badge in the branch context panel test alongside existing route-link click behavior

## Validation
- pnpm install --offline
- pnpm exec vitest run src/components/ide/ide-branch-context-panel.test.ts src/components/ide/ide-branch-context-panel.a11y.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec eslint src/components/ide/ide-branch-context-panel.ts src/components/ide/ide-branch-context-panel.test.ts src/components/ide/ide-branch-context-panel.a11y.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check origin/main...HEAD
