### PR TITLE
feat(rfc-0085): PR-5 MCP dispatch path typed_post_hooks 통일 (핵심)

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -1079,6 +1079,13 @@ let execute_tool_eio
               let result, _outcome =
                 Tool_telemetry.with_span ~tool_name:name (fun _trace_id_thunk ->
                   let r = dispatch_internal_keeper_runtime_tool () in
+                  (* RFC-0085 PR-5 — route through the unified finaliser
+                     so the five typed observers (Tool_metrics,
+                     Tool_usage_log, Otel_dispatch_hook,
+                     Tool_output_validation, server_bootstrap_loops)
+                     fire on MCP internal-keeper-runtime calls just like
+                     keeper turn calls do. *)
+                  let r = Tool_dispatch_emit.finalize_from_handler r in
                   let outcome =
                     match r with
                     | Some _ -> "handled"
@@ -1112,6 +1119,10 @@ let execute_tool_eio
                    let result, _outcome =
                      Tool_telemetry.with_span ~tool_name:name (fun _trace_id_thunk ->
                        let r = dispatch_by_tag tag in
+                       (* RFC-0085 PR-5 — see [dispatch_internal_with_telemetry]
+                          comment above; the same finaliser closes the
+                          observer-silent gap for external MCP tools/call. *)
+                       let r = Tool_dispatch_emit.finalize_from_handler r in
                        let outcome =
                          match r with
                          | Some _ -> "handled"

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -188,15 +188,14 @@ let dispatch ~(token : Tool_token.t) ~args : Tool_result.t option =
       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         Some (Tool_result.of_exn ~tool_name:name ~start_time exn)
     in
-    (match result with
-     | Some tr ->
-       (* RFC-0084 PR-I-2.d — apply the registered result transformer
-          (e.g. Tool_output_validation cap) inside the dispatch loop.
-          PR-I-3 removed the legacy run_post_hooks call; typed
-          observers fire from guarded_dispatch via
-          [run_typed_post_hooks] for every outcome arm. *)
-       Some (apply_result_transformer tr)
-     | None -> None)
+    (* RFC-0085 PR-5 — result transformer + typed post-hooks were
+       fired *inside* this function in RFC-0084.  PR-5 moves both
+       side-effects to [Tool_dispatch_emit.finalize] so MCP
+       [dispatch_by_tag], [dispatch_internal_keeper_runtime_tool], and
+       inline coord (which bypass this private [dispatch]) share the
+       same observer fanout.  Callers of [dispatch] / [guarded_dispatch]
+       must run [Tool_dispatch_emit.finalize] on the return value. *)
+    result
   | None -> None
 
 (** Structured dispatch with hook support.
@@ -232,25 +231,32 @@ let guarded_dispatch ~(token : Tool_token.t) ~args () : Tool_result.t option =
   let result, _outcome =
     Tool_telemetry.with_span ~tool_name:token.name (fun _trace_id_thunk ->
       let r = dispatch_structured ~token ~args in
-      (* RFC-0084 PR-I-1 — fire typed post-hooks against the typed
-         {!Dispatch_outcome.t}, regardless of which arm ran.  Legacy
-         [post_hooks] continue to fire from inside [dispatch] for the
-         [Handled] arm only (unchanged).  When no typed hook is
-         registered (PR-I-1 ships zero in-tree registrations), this
-         call is a single [List.iter] over an empty ref — observable
-         cost ~0. *)
-      let typed_outcome : Dispatch_outcome.t =
+      (* RFC-0085 PR-5 — finalisation is done inline here (we cannot
+         depend on [Tool_dispatch_emit] without creating a dependency
+         cycle).  The logic is byte-identical to
+         [Tool_dispatch_emit.finalize], and any change must be mirrored
+         in both places.  Future RFC may extract a shared private
+         function once [Tool_dispatch_emit] is restructured.
+
+         Order: transformer first (mutates the Tool_result.t inside the
+         [Handled] arm), then typed observer fan-out. *)
+      let r' =
         match r with
+        | Some tr -> Some (apply_result_transformer tr)
+        | None -> r
+      in
+      let typed_outcome : Dispatch_outcome.t =
+        match r' with
         | Some _ -> Handled
         | None -> No_handler
       in
-      run_typed_post_hooks typed_outcome r;
+      run_typed_post_hooks typed_outcome r';
       let outcome =
-        match r with
+        match r' with
         | Some _ -> "handled"
         | None -> "no_handler"
       in
-      r, outcome)
+      r', outcome)
   in
   result
 ;;

--- a/lib/tool_dispatch_emit.ml
+++ b/lib/tool_dispatch_emit.ml
@@ -1,0 +1,36 @@
+(** RFC-0085 PR-5 — Unified dispatch post-processing helper.
+
+    Centralises the two side-effects that every dispatch path must run
+    after the handler completes:
+
+    1. Apply the registered [result_transformer] (e.g. Tool_output_validation
+       output cap) when the [Handled] arm fires.
+    2. Fire [run_typed_post_hooks] with the typed {!Dispatch_outcome.t}
+       so all five observers (Tool_metrics, Tool_usage_log,
+       Otel_dispatch_hook, Tool_output_validation, server_bootstrap_loops)
+       see every external MCP / keeper / inline call uniformly.
+
+    Before PR-5, only [Tool_dispatch.guarded_dispatch] fired typed
+    hooks, so external MCP [tools/call] traffic flowed silently
+    through [Tool_metrics] et al.  RFC-0085 §"Root Gap 1". *)
+
+let finalize ~(outcome : Dispatch_outcome.t) (r : Tool_result.t option)
+  : Tool_result.t option
+  =
+  let r' =
+    match r with
+    | Some tr -> Some (Tool_dispatch.apply_result_transformer tr)
+    | None -> r
+  in
+  Tool_dispatch.run_typed_post_hooks outcome r';
+  r'
+;;
+
+let finalize_from_handler (r : Tool_result.t option) : Tool_result.t option =
+  let outcome : Dispatch_outcome.t =
+    match r with
+    | Some _ -> Handled
+    | None -> No_handler
+  in
+  finalize ~outcome r
+;;

--- a/lib/tool_dispatch_emit.mli
+++ b/lib/tool_dispatch_emit.mli
@@ -1,0 +1,24 @@
+(** RFC-0085 PR-5 — Unified dispatch post-processing helper.
+
+    Every dispatch path (keeper [guarded_dispatch], MCP [dispatch_by_tag],
+    MCP [dispatch_internal_keeper_runtime_tool], inline coord) must call
+    one of these after the handler completes so the five typed observers
+    fire uniformly regardless of which path produced the result. *)
+
+(** [finalize ~outcome r] applies [Tool_dispatch.apply_result_transformer]
+    on the result (when [Some _]) and fires
+    [Tool_dispatch.run_typed_post_hooks outcome r'].
+
+    [outcome] should be the typed {!Dispatch_outcome.t} chosen by the
+    caller — [Handled] when the handler returned a result, [No_handler] /
+    [Rejected_by_pre_hook] / [Rejected_by_capability] / [Handler_error]
+    for the corresponding arms. *)
+val finalize
+  :  outcome:Dispatch_outcome.t
+  -> Tool_result.t option
+  -> Tool_result.t option
+
+(** [finalize_from_handler r] is the common case where the caller has
+    no structural information about the outcome — it picks
+    [Handled]/[No_handler] based on [Some]/[None]. *)
+val finalize_from_handler : Tool_result.t option -> Tool_result.t option

--- a/test/dune
+++ b/test/dune
@@ -1676,3 +1676,10 @@
  (name test_rfc_0085_pr2_auto_responder_log_dir)
  (modules test_rfc_0085_pr2_auto_responder_log_dir)
  (libraries alcotest ast_grep))
+
+; RFC-0085 PR-5 — Tool_dispatch_emit.finalize_from_handler is invoked
+; in every MCP path so the five typed observers fire uniformly.
+(test
+ (name test_rfc_0085_pr5_dispatch_emit)
+ (modules test_rfc_0085_pr5_dispatch_emit)
+ (libraries alcotest ast_grep masc_mcp unix))

--- a/test/test_rfc_0085_pr5_dispatch_emit.ml
+++ b/test/test_rfc_0085_pr5_dispatch_emit.ml
@@ -1,0 +1,116 @@
+open Alcotest
+
+(** RFC-0085 PR-5 — Verify the unified dispatch finaliser fires typed
+    observers and applies the result transformer.
+
+    The test uses {!Tool_dispatch_emit.finalize_from_handler} directly
+    rather than spinning up the MCP server, since the MCP path's
+    behaviour is *contractually* "call [Tool_dispatch_emit.finalize_*]
+    on every dispatch result".  This isolates the side-effect contract
+    from MCP wiring noise.
+
+    Verified contracts:
+    1. [finalize_from_handler (Some r)] fires the typed post-hook with
+       [Handled].
+    2. [finalize_from_handler None] fires the typed post-hook with
+       [No_handler].
+    3. [apply_result_transformer] is applied to [Some r] before
+       hooks observe it.
+    4. Source-level: [mcp_server_eio_execute.ml] and
+       [tool_dispatch.ml] together reference
+       [Tool_dispatch_emit.finalize_from_handler]
+       (or, in the guarded_dispatch case, an inline mirror) so all
+       three dispatch paths (keeper / MCP-tag / MCP-internal) emit
+       observer events. *)
+
+let mk_result ~tool_name ~text =
+  let start = Unix.gettimeofday () in
+  Masc_mcp.Tool_result.ok ~tool_name ~start_time:start text
+;;
+
+let test_finalize_handled_fires_typed_hook () =
+  let seen = ref [] in
+  let hook (outcome : Masc_mcp.Dispatch_outcome.t) (r : Masc_mcp.Tool_result.t option) =
+    seen := (outcome, Option.is_some r) :: !seen
+  in
+  Masc_mcp.Tool_dispatch.clear_hooks ();
+  Masc_mcp.Tool_dispatch.register_typed_post_hook hook;
+  let r = Some (mk_result ~tool_name:"t" ~text:"ok") in
+  let _ = Masc_mcp.Tool_dispatch_emit.finalize_from_handler r in
+  Masc_mcp.Tool_dispatch.clear_hooks ();
+  match !seen with
+  | [ (Handled, true) ] -> ()
+  | other ->
+    failf "expected [Handled, Some]; got %d observations" (List.length other)
+;;
+
+let test_finalize_no_handler_fires_typed_hook () =
+  let seen = ref [] in
+  let hook (outcome : Masc_mcp.Dispatch_outcome.t) (r : Masc_mcp.Tool_result.t option) =
+    seen := (outcome, Option.is_some r) :: !seen
+  in
+  Masc_mcp.Tool_dispatch.clear_hooks ();
+  Masc_mcp.Tool_dispatch.register_typed_post_hook hook;
+  let _ = Masc_mcp.Tool_dispatch_emit.finalize_from_handler None in
+  Masc_mcp.Tool_dispatch.clear_hooks ();
+  match !seen with
+  | [ (No_handler, false) ] -> ()
+  | _ -> failf "expected [No_handler, None] observation"
+;;
+
+let test_finalize_applies_transformer () =
+  let called = ref 0 in
+  let transformer (r : Masc_mcp.Tool_result.t) : Masc_mcp.Tool_result.t =
+    incr called;
+    { r with legacy_message = r.legacy_message ^ "[capped]" }
+  in
+  Masc_mcp.Tool_dispatch.clear_hooks ();
+  Masc_mcp.Tool_dispatch.set_result_transformer transformer;
+  let r = Some (mk_result ~tool_name:"t" ~text:"raw") in
+  let r' = Masc_mcp.Tool_dispatch_emit.finalize_from_handler r in
+  Masc_mcp.Tool_dispatch.clear_hooks ();
+  check int "transformer ran once" 1 !called;
+  (match r' with
+   | Some out ->
+     check bool "transformer suffix appended" true
+       (String.length out.legacy_message > 0
+        && let n = String.length out.legacy_message in
+           let suffix = "[capped]" in
+           let slen = String.length suffix in
+           n >= slen && String.sub out.legacy_message (n - slen) slen = suffix)
+   | None -> fail "expected Some result")
+;;
+
+let test_mcp_execute_invokes_finalize () =
+  (* Source-level structural check: mcp_server_eio_execute.ml must
+     reference Tool_dispatch_emit.finalize_from_handler at least
+     twice (dispatch_by_tag + dispatch_internal_keeper_runtime). *)
+  let path = "lib/mcp_server_eio_execute.ml" in
+  let n =
+    Ast_grep.count_calls
+      ~module_path:path
+      ~callee:"Tool_dispatch_emit.finalize_from_handler"
+  in
+  if n < 2
+  then
+    failf
+      "mcp_server_eio_execute.ml must call \
+       Tool_dispatch_emit.finalize_from_handler >= 2 (PR-5: \
+       dispatch_by_tag + dispatch_internal_keeper_runtime); got %d"
+      n
+;;
+
+let () =
+  run
+    "rfc-0085-pr-5-dispatch-emit"
+    [ ( "typed post-hook fan-out"
+      , [ test_case "Handled arm" `Quick test_finalize_handled_fires_typed_hook
+        ; test_case "No_handler arm" `Quick test_finalize_no_handler_fires_typed_hook
+        ] )
+    ; ( "result transformer"
+      , [ test_case "applied via finalize" `Quick test_finalize_applies_transformer ] )
+    ; ( "MCP path coverage"
+      , [ test_case "MCP execute invokes finalize" `Quick test_mcp_execute_invokes_finalize
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

RFC-0085 PR-5 (핵심) — Root Gap 1 close.

Plan: `~/me/planning/claude-plans/serene-prancing-iverson.md`

### 닫는 격차

외부 MCP \`tools/call\` 호출 시 5개 typed observer (Tool_metrics, Tool_usage_log, Otel_dispatch_hook, Tool_output_validation, server_bootstrap_loops)가 silent였던 비대칭. RFC-0084 PR-I-2.*가 등록한 5 observer가 keeper turn에서만 발화하던 부분을 외부 MCP 호출에서도 발화하도록 통일.

### 도입

- `lib/tool_dispatch_emit.{ml,mli}` 단일 finaliser helper
  - `finalize ~outcome:Dispatch_outcome.t -> Tool_result.t option -> Tool_result.t option`
  - `finalize_from_handler`: outcome 자동 추론
  - 내부에서 `apply_result_transformer` + `run_typed_post_hooks` 둘 다 호출

### Migration

- `mcp_server_eio_execute.ml`: \`dispatch_tag_with_telemetry\` + \`dispatch_internal_with_telemetry\` → helper 통과
- `tool_dispatch.ml`: private \`dispatch\`에서 transformer 호출 제거; \`guarded_dispatch\`는 순환 의존성 회피 위해 helper 로직 inline mirror

### Verification

- \`dune build --root . @lib/check\`: green
- \`dune exec test/test_rfc_0085_pr5_dispatch_emit.exe\`: **4/4 OK**
  - finalize_from_handler (Some r) → Handled, hook fires
  - finalize_from_handler None → No_handler, hook fires
  - Result transformer가 Handled arm result에 적용
  - AST: \`mcp_server_eio_execute.ml\` 내 \`finalize_from_handler\` caller ≥ 2
- \`ci/lint-no-direct-dispatch.sh\`: OK

### Workaround Rejection Bar

7항목 모두 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)