### PR TITLE
refactor(keeper): lifecycle_event_origin type + 2 pure helpers → keeper_registry_types

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -53,12 +53,6 @@ let decr_running_count_clamped () =
 
     Pattern follows #7011 (executor_pool) and #7013 (runtime_state). *)
 
-let registry_key ~base_path name =
-  if String.contains name '\x1f'
-  then invalid_arg (Printf.sprintf "keeper name contains unit separator: %s" name);
-  base_path ^ "\x1f" ^ name
-;;
-
 let put_entry key entry =
   let rec loop () =
     let current = Atomic.get registry in
@@ -514,15 +508,6 @@ let set_last_correlation_id ~base_path name cid =
   update_entry ~base_path name (fun e -> { e with last_event_bus_correlation = Some cid })
 ;;
 
-let turn_phase_of_cascade_state (s : packed_cascade_state) : packed_turn_phase =
-  match s with
-  | Packed Cascade_idle -> Packed Turn_prompting
-  | Packed Cascade_selecting -> Packed Turn_routing
-  | Packed Cascade_trying -> Packed Turn_executing
-  | Packed Cascade_done -> Packed Turn_finalizing
-  | Packed Cascade_exhausted -> Packed Turn_exhausted
-;;
-
 let broadcast_composite_changed ~name ~ts_unix =
   try
     let json =
@@ -565,25 +550,6 @@ let record_phase_broadcast_failure ~name exn =
     "registry: keeper_phase_changed broadcast failed name=%s err=%s"
     name
     (Printexc.to_string exn)
-;;
-
-let completed_turn_outcome_of_observation (obs : turn_observation)
-  : Keeper_transition_audit.completed_turn_outcome
-  =
-  (* P1 silent-failure fix: the previous wildcard `| _ -> Turn_failed`
-     meant that adding a new variant to either ADT (decision_stage or
-     cascade_state) would silently fall through to Turn_failed without
-     a compile error.  Spelling out every variant lets the OCaml
-     exhaustiveness checker catch missing cases at build time. *)
-  match obs.decision_stage with
-  | Packed Decision_gate_rejected -> Keeper_transition_audit.Turn_gate_rejected
-  | Packed (Decision_undecided | Decision_guard_ok | Decision_tool_policy_selected) ->
-    (match obs.cascade_state with
-     | Packed Cascade_done -> Keeper_transition_audit.Turn_substantive
-     | Packed Cascade_idle
-     | Packed Cascade_selecting
-     | Packed Cascade_trying
-     | Packed Cascade_exhausted -> Keeper_transition_audit.Turn_failed)
 ;;
 
 let update_current_turn e f =

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1448,27 +1448,6 @@ let restore_tool_usage ~base_path name =
 
 (* ── RFC-0002 Event Dispatch ───────────────────────────── *)
 
-type lifecycle_event_origin =
-  | Generic_dispatch
-  | Post_turn_lifecycle
-  | Operator_compact
-
-let lifecycle_event_origin_to_string = function
-  | Generic_dispatch -> "generic_dispatch"
-  | Post_turn_lifecycle -> "post_turn_lifecycle"
-  | Operator_compact -> "operator_compact"
-;;
-
-let is_paired_lifecycle_event = function
-  | Keeper_state_machine.Compaction_started
-  | Keeper_state_machine.Compaction_completed _
-  | Keeper_state_machine.Compaction_failed _
-  | Keeper_state_machine.Handoff_started
-  | Keeper_state_machine.Handoff_completed _
-  | Keeper_state_machine.Handoff_failed _ -> true
-  | _ -> false
-;;
-
 let origin_allows_paired_lifecycle_event origin event =
   match origin, event with
   | Post_turn_lifecycle, event when is_paired_lifecycle_event event -> true

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -339,17 +339,6 @@ val restore_tool_usage : base_path:string -> string -> unit
 
 (** {1 RFC-0002 Event Dispatch} *)
 
-(** Dispatch origin for paired post-turn lifecycle events.
-
-    [Compaction_started]/[Compaction_completed]/[Compaction_failed] and
-    [Handoff_started]/[Handoff_completed]/[Handoff_failed] are same-turn
-    lifecycle pairs. The registry rejects them from [Generic_dispatch] so
-    keepalive/guard/manual callers cannot emit half of a pair outside the
-    owner path. *)
-type lifecycle_event_origin =
-  | Generic_dispatch
-  | Post_turn_lifecycle
-  | Operator_compact
 
 (** Dispatch a typed event through the state machine.
     Updates conditions, derives new phase, syncs legacy state.

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -1029,3 +1029,37 @@ let try_resolve_done entry value =
      | Invalid_argument _ -> false)
 ;;
 
+let registry_key ~base_path name =
+  if String.contains name '\x1f'
+  then invalid_arg (Printf.sprintf "keeper name contains unit separator: %s" name);
+  base_path ^ "\x1f" ^ name
+;;
+
+let turn_phase_of_cascade_state (s : packed_cascade_state) : packed_turn_phase =
+  match s with
+  | Packed Cascade_idle -> Packed Turn_prompting
+  | Packed Cascade_selecting -> Packed Turn_routing
+  | Packed Cascade_trying -> Packed Turn_executing
+  | Packed Cascade_done -> Packed Turn_finalizing
+  | Packed Cascade_exhausted -> Packed Turn_exhausted
+;;
+
+let completed_turn_outcome_of_observation (obs : turn_observation)
+  : Keeper_transition_audit.completed_turn_outcome
+  =
+  (* P1 silent-failure fix: the previous wildcard `| _ -> Turn_failed`
+     meant that adding a new variant to either ADT (decision_stage or
+     cascade_state) would silently fall through to Turn_failed without
+     a compile error.  Spelling out every variant lets the OCaml
+     exhaustiveness checker catch missing cases at build time. *)
+  match obs.decision_stage with
+  | Packed Decision_gate_rejected -> Keeper_transition_audit.Turn_gate_rejected
+  | Packed (Decision_undecided | Decision_guard_ok | Decision_tool_policy_selected) ->
+    (match obs.cascade_state with
+     | Packed Cascade_done -> Keeper_transition_audit.Turn_substantive
+     | Packed Cascade_idle
+     | Packed Cascade_selecting
+     | Packed Cascade_trying
+     | Packed Cascade_exhausted -> Keeper_transition_audit.Turn_failed)
+;;
+

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -1063,3 +1063,25 @@ let completed_turn_outcome_of_observation (obs : turn_observation)
      | Packed Cascade_exhausted -> Keeper_transition_audit.Turn_failed)
 ;;
 
+(* RFC-0002 Event Dispatch — lifecycle_event_origin type + pure helpers. *)
+type lifecycle_event_origin =
+  | Generic_dispatch
+  | Post_turn_lifecycle
+  | Operator_compact
+
+let lifecycle_event_origin_to_string = function
+  | Generic_dispatch -> "generic_dispatch"
+  | Post_turn_lifecycle -> "post_turn_lifecycle"
+  | Operator_compact -> "operator_compact"
+;;
+
+let is_paired_lifecycle_event = function
+  | Keeper_state_machine.Compaction_started
+  | Keeper_state_machine.Compaction_completed _
+  | Keeper_state_machine.Compaction_failed _
+  | Keeper_state_machine.Handoff_started
+  | Keeper_state_machine.Handoff_completed _
+  | Keeper_state_machine.Handoff_failed _ -> true
+  | _ -> false
+;;
+

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -635,3 +635,22 @@ val turn_phase_of_cascade_state :
     Pure function, no state access. *)
 val completed_turn_outcome_of_observation :
   turn_observation -> Keeper_transition_audit.completed_turn_outcome
+
+(** Dispatch origin for paired post-turn lifecycle events.
+
+    [Compaction_started]/[Compaction_completed]/[Compaction_failed] and
+    [Handoff_started]/[Handoff_completed]/[Handoff_failed] are same-turn
+    lifecycle pairs. The registry rejects them from [Generic_dispatch] so
+    keepalive/guard/manual callers cannot emit half of a pair outside the
+    owner path. *)
+type lifecycle_event_origin =
+  | Generic_dispatch
+  | Post_turn_lifecycle
+  | Operator_compact
+
+(** Pure converter for diagnostic / log labels. *)
+val lifecycle_event_origin_to_string : lifecycle_event_origin -> string
+
+(** Internal: predicate over [Keeper_state_machine.event] identifying the
+    compaction- and handoff-pair half-events. *)
+val is_paired_lifecycle_event : Keeper_state_machine.event -> bool

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -619,3 +619,19 @@ and completed_turn_observation = {
     Returns [false] if another fiber won the resolve race. *)
 val try_resolve_done :
   registry_entry -> [ `Stopped | `Crashed of string ] -> bool
+
+(** Internal: keeper registry key composition (base_path ^ \\x1f ^ name).
+    Exposed via mli so keeper_registry.ml's state functions can use it
+    after the intra-library split; not intended for external callers. *)
+val registry_key : base_path:string -> string -> string
+
+(** Pure mapping from cascade_state witness to its parent turn_phase
+    witness. Used by composite observer derivations. *)
+val turn_phase_of_cascade_state :
+  packed_cascade_state -> packed_turn_phase
+
+(** Classify a live turn_observation into a completed_turn_outcome
+    using exhaustive pattern matching on (decision_stage, cascade_state).
+    Pure function, no state access. *)
+val completed_turn_outcome_of_observation :
+  turn_observation -> Keeper_transition_audit.completed_turn_outcome


### PR DESCRIPTION
## Summary
9번째 PR. RFC-0002 event-dispatch type cluster 이동.

이동 대상:
- type `lifecycle_event_origin` (3-variant ADT: Generic_dispatch / Post_turn_lifecycle / Operator_compact)
- `lifecycle_event_origin_to_string` (pure converter)
- `is_paired_lifecycle_event` (pure predicate over Keeper_state_machine.event)

모두 pure. Keeper_state_machine 의존 (parent masc_mcp 안, cycle-free).

## Cumulative godfile reduction (9 PRs)
- keeper_registry.ml: **3041 → 1972 LoC (-35%)**
- keeper_registry.mli: **1012 → 435 LoC (-57%)**
- keeper_registry_types: 0 → 1693 LoC

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues series, type-+helper extraction.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)