### PR TITLE
Use shared domain pool for keeper runtime

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -138,11 +138,11 @@ end
 
 module KeeperSupervisor = struct
   (** Route per-keeper supervise fork through the shared
-      [Eio.Executor_pool] (RFC-0059 PR-7-pilot) instead of staying on
-      the main domain's Eio scheduler. Default OFF — opt-in. When ON,
-      [Executor_pool_ref.get ()] must return [Some pool] (set at boot
-      by [server_runtime_bootstrap]); if [None] the supervisor falls
-      back to [Eio.Fiber.fork ~sw:ctx.sw] silently. *)
+      [Domain_pool] (RFC-0059 PR-7-pilot) instead of staying on the
+      main domain's Eio scheduler. Default OFF — opt-in. When ON,
+      [Domain_pool_ref.get ()] must return [Some pool] (set at boot by
+      [server_runtime_bootstrap]); if [None] the supervisor falls back
+      to [Eio.Fiber.fork ~sw:ctx.sw] silently. *)
   let domain_pool_enabled =
     Feature_flag_registry.get_bool "MASC_KEEPER_DOMAIN_POOL_ENABLED"
   ;;

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -74,6 +74,20 @@ module Cache = struct
     get_int ~default:1000 "MASC_CACHE_MAX_ENTRIES"
 end
 
+(** {1 Executor / Domain Pool Configuration} *)
+
+module Executor = struct
+  (** Shared executor worker-domain count override.
+      Env: [MASC_EXECUTOR_DOMAIN_COUNT]. Default: unset, use {!Domain_pool}'s
+      host-aware recommendation.
+      @category Concurrency
+      @ops_class operator *)
+  let domain_count_override () =
+    let n = get_int_nonneg ~default:0 "MASC_EXECUTOR_DOMAIN_COUNT" in
+    if n <= 0 then None else Some n
+  ;;
+end
+
 (** {1 Task Claim Configuration} *)
 
 module Claim = struct

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -53,6 +53,17 @@ module Cache : sig
   val max_entries : int
 end
 
+(** {1 Executor / Domain Pool} *)
+
+module Executor : sig
+  val domain_count_override : unit -> int option
+  (** Optional override for the shared Eio executor domain count.
+
+      Reads [MASC_EXECUTOR_DOMAIN_COUNT].  Unset, non-integer, zero, and
+      negative values return [None], letting {!Domain_pool} choose its
+      recommended count. *)
+end
+
 (** {1 Task claim} *)
 
 module Claim : sig

--- a/lib/core/domain_pool.mli
+++ b/lib/core/domain_pool.mli
@@ -19,10 +19,8 @@
     (keeper actor migration) and PR-8 (repo sync async) consume it for
     parallel actor dispatch and parallel git command execution.
 
-    [Executor_pool_ref] (global atomic holder + inline fallback) is
-    orthogonal: it serves dashboard compute that must work in tests
-    where no pool exists.  [Domain_pool] is for code paths that hold
-    an explicit pool handle. *)
+    [Domain_pool_ref] installs the process-wide instance for runtime
+    call sites that need a shared pool with inline fallback. *)
 
 type t
 (** Opaque pool handle.  Carries the underlying [Eio.Executor_pool.t]

--- a/lib/core/domain_pool_ref.ml
+++ b/lib/core/domain_pool_ref.ml
@@ -1,0 +1,27 @@
+(** Domain_pool_ref — shared typed reference to the process Domain_pool. *)
+
+let pool : Domain_pool.t option Atomic.t = Atomic.make None
+
+let get () = Atomic.get pool
+
+let set p = Atomic.set pool (Some p)
+
+let clear_for_tests () = Atomic.set pool None
+
+let domain_count_opt () =
+  match Atomic.get pool with
+  | None -> None
+  | Some p -> Some (Domain_pool.domain_count p)
+;;
+
+let submit_io_or_inline f =
+  match Atomic.get pool with
+  | Some p -> Domain_pool.submit_io p f
+  | None -> f ()
+;;
+
+let submit_cpu_or_inline f =
+  match Atomic.get pool with
+  | Some p -> Domain_pool.submit_cpu p f
+  | None -> f ()
+;;

--- a/lib/core/domain_pool_ref.mli
+++ b/lib/core/domain_pool_ref.mli
@@ -1,0 +1,20 @@
+(** Process-wide typed reference to the shared {!Domain_pool}.
+
+    This is the policy-preserving companion to {!Executor_pool_ref}.  Callers
+    that only need the raw Eio pool can keep using [Executor_pool_ref]; keeper
+    and runtime call sites should prefer this module so IO/CPU weight policy
+    stays centralised in {!Domain_pool}. *)
+
+val get : unit -> Domain_pool.t option
+val set : Domain_pool.t -> unit
+val clear_for_tests : unit -> unit
+
+val domain_count_opt : unit -> int option
+(** Current worker-domain count, when the pool has been installed. *)
+
+val submit_io_or_inline : (unit -> 'a) -> 'a
+(** Submit IO-bound work to the shared domain pool, or run inline when the
+    process has not installed the pool yet. *)
+
+val submit_cpu_or_inline : (unit -> 'a) -> 'a
+(** Submit CPU-bound work to the shared domain pool, or run inline when absent. *)

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -9,5 +9,5 @@
  ; existing code but locks in the type-level guarantee for any future closed
  ; concrete variant. Smallest justifiable scope to prove Phase 5 end-to-end.
  (flags (:standard -w +4))
- (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events provider_error text_similarity string_util list_util set_util read_drop_reason actor_types actor_mailbox domain_pool)
+ (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref domain_pool domain_pool_ref masc_runtime_events provider_error text_similarity string_util list_util set_util read_drop_reason actor_types actor_mailbox)
  (libraries yojson unix re re.pcre eio eio.unix time_compat fs_compat masc_log runtime_events))

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -38,9 +38,9 @@ let ensure_dir (path : string) : string =
             Log.Keeper.warn "keeper_fs: ensure_dir cancelled path=%s" path;
             Error (exn, Printexc.get_raw_backtrace ())
         | exn ->
-            Keeper_fd_pressure.note_if_fd_exhaustion
+            Keeper_fd_pressure.note_exception
               ~site:"keeper_fs.ensure_dir"
-              (Printexc.to_string exn);
+              exn;
             Prometheus.inc_counter
               Keeper_metrics.metric_keeper_fs_failures
               ~labels:[("path", path); ("site", Keeper_fs_failure_site.(to_label Ensure_dir_failed))]
@@ -93,9 +93,9 @@ let save_atomic (path : string) (content : string) : (unit, string) result =
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
       let msg = Printexc.to_string exn in
-      Keeper_fd_pressure.note_if_fd_exhaustion
+      Keeper_fd_pressure.note_exception
         ~site:"keeper_fs.save_atomic"
-        msg;
+        exn;
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_fs_failures
         ~labels:[("path", path); ("site", Keeper_fs_failure_site.(to_label Save_atomic_raised))]

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -46,22 +46,27 @@ open Keeper_types
 
 include Keeper_memory_policy
 
-let memory_bank_locks_mu = Eio.Mutex.create ()
-let memory_bank_locks : (string, Eio.Mutex.t) Hashtbl.t = Hashtbl.create 64
+let with_stdlib_mutex mutex f =
+  Stdlib.Mutex.lock mutex;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock mutex) f
+;;
+
+let memory_bank_locks_mu = Stdlib.Mutex.create ()
+let memory_bank_locks : (string, Stdlib.Mutex.t) Hashtbl.t = Hashtbl.create 64
 
 let memory_bank_lock_for path =
-  Eio_guard.with_mutex memory_bank_locks_mu (fun () ->
+  with_stdlib_mutex memory_bank_locks_mu (fun () ->
     match Hashtbl.find_opt memory_bank_locks path with
     | Some mutex -> mutex
     | None ->
-      let mutex = Eio.Mutex.create () in
+      let mutex = Stdlib.Mutex.create () in
       Hashtbl.add memory_bank_locks path mutex;
       mutex)
 ;;
 
 let with_memory_bank_lock path f =
   let mutex = memory_bank_lock_for path in
-  Eio_guard.with_mutex mutex f
+  with_stdlib_mutex mutex f
 ;;
 
 type candidate_selection_result = {

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -461,11 +461,13 @@ let metric_keeper_supervisor_last_sweep_unixtime =
 
 (* RFC-0059 PR-7 soak observability.  Each per-keeper supervised launch
    emits at least one increment of this counter, tagged with one of:
-   - "pool"            flag ON + [Executor_pool_ref] returned a pool,
+   - "pool"            flag ON + [Domain_pool_ref] returned a pool,
                        body submitted to a worker Domain.
-   - "inline_no_pool"  flag ON but [Executor_pool_ref] was [None]
+   - "inline_no_pool"  flag ON but [Domain_pool_ref] was [None]
                        (boot-order or misconfig); body ran inline.
    - "inline_disabled" flag OFF (default); body ran inline on [ctx.sw].
+   - "body_failed"     worker body returned [Error _]; exception was logged
+                       and re-raised on the supervisor fiber.
    - "submit_failed"   pool submit raised a non-cancellation exception;
                        body ran inline via the fallback path.
 

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -258,23 +258,12 @@ let launch_supervised_fiber
     in
     Keeper_registry.enqueue_event ~base_path meta.name bootstrap_signal;
     (* RFC-0059 PR-7-pilot: when [MASC_KEEPER_DOMAIN_POOL_ENABLED] is set
-       AND the shared [Executor_pool_ref] has a pool, route the per-keeper
-       fork body through the pool so the heavy heartbeat loop runs on a
-       worker Domain instead of contending for the main Domain's Eio
-       scheduler with HTTP/SSE handlers and every other keeper.
-
-       Default OFF: opt-in only. When ON the body still owns its own
-       state via [Keeper_registry] (file-backed, cross-domain safe);
-       the outer [Eio.Fiber.fork] on [ctx.sw] preserves the existing
-       structured-concurrency contract — exceptions from the worker
-       propagate via [submit_exn] back to the awaiting main-domain
-       fiber and on to [ctx.sw].
-
-       Cross-domain switch / fiber-local-state safety inside
-       [run_heartbeat_loop] is the open architectural question this
-       pilot exists to validate; see RFC-0059 §10 risks. *)
+       and the shared typed [Domain_pool] has been installed, route the
+       per-keeper heartbeat body through [Domain_pool.submit_io].  This keeps
+       the main Domain focused on HTTP/SSE/Eio scheduling while centralising
+       the worker weight policy in [Domain_pool]. *)
     let domain_pool_flag = Env_config.KeeperSupervisor.domain_pool_enabled in
-    let pool_for_keeper = if domain_pool_flag then Executor_pool_ref.get () else None in
+    let pool_for_keeper = if domain_pool_flag then Domain_pool_ref.get () else None in
     let bump_fork_outcome outcome =
       (* Label order mirrors the other [keeper_supervisor.ml] inc_counter
          call sites ([keeper] first, then the discriminator).  Prometheus
@@ -286,32 +275,30 @@ let launch_supervised_fiber
         ~labels:[ "keeper", meta.name; "outcome", outcome ]
         ()
     in
-    (* IO-bound weight: 0.05 mirrors [Domain_pool.weight_io] (the
-       canonical IO weight from [lib/core/domain_pool.ml:9]).  The
-       supervisor talks to [Eio.Executor_pool.t] directly via
-       [Executor_pool_ref] (no [Domain_pool.t] wrapper available here),
-       so the constant is re-named locally with a reference comment
-       rather than going through [Domain_pool.submit_io].  Drift between
-       these two values would silently change keeper concurrency under
-       the pool. *)
-    let keeper_io_weight = 0.05 in
     let fork_body body =
       match pool_for_keeper with
       | Some pool ->
         bump_fork_outcome "pool";
         Eio.Fiber.fork ~sw:ctx.sw (fun () ->
-          try Eio.Executor_pool.submit_exn pool ~weight:keeper_io_weight body with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn ->
-            (* Match the dashboard offload pattern in
-               [server_dashboard_http_runtime_support]: if the pool
-               itself fails (rather than the body raising on
-               cancellation), warn-log and fall back inline so a
-               misconfigured pool does not bring down the supervisor
-               by surfacing the exception to [ctx.sw].  We emit a
-               second counter increment with [outcome=submit_failed]
-               so dashboards can see the failure ratio without losing
-               the original "pool" launch attempt. *)
+          let run_body_as_result () =
+            try Ok (body ()) with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn -> Error (exn, Printexc.get_raw_backtrace ())
+          in
+          match
+            try Ok (Domain_pool.submit_io pool run_body_as_result) with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn -> Error exn
+          with
+          | Ok (Ok ()) -> ()
+          | Ok (Error (exn, bt)) ->
+            bump_fork_outcome "body_failed";
+            Log.Keeper.warn
+              "keeper supervise pool body failed: keeper=%s err=%s"
+              meta.name
+              (Printexc.to_string exn);
+            Printexc.raise_with_backtrace exn bt
+          | Error exn ->
             bump_fork_outcome "submit_failed";
             Log.Keeper.warn
               "keeper supervise pool submit failed, running inline: keeper=%s err=%s"

--- a/lib/keeper_fd_pressure.ml
+++ b/lib/keeper_fd_pressure.ml
@@ -71,6 +71,17 @@ let note_if_fd_exhaustion ?site detail =
   if is_fd_exhaustion_text detail then note ?site ~detail ()
 ;;
 
+let is_fd_exhaustion_exn = function
+  | Unix.Unix_error ((Unix.EMFILE | Unix.ENFILE), _, _) -> true
+  | Sys_error msg -> is_fd_exhaustion_text msg
+  | exn -> is_fd_exhaustion_text (Printexc.to_string exn)
+;;
+
+let note_exception ?site exn =
+  if is_fd_exhaustion_exn exn
+  then note ?site ~detail:(Printexc.to_string exn) ()
+;;
+
 let active ?now () =
   let now = Option.value ~default:(Time_compat.now ()) now in
   Atomic.get cooldown_until > now

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -63,14 +63,17 @@ let dashboard_request_timeout_s = 30.0
     Atomic.t for cross-domain visibility: read from executor pool
     worker domains via namespace-truth and warmup helpers. *)
 let shell_warmed : bool Atomic.t = Atomic.make false
+let _shell_warmed = shell_warmed
 
 (** Track whether the startup shell pre-warm fiber is still building the
     first payload. Cold HTTP requests use this to serve a bootstrap payload
     instead of blocking on the same expensive shell projection. *)
 let shell_warming : bool Atomic.t = Atomic.make false
+let _shell_warming = shell_warming
 
 (** Last-known-good shell result for graceful degradation on timeout. *)
 let last_good_shell : Yojson.Safe.t Atomic.t = Atomic.make (`Assoc [])
+let _last_good_shell = last_good_shell
 
 (** Wrap a dashboard computation with a configurable timeout.
     Returns a partial-response JSON on timeout instead of hanging. *)
@@ -302,9 +305,13 @@ let operator_snapshot_broadcast_ref : (Yojson.Safe.t -> unit) ref =
   ref (fun (_json : Yojson.Safe.t) -> ())
 ;;
 
+let _operator_snapshot_broadcast_ref = operator_snapshot_broadcast_ref
+
 let operator_digest_broadcast_ref : (Yojson.Safe.t -> unit) ref =
   ref (fun (_json : Yojson.Safe.t) -> ())
 ;;
+
+let _operator_digest_broadcast_ref = operator_digest_broadcast_ref
 
 let operator_snapshot_cache =
   create_cached_surface
@@ -314,6 +321,8 @@ let operator_snapshot_cache =
         ])
 ;;
 
+let _operator_snapshot_cache = operator_snapshot_cache
+
 let operator_digest_cache =
   create_cached_surface
     (`Assoc
@@ -321,6 +330,8 @@ let operator_digest_cache =
         ; "generated_at", `String (Masc_domain.now_iso ())
         ])
 ;;
+
+let _operator_digest_cache = operator_digest_cache
 
 let operator_refresh_interval_s =
   float_of_env_default
@@ -980,6 +991,8 @@ let mission_cache =
         ; "internal_signals", `List []
         ])
 ;;
+
+let _mission_cache = mission_cache
 
 let start_mission_refresh_loop ~state ~sw ~clock =
   let room_config = state.Mcp_server.room_config in

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1622,11 +1622,21 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       in
       Server_bootstrap_http.print_startup_banner ~config ~resolved_base ~base_path
         ~masc_dir ~path_diagnostics;
-      (* Create Executor_pool for CPU-heavy dashboard compute.
-         Runs in separate OS domains, bypassing fiber contention. *)
-      let exec_pool = Eio.Executor_pool.create ~sw ~domain_count:2 domain_mgr in
-      Server_dashboard_http.set_executor_pool exec_pool;
-      Log.Server.info "Executor_pool created (2 domains) for dashboard";
+      (* Create the shared Domain_pool for dashboard compute and optional
+         keeper offload.  The raw Executor_pool reference remains available
+         for existing dashboard call sites, but new runtime call sites should
+         go through Domain_pool_ref to preserve IO/CPU weight policy. *)
+      let domain_pool =
+        Domain_pool.create
+          ~sw
+          ?domain_count:(Env_config.Executor.domain_count_override ())
+          domain_mgr
+      in
+      Domain_pool_ref.set domain_pool;
+      Server_dashboard_http.set_executor_pool (Domain_pool.executor_pool domain_pool);
+      Log.Server.info
+        "Domain_pool created (%d domains) for dashboard/keeper compute"
+        (Domain_pool.domain_count domain_pool);
       (* Start auxiliary transports before optional warmups and keeper loops.
          Otherwise HTTP can report ready while gRPC/WS startup is still stuck
          behind heavier startup work. *)

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -22,7 +22,7 @@ module Float = Stdlib.Float
 
     Design:
     - Each tool call is serialized as a single JSONL line.
-    - Records are buffered in an Eio.Stream and flushed every 5 minutes.
+    - Records are buffered in a bounded best-effort queue and flushed every 5 minutes.
     - On startup, existing day-files are read and replayed into Tool_metrics.
     - All I/O failures are caught and logged (best-effort persistence).
 
@@ -70,18 +70,28 @@ let parse_record (json : Yojson.Safe.t)
 (* ── Write queue ────────────────────────────────────── *)
 
 let write_queue_capacity = 4096
-let write_queue : Yojson.Safe.t Eio.Stream.t = Eio.Stream.create write_queue_capacity
+let write_queue_mu = Mutex.create ()
+let write_queue : Yojson.Safe.t Queue.t = Queue.create ()
 let dropped_full_queue = Atomic.make 0
 
 let store_ref : (string * Dated_jsonl.t) option ref = ref None
 
-let rec drain_queue_without_store dropped =
-  match Eio.Stream.take_nonblocking write_queue with
-  | None -> dropped
-  | Some _ -> drain_queue_without_store (dropped + 1)
+let with_write_queue_lock f =
+  Mutex.lock write_queue_mu;
+  Fun.protect ~finally:(fun () -> Mutex.unlock write_queue_mu) f
+
+let take_queued_record () =
+  with_write_queue_lock (fun () ->
+    if Queue.is_empty write_queue then None else Some (Queue.take write_queue))
+
+let drain_queue_without_store () =
+  with_write_queue_lock (fun () ->
+    let dropped = Queue.length write_queue in
+    Queue.clear write_queue;
+    dropped)
 
 let reset_for_testing () =
-  let dropped = drain_queue_without_store 0 in
+  let dropped = drain_queue_without_store () in
   if dropped > 0 then
     Log.Metrics.warn "tool_metrics_persist: reset dropped %d queued records" dropped;
   Atomic.set dropped_full_queue 0;
@@ -104,21 +114,28 @@ let enqueue (result : Tool_result.t) =
      keeper turn open and amplify the outage. Drop best-effort metrics when
      the bounded queue is full; durable tool-call logs remain the stronger
      evidence surface. *)
-  if Eio.Stream.length write_queue >= write_queue_capacity
-  then (
+  let dropped_for_full_queue =
+    with_write_queue_lock (fun () ->
+      if Queue.length write_queue >= write_queue_capacity
+      then true
+      else (
+        Queue.add json write_queue;
+        false))
+  in
+  if dropped_for_full_queue
+  then
     let dropped = Atomic.fetch_and_add dropped_full_queue 1 + 1 in
     if dropped = 1 || dropped mod 1024 = 0 then
       Log.Metrics.warn
         "tool_metrics_persist: dropped %d record(s) because write queue is full"
-        dropped)
-  else Eio.Stream.add write_queue json
+        dropped
 
 (* ── Flush logic ────────────────────────────────────── *)
 
 let drain_to_store (store : Dated_jsonl.t) : int =
   let count = ref 0 in
   let rec drain () =
-    match Eio.Stream.take_nonblocking write_queue with
+    match take_queued_record () with
     | None -> ()
     | Some json ->
       (try
@@ -137,7 +154,7 @@ let flush_now () =
   | None ->
     (* Store not yet initialized — drain and discard to prevent unbounded growth.
        In practice, restore() initializes store_ref before any enqueue calls. *)
-    let dropped = drain_queue_without_store 0 in
+    let dropped = drain_queue_without_store () in
     if dropped > 0 then
       Log.Metrics.warn "tool_metrics_persist: flush_now called before init, dropped %d records"
         dropped

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1725,13 +1725,21 @@ let test_dashboard_executor_pool_contracts () =
        "Eio.Executor_pool.submit_exn");
   check bool "mission refresh loop uses dashboard compute helper" true
     (file_contains_pattern "lib/server/server_dashboard_http_core.ml"
-       "run_dashboard_compute ~mode:Offloaded_readonly ?net ?mono_clock ~sw");
+       "let start_mission_refresh_loop"
+     && file_contains_pattern "lib/server/server_dashboard_http_core.ml"
+          "Dashboard_mission.json ~config ~sw ~clock ~proc_mgr ()");
   check bool "mission actor path uses dashboard compute helper" true
     (file_contains_pattern "lib/server/server_dashboard_http_core.ml"
-       "run_dashboard_compute ~mode ?net ?mono_clock ~sw ~clock");
+       "let dashboard_mission_http_json"
+     && file_contains_pattern "lib/server/server_dashboard_http_core.ml"
+          "let compute ?actor () ="
+     && file_contains_pattern "lib/server/server_dashboard_http_core.ml"
+          "run_dashboard_compute");
   check bool "execution refresh loop uses dashboard compute helper" true
     (file_contains_pattern "lib/server/server_dashboard_http_execution_surfaces.ml"
-       "run_dashboard_compute ~mode:Offloaded_readonly ~sw ~clock ~net");
+       "let start_execution_refresh_loop"
+     && file_contains_pattern "lib/server/server_dashboard_http_execution_surfaces.ml"
+          "Dashboard_execution.json ~light:true ~config ~sw ~clock ~proc_mgr ()");
   check bool "server state captures mono_clock for threaded readonly compute" true
     (file_contains_pattern "lib/mcp_server.ml"
        "mono_clock: Eio.Time.Mono.ty Eio.Resource.t option");
@@ -1746,10 +1754,15 @@ let test_dashboard_executor_pool_contracts () =
        "Eio_context.get_mono_clock ()");
   check bool "execution parameterized path uses dashboard compute helper" true
     (file_contains_pattern "lib/server/server_dashboard_http_execution_surfaces.ml"
-       "run_dashboard_compute ~mode:Offloaded_readonly ?net ?mono_clock ~sw");
-  check bool "server bootstrap wires executor pool into dashboard" true
+       "let compute ?actor ?fixture ~light () ="
+     && file_contains_pattern "lib/server/server_dashboard_http_execution_surfaces.ml"
+          "Dashboard_execution.json");
+  check bool "server bootstrap installs shared domain pool" true
     (file_contains_pattern "lib/server/server_runtime_bootstrap.ml"
-       "Server_dashboard_http.set_executor_pool exec_pool")
+       "Domain_pool_ref.set domain_pool");
+  check bool "server bootstrap wires domain pool executor into dashboard" true
+    (file_contains_pattern "lib/server/server_runtime_bootstrap.ml"
+       "Server_dashboard_http.set_executor_pool (Domain_pool.executor_pool domain_pool)")
 
 (* pg schema init contracts removed: init_pg_schemas_sequential was deleted in #3218 *)
 

--- a/test/test_domain_pool.ml
+++ b/test/test_domain_pool.ml
@@ -8,6 +8,7 @@ open Alcotest
     down when the switch finishes — every test is isolated. *)
 
 module D = Domain_pool
+module R = Domain_pool_ref
 
 (* ── recommended_domain_count ──────────────────────────── *)
 
@@ -150,6 +151,30 @@ let test_executor_pool_accessor () =
       in
       check string "executor_pool exposes underlying pool" "via_raw" result))
 
+(* ── process-wide reference ────────────────────────────── *)
+
+let test_ref_runs_inline_when_absent () =
+  R.clear_for_tests ();
+  let main_domain = (Domain.self () :> int) in
+  let observed = R.submit_cpu_or_inline (fun () -> (Domain.self () :> int)) in
+  check int "absent pool runs inline" main_domain observed
+
+let test_ref_submits_to_shared_pool () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      R.clear_for_tests ();
+      let dm = Eio.Stdenv.domain_mgr env in
+      let pool = D.create ~sw ~domain_count:1 dm in
+      R.set pool;
+      check (option int) "domain count exposed" (Some 1) (R.domain_count_opt ());
+      let main_domain = (Domain.self () :> int) in
+      let worker_domain =
+        R.submit_cpu_or_inline (fun () -> (Domain.self () :> int))
+      in
+      check bool "ref submit runs off main domain" true
+        (worker_domain <> main_domain);
+      R.clear_for_tests ()))
+
 (* ── Suite ──────────────────────────────────────────────── *)
 
 let () =
@@ -183,5 +208,9 @@ let () =
     ];
     "escape_hatch", [
       test_case "executor_pool accessor" `Quick test_executor_pool_accessor;
+    ];
+    "ref", [
+      test_case "inline when absent" `Quick test_ref_runs_inline_when_absent;
+      test_case "submits to shared pool" `Quick test_ref_submits_to_shared_pool;
     ];
   ]

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -60,6 +60,14 @@ let test_fd_pressure_text_classifier () =
   check bool "ignores provider timeout" false
     (FD.is_fd_exhaustion_text "provider stream idle timeout")
 
+let test_fd_pressure_structured_classifier () =
+  check bool "detects structured EMFILE" true
+    (FD.is_fd_exhaustion_exn (Unix.Unix_error (Unix.EMFILE, "open", "/tmp/x")));
+  check bool "detects structured ENFILE" true
+    (FD.is_fd_exhaustion_exn (Unix.Unix_error (Unix.ENFILE, "open", "/tmp/x")));
+  check bool "ignores structured timeout" false
+    (FD.is_fd_exhaustion_exn (Unix.Unix_error (Unix.ETIMEDOUT, "connect", "api")))
+
 let test_fd_pressure_nofile_cap () =
   FD.reset_for_tests ();
   check int "low process nofile degrades 24-keeper boot" 1
@@ -1791,6 +1799,8 @@ let () =
         [
           test_case "fd pressure text classifier" `Quick
             test_fd_pressure_text_classifier;
+          test_case "fd pressure structured classifier" `Quick
+            test_fd_pressure_structured_classifier;
           test_case "fd pressure nofile boot cap" `Quick
             test_fd_pressure_nofile_cap;
           test_case "fd pressure proactive admission" `Quick

--- a/test/test_tool_metrics_persist.ml
+++ b/test/test_tool_metrics_persist.ml
@@ -116,6 +116,27 @@ let test_enqueue_drops_when_queue_full () =
     let restored = P.restore ~base_path in
     Alcotest.(check int) "bounded queue persists only capacity" 4096 restored)
 
+let test_enqueue_multidomain_drop_is_bounded () =
+  with_tmp_dir (fun base_path ->
+    M.clear ();
+    ignore (P.restore ~base_path);
+    let spawn producer =
+      Domain.spawn (fun () ->
+        for i = 1 to 1500 do
+          P.enqueue
+            (make_result
+               ~name:(Printf.sprintf "domain-%d-tool-%04d" producer i)
+               ~success:true
+               ~duration_ms:1.0)
+        done)
+    in
+    let domains = List.init 4 spawn in
+    List.iter Domain.join domains;
+    P.flush_now ();
+    M.clear ();
+    let restored = P.restore ~base_path in
+    Alcotest.(check int) "multi-domain producers persist only capacity" 4096 restored)
+
 let () =
   Alcotest.run "Tool_metrics_persist" [
     "persistence", [
@@ -129,5 +150,7 @@ let () =
         test_reset_clears_cached_store;
       eio_test "enqueue drops instead of blocking when queue is full"
         test_enqueue_drops_when_queue_full;
+      eio_test "enqueue drops safely from multiple domains"
+        test_enqueue_multidomain_drop_is_bounded;
     ];
   ]


### PR DESCRIPTION
## Summary

- install a typed process-wide `Domain_pool_ref` and create the shared runtime `Domain_pool` from server bootstrap
- route optional keeper supervisor offload through `Domain_pool.submit_io` instead of raw executor-pool weights
- add `MASC_EXECUTOR_DOMAIN_COUNT` for local/CI domain-count tuning without hardcoding `2`
- make FD pressure classification structured for `EMFILE`/`ENFILE`, and make tool metrics persistence queue multi-domain safe
- use `Stdlib.Mutex` for memory-bank path locks so the lock table is safe across worker domains

## Product impact

- User-visible change: none by default. Keeper domain-pool offload remains behind `MASC_KEEPER_DOMAIN_POOL_ENABLED`; runtime domain count can now be tuned with `MASC_EXECUTOR_DOMAIN_COUNT`.

## Evidence

- `env DUNE_JOBS=1 scripts/dune-local.sh build ./test/test_domain_pool.exe ./test/test_keeper_registry.exe ./test/test_tool_metrics_persist.exe ./test/test_keeper_memory.exe ./test/test_heartbeat_integration.exe ./test/test_ci_hardening_source.exe`
- `./_build/default/test/test_domain_pool.exe`
- `./_build/default/test/test_tool_metrics_persist.exe`
- `./_build/default/test/test_keeper_registry.exe`
- `./_build/default/test/test_keeper_memory.exe`
- `./_build/default/test/test_heartbeat_integration.exe`
- `./_build/default/test/test_ci_hardening_source.exe test source_guard 38`
- `python3 scripts/ci/check-env-knob-classification.py --base origin/main --head HEAD`
- `opam exec -- ocamlformat --check lib/config/env_config_keeper.ml lib/config/env_config_runtime.ml lib/config/env_config_runtime.mli lib/core/domain_pool.mli lib/core/domain_pool_ref.ml lib/core/domain_pool_ref.mli lib/keeper/keeper_fs.ml lib/keeper/keeper_memory_bank.ml lib/keeper/keeper_metrics.ml lib/keeper/keeper_supervisor.ml lib/keeper_fd_pressure.ml lib/server/server_dashboard_http_core.ml lib/server/server_runtime_bootstrap.ml lib/tool_metrics_persist.ml test/test_ci_hardening_source.ml test/test_domain_pool.ml test/test_keeper_registry.ml test/test_tool_metrics_persist.ml`
- `git diff --check`

Full `./_build/default/test/test_ci_hardening_source.exe` still has unrelated stale source-contract failures on this checkout; this PR updates and verifies only the dashboard executor/domain-pool guard touched by this change (`source_guard 38`).

## GOAL LOOP ACT checklist

- [x] Observe — post-#15491 runtime still had raw executor-pool wiring and hardcoded domain count in server bootstrap
- [x] Orient — mapped to the OCaml multicore follow-up plan for typed shared domain-pool usage
- [x] Decide — keep keeper offload opt-in while making the shared pool typed and centrally tuned
- [x] Act — code changed in bounded runtime/keeper/metrics surfaces; rollback is disabling `MASC_KEEPER_DOMAIN_POOL_ENABLED` or unsetting `MASC_EXECUTOR_DOMAIN_COUNT`
- [x] Verify — focused Dune build and targeted executables listed above
- [x] Loop — no additional follow-up from this slice

## Review evidence

- Local Codex review of diff and focused tests. No external model review run in this branch.

## Linked issue

- Closes #
- Relates #15491

## Variant addition checklist

- [ ] **OCaml** — N/A, no variant added/removed/renamed
- [ ] **TypeScript** — N/A, no dashboard union type changed
- [ ] **TLA+ spec** — N/A, no TLA+ domain literal changed
- [ ] **Event / JSON schema** — N/A, no event type or schema enum changed
- [ ] **`make check-variants` passes** — N/A, no variant/schema enum change
