### PR TITLE
fix(board_core_payload): typed parse error for malformed meta_json

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -610,9 +610,21 @@ let create_post
       let now = Time_compat.now () in
       if ttl = 0 then 0.0 else now +. (Stdlib.Float.of_int ttl *. 3600.0)
     in
-    let normalized_title, normalized_body, normalized_kind, normalized_meta =
+    match
       normalize_post_payload ~content ?title ?body ~post_kind ?meta_json ()
-    in
+    with
+    | Error (Board_core_payload.Meta_not_assoc payload) ->
+        (* Reject malformed meta_json instead of silently dropping it.
+           Pre-fix behaviour at board_core_payload.ml:73 absorbed
+           non-[`Assoc] payloads (`[`String _], [`Int _], …) into an
+           empty meta object, hiding structural drift from callers. *)
+        Error
+          (Validation_error
+             (Printf.sprintf
+                "Malformed meta_json: expected JSON object, got %s"
+                (Yojson.Safe.to_string payload)))
+    | Ok (normalized_title, normalized_body, normalized_kind, normalized_meta)
+      ->
     (* Validate body length *)
     if String.length normalized_body > Limits.max_content_length
     then

--- a/lib/board_core_payload.ml
+++ b/lib/board_core_payload.ml
@@ -65,22 +65,40 @@ let meta_state_block (meta_json : Yojson.Safe.t option) =
       | _ -> None)
   | _ -> None
 
+type meta_parse_error = Meta_not_assoc of Yojson.Safe.t
+
 let merge_meta_json ?state_block (meta_json : Yojson.Safe.t option) :
-    Yojson.Safe.t option =
-  let fields =
+    (Yojson.Safe.t option, meta_parse_error) Stdlib.Result.t =
+  (* Parse-don't-validate: a non-[`Assoc] meta payload is a malformed
+     submission, not "meta absent". The pre-2026-05-15 implementation
+     silently coerced [Some (`Int _)] / [Some (`String _)] / etc. to
+     [fields = []], absorbing malformed JSON into an empty meta object.
+     We now surface those payloads as a typed [Meta_not_assoc] error so
+     callers must decide explicitly (reject, log, repair) instead of
+     letting structural drift reach [board_posts.jsonl]. *)
+  let parsed_fields =
     match meta_json with
-    | Some (`Assoc assoc) -> assoc
-    | _ -> []
+    | None -> Stdlib.Result.Ok []
+    | Some (`Assoc assoc) -> Stdlib.Result.Ok assoc
+    | Some other -> Stdlib.Result.Error (Meta_not_assoc other)
   in
-  let fields =
-    match state_block with
-    | Some block when not (String.equal block "") && not (List.mem_assoc "state_block" fields) ->
-        ("state_block", `String block) :: fields
-    | _ -> fields
-  in
-  match fields with
-  | [] -> None
-  | _ -> Some (`Assoc fields)
+  match parsed_fields with
+  | Stdlib.Result.Error _ as err -> err
+  | Stdlib.Result.Ok fields ->
+      let fields =
+        match state_block with
+        | Some block
+          when (not (String.equal block ""))
+               && not (List.mem_assoc "state_block" fields) ->
+            ("state_block", `String block) :: fields
+        | _ -> fields
+      in
+      let result =
+        match fields with
+        | [] -> None
+        | _ -> Some (`Assoc fields)
+      in
+      Stdlib.Result.Ok result
 
 let derive_post_title (body : string) =
   let first_line =
@@ -109,5 +127,8 @@ let normalize_post_payload ~content ?title ?body ~post_kind ?meta_json () =
         else derive_post_title normalized_body
     | None -> derive_post_title normalized_body
   in
-  let merged_meta = merge_meta_json ?state_block:extracted_state meta_json in
-  normalized_title, normalized_body, post_kind, merged_meta
+  match merge_meta_json ?state_block:extracted_state meta_json with
+  | Stdlib.Result.Error _ as err -> err
+  | Stdlib.Result.Ok merged_meta ->
+      Stdlib.Result.Ok
+        (normalized_title, normalized_body, post_kind, merged_meta)

--- a/lib/board_core_payload.mli
+++ b/lib/board_core_payload.mli
@@ -31,18 +31,33 @@ val meta_state_block : Yojson.Safe.t option -> string option
     a non-empty string [state_block]. Returns [None] for
     [None] / non-object / non-string / empty-after-trim values. *)
 
+type meta_parse_error = Meta_not_assoc of Yojson.Safe.t
+(** Typed parse failure for [merge_meta_json] / [normalize_post_payload].
+
+    [Meta_not_assoc payload] indicates the caller passed a
+    [Some yojson] meta value whose top-level shape is not
+    [`Assoc _] (e.g. a bare [`String _], [`Int _], or [`List _]).
+    Such payloads are malformed for board persistence — the legacy
+    behaviour silently absorbed them as an empty meta object
+    ([fields = []]) at [board_core_payload.ml:73], discarding the
+    original value without any caller-visible signal. *)
+
 val merge_meta_json :
   ?state_block:string ->
   Yojson.Safe.t option ->
-  Yojson.Safe.t option
+  (Yojson.Safe.t option, meta_parse_error) result
 (** Merge a [state_block] string into the JSON meta object.
 
-    When [meta_json] is a JSON object, [state_block] is added as
-    a [string] field iff it is [Some non_empty] and the object
+    When [meta_json] is [None] or [Some (`Assoc _)], returns
+    [Ok merged] where [merged] is the [`Assoc] payload with
+    [state_block] added iff it is [Some non_empty] and the object
     does not already contain a [state_block] entry (existing
     entries are preserved). [None] meta with no state_block
-    returns [None]; otherwise the merged [`Assoc fields] is
-    wrapped in [Some]. *)
+    yields [Ok None]; otherwise [Ok (Some (`Assoc fields))].
+
+    Returns [Error (Meta_not_assoc payload)] when [meta_json] is
+    [Some payload] with [payload] not of shape [`Assoc _]. Callers
+    must decide explicitly whether to reject, log, or repair. *)
 
 val derive_post_title : string -> string
 (** Derive a post title from [body].
@@ -62,7 +77,9 @@ val normalize_post_payload :
   post_kind:Board_types.post_kind ->
   ?meta_json:Yojson.Safe.t ->
   unit ->
-  string * string * Board_types.post_kind * Yojson.Safe.t option
+  ( string * string * Board_types.post_kind * Yojson.Safe.t option,
+    meta_parse_error )
+  result
 (** Normalise a post submission into the canonical
     [(title, body, kind, meta)] tuple persisted to
     [board_posts.jsonl].
@@ -75,4 +92,7 @@ val normalize_post_payload :
     - the body is trimmed;
     - title is the trimmed [?title] when non-empty, else
       {!derive_post_title} of the stripped body;
-    - [post_kind] is passed through unchanged. *)
+    - [post_kind] is passed through unchanged.
+
+    Returns [Error (Meta_not_assoc _)] when [?meta_json] is
+    [Some payload] with [payload] not of shape [`Assoc _]. *)

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -401,28 +401,37 @@ let post_of_yojson (json : Yojson.Safe.t) : post option =
                 ~expires_at
                 ~hearth
         in
-        let title, body, post_kind, meta_json =
-          normalize_post_payload ~content ?title:title_opt ?body:body_opt
-            ~post_kind:resolved_kind ?meta_json ()
-        in
-        Some {
-          id;
-          author;
-          title;
-          body;
-          content = body;
-          post_kind;
-          meta_json;
-          visibility;
-          created_at;
-          updated_at;
-          expires_at;
-          votes_up;
-          votes_down;
-          reply_count;
-          hearth;
-          thread_id;
-        }
+        (match
+           normalize_post_payload ~content ?title:title_opt ?body:body_opt
+             ~post_kind:resolved_kind ?meta_json ()
+         with
+         | Error (Board_core_payload.Meta_not_assoc _) ->
+             (* Row-level malformed meta_json: drop the row. The legacy
+                code path silently coerced the same payload to an empty
+                meta object at board_core_payload.ml:73, persisting a
+                "successful" row with the original meta vaporised. We
+                now reject the row outright so callers see the load
+                count drop instead of an invisible data shape change. *)
+             None
+         | Ok (title, body, post_kind, meta_json) ->
+             Some {
+               id;
+               author;
+               title;
+               body;
+               content = body;
+               post_kind;
+               meta_json;
+               visibility;
+               created_at;
+               updated_at;
+               expires_at;
+               votes_up;
+               votes_down;
+               reply_count;
+               hearth;
+               thread_id;
+             })
     | _ -> None)
   | _ -> None
 

--- a/test/test_board_core_payload.ml
+++ b/test/test_board_core_payload.ml
@@ -71,8 +71,47 @@ let test_derive_korean_with_json_roundtrip () =
        check bool "roundtrip valid UTF-8" true (is_valid_utf8 t)
    | _ -> fail "unexpected JSON shape")
 
+(* Regression: malformed meta_json must surface as a typed parse error
+   instead of being silently coerced to an empty meta object. Prior to
+   2026-05-15 the catch-all at board_core_payload.ml:73 mapped any
+   non-[`Assoc] payload to [fields = []], hiding structural drift. *)
+
+let test_merge_meta_json_none_is_ok_none () =
+  match BP.merge_meta_json None with
+  | Ok None -> ()
+  | Ok (Some _) -> fail "expected None for absent meta"
+  | Error _ -> fail "absent meta must not be a parse error"
+
+let test_merge_meta_json_assoc_is_ok_some () =
+  let meta = `Assoc [ ("k", `String "v") ] in
+  match BP.merge_meta_json (Some meta) with
+  | Ok (Some (`Assoc [ ("k", `String "v") ])) -> ()
+  | Ok _ -> fail "expected the original Assoc to round-trip"
+  | Error _ -> fail "well-formed Assoc must not error"
+
+let test_merge_meta_json_string_payload_is_error () =
+  let payload = `String "not an object" in
+  match BP.merge_meta_json (Some payload) with
+  | Error (BP.Meta_not_assoc p) when p = payload -> ()
+  | Error (BP.Meta_not_assoc _) -> fail "wrong payload in Meta_not_assoc"
+  | Ok _ ->
+      fail
+        "non-[`Assoc] meta_json must now be Error Meta_not_assoc, not Ok []"
+
+let test_merge_meta_json_int_payload_is_error () =
+  match BP.merge_meta_json (Some (`Int 42)) with
+  | Error (BP.Meta_not_assoc (`Int 42)) -> ()
+  | Error _ -> fail "wrong payload in Meta_not_assoc"
+  | Ok _ -> fail "non-[`Assoc] meta_json must error"
+
+let test_merge_meta_json_list_payload_is_error () =
+  match BP.merge_meta_json (Some (`List [ `Int 1 ])) with
+  | Error (BP.Meta_not_assoc (`List _)) -> ()
+  | Error _ -> fail "wrong payload in Meta_not_assoc"
+  | Ok _ -> fail "non-[`Assoc] meta_json must error"
+
 let () =
-  run "Board_core_payload.derive_post_title"
+  run "Board_core_payload"
     [ ( "regression-7690",
         [ test_case "short title unchanged" `Quick
             test_derive_short_title_returned_as_is;
@@ -83,4 +122,15 @@ let () =
           test_case "long Korean is valid UTF-8" `Quick
             test_derive_long_korean_title_is_valid_utf8;
           test_case "Korean JSON roundtrip" `Quick
-            test_derive_korean_with_json_roundtrip ] ) ]
+            test_derive_korean_with_json_roundtrip ] );
+      ( "meta-not-assoc-typed-parse",
+        [ test_case "None meta -> Ok None" `Quick
+            test_merge_meta_json_none_is_ok_none;
+          test_case "Assoc meta -> Ok Some" `Quick
+            test_merge_meta_json_assoc_is_ok_some;
+          test_case "`String payload -> Error Meta_not_assoc" `Quick
+            test_merge_meta_json_string_payload_is_error;
+          test_case "`Int payload -> Error Meta_not_assoc" `Quick
+            test_merge_meta_json_int_payload_is_error;
+          test_case "`List payload -> Error Meta_not_assoc" `Quick
+            test_merge_meta_json_list_payload_is_error ] ) ]


### PR DESCRIPTION
## Why

`lib/board_core_payload.ml:73` used a catch-all `_ -> []` to coerce any non-`[\`Assoc _]` `meta_json` payload (e.g. `[\`String _]`, `[\`Int _]`, `[\`List _]`) into an empty fields list. Malformed JSON was silently absorbed and persisted to `board_posts.jsonl` with `meta = None`, hiding the original payload from any caller-visible signal.

CLAUDE.md §"AI 안티패턴 §2 Unknown → Permissive Default" exact pattern: wildcard branch maps unknown input to a convenient default instead of surfacing a typed parse error.

## Single site

- 단일 처단: `lib/board_core_payload.ml:73`
- 2 callers updated: `lib/board_core.ml:614` (`create_post`), `lib/board_votes.ml:405` (`post_of_yojson` row parser)

## Type delta

```diff
+ type meta_parse_error = Meta_not_assoc of Yojson.Safe.t

- val merge_meta_json :
-   ?state_block:string -> Yojson.Safe.t option -> Yojson.Safe.t option
+ val merge_meta_json :
+   ?state_block:string ->
+   Yojson.Safe.t option ->
+   (Yojson.Safe.t option, meta_parse_error) result

- val normalize_post_payload : ... -> string * string * post_kind * Yojson.Safe.t option
+ val normalize_post_payload : ... ->
+   (string * string * post_kind * Yojson.Safe.t option, meta_parse_error) result
```

`Ok None` = absent meta. `Ok (Some assoc)` = well-formed Assoc. `Error (Meta_not_assoc payload)` = malformed.

## Caller count

`rg "Board_core_payload\.|normalize_post_payload|merge_meta_json" lib/ bin/ test/`:
- `lib/board_core.ml:614` — propagates as `Validation_error "Malformed meta_json: ..."`.
- `lib/board_votes.ml:405` — drops the row (returns `None`) instead of persisting an "empty meta" round-trip.
- `test/test_board_core_payload.ml` — 5 new typed-parse cases.

No other callers. Public re-export via `Board_core` unaffected (signature delta propagates correctly).

## Behavior change

- `Board.create_post ~meta_json:(\`String "garbage")` → now `Error (Validation_error "Malformed meta_json: \"garbage\"")` instead of silently succeeding with `meta = None`.
- `Board_votes.post_of_yojson` on a JSONL row whose `meta` column is non-`Assoc` → row is now dropped (load count -1) instead of parsing as a post with `meta = None`.
- Well-formed paths (None / Assoc) unchanged.

## Verification

- `dune build --root . @check` — PASS
- `dune exec test/test_board_core_payload.exe` — 10 tests PASS (5 legacy + 5 new typed-parse)
- `dune exec` for related board tests (TTL, vote_quarantine, attachment_meta, moderation) — all PASS

## Workaround Rejection Bar self-check (CLAUDE.md §워크어라운드 거부 기준)

1. ☐ Not telemetry-as-fix — payload is rejected, not counted.
2. ☐ Not a string/substring classifier — typed closed sum variant.
3. ☐ Single site (line 73); no N-of-M deferral.
4. ☐ Removes a `_ ->` catch-all, does not add one.
5. ☐ No cap/cooldown/dedup/repair; malformed input rejected outright.
6. ☐ No test backdoor.
7. ☐ Single-site fix, no codemod needed.

All 7 checks pass. This is the typed-variant root fix, not a workaround.

## RFC waiver

`board_core_payload` does not match any subsystem listed in `agent_delegation` (no credential / identity / repo / operator / sandbox / hooks / workflow). `RFC-WAIVED: scope limited to lib/board_core_payload single-site typed parse error; no architectural change.`

## Draft

This PR stays Draft. Ready transition is the user's call (Draft Auto-Merge Guard applies).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>