### PR TITLE
fix(provider): rescue runtime overlay purge

### DIFF
--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -310,10 +310,12 @@ let runtime_kind_of_binding (binding : Runtime_binding.t) =
 ;;
 
 let binding_supports_runtime_mcp_http_headers (binding : Runtime_binding.t) =
-  binding.Runtime_binding.capabilities.supports_runtime_mcp_tools
-  || binding.Runtime_binding.capabilities.supports_runtime_tool_events
-  || (runtime_kind_of_binding binding = Cli_agent
-      && binding.Runtime_binding.capabilities.supports_tools)
+  match runtime_kind_of_binding binding with
+  | Cli_agent ->
+    binding.Runtime_binding.capabilities.supports_tools
+  | Local | Direct_api ->
+    binding.Runtime_binding.capabilities.supports_runtime_mcp_tools
+    || binding.Runtime_binding.capabilities.supports_runtime_tool_events
 ;;
 
 let binding_uses_prompt_caching (binding : Runtime_binding.t) =

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -335,11 +335,23 @@ let test_runtime_mcp_header_support_uses_declared_policy () =
       ~base_url:""
       ()
   in
+  let gemini_cli_cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Gemini_cli
+      ~model_id:"gemini-3-flash-preview"
+      ~base_url:""
+      ()
+  in
   check
     bool
     "kimi cli supports runtime MCP headers"
     true
     (Adapter.supports_runtime_mcp_http_headers_for_config kimi_cli_cfg);
+  check
+    bool
+    "gemini cli does not support request-scoped runtime MCP headers"
+    false
+    (Adapter.supports_runtime_mcp_http_headers_for_config gemini_cli_cfg);
   check
     bool
     "codex cli does not support runtime MCP headers"


### PR DESCRIPTION
## Summary

- Rescues the useful part of orphan commit `2808853161` after rebasing onto current `main`.
- Latest `main` already contains the broader provider runtime overlay purge, so this PR now carries only the missing Gemini CLI runtime-MCP admission fix.
- Prevents keeper PR-review tools from admitting Gemini CLI's text-only path by requiring CLI runtime-MCP header support to have a materialized tool surface.

## Product impact

- User-visible change: keeper PR-review tools no longer route to a CLI provider path that cannot materialize request-scoped runtime MCP tools.

## Evidence

- Orphan source: local branch `fix/provider-adapter-target-cleanup-20260514` had local-only commit `2808853161` while merged PR #15315 used `5ca5ea8c`.
- Rebased onto current `origin/main` `813e930bf1`; final PR diff is 2 files: `lib/provider_adapter.ml`, `test/test_provider_adapter.ml`.
- `ocamlformat --check lib/provider_adapter.ml test/test_provider_adapter.ml`
- `git diff --check origin/main...HEAD`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_provider_adapter.exe test/test_oas_worker.exe`
- `./_build/default/test/test_provider_adapter.exe` PASS, 43 tests
- `./_build/default/test/test_oas_worker.exe` PASS, 164 tests

## GOAL LOOP ACT checklist

- [x] Observe — orphaned local commit and failed keeper PR-review tool filtering test were verified locally.
- [x] Orient — latest `main` had already absorbed the broad purge, leaving the Gemini CLI runtime-MCP admission gap.
- [x] Decide — publish a small rescue PR instead of reintroducing the stale 15-file delta.
- [x] Act — narrowed CLI runtime-MCP header admission using capability shape, without adding provider-name routing branches.
- [x] Verify — focused build and regression executables listed above pass.
- [x] Loop — no separate follow-up in this PR; broader provider/OAS capability cleanup remains outside this rescue diff.

## Review evidence

- Local focused review only; no cross-model review run for this rescue patch before draft publication.

## Linked issue

- Closes #
- Relates #15315

## Variant addition checklist

- [x] **OCaml** — no OCaml variants added, removed, or renamed.
- [x] **TypeScript** — not applicable; no dashboard TypeScript touched.
- [x] **TLA+ spec** — not applicable; no TLA+ domain literal touched.
- [x] **Event / JSON schema** — not applicable; no event or JSON schema enum touched.
- [ ] **`make check-variants` passes** — not run; this rescue touches no variants or schema enums, and focused OCaml checks above passed.
