### PR TITLE
feat(rfc-0085): PR-9 base_path_opt + base_path_raw_opt 폭발 (14 caller)

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -25,7 +25,7 @@ let get_mode () =
 let is_enabled () = get_mode () <> Disabled
 
 let activity_log_file () =
-  match Env_config.base_path_opt () with
+  match (Host_config.from_env ()).base_path with
   | Some root -> Filename.concat (Common.masc_dir_from_base_path ~base_path:root) (Filename.concat "logs" "auto-responder.log")
   | None -> Filename.concat (Host_config.host ()).log_dir "auto-responder.log"
 

--- a/lib/config/env_config_core.mli
+++ b/lib/config/env_config_core.mli
@@ -143,8 +143,15 @@ val get_port : default:int -> string -> int
 val base_path_env_key : string
 val base_path_input_env_key : string
 val base_path_source_opt : unit -> (string * string) option
-val base_path_raw_opt : unit -> string option
-val base_path_opt : unit -> string option
+
+(* RFC-0085 PR-9 — [base_path_raw_opt] and [base_path_opt] are no
+   longer part of the public surface.  External callers read the
+   normalised env-derived base_path from
+   [(Host_config.from_env ()).base_path] instead.  The two functions
+   remain file-private inside [env_config_core.ml] because
+   [base_path] / [sb_path_opt] still reach for the raw value
+   internally; a follow-up RFC migrates those too. *)
+
 val running_under_test_executable : unit -> bool
 val test_allow_home_base_path_env : string
 val base_path_prod_guard : string -> string

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -233,7 +233,7 @@ let current_inputs ~base_path_input ~default_base_path () =
     cwd = Sys.getcwd ();
     executable_name = Sys.executable_name;
     base_path_input;
-    env_masc_base_path = Env_config_core.base_path_raw_opt ();
+    env_masc_base_path = (Host_config.from_env ()).base_path_raw;
     env_config_dir = Config_dir_resolver.current_env_config_dir_opt ();
     env_personas_dir = Config_dir_resolver.current_env_personas_dir_opt ();
     resolution_source;

--- a/lib/coord/coord_utils_backend_setup.ml
+++ b/lib/coord/coord_utils_backend_setup.ml
@@ -111,7 +111,7 @@ let sync_test_base_path_env resolved_path =
   if running_under_test_executable ()
      && not (test_base_path_override_enabled ())
   then
-    match Env_config_core.base_path_opt () with
+    match (Host_config.from_env ()).base_path with
     | Some current when String.equal current resolved_path -> ()
     | _ ->
         Unix.putenv Env_config_core.base_path_env_key resolved_path;
@@ -166,7 +166,7 @@ let resolve_requested_base_path path =
     - otherwise resolve the requested path to its git root *)
 let resolve_masc_base_path path =
   let requested = resolve_requested_base_path path in
-  match Env_config_core.base_path_opt () with
+  match (Host_config.from_env ()).base_path with
   | Some explicit
     when running_under_test_executable ()
          && not (test_base_path_override_enabled ()) ->

--- a/lib/coord/dune
+++ b/lib/coord/dune
@@ -51,6 +51,11 @@
   masc_eio_context
   masc_process
   masc_mcp.masc_exec
+  ; RFC-0085 PR-9 — coord_utils_backend_setup reads the env-derived
+  ; base_path via Host_config.from_env now that the dep direction is
+  ; reversed (host_config no longer depends on masc_coord; audit
+  ; 2026-05-15 confirmed the masc_coord dep was unused).
+  masc_mcp.host_config
   time_compat
   fs_compat
   yojson

--- a/lib/host_config/dune
+++ b/lib/host_config/dune
@@ -18,4 +18,11 @@
  (preprocess (pps ppx_deriving.show ppx_deriving.eq))
  (libraries
   unix
-  masc_mcp.masc_coord))
+  ; RFC-0085 PR-9 — Host_config absorbs base_path normalisation
+  ; (previously Env_config_core.base_path_opt) so callers get a single
+  ; SSOT for the normalised env-derived base_path.  The masc_coord
+  ; dep was unused (audit 2026-05-15) so it is dropped here, making
+  ; Host_config a true leaf below masc_coord.  Reverse migration of
+  ; coord_utils_backend_setup callers becomes possible because
+  ; masc_coord can now depend on masc_mcp.host_config without cycling.
+  masc_mcp.config))

--- a/lib/host_config/host_config.ml
+++ b/lib/host_config/host_config.ml
@@ -38,6 +38,7 @@ type t =
   ; run_dir : string
   ; policy_dir : string
   ; base_path : string option
+  ; base_path_raw : string option
   ; config_dir : string option
   ; data_dir : string option
   ; personas_dir : string option
@@ -79,7 +80,17 @@ let host () =
   ; log_dir = tmp
   ; run_dir = tmp
   ; policy_dir = tmp
-  ; base_path = get_opt "MASC_BASE_PATH"
+  ; base_path =
+      (* RFC-0085 PR-9 — base_path field carries the *normalised* value
+         (previously Env_config_core.base_path_opt).  Empty / missing
+         env returns None; non-empty trimmed values are passed through
+         Env_config_core.normalize_masc_base_path_input. *)
+      get_opt "MASC_BASE_PATH"
+      |> Option.map Env_config_core.normalize_masc_base_path_input
+      |> (function
+        | Some "" -> None
+        | other -> other)
+  ; base_path_raw = get_opt "MASC_BASE_PATH"
   ; config_dir = get_opt "MASC_CONFIG_DIR"
   ; data_dir = get_opt "MASC_DATA_DIR"
   ; personas_dir = get_opt "MASC_PERSONAS_DIR"
@@ -176,7 +187,13 @@ let resolve ?base_path () =
     ; log_dir = tmp
     ; run_dir = tmp
     ; policy_dir = tmp
-    ; base_path = get_opt "MASC_BASE_PATH"
+    ; base_path =
+        get_opt "MASC_BASE_PATH"
+        |> Option.map Env_config_core.normalize_masc_base_path_input
+        |> (function
+          | Some "" -> None
+          | other -> other)
+    ; base_path_raw = get_opt "MASC_BASE_PATH"
     ; config_dir = get_opt "MASC_CONFIG_DIR"
     ; data_dir = get_opt "MASC_DATA_DIR"
     ; personas_dir = get_opt "MASC_PERSONAS_DIR"

--- a/lib/host_config/host_config.mli
+++ b/lib/host_config/host_config.mli
@@ -64,10 +64,16 @@ type t =
         (** Directory for runtime policy files.  Default [<tmp>] from
             [host ()]. *)
   ; base_path : string option
-        (** Resolved [MASC_BASE_PATH] (or default fallback).  When [None],
-            the caller treats it as "no operator-provided base path".
-            RFC-0085 PR-6: surfaces the env-var processing that today
-            lives in [Env_config_core.base_path_raw_opt]. *)
+        (** Resolved [MASC_BASE_PATH] in *normalised* form (path
+            normalisation applied).  [None] when unset or empty after
+            normalisation.  RFC-0085 PR-9 replaces
+            [Env_config_core.base_path_opt]. *)
+  ; base_path_raw : string option
+        (** [MASC_BASE_PATH] value as read from the environment, with
+            whitespace trimmed but no path normalisation.  Used by
+            routes / dashboard / config_doctor inputs that surface
+            the operator's literal input.  RFC-0085 PR-9 replaces
+            [Env_config_core.base_path_raw_opt]. *)
   ; config_dir : string option
         (** Resolved [MASC_CONFIG_DIR].  [None] when unset. *)
   ; data_dir : string option

--- a/lib/keeper/keeper_artifact_hydrator.ml
+++ b/lib/keeper/keeper_artifact_hydrator.ml
@@ -72,7 +72,7 @@ let hydrate_recent ~store ~keep_recent : Agent_sdk.Context_reducer.t =
   { Agent_sdk.Context_reducer.strategy }
 
 let reducer_from_env () =
-  match Env_config_core.base_path_opt () with
+  match (Host_config.from_env ()).base_path with
   | None -> None
   | Some base_path ->
       let store = Tool_blob_store.create ~base_path in

--- a/lib/keeper_voice_local.ml
+++ b/lib/keeper_voice_local.ml
@@ -13,7 +13,7 @@ let trim_opt = function
   | None -> None
 
 let resolved_base_path_opt () =
-  match Env_config_core.base_path_opt () with
+  match (Host_config.from_env ()).base_path with
   | Some path -> Some path
   | None -> Coord_utils_backend_setup.find_git_root (Sys.getcwd ())
 

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -1398,8 +1398,8 @@ let meta_cognition_summary_cached (config : Coord.config) : Yojson.Safe.t =
 
 let dashboard_shell_paths_json (config : Coord.config) : Yojson.Safe.t =
   Server_base_path_diagnostics.detect
-    ?input_base_path:(Env_config_core.base_path_raw_opt ())
-    ?env_masc_base_path:(Env_config_core.base_path_raw_opt ())
+    ?input_base_path:((Host_config.from_env ()).base_path_raw)
+    ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
     ~effective_base_path:config.base_path
     ~effective_masc_root:(Coord.masc_root_dir config)
     ()

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -431,7 +431,7 @@ let runtime_resolution_json (config : Coord.config) =
   let workspace_commit = git_rev_parse_short config.workspace_path in
   let resolved_base_commit = git_rev_parse_short config.base_path in
   let base_path_input =
-    Env_config_core.base_path_raw_opt () |> Option.value ~default:config.workspace_path
+    (Host_config.from_env ()).base_path_raw |> Option.value ~default:config.workspace_path
   in
   let prompt_markdown_dir =
     Prompt_registry.get_markdown_dir () |> Option.value ~default:""

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -22,7 +22,7 @@ let default_base_path () =
      When no explicit base path is set, prefer HOME so runtime artifacts land
      under ~/.masc instead of the current checkout. *)
   let requested_path =
-    match Env_config_core.base_path_opt () with
+    match (Host_config.from_env ()).base_path with
     | Some _ -> Sys.getcwd ()
     | None -> (
         match Env_config_core.home_dir_opt () with

--- a/lib/server/server_routes_http_routes_artifacts.ml
+++ b/lib/server/server_routes_http_routes_artifacts.ml
@@ -30,7 +30,7 @@ let is_valid_sha256 (s : string) : bool =
        s
 
 let blob_response ~sha256 =
-  match Env_config_core.base_path_opt () with
+  match (Host_config.from_env ()).base_path with
   | None ->
       ( `Assoc
           [

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -124,8 +124,8 @@ let health_path_diagnostics () =
   match current_server_state_opt () with
   | Some state ->
       Server_base_path_diagnostics.detect
-        ?input_base_path:(Env_config_core.base_path_raw_opt ())
-        ?env_masc_base_path:(Env_config_core.base_path_raw_opt ())
+        ?input_base_path:((Host_config.from_env ()).base_path_raw)
+        ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
         ~effective_base_path:state.room_config.base_path
         ~effective_masc_root:(Coord.masc_root_dir state.room_config)
         ()
@@ -133,8 +133,8 @@ let health_path_diagnostics () =
       let effective_base_path = default_base_path () in
       let effective_masc_root = Common.masc_dir_from_base_path ~base_path:effective_base_path in
       Server_base_path_diagnostics.detect
-        ?input_base_path:(Env_config_core.base_path_raw_opt ())
-        ?env_masc_base_path:(Env_config_core.base_path_raw_opt ())
+        ?input_base_path:((Host_config.from_env ()).base_path_raw)
+        ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
         ~effective_base_path ~effective_masc_root ()
 
 type paused_keeper_scan = {

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -310,7 +310,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   let path_diagnostics =
     Server_base_path_diagnostics.detect
       ?input_base_path
-      ?env_masc_base_path:(Env_config_core.base_path_raw_opt ())
+      ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
       ~effective_base_path:state.room_config.base_path
       ~effective_masc_root:(Coord.masc_root_dir state.room_config)
       ()
@@ -323,7 +323,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
 let runtime_path_diagnostics ?input_base_path (state : Mcp_server.server_state) =
   Server_base_path_diagnostics.detect
     ?input_base_path
-    ?env_masc_base_path:(Env_config_core.base_path_raw_opt ())
+    ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
     ~effective_base_path:state.room_config.base_path
     ~effective_masc_root:(Coord.masc_root_dir state.room_config)
     ()

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -72,7 +72,7 @@ let resolve_blob_store () =
         | Some store -> store
         | None ->
             let store =
-              match Env_config_core.base_path_opt () with
+              match (Host_config.from_env ()).base_path with
               | None -> None
               | Some base_path -> Some (Tool_blob_store.create ~base_path)
             in

--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -298,7 +298,7 @@ let trim_opt = function
 
 (** Ensure .masc/audio/ directory exists *)
 let resolved_base_path_opt () =
-  match Env_config_core.base_path_opt () with
+  match (Host_config.from_env ()).base_path with
   | Some path -> Some path
   | None -> Coord_utils_backend_setup.find_git_root (Sys.getcwd ())
 

--- a/lib/voice/voice_config.ml
+++ b/lib/voice/voice_config.ml
@@ -77,12 +77,12 @@ let voice_config_file_in root =
   Filename.concat masc_dir "voice_config.json"
 
 let base_path_voice_config_path_opt () =
-  Env_config_core.base_path_opt ()
+  (Host_config.from_env ()).base_path
   |> Option.map voice_config_file_in
 
 let repo_voice_config_path_opt () =
   let root =
-    match Env_config_core.base_path_opt () with
+    match (Host_config.from_env ()).base_path with
     | Some bp -> bp
     | None ->
       let cwd = Sys.getcwd () in
@@ -94,7 +94,7 @@ let repo_voice_config_path_opt () =
 
 let fallback_voice_config_path () =
   let root =
-    match Env_config_core.base_path_opt () with
+    match (Host_config.from_env ()).base_path with
     | Some bp -> bp
     | None -> Sys.getcwd ()
   in

--- a/test/dune
+++ b/test/dune
@@ -1704,3 +1704,11 @@
  (name test_rfc_0085_pr8_config_dir_resolver_host_config)
  (modules test_rfc_0085_pr8_config_dir_resolver_host_config)
  (libraries alcotest ast_grep))
+
+; RFC-0085 PR-9 — Env_config_core.base_path_opt + base_path_raw_opt
+; public-surface purge; 9 caller migrate to Host_config.from_env;
+; Host_config.t gains base_path (normalised) + base_path_raw fields.
+(test
+ (name test_rfc_0085_pr9_base_path_opt_purge)
+ (modules test_rfc_0085_pr9_base_path_opt_purge)
+ (libraries alcotest ast_grep))

--- a/test/test_rfc_0085_pr9_base_path_opt_purge.ml
+++ b/test/test_rfc_0085_pr9_base_path_opt_purge.ml
@@ -1,0 +1,81 @@
+open Alcotest
+
+(** RFC-0085 PR-9 — Verify Env_config_core.base_path_opt /
+    base_path_raw_opt have 0 external callers; Host_config.t
+    surfaces both [base_path] (normalised) and [base_path_raw] (raw). *)
+
+let walk_dirs dirs =
+  let rec collect acc = function
+    | [] -> acc
+    | dir :: rest ->
+      let entries = try Sys.readdir dir with Sys_error _ -> [||] in
+      let next, files =
+        Array.fold_left
+          (fun (sub, files) name ->
+            let p = Filename.concat dir name in
+            if try Sys.is_directory p with Sys_error _ -> false
+            then p :: sub, files
+            else if Filename.check_suffix p ".ml"
+            then sub, p :: files
+            else sub, files)
+          ([], [])
+          entries
+      in
+      collect (List.rev_append files acc) (List.rev_append next rest)
+  in
+  collect [] dirs
+;;
+
+let test_base_path_opt_callers_zero () =
+  let files = walk_dirs [ "lib"; "bin" ] in
+  let total =
+    List.fold_left
+      (fun acc f ->
+        if String.equal (Filename.basename f) "env_config_core.ml"
+        then acc (* file-private internal uses OK *)
+        else
+          acc
+          + Ast_grep.count_calls ~module_path:f ~callee:"Env_config_core.base_path_opt"
+          + Ast_grep.count_calls ~module_path:f ~callee:"Env_config.base_path_opt")
+      0
+      files
+  in
+  check int "external Env_config_core.base_path_opt callers = 0" 0 total
+;;
+
+let test_base_path_raw_opt_callers_zero () =
+  let files = walk_dirs [ "lib"; "bin" ] in
+  let total =
+    List.fold_left
+      (fun acc f ->
+        if String.equal (Filename.basename f) "env_config_core.ml"
+        then acc
+        else acc + Ast_grep.count_calls ~module_path:f ~callee:"Env_config_core.base_path_raw_opt")
+      0
+      files
+  in
+  check int "external Env_config_core.base_path_raw_opt callers = 0" 0 total
+;;
+
+let test_host_config_base_path_used () =
+  let n =
+    Ast_grep.count_calls
+      ~module_path:"lib/voice/voice_config.ml"
+      ~callee:"Host_config.from_env"
+  in
+  if n < 1
+  then failf "voice_config.ml must use Host_config.from_env >= 1; got %d" n
+;;
+
+let () =
+  run
+    "rfc-0085-pr-9-base-path-opt-purge"
+    [ ( "Env_config_core public surface"
+      , [ test_case "base_path_opt purge" `Quick test_base_path_opt_callers_zero
+        ; test_case "base_path_raw_opt purge" `Quick test_base_path_raw_opt_callers_zero
+        ] )
+    ; ( "Host_config adoption"
+      , [ test_case "voice_config uses host_config" `Quick test_host_config_base_path_used ]
+      )
+    ]
+;;


### PR DESCRIPTION
RFC-0085 PR-9 — Env_config_core.base_path_opt + base_path_raw_opt 공용 surface 박멸. 14 caller across 13 files를 Host_config.from_env로 routing. Host_config.t에 base_path (normalised) + base_path_raw 필드 추가. host_config sub-library의 unused masc_coord dep 제거 + masc_config dep 추가 (dep direction 뒤집기로 coord_utils_backend_setup의 host_config 의존 가능해짐). 3/3 test OK. env_config_core.ml 내부에서 base_path() / sb_path_opt() 가 여전히 file-private로 호출 — full removal은 별도 RFC.