### PR TITLE
fix(llm_metric_bridge): typed variants eliminate 5 silent defaults

### DIFF
--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -68,20 +68,49 @@ let remember_provider ~model_id ~provider =
       Hashtbl.replace provider_by_model model_id provider)
   | _ -> ()
 
-let provider_for_latency ?provider ~model_id () =
+(** Resolution outcome for the [provider] label of a latency observation.
+    Internal — kept out of [.mli] so callers stay byte-identical.
+
+    Replaces the previous [Option.value ~default:unknown_provider_label]
+    fallback in [provider_for_latency], which silently collapsed two
+    distinct conditions (empty [model_id] vs. cache miss) into the same
+    label. The variant lets [emit_request_latency] increment the
+    pre-existing [request_latency_clamped] counter with a typed [reason]
+    so cache misses are visible per provider. *)
+type provider_resolution =
+  | Provider_explicit of string
+      (** Caller supplied non-empty [?provider]. *)
+  | Provider_cached of string
+      (** Caller omitted [?provider]; recovered via model→provider cache. *)
+  | Provider_unknown_no_model_id
+      (** Caller omitted [?provider] and [model_id] is empty after trim. *)
+  | Provider_unknown_cache_miss of { model_id : string }
+      (** Caller omitted [?provider]; [model_id] non-empty but absent from
+          cache (no adjacent [on_http_status] / [on_retry] /
+          [on_token_usage] observed yet). *)
+
+let resolve_provider_for_latency ?provider ~model_id () =
   match Option.bind provider nonempty_or_none with
   | Some provider ->
     remember_provider ~model_id ~provider;
-    provider
+    Provider_explicit provider
   | None ->
     let model_id = String.trim model_id in
-    if model_id = ""
-    then unknown_provider_label
+    if model_id = "" then Provider_unknown_no_model_id
     else
       Stdlib.Mutex.protect provider_cache_mutex (fun () ->
-        Option.value
-          ~default:unknown_provider_label
-          (Hashtbl.find_opt provider_by_model model_id))
+        match Hashtbl.find_opt provider_by_model model_id with
+        | Some cached -> Provider_cached cached
+        | None -> Provider_unknown_cache_miss { model_id })
+
+(** Project a [provider_resolution] to the Prometheus [provider] label.
+    Cardinality budget unchanged: both unknown variants emit
+    [unknown_provider_label] so the upper bound stays at the documented
+    6 × 10 × 10 = 600 series. *)
+let provider_label_of_resolution = function
+  | Provider_explicit p | Provider_cached p -> p
+  | Provider_unknown_no_model_id | Provider_unknown_cache_miss _ ->
+    unknown_provider_label
 
 (** Emit a single HTTP status observation to the Prometheus counter.
 
@@ -121,33 +150,84 @@ let emit_request_start ~model_id =
     ~labels:[("model", model_id)]
     ()
 
-let error_reason_label error =
+(** Closed sum classifying the free-form OAS error string from
+    [on_error] into the Prometheus [error_reason] label values.
+
+    Internal — kept out of [.mli] so callers stay byte-identical.
+
+    Replaces the previous two [else "unknown"] catch-alls (one for the
+    empty trimmed input, one for the substring sieve falling through)
+    with two distinct variants. [Reason_absent] is the documented "no
+    diagnostic available" path; [Reason_unmapped] preserves the trimmed
+    lower-case substring so a future audit counter labeled by unmapped
+    head-of-string can show which provider error shapes the sieve does
+    not yet recognise. Both project to the same [unknown] label today
+    so the bounded-cardinality assumption (~10 reasons) is preserved.
+
+    The substring sieve itself is *not* expanded by this PR — adding
+    more string classifiers is the CLAUDE.md §워크어라운드 시그니처 #2
+    antipattern. The typed variant is the surface that makes future
+    closure possible (typed provider error → [error_reason] mapping
+    in OAS, removing this sieve). *)
+type error_reason =
+  | Reason_timeout
+  | Reason_cancelled
+  | Reason_rate_limit
+  | Reason_quota
+  | Reason_capacity
+  | Reason_auth
+  | Reason_network
+  | Reason_parse
+  | Reason_invalid_request
+  | Reason_provider_error
+  | Reason_unmapped of { trimmed_lower : string }
+  | Reason_absent
+
+let classify_error_reason error =
   let lower = String.lowercase_ascii (String.trim error) in
   let has needle = String_util.contains_substring lower needle in
-  if lower = "" then "unknown"
-  else if has "timeout" || has "timed out" || has "deadline" then "timeout"
-  else if has "cancel" then "cancelled"
+  if lower = "" then Reason_absent
+  else if has "timeout" || has "timed out" || has "deadline" then Reason_timeout
+  else if has "cancel" then Reason_cancelled
   else if has "429" || has "rate limit" || has "too many requests" then
-    "rate_limit"
-  else if has "quota" then "quota"
-  else if has "capacity" || has "overloaded" then "capacity"
+    Reason_rate_limit
+  else if has "quota" then Reason_quota
+  else if has "capacity" || has "overloaded" then Reason_capacity
   else if has "401" || has "403" || has "unauthorized" || has "forbidden"
-          || has "auth" then "auth"
+          || has "auth" then Reason_auth
   else if has "connection" || has "network" || has "dns" || has "socket"
-          || has "econn" then "network"
-  else if has "json" || has "parse" || has "unparseable" then "parse"
+          || has "econn" then Reason_network
+  else if has "json" || has "parse" || has "unparseable" then Reason_parse
   else if has "400" || has "invalid" || has "schema" || has "validation" then
-    "invalid_request"
+    Reason_invalid_request
   else if has "500" || has "503" || has "provider" || has "internal server"
-  then "provider_error"
-  else "unknown"
+  then Reason_provider_error
+  else Reason_unmapped { trimmed_lower = lower }
+
+(** Project an [error_reason] to the Prometheus label. Both
+    [Reason_absent] and [Reason_unmapped] project to ["unknown"] —
+    cardinality budget unchanged. *)
+let error_reason_label = function
+  | Reason_timeout -> "timeout"
+  | Reason_cancelled -> "cancelled"
+  | Reason_rate_limit -> "rate_limit"
+  | Reason_quota -> "quota"
+  | Reason_capacity -> "capacity"
+  | Reason_auth -> "auth"
+  | Reason_network -> "network"
+  | Reason_parse -> "parse"
+  | Reason_invalid_request -> "invalid_request"
+  | Reason_provider_error -> "provider_error"
+  | Reason_unmapped _ | Reason_absent -> "unknown"
 
 let emit_error ~model_id ~error =
   Prometheus.inc_counter error_metric
     ~labels:[("model", model_id)]
     ();
+  let reason = classify_error_reason error in
   Prometheus.inc_counter error_by_reason_metric
-    ~labels:[("model", model_id); ("error_reason", error_reason_label error)]
+    ~labels:
+      [ ("model", model_id); ("error_reason", error_reason_label reason) ]
     ()
 
 let emit_retry ~provider ~model_id ~attempt =
@@ -174,14 +254,46 @@ let emit_token_usage ~provider ~model_id ~input_tokens ~output_tokens =
       ~delta:(Float.of_int output_tokens)
       ()
 
-let seconds_of_ms ms =
-  if Float.is_finite ms && ms > 0.0 then Some (Float.max 0.001 (ms /. 1000.0))
-  else None
+(** Validation outcome for a streaming or latency duration carried in
+    milliseconds. Internal — kept out of [.mli] so callers stay
+    byte-identical.
+
+    Replaces the previous [seconds_of_ms : float -> float option] +
+    [| None -> ()] silent drop at both streaming call sites. The two
+    invalid cases (NaN/Inf vs. non-positive) are distinct production
+    bugs in the OAS provider plumbing — collapsing them to [None]
+    blanked out the operator signal. The reason variant routes to the
+    new [streaming_invalid_ms] counter with a typed [reason] label so
+    each invalid sample is visible. *)
+type ms_duration =
+  | Ms_valid of float                    (** seconds, positive, finite. *)
+  | Ms_invalid_not_finite                (** NaN or ±∞ in the input. *)
+  | Ms_invalid_non_positive              (** zero or negative input. *)
+
+let classify_ms ms : ms_duration =
+  if not (Float.is_finite ms) then Ms_invalid_not_finite
+  else if ms <= 0.0 then Ms_invalid_non_positive
+  else Ms_valid (Float.max 0.001 (ms /. 1000.0))
+
+let ms_invalid_reason = function
+  | Ms_invalid_not_finite -> "not_finite"
+  | Ms_invalid_non_positive -> "non_positive"
+  | Ms_valid _ ->
+    (* Unreachable — caller only invokes on invalid branches. The
+       exhaustive match is preserved here so adding a new invalid
+       variant in [ms_duration] forces a compile error here too. *)
+    assert false
+
+let streaming_first_chunk_invalid_metric =
+  Prometheus.metric_llm_provider_streaming_first_chunk_invalid
+
+let streaming_inter_chunk_invalid_metric =
+  Prometheus.metric_llm_provider_streaming_inter_chunk_invalid
 
 let emit_streaming_first_chunk ~provider ~model_id ~ttfrc_ms =
   remember_provider ~model_id ~provider;
-  match seconds_of_ms ttfrc_ms with
-  | Some seconds ->
+  match classify_ms ttfrc_ms with
+  | Ms_valid seconds ->
     Otel_spans.add_event
       ~name:"ttfrc.received"
       ~attrs:
@@ -193,12 +305,19 @@ let emit_streaming_first_chunk ~provider ~model_id ~ttfrc_ms =
     Prometheus.observe_histogram streaming_first_chunk_metric
       ~labels:[("provider", provider); ("model", model_id)]
       seconds
-  | None -> ()
+  | (Ms_invalid_not_finite | Ms_invalid_non_positive) as invalid ->
+    Prometheus.inc_counter streaming_first_chunk_invalid_metric
+      ~labels:
+        [ ("provider", provider)
+        ; ("model", model_id)
+        ; ("reason", ms_invalid_reason invalid)
+        ]
+      ()
 
 let emit_streaming_chunk ~provider ~model_id ~chunk_index ~inter_chunk_ms =
   remember_provider ~model_id ~provider;
-  match seconds_of_ms inter_chunk_ms with
-  | Some seconds ->
+  match classify_ms inter_chunk_ms with
+  | Ms_valid seconds ->
     Otel_spans.add_event
       ~name:"streaming.chunk"
       ~attrs:
@@ -211,7 +330,14 @@ let emit_streaming_chunk ~provider ~model_id ~chunk_index ~inter_chunk_ms =
     Prometheus.observe_histogram streaming_inter_chunk_metric
       ~labels:[("provider", provider); ("model", model_id)]
       seconds
-  | None -> ()
+  | (Ms_invalid_not_finite | Ms_invalid_non_positive) as invalid ->
+    Prometheus.inc_counter streaming_inter_chunk_invalid_metric
+      ~labels:
+        [ ("provider", provider)
+        ; ("model", model_id)
+        ; ("reason", ms_invalid_reason invalid)
+        ]
+      ()
 
 let emit_circuit_state ~provider ~model_id ~provider_key ~state =
   remember_provider ~model_id ~provider;
@@ -271,15 +397,31 @@ let emit_request_latency_clamped ~provider ~model_id ~reason =
     same histogram without duplicating the label shape.  This is the
     single source of truth for the label key names. *)
 let emit_request_latency ?provider ~model_id ~latency_ms () =
-  let provider = provider_for_latency ?provider ~model_id () in
+  let resolution = resolve_provider_for_latency ?provider ~model_id () in
+  let provider_label = provider_label_of_resolution resolution in
+  (* The clamped counter is the operator surface for *both* invalid
+     [latency_ms] inputs and unknown-provider attribution. Two distinct
+     [reason] label values keep the bug classes separable. *)
+  (match resolution with
+   | Provider_unknown_no_model_id ->
+     emit_request_latency_clamped
+       ~provider:provider_label
+       ~model_id
+       ~reason:"provider_unknown_no_model_id"
+   | Provider_unknown_cache_miss _ ->
+     emit_request_latency_clamped
+       ~provider:provider_label
+       ~model_id
+       ~reason:"provider_unknown_cache_miss"
+   | Provider_explicit _ | Provider_cached _ -> ());
   if latency_ms <= 0 then
     emit_request_latency_clamped
-      ~provider
+      ~provider:provider_label
       ~model_id
       ~reason:"non_positive_latency_ms";
   let seconds = request_latency_seconds ~latency_ms in
   Prometheus.observe_histogram request_latency_metric
-    ~labels:[("provider", provider); ("model", model_id)] seconds
+    ~labels:[("provider", provider_label); ("model", model_id)] seconds
 
 (** Build the OAS Metrics.t sink.
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -746,6 +746,8 @@ let metric_llm_provider_request_latency = "masc_llm_provider_request_latency_sec
 let metric_llm_provider_request_latency_clamped = "masc_llm_provider_request_latency_clamped_total"
 let metric_llm_provider_streaming_first_chunk = "masc_llm_provider_streaming_first_chunk_seconds"
 let metric_llm_provider_streaming_inter_chunk = "masc_llm_provider_streaming_inter_chunk_seconds"
+let metric_llm_provider_streaming_first_chunk_invalid = "masc_llm_provider_streaming_first_chunk_invalid_total"
+let metric_llm_provider_streaming_inter_chunk_invalid = "masc_llm_provider_streaming_inter_chunk_invalid_total"
 let metric_llm_provider_capability_drops = "masc_llm_provider_capability_drops_total"
 let metric_llm_provider_cache_hits = "masc_llm_provider_cache_hits_total"
 let metric_llm_provider_cache_misses = "masc_llm_provider_cache_misses_total"
@@ -2249,6 +2251,18 @@ let init () =
     ~help:"OAS streaming time to first parsed chunk. Labels: provider, model." ();
   register_histogram ~name:metric_llm_provider_streaming_inter_chunk
     ~help:"OAS streaming inter-chunk gap. Labels: provider, model." ();
+  add
+    metric_llm_provider_streaming_first_chunk_invalid
+    "Total OAS streaming first-chunk observations rejected before histogram emission \
+     because the [ttfrc_ms] input was non-finite or non-positive. Labels: provider, \
+     model, reason (not_finite | non_positive)."
+    Counter;
+  add
+    metric_llm_provider_streaming_inter_chunk_invalid
+    "Total OAS streaming inter-chunk observations rejected before histogram emission \
+     because the [inter_chunk_ms] input was non-finite or non-positive. Labels: \
+     provider, model, reason (not_finite | non_positive)."
+    Counter;
   (* Process-level resource gauges.  Sampled on every /metrics scrape via
      [update_fd_gauges] so a monotonic ramp (fd leak) is visible in the
      time series before it crosses the OS limit and crashes the server.

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -476,6 +476,8 @@ val metric_llm_provider_request_latency : string
 val metric_llm_provider_request_latency_clamped : string
 val metric_llm_provider_streaming_first_chunk : string
 val metric_llm_provider_streaming_inter_chunk : string
+val metric_llm_provider_streaming_first_chunk_invalid : string
+val metric_llm_provider_streaming_inter_chunk_invalid : string
 val metric_llm_provider_capability_drops : string
 val metric_llm_provider_cache_hits : string
 val metric_llm_provider_cache_misses : string

--- a/test/test_llm_metric_bridge.ml
+++ b/test/test_llm_metric_bridge.ml
@@ -173,6 +173,103 @@ let test_streaming_metrics_ignore_invalid_ms () =
     (Prom.metric_llm_provider_streaming_inter_chunk ^ "_count")
     ~labels ~before:inter_before ~delta:0.0
 
+let test_streaming_invalid_ms_increments_typed_counter () =
+  let model_id =
+    Printf.sprintf "bridge-streaming-typed-%d" (Unix.getpid ())
+  in
+  let provider = "bridge-streaming-typed-provider" in
+  let first_non_positive =
+    [ ("provider", provider); ("model", model_id); ("reason", "non_positive") ]
+  in
+  let inter_not_finite =
+    [ ("provider", provider); ("model", model_id); ("reason", "not_finite") ]
+  in
+  let before_first =
+    metric Prom.metric_llm_provider_streaming_first_chunk_invalid
+      ~labels:first_non_positive
+  in
+  let before_inter =
+    metric Prom.metric_llm_provider_streaming_inter_chunk_invalid
+      ~labels:inter_not_finite
+  in
+  Bridge.emit_streaming_first_chunk ~provider ~model_id ~ttfrc_ms:0.0;
+  Bridge.emit_streaming_chunk
+    ~provider ~model_id ~chunk_index:1 ~inter_chunk_ms:(0.0 /. 0.0);
+  check_metric_delta "streaming first chunk non_positive +1"
+    Prom.metric_llm_provider_streaming_first_chunk_invalid
+    ~labels:first_non_positive ~before:before_first ~delta:1.0;
+  check_metric_delta "streaming inter chunk not_finite +1"
+    Prom.metric_llm_provider_streaming_inter_chunk_invalid
+    ~labels:inter_not_finite ~before:before_inter ~delta:1.0
+
+let test_streaming_invalid_ms_distinguishes_not_finite_from_non_positive () =
+  let model_id =
+    Printf.sprintf "bridge-streaming-distinct-%d" (Unix.getpid ())
+  in
+  let provider = "bridge-streaming-distinct-provider" in
+  let first_not_finite =
+    [ ("provider", provider); ("model", model_id); ("reason", "not_finite") ]
+  in
+  let first_non_positive =
+    [ ("provider", provider); ("model", model_id); ("reason", "non_positive") ]
+  in
+  let before_nf =
+    metric Prom.metric_llm_provider_streaming_first_chunk_invalid
+      ~labels:first_not_finite
+  in
+  let before_np =
+    metric Prom.metric_llm_provider_streaming_first_chunk_invalid
+      ~labels:first_non_positive
+  in
+  Bridge.emit_streaming_first_chunk
+    ~provider ~model_id ~ttfrc_ms:Float.infinity;
+  Bridge.emit_streaming_first_chunk
+    ~provider ~model_id ~ttfrc_ms:(-1.0);
+  check_metric_delta "infinity routes to not_finite reason"
+    Prom.metric_llm_provider_streaming_first_chunk_invalid
+    ~labels:first_not_finite ~before:before_nf ~delta:1.0;
+  check_metric_delta "negative routes to non_positive reason"
+    Prom.metric_llm_provider_streaming_first_chunk_invalid
+    ~labels:first_non_positive ~before:before_np ~delta:1.0
+
+let test_request_latency_cache_miss_clamped_counter () =
+  let model_id =
+    Printf.sprintf "bridge-latency-cache-miss-%d" (Unix.getpid ())
+  in
+  let clamp_labels =
+    [ ("provider", "unknown")
+    ; ("model", model_id)
+    ; ("reason", "provider_unknown_cache_miss")
+    ]
+  in
+  let before =
+    metric Prom.metric_llm_provider_request_latency_clamped
+      ~labels:clamp_labels
+  in
+  (* Caller omits [?provider] and the cache has no entry for this
+     freshly-minted [model_id] — previously silently fell back to the
+     [unknown] label with no operator signal. *)
+  Bridge.emit_request_latency ~model_id ~latency_ms:42 ();
+  check_metric_delta "cache miss provider attribution increments clamp counter"
+    Prom.metric_llm_provider_request_latency_clamped
+    ~labels:clamp_labels ~before ~delta:1.0
+
+let test_request_latency_no_model_id_clamped_counter () =
+  let clamp_labels =
+    [ ("provider", "unknown")
+    ; ("model", "")
+    ; ("reason", "provider_unknown_no_model_id")
+    ]
+  in
+  let before =
+    metric Prom.metric_llm_provider_request_latency_clamped
+      ~labels:clamp_labels
+  in
+  Bridge.emit_request_latency ~model_id:"" ~latency_ms:42 ();
+  check_metric_delta "empty model_id increments distinct clamp reason"
+    Prom.metric_llm_provider_request_latency_clamped
+    ~labels:clamp_labels ~before ~delta:1.0
+
 let assoc_string key attrs =
   match List.assoc_opt key attrs with
   | Some (`String value) -> value
@@ -335,6 +432,19 @@ let () =
             test_sink_records_oas_callbacks;
           Alcotest.test_case "streaming metrics ignore invalid ms" `Quick
             test_streaming_metrics_ignore_invalid_ms;
+          Alcotest.test_case
+            "streaming invalid ms increments typed counter" `Quick
+            test_streaming_invalid_ms_increments_typed_counter;
+          Alcotest.test_case
+            "streaming invalid ms distinguishes not_finite from non_positive"
+            `Quick
+            test_streaming_invalid_ms_distinguishes_not_finite_from_non_positive;
+          Alcotest.test_case
+            "request latency cache miss increments typed clamp reason" `Quick
+            test_request_latency_cache_miss_clamped_counter;
+          Alcotest.test_case
+            "request latency no model_id increments typed clamp reason" `Quick
+            test_request_latency_no_model_id_clamped_counter;
           Alcotest.test_case "streaming callbacks emit OTel events" `Quick
             test_streaming_callbacks_emit_otel_events;
           Alcotest.test_case "request latency floors zero ms" `Quick


### PR DESCRIPTION
## Why

Hunter audit flagged five silent failures along the OAS → Prometheus telemetry bridge in `lib/llm_metric_bridge.ml`. Sister PR to #15502, which closed seven analogous defaults in `lib/model_inference_metrics.ml`. CLAUDE.md classifies the family as:

- AI antipatterns §2 — Unknown → Permissive Default
- Workaround rejection bar §1 — Telemetry-as-fix (instrument failure but do not fix)

Concrete impact before this PR: streaming first-chunk latency observations with `ttfrc_ms = NaN` or `≤ 0` were silently dropped with **no operator signal**. A request latency call without `~provider` and with a model_id that hadn't yet appeared on `on_http_status` was labeled `provider="unknown"` and the cache miss was indistinguishable from "we genuinely don't know the provider for this call shape."

## Sites closed (5)

Line numbers refer to the pre-change file.

| Line | Symptom | Replacement |
|-----:|---------|-------------|
| 76-84 | `provider_for_latency` cache miss → `Option.value ~default:unknown_provider_label` | `provider_resolution` variant (`Provider_explicit \| Provider_cached \| Provider_unknown_no_model_id \| Provider_unknown_cache_miss`) projected to the same label, but routed to two new typed `request_latency_clamped` reasons |
| 127 | `error_reason_label` empty input → `"unknown"` catch-all | `Reason_absent` variant (label-equivalent) |
| 143 | `error_reason_label` substring sieve fall-through → `"unknown"` catch-all | `Reason_unmapped { trimmed_lower }` variant (label-equivalent, preserves trimmed substring for future closure) |
| 196 | `emit_streaming_first_chunk` invalid `ttfrc_ms` → `\| None -> ()` silent drop | `ms_duration` variant + new `masc_llm_provider_streaming_first_chunk_invalid_total{reason}` counter |
| 214 | `emit_streaming_chunk` invalid `inter_chunk_ms` → `\| None -> ()` silent drop | `ms_duration` variant + new `masc_llm_provider_streaming_inter_chunk_invalid_total{reason}` counter |

## Type signature delta

All new types are **module-private** (not exposed in `.mli`). Public surface is byte-identical: `emit_http_status`, `emit_request_latency`, `emit_capability_drop`, `emit_cache_hit`, `emit_cache_miss`, `emit_request_start`, `emit_error`, `emit_retry`, `emit_circuit_state`, `emit_token_usage`, `emit_streaming_first_chunk`, `emit_streaming_chunk`, `emit_fallback_triggered`, `make_sink`, `install` keep their existing signatures.

```ocaml
(* internal, lib/llm_metric_bridge.ml only *)
type provider_resolution =
  | Provider_explicit of string
  | Provider_cached of string
  | Provider_unknown_no_model_id
  | Provider_unknown_cache_miss of { model_id : string }

type error_reason =
  | Reason_timeout | Reason_cancelled | Reason_rate_limit | Reason_quota
  | Reason_capacity | Reason_auth | Reason_network | Reason_parse
  | Reason_invalid_request | Reason_provider_error
  | Reason_unmapped of { trimmed_lower : string }
  | Reason_absent

type ms_duration =
  | Ms_valid of float
  | Ms_invalid_not_finite
  | Ms_invalid_non_positive
```

`.mli` additions are **two** new Prometheus metric-name constants only:

```diff
+val metric_llm_provider_streaming_first_chunk_invalid : string
+val metric_llm_provider_streaming_inter_chunk_invalid : string
```

## Caller blast radius

- `rg "Llm_metric_bridge\." lib/ bin/ test/` → **18 references in 5 files** (`server_runtime_bootstrap.ml`, `cascade/cascade_legacy_runner.{ml,mli}`, `cascade/cascade_oas_runner.ml`, `cascade/cascade_event_bridge.ml`).
- All 18 sites reference only `emit_*` / `install` / metric-name constants — **no caller** references the renamed internal helpers (`provider_for_latency` → `resolve_provider_for_latency`, `seconds_of_ms` → `classify_ms`, `error_reason_label` now consumes the variant).
- No `.mli` signature breakage. No external file modified.

## Cardinality budget (unchanged)

- `error_reason` label: 10 known reasons + `unknown` (both new variants project to `unknown`). Same ~10-value bound.
- `provider` label on `request_latency_seconds`: both `Provider_unknown_*` variants project to `unknown_provider_label`. Same 6 × 10 × 10 = 600 bound documented at the top of the file.
- New `streaming_*_invalid_total{provider,model,reason}` counters: reason ∈ `{not_finite, non_positive}`, bounded by `2 × providers × models`.

## Behaviour change

| | Before | After |
|--|--------|-------|
| Streaming invalid `ttfrc_ms` / `inter_chunk_ms` (NaN / ±∞ / ≤ 0) | silently dropped, no signal | dropped from histogram (preserved) **and** typed counter increments with `reason ∈ {not_finite, non_positive}` |
| Request latency cache miss (no `~provider`, cache empty for `model_id`) | `provider="unknown"` label, no signal | label preserved **and** `request_latency_clamped_total{reason="provider_unknown_cache_miss"}` increments |
| Request latency empty `model_id` (no `~provider`) | `provider="unknown"` label, no signal | label preserved **and** `request_latency_clamped_total{reason="provider_unknown_no_model_id"}` increments |
| `error_reason` label values | 10 known + `unknown` | identical |
| `provider`, `model` label values on histograms | unchanged | unchanged |

The existing test `streaming metrics ignore invalid ms` (which asserts the histogram count delta is `0.0` for an invalid input) still passes — the histogram drop is preserved. The new counter is *additive* signal, not a behaviour escape hatch.

## Tests

- `dune build --root . @check` — clean
- `dune exec --root . test/test_llm_metric_bridge.exe` — **12/12 green** (8 existing + 4 new)

New test cases added:
- `streaming invalid ms increments typed counter` — asserts `ttfrc_ms=0.0` and `inter_chunk_ms=NaN` each increment their respective typed-reason counters.
- `streaming invalid ms distinguishes not_finite from non_positive` — asserts `Infinity` routes to `reason=not_finite` and `-1.0` routes to `reason=non_positive`, distinct rows.
- `request latency cache miss increments typed clamp reason` — asserts a fresh `model_id` with omitted `?provider` increments `request_latency_clamped{reason="provider_unknown_cache_miss"}`.
- `request latency no model_id increments typed clamp reason` — asserts empty `model_id` with omitted `?provider` increments `request_latency_clamped{reason="provider_unknown_no_model_id"}`.

## Workaround-rejection self-check (CLAUDE.md §워크어라운드 거부 기준)

- [x] **Not telemetry-as-fix**: typed variants *are* the fix at the classification boundary; the new counters make previously silent drops visible. Future OAS typed errors can map directly into `error_reason` without expanding the substring sieve.
- [x] **No new string/substring classifier**: the existing 10-branch substring sieve in `classify_error_reason` is unchanged in scope. The variant is the new surface.
- [x] **No N-of-M patch**: all 5 sites closed in this PR.
- [x] **No catch-all `_ ->` added**: the only `_ ->` is the unreachable `assert false` in `ms_invalid_reason`, justified by a comment. Adding a new invalid variant to `ms_duration` forces a compile error at the call sites because they match `Ms_invalid_not_finite | Ms_invalid_non_positive` explicitly.
- [x] **No cap/cooldown/dedup/repair**.
- [x] **No `set_X_for_test` / `reset_for_test` backdoor**.
- [x] **No same-typo fix in N sites**.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>