### PR TITLE
fix(keeper): target board reactive prompts

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -98,8 +98,15 @@ let format_board_events
                 | _ -> "")
            else ""
          in
-         Printf.sprintf "- [%s] %s%s%s%s: %s"
-           kind event.author hearth_note mention_note self_note event.preview)
+         Printf.sprintf "- [%s] post_id=%s title=%S author=%s%s%s%s preview: %s"
+           kind
+           event.post_id
+           (Keeper_types.short_preview ~max_len:80 event.title)
+           event.author
+           hearth_note
+           mention_note
+           self_note
+           event.preview)
        events)
 
 let line_block label value =
@@ -300,7 +307,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
   in
   let board_activity_guidance =
     if tool_allowed "keeper_board_get" && tool_allowed "keeper_board_comment" then
-      "- See board activity? Read the full post with keeper_board_get, then comment with keeper_board_comment.\n"
+      "- See board activity? Use the listed post_id with keeper_board_get before replying; do not use keeper_board_list to rediscover the target. Then comment with keeper_board_comment on that same post_id.\n"
     else
       ""
   in

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -7013,8 +7013,17 @@ let test_metrics_failure_response_redacts_resumable_cli_session_detail () =
 
 let test_prompt_includes_board_activity_section () =
   let obs = { base_observation with pending_board_events = [ sample_board_event ] } in
-  let _sys, user =
-    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
+  let board_meta =
+    { minimal_meta with
+      tool_access =
+        Preset
+          { preset = Social
+          ; also_allow = []
+          }
+    }
+  in
+  let sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:board_meta ~observation:obs ()
   in
   check
     bool
@@ -7039,7 +7048,22 @@ let test_prompt_includes_board_activity_section () =
        with
        | Not_found -> false
      in
-     found)
+     found);
+  check
+    bool
+    "includes board event post id"
+    true
+    (contains_substring user "post_id=board-post-1");
+  check
+    bool
+    "includes board event title"
+    true
+    (contains_substring user "title=\"Need help\"");
+  check
+    bool
+    "guides direct board get by post id"
+    true
+    (contains_substring sys "Use the listed post_id with keeper_board_get")
 ;;
 
 let test_prompt_marks_board_curation_due_for_multi_event_window () =


### PR DESCRIPTION
## Summary

- Include the pending board `post_id` and title in keeper board-reactive prompt lines.
- Tighten board activity guidance so keepers read the listed `post_id` with `keeper_board_get` before commenting, instead of rediscovering via `keeper_board_list`.
- Extend the unified prompt regression test to cover `post_id`, title, and direct board-get guidance.

## Product impact

- User-visible change: board-reactive keepers should respond to the specific post that woke them instead of drifting to older hot board threads.

## Root Cause

Live logs showed board wakeups firing for a fresh dashboard post, but keepers then called `keeper_board_list` with empty/default sorting and latched onto older hot posts. The prompt only included author/hearth/preview, so the model did not have the target `post_id` needed for `keeper_board_get`.

## Validation

- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe test unified_prompt 15 --show-errors`

## Evidence

- Live log pattern observed on 2026-05-15: `board signal wakeup ... post=p-25e50f48...`, followed by `keeper_board_list` with empty/default args, then comments on older hot posts.
- Regression evidence: targeted unified prompt case now asserts the board activity prompt includes `post_id`, title, and direct `keeper_board_get` guidance.

## GOAL LOOP ACT checklist

- [x] Observe — live board wakeup/tool-call/comment logs showed target drift.
- [x] Orient — mapped to missing `post_id` in `Board Activity` prompt lines.
- [x] Decide — prompt-only change is the smallest scope; it avoids changing board dispatch or tool contracts.
- [x] Act — updated keeper unified prompt formatting and test.
- [x] Verify — focused Dune build and targeted Alcotest case pass locally.
- [x] Loop — no additional follow-up in this PR.

## Review evidence

- Local Codex review of diff and focused regression output.

## Linked issue

- Relates # none

## Variant addition checklist

- [ ] **OCaml** — N/A, no variant changes.
- [ ] **TypeScript** — N/A, no dashboard type changes.
- [ ] **TLA+ spec** — N/A, no domain literal changes.
- [ ] **Event / JSON schema** — N/A, no event/schema enum changes.
- [ ] **`make check-variants` passes** — N/A, no variant/schema changes.
