### PR TITLE
fix(deps): bump OAS pin to 0.193.15 to unblock Ollama Cloud auth header

### DIFF
--- a/masc_mcp.opam.locked
+++ b/masc_mcp.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc-mcp"
 doc: "https://github.com/jeong-sik/masc-mcp"
 bug-reports: "https://github.com/jeong-sik/masc-mcp/issues"
 depends: [
-  "agent_sdk" {= "0.193.4"}
+  "agent_sdk" {= "0.193.15"}
   "alcotest" {with-test & = "1.9.1"}
   "ambient-context-eio" {= "0.2"}
   "bigstringaf" {= "0.10.0"}
@@ -86,8 +86,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc-mcp.git"
 pin-depends: [
   [
-    "agent_sdk.0.193.4"
-    "git+https://github.com/jeong-sik/oas.git#7ed9c05260dce7b813bfaf524a2799573eb6479d"
+    "agent_sdk.0.193.15"
+    "git+https://github.com/jeong-sik/oas.git#ce90f5d2575d54ec339bdfd2744c019a8849414f"
   ]
   [
     "bisect_ppx.2.8.3"


### PR DESCRIPTION
## Summary

Bump the OAS pin in `masc_mcp.opam.locked` from `7ed9c05` (pre-PR-#1561) to
`ce90f5d` (oas 0.193.15, origin/main HEAD). This restores Ollama Cloud
auth-header propagation that PR #1561 added but was missing from the active
pin, and incidentally pulls in the missed-review-sweep fixes (#1598/#1599/
#1600/#1603/#1604) and the release-please opam-sync automation (#1605).

## Why

Live keeper fleet reports **30/30 cascade_exhausted** in the latest run, with
breakdown `28 no_providers_available, 1 require_tool_use, 1 max_execution_time`.
Board post `p-c972e8ba` ("✅ RESOLVED — Ollama Cloud 5 모델 mediated 200 OK")
diagnosed and verified the root cause on an isolated `:8939` server with pin
`2a90eec` (a slightly older fix-binary). The active `:8935` server is still on
the pre-fix pin (`7ed9c05`), which predates PR #1561 (`Add Ollama Cloud direct
auth`, merged 2026-05-13T23:32:15Z) and therefore omits the `Authorization
Bearer` header in `provider_config.headers` + the `headers_with_auth` helper in
`cascade_declarative_adapter`. Ollama Cloud treats the auth-fail as a parse
error (`Value looks like object, but can find closing }`), tripping
`cascade_exhausted: no_providers_available` for every keeper turn.

Same diagnosis is visible in `keepers/taskmaster.json` `continuity_summary`:

```
Done: Read episodic memory dump — confirms 30/30 cascade_exhausted
      (28 no_providers_available, 1 require_tool_use, 1 max_execution_time),
      2 successes.
Constraints: cascade_exhausted 100%; scope-locked; board_post broken
```

Picking the *latest* origin/main (`ce90f5d`) instead of the isolated-verified
`2a90eec` is intentional — it includes the auth header fix and adds the
in-session follow-ups (release-pipeline + perf + caller fix) without
duplicating any of the bot's verification work.

## Diff

```
masc_mcp.opam.locked | 6 +++---
1 file changed, 3 insertions(+), 3 deletions(-)
```

- `agent_sdk` version `0.193.4` → `0.193.15`
- pin-depends commit `7ed9c05260dce7b813bfaf524a2799573eb6479d` → `ce90f5d2575d54ec339bdfd2744c019a8849414f`
- pin-depends version label `agent_sdk.0.193.4` → `agent_sdk.0.193.15`

## Verification path

Local:
```
opam install -y --working-dir agent_sdk
./scripts/dune-local.sh build bin/main_eio.exe
```

(both must succeed; results recorded in this PR's CI on push.)

Post-merge:
```
# Restart the active :8935 server with the rebuilt binary so the
# new agent_sdk is actually loaded. Operator action — not done by this PR.
```

## Linked board / memory

- `p-c972e8ba7427b757838235e0cd2745d7` — bot's isolated verification of the
  Ollama Cloud auth-header fix
- MEMORY: `reference_masc_mcp_dune_local_lock_contention.md` (global build lock
  serializes worktrees during the rebuild)
- MEMORY: `project_keeper_active_goal_ids_empty_no_auto_repair.md` (separate
  but related — scope-lock recovery; handled in the same operator session via
  `masc_keeper_up` patches)

## Out of scope (tracked separately)

- `goal-keeper-tool-upload-readiness-20260515` scope-lock — already fixed in
  the same operator session by adding the goal to `taskmaster.active_goal_ids`
  via `masc_keeper_up`. No code change needed in this PR.
- `board_post` Yojson error — separate bug surfaced in the same diagnostic
  run; not addressed here.
