### PR TITLE
refactor(keeper): 3 more pure helpers (origin gate + event derivations) → keeper_registry_types

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1448,18 +1448,6 @@ let restore_tool_usage ~base_path name =
 
 (* ── RFC-0002 Event Dispatch ───────────────────────────── *)
 
-let origin_allows_paired_lifecycle_event origin event =
-  match origin, event with
-  | Post_turn_lifecycle, event when is_paired_lifecycle_event event -> true
-  | ( Operator_compact
-    , ( Keeper_state_machine.Compaction_started
-      | Keeper_state_machine.Compaction_completed _
-      | Keeper_state_machine.Compaction_failed _ ) ) -> true
-  | Generic_dispatch, event when is_paired_lifecycle_event event -> false
-  | Operator_compact, event when is_paired_lifecycle_event event -> false
-  | _, _ -> true
-;;
-
 let validate_paired_lifecycle_origin origin event =
   if origin_allows_paired_lifecycle_event origin event
   then Ok ()
@@ -1527,23 +1515,6 @@ let record_followup_dispatch_rejection event =
     Keeper_metrics.metric_keeper_lifecycle_dispatch_rejections
     ~labels:[ "event", Keeper_state_machine.event_to_string event ]
     ()
-;;
-
-let pending_measurement_after_event now entry event =
-  match event with
-  | Keeper_state_machine.Context_measured { auto_rules; _ } ->
-    Some { tm_captured_at = now; tm_auto_rules = auto_rules }
-  | _ -> entry.pending_turn_measurement
-;;
-
-let compaction_stage_of_event entry event =
-  match event with
-  | Keeper_state_machine.Compaction_started
-  | Keeper_state_machine.Auto_compact_triggered
-  | Keeper_state_machine.Operator_compact_requested -> Packed Compaction_compacting
-  | Keeper_state_machine.Compaction_completed _ -> Packed Compaction_done
-  | Keeper_state_machine.Compaction_failed _ -> Packed Compaction_accumulating
-  | _ -> entry.compaction_stage
 ;;
 
 (* RFC-0072 Phase 6: the 3×3 compaction matrix dispatched as an exhaustive

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -1085,3 +1085,32 @@ let is_paired_lifecycle_event = function
   | _ -> false
 ;;
 
+let origin_allows_paired_lifecycle_event origin event =
+  match origin, event with
+  | Post_turn_lifecycle, event when is_paired_lifecycle_event event -> true
+  | ( Operator_compact
+    , ( Keeper_state_machine.Compaction_started
+      | Keeper_state_machine.Compaction_completed _
+      | Keeper_state_machine.Compaction_failed _ ) ) -> true
+  | Generic_dispatch, event when is_paired_lifecycle_event event -> false
+  | Operator_compact, event when is_paired_lifecycle_event event -> false
+  | _, _ -> true
+;;
+
+let pending_measurement_after_event now entry event =
+  match event with
+  | Keeper_state_machine.Context_measured { auto_rules; _ } ->
+    Some { tm_captured_at = now; tm_auto_rules = auto_rules }
+  | _ -> entry.pending_turn_measurement
+;;
+
+let compaction_stage_of_event entry event =
+  match event with
+  | Keeper_state_machine.Compaction_started
+  | Keeper_state_machine.Auto_compact_triggered
+  | Keeper_state_machine.Operator_compact_requested -> Packed Compaction_compacting
+  | Keeper_state_machine.Compaction_completed _ -> Packed Compaction_done
+  | Keeper_state_machine.Compaction_failed _ -> Packed Compaction_accumulating
+  | _ -> entry.compaction_stage
+;;
+

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -654,3 +654,19 @@ val lifecycle_event_origin_to_string : lifecycle_event_origin -> string
 (** Internal: predicate over [Keeper_state_machine.event] identifying the
     compaction- and handoff-pair half-events. *)
 val is_paired_lifecycle_event : Keeper_state_machine.event -> bool
+
+(** Pure dispatch-origin gate: returns true iff the (origin, event) pair
+    is allowed under the paired-lifecycle invariant. *)
+val origin_allows_paired_lifecycle_event :
+  lifecycle_event_origin -> Keeper_state_machine.event -> bool
+
+(** Pure: derive the next [pending_turn_measurement] field after observing
+    [event] at wall-clock [now], preserving the prior value when the event
+    is not a [Context_measured]. *)
+val pending_measurement_after_event :
+  float -> registry_entry -> Keeper_state_machine.event -> turn_measurement option
+
+(** Pure: derive the next [compaction_stage] after observing [event],
+    preserving the entry's prior stage on non-compaction events. *)
+val compaction_stage_of_event :
+  registry_entry -> Keeper_state_machine.event -> packed_compaction_stage


### PR DESCRIPTION
## Summary
10번째 PR. Pure helper batch — pattern match only, no state writes.

이동 대상:
- `origin_allows_paired_lifecycle_event` (11 LoC) — paired-lifecycle invariant gate
- `pending_measurement_after_event` (6 LoC) — turn_measurement update derivation
- `compaction_stage_of_event` (9 LoC) — compaction stage derivation

모두 (entry/origin, event) → next-value pure functions. registry global state mutation 없음.

## Cumulative godfile reduction (10 PRs)
- keeper_registry.ml: **3041 → 1946 LoC (-36%)**
- keeper_registry.mli: **1012 → 435 LoC (-57%)**
- keeper_registry_types: 0 → 1719 LoC

남은 1946 LoC 는 *registry global state mutation* (Atomic.t CAS / StringMap / Eio bus). 추가 분해는 RFC-level vertical split 필요.

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues series, pure helper extraction.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)