### PR TITLE
fix(keeper): force verifier transitions on task verify

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -402,6 +402,9 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
   else if has_turn_affordance Task_audit turn_affordances
           && progress_tool_available "keeper_tasks_audit"
   then Agent_sdk.Types.Tool "keeper_tasks_audit"
+  else if has_turn_affordance Task_verify turn_affordances
+          && progress_tool_available "masc_transition"
+  then Agent_sdk.Types.Any
   else if has_current_task
           && has_turn_affordance Task_verify turn_affordances
           && progress_tool_available "keeper_task_submit_for_verification"
@@ -464,17 +467,22 @@ let preferred_tool_choice_for_required_tool_names
     required_tool_names
     |> List.filter_map (fun name ->
       let canonical = Keeper_tool_disclosure.canonical_tool_name name in
-      if List.mem canonical allowed_tool_names then Some canonical
-      else if List.mem name allowed_tool_names then Some name
+      if List.mem canonical allowed_tool_names then Some (canonical, canonical)
+      else if List.mem name allowed_tool_names then Some (canonical, name)
       else (
         match Keeper_tool_alias.public_name_for_internal canonical with
-        | Some public when List.mem public allowed_tool_names -> Some public
+        | Some public when List.mem public allowed_tool_names ->
+          Some (canonical, public)
         | _ -> None))
     |> Keeper_types.dedupe_keep_order
   in
   match visible_required with
-  | [ name ] when
-      not (Keeper_tool_disclosure.tool_name_can_satisfy_required_contract name) ->
+  | [ canonical, name ]
+    when not
+           (Keeper_tool_disclosure.tool_name_can_satisfy_required_contract
+              canonical
+            || Keeper_tool_disclosure.tool_name_can_satisfy_required_contract name)
+    ->
     (* Passive/read-only tools do not suffer the mutating-tool raw-name
        satisfaction ambiguity described below. When an operator explicitly
        requires one passive tool, exact tool_choice keeps the model from

--- a/scripts/check-variants.sh
+++ b/scripts/check-variants.sh
@@ -155,12 +155,12 @@ fi
 echo ""
 echo "=== Check 2: turn_phase (OCaml) vs KeeperCascadeLifecycle.tla domain ==="
 
-KR_ML="lib/keeper/keeper_registry.ml"
+KR_TYPES_ML="lib/keeper/keeper_registry_types.ml"
 KCL_TLA="specs/keeper-state-machine/KeeperCascadeLifecycle.tla"
 
-if [ -f "$KR_ML" ]; then
+if [ -f "$KR_TYPES_ML" ]; then
   # turn_phase constructors (strip "Turn_" prefix, lowercase for TLA+ comparison)
-  ocaml_turn_constructors=$(extract_ocaml_type "$KR_ML" "turn_phase")
+  ocaml_turn_constructors=$(extract_ocaml_type "$KR_TYPES_ML" "turn_phase")
   assert_contains_variant "OCaml(turn_phase)" "$ocaml_turn_constructors" "Turn_idle"
   assert_contains_variant "OCaml(turn_phase)" "$ocaml_turn_constructors" "Turn_prompting"
   ocaml_turn=$(echo "$ocaml_turn_constructors" \
@@ -181,10 +181,10 @@ if [ -f "$KR_ML" ]; then
       echo "INFO: ${KCL_TLA} not found — TLA+ turn_phase check skipped"
     fi
   else
-    echo "WARN: could not extract OCaml turn_phase from ${KR_ML}"
+    echo "WARN: could not extract OCaml turn_phase from ${KR_TYPES_ML}"
   fi
 else
-  echo "WARN: ${KR_ML} not found — turn_phase check skipped"
+  echo "WARN: ${KR_TYPES_ML} not found — turn_phase check skipped"
 fi
 
 # ── Check 3: cascade_state (OCaml) vs CascadeSet in TLA+ ────────────────────
@@ -192,8 +192,8 @@ fi
 echo ""
 echo "=== Check 3: cascade_state (OCaml) vs KeeperCascadeLifecycle.tla domain ==="
 
-if [ -f "$KR_ML" ]; then
-  ocaml_cascade=$(extract_ocaml_type "$KR_ML" "cascade_state" \
+if [ -f "$KR_TYPES_ML" ]; then
+  ocaml_cascade=$(extract_ocaml_type "$KR_TYPES_ML" "cascade_state" \
     | sed 's/Cascade_//' | tr '[:upper:]' '[:lower:]' | sort -u)
 
   if [ -n "$ocaml_cascade" ]; then

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -10502,6 +10502,11 @@ let test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool () =
     (gate ~tools:[ "keeper_task_submit_for_verification" ] [ "task_verify" ]);
   check
     bool
+    "task_verify with lifecycle transition tool -> gate fires"
+    true
+    (gate ~tools:[ "masc_transition" ] [ "task_verify" ]);
+  check
+    bool
     "timer-only work_discovery does not hard-gate even with progress tools"
     false
     (gate ~tools:[ "keeper_board_post"; "keeper_task_create" ] [ "work_discovery" ]);
@@ -10851,7 +10856,19 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
    | other ->
      fail
        (Printf.sprintf
-          "expected Auto for idle task verify turn, got %s"
+         "expected Auto for idle task verify turn, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
+  (match
+     choose
+       ~turn_affordances:[ "task_verify" ]
+       ~allowed_tool_names:[ "keeper_tasks_list"; "masc_transition" ]
+       ()
+   with
+   | Agent_sdk.Types.Any -> ()
+   | other ->
+     fail
+       (Printf.sprintf
+          "expected Any for idle verifier task_verify turn with masc_transition, got %s"
           (Agent_sdk.Types.show_tool_choice other)));
   (match
      choose


### PR DESCRIPTION
## What changed

- Keep verifier `task_verify` turns tool-required when `masc_transition` is available, so pending verification work can approve/reject instead of falling back to `Auto`.
- Preserve `Any` tool choice when internal required tools such as `keeper_shell` are exposed through public aliases like `Grep`, using the canonical required tool name for contract classification.
- Added focused regression coverage for the `task_verify` + `masc_transition` gate and the required-tool alias behavior.

## Why

Live keeper logs showed pending verification work and verifier affordances, but the verifier could spend turns on passive board curation instead of lifecycle transitions. This keeps the transition lane active without forcing exact provider tool names.

## Validation

- `ocamlformat --check lib/keeper/keeper_agent_tool_surface.ml test/test_keeper_unified.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe test tool_classification`