### PR TITLE
fix(keeper): let structured PR tool bypass bash path guard

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -686,7 +686,8 @@ type docker_shell_result =
    only to the run path, not to docker exec against a warm container. *)
 let docker_run_min_timeout_sec = 5.0
 
-let run_docker_shell_command_with_status
+let run_docker_shell_command_with_status_internal
+      ~validate_command_paths
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(cwd : string)
@@ -734,7 +735,12 @@ let run_docker_shell_command_with_status
       match multi_repo_blocker with
       | Some msg -> sandbox_error msg
       | None ->
-      match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd with
+      let path_validation =
+        if validate_command_paths
+        then Worker_dev_tools.validate_command_paths ~workdir:cwd cmd
+        else Ok ()
+      in
+      match path_validation with
       | Error err -> sandbox_error err
       | Ok () ->
       let _cleanup =
@@ -939,6 +945,14 @@ let run_docker_shell_command_with_status
                         Ok { status; output; image; network_label }
                       with
                       | Failure err -> sandbox_error err)))))
+;;
+
+let run_docker_shell_command_with_status =
+  run_docker_shell_command_with_status_internal ~validate_command_paths:true
+;;
+
+let run_trusted_docker_shell_command_with_status =
+  run_docker_shell_command_with_status_internal ~validate_command_paths:false
 ;;
 
 let run_docker_with_git_bash

--- a/lib/keeper/keeper_shell_docker.mli
+++ b/lib/keeper/keeper_shell_docker.mli
@@ -142,6 +142,20 @@ val run_docker_shell_command_with_status :
   network_mode:Keeper_types.network_mode ->
   (docker_shell_result, string) result
 
+(** Same as {!run_docker_shell_command_with_status}, but skips freeform
+    command path syntax validation. Use only for commands generated from
+    structured argv by a dedicated MASC tool; keeper-authored Bash must use
+    the default validated entrypoint. *)
+val run_trusted_docker_shell_command_with_status :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  cwd:string ->
+  timeout_sec:float ->
+  cmd:string ->
+  git_creds_enabled:bool ->
+  network_mode:Keeper_types.network_mode ->
+  (docker_shell_result, string) result
+
 (** Run [cmd] inside the Docker sandbox with git credentials
     forwarded (Network_inherit). Returns the JSON envelope to
     surface to the LLM, including [gh_exit_class] when applicable. *)

--- a/lib/keeper/keeper_tool_github_pr.ml
+++ b/lib/keeper/keeper_tool_github_pr.ml
@@ -253,7 +253,7 @@ let run_gh_argv ~(config : Coord.config) ~(meta : keeper_meta) ~env ~cwd
     { status; output; via = "brokered" }
   else if meta.sandbox_profile = Docker then
     match
-      Keeper_shell_shared.run_docker_shell_command_with_status
+      Keeper_shell_docker.run_trusted_docker_shell_command_with_status
         ~config ~meta ~cwd ~timeout_sec ~cmd:(quote_argv argv)
         ~git_creds_enabled:true ~network_mode:Network_inherit
     with


### PR DESCRIPTION
## Summary

- Add a trusted Docker shell entrypoint for structured argv-generated tools.
- Route keeper_pr_create through that entrypoint so its own safe shell quoting is not rejected as keeper-authored path syntax.
- Keep freeform keeper Bash on the existing path validation guard.

## Product impact

Unblocks Docker-profile keepers from creating draft PRs through the intended keeper_pr_create path after they already produced a valid structured PR request.

## Evidence

- `ocamlformat --check lib/keeper/keeper_shell_docker.ml lib/keeper/keeper_shell_docker.mli lib/keeper/keeper_tool_github_pr.ml`
- `env DUNE_CACHE=disabled MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build --cache=disabled test/test_keeper_shell_docker_route.exe test/test_keeper_github_pr.exe`
- `_build/default/test/test_keeper_github_pr.exe test docker_route 0`
- `_build/default/test/test_keeper_shell_docker_route.exe test docker_route_fires 4`
- `_build/default/test/test_keeper_shell_docker_route.exe test docker_route_fires 5`
- `_build/default/test/test_keeper_shell_docker_route.exe test docker_route_fires 9`
- `git diff --check origin/main..HEAD`

## Review evidence

Focused on the keeper PR path observed in live logs: structured keeper_pr_create built a safe argv, converted it with shell quoting for Docker, and then hit the generic freeform Bash path-syntax validator. This patch only bypasses that validator for dedicated structured tool commands.

## Linked issue

Follow-up to the keeper fan-out / active tool contract investigation.
