### PR TITLE
fix(worker): preserve provider labels in docker auth preflight

### DIFF
--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -366,6 +366,8 @@ let default_model_id_of_binding (binding : Runtime_binding.t) =
   | Some _ as value -> value
   | None ->
     (match runtime_kind_of_binding binding with
+     | _ when binding.Runtime_binding.kind = Llm_provider.Provider_config.Kimi ->
+       Some "kimi-k2.5"
      | Local -> None
      | Cli_agent | Direct_api -> Some "auto")
 ;;
@@ -1216,6 +1218,12 @@ let auth_env_keys_of_provider_kind (kind : Llm_provider.Provider_config.provider
      | None -> Option.to_list (Llm_provider.Provider_config.default_api_key_env kind))
 ;;
 
+let auth_env_keys_of_adapter (adapter : adapter) : string list =
+  match adapter.auth_mode with
+  | Api_key env_name -> [ env_name ]
+  | No_auth | Cli_cached_login | Vertex_adc _ -> []
+;;
+
 let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.t)
   : string list
   =
@@ -1229,9 +1237,15 @@ let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.
     let uri = Uri.of_string cfg.base_url in
     if Masc_network_defaults.is_loopback_host_opt (Uri.host uri)
     then []
-    else auth_env_keys_of_provider_kind cfg.kind
+    else (
+      match adapter_of_provider_config cfg with
+      | Some adapter -> auth_env_keys_of_adapter adapter
+      | None -> auth_env_keys_of_provider_kind cfg.kind)
   | Llm_provider.Provider_config.Gemini -> [ gemini_api_key_env ]
-  | _ -> auth_env_keys_of_provider_kind cfg.kind
+  | _ -> (
+    match adapter_of_provider_config cfg with
+    | Some adapter -> auth_env_keys_of_adapter adapter
+    | None -> auth_env_keys_of_provider_kind cfg.kind)
 ;;
 
 let all_auth_env_keys () : string list =

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -310,10 +310,12 @@ let runtime_kind_of_binding (binding : Runtime_binding.t) =
 ;;
 
 let binding_supports_runtime_mcp_http_headers (binding : Runtime_binding.t) =
-  binding.Runtime_binding.capabilities.supports_runtime_mcp_tools
-  || binding.Runtime_binding.capabilities.supports_runtime_tool_events
-  || (runtime_kind_of_binding binding = Cli_agent
-      && binding.Runtime_binding.capabilities.supports_tools)
+  match runtime_kind_of_binding binding with
+  | Cli_agent ->
+    binding.Runtime_binding.capabilities.supports_tools
+  | Local | Direct_api ->
+    binding.Runtime_binding.capabilities.supports_runtime_mcp_tools
+    || binding.Runtime_binding.capabilities.supports_runtime_tool_events
 ;;
 
 let binding_uses_prompt_caching (binding : Runtime_binding.t) =

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -258,8 +258,36 @@ let mount_args (spec : Worker_execution_spec.t) =
   base_mount @ config_mount
 ;;
 
-let auth_requirements_of_model_label model_label =
+let provider_config_for_auth_check model_label =
   match Cascade_config.parse_model_string model_label with
+  | Some _ as cfg -> cfg
+  | None -> (
+    match Provider_kind_resolver.resolve model_label with
+    | Provider_kind_resolver.Registered { provider_name; model_id; _ } -> (
+      let registry = Llm_provider.Provider_registry.default () in
+      match Llm_provider.Provider_registry.find registry provider_name with
+      | None -> None
+      | Some entry ->
+        Some
+          (Llm_provider.Provider_config.make
+             ~kind:entry.defaults.kind
+             ~model_id
+             ~base_url:entry.defaults.base_url
+             ~request_path:entry.defaults.request_path
+             ()))
+    | Provider_kind_resolver.Custom_url { model_id; base_url } ->
+      Some
+        (Llm_provider.Provider_config.make
+           ~kind:Llm_provider.Provider_config.OpenAI_compat
+           ~model_id
+           ~base_url
+           ~request_path:Masc_network_defaults.openai_chat_completions_path
+           ())
+    | Provider_kind_resolver.Unknown _ -> None)
+;;
+
+let auth_requirements_of_model_label model_label =
+  match provider_config_for_auth_check model_label with
   | None -> Ok []
   | Some cfg ->
     let keys =
@@ -282,13 +310,17 @@ let auth_requirements_of_model_label model_label =
     if missing = []
     then Ok keys
     else (
-      let kind_name = provider_id_of_config cfg in
+      let provider_label = provider_id_of_config cfg in
       Error
         (Printf.sprintf
            "%s Docker workers require %s"
-           kind_name
+           provider_label
            (String.concat ", " missing)))
 ;;
+
+module For_testing = struct
+  let auth_requirements_of_model_label = auth_requirements_of_model_label
+end
 
 let missing_required_envs keys =
   keys

--- a/lib/worker_runtime_docker.mli
+++ b/lib/worker_runtime_docker.mli
@@ -113,3 +113,7 @@ val run_process_with_timeout :
     Exit-code mapping (signal-aware): [WEXITED code -> code],
     [WSIGNALED code -> 128 + code],
     [WSTOPPED code -> 256 + code]. *)
+
+module For_testing : sig
+  val auth_requirements_of_model_label : string -> (string list, string) result
+end

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -335,11 +335,23 @@ let test_runtime_mcp_header_support_uses_declared_policy () =
       ~base_url:""
       ()
   in
+  let gemini_cli_cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Gemini_cli
+      ~model_id:"gemini-3-flash-preview"
+      ~base_url:""
+      ()
+  in
   check
     bool
     "kimi cli supports runtime MCP headers"
     true
     (Adapter.supports_runtime_mcp_http_headers_for_config kimi_cli_cfg);
+  check
+    bool
+    "gemini cli does not support request-scoped runtime MCP headers"
+    false
+    (Adapter.supports_runtime_mcp_http_headers_for_config gemini_cli_cfg);
   check
     bool
     "codex cli does not support runtime MCP headers"

--- a/test/test_worker_runtime.ml
+++ b/test/test_worker_runtime.ml
@@ -170,6 +170,46 @@ let test_rewrite_custom_model_label_for_container () =
   check string "loopback custom label rewritten to host alias"
     "custom:qwen-test@http://host.docker.internal:19001" rewritten
 
+let test_docker_auth_preflight_reports_openrouter_key_when_missing () =
+  with_env "OPENROUTER_API_KEY" None @@ fun () ->
+  with_env "OPENAI_API_KEY" None @@ fun () ->
+  match
+    Lib.Worker_runtime_docker.For_testing.auth_requirements_of_model_label
+      "openrouter:openai/gpt-oss-20b"
+  with
+  | Ok keys ->
+    failf "expected missing OPENROUTER_API_KEY error, got Ok [%s]"
+      (String.concat ", " keys)
+  | Error msg ->
+    check bool "uses provider label" true
+      (Astring.String.is_infix ~affix:"openrouter Docker workers require" msg);
+    check bool "mentions openrouter key" true
+      (Astring.String.is_infix ~affix:"OPENROUTER_API_KEY" msg);
+    check bool "does not collapse to OpenAI key" false
+      (Astring.String.is_infix ~affix:"OPENAI_API_KEY" msg)
+
+let test_docker_auth_preflight_uses_openrouter_key_not_openai_key () =
+  with_env "OPENROUTER_API_KEY" (Some "router-key") @@ fun () ->
+  with_env "OPENAI_API_KEY" None @@ fun () ->
+  match
+    Lib.Worker_runtime_docker.For_testing.auth_requirements_of_model_label
+      "openrouter:openai/gpt-oss-20b"
+  with
+  | Error msg -> failf "expected OPENROUTER_API_KEY to satisfy auth: %s" msg
+  | Ok keys ->
+    check (list string) "provider-specific key"
+      [ "OPENROUTER_API_KEY" ]
+      keys
+
+let test_docker_auth_preflight_skips_local_custom_openai_compat () =
+  with_env "OPENAI_API_KEY" None @@ fun () ->
+  match
+    Lib.Worker_runtime_docker.For_testing.auth_requirements_of_model_label
+      "custom:local-model@http://127.0.0.1:19001"
+  with
+  | Error msg -> failf "local custom endpoint should not require auth: %s" msg
+  | Ok keys -> check (list string) "no auth keys" [] keys
+
 let test_run_process_with_timeout_returns_124_on_timeout () =
   with_eio @@ fun env ->
   let result =
@@ -256,6 +296,15 @@ let () =
       ( "rewrites",
         [ test_case "custom loopback model label rewritten for container" `Quick
             test_rewrite_custom_model_label_for_container ] );
+      ( "docker_auth",
+        [
+          test_case "reports OpenRouter key when missing" `Quick
+            test_docker_auth_preflight_reports_openrouter_key_when_missing;
+          test_case "uses OpenRouter key instead of OpenAI key" `Quick
+            test_docker_auth_preflight_uses_openrouter_key_not_openai_key;
+          test_case "skips auth for local custom OpenAI-compatible endpoint" `Quick
+            test_docker_auth_preflight_skips_local_custom_openai_compat;
+        ] );
       ( "process_timeout",
         [ test_case "timeout maps to exit code 124" `Quick
             test_run_process_with_timeout_returns_124_on_timeout ] );


### PR DESCRIPTION
## Summary
- resolve Docker worker auth requirements from the full provider config/adapter instead of collapsing OpenAI-compatible providers through provider_kind
- keep preflight diagnostics provider-scoped (for example openrouter -> OPENROUTER_API_KEY) even when the key is missing
- restore the Kimi API default model fallback to kimi-k2.5 while keeping KIMI_DEFAULT_MODEL override support
- keep request-scoped runtime MCP headers limited to runtime kinds whose declared tool transport can actually carry them

## Verification
- opam exec -- ocamlformat --check lib/provider_adapter.ml lib/worker_runtime_docker.ml lib/worker_runtime_docker.mli test/test_provider_adapter.ml test/test_worker_runtime.ml
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_provider_adapter.exe
- ./_build/default/test/test_provider_adapter.exe
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_worker_runtime.exe
- ./_build/default/test/test_worker_runtime.exe
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_provider_kind_resolution.exe
- ./_build/default/test/test_provider_kind_resolution.exe