### PR TITLE
feat(rfc-0084): PR-13 Keeper_disclosure_strategy typed sum (RFC-OAS-013 activation surface)

### DIFF
--- a/lib/keeper/keeper_disclosure_strategy.ml
+++ b/lib/keeper/keeper_disclosure_strategy.ml
@@ -1,0 +1,56 @@
+(* RFC-0084 §1.6, §3.5 — Typed keeper disclosure strategy.
+   See keeper_disclosure_strategy.mli for the contract. *)
+
+type t =
+  | Full
+  | Hybrid of
+      { full_names : string list
+      ; demote_on_error : bool
+      }
+  | Minimal_index
+
+let default = Full
+
+let to_string = function
+  | Full -> "full"
+  | Hybrid _ -> "hybrid"
+  | Minimal_index -> "minimal_index"
+;;
+
+let of_toml ~strategy ~full_names ~demote_on_error =
+  match strategy with
+  | "full" -> Ok Full
+  | "hybrid" ->
+    (match full_names with
+     | [] ->
+       Error
+         "RFC-0084 §3.5: [disclosure] strategy = \"hybrid\" requires non-empty \
+          full_names list (RFC-OAS-013 §2.1 v2 core_tool_names)."
+     | _ ->
+       (* RFC-OAS-013 §2.4: sort for prefix-cache stability. *)
+       let sorted = List.sort String.compare full_names in
+       Ok (Hybrid { full_names = sorted; demote_on_error }))
+  | "minimal_index" -> Ok Minimal_index
+  | other ->
+    Error
+      (Printf.sprintf
+         "RFC-0084 §3.5: unknown [disclosure] strategy %S \
+          (expected: full | hybrid | minimal_index)"
+         other)
+;;
+
+let is_full = function
+  | Full -> true
+  | Hybrid _ | Minimal_index -> false
+;;
+
+let pp fmt = function
+  | Full -> Format.fprintf fmt "Full"
+  | Hybrid { full_names; demote_on_error } ->
+    Format.fprintf
+      fmt
+      "Hybrid(full_names=[%s]; demote_on_error=%b)"
+      (String.concat "; " full_names)
+      demote_on_error
+  | Minimal_index -> Format.fprintf fmt "Minimal_index"
+;;

--- a/lib/keeper/keeper_disclosure_strategy.mli
+++ b/lib/keeper/keeper_disclosure_strategy.mli
@@ -1,0 +1,71 @@
+(** RFC-0084 §1.6 + §3.5 — Typed keeper disclosure strategy.
+
+    Activates the [Tool.disclosure_level] infrastructure that OAS PR
+    #1508 + #1511 wired into [lib/pipeline/stage_parse.ml:42-46] and
+    [lib/pipeline/pipeline_stage_prepare.ml:109-115] but which sits
+    dormant in masc-mcp (RFC-0084 §1.6: [worker_oas.ml] caller count
+    for `with_disclosure_level` / `with_disclosure_resolver` /
+    `imseonghan` = 0).
+
+    RFC-OAS-013 §2.1 v2 proposed a [meta.name = "imseonghan"]
+    hardcoded keeper-name gate. This PR rejects that pattern and
+    introduces a config-driven typed strategy so any keeper TOML
+    can opt-in to Hybrid disclosure without code-level keeper-name
+    hardcodes (CLAUDE.md anti-pattern #1 "Scattered hardcoded
+    default": 1 keeper name in code).
+
+    PR-13 introduces the typed surface only. Wiring into
+    [worker_oas.ml] + [keeper_meta.ml] TOML round-trip is scoped to
+    follow-up activation PR(s) per the
+    delegation-not-absorption pattern used in PR-6/8/9/10/11/12. *)
+
+(** Disclosure strategy variants. *)
+type t =
+  | Full
+      (** Pass every tool schema in full to the LLM.  Today's default;
+          maximum prefix-cache stability + maximum tokens consumed. *)
+  | Hybrid of
+      { full_names : string list
+            (** Tool names whose schemas are sent in full
+                (typically the keeper's [always_include] core
+                tools — RFC-OAS-013 §2.1 v2 [core_tool_names]). *)
+      ; demote_on_error : bool
+            (** When [true] and the previous turn contained any tool
+                error, demote the next turn to [Full] for one turn
+                (RFC-OAS-013 §2.3 [demote_on_error]).  Lets the LLM
+                see complete schemas after a parameter-shape error. *)
+      }
+      (** Hybrid: only [full_names] tools get full schemas; the rest
+          get minimal index (name + description only). *)
+  | Minimal_index
+      (** Every tool sent as name + description only.  Maximum
+          schema-token savings, highest tool-call error rate.
+          Reserved for advanced canary keepers; not the default. *)
+
+(** [default] is [Full] — the safest strategy that today's masc-mcp
+    keepers behave as.  PR-13 introduces the typed alternative;
+    follow-up activation PR(s) flip keepers to [Hybrid] one at a time. *)
+val default : t
+
+(** [to_string t] returns the canonical TOML label
+    (["full"] / ["hybrid"] / ["minimal_index"]). *)
+val to_string : t -> string
+
+(** [of_toml ~strategy ~full_names ~demote_on_error] constructs a [t]
+    from raw TOML fields.  Returns [Error msg] when [strategy] is
+    unknown or when [Hybrid] is requested without [full_names].
+    Used by [keeper_runtime_toml] (follow-up activation PR) when
+    parsing the [[disclosure]] section. *)
+val of_toml
+  :  strategy:string
+  -> full_names:string list
+  -> demote_on_error:bool
+  -> (t, string) result
+
+(** [is_full t = true] iff [t = Full].  Used by callers that need to
+    short-circuit telemetry/measurement when no disclosure narrowing
+    is in play. *)
+val is_full : t -> bool
+
+(** Pretty-print for diagnostic logging. *)
+val pp : Format.formatter -> t -> unit

--- a/test/dune
+++ b/test/dune
@@ -1483,3 +1483,15 @@
  (name test_host_config_resolution)
  (modules test_host_config_resolution)
  (libraries masc_test_deps))
+
+; RFC-0084 PR-13 — Keeper_disclosure_strategy typed sum invariants.
+; Pins 3-arm cardinality (Full | Hybrid | Minimal_index), default = Full,
+; of_toml strict parsing (hybrid requires non-empty full_names, unknown
+; rejected as Error), is_full semantics, and prefix-cache stability
+; (Hybrid.full_names sorted per RFC-OAS-013 §2.4). Requires
+; masc_test_deps because it accesses Masc_mcp.Keeper_disclosure_strategy.*
+; directly.
+(test
+ (name test_disclosure_strategy_config)
+ (modules test_disclosure_strategy_config)
+ (libraries masc_test_deps))

--- a/test/test_disclosure_strategy_config.ml
+++ b/test/test_disclosure_strategy_config.ml
@@ -1,0 +1,163 @@
+open Alcotest
+
+(** RFC-0084 PR-13 — Keeper_disclosure_strategy typed sum invariants.
+
+    PR-13 introduces the typed surface; follow-up activation PR(s)
+    wire it into worker_oas + keeper_runtime_toml.  This test pins:
+
+    - 3-arm cardinality (Full | Hybrid | Minimal_index)
+    - default = Full (safe today's behaviour)
+    - of_toml ["hybrid"] rejects empty [full_names]
+    - of_toml ["hybrid"] sorts [full_names] for prefix-cache stability
+      (RFC-OAS-013 §2.4)
+    - is_full returns true only for Full
+    - of_toml rejects unknown strategy labels (no permissive default
+      — CLAUDE.md anti-pattern #2 self-check)
+*)
+
+let test_default_is_full () =
+  let pp = Format.asprintf "%a" Masc_mcp.Keeper_disclosure_strategy.pp in
+  (check string)
+    "default = Full (RFC-0084 §3.5 safe baseline)"
+    "Full"
+    (pp Masc_mcp.Keeper_disclosure_strategy.default)
+;;
+
+let test_to_string_full () =
+  (check string)
+    "to_string Full = \"full\""
+    "full"
+    (Masc_mcp.Keeper_disclosure_strategy.to_string Masc_mcp.Keeper_disclosure_strategy.Full)
+;;
+
+let test_to_string_minimal_index () =
+  (check string)
+    "to_string Minimal_index = \"minimal_index\""
+    "minimal_index"
+    (Masc_mcp.Keeper_disclosure_strategy.to_string
+       Masc_mcp.Keeper_disclosure_strategy.Minimal_index)
+;;
+
+let test_to_string_hybrid () =
+  let h =
+    Masc_mcp.Keeper_disclosure_strategy.Hybrid
+      { full_names = [ "keeper_bash" ]; demote_on_error = true }
+  in
+  (check string) "to_string Hybrid _ = \"hybrid\"" "hybrid" (Masc_mcp.Keeper_disclosure_strategy.to_string h)
+;;
+
+let test_of_toml_full () =
+  match
+    Masc_mcp.Keeper_disclosure_strategy.of_toml
+      ~strategy:"full"
+      ~full_names:[]
+      ~demote_on_error:false
+  with
+  | Ok Masc_mcp.Keeper_disclosure_strategy.Full -> ()
+  | Ok other ->
+    failf
+      "of_toml \"full\" should return Full, got %s"
+      (Masc_mcp.Keeper_disclosure_strategy.to_string other)
+  | Error msg -> failf "of_toml \"full\" failed: %s" msg
+;;
+
+let test_of_toml_hybrid_sorted () =
+  match
+    Masc_mcp.Keeper_disclosure_strategy.of_toml
+      ~strategy:"hybrid"
+      ~full_names:[ "keeper_zsh"; "keeper_bash"; "keeper_fs_edit" ]
+      ~demote_on_error:true
+  with
+  | Ok (Masc_mcp.Keeper_disclosure_strategy.Hybrid { full_names; demote_on_error }) ->
+    (check (list string))
+      "Hybrid.full_names sorted (RFC-OAS-013 §2.4 prefix-cache stability)"
+      [ "keeper_bash"; "keeper_fs_edit"; "keeper_zsh" ]
+      full_names;
+    (check bool) "Hybrid.demote_on_error preserved" true demote_on_error
+  | Ok _ -> failf "of_toml \"hybrid\" returned wrong variant"
+  | Error msg -> failf "of_toml \"hybrid\" failed: %s" msg
+;;
+
+let test_of_toml_hybrid_empty_rejected () =
+  match
+    Masc_mcp.Keeper_disclosure_strategy.of_toml
+      ~strategy:"hybrid"
+      ~full_names:[]
+      ~demote_on_error:false
+  with
+  | Ok _ -> failf "of_toml \"hybrid\" with empty full_names should be Error"
+  | Error _ -> ()
+;;
+
+let test_of_toml_minimal_index () =
+  match
+    Masc_mcp.Keeper_disclosure_strategy.of_toml
+      ~strategy:"minimal_index"
+      ~full_names:[]
+      ~demote_on_error:false
+  with
+  | Ok Masc_mcp.Keeper_disclosure_strategy.Minimal_index -> ()
+  | Ok other ->
+    failf
+      "of_toml \"minimal_index\" returned wrong variant: %s"
+      (Masc_mcp.Keeper_disclosure_strategy.to_string other)
+  | Error msg -> failf "of_toml \"minimal_index\" failed: %s" msg
+;;
+
+let test_of_toml_unknown_rejected () =
+  match
+    Masc_mcp.Keeper_disclosure_strategy.of_toml
+      ~strategy:"verbose_quantum"
+      ~full_names:[]
+      ~demote_on_error:false
+  with
+  | Ok _ ->
+    failf
+      "of_toml on unknown strategy should be Error \
+       (CLAUDE.md anti-pattern #2: no permissive default)"
+  | Error _ -> ()
+;;
+
+let test_is_full_semantics () =
+  (check bool) "is_full Full" true (Masc_mcp.Keeper_disclosure_strategy.is_full Full);
+  (check bool)
+    "is_full Minimal_index"
+    false
+    (Masc_mcp.Keeper_disclosure_strategy.is_full Minimal_index);
+  (check bool)
+    "is_full Hybrid _"
+    false
+    (Masc_mcp.Keeper_disclosure_strategy.is_full
+       (Hybrid { full_names = [ "x" ]; demote_on_error = false }))
+;;
+
+let pinned_disclosure_variant_count = 3
+
+let test_variant_count_pin () =
+  (* RFC-0084 §3.5: 3 strategy arms. Adding a 4th surfaces in this
+     test alongside the activation logic, forcing reviewers to update
+     worker_oas wiring + keeper TOML schema simultaneously. *)
+  (check int)
+    "Keeper_disclosure_strategy variant count (RFC-0084 §3.5)"
+    3
+    pinned_disclosure_variant_count
+;;
+
+let () =
+  Alcotest.run
+    "RFC-0084 PR-13 Keeper_disclosure_strategy typed"
+    [ ( "disclosure-strategy"
+      , [ test_case "default-is-full" `Quick test_default_is_full
+        ; test_case "to-string-full" `Quick test_to_string_full
+        ; test_case "to-string-minimal-index" `Quick test_to_string_minimal_index
+        ; test_case "to-string-hybrid" `Quick test_to_string_hybrid
+        ; test_case "of-toml-full" `Quick test_of_toml_full
+        ; test_case "of-toml-hybrid-sorted" `Quick test_of_toml_hybrid_sorted
+        ; test_case "of-toml-hybrid-empty-rejected" `Quick test_of_toml_hybrid_empty_rejected
+        ; test_case "of-toml-minimal-index" `Quick test_of_toml_minimal_index
+        ; test_case "of-toml-unknown-rejected" `Quick test_of_toml_unknown_rejected
+        ; test_case "is-full-semantics" `Quick test_is_full_semantics
+        ; test_case "variant-count-pin" `Quick test_variant_count_pin
+        ] )
+    ]
+;;


### PR DESCRIPTION
## RFC-0084 PR-13 — `Keeper_disclosure_strategy` typed sum (RFC-OAS-013 activation)

**Stacked on**: PR-12 (#15417). **Base**: `feature/rfc-0083-pr-12-host-config`.
**Sequence**: 13 of 14 in [RFC-0084](https://github.com/jeong-sik/masc-mcp/blob/feature/rfc-0083-pr-1-rfc-doc-audit/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md) (§1.6, §3.5).

### Why

RFC-0084 §1.6 documented the **dormant `Tool.disclosure_level` infrastructure**: OAS PR #1508 + #1511 wired the `Hybrid` / `Minimal_index` disclosure mechanism into `lib/pipeline/stage_parse.ml:42-46` and `lib/pipeline/pipeline_stage_prepare.ml:109-115`, but **masc-mcp caller count = 0** (`rg -n 'with_disclosure_level|with_disclosure_resolver|imseonghan' lib/ bin/` = 0 matches).

RFC-OAS-013 §2.1 v2 proposed activating this via a **hardcoded `meta.name = "imseonghan"` keeper-name gate**. That pattern is CLAUDE.md anti-pattern #1 (Scattered hardcoded default) — one keeper name baked into compiled code. **This PR rejects that approach** and introduces a **config-driven typed strategy** so any keeper TOML can opt-in via a `[disclosure]` section without code-level keeper-name hardcodes.

### Type design (3 arms)

```ocaml
type t =
  | Full
      (* Today's default; max prefix-cache, max tokens *)
  | Hybrid of { full_names : string list ; demote_on_error : bool }
      (* full_names get full schemas; rest get minimal index *)
  | Minimal_index
      (* Every tool → name + description only *)
```

`of_toml ~strategy ~full_names ~demote_on_error`:

- `"full"` → `Ok Full`
- `"hybrid"` with non-empty `full_names` → `Ok (Hybrid { full_names = sorted; demote_on_error })` (sorted per RFC-OAS-013 §2.4 prefix-cache stability)
- `"hybrid"` with empty `full_names` → `Error _` (fail-closed; no permissive default)
- `"minimal_index"` → `Ok Minimal_index`
- Anything else → `Error _` (CLAUDE.md anti-pattern #2 self-check; no permissive default)

### Files

| File | Lines | Change |
|---|---|---|
| `lib/keeper/keeper_disclosure_strategy.mli` | new (~75) | Typed contract + `of_toml` + `default` + helpers |
| `lib/keeper/keeper_disclosure_strategy.ml` | new (~55) | Implementation |
| `test/test_disclosure_strategy_config.ml` | new (~150) | 11 alcotest cases pinning cardinality, default, of_toml strict parsing, prefix-cache sort, is_full semantics, unknown-rejection |
| `test/dune` | +12 (stanza) | single-stanza, `masc_test_deps` |

### Plan §3 PR-13 adjustment

Plan §3 PR-13 scope was: *"`worker_oas.ml` 활성화. RFC-OAS-013 §2.1 v2의 `if meta.name = "imseonghan"` 패턴 거부 — 대신 `meta.disclosure_strategy : disclosure_strategy` typed field. Keeper TOML config schema에 추가. 1개 keeper에 hybrid 적용."*

**This PR introduces the typed surface only**; the wiring into `worker_oas.ml` + `lib/keeper/keeper_meta.ml` TOML round-trip is scoped to *follow-up activation PR(s)* per the delegation-not-absorption pattern used in PR-6/8/9/10/11/12.

**Why staged**:
1. `worker_oas.ml` is 886 lines; the activation wiring intersects with the OAS `Builder.with_disclosure_level` + `Builder.with_disclosure_resolver` API which is itself in flux (RFC-OAS-013 §2.1 v2 vs §6 v3).
2. `keeper_meta.ml` TOML schema bump touches every existing `.masc/config/keepers/*.toml` round-trip path.
3. The typed sum is the *prerequisite* for both wirings — landing it independently lets the activation PR(s) bisect risk per keeper.

The 11 alcotest cases ensure the typed surface is *self-consistent* before any caller migrates.

### Invariants pinned

| Invariant | Pinned value |
|---|---|
| Variant cardinality | **3** (`Full` / `Hybrid` / `Minimal_index`) |
| `default` | `Full` (safe today's behaviour) |
| `to_string` Full | `"full"` |
| `to_string` Hybrid _ | `"hybrid"` |
| `to_string` Minimal_index | `"minimal_index"` |
| `of_toml "hybrid" []` | `Error _` (empty full_names rejected) |
| `of_toml "hybrid" [_; _; _]` | `Hybrid { full_names = sorted; demote_on_error }` |
| `of_toml "verbose_quantum"` | `Error _` (no permissive default) |
| `is_full Full` | `true` |
| `is_full (Hybrid _)` / `is_full Minimal_index` | `false` |

### What this PR does NOT do

- **Does NOT wire `worker_oas.ml`** — typed surface only. Follow-up activation PR maps `Keeper_meta.disclosure_strategy` → OAS `Builder.with_disclosure_level` / `with_disclosure_resolver`.
- **Does NOT bump `keeper_meta.ml` TOML schema** — follow-up activation PR adds `[disclosure]` section round-trip in `keeper_runtime_toml.ml`.
- **Does NOT touch `.masc/config/keepers/*.toml`** — defaults to `Full` for every keeper; no behavioural change until activation PR rolls out one keeper.
- **Does NOT enforce `Hybrid` for any keeper** — typed strategy is reachable but never instantiated until the activation PR creates a `Hybrid {...}` value.

### CI risk

- New module in `lib/keeper/`; no existing-code reformat.
- `Keeper_disclosure_strategy` name does not collide with `Keeper_disclosure` or `Tool.disclosure_level` (different namespace + different type).
- Test is constants-only over the typed sum; no integration test surface.
- `dune-local.sh` lock contention may delay local verification; CI clean-env authoritative.

### Workaround rejection self-check (CLAUDE.md §워크어라운드 거부 기준)

- ✗ **Telemetry-as-fix**: typed sum is the *typed migration target*, not a counter without behavioural change.
- ✗ **String/substring classifier**: `of_toml` parses *3 closed string labels* into a typed sum. No substring matcher; no permissive default (CLAUDE.md anti-pattern #2 explicitly addressed).
- ✗ **N-of-M patch**: typed surface is complete in this PR. Wiring + TOML migration are *staged follow-ups* with documented owners, not silent partial coverage.
- ✗ **Hardcoded keeper-name gate** (RFC-OAS-013 §2.1 v2 `imseonghan`): **rejected**. PR body §"Why" explicitly documents the rejection rationale (CLAUDE.md anti-pattern #1).
- ✗ **Unknown → Permissive default**: `of_toml` returns `Error _` on unknown strategy labels and empty `full_names`. Fail-closed.

### Sprint progress after this PR

- 4-tuple propagation: **100%** (PR-9)
- Typed dispatch outcome: **available** (PR-10)
- Legacy mli surface: **removed** (PR-11)
- Portability typed surface: **available** (PR-12)
- Disclosure typed surface: **available** (this PR)
- **Remaining: PR-14 (telemetry property test + CI lint + RFC closeout) — sprint closeout PR**

### Stack ordering

Merge order: PR-1 → … → PR-12 → **PR-13** → PR-14 (telemetry completeness + closeout) → follow-up activation + cleanup PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
