### PR TITLE
[codex] Let keeper observation tools satisfy tool-use contract

### DIFF
--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -425,13 +425,44 @@ let tool_name_can_satisfy_required_contract name =
     | None -> not (Tool_dispatch.is_read_only name))
 ;;
 
+let is_keeper_observation_tool_name name =
+  let name = canonical_tool_name name in
+  match Tool_name.of_string name with
+  | Some
+      (Keeper
+        ( Board_curation_read
+        | Board_get
+        | Board_list
+        | Board_search
+        | Board_stats
+        | Board_sub_board_get
+        | Board_sub_board_list
+        | Code_read
+        | Context_status
+        | Fs_read
+        | Library_read
+        | Library_search
+        | Memory_search
+        | Pr_list
+        | Pr_review_read
+        | Pr_status
+        | Tasks_audit
+        | Tasks_list
+        | Time_now
+        | Tool_search
+        | Tools_list )) -> Keeper_exec_tools.is_keeper_read_only_tool name
+  | _ -> false
+;;
+
 let required_tool_satisfaction (call : Agent_sdk.Completion_contract.tool_call)
   : (unit, string) result
   =
   let tool_name = canonical_tool_name call.name in
-  (* Completion tools intentionally satisfy the contract.  See
-     tool_name_can_satisfy_required_contract for the same exemption. *)
-  if is_completion_tool_name tool_name
+  (* Generic Require_tool_use is a tool-presence contract, not proof of
+     execution progress. Keeper-local read/status/discovery tools satisfy the
+     SDK contract so a valid observation turn does not explode into cascade
+     retries; classify_tool_progress still records them as Passive_status. *)
+  if is_completion_tool_name tool_name || is_keeper_observation_tool_name tool_name
   then Ok ()
   else (
     let mutates =

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -152,21 +152,23 @@ val is_claim_tool_name : string -> bool
 val is_claim_context_tool_name : string -> bool
 val is_completion_tool_name : string -> bool
 
-(** [true] iff the tool name represents a non-read-only effect
-    (Masc_coordination / Playground_write / Main_worktree_write). *)
+(** [true] iff the tool name represents productive execution progress for a
+    required-action gate. Completion tools are exempted even when read-only;
+    passive keeper observation tools remain [false] here so liveness metrics
+    and surface trimming keep treating them as passive. *)
 val tool_name_can_satisfy_required_contract : string -> bool
 
-(** Validate that an observed tool call actually mutates state —
-    used by the run contract to reject read-only calls under
-    [Require_tool_use]. *)
+(** Validate an observed generic [Require_tool_use] call. This accepts mutating
+    tools, completion tools, and keeper-local observation/discovery tools. The
+    latter still classify as [Passive_status]; accepting them here prevents a
+    valid read/status turn from turning into provider cascade churn. *)
 val required_tool_satisfaction
   :  Agent_sdk.Completion_contract.tool_call
   -> (unit, string) result
 
 (** Variant of [required_tool_satisfaction] for an explicit
-    [required_tools] contract. A read-only tool can satisfy the turn only when
-    the operator/task contract named that exact tool; generic required-tool
-    gates remain mutating-only. *)
+    [required_tools] contract. A non-keeper read-only tool can satisfy the turn
+    only when the operator/task contract named that exact tool. *)
 val required_tool_satisfaction_for_required_names
   :  required_tool_names:string list
   -> Agent_sdk.Completion_contract.tool_call

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -9119,17 +9119,47 @@ let satisfies_explicit_required_tool ~required_tool_names name input =
        (required_tool_call name input))
 ;;
 
-let test_required_tool_satisfaction_rejects_passive_tools () =
+let test_required_tool_satisfaction_handles_passive_tools () =
   check
     bool
-    "masc_status is passive"
+    "global masc_status remains passive"
     false
     (satisfies_required_tool "masc_status" (`Assoc []));
   check
     bool
-    "keeper_tasks_list is passive"
-    false
+    "keeper_tasks_list satisfies tool-presence contract"
+    true
     (satisfies_required_tool "keeper_tasks_list" (`Assoc []));
+  check
+    bool
+    "keeper_context_status satisfies tool-presence contract"
+    true
+    (satisfies_required_tool "keeper_context_status" (`Assoc []));
+  check
+    bool
+    "keeper_memory_search satisfies tool-presence contract"
+    true
+    (satisfies_required_tool "keeper_memory_search" (`Assoc []));
+  check
+    bool
+    "keeper_tool_search satisfies tool-presence contract"
+    true
+    (satisfies_required_tool "keeper_tool_search" (`Assoc []));
+  check
+    bool
+    "keeper_board_get satisfies tool-presence contract"
+    true
+    (satisfies_required_tool "keeper_board_get" (`Assoc []));
+  check
+    bool
+    "keeper_memory_search remains passive progress"
+    true
+    (KTD.is_passive_status_tool_name "keeper_memory_search");
+  check
+    bool
+    "keeper_memory_search is not execution progress"
+    false
+    (KTD.is_execution_progress_tool_name "keeper_memory_search");
   (* keeper_stay_silent is a Completion tool and intentionally satisfies
      the required-tool contract despite its Read_only effect_domain.
      See keeper_tool_disclosure.ml is_completion_tool_name exemption. *)
@@ -9138,7 +9168,16 @@ let test_required_tool_satisfaction_rejects_passive_tools () =
     "keeper_stay_silent satisfies as completion"
     true
     (satisfies_required_tool "keeper_stay_silent" (`Assoc []));
-  check bool "Read alias is passive" false (satisfies_required_tool "Read" (`Assoc []));
+  check
+    bool
+    "Read alias satisfies tool-presence contract"
+    true
+    (satisfies_required_tool "Read" (`Assoc []));
+  check
+    bool
+    "Read alias remains passive progress"
+    true
+    (KTD.is_passive_status_tool_name "Read");
   check
     bool
     "read-only gh shell is passive"
@@ -11748,9 +11787,9 @@ let () =
             `Quick
             test_stay_silent_requires_typed_no_work_proof_on_actionable_signal
         ; test_case
-            "required tool predicate rejects passive tools"
+            "required tool predicate handles passive tools"
             `Quick
-            test_required_tool_satisfaction_rejects_passive_tools
+            test_required_tool_satisfaction_handles_passive_tools
         ; test_case
             "required tool predicate accepts mutating tools"
             `Quick


### PR DESCRIPTION
## Summary

- Let keeper-local observation and discovery read tools satisfy the generic Require_tool_use tool-presence contract.
- Keep those tools classified as passive progress so liveness metrics, passive-loop detection, and required gate surface trimming still treat them as non-execution.
- Leave global read-only tools and read-only keeper shell commands rejected by the generic contract.

## Root Cause

Fleet logs showed keepers calling valid observation tools such as keeper_board_get, keeper_memory_search, keeper_tool_search, and keeper_context_status, then failing Require_tool_use because the contract equated generic tool use with mutating execution. That failure sent turns into cascade retries even though a valid keeper-surface tool call happened.

## Validation

- scripts/dune-local.sh build ./test/test_keeper_unified.exe
- ./_build/default/test/test_keeper_unified.exe test metrics_observation 49-60 --color=never --quick-tests
- ./_build/default/test/test_keeper_unified.exe test tool_classification 6-9 --color=never --quick-tests
- opam exec -- ocamlformat --check lib/keeper/keeper_tool_disclosure.ml lib/keeper/keeper_tool_disclosure.mli test/test_keeper_unified.ml
