### PR TITLE
refactor(keeper): try_resolve_done helper → keeper_registry_types (1st non-type extraction)

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -24,18 +24,6 @@ open Keeper_types
     keep using [Keeper_registry.failure_reason] etc. unchanged. *)
 include Keeper_registry_types
 
-
-let try_resolve_done entry value =
-  match Eio.Promise.peek entry.done_p with
-  | Some _ -> false
-  | None ->
-    (try
-       Eio.Promise.resolve entry.done_r value;
-       true
-     with
-     | Invalid_argument _ -> false)
-;;
-
 let registry : registry_entry StringMap.t Atomic.t = Atomic.make StringMap.empty
 let running_count_atomic = Atomic.make 0
 

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -30,11 +30,6 @@ val validate_cascade_transition
   -> unit
 
 
-(** Resolve a keeper run completion promise at most once.
-    Returns [false] if another fiber won the resolve race. *)
-val try_resolve_done :
-  registry_entry -> [ `Stopped | `Crashed of string ] -> bool
-
 (** Register a keeper with an already-live fiber. Primarily used by tests and
     direct fixtures that want a keeper to begin in [Running]. *)
 val register : base_path:string -> string -> keeper_meta -> registry_entry

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -1018,3 +1018,14 @@ and completed_turn_observation =
   ; ct_selected_model : string option
   }
 
+let try_resolve_done entry value =
+  match Eio.Promise.peek entry.done_p with
+  | Some _ -> false
+  | None ->
+    (try
+       Eio.Promise.resolve entry.done_r value;
+       true
+     with
+     | Invalid_argument _ -> false)
+;;
+

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -614,3 +614,8 @@ and completed_turn_observation = {
   ct_cascade_state : packed_cascade_state;
   ct_selected_model : string option;
 }
+
+(** Resolve a keeper run completion promise at most once.
+    Returns [false] if another fiber won the resolve race. *)
+val try_resolve_done :
+  registry_entry -> [ `Stopped | `Crashed of string ] -> bool


### PR DESCRIPTION
## Summary
7번째 cluster — *처음으로 type 이 아닌 pure helper* 이동.

이전 6 PR 은 type definitions 와 type-helper converters 이동. 본 PR 은 `try_resolve_done` (pure function on registry_entry, no global state) 만 이동. 작은 PR (14 LoC) 이지만 *non-type pure helper* extraction 패턴의 첫 진입.

`try_resolve_done`:
- registry_entry 의 promise 만 조작 (entry.done_p / entry.done_r)
- registry global state read/write 없음
- pure on (entry, value) inputs

## Files Changed
- keeper_registry_types.ml: +10 LoC (1019 → 1029)
- keeper_registry_types.mli: +4 LoC (614 → 618 with doc)
- keeper_registry.ml: -10 LoC
- keeper_registry.mli: -4 LoC

## Cumulative godfile reduction (7 PRs)
- keeper_registry.ml: **3041 → 2022 LoC (-33%)**
- keeper_registry.mli: **1012 → 446 LoC (-56%)**
- keeper_registry_types: 0 → 1646 LoC

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues series, first pure-helper extraction.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)