### PR TITLE
fix(coord): fold warn_telemetry_drop into typed event per RFC-0088 §4 Option A

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -71,9 +71,20 @@ let merge_detail_fields fields details =
    the caller's control flow), but we now emit a Warn log line and
    bump [masc_coord_telemetry_drop_total{event_family,event_kind}] so
    operators can see in Grafana / log aggregation when production
-   paths are dispatching lifecycle outside an Eio fiber. *)
-let warn_telemetry_drop ~event_family ~event_kind exn =
+   paths are dispatching lifecycle outside an Eio fiber.
+
+   RFC-0088 §4 Option A (2026-05-15): [event_family] / [event_kind]
+   were previously two free strings. They are now derived from a closed
+   sum [Coord_telemetry_drop_event.t] mirroring the [Read_drop_reason.t]
+   pattern of RFC-0044. The counter itself is retained — per RFC-0088
+   §4.1 the "event itself is the telemetry payload" and the caller is a
+   fire-and-forget lifecycle hook with no [Result.t] chain to propagate
+   to. But the label cardinality is now compiler-bounded so a new emit
+   site cannot silently widen it. *)
+let warn_telemetry_drop ~(event : Coord_telemetry_drop_event.t) exn =
   let exn_str = Printexc.to_string exn in
+  let event_family = Coord_telemetry_drop_event.family_to_wire event in
+  let event_kind = Coord_telemetry_drop_event.kind_to_wire event in
   let details =
     `Assoc
       [ "event_family", `String event_family
@@ -101,7 +112,7 @@ let warn_telemetry_drop ~event_family ~event_kind exn =
   Telemetry_observe.observe_silent ~kind:"coord_telemetry_drop_metric" (fun () ->
     Prometheus.inc_counter
       Prometheus.metric_coord_telemetry_drop
-      ~labels:[ "event_family", event_family; "event_kind", event_kind ]
+      ~labels:(Coord_telemetry_drop_event.to_prometheus_labels event)
       ())
 ;;
 
@@ -191,7 +202,13 @@ let observe_agent_lifecycle
         Telemetry_eio.track_agent_joined config ~agent_id ())
   with
   | Stdlib.Effect.Unhandled _ as exn ->
-    warn_telemetry_drop ~event_family:"agent_lifecycle" ~event_kind exn
+    let lifecycle_kind : Coord_telemetry_drop_event.lifecycle_kind =
+      match event with
+      | Coord_hooks.Lifecycle_join -> Lifecycle_join
+      | Coord_hooks.Lifecycle_rejoin -> Lifecycle_rejoin
+      | Coord_hooks.Lifecycle_leave -> Lifecycle_leave
+    in
+    warn_telemetry_drop ~event:(Agent_lifecycle lifecycle_kind) exn
 ;;
 
 (* #8605 family: replaced four parallel string switches on [transition]
@@ -256,7 +273,7 @@ let observe_task_transition_event
        | Masc_domain.Reject_verification -> ())
    with
    | Stdlib.Effect.Unhandled _ as exn ->
-     warn_telemetry_drop ~event_family:"task_transition" ~event_kind:transition_s exn);
+     warn_telemetry_drop ~event:(Task_transition transition) exn);
   try
     Keeper_accountability.record_task_transition
       config
@@ -266,7 +283,7 @@ let observe_task_transition_event
       ~details
   with
   | Stdlib.Effect.Unhandled _ as exn ->
-    warn_telemetry_drop ~event_family:"accountability" ~event_kind:transition_s exn
+    warn_telemetry_drop ~event:(Accountability transition) exn
 ;;
 
 (* force_release_task — zombie cleanup needs task management logic *)

--- a/lib/coord.mli
+++ b/lib/coord.mli
@@ -27,10 +27,16 @@ val init : config -> agent_name:string option -> string
 
 module For_testing : sig
   val warn_telemetry_drop :
-    event_family:string -> event_kind:string -> exn -> unit
+    event:Coord_telemetry_drop_event.t -> exn -> unit
   (** Emit the same observable drop marker used when audit/telemetry hooks
       cannot run. Exposed so tests do not depend on backend-specific
-      [Effect.Unhandled] behavior. *)
+      [Effect.Unhandled] behavior.
+
+      RFC-0088 §4 Option A (2026-05-15): the previous
+      [~event_family:string -> ~event_kind:string] surface was replaced
+      by the typed {!Coord_telemetry_drop_event.t} sum. The Prometheus
+      label wire format is unchanged ([family_to_wire] / [kind_to_wire]
+      are byte-for-byte compatible with the prior free-string values). *)
 end
 
 (** {1 FSM drift observability (#9795)} *)

--- a/lib/coord/coord_telemetry_drop_event.ml
+++ b/lib/coord/coord_telemetry_drop_event.ml
@@ -1,0 +1,43 @@
+(* RFC-0088 §4 Option A — typed event for the Coord async-context-free
+   telemetry drop counter [Prometheus.metric_coord_telemetry_drop].
+
+   See [.mli] for the public contract. The wire strings are chosen to be
+   byte-for-byte compatible with the legacy free-string call sites in
+   [lib/coord.ml] (lifecycle: "agent_lifecycle/{join,rejoin,leave}",
+   task transition: "task_transition/<task_action>", accountability:
+   "accountability/<task_action>") so the Grafana / alerting rules
+   filtering on the existing label values keep matching. *)
+
+type lifecycle_kind =
+  | Lifecycle_join
+  | Lifecycle_rejoin
+  | Lifecycle_leave
+
+type t =
+  | Agent_lifecycle of lifecycle_kind
+  | Task_transition of Masc_domain.task_action
+  | Accountability of Masc_domain.task_action
+
+let family_to_wire = function
+  | Agent_lifecycle _ -> "agent_lifecycle"
+  | Task_transition _ -> "task_transition"
+  | Accountability _ -> "accountability"
+;;
+
+let lifecycle_kind_to_wire = function
+  | Lifecycle_join -> "join"
+  | Lifecycle_rejoin -> "rejoin"
+  | Lifecycle_leave -> "leave"
+;;
+
+let kind_to_wire = function
+  | Agent_lifecycle k -> lifecycle_kind_to_wire k
+  | Task_transition action | Accountability action ->
+    Masc_domain.task_action_to_string action
+;;
+
+let to_prometheus_labels t =
+  [ "event_family", family_to_wire t; "event_kind", kind_to_wire t ]
+;;
+
+let pp fmt t = Format.fprintf fmt "%s/%s" (family_to_wire t) (kind_to_wire t)

--- a/lib/coord/coord_telemetry_drop_event.mli
+++ b/lib/coord/coord_telemetry_drop_event.mli
@@ -1,0 +1,83 @@
+(** Closed sum type for the [(event_family, event_kind)] label pair of
+    [Prometheus.metric_coord_telemetry_drop].
+
+    Introduced by RFC-0088 §4 Option A (Counter-as-Fix umbrella scoping,
+    Coord async-context-free telemetry drop sub-scope) as a fold-in
+    amendment to RFC-0044 (`docs/rfc/RFC-0044-persistence-read-drop-typed.md`).
+
+    Motivation: the three call sites in [Coord] that invoke
+    [warn_telemetry_drop] (after catching [Stdlib.Effect.Unhandled] when
+    the lifecycle/task/accountability hook runs outside an Eio scheduler)
+    previously passed free strings for [event_family] / [event_kind].
+    [Read_drop_reason.t] closed-sums the [reason] label of
+    [metric_persistence_read_drops]; this module mirrors that pattern for
+    the coord drop counter so dashboards built around the existing
+    (family, kind) label set cannot silently lose tracking when a new
+    site is added.
+
+    Per RFC-0088 §4.1 the counter itself is retained: the "data loss"
+    here is loss of a single observability event, not durable state, and
+    the caller is a fire-and-forget lifecycle hook with no [Result.t]
+    chain to propagate to. So this module narrows the *typing* surface
+    without altering the *behaviour* contract.
+
+    Adding a new constructor is, by construction, a compile obligation
+    for {!Coord.warn_telemetry_drop} and every caller.
+
+    @stability Evolving *)
+
+(** Lifecycle kind, mirrored from {!Coord_hooks.agent_lifecycle_event}.
+    Kept as a distinct sum (rather than re-exporting the [Coord_hooks]
+    variant) so the wire mapping is owned by this module and adding a
+    lifecycle variant in [Coord_hooks] does not silently widen the drop
+    counter label set without a deliberate change here. *)
+type lifecycle_kind =
+  | Lifecycle_join
+  | Lifecycle_rejoin
+  | Lifecycle_leave
+
+(** Drop event identifies which Coord sub-path raised
+    [Stdlib.Effect.Unhandled]. *)
+type t =
+  | Agent_lifecycle of lifecycle_kind
+      (** Lifecycle observer ([observe_agent_lifecycle]) caught
+          [Effect.Unhandled] from [Audit_log.log_action] or
+          [Telemetry_eio.track_agent_*]. *)
+  | Task_transition of Masc_domain.task_action
+      (** Task transition observer ([observe_task_transition_event])
+          caught [Effect.Unhandled] from [Audit_log.log_action] or
+          [Telemetry_eio.track_task_*]. *)
+  | Accountability of Masc_domain.task_action
+      (** Keeper accountability hook ([Keeper_accountability.record_task_transition])
+          caught [Effect.Unhandled]. Carries the originating
+          [task_action] so dashboards can correlate dropped
+          accountability records with the transition that produced
+          them. *)
+
+(** Wire label for the [event_family] Prometheus label. Stable: matches
+    the byte-for-byte strings emitted before the typed swap-over
+    (["agent_lifecycle"], ["task_transition"], ["accountability"]) so
+    Prometheus label cardinality does not change at the migration
+    boundary. *)
+val family_to_wire : t -> string
+
+(** Wire label for the [event_kind] Prometheus label. For
+    [Agent_lifecycle] this is one of ["join" / "rejoin" / "leave"]
+    (matching {!Coord_hooks.agent_lifecycle_event_to_string}). For
+    [Task_transition] / [Accountability] it is
+    {!Masc_domain.task_action_to_string} of the carried action
+    (["claim" / "start" / "done" / ...]).
+
+    Stable: the wire strings are unchanged from the pre-typed callers,
+    so existing Grafana dashboards / alerting rules keep matching. *)
+val kind_to_wire : t -> string
+
+(** Convenience: both labels in the order Prometheus expects, suitable
+    for direct splat into the [~labels] argument of
+    [Prometheus.inc_counter]. Equivalent to
+    [[("event_family", family_to_wire t); ("event_kind", kind_to_wire t)]]
+    but centralised so the label *names* are also locked at one site. *)
+val to_prometheus_labels : t -> (string * string) list
+
+(** Pretty-printer (emits ["family/kind"] using the wire labels). *)
+val pp : Format.formatter -> t -> unit

--- a/lib/coord/dune
+++ b/lib/coord/dune
@@ -9,6 +9,7 @@
   coord_bootstrap
   coord_broadcast
   coord_hooks
+  coord_telemetry_drop_event
   coord_identity
   coord_task_id
   coord_utils_backend_setup

--- a/test/test_coord_telemetry_drop_non_eio.ml
+++ b/test/test_coord_telemetry_drop_non_eio.ml
@@ -3,7 +3,14 @@
     targets the helper directly instead of relying on backend-specific
     [Effect.Unhandled] behavior. The invariant is still the same:
     [masc_coord_telemetry_drop_total{event_family=...,event_kind=...}] must
-    increment so dropped audit/telemetry writes remain observable. *)
+    increment so dropped audit/telemetry writes remain observable.
+
+    RFC-0088 §4 Option A (2026-05-15): [For_testing.warn_telemetry_drop]
+    now takes a typed [Coord_telemetry_drop_event.t] instead of two free
+    strings. The Prometheus label values remain byte-for-byte identical
+    (["agent_lifecycle", "leave"] / ["agent_lifecycle", "join"]) so the
+    assertions below — which still pin the wire label values — are the
+    correct regression coverage for the swap-over. *)
 
 open Masc_mcp
 
@@ -14,10 +21,13 @@ let counter_value ~event_family ~event_kind =
     ()
 
 let test_lifecycle_drop_increments_counter () =
-  let event_family = "agent_lifecycle" in
-  let event_kind = "leave" in
+  let event : Coord_telemetry_drop_event.t =
+    Agent_lifecycle Lifecycle_leave
+  in
+  let event_family = Coord_telemetry_drop_event.family_to_wire event in
+  let event_kind = Coord_telemetry_drop_event.kind_to_wire event in
   let before = counter_value ~event_family ~event_kind in
-  Coord.For_testing.warn_telemetry_drop ~event_family ~event_kind
+  Coord.For_testing.warn_telemetry_drop ~event
     (Failure "simulated non-Eio telemetry drop");
   let after = counter_value ~event_family ~event_kind in
   Alcotest.(check (float 0.001))
@@ -28,15 +38,55 @@ let test_lifecycle_drop_increments_counter () =
    single regression on the wrong label key (e.g. hard-coded "leave")
    would still pass the test above. *)
 let test_lifecycle_drop_join_label () =
-  let event_family = "agent_lifecycle" in
-  let event_kind = "join" in
+  let event : Coord_telemetry_drop_event.t =
+    Agent_lifecycle Lifecycle_join
+  in
+  let event_family = Coord_telemetry_drop_event.family_to_wire event in
+  let event_kind = Coord_telemetry_drop_event.kind_to_wire event in
   let before = counter_value ~event_family ~event_kind in
-  Coord.For_testing.warn_telemetry_drop ~event_family ~event_kind
+  Coord.For_testing.warn_telemetry_drop ~event
     (Failure "simulated non-Eio telemetry drop");
   let after = counter_value ~event_family ~event_kind in
   Alcotest.(check (float 0.001))
     "drop counter increments by exactly 1 for the join label"
     1.0 (after -. before)
+
+(* RFC-0088 §4 Option A: confirm the wire mapping is byte-for-byte
+   compatible with the pre-typed call sites. If a future refactor
+   accidentally rewires the wire labels (e.g. drops the snake_case),
+   Grafana dashboards built on the existing labels would silently
+   stop matching. *)
+let test_wire_mapping_stable () =
+  Alcotest.(check string)
+    "agent_lifecycle family"
+    "agent_lifecycle"
+    (Coord_telemetry_drop_event.family_to_wire
+       (Agent_lifecycle Lifecycle_leave));
+  Alcotest.(check string)
+    "agent_lifecycle / leave kind"
+    "leave"
+    (Coord_telemetry_drop_event.kind_to_wire
+       (Agent_lifecycle Lifecycle_leave));
+  Alcotest.(check string)
+    "task_transition family"
+    "task_transition"
+    (Coord_telemetry_drop_event.family_to_wire
+       (Task_transition Masc_domain.Claim));
+  Alcotest.(check string)
+    "task_transition / claim kind"
+    "claim"
+    (Coord_telemetry_drop_event.kind_to_wire
+       (Task_transition Masc_domain.Claim));
+  Alcotest.(check string)
+    "accountability family"
+    "accountability"
+    (Coord_telemetry_drop_event.family_to_wire
+       (Accountability Masc_domain.Done_action));
+  Alcotest.(check string)
+    "accountability / done kind"
+    "done"
+    (Coord_telemetry_drop_event.kind_to_wire
+       (Accountability Masc_domain.Done_action))
 
 let () =
   Alcotest.run "coord_telemetry_drop_non_eio"
@@ -47,5 +97,7 @@ let () =
             test_lifecycle_drop_increments_counter;
           Alcotest.test_case "join label increments counter" `Quick
             test_lifecycle_drop_join_label;
+          Alcotest.test_case "wire mapping stable across all 3 families"
+            `Quick test_wire_mapping_stable;
         ] );
     ]


### PR DESCRIPTION
## Why

`lib/coord.ml`의 `warn_telemetry_drop` 함수와 그 3 emit site (lines 194, 259, 269)는 CLAUDE.md §"워크어라운드 거부 기준 §1 (Counter-as-Fix)"의 마지막 unowned site였습니다.

RFC-0088 (PR #15500 MERGED) §4 inventory가 16+ telemetry-as-fix 후보를 4 bucket으로 partition했고, 이 1 counter / 3 emit site는 **unowned**로 식별되어 §4 Option A (RFC-0044 typed pattern으로 fold-in) 또는 Option B (buffered replay)로 처분 대기였습니다.

본 PR은 **§4 Option A — RFC-0044 typed reason 패턴 fold-in**의 구현입니다.

## Site

| File | Line | 변경 |
|------|------|------|
| `lib/coord/coord_telemetry_drop_event.{ml,mli}` | 신규 | 폐쇄형 합타입 `Coord_telemetry_drop_event.t` 도입 (Agent_lifecycle / Task_transition / Accountability) |
| `lib/coord.ml:75-110` | 함수 시그니처 | `~event_family:string -> ~event_kind:string` → `~event:Coord_telemetry_drop_event.t` |
| `lib/coord.ml:194` (lifecycle emit) | typed call | `Agent_lifecycle (Lifecycle_join/Rejoin/Leave)` mapping from `Coord_hooks.agent_lifecycle_event` |
| `lib/coord.ml:259` (task_transition emit) | typed call | `Task_transition transition` (`Masc_domain.task_action`) |
| `lib/coord.ml:269` (accountability emit) | typed call | `Accountability transition` (`Masc_domain.task_action`) |
| `lib/coord.mli` `For_testing` | 시그니처 narrow | typed `~event` |
| `test/test_coord_telemetry_drop_non_eio.ml` | typed call + new wire-stability test | 3 tests (기존 2 + 새 wire mapping test) |

## Approach — RFC-0044 fold-in 채택 근거

RFC-0088 §Q2 tentative ("amendment to RFC-0044 — `Coord_telemetry_drop_reason.t` lives next to `Read_drop_reason.t`") + §4.3 "Recommendation: A first" 그대로 구현했습니다. 새 typed variant를 도입하는 정당화:

- `Read_drop_reason.t`는 *single* label (`reason`)을 닫는 closed sum입니다. Coord drop은 *2-label* (`event_family` × `event_kind`)을 닫아야 하므로, Read_drop_reason을 *재사용*하는 것은 불가능합니다.
- 두 label은 *coupled*입니다 (예: `agent_lifecycle` family는 lifecycle kinds만, `task_transition` family는 task_action만 — cross-product는 허용되지 않음). 그래서 `Coord_telemetry_drop_event.t`는 family를 sum constructor로, kind를 그 constructor의 payload로 인코딩합니다. 이는 RFC-0044 pattern의 **동일한 원리** (closed sum이 label cardinality를 압축)의 확장입니다.
- 모듈 위치: `lib/coord/` (`Masc_domain.task_action`과 `Coord_hooks.agent_lifecycle_event`를 의존). `lib/core/` 배치는 reverse-dep 발생.

## Why NOT Result propagation

RFC-0088 §4.1이 명시한 대로:

> The *event itself is the telemetry payload*. The "data loss" is loss of a single observability event, not durable state. There is no `Result.t` chain to propagate to — the immediate caller is the lifecycle hook (e.g. `agent_lifecycle`) which is fire-and-forget by design.

세 emit site는 모두 `try ... with Stdlib.Effect.Unhandled _ as exn -> warn_telemetry_drop ...` 패턴으로, 이미 *recovery* 경로입니다 (Eio scheduler가 없을 때 `Audit_log.log_action` / `Telemetry_eio.track_*`이 raise하는 effect를 흡수). 호출자 (`observe_agent_lifecycle` / `observe_task_transition_event`)는 fire-and-forget이라 Result.t를 받을 caller가 없습니다.

따라서 본 PR은 *behavior change 0* (counter 유지 + log 유지) + *typing 강화* 입니다.

## Type delta

```ocaml
type lifecycle_kind = Lifecycle_join | Lifecycle_rejoin | Lifecycle_leave

type t =
  | Agent_lifecycle of lifecycle_kind
  | Task_transition of Masc_domain.task_action
  | Accountability of Masc_domain.task_action
```

- 새 type 1개 (Coord_telemetry_drop_event.t) + 보조 lifecycle_kind.
- 향후 emit site 추가는 *컴파일러가 강제*. `to_prometheus_labels`도 같은 모듈에서 owned.
- `lifecycle_kind`는 `Coord_hooks.agent_lifecycle_event`를 re-export하지 않고 **distinct sum**으로 정의 — `Coord_hooks`에 lifecycle variant 추가 시 자동으로 drop counter label set이 widen되는 silent expansion을 차단 (mli 주석 명시).

## Caller count

`rg "warn_telemetry_drop|metric_coord_telemetry_drop" lib/ bin/ test/`:
- `lib/coord.ml`: 1 def + 1 export + 3 call sites
- `lib/coord/coord_telemetry_drop_event.{ml,mli}` (신규)
- `lib/prometheus.{ml,mli}`: 메트릭 이름 상수 (변경 없음 — wire format 보존)
- `test/test_coord_telemetry_drop_non_eio.ml`: typed call로 migration
- `test/test_prometheus_coverage.ml:451`: 메트릭 등록 확인만 (변경 없음, PASS)

bin/ caller 0.

## Behavior change (explicit)

- Counter `masc_coord_telemetry_drop_total` 유지. **Wire format 무변경** — `family_to_wire` / `kind_to_wire`가 byte-for-byte 동일 (`"agent_lifecycle"`, `"task_transition"`, `"accountability"` / `"join"`, `"rejoin"`, `"leave"`, `Masc_domain.task_action_to_string` 출력).
- Grafana dashboards / alerting rules에 영향 없음. 새 test `test_wire_mapping_stable`로 회귀 차단.
- Log line ("telemetry/audit dropped (non-Eio context): family/kind") 무변경.
- Type 표면만 좁힘 (string × string → closed sum). 새 emit site는 컴파일 강제.

## Hot path risk audit

- `warn_telemetry_drop`은 **error 경로**만 (Effect.Unhandled 흡수 후 호출). hot success path는 통과하지 않음.
- Closed sum constructor allocation은 매 호출당 1-word boxed pointer. error 경로 빈도는 dashboard 기준 sub-Hz이므로 무시 가능.
- 기존 `Telemetry_observe.observe_silent` wrapper / `try/with` 구조 그대로.

## RFC-0088 §3 §4 reject-bar 7항목 self-check

1. ❌ "makes X visible" / "instrument Y" 만 수행: **No** — counter는 이미 존재. 이 PR은 **typing**만 강화. Counter-as-Fix 추가가 아님.
2. ❌ string/substring/prefix 분류기 추가: **No** — 정반대. *제거*하고 closed sum으로 교체.
3. ❌ "PR #N only fixed K of M sites" 자인: **No** — 3 emit site 전부 한 PR에서 typed로 전환.
4. ❌ catch-all `_ ->` 추가: **No** — `family_to_wire` / `kind_to_wire`는 closed-sum exhaustive match.
5. ❌ cap/cooldown/dedup/repair: **No**.
6. ❌ test backdoor (`set_X_for_test` / `reset_for_test`) 노출: **No** — 기존 `For_testing.warn_telemetry_drop`은 시그니처만 narrow.
7. ❌ typo/off-by-one N개 사이트 N번 fix: **No**.

→ 7/7 PASS. RFC-0088 §5 row 4 (`Prometheus.metric_coord_telemetry_drop` → owner: RFC-0088 §4)에 적합.

## Build / Test

- `dune build --root . @check` PASS (전체 트리)
- `dune exec --root . test/test_coord_telemetry_drop_non_eio.exe` PASS (3 tests including new wire-stability test)
- `dune exec --root . test/test_prometheus_coverage.exe` PASS (63 tests)

## RFC reference

- **RFC-0088** §4 Option A (이 PR이 그 구현). PR #15500 MERGED.
- **RFC-0044** (Read_drop_reason.t pattern 원형). 본 PR이 §Q2 amendment 형식으로 fold-in.

## Co-authored

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>