### PR TITLE
fix(dashboard): stabilize activity replay cursors

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -215,15 +215,23 @@ let read_all_events config =
        []
   |> List.sort (fun a b -> Int.compare a.seq b.seq)
 
+let max_event_seq events =
+  List.fold_left (fun acc (value : event) -> max acc value.seq) 0 events
+
 let matches_filters ?(kinds = []) (value : event) =
   kinds = [] || List.mem value.kind kinds
 
-(** Returns [(page, total_matching)] where [total_matching] is the count
-    of all events matching filters before [limit] is applied. *)
-let list_events_with_total config ?(kinds = []) ~after_seq ~limit
+(** Returns [(page, total_matching, latest_store_seq, latest_matching_seq)].
+    [total_matching] and [latest_matching_seq] are computed before [limit].
+    [latest_store_seq] is the max of the persisted sequence counter and the
+    JSONL rows so a stale [_seq] file cannot make dashboard cursors move
+    backward. *)
+let list_events_with_meta config ?(kinds = []) ~after_seq ~limit
     ?since_ms () =
+  let stored = read_all_events config in
+  let latest_store_seq = max (read_current_seq config) (max_event_seq stored) in
   let all =
-    read_all_events config
+    stored
     |> List.filter (fun value ->
            value.seq > after_seq
            && matches_filters ~kinds value
@@ -238,10 +246,22 @@ let list_events_with_total config ?(kinds = []) ~after_seq ~limit
     else
       all |> List.drop (max 0 (total - limit))
   in
+  (page, total, latest_store_seq, max_event_seq all)
+
+(** Returns [(page, total_matching)] where [total_matching] is the count
+    of all events matching filters before [limit] is applied. *)
+let list_events_with_total config ?(kinds = []) ~after_seq ~limit
+    ?since_ms () =
+  let page, total, _latest_store_seq, _latest_matching_seq =
+    list_events_with_meta config ~kinds ~after_seq ~limit ?since_ms ()
+  in
   (page, total)
 
 let list_events config ?(kinds = []) ~after_seq ~limit () =
-  fst (list_events_with_total config ~kinds ~after_seq ~limit ())
+  let page, _total, _latest_store_seq, _latest_matching_seq =
+    list_events_with_meta config ~kinds ~after_seq ~limit ()
+  in
+  page
 
 let window_meta ~limit ~events_shown ~events_store_total
     ?(extra = []) () : Yojson.Safe.t =
@@ -253,6 +273,8 @@ let window_meta ~limit ~events_shown ~events_store_total
   ] @ extra)
 
 let latest_seq config = read_current_seq config
+
+let activity_events_store_path config = root_dir config
 
 (* ================================================================ *)
 (* Event emission                                                   *)
@@ -307,7 +329,9 @@ let emit config ?actor ?subject ?(tags = []) ~kind ~payload () =
 (* ================================================================ *)
 
 let json_response config ?(kinds = []) ~after_seq ~limit () =
-  let events = list_events config ~kinds ~after_seq ~limit () in
+  let events, total_matching, latest_store_seq, latest_matching_seq =
+    list_events_with_meta config ~kinds ~after_seq ~limit ()
+  in
   let next_after_seq =
     match List.rev events with
     | last :: _ -> last.seq
@@ -315,14 +339,38 @@ let json_response config ?(kinds = []) ~after_seq ~limit () =
   in
   `Assoc
     [
+      ("generated_at_iso", `String (Masc_domain.now_iso ()));
+      ("dashboard_surface", `String "/api/v1/activity/events");
+      ("source", `String "activity_graph_jsonl");
+      ( "retention",
+        `Assoc
+          [
+            ("scope", `String "activity_events");
+            ("coordination_root", `String (Coord_utils.masc_dir config));
+            ("durable_store", `String (activity_events_store_path config));
+            ("file_pattern", `String "activity-events/YYYY-MM/DD.jsonl");
+            ("seq_counter", `String (seq_path config));
+            ( "cache_policy",
+              `String
+                "uncached; reads persisted JSONL rows; delta cursor via after_seq" );
+          ] );
+      ( "query",
+        `Assoc
+          [
+            ("after_seq", `Int after_seq);
+            ("limit", `Int limit);
+            ("kinds", `List (List.map (fun value -> `String value) kinds));
+          ] );
       ("events", `List (List.map event_to_yojson events));
       ("count", `Int (List.length events));
+      ("total_matching_events", `Int total_matching);
       ("after_seq", `Int after_seq);
       ("next_after_seq", `Int next_after_seq);
       ("limit", `Int limit);
       ("room_id", `String "default");  (* backward compat *)
       ("kinds", `List (List.map (fun value -> `String value) kinds));
-      ("latest_seq", `Int (latest_seq config));
+      ("latest_seq", `Int latest_store_seq);
+      ("latest_matching_seq", `Int latest_matching_seq);
     ]
 
 (* ================================================================ *)

--- a/lib/activity_graph/activity_graph.mli
+++ b/lib/activity_graph/activity_graph.mli
@@ -103,12 +103,16 @@ val json_response :
   limit:int ->
   unit ->
   Yojson.Safe.t
-(** Polling-friendly JSON envelope: [events], [count],
-    [after_seq], [next_after_seq], [limit], [room_id]
-    (kept as ["default"] for backward-compat), [kinds],
-    [latest_seq].  [next_after_seq] is the seq of the last
-    returned event so the caller can resume cleanly on the
-    next poll. *)
+(** Polling-friendly JSON envelope: [generated_at_iso],
+    [dashboard_surface], [source], [retention], [query],
+    [events], [count], [total_matching_events], [after_seq],
+    [next_after_seq], [limit], [room_id] (kept as ["default"]
+    for backward-compat), [kinds], [latest_seq], and
+    [latest_matching_seq].  [next_after_seq] is the seq of the
+    last returned event so the caller can resume cleanly on the
+    next poll.  [latest_seq] is the max of the persisted counter
+    and JSONL rows so stale [_seq] files cannot make dashboard
+    cursors move backward. *)
 
 val graph_json :
   Coord_utils.config ->

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -173,7 +173,7 @@ check_json "goal-loop status exposes phases" "$BASE/api/v1/dashboard/goal-loop/s
 check_http "activity graph 200" "$BASE/api/v1/activity/graph" "200"
 check_json "activity graph has nodes" "$BASE/api/v1/activity/graph" "len(d.get('nodes', [])) >= 0" '^True$'
 check_http "activity events 200" "$BASE/api/v1/activity/events?limit=1" "200"
-check_json "activity events exposes replay window" "$BASE/api/v1/activity/events?limit=1" "'events' in d and 'latest_seq' in d" '^True$'
+check_json "activity events exposes replay provenance" "$BASE/api/v1/activity/events?limit=1" "'events' in d and d.get('dashboard_surface') == '/api/v1/activity/events' and d.get('source') == 'activity_graph_jsonl' and d.get('retention', {}).get('scope') == 'activity_events' and d.get('latest_seq', 0) >= d.get('next_after_seq', 0)" '^True$'
 check_http "agent timeline 200" "$BASE/api/v1/agent-timeline?agent_name=sangsu&limit=1" "200"
 check_json "agent timeline exposes provenance" "$BASE/api/v1/agent-timeline?agent_name=sangsu&limit=1" "'events' in d and d.get('dashboard_surface') == '/api/v1/agent-timeline' and d.get('source') == 'agent_timeline_read_model' and 'retention' in d" '^True$'
 check_http "agent relations 200" "$BASE/api/v1/agent-relations?agent_name=sangsu" "200"

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -229,6 +229,45 @@ let test_events_json_ignores_invalid_derived_pr_number () =
          | `Null -> true
          | _ -> context |> member "pr_id" |> fun value -> value = `Null))
 
+let test_events_json_exposes_provenance_and_non_stale_latest_seq () =
+  with_config (fun config ->
+      let first =
+        Activity_graph.emit config ~kind:"agent.joined"
+          ~actor:(Activity_graph.entity ~kind:"agent" "claude")
+          ~subject:(Activity_graph.entity ~kind:"agent" "claude")
+          ~payload:(`Assoc [ ("agent_name", `String "claude") ])
+          ()
+      in
+      let second =
+        Activity_graph.emit config ~kind:"task.created"
+          ~actor:(Activity_graph.entity ~kind:"agent" "system")
+          ~subject:(Activity_graph.entity ~kind:"task" "task-activity")
+          ~payload:(`Assoc [ ("task_id", `String "task-activity") ])
+          ()
+      in
+      let seq_counter =
+        Filename.concat
+          (Filename.concat (Coord_utils.masc_dir config) "activity-events")
+          "_seq"
+      in
+      Fs_compat.save_file seq_counter (string_of_int first.seq);
+      let json = Activity_graph.json_response config ~after_seq:0 ~limit:10 () in
+      let open Yojson.Safe.Util in
+      check string "surface" "/api/v1/activity/events"
+        (json |> member "dashboard_surface" |> to_string);
+      check string "source" "activity_graph_jsonl"
+        (json |> member "source" |> to_string);
+      check string "retention scope" "activity_events"
+        (json |> member "retention" |> member "scope" |> to_string);
+      check string "query kind list is empty" "[]"
+        (json |> member "query" |> member "kinds" |> Yojson.Safe.to_string);
+      check int "next cursor is newest returned event" second.seq
+        (json |> member "next_after_seq" |> to_int);
+      check int "latest matching seq sees JSONL rows" second.seq
+        (json |> member "latest_matching_seq" |> to_int);
+      check bool "latest seq does not move behind persisted rows" true
+        ((json |> member "latest_seq" |> to_int) >= second.seq))
+
 let test_emit_sanitizes_invalid_utf8_before_persisting () =
   with_config (fun config ->
       Safe_ops.reset_persistence_utf8_repair_stats_for_tests ();
@@ -560,6 +599,8 @@ let () =
             test_events_json_omits_unsafe_ide_context_file_paths;
           test_case "events json ignores invalid derived PR number" `Quick
             test_events_json_ignores_invalid_derived_pr_number;
+          test_case "events json exposes provenance and non-stale latest seq"
+            `Quick test_events_json_exposes_provenance_and_non_stale_latest_seq;
           test_case "emit sanitizes invalid utf8 before persisting" `Quick
             test_emit_sanitizes_invalid_utf8_before_persisting;
           test_case "read self-heals historic invalid utf8 event file" `Quick


### PR DESCRIPTION
## Summary
- expose /api/v1/activity/events provenance plus query and retention metadata
- make latest_seq derive from persisted JSONL rows as well as _seq so stale counters cannot move replay cursors backward
- extend dashboard smoke coverage for activity replay provenance

## Evidence
- ocamlformat --check lib/activity_graph/activity_graph.ml lib/activity_graph/activity_graph.mli test/test_activity_graph.ml
- git diff --check
- env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-build-activity-events-provenance-main DUNE_JOBS=1 scripts/dune-local.sh build --display=short test/test_activity_graph.exe bin/main_eio.exe
- /private/tmp/masc-mcp-build-activity-events-provenance-main/default/test/test_activity_graph.exe => 17 tests passed
- live /health => commit=308249a46d, executable_path=/private/tmp/masc-mcp-build-activity-events-provenance-main/default/bin/main_eio.exe, effective_base_path=/Users/dancer/me
- live /api/v1/activity/events?limit=1 => dashboard_surface=/api/v1/activity/events, source=activity_graph_jsonl, retention.scope=activity_events, latest_seq=48987, next_after_seq=48987
- scripts/verify-dashboard.sh http://127.0.0.1:8935 => ALL 176 TESTS PASSED