### PR TITLE
feat(ide): carry record trace route context

### DIFF
--- a/dashboard/src/components/ide/bdi-snapshot-trace-bridge.test.ts
+++ b/dashboard/src/components/ide/bdi-snapshot-trace-bridge.test.ts
@@ -12,8 +12,9 @@ function snap(
   keeper: string,
   generated_at: string | null,
   intention: string | null = 'analyze diff',
+  context: BdiSnapshotProducerInput['context'] = undefined,
 ): BdiSnapshotProducerInput {
-  return { keeper, generated_at, intention }
+  return { keeper, generated_at, intention, context }
 }
 
 beforeEach(() => {
@@ -120,6 +121,42 @@ describe('bridgeBdiSnapshotsToTrace — RFC-0028 PR-δ bdi-snapshot producer', (
     if (event.source === 'bdi-snapshot') {
       expect(event.intention).toBe('verify cascade route')
     }
+  })
+
+  it('maps optional IDE route context into the trace event', () => {
+    bridgeBdiSnapshotsToTrace(
+      [snap('scholar', '2026-05-06T01:00:00Z', 'verify cascade route', {
+        file_path: 'runtime.ts',
+        line: 7,
+        goal_id: 'goal-runtime',
+        task_id: 'task-runtime',
+        board_post_id: 'post-runtime',
+        comment_id: 'comment-runtime',
+        pr_id: '15035',
+        git_ref: 'refs/heads/review-response',
+        log_id: 'turn-7',
+        session_id: 'sess-runtime',
+        operation_id: 'op-runtime',
+        worker_run_id: 'worker-runtime',
+      })],
+      new Set(),
+    )
+
+    const event = keeperTraceState.value.events[0]!
+    expect(event).toMatchObject({
+      filePath: 'runtime.ts',
+      line: 7,
+      goalId: 'goal-runtime',
+      taskId: 'task-runtime',
+      boardPostId: 'post-runtime',
+      commentId: 'comment-runtime',
+      prId: '15035',
+      gitRef: 'refs/heads/review-response',
+      logId: 'turn-7',
+      sessionId: 'sess-runtime',
+      operationId: 'op-runtime',
+      workerRunId: 'worker-runtime',
+    })
   })
 
   it('preserves a null intention (keeper between intentions)', () => {

--- a/dashboard/src/components/ide/bdi-snapshot-trace-bridge.ts
+++ b/dashboard/src/components/ide/bdi-snapshot-trace-bridge.ts
@@ -1,4 +1,8 @@
 import { pushTrace } from './keeper-trace-store'
+import {
+  normalizeTraceProducerContext,
+  type KeeperTraceProducerContextInput,
+} from './keeper-trace-context'
 
 /**
  * RFC-0028 PR-δ producer: bdi-snapshot → keeper-trace bridge.
@@ -53,6 +57,7 @@ export interface BdiSnapshotProducerInput {
   readonly keeper: string
   readonly generated_at: string | null
   readonly intention: string | null
+  readonly context?: KeeperTraceProducerContextInput | null
 }
 
 function dedupKey(snapshot: BdiSnapshotProducerInput): string {
@@ -83,6 +88,7 @@ export function bridgeBdiSnapshotsToTrace(
       keeperName: snapshot.keeper,
       source: 'bdi-snapshot',
       intention: snapshot.intention,
+      ...normalizeTraceProducerContext(snapshot.context),
     })
     next.add(key)
   }

--- a/dashboard/src/components/ide/cascade-hop-trace-bridge.test.ts
+++ b/dashboard/src/components/ide/cascade-hop-trace-bridge.test.ts
@@ -13,8 +13,9 @@ function evt(
   cycle: number,
   ts: number,
   strategy = 'round_robin',
+  context: CascadeHopProducerInput['context'] = undefined,
 ): CascadeHopProducerInput {
-  return { cascade_name, cycle, ts, strategy }
+  return { cascade_name, cycle, ts, strategy, context }
 }
 
 beforeEach(() => {
@@ -115,6 +116,31 @@ describe('bridgeCascadeEventsToTrace — RFC-0028 PR-δ cascade-hop producer', (
       expect(event.hopId).toBe('mainline-7')
       expect(event.provider).toBe('weighted_score')
     }
+  })
+
+  it('maps optional IDE route context into the trace event', () => {
+    bridgeCascadeEventsToTrace(
+      [evt('mainline', 7, 1_715_000_000, 'weighted_score', {
+        file_path: 'router/runtime.ts',
+        line: 42,
+        goal_id: 'goal-cascade',
+        task_id: 'task-cascade',
+        pr_id: '15035',
+        git_ref: 'refs/heads/cascade-route',
+        log_id: 'cascade-turn-42',
+      })],
+      new Set(),
+    )
+    const event = keeperTraceState.value.events[0]!
+    expect(event).toMatchObject({
+      filePath: 'router/runtime.ts',
+      line: 42,
+      goalId: 'goal-cascade',
+      taskId: 'task-cascade',
+      prId: '15035',
+      gitRef: 'refs/heads/cascade-route',
+      logId: 'cascade-turn-42',
+    })
   })
 
   it('is idempotent across repeated calls with the returned set', () => {

--- a/dashboard/src/components/ide/cascade-hop-trace-bridge.ts
+++ b/dashboard/src/components/ide/cascade-hop-trace-bridge.ts
@@ -1,4 +1,8 @@
 import { pushTrace } from './keeper-trace-store'
+import {
+  normalizeTraceProducerContext,
+  type KeeperTraceProducerContextInput,
+} from './keeper-trace-context'
 
 /**
  * RFC-0028 PR-δ producer: cascade-hop → keeper-trace bridge.
@@ -52,6 +56,7 @@ export interface CascadeHopProducerInput {
   readonly cascade_name: string
   readonly strategy: string
   readonly cycle: number
+  readonly context?: KeeperTraceProducerContextInput | null
 }
 
 function unixishToMs(ts: number): number {
@@ -86,6 +91,7 @@ export function bridgeCascadeEventsToTrace(
       source: 'cascade-hop',
       hopId: `${event.cascade_name}-${event.cycle}`,
       provider: event.strategy,
+      ...normalizeTraceProducerContext(event.context),
     })
     next.add(key)
   }

--- a/dashboard/src/components/ide/decision-log-trace-bridge.test.ts
+++ b/dashboard/src/components/ide/decision-log-trace-bridge.test.ts
@@ -13,8 +13,9 @@ function dec(
   ts_unix: number | null,
   event_type = 'turn',
   outcome: string | null = 'ok',
+  context: DecisionLogProducerInput['context'] = undefined,
 ): DecisionLogProducerInput {
-  return { keeper_name, ts_unix, event_type, outcome }
+  return { keeper_name, ts_unix, event_type, outcome, context }
 }
 
 beforeEach(() => {
@@ -124,6 +125,41 @@ describe('bridgeDecisionsToTrace — RFC-0028 PR-δ decision-log producer', () =
       expect(event.decisionId).toBe('decision:scholar:1715000000:tool_use')
       expect(event.semanticOutcome).toBe('error_retryable')
     }
+  })
+
+  it('maps optional IDE route context into the trace event', () => {
+    bridgeDecisionsToTrace(
+      [dec('scholar', 1_715_000_000, 'tool_use', 'error_retryable', {
+        file_path: 'runtime.ts',
+        line: 9,
+        goal_id: 'goal-decision',
+        task_id: 'task-decision',
+        board_post_id: 'post-decision',
+        comment_id: 'comment-decision',
+        pr_id: '15035',
+        git_ref: 'refs/heads/decision-route',
+        log_id: 'decision-turn-9',
+        session_id: 'sess-decision',
+        operation_id: 'op-decision',
+        worker_run_id: 'worker-decision',
+      })],
+      new Set(),
+    )
+    const event = keeperTraceState.value.events[0]!
+    expect(event).toMatchObject({
+      filePath: 'runtime.ts',
+      line: 9,
+      goalId: 'goal-decision',
+      taskId: 'task-decision',
+      boardPostId: 'post-decision',
+      commentId: 'comment-decision',
+      prId: '15035',
+      gitRef: 'refs/heads/decision-route',
+      logId: 'decision-turn-9',
+      sessionId: 'sess-decision',
+      operationId: 'op-decision',
+      workerRunId: 'worker-decision',
+    })
   })
 
   it('preserves a null semanticOutcome (in-flight decisions)', () => {

--- a/dashboard/src/components/ide/decision-log-trace-bridge.ts
+++ b/dashboard/src/components/ide/decision-log-trace-bridge.ts
@@ -1,4 +1,8 @@
 import { pushTrace } from './keeper-trace-store'
+import {
+  normalizeTraceProducerContext,
+  type KeeperTraceProducerContextInput,
+} from './keeper-trace-context'
 
 /**
  * RFC-0028 PR-δ producer: decision-log → keeper-trace bridge.
@@ -57,6 +61,7 @@ export interface DecisionLogProducerInput {
   readonly keeper_name: string
   readonly event_type: string
   readonly outcome: string | null
+  readonly context?: KeeperTraceProducerContextInput | null
 }
 
 function unixishToMs(ts: number | null): number {
@@ -92,6 +97,7 @@ export function bridgeDecisionsToTrace(
       source: 'decision-log',
       decisionId: key,
       semanticOutcome: decision.outcome,
+      ...normalizeTraceProducerContext(decision.context),
     })
     next.add(key)
   }

--- a/dashboard/src/components/ide/keeper-trace-context.ts
+++ b/dashboard/src/components/ide/keeper-trace-context.ts
@@ -1,0 +1,39 @@
+import type { KeeperTraceContextFields } from './keeper-trace-store'
+import { normalizeIdeContextFilePath, normalizeIdeContextLine } from './ide-state'
+
+export interface KeeperTraceProducerContextInput {
+  readonly file_path?: string | null
+  readonly line?: number | null
+  readonly goal_id?: string
+  readonly task_id?: string
+  readonly board_post_id?: string
+  readonly comment_id?: string
+  readonly pr_id?: string
+  readonly git_ref?: string
+  readonly log_id?: string
+  readonly session_id?: string
+  readonly operation_id?: string
+  readonly worker_run_id?: string
+}
+
+export function normalizeTraceProducerContext(
+  context?: KeeperTraceProducerContextInput | null,
+): KeeperTraceContextFields {
+  if (!context) return {}
+  const filePath = context.file_path ? normalizeIdeContextFilePath(context.file_path) : null
+  const line = normalizeIdeContextLine(context.line ?? undefined)
+  return {
+    filePath: filePath ?? undefined,
+    line,
+    goalId: context.goal_id,
+    taskId: context.task_id,
+    boardPostId: context.board_post_id,
+    commentId: context.comment_id,
+    prId: context.pr_id,
+    gitRef: context.git_ref,
+    logId: context.log_id,
+    sessionId: context.session_id,
+    operationId: context.operation_id,
+    workerRunId: context.worker_run_id,
+  }
+}

--- a/dashboard/src/components/ide/keeper-trace-store.test.ts
+++ b/dashboard/src/components/ide/keeper-trace-store.test.ts
@@ -222,6 +222,49 @@ describe('keeper-trace-store', () => {
     expect(keeperTraceState.value.events.map(e => e.count)).toEqual([1, 1, 1])
   })
 
+  it('does NOT coalesce record events with different optional trace contexts', () => {
+    pushTrace({
+      id: 'decision-1',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'decision-log',
+      decisionId: 'd-1',
+      semanticOutcome: 'success',
+      filePath: 'runtime.ts',
+      line: 12,
+      goalId: 'goal-runtime',
+    })
+    pushTrace({
+      id: 'decision-2',
+      tsMs: 1010,
+      keeperName: 'scholar',
+      source: 'decision-log',
+      decisionId: 'd-2',
+      semanticOutcome: 'success',
+      filePath: 'runtime.ts',
+      line: 13,
+      goalId: 'goal-runtime',
+    })
+    pushTrace({
+      id: 'decision-3',
+      tsMs: 1020,
+      keeperName: 'scholar',
+      source: 'decision-log',
+      decisionId: 'd-3',
+      semanticOutcome: 'success',
+      filePath: 'runtime.ts',
+      line: 12,
+      goalId: 'goal-other',
+    })
+
+    expect(keeperTraceState.value.events.map(e => e.id)).toEqual([
+      'decision-1',
+      'decision-2',
+      'decision-3',
+    ])
+    expect(keeperTraceState.value.events.map(e => e.count)).toEqual([1, 1, 1])
+  })
+
   it('inserts out-of-order events into ascending tsMs position', () => {
     pushTrace({
       id: 'a-1',

--- a/dashboard/src/components/ide/keeper-trace-store.ts
+++ b/dashboard/src/components/ide/keeper-trace-store.ts
@@ -47,6 +47,21 @@ interface KeeperTraceBase {
   readonly source: KeeperTraceSource
 }
 
+export interface KeeperTraceContextFields {
+  readonly filePath?: string
+  readonly line?: number
+  readonly goalId?: string
+  readonly taskId?: string
+  readonly boardPostId?: string
+  readonly commentId?: string
+  readonly prId?: string
+  readonly gitRef?: string
+  readonly logId?: string
+  readonly sessionId?: string
+  readonly operationId?: string
+  readonly workerRunId?: string
+}
+
 export type KeeperTraceEvent =
   | (KeeperTraceBase & {
       readonly source: 'anchored-thread'
@@ -54,16 +69,16 @@ export type KeeperTraceEvent =
       readonly filePath?: string | null
       readonly line: number | null
     })
-  | (KeeperTraceBase & {
+  | (KeeperTraceBase & KeeperTraceContextFields & {
       readonly source: 'cascade-hop'
       readonly hopId: string
       readonly provider: string
     })
-  | (KeeperTraceBase & {
+  | (KeeperTraceBase & KeeperTraceContextFields & {
       readonly source: 'bdi-snapshot'
       readonly intention: string | null
     })
-  | (KeeperTraceBase & {
+  | (KeeperTraceBase & KeeperTraceContextFields & {
       readonly source: 'decision-log'
       readonly decisionId: string
       readonly semanticOutcome: string | null
@@ -229,5 +244,39 @@ function sameTraceBucket(left: KeeperTraceEvent, right: KeeperTraceEvent): boole
   if (left.source === 'activity-event' && right.source === 'activity-event') {
     return left.filePath === right.filePath && left.line === right.line
   }
+  if (hasTraceContext(left) || hasTraceContext(right)) {
+    return traceContextKey(left) === traceContextKey(right)
+  }
   return true
+}
+
+function hasTraceContext(event: KeeperTraceEvent): boolean {
+  return event.source === 'cascade-hop'
+    || event.source === 'bdi-snapshot'
+    || event.source === 'decision-log'
+    ? traceContextKey(event) !== ''
+    : false
+}
+
+function traceContextKey(event: KeeperTraceEvent): string {
+  if (
+    event.source !== 'cascade-hop'
+    && event.source !== 'bdi-snapshot'
+    && event.source !== 'decision-log'
+  ) return ''
+
+  return [
+    event.filePath ?? '',
+    event.line ?? '',
+    event.goalId ?? '',
+    event.taskId ?? '',
+    event.boardPostId ?? '',
+    event.commentId ?? '',
+    event.prId ?? '',
+    event.gitRef ?? '',
+    event.logId ?? '',
+    event.sessionId ?? '',
+    event.operationId ?? '',
+    event.workerRunId ?? '',
+  ].join('\u001f')
 }

--- a/dashboard/src/components/ide/overlay-keeper-trace.test.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.test.ts
@@ -137,6 +137,44 @@ describe('bucketTraceEvents — RFC-0028 §5 grouping', () => {
     expect(lineBucket?.events.map(e => e.source).sort()).toEqual(['activity-event', 'anchored-thread'])
   })
 
+  it('record traces with optional file context enter file-line buckets', () => {
+    pushTrace({
+      id: 'bdi-context',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'bdi-snapshot',
+      intention: 'verify route',
+      filePath: 'runtime.ts',
+      line: 12,
+    })
+    pushTrace({
+      id: 'decision-context',
+      tsMs: 1100,
+      keeperName: 'scholar',
+      source: 'decision-log',
+      decisionId: 'decision:scholar:1:tool',
+      semanticOutcome: 'success',
+      filePath: 'runtime.ts',
+      line: 12,
+    })
+    pushTrace({
+      id: 'cascade-context',
+      tsMs: 1200,
+      keeperName: 'mainline',
+      source: 'cascade-hop',
+      hopId: 'mainline-7',
+      provider: 'weighted_score',
+      filePath: 'router.ts',
+      line: 44,
+    })
+
+    const buckets = bucketTraceEvents(keeperTraceState.value.events)
+    const runtimeBucket = buckets.find(b => b.filePath === 'runtime.ts' && b.line === 12)
+    expect(runtimeBucket?.events.map(e => e.source).sort()).toEqual(['bdi-snapshot', 'decision-log'])
+    const cascadeBucket = buckets.find(b => b.filePath === 'router.ts' && b.line === 44)
+    expect(cascadeBucket?.events.map(e => e.source)).toEqual(['cascade-hop'])
+  })
+
   it('sorts events newest-first within each bucket', () => {
     pushAnchored('a', 'scholar', 12, 1000)
     pushAnchored('b', 'scholar', 12, 3000)
@@ -369,6 +407,73 @@ describe('OverlayKeeperTrace — bucket render (RFC-0028 §5)', () => {
 
     fireEvent.click(links[7]!)
     expect(window.location.hash).toBe('#monitoring?section=agents&view=keepers&keeper=scholar')
+  })
+
+  it('renders operational route links for contextual decision traces', () => {
+    pushTrace({
+      id: 'decision-context',
+      tsMs: 2000,
+      keeperName: 'scholar',
+      source: 'decision-log',
+      decisionId: 'decision:scholar:2000:tool_use',
+      semanticOutcome: 'error_retryable',
+      filePath: 'runtime.ts',
+      line: 19,
+      goalId: 'goal-decision',
+      taskId: 'task-decision',
+      boardPostId: 'post-decision',
+      commentId: 'comment-decision',
+      prId: '15035',
+      gitRef: 'refs/heads/decision-route',
+      logId: 'decision-turn-19',
+      sessionId: 'sess-decision',
+      operationId: 'op-decision',
+      workerRunId: 'worker-decision',
+    })
+
+    const container = createContainer()
+    render(html`<${OverlayKeeperTrace} active=${true} />`, container)
+
+    const bucket = container.querySelector('[role="group"][data-keeper="scholar"][data-line="19"]')
+    expect(bucket?.getAttribute('data-file')).toBe('runtime.ts')
+    const links = [...container.querySelectorAll<HTMLButtonElement>('.ide-trace-route-link')]
+    expect(links.map(link => link.textContent)).toEqual([
+      'Code',
+      'Goal',
+      'Task',
+      'Board',
+      'Comment',
+      'PR',
+      'Git',
+      'Log',
+      'Telemetry',
+      'Keeper',
+    ])
+
+    const chip = container.querySelector<HTMLButtonElement>('.ide-trace-chip[data-event-id="decision-context"]')
+    expect(chip).not.toBeNull()
+    fireEvent.click(chip!)
+    expect(ideReplayUntilMs.value).toBe(2000)
+    expect(ideContextFocus.value).toMatchObject({
+      file_path: 'runtime.ts',
+      line: 19,
+      surface: 'Decision',
+      label: 'error_retryable',
+      source_id: 'trace:decision-context',
+      keeper_id: 'scholar',
+    })
+    expect(ideContextFocus.value?.route_links?.map(link => link.label)).toEqual([
+      'Code',
+      'Goal',
+      'Task',
+      'Board',
+      'Comment',
+      'PR',
+      'Git',
+      'Log',
+      'Telemetry',
+      'Keeper',
+    ])
   })
 })
 

--- a/dashboard/src/components/ide/overlay-keeper-trace.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.ts
@@ -106,12 +106,18 @@ export function bucketTraceEvents(
 function lineOf(event: KeeperTraceEvent): number | null {
   if (event.source === 'anchored-thread') return event.line
   if (event.source === 'activity-event') return event.line
+  if (event.source === 'bdi-snapshot') return event.line ?? null
+  if (event.source === 'decision-log') return event.line ?? null
+  if (event.source === 'cascade-hop') return event.line ?? null
   return null
 }
 
 function filePathOf(event: KeeperTraceEvent): string | null {
   if (event.source === 'anchored-thread') return event.filePath ?? null
   if (event.source === 'activity-event') return event.filePath
+  if (event.source === 'bdi-snapshot') return event.filePath ?? null
+  if (event.source === 'decision-log') return event.filePath ?? null
+  if (event.source === 'cascade-hop') return event.filePath ?? null
   return null
 }
 
@@ -403,31 +409,68 @@ function traceRouteContext(event: KeeperTraceEvent): IdeContextRouteContext {
 
   if (event.source === 'bdi-snapshot') {
     return {
+      filePath: event.filePath,
+      line: event.line,
       surface: 'BDI',
       label: event.intention ?? 'BDI snapshot',
       sourceId: `trace:${event.id}`,
+      goalId: event.goalId,
+      taskId: event.taskId,
+      boardPostId: event.boardPostId,
+      commentId: event.commentId,
+      prId: event.prId,
+      gitRef: event.gitRef,
+      logId: event.logId,
+      sessionId: event.sessionId,
+      operationId: event.operationId,
+      workerRunId: event.workerRunId,
       keeperId: event.keeperName,
-      telemetryQuery: event.id,
+      telemetryQuery: event.logId ?? event.id,
       telemetry: true,
     }
   }
 
   if (event.source === 'decision-log') {
     return {
+      filePath: event.filePath,
+      line: event.line,
       surface: 'Decision',
       label: event.semanticOutcome ?? '(unknown outcome)',
       sourceId: `trace:${event.id}`,
+      goalId: event.goalId,
+      taskId: event.taskId,
+      boardPostId: event.boardPostId,
+      commentId: event.commentId,
+      prId: event.prId,
+      gitRef: event.gitRef,
+      logId: event.logId,
+      sessionId: event.sessionId,
+      operationId: event.operationId,
+      workerRunId: event.workerRunId,
       keeperId: event.keeperName,
-      telemetryQuery: event.decisionId,
+      telemetryQuery: event.logId ?? event.decisionId,
       telemetry: true,
     }
   }
 
   return {
+    filePath: event.filePath,
+    line: event.line,
     surface: 'Cascade',
     label: event.provider,
     sourceId: `trace:${event.id}`,
-    telemetryQuery: event.hopId,
+    goalId: event.goalId,
+    taskId: event.taskId,
+    boardPostId: event.boardPostId,
+    commentId: event.commentId,
+    prId: event.prId,
+    gitRef: event.gitRef,
+    logId: event.logId,
+    sessionId: event.sessionId,
+    operationId: event.operationId,
+    workerRunId: event.workerRunId,
+    keeperId: event.keeperName,
+    telemetryQuery: event.logId ?? event.hopId,
     telemetry: true,
   }
 }


### PR DESCRIPTION
## Summary
- Allow BDI snapshot, decision-log, and cascade-hop trace producers to carry optional IDE route context when the runtime has file/line and operational refs.
- Reuse the existing keeper-trace overlay route-link/focus plumbing so contextual records can appear in file-line buckets and link to Code, Goal, Task, Board, Comment, PR, Git, Log, Telemetry, and Keeper surfaces.
- Preserve existing keeper-level no-line behavior when record context is absent.

## Verification
- pnpm vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/keeper-trace-store.test.ts src/components/ide/bdi-snapshot-trace-bridge.test.ts src/components/ide/cascade-hop-trace-bridge.test.ts src/components/ide/decision-log-trace-bridge.test.ts src/components/ide/overlay-keeper-trace.test.ts
- pnpm typecheck
- pnpm lint (passes with existing virtual-list.ts unused eslint-disable warning)
- git diff --check