### PR TITLE
feat(ide): summarize keeper work context routes

### DIFF
--- a/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
@@ -81,6 +81,8 @@ describe('IdeKeeperWorkPanel', () => {
     expect(container.textContent).toContain('50%')
     expect(container.textContent).toContain('Goal')
     expect(container.textContent).toContain('Task')
+    expect(container.querySelector('.ide-keeper-work-goal .ide-keeper-work-route-count')?.textContent)
+      .toBe('CTX 2')
 
     fireEvent.click(buttonByText(container, 'Goal'))
     expect(window.location.hash).toBe('#workspace?section=planning&goal=goal-runtime')
@@ -103,6 +105,8 @@ describe('IdeKeeperWorkPanel', () => {
     const taskLinks = Array.from(
       container.querySelectorAll<HTMLButtonElement>('.ide-keeper-work-card .ide-keeper-work-links button'),
     )
+    expect(container.querySelector('.ide-keeper-work-card .ide-keeper-work-route-count')?.textContent)
+      .toBe('CTX 5')
     expect(taskLinks.map(link => link.textContent)).toEqual([
       'Goal',
       'Task',

--- a/dashboard/src/components/ide/ide-keeper-work-panel.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.ts
@@ -212,6 +212,13 @@ function KeeperWorkRouteLinks(
   if (links.length === 0) return null
   return html`
     <div class="ide-keeper-work-links" aria-label=${label}>
+      <span
+        class="ide-keeper-work-route-count"
+        title=${`${links.length} linked keeper work context routes`}
+        aria-label=${`${links.length} linked keeper work context routes`}
+      >
+        CTX ${links.length}
+      </span>
       ${links.map(link => html`
         <button
           key=${link.id}

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -988,6 +988,19 @@
   cursor: pointer;
 }
 
+.ide-keeper-work-route-count {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 1px var(--sp-2);
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--r-1);
+  background: var(--color-bg-canvas);
+  color: var(--color-fg-muted);
+  flex-shrink: 0;
+  font: var(--type-eyebrow);
+}
+
 .ide-keeper-work-links button:hover,
 .ide-keeper-work-links button:focus-visible {
   border-color: var(--color-accent-fg);


### PR DESCRIPTION
## Summary

- add a compact `CTX N` route-count chip to Keeper Work task and goal operational-link rows
- keep existing Goal/Task/Git/Telemetry/Keeper buttons and navigation behavior unchanged
- cover task and goal route-count chips in the focused Keeper Work panel test

## Validation

- `pnpm install --offline`
- `pnpm exec vitest run src/components/ide/ide-keeper-work-panel.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/ide/ide-keeper-work-panel.ts src/components/ide/ide-keeper-work-panel.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`
