### PR TITLE
fix(keeper): contain FD-pressure recovery paths

### DIFF
--- a/lib/cascade/cascade_health_filter.ml
+++ b/lib/cascade/cascade_health_filter.ml
@@ -38,6 +38,7 @@ type cascade_failure_class =
   | Accept_rejected_capability_mismatch
   | Accept_rejected_terminal
   | Cli_transport_required
+  | Tls_error
   | Network_error
   | Provider_terminal
   | Provider_capacity_exhausted

--- a/lib/cascade/cascade_health_filter.mli
+++ b/lib/cascade/cascade_health_filter.mli
@@ -33,6 +33,7 @@ type cascade_failure_class =
   | Accept_rejected_capability_mismatch
   | Accept_rejected_terminal
   | Cli_transport_required
+  | Tls_error
   | Network_error
   | Provider_terminal
   | Provider_capacity_exhausted

--- a/lib/cascade/cascade_http_probe_url.mli
+++ b/lib/cascade/cascade_http_probe_url.mli
@@ -1,0 +1,4 @@
+(** HTTP capacity probe URL selection for cascade runtime candidates. *)
+
+val of_provider_config : Llm_provider.Provider_config.t -> string option
+

--- a/lib/cascade/cascade_wire_overlay.mli
+++ b/lib/cascade/cascade_wire_overlay.mli
@@ -1,0 +1,9 @@
+(** Wire-layer overlays applied after OAS resolves a provider config. *)
+
+val auth_header_authorization : string
+
+val apply :
+  provider_cfg:Llm_provider.Provider_config.t ->
+  Agent_sdk.Provider.config ->
+  Agent_sdk.Provider.config
+

--- a/lib/coord/coord_gc.ml
+++ b/lib/coord/coord_gc.ml
@@ -51,7 +51,13 @@ let cleanup_zombies
   (* agents_dir under .masc/ *)
   let agents_path = agents_dir config in
   let scan_paths =
-    if Sys.file_exists agents_path then [ agents_path ] else []
+    try if Sys.file_exists agents_path then [ agents_path ] else [] with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn when is_fd_pressure_text (Printexc.to_string exn) ->
+      Log.Gc.warn
+        "cleanup_zombies: skipping scan while agent directory is unreadable due to FD pressure: %s"
+        (Printexc.to_string exn);
+      []
   in
   if scan_paths = [] then
     No_agents_dir
@@ -59,7 +65,20 @@ let cleanup_zombies
     (* Phase 1: Detect zombie agents (no side effects) *)
     let zombie_entries = ref [] in (* (name, path) list *)
     List.iter (fun agents_path ->
-      Sys.readdir agents_path |> Array.iter (fun name ->
+      let names =
+        try Some (Sys.readdir agents_path) with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn when is_fd_pressure_text (Printexc.to_string exn) ->
+          Log.Gc.warn
+            "cleanup_zombies: skipping directory %s while FD pressure is active: %s"
+            agents_path
+            (Printexc.to_string exn);
+          None
+      in
+      match names with
+      | None -> ()
+      | Some names ->
+      names |> Array.iter (fun name ->
         Coord_query.safe_yield ();
         if Filename.check_suffix name ".json" then begin
           let path = Filename.concat agents_path name in
@@ -74,6 +93,10 @@ let cleanup_zombies
                    agent.last_seen ->
               zombie_entries := (agent.name, path) :: !zombie_entries
           | Ok _ -> () (* not a zombie, skip *)
+          | Error err when is_fd_pressure_text err ->
+              Log.Gc.warn
+                "cleanup_zombies: skipping quarantine for %s because read failed under FD pressure: %s"
+                name err
           | Error err ->
               (* #7947: previously deleted the file outright, losing
                  current_task/meta with no postmortem trail.  Quarantine

--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -402,7 +402,25 @@ let agent_json_needs_repair = function
       | _ -> false)
   | _ -> false
 
+let is_fd_pressure_text detail =
+  let detail = String.lowercase_ascii detail in
+  List.exists
+    (fun needle -> String_util.contains_substring detail needle)
+    [ "too many open files"
+    ; "emfile"
+    ; "enfile"
+    ; "file descriptor"
+    ; "os error 24"
+    ; "execve: too many open files"
+    ]
+;;
+
 let read_agent_with_repair config path =
+  (match read_json_result config path with
+   | Error msg when is_fd_pressure_text msg ->
+     Error ("fd_pressure_io: " ^ msg)
+   | Ok _
+   | Error _ ->
   let json = read_json config path in
   match Masc_domain.agent_of_yojson json with
   | Ok agent as ok ->
@@ -412,7 +430,7 @@ let read_agent_with_repair config path =
           path;
         write_json config path (Masc_domain.agent_to_yojson agent));
       ok
-  | Error _ as error -> error
+  | Error _ as error -> error)
 
 (* ============================================ *)
 (* File locking                                 *)

--- a/lib/coord/coord_utils_ops.mli
+++ b/lib/coord/coord_utils_ops.mli
@@ -96,6 +96,10 @@ val read_json_opt : config -> string -> Yojson.Safe.t option
     pre-canonical-form) and needs rewriting. *)
 val agent_json_needs_repair : Yojson.Safe.t -> bool
 
+val is_fd_pressure_text : string -> bool
+(** [true] for OS/resource-pressure text that means an agent file could not be
+    opened, not that it is malformed. *)
+
 (** Read an agent JSON and rewrite it in canonical form when the
     [last_seen] repair predicate fires. *)
 val read_agent_with_repair :

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -388,7 +388,11 @@ let append_to_path path manifest =
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn -> Error (Printexc.to_string exn)
+  | exn ->
+    Keeper_fd_pressure.note_exception
+      ~site:"keeper_runtime_manifest.append_to_path"
+      exn;
+    Error (Printexc.to_string exn)
 
 let append config manifest =
   append_to_path
@@ -400,8 +404,22 @@ let append_best_effort ?(site = "runtime_manifest") config manifest =
   match append config manifest with
   | Ok () -> ()
   | Error msg ->
+      Keeper_fd_pressure.note_if_fd_exhaustion
+        ~site:"keeper_runtime_manifest.append_best_effort"
+        msg;
       let masc_root = Coord.masc_root_dir config in
-      (try
+      let fd_pressure =
+        Keeper_fd_pressure.active () || Keeper_fd_pressure.is_fd_exhaustion_text msg
+      in
+      (if fd_pressure then
+         Log.Keeper.warn
+           "keeper:%s runtime_manifest coverage-gap append skipped during FD pressure \
+            site=%s trace_id=%s event=%s: %s"
+           manifest.keeper_name site manifest.trace_id
+           (event_kind_to_string manifest.event)
+           msg
+       else
+       try
          Telemetry_coverage_gap.record
            ~masc_root
            ~source:"runtime_manifest"

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -10,6 +10,7 @@ module Http_client = struct
     | Accept_rejected_capability_mismatch
     | Accept_rejected_terminal
     | Cli_transport_required
+    | Tls_error
     | Network_error
     | Provider_terminal
         (** OAS [ProviderTerminal] — provider has signalled a terminal
@@ -173,11 +174,13 @@ module Http_client = struct
           Provider_terminal
       | Llm_provider.Http_client.ProviderFailure { kind; _ } ->
           classify_provider_failure_kind kind
-      | Llm_provider.Http_client.NetworkError _ -> Network_error
+      | Llm_provider.Http_client.NetworkError { kind; _ } ->
+          if kind = Llm_provider.Http_client.Tls_error then Tls_error else Network_error
 
   let should_cascade (err : Llm_provider.Http_client.http_error) : bool =
     match classify err with
     | Local_resource_exhaustion
+    | Tls_error
     | Terminal_http _
     | Accept_rejected_terminal
     | Provider_terminal ->

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -30,6 +30,7 @@ module Http_client : sig
     | Accept_rejected_capability_mismatch
     | Accept_rejected_terminal
     | Cli_transport_required
+    | Tls_error
     | Network_error
     | Provider_terminal
         (** Provider-level terminal condition that should stop cascading. *)

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -1910,7 +1910,12 @@ let test_wired_manifest_sites () =
           "guard_keeper_hot_path";
         ] );
       ( "lib/keeper/keeper_runtime_manifest.ml",
-        [ "Telemetry_coverage_gap.record"; "runtime_manifest_append_failed" ]
+        [
+          "Telemetry_coverage_gap.record";
+          "runtime_manifest_append_failed";
+          "coverage-gap append skipped during FD pressure";
+          "Keeper_fd_pressure.active";
+        ]
       );
       ( "lib/server/server_dashboard_http_keeper_api.ml",
         [ "keeper_runtime_trace_json"; "/runtime-trace" ] );

--- a/test/test_oas_compat_cascade_fallback.ml
+++ b/test/test_oas_compat_cascade_fallback.ml
@@ -101,6 +101,32 @@ let test_http_429_cascades () =
     true
     (Oas_compat.Http_client.should_cascade err)
 
+let test_tls_error_does_not_cascade () =
+  let err =
+    Http_client.NetworkError
+      { kind = Tls_error; message = "TLS failure: invalid certificate chain" }
+  in
+  Alcotest.(check bool)
+    "TLS errors are route/config terminal and must not fan out to another provider"
+    false
+    (Oas_compat.Http_client.should_cascade err);
+  match Oas_compat.Http_client.classify err with
+  | Tls_error -> ()
+  | _ -> Alcotest.fail "TLS NetworkError must classify as Tls_error"
+
+let test_local_resource_error_does_not_cascade () =
+  let err =
+    Http_client.NetworkError
+      { kind = Local_resource_exhaustion; message = "Too many open files in system" }
+  in
+  Alcotest.(check bool)
+    "local resource exhaustion must not cascade"
+    false
+    (Oas_compat.Http_client.should_cascade err);
+  match Oas_compat.Http_client.classify err with
+  | Local_resource_exhaustion -> ()
+  | _ -> Alcotest.fail "local resource exhaustion must keep its typed class"
+
 (* --- ProviderTerminal: pin classify, should_cascade, and the new
        error_message helper. The variant arrived in agent_sdk without
        a sweep, so [warn-error +8] flipped 5 [partial-match] warnings
@@ -347,6 +373,13 @@ let () =
       ( "Baseline: HTTP errors unaffected",
         [
           Alcotest.test_case "HTTP 429 cascades" `Quick test_http_429_cascades;
+        ] );
+      ( "Network terminal errors do not cascade",
+        [
+          Alcotest.test_case "TLS error does not cascade"
+            `Quick test_tls_error_does_not_cascade;
+          Alcotest.test_case "local resource error does not cascade"
+            `Quick test_local_resource_error_does_not_cascade;
         ] );
       ( "ProviderTerminal — agent-level terminal does not cascade",
         [

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -1089,6 +1089,18 @@ let test_cleanup_zombies_removes_broken_agent_file () =
       false (Sys.file_exists path)
   )
 
+let test_fd_pressure_text_classification () =
+  Alcotest.(check bool)
+    "EMFILE text is resource pressure, not malformed JSON"
+    true
+    (Coord.is_fd_pressure_text
+       {|[read_json_result] backend_get failed for agents:keeper.json:
+         Eio.Io Unix_error (Too many open files in system, "openat", "/tmp/keeper.json")|});
+  Alcotest.(check bool)
+    "schema errors are not resource pressure"
+    false
+    (Coord.is_fd_pressure_text "Types_core.agent.last_seen (last_seen=<missing>)")
+
 let test_cleanup_zombies_preserves_non_json_files () =
   with_test_env (fun config ->
     (* Place a non-JSON file in the agents directory *)
@@ -1920,6 +1932,7 @@ let () =
       Alcotest.test_case "cleanup spares recent keeper" `Quick test_cleanup_zombies_spares_recent_keeper;
       Alcotest.test_case "cleanup spares type keeper" `Quick test_cleanup_zombies_spares_type_keeper;
       Alcotest.test_case "cleanup removes broken agent file" `Quick test_cleanup_zombies_removes_broken_agent_file;
+      Alcotest.test_case "fd pressure text is not broken JSON" `Quick test_fd_pressure_text_classification;
       Alcotest.test_case "cleanup preserves non-json files" `Quick test_cleanup_zombies_preserves_non_json_files;
     ];
 


### PR DESCRIPTION
## Summary
- classify OAS TLS failures as terminal for MASC cascade decisions
- treat local FD-pressure reads as resource pressure instead of malformed agent JSON
- skip runtime-manifest coverage-gap writes while FD pressure is active

## Root cause
When the host entered FD pressure, recovery paths performed additional filesystem work: agent GC could misread transient IO failures as broken JSON and runtime-manifest failure handling attempted another durable coverage-gap write. That amplified the original `Too many open files` condition.

## OAS context
Paired upstream OAS PR: https://github.com/jeong-sik/oas/pull/1607

## Safety gate
This MASC patch is safe as a repo-local containment layer, but the full cross-repo fix is not complete until the paired OAS behavior lands and downstream pin/release flow is handled as needed. Keep the PR draft-only unless a human explicitly applies the configured approval label.

## Validation
- `scripts/dune-local.sh exec test/test_oas_compat_cascade_fallback.exe`
- `scripts/dune-local.sh exec test/test_room.exe`
- `scripts/dune-local.sh exec test/test_keeper_runtime_manifest.exe`
- `scripts/check-oas-pin.sh --local-only`
- `ocamlformat --check lib/cascade/cascade_health_filter.ml lib/cascade/cascade_health_filter.mli lib/coord/coord_gc.ml lib/coord/coord_utils_ops.ml lib/coord/coord_utils_ops.mli lib/keeper/keeper_runtime_manifest.ml lib/oas_compat/oas_compat.ml lib/oas_compat/oas_compat.mli test/test_keeper_runtime_manifest.ml test/test_oas_compat_cascade_fallback.ml test/test_room.ml`
- `git diff --check`