### PR TITLE
fix(dashboard): expose execution transport provenance

### DIFF
--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -170,6 +170,178 @@ let _transport_health_cache =
         ])
 ;;
 
+let json_string_opt = function
+  | Some value -> `String value
+  | None -> `Null
+;;
+
+let cached_surface_assoc_field_opt key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+;;
+
+let cached_surface_projection_fields json =
+  match cached_surface_assoc_field_opt "projection_diagnostics" json with
+  | Some (`Assoc fields) -> fields
+  | _ -> []
+;;
+
+let cached_surface_projection_field json key =
+  List.assoc_opt key (cached_surface_projection_fields json)
+;;
+
+let cached_surface_generated_at_iso json =
+  match cached_surface_projection_field json "generated_at" with
+  | Some (`String value) -> value
+  | _ ->
+    (match cached_surface_assoc_field_opt "generated_at" json with
+     | Some (`String value) -> value
+     | _ -> Masc_domain.now_iso ())
+;;
+
+let cached_surface_cache_json
+      ?cache_key
+      ~scope
+      ~ttl_s
+      ~timeout_s
+      ~background_refresh_interval_s
+      json
+  =
+  let diagnostic_field key =
+    match cached_surface_projection_field json key with
+    | Some value -> value
+    | None -> `Null
+  in
+  let cache_state =
+    match cached_surface_projection_field json "cache_state" with
+    | Some (`String value) -> value
+    | _ -> "request_swr_or_inline_compute"
+  in
+  `Assoc
+    [ "scope", `String scope
+    ; "cache_state", `String cache_state
+    ; "projection_surface", diagnostic_field "surface"
+    ; "last_success_at", diagnostic_field "last_success_at"
+    ; "last_attempt_at", diagnostic_field "last_attempt_at"
+    ; "last_error_at", diagnostic_field "last_error_at"
+    ; "stale_reason", diagnostic_field "stale_reason"
+    ; "stale_age_ms", diagnostic_field "stale_age_ms"
+    ; "request_cache_key", json_string_opt cache_key
+    ; "request_cache_ttl_s", `Float ttl_s
+    ; "request_timeout_s", `Float timeout_s
+    ; "background_refresh_interval_s", `Float background_refresh_interval_s
+    ; "policy", `String "cached_surface plus HTTP stale-while-revalidate"
+    ]
+;;
+
+let with_cached_dashboard_surface_metadata
+      ~(config : Coord_utils.config)
+      ?cache_key
+      ~dashboard_surface
+      ~source
+      ~scope
+      ~producer
+      ~store_kind
+      ~ttl_s
+      ~timeout_s
+      ~background_refresh_interval_s
+      ~query
+      json
+  =
+  match json with
+  | `Assoc fields ->
+    let metadata_keys =
+      [ "dashboard_surface"
+      ; "source"
+      ; "generated_at_iso"
+      ; "retention"
+      ; "query"
+      ; "cache"
+      ]
+    in
+    let metadata =
+      [ "dashboard_surface", `String dashboard_surface
+      ; "source", `String source
+      ; "generated_at_iso", `String (cached_surface_generated_at_iso json)
+      ; ( "retention"
+        , `Assoc
+            [ "scope", `String scope
+            ; "coordination_root", `String config.base_path
+            ; "workspace_path", `String config.workspace_path
+            ; "producer", `String producer
+            ; "store_kind", `String store_kind
+            ; "cache_surface", `String "Server_dashboard_http_execution_surfaces.cached_surface"
+            ; "http_swr_ttl_s", `Float ttl_s
+            ; "background_refresh_interval_s", `Float background_refresh_interval_s
+            ; "request_timeout_s", `Float timeout_s
+            ; ( "cache_policy"
+              , `String
+                  "default route uses proactive cached_surface; parameterized route uses HTTP stale-while-revalidate"
+              )
+            ] )
+      ; ( "query", query )
+      ; ( "cache"
+        , cached_surface_cache_json
+            ?cache_key
+            ~scope
+            ~ttl_s
+            ~timeout_s
+            ~background_refresh_interval_s
+            json )
+      ]
+    in
+    let fields =
+      List.filter (fun (key, _) -> not (List.mem key metadata_keys)) fields
+    in
+    `Assoc (metadata @ fields)
+  | other -> other
+;;
+
+let execution_query_json ~actor ~fixture ~full_mode ~light ~default_light_request =
+  `Assoc
+    [ "actor", json_string_opt actor
+    ; "fixture", json_string_opt fixture
+    ; "full", `Bool full_mode
+    ; "light", `Bool light
+    ; "default_light_request", `Bool default_light_request
+    ]
+;;
+
+let with_execution_metadata ~config ?cache_key ~query json =
+  with_cached_dashboard_surface_metadata
+    ~config
+    ?cache_key
+    ~dashboard_surface:"/api/v1/dashboard/execution"
+    ~source:"dashboard_execution_read_model"
+    ~scope:"dashboard_execution"
+    ~producer:"Dashboard_execution.json"
+    ~store_kind:"process_cache"
+    ~ttl_s:120.0
+    ~timeout_s:Env_config_runtime.Dashboard.execution_timeout_sec
+    ~background_refresh_interval_s:60.0
+    ~query
+    json
+;;
+
+let transport_health_query_json () =
+  `Assoc [ "default_snapshot_request", `Bool true ]
+;;
+
+let with_transport_health_metadata ~config ~timeout_s json =
+  with_cached_dashboard_surface_metadata
+    ~config
+    ~dashboard_surface:"/api/v1/dashboard/transport-health"
+    ~source:"transport_health_read_model"
+    ~scope:"dashboard_transport_health"
+    ~producer:"Transport_metrics.transport_health_json"
+    ~store_kind:"process_cache"
+    ~ttl_s:30.0
+    ~timeout_s
+    ~background_refresh_interval_s:30.0
+    ~query:(transport_health_query_json ())
+    json
+;;
+
 let dashboard_execution_snapshot_json () = cached_surface_json _execution_cache
 
 let dashboard_transport_health_snapshot_json () =
@@ -437,7 +609,18 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
     ~compute
     ~on_result:(fun json ->
       mark_cached_surface_success _execution_cache json;
-      broadcast_cached_surface ~event_type:"execution_snapshot" json;
+      broadcast_cached_surface
+        ~event_type:"execution_snapshot"
+        (cached_surface_json _execution_cache
+         |> with_execution_metadata
+              ~config:room_config
+              ~query:
+                (execution_query_json
+                   ~actor:None
+                   ~fixture:None
+                   ~full_mode:false
+                   ~light:true
+                   ~default_light_request:true));
       !_broadcast_namespace_truth_ref state)
 ;;
 
@@ -470,18 +653,32 @@ let start_transport_health_refresh_loop ~state ~sw ~clock =
     ~compute
     ~on_result:(fun json ->
       mark_cached_surface_success _transport_health_cache json;
-      broadcast_cached_surface ~event_type:"transport_health_snapshot" json)
+      broadcast_cached_surface
+        ~event_type:"transport_health_snapshot"
+        (cached_surface_json _transport_health_cache
+         |> with_transport_health_metadata
+              ~config:state.Mcp_server.room_config
+              ~timeout_s))
 ;;
 
 let dashboard_execution_http_json ~state ~sw ~clock request =
+  let config = state.Mcp_server.room_config in
   let net = state.Mcp_server.net in
   let mono_clock = state.Mcp_server.mono_clock in
   let fixture = query_param request "fixture" in
   let actor =
-    execution_actor_for_request ~base_path:state.Mcp_server.room_config.base_path request
+    execution_actor_for_request ~base_path:config.base_path request
   in
   let full_mode = bool_query_param request "full" ~default:false in
   let light = not full_mode in
+  let query =
+    execution_query_json
+      ~actor
+      ~fixture
+      ~full_mode
+      ~light
+      ~default_light_request:(fixture = None && actor = None && not full_mode)
+  in
   let compute ?actor ?fixture ~light () =
     let started_at = Unix.gettimeofday () in
     run_dashboard_compute
@@ -490,7 +687,7 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
       ?mono_clock
       ~sw
       ~clock
-      ~config:state.Mcp_server.room_config
+      ~config
       (fun ~config ~sw ->
          Dashboard_execution.json
            ?actor
@@ -521,6 +718,10 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
       ~clock
       ~timeout_sec:Env_config_runtime.Dashboard.execution_timeout_sec
       (compute ~light:true)
+    |> with_execution_metadata
+         ~config
+         ~cache_key:"execution:default:light"
+         ~query
   | _ ->
     (* Parameterized requests (fixture/actor/full): on-demand with SWR cache.
          These are rare (test fixtures, actor-specific views, full mode). *)
@@ -537,6 +738,7 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
       ~clock
       ~timeout_sec:Env_config_runtime.Dashboard.execution_timeout_sec
       (compute ?actor ?fixture ~light)
+    |> with_execution_metadata ~config ~cache_key ~query
 ;;
 
 let dashboard_execution_trust_http_json ~state ~sw ~clock _request =
@@ -573,9 +775,19 @@ let transport_health_cache_diagnostics () =
   | _ -> []
 ;;
 
-let dashboard_transport_health_http_json ~state:_ =
+let dashboard_transport_health_http_json ~state =
+  let timeout_s =
+    float_of_env_default
+      "MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S"
+      ~default:8.0
+      ~min_v:3.0
+      ~max_v:30.0
+  in
   let json = cached_surface_json _transport_health_cache in
   extend_projection_diagnostics
     json
     (("source", `String "cached_surface") :: transport_health_cache_diagnostics ())
+  |> with_transport_health_metadata
+       ~config:state.Mcp_server.room_config
+       ~timeout_s
 ;;

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -124,7 +124,7 @@ check_json "dashboard config exposes runtime categories" "$BASE/api/v1/dashboard
 check_http "project snapshot 200" "$BASE/api/v1/dashboard/project-snapshot" "200"
 check_json "project snapshot exposes execution/readiness" "$BASE/api/v1/dashboard/project-snapshot" "'execution' in d and 'readiness' in d" '^True$'
 check_http "dashboard execution 200" "$BASE/api/v1/dashboard/execution" "200"
-check_json "dashboard execution exposes queue and agents" "$BASE/api/v1/dashboard/execution" "'status' in d and 'agents' in d and 'execution_queue' in d" '^True$'
+check_json "dashboard execution exposes provenance" "$BASE/api/v1/dashboard/execution" "'status' in d and 'agents' in d and 'execution_queue' in d and d.get('dashboard_surface') == '/api/v1/dashboard/execution' and d.get('source') == 'dashboard_execution_read_model' and d.get('retention', {}).get('scope') == 'dashboard_execution' and d.get('query', {}).get('default_light_request') is True and d.get('cache', {}).get('cache_state') in ('fresh', 'stale', 'initializing', 'request_swr_or_inline_compute')" '^True$'
 check_http "dashboard execution trust 200" "$BASE/api/v1/dashboard/execution-trust" "200"
 check_json "dashboard execution trust exposes provenance" "$BASE/api/v1/dashboard/execution-trust" "'dashboard_surface' in d and 'keepers' in d and 'coverage_gaps' in d" '^True$'
 check_http "dashboard mission 200" "$BASE/api/v1/dashboard/mission" "200"
@@ -215,7 +215,7 @@ check_json "keeper costs exposes keepers" "$BASE/api/v1/dashboard/keeper-costs?w
 check_http "memory subsystems 200" "$BASE/api/v1/dashboard/memory-subsystems" "200"
 check_json "memory subsystems has hebbian block" "$BASE/api/v1/dashboard/memory-subsystems" "'hebbian' in d" '^True$'
 check_http "transport health 200" "$BASE/api/v1/dashboard/transport-health" "200"
-check_json "transport health has summary" "$BASE/api/v1/dashboard/transport-health" "'summary' in d" '^True$'
+check_json "transport health exposes provenance" "$BASE/api/v1/dashboard/transport-health" "'summary' in d and d.get('dashboard_surface') == '/api/v1/dashboard/transport-health' and d.get('source') == 'transport_health_read_model' and d.get('retention', {}).get('scope') == 'dashboard_transport_health' and d.get('query', {}).get('default_snapshot_request') is True and d.get('cache', {}).get('cache_state') in ('fresh', 'stale', 'initializing', 'request_swr_or_inline_compute')" '^True$'
 check_http "attribution summary 200" "$BASE/api/v1/attribution/summary" "200"
 check_json "attribution summary has gates" "$BASE/api/v1/attribution/summary" "'gates' in d" '^True$'
 check_http "attribution recent 200" "$BASE/api/v1/attribution/recent?limit=1" "200"

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -67,6 +67,9 @@ let post_json ~id ~author ?(title = "") ?(body = "") ?hearth ?thread_id
   in
   `Assoc fields
 
+let request target =
+  Httpun.Request.create ~headers:(Httpun.Headers.of_list []) `GET target
+
 let comment_json ~id ~post_id ~author ~content ?(created_at = 1000.0) () =
   `Assoc
     [
@@ -935,6 +938,79 @@ let test_patch_keeper_dependent_caches_tolerates_null_agent () =
       true
       (row |> member "keepalive_running" |> to_bool))
 
+let test_execution_default_route_exposes_provenance () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Eio.Switch.run (fun sw ->
+        let state =
+          Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir ()
+        in
+        let seed =
+          `Assoc
+            [ "status", `Assoc [ "namespace", `String "default" ]
+            ; "agents", `List []
+            ; "execution_queue", `List []
+            ; "generated_at", `String "2026-05-15T01:00:00Z"
+            ]
+        in
+        with_execution_cache seed (fun () ->
+          let json =
+            Lib.Server_dashboard_http.dashboard_execution_http_json
+              ~state
+              ~sw
+              ~clock:(Eio.Stdenv.clock env)
+              (request "/api/v1/dashboard/execution")
+          in
+          let open Yojson.Safe.Util in
+          check string "surface" "/api/v1/dashboard/execution"
+            (json |> member "dashboard_surface" |> to_string);
+          check string "source" "dashboard_execution_read_model"
+            (json |> member "source" |> to_string);
+          check string "generated_at_iso" "2026-05-15T01:00:00Z"
+            (json |> member "generated_at_iso" |> to_string);
+          check string "retention scope" "dashboard_execution"
+            (json |> member "retention" |> member "scope" |> to_string);
+          check string "retention store" "process_cache"
+            (json |> member "retention" |> member "store_kind" |> to_string);
+          check bool "query default" true
+            (json |> member "query" |> member "default_light_request" |> to_bool);
+          check bool "query light" true
+            (json |> member "query" |> member "light" |> to_bool);
+          check string "cache state" "fresh"
+            (json |> member "cache" |> member "cache_state" |> to_string);
+          check string "cache key" "execution:default:light"
+            (json |> member "cache" |> member "request_cache_key" |> to_string))))
+
+let test_transport_health_route_exposes_provenance () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let state =
+        Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir ()
+      in
+      let json =
+        Lib.Server_dashboard_http.dashboard_transport_health_http_json ~state
+      in
+      let open Yojson.Safe.Util in
+      check string "surface" "/api/v1/dashboard/transport-health"
+        (json |> member "dashboard_surface" |> to_string);
+      check string "source" "transport_health_read_model"
+        (json |> member "source" |> to_string);
+      check string "retention scope" "dashboard_transport_health"
+        (json |> member "retention" |> member "scope" |> to_string);
+      check string "retention store" "process_cache"
+        (json |> member "retention" |> member "store_kind" |> to_string);
+      check bool "query default" true
+        (json |> member "query" |> member "default_snapshot_request" |> to_bool);
+      check string "cache scope" "dashboard_transport_health"
+        (json |> member "cache" |> member "scope" |> to_string);
+      check bool "generated surfaced" true
+        (String.length (json |> member "generated_at_iso" |> to_string) > 0))
+
 let callback_metric_value callback =
   Lib.Prometheus.metric_value_or_zero
     Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
@@ -1063,6 +1139,10 @@ let () =
             test_invalidate_execution_cache_counts_failures;
           Alcotest.test_case "lifecycle patch tolerates null agent" `Quick
             test_patch_keeper_dependent_caches_tolerates_null_agent;
+          Alcotest.test_case "execution default route exposes provenance" `Quick
+            test_execution_default_route_exposes_provenance;
+          Alcotest.test_case "transport health route exposes provenance" `Quick
+            test_transport_health_route_exposes_provenance;
           Alcotest.test_case "running keeper patch tolerates null agent" `Quick
             test_patch_surface_json_for_running_keepers_tolerates_null_agent;
           Alcotest.test_case "patch keeper row tolerates null agent shape" `Quick


### PR DESCRIPTION
## Summary
- add provenance metadata to dashboard execution and transport-health surfaces
- include retention/query/cache metadata for default and parameterized execution requests
- extend dashboard verification and focused execution tests for the new contract

## Verification
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_dashboard_execution.exe
- ./_build/default/test/test_dashboard_execution.exe