### PR TITLE
feat(ide): summarize keeper shell context

### DIFF
--- a/dashboard/src/components/ide/keeper-shell-drawer.test.ts
+++ b/dashboard/src/components/ide/keeper-shell-drawer.test.ts
@@ -222,6 +222,12 @@ describe('KeeperShellDrawer event mapping', () => {
       'Telemetry',
       'Keeper',
     ])
+    const badge = mounted.querySelector<HTMLElement>('.keeper-shell-context-badge')
+    expect(badge?.textContent?.trim()).toBe('CTX 6')
+    expect(badge?.getAttribute('data-context-route-count')).toBe('6')
+    expect(badge?.getAttribute('title')).toBe('Linked context: Code, Goal, Task, Git, Telemetry, Keeper')
+    expect(badge?.getAttribute('aria-label'))
+      .toBe('Keeper shell has 6 linked context routes: Code, Goal, Task, Git, Telemetry, Keeper')
 
     fireEvent.click(routeLinks.find(link => link.textContent === 'Code')!)
     expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=42&surface=Terminal&label=keeper+shell+task-123&source_id=keeper-shell%3Asangsu%3Atask-123&keeper=sangsu')

--- a/dashboard/src/components/ide/keeper-shell-drawer.ts
+++ b/dashboard/src/components/ide/keeper-shell-drawer.ts
@@ -168,8 +168,18 @@ function KeeperShellContextLinks({
   readonly links: ReadonlyArray<IdeContextRouteLink>
 }) {
   if (links.length === 0) return null
+  const routeLabels = routeLinkLabels(links)
   return html`
     <div class="keeper-shell-context-links" aria-label="Keeper shell operational links">
+      <span
+        class="keeper-shell-context-badge"
+        data-context-route-count=${links.length}
+        title=${`Linked context: ${routeLabels}`}
+        aria-label=${`Keeper shell has ${links.length} linked context routes: ${routeLabels}`}
+        style=${KEEPER_SHELL_CONTEXT_BADGE_STYLE}
+      >
+        CTX ${links.length}
+      </span>
       ${links.map(link => html`
         <button
           key=${link.id}
@@ -181,6 +191,24 @@ function KeeperShellContextLinks({
       `)}
     </div>
   `
+}
+
+const KEEPER_SHELL_CONTEXT_BADGE_STYLE = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  height: '17px',
+  padding: '0 5px',
+  border: '1px solid var(--color-border-muted)',
+  borderRadius: 'var(--r-1)',
+  background: 'var(--color-bg-subtle)',
+  color: 'var(--color-fg-muted)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 'var(--fs-9)',
+  whiteSpace: 'nowrap',
+} as const
+
+function routeLinkLabels(links: ReadonlyArray<IdeContextRouteLink>): string {
+  return links.map(link => link.label).join(', ')
 }
 
 function KeeperShellSummaryStrip({


### PR DESCRIPTION
## Summary
- add a compact CTX badge to the keeper shell operational link row so shell output shows its linked context coverage at a glance
- expose the Code/Goal/Task/Git/Telemetry/Keeper surface list through title and ARIA text
- keep existing shell route buttons and navigation behavior intact

## Validation
- pnpm install --offline
- pnpm exec vitest run src/components/ide/keeper-shell-drawer.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec eslint src/components/ide/keeper-shell-drawer.ts src/components/ide/keeper-shell-drawer.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check origin/main...HEAD
