### PR TITLE
fix(dune): link masc_mcp.tool_types from parent lib (unbreaks main, follow-up #15531)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -217,6 +217,7 @@
  (libraries
    mcp_protocol
    mcp_protocol.eio
+   masc_mcp.tool_types
    yojson
    otoml
    base64


### PR DESCRIPTION
## Summary

Add `masc_mcp.tool_types` to `lib/dune`'s `(libraries ...)` block. One line.

## Why — main is currently un-buildable

`origin/main` HEAD `d957079b2e` fails `dune build ./lib` with widespread
`Unbound module Tool_result` / `Unbound module Tool_args` errors across
~40 `.mli`/`.ml` files in `lib/`, `lib/keeper/`, `lib/dashboard/`,
`lib/voice/`, `lib/operator/`, `lib/cascade/`, etc.

Root cause: PR #15531 (`chore(tool): RFC-0086 PR-2H — extract Tool_args +
Tool_result to lib/tool_types/`) extracted both modules to a new sub-library
at `lib/tool_types/dune`:

```dune
(library
 (name masc_mcp_tool_types)
 (public_name masc_mcp.tool_types)
 (wrapped false)
 (libraries yojson masc_log masc_core eio time_compat))
```

The `(wrapped false)` is deliberate — the dune comment explains that all
1156 external bare references (`Tool_args.x`, `Tool_result.x`) keep
working because the sub-library exposes those names directly. But the
parent `lib/dune` was never updated to *link* the new sub-library, so
the bare names resolve to nothing and every caller fails to compile.

## Fix

`lib/dune`:

```diff
 (libraries
   mcp_protocol
   mcp_protocol.eio
+  masc_mcp.tool_types
   yojson
   ...
```

## Verification

Local: `scripts/dune-local.sh build ./lib` against this branch — must
exit 0 with no `Unbound module Tool_result` / `Unbound module Tool_args`
errors. (Recorded by CI on push.)

Same `dune build ./lib` on `origin/main` fails repeatably with the
unbound-module wave above.

## Diff shape

```
lib/dune | 1 +
1 file changed, 1 insertion(+)
```

## Follow-up to #15531

This is a one-line completion of the PR-2H extraction. The extraction PR
correctly created the sub-library + `(wrapped false)` design that
preserves all 1156 caller references; it only missed the `(libraries)`
edit needed for the parent to *find* the sub-library at link time.

This is the same N-of-M caller-update pattern that bit us earlier this
session in OAS #1599 (`Pipeline_stage_prepare.turn_ready_tool_names`
signature narrowed in #1596 with two external callers in `pipeline.ml`
missed). Mechanically identical: extraction/narrowing done correctly,
caller-side wiring left for next PR but never landed.

## Unblocks

- PR #15537 (`fix(tool_task): surface active goal phases on
  claim_next_no_eligible`) — currently CI-fails on the same baseline
  breakage; should turn green once this lands.
- Any other PR currently parked on main breakage.
