### PR TITLE
feat(ide): expose runtime scope in context lens

### DIFF
--- a/dashboard/src/components/ide/ide-context-lens.test.ts
+++ b/dashboard/src/components/ide/ide-context-lens.test.ts
@@ -165,7 +165,7 @@ describe('IdeContextLens', () => {
 
     expect(container.querySelector('[data-testid="ide-context-lens"]')).not.toBeNull()
     expect(container.textContent).toContain('CONTEXT LENS')
-    expect(container.textContent).toContain('11/11 linked')
+    expect(container.textContent).toContain('11/12 linked')
     expect(container.textContent).toContain('keeper_exec_ide.ml')
     expect(container.textContent).toContain('4 anchors')
     expect(container.textContent).toContain('goal goal-ide')
@@ -606,6 +606,8 @@ describe('IdeContextLens', () => {
     expect(counts.get('git')).toBeGreaterThan(0)
     expect(counts.get('pr')).toBeGreaterThan(0)
     expect(counts.get('log')).toBe(1)
+    expect(counts.get('runtime')).toBe(1)
+    expect(counts.get('telemetry')).toBe(1)
     expect(model.anchors[0]).toMatchObject({
       surface: 'Comment',
       line: 27,
@@ -656,6 +658,21 @@ describe('IdeContextLens', () => {
       },
       evidence: 'Fleet telemetry event log · session sess-9 · operation op-9 · worker wr-9 · query turn-9',
     })
+    expect(model.surfaces.find(surface => surface.id === 'runtime')).toMatchObject({
+      label: 'Runtime',
+      count: 1,
+      routeLink: expect.objectContaining({
+        label: 'Telemetry',
+        params: {
+          section: 'fleet-health',
+          view: 'event-log',
+          session_id: 'sess-9',
+          operation_id: 'op-9',
+          worker_run_id: 'wr-9',
+          q: 'turn-9',
+        },
+      }),
+    })
     expect(model.anchors[0]?.route_links?.find(link => link.label === 'Keeper')).toMatchObject({
       tab: 'monitoring',
       params: { section: 'agents', view: 'keepers', keeper: 'sangsu' },
@@ -692,6 +709,10 @@ describe('IdeContextLens', () => {
     })
 
     expect(model.activeLineCount).toBe(1)
+    expect(model.surfaces.find(surface => surface.id === 'runtime')).toMatchObject({
+      status: 'linked',
+      count: 1,
+    })
     expect(model.anchors[0]).toMatchObject({
       surface: 'PR',
       line: 27,
@@ -729,6 +750,64 @@ describe('IdeContextLens', () => {
         operation_id: 'op-9',
         worker_run_id: 'wr-9',
         q: 'turn-9',
+      },
+    })
+  })
+
+  it('promotes tagged runtime references into runtime anchors', () => {
+    const model = deriveIdeContextLens({
+      filePath: 'lib/keeper/keeper_exec_ide.ml',
+      annotations: [],
+      diffRows: [],
+      events: [{
+        id: 'evt-tagged-runtime',
+        run_id: 'run-default',
+        keeper_id: 'sangsu',
+        verb: 'noted',
+        target: 'runtime scope',
+        timestamp_ms: 400,
+        detail: 'session:sess-9 op:op-9 wr:wr-9 line:27',
+      }],
+      overlay: { ...overlay, cursors: new Map() },
+    })
+
+    expect(model.surfaces.find(surface => surface.id === 'runtime')).toMatchObject({
+      status: 'linked',
+      count: 1,
+      routeLink: expect.objectContaining({
+        label: 'Telemetry',
+        params: {
+          section: 'fleet-health',
+          view: 'event-log',
+          session_id: 'sess-9',
+          operation_id: 'op-9',
+          worker_run_id: 'wr-9',
+        },
+      }),
+    })
+    expect(model.anchors[0]).toMatchObject({
+      surface: 'Runtime',
+      line: 27,
+      keeper_id: 'sangsu',
+    })
+    expect(model.anchors[0]?.route_links?.find(link => link.label === 'Code')).toMatchObject({
+      tab: 'code',
+      params: {
+        section: 'ide-shell',
+        view: 'source',
+        file: 'lib/keeper/keeper_exec_ide.ml',
+        line: '27',
+        surface: 'Runtime',
+      },
+    })
+    expect(model.anchors[0]?.route_links?.find(link => link.label === 'Telemetry')).toMatchObject({
+      tab: 'monitoring',
+      params: {
+        section: 'fleet-health',
+        view: 'event-log',
+        session_id: 'sess-9',
+        operation_id: 'op-9',
+        worker_run_id: 'wr-9',
       },
     })
   })

--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -23,6 +23,7 @@ export type IdeContextSurfaceId =
   | 'pr'
   | 'comment'
   | 'log'
+  | 'runtime'
   | 'telemetry'
 
 export interface IdeContextSurface {
@@ -122,6 +123,7 @@ const SURFACE_LABELS: Readonly<Record<IdeContextSurfaceId, string>> = {
   pr: 'PR',
   comment: 'Comment',
   log: 'Log',
+  runtime: 'Runtime',
   telemetry: 'Telemetry',
 }
 
@@ -136,6 +138,7 @@ const SURFACE_ORDER: ReadonlyArray<IdeContextSurfaceId> = [
   'pr',
   'comment',
   'log',
+  'runtime',
   'telemetry',
 ]
 const MAX_CONTEXT_ANCHORS = 6
@@ -147,6 +150,7 @@ const CONTEXT_ANCHOR_BUCKET_ORDER = [
   'task',
   'board',
   'log',
+  'runtime',
   'goal',
   'comment',
   'telemetry',
@@ -166,6 +170,7 @@ const SURFACE_ROUTE_LABELS: Readonly<Record<IdeContextSurfaceId, ReadonlyArray<s
   pr: ['PR'],
   comment: ['Comment', 'Board'],
   log: ['Log'],
+  runtime: ['Telemetry'],
   telemetry: ['Telemetry'],
 }
 
@@ -304,7 +309,16 @@ function contextAnchorBuckets(anchor: IdeContextAnchor): ReadonlySet<ContextAnch
     else if (label === 'pr') buckets.add('pr')
     else if (label === 'git') buckets.add('git')
     else if (label === 'log') buckets.add('log')
-    else if (label === 'telemetry') buckets.add('telemetry')
+    else if (label === 'telemetry') {
+      buckets.add('telemetry')
+      if (
+        link.params.session_id !== undefined
+        || link.params.operation_id !== undefined
+        || link.params.worker_run_id !== undefined
+      ) {
+        buckets.add('runtime')
+      }
+    }
     else if (label === 'keeper') buckets.add('keeper')
   }
 
@@ -317,6 +331,7 @@ function contextAnchorBuckets(anchor: IdeContextAnchor): ReadonlySet<ContextAnch
   else if (surface === 'git') buckets.add('git')
   else if (surface === 'pr') buckets.add('pr')
   else if (surface === 'log') buckets.add('log')
+  else if (surface === 'runtime') buckets.add('runtime')
   else if (surface === 'telemetry') buckets.add('telemetry')
   else if (surface === 'comment' || surface === 'question' || surface === 'note' || surface === 'suggest') {
     buckets.add('comment')
@@ -610,6 +625,23 @@ function surfaceCount(
   if (id === 'log') {
     return state.events.length
   }
+  if (id === 'runtime') {
+    return state.events.filter(event =>
+      event.context?.session_id
+      || event.context?.operation_id
+      || event.context?.worker_run_id,
+    ).length
+      + countUnstructuredEventText(
+        state.events,
+        /\b(session|operation|op|worker_run|worker|wr)[:#/\s-]/,
+        event => Boolean(
+          event.context?.session_id
+          || event.context?.operation_id
+          || event.context?.worker_run_id,
+        ),
+        state.eventSearchTextByEvent,
+      )
+  }
   if (id === 'telemetry') return state.events.length
   return 0
 }
@@ -626,6 +658,7 @@ function surfaceEvidence(id: IdeContextSurfaceId, count: number): string {
   if (id === 'pr') return `${count} PR/review signal${plural(count)}`
   if (id === 'comment') return `${count} comment/question anchor${plural(count)}`
   if (id === 'log') return `${count} activity log event${plural(count)}`
+  if (id === 'runtime') return `${count} runtime scope signal${plural(count)}`
   return `${count} telemetry signal${plural(count)}`
 }
 
@@ -866,6 +899,13 @@ function surfaceFromEvent(
   if (event.context?.task_id) return 'Task'
   if (event.context?.git_ref) return 'Git'
   if (event.context?.log_id) return 'Log'
+  if (
+    event.context?.session_id
+    || event.context?.operation_id
+    || event.context?.worker_run_id
+  ) {
+    return 'Runtime'
+  }
   const text = eventSearchTextByEvent
     ? cachedEventSearchText(event, eventSearchTextByEvent)
     : eventSearchText(event)
@@ -875,6 +915,7 @@ function surfaceFromEvent(
   if (/\btask[:#/\s-]/.test(text)) return 'Task'
   if (/\b(git|commit|branch|diff)[:#/\s-]/.test(text)) return 'Git'
   if (/\b(comment|note|question)[:#/\s-]/.test(text)) return 'Comment'
+  if (/\b(session|operation|op|worker_run|worker|wr)[:#/\s-]/.test(text)) return 'Runtime'
   return 'Log'
 }
 


### PR DESCRIPTION
## Summary
- add a first-class Runtime surface to the IDE context lens for session, operation, and worker-run scoped activity
- route Runtime surface actions through the canonical Telemetry event-log link
- cover structured runtime context and tagged session/op/worker references in context-lens tests

## Verification
- pnpm vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-context-lens.test.ts
- pnpm typecheck
- pnpm lint (passes with existing virtual-list.ts unused eslint-disable warning)
- git diff --check
- rg raw-hex guard on touched files only matched PR number literals