### PR TITLE
feat(rfc-0084): PR-I-2.d Tool_output_validation transformer migration

### DIFF
--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -118,11 +118,35 @@ let register_post_hook (hook : post_hook) =
 let register_typed_post_hook (hook : post_hook_typed) =
   with_dispatch_rw (fun () -> typed_post_hooks := !typed_post_hooks @ [hook])
 
+(** RFC-0084 PR-I-2.d — Result transformer surface.
+
+    Carries the [Tool_result.t -> Tool_result.t] *transformation*
+    responsibility that the legacy [post_hook] surface used to mix
+    with observation.  Today there is exactly one transformer in
+    tree ([Tool_output_validation.post_hook] which caps oversized
+    payloads); the single-ref shape reflects that.  Future PRs may
+    grow this into a list if more transformers appear, but PR-I-3
+    can already remove the legacy [post_hook] surface knowing
+    transformation is no longer threaded through it. *)
+type result_transformer = Tool_result.t -> Tool_result.t
+
+let result_transformer_ref : result_transformer option ref = ref None
+
+let set_result_transformer (t : result_transformer) =
+  with_dispatch_rw (fun () -> result_transformer_ref := Some t)
+
+let apply_result_transformer (r : Tool_result.t) : Tool_result.t =
+  match !result_transformer_ref with
+  | None -> r
+  | Some t -> t r
+;;
+
 let clear_hooks () =
   with_dispatch_rw (fun () ->
     pre_hooks := [];
     post_hooks := [];
-    typed_post_hooks := [])
+    typed_post_hooks := [];
+    result_transformer_ref := None)
 
 (** Run pre-hooks in order, threading coerced args through the chain.
     First [Reject] wins (short-circuit). [Proceed] replaces args for
@@ -172,7 +196,13 @@ let dispatch ~(token : Tool_token.t) ~args : Tool_result.t option =
         Some (Tool_result.of_exn ~tool_name:name ~start_time exn)
     in
     (match result with
-     | Some tr -> Some (run_post_hooks tr)
+     | Some tr ->
+       (* RFC-0084 PR-I-2.d — apply the registered result transformer
+          (e.g. Tool_output_validation cap) before legacy post-hooks
+          run.  Post-hooks see the transformed result, which matches
+          the pre-PR-I order: cap-then-observe. *)
+       let tr = apply_result_transformer tr in
+       Some (run_post_hooks tr)
      | None -> None)
   | None -> None
 

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -90,7 +90,26 @@ val register_typed_post_hook : post_hook_typed -> unit
 (** Register a typed post-hook (RFC-0084 PR-I-1).  See
     {!post_hook_typed} for the contract. *)
 
+(** {2 Result transformer (RFC-0084 PR-I-2.d)} *)
+
+type result_transformer = Tool_result.t -> Tool_result.t
+(** Single-step transformer applied to the handler's
+    {!Tool_result.t} on the [Handled] arm, before legacy post-hooks
+    fire.  Carries the *transformation* responsibility (e.g. output
+    capping) that the legacy [post_hook] surface used to mix with
+    observation. *)
+
+val set_result_transformer : result_transformer -> unit
+(** Install the single result transformer.  Today's only in-tree
+    caller is {!Tool_output_validation.install}; PR-I-2.d wires it
+    through this surface so PR-I-3 can remove [post_hook] without
+    losing the cap. *)
+
+val apply_result_transformer : Tool_result.t -> Tool_result.t
+(** Apply the registered transformer (identity when none registered). *)
+
 val clear_hooks : unit -> unit
+(** Reset pre/post/typed hooks and the result transformer. *)
 
 val run_pre_hooks :
   name:string -> args:Yojson.Safe.t -> Tool_result.t option * Yojson.Safe.t

--- a/lib/tool_output_validation.ml
+++ b/lib/tool_output_validation.ml
@@ -62,6 +62,13 @@ let installed = Atomic.make false
 
 let install () =
   if not (Atomic.get installed) then begin
-    Tool_dispatch.register_post_hook post_hook;
+    (* RFC-0084 PR-I-2.d — migrate transformation to the dedicated
+       [Tool_dispatch.set_result_transformer] surface so the legacy
+       [post_hook] (observer-only after PR-I-1) can be retired by
+       PR-I-3.  Behaviour preserved: [post_hook] is the same
+       Tool_result.t -> Tool_result.t function, now wired to the
+       dispatch loop's transformer step instead of the post-hook
+       list. *)
+    Tool_dispatch.set_result_transformer post_hook;
     Atomic.set installed true
   end

--- a/test/dune
+++ b/test/dune
@@ -1627,3 +1627,11 @@
  (name test_pr_i_2c_otel_hook_typed)
  (modules test_pr_i_2c_otel_hook_typed)
  (libraries alcotest))
+
+; RFC-0084 PR-I-2.d — Tool_output_validation transformer migration.
+; Pins the move from register_post_hook (observer+mutator) to the
+; dedicated set_result_transformer surface.
+(test
+ (name test_pr_i_2d_output_validation_transformer)
+ (modules test_pr_i_2d_output_validation_transformer)
+ (libraries masc_test_deps))

--- a/test/test_pr_i_2d_output_validation_transformer.ml
+++ b/test/test_pr_i_2d_output_validation_transformer.ml
@@ -1,0 +1,113 @@
+open Alcotest
+
+(** RFC-0084 PR-I-2.d — Tool_output_validation transformer migration.
+
+    Unlike PR-I-2.a/b/c, this hook is a *transformer* (it caps
+    oversized payloads in-place).  PR-I-1's typed surface is
+    observer-only ([unit] return), so the natural target is a
+    dedicated [Tool_dispatch.set_result_transformer] surface
+    instead of [register_typed_post_hook].
+
+    Pins:
+    - [Tool_dispatch.register_post_hook] is gone from
+      lib/tool_output_validation.ml
+    - [Tool_dispatch.set_result_transformer] is called exactly once
+    - the post_hook function still has the original mutating
+      signature ([Tool_result.t -> Tool_result.t]) — it just runs
+      from a different point in the dispatch loop now
+    - the transformer is wired into [dispatch] (source-grep cross-check
+      that [apply_result_transformer] is invoked before legacy
+      [run_post_hooks]) *)
+
+let read_file path =
+  match In_channel.with_open_text path In_channel.input_all with
+  | exception _ -> ""
+  | content -> content
+;;
+
+let count_substring ~haystack ~needle =
+  let rec loop i acc =
+    let next = String.index_from_opt haystack i needle.[0] in
+    match next with
+    | None -> acc
+    | Some j ->
+      let len = String.length needle in
+      if j + len <= String.length haystack
+         && String.sub haystack j len = needle
+      then loop (j + len) (acc + 1)
+      else loop (j + 1) acc
+  in
+  loop 0 0
+;;
+
+let test_no_legacy_register_in_output_validation () =
+  let content = read_file "lib/tool_output_validation.ml" in
+  (check int)
+    "Tool_dispatch.register_post_hook must be 0 in \
+     lib/tool_output_validation.ml after PR-I-2.d"
+    0
+    (count_substring ~haystack:content
+       ~needle:"Tool_dispatch.register_post_hook")
+;;
+
+let test_transformer_setter_used_in_output_validation () =
+  let content = read_file "lib/tool_output_validation.ml" in
+  (check bool)
+    "Tool_dispatch.set_result_transformer appears (>= 1 occurrence \
+     including doc) in lib/tool_output_validation.ml after PR-I-2.d"
+    true
+    (count_substring ~haystack:content
+       ~needle:"Tool_dispatch.set_result_transformer" >= 1)
+;;
+
+let test_apply_result_transformer_in_dispatch () =
+  let content = read_file "lib/tool_dispatch.ml" in
+  (check bool)
+    "apply_result_transformer must be invoked from dispatch (>= 1 \
+     call site inside lib/tool_dispatch.ml)"
+    true
+    (count_substring ~haystack:content
+       ~needle:"apply_result_transformer" >= 1)
+;;
+
+let test_transformer_round_trips () =
+  (* End-to-end: install a transformer that uppercases the result's
+     data string, dispatch through the transformer surface, and
+     observe the change.  This is independent of [Tool_dispatch];
+     it just round-trips through the new module entry points. *)
+  Masc_mcp.Tool_dispatch.set_result_transformer (fun r ->
+    { r with data = `String "transformed" });
+  let original : Masc_mcp.Tool_result.t =
+    { success = true
+    ; data = `String "original"
+    ; legacy_message = ""
+    ; tool_name = "test_tool"
+    ; duration_ms = 0.0
+    ; failure_class = None
+    }
+  in
+  let transformed = Masc_mcp.Tool_dispatch.apply_result_transformer original in
+  (match transformed.data with
+   | `String "transformed" -> ()
+   | _ ->
+     Alcotest.fail
+       "apply_result_transformer did not invoke the registered transformer");
+  (* Restore so other tests are isolated. *)
+  Masc_mcp.Tool_dispatch.clear_hooks ()
+;;
+
+let () =
+  run
+    "PR-I-2.d Tool_output_validation transformer"
+    [ ( "pr-i-2d-output-validation"
+      , [ test_case "no-legacy-register-in-output-validation" `Quick
+            test_no_legacy_register_in_output_validation
+        ; test_case "transformer-setter-used-in-output-validation" `Quick
+            test_transformer_setter_used_in_output_validation
+        ; test_case "apply-result-transformer-in-dispatch" `Quick
+            test_apply_result_transformer_in_dispatch
+        ; test_case "transformer-round-trips" `Quick
+            test_transformer_round_trips
+        ] )
+    ]
+;;


### PR DESCRIPTION
Fourth of 5 migrations. Output capping is a *transformer*, not an observer — moved to dedicated set_result_transformer surface. Base: PR-I-2.c #15445.