### PR TITLE
feat(dashboard): group telemetry by turn

### DIFF
--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -275,7 +275,7 @@ describe('TelemetryUnified', () => {
   })
 
   it('hydrates telemetry scope and entry focus from route params', async () => {
-    window.location.hash = '#monitoring?section=fleet-health&view=event-log&session_id=sess-route&operation_id=op-route&worker_run_id=wr-route&q=turn-9'
+    window.location.hash = '#monitoring?section=fleet-health&view=event-log&source=oas_event&n=500&session_id=sess-route&operation_id=op-route&worker_run_id=wr-route&q=turn-9'
     const fetchTelemetry = vi.fn().mockResolvedValue({
       ...baseTelemetry,
       count: 2,
@@ -310,14 +310,17 @@ describe('TelemetryUnified', () => {
     await flushUi()
 
     expect(fetchTelemetry).toHaveBeenCalledWith(expect.objectContaining({
+      source: 'oas_event',
       session_id: 'sess-route',
       operation_id: 'op-route',
       worker_run_id: 'wr-route',
-      n: 100,
+      n: 500,
     }))
     expect(container.textContent).toContain('session sess-route')
     expect(container.textContent).toContain('operation op-route')
     expect(container.textContent).toContain('worker_run wr-route')
+    expect(container.textContent).toContain('source OAS 이벤트')
+    expect(container.textContent).toContain('limit 500')
     expect(container.textContent).toContain('focus turn-9')
     expect(container.querySelector('[data-testid="telemetry-route-focus"]')).not.toBeNull()
     expect(container.textContent).toContain('SESSION sess-route')
@@ -325,6 +328,10 @@ describe('TelemetryUnified', () => {
     expect(container.textContent).toContain('WORKER wr-route')
     expect(container.textContent).toContain('QUERY turn-9')
     expect(container.textContent).toContain('1 focused item')
+    const sourceSelect = container.querySelector<HTMLSelectElement>('select[aria-label="텔레메트리 소스 필터"]')
+    expect(sourceSelect?.value).toBe('oas_event')
+    const limitSelect = container.querySelector<HTMLSelectElement>('select[aria-label="표시 개수 제한"]')
+    expect(limitSelect?.value).toBe('500')
     const searchInput = container.querySelector<HTMLInputElement>('input[aria-label="엔트리 텍스트 검색"]')
     expect(searchInput?.value).toBe('turn-9')
     expect(container.textContent).toContain('검색 매치 1건')
@@ -344,6 +351,8 @@ describe('TelemetryUnified', () => {
     expect(window.location.hash).not.toContain('operation_id=')
     expect(window.location.hash).not.toContain('worker_run_id=')
     expect(window.location.hash).not.toContain('q=')
+    expect(window.location.hash).toContain('source=oas_event')
+    expect(window.location.hash).toContain('n=500')
   })
 
   it('renders a telemetry entry raw JSON copy action', async () => {

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -449,7 +449,7 @@ describe('TelemetryUnified', () => {
     })
     await flushUi()
 
-    expect(container.textContent).toContain('반복 그룹 1개 · 원본 3건')
+    expect(container.textContent).toContain('접힌 그룹 1개 · 원본 3건')
     expect(container.textContent).toContain('폴링 / 무동작')
     expect(container.textContent).toContain('폴링 / 무동작 · masc_status · 3 events')
     expect(container.textContent).toContain('task_claimed: keeper-alpha')
@@ -635,6 +635,131 @@ describe('TelemetryUnified', () => {
     }
     const receiptMatches = filterTelemetryDisplayItems(items, 'turn_done')
     expect(receiptMatches).toHaveLength(1)
+  })
+
+  it('groups turn-scoped lifecycle, nested telemetry_event, and tool rows', async () => {
+    const { buildTelemetryDisplayItems, filterTelemetryDisplayItems } = await loadPanel(
+      vi.fn().mockResolvedValue(baseTelemetry),
+      vi.fn().mockResolvedValue(baseSummary),
+    )
+
+    const items = buildTelemetryDisplayItems([
+      {
+        source: 'oas_event',
+        ts_unix: 1_775_709_400,
+        event_type: 'turn_ready',
+        agent_name: 'keeper-alpha-agent',
+        turn: 42,
+      },
+      {
+        source: 'oas_event',
+        ts_unix: 1_775_709_399,
+        event_type: 'telemetry_event',
+        payload: [
+          'Context_window_usage',
+          {
+            agent_name: 'keeper-alpha-agent',
+            turn: 42,
+            estimated_tokens: 1234,
+          },
+        ],
+      },
+      {
+        source: 'tool_call_io',
+        ts: 1_775_709_398,
+        keeper: 'alpha',
+        tool: 'keeper_tasks_list',
+        turn: 42,
+        runtime_contract: {
+          agent_name: 'keeper-alpha-agent',
+        },
+      },
+      {
+        source: 'oas_event',
+        ts_unix: 1_775_709_397,
+        event_type: 'telemetry_event',
+        payload: [
+          'Streaming_first_chunk',
+          {
+            provider: 'openai_compat',
+            model: 'deepseek-v4-flash:cloud',
+            ttfrc_ms: 1685,
+          },
+        ],
+      },
+    ])
+
+    expect(items[0]).toMatchObject({
+      kind: 'group',
+      category: 'turn',
+      label: 'keeper-alpha-agent · turn 42',
+      count: 3,
+    })
+    expect(items[1]).toMatchObject({ kind: 'entry' })
+    if (items[1]?.kind === 'entry') {
+      expect(items[1].entry.source).toBe('oas_event')
+      expect(items[1].entry.event_type).toBe('telemetry_event')
+    }
+
+    const contextMatches = filterTelemetryDisplayItems(items, 'Context_window_usage')
+    expect(contextMatches).toHaveLength(1)
+    expect(contextMatches[0]).toMatchObject({
+      kind: 'group',
+      category: 'turn',
+    })
+
+    const cloudMatches = filterTelemetryDisplayItems(items, 'deepseek-v4-flash:cloud')
+    expect(cloudMatches).toHaveLength(1)
+    expect(cloudMatches[0]).toMatchObject({ kind: 'entry' })
+  })
+
+  it('surfaces cloud Ollama provider details in OAS telemetry previews and search', async () => {
+    const { buildTelemetryDisplayItems, filterTelemetryDisplayItems } = await loadPanel(
+      vi.fn().mockResolvedValue(baseTelemetry),
+      vi.fn().mockResolvedValue(baseSummary),
+    )
+
+    const items = buildTelemetryDisplayItems([
+      {
+        source: 'oas_event',
+        ts_unix: 1_775_709_500,
+        event_type: 'masc:oas_worker:build',
+        agent_name: 'oas-tier-group.ollama_cloud_stable',
+        payload: {
+          agent: 'oas-tier-group.ollama_cloud_stable',
+          provider_kind: 'openai_compat',
+          model_id: 'kimi-k2.6:cloud',
+          provider_model_id: 'kimi-k2.6:cloud',
+          base_url: 'https://ollama.com/v1',
+          endpoint: 'https://ollama.com/v1/chat/completions',
+        },
+      },
+      {
+        source: 'oas_event',
+        ts_unix: 1_775_709_499,
+        event_type: 'telemetry_event',
+        payload: [
+          'Streaming_summary',
+          {
+            provider: 'openai_compat',
+            model: 'deepseek-v4-flash:cloud',
+            total_ms: 3450,
+          },
+        ],
+      },
+    ])
+
+    const buildMatches = filterTelemetryDisplayItems(items, 'ollama.com')
+    expect(buildMatches).toHaveLength(1)
+    expect(buildMatches[0]).toMatchObject({ kind: 'entry' })
+
+    const streamingMatches = filterTelemetryDisplayItems(items, 'Streaming_summary')
+    expect(streamingMatches).toHaveLength(1)
+    expect(streamingMatches[0]).toMatchObject({ kind: 'entry' })
+
+    const modelMatches = filterTelemetryDisplayItems(items, 'deepseek-v4-flash:cloud')
+    expect(modelMatches).toHaveLength(1)
+    expect(modelMatches[0]).toMatchObject({ kind: 'entry' })
   })
 
   it('expands grouped rows to reveal the condensed raw entries', async () => {

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -713,6 +713,69 @@ describe('TelemetryUnified', () => {
     expect(cloudMatches[0]).toMatchObject({ kind: 'entry' })
   })
 
+  it('keeps turn groups separated by run scope (session_id / operation_id / worker_run_id)', async () => {
+    const { buildTelemetryDisplayItems } = await loadPanel(
+      vi.fn().mockResolvedValue(baseTelemetry),
+      vi.fn().mockResolvedValue(baseSummary),
+    )
+
+    // Two different sessions reusing the same agent_name + turn number.
+    // Without run-scope in the grouping key these collapse into one row;
+    // with run-scope they MUST stay in two distinct groups.
+    const items = buildTelemetryDisplayItems([
+      {
+        source: 'oas_event',
+        ts_unix: 1_775_710_000,
+        event_type: 'turn_ready',
+        agent_name: 'keeper-alpha-agent',
+        turn: 1,
+        session_id: 'sess-foo',
+      },
+      {
+        source: 'oas_event',
+        ts_unix: 1_775_709_999,
+        event_type: 'telemetry_event',
+        session_id: 'sess-foo',
+        payload: [
+          'Context_window_usage',
+          { agent_name: 'keeper-alpha-agent', turn: 1, estimated_tokens: 100 },
+        ],
+      },
+      {
+        source: 'oas_event',
+        ts_unix: 1_775_709_998,
+        event_type: 'turn_ready',
+        agent_name: 'keeper-alpha-agent',
+        turn: 1,
+        session_id: 'sess-bar',
+      },
+      {
+        source: 'oas_event',
+        ts_unix: 1_775_709_997,
+        event_type: 'telemetry_event',
+        session_id: 'sess-bar',
+        payload: [
+          'Context_window_usage',
+          { agent_name: 'keeper-alpha-agent', turn: 1, estimated_tokens: 200 },
+        ],
+      },
+    ])
+
+    const turnGroups = items.filter(
+      (item): item is Extract<typeof item, { kind: 'group' }> =>
+        item.kind === 'group' && item.category === 'turn',
+    )
+    expect(turnGroups).toHaveLength(2)
+    expect(turnGroups[0]).toMatchObject({
+      label: 'keeper-alpha-agent · turn 1',
+      count: 2,
+    })
+    expect(turnGroups[1]).toMatchObject({
+      label: 'keeper-alpha-agent · turn 1',
+      count: 2,
+    })
+  })
+
   it('surfaces cloud Ollama provider details in OAS telemetry previews and search', async () => {
     const { buildTelemetryDisplayItems, filterTelemetryDisplayItems } = await loadPanel(
       vi.fn().mockResolvedValue(baseTelemetry),

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -776,6 +776,50 @@ describe('TelemetryUnified', () => {
     })
   })
 
+  it('does not group on turn=0 sentinel (turn-not-tracked records stay as entries)', async () => {
+    const { buildTelemetryDisplayItems } = await loadPanel(
+      vi.fn().mockResolvedValue(baseTelemetry),
+      vi.fn().mockResolvedValue(baseSummary),
+    )
+
+    // turn=0 is used by keeper telemetry as "turn not tracked" (e.g.,
+    // trajectory tool-call records). These entries must not be collapsed
+    // into a fake `actor · turn 0` group even when they share an actor.
+    const items = buildTelemetryDisplayItems([
+      {
+        source: 'tool_call_io',
+        ts: 1_775_711_000,
+        keeper: 'alpha',
+        tool: 'keeper_tasks_list',
+        turn: 0,
+        runtime_contract: { agent_name: 'keeper-alpha-agent' },
+      },
+      {
+        source: 'tool_call_io',
+        ts: 1_775_710_999,
+        keeper: 'alpha',
+        tool: 'masc_status',
+        turn: 0,
+        runtime_contract: { agent_name: 'keeper-alpha-agent' },
+      },
+      {
+        source: 'oas_event',
+        ts_unix: 1_775_710_998,
+        event_type: 'telemetry_event',
+        payload: [
+          'Context_window_usage',
+          { agent_name: 'keeper-alpha-agent', turn: 0, estimated_tokens: 50 },
+        ],
+      },
+    ])
+
+    const turnGroups = items.filter(
+      (item): item is Extract<typeof item, { kind: 'group' }> =>
+        item.kind === 'group' && item.category === 'turn',
+    )
+    expect(turnGroups).toHaveLength(0)
+  })
+
   it('surfaces cloud Ollama provider details in OAS telemetry previews and search', async () => {
     const { buildTelemetryDisplayItems, filterTelemetryDisplayItems } = await loadPanel(
       vi.fn().mockResolvedValue(baseTelemetry),

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -314,6 +314,26 @@ function telemetryTurnActor(entry: TelemetryEntry): string | null {
     ?? normalizeText(entry.agent)
 }
 
+function telemetryRunScope(entry: TelemetryEntry): string | null {
+  const payload = telemetryPayloadRecord(entry)
+  const session =
+    normalizeText(entry.session_id)
+    ?? normalizeText(recordField(payload, 'session_id'))
+    ?? normalizeText(recordField(entry.runtime_contract, 'session_id'))
+  if (session) return `S:${session}`
+  const operation =
+    normalizeText(entry.operation_id)
+    ?? normalizeText(recordField(payload, 'operation_id'))
+    ?? normalizeText(recordField(entry.runtime_contract, 'operation_id'))
+  if (operation) return `OP:${operation}`
+  const workerRun =
+    normalizeText(entry.worker_run_id)
+    ?? normalizeText(recordField(payload, 'worker_run_id'))
+    ?? normalizeText(recordField(entry.runtime_contract, 'worker_run_id'))
+  if (workerRun) return `WR:${workerRun}`
+  return null
+}
+
 function entryTurnGroupingDescriptor(entry: TelemetryEntry): {
   key: string
   category: TelemetryCondensedCategory
@@ -322,8 +342,10 @@ function entryTurnGroupingDescriptor(entry: TelemetryEntry): {
   const turn = telemetryTurn(entry)
   const actor = telemetryTurnActor(entry)
   if (turn == null || !actor) return null
+  const runScope = telemetryRunScope(entry)
+  const scopedKey = runScope ? `turn:${runScope}:${actor}:${turn}` : `turn:${actor}:${turn}`
   return {
-    key: `turn:${actor}:${turn}`,
+    key: scopedKey,
     category: 'turn',
     label: `${actor} · turn ${turn}`,
   }

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -341,7 +341,11 @@ function entryTurnGroupingDescriptor(entry: TelemetryEntry): {
 } | null {
   const turn = telemetryTurn(entry)
   const actor = telemetryTurnActor(entry)
-  if (turn == null || !actor) return null
+  // turn=0 is a "turn not tracked" sentinel in keeper telemetry (e.g.,
+  // trajectory tool-call records); collapsing on it would merge unrelated
+  // events into a fake `actor · turn 0` group. Only group on real turn ids
+  // (positive integers).
+  if (turn == null || turn <= 0 || !actor) return null
   const runScope = telemetryRunScope(entry)
   const scopedKey = runScope ? `turn:${runScope}:${actor}:${turn}` : `turn:${actor}:${turn}`
   return {

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -63,7 +63,7 @@ interface TelemetryState {
 
 const sourceMeta = telemetrySourceMeta
 
-type TelemetryCondensedCategory = 'heartbeat' | 'polling'
+type TelemetryCondensedCategory = 'heartbeat' | 'polling' | 'turn'
 
 interface TelemetryRouteFocus {
   readonly sessionId: string | null
@@ -104,6 +104,11 @@ const CONDENSED_CATEGORY_META: Record<TelemetryCondensedCategory, {
   polling: {
     label: '폴링 / 무동작',
     icon: 'P',
+    color: 'text-[var(--color-accent-fg)]',
+  },
+  turn: {
+    label: '턴',
+    icon: 'T',
     color: 'text-[var(--color-accent-fg)]',
   },
 }
@@ -148,6 +153,20 @@ function normalizeStringArray(value: unknown): string[] {
 function recordField(value: unknown, key: string): unknown {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined
   return (value as Record<string, unknown>)[key]
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+function normalizeNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
 }
 
 function uniqueStrings(values: Array<string | null | undefined>): string[] {
@@ -237,6 +256,79 @@ function canonicalToolName(value: string | null): string | null {
   return normalizeText(value)
 }
 
+function telemetryPayloadRecord(entry: TelemetryEntry): Record<string, unknown> | null {
+  const direct = recordValue(entry.payload)
+  if (direct) return direct
+  if (Array.isArray(entry.payload)) {
+    return recordValue(entry.payload[1])
+  }
+  return null
+}
+
+function telemetryPayloadKind(entry: TelemetryEntry): string | null {
+  if (Array.isArray(entry.payload)) return normalizeText(entry.payload[0])
+  return normalizeText(recordField(entry.payload, 'kind'))
+    ?? normalizeText(recordField(entry.payload, 'event_type'))
+}
+
+function telemetryPayloadProviderParts(entry: TelemetryEntry): string[] {
+  const payload = telemetryPayloadRecord(entry)
+  if (!payload) return []
+  return uniqueStrings([
+    normalizeText(recordField(payload, 'provider_kind')),
+    normalizeText(recordField(payload, 'provider')),
+    normalizeText(recordField(payload, 'model_id')),
+    normalizeText(recordField(payload, 'provider_model_id')),
+    normalizeText(recordField(payload, 'model')),
+    normalizeText(recordField(payload, 'base_url')),
+    normalizeText(recordField(payload, 'endpoint')),
+  ])
+}
+
+function compactTelemetryPayloadSearch(entry: TelemetryEntry): string {
+  const payload = entry.payload
+  if (payload == null) return ''
+  try {
+    return JSON.stringify(payload).slice(0, 4096)
+  } catch {
+    return ''
+  }
+}
+
+function telemetryTurn(entry: TelemetryEntry): number | null {
+  return normalizeNumber(entry.turn)
+    ?? normalizeNumber(recordField(telemetryPayloadRecord(entry), 'turn'))
+    ?? normalizeNumber(recordField(entry.runtime_contract, 'turn'))
+}
+
+function telemetryTurnActor(entry: TelemetryEntry): string | null {
+  const payload = telemetryPayloadRecord(entry)
+  return normalizeText(entry.agent_name)
+    ?? normalizeText(recordField(payload, 'agent_name'))
+    ?? normalizeText(recordField(entry.runtime_contract, 'agent_name'))
+    ?? normalizeText(entry.keeper_name)
+    ?? normalizeText(recordField(entry.runtime_contract, 'keeper_name'))
+    ?? normalizeText(entry.keeper)
+    ?? normalizeText(entry.name)
+    ?? normalizeText(entry.caller)
+    ?? normalizeText(entry.agent)
+}
+
+function entryTurnGroupingDescriptor(entry: TelemetryEntry): {
+  key: string
+  category: TelemetryCondensedCategory
+  label: string
+} | null {
+  const turn = telemetryTurn(entry)
+  const actor = telemetryTurnActor(entry)
+  if (turn == null || !actor) return null
+  return {
+    key: `turn:${actor}:${turn}`,
+    category: 'turn',
+    label: `${actor} · turn ${turn}`,
+  }
+}
+
 /** Per-keeper polling artifacts that fill the 100-entry window with no
  *  per-event signal: keeper_metric/heartbeat snapshots and the matching
  *  oas_event/masc:keeper:{snapshot,lifecycle} relays. We classify them as
@@ -277,6 +369,9 @@ function entryGroupingDescriptor(entry: TelemetryEntry): {
       label: 'fleet heartbeat',
     }
   }
+
+  const turnDescriptor = entryTurnGroupingDescriptor(entry)
+  if (turnDescriptor) return turnDescriptor
 
   const tool = canonicalToolName(telemetryToolName(entry))
   if (!tool || !NOISY_TOOL_NAMES.has(tool)) return null
@@ -345,15 +440,18 @@ function entryPreview(e: TelemetryEntry): string {
     }
     case 'oas_event': {
       const eventType = normalizeText(e.event_type) ?? normalizeText(e.type) ?? '(unknown event_type)'
-      const agentName = normalizeText(e.agent_name)
-      const toolName = normalizeText(e.tool_name)
-      const turn = typeof e.turn === 'number' ? e.turn : null
+      const payloadKind = telemetryPayloadKind(e)
+      const agentName = telemetryTurnActor(e)
+      const toolName = normalizeText(e.tool_name) ?? normalizeText(recordField(telemetryPayloadRecord(e), 'tool_name'))
+      const turn = telemetryTurn(e)
       const taskId = normalizeText(e.task_id)
       const parts = [
+        payloadKind,
         agentName,
         toolName,
         turn != null ? `turn ${turn}` : null,
         taskId,
+        ...telemetryPayloadProviderParts(e),
       ].filter(Boolean)
       return parts.length > 0 ? `${eventType}: ${parts.join(' · ')}` : eventType
     }
@@ -406,7 +504,8 @@ function telemetryEntryHaystack(entry: TelemetryEntry): string {
   const source = typeof entry.source === 'string' ? entry.source : ''
   const preview = entryPreview(entry)
   const badges = telemetryScopeBadges(entry).join(' ')
-  return `${source} ${preview} ${badges}`
+  const payload = entry.source === 'oas_event' ? compactTelemetryPayloadSearch(entry) : ''
+  return `${source} ${preview} ${badges} ${payload}`
 }
 
 function telemetryDisplayItemHaystack(item: TelemetryDisplayItem): string {
@@ -443,22 +542,10 @@ export function buildTelemetryDisplayItems(entries: TelemetryEntry[]): Telemetry
     oldestTs: number
     sourceKeys: Set<TelemetrySource>
     scopeBadges: string[]
-    /** Position in [items] where this group's row will eventually be
-     *  inserted via [flushGroup]. Used by the fleet-heartbeat group so it
-     *  stays at the position of its first entry even when intervening
-     *  rows of other categories have already been pushed past it. */
-    insertIndex: number
   }
 
   let activeGroup: ActiveGroup | null = null
-
-  /** A persistent group for the fleet polling/heartbeat category. Heartbeat
-   *  entries arrive interleaved with real activity, so we accumulate ALL
-   *  of them here regardless of position and only emit the merged row at
-   *  the end. The row is then spliced into [items] at the position of the
-   *  first heartbeat we saw — preserving rough chronology while collapsing
-   *  the noise. */
-  let fleetHeartbeat: ActiveGroup | null = null
+  const persistentGroups = new Map<string, ActiveGroup>()
 
   const renderGroup = (g: ActiveGroup): TelemetryDisplayItem => {
     if (g.entries.length === 1) {
@@ -506,29 +593,43 @@ export function buildTelemetryDisplayItems(entries: TelemetryEntry[]): Telemetry
     ])
   }
 
+  // Heartbeat and turn groups are causal groups, not just adjacent noisy rows.
+  // Build them up front so interleaved rows still collapse at first occurrence.
+  for (const entry of entries) {
+    const descriptor = entryGroupingDescriptor(entry)
+    if (!descriptor || (descriptor.key !== 'heartbeat:fleet' && descriptor.category !== 'turn')) {
+      continue
+    }
+    const ts = entryTimestamp(entry)
+    const existing = persistentGroups.get(descriptor.key)
+    if (existing) {
+      accumulate(existing, entry, ts)
+    } else {
+      persistentGroups.set(descriptor.key, {
+        key: descriptor.key,
+        category: descriptor.category,
+        label: descriptor.label,
+        entries: [entry],
+        latestTs: ts,
+        oldestTs: ts,
+        sourceKeys: new Set([entry.source]),
+        scopeBadges: telemetryScopeBadges(entry),
+      })
+    }
+  }
+
+  const emittedPersistentGroups = new Set<string>()
+
   for (const entry of entries) {
     const descriptor = entryGroupingDescriptor(entry)
     const ts = entryTimestamp(entry)
 
-    // Special path: fleet-wide polling/heartbeat artifacts always merge
-    // into a single group regardless of position. Without this, 14
-    // keepers heartbeating every 60s produce 14 separate single-entry
-    // rows that drown out real activity (#13002).
-    if (descriptor && descriptor.key === 'heartbeat:fleet') {
-      if (!fleetHeartbeat) {
-        fleetHeartbeat = {
-          key: descriptor.key,
-          category: descriptor.category,
-          label: descriptor.label,
-          entries: [entry],
-          latestTs: ts,
-          oldestTs: ts,
-          sourceKeys: new Set([entry.source]),
-          scopeBadges: telemetryScopeBadges(entry),
-          insertIndex: items.length + (activeGroup ? 1 : 0),
-        }
-      } else {
-        accumulate(fleetHeartbeat, entry, ts)
+    if (descriptor && persistentGroups.has(descriptor.key)) {
+      flushGroup()
+      if (!emittedPersistentGroups.has(descriptor.key)) {
+        const group = persistentGroups.get(descriptor.key) as ActiveGroup
+        items.push(renderGroup(group))
+        emittedPersistentGroups.add(descriptor.key)
       }
       continue
     }
@@ -559,16 +660,10 @@ export function buildTelemetryDisplayItems(entries: TelemetryEntry[]): Telemetry
       oldestTs: ts,
       sourceKeys: new Set([entry.source]),
       scopeBadges: telemetryScopeBadges(entry),
-      insertIndex: items.length,
     }
   }
 
   flushGroup()
-
-  if (fleetHeartbeat) {
-    const idx = Math.max(0, Math.min(fleetHeartbeat.insertIndex, items.length))
-    items.splice(idx, 0, renderGroup(fleetHeartbeat))
-  }
 
   return items
 }
@@ -1193,7 +1288,7 @@ export function TelemetryUnified() {
             ? ` · 검색 매치 ${displayItems.length.toLocaleString()}건`
             : ''}
           ${condensed.groups > 0
-            ? ` · 반복 그룹 ${condensed.groups.toLocaleString()}개 · 원본 ${condensed.groupedEntries.toLocaleString()}건`
+            ? ` · 접힌 그룹 ${condensed.groups.toLocaleString()}개 · 원본 ${condensed.groupedEntries.toLocaleString()}건`
             : ''}
         </div>
         ${condensed.groups > 0 ? html`

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -169,6 +169,16 @@ function normalizeNumber(value: unknown): number | null {
   return null
 }
 
+function telemetrySourceFromRouteParam(value: unknown): TelemetrySource | '' {
+  const source = normalizeText(value)
+  return source && source in TELEMETRY_SOURCE_META ? (source as TelemetrySource) : ''
+}
+
+function telemetryLimitFromRouteParam(value: unknown): number {
+  const parsed = normalizeNumber(value)
+  return parsed != null && [50, 100, 200, 500].includes(parsed) ? parsed : 100
+}
+
 function uniqueStrings(values: Array<string | null | undefined>): string[] {
   const seen = new Set<string>()
   const result: string[] = []
@@ -1020,23 +1030,28 @@ export function TelemetryUnified() {
     loading: true,
     error: null,
   })
-  const sourceFilter = useSignal<TelemetrySource | ''>('')
+  const sourceFilter = useSignal<TelemetrySource | ''>(telemetrySourceFromRouteParam(params.source))
   const keeperFilter = useSignal('')
   const sessionFilter = useSignal(params.session_id ?? '')
   const operationFilter = useSignal(params.operation_id ?? '')
   const workerRunFilter = useSignal(params.worker_run_id ?? '')
-  const limit = useSignal(100)
+  const limit = useSignal(telemetryLimitFromRouteParam(params.n ?? params.limit))
   const entrySearch = useSignal(params.q ?? '')
 
   useEffect(() => {
+    sourceFilter.value = telemetrySourceFromRouteParam(route.value.params.source)
     sessionFilter.value = route.value.params.session_id ?? ''
     operationFilter.value = route.value.params.operation_id ?? ''
     workerRunFilter.value = route.value.params.worker_run_id ?? ''
+    limit.value = telemetryLimitFromRouteParam(route.value.params.n ?? route.value.params.limit)
     entrySearch.value = route.value.params.q ?? ''
   }, [
+    route.value.params.source,
     route.value.params.session_id,
     route.value.params.operation_id,
     route.value.params.worker_run_id,
+    route.value.params.n,
+    route.value.params.limit,
     route.value.params.q,
   ])
 
@@ -1190,6 +1205,8 @@ export function TelemetryUnified() {
           ${sessionFilter.value ? html`<span class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs font-mono text-[var(--color-fg-disabled)]">session ${sessionFilter.value}</span>` : null}
           ${operationFilter.value ? html`<span class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs font-mono text-[var(--color-fg-disabled)]">operation ${operationFilter.value}</span>` : null}
           ${workerRunFilter.value ? html`<span class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs font-mono text-[var(--color-fg-disabled)]">worker_run ${workerRunFilter.value}</span>` : null}
+          ${sourceFilter.value ? html`<span class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs font-mono text-[var(--color-fg-disabled)]">source ${telemetrySourceMeta(sourceFilter.value).label}</span>` : null}
+          ${limit.value !== 100 ? html`<span class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs font-mono text-[var(--color-fg-disabled)]">limit ${limit.value}</span>` : null}
           ${route.value.params.q ? html`<span class="rounded-[var(--r-1)] border border-[var(--color-accent-muted)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs font-mono text-[var(--color-accent-fg)]">focus ${route.value.params.q}</span>` : null}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- group telemetry display items by `agent + turn` so turn lifecycle, context usage, and tool rows collapse into one readable row
- extract turn/agent metadata from nested `telemetry_event` payloads such as `Context_window_usage`
- keep raw streaming rows without turn metadata visible as standalone raw telemetry

## Why
The System Telemetry view showed related turn events as separate rows because `telemetry_event` often carries `agent_name` and `turn` inside the payload rather than top-level fields. This made one turn look like multiple unrelated events.

## Validation
- `pnpm exec vitest run src/components/telemetry-unified.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`