### PR TITLE
feat(ide): anchor BDI traces to keeper cursor

### DIFF
--- a/dashboard/src/components/ide/bdi-snapshot-trace-bridge.test.ts
+++ b/dashboard/src/components/ide/bdi-snapshot-trace-bridge.test.ts
@@ -122,6 +122,39 @@ describe('bridgeBdiSnapshotsToTrace — RFC-0028 PR-δ bdi-snapshot producer', (
     }
   })
 
+  it('normalizes optional cursor file and line context for line gutter projection', () => {
+    bridgeBdiSnapshotsToTrace(
+      [{
+        ...snap('scholar', '2026-05-06T01:00:00Z', 'inspect focused line'),
+        file_path: ' src\\runtime.ml ',
+        line: 42,
+      }],
+      new Set(),
+    )
+    const event = keeperTraceState.value.events[0]!
+    expect(event.source).toBe('bdi-snapshot')
+    if (event.source === 'bdi-snapshot') {
+      expect(event.filePath).toBe('src/runtime.ml')
+      expect(event.line).toBe(42)
+    }
+  })
+
+  it('drops cursor line context when the cursor file is not usable', () => {
+    bridgeBdiSnapshotsToTrace(
+      [{
+        ...snap('scholar', '2026-05-06T01:00:00Z', 'inspect focused line'),
+        line: 42,
+      }],
+      new Set(),
+    )
+    const event = keeperTraceState.value.events[0]!
+    expect(event.source).toBe('bdi-snapshot')
+    if (event.source === 'bdi-snapshot') {
+      expect(event.filePath).toBeNull()
+      expect(event.line).toBeNull()
+    }
+  })
+
   it('preserves a null intention (keeper between intentions)', () => {
     bridgeBdiSnapshotsToTrace(
       [snap('scholar', '2026-05-06T01:00:00Z', null)],

--- a/dashboard/src/components/ide/bdi-snapshot-trace-bridge.ts
+++ b/dashboard/src/components/ide/bdi-snapshot-trace-bridge.ts
@@ -1,4 +1,5 @@
 import { pushTrace } from './keeper-trace-store'
+import { normalizeIdeContextFilePath, normalizeIdeContextLine } from './ide-state'
 
 /**
  * RFC-0028 PR-δ producer: bdi-snapshot → keeper-trace bridge.
@@ -53,6 +54,8 @@ export interface BdiSnapshotProducerInput {
   readonly keeper: string
   readonly generated_at: string | null
   readonly intention: string | null
+  readonly file_path?: string | null
+  readonly line?: number | null
 }
 
 function dedupKey(snapshot: BdiSnapshotProducerInput): string {
@@ -77,12 +80,16 @@ export function bridgeBdiSnapshotsToTrace(
     if (next.has(key)) continue
     const tsMs = Date.parse(snapshot.generated_at)
     if (!Number.isFinite(tsMs)) continue
+    const filePath = snapshot.file_path ? normalizeIdeContextFilePath(snapshot.file_path) : null
+    const line = filePath === null ? null : normalizeIdeContextLine(snapshot.line ?? undefined) ?? null
     pushTrace({
       id: key,
       tsMs,
       keeperName: snapshot.keeper,
       source: 'bdi-snapshot',
       intention: snapshot.intention,
+      filePath,
+      line,
     })
     next.add(key)
   }

--- a/dashboard/src/components/ide/ide-editor-extensions.test.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.test.ts
@@ -206,12 +206,22 @@ describe('keeperTraceLinesForFile + keeper trace gutter', () => {
         line: 2,
         surface: 'Goal',
       },
+      {
+        id: 'bdi-1',
+        tsMs: 4500,
+        keeperName: 'scholar',
+        count: 1,
+        source: 'bdi-snapshot',
+        intention: 'inspect focused line',
+        filePath: 'runtime.ts',
+        line: 2,
+      },
     ]
 
     const traceLines = keeperTraceLinesForFile('runtime.ts', events)
     expect(traceLines).toHaveLength(1)
     expect(traceLines[0]?.line).toBe(2)
-    expect(traceLines[0]?.events).toHaveLength(2)
+    expect(traceLines[0]?.events).toHaveLength(3)
     expect(traceLines[0]?.events[0]).toMatchObject({
       id: 'activity-1',
       source: 'activity-event',
@@ -224,6 +234,15 @@ describe('keeperTraceLinesForFile + keeper trace gutter', () => {
       surface: 'Goal',
     })
     expect(traceLines[0]?.events[1]).toMatchObject({
+      id: 'bdi-1',
+      source: 'bdi-snapshot',
+      keeperName: 'scholar',
+      count: 1,
+      tsMs: 4500,
+      filePath: 'runtime.ts',
+      line: 2,
+    })
+    expect(traceLines[0]?.events[2]).toMatchObject({
       id: 'thread-1',
       source: 'anchored-thread',
       keeperName: 'scholar',

--- a/dashboard/src/components/ide/ide-editor-extensions.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.ts
@@ -551,6 +551,7 @@ function traceSourceLabel(source: KeeperTraceSource): string {
 function traceEventFilePath(event: KeeperTraceEvent): string | null {
   if (event.source === 'anchored-thread') return event.filePath ?? null
   if (event.source === 'activity-event') return event.filePath
+  if (event.source === 'bdi-snapshot') return event.filePath ?? null
   return null
 }
 
@@ -562,6 +563,11 @@ function traceEventLine(event: KeeperTraceEvent): number | null {
   }
   if (event.source === 'activity-event') {
     return Number.isSafeInteger(event.line) && event.line >= 1
+      ? event.line
+      : null
+  }
+  if (event.source === 'bdi-snapshot') {
+    return event.line !== null && event.line !== undefined && Number.isSafeInteger(event.line) && event.line >= 1
       ? event.line
       : null
   }

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -414,6 +414,7 @@ function buildCurrentFileSignals({
 function traceEventFilePath(event: KeeperTraceEvent): string | null {
   if (event.source === 'anchored-thread') return event.filePath ?? null
   if (event.source === 'activity-event') return event.filePath
+  if (event.source === 'bdi-snapshot') return event.filePath ?? null
   return null
 }
 

--- a/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
@@ -9,7 +9,7 @@ import {
   pinInspectorKeeper,
 } from './inspector-keeper-bdi'
 import { clearPins } from './multi-keeper-pin-store'
-import { clearTraces, pushTrace } from './keeper-trace-store'
+import { clearTraces, keeperTraceState, pushTrace } from './keeper-trace-store'
 import { cursorOverlaySignal, type KeeperCursor } from './keeper-cursor-overlay'
 import { activeIdeFile, ideContextFocus } from './ide-state'
 
@@ -344,6 +344,31 @@ describe('InspectorKeeperBDI', () => {
 
     links.find(link => link.textContent === 'Keeper')!.click()
     expect(window.location.hash).toBe('#monitoring?section=agents&view=keepers&keeper=scholar')
+
+    render(null, container)
+  })
+
+  it('anchors fresh BDI trace events to the keeper cursor line', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(snapshot)))
+    vi.stubGlobal('fetch', fetchMock)
+    activeKeeperName.value = 'scholar'
+    setCursorFor('scholar', { file_path: 'src/components/ide/inspector-keeper-bdi.ts', line: 42 })
+
+    const container = createContainer()
+    render(html`<${InspectorKeeperBDI} pollMs=${60_000} />`, container)
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/keepers/scholar/bdi-snapshot', expect.any(Object))
+    })
+    await vi.waitFor(() => {
+      expect(keeperTraceState.value.events).toHaveLength(1)
+    })
+
+    const event = keeperTraceState.value.events[0]!
+    expect(event.source).toBe('bdi-snapshot')
+    if (event.source === 'bdi-snapshot') {
+      expect(event.filePath).toBe('src/components/ide/inspector-keeper-bdi.ts')
+      expect(event.line).toBe(42)
+    }
 
     render(null, container)
   })

--- a/dashboard/src/components/ide/inspector-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.ts
@@ -303,17 +303,6 @@ export function InspectorKeeperBDI({
     }
   }, [keeperName, pollMs])
 
-  // RFC-0028 PR-δ-4 bdi-snapshot producer: each fresh poll result becomes
-  // a keeper-trace event. Dedup key is `bdi:${keeper}:${generated_at}` so
-  // a polling tick that returns the same snapshot does not re-emit; a
-  // server publish of a fresh BDI tick advances `generated_at` and emits
-  // a new event.
-  const knownBdiKeys = useRef<ReadonlySet<string>>(new Set())
-  useEffect(() => {
-    if (snapshot === null) return
-    knownBdiKeys.current = bridgeBdiSnapshotsToTrace([snapshot], knownBdiKeys.current)
-  }, [snapshot])
-
   const cursor = cursorOverlaySignal.value.cursors.get(keeperName)
   // The SSE adapter defaults a missing `line` to 0 (see
   // `keeper-cursor-overlay.ts::connectKeeperCursorStream` —
@@ -324,6 +313,22 @@ export function InspectorKeeperBDI({
   const focusLabel = hasValidFocus
     ? `${cursor!.file_path.split('/').pop()}:${cursor!.line}`
     : null
+
+  // RFC-0028 PR-δ-4 bdi-snapshot producer: each fresh poll result becomes
+  // a keeper-trace event. Dedup key is `bdi:${keeper}:${generated_at}` so
+  // a polling tick that returns the same snapshot does not re-emit; a
+  // server publish of a fresh BDI tick advances `generated_at` and emits
+  // a new event.
+  const knownBdiKeys = useRef<ReadonlySet<string>>(new Set())
+  useEffect(() => {
+    if (snapshot === null) return
+    knownBdiKeys.current = bridgeBdiSnapshotsToTrace([{
+      ...snapshot,
+      file_path: hasValidFocus ? cursor?.file_path : undefined,
+      line: hasValidFocus ? cursor?.line : undefined,
+    }], knownBdiKeys.current)
+  }, [cursor?.file_path, cursor?.line, hasValidFocus, snapshot])
+
   const tokenRows = snapshot?.recent_token_spend ?? []
   const lastTool = snapshot?.last_tool_call ?? null
   const presence = globalPresenceSnapshot.value

--- a/dashboard/src/components/ide/keeper-trace-store.test.ts
+++ b/dashboard/src/components/ide/keeper-trace-store.test.ts
@@ -222,6 +222,39 @@ describe('keeper-trace-store', () => {
     expect(keeperTraceState.value.events.map(e => e.count)).toEqual([1, 1, 1])
   })
 
+  it('does NOT coalesce bdi snapshots for different file lines within the window', () => {
+    pushTrace({
+      id: 'bdi-1',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'bdi-snapshot',
+      intention: 'inspect runtime',
+      filePath: 'runtime.ts',
+      line: 12,
+    })
+    pushTrace({
+      id: 'bdi-2',
+      tsMs: 1010,
+      keeperName: 'scholar',
+      source: 'bdi-snapshot',
+      intention: 'inspect worker',
+      filePath: 'worker.ts',
+      line: 12,
+    })
+    pushTrace({
+      id: 'bdi-3',
+      tsMs: 1020,
+      keeperName: 'scholar',
+      source: 'bdi-snapshot',
+      intention: 'inspect later runtime',
+      filePath: 'runtime.ts',
+      line: 20,
+    })
+
+    expect(keeperTraceState.value.events.map(e => e.id)).toEqual(['bdi-1', 'bdi-2', 'bdi-3'])
+    expect(keeperTraceState.value.events.map(e => e.count)).toEqual([1, 1, 1])
+  })
+
   it('inserts out-of-order events into ascending tsMs position', () => {
     pushTrace({
       id: 'a-1',

--- a/dashboard/src/components/ide/keeper-trace-store.ts
+++ b/dashboard/src/components/ide/keeper-trace-store.ts
@@ -62,6 +62,8 @@ export type KeeperTraceEvent =
   | (KeeperTraceBase & {
       readonly source: 'bdi-snapshot'
       readonly intention: string | null
+      readonly filePath?: string | null
+      readonly line?: number | null
     })
   | (KeeperTraceBase & {
       readonly source: 'decision-log'
@@ -228,6 +230,10 @@ function sameTraceBucket(left: KeeperTraceEvent, right: KeeperTraceEvent): boole
   }
   if (left.source === 'activity-event' && right.source === 'activity-event') {
     return left.filePath === right.filePath && left.line === right.line
+  }
+  if (left.source === 'bdi-snapshot' && right.source === 'bdi-snapshot') {
+    return (left.filePath ?? null) === (right.filePath ?? null)
+      && (left.line ?? null) === (right.line ?? null)
   }
   return true
 }

--- a/dashboard/src/components/ide/overlay-keeper-trace.test.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.test.ts
@@ -42,13 +42,22 @@ function pushAnchored(
   })
 }
 
-function pushBdi(id: string, keeperName: string, tsMs: number, intention: string | null = 'inspect'): void {
+function pushBdi(
+  id: string,
+  keeperName: string,
+  tsMs: number,
+  intention: string | null = 'inspect',
+  filePath?: string,
+  line?: number,
+): void {
   pushTrace({
     id,
     tsMs,
     keeperName,
     source: 'bdi-snapshot',
     intention,
+    filePath,
+    line,
   })
 }
 
@@ -135,6 +144,17 @@ describe('bucketTraceEvents — RFC-0028 §5 grouping', () => {
     expect(noLineBucket?.events.map(e => e.source).sort()).toEqual(['bdi-snapshot', 'decision-log'])
     const lineBucket = buckets.find(b => b.filePath === 'runtime.ts' && b.line === 12)
     expect(lineBucket?.events.map(e => e.source).sort()).toEqual(['activity-event', 'anchored-thread'])
+  })
+
+  it('groups cursor-anchored BDI snapshots with the file line bucket', () => {
+    pushBdi('bdi-line', 'scholar', 1000, 'inspect focused line', 'runtime.ts', 12)
+    pushDecision('decision', 'scholar', 1100)
+
+    const buckets = bucketTraceEvents(keeperTraceState.value.events)
+    expect(buckets.map(b => `${b.keeperName}@${b.filePath}@${b.line}`).sort())
+      .toEqual(['scholar@null@null', 'scholar@runtime.ts@12'])
+    const lineBucket = buckets.find(b => b.filePath === 'runtime.ts' && b.line === 12)
+    expect(lineBucket?.events.map(e => e.source)).toEqual(['bdi-snapshot'])
   })
 
   it('sorts events newest-first within each bucket', () => {

--- a/dashboard/src/components/ide/overlay-keeper-trace.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.ts
@@ -106,12 +106,14 @@ export function bucketTraceEvents(
 function lineOf(event: KeeperTraceEvent): number | null {
   if (event.source === 'anchored-thread') return event.line
   if (event.source === 'activity-event') return event.line
+  if (event.source === 'bdi-snapshot') return event.line ?? null
   return null
 }
 
 function filePathOf(event: KeeperTraceEvent): string | null {
   if (event.source === 'anchored-thread') return event.filePath ?? null
   if (event.source === 'activity-event') return event.filePath
+  if (event.source === 'bdi-snapshot') return event.filePath ?? null
   return null
 }
 
@@ -371,6 +373,8 @@ function traceRouteContext(event: KeeperTraceEvent): IdeContextRouteContext {
 
   if (event.source === 'bdi-snapshot') {
     return {
+      filePath: event.filePath ?? undefined,
+      line: event.line ?? undefined,
       surface: 'BDI',
       label: event.intention ?? 'BDI snapshot',
       sourceId: `trace:${event.id}`,


### PR DESCRIPTION
## Summary
- carry optional keeper cursor file/line through BDI snapshot trace events
- project cursor-anchored BDI snapshots into overlay and editor line-gutter trace buckets
- keep BDI coalescing separated by file/line once BDI events are line-scoped

## Verification
- pnpm exec vitest run src/components/ide/keeper-trace-store.test.ts src/components/ide/bdi-snapshot-trace-bridge.test.ts src/components/ide/inspector-keeper-bdi.test.ts src/components/ide/overlay-keeper-trace.test.ts src/components/ide/ide-editor-extensions.test.ts src/components/ide/ide-editor.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec eslint src/components/ide/keeper-trace-store.ts src/components/ide/keeper-trace-store.test.ts src/components/ide/bdi-snapshot-trace-bridge.ts src/components/ide/bdi-snapshot-trace-bridge.test.ts src/components/ide/inspector-keeper-bdi.ts src/components/ide/inspector-keeper-bdi.test.ts src/components/ide/overlay-keeper-trace.ts src/components/ide/overlay-keeper-trace.test.ts src/components/ide/ide-editor-extensions.ts src/components/ide/ide-editor-extensions.test.ts src/components/ide/ide-editor.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check