### PR TITLE
feat(ide): summarize activity context routes

### DIFF
--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -174,6 +174,7 @@ describe('IdeActivityPanel', () => {
     expect(window.location.hash).toBe('#monitoring?section=agents&view=keepers&keeper=sangsu')
 
     const activityRouteLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-activity-route-link')]
+    expect(container.querySelector('.ide-activity-route-count')?.textContent).toBe('CTX 10')
     expect(activityRouteLinks.map(link => link.textContent)).toEqual([
       'Code',
       'Goal',
@@ -318,6 +319,7 @@ describe('IdeActivityPanel', () => {
     })
 
     const activityRouteLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-activity-route-link')]
+    expect(container.querySelector('.ide-activity-route-count')?.textContent).toBe('CTX 10')
     expect(activityRouteLinks.map(link => link.textContent)).toEqual([
       'Code',
       'Goal',
@@ -571,6 +573,7 @@ describe('IdeActivityPanel', () => {
       expect(container.textContent).toContain('telemetry.turn')
     })
     expect(container.querySelector('.ide-activity-context-jump')).toBeNull()
+    expect(container.querySelector('.ide-activity-route-count')?.textContent).toBe('CTX 3')
     expect([...container.querySelectorAll<HTMLButtonElement>('.ide-activity-route-link')]
       .map(link => link.textContent)).toEqual(['Log', 'Telemetry', 'Keeper'])
     fireEvent.click(container.querySelectorAll<HTMLButtonElement>('.ide-activity-route-link')[1]!)

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -898,6 +898,7 @@ function ActivityRow(
         ` : null}
         ${routeLinks.length > 0 ? html`
           <div class="ide-activity-route-links" aria-label="Activity operational links">
+            <${ActivityRouteCount} count=${routeLinks.length} />
             ${routeLinks.map(link => ActivityRouteLink(link))}
           </div>
         ` : null}
@@ -930,6 +931,18 @@ function ActivityRouteLink(link: IdeContextRouteLink) {
     >
       ${link.label}
     </button>
+  `
+}
+
+function ActivityRouteCount({ count }: { count: number }) {
+  return html`
+    <span
+      class="ide-activity-route-count"
+      title=${`${count} linked activity context routes`}
+      aria-label=${`${count} linked activity context routes`}
+    >
+      CTX ${count}
+    </span>
   `
 }
 

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -2179,9 +2179,26 @@ button.ide-persistence-focus:focus-visible {
 
 .ide-activity-route-links {
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
   gap: 3px;
   min-width: 0;
+}
+
+.ide-activity-route-count {
+  display: inline-flex;
+  align-items: center;
+  height: 17px;
+  padding: 0 5px;
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--r-1);
+  background: var(--color-bg-canvas);
+  color: var(--color-fg-muted);
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  font-weight: 700;
+  line-height: 1;
 }
 
 .ide-activity-route-link {


### PR DESCRIPTION
## Summary

- add a compact `CTX N` count chip to Activity rail operational route rows
- keep existing Code/Goal/Task/Board/Comment/PR/Git/Log/Telemetry/Keeper route buttons unchanged
- cover rich and log-only activity contexts in focused dashboard tests

## Validation

- `pnpm install --offline`
- `pnpm exec vitest run src/components/ide/ide-activity-panel.test.ts src/components/ide/ide-activity-panel.a11y.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/ide/ide-activity-panel.ts src/components/ide/ide-activity-panel.test.ts src/components/ide/ide-activity-panel.a11y.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`
