### PR TITLE
Fix board signal required tool choice

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -388,6 +388,17 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
        turn tool-required and let MASC validate the canonical observed
        tool names after execution. *)
     Agent_sdk.Types.Any
+  else if has_turn_affordance Board_post_or_comment turn_affordances
+          && List.exists
+               progress_tool_available
+               [ "keeper_board_comment"; "keeper_board_post"; "masc_broadcast" ]
+  then Agent_sdk.Types.Any
+  else if has_turn_affordance Reply_in_room turn_affordances
+          && List.exists
+               progress_tool_available
+               [ "keeper_board_comment"; "keeper_board_post"; "masc_keeper_msg";
+                 "masc_broadcast" ]
+  then Agent_sdk.Types.Any
   else if has_turn_affordance Task_audit turn_affordances
           && progress_tool_available "keeper_tasks_audit"
   then Agent_sdk.Types.Tool "keeper_tasks_audit"

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -901,7 +901,7 @@ let prepare_agent_setup
     in
     let visible_affordance_tool_names =
       preferred_tool_names_for_turn_affordances turn_affordances
-      |> validate_allow_list ~turn
+      |> filter_visible_policy_surface
       |> Keeper_types.dedupe_keep_order
     in
     let merged =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -10755,6 +10755,42 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
        (Printf.sprintf
           "expected Any when board cleanup can satisfy curation lane, got %s"
           (Agent_sdk.Types.show_tool_choice other)));
+  (match
+     choose
+       ~turn_affordances:[ "board_post_or_comment" ]
+       ~allowed_tool_names:[ "keeper_board_comment"; "keeper_tasks_list" ]
+       ()
+   with
+   | Agent_sdk.Types.Any -> ()
+   | other ->
+     fail
+       (Printf.sprintf
+          "expected Any for idle board response turn with comment tool, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
+  (match
+     choose
+       ~turn_affordances:[ "reply_in_room" ]
+       ~allowed_tool_names:[ "masc_keeper_msg"; "keeper_tasks_list" ]
+       ()
+   with
+   | Agent_sdk.Types.Any -> ()
+   | other ->
+     fail
+       (Printf.sprintf
+          "expected Any for idle room reply turn with message tool, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
+  (match
+     choose
+       ~turn_affordances:[ "board_post_or_comment" ]
+       ~allowed_tool_names:[ "keeper_tasks_list" ]
+       ()
+   with
+   | Agent_sdk.Types.Auto -> ()
+   | other ->
+     fail
+       (Printf.sprintf
+          "expected Auto when board response has no actionable board tool, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
   (* #10008: when no specific tool is applicable for the current
      affordance, fall back to [Auto] so the model can respond with
      honest refusal text ("no eligible task to claim") instead of


### PR DESCRIPTION
## Summary

- force board-response and room-reply actionable turns to use a tool-required `Any` choice when a matching active tool is visible
- keep idle no-tool fallback for affordances without actionable tools
- silently filter internally generated affordance hints that are outside the keeper policy surface, avoiding noisy allowlist-pruned logs for fallback names

## Product impact

Keepers reacting to board or room activity should be less likely to end an actionable turn with no tool call, and logs should stop warning on internally generated fallback affordance names that are not part of the current keeper policy.

## Evidence

Live runtime showed `analyst` failing `require_tool_use` on `has_board_activity` while the tool-choice selection path could still fall back to `Auto` for idle board/reply turns. Live logs also showed repeated `AllowList pruned ... masc_transition, masc_add_task` warnings from internally generated affordance hints.

## Review evidence

This is a small tool-surface selection change with focused regression coverage in `test_preferred_tool_choice_for_required_turn_claims_first`.

## Linked issue

Follow-up from live keeper activity triage under `/Users/dancer/me/.masc`; no GitHub issue assigned.

## Verification

- `ocamlformat --check lib/keeper/keeper_agent_tool_surface.ml lib/keeper/keeper_run_tools.ml test/test_keeper_unified.ml`
- `git diff --check origin/main..HEAD`
- `env DUNE_CACHE=disabled MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build --cache=disabled test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe test tool_classification --show-errors`
