### PR TITLE
feat(ide): link annotations to route context

### DIFF
--- a/dashboard/src/api/ide.ts
+++ b/dashboard/src/api/ide.ts
@@ -29,6 +29,14 @@ export interface CreateAnnotationInput {
   readonly content: string
   readonly goal_id?: string
   readonly task_id?: string
+  readonly board_post_id?: string
+  readonly comment_id?: string
+  readonly pr_id?: string
+  readonly git_ref?: string
+  readonly log_id?: string
+  readonly session_id?: string
+  readonly operation_id?: string
+  readonly worker_run_id?: string
 }
 
 function appendFilterParams(

--- a/dashboard/src/api/schemas/ide-annotations.ts
+++ b/dashboard/src/api/schemas/ide-annotations.ts
@@ -12,6 +12,14 @@ export interface IdeAnnotation {
   readonly content: string
   readonly goal_id: string | null
   readonly task_id: string | null
+  readonly board_post_id?: string | null
+  readonly comment_id?: string | null
+  readonly pr_id?: string | null
+  readonly git_ref?: string | null
+  readonly log_id?: string | null
+  readonly session_id?: string | null
+  readonly operation_id?: string | null
+  readonly worker_run_id?: string | null
   readonly created_at_ms: number
   readonly updated_at_ms: number
 }
@@ -54,6 +62,14 @@ export function parseIdeAnnotation(value: unknown): IdeAnnotation | null {
     content: asString(value.content, ''),
     goal_id: asNullableString(value.goal_id),
     task_id: asNullableString(value.task_id),
+    board_post_id: asNullableString(value.board_post_id),
+    comment_id: asNullableString(value.comment_id),
+    pr_id: asNullableString(value.pr_id),
+    git_ref: asNullableString(value.git_ref),
+    log_id: asNullableString(value.log_id),
+    session_id: asNullableString(value.session_id),
+    operation_id: asNullableString(value.operation_id),
+    worker_run_id: asNullableString(value.worker_run_id),
     created_at_ms: asNumber(value.created_at_ms, 0),
     updated_at_ms: asNumber(value.updated_at_ms, 0),
   }

--- a/dashboard/src/components/ide/ide-context-lens.test.ts
+++ b/dashboard/src/components/ide/ide-context-lens.test.ts
@@ -509,6 +509,70 @@ describe('IdeContextLens', () => {
     })
   })
 
+  it('routes keeper annotations into comment, PR, git, log, and telemetry context', () => {
+    const linkedAnnotation: IdeAnnotation = {
+      ...annotation,
+      id: 'ann-linked-route-context',
+      kind: 'Bookmark',
+      board_post_id: 'post-1',
+      comment_id: 'comment-1',
+      pr_id: '15035',
+      git_ref: 'feat/context-lens',
+      log_id: 'turn-9',
+      session_id: 'sess-9',
+      operation_id: 'op-9',
+      worker_run_id: 'wr-9',
+    }
+    const model = deriveIdeContextLens({
+      filePath: 'lib/keeper/keeper_exec_ide.ml',
+      annotations: [linkedAnnotation],
+      diffRows: [],
+      events: [],
+      overlay: { ...overlay, cursors: new Map() },
+    })
+
+    const counts = new Map(model.surfaces.map(surface => [surface.id, surface.count]))
+    expect(counts.get('board')).toBe(1)
+    expect(counts.get('comment')).toBe(1)
+    expect(counts.get('pr')).toBe(1)
+    expect(counts.get('git')).toBe(1)
+    expect(counts.get('log')).toBe(1)
+    expect(counts.get('telemetry')).toBe(1)
+    expect(model.anchors[0]?.meta).toContain('PR 15035')
+    expect(model.anchors[0]?.meta).toContain('log turn-9')
+    expect(model.anchors[0]?.route_links?.map(link => link.label)).toEqual([
+      'Code',
+      'Goal',
+      'Task',
+      'Board',
+      'Comment',
+      'PR',
+      'Git',
+      'Log',
+      'Telemetry',
+      'Keeper',
+    ])
+    expect(model.surfaces.find(surface => surface.id === 'comment')?.routeLink).toMatchObject({
+      label: 'Comment',
+      params: { section: 'board', post: 'post-1', comment: 'comment-1' },
+    })
+    expect(model.surfaces.find(surface => surface.id === 'pr')?.routeLink).toMatchObject({
+      label: 'PR',
+      params: { section: 'repositories', view: 'graph', pr: '15035' },
+    })
+    expect(model.surfaces.find(surface => surface.id === 'telemetry')?.routeLink).toMatchObject({
+      label: 'Telemetry',
+      params: {
+        section: 'fleet-health',
+        view: 'event-log',
+        session_id: 'sess-9',
+        operation_id: 'op-9',
+        worker_run_id: 'wr-9',
+        q: 'turn-9',
+      },
+    })
+  })
+
   it('routes file and line context back into the Code IDE shell', () => {
     const links = routeLinksForContext({
       filePath: ' lib\\runtime.ml ',

--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -582,6 +582,7 @@ function surfaceCount(
   }
   if (id === 'board') {
     return state.threads.length
+      + state.annotations.filter(annotation => annotation.board_post_id).length
       + state.events.filter(event => event.context?.board_post_id).length
       + countUnstructuredEventText(
         state.events,
@@ -592,6 +593,7 @@ function surfaceCount(
   }
   if (id === 'git') {
     return state.changedLineCount
+      + state.annotations.filter(annotation => annotation.git_ref).length
       + state.events.filter(event => event.context?.git_ref).length
       + countUnstructuredEventText(
         state.events,
@@ -601,7 +603,8 @@ function surfaceCount(
       )
   }
   if (id === 'pr') {
-    return state.events.filter(event => event.context?.pr_id).length
+    return state.annotations.filter(annotation => annotation.pr_id).length
+      + state.events.filter(event => event.context?.pr_id).length
       + countUnstructuredEventText(
         state.events,
         /\b(pr|pull[_\s-]?request|review)[:#/\s-]/,
@@ -611,7 +614,7 @@ function surfaceCount(
   }
   if (id === 'comment') {
     return state.annotations.filter(annotation =>
-      annotation.kind === 'Comment' || annotation.kind === 'Question',
+      annotation.kind === 'Comment' || annotation.kind === 'Question' || annotation.comment_id,
     ).length
       + state.threads.length
       + state.events.filter(event => event.context?.comment_id).length
@@ -623,14 +626,15 @@ function surfaceCount(
       )
   }
   if (id === 'log') {
-    return state.events.length
+    return state.events.length + state.annotations.filter(annotation => annotation.log_id).length
   }
   if (id === 'runtime') {
-    return state.events.filter(event =>
-      event.context?.session_id
-      || event.context?.operation_id
-      || event.context?.worker_run_id,
-    ).length
+    return state.annotations.filter(annotationHasRuntimeScope).length
+      + state.events.filter(event =>
+        event.context?.session_id
+        || event.context?.operation_id
+        || event.context?.worker_run_id,
+      ).length
       + countUnstructuredEventText(
         state.events,
         /\b(session|operation|op|worker_run|worker|wr)[:#/\s-]/,
@@ -642,7 +646,9 @@ function surfaceCount(
         state.eventSearchTextByEvent,
       )
   }
-  if (id === 'telemetry') return state.events.length
+  if (id === 'telemetry') {
+    return state.events.length + state.annotations.filter(annotationHasTelemetry).length
+  }
   return 0
 }
 
@@ -719,26 +725,34 @@ function buildAnchors(
   }
 
   for (const annotation of annotations.slice(0, 3)) {
+    const line = positiveLine(annotation.line_start)
+    const sourceId = `annotation-${annotation.id}`
     anchors.push({
-      id: `annotation-${annotation.id}`,
+      id: sourceId,
       file_path: annotation.file_path,
       surface: annotation.kind,
       label: truncate(annotation.content || '(no content)', 48),
-      meta: compactMeta([
-        annotation.goal_id ? `goal ${annotation.goal_id}` : null,
-        annotation.task_id ? `task ${annotation.task_id}` : null,
-        `keeper ${annotation.keeper_id}`,
-      ]),
-      line: positiveLine(annotation.line_start),
+      meta: annotationContextMeta(annotation),
+      line,
       keeper_id: annotation.keeper_id,
       route_links: routeLinksForContext({
         filePath: annotation.file_path,
-        line: positiveLine(annotation.line_start),
+        line,
         surface: annotation.kind,
         label: truncate(annotation.content || '(no content)', 48),
-        sourceId: `annotation-${annotation.id}`,
+        sourceId,
         goalId: annotation.goal_id ?? undefined,
         taskId: annotation.task_id ?? undefined,
+        boardPostId: annotation.board_post_id ?? undefined,
+        commentId: annotation.comment_id ?? undefined,
+        prId: annotation.pr_id ?? undefined,
+        gitRef: annotation.git_ref ?? undefined,
+        logId: annotation.log_id ?? undefined,
+        sessionId: annotation.session_id ?? undefined,
+        operationId: annotation.operation_id ?? undefined,
+        workerRunId: annotation.worker_run_id ?? undefined,
+        telemetryQuery: annotation.log_id ?? undefined,
+        telemetry: annotationHasTelemetry(annotation),
         keeperId: annotation.keeper_id,
       }),
     })
@@ -1060,6 +1074,39 @@ function eventContextMeta(event: RunActivityEvent, refs: IdeContextTextRouteRefs
   ])
 }
 
+function annotationHasTelemetry(annotation: IdeAnnotation): boolean {
+  return Boolean(
+    annotation.log_id
+    || annotation.session_id
+    || annotation.operation_id
+    || annotation.worker_run_id,
+  )
+}
+
+function annotationHasRuntimeScope(annotation: IdeAnnotation): boolean {
+  return Boolean(
+    annotation.session_id
+    || annotation.operation_id
+    || annotation.worker_run_id,
+  )
+}
+
+function annotationContextMeta(annotation: IdeAnnotation): string {
+  return compactMeta([
+    annotation.goal_id ? `goal ${annotation.goal_id}` : null,
+    annotation.task_id ? `task ${annotation.task_id}` : null,
+    annotation.pr_id ? `PR ${annotation.pr_id}` : null,
+    annotation.board_post_id ? `board ${annotation.board_post_id}` : null,
+    annotation.comment_id ? `comment ${annotation.comment_id}` : null,
+    annotation.git_ref ? `git ${annotation.git_ref}` : null,
+    annotation.log_id ? `log ${annotation.log_id}` : null,
+    annotation.session_id ? `session ${annotation.session_id}` : null,
+    annotation.operation_id ? `operation ${annotation.operation_id}` : null,
+    annotation.worker_run_id ? `worker ${annotation.worker_run_id}` : null,
+    `keeper ${annotation.keeper_id}`,
+  ])
+}
+
 function firstChangedLine(rows: ReadonlyArray<UnifiedDiffRow>): number | undefined {
   const row = rows.find(candidate => candidate.newLine !== null && candidate.newLine >= 1)
   return row?.newLine ?? undefined
@@ -1217,7 +1264,7 @@ export function routeLinksForContext(
   return links.slice(0, MAX_CONTEXT_ROUTE_LINKS)
 }
 
-function cleanId(value: string | undefined): string | null {
+function cleanId(value: string | null | undefined): string | null {
   const trimmed = value?.trim()
   return trimmed ? trimmed : null
 }

--- a/lib/ide/ide_annotation_types.ml
+++ b/lib/ide/ide_annotation_types.ml
@@ -42,6 +42,14 @@ type annotation =
   ; content : string
   ; goal_id : string option
   ; task_id : string option
+  ; board_post_id : string option
+  ; comment_id : string option
+  ; pr_id : string option
+  ; git_ref : string option
+  ; log_id : string option
+  ; session_id : string option
+  ; operation_id : string option
+  ; worker_run_id : string option
   ; created_at_ms : int64
   ; updated_at_ms : int64
   }
@@ -71,6 +79,11 @@ type annotation_filter =
   ; task_id : string option
   }
 
+let string_opt_to_json = function
+  | None -> `Null
+  | Some s -> `String s
+;;
+
 let annotation_to_json (a : annotation) : Yojson.Safe.t =
   `Assoc
     [ "id", `String a.id
@@ -80,14 +93,16 @@ let annotation_to_json (a : annotation) : Yojson.Safe.t =
     ; "keeper_id", `String a.keeper_id
     ; "kind", `String (annotation_kind_to_string a.kind)
     ; "content", `String a.content
-    ; ( "goal_id"
-      , match a.goal_id with
-        | None -> `Null
-        | Some g -> `String g )
-    ; ( "task_id"
-      , match a.task_id with
-        | None -> `Null
-        | Some t -> `String t )
+    ; "goal_id", string_opt_to_json a.goal_id
+    ; "task_id", string_opt_to_json a.task_id
+    ; "board_post_id", string_opt_to_json a.board_post_id
+    ; "comment_id", string_opt_to_json a.comment_id
+    ; "pr_id", string_opt_to_json a.pr_id
+    ; "git_ref", string_opt_to_json a.git_ref
+    ; "log_id", string_opt_to_json a.log_id
+    ; "session_id", string_opt_to_json a.session_id
+    ; "operation_id", string_opt_to_json a.operation_id
+    ; "worker_run_id", string_opt_to_json a.worker_run_id
     ; "created_at_ms", `Intlit (Int64.to_string a.created_at_ms)
     ; "updated_at_ms", `Intlit (Int64.to_string a.updated_at_ms)
     ]
@@ -138,6 +153,14 @@ let annotation_of_json (json : Yojson.Safe.t) : (annotation, string) result =
       ; content = find_string "content" ""
       ; goal_id = find_opt_string "goal_id"
       ; task_id = find_opt_string "task_id"
+      ; board_post_id = find_opt_string "board_post_id"
+      ; comment_id = find_opt_string "comment_id"
+      ; pr_id = find_opt_string "pr_id"
+      ; git_ref = find_opt_string "git_ref"
+      ; log_id = find_opt_string "log_id"
+      ; session_id = find_opt_string "session_id"
+      ; operation_id = find_opt_string "operation_id"
+      ; worker_run_id = find_opt_string "worker_run_id"
       ; created_at_ms = find_int64 "created_at_ms" 0L
       ; updated_at_ms = find_int64 "updated_at_ms" 0L
       }

--- a/lib/ide/ide_annotation_types.mli
+++ b/lib/ide/ide_annotation_types.mli
@@ -19,6 +19,14 @@ type annotation =
   ; content : string
   ; goal_id : string option
   ; task_id : string option
+  ; board_post_id : string option
+  ; comment_id : string option
+  ; pr_id : string option
+  ; git_ref : string option
+  ; log_id : string option
+  ; session_id : string option
+  ; operation_id : string option
+  ; worker_run_id : string option
   ; created_at_ms : int64
   ; updated_at_ms : int64
   }

--- a/lib/ide/ide_annotations.ml
+++ b/lib/ide/ide_annotations.ml
@@ -1,6 +1,5 @@
 (** IDE annotation storage — CRUD backed by [.masc-ide/annotations.jsonl].
 
-    Uses {!Dated_jsonl} for concurrent-safe append-only writes.
     In-memory compaction rewrites the store when tombstones exceed
     [COMPACT_THRESHOLD]. *)
 
@@ -98,6 +97,14 @@ let create
       ~content
       ?goal_id
       ?task_id
+      ?board_post_id
+      ?comment_id
+      ?pr_id
+      ?git_ref
+      ?log_id
+      ?session_id
+      ?operation_id
+      ?worker_run_id
       ()
   =
   ensure_store ~base_dir;
@@ -119,12 +126,19 @@ let create
       ; content
       ; goal_id
       ; task_id
+      ; board_post_id
+      ; comment_id
+      ; pr_id
+      ; git_ref
+      ; log_id
+      ; session_id
+      ; operation_id
+      ; worker_run_id
       ; created_at_ms = ts
       ; updated_at_ms = ts
       }
     in
-    let store = Dated_jsonl.create ~base_dir:(store_path ~base_dir) () in
-    Dated_jsonl.append store (annotation_to_json annotation);
+    Fs_compat.append_jsonl (annotations_file ~base_dir) (annotation_to_json annotation);
     Ok annotation)
 ;;
 
@@ -178,8 +192,7 @@ let delete ~base_dir ~id ~keeper_id =
   | None -> Error "annotation not found or keeper mismatch"
   | Some _ ->
     let ts = now_ms () in
-    let store = Dated_jsonl.create ~base_dir:(store_path ~base_dir) () in
-    Dated_jsonl.append store (tombstone_json id keeper_id ts);
+    Fs_compat.append_jsonl (annotations_file ~base_dir) (tombstone_json id keeper_id ts);
     (* Streaming count — we only need cardinalities to compute the
        compaction ratio, not the row list itself. *)
     let tombstone_count =

--- a/lib/ide/ide_annotations.mli
+++ b/lib/ide/ide_annotations.mli
@@ -5,7 +5,8 @@
     in-memory compaction on read: deleted annotations are filtered out
     and the file is rewritten when the tombstone ratio exceeds a threshold.
 
-    Thread-safety is provided by {!Dated_jsonl} mutex per [base_dir]. *)
+    Tombstoned rows are compacted back into the same JSONL file when the
+    tombstone ratio exceeds the threshold. *)
 
 open Ide_annotation_types
 
@@ -27,6 +28,14 @@ val create
   -> content:string
   -> ?goal_id:string
   -> ?task_id:string
+  -> ?board_post_id:string
+  -> ?comment_id:string
+  -> ?pr_id:string
+  -> ?git_ref:string
+  -> ?log_id:string
+  -> ?session_id:string
+  -> ?operation_id:string
+  -> ?worker_run_id:string
   -> unit
   -> (annotation, string) result
 

--- a/lib/keeper/keeper_exec_ide.ml
+++ b/lib/keeper/keeper_exec_ide.ml
@@ -1,4 +1,4 @@
-(** Keeper_exec_ide — MCP tool handler for masc_ide_annotate.
+(** Keeper_exec_ide — MCP tool handler for keeper_ide_annotate.
 
     Allows keepers to leave line-bound annotations on code files,
     stored in [.masc-ide/annotations.jsonl] and surfaced by the
@@ -24,6 +24,14 @@ let handle_keeper_ide_annotate
   let content = Safe_ops.json_string ~default:"" "content" args in
   let goal_id = Safe_ops.json_string_opt "goal_id" args in
   let task_id = Safe_ops.json_string_opt "task_id" args in
+  let board_post_id = Safe_ops.json_string_opt "board_post_id" args in
+  let comment_id = Safe_ops.json_string_opt "comment_id" args in
+  let pr_id = Safe_ops.json_string_opt "pr_id" args in
+  let git_ref = Safe_ops.json_string_opt "git_ref" args in
+  let log_id = Safe_ops.json_string_opt "log_id" args in
+  let session_id = Safe_ops.json_string_opt "session_id" args in
+  let operation_id = Safe_ops.json_string_opt "operation_id" args in
+  let worker_run_id = Safe_ops.json_string_opt "worker_run_id" args in
   if String.trim file_path = ""
   then error_json "file_path is required for ide_annotate"
   else if line_start < 1
@@ -49,6 +57,14 @@ let handle_keeper_ide_annotate
         ~content
         ?goal_id
         ?task_id
+        ?board_post_id
+        ?comment_id
+        ?pr_id
+        ?git_ref
+        ?log_id
+        ?session_id
+        ?operation_id
+        ?worker_run_id
         ()
     with
     | Ok annotation ->

--- a/lib/keeper/keeper_exec_ide.mli
+++ b/lib/keeper/keeper_exec_ide.mli
@@ -1,4 +1,4 @@
-(** Keeper_exec_ide — MCP tool handler for masc_ide_annotate.
+(** Keeper_exec_ide — MCP tool handler for keeper_ide_annotate.
 
     @since 0.6.0 — observational IDE Phase 1 *)
 
@@ -7,6 +7,6 @@ val handle_keeper_ide_annotate :
   keeper_name:string ->
   args:Yojson.Safe.t ->
   string
-(** Handle [masc_ide_annotate] tool call. Creates a line-bound
+(** Handle [keeper_ide_annotate] tool call. Creates a line-bound
     annotation in the [.masc-ide/] store and returns the created
     record's id and coordinates on success, or an error message. *)

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -561,7 +561,10 @@ let keeper_tools_list_json ~(meta : keeper_meta) =
     | Tool_name.Keeper.Bash_kill
     | Tool_name.Keeper.Bash_output
     | Tool_name.Keeper.Shell -> "shell"
-    | Tool_name.Keeper.Fs_edit | Tool_name.Keeper.Fs_read | Tool_name.Keeper.Write -> "fs"
+    | Tool_name.Keeper.Fs_edit
+    | Tool_name.Keeper.Fs_read
+    | Tool_name.Keeper.Ide_annotate
+    | Tool_name.Keeper.Write -> "fs"
     | Tool_name.Keeper.Library_read
     | Tool_name.Keeper.Library_search
     | Tool_name.Keeper.Memory_search

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -438,6 +438,12 @@ let execute_keeper_tool_call_with_outcome
               ~config
               ~keeper_name:meta.name
               ~args)
+       | "keeper_ide_annotate" ->
+         make_executed_tool_result
+           (Keeper_exec_ide.handle_keeper_ide_annotate
+              ~config
+              ~keeper_name:meta.name
+              ~args)
        | "keeper_bash" ->
          make_executed_tool_result
            (Keeper_exec_shell.handle_keeper_bash

--- a/lib/server/lsp_overlay_provider.ml
+++ b/lib/server/lsp_overlay_provider.ml
@@ -2,7 +2,7 @@
 
     Converts MASC annotations (comments, decisions, questions, bookmarks)
     into LSP CodeLens entries. Provides diagnostic merging and inlay hints
-    for goal/task bindings. *)
+    for route-context bindings. *)
 
 open Ide_annotation_types
 
@@ -35,6 +35,41 @@ module Cache = struct
 end
 
 (** LSP CodeLens entry as JSON. *)
+let tag_opt label value =
+  match value with
+  | Some raw when String.trim raw <> "" -> [ Printf.sprintf "%s:%s" label raw ]
+  | _ -> []
+;;
+
+let annotation_route_tags (a : annotation) =
+  tag_opt "goal" a.goal_id
+  @ tag_opt "task" a.task_id
+  @ tag_opt "board" a.board_post_id
+  @ tag_opt "comment" a.comment_id
+  @ tag_opt "PR" a.pr_id
+  @ tag_opt "git" a.git_ref
+  @ tag_opt "log" a.log_id
+  @ tag_opt "session" a.session_id
+  @ tag_opt "op" a.operation_id
+  @ tag_opt "worker" a.worker_run_id
+;;
+
+let annotation_context_label (a : annotation) =
+  String.concat " · " (annotation_route_tags a)
+;;
+
+let annotation_context_suffix (a : annotation) =
+  match annotation_context_label a with
+  | "" -> ""
+  | label -> " · " ^ label
+;;
+
+let annotation_message_with_context (a : annotation) =
+  match annotation_context_label a with
+  | "" -> a.content
+  | label -> Printf.sprintf "%s (%s)" a.content label
+;;
+
 let codelens_to_json (a : annotation) : Yojson.Safe.t =
   let range =
     `Assoc [
@@ -43,11 +78,7 @@ let codelens_to_json (a : annotation) : Yojson.Safe.t =
     ]
   in
   let kind_label = annotation_kind_to_string a.kind in
-  let title =
-    match a.goal_id with
-    | Some g -> Printf.sprintf "[%s] %s (%s)" kind_label a.content g
-    | None -> Printf.sprintf "[%s] %s" kind_label a.content
-  in
+  let title = Printf.sprintf "[%s] %s%s" kind_label a.content (annotation_context_suffix a) in
   `Assoc [
     ("range", range);
     ("command", `Assoc [
@@ -57,19 +88,17 @@ let codelens_to_json (a : annotation) : Yojson.Safe.t =
     ]);
   ]
 
-(** LSP InlayHint entry — shows goal/task binding inline. *)
+(** LSP InlayHint entry — shows route-context binding inline. *)
 let inlay_hint_to_json (a : annotation) : Yojson.Safe.t =
   let label =
-    match (a.goal_id, a.task_id) with
-    | Some g, Some t -> Printf.sprintf "goal:%s task:%s" g t
-    | Some g, None -> Printf.sprintf "goal:%s" g
-    | None, Some t -> Printf.sprintf "task:%s" t
-    | None, None -> Printf.sprintf "[%s]" (annotation_kind_to_string a.kind)
+    match annotation_context_label a with
+    | "" -> Printf.sprintf "[%s]" (annotation_kind_to_string a.kind)
+    | label -> label
   in
   `Assoc [
     ("position", `Assoc [("line", `Int (a.line_start - 1)); ("character", `Int 0)]);
     ("label", `String label);
-    ("tooltip", `String a.content);
+    ("tooltip", `String (annotation_message_with_context a));
     ("kind", `Int 2);  (* TypeParameter kind for inline annotations *)
   ]
 
@@ -85,11 +114,11 @@ let codelenses ~base_dir ~file_path : Yojson.Safe.t list =
   ) annotations
 
 (** Generate LSP InlayHint entries for a file.
-    Only annotations with goal_id or task_id bindings produce hints. *)
+    Only annotations with route-context bindings produce hints. *)
 let inlay_hints ~base_dir ~file_path : Yojson.Safe.t list =
   let annotations = Cache.get ~base_dir ~file_path in
   List.filter_map (fun (a : annotation) ->
-    if a.goal_id <> None || a.task_id <> None then
+    if annotation_route_tags a <> [] then
       Some (inlay_hint_to_json a)
     else
       None
@@ -114,7 +143,7 @@ let diagnostics ~base_dir ~file_path ~(lsp_diagnostics : Yojson.Safe.t list) :
           ("range", range);
           ("severity", `Int 3);  (* Information *)
           ("source", `String "masc");
-          ("message", `String a.content);
+          ("message", `String (annotation_message_with_context a));
         ])
     | Decision | Bookmark | Comment -> None
   ) annotations in
@@ -172,15 +201,7 @@ let enrich_hover ~base_dir ~file_path ~line (result : Yojson.Safe.t) =
     let masc_section =
       String.concat "\n" (List.map (fun (a : annotation) ->
         let kind = annotation_kind_to_string a.kind in
-        match (a.goal_id, a.task_id) with
-        | Some g, Some t ->
-          Printf.sprintf "- **[%s]** %s (goal:%s task:%s)" kind a.content g t
-        | Some g, None ->
-          Printf.sprintf "- **[%s]** %s (goal:%s)" kind a.content g
-        | None, Some t ->
-          Printf.sprintf "- **[%s]** %s (task:%s)" kind a.content t
-        | None, None ->
-          Printf.sprintf "- **[%s]** %s" kind a.content
+        Printf.sprintf "- **[%s]** %s" kind (annotation_message_with_context a)
       ) matching)
     in
     let masc_suffix = "\n---\n**MASC Annotations:**\n" ^ masc_section in

--- a/lib/server/lsp_overlay_provider.mli
+++ b/lib/server/lsp_overlay_provider.mli
@@ -8,7 +8,7 @@ val codelenses : base_dir:string -> file_path:string -> Yojson.Safe.t list
 (** Generate LSP CodeLens entries for a file from MASC annotations. *)
 
 val inlay_hints : base_dir:string -> file_path:string -> Yojson.Safe.t list
-(** Generate LSP InlayHint entries for annotations with goal/task bindings. *)
+(** Generate LSP InlayHint entries for annotations with route-context bindings. *)
 
 val diagnostics :
   base_dir:string ->

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -166,6 +166,14 @@ let add_routes router =
              in
              let goal_id = find_string "goal_id" in
              let task_id = find_string "task_id" in
+             let board_post_id = find_string "board_post_id" in
+             let comment_id = find_string "comment_id" in
+             let pr_id = find_string "pr_id" in
+             let git_ref = find_string "git_ref" in
+             let log_id = find_string "log_id" in
+             let session_id = find_string "session_id" in
+             let operation_id = find_string "operation_id" in
+             let worker_run_id = find_string "worker_run_id" in
              (match
                 Ide_annotations.create
                   ~base_dir:base
@@ -177,6 +185,14 @@ let add_routes router =
                   ~content
                   ?goal_id
                   ?task_id
+                  ?board_post_id
+                  ?comment_id
+                  ?pr_id
+                  ?git_ref
+                  ?log_id
+                  ?session_id
+                  ?operation_id
+                  ?worker_run_id
                   ()
               with
               | Ok annotation ->

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -471,6 +471,7 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Keeper TK.Board_vote
   | TN.Keeper TK.Broadcast
   | TN.Keeper TK.Handoff
+  | TN.Keeper TK.Ide_annotate
   | TN.Keeper TK.Pr_create
   | TN.Keeper TK.Pr_review_comment
   | TN.Keeper TK.Pr_review_reply
@@ -668,7 +669,7 @@ let tool_group_of_typed_tool_name = function
       | TK.Voice_sessions
       | TK.Voice_speak ) ->
       Some Voice
-  | TN.Keeper (TK.Bash | TK.Fs_edit | TK.Fs_read | TK.Shell | TK.Write) ->
+  | TN.Keeper (TK.Bash | TK.Fs_edit | TK.Fs_read | TK.Ide_annotate | TK.Shell | TK.Write) ->
       Some Filesystem
   | TN.Keeper
       ( TK.Bash_kill

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -49,6 +49,7 @@ module Keeper = struct
     | Discovery
     | Fs_edit
     | Fs_read
+    | Ide_annotate
     | Handoff
     | Library_read
     | Library_search
@@ -109,6 +110,7 @@ module Keeper = struct
     | Discovery -> "keeper_discovery"
     | Fs_edit -> "keeper_fs_edit"
     | Fs_read -> "keeper_fs_read"
+    | Ide_annotate -> "keeper_ide_annotate"
     | Handoff -> "keeper_handoff"
     | Library_read -> "keeper_library_read"
     | Library_search -> "keeper_library_search"
@@ -170,6 +172,7 @@ module Keeper = struct
     | "keeper_discovery" -> Some Discovery
     | "keeper_fs_edit" -> Some Fs_edit
     | "keeper_fs_read" -> Some Fs_read
+    | "keeper_ide_annotate" -> Some Ide_annotate
     | "keeper_handoff" -> Some Handoff
     | "keeper_library_read" -> Some Library_read
     | "keeper_library_search" -> Some Library_search

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -31,6 +31,7 @@ module Keeper : sig
     | Discovery
     | Fs_edit
     | Fs_read
+    | Ide_annotate
     | Handoff
     | Library_read
     | Library_search

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -712,6 +712,75 @@ let filesystem_tools : Masc_domain.tool_schema list =
           ; "required", `List [ `String "path"; `String "content" ]
           ]
     }
+  ; { name = "keeper_ide_annotate"
+    ; description =
+        "Attach a keeper-authored annotation to a source file line range. Use this to \
+         leave durable IDE context that links code to goal/task/board/comment/PR/git/log \
+         evidence. file_path, line_start, and content are required; optional route \
+         fields are preserved for dashboard Context Lens links."
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ ( "file_path"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; "description", `String "Workspace-relative source file path"
+                      ] )
+                ; ( "line_start"
+                  , `Assoc
+                      [ "type", `String "integer"
+                      ; "minimum", `Int 1
+                      ; "description", `String "First 1-based source line"
+                      ] )
+                ; ( "line_end"
+                  , `Assoc
+                      [ "type", `String "integer"
+                      ; "minimum", `Int 1
+                      ; "description", `String "Last 1-based source line; defaults to line_start"
+                      ] )
+                ; ( "kind"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "enum"
+                        , `List
+                            [ `String "Comment"
+                            ; `String "Decision"
+                            ; `String "Question"
+                            ; `String "Bookmark"
+                            ] )
+                      ; "description", `String "Annotation kind; defaults to Comment"
+                      ] )
+                ; ( "content"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; "description", `String "Short annotation text shown in the IDE"
+                      ] )
+                ; ( "goal_id"
+                  , `Assoc [ "type", `String "string"; "description", `String "Optional Goal route id" ] )
+                ; ( "task_id"
+                  , `Assoc [ "type", `String "string"; "description", `String "Optional Task route id" ] )
+                ; ( "board_post_id"
+                  , `Assoc [ "type", `String "string"; "description", `String "Optional Board post route id" ] )
+                ; ( "comment_id"
+                  , `Assoc [ "type", `String "string"; "description", `String "Optional Board/GitHub comment route id" ] )
+                ; ( "pr_id"
+                  , `Assoc [ "type", `String "string"; "description", `String "Optional PR number or id" ] )
+                ; ( "git_ref"
+                  , `Assoc [ "type", `String "string"; "description", `String "Optional branch, commit, or ref" ] )
+                ; ( "log_id"
+                  , `Assoc [ "type", `String "string"; "description", `String "Optional runtime audit log id" ] )
+                ; ( "session_id"
+                  , `Assoc [ "type", `String "string"; "description", `String "Optional telemetry session id" ] )
+                ; ( "operation_id"
+                  , `Assoc [ "type", `String "string"; "description", `String "Optional telemetry operation id" ] )
+                ; ( "worker_run_id"
+                  , `Assoc [ "type", `String "string"; "description", `String "Optional telemetry worker run id" ] )
+                ] )
+          ; "required", `List [ `String "file_path"; `String "line_start"; `String "content" ]
+          ]
+    }
   ]
 ;;
 

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -53,6 +53,7 @@
    (re_export masc_mcp.config)
    (re_export masc_mcp.fs_compat)
    (re_export masc_mcp.gate)
+   (re_export masc_mcp.ide)
    (re_export masc_mcp.masc_backend)
    (re_export masc_mcp.masc_compression)
    (re_export masc_mcp.mcp_session)

--- a/test/dune
+++ b/test/dune
@@ -90,6 +90,7 @@
         test_keeper_memory
         test_keeper_chat_store
         test_keeper_runtime_trust_snapshot
+        test_ide_annotations
         test_keeper_runtime_manifest
         test_schema_surface_index
         test_keeper_accountability
@@ -329,6 +330,7 @@
           test_keeper_memory
           test_keeper_chat_store
           test_keeper_runtime_trust_snapshot
+          test_ide_annotations
           test_keeper_runtime_manifest
           test_schema_surface_index
           test_keeper_accountability

--- a/test/test_ide_annotations.ml
+++ b/test/test_ide_annotations.ml
@@ -1,0 +1,234 @@
+open Alcotest
+
+module Types = Ide_annotation_types
+module Store = Ide_annotations
+module Lsp = Masc_mcp.Lsp_overlay_provider
+
+let route_annotation : Types.annotation =
+  { id = "ann-route"
+  ; file_path = "lib/keeper/keeper_exec_ide.ml"
+  ; line_start = 12
+  ; line_end = 14
+  ; keeper_id = "sangsu"
+  ; kind = Types.Comment
+  ; content = "Connect this line to the active review context."
+  ; goal_id = Some "goal-ide"
+  ; task_id = Some "task-42"
+  ; board_post_id = Some "post-1"
+  ; comment_id = Some "comment-1"
+  ; pr_id = Some "15035"
+  ; git_ref = Some "feat/context-lens"
+  ; log_id = Some "turn-9"
+  ; session_id = Some "sess-9"
+  ; operation_id = Some "op-9"
+  ; worker_run_id = Some "wr-9"
+  ; created_at_ms = 1L
+  ; updated_at_ms = 2L
+  }
+;;
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let with_temp_dir f =
+  let path = Filename.temp_file "masc-ide-annotations" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  Fun.protect ~finally:(fun () -> rm_rf path) (fun () -> f path)
+;;
+
+let contains ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    idx + needle_len <= haystack_len
+    && (String.equal (String.sub haystack idx needle_len) needle || loop (idx + 1))
+  in
+  needle_len = 0 || loop 0
+;;
+
+let check_contains label needle haystack =
+  check bool label true (contains ~needle haystack)
+;;
+
+let assoc key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+;;
+
+let string_field key json =
+  match assoc key json with
+  | Some (`String value) -> Some value
+  | _ -> None
+;;
+
+let codelens_title = function
+  | `Assoc fields ->
+    (match List.assoc_opt "command" fields with
+     | Some (`Assoc command) ->
+       (match List.assoc_opt "title" command with
+        | Some (`String title) -> Some title
+        | _ -> None)
+     | _ -> None)
+  | _ -> None
+;;
+
+let hover_value = function
+  | `Assoc fields ->
+    (match List.assoc_opt "contents" fields with
+     | Some contents -> string_field "value" contents
+     | None -> None)
+  | _ -> None
+;;
+
+let test_annotation_json_preserves_route_context () =
+  match Types.annotation_of_json (Types.annotation_to_json route_annotation) with
+  | Error msg -> fail msg
+  | Ok decoded ->
+    check (option string) "board post" route_annotation.board_post_id decoded.board_post_id;
+    check (option string) "comment" route_annotation.comment_id decoded.comment_id;
+    check (option string) "pr" route_annotation.pr_id decoded.pr_id;
+    check (option string) "git" route_annotation.git_ref decoded.git_ref;
+    check (option string) "log" route_annotation.log_id decoded.log_id;
+    check (option string) "session" route_annotation.session_id decoded.session_id;
+    check (option string) "operation" route_annotation.operation_id decoded.operation_id;
+    check (option string) "worker" route_annotation.worker_run_id decoded.worker_run_id
+;;
+
+let test_create_lists_route_context () =
+  with_temp_dir (fun base_dir ->
+    match
+      Store.create
+        ~base_dir
+        ~keeper_id:"sangsu"
+        ~file_path:"lib/keeper/keeper_exec_ide.ml"
+        ~line_start:12
+        ~line_end:14
+        ~kind:Types.Question
+        ~content:"Should this trace be attached to the PR review?"
+        ~goal_id:"goal-ide"
+        ~task_id:"task-42"
+        ~board_post_id:"post-1"
+        ~comment_id:"comment-1"
+        ~pr_id:"15035"
+        ~git_ref:"feat/context-lens"
+        ~log_id:"turn-9"
+        ~session_id:"sess-9"
+        ~operation_id:"op-9"
+        ~worker_run_id:"wr-9"
+        ()
+    with
+    | Error msg -> fail msg
+    | Ok created ->
+      check (option string) "created pr" (Some "15035") created.pr_id;
+      let filter =
+        { Types.file_path = Some "lib/keeper/keeper_exec_ide.ml"
+        ; keeper_id = None
+        ; goal_id = None
+        ; task_id = None
+        }
+      in
+      (match Store.list ~base_dir ~filter with
+       | [ listed ] ->
+         check string "id" created.id listed.id;
+         check (option string) "listed comment" (Some "comment-1") listed.comment_id;
+         check (option string) "listed log" (Some "turn-9") listed.log_id
+       | rows -> failf "expected one listed annotation, got %d" (List.length rows)))
+;;
+
+let test_lsp_overlay_exposes_route_context () =
+  Eio_main.run (fun _env ->
+    with_temp_dir (fun base_dir ->
+    match
+      Store.create
+        ~base_dir
+        ~keeper_id:"sangsu"
+        ~file_path:"lib/keeper/keeper_exec_ide.ml"
+        ~line_start:12
+        ~line_end:14
+        ~kind:Types.Question
+        ~content:"Should this trace be attached to the PR review?"
+        ~goal_id:"goal-ide"
+        ~task_id:"task-42"
+        ~board_post_id:"post-1"
+        ~comment_id:"comment-1"
+        ~pr_id:"15035"
+        ~git_ref:"feat/context-lens"
+        ~log_id:"turn-9"
+        ~session_id:"sess-9"
+        ~operation_id:"op-9"
+        ~worker_run_id:"wr-9"
+        ()
+    with
+    | Error msg -> fail msg
+    | Ok _ ->
+      Lsp.clear_cache ();
+      let codelenses =
+        Lsp.codelenses ~base_dir ~file_path:"lib/keeper/keeper_exec_ide.ml"
+      in
+      (match codelenses with
+       | [ codelens ] ->
+         let title = Option.value ~default:"" (codelens_title codelens) in
+         check_contains "codelens carries PR route" "PR:15035" title;
+         check_contains "codelens carries log route" "log:turn-9" title
+       | rows -> failf "expected one codelens, got %d" (List.length rows));
+      let inlay_hints =
+        Lsp.inlay_hints ~base_dir ~file_path:"lib/keeper/keeper_exec_ide.ml"
+      in
+      (match inlay_hints with
+       | [ hint ] ->
+         let label = Option.value ~default:"" (string_field "label" hint) in
+         let tooltip = Option.value ~default:"" (string_field "tooltip" hint) in
+         check_contains "inlay carries task route" "task:task-42" label;
+         check_contains "inlay carries telemetry route" "worker:wr-9" label;
+         check_contains "inlay tooltip carries comment route" "comment:comment-1" tooltip
+       | rows -> failf "expected one inlay hint, got %d" (List.length rows));
+      let diagnostics =
+        Lsp.diagnostics
+          ~base_dir
+          ~file_path:"lib/keeper/keeper_exec_ide.ml"
+          ~lsp_diagnostics:[]
+      in
+      (match diagnostics with
+       | [ diagnostic ] ->
+         let message = Option.value ~default:"" (string_field "message" diagnostic) in
+         check_contains "diagnostic carries git route" "git:feat/context-lens" message
+       | rows -> failf "expected one diagnostic, got %d" (List.length rows));
+      let hover =
+        Lsp.enrich_hover
+          ~base_dir
+          ~file_path:"lib/keeper/keeper_exec_ide.ml"
+          ~line:11
+          (`Assoc
+             [ "contents"
+             , `Assoc [ "kind", `String "markdown"; "value", `String "Base hover" ]
+             ])
+      in
+      let value = Option.value ~default:"" (hover_value hover) in
+      check_contains "hover carries board route" "board:post-1" value;
+      check_contains "hover carries operation route" "op:op-9" value))
+;;
+
+let () =
+  run
+    "ide_annotations"
+    [ ( "route_context"
+      , [ test_case
+            "annotation json preserves route context"
+            `Quick
+            test_annotation_json_preserves_route_context
+        ; test_case "create/list preserves route context" `Quick test_create_lists_route_context
+        ; test_case
+            "LSP overlays expose route context"
+            `Quick
+            test_lsp_overlay_exposes_route_context
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- extend IDE annotations with board/comment/PR/git/log/session/operation/worker route fields
- wire keeper_ide_annotate, dashboard POST parsing, and Context Lens route counts/links for those fields
- surface the same route context through LSP CodeLens, InlayHint, diagnostics, and hover overlays
- store annotation create/delete rows in the same annotations.jsonl file that list/load reads

## Verification
- scripts/dune-local.sh build test/test_ide_annotations.exe
- ./_build/default/test/test_ide_annotations.exe
- pnpm vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-context-lens.test.ts
- pnpm typecheck
- pnpm lint (passes with existing virtual-list unused eslint-disable warning)
- git diff --check