### PR TITLE
feat(rfc-0084): PR-I-3 legacy post-hook surface removal (FINAL)

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -467,7 +467,13 @@ let make_keeper_tool_handler
         meta.name
         ~tool_name:name
         ~success:false;
-      ignore (Tool_dispatch.run_post_hooks validation_result);
+      (* RFC-0084 PR-I-3 — run_post_hooks retired.  Validation failure
+         is a Handler_error from the typed-outcome perspective; emit
+         the typed observers directly so metrics / usage_log still
+         see it. *)
+      Tool_dispatch.run_typed_post_hooks
+        (Dispatch_outcome.Handler_error { exn = "validation_failed" })
+        (Some validation_result);
       broadcast_keeper_tool_call_event
         ~keeper_name:meta.name
         ~tool_name:name
@@ -567,7 +573,10 @@ let make_keeper_tool_handler
                    failure_class = Some Tool_result.Runtime_failure
                  }
              in
-             ignore (Tool_dispatch.run_post_hooks tr));
+             (* RFC-0084 PR-I-3 — typed observers replace
+                run_post_hooks. *)
+             Tool_dispatch.run_typed_post_hooks
+               Dispatch_outcome.Handled (Some tr));
             let detail =
               let s = String.trim raw_result in
               String_util.utf8_safe
@@ -636,7 +645,10 @@ let make_keeper_tool_handler
                  ; failure_class = None
                  }
              in
-             ignore (Tool_dispatch.run_post_hooks tr));
+             (* RFC-0084 PR-I-3 — typed observers replace
+                run_post_hooks. *)
+             Tool_dispatch.run_typed_post_hooks
+               Dispatch_outcome.Handled (Some tr));
             let ts = Time_compat.now () in
             broadcast_keeper_tool_call_event
               ~keeper_name:meta.name

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -73,14 +73,11 @@ type pre_hook_action =
 (** Pre-hook: receives tool name and args before handler runs. *)
 type pre_hook = name:string -> args:Yojson.Safe.t -> pre_hook_action
 
-(** Post-hook: receives result after handler completes.
-    Return the (possibly transformed) tool result.
-
-    RFC-0084 PR-I-1 keeps this legacy surface as-is and adds the
-    typed [post_hook_typed] surface below in parallel.  PR-I-2.*
-    migrates the 5 in-tree registrations one at a time; PR-I-3
-    removes this type once those land. *)
-type post_hook = Tool_result.t -> Tool_result.t
+(* RFC-0084 PR-I-3 — legacy [type post_hook = Tool_result.t -> Tool_result.t]
+   removed.  All 5 in-tree call-sites migrated by PR-I-2.a..e:
+   tool_metrics / tool_usage_log / otel_dispatch_hook / tool_output_validation
+   / server_bootstrap_loops.  Observation moved to [post_hook_typed]
+   below; transformation moved to [result_transformer] further down. *)
 
 (** Typed post-hook (RFC-0084 PR-I-1).
 
@@ -106,14 +103,10 @@ type post_hook = Tool_result.t -> Tool_result.t
 type post_hook_typed = Dispatch_outcome.t -> Tool_result.t option -> unit
 
 let pre_hooks : pre_hook list ref = ref []
-let post_hooks : post_hook list ref = ref []
 let typed_post_hooks : post_hook_typed list ref = ref []
 
 let register_pre_hook (hook : pre_hook) =
   with_dispatch_rw (fun () -> pre_hooks := !pre_hooks @ [hook])
-
-let register_post_hook (hook : post_hook) =
-  with_dispatch_rw (fun () -> post_hooks := !post_hooks @ [hook])
 
 let register_typed_post_hook (hook : post_hook_typed) =
   with_dispatch_rw (fun () -> typed_post_hooks := !typed_post_hooks @ [hook])
@@ -144,7 +137,6 @@ let apply_result_transformer (r : Tool_result.t) : Tool_result.t =
 let clear_hooks () =
   with_dispatch_rw (fun () ->
     pre_hooks := [];
-    post_hooks := [];
     typed_post_hooks := [];
     result_transformer_ref := None)
 
@@ -162,9 +154,10 @@ let run_pre_hooks ~name ~args =
   in
   go args !pre_hooks
 
-(** Run post-hooks in order, threading the result through. *)
-let run_post_hooks result =
-  List.fold_left (fun r hook -> hook r) result !post_hooks
+(* RFC-0084 PR-I-3 — [run_post_hooks] removed alongside the legacy
+   [post_hook] type and [post_hooks] ref.  Observation flows through
+   [run_typed_post_hooks] below; transformation through
+   [apply_result_transformer]. *)
 
 (** Run typed post-hooks in order against the typed dispatch outcome.
     Each hook is invoked for its side-effects; mutation of the
@@ -198,11 +191,11 @@ let dispatch ~(token : Tool_token.t) ~args : Tool_result.t option =
     (match result with
      | Some tr ->
        (* RFC-0084 PR-I-2.d — apply the registered result transformer
-          (e.g. Tool_output_validation cap) before legacy post-hooks
-          run.  Post-hooks see the transformed result, which matches
-          the pre-PR-I order: cap-then-observe. *)
-       let tr = apply_result_transformer tr in
-       Some (run_post_hooks tr)
+          (e.g. Tool_output_validation cap) inside the dispatch loop.
+          PR-I-3 removed the legacy run_post_hooks call; typed
+          observers fire from guarded_dispatch via
+          [run_typed_post_hooks] for every outcome arm. *)
+       Some (apply_result_transformer tr)
      | None -> None)
   | None -> None
 

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -48,13 +48,10 @@ type pre_hook_action =
 type pre_hook = name:string -> args:Yojson.Safe.t -> pre_hook_action
 (** Pre-hook: receives tool name and args before handler runs. *)
 
-type post_hook = Tool_result.t -> Tool_result.t
-(** Post-hook: receives result after handler completes.
-    Return the (possibly transformed) tool result.
-
-    RFC-0084 PR-I-1 keeps this legacy surface; PR-I-2.* migrates the
-    5 in-tree registrations to the typed [post_hook_typed] surface
-    below; PR-I-3 removes this type. *)
+(* RFC-0084 PR-I-3 — [type post_hook] removed.  All 5 in-tree
+   register_post_hook callers migrated to [register_typed_post_hook]
+   (observer) or [set_result_transformer] (transformer) by
+   PR-I-2.a..e. *)
 
 type post_hook_typed =
   Dispatch_outcome.t -> Tool_result.t option -> unit
@@ -77,14 +74,13 @@ type post_hook_typed =
 val pre_hooks : pre_hook list ref
 (** Mutable list of registered pre-hooks. *)
 
-val post_hooks : post_hook list ref
-(** Mutable list of registered post-hooks. *)
+(* RFC-0084 PR-I-3 — the legacy post-hooks ref and registration
+   entry are gone alongside [type post_hook]. *)
 
 val typed_post_hooks : post_hook_typed list ref
 (** Mutable list of registered typed post-hooks (RFC-0084 PR-I-1). *)
 
 val register_pre_hook : pre_hook -> unit
-val register_post_hook : post_hook -> unit
 
 val register_typed_post_hook : post_hook_typed -> unit
 (** Register a typed post-hook (RFC-0084 PR-I-1).  See
@@ -117,19 +113,18 @@ val run_pre_hooks :
     Returns [(Some rejection, _)] on short-circuit,
     or [(None, final_args)] when all hooks pass. *)
 
-val run_post_hooks : Tool_result.t -> Tool_result.t
-(** Execute registered post-hooks in order, threading the result.
-    Used by keeper dispatch to feed metrics/usage hooks for tools
-    that bypass [dispatch]. *)
+(* RFC-0084 PR-I-3 — [val run_post_hooks] removed.  Dispatch loop
+   now applies [apply_result_transformer] (transformation) inside
+   [dispatch], and [run_typed_post_hooks] (observation) from
+   [guarded_dispatch] for every outcome arm. *)
 
 val run_typed_post_hooks :
   Dispatch_outcome.t -> Tool_result.t option -> unit
 (** Execute registered typed post-hooks against the typed outcome
     (RFC-0084 PR-I-1).  Invoked from [guarded_dispatch] for every
     arm with the optional handler {!Tool_result.t} ([Some _] on the
-    [Handled] arm, [None] otherwise).  Fires in addition to the
-    legacy [run_post_hooks] call inside [dispatch] (which still
-    fires only on the [Handled] arm). *)
+    [Handled] arm, [None] otherwise).  Sole observer-side dispatch
+    seam after PR-I-3 retired the legacy [run_post_hooks]. *)
 
 (* RFC-0084 PR-11 — [val dispatch_structured] removed from the public mli
    surface. PR-7~9 migration verified external callers = 0 (rg in lib/ +

--- a/test/dune
+++ b/test/dune
@@ -1646,3 +1646,13 @@
  (name test_pr_i_2e_bootstrap_loops_typed)
  (modules test_pr_i_2e_bootstrap_loops_typed)
  (libraries alcotest))
+
+; RFC-0084 PR-I-3 — legacy post-hook surface removal (final).
+; Pins 0 references to register_post_hook / run_post_hooks across
+; all of lib/, 0 declarations of legacy entries in the mli, and
+; presence of the typed surface entries (register_typed_post_hook,
+; run_typed_post_hooks, set_result_transformer).
+(test
+ (name test_pr_i_3_legacy_post_hook_removed)
+ (modules test_pr_i_3_legacy_post_hook_removed)
+ (libraries alcotest))

--- a/test/test_pr_i_3_legacy_post_hook_removed.ml
+++ b/test/test_pr_i_3_legacy_post_hook_removed.ml
@@ -1,0 +1,156 @@
+open Alcotest
+
+(** RFC-0084 PR-I-3 — legacy post-hook surface removal (final).
+
+    After PR-I-2.a..e migrated all 5 in-tree register_post_hook
+    call-sites, PR-I-3 removes the legacy [type post_hook],
+    [val register_post_hook], [val post_hooks], and
+    [val run_post_hooks] from Tool_dispatch.
+
+    The dispatch loop now threads transformation through
+    [apply_result_transformer] (PR-I-2.d) and observation through
+    [run_typed_post_hooks] (PR-I-1).  Legacy keeper_tools_oas
+    call-sites that previously called [Tool_dispatch.run_post_hooks]
+    on bypass paths are migrated to the typed observer surface in
+    this PR as well.
+
+    Pins:
+    - [Tool_dispatch.register_post_hook] not declared in mli
+    - [Tool_dispatch.run_post_hooks] not declared in mli
+    - [Tool_dispatch.post_hooks] not declared in mli
+    - [type post_hook] not declared in mli
+    - no [Tool_dispatch.run_post_hooks] references in lib/
+    - no [Tool_dispatch.register_post_hook] references in lib/ *)
+
+let read_file path =
+  match In_channel.with_open_text path In_channel.input_all with
+  | exception _ -> ""
+  | content -> content
+;;
+
+let count_substring ~haystack ~needle =
+  let rec loop i acc =
+    let next = String.index_from_opt haystack i needle.[0] in
+    match next with
+    | None -> acc
+    | Some j ->
+      let len = String.length needle in
+      if j + len <= String.length haystack
+         && String.sub haystack j len = needle
+      then loop (j + len) (acc + 1)
+      else loop (j + 1) acc
+  in
+  loop 0 0
+;;
+
+(* Walk lib/ for any .ml file containing the legacy entry references.
+   Limit the walk to a hand-rolled BFS over [lib/] subtree.  Excludes
+   the documentation comment in [tool_dispatch.mli] which is
+   *removal-notice* prose, not a live reference. *)
+let walk_ml_files root =
+  let rec aux acc paths =
+    match paths with
+    | [] -> acc
+    | path :: rest ->
+      (match Sys.is_directory path with
+       | true ->
+         let children =
+           try
+             Sys.readdir path
+             |> Array.to_list
+             |> List.map (fun child -> Filename.concat path child)
+           with _ -> []
+         in
+         aux acc (children @ rest)
+       | false ->
+         if Filename.check_suffix path ".ml"
+         then aux (path :: acc) rest
+         else aux acc rest
+       | exception _ -> aux acc rest)
+  in
+  aux [] [ root ]
+;;
+
+let test_no_legacy_register_in_lib () =
+  let files = walk_ml_files "lib" in
+  let total =
+    List.fold_left
+      (fun acc path ->
+        acc + count_substring ~haystack:(read_file path)
+                ~needle:"Tool_dispatch.register_post_hook")
+      0 files
+  in
+  (check int)
+    "Tool_dispatch.register_post_hook must be unreferenced across \
+     all of lib/ after PR-I-3"
+    0 total
+;;
+
+let test_no_legacy_run_post_hooks_in_lib () =
+  let files = walk_ml_files "lib" in
+  let total =
+    List.fold_left
+      (fun acc path ->
+        acc + count_substring ~haystack:(read_file path)
+                ~needle:"Tool_dispatch.run_post_hooks")
+      0 files
+  in
+  (check int)
+    "Tool_dispatch.run_post_hooks must be unreferenced across \
+     all of lib/ after PR-I-3"
+    0 total
+;;
+
+let test_mli_does_not_declare_legacy_post_hook () =
+  let mli = read_file "lib/tool_dispatch.mli" in
+  (check int)
+    "mli must not declare [type post_hook] after PR-I-3"
+    0
+    (count_substring ~haystack:mli ~needle:"type post_hook =")
+;;
+
+let test_mli_does_not_declare_register_post_hook_val () =
+  let mli = read_file "lib/tool_dispatch.mli" in
+  (check int)
+    "mli must not declare [val register_post_hook] after PR-I-3"
+    0
+    (count_substring ~haystack:mli ~needle:"val register_post_hook")
+;;
+
+let test_mli_does_not_declare_run_post_hooks_val () =
+  let mli = read_file "lib/tool_dispatch.mli" in
+  (check int)
+    "mli must not declare [val run_post_hooks] after PR-I-3"
+    0
+    (count_substring ~haystack:mli ~needle:"val run_post_hooks ")
+;;
+
+let test_typed_surface_still_present () =
+  let mli = read_file "lib/tool_dispatch.mli" in
+  (check bool)
+    "typed post-hook surface still declared in mli after PR-I-3"
+    true
+    (count_substring ~haystack:mli ~needle:"val register_typed_post_hook" >= 1
+     && count_substring ~haystack:mli ~needle:"val run_typed_post_hooks" >= 1
+     && count_substring ~haystack:mli ~needle:"set_result_transformer" >= 1)
+;;
+
+let () =
+  run
+    "PR-I-3 legacy post-hook surface removal"
+    [ ( "pr-i-3-legacy-removal"
+      , [ test_case "no-legacy-register-in-lib" `Quick
+            test_no_legacy_register_in_lib
+        ; test_case "no-legacy-run-post-hooks-in-lib" `Quick
+            test_no_legacy_run_post_hooks_in_lib
+        ; test_case "mli-does-not-declare-legacy-post-hook" `Quick
+            test_mli_does_not_declare_legacy_post_hook
+        ; test_case "mli-does-not-declare-register-post-hook-val" `Quick
+            test_mli_does_not_declare_register_post_hook_val
+        ; test_case "mli-does-not-declare-run-post-hooks-val" `Quick
+            test_mli_does_not_declare_run_post_hooks_val
+        ; test_case "typed-surface-still-present" `Quick
+            test_typed_surface_still_present
+        ] )
+    ]
+;;


### PR DESCRIPTION
Final slice of PR-I series. Removes legacy register_post_hook / post_hooks / run_post_hooks. Bypass call-sites in keeper_tools_oas migrated. Base: PR-I-2.e #15449.