### PR TITLE
feat(ide): summarize BDI context routes

### DIFF
--- a/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
@@ -331,6 +331,9 @@ describe('InspectorKeeperBDI', () => {
 
     const links = [...container.querySelectorAll<HTMLButtonElement>('.ide-bdi-route-link')]
     expect(links.map(link => link.textContent)).toEqual(['Code', 'Telemetry', 'Keeper'])
+    expect(container.querySelector('.ide-bdi-route-count')?.textContent).toBe('CTX 3')
+    expect(container.querySelector('.ide-bdi-route-count')?.getAttribute('title'))
+      .toBe('3 BDI context routes')
 
     links.find(link => link.textContent === 'Code')!.click()
     expect(window.location.hash.startsWith('#code?')).toBe(true)

--- a/dashboard/src/components/ide/inspector-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.ts
@@ -230,6 +230,11 @@ export function BdiRouteLinks({
   if (links.length === 0) return null
   return html`
     <div class="ide-bdi-route-links" aria-label=${ariaLabel}>
+      <span
+        class="ide-bdi-route-count"
+        aria-hidden="true"
+        title=${`${links.length} BDI context route${links.length === 1 ? '' : 's'}`}
+      >CTX ${links.length}</span>
       ${links.map(link => html`
         <button
           key=${link.id}

--- a/dashboard/src/components/ide/inspector-multi-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-multi-keeper-bdi.test.ts
@@ -721,6 +721,7 @@ describe('InspectorMultiKeeperBDI — file focus label (cursor overlay → IDE j
     expect(ashPanel).not.toBeNull()
     const ashLinks = [...ashPanel!.querySelectorAll<HTMLButtonElement>('.ide-bdi-route-link')]
     expect(ashLinks.map(link => link.textContent)).toEqual(['Code', 'Telemetry', 'Keeper'])
+    expect(ashPanel!.querySelector('.ide-bdi-route-count')?.textContent).toBe('CTX 3')
 
     ashLinks.find(link => link.textContent === 'Code')!.click()
     expect(routeHashParams().get('file')).toBe('src/runtime/ash.ts')
@@ -730,6 +731,7 @@ describe('InspectorMultiKeeperBDI — file focus label (cursor overlay → IDE j
     expect(scholarChip).not.toBeNull()
     const scholarLinks = [...scholarChip!.querySelectorAll<HTMLButtonElement>('.ide-bdi-route-link')]
     expect(scholarLinks.map(link => link.textContent)).toEqual(['Code', 'Telemetry', 'Keeper'])
+    expect(scholarChip!.querySelector('.ide-bdi-route-count')?.textContent).toBe('CTX 3')
 
     scholarLinks.find(link => link.textContent === 'Telemetry')!.click()
     expect(routeHashParams().get('q')).toContain('bdi keeper:scholar')

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -1510,6 +1510,21 @@ button.ide-persistence-focus:focus-visible {
   min-width: 0;
 }
 
+.ide-bdi-route-count {
+  display: inline-flex;
+  align-items: center;
+  height: 17px;
+  padding: 0 5px;
+  border: 1px solid color-mix(in srgb, var(--color-accent-fg) 38%, var(--color-border-default));
+  border-radius: var(--r-1);
+  background: color-mix(in srgb, var(--color-bg-elevated) 88%, var(--color-accent-fg));
+  color: var(--color-accent-fg);
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  font-weight: var(--fw-semi);
+  white-space: nowrap;
+}
+
 .ide-bdi-route-link {
   min-width: 0;
   max-width: 72px;


### PR DESCRIPTION
## Summary

- Add a compact `CTX N` route-count marker to the shared BDI operational link strip.
- Apply the count consistently to single-keeper and multi-keeper BDI inspector layouts.
- Keep existing Code, Telemetry, and Keeper route buttons unchanged.

## Product impact

- Keeper cognition panels now show the amount of linked operational context at a glance.
- This makes BDI snapshots easier to scan alongside code focus, telemetry, and keeper identity routes.

## Evidence

- `pnpm exec vitest run src/components/ide/inspector-keeper-bdi.test.ts src/components/ide/inspector-multi-keeper-bdi.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/ide/inspector-keeper-bdi.ts src/components/ide/inspector-keeper-bdi.test.ts src/components/ide/inspector-multi-keeper-bdi.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`

## Review evidence

- Local focused dashboard validation passed on current `origin/main`.
- Draft PR remains behind `do-not-merge` for visual verification before merge.

## Linked issue

- Part of the ongoing IDE context visibility polish stream.
