### PR TITLE
feat(rfc-0085): PR-8 config_dir_resolver + tool_code_write → Host_config.from_env (Phase 2)

### DIFF
--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -461,13 +461,12 @@ let storage_type () =
 let config_dir_env_key = "MASC_CONFIG_DIR"
 let personas_dir_env_key = "MASC_PERSONAS_DIR"
 
-(** Config directory override. *)
-let config_dir_opt () =
-  raw_value_opt config_dir_env_key |> trim_opt
-
-(** Personas directory override. *)
-let personas_dir_opt () =
-  raw_value_opt personas_dir_env_key |> trim_opt
+(* RFC-0085 PR-8 — [config_dir_opt] and [personas_dir_opt] removed.
+   All readers now obtain these path values from
+   [Host_config.from_env ()] (fields [config_dir] / [personas_dir]).
+   The two [_env_key] string constants above remain because docker
+   inheritance lists and snapshot catalogs still need them as
+   identifier strings, not as readers. *)
 
 (** SSOT for the MASC_DATA_DIR env-var name (issue 8352).
     Overrides [<base_path>/data] as the root for CDAL verdicts and other

--- a/lib/config/env_config_core.mli
+++ b/lib/config/env_config_core.mli
@@ -160,8 +160,11 @@ val storage_type : unit -> string
 
 val config_dir_env_key : string
 val personas_dir_env_key : string
-val config_dir_opt : unit -> string option
-val personas_dir_opt : unit -> string option
+
+(* RFC-0085 PR-8 — [config_dir_opt] and [personas_dir_opt] removed
+   from the public surface; callers now read these path values from
+   [Host_config.from_env ()] (fields [config_dir] / [personas_dir]). *)
+
 val data_dir_env_key : string
 val data_dir_opt : unit -> string option
 

--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -74,9 +74,11 @@ let allow_inherited_test_base_path () =
   Env_config_core.get_bool ~default:false
     test_base_path_override_env
 
-let initial_env_base_path = Env_config_core.base_path_raw_opt ()
-let initial_env_config_dir = Env_config_core.config_dir_opt ()
-let initial_env_personas_dir = Env_config_core.personas_dir_opt ()
+(* RFC-0085 PR-8 — Route path-derived env reads through Host_config.from_env
+   so the SSOT lives in lib/host_config/ instead of Env_config_core. *)
+let initial_env_base_path = (Host_config.from_env ()).base_path
+let initial_env_config_dir = (Host_config.from_env ()).config_dir
+let initial_env_personas_dir = (Host_config.from_env ()).personas_dir
 let initial_env_home = Sys.getenv_opt "HOME" |> trim_opt
 
 let sanitize_inherited_test_env_opt ~running_under_test_executable ~allow_inherited
@@ -118,7 +120,7 @@ let current_env_config_dir_opt () =
       (running_under_test_executable ())
     ~allow_inherited:(allow_inherited_test_config_paths ())
     ~initial:initial_env_config_dir
-    ~current:(Env_config_core.config_dir_opt ())
+    ~current:((Host_config.from_env ()).config_dir)
 
 let current_env_base_path_opt () =
   sanitize_inherited_test_base_path_opt
@@ -126,7 +128,7 @@ let current_env_base_path_opt () =
       (running_under_test_executable ())
     ~allow_inherited:(allow_inherited_test_base_path ())
     ~initial:initial_env_base_path
-    ~current:(Env_config_core.base_path_raw_opt ())
+    ~current:((Host_config.from_env ()).base_path)
     ~home:initial_env_home
 
 let current_env_personas_dir_opt () =
@@ -135,7 +137,7 @@ let current_env_personas_dir_opt () =
       (running_under_test_executable ())
     ~allow_inherited:(allow_inherited_test_config_paths ())
     ~initial:initial_env_personas_dir
-    ~current:(Env_config_core.personas_dir_opt ())
+    ~current:((Host_config.from_env ()).personas_dir)
 
 let current_env_home_opt () =
   sanitize_inherited_test_env_opt

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -235,7 +235,8 @@ let observe_policy_config_load_error ~base_path ~env_config_dir msg =
     base_path config_dir msg
 
 let get_policy_config_result ~base_path =
-  let env_config_dir = Env_config.config_dir_opt () in
+  (* RFC-0085 PR-8 — route env-derived config_dir read through Host_config. *)
+  let env_config_dir = (Host_config.from_env ()).config_dir in
   match !_policy_config_cache with
   | Some { base_path = cached_base_path; env_config_dir = cached_env; result }
     when String.equal cached_base_path base_path && Option.equal String.equal cached_env env_config_dir ->

--- a/test/dune
+++ b/test/dune
@@ -1696,3 +1696,11 @@
  (name test_rfc_0085_pr4_tool_library_proof_store)
  (modules test_rfc_0085_pr4_tool_library_proof_store)
  (libraries alcotest ast_grep))
+
+; RFC-0085 PR-8 — config_dir_resolver + tool_code_write env-derived
+; path reads routed through Host_config.from_env; Env_config_core
+; config_dir_opt + personas_dir_opt removed.
+(test
+ (name test_rfc_0085_pr8_config_dir_resolver_host_config)
+ (modules test_rfc_0085_pr8_config_dir_resolver_host_config)
+ (libraries alcotest ast_grep))

--- a/test/test_rfc_0085_pr8_config_dir_resolver_host_config.ml
+++ b/test/test_rfc_0085_pr8_config_dir_resolver_host_config.ml
@@ -1,0 +1,114 @@
+open Alcotest
+
+(** RFC-0085 PR-8 — config_dir_resolver + tool_code_write env-derived path
+    reads migrated from Env_config_core to Host_config.from_env.
+
+    Verifies:
+    1. Env_config_core.config_dir_opt has 0 callers (function removed).
+    2. Env_config_core.personas_dir_opt has 0 callers (function removed).
+    3. config_dir_resolver.ml invokes Host_config.from_env at least 4 times
+       (initial bindings + 3 sanitiser current readers).
+    4. tool_code_write.ml invokes Host_config.from_env at least once. *)
+
+let walk_dirs dirs =
+  let rec collect acc = function
+    | [] -> acc
+    | dir :: rest ->
+      let entries = try Sys.readdir dir with Sys_error _ -> [||] in
+      let next, files =
+        Array.fold_left
+          (fun (sub, files) name ->
+            let p = Filename.concat dir name in
+            if try Sys.is_directory p with Sys_error _ -> false
+            then p :: sub, files
+            else if Filename.check_suffix p ".ml"
+            then sub, p :: files
+            else sub, files)
+          ([], [])
+          entries
+      in
+      collect (List.rev_append files acc) (List.rev_append next rest)
+  in
+  collect [] dirs
+;;
+
+let test_config_dir_opt_callers_zero () =
+  let files = walk_dirs [ "lib"; "bin" ] in
+  let total =
+    List.fold_left
+      (fun acc f ->
+        acc
+        + Ast_grep.count_calls
+            ~module_path:f
+            ~callee:"Env_config_core.config_dir_opt")
+      0
+      files
+  in
+  check int "Env_config_core.config_dir_opt callers = 0" 0 total
+;;
+
+let test_personas_dir_opt_callers_zero () =
+  let files = walk_dirs [ "lib"; "bin" ] in
+  let total =
+    List.fold_left
+      (fun acc f ->
+        acc
+        + Ast_grep.count_calls
+            ~module_path:f
+            ~callee:"Env_config_core.personas_dir_opt")
+      0
+      files
+  in
+  check int "Env_config_core.personas_dir_opt callers = 0" 0 total
+;;
+
+let test_config_dir_resolver_uses_host_config_from_env () =
+  let n =
+    Ast_grep.count_calls
+      ~module_path:"lib/config_dir_resolver.ml"
+      ~callee:"Host_config.from_env"
+  in
+  if n < 4
+  then
+    failf
+      "config_dir_resolver.ml must call Host_config.from_env >= 4 (3 \
+       sanitiser current readers + 3 initial bindings); got %d"
+      n
+;;
+
+let test_tool_code_write_uses_host_config_from_env () =
+  let n =
+    Ast_grep.count_calls
+      ~module_path:"lib/tool_code_write.ml"
+      ~callee:"Host_config.from_env"
+  in
+  if n < 1
+  then
+    failf "tool_code_write.ml must call Host_config.from_env >= 1; got %d" n
+;;
+
+let () =
+  run
+    "rfc-0085-pr-8-config-dir-resolver-host-config"
+    [ ( "Env_config_core purge"
+      , [ test_case
+            "config_dir_opt callers = 0"
+            `Quick
+            test_config_dir_opt_callers_zero
+        ; test_case
+            "personas_dir_opt callers = 0"
+            `Quick
+            test_personas_dir_opt_callers_zero
+        ] )
+    ; ( "Host_config.from_env adoption"
+      , [ test_case
+            "config_dir_resolver migrated"
+            `Quick
+            test_config_dir_resolver_uses_host_config_from_env
+        ; test_case
+            "tool_code_write migrated"
+            `Quick
+            test_tool_code_write_uses_host_config_from_env
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

RFC-0085 PR-8 (Phase 2 부분) — env-derived path 결정 SSOT를 \`Env_config_core\`에서 \`Host_config.from_env\`로 격리.

### Migration

\`config_dir_resolver.ml\` 6 sites + \`tool_code_write.ml\` 1 site → \`Host_config.from_env\` 호출로 변경.

### Legacy 폭발

caller가 0건이 된 직후 \`Env_config_core\`의 함수 자체 삭제:
- \`val config_dir_opt\`
- \`val personas_dir_opt\`

### 유지

- \`Env_config_core.base_path_raw_opt\` — internal dep of \`base_path_opt\` (still has \`tool_bridge.ml\` caller, separate PR scope)
- \`normalize_masc_base_path_input\` — generic string transform utility (not a path-decision SSOT)
- \`*_env_key\` constants — string identifiers for docker inheritance / snapshot catalogs

### Out of Scope (별도 RFC)

- cdal (\`cdal_verdict_gate\`, \`cdal_eval_v1\`) → sub-library 격리 보존 위해 별도 처리
- auth (\`auth_doctor\`, \`auth_login\`, \`config_doctor\`) → 별도 sprint
- worker_runtime_docker → 별도 sprint

### Verification

- \`dune build --root . @lib/check\`: green
- \`dune exec test/test_rfc_0085_pr8_config_dir_resolver_host_config.exe\`: **4/4 OK**
  - AST: \`Env_config_core.config_dir_opt\` callers = 0
  - AST: \`Env_config_core.personas_dir_opt\` callers = 0
  - AST: \`config_dir_resolver\` invokes \`Host_config.from_env\` ≥ 4
  - AST: \`tool_code_write\` invokes \`Host_config.from_env\` ≥ 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)