### PR TITLE
fix(agent-identity): typed session_key prefix classifier

### DIFF
--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -43,6 +43,34 @@ let identity_rng_mutex = Eio.Mutex.create ()
 let with_identity_rng f =
   Eio.Mutex.use_ro identity_rng_mutex (fun () -> f identity_rng)
 
+(** Typed classification of a session_key's display prefix.
+
+    Replaces the previous string-collapsing helpers that mapped
+    zero-length keys to the literal ["unknown"] inside both
+    [from_mcp_params] and [to_display_string]. The collapse made it
+    impossible for callers to distinguish a genuinely empty key from a
+    key whose first eight bytes happened to spell ["unknown"], and it
+    silenced short-key cases that downstream display logic might want
+    to flag.
+
+    Each call site now matches exhaustively on this closed sum, so any
+    future variant (e.g. truncated/hashed prefix) forces an explicit
+    decision at every consumer instead of being silently merged into a
+    catch-all string. *)
+type session_key_prefix =
+  | Empty_session_key
+      (** Original key had zero length — no usable display prefix. *)
+  | Short_session_key of string
+      (** Key shorter than 8 bytes; the entire key is the prefix. *)
+  | Prefix of string
+      (** Exactly the first 8 bytes of a key ≥ 8 bytes long. *)
+
+let classify_session_key_prefix session_key =
+  let len = String.length session_key in
+  if len = 0 then Empty_session_key
+  else if len < 8 then Short_session_key session_key
+  else Prefix (String.sub session_key 0 8)
+
 (** {1 Core Types} *)
 
 (** Connection surface known to core.
@@ -136,15 +164,11 @@ let from_mcp_params params =
     | `String s -> Some s
     | _ -> None
   in
-  let session_key_prefix session_key =
-    let prefix_len = min 8 (String.length session_key) in
-    if prefix_len = 0 then "unknown"
-    else String.sub session_key 0 prefix_len
-  in
   let fallback_agent_name session_key =
-    let prefix = session_key_prefix session_key in
-    let prefix = if String.equal prefix "unknown" then "anon" else prefix in
-    Printf.sprintf "agent-%s" prefix
+    match classify_session_key_prefix session_key with
+    | Empty_session_key -> "agent-anon"
+    | Short_session_key s -> Printf.sprintf "agent-%s" s
+    | Prefix s -> Printf.sprintf "agent-%s" s
   in
   let session_key = match get_opt "_session_key" with
     | Some k ->
@@ -304,10 +328,11 @@ let has_capability identity cap =
 
 (** Get display string for logging *)
 let to_display_string identity =
-  let session_key_prefix session_key =
-    let prefix_len = min 8 (String.length session_key) in
-    if prefix_len = 0 then "unknown"
-    else String.sub session_key 0 prefix_len
+  let prefix_str =
+    match classify_session_key_prefix identity.session_key with
+    | Empty_session_key -> "unknown"
+    | Short_session_key s -> s
+    | Prefix s -> s
   in
   let channel_str = match identity.channel with
     | Some c -> Printf.sprintf " via %s" (string_of_channel c)
@@ -319,7 +344,7 @@ let to_display_string identity =
   in
   Printf.sprintf "%s (%s)%s%s"
     identity.agent_name
-    (session_key_prefix identity.session_key)
+    prefix_str
     channel_str
     room_str
 


### PR DESCRIPTION
## Why

Bug-hunter audit (MEDIUM) flagged two private helpers in `lib/agent_identity.ml` that silently compress *short* or *empty* `session_key` values into the literal string `"unknown"`:

- `from_mcp_params.session_key_prefix` (lines 141-142, pre-patch)
- `to_display_string.session_key_prefix` (lines 309-310, pre-patch)

The collapse made a genuinely empty key indistinguishable from a key whose first 8 bytes happen to spell `unknown`, and merged short-key cases into the same display path as full-length keys — degrading identity tracking visibility.

## 처단 (Two sites, one typed variant)

```ocaml
type session_key_prefix =
  | Empty_session_key            (* len = 0 *)
  | Short_session_key of string  (* 1..7 bytes; full key is the prefix *)
  | Prefix of string             (* exactly the first 8 bytes *)

let classify_session_key_prefix session_key =
  let len = String.length session_key in
  if len = 0 then Empty_session_key
  else if len < 8 then Short_session_key session_key
  else Prefix (String.sub session_key 0 8)
```

Both consumers now match exhaustively. Boundary literals (`"agent-anon"`, `"(unknown)"`) remain at the formatting layer where they are observable behavior covered by tests; the *internal* string compression that fed them is gone.

## Type delta

- `+ type session_key_prefix = Empty_session_key | Short_session_key of string | Prefix of string` (file-local; not in `.mli`)
- `+ val classify_session_key_prefix : string -> session_key_prefix` (file-local)
- `- let session_key_prefix session_key = ...` × 2 (deleted from `from_mcp_params` and `to_display_string`)
- `.mli`: **unchanged** — public API (`from_mcp_params : Yojson.Safe.t -> t`, `to_display_string : t -> string`) preserved, no caller delta.

## Caller blast & cardinality

- `Agent_identity.*` callers: **10 files** (1 lib, 9 tests). All consume the public functions, no new symbols required.
- `to_display_string` consumers: `lib/mcp_server_eio_execute.ml:Log.Mcp.debug "[Identity] %s" (...)` — **log line only, not a metric label**.
- Prometheus exposure for `session_key`: `rg session_key lib/ bin/ | rg -i 'prometheus|metric|label|counter|gauge'` → **0 hits**. No cardinality risk.

## Workaround Rejection self-check (CLAUDE.md §워크어라운드 거부 기준)

| # | Pattern | This PR |
|---|---|---|
| 1 | telemetry-as-fix | no — removes string compression at the source |
| 2 | string/substring classifier added | no — typed closed sum *replaces* the strings |
| 3 | N-of-M patch | no — both sites in this PR, single helper |
| 4 | catch-all `_ ->` added | no — exhaustive 3-arm match |
| 5 | cap/cooldown/dedup/repair | no |
| 6 | test backdoor | no |
| 7 | same typo at N sites | no — single `classify_session_key_prefix` |

## Verification

```
$ dune build --root . @check          # clean
$ test_agent_identity.exe              # 19/19 OK (incl. empty/short/long key cases)
$ test_identity_e2e.exe                # 6/6 OK
$ test_mcp_full_cycle.exe              # 8/8 OK
```

Behavior preservation evidence (assertions unchanged, all green):
- `from_mcp_params_short_session_key` → `agent_name = "agent-abc"`
- `from_mcp_params_long_session_key_prefix` → `agent_name = "agent-abcdefgh"`
- `to_display_string_empty_session_key` → display contains `"(unknown)"`
- `from_mcp_params_empty_session_key` / `_blank_session_key` → key regenerated upstream (line 152), so `Empty_session_key` is unreachable from that path; still typed-safe.

## Scope

Single file (`lib/agent_identity.ml`, +38/-13). No `.mli` change. No test changes (existing tests already cover the boundary).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>