### PR TITLE
fix(keeper): normalize bare PR repo names

### DIFF
--- a/lib/keeper/keeper_tool_github_pr.ml
+++ b/lib/keeper/keeper_tool_github_pr.ml
@@ -33,6 +33,36 @@ let with_repo_arg repo argv =
   let repo = String.trim repo in
   if repo = "" then argv else argv @ [ "-R"; repo ]
 
+let repo_name_of_slug slug =
+  match String.split_on_char '/' slug with
+  | [ _owner; repo ] -> Some repo
+  | _ -> None
+
+let effective_repo_arg ~(config : Coord.config) repo =
+  let repo = String.trim repo in
+  if repo = "" then
+    Ok ""
+  else
+    match Keeper_gh_shared.validate_repo_slug repo with
+    | Ok slug -> Ok slug
+    | Error reason when not (String.contains repo '/') -> (
+        let root = Keeper_alerting_path.project_root_of_config config in
+        match Keeper_gh_shared.repo_slug_of_git_root ~git_root:root with
+        | Some slug when repo_name_of_slug slug = Some repo -> Ok slug
+        | Some slug ->
+            Error
+              (Printf.sprintf
+                 "repo must be owner/repo; got bare repo %S. Current \
+                  project repository is %S."
+                 repo slug)
+        | None ->
+            Error
+              (Printf.sprintf
+                 "repo must be owner/repo; got bare repo %S and current \
+                  project repository could not be inferred."
+                 repo))
+    | Error reason -> Error reason
+
 let opt_flag flag = function
   | None -> []
   | Some value ->
@@ -331,11 +361,14 @@ let handle_keeper_pr_list ~(config : Coord.config) ~(meta : keeper_meta)
     ~(args : Yojson.Safe.t) =
   let repo = Safe_ops.json_string ~default:"" "repo" args in
   let limit = Safe_ops.json_int ~default:20 "limit" args |> clamp_limit in
-  match Safe_ops.json_string ~default:"open" "state" args |> normalize_state with
-  | Error reason -> error_json reason
-  | Ok state ->
-      run_gh ~tool:"keeper_pr_list" ~operation:"pr_list" ~config ~meta
-        ~args ~write:false (build_pr_list_argv ~repo ~state ~limit)
+  match
+    ( effective_repo_arg ~config repo,
+      Safe_ops.json_string ~default:"open" "state" args |> normalize_state )
+  with
+  | Error reason, _ | _, Error reason -> error_json reason
+  | Ok repo, Ok state ->
+      run_gh ~tool:"keeper_pr_list" ~operation:"pr_list" ~config ~meta ~args
+        ~write:false (build_pr_list_argv ~repo ~state ~limit)
 
 let handle_keeper_pr_status ~(config : Coord.config) ~(meta : keeper_meta)
     ~(args : Yojson.Safe.t) =
@@ -344,8 +377,11 @@ let handle_keeper_pr_status ~(config : Coord.config) ~(meta : keeper_meta)
   if pr_number = 0 then
     error_json "pr_number is required. Good: pr_number=123."
   else
-    run_gh ~tool:"keeper_pr_status" ~operation:"pr_status" ~config ~meta
-      ~args ~write:false (build_pr_status_argv ~repo ~pr_number)
+    match effective_repo_arg ~config repo with
+    | Error reason -> error_json reason
+    | Ok repo ->
+        run_gh ~tool:"keeper_pr_status" ~operation:"pr_status" ~config
+          ~meta ~args ~write:false (build_pr_status_argv ~repo ~pr_number)
 
 let handle_keeper_pr_create ~(config : Coord.config) ~(meta : keeper_meta)
     ~(args : Yojson.Safe.t) =
@@ -369,9 +405,12 @@ let handle_keeper_pr_create ~(config : Coord.config) ~(meta : keeper_meta)
           "reason", `String "keeper_pr_create requires research, delivery, coding, or full preset";
         ])
   else
-    run_gh ~tool:"keeper_pr_create" ~operation:"pr_create" ~config ~meta
-      ~args ~write:true ~recover_pr_create:(repo, head)
-      (build_pr_create_argv ~repo ~title ~body ~base ~head)
+    match effective_repo_arg ~config repo with
+    | Error reason -> error_json reason
+    | Ok repo ->
+        run_gh ~tool:"keeper_pr_create" ~operation:"pr_create" ~config
+          ~meta ~args ~write:true ~recover_pr_create:(repo, head)
+          (build_pr_create_argv ~repo ~title ~body ~base ~head)
 
 module For_testing = struct
   let build_pr_list_argv = build_pr_list_argv
@@ -379,6 +418,7 @@ module For_testing = struct
   let build_pr_view_recovery_argv = build_pr_view_recovery_argv
   let build_pr_create_argv = build_pr_create_argv
   let draft_request_allowed = draft_request_allowed
+  let effective_repo_arg = effective_repo_arg
   let pr_create_failure_may_have_created_pr =
     pr_create_failure_may_have_created_pr
   let pr_create_failure_already_exists = pr_create_failure_already_exists

--- a/lib/keeper/keeper_tool_github_pr.mli
+++ b/lib/keeper/keeper_tool_github_pr.mli
@@ -37,6 +37,9 @@ module For_testing : sig
     head:string option ->
     string list
 
+  val effective_repo_arg :
+    config:Coord.config -> string -> (string, string) result
+
   val draft_request_allowed : Yojson.Safe.t -> bool
 
   val quote_argv : string list -> string

--- a/test/test_keeper_github_pr.ml
+++ b/test/test_keeper_github_pr.ml
@@ -246,6 +246,20 @@ let test_pr_list_argv_uses_repo_state_limit_json () =
     ]
     (K.For_testing.build_pr_list_argv ~repo:"owner/repo" ~state:"open" ~limit:20)
 
+let test_effective_repo_arg_expands_current_project_name () =
+  setup_docker_pr_tool @@ fun ~config ~meta:_ ->
+  match K.For_testing.effective_repo_arg ~config "masc-mcp" with
+  | Ok repo -> check string "expanded repo" "jeong-sik/masc-mcp" repo
+  | Error reason -> Alcotest.fail reason
+
+let test_effective_repo_arg_rejects_ambiguous_bare_repo () =
+  setup_docker_pr_tool @@ fun ~config ~meta:_ ->
+  match K.For_testing.effective_repo_arg ~config "not-this-repo" with
+  | Ok repo -> Alcotest.failf "unexpected repo: %s" repo
+  | Error reason ->
+      check bool "mentions current project slug" true
+        (contains_substring reason "jeong-sik/masc-mcp")
+
 let test_pr_status_argv_accepts_number () =
   let argv =
     K.For_testing.build_pr_status_argv ~repo:"owner/repo" ~pr_number:42
@@ -485,6 +499,10 @@ let () =
         [
           test_case "pr list argv" `Quick
             test_pr_list_argv_uses_repo_state_limit_json;
+          test_case "bare repo expands to current project slug" `Quick
+            test_effective_repo_arg_expands_current_project_name;
+          test_case "ambiguous bare repo rejects before gh" `Quick
+            test_effective_repo_arg_rejects_ambiguous_bare_repo;
           test_case "pr status argv" `Quick
             test_pr_status_argv_accepts_number;
           test_case "pr create argv is draft" `Quick


### PR DESCRIPTION
## Summary
- normalize keeper PR tool repo args before invoking gh
- expand a bare current project name like `masc-mcp` to the git-root slug `jeong-sik/masc-mcp`
- reject ambiguous bare repo names before gh guesses the wrong owner

## Runtime Evidence
- live keeper logs showed `keeper_pr_list` failing with: `expected the "[HOST/]OWNER/REPO" format, got "masc-mcp"`
- follow-up retry drifted to the wrong owner path: `anyang-keepers/masc-mcp`

## Validation
- `ocamlformat --check lib/keeper/keeper_tool_github_pr.ml lib/keeper/keeper_tool_github_pr.mli test/test_keeper_github_pr.ml`
- `git diff --check`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_github_pr.exe` (first run hit stale Dune artifact; retry passed)
- `./_build/default/test/test_keeper_github_pr.exe`