### PR TITLE
docs(tool_schemas): drop dead {!Tool_schemas_inline_coord} reference

### DIFF
--- a/lib/tool_schemas/tool_schemas_inline.mli
+++ b/lib/tool_schemas/tool_schemas_inline.mli
@@ -1,6 +1,8 @@
 (** MCP tool schemas for inline-dispatched tools (facade).
 
-    Concatenates schemas from {!Tool_schemas_inline_coord},
-    {!Tool_schemas_inline_infra}, and {!Tool_schemas_inline_episodes}. *)
+    Concatenates the [inline_coord] subset of {!Tool_schemas_misc} (six
+    [masc_*] names: start/join/leave/broadcast/messages/who, moved out
+    in RFC-0057 PR-2d to [Tool_descriptors_gen]), {!Tool_schemas_inline_infra},
+    and {!Tool_schemas_inline_episodes}. *)
 
 val schemas : Masc_domain.tool_schema list


### PR DESCRIPTION
## 발견

`dune build @doc` 능동 audit (continuous-loop iter #8, main HEAD 9681a5b0f5):

\`\`\`
Warning: Failed to resolve reference unresolvedroot(Tool_schemas_inline_coord)
Couldn't find \"Tool_schemas_inline_coord\"
File \"lib/tool_schemas/tool_schemas_inline.mli\", line 3, characters 30-58
\`\`\`

`Tool_schemas_inline_coord` 모듈은 **RFC-0057 PR-2d** (#14396, 2026-05-09)에서 \`Tool_descriptors_gen\`으로 이동/제거됨. 실 .ml 코드는 *이미 새 구현*을 사용:

\`\`\`ocaml
let inline_coord_from_codegen =
  List.filter ... Tool_schemas_misc.schemas

let schemas =
  inline_coord_from_codegen
  @ Tool_schemas_inline_infra.schemas
  @ Tool_schemas_inline_episodes.schemas
\`\`\`

그러나 .mli docstring은 *옛 module name 잔존*. 진짜 docstring legacy.

## 변경

\`tool_schemas_inline.mli\` line 3-4 docstring 1 file, +4/-2.

새 description은 *실 구현 shape* 정확히 기술:
- \`inline_coord\` subset of \`Tool_schemas_misc\` (6 \`masc_*\` names)
- \`Tool_schemas_inline_infra\`
- \`Tool_schemas_inline_episodes\`

RFC-0057 PR-2d 인용 (archeology).

## 검증

\`\`\`
\$ dune build lib/tool_schemas/  # green
\$ dune build @doc 2>&1 | rg \"Tool_schemas_inline_coord\"  # 0 (resolved)
\`\`\`

## RFC / 발견 경위

- 본 발견: continuous-loop iteration #8 (\`@doc\` 능동 audit)
- 관련: #14396 (RFC-0057 PR-2d original move)