### PR TITLE
feat(ide): summarize toolbar context routes

### DIFF
--- a/dashboard/src/components/ide/ide-toolbar.test.ts
+++ b/dashboard/src/components/ide/ide-toolbar.test.ts
@@ -95,6 +95,7 @@ describe('IdeToolbar', () => {
     ])
 
     const routeLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-toolbar-context-links button')]
+    expect(container.querySelector('.ide-toolbar-context-route-count')?.textContent).toBe('CTX 4')
     expect(routeLinks.map(link => link.getAttribute('aria-label'))).toEqual([
       'Open Code lib/runtime.ml:42',
       'Open Task task-runtime',

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -328,6 +328,13 @@ function ToolbarContextFocus({
       ` : null}
       ${routeLinks.length > 0 ? html`
         <div class="ide-toolbar-context-links" aria-label="Current context route links">
+          <span
+            class="ide-toolbar-context-route-count"
+            title=${`${routeLinks.length} current context route links`}
+            aria-label=${`${routeLinks.length} current context route links`}
+          >
+            CTX ${routeLinks.length}
+          </span>
           ${routeLinks.map(link => html`
             <button
               key=${link.id}

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -421,9 +421,26 @@
 
 .ide-toolbar-context-links {
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
   gap: 3px;
   min-width: 0;
+}
+
+.ide-toolbar-context-route-count {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 5px;
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--r-1);
+  background: var(--color-bg-canvas);
+  color: var(--color-fg-muted);
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  font-weight: 700;
+  line-height: 1;
 }
 
 .ide-toolbar-context-links button {


### PR DESCRIPTION
## Summary

- add a compact `CTX N` chip to the IDE toolbar current-context route list
- keep existing context route buttons and surface group actions unchanged
- cover the route-count chip in the focused toolbar test

## Validation

- `pnpm install --offline`
- `pnpm exec vitest run src/components/ide/ide-toolbar.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/ide/ide-toolbar.ts src/components/ide/ide-toolbar.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`
