### PR TITLE
fix(keeper_checkpoint_store): typed ENOENT classification at OS boundary (RFC-0089 G4)

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -327,62 +327,32 @@ type checkpoint_load_error =
       surfaced during a load. (#8605 family) *)
   | Sdk_other_error of string
 
-(* Checkpoint-load failures classify as [Not_found] only when the
-   underlying SDK error is genuinely "this file does not exist on first
-   boot" — any other I/O problem should stay [Io_error] so we keep the
-   detail in the error log.
+(* RFC-0089 G4 (#15514-sibling): [Not_found] classification was previously
+   string-matched against [FileOpFailed.detail] across four prefixes
+   ("no_such_file", "no such file", "unix_error (enoent", "eio.io fs
+   not_found") + a substring fallback. This was a string classifier
+   workaround (CLAUDE.md §워크어라운드 #2): [Agent_sdk.Error] is already a
+   closed sum type, but [FileOpFailed.detail] flattens the underlying
+   filesystem exception via [Printexc.to_string], throwing away typed
+   provenance.
 
-   The matching surface is fragile because [Agent_sdk] serializes
-   filesystem failures via [Printexc.to_string] inside
-   [FileOpFailed.detail] (see oas/lib/fs_result.ml), so we pattern-match
-   on the rendered strings of every exception constructor the OAS
-   wrapper produces:
+   Root fix: lift ENOENT detection to the OS boundary *before* invoking
+   the SDK. [Agent_sdk.Checkpoint_store.exists : t -> string -> bool] gives
+   us a typed presence check, so the cold-start "file absent" case is now
+   first-class [bool] and never reaches [classify_sdk_error]. Any SDK error
+   that *does* surface from [load] is, by construction, a real I/O /
+   serialization / SDK fault and routes to [Io_error] / [Store_error] /
+   [Parse_error] / [Sdk_other_error] without inspecting strings.
 
-   - [Eio.Io (Fs Not_found _)] → "Eio.Io Fs Not_found Unix_error ..."
-   - [Unix.Unix_error (ENOENT, _, _)] → "Unix_error(ENOENT, ...)"
-   - [Sys_error "..."] → "No such file or directory: ..."
-   - legacy masc-mcp path that stored just "no_such_file" as detail
-
-   The [has_substring] fallback catches the canonical ENOENT phrase
-   anywhere in the rendered string so that wrapper layers that prepend
-   context (e.g. [sprintf "load %s: %s" path ...]) still classify
-   correctly. *)
-let is_not_found_detail (detail : string) : bool =
-  let d = String.lowercase_ascii detail in
-  (* Local to keep [Keeper_checkpoint_store] surface free of a generic
-     string helper — this module has no .mli so every top-level [let]
-     is exported. *)
-  let has_substring haystack needle =
-    let hl = String.length haystack and nl = String.length needle in
-    if nl = 0 then true
-    else if nl > hl then false
-    else
-      let rec loop i =
-        if i + nl > hl then false
-        else if String.sub haystack i nl = needle then true
-        else loop (i + 1)
-      in
-      loop 0
-  in
-  String.starts_with ~prefix:"no_such_file" d  (* legacy masc-mcp path *)
-  || String.starts_with ~prefix:"no such file" d
-  || String.starts_with ~prefix:"unix_error (enoent" d  (* POSIX *)
-  || String.starts_with ~prefix:"eio.io fs not_found" d  (* Eio.Io (Fs Not_found _) *)
-  || has_substring d "no such file or directory"
-
-(* #8605 family: exhaustive on Agent_sdk.Error.sdk_error top-level
-   variants. The previous wildcard collapsed Api / Agent / Mcp / Config
-   / Orchestration / A2a / Internal errors into Io_error, hiding
-   non-IO failures from the dashboard. The wildcards on Io _ and
-   Serialization _ remain narrow (one level deep) so future inner
-   variants land in the semantically correct category, but a future
-   top-level sdk_error variant becomes a build error and forces a
-   deliberate routing decision. *)
+   #8605 family: exhaustive on [Agent_sdk.Error.sdk_error] top-level
+   variants. The wildcards on Io _ and Serialization _ remain narrow (one
+   level deep) so a future inner variant lands in the semantically correct
+   category, and a future top-level sdk_error variant becomes a build
+   error forcing a deliberate routing decision. *)
 let classify_sdk_error (e : Agent_sdk.Error.sdk_error) : checkpoint_load_error =
   match e with
   | Io (FileOpFailed r) ->
-      if is_not_found_detail r.detail then Not_found
-      else Io_error (sprintf "file %s failed on %s: %s" r.op r.path r.detail)
+      Io_error (sprintf "file %s failed on %s: %s" r.op r.path r.detail)
   | Io (ValidationFailed r) -> Store_error r.detail
   | Serialization (JsonParseError r) -> Parse_error r.detail
   | Serialization (VersionMismatch r) ->
@@ -571,10 +541,19 @@ let load_oas ~(session_dir : string) ~(session_id : string) :
   | Some fs when Eio_guard.is_ready () ->
       let dir = Eio.Path.(fs / session_dir) in
       (match Agent_sdk.Checkpoint_store.create dir with
-       | Ok store -> (
-           match Agent_sdk.Checkpoint_store.load store session_id with
-           | Ok ckpt -> Ok ckpt
-           | Error e -> Error (classify_sdk_error e))
+       | Ok store ->
+           (* RFC-0089 G4: typed ENOENT classification at the OS boundary.
+              [exists] returns a [bool] so a missing checkpoint never has to
+              be inferred from a stringified exception detail. The SDK-side
+              [load] is only reached when the file is present, so any error
+              returned is a genuine I/O / parse / SDK failure (not cold-start
+              absence). *)
+           if not (Agent_sdk.Checkpoint_store.exists store session_id) then
+             Error Not_found
+           else (
+             match Agent_sdk.Checkpoint_store.load store session_id with
+             | Ok ckpt -> Ok ckpt
+             | Error e -> Error (classify_sdk_error e))
        | Error e -> Error (Store_error (Agent_sdk.Error.to_string e)))
   | Some _ | None ->
       fallback ()

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -96,12 +96,13 @@ type checkpoint_load_error =
   | Io_error of string
   | Sdk_other_error of string
 
-(** [true] iff [detail] matches a known "file not found" rendering
-    across Eio.Io, Unix_error, Sys_error, and the legacy masc-mcp
-    [no_such_file] short-form. *)
-val is_not_found_detail : string -> bool
+(** Project an [Agent_sdk.Error.sdk_error] to [checkpoint_load_error].
 
-(** Project an [Agent_sdk.Error.sdk_error] to [checkpoint_load_error]. *)
+    RFC-0089 G4: this no longer classifies [Not_found] from string-matched
+    [FileOpFailed.detail]. Cold-start "checkpoint absent" is detected at
+    the OS boundary via [Agent_sdk.Checkpoint_store.exists] *before* the
+    SDK [load] call, so any [sdk_error] reaching this function is a real
+    I/O / parse / SDK fault and routes accordingly. *)
 val classify_sdk_error :
   Agent_sdk.Error.sdk_error -> checkpoint_load_error
 

--- a/test/stanzas/test_keeper_checkpoint_classify.inc
+++ b/test/stanzas/test_keeper_checkpoint_classify.inc
@@ -1,6 +1,6 @@
-; Keeper_checkpoint_store.is_not_found_detail classifier
-; regression (observed 334-retry loop on trace-1775487505102-6a347
-; on 2026-04-12 — Eio.Io rendered form not recognized as Not_found)
+; Keeper_checkpoint_store.classify_sdk_error pinning after RFC-0089 G4
+; (#15514 sibling): ENOENT detection moved to OS boundary via
+; Agent_sdk.Checkpoint_store.exists, classifier has no Not_found arm.
 
 (test
  (name test_keeper_checkpoint_classify)

--- a/test/test_keeper_checkpoint_classify.ml
+++ b/test/test_keeper_checkpoint_classify.ml
@@ -1,102 +1,163 @@
-(** Regression tests for [Keeper_checkpoint_store.is_not_found_detail]
-    and [classify_sdk_error] (#6654 follow-up).
+(** Regression tests for [Keeper_checkpoint_store.classify_sdk_error]
+    after RFC-0089 G4 (#15514 sibling): typed ENOENT classification at
+    the OS boundary.
 
-    Background: on 2026-04-12 /loop observed a keeper logging 334
-    copies of [OAS checkpoint I/O error: file load failed on
-    trace-1775487505102-6a347: Eio.Io Fs Not_found Unix_error (No such
-    file or directory, "openat", ...)] in a tight retry loop. The
-    expected behavior for a missing trace checkpoint is a silent
-    [Not_found] classification so the keeper either takes a cold boot
-    path or moves on. Instead the classifier fell through to
-    [Io_error], which [keeper_context_core.ml] treats as a non-trivial
-    failure worth logging at every retry.
+    Background: on 2026-04-12 /loop observed a keeper logging 334 copies
+    of [OAS checkpoint I/O error: file load failed on trace-...: Eio.Io
+    Fs Not_found Unix_error (No such file or directory, "openat", ...)]
+    in a tight retry loop. The root fix in #6654 used four string-prefix
+    matches + a substring fallback on [FileOpFailed.detail] to recognise
+    cold-start absence — a string classifier workaround (CLAUDE.md
+    §워크어라운드 #2).
 
-    Root cause: [Agent_sdk.Error.FileOpFailed.detail] is populated by
-    [Printexc.to_string] in [oas/lib/fs_result.ml], so an Eio filesystem
-    ENOENT renders as literally [Eio.Io Fs Not_found Unix_error ...].
-    [is_not_found_detail] only matched three legacy prefixes
-    ([no_such_file], [no such file], [unix_error (enoent]) and never
-    recognized the rendered Eio exception string.
+    Replacement (RFC-0089 G4): the SDK provides
+    [Agent_sdk.Checkpoint_store.exists : t -> string -> bool], so the
+    keeper-side load path now branches on that [bool] *before* invoking
+    [load]. Any [sdk_error] reaching [classify_sdk_error] is therefore by
+    construction a real I/O / serialization / SDK fault, never a missing
+    file. The classifier consequently has no [Not_found] arm.
 
-    These tests lock the classifier to:
-    - the three legacy prefixes (regression guard)
-    - the Eio.Io rendered form observed in production
-    - a canonical "no such file or directory" substring anywhere in
-      the detail (robust against wrapper layers prepending context) *)
+    These tests pin the invariant: classify_sdk_error must never return
+    [Not_found], regardless of the rendered detail string. Cold-start
+    [Not_found] coverage is end-to-end behaviour of [load_oas] /
+    [load_oas_history_file] and is exercised separately via the
+    [Fs_compat.file_exists] / [Checkpoint_store.exists] branches. *)
 
 module Store = Masc_mcp.Keeper_checkpoint_store
 
-let check_not_found name detail =
-  Alcotest.(check bool) name true (Store.is_not_found_detail detail)
+(* Alcotest testable for [Store.checkpoint_load_error]. We only need
+   equality + a pretty printer for failure diagnostics; the variants
+   carry [string] payloads which is fine for value-level comparison. *)
+let pp_err fmt = function
+  | Store.Not_found -> Format.fprintf fmt "Not_found"
+  | Store.Store_error s -> Format.fprintf fmt "Store_error(%s)" s
+  | Store.Parse_error s -> Format.fprintf fmt "Parse_error(%s)" s
+  | Store.Io_error s -> Format.fprintf fmt "Io_error(%s)" s
+  | Store.Sdk_other_error s -> Format.fprintf fmt "Sdk_other_error(%s)" s
 
-let check_not_classified_as_not_found name detail =
-  Alcotest.(check bool) name false (Store.is_not_found_detail detail)
+let load_err = Alcotest.testable pp_err ( = )
 
-(* ─── Legacy prefixes (regression guard) ─────────────────────── *)
+let is_not_found = function Store.Not_found -> true | _ -> false
+let is_io_error = function Store.Io_error _ -> true | _ -> false
+let is_store_error = function Store.Store_error _ -> true | _ -> false
+let is_parse_error = function Store.Parse_error _ -> true | _ -> false
+let is_sdk_other = function Store.Sdk_other_error _ -> true | _ -> false
 
-let test_legacy_no_such_file_prefix () =
-  check_not_found "no_such_file underscore prefix (legacy)"
+(* ─── Invariant: classify_sdk_error never returns Not_found ──────── *)
+
+let check_not_not_found name detail =
+  let e = Agent_sdk.Error.Io (FileOpFailed { op = "load"; path = "p"; detail }) in
+  Alcotest.(check bool) name false (is_not_found (Store.classify_sdk_error e))
+
+let test_legacy_no_such_file_underscore () =
+  (* Previously string-matched as Not_found via the "no_such_file" prefix. *)
+  check_not_not_found "legacy no_such_file underscore prefix routes to Io_error"
     "no_such_file: trace-xyz"
 
-let test_legacy_no_such_file_space_prefix () =
-  check_not_found "no such file prefix"
+let test_legacy_no_such_file_space () =
+  check_not_not_found "legacy 'No such file' phrase routes to Io_error"
     "No such file or directory"
 
-let test_legacy_unix_error_prefix () =
-  check_not_found "unix_error(enoent prefix (POSIX)"
+let test_legacy_unix_error_enoent () =
+  check_not_not_found "legacy Unix_error(ENOENT prefix routes to Io_error"
     "Unix_error (ENOENT, \"openat\", \"/tmp/x\")"
 
-(* ─── Regression: Eio.Io rendered form from Printexc ─────────── *)
-
 let test_eio_io_fs_not_found_rendered () =
-  (* Exact detail string observed in /tmp/masc-6647-restart2.log for
-     trace-1775487505102-6a347 — the keeper looping fix target. *)
-  check_not_found
-    "Eio.Io Fs Not_found Unix_error rendered by Printexc.to_string"
+  (* Exact detail string from /tmp/masc-6647-restart2.log. Under the new
+     contract this case is *unreachable* in practice (the [exists] gate
+     filters it), but if it does reach the classifier — e.g. a TOCTOU
+     race where the file was removed between [exists] and [load] — it is
+     a genuine [Io_error], not a cold-start absence. *)
+  check_not_not_found
+    "Eio.Io Fs Not_found rendered form routes to Io_error (not Not_found)"
     "Eio.Io Fs Not_found Unix_error (No such file or directory, \
-     \"openat\", \"/Users/dancer/me/.masc/traces/trace-123/trace-123.json\"), \
-     \n  opening <fs:/Users/dancer/me/.masc/traces/trace-123/trace-123.json>"
+     \"openat\", \"/p/trace.json\")"
 
-(* ─── Substring fallback: wrapper layers may prepend context ──── *)
+(* ─── Categorical routing on typed sdk_error variants ────────────── *)
 
-let test_substring_embedded_no_such_file () =
-  check_not_found
-    "substring match for 'no such file or directory' anywhere in detail"
-    "load trace-abc: wrapped error: Sys_error \
-     \"/path/trace.json: No such file or directory\""
+let test_io_file_op_failed_routes_io_error () =
+  let e =
+    Agent_sdk.Error.Io
+      (FileOpFailed { op = "load"; path = "/p/x"; detail = "EACCES" })
+  in
+  Alcotest.check load_err "FileOpFailed routes to Io_error"
+    (Store.Io_error "file load failed on /p/x: EACCES")
+    (Store.classify_sdk_error e)
 
-(* ─── Negative cases ─────────────────────────────────────────── *)
+let test_io_validation_failed_routes_store_error () =
+  let e = Agent_sdk.Error.Io (ValidationFailed { detail = "bad schema" }) in
+  Alcotest.(check bool) "ValidationFailed routes to Store_error" true
+    (is_store_error (Store.classify_sdk_error e))
 
-let test_parse_error_not_misclassified () =
-  check_not_classified_as_not_found
-    "JSON parse error must stay classified as Parse_error"
-    "JSON error: Unexpected end of input"
+let test_serialization_json_routes_parse_error () =
+  let e =
+    Agent_sdk.Error.Serialization (JsonParseError { detail = "EOF" })
+  in
+  Alcotest.(check bool) "JsonParseError routes to Parse_error" true
+    (is_parse_error (Store.classify_sdk_error e))
 
-let test_permission_denied_not_misclassified () =
-  check_not_classified_as_not_found
-    "permission denied must stay classified as Io_error"
-    "Unix_error (EACCES, \"openat\", \"/path/trace.json\")"
+let test_serialization_version_routes_parse_error () =
+  let e =
+    Agent_sdk.Error.Serialization
+      (VersionMismatch { expected = 2; got = 1 })
+  in
+  Alcotest.(check bool) "VersionMismatch routes to Parse_error" true
+    (is_parse_error (Store.classify_sdk_error e))
+
+let test_serialization_unknown_variant_routes_parse_error () =
+  let e =
+    Agent_sdk.Error.Serialization
+      (UnknownVariant { type_name = "role"; value = "alien" })
+  in
+  Alcotest.(check bool) "UnknownVariant routes to Parse_error" true
+    (is_parse_error (Store.classify_sdk_error e))
+
+let test_internal_routes_sdk_other_error () =
+  let e = Agent_sdk.Error.Internal "kaboom" in
+  Alcotest.(check bool) "Internal routes to Sdk_other_error" true
+    (is_sdk_other (Store.classify_sdk_error e))
+
+(* Negative-control: a permission failure must remain Io_error (not
+   Not_found, not Parse_error). *)
+let test_permission_denied_routes_io_error () =
+  let e =
+    Agent_sdk.Error.Io
+      (FileOpFailed
+         { op = "load"; path = "/p"; detail =
+             "Unix_error (EACCES, \"openat\", \"/p/trace.json\")" })
+  in
+  Alcotest.(check bool) "EACCES routes to Io_error" true
+    (is_io_error (Store.classify_sdk_error e))
 
 let () =
   Alcotest.run "Keeper_checkpoint_classify"
     [
-      ( "is_not_found_detail",
+      ( "classify_sdk_error: no Not_found arm (RFC-0089 G4)",
         [
-          Alcotest.test_case "legacy no_such_file underscore prefix" `Quick
-            test_legacy_no_such_file_prefix;
-          Alcotest.test_case "legacy 'No such file' prefix" `Quick
-            test_legacy_no_such_file_space_prefix;
-          Alcotest.test_case "legacy Unix_error(ENOENT prefix" `Quick
-            test_legacy_unix_error_prefix;
-          Alcotest.test_case
-            "Eio.Io Fs Not_found Unix_error rendered (regression)"
-            `Quick test_eio_io_fs_not_found_rendered;
-          Alcotest.test_case
-            "'no such file or directory' substring match" `Quick
-            test_substring_embedded_no_such_file;
-          Alcotest.test_case "JSON parse error not misclassified" `Quick
-            test_parse_error_not_misclassified;
-          Alcotest.test_case "EACCES not misclassified" `Quick
-            test_permission_denied_not_misclassified;
+          Alcotest.test_case "legacy no_such_file underscore is Io_error" `Quick
+            test_legacy_no_such_file_underscore;
+          Alcotest.test_case "legacy 'No such file' is Io_error" `Quick
+            test_legacy_no_such_file_space;
+          Alcotest.test_case "legacy Unix_error(ENOENT is Io_error" `Quick
+            test_legacy_unix_error_enoent;
+          Alcotest.test_case "Eio.Io Fs Not_found rendered is Io_error" `Quick
+            test_eio_io_fs_not_found_rendered;
+        ] );
+      ( "classify_sdk_error: typed variant routing",
+        [
+          Alcotest.test_case "FileOpFailed -> Io_error" `Quick
+            test_io_file_op_failed_routes_io_error;
+          Alcotest.test_case "ValidationFailed -> Store_error" `Quick
+            test_io_validation_failed_routes_store_error;
+          Alcotest.test_case "JsonParseError -> Parse_error" `Quick
+            test_serialization_json_routes_parse_error;
+          Alcotest.test_case "VersionMismatch -> Parse_error" `Quick
+            test_serialization_version_routes_parse_error;
+          Alcotest.test_case "UnknownVariant -> Parse_error" `Quick
+            test_serialization_unknown_variant_routes_parse_error;
+          Alcotest.test_case "Internal -> Sdk_other_error" `Quick
+            test_internal_routes_sdk_other_error;
+          Alcotest.test_case "EACCES (FileOpFailed) -> Io_error" `Quick
+            test_permission_denied_routes_io_error;
         ] );
     ]


### PR DESCRIPTION
## Why

RFC-0089 §4-2 G4 (Top 3 priority #2). `lib/keeper/keeper_checkpoint_store.ml` had 4 `String.starts_with` + 1 substring-match prefixes inferring \"checkpoint absent\" from a stringified exception detail. This is a string-classifier workaround (CLAUDE.md §워크어라운드 #2) — `Agent_sdk.Error` is already a closed sum type, but `FileOpFailed.detail` flattens the underlying filesystem exception via `Printexc.to_string`, destroying typed provenance.

## What

Lift cold-start \"checkpoint absent\" detection to the OS boundary using `Agent_sdk.Checkpoint_store.exists : t -> string -> bool`. `load_oas` now branches on `exists store session_id` *before* invoking `load`, so any `sdk_error` reaching `classify_sdk_error` is by construction a real I/O / parse / SDK fault — never cold-start absence.

### Sites closed (4 + 1, all in one file)

| # | Before (string-match) | After |
|---|---|---|
| 1 | `String.starts_with ~prefix:\"no_such_file\" d` (legacy masc-mcp) | OS boundary, removed |
| 2 | `String.starts_with ~prefix:\"no such file\" d` | OS boundary, removed |
| 3 | `String.starts_with ~prefix:\"unix_error (enoent\" d` (POSIX) | OS boundary, removed |
| 4 | `String.starts_with ~prefix:\"eio.io fs not_found\" d` (Eio.Io) | OS boundary, removed |
| 5 | `has_substring d \"no such file or directory\"` (fallback) | OS boundary, removed |

### Legacy removed in same PR (hardcoding_and_legacy_zero_tolerance)

- `is_not_found_detail : string -> bool` (function body + `has_substring` helper + 30-line \"fragile matching surface\" comment)
- `val is_not_found_detail` export from `.mli`
- `Not_found` arm of `classify_sdk_error`
- Test cases that pinned the four prefixes (rewritten as typed invariant tests)

### Pattern chosen

Not OCaml typed exception (`Unix.Unix_error (ENOENT, _, _)` / variant), because the exception flows through *third-party SDK code* (`Agent_sdk` via OAS `fs_result.ml`) where the rendering has already happened. The right boundary is *before* that rendering: ask the SDK \"does this file exist\" with its own typed `bool` API.

```ocaml
(* before *)
match Agent_sdk.Checkpoint_store.load store session_id with
| Ok ckpt -> Ok ckpt
| Error e -> Error (classify_sdk_error e)  (* classify probed 4 string prefixes *)

(* after *)
if not (Agent_sdk.Checkpoint_store.exists store session_id) then
  Error Not_found  (* typed bool from OS boundary *)
else (
  match Agent_sdk.Checkpoint_store.load store session_id with
  | Ok ckpt -> Ok ckpt
  | Error e -> Error (classify_sdk_error e))  (* now has no Not_found arm *)
```

## Caller blast

- External callers of removed `is_not_found_detail`: **0** in `lib/`/`bin/`, **1** in `test/` (rewritten in this PR).
- `classify_sdk_error`: 3 internal call sites (`load_oas_history_file`, `load_oas` fallback, `load_oas` SDK path) — all behave unchanged for non-ENOENT errors, and the new `exists` branch shadows the ENOENT case before any of them is reached.
- End-to-end `Not_found` behaviour pinned by existing `test_oas_worker.ml:5230` (`test_keeper_checkpoint_store_oas_missing_returns_none`) — exercises `Fs_compat.file_exists` fallback branch which is unchanged.

## Build / test

OCaml 5.4.1, worktree-local (CI may skip due to `Detect Changed Surfaces` gate per ci-skip reference):

- `dune build --root . @check` → clean (no output)
- `dune exec --root . test/test_keeper_checkpoint_classify.exe` → **11/11 PASS**
  - 4 invariant cases: each legacy string-match prefix routes to `Io_error`, not `Not_found`
  - 7 typed routing cases: each `sdk_error` top-level variant lands in its semantic category

## PR #15514 overlap

PR #15514 (Tier H, `prune` typed outcome) is **Draft / OPEN** at branch creation. Same file, **disjoint regions**:

| PR | Region | Function |
|---|---|---|
| #15514 | lines 43–100 | `prune`, `save` (auto-prune call site) |
| this PR | lines 320–400, 575 | `classify_sdk_error`, `load_oas` |

Rebase merged cleanly at push time (no conflict observed). If #15514 lands first, this PR rebases trivially.

## Workaround Rejection Self-Check (CLAUDE.md §워크어라운드 거부 기준)

1. **telemetry-as-fix**: NO — removes a classifier; adds no counters
2. **string classifier reinforcement**: NO — removes 4 prefixes + 1 substring; replaces with typed `bool` from SDK
3. **N-of-M patch**: NO — all 5 string-match sites + the helper + the `.mli` export + the test pins closed in one PR
4. **catch-all added**: NO — the existing one-level-deep wildcards on `Io _` / `Serialization _` are preserved exactly (a future top-level `sdk_error` variant still becomes a build error)
5. **cap / cooldown / dedup / repair**: NO
6. **test backdoor**: NO
7. **typo N-fix**: NO — single-site root cause

## RFC

- `docs/rfc/RFC-0089-string-classifier-purge.md` §4-2 G4

## Status

Draft. Awaiting `human-approved-ready` label per Draft Auto-Merge Guard (reference_masc_mcp_draft_auto_merge_guard.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>