### PR TITLE
fix(tool_task): surface active goal phases on claim_next_no_eligible

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -579,6 +579,44 @@ let handle_claim ?agent_tool_names ~tool_name ~start_time ctx args =
    | Error e -> Log.Task.warn "task claim failed for %s: %s" task_id (Masc_domain.masc_error_to_string e));
   result_to_response ~tool_name ~start_time result
 
+(* Look up the current Goal_store phase for each goal id in the agent's
+   active_goal_ids. Returns a list of "<goal_id>=<phase>" strings, e.g.
+   ["goal-1777967605002-004b=executing"; "goal-other=completed"].
+
+   This is consumed only by [format_no_eligible] below, to give the LLM
+   the *current* goal phase instead of letting it infer "completed goal"
+   from the bare excluded_count. See PR body for the velvet-hammer
+   misdiagnosis that motivated this surface. *)
+let active_goal_phases_for_agent ctx =
+  match Keeper_types.read_meta_resolved ctx.config ctx.agent_name with
+  | Ok (Some (_, meta)) ->
+      List.map
+        (fun goal_id ->
+           match Goal_store.get_goal ctx.config ~goal_id with
+           | Some goal ->
+               Printf.sprintf "%s=%s" goal_id (Goal_phase.to_string goal.phase)
+           | None -> Printf.sprintf "%s=missing" goal_id)
+        meta.active_goal_ids
+  | Ok None | Error _ -> []
+
+let format_no_eligible ctx excluded_count =
+  match active_goal_phases_for_agent ctx with
+  | [] ->
+      Printf.sprintf
+        "No eligible tasks available (blocked/excluded: %d). This agent has no \
+         active_goal_ids — every open task is out of scope. Operator should \
+         set active_goal_ids via masc_keeper_up."
+        excluded_count
+  | phases ->
+      Printf.sprintf
+        "No eligible tasks available (blocked/excluded: %d). active goal \
+         phases: [%s]. NOTE: excluded ≠ completed. If every phase above is \
+         'executing', the cause is goal-scope mismatch — open tasks are \
+         scoped to a goal not in this agent's active_goal_ids — not goal \
+         completion."
+        excluded_count
+        (String.concat ", " phases)
+
 let handle_claim_next ?agent_tool_names ~tool_name ~start_time ctx _args =
   if not (try Coord.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Stdlib.Not_found -> false) then
     Tool_result.error ~tool_name ~start_time (Printf.sprintf "Agent '%s' is not a member of this room" ctx.agent_name)
@@ -599,7 +637,7 @@ let handle_claim_next ?agent_tool_names ~tool_name ~start_time ctx _args =
           ~agent_name:ctx.agent_name ~task_id
     | Coord.Claim_next_no_unclaimed -> "No unclaimed tasks available"
     | Coord.Claim_next_no_eligible { excluded_count; _ } ->
-        Printf.sprintf "No eligible tasks available (blocked/excluded: %d)" excluded_count
+        format_no_eligible ctx excluded_count
     | Coord.Claim_next_error e -> Printf.sprintf "Error: %s" e
   in
   Tool_result.ok ~tool_name ~start_time message


### PR DESCRIPTION
## Summary

When `masc_claim_next` returns `Claim_next_no_eligible`, surface the **current
phase** of each goal in the agent's `active_goal_ids` instead of just an
opaque `excluded` count. This stops LLM-driven keepers from mis-inferring
"goal completed" when the real cause is goal-scope mismatch.

## Why — the velvet-hammer misdiagnosis

`~/me/.masc/keepers/velvet-hammer.json` `continuity_summary`:

```
Goal: goal-1777967605002-004b (completed, scope-locked)
Decisions: All diagnostics complete; curation current; no new task creation
           (no executing goals)
Constraints: cascade_exhausted; claimable=0; scope-locked
```

But `~/me/.masc/goals.json` for the same goal id shows `phase=executing` —
i.e. the goal was *not* completed. velvet-hammer guessed "completed" from
the bare excluded count it received via `claim_next`:

```
No eligible tasks available (blocked/excluded: 7)
```

The 7 excluded tasks are all scoped to `goal-keeper-tool-upload-readiness-20260515`
— a goal *no* keeper had in `active_goal_ids` (fleet-wide deadlock). The
message gave the LLM no way to distinguish:

  (a) my goal is done → wait for new goal
  (b) my goal is active but the open tasks belong to a different goal →
      operator action: extend my active_goal_ids

velvet-hammer landed on (a) and parked the PM lane.

## Fix

`lib/tool_task.ml`: extract `format_no_eligible` and `active_goal_phases_for_agent`.
On `Claim_next_no_eligible`, look up each `active_goal_id` in `Goal_store`
and append a `[goal-X=executing, goal-Y=completed, ...]` list to the
message. Tail of the message states explicitly:

```
NOTE: excluded ≠ completed. If every phase above is 'executing', the cause
is goal-scope mismatch — open tasks are scoped to a goal not in this
agent's active_goal_ids — not goal completion.
```

If `active_goal_ids` is empty (separate failure mode, already known —
`project_keeper_active_goal_ids_empty_no_auto_repair`), the message says so
and points at `masc_keeper_up` as the recovery path.

## Diff shape

```
lib/tool_task.ml | ~38 +++++++++++++++++++++++++++++-- (one helper + one
                                                       case rewrite)
```

No type changes, no dune changes (`Keeper_types`, `Goal_store`,
`Goal_phase` all live in the same wrapped `masc_mcp` library and
`Goal_store` is already imported in this file).

## Verification

- Static review: 1 file, 38 lines added, no type changes, no `.mli` touched.
  `Keeper_types.read_meta_resolved` and `Goal_store.get_goal` are existing
  module surfaces; `Goal_store` is already imported in this file
  (`tool_task.ml:473`).
- Behavioral verification will land in the field — a keeper that hits
  `claim_next` with no scoped task will now see the goal phases instead
  of an opaque count. The taskmaster scope-lock that this session
  patched manually via `masc_keeper_up` would have been self-diagnosable
  by velvet-hammer with this fix in place.

## ⚠️ CI status warning — main is currently un-buildable

Local `dune build ./lib` against `origin/main` HEAD `d957079b2e` (the same
commit this branch is rebased on) **fails identically with our 1-file change
stashed out**: widespread `Unbound module Tool_result` and `Unbound module
Tool_args` errors across ~40 `.mli`/`.ml` files in `lib/`, `lib/keeper/`,
`lib/dashboard/`, `lib/voice/`, `lib/operator/`, `lib/cascade/`, etc.

This is unrelated to this PR. It looks like an in-flight wrapped-lib
boundary change (RFC-0086 Phase 2.B keeper sub-library promotion is the
most likely candidate — `Tool_result`/`Tool_args` would be the two
modules a sub-library extraction would temporarily strand). Until the
main build is restored, this PR's CI will fail with the same baseline
errors; no fail is attributable to the diagnostic-surface change here.

Recommendation: hold merge until main is green; the fix is small enough
to rebase cleanly. If main recovery includes additional changes near
`tool_task.ml`, this PR can be re-applied with the same diff.

## Out of scope

- **R1** (Goal-keeper registration automation) — separate RFC. This PR
  fixes only the *diagnostic* surface; it does not auto-assign keepers
  to new goals.
- `coord_task_schedule.ml` `Claim_next_no_eligible` payload split into
  scope/filter/tool buckets — would be cleaner but ripples through
  `types_core.ml`, `coord_task.ml`, and the dashboard JSON readers.
  Worth a follow-up; the present PR is intentionally minimal so it
  ships.
