### PR TITLE
fix(opam): drop unused pbrt_services + neo4j_bolt_eio + ctypes + ctypes-foreign deps

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -56,8 +56,6 @@
   (sqlite3 (>= 5.1))
   (mirage-crypto (>= 1.0))
   (mirage-crypto-rng (>= 1.0))
-  (ctypes (>= 0.20))
-  (ctypes-foreign (>= 0.20))
   (integers (>= 0.7))
   (zstd (>= 0.4))
   (httpun (>= 0.2))
@@ -72,6 +70,11 @@
   (digestif (>= 1.1))
   (ocaml-protoc-plugin (>= 4.0))
   (pbrt (and (>= 3.0) (< 4.0)))
+  ; [ctypes] + [ctypes-foreign] removed: zero callers in lib/ bin/ test/
+  ; since webrtc_bindings.ml was removed (per lib/dune:252 comment).
+  ; Confirmed by `rg '\bctypes\b' lib/ bin/ test/` = empty.  Audited
+  ; continuous-loop iter #17 (2026-05-15).  Re-add if native FFI work
+  ; resumes.
   ; [pbrt_services] removed: no caller in lib/ bin/ test/ since
   ; continuous-loop iter #11 audit (2026-05-15).  Re-add if gRPC
   ; service support resumes.

--- a/dune-project
+++ b/dune-project
@@ -72,7 +72,9 @@
   (digestif (>= 1.1))
   (ocaml-protoc-plugin (>= 4.0))
   (pbrt (and (>= 3.0) (< 4.0)))
-  (pbrt_services (and (>= 3.0) (< 4.0)))
+  ; [pbrt_services] removed: no caller in lib/ bin/ test/ since
+  ; continuous-loop iter #11 audit (2026-05-15).  Re-add if gRPC
+  ; service support resumes.
   (h2 (>= 0.13))
   (h2-eio (>= 0.13))
   (alcotest (and :with-test (>= 1.6)))

--- a/dune-project
+++ b/dune-project
@@ -83,8 +83,10 @@
   (bisect_ppx (and :with-test (>= 2.8)))
   (mtime (>= 2.0))
   (uuidm (>= 0.9))
-  ; Neo4j Bolt native driver
-  (neo4j_bolt_eio (>= 0.4))
+  ; [neo4j_bolt_eio] removed: no caller in lib/ bin/ test/ since
+  ; continuous-loop iter #12 audit (2026-05-15).  Same shape as
+  ; pbrt_services (iter #11): declared but never imported.  Re-add
+  ; when Neo4j Bolt support resumes.
   ; OpenTelemetry observability + OTLP exporter
   (opentelemetry (>= 0.13))
   (ambient-context-eio (>= 0.2))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -54,7 +54,6 @@ depends: [
   "digestif" {>= "1.1"}
   "ocaml-protoc-plugin" {>= "4.0"}
   "pbrt" {>= "3.0" & < "4.0"}
-  "pbrt_services" {>= "3.0" & < "4.0"}
   "h2" {>= "0.13"}
   "h2-eio" {>= "0.13"}
   "alcotest" {with-test & >= "1.6"}

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -62,7 +62,6 @@ depends: [
   "bisect_ppx" {with-test & >= "2.8"}
   "mtime" {>= "2.0"}
   "uuidm" {>= "0.9"}
-  "neo4j_bolt_eio" {>= "0.4"}
   "opentelemetry" {>= "0.13"}
   "ambient-context-eio" {>= "0.2"}
   "crunch" {build & >= "4.0"}


### PR DESCRIPTION
## Summary

Four opam dependencies declared in `dune-project` but with zero callers in `lib/ bin/ test/`. Same axis: opam dep left declared after sole consumer was removed.

## Commits

| Commit | Dep | Reason |
|---|---|---|
| 1dcc444969 | `pbrt_services` | no `Pbrt_services` import anywhere |
| 9337e1fc7a | `neo4j_bolt_eio` | no `Neo4j_bolt_eio` import anywhere |
| 010a651f9e | `ctypes` + `ctypes-foreign` | sole consumer `lib/webrtc_bindings.ml` removed (per `lib/dune:252`) |

## Verification

```
rg '\bPbrt_services\b' lib/ bin/ test/    # empty
rg 'Neo4j_bolt_eio' lib/ bin/ test/        # empty
rg '\bctypes\b' lib/ bin/ test/            # empty
rg 'ctypes-foreign|Ctypes_foreign' lib/ bin/ test/  # empty
find lib bin -name 'webrtc_bindings*'      # empty
```

## Re-add condition

Comments in dune-project specify re-add condition for each:
- `pbrt_services`: gRPC service support resumes
- `neo4j_bolt_eio`: Neo4j Bolt support resumes
- `ctypes` + `ctypes-foreign`: native FFI work resumes

## Audit context

Continuous-loop iter #11 (pbrt_services), iter #12 (neo4j_bolt_eio), iter #17 (ctypes/ctypes-foreign). Each iteration found same root cause: comment-only "removed" mark on consumer but dep declaration still alive.

## Zero workaround signatures

Pure dead-dep deletion. No counters, no string classifiers, no caps, no N-of-M (all 4 deps cleaned in same PR per same axis).

RFC-WAIVED: opam manifest only (no credential/identity/operator/sandbox/dashboard/hook surface).