### PR TITLE
fix(keeper): gate bash structure and expose shell constraints

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -462,12 +462,73 @@ let handle_keeper_bash
       else (base_profile, base_network_mode, false)
     in
     let sandbox_root = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
-    (* Destructive guard: always active regardless of Docker or preset *)
-    if Worker_dev_tools.is_destructive_bash_operation cmd
-    then (
+    let command_blocked_json reason =
+      let reason_str = Worker_dev_tools.block_reason_to_string reason in
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_shell_bash_failures
-        ~labels:[("keeper", meta.name); ("site", "destructive")]
+        ~labels:[("site", "generic_blocked")]
+        ();
+      Log.Keeper.warn "keeper_bash blocked: %s (cmd=%s)" reason_str cmd_for_log;
+      let hint =
+        match reason with
+        | Worker_dev_tools.Command_not_allowed name
+          when String_util.equals_ci name "gh" ->
+          "`gh` is not allowed via keeper_bash. Use keeper_shell with \
+           op=\"gh\" (e.g. keeper_shell op=gh cmd=\"pr list --state open\")."
+        | Chain_or_redirect | Pipes_not_allowed | Unsafe_redirect ->
+          "Use separate tool calls instead of chaining. Call keeper_bash once per command."
+        | Injection | Process_substitution ->
+          "Avoid shell metacharacters. Use keeper_shell with a specific op (rg, find, ls) instead."
+        | Command_not_allowed _ ->
+          "Check the command for blocked patterns. Use keeper_shell for structured ops (rg, ls, find)."
+        | Empty_command ->
+          "Provide a non-empty command string."
+      in
+      let alternatives =
+        match reason with
+        | Worker_dev_tools.Command_not_allowed name
+          when String_util.equals_ci name "gh" ->
+          [ "Use keeper_shell with op=\"gh\" for GitHub CLI operations."
+          ; "Example: keeper_shell op=gh cmd=\"pr list --state open\"."
+          ]
+        | Chain_or_redirect | Pipes_not_allowed | Unsafe_redirect ->
+          [ "Break the pipeline into separate keeper_bash calls."
+          ; "Save intermediate output to a file, then process it in the next call."
+          ]
+        | Injection | Process_substitution ->
+          [ "Use keeper_shell with a specific op (rg, find, ls) for structured queries."
+          ; "Avoid $(...) and backtick substitution in commands."
+          ]
+        | Command_not_allowed _ ->
+          [ "Use keeper_shell for structured ops (rg, ls, find)."
+          ; "Check if the command is available under a different name or op."
+          ]
+        | Empty_command ->
+          [ "Provide a non-empty command string."
+          ; "Example: keeper_bash cmd='ls -la lib/'."
+          ]
+      in
+      Yojson.Safe.to_string
+        (Exec_core.blocked_result_json
+           ~cmd
+           ~error:"command_blocked"
+           ~reason:reason_str
+           ~hint
+           ~alternatives
+           ~diag:(Keeper_shell_shared.diagnosis_of_block_reason reason)
+           ~extra:[ "execution_time_ms", `Int 0 ]
+           ~env_snapshot:env_snap
+           ())
+    in
+    (* Destructive guard: always active regardless of Docker or preset *)
+    match Worker_dev_tools.validate_command_structure ~allow_pipes:write_enabled cmd with
+    | Error reason -> command_blocked_json reason
+    | Ok () ->
+      if Worker_dev_tools.is_destructive_bash_operation cmd
+      then (
+        Prometheus.inc_counter
+          Keeper_metrics.metric_keeper_shell_bash_failures
+          ~labels:[("keeper", meta.name); ("site", "destructive")]
         ();
       Log.Keeper.warn "keeper_bash DESTRUCTIVE blocked: %s (keeper=%s)" cmd_for_log meta.name;
       Yojson.Safe.to_string
@@ -677,66 +738,9 @@ let handle_keeper_bash
         else Worker_dev_tools.validate_command
       in
       match validate cmd with
-      | Error reason ->
-        let reason_str = Worker_dev_tools.block_reason_to_string reason in
-        Prometheus.inc_counter
-          Keeper_metrics.metric_keeper_shell_bash_failures
-          ~labels:[("site", "generic_blocked")]
-          ();
-        Log.Keeper.warn "keeper_bash blocked: %s (cmd=%s)" reason_str cmd_for_log;
-        let hint =
-          match reason with
-          | Worker_dev_tools.Command_not_allowed name
-            when String_util.equals_ci name "gh" ->
-            "`gh` is not allowed via keeper_bash. Use keeper_shell with \
-             op=\"gh\" (e.g. keeper_shell op=gh cmd=\"pr list --state open\")."
-          | Chain_or_redirect | Pipes_not_allowed | Unsafe_redirect ->
-            "Use separate tool calls instead of chaining. Call keeper_bash once per command."
-          | Injection | Process_substitution ->
-            "Avoid shell metacharacters. Use keeper_shell with a specific op (rg, find, ls) instead."
-          | Command_not_allowed _ ->
-            "Check the command for blocked patterns. Use keeper_shell for structured ops (rg, ls, find)."
-          | Empty_command ->
-            "Provide a non-empty command string."
-        in
-        let alternatives =
-          match reason with
-          | Worker_dev_tools.Command_not_allowed name
-            when String_util.equals_ci name "gh" ->
-            [ "Use keeper_shell with op=\"gh\" for GitHub CLI operations."
-            ; "Example: keeper_shell op=gh cmd=\"pr list --state open\"."
-            ]
-          | Chain_or_redirect | Pipes_not_allowed | Unsafe_redirect ->
-            [ "Break the pipeline into separate keeper_bash calls."
-            ; "Save intermediate output to a file, then process it in the next call."
-            ]
-          | Injection | Process_substitution ->
-            [ "Use keeper_shell with a specific op (rg, find, ls) for structured queries."
-            ; "Avoid $(...) and backtick substitution in commands."
-            ]
-          | Command_not_allowed _ ->
-            [ "Use keeper_shell for structured ops (rg, ls, find)."
-            ; "Check if the command is available under a different name or op."
-            ]
-          | Empty_command ->
-            [ "Provide a non-empty command string."
-            ; "Example: keeper_bash cmd='ls -la lib/'."
-            ]
-        in
-        Yojson.Safe.to_string
-          (Exec_core.blocked_result_json
-             ~cmd
-             ~error:"command_blocked"
-             ~reason:reason_str
-             ~hint
-             ~alternatives
-             ~diag:(Keeper_shell_shared.diagnosis_of_block_reason reason)
-             ~extra:[ "execution_time_ms", `Int 0 ]
-             ~env_snapshot:env_snap
-             ())
+      | Error reason -> command_blocked_json reason
       | Ok () ->
-        (
-            (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd with
+        (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd with
              | Error e -> error_json e
              | Ok () ->
                if write_enabled
@@ -1033,7 +1037,7 @@ let handle_keeper_bash
                       (match Masc_exec.Exec_cache.lookup cache cmd with
                        | Some entry -> cached_result_json entry
                        | None -> run_uncached ())
-                    | None -> run_uncached ())
-               end))
+                   | None -> run_uncached ())
+               end)
   end)
 ;;

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -228,7 +228,17 @@ let params_of_json_schema schema =
     Create OAS [Tool.t] from MASC schema definition + dispatch handler.
     This allows incremental migration: each tool can be converted independently. *)
 
+let oas_descriptor_lookup_name = function
+  | "Bash" -> "keeper_bash"
+  | "Edit" | "Write" -> "keeper_fs_edit"
+  | "Grep" -> "keeper_shell"
+  | "Read" -> "keeper_fs_read"
+  | "WebFetch" -> "masc_web_fetch"
+  | "WebSearch" -> "masc_web_search"
+  | name -> name
+
 let oas_permission_of_masc_tool name =
+  let name = oas_descriptor_lookup_name name in
   let meta = Tool_catalog.metadata name in
   match meta.destructive, meta.readonly with
   | Some true, _ -> Some Agent_sdk.Tool.Destructive
@@ -236,6 +246,19 @@ let oas_permission_of_masc_tool name =
   | _, Some false -> Some Agent_sdk.Tool.Write
   | _ when Tool_dispatch.is_destructive name -> Some Agent_sdk.Tool.Destructive
   | _ when Tool_dispatch.is_read_only name -> Some Agent_sdk.Tool.ReadOnly
+  | _ -> None
+
+let oas_shell_constraints_of_masc_tool name =
+  match String.lowercase_ascii (oas_descriptor_lookup_name name) with
+  | "bash" | "keeper_bash" | "masc_code_shell" ->
+    Some
+      { Agent_sdk.Tool.single_command_only = false
+      ; shell_metacharacters_allowed = false
+      ; chaining_allowed = false
+      ; redirection_allowed = true
+      ; pipes_allowed = true
+      ; workdir_policy = Some Agent_sdk.Tool.Recommended
+      }
   | _ -> None
 
 let oas_descriptor_of_masc_tool name =
@@ -254,7 +277,7 @@ let oas_descriptor_of_masc_tool name =
       mutation_class;
       concurrency_class;
       permission = Some permission;
-      shell = None;
+      shell = oas_shell_constraints_of_masc_tool name;
       notes = [];
       examples = [];
     }

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -398,6 +398,88 @@ type block_reason =
   | Pipes_not_allowed
   | Command_not_allowed of string
 
+let parse_error_fallback_reason cmd =
+  if contains_substring cmd "&&"
+     || contains_substring cmd "||"
+     || String.contains cmd ';'
+     || String.contains cmd '\n'
+     || String.contains cmd '\r'
+  then Chain_or_redirect
+  else if has_process_substitution cmd
+  then Process_substitution
+  else if has_unsafe_redirection cmd
+  then Unsafe_redirect
+  else if String.contains cmd '`'
+          || String.contains cmd '$'
+          || has_dangerous_ampersand cmd
+  then Injection
+  else Command_not_allowed "unsupported_shell_syntax"
+;;
+
+let has_unbalanced_shell_quotes cmd =
+  let len = String.length cmd in
+  let rec loop i quote escaped =
+    if i >= len
+    then quote <> None
+    else if escaped
+    then loop (i + 1) quote false
+    else (
+      match quote, cmd.[i] with
+      | Some '"', '\\' -> loop (i + 1) quote true
+      | None, '\'' -> loop (i + 1) (Some '\'') false
+      | None, '"' -> loop (i + 1) (Some '"') false
+      | Some '\'', '\'' -> loop (i + 1) None false
+      | Some '"', '"' -> loop (i + 1) None false
+      | _ -> loop (i + 1) quote false)
+  in
+  loop 0 None false
+;;
+
+let block_reason_of_too_complex = function
+  | `Proc_subst -> Process_substitution
+  | `Redirect | `Heredoc | `Here_string -> Unsafe_redirect
+  | `Logic_op -> Chain_or_redirect
+  | `Cmd_subst
+  | `Arith_expansion
+  | `Subshell
+  | `Control_flow
+  | `Function_def
+  | `Background
+  | `Glob_brace
+  | `Unknown_construct _ -> Injection
+;;
+
+let command_for_bash_structure_parse cmd =
+  cmd
+  |> split_shell_tokens
+  |> List.filter (fun token -> not (is_safe_fd_redirect_token token))
+  |> String.concat " "
+;;
+
+let validate_command_structure ?(allow_pipes = true) cmd =
+  let trimmed = String.trim cmd in
+  if trimmed = ""
+  then Error Empty_command
+  else (
+    match
+      trimmed
+      |> command_for_bash_structure_parse
+      |> Masc_exec_bash_parser.Bash.parse_string
+    with
+    | Masc_exec.Parsed.Parsed (Masc_exec.Shell_ir.Pipeline (_ :: _ :: _))
+      when not allow_pipes -> Error Pipes_not_allowed
+    | Masc_exec.Parsed.Parsed _ -> Ok ()
+    | Masc_exec.Parsed.Too_complex reason ->
+      Error (block_reason_of_too_complex reason)
+    | Masc_exec.Parsed.Parse_aborted _ ->
+      Error (Command_not_allowed "bash_parse_aborted")
+    | Masc_exec.Parsed.Parse_error _ ->
+      (match parse_error_fallback_reason trimmed with
+       | Command_not_allowed "unsupported_shell_syntax"
+         when not (has_unbalanced_shell_quotes trimmed) -> Ok ()
+       | reason -> Error reason))
+;;
+
 let block_reason_to_string = function
   | Empty_command -> "command must not be empty"
   | Chain_or_redirect ->
@@ -423,13 +505,17 @@ let validate_command_with_allowlist ~allowed_commands cmd =
   let trimmed = String.trim cmd in
   if trimmed = ""
   then Error Empty_command
-  else if contains_forbidden_shell_chars trimmed
-  then Error Chain_or_redirect
   else (
-    match extract_command_name trimmed with
-    | None -> Error Empty_command
-    | Some name when List.mem name allowed_commands -> Ok ()
-    | Some name -> Error (Command_not_allowed name))
+    match validate_command_structure ~allow_pipes:false trimmed with
+    | Error _ as err -> err
+    | Ok () ->
+      if contains_forbidden_shell_chars trimmed
+      then Error Chain_or_redirect
+      else (
+        match extract_command_name trimmed with
+        | None -> Error Empty_command
+        | Some name when List.mem name allowed_commands -> Ok ()
+        | Some name -> Error (Command_not_allowed name)))
 ;;
 
 let validate_command cmd =
@@ -444,28 +530,32 @@ let validate_command_coding_with_allowlist
   let trimmed = String.trim cmd in
   if trimmed = ""
   then Error Empty_command
-  else if contains_forbidden_shell_chars_coding trimmed
-  then Error Injection
-  else if has_process_substitution trimmed
-  then Error Process_substitution
-  else if has_unsafe_redirection trimmed
-  then Error Unsafe_redirect
   else (
-    match split_pipeline_segments trimmed with
-    | Error msg -> Error (Command_not_allowed msg)
-    | Ok segments ->
-      if (not allow_pipes) && List.length segments > 1
-      then Error Pipes_not_allowed
+    match validate_command_structure ~allow_pipes trimmed with
+    | Error _ as err -> err
+    | Ok () ->
+      if contains_forbidden_shell_chars_coding trimmed
+      then Error Injection
+      else if has_process_substitution trimmed
+      then Error Process_substitution
+      else if has_unsafe_redirection trimmed
+      then Error Unsafe_redirect
       else (
-        let rec validate_segments = function
-          | [] -> Ok ()
-          | segment :: rest ->
-            (match extract_command_name segment with
-             | None -> Error Empty_command
-             | Some name when List.mem name allowed_commands -> validate_segments rest
-             | Some name -> Error (Command_not_allowed name))
-        in
-        validate_segments segments))
+        match split_pipeline_segments trimmed with
+        | Error msg -> Error (Command_not_allowed msg)
+        | Ok segments ->
+          if (not allow_pipes) && List.length segments > 1
+          then Error Pipes_not_allowed
+          else (
+            let rec validate_segments = function
+              | [] -> Ok ()
+              | segment :: rest ->
+                (match extract_command_name segment with
+                 | None -> Error Empty_command
+                 | Some name when List.mem name allowed_commands -> validate_segments rest
+                 | Some name -> Error (Command_not_allowed name))
+            in
+            validate_segments segments)))
 ;;
 
 (** Relaxed command validation for Coding/Full preset keepers.

--- a/lib/worker_dev_tools.mli
+++ b/lib/worker_dev_tools.mli
@@ -42,6 +42,18 @@ type block_reason =
     {!Chain_or_redirect}, {!Injection}, etc.). *)
 val block_reason_to_string : block_reason -> string
 
+(** Menhir/Shell_ir-backed structural validator for Bash input.  It rejects
+    parser-classified shell constructs such as command substitution, unsafe
+    redirects, control operators, and disallowed pipelines before any
+    executor-specific routing can reach raw [bash -lc].  Parser gaps that do
+    not carry a known risky construct stay legacy-compatible.  It does not
+    enforce the command allowlist; callers that need command policy should
+    compose this with {!validate_command} / {!validate_command_coding}. *)
+val validate_command_structure
+  :  ?allow_pipes:bool
+  -> string
+  -> (unit, block_reason) result
+
 (** Strict (allowlist + no shell metacharacters) validator used by the
     default [shell_exec] tool.  Rejects empty input, chaining, and any
     command outside the dev allowlist (rg / grep / dune / git / ...). *)

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -366,6 +366,38 @@ let test_docker_blocks_docker_socket_reference () =
   | None ->
       Alcotest.fail ("expected error json, got: " ^ raw)
 
+let test_docker_bash_structural_gate_blocks_command_substitution () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_docker_meta "typed-structure-subst" in
+  let playground =
+    Filename.concat base_path (playground_path_of meta.name)
+  in
+  ensure_dir playground;
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None
+      ~config ~meta
+      ~args:
+        (`Assoc
+           [ ("cmd", `String "echo $(date)") ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check (option string))
+    "error"
+    (Some "command_blocked")
+    (Json.member "error" json |> Json.to_string_option);
+  Alcotest.(check bool)
+    "reason names shell injection"
+    true
+    (String_util.contains_substring
+       (Json.member "reason" json |> Json.to_string)
+       "Shell injection syntax")
+
 let test_nested_runtime_detector_ignores_git_commit_message () =
   Alcotest.(check bool)
     "quoted docker in git commit message is not a nested runtime"
@@ -710,9 +742,7 @@ let test_keeper_shell_ls_recovers_doubled_playground_prefix () =
   let repos = Filename.concat playground "repos" in
   ensure_dir repos;
   ignore (Fs_compat.save_file_atomic (Filename.concat repos "demo.txt") "ok");
-  let doubled_path =
-    Filename.concat playground ((playground_path_of meta.name) ^ "repos")
-  in
+  let doubled_path = Filename.concat (playground_path_of meta.name) "repos" in
   let raw =
     Keeper_exec_shell.handle_keeper_shell
       ~turn_sandbox_factory:None ~exec_cache:None
@@ -992,6 +1022,8 @@ let () =
         test_docker_blocks_nested_docker_command;
       Alcotest.test_case "docker blocks docker socket reference" `Quick
         test_docker_blocks_docker_socket_reference;
+      Alcotest.test_case "docker keeper_bash uses typed structure gate" `Quick
+        test_docker_bash_structural_gate_blocks_command_substitution;
       Alcotest.test_case "nested runtime detector ignores commit messages" `Quick
         test_nested_runtime_detector_ignores_git_commit_message;
       Alcotest.test_case "command substitution trips docker guard" `Quick

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -155,6 +155,41 @@ let find_tool name tools =
   List.find (fun (tool : Tool.t) -> String.equal tool.schema.name name) tools
 ;;
 
+let test_bash_alias_carries_shell_descriptor () =
+  let meta = make_test_meta () in
+  let ctx_snapshot = make_test_ctx () in
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_tools_shell_descriptor_%d" (Random.int 100000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      try
+        Sys.readdir dir |> Array.iter (fun f -> Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir
+      with
+      | _ -> ())
+    (fun () ->
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+       let bash = find_tool "Bash" tools in
+       match Tool.descriptor bash with
+       | Some { Tool.shell = Some shell; permission = Some Tool.Destructive; _ } ->
+         check bool "metacharacters disabled" false shell.shell_metacharacters_allowed;
+         check bool "chaining disabled" false shell.chaining_allowed;
+         check bool "pipes allowed" true shell.pipes_allowed;
+         check bool "redirection allowed" true shell.redirection_allowed
+       | Some { Tool.shell = None; _ } -> fail "Bash descriptor must carry shell constraints"
+       | Some _ -> fail "Bash descriptor must preserve destructive permission"
+       | None -> fail "Bash must carry an OAS descriptor")
+;;
+
 let find_read_tool tools = find_tool "Read" tools
 
 let read_repo_dir meta =
@@ -1198,6 +1233,10 @@ let () =
       , [ test_case "returns nonempty" `Quick test_make_tools_returns_nonempty
         ; test_case "valid schemas" `Quick test_tools_have_valid_schemas
         ; test_case "count matches allowed" `Quick test_tool_count_matches_allowed
+        ; test_case
+            "Bash alias carries shell descriptor"
+            `Quick
+            test_bash_alias_carries_shell_descriptor
         ; test_case
             "error json becomes tool error"
             `Quick

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -532,6 +532,69 @@ let () =
         match Worker_dev_tools.validate_command_coding "dune test 2>&1" with
         | Ok () -> ()
         | Error e -> Alcotest.fail ("should allow 2>&1: " ^ Worker_dev_tools.block_reason_to_string e));
+      Alcotest.test_case "typed structure allows pipeline when enabled" `Quick
+        (fun () ->
+          match
+            Worker_dev_tools.validate_command_structure
+              ~allow_pipes:true
+              "git log | head -5"
+          with
+          | Ok () -> ()
+          | Error e ->
+            Alcotest.fail
+              ("typed structure should allow pipeline: "
+               ^ Worker_dev_tools.block_reason_to_string e));
+      Alcotest.test_case "typed structure rejects pipeline when disabled" `Quick
+        (fun () ->
+          match
+            Worker_dev_tools.validate_command_structure
+              ~allow_pipes:false
+              "git log | head -5"
+          with
+          | Error Worker_dev_tools.Pipes_not_allowed -> ()
+          | Error e ->
+            Alcotest.fail
+              ("wrong typed structure rejection: "
+               ^ Worker_dev_tools.block_reason_to_string e)
+          | Ok () -> Alcotest.fail "typed structure should reject pipeline");
+      Alcotest.test_case "typed structure keeps fd redirect exception" `Quick
+        (fun () ->
+          match
+            Worker_dev_tools.validate_command_structure
+              ~allow_pipes:false
+              "dune build 2>&1"
+          with
+          | Ok () -> ()
+          | Error e ->
+            Alcotest.fail
+              ("fd redirect should remain structural-safe: "
+               ^ Worker_dev_tools.block_reason_to_string e));
+      Alcotest.test_case "typed structure rejects command substitution" `Quick
+        (fun () ->
+          match
+            Worker_dev_tools.validate_command_structure
+              ~allow_pipes:true
+              "echo $(date)"
+          with
+          | Error Worker_dev_tools.Injection -> ()
+          | Error e ->
+            Alcotest.fail
+              ("wrong command-substitution rejection: "
+               ^ Worker_dev_tools.block_reason_to_string e)
+          | Ok () -> Alcotest.fail "command substitution must be rejected");
+      Alcotest.test_case "typed structure rejects unterminated quote" `Quick
+        (fun () ->
+          match
+            Worker_dev_tools.validate_command_structure
+              ~allow_pipes:true
+              "echo 'unterminated"
+          with
+          | Error (Worker_dev_tools.Command_not_allowed "unsupported_shell_syntax") -> ()
+          | Error e ->
+            Alcotest.fail
+              ("wrong unterminated-quote rejection: "
+               ^ Worker_dev_tools.block_reason_to_string e)
+          | Ok () -> Alcotest.fail "unterminated quote must be rejected");
       Alcotest.test_case "single-command contract rejects pipe" `Quick (fun () ->
         match
           Worker_dev_tools.validate_command_coding_with_allowlist


### PR DESCRIPTION
## Summary

- route keeper bash structural validation through the existing Shell IR parser before raw bash execution
- reject parser-classified risky constructs such as command substitution, unsafe redirects, control operators, and disallowed pipelines
- preserve safe fd redirect behavior like `2>&1`
- carry Bash/keeper_bash shell constraints through the MASC -> OAS tool bridge so downstream OAS enforcement sees the descriptor

## Why

MASC already had a typed Shell IR/parser, but keeper bash policy still depended on narrower string-shape checks in key paths. The OAS wrapper also dropped shell constraint metadata, which meant the stronger downstream tool middleware could not reason from the descriptor for Bash aliases.

## Validation

- `git diff --check origin/main...HEAD`
- `ocamlformat --check lib/tool_bridge.ml lib/keeper/keeper_shell_bash.ml lib/worker_dev_tools.ml lib/worker_dev_tools.mli test/test_keeper_bash_safety.ml test/test_worker_dev_tools.ml test/test_keeper_tools_oas.ml`
- `scripts/dune-local.sh build test/test_worker_dev_tools.exe test/test_keeper_bash_safety.exe test/test_keeper_tools_oas.exe`
- `./_build/default/test/test_worker_dev_tools.exe`
- `./_build/default/test/test_keeper_bash_safety.exe`
- `./_build/default/test/test_keeper_tools_oas.exe`
