### PR TITLE
feat(ide): link interject telemetry context

### DIFF
--- a/dashboard/src/components/ide/ide-interject.test.ts
+++ b/dashboard/src/components/ide/ide-interject.test.ts
@@ -34,7 +34,7 @@ describe('IdeInterject', () => {
       tool_name: 'ocamllsp',
     })
 
-    expect(links.map(link => link.label)).toEqual(['Code', 'Keeper'])
+    expect(links.map(link => link.label)).toEqual(['Code', 'Telemetry', 'Keeper'])
     expect(links.find(link => link.label === 'Code')).toMatchObject({
       params: {
         section: 'ide-shell',
@@ -47,6 +47,14 @@ describe('IdeInterject', () => {
         keeper: 'sangsu',
       },
       evidence: 'Code lib/runtime.ml:42',
+    })
+    expect(links.find(link => link.label === 'Telemetry')).toMatchObject({
+      params: {
+        section: 'fleet-health',
+        view: 'event-log',
+        q: 'interject keeper:sangsu mode:reviewing tool:ocamllsp',
+      },
+      evidence: 'Fleet telemetry event log · query interject keeper:sangsu mode:reviewing tool:ocamllsp',
     })
   })
 
@@ -66,7 +74,8 @@ describe('IdeInterject', () => {
     expect(input?.getAttribute('aria-label')).toBe('Interject input')
 
     const contextButtons = [...container.querySelectorAll('.ide-interject-context-links button')]
-    expect(contextButtons.map(button => button.textContent)).toEqual(['Keeper'])
+    expect(container.querySelector('.ide-interject-context-count')?.textContent).toBe('CTX 2')
+    expect(contextButtons.map(button => button.textContent)).toEqual(['Telemetry', 'Keeper'])
 
     const buttons = [...container.querySelectorAll<HTMLButtonElement>('.ide-interject-actions button')]
     expect(buttons.map(button => button.textContent)).toEqual(['Send', 'Approve', 'Pause', 'Drain'])
@@ -154,9 +163,17 @@ describe('IdeInterject', () => {
     })
 
     const contextButtons = [...container.querySelectorAll<HTMLButtonElement>('.ide-interject-context-links button')]
-    expect(contextButtons.map(button => button.textContent)).toEqual(['Code', 'Keeper'])
+    expect(container.querySelector('.ide-interject-context-count')?.textContent).toBe('CTX 3')
+    expect(contextButtons.map(button => button.textContent)).toEqual(['Code', 'Telemetry', 'Keeper'])
 
     fireEvent.click(contextButtons.find(button => button.textContent === 'Code')!)
     expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=42&surface=Interject&label=ocamllsp&source_id=interject%3Asangsu&keeper=sangsu')
+
+    fireEvent.click(contextButtons.find(button => button.textContent === 'Telemetry')!)
+    expect(routeHashParams().get('q')).toBe('interject keeper:sangsu mode:reviewing tool:ocamllsp')
   })
 })
+
+function routeHashParams(): URLSearchParams {
+  return new URLSearchParams(window.location.hash.split('?')[1] ?? '')
+}

--- a/dashboard/src/components/ide/ide-interject.ts
+++ b/dashboard/src/components/ide/ide-interject.ts
@@ -171,7 +171,18 @@ export function interjectContextRouteLinks(
     label: cursor?.tool_name ?? cursor?.focus_mode ?? 'active keeper',
     sourceId: `interject:${keeper}`,
     keeperId: keeper,
+    telemetry: true,
+    telemetryQuery: interjectTelemetryQuery(keeper, cursor),
   })
+}
+
+function interjectTelemetryQuery(keeperId: string, cursor: KeeperCursor | null): string {
+  return [
+    'interject',
+    `keeper:${keeperId}`,
+    cursor?.focus_mode ? `mode:${cursor.focus_mode}` : null,
+    cursor?.tool_name ? `tool:${cursor.tool_name}` : null,
+  ].filter((value): value is string => value !== null).join(' ')
 }
 
 function InterjectContextLinks({
@@ -182,6 +193,13 @@ function InterjectContextLinks({
   if (links.length === 0) return null
   return html`
     <div class="ide-interject-context-links" aria-label="Interject context links">
+      <span
+        class="ide-interject-context-count"
+        title=${`${links.length} linked interject context routes`}
+        aria-label=${`${links.length} linked interject context routes`}
+      >
+        CTX ${links.length}
+      </span>
       ${links.map(link => html`
         <button
           key=${link.id}

--- a/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
@@ -330,6 +330,7 @@ describe('InspectorKeeperBDI', () => {
     })
 
     const links = [...container.querySelectorAll<HTMLButtonElement>('.ide-bdi-route-link')]
+    expect(container.querySelector('.ide-bdi-route-count')?.textContent).toBe('CTX 3')
     expect(links.map(link => link.textContent)).toEqual(['Code', 'Telemetry', 'Keeper'])
 
     links.find(link => link.textContent === 'Code')!.click()

--- a/dashboard/src/components/ide/inspector-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.ts
@@ -230,6 +230,13 @@ export function BdiRouteLinks({
   if (links.length === 0) return null
   return html`
     <div class="ide-bdi-route-links" aria-label=${ariaLabel}>
+      <span
+        class="ide-bdi-route-count"
+        title=${`${links.length} linked BDI context routes`}
+        aria-label=${`${links.length} linked BDI context routes`}
+      >
+        CTX ${links.length}
+      </span>
       ${links.map(link => html`
         <button
           key=${link.id}

--- a/dashboard/src/components/ide/inspector-multi-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-multi-keeper-bdi.test.ts
@@ -719,6 +719,7 @@ describe('InspectorMultiKeeperBDI — file focus label (cursor overlay → IDE j
 
     const ashPanel = container.querySelector('article[data-keeper="ash"]')
     expect(ashPanel).not.toBeNull()
+    expect(ashPanel!.querySelector('.ide-bdi-route-count')?.textContent).toBe('CTX 3')
     const ashLinks = [...ashPanel!.querySelectorAll<HTMLButtonElement>('.ide-bdi-route-link')]
     expect(ashLinks.map(link => link.textContent)).toEqual(['Code', 'Telemetry', 'Keeper'])
 
@@ -728,6 +729,7 @@ describe('InspectorMultiKeeperBDI — file focus label (cursor overlay → IDE j
 
     const scholarChip = container.querySelector('span[role="listitem"][data-keeper="scholar"]')
     expect(scholarChip).not.toBeNull()
+    expect(scholarChip!.querySelector('.ide-bdi-route-count')?.textContent).toBe('CTX 3')
     const scholarLinks = [...scholarChip!.querySelectorAll<HTMLButtonElement>('.ide-bdi-route-link')]
     expect(scholarLinks.map(link => link.textContent)).toEqual(['Code', 'Telemetry', 'Keeper'])
 

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -1471,8 +1471,23 @@ button.ide-persistence-focus:focus-visible {
 .ide-bdi-route-links {
   display: inline-flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 3px;
   min-width: 0;
+}
+
+.ide-bdi-route-count,
+.ide-interject-context-count {
+  height: 17px;
+  padding: 0 5px;
+  border: 1px solid var(--color-border-divider);
+  border-radius: var(--r-1);
+  background: var(--color-bg-surface);
+  color: var(--color-fg-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  line-height: 15px;
+  white-space: nowrap;
 }
 
 .ide-bdi-route-link {
@@ -1506,8 +1521,14 @@ button.ide-persistence-focus:focus-visible {
 .ide-interject-context-links {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 3px;
   min-width: 0;
+}
+
+.ide-interject-context-count {
+  height: 18px;
+  line-height: 16px;
 }
 
 .ide-interject-context-links button {


### PR DESCRIPTION
Summary:
- add telemetry route context to the IDE interject bar so keeper interruptions can jump to fleet event logs
- show compact CTX route counts on Interject and BDI operational link rows
- cover the new route counts and telemetry query in focused IDE tests

Validation:
- pnpm exec vitest run src/components/ide/ide-interject.test.ts src/components/ide/ide-interject.a11y.test.ts src/components/ide/inspector-keeper-bdi.test.ts src/components/ide/inspector-multi-keeper-bdi.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec eslint src/components/ide/ide-interject.ts src/components/ide/ide-interject.test.ts src/components/ide/ide-interject.a11y.test.ts src/components/ide/inspector-keeper-bdi.ts src/components/ide/inspector-keeper-bdi.test.ts src/components/ide/inspector-multi-keeper-bdi.ts src/components/ide/inspector-multi-keeper-bdi.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check