### PR TITLE
fix(keeper): gate turns on cascade backpressure

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -369,6 +369,50 @@ let record_semaphore_wait_observation
     ~reasons:(semaphore_wait_observation_reasons ?phase_label ~kind ~channel ())
 ;;
 
+type cascade_backpressure_decision =
+  | Cascade_admitted
+  | Cascade_backpressured of {
+      cascade_name : string;
+      reason : string;
+    }
+
+let skip_reason_component raw =
+  let normalized = String.lowercase_ascii (String.trim raw) in
+  let mapped =
+    String.map
+      (function
+        | ('a' .. 'z' | '0' .. '9' | '_') as c -> c
+        | '-' -> '_'
+        | _ -> '_')
+      normalized
+  in
+  if String.equal mapped "" then "unknown" else mapped
+;;
+
+let cascade_backpressure_observation_reasons ~reason =
+  [ "cascade_backpressure"
+  ; "cascade_unhealthy"
+  ; "reason_" ^ skip_reason_component reason
+  ]
+;;
+
+let cascade_backpressure_decision ~should_run_turn ~cascade_name ~cascade_status =
+  match should_run_turn, cascade_status with
+  | true, Keeper_health_probe.Unhealthy reason ->
+    Cascade_backpressured { cascade_name; reason }
+  | false, _
+  | true, Keeper_health_probe.Unknown
+  | true, Keeper_health_probe.Healthy -> Cascade_admitted
+;;
+
+let record_cascade_backpressure_observation ~base_path ~keeper_name ~reason =
+  Keeper_registry.record_skip_reasons
+    ~base_path
+    keeper_name
+    ~reasons:(cascade_backpressure_observation_reasons ~reason);
+  Keeper_registry.touch_last_turn_ts ~base_path keeper_name
+;;
+
 let oas_timeout_budget_observation_reasons =
   [ "provider_runtime_error"; "oas_timeout_budget"; "keeper_turn_retry_backoff" ]
 ;;
@@ -858,7 +902,21 @@ let run_keepalive_unified_turn
          stuck behind sticky blockers. Failed turns record evidence via
          Keeper_registry; recovery is autonomous (next turn's observation)
          or operator-driven (board/keeper_chat), not blocker-driven. *)
-      let should_run_turn = (not (Atomic.get stop)) && turn_decision.should_run in
+      let requested_should_run_turn =
+        (not (Atomic.get stop)) && turn_decision.should_run
+      in
+      let cascade_name = cascade_name_of_meta meta_after_triage in
+      let cascade_backpressure =
+        cascade_backpressure_decision
+          ~should_run_turn:requested_should_run_turn
+          ~cascade_name
+          ~cascade_status:(Keeper_health_probe.get_cascade_status ~cascade_name)
+      in
+      let should_run_turn =
+        match cascade_backpressure with
+        | Cascade_admitted -> requested_should_run_turn
+        | Cascade_backpressured _ -> false
+      in
       let meta_after_cursor_persist =
         persist_message_cursor_updates
           ~config:ctx.config
@@ -871,6 +929,12 @@ let run_keepalive_unified_turn
       in
       let verdict_strs =
         Keeper_world_observation.verdict_reasons_to_strings turn_decision.verdict
+      in
+      let admission_reason_strs =
+        match cascade_backpressure with
+        | Cascade_admitted -> verdict_strs
+        | Cascade_backpressured { reason; _ } ->
+          cascade_backpressure_observation_reasons ~reason
       in
       let channel_str =
         Keeper_world_observation.channel_to_string turn_decision.channel
@@ -893,7 +957,7 @@ let run_keepalive_unified_turn
                Keeper_heartbeat_snapshot.proactive_skip_reason_metric
                ~labels:[ "keeper", meta_after_triage.name; "reason", reason_str ]
                ())
-          verdict_strs;
+          admission_reason_strs;
         (* #10940 follow-up — Prometheus counters aggregate skip reasons
            across time, but operators need to see *which* reasons were
            live just before a stale-watchdog [idle_stale=true]
@@ -901,10 +965,23 @@ let run_keepalive_unified_turn
            [Keeper_stale_watchdog] surface the most recent reasons in
            the kill warn line, distinguishing deliberate-skip dead
            paths from genuinely stuck fibers. *)
-        Keeper_registry.record_skip_reasons
-          ~base_path:ctx.config.base_path
-          meta_after_triage.name
-          ~reasons:verdict_strs;
+        (match cascade_backpressure with
+         | Cascade_admitted ->
+           Keeper_registry.record_skip_reasons
+             ~base_path:ctx.config.base_path
+             meta_after_triage.name
+             ~reasons:admission_reason_strs
+         | Cascade_backpressured { cascade_name; reason } ->
+           record_cascade_backpressure_observation
+             ~base_path:ctx.config.base_path
+             ~keeper_name:meta_after_triage.name
+             ~reason;
+           Log.Keeper.info
+             "keepalive turn backpressured for %s: cascade=%s reason=%s requested=[%s]"
+             meta_after_triage.name
+             cascade_name
+             reason
+             (String.concat "," verdict_strs));
         let paused_info =
           if meta_after_triage.paused
           then (
@@ -940,7 +1017,7 @@ let run_keepalive_unified_turn
           meta_after_triage.name
           turn_decision.should_run
           channel_str
-          (String.concat "," verdict_strs)
+          (String.concat "," admission_reason_strs)
           obs.idle_seconds
           (Keeper_keepalive_signal.format_since_last_scheduled_autonomous
              turn_decision.since_last_scheduled_autonomous)

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -69,6 +69,24 @@ val record_semaphore_wait_observation :
   unit ->
   unit
 
+type cascade_backpressure_decision =
+  | Cascade_admitted
+  | Cascade_backpressured of {
+      cascade_name : string;
+      reason : string;
+    }
+
+val cascade_backpressure_decision :
+  should_run_turn:bool ->
+  cascade_name:string ->
+  cascade_status:Keeper_health_probe.health_status ->
+  cascade_backpressure_decision
+
+val cascade_backpressure_observation_reasons : reason:string -> string list
+
+val record_cascade_backpressure_observation :
+  base_path:string -> keeper_name:string -> reason:string -> unit
+
 val semaphore_wait_timeout_blocker_class :
   Keeper_turn_slot.semaphore_wait_timeout -> blocker_class
 

--- a/test/test_keeper_semaphore_wait_counter.ml
+++ b/test/test_keeper_semaphore_wait_counter.ml
@@ -232,6 +232,89 @@ let test_wait_observation_reason_labels () =
        ~channel:Masc_mcp.Keeper_world_observation.Scheduled_autonomous
        ())
 
+let test_cascade_backpressure_decision () =
+  let unhealthy =
+    KHL.cascade_backpressure_decision
+      ~should_run_turn:true
+      ~cascade_name:"primary"
+      ~cascade_status:(Masc_mcp.Keeper_health_probe.Unhealthy "failure_ratio")
+  in
+  (match unhealthy with
+   | KHL.Cascade_backpressured { cascade_name; reason } ->
+     Alcotest.(check string) "cascade name" "primary" cascade_name;
+     Alcotest.(check string) "reason" "failure_ratio" reason
+   | KHL.Cascade_admitted -> Alcotest.fail "unhealthy cascade was admitted");
+  (match
+     KHL.cascade_backpressure_decision
+       ~should_run_turn:true
+       ~cascade_name:"primary"
+       ~cascade_status:Masc_mcp.Keeper_health_probe.Healthy
+   with
+   | KHL.Cascade_admitted -> ()
+   | KHL.Cascade_backpressured _ -> Alcotest.fail "healthy cascade was blocked");
+  (match
+     KHL.cascade_backpressure_decision
+       ~should_run_turn:true
+       ~cascade_name:"primary"
+       ~cascade_status:Masc_mcp.Keeper_health_probe.Unknown
+   with
+   | KHL.Cascade_admitted -> ()
+   | KHL.Cascade_backpressured _ -> Alcotest.fail "unknown cascade was blocked");
+  match
+    KHL.cascade_backpressure_decision
+      ~should_run_turn:false
+      ~cascade_name:"primary"
+      ~cascade_status:(Masc_mcp.Keeper_health_probe.Unhealthy "failure_ratio")
+  with
+  | KHL.Cascade_admitted -> ()
+  | KHL.Cascade_backpressured _ ->
+    Alcotest.fail "already-skipped turn was reclassified"
+
+let test_cascade_backpressure_reason_labels () =
+  Alcotest.(check (list string))
+    "cascade backpressure reasons"
+    [ "cascade_backpressure"; "cascade_unhealthy"; "reason_failure_ratio_" ]
+    (KHL.cascade_backpressure_observation_reasons ~reason:"Failure Ratio!")
+
+let test_cascade_backpressure_updates_registry () =
+  let base_path =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-cascade-backpressure-observation-%d" (Unix.getpid ()))
+  in
+  let keeper = "cascade-backpressure-153xx" in
+  Masc_mcp.Keeper_registry.unregister ~base_path keeper;
+  let meta = make_meta keeper in
+  ignore (Masc_mcp.Keeper_registry.register ~base_path keeper meta);
+  Fun.protect
+    ~finally:(fun () -> Masc_mcp.Keeper_registry.unregister ~base_path keeper)
+    (fun () ->
+       let before =
+         match Masc_mcp.Keeper_registry.get ~base_path keeper with
+         | Some entry -> entry.meta.runtime.usage.last_turn_ts
+         | None -> Alcotest.fail "registered keeper missing before observation"
+       in
+       KHL.record_cascade_backpressure_observation
+         ~base_path
+         ~keeper_name:keeper
+         ~reason:"failure_ratio";
+       match Masc_mcp.Keeper_registry.get ~base_path keeper with
+       | Some
+           { Masc_mcp.Keeper_registry.last_skip_observation = Some (_, reasons)
+           ; meta = updated_meta
+           ; _
+           } ->
+         Alcotest.(check (list string))
+           "backpressure stamped for watchdog routing"
+           [ "cascade_backpressure"; "cascade_unhealthy"; "reason_failure_ratio" ]
+           reasons;
+         Alcotest.(check bool)
+           "last_turn_ts touched"
+           true
+           (updated_meta.runtime.usage.last_turn_ts >= before)
+       | Some _ -> Alcotest.fail "last_skip_observation was not stamped"
+       | None -> Alcotest.fail "registered keeper missing")
+
 let test_queue_head_timeout_diagnostic_names_fifo_blocker () =
   let timeout = make_timeout ~queue_ahead:3 KTS.Autonomous_queue_head in
   let blocker_class = KHL.semaphore_wait_timeout_blocker_class timeout in
@@ -377,6 +460,12 @@ let () =
     "watchdog_observation", [
       Alcotest.test_case "reason labels are stable" `Quick
         test_wait_observation_reason_labels;
+      Alcotest.test_case "cascade backpressure blocks unhealthy" `Quick
+        test_cascade_backpressure_decision;
+      Alcotest.test_case "cascade backpressure labels are stable" `Quick
+        test_cascade_backpressure_reason_labels;
+      Alcotest.test_case "cascade backpressure registry stamp is updated" `Quick
+        test_cascade_backpressure_updates_registry;
       Alcotest.test_case
         "queue-head timeout names fifo blocker, not empty holders" `Quick
         test_queue_head_timeout_diagnostic_names_fifo_blocker;


### PR DESCRIPTION
## Summary\n- promote cascade health probe results into pre-dispatch keeper turn admission\n- block requested keeper turns when the active cascade is cached as unhealthy instead of sending another LLM request into the same bad route\n- stamp cascade backpressure skip reasons and touch last_turn_ts so stale watchdog logs preserve intentional backpressure instead of classifying it as a stuck fiber\n\n## Deep-dive link\n- DD-009: Stale_termination_storm / Stale_fleet_batch / Oas_timeout_budget_loop were symptom caps; this adds the first direct admission backpressure gate.\n\n## Verification\n- ocamlformat --check lib/keeper/keeper_heartbeat_loop.ml lib/keeper/keeper_heartbeat_loop.mli test/test_keeper_semaphore_wait_counter.ml\n- scripts/dune-local.sh build test/test_keeper_semaphore_wait_counter.exe\n- ./_build/default/test/test_keeper_semaphore_wait_counter.exe (15 tests)\n- git diff --check