### PR TITLE
test(rfc-0086): pin keeper namespace invariant (G-A)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1713,6 +1713,14 @@
  (modules test_rfc_0085_pr7_retired_pg_envs_purge)
  (libraries alcotest ast_grep))
 
+; RFC-0086 — keeper namespace bulk promotion invariant.
+; Pins G-A (Phase 2.A wave 1, #15474): every .ml/.mli under
+; lib/keeper/ carries the keeper_ prefix.
+(test
+ (name test_rfc_0086_keeper_namespace_invariant)
+ (modules test_rfc_0086_keeper_namespace_invariant)
+ (libraries alcotest))
+
 ; RFC-0085 PR-18 — Retroactive AST test for execution_surfaces +
 ; namespace_truth rename (#15486 shipped without a regression test;
 ; restored by #15495).

--- a/test/test_rfc_0086_keeper_namespace_invariant.ml
+++ b/test/test_rfc_0086_keeper_namespace_invariant.ml
@@ -1,0 +1,82 @@
+open Alcotest
+
+(** RFC-0086 — keeper namespace bulk promotion invariant.
+
+    G-A (Phase 2.A wave 1, #15474): every .ml/.mli file under
+    [lib/keeper/] carries the [keeper_] prefix.  Confirmed manually at
+    250 files / 0 non-prefix on main HEAD (ac2138887c, 2026-05-15).
+
+    This test pins the invariant so a future mechanical-rename
+    regression (e.g. someone adds [lib/keeper/foo.ml] without the
+    prefix) fails at CI rather than slipping past dune build.
+
+    Approach: file-system scan (Sys.readdir / Unix.lstat) — naming
+    convention is a structural property of the filesystem layout, not
+    of any individual .ml AST, so an AST-grep would be the wrong axis
+    here. *)
+
+let keeper_root = "lib/keeper"
+
+let rec collect_ml_files dir acc =
+  let entries = try Sys.readdir dir with Sys_error _ -> [||] in
+  Array.fold_left
+    (fun acc name ->
+      let p = Filename.concat dir name in
+      if (try Sys.is_directory p with Sys_error _ -> false)
+      then collect_ml_files p acc
+      else if Filename.check_suffix p ".ml" || Filename.check_suffix p ".mli"
+      then p :: acc
+      else acc)
+    acc
+    entries
+;;
+
+let basename_no_ext path =
+  let b = Filename.basename path in
+  try Filename.chop_extension b with Invalid_argument _ -> b
+;;
+
+let test_all_files_have_keeper_prefix () =
+  let files = collect_ml_files keeper_root [] in
+  let offenders =
+    List.filter
+      (fun path ->
+        let base = basename_no_ext path in
+        not (String.length base >= 7 && String.sub base 0 7 = "keeper_"))
+      files
+  in
+  match offenders with
+  | [] -> ()
+  | xs ->
+    failf
+      "lib/keeper/ files missing [keeper_] prefix (%d): %s"
+      (List.length xs)
+      (String.concat ", " xs)
+;;
+
+let test_population_sanity () =
+  let files = collect_ml_files keeper_root [] in
+  (* Population sanity: a sudden drop to near-zero or jump beyond
+     historical range would indicate a directory move / restructure
+     worth re-validating.  Range chosen with margin around the
+     observed 250 .ml + ~250 .mli ≈ 500 (lower 200, upper 1500). *)
+  let n = List.length files in
+  if n < 200 || n > 1500
+  then
+    failf
+      "lib/keeper/ population out of expected range — got %d (expected 200..1500)"
+      n
+;;
+
+let () =
+  run
+    "rfc-0086-keeper-namespace-invariant"
+    [ ( "prefix"
+      , [ test_case
+            "every lib/keeper/**/*.ml{,i} has keeper_ prefix"
+            `Quick
+            test_all_files_have_keeper_prefix
+        ; test_case "population sanity (200..1500)" `Quick test_population_sanity
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 컨텍스트

RFC-0086 keeper namespace bulk promotion sprint이 Phase 2.A wave 1 (#15474, 35 file rename) + #15488 (host_config_provider rename) + base #15467로 **Goal-A** 달성:

```
$ find lib/keeper -name "*.ml" -not -name "keeper_*" | wc -l
0
$ find lib/keeper -name "*.ml" | wc -l
250
```

본 main HEAD `ac2138887c` 기준 검증.

## 문제

sprint의 bulk-rename PR들이 **자동 guard 없이** 머지됨. 미래 contributor가 `lib/keeper/foo.ml` (prefix 없음) 추가하면:
- `dune build` green (file 자체가 valid OCaml)
- Phase 2.B sub-library 전환 차단 (`(wrapped false)` 안정성 깨짐)
- RFC-0086 invariant 무성으로 깨짐

`feedback_continuous_loop_terminate_at_value_positive_threshold.md` 원칙 + `CLAUDE.md` "테스트 항상 작성"에 따라 *invariant 보호 test* 추가.

## 변경

**`test/test_rfc_0086_keeper_namespace_invariant.ml`** (신규, 90 LOC):

1. `every lib/keeper/**/*.ml{,i} has keeper_ prefix` — file-system scan (Sys.readdir + Filename.check_suffix). 위반 file 목록 fail message에 포함.
2. `population sanity (200..1500)` — directory 통째 이동 / wave 미적용 회귀 감지.

## Axis 선택 사유

naming convention은 *directory layout의 structural property* — 어떤 individual .ml의 AST 안에 없음. `ast_grep`은 wrong axis. `Sys.readdir`가 정확.

## 검증

```
$ dune exec test/test_rfc_0086_keeper_namespace_invariant.exe
[OK] every lib/keeper/**/*.ml{,i} has keeper_ prefix
[OK] population sanity (200..1500)
Test Successful in 0.005s. 2 tests run.
```

## RFC

RFC-0086 (#15467) Phase 2.A wave 1 invariant. Phase 2.B (sub-library 전환) prereq.
