### PR TITLE
fix(dashboard): expose telemetry replay provenance

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1152,13 +1152,63 @@ let rec add_routes ~sw ~clock router =
               | Some src -> [src]
               | None -> Telemetry_unified.all_sources)
          in
+         let query_json =
+           let source_query =
+             match Server_utils.query_param req "source" with
+             | Some value -> `String value
+             | None -> `Null
+           in
+           `Assoc
+             [
+               ("source", source_query);
+               ( "resolved_sources",
+                 `List
+                   (List.map
+                      (fun source ->
+                        `String (Telemetry_unified.source_to_string source))
+                      sources) );
+               ("n", `Int n);
+               ( "keeper",
+                 Option.fold ~none:`Null
+                   ~some:(fun value -> `String value)
+                   keeper_name );
+               ( "session_id",
+                 Option.fold ~none:`Null
+                   ~some:(fun value -> `String value)
+                   session_id );
+               ( "operation_id",
+                 Option.fold ~none:`Null
+                   ~some:(fun value -> `String value)
+                   operation_id );
+               ( "worker_run_id",
+                 Option.fold ~none:`Null
+                   ~some:(fun value -> `String value)
+                   worker_run_id );
+               ( "since_ms",
+                 Option.fold ~none:`Null
+                   ~some:(fun value -> `Float (value *. 1000.0))
+                   since_ts );
+               ( "until_ms",
+                 Option.fold ~none:`Null
+                   ~some:(fun value -> `Float (value *. 1000.0))
+                   until_ts );
+             ]
+         in
          let result =
            Telemetry_unified.read_unified_result ~base_path ~masc_root ~sources
              ?keeper_name ?session_id ?operation_id ?worker_run_id
              ?since_ts ?until_ts ~n ()
          in
+         let generated_at = Masc_domain.now_iso () in
          let json = `Assoc [
-           ("generated_at", `String (Masc_domain.now_iso ()));
+           ("generated_at", `String generated_at);
+           ("generated_at_iso", `String generated_at);
+           ("dashboard_surface", `String "/api/v1/dashboard/telemetry");
+           ("source", `String "telemetry_unified");
+           ( "retention",
+             Telemetry_unified.replay_retention_json ~base_path ~masc_root
+               ~sources );
+           ("query", query_json);
            ("count", `Int (List.length result.entries));
            ("total_matching_entries", `Int result.total_matching_entries);
            ("truncated", `Bool result.truncated);

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -153,6 +153,40 @@ let source_durable_store ~masc_root ~base_path = function
       | Some dir -> dir
       | None -> "")
 
+let source_metadata_fields ~base_path ~masc_root source =
+  [
+    ("freshness_slo_s", `Float (source_freshness_slo_s source));
+    ("producer", `String (source_producer source));
+    ( "durable_store",
+      `String (source_durable_store ~masc_root ~base_path source) );
+    ("dashboard_surface", `String (source_dashboard_surface source));
+  ]
+
+let replay_retention_json ~base_path ~masc_root ~sources : Yojson.Safe.t =
+  `Assoc
+    [
+      ("scope", `String "dashboard_telemetry_replay");
+      ("coordination_root", `String masc_root);
+      ("base_path", `String base_path);
+      ( "selected_sources",
+        `List
+          (List.map
+             (fun source -> `String (source_to_string source))
+             sources) );
+      ( "durable_stores",
+        `List
+          (List.map
+             (fun source ->
+               `Assoc
+                 (("source", `String (source_to_string source))
+                 :: source_metadata_fields ~base_path ~masc_root source))
+             sources) );
+      ( "cache_policy",
+        `String
+          "uncached; reads persisted JSONL rows; sorts newest first; n<=0 returns the full filtered window"
+      );
+    ]
+
 type store_dir_state =
   | Store_missing
   | Store_directory
@@ -988,15 +1022,7 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
   in
   let source_json_and_count source =
     let freshness_slo_s = source_freshness_slo_s source in
-    let metadata_fields =
-      [
-        ("freshness_slo_s", `Float freshness_slo_s);
-        ("producer", `String (source_producer source));
-        ( "durable_store",
-          `String (source_durable_store ~masc_root ~base_path source) );
-        ("dashboard_surface", `String (source_dashboard_surface source));
-      ]
-    in
+    let metadata_fields = source_metadata_fields ~base_path ~masc_root source in
     let coverage_gap = latest_coverage_gap_for_source coverage_gaps source in
     let keeper_dir_fields dirs =
       [

--- a/lib/telemetry_unified.mli
+++ b/lib/telemetry_unified.mli
@@ -92,3 +92,12 @@ val summary_json :
     each source: path, entry count, whether the store directory exists,
     and freshness metadata ([latest_ts_unix], [latest_ts_iso],
     [latest_age_s]).  [masc_root] is the cluster-aware .masc directory. *)
+
+val replay_retention_json :
+  base_path:string ->
+  masc_root:string ->
+  sources:source list ->
+  Yojson.Safe.t
+(** [replay_retention_json ~base_path ~masc_root ~sources] returns the
+    provenance block for the dashboard telemetry replay endpoint, including
+    the selected source list and durable stores read for each source. *)

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -183,7 +183,7 @@ check_json "activity swimlane exposes spans" "$BASE/api/v1/activity/swimlane" "'
 check_http "telemetry summary 200" "$BASE/api/v1/dashboard/telemetry/summary" "200"
 check_json "telemetry summary has sources" "$BASE/api/v1/dashboard/telemetry/summary" "'sources' in d" '^True$'
 check_http "telemetry entries 200" "$BASE/api/v1/dashboard/telemetry?source=oas_event&n=5" "200"
-check_json "telemetry entries exposes replay envelope" "$BASE/api/v1/dashboard/telemetry?source=oas_event&n=5" "'entries' in d and 'total_matching_entries' in d and 'truncated' in d" '^True$'
+check_json "telemetry entries exposes replay provenance" "$BASE/api/v1/dashboard/telemetry?source=oas_event&n=5" "'entries' in d and 'total_matching_entries' in d and 'truncated' in d and d.get('dashboard_surface') == '/api/v1/dashboard/telemetry' and d.get('source') == 'telemetry_unified' and d.get('retention', {}).get('scope') == 'dashboard_telemetry_replay' and 'oas_event' in d.get('query', {}).get('resolved_sources', [])" '^True$'
 check_http "oas telemetry recent 200" "$BASE/api/v1/dashboard/oas/telemetry/recent?limit=5" "200"
 check_json "oas telemetry recent exposes provenance" "$BASE/api/v1/dashboard/oas/telemetry/recent?limit=5" "'samples' in d and 'dashboard_surface' in d and 'retention' in d" '^True$'
 check_http "oas telemetry summary 200" "$BASE/api/v1/dashboard/oas/telemetry/summary?limit=5" "200"

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -1084,6 +1084,50 @@ let test_summary_counts_all_entries_beyond_recent_cap () =
     Alcotest.(check int) "counts all rows, not read_recent cap" 10_050 total
   | _ -> Alcotest.fail "expected Assoc"
 
+let test_replay_retention_lists_selected_sources () =
+  let dir = tmpdir "telem_replay_retention" in
+  let root = masc_root dir in
+  let json =
+    Telemetry_unified.replay_retention_json ~base_path:dir ~masc_root:root
+      ~sources:[ Telemetry_unified.Oas_event; Telemetry_unified.Tool_metric ]
+  in
+  match json with
+  | `Assoc fields ->
+    Alcotest.(check string) "scope" "dashboard_telemetry_replay"
+      (json_string_field "scope" json);
+    Alcotest.(check string) "coordination root" root
+      (json_string_field "coordination_root" json);
+    let selected_sources =
+      match List.assoc_opt "selected_sources" fields with
+      | Some (`List values) ->
+        List.map
+          (function `String value -> value | _ -> Alcotest.fail "bad source")
+          values
+      | _ -> Alcotest.fail "expected selected_sources"
+    in
+    Alcotest.(check (list string)) "selected sources"
+      [ "oas_event"; "tool_metric" ]
+      selected_sources;
+    let durable_stores =
+      match List.assoc_opt "durable_stores" fields with
+      | Some (`List values) -> values
+      | _ -> Alcotest.fail "expected durable_stores"
+    in
+    Alcotest.(check int) "durable store count" 2 (List.length durable_stores);
+    let oas_store =
+      List.find
+        (fun value ->
+          String.equal "oas_event" (json_string_field "source" value))
+        durable_stores
+    in
+    Alcotest.(check string) "oas durable store"
+      (Filename.concat root "oas-events")
+      (json_string_field "durable_store" oas_store);
+    Alcotest.(check string) "oas dashboard surface"
+      "/api/v1/dashboard/telemetry"
+      (json_string_field "dashboard_surface" oas_store)
+  | _ -> Alcotest.fail "expected Assoc"
+
 (* ── Cluster-aware path ─────────────────────────── *)
 
 let test_cluster_aware_read () =
@@ -1195,6 +1239,8 @@ let () =
             test_summary_bad_trajectory_root_observed_once;
           Alcotest.test_case "counts all rows beyond recent cap" `Quick
             test_summary_counts_all_entries_beyond_recent_cap;
+          Alcotest.test_case "replay retention selected sources" `Quick
+            test_replay_retention_lists_selected_sources;
         ] );
       ( "cluster",
         [


### PR DESCRIPTION
## Summary
- Expose dashboard replay provenance on `/api/v1/dashboard/telemetry`: `dashboard_surface`, `source`, `retention`, and normalized `query`.
- Preserve existing replay payload fields: `count`, `total_matching_entries`, `truncated`, and `entries`.
- Extend telemetry unit coverage and dashboard smoke coverage for the replay provenance contract.

## Evidence
- `ocamlformat --check lib/telemetry_unified.ml lib/telemetry_unified.mli lib/server/server_routes_http_routes_dashboard.ml test/test_telemetry_unified.ml`
- `git diff --check`
- `env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-build-telemetry-replay-provenance DUNE_JOBS=1 scripts/dune-local.sh build --display=short test/test_telemetry_unified.exe bin/main_eio.exe`
- `/private/tmp/masc-mcp-build-telemetry-replay-provenance/default/test/test_telemetry_unified.exe` => 34 tests passed
- `curl -fsS http://127.0.0.1:8935/health` => commit `cf02bda931`, executable `/private/tmp/masc-mcp-build-telemetry-replay-provenance/default/bin/main_eio.exe`, effective base path `/Users/dancer/me`
- `curl -fsS http://127.0.0.1:8935/api/v1/dashboard/telemetry?source=oas_event&n=5` => `dashboard_surface=/api/v1/dashboard/telemetry`, `source=telemetry_unified`, `retention.scope=dashboard_telemetry_replay`, `query.resolved_sources=[oas_event]`
- `scripts/verify-dashboard.sh http://127.0.0.1:8935` => `ALL 176 TESTS PASSED`