### PR TITLE
feat(ide): summarize context lens routes

### DIFF
--- a/dashboard/src/components/ide/ide-context-lens.test.ts
+++ b/dashboard/src/components/ide/ide-context-lens.test.ts
@@ -498,6 +498,7 @@ describe('IdeContextLens', () => {
     )
 
     const links = [...container.querySelectorAll<HTMLButtonElement>('.ide-context-route-link')]
+    expect(container.querySelector('.ide-context-route-count')?.textContent).toBe('CTX 4')
     expect(links.map(link => link.textContent)).toEqual(['Code', 'Goal', 'Task', 'Keeper'])
 
     fireEvent.click(links.find(link => link.textContent === 'Goal')!)

--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -462,6 +462,7 @@ function ContextAnchorRow(
         </button>
         ${anchor.route_links && anchor.route_links.length > 0 ? html`
           <div class="ide-context-route-links" aria-label="Operational links">
+            <${ContextRouteCount} count=${anchor.route_links.length} />
             ${anchor.route_links.map(link => html`
               <button
                 key=${link.id}
@@ -481,6 +482,18 @@ function ContextAnchorRow(
         ? html`<${KeeperBadge} id=${anchor.keeper_id} variant="sigil" size="sm" />`
         : null}
     </li>
+  `
+}
+
+function ContextRouteCount({ count }: { count: number }) {
+  return html`
+    <span
+      class="ide-context-route-count"
+      title=${`${count} linked context routes`}
+      aria-label=${`${count} linked context routes`}
+    >
+      CTX ${count}
+    </span>
   `
 }
 

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -2065,9 +2065,26 @@ button.ide-persistence-focus:focus-visible {
 
 .ide-context-route-links {
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
   gap: 3px;
   min-width: 0;
+}
+
+.ide-context-route-count {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 5px;
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--r-1);
+  background: var(--color-bg-canvas);
+  color: var(--color-fg-muted);
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  font-weight: 700;
+  line-height: 1;
 }
 
 .ide-context-route-link {


### PR DESCRIPTION
## Summary

- add a compact `CTX N` count chip to Context Lens anchor operational-link rows
- keep the existing Code/Goal/Task/Keeper route buttons and activation behavior unchanged
- cover the route-count chip in the focused Context Lens unit test

## Validation

- `pnpm install --offline`
- `pnpm exec vitest run src/components/ide/ide-context-lens.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/ide/ide-context-lens.ts src/components/ide/ide-context-lens.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`
