### PR TITLE
fix(orchestrator): typed Result for zombie cleanup + stale claim release

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -187,27 +187,80 @@ let make_zero_zombie_consumer ~sw ~room_config
       (* Run GC in background fiber to avoid blocking Pulse consumers.
          Heartbeat and other consumers proceed without waiting for
          cleanup_zombies I/O. See RFC #3646 M5 / #3626. *)
+      (* Typed outcome for stale-claim release. Carries a structured
+         [reason] so the catch-all wildcard and untyped [Printexc.to_string]
+         warn cannot hide error classification.  benign := matches
+         {!Coord_resilience.ZeroZombie.is_benign_error} (transient FS race
+         or MASC-not-initialized at startup), in which case operators
+         expect no log noise.
+
+         Kept local to the consumer body — release_stale_claims itself
+         still raises and is wrapped here, because lifting Result into
+         the public signature would force every test-suite caller
+         (test_room.ml:909-964) to be rewritten.  Follow-up RFC =
+         Liveness Recovery Supervisor that consumes typed failures here
+         and escalates to operators (see project_keeper-reaction-chain-break). *)
+      let module Stale_claim_outcome = struct
+        type t =
+          | Released of (string * string) list
+          | Empty
+          | Failed of { benign : bool; reason : string }
+      end in
+      let release_stale_claims_typed () : Stale_claim_outcome.t =
+        let ttl = Env_config_runtime.Claim.ttl_seconds in
+        match
+          Coord_task_schedule.release_stale_claims room_config ~ttl_seconds:ttl
+        with
+        | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+        | exception exn ->
+          Stale_claim_outcome.Failed
+            { benign = Coord_resilience.ZeroZombie.is_benign_error exn
+            ; reason = Printexc.to_string exn
+            }
+        | [] -> Stale_claim_outcome.Empty
+        | released -> Stale_claim_outcome.Released released
+      in
       Eio.Fiber.fork ~sw (fun () ->
         try
           let zombie_result = Coord.cleanup_zombies room_config in
+          (* Explicit variant match — no catch-all.  Adding a new
+             [cleanup_zombie_result] constructor must surface as a
+             compile error here, not a silent debug. *)
           (match zombie_result with
-           | Coord.Cleaned { count; names; _ } when count > 0 ->
+           | Coord.Cleaned { count = 0; _ } ->
+               Log.Orchestrator.debug "[zombie] no zombies to clean"
+           | Coord.Cleaned { count; names; _ } ->
                let status =
                  Printf.sprintf "Cleaned up %d zombie agent(s): %s"
                    count (String.concat ", " names)
                in
                Log.Orchestrator.info "[zombie] %s" status
-           | _ -> ());
-          let ttl = Env_config_runtime.Claim.ttl_seconds in
-          (try
-            let released = Coord_task_schedule.release_stale_claims room_config ~ttl_seconds:ttl in
-            if released <> [] then
-              Log.Orchestrator.info "[stale-claims] released %d stale task(s): %s"
-                (List.length released)
-                (String.concat ", " (List.map (fun (tid, agent) ->
-                  Printf.sprintf "%s(%s)" tid agent) released))
-          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-            Log.Orchestrator.warn "[stale-claims] error: %s" (Printexc.to_string exn))
+           | Coord.No_zombies ->
+               Log.Orchestrator.debug "[zombie] no zombies to clean"
+           | Coord.No_agents_dir ->
+               (* Misconfiguration signal: room has no agents/ directory.
+                  Distinct from No_zombies — operators should know GC
+                  ran against a missing target. *)
+               Log.Orchestrator.warn
+                 "[zombie] skipped: agents directory missing for room");
+          (match release_stale_claims_typed () with
+           | Stale_claim_outcome.Empty ->
+               Log.Orchestrator.debug "[stale-claims] no stale claims to release"
+           | Stale_claim_outcome.Released released ->
+               Log.Orchestrator.info "[stale-claims] released %d stale task(s): %s"
+                 (List.length released)
+                 (String.concat ", " (List.map (fun (tid, agent) ->
+                   Printf.sprintf "%s(%s)" tid agent) released))
+           | Stale_claim_outcome.Failed { benign = true; reason } ->
+               (* Same policy as zombie-loop benign-error filter:
+                  startup FS races / MASC-not-initialized should not
+                  page operators. *)
+               Log.Orchestrator.debug "[stale-claims] benign: %s" reason
+           | Stale_claim_outcome.Failed { benign = false; reason } ->
+               (* Real failure — not silent.  Promoted from .warn to
+                  .error so it surfaces past the default WARN→DEBUG
+                  demote of repeated lines. *)
+               Log.Orchestrator.error "[stale-claims] non-benign failure: %s" reason)
         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           if not (Coord_resilience.ZeroZombie.is_benign_error exn) then
             Log.Orchestrator.warn "[zombie] error: %s" (Printexc.to_string exn));


### PR DESCRIPTION
## Why

CLAUDE.md §"AI 안티패턴 §1 Catch-all wildcard" 처단. `lib/orchestrator.ml` 의 `make_zero_zombie_consumer` 내 **2건 silent failure** 를 typed variant 로 박멸. Hot-path 영역이라 public `release_stale_claims` signature 는 의도적으로 건드리지 않음.

## Sites

| Line (before) | Pattern | Fix |
|---|---|---|
| `lib/orchestrator.ml:200` | zombie cleanup `\| _ -> ()` 가 `No_agents_dir`, `No_zombies`, `Cleaned {count=0}` 셋을 한 wildcard 로 처리 | exhaustive variant match. `No_agents_dir` → `warn` (misconfig 신호), `No_zombies`/`Cleaned {count=0}` → `debug`, `Cleaned {count>0}` → `info`. Catch-all 제거 — 새 constructor 추가 시 컴파일 에러 |
| `lib/orchestrator.ml:209-210` | `try ... with ... exn -> Log.Orchestrator.warn` — benign vs non-benign 분기 없는 untyped warn | local `Stale_claim_outcome` variant (`Released \| Empty \| Failed { benign; reason }`). benign 분류는 기존 `Coord_resilience.ZeroZombie.is_benign_error` 재사용. non-benign → `error` 로 승급 |

## Type delta

```ocaml
let module Stale_claim_outcome = struct
  type t =
    | Released of (string * string) list
    | Empty
    | Failed of { benign : bool; reason : string }
end in
```

Local-only. `orchestrator.mli` 변경 없음.

Zombie cleanup match 는 `Coord.cleanup_zombie_result` 3 constructor 모두 explicit:

```ocaml
| Coord.Cleaned { count = 0; _ } -> debug
| Coord.Cleaned { count; names; _ } -> info
| Coord.No_zombies -> debug
| Coord.No_agents_dir -> warn  (* misconfig surfaced *)
```

## Caller blast radius

```
rg "Orchestrator\." lib/ bin/ test/  →  59 refs
```

전부 public surface (`default_config`, `load_config`, `should_orchestrate`, `make_orchestrator_prompt`, `start`). 변경 영역은 `make_zero_zombie_consumer` private body 내부라 caller delta **0**.

## Behavior change

| Path | Before | After |
|---|---|---|
| zombie `No_agents_dir` | silent | `warn` |
| zombie `Cleaned {count=0}` / `No_zombies` | silent | `debug` |
| zombie `Cleaned {count>0}` | `info` | `info` (unchanged) |
| stale-claim empty | silent (no log) | `debug` |
| stale-claim benign exn (FS race / MASC-not-init) | `warn` | `debug` |
| stale-claim non-benign exn | `warn` | `error` |
| `Eio.Cancel.Cancelled` | re-raised | re-raised (preserved) |

Hot-path 안전: chain break 없음. Pulse fiber lifecycle 동일. 모든 path는 동일하게 `Eio.Fiber.fork ~sw` 안에서 동작.

## 7항목 self-check (CLAUDE.md §워크어라운드 거부 기준)

1. counter-as-fix? **no** — typed variant, instrumentation 만이 아닌 분기 로직 자체 교체
2. string/substring 분류기? **no** — `Coord_resilience.ZeroZombie.is_benign_error` 는 본 PR에서 추가하지 않은 기존 helper. 본 PR이 새로 만든 분기는 closed sum type
3. N-of-M 패치? **no** — 2 site 모두 한 PR
4. catch-all `_ ->` 추가? **no** — 오히려 **2건 제거** (zombie match wildcard, stale-claim try/with)
5. cap/cooldown/dedup/repair symptom 억제? **no**
6. test backdoor (`set_X_for_test`)? **no**
7. typo×N 사이트 codemod 누락? **n/a**

## Follow-up RFC 후보

`Stale_claim_outcome.Failed { benign = false }` 를 consume 해서 operator 에게 escalate 하는 **Liveness Recovery Supervisor** (`~/me/memory/project_keeper-reaction-chain-break-analysis-2026-05-04.md` P0 chain 영역). 본 PR 은 hot-path 보호 목적으로 `release_stale_claims` 자체의 signature 는 `(string*string) list raises exn` 그대로 유지 — Result.t 로 올리면 `test_room.ml:909-964` 의 caller 들이 전면 재작성됨.

## Build / Test

```
dune build --root . @check   →  PASS
test_orchestrator_coverage   →  27/27 PASS
test_resilience              →  34/34 PASS
```

Worktree: `.worktrees/orchestrator-zombie-typed` from `origin/main` (acff58ff96).

## RFC-WAIVED

CLAUDE.md §agent_delegation subsystem 매칭 없음:
- credential/identity 영역 ❌
- repo_manager ❌
- operator_control ❌
- dashboard credential/keeper-repo-mapping ❌
- `.claude/hooks/` / `instructions/workflow*` ❌

변경 surface 는 `lib/orchestrator.ml` private consumer body 단일.

## Escalation 권장

없음. Hot-path 위험 audit 완료:
- Pulse fiber lifecycle 동일
- Eio.Cancel.Cancelled propagation 보존
- Public mli 무변경
- 새 외부 의존성 없음
- 단순 분기 분해라 회귀 표면적 최소

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>