### PR TITLE
test(rfc-0085): full regression bar — PR-7/12-18 retroactive AST tests + helper axis fix

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1705,6 +1705,35 @@
  (modules test_rfc_0085_pr8_config_dir_resolver_host_config)
  (libraries alcotest ast_grep))
 
+; RFC-0085 PR-18 — Retroactive AST test for execution_surfaces +
+; namespace_truth rename (#15486 shipped without a regression test;
+; restored by #15495).
+(test
+ (name test_rfc_0085_pr18_execution_surfaces_rename)
+ (modules test_rfc_0085_pr18_execution_surfaces_rename)
+ (libraries alcotest ast_grep))
+
+; RFC-0085 PR-17 — Retroactive AST test for 4 dead deletion + 2 rename
+; (#15485 shipped without a regression test; restored by #15495).
+(test
+ (name test_rfc_0085_pr17_dead_purge_and_rename)
+ (modules test_rfc_0085_pr17_dead_purge_and_rename)
+ (libraries alcotest ast_grep))
+
+; RFC-0085 PR-16 — Retroactive AST test for dashboard_http_core rename
+; (#15484 shipped without a regression test; restored by #15495).
+(test
+ (name test_rfc_0085_pr16_dashboard_http_core_rename)
+ (modules test_rfc_0085_pr16_dashboard_http_core_rename)
+ (libraries alcotest ast_grep))
+
+; RFC-0085 PR-15 — Retroactive AST test for tool_schemas_inline rename
+; (#15483 shipped without a regression test; restored by #15495).
+(test
+ (name test_rfc_0085_pr15_tool_schemas_inline_rename)
+ (modules test_rfc_0085_pr15_tool_schemas_inline_rename)
+ (libraries alcotest ast_grep))
+
 ; RFC-0085 PR-14 — dispatch / dispatch_structured / guarded_dispatch
 ; 3-step chain inlined; guarded_dispatch is the only dispatch entry.
 (test

--- a/test/dune
+++ b/test/dune
@@ -1705,6 +1705,14 @@
  (modules test_rfc_0085_pr8_config_dir_resolver_host_config)
  (libraries alcotest ast_grep))
 
+; RFC-0085 PR-7 — Retroactive AST test for retired_pg_env_keys +
+; clear_retired_pg_envs deletion (#15468 user-identified legacy;
+; shipped without a regression test; restored by #15495).
+(test
+ (name test_rfc_0085_pr7_retired_pg_envs_purge)
+ (modules test_rfc_0085_pr7_retired_pg_envs_purge)
+ (libraries alcotest ast_grep))
+
 ; RFC-0085 PR-18 — Retroactive AST test for execution_surfaces +
 ; namespace_truth rename (#15486 shipped without a regression test;
 ; restored by #15495).

--- a/test/test_rfc_0085_pr12_tool_spec_rename.ml
+++ b/test/test_rfc_0085_pr12_tool_spec_rename.ml
@@ -7,52 +7,69 @@ open Alcotest
     registration).  Renamed to drop the prefix so the convention
     matches reality.
 
-    Verifies 0 occurrences of the [_tool_spec_] prefix across lib/. *)
+    Original PR-12 test scanned [count_string_literals], which only
+    examines [Pconst_string] nodes — identifiers are NOT string
+    literals, so the test passed trivially regardless of the rename.
+    This revision uses [count_value_bindings_with_prefix], which
+    inspects [Ppat_var] nodes (actual identifier bindings). *)
 
-let walk_dirs dirs =
-  let rec collect acc = function
-    | [] -> acc
-    | dir :: rest ->
-      let entries = try Sys.readdir dir with Sys_error _ -> [||] in
-      let next, files =
-        Array.fold_left
-          (fun (sub, files) name ->
-            let p = Filename.concat dir name in
-            if try Sys.is_directory p with Sys_error _ -> false
-            then p :: sub, files
-            else if Filename.check_suffix p ".ml"
-            then sub, p :: files
-            else sub, files)
-          ([], [])
-          entries
-      in
-      collect (List.rev_append files acc) (List.rev_append next rest)
-  in
-  collect [] dirs
+let rec walk_ml_files dir acc =
+  let entries = try Sys.readdir dir with Sys_error _ -> [||] in
+  Array.fold_left
+    (fun acc name ->
+      let p = Filename.concat dir name in
+      if (try Sys.is_directory p with Sys_error _ -> false)
+      then walk_ml_files p acc
+      else if Filename.check_suffix p ".ml"
+      then p :: acc
+      else acc)
+    acc
+    entries
 ;;
 
-let test_no_underscore_prefix () =
-  let files = walk_dirs [ "lib" ] in
+let test_no_underscore_prefix_bindings () =
+  let files = walk_ml_files "lib" [] in
+  let offenders =
+    List.filter_map
+      (fun f ->
+        let n =
+          Ast_grep.count_value_bindings_with_prefix
+            ~module_path:f
+            ~prefix:"_tool_spec_"
+        in
+        if n > 0 then Some (f, n) else None)
+      files
+  in
+  match offenders with
+  | [] -> ()
+  | xs ->
+    let msg =
+      String.concat
+        "; "
+        (List.map (fun (f, n) -> Printf.sprintf "%s=%d" f n) xs)
+    in
+    failf "_tool_spec_* prefix bindings still present: %s" msg
+;;
+
+let test_renamed_bindings_present () =
+  let files = walk_ml_files "lib" [] in
   let total =
     List.fold_left
       (fun acc f ->
-        acc + Ast_grep.count_string_literals ~module_path:f ~needle:"_tool_spec_")
+        acc
+        + Ast_grep.count_value_bindings_with_prefix
+            ~module_path:f
+            ~prefix:"tool_spec_")
       0
       files
   in
-  (* count_string_literals scans string literals; the prefix only
-     appears in identifiers, so this should be 0 from the AST. *)
-  ignore total;
-  ()
+  if total < 1
+  then failf "expected ≥1 [tool_spec_*] active binding post-rename; got %d" total
 ;;
 
-let test_tool_spec_callers_exist () =
-  (* Verify rename didn't break callers: at least 1 List.mem call
-     against the renamed identifiers per module. *)
+let test_list_mem_callers_preserved () =
   let n =
-    Ast_grep.count_calls
-      ~module_path:"lib/tool_worktree.ml"
-      ~callee:"List.mem"
+    Ast_grep.count_calls ~module_path:"lib/tool_worktree.ml" ~callee:"List.mem"
   in
   if n < 1
   then failf "tool_worktree.ml expected List.mem caller; got %d" n
@@ -61,9 +78,19 @@ let test_tool_spec_callers_exist () =
 let () =
   run
     "rfc-0085-pr-12-tool-spec-rename"
-    [ ( "naming"
-      , [ test_case "no _tool_spec_ string literal" `Quick test_no_underscore_prefix
-        ; test_case "List.mem callers preserved" `Quick test_tool_spec_callers_exist
+    [ ( "identifier purge"
+      , [ test_case
+            "no _tool_spec_ underscore-prefix bindings"
+            `Quick
+            test_no_underscore_prefix_bindings
+        ; test_case
+            "renamed tool_spec_ bindings exist"
+            `Quick
+            test_renamed_bindings_present
+        ; test_case
+            "List.mem callers preserved"
+            `Quick
+            test_list_mem_callers_preserved
         ] )
     ]
 ;;

--- a/test/test_rfc_0085_pr13_underscore_rename.ml
+++ b/test/test_rfc_0085_pr13_underscore_rename.ml
@@ -16,77 +16,72 @@ open Alcotest
        - tool_coord._status_cache
     All renamed (drop _ prefix), callers in same file updated.
 
-    AST verification: no underscore-prefixed string literals of the
-    affected identifiers remain. *)
+    Original test scanned [count_string_literals], which examines only
+    [Pconst_string] nodes — identifiers are NOT string literals, so the
+    test would pass even if [_xxx] identifiers were reintroduced.
+    This revision uses [count_value_bindings ~name], which inspects
+    [Ppat_var] nodes (actual identifier bindings). *)
 
-let walk_dirs dirs =
-  let rec collect acc = function
-    | [] -> acc
-    | dir :: rest ->
-      let entries = try Sys.readdir dir with Sys_error _ -> [||] in
-      let next, files =
-        Array.fold_left
-          (fun (sub, files) name ->
-            let p = Filename.concat dir name in
-            if try Sys.is_directory p with Sys_error _ -> false
-            then p :: sub, files
-            else if Filename.check_suffix p ".ml"
-            then sub, p :: files
-            else sub, files)
-          ([], [])
-          entries
-      in
-      collect (List.rev_append files acc) (List.rev_append next rest)
-  in
-  collect [] dirs
+let dead_identifiers =
+  [ "lib/governance_pipeline_risk.ml", "_tool_names_of_input" ]
 ;;
 
-let test_dead_function_removed () =
-  (* AST: governance_pipeline_risk should have 0 references to
-     _tool_names_of_input identifier in any string. *)
-  let n =
-    Ast_grep.count_string_literals
-      ~module_path:"lib/governance_pipeline_risk.ml"
-      ~needle:"_tool_names_of_input"
-  in
-  check int "no _tool_names_of_input string literal" 0 n
+let renamed_identifiers =
+  [ "lib/config_dir_resolver.ml", "_cached_resolution", "cached_resolution"
+  ; "lib/tool_code_write.ml", "_policy_config_cache", "policy_config_cache"
+  ; "lib/tool_keeper.ml", "_keeper_list_cache", "keeper_list_cache"
+  ; "lib/tool_board.ml", "_board_list_cache", "board_list_cache"
+  ; ( "lib/context_compact_oas.ml"
+    , "_legacy_memory_summary_prefix"
+    , "legacy_memory_summary_prefix" )
+  ; "lib/context_compact_oas.ml", "_legacy_goal_prefix", "legacy_goal_prefix"
+  ; ( "lib/governance_pipeline_risk.ml"
+    , "_destructive_pattern_strings"
+    , "destructive_pattern_strings" )
+  ; "lib/tool_coord.ml", "_status_cache", "status_cache"
+  ]
 ;;
 
-let test_no_underscore_active_cache_remains () =
-  (* Spot-check a representative file from each rename. *)
-  let pairs =
-    [ "lib/config_dir_resolver.ml", "_cached_resolution"
-    ; "lib/tool_code_write.ml", "_policy_config_cache"
-    ; "lib/tool_keeper.ml", "_keeper_list_cache"
-    ; "lib/tool_board.ml", "_board_list_cache"
-    ; "lib/context_compact_oas.ml", "_legacy_memory_summary_prefix"
-    ; "lib/governance_pipeline_risk.ml", "_destructive_pattern_strings"
-    ; "lib/tool_coord.ml", "_status_cache"
-    ]
-  in
+let test_dead_identifiers_gone () =
   List.iter
     (fun (path, name) ->
-      let n = Ast_grep.count_string_literals ~module_path:path ~needle:name in
-      let msg = Printf.sprintf "no %s string in %s" name path in
+      let n = Ast_grep.count_value_bindings ~module_path:path ~name in
+      let msg = Printf.sprintf "%s should be deleted in %s" name path in
       check int msg 0 n)
-    pairs
+    dead_identifiers
+;;
+
+let test_renamed_old_names_gone () =
+  List.iter
+    (fun (path, old_name, _new_name) ->
+      let n = Ast_grep.count_value_bindings ~module_path:path ~name:old_name in
+      let msg =
+        Printf.sprintf "old name %s should be removed in %s" old_name path
+      in
+      check int msg 0 n)
+    renamed_identifiers
+;;
+
+let test_renamed_new_names_present () =
+  List.iter
+    (fun (path, _old_name, new_name) ->
+      let n = Ast_grep.count_value_bindings ~module_path:path ~name:new_name in
+      let msg =
+        Printf.sprintf "new name %s should be defined in %s" new_name path
+      in
+      if n < 1 then failf "%s — count=%d" msg n)
+    renamed_identifiers
 ;;
 
 let () =
-  ignore walk_dirs;
   run
     "rfc-0085-pr-13-underscore-rename"
     [ ( "dead removal"
-      , [ test_case
-            "_tool_names_of_input deleted"
-            `Quick
-            test_dead_function_removed
+      , [ test_case "dead _tool_names_of_input gone" `Quick test_dead_identifiers_gone
         ] )
     ; ( "active rename"
-      , [ test_case
-            "no underscore-prefix string literal"
-            `Quick
-            test_no_underscore_active_cache_remains
+      , [ test_case "old underscore names gone" `Quick test_renamed_old_names_gone
+        ; test_case "new names present" `Quick test_renamed_new_names_present
         ] )
     ]
 ;;

--- a/test/test_rfc_0085_pr14_dispatch_inline.ml
+++ b/test/test_rfc_0085_pr14_dispatch_inline.ml
@@ -2,21 +2,32 @@ open Alcotest
 
 (** RFC-0085 PR-14 — Verify the file-private [dispatch] /
     [dispatch_structured] chain is gone from tool_dispatch.ml; only
-    [guarded_dispatch] (and its mli-exported helpers) remains. *)
+    [guarded_dispatch] (and its mli-exported helpers) remains.
 
-let test_no_dispatch_function_define () =
-  (* AST: tool_dispatch.ml should have 0 top-level [let dispatch] or
-     [let dispatch_structured] definitions.  We approximate via
-     string-literal scan — these names also appear in docstrings, so
-     the assertion is "the identifier is gone *as a top-level binding*",
-     which we verify by attempting to read the symbol via Tool_dispatch
-     itself (only guarded_dispatch should be exported). *)
-  let exists_call =
-    Ast_grep.count_calls
-      ~module_path:"lib/tool_dispatch.ml"
-      ~callee:"Tool_dispatch.dispatch_structured"
+    Original PR-14 test used [count_calls] (application sites) to
+    approximate "no definition", which is indirect.  This revision
+    uses [count_value_bindings] (Ppat_var nodes — actual definitions)
+    so the assertion is direct: top-level [let dispatch = ...] and
+    [let dispatch_structured = ...] must not exist in tool_dispatch.ml. *)
+
+let file = "lib/tool_dispatch.ml"
+
+let test_no_dispatch_top_level_binding () =
+  let n = Ast_grep.count_value_bindings ~module_path:file ~name:"dispatch" in
+  check int "tool_dispatch.ml must have 0 top-level [let dispatch]" 0 n
+;;
+
+let test_no_dispatch_structured_binding () =
+  let n =
+    Ast_grep.count_value_bindings ~module_path:file ~name:"dispatch_structured"
   in
-  check int "no internal dispatch_structured call" 0 exists_call
+  check int "tool_dispatch.ml must have 0 top-level [let dispatch_structured]" 0 n
+;;
+
+let test_guarded_dispatch_binding_present () =
+  let n = Ast_grep.count_value_bindings ~module_path:file ~name:"guarded_dispatch" in
+  if n < 1
+  then failf "tool_dispatch.ml must define guarded_dispatch ≥ 1; got %d" n
 ;;
 
 let test_guarded_dispatch_callers_intact () =
@@ -26,14 +37,25 @@ let test_guarded_dispatch_callers_intact () =
       ~callee:"Tool_dispatch.guarded_dispatch"
   in
   if n < 1
-  then failf "keeper_exec_masc.ml must call guarded_dispatch >= 1; got %d" n
+  then failf "keeper_exec_masc.ml must call guarded_dispatch ≥ 1; got %d" n
 ;;
 
 let () =
   run
     "rfc-0085-pr-14-dispatch-inline"
     [ ( "chain inline"
-      , [ test_case "no dispatch_structured call" `Quick test_no_dispatch_function_define
+      , [ test_case
+            "no top-level [let dispatch =] binding"
+            `Quick
+            test_no_dispatch_top_level_binding
+        ; test_case
+            "no top-level [let dispatch_structured =] binding"
+            `Quick
+            test_no_dispatch_structured_binding
+        ; test_case
+            "guarded_dispatch binding present"
+            `Quick
+            test_guarded_dispatch_binding_present
         ; test_case
             "guarded_dispatch caller intact"
             `Quick

--- a/test/test_rfc_0085_pr15_tool_schemas_inline_rename.ml
+++ b/test/test_rfc_0085_pr15_tool_schemas_inline_rename.ml
@@ -1,0 +1,80 @@
+open Alcotest
+
+(** RFC-0085 PR-15 — Retroactive regression test.
+
+    Original PR-15 (#15483) renamed 4 misleading underscore-prefix
+    bindings in [tool_schemas/tool_schemas_inline.ml] and
+    [tool_schemas/tool_schemas_inline_infra.ml] but shipped *no* test.
+    Each identifier is actively used (List.mem / list concat) so the
+    underscore prefix violated OCaml convention (intentionally-unused).
+
+    This retroactive test pins the rename so any future reintroduction
+    of [_inline_*] or [_codegen_*] prefix on these names fails CI. *)
+
+let renamed_identifiers =
+  [ ( "lib/tool_schemas/tool_schemas_inline.ml"
+    , "_inline_coord_codegen_names"
+    , "inline_coord_codegen_names" )
+  ; ( "lib/tool_schemas/tool_schemas_inline.ml"
+    , "_inline_coord_from_codegen"
+    , "inline_coord_from_codegen" )
+  ; ( "lib/tool_schemas/tool_schemas_inline_infra.ml"
+    , "_codegen_inline_infra_names"
+    , "codegen_inline_infra_names" )
+  ; ( "lib/tool_schemas/tool_schemas_inline_infra.ml"
+    , "_inline_infra_from_codegen"
+    , "inline_infra_from_codegen" )
+  ]
+;;
+
+let test_old_underscore_names_gone () =
+  List.iter
+    (fun (path, old_name, _new_name) ->
+      let n = Ast_grep.count_value_bindings ~module_path:path ~name:old_name in
+      let msg =
+        Printf.sprintf "old underscore name %s should be removed in %s" old_name path
+      in
+      check int msg 0 n)
+    renamed_identifiers
+;;
+
+let test_new_names_present () =
+  List.iter
+    (fun (path, _old_name, new_name) ->
+      let n = Ast_grep.count_value_bindings ~module_path:path ~name:new_name in
+      let msg =
+        Printf.sprintf "renamed binding %s must exist in %s" new_name path
+      in
+      if n < 1 then failf "%s — count=%d" msg n)
+    renamed_identifiers
+;;
+
+let test_list_mem_caller_preserved () =
+  (* The renamed bindings exist because List.mem / list concat call
+     them — verify those caller sites still resolve (compile-time
+     check via build, runtime check here that the file shape kept the
+     same caller pattern). *)
+  let n =
+    Ast_grep.count_calls
+      ~module_path:"lib/tool_schemas/tool_schemas_inline.ml"
+      ~callee:"List.mem"
+  in
+  if n < 1 then failf "tool_schemas_inline.ml expects ≥1 List.mem caller; got %d" n
+;;
+
+let () =
+  run
+    "rfc-0085-pr-15-tool-schemas-inline-rename"
+    [ ( "identifier rename"
+      , [ test_case
+            "old underscore names gone"
+            `Quick
+            test_old_underscore_names_gone
+        ; test_case "new names present" `Quick test_new_names_present
+        ; test_case
+            "List.mem caller preserved"
+            `Quick
+            test_list_mem_caller_preserved
+        ] )
+    ]
+;;

--- a/test/test_rfc_0085_pr16_dashboard_http_core_rename.ml
+++ b/test/test_rfc_0085_pr16_dashboard_http_core_rename.ml
@@ -1,0 +1,51 @@
+open Alcotest
+
+(** RFC-0085 PR-16 — Retroactive regression test.
+
+    Original PR-16 (#15484) renamed 9 underscore-prefix bindings in
+    [lib/server/server_dashboard_http_core.ml].  All are mutable
+    refs/atomics/caches — actively used at runtime, so the [_xxx]
+    convention misled readers.  Shipped without test; pin now. *)
+
+let file = "lib/server/server_dashboard_http_core.ml"
+
+let renamed_identifiers =
+  [ "_shell_warmed", "shell_warmed"
+  ; "_shell_warming", "shell_warming"
+  ; "_last_good_shell", "last_good_shell"
+  ; "_operator_snapshot_broadcast_ref", "operator_snapshot_broadcast_ref"
+  ; "_operator_digest_broadcast_ref", "operator_digest_broadcast_ref"
+  ; "_operator_snapshot_cache", "operator_snapshot_cache"
+  ; "_operator_digest_cache", "operator_digest_cache"
+  ; "_operator_refresh_interval_s", "operator_refresh_interval_s"
+  ; "_mission_cache", "mission_cache"
+  ]
+;;
+
+let test_old_underscore_names_gone () =
+  List.iter
+    (fun (old_name, _) ->
+      let n = Ast_grep.count_value_bindings ~module_path:file ~name:old_name in
+      let msg = Printf.sprintf "old underscore name %s should be removed" old_name in
+      check int msg 0 n)
+    renamed_identifiers
+;;
+
+let test_new_names_present () =
+  List.iter
+    (fun (_, new_name) ->
+      let n = Ast_grep.count_value_bindings ~module_path:file ~name:new_name in
+      let msg = Printf.sprintf "renamed binding %s must exist" new_name in
+      if n < 1 then failf "%s — count=%d" msg n)
+    renamed_identifiers
+;;
+
+let () =
+  run
+    "rfc-0085-pr-16-dashboard-http-core-rename"
+    [ ( "identifier rename"
+      , [ test_case "old underscore names gone" `Quick test_old_underscore_names_gone
+        ; test_case "new names present" `Quick test_new_names_present
+        ] )
+    ]
+;;

--- a/test/test_rfc_0085_pr17_dead_purge_and_rename.ml
+++ b/test/test_rfc_0085_pr17_dead_purge_and_rename.ml
@@ -1,0 +1,81 @@
+open Alcotest
+
+(** RFC-0085 PR-17 — Retroactive regression test.
+
+    Original PR-17 (#15485) deleted 4 truly-dead functions (~250 LOC)
+    and renamed 2 active bindings.  Shipped without test; pin now. *)
+
+let dead_in_dashboard_mission =
+  [ "_build_session_context"; "_build_briefs_from_sessions" ]
+;;
+
+let dead_in_channel_gate_metrics =
+  [ "_binding_snapshot"; "_effective_attempt_count" ]
+;;
+
+let renamed_in_coord =
+  ( "lib/coord/coord_utils_paths_backend.ml"
+  , "_shared_pubsub"
+  , "shared_pubsub" )
+;;
+
+let renamed_in_diagnostics =
+  ( "lib/server_base_path_diagnostics.ml"
+  , "_logged_once"
+  , "logged_once" )
+;;
+
+let test_dashboard_mission_dead_gone () =
+  let path = "lib/dashboard/dashboard_mission.ml" in
+  List.iter
+    (fun name ->
+      let n = Ast_grep.count_value_bindings ~module_path:path ~name in
+      let msg = Printf.sprintf "dead %s should be deleted in %s" name path in
+      check int msg 0 n)
+    dead_in_dashboard_mission
+;;
+
+let test_channel_gate_metrics_dead_gone () =
+  let path = "lib/gate/channel_gate_metrics.ml" in
+  List.iter
+    (fun name ->
+      let n = Ast_grep.count_value_bindings ~module_path:path ~name in
+      let msg = Printf.sprintf "dead %s should be deleted in %s" name path in
+      check int msg 0 n)
+    dead_in_channel_gate_metrics
+;;
+
+let test_renamed_old_names_gone () =
+  List.iter
+    (fun (path, old_name, _) ->
+      let n = Ast_grep.count_value_bindings ~module_path:path ~name:old_name in
+      let msg = Printf.sprintf "old %s should be gone in %s" old_name path in
+      check int msg 0 n)
+    [ renamed_in_coord; renamed_in_diagnostics ]
+;;
+
+let test_renamed_new_names_present () =
+  List.iter
+    (fun (path, _, new_name) ->
+      let n = Ast_grep.count_value_bindings ~module_path:path ~name:new_name in
+      let msg = Printf.sprintf "new %s must exist in %s" new_name path in
+      if n < 1 then failf "%s — count=%d" msg n)
+    [ renamed_in_coord; renamed_in_diagnostics ]
+;;
+
+let () =
+  run
+    "rfc-0085-pr-17-dead-purge-and-rename"
+    [ ( "dead removal"
+      , [ test_case "dashboard_mission dead gone" `Quick test_dashboard_mission_dead_gone
+        ; test_case
+            "channel_gate_metrics dead gone"
+            `Quick
+            test_channel_gate_metrics_dead_gone
+        ] )
+    ; ( "rename"
+      , [ test_case "old underscore names gone" `Quick test_renamed_old_names_gone
+        ; test_case "new names present" `Quick test_renamed_new_names_present
+        ] )
+    ]
+;;

--- a/test/test_rfc_0085_pr18_execution_surfaces_rename.ml
+++ b/test/test_rfc_0085_pr18_execution_surfaces_rename.ml
@@ -1,0 +1,65 @@
+open Alcotest
+
+(** RFC-0085 PR-18 — Retroactive regression test.
+
+    Original PR-18 (#15486) renamed 8 underscore-prefix bindings across
+    [server_dashboard_http_execution_surfaces.ml] (5),
+    [server_dashboard_http_namespace_truth.ml] (2),
+    [server_dashboard_http_namespace_truth_support.ml] (1).
+    Shipped without test; pin now. *)
+
+let renames =
+  [ ( "lib/server/server_dashboard_http_execution_surfaces.ml"
+    , "_last_broadcast_hash"
+    , "last_broadcast_hash" )
+  ; ( "lib/server/server_dashboard_http_execution_surfaces.ml"
+    , "_broadcast_hash_mu"
+    , "broadcast_hash_mu" )
+  ; ( "lib/server/server_dashboard_http_execution_surfaces.ml"
+    , "_execution_cache"
+    , "execution_cache" )
+  ; ( "lib/server/server_dashboard_http_execution_surfaces.ml"
+    , "_transport_health_cache"
+    , "transport_health_cache" )
+  ; ( "lib/server/server_dashboard_http_execution_surfaces.ml"
+    , "_broadcast_namespace_truth_ref"
+    , "broadcast_namespace_truth_ref" )
+  ; ( "lib/server/server_dashboard_http_namespace_truth.ml"
+    , "_last_namespace_truth_snapshot_hash"
+    , "last_namespace_truth_snapshot_hash" )
+  ; ( "lib/server/server_dashboard_http_namespace_truth.ml"
+    , "_namespace_truth_snapshot_hash_mu"
+    , "namespace_truth_snapshot_hash_mu" )
+  ; ( "lib/server/server_dashboard_http_namespace_truth_support.ml"
+    , "_last_good_pending_confirm_summary"
+    , "last_good_pending_confirm_summary" )
+  ]
+;;
+
+let test_old_underscore_names_gone () =
+  List.iter
+    (fun (path, old_name, _) ->
+      let n = Ast_grep.count_value_bindings ~module_path:path ~name:old_name in
+      let msg = Printf.sprintf "old %s should be removed in %s" old_name path in
+      check int msg 0 n)
+    renames
+;;
+
+let test_new_names_present () =
+  List.iter
+    (fun (path, _, new_name) ->
+      let n = Ast_grep.count_value_bindings ~module_path:path ~name:new_name in
+      let msg = Printf.sprintf "renamed %s must exist in %s" new_name path in
+      if n < 1 then failf "%s — count=%d" msg n)
+    renames
+;;
+
+let () =
+  run
+    "rfc-0085-pr-18-execution-surfaces-rename"
+    [ ( "identifier rename"
+      , [ test_case "old underscore names gone" `Quick test_old_underscore_names_gone
+        ; test_case "new names present" `Quick test_new_names_present
+        ] )
+    ]
+;;

--- a/test/test_rfc_0085_pr7_retired_pg_envs_purge.ml
+++ b/test/test_rfc_0085_pr7_retired_pg_envs_purge.ml
@@ -1,0 +1,56 @@
+open Alcotest
+
+(** RFC-0085 PR-7 — Retroactive regression test.
+
+    Original PR-7 (#15468, user-identified legacy) deleted the
+    [retired_pg_env_keys] list constant and the [clear_retired_pg_envs]
+    function from [lib/server/server_runtime_bootstrap.ml].  The list
+    held Postgres env keys (MASC_POSTGRES_URL, DATABASE_URL, ...) that
+    were already deprecated; the clearing function was a no-op safety
+    net.  User pinpointed: "이거 자체가 ... 안하는거잖아 우리 이거
+    레거시임.. 폭파야."
+
+    Shipped without test; pin now so neither symbol can sneak back. *)
+
+let file = "lib/server/server_runtime_bootstrap.ml"
+
+let test_retired_pg_env_keys_gone () =
+  let n = Ast_grep.count_value_bindings ~module_path:file ~name:"retired_pg_env_keys" in
+  check int "retired_pg_env_keys binding should be deleted" 0 n
+;;
+
+let test_clear_retired_pg_envs_gone () =
+  let n =
+    Ast_grep.count_value_bindings ~module_path:file ~name:"clear_retired_pg_envs"
+  in
+  check int "clear_retired_pg_envs function should be deleted" 0 n
+;;
+
+let test_postgres_env_string_literal_gone () =
+  (* The deleted list held "MASC_POSTGRES_URL" as a string literal.
+     Verify no lingering reference in this file. *)
+  let n =
+    Ast_grep.count_string_literals ~module_path:file ~needle:"MASC_POSTGRES_URL"
+  in
+  check int "MASC_POSTGRES_URL string literal should not survive" 0 n
+;;
+
+let () =
+  run
+    "rfc-0085-pr-7-retired-pg-envs-purge"
+    [ ( "deletion"
+      , [ test_case
+            "retired_pg_env_keys deleted"
+            `Quick
+            test_retired_pg_env_keys_gone
+        ; test_case
+            "clear_retired_pg_envs deleted"
+            `Quick
+            test_clear_retired_pg_envs_gone
+        ; test_case
+            "MASC_POSTGRES_URL literal gone"
+            `Quick
+            test_postgres_env_string_literal_gone
+        ] )
+    ]
+;;

--- a/test_lib/ast_grep.ml
+++ b/test_lib/ast_grep.ml
@@ -51,6 +51,58 @@ let count_calls ~module_path ~callee =
     !count
 ;;
 
+(* Count value-binding patterns ([let name = ...] or [let rec name = ...])
+   whose identifier equals [name] exactly.  Catches the *identifier* —
+   the axis [count_string_literals] cannot see, because identifiers are
+   [Ppat_var] / [Pexp_ident] nodes, not [Pconst_string].
+
+   Use this for rename-regression tests: if a sweep dropped a
+   misleading [_xxx] underscore prefix, [count_value_bindings ~name:"_xxx"]
+   must return 0 across the affected files. *)
+let count_value_bindings ~module_path ~name =
+  match parse_implementation module_path with
+  | Error _ -> 0
+  | Ok structure ->
+    let count = ref 0 in
+    let iter =
+      { Ast_iterator.default_iterator with
+        pat =
+          (fun self p ->
+            (match p.ppat_desc with
+             | Ppat_var { txt; _ } when txt = name -> incr count
+             | _ -> ());
+            Ast_iterator.default_iterator.pat self p)
+      }
+    in
+    iter.structure iter structure;
+    !count
+;;
+
+(* Count value bindings whose identifier starts with [prefix].
+   Useful for prefix-purge regressions (e.g., [_tool_spec_*]). *)
+let count_value_bindings_with_prefix ~module_path ~prefix =
+  match parse_implementation module_path with
+  | Error _ -> 0
+  | Ok structure ->
+    let count = ref 0 in
+    let plen = String.length prefix in
+    let starts_with s =
+      String.length s >= plen && String.sub s 0 plen = prefix
+    in
+    let iter =
+      { Ast_iterator.default_iterator with
+        pat =
+          (fun self p ->
+            (match p.ppat_desc with
+             | Ppat_var { txt; _ } when starts_with txt -> incr count
+             | _ -> ());
+            Ast_iterator.default_iterator.pat self p)
+      }
+    in
+    iter.structure iter structure;
+    !count
+;;
+
 (* Count string literals whose value contains [needle] as a substring.
    Excludes comments and docstrings — those are not Pconst_string
    nodes in the Parsetree. *)


### PR DESCRIPTION
## 컨텍스트

RFC-0085 sprint (#15490 RFC-0087 정착) 후 후속 audit이 *3종*의 진짜 부채를 발견:

### 부채 ① — PR-12/13 regression bar 실효 0
`Ast_grep.count_string_literals`는 **string literal**만 scan (`Pconst_string` AST node). *identifier* (`let _xxx = ...`)는 `Ppat_var` 노드 — string literal 아님. 따라서:

- **PR-12 test**: `ignore total; ()` — 결과 무시, 항상 pass
- **PR-13 test**: `check int "..." 0 n` 호출은 했지만 axis 자체가 잘못됨

### 부채 ② — PR-15~18 retroactive test 부재
4 PR 모두 regression test 자체가 없음 (`CLAUDE.md` "테스트 항상 작성" 위반).

### 부채 ③ — PR-7 (사용자 식별 legacy) test 부재 + PR-14 axis indirection
- **PR-7** (#15468 사용자 직접 식별 `retired_pg_env_keys` 폭발): test 없음
- **PR-14**: `count_calls` (application sites)로 "binding 삭제" 간접 검증 — `count_value_bindings`가 정확

## 변경 (3 commits)

### Commit 1 — AST helper 강화 + PR-12/13 bar 회복

1. `test_lib/ast_grep.ml`: `Ppat_var` 기반 counter 2개 추가
   - `count_value_bindings ~module_path ~name : int`
   - `count_value_bindings_with_prefix ~module_path ~prefix : int`
2. PR-12/13 test 재작성 — identifier 검증 (3/3 + 3/3 pass)

### Commit 2 — PR-15/16/17/18 retroactive tests
4 새 test 파일 + 4 stanza:
- PR-15: 4 renames (3/3)
- PR-16: 9 renames (2/2)
- PR-17: 4 dead + 2 renames (4/4)
- PR-18: 8 renames (2/2)

### Commit 3 — PR-7 retro test + PR-14 direct axis
- PR-7: 사용자 식별 `retired_pg_env_keys` + `clear_retired_pg_envs` deletion (3/3 pass)
- PR-14: `count_calls` → `count_value_bindings` 직접 검증 (4/4 pass, was 2)

## 검증 (총 27 test case)

```
test_rfc_0085_pr7_retired_pg_envs_purge.exe         -> 3/3 pass
test_rfc_0085_pr12_tool_spec_rename.exe             -> 3/3 pass
test_rfc_0085_pr13_underscore_rename.exe            -> 3/3 pass
test_rfc_0085_pr14_dispatch_inline.exe              -> 4/4 pass
test_rfc_0085_pr15_tool_schemas_inline_rename.exe   -> 3/3 pass
test_rfc_0085_pr16_dashboard_http_core_rename.exe   -> 2/2 pass
test_rfc_0085_pr17_dead_purge_and_rename.exe        -> 4/4 pass
test_rfc_0085_pr18_execution_surfaces_rename.exe    -> 2/2 pass
```

RFC-0085 sprint의 PR-7/12~18 (8 PR) 모두 *진짜* identifier-level regression bar 정착.

## 남은 audit 결과 (no action)

PR-1/2/3/4/5/6/8/9/10/11 test는 각자 *정확한 axis* 사용:
- PR-2/3/4: path string 폭발 → `count_string_literals` 정확
- PR-5/6/8/9/10/11: 함수 caller 폭발 → `count_calls` 정확
- PR-1: PPX semantic check → 직접 `show`/`equal` 호출 검증

## RFC

RFC-0087 §6 "학습" — *AST infrastructure 자체의 axis 결함* + *test 누락*. RFC-0087에 errata footnote 후속.
