### PR TITLE
chore(keeper,credential): RFC-0085 Phase 2.A — rename Credential_provider to Keeper_credential_provider

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -95,7 +95,7 @@
    keeper_shell_ops
    keeper_exec_shell
    keeper_gh_env
-   credential_provider
+   keeper_credential_provider
    host_config_provider
    in_container_login_provider
    keeper_gh_shared

--- a/lib/keeper/host_config_provider.ml
+++ b/lib/keeper/host_config_provider.ml
@@ -11,7 +11,7 @@ let cred_root = (Host_config.host ()).cred_root
 let explicit_ssh_key_container_path =
   Filename.concat (Filename.concat cred_root ".ssh") "id_credential"
 
-let mount_if_present ~host ~container : Credential_provider.ro_mount list =
+let mount_if_present ~host ~container : Keeper_credential_provider.ro_mount list =
   if host = "" then []
   else if not (Sys.file_exists host) then []
   else [ { host; container } ]
@@ -111,7 +111,7 @@ let compose_env ?ssh_key_container ~git_author_name ~git_author_email () =
 
 let required_mount_result (attempt : mount_attempt) ~container =
   match attempt.status with
-  | `Mounted -> Ok Credential_provider.{ host = attempt.host; container }
+  | `Mounted -> Ok Keeper_credential_provider.{ host = attempt.host; container }
   | `Empty ->
       Error
         (Printf.sprintf
@@ -210,7 +210,7 @@ let bind_from_keeper_binding ?ssh_key_path ~keeper_name
   match compose_ro_mounts_result ~keeper_name kb with
   | Error reason ->
       Error
-        (Credential_provider.Missing_bundle
+        (Keeper_credential_provider.Missing_bundle
            { identity = keeper_name; path = reason })
   | Ok bundle_mounts ->
     let ro_mounts =
@@ -220,7 +220,7 @@ let bind_from_keeper_binding ?ssh_key_path ~keeper_name
       | None -> []
       | Some host ->
           [
-            Credential_provider.
+            Keeper_credential_provider.
               { host; container = explicit_ssh_key_container_path };
           ]
     in
@@ -238,7 +238,7 @@ let bind_from_keeper_binding ?ssh_key_path ~keeper_name
     | Repo_manager_types.Materialized _ ->
         let metadata = metadata_of_binding kb @ extra_metadata in
         Ok
-          Credential_provider.
+          Keeper_credential_provider.
             {
               identity = kb.effective_github_identity;
               env;
@@ -248,7 +248,7 @@ let bind_from_keeper_binding ?ssh_key_path ~keeper_name
             }
     | Repo_manager_types.Stale { reason } ->
         Error
-          (Credential_provider.Missing_bundle
+          (Keeper_credential_provider.Missing_bundle
              { identity = keeper_name
              ; path =
                  Printf.sprintf
@@ -259,7 +259,7 @@ let bind_from_keeper_binding ?ssh_key_path ~keeper_name
              })
     | Repo_manager_types.Unmaterialized ->
         Error
-          (Credential_provider.Missing_bundle
+          (Keeper_credential_provider.Missing_bundle
              { identity = keeper_name
              ; path =
                  Printf.sprintf
@@ -273,7 +273,7 @@ let legacy_resolve ~config ~keeper_name =
   match Keeper_gh_env.keeper_binding config ~keeper_name with
   | Error reason ->
       Error
-        (Credential_provider.Missing_bundle
+        (Keeper_credential_provider.Missing_bundle
            { identity = keeper_name; path = reason })
   | Ok kb -> bind_from_keeper_binding ~keeper_name kb ~extra_metadata:[]
 
@@ -320,7 +320,7 @@ let bind_from_credential ~keeper_name (cred : Repo_manager_types.credential) =
   match binding_of_credential cred with
   | Error reason ->
       Error
-        (Credential_provider.Missing_bundle
+        (Keeper_credential_provider.Missing_bundle
            { identity = keeper_name; path = reason })
   | Ok kb ->
       let ssh_key_path =
@@ -333,7 +333,7 @@ let bind_from_credential ~keeper_name (cred : Repo_manager_types.credential) =
       (match ssh_key_path with
       | Some path when not (Sys.file_exists path) ->
           Error
-            (Credential_provider.Missing_bundle
+            (Keeper_credential_provider.Missing_bundle
                { identity = keeper_name
                ; path =
                    Printf.sprintf
@@ -342,7 +342,7 @@ let bind_from_credential ~keeper_name (cred : Repo_manager_types.credential) =
                })
       | Some path when Sys.is_directory path ->
           Error
-            (Credential_provider.Missing_bundle
+            (Keeper_credential_provider.Missing_bundle
                { identity = keeper_name
                ; path =
                    Printf.sprintf
@@ -392,7 +392,7 @@ let bind_from_credential_checked ~keeper_name cred =
         Option.value ~default:"<none>" cred.Repo_manager_types.gh_config_dir
       in
       Error
-        (Credential_provider.Missing_bundle
+        (Keeper_credential_provider.Missing_bundle
            { identity = keeper_name
            ; path =
                Printf.sprintf
@@ -437,7 +437,7 @@ let resolve ~config ~identity:keeper_name =
         List.map (fun (c : Repo_manager_types.credential) -> c.id) many
       in
       Error
-        (Credential_provider.Missing_bundle
+        (Keeper_credential_provider.Missing_bundle
            { identity = keeper_name
            ; path =
                Printf.sprintf
@@ -448,12 +448,12 @@ let resolve ~config ~identity:keeper_name =
                  keeper_name (List.length many) (String.concat ", " ids)
            })
 
-let finalize (_b : Credential_provider.binding) ~container_id:_ =
+let finalize (_b : Keeper_credential_provider.binding) ~container_id:_ =
   (* PR-1: noop.  PR-3 will rewrite hosts.yml:user inside the
      container after `gh auth login --with-token` runs. *)
   Ok ()
 
-let tear_down (_b : Credential_provider.binding) ~container_id:_ =
+let tear_down (_b : Keeper_credential_provider.binding) ~container_id:_ =
   (* PR-1: noop.  The RO mount lifetime equals the `docker run`
      lifetime; nothing to unmount. *)
   ()

--- a/lib/keeper/host_config_provider.mli
+++ b/lib/keeper/host_config_provider.mli
@@ -10,7 +10,7 @@
     [finalize] and [tear_down] are noops here — the RO mount lifetime is
     the docker [run]. *)
 
-include Credential_provider.S
+include Keeper_credential_provider.S
 
 val cred_root : string
 (** [/tmp/keeper-creds] — in-container path under which credentials
@@ -29,10 +29,10 @@ module For_testing : sig
     unit -> (string * string) list
 
   val mount_if_present :
-    host:string -> container:string -> Credential_provider.ro_mount list
+    host:string -> container:string -> Keeper_credential_provider.ro_mount list
 
   val compose_ro_mounts_result :
     ?keeper_name:string ->
     Keeper_gh_env.keeper_binding ->
-    (Credential_provider.ro_mount list, string) result
+    (Keeper_credential_provider.ro_mount list, string) result
 end

--- a/lib/keeper/in_container_login_provider.ml
+++ b/lib/keeper/in_container_login_provider.ml
@@ -7,11 +7,11 @@
 
     The F-1 gate ([provider_gate]) rejects credentials whose token
     SHA-256 matches the operator's ambient token — this prevents the
-    keeper from acting as the operator.  The [Credential_provider.S]
+    keeper from acting as the operator.  The [Keeper_credential_provider.S]
     lifecycle stubs are included as scaffolding for subsequent PRs
     (F-2 hosts.yml rewrite, temp-file management, tear_down cleanup). *)
 
-open Credential_provider
+open Keeper_credential_provider
 
 (** F-1 security gate: reject when the keeper's token hash matches the
     operator's ambient token.  This prevents the keeper subprocess from
@@ -45,7 +45,7 @@ let provider_gate ~keeper_token ~operator_token ~identity =
 let ct_hex_equal a b =
   String.length a = 64 && String.length b = 64 && String.equal a b
 
-(* ── Credential_provider.S stubs ──────────────────────────────────
+(* ── Keeper_credential_provider.S stubs ──────────────────────────────────
    Full implementation in subsequent PRs.  The stubs return errors
    or noops so callers that resolve through this provider get a clear
    signal that the feature is not yet active. *)

--- a/lib/keeper/in_container_login_provider.mli
+++ b/lib/keeper/in_container_login_provider.mli
@@ -3,7 +3,7 @@
     @see {!In_container_login_provider} for full documentation.
     @since 2.90.0 *)
 
-include Credential_provider.S
+include Keeper_credential_provider.S
 
 (** {1 F-1 Security Gate} *)
 
@@ -21,7 +21,7 @@ val provider_gate :
   keeper_token:string ->
   operator_token:string ->
   identity:string ->
-  (unit, Credential_provider.error) result
+  (unit, Keeper_credential_provider.error) result
 
 (**/**)
 
@@ -31,7 +31,7 @@ module For_testing : sig
     keeper_token:string ->
     operator_token:string ->
     identity:string ->
-    (unit, Credential_provider.error) result
+    (unit, Keeper_credential_provider.error) result
 
   val ct_hex_equal : string -> string -> bool
 end

--- a/lib/keeper/keeper_credential_provider.ml
+++ b/lib/keeper/keeper_credential_provider.ml
@@ -1,4 +1,4 @@
-(** See {!Credential_provider} interface. *)
+(** See {!Keeper_credential_provider} interface. *)
 
 type ro_mount = {
   host : string;

--- a/lib/keeper/keeper_credential_provider.mli
+++ b/lib/keeper/keeper_credential_provider.mli
@@ -64,9 +64,9 @@ val pp_error : error -> string
 (** Human-readable rendering for log lines. *)
 
 (** Module signature implemented by each concrete provider.  RFC-0008
-    §3 spelled this as [include module type of Credential_provider];
+    §3 spelled this as [include module type of Keeper_credential_provider];
     in OCaml the idiomatic equivalent is a named [module type S] that
-    callers can refer to as [Credential_provider.S]. *)
+    callers can refer to as [Keeper_credential_provider.S]. *)
 module type S = sig
   val resolve :
     config:Coord.config -> identity:string -> (binding, error) result

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -800,11 +800,11 @@ let run_docker_shell_command_with_status
              ~/.config/gh, ~/.ssh, and keychain probes are not part of
              keeper execution. *)
                       match Host_config_provider.resolve ~config ~identity:meta.name with
-                      | Error err -> Error (Credential_provider.pp_error err)
+                      | Error err -> Error (Keeper_credential_provider.pp_error err)
                       | Ok binding ->
                         let mounts =
                           List.concat_map
-                            (fun (m : Credential_provider.ro_mount) ->
+                            (fun (m : Keeper_credential_provider.ro_mount) ->
                                [ "-v"; m.host ^ ":" ^ m.container ^ ":ro" ])
                             binding.ro_mounts
                         in

--- a/lib/repo_manager/credential_materializer.ml
+++ b/lib/repo_manager/credential_materializer.ml
@@ -13,7 +13,7 @@
     PR-B Slice 1 ships this **verify-only** path.  The two [oauth_method]
     materialisation flows (web device-flow, with-token) are layered on
     top by Slice 2 in [Server_routes_http_routes_credentials].  The trait
-    surface stays minimal so PR-C can wire [Credential_provider.finalize]
+    surface stays minimal so PR-C can wire [Keeper_credential_provider.finalize]
     against it without introducing new public types. *)
 
 open Repo_manager_types

--- a/test/test_credential_provider.ml
+++ b/test/test_credential_provider.ml
@@ -1,4 +1,4 @@
-(** Pin {!Credential_provider} type surface and
+(** Pin {!Keeper_credential_provider} type surface and
     {!Host_config_provider} pure helpers.
 
     Integration coverage of [resolve] (which goes through
@@ -9,7 +9,7 @@
 
     What this file pins:
 
-    1. [Credential_provider.pp_error] formats every variant.  Mostly
+    1. [Keeper_credential_provider.pp_error] formats every variant.  Mostly
        a regression guard: if a future PR adds a fifth error case
        and forgets [pp_error], the [exhaustive] assertion catches it.
     2. [Host_config_provider.For_testing.compose_ro_mounts_result]
@@ -26,7 +26,7 @@
 
 open Alcotest
 
-module CP = Masc_mcp.Credential_provider
+module CP = Masc_mcp.Keeper_credential_provider
 module HCP = Masc_mcp.Host_config_provider
 module KGE = Masc_mcp.Keeper_gh_env
 open Repo_manager_types


### PR DESCRIPTION
## Summary
- Rename `Credential_provider` → `Keeper_credential_provider` in `lib/keeper/`
- Update all external callers: `lib/repo_manager/credential_materializer.ml`, `test/test_credential_provider.ml`
- Update `lib/dune` module listing

## Files changed
- `lib/keeper/credential_provider.ml` → `lib/keeper/keeper_credential_provider.ml` (rename)
- `lib/keeper/credential_provider.mli` → `lib/keeper/keeper_credential_provider.mli` (rename)
- `lib/dune` — module name update
- `lib/keeper/host_config_provider.{ml,mli}` — module reference update
- `lib/keeper/in_container_login_provider.{ml,mli}` — module reference update
- `lib/keeper/keeper_shell_docker.ml` — module reference update
- `lib/repo_manager/credential_materializer.ml` — module reference update
- `test/test_credential_provider.ml` — module reference update

## RFC References
- RFC-0008 (CredentialProvider trait)
- RFC-0019 (Keeper Credential Unification)
- RFC-0084 (keeper-tool-dispatch-unification)
- RFC-0085 Phase 2.A

## Test plan
- [x] `dune build @check` passes (no Credential_provider errors; pre-existing errors unrelated)
- [x] No remaining `Credential_provider` references in `lib/`, `test/`, `bin/`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>