### PR TITLE
fix(memory): route keeper turns through bridge factory

### DIFF
--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -1722,14 +1722,15 @@ let prepare_agent_setup
     let hooks = Agent_sdk.Hooks.compose ~outer:before_turn_hook ~inner:base_hooks in
     let base_dir = Coord.masc_root_dir config in
     let memory_session_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
-    let memory_backend =
-      Memory_oas_bridge.make_backend
+    let memory_bundle =
+      Memory_oas_bridge.create_memory_with_backend
         ~agent_name
         ~base_dir
         ~session_id:memory_session_id
         ()
     in
-    let memory = Agent_sdk.Memory.create ~long_term:memory_backend () in
+    let memory = memory_bundle.created_memory in
+    let memory_backend = memory_bundle.created_memory_long_term_backend in
     let hooks =
       let mem_hooks =
         Memory_hooks.make

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -250,19 +250,31 @@ let make_backend ?base_dir ~(agent_name : string) ~(session_id : string) ()
   let base_dir = resolve_base_dir ?base_dir () in
   Memory_jsonl.make_backend ~base_dir ~agent_name ~session_id
 
+type created_memory =
+  { created_memory : Agent_sdk.Memory.t
+  ; created_memory_long_term_backend : Agent_sdk.Memory.long_term_backend
+  }
+
 (** Create an OAS [Memory.t] instance.
 
     Uses JSONL long_term_backend (filesystem-first).
     @param session_id Session identifier; defaults to timestamp-based ID. *)
-let create_memory ~(agent_name : string) ?(base_dir : string option)
+let create_memory_with_backend ~(agent_name : string) ?(base_dir : string option)
     ?(session_id : string option)
-    () : Agent_sdk.Memory.t =
+    () : created_memory =
   let sid = match session_id with
     | Some s -> s
     | None -> generate_session_id ()
   in
   let backend = make_backend ?base_dir ~agent_name ~session_id:sid () in
-  Agent_sdk.Memory.create ~long_term:backend ()
+  { created_memory = Agent_sdk.Memory.create ~long_term:backend ()
+  ; created_memory_long_term_backend = backend
+  }
+
+let create_memory ~(agent_name : string) ?(base_dir : string option)
+    ?(session_id : string option)
+    () : Agent_sdk.Memory.t =
+  (create_memory_with_backend ~agent_name ?base_dir ?session_id ()).created_memory
 
 (** Load and return the institution welcome text, or [None] when empty.
     Used by [load_institution_text]. *)

--- a/lib/memory_oas_bridge.mli
+++ b/lib/memory_oas_bridge.mli
@@ -44,6 +44,22 @@ val create_memory :
     {!Time_compat.now}.  Filesystem-first: no PG, no
     network. *)
 
+type created_memory =
+  { created_memory : Agent_sdk.Memory.t
+  ; created_memory_long_term_backend : Agent_sdk.Memory.long_term_backend
+  }
+
+val create_memory_with_backend :
+  agent_name:string ->
+  ?base_dir:string ->
+  ?session_id:string ->
+  unit ->
+  created_memory
+(** Creates an [Agent_sdk.Memory.t] and returns the exact long-term
+    backend installed into it.  Keeper turn hot paths use this when
+    hooks also need to read long-term world memory through the same
+    backend. *)
+
 (** {1 OAS / MASC episode round-trip} *)
 
 val oas_procedure_of_masc :

--- a/test/test_memory_oas_5tier.ml
+++ b/test/test_memory_oas_5tier.ml
@@ -439,6 +439,30 @@ let test_jsonl_backend_uses_explicit_base_dir () =
   Alcotest.(check bool) "writes under explicit base_dir" true (Sys.file_exists expected_path);
   cleanup_tmp_dir dir
 
+let test_create_memory_with_backend_uses_same_backend () =
+  let dir = setup_tmp_dir () in
+  let base_dir = Filename.concat dir ".masc-room-b" in
+  let sid = Printf.sprintf "test-bundle-%d" (int_of_float (Unix.gettimeofday () *. 1000.0)) in
+  let bundle =
+    Memory_oas_bridge.create_memory_with_backend
+      ~base_dir
+      ~agent_name:"test-jsonl"
+      ~session_id:sid
+      ()
+  in
+  ignore
+    (Agent_sdk.Memory.store
+       bundle.created_memory
+       ~tier:Agent_sdk.Memory.Long_term
+       "world:bundle"
+       (`String "ok"));
+  (match
+     bundle.created_memory_long_term_backend.retrieve ~key:"world:bundle"
+   with
+   | Some (`String value) -> Alcotest.(check string) "stored via same backend" "ok" value
+   | _ -> Alcotest.fail "expected memory store to use returned backend");
+  cleanup_tmp_dir dir
+
 let test_flush_episodes_appends_only_new_records () =
   let dir = setup_tmp_dir () in
   let existing =
@@ -613,6 +637,8 @@ let () =
       Alcotest.test_case "query returns empty" `Quick test_jsonl_backend_query;
       Alcotest.test_case "uses explicit base_dir" `Quick
         test_jsonl_backend_uses_explicit_base_dir;
+      Alcotest.test_case "create_memory_with_backend uses same backend" `Quick
+        test_create_memory_with_backend_uses_same_backend;
       Alcotest.test_case "flush_episodes appends only new" `Quick
         test_flush_episodes_appends_only_new_records;
       Alcotest.test_case "successful keeper turn preserves OAS turn count" `Quick


### PR DESCRIPTION
## Summary
- add `Memory_oas_bridge.create_memory_with_backend` so callers can get the exact long-term backend installed into the returned `Memory.t`
- route the keeper turn hot path through the bridge factory instead of rebuilding `make_backend + Agent_sdk.Memory.create` inline
- add regression coverage that stores through the returned memory and reads through the returned backend

## Why
This keeps the real keeper execution path on the bridge factory boundary. Future OAS Memory backend expansion, including episodic/procedural persistence work, can be adopted in one bridge constructor instead of being bypassed by keeper turns.

## Verification
- `opam exec -- ocamlformat --check lib/memory_oas_bridge.ml lib/memory_oas_bridge.mli lib/keeper/keeper_run_tools.ml test/test_memory_oas_5tier.ml`
- `git diff --check`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_memory_oas_5tier.exe`
- `./_build/default/test/test_memory_oas_5tier.exe` (21 tests)