### PR TITLE
refactor(rfc-0085/pr-2d): rename tool_resolution → keeper_tool_resolution

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -78,7 +78,7 @@
  server_mcp_transport_http_respond
  server_mcp_transport_http_agui
   keeper_tool_registry
-  tool_resolution
+  keeper_tool_resolution
   keeper_tool_policy_config
   keeper_discovered_tools
   keeper_tool_affinity

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -37,7 +37,7 @@ let tool_usage_delta ~(before : (string * int) list) ~(after : (string * int) li
 (* Three input surfaces, packed into an outcome variant so the pure
    canonicalisation and the observation-emitting wrapper share one
    decision tree. *)
-type canonicalisation_outcome = Tool_resolution.runtime_decision_outcome =
+type canonicalisation_outcome = Keeper_tool_resolution.runtime_decision_outcome =
   | Mcp_mapped of
       { stripped : string
       ; internal : string
@@ -46,7 +46,7 @@ type canonicalisation_outcome = Tool_resolution.runtime_decision_outcome =
   | Already_internal of { canonical : string }
   | Miss
 
-let canonicalise_outcome = Tool_resolution.runtime_decision
+let canonicalise_outcome = Keeper_tool_resolution.runtime_decision
 
 (** Pure canonicalisation — no telemetry. Used by set-logic call sites
     (required-tool canonicalisation, surface composition, satisfaction

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -220,13 +220,13 @@ let parse_git_clone (doc : Keeper_toml_loader.toml_doc) : git_clone_config =
     clone_timeout_sec; push_timeout_sec; pr_create_timeout_sec }
 
 let unresolved_tool_message ~label ~name =
-  match Tool_resolution.resolve name with
-  | Tool_resolution.Resolved _ | Tool_resolution.Alias_to _ -> None
-  | Tool_resolution.Unknown { tried; _ } ->
+  match Keeper_tool_resolution.resolve name with
+  | Keeper_tool_resolution.Resolved _ | Keeper_tool_resolution.Alias_to _ -> None
+  | Keeper_tool_resolution.Unknown { tried; _ } ->
       Some (Printf.sprintf "%s: tool '%s' unresolved: tried [%s]"
-              label name (Tool_resolution.string_of_tried tried))
+              label name (Keeper_tool_resolution.string_of_tried tried))
 
-let is_known_policy_tool_name = Tool_resolution.is_known_policy_tool_name
+let is_known_policy_tool_name = Keeper_tool_resolution.is_known_policy_tool_name
 
 (* Shortcut: if the caller's [base_path] already points at a project root
    that has [base_path/config/tool_policy.toml], prefer that directly.

--- a/lib/keeper/keeper_tool_resolution.ml
+++ b/lib/keeper/keeper_tool_resolution.ml
@@ -1,4 +1,4 @@
-(** Tool_resolution — unified resolution behind the 15-fold OR membership check.
+(** Keeper_tool_resolution — unified resolution behind the 15-fold OR membership check.
 
     RFC-0080 Phase 2 shim. Wraps the existing sources behind a single [resolve]
     function that returns a typed [resolution]. Every call site that previously

--- a/lib/keeper/keeper_tool_resolution.mli
+++ b/lib/keeper/keeper_tool_resolution.mli
@@ -1,4 +1,4 @@
-(** Tool_resolution — typed resolution for policy tool name validation.
+(** Keeper_tool_resolution — typed resolution for policy tool name validation.
 
     RFC-0080 Phase 2. Replaces the 15-fold OR boolean check with a typed
     [resolve] function that returns provenance information.

--- a/test/dune
+++ b/test/dune
@@ -142,7 +142,7 @@
         test_keeper_toml
         test_keeper_runtime_toml
         test_keeper_tool_policy_config
-        test_tool_resolution
+        test_keeper_tool_resolution
         test_dispatch_disclosure_parity
         test_coord_worktree_policy_path
         test_claim_post_provision_hook
@@ -382,7 +382,7 @@
           test_keeper_toml
           test_keeper_runtime_toml
           test_keeper_tool_policy_config
-          test_tool_resolution
+          test_keeper_tool_resolution
           test_dispatch_disclosure_parity
           test_coord_worktree_policy_path
           test_claim_post_provision_hook
@@ -1396,7 +1396,7 @@
 
 ; RFC-0084 §6.1 — pinned-fail tests for keeper→tool dispatch unification.
 ; PR-1 establishes 3 evidence tests for the current telemetry/surface/prehook
-; gaps in lib/tool_dispatch.ml and lib/keeper/tool_resolution.ml. PR-5/7/9
+; gaps in lib/tool_dispatch.ml and lib/keeper/keeper_tool_resolution.ml. PR-5/7/9
 ; update each pinned constant alongside the code fix in the same PR so that
 ; drift between code state and pinned evidence is caught by single-PR diff.
 ; Constants-only (no Masc_mcp lib dependency) — keeps tests fast and isolated.

--- a/test/test_dispatch_disclosure_parity.ml
+++ b/test/test_dispatch_disclosure_parity.ml
@@ -1,10 +1,10 @@
 open Alcotest
 
-module TR = Masc_mcp.Tool_resolution
+module TR = Masc_mcp.Keeper_tool_resolution
 
 (** RFC-0084 §1.4, §6.2 — boot policy load vs runtime routing parity.
 
-    PR-6 introduces [Tool_resolution.runtime_decision] as the SSOT entry
+    PR-6 introduces [Keeper_tool_resolution.runtime_decision] as the SSOT entry
     for runtime tool-name routing. [Keeper_tool_disclosure.canonical_tool_name]
     remains as the legacy public wrapper during migration and must preserve
     the same canonical string result.
@@ -18,7 +18,7 @@ module TR = Masc_mcp.Tool_resolution
     edge cases (empty string, all-internal, all-public).
 
     For each name, assert:
-      canonical_string(Tool_resolution.runtime_decision name)
+      canonical_string(Keeper_tool_resolution.runtime_decision name)
         = Keeper_tool_disclosure.canonical_tool_name name
 *)
 

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -1,6 +1,6 @@
 open Alcotest
 
-module TR = Masc_mcp.Tool_resolution
+module TR = Masc_mcp.Keeper_tool_resolution
 
 (* ── resolve returns correct tried_source for each admission path ── *)
 

--- a/test/test_telemetry_completeness.ml
+++ b/test/test_telemetry_completeness.ml
@@ -23,7 +23,7 @@ open Alcotest
     - Host_config.t: 11 hardcode sites tracked (PR-12)
 
     Boot/runtime parity (RFC-0084 §1.4):
-    - Tool_resolution.runtime_decision SSOT entry (PR-6)
+    - Keeper_tool_resolution.runtime_decision SSOT entry (PR-6)
     - keeper turn + MCP + tag-dispatch all go through guarded_dispatch
 *)
 


### PR DESCRIPTION
## Summary
- Rename `tool_resolution.ml` → `keeper_tool_resolution.ml` (+ .mli)
- Rename test file `test_tool_resolution.ml` → `test_keeper_tool_resolution.ml`
- Update all 6 referencing files: `Tool_resolution` → `Keeper_tool_resolution`
- Update `lib/dune` and `test/dune` module lists

## Context
Part of RFC-0085 Phase 2.A — keeper namespace bulk promotion.
PR-2D of 5 (depends on none, blocks PR-2E bulk sub-library promotion).

## Verification
- [x] `dune build` passes (no new errors; pre-existing errors in unrelated modules)
- [ ] CI checks pending

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>