### PR TITLE
fix(dashboard): expose cascade observability provenance

### DIFF
--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -941,6 +941,36 @@ let client_capacity_entry_to_json ((url, info) : string * Cascade_throttle.capac
     ]
 ;;
 
+let cascade_query_json fields = `Assoc fields
+
+let optional_string_field key = function
+  | None -> key, `Null
+  | Some value -> key, `String value
+;;
+
+let optional_float_field key = function
+  | None -> key, `Null
+  | Some value -> key, `Float value
+;;
+
+let retention_json ?durable_store ?ring_capacity ~scope ~producer ~store_kind
+    ~cache_policy () =
+  let optional_fields =
+    List.filter_map
+      (fun x -> x)
+      [ Option.map (fun path -> "durable_store", `String path) durable_store
+      ; Option.map (fun capacity -> "ring_capacity", `Int capacity) ring_capacity
+      ]
+  in
+  `Assoc
+    ([ "scope", `String scope
+     ; "producer", `String producer
+     ; "store_kind", `String store_kind
+     ; "cache_policy", `String cache_policy
+     ]
+     @ optional_fields)
+;;
+
 let client_capacity_json () =
   let entries = Cascade_client_capacity.snapshot () in
   (* Stable ordering by (kind, key) so the dashboard table doesn't
@@ -956,8 +986,18 @@ let client_capacity_json () =
          | n -> n)
       entries
   in
+  let generated_at = now_iso () in
   `Assoc
-    [ "updated_at", `String (now_iso ())
+    [ "updated_at", `String generated_at
+    ; "generated_at_iso", `String generated_at
+    ; "dashboard_surface", `String "/api/v1/cascade/client_capacity"
+    ; "source", `String "cascade_client_capacity_registry"
+    ; ( "retention"
+      , retention_json
+          ~scope:"cascade_client_capacity"
+          ~producer:"Cascade_client_capacity.register"
+          ~store_kind:"process_registry"
+          ~cache_policy:"uncached; reads the live process-local registry" () )
     ; "entries", `List (List.map client_capacity_entry_to_json sorted)
     ]
 ;;
@@ -981,8 +1021,26 @@ let history_event_to_json (ev : Cascade_client_capacity_history.event) : Yojson.
 
 let client_capacity_history_json ?limit ?kind ?since_ts () =
   let events = Cascade_client_capacity_history.snapshot ?limit ?kind ?since_ts () in
+  let generated_at = now_iso () in
   `Assoc
-    [ "updated_at", `String (now_iso ())
+    [ "updated_at", `String generated_at
+    ; "generated_at_iso", `String generated_at
+    ; "dashboard_surface", `String "/api/v1/cascade/client_capacity/history"
+    ; "source", `String "cascade_client_capacity_history_ring"
+    ; ( "retention"
+      , retention_json
+          ~scope:"cascade_client_capacity_history"
+          ~producer:"Cascade_client_capacity_history.record"
+          ~store_kind:"process_ring_buffer"
+          ~ring_capacity:(Cascade_client_capacity_history.capacity ())
+          ~cache_policy:"uncached; reads the newest entries from the process ring buffer"
+          () )
+    ; ( "query"
+      , cascade_query_json
+          [ "limit", (match limit with None -> `Null | Some n -> `Int n)
+          ; optional_string_field "kind" kind
+          ; optional_float_field "since_ts" since_ts
+          ] )
     ; "total_events", `Int (List.length events)
     ; "events", `List (List.map history_event_to_json events)
     ]
@@ -1015,8 +1073,25 @@ let strategy_trace_event_to_json (ev : Cascade_strategy_trace.event) : Yojson.Sa
 
 let strategy_trace_json ?limit ?cascade () =
   let events = Cascade_strategy_trace.snapshot ?limit ?cascade () in
+  let generated_at = now_iso () in
   `Assoc
-    [ "updated_at", `String (now_iso ())
+    [ "updated_at", `String generated_at
+    ; "generated_at_iso", `String generated_at
+    ; "dashboard_surface", `String "/api/v1/cascade/strategy_trace"
+    ; "source", `String "cascade_strategy_trace_ring"
+    ; ( "retention"
+      , retention_json
+          ~scope:"cascade_strategy_trace"
+          ~producer:"Cascade_strategy_trace.record"
+          ~store_kind:"process_ring_buffer"
+          ~ring_capacity:(Cascade_strategy_trace.capacity ())
+          ~cache_policy:"uncached; reads the newest entries from the process ring buffer"
+          () )
+    ; ( "query"
+      , cascade_query_json
+          [ "limit", (match limit with None -> `Null | Some n -> `Int n)
+          ; optional_string_field "cascade" cascade
+          ] )
     ; "total_events", `Int (List.length events)
     ; "events", `List (List.map strategy_trace_event_to_json events)
     ]
@@ -1208,9 +1283,11 @@ let audit_run_cascade_matches cascade_filter run =
      | None -> false)
 ;;
 
-let audit_runs_json ~base_path ?limit ?cascade () =
+let audit_runs_json ?(dashboard_surface = "/api/v1/cascade/audit_runs") ~base_path ?limit
+    ?cascade () =
   let limit = Option.value ~default:100 limit |> max 1 |> min 1024 in
   let read_limit = if Option.is_some cascade then min 4096 (limit * 4) else limit in
+  let audit_store_dir = audit_store_dir ~base_path in
   let runs =
     Dated_jsonl.read_recent (cascade_audit_store ~base_path) read_limit
     |> List.rev
@@ -1223,8 +1300,25 @@ let audit_runs_json ~base_path ?limit ?cascade () =
     | x :: xs -> x :: take (n - 1) xs
   in
   let runs = take limit runs in
+  let generated_at = now_iso () in
   `Assoc
-    [ "updated_at", `String (now_iso ())
+    [ "updated_at", `String generated_at
+    ; "generated_at_iso", `String generated_at
+    ; "dashboard_surface", `String dashboard_surface
+    ; "source", `String "cascade_audit_jsonl"
+    ; ( "retention"
+      , retention_json
+          ~scope:"cascade_audit_runs"
+          ~producer:"Cascade_legacy_runner.cascade_observation_to_json"
+          ~store_kind:"dated_jsonl"
+          ~durable_store:audit_store_dir
+          ~cache_policy:"uncached; reads recent persisted JSONL rows newest first"
+          () )
+    ; ( "query"
+      , cascade_query_json
+          [ "limit", `Int limit
+          ; optional_string_field "cascade" cascade
+          ] )
     ; "total_runs", `Int (List.length runs)
     ; "audit_runs", `List runs
     ]

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -304,6 +304,10 @@ val declared_provider_schemes_of_config : ?config_path:string -> unit -> string 
     {[
       {
         "updated_at": "2026-04-16T22:30:00Z",
+        "generated_at_iso": "2026-04-16T22:30:00Z",
+        "dashboard_surface": "/api/v1/cascade/client_capacity",
+        "source": "cascade_client_capacity_registry",
+        "retention": { ... },
         "entries": [
           { "key": "cli:claude_code",
             "kind": "cli",
@@ -341,6 +345,11 @@ val client_capacity_json : unit -> Yojson.Safe.t
     {[
       {
         "updated_at": "2026-04-16T22:31:00Z",
+        "generated_at_iso": "2026-04-16T22:31:00Z",
+        "dashboard_surface": "/api/v1/cascade/client_capacity/history",
+        "source": "cascade_client_capacity_history_ring",
+        "retention": { ... },
+        "query": { "limit": 100, "kind": "cli", "since_ts": null },
         "total_events": 3,
         "events": [
           { "ts": 1713280000.5,
@@ -381,6 +390,11 @@ val client_capacity_history_json
     {[
       {
         "updated_at": "ISO-8601",
+        "generated_at_iso": "ISO-8601",
+        "dashboard_surface": "/api/v1/cascade/strategy_trace",
+        "source": "cascade_strategy_trace_ring",
+        "retention": { ... },
+        "query": { "limit": 100, "cascade": null },
         "total_events": <int>,
         "events": [
           { "ts": <unix seconds>,
@@ -411,6 +425,11 @@ val strategy_trace_json : ?limit:int -> ?cascade:string -> unit -> Yojson.Safe.t
     {[
       {
         "updated_at": "ISO-8601",
+        "generated_at_iso": "ISO-8601",
+        "dashboard_surface": "/api/v1/cascade/audit_runs",
+        "source": "cascade_audit_jsonl",
+        "retention": { ... },
+        "query": { "limit": 100, "cascade": null },
         "total_runs": <int>,
         "audit_runs": [
           { "id": "cascade-audit-...",
@@ -441,7 +460,8 @@ val strategy_trace_json : ?limit:int -> ?cascade:string -> unit -> Yojson.Safe.t
     @param cascade  filter by projected [cascade]; omit to include every
                     cascade. *)
 val audit_runs_json
-  :  base_path:string
+  :  ?dashboard_surface:string
+  -> base_path:string
   -> ?limit:int
   -> ?cascade:string
   -> unit

--- a/lib/server/server_routes_http_routes_cascade.ml
+++ b/lib/server/server_routes_http_routes_cascade.ml
@@ -136,7 +136,8 @@ let add_routes router =
          let cascade = query_param req "cascade" in
          let base_path = state.Mcp_server.room_config.base_path in
          let json =
-           Dashboard_cascade.audit_runs_json ~base_path ~limit ?cascade ()
+           Dashboard_cascade.audit_runs_json
+             ~dashboard_surface:"/api/v1/cascade/inspector" ~base_path ~limit ?cascade ()
          in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -191,9 +191,9 @@ check_json "oas telemetry summary exposes provenance" "$BASE/api/v1/dashboard/oa
 check_http "cascade health 200" "$BASE/api/v1/cascade/health" "200"
 check_json "cascade health exposes providers" "$BASE/api/v1/cascade/health" "'providers' in d" '^True$'
 check_http "cascade strategy trace 200" "$BASE/api/v1/cascade/strategy_trace?limit=1" "200"
-check_json "cascade strategy trace exposes events" "$BASE/api/v1/cascade/strategy_trace?limit=1" "'events' in d" '^True$'
+check_json "cascade strategy trace exposes provenance" "$BASE/api/v1/cascade/strategy_trace?limit=1" "'events' in d and d.get('dashboard_surface') == '/api/v1/cascade/strategy_trace' and d.get('source') == 'cascade_strategy_trace_ring' and d.get('retention', {}).get('scope') == 'cascade_strategy_trace' and d.get('query', {}).get('limit') == 1" '^True$'
 check_http "cascade audit runs 200" "$BASE/api/v1/cascade/audit_runs?limit=1" "200"
-check_json "cascade audit runs exposes runs" "$BASE/api/v1/cascade/audit_runs?limit=1" "'audit_runs' in d and 'total_runs' in d" '^True$'
+check_json "cascade audit runs exposes provenance" "$BASE/api/v1/cascade/audit_runs?limit=1" "'audit_runs' in d and 'total_runs' in d and d.get('dashboard_surface') == '/api/v1/cascade/audit_runs' and d.get('source') == 'cascade_audit_jsonl' and d.get('retention', {}).get('scope') == 'cascade_audit_runs' and d.get('query', {}).get('limit') == 1" '^True$'
 check_http "keeper cascades 200" "$BASE/api/v1/keeper/cascades" "200"
 check_json "keeper cascades exposes profiles" "$BASE/api/v1/keeper/cascades" "'profiles' in d and 'invalid_profiles' in d" '^True$'
 check_http "runtime providers 200" "$BASE/api/v1/providers" "200"
@@ -203,9 +203,9 @@ check_json "cascade config exposes profiles" "$BASE/api/v1/cascade/config" "'val
 check_http "cascade raw config 200" "$BASE/api/v1/cascade/config/raw" "200"
 check_json "cascade raw config exposes source" "$BASE/api/v1/cascade/config/raw" "'source_text' in d and 'source_editable' in d" '^True$'
 check_http "cascade client capacity 200" "$BASE/api/v1/cascade/client_capacity" "200"
-check_json "cascade client capacity exposes entries" "$BASE/api/v1/cascade/client_capacity" "'entries' in d" '^True$'
+check_json "cascade client capacity exposes provenance" "$BASE/api/v1/cascade/client_capacity" "'entries' in d and d.get('dashboard_surface') == '/api/v1/cascade/client_capacity' and d.get('source') == 'cascade_client_capacity_registry' and d.get('retention', {}).get('scope') == 'cascade_client_capacity'" '^True$'
 check_http "cascade capacity history 200" "$BASE/api/v1/cascade/client_capacity/history?limit=1" "200"
-check_json "cascade capacity history exposes events" "$BASE/api/v1/cascade/client_capacity/history?limit=1" "'events' in d" '^True$'
+check_json "cascade capacity history exposes provenance" "$BASE/api/v1/cascade/client_capacity/history?limit=1" "'events' in d and d.get('dashboard_surface') == '/api/v1/cascade/client_capacity/history' and d.get('source') == 'cascade_client_capacity_history_ring' and d.get('retention', {}).get('scope') == 'cascade_client_capacity_history' and d.get('query', {}).get('limit') == 1" '^True$'
 check_http "cascade slo 200" "$BASE/api/v1/cascade/slo" "200"
 check_json "cascade slo exposes status" "$BASE/api/v1/cascade/slo" "'status' in d and 'current' in d" '^True$'
 check_http "model metrics 200" "$BASE/api/v1/models/metrics?window=30&bucket_min=5" "200"

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -17,6 +17,8 @@ module ST = Masc_mcp.Cascade_strategy_trace
 module Kcp = Masc_mcp.Keeper_cascade_profile
 module T = Masc_mcp.Cascade_throttle
 module Cascade_state = Masc_mcp.Cascade_state
+module DC = Masc_mcp.Dashboard_cascade
+module Json = Yojson.Safe.Util
 
 (* ── Test fixture ────────────────────────────────────────────── *)
 
@@ -42,6 +44,42 @@ let mk_capacity_info ~total ~active = {
   process_queue_length = 0;
   source = Llm_provider.Provider_throttle.Fallback;
 }
+
+let json_string key json =
+  match Json.member key json with
+  | `String value -> value
+  | value ->
+    failf "expected JSON string field %s, got %s"
+      key (Yojson.Safe.to_string value)
+;;
+
+let json_int key json =
+  match Json.member key json with
+  | `Int value -> value
+  | value ->
+    failf "expected JSON int field %s, got %s" key (Yojson.Safe.to_string value)
+;;
+
+let json_float key json =
+  match Json.member key json with
+  | `Float value -> value
+  | `Int value -> float_of_int value
+  | value ->
+    failf "expected JSON float field %s, got %s"
+      key (Yojson.Safe.to_string value)
+;;
+
+let json_object key json =
+  match Json.member key json with
+  | `Assoc _ as value -> value
+  | value ->
+    failf "expected JSON object field %s, got %s"
+      key (Yojson.Safe.to_string value)
+;;
+
+let check_nonempty_string_field key json =
+  check bool (key ^ " present") true (String.length (json_string key json) > 0)
+;;
 
 (* Capacity stub: caller supplies a closure mapping URL → capacity_info. *)
 let stub_capacity table url =
@@ -326,6 +364,21 @@ let test_snapshot_reflects_active_acquires () =
       check int "active counted" 1 info.process_active;
       check int "available decremented" 1 info.process_available
 
+let test_client_capacity_json_exposes_provenance () =
+  C.unregister_all ();
+  C.register ~url:"cli:codex_cli" ~max_concurrent:2;
+  let json = DC.client_capacity_json () in
+  check string "dashboard surface"
+    "/api/v1/cascade/client_capacity"
+    (json_string "dashboard_surface" json);
+  check string "source" "cascade_client_capacity_registry"
+    (json_string "source" json);
+  check_nonempty_string_field "generated_at_iso" json;
+  let retention = json_object "retention" json in
+  check string "retention scope" "cascade_client_capacity"
+    (json_string "scope" retention);
+  check string "store kind" "process_registry" (json_string "store_kind" retention)
+
 (* ── Phase B: Priority_tier (S5) ───────────────────────────── *)
 
 let test_priority_tier_picks_first_tier () =
@@ -563,6 +616,28 @@ let test_history_prometheus_counter_increments () =
   check bool "http_probe/rejected_full counter advanced by >= 1"
     true (http_probe_rejected >= 1.0)
 
+let test_history_json_exposes_provenance () =
+  CH.clear ();
+  CH.record { ts = 10.0; key = "cli:codex_cli";
+              kind = Acquired; active_after = 1 };
+  let json = DC.client_capacity_history_json ~limit:1 ~kind:"cli" ~since_ts:1.0 () in
+  check string "dashboard surface"
+    "/api/v1/cascade/client_capacity/history"
+    (json_string "dashboard_surface" json);
+  check string "source" "cascade_client_capacity_history_ring"
+    (json_string "source" json);
+  check_nonempty_string_field "generated_at_iso" json;
+  let retention = json_object "retention" json in
+  check string "retention scope" "cascade_client_capacity_history"
+    (json_string "scope" retention);
+  check string "store kind" "process_ring_buffer"
+    (json_string "store_kind" retention);
+  check int "ring capacity" (CH.capacity ()) (json_int "ring_capacity" retention);
+  let query = json_object "query" json in
+  check int "query limit" 1 (json_int "limit" query);
+  check string "query kind" "cli" (json_string "kind" query);
+  check (float 0.0) "query since_ts" 1.0 (json_float "since_ts" query)
+
 (* ── Strategy decision trace (LT-5) ─────────────────── *)
 
 let mk_trace_event ?(ts = 0.0) ?(cascade_name = "primary")
@@ -707,6 +782,104 @@ let test_trace_prometheus_counter_increments () =
   check bool "nick0cave/priority_tier/filtered_empty >= 1"
     true (filtered >= 1.0)
 
+let test_strategy_trace_json_exposes_provenance () =
+  ST.clear ();
+  ST.record
+    (mk_trace_event ~cascade_name:"primary" ~strategy:"failover"
+       ~kind:ST.Ordered ());
+  let json = DC.strategy_trace_json ~limit:1 ~cascade:"primary" () in
+  check string "dashboard surface" "/api/v1/cascade/strategy_trace"
+    (json_string "dashboard_surface" json);
+  check string "source" "cascade_strategy_trace_ring" (json_string "source" json);
+  check_nonempty_string_field "generated_at_iso" json;
+  let retention = json_object "retention" json in
+  check string "retention scope" "cascade_strategy_trace"
+    (json_string "scope" retention);
+  check string "store kind" "process_ring_buffer"
+    (json_string "store_kind" retention);
+  check int "ring capacity" (ST.capacity ()) (json_int "ring_capacity" retention);
+  let query = json_object "query" json in
+  check int "query limit" 1 (json_int "limit" query);
+  check string "query cascade" "primary" (json_string "cascade" query)
+
+let test_audit_runs_json_exposes_provenance () =
+  let base_path =
+    Filename.concat (Filename.get_temp_dir_name ()) "masc-cascade-provenance-test"
+  in
+  let json =
+    DC.audit_runs_json ~base_path ~limit:2 ~cascade:"keeper_unified" ()
+  in
+  check string "dashboard surface" "/api/v1/cascade/audit_runs"
+    (json_string "dashboard_surface" json);
+  check string "source" "cascade_audit_jsonl" (json_string "source" json);
+  check_nonempty_string_field "generated_at_iso" json;
+  let retention = json_object "retention" json in
+  check string "retention scope" "cascade_audit_runs"
+    (json_string "scope" retention);
+  check string "store kind" "dated_jsonl" (json_string "store_kind" retention);
+  check string "durable store"
+    (Filename.concat (Filename.concat base_path ".masc") "cascade_audit")
+    (json_string "durable_store" retention);
+  let query = json_object "query" json in
+  check int "query limit" 2 (json_int "limit" query);
+  check string "query cascade" "keeper_unified" (json_string "cascade" query)
+
+(* ── server_error_score_for_provider (#12797) ─────────────────── *)
+
+let test_se_score_unknown_provider_full () =
+  let h = H.create () in
+  let s = S.server_error_score_for_provider h ~provider_key:"unseen" in
+  check (float 0.001) "unknown → 1.0" 1.0 s
+
+let test_se_score_no_failures_full () =
+  let h = H.create () in
+  H.record_success h ~provider_key:"p" ();
+  H.record_success h ~provider_key:"p" ();
+  let s = S.server_error_score_for_provider h ~provider_key:"p" in
+  check (float 0.001) "no failures → 1.0" 1.0 s
+
+let test_se_score_one_failure_decays () =
+  (* Default decay base 0.6: 1 recent failure → 0.6 *)
+  let h = H.create () in
+  H.record_failure h ~provider_key:"p" ();
+  let s = S.server_error_score_for_provider h ~provider_key:"p" in
+  (* Allow for env override: just verify score < 1.0 and > 0.0 *)
+  check bool "1 failure → score < 1.0" true (s < 1.0);
+  check bool "1 failure → score > 0.0" true (s > 0.0)
+
+let test_se_score_many_failures_skips () =
+  (* Default skip_after is 4: 4 failures should zero the score *)
+  let h = H.create () in
+  for _ = 1 to 4 do
+    H.record_failure h ~provider_key:"p" ()
+  done;
+  let s = S.server_error_score_for_provider h ~provider_key:"p" in
+  check (float 0.001) "4 failures → hard skip (0.0)" 0.0 s
+
+let test_se_score_only_rate_limits_no_penalty () =
+  (* Rate-limit events should NOT increase server-error score *)
+  let h = H.create () in
+  H.record_soft_rate_limited h ~provider_key:"p" ();
+  H.record_soft_rate_limited h ~provider_key:"p" ();
+  let s = S.server_error_score_for_provider h ~provider_key:"p" in
+  check (float 0.001) "429s don't affect se score" 1.0 s
+
+let test_weighted_shuffle_server_error_provider_deprioritised () =
+  (* A provider with 4 server errors should be skipped when there is a
+     clean peer.  All other conditions are equal (weight, no 429s). *)
+  let h = H.create () in
+  for _ = 1 to 4 do
+    H.record_failure h ~provider_key:"errored" ()
+  done;
+  let cands = [mk_cand ~w:100 "errored"; mk_cand ~w:100 "clean"] in
+  let strat = mk_t S.Weighted_random in
+  let ctx = mk_ctx ~health:h ~rand:(fun _ -> 0) () in
+  let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
+  match ordered with
+  | [] -> fail "expected at least clean provider"
+  | hd :: _ ->
+      check string "clean provider heads the list" "clean" hd.name
+
 let () =
   run "cascade_strategy" [
     "failover", [
@@ -751,6 +924,8 @@ let () =
         test_snapshot_returns_all_entries;
       test_case "snapshot reflects active acquires" `Quick
         test_snapshot_reflects_active_acquires;
+      test_case "dashboard JSON exposes provenance" `Quick
+        test_client_capacity_json_exposes_provenance;
     ];
     "priority_tier", [
       test_case "cycle 0 picks first tier" `Quick
@@ -779,6 +954,8 @@ let () =
         test_history_try_acquire_records_events;
       test_case "record bumps Prometheus counter with label" `Quick
         test_history_prometheus_counter_increments;
+      test_case "dashboard JSON exposes provenance" `Quick
+        test_history_json_exposes_provenance;
     ];
     "strategy_trace", [
       test_case "record + snapshot newest-first" `Quick
@@ -793,5 +970,9 @@ let () =
         test_trace_kind_labels;
       test_case "record bumps Prometheus counter with labels" `Quick
         test_trace_prometheus_counter_increments;
+      test_case "dashboard JSON exposes provenance" `Quick
+        test_strategy_trace_json_exposes_provenance;
+      test_case "audit runs JSON exposes provenance" `Quick
+        test_audit_runs_json_exposes_provenance;
     ];
   ]


### PR DESCRIPTION
## Summary
- Add provenance, retention, generated_at, and query envelopes to cascade strategy trace, audit runs/inspector, client capacity, and capacity history dashboard APIs.
- Preserve inspector-specific dashboard_surface while keeping audit_runs on its canonical surface.
- Strengthen dashboard smoke checks so cascade replay/log endpoints cannot regress to shallow events-only payloads.

## Verification
- ocamlformat --check lib/dashboard_cascade.ml lib/dashboard_cascade.mli lib/server/server_routes_http_routes_cascade.ml test/test_cascade_strategy.ml
- git diff --check
- env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-build-cascade-observability-provenance DUNE_JOBS=1 scripts/dune-local.sh build --display=short test/test_cascade_strategy.exe bin/main_eio.exe
- /private/tmp/masc-mcp-build-cascade-observability-provenance/default/test/test_cascade_strategy.exe: 75 tests passed
- live /health on 127.0.0.1:8935 reports commit bc160b0d6d from this worktree
- scripts/verify-dashboard.sh http://127.0.0.1:8935: ALL 176 TESTS PASSED