### PR TITLE
fix(test_lib): drop public_name to stop ast_grep leaking into install

### DIFF
--- a/test_lib/dune
+++ b/test_lib/dune
@@ -6,10 +6,13 @@
 ; Depends only on stdlib + compiler-libs.common (OCaml AST), so it
 ; can be linked into any test executable without forcing ppxlib on
 ; downstream test crates.
+;
+; No (public_name) — this is test-only infrastructure and must not
+; leak into the masc_mcp opam install artifact (test_lib was found
+; in _build/install/default/lib/masc_mcp/ast_grep/* by audit).
 
 (library
  (name ast_grep)
- (public_name masc_mcp.ast_grep)
  (wrapped false)
  (libraries
   compiler-libs.common))


### PR DESCRIPTION
## 컨텍스트

RFC-0085 sprint regression bar 완성 (#15495 MERGED) 후 능동 audit에서 *install metadata leak* 발견:

```
$ dune build masc_mcp.install
$ rg "ast_grep" _build/default/masc_mcp.install
"_build/install/default/lib/masc_mcp/ast_grep/ast_grep.a"
"_build/install/default/lib/masc_mcp/ast_grep/ast_grep.cma"
"_build/install/default/lib/masc_mcp/ast_grep/ast_grep.cmi"
"_build/install/default/lib/masc_mcp/ast_grep/ast_grep.cmt"
"_build/install/default/lib/masc_mcp/ast_grep/ast_grep.cmx"
```

`test_lib/ast_grep`는 *AST regression test helper* (RFC-0085 PR-1 #15458). 그러나 `(public_name masc_mcp.ast_grep)` 때문에 opam package에 *함께 install*. *test-only infrastructure가 production binary distribution에 leak*.

사용자 directive `feedback_hardcoding_and_legacy_zero_tolerance.md`: "legacy 폭발". 정확 매칭.

## 변경

**`test_lib/dune`** (1 file, +4/-1):
- `(public_name masc_mcp.ast_grep)` 삭제
- 주석으로 *왜 public_name 없는지* 명시 (audit context + 재발 방지)

Dune은 *같은 workspace 안*에서 `(libraries ast_grep)` declaration으로 bare name resolution. cross-directory linking 보존.

## 검증

```
$ rg "ast_grep" _build/default/masc_mcp.install | wc -l
0    # ← leak 박멸

$ dune build test_lib/  # ← green

$ dune build test/test_rfc_0085_pr{7,12,13,14,15,16,17,18}_*.exe  # ← all green (ast_grep 의존 8 test)

$ dune exec test/test_rfc_0085_pr12_tool_spec_rename.exe
Test Successful in 1.647s. 3 tests run.
```

## RFC / Issue 참조

- 본 audit: continuous-loop iteration #7 (자율 능동 audit)
- 관련 PR: #15458 (RFC-0085 PR-1 original test_lib 도입), #15495 (regression bar restoration), #15503 (RFC-0086 invariant)
