### PR TITLE
fix(metrics): attribute null-model successes to cascade

### DIFF
--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -328,6 +328,13 @@ let private_provider_hint_of_fields (fields : (string * Yojson.Safe.t) list) =
   | None -> read "provider"
 ;;
 
+let cascade_model_attribution_of_fields (fields : (string * Yojson.Safe.t) list) =
+  match json_string_field_opt "cascade_name" fields with
+  | Some cascade_name ->
+    Some (Keeper_cascade_profile.canonicalize cascade_name ^ " (cascade)")
+  | None -> None
+;;
+
 (* ── Parse-level failure variants ─────────────────────────────────────────────
    A typed reason every dropped record carries so silent-default substitutions
    (1970 timestamps, "unknown" model attributions, "success" outcome on missing
@@ -342,7 +349,7 @@ type parse_error =
   | Out_of_window                  (* ts_unix older than [since_unix] *)
   | No_telemetry_object            (* decisions.jsonl entry without telemetry { ... } *)
   | Missing_outcome                (* telemetry.outcome absent on success-branch row *)
-  | Missing_success_model          (* no selected_model / model_used on success turn *)
+  | Missing_success_model          (* no selected_model / model_used / cascade_name *)
   | Missing_error_model_attribution (* no candidate_models / cascade_name on error turn *)
   | Missing_cost_model             (* costs.jsonl row without "model" field *)
 
@@ -412,11 +419,8 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
              match List.assoc_opt "candidate_models" tfields with
              | Some (`List (`String m :: _)) -> Ok m
              | _ ->
-               (match List.assoc_opt "cascade_name" tfields with
-                | Some (`String s) ->
-                  (* Canonicalize so error attribution buckets match the
-                    SSOT profile names instead of drift/ghost values. *)
-                  Ok (Keeper_cascade_profile.canonicalize s ^ " (cascade)")
+               (match cascade_model_attribution_of_fields tfields with
+                | Some model -> Ok model
                 | _ -> Error Missing_error_model_attribution)
            in
            match model_result with
@@ -455,17 +459,21 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
              })
          else (
            (* Success turns: full telemetry parsing.
-              Model attribution is structural — refusing the row is the
-              only honest behaviour when neither selected_model nor
-              model_used is present (the older "unknown" default collapsed
-              every such row into one bucket and broke cost accounting). *)
+              Model attribution is structural: prefer explicit selected/model
+              fields, then fall back to the cascade route when the row proves
+              the route but OAS did not surface the concrete model. This keeps
+              null-model historical rows from being repeatedly dropped without
+              reintroducing the old "unknown" bucket. *)
            let model_result : (string, parse_error) result =
-             match List.assoc_opt "selected_model" tfields with
-             | Some (`String s) -> Ok s
+             match json_string_field_opt "selected_model" tfields with
+             | Some s -> Ok s
              | _ ->
-               (match List.assoc_opt "model_used" tfields with
-                | Some (`String s) -> Ok s
-                | _ -> Error Missing_success_model)
+               (match json_string_field_opt "model_used" tfields with
+                | Some s -> Ok s
+                | _ ->
+                  (match cascade_model_attribution_of_fields tfields with
+                   | Some model -> Ok model
+                   | None -> Error Missing_success_model))
            in
            match model_result with
            | Error _ as e -> e

--- a/scripts/check-variants.sh
+++ b/scripts/check-variants.sh
@@ -155,12 +155,12 @@ fi
 echo ""
 echo "=== Check 2: turn_phase (OCaml) vs KeeperCascadeLifecycle.tla domain ==="
 
-KR_ML="lib/keeper/keeper_registry.ml"
+KR_TYPES_ML="lib/keeper/keeper_registry_types.ml"
 KCL_TLA="specs/keeper-state-machine/KeeperCascadeLifecycle.tla"
 
-if [ -f "$KR_ML" ]; then
+if [ -f "$KR_TYPES_ML" ]; then
   # turn_phase constructors (strip "Turn_" prefix, lowercase for TLA+ comparison)
-  ocaml_turn_constructors=$(extract_ocaml_type "$KR_ML" "turn_phase")
+  ocaml_turn_constructors=$(extract_ocaml_type "$KR_TYPES_ML" "turn_phase")
   assert_contains_variant "OCaml(turn_phase)" "$ocaml_turn_constructors" "Turn_idle"
   assert_contains_variant "OCaml(turn_phase)" "$ocaml_turn_constructors" "Turn_prompting"
   ocaml_turn=$(echo "$ocaml_turn_constructors" \
@@ -181,10 +181,10 @@ if [ -f "$KR_ML" ]; then
       echo "INFO: ${KCL_TLA} not found — TLA+ turn_phase check skipped"
     fi
   else
-    echo "WARN: could not extract OCaml turn_phase from ${KR_ML}"
+    echo "WARN: could not extract OCaml turn_phase from ${KR_TYPES_ML}"
   fi
 else
-  echo "WARN: ${KR_ML} not found — turn_phase check skipped"
+  echo "WARN: ${KR_TYPES_ML} not found — turn_phase check skipped"
 fi
 
 # ── Check 3: cascade_state (OCaml) vs CascadeSet in TLA+ ────────────────────
@@ -192,8 +192,8 @@ fi
 echo ""
 echo "=== Check 3: cascade_state (OCaml) vs KeeperCascadeLifecycle.tla domain ==="
 
-if [ -f "$KR_ML" ]; then
-  ocaml_cascade=$(extract_ocaml_type "$KR_ML" "cascade_state" \
+if [ -f "$KR_TYPES_ML" ]; then
+  ocaml_cascade=$(extract_ocaml_type "$KR_TYPES_ML" "cascade_state" \
     | sed 's/Cascade_//' | tr '[:upper:]' '[:lower:]' | sort -u)
 
   if [ -n "$ocaml_cascade" ]; then

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -216,6 +216,26 @@ let success_entry_without_usage ~model ~ts ?provider
     ] @ extra_fields @ diag_fields));
   ]
 
+let success_entry_without_model ~cascade_name ~ts ?(tool_count = 1) () =
+  `Assoc [
+    ("ts_unix", `Float ts);
+    ("tool_call_count", `Int tool_count);
+    ("tools_used", `List [ `String "keeper_board_comment" ]);
+    ( "telemetry",
+      `Assoc [
+        ("model_used", `Null);
+        ("selected_model", `Null);
+        ("cascade_name", `String cascade_name);
+        ("outcome", `String "success");
+        ("stop_reason", `String "completed");
+        ("usage_reported", `Bool false);
+        ("telemetry_reported", `Bool false);
+        ("coverage_stage", `String "oas");
+        ("coverage_reason", `String "missing_usage_and_inference");
+        ("fallback_applied", `Bool false);
+      ] );
+  ]
+
 (* ── Tests ───────────────────────────────────────── *)
 
 let test_empty_dir () =
@@ -586,6 +606,28 @@ let test_coverage_diagnostics_survive_aggregation () =
       (recent_json |> member "outcome" |> to_string);
     check string "recent json stage" "oas"
       (recent_json |> member "coverage_stage" |> to_string))
+
+let test_success_without_model_uses_cascade_attribution () =
+  let base = test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let path = make_keeper_dir base "null_model" in
+    let ts = now_unix () in
+    write_decisions path [
+      success_entry_without_model ~cascade_name:"tier-group.coding_plan"
+        ~ts:(ts -. 5.0) ();
+    ];
+    let agg = M.compute ~base_path:base ~window_minutes:60 in
+    check int "null-model row retained" 1 agg.total_entries;
+    check int "one attributed bucket" 1 (List.length agg.models);
+    let s = List.hd agg.models in
+    check string "cascade attribution"
+      "tier-group.coding_plan (cascade)"
+      s.model_id;
+    check int "success count" 1 s.success_count;
+    check int "tool calls preserved" 1 s.total_tool_calls;
+    check (option string) "coverage reason retained"
+      (Some "missing_usage_and_inference")
+      s.primary_coverage_reason)
 
 let test_costs_jsonl_backfills_wall_tok_per_sec () =
   let base = test_dir () in
@@ -1226,6 +1268,8 @@ let () =
       test_case "prompt tps and peak memory aggregates" `Quick test_prompt_tps_and_peak_memory_aggregates;
       test_case "missing usage serializes unknowns" `Quick test_missing_usage_serializes_unknowns;
       test_case "coverage diagnostics survive aggregation" `Quick test_coverage_diagnostics_survive_aggregation;
+      test_case "success without model uses cascade attribution" `Quick
+        test_success_without_model_uses_cascade_attribution;
       test_case "costs.jsonl backfills wall tok/sec" `Quick test_costs_jsonl_backfills_wall_tok_per_sec;
       test_case "costs.jsonl disambiguates matching model names by provider" `Quick
         test_costs_jsonl_disambiguates_matching_model_names_by_provider;


### PR DESCRIPTION
## Summary
- Preserve successful decision rows when OAS emits model_used/selected_model as null but includes cascade_name
- Attribute those rows to the canonical cascade bucket instead of repeatedly dropping them as missing_success_model
- Add a regression covering the live #15530 row shape and preserved coverage/tool diagnostics

Fixes part of #15530.

## Verification
- ocamlformat --check lib/model_inference_metrics.ml test/test_model_inference_metrics.ml
- scripts/dune-local.sh build test/test_model_inference_metrics.exe
- ./_build/default/test/test_model_inference_metrics.exe --compact --show-errors
- After rebasing onto latest origin/main: ocamlformat --check lib/model_inference_metrics.ml test/test_model_inference_metrics.ml; git diff --check

Note: a second post-rebase focused build was queued but stopped because other agents held the shared dune-local lock; the upstream rebase touched only keeper registry files, not this metric parser/test surface.