### PR TITLE
fix(opam): drop redundant (dune (>= 3.22)) duplicate-emit

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,9 @@
  (description "MASC Protocol: File-based coordination for Claude, Gemini, and Codex agents")
  (depends
   (ocaml (>= 5.4))
-  (dune (>= 3.22))
+  ; [dune] dependency is implicit from [(lang dune 3.22)] above —
+  ; declaring it again here makes the generated .opam emit
+  ; [{>= "3.22" & >= "3.22"}] (audited continuous-loop iter #10).
   ; External dependencies (opam pin)
   (mcp_protocol (>= 1.3.0))
   (ocaml-webrtc (>= 0.2.3))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -11,8 +11,8 @@ homepage: "https://github.com/jeong-sik/masc-mcp"
 doc: "https://github.com/jeong-sik/masc-mcp"
 bug-reports: "https://github.com/jeong-sik/masc-mcp/issues"
 depends: [
+  "dune" {>= "3.22"}
   "ocaml" {>= "5.4"}
-  "dune" {>= "3.22" & >= "3.22"}
   "mcp_protocol" {>= "1.3.0"}
   "ocaml-webrtc" {>= "0.2.3"}
   "grpc-direct-core" {>= "0.1.0"}


### PR DESCRIPTION
## 발견

continuous-loop iteration #10 능동 opam metadata audit:

\`\`\`
$ rg '\"dune\"' masc_mcp.opam
  \"dune\" {>= \"3.22\" & >= \"3.22\"}     ← 중복 emit
\`\`\`

\`dune-project\`이 \`dune\` dependency를 *두 번* 선언:
- line 1: \`(lang dune 3.22)\` → implicit constraint
- line 29: \`(dune (>= 3.22))\` → explicit \`(depends)\` 안

Dune의 opam generator가 두 constraint를 *concat* (dedup 안 함) → \`{>= \"3.22\" & >= \"3.22\"}\` redundant.

## 변경

\`dune-project\` line 29 explicit dep 제거. comment로 *왜* implicit가 더 정확한지 명시.

## 검증

\`\`\`
$ dune build masc_mcp.opam   # green
$ rg '\"dune\"' masc_mcp.opam
  \"dune\" {>= \"3.22\"}     ← single, deduped
\`\`\`

## 사용자 directive 부합

\`feedback_hardcoding_and_legacy_zero_tolerance.md\` *legacy 폭발*. opam metadata 안의 redundant constraint = legacy. 1-line fix, low-risk.