### PR TITLE
fix(keeper): sync registry turn phase at provider attempt

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1850,9 +1850,47 @@ let mark_turn_cascade_exhausted ~base_path name =
      | Packed Cascade_trying -> set_cascade_state Cascade_exhausted
      | Packed Cascade_exhausted -> set_cascade_state Cascade_exhausted
      | Packed Cascade_done ->
+	       Log.Keeper.warn
+	         "registry: ignoring cascade exhaustion after Cascade_done name=%s \
+	          base_path=%s"
+	         name
+	         base_path)
+;;
+
+let mark_turn_provider_attempt_started ~base_path name =
+  let set_cascade_state cascade_state =
+    set_turn_cascade_state
+      ~base_path
+      name
+      (Packed cascade_state : packed_cascade_state)
+  in
+  match get ~base_path name with
+  | None | Some { current_turn_observation = None; _ } -> ()
+  | Some { current_turn_observation = Some obs; _ } ->
+    (match obs.cascade_state with
+     | Packed Cascade_idle ->
+       set_turn_decision_stage
+         ~base_path
+         name
+         Decision_active_tool_policy_selected;
+       set_cascade_state Cascade_selecting;
+       set_cascade_state Cascade_trying
+     | Packed Cascade_selecting ->
+       set_turn_decision_stage
+         ~base_path
+         name
+         Decision_active_tool_policy_selected;
+       set_cascade_state Cascade_trying
+     | Packed Cascade_trying ->
+       set_turn_decision_stage
+         ~base_path
+         name
+         Decision_active_tool_policy_selected
+     | Packed Cascade_done
+     | Packed Cascade_exhausted ->
        Log.Keeper.warn
-         "registry: ignoring cascade exhaustion after Cascade_done name=%s \
-          base_path=%s"
+         "registry: ignoring provider-attempt start after terminal cascade state \
+          name=%s base_path=%s"
          name
          base_path)
 ;;

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -716,6 +716,15 @@ val set_turn_cascade_state :
     when no turn is active. *)
 val mark_turn_cascade_exhausted : base_path:string -> string -> unit
 
+(** Mark that the live turn has entered a provider attempt.
+
+    This materializes the registry-side projection that corresponds to
+    [Keeper_turn_fsm.Streaming]: [Cascade_idle] advances through
+    [Cascade_selecting] into [Cascade_trying], and [turn_phase] follows to
+    [Turn_executing]. No-op when no turn is active or the cascade is already
+    trying/terminal. *)
+val mark_turn_provider_attempt_started : base_path:string -> string -> unit
+
 (** Update the live turn's phase directly. No-op if idle. *)
 val set_turn_phase :
   base_path:string -> string -> packed_turn_phase -> unit

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1070,6 +1070,9 @@ let run_keeper_cycle
                                 Keeper_id.Task_id.to_string
                                 run_meta.current_task_id)
                            (fun () ->
+                              Keeper_registry.mark_turn_provider_attempt_started
+                                ~base_path:config.base_path
+                                meta.name;
                               Keeper_turn_fsm.emit_transition
                                 ~keeper_name:meta.name
                                 ~turn_id:keeper_turn_id

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -1586,6 +1586,77 @@ let test_mark_turn_cascade_exhausted_materializes_pre_disclosure_path () =
     fail "mark_turn_cascade_exhausted cleared observation"
   | None -> fail "entry missing"
 
+let test_mark_turn_provider_attempt_started_lands_on_executing () =
+  R.clear ();
+  let keeper_name = "k-provider-attempt-started" in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  R.mark_turn_started ~base_path:bp keeper_name;
+  R.mark_turn_provider_attempt_started ~base_path:bp keeper_name;
+  match R.get ~base_path:bp keeper_name with
+  | Some { current_turn_observation = Some obs; _ } ->
+    check bool "cascade_state lands on Cascade_trying" true
+      (obs.R.cascade_state = R.Packed R.Cascade_trying);
+    check bool "turn_phase lands on Turn_executing" true
+      (obs.R.turn_phase = R.Packed R.Turn_executing);
+    check bool "decision_stage records tool policy boundary" true
+      (obs.R.decision_stage = R.Packed R.Decision_tool_policy_selected)
+  | Some { current_turn_observation = None; _ } ->
+    fail "mark_turn_provider_attempt_started cleared observation"
+  | None -> fail "entry missing"
+
+let test_mark_turn_provider_attempt_started_no_op_without_obs () =
+  R.clear ();
+  let keeper_name = "k-provider-attempt-no-obs" in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  R.mark_turn_provider_attempt_started ~base_path:bp keeper_name;
+  match R.get ~base_path:bp keeper_name with
+  | Some { current_turn_observation = None; _ } -> ()
+  | Some { current_turn_observation = Some _; _ } ->
+    fail "mark_turn_provider_attempt_started installed observation without keeper-turn"
+  | None -> fail "entry missing"
+
+let test_mark_turn_provider_attempt_started_is_idempotent () =
+  R.clear ();
+  let keeper_name = "k-provider-attempt-idempotent" in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  R.mark_turn_started ~base_path:bp keeper_name;
+  R.mark_turn_provider_attempt_started ~base_path:bp keeper_name;
+  R.mark_turn_provider_attempt_started ~base_path:bp keeper_name;
+  match R.get ~base_path:bp keeper_name with
+  | Some { current_turn_observation = Some obs; _ } ->
+    check bool "cascade_state remains Cascade_trying" true
+      (obs.R.cascade_state = R.Packed R.Cascade_trying);
+    check bool "turn_phase remains Turn_executing" true
+      (obs.R.turn_phase = R.Packed R.Turn_executing)
+  | Some { current_turn_observation = None; _ } ->
+    fail "mark_turn_provider_attempt_started cleared observation"
+  | None -> fail "entry missing"
+
+let test_mark_turn_provider_attempt_started_no_op_after_done () =
+  R.clear ();
+  let keeper_name = "k-provider-attempt-done" in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  R.mark_turn_started ~base_path:bp keeper_name;
+  R.set_turn_cascade_state
+    ~base_path:bp
+    keeper_name
+    (R.Packed R.Cascade_selecting);
+  R.set_turn_cascade_state
+    ~base_path:bp
+    keeper_name
+    (R.Packed R.Cascade_trying);
+  R.set_turn_cascade_state ~base_path:bp keeper_name (R.Packed R.Cascade_done);
+  R.mark_turn_provider_attempt_started ~base_path:bp keeper_name;
+  match R.get ~base_path:bp keeper_name with
+  | Some { current_turn_observation = Some obs; _ } ->
+    check bool "cascade_state remains Cascade_done" true
+      (obs.R.cascade_state = R.Packed R.Cascade_done);
+    check bool "decision_stage remains unchanged" true
+      (obs.R.decision_stage = R.Packed R.Decision_undecided)
+  | Some { current_turn_observation = None; _ } ->
+    fail "mark_turn_provider_attempt_started cleared observation"
+  | None -> fail "entry missing"
+
 (* The production [Assert_failure] at keeper_registry.ml:775 was triggered
    when the SDK fired [before_turn_params] for a second time inside one
    keeper-turn.  This test reproduces the same shape: two
@@ -1810,6 +1881,14 @@ let () =
             test_mark_sdk_turn_started_no_op_without_obs;
           eio_test "mark_turn_cascade_exhausted materializes pre-disclosure path"
             test_mark_turn_cascade_exhausted_materializes_pre_disclosure_path;
+          eio_test "mark_turn_provider_attempt_started lands on executing"
+            test_mark_turn_provider_attempt_started_lands_on_executing;
+          eio_test "mark_turn_provider_attempt_started no-op without observation"
+            test_mark_turn_provider_attempt_started_no_op_without_obs;
+          eio_test "mark_turn_provider_attempt_started is idempotent"
+            test_mark_turn_provider_attempt_started_is_idempotent;
+          eio_test "mark_turn_provider_attempt_started no-op after done"
+            test_mark_turn_provider_attempt_started_no_op_after_done;
           eio_test "two SDK-turn boundaries inside one keeper-turn"
             test_two_sdk_turn_boundaries_no_assert;
           eio_test "set_turn_phase rejection bumps guard metric"


### PR DESCRIPTION
## Summary

- add `Keeper_registry.mark_turn_provider_attempt_started` to materialize the registry-side provider-attempt boundary
- advance live turn observation from `Cascade_idle`/`Cascade_selecting` to `Cascade_trying`, which derives `Turn_executing`, before `Keeper_turn_fsm.Streaming` is emitted
- keep the helper defensive: no-op without an active observation, idempotent while already trying, and no mutation after terminal cascade states

## Why

DD-022 found that the typed turn FSM emitted `Streaming` at provider-attempt start, but the registry/dashboard projection could remain in `Turn_prompting` until cascade completion. That left live keeper surfaces stale during actual provider work.

## Validation

- `ocamlformat --check lib/keeper/keeper_registry.mli lib/keeper/keeper_registry.ml lib/keeper/keeper_unified_turn.ml test/test_keeper_registry.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_registry.exe test/test_keeper_unified.exe test/test_keeper_fsm_joints.exe test/test_keeper_turn_fsm_emit.exe`
- `scripts/dune-local.sh exec test/test_keeper_registry.exe` (86 tests)
- `scripts/dune-local.sh exec test/test_keeper_fsm_joints.exe` (14 tests)
- `scripts/dune-local.sh exec test/test_keeper_turn_fsm_emit.exe` (13 tests)

Attempted:

- `scripts/dune-local.sh exec test/test_keeper_unified.exe` still fails one pre-existing local fixture/config alias case: `phase_gate 8 async keeper_msg preflight` cannot resolve `tier-group.primary` because `qwen3-5` / `openai_compat.qwen3-5.for-keeper-turn` is missing. The failure happens during cascade config resolution before the provider-attempt registry transition added here.
