### PR TITLE
feat(rfc-0084): PR-D agent runtime root migration (host-config-cleanup-D)

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -8,6 +8,14 @@
 let log_mcp_exn = Mcp_server_eio_helpers.log_mcp_exn
 let wait_for_message_eio = Mcp_server_eio_helpers.wait_for_message_eio
 
+(* RFC-0084 host-config-cleanup-D — agent runtime root migration.
+   Resolves the host runtime root once at module-init from the typed
+   [Host_config.agent_runtime_root] field; the 5 cross-process
+   agent-identity scratch files below reference the bound name so a
+   future PR can flip the typed surface to a base-path-relative
+   layout without touching this module's call sites. *)
+let agent_runtime_root = (Host_config.legacy_macos_default ()).agent_runtime_root
+
 (* #10699 Family A — "Join required" surfaces 28 / 24h events for
    masc_transition + masc_claim_next while the underlying keeper had
    joined under its canonical name at boot via
@@ -188,7 +196,7 @@ let execute_tool_eio
     match mcp_session_id with
     | None -> None
     | Some sid ->
-      let file = Printf.sprintf "/tmp/.masc_agent_mcp_%s" sid in
+      let file = Filename.concat agent_runtime_root (Printf.sprintf ".masc_agent_mcp_%s" sid) in
       (try
          let name = Fs_compat.load_file file |> String.trim in
          if name = ""
@@ -207,7 +215,7 @@ let execute_tool_eio
     match mcp_session_id with
     | None -> ()
     | Some sid ->
-      let file = Printf.sprintf "/tmp/.masc_agent_mcp_%s" sid in
+      let file = Filename.concat agent_runtime_root (Printf.sprintf ".masc_agent_mcp_%s" sid) in
       (try Fs_compat.save_file file agent_name with
        | Sys_error msg -> Log.Misc.warn "write_mcp_session_agent: %s" msg
        | Eio.Io _ as exn ->
@@ -250,7 +258,7 @@ let execute_tool_eio
                let term_session_id =
                  Option.value ~default:"" (Sys.getenv_opt "TERM_SESSION_ID")
                in
-               let term_file = Printf.sprintf "/tmp/.masc_agent_%s" term_session_id in
+               let term_file = Filename.concat agent_runtime_root (Printf.sprintf ".masc_agent_%s" term_session_id) in
                match
                  Safe_ops.protect ~default:None (fun () ->
                    let name = Fs_compat.load_file term_file |> String.trim in
@@ -328,7 +336,7 @@ let execute_tool_eio
       match Sys.getenv_opt "TERM_SESSION_ID" with
       | None -> None
       | Some sid ->
-        let file = Printf.sprintf "/tmp/.masc_agent_%s" sid in
+        let file = Filename.concat agent_runtime_root (Printf.sprintf ".masc_agent_%s" sid) in
         (try
            let name = Fs_compat.load_file file |> String.trim in
            if name = "" then None else Some name
@@ -567,7 +575,7 @@ let execute_tool_eio
            match Sys.getenv_opt "TERM_SESSION_ID" with
            | None -> ()
            | Some sid ->
-             let file = Printf.sprintf "/tmp/.masc_agent_%s" sid in
+             let file = Filename.concat agent_runtime_root (Printf.sprintf ".masc_agent_%s" sid) in
              (try Fs_compat.save_file file nickname with
               | Eio.Cancel.Cancelled _ as e -> raise e
               | e ->

--- a/lib/tool_inline_dispatch_coord.ml
+++ b/lib/tool_inline_dispatch_coord.ml
@@ -23,6 +23,12 @@ module Float = Stdlib.Float
 
 open Tool_inline_dispatch_types
 
+(* RFC-0084 host-config-cleanup-D — agent runtime root migration.
+   Resolves the host runtime root once at module-init from the typed
+   [Host_config.agent_runtime_root] field; the 2 cross-process
+   agent-identity scratch files below reference the bound name. *)
+let agent_runtime_root = (Host_config.legacy_macos_default ()).agent_runtime_root
+
 (** Argument extraction helpers bound to ctx.arguments. *)
 let arg_get_string ctx key default =
   Safe_ops.json_string ~default key ctx.arguments
@@ -184,7 +190,7 @@ let handle_join ~tool_name ~start_time (ctx : context) : tool_result option =
     if Option.is_none mcp_session_id then begin
       Log.Misc.warn "[sid=%s] [deprecated] writing agent name to /tmp file for TERM session — migrate to Agent_identity" sid;
       let term_session_id = Option.value ~default:"default" (Sys.getenv_opt "TERM_SESSION_ID") in
-      let agent_file = Printf.sprintf "/tmp/.masc_agent_%s" term_session_id in
+      let agent_file = Filename.concat agent_runtime_root (Printf.sprintf ".masc_agent_%s" term_session_id) in
       (try
         Fs_compat.save_file agent_file nickname
       with
@@ -264,7 +270,7 @@ let handle_leave ~tool_name ~start_time (ctx : context) : tool_result option =
   Session.unregister registry ~agent_name;
   if Option.is_none mcp_session_id then begin
     let session_id = Option.value ~default:"default" (Sys.getenv_opt "TERM_SESSION_ID") in
-    let agent_file = Printf.sprintf "/tmp/.masc_agent_%s" session_id in
+    let agent_file = Filename.concat agent_runtime_root (Printf.sprintf ".masc_agent_%s" session_id) in
     Safe_ops.remove_file_logged ~context:"masc_leave" agent_file
   end;
   Some (Tool_result.ok ~tool_name ~start_time result)

--- a/test/dune
+++ b/test/dune
@@ -1587,3 +1587,12 @@
  (name test_pr_h_disclosure_meta_wiring)
  (modules test_pr_h_disclosure_meta_wiring)
  (libraries masc_test_deps))
+
+; RFC-0084 host-config-cleanup-D — agent runtime root migration.
+; Pins 0 occurrences of /tmp/.masc_agent[_mcp]_<sid> literals
+; across mcp_server_eio_execute.ml + tool_inline_dispatch_coord.ml
+; and exactly 1 Host_config.legacy_macos_default binding per module.
+(test
+ (name test_pr_d_agent_runtime_migration)
+ (modules test_pr_d_agent_runtime_migration)
+ (libraries masc_test_deps))

--- a/test/test_pr_d_agent_runtime_migration.ml
+++ b/test/test_pr_d_agent_runtime_migration.ml
@@ -1,0 +1,110 @@
+open Alcotest
+
+(** RFC-0084 host-config-cleanup-D — agent runtime root migration.
+
+    PR-D migrates the 7 cross-process agent-identity scratch-file
+    literals (`/tmp/.masc_agent[_mcp]_<sid>`) across 2 modules to
+    the typed [Host_config.agent_runtime_root] field:
+
+    - lib/mcp_server_eio_execute.ml (5 sites at 191, 210, 253, 331,
+      570 in PR-1 audit; lines may have shifted by ±N after PR-D's
+      module-init binding inserted earlier in the file)
+    - lib/tool_inline_dispatch_coord.ml (2 sites at 187, 267)
+
+    Each module has its own module-init binding because the modules
+    don't share a common ancestor other than [Host_config] itself.
+
+    Out of PR-D scope (intentional, separate follow-up cleanup):
+    - The [Sys.getenv_opt "TERM_SESSION_ID" |> Option.value
+      ~default:"default"] silent-collision issue documented in
+      03-hardcode-path-audit.md Top10 #5.  PR-D is a pure
+      typed-surface migration; the [default:"default"] fail-loud
+      conversion belongs in its own PR so its behaviour change
+      lands in isolation. *)
+
+let pinned_tmp_agent_literal_count = 0
+let pinned_agent_runtime_root_binding_count = 2
+
+let read_file path =
+  match In_channel.with_open_text path In_channel.input_all with
+  | exception _ -> ""
+  | content -> content
+;;
+
+let count_substring ~haystack ~needle =
+  let rec loop i acc =
+    let next = String.index_from_opt haystack i needle.[0] in
+    match next with
+    | None -> acc
+    | Some j ->
+      let len = String.length needle in
+      if j + len <= String.length haystack
+         && String.sub haystack j len = needle
+      then loop (j + len) (acc + 1)
+      else loop (j + 1) acc
+  in
+  loop 0 0
+;;
+
+let count_across_files ~files ~needle =
+  List.fold_left
+    (fun acc path ->
+      acc + count_substring ~haystack:(read_file path) ~needle)
+    0 files
+;;
+
+let consumer_files =
+  [ "lib/mcp_server_eio_execute.ml"
+  ; "lib/tool_inline_dispatch_coord.ml"
+  ]
+;;
+
+let test_no_tmp_agent_literals_in_consumers () =
+  (* Both prefix variants in one sweep. *)
+  let needles =
+    [ {|"/tmp/.masc_agent_%s"|}
+    ; {|"/tmp/.masc_agent_mcp_%s"|}
+    ]
+  in
+  let total =
+    List.fold_left
+      (fun acc needle -> acc + count_across_files ~files:consumer_files ~needle)
+      0 needles
+  in
+  (check int)
+    "literal occurrences of `/tmp/.masc_agent[_mcp]_<sid>` in the 2 \
+     consumer modules must be 0 after PR-D"
+    pinned_tmp_agent_literal_count total
+;;
+
+let test_agent_runtime_root_binding_count () =
+  let occurrences =
+    count_across_files ~files:consumer_files
+      ~needle:"Host_config.legacy_macos_default"
+  in
+  (check int)
+    "Host_config.legacy_macos_default invoked exactly once per \
+     consumer module (2 modules)"
+    pinned_agent_runtime_root_binding_count occurrences
+;;
+
+let test_agent_runtime_root_field_value () =
+  let d = Masc_mcp.Host_config.legacy_macos_default () in
+  (check string)
+    "Host_config.legacy_macos_default ().agent_runtime_root = /tmp today"
+    "/tmp" d.agent_runtime_root
+;;
+
+let () =
+  run
+    "PR-D host-config-cleanup-D (agent runtime root)"
+    [ ( "pr-d-agent-runtime"
+      , [ test_case "no-tmp-agent-literals-in-consumers" `Quick
+            test_no_tmp_agent_literals_in_consumers
+        ; test_case "agent-runtime-root-binding-count" `Quick
+            test_agent_runtime_root_binding_count
+        ; test_case "agent-runtime-root-field-value" `Quick
+            test_agent_runtime_root_field_value
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
RFC-0084 cleanup PR-D. Migrates 7 `/tmp/.masc_agent[_mcp]_<sid>` literal sites across 2 modules (`mcp_server_eio_execute.ml` × 5 + `tool_inline_dispatch_coord.ml` × 2) to the typed `Host_config.agent_runtime_root` field. Module-init binding per consumer.

## Out of PR-D scope (deferred)
The `TERM_SESSION_ID="default"` silent-collision (03-hardcode-path-audit.md Top10 #5) is *not* fixed here. PR-D is a pure typed-surface migration; the fail-loud conversion is a separate behaviour-change PR.

## Test plan
- [x] `dune build @lib/check` green
- [x] `dune exec test/test_pr_d_agent_runtime_migration.exe` — 3/3 OK
- [x] `ci/lint-no-direct-dispatch.sh` OK

## Stack
Base: `feature/rfc-0084-pr-h-disclosure-toml` (PR-H #15435).

## Scope
~90 LOC. RFC-0084 `follow_up_prs` slug: `host-config-cleanup-D`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)