### PR TITLE
fix(build): close 4 unclosed test/dune stanzas (RFC-0085 PR-11~14)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1710,21 +1710,26 @@
 (test
  (name test_rfc_0085_pr14_dispatch_inline)
  (modules test_rfc_0085_pr14_dispatch_inline)
+ (libraries alcotest ast_grep))
 ; RFC-0085 PR-13 — Underscore-prefix audit: 1 truly-dead deletion +
 ; 8 active rename across 7 modules.
 (test
  (name test_rfc_0085_pr13_underscore_rename)
  (modules test_rfc_0085_pr13_underscore_rename)
+ (libraries alcotest ast_grep))
 ; RFC-0085 PR-12 — Tool_spec list bindings renamed (drop misleading
 ; _ prefix that signalled "unused" in OCaml but was wrong because the
 ; bindings are actively used by List.mem in the Tool_spec.register loop).
 (test
  (name test_rfc_0085_pr12_tool_spec_rename)
  (modules test_rfc_0085_pr12_tool_spec_rename)
+ (libraries alcotest ast_grep))
 ; RFC-0085 PR-11 — Env_config_core deprecation mechanism removed.
 (test
  (name test_rfc_0085_pr11_deprecation_purge)
  (modules test_rfc_0085_pr11_deprecation_purge)
+ (libraries alcotest ast_grep))
+
 ; RFC-0085 PR-10 — home + assets_dir env readers absorbed into
 ; Host_config.t; Env_config_core.assets_dir_opt fully removed,
 ; home_dir_opt demoted to file-private.


### PR DESCRIPTION
## Summary

Fixes the latest `origin/main` Dune parse/build break left after the RFC-0085 PR-14/13/12/11 test stanzas landed without their library/closing-paren lines.

Current diff:

- `test/dune`: adds `(libraries alcotest ast_grep))` to `test_rfc_0085_pr14_dispatch_inline`, `test_rfc_0085_pr13_underscore_rename`, `test_rfc_0085_pr12_tool_spec_rename`, and `test_rfc_0085_pr11_deprecation_purge`.

## Root Cause

The adjacent test stanzas were introduced with `(name ...)` and `(modules ...)` but no closing library line, so Dune parsed the next stanza/comment as part of the previous form and blocked all build commands from reading `test/dune` cleanly.

## Validation

GitHub checks on head `73fcba3fbb1f288020d9a2dcbe9a776796480641`:

- `check`: pass
- `CI Gate`: pass
- `PR Sync Check`: pass
- `Draft Auto-Merge Guard`: pass
- guard/ratchet checks: pass

Changed-surface workflow jobs that do not apply to this one-file `test/dune` fix are skipped by CI gating.