### PR TITLE
fix(paths): replace hardcoded /tmp with Filename.get_temp_dir_name

### DIFF
--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -587,7 +587,7 @@ let default_recovery_hint classification semantic_status =
 
 let ensure_exec_artifact_dir path =
   try Fs_compat.mkdir_p path with
-  | Sys_error msg -> Logs.warn (fun f -> f "exec artifact mkdir failed: %s" msg)
+  | Sys_error msg -> Logs.err (fun f -> f "exec artifact mkdir failed: %s" msg)
 ;;
 
 let persist_artifact_if_needed ~base_path ~keeper_name ~cmd ~output =
@@ -620,7 +620,7 @@ let persist_artifact_if_needed ~base_path ~keeper_name ~cmd ~output =
     match Fs_compat.save_file_atomic path output with
     | Ok () -> Some { path; bytes = String.length output; storage = Filesystem }
     | Error err ->
-      Logs.warn (fun f -> f "exec artifact persist failed: %s" err);
+      Logs.err (fun f -> f "exec artifact persist failed: %s" err);
       None)
 ;;
 

--- a/lib/grpc/masc_grpc_client.ml
+++ b/lib/grpc/masc_grpc_client.ml
@@ -23,6 +23,7 @@ let create_from_env ~sw ~env =
     match Env_config.Transport.grpc_target_opt () with
     | Some t -> t
     | None ->
+      (* Fallback: local gRPC only.  Set MASC_GRPC_TARGET for remote hosts. *)
       let port = Masc_grpc_server.configured_port () in
       Printf.sprintf "http://127.0.0.1:%d" port
   in

--- a/lib/keeper/host_config.ml
+++ b/lib/keeper/host_config.ml
@@ -36,16 +36,20 @@ let legacy_coreutils_macos =
 ;;
 
 let legacy_macos_default () =
-  { cred_root = "/tmp/keeper-creds"
+  let tmpdir = Filename.get_temp_dir_name () in
+  { cred_root =
+      (match Sys.getenv_opt "MASC_CRED_ROOT" with
+       | Some p -> p
+       | None -> Filename.concat tmpdir "keeper-creds")
   ; host_bash = "/bin/bash"
   ; host_zsh = "/bin/zsh"
   ; host_sh = "/bin/sh"
   ; coreutils = legacy_coreutils_macos
-  ; agent_runtime_root = "/tmp"
+  ; agent_runtime_root = tmpdir
   ; sandbox_workspace_root =
       (match Sys.getenv_opt "HOME" with
        | Some home -> Filename.concat home "me"
-       | None -> "/tmp/masc-fleet")
+       | None -> Filename.concat tmpdir "masc-fleet")
   ; test_mode =
       (let exec = Filename.basename Sys.executable_name in
        if String.length exec >= 5 && String.sub exec 0 5 = "test_"

--- a/lib/keeper/host_config_provider.ml
+++ b/lib/keeper/host_config_provider.ml
@@ -1,12 +1,8 @@
 (** See {!Host_config_provider} interface. *)
 
 (* RFC-0084 host-config-cleanup-A — credential root migration.
-   Was: ad-hoc literal string for the credential root.  Now delegates
-   to the typed [Host_config.legacy_macos_default] surface so the
-   constant has a single source of truth.  Behaviour is byte-identical
-   today (the field's value matches the previous literal at PR-1
-   author time); a future PR can flip [legacy_macos_default] to a
-   [resolve ~base_path]-relative value without touching this module. *)
+   Delegates to [Host_config.legacy_macos_default] which now uses
+   MASC_CRED_ROOT env var and Filename.get_temp_dir_name(). *)
 let cred_root = (Host_config.legacy_macos_default ()).cred_root
 let explicit_ssh_key_container_path =
   Filename.concat (Filename.concat cred_root ".ssh") "id_credential"


### PR DESCRIPTION
## Summary

- Replace 5 hardcoded /tmp/.masc_agent_* session file paths with Filename.get_temp_dir_name() — respects TMPDIR
- Replace hardcoded /tmp/keeper-creds and /tmp/masc-fleet with MASC_CRED_ROOT env var + get_temp_dir_name()
- Promote filesystem error logs from Logs.warn to Logs.err in exec_core.ml
- Add env var override documentation to gRPC client localhost fallback

## Audit findings addressed
P1, P2, P8, P10, L1, L2, U4 (7 HIGH items)

## Test plan
- [x] dune build @check passes
- [ ] CI green

🤖 Generated with Claude Code