### PR TITLE
fix(paths): replace hardcoded /tmp with Filename.get_temp_dir_name

### DIFF
--- a/lib/keeper/host_config.ml
+++ b/lib/keeper/host_config.ml
@@ -36,16 +36,16 @@ let legacy_coreutils_macos =
 ;;
 
 let legacy_macos_default () =
-  { cred_root = "/tmp/keeper-creds"
+  { cred_root = Filename.concat (Filename.get_temp_dir_name ()) "keeper-creds"
   ; host_bash = "/bin/bash"
   ; host_zsh = "/bin/zsh"
   ; host_sh = "/bin/sh"
   ; coreutils = legacy_coreutils_macos
-  ; agent_runtime_root = "/tmp"
+  ; agent_runtime_root = Filename.get_temp_dir_name ()
   ; sandbox_workspace_root =
       (match Sys.getenv_opt "HOME" with
        | Some home -> Filename.concat home "me"
-       | None -> "/tmp/masc-fleet")
+       | None -> Filename.concat (Filename.get_temp_dir_name ()) "masc-fleet")
   ; test_mode =
       (let exec = Filename.basename Sys.executable_name in
        if String.length exec >= 5 && String.sub exec 0 5 = "test_"
@@ -107,7 +107,7 @@ let resolve_coreutils () =
 ;;
 
 let resolve ?base_path () =
-  let base = Option.value base_path ~default:"/tmp" in
+  let base = Option.value base_path ~default:(Filename.get_temp_dir_name ()) in
   let agent_runtime_root = Filename.concat base ".masc/runtime/agent" in
   let cred_root = Filename.concat base ".masc/credentials" in
   let sandbox_workspace_root =

--- a/lib/tool_inline_dispatch_coord.ml
+++ b/lib/tool_inline_dispatch_coord.ml
@@ -56,10 +56,10 @@ let handle_start ~tool_name ~start_time (ctx : context) : tool_result option =
     end else begin
       let expanded =
         if String.length path >= 2 && Char.equal path.[0] '~' && Char.equal path.[1] '/' then
-          let home = match Sys.getenv_opt "HOME" with Some h -> h | None -> "/tmp" in
+          let home = match Sys.getenv_opt "HOME" with Some h -> h | None -> Filename.get_temp_dir_name () in
           Filename.concat home (String.sub path 2 (String.length path - 2))
         else if String.length path = 1 && Char.equal path.[0] '~' then
-          (match Sys.getenv_opt "HOME" with Some h -> h | None -> "/tmp")
+          (match Sys.getenv_opt "HOME" with Some h -> h | None -> Filename.get_temp_dir_name ())
         else if Filename.is_relative path then
           Filename.concat (Sys.getcwd ()) path
         else


### PR DESCRIPTION
## Summary
- Replace 6 hardcoded `"/tmp"` literals with `Filename.get_temp_dir_name()` in host_config.ml and tool_inline_dispatch_coord.ml
- Respects TMPDIR and platform temp directory conventions (macOS `/var/folders/...`, Linux `$TMPDIR`, etc.)

## Scope
- `lib/keeper/host_config.ml`: 4 sites — `cred_root`, `agent_runtime_root`, `sandbox_workspace_root` fallback, `resolve ~base_path` default
- `lib/tool_inline_dispatch_coord.ml`: 2 sites — tilde expansion HOME fallback

## Verification
- `dune build @check` passes
- Replaces closed #15433 (conflicted with main)