### PR TITLE
refactor(keeper): predicates + cohort keys → keeper_supervisor_types (#3)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -32,45 +32,6 @@ let keep_last_n n item lst =
 include Keeper_supervisor_types
 
 
-let should_cleanup_dead ~now ~dead_ttl_sec (entry : Keeper_registry.registry_entry) =
-  match entry.phase, entry.dead_since_ts with
-  | Keeper_state_machine.Dead, Some dead_since -> now -. dead_since >= dead_ttl_sec
-  (* Dead but no [dead_since_ts] yet — first observation will set it. *)
-  | Keeper_state_machine.Dead, None -> false
-  (* Non-Dead phases never trigger Dead cleanup, regardless of timestamp. *)
-  | ( ( Keeper_state_machine.Offline
-      | Keeper_state_machine.Running
-      | Keeper_state_machine.Failing
-      | Keeper_state_machine.Overflowed
-      | Keeper_state_machine.Compacting
-      | Keeper_state_machine.HandingOff
-      | Keeper_state_machine.Draining
-      | Keeper_state_machine.Paused
-      | Keeper_state_machine.Stopped
-      | Keeper_state_machine.Crashed
-      | Keeper_state_machine.Restarting
-      | Keeper_state_machine.Zombie )
-    , _ ) -> false
-;;
-
-(** Check if a paused keeper meta file on disk is stale enough to remove. *)
-let is_stale_paused_meta ~now ~paused_ttl_sec (meta : keeper_meta) =
-  if not meta.paused
-  then false
-  else (
-    let updated_ts =
-      Coord_resilience.Time.parse_iso8601_opt meta.updated_at |> Option.value ~default:0.0
-    in
-    updated_ts > 0.0 && now -. updated_ts >= paused_ttl_sec)
-;;
-
-let paused_meta_requires_reconcile_recovery (meta : keeper_meta) =
-  meta.paused
-  &&
-  match meta.runtime.last_blocker with
-  | Some info -> blocker_class_continue_gate info.klass
-  | None -> false
-;;
 
 let committed_tools_of_ambiguous_blocker (blocker : string) =
   let trimmed = String.trim blocker in
@@ -1018,14 +979,6 @@ let cleanup_dead_tombstone (ctx : _ context) (entry : Keeper_registry.registry_e
     new variant in keeper_registry forces a same-PR converter update via
     the source module's exhaustive-match check, instead of breaking main
     here on first build (the recurring P0 pattern from #10490 + #10574). *)
-let cohort_key_of_reason = Keeper_registry.failure_reason_cohort_key
-
-let stale_turn_timeout_cohort_key =
-  cohort_key_of_reason
-    (Some
-       (Keeper_registry.Stale_turn_timeout
-          (Keeper_registry.Idle_turn { stall_seconds = 0.0 })))
-;;
 
 (* #10887: persistent self-preservation lock.  Fleet log shows 125
    identical [ratio=1.00, cohort=stale_turn_timeout] events / 2 days
@@ -1076,12 +1029,6 @@ let reset_self_preservation_escape_state_for_test () =
   sp_escape_state.consecutive_suppressions <- 0
 ;;
 
-let active_supervision_keeper_count entries =
-  List_util.count_if
-    (fun (e : Keeper_registry.registry_entry) ->
-       e.phase = Keeper_state_machine.Running || e.phase = Keeper_state_machine.Crashed)
-    entries
-;;
 
 (** Self-preservation gate. Suppresses restarts when a dominant failure
     cohort exceeds ratio threshold AND minimum candidate count.

--- a/lib/keeper/keeper_supervisor_types.ml
+++ b/lib/keeper/keeper_supervisor_types.ml
@@ -105,11 +105,10 @@ let should_cleanup_dead ~now ~dead_ttl_sec (entry : Keeper_registry.registry_ent
 let is_stale_paused_meta ~now ~paused_ttl_sec (meta : keeper_meta) =
   if not meta.paused
   then false
-  else (
-    let updated_ts =
-      Coord_resilience.Time.parse_iso8601_opt meta.updated_at |> Option.value ~default:0.0
-    in
-    updated_ts > 0.0 && now -. updated_ts >= paused_ttl_sec)
+  else
+    match Coord_resilience.Time.parse_iso8601_opt meta.updated_at with
+    | Some updated_ts -> updated_ts > 0.0 && now -. updated_ts >= paused_ttl_sec
+    | None -> false
 ;;
 
 let paused_meta_requires_reconcile_recovery (meta : keeper_meta) =

--- a/lib/keeper/keeper_supervisor_types.ml
+++ b/lib/keeper/keeper_supervisor_types.ml
@@ -82,3 +82,56 @@ let persona_drift_log_level_for_missing_profile (meta : keeper_meta) =
     Persona_drift_warn
   | Ok _ | Error _ -> Persona_drift_error
 ;;
+
+let should_cleanup_dead ~now ~dead_ttl_sec (entry : Keeper_registry.registry_entry) =
+  match entry.phase, entry.dead_since_ts with
+  | Keeper_state_machine.Dead, Some dead_since -> now -. dead_since >= dead_ttl_sec
+  | Keeper_state_machine.Dead, None -> false
+  | ( ( Keeper_state_machine.Offline
+      | Keeper_state_machine.Running
+      | Keeper_state_machine.Failing
+      | Keeper_state_machine.Overflowed
+      | Keeper_state_machine.Compacting
+      | Keeper_state_machine.HandingOff
+      | Keeper_state_machine.Draining
+      | Keeper_state_machine.Paused
+      | Keeper_state_machine.Stopped
+      | Keeper_state_machine.Crashed
+      | Keeper_state_machine.Restarting
+      | Keeper_state_machine.Zombie )
+    , _ ) -> false
+;;
+
+let is_stale_paused_meta ~now ~paused_ttl_sec (meta : keeper_meta) =
+  if not meta.paused
+  then false
+  else (
+    let updated_ts =
+      Coord_resilience.Time.parse_iso8601_opt meta.updated_at |> Option.value ~default:0.0
+    in
+    updated_ts > 0.0 && now -. updated_ts >= paused_ttl_sec)
+;;
+
+let paused_meta_requires_reconcile_recovery (meta : keeper_meta) =
+  meta.paused
+  &&
+  match meta.runtime.last_blocker with
+  | Some info -> blocker_class_continue_gate info.klass
+  | None -> false
+;;
+
+let cohort_key_of_reason = Keeper_registry.failure_reason_cohort_key
+
+let stale_turn_timeout_cohort_key =
+  cohort_key_of_reason
+    (Some
+       (Keeper_registry.Stale_turn_timeout
+          (Keeper_registry.Idle_turn { stall_seconds = 0.0 })))
+;;
+
+let active_supervision_keeper_count entries =
+  List_util.count_if
+    (fun (e : Keeper_registry.registry_entry) ->
+       e.phase = Keeper_state_machine.Running || e.phase = Keeper_state_machine.Crashed)
+    entries
+;;

--- a/lib/keeper/keeper_supervisor_types.mli
+++ b/lib/keeper/keeper_supervisor_types.mli
@@ -48,3 +48,26 @@ val persona_drift_log_level_for_missing_profile :
 (** Classify a missing persona profile.  Keeper TOML with enough inline
     identity remains operational and is WARN; keepers without TOML/persona
     identity are ERROR. *)
+
+val should_cleanup_dead :
+  now:float -> dead_ttl_sec:float -> Keeper_registry.registry_entry -> bool
+(** True when a Dead tombstone has exceeded the configured TTL. *)
+
+val is_stale_paused_meta :
+  now:float -> paused_ttl_sec:float -> keeper_meta -> bool
+(** Check if a paused keeper meta file on disk is stale enough to remove. *)
+
+val paused_meta_requires_reconcile_recovery : keeper_meta -> bool
+(** Internal: predicate identifying paused metas whose last_blocker class
+    requires reconcile-recovery rather than straight resume. *)
+
+val cohort_key_of_reason : Keeper_registry.failure_reason option -> string
+(** Map a structured failure_reason to a cohort key for self-preservation grouping. *)
+
+val stale_turn_timeout_cohort_key : string
+(** Internal: pre-computed cohort key for [Stale_turn_timeout] used by the
+    self-preservation probe escape valve. *)
+
+val active_supervision_keeper_count :
+  Keeper_registry.registry_entry list -> int
+(** Count currently active keepers for self-preservation denominators. *)


### PR DESCRIPTION
## Summary
3번째 keeper_supervisor_types PR. 6 pure helpers + 1 constant 이동.

이동:
- `should_cleanup_dead` (20 LoC) — Dead tombstone TTL 판정
- `is_stale_paused_meta` (9 LoC) — paused meta 타임아웃 판정
- `paused_meta_requires_reconcile_recovery` (7 LoC) — blocker class 기반 reconcile 분기
- `cohort_key_of_reason` (1 LoC) — Keeper_registry alias
- `stale_turn_timeout_cohort_key` (6 LoC) — 사전 계산 상수
- `active_supervision_keeper_count` (6 LoC) — Running/Crashed count

내부 helpers (is_stale_paused_meta, paused_meta_requires_reconcile_recovery, stale_turn_timeout_cohort_key) mli 노출 — include 패턴.

## Cumulative keeper_supervisor reduction (3 PRs)
- ml: **2632 → 2502 LoC (-5%)**
- mli: **228 → 187 LoC (-18%)**

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues intra-library split series.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)