### PR TITLE
fix(ide): prioritize comment activity surfaces

### DIFF
--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -187,7 +187,7 @@ describe('IdeActivityPanel', () => {
       'Keeper',
     ])
     fireEvent.click(activityRouteLinks.find(link => link.textContent === 'Code')!)
-    expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=4&surface=PR&label=telemetry.turn&source_id=evt-1&keeper=sangsu')
+    expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=4&surface=Comment&label=telemetry.turn&source_id=evt-1&keeper=sangsu')
     fireEvent.click(activityRouteLinks.find(link => link.textContent === 'Telemetry')!)
     expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&session_id=sess-runtime&operation_id=op-runtime&worker_run_id=wr-runtime&q=turn-1')
 
@@ -199,7 +199,7 @@ describe('IdeActivityPanel', () => {
     expect(ideContextFocus.value).toMatchObject({
       file_path: 'lib/runtime.ml',
       line: 4,
-      surface: 'PR',
+      surface: 'Comment',
       keeper_id: 'sangsu',
       source_id: 'evt-1',
     })
@@ -222,7 +222,7 @@ describe('IdeActivityPanel', () => {
       eventId: 'evt-1',
       filePath: 'lib/runtime.ml',
       line: 4,
-      surface: 'PR',
+      surface: 'Comment',
     })])
   })
 
@@ -332,7 +332,7 @@ describe('IdeActivityPanel', () => {
     ])
 
     fireEvent.click(activityRouteLinks.find(link => link.textContent === 'Code')!)
-    expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=8&surface=PR&label=telemetry.turn&source_id=evt-1&keeper=sangsu')
+    expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=8&surface=Comment&label=telemetry.turn&source_id=evt-1&keeper=sangsu')
 
     fireEvent.click(activityRouteLinks.find(link => link.textContent === 'Telemetry')!)
     expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&session_id=sess-nested&operation_id=op-nested&worker_run_id=wr-nested&q=turn-8')

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -934,6 +934,7 @@ function ActivityRouteLink(link: IdeContextRouteLink) {
 }
 
 function activityContextSurface(item: RunActivityEvent): string {
+  if (item.context?.comment_id) return 'Comment'
   if (item.context?.pr_id) return 'PR'
   if (item.context?.board_post_id) return 'Board'
   if (item.context?.goal_id) return 'Goal'

--- a/dashboard/src/components/ide/run-activity-trace-bridge.test.ts
+++ b/dashboard/src/components/ide/run-activity-trace-bridge.test.ts
@@ -47,7 +47,7 @@ describe('bridgeRunActivityEventsToTrace', () => {
       eventId: 'evt-1',
       filePath: 'lib/runtime.ml',
       line: 7,
-      surface: 'PR',
+      surface: 'Comment',
       goalId: 'goal-runtime',
       taskId: 'task-runtime',
       boardPostId: 'post-runtime',

--- a/dashboard/src/components/ide/run-activity-trace-bridge.ts
+++ b/dashboard/src/components/ide/run-activity-trace-bridge.ts
@@ -50,6 +50,7 @@ export function bridgeRunActivityEventsToTrace(
 }
 
 function activityTraceSurface(event: RunActivityEvent): string {
+  if (event.context?.comment_id) return 'Comment'
   if (event.context?.pr_id) return 'PR'
   if (event.context?.board_post_id) return 'Board'
   if (event.context?.goal_id) return 'Goal'


### PR DESCRIPTION
## Summary
- treat activity events with comment_id as Comment surfaces before PR/Board/Goal/Task fallbacks
- keep PR/Board/Git/Telemetry route links intact while making Code focus and trace chips label comment work correctly
- align activity panel and activity trace bridge with the context lens Comment-first behavior

## Verification
- pnpm exec vitest run src/components/ide/run-activity-trace-bridge.test.ts src/components/ide/ide-activity-panel.test.ts src/components/ide/ide-context-lens.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec eslint src/components/ide/run-activity-trace-bridge.ts src/components/ide/run-activity-trace-bridge.test.ts src/components/ide/ide-activity-panel.ts src/components/ide/ide-activity-panel.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check