### PR TITLE
feat(ide): expose activity telemetry scope

### DIFF
--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -150,7 +150,19 @@ describe('IdeActivityPanel', () => {
 
     const surfaces = [...container.querySelectorAll('.ide-run-progress-surfaces > span')]
       .map(node => node.textContent)
-    expect(surfaces).toEqual(['Goal1', 'Task1', 'Board1', 'Comment1', 'PR1', 'Git1', 'Log1', 'Telemetry1'])
+    expect(surfaces).toEqual([
+      'Goal1',
+      'Task1',
+      'Board1',
+      'Comment1',
+      'PR1',
+      'Git1',
+      'Log1',
+      'Session1',
+      'Operation1',
+      'Run1',
+      'Telemetry1',
+    ])
 
     const surfaceLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-run-progress-surface-link')]
     expect(surfaceLinks.map(link => link.textContent)).toEqual([
@@ -161,10 +173,15 @@ describe('IdeActivityPanel', () => {
       'PR1',
       'Git1',
       'Log1',
+      'Session1',
+      'Operation1',
+      'Run1',
       'Telemetry1',
     ])
     fireEvent.click(surfaceLinks.find(link => link.textContent === 'PR1')!)
     expect(window.location.hash).toBe('#workspace?section=repositories&view=graph&pr=15000')
+    fireEvent.click(surfaceLinks.find(link => link.textContent === 'Session1')!)
+    expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&session_id=sess-runtime&operation_id=op-runtime&worker_run_id=wr-runtime&q=turn-1')
     fireEvent.click(surfaceLinks.find(link => link.textContent === 'Telemetry1')!)
     expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&session_id=sess-runtime&operation_id=op-runtime&worker_run_id=wr-runtime&q=turn-1')
 
@@ -542,7 +559,19 @@ describe('IdeActivityPanel', () => {
     await waitFor(() => {
       const surfaces = [...container.querySelectorAll('.ide-run-progress-surfaces > span')]
         .map(node => node.textContent)
-      expect(surfaces).toEqual(['Goal0', 'Task0', 'Board0', 'Comment0', 'PR0', 'Git0', 'Log1', 'Telemetry1'])
+      expect(surfaces).toEqual([
+        'Goal0',
+        'Task0',
+        'Board0',
+        'Comment0',
+        'PR0',
+        'Git0',
+        'Log1',
+        'Session0',
+        'Operation0',
+        'Run0',
+        'Telemetry1',
+      ])
     })
   })
 
@@ -758,6 +787,9 @@ describe('IdeActivityPanel', () => {
       ['PR', 1],
       ['Git', 1],
       ['Log', 1],
+      ['Session', 0],
+      ['Operation', 0],
+      ['Run', 0],
       ['Telemetry', 3],
     ])
     expect(summary.surfaceCounts.find(surface => surface.label === 'PR')?.routeLink).toMatchObject({
@@ -814,6 +846,8 @@ describe('IdeActivityPanel', () => {
           pr_id: '15000',
           log_id: 'turn-latest',
           session_id: 'sess-latest',
+          operation_id: 'op-latest',
+          worker_run_id: 'wr-latest',
         },
       },
     ], 'lib/runtime.ml')
@@ -828,6 +862,19 @@ describe('IdeActivityPanel', () => {
         section: 'fleet-health',
         view: 'event-log',
         session_id: 'sess-latest',
+        operation_id: 'op-latest',
+        worker_run_id: 'wr-latest',
+        q: 'turn-latest',
+      },
+    })
+    expect(summary.surfaceCounts.find(surface => surface.label === 'Session')?.routeLink).toMatchObject({
+      label: 'Telemetry',
+      params: {
+        section: 'fleet-health',
+        view: 'event-log',
+        session_id: 'sess-latest',
+        operation_id: 'op-latest',
+        worker_run_id: 'wr-latest',
         q: 'turn-latest',
       },
     })

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -89,15 +89,24 @@ const INITIAL_REFRESH_STATE: ActivityRefreshState = {
   lastAttemptMs: null,
   failedCount: 0,
 }
-const PROGRESS_SURFACES = [
-  ['goal_id', 'Goal'],
-  ['task_id', 'Task'],
-  ['board_post_id', 'Board'],
-  ['comment_id', 'Comment'],
-  ['pr_id', 'PR'],
-  ['git_ref', 'Git'],
-  ['log_id', 'Log'],
-] as const
+interface ProgressSurfaceSpec {
+  readonly key: keyof RunActivityContext
+  readonly label: string
+  readonly routeLabel?: string
+}
+
+const PROGRESS_SURFACES: ReadonlyArray<ProgressSurfaceSpec> = [
+  { key: 'goal_id', label: 'Goal' },
+  { key: 'task_id', label: 'Task' },
+  { key: 'board_post_id', label: 'Board' },
+  { key: 'comment_id', label: 'Comment' },
+  { key: 'pr_id', label: 'PR' },
+  { key: 'git_ref', label: 'Git' },
+  { key: 'log_id', label: 'Log' },
+  { key: 'session_id', label: 'Session', routeLabel: 'Telemetry' },
+  { key: 'operation_id', label: 'Operation', routeLabel: 'Telemetry' },
+  { key: 'worker_run_id', label: 'Run', routeLabel: 'Telemetry' },
+]
 
 const DEFAULT_ROOM_ID = 'run-default'
 type MutableRunActivityContext = {
@@ -481,12 +490,12 @@ export function deriveIdeRunProgressSummary(
   const linkedCoveragePercent = events.length === 0
     ? 0
     : Math.round((linkedEvents / events.length) * 100)
-  const surfaceCounts: IdeRunProgressSurfaceCount[] = PROGRESS_SURFACES.map(([key, label]) => {
-    const matchingEvents = events.filter(event => event.context?.[key])
+  const surfaceCounts: IdeRunProgressSurfaceCount[] = PROGRESS_SURFACES.map(surface => {
+    const matchingEvents = events.filter(event => event.context?.[surface.key])
     return {
-      label,
+      label: surface.label,
       count: matchingEvents.length,
-      routeLink: latestSurfaceRouteLink(label, matchingEvents),
+      routeLink: latestSurfaceRouteLink(surface.routeLabel ?? surface.label, matchingEvents),
     }
   })
   surfaceCounts.push({


### PR DESCRIPTION
Summary:
- Split activity Run Progress telemetry into routeable Session, Operation, and Run scope chips.
- Keep Telemetry as the canonical destination while exposing scoped runtime record counts next to Goal/Task/Board/PR/Git/Log.
- Extend activity panel tests for scoped telemetry routes and zero-count rendering.

Verification:
- pnpm vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-activity-panel.test.ts
- pnpm typecheck
- pnpm lint (existing virtual-list.ts unused-disable warning only)
- git diff --check
- rg -n "#[0-9a-fA-F]{3,8}" dashboard/src/components/ide/ide-activity-panel.ts dashboard/src/components/ide/ide-activity-panel.test.ts (no matches)