### PR TITLE
fix(keeper): gate idle heartbeat on visible consumers

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -1162,6 +1162,31 @@ let cycle_continues_after_wake
   | _, _ -> smart_heartbeat_cycle_continues d
 ;;
 
+let unobserved_visibility_idle_window_s = 900.0
+
+let visible_consumer_count () =
+  Sse.client_count_by_kind Sse.Observer + Sse.external_subscriber_count ()
+;;
+
+let visibility_gate_decision
+      ~(visible_consumers : int)
+      ~(has_pending_signal : bool)
+      ~(now : float)
+      ~(last_heartbeat_cycle_ts : float)
+      (decision : Heartbeat_smart.decision)
+  : Heartbeat_smart.decision
+  =
+  match decision with
+  | Heartbeat_smart.Emit
+    when visible_consumers <= 0
+         && (not has_pending_signal)
+         && last_heartbeat_cycle_ts > 0.0
+         && now -. last_heartbeat_cycle_ts < unobserved_visibility_idle_window_s ->
+    Heartbeat_smart.Skip_idle
+      (last_heartbeat_cycle_ts +. unobserved_visibility_idle_window_s)
+  | _ -> decision
+;;
+
 let run_smart_heartbeat_gate
       ~(config : Coord.config)
       ~(clock : _ Eio.Time.clock)
@@ -1190,47 +1215,90 @@ let run_smart_heartbeat_gate
      regardless of the busy/idle decision so the next cycle consumes the
      stimulus on time. Pinned by KeeperEventQueue.tla
      QueueNeverStarvedBySkip invariant. *)
+  let pending_signal_present =
+    lazy
+      (let queue =
+         Keeper_registry.event_queue_snapshot
+           ~base_path:config.base_path
+           meta_current.name
+       in
+       if not (Keeper_event_queue.is_empty queue)
+       then (
+         Prometheus.inc_counter
+           Keeper_metrics.metric_keeper_event_queue_override
+           ~labels:[ "keeper", meta_current.name; "reason", "event_queue" ]
+           ();
+         true)
+       else (
+         let allowed_tool_names =
+           Keeper_tool_policy.keeper_allowed_tool_names meta_current
+         in
+         if
+           Keeper_world_observation.durable_signal_present
+             ~allowed_tool_names:(Some allowed_tool_names)
+             ~pending_board_events:None
+             ~config
+             ~meta:meta_current
+         then (
+           Prometheus.inc_counter
+             Keeper_metrics.metric_keeper_event_queue_override
+             ~labels:[ "keeper", meta_current.name; "reason", "durable_state" ]
+             ();
+           Log.Keeper.info
+             "smart heartbeat: durable signal present - cycle resumed before stale \
+              watchdog";
+           true)
+         else false))
+  in
   let smart_hb_decision =
     if Heartbeat_smart.should_emit_now smart_hb_decision
     then smart_hb_decision
     else (
-      let queue =
-        Keeper_registry.event_queue_snapshot ~base_path:config.base_path meta_current.name
+      (* Skip_busy already continues the cycle (no idle sleep), so
+         probing the world-observation signal here would be redundant
+         backlog/board I/O.  The durable-signal probe only matters when
+         the gate would otherwise sleep on Skip_idle. *)
+      match smart_hb_decision with
+      | Heartbeat_smart.Skip_idle _ when Lazy.force pending_signal_present ->
+        Heartbeat_smart.Emit
+      | Heartbeat_smart.Skip_idle _
+      | Heartbeat_smart.Skip_busy
+      | Heartbeat_smart.Emit -> smart_hb_decision)
+  in
+  let smart_hb_decision =
+    match smart_hb_decision with
+    | Heartbeat_smart.Emit when smart_hb_enabled () ->
+      let consumers = visible_consumer_count () in
+      let now = Time_compat.now () in
+      let delay_possible =
+        consumers <= 0
+        && !last_heartbeat_cycle_ts > 0.0
+        && now -. !last_heartbeat_cycle_ts < unobserved_visibility_idle_window_s
       in
-      if not (Keeper_event_queue.is_empty queue)
-      then (
-        Prometheus.inc_counter
-          Keeper_metrics.metric_keeper_event_queue_override
-          ~labels:[ "keeper", meta_current.name; "reason", "event_queue" ]
-          ();
-        Heartbeat_smart.Emit)
-      else (
-        (* Skip_busy already continues the cycle (no idle sleep), so
-           probing the world-observation signal here would be redundant
-           backlog/board I/O.  The durable-signal probe only matters when
-           the gate would otherwise sleep on Skip_idle. *)
-        match smart_hb_decision with
-        | Heartbeat_smart.Skip_idle _ ->
-          let allowed_tool_names =
-            Keeper_tool_policy.keeper_allowed_tool_names meta_current
-          in
-          if
-            Keeper_world_observation.durable_signal_present
-              ~allowed_tool_names:(Some allowed_tool_names)
-              ~pending_board_events:None
-              ~config
-              ~meta:meta_current
-          then (
-            Prometheus.inc_counter
-              Keeper_metrics.metric_keeper_event_queue_override
-              ~labels:[ "keeper", meta_current.name; "reason", "durable_state" ]
-              ();
-            Log.Keeper.info
-              "smart heartbeat: durable signal present - cycle resumed before stale \
-               watchdog";
-            Heartbeat_smart.Emit)
-          else smart_hb_decision
-        | Heartbeat_smart.Skip_busy | Heartbeat_smart.Emit -> smart_hb_decision))
+      let gated =
+        if delay_possible
+        then
+          visibility_gate_decision
+            ~visible_consumers:consumers
+            ~has_pending_signal:(Lazy.force pending_signal_present)
+            ~now
+            ~last_heartbeat_cycle_ts:!last_heartbeat_cycle_ts
+            smart_hb_decision
+        else smart_hb_decision
+      in
+      (match gated with
+       | Heartbeat_smart.Skip_idle _ ->
+         Prometheus.inc_counter
+           Keeper_heartbeat_snapshot.proactive_skip_reason_metric
+           ~labels:[ "keeper", meta_current.name; "reason", "no_visible_consumers" ]
+           ();
+         Log.Keeper.debug
+           "smart heartbeat: no visible consumers - delaying idle turn dispatch"
+       | Heartbeat_smart.Emit | Heartbeat_smart.Skip_busy -> ());
+      gated
+    | Heartbeat_smart.Emit
+    | Heartbeat_smart.Skip_busy
+    | Heartbeat_smart.Skip_idle _ -> smart_hb_decision
   in
   (* Run side-effects (idle sleep, cycle-timestamp update) per the
      decision, then delegate the gate answer to [cycle_continues_after_wake]

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -137,6 +137,16 @@ val smart_heartbeat_cycle_continues : Heartbeat_smart.decision -> bool
 val cycle_continues_after_wake :
   Heartbeat_smart.decision -> Keeper_keepalive_signal.sleep_outcome -> bool
 
+val visible_consumer_count : unit -> int
+
+val visibility_gate_decision :
+  visible_consumers:int ->
+  has_pending_signal:bool ->
+  now:float ->
+  last_heartbeat_cycle_ts:float ->
+  Heartbeat_smart.decision ->
+  Heartbeat_smart.decision
+
 val run_smart_heartbeat_gate :
   config:Coord.config ->
   clock:'a Eio.Time.clock ->

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -169,6 +169,16 @@ val smart_heartbeat_cycle_continues : Heartbeat_smart.decision -> bool
 val cycle_continues_after_wake :
   Heartbeat_smart.decision -> Keeper_keepalive_signal.sleep_outcome -> bool
 
+val visible_consumer_count : unit -> int
+
+val visibility_gate_decision :
+  visible_consumers:int ->
+  has_pending_signal:bool ->
+  now:float ->
+  last_heartbeat_cycle_ts:float ->
+  Heartbeat_smart.decision ->
+  Heartbeat_smart.decision
+
 val status_tick_usage_json : unit -> Yojson.Safe.t
 (** Usage payload for heartbeat/status metrics rows.  Status ticks are not
     LLM calls, so all per-turn token counters are explicit zeroes while

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -960,6 +960,13 @@ let try_pop session_id =
 let client_count () =
   (Atomic.get clients).count
 
+let client_count_by_kind kind =
+  SMap.fold
+    (fun _session_id (client : client) count ->
+       if client.kind = kind then count + 1 else count)
+    (Atomic.get clients).entries
+    0
+
 (** Return list of session_ids for all connected clients.
     Used by transport metrics to report session count by kind. *)
 let all_session_ids () =

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -86,6 +86,7 @@ val touch : string -> unit
 val update_last_event_id : string -> int -> unit
 val all_session_ids : unit -> string list
 val client_count : unit -> int
+val client_count_by_kind : session_kind -> int
 val close_all_clients : unit -> int
 val cleanup_stale : ?max_age_s:float -> unit -> string list
 

--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -146,6 +146,53 @@ let test_cycle_pauses_on_skip_idle () =
   check bool "Skip_idle pauses cycle" false
     (KK.smart_heartbeat_cycle_continues (HS.Skip_idle next))
 
+let test_visibility_gate_delays_unobserved_idle_emit () =
+  let now = 1_000.0 in
+  match
+    KK.visibility_gate_decision
+      ~visible_consumers:0
+      ~has_pending_signal:false
+      ~now
+      ~last_heartbeat_cycle_ts:(now -. 60.0)
+      HS.Emit
+  with
+  | HS.Skip_idle next ->
+    check bool "next heartbeat stays bounded" true (next > now)
+  | HS.Emit | HS.Skip_busy -> fail "expected unobserved emit to become Skip_idle"
+
+let test_visibility_gate_allows_pending_signal () =
+  let decision =
+    KK.visibility_gate_decision
+      ~visible_consumers:0
+      ~has_pending_signal:true
+      ~now:1_000.0
+      ~last_heartbeat_cycle_ts:940.0
+      HS.Emit
+  in
+  check bool "pending signal keeps emit" true (decision = HS.Emit)
+
+let test_visibility_gate_allows_visible_consumer () =
+  let decision =
+    KK.visibility_gate_decision
+      ~visible_consumers:1
+      ~has_pending_signal:false
+      ~now:1_000.0
+      ~last_heartbeat_cycle_ts:940.0
+      HS.Emit
+  in
+  check bool "visible consumer keeps emit" true (decision = HS.Emit)
+
+let test_visibility_gate_preserves_busy () =
+  let decision =
+    KK.visibility_gate_decision
+      ~visible_consumers:0
+      ~has_pending_signal:false
+      ~now:1_000.0
+      ~last_heartbeat_cycle_ts:940.0
+      HS.Skip_busy
+  in
+  check bool "busy keeps cycle path" true (decision = HS.Skip_busy)
+
 (* ── MissedWakeup gap regression guard (KeeperHeartbeat.tla) ───────
    Skip_idle + Woken must promote the gate to [true]. Without this,
    external wakeup_keeper / board_signal calls that fire during a
@@ -363,6 +410,15 @@ let () =
         `Quick test_cycle_continues_on_skip_busy;
       test_case "Emit -> cycle continues" `Quick test_cycle_continues_on_emit;
       test_case "Skip_idle -> cycle pauses" `Quick test_cycle_pauses_on_skip_idle;
+    ];
+    "visibility_gate", [
+      test_case "unobserved idle emit delays dispatch" `Quick
+        test_visibility_gate_delays_unobserved_idle_emit;
+      test_case "pending signal bypasses no-consumer delay" `Quick
+        test_visibility_gate_allows_pending_signal;
+      test_case "visible consumer bypasses delay" `Quick
+        test_visibility_gate_allows_visible_consumer;
+      test_case "busy decision is preserved" `Quick test_visibility_gate_preserves_busy;
     ];
     "board_wakeup_selection", [
       test_case "generic board activity is capped"

--- a/test/test_sse_coverage.ml
+++ b/test/test_sse_coverage.ml
@@ -192,6 +192,34 @@ let test_client_count_exact_unregister_decrement () =
       check int "second unregister restores original count"
         before (Sse.client_count ()))
 
+let test_client_count_by_kind_tracks_session_roles () =
+  let before_observer = Sse.client_count_by_kind Sse.Observer in
+  let before_coordinator = Sse.client_count_by_kind Sse.Coordinator in
+  let observer = "test_kind_observer_" ^ string_of_int (Random.bits ()) in
+  let coordinator = "test_kind_coord_" ^ string_of_int (Random.bits ()) in
+  Fun.protect
+    ~finally:(fun () ->
+      Sse.unregister observer;
+      Sse.unregister coordinator)
+    (fun () ->
+      let (_id1, _, _) = Sse.register ~kind:Sse.Observer observer ~last_event_id:0 in
+      let (_id2, _, _) =
+        Sse.register ~kind:Sse.Coordinator coordinator ~last_event_id:0
+      in
+      check int "observer count increments"
+        (before_observer + 1)
+        (Sse.client_count_by_kind Sse.Observer);
+      check int "coordinator count increments"
+        (before_coordinator + 1)
+        (Sse.client_count_by_kind Sse.Coordinator);
+      Sse.unregister observer;
+      check int "observer count decrements"
+        before_observer
+        (Sse.client_count_by_kind Sse.Observer);
+      check int "coordinator still present"
+        (before_coordinator + 1)
+        (Sse.client_count_by_kind Sse.Coordinator))
+
 let test_unregister_if_current_replacement_count () =
   let before = Sse.client_count () in
   let session_id =
@@ -448,6 +476,8 @@ let () =
       test_case "increments" `Quick test_client_count_increments;
       test_case "unregister decrements exactly" `Quick
         test_client_count_exact_unregister_decrement;
+      test_case "by kind tracks session roles" `Quick
+        test_client_count_by_kind_tracks_session_roles;
     ];
     "event_buffer", [
       test_case "buffer and retrieve" `Quick test_buffer_event_and_retrieve;


### PR DESCRIPTION
## Summary
- Add an SSE kind-specific client count so keepalive can distinguish dashboard observers from coordinator/presence sessions.
- Gate idle smart-heartbeat turn dispatch when there are no visible consumers and no pending durable/event signal, using a bounded 15m idle window.
- Preserve busy/task, event-queue, and durable-signal paths so active keepers still progress without dashboard viewers.

## Deep Dive
- DD-010: visibility and heartbeat dispatch were not separated; zero dashboard/SSE consumers still allowed keepalive cycles to spend turn budget.

## Tests
- opam exec -- ocamlformat --check lib/sse.ml lib/sse.mli lib/keeper/keeper_heartbeat_loop.ml lib/keeper/keeper_heartbeat_loop.mli lib/keeper/keeper_keepalive.mli test/test_sse_coverage.ml test/test_smart_heartbeat_keepalive.ml
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_sse_coverage.exe test/test_smart_heartbeat_keepalive.exe
- ./_build/default/test/test_sse_coverage.exe
- ./_build/default/test/test_smart_heartbeat_keepalive.exe