### PR TITLE
docs(memory): align OAS bridge hook-first state

### DIFF
--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -332,7 +332,7 @@ Profile별 종류당 보존 상한:
 
 ### 6.5 OAS Memory Bridge
 
-`run_turn`에서 `Memory_oas_bridge.create_memory`로 institution / procedures / memory bank / episodes 계층을 seed한다. 턴 후 영속화는 분리된다: memory bank는 `append_memory_notes_from_reply`, episode는 `store_episode_from_snapshot` + `flush_incremental`, hebbian은 별도의 task lifecycle에서 기록된다.
+`run_turn`은 `Memory_oas_bridge.create_memory`로 filesystem-first JSONL `long_term_backend`가 연결된 OAS `Memory.t`를 만든다. Institution / procedural / world memory는 imperative seed가 아니라 `load_*_text` hook-first prompt injection으로 읽고, 턴 후에는 memory bank가 `append_memory_notes_from_reply`, episode/procedure가 `store_episode_from_snapshot` + `flush_incremental`, hebbian이 별도 task lifecycle에서 기록된다.
 
 ---
 
@@ -575,7 +575,7 @@ Keeper turn에서 어떤 "skill" 경로를 사용할지 결정:
 
 ### 15.6 OAS Memory Bridge 부분 통합
 
-MASC 자체 memory 4개(memory_stream, institution, procedural, context_manager)가 OAS Memory.t(3-tier: Scratchpad/Working/Long_term)와 별도로 운영된다. `long_term_backend` callback 연결이 미완.
+MASC memory bank / institution / procedural memory는 아직 MASC가 소유하지만, OAS `Memory.t` 5-tier와의 경계는 `memory_oas_bridge.ml`에 있다. `long_term_backend` callback은 filesystem JSONL로 연결됐고, 남은 경계 이슈는 keeper context/checkpoint nativeization과 raw marker leakage다.
 
 ---
 

--- a/docs/spec/12-memory-systems.md
+++ b/docs/spec/12-memory-systems.md
@@ -406,8 +406,8 @@ type recall_config = {
 | Scratchpad | OAS 내부 관리 | bridge 불필요 |
 | Working | OAS 내부 관리 | bridge 불필요 |
 | Long_term | JSONL/filesystem (`Memory_jsonl`) | `make_backend` |
-| Episodic | `Institution_eio` JSONL episodes | `seed_episodes` / `flush_episodes` |
-| Procedural | `Procedural_memory` | `seed_procedures_as_oas` / `flush_procedures` |
+| Episodic | `Institution_eio` JSONL episodes | `load_episodes_text` / `flush_episodes` |
+| Procedural | `Procedural_memory` | `load_procedures_text` / `flush_procedures` |
 
 ### 9.2 Storage Backends
 
@@ -422,14 +422,18 @@ type recall_config = {
 ### 9.3 Lifecycle
 
 ```
-create_memory_full
+create_memory
   1. make_backend (JSONL/filesystem)
-  2. seed_episodes (Institution JSONL -> OAS Episodic, 기본 50개)
-  3. seed_procedures_as_oas (crystallized procedures -> OAS Procedural, 기본 20개)
-  4. seed_institution (institution.json -> OAS Long_term, 선택)
+  2. Agent_sdk.Memory.create ~long_term:backend
+
+Prompt injection:
+  1. load_episodes_text (Institution JSONL -> prompt context)
+  2. load_procedures_text (crystallized procedures -> prompt context)
+  3. load_world_text (OAS long_term world keys -> prompt context)
+  4. load_institution_text (institution.json -> welcome/context text)
 
 Agent.run 완료 후:
-  flush_all
+  flush_incremental
     1. flush_episodes (OAS -> Institution JSONL, 중복 ID 제거)
     2. flush_procedures (OAS -> Procedural_memory, 변경된 count만)
 ```
@@ -483,7 +487,7 @@ type synapse = {
 1. **Compaction은 원자적이다**: memory bank 재작성은 .tmp 파일에 쓰고 rename한다. 실패 시 원본 불변.
 2. **Dedup은 정규화 기반이다**: `normalize_memory_text_key`가 공백/구두점 제거 + lowercase 후 비교한다.
 3. **kind가 우선순위를 결정한다**: 동일 kind + text는 항상 동일한 priority를 받는다. `signal_bonus`가 키워드 기반 보정을 추가한다.
-4. **OAS bridge는 비파괴적이다**: flush 시 기존 데이터를 제거하지 않고 append 또는 update-in-place만 한다.
+4. **OAS bridge는 비파괴적이다**: load는 prompt context만 만들고, flush 시 기존 데이터를 제거하지 않고 append 또는 update-in-place만 한다.
 5. **Context compaction은 기본적으로 결정론적이다**: Memory-bank progress consolidation만 opt-in LLM summarizer를 제공하며, off/fail/no-direct-provider 상태는 deterministic fallback을 사용한다.
 6. **OAS bridge storage follows current bootstrap truth**: filesystem/JSONL is the active runtime storage lane; PostgreSQL is not used as the primary or fallback backend.
 7. **Procedural crystallization은 비가역적이다**: 일단 결정화되면 evidence가 줄어도 상태가 변하지 않는다.

--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -448,8 +448,9 @@ Static pre-filtering은 OAS Guardrails가, stateful per-call checks는 Eval_gate
 `memory_oas_bridge.ml`은 MASC 메모리를 OAS `Memory.t` 5-tier에 연결한다. 상세는 12-memory-systems.md 9절 참조.
 
 핵심 API:
-- `create_memory_full`: 5-tier 전체를 seed하는 팩토리
-- `flush_all`: Agent.run 완료 후 episodic + procedural flush
+- `create_memory`: filesystem-first JSONL long_term backend가 연결된 OAS `Memory.t` 생성
+- `load_episodes_text` / `load_procedures_text` / `load_world_text`: hook-first prompt injection용 read path
+- `flush_incremental`: Agent.run 완료 후 episodic + procedural flush
 - `make_backend`: filesystem-first JSONL long_term_backend 선택
 
 ---
@@ -479,7 +480,7 @@ Static pre-filtering은 OAS Guardrails가, stateful per-call checks는 Eval_gate
 | keeper `working_context` wrapper | Open | keeper runtime still wraps OAS context/checkpoint state |
 | keeper checkpoint nativeization | Open | keeper path still serializes MASC-owned context |
 | message marker leakage | Open | `[STATE]`, `[GOAL]`, memory-summary markers still carry domain semantics in raw text |
-| memory bridge hooks/callbacks | Open | seeding/flushing remains imperative in `memory_oas_bridge.ml` |
+| memory bridge hooks/callbacks | Complete for current bridge | imperative seeding was removed; read-side hook-first injection plus post-turn `flush_incremental` is the active contract |
 | team-session bridge fidelity | Open | healthcheck still calls out projection/resource-health gaps |
 
 Checkpoint truth / replay semantics for the first three ledger items are
@@ -515,7 +516,7 @@ Detailed implementation checklist lives in
 |---------|----------------|-------|
 | `oas_worker` / `worker_oas` / `verifier_oas` | Correct | MASC consumes OAS runtime/build/hook contracts without teaching OAS about room/task semantics |
 | `context_compact_oas` | Acceptable but lossy | OAS reducer is authoritative, but MASC marker heuristics still influence scoring |
-| `memory_oas_bridge` | Acceptable but lossy | consumer adapter is correct; lifecycle is still seed/flush driven rather than hook-first |
+| `memory_oas_bridge` | Acceptable | consumer adapter is correct; lifecycle is hook-first read injection plus post-turn flush |
 | keeper context/checkpoint continuity path | Boundary violation | duplicate runtime ownership + raw text continuity markers remain |
 
 ### 12.3 Priority Order


### PR DESCRIPTION
## Summary
- update memory specs to match current Memory_oas_bridge API names and lifecycle
- remove stale seed/flush and long_term callback-incomplete claims from spec docs
- record the active contract: filesystem JSONL long_term backend, hook-first read injection, post-turn flush_incremental

## Verification
- rg stale memory bridge terms in updated spec docs
- git diff --check