### PR TITLE
fix(build): link extracted tool types library

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -331,6 +331,10 @@
    ;; extracted to lib/tool_catalog_surfaces/. deps: Agent_sdk + stdlib only.
    ;; Unblocks one of 6 cycle modules identified in plan §8.14 iter-2.
    masc_mcp.tool_catalog_surfaces
+   ;; RFC-0086 PR-2H — Tool_args + Tool_result extracted to lib/tool_types/.
+   ;; Keep the parent library linked to the leaf so existing bare
+   ;; Tool_args/Tool_result references remain visible while cycles are cut.
+   masc_mcp.tool_types
    ;; RFC-0086 Phase 2.B prereq — Config_dir_resolver (lib/ root, 563+156 LoC)
    ;; extracted to lib/config_dir_resolver/. deps: masc_core (Common) +
    ;; masc_mcp.config (Env_config_core) + masc_mcp.host_config + masc_log + yojson.


### PR DESCRIPTION
## Summary

- Link the new `masc_mcp.tool_types` leaf library from the parent `masc_mcp` library.
- Preserve existing bare `Tool_args` / `Tool_result` references after the RFC-0086 PR-2H extraction.

## Root Cause

`lib/tool_types/` defines `Tool_args` and `Tool_result` as a wrapped-false leaf library, but `lib/dune` did not list `masc_mcp.tool_types` in the parent library dependencies. A fresh `bin/main_eio.exe` build from current `main` therefore failed with `Unbound module Tool_args` / `Unbound module Tool_result`.

## Verification

- `scripts/dune-local.sh build bin/main_eio.exe`
- `git diff --check`
- `bash scripts/ocaml-structure-ratchet.sh`