### PR TITLE
fix(ci): read registry variants from split types module

### DIFF
--- a/scripts/check-variants.sh
+++ b/scripts/check-variants.sh
@@ -155,7 +155,7 @@ fi
 echo ""
 echo "=== Check 2: turn_phase (OCaml) vs KeeperCascadeLifecycle.tla domain ==="
 
-KR_ML="lib/keeper/keeper_registry.ml"
+KR_ML="lib/keeper/keeper_registry_types.ml"
 KCL_TLA="specs/keeper-state-machine/KeeperCascadeLifecycle.tla"
 
 if [ -f "$KR_ML" ]; then


### PR DESCRIPTION
## What changed

- Updated `scripts/check-variants.sh` to extract `turn_phase` and `cascade_state` from `lib/keeper/keeper_registry_types.ml` after the registry type split.

## Why

`Meta Guards` was still looking in `lib/keeper/keeper_registry.ml` for `Turn_idle` / `Turn_prompting`, so CI failed even though the variants now live in the split types module on current `main`.

## Validation

- `bash scripts/check-variants.sh`
- `bash scripts/ci/check-tla-variant-sync.sh`
- `git diff --check`