### PR TITLE
fix(dune): remove duplicate tool types dependency

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -217,7 +217,6 @@
  (libraries
    mcp_protocol
    mcp_protocol.eio
-   masc_mcp.tool_types
    yojson
    otoml
    base64


### PR DESCRIPTION
## Summary

- Remove the duplicate `masc_mcp.tool_types` entry from the parent `masc_mcp` library dependencies.
- Keep the documented `masc_mcp.tool_types` dependency near the Agent SDK/tooling section.

## Root Cause

`main` currently lists `masc_mcp.tool_types` twice in `lib/dune` after the tool-types link landed from overlapping fixes. Fresh builds fail before compilation with:

```text
Error: library "masc_mcp.tool_types" is present twice
```

## Verification

- `scripts/dune-local.sh build bin/main_eio.exe`
- `git diff --check`
- `bash scripts/ocaml-structure-ratchet.sh`