### PR TITLE
refactor(ide): centralise .masc-ide store path via Ide_paths SSOT (RFC-0084 §1.7)

### DIFF
--- a/lib/ide/dune
+++ b/lib/ide/dune
@@ -10,6 +10,7 @@
   ide_annotation_types
   ide_annotations
   ide_meta_sync
+  ide_paths
   ide_region_tracker)
  (libraries
   unix

--- a/lib/ide/ide_annotations.ml
+++ b/lib/ide/ide_annotations.ml
@@ -5,7 +5,7 @@
 
 open Ide_annotation_types
 
-let store_path ~base_dir = Filename.concat base_dir ".masc-ide"
+let store_path ~base_dir = Ide_paths.store_path ~base_dir
 
 let annotations_file ~base_dir =
   Filename.concat (store_path ~base_dir) "annotations.jsonl"

--- a/lib/ide/ide_meta_sync.ml
+++ b/lib/ide/ide_meta_sync.ml
@@ -74,7 +74,7 @@ let flush_regions (config : config) (state : sync_state) : sync_state =
   match state.pending_regions with
   | [] -> state
   | pending ->
-    let store_dir = Filename.concat config.base_path ".masc-ide" in
+    let store_dir = Ide_paths.store_path ~base_dir:config.base_path in
     let store = Dated_jsonl.create ~base_dir:store_dir () in
     List.iter
       (fun (region : code_region) -> Dated_jsonl.append store (region_to_json region))

--- a/lib/ide/ide_paths.ml
+++ b/lib/ide/ide_paths.ml
@@ -1,0 +1,3 @@
+let store_subdir = ".masc-ide"
+
+let store_path ~base_dir = Filename.concat base_dir store_subdir

--- a/lib/ide/ide_paths.mli
+++ b/lib/ide/ide_paths.mli
@@ -1,0 +1,14 @@
+(** IDE store path SSOT.
+
+    Centralises the [.masc-ide/] subdirectory name and store path
+    construction used by the IDE annotation, region tracker, meta sync,
+    and HTTP query modules.
+
+    Replaces the previously scattered [Filename.concat _ ".masc-ide"]
+    literal flagged in RFC-0084 §1.7 (Scattered hardcoded default). *)
+
+val store_subdir : string
+(** The literal subdirectory name [".masc-ide"]. *)
+
+val store_path : base_dir:string -> string
+(** [store_path ~base_dir] returns [base_dir/.masc-ide]. *)

--- a/lib/ide/ide_region_tracker.ml
+++ b/lib/ide/ide_region_tracker.ml
@@ -153,7 +153,7 @@ let ingest_tool_call ~base_dir ~keeper_id ~turn json =
                 | Some (`String patch_text) -> extract_regions_from_diff ~keeper_id ~file_path:fp ~turn ~diff_text:patch_text
                 | _ -> [])
         in
-        let store_dir = Filename.concat base_dir ".masc-ide" in
+        let store_dir = Ide_paths.store_path ~base_dir in
         if not (Sys.file_exists store_dir && Sys.is_directory store_dir) then
           Unix.mkdir store_dir 0o755;
         let store = Dated_jsonl.create ~base_dir:store_dir () in

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -263,7 +263,7 @@ let add_routes router =
            | Some p when p <> "" -> p
            | _ -> ""
          in
-         let store_dir = Filename.concat base ".masc-ide" in
+         let store_dir = Ide_paths.store_path ~base_dir:base in
          let path = Filename.concat store_dir "regions.jsonl" in
          (* Streaming filter — file_path filter usually drops most lines,
             and regions.jsonl grows append-only. fold_jsonl_lines avoids


### PR DESCRIPTION
## 목적

RFC-0084 §1.7 *Workaround Rejection Signature 매핑*에서 \`.masc-ide\` 를 안티패턴 **#1 Scattered hardcoded default** (4 sites) 으로 명시했습니다. 이 PR 은 그 4 site 를 SSOT 한 곳으로 통합합니다.

CLAUDE.md §AI 코드 생성 안티패턴 #1 "설정값 추가 전 \`rg "해당값" lib/\` 로 기존 상수 검색. 2곳+ 등장하면 SSOT 상수 추출 필수" 의 직접 적용 사례입니다.

## 변경

신규 모듈:
- \`lib/ide/ide_paths.ml\` / \`.mli\` — \`store_subdir = ".masc-ide"\` + \`store_path ~base_dir\`

4 caller 교체 (정확히 RFC-0084 §1.7 가 지목한 site):
- \`lib/ide/ide_annotations.ml:8\` — thin delegate, 시그니처 유지 (\`val store_path\` external caller 0건이지만 mli export 보존)
- \`lib/ide/ide_region_tracker.ml:156\`
- \`lib/ide/ide_meta_sync.ml:77\`
- \`lib/server/server_ide_http.ml:266\` — cross-library leak 였던 hardcoded literal 을 \`masc_mcp.ide\` 의존성을 통해 정상 흡수

\`lib/ide/dune\` modules 리스트에 \`ide_paths\` 추가.

## 로컬 검증

- \`dune build --root . lib/ide/\` — PASS
- \`dune build --root . lib/\` — PASS (server_ide_http 포함)
- \`dune exec --root . test/test_ide_annotations.exe\` — 3 tests PASS
- 잔존 \`.masc-ide\` literal grep — \`Ide_paths\` 모듈 자체와 docstring 1건 외 0건 (SSOT 달성)
- \`Ide_paths\` 사용처 grep — 정확히 4 site (annotations + region_tracker + meta_sync + server_ide_http)

## Out of scope

- \`ide_annotations.mli\` 의 \`val store_path\` export 자체 제거 — external caller 0건이라 dead API 후보이지만, 시그니처 보존 = caller delta 0 우선
- \`ensure_store\` / mkdir-if-not-exists 패턴 dedup — 3 caller 에서 유사 흐름이지만 본 PR 범위 밖 (literal SSOT 만 처리)
- RFC-0084 §1.7 의 다른 안티패턴 (\`/tmp/.masc_agent[_mcp]_<sid>\` 7 sites, \`/bin/zsh\` 5 sites) — 별도 PR

## 동작 변화

없음. 같은 경로 같은 시그니처. \`Filename.concat base_dir ".masc-ide"\` → \`Ide_paths.store_path ~base_dir\` 으로 호출 형태만 바뀜.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>