### PR TITLE
feat(ide): summarize diff context routes

### DIFF
--- a/dashboard/src/components/ide/ide-diff-view.test.ts
+++ b/dashboard/src/components/ide/ide-diff-view.test.ts
@@ -215,6 +215,7 @@ describe('diff preview chrome', () => {
       .toBe('Diff context: Task line 4, task task-runtime, 2 route links')
     expect(focus?.textContent).toContain('Task')
     expect(focus?.textContent).toContain('L4')
+    expect(container.querySelector('.ide-diff-context-count')?.textContent).toBe('CTX 2')
     const focusedRows = container.querySelectorAll<HTMLElement>('[data-context-focus="true"]')
     expect(focusedRows).toHaveLength(2)
     expect(focusedRows[0]?.getAttribute('style')).toContain('inset 3px 0 0 var(--color-accent-fg)')

--- a/dashboard/src/components/ide/ide-diff-view.ts
+++ b/dashboard/src/components/ide/ide-diff-view.ts
@@ -172,6 +172,13 @@ function DiffContextFocus({
       <strong>${focus.label}</strong>
       ${links.length > 0 ? html`
         <span class="ide-diff-context-links" aria-label="Diff context route links">
+          <span
+            class="ide-diff-context-count"
+            title=${`${links.length} linked diff context routes`}
+            aria-label=${`${links.length} linked diff context routes`}
+          >
+            CTX ${links.length}
+          </span>
           ${links.map(link => html`
             <button
               key=${link.id}

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -559,8 +559,22 @@
 .ide-diff-context-links {
   display: inline-flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 3px;
   min-width: 0;
+}
+
+.ide-diff-context-count {
+  height: 18px;
+  padding: 0 5px;
+  border: 1px solid var(--color-border-divider);
+  border-radius: var(--r-1);
+  background: var(--color-bg-surface);
+  color: var(--color-fg-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  line-height: 16px;
+  white-space: nowrap;
 }
 
 .ide-diff-context-links button {


### PR DESCRIPTION
Summary:
- add a compact CTX route count to focused diff context links
- keep existing diff route navigation intact while making linked surface coverage visible in the line/diff strip
- cover the visible count in the focused diff view test

Validation:
- pnpm exec vitest run src/components/ide/ide-diff-view.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec eslint src/components/ide/ide-diff-view.ts src/components/ide/ide-diff-view.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check