### PR TITLE
[codex] Harden keeper 24 fleet pressure controls

### DIFF
--- a/docs/audit/2026-05-15-keeper-24-risk-remediation-plan.md
+++ b/docs/audit/2026-05-15-keeper-24-risk-remediation-plan.md
@@ -1,0 +1,115 @@
+# Keeper 24 Risk Remediation Plan
+
+Date: 2026-05-15
+
+Inputs:
+
+- Report: `/Users/dancer/me/memory/keeper-24-risk-report-2026-05-15.html`
+- Runtime logs: `/Users/dancer/me/.masc/logs/system_log_2026-05-15.jsonl`
+- Coverage gap: `/Users/dancer/me/.masc/telemetry-coverage-gaps/2026-05/15.jsonl`
+
+## Finding
+
+The likely fleet-stop mechanism is FD exhaustion plus write/spawn fanout, not a
+single classical deadlock. The live log sequence at 2026-05-15T03:52:50Z shows
+`fstatat`, `openat`, `mkdirat`, and `execve` failing with "Too many open files
+in system". Once that starts, runtime manifests, coverage gaps, cost events,
+tool logs, OAS events, activity events, keeper meta reads, progress snapshots,
+and docker subprocess checks all fail in the same window.
+
+## Code-Level Remediation
+
+1. FD pressure guard:
+   - Add a process-local circuit breaker for EMFILE/ENFILE text.
+   - Trip it from central keeper error and keeper filesystem failure paths.
+   - While tripped, block new keeper spawn slots and skip turn scheduling until
+     cooldown expires.
+   - Cap active keeper bootstrap when the process inherited `nofile` soft limit
+     is below the 24-keeper floor.
+   - Add proactive fleet-resource admission: compute the projected FD budget
+     from current open FDs, active keepers, starting keepers, per-keeper
+     estimate, and headroom. Block spawn/turn admission before the projected
+     budget crosses the inherited `nofile` soft limit.
+   - Pin the admission invariant with `KeeperFleetPressureAdmission.tla`: clean
+     model must pass, buggy model must violate `Safety`.
+
+2. Turn slot release:
+   - Force-release held turn/reactive/autonomous slots before manual
+     `stop_keepalive` marks a keeper stopped.
+   - This prevents a stopped keeper from continuing to occupy a semaphore slot.
+
+3. Event queue cost:
+   - Replace list append enqueue with a two-list FIFO queue.
+   - Preserve FIFO dequeue semantics while making enqueue O(1).
+
+4. Tool metrics backpressure:
+   - Keep the bounded 4096 queue, but drop best-effort metrics when full instead
+     of blocking the tool completion path.
+
+5. Memory cycle:
+   - Read memory bank tails from the end of the file instead of loading the full
+     file for recall.
+   - Serialize memory bank append/rewrite per path with an Eio-aware mutex.
+   - Preserve rows appended after compaction's initial read by re-reading under
+     the lock before rewrite.
+
+## Verification Plan
+
+- Build focused targets for the touched keeper/runtime tests.
+- Run:
+  - `test_keeper_registry.exe`
+  - `test_heartbeat_integration.exe`
+  - `test_keeper_memory.exe`
+  - `test_tool_metrics_persist.exe`
+  - `test_keeper_event_queue.exe`
+- Confirm the 2026-05-15 runtime logs still map to the patched failure paths:
+  FD pressure, tool metrics backpressure, memory tail read, manual stop slot
+  cleanup, and event queue cost.
+- Check current local keeper runtime status. If no server is listening, record
+  that live keeper verification is unavailable and use the focused keeper tests
+  as the verification surface for this patch.
+
+## Verification Status
+
+Checked on 2026-05-15 from
+`/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-24-fleet-risk-controls`.
+
+- `git diff --check`: passed.
+- `env DUNE_JOBS=1 scripts/dune-local.sh build ./test/test_keeper_registry.exe ./test/test_heartbeat_integration.exe ./test/test_keeper_memory.exe ./test/test_tool_metrics_persist.exe ./test/test_keeper_event_queue.exe`:
+  passed.
+- `./_build/default/test/test_keeper_registry.exe`: passed, 89 tests.
+- `./_build/default/test/test_heartbeat_integration.exe`: passed, 20 tests.
+- `./_build/default/test/test_keeper_memory.exe`: passed, 79 tests.
+- `./_build/default/test/test_tool_metrics_persist.exe`: passed, 5 tests.
+- `./_build/default/test/test_keeper_event_queue.exe`: passed.
+- Runtime log evidence still maps to this patch: system log seq
+  `50483`-`50518` on 2026-05-15T03:52:50Z-03:53:43Z shows
+  `fstatat`, `openat`, `mkdirat`, and `execve` failures with "Too many open
+  files in system"; coverage gap line 1 records
+  `tool_call_io_append_failed` for `imseonghan/keeper_broadcast`.
+- Host limit check: `ulimit -n` returned `245760`; `sysctl kern.maxfiles
+  kern.maxfilesperproc` returned `491520` and `245760`.
+- Live endpoint check: `127.0.0.1:8935` was not listening, so live keeper
+  endpoint verification was unavailable in this pass.
+
+Follow-up hardening check after proactive admission/TLA+ addition:
+
+- `bash scripts/audit-tla-ml-line-refs.sh`: passed, 34 keeper-state-machine
+  specs checked.
+- `env DUNE_JOBS=1 scripts/dune-local.sh build ./test/test_keeper_registry.exe ./test/test_heartbeat_integration.exe`:
+  passed.
+- `./_build/default/test/test_keeper_registry.exe`: passed, 89 tests.
+- `./_build/default/test/test_heartbeat_integration.exe`: passed, 20 tests.
+- `KeeperFleetPressureAdmission.cfg`: TLC clean model passed, 49 distinct
+  states.
+- `KeeperFleetPressureAdmission-buggy.cfg`: TLC buggy model violated `Safety`
+  as intended, exit 12.
+
+## Remaining Operational Work
+
+- Host-level nofile configuration is still required for sustained 24-keeper
+  operation. This patch degrades or cools down when the inherited process limit
+  is unsafe; it does not raise the host limit.
+- A future dashboard follow-up should expose FD-pressure cooldown as first-class
+  partial-truth state, so missing telemetry is shown as "recording failed" rather
+  than as an empty trace.

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -38,6 +38,9 @@ let ensure_dir (path : string) : string =
             Log.Keeper.warn "keeper_fs: ensure_dir cancelled path=%s" path;
             Error (exn, Printexc.get_raw_backtrace ())
         | exn ->
+            Keeper_fd_pressure.note_if_fd_exhaustion
+              ~site:"keeper_fs.ensure_dir"
+              (Printexc.to_string exn);
             Prometheus.inc_counter
               Keeper_metrics.metric_keeper_fs_failures
               ~labels:[("path", path); ("site", Fs_failure_site.(to_label Ensure_dir_failed))]
@@ -77,6 +80,9 @@ let save_atomic (path : string) (content : string) : (unit, string) result =
     match Fs_compat.save_file_atomic path content with
     | Ok () -> Ok ()
     | Error msg ->
+        Keeper_fd_pressure.note_if_fd_exhaustion
+          ~site:"keeper_fs.save_atomic"
+          msg;
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_fs_failures
           ~labels:[("path", path); ("site", Fs_failure_site.(to_label Save_atomic_failed))]
@@ -87,6 +93,9 @@ let save_atomic (path : string) (content : string) : (unit, string) result =
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
       let msg = Printexc.to_string exn in
+      Keeper_fd_pressure.note_if_fd_exhaustion
+        ~site:"keeper_fs.save_atomic"
+        msg;
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_fs_failures
         ~labels:[("path", path); ("site", Fs_failure_site.(to_label Save_atomic_raised))]

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -1103,6 +1103,24 @@ let run_keepalive_unified_turn
           ~keeper_name:meta_after_triage.name);
       if Atomic.get stop
       then meta_after_cursor_persist
+      else if should_run_turn && Keeper_fd_pressure.active ()
+      then (
+        Log.Keeper.debug
+          "%s: skipping turn while fd-pressure circuit breaker is active (remaining=%.0fs)"
+          meta_after_triage.name
+          (Keeper_fd_pressure.remaining_sec ());
+        meta_after_cursor_persist)
+      else if
+        should_run_turn
+        && not
+             (Keeper_fd_pressure.admit_turn
+                ~active_keepers:(Keeper_registry.count_running ())
+                ())
+      then (
+        Log.Keeper.debug
+          "%s: skipping turn because projected FD budget is exhausted before pressure"
+          meta_after_triage.name;
+        meta_after_cursor_persist)
       else if should_run_turn
       then (
         (* Admission wait happens before [mark_turn_started], so the stale

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -774,6 +774,13 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
 ;;
 
 let stop_keepalive ?base_path name =
+  let eio_context_available () =
+    try
+      Eio.Fiber.yield ();
+      true
+    with
+    | Effect.Unhandled _ -> false
+  in
   let entries =
     Keeper_registry.all ?base_path ()
     |> List.filter (fun (e : Keeper_registry.registry_entry) -> String.equal e.name name)
@@ -801,6 +808,16 @@ let stop_keepalive ?base_path name =
        match entry.phase with
        | Keeper_state_machine.Crashed | Keeper_state_machine.Dead -> ()
        | _ ->
+         let released_slots =
+           if eio_context_available ()
+           then force_release_holder_for ~keeper_name:entry.name
+           else []
+         in
+         if released_slots <> [] then
+           Log.Keeper.warn
+             "%s: manual stop force-released holder slot(s) [%s] before marking stopped"
+             entry.name
+             (String.concat "," (List.map fst released_slots));
          if
            record_keeper_stopped
              entry

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -46,6 +46,24 @@ open Keeper_types
 
 include Keeper_memory_policy
 
+let memory_bank_locks_mu = Eio.Mutex.create ()
+let memory_bank_locks : (string, Eio.Mutex.t) Hashtbl.t = Hashtbl.create 64
+
+let memory_bank_lock_for path =
+  Eio_guard.with_mutex memory_bank_locks_mu (fun () ->
+    match Hashtbl.find_opt memory_bank_locks path with
+    | Some mutex -> mutex
+    | None ->
+      let mutex = Eio.Mutex.create () in
+      Hashtbl.add memory_bank_locks path mutex;
+      mutex)
+;;
+
+let with_memory_bank_lock path f =
+  let mutex = memory_bank_lock_for path in
+  Eio_guard.with_mutex mutex f
+;;
+
 type candidate_selection_result = {
   selected: (string * string * int) list;
   dropped_by_kind: (string * int) list;
@@ -361,6 +379,24 @@ let parse_memory_bank_row (line : string) : keeper_memory_row_raw option =
   with Yojson.Json_error _ ->
     None
 
+let parse_memory_bank_content content =
+  let lines =
+    content
+    |> String.split_on_char '\n'
+    |> List.filter (fun s -> String.trim s <> "")
+  in
+  let parsed_rev, invalid =
+    List.fold_left
+      (fun (acc, inv) line ->
+         match parse_memory_bank_row line with
+         | Some row -> row :: acc, inv
+         | None -> acc, inv + 1)
+      ([], 0)
+      lines
+  in
+  List.rev parsed_rev, invalid
+;;
+
 (* ── Memory Consolidation ───────────────────────────────── *)
 
 (** Extract trace_id from a memory row's JSON. *)
@@ -575,7 +611,7 @@ let compaction_priority
   in
   max 1 (min 120 (row.priority + horizon_bonus + source_bonus))
 
-let write_memory_bank_rows
+let write_memory_bank_rows_unlocked
     (path : string)
     (rows : keeper_memory_row_raw list) : (unit, string) result =
   try
@@ -589,6 +625,10 @@ let write_memory_bank_rows
     Fs_compat.save_file_atomic path content
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "failed to rewrite memory bank: %s" (Printexc.to_string exn))
+
+let write_memory_bank_rows path rows =
+  with_memory_bank_lock path (fun () -> write_memory_bank_rows_unlocked path rows)
+;;
 
 let drop_memory_rows n rows =
   let rec go remaining rest =
@@ -607,6 +647,46 @@ let consolidation_metric_source source =
 
 let memory_row_identity (row : keeper_memory_row_raw) =
   Yojson.Safe.to_string row.json
+
+let identity_counts rows =
+  let counts : (string, int) Hashtbl.t = Hashtbl.create (max 16 (List.length rows)) in
+  List.iter
+    (fun row ->
+       let id = memory_row_identity row in
+       let cur = Option.value ~default:0 (Hashtbl.find_opt counts id) in
+       Hashtbl.replace counts id (cur + 1))
+    rows;
+  counts
+;;
+
+let consume_identity counts row =
+  let id = memory_row_identity row in
+  match Hashtbl.find_opt counts id with
+  | Some n when n > 1 ->
+    Hashtbl.replace counts id (n - 1);
+    true
+  | Some _ ->
+    Hashtbl.remove counts id;
+    true
+  | None -> false
+;;
+
+let rewrite_memory_bank_preserving_concurrent_appends ~path ~base_rows selected =
+  with_memory_bank_lock path (fun () ->
+    let selected =
+      match Safe_ops.read_file_safe path with
+      | Error _ -> selected
+      | Ok current_content ->
+        let current_rows, _invalid = parse_memory_bank_content current_content in
+        let base_counts = identity_counts base_rows in
+        let concurrent_rows =
+          current_rows
+          |> List.filter (fun row -> not (consume_identity base_counts row))
+        in
+        if concurrent_rows = [] then selected else selected @ concurrent_rows
+    in
+    write_memory_bank_rows_unlocked path selected)
+;;
 
 let count_rows_by_consolidation_source rows =
   rows
@@ -678,207 +758,189 @@ let compact_memory_bank_if_needed
     in
     let trigger_bytes = memory_compaction_trigger_bytes ~target_notes in
     match Safe_ops.read_file_safe path with
-      | Error _ ->
+    | Error _ ->
+      { no_memory_bank_compaction with
+        target_notes;
+        reason = Some "read_failed";
+      }
+    | Ok content ->
+      let parsed, invalid = parse_memory_bank_content content in
+      let before_notes = List.length parsed in
+      if size_bytes < trigger_bytes && before_notes <= target_notes && invalid = 0
+      then
+        { no_memory_bank_compaction with
+          target_notes;
+          before_notes;
+          after_notes = before_notes;
+          reason = Some "under_trigger_bytes";
+        }
+      else if before_notes <= target_notes && invalid = 0 then
+        { no_memory_bank_compaction with
+          target_notes;
+          before_notes;
+          after_notes = before_notes;
+          reason = Some "under_target";
+        }
+      else
+        (* Consolidation: merge progress clusters and promote recurring notes *)
+        let consolidated_parsed, consolidated_count =
+          consolidate_memory_notes ?summarizer parsed
+        in
+        let generated_consolidated =
+          drop_memory_rows before_notes consolidated_parsed
+        in
+        if consolidated_count > 0 then
+          record_memory_consolidation_metrics
+            ~keeper_name:meta.name
+            ~outcome:"generated"
+            generated_consolidated;
+        let current_generation = meta.runtime.generation in
+        let by_recency =
+          List.sort
+            (fun (a : keeper_memory_row_raw) (b : keeper_memory_row_raw) ->
+              let c = compare b.ts_unix a.ts_unix in
+              if c <> 0 then c
+              else
+                compare
+                  (compaction_priority ~current_generation b)
+                  (compaction_priority ~current_generation a))
+            consolidated_parsed
+        in
+        let deduped = dedup_by_key memory_row_key by_recency in
+        let dedup_dropped = max 0 (before_notes - List.length deduped) in
+        if List.length deduped <= target_notes && dedup_dropped = 0 && invalid = 0
+        then
           { no_memory_bank_compaction with
             target_notes;
-            reason = Some "read_failed";
+            before_notes;
+            after_notes = before_notes;
+            reason = Some "already_compact";
           }
-      | Ok content ->
-          let lines =
-            content
-            |> String.split_on_char '\n'
-            |> List.filter (fun s -> String.trim s <> "")
+        else
+          let kind_caps = memory_kind_caps_for_compaction ~target_notes in
+          let kind_used : (string, int) Hashtbl.t = Hashtbl.create 16 in
+          let selected_keys : (string, unit) Hashtbl.t = Hashtbl.create 1024 in
+          let kind_dropped_keys : (string, string) Hashtbl.t = Hashtbl.create 256 in
+          let selected_rev = ref [] in
+          let selected_count = ref 0 in
+          let fallback_kind_cap = max 8 (target_notes / 8) in
+          let yield_meter = Eio_guard.create_yield_meter () in
+          let add_row ~ignore_kind_cap (row : keeper_memory_row_raw) =
+            Eio_guard.yield_step yield_meter;
+            if !selected_count >= target_notes then
+              ()
+            else
+              let key = memory_row_key row in
+              if key = "" || Hashtbl.mem selected_keys key then
+                ()
+              else
+                let used =
+                  Option.value ~default:0 (Hashtbl.find_opt kind_used row.kind)
+                in
+                let cap =
+                  Option.value
+                    ~default:fallback_kind_cap
+                    (Hashtbl.find_opt kind_caps row.kind)
+                in
+                if ignore_kind_cap || used < cap then begin
+                  Hashtbl.remove kind_dropped_keys key;
+                  Hashtbl.add selected_keys key ();
+                  Hashtbl.replace kind_used row.kind (used + 1);
+                  selected_rev := row :: !selected_rev;
+                  incr selected_count
+                end else
+                  Hashtbl.replace kind_dropped_keys key row.kind
           in
-          let (parsed_rev, invalid) =
-            List.fold_left
-              (fun (acc, inv) line ->
-                match parse_memory_bank_row line with
-                | Some row -> (row :: acc, inv)
-                | None -> (acc, inv + 1))
-              ([], 0) lines
+          let recent_floor = max 16 (min 64 (target_notes / 5)) in
+          by_recency
+          |> take recent_floor
+          |> List.iter (fun row -> add_row ~ignore_kind_cap:false row);
+          let by_priority =
+            List.sort
+              (fun (a : keeper_memory_row_raw) (b : keeper_memory_row_raw) ->
+                let c =
+                  compare
+                    (compaction_priority ~current_generation b)
+                    (compaction_priority ~current_generation a)
+                in
+                if c <> 0 then c else compare b.ts_unix a.ts_unix)
+              deduped
           in
-          let parsed = List.rev parsed_rev in
-          let before_notes = List.length parsed in
-          if
-            size_bytes < trigger_bytes
-            && before_notes <= target_notes
-            && invalid = 0
-          then
+          List.iter (fun row -> add_row ~ignore_kind_cap:false row) by_priority;
+          if !selected_count < target_notes then
+            List.iter (fun row -> add_row ~ignore_kind_cap:true row) by_recency;
+          let selected =
+            !selected_rev
+            |> List.rev
+            |> List.sort (fun (a : keeper_memory_row_raw) (b : keeper_memory_row_raw) ->
+              let c = compare a.ts_unix b.ts_unix in
+              if c <> 0 then c else compare a.priority b.priority)
+          in
+          let after_notes = List.length selected in
+          let dropped_notes = max 0 (before_notes - after_notes) in
+          let dropped_by_kind =
+            Hashtbl.to_seq kind_dropped_keys
+            |> Seq.fold_left
+                 (fun acc (_, kind) ->
+                   let cur = Option.value ~default:0 (List.assoc_opt kind acc) in
+                   (kind, cur + 1) :: List.remove_assoc kind acc)
+                 []
+            |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+          in
+          if dropped_notes = 0 && invalid = 0 then
             { no_memory_bank_compaction with
               target_notes;
               before_notes;
-              after_notes = before_notes;
-              reason = Some "under_trigger_bytes";
-            }
-          else if before_notes <= target_notes && invalid = 0 then
-            { no_memory_bank_compaction with
-              target_notes;
-              before_notes;
-              after_notes = before_notes;
-              reason = Some "under_target";
+              after_notes;
+              dedup_dropped;
+              reason = Some "no_reduction";
             }
           else
-            (* Consolidation: merge progress clusters and promote recurring notes *)
-            let (consolidated_parsed, consolidated_count) =
-              consolidate_memory_notes ?summarizer parsed
-            in
-            let generated_consolidated =
-              drop_memory_rows before_notes consolidated_parsed
-            in
-            if consolidated_count > 0 then
+            match
+              rewrite_memory_bank_preserving_concurrent_appends
+                ~path
+                ~base_rows:parsed
+                selected
+            with
+            | Error _ ->
               record_memory_consolidation_metrics
                 ~keeper_name:meta.name
-                ~outcome:"generated"
+                ~outcome:"write_failed"
                 generated_consolidated;
-            let current_generation = meta.runtime.generation in
-            let by_recency =
-              List.sort
-                (fun (a : keeper_memory_row_raw) (b : keeper_memory_row_raw) ->
-                  let c = compare b.ts_unix a.ts_unix in
-                  if c <> 0 then c
-                  else
-                    compare
-                      (compaction_priority ~current_generation b)
-                      (compaction_priority ~current_generation a))
-                consolidated_parsed
-            in
-            let deduped = dedup_by_key memory_row_key by_recency in
-            let dedup_dropped = max 0 (before_notes - List.length deduped) in
-            if List.length deduped <= target_notes && dedup_dropped = 0 && invalid = 0 then
               { no_memory_bank_compaction with
                 target_notes;
                 before_notes;
                 after_notes = before_notes;
-                reason = Some "already_compact";
+                dedup_dropped;
+                invalid_dropped = invalid;
+                reason = Some "write_failed";
               }
-            else
-              let kind_caps =
-                memory_kind_caps_for_compaction ~target_notes
+            | Ok () ->
+              let retained =
+                retained_generated_rows ~generated:generated_consolidated selected
               in
-              let kind_used : (string, int) Hashtbl.t = Hashtbl.create 16 in
-              let selected_keys : (string, unit) Hashtbl.t = Hashtbl.create 1024 in
-              let kind_dropped_keys : (string, string) Hashtbl.t = Hashtbl.create 256 in
-              let selected_rev = ref [] in
-              let selected_count = ref 0 in
-              let fallback_kind_cap = max 8 (target_notes / 8) in
-              let yield_meter = Eio_guard.create_yield_meter () in
-              let add_row ~ignore_kind_cap (row : keeper_memory_row_raw) =
-                Eio_guard.yield_step yield_meter;
-                if !selected_count >= target_notes then
-                  ()
-                else
-                  let key = memory_row_key row in
-                  if key = "" || Hashtbl.mem selected_keys key then
-                    ()
-                  else
-                    let used =
-                      Option.value ~default:0 (Hashtbl.find_opt kind_used row.kind)
-                    in
-                    let cap =
-                      Option.value ~default:fallback_kind_cap
-                        (Hashtbl.find_opt kind_caps row.kind)
-                    in
-                    if ignore_kind_cap || used < cap then begin
-                      Hashtbl.remove kind_dropped_keys key;
-                      Hashtbl.add selected_keys key ();
-                      Hashtbl.replace kind_used row.kind (used + 1);
-                      selected_rev := row :: !selected_rev;
-                      incr selected_count
-                    end else
-                      Hashtbl.replace kind_dropped_keys key row.kind
+              let evicted =
+                evicted_generated_rows ~generated:generated_consolidated ~retained
               in
-              let recent_floor = max 16 (min 64 (target_notes / 5)) in
-              by_recency
-              |> take recent_floor
-              |> List.iter (fun row -> add_row ~ignore_kind_cap:false row);
-              let by_priority =
-                List.sort
-                  (fun (a : keeper_memory_row_raw) (b : keeper_memory_row_raw) ->
-                    let c =
-                      compare
-                        (compaction_priority ~current_generation b)
-                        (compaction_priority ~current_generation a)
-                    in
-                    if c <> 0 then c else compare b.ts_unix a.ts_unix)
-                  deduped
-              in
-              List.iter (fun row -> add_row ~ignore_kind_cap:false row) by_priority;
-              if !selected_count < target_notes then
-                List.iter (fun row -> add_row ~ignore_kind_cap:true row) by_recency;
-              let selected =
-                !selected_rev
-                |> List.rev
-                |> List.sort
-                     (fun (a : keeper_memory_row_raw) (b : keeper_memory_row_raw) ->
-                       let c = compare a.ts_unix b.ts_unix in
-                       if c <> 0 then c else compare a.priority b.priority)
-              in
-              let after_notes = List.length selected in
-              let dropped_notes = max 0 (before_notes - after_notes) in
-              let dropped_by_kind =
-                Hashtbl.to_seq kind_dropped_keys
-                |> Seq.fold_left
-                     (fun acc (_, kind) ->
-                       let cur =
-                         Option.value ~default:0 (List.assoc_opt kind acc)
-                       in
-                       (kind, cur + 1) :: List.remove_assoc kind acc)
-                     []
-                |> List.sort (fun (a, _) (b, _) -> String.compare a b)
-              in
-              if dropped_notes = 0 && invalid = 0 then
-                { no_memory_bank_compaction with
-                  target_notes;
-                  before_notes;
-                  after_notes;
-                  dedup_dropped;
-                  reason = Some "no_reduction";
-                }
-              else
-                match write_memory_bank_rows path selected with
-                | Error _ ->
-                    record_memory_consolidation_metrics
-                      ~keeper_name:meta.name
-                      ~outcome:"write_failed"
-                      generated_consolidated;
-                    { no_memory_bank_compaction with
-                      target_notes;
-                      before_notes;
-                      after_notes = before_notes;
-                      dedup_dropped;
-                      invalid_dropped = invalid;
-                      reason = Some "write_failed";
-                    }
-                | Ok () ->
-                    let retained =
-                      retained_generated_rows
-                        ~generated:generated_consolidated
-                        selected
-                    in
-                    let evicted =
-                      evicted_generated_rows
-                        ~generated:generated_consolidated
-                        ~retained
-                    in
-                    record_memory_consolidation_metrics
-                      ~keeper_name:meta.name
-                      ~outcome:"persisted"
-                      retained;
-                    record_memory_consolidation_metrics
-                      ~keeper_name:meta.name
-                      ~outcome:"evicted"
-                      evicted;
-                    {
-                      performed = true;
-                      reason = Some "compacted";
-                      target_notes;
-                      before_notes;
-                      after_notes;
-                      dropped_notes;
-                      dedup_dropped;
-                      invalid_dropped = invalid;
-                      dropped_by_kind;
-                    }
+              record_memory_consolidation_metrics
+                ~keeper_name:meta.name
+                ~outcome:"persisted"
+                retained;
+              record_memory_consolidation_metrics
+                ~keeper_name:meta.name
+                ~outcome:"evicted"
+                evicted;
+              {
+                performed = true;
+                reason = Some "compacted";
+                target_notes;
+                before_notes;
+                after_notes;
+                dropped_notes;
+                dedup_dropped;
+                invalid_dropped = invalid;
+                dropped_by_kind;
+              }
 
 let append_memory_notes_from_reply
     (config : Coord.config)
@@ -925,30 +987,31 @@ let append_memory_notes_from_reply
     let path = keeper_memory_bank_path config meta.name in
     let kinds_acc = ref [] in
     let seen_kinds : (string, unit) Hashtbl.t = Hashtbl.create 8 in
-    List.iter
-      (fun (kind, text, priority) ->
-        let horizon = memory_horizon_of_kind kind in
-        if not (Hashtbl.mem seen_kinds kind) then begin
-          Hashtbl.add seen_kinds kind ();
-          kinds_acc := kind :: !kinds_acc
-        end;
-        append_jsonl_line path
-          (`Assoc
-            [
-              ("ts", `String (now_iso ()));
-              ("ts_unix", `Float now_ts);
-              ("name", `String meta.name);
-              ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
-              ("generation", `Int meta.runtime.generation);
-              ("turn", `Int turn);
-              ("kind", `String kind);
-              ("horizon", `String horizon);
-              ("source", `String source);
-              ("schema_version", `Int keeper_memory_schema_version);
-              ("priority", `Int priority);
-              ("text", `String text);
-            ]))
-      notes;
+    with_memory_bank_lock path (fun () ->
+      List.iter
+        (fun (kind, text, priority) ->
+           let horizon = memory_horizon_of_kind kind in
+           if not (Hashtbl.mem seen_kinds kind) then begin
+             Hashtbl.add seen_kinds kind ();
+             kinds_acc := kind :: !kinds_acc
+           end;
+           append_jsonl_line path
+             (`Assoc
+               [
+                 ("ts", `String (now_iso ()));
+                 ("ts_unix", `Float now_ts);
+                 ("name", `String meta.name);
+                 ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
+                 ("generation", `Int meta.runtime.generation);
+                 ("turn", `Int turn);
+                 ("kind", `String kind);
+                 ("horizon", `String horizon);
+                 ("source", `String source);
+                 ("schema_version", `Int keeper_memory_schema_version);
+                 ("priority", `Int priority);
+                 ("text", `String text);
+               ]))
+        notes);
     (List.length notes, List.rev !kinds_acc)
 
 let strip_tool_result_reserved_keys (result : Yojson.Safe.t) : Yojson.Safe.t =
@@ -996,50 +1059,46 @@ let append_memory_notes_from_tool_results
   let path = keeper_memory_bank_path config meta.name in
   let seen_artifacts : (string, unit) Hashtbl.t = Hashtbl.create 16 in
   let written = ref 0 in
-  List.iter
-    (fun result ->
-      match
-        ( Multimodal.Tool_emission.extract_kind_from_result result,
-          Multimodal.Tool_emission.extract_id_from_result result )
-      with
-      | Some kind_tag, Some artifact_id
-        when String.trim artifact_id <> ""
-             && not (Hashtbl.mem seen_artifacts artifact_id) ->
-          Hashtbl.add seen_artifacts artifact_id ();
-          let kind = Multimodal.Artifact.kind_tag_to_string kind_tag in
-          let payload_preview = tool_result_payload_preview result in
-          let text =
-            tool_result_memory_text ~kind ~artifact_id ~payload_preview
-          in
-          if is_meaningful_memory_text text then begin
-            append_jsonl_line path
-              (`Assoc
-                [ ("ts", `String (now_iso ()))
-                ; ("ts_unix", `Float now_ts)
-                ; ("name", `String meta.name)
-                ; ( "trace_id",
-                    `String
-                      (Keeper_id.Trace_id.to_string meta.runtime.trace_id) )
-                ; ("generation", `Int meta.runtime.generation)
-                ; ("turn", `Int turn)
-                ; ("kind", `String "long_term")
-                ; ("horizon", `String long_term_horizon)
-                ; ("source", `String "tool_result")
-                ; ("schema_version", `Int keeper_memory_schema_version)
-                ; ( "priority",
-                    `Int
-                      (tuned_priority_for_candidate
-                         ~kind:"long_term" ~text) )
-                ; ("text", `String text)
-                ; ("artifact_id", `String artifact_id)
-                ; ("artifact_kind", `String kind)
-                ; ("payload_preview", `String payload_preview)
-                ; ("metadata", tool_result_metadata result)
-                ]);
-            incr written
-          end
-      | _ -> ())
-    results;
+  with_memory_bank_lock path (fun () ->
+    List.iter
+      (fun result ->
+         match
+           ( Multimodal.Tool_emission.extract_kind_from_result result,
+             Multimodal.Tool_emission.extract_id_from_result result )
+         with
+         | Some kind_tag, Some artifact_id
+           when String.trim artifact_id <> ""
+                && not (Hashtbl.mem seen_artifacts artifact_id) ->
+           Hashtbl.add seen_artifacts artifact_id ();
+           let kind = Multimodal.Artifact.kind_tag_to_string kind_tag in
+           let payload_preview = tool_result_payload_preview result in
+           let text = tool_result_memory_text ~kind ~artifact_id ~payload_preview in
+           if is_meaningful_memory_text text then begin
+             append_jsonl_line path
+               (`Assoc
+                 [ ("ts", `String (now_iso ()))
+                 ; ("ts_unix", `Float now_ts)
+                 ; ("name", `String meta.name)
+                 ; ( "trace_id",
+                     `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id) )
+                 ; ("generation", `Int meta.runtime.generation)
+                 ; ("turn", `Int turn)
+                 ; ("kind", `String "long_term")
+                 ; ("horizon", `String long_term_horizon)
+                 ; ("source", `String "tool_result")
+                 ; ("schema_version", `Int keeper_memory_schema_version)
+                 ; ( "priority",
+                     `Int (tuned_priority_for_candidate ~kind:"long_term" ~text) )
+                 ; ("text", `String text)
+                 ; ("artifact_id", `String artifact_id)
+                 ; ("artifact_kind", `String kind)
+                 ; ("payload_preview", `String payload_preview)
+                 ; ("metadata", tool_result_metadata result)
+                 ]);
+             incr written
+           end
+         | _ -> ())
+      results);
   !written
 
 let summarize_memory_bank_lines

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -18,30 +18,60 @@ let read_file_tail_lines path ~max_bytes ~max_lines : string list =
   else if not (Fs_compat.file_exists path) then []
   else
     try
-      let full_content = Fs_compat.load_file path in
-      let file_len = String.length full_content in
-      let read_start =
-        if max_bytes <= 0 then 0
-        else max 0 (file_len - max_bytes)
-      in
-      let content = String.sub full_content read_start (file_len - read_start) in
-        let lines =
-          content
-          |> String.split_on_char '\n'
-          |> List.filter (fun s -> String.trim s <> "")
-        in
-        (* When reading from mid-file, first line may be partial — drop it *)
-        let lines =
-          if read_start > 0 then
-            match lines with _ :: rest -> rest | [] -> []
-          else lines
-        in
-        let n = List.length lines in
-        if n <= max_lines then lines
-        else
-          let drop = n - max_lines in
-          List.filteri (fun i _ -> i >= drop) lines
-    with Sys_error _ | End_of_file ->
+      let fd = Unix.openfile path [ Unix.O_RDONLY ] 0 in
+      Fun.protect
+        ~finally:(fun () -> try Unix.close fd with _ -> ())
+        (fun () ->
+          let file_len = (Unix.LargeFile.fstat fd).Unix.LargeFile.st_size in
+          let min_start =
+            if max_bytes <= 0
+            then 0L
+            else Int64.max 0L (Int64.sub file_len (Int64.of_int max_bytes))
+          in
+          let chunk_size = 64 * 1024 in
+          let pos = ref file_len in
+          let chunks = ref [] in
+          let newline_count = ref 0 in
+          let count_newlines s =
+            String.iter (fun ch -> if ch = '\n' then incr newline_count) s
+          in
+          while Int64.compare !pos min_start > 0 && !newline_count <= max_lines do
+            let available = Int64.sub !pos min_start in
+            let read_len =
+              Int64.to_int (Int64.min (Int64.of_int chunk_size) available)
+            in
+            let start = Int64.sub !pos (Int64.of_int read_len) in
+            ignore (Unix.LargeFile.lseek fd start Unix.SEEK_SET);
+            let buf = Bytes.create read_len in
+            let rec read_exact offset remaining =
+              if remaining <= 0 then offset
+              else
+                let n = Unix.read fd buf offset remaining in
+                if n = 0 then offset else read_exact (offset + n) (remaining - n)
+            in
+            let bytes_read = read_exact 0 read_len in
+            let chunk = Bytes.sub_string buf 0 bytes_read in
+            count_newlines chunk;
+            chunks := chunk :: !chunks;
+            pos := start
+          done;
+          let content = String.concat "" !chunks in
+          let lines =
+            content
+            |> String.split_on_char '\n'
+            |> List.filter (fun s -> String.trim s <> "")
+          in
+          let lines =
+            if Int64.compare !pos 0L > 0
+            then (match lines with _ :: rest -> rest | [] -> [])
+            else lines
+          in
+          let n = List.length lines in
+          if n <= max_lines then lines
+          else
+            let drop = n - max_lines in
+            List.filteri (fun i _ -> i >= drop) lines)
+    with Sys_error _ | Unix.Unix_error _ | End_of_file ->
       []
 
 let read_keeper_memory_summary

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1519,6 +1519,7 @@ let record_restart ~base_path name =
 
 let record_error ~base_path name err =
   Log.Keeper.error "registry: recording error name=%s error=%s" name err;
+  Keeper_fd_pressure.note_if_fd_exhaustion ~site:"keeper_registry.record_error" err;
   update_entry ~base_path name (fun e -> { e with last_error = Some err })
 ;;
 
@@ -2176,7 +2177,13 @@ let set_started_at_for_test ~base_path name started_at =
 
 let spawn_slots_available () =
   let max_keepers = Keeper_runtime_resolved.bootstrap_max_active_keepers () in
-  max_keepers <= 0 || Atomic.get running_count_atomic < max_keepers
+  let running_count = Atomic.get running_count_atomic in
+  (not (Keeper_fd_pressure.active ()))
+  && Keeper_fd_pressure.admit_start
+       ~active_keepers:running_count
+       ~starting_keepers:1
+       ()
+  && (max_keepers <= 0 || running_count < max_keepers)
 ;;
 
 let wakeup ~base_path name =

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -49,6 +49,7 @@ let max_turns_per_call_max = 100
 
 let bootstrap_max_active_keepers_live () =
   get_int ~default:10000 "MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE_KEEPERS"
+  |> Keeper_fd_pressure.cap_active_keepers_for_nofile
 
 let reactive_max_turns_per_call_live () =
   max max_turns_per_call_min

--- a/lib/keeper_event_queue/keeper_event_queue.ml
+++ b/lib/keeper_event_queue/keeper_event_queue.ml
@@ -17,19 +17,36 @@ type stimulus = {
   payload : string;
 }
 
-type t = stimulus list
+type t =
+  { front : stimulus list
+  ; back_rev : stimulus list
+  ; length : int
+  }
 
-let empty : t = []
+let empty : t = { front = []; back_rev = []; length = 0 }
 
-let length = List.length
+let length q = q.length
 
-let is_empty = function [] -> true | _ -> false
+let is_empty q = q.length = 0
 
-let enqueue (queue : t) (s : stimulus) : t = queue @ [ s ]
+let enqueue (queue : t) (s : stimulus) : t =
+  { queue with back_rev = s :: queue.back_rev; length = queue.length + 1 }
 
-let dequeue : t -> (stimulus * t) option = function
-  | [] -> None
-  | s :: rest -> Some (s, rest)
+let to_list (queue : t) : stimulus list =
+  match queue.back_rev with
+  | [] -> queue.front
+  | back_rev -> queue.front @ List.rev back_rev
+
+let of_list (items : stimulus list) : t =
+  { front = items; back_rev = []; length = List.length items }
+
+let dequeue (queue : t) : (stimulus * t) option =
+  match queue.front with
+  | s :: rest -> Some (s, { queue with front = rest; length = queue.length - 1 })
+  | [] ->
+    (match List.rev queue.back_rev with
+     | [] -> None
+     | s :: rest -> Some (s, { front = rest; back_rev = []; length = queue.length - 1 }))
 
 let dedup_by_post_id ?(window_seconds = 60.0) (queue : t) : t =
   let within_window a b =
@@ -45,12 +62,14 @@ let dedup_by_post_id ?(window_seconds = 60.0) (queue : t) : t =
         in
         aux (s :: acc) later
   in
-  aux [] queue
+  of_list (aux [] (to_list queue))
 
 let sort_by_urgency (queue : t) : t =
-  List.stable_sort
-    (fun a b -> Int.compare (urgency_rank a.urgency) (urgency_rank b.urgency))
-    queue
+  queue
+  |> to_list
+  |> List.stable_sort
+       (fun a b -> Int.compare (urgency_rank a.urgency) (urgency_rank b.urgency))
+  |> of_list
 
 type stimulus_class =
   | Board_signal
@@ -82,10 +101,10 @@ let drain_board_window ?(window_sec = 2.0) (queue : t) : stimulus list * t =
     | Board_signal -> Float.abs (now -. s.arrived_at) <= window_sec
     | _ -> false
   in
-  let board, rest = List.partition is_board_in_window queue in
-  (sort_by_urgency board, rest)
+  let board, rest = List.partition is_board_in_window (to_list queue) in
+  (to_list (sort_by_urgency (of_list board)), of_list rest)
 
 let summary (queue : t) : string =
   Printf.sprintf "%d stimulus%s pending"
-    (List.length queue)
-    (if List.length queue = 1 then "" else "es")
+    queue.length
+    (if queue.length = 1 then "" else "es")

--- a/lib/keeper_event_queue/keeper_event_queue.mli
+++ b/lib/keeper_event_queue/keeper_event_queue.mli
@@ -47,7 +47,7 @@ val length : t -> int
 val is_empty : t -> bool
 
 val enqueue : t -> stimulus -> t
-(** [enqueue q s] appends [s] to the back of [q]. Always succeeds. *)
+(** [enqueue q s] appends [s] to the back of [q] in O(1). Always succeeds. *)
 
 val dequeue : t -> (stimulus * t) option
 (** [dequeue q] removes and returns the front of [q], or [None] when

--- a/lib/keeper_fd_pressure.ml
+++ b/lib/keeper_fd_pressure.ml
@@ -1,0 +1,220 @@
+(** Keeper_fd_pressure — process-local FD exhaustion guard.
+
+    The 24-keeper failure mode is not a classic mutex deadlock. Once the
+    process reaches EMFILE/ENFILE pressure, unrelated append/read/spawn paths
+    all start failing and retries amplify the outage. This module provides a
+    low-cardinality circuit breaker that can be tripped from central error
+    sites and consulted by turn/spawn scheduling. *)
+
+let cooldown_until = Atomic.make 0.0
+let last_log_at = Atomic.make 0.0
+let nofile_guard_warned = Atomic.make false
+let nofile_soft_limit_cache : int option option Atomic.t = Atomic.make None
+
+type admission_block =
+  | Fd_pressure_cooldown of float
+  | Projected_fd_budget_exhausted of
+      { soft_limit : int
+      ; open_fds : int option
+      ; active_keepers : int
+      ; starting_keepers : int
+      ; projected_fds : int
+      }
+
+type admission_decision =
+  | Admit
+  | Block of admission_block
+
+let lowercase s = String.lowercase_ascii s
+
+let contains haystack needle =
+  let haystack = lowercase haystack in
+  let needle = lowercase needle in
+  String_util.contains_substring haystack needle
+;;
+
+let is_fd_exhaustion_text detail =
+  List.exists
+    (contains detail)
+    [ "too many open files"
+    ; "emfile"
+    ; "enfile"
+    ; "file descriptor"
+    ; "os error 24"
+    ; "execve: too many open files"
+    ]
+;;
+
+let cooldown_sec () =
+  Env_config_core.get_float ~default:60.0 "MASC_KEEPER_FD_PRESSURE_COOLDOWN_SEC"
+  |> Float.max 5.0
+  |> Float.min 600.0
+;;
+
+let note ?(site = "unknown") ?(detail = "") () =
+  let now = Time_compat.now () in
+  let until_ts = now +. cooldown_sec () in
+  let prev = Atomic.get cooldown_until in
+  if until_ts > prev then Atomic.set cooldown_until until_ts;
+  let last = Atomic.get last_log_at in
+  if now -. last >= 10.0 then begin
+    Atomic.set last_log_at now;
+    Log.Keeper.error
+      "fd_pressure: circuit breaker active for %.0fs site=%s detail=%s"
+      (max 0.0 (Atomic.get cooldown_until -. now))
+      site
+      detail
+  end
+;;
+
+let note_if_fd_exhaustion ?site detail =
+  if is_fd_exhaustion_text detail then note ?site ~detail ()
+;;
+
+let active ?now () =
+  let now = Option.value ~default:(Time_compat.now ()) now in
+  Atomic.get cooldown_until > now
+;;
+
+let remaining_sec ?now () =
+  let now = Option.value ~default:(Time_compat.now ()) now in
+  max 0.0 (Atomic.get cooldown_until -. now)
+;;
+
+let reset_for_tests () =
+  Atomic.set cooldown_until 0.0;
+  Atomic.set last_log_at 0.0;
+  Atomic.set nofile_guard_warned false;
+  Atomic.set nofile_soft_limit_cache None
+;;
+
+let process_nofile_soft_limit () =
+  match Atomic.get nofile_soft_limit_cache with
+  | Some cached -> cached
+  | None ->
+    let detected =
+      try
+        let lines, status =
+          With_process.with_process_args_in
+            "/bin/sh"
+            [| "sh"; "-c"; "ulimit -n" |]
+            With_process.drain_lines
+        in
+        match status, lines with
+        | Unix.WEXITED 0, line :: _ -> int_of_string_opt (String.trim line)
+        | _ -> None
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | _ -> None
+    in
+    Atomic.set nofile_soft_limit_cache (Some detected);
+    detected
+;;
+
+let process_open_fd_count () =
+  let count_dir path =
+    try Some (Array.length (Sys.readdir path)) with
+    | Sys_error _ | Unix.Unix_error _ -> None
+  in
+  match count_dir "/dev/fd" with
+  | Some _ as count -> count
+  | None -> count_dir "/proc/self/fd"
+;;
+
+let min_nofile_for_24_keepers () =
+  Env_config_core.get_int ~default:4096 "MASC_KEEPER_MIN_NOFILE_FOR_24"
+  |> max 256
+;;
+
+let fd_headroom () =
+  Env_config_core.get_int ~default:128 "MASC_KEEPER_FD_HEADROOM"
+  |> max 32
+;;
+
+let fd_per_active_keeper () =
+  Env_config_core.get_int ~default:96 "MASC_KEEPER_FD_PER_ACTIVE_KEEPER"
+  |> max 16
+;;
+
+let active_keeper_cap_for_soft_limit soft =
+  let usable = max 0 (soft - fd_headroom ()) in
+  max 1 (usable / fd_per_active_keeper ())
+;;
+
+let projected_fd_budget
+  ?open_fds
+  ~active_keepers
+  ~starting_keepers
+  ()
+  =
+  let active_keepers = max 0 active_keepers in
+  let starting_keepers = max 0 starting_keepers in
+  let fleet_projected =
+    fd_headroom () + ((active_keepers + starting_keepers) * fd_per_active_keeper ())
+  in
+  match open_fds with
+  | None -> fleet_projected
+  | Some open_fds ->
+    max fleet_projected (max 0 open_fds + fd_headroom () + (starting_keepers * fd_per_active_keeper ()))
+;;
+
+let admission_decision
+  ?(soft_limit = process_nofile_soft_limit ())
+  ?(open_fds = process_open_fd_count ())
+  ~active_keepers
+  ~starting_keepers
+  ()
+  =
+  if active ()
+  then Block (Fd_pressure_cooldown (remaining_sec ()))
+  else (
+    match soft_limit with
+    | Some soft_limit when soft_limit > 0 ->
+      let projected_fds =
+        projected_fd_budget ?open_fds ~active_keepers ~starting_keepers ()
+      in
+      if projected_fds <= soft_limit
+      then Admit
+      else
+        Block
+          (Projected_fd_budget_exhausted
+             { soft_limit
+             ; open_fds
+             ; active_keepers = max 0 active_keepers
+             ; starting_keepers = max 0 starting_keepers
+             ; projected_fds
+             })
+    | _ -> Admit)
+;;
+
+let admitted = function
+  | Admit -> true
+  | Block _ -> false
+;;
+
+let admit_start ?soft_limit ?open_fds ~active_keepers ~starting_keepers () =
+  admitted (admission_decision ?soft_limit ?open_fds ~active_keepers ~starting_keepers ())
+;;
+
+let admit_turn ?soft_limit ?open_fds ~active_keepers () =
+  admit_start ?soft_limit ?open_fds ~active_keepers ~starting_keepers:0 ()
+;;
+
+let cap_active_keepers_for_nofile ?(soft_limit = process_nofile_soft_limit ()) requested =
+  match soft_limit with
+  | Some soft when soft > 0 && soft < min_nofile_for_24_keepers () ->
+    let soft_cap = active_keeper_cap_for_soft_limit soft in
+    let cap = if requested <= 0 then soft_cap else min requested soft_cap in
+    if (requested <= 0 || cap < requested) && not (Atomic.get nofile_guard_warned) then begin
+      Atomic.set nofile_guard_warned true;
+      Log.Keeper.error
+        "fd_pressure: process nofile soft limit %d is below safe 24-keeper floor %d; \
+         reducing active keeper cap from %d to %d"
+        soft
+        (min_nofile_for_24_keepers ())
+        requested
+        cap
+    end;
+    cap
+  | _ -> requested
+;;

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -69,7 +69,9 @@ let parse_record (json : Yojson.Safe.t)
 
 (* ── Write queue ────────────────────────────────────── *)
 
-let write_queue : Yojson.Safe.t Eio.Stream.t = Eio.Stream.create 4096
+let write_queue_capacity = 4096
+let write_queue : Yojson.Safe.t Eio.Stream.t = Eio.Stream.create write_queue_capacity
+let dropped_full_queue = Atomic.make 0
 
 let store_ref : (string * Dated_jsonl.t) option ref = ref None
 
@@ -82,6 +84,7 @@ let reset_for_testing () =
   let dropped = drain_queue_without_store 0 in
   if dropped > 0 then
     Log.Metrics.warn "tool_metrics_persist: reset dropped %d queued records" dropped;
+  Atomic.set dropped_full_queue 0;
   store_ref := None
 
 let get_or_create_store ~base_path : Dated_jsonl.t =
@@ -96,9 +99,19 @@ let get_or_create_store ~base_path : Dated_jsonl.t =
 
 let enqueue (result : Tool_result.t) =
   let json = record_to_json result in
-  (* Bounded stream (4096): blocks briefly if full, providing backpressure.
-     Under normal operation the flush fiber drains well before capacity. *)
-  Eio.Stream.add write_queue json
+  (* This hook runs inline on the tool completion path. If the persistence
+     fiber is wedged behind FD/IO exhaustion, blocking here would hold the
+     keeper turn open and amplify the outage. Drop best-effort metrics when
+     the bounded queue is full; durable tool-call logs remain the stronger
+     evidence surface. *)
+  if Eio.Stream.length write_queue >= write_queue_capacity
+  then (
+    let dropped = Atomic.fetch_and_add dropped_full_queue 1 + 1 in
+    if dropped = 1 || dropped mod 1024 = 0 then
+      Log.Metrics.warn
+        "tool_metrics_persist: dropped %d record(s) because write queue is full"
+        dropped)
+  else Eio.Stream.add write_queue json
 
 (* ── Flush logic ────────────────────────────────────── *)
 

--- a/lib/tool_metrics_persist.mli
+++ b/lib/tool_metrics_persist.mli
@@ -11,7 +11,9 @@
 
 val enqueue : Tool_result.t -> unit
 (** [enqueue result] buffers a tool invocation record for eventual disk flush.
-    Safe to call from any fiber. Records are batched and written periodically. *)
+    Safe to call from any fiber. Records are batched and written periodically.
+    If the bounded best-effort queue is full, the record is dropped instead of
+    blocking the tool completion path. *)
 
 val start_flush_fiber : sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> base_path:string -> unit
 (** [start_flush_fiber ~sw ~clock ~base_path] spawns a background fiber that

--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -158,6 +158,8 @@ run_tlc_buggy "$REPO_ROOT/specs/keeper-state-machine" "KeeperCompactionLifecycle
 run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperCompositeLifecycle.tla"
 run_tlc_buggy "$REPO_ROOT/specs/keeper-state-machine" "KeeperCompositeLifecycle.tla"
 run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperCircuitBreaker.tla"
+run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperFleetPressureAdmission.tla"
+run_tlc_buggy "$REPO_ROOT/specs/keeper-state-machine" "KeeperFleetPressureAdmission.tla"
 run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperCoreTriad.tla"
 run_tlc_buggy "$REPO_ROOT/specs/keeper-state-machine" "KeeperCoreTriad.tla"
 run_tlc_buggy "$REPO_ROOT/specs/keeper-state-machine" "KeeperCircuitBreaker.tla"

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-14T16:10:24Z (HEAD: 6cd55add32)
+Generated: 2026-05-15T09:42:54Z (HEAD: 6448d363fd)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -13,12 +13,12 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | Metric | Value |
 |--------|-------|
-| Total .tla files | 94 |
-| Manual specs | 94 |
+| Total .tla files | 95 |
+| Manual specs | 95 |
 | TTrace (auto-generated) | 0 |
 | Directories | 18 |
-| Total .cfg files | 196 |
-| Buggy .cfg (bug-model pair) | 100 |
+| Total .cfg files | 198 |
+| Buggy .cfg (bug-model pair) | 101 |
 
 `kind` column: **manual** = hand-authored spec; **ttrace** = TLC counterexample export (`*TTrace*` or trace marker in header). `cfg`/`buggy` columns count companion `.cfg` files. `invariants/properties` lists names per cfg label (`clean=...`, `buggy=...`). `source hash` is the tracked `.tla` blob fingerprint.
 
@@ -113,7 +113,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 |------|--------|------|-----|-------|-------------------------|---------------|
 | ContractClosure.tla | ContractClosure | manual | 2 | 1 | clean={inv:TypeOK, inv:ClosureIntegrity, prop:VerdictUnblocksFsm} buggy={inv:ClosureIntegrity} | d4121bf6a81c |
 
-### specs/keeper-state-machine (33 specs)
+### specs/keeper-state-machine (34 specs)
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Source Hash |
 |------|--------|------|-----|-------|-------------------------|---------------|
@@ -131,6 +131,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperDecisionPipeline.tla | KeeperDecisionPipeline | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:DecisionBoundaryRequiresMeasurement} | aaa933f7e5ba |
 | KeeperDwellMonotone.tla | KeeperDwellMonotone | manual | 2 | 1 | clean={inv:Safety} buggy={inv:DwellNonNegative} | 69416fba4415 |
 | KeeperEventQueue.tla | KeeperEventQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | c2c464472dca |
+| KeeperFleetPressureAdmission.tla | KeeperFleetPressureAdmission | manual | 2 | 1 | clean={inv:Safety} buggy={inv:Safety} | 896bfc64bc24 |
 | KeeperGenerationLineage.tla | KeeperGenerationLineage | manual | 2 | 1 | clean={inv:TypeOK, inv:CurrentTraceIsolation, inv:GenerationMatchesHistory, inv:CurrentTraceNotInHistory, inv:TraceHistoryUnique, inv:TraceIdsAllocated, inv:IdleCheckpointMatchesCommittedLineage, prop:HandoffEventuallyResolves} buggy={inv:TypeOK, inv:GenerationMatchesHistory, inv:CurrentTraceNotInHistory, inv:TraceHistoryUnique, inv:TraceIdsAllocated, inv:IdleCheckpointMatchesCommittedLineage} | bc957a36caf6 |
 | KeeperHeartbeat.tla | KeeperHeartbeat | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 127b595d597d |
 | KeeperLaunchPending.tla | KeeperLaunchPending | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | b40572292792 |

--- a/specs/keeper-state-machine/KeeperFleetPressureAdmission-buggy.cfg
+++ b/specs/keeper-state-machine/KeeperFleetPressureAdmission-buggy.cfg
@@ -1,0 +1,12 @@
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    FdSoftLimit = 5
+    FdHeadroom = 1
+    FdPerKeeper = 2
+    MaxKeepers = 4
+    MaxSteps = 8
+
+INVARIANT Safety
+
+CHECK_DEADLOCK FALSE

--- a/specs/keeper-state-machine/KeeperFleetPressureAdmission.cfg
+++ b/specs/keeper-state-machine/KeeperFleetPressureAdmission.cfg
@@ -1,0 +1,12 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    FdSoftLimit = 5
+    FdHeadroom = 1
+    FdPerKeeper = 2
+    MaxKeepers = 4
+    MaxSteps = 8
+
+INVARIANT Safety
+
+CHECK_DEADLOCK FALSE

--- a/specs/keeper-state-machine/KeeperFleetPressureAdmission.tla
+++ b/specs/keeper-state-machine/KeeperFleetPressureAdmission.tla
@@ -1,0 +1,167 @@
+---- MODULE KeeperFleetPressureAdmission ----
+\* KeeperFleetPressureAdmission -- proactive FD-budget admission for 24-keeper fleets.
+\*
+\* This is the formal target for the 2026-05-15 Keeper 24 failure class:
+\* do not wait until EMFILE/ENFILE has already poisoned append/read/spawn
+\* paths.  A keeper spawn or turn admission must be blocked before the
+\* projected FD budget crosses the inherited process nofile limit.
+\*
+\* OCaml <-> TLA+ mapping (symbol anchors, not line numbers):
+\*
+\*   spec variable / action      | OCaml surface
+\*   ----------------------------+---------------------------------------------
+\*   FdSoftLimit                 | keeper_fd_pressure.ml — process_nofile_soft_limit
+\*   FdHeadroom                  | keeper_fd_pressure.ml — fd_headroom
+\*   FdPerKeeper                 | keeper_fd_pressure.ml — fd_per_active_keeper
+\*   ProjectedFdUse              | keeper_fd_pressure.ml — projected_fd_budget
+\*   AdmitKeeper                 | keeper_fd_pressure.ml — admit_start
+\*   BlockByBudget               | keeper_fd_pressure.ml — admission_decision
+\*   breaker                     | keeper_fd_pressure.ml — active / cooldown_until
+\*   active_keepers              | keeper_registry.ml — count_running
+\*
+\* Scope projection:
+\*   The runtime can also trip a reactive cooldown after actual FD exhaustion.
+\*   This spec models the proactive admission invariant only: while the runtime
+\*   is in charge of a fleet admission decision, it must never admit work that
+\*   makes [FdHeadroom + active_keepers * FdPerKeeper] exceed [FdSoftLimit].
+\*   Host-wide ENFILE from unrelated processes is outside this process-local
+\*   model and remains an operational limit/telemetry concern.
+\*
+\* Bug model:
+\*   Clean cfg  : Safety passes.
+\*   Buggy cfg  : AdmitKeeperBuggy ignores [WithinBudget(active_keepers + 1)]
+\*                and must violate [NoOverBudgetAdmission].
+
+EXTENDS Naturals
+
+CONSTANTS
+    FdSoftLimit,
+    FdHeadroom,
+    FdPerKeeper,
+    MaxKeepers,
+    MaxSteps
+
+VARIABLES
+    active_keepers,
+    breaker,
+    last_admitted,
+    step
+
+vars == <<active_keepers, breaker, last_admitted, step>>
+
+ProjectedFdUse(k) == FdHeadroom + (k * FdPerKeeper)
+
+WithinBudget(k) == ProjectedFdUse(k) <= FdSoftLimit
+
+TypeOK ==
+    /\ FdSoftLimit \in Nat \ {0}
+    /\ FdHeadroom \in Nat
+    /\ FdPerKeeper \in Nat \ {0}
+    /\ MaxKeepers \in Nat
+    /\ MaxSteps \in Nat
+    /\ active_keepers \in 0..MaxKeepers
+    /\ breaker \in BOOLEAN
+    /\ last_admitted \in BOOLEAN
+    /\ step \in 0..MaxSteps
+
+Init ==
+    /\ active_keepers = 0
+    /\ breaker = FALSE
+    /\ last_admitted = FALSE
+    /\ step = 0
+
+\* Proactive admission: a new keeper can be admitted only if the projected
+\* fleet budget remains within the process nofile budget.
+AdmitKeeper ==
+    /\ step < MaxSteps
+    /\ ~breaker
+    /\ active_keepers < MaxKeepers
+    /\ WithinBudget(active_keepers + 1)
+    /\ active_keepers' = active_keepers + 1
+    /\ last_admitted' = TRUE
+    /\ step' = step + 1
+    /\ UNCHANGED breaker
+
+\* The desired prevention point: once the next keeper would exceed budget, the
+\* admission layer blocks before any EMFILE/ENFILE observation is required.
+BlockByBudget ==
+    /\ step < MaxSteps
+    /\ ~breaker
+    /\ active_keepers < MaxKeepers
+    /\ ~WithinBudget(active_keepers + 1)
+    /\ active_keepers' = active_keepers
+    /\ last_admitted' = FALSE
+    /\ step' = step + 1
+    /\ UNCHANGED breaker
+
+\* Reactive pressure can still happen from outside this model, but while the
+\* breaker is active no new admission is allowed.
+TripBreaker ==
+    /\ step < MaxSteps
+    /\ ~breaker
+    /\ breaker' = TRUE
+    /\ last_admitted' = FALSE
+    /\ step' = step + 1
+    /\ UNCHANGED active_keepers
+
+RecoverBreaker ==
+    /\ step < MaxSteps
+    /\ breaker
+    /\ breaker' = FALSE
+    /\ last_admitted' = FALSE
+    /\ step' = step + 1
+    /\ UNCHANGED active_keepers
+
+StopKeeper ==
+    /\ step < MaxSteps
+    /\ active_keepers > 0
+    /\ active_keepers' = active_keepers - 1
+    /\ last_admitted' = FALSE
+    /\ step' = step + 1
+    /\ UNCHANGED breaker
+
+Done ==
+    /\ step = MaxSteps
+    /\ UNCHANGED vars
+
+Next ==
+    \/ AdmitKeeper
+    \/ BlockByBudget
+    \/ TripBreaker
+    \/ RecoverBreaker
+    \/ StopKeeper
+    \/ Done
+
+Spec == Init /\ [][Next]_vars
+
+\* Safety invariants.
+NoOverBudgetAdmission == WithinBudget(active_keepers)
+
+NoAdmitWhileBreaker == breaker => ~last_admitted
+
+Safety ==
+    /\ TypeOK
+    /\ NoOverBudgetAdmission
+    /\ NoAdmitWhileBreaker
+
+\* Bug model: admission ignores the projected budget and increments anyway.
+AdmitKeeperBuggy ==
+    /\ step < MaxSteps
+    /\ ~breaker
+    /\ active_keepers < MaxKeepers
+    /\ active_keepers' = active_keepers + 1
+    /\ last_admitted' = TRUE
+    /\ step' = step + 1
+    /\ UNCHANGED breaker
+
+NextBuggy ==
+    \/ AdmitKeeperBuggy
+    \/ BlockByBudget
+    \/ TripBreaker
+    \/ RecoverBreaker
+    \/ StopKeeper
+    \/ Done
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+====

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -469,6 +469,39 @@ let test_stop_keepalive_resolves_running_entry_immediately () =
        fail ("expected stopped promise, got crashed: " ^ reason)
      | None -> fail "expected manual stop to resolve done_p")
 
+let test_stop_keepalive_force_releases_held_slots () =
+  R.clear ();
+  let keeper_name = "manual-stop-held-slot" in
+  let _reg = R.register ~base_path:bp keeper_name (make_meta keeper_name) in
+  let result =
+    Masc_mcp.Keeper_keepalive.with_keeper_turn_slot_for_test
+      ~keeper_name
+      ~channel:Masc_mcp.Keeper_world_observation.Reactive
+      (fun ~semaphore_wait_ms:_ ->
+         let now = Time_compat.now () in
+         check bool "precondition holder present" true
+           (List.mem keeper_name
+              (List.map fst (Masc_mcp.Keeper_keepalive.turn_slot_holders ~now)));
+         Masc_mcp.Keeper_keepalive.stop_keepalive ~base_path:bp keeper_name;
+         let now_after = Time_compat.now () in
+         check bool "turn holder force released on manual stop" false
+           (List.mem keeper_name
+              (List.map fst
+                 (Masc_mcp.Keeper_keepalive.turn_slot_holders ~now:now_after)));
+         check bool "reactive holder force released on manual stop" false
+           (List.mem keeper_name
+              (List.map fst
+                 (Masc_mcp.Keeper_keepalive.reactive_slot_holders ~now:now_after)));
+         match R.get ~base_path:bp keeper_name with
+         | Some entry ->
+           check string "state stopped" "stopped" (KSM.phase_to_string entry.phase)
+         | None -> fail "expected keeper entry after manual stop")
+  in
+  match result with
+  | Ok () -> ()
+  | Error (`Semaphore_wait_timeout _) ->
+    fail "unexpected semaphore timeout while testing manual stop force-release"
+
 let test_stop_keepalive_preserves_existing_crash_outcome () =
   R.clear ();
   let keeper_name = "crashed-before-stop" in
@@ -608,6 +641,8 @@ let () =
         test_direct_start_keepalive_resolves_done_on_stop;
       test_case "manual stop resolves running entry immediately" `Quick
         test_stop_keepalive_resolves_running_entry_immediately;
+      eio_test "manual stop force-releases held turn slots"
+        test_stop_keepalive_force_releases_held_slots;
       test_case "manual stop preserves crashed outcome" `Quick
         test_stop_keepalive_preserves_existing_crash_outcome;
     ];

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -370,6 +370,34 @@ let test_load_history_user_messages_ignores_internal_prompt_entries () =
       (List.nth result 1);
     check string "second real" "second real question" (List.nth result 2))
 
+let test_read_file_tail_lines_reads_tail_without_byte_cap () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
+    let path = Filename.concat dir "large-history.jsonl" in
+    let oc = open_out path in
+    for i = 1 to 1000 do
+      output_string oc (Printf.sprintf "line-%04d\n" i)
+    done;
+    close_out oc;
+    let lines =
+      Keeper_memory_recall.read_file_tail_lines path ~max_bytes:0 ~max_lines:3
+    in
+    check (list string) "last three lines"
+      [ "line-0998"; "line-0999"; "line-1000" ]
+      lines)
+
+let test_read_file_tail_lines_drops_partial_byte_cap_line () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
+    let path = Filename.concat dir "capped-history.jsonl" in
+    let oc = open_out path in
+    output_string oc "first\nsecond\nthird\n";
+    close_out oc;
+    let lines =
+      Keeper_memory_recall.read_file_tail_lines path ~max_bytes:8 ~max_lines:3
+    in
+    check (list string) "partial first capped line dropped" [ "third" ] lines)
+
 let test_recall_candidates_with_history_dedup () =
   let dir = test_tmpdir () in
   Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
@@ -1759,6 +1787,10 @@ let () =
             test_load_history_user_messages;
           test_case "load_history_user_messages ignores internal prompt entries" `Quick
             test_load_history_user_messages_ignores_internal_prompt_entries;
+          test_case "read_file_tail_lines reads tail without byte cap" `Quick
+            test_read_file_tail_lines_reads_tail_without_byte_cap;
+          test_case "read_file_tail_lines drops partial byte-cap line" `Quick
+            test_read_file_tail_lines_drops_partial_byte_cap_line;
           test_case "recall_candidates_with_history deduplicates" `Quick
             test_recall_candidates_with_history_dedup;
           test_case "recall_candidates_with_history appends history" `Quick

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -8,6 +8,7 @@ module Hooks = Masc_mcp.Keeper_lifecycle_hooks
 module Meas = Masc_mcp.Keeper_measurement
 module Pages = Masc_mcp.Server_routes_http_pages
 module Json = Yojson.Safe.Util
+module FD = Masc_mcp.Keeper_fd_pressure
 
 let bp = "/tmp/test"
 
@@ -51,6 +52,45 @@ let make_meta name =
 let make_stimulus ?(urgency = Keeper_event_queue.Normal)
     ?(arrived_at = 0.0) post_id payload =
   Keeper_event_queue.{ post_id; urgency; arrived_at; payload }
+
+let test_fd_pressure_text_classifier () =
+  check bool "detects EMFILE text" true
+    (FD.is_fd_exhaustion_text
+       "Unix_error (Too many open files in system, \"openat\", path)");
+  check bool "ignores provider timeout" false
+    (FD.is_fd_exhaustion_text "provider stream idle timeout")
+
+let test_fd_pressure_nofile_cap () =
+  FD.reset_for_tests ();
+  check int "low process nofile degrades 24-keeper boot" 1
+    (FD.cap_active_keepers_for_nofile ~soft_limit:(Some 256) 24);
+  check int "safe process nofile leaves 24-keeper boot alone" 24
+    (FD.cap_active_keepers_for_nofile ~soft_limit:(Some 4096) 24);
+  check int "low process nofile also caps unlimited boot config" 1
+    (FD.cap_active_keepers_for_nofile ~soft_limit:(Some 256) 0)
+
+let test_fd_pressure_proactive_admission () =
+  FD.reset_for_tests ();
+  check bool "admits projected fleet within nofile budget" true
+    (FD.admit_start
+       ~soft_limit:(Some 512)
+       ~open_fds:(Some 16)
+       ~active_keepers:2
+       ~starting_keepers:1
+       ());
+  check bool "blocks projected fleet before nofile exhaustion" false
+    (FD.admit_start
+       ~soft_limit:(Some 512)
+       ~open_fds:(Some 460)
+       ~active_keepers:2
+       ~starting_keepers:1
+       ());
+  check bool "blocks turns when already over projected active keeper budget" false
+    (FD.admit_turn
+       ~soft_limit:(Some 512)
+       ~open_fds:(Some 16)
+       ~active_keepers:8
+       ())
 
 let test_bonsai_keepers_summary_uses_scoped_registry () =
   let base_path = temp_base_path "bonsai-summary" in
@@ -1749,6 +1789,12 @@ let () =
     [
       ( "basic",
         [
+          test_case "fd pressure text classifier" `Quick
+            test_fd_pressure_text_classifier;
+          test_case "fd pressure nofile boot cap" `Quick
+            test_fd_pressure_nofile_cap;
+          test_case "fd pressure proactive admission" `Quick
+            test_fd_pressure_proactive_admission;
           eio_test "bonsai summary uses scoped registry"
             test_bonsai_keepers_summary_uses_scoped_registry;
           eio_test "register and get" test_register_and_get;

--- a/test/test_tool_metrics_persist.ml
+++ b/test/test_tool_metrics_persist.ml
@@ -100,6 +100,22 @@ let test_reset_clears_cached_store () =
     let restored = P.restore ~base_path in
     Alcotest.(check int) "reset drops queued records and cache" 0 restored)
 
+let test_enqueue_drops_when_queue_full () =
+  with_tmp_dir (fun base_path ->
+    M.clear ();
+    ignore (P.restore ~base_path);
+    for i = 1 to 4101 do
+      P.enqueue
+        (make_result
+           ~name:(Printf.sprintf "tool-%04d" i)
+           ~success:true
+           ~duration_ms:1.0)
+    done;
+    P.flush_now ();
+    M.clear ();
+    let restored = P.restore ~base_path in
+    Alcotest.(check int) "bounded queue persists only capacity" 4096 restored)
+
 let () =
   Alcotest.run "Tool_metrics_persist" [
     "persistence", [
@@ -111,5 +127,7 @@ let () =
         test_malformed_lines_skipped;
       eio_test "reset clears cached store"
         test_reset_clears_cached_store;
+      eio_test "enqueue drops instead of blocking when queue is full"
+        test_enqueue_drops_when_queue_full;
     ];
   ]


### PR DESCRIPTION
## Summary

- add a proactive Keeper fleet FD-budget admission model that blocks spawn/turn admission before projected FD use crosses the inherited `nofile` soft limit
- add `KeeperFleetPressureAdmission.tla` with clean/buggy configs and wire it into the TLA check script; clean must pass and buggy must violate `Safety`
- keep the reactive FD-pressure circuit breaker for EMFILE/ENFILE failures, blocking spawn slots and turn scheduling during cooldown
- release held turn slots during manual keepalive stop, make Keeper event enqueue O(1), and prevent tool metrics queue saturation from blocking tool completion
- reduce memory-cycle pressure with tail reads and per-path memory bank serialization that preserves concurrent appends
- record the remediation plan and verification evidence for the 2026-05-15 Keeper 24 incident analysis

## Root Cause

The 2026-05-15 runtime logs show a fleet-wide failure pattern caused by FD exhaustion and write/spawn fanout, not a single classical mutex deadlock. Once `Too many open files in system` appeared, runtime manifests, tool-call logs, coverage gaps, cost events, keeper meta reads, progress snapshots, and docker subprocess checks failed in the same window.

The amended fix treats this as an admission-control invariant first and a circuit-breaker fallback second: MASC should not start another keeper/turn when its projected FD budget is already unsafe.

## Formal Model

- `specs/keeper-state-machine/KeeperFleetPressureAdmission.tla`
- `KeeperFleetPressureAdmission.cfg`: `Safety` passes
- `KeeperFleetPressureAdmission-buggy.cfg`: `Safety` is violated when admission ignores budget

## Validation

- `git diff --check`
- `bash scripts/audit-tla-ml-line-refs.sh`
- `env DUNE_JOBS=1 scripts/dune-local.sh build ./test/test_keeper_registry.exe ./test/test_heartbeat_integration.exe`
- `./_build/default/test/test_keeper_registry.exe` — 89 tests
- `./_build/default/test/test_heartbeat_integration.exe` — 20 tests
- TLC clean: `KeeperFleetPressureAdmission.cfg` — passed, 49 distinct states
- TLC buggy: `KeeperFleetPressureAdmission-buggy.cfg` — violated `Safety`, exit 12

Earlier focused validation on the same PR branch also passed `test_keeper_memory.exe`, `test_tool_metrics_persist.exe`, and `test_keeper_event_queue.exe`.

Live endpoint verification was unavailable because `127.0.0.1:8935` was not listening during the verification pass.