### PR TITLE
[codex] Improve dashboard board UX and health strip

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -5,6 +5,7 @@ import {
   createPost,
   fetchBoard,
   fetchBoardCuration,
+  fetchBoardFlairs,
   fetchBoardHearths,
   fetchBoardKarmaLedger,
   fetchBoardPost,
@@ -611,6 +612,30 @@ describe('fetchBoardHearths', () => {
       { name: 'research', count: 0 },
     ])
     expect(fetchMock).toHaveBeenCalledWith('/api/v1/board/hearths', expect.any(Object))
+  })
+})
+
+describe('fetchBoardFlairs', () => {
+  it('normalizes the board flair catalog from the server', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        flairs: [
+          { name: 'insight', emoji: '💡', label: 'Insight' },
+          { name: '  ', emoji: 'x', label: 'Ignored' },
+          { name: 'meta' },
+        ],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchBoardFlairs()).resolves.toEqual([
+      { name: 'insight', emoji: '💡', label: 'Insight' },
+      { name: 'meta', emoji: '', label: 'meta' },
+    ])
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/board/flairs', expect.any(Object))
   })
 })
 

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -19,6 +19,12 @@ export interface BoardHearth {
   count: number
 }
 
+export interface BoardFlair {
+  name: string
+  emoji: string
+  label: string
+}
+
 function toIsoTimestamp(value: unknown): string | null {
   if (typeof value === 'string' && value.trim()) return value
   if (typeof value !== 'number' || Number.isNaN(value)) return null
@@ -508,6 +514,19 @@ function normalizeBoardHearth(raw: unknown): BoardHearth | null {
   }
 }
 
+function normalizeBoardFlair(raw: unknown): BoardFlair | null {
+  if (!isRecord(raw)) return null
+  const name = asString(raw.name, '').trim()
+  if (!name) return null
+  const emoji = asString(raw.emoji, '').trim()
+  const label = asString(raw.label, '').trim()
+  return {
+    name,
+    emoji,
+    label: label || name,
+  }
+}
+
 function asStrictStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) return []
   return value
@@ -711,6 +730,15 @@ export async function fetchBoardHearths(): Promise<BoardHearth[]> {
     const raw = await get<{ hearths?: unknown[] }>('/api/v1/board/hearths')
     return Array.isArray(raw.hearths)
       ? raw.hearths.map(normalizeBoardHearth).filter((row): row is BoardHearth => row !== null)
+      : []
+  })
+}
+
+export async function fetchBoardFlairs(): Promise<BoardFlair[]> {
+  return withRetries('fetchBoardFlairs', async () => {
+    const raw = await get<{ flairs?: unknown[] }>('/api/v1/board/flairs')
+    return Array.isArray(raw.flairs)
+      ? raw.flairs.map(normalizeBoardFlair).filter((row): row is BoardFlair => row !== null)
       : []
   })
 }

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -27,6 +27,7 @@ import { setContextThresholds } from './config/context-thresholds'
 import {
   BuildIdentityBadge,
   ConnectionStatus,
+  DashboardHealthStrip,
   DashboardMain,
   ErrorCounterBadge,
   SideRail,
@@ -313,6 +314,7 @@ export function App() {
         <${Suspense} fallback=${null}>
           <${LazyRemoteWarningBanner} />
         <//>
+        <${DashboardHealthStrip} />
       `}
 
       <div class=${compactChromeMode ? 'flex flex-1 overflow-hidden p-0' : 'flex flex-1 gap-2 overflow-hidden p-2 max-[1100px]:flex-col'}>

--- a/dashboard/src/components/board/board-state.test.ts
+++ b/dashboard/src/components/board/board-state.test.ts
@@ -5,6 +5,7 @@ vi.mock('../../api', async (importOriginal) => {
   return {
     ...actual,
     fetchBoardHearths: vi.fn(),
+    fetchBoardFlairs: vi.fn(),
   }
 })
 
@@ -13,6 +14,9 @@ vi.mock('../common/toast', () => ({
 }))
 
 import {
+  boardFlairs,
+  boardFlairsError,
+  boardFlairsLoading,
   boardHearths,
   boardHearthsError,
   boardHearthsLoading,
@@ -25,12 +29,13 @@ import {
   visibilityLabel,
   filterHint,
   splitVisiblePosts,
+  refreshBoardFlairs,
   refreshBoardHearths,
   type ContentCategory,
   type VisibleBoardGroups,
 } from './board-state'
 import type { BoardPost } from '../../types'
-import { fetchBoardHearths, type BoardHearth } from '../../api'
+import { fetchBoardFlairs, fetchBoardHearths, type BoardFlair, type BoardHearth } from '../../api'
 import { showToast } from '../common/toast'
 
 // Reset module-scope signals between tests
@@ -66,7 +71,11 @@ beforeEach(() => {
   boardHearths.value = []
   boardHearthsError.value = false
   boardHearthsLoading.value = false
+  boardFlairs.value = []
+  boardFlairsError.value = false
+  boardFlairsLoading.value = false
   vi.mocked(fetchBoardHearths).mockReset()
+  vi.mocked(fetchBoardFlairs).mockReset()
   vi.mocked(showToast).mockReset()
 })
 
@@ -272,5 +281,29 @@ describe('refreshBoardHearths', () => {
     expect(boardHearthsError.value).toBe(false)
     expect(boardHearthsLoading.value).toBe(false)
     expect(showToast).not.toHaveBeenCalled()
+  })
+})
+
+describe('refreshBoardFlairs', () => {
+  it('loads flair options for the composer catalog', async () => {
+    const flairs: BoardFlair[] = [{ name: 'insight', emoji: '💡', label: 'Insight' }]
+    vi.mocked(fetchBoardFlairs).mockResolvedValue(flairs)
+
+    await refreshBoardFlairs()
+
+    expect(boardFlairs.value).toEqual(flairs)
+    expect(boardFlairsError.value).toBe(false)
+    expect(boardFlairsLoading.value).toBe(false)
+  })
+
+  it('keeps the composer usable when flair loading fails', async () => {
+    vi.mocked(fetchBoardFlairs).mockRejectedValue(new Error('offline'))
+
+    await refreshBoardFlairs()
+
+    expect(boardFlairs.value).toEqual([])
+    expect(boardFlairsError.value).toBe(true)
+    expect(boardFlairsLoading.value).toBe(false)
+    expect(showToast).toHaveBeenCalledWith('Flair 목록을 불러오지 못했습니다', 'error')
   })
 })

--- a/dashboard/src/components/board/board-state.ts
+++ b/dashboard/src/components/board/board-state.ts
@@ -22,11 +22,13 @@ import {
   votePost,
   voteComment,
   fetchBoardHearths,
+  fetchBoardFlairs,
   fetchSubBoards,
   fetchBoardPost,
   commentPost,
   createPost,
   type BoardHearth,
+  type BoardFlair,
 } from '../../api'
 import { deleteBoardPost } from '../../api/actions'
 import type { BoardComment, BoardPost, BoardSortMode } from '../../types'
@@ -73,6 +75,9 @@ export const detailPostId = signal<string | null>(null)
 export const boardHearths = signal<BoardHearth[]>([])
 export const boardHearthsLoading = signal(false)
 export const boardHearthsError = signal(false)
+export const boardFlairs = signal<BoardFlair[]>([])
+export const boardFlairsLoading = signal(false)
+export const boardFlairsError = signal(false)
 
 // SubBoard options for post creation dropdown
 export const subBoardOptions = signal<Array<{ slug: string; name: string }>>([])
@@ -90,6 +95,7 @@ export const showNewPostForm = signal(false)
 export const newPostTitle = signal('')
 export const newPostContent = signal('')
 export const newPostHearth = signal('')
+export const newPostFlair = signal('')
 export const newPostSubmitting = signal(false)
 
 // ── Pagination ─────────────────────────────────────────────────────
@@ -141,6 +147,20 @@ export async function refreshBoardHearths(): Promise<void> {
     if (requestId === boardHearthsRequestId) {
       boardHearthsLoading.value = false
     }
+  }
+}
+
+export async function refreshBoardFlairs(): Promise<void> {
+  boardFlairsLoading.value = true
+  try {
+    boardFlairs.value = await fetchBoardFlairs()
+    boardFlairsError.value = false
+  } catch (err) {
+    console.warn('[Board] failed to load flair options:', err)
+    boardFlairsError.value = true
+    showToast('Flair 목록을 불러오지 못했습니다', 'error')
+  } finally {
+    boardFlairsLoading.value = false
   }
 }
 
@@ -396,13 +416,18 @@ export async function submitNewPost() {
   const title = newPostTitle.value.trim()
   const content = newPostContent.value.trim()
   const hearth = newPostHearth.value.trim()
+  const flair = newPostFlair.value.trim()
   if (!title || !content) return
   newPostSubmitting.value = true
   try {
-    await createPost(title, content, commentAuthor.value, { hearth: hearth || undefined })
+    const contentWithFlair = flair
+      ? `[flair:${flair}]\n${content.replace(/^\[flair:[a-z]+\]\s*/i, '')}`
+      : content
+    await createPost(title, contentWithFlair, commentAuthor.value, { hearth: hearth || undefined })
     newPostTitle.value = ''
     newPostContent.value = ''
     newPostHearth.value = ''
+    newPostFlair.value = ''
     showNewPostForm.value = false
     showToast('글을 등록했습니다', 'success')
     refreshBoard()

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { BoardSurface } from './board-surface'
 import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter, boardHasMore, boardLoadingMore, messages, shellAuthSummary } from '../../store'
 import { route } from '../../router'
-import { PAGE_SIZE, boardHearths, boardHearthsError, categoryVisibleLimits, contentCategory, newPostHearth, newPostSubmitting, showNewPostForm } from './board-state'
+import { PAGE_SIZE, boardFlairs, boardFlairsError, boardHearths, boardHearthsError, categoryVisibleLimits, contentCategory, newPostFlair, newPostHearth, newPostSubmitting, showNewPostForm, subBoardOptions, subBoardOptionsError } from './board-state'
 import { boardLatencyMetrics, resetBoardLatencyMetrics } from '../../board-metrics'
 import type { BoardPost } from '../../types'
 
@@ -28,6 +28,7 @@ vi.mock('../../api', () => ({
   fetchBoardPost: vi.fn(),
   votePost: vi.fn(),
   fetchBoardHearths: vi.fn().mockResolvedValue([]),
+  fetchSubBoards: vi.fn().mockResolvedValue([]),
   commentPost: vi.fn(),
   createPost: vi.fn(),
 }))
@@ -161,9 +162,17 @@ describe('BoardSurface Component', () => {
     boardHearthFilter.value = ''
     boardHearths.value = [{ name: 'ops', count: 0 }]
     boardHearthsError.value = false
+    boardFlairs.value = [
+      { name: 'insight', emoji: '💡', label: 'Insight' },
+      { name: 'bug', emoji: '🐛', label: 'Bug Report' },
+    ]
+    boardFlairsError.value = false
+    subBoardOptions.value = []
+    subBoardOptionsError.value = false
     resetBoardLatencyMetrics()
     showNewPostForm.value = false
     newPostHearth.value = ''
+    newPostFlair.value = ''
     newPostSubmitting.value = false
     categoryVisibleLimits.value = {
       article: PAGE_SIZE,
@@ -235,6 +244,38 @@ describe('BoardSurface Component', () => {
     render(h(BoardSurface, null))
 
     expect(screen.getByRole('button', { name: '🔥 리액션 2개' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('keeps reaction controls visible for zero-reaction post cards', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'post-zero-reactions',
+        title: 'Reaction affordance',
+        body: 'content',
+        author: 'ani1999',
+      }),
+    ]
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByRole('button', { name: '👍 리액션 0개' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '👀 리액션 0개' })).toBeInTheDocument()
+  })
+
+  it('renders flair badges on post cards', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'post-flair',
+        title: 'Flair projection',
+        body: 'content',
+        author: 'ani1999',
+        flair: 'insight',
+      }),
+    ]
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByText('flair:insight')).toBeInTheDocument()
   })
 
   it('renders post moderation projection badges', () => {
@@ -455,8 +496,18 @@ describe('BoardSurface Component', () => {
     render(h(BoardSurface, null))
     fireEvent.click(screen.getByRole('button', { name: '+ 새 글 작성' }))
 
-    expect(screen.getByLabelText('새 글 hearth')).toHaveValue('ops')
+    expect(screen.getByLabelText('새 글 category')).toHaveValue('ops')
     expect(newPostHearth.value).toBe('ops')
+  })
+
+  it('renders explicit flair selection in the post composer', () => {
+    render(h(BoardSurface, null))
+    fireEvent.click(screen.getByRole('button', { name: '+ 새 글 작성' }))
+
+    const flair = screen.getByLabelText('새 글 flair')
+    expect(flair).toBeInTheDocument()
+    fireEvent.change(flair, { target: { value: 'bug' } })
+    expect(newPostFlair.value).toBe('bug')
   })
 
   it('disables compose cancel while a post is submitting', () => {

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -47,8 +47,12 @@ import {
   boardHearths,
   boardHearthsLoading,
   boardHearthsError,
+  boardFlairs,
+  boardFlairsLoading,
+  boardFlairsError,
   subBoardOptions,
   subBoardOptionsLoading,
+  subBoardOptionsError,
   boardExcludeAutomation,
   boardLoading,
   boardLoadingMore,
@@ -65,6 +69,7 @@ import {
   newPostTitle,
   newPostContent,
   newPostHearth,
+  newPostFlair,
   newPostSubmitting,
   PAGE_SIZE,
   categoryVisibleLimits,
@@ -90,6 +95,8 @@ import {
   votePost,
   deleteBoardPost,
   refreshBoardHearths,
+  refreshBoardFlairs,
+  loadSubBoardOptionsForPost,
 } from './board-state'
 import type { BoardPost, ContentCategory } from './board-state'
 
@@ -240,6 +247,15 @@ function CategorySection({ group }: { group: { category: ContentCategory; posts:
 
 // ── New post form ──────────────────────────────────────────────────
 function NewPostForm() {
+  useEffect(() => {
+    if (showNewPostForm.value && boardFlairs.value.length === 0 && !boardFlairsLoading.value) {
+      void refreshBoardFlairs()
+    }
+    if (showNewPostForm.value && subBoardOptions.value.length === 0 && !subBoardOptionsLoading.value) {
+      void loadSubBoardOptionsForPost()
+    }
+  }, [showNewPostForm.value])
+
   if (!showNewPostForm.value) {
     return html`
       <button type="button"
@@ -258,6 +274,22 @@ function NewPostForm() {
     && !subBoardSelectOptions.some(option => option.value === activeHearth)
     ? [{ value: activeHearth, label: activeHearth }, ...subBoardSelectOptions]
     : subBoardSelectOptions
+  const categorySelectOptions = [
+    { value: '', label: 'No category' },
+    ...selectedSubBoardOptions,
+  ]
+  const activeFlair = newPostFlair.value.trim()
+  const flairSelectOptions = [
+    { value: '', label: 'No flair' },
+    ...boardFlairs.value.map(flair => ({
+      value: flair.name,
+      label: `${flair.emoji ? `${flair.emoji} ` : ''}${flair.label}`,
+    })),
+  ]
+  const selectedFlairOptions = activeFlair
+    && !flairSelectOptions.some(option => option.value === activeFlair)
+    ? [{ value: activeFlair, label: activeFlair }, ...flairSelectOptions]
+    : flairSelectOptions
 
   return html`
     <div class="p-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] grid gap-3">
@@ -277,14 +309,34 @@ function NewPostForm() {
         helpText="예: ts 코드펜스, 일반 URL 링크 카드, 단독 이미지 URL 자동 인라인"
         previewLimit=${2}
       />
-      <${Select}
-        value=${newPostHearth.value}
-        options=${selectedSubBoardOptions}
-        placeholder="Sub-board (hearth) 선택"
-        disabled=${newPostSubmitting.value || subBoardOptionsLoading.value}
-        ariaLabel="새 글 hearth"
-        onInput=${(value: string) => { newPostHearth.value = value }}
-      />
+      <div class="grid gap-3 md:grid-cols-2">
+        <label class="grid gap-1 text-2xs font-medium uppercase text-[var(--color-fg-muted)]">
+          Category
+          <${Select}
+            value=${newPostHearth.value}
+            options=${categorySelectOptions}
+            disabled=${newPostSubmitting.value || subBoardOptionsLoading.value}
+            ariaLabel="새 글 category"
+            onInput=${(value: string) => { newPostHearth.value = value }}
+          />
+        </label>
+        <label class="grid gap-1 text-2xs font-medium uppercase text-[var(--color-fg-muted)]">
+          Flair
+          <${Select}
+            value=${newPostFlair.value}
+            options=${selectedFlairOptions}
+            disabled=${newPostSubmitting.value || boardFlairsLoading.value}
+            ariaLabel="새 글 flair"
+            onInput=${(value: string) => { newPostFlair.value = value }}
+          />
+        </label>
+      </div>
+      ${boardFlairsError.value ? html`
+        <div class="text-2xs text-[var(--color-status-warn)]">Flair 목록을 불러오지 못했습니다. 직접 [flair:name] prefix를 사용할 수 있습니다.</div>
+      ` : null}
+      ${subBoardOptionsError.value ? html`
+        <div class="text-2xs text-[var(--color-status-warn)]">Sub-board 목록을 불러오지 못했습니다. Category 값을 직접 입력하려면 현재 Board 필터를 먼저 선택하세요.</div>
+      ` : null}
       <div class="flex gap-2 justify-end">
         <button type="button"
           class="px-3 py-1.5 rounded-[var(--r-1)] text-sm border border-[var(--color-border-default)] bg-transparent text-[var(--color-fg-muted)] cursor-pointer hover:bg-[var(--color-bg-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
@@ -294,6 +346,7 @@ function NewPostForm() {
             newPostTitle.value = ''
             newPostContent.value = ''
             newPostHearth.value = ''
+            newPostFlair.value = ''
           }}
         >취소</button>
         <button type="button"
@@ -722,6 +775,7 @@ function PostCard({ post }: { post: BoardPost }) {
 
           <!-- Category badges -->
           <span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${categoryBadgeColor(cat)}">${categoryLabel(cat)}</span>
+          ${post.flair ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border bg-[var(--cyan-16)] text-[var(--color-accent-fg)] border-[var(--cyan-16)]">flair:${post.flair}</span>` : null}
           ${qualityPercent !== null ? html`
             <span
               class=${`inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${contributorQualityBadgeClass(post.contributor_quality)}`}
@@ -746,20 +800,18 @@ function PostCard({ post }: { post: BoardPost }) {
             ${isDeleting ? '삭제 중...' : '삭제'}
           <//>
         </div>
-        ${reactionPreview ? html`
-          <div
-            class="mt-2"
-            onClick=${(event: Event) => event.stopPropagation()}
-            onKeyDown=${(event: KeyboardEvent) => event.stopPropagation()}
-          >
-            <${ReactionBar}
-              targetType="post"
-              targetId=${post.id}
-              compact
-              initialSummaries=${post.reactions}
-            />
-          </div>
-        ` : null}
+        <div
+          class=${reactionPreview ? 'mt-2' : 'mt-2 opacity-75 transition-opacity group-hover:opacity-100'}
+          onClick=${(event: Event) => event.stopPropagation()}
+          onKeyDown=${(event: KeyboardEvent) => event.stopPropagation()}
+        >
+          <${ReactionBar}
+            targetType="post"
+            targetId=${post.id}
+            compact
+            initialSummaries=${post.reactions ?? []}
+          />
+        </div>
       </div>
     </article>
   `
@@ -773,6 +825,9 @@ export function BoardSurface() {
   }), [])
   useEffect(() => {
     if (boardHearths.value.length === 0) void refreshBoardHearths()
+  }, [])
+  useEffect(() => {
+    if (boardFlairs.value.length === 0) void refreshBoardFlairs()
   }, [])
   const [contentQuery, setContentQuery] = useState('')
   const rawPosts = boardPosts.value

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -581,10 +581,11 @@ export function PostDetail({ post }: { post: BoardPost }) {
           </div>
 
           <!-- Badges -->
-          ${(post.hearth || post.visibility || post.expires_at || post.classification_reason || qualityPercent !== null || (post.moderation_status && post.moderation_status !== 'none') || (post.report_count ?? 0) > 0)
+          ${(post.flair || post.hearth || post.visibility || post.expires_at || post.classification_reason || qualityPercent !== null || (post.moderation_status && post.moderation_status !== 'none') || (post.report_count ?? 0) > 0)
             ? html`
                 <div class="flex flex-col gap-2">
                   <div class="flex gap-1.5 flex-wrap">
+                    ${post.flair ? html`<span class="inline-flex items-center px-2 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border bg-[var(--cyan-16)] text-[var(--color-accent-fg)] border-[var(--cyan-16)]">flair:${post.flair}</span>` : null}
                     ${post.hearth ? html`<span class="inline-flex items-center px-2 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border bg-[var(--ff-gold-10)] text-[var(--ff-gold-bright)] border-[var(--ff-gold-20)]">${post.hearth}</span>` : null}
                     ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-2 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}
                     <span class="inline-flex items-center px-2 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${kindBadgeColor(boardPostKind(post))}">${kindLabel(boardPostKind(post))}</span>

--- a/dashboard/src/components/board/sub-board-surface.ts
+++ b/dashboard/src/components/board/sub-board-surface.ts
@@ -398,7 +398,11 @@ export function SubBoardSurface() {
       ${loading
         ? html`<${LoadingState}>Loading sub-boards...<//>`
         : boards.length === 0
-          ? html`<${EmptyState} message="No sub-boards yet." compact />`
+          ? html`
+            <div class="rounded-[var(--r-1)] border border-dashed border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4">
+              <${EmptyState} message="No sub-boards yet. Create one above when a board category needs owner, member, or access policy. Plain board categories stay as hearth tags until a Sub-board is explicitly created." compact />
+            </div>
+          `
           : html`
             <div class="grid gap-3" data-testid="sub-board-list">
               ${boards.map(board => html`<${SubBoardRow}

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { h, render } from 'preact'
 import { waitFor } from '@testing-library/preact'
-import { DashboardMain } from './dashboard-shell'
+import { DashboardMain, dashboardHealthChips } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
 import { dashboardLoading } from '../store'
@@ -40,8 +40,52 @@ describe('DashboardMain solo mode', () => {
 
     render(h(DashboardMain, {}), container)
 
-    await waitFor(() => expect(document.title).toBe('MASC · Cascade'))
+    await waitFor(() => expect(document.title).toBe('MASC · Live Runtime'))
     expect(container.querySelector('[data-testid="dashboard-widget-solo-bar"]')).not.toBeNull()
     expect(container.querySelector('[aria-label="Active observability filters"]')).not.toBeNull()
+  })
+})
+
+describe('dashboardHealthChips', () => {
+  it('separates source mismatch, paused keepers, and execution errors', () => {
+    const chips = dashboardHealthChips({
+      connected: true,
+      counts: { keepers: 1, configured_keepers: 2 },
+      keepers: [{
+        name: 'keeper-a',
+        status: 'paused',
+        paused: true,
+      } as any],
+      runtimeResolution: {
+        status: 'warn',
+        warnings: [],
+        source_mismatch: true,
+        server_workspace_mismatch: false,
+      } as any,
+      executionError: 'snapshot failed',
+      loading: false,
+    })
+
+    expect(chips.map(chip => chip.key)).toEqual([
+      'source-mismatch',
+      'paused-keepers',
+      'execution-error',
+    ])
+  })
+
+  it('returns a healthy chip when no runtime risk is visible', () => {
+    const chips = dashboardHealthChips({
+      connected: true,
+      counts: { keepers: 2, configured_keepers: 2 },
+      keepers: [],
+      runtimeResolution: null,
+      executionError: null,
+      loading: false,
+    })
+
+    expect(chips).toEqual([expect.objectContaining({
+      key: 'runtime-ok',
+      tone: 'ok',
+    })])
   })
 })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -3,11 +3,12 @@ import { signal } from '@preact/signals'
 import { lazy, Suspense } from 'preact/compat'
 import { useEffect } from 'preact/hooks'
 import type { RouteState, TabId } from '../types'
+import type { DashboardRuntimeResolution, Keeper } from '../types'
 import { hashForRoute, navigate, route } from '../router'
 import { connected, reconnectCount, lastDisconnectedAt } from '../sse'
 import { dashboardWsOnlyEnabled } from '../dashboard-ws-cutover'
 import { dashboardWsConnected, dashboardWsSseFallbackActive } from '../dashboard-ws-state'
-import { dashboardLoading, serverStatus } from '../store'
+import { dashboardLoading, executionError, keepers, serverStatus, shellCounts, shellRuntimeResolution } from '../store'
 import { missionSnapshot, missionLoading } from '../mission-signals'
 import { namespaceTruthInitializing } from '../namespace-truth-store'
 import { ErrorBoundary } from './common/error-boundary'
@@ -139,6 +140,155 @@ export function ConnectionStatus() {
           class="inline-flex items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 tabular-nums attention-badge"
         >Attention ${attentionCount}<//>
       ` : null}
+    </div>
+  `
+}
+
+type DashboardHealthChipTone = 'ok' | 'warn' | 'bad' | 'muted'
+
+interface DashboardHealthChip {
+  key: string
+  label: string
+  detail: string
+  tone: DashboardHealthChipTone
+}
+
+interface DashboardHealthInput {
+  connected: boolean
+  counts: {
+    keepers: number
+    configured_keepers: number
+  } | null
+  keepers: Keeper[]
+  runtimeResolution: DashboardRuntimeResolution | null
+  executionError: string | null
+  loading: boolean
+}
+
+function keeperLooksPaused(keeper: Keeper): boolean {
+  const phase = String(keeper.phase ?? '').toLowerCase()
+  const stage = String(keeper.pipeline_stage ?? '').toLowerCase()
+  const status = String(keeper.status ?? '').toLowerCase()
+  return keeper.paused === true || phase === 'paused' || stage === 'paused' || status === 'paused'
+}
+
+export function dashboardHealthChips(input: DashboardHealthInput): DashboardHealthChip[] {
+  const chips: DashboardHealthChip[] = []
+  if (!input.connected) {
+    chips.push({
+      key: 'transport-offline',
+      label: 'Transport offline',
+      detail: 'Dashboard stream is disconnected; live state can be stale.',
+      tone: 'bad',
+    })
+  }
+
+  const runtime = input.runtimeResolution
+  if (runtime?.source_mismatch || runtime?.server_workspace_mismatch) {
+    chips.push({
+      key: 'source-mismatch',
+      label: 'Source mismatch',
+      detail: 'Server, workspace, or resolved base path source differs.',
+      tone: 'warn',
+    })
+  } else if (runtime?.status && runtime.status !== 'ready') {
+    chips.push({
+      key: 'runtime-warning',
+      label: 'Runtime warning',
+      detail: runtime.warnings[0] ?? runtime.status,
+      tone: 'warn',
+    })
+  }
+
+  const pausedKeepers = input.keepers.filter(keeperLooksPaused).length
+  if (pausedKeepers > 0) {
+    chips.push({
+      key: 'paused-keepers',
+      label: `Paused keepers ${pausedKeepers}`,
+      detail: 'One or more keeper rows are paused; board/tool activity may look quiet.',
+      tone: 'warn',
+    })
+  }
+
+  const configured = input.counts?.configured_keepers ?? 0
+  const liveKeepers = input.counts?.keepers ?? input.keepers.length
+  if (configured > 0 && liveKeepers === 0) {
+    chips.push({
+      key: 'no-keeper-rows',
+      label: 'No keeper rows',
+      detail: `${configured} keepers are configured but no live keeper rows are visible.`,
+      tone: 'warn',
+    })
+  }
+
+  if (input.executionError) {
+    chips.push({
+      key: 'execution-error',
+      label: 'Execution refresh failed',
+      detail: input.executionError,
+      tone: 'bad',
+    })
+  }
+
+  if (chips.length === 0) {
+    chips.push({
+      key: input.loading ? 'hydrating' : 'runtime-ok',
+      label: input.loading ? 'Hydrating' : 'Runtime UI healthy',
+      detail: input.loading
+        ? 'Dashboard data is still loading.'
+        : 'No transport, source, paused-keeper, or execution-refresh issue is currently visible.',
+      tone: input.loading ? 'muted' : 'ok',
+    })
+  }
+
+  return chips
+}
+
+function healthChipClass(tone: DashboardHealthChipTone): string {
+  switch (tone) {
+    case 'ok':
+      return 'border-[var(--ok-30)] bg-[var(--ok-soft)] text-[var(--color-status-ok)]'
+    case 'warn':
+      return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn-bright)]'
+    case 'bad':
+      return 'border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--color-status-err)]'
+    case 'muted':
+      return 'border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)]'
+  }
+}
+
+export function DashboardHealthStrip() {
+  const wsOnly = dashboardWsOnlyEnabled()
+  const live = wsOnly
+    ? dashboardWsConnected.value || dashboardWsSseFallbackActive.value
+    : connected.value
+  const chips = dashboardHealthChips({
+    connected: live,
+    counts: shellCounts.value,
+    keepers: keepers.value,
+    runtimeResolution: shellRuntimeResolution.value,
+    executionError: executionError.value,
+    loading: dashboardLoading.value || namespaceTruthInitializing.value,
+  })
+
+  return html`
+    <div
+      class="flex shrink-0 flex-wrap items-center gap-2 border-b border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-3 py-1.5 text-2xs"
+      role="status"
+      aria-label="Dashboard runtime health"
+      data-testid="dashboard-health-strip"
+    >
+      <span class="font-mono uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Health</span>
+      ${chips.map(chip => html`
+        <span
+          key=${chip.key}
+          class=${`inline-flex min-h-6 items-center rounded-[var(--r-1)] border px-2 py-0.5 font-medium ${healthChipClass(chip.tone)}`}
+          title=${chip.detail}
+          data-testid=${`dashboard-health-chip-${chip.key}`}
+        >
+          ${chip.label}
+        </span>
+      `)}
     </div>
   `
 }


### PR DESCRIPTION
## Summary

- Add explicit Board composer controls for Category/Sub-board and Flair using the existing hearth and `[flair:name]` data contracts.
- Keep reaction controls visible on Board post cards even when all reaction counts are zero, and surface flair badges on cards/details.
- Add a top-level dashboard health strip that separates transport, source mismatch, paused keeper, missing keeper row, and execution refresh issues.
- Clarify the Sub-board empty state so operators can tell that sub-boards are explicit spaces, not automatically created categories.

## Why

The dashboard already had backend support for hearths, flairs, reactions, and sub-boards, but several controls were hidden or under-discoverable. This made live Board activity look like it was absent or broken. The health strip also makes common runtime problems visible without collapsing every issue into a generic zero/empty state.

## Validation

- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/board.test.ts src/components/board/board-state.test.ts src/components/board/board-surface.test.ts src/components/dashboard-shell.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint` (passes with one pre-existing warning in `src/components/common/virtual-list.ts`)
- `git diff --check`
- Playwright browser QA against `http://127.0.0.1:5179/dashboard/#workspace?section=board`: page nonblank, health strip visible, composer opens, Category/Flair controls visible, zero-count reaction buttons visible, console clean.