### PR TITLE
feat(ide): summarize explorer context routes

### DIFF
--- a/dashboard/src/components/ide/ide-explorer.test.ts
+++ b/dashboard/src/components/ide/ide-explorer.test.ts
@@ -188,6 +188,9 @@ describe('IdeExplorer tree row keyboard accessibility', () => {
 
     expect(chip?.textContent).toContain('Task')
     expect(chip?.textContent).toContain('L42')
+    expect(chip?.textContent).toContain('CTX 2')
+    expect(chip?.querySelector('.ide-explorer-context-count')?.getAttribute('title'))
+      .toBe('2 context routes')
     const routeButtons = [...focusedRow!.querySelectorAll<HTMLButtonElement>('.ide-explorer-context-chip button')]
     expect(routeButtons.map(button => button.textContent)).toEqual(['Task', 'Telemetry'])
     expect(routeButtons.map(button => button.getAttribute('aria-label'))).toEqual([

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -484,6 +484,13 @@ function ExplorerContextChip(focus: IdeContextFocus) {
     >
       <span>${focus.surface}</span>
       ${line ? html`<span>${line}</span>` : null}
+      ${routeLinks.length > 0 ? html`
+        <span
+          class="ide-explorer-context-count"
+          aria-hidden="true"
+          title=${`${routeLinks.length} context route${routeLinks.length === 1 ? '' : 's'}`}
+        >CTX ${routeLinks.length}</span>
+      ` : null}
       ${visibleLinks.map(link => html`
         <button
           key=${link.id}

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -758,6 +758,16 @@
   white-space: nowrap;
 }
 
+.ide-explorer-context-count {
+  flex: 0 0 auto;
+  padding: 0 4px;
+  border: 1px solid color-mix(in srgb, var(--color-accent-fg) 38%, var(--color-border-default));
+  border-radius: var(--r-0);
+  color: var(--color-accent-fg);
+  background: color-mix(in srgb, var(--color-bg-elevated) 88%, var(--color-accent-fg));
+  font-weight: var(--fw-semi);
+}
+
 .ide-plane-editor {
   grid-column: 2;
   grid-row: 1 / span 2;


### PR DESCRIPTION
## Summary

- Add a compact `CTX N` route-count marker to the IDE explorer focus chip.
- Keep existing route buttons and focus navigation behavior unchanged.
- Cover the visible count and tooltip in the explorer test.

## Product impact

- The file tree now shows how much Task/Telemetry/PR/Goal context is attached to the focused file before operators inspect each route button.
- This extends the IDE context-route visibility polish into the Explorer surface.

## Evidence

- `pnpm exec vitest run src/components/ide/ide-explorer.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/ide/ide-explorer.ts src/components/ide/ide-explorer.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check origin/main`

## Review evidence

- Local targeted dashboard validation passed after rebasing on current `origin/main`.
- Draft PR remains behind `do-not-merge` for visual verification before merge.

## Linked issue

- Part of the ongoing IDE context visibility polish stream.
