### PR TITLE
[codex] Harden board visibility and runtime manifest audits

### DIFF
--- a/dashboard/src/components/board/board-state.test.ts
+++ b/dashboard/src/components/board/board-state.test.ts
@@ -27,6 +27,7 @@ import {
   authorAvatar,
   kindLabel,
   visibilityLabel,
+  postVisibilityAuditLabel,
   filterHint,
   splitVisiblePosts,
   refreshBoardFlairs,
@@ -191,6 +192,26 @@ describe('visibilityLabel', () => {
 
   it('passes through unknown', () => {
     expect(visibilityLabel('secret')).toBe('secret')
+  })
+})
+
+describe('postVisibilityAuditLabel', () => {
+  it('summarizes visible, scoped, hidden-score, and updated state', () => {
+    expect(postVisibilityAuditLabel(makePost({
+      visibility: 'internal',
+      comment_count: 13,
+      votes: null,
+      vote_blind: true,
+      updated_at: '2026-04-17T01:00:00Z',
+    }))).toBe('표시 중 · 내부 · 댓글 13개 · 점수 투표 후 공개 · 최근 갱신됨')
+  })
+
+  it('uses public scope and numeric score for ordinary posts', () => {
+    expect(postVisibilityAuditLabel(makePost({
+      visibility: 'public',
+      comment_count: 2,
+      votes: 7,
+    }))).toBe('표시 중 · 공개 · 댓글 2개 · 점수 7 · 원본 작성 시각 기준')
   })
 })
 

--- a/dashboard/src/components/board/board-state.ts
+++ b/dashboard/src/components/board/board-state.ts
@@ -342,6 +342,26 @@ export function visibilityLabel(vis: string): string | null {
   }
 }
 
+function visibilityAuditLabel(vis: string | null | undefined): string {
+  if (!vis || vis === 'public') return '공개'
+  return visibilityLabel(vis) ?? vis
+}
+
+export function postVisibilityAuditDetails(post: BoardPost): string {
+  const scoreLabel = post.vote_blind ? '점수 투표 후 공개' : `점수 ${post.votes ?? 0}`
+  const updatedLabel = isUpdated(post) ? '최근 갱신됨' : '원본 작성 시각 기준'
+  return [
+    visibilityAuditLabel(post.visibility),
+    `댓글 ${post.comment_count ?? 0}개`,
+    scoreLabel,
+    updatedLabel,
+  ].join(' · ')
+}
+
+export function postVisibilityAuditLabel(post: BoardPost): string {
+  return `표시 중 · ${postVisibilityAuditDetails(post)}`
+}
+
 export function visibilityBadgeColor(vis: string): string {
   if (vis === 'internal') return 'bg-[var(--color-bg-hover)] text-[var(--purple)] border-[var(--color-border-strong)]'
   return 'bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)] border-[var(--color-border-default)]'

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -314,6 +314,33 @@ describe('BoardSurface Component', () => {
     expect(screen.getByLabelText('점수 투표 후 공개')).toHaveTextContent('투표 후 공개')
   })
 
+  it('renders board visibility audit details on post cards', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'post-audit',
+        title: 'Audit visible',
+        body: 'content',
+        author: 'ani1999',
+        votes: null,
+        vote_balance: null,
+        vote_blind: true,
+        comment_count: 13,
+        created_at: '2026-04-17T00:00:00Z',
+        updated_at: '2026-04-17T01:00:00Z',
+      }),
+    ]
+
+    render(h(BoardSurface, null))
+
+    const audit = screen.getByLabelText(/게시글 표시 감사:/)
+    expect(audit).toHaveTextContent('표시 중')
+    expect(audit).toHaveTextContent('내부')
+    expect(audit).toHaveTextContent('댓글 13개')
+    expect(audit).toHaveTextContent('점수 투표 후 공개')
+    expect(audit).toHaveTextContent('최근 갱신됨')
+    expect(audit).toHaveTextContent('정렬 최신순')
+  })
+
   it('renders contributor quality badges on post cards', () => {
     boardPosts.value = [
       makePost({

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -92,6 +92,8 @@ import {
   authorAvatar,
   visibilityLabel,
   visibilityBadgeColor,
+  postVisibilityAuditLabel,
+  postVisibilityAuditDetails,
   votePost,
   deleteBoardPost,
   refreshBoardHearths,
@@ -655,6 +657,9 @@ function PostCard({ post }: { post: BoardPost }) {
   const downvoteActive = post.current_vote === 'down'
   const voteScoreLabel = post.vote_blind ? '투표 후 공개' : String(post.votes ?? 0)
   const voteScoreAria = post.vote_blind ? '점수 투표 후 공개' : `점수 ${post.votes ?? 0}`
+  const auditLabel = postVisibilityAuditLabel(post)
+  const auditDetails = postVisibilityAuditDetails(post)
+  const sortLabel = SORT_MODES.find(mode => mode.id === boardSortMode.value)?.label ?? boardSortMode.value
   const reactionPreview = post.reactions?.some(summary => summary.count > 0 || summary.reacted || summary.has_reacted)
 
   const handleVote = async (dir: 'up' | 'down', event: Event) => {
@@ -799,6 +804,15 @@ function PostCard({ post }: { post: BoardPost }) {
           >
             ${isDeleting ? '삭제 중...' : '삭제'}
           <//>
+        </div>
+        <div
+          class="mt-2 flex items-center gap-1.5 flex-wrap text-2xs text-[var(--color-fg-muted)]"
+          aria-label=${`게시글 표시 감사: ${auditLabel}; 현재 정렬 ${sortLabel}`}
+          title=${`${auditLabel} · 현재 정렬 ${sortLabel}`}
+        >
+          <span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] border border-[var(--ok-30)] bg-[var(--ok-soft)] text-[var(--color-status-ok)] font-medium">표시 중</span>
+          <span>${auditDetails}</span>
+          <span class="opacity-60">· 정렬 ${sortLabel}</span>
         </div>
         <div
           class=${reactionPreview ? 'mt-2' : 'mt-2 opacity-75 transition-opacity group-hover:opacity-100'}

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -78,6 +78,12 @@ vi.mock('./board-state', () => ({
   kindLabel: (kind: string) => (kind === 'direct' ? '직접' : kind),
   visibilityLabel: () => '',
   visibilityBadgeColor: () => '',
+  postVisibilityAuditLabel: (post: any) => {
+    const visibility = post.visibility === 'internal' ? '내부' : '공개'
+    const score = post.vote_blind ? '점수 투표 후 공개' : `점수 ${post.votes ?? 0}`
+    const updated = post.updated_at !== post.created_at ? '최근 갱신됨' : '원본 작성 시각 기준'
+    return `표시 중 · ${visibility} · 댓글 ${post.comment_count ?? 0}개 · ${score} · ${updated}`
+  },
   boardPostKind: () => 'direct',
   votePost: vi.fn(),
   voteComment: vi.fn().mockResolvedValue(undefined),
@@ -603,6 +609,31 @@ describe('PostDetail', () => {
     render(h(PostDetail, { post }))
 
     expect(screen.getByLabelText('게시글 점수 투표 후 공개')).toHaveTextContent('투표 후 공개')
+  })
+
+  it('renders board visibility audit details on post detail', () => {
+    const post = {
+      id: 'post-1',
+      author: 'sleepers',
+      title: 'Post',
+      body: 'Body',
+      content: 'Body',
+      created_at: '2026-04-02T00:00:00Z',
+      updated_at: '2026-04-02T01:00:00Z',
+      votes: null,
+      vote_balance: null,
+      vote_blind: true,
+      comment_count: 5,
+      visibility: 'internal',
+      post_kind: 'direct',
+      comments: [],
+    } as any
+
+    render(h(PostDetail, { post }))
+
+    const audit = screen.getByLabelText(/게시글 표시 감사:/)
+    expect(audit).toHaveTextContent('표시 감사: 표시 중 · 내부 · 댓글 5개 · 점수 투표 후 공개 · 최근 갱신됨')
+    expect(audit).toHaveTextContent('목록 정렬/필터에 따라 위치가 바뀔 수 있습니다.')
   })
 
   it('renders and clears the board comment route focus receipt', () => {

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -37,6 +37,7 @@ import {
   kindLabel,
   visibilityLabel,
   visibilityBadgeColor,
+  postVisibilityAuditLabel,
   boardPostKind,
   votePost,
   voteComment,
@@ -547,6 +548,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
   const downvoteActive = post.current_vote === 'down'
   const postVoteLabel = post.vote_blind ? '투표 후 공개' : `${post.votes ?? 0} votes`
   const postVoteAria = post.vote_blind ? '게시글 점수 투표 후 공개' : `게시글 점수 ${post.votes ?? 0}`
+  const auditLabel = postVisibilityAuditLabel(post)
   const focusedCommentId = cleanCommentRouteParam((route.value.params as Record<string, string | undefined>).comment)
 
   return html`
@@ -578,6 +580,14 @@ export function PostDetail({ post }: { post: BoardPost }) {
               aria-label=${postVoteAria}
               title=${postVoteLabel}
             >${postVoteLabel}</span>
+          </div>
+
+          <div
+            class="text-2xs text-[var(--color-fg-muted)] leading-relaxed"
+            aria-label=${`게시글 표시 감사: ${auditLabel}`}
+            title=${auditLabel}
+          >
+            표시 감사: ${auditLabel}. 목록 정렬/필터에 따라 위치가 바뀔 수 있습니다.
           </div>
 
           <!-- Badges -->

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -373,7 +373,9 @@ let execution_receipt_path_for_today config ~keeper_name =
 
 let base_dir config ~keeper_name =
   Filename.concat
-    (Filename.concat (Keeper_types_support.keeper_dir_ config) keeper_name)
+    (Filename.concat
+       (Filename.concat (Coord.masc_root_dir config) "keepers")
+       keeper_name)
     "runtime-manifests"
 
 let path_for_trace config ~keeper_name ~trace_id =

--- a/scripts/ci/check-silent-failure-patterns.sh
+++ b/scripts/ci/check-silent-failure-patterns.sh
@@ -17,13 +17,17 @@ cd "$(git rev-parse --show-toplevel)"
 
 exit_code=0
 
+print_first_lines() {
+  awk -v limit="${1:?line limit required}" 'NR <= limit'
+}
+
 # 1. try/ignore on unit-returning calls (exceptions swallowed silently)
 #    Exclude comments and test files where deliberate mocking is expected.
 echo "=== Scan: try/ignore anti-pattern ==="
 matches=$(rg -n 'try\s+ignore\s*\(' lib/ --type ml -g '!test/' || true)
 if [ -n "$matches" ]; then
   echo "FAIL: try/ignore wrapping found (exceptions silently swallowed):"
-  echo "$matches" | head -20
+  printf '%s\n' "$matches" | print_first_lines 20
   exit_code=1
 else
   echo "PASS"
@@ -37,7 +41,7 @@ matches=$(rg -B1 -n '\|\s*_\s*->\s*\(\)' lib/ --type ml -g '!test/' || true)
 filtered=$(echo "$matches" | rg -v 'Log\.|traceln|log_' || true)
 if [ -n "$filtered" ]; then
   echo "WARN: wildcard -> () branches without visible logging:"
-  echo "$filtered" | head -20
+  printf '%s\n' "$filtered" | print_first_lines 20
   # Treat as warning for now; escalate to FAIL after codebase cleanup.
 fi
 
@@ -60,7 +64,7 @@ echo "=== Scan: naked Option.get ==="
 matches=$(rg -n 'Option\.get\b' lib/ --type ml -g '!test/' || true)
 if [ -n "$matches" ]; then
   echo "WARN: Option.get found (prefer Option.value or pattern match):"
-  echo "$matches" | head -20
+  printf '%s\n' "$matches" | print_first_lines 20
 fi
 
 if [ "$exit_code" -eq 0 ]; then

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -568,6 +568,32 @@ let append_manifest_or_fail config manifest =
   | Ok () -> ()
   | Error msg -> Alcotest.fail ("manifest append failed: " ^ msg)
 
+let test_append_best_effort_stays_best_effort_when_manifest_dir_unavailable () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.save_file (Filename.concat base_dir ".masc") "not-a-directory";
+      let config = Masc_mcp.Coord.default_config base_dir in
+      let manifest =
+        M.make ~ts:"2026-05-16T00:00:00Z"
+          ~keeper_name:"runtime-manifest-fd-pressure"
+          ~trace_id:"trace-runtime-manifest-fd-pressure"
+          ~event:M.Turn_started ()
+      in
+      let path =
+        M.path_for_trace config ~keeper_name:manifest.M.keeper_name
+          ~trace_id:manifest.M.trace_id
+      in
+      Alcotest.(check bool)
+        "path construction does not create keeper dirs"
+        true
+        (contains_substring path "runtime-manifest-fd-pressure");
+      (match M.append config manifest with
+       | Ok () -> Alcotest.fail "append unexpectedly succeeded"
+       | Error _ -> ());
+      M.append_best_effort ~site:"fd-pressure-test" config manifest)
+
 let make_tool name : Agent_sdk.Tool.t =
   Agent_sdk.Tool.create ~name ~description:("test tool " ^ name)
     ~parameters:[] (fun _input -> Ok { content = "ok" })
@@ -2410,6 +2436,10 @@ let () =
         [
           Alcotest.test_case "append preserves order" `Quick
             test_append_to_path_preserves_order;
+          Alcotest.test_case
+            "append best-effort survives unavailable manifest dir"
+            `Quick
+            test_append_best_effort_stays_best_effort_when_manifest_dir_unavailable;
           Alcotest.test_case "pre-dispatch emits manifest rows" `Quick
             test_pre_dispatch_terminal_observation_emits_manifest_rows;
           Alcotest.test_case


### PR DESCRIPTION
## Summary

- Surface board post visibility audit details in the dashboard list and detail views.
- Show scope, comment count, vote-blind score state, update state, and current sort so visible posts are less likely to look deleted.
- Keep runtime manifest path construction side-effect free so `append_best_effort` can actually swallow unavailable manifest directory failures during FD pressure.
- Make the SIL meta guard warning truncation pipe-safe under `set -o pipefail`.

## Root Cause

The board data already carried the relevant signals, but the UI did not present enough of them near the post. In parallel, `Keeper_runtime_manifest.path_for_trace` reached `Keeper_types_support.keeper_dir_`, which can create directories before `append_to_path` enters its failure-handling block. Under FD pressure this made a best-effort manifest write capable of terminating a keeper cycle.

The first CI pass also exposed that the SIL meta guard could fail while printing non-blocking warnings because `echo ... | head -20` can trip `pipefail` with `SIGPIPE`.

## Validation

- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/board/board-state.test.ts src/components/board/board-surface.test.ts src/components/board/post-detail.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/components/board/board-state.ts src/components/board/board-surface.ts src/components/board/post-detail.ts src/components/board/board-state.test.ts src/components/board/board-surface.test.ts src/components/board/post-detail.test.ts`
- `scripts/dune-local.sh build ./test/test_keeper_runtime_manifest.exe`
- `./_build/default/test/test_keeper_runtime_manifest.exe test append --color=never --quick-tests`
- `bash scripts/ci/check-silent-failure-patterns.sh`
