### PR TITLE
fix(dashboard/ide): null-safe cluster handling in IdePresenceStrip

### DIFF
--- a/dashboard/src/components/ide/ide-presence-strip.test.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import {
+  agentsToPresence,
   parseWorktreeSSE,
   presenceContextAnchor,
   presenceContextSummary,
   prLabel,
   workspaceLabelForAgent,
+  type ApiAgent,
+  type ApiStatus,
   type WorktreeEntry,
 } from './ide-presence-strip'
 
@@ -91,6 +94,58 @@ describe('parseWorktreeSSE', () => {
     // Verify that the parsed entries carry enough information to derive workspace labels
     const label = workspaceLabelForAgent('nick0cave', entries)
     expect(label).toBe('wt-run-47')
+  })
+})
+
+describe('agentsToPresence', () => {
+  const sampleAgent: ApiAgent = {
+    name: 'nick0cave',
+    status: 'idle',
+    current_task: null,
+    model: null,
+  }
+
+  it('returns disconnected snapshot when cluster is undefined', () => {
+    const status: ApiStatus = { cluster: undefined }
+    const snap = agentsToPresence([sampleAgent], status, [])
+    expect(snap.kind).toBe('disconnected')
+  })
+
+  // Regression: prior code only checked `status.cluster === undefined`, so a
+  // JSON payload with `cluster: null` (the wire form of OCaml's [None]) hit
+  // `null.trim()` and crashed the entire CODE / IDE-shell surface render.
+  it('returns disconnected snapshot when cluster is null', () => {
+    const status: ApiStatus = { cluster: null }
+    const snap = agentsToPresence([sampleAgent], status, [])
+    expect(snap.kind).toBe('disconnected')
+    if (snap.kind === 'disconnected') {
+      expect(snap.reason).toBe('runtime_unknown')
+    }
+  })
+
+  it('returns disconnected snapshot when cluster is whitespace only', () => {
+    const status: ApiStatus = { cluster: '   ' }
+    const snap = agentsToPresence([sampleAgent], status, [])
+    expect(snap.kind).toBe('disconnected')
+  })
+
+  it('returns disconnected snapshot when cluster is set but no agents present', () => {
+    const status: ApiStatus = { cluster: 'masc-local' }
+    const snap = agentsToPresence([], status, [])
+    expect(snap.kind).toBe('disconnected')
+    if (snap.kind === 'disconnected') {
+      expect(snap.reason).toBe('no_agents')
+    }
+  })
+
+  it('returns live snapshot with trimmed cluster id when both cluster and agents present', () => {
+    const status: ApiStatus = { cluster: '  masc-local  ' }
+    const snap = agentsToPresence([sampleAgent], status, [])
+    expect(snap.kind).toBe('live')
+    if (snap.kind === 'live') {
+      expect(snap.runtime_id).toBe('masc-local')
+      expect(snap.entries).toHaveLength(1)
+    }
   })
 })
 

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -13,16 +13,16 @@ import { cursorOverlaySignal, type KeeperCursor } from './keeper-cursor-overlay'
 import { focusIdeContextAnchor, type IdeContextFocus } from './ide-state'
 import { routeLinksForContext } from './ide-context-lens'
 
-interface ApiAgent {
+export interface ApiAgent {
   readonly name: string
   readonly status: string
   readonly current_task: string | null
   readonly model: string | null
 }
 
-interface ApiStatus {
-  readonly cluster?: string
-  readonly project?: string
+export interface ApiStatus {
+  readonly cluster?: string | null
+  readonly project?: string | null
   readonly paused?: boolean
 }
 
@@ -78,12 +78,17 @@ export function workspaceLabelForAgent(
   return agentName
 }
 
-function agentsToPresence(
+/** @internal — exported only so {@link ./ide-presence-strip.test.ts}
+    can pin the disconnected/live branch behaviour against runtime
+    payloads where [cluster] may arrive as [null] (the JSON wire form
+    of OCaml's [None]) rather than [undefined]. */
+export function agentsToPresence(
   agents: ReadonlyArray<ApiAgent>,
   status: ApiStatus,
   worktrees: ReadonlyArray<WorktreeEntry>,
 ): KeeperPresenceSnapshot {
-  if (status.cluster === undefined || status.cluster.trim() === '') {
+  const cluster = status.cluster?.trim() ?? ''
+  if (cluster === '') {
     return disconnectedSnapshot('runtime_unknown')
   }
   if (agents.length === 0) {
@@ -92,7 +97,7 @@ function agentsToPresence(
   const now = Date.now()
   return {
     kind: 'live',
-    runtime_id: status.cluster,
+    runtime_id: cluster,
     entries: agents.map((agent, idx) => ({
       keeper_id: agent.name,
       workspace_label: workspaceLabelForAgent(agent.name, worktrees),


### PR DESCRIPTION
## Repro

URL `http://127.0.0.1:8935/dashboard#code?section=ide-shell` shows
**렌더링 오류** with `Cannot read properties of null (reading 'trim')`
when the runtime WS is `disconnected` or the backend status payload
serves `cluster: null` (JSON wire form of OCaml `None`). The throw
escapes the render tree and the surface-level ErrorBoundary fully
blocks the CODE/IDE shell.

## Root cause (one line)

`dashboard/src/components/ide/ide-presence-strip.ts:86` only
short-circuits on `=== undefined`, but the wire payload from
`/api/v1/status` carries `cluster: null`. JS treats them as distinct
(`null === undefined === false`), so the second branch of the `||`
evaluates `null.trim()` → `TypeError`.

The TS interface declared `cluster?: string` — *undefined-able* but
not *nullable* — so the gap was invisible at compile time.

## Fix

1. `ApiStatus.cluster` and `ApiStatus.project` declared `string | null`
   to match the wire shape. TS now refuses any future call site that
   uses cluster without narrowing.
2. `agentsToPresence` rewritten to compute a single normalised cluster
   value via `status.cluster?.trim() ?? ''` and dispatch on that. The
   downstream `runtime_id` is assigned from the narrowed value so the
   `KeeperPresenceSnapshot.live` invariant (`runtime_id: string`)
   stays honoured.

## Regression guard

`agentsToPresence` exported with `@internal` JSDoc tag.
`ide-presence-strip.test.ts` gains an `agentsToPresence` suite (16 →
21 tests). New cases pin:

- `cluster: undefined` → `disconnected('runtime_unknown')` (existing).
- `cluster: null` → `disconnected('runtime_unknown')` — **the
  regression that broke the surface, now guarded**.
- `cluster: '   '` (whitespace) → `disconnected('runtime_unknown')`.
- `cluster: 'masc-local'` + no agents → `disconnected('no_agents')`.
- `cluster: '  masc-local  '` + 1 agent → `live` with trimmed
  `runtime_id`.

**Red phase verified.** Reverting only the `agentsToPresence` body to
the prior logic produces:
- `tsc --noEmit` → 2 errors at line 90 (`'status.cluster' is possibly 'null'`) + line 99 (`Type 'string | null' is not assignable to type 'string'`).
- `vitest` → null-cluster case fails with `TypeError: Cannot read properties of null (reading 'trim')`, trimmed-cluster case fails with whitespace preserved in `runtime_id`.

Both layers reinforce each other: compile-time guard + runtime guard.

## Build / test

```
npm run typecheck                                  # PASS
npx vitest run src/components/ide/ide-presence-strip.test.ts
                                                   # 21/21 PASS
```

## Out-of-scope follow-ups

- `dashboard/src/components/ide/run-activity-store.ts:182` —
  `optionalNonEmptyString` uses the same `value === undefined` pattern.
  Different class (validation strictness, not crash) — `null` payloads
  are falsely classified as invalid rather than throwing. Defer to a
  separate validation-correctness PR.
- Wire-format alignment between OCaml `None` ↔ TS `string | undefined`:
  this PR fixes the one site that crashed; an RFC-level sweep across
  all `?: string` interfaces in `dashboard/src/` against the actual
  JSON serialisers would catch the next instance before runtime.

## Workaround rejection self-check

1. Telemetry-as-fix — no counter.
2. String classifier reinforced — nullable typed at boundary, not a
   prefix rule.
3. N-of-M patch — both cluster sites in `agentsToPresence` (read +
   assign) closed together in the same merge.
4. Catch-all `| _ -> ...` — none added.
5. Cap/cooldown/dedup — none.
6. Test backdoor — `export` of `agentsToPresence` documented `@internal`,
   used only by the pinned regression suite in the same module's test
   file.
7. Same typo N-sites — only one function (`agentsToPresence`),
   line 86 + 95, both fixed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)