### PR TITLE
fix(keeper): honor warmup in stale watchdog grace

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -681,7 +681,11 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
        behavioral_stats no longer consumed by build_prompt. *)
       dispatch_fiber_started ~base_path:ctx.config.base_path live_meta.name;
       publish_keeper_started ~live_meta;
-      Keeper_stale_watchdog.fork_stale_watchdog ctx live_meta reg;
+      Keeper_stale_watchdog.fork_stale_watchdog
+        ctx
+        live_meta
+        ~startup_warmup_sec:proactive_warmup_sec
+        reg;
       Eio.Fiber.fork ~sw:ctx.sw (fun () ->
         let record_crash failure_reason =
           record_keeper_crashed

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -380,7 +380,13 @@ let latch_stale_fleet_batch_reasons ~config ~distinct_count keeper_names =
 let latch_stale_fleet_batch_reasons_for_test =
   latch_stale_fleet_batch_reasons
 
+let effective_startup_grace_sec ~base_grace_sec ~poll_sec ~startup_warmup_sec =
+  Float.max
+    base_grace_sec
+    (Float.of_int (max 0 startup_warmup_sec) +. Float.max 0.0 poll_sec)
+
 let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
+    ?(startup_warmup_sec = 0)
     (reg : Keeper_registry.registry_entry) =
   let base_path = ctx.config.base_path in
   let stale_threshold_sec () =
@@ -394,6 +400,12 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
   in
   let grace_period_sec () =
     Env_config_keeper.KeeperWatchdog.grace_period_sec
+  in
+  let effective_grace_period_sec () =
+    effective_startup_grace_sec
+      ~base_grace_sec:(grace_period_sec ())
+      ~poll_sec:(watchdog_poll_sec ())
+      ~startup_warmup_sec
   in
   let last_broadcast_ts = ref 0.0 in
   let request_watchdog_stop () =
@@ -415,7 +427,8 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
              when entry.phase = Keeper_state_machine.Running ->
              let last_turn = entry.meta.runtime.usage.last_turn_ts in
              let fiber_age = now -. entry.started_at in
-             let grace_remaining = grace_period_sec () -. fiber_age in
+             let startup_grace = effective_grace_period_sec () in
+             let grace_remaining = startup_grace -. fiber_age in
              (* #10765-followup: separate idle-stale (no turn running) from
                 in-turn-stale (turn running too long).  Production
                 observation (2026-04-26): 9 keepers killed at idle
@@ -441,11 +454,11 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                match entry.current_turn_observation with
                | Some obs ->
                  let elapsed = now -. obs.started_at in
-                 ( false
-                 , elapsed > active_turn_timeout_sec
-                   && fiber_age >= grace_period_sec ()
-                 , elapsed
-                 , false )
+                ( false
+                , elapsed > active_turn_timeout_sec
+                  && fiber_age >= startup_grace
+                , elapsed
+                , false )
                | None -> (
                  match active_slot_holder_age with
                  | Some elapsed ->
@@ -457,7 +470,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                       still owns slots, causing fleet-wide slot starvation. *)
                    ( false
                    , elapsed > active_turn_timeout_sec
-                     && fiber_age >= grace_period_sec ()
+                     && fiber_age >= startup_grace
                    , elapsed
                    , false )
                  | None ->
@@ -467,7 +480,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                  let stale =
                    last_turn > 0.0
                    && now -. last_turn > threshold
-                   && fiber_age >= grace_period_sec ()
+                   && fiber_age >= startup_grace
                    && not skip_observed
                  in
                  (stale, false, 0.0, skip_observed))

--- a/lib/keeper/keeper_stale_watchdog.mli
+++ b/lib/keeper/keeper_stale_watchdog.mli
@@ -47,8 +47,21 @@ val latch_stale_fleet_batch_reasons_for_test :
   config:Coord.config -> distinct_count:int -> string list -> unit
 (** Test-only wrapper for the batch failure-reason latch. *)
 
+val effective_startup_grace_sec :
+     base_grace_sec:float
+  -> poll_sec:float
+  -> startup_warmup_sec:int
+  -> float
+(** Effective grace window before stale detection can kill a newly-started
+    keeper.  It must cover the configured watchdog grace and the proactive
+    startup warmup plus one poll interval. *)
+
 val fork_stale_watchdog :
-  'a context -> keeper_meta -> Keeper_registry.registry_entry -> unit
+     'a context
+  -> keeper_meta
+  -> ?startup_warmup_sec:int
+  -> Keeper_registry.registry_entry
+  -> unit
 (** Fork a stale-turn watchdog fiber for the given keeper.
 
     Three detection modes — see {!Keeper_registry.stale_kill_class}:

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -246,7 +246,7 @@ let launch_supervised_fiber
   if restart_launch_noop_enabled_for_test ()
   then ()
   else (
-    fork_stale_watchdog ctx meta reg;
+    fork_stale_watchdog ctx meta ~startup_warmup_sec:proactive_warmup_sec reg;
     (* Task 137: Inject bootstrap signal to ensure at least one warm-up turn runs
      and break the initial proactive deadlock. *)
     let bootstrap_signal : Keeper_event_queue.stimulus =

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -23,7 +23,11 @@ val supervise_keepalive :
 (** {1 Watchdog} *)
 
 val fork_stale_watchdog :
-  'a context -> keeper_meta -> Keeper_registry.registry_entry -> unit
+     'a context
+  -> keeper_meta
+  -> ?startup_warmup_sec:int
+  -> Keeper_registry.registry_entry
+  -> unit
 (** Fork a stale-turn watchdog fiber for the given keeper.  This is a
     re-export of {!Keeper_stale_watchdog.fork_stale_watchdog}; see
     that module's docstring for the authoritative description of the

--- a/scripts/check-variants.sh
+++ b/scripts/check-variants.sh
@@ -155,12 +155,12 @@ fi
 echo ""
 echo "=== Check 2: turn_phase (OCaml) vs KeeperCascadeLifecycle.tla domain ==="
 
-KR_ML="lib/keeper/keeper_registry.ml"
+KR_TYPES_ML="lib/keeper/keeper_registry_types.ml"
 KCL_TLA="specs/keeper-state-machine/KeeperCascadeLifecycle.tla"
 
-if [ -f "$KR_ML" ]; then
+if [ -f "$KR_TYPES_ML" ]; then
   # turn_phase constructors (strip "Turn_" prefix, lowercase for TLA+ comparison)
-  ocaml_turn_constructors=$(extract_ocaml_type "$KR_ML" "turn_phase")
+  ocaml_turn_constructors=$(extract_ocaml_type "$KR_TYPES_ML" "turn_phase")
   assert_contains_variant "OCaml(turn_phase)" "$ocaml_turn_constructors" "Turn_idle"
   assert_contains_variant "OCaml(turn_phase)" "$ocaml_turn_constructors" "Turn_prompting"
   ocaml_turn=$(echo "$ocaml_turn_constructors" \
@@ -181,10 +181,10 @@ if [ -f "$KR_ML" ]; then
       echo "INFO: ${KCL_TLA} not found — TLA+ turn_phase check skipped"
     fi
   else
-    echo "WARN: could not extract OCaml turn_phase from ${KR_ML}"
+    echo "WARN: could not extract OCaml turn_phase from ${KR_TYPES_ML}"
   fi
 else
-  echo "WARN: ${KR_ML} not found — turn_phase check skipped"
+  echo "WARN: ${KR_TYPES_ML} not found — turn_phase check skipped"
 fi
 
 # ── Check 3: cascade_state (OCaml) vs CascadeSet in TLA+ ────────────────────
@@ -192,8 +192,8 @@ fi
 echo ""
 echo "=== Check 3: cascade_state (OCaml) vs KeeperCascadeLifecycle.tla domain ==="
 
-if [ -f "$KR_ML" ]; then
-  ocaml_cascade=$(extract_ocaml_type "$KR_ML" "cascade_state" \
+if [ -f "$KR_TYPES_ML" ]; then
+  ocaml_cascade=$(extract_ocaml_type "$KR_TYPES_ML" "cascade_state" \
     | sed 's/Cascade_//' | tr '[:upper:]' '[:lower:]' | sort -u)
 
   if [ -n "$ocaml_cascade" ]; then

--- a/test/dune
+++ b/test/dune
@@ -258,6 +258,7 @@
         test_keeper_event_queue
         test_keeper_relevance_check
         test_gh_api_classification
+        test_stale_kill_class
         test_workspace_routes_keeper
         test_provider_capability_matrix
         test_effect_evidence_source_path

--- a/test/test_stale_kill_class.ml
+++ b/test/test_stale_kill_class.ml
@@ -268,6 +268,30 @@ let test_noop_failure_loop_boundary_equal_timestamps () =
        ~started_at:200.0
        ~last_completed_turn_ended_at:(Some 200.0))
 
+let test_effective_startup_grace_covers_warmup () =
+  let check_float = Alcotest.(check (float 0.001)) in
+  check_float
+    "base grace remains when warmup fits inside it"
+    360.0
+    (SW.effective_startup_grace_sec
+       ~base_grace_sec:360.0
+       ~poll_sec:30.0
+       ~startup_warmup_sec:120);
+  check_float
+    "warmup plus one poll extends startup grace"
+    418.0
+    (SW.effective_startup_grace_sec
+       ~base_grace_sec:360.0
+       ~poll_sec:30.0
+       ~startup_warmup_sec:388);
+  check_float
+    "negative warmup is clamped"
+    360.0
+    (SW.effective_startup_grace_sec
+       ~base_grace_sec:360.0
+       ~poll_sec:30.0
+       ~startup_warmup_sec:(-1))
+
 let () =
   Alcotest.run "stale_kill_class"
     [
@@ -341,5 +365,10 @@ let () =
             test_noop_failure_loop_triggers_after_current_turn;
           Alcotest.test_case "boundary equal timestamps" `Quick
             test_noop_failure_loop_boundary_equal_timestamps;
+        ] );
+      ( "startup_grace",
+        [
+          Alcotest.test_case "covers proactive warmup" `Quick
+            test_effective_startup_grace_covers_warmup;
         ] );
     ]


### PR DESCRIPTION
## What changed

- Pass the configured proactive startup warmup into the stale watchdog from both normal keepalive startup and supervised restart paths.
- Compute startup grace as `max(base_watchdog_grace, startup_warmup + watchdog_poll_interval)` so newly booted keepers are not killed before their first eligible proactive turn.
- Register and extend `test_stale_kill_class` with focused coverage for the effective startup grace calculation.

## Why

Live logs showed autobooted keepers starting with warmups around 336-388 seconds while the watchdog grace boundary was 360 seconds. The watchdog killed the fibers with `stale_turn_timeout(idle_turn(360s))` before the first scheduled autonomous turn could run, then self-preservation suppressed restarts.

## Validation

- `ocamlformat --check lib/keeper/keeper_stale_watchdog.ml lib/keeper/keeper_stale_watchdog.mli lib/keeper/keeper_supervisor.ml lib/keeper/keeper_supervisor.mli lib/keeper/keeper_keepalive.ml test/test_stale_kill_class.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_stale_kill_class.exe`
- `./_build/default/test/test_stale_kill_class.exe`