### PR TITLE
fix(keeper): pin OAS termination semantics

### DIFF
--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -1,9 +1,10 @@
 ---
 status: reference
-last_verified: 2026-04-17
+last_verified: 2026-05-15
 code_refs:
   - lib/verifier_oas.ml
   - lib/memory_oas_bridge.ml
+  - lib/keeper/keeper_agent_error.ml
   - lib/worker_oas.ml
 ---
 
@@ -193,7 +194,31 @@ Hardcoded fallback (cascade.toml 없을 때):
 이 fallback은 runtime failsafe다. 저장소에 커밋되는 `config/cascade.toml`
 기본값과 동일시하지 않는다.
 
-### 4.6 MASC Tool Bridge
+### 4.6 Termination Semantics
+
+OAS와 MASC는 "turn"과 "timeout"을 같은 layer에서 쓰지 않는다. OAS
+`Agent.run`의 `MaxTurnsExceeded`는 OAS SDK turn budget이고, keeper
+wall-clock timeout이나 provider timeout과 동일한 개념이 아니다.
+
+`lib/keeper/keeper_agent_error.ml`의 `sdk_termination_semantics`가 OAS
+error를 keeper receipt로 접기 전 layer-aware 의미를 먼저 고정한다:
+
+| OAS / SDK signal | MASC semantic | Receipt outcome |
+|------------------|---------------|-----------------|
+| `Retry.Timeout` | `provider_wall_clock_timeout` | `cancelled` |
+| `MaxTurnsExceeded` | `oas_turn_budget_exhausted` | `cancelled` |
+| `IdleDetected` | `oas_idle_budget_exhausted` | `cancelled` |
+| `ExitConditionMet` | `oas_exit_condition_reached` | `cancelled` |
+| `TokenBudgetExceeded` | `oas_token_budget_exhausted` | `error` |
+| `CostBudgetExceeded` | `oas_cost_budget_exhausted` | `error` |
+| other SDK/API failure | `sdk_error_failure` or specific OAS failure semantic | `error` |
+
+Invariant: new OAS terminal variants must first be assigned a stable
+`sdk_termination_semantics` value, then mapped to keeper receipt outcome.
+Tests in `test/test_keeper_terminal_reason.ml` pin the semantic layer and the
+collapsed receipt outcome separately.
+
+### 4.7 MASC Tool Bridge
 
 `run_with_masc_tools`와 `run_named_with_masc_tools`가 MASC 도구 스키마를 OAS `Tool.t`로 변환한다.
 

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -55,6 +55,68 @@ let sdk_error_kind = function
   | Agent_sdk.Error.Internal _ -> "internal"
 ;;
 
+type sdk_termination_semantics =
+  | Provider_wall_clock_timeout
+  | Oas_turn_budget_exhausted
+  | Oas_idle_budget_exhausted
+  | Oas_exit_condition_reached
+  | Oas_token_budget_exhausted
+  | Oas_cost_budget_exhausted
+  | Oas_cost_budget_unenforceable
+  | Oas_contract_violation
+  | Oas_tool_retry_exhausted
+  | Oas_guardrail_violation
+  | Oas_tripwire_violation
+  | Sdk_error_failure
+
+let sdk_termination_semantics = function
+  | Agent_sdk.Error.Api (Agent_sdk.Retry.Timeout _) -> Provider_wall_clock_timeout
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded _) ->
+    Oas_turn_budget_exhausted
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.IdleDetected _) ->
+    Oas_idle_budget_exhausted
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.ExitConditionMet _) ->
+    Oas_exit_condition_reached
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.TokenBudgetExceeded _) ->
+    Oas_token_budget_exhausted
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.CostBudgetExceeded _) ->
+    Oas_cost_budget_exhausted
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.CostBudgetUnenforceable _) ->
+    Oas_cost_budget_unenforceable
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.CompletionContractViolation _) ->
+    Oas_contract_violation
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.ToolRetryExhausted _) ->
+    Oas_tool_retry_exhausted
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.GuardrailViolation _) ->
+    Oas_guardrail_violation
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.TripwireViolation _) ->
+    Oas_tripwire_violation
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.UnrecognizedStopReason _) -> Sdk_error_failure
+  | Agent_sdk.Error.Api _ -> Sdk_error_failure
+  | Agent_sdk.Error.Mcp _ -> Sdk_error_failure
+  | Agent_sdk.Error.Config _ -> Sdk_error_failure
+  | Agent_sdk.Error.Serialization _ -> Sdk_error_failure
+  | Agent_sdk.Error.Io _ -> Sdk_error_failure
+  | Agent_sdk.Error.Orchestration _ -> Sdk_error_failure
+  | Agent_sdk.Error.A2a _ -> Sdk_error_failure
+  | Agent_sdk.Error.Internal _ -> Sdk_error_failure
+;;
+
+let sdk_termination_semantics_to_string = function
+  | Provider_wall_clock_timeout -> "provider_wall_clock_timeout"
+  | Oas_turn_budget_exhausted -> "oas_turn_budget_exhausted"
+  | Oas_idle_budget_exhausted -> "oas_idle_budget_exhausted"
+  | Oas_exit_condition_reached -> "oas_exit_condition_reached"
+  | Oas_token_budget_exhausted -> "oas_token_budget_exhausted"
+  | Oas_cost_budget_exhausted -> "oas_cost_budget_exhausted"
+  | Oas_cost_budget_unenforceable -> "oas_cost_budget_unenforceable"
+  | Oas_contract_violation -> "oas_contract_violation"
+  | Oas_tool_retry_exhausted -> "oas_tool_retry_exhausted"
+  | Oas_guardrail_violation -> "oas_guardrail_violation"
+  | Oas_tripwire_violation -> "oas_tripwire_violation"
+  | Sdk_error_failure -> "sdk_error_failure"
+;;
+
 (* Per-variant terminal_reason_code for Agent_sdk.Error.Api.
    Previously every API failure collapsed to "api_error", so 7 keepers
    stuck on different conditions (rate limit, overload, server fault,
@@ -146,27 +208,20 @@ let api_error_terminal_reason_code_typed err =
   Keeper_turn_terminal_code.of_sdk_error_wire (api_error_terminal_reason_code err)
 ;;
 
-let receipt_outcome_kind_of_sdk_error = function
-  | Agent_sdk.Error.Api (Agent_sdk.Retry.Timeout _) -> `Cancelled
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded _) -> `Cancelled
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.IdleDetected _) -> `Cancelled
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.ExitConditionMet _) -> `Cancelled
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.TokenBudgetExceeded _) -> `Error
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.CostBudgetExceeded _) -> `Error
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.CostBudgetUnenforceable _) -> `Error
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.UnrecognizedStopReason _) -> `Error
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.ToolRetryExhausted _) -> `Error
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.CompletionContractViolation _) -> `Error
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.GuardrailViolation _) -> `Error
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.TripwireViolation _) -> `Error
-  | Agent_sdk.Error.Api _ -> `Error
-  | Agent_sdk.Error.Mcp _ -> `Error
-  | Agent_sdk.Error.Config _ -> `Error
-  | Agent_sdk.Error.Serialization _ -> `Error
-  | Agent_sdk.Error.Io _ -> `Error
-  | Agent_sdk.Error.Orchestration _ -> `Error
-  | Agent_sdk.Error.A2a _ -> `Error
-  | Agent_sdk.Error.Internal _ -> `Error
+let receipt_outcome_kind_of_sdk_error err =
+  match sdk_termination_semantics err with
+  | Provider_wall_clock_timeout
+  | Oas_turn_budget_exhausted
+  | Oas_idle_budget_exhausted
+  | Oas_exit_condition_reached -> `Cancelled
+  | Oas_token_budget_exhausted
+  | Oas_cost_budget_exhausted
+  | Oas_cost_budget_unenforceable
+  | Oas_contract_violation
+  | Oas_tool_retry_exhausted
+  | Oas_guardrail_violation
+  | Oas_tripwire_violation
+  | Sdk_error_failure -> `Error
 ;;
 
 let checkpoint_persistence_error ~keeper_name ~detail =

--- a/lib/keeper/keeper_agent_error.mli
+++ b/lib/keeper/keeper_agent_error.mli
@@ -31,6 +31,33 @@ val sdk_error_of_keeper_internal_error
 (** Coarse categorisation of [Agent_sdk.Error.sdk_error] (for dashboards). *)
 val sdk_error_kind : Agent_sdk.Error.sdk_error -> string
 
+(** Layer-aware termination semantics for SDK errors crossing the OAS ->
+    keeper boundary.
+
+    DD-015: adjacent runtimes use "turn" and "timeout" at different
+    layers.  This contract keeps OAS turn-budget stops distinct from
+    keeper wall-clock/provider timeouts before they collapse to receipt
+    outcomes. *)
+type sdk_termination_semantics =
+  | Provider_wall_clock_timeout
+  | Oas_turn_budget_exhausted
+  | Oas_idle_budget_exhausted
+  | Oas_exit_condition_reached
+  | Oas_token_budget_exhausted
+  | Oas_cost_budget_exhausted
+  | Oas_cost_budget_unenforceable
+  | Oas_contract_violation
+  | Oas_tool_retry_exhausted
+  | Oas_guardrail_violation
+  | Oas_tripwire_violation
+  | Sdk_error_failure
+
+val sdk_termination_semantics
+  :  Agent_sdk.Error.sdk_error
+  -> sdk_termination_semantics
+
+val sdk_termination_semantics_to_string : sdk_termination_semantics -> string
+
 (** RFC-0042 PR-2.5: typed bridge variants of the wire accessors.
     Wrap the existing parametrised wire string in
     [Keeper_turn_terminal_code.Sdk_error]. PR-3 swaps

--- a/test/test_keeper_terminal_reason.ml
+++ b/test/test_keeper_terminal_reason.ml
@@ -105,6 +105,56 @@ let outcome_code err =
     (KAE.receipt_outcome_kind_of_sdk_error err)
 ;;
 
+let termination_semantics_code err =
+  KAE.sdk_termination_semantics err |> KAE.sdk_termination_semantics_to_string
+;;
+
+let test_layered_termination_semantics () =
+  check
+    string
+    "provider timeout stays provider layer"
+    "provider_wall_clock_timeout"
+    (termination_semantics_code (mk_api (Agent_sdk.Retry.Timeout { message = "x" })));
+  check
+    string
+    "max_turns stays OAS turn budget"
+    "oas_turn_budget_exhausted"
+    (termination_semantics_code
+       (mk_agent (Agent_sdk.Error.MaxTurnsExceeded { turns = 1; limit = 1 })));
+  check
+    string
+    "idle stays OAS idle budget"
+    "oas_idle_budget_exhausted"
+    (termination_semantics_code
+       (mk_agent (Agent_sdk.Error.IdleDetected { consecutive_idle_turns = 3 })));
+  check
+    string
+    "exit condition stays OAS exit condition"
+    "oas_exit_condition_reached"
+    (termination_semantics_code
+       (mk_agent (Agent_sdk.Error.ExitConditionMet { turn = 5 })));
+  check
+    string
+    "token budget stays OAS token budget"
+    "oas_token_budget_exhausted"
+    (termination_semantics_code
+       (mk_agent
+          (Agent_sdk.Error.TokenBudgetExceeded
+             { kind = "Input"; used = 10; limit = 5 })));
+  check
+    string
+    "cost budget stays OAS cost budget"
+    "oas_cost_budget_exhausted"
+    (termination_semantics_code
+       (mk_agent
+          (Agent_sdk.Error.CostBudgetExceeded { spent_usd = 2.0; limit_usd = 1.0 })));
+  check
+    string
+    "auth is generic SDK failure"
+    "sdk_error_failure"
+    (termination_semantics_code (mk_api (Agent_sdk.Retry.AuthError { message = "x" })))
+;;
+
 let test_timeout_receipt_outcome_is_cancelled () =
   check
     string
@@ -484,6 +534,10 @@ let () =
             "non-timeout receipt outcome -> error"
             `Quick
             test_non_timeout_receipt_outcome_is_error
+        ; test_case
+            "OAS termination semantics preserve layer"
+            `Quick
+            test_layered_termination_semantics
         ; test_case
             "agent max_turns receipt outcome -> cancelled"
             `Quick


### PR DESCRIPTION
## Summary
- add a layer-aware sdk_termination_semantics contract for OAS -> keeper SDK errors
- route keeper receipt outcome mapping through that contract without changing existing outcomes
- document the OAS termination boundary so OAS max_turns stays distinct from keeper/provider wall-clock timeout

## Deep-dive link
- DD-015: termination conditions were defined at different layers across systems, which risked silently conflating OAS turn budgets with keeper/provider timeouts.

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_agent_error.ml lib/keeper/keeper_agent_error.mli test/test_keeper_terminal_reason.ml
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_terminal_reason.exe
- ./_build/default/test/test_keeper_terminal_reason.exe (36 tests)