### PR TITLE
fix(keeper): inject telemetry feedback into turns

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -415,11 +415,33 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                   ^ "Use all of these tools before your final reply: "
                   ^ String.concat ", " tools
               in
+              let telemetry_feedback_text =
+                match meta.telemetry_feedback_enabled with
+                | Some true ->
+                  let window_hours =
+                    match meta.telemetry_feedback_window_hours with
+                    | Some n when n > 0 -> min n 168
+                    | _ -> 24
+                  in
+                  let window_minutes = window_hours * 60 in
+                  (try
+                     Model_inference_metrics.compute
+                       ~base_path:ctx.config.base_path
+                       ~window_minutes
+                     |> Model_inference_metrics.render_keeper_prompt_feedback
+                   with exn ->
+                     Log.Keeper.warn
+                       "%s: telemetry feedback render failed: %s"
+                       meta.name (Printexc.to_string exn);
+                     "")
+                | Some false | None -> ""
+              in
               let soft_parts = List.filter
                 (fun s -> String.trim s <> "")
                 [ continuity_text;
                   skill_route_text;
                   worktree_text;
+                  telemetry_feedback_text;
                   turn_instructions_text;
                   required_tools_text ]
               in

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -1447,6 +1447,109 @@ let to_json (agg : aggregate) : Yojson.Safe.t =
     ]
 ;;
 
+let pct numerator denominator =
+  if denominator <= 0 then 0.0
+  else Float.of_int numerator *. 100.0 /. Float.of_int denominator
+;;
+
+let float_field ?(suffix = "") = function
+  | None -> "unknown"
+  | Some value -> Printf.sprintf "%.1f%s" value suffix
+;;
+
+let int_field = function
+  | None -> "unknown"
+  | Some value -> string_of_int value
+;;
+
+let prompt_lane_line (index : int) (stats : model_stats) =
+  let lane = public_runtime_lane_label stats.model_id in
+  let error_rate = pct stats.error_count stats.entry_count in
+  let cost =
+    match stats.total_cost_usd with
+    | None -> "unknown"
+    | Some value -> Printf.sprintf "$%.4f" value
+  in
+  Printf.sprintf
+    "- lane %d %s: turns=%d success=%d errors=%d error_rate=%.1f%% \
+     p95_latency_ms=%s avg_tok_per_sec=%s input_tokens=%s output_tokens=%s \
+     cost=%s coverage=%s"
+    index
+    lane
+    stats.entry_count
+    stats.success_count
+    stats.error_count
+    error_rate
+    (float_field stats.p95_latency_ms)
+    (float_field stats.avg_tok_per_sec)
+    (int_field stats.total_input_tokens)
+    (int_field stats.total_output_tokens)
+    cost
+    stats.coverage_status
+;;
+
+let prompt_feedback_guidance (agg : aggregate) =
+  let error_rate = pct agg.total_error_entries agg.total_entries in
+  let p95_values =
+    List.filter_map (fun (stats : model_stats) -> stats.p95_latency_ms) agg.models
+  in
+  let max_p95 =
+    match p95_values with
+    | [] -> None
+    | hd :: tl -> Some (List.fold_left Float.max hd tl)
+  in
+  let has_missing_coverage =
+    List.exists
+      (fun (stats : model_stats) ->
+         stats.usage_missing_count > 0 || stats.telemetry_missing_count > 0)
+      agg.models
+  in
+  let guidance =
+    [
+      ( error_rate >= 25.0
+      , "recent error rate is high; checkpoint before long tool chains and stop \
+         after repeated provider failures instead of looping." );
+      ( Option.value ~default:0.0 max_p95 >= 120_000.0
+      , "recent p95 latency is very high; keep turns smaller and prefer \
+         incremental commits/log evidence." );
+      ( has_missing_coverage
+      , "some turns are missing usage or telemetry; preserve receipts/logs and \
+         avoid treating missing metrics as success." );
+    ]
+    |> List.filter_map (fun (active, text) -> if active then Some text else None)
+  in
+  match guidance with
+  | [] -> "runtime telemetry is healthy enough for normal turn planning."
+  | items -> String.concat " " items
+;;
+
+let render_keeper_prompt_feedback (agg : aggregate) =
+  if agg.total_entries <= 0 then ""
+  else
+    let models =
+      agg.models
+      |> List.sort (fun a b -> Int.compare b.entry_count a.entry_count)
+      |> take 3
+    in
+    let header =
+      Printf.sprintf
+        "Recent model telemetry (last %d minutes): total_turns=%d \
+         error_turns=%d error_rate=%.1f%% observed_lanes=%d"
+        agg.window_minutes
+        agg.total_entries
+        agg.total_error_entries
+        (pct agg.total_error_entries agg.total_entries)
+        (List.length agg.models)
+    in
+    let lane_lines = List.mapi (fun i stats -> prompt_lane_line (i + 1) stats) models in
+    String.concat
+      "\n"
+      (header :: lane_lines
+       @ [ "Guidance: " ^ prompt_feedback_guidance agg
+         ; "Use these redacted runtime-lane labels only as telemetry context; \
+            do not invent concrete provider/model names from them." ])
+;;
+
 (* ── Runtime-lane rollup ────────────────────────────────────
    Legacy provider strings are not reconstructed here.  Public dashboard
    projections keep aggregate throughput/latency evidence while model/provider

--- a/lib/model_inference_metrics.mli
+++ b/lib/model_inference_metrics.mli
@@ -162,6 +162,12 @@ val model_stats_to_json : ?model_label:string -> model_stats -> Yojson.Safe.t
     redacted public runtime lane label; [provider] and recent-entry provider
     fields serialize as [null]. *)
 
+val render_keeper_prompt_feedback : aggregate -> string
+(** Render a compact, redacted telemetry block for opt-in keeper prompt
+    feedback. Returns the empty string when the aggregate has no entries.
+    Provider/model identities are represented as stable runtime-lane labels
+    rather than concrete provider or model names. *)
+
 (** Per-provider rollup of {!model_stats} aggregated across every model id
     whose [provider] matches. Feeds {!Dashboard_cascade.health_json}'s
     [providers] array so the UI can render per-provider throughput and

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -72,6 +72,18 @@ let now_unix () = Unix.gettimeofday ()
 let runtime_lane_label_for_test model_key =
   "runtime_lane_" ^ String.sub (Digest.to_hex (Digest.string model_key)) 0 12
 
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 then true
+  else
+    let rec loop i =
+      if i + needle_len > haystack_len then false
+      else if String.sub haystack i needle_len = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
 let success_entry ~model ~ts ?(input_tokens=100) ?(output_tokens=50)
     ?(latency_ms=500) ?prompt_per_second ?peak_memory_gb
     ?provider ?provider_kind ?usage_trust ?(usage_anomaly_reasons=[])
@@ -1144,6 +1156,51 @@ let test_provider_rollup_json_shape () =
      | _ -> fail "avg_prompt_tok_per_sec should be Float 180.0")
   | _ -> fail "provider_stats_to_json should return an Assoc"
 
+let test_prompt_feedback_empty_aggregate () =
+  let agg : M.aggregate =
+    { window_minutes = 60
+    ; bucket_minutes = 0
+    ; models = []
+    ; total_entries = 0
+    ; total_error_entries = 0
+    ; latency_buckets = []
+    }
+  in
+  check string "empty aggregate renders empty prompt block" ""
+    (M.render_keeper_prompt_feedback agg)
+
+let test_prompt_feedback_redacts_provider_model_identity () =
+  let raw_model = "openrouter:secret-model" in
+  let lane = runtime_lane_label_for_test raw_model in
+  let stats =
+    { (zero_model_stats raw_model ~provider:(Some "openrouter") ~entry_count:10)
+      with success_count = 7
+         ; error_count = 3
+         ; p95_latency_ms = Some 130_000.0
+         ; avg_tok_per_sec = Some 12.5
+         ; total_input_tokens = Some 1000
+         ; total_output_tokens = Some 250
+         ; usage_missing_count = 1
+         ; telemetry_missing_count = 1
+         ; coverage_status = "partial"
+    }
+  in
+  let agg : M.aggregate =
+    { window_minutes = 120
+    ; bucket_minutes = 0
+    ; models = [ stats ]
+    ; total_entries = 10
+    ; total_error_entries = 3
+    ; latency_buckets = []
+    }
+  in
+  let text = M.render_keeper_prompt_feedback agg in
+  check bool "contains redacted lane label" true (contains_substring text lane);
+  check bool "contains total turns" true (contains_substring text "total_turns=10");
+  check bool "contains error rate" true (contains_substring text "error_rate=30.0%");
+  check bool "does not expose provider" false (contains_substring text "openrouter");
+  check bool "does not expose raw model" false (contains_substring text "secret-model")
+
 (* ── Runner ──────────────────────────────────────── *)
 
 let () =
@@ -1201,5 +1258,11 @@ let () =
         test_provider_rollup_sort_by_entry_count_desc;
       test_case "provider_stats_to_json shape" `Quick
         test_provider_rollup_json_shape;
+    ];
+    "prompt_feedback", [
+      test_case "empty aggregate renders empty" `Quick
+        test_prompt_feedback_empty_aggregate;
+      test_case "redacts provider and model identity" `Quick
+        test_prompt_feedback_redacts_provider_model_identity;
     ];
   ]


### PR DESCRIPTION
## Summary

- wire opt-in keeper telemetry feedback into the soft turn context
- render recent model inference metrics as redacted runtime-lane prompt guidance
- add coverage that empty telemetry is omitted and provider/model identities stay redacted

## Product impact

Keepers that set `telemetry_feedback_enabled=true` now receive recent model
runtime telemetry in their turn context, so high error/latency/missing-coverage
signals can shape turn planning instead of staying dashboard-only.

## Verification

- `opam exec -- ocamlformat --check lib/model_inference_metrics.ml lib/model_inference_metrics.mli lib/keeper/keeper_turn.ml test/test_model_inference_metrics.ml`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_model_inference_metrics.exe`
- `./_build/default/test/test_model_inference_metrics.exe`
- `git diff --check`

## Evidence

Local focused verification passed. The prompt renderer returns an empty block
for empty aggregates and redacts provider/model identities into stable runtime
lane labels.

## Review evidence

Self-reviewed the diff for prompt-bloat risk, default-off behavior, and runtime
identity redaction. The compute path only runs for keepers that explicitly opt
in via `telemetry_feedback_enabled=true`.

## Linked issue

Deep-dive DD-018 follow-up: `model_inference_metrics` was dashboard-only and
not fed back into keeper behavior.
