### PR TITLE
fix(cascade): purge provider residue from model projections

### DIFF
--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -151,8 +151,8 @@ contains four sections: `tts`, `stt`, `session`, `local_playback`.
 | `MASC_INFERENCE_CACHE_MAX_TEMP` | float | 0.0 | 캐시 허용 최대 온도 |
 | `MASC_INFERENCE_CACHE_L1_MAX_ENTRIES` | int | 512 | L1 인메모리 캐시 상한 |
 | `MASC_SPAWN_CACHE_POLICY` | string | `"safe_only"` | Spawn 캐시 정책 (`off`/`safe_only`) |
-| `ZAI_DEFAULT_MODEL` | string | OAS ZAI catalog head | `glm` provider `auto` 기본 모델. 코드 기본값은 `Llm_provider.Zai_catalog`에서 가져온다. |
-| `ZAI_CODING_DEFAULT_MODEL` | string | OAS ZAI catalog head | `glm-coding` provider `auto` 기본 모델. 코드 기본값은 `Llm_provider.Zai_catalog`에서 가져온다. |
+| `ZAI_DEFAULT_MODEL` | string | OAS runtime binding/catalog default | 설정 시 `glm` provider `auto` 기본 모델로 사용. 미설정이면 OAS runtime binding/catalog default에 위임한다. |
+| `ZAI_CODING_DEFAULT_MODEL` | string | OAS runtime binding/catalog default | 설정 시 `glm-coding` provider `auto` 기본 모델로 사용. 미설정이면 OAS runtime binding/catalog default에 위임한다. |
 | `GEMINI_DEFAULT_MODEL` | string | 없음 | 설정 시 direct `gemini` provider `auto` 기본 모델로 사용. 미설정이면 direct 기본 동작에 위임한다. |
 | `GEMINI_CLI_DEFAULT_MODEL` | string | 없음 | 설정 시 `gemini_cli` provider `auto` 기본 모델로 사용. 미설정이면 Gemini CLI 기본 동작에 위임한다. |
 | `MASC_GEMINI_CLI_AUTO_MODELS` | csv string | `"auto"` | 설정 시 `gemini_cli:auto`를 operator 지정 후보 목록으로 확장. 미설정이면 Gemini CLI 기본 모델에 위임한다. |
@@ -464,11 +464,11 @@ is-default = true
 max-concurrent = 1
 ```
 
-`gemini_cli:auto`, `codex_cli:auto`, `claude_code:auto`는 기본적으로 concrete 후보 목록을 코드에 갖지 않는다. 미설정 기본값은 `auto` 1개이며 각 CLI의 현재 기본 모델 선택에 위임한다. 특정 모델 rotation이 필요하면 `MASC_GEMINI_CLI_AUTO_MODELS`, `MASC_CODEX_CLI_AUTO_MODELS`, `MASC_CLAUDE_CODE_AUTO_MODELS`에 operator가 명시한 CSV를 넣는다. GLM 계열은 HTTP API가 concrete model id를 요구하므로 `Llm_provider.Zai_catalog`의 catalog 순서를 사용한다.
+`gemini_cli:auto`, `codex_cli:auto`, `claude_code:auto`는 기본적으로 concrete 후보 목록을 코드에 갖지 않는다. 미설정 기본값은 `auto` 1개이며 각 CLI의 현재 기본 모델 선택에 위임한다. 특정 모델 rotation이 필요하면 `MASC_GEMINI_CLI_AUTO_MODELS`, `MASC_CODEX_CLI_AUTO_MODELS`, `MASC_CLAUDE_CODE_AUTO_MODELS`에 operator가 명시한 CSV를 넣는다. Direct API provider의 concrete 후보 목록과 기본값은 OAS runtime binding/catalog가 제공하는 값을 projection해서 사용한다. binding이 supported model 목록을 제공하지 않으면 MASC는 `auto`를 임의 concrete model로 확장하지 않는다.
 
-### 7.6 Ollama HTTP Probe (Phase C2, #7619)
+### 7.6 HTTP Probe Capacity (Phase C2, #7619)
 
-ollama provider는 `/api/ps` endpoint를 가진다. MASC는 cycle 시작마다 등록된 URL들을 순차적으로 조회하여 (`Cascade_capacity_probe.refresh_many` → `Cascade_http_probe.refresh_many` 내부에서 `List.iter`) 실제 활성 모델 수를 capacity로 변환한다. 캐시 TTL 2초. 응답 실패 시 silent fail → Phase A client-capacity semaphore로 fallback. 병렬 fan-out이 필요해지면 `Cascade_http_probe.refresh_many`에서 `Eio.Fiber.both` 로 전환.
+등록된 HTTP probe provider는 provider별 probe endpoint를 가진다. MASC는 cycle 시작마다 등록된 URL들을 순차적으로 조회하여 (`Cascade_capacity_probe.refresh_many` → registered probe 내부 `refresh_many`) 실제 활성 모델 수를 capacity로 변환한다. 캐시 TTL 2초. 응답 실패 시 silent fail → Phase A client-capacity semaphore로 fallback. 병렬 fan-out이 필요해지면 probe adapter의 `refresh_many`에서 `Eio.Fiber.both` 로 전환.
 
 capacity 조회 순서: `Cascade_throttle` (llama-server /slots 기반) → `Cascade_capacity_probe` (discovered via registered probes, e.g. `/api/ps`) → `Cascade_client_capacity` (declared semaphore).
 

--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -361,15 +361,15 @@ let exit_code_of_message (message : string) : int option =
               int_of_string_opt raw
 
 let message_looks_like_resumable_cli_session (message : string) : bool =
-  Cascade_transport.Kimi_cli_transport_local.text_looks_like_resumable_session
+  Cascade_transport.Json_stream_cli_transport_local.text_looks_like_resumable_session
     message
 
 let resumable_cli_session_detail (message : string) : string =
-  Cascade_transport.Kimi_cli_transport_local.resumable_session_detail_of_text
+  Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail_of_text
     message
 
 let resumable_cli_session_exit_code (message : string) : int option =
-  Cascade_transport.Kimi_cli_transport_local.resumable_session_exit_code_of_text
+  Cascade_transport.Json_stream_cli_transport_local.resumable_session_exit_code_of_text
     message
 
 let sdk_error_to_resumable_cli_session ~cascade_name
@@ -414,7 +414,8 @@ let sdk_error_is_resumable_cli_session (err : Agent_sdk.Error.sdk_error) : bool 
 
 let message_looks_like_terminal_provider_runtime_failure message =
   let contains needle = String_util.contains_substring_ci message needle in
-  (contains "kimi_cli rejected" && contains "startup crash")
+  (contains "provider cli rejected" && contains "exit 1")
+  || (contains "provider cli startup crash" && contains "unicodedecodeerror")
   || contains "unicodedecodeerror"
   || (contains "jsonrpcmessage"
       && (contains "validationerror" || contains "invalid json"))

--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -361,15 +361,15 @@ let exit_code_of_message (message : string) : int option =
               int_of_string_opt raw
 
 let message_looks_like_resumable_cli_session (message : string) : bool =
-  Cascade_runner.Kimi_cli_transport_local.text_looks_like_resumable_session
+  Cascade_transport.Kimi_cli_transport_local.text_looks_like_resumable_session
     message
 
 let resumable_cli_session_detail (message : string) : string =
-  Cascade_runner.Kimi_cli_transport_local.resumable_session_detail_of_text
+  Cascade_transport.Kimi_cli_transport_local.resumable_session_detail_of_text
     message
 
 let resumable_cli_session_exit_code (message : string) : int option =
-  Cascade_runner.Kimi_cli_transport_local.resumable_session_exit_code_of_text
+  Cascade_transport.Kimi_cli_transport_local.resumable_session_exit_code_of_text
     message
 
 let sdk_error_to_resumable_cli_session ~cascade_name

--- a/lib/cascade/cascade_client_capacity_history.ml
+++ b/lib/cascade/cascade_client_capacity_history.ml
@@ -9,15 +9,11 @@ type event = {
   active_after : int;
 }
 
-(* ── Classifier (shares {!Masc_network_defaults.is_cli_sentinel_url}
-      and {!Masc_network_defaults.is_ollama_url} with
-      {!Dashboard_cascade.classify_capacity_key}).  Both call sites
-      resolve to the same SSOT predicates; [test_snapshot_kind_filter]
-      below and the existing [Dashboard_cascade] tests still cover the
-      mapping. *)
+(* ── Classifier.  Kept leaf-level to avoid pulling the dashboard or aggregate
+      capacity-probe adapter into this ring buffer module. *)
 let classify_key url =
   if Masc_network_defaults.is_cli_sentinel_url url then "cli"
-  else if Masc_network_defaults.is_ollama_url url then "ollama"
+  else if Cascade_http_probe.is_registered ~url then "http_probe"
   else "other"
 
 (* ── Ring buffer configuration ─────────────────────────────── *)
@@ -149,7 +145,7 @@ let snapshot ?(limit = 100) ?kind ?since_ts () =
   let kind_match =
     match kind with
     | None -> fun _ -> true
-    | Some k when k = "cli" || k = "ollama" || k = "other" ->
+    | Some k when k = "cli" || k = "http_probe" || k = "other" ->
       fun e -> classify_key e.key = k
     | Some _ ->
       (* Unknown kind filter: return nothing rather than silently

--- a/lib/cascade/cascade_client_capacity_history.mli
+++ b/lib/cascade/cascade_client_capacity_history.mli
@@ -59,12 +59,8 @@ val snapshot : ?limit:int -> ?kind:string -> ?since_ts:float -> unit -> event li
     @param limit  maximum number of events returned (default 100,
            clamped to the ring's current count).
     @param kind   filter by dashboard classification — one of
-           ["cli"], ["ollama"], ["other"].  Unknown values return
-           [[]]; omitting the argument returns every kind.  The
-           classifier matches {!Dashboard_cascade}'s [classify_capacity_key]
-           (copy-paste rather than a shared helper — both are ~12
-           lines and we did not want the new module to depend on
-           [Dashboard_cascade]).
+           ["cli"], ["http_probe"], ["other"].  Unknown values return
+           [[]]; omitting the argument returns every kind.
     @param since_ts  keep only events with [ts >= since_ts].
            Omitting returns every timestamp.
 
@@ -84,6 +80,5 @@ val capacity : unit -> int
     overflow the ring without hardcoding the default. *)
 
 val classify_key : string -> string
-(** Same classification as {!Dashboard_cascade.classify_capacity_key}.
-    Exposed for tests that want to assert ["cli"]/["ollama"]/["other"]
-    labels without pulling in the dashboard module. *)
+(** Classify a capacity key as ["cli"], ["http_probe"], or ["other"] without
+    pulling in the dashboard projection. *)

--- a/lib/cascade/cascade_client_capacity_history.mli
+++ b/lib/cascade/cascade_client_capacity_history.mli
@@ -4,7 +4,7 @@
     Phase A ({!Cascade_client_capacity}) introduced the process-local
     semaphore.  Phase D ({!Dashboard_cascade.client_capacity_json})
     exposed the *current* snapshot.  Operators still could not answer
-    "how often was the ollama slot full in the last hour?" — this
+    "how often was the HTTP-probe slot full in the last hour?" — this
     module fills that gap by recording every transition and surfacing
     recent events via {!snapshot}.
 

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -11,7 +11,6 @@
 
 (* Model resolution *)
 let resolve_auto_model = Cascade_model_resolve.resolve_auto_model
-let resolve_glm_model_id = Cascade_model_resolve.resolve_glm_model_id
 let resolve_auto_model_id = Cascade_model_resolve.resolve_auto_model_id
 let parse_custom_model = Cascade_model_resolve.parse_custom_model
 
@@ -246,9 +245,7 @@ let nonempty_env name =
     if trimmed = "" then None else Some trimmed
   | None -> None
 
-let kimi_provider_name = "kimi"
-
-(* #9953: Resolve Kimi max_context from OAS runtime binding truth.
+(* #9953: Resolve provider/model max_context from OAS runtime binding truth.
 
    Resolution order:
    1. Per-model capabilities override ({!Capabilities.for_model_id}
@@ -257,7 +254,7 @@ let kimi_provider_name = "kimi"
    2. Provider-level capability exposed by [Provider_runtime_binding].
    3. Registry entry default (safety net for exotic configs).
 *)
-let resolve_kimi_max_context resolved_model_id =
+let resolve_provider_model_max_context ~provider_name resolved_model_id =
   let open Llm_provider in
   let from_model =
     Option.bind
@@ -269,14 +266,14 @@ let resolve_kimi_max_context resolved_model_id =
   | None ->
     (match
        Option.bind
-         (Agent_sdk.Provider_runtime_binding.find kimi_provider_name)
+         (Agent_sdk.Provider_runtime_binding.find provider_name)
          (fun binding ->
             binding.Agent_sdk.Provider_runtime_binding.capabilities.max_context_tokens)
      with
      | Some n -> n
      | None ->
        (match Provider_registry.find (Provider_registry.default ())
-                kimi_provider_name with
+                provider_name with
         | Some entry -> entry.Provider_registry.max_context
         | None -> 0))
 

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -479,11 +479,10 @@ let parse_weighted_entry_with_drop_metric
     None
 
 (** Expand provider:auto specs that map to multiple models.
-    "glm:auto" expands to ["glm:glm-5.1"; "glm:glm-5-turbo"; ...].
-    CLI-backed transports expand too, so a single [gemini_cli:auto] can
-    cascade through concrete CLI model overrides instead of delegating to
-    the CLI's interactive/default model picker. Other specs pass through
-    as-is. *)
+    Direct API providers project their candidate list from OAS runtime
+    bindings. CLI-backed transports can use operator-provided override
+    lists instead of delegating to an interactive/default model picker.
+    Other specs pass through as-is. *)
 let rotate_list_by offset items =
   if offset <= 0 then items
   else

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -13,20 +13,10 @@
     @stability Internal
     @since 0.93.1 *)
 
-(** {1 Model Alias Resolution} *)
+(** {1 Model Resolution} *)
 
-(** Resolve a GLM model alias to the concrete API model ID.
-    - ["auto"] → env var [ZAI_DEFAULT_MODEL] or the OAS ZAI catalog head
-    - ["flash"] → ["glm-4.7-flashx"]
-    - ["turbo"] → ["glm-5-turbo"]
-    - ["vision"] → ["glm-4.6v"]
-    - Concrete IDs pass through unchanged.
-    @since 0.89.1 *)
-val resolve_glm_model_id : string -> string
-
-(** Resolve "auto" and aliases to concrete model IDs for any provider.
-    Cloud providers resolve aliases; local providers resolve ["auto"]
-    via discovery first and otherwise pass through explicit model IDs.
+(** Resolve ["auto"] for a provider through runtime binding defaults or local
+    discovery. Explicit model IDs pass through unchanged.
     @since 0.89.1 *)
 val resolve_auto_model_id : string -> string -> string
 
@@ -415,11 +405,11 @@ val filter_healthy_strict :
 
 (** {1 Context Window Resolution} *)
 
-(** Resolve the Kimi context window from the OAS capability SSOT.
+(** Resolve a provider/model context window from the OAS capability SSOT.
 
-    This is shared by cascade profile generation and Kimi CLI transport config
-    so those paths do not drift through local "256k" constants. *)
-val resolve_kimi_max_context : string -> int
+    This is shared by cascade profile generation and transport config paths so
+    those paths do not drift through local context-window constants. *)
+val resolve_provider_model_max_context : provider_name:string -> string -> int
 
 (** Effective max context tokens for a provider entry.
 

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -172,10 +172,9 @@ val parse_model_string_result :
   string -> (Llm_provider.Provider_config.t, string) result
 
 (** Expand provider:auto specs that map to multiple models.
-    ["glm:auto"] expands to ["glm:glm-5.1"; "glm:glm-5-turbo"; ...].
-    CLI specs such as ["gemini_cli:auto"], ["codex_cli:auto"], and
-    ["claude_code:auto"] expand through their provider-specific
-    auto-model lists. Other specs pass through unchanged. *)
+    Direct API providers project their candidate list from OAS runtime
+    bindings. CLI specs can expand through operator-provided auto-model
+    lists. Other specs pass through unchanged. *)
 val expand_auto_models : string list -> string list
 
 val expand_weighted_auto_entries :
@@ -223,7 +222,7 @@ val resolve_model_strings :
 (** Expand execution-time convenience fallbacks while preserving stable order.
 
     Uses the same provider:auto expansion as {!expand_auto_models}, so
-    CLI and GLM family entries execute in the same concrete order the
+    provider-family entries execute in the same concrete order the
     dashboard shows by default.
 
     When [rotation_scope] is provided, each [provider:auto] entry is

--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -182,7 +182,7 @@ let hard_quota_cooldown_sec =
 (** Cooldown duration for provider calls classified as terminal structural
     failures, where retrying the same provider on the next cascade tick is
     expected to reproduce the same failure until operator/runtime state changes.
-    Examples: Kimi CLI reporting a resumable session conflict instead of
+    Example: a provider CLI reporting a resumable session conflict instead of
     accepting a fresh non-interactive invocation.
 
     This is separate from hard-quota so dashboards and future policy can
@@ -294,10 +294,10 @@ let cost_ring_size =
    [cooldown_threshold] does not apply because retry on the next cascade
    tick is pointless when the upstream account is out of credit. *)
 (* [Terminal_failure] represents structural provider/adapter failures that are
-   deterministic for the current runtime state.  A Kimi CLI resumable-session
-   conflict is the motivating case: fallback is correct for the current call,
-   but repeatedly attempting Kimi first on every later call only adds latency
-   and silently degrades cascade diversity. *)
+   deterministic for the current runtime state.  A provider CLI
+   resumable-session conflict is the motivating case: fallback is correct for
+   the current call, but repeatedly attempting the same provider first on every
+   later call only adds latency and silently degrades cascade diversity. *)
 (* [Soft_rate_limited] represents a transient HTTP 429 — provider is healthy
    but momentarily over its rate budget.  Distinct from [Failure] so a single
    event triggers an immediate (short) cooldown without waiting for the

--- a/lib/cascade/cascade_health_tracker.mli
+++ b/lib/cascade/cascade_health_tracker.mli
@@ -36,7 +36,7 @@ val hard_quota_cooldown_sec : float
 
 val terminal_failure_cooldown_sec : float
 (** Cooldown duration applied immediately on a terminal structural
-    provider/adapter failure, such as a Kimi CLI resumable-session conflict.
+    provider/adapter failure, such as a provider CLI resumable-session conflict.
     Unlike {!cooldown_sec}, no threshold is required.  Default 3600.0 (1h).
 
     Env: [MASC_CASCADE_TERMINAL_FAILURE_COOLDOWN_SEC] (with deprecated

--- a/lib/cascade/cascade_http_probe_url.ml
+++ b/lib/cascade/cascade_http_probe_url.ml
@@ -1,13 +1,13 @@
 (** HTTP capacity probe selection for cascade runtime candidates.
 
-    The probe implementation is tied to the native Ollama [/api/ps] schema, so
-    the provider-kind check lives next to the probe URL decision instead of in
-    the legacy provider adapter boundary. *)
+    MASC does not decide probe eligibility by provider brand. A URL is probed
+    only when a registered capacity probe claims it. *)
 
 let of_provider_config (cfg : Llm_provider.Provider_config.t) =
-  match cfg.kind with
-  | Llm_provider.Provider_config.Ollama when not (String.equal cfg.base_url "") ->
-    Some cfg.base_url
-  | Anthropic | Claude_code | OpenAI_compat | Glm | DashScope | Codex_cli
-  | Gemini | Gemini_cli | Kimi | Kimi_cli | Ollama -> None
+  let base_url = String.trim cfg.base_url in
+  if String.equal base_url ""
+  then None
+  else if Cascade_capacity_probe.can_probe ~url:base_url
+  then Some base_url
+  else None
 ;;

--- a/lib/cascade/cascade_metrics.ml
+++ b/lib/cascade/cascade_metrics.ml
@@ -310,10 +310,10 @@ let on_provider_filter_widening ~cascade =
 
 (* [expand_weighted_entries] fans a single [provider:auto] entry out
    to N concrete candidates via [Cascade_config.expand_auto_models]
-   ("glm:auto" -> ["glm:glm-5.1"; "glm:glm-5-turbo"; ...]).  The
-   per-cascade fan-out amount was silent: operators saw one line in
-   cascade.toml but the runtime cascading list was N entries, and a
-   change in the registry (new provider added, model deprecated)
+   using the candidate list projected from OAS runtime bindings or
+   operator-provided CLI override lists.  The per-cascade fan-out
+   amount was silent: operators saw one line in cascade.toml but the
+   runtime cascading list was N entries, and a change in the registry
    would silently shift the effective candidate count without any
    dashboard signal.
 

--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -1,26 +1,12 @@
-(** Model ID resolution: aliases and auto-detection for cloud providers.
+(** Model ID resolution for cascade provider labels.
 
-    Pure functions that map user-facing aliases to concrete API model IDs.
+    Pure functions that map user-facing [auto] selectors through the OAS
+    provider runtime binding projection. Provider-specific alias/catalog truth
+    belongs upstream in OAS, not in MASC cascade code.
     No side effects beyond reading environment variables.
 
     @since 0.92.0 extracted from Cascade_config *)
 
-(* ── GLM model catalog ──────────────────────────────── *)
-
-(** Resolve GLM alias to concrete model ID.
-    ZhipuAI serves all models on one endpoint; the "model" field
-    must be an exact ID from their catalog.
-
-    Catalog (2026-03, updated):
-    {b Text}: glm-5.1, glm-5, glm-5-turbo, glm-4.7, glm-4.7-flashx,
-              glm-4.6, glm-4.5, glm-4.5-air, glm-4.5-airx,
-              glm-4.5-flash, glm-4.5-x, glm-4-32b-0414-128k
-    {b Vision}: glm-4.6v, glm-4.6v-flashx, glm-4.6v-flash, glm-4.5v
-    {b Audio}: glm-asr-2512
-    {b Image gen}: cogview-4, glm-image
-
-    All text/vision models support function calling.
-    glm-5.1 supports reasoning (reasoning_content field). *)
 type model_selector =
   | Concrete of string
   | Auto
@@ -33,9 +19,8 @@ let model_selector_of_string s =
 
 type model_resolution_provenance =
   | Explicit_input
-  | Alias of string
   | Env_default of string
-  | Hardcoded_default
+  | Binding_default
   | Discovery
   | Unresolved_auto
 
@@ -64,16 +49,11 @@ let unresolved_auto requested_model_id =
   }
 ;;
 
-let hardcoded_default requested_model_id resolved_model_id =
-  { requested_model_id; resolved_model_id; provenance = Hardcoded_default }
+let binding_default requested_model_id resolved_model_id =
+  { requested_model_id; resolved_model_id; provenance = Binding_default }
 ;;
 
-let default_resolution ?getenv ?fallback_model provider_name ~requested_model_id =
-  let fallback () =
-    match fallback_model with
-    | Some resolved_model_id -> hardcoded_default requested_model_id resolved_model_id
-    | None -> unresolved_auto requested_model_id
-  in
+let default_resolution ?getenv provider_name ~requested_model_id =
   match
     Provider_runtime_projection.default_model_candidate_for_cascade_prefix
       ?getenv
@@ -87,107 +67,9 @@ let default_resolution ?getenv ?fallback_model provider_name ~requested_model_id
   | Some
       { source = Provider_runtime_projection.Binding_default
       ; model_id = resolved_model_id
-      }
-    when (String.equal (String.lowercase_ascii (String.trim resolved_model_id)) "auto"
-          && Option.is_some fallback_model) -> fallback ()
-  | Some
-      { source = Provider_runtime_projection.Binding_default
-      ; model_id = resolved_model_id
       } ->
-    hardcoded_default requested_model_id resolved_model_id
-  | None -> fallback ()
-;;
-
-let cascade_prefix_of_canonical_provider canonical_name =
-  Provider_runtime_projection.cascade_prefix_of_provider_label canonical_name
-  |> Option.value ~default:canonical_name
-;;
-
-(** Default GLM auto-cascade order: quality-first, then speed.
-    glm-5.1 = best quality (reasoning), glm-5-turbo = fast tool calling,
-    glm-4.7 = stable general, glm-4.7-flashx = fastest/cheapest.
-    Configurable via ZAI_AUTO_MODELS env var (comma-separated). *)
-let glm_auto_models = Llm_provider.Zai_catalog.glm_auto_models
-
-let glm_coding_auto_models = Llm_provider.Zai_catalog.glm_coding_auto_models
-
-let first_model models =
-  models
-  |> List.find_map (fun model ->
-    let trimmed = String.trim model in
-    if String.equal trimmed "" then None else Some trimmed)
-;;
-
-let resolve_glm_model ?getenv selector =
-  let model_id =
-    match selector with
-    | Concrete s -> s
-    | Auto -> "auto"
-  in
-  let default_model =
-    default_resolution
-      ?getenv
-      ?fallback_model:(first_model (glm_auto_models ()))
-      (cascade_prefix_of_canonical_provider "glm")
-      ~requested_model_id:model_id
-  in
-  let resolved_model_id =
-    Llm_provider.Zai_catalog.resolve_glm_alias
-      ~default_model:default_model.resolved_model_id
-      model_id
-  in
-  match selector with
-  | Auto -> { default_model with resolved_model_id }
-  | Concrete _ ->
-    if String.equal resolved_model_id model_id
-    then explicit_resolution model_id resolved_model_id
-    else { requested_model_id = model_id; resolved_model_id; provenance = Alias model_id }
-;;
-
-let resolve_glm_coding_model ?getenv selector =
-  let model_id =
-    match selector with
-    | Concrete s -> s
-    | Auto -> "auto"
-  in
-  let default_model =
-    default_resolution
-      ?getenv
-      ?fallback_model:(first_model (glm_coding_auto_models ()))
-      (cascade_prefix_of_canonical_provider "glm-coding")
-      ~requested_model_id:model_id
-  in
-  let resolved_model_id =
-    Llm_provider.Zai_catalog.resolve_glm_coding_alias
-      ~default_model:default_model.resolved_model_id
-      model_id
-  in
-  match selector with
-  | Auto -> { default_model with resolved_model_id }
-  | Concrete _ ->
-    if String.equal resolved_model_id model_id
-    then explicit_resolution model_id resolved_model_id
-    else { requested_model_id = model_id; resolved_model_id; provenance = Alias model_id }
-;;
-
-let resolve_kimi_model ?getenv selector =
-  let model_id =
-    match selector with
-    | Concrete s -> s
-    | Auto -> "auto"
-  in
-  let trimmed = String.trim model_id in
-  match String.lowercase_ascii trimmed with
-  | "auto" -> default_resolution ?getenv "kimi" ~requested_model_id:model_id
-  | _ -> explicit_resolution model_id trimmed
-;;
-
-let resolve_glm_model_id model_id =
-  (resolve_glm_model (model_selector_of_string model_id)).resolved_model_id
-;;
-
-let resolve_glm_coding_model_id model_id =
-  (resolve_glm_coding_model (model_selector_of_string model_id)).resolved_model_id
+    binding_default requested_model_id resolved_model_id
+  | None -> unresolved_auto requested_model_id
 ;;
 
 let env_fragment value =
@@ -207,17 +89,11 @@ let csv_items raw =
 
 let default_auto_models_for_profile (profile : Provider_runtime_projection.provider_profile)
   =
-  match profile.kind with
-  | Llm_provider.Provider_config.Glm
-    when Llm_provider.Zai_catalog.is_coding_base_url profile.base_url ->
-    Some (glm_coding_auto_models ())
-  | Llm_provider.Provider_config.Glm -> Some (glm_auto_models ())
-  | _ ->
-    (match profile.supported_models, profile.runtime_kind with
-     | _ :: _ as models, _ -> Some models
-     | [], Provider_runtime_projection.Cli_agent -> Some [ "auto" ]
-     | [], (Provider_runtime_projection.Local | Provider_runtime_projection.Direct_api) ->
-       None)
+  match profile.supported_models, profile.runtime_kind with
+  | _ :: _ as models, _ -> Some models
+  | [], Provider_runtime_projection.Cli_agent -> Some [ "auto" ]
+  | [], (Provider_runtime_projection.Local | Provider_runtime_projection.Direct_api) ->
+    None
 ;;
 
 let auto_models_for_cascade_prefix ?getenv provider_name =
@@ -261,22 +137,15 @@ let resolve_auto_model
         | Some resolved_model_id ->
           { requested_model_id = model_id; resolved_model_id; provenance = Discovery }
         | None -> default_resolution ?getenv provider_name ~requested_model_id:model_id)
-     | Concrete _ -> explicit_resolution model_id model_id)
-  | Some
-      { kind = Llm_provider.Provider_config.Glm; base_url; _ }
-    when Llm_provider.Zai_catalog.is_coding_base_url base_url ->
-    resolve_glm_coding_model ?getenv selector
-  | Some { kind = Llm_provider.Provider_config.Glm; _ } -> resolve_glm_model ?getenv selector
-  | Some { kind = Llm_provider.Provider_config.Kimi; _ } ->
-    resolve_kimi_model ?getenv selector
+     | Concrete _ -> explicit_resolution model_id (String.trim model_id))
   | Some _ ->
     (match selector with
      | Auto -> default_resolution ?getenv provider_name ~requested_model_id:model_id
-     | Concrete _ -> explicit_resolution model_id model_id)
+     | Concrete _ -> explicit_resolution model_id (String.trim model_id))
   | None ->
     (match selector with
      | Auto -> unresolved_auto model_id
-     | Concrete _ -> explicit_resolution model_id model_id)
+     | Concrete _ -> explicit_resolution model_id (String.trim model_id))
 ;;
 
 let resolve_auto_model_id provider_name model_id =

--- a/lib/cascade/cascade_model_resolve.mli
+++ b/lib/cascade/cascade_model_resolve.mli
@@ -1,30 +1,12 @@
-(** Model ID resolution: aliases and auto-detection for cloud providers.
+(** Model ID resolution through OAS runtime provider bindings.
 
-    Pure functions that map user-facing aliases to concrete API model IDs.
+    Pure functions that map [auto] to runtime binding defaults or local
+    discovery. Provider-specific alias/catalog truth belongs upstream in OAS.
 
     @since 0.92.0 extracted from Cascade_config
 
     @stability Internal
     @since 0.93.1 *)
-
-(** GLM auto-cascade model list: quality-first, then speed.
-    Returns the ordered list of models to try when [glm:auto] is specified.
-    The default order comes from the OAS ZAI catalog and remains configurable
-    via [ZAI_AUTO_MODELS] env var (comma-separated). *)
-val glm_auto_models : unit -> string list
-
-val glm_coding_auto_models : unit -> string list
-
-(** {2 Removed in RFC-0058 Phase 5.3a}
-
-    The per-provider [gemini_cli_auto_models], [codex_cli_auto_models],
-    [claude_code_auto_models], and [kimi_cli_auto_models] thin wrappers
-    have been deleted. They were unused in production; routing goes through
-    the generic auto-model API. Hardcoded provider names were a §2.4 "code
-    knows provider names" violation. Callers that need a specific provider's
-    auto list use the generic API; per-provider env-override behaviour
-    ([MASC_<PROVIDER>_AUTO_MODELS]) remains intact and is now exercised against
-    the generic path in [test/test_cascade_model_resolve.ml]. *)
 
 type model_selector =
   | Concrete of string
@@ -34,9 +16,8 @@ val model_selector_of_string : string -> model_selector
 
 type model_resolution_provenance =
   | Explicit_input
-  | Alias of string
   | Env_default of string
-  | Hardcoded_default
+  | Binding_default
   | Discovery
   | Unresolved_auto
 
@@ -46,35 +27,15 @@ type model_resolution =
   ; provenance : model_resolution_provenance
   }
 
-val resolve_glm_model
-  :  ?getenv:(string -> string option)
-  -> model_selector
-  -> model_resolution
-
-val resolve_glm_coding_model
-  :  ?getenv:(string -> string option)
-  -> model_selector
-  -> model_resolution
-
-(** Resolve a GLM model alias to the concrete API model ID.
-    - ["auto"] -> env var [ZAI_DEFAULT_MODEL] or the OAS ZAI catalog head
-    - ["flash"] -> ["glm-4.7-flashx"]
-    - ["turbo"] -> ["glm-5-turbo"]
-    - ["vision"] -> ["glm-4.6v"]
-    - Concrete IDs pass through unchanged. *)
-val resolve_glm_model_id : string -> string
-
-val resolve_glm_coding_model_id : string -> string
-
 (** Resolve provider:auto expansion for any registered cascade provider. *)
 val auto_models_for_cascade_prefix
   :  ?getenv:(string -> string option)
   -> string
   -> string list option
 
-(** Resolve "auto" and aliases to concrete model IDs for any provider.
-    Cloud providers resolve aliases; local providers (llama, ollama) resolve
-    "auto" via {!Llm_provider.Discovery.first_discovered_model_id}. *)
+(** Resolve ["auto"] for any provider. Local providers resolve ["auto"] via
+    {!Llm_provider.Discovery.first_discovered_model_id}; non-local providers
+    use OAS runtime binding defaults. *)
 val resolve_auto_model
   :  ?getenv:(string -> string option)
   -> ?discover:(unit -> string option)

--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -140,8 +140,8 @@ let provider_caps_of_config =
 let kimi_mcp_config_json_of_policy =
   Cascade_transport.kimi_mcp_config_json_of_policy
 
-let kimi_cli_model_for_provider =
-  Cascade_transport.kimi_cli_model_for_provider
+let cli_model_for_provider_config =
+  Cascade_transport.cli_model_for_provider_config
 
 let kimi_cli_config_json_for_provider =
   Cascade_transport.kimi_cli_config_json_for_provider

--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -137,15 +137,6 @@ let cli_model_override =
 let provider_caps_of_config =
   Cascade_transport.provider_caps_of_config
 
-let kimi_mcp_config_json_of_policy =
-  Cascade_transport.kimi_mcp_config_json_of_policy
-
-let cli_model_for_provider_config =
-  Cascade_transport.cli_model_for_provider_config
-
-let kimi_cli_config_json_for_provider =
-  Cascade_transport.kimi_cli_config_json_for_provider
-
 let provider_supports_inline_tools =
   Cascade_transport.provider_supports_inline_tools
 
@@ -173,9 +164,6 @@ let codex_cli_can_auth_keeper_bound_runtime_mcp =
 let runtime_mcp_policy_for_provider =
   Cascade_transport.runtime_mcp_policy_for_provider
 
-let kimi_cli_runtime_mcp_jsons =
-  Cascade_transport.kimi_cli_runtime_mcp_jsons
-
 let public_mcp_tools_of_oas_tools =
   Cascade_transport.public_mcp_tools_of_oas_tools
 
@@ -202,8 +190,6 @@ let resolve_tool_lane_for_oas_tools =
 
 let make_per_call_switch_transport =
   Cascade_transport.make_per_call_switch_transport
-
-module Kimi_cli_transport_local = Cascade_transport.Kimi_cli_transport_local
 
 let non_http_transport_of_provider =
   Cascade_transport.non_http_transport_of_provider

--- a/lib/cascade/cascade_runner.mli
+++ b/lib/cascade/cascade_runner.mli
@@ -54,10 +54,9 @@ type cli_transport_overrides =
   gemini_yolo : bool option;
   cli_subprocess_idle_sec : float option;
 }
-(** Per-call overrides threaded into the local CLI transports
-    (Claude Code, Gemini CLI, Kimi CLI).
-    [cli_subprocess_idle_sec] is currently honoured only by Kimi CLI;
-    see {!Cascade_transport.cli_transport_overrides}. *)
+(** Per-call overrides threaded into local CLI transports.
+    [cli_subprocess_idle_sec] is honoured by transports that execute their
+    subprocess directly; see {!Cascade_transport.cli_transport_overrides}. *)
 
 (** {1 Config} *)
 

--- a/lib/cascade/cascade_runner.mli
+++ b/lib/cascade/cascade_runner.mli
@@ -4,13 +4,10 @@
     Thin facade over {!Cascade_agent_context},
     {!Cascade_transport}, and
     {!Keeper_oas_checkpoint}.  External callers reach
-    the entry points via [Cascade_runner.X]; the heavy
-    transport machinery (CLI / MCP wire formats, runtime
-    policy projections) is implemented in
-    {!Cascade_transport} and re-exposed here for
-    backward compatibility — that sub-module has no .mli
-    of its own, so the canonical contract is the one
-    pinned at this boundary.
+    the run/config entry points via [Cascade_runner.X];
+    provider transport internals (CLI / MCP wire formats,
+    runtime policy projections, and transport-local
+    diagnostics) are owned by {!Cascade_transport}.
 
     All model-selection and cascade logic lives in
     {!Cascade_legacy_runner} and {!Keeper_turn_driver}.
@@ -164,23 +161,6 @@ val provider_label : Llm_provider.Provider_config.t -> string
 val claude_code_max_turns_hard_cap : int
 val provider_effective_max_turns :
   Llm_provider.Provider_config.provider_kind -> int -> int
-
-(** {1 Kimi CLI configuration} *)
-
-val kimi_mcp_config_json_of_policy :
-  Llm_provider.Llm_transport.runtime_mcp_policy ->
-  string option
-val cli_model_for_provider_config :
-  Llm_provider.Provider_config.t -> string option
-val kimi_cli_config_json_for_provider :
-  Llm_provider.Provider_config.t -> string option
-val kimi_cli_runtime_mcp_jsons :
-  base:string list ->
-  Llm_provider.Llm_transport.runtime_mcp_policy option ->
-  string list
-
-module Kimi_cli_transport_local :
-  module type of Cascade_transport.Kimi_cli_transport_local
 
 (** {1 Runtime-MCP policy} *)
 

--- a/lib/cascade/cascade_runner.mli
+++ b/lib/cascade/cascade_runner.mli
@@ -170,7 +170,7 @@ val provider_effective_max_turns :
 val kimi_mcp_config_json_of_policy :
   Llm_provider.Llm_transport.runtime_mcp_policy ->
   string option
-val kimi_cli_model_for_provider :
+val cli_model_for_provider_config :
   Llm_provider.Provider_config.t -> string option
 val kimi_cli_config_json_for_provider :
   Llm_provider.Provider_config.t -> string option

--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -14,7 +14,7 @@ type cli_transport_overrides =
   ; cli_subprocess_idle_sec : float option
     (* When [Some s], the CLI subprocess is aborted via SIGINT if no
      stdout line arrives within [s] seconds. Currently honoured only
-     by [Kimi_cli_transport_local], which calls
+     by [Json_stream_cli_transport_local], which calls
      [Cli_common_subprocess.run_stream_lines] directly. The other CLI
      transports (claude_code, gemini_cli, codex_cli) route through
      agent_sdk [Transport_*_cli.create] whose configs do not yet
@@ -164,7 +164,7 @@ let cli_model_override model_id =
 
 let json_of_string_pairs pairs = `Assoc (List.map (fun (k, v) -> k, `String v) pairs)
 
-let json_of_kimi_mcp_server = function
+let json_of_cli_mcp_server = function
   | Llm_provider.Llm_transport.Stdio_server { command; args; env; _ } ->
     `Assoc
       [ "command", `String command
@@ -175,7 +175,7 @@ let json_of_kimi_mcp_server = function
     `Assoc [ "url", `String url; "headers", json_of_string_pairs headers ]
 ;;
 
-let kimi_mcp_config_json_of_policy
+let cli_mcp_config_json_of_policy
       (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
   : string option
   =
@@ -200,7 +200,7 @@ let kimi_mcp_config_json_of_policy
               (List.map
                  (fun server ->
                     ( Llm_provider.Llm_transport.runtime_mcp_server_name server
-                    , json_of_kimi_mcp_server server ))
+                    , json_of_cli_mcp_server server ))
                  servers) )
         ]
     in
@@ -472,13 +472,13 @@ let runtime_mcp_policy_for_provider
   | None, _, _ -> None
 ;;
 
-let kimi_cli_runtime_mcp_jsons
+let cli_runtime_mcp_jsons
       ~(base : string list)
       (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option)
   =
   let request_json =
     match policy_opt with
-    | Some policy -> Option.to_list (kimi_mcp_config_json_of_policy policy)
+    | Some policy -> Option.to_list (cli_mcp_config_json_of_policy policy)
     | None -> []
   in
   dedupe_preserve_order (base @ request_json)
@@ -564,9 +564,8 @@ let runtime_mcp_policy_of_tool_names
           let env_token = first_nonempty_env [ "MASC_MCP_TOKEN" ] in
           (* Phase A F1: when MASC_MCP_TOKEN is unset, fall back to the
              per-keeper raw token at <base_path>/.masc/auth/<agent_name>.token.
-             This wires CLI-spawned subprocesses (codex_cli/gemini_cli/kimi_cli)
-             that callback to masc-mcp tools but do not inherit the parent
-             process env. *)
+             This wires CLI-spawned subprocesses that callback to masc-mcp tools
+             but do not inherit the parent process env. *)
           let per_keeper_token =
             match env_token, agent_name with
             | None, Some name ->
@@ -637,6 +636,25 @@ let cli_model_for_provider_config (provider_cfg : Llm_provider.Provider_config.t
   match cli_model_override provider_cfg.model_id with
   | Some explicit -> Some explicit
   | None -> Option.bind (provider_config_runtime_binding provider_cfg) runtime_binding_default_model
+;;
+
+let cli_command_for_provider_config provider_cfg =
+  Option.bind (provider_config_runtime_binding provider_cfg) (fun binding ->
+    trim_nonempty binding.Agent_sdk.Provider_runtime_binding.command)
+;;
+
+let basename_of_command command =
+  command
+  |> String.split_on_char '/'
+  |> List.rev
+  |> List.find_opt (fun segment -> String.trim segment <> "")
+  |> Option.value ~default:command
+;;
+
+let cli_process_name_for_provider_config provider_cfg =
+  cli_command_for_provider_config provider_cfg
+  |> Option.map basename_of_command
+  |> Option.value ~default:"json_stream_cli"
 ;;
 
 let nonempty_opt value =
@@ -710,7 +728,7 @@ let binding_api_base_url (binding : Agent_sdk.Provider_runtime_binding.t) =
       Some (Env_config_core.strip_trailing_slashes base_url ^ path_prefix)))
 ;;
 
-let kimi_cli_auth_value
+let cli_direct_auth_value
       ?(direct_binding = direct_binding_for_cli_provider_config)
       (provider_cfg : Llm_provider.Provider_config.t)
   =
@@ -722,7 +740,7 @@ let kimi_cli_auth_value
      | None -> None)
 ;;
 
-let kimi_cli_backing_runtime
+let cli_backing_runtime
       ?(direct_binding = direct_binding_for_cli_provider_config)
       provider_cfg
   =
@@ -732,13 +750,13 @@ let kimi_cli_backing_runtime
     | None -> None)
 ;;
 
-let kimi_cli_config_json_for_provider (provider_cfg : Llm_provider.Provider_config.t)
+let cli_runtime_config_json_for_provider (provider_cfg : Llm_provider.Provider_config.t)
   : string option
   =
   match
     ( cli_model_for_provider_config provider_cfg
-    , kimi_cli_auth_value provider_cfg
-    , kimi_cli_backing_runtime provider_cfg )
+    , cli_direct_auth_value provider_cfg
+    , cli_backing_runtime provider_cfg )
   with
   | Some model_name, Some _, Some (binding, api_base_url) ->
     let provider_name = binding.Agent_sdk.Provider_runtime_binding.id in
@@ -774,8 +792,8 @@ let kimi_cli_config_json_for_provider (provider_cfg : Llm_provider.Provider_conf
   | _ -> None
 ;;
 
-let kimi_cli_extra_env (provider_cfg : Llm_provider.Provider_config.t) =
-  match direct_binding_for_cli_provider_config provider_cfg, kimi_cli_auth_value provider_cfg with
+let cli_direct_binding_extra_env (provider_cfg : Llm_provider.Provider_config.t) =
+  match direct_binding_for_cli_provider_config provider_cfg, cli_direct_auth_value provider_cfg with
   | Some binding, Some key ->
     (match auth_env_names_of_binding binding with
      | env_name :: _ -> [ env_name, key ]
@@ -952,9 +970,10 @@ let resolve_tool_lane_for_oas_tools
       Error (invalid_runtime_config "tool_support" detail))
 ;;
 
-module Kimi_cli_transport_local = struct
+module Json_stream_cli_transport_local = struct
   type config =
-    { kimi_path : string
+    { cli_path : string
+    ; process_name : string
     ; model : string option
     ; cwd : string option
     ; config_json : string option
@@ -965,8 +984,9 @@ module Kimi_cli_transport_local = struct
     }
 
   let default_config =
-    { kimi_path = "kimi"
-    ; model = Some "kimi-for-coding"
+    { cli_path = "json-stream-cli"
+    ; process_name = "json_stream_cli"
+    ; model = None
     ; cwd = None
     ; config_json = None
     ; mcp_config_json = []
@@ -976,14 +996,14 @@ module Kimi_cli_transport_local = struct
     }
   ;;
 
-  (* Kimi CLI imports [setproctitle] on macOS before processing the
+  (* Some Python CLI launchers import [setproctitle] before processing the
      request. UTF-8 prompts in argv can make setproctitle's import-time
-     [getproctitle()] decode fail before Kimi reads the prompt, so keep
+     [getproctitle()] decode fail before the CLI reads the prompt, so keep
      non-ASCII or large prompts out of argv and stream them via stdin. *)
   let default_prompt_argv_threshold = 16 * 1024
 
   let prompt_argv_threshold () =
-    match Sys.getenv_opt "OAS_KIMI_PROMPT_ARGV_THRESHOLD" with
+    match Sys.getenv_opt "MASC_JSON_STREAM_CLI_PROMPT_ARGV_THRESHOLD" with
     | Some raw ->
       (match int_of_string_opt (String.trim raw) with
        | Some value when value >= 0 -> value
@@ -1004,10 +1024,10 @@ module Kimi_cli_transport_local = struct
     prompt_exceeds_argv_budget prompt || prompt_contains_non_ascii prompt
   ;;
 
-  let sanitize_for_kimi prompt = Inference_utils.sanitize_text_utf8 prompt
+  let sanitize_for_cli_prompt prompt = Inference_utils.sanitize_text_utf8 prompt
 
   let stdin_for_prompt prompt =
-    let prompt = sanitize_for_kimi prompt in
+    let prompt = sanitize_for_cli_prompt prompt in
     if prompt_needs_stdin prompt then Some prompt else None
   ;;
 
@@ -1024,9 +1044,9 @@ module Kimi_cli_transport_local = struct
         ~(mcp_config_json : string list)
         ~prompt
     =
-    let prompt = sanitize_for_kimi prompt in
+    let prompt = sanitize_for_cli_prompt prompt in
     let prompt_via_stdin = prompt_needs_stdin prompt in
-    let args = ref [ config.kimi_path; "--print"; "--output-format"; "stream-json" ] in
+    let args = ref [ config.cli_path; "--print"; "--output-format"; "stream-json" ] in
     let add xs = args := !args @ xs in
     (match config.config_json with
      | Some json -> add [ "--config"; json ]
@@ -1075,7 +1095,8 @@ module Kimi_cli_transport_local = struct
       match fn |> member "arguments" |> to_string_option |> json_of_argument_string with
       | Ok args -> Ok (Some (Agent_sdk.Types.ToolUse { id; name; input = args }))
       | Error msg ->
-        Error (Printf.sprintf "invalid kimi tool arguments JSON for tool %S: %s" name msg)
+        Error
+          (Printf.sprintf "invalid CLI tool arguments JSON for tool %S: %s" name msg)
     with
     | Type_error _ -> Ok None
   ;;
@@ -1149,7 +1170,7 @@ module Kimi_cli_transport_local = struct
       with
       | Yojson.Json_error _ | Type_error _ -> None
     in
-    List.find_map find_id lines |> Option.value ~default:"kimi-print"
+    List.find_map find_id lines |> Option.value ~default:"cli-json-stream"
   ;;
 
   let response_model_of_lines ~model_id lines =
@@ -1183,7 +1204,7 @@ module Kimi_cli_transport_local = struct
     | Ok [] ->
       Error
         (Llm_provider.Http_client.NetworkError
-           { message = "no messages parsed from kimi output"; kind = Unknown })
+           { message = "no messages parsed from CLI JSON-stream output"; kind = Unknown })
     | Ok content ->
       Ok
         { Agent_sdk.Types.id = response_id_of_lines lines
@@ -1249,7 +1270,8 @@ module Kimi_cli_transport_local = struct
   let starts_with text prefix = String.starts_with ~prefix text
 
   let resumable_session_detail =
-    "kimi_cli reported a resumable CLI session. Resumable session available via -r."
+    "CLI JSON-stream transport reported a resumable session. Resumable session \
+     available via -r."
   ;;
 
   let resume_hint_marker = "to resume this session:"
@@ -1266,24 +1288,42 @@ module Kimi_cli_transport_local = struct
     trimmed <> "" && not (is_resume_hint_line trimmed)
   ;;
 
-  let on_stderr_line line =
+  let on_stderr_line ~process_name line =
     if should_log_stderr_line line
-    then Llm_provider.Cli_common_subprocess.default_on_stderr_line ~name:"kimi" line
+    then
+      Llm_provider.Cli_common_subprocess.default_on_stderr_line ~name:process_name line
+  ;;
+
+  let index_of_substring text marker =
+    let marker_len = String.length marker in
+    let text_len = String.length text in
+    let rec loop idx =
+      if marker_len = 0
+      then Some idx
+      else if idx + marker_len > text_len
+      then None
+      else if String.sub text idx marker_len = marker
+      then Some idx
+      else loop (idx + 1)
+    in
+    loop 0
+  ;;
+
+  let exit_code_span_of_message message =
+    let marker = " exited with code " in
+    match index_of_substring message marker with
+    | None -> None
+    | Some marker_start ->
+      let code_start = marker_start + String.length marker in
+      (match String.index_from_opt message code_start ':' with
+       | None -> None
+       | Some colon ->
+         let raw = String.sub message code_start (colon - code_start) |> String.trim in
+         Option.map (fun code -> code, colon) (int_of_string_opt raw))
   ;;
 
   let exit_code_of_message message =
-    let prefix = "kimi exited with code " in
-    if not (starts_with message prefix)
-    then None
-    else (
-      match String.index_from_opt message (String.length prefix) ':' with
-      | None -> None
-      | Some colon ->
-        let raw =
-          String.sub message (String.length prefix) (colon - String.length prefix)
-          |> String.trim
-        in
-        int_of_string_opt raw)
+    Option.map fst (exit_code_span_of_message message)
   ;;
 
   let exit_code_marker_of_text text =
@@ -1309,16 +1349,12 @@ module Kimi_cli_transport_local = struct
   ;;
 
   let exit_payload_of_message message =
-    let prefix = "kimi exited with code " in
-    if not (starts_with message prefix)
-    then None
-    else (
-      match String.index_from_opt message (String.length prefix) ':' with
-      | None -> None
-      | Some colon ->
-        Some
-          (String.sub message (colon + 1) (String.length message - colon - 1)
-           |> String.trim))
+    match exit_code_span_of_message message with
+    | None -> None
+    | Some (_, colon) ->
+      Some
+        (String.sub message (colon + 1) (String.length message - colon - 1)
+         |> String.trim)
   ;;
 
   let payload_has_only_resume_hint payload =
@@ -1359,8 +1395,8 @@ module Kimi_cli_transport_local = struct
       with
       | Some code ->
         Printf.sprintf
-          "kimi_cli reported a resumable CLI session (exit %d). Resumable session \
-           available via -r."
+          "CLI JSON-stream transport reported a resumable session (exit %d). \
+           Resumable session available via -r."
           code
       | None -> resumable_session_detail)
     else String.trim text
@@ -1391,7 +1427,7 @@ module Kimi_cli_transport_local = struct
         Error
           (Llm_provider.Http_client.AcceptRejected
              { reason =
-                 "kimi_cli startup crash while setting process title \
+                 "provider CLI startup crash while setting process title \
                   (UnicodeDecodeError). This is a local CLI/runtime failure, not keeper \
                   auth or sandbox failure; rejecting without retry so the cascade can \
                   move on. "
@@ -1403,7 +1439,7 @@ module Kimi_cli_transport_local = struct
           Error
             (Llm_provider.Http_client.AcceptRejected
                { reason =
-                   "kimi_cli rejected the request (exit 1). "
+                   "provider CLI rejected the request (exit 1). "
                    ^ "This is usually a permanent auth/config/model error rather "
                    ^ "than a transient transport failure. "
                    ^ message
@@ -1422,7 +1458,7 @@ module Kimi_cli_transport_local = struct
     else (
       warned := true;
       Log.Misc.warn
-        "kimi_cli print mode ignores OAS req.tools. Provider-native built-in tools and \
+        "CLI JSON-stream print mode ignores OAS req.tools. Provider-native built-in tools and \
          configured MCP servers remain available; external OAS tool callbacks require a \
          future wire-mode transport.")
   ;;
@@ -1449,14 +1485,14 @@ module Kimi_cli_transport_local = struct
               ~prompt
               ~system_prompt
           in
-          let prompt = sanitize_for_kimi prompt in
+          let prompt = sanitize_for_cli_prompt prompt in
           let model_id =
-            Option.value
-              ~default:"kimi-for-coding"
-              (cli_model_override ~config ~req_config:req.config)
+            match cli_model_override ~config ~req_config:req.config with
+            | Some model -> model
+            | None -> req.config.model_id
           in
           let mcp_config_json =
-            kimi_cli_runtime_mcp_jsons ~base:config.mcp_config_json req.runtime_mcp_policy
+            cli_runtime_mcp_jsons ~base:config.mcp_config_json req.runtime_mcp_policy
           in
           let argv = build_args ~config ~req_config:req.config ~mcp_config_json ~prompt in
           let seen_lines = ref [] in
@@ -1479,10 +1515,10 @@ module Kimi_cli_transport_local = struct
                 ~mgr
                 ?clock:clock_opt
                 ?stdout_idle_timeout_s
-                ~name:"kimi"
+                ~name:config.process_name
                 ~cwd:config.cwd
                 ~extra_env:config.extra_env
-                ~on_stderr_line
+                ~on_stderr_line:(on_stderr_line ~process_name:config.process_name)
                 ?stdin_content:(stdin_for_prompt prompt)
                 ~on_line
                 ?cancel:config.cancel
@@ -1518,14 +1554,14 @@ module Kimi_cli_transport_local = struct
               ~prompt
               ~system_prompt
           in
-          let prompt = sanitize_for_kimi prompt in
+          let prompt = sanitize_for_cli_prompt prompt in
           let model_id =
-            Option.value
-              ~default:"kimi-for-coding"
-              (cli_model_override ~config ~req_config:req.config)
+            match cli_model_override ~config ~req_config:req.config with
+            | Some model -> model
+            | None -> req.config.model_id
           in
           let mcp_config_json =
-            kimi_cli_runtime_mcp_jsons ~base:config.mcp_config_json req.runtime_mcp_policy
+            cli_runtime_mcp_jsons ~base:config.mcp_config_json req.runtime_mcp_policy
           in
           let argv = build_args ~config ~req_config:req.config ~mcp_config_json ~prompt in
           let seen_lines = ref [] in
@@ -1538,7 +1574,7 @@ module Kimi_cli_transport_local = struct
               started := true;
               on_event
                 (Agent_sdk.Types.MessageStart
-                   { id = "kimi-print"; model = model_id; usage = None }))
+                   { id = "cli-json-stream"; model = model_id; usage = None }))
           in
           let on_line line =
             match !parse_error with
@@ -1571,10 +1607,10 @@ module Kimi_cli_transport_local = struct
                  ~mgr
                  ?clock:clock_opt
                  ?stdout_idle_timeout_s
-                 ~name:"kimi"
+                 ~name:config.process_name
                  ~cwd:config.cwd
                  ~extra_env:config.extra_env
-                 ~on_stderr_line
+                 ~on_stderr_line:(on_stderr_line ~process_name:config.process_name)
                  ?stdin_content:(stdin_for_prompt prompt)
                  ~on_line
                  ?cancel:config.cancel
@@ -1766,7 +1802,7 @@ let gemini_cli_transport_ctor
       Llm_provider.Transport_gemini_cli.create ~sw ~mgr ~config))
 ;;
 
-let kimi_cli_transport_ctor
+let json_stream_cli_transport_ctor
       ~(provider_cfg : Llm_provider.Provider_config.t)
       ~runtime_mcp_policy
       ~cli_transport_overrides
@@ -1776,13 +1812,20 @@ let kimi_cli_transport_ctor
     Option.bind cli_transport_overrides (fun overrides ->
       overrides.cli_subprocess_idle_sec)
   in
-  let mcp_config_json = kimi_cli_runtime_mcp_jsons ~base:[] runtime_mcp_policy in
+  let mcp_config_json = cli_runtime_mcp_jsons ~base:[] runtime_mcp_policy in
   let model = cli_model_for_provider_config provider_cfg in
-  let config_json = kimi_cli_config_json_for_provider provider_cfg in
-  let extra_env = kimi_cli_extra_env provider_cfg in
+  let config_json = cli_runtime_config_json_for_provider provider_cfg in
+  let extra_env = cli_direct_binding_extra_env provider_cfg in
+  let cli_path =
+    cli_command_for_provider_config provider_cfg
+    |> Option.value ~default:Json_stream_cli_transport_local.default_config.cli_path
+  in
+  let process_name = cli_process_name_for_provider_config provider_cfg in
   let config =
-    { Kimi_cli_transport_local.default_config with
-      model
+    { Json_stream_cli_transport_local.default_config with
+      cli_path
+    ; process_name
+    ; model
     ; cwd
     ; config_json
     ; mcp_config_json
@@ -1792,7 +1835,7 @@ let kimi_cli_transport_ctor
   in
   with_proc_mgr (fun ~mgr ->
     make_per_call_switch_transport (fun ~sw ->
-      Kimi_cli_transport_local.create ~sw ~mgr ~config))
+      Json_stream_cli_transport_local.create ~sw ~mgr ~config))
 ;;
 
 let codex_cli_transport_ctor
@@ -1819,7 +1862,7 @@ let () =
     ~ctor:gemini_cli_transport_ctor;
   register_non_http_transport
     ~kind:Llm_provider.Provider_config.Kimi_cli
-    ~ctor:kimi_cli_transport_ctor;
+    ~ctor:json_stream_cli_transport_ctor;
   register_non_http_transport
     ~kind:Llm_provider.Provider_config.Codex_cli
     ~ctor:codex_cli_transport_ctor
@@ -1843,9 +1886,8 @@ let non_http_transport_of_provider
     (* Fail-fast for subprocess CLI kinds that have no registered ctor:
        falling through to [Ok None] would route the request to the HTTP
        lane, which cannot serve a CLI provider. HTTP-shaped providers
-       (Anthropic / OpenAI_compat / Ollama / Gemini / Glm / Kimi /
-       DashScope) correctly return [Ok None]; they live behind a
-       different transport selector upstream. *)
+       correctly return [Ok None]; they live behind a different transport
+       selector upstream. *)
     if Llm_provider.Provider_config.is_subprocess_cli provider_cfg.kind
     then
       Error

--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -207,12 +207,6 @@ let kimi_mcp_config_json_of_policy
     Some (Yojson.Safe.to_string config_json)
 ;;
 
-let kimi_cli_model_for_provider (provider_cfg : Llm_provider.Provider_config.t) =
-  match cli_model_override provider_cfg.model_id with
-  | Some explicit -> Some explicit
-  | None -> Llm_provider.Transport_kimi_cli.default_config.model
-;;
-
 let provider_caps_of_config = Provider_tool_support.oas_capabilities_of_config
 let provider_supports_inline_tools = Provider_tool_support.provider_supports_inline_tools
 
@@ -626,29 +620,133 @@ let provider_label (provider_cfg : Llm_provider.Provider_config.t) =
     provider_cfg.model_id
 ;;
 
-let kimi_cli_auth_value (provider_cfg : Llm_provider.Provider_config.t) =
+let provider_config_runtime_binding (provider_cfg : Llm_provider.Provider_config.t) =
+  Agent_sdk.Provider_runtime_binding.binding_for_provider_config provider_cfg
+;;
+
+let runtime_binding_default_model (binding : Agent_sdk.Provider_runtime_binding.t) =
+  match trim_nonempty binding.default_model with
+  | Some model -> Some model
+  | None ->
+    (match binding.capabilities.supported_models with
+     | Some (model :: _) -> trim_nonempty (Some model)
+     | Some [] | None -> None)
+;;
+
+let cli_model_for_provider_config (provider_cfg : Llm_provider.Provider_config.t) =
+  match cli_model_override provider_cfg.model_id with
+  | Some explicit -> Some explicit
+  | None -> Option.bind (provider_config_runtime_binding provider_cfg) runtime_binding_default_model
+;;
+
+let nonempty_opt value =
+  match value with
+  | Some value -> trim_nonempty (Some value)
+  | None -> None
+;;
+
+let direct_binding_candidates_for_cli_binding
+      (binding : Agent_sdk.Provider_runtime_binding.t)
+  =
+  [ binding.credential_scope; binding.command ]
+  |> List.filter_map nonempty_opt
+  |> dedupe_preserve_order
+;;
+
+let binding_is_direct_runtime (binding : Agent_sdk.Provider_runtime_binding.t) =
+  match binding.transport with
+  | Agent_sdk.Provider_runtime_binding.Http
+  | Agent_sdk.Provider_runtime_binding.Managed
+  | Agent_sdk.Provider_runtime_binding.Custom_openai_compat -> true
+  | Agent_sdk.Provider_runtime_binding.Cli -> false
+;;
+
+let direct_binding_for_cli_provider_config provider_cfg =
+  match provider_config_runtime_binding provider_cfg with
+  | None -> None
+  | Some binding ->
+    direct_binding_candidates_for_cli_binding binding
+    |> List.find_map (fun label ->
+      match Agent_sdk.Provider_runtime_binding.find label with
+      | Some direct when binding_is_direct_runtime direct -> Some direct
+      | Some _ | None -> None)
+;;
+
+let auth_env_names_of_binding (binding : Agent_sdk.Provider_runtime_binding.t) =
+  let auth_env =
+    match binding.auth with
+    | Agent_sdk.Provider_runtime_binding.Api_key_env env
+    | Agent_sdk.Provider_runtime_binding.Setup_token_env env -> [ env ]
+    | Agent_sdk.Provider_runtime_binding.No_auth
+    | Agent_sdk.Provider_runtime_binding.Cli_cached_login
+    | Agent_sdk.Provider_runtime_binding.Oauth_cached_login
+    | Agent_sdk.Provider_runtime_binding.File _
+    | Agent_sdk.Provider_runtime_binding.Exec _ -> []
+  in
+  binding.api_key_env :: auth_env
+  |> List.filter_map (fun env -> trim_nonempty (Some env))
+  |> dedupe_preserve_order
+;;
+
+let binding_api_base_url (binding : Agent_sdk.Provider_runtime_binding.t) =
+  let base_url = String.trim binding.base_url in
+  if String.equal base_url ""
+  then None
+  else (
+    let request_path = String.trim binding.request_path in
+    if String.equal request_path ""
+    then Some base_url
+    else (
+      let request_path =
+        if String.starts_with ~prefix:"/" request_path
+        then request_path
+        else "/" ^ request_path
+      in
+      let path_prefix =
+        match String.rindex_opt request_path '/' with
+        | Some 0 | None -> ""
+        | Some idx -> String.sub request_path 0 idx
+      in
+      Some (Env_config_core.strip_trailing_slashes base_url ^ path_prefix)))
+;;
+
+let kimi_cli_auth_value
+      ?(direct_binding = direct_binding_for_cli_provider_config)
+      (provider_cfg : Llm_provider.Provider_config.t)
+  =
   match trim_nonempty (Some provider_cfg.api_key) with
   | Some key -> Some key
   | None ->
-    first_nonempty_env
-      (Llm_provider.Provider_config.default_api_key_env
-         Llm_provider.Provider_config.Kimi
-       |> Option.to_list)
+    (match direct_binding provider_cfg with
+     | Some binding -> first_nonempty_env (auth_env_names_of_binding binding)
+     | None -> None)
 ;;
 
-let kimi_cli_base_url () =
-  match Sys.getenv_opt "KIMI_BASE_URL" |> trim_nonempty with
-  | Some url -> url
-  | None -> "https://api.kimi.com/coding/v1"
+let kimi_cli_backing_runtime
+      ?(direct_binding = direct_binding_for_cli_provider_config)
+      provider_cfg
+  =
+  Option.bind (direct_binding provider_cfg) (fun binding ->
+    match binding_api_base_url binding with
+    | Some api_base_url -> Some (binding, api_base_url)
+    | None -> None)
 ;;
 
 let kimi_cli_config_json_for_provider (provider_cfg : Llm_provider.Provider_config.t)
   : string option
   =
-  match kimi_cli_model_for_provider provider_cfg, kimi_cli_auth_value provider_cfg with
-  | Some model_name, Some _ ->
-    let provider_name = "masc-kimi" in
-    let max_context_size = Cascade_config.resolve_kimi_max_context model_name in
+  match
+    ( cli_model_for_provider_config provider_cfg
+    , kimi_cli_auth_value provider_cfg
+    , kimi_cli_backing_runtime provider_cfg )
+  with
+  | Some model_name, Some _, Some (binding, api_base_url) ->
+    let provider_name = binding.Agent_sdk.Provider_runtime_binding.id in
+    let max_context_size =
+      Cascade_config.resolve_provider_model_max_context
+        ~provider_name
+        model_name
+    in
     let config_json =
       `Assoc
         [ "default_model", `String model_name
@@ -656,8 +754,8 @@ let kimi_cli_config_json_for_provider (provider_cfg : Llm_provider.Provider_conf
           , `Assoc
               [ ( provider_name
                 , `Assoc
-                    [ "type", `String "kimi"
-                    ; "base_url", `String (kimi_cli_base_url ())
+                    [ "type", `String provider_name
+                    ; "base_url", `String api_base_url
                     ; "api_key", `String ""
                     ] )
               ] )
@@ -677,9 +775,12 @@ let kimi_cli_config_json_for_provider (provider_cfg : Llm_provider.Provider_conf
 ;;
 
 let kimi_cli_extra_env (provider_cfg : Llm_provider.Provider_config.t) =
-  match kimi_cli_auth_value provider_cfg with
-  | Some key -> [ "KIMI_API_KEY", key ]
-  | None -> []
+  match direct_binding_for_cli_provider_config provider_cfg, kimi_cli_auth_value provider_cfg with
+  | Some binding, Some key ->
+    (match auth_env_names_of_binding binding with
+     | env_name :: _ -> [ env_name, key ]
+     | [] -> [])
+  | _ -> []
 ;;
 
 let resolve_tool_lane_for_oas_tools
@@ -1676,7 +1777,7 @@ let kimi_cli_transport_ctor
       overrides.cli_subprocess_idle_sec)
   in
   let mcp_config_json = kimi_cli_runtime_mcp_jsons ~base:[] runtime_mcp_policy in
-  let model = kimi_cli_model_for_provider provider_cfg in
+  let model = cli_model_for_provider_config provider_cfg in
   let config_json = kimi_cli_config_json_for_provider provider_cfg in
   let extra_env = kimi_cli_extra_env provider_cfg in
   let config =

--- a/lib/cascade/cascade_transport.mli
+++ b/lib/cascade/cascade_transport.mli
@@ -17,7 +17,7 @@ type cli_transport_overrides = {
   cli_subprocess_idle_sec : float option;
       (** When [Some s], the CLI subprocess is aborted via SIGINT if no
           stdout line arrives within [s] seconds.  Currently honoured
-          only by [Kimi_cli_transport_local], which calls
+          only by [Json_stream_cli_transport_local], which calls
           [Cli_common_subprocess.run_stream_lines] directly.  Other CLI
           transports route through agent_sdk [Transport_*_cli.create]
           configs that do not yet expose [stdout_idle_timeout_s]; an
@@ -103,10 +103,10 @@ val provider_supports_inline_tools : Llm_provider.Provider_config.t -> bool
 val provider_supports_runtime_mcp_lane :
   Llm_provider.Provider_config.t -> bool
 
-(** Render the [mcpServers] config JSON consumed by [kimi_cli], filtering
+(** Render the [mcpServers] config JSON consumed by JSON-stream CLI transports, filtering
     by [policy.allowed_server_names].  Returns [None] when no allowed
     server remains after filtering. *)
-val kimi_mcp_config_json_of_policy :
+val cli_mcp_config_json_of_policy :
   Llm_provider.Llm_transport.runtime_mcp_policy -> string option
 
 (** Resolve a CLI provider model name from explicit provider config first,
@@ -115,10 +115,10 @@ val kimi_mcp_config_json_of_policy :
 val cli_model_for_provider_config :
   Llm_provider.Provider_config.t -> string option
 
-(** Render the kimi_cli root config JSON (default_model + providers + models)
-    for a provider.  Returns [None] when either the model resolution or the
-    auth value resolution fails. *)
-val kimi_cli_config_json_for_provider :
+(** Render root config JSON (default_model + providers + models) for a
+    JSON-stream CLI provider.  Returns [None] when either the model
+    resolution or the auth value resolution fails. *)
+val cli_runtime_config_json_for_provider :
   Llm_provider.Provider_config.t -> string option
 
 (** Drop duplicates from a list while preserving the first-seen order. *)
@@ -175,9 +175,9 @@ val runtime_mcp_policy_for_provider :
   Llm_provider.Llm_transport.runtime_mcp_policy option ->
   Llm_provider.Llm_transport.runtime_mcp_policy option
 
-(** Compose the kimi_cli [--mcp-config] arguments from a [base] list and an
-    optional runtime MCP policy.  Output is deduped, preserving order. *)
-val kimi_cli_runtime_mcp_jsons :
+(** Compose JSON-stream CLI [--mcp-config] arguments from a [base] list and
+    an optional runtime MCP policy.  Output is deduped, preserving order. *)
+val cli_runtime_mcp_jsons :
   base:string list ->
   Llm_provider.Llm_transport.runtime_mcp_policy option ->
   string list
@@ -234,10 +234,9 @@ val make_per_call_switch_transport :
   (sw:Eio.Switch.t -> Llm_provider.Llm_transport.t) ->
   Llm_provider.Llm_transport.t
 
-(** Construct a non-HTTP CLI transport for [provider_cfg] (Claude_code,
-    Gemini_cli, Kimi_cli, Codex_cli).  Returns [Ok None] for HTTP-only
-    providers (Anthropic, OpenAI_compat, Ollama, Gemini, Glm, Kimi,
-    DashScope).  Returns [Error] when the process manager is not initialized. *)
+(** Construct a non-HTTP CLI transport for [provider_cfg].  Returns [Ok None]
+    for HTTP-shaped providers.  Returns [Error] when the process manager is not
+    initialized. *)
 val non_http_transport_of_provider :
   sw:Eio.Switch.t ->
   provider_cfg:Llm_provider.Provider_config.t ->
@@ -246,11 +245,12 @@ val non_http_transport_of_provider :
   unit ->
   (Llm_provider.Llm_transport.t option, Agent_sdk.Error.sdk_error) result
 
-(** kimi_cli print-mode transport.  Owned by the transport layer; runner
-    facades must not re-export this provider-local surface. *)
-module Kimi_cli_transport_local : sig
+(** JSON-stream print-mode CLI transport.  Owned by the transport layer;
+    runner facades must not re-export this protocol-local surface. *)
+module Json_stream_cli_transport_local : sig
   type config = {
-    kimi_path : string;
+    cli_path : string;
+    process_name : string;
     model : string option;
     cwd : string option;
     config_json : string option;
@@ -258,7 +258,7 @@ module Kimi_cli_transport_local : sig
     extra_env : (string * string) list;
     cancel : unit Eio.Promise.t option;
     stdout_idle_timeout_s : float option;
-        (** When [Some s], the kimi subprocess is aborted via SIGINT if no
+        (** When [Some s], the CLI subprocess is aborted via SIGINT if no
             stdout line arrives within [s] seconds.  Forwarded to
             [Llm_provider.Cli_common_subprocess.run_stream_lines] together
             with the process clock obtained from [Process_eio.get_clock].
@@ -268,9 +268,9 @@ module Kimi_cli_transport_local : sig
 
   val default_config : config
 
-  (** Build the kimi_cli argv from a config + per-call request, deciding
+  (** Build the CLI argv from a config + per-call request, deciding
       whether the prompt goes via [-p] or stdin. Non-ASCII or large prompts
-      use stdin to avoid Kimi CLI macOS setproctitle UTF-8 decode crashes. *)
+      use stdin to avoid Python CLI setproctitle UTF-8 decode crashes. *)
   val build_args :
     config:config ->
     req_config:Llm_provider.Provider_config.t ->
@@ -278,15 +278,15 @@ module Kimi_cli_transport_local : sig
     prompt:string ->
     string list
 
-  (** Whether a kimi_cli stderr line should be forwarded to the default
+  (** Whether a CLI stderr line should be forwarded to the default
       stderr logger.  Drops the [resume hint] lines, which are noise. *)
   val should_log_stderr_line : string -> bool
 
-  (** Constant detail string used when [kimi_cli] reports a resumable session
+  (** Constant detail string used when the CLI reports a resumable session
       without an embedded exit code. *)
   val resumable_session_detail : string
 
-  (** Whether [text] looks like a resumable-session report from kimi_cli. *)
+  (** Whether [text] looks like a resumable-session report from the CLI. *)
   val text_looks_like_resumable_session : string -> bool
 
   (** Render the resumable-session detail message for [text].  Includes the
@@ -299,7 +299,7 @@ module Kimi_cli_transport_local : sig
       carries the resume hint. *)
   val resumable_session_exit_code_of_text : string -> int option
 
-  (** Reclassify a [NetworkError] from kimi_cli into [AcceptRejected] when
+  (** Reclassify a [NetworkError] from the CLI into [AcceptRejected] when
       the message indicates a permanent per-provider error
       (auth/config/model), a local CLI startup crash, or a resumable-session
       report.  Other variants pass through. *)
@@ -307,8 +307,8 @@ module Kimi_cli_transport_local : sig
     ('a, Llm_provider.Http_client.http_error) result ->
     ('a, Llm_provider.Http_client.http_error) result
 
-  (** Create a kimi_cli completion transport bound to [sw].  The transport
-      runs [kimi --print --output-format stream-json ...] via [mgr] and
+  (** Create a JSON-stream CLI completion transport bound to [sw].  The transport
+      runs [<cli> --print --output-format stream-json ...] via [mgr] and
       parses JSONL output into OAS response/event blocks. *)
   val create :
     sw:Eio.Switch.t ->

--- a/lib/cascade/cascade_transport.mli
+++ b/lib/cascade/cascade_transport.mli
@@ -109,10 +109,10 @@ val provider_supports_runtime_mcp_lane :
 val kimi_mcp_config_json_of_policy :
   Llm_provider.Llm_transport.runtime_mcp_policy -> string option
 
-(** Resolve the kimi_cli model name for a provider, falling back to
-    [Transport_kimi_cli.default_config.model] when the provider's
-    [model_id] is [auto] or empty. *)
-val kimi_cli_model_for_provider :
+(** Resolve a CLI provider model name from explicit provider config first,
+    then from the OAS runtime binding default/supported-model projection.
+    Returns [None] when the CLI binding does not publish a default. *)
+val cli_model_for_provider_config :
   Llm_provider.Provider_config.t -> string option
 
 (** Render the kimi_cli root config JSON (default_model + providers + models)

--- a/lib/cascade/cascade_transport.mli
+++ b/lib/cascade/cascade_transport.mli
@@ -246,8 +246,8 @@ val non_http_transport_of_provider :
   unit ->
   (Llm_provider.Llm_transport.t option, Agent_sdk.Error.sdk_error) result
 
-(** kimi_cli print-mode transport.  Re-exported via [module type of] from
-    {!Cascade_runner.Kimi_cli_transport_local}. *)
+(** kimi_cli print-mode transport.  Owned by the transport layer; runner
+    facades must not re-export this provider-local surface. *)
 module Kimi_cli_transport_local : sig
   type config = {
     kimi_path : string;

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -20,10 +20,6 @@ module Float = Stdlib.Float
 module CC = Cascade_config
 module Health = Cascade_health_tracker
 module StringSet = Set.Make (String)
-let ollama_provider_name =
-  Llm_provider.Provider_config.string_of_provider_kind
-    Llm_provider.Provider_config.Ollama
-;;
 
 (* ── Shared helpers ─────────────────────────────────── *)
 
@@ -34,36 +30,13 @@ let json_string_option = function
   | None -> `Null
 ;;
 
-let is_ollama_cloud_profile profile_name =
-  String.starts_with ~prefix:"tier.ollama_cloud" profile_name
-  || String.starts_with ~prefix:(ollama_provider_name ^ "_cloud") profile_name
-;;
-
-let is_ollama_cloud_candidate ~profile_name (c : CC.candidate_info) =
-  is_ollama_cloud_profile profile_name
-  ||
-  match c.provider_name with
-  | Some provider_name ->
-    String.equal provider_name ollama_provider_name
-    && (String.ends_with ~suffix:":cloud" c.model_string
-        || List.exists
-             (fun model -> String.ends_with ~suffix:":cloud" model)
-             c.expanded_models)
-  | None -> false
-;;
-
-let candidate_to_json ~profile_name (c : CC.candidate_info) : Yojson.Safe.t =
-  let provider_name, display_provider_name, runtime_kind =
-    if is_ollama_cloud_candidate ~profile_name c
-    then Some (ollama_provider_name ^ "_cloud"), Some "Ollama Cloud", Some "direct_api"
-    else c.provider_name, c.display_provider_name, c.runtime_kind
-  in
+let candidate_to_json (c : CC.candidate_info) : Yojson.Safe.t =
   `Assoc
     [ "model", `String c.model_string
     ; "display_model", `String c.display_model_string
-    ; "provider_name", json_string_option provider_name
-    ; "display_provider_name", json_string_option display_provider_name
-    ; "runtime_kind", json_string_option runtime_kind
+    ; "provider_name", json_string_option c.provider_name
+    ; "display_provider_name", json_string_option c.display_provider_name
+    ; "runtime_kind", json_string_option c.runtime_kind
     ; "expanded_models", `List (List.map (fun value -> `String value) c.expanded_models)
     ; "config_weight", `Int c.config_weight
     ; "effective_weight", `Int c.effective_weight
@@ -216,7 +189,7 @@ let profile_json_of_trace ~keeper_assignable name (trace : CC.selection_trace) =
     [ "name", `String name
     ; "source", `String (source_to_string trace.source)
     ; "keeper_assignable", `Bool keeper_assignable
-    ; "candidates", `List (List.map (candidate_to_json ~profile_name:name) trace.candidates)
+    ; "candidates", `List (List.map candidate_to_json trace.candidates)
     ]
 ;;
 
@@ -944,19 +917,15 @@ let health_json ?(window_minutes = 30) ?(base_path : string option) () =
 
 (* ── Client capacity projection ─────────────────────── *)
 
-(** Classify a capacity registry key for the dashboard.  Both sentinel
-    predicates come from {!Masc_network_defaults}: CLI transports via
-    {!Masc_network_defaults.is_cli_sentinel_url} (matches the [cli:]
-    prefix) and ollama endpoints via
-    {!Masc_network_defaults.is_ollama_url} (matches the well-known
-    port).  Everything else is reported as [other] so operators can
-    spot surprise registrations (e.g. a manually-registered HTTP
-    slot). *)
+(** Classify a capacity registry key for the dashboard. CLI transports keep
+    their sentinel label; HTTP endpoints are labelled by registered probe
+    capability instead of by provider brand or default port. Everything else is
+    [other], so operators can spot surprise registrations. *)
 let classify_capacity_key url =
   if Masc_network_defaults.is_cli_sentinel_url url
   then "cli"
-  else if Masc_network_defaults.is_ollama_url url
-  then "ollama"
+  else if Cascade_capacity_probe.can_probe ~url
+  then "http_probe"
   else "other"
 ;;
 

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -297,7 +297,7 @@ val provider_scheme_of_model_string : string -> string
 val declared_provider_schemes_of_config : ?config_path:string -> unit -> string list
 
 (** JSON snapshot of the {!Cascade_client_capacity} registry —
-    the per-URL/sentinel slot table used for ollama HTTP and CLI
+    the per-URL/sentinel slot table used for registered HTTP probes and CLI
     subprocess throttling.
 
     Shape:
@@ -311,7 +311,7 @@ val declared_provider_schemes_of_config : ?config_path:string -> unit -> string 
             "active": 0,
             "available": 1 },
           { "key": "http://127.0.0.1:11434",
-            "kind": "ollama",
+            "kind": "http_probe",
             "total": 1,
             "active": 1,
             "available": 0 },
@@ -322,8 +322,8 @@ val declared_provider_schemes_of_config : ?config_path:string -> unit -> string 
 
     Entries are sorted by [(kind, key)] for stable rendering.
     The [kind] field is the dashboard's classification:
-    [cli] for [cli:*] sentinels, [ollama] for keys containing
-    [:11434], [other] for any manually-registered slot.
+    [cli] for [cli:*] sentinels, [http_probe] for registered probe URLs,
+    [other] for any manually-registered slot.
 
     @since 0.9.9 *)
 val client_capacity_json : unit -> Yojson.Safe.t
@@ -362,7 +362,7 @@ val client_capacity_json : unit -> Yojson.Safe.t
 
     @param limit   max events returned (default 100).
     @param kind    dashboard classification filter: one of
-           ["cli"], ["ollama"], ["other"].  Unknown filters return
+           ["cli"], ["http_probe"], ["other"].  Unknown filters return
            an empty event list; omitting returns every kind.
     @param since_ts  keep only events with [ts >= since_ts].
 

--- a/lib/keeper/keeper_cli_mcp_config.ml
+++ b/lib/keeper/keeper_cli_mcp_config.ml
@@ -1,9 +1,9 @@
-(* #10049: auto-construct Claude Code / Kimi CLI MCP config JSON for
-   keepers whose cascade includes those CLI providers but whose env
+(* #10049: auto-construct CLI MCP config JSON for keepers whose cascade
+   includes CLI providers but whose env
    (OAS_CLAUDE_MCP_CONFIG) is unset.
 
-   Without this fallback, Claude Code / Kimi CLI launches with no
-   [mcpServers] entry and the keeper cannot reach the masc-mcp HTTP
+   Without this fallback, affected CLI providers launch with no [mcpServers]
+   entry and the keeper cannot reach the masc-mcp HTTP
    endpoint; tool calls surface as "keeper_shell not in session's tool
    registry". See #10049 for the full root-cause analysis and the
    codex_cli sibling path in [server_runtime_bootstrap.sync_codex_mcp_config].

--- a/lib/keeper/keeper_cli_mcp_config.mli
+++ b/lib/keeper/keeper_cli_mcp_config.mli
@@ -1,5 +1,5 @@
-(* #10049: auto-construct Claude Code / Kimi CLI MCP config JSON when
-   OAS_CLAUDE_MCP_CONFIG env is unset. Gated behind
+(* #10049: auto-construct CLI MCP config JSON when OAS_CLAUDE_MCP_CONFIG env is
+   unset. Gated behind
    MASC_AUTO_CONSTRUCT_CLAUDE_MCP (default true since #10059 validation;
    set to "false" to opt out). *)
 

--- a/lib/keeper/keeper_runtime_resolved.mli
+++ b/lib/keeper/keeper_runtime_resolved.mli
@@ -54,7 +54,7 @@ val stream_idle_timeout_for_total_timeout : total_timeout_s:float -> float
 
 (** CLI subprocess stdout-idle timeout, read fresh per turn from
     [MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC] and clamped to [10, 600].
-    Default 120 s. Honoured by [Kimi_cli_transport_local]; other CLI
+    Default 120 s. Honoured by [Json_stream_cli_transport_local]; other CLI
     transports require an OAS upstream change to expose
     [stdout_idle_timeout_s]. *)
 val cli_subprocess_idle_sec : unit -> float

--- a/scripts/audit-hardcoding-truth.sh
+++ b/scripts/audit-hardcoding-truth.sh
@@ -90,10 +90,12 @@ print_matches \
   lib/keeper/keeper_agent_run.ml \
   'tool_required_affordances|String\.starts_with|String\.equal[[:space:]]+[a-zA-Z_]+[[:space:]]+"(keeper|masc)_[^"]+"|List\.mem[[:space:]]+[a-zA-Z_]+[[:space:]]+turn_affordances'
 
-print_matches \
-  "provider adapter still has model-label/provider heuristics" \
-  lib/provider_adapter.ml \
-  'prefix_classification_vocabulary|bare_heuristic|is_kimi_model_id|is_moonshot_base_url|String\.starts_with|List\.mem[[:space:]]+provider[[:space:]]+\['
+if [ -e lib/provider_adapter.ml ] || [ -e lib/provider_adapter.mli ]; then
+  mark_confirmed "legacy Provider_adapter implementation files still exist"
+  ls -1 lib/provider_adapter.ml lib/provider_adapter.mli 2>/dev/null || true
+else
+  echo "PASS: legacy Provider_adapter implementation files are absent."
+fi
 
 section "Anti-Fake Detector"
 anti_fake_output=""

--- a/scripts/lint/exhaustive-guard.allowlist
+++ b/scripts/lint/exhaustive-guard.allowlist
@@ -731,7 +731,6 @@ lib/process/exec_tap.ml:171
 lib/process/process_eio.ml:113
 lib/process/process_eio.ml:809
 lib/prompt_registry/prompt_registry.ml:276
-lib/provider_adapter.ml:1251
 lib/provider_kind_resolver.ml:40
 lib/repo_manager/credential_materializer.ml:52
 lib/repo_manager/keeper_repo_mapping.ml:428

--- a/scripts/lint/no-roadmap-stale-hardcoding.allowlist
+++ b/scripts/lint/no-roadmap-stale-hardcoding.allowlist
@@ -6,20 +6,10 @@
 #
 # Baseline (2026-05-05, HEAD 5806519c0b): the audit at
 # docs/audit/2026-05-05-fundamental-roadmap-reality-check.md found that
-# `lib/cascade/capabilities.ml` was deleted but its model lists migrated
-# into lib/provider_adapter.ml (1,623 lines). The model-name literals
-# below are grandfathered as existing tech debt, NOT endorsed. The
-# cleanup is queued for Sprint 2 (oas backend dispatch separation) /
-# Sprint 3 follow-up of joyful-tumbling-dragon.md and tracked as gap #6.
+# `lib/cascade/capabilities.ml` was deleted but model lists had migrated
+# into the now-removed provider adapter. Keep this allowlist narrow: stale
+# entries for deleted implementation files must be removed instead of
+# grandfathered.
 
 # Documentation example in interface comment (legitimate)
 lib/keeper/keeper_hooks_oas.mli:22
-
-# lib/provider_adapter.ml model list — gap #6, queued for Sprint 2/3
-lib/provider_adapter.ml:382
-lib/provider_adapter.ml:383
-lib/provider_adapter.ml:384
-lib/provider_adapter.ml:385
-lib/provider_adapter.ml:386
-lib/provider_adapter.ml:387
-lib/provider_adapter.ml:407

--- a/scripts/smoke/cascade-cli-throttle.sh
+++ b/scripts/smoke/cascade-cli-throttle.sh
@@ -70,10 +70,10 @@ pass "response schema looks correct"
 
 # ── 4. Categorise entries ─────────────────────────────────────────
 cli_count="$(echo "$snap" | jq '[.entries[] | select(.kind == "cli")] | length')"
-ollama_count="$(echo "$snap" | jq '[.entries[] | select(.kind == "ollama")] | length')"
+http_probe_count="$(echo "$snap" | jq '[.entries[] | select(.kind == "http_probe")] | length')"
 other_count="$(echo "$snap" | jq '[.entries[] | select(.kind == "other")] | length')"
 
-say "by kind: cli=$cli_count ollama=$ollama_count other=$other_count"
+say "by kind: cli=$cli_count http_probe=$http_probe_count other=$other_count"
 
 if [ "$entry_count" -eq 0 ]; then
   say ""
@@ -117,14 +117,14 @@ if [ "$cli_count" -gt 0 ]; then
   echo "$snap" | jq -r '.entries[] | select(.kind == "cli") |
     "  \(.key)  total=\(.total) active=\(.active) available=\(.available)"' >&2
 fi
-if [ "$ollama_count" -gt 0 ]; then
-  echo "$snap" | jq -r '.entries[] | select(.kind == "ollama") |
+if [ "$http_probe_count" -gt 0 ]; then
+  echo "$snap" | jq -r '.entries[] | select(.kind == "http_probe") |
     "  \(.key)  total=\(.total) active=\(.active) available=\(.available)"' >&2
 fi
 
 # ── 8. Cross-check vs /cascade/health: provider keys should overlap ─
-# Strategy's capacity_key for ollama = base_url. For CLI = cli:<kind>.
-# health_tracker keys are provider model_ids (e.g. glm:glm-5.1).
+# Strategy's capacity_key for HTTP-probe providers = registered probe URL.
+# For CLI = cli:<kind>. Health-tracker keys are provider/model labels.
 # These live in DIFFERENT registries so no overlap requirement —
 # we only assert both endpoints respond.
 if ! curl -fsS --max-time "$CURL_TIMEOUT" "$BASE_URL/api/v1/cascade/health" >/dev/null; then

--- a/test/test_cascade_health_tracker.ml
+++ b/test/test_cascade_health_tracker.ml
@@ -413,14 +413,14 @@ let test_fingerprint_top_sorted_descending () =
 
 let test_terminal_failure_triggers_immediate_cooldown () =
   let t = H.create () in
-  H.record_terminal_failure t ~provider_key:"kimi-for-coding" ();
+  H.record_terminal_failure t ~provider_key:"cli-json-model" ();
   check bool "single terminal_failure event trips cooldown immediately"
-    true (H.is_in_cooldown t ~provider_key:"kimi-for-coding")
+    true (H.is_in_cooldown t ~provider_key:"cli-json-model")
 
 let test_terminal_failure_cooldown_is_long () =
   let t = H.create () in
-  H.record_terminal_failure t ~provider_key:"kimi-for-coding" ();
-  match H.provider_info t ~provider_key:"kimi-for-coding" with
+  H.record_terminal_failure t ~provider_key:"cli-json-model" ();
+  match H.provider_info t ~provider_key:"cli-json-model" with
   | None -> fail "provider_info returned None after record_terminal_failure"
   | Some info ->
     let now = Unix.gettimeofday () in
@@ -434,28 +434,28 @@ let test_terminal_failure_cooldown_is_long () =
 
 let test_terminal_failure_effective_weight_zero () =
   let t = H.create () in
-  H.record_terminal_failure t ~provider_key:"kimi-for-coding" ();
+  H.record_terminal_failure t ~provider_key:"cli-json-model" ();
   check int "effective_weight = 0 during terminal_failure cooldown"
-    0 (H.effective_weight t ~provider_key:"kimi-for-coding" ~config_weight:100)
+    0 (H.effective_weight t ~provider_key:"cli-json-model" ~config_weight:100)
 
 let test_terminal_failure_success_clears_cooldown () =
   let t = H.create () in
-  H.record_terminal_failure t ~provider_key:"kimi-for-coding" ();
-  H.record_success t ~provider_key:"kimi-for-coding" ();
+  H.record_terminal_failure t ~provider_key:"cli-json-model" ();
+  H.record_success t ~provider_key:"cli-json-model" ();
   check bool "success after terminal_failure clears cooldown"
-    false (H.is_in_cooldown t ~provider_key:"kimi-for-coding")
+    false (H.is_in_cooldown t ~provider_key:"cli-json-model")
 
 let test_terminal_failure_preserves_longer_existing_cooldown () =
   let t = H.create () in
-  H.record_terminal_failure t ~provider_key:"kimi-for-coding" ();
+  H.record_terminal_failure t ~provider_key:"cli-json-model" ();
   let expires_after_first =
-    match H.provider_info t ~provider_key:"kimi-for-coding" with
+    match H.provider_info t ~provider_key:"cli-json-model" with
     | Some { cooldown_expires_at = Some x; _ } -> x
     | _ -> fail "no cooldown after first terminal_failure"
   in
-  H.record_terminal_failure t ~provider_key:"kimi-for-coding" ();
+  H.record_terminal_failure t ~provider_key:"cli-json-model" ();
   let expires_after_second =
-    match H.provider_info t ~provider_key:"kimi-for-coding" with
+    match H.provider_info t ~provider_key:"cli-json-model" with
     | Some { cooldown_expires_at = Some x; _ } -> x
     | _ -> fail "no cooldown after second terminal_failure"
   in
@@ -464,10 +464,10 @@ let test_terminal_failure_preserves_longer_existing_cooldown () =
 
 let test_terminal_failure_records_fingerprint () =
   let t = H.create () in
-  H.record_terminal_failure t ~provider_key:"kimi-for-coding"
+  H.record_terminal_failure t ~provider_key:"cli-json-model"
     ~error_kind:(kind "resumable_cli_session")
-    ~error_reason:"kimi exited with code 1: session conflict" ();
-  let info = info_or_fail t ~provider_key:"kimi-for-coding" in
+    ~error_reason:"cli-tool exited with code 1: session conflict" ();
+  let info = info_or_fail t ~provider_key:"cli-json-model" in
   match info.top_fingerprints with
   | [ (fp, count) ] ->
     check bool "terminal failure fingerprint keeps kind"

--- a/test/test_cascade_model_resolve.ml
+++ b/test/test_cascade_model_resolve.ml
@@ -1,9 +1,7 @@
-(** Unit tests for Cascade_model_resolve.resolve_auto_model_id.
+(** Unit tests for generic cascade model resolution.
 
-    Focus: "auto" handling without reintroducing MASC-side concrete model
-    lists. GLM resolves through the OAS ZAI catalog because the HTTP API needs
-    a concrete model id. CLI providers keep "auto" as the default delegation
-    path unless the operator supplies MASC_<PROVIDER>_AUTO_MODELS. *)
+    These tests install a synthetic OAS provider catalog so MASC verifies the
+    boundary contract without pinning real vendor model catalogs. *)
 
 open Alcotest
 module R = Masc_mcp.Cascade_model_resolve
@@ -11,20 +9,75 @@ module C = Masc_mcp.Cascade_config
 module State = Masc_mcp.Cascade_state
 module H = Masc_mcp.Cascade_health_tracker
 
-(* RFC-0058 Phase 5.3a — the per-provider thin wrappers
-   ([gemini_cli_auto_models], etc.) were deleted because they were unused
-   in production. Tests now exercise the generic
-   [Cascade_config.expand_auto_models] production path; the provider id is the
-   test's pin, not a production literal in the test body. *)
-let auto_models_for pid =
-  let prefix = pid ^ ":" in
-  let prefix_len = String.length prefix in
-  C.expand_auto_models [ prefix ^ "auto" ]
-  |> List.filter_map (fun spec ->
-    if String.length spec >= prefix_len
-       && String.equal (String.sub spec 0 prefix_len) prefix
-    then Some (String.sub spec prefix_len (String.length spec - prefix_len))
-    else None)
+let synthetic_catalog_json =
+  {|
+{
+  "schema_version": 1,
+  "providers": [
+    {
+      "id": "synthetic-api",
+      "aliases": ["synthetic_api"],
+      "kind": "openai_compat",
+      "transport": "http",
+      "base_url": "https://synthetic.example/v1",
+      "request_path": "/chat/completions",
+      "auth": {"type": "api_key_env", "env": "SYNTHETIC_API_KEY"},
+      "default_model": "api-default",
+      "capabilities_base": "openai_chat",
+      "capabilities": {
+        "supported_models": ["api-a", "api-b", "api-c"]
+      },
+      "non_interactive": true,
+      "interactive_required": false,
+      "daemon_safe": true
+    },
+    {
+      "id": "synthetic-cli",
+      "aliases": ["synthetic_cli"],
+      "kind": "codex_cli",
+      "transport": "cli",
+      "command": "synthetic-cli",
+      "auth": {"type": "cli_cached_login"},
+      "capabilities_base": "codex_cli",
+      "non_interactive": true,
+      "interactive_required": false,
+      "daemon_safe": true
+    },
+    {
+      "id": "synthetic-direct",
+      "aliases": ["synthetic_direct"],
+      "kind": "openai_compat",
+      "transport": "http",
+      "base_url": "https://direct.example/v1",
+      "request_path": "/chat/completions",
+      "auth": {"type": "api_key_env", "env": "SYNTHETIC_DIRECT_KEY"},
+      "capabilities_base": "openai_chat",
+      "non_interactive": true,
+      "interactive_required": false,
+      "daemon_safe": true
+    },
+    {
+      "id": "synthetic-local",
+      "aliases": ["synthetic_local"],
+      "kind": "openai_compat",
+      "transport": "http",
+      "base_url": "http://127.0.0.1:8123",
+      "request_path": "/v1/chat/completions",
+      "auth": {"type": "none"},
+      "capabilities_base": "openai_chat",
+      "non_interactive": true,
+      "interactive_required": false,
+      "daemon_safe": true
+    }
+  ]
+}
+|}
+;;
+
+let install_synthetic_catalog () =
+  match Llm_provider.Provider_catalog.of_json (Yojson.Safe.from_string synthetic_catalog_json) with
+  | Error msg -> fail msg
+  | Ok catalog -> Llm_provider.Provider_catalog.set_global catalog
 ;;
 
 let unset_env k =
@@ -35,20 +88,28 @@ let unset_env k =
 let with_clean_env f =
   List.iter
     unset_env
-    [ "ZAI_CODING_DEFAULT_MODEL"
-    ; "ZAI_CODING_AUTO_MODELS"
-    ; "GEMINI_DEFAULT_MODEL"
-    ; "GEMINI_CLI_DEFAULT_MODEL"
-    ; "ANTHROPIC_DEFAULT_MODEL"
-    ; "OPENAI_DEFAULT_MODEL"
-    ; "OPENROUTER_DEFAULT_MODEL"
-    ; "OLLAMA_DEFAULT_MODEL"
-    ; "MASC_GEMINI_CLI_AUTO_MODELS"
-    ; "MASC_CODEX_CLI_AUTO_MODELS"
-    ; "MASC_CLAUDE_CODE_AUTO_MODELS"
-    ; "MASC_KIMI_CLI_AUTO_MODELS"
+    [ "SYNTHETIC_API_DEFAULT_MODEL"
+    ; "SYNTHETIC_CLI_DEFAULT_MODEL"
+    ; "SYNTHETIC_DIRECT_DEFAULT_MODEL"
+    ; "SYNTHETIC_LOCAL_DEFAULT_MODEL"
+    ; "MASC_SYNTHETIC_API_AUTO_MODELS"
+    ; "MASC_SYNTHETIC_CLI_AUTO_MODELS"
+    ; "MASC_SYNTHETIC_DIRECT_AUTO_MODELS"
     ];
   f ()
+;;
+
+let prefixed provider model = provider ^ ":" ^ model
+
+let auto_models_for pid =
+  let prefix = pid ^ ":" in
+  let prefix_len = String.length prefix in
+  C.expand_auto_models [ prefix ^ "auto" ]
+  |> List.filter_map (fun spec ->
+    if String.length spec >= prefix_len
+       && String.equal (String.sub spec 0 prefix_len) prefix
+    then Some (String.sub spec prefix_len (String.length spec - prefix_len))
+    else None)
 ;;
 
 let require_first_model label = function
@@ -61,155 +122,97 @@ let require_second_model label = function
   | _ -> fail (label ^ " produced fewer than two models")
 ;;
 
-let glm_coding_catalog_models () =
-  let models = R.glm_coding_auto_models () in
-  check bool "glm-coding catalog has concrete models" true (models <> []);
-  check bool "glm-coding catalog does not delegate auto" true
-    (not (List.exists (String.equal "auto") models));
-  models
-;;
-
-let prefixed provider model = provider ^ ":" ^ model
-
-let test_gemini_auto_without_env_delegates () =
+let test_api_auto_uses_binding_default () =
   with_clean_env (fun () ->
-    let resolved = R.resolve_auto_model_id "gemini" "auto" in
-    check string "gemini:auto without env stays delegated" "auto" resolved)
+    let resolved = R.resolve_auto_model_id "synthetic-api" "auto" in
+    check string "auto uses binding default" "api-default" resolved)
 ;;
 
-let test_gemini_cli_auto_without_env_delegates () =
-  with_clean_env (fun () ->
-    let resolved = R.resolve_auto_model_id "gemini_cli" "auto" in
-    check string "gemini_cli:auto delegates to CLI default" "auto" resolved)
-;;
-
-let test_gemini_cli_explicit_model_passthrough () =
-  with_clean_env (fun () ->
-    let resolved = R.resolve_auto_model_id "gemini_cli" "explicit-model" in
-    check string "explicit model untouched" "explicit-model" resolved)
-;;
-
-let test_gemini_env_override () =
-  Unix.putenv "GEMINI_DEFAULT_MODEL" "operator-gemini-model";
-  Unix.putenv "GEMINI_CLI_DEFAULT_MODEL" "operator-gemini-cli-model";
-  let resolved_gemini = R.resolve_auto_model_id "gemini" "auto" in
-  let resolved_cli = R.resolve_auto_model_id "gemini_cli" "auto" in
-  Unix.putenv "GEMINI_DEFAULT_MODEL" "";
-  Unix.putenv "GEMINI_CLI_DEFAULT_MODEL" "";
-  check string "gemini respects env override" "operator-gemini-model" resolved_gemini;
+let test_api_env_default_provenance () =
+  let getenv = function
+    | "SYNTHETIC_API_DEFAULT_MODEL" -> Some "operator-model"
+    | _ -> None
+  in
+  let resolved =
+    R.resolve_auto_model
+      ~getenv
+      "synthetic-api"
+      (R.model_selector_of_string "auto")
+  in
+  check string "env default wins" "operator-model" resolved.resolved_model_id;
   check
-    string
-    "gemini_cli respects cli env override"
-    "operator-gemini-cli-model"
-    resolved_cli
+    bool
+    "env provenance"
+    true
+    (resolved.provenance = R.Env_default "SYNTHETIC_API_DEFAULT_MODEL")
 ;;
 
-let test_glm_coding_auto_maps_to_glm_5_1 () =
+let test_cli_auto_delegates_without_catalog_models () =
   with_clean_env (fun () ->
-    let expected = require_first_model "glm-coding catalog" (glm_coding_catalog_models ()) in
-    let resolved = R.resolve_auto_model_id "glm-coding" "auto" in
-    check string "glm-coding:auto resolves to OAS catalog head" expected resolved)
-;;
-
-let test_glm_coding_auto_models_catalog_order () =
-  with_clean_env (fun () ->
-    let models = glm_coding_catalog_models () in
-    check
-      (list string)
-      "generic expansion follows OAS catalog order"
-      models
-      (auto_models_for "glm-coding"))
-;;
-
-let test_gemini_cli_auto_models_default_rotation_order () =
-  with_clean_env (fun () ->
-    check
-      (list string)
-      "gemini_cli:auto default delegates to CLI"
-      [ "auto" ]
-      (auto_models_for "gemini_cli"))
-;;
-
-let test_gemini_cli_auto_models_env_override () =
-  Unix.putenv "MASC_GEMINI_CLI_AUTO_MODELS" "gemini-a, gemini-b,, gemini-c ";
-  let models = auto_models_for "gemini_cli" in
-  Unix.putenv "MASC_GEMINI_CLI_AUTO_MODELS" "";
-  check
-    (list string)
-    "operator override trims blanks"
-    [ "gemini-a"; "gemini-b"; "gemini-c" ]
-    models
-;;
-
-let test_codex_and_claude_cli_auto_models_env_override () =
-  with_clean_env (fun () ->
-    check
-      (list string)
-      "codex default delegates to CLI"
-      [ "auto" ]
-      (auto_models_for "codex_cli");
-    check
-      (list string)
-      "claude default delegates to CLI"
-      [ "auto" ]
-      (auto_models_for "claude_code");
-    Unix.putenv "MASC_CODEX_CLI_AUTO_MODELS" "model-a,model-b";
-    Unix.putenv "MASC_CLAUDE_CODE_AUTO_MODELS" "sonnet,opus";
-    let codex = auto_models_for "codex_cli" in
-    let claude = auto_models_for "claude_code" in
-    Unix.putenv "MASC_CODEX_CLI_AUTO_MODELS" "";
-    Unix.putenv "MASC_CLAUDE_CODE_AUTO_MODELS" "";
-    check (list string) "codex operator rotation" [ "model-a"; "model-b" ] codex;
-    check (list string) "claude operator rotation" [ "sonnet"; "opus" ] claude)
-;;
-
-let test_kimi_cli_auto_model_declared_default () =
-  with_clean_env (fun () ->
-    let declared_default =
-      match auto_models_for "kimi_cli" with
-      | [ model ] -> model
-      | models ->
-        fail
-          (Printf.sprintf
-             "expected one kimi_cli declared default, got: %s"
-             (String.concat "," models))
-    in
     check
       string
-      "kimi_cli:auto resolves to concrete CLI default"
-      declared_default
-      (R.resolve_auto_model_id "kimi_cli" "auto");
+      "cli auto delegates"
+      "auto"
+      (R.resolve_auto_model_id "synthetic-cli" "auto");
     check
       (list string)
-      "kimi_cli:auto expands to declared default"
-      [ declared_default ]
-      (auto_models_for "kimi_cli");
-    Unix.putenv "MASC_KIMI_CLI_AUTO_MODELS" "model-a,model-b";
-    let models = auto_models_for "kimi_cli" in
-    Unix.putenv "MASC_KIMI_CLI_AUTO_MODELS" "";
-    check (list string) "kimi cli operator rotation" [ "model-a"; "model-b" ] models)
+      "cli auto expands to delegation token"
+      [ "auto" ]
+      (auto_models_for "synthetic-cli"))
 ;;
 
-let test_expand_auto_models_includes_cli_auto_specs () =
+let test_explicit_model_passthrough_trims_result () =
   with_clean_env (fun () ->
-    let expanded =
-      C.expand_auto_models
-        [ "gemini_cli:auto"; "codex_cli:auto"; "claude_code:auto"; "kimi_cli:auto" ]
+    let resolved = R.resolve_auto_model_id "synthetic-api" " explicit-model " in
+    check string "explicit model trimmed" "explicit-model" resolved)
+;;
+
+let test_unsupported_provider_auto_is_unresolved () =
+  with_clean_env (fun () ->
+    let resolved =
+      R.resolve_auto_model
+        ~getenv:(fun _ -> None)
+        "unknown-provider"
+        (R.model_selector_of_string "auto")
     in
+    check string "unknown auto remains auto" "auto" resolved.resolved_model_id;
+    check bool "unresolved provenance" true (resolved.provenance = R.Unresolved_auto))
+;;
+
+let test_supported_models_expand_from_binding () =
+  with_clean_env (fun () ->
     check
       (list string)
-      "CLI auto specs expand in-place"
-      [ "gemini_cli:auto"
-      ; "codex_cli:auto"
-      ; "claude_code:auto"
-      ; "kimi_cli:kimi-for-coding"
-      ]
-      expanded)
+      "supported models from OAS binding"
+      [ "api-a"; "api-b"; "api-c" ]
+      (auto_models_for "synthetic-api"))
+;;
+
+let test_auto_models_env_override () =
+  with_clean_env (fun () ->
+    Unix.putenv "MASC_SYNTHETIC_API_AUTO_MODELS" "override-a, override-b,, override-c ";
+    let models = auto_models_for "synthetic-api" in
+    Unix.putenv "MASC_SYNTHETIC_API_AUTO_MODELS" "";
+    check
+      (list string)
+      "operator override trims blanks"
+      [ "override-a"; "override-b"; "override-c" ]
+      models)
+;;
+
+let test_direct_api_without_supported_models_does_not_expand () =
+  with_clean_env (fun () ->
+    check (list string) "no generic direct expansion" [ "auto" ] (auto_models_for "synthetic-direct");
+    check
+      string
+      "runtime default remains delegated"
+      "auto"
+      (R.resolve_auto_model_id "synthetic-direct" "auto"))
 ;;
 
 let test_expand_model_strings_for_execution_matches_auto_expansion () =
   with_clean_env (fun () ->
-    let items = [ "glm-coding:auto"; "gemini_cli:auto" ] in
+    let items = [ "synthetic-api:auto"; "synthetic-cli:auto" ] in
     check
       (list string)
       "execution expansion matches auto expansion"
@@ -219,93 +222,76 @@ let test_expand_model_strings_for_execution_matches_auto_expansion () =
 
 let test_expand_model_strings_for_execution_dedupe_stable_repeated_inputs () =
   with_clean_env (fun () ->
-    (* Pure repeated literals: dedupe must keep first occurrence and
-       preserve insertion order. *)
     let items =
       [ "test-provider:model-a"
-      ; "kimi_cli:kimi-for-coding"
+      ; "synthetic-api:api-a"
       ; "test-provider:model-a"
-      ; "kimi_cli:kimi-for-coding"
+      ; "synthetic-api:api-a"
       ; "test-provider:model-a"
       ]
     in
     check
       (list string)
       "first occurrence wins, order preserved"
-      [ "test-provider:model-a"; "kimi_cli:kimi-for-coding" ]
+      [ "test-provider:model-a"; "synthetic-api:api-a" ]
       (C.expand_model_strings_for_execution items))
 ;;
 
 let test_expand_model_strings_for_execution_dedupe_explicit_and_auto () =
   with_clean_env (fun () ->
-    let first_glm_model =
-      require_first_model "glm-coding catalog" (glm_coding_catalog_models ())
-    in
-    let explicit_glm = prefixed "glm-coding" first_glm_model in
-    (* Explicit model that an auto-expansion would also produce: the
-       explicit one (declared first) wins; the auto-expansion's
-       contribution of the same name is dropped, but its other entries
-       remain in expansion order. *)
-    let items = [ explicit_glm; "glm-coding:auto" ] in
+    let first_model = require_first_model "synthetic-api catalog" (auto_models_for "synthetic-api") in
+    let explicit = prefixed "synthetic-api" first_model in
+    let items = [ explicit; "synthetic-api:auto" ] in
     let expanded = C.expand_model_strings_for_execution items in
-    (* (a) head is the explicit declaration *)
-    check
-      string
-      "explicit first occurrence retained at head"
-      explicit_glm
-      (List.hd expanded);
-    (* (b) duplicate of the explicit name does not reappear *)
-    let occurrences =
-      List.filter (String.equal explicit_glm) expanded |> List.length
-    in
+    check string "explicit first occurrence retained at head" explicit (List.hd expanded);
+    let occurrences = List.filter (String.equal explicit) expanded |> List.length in
     check int "no duplicate of explicit name" 1 occurrences;
-    (* (c) auto-expansion of other entries still present (sanity) *)
     check bool "auto-expanded siblings present" true (List.length expanded > 1))
 ;;
 
 let test_expand_model_strings_for_execution_rotation_scope_rotates () =
   with_clean_env (fun () ->
-    let models = glm_coding_catalog_models () in
-    let first_model = require_first_model "glm-coding catalog" models in
-    let second_model = require_second_model "glm-coding catalog" models in
+    let models = auto_models_for "synthetic-api" in
+    let first_model = require_first_model "synthetic-api catalog" models in
+    let second_model = require_second_model "synthetic-api catalog" models in
     State.clear_all ();
     let first =
       C.expand_model_strings_for_execution
         ~rotation_scope:"primary"
-        [ "glm-coding:auto" ]
+        [ "synthetic-api:auto" ]
     in
     let second =
       C.expand_model_strings_for_execution
         ~rotation_scope:"primary"
-        [ "glm-coding:auto" ]
+        [ "synthetic-api:auto" ]
     in
     let other_scope =
       C.expand_model_strings_for_execution
         ~rotation_scope:"scoring"
-        [ "glm-coding:auto" ]
+        [ "synthetic-api:auto" ]
     in
     check
       string
       "first scoped call starts at default head"
-      (prefixed "glm-coding" first_model)
+      (prefixed "synthetic-api" first_model)
       (List.hd first);
     check
       string
       "second scoped call advances head"
-      (prefixed "glm-coding" second_model)
+      (prefixed "synthetic-api" second_model)
       (List.hd second);
     check
       string
       "different scope has its own cursor"
-      (prefixed "glm-coding" first_model)
+      (prefixed "synthetic-api" first_model)
       (List.hd other_scope))
 ;;
 
 let test_order_weighted_entries_rotation_scope_rotates_generically () =
   with_clean_env (fun () ->
-    let models = glm_coding_catalog_models () in
-    let first_model = require_first_model "glm-coding catalog" models in
-    let second_model = require_second_model "glm-coding catalog" models in
+    let models = auto_models_for "synthetic-api" in
+    let first_model = require_first_model "synthetic-api catalog" models in
+    let second_model = require_second_model "synthetic-api catalog" models in
     State.clear_all ();
     let entry model =
       { Masc_mcp.Cascade_config_loader.model
@@ -316,31 +302,31 @@ let test_order_weighted_entries_rotation_scope_rotates_generically () =
       }
     in
     let first =
-      C.order_weighted_entries ~rotation_scope:"primary" [ entry "glm-coding:auto" ]
+      C.order_weighted_entries ~rotation_scope:"primary" [ entry "synthetic-api:auto" ]
       |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) -> e.model)
     in
     let second =
-      C.order_weighted_entries ~rotation_scope:"primary" [ entry "glm-coding:auto" ]
+      C.order_weighted_entries ~rotation_scope:"primary" [ entry "synthetic-api:auto" ]
       |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) -> e.model)
     in
     let other_scope =
-      C.order_weighted_entries ~rotation_scope:"scoring" [ entry "glm-coding:auto" ]
+      C.order_weighted_entries ~rotation_scope:"scoring" [ entry "synthetic-api:auto" ]
       |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) -> e.model)
     in
     check
       string
       "weighted first call keeps default head"
-      (prefixed "glm-coding" first_model)
+      (prefixed "synthetic-api" first_model)
       (List.hd first);
     check
       string
       "weighted second call advances head"
-      (prefixed "glm-coding" second_model)
+      (prefixed "synthetic-api" second_model)
       (List.hd second);
     check
       string
       "weighted rotation is scoped"
-      (prefixed "glm-coding" first_model)
+      (prefixed "synthetic-api" first_model)
       (List.hd other_scope))
 ;;
 
@@ -356,7 +342,7 @@ let test_order_weighted_entries_rotation_scope_rotates_top_level_providers () =
       }
     in
     let entries =
-      [ entry "claude_code:auto"; entry "codex_cli:auto"; entry "gemini_cli:auto" ]
+      [ entry "provider-a:model"; entry "provider-b:model"; entry "provider-c:model" ]
     in
     let first =
       C.order_weighted_entries ~rotation_scope:"primary" entries
@@ -374,25 +360,13 @@ let test_order_weighted_entries_rotation_scope_rotates_top_level_providers () =
       C.order_weighted_entries ~rotation_scope:"scoring" entries
       |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) -> e.model)
     in
-    check
-      string
-      "first call starts with declared provider"
-      "claude_code:auto"
-      (List.hd first);
-    check
-      string
-      "second call rotates to codex provider"
-      "codex_cli:auto"
-      (List.hd second);
-    check
-      string
-      "third call rotates to gemini provider"
-      "gemini_cli:auto"
-      (List.hd third);
+    check string "first call starts with declared provider" "provider-a:model" (List.hd first);
+    check string "second call rotates to next provider" "provider-b:model" (List.hd second);
+    check string "third call rotates to third provider" "provider-c:model" (List.hd third);
     check
       string
       "different scope restarts top-level provider order"
-      "claude_code:auto"
+      "provider-a:model"
       (List.hd other_scope))
 ;;
 
@@ -415,52 +389,25 @@ let test_order_weighted_entries_cooldown_is_provider_scoped () =
         [ entry "test-provider:model-a"; entry "other-provider:model-a" ]
       |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) -> e.model)
     in
-    check
-      string
-      "cooled provider model is skipped"
-      "other-provider:model-a"
-      (List.hd ordered))
+    check string "cooled provider model is skipped" "other-provider:model-a" (List.hd ordered))
 ;;
 
 let () =
+  install_synthetic_catalog ();
   run
     "Cascade_model_resolve"
-    [ ( "gemini auto"
-      , [ test_case "glm-coding:auto" `Quick test_glm_coding_auto_maps_to_glm_5_1
+    [ ( "generic auto"
+      , [ test_case "api auto binding default" `Quick test_api_auto_uses_binding_default
+        ; test_case "api env default provenance" `Quick test_api_env_default_provenance
+        ; test_case "cli auto delegates by default" `Quick test_cli_auto_delegates_without_catalog_models
+        ; test_case "explicit model passthrough" `Quick test_explicit_model_passthrough_trims_result
+        ; test_case "unknown auto unresolved" `Quick test_unsupported_provider_auto_is_unresolved
+        ; test_case "supported model expansion" `Quick test_supported_models_expand_from_binding
+        ; test_case "auto model env override" `Quick test_auto_models_env_override
         ; test_case
-            "glm-coding:auto model list"
+            "direct api without supported models"
             `Quick
-            test_glm_coding_auto_models_catalog_order
-        ; test_case "gemini:auto" `Quick test_gemini_auto_without_env_delegates
-        ; test_case
-            "gemini_cli:auto delegates by default"
-            `Quick
-            test_gemini_cli_auto_without_env_delegates
-        ; test_case
-            "gemini_cli explicit"
-            `Quick
-            test_gemini_cli_explicit_model_passthrough
-        ; test_case "GEMINI_DEFAULT_MODEL env override" `Quick test_gemini_env_override
-        ; test_case
-            "gemini_cli:auto model list"
-            `Quick
-            test_gemini_cli_auto_models_default_rotation_order
-        ; test_case
-            "gemini_cli:auto env list override"
-            `Quick
-            test_gemini_cli_auto_models_env_override
-        ; test_case
-            "codex/claude cli auto env list override"
-            `Quick
-            test_codex_and_claude_cli_auto_models_env_override
-        ; test_case
-            "kimi_cli:auto declared default"
-            `Quick
-            test_kimi_cli_auto_model_declared_default
-        ; test_case
-            "expand_auto_models covers CLI auto"
-            `Quick
-            test_expand_auto_models_includes_cli_auto_specs
+            test_direct_api_without_supported_models_does_not_expand
         ; test_case
             "execution expansion matches auto expansion"
             `Quick

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -557,13 +557,10 @@ let test_client_capacity_clamp_max () =
   | Some info ->
     check int "max_concurrent <=0 clamped to 1" 1 info.total
 
-(* The previous [test_ollama_auto_register] /
-   [test_ollama_register_with_override] tests exercised the substring-scan
-   auto-registration path inside [Cascade_client_capacity]. That path is
-   gone now — the caller consults provider-kind HTTP-probe capability and
-   calls [Cascade_client_capacity.register] explicitly, so the test surface
-   for the removed [auto_register_for_candidates] /
-   [auto_register_ollama_with_override] functions is gone with them. *)
+(* The previous HTTP auto-registration tests exercised the substring-scan path
+   inside [Cascade_client_capacity]. That path is gone now: callers consult the
+   registered probe surface and call [Cascade_client_capacity.register]
+   explicitly, so the removed auto-register functions have no test surface. *)
 
 (* ── Phase C3: CLI sentinel auto-registration ──────────────── *)
 
@@ -628,8 +625,8 @@ let test_snapshot_returns_all_entries () =
   check int "snapshot contains both entries" 2 (List.length entries);
   let lookup k = List.assoc_opt k entries in
   (match lookup "http://127.0.0.1:11434" with
-   | Some info -> check int "ollama total" 1 info.total
-   | None -> fail "ollama entry missing");
+   | Some info -> check int "http probe total" 1 info.total
+   | None -> fail "http probe entry missing");
   (match lookup "cli:claude_code" with
    | Some info ->
      check int "cli total" 2 info.total;
@@ -879,9 +876,9 @@ let test_history_snapshot_kind_filter () =
        check string "cli filter matches classify_key"
          "cli" (CH.classify_key e.CH.key))
     cli_events;
-  (* ollama filter → 1 event for :11434 *)
-  let ollama_events = CH.snapshot ~kind:"ollama" () in
-  check int "ollama filter → 1 event" 1 (List.length ollama_events);
+  (* http_probe filter -> 1 event for the registered probe URL. *)
+  let http_probe_events = CH.snapshot ~kind:"http_probe" () in
+  check int "http_probe filter -> 1 event" 1 (List.length http_probe_events);
   (* other filter → 1 event for http://other *)
   let other_events = CH.snapshot ~kind:"other" () in
   check int "other filter → 1 event" 1 (List.length other_events);
@@ -977,14 +974,14 @@ let test_history_prometheus_counter_increments () =
     counter_value_from_text text "acquired" "cli"
     |> Option.value ~default:0.0
   in
-  let ollama_rejected =
-    counter_value_from_text text "rejected_full" "ollama"
+  let http_probe_rejected =
+    counter_value_from_text text "rejected_full" "http_probe"
     |> Option.value ~default:0.0
   in
   check bool "cli/acquired counter advanced by >= 2"
     true (cli_acquired >= before +. 2.0);
-  check bool "ollama/rejected_full counter advanced by >= 1"
-    true (ollama_rejected >= 1.0)
+  check bool "http_probe/rejected_full counter advanced by >= 1"
+    true (http_probe_rejected >= 1.0)
 
 (* ── Strategy decision trace (LT-5) ─────────────────── *)
 

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -673,7 +673,7 @@ let test_runtime_surface_exposes_redacted_resumable_cli_session_blocker () =
   KR.clear ();
   let base = make_meta ~name:"runtime-resumable-cli-session-test" () in
   let reason =
-    Masc_mcp.Cascade_runner.Kimi_cli_transport_local.resumable_session_detail
+    Masc_mcp.Cascade_transport.Kimi_cli_transport_local.resumable_session_detail
   in
   let meta =
     {

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -673,7 +673,7 @@ let test_runtime_surface_exposes_redacted_resumable_cli_session_blocker () =
   KR.clear ();
   let base = make_meta ~name:"runtime-resumable-cli-session-test" () in
   let reason =
-    Masc_mcp.Cascade_transport.Kimi_cli_transport_local.resumable_session_detail
+    Masc_mcp.Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail
   in
   let meta =
     {
@@ -714,7 +714,7 @@ let test_runtime_surface_exposes_redacted_resumable_cli_session_blocker () =
     reason
     summary;
   check bool "runtime blocker hides raw session command" false
-    (contains_substring summary "kimi -r");
+    (contains_substring summary "cli-tool -r");
   check bool "runtime blocker continue gate stays false"
     false
     (runtime |> member "runtime_blocker_continue_gate" |> to_bool)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6954,7 +6954,7 @@ let test_metrics_failure_response_redacts_resumable_cli_session_detail () =
      To resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
   in
   let canonical_detail =
-    Masc_mcp.Cascade_runner.Kimi_cli_transport_local.resumable_session_detail
+    Masc_mcp.Cascade_transport.Kimi_cli_transport_local.resumable_session_detail
   in
   let sdk_error =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
@@ -7819,7 +7819,7 @@ let test_auto_recoverable_turn_error_includes_resumable_cli_session_error () =
       (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
          { cascade_name = oas_error_cascade_name "kimi_cli_keeper"
          ; detail =
-             Masc_mcp.Cascade_runner.Kimi_cli_transport_local.resumable_session_detail
+             Masc_mcp.Cascade_transport.Kimi_cli_transport_local.resumable_session_detail
          ; exit_code = Some 75
          })
   in
@@ -7836,7 +7836,7 @@ let test_cascade_exhausted_error_includes_resumable_cli_session_error () =
       (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
          { cascade_name = oas_error_cascade_name "kimi_cli_keeper"
          ; detail =
-             Masc_mcp.Cascade_runner.Kimi_cli_transport_local.resumable_session_detail
+             Masc_mcp.Cascade_transport.Kimi_cli_transport_local.resumable_session_detail
          ; exit_code = Some 75
          })
   in

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6115,8 +6115,8 @@ let test_degraded_retry_after_recoverable_error_uses_local_recovery_for_resumabl
          (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
             { cascade_name = oas_error_cascade_name "kimi_cli_keeper"
             ; detail =
-                "kimi exited with code 75: \n\
-                 To resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
+                "cli-tool exited with code 75: \n\
+                 To resume this session: cli-tool -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
             ; exit_code = Some 75
             }))
   in
@@ -6950,11 +6950,11 @@ let test_metrics_failure_timeout_increments_proactive_backoff () =
 
 let test_metrics_failure_response_redacts_resumable_cli_session_detail () =
   let raw_reason =
-    "kimi exited with code 75: \n\
-     To resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
+    "cli-tool exited with code 75: \n\
+     To resume this session: cli-tool -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
   in
   let canonical_detail =
-    Masc_mcp.Cascade_transport.Kimi_cli_transport_local.resumable_session_detail
+    Masc_mcp.Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail
   in
   let sdk_error =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
@@ -6999,7 +6999,7 @@ let test_metrics_failure_response_redacts_resumable_cli_session_detail () =
     bool
     "raw session token removed from last reason"
     false
-    (contains_substring updated.runtime.proactive_rt.last_reason "kimi -r");
+    (contains_substring updated.runtime.proactive_rt.last_reason "cli-tool -r");
   match updated.runtime.last_blocker with
   | Some { klass = Keeper_types.Cascade_exhausted (Keeper_types.Other_detail detail); _ }
     ->
@@ -7819,7 +7819,7 @@ let test_auto_recoverable_turn_error_includes_resumable_cli_session_error () =
       (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
          { cascade_name = oas_error_cascade_name "kimi_cli_keeper"
          ; detail =
-             Masc_mcp.Cascade_transport.Kimi_cli_transport_local.resumable_session_detail
+             Masc_mcp.Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail
          ; exit_code = Some 75
          })
   in
@@ -7836,7 +7836,7 @@ let test_cascade_exhausted_error_includes_resumable_cli_session_error () =
       (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
          { cascade_name = oas_error_cascade_name "kimi_cli_keeper"
          ; detail =
-             Masc_mcp.Cascade_transport.Kimi_cli_transport_local.resumable_session_detail
+             Masc_mcp.Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail
          ; exit_code = Some 75
          })
   in

--- a/test/test_oas_compat_cascade_fallback.ml
+++ b/test/test_oas_compat_cascade_fallback.ml
@@ -1,11 +1,11 @@
 (* test/test_oas_compat_cascade_fallback.ml
 
-   #9932: kimi_cli permanent failure blocks 5 keepers (409 BDI blockers) —
+   #9932: a provider-local CLI failure blocked 5 keepers (409 BDI blockers) —
    primary cascade fallback was not firing because
    [Oas_compat.Http_client.should_cascade] classified per-provider CLI
    rejections as non-cascadable. The correct policy: a permanent error
-   specific to one provider (kimi auth/config, gemini startup crash) still
-   cascades because the NEXT hop is a different provider that may succeed.
+   specific to one provider (auth/config, startup crash) still cascades because
+   the NEXT hop is a different provider that may succeed.
 
    This test pins the should_cascade policy for AcceptRejected reasons. The
    FSM call site is [lib/cascade/cascade_fsm.ml:43-48]: Call_err -> Try_next
@@ -23,16 +23,16 @@
 
 module Http_client = Llm_provider.Http_client
 
-let test_kimi_cli_exit_1_cascades () =
+let test_provider_cli_exit_1_cascades () =
   let reason =
-    "kimi_cli rejected the request (exit 1). "
+    "provider CLI rejected the request (exit 1). "
     ^ "This is usually a permanent auth/config/model error rather "
     ^ "than a transient transport failure. "
-    ^ "kimi exited with code 1: To resume this session…"
+    ^ "cli-tool exited with code 1: To resume this session…"
   in
   let err = Http_client.AcceptRejected { reason } in
   Alcotest.(check bool)
-    "kimi_cli exit 1 must cascade — permanent error is provider-local, \
+    "provider CLI exit 1 must cascade — permanent error is provider-local, \
      next cascade hop (claude/gpt/ollama) unaffected"
     true
     (Oas_compat.Http_client.should_cascade err)
@@ -50,16 +50,16 @@ let test_gemini_cli_startup_crash_cascades () =
     true
     (Oas_compat.Http_client.should_cascade err)
 
-let test_kimi_cli_startup_crash_cascades () =
+let test_provider_cli_startup_crash_cascades () =
   let reason =
-    "kimi_cli startup crash while setting process title \
+    "provider CLI startup crash while setting process title \
      (UnicodeDecodeError). This is a local CLI/runtime failure, not \
      keeper auth or sandbox failure; rejecting without retry so the \
      cascade can move on."
   in
   let err = Http_client.AcceptRejected { reason } in
   Alcotest.(check bool)
-    "kimi_cli startup crash must cascade — next provider may still succeed"
+    "provider CLI startup crash must cascade — next provider may still succeed"
     true
     (Oas_compat.Http_client.should_cascade err)
 
@@ -254,7 +254,7 @@ let test_classify_accept_rejected_model_unsupported () =
 
 let test_classify_accept_rejected_request_rejected () =
   let reason =
-    "kimi_cli rejected the request (exit 1). Permanent auth/config/model error"
+    "provider CLI rejected the request (exit 1). Permanent auth/config/model error"
   in
   (match Oas_compat.Http_client.classify_accept_rejected reason with
    | Some Oas_compat.Http_client.Request_rejected -> ()
@@ -327,12 +327,12 @@ let () =
     [
       ( "AcceptRejected — per-provider failure cascades (#9932)",
         [
-          Alcotest.test_case "kimi_cli exit 1 cascades"
-            `Quick test_kimi_cli_exit_1_cascades;
+          Alcotest.test_case "provider_cli exit 1 cascades"
+            `Quick test_provider_cli_exit_1_cascades;
           Alcotest.test_case "gemini_cli startup crash cascades"
             `Quick test_gemini_cli_startup_crash_cascades;
-          Alcotest.test_case "kimi_cli startup crash cascades"
-            `Quick test_kimi_cli_startup_crash_cascades;
+          Alcotest.test_case "provider_cli startup crash cascades"
+            `Quick test_provider_cli_startup_crash_cascades;
         ] );
       ( "AcceptRejected — capability mismatch still cascades (#9850)",
         [

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1340,11 +1340,11 @@ let test_sdk_error_to_cascade_outcome_cascades_runtime_mcp_auth_config () =
 
 let test_sdk_error_to_cascade_outcome_cascades_resumable_cli_session () =
   let raw_message =
-    "kimi exited with code 1: \n\
-     To resume this session: kimi -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
+    "cli-tool exited with code 1: \n\
+     To resume this session: cli-tool -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
   in
   let detail =
-    Cascade_transport.Kimi_cli_transport_local.resumable_session_detail_of_text raw_message
+    Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail_of_text raw_message
   in
   let sdk_error =
     Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest { message = detail })
@@ -1381,8 +1381,8 @@ let test_sdk_error_is_resumable_cli_session_detects_structured_error () =
       (Keeper_turn_driver.Resumable_cli_session
          { cascade_name = internal_cascade_name "governance_judge"
          ; detail =
-             "kimi_cli reported a resumable CLI session (exit 1). Resumable session \
-              available via -r."
+             "CLI JSON-stream transport reported a resumable session (exit 1). \
+              Resumable session available via -r."
          ; exit_code = Some 1
          })
   in
@@ -1396,10 +1396,10 @@ let test_sdk_error_is_resumable_cli_session_detects_structured_error () =
     (Keeper_turn_driver.sdk_error_is_hard_quota err)
 ;;
 
-let test_sdk_error_is_resumable_cli_session_detects_raw_kimi_hint () =
+let test_sdk_error_is_resumable_cli_session_detects_raw_cli_hint () =
   let raw_message =
-    "kimi exited with code 1: \n\
-     To resume this session: kimi -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
+    "cli-tool exited with code 1: \n\
+     To resume this session: cli-tool -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
   in
   let err =
     Agent_sdk.Error.Api
@@ -1407,7 +1407,7 @@ let test_sdk_error_is_resumable_cli_session_detects_raw_kimi_hint () =
          { message = raw_message; kind = Llm_provider.Http_client.Unknown })
   in
   Alcotest.(check bool)
-    "raw Kimi resume hint detected"
+    "raw CLI resume hint detected"
     true
     (Keeper_turn_driver.sdk_error_is_resumable_cli_session err)
 ;;
@@ -1418,8 +1418,8 @@ let test_fallback_class_labels_resumable_cli_session () =
       (Keeper_turn_driver.Resumable_cli_session
          { cascade_name = internal_cascade_name "primary"
          ; detail =
-             "kimi_cli reported a resumable CLI session (exit 1). Resumable session \
-              available via -r."
+             "CLI JSON-stream transport reported a resumable session (exit 1). \
+              Resumable session available via -r."
          ; exit_code = Some 1
          })
   in
@@ -2515,8 +2515,8 @@ let test_classify_masc_internal_error_roundtrip () =
   let resumable_err =
     Keeper_turn_driver.sdk_error_of_masc_internal_error
       (Keeper_turn_driver.Resumable_cli_session
-         { cascade_name = internal_cascade_name "kimi_cli_keeper"
-         ; detail = Cascade_transport.Kimi_cli_transport_local.resumable_session_detail
+         { cascade_name = internal_cascade_name "json_stream_cli_keeper"
+         ; detail = Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail
          ; exit_code = Some 75
          })
   in
@@ -2524,11 +2524,11 @@ let test_classify_masc_internal_error_roundtrip () =
   | Some (Keeper_turn_driver.Resumable_cli_session { cascade_name; detail; exit_code }) ->
     Alcotest.(check string)
       "resumable cascade"
-      "kimi_cli_keeper"
+      "json_stream_cli_keeper"
       (internal_cascade_name_to_string cascade_name);
     Alcotest.(check string)
       "resumable detail redacted"
-      Cascade_transport.Kimi_cli_transport_local.resumable_session_detail
+      Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail
       detail;
     Alcotest.(check bool)
       "resumable detail hides raw resume hint"
@@ -2537,7 +2537,7 @@ let test_classify_masc_internal_error_roundtrip () =
     Alcotest.(check bool)
       "resumable detail hides session token"
       false
-      (contains_substring ~needle:"kimi -r" detail);
+      (contains_substring ~needle:"cli-tool -r" detail);
     Alcotest.(check (option int)) "resumable exit code" (Some 75) exit_code
   | _ -> Alcotest.fail "expected structured resumable CLI session error"
 ;;
@@ -3738,7 +3738,7 @@ let test_classify_filter_rejection_passes_when_provider_supported () =
     (reason = None)
 ;;
 
-let test_kimi_mcp_config_json_of_policy_filters_to_allowed_servers () =
+let test_cli_mcp_config_json_of_policy_filters_to_allowed_servers () =
   let policy =
     { Llm_provider.Llm_transport.empty_runtime_mcp_policy with
       servers =
@@ -3756,8 +3756,8 @@ let test_kimi_mcp_config_json_of_policy_filters_to_allowed_servers () =
     ; disable_builtin_tools = true
     }
   in
-  match Cascade_transport.kimi_mcp_config_json_of_policy policy with
-  | None -> Alcotest.fail "expected kimi runtime MCP config JSON"
+  match Cascade_transport.cli_mcp_config_json_of_policy policy with
+  | None -> Alcotest.fail "expected CLI runtime MCP config JSON"
   | Some raw_json ->
     let open Yojson.Safe.Util in
     let json = Yojson.Safe.from_string raw_json in
@@ -4015,7 +4015,7 @@ let test_runtime_mcp_policy_for_provider_codex_cli_no_agent_strips_all () =
   | None -> Alcotest.fail "expected masc runtime server headers"
 ;;
 
-let test_kimi_cli_runtime_mcp_jsons_include_request_policy () =
+let test_cli_runtime_mcp_jsons_include_request_policy () =
   let policy =
     { Llm_provider.Llm_transport.empty_runtime_mcp_policy with
       servers =
@@ -4028,9 +4028,9 @@ let test_kimi_cli_runtime_mcp_jsons_include_request_policy () =
     ; disable_builtin_tools = true
     }
   in
-  let merged = Cascade_transport.kimi_cli_runtime_mcp_jsons ~base:[] (Some policy) in
+  let merged = Cascade_transport.cli_runtime_mcp_jsons ~base:[] (Some policy) in
   Alcotest.(check int)
-    "request policy contributes one kimi mcp config"
+    "request policy contributes one CLI MCP config"
     1
     (List.length merged);
   Alcotest.(check bool)
@@ -4039,7 +4039,7 @@ let test_kimi_cli_runtime_mcp_jsons_include_request_policy () =
     (List.exists (contains_substring ~needle:"http://127.0.0.1:8947/mcp") merged)
 ;;
 
-let test_kimi_cli_build_args_include_runtime_mcp_config () =
+let test_json_stream_cli_build_args_include_runtime_mcp_config () =
   let policy =
     { Llm_provider.Llm_transport.empty_runtime_mcp_policy with
       servers =
@@ -4053,11 +4053,11 @@ let test_kimi_cli_build_args_include_runtime_mcp_config () =
     }
   in
   let mcp_config_json =
-    Cascade_transport.kimi_cli_runtime_mcp_jsons ~base:[] (Some policy)
+    Cascade_transport.cli_runtime_mcp_jsons ~base:[] (Some policy)
   in
   let argv =
-    Cascade_transport.Kimi_cli_transport_local.build_args
-      ~config:Cascade_transport.Kimi_cli_transport_local.default_config
+    Cascade_transport.Json_stream_cli_transport_local.build_args
+      ~config:Cascade_transport.Json_stream_cli_transport_local.default_config
       ~req_config:(make_kimi_cli_provider_cfg ())
       ~mcp_config_json
       ~prompt:"hello"
@@ -4069,11 +4069,11 @@ let test_kimi_cli_build_args_include_runtime_mcp_config () =
     (List.exists (contains_substring ~needle:"http://127.0.0.1:8947/mcp") argv)
 ;;
 
-let test_kimi_cli_build_args_uses_stdin_for_large_prompt () =
+let test_json_stream_cli_build_args_uses_stdin_for_large_prompt () =
   let long_prompt = String.make (20 * 1024) 'x' in
   let argv =
-    Cascade_transport.Kimi_cli_transport_local.build_args
-      ~config:Cascade_transport.Kimi_cli_transport_local.default_config
+    Cascade_transport.Json_stream_cli_transport_local.build_args
+      ~config:Cascade_transport.Json_stream_cli_transport_local.default_config
       ~req_config:(make_kimi_cli_provider_cfg ())
       ~mcp_config_json:[]
       ~prompt:long_prompt
@@ -4085,11 +4085,11 @@ let test_kimi_cli_build_args_uses_stdin_for_large_prompt () =
   Alcotest.(check bool) "large prompt does not use -p" false (List.mem "-p" argv)
 ;;
 
-let test_kimi_cli_build_args_uses_stdin_for_non_ascii_prompt () =
+let test_json_stream_cli_build_args_uses_stdin_for_non_ascii_prompt () =
   let prompt = "한글 prompt" in
   let argv =
-    Cascade_transport.Kimi_cli_transport_local.build_args
-      ~config:Cascade_transport.Kimi_cli_transport_local.default_config
+    Cascade_transport.Json_stream_cli_transport_local.build_args
+      ~config:Cascade_transport.Json_stream_cli_transport_local.default_config
       ~req_config:(make_kimi_cli_provider_cfg ())
       ~mcp_config_json:[]
       ~prompt
@@ -4101,11 +4101,11 @@ let test_kimi_cli_build_args_uses_stdin_for_non_ascii_prompt () =
   Alcotest.(check bool) "non-ASCII prompt does not use -p" false (List.mem "-p" argv)
 ;;
 
-let test_kimi_cli_build_args_sanitizes_broken_utf8_prompt () =
+let test_json_stream_cli_build_args_sanitizes_broken_utf8_prompt () =
   let prompt = "prefix\x80suffix" in
   let argv =
-    Cascade_transport.Kimi_cli_transport_local.build_args
-      ~config:Cascade_transport.Kimi_cli_transport_local.default_config
+    Cascade_transport.Json_stream_cli_transport_local.build_args
+      ~config:Cascade_transport.Json_stream_cli_transport_local.default_config
       ~req_config:(make_kimi_cli_provider_cfg ())
       ~mcp_config_json:[]
       ~prompt
@@ -4172,18 +4172,18 @@ let test_cli_model_for_provider_config_keeps_explicit_model () =
   let provider_cfg =
     Llm_provider.Provider_config.make
       ~kind:Llm_provider.Provider_config.Kimi_cli
-      ~model_id:"kimi-k2.5"
+      ~model_id:"provider-model-2.5"
       ~base_url:""
       ()
   in
   Alcotest.(check (option string))
     "explicit model preserved"
-    (Some "kimi-k2.5")
+    (Some "provider-model-2.5")
     (Cascade_transport.cli_model_for_provider_config provider_cfg)
 ;;
 
-let test_kimi_cli_config_uses_oas_context_ssot () =
-  let model_id = "kimi-for-coding" in
+let test_json_stream_cli_config_uses_oas_context_ssot () =
+  let model_id = "provider-model" in
   let provider_cfg =
     Llm_provider.Provider_config.make
       ~kind:Llm_provider.Provider_config.Kimi_cli
@@ -4192,8 +4192,8 @@ let test_kimi_cli_config_uses_oas_context_ssot () =
       ~api_key:"test-key"
       ()
   in
-  match Cascade_transport.kimi_cli_config_json_for_provider provider_cfg with
-  | None -> Alcotest.fail "expected kimi_cli config json"
+  match Cascade_transport.cli_runtime_config_json_for_provider provider_cfg with
+  | None -> Alcotest.fail "expected CLI config json"
   | Some raw ->
     let json = _parse_json raw in
     let backing = direct_runtime_binding_for_cli_provider_exn provider_cfg in
@@ -4210,9 +4210,9 @@ let test_kimi_cli_config_uses_oas_context_ssot () =
     Alcotest.(check int) "max_context_size from OAS capabilities SSOT" expected actual
 ;;
 
-let test_kimi_cli_rejects_invalid_tool_argument_json () =
-  let dir = temp_dir "kimi_cli_bad_tool_args" in
-  let fake_kimi_path = Filename.concat dir "fake-kimi" in
+let test_json_stream_cli_rejects_invalid_tool_argument_json () =
+  let dir = temp_dir "json_stream_cli_bad_tool_args" in
+  let fake_cli_path = Filename.concat dir "fake-cli" in
   let invalid_tool_line =
     Yojson.Safe.to_string
       (`Assoc
@@ -4230,13 +4230,13 @@ let test_kimi_cli_rejects_invalid_tool_argument_json () =
                 ] )
           ])
   in
-  let oc = open_out fake_kimi_path in
+  let oc = open_out fake_cli_path in
   output_string oc ("#!/bin/sh\ncat <<'JSON'\n" ^ invalid_tool_line ^ "\nJSON\n");
   close_out oc;
-  Unix.chmod fake_kimi_path 0o755;
+  Unix.chmod fake_cli_path 0o755;
   let config =
-    { Cascade_transport.Kimi_cli_transport_local.default_config with
-      kimi_path = fake_kimi_path
+    { Cascade_transport.Json_stream_cli_transport_local.default_config with
+      cli_path = fake_cli_path
     }
   in
   let req =
@@ -4255,7 +4255,7 @@ let test_kimi_cli_rejects_invalid_tool_argument_json () =
   Eio.Switch.run
   @@ fun sw ->
   let transport =
-    Cascade_transport.Kimi_cli_transport_local.create
+    Cascade_transport.Json_stream_cli_transport_local.create
       ~sw
       ~mgr:(require_test_proc_mgr ())
       ~config
@@ -4272,7 +4272,7 @@ let test_kimi_cli_rejects_invalid_tool_argument_json () =
     Alcotest.(check bool)
       "invalid arguments rejected"
       true
-      (contains_substring ~needle:"invalid kimi tool arguments JSON" message);
+      (contains_substring ~needle:"invalid CLI tool arguments JSON" message);
     Alcotest.(check bool)
       "tool name included"
       true
@@ -4281,9 +4281,9 @@ let test_kimi_cli_rejects_invalid_tool_argument_json () =
   | Ok _ -> Alcotest.fail "expected invalid tool arguments to fail parsing"
 ;;
 
-let test_kimi_cli_treats_whitespace_tool_arguments_as_empty_json () =
-  let dir = temp_dir "kimi_cli_whitespace_tool_args" in
-  let fake_kimi_path = Filename.concat dir "fake-kimi" in
+let test_json_stream_cli_treats_whitespace_tool_arguments_as_empty_json () =
+  let dir = temp_dir "json_stream_cli_whitespace_tool_args" in
+  let fake_cli_path = Filename.concat dir "fake-cli" in
   let whitespace_tool_line =
     Yojson.Safe.to_string
       (`Assoc
@@ -4302,11 +4302,11 @@ let test_kimi_cli_treats_whitespace_tool_arguments_as_empty_json () =
           ])
   in
   write_executable_file
-    fake_kimi_path
+    fake_cli_path
     ("#!/bin/sh\ncat <<'JSON'\n" ^ whitespace_tool_line ^ "\nJSON\n");
   let config =
-    { Cascade_transport.Kimi_cli_transport_local.default_config with
-      kimi_path = fake_kimi_path
+    { Cascade_transport.Json_stream_cli_transport_local.default_config with
+      cli_path = fake_cli_path
     }
   in
   let req =
@@ -4325,7 +4325,7 @@ let test_kimi_cli_treats_whitespace_tool_arguments_as_empty_json () =
   Eio.Switch.run
   @@ fun sw ->
   let transport =
-    Cascade_transport.Kimi_cli_transport_local.create
+    Cascade_transport.Json_stream_cli_transport_local.create
       ~sw
       ~mgr:(require_test_proc_mgr ())
       ~config
@@ -4344,9 +4344,9 @@ let test_kimi_cli_treats_whitespace_tool_arguments_as_empty_json () =
   | Error _ -> Alcotest.fail "expected whitespace arguments to parse as {}"
 ;;
 
-let test_kimi_cli_stream_rejects_invalid_tool_argument_json () =
-  let dir = temp_dir "kimi_cli_stream_bad_tool_args" in
-  let fake_kimi_path = Filename.concat dir "fake-kimi" in
+let test_json_stream_cli_stream_rejects_invalid_tool_argument_json () =
+  let dir = temp_dir "json_stream_cli_stream_bad_tool_args" in
+  let fake_cli_path = Filename.concat dir "fake-cli" in
   let assistant_text text =
     Yojson.Safe.to_string
       (`Assoc [ "role", `String "assistant"; "content", `String text ])
@@ -4369,7 +4369,7 @@ let test_kimi_cli_stream_rejects_invalid_tool_argument_json () =
           ])
   in
   write_executable_file
-    fake_kimi_path
+    fake_cli_path
     (String.concat
        "\n"
        [ "#!/bin/sh"
@@ -4381,8 +4381,8 @@ let test_kimi_cli_stream_rejects_invalid_tool_argument_json () =
        ]
      ^ "\n");
   let config =
-    { Cascade_transport.Kimi_cli_transport_local.default_config with
-      kimi_path = fake_kimi_path
+    { Cascade_transport.Json_stream_cli_transport_local.default_config with
+      cli_path = fake_cli_path
     }
   in
   let req =
@@ -4401,7 +4401,7 @@ let test_kimi_cli_stream_rejects_invalid_tool_argument_json () =
   Eio.Switch.run
   @@ fun sw ->
   let transport =
-    Cascade_transport.Kimi_cli_transport_local.create
+    Cascade_transport.Json_stream_cli_transport_local.create
       ~sw
       ~mgr:(require_test_proc_mgr ())
       ~config
@@ -4429,7 +4429,7 @@ let test_kimi_cli_stream_rejects_invalid_tool_argument_json () =
     Alcotest.(check bool)
       "invalid arguments rejected"
       true
-      (contains_substring ~needle:"invalid kimi tool arguments JSON" message);
+      (contains_substring ~needle:"invalid CLI tool arguments JSON" message);
     Alcotest.(check bool)
       "tool name included"
       true
@@ -4438,37 +4438,37 @@ let test_kimi_cli_stream_rejects_invalid_tool_argument_json () =
   | Ok _ -> Alcotest.fail "expected invalid tool arguments to fail streaming"
 ;;
 
-let test_kimi_cli_should_log_stderr_line_filters_resume_noise () =
-  let should_log = Cascade_transport.Kimi_cli_transport_local.should_log_stderr_line in
+let test_json_stream_cli_should_log_stderr_line_filters_resume_noise () =
+  let should_log = Cascade_transport.Json_stream_cli_transport_local.should_log_stderr_line in
   Alcotest.(check bool) "blank stderr line suppressed" false (should_log "");
   Alcotest.(check bool) "whitespace stderr line suppressed" false (should_log "   ");
   Alcotest.(check bool)
     "resume hint suppressed"
     false
-    (should_log "To resume this session: kimi -r ff37febe");
+    (should_log "To resume this session: cli-tool -r ff37febe");
   Alcotest.(check bool)
     "case-insensitive resume hint suppressed"
     false
-    (should_log "  TO RESUME THIS SESSION: kimi -r ff37febe");
+    (should_log "  TO RESUME THIS SESSION: cli-tool -r ff37febe");
   Alcotest.(check bool)
     "unexpected stderr remains visible"
     true
-    (should_log "fatal: kimi auth missing");
+    (should_log "fatal: CLI auth missing");
   Alcotest.(check bool)
     "other stderr guidance remains visible"
     true
     (should_log "warning: upstream endpoint is slow")
 ;;
 
-let test_kimi_cli_error_completion_uses_measured_latency () =
-  let dir = temp_dir "kimi_cli_error_latency" in
-  let fake_kimi_path = Filename.concat dir "fake-kimi" in
+let test_json_stream_cli_error_completion_uses_measured_latency () =
+  let dir = temp_dir "json_stream_cli_error_latency" in
+  let fake_cli_path = Filename.concat dir "fake-cli" in
   write_executable_file
-    fake_kimi_path
+    fake_cli_path
     "#!/bin/sh\nsleep 0.05\nprintf '%s\\n' 'simulated failure' >&2\nexit 7\n";
   let config =
-    { Cascade_transport.Kimi_cli_transport_local.default_config with
-      kimi_path = fake_kimi_path
+    { Cascade_transport.Json_stream_cli_transport_local.default_config with
+      cli_path = fake_cli_path
     }
   in
   let req =
@@ -4487,7 +4487,7 @@ let test_kimi_cli_error_completion_uses_measured_latency () =
   Eio.Switch.run
   @@ fun sw ->
   let transport =
-    Cascade_transport.Kimi_cli_transport_local.create
+    Cascade_transport.Json_stream_cli_transport_local.create
       ~sw
       ~mgr:(require_test_proc_mgr ())
       ~config
@@ -4501,19 +4501,19 @@ let test_kimi_cli_error_completion_uses_measured_latency () =
      | None -> false);
   match response with
   | Error _ -> ()
-  | Ok _ -> Alcotest.fail "expected fake kimi subprocess to fail"
+  | Ok _ -> Alcotest.fail "expected fake CLI subprocess to fail"
 ;;
 
-let test_kimi_cli_classify_cli_error_redacts_resumable_session_detail () =
+let test_json_stream_cli_classify_cli_error_redacts_resumable_session_detail () =
   let raw_message =
-    "kimi exited with code 75: \n\
-     To resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
+    "cli-tool exited with code 75: \n\
+     To resume this session: cli-tool -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
   in
   let canonical_detail =
-    Cascade_transport.Kimi_cli_transport_local.resumable_session_detail_of_text raw_message
+    Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail_of_text raw_message
   in
   match
-    Cascade_transport.Kimi_cli_transport_local.classify_cli_error
+    Cascade_transport.Json_stream_cli_transport_local.classify_cli_error
       (Error
          (Llm_provider.Http_client.NetworkError
             { message = raw_message; kind = Llm_provider.Http_client.Unknown }))
@@ -4531,26 +4531,26 @@ let test_kimi_cli_classify_cli_error_redacts_resumable_session_detail () =
   | _ -> Alcotest.fail "expected resumable session to map to AcceptRejected"
 ;;
 
-let test_kimi_cli_classify_cli_error_treats_exit_1_resume_hint_as_resumable () =
+let test_json_stream_cli_classify_cli_error_treats_exit_1_resume_hint_as_resumable () =
   let raw_message =
-    "kimi exited with code 1: \n\
-     To resume this session: kimi -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
+    "cli-tool exited with code 1: \n\
+     To resume this session: cli-tool -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
   in
   let canonical_detail =
-    Cascade_transport.Kimi_cli_transport_local.resumable_session_detail_of_text raw_message
+    Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail_of_text raw_message
   in
   Alcotest.(check bool)
     "exit 1 resume hint is resumable"
     true
-    (Cascade_transport.Kimi_cli_transport_local.text_looks_like_resumable_session
+    (Cascade_transport.Json_stream_cli_transport_local.text_looks_like_resumable_session
        raw_message);
   Alcotest.(check (option int))
     "exit code preserved"
     (Some 1)
-    (Cascade_transport.Kimi_cli_transport_local.resumable_session_exit_code_of_text
+    (Cascade_transport.Json_stream_cli_transport_local.resumable_session_exit_code_of_text
        raw_message);
   match
-    Cascade_transport.Kimi_cli_transport_local.classify_cli_error
+    Cascade_transport.Json_stream_cli_transport_local.classify_cli_error
       (Error
          (Llm_provider.Http_client.NetworkError
             { message = raw_message; kind = Llm_provider.Http_client.Unknown }))
@@ -4572,20 +4572,20 @@ let test_kimi_cli_classify_cli_error_treats_exit_1_resume_hint_as_resumable () =
   | _ -> Alcotest.fail "expected exit 1 resume hint to map to resumable session"
 ;;
 
-let test_kimi_cli_resumable_invalid_request_reclassifies_as_structured () =
+let test_json_stream_cli_resumable_invalid_request_reclassifies_as_structured () =
   let raw_message =
-    "kimi exited with code 1: \n\
-     To resume this session: kimi -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
+    "cli-tool exited with code 1: \n\
+     To resume this session: cli-tool -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
   in
   let detail =
-    Cascade_transport.Kimi_cli_transport_local.resumable_session_detail_of_text raw_message
+    Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail_of_text raw_message
   in
   let sdk_error =
     Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest { message = detail })
   in
   match
     Keeper_turn_driver.sdk_error_to_resumable_cli_session
-      ~cascade_name:(internal_cascade_name "kimi_cli_keeper")
+      ~cascade_name:(internal_cascade_name "json_stream_cli_keeper")
       sdk_error
   with
   | Some structured ->
@@ -4595,7 +4595,7 @@ let test_kimi_cli_resumable_invalid_request_reclassifies_as_structured () =
             { cascade_name; detail = structured_detail; exit_code }) ->
        Alcotest.(check string)
          "cascade"
-         "kimi_cli_keeper"
+         "json_stream_cli_keeper"
          (internal_cascade_name_to_string cascade_name);
        Alcotest.(check string) "detail" detail structured_detail;
        Alcotest.(check (option int)) "exit code" (Some 1) exit_code
@@ -4603,19 +4603,19 @@ let test_kimi_cli_resumable_invalid_request_reclassifies_as_structured () =
   | None -> Alcotest.fail "expected InvalidRequest detail to reclassify"
 ;;
 
-let test_kimi_cli_classify_cli_error_keeps_exit_1_with_error_as_reject () =
+let test_json_stream_cli_classify_cli_error_keeps_exit_1_with_error_as_reject () =
   let raw_message =
-    "kimi exited with code 1: \n\
+    "cli-tool exited with code 1: \n\
      Authentication failed\n\
-     To resume this session: kimi -r ff37febe"
+     To resume this session: cli-tool -r ff37febe"
   in
   Alcotest.(check bool)
     "exit 1 with real stderr is not resumable"
     false
-    (Cascade_transport.Kimi_cli_transport_local.text_looks_like_resumable_session
+    (Cascade_transport.Json_stream_cli_transport_local.text_looks_like_resumable_session
        raw_message);
   match
-    Cascade_transport.Kimi_cli_transport_local.classify_cli_error
+    Cascade_transport.Json_stream_cli_transport_local.classify_cli_error
       (Error
          (Llm_provider.Http_client.NetworkError
             { message = raw_message; kind = Llm_provider.Http_client.Unknown }))
@@ -4624,7 +4624,7 @@ let test_kimi_cli_classify_cli_error_keeps_exit_1_with_error_as_reject () =
     Alcotest.(check bool)
       "reject reason preserved"
       true
-      (contains_substring ~needle:"kimi_cli rejected the request (exit 1)" reason);
+      (contains_substring ~needle:"provider CLI rejected the request (exit 1)" reason);
     Alcotest.(check bool)
       "stderr detail preserved"
       true
@@ -4632,13 +4632,13 @@ let test_kimi_cli_classify_cli_error_keeps_exit_1_with_error_as_reject () =
   | _ -> Alcotest.fail "expected exit 1 with real stderr to stay rejected"
 ;;
 
-let test_kimi_cli_classify_cli_error_labels_process_title_unicode_crash () =
+let test_json_stream_cli_classify_cli_error_labels_process_title_unicode_crash () =
   let raw_message =
-    "kimi exited with code 1: Traceback ... setproctitle/__init__.py:57 in <module> \
+    "cli-tool exited with code 1: Traceback ... setproctitle/__init__.py:57 in <module> \
      getproctitle() UnicodeDecodeError: 'utf-8' codec can't decode byte 0xef"
   in
   match
-    Cascade_transport.Kimi_cli_transport_local.classify_cli_error
+    Cascade_transport.Json_stream_cli_transport_local.classify_cli_error
       (Error
          (Llm_provider.Http_client.NetworkError
             { message = raw_message; kind = Llm_provider.Http_client.Unknown }))
@@ -4659,17 +4659,17 @@ let test_kimi_cli_classify_cli_error_labels_process_title_unicode_crash () =
   | _ -> Alcotest.fail "expected setproctitle UnicodeDecodeError to map to AcceptRejected"
 ;;
 
-let test_sdk_error_terminal_provider_runtime_detects_kimi_unicode_crash () =
+let test_sdk_error_terminal_provider_runtime_detects_cli_unicode_crash () =
   let err =
     Agent_sdk.Error.Api
       (Llm_provider.Retry.InvalidRequest
          { message =
-             "kimi_cli rejected the request (exit 1): startup crash: UnicodeDecodeError: \
+             "provider CLI rejected the request (exit 1): startup crash: UnicodeDecodeError: \
               'utf-8' codec can't decode byte 0xef"
          })
   in
   Alcotest.(check bool)
-    "Kimi startup UnicodeDecodeError is terminal provider runtime"
+    "CLI startup UnicodeDecodeError is terminal provider runtime"
     true
     (Keeper_turn_driver.sdk_error_is_terminal_provider_runtime_failure err)
 ;;
@@ -6443,9 +6443,9 @@ let () =
             `Quick
             test_sdk_error_is_resumable_cli_session_detects_structured_error
         ; Alcotest.test_case
-            "sdk_error_is_resumable_cli_session detects raw Kimi hint"
+            "sdk_error_is_resumable_cli_session detects raw CLI hint"
             `Quick
-            test_sdk_error_is_resumable_cli_session_detects_raw_kimi_hint
+            test_sdk_error_is_resumable_cli_session_detects_raw_cli_hint
         ; Alcotest.test_case
             "fallback class labels resumable CLI session"
             `Quick
@@ -6690,9 +6690,9 @@ let () =
             `Quick
             test_classify_filter_rejection_passes_when_provider_supported
         ; Alcotest.test_case
-            "kimi runtime MCP config keeps only allowed servers"
+            "CLI runtime MCP config keeps only allowed servers"
             `Quick
-            test_kimi_mcp_config_json_of_policy_filters_to_allowed_servers
+            test_cli_mcp_config_json_of_policy_filters_to_allowed_servers
         ; Alcotest.test_case
             "runtime MCP policy injects keeper agent header for masc server"
             `Quick
@@ -6715,25 +6715,25 @@ let () =
             `Quick
             test_runtime_mcp_policy_for_provider_codex_cli_no_agent_strips_all
         ; Alcotest.test_case
-            "kimi request runtime MCP config is merged"
+            "CLI request runtime MCP config is merged"
             `Quick
-            test_kimi_cli_runtime_mcp_jsons_include_request_policy
+            test_cli_runtime_mcp_jsons_include_request_policy
         ; Alcotest.test_case
-            "kimi argv includes request runtime MCP config"
+            "CLI argv includes request runtime MCP config"
             `Quick
-            test_kimi_cli_build_args_include_runtime_mcp_config
+            test_json_stream_cli_build_args_include_runtime_mcp_config
         ; Alcotest.test_case
-            "kimi large prompt uses stdin, not argv"
+            "CLI large prompt uses stdin, not argv"
             `Quick
-            test_kimi_cli_build_args_uses_stdin_for_large_prompt
+            test_json_stream_cli_build_args_uses_stdin_for_large_prompt
         ; Alcotest.test_case
-            "kimi non-ASCII prompt uses stdin, not argv"
+            "CLI non-ASCII prompt uses stdin, not argv"
             `Quick
-            test_kimi_cli_build_args_uses_stdin_for_non_ascii_prompt
+            test_json_stream_cli_build_args_uses_stdin_for_non_ascii_prompt
         ; Alcotest.test_case
-            "kimi broken UTF-8 prompt is sanitized off argv"
+            "CLI broken UTF-8 prompt is sanitized off argv"
             `Quick
-            test_kimi_cli_build_args_sanitizes_broken_utf8_prompt
+            test_json_stream_cli_build_args_sanitizes_broken_utf8_prompt
         ; Alcotest.test_case
             "CLI auto model uses runtime binding default"
             `Quick
@@ -6743,53 +6743,53 @@ let () =
             `Quick
             test_cli_model_for_provider_config_keeps_explicit_model
         ; Alcotest.test_case
-            "kimi config max context uses OAS SSOT"
+            "CLI config max context uses OAS SSOT"
             `Quick
-            test_kimi_cli_config_uses_oas_context_ssot
+            test_json_stream_cli_config_uses_oas_context_ssot
         ; Alcotest.test_case
-            "kimi invalid tool argument JSON is rejected"
+            "CLI invalid tool argument JSON is rejected"
             `Quick
-            test_kimi_cli_rejects_invalid_tool_argument_json
+            test_json_stream_cli_rejects_invalid_tool_argument_json
         ; Alcotest.test_case
-            "kimi whitespace tool arguments become empty JSON"
+            "CLI whitespace tool arguments become empty JSON"
             `Quick
-            test_kimi_cli_treats_whitespace_tool_arguments_as_empty_json
+            test_json_stream_cli_treats_whitespace_tool_arguments_as_empty_json
         ; Alcotest.test_case
-            "kimi stream invalid tool argument JSON is rejected"
+            "CLI stream invalid tool argument JSON is rejected"
             `Quick
-            test_kimi_cli_stream_rejects_invalid_tool_argument_json
+            test_json_stream_cli_stream_rejects_invalid_tool_argument_json
         ; Alcotest.test_case
-            "kimi stderr resume noise is filtered"
+            "CLI stderr resume noise is filtered"
             `Quick
-            test_kimi_cli_should_log_stderr_line_filters_resume_noise
+            test_json_stream_cli_should_log_stderr_line_filters_resume_noise
         ; Alcotest.test_case
-            "kimi error completion measures latency"
+            "CLI error completion measures latency"
             `Quick
-            test_kimi_cli_error_completion_uses_measured_latency
+            test_json_stream_cli_error_completion_uses_measured_latency
         ; Alcotest.test_case
-            "kimi exit 75 detail is redacted"
+            "CLI exit 75 detail is redacted"
             `Quick
-            test_kimi_cli_classify_cli_error_redacts_resumable_session_detail
+            test_json_stream_cli_classify_cli_error_redacts_resumable_session_detail
         ; Alcotest.test_case
-            "kimi exit 1 resume hint is resumable"
+            "CLI exit 1 resume hint is resumable"
             `Quick
-            test_kimi_cli_classify_cli_error_treats_exit_1_resume_hint_as_resumable
+            test_json_stream_cli_classify_cli_error_treats_exit_1_resume_hint_as_resumable
         ; Alcotest.test_case
-            "kimi resumable InvalidRequest is structured"
+            "CLI resumable InvalidRequest is structured"
             `Quick
-            test_kimi_cli_resumable_invalid_request_reclassifies_as_structured
+            test_json_stream_cli_resumable_invalid_request_reclassifies_as_structured
         ; Alcotest.test_case
-            "kimi exit 1 with stderr remains rejected"
+            "CLI exit 1 with stderr remains rejected"
             `Quick
-            test_kimi_cli_classify_cli_error_keeps_exit_1_with_error_as_reject
+            test_json_stream_cli_classify_cli_error_keeps_exit_1_with_error_as_reject
         ; Alcotest.test_case
-            "kimi setproctitle unicode crash is startup crash"
+            "CLI setproctitle unicode crash is startup crash"
             `Quick
-            test_kimi_cli_classify_cli_error_labels_process_title_unicode_crash
+            test_json_stream_cli_classify_cli_error_labels_process_title_unicode_crash
         ; Alcotest.test_case
-            "terminal runtime detects Kimi unicode crash"
+            "terminal runtime detects CLI unicode crash"
             `Quick
-            test_sdk_error_terminal_provider_runtime_detects_kimi_unicode_crash
+            test_sdk_error_terminal_provider_runtime_detects_cli_unicode_crash
         ; Alcotest.test_case
             "terminal runtime detects JSON-RPC SSE parse storm"
             `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2582,11 +2582,18 @@ let make_openai_compat_provider_cfg ?(model_id = "gpt-4.1") () =
     ()
 ;;
 
-let make_glm_provider_cfg
-      ?(base_url = Llm_provider.Zai_catalog.general_base_url)
-      ?(model_id = "glm-5.1")
-      ()
-  =
+let provider_binding_base_url_exn id =
+  match Agent_sdk.Provider_runtime_binding.find id with
+  | Some binding -> binding.Agent_sdk.Provider_runtime_binding.base_url
+  | None -> Alcotest.failf "expected OAS runtime binding %S" id
+;;
+
+let make_glm_provider_cfg ?base_url ?(model_id = "glm-5.1") () =
+  let base_url =
+    match base_url with
+    | Some url -> url
+    | None -> provider_binding_base_url_exn "glm"
+  in
   Llm_provider.Provider_config.make
     ~kind:Llm_provider.Provider_config.Glm
     ~model_id
@@ -2634,7 +2641,7 @@ let test_cascade_provider_labels_keep_glm_and_glm_coding_distinct () =
   in
   let glm_coding =
     Masc_mcp.Cascade_legacy_runner.provider_name_of_config
-      (make_glm_provider_cfg ~base_url:Llm_provider.Zai_catalog.coding_base_url ())
+      (make_glm_provider_cfg ~base_url:(provider_binding_base_url_exn "glm-coding") ())
   in
   Alcotest.(check string) "general GLM label" "glm" glm;
   Alcotest.(check string) "coding GLM label" "glm-coding" glm_coding
@@ -4110,15 +4117,58 @@ let test_kimi_cli_build_args_sanitizes_broken_utf8_prompt () =
     (List.mem "-p" argv)
 ;;
 
-let test_kimi_cli_model_for_provider_keeps_transport_default_on_auto () =
-  let provider_cfg = make_kimi_cli_provider_cfg () in
-  Alcotest.(check (option string))
-    "auto uses transport default"
-    Llm_provider.Transport_kimi_cli.default_config.model
-    (Cascade_runner.kimi_cli_model_for_provider provider_cfg)
+let runtime_binding_for_config_exn provider_cfg =
+  match Agent_sdk.Provider_runtime_binding.binding_for_provider_config provider_cfg with
+  | Some binding -> binding
+  | None -> Alcotest.fail "expected OAS runtime binding for provider config"
 ;;
 
-let test_kimi_cli_model_for_provider_keeps_explicit_model () =
+let runtime_binding_default_model_exn provider_cfg =
+  let binding = runtime_binding_for_config_exn provider_cfg in
+  match binding.Agent_sdk.Provider_runtime_binding.default_model with
+  | Some model when String.trim model <> "" -> Some model
+  | _ ->
+    (match binding.Agent_sdk.Provider_runtime_binding.capabilities.supported_models with
+     | Some (model :: _) -> Some model
+     | Some [] | None -> None)
+;;
+
+let direct_runtime_binding_for_cli_provider_exn provider_cfg =
+  let binding = runtime_binding_for_config_exn provider_cfg in
+  let candidates =
+    [ binding.Agent_sdk.Provider_runtime_binding.credential_scope
+    ; binding.Agent_sdk.Provider_runtime_binding.command
+    ]
+    |> List.filter_map (function
+      | Some value when String.trim value <> "" -> Some value
+      | Some _ | None -> None)
+  in
+  match
+    List.find_map
+      (fun label ->
+         match Agent_sdk.Provider_runtime_binding.find label with
+         | Some candidate ->
+           (match candidate.Agent_sdk.Provider_runtime_binding.transport with
+            | Agent_sdk.Provider_runtime_binding.Http
+            | Agent_sdk.Provider_runtime_binding.Managed
+            | Agent_sdk.Provider_runtime_binding.Custom_openai_compat -> Some candidate
+            | Agent_sdk.Provider_runtime_binding.Cli -> None)
+         | None -> None)
+      candidates
+  with
+  | Some binding -> binding
+  | None -> Alcotest.fail "expected direct OAS runtime binding for CLI provider"
+;;
+
+let test_cli_model_for_provider_config_uses_runtime_default_on_auto () =
+  let provider_cfg = make_kimi_cli_provider_cfg () in
+  Alcotest.(check (option string))
+    "auto uses runtime binding default"
+    (runtime_binding_default_model_exn provider_cfg)
+    (Cascade_runner.cli_model_for_provider_config provider_cfg)
+;;
+
+let test_cli_model_for_provider_config_keeps_explicit_model () =
   let provider_cfg =
     Llm_provider.Provider_config.make
       ~kind:Llm_provider.Provider_config.Kimi_cli
@@ -4129,7 +4179,7 @@ let test_kimi_cli_model_for_provider_keeps_explicit_model () =
   Alcotest.(check (option string))
     "explicit model preserved"
     (Some "kimi-k2.5")
-    (Cascade_runner.kimi_cli_model_for_provider provider_cfg)
+    (Cascade_runner.cli_model_for_provider_config provider_cfg)
 ;;
 
 let test_kimi_cli_config_uses_oas_context_ssot () =
@@ -4146,11 +4196,17 @@ let test_kimi_cli_config_uses_oas_context_ssot () =
   | None -> Alcotest.fail "expected kimi_cli config json"
   | Some raw ->
     let json = _parse_json raw in
+    let backing = direct_runtime_binding_for_cli_provider_exn provider_cfg in
+    let provider_name = backing.Agent_sdk.Provider_runtime_binding.id in
     let actual =
       Yojson.Safe.Util.(
         json |> member "models" |> member model_id |> member "max_context_size" |> to_int)
     in
-    let expected = Cascade_config.resolve_kimi_max_context model_id in
+    let expected =
+      Cascade_config.resolve_provider_model_max_context
+        ~provider_name
+        model_id
+    in
     Alcotest.(check int) "max_context_size from OAS capabilities SSOT" expected actual
 ;;
 
@@ -6679,13 +6735,13 @@ let () =
             `Quick
             test_kimi_cli_build_args_sanitizes_broken_utf8_prompt
         ; Alcotest.test_case
-            "kimi auto model keeps transport default"
+            "CLI auto model uses runtime binding default"
             `Quick
-            test_kimi_cli_model_for_provider_keeps_transport_default_on_auto
+            test_cli_model_for_provider_config_uses_runtime_default_on_auto
         ; Alcotest.test_case
-            "kimi explicit model is preserved"
+            "CLI explicit model is preserved"
             `Quick
-            test_kimi_cli_model_for_provider_keeps_explicit_model
+            test_cli_model_for_provider_config_keeps_explicit_model
         ; Alcotest.test_case
             "kimi config max context uses OAS SSOT"
             `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -827,33 +827,33 @@ let test_cascade_observation_json_includes_fallback_fields () =
         Masc_mcp.Keeper_cascade_profile.Runtime_name
           Masc_mcp.(Keeper_config.default_cascade_name ())
     ; strategy = Some "round_robin"
-    ; configured_labels = [ "glm:auto"; "llama:auto" ]
-    ; candidate_models = [ "glm:glm-5.1"; "openai:qwen3.5-35b" ]
-    ; primary_model = Some "glm:glm-5.1"
-    ; selected_model = Some "openai:qwen3.5-35b"
-    ; selected_model_raw = Some "qwen3.5-35b"
+    ; configured_labels = [ "primary:auto"; "secondary:auto" ]
+    ; candidate_models = [ "primary:model-alpha"; "secondary:model-beta" ]
+    ; primary_model = Some "primary:model-alpha"
+    ; selected_model = Some "secondary:model-beta"
+    ; selected_model_raw = Some "model-beta"
     ; selected_index = Some 1
     ; fallback_hops = Some 1
     ; fallback_applied = true
     ; attempts =
         [ { attempt_index = 0
-          ; model_id = "glm-5.1"
-          ; model_label = Some "glm:glm-5.1"
+          ; model_id = "model-alpha"
+          ; model_label = Some "primary:model-alpha"
           ; latency_ms = None
           ; error = Some "HTTP 503"
           }
         ; { attempt_index = 1
-          ; model_id = "qwen3.5-35b"
-          ; model_label = Some "openai:qwen3.5-35b"
+          ; model_id = "model-beta"
+          ; model_label = Some "secondary:model-beta"
           ; latency_ms = Some 212
           ; error = None
           }
         ]
     ; fallback_events =
-        [ { from_model_id = "glm-5.1"
-          ; from_model_label = Some "glm:glm-5.1"
-          ; to_model_id = "qwen3.5-35b"
-          ; to_model_label = Some "openai:qwen3.5-35b"
+        [ { from_model_id = "model-alpha"
+          ; from_model_label = Some "primary:model-alpha"
+          ; to_model_id = "model-beta"
+          ; to_model_label = Some "secondary:model-beta"
           ; reason = "HTTP 503"
           }
         ]
@@ -876,7 +876,7 @@ let test_cascade_observation_json_includes_fallback_fields () =
     Yojson.Safe.Util.(json |> member "fallback_hops" |> to_int);
   Alcotest.(check string)
     "selected model preserved"
-    "openai:qwen3.5-35b"
+    "secondary:model-beta"
     Yojson.Safe.Util.(json |> member "selected_model" |> to_string);
   Alcotest.(check int)
     "attempt count preserved"
@@ -1019,33 +1019,33 @@ let test_cascade_audit_persists_observation () =
        let observation : Masc_mcp.Cascade_legacy_runner.cascade_observation =
          { cascade_name = Masc_mcp.Keeper_cascade_profile.Runtime_name "audit-cascade"
          ; strategy = Some "round_robin"
-         ; configured_labels = [ "glm:auto"; "openai:auto" ]
-         ; candidate_models = [ "glm:glm-5.1"; "openai:qwen3.5-35b" ]
-         ; primary_model = Some "glm:glm-5.1"
-         ; selected_model = Some "openai:qwen3.5-35b"
-         ; selected_model_raw = Some "qwen3.5-35b"
+         ; configured_labels = [ "primary:auto"; "secondary:auto" ]
+         ; candidate_models = [ "primary:model-alpha"; "secondary:model-beta" ]
+         ; primary_model = Some "primary:model-alpha"
+         ; selected_model = Some "secondary:model-beta"
+         ; selected_model_raw = Some "model-beta"
          ; selected_index = Some 1
          ; fallback_hops = Some 1
          ; fallback_applied = true
          ; attempts =
              [ { attempt_index = 0
-               ; model_id = "glm-5.1"
-               ; model_label = Some "glm:glm-5.1"
+               ; model_id = "model-alpha"
+               ; model_label = Some "primary:model-alpha"
                ; latency_ms = Some 120
                ; error = Some "HTTP 503"
                }
              ; { attempt_index = 1
-               ; model_id = "qwen3.5-35b"
-               ; model_label = Some "openai:qwen3.5-35b"
+               ; model_id = "model-beta"
+               ; model_label = Some "secondary:model-beta"
                ; latency_ms = Some 90
                ; error = None
                }
              ]
          ; fallback_events =
-             [ { from_model_id = "glm-5.1"
-               ; from_model_label = Some "glm:glm-5.1"
-               ; to_model_id = "qwen3.5-35b"
-               ; to_model_label = Some "openai:qwen3.5-35b"
+             [ { from_model_id = "model-alpha"
+               ; from_model_label = Some "primary:model-alpha"
+               ; to_model_id = "model-beta"
+               ; to_model_label = Some "secondary:model-beta"
                ; reason = "HTTP 503"
                }
              ]
@@ -1054,7 +1054,7 @@ let test_cascade_audit_persists_observation () =
          }
        in
        Masc_mcp.Cascade_legacy_runner.record_cascade
-         ~keeper_name:"keeper-glm-agent-test"
+         ~keeper_name:"keeper-provider-agent-test"
          ~cascade_name:(internal_cascade_name "audit-cascade")
          ~observation:(Some observation)
          ~outcome:`Failure
@@ -1071,7 +1071,7 @@ let test_cascade_audit_persists_observation () =
            Yojson.Safe.Util.(json |> member "cascade_name" |> to_string);
          Alcotest.(check string)
            "keeper_name persisted (#11081)"
-           "keeper-glm-agent-test"
+           "keeper-provider-agent-test"
            Yojson.Safe.Util.(json |> member "keeper_name" |> to_string);
          Alcotest.(check string)
            "top_level_reason promoted (#11081)"
@@ -1083,7 +1083,7 @@ let test_cascade_audit_persists_observation () =
            Yojson.Safe.Util.(json |> member "outcome" |> to_string);
          Alcotest.(check string)
            "selected model persisted"
-           "openai:qwen3.5-35b"
+           "secondary:model-beta"
            Yojson.Safe.Util.(
              json |> member "observation" |> member "selected_model" |> to_string);
          Alcotest.(check bool)

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1344,7 +1344,7 @@ let test_sdk_error_to_cascade_outcome_cascades_resumable_cli_session () =
      To resume this session: kimi -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
   in
   let detail =
-    Cascade_runner.Kimi_cli_transport_local.resumable_session_detail_of_text raw_message
+    Cascade_transport.Kimi_cli_transport_local.resumable_session_detail_of_text raw_message
   in
   let sdk_error =
     Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest { message = detail })
@@ -2516,7 +2516,7 @@ let test_classify_masc_internal_error_roundtrip () =
     Keeper_turn_driver.sdk_error_of_masc_internal_error
       (Keeper_turn_driver.Resumable_cli_session
          { cascade_name = internal_cascade_name "kimi_cli_keeper"
-         ; detail = Cascade_runner.Kimi_cli_transport_local.resumable_session_detail
+         ; detail = Cascade_transport.Kimi_cli_transport_local.resumable_session_detail
          ; exit_code = Some 75
          })
   in
@@ -2528,7 +2528,7 @@ let test_classify_masc_internal_error_roundtrip () =
       (internal_cascade_name_to_string cascade_name);
     Alcotest.(check string)
       "resumable detail redacted"
-      Cascade_runner.Kimi_cli_transport_local.resumable_session_detail
+      Cascade_transport.Kimi_cli_transport_local.resumable_session_detail
       detail;
     Alcotest.(check bool)
       "resumable detail hides raw resume hint"
@@ -3756,7 +3756,7 @@ let test_kimi_mcp_config_json_of_policy_filters_to_allowed_servers () =
     ; disable_builtin_tools = true
     }
   in
-  match Cascade_runner.kimi_mcp_config_json_of_policy policy with
+  match Cascade_transport.kimi_mcp_config_json_of_policy policy with
   | None -> Alcotest.fail "expected kimi runtime MCP config JSON"
   | Some raw_json ->
     let open Yojson.Safe.Util in
@@ -4028,7 +4028,7 @@ let test_kimi_cli_runtime_mcp_jsons_include_request_policy () =
     ; disable_builtin_tools = true
     }
   in
-  let merged = Cascade_runner.kimi_cli_runtime_mcp_jsons ~base:[] (Some policy) in
+  let merged = Cascade_transport.kimi_cli_runtime_mcp_jsons ~base:[] (Some policy) in
   Alcotest.(check int)
     "request policy contributes one kimi mcp config"
     1
@@ -4053,11 +4053,11 @@ let test_kimi_cli_build_args_include_runtime_mcp_config () =
     }
   in
   let mcp_config_json =
-    Cascade_runner.kimi_cli_runtime_mcp_jsons ~base:[] (Some policy)
+    Cascade_transport.kimi_cli_runtime_mcp_jsons ~base:[] (Some policy)
   in
   let argv =
-    Cascade_runner.Kimi_cli_transport_local.build_args
-      ~config:Cascade_runner.Kimi_cli_transport_local.default_config
+    Cascade_transport.Kimi_cli_transport_local.build_args
+      ~config:Cascade_transport.Kimi_cli_transport_local.default_config
       ~req_config:(make_kimi_cli_provider_cfg ())
       ~mcp_config_json
       ~prompt:"hello"
@@ -4072,8 +4072,8 @@ let test_kimi_cli_build_args_include_runtime_mcp_config () =
 let test_kimi_cli_build_args_uses_stdin_for_large_prompt () =
   let long_prompt = String.make (20 * 1024) 'x' in
   let argv =
-    Cascade_runner.Kimi_cli_transport_local.build_args
-      ~config:Cascade_runner.Kimi_cli_transport_local.default_config
+    Cascade_transport.Kimi_cli_transport_local.build_args
+      ~config:Cascade_transport.Kimi_cli_transport_local.default_config
       ~req_config:(make_kimi_cli_provider_cfg ())
       ~mcp_config_json:[]
       ~prompt:long_prompt
@@ -4088,8 +4088,8 @@ let test_kimi_cli_build_args_uses_stdin_for_large_prompt () =
 let test_kimi_cli_build_args_uses_stdin_for_non_ascii_prompt () =
   let prompt = "한글 prompt" in
   let argv =
-    Cascade_runner.Kimi_cli_transport_local.build_args
-      ~config:Cascade_runner.Kimi_cli_transport_local.default_config
+    Cascade_transport.Kimi_cli_transport_local.build_args
+      ~config:Cascade_transport.Kimi_cli_transport_local.default_config
       ~req_config:(make_kimi_cli_provider_cfg ())
       ~mcp_config_json:[]
       ~prompt
@@ -4104,8 +4104,8 @@ let test_kimi_cli_build_args_uses_stdin_for_non_ascii_prompt () =
 let test_kimi_cli_build_args_sanitizes_broken_utf8_prompt () =
   let prompt = "prefix\x80suffix" in
   let argv =
-    Cascade_runner.Kimi_cli_transport_local.build_args
-      ~config:Cascade_runner.Kimi_cli_transport_local.default_config
+    Cascade_transport.Kimi_cli_transport_local.build_args
+      ~config:Cascade_transport.Kimi_cli_transport_local.default_config
       ~req_config:(make_kimi_cli_provider_cfg ())
       ~mcp_config_json:[]
       ~prompt
@@ -4165,7 +4165,7 @@ let test_cli_model_for_provider_config_uses_runtime_default_on_auto () =
   Alcotest.(check (option string))
     "auto uses runtime binding default"
     (runtime_binding_default_model_exn provider_cfg)
-    (Cascade_runner.cli_model_for_provider_config provider_cfg)
+    (Cascade_transport.cli_model_for_provider_config provider_cfg)
 ;;
 
 let test_cli_model_for_provider_config_keeps_explicit_model () =
@@ -4179,7 +4179,7 @@ let test_cli_model_for_provider_config_keeps_explicit_model () =
   Alcotest.(check (option string))
     "explicit model preserved"
     (Some "kimi-k2.5")
-    (Cascade_runner.cli_model_for_provider_config provider_cfg)
+    (Cascade_transport.cli_model_for_provider_config provider_cfg)
 ;;
 
 let test_kimi_cli_config_uses_oas_context_ssot () =
@@ -4192,7 +4192,7 @@ let test_kimi_cli_config_uses_oas_context_ssot () =
       ~api_key:"test-key"
       ()
   in
-  match Cascade_runner.kimi_cli_config_json_for_provider provider_cfg with
+  match Cascade_transport.kimi_cli_config_json_for_provider provider_cfg with
   | None -> Alcotest.fail "expected kimi_cli config json"
   | Some raw ->
     let json = _parse_json raw in
@@ -4235,7 +4235,7 @@ let test_kimi_cli_rejects_invalid_tool_argument_json () =
   close_out oc;
   Unix.chmod fake_kimi_path 0o755;
   let config =
-    { Cascade_runner.Kimi_cli_transport_local.default_config with
+    { Cascade_transport.Kimi_cli_transport_local.default_config with
       kimi_path = fake_kimi_path
     }
   in
@@ -4255,7 +4255,7 @@ let test_kimi_cli_rejects_invalid_tool_argument_json () =
   Eio.Switch.run
   @@ fun sw ->
   let transport =
-    Cascade_runner.Kimi_cli_transport_local.create
+    Cascade_transport.Kimi_cli_transport_local.create
       ~sw
       ~mgr:(require_test_proc_mgr ())
       ~config
@@ -4305,7 +4305,7 @@ let test_kimi_cli_treats_whitespace_tool_arguments_as_empty_json () =
     fake_kimi_path
     ("#!/bin/sh\ncat <<'JSON'\n" ^ whitespace_tool_line ^ "\nJSON\n");
   let config =
-    { Cascade_runner.Kimi_cli_transport_local.default_config with
+    { Cascade_transport.Kimi_cli_transport_local.default_config with
       kimi_path = fake_kimi_path
     }
   in
@@ -4325,7 +4325,7 @@ let test_kimi_cli_treats_whitespace_tool_arguments_as_empty_json () =
   Eio.Switch.run
   @@ fun sw ->
   let transport =
-    Cascade_runner.Kimi_cli_transport_local.create
+    Cascade_transport.Kimi_cli_transport_local.create
       ~sw
       ~mgr:(require_test_proc_mgr ())
       ~config
@@ -4381,7 +4381,7 @@ let test_kimi_cli_stream_rejects_invalid_tool_argument_json () =
        ]
      ^ "\n");
   let config =
-    { Cascade_runner.Kimi_cli_transport_local.default_config with
+    { Cascade_transport.Kimi_cli_transport_local.default_config with
       kimi_path = fake_kimi_path
     }
   in
@@ -4401,7 +4401,7 @@ let test_kimi_cli_stream_rejects_invalid_tool_argument_json () =
   Eio.Switch.run
   @@ fun sw ->
   let transport =
-    Cascade_runner.Kimi_cli_transport_local.create
+    Cascade_transport.Kimi_cli_transport_local.create
       ~sw
       ~mgr:(require_test_proc_mgr ())
       ~config
@@ -4439,7 +4439,7 @@ let test_kimi_cli_stream_rejects_invalid_tool_argument_json () =
 ;;
 
 let test_kimi_cli_should_log_stderr_line_filters_resume_noise () =
-  let should_log = Cascade_runner.Kimi_cli_transport_local.should_log_stderr_line in
+  let should_log = Cascade_transport.Kimi_cli_transport_local.should_log_stderr_line in
   Alcotest.(check bool) "blank stderr line suppressed" false (should_log "");
   Alcotest.(check bool) "whitespace stderr line suppressed" false (should_log "   ");
   Alcotest.(check bool)
@@ -4467,7 +4467,7 @@ let test_kimi_cli_error_completion_uses_measured_latency () =
     fake_kimi_path
     "#!/bin/sh\nsleep 0.05\nprintf '%s\\n' 'simulated failure' >&2\nexit 7\n";
   let config =
-    { Cascade_runner.Kimi_cli_transport_local.default_config with
+    { Cascade_transport.Kimi_cli_transport_local.default_config with
       kimi_path = fake_kimi_path
     }
   in
@@ -4487,7 +4487,7 @@ let test_kimi_cli_error_completion_uses_measured_latency () =
   Eio.Switch.run
   @@ fun sw ->
   let transport =
-    Cascade_runner.Kimi_cli_transport_local.create
+    Cascade_transport.Kimi_cli_transport_local.create
       ~sw
       ~mgr:(require_test_proc_mgr ())
       ~config
@@ -4510,10 +4510,10 @@ let test_kimi_cli_classify_cli_error_redacts_resumable_session_detail () =
      To resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
   in
   let canonical_detail =
-    Cascade_runner.Kimi_cli_transport_local.resumable_session_detail_of_text raw_message
+    Cascade_transport.Kimi_cli_transport_local.resumable_session_detail_of_text raw_message
   in
   match
-    Cascade_runner.Kimi_cli_transport_local.classify_cli_error
+    Cascade_transport.Kimi_cli_transport_local.classify_cli_error
       (Error
          (Llm_provider.Http_client.NetworkError
             { message = raw_message; kind = Llm_provider.Http_client.Unknown }))
@@ -4537,20 +4537,20 @@ let test_kimi_cli_classify_cli_error_treats_exit_1_resume_hint_as_resumable () =
      To resume this session: kimi -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
   in
   let canonical_detail =
-    Cascade_runner.Kimi_cli_transport_local.resumable_session_detail_of_text raw_message
+    Cascade_transport.Kimi_cli_transport_local.resumable_session_detail_of_text raw_message
   in
   Alcotest.(check bool)
     "exit 1 resume hint is resumable"
     true
-    (Cascade_runner.Kimi_cli_transport_local.text_looks_like_resumable_session
+    (Cascade_transport.Kimi_cli_transport_local.text_looks_like_resumable_session
        raw_message);
   Alcotest.(check (option int))
     "exit code preserved"
     (Some 1)
-    (Cascade_runner.Kimi_cli_transport_local.resumable_session_exit_code_of_text
+    (Cascade_transport.Kimi_cli_transport_local.resumable_session_exit_code_of_text
        raw_message);
   match
-    Cascade_runner.Kimi_cli_transport_local.classify_cli_error
+    Cascade_transport.Kimi_cli_transport_local.classify_cli_error
       (Error
          (Llm_provider.Http_client.NetworkError
             { message = raw_message; kind = Llm_provider.Http_client.Unknown }))
@@ -4578,7 +4578,7 @@ let test_kimi_cli_resumable_invalid_request_reclassifies_as_structured () =
      To resume this session: kimi -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
   in
   let detail =
-    Cascade_runner.Kimi_cli_transport_local.resumable_session_detail_of_text raw_message
+    Cascade_transport.Kimi_cli_transport_local.resumable_session_detail_of_text raw_message
   in
   let sdk_error =
     Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest { message = detail })
@@ -4612,10 +4612,10 @@ let test_kimi_cli_classify_cli_error_keeps_exit_1_with_error_as_reject () =
   Alcotest.(check bool)
     "exit 1 with real stderr is not resumable"
     false
-    (Cascade_runner.Kimi_cli_transport_local.text_looks_like_resumable_session
+    (Cascade_transport.Kimi_cli_transport_local.text_looks_like_resumable_session
        raw_message);
   match
-    Cascade_runner.Kimi_cli_transport_local.classify_cli_error
+    Cascade_transport.Kimi_cli_transport_local.classify_cli_error
       (Error
          (Llm_provider.Http_client.NetworkError
             { message = raw_message; kind = Llm_provider.Http_client.Unknown }))
@@ -4638,7 +4638,7 @@ let test_kimi_cli_classify_cli_error_labels_process_title_unicode_crash () =
      getproctitle() UnicodeDecodeError: 'utf-8' codec can't decode byte 0xef"
   in
   match
-    Cascade_runner.Kimi_cli_transport_local.classify_cli_error
+    Cascade_transport.Kimi_cli_transport_local.classify_cli_error
       (Error
          (Llm_provider.Http_client.NetworkError
             { message = raw_message; kind = Llm_provider.Http_client.Unknown }))

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -9,11 +9,38 @@ open Alcotest
 
 module Model_resolve = Masc_mcp.Cascade_model_resolve
 
+let with_provider_catalog json f =
+  match Llm_provider.Provider_catalog.of_json (Yojson.Safe.from_string json) with
+  | Error msg -> fail msg
+  | Ok catalog ->
+    Llm_provider.Provider_catalog.set_global catalog;
+    Fun.protect ~finally:Llm_provider.Provider_catalog.clear_global f
+
+let local_runtime_catalog_json =
+  {|
+{
+  "schema_version": 1,
+  "providers": [
+    {
+      "id": "observability-local",
+      "kind": "openai_compat",
+      "transport": "http",
+      "base_url": "http://127.0.0.1:8124",
+      "request_path": "/v1/chat/completions",
+      "auth": {"type": "none"},
+      "capabilities_base": "openai_chat",
+      "non_interactive": true,
+      "interactive_required": false,
+      "daemon_safe": true
+    }
+  ]
+}
+|}
+
 let string_of_resolution_provenance = function
   | Model_resolve.Explicit_input -> "explicit_input"
-  | Model_resolve.Alias alias -> "alias:" ^ alias
   | Model_resolve.Env_default var -> "env_default:" ^ var
-  | Model_resolve.Hardcoded_default -> "hardcoded_default"
+  | Model_resolve.Binding_default -> "binding_default"
   | Model_resolve.Discovery -> "discovery"
   | Model_resolve.Unresolved_auto -> "unresolved_auto"
 
@@ -126,16 +153,7 @@ let test_labels_require_local_discovery () =
     (Masc_mcp.Cascade_runtime.labels_require_local_discovery
        [ "default"; "glm:auto" ])
 
-let test_cascade_model_resolve_alias_provenance () =
-  let resolved =
-    Model_resolve.resolve_glm_model ~getenv:(fun _ -> None)
-      (Model_resolve.model_selector_of_string "flash")
-  in
-  check string "glm flash alias" "glm-4.7-flashx" resolved.resolved_model_id;
-  check resolution_provenance "alias provenance"
-    (Model_resolve.Alias "flash") resolved.provenance
-
-let test_cascade_model_resolve_hardcoded_default_provenance () =
+let test_cascade_model_resolve_unregistered_default_provenance () =
   let resolved =
     Model_resolve.resolve_auto_model ~getenv:(fun _ -> None) "openai"
       (Model_resolve.model_selector_of_string "auto")
@@ -160,15 +178,16 @@ let test_cascade_model_resolve_env_default_provenance () =
     resolved.provenance
 
 let test_cascade_model_resolve_discovery_provenance () =
-  let resolved =
-    Model_resolve.resolve_auto_model
-      ~getenv:(fun _ -> None)
-      ~discover:(fun () -> Some "qwen3:8b")
-      "ollama" (Model_resolve.model_selector_of_string "auto")
-  in
-  check string "ollama discovery" "qwen3:8b" resolved.resolved_model_id;
-  check resolution_provenance "discovery provenance"
-    Model_resolve.Discovery resolved.provenance
+  with_provider_catalog local_runtime_catalog_json (fun () ->
+    let resolved =
+      Model_resolve.resolve_auto_model
+        ~getenv:(fun _ -> None)
+        ~discover:(fun () -> Some "local-model")
+        "observability-local" (Model_resolve.model_selector_of_string "auto")
+    in
+    check string "local discovery" "local-model" resolved.resolved_model_id;
+    check resolution_provenance "discovery provenance"
+      Model_resolve.Discovery resolved.provenance)
 
 let test_cascade_model_resolve_unresolved_auto_provenance () =
   let resolved =
@@ -178,7 +197,7 @@ let test_cascade_model_resolve_unresolved_auto_provenance () =
   check string "openrouter unresolved auto stays auto" "auto"
     resolved.resolved_model_id;
   check resolution_provenance "generic OAS binding provenance"
-    Model_resolve.Hardcoded_default resolved.provenance
+    Model_resolve.Binding_default resolved.provenance
 
 (* ── Section 2: Dashboard schema contracts ── *)
 
@@ -280,10 +299,8 @@ let () =
             test_effective_discovered_ctx;
           test_case "local discovery label detection" `Quick
             test_labels_require_local_discovery;
-          test_case "cascade alias provenance" `Quick
-            test_cascade_model_resolve_alias_provenance;
-          test_case "cascade hardcoded default provenance" `Quick
-            test_cascade_model_resolve_hardcoded_default_provenance;
+          test_case "cascade unregistered default provenance" `Quick
+            test_cascade_model_resolve_unregistered_default_provenance;
           test_case "cascade env default provenance" `Quick
             test_cascade_model_resolve_env_default_provenance;
           test_case "cascade discovery provenance" `Quick


### PR DESCRIPTION
## Summary

- Remove MASC-side provider/model catalog residue from cascade auto-model resolution.
- Route auto model expansion/defaults through OAS runtime binding projection, and keep unknown direct API auto selectors delegated instead of inventing concrete vendor lists.
- Replace provider-kind HTTP probe classification with registered probe capability checks, and rename capacity history/dashboard grouping from `ollama` to `http_probe`.
- Replace the Kimi-specific max-context public helper with a generic provider/model context resolver.
- Clean stale Provider_adapter audit/allowlist/docs references that pointed at deleted implementation files.

## Product impact

Provider-specific model catalog ownership stays in OAS. MASC cascade no longer carries GLM/Kimi catalog defaults or Ollama Cloud/provider-name rewrites in the model/probe projection path.

## Evidence

- `git fetch origin main`
- `git rebase origin/main`
- `git diff --check origin/main...HEAD`
- `bash scripts/lint/provider-adapter-removal-ratchet.sh`
- `scripts/lint/no-roadmap-stale-hardcoding.sh`
- `bash scripts/audit-hardcoding-truth.sh --fail-on-confirmed`
- `scripts/dune-local.sh build test/test_cascade_model_resolve.exe test/test_observability_provider_contracts.exe test/test_cascade_strategy.exe test/test_oas_worker.exe`
- `./_build/default/test/test_cascade_model_resolve.exe`
- `./_build/default/test/test_observability_provider_contracts.exe`
- `./_build/default/test/test_cascade_strategy.exe`
- `./_build/default/test/test_oas_worker.exe`

## Review evidence

Focused local checks passed after rebasing on current `origin/main`. `test_oas_worker.exe` passed 164 tests; config-root warnings are the existing local test environment warning path.

## Linked issue

Provider_adapter removal follow-up from the merged mainline cleanup wave; no separate issue linked.
