### PR TITLE
fix(keeper): treat Grep as observation for tool-use contract

### DIFF
--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -405,7 +405,14 @@ let is_stay_silent_tool_name name =
   | _ -> false
 ;;
 
+let is_keeper_observation_alias name =
+  match Keeper_tool_alias.strip_mcp_masc_prefix name with
+  | "Grep" | "Read" -> true
+  | _ -> false
+;;
+
 let tool_name_can_satisfy_required_contract name =
+  let observation_alias = is_keeper_observation_alias name in
   let name = canonical_tool_name name in
   (* Completion tools (stay_silent, release, done, etc.) intentionally
      satisfy the contract even though their effect_domain is Read_only.
@@ -413,7 +420,9 @@ let tool_name_can_satisfy_required_contract name =
      call keeper_stay_silent alongside status reads trigger false
      contract violations — observed 2026-04-28 when codex-spark
      returned stay_silent + keeper_task_list on an actionable signal. *)
-  if is_completion_tool_name name
+  if observation_alias
+  then false
+  else if is_completion_tool_name name
   then true
   else (
     match Tool_catalog.effect_domain name with
@@ -459,10 +468,14 @@ let required_tool_satisfaction (call : Agent_sdk.Completion_contract.tool_call)
   =
   let tool_name = canonical_tool_name call.name in
   (* Generic Require_tool_use is a tool-presence contract, not proof of
-     execution progress. Keeper-local read/status/discovery tools satisfy the
-     SDK contract so a valid observation turn does not explode into cascade
-     retries; classify_tool_progress still records them as Passive_status. *)
-  if is_completion_tool_name tool_name || is_keeper_observation_tool_name tool_name
+     execution progress. Keeper-local read/status/discovery tools and their
+     LLM-native read/search aliases satisfy the SDK contract so a valid
+     observation turn does not explode into cascade retries;
+     classify_tool_progress still records them as Passive_status. *)
+  if
+    is_completion_tool_name tool_name
+    || is_keeper_observation_tool_name tool_name
+    || is_keeper_observation_alias call.name
   then Ok ()
   else (
     let mutates =
@@ -495,6 +508,9 @@ let required_tool_satisfaction_for_required_names
 ;;
 
 let classify_tool_progress name =
+  if is_keeper_observation_alias name
+  then Passive_status
+  else
   let name = canonical_tool_name name in
   if is_completion_tool_name name
   then Completion

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -159,9 +159,10 @@ val is_completion_tool_name : string -> bool
 val tool_name_can_satisfy_required_contract : string -> bool
 
 (** Validate an observed generic [Require_tool_use] call. This accepts mutating
-    tools, completion tools, and keeper-local observation/discovery tools. The
-    latter still classify as [Passive_status]; accepting them here prevents a
-    valid read/status turn from turning into provider cascade churn. *)
+    tools, completion tools, keeper-local observation/discovery tools, and
+    LLM-native read/search aliases that route to keeper observation. The latter
+    still classify as [Passive_status]; accepting them here prevents a valid
+    read/status turn from turning into provider cascade churn. *)
 val required_tool_satisfaction
   :  Agent_sdk.Completion_contract.tool_call
   -> (unit, string) result

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -9175,9 +9175,19 @@ let test_required_tool_satisfaction_handles_passive_tools () =
     (satisfies_required_tool "Read" (`Assoc []));
   check
     bool
+    "Grep alias satisfies tool-presence contract"
+    true
+    (satisfies_required_tool "Grep" (`Assoc []));
+  check
+    bool
     "Read alias remains passive progress"
     true
     (KTD.is_passive_status_tool_name "Read");
+  check
+    bool
+    "Grep alias remains passive progress"
+    true
+    (KTD.is_passive_status_tool_name "Grep");
   check
     bool
     "read-only gh shell is passive"


### PR DESCRIPTION
## Summary

Fixes the remaining `Grep` slice of #15542 after #15554 taught generic `Require_tool_use` to accept keeper-local observation tools.

`Grep` is an LLM-native read/search alias routed through `keeper_shell`. The generic SDK contract only needs a tool call to be present, so `Grep` should satisfy `Require_tool_use`; however it must still classify as passive progress so liveness/progress metrics do not treat a search as execution.

## Changes

- accept `Grep` / `Read` public observation aliases in generic `required_tool_satisfaction`
- keep those aliases out of `tool_name_can_satisfy_required_contract` so required-action surface trimming does not treat them as execution tools
- classify public observation aliases as `Passive_status`
- add regression coverage for `Grep` satisfaction + passive classification

## Verification

- `ocamlformat --check lib/keeper/keeper_tool_disclosure.ml lib/keeper/keeper_tool_disclosure.mli test/test_keeper_unified.ml`
- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 58-60 --compact --show-errors`
