### PR TITLE
feat(rfc-0085): PR-4 tool_library + cdal proof_store /tmp fallback 폭발

### DIFF
--- a/lib/cdal_runtime/proof_store.ml
+++ b/lib/cdal_runtime/proof_store.ml
@@ -11,7 +11,7 @@ open Result_syntax
 let default_config =
   let home =
     try Sys.getenv "HOME" with
-    | Not_found -> "/tmp"
+    | Not_found -> Filename.get_temp_dir_name ()
   in
   { root = Filename.concat home ".oas" }
 ;;

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -87,7 +87,10 @@ type context = {
 
 (* Paths *)
 let library_root () =
-  let home = Sys.getenv_opt "HOME" |> Option.value ~default:"/tmp" in
+  let home =
+    Sys.getenv_opt "HOME"
+    |> Option.value ~default:(Host_config.host ()).agent_runtime_root
+  in
   Filename.concat home "me/docs/library"
 
 let candidates_dir () =

--- a/test/dune
+++ b/test/dune
@@ -1683,3 +1683,9 @@
  (name test_rfc_0085_pr6_host_config_from_env)
  (modules test_rfc_0085_pr6_host_config_from_env)
  (libraries alcotest masc_mcp.host_config unix))
+
+; RFC-0085 PR-4 — tool_library + cdal proof_store /tmp fallback purge.
+(test
+ (name test_rfc_0085_pr4_tool_library_proof_store)
+ (modules test_rfc_0085_pr4_tool_library_proof_store)
+ (libraries alcotest ast_grep))

--- a/test/test_rfc_0085_pr4_tool_library_proof_store.ml
+++ b/test/test_rfc_0085_pr4_tool_library_proof_store.ml
@@ -1,0 +1,45 @@
+open Alcotest
+
+(** RFC-0085 PR-4 — tool_library + cdal proof_store /tmp fallback 박멸.
+
+    Verifies:
+    - lib/tool_library.ml: ~default:"/tmp" 리터럴 fallback 제거
+      (Host_config.host()-based로 변경).
+    - lib/cdal_runtime/proof_store.ml: Not_found -> "/tmp" 리터럴 제거
+      (cdal_runtime sub-library는 masc_mcp 본 라이브러리와 격리되어
+       있어 Filename.get_temp_dir_name () 직접 사용 — cdal-local
+       fallback, RFC-OAS-011 격리 보존).
+
+    AST-based via Ast_grep. *)
+
+let test_no_tmp_default_in_tool_library () =
+  let path = "lib/tool_library.ml" in
+  (* "/tmp" 문자열 자체가 fallback에 등장하지 않아야 한다. *)
+  let n = Ast_grep.count_string_literals ~module_path:path ~needle:"/tmp" in
+  check int "/tmp literal removed from tool_library fallback" 0 n
+;;
+
+let test_tool_library_uses_host_config () =
+  let path = "lib/tool_library.ml" in
+  let n = Ast_grep.count_calls ~module_path:path ~callee:"Host_config.host" in
+  if n < 1
+  then failf "tool_library.ml must call Host_config.host >= 1, got %d" n
+;;
+
+let test_no_tmp_default_in_proof_store () =
+  let path = "lib/cdal_runtime/proof_store.ml" in
+  let n = Ast_grep.count_string_literals ~module_path:path ~needle:"/tmp" in
+  check int "/tmp literal removed from proof_store fallback" 0 n
+;;
+
+let () =
+  run
+    "rfc-0085-pr-4-tool-library-proof-store"
+    [ ( "tool_library"
+      , [ test_case "no /tmp literal" `Quick test_no_tmp_default_in_tool_library
+        ; test_case "uses Host_config.host" `Quick test_tool_library_uses_host_config
+        ] )
+    ; ( "proof_store"
+      , [ test_case "no /tmp literal" `Quick test_no_tmp_default_in_proof_store ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

RFC-0085 PR-4 (stacked on PR-1 #15458) — `tool_library.ml`와 `cdal_runtime/proof_store.ml`의 HOME-missing `/tmp` fallback 박멸.

- `tool_library.ml`: `Option.value ~default:\"/tmp\"` → `(Host_config.host ()).agent_runtime_root`
- `cdal_runtime/proof_store.ml`: `Not_found -> \"/tmp\"` → `Filename.get_temp_dir_name ()` *(cdal_runtime은 RFC-OAS-011 의도적 격리 — masc_mcp 본 라이브러리 dep 회피하여 cdal-local fallback 유지)*

### Verification

- `dune build --root . @lib/check`: green
- `dune exec test/test_rfc_0085_pr4_tool_library_proof_store.exe`: **3/3 OK**

🤖 Generated with [Claude Code](https://claude.com/claude-code)