### PR TITLE
fix(cascade): dedupe automatic max token clamp warnings

### DIFF
--- a/lib/cascade/cascade_metrics.mli
+++ b/lib/cascade/cascade_metrics.mli
@@ -291,10 +291,11 @@ val on_cascade_metrics_eviction : unit -> unit
     [cascade_max_keys] or canonicalize synthesized names. *)
 
 val on_max_tokens_clamped : unit -> unit
-(** Legacy iter-46 counter retained for metric compatibility. DD-020
-    replaced runtime max_tokens clipping with the structured
-    [max_tokens_ceiling_violation] pre-dispatch error, so current code
-    paths should not emit this counter. *)
+(** Tick when an automatically-derived max_tokens fallback is reduced to the
+    resolved cascade output ceiling. Repeated clamps are counted here even
+    when the corresponding WARN log is deduplicated. Explicit cascade.toml or
+    caller-provided over-ceiling values still use the structured
+    [max_tokens_ceiling_violation] pre-dispatch error instead. *)
 
 val on_cascade_audit_failure : stage:string -> unit
 (** Tick the cascade-audit subsystem failure counter at

--- a/lib/cascade_inference.ml
+++ b/lib/cascade_inference.ml
@@ -90,17 +90,43 @@ let resolve_temperature
   | Some t -> t
   | None -> fallback ()
 
+let auto_max_tokens_clamp_seen : (string, unit) Hashtbl.t = Hashtbl.create 16
+let auto_max_tokens_clamp_seen_mutex = Mutex.create ()
+
+let auto_max_tokens_clamp_key ~cascade_name ~source ~max_tokens ~ceiling =
+  Printf.sprintf
+    "%s\x1f%s\x1f%d\x1f%d"
+    (Keeper_cascade_profile.runtime_name_to_string cascade_name)
+    source
+    max_tokens
+    ceiling
+
+let mark_auto_max_tokens_clamp_seen key =
+  Mutex.protect auto_max_tokens_clamp_seen_mutex (fun () ->
+    if Hashtbl.mem auto_max_tokens_clamp_seen key
+    then false
+    else (
+      Hashtbl.replace auto_max_tokens_clamp_seen key ();
+      true))
+
+let should_log_auto_max_tokens_clamp ~cascade_name ~source ~max_tokens ~ceiling =
+  auto_max_tokens_clamp_key ~cascade_name ~source ~max_tokens ~ceiling
+  |> mark_auto_max_tokens_clamp_seen
+
 (** Cap an automatically-derived max_tokens value to the narrowest output
     ceiling in the resolved cascade. Explicit caller-provided overrides and
     cascade.toml values stay hard rejected by the pre-dispatch validator. *)
 let cap_auto_resolved_max_tokens ~cascade_name ~source max_tokens =
   match Cascade_runtime.max_output_tokens_ceiling_of_cascade_name cascade_name with
   | Some ceiling when ceiling > 0 && max_tokens > ceiling ->
-    Log.warn ~ctx:"cascade"
-      "%s: auto-resolved max_tokens=%d from %s exceeds output ceiling=%d; \
-       using ceiling"
-      (Keeper_cascade_profile.runtime_name_to_string cascade_name)
-      max_tokens source ceiling;
+    Cascade_metrics.on_max_tokens_clamped ();
+    if should_log_auto_max_tokens_clamp ~cascade_name ~source ~max_tokens ~ceiling
+    then
+      Log.warn ~ctx:"cascade"
+        "%s: auto-resolved max_tokens=%d from %s exceeds output ceiling=%d; \
+         using ceiling; suppressing repeats for this tuple"
+        (Keeper_cascade_profile.runtime_name_to_string cascade_name)
+        max_tokens source ceiling;
     ceiling
   | _ -> max_tokens
 
@@ -148,3 +174,12 @@ let validate_max_tokens_within_ceiling
         ~reason:"requested_exceeds_provider_ceiling"
         ~provider_ceiling:ceiling
     else Ok max_tokens
+
+module For_testing = struct
+  let reset_auto_max_tokens_clamp_warnings () =
+    Mutex.protect auto_max_tokens_clamp_seen_mutex (fun () ->
+      Hashtbl.clear auto_max_tokens_clamp_seen)
+
+  let should_log_auto_max_tokens_clamp =
+    should_log_auto_max_tokens_clamp
+end

--- a/lib/cascade_inference.mli
+++ b/lib/cascade_inference.mli
@@ -62,3 +62,14 @@ val validate_max_tokens_within_ceiling :
   provider_ceiling:int option ->
   int ->
   (int, Cascade_error_classify.masc_internal_error) result
+
+module For_testing : sig
+  val reset_auto_max_tokens_clamp_warnings : unit -> unit
+
+  val should_log_auto_max_tokens_clamp :
+    cascade_name:Keeper_cascade_profile.runtime_name ->
+    source:string ->
+    max_tokens:int ->
+    ceiling:int ->
+    bool
+end

--- a/test/test_cascade_capability_gate.ml
+++ b/test/test_cascade_capability_gate.ml
@@ -8,8 +8,10 @@ open Alcotest
 module CI = Masc_mcp.Cascade_inference
 module CE = Masc_mcp.Cascade_error_classify
 module CR = Masc_mcp.Cascade_runtime
+module P = Masc_mcp.Prometheus
 
 let cascade_name = Masc_mcp.Keeper_cascade_profile.Runtime_name "keeper_unified"
+let metric_max_tokens_clamped = "masc_cascade_max_tokens_clamped_total"
 
 let validate ?(provider_ceiling = Some 40960) max_tokens =
   CI.validate_max_tokens_within_ceiling
@@ -191,13 +193,55 @@ target = "tier-group.strict_tool_candidates"
     (fun () ->
       let ceiling = CR.max_output_tokens_ceiling_of_cascade_name cascade_name in
       check (option int) "mixed cascade output ceiling" (Some 16384) ceiling;
+      let before =
+        P.metric_value_or_zero metric_max_tokens_clamped ()
+      in
       let resolved =
         CI.resolve_max_tokens ~cascade_name ~fallback:(fun () -> 65536)
       in
       check int "automatic max_tokens capped to ceiling" 16384 resolved;
+      let resolved_again =
+        CI.resolve_max_tokens ~cascade_name ~fallback:(fun () -> 65536)
+      in
+      check int "repeat automatic max_tokens capped to ceiling" 16384 resolved_again;
+      check
+        (float 0.0001)
+        "clamp metric counts every automatic clamp"
+        (before +. 2.0)
+        (P.metric_value_or_zero metric_max_tokens_clamped ());
       CI.validate_max_tokens_within_ceiling ~cascade_name
         ~provider_ceiling:ceiling resolved
       |> check_ok "capped value accepted" 16384)
+
+let test_auto_max_tokens_clamp_warning_dedupes_by_tuple () =
+  CI.For_testing.reset_auto_max_tokens_clamp_warnings ();
+  check
+    bool
+    "first tuple logs"
+    true
+    (CI.For_testing.should_log_auto_max_tokens_clamp
+       ~cascade_name
+       ~source:"fallback"
+       ~max_tokens:65536
+       ~ceiling:16384);
+  check
+    bool
+    "same tuple suppressed"
+    false
+    (CI.For_testing.should_log_auto_max_tokens_clamp
+       ~cascade_name
+       ~source:"fallback"
+       ~max_tokens:65536
+       ~ceiling:16384);
+  check
+    bool
+    "different ceiling logs"
+    true
+    (CI.For_testing.should_log_auto_max_tokens_clamp
+       ~cascade_name
+       ~source:"fallback"
+       ~max_tokens:65536
+       ~ceiling:8192)
 
 let test_resolve_provider_derived_max_tokens_matches_failover_ceiling () =
   with_temp_cascade_toml
@@ -310,6 +354,10 @@ let () =
         "automatic max_tokens respects mixed failover ceiling"
         `Quick
         test_resolve_max_tokens_caps_automatic_value_to_cascade_ceiling;
+      test_case
+        "automatic max_tokens clamp warning dedupes by tuple"
+        `Quick
+        test_auto_max_tokens_clamp_warning_dedupes_by_tuple;
       test_case
         "provider-derived max_tokens matches failover ceiling"
         `Quick


### PR DESCRIPTION
## Summary
- keep automatic max_tokens fallback clamping to provider output ceilings
- emit the clamp WARN only once per cascade/source/requested/ceiling tuple
- count every repeated clamp with `masc_cascade_max_tokens_clamped_total` so dashboards keep rate visibility without log spam

## Runtime Evidence
- repeated 24h WARN sample: `auto-resolved max_tokens=65536 from fallback exceeds output ceiling=16384; using ceiling` across `tier.ollama_cloud_primary`, `ollama_cloud_primary`, and `direct_api_manual`
- root cause: `Cascade_inference.cap_auto_resolved_max_tokens` logged on every automatic fallback clamp even though runtime behavior was already safe

## Verification
- `ocamlformat --check lib/cascade_inference.ml lib/cascade_inference.mli lib/cascade/cascade_metrics.mli test/test_cascade_capability_gate.ml`
- `git diff --check`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_cascade_capability_gate.exe`
- `./_build/default/test/test_cascade_capability_gate.exe`