### PR TITLE
fix(ci): repair fd-pressure gate followups

### DIFF
--- a/docs/ADAPTIVE-HEARTBEAT-PRODUCTION-RUNBOOK.md
+++ b/docs/ADAPTIVE-HEARTBEAT-PRODUCTION-RUNBOOK.md
@@ -4,7 +4,7 @@ last_verified: 2026-04-17
 code_refs:
   - lib/keeper/keeper_state_machine.ml
   - lib/keeper/keeper_config.ml
-  - lib/keeper/heartbeat_smart.ml
+  - lib/keeper/keeper_heartbeat_smart.ml
 ---
 
 # Adaptive Heartbeat Production Runbook

--- a/docs/design/adaptive-heartbeat-grpc-and-phi-rollout-rfc.md
+++ b/docs/design/adaptive-heartbeat-grpc-and-phi-rollout-rfc.md
@@ -2,7 +2,7 @@
 status: reference
 last_verified: 2026-04-17
 code_refs:
-  - lib/keeper/heartbeat_smart.ml
+  - lib/keeper/keeper_heartbeat_smart.ml
   - lib/keeper/keeper_state_machine.ml
   - lib/keeper/keeper_config.ml
 ---

--- a/docs/design/adaptive-heartbeat-phi-enforcement-rfc.md
+++ b/docs/design/adaptive-heartbeat-phi-enforcement-rfc.md
@@ -4,7 +4,7 @@ last_verified: 2026-04-17
 code_refs:
   - lib/keeper/keeper_state_machine.ml
   - lib/keeper/keeper_config.ml
-  - lib/keeper/heartbeat_smart.ml
+  - lib/keeper/keeper_heartbeat_smart.ml
 ---
 
 # Adaptive Heartbeat Phi Enforcement RFC

--- a/scripts/stringly-boundary-ratchet.sh
+++ b/scripts/stringly-boundary-ratchet.sh
@@ -35,7 +35,7 @@ count_field_string_signatures() {
   local field="$1"
   ( set +o pipefail
     cd "$REPO_ROOT"
-    rg -c -e "[?]?${field}[[:space:]]*:[[:space:]]*string" \
+    rg -c -e "(^|[^[:alnum:]_?])\\??${field}[[:space:]]*:[[:space:]]*string" \
       --glob "*.ml" --glob "*.mli" lib test 2>/dev/null \
       | awk -F: '{sum+=$NF} END {print sum+0}'
   )


### PR DESCRIPTION
## Summary
- tighten stringly boundary ratchet matching so `runtime_decision : string` is not counted as a raw `decision:string` field
- update adaptive-heartbeat doc code_refs to the renamed `keeper_heartbeat_smart.ml` path

## Context
Follow-up to #15528. The FD-pressure runtime fix merged, but the manual full CI run exposed these existing gate blockers on the merged head.

## Validation
- `scripts/stringly-boundary-ratchet.sh`
- `bash scripts/check-doc-truth.sh`
- `git diff --check`
