### PR TITLE
fix(keeper): gate internal tool alias calls

### DIFF
--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -1016,8 +1016,17 @@ let prepare_agent_setup
         essential @ List.filteri (fun i _ -> i < budget) non_essential)
       else all_allowed
     in
+    let allowed_canonical_tool_names =
+      all_allowed
+      |> List.map Keeper_tool_disclosure.canonical_tool_name
+      |> Keeper_types.dedupe_keep_order
+    in
     let missing_required_tool_names =
-      List.filter (fun name -> not (List.mem name all_allowed)) required_tool_names
+      List.filter
+        (fun name ->
+           let canonical = Keeper_tool_disclosure.canonical_tool_name name in
+           not (List.mem canonical allowed_canonical_tool_names))
+        required_tool_names
     in
     let visible_tool_count = List.length all_allowed in
     let tool_surface_class : Keeper_agent_tool_surface.tool_surface_class =
@@ -1247,6 +1256,11 @@ let prepare_agent_setup
                  unknown_tool_guard))
     in
     let meta_ref = ref acc.meta in
+    let public_alias_pre_tool_use_guard ~tool_name ~input:_ =
+      Keeper_tool_disclosure.public_alias_guidance_for_internal_call
+        ~visible_tool_names:acc.requested_tool_names
+        tool_name
+    in
     let base_hooks =
       Keeper_hooks_oas.make_hooks
         ~config
@@ -1279,6 +1293,7 @@ let prepare_agent_setup
         ~discover_work_nudge
         ~passive_loop_nudge:(fun () ->
           Keeper_passive_loop_detector.nudge_message ~keeper_name:acc.meta.name)
+        ~pre_tool_use_guard:public_alias_pre_tool_use_guard
         ()
     in
     let before_turn_hook : Agent_sdk.Hooks.hooks =

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -310,6 +310,55 @@ let tool_progress_class_to_string = function
 let canonical_tool_name = canonical_name
 let canonical_tool_name_observed = canonical_name_observed
 
+let public_aliases_for_internal_name internal_name =
+  Keeper_tool_alias.public_names ()
+  |> List.filter (fun public ->
+    match Keeper_tool_alias.route public with
+    | Some route -> String.equal route.internal_name internal_name
+    | None -> false)
+;;
+
+let public_alias_guidance_for_internal_call
+      ~(visible_tool_names : string list)
+      (tool_name : string)
+  : string option
+  =
+  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
+  match Keeper_tool_alias.route stripped with
+  | Some _ -> None
+  | None ->
+    let canonical = canonical_tool_name stripped in
+    (match public_aliases_for_internal_name canonical with
+     | [] -> None
+     | aliases ->
+       let visible_aliases =
+         List.filter (fun alias -> List.mem alias visible_tool_names) aliases
+       in
+       let alias_words =
+         match visible_aliases with
+         | [] -> aliases
+         | _ -> visible_aliases
+       in
+       let alias_text = String.concat " or " alias_words in
+       let correction =
+         match visible_aliases with
+         | _ :: _ -> Printf.sprintf "Use %s instead." alias_text
+         | [] ->
+           Printf.sprintf
+             "No public alias for it is visible in this turn; do not invent \
+              internal tool names. Wait for a visible tool or report the blocker. \
+              Public alias%s: %s."
+             (if List.length aliases = 1 then "" else "es")
+             alias_text
+       in
+       Some
+         (Printf.sprintf
+            "%s is an internal keeper implementation tool name, not a \
+             model-facing tool. %s"
+            stripped
+            correction))
+;;
+
 let claim_context_tool_names : string list =
   Tool_name.[ Masc Claim_next; Masc Claim_task; Keeper Task_claim ]
   |> List.map Tool_name.to_string

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -135,6 +135,11 @@ val canonical_tool_name : string -> string
     [canonical_tool_name] to avoid double-counting. *)
 val canonical_tool_name_observed : string -> string
 
+(** Return a model-facing correction when a tool call uses a keeper-internal
+    implementation name whose public alias is the supported LLM surface. *)
+val public_alias_guidance_for_internal_call
+  :  visible_tool_names:string list -> string -> string option
+
 (** Canonical names of claim-context tools (Task_claim, Claim_next,
     Claim_task). *)
 val claim_context_tool_names : string list

--- a/test/test_keeper_tool_surface_guard.ml
+++ b/test/test_keeper_tool_surface_guard.ml
@@ -42,6 +42,54 @@ let test_final_keeper_tool_names_accepts_public_alias_surface () =
        ~allowed_tool_names:[ "Bash" ])
 ;;
 
+let test_public_alias_guidance_blocks_internal_bash () =
+  check
+    (option string)
+    "internal bash guidance"
+    (Some
+       "keeper_bash is an internal keeper implementation tool name, not a \
+        model-facing tool. Use Bash instead.")
+    (KTD.public_alias_guidance_for_internal_call
+       ~visible_tool_names:[ "Bash"; "Read" ]
+       "keeper_bash")
+;;
+
+let test_public_alias_guidance_ignores_public_bash () =
+  check
+    (option string)
+    "public bash is already model-facing"
+    None
+    (KTD.public_alias_guidance_for_internal_call
+       ~visible_tool_names:[ "Bash" ]
+       "Bash")
+;;
+
+let test_public_alias_guidance_prefers_visible_write_alias () =
+  check
+    (option string)
+    "visible write alias"
+    (Some
+       "keeper_fs_edit is an internal keeper implementation tool name, not a \
+        model-facing tool. Use Write instead.")
+    (KTD.public_alias_guidance_for_internal_call
+       ~visible_tool_names:[ "Write" ]
+       "keeper_fs_edit")
+;;
+
+let test_public_alias_guidance_reports_alias_not_visible () =
+  check
+    (option string)
+    "alias not visible"
+    (Some
+       "keeper_bash is an internal keeper implementation tool name, not a \
+        model-facing tool. No public alias for it is visible in this turn; do \
+        not invent internal tool names. Wait for a visible tool or report the \
+        blocker. Public alias: Bash.")
+    (KTD.public_alias_guidance_for_internal_call
+       ~visible_tool_names:[ "keeper_tasks_list" ]
+       "keeper_bash")
+;;
+
 (* #8471 partial tolerance: mixed turn (valid + unexpected) must not
    hard-fail — the valid tool call is real work and should survive. *)
 let test_has_valid_tool_call_true_when_mixed () =
@@ -180,6 +228,22 @@ let () =
             "final names accept public alias surface"
             `Quick
             test_final_keeper_tool_names_accepts_public_alias_surface
+        ; test_case
+            "internal bash receives public alias guidance"
+            `Quick
+            test_public_alias_guidance_blocks_internal_bash
+        ; test_case
+            "public bash does not receive alias guidance"
+            `Quick
+            test_public_alias_guidance_ignores_public_bash
+        ; test_case
+            "internal edit prefers visible Write alias"
+            `Quick
+            test_public_alias_guidance_prefers_visible_write_alias
+        ; test_case
+            "internal alias reports when public alias is not visible"
+            `Quick
+            test_public_alias_guidance_reports_alias_not_visible
         ] )
     ; ( "partial_tolerance"
       , [ test_case


### PR DESCRIPTION
## Summary
- Convert keeper-internal alias calls such as keeper_bash into pre-tool guard feedback instead of OAS Tool not found errors.
- Keep the LLM-visible tool surface public-only while still explaining the correct public alias for the current visible surface.
- Compare required-tool coverage by canonical names so required keeper_bash is satisfied when the visible public Bash alias is allowed.

## Validation
- ocamlformat --check lib/keeper/keeper_tool_disclosure.ml lib/keeper/keeper_tool_disclosure.mli lib/keeper/keeper_run_tools.ml test/test_keeper_tool_surface_guard.ml
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_tool_surface_guard.exe
- ./_build/default/test/test_keeper_tool_surface_guard.exe