### PR TITLE
chore(dashboard): retire dead "swarm" command-surface token

### DIFF
--- a/dashboard/CSS-ARCHITECTURE.md
+++ b/dashboard/CSS-ARCHITECTURE.md
@@ -41,7 +41,6 @@ The MASC Dashboard CSS has been refactored from a single 2199-line `global.css` 
 - `agent-monitor.css` - Agent monitoring views
 - `board.css` - Board/posts interface
 - `chat.css` - Chat interface
-- `command-swarm.css` - Command swarm UI
 - `dashboard.css` - Dashboard layouts
 - `governance.css` - Governance interfaces
 - `governance-agent.css` - Agent governance

--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -59,8 +59,6 @@ export function targetTypeLabel(value?: string | null): string {
       return 'Namespace'
     case 'keeper':
       return 'Keeper'
-    case 'swarm_run':
-      return 'Swarm Run'
     default:
       return value?.trim() || 'Target'
   }

--- a/lib/dashboard/dashboard_execution_sessions.ml
+++ b/lib/dashboard/dashboard_execution_sessions.ml
@@ -265,7 +265,7 @@ let build_session_contexts seeds operation_contexts : session_context list =
            handoff_json
              ~surface:"command"
              ~command_surface:
-               (if Option.is_some linked_operation_id then "operations" else "swarm")
+               (if Option.is_some linked_operation_id then "operations" else "agents")
              ?operation_id:linked_operation_id
              ~label:"세션 원인 보기"
              ~target_type:"operation"


### PR DESCRIPTION
Continuation of #15532 (team-session/swarm purge).  Cleans up the
remaining dead `"swarm"` string tokens from the retired `masc_swarm_*`
tool surface that survived in:

1. **Backend wire emission** (`lib/dashboard/dashboard_execution_sessions.ml:268`) —
   `command_surface` fallback to `"swarm"` when no `linked_operation_id`
   exists.  Frontend has *zero* `surface === 'swarm'` handlers; the
   value was a dead string token never read.  Switched to `"agents"`,
   which mirrors the live emission from `dashboard_execution.ml:375`
   and routes to the actually-rendered agents surface.

2. **Frontend dead enum case** (`dashboard/src/components/ops/helpers.ts:62-63`) —
   `case 'swarm_run':` in `targetTypeLabel`.  Backend emits zero
   `swarm_run` `target_type` values anywhere in `lib/`.

3. **Stale doc reference** (`dashboard/CSS-ARCHITECTURE.md:44`) —
   `command-swarm.css - Command swarm UI`.  The file is not in tree
   (`find dashboard -name command-swarm.css` → 0 hits).

## Intentionally NOT touched

| Site | Reason |
|------|--------|
| `dashboard/src/router.test.ts:31` (`navigate('command', { section: 'warroom', surface: 'swarm' })`) | **Negative regression guard** that asserts the router redirects retired `surface: 'swarm'` params to canonical `section: 'operations'`.  Correct shape of dead-concept handling. |
| `dashboard/design-system/ui_kits/cockpit/CrewPlane.jsx` | Standalone POC; `dashboard/src/` imports it zero times.  Not in the production Vite bundle. |
| `lib/repo_synthesis_benchmark.*` + `test/fixtures/repo_synthesis_benchmark/swarm_answers.json` | Benchmark schema rename, cross-file (lib doc + fixture filename + output keys).  Deferred to scoped PR. |
| `.masc/team-sessions/<id>/autoresearch.json` + `swarm.json` artifact filename | Live infrastructure used by `autoresearch_storage`; renaming needs back-compat read path for deployed installs. |
| `handle_keeper_repair` dead handler | MCP tool surface change, needs explicit user approval per CLAUDE.md `<governance>`. |

## Build / test

```
dune build --root . lib                                                 # PASS
cd dashboard && npm run typecheck                                       # PASS
cd dashboard && npx vitest run src/router.test.ts src/components/ops/helpers.test.ts
                                                                        # 31/31 PASS
```

The router-test pass confirms the negative regression guard still
rejects `surface: 'swarm'` and redirects it to `operations`.

## Workaround rejection self-check

1. Telemetry-as-fix — none.
2. String classifier reinforced — removes dead `case` arms; does not add.
3. N-of-M patch — all in-scope dashboard `"swarm"` token sites closed in one merge.
4. Catch-all `_` added — none.
5. Cap/cooldown/dedup — none.
6. Test backdoor — none.
7. Same typo N-sites — single change per file, no codemod required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)