### PR TITLE
fix(task-sandbox): resolve docker-visible worktree paths

### DIFF
--- a/lib/task_sandbox.ml
+++ b/lib/task_sandbox.ml
@@ -52,6 +52,7 @@ let rel_worktree_re =
   Re.Pcre.re {|((?:[^ \t\n\r:]+/)?\.worktrees/[^ \t\n\r]+)|} |> Re.compile
 ;;
 let branch_name_re = Re.Pcre.re {|Branch: ([^ \t\n\r]+)|} |> Re.compile
+let repo_name_re = Re.Pcre.re {|Repo: ([^ \t\n\r]+)|} |> Re.compile
 
 (** Extract absolute worktree path from [Coord_worktree.worktree_create_r]
     success message. Tries "Path: <absolute>" first, then falls back to
@@ -73,20 +74,72 @@ let extract_branch_name msg =
   | None -> None
 ;;
 
-(** Symlink [.masc/] from the repo root into the worktree for read-only
+let extract_repo_name msg =
+  match Re.exec_opt repo_name_re msg with
+  | Some g -> Some (Re.Group.get g 1)
+  | None -> None
+;;
+
+let safe_file_exists path =
+  try Sys.file_exists path with
+  | Sys_error _ -> false
+;;
+
+let safe_is_directory path =
+  try Sys.file_exists path && Sys.is_directory path with
+  | Sys_error _ -> false
+;;
+
+let host_worktree_path ~config ~agent_name ~task_id ~repo_name =
+  let repo_root =
+    Filename.concat (Coord_worktree.repos_dir_of_keeper config agent_name) repo_name
+  in
+  Filename.concat
+    repo_root
+    (Filename.concat ".worktrees" (Playground_paths.worktree_dir_name agent_name task_id))
+;;
+
+let resolve_created_worktree_path ~config ~agent_name ~task_id ~response_path ~repo_name =
+  let host_candidate =
+    Option.map
+      (fun repo_name -> host_worktree_path ~config ~agent_name ~task_id ~repo_name)
+      repo_name
+  in
+  match
+    List.filter_map (fun x -> x) [ response_path; host_candidate ]
+    |> List.sort_uniq String.compare
+    |> List.find_opt safe_is_directory
+  with
+  | Some path -> Ok path
+  | None ->
+    Error
+      (Printf.sprintf
+         "worktree created but host path does not exist: response_path=%s host_candidate=%s"
+         (Option.value response_path ~default:"<missing>")
+         (Option.value host_candidate ~default:"<missing>"))
+;;
+
+(** Symlink [.masc/] from the active runtime base into the worktree for read-only
     access to room state. Idempotent: does nothing if link already exists. *)
-let symlink_masc ~repo_root ~worktree_path =
-  let masc_source = Common.masc_dir_from_base_path ~base_path:repo_root in
+let symlink_masc ~base_path ~worktree_path =
+  let masc_source = Common.masc_dir_from_base_path ~base_path in
   let masc_target = Common.masc_dir_from_base_path ~base_path:worktree_path in
-  if Sys.file_exists masc_source && not (Sys.file_exists masc_target)
-  then (
+  if not (safe_is_directory masc_source)
+  then Error (Printf.sprintf "active .masc source is missing: %s" masc_source)
+  else if safe_file_exists masc_target
+  then Ok ()
+  else
     try
       Unix.symlink masc_source masc_target;
       Ok ()
     with
     | Unix.Unix_error (e, _, _) ->
-      Error (Printf.sprintf "symlink .masc failed: %s" (Unix.error_message e)))
-  else Ok ()
+      Error
+        (Printf.sprintf
+           "symlink .masc failed: source=%s target=%s error=%s"
+           masc_source
+           masc_target
+           (Unix.error_message e))
 ;;
 
 let create ~config ~task_id ?(base_branch = "main") ?repo_name ~agent_name () =
@@ -105,26 +158,26 @@ let create ~config ~task_id ?(base_branch = "main") ?repo_name ~agent_name () =
       (Printf.sprintf "worktree creation failed: %s" (Masc_domain.masc_error_to_string e))
   | Ok msg ->
     let base_path = config.base_path in
-    (match extract_worktree_path ~base_path msg with
-     | None ->
-       Error (Printf.sprintf "worktree created but path not found in response: %s" msg)
-     | Some worktree_path ->
+    (match
+       resolve_created_worktree_path
+         ~config
+         ~agent_name
+         ~task_id
+         ~response_path:(extract_worktree_path ~base_path msg)
+         ~repo_name:(extract_repo_name msg)
+     with
+     | Error e -> Error (Printf.sprintf "%s; response=%s" e msg)
+     | Ok worktree_path ->
        let branch_name =
          extract_branch_name msg
          |> Option.value
               ~default:(Playground_paths.worktree_branch_name agent_name task_id)
        in
-       (* Resolve git root for symlink *)
-       let repo_root =
-         match Coord_git.git_root ~base_path with
-         | Some r -> r
-         | None -> base_path
-       in
        (* Symlink .masc/ into the worktree *)
-       (match symlink_masc ~repo_root ~worktree_path with
-        | Error e -> Log.Misc.warn "[task_sandbox] %s" e
-        | Ok () -> ());
-       Ok { task_id; worktree_path; branch_name; created_at = Time_compat.now () })
+       (match symlink_masc ~base_path ~worktree_path with
+        | Error e -> Error e
+        | Ok () ->
+          Ok { task_id; worktree_path; branch_name; created_at = Time_compat.now () }))
 ;;
 
 let changed_files sandbox =

--- a/test/test_task_sandbox.ml
+++ b/test/test_task_sandbox.ml
@@ -172,6 +172,25 @@ let run_cmd cmd =
   if exit_code <> 0 then
     failwith (Printf.sprintf "command failed (exit %d): %s" exit_code cmd)
 
+let write_file path content =
+  Fs_compat.mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
+    output_string oc content)
+
+let write_keeper_toml ~base_path ~name ~sandbox_profile =
+  let keepers_dir =
+    Filename.concat
+      (Filename.concat (Common.masc_dir_from_base_path ~base_path) "config")
+      "keepers"
+  in
+  write_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    (Printf.sprintf
+       "[keeper]\npersona_name = %S\nsandbox_profile = %S\n"
+       name
+       sandbox_profile)
+
 let seed_playground_clone ~base_path ~agent_name ~source_repo =
   let repos_dir =
     Filename.concat base_path
@@ -418,6 +437,78 @@ let test_create_infers_repo_from_task_file_evidence () =
              | None -> fail "expected linked worktree metadata");
             ignore
               (Task_sandbox.cleanup ~config ~agent_name:"router-agent" sb)))
+
+let test_create_resolves_docker_visible_path_to_host_worktree () =
+  let base = make_temp_dir () in
+  let dir = base in
+  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
+  let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
+  Fun.protect
+    ~finally:(fun () ->
+      (match saved_base with
+       | Some v -> Unix.putenv "MASC_BASE_PATH" v
+       | None -> Unix.putenv "MASC_BASE_PATH" "");
+      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
+    (fun () ->
+      Eio_main.run (fun env ->
+        Fs_compat.set_fs (Eio.Stdenv.fs env);
+        run_cmd (Printf.sprintf "git init -q -b main %s" (Filename.quote dir));
+        let proc_mgr = Eio.Stdenv.process_mgr env in
+        let clock = Eio.Stdenv.clock env in
+        let cwd = Eio.Stdenv.cwd env in
+        Process_eio.init ~cwd_default:cwd ~proc_mgr ~clock;
+
+        Unix.putenv "MASC_BASE_PATH" dir;
+        let config = Coord.default_config dir in
+        let _msg = Coord.init config ~agent_name:None in
+        write_keeper_toml
+          ~base_path:dir
+          ~name:"docker-agent"
+          ~sandbox_profile:"docker";
+        let _join =
+          Coord.join config ~agent_name:"docker-agent" ~capabilities:[ "test" ] ()
+        in
+        let source_repo =
+          setup_named_repo_with_file
+            ~base_path:dir
+            ~repo_name:"masc-mcp"
+            ~file_path:"README.md"
+        in
+        let docker_repos_dir =
+          Filename.concat
+            (Common.masc_dir_from_base_path ~base_path:dir)
+            "playground/docker/docker-agent/repos"
+        in
+        Fs_compat.mkdir_p docker_repos_dir;
+        let docker_clone = Filename.concat docker_repos_dir "masc-mcp" in
+        run_cmd
+          (Printf.sprintf
+             "git clone %s %s"
+             (Filename.quote source_repo)
+             (Filename.quote docker_clone));
+        let task_id = "task-docker-visible" in
+        let expected_worktree =
+          Filename.concat
+            docker_clone
+            (Filename.concat
+               ".worktrees"
+               (Playground_paths.worktree_dir_name "docker-agent" task_id))
+        in
+        match
+          Task_sandbox.create
+            ~config
+            ~task_id
+            ~agent_name:"docker-agent"
+            ~repo_name:"masc-mcp"
+            ()
+        with
+        | Error e -> fail (Printf.sprintf "sandbox create failed: %s" e)
+        | Ok sb ->
+          check string "returns host worktree path" expected_worktree sb.worktree_path;
+          check bool "host worktree exists" true (Sys.file_exists sb.worktree_path);
+          check bool "linked .masc at host worktree" true
+            (Sys.file_exists (Filename.concat sb.worktree_path Common.masc_dirname));
+          ignore (Task_sandbox.cleanup ~config ~agent_name:"docker-agent" sb)))
 
 let test_create_fails_ambiguous_multi_repo_without_evidence () =
   let base = make_temp_dir () in
@@ -699,6 +790,8 @@ let () =
       test_case "full_lifecycle" `Quick test_full_lifecycle;
       test_case "infer_repo_from_task_file_evidence" `Quick
         test_create_infers_repo_from_task_file_evidence;
+      test_case "docker_visible_path_resolves_to_host" `Quick
+        test_create_resolves_docker_visible_path_to_host_worktree;
       test_case "ambiguous_multi_repo_without_evidence" `Quick
         test_create_fails_ambiguous_multi_repo_without_evidence;
       test_case "infer_repo_from_task_repo_mentions" `Quick


### PR DESCRIPTION
## Summary
- resolve Task_sandbox worktree paths back to host paths when Coord_worktree returns docker-visible cwd paths
- fail sandbox creation when the host worktree or active .masc symlink cannot be established, instead of warning and continuing into repeated cwd/config errors
- add a docker keeper lane regression test that verifies the returned path and .masc symlink are host-valid

## Runtime evidence
- observed repeated [task_sandbox] symlink .masc failed: No such file or directory in ~/.masc/logs/system_log_2026-05-14.jsonl
- same window had downstream docker errors for missing .masc/config and missing repos/<repo>/.worktrees/<task> cwd

## Validation
- ocamlformat --check lib/task_sandbox.ml test/test_task_sandbox.ml
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_task_sandbox.exe
- ./_build/default/test/test_task_sandbox.exe