### PR TITLE
fix(keeper): classify empty cascades by resolved candidates

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -307,6 +307,7 @@ let run_named
         classify_empty_candidates
           ~require_tool_choice_support
           ~require_tool_support
+          ~original_candidate_count
           ~tool_filtered_candidate_count
       in
       let classification_code =

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -92,9 +92,10 @@ type empty_candidate_classification =
   | Provider_unavailable
 
 let classify_empty_candidates ~require_tool_choice_support ~require_tool_support
-    ~tool_filtered_candidate_count =
+    ~original_candidate_count ~tool_filtered_candidate_count =
   if
     (require_tool_choice_support || require_tool_support)
+    && original_candidate_count > 0
     && tool_filtered_candidate_count = 0
   then Tool_capability_empty
   else Provider_unavailable

--- a/lib/keeper/keeper_turn_driver_helpers.mli
+++ b/lib/keeper/keeper_turn_driver_helpers.mli
@@ -42,6 +42,7 @@ type empty_candidate_classification =
 val classify_empty_candidates :
   require_tool_choice_support:bool ->
   require_tool_support:bool ->
+  original_candidate_count:int ->
   tool_filtered_candidate_count:int ->
   empty_candidate_classification
 

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -2009,18 +2009,28 @@ let test_empty_candidate_classification_separates_tool_filter_from_availability 
     (FT.classify_empty_candidates
        ~require_tool_choice_support:true
        ~require_tool_support:true
+       ~original_candidate_count:2
+       ~tool_filtered_candidate_count:0);
+  check "required tools but no resolved candidates"
+    FT.Provider_unavailable
+    (FT.classify_empty_candidates
+       ~require_tool_choice_support:true
+       ~require_tool_support:true
+       ~original_candidate_count:0
        ~tool_filtered_candidate_count:0);
   check "required tools but candidates were only unavailable"
     FT.Provider_unavailable
     (FT.classify_empty_candidates
        ~require_tool_choice_support:true
        ~require_tool_support:true
+       ~original_candidate_count:2
        ~tool_filtered_candidate_count:2);
   check "optional tools and no providers"
     FT.Provider_unavailable
     (FT.classify_empty_candidates
        ~require_tool_choice_support:false
        ~require_tool_support:false
+       ~original_candidate_count:0
        ~tool_filtered_candidate_count:0);
   Alcotest.(check string)
     "tool capability code"


### PR DESCRIPTION
## Summary
- classify empty cascade pre-dispatch failures as provider-unavailable when provider resolution produced zero candidates
- keep no_tool_capable_provider only for cascades that had resolved candidates and lost them to the tool-use gate
- extend keeper runtime manifest regression coverage for the zero-resolved-candidate case

## Verification
- ocamlformat --check lib/keeper/keeper_turn_driver_helpers.ml lib/keeper/keeper_turn_driver_helpers.mli lib/keeper/keeper_turn_driver.ml test/test_keeper_runtime_manifest.ml
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_runtime_manifest.exe
- ./_build/default/test/test_keeper_runtime_manifest.exe