### PR TITLE
fix(ci): run heavy CI on draft PRs to catch fast-track regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,21 @@ jobs:
             exit 1
           fi
 
+          # Heavy CI runs whenever the PR is live (OPEN), regardless of draft
+          # status. Earlier we skipped draft PRs to save CI minutes, but the
+          # masc-mcp fast-track pattern (open Draft → mark ready → admin-merge
+          # within seconds) means the build/lint/test surfaces almost never
+          # got a chance to run. Two visible failures from that gap this week:
+          # - masc-mcp #15531 (Tool_args / Tool_result sub-lib extract) merged
+          #   main in a non-building state; recovered by #15540.
+          # - oas #1596 (turn_ready_tool_names signature narrow) — same shape,
+          #   recovered by oas #1599.
+          # Running heavy CI on draft PRs costs minutes but catches both
+          # classes of regression *before* the admin-merge decision instead
+          # of after, when the only remaining lever is fix-forward.
+          # Closed/merged PRs still skip — there is nothing to verify there.
           run_heavy=true
           if [ "$live_state" != "OPEN" ]; then
-            run_heavy=false
-          elif [ "$live_is_draft" = "true" ]; then
             run_heavy=false
           fi
 


### PR DESCRIPTION
## Summary

In `.github/workflows/ci.yml`'s `pr-live-gate`, drop the `live_is_draft == "true"` branch that forces `run_heavy=false`. Heavy CI (changes / build / lint / test) now runs on draft PRs too, gated only on the PR being live (`OPEN`).

## Why

`pr-live-gate` previously skipped heavy CI for two conditions: non-OPEN PRs (closed/merged — sensible) **and** Draft PRs (intended to save CI minutes on WIP).

The Draft-skip branch turned out to be the silent collaborator behind the two N-of-M regressions this week:

- **masc-mcp #15531** (`chore(tool): RFC-0086 PR-2H — extract Tool_args + Tool_result to lib/tool_types/`) merged main in a non-building state. PR `statusCheckRollup` showed:

  ```
  Build and Test: SKIPPED
  Build and Test: SKIPPED
  CI Gate: SUCCESS
  ```

  The extract was correct *internally* but the parent `lib/dune`'s `(libraries …)` block never gained `masc_mcp.tool_types`. With `(wrapped false)` keeping all 1156 caller references bare, the missing link silently turned every `Tool_result.x` / `Tool_args.x` reference into "Unbound module" once `dune build` actually ran. The PR rode the fast-track path (`Draft → ready → admin-merge`) and the build never ran on the PR head. Recovery: #15540.

- **oas #1596** (`fix(agent): narrow runtime mcp per turn`) narrowed `Pipeline_stage_prepare.turn_ready_tool_names` from `agent → turn_preparation → _` to `turn_preparation → _`. The internal caller in `pipeline_stage_prepare.ml:301` was updated; the two external callers in `pipeline.ml` (`:203`, `:1188`) were not. Same fast-track shape, same silent main breakage. Recovery: #1599.

Both regressions are exactly what a `dune build` would catch — and exactly what was being skipped.

We were paying for the gate (extra wait on stale-draft PRs) without the benefit (the hot-path fast-track flow was the one being silenced).

## What changed

`pr-live-gate.outputs.run_heavy`:

| live_state | live_is_draft | Before | After |
|------------|---------------|--------|-------|
| OPEN       | false         | true   | true  |
| OPEN       | **true**      | **false** | **true** |
| CLOSED / MERGED | any | false | false |

Comment in the workflow records the two precedents so the next reviewer doesn't reintroduce the skip without seeing the history.

## Cost / Benefit

- **Cost**: heavy CI minutes on draft PRs that get pushed but never merged. In practice this repo's draft PRs are short-lived (open → merged within minutes for fast-track), so the marginal cost is low.
- **Benefit**: build/lint/test now run on every fast-track PR *before* the admin-merge decision instead of after, when the only remaining lever is fix-forward. The two examples above each cost a fix-forward PR + a few hours of fleet downtime (masc-mcp keepers cascade_exhausted while main was broken).

## Diff shape

```
.github/workflows/ci.yml | 15 +++++++++++++--
1 file changed, 13 insertions(+), 2 deletions(-)
```

## Verification

- YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → ok.
- Behavioral: next draft PR will trigger `changes` → `build` instead of skipping. CI runtime increases by the build job's duration but does not change merge mechanics — admin-merge can still bypass a failing build if explicitly requested.

## Out of scope

- **Post-merge main-fail alerting**: the last 5 main push CI runs on this repo are all `failure`. Push-trigger CI catches the regression but nothing fires on the failure — the next PR just runs against a broken `main`. Separate workflow (Slack / board notify / auto-revert PR) is the natural follow-up. Not in this PR.
- **Required-check enforcement**: branch protection could mark `build` as required, blocking merges (admin override notwithstanding). Policy decision — not in this PR.
