### PR TITLE
fix(keeper_checkpoint_store): typed prune outcome eliminates silent failure

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -43,15 +43,26 @@ let max_checkpoints_retained = 3
 (* Prune                                                              *)
 (* ================================================================ *)
 
-let prune ~(session_dir : string) ~(keep : int) : int =
+(** Outcome of a [prune] pass. [removed] counts files successfully
+    deleted; [failed] counts files whose [Sys.remove] raised
+    (already logged + counted in [metric_keeper_checkpoint_failures]).
+    Returning both lets the caller distinguish "nothing to do"
+    ([removed=0; failed=0]) from "every deletion failed"
+    ([removed=0; failed=N]) — the previous [int] return collapsed
+    them and forced the caller to [ignore] both cases. *)
+type prune_outcome = { removed : int; failed : int }
+
+let prune ~(session_dir : string) ~(keep : int) : prune_outcome =
   let files = list_checkpoints ~session_dir in
-  if List.length files <= keep then 0
+  if List.length files <= keep then { removed = 0; failed = 0 }
   else
     let to_remove = List.filteri (fun i _ -> i >= keep) files in
+    let failed = ref 0 in
     List.iter (fun filename ->
       let path = Filename.concat session_dir filename in
       (try Sys.remove path
        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+         incr failed;
          Log.Keeper.warn "checkpoint cleanup failed for %s: %s"
            path (Printexc.to_string exn);
          Prometheus.inc_counter
@@ -59,7 +70,8 @@ let prune ~(session_dir : string) ~(keep : int) : int =
            ~labels:[("keeper", "aggregate"); ("operation", Keeper_checkpoint_failure_operation.(to_label Cleanup))]
            ()))
       to_remove;
-    List.length to_remove
+    let attempted = List.length to_remove in
+    { removed = attempted - !failed; failed = !failed }
 
 (* ================================================================ *)
 (* Save                                                               *)
@@ -85,8 +97,21 @@ let save
   let content = Yojson.Safe.to_string json in
   match Keeper_fs.save_atomic path content with
   | Ok () ->
-    (* Auto-prune old checkpoints after each save *)
-    ignore (prune ~session_dir ~keep:max_checkpoints_retained)
+    (* Auto-prune old checkpoints after each save. Per-file deletion
+       errors are logged + counted in [metric_keeper_checkpoint_failures]
+       inside [prune]; we additionally surface the aggregate count here
+       so that storage-growth incidents have a single Log.warn line in
+       the save audit trail instead of being visible only via metrics.
+       Bug-hunter audit 2026-05-15: the previous [ignore] discarded both
+       the success count and the failure count, leaving prune-storm
+       failures silent at the save call site. *)
+    let { removed = _; failed } =
+      prune ~session_dir ~keep:max_checkpoints_retained
+    in
+    if failed > 0 then
+      Log.Keeper.warn
+        "checkpoint prune partial failure for %s: %d file(s) failed to delete"
+        session_dir failed
   | Error msg ->
     Log.Keeper.warn "save_checkpoint failed for %s: %s" path msg;
     Prometheus.inc_counter

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -17,9 +17,16 @@ val list_checkpoints : session_dir:string -> string list
 (** Number of legacy checkpoints retained after [save] auto-prune. *)
 val max_checkpoints_retained : int
 
-(** Remove all legacy checkpoints beyond the [keep] most recent.
-    Returns the number deleted. *)
-val prune : session_dir:string -> keep:int -> int
+(** Outcome of [prune]: [removed] is the count of files successfully
+    deleted, [failed] is the count whose [Sys.remove] raised (each
+    already logged + counted in
+    [Keeper_metrics.metric_keeper_checkpoint_failures]). Returning
+    both lets callers distinguish "nothing to do" from "every
+    deletion failed" — see bug-hunter audit 2026-05-15. *)
+type prune_outcome = { removed : int; failed : int }
+
+(** Remove all legacy checkpoints beyond the [keep] most recent. *)
+val prune : session_dir:string -> keep:int -> prune_outcome
 
 (** Atomically write [ckpt] to [session_dir/<id>.json]; auto-prunes
     older entries to [max_checkpoints_retained]. Logs and swallows


### PR DESCRIPTION
## Why

Bug-hunter audit 2026-05-15 flagged `lib/keeper/keeper_checkpoint_store.ml:89`:

```ocaml
| Ok () ->
  (* Auto-prune old checkpoints after each save *)
  ignore (prune ~session_dir ~keep:max_checkpoints_retained)
```

Per-file `Sys.remove` failures inside `prune` were already logged + counted in `Keeper_metrics.metric_keeper_checkpoint_failures`, **but the aggregate count never surfaced at the save call site**. A prune-storm (e.g. all 3 retained checkpoints fail to delete due to a transient FS error) was visible only through Prometheus, not in the save audit trail. CLAUDE.md §"AI 안티패턴 §1 Result swallowing".

## Single site

- File: `lib/keeper/keeper_checkpoint_store.ml` (also `.mli`)
- Site: line 89 (now lines 100-103 after the fix)
- No other sites touched

## Type delta

```diff
-val prune : session_dir:string -> keep:int -> int
+type prune_outcome = { removed : int; failed : int }
+val prune : session_dir:string -> keep:int -> prune_outcome
```

Internal record, not a `Result.t` — pre-existing per-file recovery semantics are preserved (one bad file does not cancel the rest); aggregate failure count is now reported.

## Caller count

```
$ rg "Keeper_checkpoint_store\.prune\b" lib/ bin/ test/
(0 hits)
```

`prune` has no external callers. `Keeper_checkpoint_store.save` is called from `lib/keeper/keeper_context_core.ml:872`; its `unit` signature is unchanged. **Caller blast: 0**.

## Behavior change

| Before | After |
|---|---|
| Prune return value `ignore`d | `failed > 0` → single aggregate `Log.warn "checkpoint prune partial failure for %s: %d file(s) failed to delete"` |
| Storage growth from repeated cleanup failures invisible in save audit | Save site explicitly logs aggregate failure count |
| Per-file `Log.warn` + Prometheus counter unchanged | Same — preserved as cardinality safety net |

## Workaround self-check (CLAUDE.md §rejection bar)

1. **telemetry-as-fix**: ❌ — counter pre-existed; this PR surfaces aggregate at the **call site**, not invented as a substitute for fix.
2. **string classifier**: ❌ — typed closed record (`{removed; failed}`), exhaustive destructure at the call site.
3. **N-of-M patch**: ❌ — single site, full caller audit (0 external callers).
4. **catch-all `_ ->` added**: ❌ — none added or removed.
5. **cap/cooldown/dedup/repair**: ❌.
6. **test backdoor**: ❌.
7. **N-site typo / fan-out fix**: ❌ — single conceptual change.

## Local verification

```
$ dune build --root . @check                     # green
$ dune exec test/test_keeper_checkpoint_classify.exe   # 7/7 OK
```

(`--cache=disabled` locally — shared dune cache was serving a stale test cmi for this module path; cf. `reference_masc_mcp_ci_build_test_skips` keeper/ changes can be CI-skipped via Detect Changed Surfaces gate, so local dune exec is the load-bearing signal.)

## RFC-0086 conflict risk

keeper/ namespace promotion is in flight. Audited:
- PR-2A merged (lib/keeper/ prefix sweep, no signature changes)
- PR-2C draft is scope-A prefix-only, doesn't touch `keeper_checkpoint_store.ml` semantics
- This PR changes a function signature inside an already-`keeper_`-prefixed file

Conflict surface: low. Worst case = textual conflict on the prune block if RFC-0086 PR concurrently edits this file, resolved by re-applying the typed return.

## Draft

Stays Draft. Ready transition awaits user `human-approved-ready` label per `reference_masc_mcp_draft_auto_merge_guard`.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>