### PR TITLE
fix(cascade): hydrate persisted routing hints

### DIFF
--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -341,6 +341,9 @@ type provider_restore = {
   restore_cooldown_until : float option;
   restore_last_failure_at : float option;
   restore_top_fingerprints : (string * int) list;
+  restore_latency_ms : float option;
+  restore_confidence : float option;
+  restore_cost_usd : float option;
 }
 
 (* ── Constructor ──────────────────────────────── *)
@@ -403,6 +406,38 @@ let finite_positive = function
   | Some value when Float.is_finite value && value > 0.0 -> Some value
   | _ -> None
 
+let restore_latency_sample state = function
+  | Some lat_ms when latency_ring_size > 0
+                     && Float.is_finite lat_ms
+                     && lat_ms > 0.0 ->
+    let ring = Array.make latency_ring_size 0.0 in
+    ring.(0) <- lat_ms;
+    state.latency_ring <- Some ring;
+    state.latency_count <- 1;
+    state.latency_cursor <- (if latency_ring_size = 1 then 0 else 1)
+  | _ -> ()
+
+let restore_confidence_sample state = function
+  | Some confidence when confidence_ring_size > 0
+                         && Float.is_finite confidence ->
+    let ring = Array.make confidence_ring_size 0.0 in
+    ring.(0) <- confidence;
+    state.confidence_ring <- Some ring;
+    state.confidence_count <- 1;
+    state.confidence_cursor <- (if confidence_ring_size = 1 then 0 else 1)
+  | _ -> ()
+
+let restore_cost_sample state = function
+  | Some cost_usd when cost_ring_size > 0
+                       && Float.is_finite cost_usd
+                       && cost_usd >= 0.0 ->
+    let ring = Array.make cost_ring_size 0.0 in
+    ring.(0) <- cost_usd;
+    state.cost_ring <- Some ring;
+    state.cost_count <- 1;
+    state.cost_cursor <- (if cost_ring_size = 1 then 0 else 1)
+  | _ -> ()
+
 let restore_providers t providers =
   with_lock t (fun () ->
     let now = Unix.gettimeofday () in
@@ -429,6 +464,9 @@ let restore_providers t providers =
               if (not (String.equal fp "")) && count > 0
               then Hashtbl.replace state.fingerprint_counts fp count)
             row.restore_top_fingerprints;
+          restore_latency_sample state row.restore_latency_ms;
+          restore_confidence_sample state row.restore_confidence;
+          restore_cost_sample state row.restore_cost_usd;
           restored + 1))
       0
       providers)

--- a/lib/cascade/cascade_health_tracker.mli
+++ b/lib/cascade/cascade_health_tracker.mli
@@ -106,16 +106,20 @@ val create : unit -> t
 
 (** Durable provider state that can be restored after process restart.
 
-    This intentionally excludes rolling-window events and latency/cost rings:
-    those are short-lived routing signals. Cooldown, failure count, and error
-    fingerprints are enough to prevent a restart from immediately retrying a
-    provider that was just circuit-broken. *)
+    Cooldown, failure count, and error fingerprints prevent a restart from
+    immediately retrying a provider that was just circuit-broken.  The optional
+    routing hints seed the bounded latency/confidence/cost rings from the last
+    persisted snapshot so weighted cascade selection does not restart with a
+    fully cold view of recent provider performance. *)
 type provider_restore = {
   restore_provider_key : string;
   restore_consecutive_failures : int;
   restore_cooldown_until : float option;
   restore_last_failure_at : float option;
   restore_top_fingerprints : (string * int) list;
+  restore_latency_ms : float option;
+  restore_confidence : float option;
+  restore_cost_usd : float option;
 }
 
 (** Restore durable provider state into a tracker.

--- a/lib/cascade/cascade_trust_persist.ml
+++ b/lib/cascade/cascade_trust_persist.ml
@@ -41,6 +41,10 @@ let get_or_create_store ~base_path : Dated_jsonl.t =
 (* ── Serialization ──────────────────────────────────── *)
 
 let provider_info_to_json (info : H.provider_info) : Yojson.Safe.t =
+  let opt_float = function
+    | Some v when Float.is_finite v -> `Float v
+    | _ -> `Null
+  in
   let fingerprints =
     `List
       (List.map
@@ -67,6 +71,14 @@ let provider_info_to_json (info : H.provider_info) : Yojson.Safe.t =
     ; ("cooldown_expires_at", cooldown_expires_at)
     ; ("events_in_window", `Int info.events_in_window)
     ; ("rejected_in_window", `Int info.rejected_in_window)
+    ; ("p50_latency_ms", opt_float info.p50_latency_ms)
+    ; ("p95_latency_ms", opt_float info.p95_latency_ms)
+    ; ("latency_samples", `Int info.latency_samples)
+    ; ("avg_confidence", opt_float info.avg_confidence)
+    ; ("confidence_samples", `Int info.confidence_samples)
+    ; ("avg_cost_usd", opt_float info.avg_cost_usd)
+    ; ("cost_samples", `Int info.cost_samples)
+    ; ("health_score", `Float info.health_score)
     ; ("top_fingerprints", fingerprints)
     ; ("last_failure_at", last_failure_at)
     ]
@@ -119,6 +131,9 @@ let restore_provider_of_json json =
         ; restore_cooldown_until
         ; restore_last_failure_at
         ; restore_top_fingerprints
+        ; restore_latency_ms = json |> member "p50_latency_ms" |> float_opt
+        ; restore_confidence = json |> member "avg_confidence" |> float_opt
+        ; restore_cost_usd = json |> member "avg_cost_usd" |> float_opt
         }
   | _ -> None
 

--- a/lib/cascade/cascade_trust_persist.mli
+++ b/lib/cascade/cascade_trust_persist.mli
@@ -12,8 +12,9 @@
 
     Companion to Phase 0a observability (PR #10292) — fingerprint counter
     in {!Cascade_health_tracker} captures the *what*, this module
-    captures the *over time*.  Phase 1 (in-memory trust_score) consumes
-    these snapshots offline to calibrate reward / decay defaults.
+    captures the *over time*.  Hydration restores durable cooldown/failure
+    state plus the latest bounded routing hints, so cascade selection does
+    not restart with a cold latency/cost view after a process restart.
 
     Best-effort: I/O failures are logged but never propagated.
 
@@ -29,9 +30,9 @@ val snapshot_now : base_path:string -> unit
     Used by the tick fiber and shutdown hook. *)
 
 val hydrate_latest : base_path:string -> int
-(** Restore provider cooldown/failure state from the latest JSONL snapshot.
-    Returns the number of provider rows applied. Best-effort: malformed or
-    missing snapshots return [0]. *)
+(** Restore provider cooldown/failure state and routing hints from the latest
+    JSONL snapshot.  Returns the number of provider rows applied. Best-effort:
+    malformed or missing snapshots return [0]. *)
 
 val start_snapshot_fiber :
   sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> base_path:string -> unit

--- a/test/test_cascade_health_tracker.ml
+++ b/test/test_cascade_health_tracker.ml
@@ -768,6 +768,9 @@ let test_restore_providers_reinstates_active_cooldown () =
         ; restore_cooldown_until = Some until
         ; restore_last_failure_at = Some (until -. 10.0)
         ; restore_top_fingerprints = [ "timeout|abc12345", 2 ]
+        ; restore_latency_ms = None
+        ; restore_confidence = None
+        ; restore_cost_usd = None
         }
       ]
   in
@@ -792,6 +795,9 @@ let test_restore_providers_ignores_blank_provider_key () =
         ; restore_cooldown_until = Some (Unix.gettimeofday () +. 60.0)
         ; restore_last_failure_at = None
         ; restore_top_fingerprints = []
+        ; restore_latency_ms = None
+        ; restore_confidence = None
+        ; restore_cost_usd = None
         }
       ]
   in

--- a/test/test_cascade_trust_persist.ml
+++ b/test/test_cascade_trust_persist.ml
@@ -13,6 +13,7 @@
 open Alcotest
 module H = Masc_mcp.Cascade_health_tracker
 module P = Masc_mcp.Cascade_trust_persist
+module S = Masc_mcp.Cascade_strategy
 
 let kind value = H.error_kind_of_string value
 
@@ -147,14 +148,30 @@ let test_snapshot_provider_record_shape () =
           ; "in_cooldown"
           ; "events_in_window"
           ; "rejected_in_window"
+          ; "p50_latency_ms"
+          ; "p95_latency_ms"
+          ; "latency_samples"
+          ; "avg_confidence"
+          ; "confidence_samples"
+          ; "avg_cost_usd"
+          ; "cost_samples"
+          ; "health_score"
           ; "top_fingerprints"
           ; "last_failure_at"
+          ]
+        in
+        let nullable_fields =
+          [ "last_failure_at"
+          ; "p50_latency_ms"
+          ; "p95_latency_ms"
+          ; "avg_confidence"
+          ; "avg_cost_usd"
           ]
         in
         List.iter
           (fun field ->
             match member field p with
-            | `Null when field = "last_failure_at" -> ()
+            | `Null when List.mem field nullable_fields -> ()
             | `Null -> fail (Printf.sprintf "field %s missing" field)
             | _ -> ())
           required_fields;
@@ -169,6 +186,29 @@ let test_snapshot_provider_record_shape () =
             (String.length fp_str >= String.length "timeout"
              && String.sub fp_str 0 (String.length "timeout") = "timeout")
         | [] -> fail "unreachable")
+
+let test_hydrate_latest_restores_latency_hint_from_snapshot () =
+  with_temp_base (fun dir ->
+    let key = "test_hydrate_latency:" ^ string_of_int (Random.bits ()) in
+    H.record_success H.global ~provider_key:key ~latency_ms:8000.0 ();
+    P.snapshot_now ~base_path:dir;
+    for _ = 1 to 20 do
+      H.record_success H.global ~provider_key:key ~latency_ms:10.0 ()
+    done;
+    let warm_score = S.latency_score_for_provider H.global ~provider_key:key in
+    check bool "fast samples warm latency score" true (warm_score > 0.9);
+    let restored = P.hydrate_latest ~base_path:dir in
+    check bool "hydrate applied at least one row" true (restored > 0);
+    let restored_score =
+      S.latency_score_for_provider H.global ~provider_key:key
+    in
+    check bool "hydrate restores slow p50 routing penalty"
+      true (restored_score < 0.5);
+    match H.provider_info H.global ~provider_key:key with
+    | None -> fail "missing hydrated provider"
+    | Some info ->
+      check (option (float 0.001)) "restored p50 latency"
+        (Some 8000.0) info.p50_latency_ms)
 
 let test_two_snapshots_produce_two_records () =
   with_temp_base (fun dir ->
@@ -228,6 +268,8 @@ let () =
             test_snapshot_includes_recorded_provider
         ; test_case "provider record has expected shape" `Quick
             test_snapshot_provider_record_shape
+        ; test_case "hydrate restores latency hint" `Quick
+            test_hydrate_latest_restores_latency_hint_from_snapshot
         ; test_case "two calls → two records" `Quick
             test_two_snapshots_produce_two_records
         ; test_case "no throw on empty tracker" `Quick


### PR DESCRIPTION
## Summary
- persist latency/confidence/cost routing hints in cascade trust snapshots
- hydrate those hints back into Cascade_health_tracker after restart so weighted cascade selection keeps recent p50 latency signal
- add regression coverage for hydrated latency affecting Cascade_strategy latency scoring

## Verification
- scripts/dune-local.sh build test/test_cascade_trust_persist.exe test/test_cascade_health_tracker.exe test/test_cascade_strategy.exe
- ./_build/default/test/test_cascade_trust_persist.exe
- ./_build/default/test/test_cascade_health_tracker.exe
- ./_build/default/test/test_cascade_strategy.exe
- git diff --check