### PR TITLE
fix(test): remove stale full-build surfaces

### DIFF
--- a/test/test_briefing_json_helpers.ml
+++ b/test/test_briefing_json_helpers.ml
@@ -6,7 +6,7 @@
     smallest of the four (82 LOC impl, 14 LOC mli) with property
     pins on every exposed helper. *)
 
-module B = Masc_mcp.Briefing_json_helpers
+module B = Briefing_json_helpers
 
 (* Diagnostic helper — prints the actual JSON value when a
    pattern-match fallback fires, instead of bare [assert false].

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -824,62 +824,6 @@ let test_audit_runs_json_exposes_provenance () =
   check int "query limit" 2 (json_int "limit" query);
   check string "query cascade" "keeper_unified" (json_string "cascade" query)
 
-(* ── server_error_score_for_provider (#12797) ─────────────────── *)
-
-let test_se_score_unknown_provider_full () =
-  let h = H.create () in
-  let s = S.server_error_score_for_provider h ~provider_key:"unseen" in
-  check (float 0.001) "unknown → 1.0" 1.0 s
-
-let test_se_score_no_failures_full () =
-  let h = H.create () in
-  H.record_success h ~provider_key:"p" ();
-  H.record_success h ~provider_key:"p" ();
-  let s = S.server_error_score_for_provider h ~provider_key:"p" in
-  check (float 0.001) "no failures → 1.0" 1.0 s
-
-let test_se_score_one_failure_decays () =
-  (* Default decay base 0.6: 1 recent failure → 0.6 *)
-  let h = H.create () in
-  H.record_failure h ~provider_key:"p" ();
-  let s = S.server_error_score_for_provider h ~provider_key:"p" in
-  (* Allow for env override: just verify score < 1.0 and > 0.0 *)
-  check bool "1 failure → score < 1.0" true (s < 1.0);
-  check bool "1 failure → score > 0.0" true (s > 0.0)
-
-let test_se_score_many_failures_skips () =
-  (* Default skip_after is 4: 4 failures should zero the score *)
-  let h = H.create () in
-  for _ = 1 to 4 do
-    H.record_failure h ~provider_key:"p" ()
-  done;
-  let s = S.server_error_score_for_provider h ~provider_key:"p" in
-  check (float 0.001) "4 failures → hard skip (0.0)" 0.0 s
-
-let test_se_score_only_rate_limits_no_penalty () =
-  (* Rate-limit events should NOT increase server-error score *)
-  let h = H.create () in
-  H.record_soft_rate_limited h ~provider_key:"p" ();
-  H.record_soft_rate_limited h ~provider_key:"p" ();
-  let s = S.server_error_score_for_provider h ~provider_key:"p" in
-  check (float 0.001) "429s don't affect se score" 1.0 s
-
-let test_weighted_shuffle_server_error_provider_deprioritised () =
-  (* A provider with 4 server errors should be skipped when there is a
-     clean peer.  All other conditions are equal (weight, no 429s). *)
-  let h = H.create () in
-  for _ = 1 to 4 do
-    H.record_failure h ~provider_key:"errored" ()
-  done;
-  let cands = [mk_cand ~w:100 "errored"; mk_cand ~w:100 "clean"] in
-  let strat = mk_t S.Weighted_random in
-  let ctx = mk_ctx ~health:h ~rand:(fun _ -> 0) () in
-  let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
-  match ordered with
-  | [] -> fail "expected at least clean provider"
-  | hd :: _ ->
-      check string "clean provider heads the list" "clean" hd.name
-
 let () =
   run "cascade_strategy" [
     "failover", [

--- a/test/test_cascade_trust_persist.ml
+++ b/test/test_cascade_trust_persist.ml
@@ -13,7 +13,6 @@
 open Alcotest
 module H = Masc_mcp.Cascade_health_tracker
 module P = Masc_mcp.Cascade_trust_persist
-module S = Masc_mcp.Cascade_strategy
 
 let kind value = H.error_kind_of_string value
 
@@ -195,15 +194,16 @@ let test_hydrate_latest_restores_latency_hint_from_snapshot () =
     for _ = 1 to 20 do
       H.record_success H.global ~provider_key:key ~latency_ms:10.0 ()
     done;
-    let warm_score = S.latency_score_for_provider H.global ~provider_key:key in
-    check bool "fast samples warm latency score" true (warm_score > 0.9);
+    let warm_p50 =
+      match H.provider_info H.global ~provider_key:key with
+      | Some info -> info.p50_latency_ms
+      | None -> None
+    in
+    check (option (float 0.001)) "fast samples warm p50 latency"
+      (Some 10.0)
+      warm_p50;
     let restored = P.hydrate_latest ~base_path:dir in
     check bool "hydrate applied at least one row" true (restored > 0);
-    let restored_score =
-      S.latency_score_for_provider H.global ~provider_key:key
-    in
-    check bool "hydrate restores slow p50 routing penalty"
-      true (restored_score < 0.5);
     match H.provider_info H.global ~provider_key:key with
     | None -> fail "missing hydrated provider"
     | Some info ->

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1934,6 +1934,7 @@ let make_worker_meta ?(effective_model = "local-qwen") ()
   ; checkpoint_path = "/tmp/checkpoint.json"
   ; turn_log_path = "/tmp/turns.jsonl"
   ; last_run_at = None
+  ; disclosure_strategy = None
   }
 ;;
 

--- a/test/test_otel_genai.ml
+++ b/test/test_otel_genai.ml
@@ -338,8 +338,15 @@ let test_dispatch_hook_emits_tool_span_payload () =
             ; failure_class = None
             }
           in
-          let returned = Lib.Tool_dispatch.run_post_hooks result in
-          check bool "post-hook preserves success" true returned.success);
+          let returned =
+            Lib.Tool_dispatch_emit.finalize
+              ~outcome:Lib.Dispatch_outcome.Handled
+              (Some result)
+          in
+          match returned with
+          | Some returned ->
+              check bool "post-hook preserves success" true returned.success
+          | None -> fail "expected finalized result");
       match !spans with
       | [ (name, attrs) ] ->
           check string "span name" "tool/keeper_shell" name;

--- a/test/test_pr_a_cred_root_migration.ml
+++ b/test/test_pr_a_cred_root_migration.ml
@@ -62,7 +62,7 @@ let test_cred_root_byte_identical_to_typed_surface () =
   (* Today's behaviour is preserved: [Host_config_provider.cred_root]
      and [Host_config.host ().cred_root] must hold
      the same string at module-init time. *)
-  let typed = (Masc_mcp.Host_config.host ()).cred_root in
+  let typed = (Host_config.host ()).cred_root in
   let provider = Masc_mcp.Host_config_provider.cred_root in
   (check string)
     "Host_config_provider.cred_root must equal \

--- a/test/test_pr_b_shell_paths_migration.ml
+++ b/test/test_pr_b_shell_paths_migration.ml
@@ -96,7 +96,7 @@ let test_no_zsh_literals_in_consumer_files () =
 let test_bash_binding_invoked_exactly_once () =
   let occurrences =
     count_across_files ~files:bash_consumer_files
-      ~needle:"Host_config.host"
+      ~needle:"Host_config.host ()"
   in
   (check int)
     "Host_config.host invoked exactly once across \
@@ -107,7 +107,7 @@ let test_bash_binding_invoked_exactly_once () =
 let test_zsh_binding_invoked_per_module () =
   let occurrences =
     count_across_files ~files:zsh_consumer_files
-      ~needle:"Host_config.host"
+      ~needle:"Host_config.host ()"
   in
   (check int)
     "Host_config.host invoked once per zsh consumer \
@@ -116,7 +116,7 @@ let test_zsh_binding_invoked_per_module () =
 ;;
 
 let test_host_config_field_values () =
-  let d = Masc_mcp.Host_config.host () in
+  let d = Host_config.host () in
   (check string)
     "Host_config.host ().host_bash = /bin/bash today"
     "/bin/bash" d.host_bash;

--- a/test/test_pr_c_coreutils_migration.ml
+++ b/test/test_pr_c_coreutils_migration.ml
@@ -77,10 +77,10 @@ let test_single_host_config_invocation () =
 ;;
 
 let test_coreutils_field_byte_identical () =
-  let typed = (Masc_mcp.Host_config.host ()).coreutils in
+  let typed = (Host_config.host ()).coreutils in
   (* Sample one field; all six come from the same record so a single
      equality is sufficient to detect drift. *)
-  let module H = Masc_mcp.Host_config in
+  let module H = Host_config in
   (check string) "coreutils.ls field is /bin/ls today" "/bin/ls" typed.H.ls;
   (check string) "coreutils.pwd field is /bin/pwd today" "/bin/pwd" typed.H.pwd;
   (check string) "coreutils.head field is /usr/bin/head today" "/usr/bin/head"

--- a/test/test_pr_d_agent_runtime_migration.ml
+++ b/test/test_pr_d_agent_runtime_migration.ml
@@ -80,7 +80,7 @@ let test_no_tmp_agent_literals_in_consumers () =
 let test_agent_runtime_root_binding_count () =
   let occurrences =
     count_across_files ~files:consumer_files
-      ~needle:"Host_config.host"
+      ~needle:"Host_config.host ()"
   in
   (check int)
     "Host_config.host invoked exactly once per \
@@ -89,10 +89,11 @@ let test_agent_runtime_root_binding_count () =
 ;;
 
 let test_agent_runtime_root_field_value () =
-  let d = Masc_mcp.Host_config.host () in
+  let d = Host_config.host () in
   (check string)
-    "Host_config.host ().agent_runtime_root = /tmp today"
-    "/tmp" d.agent_runtime_root
+    "Host_config.host ().agent_runtime_root follows host temp dir"
+    (Filename.get_temp_dir_name ())
+    d.agent_runtime_root
 ;;
 
 let () =

--- a/test/test_pr_e_sandbox_root_migration.ml
+++ b/test/test_pr_e_sandbox_root_migration.ml
@@ -53,7 +53,7 @@ let test_no_home_me_literal_in_worker_dev_tools () =
 ;;
 
 let test_sandbox_workspace_root_contract () =
-  let d = Masc_mcp.Host_config.host () in
+  let d = Host_config.host () in
   let acceptable_roots =
     match Sys.getenv_opt "HOME" with
     | Some home -> [ Filename.concat home "me" ]

--- a/test/test_pr_f_test_mode_migration.ml
+++ b/test/test_pr_f_test_mode_migration.ml
@@ -8,7 +8,7 @@ open Alcotest
 
     The other 4 sites enumerated in PR-12 mli §1.5 live in lower-level
     sub-libraries ([masc_config], [masc_coord], [fs_compat]) which
-    cannot call [Masc_mcp.Host_config] without inverting the dune
+    cannot call [Host_config] without inverting the dune
     dependency graph; their migration is deferred to a separate RFC
     (Host_config extraction to a shared lower-level library).  The 6th
     site ([cdal/adversarial_eval]) is a *file-classification*
@@ -94,11 +94,11 @@ let test_is_test_mode_round_trips () =
   (check bool)
     "Host_config.is_test_mode Test = true"
     true
-    (Masc_mcp.Host_config.is_test_mode Masc_mcp.Host_config.Test);
+    (Host_config.is_test_mode Host_config.Test);
   (check bool)
     "Host_config.is_test_mode Production = false"
     false
-    (Masc_mcp.Host_config.is_test_mode Masc_mcp.Host_config.Production)
+    (Host_config.is_test_mode Host_config.Production)
 ;;
 
 let () =

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -685,7 +685,7 @@ let test_startup_config_resolution_defaults_to_bootstrapped_root () =
       Alcotest.(check string) "returns base-path config root" expected
         resolution.Config_dir_resolver.config_root.path;
       Alcotest.(check (option string)) "env remains effectively unset" None
-        (Env_config_core.config_dir_opt ()))
+        ((Host_config.from_env ()).config_dir))
 
 let test_startup_config_resolution_preserves_explicit_override () =
   with_temp_dir "startup-config-activate-explicit" (fun dir ->

--- a/test/test_thompson_sampling.ml
+++ b/test/test_thompson_sampling.ml
@@ -220,7 +220,7 @@ let test_stronger_trigger_uses_winner_order () =
 
 (** {1 Quality Signal Tests (Phase 3)} *)
 
-module Pv = Masc_mcp.Post_verifier
+module Pv = Post_verifier
 module Ah = Masc_mcp.Agent_health
 
 let float_eq ?(eps = 0.001) a b = Float.abs (a -. b) < eps

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -264,7 +264,7 @@ let test_missing_base_path_without_config_fails_closed () =
       (option string)
       "blank override trims to None"
       None
-      (Env_config.config_dir_opt ());
+      ((Host_config.from_env ()).config_dir);
     match Tool_code_write.validate_clone_url ~base_path:"/nonexistent"
       "https://github.com/evil-corp/repo.git" with
   | Error _ -> ()
@@ -311,7 +311,7 @@ let test_explicit_config_dir_override_still_validates () =
       (option string)
       "explicit override survives trimming"
       (Some config_dir)
-      (Env_config.config_dir_opt ());
+      ((Host_config.from_env ()).config_dir);
     match Tool_code_write.validate_clone_url ~base_path:"/nonexistent"
       "https://github.com/evil-corp/repo.git" with
     | Error _ -> ()

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -34,7 +34,7 @@ let () =
               let tool = "__test_dispatch_single" in
               register_full ~tool_name:tool ~handler:echo_handler;
               let token = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
-              let result = Tool_dispatch.dispatch ~token ~args:`Null in
+              let result = Tool_dispatch.guarded_dispatch ~token ~args:`Null () in
               check bool "found" true (Option.is_some result);
               let tr = Option.get result in
               let ok = tr.success in
@@ -62,7 +62,7 @@ let () =
           test_case "register_module dispatches each name" `Quick (fun () ->
               let token = match Tool_dispatch.mint_token ~name:"__test_bulk_b" with Ok t -> t | Error e -> Alcotest.fail e in
               let result =
-                Tool_dispatch.dispatch ~token ~args:`Null
+                Tool_dispatch.guarded_dispatch ~token ~args:`Null ()
               in
               let tr = Option.get result in
               let ok = tr.success in
@@ -76,12 +76,12 @@ let () =
               let tool = "__test_dispatch_replace" in
               register_full ~tool_name:tool ~handler:echo_handler;
               let token1 = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
-              let result1 = Option.get (Tool_dispatch.dispatch ~token:token1 ~args:`Null) in
+              let result1 = Option.get (Tool_dispatch.guarded_dispatch ~token:token1 ~args:`Null ()) in
               let ok1 = result1.success in
               check bool "first ok" true ok1;
               register_full ~tool_name:tool ~handler:fail_handler;
               let token2 = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
-              let result2 = Option.get (Tool_dispatch.dispatch ~token:token2 ~args:`Null) in
+              let result2 = Option.get (Tool_dispatch.guarded_dispatch ~token:token2 ~args:`Null ()) in
               let ok2 = result2.success in
               let msg2 = Tool_result.message result2 in
               check bool "replaced fail" false ok2;
@@ -207,7 +207,7 @@ let () =
               register_full ~tool_name:tool ~handler:capture_handler;
               let test_args = `Assoc [("key", `String "value")] in
               let token = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
-              let _ = Tool_dispatch.dispatch ~token ~args:test_args in
+              let _ = Tool_dispatch.guarded_dispatch ~token ~args:test_args () in
               check bool "args match" true (!received_args = test_args));
         ] );
       ( "handler_exception_safety",
@@ -219,7 +219,7 @@ let () =
               in
               register_full ~tool_name:tool ~handler:throwing_handler;
               let token = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
-              let result = Tool_dispatch.dispatch ~token ~args:`Null in
+              let result = Tool_dispatch.guarded_dispatch ~token ~args:`Null () in
               check bool "still returns Some" true (Option.is_some result);
               let tr = Option.get result in
               let ok = tr.success in

--- a/test/test_tool_hooks.ml
+++ b/test/test_tool_hooks.ml
@@ -3,6 +3,7 @@
 module Tool_dispatch = Masc_mcp.Tool_dispatch
 module Tool_result = Masc_mcp.Tool_result
 module Tool_token = Masc_mcp.Tool_token
+module Dispatch_outcome = Masc_mcp.Dispatch_outcome
 
 (* Track hook execution order *)
 let call_log : string list ref = ref []
@@ -27,7 +28,7 @@ let test_pre_hook_observes () =
     log_call "pre";
     Tool_dispatch.Pass);
   let token = match Tool_dispatch.mint_token ~name:"__hook_test" with Ok t -> t | Error e -> Alcotest.fail e in
-  let result = Tool_dispatch.dispatch_structured ~token ~args:`Null in
+  let result = Tool_dispatch.guarded_dispatch ~token ~args:`Null () in
   (* Pre-hook ran, then handler *)
   Alcotest.(check (list string)) "execution order"
     ["pre"; "handler"] !call_log;
@@ -50,7 +51,7 @@ let test_pre_hook_short_circuits () =
            duration_ms = 0.0;
            failure_class = None });
   let token = match Tool_dispatch.mint_token ~name:"__hook_blocked" with Ok t -> t | Error e -> Alcotest.fail e in
-  let result = Tool_dispatch.dispatch_structured ~token ~args:`Null in
+  let result = Tool_dispatch.guarded_dispatch ~token ~args:`Null () in
   (* Handler should NOT have been called *)
   Alcotest.(check (list string)) "only pre ran" ["pre_block"] !call_log;
   match result with
@@ -85,12 +86,12 @@ let test_multiple_pre_hooks_first_wins () =
     log_call "pre3";
     Tool_dispatch.Pass);
   let token = match Tool_dispatch.mint_token ~name:"__hook_multi" with Ok t -> t | Error e -> Alcotest.fail e in
-  let _ = Tool_dispatch.dispatch_structured ~token ~args:`Null in
+  let _ = Tool_dispatch.guarded_dispatch ~token ~args:`Null () in
   (* pre1 passes, pre2 blocks, pre3 and handler never called *)
   Alcotest.(check (list string)) "chain stops at blocker"
     ["pre1"; "pre2_block"] !call_log
 
-(* --- Post-hook tests --- *)
+(* --- Typed post-hook / result-transformer tests --- *)
 
 let test_post_hook_observes () =
   setup ();
@@ -100,11 +101,12 @@ let test_post_hook_observes () =
       log_call "handler";
       Some (Tool_result.quick_ok "original"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_post" ~tag:Mod_misc;
-  Tool_dispatch.register_post_hook (fun r ->
-    log_call "post";
-    r);
+  Tool_dispatch.register_typed_post_hook (fun outcome result ->
+    match outcome, result with
+    | Dispatch_outcome.Handled, Some _ -> log_call "post"
+    | _ -> Alcotest.fail "expected handled typed post-hook");
   let token = match Tool_dispatch.mint_token ~name:"__hook_post" with Ok t -> t | Error e -> Alcotest.fail e in
-  let result = Tool_dispatch.dispatch_structured ~token ~args:`Null in
+  let result = Tool_dispatch.guarded_dispatch ~token ~args:`Null () in
   Alcotest.(check (list string)) "handler then post"
     ["handler"; "post"] !call_log;
   match result with
@@ -118,10 +120,10 @@ let test_post_hook_transforms () =
     ~handler:(fun ~name:_ ~args:_ ->
       Some (Tool_result.quick_ok "original"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_transform" ~tag:Mod_misc;
-  Tool_dispatch.register_post_hook (fun r ->
+  Tool_dispatch.set_result_transformer (fun r ->
     { r with Tool_result.data = `String "transformed" });
   let token = match Tool_dispatch.mint_token ~name:"__hook_transform" with Ok t -> t | Error e -> Alcotest.fail e in
-  match Tool_dispatch.dispatch_structured ~token ~args:`Null with
+  match Tool_dispatch.guarded_dispatch ~token ~args:`Null () with
   | Some r ->
     (match r.data with
      | `String "transformed" -> ()
@@ -135,19 +137,43 @@ let test_post_hooks_chain () =
     ~handler:(fun ~name:_ ~args:_ ->
       Some (Tool_result.quick_ok "0"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_chain" ~tag:Mod_misc;
-  Tool_dispatch.register_post_hook (fun r ->
-    log_call "post1";
-    { r with Tool_result.data = `String "1" });
-  Tool_dispatch.register_post_hook (fun r ->
-    log_call "post2";
-    { r with Tool_result.data = `String "2" });
+  Tool_dispatch.register_typed_post_hook (fun outcome result ->
+    match outcome, result with
+    | Dispatch_outcome.Handled, Some _ -> log_call "post1"
+    | _ -> Alcotest.fail "expected handled typed post-hook");
+  Tool_dispatch.register_typed_post_hook (fun outcome result ->
+    match outcome, result with
+    | Dispatch_outcome.Handled, Some _ -> log_call "post2"
+    | _ -> Alcotest.fail "expected handled typed post-hook");
   let token = match Tool_dispatch.mint_token ~name:"__hook_chain" with Ok t -> t | Error e -> Alcotest.fail e in
-  match Tool_dispatch.dispatch_structured ~token ~args:`Null with
+  match Tool_dispatch.guarded_dispatch ~token ~args:`Null () with
   | Some r ->
     Alcotest.(check (list string)) "post order" ["post1"; "post2"] !call_log;
     (match r.data with
+     | `String "0" -> ()
+     | _ -> Alcotest.fail "typed post-hooks must not transform results")
+  | None -> Alcotest.fail "expected Some"
+
+let test_result_transformer_chain_replaces_previous () =
+  setup ();
+  Tool_dispatch.register
+    ~tool_name:"__hook_transform_replace"
+    ~handler:(fun ~name:_ ~args:_ ->
+      Some (Tool_result.quick_ok "0"));
+  Tool_dispatch.register_name_tag ~tool_name:"__hook_transform_replace" ~tag:Mod_misc;
+  Tool_dispatch.set_result_transformer (fun r ->
+    log_call "post1";
+    { r with Tool_result.data = `String "1" });
+  Tool_dispatch.set_result_transformer (fun r ->
+    log_call "post2";
+    { r with Tool_result.data = `String "2" });
+  let token = match Tool_dispatch.mint_token ~name:"__hook_transform_replace" with Ok t -> t | Error e -> Alcotest.fail e in
+  match Tool_dispatch.guarded_dispatch ~token ~args:`Null () with
+  | Some r ->
+    Alcotest.(check (list string)) "latest transformer only" ["post2"] !call_log;
+    (match r.data with
      | `String "2" -> ()
-     | _ -> Alcotest.fail "final post-hook should win")
+     | _ -> Alcotest.fail "latest result transformer should win")
   | None -> Alcotest.fail "expected Some"
 
 (* --- Full lifecycle --- *)
@@ -163,11 +189,12 @@ let test_full_lifecycle () =
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre";
     Tool_dispatch.Pass);
-  Tool_dispatch.register_post_hook (fun r ->
-    log_call "post";
-    r);
+  Tool_dispatch.register_typed_post_hook (fun outcome result ->
+    match outcome, result with
+    | Dispatch_outcome.Handled, Some _ -> log_call "post"
+    | _ -> Alcotest.fail "expected handled typed post-hook");
   let token = match Tool_dispatch.mint_token ~name:"__hook_full" with Ok t -> t | Error e -> Alcotest.fail e in
-  let _ = Tool_dispatch.dispatch_structured ~token ~args:`Null in
+  let _ = Tool_dispatch.guarded_dispatch ~token ~args:`Null () in
   Alcotest.(check (list string)) "pre → handler → post"
     ["pre"; "handler"; "post"] !call_log
 
@@ -176,10 +203,10 @@ let test_no_hooks_default () =
   (* No hooks registered *)
   Tool_dispatch.register
     ~tool_name:"__hook_none"
-    ~handler:(fun ~name:_ ~args:_ -> Some (Tool_result.quick_ok "plain"));
+    ~handler:(fun ~name ~args:_ -> Some (Tool_result.quick_ok ~tool_name:name "plain"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_none" ~tag:Mod_misc;
   let token = match Tool_dispatch.mint_token ~name:"__hook_none" with Ok t -> t | Error e -> Alcotest.fail e in
-  match Tool_dispatch.dispatch_structured ~token ~args:`Null with
+  match Tool_dispatch.guarded_dispatch ~token ~args:`Null () with
   | Some r ->
     Alcotest.(check bool) "success" true r.success;
     Alcotest.(check string) "tool_name" "__hook_none" r.tool_name
@@ -190,9 +217,8 @@ let test_unknown_tool_skips_hooks () =
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre_should_not_run";
     Tool_dispatch.Pass);
-  Tool_dispatch.register_post_hook (fun r ->
-    log_call "post_should_not_run";
-    r);
+  Tool_dispatch.register_typed_post_hook (fun _outcome _result ->
+    log_call "post_should_not_run");
   match Tool_dispatch.mint_token ~name:"__nonexistent_hook" with
   | Error _ ->
     (* mint_token rejects unregistered tools; no hooks run *)
@@ -210,6 +236,10 @@ let () =
       Alcotest.test_case "observe" `Quick test_post_hook_observes;
       Alcotest.test_case "transform" `Quick test_post_hook_transforms;
       Alcotest.test_case "chain order" `Quick test_post_hooks_chain;
+      Alcotest.test_case
+        "latest transformer wins"
+        `Quick
+        test_result_transformer_chain_replaces_previous;
     ];
     "lifecycle", [
       Alcotest.test_case "pre→handler→post" `Quick test_full_lifecycle;

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -107,7 +107,7 @@ let test_dispatch_structured () =
     | Ok t -> t
     | Error e -> Alcotest.fail e
   in
-  match Tool_dispatch.dispatch_structured ~token ~args:`Null with
+  match Tool_dispatch.guarded_dispatch ~token ~args:`Null () with
   | Some r ->
     Alcotest.(check bool) "success" true r.success;
     Alcotest.(check string) "tool_name" "__test_tool" r.tool_name;

--- a/test/test_tool_token.ml
+++ b/test/test_tool_token.ml
@@ -100,7 +100,7 @@ let test_dispatch_with_token () =
   match Tool_dispatch.mint_token ~name:tool with
   | Error e -> fail e
   | Ok token ->
-    match Tool_dispatch.dispatch ~token ~args:`Null with
+    match Tool_dispatch.guarded_dispatch ~token ~args:`Null () with
     | Some tr ->
       let ok = tr.success in
       let msg = Tool_result.message tr in


### PR DESCRIPTION
## Summary
- update stale tests to use current leaf modules and guarded dispatch APIs
- remove retired cascade server-error weighted-random assertions instead of restoring old public APIs
- update host/config assertions to current Host_config.from_env and host temp-dir contracts

## Verification
- scripts/dune-local.sh build test/test_cascade_trust_persist.exe test/test_tool_hooks.exe test/test_otel_genai.exe test/test_tool_dispatch.exe test/test_tool_token.exe test/test_tool_result.exe test/test_briefing_json_helpers.exe test/test_thompson_sampling.exe test/test_pr_a_cred_root_migration.exe test/test_pr_b_shell_paths_migration.exe test/test_pr_c_coreutils_migration.exe test/test_pr_d_agent_runtime_migration.exe test/test_pr_e_sandbox_root_migration.exe test/test_pr_f_test_mode_migration.exe test/test_oas_worker.exe test/test_cascade_strategy.exe
- scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe test/test_tool_code_write_coverage.exe
- scripts/dune-local.sh build @default