### PR TITLE
feat(ide): summarize editor context routes

### DIFF
--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -675,6 +675,7 @@ describe('IdeEditor', () => {
     const focusMeta = [...container.querySelectorAll('.ide-editor-context-focus-meta > span')]
       .map(node => node.textContent)
     expect(focusMeta).toEqual(['Task', 'keeper sangsu', 'source event-1', '2 links'])
+    expect(container.querySelector('.ide-editor-context-route-count')?.textContent).toBe('CTX 2')
     const routeLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-editor-context-route-link')]
     expect(routeLinks.map(link => link.textContent)).toEqual(['Task', 'Telemetry'])
     fireEvent.click(routeLinks.find(link => link.textContent === 'Telemetry')!)

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -255,6 +255,7 @@ export function IdeEditor({
             </span>
             ${currentFileFocus.route_links && currentFileFocus.route_links.length > 0 ? html`
               <span class="ide-editor-context-route-links" aria-label="Focused context operational links">
+                <${EditorContextRouteCount} count=${currentFileFocus.route_links.length} label="focused context" />
                 ${currentFileFocus.route_links.map(link => EditorContextRouteLink(link))}
               </span>
             ` : null}
@@ -523,6 +524,24 @@ function EditorContextRouteLink(link: IdeContextRouteLink) {
     >
       ${link.label}
     </button>
+  `
+}
+
+function EditorContextRouteCount({
+  count,
+  label,
+}: {
+  readonly count: number
+  readonly label: string
+}) {
+  return html`
+    <span
+      class="ide-editor-context-route-count"
+      title=${`${count} linked ${label} routes`}
+      aria-label=${`${count} linked ${label} routes`}
+    >
+      CTX ${count}
+    </span>
   `
 }
 
@@ -1365,6 +1384,7 @@ function AnnotationPopover({
           aria-label="Annotation operational links"
           style=${{ marginTop: 'var(--sp-2)' }}
         >
+          <${EditorContextRouteCount} count=${routeLinks.length} label="annotation context" />
           ${routeLinks.map(link => EditorContextRouteLink(link))}
         </div>
       ` : null}

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -2301,9 +2301,23 @@ button.ide-persistence-focus:focus-visible {
 .ide-editor-context-route-links {
   display: inline-flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 3px;
   min-width: 0;
   flex-shrink: 0;
+}
+
+.ide-editor-context-route-count {
+  height: 17px;
+  padding: 0 5px;
+  border: 1px solid var(--color-border-divider);
+  border-radius: var(--r-1);
+  background: var(--color-bg-surface);
+  color: var(--color-fg-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  line-height: 15px;
+  white-space: nowrap;
 }
 
 .ide-editor-context-route-link {


### PR DESCRIPTION
Summary:
- add compact CTX route counts to editor focused-context links
- reuse the same count chip in annotation operational links so line annotations expose linked-surface coverage
- preserve existing route navigation and metadata text while matching the other IDE context surfaces

Validation:
- pnpm exec vitest run src/components/ide/ide-editor.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec eslint src/components/ide/ide-editor.ts src/components/ide/ide-editor.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check