### PR TITLE
fix(keeper): validate docker container paths against host roots

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -117,6 +117,36 @@ let rewrite_docker_command_paths ~(config : Coord.config) ~(meta : keeper_meta) 
       rewritten
 ;;
 
+let rewrite_docker_command_paths_for_host_validation
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      cmd
+  =
+  let raw_host_root =
+    Keeper_sandbox.host_root_abs_of_meta ~config meta
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  let normalized_host_root =
+    raw_host_root |> Keeper_alerting_path.normalize_path_for_check_stripped
+  in
+  let container_root =
+    keeper_private_container_root meta |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  let rewritten =
+    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
+      ~host_root:container_root
+      ~container_root:raw_host_root
+      cmd
+  in
+  if String.equal raw_host_root normalized_host_root
+  then rewritten
+  else
+    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
+      ~host_root:container_root
+      ~container_root:normalized_host_root
+      rewritten
+;;
+
 (* ── Profile resolution ────────────────────────────────── *)
 
 (* Invariant (root-fix family 2/3, 2026-04-28):
@@ -737,7 +767,11 @@ let run_docker_shell_command_with_status_internal
       | None ->
       let path_validation =
         if validate_command_paths
-        then Worker_dev_tools.validate_command_paths ~workdir:cwd cmd
+        then
+          let validation_cmd =
+            rewrite_docker_command_paths_for_host_validation ~config ~meta cmd
+          in
+          Worker_dev_tools.validate_command_paths ~workdir:cwd validation_cmd
         else Ok ()
       in
       match path_validation with
@@ -996,7 +1030,10 @@ let run_docker_with_git_bash
       (match sandbox_root_git_blocker with
        | Some message -> sandbox_error_json message
        | None ->
-         (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd with
+         let validation_cmd =
+           rewrite_docker_command_paths_for_host_validation ~config ~meta cmd
+         in
+         (match Worker_dev_tools.validate_command_paths ~workdir:cwd validation_cmd with
           | Error err -> sandbox_error_json err
           | Ok () ->
            let _ = turn_sandbox_runtime in
@@ -1066,7 +1103,10 @@ let run_docker_hardened_bash
     match sandbox_root_git_blocker with
     | Some message -> sandbox_error_json message
     | None ->
-      (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd with
+      let validation_cmd =
+        rewrite_docker_command_paths_for_host_validation ~config ~meta cmd
+      in
+      (match Worker_dev_tools.validate_command_paths ~workdir:cwd validation_cmd with
        | Error err -> sandbox_error_json err
        | Ok () ->
       (match turn_sandbox_runtime, network_mode with

--- a/lib/keeper/keeper_shell_docker.mli
+++ b/lib/keeper/keeper_shell_docker.mli
@@ -48,6 +48,15 @@ val docker_private_workspace_cwd :
   string ->
   string
 
+(** Translate keeper-private in-container absolute paths back to their host
+    playground paths for host-side path validation. Actual Docker execution
+    still receives the original container paths. *)
+val rewrite_docker_command_paths_for_host_validation :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  string ->
+  string
+
 (** Resolve [(sandbox_profile, network_mode)] given the keeper's
     declared profile and whether the cwd is in-playground. Hard
     mode forces the keeper's declared profile; otherwise [Local]

--- a/scripts/check-variants.sh
+++ b/scripts/check-variants.sh
@@ -155,12 +155,12 @@ fi
 echo ""
 echo "=== Check 2: turn_phase (OCaml) vs KeeperCascadeLifecycle.tla domain ==="
 
-KR_ML="lib/keeper/keeper_registry.ml"
+KR_TYPES_ML="lib/keeper/keeper_registry_types.ml"
 KCL_TLA="specs/keeper-state-machine/KeeperCascadeLifecycle.tla"
 
-if [ -f "$KR_ML" ]; then
+if [ -f "$KR_TYPES_ML" ]; then
   # turn_phase constructors (strip "Turn_" prefix, lowercase for TLA+ comparison)
-  ocaml_turn_constructors=$(extract_ocaml_type "$KR_ML" "turn_phase")
+  ocaml_turn_constructors=$(extract_ocaml_type "$KR_TYPES_ML" "turn_phase")
   assert_contains_variant "OCaml(turn_phase)" "$ocaml_turn_constructors" "Turn_idle"
   assert_contains_variant "OCaml(turn_phase)" "$ocaml_turn_constructors" "Turn_prompting"
   ocaml_turn=$(echo "$ocaml_turn_constructors" \
@@ -181,10 +181,10 @@ if [ -f "$KR_ML" ]; then
       echo "INFO: ${KCL_TLA} not found — TLA+ turn_phase check skipped"
     fi
   else
-    echo "WARN: could not extract OCaml turn_phase from ${KR_ML}"
+    echo "WARN: could not extract OCaml turn_phase from ${KR_TYPES_ML}"
   fi
 else
-  echo "WARN: ${KR_ML} not found — turn_phase check skipped"
+  echo "WARN: ${KR_TYPES_ML} not found — turn_phase check skipped"
 fi
 
 # ── Check 3: cascade_state (OCaml) vs CascadeSet in TLA+ ────────────────────
@@ -192,8 +192,8 @@ fi
 echo ""
 echo "=== Check 3: cascade_state (OCaml) vs KeeperCascadeLifecycle.tla domain ==="
 
-if [ -f "$KR_ML" ]; then
-  ocaml_cascade=$(extract_ocaml_type "$KR_ML" "cascade_state" \
+if [ -f "$KR_TYPES_ML" ]; then
+  ocaml_cascade=$(extract_ocaml_type "$KR_TYPES_ML" "cascade_state" \
     | sed 's/Cascade_//' | tr '[:upper:]' '[:lower:]' | sort -u)
 
   if [ -n "$ocaml_cascade" ]; then

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -852,6 +852,33 @@ let test_rewrite_docker_host_paths_to_container () =
        container_root host_root)
     rewritten
 
+let test_rewrite_docker_container_paths_for_host_validation () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  let meta = make_docker_meta "minjae" in
+  let host_root =
+    Keeper_sandbox.host_root_abs_of_meta ~config meta
+    |> Masc_mcp.Keeper_alerting_path.strip_trailing_slashes
+  in
+  let host_repo = Filename.concat (Filename.concat host_root "repos") "masc-mcp" in
+  let container_root = Keeper_sandbox.container_root meta.name in
+  let input =
+    Printf.sprintf "cd %s/repos/masc-mcp && git log --oneline -5\n" container_root
+  in
+  Alcotest.(check bool) "raw container path is outside host workdir" true
+    (is_error (Masc_mcp.Worker_dev_tools.validate_command_paths ~workdir:host_repo input));
+  let rewritten =
+    Keeper_shell_docker.rewrite_docker_command_paths_for_host_validation
+      ~config ~meta input
+  in
+  Alcotest.(check string) "container root rewritten to host root for validation"
+    (Printf.sprintf "cd %s/repos/masc-mcp && git log --oneline -5\n" host_root)
+    rewritten;
+  Alcotest.(check bool) "rewritten path validates under host workdir" true
+    (is_ok
+       (Masc_mcp.Worker_dev_tools.validate_command_paths ~workdir:host_repo rewritten))
+
 (* ── Negative / error-path tests (task-034) ──────────────────────── *)
 
 let test_bash_missing_cmd_field () =
@@ -1035,6 +1062,8 @@ let () =
         test_rewrite_turn_runtime_paths_to_host_is_noop_without_container_path;
       Alcotest.test_case "docker commands rewrite host paths to container paths" `Quick
         test_rewrite_docker_host_paths_to_container;
+      Alcotest.test_case "docker container paths validate as host paths" `Quick
+        test_rewrite_docker_container_paths_for_host_validation;
     ]);
     ("negative_path", [
       Alcotest.test_case "missing cmd field" `Quick test_bash_missing_cmd_field;


### PR DESCRIPTION
Summary:
- translate keeper-private container absolute paths back to host playground roots before host-side path validation
- keep Docker execution commands unchanged
- add coverage for validating container paths against the host workdir

Validation:
- scripts/dune-local.sh build test/test_keeper_bash_safety.exe
- ./_build/default/test/test_keeper_bash_safety.exe test turn_runtime_paths 3