### PR TITLE
feat(rfc-0084): PR-B shell binary path migration (host-config-cleanup-B)

### DIFF
--- a/lib/keeper/keeper_exec_preflight.ml
+++ b/lib/keeper/keeper_exec_preflight.ml
@@ -1,5 +1,8 @@
 open Keeper_types
 
+(* RFC-0084 host-config-cleanup-B — zsh binary path migration. *)
+let host_zsh = (Host_config.legacy_macos_default ()).host_zsh
+
 let json_string_field name json = Json_util.get_string json name
 
 let handle_keeper_preflight_check
@@ -24,7 +27,7 @@ let handle_keeper_preflight_check
         ~raw_source:"/bin/zsh -lc gh auth status 2>&1"
         ~summary:"keeper preflight gh auth status"
         ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Preflight ())
-        [ "/bin/zsh"; "-lc"; "gh auth status 2>&1" ]
+        [ host_zsh; "-lc"; "gh auth status 2>&1" ]
     in
     add_check "gh_auth" (st = Unix.WEXITED 0) out
   in
@@ -40,7 +43,7 @@ let handle_keeper_preflight_check
           ~raw_source:(Printf.sprintf "/bin/zsh -lc gh repo view %s --json name,defaultBranchRef 2>&1" (Filename.quote repo))
           ~summary:"keeper preflight gh repo view"
           ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Preflight ())
-          [ "/bin/zsh"; "-lc";
+          [ host_zsh; "-lc";
             Printf.sprintf "gh repo view %s --json name,defaultBranchRef 2>&1"
               (Filename.quote repo) ]
       in

--- a/lib/keeper/keeper_gh_shared.ml
+++ b/lib/keeper/keeper_gh_shared.ml
@@ -1,6 +1,9 @@
 (* GH credential isolation — SSOT in Keeper_gh_env. *)
 let with_keeper_gh_env = Keeper_gh_env.with_env
 
+(* RFC-0084 host-config-cleanup-B — zsh binary path migration. *)
+let host_zsh = (Host_config.legacy_macos_default ()).host_zsh
+
 (* ================================================================ *)
 (* GH entity cache (inlined from former keeper_gh_cache.ml).         *)
 (* In-memory cache of valid PR/issue numbers per repo, populated     *)
@@ -214,7 +217,7 @@ let fetch_entity_numbers
       (Filename.quote (jq_filter kind))
   in
   let scoped = Keeper_gh_env.with_env config raw in
-  let argv = [ "/bin/zsh"; "-lc"; Printf.sprintf "%s 2>/dev/null" scoped ] in
+  let argv = [ host_zsh; "-lc"; Printf.sprintf "%s 2>/dev/null" scoped ] in
   match
     Masc_exec.Exec_gate.run_argv_with_status
       ~actor:`Coord_git

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -1,6 +1,12 @@
 open Keeper_types
 open Keeper_exec_shared
 
+(* RFC-0084 host-config-cleanup-B — bash binary path migration.
+   Resolves the host bash binary once at module-init from the typed
+   [Host_config.host_bash] field; consumer sites reference the bound
+   name so a future PR can flip the typed surface to PATH lookup. *)
+let host_bash = (Host_config.legacy_macos_default ()).host_bash
+
 let elapsed_duration_ms ~start_time ~end_time =
   let elapsed_ms = (end_time -. start_time) *. 1000. in
   match classify_float elapsed_ms with
@@ -742,7 +748,7 @@ let handle_keeper_bash
                   Foreground mode merges via [2>&1] for backward
                   compatibility with the single [output] JSON field. *)
                if run_in_background then begin
-                 let argv = [ "/bin/bash"; "-lc"; cmd ] in
+                 let argv = [ host_bash; "-lc"; cmd ] in
                  match
                    Bg_task.spawn
                      ~base_path:root
@@ -799,7 +805,7 @@ let handle_keeper_bash
                    | _ -> false
                  in
                  let argv_merged =
-                   [ "/bin/bash"; "-lc"; cmd ^ " 2>&1" ]
+                   [ host_bash; "-lc"; cmd ^ " 2>&1" ]
                  in
                  (* Tick 23: AUTO_BG dark-launch observer.  When
                     [MASC_BASH_AUTO_BG_OBSERVE] is set, time the

--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -5,6 +5,9 @@
 open Keeper_types
 open Keeper_exec_shared
 
+(* RFC-0084 host-config-cleanup-B — zsh binary path migration. *)
+let host_zsh = (Host_config.legacy_macos_default ()).host_zsh
+
 (* Issue #8480: Variant SSOT for PR review event. Adding a new
    constructor forces compilation in [pr_review_event_to_string],
    [pr_review_event_of_string_opt], and [pr_review_event_to_gh_flag],
@@ -189,7 +192,7 @@ let run_pr_review_shell ~(config : Coord.config) ~(meta : keeper_meta)
     let host_cmd =
       Printf.sprintf "cd %s && %s" (Filename.quote root) cmd
     in
-    let argv = [ "/bin/zsh"; "-lc"; host_cmd ] in
+    let argv = [ host_zsh; "-lc"; host_cmd ] in
     let status, output =
       Masc_exec.Exec_gate.run_argv_with_status
         ~actor:`Keeper_shell

--- a/test/dune
+++ b/test/dune
@@ -1569,3 +1569,12 @@
  (name test_pr_c_coreutils_migration)
  (modules test_pr_c_coreutils_migration)
  (libraries masc_test_deps))
+
+; RFC-0084 host-config-cleanup-B — shell binary path migration.
+; Pins 0 occurrences of /bin/bash and /bin/zsh literals across
+; the 4 keeper consumer modules (1 bash + 3 zsh) and verifies one
+; Host_config.legacy_macos_default binding per consumer module.
+(test
+ (name test_pr_b_shell_paths_migration)
+ (modules test_pr_b_shell_paths_migration)
+ (libraries masc_test_deps))

--- a/test/test_pr_b_shell_paths_migration.ml
+++ b/test/test_pr_b_shell_paths_migration.ml
@@ -1,0 +1,144 @@
+open Alcotest
+
+(** RFC-0084 host-config-cleanup-B — shell binary path migration.
+
+    PR-B migrates the absolute literals for the host bash + zsh
+    binaries to the typed [Host_config.host_bash] / [host_zsh]
+    fields.
+
+    bash sites:
+    - lib/keeper/keeper_shell_bash.ml (2 sites: keeper_bash exec
+      argv) — single [let host_bash = ...] binding at module top
+
+    zsh sites:
+    - lib/keeper/keeper_gh_shared.ml (1 site: gh cache fetch argv)
+    - lib/keeper/keeper_exec_preflight.ml (2 sites: gh auth status
+      + preflight cache fetch argv)
+    - lib/keeper/keeper_tool_pr_review.ml (1 site: PR review argv)
+
+    Each module has its own module-init binding (rather than one
+    shared SSOT) because the modules don't share a common ancestor
+    other than [Host_config] itself, and per-module bindings keep
+    the dependency local.
+
+    Behaviour byte-identical today; a future PR can flip
+    [Host_config.legacy_macos_default] to PATH-resolved binaries
+    for NixOS / Alpine portability without touching this PR's call
+    sites.
+
+    [lib/exec/test/test_exec_run_json.ml:89] also contains a
+    [/bin/bash] literal but lives in the [lib/exec/test/] sub-tree
+    (separate dune stanza) and is a *test fixture*, not a production
+    dispatch path — out of PR-B scope. *)
+
+let pinned_bash_literal_count = 0
+let pinned_zsh_literal_count = 0
+let pinned_bash_binding_count = 1
+let pinned_zsh_binding_count = 3
+
+let read_file path =
+  match In_channel.with_open_text path In_channel.input_all with
+  | exception _ -> ""
+  | content -> content
+;;
+
+let count_substring ~haystack ~needle =
+  let rec loop i acc =
+    let next = String.index_from_opt haystack i needle.[0] in
+    match next with
+    | None -> acc
+    | Some j ->
+      let len = String.length needle in
+      if j + len <= String.length haystack
+         && String.sub haystack j len = needle
+      then loop (j + len) (acc + 1)
+      else loop (j + 1) acc
+  in
+  loop 0 0
+;;
+
+let count_across_files ~files ~needle =
+  List.fold_left
+    (fun acc path ->
+      acc + count_substring ~haystack:(read_file path) ~needle)
+    0 files
+;;
+
+let bash_consumer_files = [ "lib/keeper/keeper_shell_bash.ml" ]
+
+let zsh_consumer_files =
+  [ "lib/keeper/keeper_gh_shared.ml"
+  ; "lib/keeper/keeper_exec_preflight.ml"
+  ; "lib/keeper/keeper_tool_pr_review.ml"
+  ]
+;;
+
+let test_no_bash_literals_in_consumer_files () =
+  let occurrences =
+    count_across_files ~files:bash_consumer_files
+      ~needle:{|"/bin/bash"|}
+  in
+  (check int)
+    "literal `\"/bin/bash\"` in 1 keeper consumer file must be 0 after PR-B"
+    pinned_bash_literal_count occurrences
+;;
+
+let test_no_zsh_literals_in_consumer_files () =
+  let occurrences =
+    count_across_files ~files:zsh_consumer_files
+      ~needle:{|"/bin/zsh"|}
+  in
+  (check int)
+    "literal `\"/bin/zsh\"` in 3 keeper consumer files must be 0 after PR-B"
+    pinned_zsh_literal_count occurrences
+;;
+
+let test_bash_binding_invoked_exactly_once () =
+  let occurrences =
+    count_across_files ~files:bash_consumer_files
+      ~needle:"Host_config.legacy_macos_default"
+  in
+  (check int)
+    "Host_config.legacy_macos_default invoked exactly once across \
+     bash consumer files"
+    pinned_bash_binding_count occurrences
+;;
+
+let test_zsh_binding_invoked_per_module () =
+  let occurrences =
+    count_across_files ~files:zsh_consumer_files
+      ~needle:"Host_config.legacy_macos_default"
+  in
+  (check int)
+    "Host_config.legacy_macos_default invoked once per zsh consumer \
+     module (3 modules)"
+    pinned_zsh_binding_count occurrences
+;;
+
+let test_host_config_field_values () =
+  let d = Masc_mcp.Host_config.legacy_macos_default () in
+  (check string)
+    "Host_config.legacy_macos_default ().host_bash = /bin/bash today"
+    "/bin/bash" d.host_bash;
+  (check string)
+    "Host_config.legacy_macos_default ().host_zsh = /bin/zsh today"
+    "/bin/zsh" d.host_zsh
+;;
+
+let () =
+  run
+    "PR-B host-config-cleanup-B (shell paths)"
+    [ ( "pr-b-shell-paths"
+      , [ test_case "no-bash-literals-in-consumer-files" `Quick
+            test_no_bash_literals_in_consumer_files
+        ; test_case "no-zsh-literals-in-consumer-files" `Quick
+            test_no_zsh_literals_in_consumer_files
+        ; test_case "bash-binding-invoked-exactly-once" `Quick
+            test_bash_binding_invoked_exactly_once
+        ; test_case "zsh-binding-invoked-per-module" `Quick
+            test_zsh_binding_invoked_per_module
+        ; test_case "host-config-field-values" `Quick
+            test_host_config_field_values
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
RFC-0084 cleanup PR-B. Migrates host bash + zsh literals to `Host_config.host_bash` / `host_zsh` across 4 keeper consumer modules: `keeper_shell_bash.ml` (bash 2 sites), `keeper_gh_shared.ml` (zsh 1), `keeper_exec_preflight.ml` (zsh 2), `keeper_tool_pr_review.ml` (zsh 1). Each module has its own module-init binding.

## Test plan
- [x] `dune build @lib/check` green
- [x] `dune exec test/test_pr_b_shell_paths_migration.exe` — 5/5 OK
- [x] `ci/lint-no-direct-dispatch.sh` OK

## Stack
Base: `feature/rfc-0084-pr-c-coreutils` (PR-C #15432).

## Scope
~120 LOC. RFC-0084 `follow_up_prs` slug: `host-config-cleanup-B`. `lib/exec/test/test_exec_run_json.ml:89` test fixture out of scope by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)