### PR TITLE
fix(keeper): cancel in-turn liveness pulse on exit

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -256,24 +256,50 @@ let with_in_turn_liveness_pulse_for_test ~sw:_sw ~clock ~interval_sec ~tick f =
   let interval_sec = max 0.001 interval_sec in
   Eio.Switch.run (fun pulse_sw ->
     let pulse_stop = Atomic.make false in
-    Eio.Switch.on_release pulse_sw (fun () -> Atomic.set pulse_stop true);
+    let pulse_cancel = ref None in
+    let stop_pulse () =
+      Atomic.set pulse_stop true;
+      match !pulse_cancel with
+      | None -> ()
+      | Some cc ->
+        (try Eio.Cancel.cancel cc (Failure "in_turn_liveness_pulse_stop") with
+         | Eio.Cancel.Cancelled _ -> ()
+         | Invalid_argument _ -> ())
+    in
+    Eio.Switch.on_release pulse_sw stop_pulse;
     Eio.Fiber.fork ~sw:pulse_sw (fun () ->
-      let rec loop () =
-        Eio.Time.sleep clock interval_sec;
-        if not (Atomic.get pulse_stop)
-        then (
-          (try tick () with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-             Log.Keeper.warn "in-turn liveness pulse failed: %s" (Printexc.to_string exn);
-             Prometheus.inc_counter
-               Keeper_metrics.metric_keeper_heartbeat_failures
-               ~labels:[ "keeper", "liveness_pulse"; "phase", "pulse_tick" ]
-               ());
+      try
+        Eio.Cancel.sub (fun cc ->
+          pulse_cancel := Some cc;
+          let rec loop () =
+            if not (Atomic.get pulse_stop)
+            then (
+              Eio.Time.sleep clock interval_sec;
+              if not (Atomic.get pulse_stop)
+              then
+                (try tick () with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | exn ->
+                   Log.Keeper.warn
+                     "in-turn liveness pulse failed: %s"
+                     (Printexc.to_string exn);
+                   Prometheus.inc_counter
+                     Keeper_metrics.metric_keeper_heartbeat_failures
+                     ~labels:[ "keeper", "liveness_pulse"; "phase", "pulse_tick" ]
+                     ());
+              loop ())
+          in
           loop ())
-      in
-      loop ());
-    f ())
+      with
+      | Eio.Cancel.Cancelled _ -> ());
+    match f () with
+    | result ->
+      stop_pulse ();
+      result
+    | exception exn ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      stop_pulse ();
+      Printexc.raise_with_backtrace exn backtrace)
 ;;
 
 let emit_in_turn_liveness_pulse ~(ctx : _ context) ~(meta : keeper_meta) =

--- a/test/test_keeper_semaphore_fairness.ml
+++ b/test/test_keeper_semaphore_fairness.ml
@@ -229,6 +229,45 @@ let test_in_turn_liveness_pulse_stops_when_body_raises env =
   Alcotest.(check int) "pulse stopped after body raised" ticks_after_raise
     (Atomic.get ticks)
 
+let test_in_turn_liveness_pulse_returns_before_first_sleep env =
+  Eio.Switch.run @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let returned =
+    try
+      Eio.Time.with_timeout_exn clock 0.05 (fun () ->
+        KK.with_in_turn_liveness_pulse_for_test
+          ~sw
+          ~clock
+          ~interval_sec:60.0
+          ~tick:(fun () -> Alcotest.fail "pulse should not tick after body returns")
+          (fun () -> true))
+    with
+    | Eio.Time.Timeout -> false
+  in
+  Alcotest.(check bool) "wrapper returns before first pulse sleep" true returned
+
+let test_in_turn_liveness_pulse_cancels_blocked_tick env =
+  Eio.Switch.run @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let tick_entered, wake_tick = Eio.Promise.create () in
+  let returned =
+    try
+      Eio.Time.with_timeout_exn clock 0.1 (fun () ->
+        KK.with_in_turn_liveness_pulse_for_test
+          ~sw
+          ~clock
+          ~interval_sec:0.001
+          ~tick:(fun () ->
+            Eio.Promise.resolve wake_tick ();
+            Eio.Time.sleep clock 60.0)
+          (fun () ->
+            Eio.Promise.await tick_entered;
+            true))
+    with
+    | Eio.Time.Timeout -> false
+  in
+  Alcotest.(check bool) "blocked pulse tick is cancelled on body return" true returned
+
 let () =
   Alcotest.run "Keeper_semaphore_fairness"
     [
@@ -269,5 +308,9 @@ let () =
         [
           Alcotest.test_case "pulse stops when body raises" `Quick
             (with_fresh_state_env test_in_turn_liveness_pulse_stops_when_body_raises);
+          Alcotest.test_case "pulse returns before first sleep" `Quick
+            (with_fresh_state_env test_in_turn_liveness_pulse_returns_before_first_sleep);
+          Alcotest.test_case "pulse cancels blocked tick" `Quick
+            (with_fresh_state_env test_in_turn_liveness_pulse_cancels_blocked_tick);
         ] );
     ]


### PR DESCRIPTION
## Summary
- Cancel the in-turn liveness pulse child fiber when the wrapped keeper turn exits.
- Check the stop flag before the first pulse sleep so immediate pre-dispatch failures cannot keep turn-slot cleanup waiting.
- Add regression coverage for immediate return and blocked tick cancellation.

## Evidence
- opam exec -- ocamlformat --check lib/keeper/keeper_heartbeat_loop.ml test/test_keeper_semaphore_fairness.ml
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_semaphore_fairness.exe
- ./_build/default/test/test_keeper_semaphore_fairness.exe (15 tests)