### PR TITLE
[codex] fix keeper runtime boundary visibility

### DIFF
--- a/lib/keeper/keeper_cascade_routing.ml
+++ b/lib/keeper/keeper_cascade_routing.ml
@@ -2,6 +2,10 @@
 
     Maps keeper phase to an effective cascade profile name.
     Pure function — mirrors TLA+ KeeperCoreTriad.SelectCascade action.
+    The live keeper-turn hot path phase-gates non-executable phases before
+    provider dispatch; those branches are retained for diagnostics/spec parity
+    and must not imply that a new provider turn will run while paused,
+    draining, overflowed, compacting, or handing off.
 
     @since Core Triad (State x Decision x Cascade) *)
 
@@ -22,13 +26,13 @@ let select_cascade ~(base_cascade : string) ~(phase : Keeper_state_machine.phase
           reason = "failing phase: cheap local recovery" }
     | Compacting | HandingOff ->
         { effective_cascade = Keeper_config.local_only_cascade_name;
-          reason = "buffer operation: local model sufficient" }
+          reason = "buffer operation: diagnostic route; hot path blocks new turns" }
     | Overflowed ->
         { effective_cascade = base_cascade;
           reason = "overflowed phase: turn blocked upstream pending compaction" }
     | Draining | Paused ->
         { effective_cascade = base_cascade;
-          reason = "winding down: complete in-progress work" }
+          reason = "non-executable phase: turn blocked upstream" }
     | Offline | Stopped | Dead | Zombie | Crashed | Restarting ->
         { effective_cascade = base_cascade;
           reason = "non-turn phase (blocked upstream)" }

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -108,6 +108,26 @@ let partition_tool_search_hits ~core ~core_always ~allowed ~retrieved ~max_resul
   }
 ;;
 
+let truncate_tool_surface_names ~max_tools ~essential_names all_allowed =
+  if List.length all_allowed <= max_tools
+  then all_allowed
+  else (
+    let essential_names = Keeper_types.dedupe_keep_order essential_names in
+    let essential =
+      all_allowed
+      |> List.filter (fun name -> List.mem name essential_names)
+      |> Keeper_types.dedupe_keep_order
+    in
+    let non_essential =
+      List.filter (fun name -> not (List.mem name essential_names)) all_allowed
+    in
+    let budget = max 0 (max_tools - List.length essential) in
+    essential
+    @ (non_essential
+       |> List.filteri (fun i _ -> i < budget)
+       |> Keeper_types.dedupe_keep_order))
+;;
+
 (** Agent setup produced by Step 7.
 
     Hook mutations flow through {!acc}, receipt refs are kept for
@@ -1004,16 +1024,7 @@ let prepare_agent_setup
           Keeper_types.dedupe_keep_order
             (visible_always_include_tools @ required_turn_essential_tool_names)
         in
-        let essential =
-          List.filter (fun name -> List.mem name essential_names) all_allowed
-        in
-        let non_essential =
-          List.filter
-            (fun name -> not (List.mem name visible_always_include_tools))
-            all_allowed
-        in
-        let budget = max_tools - List.length essential in
-        essential @ List.filteri (fun i _ -> i < budget) non_essential)
+        truncate_tool_surface_names ~max_tools ~essential_names all_allowed)
       else all_allowed
     in
     let allowed_canonical_tool_names =

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -60,6 +60,15 @@ val partition_tool_search_hits
   -> max_results:int
   -> tool_search_hit_partition
 
+val truncate_tool_surface_names
+  :  max_tools:int
+  -> essential_names:string list
+  -> string list
+  -> string list
+(** Keep essential tools at the front while truncating an already ordered
+    visible tool surface. Essential names are removed from the tail before the
+    budget slice so required/affordance tools cannot be double-counted. *)
+
 (** Agent setup produced by Step 7.
 
     Hook mutations flow through {!acc}, receipt refs are kept for

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -350,6 +350,8 @@ let record_pre_dispatch_terminal_observation
       false
   in
   if receipt_append_ok then
+    Keeper_status_detail.invalidate_status_cache_for meta.name;
+  if receipt_append_ok then
     append_manifest
       ~site:"pre_dispatch_receipt_appended"
       Keeper_runtime_manifest.Receipt_appended;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -465,6 +465,49 @@ let run_keeper_cycle
         ~prev:Keeper_turn_fsm.Phase_gating
         Keeper_turn_fsm.Done;
       Ok meta
+    | None ->
+      let terminal_reason_code = "registry_phase_missing" in
+      let error_message =
+        Printf.sprintf
+          "%s: keeper registry phase lookup returned None before dispatch"
+          meta.name
+      in
+      append_manifest ~site:"phase_gate_decided"
+        ~status:"error"
+        ~decision:
+          (`Assoc
+            [
+              ("phase", `Null);
+              ("reason", `String terminal_reason_code);
+              ("executable", `Bool false);
+            ])
+        Keeper_runtime_manifest.Phase_gate_decided;
+      Log.Keeper.error
+        ~keeper_name:meta.name
+        ~turn_id:keeper_turn_id
+        "%s"
+        error_message;
+      record_pre_dispatch_terminal_observation
+        ~config
+        ~meta
+        ~generation
+        ~cascade_name:
+          (Keeper_execution_receipt.cascade_name_of_string (cascade_name_of_meta meta))
+        ~outcome:`Error
+        ~terminal_reason_code
+        ~activity_kind:"keeper.turn_blocked"
+        ~trajectory_outcome:(Trajectory.Failed terminal_reason_code)
+        ~error_kind:(Keeper_execution_receipt.error_kind_of_string terminal_reason_code)
+        ~error_message
+        ~keeper_turn_id
+        ();
+      Keeper_turn_fsm.emit_transition
+        ~keeper_name:meta.name
+        ~turn_id:keeper_turn_id
+        ~prev:Keeper_turn_fsm.Phase_gating
+        (Keeper_turn_fsm.Failed
+           (Keeper_turn_fsm.Failure_runtime_error terminal_reason_code));
+      Error (Agent_sdk.Error.Internal error_message)
     | phase_opt ->
       (* State-aware cascade routing (TLA+ KeeperCoreTriad.SelectCascade).
          At this point [phase] is executable; blocked phases returned above. *)
@@ -477,7 +520,7 @@ let run_keeper_cycle
                 `String
                   (match phase_opt with
                    | Some phase -> Keeper_state_machine.phase_to_string phase
-                   | None -> "missing_default_failing") );
+                   | None -> "missing_registry_phase_unreachable") );
               ("reason", `String "executable_phase");
               ("executable", `Bool true);
             ])
@@ -502,11 +545,9 @@ let run_keeper_cycle
           match phase_opt with
           | Some p -> p
           | None ->
-            Log.Keeper.warn
-              ~keeper_name:meta.name
-              ~turn_id:keeper_turn_id
-              "%s: registry phase lookup returned None, defaulting to Failing"
-              meta.name;
+            (* The [None] branch above fails closed before cascade routing.
+               Keep this fallback only to preserve exhaustiveness if the
+               match shape changes. *)
             Keeper_state_machine.Failing
         in
         let routing =

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -29,6 +29,41 @@ type context = {
 
 (* Handlers *)
 
+let keeper_pause_status_json ctx =
+  let names = Keeper_types.keeper_names ctx.config in
+  let read_errors = ref [] in
+  let paused_by_meta = ref [] in
+  let paused_by_phase = ref [] in
+  List.iter
+    (fun name ->
+      (match Keeper_types.read_meta ctx.config name with
+       | Ok (Some meta) when meta.paused -> paused_by_meta := meta.name :: !paused_by_meta
+       | Ok _ -> ()
+       | Error err -> read_errors := (name, err) :: !read_errors);
+      match Keeper_registry.get_phase ~base_path:ctx.config.base_path name with
+      | Some Keeper_state_machine.Paused -> paused_by_phase := name :: !paused_by_phase
+      | _ -> ())
+    names;
+  let meta_paused_names = List.rev !paused_by_meta in
+  let phase_paused_names = List.rev !paused_by_phase in
+  let paused_names =
+    Keeper_types.dedupe_keep_order (meta_paused_names @ phase_paused_names)
+  in
+  `Assoc
+    [
+      ("paused", `Bool (paused_names <> []));
+      ("paused_count", `Int (List.length paused_names));
+      ("paused_names", `List (List.map (fun name -> `String name) paused_names));
+      ("meta_paused_count", `Int (List.length meta_paused_names));
+      ("phase_paused_count", `Int (List.length phase_paused_names));
+      ( "read_errors",
+        `List
+          (List.rev_map
+             (fun (name, error) ->
+               `Assoc [ ("name", `String name); ("error", `String error) ])
+             !read_errors) );
+    ]
+
 let handle_pause ~tool_name ~start_time ctx args =
   let reason = get_string args "reason" "Manual pause" in
   Coord.pause ctx.config ~by:ctx.agent_name ~reason;
@@ -43,6 +78,28 @@ let handle_resume ~tool_name ~start_time ctx _args =
         "Default project scope is not paused"
 
 let handle_pause_status ~tool_name ~start_time ctx _args =
+  let keeper_pause =
+    if not (Coord.is_initialized ctx.config)
+    then
+      `Assoc
+        [
+          ("paused", `Null);
+          ("paused_count", `Null);
+          ("paused_names", `List []);
+          ("meta_paused_count", `Null);
+          ("phase_paused_count", `Null);
+          ("read_errors", `List []);
+        ]
+    else keeper_pause_status_json ctx
+  in
+  let keeper_paused =
+    match keeper_pause with
+    | `Assoc fields -> (
+      match List.assoc_opt "paused" fields with
+      | Some (`Bool value) -> value
+      | _ -> false)
+    | _ -> false
+  in
   let pause_state =
     if not (Coord.is_initialized ctx.config) then `Initializing
     else
@@ -64,6 +121,9 @@ let handle_pause_status ~tool_name ~start_time ctx _args =
             ("paused_by", Json_util.string_opt_to_json by);
             ("pause_reason", Json_util.string_opt_to_json reason);
             ("paused_at", Json_util.string_opt_to_json at);
+            ("pause_scope", `String "coord_room");
+            ("any_pause_active", `Bool true);
+            ("keeper_pause", keeper_pause);
             ("message", `String "Server is paused");
           ]
     | `Running ->
@@ -76,7 +136,14 @@ let handle_pause_status ~tool_name ~start_time ctx _args =
             ("paused_by", `Null);
             ("pause_reason", `Null);
             ("paused_at", `Null);
-            ("message", `String "Server is running (not paused)");
+            ("pause_scope", `String "coord_room");
+            ("any_pause_active", `Bool keeper_paused);
+            ("keeper_pause", keeper_pause);
+            ( "message",
+              `String
+                (if keeper_paused
+                 then "Server is running, but one or more keepers are paused"
+                 else "Server is running (not paused)") );
           ]
     | `Initializing ->
         `Assoc
@@ -88,6 +155,9 @@ let handle_pause_status ~tool_name ~start_time ctx _args =
             ("paused_by", `Null);
             ("pause_reason", `Null);
             ("paused_at", `Null);
+            ("pause_scope", `String "coord_room");
+            ("any_pause_active", `Null);
+            ("keeper_pause", keeper_pause);
             ( "message",
               `String
                 "Server is initializing; pause state is not available yet" );

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -638,6 +638,67 @@ let test_pre_dispatch_terminal_observation_emits_manifest_rows () =
             first.M.decision |> member "terminal_reason_code" |> to_string)
       | [] -> Alcotest.fail "expected manifest rows")
 
+let test_pre_dispatch_terminal_observation_invalidates_keeper_status_cache () =
+  with_eio
+  @@ fun ~sw ~net:_ ~clock ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_status_detail.invalidate_status_cache_all ();
+      cleanup_dir base_dir)
+    (fun () ->
+      Masc_mcp.Keeper_status_detail.invalidate_status_cache_all ();
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "operator"));
+      let meta = make_meta ~name:"pre-dispatch-status-cache" () in
+      (match Masc_mcp.Keeper_types.write_meta config meta with
+       | Ok () -> ()
+       | Error err -> Alcotest.fail ("meta write failed: " ^ err));
+      let ctx : _ Masc_mcp.Keeper_types.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock;
+          proc_mgr = None;
+          net = None;
+        }
+      in
+      let args =
+        `Assoc
+          [
+            ("name", `String meta.name);
+            ("fast", `Bool true);
+            ("include_context", `Bool false);
+            ("include_metrics_overview", `Bool false);
+            ("include_memory_bank", `Bool false);
+            ("include_history_tail", `Bool false);
+          ]
+      in
+      let ok, _body = Masc_mcp.Keeper_status_detail.handle_keeper_status ctx args in
+      Alcotest.(check bool) "initial status ok" true ok;
+      Masc_mcp.Keeper_turn_helpers.record_pre_dispatch_terminal_observation
+        ~config
+        ~meta
+        ~generation:meta.runtime.generation
+        ~cascade_name:
+          (Masc_mcp.Keeper_execution_receipt.cascade_name_of_string "default")
+        ~outcome:`Skipped
+        ~terminal_reason_code:"phase_not_executable"
+        ~activity_kind:"keeper.turn_skipped"
+        ~trajectory_outcome:(Trajectory.Gated "phase_not_executable")
+        ~keeper_turn_id:(meta.runtime.usage.total_turns + 1)
+        ();
+      let ok, body = Masc_mcp.Keeper_status_detail.handle_keeper_status ctx args in
+      Alcotest.(check bool) "status after receipt ok" true ok;
+      let json = Yojson.Safe.from_string body in
+      Alcotest.(check string)
+        "status cache sees latest terminal reason"
+        "phase_not_executable"
+        Yojson.Safe.Util.(
+          json |> member "runtime_trust" |> member "latest_terminal_reason"
+          |> member "code" |> to_string))
+
 let test_runtime_trace_api_links_manifest_and_receipt_rows () =
   let base_dir = temp_dir () in
   Fun.protect
@@ -2346,6 +2407,10 @@ let () =
             test_append_to_path_preserves_order;
           Alcotest.test_case "pre-dispatch emits manifest rows" `Quick
             test_pre_dispatch_terminal_observation_emits_manifest_rows;
+          Alcotest.test_case
+            "pre-dispatch receipt invalidates keeper status cache"
+            `Quick
+            test_pre_dispatch_terminal_observation_invalidates_keeper_status_cache;
           Alcotest.test_case
             "runtime trace API links manifest and receipt rows"
             `Quick test_runtime_trace_api_links_manifest_and_receipt_rows;

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -502,6 +502,30 @@ let test_tool_search_partition_filters_policy_denied_core_hits () =
     (List.map fst partition.discoverable_hits);
   Alcotest.(check int) "one policy-filtered hit" 1 partition.filtered_by_policy
 
+let test_tool_surface_truncation_dedupes_essential_tools () =
+  let truncated =
+    Keeper_run_tools.truncate_tool_surface_names
+      ~max_tools:4
+      ~essential_names:[ "keeper_context_status"; "keeper_task_done" ]
+      [
+        "keeper_context_status";
+        "keeper_task_done";
+        "keeper_board_get";
+        "keeper_task_done";
+        "keeper_shell";
+        "keeper_fs_read";
+      ]
+  in
+  Alcotest.(check (list string))
+    "required essential is not double-counted in truncated surface"
+    [
+      "keeper_context_status";
+      "keeper_task_done";
+      "keeper_board_get";
+      "keeper_shell";
+    ]
+    truncated
+
 let test_keeper_config_defaults () =
   (* Default: LLM rerank disabled *)
   Alcotest.(check bool) "llm_rerank disabled by default"
@@ -509,7 +533,7 @@ let test_keeper_config_defaults () =
   (* Default cascade name *)
   let cascade = Keeper_config.keeper_llm_rerank_cascade () in
   Alcotest.(check string) "default cascade name"
-    "scoring" cascade
+    "llm_rerank" cascade
 
 (* ── Suite ───────────────────────────────────────────────── *)
 
@@ -558,6 +582,8 @@ let () =
         test_tool_search_partition_returns_allowed_core_hits;
       Alcotest.test_case "tool_search filters denied core hits" `Quick
         test_tool_search_partition_filters_policy_denied_core_hits;
+      Alcotest.test_case "tool surface truncation dedupes essential tools" `Quick
+        test_tool_surface_truncation_dedupes_essential_tools;
     ];
     "keeper_config", [
       Alcotest.test_case "config defaults" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5389,12 +5389,63 @@ let test_run_keeper_cycle_skips_non_executable_phase () =
            "gated"
            Yojson.Safe.Util.(
              trajectory_summary |> member "outcome" |> member "status" |> to_string);
+	         check
+	           string
+	           "skipped trajectory outcome reason"
+	           "non_executable_phase:paused"
+	           Yojson.Safe.Util.(
+	             trajectory_summary |> member "outcome" |> member "reason" |> to_string))
+;;
+
+let test_run_keeper_cycle_fails_closed_when_registry_phase_missing () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  let old_base_path = Sys.getenv_opt "MASC_BASE_PATH" in
+  Fun.protect
+    ~finally:(fun () ->
+      (match old_base_path with
+       | Some value -> Unix.putenv "MASC_BASE_PATH" value
+       | None -> Unix.putenv "MASC_BASE_PATH" "");
+      KR.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+       KR.clear ();
+       Unix.putenv "MASC_BASE_PATH" base_dir;
+       let meta = make_meta "missing-registry-phase-keeper" in
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       match
+         UT.run_keeper_cycle
+           ~config
+           ~meta
+           ~observation:base_observation
+           ~generation:meta.runtime.generation
+           ()
+       with
+       | Ok _ -> Alcotest.fail "expected missing registry phase to fail closed"
+       | Error err ->
          check
-           string
-           "skipped trajectory outcome reason"
-           "non_executable_phase:paused"
-           Yojson.Safe.Util.(
-             trajectory_summary |> member "outcome" |> member "reason" |> to_string))
+           bool
+           "error explains registry phase gap"
+           true
+           (KTH.string_contains_substring
+              ~needle:"registry phase lookup returned None"
+              (Agent_sdk.Error.to_string err));
+         (match Masc_mcp.Keeper_execution_receipt.latest_json config meta.name with
+          | None -> fail "expected registry phase gap execution receipt"
+          | Some receipt ->
+            check
+              string
+              "missing registry receipt terminal reason"
+              "registry_phase_missing"
+              Yojson.Safe.Util.(receipt |> member "terminal_reason_code" |> to_string);
+            check
+              string
+              "missing registry receipt outcome"
+              "receipt_failed"
+              Yojson.Safe.Util.(receipt |> member "outcome" |> to_string)))
 ;;
 
 let test_run_keeper_cycle_livelock_block_returns_error () =
@@ -12115,15 +12166,19 @@ let () =
             `Quick
             test_context_overflow_event_falls_back_without_event_bus_signal
         ] )
-    ; ( "phase_gate"
-      , [ test_case
-            "run_keeper_cycle skips paused keeper"
-            `Quick
-            test_run_keeper_cycle_skips_non_executable_phase
-        ; test_case
-            "run_keeper_cycle errors on livelock block"
-            `Quick
-            test_run_keeper_cycle_livelock_block_returns_error
+	    ; ( "phase_gate"
+	      , [ test_case
+	            "run_keeper_cycle skips paused keeper"
+	            `Quick
+	            test_run_keeper_cycle_skips_non_executable_phase
+	        ; test_case
+	            "run_keeper_cycle fails closed when registry phase is missing"
+	            `Quick
+	            test_run_keeper_cycle_fails_closed_when_registry_phase_missing
+	        ; test_case
+	            "run_keeper_cycle errors on livelock block"
+	            `Quick
+	            test_run_keeper_cycle_livelock_block_returns_error
         ; test_case
             "streaming cancel records supervisor stop"
             `Quick

--- a/test/test_tool_control_coverage.ml
+++ b/test/test_tool_control_coverage.ml
@@ -8,6 +8,25 @@ let parse_json s =
   try Yojson.Safe.from_string s
   with Yojson.Json_error err -> failwith ("invalid json: " ^ err)
 
+let seed_keeper_meta (ctx : Tool_control.context) name ~paused =
+  let meta =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+          [
+            ("name", `String name);
+            ("agent_name", `String (Keeper_types.keeper_agent_name name));
+            ("trace_id", `String ("trace-" ^ name));
+            ("goal", `String "pause status fixture");
+          ])
+    with
+    | Ok meta -> { meta with paused }
+    | Error err -> failwith ("meta fixture failed: " ^ err)
+  in
+  match Keeper_types.write_meta ctx.config meta with
+  | Ok () -> ()
+  | Error err -> failwith ("meta write failed: " ^ err)
+
 let with_env name value_opt f =
   let original = Sys.getenv_opt name in
   let restore () =
@@ -113,6 +132,27 @@ let () =
           let json = parse_json result.legacy_message in
           assert (Yojson.Safe.Util.member "paused" json = `Bool false);
           assert (Yojson.Safe.Util.member "status" json = `String "running")
+      | None -> failwith "dispatch returned None")
+
+let () =
+  test "dispatch_pause_status_surfaces_keeper_pause_when_room_running" (fun () ->
+      with_ctx @@ fun ctx ->
+      seed_keeper_meta ctx "paused-keeper" ~paused:true;
+      match Tool_control.dispatch ctx ~name:"masc_pause_status" ~args:(`Assoc []) with
+      | Some result ->
+          assert result.success;
+          let json = parse_json result.legacy_message in
+          let open Yojson.Safe.Util in
+          let keeper_pause = json |> member "keeper_pause" in
+          assert (json |> member "status" = `String "running");
+          assert (json |> member "paused" = `Bool false);
+          assert (json |> member "any_pause_active" = `Bool true);
+          assert (keeper_pause |> member "paused" = `Bool true);
+          assert (keeper_pause |> member "paused_count" = `Int 1);
+          assert
+            (keeper_pause |> member "paused_names" |> to_list
+             |> List.map to_string
+             = [ "paused-keeper" ])
       | None -> failwith "dispatch returned None")
 
 let () =


### PR DESCRIPTION
## Summary
- surface keeper pause state in masc_pause_status alongside Coord room pause
- invalidate keeper status cache after pre-dispatch receipt append
- fail closed when keeper registry phase is missing before dispatch
- dedupe essential tools during tool surface truncation and clarify non-executable cascade routing text

## Why
These paths previously allowed operator-facing status to diverge from runtime truth: keeper pause could be hidden by room-level pause_status, pre-dispatch terminal receipts could be masked by cached status, missing registry phase could silently route through Failing recovery, and required tools could be double-counted during truncation.

## Validation
- scripts/dune-local.sh build test/test_tool_control_coverage.exe test/test_keeper_runtime_manifest.exe test/test_keeper_unified.exe test/test_keeper_topk_llm.exe
- scripts/dune-local.sh exec test/test_tool_control_coverage.exe
- scripts/dune-local.sh exec test/test_keeper_topk_llm.exe
- scripts/dune-local.sh exec test/test_keeper_runtime_manifest.exe
- scripts/dune-local.sh exec test/test_keeper_unified.exe
- git diff --check