### PR TITLE
feat(ide): surface persistence context routes

### DIFF
--- a/dashboard/src/components/ide/ide-persistence-panel.test.ts
+++ b/dashboard/src/components/ide/ide-persistence-panel.test.ts
@@ -172,13 +172,23 @@ describe('IdePersistencePanel', () => {
 
     const links = Array.from(screen.getByLabelText('Persistence context links')
       .querySelectorAll<HTMLButtonElement>('button'))
-    expect(links.map(link => link.textContent)).toEqual(['Code', 'Keeper'])
+    expect(links.map(link => link.textContent)).toEqual(['Code', 'Telemetry', 'Keeper'])
     expect(links[0]?.title).toBe('Code lib/runtime.ml:42')
-    expect(links[1]?.title).toBe('Keeper sangsu')
+    expect(links[1]?.title).toBe('Fleet telemetry event log · query sangsu')
+    expect(links[2]?.title).toBe('Keeper sangsu')
+
+    const badge = screen.getByText('CTX 3')
+    expect(badge.getAttribute('data-context-route-count')).toBe('3')
+    expect(badge.getAttribute('title')).toBe('Linked context: Code, Telemetry, Keeper')
+    expect(badge.getAttribute('aria-label'))
+      .toBe('Persistence map has 3 linked context routes: Code, Telemetry, Keeper')
 
     fireEvent.click(links[0]!)
     expect(window.location.hash).toBe(
       '#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=42&surface=Persistence&label=sangsu+current+focus&source_id=persistence%3Asangsu&keeper=sangsu',
     )
+
+    fireEvent.click(links[1]!)
+    expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&q=sangsu')
   })
 })

--- a/dashboard/src/components/ide/ide-persistence-panel.ts
+++ b/dashboard/src/components/ide/ide-persistence-panel.ts
@@ -467,8 +467,24 @@ function persistenceRouteLinks(
     label: keeperId ? `${keeperId} current focus` : 'keeper current focus',
     sourceId: keeperId ? `persistence:${keeperId}` : 'persistence',
     keeperId,
+    telemetry: Boolean(keeperId),
+    telemetryQuery: keeperId || undefined,
   })
 }
+
+const PERSISTENCE_CONTEXT_BADGE_STYLE = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  height: '17px',
+  padding: '0 5px',
+  border: '1px solid var(--color-border-muted)',
+  borderRadius: 'var(--r-1)',
+  background: 'var(--color-bg-subtle)',
+  color: 'var(--color-fg-muted)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 'var(--fs-9)',
+  whiteSpace: 'nowrap',
+} as const
 
 function PersistenceRouteLinks({
   links,
@@ -476,8 +492,18 @@ function PersistenceRouteLinks({
   readonly links: ReadonlyArray<IdeContextRouteLink>
 }) {
   if (links.length === 0) return null
+  const routeLabels = routeLinkLabels(links)
   return html`
     <div class="ide-persistence-links" aria-label="Persistence context links">
+      <span
+        class="ide-persistence-context-badge"
+        data-context-route-count=${links.length}
+        title=${`Linked context: ${routeLabels}`}
+        aria-label=${`Persistence map has ${links.length} linked context routes: ${routeLabels}`}
+        style=${PERSISTENCE_CONTEXT_BADGE_STYLE}
+      >
+        CTX ${links.length}
+      </span>
       ${links.map(link => html`
         <button
           key=${link.id}
@@ -489,4 +515,8 @@ function PersistenceRouteLinks({
       `)}
     </div>
   `
+}
+
+function routeLinkLabels(links: ReadonlyArray<IdeContextRouteLink>): string {
+  return links.map(link => link.label).join(', ')
 }


### PR DESCRIPTION
## Summary
- add keeper-scoped telemetry routing to the IDE persistence map so a persisted keeper state can jump to fleet event logs
- show a compact CTX badge for persistence context links with Code/Telemetry/Keeper coverage in title and ARIA text
- extend the persistence panel regression test to cover the telemetry route and context badge

## Validation
- pnpm install --offline
- pnpm exec vitest run src/components/ide/ide-persistence-panel.test.ts src/components/ide/ide-persistence-panel.a11y.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec eslint src/components/ide/ide-persistence-panel.ts src/components/ide/ide-persistence-panel.test.ts src/components/ide/ide-persistence-panel.a11y.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check origin/main...HEAD
