### PR TITLE
docs(tool-output): update transformer hook docs

### DIFF
--- a/lib/tool_output_validation.mli
+++ b/lib/tool_output_validation.mli
@@ -15,10 +15,10 @@ val max_output_chars : int
     [max_output_chars]; otherwise truncates and appends a marker. *)
 val cap : string -> string
 
-(** Post-hook for [Tool_dispatch.register_post_hook].
+(** Result transformer for [Tool_dispatch.set_result_transformer].
     Applies [cap] to [masc_*] tools that go through the dispatch
     pipeline. *)
 val post_hook : Tool_result.t -> Tool_result.t
 
-(** Install the post-hook into [Tool_dispatch]. Idempotent. *)
+(** Install the result transformer into [Tool_dispatch]. Idempotent. *)
 val install : unit -> unit


### PR DESCRIPTION
## Summary
- update Tool_output_validation mli docs to reference set_result_transformer after PR-I-3 removed legacy post hooks
- keep behavior unchanged; doc-only follow-up for #15451

## Verification
- git diff --check
- scripts/dune-local.sh build test/test_pr_i_2d_output_validation_transformer.exe