### PR TITLE
fix(keeper): persist turn FSM transition WAL

### DIFF
--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -229,6 +229,16 @@ type completed_turn_record =
   ; outcome : completed_turn_outcome
   }
 
+type turn_fsm_transition_record =
+  { turn_fsm_turn_id : int
+  ; turn_fsm_prev_state : string
+  ; turn_fsm_new_state : string
+  ; turn_fsm_action : string
+  ; turn_fsm_stop_signaled_before : bool option
+  ; turn_fsm_stop_signaled_after : bool option
+  ; turn_fsm_wall_clock_at : float
+  }
+
 let completed_turn_outcome_to_json = function
   | Turn_substantive -> `String "substantive"
   | Turn_failed -> `String "failed"
@@ -248,6 +258,19 @@ let completed_turn_to_json (r : completed_turn_record) : Yojson.Safe.t =
     ; "started_at", `Float r.started_at
     ; "ended_at", `Float r.ended_at
     ; "outcome", completed_turn_outcome_to_json r.outcome
+    ]
+;;
+
+let turn_fsm_transition_to_json (r : turn_fsm_transition_record) : Yojson.Safe.t =
+  `Assoc
+    [ "turn_id", `Int r.turn_fsm_turn_id
+    ; "prev_state", `String r.turn_fsm_prev_state
+    ; "new_state", `String r.turn_fsm_new_state
+    ; "action", `String r.turn_fsm_action
+    ; ( "stop_signaled_before"
+      , Json_util.bool_opt_to_json r.turn_fsm_stop_signaled_before )
+    ; "stop_signaled_after", Json_util.bool_opt_to_json r.turn_fsm_stop_signaled_after
+    ; "wall_clock_at", `Float r.turn_fsm_wall_clock_at
     ]
 ;;
 
@@ -426,6 +449,23 @@ let append_completed_turn_to_default_store ~keeper_name (rec_ : completed_turn_r
      | exn -> observe_append_failure ~site:"default_completed_append" exn)
 ;;
 
+let append_turn_fsm_transition_to_default_store
+      ~keeper_name
+      (rec_ : turn_fsm_transition_record)
+  =
+  match get_default_store () with
+  | None -> ()
+  | Some store ->
+    let json =
+      `Assoc
+        [ "keeper", `String keeper_name
+        ; "turn_fsm_transition", turn_fsm_transition_to_json rec_
+        ]
+    in
+    (try Dated_jsonl.append store json with
+     | exn -> observe_append_failure ~site:"default_turn_fsm_append" exn)
+;;
+
 let record_transition ~keeper_name (rec_ : transition_record) =
   let ring = get_or_create_ring keeper_name in
   ring.buf.(ring.pos) <- Some rec_;
@@ -495,6 +535,26 @@ let record_completed_turn ~keeper_name (rec_ : completed_turn_record) =
          (fun () -> output_string oc (line ^ "\n"))
      with
      | exn -> observe_append_failure ~site:"sink_completed_append" exn)
+;;
+
+let record_turn_fsm_transition ~keeper_name (rec_ : turn_fsm_transition_record) =
+  match sink_path () with
+  | None -> append_turn_fsm_transition_to_default_store ~keeper_name rec_
+  | Some path ->
+    (try
+       let line =
+         Yojson.Safe.to_string
+           (`Assoc
+               [ "keeper", `String keeper_name
+               ; "turn_fsm_transition", turn_fsm_transition_to_json rec_
+               ])
+       in
+       let oc = open_out_gen [ Open_wronly; Open_append; Open_creat ] 0o644 path in
+       Eio_guard.protect
+         ~finally:(fun () -> close_out_noerr oc)
+         (fun () -> output_string oc (line ^ "\n"))
+     with
+     | exn -> observe_append_failure ~site:"sink_turn_fsm_append" exn)
 ;;
 
 let recent_completed_turns_from_store ~keeper_name ~limit =

--- a/lib/keeper/keeper_transition_audit.mli
+++ b/lib/keeper/keeper_transition_audit.mli
@@ -32,6 +32,23 @@ type completed_turn_record = {
   outcome : completed_turn_outcome;
 }
 
+(** Append-only WAL row for RFC-0072 keeper turn FSM transitions.  This
+    records turn-internal state movement before the final execution receipt
+    exists, so restart forensics do not have to rely on stderr/log scraping. *)
+type turn_fsm_transition_record = {
+  turn_fsm_turn_id : int;
+  turn_fsm_prev_state : string;
+  turn_fsm_new_state : string;
+  turn_fsm_action : string;
+  turn_fsm_stop_signaled_before : bool option;
+  turn_fsm_stop_signaled_after : bool option;
+  turn_fsm_wall_clock_at : float;
+}
+
+(** Serialize a turn FSM transition WAL row. *)
+val turn_fsm_transition_to_json :
+  turn_fsm_transition_record -> Yojson.Safe.t
+
 (** {1 In-memory Ring Buffer} *)
 
 (** Record a transition in the per-keeper ring buffer (last 50). *)
@@ -49,6 +66,11 @@ val recent_transitions_json :
 (** Record a completed keeper turn in the per-keeper ring buffer (last 50). *)
 val record_completed_turn :
   keeper_name:string -> completed_turn_record -> unit
+
+(** Append a turn FSM transition to the same durable audit sink used by
+    lifecycle transitions and completed turns. *)
+val record_turn_fsm_transition :
+  keeper_name:string -> turn_fsm_transition_record -> unit
 
 (** Retrieve recent completed keeper turns for a keeper, newest first. *)
 val recent_completed_turns :

--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -307,6 +307,7 @@ let observe_phase_dwell ~keeper_name ~from_label =
         dwell)
 
 let emit_transition ?ctx ~keeper_name ~turn_id ?prev state =
+  let now = Unix.gettimeofday () in
   let prev_label =
     match prev with
     | Some s -> turn_state_label s
@@ -315,7 +316,7 @@ let emit_transition ?ctx ~keeper_name ~turn_id ?prev state =
   (match prev with
    | Some _ -> observe_phase_dwell ~keeper_name ~from_label:prev_label
    | None -> ());
-  Hashtbl.replace last_transition_at keeper_name (Unix.gettimeofday ());
+  Hashtbl.replace last_transition_at keeper_name now;
   let classified =
     match prev with
     | Some from_state ->
@@ -342,6 +343,16 @@ let emit_transition ?ctx ~keeper_name ~turn_id ?prev state =
   Log.Keeper.info ~keeper_name ~turn_id
     "[fsm:transition] %s -> %s action=%s%s" prev_label state_label action_label
     stop_label;
+  Keeper_transition_audit.record_turn_fsm_transition
+    ~keeper_name
+    { turn_fsm_turn_id = turn_id
+    ; turn_fsm_prev_state = prev_label
+    ; turn_fsm_new_state = state_label
+    ; turn_fsm_action = action_label
+    ; turn_fsm_stop_signaled_before = Option.map (fun c -> c.stop_signaled_before) ctx
+    ; turn_fsm_stop_signaled_after = Option.map (fun c -> c.stop_signaled_after) ctx
+    ; turn_fsm_wall_clock_at = now
+    };
   Prometheus.inc_counter Keeper_metrics.metric_keeper_turn_fsm_transitions
     ~labels:
       [ ("from", prev_label);

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -169,12 +169,12 @@ val emit_transition :
 (** Emit a structured FSM transition log line.
 
     Step 4b kicks off the call-site adoption stack: this is an
-    observe-only secondary emit alongside the existing receipt
-    path.  The runtime branch shape is unchanged; the line
-    surfaces in [bin/masc-trace] via the [turn_id] correlator
-    wired in Step 0a (#11154 / #11156 / #11159) so an operator
-    can see the state the runtime *intended* without parsing
-    the receipt JSON.
+    observe-only secondary emit alongside the existing receipt path.  The
+    runtime branch shape is unchanged; the transition is both logged and
+    appended to [Keeper_transition_audit] as a turn-FSM WAL row via the
+    [turn_id] correlator wired in Step 0a (#11154 / #11156 / #11159), so an
+    operator can see the state the runtime *intended* without waiting for the
+    final receipt JSON.
 
     The line format is
     [\[fsm:transition\] <prev> -> <state> action=<action> stop_before=.. stop_after=..];

--- a/test/test_keeper_transition_audit.ml
+++ b/test/test_keeper_transition_audit.ml
@@ -4,6 +4,7 @@
 open Alcotest
 
 module Audit = Masc_mcp.Keeper_transition_audit
+module KTF = Masc_mcp.Keeper_turn_fsm
 module KSM = Masc_mcp.Keeper_state_machine
 module P = Masc_mcp.Prometheus
 
@@ -81,6 +82,15 @@ let with_invalid_default_store f =
       with_env "MASC_KEEPER_TRANSITION_LOG" "" (fun () ->
           with_env "MASC_BASE_PATH" base_file (fun () ->
               with_env "MASC_BASE_PATH_INPUT" base_file f)))
+
+let read_jsonl path =
+  let ic = open_in path in
+  let rec loop acc =
+    match input_line ic with
+    | line -> loop (Yojson.Safe.from_string line :: acc)
+    | exception End_of_file -> List.rev acc
+  in
+  Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () -> loop [])
 
 (* ── Helpers to exercise the JSON round-trip via store ─────────── *)
 
@@ -187,6 +197,8 @@ let test_compact_retry_exhausted_signal_is_alerting () =
     (signal |> member "next_human_action" |> to_string)
 
 let test_runtime_trust_timeline_carries_transition_operator_signal () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Audit.For_testing.reset_state ();
   let base_dir = temp_dir () in
   Fun.protect
@@ -211,6 +223,37 @@ let test_runtime_trust_timeline_carries_transition_operator_signal () =
             (event |> member "next_human_action" |> to_string);
           check string "transition severity" "warn"
             (event |> member "severity" |> to_string)))
+
+let test_turn_fsm_emit_transition_appends_wal_row () =
+  Audit.For_testing.reset_state ();
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Audit.For_testing.reset_state ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let sink = Filename.concat base_dir "transition-audit.jsonl" in
+      with_env "MASC_KEEPER_TRANSITION_LOG" sink (fun () ->
+          KTF.emit_transition
+            ~keeper_name:"turn-fsm-wal-keeper"
+            ~turn_id:42
+            ~prev:KTF.Streaming
+            KTF.Completing;
+          match read_jsonl sink with
+          | [ json ] ->
+            let open Yojson.Safe.Util in
+            check string "keeper" "turn-fsm-wal-keeper"
+              (json |> member "keeper" |> to_string);
+            let row = json |> member "turn_fsm_transition" in
+            check int "turn_id" 42 (row |> member "turn_id" |> to_int);
+            check string "prev_state" "streaming"
+              (row |> member "prev_state" |> to_string);
+            check string "new_state" "completing"
+              (row |> member "new_state" |> to_string);
+            check string "action" "StreamComplete"
+              (row |> member "action" |> to_string)
+          | rows ->
+            failf "expected one turn_fsm_transition row, got %d" (List.length rows)))
 
 let test_default_transition_append_failure_is_observed_and_ring_retained () =
   Audit.For_testing.reset_state ();
@@ -303,6 +346,32 @@ let test_completed_turn_sink_failure_is_observed_and_ring_retained () =
             (List.length
                (Audit.recent_completed_turns ~keeper_name ~limit:5))))
 
+let test_turn_fsm_sink_failure_is_observed () =
+  Audit.For_testing.reset_state ();
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Audit.For_testing.reset_state ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let missing_parent = Filename.concat base_dir "missing-parent" in
+      let sink = Filename.concat missing_parent "transition-audit.jsonl" in
+      with_env "MASC_KEEPER_TRANSITION_LOG" sink (fun () ->
+          let before = transition_audit_failure_count "sink_turn_fsm_append" in
+          Audit.record_turn_fsm_transition
+            ~keeper_name:"turn-fsm-sink-failure"
+            { turn_fsm_turn_id = 1
+            ; turn_fsm_prev_state = "Streaming"
+            ; turn_fsm_new_state = "Completing"
+            ; turn_fsm_action = "StreamComplete"
+            ; turn_fsm_stop_signaled_before = None
+            ; turn_fsm_stop_signaled_after = None
+            ; turn_fsm_wall_clock_at = 1.0
+            };
+          let after = transition_audit_failure_count "sink_turn_fsm_append" in
+          check (float 0.0001) "turn fsm sink append failure counted"
+            (before +. 1.0) after))
+
 let test_append_failure_observer_reraises_cancelled () =
   let raised = ref false in
   (try
@@ -333,6 +402,8 @@ let () =
             test_compact_retry_exhausted_signal_is_alerting;
           test_case "runtime trust timeline carries signal" `Quick
             test_runtime_trust_timeline_carries_transition_operator_signal;
+          test_case "turn FSM emit appends WAL row" `Quick
+            test_turn_fsm_emit_transition_appends_wal_row;
         ] );
       ( "append_failures",
         [
@@ -344,6 +415,8 @@ let () =
             test_sink_append_failure_is_observed_and_ring_retained;
           test_case "completed sink append failure observed and ring retained" `Quick
             test_completed_turn_sink_failure_is_observed_and_ring_retained;
+          test_case "turn FSM sink failure observed" `Quick
+            test_turn_fsm_sink_failure_is_observed;
           test_case "observer re-raises cancellation" `Quick
             test_append_failure_observer_reraises_cancelled;
         ] );


### PR DESCRIPTION
## Summary
- append keeper turn-FSM transitions to the durable transition audit sink
- expose a typed turn_fsm_transition WAL record for both explicit sink and default dated-jsonl stores
- add regression tests for emit_transition persistence and sink failure metrics

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_transition_audit.ml lib/keeper/keeper_transition_audit.mli lib/keeper/keeper_turn_fsm.ml lib/keeper/keeper_turn_fsm.mli test/test_keeper_transition_audit.ml
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_transition_audit.exe
- ./_build/default/test/test_keeper_transition_audit.exe