### PR TITLE
chore: purge dead team-session / swarm references

### DIFF
--- a/lib/board_core_classify.ml
+++ b/lib/board_core_classify.ml
@@ -101,7 +101,6 @@ type system_actor =
   | Keeper_alert_bot
   | Keeper_system
   | Operator
-  | Team_session
 
 type author_kind =
   | Human_author
@@ -114,7 +113,6 @@ let system_actor_of_string = function
   | "keeper-alert-bot" -> Some Keeper_alert_bot
   | "keeper-system" -> Some Keeper_system
   | "operator" -> Some Operator
-  | "team-session" -> Some Team_session
   | _ -> None
 
 let automation_label_of_string author =

--- a/lib/board_core_classify.mli
+++ b/lib/board_core_classify.mli
@@ -93,7 +93,6 @@ type system_actor =
   | Keeper_alert_bot
   | Keeper_system
   | Operator
-  | Team_session
 
 type author_kind =
   | Human_author
@@ -125,8 +124,8 @@ val legacy_migrate_post_kind :
     (first match wins):
 
     + System author (one of \["ecosystem"; "keeper";
-      "keeper-alert-bot"; "keeper-system"; "operator";
-      "team-session"\]) -> [System_post].
+      "keeper-alert-bot"; "keeper-system"; "operator"\]) ->
+      [System_post].
     + [meta_json.source = "keeper_board_post"] -> [Automation_post].
     + Internal visibility + [expires_at > 0.0] + non-empty hearth
       starting with ["mdal"] or containing ["harness"] ->

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -518,7 +518,6 @@ let session_json ?actor ~session_id ~config ~sw
       projection.sessions
   in
   let worker_runs_json =
-    (* Team_session_store + Team_session_engine_eio removed *)
     ignore (config, session_id);
     `Null
   in

--- a/lib/exec/agent_id.ml
+++ b/lib/exec/agent_id.ml
@@ -15,7 +15,6 @@ type t =
   | `System_worker_runtime_docker
   | `System_spawn
   | `System_auto_responder
-  | `Swarm_goal_loop
   | `Coord_identity
   | `Tool_local_runtime
   | `Tool_local_runtime_bench
@@ -41,7 +40,6 @@ let of_string = function
   | "system/worker_runtime_docker" -> `System_worker_runtime_docker
   | "system/spawn" -> `System_spawn
   | "system/auto_responder" -> `System_auto_responder
-  | "swarm/goal_loop" -> `Swarm_goal_loop
   | "coord/identity" -> `Coord_identity
   | "tool/local_runtime" -> `Tool_local_runtime
   | "tool/local_runtime_bench" -> `Tool_local_runtime_bench
@@ -66,7 +64,6 @@ let to_string = function
   | `System_worker_runtime_docker -> "system/worker_runtime_docker"
   | `System_spawn -> "system/spawn"
   | `System_auto_responder -> "system/auto_responder"
-  | `Swarm_goal_loop -> "swarm/goal_loop"
   | `Coord_identity -> "coord/identity"
   | `Tool_local_runtime -> "tool/local_runtime"
   | `Tool_local_runtime_bench -> "tool/local_runtime_bench"

--- a/lib/exec/agent_id.mli
+++ b/lib/exec/agent_id.mli
@@ -22,7 +22,6 @@ type t =
   | `System_worker_runtime_docker
   | `System_spawn
   | `System_auto_responder
-  | `Swarm_goal_loop
   | `Coord_identity
   | `Tool_local_runtime
   | `Tool_local_runtime_bench

--- a/lib/exec/exec_gate.ml
+++ b/lib/exec/exec_gate.ml
@@ -54,7 +54,6 @@ let rollout_config : Approval_config.t =
         (`System_worker_runtime_docker, internal_observer_overlay);
         (`System_spawn, internal_observer_overlay);
         (`System_auto_responder, internal_observer_overlay);
-        (`Swarm_goal_loop, internal_observer_overlay);
         (`Coord_identity, internal_observer_overlay);
         (`Tool_local_runtime, internal_observer_overlay);
         (`Tool_local_runtime_bench, internal_observer_overlay);

--- a/lib/keeper/keeper_cdal_contract.mli
+++ b/lib/keeper/keeper_cdal_contract.mli
@@ -1,6 +1,5 @@
-(* Team session contract system removed (#6107). *)
-
-(** Risk-contract projection of a [keeper_meta]. Always returns
-    [None] since the team-session contract system was removed. *)
+(** Risk-contract projection of a [keeper_meta].  Currently always
+    returns [None]; the prior contract derivation pipeline was
+    removed in #6107 and no replacement has been wired in. *)
 val of_keeper_meta :
   Keeper_types.keeper_meta -> Masc_mcp_cdal_runtime.Risk_contract.t option

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -7,7 +7,6 @@
 
     Sub-modules:
     - Keeper_turn_up: start/reconfigure
-    - Keeper_turn_session: team-session helpers
     - Keeper_turn_setup: ensure_keeper_exists
     - Keeper_turn_lifecycle: shutdown *)
 

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -274,16 +274,6 @@ let status_json (ctx : context) ~loop_id json_fields =
           Json_util.string_opt_to_json queued_hypothesis );
       ])
 
-let build_swarm_goal ~goal ~target_file ~program_note =
-  match program_note with
-  | Some note ->
-      Printf.sprintf
-        "Autoresearch swarm goal: %s\nTarget file: %s\nProgram note:\n%s"
-        goal target_file note
-  | None ->
-      Printf.sprintf "Autoresearch swarm goal: %s\nTarget file: %s" goal
-        target_file
-
 let parse_operation_id json =
   match Yojson.Safe.Util.member "operation_id" json with
   | `String value when not (String.equal (String.trim value) "") -> Some (String.trim value)
@@ -379,11 +369,6 @@ let handle_stop (ctx : context) args =
     | Some state ->
         let _config = Coord.default_config ctx.base_path in
         broadcast_loop_lifecycle "autoresearch_stopped" state;
-        (match Autoresearch.load_execution_link_by_loop ~base_path:ctx.base_path id with
-        | Some _link ->
-            (* Team_session_store removed — skip event append *)
-            ()
-        | None -> ());
         `Assoc [
           ("loop_id", `String id);
           ("status", `String "stopped");

--- a/lib/tool_autoresearch.mli
+++ b/lib/tool_autoresearch.mli
@@ -25,7 +25,7 @@
     ([persisted_summary_json], [resolve_loop_id],
     [prepare_start_params], [register_loop],
     [prepare_managed_target_file], [setup_running_loop],
-    [status_json], [build_swarm_goal], [parse_operation_id],
+    [status_json], [parse_operation_id],
     [check_concurrency_limit], the [handle_status] /
     [handle_stop] / [handle_inject] /
     [handle_record_finding] / [handle_search_findings]

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -638,14 +638,6 @@ let handle_cycle (ctx : Tool_autoresearch_context.t) args =
                          Hashtbl.replace Autoresearch.active_loops id state);
                        Autoresearch.save_state ~base_path:ctx.base_path state;
                        let _config = Coord.default_config ctx.base_path in
-                       (match
-                          Autoresearch.load_execution_link_by_loop
-                            ~base_path:ctx.base_path id
-                        with
-                       | Some _link ->
-                         (* Team_session_store removed — skip event append *)
-                         ()
-                       | None -> ());
                        broadcast_cycle_result state effective_record;
                        `Assoc
                          [

--- a/lib/tool_inline_dispatch_comm.ml
+++ b/lib/tool_inline_dispatch_comm.ml
@@ -83,7 +83,6 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
           ~content:message
           ~mention
         in
-        (* Team_session_engine_eio removed — skip broadcast increment *)
         ignore (config, agent_name);
         Audit_log.log_broadcast config ~agent_id:agent_name
           ~message_preview:message ();

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -689,9 +689,8 @@ let handle_keeper_repair ctx args : tool_result =
                       | None -> fields
                     in
                     let ok, body =
-                      (* Team_session_oas_bridge removed *)
                       ignore (ctx.sw, ctx.clock, ctx.config, fields);
-                      (false, {|{"error":"team session oas bridge removed"}|})
+                      (false, {|{"error":"keeper repair handler not implemented"}|})
                     in
                     invalidate_status_cache meta.name;
                     ( ok,

--- a/scripts/harness/lib/obs_smoke_common.sh
+++ b/scripts/harness/lib/obs_smoke_common.sh
@@ -114,7 +114,7 @@ obs_start_server() {
 # Usage: obs_bootstrap_room <mcp_url> <session_id> <agent_name> [capabilities_json_array]
 obs_bootstrap_room() {
   local mcp_url="$1" session_id="$2" agent_name="$3"
-  local capabilities="${4:-[\"supervisor\",\"operator\",\"team-session\"]}"
+  local capabilities="${4:-[\"supervisor\",\"operator\"]}"
   local init_raw join_raw nickname
 
   init_raw="$(mcp_call_tool 1 "masc_init" "$(jq -cn --arg a "$agent_name" '{agent_name:$a}')" "$session_id" "" "$mcp_url")"

--- a/scripts/harness/workload/agent_swarm_live.sh
+++ b/scripts/harness/workload/agent_swarm_live.sh
@@ -23,10 +23,9 @@ usage() {
   cat <<'EOF'
 Usage: scripts/harness_agent_swarm_live.sh [options]
 
-Compatibility entrypoint for the retired managed-swarm proof lane.
+Keeper fleet production-readiness gate against persisted runtime truth.
 
-The old team-session/swarm substrate is retired. This entrypoint now runs the
-keeper fleet production-readiness gate against persisted runtime truth:
+This entrypoint scans the persisted keeper runtime evidence:
 runtime manifests, receipts, checkpoints, provider attempt closure, memory
 injection, and tool-call logs. It is read-only and does not start keepers.
 
@@ -231,9 +230,9 @@ cat >"$SUMMARY_MD" <<EOF
 
 ## Contract
 
-This compatibility entrypoint replaces the retired team-session swarm proof with
-read-only keeper runtime evidence. A passing run proves that persisted keeper
-runtime manifests have complete receipt, checkpoint, provider-closure,
+This gate inspects read-only keeper runtime evidence. A passing run proves that
+persisted keeper runtime manifests have complete receipt, checkpoint,
+provider-closure,
 memory-injection, and tool-log chains for the configured 18+ keeper fleet.
 EOF
 

--- a/scripts/harness/workload/keeper_campaign.sh
+++ b/scripts/harness/workload/keeper_campaign.sh
@@ -288,7 +288,7 @@ create_keeper() {
     --arg goal "$CAMPAIGN_GOAL" \
     --arg short_goal "Claim the campaign task and start autoresearch on the fixture repo." \
     --arg mid_goal "Reach the target score, then preserve goal/task lineage through pressure." \
-    --arg long_goal "Prove keeper-only goal-reaching continuity without team_session." \
+    --arg long_goal "Prove keeper-only goal-reaching continuity end to end." \
     --arg instructions "모든 응답은 한국어로 짧게 작성하세요. 목표와 current_task를 잃지 말고, 필요한 경우 masc_claim_next, masc_plan_set_task, masc_autoresearch_* 도구를 사용하세요." \
     --argjson models "$models_json_payload" \
     --argjson presence_keepalive_sec "$KEEPER_PRESENCE_KEEPALIVE_SEC" \

--- a/scripts/lint-cancel-guard.sh
+++ b/scripts/lint-cancel-guard.sh
@@ -3,7 +3,7 @@
 # Exit 0 = no violations, Exit 1 = violations found.
 set -euo pipefail
 REPO_ROOT="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel)"
-NO_EIO_DIRS="dashboard_utils|masc_log|types|response|config|swarm_status|tool_schemas|mcp_session|ag_ui|compression|mcp_transport_protocol"
+NO_EIO_DIRS="dashboard_utils|masc_log|types|response|config|tool_schemas|mcp_session|ag_ui|compression|mcp_transport_protocol"
 VIOLATIONS=0
 while IFS= read -r file; do
   echo "$file" | grep -qE "/(${NO_EIO_DIRS})/" 2>/dev/null && continue

--- a/scripts/setup_dashboard_mission_fixture.sh
+++ b/scripts/setup_dashboard_mission_fixture.sh
@@ -30,7 +30,7 @@ const sessionId = process.env.SESSION_ID || 'ts-mission-fixture-001';
 const keeperName = process.env.KEEPER_NAME || 'mission-fixture-keeper';
 
 const fixtureAgents = [
-  { name: 'team-session-local64-smoke', capabilities: ['operator', 'fixture', 'local64'] },
+  { name: 'mission-local64-smoke', capabilities: ['operator', 'fixture', 'local64'] },
   { name: 'llama-local-alpha', capabilities: ['worker', 'local64', 'manager'] },
   { name: 'llama-local-beta', capabilities: ['worker', 'local64', 'metacog'] },
   { name: 'llama-local-gamma', capabilities: ['worker', 'local64', 'executor'] },
@@ -98,7 +98,7 @@ async function seedRoom() {
   });
 
   await mcpCall('masc_broadcast', {
-    agent_name: 'team-session-local64-smoke',
+    agent_name: 'mission-local64-smoke',
     message: '@llama-local-alpha recover failed worker coverage',
     format: 'compact',
   });
@@ -165,13 +165,13 @@ function seedExecutionSession() {
         spawn_role: 'manager',
         spawn_model: 'qwen3.5-35b-a3b-ud-q8-xl',
         worker_class: 'manager',
-        parent_actor: 'team-session-local64-smoke',
+        parent_actor: 'mission-local64-smoke',
         capsule_mode: 'inherit',
         runtime_pool: 'local64',
         lane_id: 'lane-manager',
         controller_level: 'root',
         control_domain: 'execution',
-        supervisor_actor: 'team-session-local64-smoke',
+        supervisor_actor: 'mission-local64-smoke',
         model_tier: '35b',
         task_profile: 'decide',
         risk_level: 'high',
@@ -185,7 +185,7 @@ function seedExecutionSession() {
         spawn_role: 'metacog',
         spawn_model: 'qwen27-balanced',
         worker_class: 'metacog',
-        parent_actor: 'team-session-local64-smoke',
+        parent_actor: 'mission-local64-smoke',
         capsule_mode: 'inherit',
         runtime_pool: 'local64',
         lane_id: 'lane-meta',
@@ -205,7 +205,7 @@ function seedExecutionSession() {
         spawn_role: 'executor',
         spawn_model: 'qwen9-worker',
         worker_class: 'executor',
-        parent_actor: 'team-session-local64-smoke',
+        parent_actor: 'mission-local64-smoke',
         capsule_mode: 'fresh',
         runtime_pool: 'local64',
         lane_id: 'lane-worker',
@@ -250,7 +250,7 @@ function seedExecutionSession() {
       ts_iso: new Date((startedAt + 5) * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z'),
       event_type: 'team_step_spawn',
       detail: {
-        actor: 'team-session-local64-smoke',
+        actor: 'mission-local64-smoke',
         spawn_agent: 'llama',
         runtime_actor: 'llama-local-delta',
         success: false,
@@ -263,7 +263,7 @@ function seedExecutionSession() {
       ts_iso: new Date((startedAt + 8) * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z'),
       event_type: 'team_step_spawn',
       detail: {
-        actor: 'team-session-local64-smoke',
+        actor: 'mission-local64-smoke',
         spawn_agent: 'llama',
         runtime_actor: 'llama-local-epsilon',
         success: false,
@@ -306,7 +306,7 @@ function seedExecutionSession() {
       ts_iso: new Date((startedAt + 42) * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z'),
       event_type: 'local64_smoke_cleanup',
       detail: {
-        actor: 'team-session-local64-smoke',
+        actor: 'mission-local64-smoke',
         result: 'interrupted after fixture spawn failure reproduction',
       },
     },

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -87,8 +87,6 @@
    (re_export masc_mcp.resilience)
    (re_export masc_mcp.response)
    (re_export masc_mcp.shared_audit)
-   ;; masc_mcp.swarm_status removed (retire swarm read surfaces, #7572)
-   ;; masc_mcp.team_session_types removed (Epic #6107)
    (re_export masc_mcp.tool_schemas)
    (re_export masc_mcp.tool_catalog_surfaces)
    (re_export masc_mcp.config_dir_resolver)

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -414,7 +414,7 @@ let test_graph_json_tracks_runtime_activity_kinds () =
   with_config (fun config ->
       ignore
         (Activity_graph.emit config           ~kind:"operation.started"
-           ~actor:(Activity_graph.entity ~kind:"agent" "team-session")
+           ~actor:(Activity_graph.entity ~kind:"agent" "mission-agent")
            ~subject:(Activity_graph.entity ~kind:"operation" "sess-001")
            ~tags:[ "operation"; "operation.started" ]
            ~payload:(`Assoc [ ("session_id", `String "sess-001") ])

--- a/test/test_backend.ml
+++ b/test/test_backend.ml
@@ -137,9 +137,9 @@ let test_recursive_prefix_get_all () =
   with_eio_env @@ fun backend ->
   let writes =
     [
-      ("team-sessions:ts-1:session.json", "s1");
-      ("team-sessions:ts-1:events.jsonl", "e1");
-      ("team-sessions:ts-2:session.json", "s2");
+      ("mission-sessions:ts-1:session.json", "s1");
+      ("mission-sessions:ts-1:events.jsonl", "e1");
+      ("mission-sessions:ts-2:session.json", "s2");
       ("relay:node-1", "m1");
     ]
   in
@@ -149,11 +149,11 @@ let test_recursive_prefix_get_all () =
       | Ok () -> ()
       | Error _ -> Alcotest.fail "set for recursive prefix test failed")
     writes;
-  match Backend.FileSystem.list_keys backend ~prefix:"team-sessions:" with
+  match Backend.FileSystem.list_keys backend ~prefix:"mission-sessions:" with
   | Ok keys ->
       Alcotest.(check int) "recursive keys" 3 (List.length keys);
       Alcotest.(check bool) "session key present" true
-        (List.mem "team-sessions:ts-2:session.json" keys)
+        (List.mem "mission-sessions:ts-2:session.json" keys)
   | Error _ -> Alcotest.fail "recursive list_keys failed"
 
 (** Test set_if_not_exists *)

--- a/test/test_backend_coverage.ml
+++ b/test/test_backend_coverage.ml
@@ -487,7 +487,7 @@ let test_eio_fs_rejects_reserved_atomic_tmp_suffix () =
 
 let test_eio_fs_list_keys_ignores_atomic_tmp_orphans () =
   with_eio_backend_and_dir @@ fun backend tmp_dir ->
-  let nested_dir = Filename.concat (Filename.concat tmp_dir "team-sessions") "ts-1" in
+  let nested_dir = Filename.concat (Filename.concat tmp_dir "mission-sessions") "ts-1" in
   mkdir_p nested_dir;
   write_file (Filename.concat tmp_dir "root.tmp-atomic") "partial";
   write_file (Filename.concat tmp_dir "root") "root";
@@ -497,7 +497,7 @@ let test_eio_fs_list_keys_ignores_atomic_tmp_orphans () =
   | Ok keys ->
       check bool "root key listed" true (List.mem "root" keys);
       check bool "nested key listed" true
-        (List.mem "team-sessions:ts-1:session.json" keys);
+        (List.mem "mission-sessions:ts-1:session.json" keys);
       check bool "atomic temp orphan hidden" false
         (List.exists (String.ends_with ~suffix:".tmp-atomic") keys)
   | Error _ -> fail "list_keys error"

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -73,7 +73,7 @@ let write_pending_confirm config _session_id =
 
 let seed_room config session_id =
   ignore (Lib.Coord.init config ~agent_name:(Some "fixture-root"));
-  ignore (Lib.Coord.join config ~agent_name:"team-session-local64-smoke"
+  ignore (Lib.Coord.join config ~agent_name:"mission-local64-smoke"
             ~capabilities:[ "operator"; "fixture"; "local64" ] ());
   ignore (Lib.Coord.join config ~agent_name:"llama-local-alpha"
             ~capabilities:[ "worker"; "local64"; "manager" ] ());
@@ -84,7 +84,7 @@ let seed_room config session_id =
   ignore (Lib.Coord.join config ~agent_name:"llama-local-delta"
             ~capabilities:[ "worker"; "local64"; "observer" ] ());
   ignore
-    (Lib.Coord.broadcast config ~from_agent:"team-session-local64-smoke"
+    (Lib.Coord.broadcast config ~from_agent:"mission-local64-smoke"
        ~content:"@llama-local-alpha recover failed worker coverage");
   ignore
     (Lib.Coord.broadcast config ~from_agent:"llama-local-alpha"

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -3326,7 +3326,7 @@ let test_keeper_msg_auto_execution_session_bridge () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      Keeper_keepalive.stop_keepalive "team-session-keeper";
+      Keeper_keepalive.stop_keepalive "mission-control-keeper";
       Keeper_registry.clear ();
       Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
@@ -3343,14 +3343,14 @@ let test_keeper_msg_auto_execution_session_bridge () =
           net = None;
         }
       in
-      let keeper_name = "team-session-keeper" in
+      let keeper_name = "mission-control-keeper" in
       let ok, _ =
         dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
           ~args:
             (`Assoc
               [
                 ("name", `String keeper_name);
-                ("goal", `String "Start projected team sessions from explicit keeper messages");
+                ("goal", `String "Start projected execution sessions from explicit keeper messages");
                 ("proactive_enabled", `Bool false);
                 ("autoboot_enabled", `Bool false);
               ])
@@ -3397,9 +3397,7 @@ let test_keeper_msg_auto_execution_session_bridge () =
         Alcotest.(check bool) "reused" false
           (first_json |> member "reused" |> to_bool);
         let session_id = first_json |> member "session_id" |> to_string in
-        (* Team_session_store removed — skip session verification *)
         ignore session_id;
-        (* Team session tools removed — skip execution_session_status dispatch test *)
         ignore (config, sw, env, session_id);
         Alcotest.(check bool) "spawn_error surfaced" true
           (first_json |> member "spawn_error" <> `Null);
@@ -3418,15 +3416,14 @@ let test_keeper_msg_auto_execution_session_bridge () =
         in
         Alcotest.(check bool) "keeper status ok" true status_ok;
         let status_json = parse_json_exn status_body in
-        Alcotest.(check string) "status exposes auto team session removal" "removed"
+        Alcotest.(check string) "status exposes auto execution session removal" "removed"
           Yojson.Safe.Util.(status_json |> member "auto_execution_session" |> member "status" |> to_string);
-        Alcotest.(check bool) "status exposes auto team session disabled" false
+        Alcotest.(check bool) "status exposes auto execution session disabled" false
           Yojson.Safe.Util.(status_json |> member "auto_execution_session_enabled" |> to_bool);
-        Alcotest.(check bool) "status omits team session state" true
+        Alcotest.(check bool) "status omits execution session state" true
           Yojson.Safe.Util.(status_json |> member "execution_session_state" = `Null);
-        Alcotest.(check bool) "status omits team session bridge" true
+        Alcotest.(check bool) "status omits execution session bridge" true
           Yojson.Safe.Util.(status_json |> member "execution_session_bridge" = `Null);
-        (* Team_session_store removed — skip event verification *)
         ignore (config, session_id);
         let ok, second_body =
           dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_msg"
@@ -3445,7 +3442,6 @@ let test_keeper_msg_auto_execution_session_bridge () =
           Yojson.Safe.Util.(second_json |> member "created" |> to_bool);
         Alcotest.(check bool) "second reused true" true
           Yojson.Safe.Util.(second_json |> member "reused" |> to_bool);
-        (* Team_session_store removed — skip event count verification *)
         ignore (config, session_id);
         let ok, _ =
           dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_down"
@@ -3459,7 +3455,6 @@ let test_keeper_msg_auto_execution_session_bridge () =
           | Error err -> Alcotest.fail ("meta read after down failed: " ^ err)
         in
         Alcotest.(check bool) "keeper paused on down" true meta_after_down.paused;
-        (* Team_session_engine_eio removed — skip session cleanup *)
         ignore (config, session_id))
 
 let test_operator_keeper_message_rejects_legacy_model_args () =

--- a/test/test_operator_control_support.ml
+++ b/test/test_operator_control_support.ml
@@ -70,5 +70,3 @@ let record_operator_judgment config ~surface ~target_type ~target_id ~summary
        ~fresh_until:(iso_of_unix (now_unix +. fresh_for_sec))
        ~fresh_until_unix:(now_unix +. fresh_for_sec)
        ~keeper_name:"operator-judge" ())
-
-(* setup_swarm_run_env removed (CP purge: Command_plane_v2 deleted) *)

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -364,17 +364,17 @@ let with_server ?(host = "127.0.0.1") ?(enable_auth = true) f =
   in
   let planner_nickname =
     Masc_mcp.Coord.join config ~agent_name:"planner"
-      ~capabilities:[ "planner"; "team-session" ] ()
+      ~capabilities:[ "planner" ] ()
     |> extract_nickname_from_join_result
   in
   let implementer_a_nickname =
     Masc_mcp.Coord.join config ~agent_name:"implementer-a"
-      ~capabilities:[ "backend"; "team-session" ] ()
+      ~capabilities:[ "backend" ] ()
     |> extract_nickname_from_join_result
   in
   let implementer_b_nickname =
     Masc_mcp.Coord.join config ~agent_name:"implementer-b"
-      ~capabilities:[ "docs"; "tests"; "team-session" ] ()
+      ~capabilities:[ "docs"; "tests" ] ()
     |> extract_nickname_from_join_result
   in
   Mirage_crypto_rng_unix.use_default ();

--- a/test/test_tool_surface_ssot.ml
+++ b/test/test_tool_surface_ssot.ml
@@ -73,9 +73,10 @@ let test_keeper_denied_parity () =
 (* {1 Structural Invariants — hold regardless of migration phase} *)
 
 let test_session_min_and_local_worker_share_core () =
-  (* Session_min (worker container fallback) and Local_worker (team-session
-     bridge) serve different purposes and are NOT in a subset relationship.
-     Instead we verify they share the expected coordination core. *)
+  (* Session_min (worker container fallback) and Local_worker (mission
+     execution bridge) serve different purposes and are NOT in a subset
+     relationship.  Instead we verify they share the expected coordination
+     core. *)
   let min_set = set_of (Tool_catalog.tools_for_surface Tool_catalog.Session_min) in
   let worker_set = set_of (Tool_catalog.tools_for_surface Tool_catalog.Local_worker) in
   let shared = SS.inter min_set worker_set in

--- a/test/test_worker_runtime.ml
+++ b/test/test_worker_runtime.ml
@@ -213,11 +213,7 @@ let test_run_worker_oas_rejects_invalid_explicit_model_label () =
           fail "expected invalid explicit model label to fail before execution"
       | Error err ->
           check bool "mentions rejected label" true
-            (String.contains err 'n' && String.contains err '-');
-          check bool "does not use removed team-session stub" false
-            (Astring.String.is_infix
-               ~affix:"Worker_run_once removed (team session layer)"
-               err))
+            (String.contains err 'n' && String.contains err '-'))
 
 let test_worker_execution_spec_rejects_removed_fields () =
   let json =


### PR DESCRIPTION
## Why

Sweeps lingering references to the **team_session** subsystem
(`Team_session_store`, `Team_session_engine_eio`, `Team_session_oas_bridge`
— all removed in #6107 + follow-ups) and the **swarm** tool surface
(`masc_swarm_*` retired in #7572) that survived as tombstone comments,
stale string members, dead variants, and fixture identifiers.

The trigger was #15524 (RFC-0089 G2 typed `author_kind` variant): the
typed `system_actor` constructor list included `Team_session` purely
because the legacy `legacy_system_board_author` string list included
`"team-session"`. Mechanical translation reified a dead concept into the
type system. This PR removes the `Team_session` constructor (and the
matching `"team-session"` parser arm), then sweeps the rest of the
dead-name surface area in adjacent code/scripts/tests.

## What this removes

| Site | Shape | Removed |
|------|-------|---------|
| `lib/board_core_classify.{ml,mli}` | typed variant member | `Team_session` constructor + `"team-session"` arm in `system_actor_of_string`. Closed sum, 0 external callers. |
| `lib/exec/agent_id.{ml,mli}` + `lib/exec/exec_gate.ml` | polymorphic variant | `` `Swarm_goal_loop `` + its overlay-map entry. 0 emitters found in `lib/`. |
| `lib/tool_autoresearch.{ml,mli}` | function | `build_swarm_goal` (0 callers anywhere). |
| `lib/tool_autoresearch.ml` / `lib/tool_autoresearch_cycle.ml` | dead match block | `match Autoresearch.load_execution_link_by_loop` arms that did `(* Team_session_store removed *) ()` on every branch. |
| `lib/dashboard/dashboard_mission.ml` | tombstone | `(* Team_session_store + Team_session_engine_eio removed *)` on noop `worker_runs_json`. |
| `lib/tool_inline_dispatch_comm.ml`, `lib/tool_keeper.ml`, `lib/keeper/keeper_cdal_contract.mli`, `lib/keeper/keeper_turn.ml` | comment / error string | Reword to drop `team_session` / `Team_session_*` naming. |
| `test/deps/dune`, `test/test_operator_control_support.ml`, `test/test_tool_surface_ssot.ml` | tombstone comments | Deleted. |
| `scripts/lint-cancel-guard.sh` | stale `NO_EIO_DIRS` entry | `swarm_status` (the directory does not exist on tree). |

## Fixture renames (test-only, no semantic change)

| File | Before | After |
|------|--------|-------|
| `scripts/setup_dashboard_mission_fixture.sh` + `test/test_dashboard_mission.ml` | `team-session-local64-smoke` | `mission-local64-smoke` |
| `test/test_operator_control_keeper.ml` | `team-session-keeper` (keeper name) | `mission-control-keeper` |
| `test/test_operator_control_keeper.ml` | assertion labels saying "team session" | "execution session" (matches actual response field names `auto_execution_session*`/`execution_session_*`) |
| `test/test_operator_mcp_e2e.ml` | `"team-session"` capability tag on 3 test agents | removed (metadata-only, no behavior) |
| `test/test_activity_graph.ml` | actor name `"team-session"` | `"mission-agent"` |
| `test/test_backend.ml` + `test/test_backend_coverage.ml` | `team-sessions:` test prefix | `mission-sessions:` (testing prefix mechanism, literal incidental) |
| `scripts/harness/lib/obs_smoke_common.sh` | default `"team-session"` capability | removed |
| `scripts/harness/workload/agent_swarm_live.sh` | docstring "old team-session/swarm substrate" phrasing | rewrote without |
| `scripts/harness/workload/keeper_campaign.sh` | long-goal text `"...without team_session."` | `"...end to end."` |

`test/test_worker_runtime.ml` lost one vacuous regression assertion against the legacy affix `"Worker_run_once removed (team session layer)"` — no emitter exists, the guard cannot fire.

## What is intentionally **NOT** touched (Tier B / separate PR)

These need migration coordination with deployed installs / dashboard
frontend / external schema and are out of scope:

1. **Filesystem layout** `.masc/team-sessions/<id>/autoresearch.json` —
   `autoresearch_storage.ml:session_link_file` actively writes there
   (`lib/autoresearch/autoresearch_storage.ml`); `coord_gc.ml` archives
   it; `scripts/audit-event-linkage.sh` reads it. Comment in
   `autoresearch_storage.ml` explicitly preserves the dir name for
   back-compat with existing data in deployed installs. Renaming
   requires a back-compat read path.
2. **Artifact filename** `swarm.json` (autoresearch_storage.loop_link_file).
3. **Dashboard `command_surface: "swarm"`** in
   `lib/dashboard/dashboard_execution_sessions.ml:268` — consumed by
   `dashboard/design-system/ui_kits/cockpit/CrewPlane.jsx` "swarm" view
   tab and `<SwarmGrid>` component. Backend+frontend coordinated rename.
4. **`repo_synthesis_benchmark` "swarm" label** — benchmark fixture
   filenames + output JSON schema (cross-file rename).
5. **Negative-regression guards** in `test_tools_coverage.ml` /
   `test_tool_access_policy.ml` / `test_tool_shard_coverage.ml` /
   `test_operator_control_snapshot.ml` enforcing `masc_swarm_*` /
   `swarm_status` absence — **kept intentionally** as the correct
   shape of dead-concept handling (closed-sum ratchet).
6. **`handle_keeper_repair` dead handler** in `lib/tool_keeper.ml`
   (whole branch returns stub error after all input validation) —
   substantial dead-tool cleanup, MCP surface change, separate
   decision.

## Build / test

```
dune build --root . lib                          # PASS (0 warnings)
dune build --root . test/test_operator_control.exe (MASC_INCLUDE_OPERATOR_CONTROL=true)  # PASS
dune exec --root . test/test_board_fixture_detector.exe   # 7/7 PASS
dune exec --root . test/test_heuristic_theatre_audit.exe  # 4/4 PASS
dune exec --root . test/test_activity_graph.exe           # 17/17 PASS
dune exec --root . test/test_backend.exe                  # 10/10 PASS
dune exec --root . test/test_backend_coverage.exe         # 40/40 PASS
dune exec --root . test/test_worker_runtime.exe           # 8/8 PASS
```

### Pre-existing failures unrelated to this PR

Both reproduce on `origin/main` (`c55c7791f9`):

- `test_tool_surface_ssot` `ssot_validation/no orphaned tools` — fails
  on `keeper_ide_annotate` orphan. Introduced by #14436 / #15398. Build
  and Test CI gate SKIP pattern allowed this to land latent.
- `test_dashboard_mission` 3 failures with
  `Yojson.Util.Type_error("Expected string, got null")` at "heartbeat
  task allowed tools present" assertion. Unrelated to this PR's fixture
  rename — same error on main with the old `team-session-local64-smoke`
  name.

## Workaround rejection self-check (CLAUDE.md §"머지 거부 체크리스트")

1. ❌ Telemetry-as-fix — no counter added.
2. ❌ String/substring classifier reinforced — *removes* a typed variant
   member and its string parser arm.
3. ❌ N-of-M patch — all dead-name sites in this PR's scope are closed
   in one merge.
4. ❌ Catch-all `| _ -> ...` added — removals leverage existing
   exhaustive matches; closed-sum (`system_actor`) caller delta is 0.
5. ❌ Cap/cooldown/dedup/repair — none.
6. ❌ Test backdoor — none.
7. ❌ Same typo fixed in N sites — N/A.

## RFC reference

No matching RFC (per `pr-rfc-check.sh`). `RFC-WAIVED: dead-name purge,
no behavior change in production code paths; live infrastructure that
*uses* the legacy names (autoresearch_storage filesystem layout,
dashboard `command_surface`, swarm tool absence guards) explicitly
deferred and listed in §"Tier B" of this PR body.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)