### PR TITLE
fix(tool_board): yojson Type_error boundary on masc_board_post + _comment

### DIFF
--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -1702,17 +1702,55 @@ let handle_sub_board_delete ~tool_name ~start_time args =
 (** Tool dispatcher.
     Mutation tools (post, comment, vote, delete, cleanup) invalidate
     the board_list TTL cache so the next read sees fresh data. *)
+(* Boundary that converts a stray [Yojson.Safe.Util.Type_error] from a
+   board-tool handler into a structured [Tool_result.error]. Without this
+   the exception bubbles out to the MCP transport as
+   "Yojson__Safe.Util.Type_error(\"Expected string or null, got array\", _)",
+   which is opaque to keeper LLMs — see analyst's task-213 board post
+   (p-1efba4b2311478dff37fff9fdbfea483) and the sangsu broadcast on
+   2026-05-15T10:51:20Z. With this boundary the LLM gets a typed
+   message that names the offending value and the likely cause, so the
+   next call can correct the offending field without retry-loop noise.
+
+   This is a diagnostic boundary, not a workaround: when the raise
+   originates from a path that should accept a non-string value (e.g.
+   sources entry shape), the offending value in the error gives whoever
+   triages the next regression a direct pointer to the failing field. *)
+let with_yojson_boundary ~tool_name ~start_time handler =
+  try handler () with
+  | Yojson.Safe.Util.Type_error (msg, bad_value) ->
+    let value_repr =
+      let s = Yojson.Safe.to_string bad_value in
+      if String.length s > 120 then String.sub s 0 120 ^ "…" else s
+    in
+    Tool_result.error
+      ~tool_name
+      ~start_time
+      (Printf.sprintf
+         "JSON arg type error: %s. Offending value: %s. Likely cause: an \
+          optional field (sources / judgment / meta / hearth / title / body) \
+          was sent as a non-string JSON type. Send string-typed scalars only."
+         msg
+         value_repr)
+;;
+
 let handle_tool name args =
   let start_time = Time_compat.now () in
   match name with
   | "masc_board_post" ->
-    let result = handle_post_create ~tool_name:name ~start_time args in
+    let result =
+      with_yojson_boundary ~tool_name:name ~start_time (fun () ->
+        handle_post_create ~tool_name:name ~start_time args)
+    in
     invalidate_board_list_cache ();
     result
   | "masc_board_list" -> handle_post_list ~tool_name:name ~start_time args
   | "masc_board_get" -> handle_post_get ~tool_name:name ~start_time args
   | "masc_board_comment" ->
-    let result = handle_comment_add ~tool_name:name ~start_time args in
+    let result =
+      with_yojson_boundary ~tool_name:name ~start_time (fun () ->
+        handle_comment_add ~tool_name:name ~start_time args)
+    in
     invalidate_board_list_cache ();
     result
   | "masc_board_vote" ->


### PR DESCRIPTION
## Summary

Wrap `handle_post_create` and `handle_comment_add` in `tool_board.handle_tool`
with a `Yojson.Safe.Util.Type_error` boundary. When the underlying handler
raises a Yojson type mismatch (e.g. an LLM caller sends an array where a
string is expected), convert it into a structured `Tool_result.error` that
names the offending JSON value and lists the likely-offending fields.

## Why

analyst's task-213 board post (`p-1efba4b2311478dff37fff9fdbfea483`)
documented this pattern precisely:

> **Board post serialization fix**: `keeper_board_post` fails with
> `Yojson__Safe.Util.Type_error("Expected string or null, got array")` —
> this prevented me from reporting findings via the board earlier.

sangsu confirmed via room broadcast (2026-05-15T10:51:20Z):

> 상수입니다. keeper_board_post 방금 또 터졌어요. Yojson type error —
> "Expected string or null, got array."

The exception currently bubbles out of `tool_board.ml`'s dispatch into the
MCP transport, where the keeper LLM receives the raw OCaml exception
string. LLMs cannot trace `Yojson__Safe.Util.Type_error("Expected string or
null, got array", _)` back to a specific tool arg, so they retry the same
payload — see velvet-hammer's trace
(`trajectories/velvet-hammer/trace-1777729113839-fc304.jsonl`):

> "could be the `sources` parameter or `judgment` parameter. Let me try
> posting without any optional parameters except content."

Multiple keepers in the live fleet have lost turns to this. The taskmaster
`continuity_summary` explicitly lists "board_post broken" as a constraint.

## What changed

- New helper `with_yojson_boundary` in `lib/tool_board.ml` (no `.mli`
  exposure — internal to the dispatcher).
- `masc_board_post` and `masc_board_comment` dispatch entries wrap their
  handler call in the boundary. Other board tools left as-is for this PR
  (their args are simpler — votes/reactions take ids only).

The error message names:
- the raised reason (Yojson's own diagnostic)
- the offending JSON value (truncated to 120 chars to bound noise)
- the most-likely-offending fields (`sources / judgment / meta / hearth /
  title / body`) drawn from the analyst's diagnosis

## Diff shape

```
lib/tool_board.ml | ~40 ++++++++++++++++++++++++++++++++++++++++
1 file changed, ~40 insertions(+)
```

## What this does NOT fix

The *original* raise location is still unknown — `tool_board.ml`'s own
parsing path uses `Safe_ops.json_string_opt` + `Yojson.Safe.Util.member`
(both pattern-match-safe and never raise on a `` `List ``). The raise
likely originates from downstream code in `board_core_payload` /
schema validation / SSE broadcast (a quick grep of `tool_board.ml` shows
no direct `to_string` / `to_string_option` calls on user args). This PR
gives the next regression a self-describing error instead of an opaque
stack trace — the offending value in the message will pinpoint which
field actually trips the underlying code.

Follow-up: trace the actual raise site via the structured error
(operator can grep `board_post.*JSON arg type error` once the new message
lands) and replace the boundary with a parse-don't-validate fix at the
source.

## Verification

- Local: `scripts/dune-local.sh build ./lib` → exit 0 expected. (Recorded
  on PR push.)

## Operator action

masc-mcp `:8935` server must be restarted to pick up the new binary —
same restart that was already pending for #15534 + #15537 + #15540.
A single restart applies all four changes.
