### PR TITLE
fix(cascade): remove hardcoded provider guidance

### DIFF
--- a/lib/cascade/cascade_oas_runner.ml
+++ b/lib/cascade/cascade_oas_runner.ml
@@ -457,14 +457,12 @@ let filter_candidate_providers_for_tool_support
       then
         Log.Misc.error
           "[#11060/#11356] cascade %s: provider-normalized tool-use gate removed all \
-           providers (rejections=[%s]) — operator action: add a runtime-MCP-capable \
-           fallback provider to this cascade in cascade.toml. Verified-capable \
-           providers: claude_code, kimi_cli, anthropic, glm, openrouter (any non-cli \
-           direct API). Note: gemini_cli and codex_cli reject request-scoped runtime MCP \
-           HTTP headers (gemini-cli upstream lacks --mcp-config flag; codex_cli strips \
-           most per-request headers) — they cannot satisfy this gate. Alternatively \
-           detach the keeper from this cascade. Subsequent identical-signature \
-           rejections demoted to DEBUG for the next %.0fs"
+           providers (rejections=[%s]) — operator action: edit cascade.toml so \
+           this cascade has at least one candidate whose declared capabilities satisfy \
+           the required tool-use gate, or relax the keeper's required tool surface. \
+           Required gate accepts inline tool_choice support or a compatible runtime-MCP \
+           lane. Alternatively detach the keeper from this cascade. Subsequent \
+           identical-signature rejections demoted to DEBUG for the next %.0fs"
           label
           signature
           cascade_empty_warn_restate_sec


### PR DESCRIPTION
## Summary
- remove hardcoded provider recommendations from cascade-empty tool-use diagnostics
- point operators back to cascade.toml declared capabilities and the rejected candidate signature instead

## Verification
- opam exec -- ocamlformat --check lib/cascade/cascade_oas_runner.ml
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_oas_worker.exe