### PR TITLE
fix(network): replace 3 hardcoded 127.0.0.1 literals with SSOT

### DIFF
--- a/lib/grpc/masc_grpc_client.ml
+++ b/lib/grpc/masc_grpc_client.ml
@@ -24,7 +24,7 @@ let create_from_env ~sw ~env =
     | Some t -> t
     | None ->
       let port = Masc_grpc_server.configured_port () in
-      Printf.sprintf "http://127.0.0.1:%d" port
+      Printf.sprintf "http://%s:%d" Masc_network_defaults.masc_http_default_host port
   in
   create ~sw ~env target
 

--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -486,7 +486,8 @@ let start
         Transport_metrics.set_grpc_runtime_listening false;
         Transport_metrics.set_grpc_listen_status "bind_failed";
         Log.Server.error
-          "gRPC coordination transport unavailable on 127.0.0.1:%d: port already in use"
+          "gRPC coordination transport unavailable on %s:%d: port already in use"
+          Masc_network_defaults.masc_http_default_host
           port
       | exn ->
         Transport_metrics.set_grpc_runtime_listening false;

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -448,7 +448,8 @@ let start
       Transport_metrics.set_ws_runtime_listening false;
       Transport_metrics.set_ws_listen_status "bind_failed";
       Log.Server.error
-        "WebSocket transport unavailable on 127.0.0.1:%d: port already in use"
+        "WebSocket transport unavailable on %s:%d: port already in use"
+        Masc_network_defaults.masc_http_default_host
         port
     | exception exn ->
       Transport_metrics.set_ws_runtime_listening false;


### PR DESCRIPTION
## Why
Three production sites bypass SSOT `Masc_network_defaults.masc_http_default_host` (lib/config/masc_network_defaults.ml:98) and embed `127.0.0.1` literal directly. CLAUDE.md §"AI 코드 생성 안티패턴 §1 하드코딩 산포" 정확한 사례. SSOT가 존재하는데 안 쓰이는 형태라 drift risk.

## Sites
- lib/grpc/masc_grpc_client.ml:27 — connection URL builder
- lib/grpc/masc_grpc_server.ml:489 — error log message
- lib/server/server_ws_standalone.ml:451 — error log message

## What
3 literals → `Masc_network_defaults.masc_http_default_host` 인용. Behavior 변화 0 (값 동일).

## Out of scope
- lib/server/server_startup_takeover.ml:131: HTTP Host header literal requirement, separate concern.
- test/* 60 sites: `with_env` MASC_HTTP_BASE_URL 패턴으로 이미 configurable.

## Verification
- `dune build --root . lib/` 의 lib 영역 오류는 `lib/server/server_dashboard_http_core.ml` 의 mli/ml mismatch 만 출력됨 (origin/main 에 pre-existing, 본 PR 무관). stash 비교로 동일 오류 재현 확인.
- 본 PR이 건드린 3 모듈 (`masc_grpc_client`, `masc_grpc_server`, `server_ws_standalone`) 은 빌드 통과.
- 값 변화 없음 (`Masc_network_defaults.masc_http_default_host = "127.0.0.1"`).

## Audit source
Bug hunter result, 2026-05-15 parallel hunt session.

RFC-WAIVED: 3-line drop-in SSOT replacement, no API/behavior delta.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>