### PR TITLE
refactor(keeper): cohort iterators + persona_drift cluster → keeper_supervisor_types (#2)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -31,24 +31,6 @@ let keep_last_n n item lst =
     (intra-library file split, 2026-05-16). *)
 include Keeper_supervisor_types
 
-let fresh_supervision_cohort_keepers ~base_path (cohort : supervision_cohort) =
-  List.filter_map
-    (fun (entry : Keeper_registry.registry_entry) ->
-       Keeper_registry.get ~base_path entry.name)
-    cohort.keepers
-;;
-
-let iter_supervision_cohorts ?(yield_between = Eio_guard.fair_yield) cohorts ~f =
-  let rec loop = function
-    | [] -> ()
-    | [ cohort ] -> f cohort
-    | cohort :: rest ->
-      f cohort;
-      yield_between ();
-      loop rest
-  in
-  loop cohorts
-;;
 
 let should_cleanup_dead ~now ~dead_ttl_sec (entry : Keeper_registry.registry_entry) =
   match entry.phase, entry.dead_since_ts with
@@ -628,30 +610,6 @@ let persona_profile_path_for_drift_check ~base_path persona_name =
       "profile.json"
 ;;
 
-type persona_drift_log_level =
-  | Persona_drift_warn
-  | Persona_drift_error
-
-let keeper_defaults_have_inline_identity
-    (defaults : Keeper_types_profile.keeper_profile_defaults)
-  =
-  Option.is_some defaults.goal
-  || Option.is_some defaults.short_goal
-  || Option.is_some defaults.mid_goal
-  || Option.is_some defaults.long_goal
-  || Option.is_some defaults.will
-  || Option.is_some defaults.needs
-  || Option.is_some defaults.desires
-  || Option.is_some defaults.instructions
-  || defaults.mention_targets <> []
-;;
-
-let persona_drift_log_level_for_missing_profile (meta : keeper_meta) =
-  match Keeper_types_profile.load_keeper_profile_defaults_result meta.name with
-  | Ok defaults when keeper_defaults_have_inline_identity defaults ->
-    Persona_drift_warn
-  | Ok _ | Error _ -> Persona_drift_error
-;;
 
 let log_persona_drift_if_missing ~base_path (meta : keeper_meta) =
   let persona_name = persona_name_for_drift_check meta in

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -61,35 +61,11 @@ val persona_profile_path_for_drift_check :
 (** Return the concrete persona [profile.json] path reported by supervisor
     drift diagnostics. *)
 
-type persona_drift_log_level =
-  | Persona_drift_warn
-  | Persona_drift_error
-
-val persona_drift_log_level_for_missing_profile :
-  keeper_meta -> persona_drift_log_level
-(** Classify a missing persona profile.  Keeper TOML with enough inline
-    identity remains operational and is WARN; keepers without TOML/persona
-    identity are ERROR. *)
-
-(** supervision_cohort type + foundational helpers live in
+(** supervision_cohort type + cohort/persona helpers live in
     Keeper_supervisor_types (intra-library file split, 2026-05-16).
     Re-exported here so existing callers keep using
     [Keeper_supervisor.supervision_cohort] etc. unchanged. *)
 include module type of Keeper_supervisor_types
-
-val fresh_supervision_cohort_keepers :
-  base_path:string ->
-  supervision_cohort ->
-  Keeper_registry.registry_entry list
-(** Re-read a cohort's keeper entries from the registry by name. Entries that
-    disappeared since the original sweep snapshot are omitted. *)
-
-val iter_supervision_cohorts :
-  ?yield_between:(unit -> unit) ->
-  supervision_cohort list ->
-  f:(supervision_cohort -> unit) ->
-  unit
-(** Iterate cohorts in order and yield only between cohort boundaries. *)
 
 val next_auto_resume_after_sec :
   initial_sec:float -> max_sec:float -> float option -> float option

--- a/lib/keeper/keeper_supervisor_types.ml
+++ b/lib/keeper/keeper_supervisor_types.ml
@@ -3,6 +3,8 @@
 
     See keeper_supervisor_types.mli for rationale and contract. *)
 
+open Keeper_types
+
 let supervision_cohort_size = 8
 
 type supervision_cohort =
@@ -35,4 +37,48 @@ let supervision_cohorts
       loop (cohort_id + 1) ({ cohort_id; keepers } :: acc) rest
   in
   loop 0 [] sorted
+;;
+
+let fresh_supervision_cohort_keepers ~base_path (cohort : supervision_cohort) =
+  List.filter_map
+    (fun (entry : Keeper_registry.registry_entry) ->
+       Keeper_registry.get ~base_path entry.name)
+    cohort.keepers
+;;
+
+let iter_supervision_cohorts ?(yield_between = Eio_guard.fair_yield) cohorts ~f =
+  let rec loop = function
+    | [] -> ()
+    | [ cohort ] -> f cohort
+    | cohort :: rest ->
+      f cohort;
+      yield_between ();
+      loop rest
+  in
+  loop cohorts
+;;
+
+type persona_drift_log_level =
+  | Persona_drift_warn
+  | Persona_drift_error
+
+let keeper_defaults_have_inline_identity
+    (defaults : Keeper_types_profile.keeper_profile_defaults)
+  =
+  Option.is_some defaults.goal
+  || Option.is_some defaults.short_goal
+  || Option.is_some defaults.mid_goal
+  || Option.is_some defaults.long_goal
+  || Option.is_some defaults.will
+  || Option.is_some defaults.needs
+  || Option.is_some defaults.desires
+  || Option.is_some defaults.instructions
+  || defaults.mention_targets <> []
+;;
+
+let persona_drift_log_level_for_missing_profile (meta : keeper_meta) =
+  match Keeper_types_profile.load_keeper_profile_defaults_result meta.name with
+  | Ok defaults when keeper_defaults_have_inline_identity defaults ->
+    Persona_drift_warn
+  | Ok _ | Error _ -> Persona_drift_error
 ;;

--- a/lib/keeper/keeper_supervisor_types.mli
+++ b/lib/keeper/keeper_supervisor_types.mli
@@ -1,11 +1,12 @@
 (** Keeper_supervisor_types — pure type definitions and helpers extracted
     from Keeper_supervisor (2632 LoC godfile).
 
-    Holds the [supervision_cohort] type + the deterministic-chunking
-    [supervision_cohorts] function. State-touching supervisor operations
-    remain in Keeper_supervisor. Re-included by Keeper_supervisor so
-    existing callers continue to use [Keeper_supervisor.supervision_cohort]
-    unchanged. *)
+    Holds cohort + persona-drift types + their pure helpers. State-touching
+    supervisor operations remain in Keeper_supervisor. Re-included by
+    Keeper_supervisor so existing callers continue to use
+    [Keeper_supervisor.supervision_cohort] etc. unchanged. *)
+
+open Keeper_types
 
 val supervision_cohort_size : int
 (** Target keeper count per supervisor cohort.  The first 2-level
@@ -23,3 +24,27 @@ val supervision_cohorts :
   supervision_cohort list
 (** Sort and chunk registry entries into deterministic supervisor cohorts.
     [cohort_size <= 0] is coerced to 1. *)
+
+val fresh_supervision_cohort_keepers :
+  base_path:string ->
+  supervision_cohort ->
+  Keeper_registry.registry_entry list
+(** Re-read a cohort's keeper entries from the registry by name. Entries that
+    disappeared since the original sweep snapshot are omitted. *)
+
+val iter_supervision_cohorts :
+  ?yield_between:(unit -> unit) ->
+  supervision_cohort list ->
+  f:(supervision_cohort -> unit) ->
+  unit
+(** Iterate cohorts in order and yield only between cohort boundaries. *)
+
+type persona_drift_log_level =
+  | Persona_drift_warn
+  | Persona_drift_error
+
+val persona_drift_log_level_for_missing_profile :
+  keeper_meta -> persona_drift_log_level
+(** Classify a missing persona profile.  Keeper TOML with enough inline
+    identity remains operational and is WARN; keepers without TOML/persona
+    identity are ERROR. *)


### PR DESCRIPTION
## Summary
2번째 keeper_supervisor_types PR. PR #15576 의 후속, 같은 series 확장.

이동 대상:
1. **cohort iterators**:
   - `fresh_supervision_cohort_keepers` (6 LoC, registry-read pure)
   - `iter_supervision_cohorts` (11 LoC, Eio yield iteration)
2. **persona_drift_log_level cluster** (24 LoC):
   - type `persona_drift_log_level` (2-variant ADT)
   - `keeper_defaults_have_inline_identity` (private pure predicate)
   - `persona_drift_log_level_for_missing_profile` (pure classifier)

`open Keeper_types` 추가 — `keeper_meta` 타입 가용성 확보.

## Stack
```
main
 └─ #15576 (supervision_cohort foundation) Draft
     └─ #THIS (cohort iterators + persona_drift) Draft
```

## Cumulative keeper_supervisor reduction (2 PRs)
- keeper_supervisor.ml: **2632 → 2557 LoC (-3%)**
- keeper_supervisor.mli: **228 → 195 LoC (-14%)**
- keeper_supervisor_types: 0 → 142 LoC

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues series, intra-library split.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)