### PR TITLE
refactor(keeper): backoff/liveness helpers → keeper_supervisor_types (#4)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1200,15 +1200,6 @@ let apply_self_preservation ~keepers_dir ~total_keepers to_restart =
     to_restart)
 ;;
 
-let next_auto_resume_after_sec ~initial_sec ~max_sec previous =
-  if initial_sec <= 0.0
-  then None
-  else
-    Some
-      (match previous with
-       | None -> Float.min max_sec initial_sec
-       | Some prev -> Float.min max_sec (prev *. 2.0))
-;;
 
 (** #10765 Phase 2: persist [meta.paused = true] for a keeper whose stale
     watchdog detected a termination storm (window count >= threshold).  The
@@ -1997,28 +1988,6 @@ let get_or_create_recovery_state name =
       s)
 ;;
 
-let liveness_recovery_backoff attempt =
-  let base = Env_config.KeeperSupervisor.liveness_recovery_backoff_base_sec in
-  let max_delay = Env_config.KeeperSupervisor.liveness_recovery_backoff_max_sec in
-  Float.min max_delay (base *. Float.of_int (1 lsl min attempt 20))
-;;
-
-let should_attempt_liveness_recovery ~now (entry : Keeper_registry.registry_entry) : bool =
-  (* Only Dead keepers, not Zombie (terminal_failure_latched = structural) *)
-  if entry.phase <> Keeper_state_machine.Dead
-  then false (* Zombie timeout reached: structural terminal — skip *)
-  else if entry.conditions.zombie_timeout_reached
-  then false
-  else (
-    let min_dead_sec = Env_config.KeeperSupervisor.liveness_recovery_min_dead_sec in
-    (* Pattern-match dead_since_ts directly: collapsing None -> 0.0 via
-       Option.value created a strict-`>` guard that rejected legitimate
-       at:0.0 fixtures (the synthetic epoch used in tests like
-       liveness_recovery_2 — see #12826). *)
-    match entry.dead_since_ts with
-    | None -> false
-    | Some dead_since -> now -. dead_since >= min_dead_sec)
-;;
 
 type credential_recovery_outcome =
   | Credential_recovery_not_needed

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -67,15 +67,6 @@ val persona_profile_path_for_drift_check :
     [Keeper_supervisor.supervision_cohort] etc. unchanged. *)
 include module type of Keeper_supervisor_types
 
-val next_auto_resume_after_sec :
-  initial_sec:float -> max_sec:float -> float option -> float option
-(** Compute the next auto-resume backoff delay after an auto-pause.  [None]
-    means this is the first auto-pause; [Some sec] means the previous
-    backoff should double up to [max_sec].  [initial_sec <= 0] disables
-    auto-resume. *)
-
-val should_cleanup_dead : now:float -> dead_ttl_sec:float -> Keeper_registry.registry_entry -> bool
-(** True when a dead tombstone has exceeded the configured TTL. *)
 
 val cohort_key_of_reason : Keeper_registry.failure_reason option -> string
 (** Map a structured failure_reason to a cohort key for self-preservation grouping. *)
@@ -139,13 +130,6 @@ val credential_recovery_before_restart_for_test :
 (** Test hook for the credential self-heal step used before liveness recovery
     relaunches a [credential_archived] keeper. *)
 
-val liveness_recovery_backoff : int -> float
-(** Compute the exponential backoff delay for liveness recovery attempt [n]. *)
-
-val should_attempt_liveness_recovery :
-  now:float -> Keeper_registry.registry_entry -> bool
-(** Pure predicate: true when a Dead keeper passes the eligibility gate for
-    a liveness recovery attempt.  Exposed for tests. *)
 
 (** {1 Alive-but-stuck detector (#12838)} *)
 

--- a/lib/keeper/keeper_supervisor_types.ml
+++ b/lib/keeper/keeper_supervisor_types.ml
@@ -134,3 +134,31 @@ let active_supervision_keeper_count entries =
        e.phase = Keeper_state_machine.Running || e.phase = Keeper_state_machine.Crashed)
     entries
 ;;
+
+let next_auto_resume_after_sec ~initial_sec ~max_sec previous =
+  if initial_sec <= 0.0
+  then None
+  else
+    Some
+      (match previous with
+       | None -> Float.min max_sec initial_sec
+       | Some prev -> Float.min max_sec (prev *. 2.0))
+;;
+
+let liveness_recovery_backoff attempt =
+  let base = Env_config.KeeperSupervisor.liveness_recovery_backoff_base_sec in
+  let max_delay = Env_config.KeeperSupervisor.liveness_recovery_backoff_max_sec in
+  Float.min max_delay (base *. Float.of_int (1 lsl min attempt 20))
+;;
+
+let should_attempt_liveness_recovery ~now (entry : Keeper_registry.registry_entry) : bool =
+  if entry.phase <> Keeper_state_machine.Dead
+  then false
+  else if entry.conditions.zombie_timeout_reached
+  then false
+  else (
+    let min_dead_sec = Env_config.KeeperSupervisor.liveness_recovery_min_dead_sec in
+    match entry.dead_since_ts with
+    | None -> false
+    | Some dead_since -> now -. dead_since >= min_dead_sec)
+;;

--- a/lib/keeper/keeper_supervisor_types.mli
+++ b/lib/keeper/keeper_supervisor_types.mli
@@ -71,3 +71,18 @@ val stale_turn_timeout_cohort_key : string
 val active_supervision_keeper_count :
   Keeper_registry.registry_entry list -> int
 (** Count currently active keepers for self-preservation denominators. *)
+
+val next_auto_resume_after_sec :
+  initial_sec:float -> max_sec:float -> float option -> float option
+(** Compute the next auto-resume backoff delay after an auto-pause.  [None]
+    means this is the first auto-pause; [Some sec] means the previous
+    backoff should double up to [max_sec].  [initial_sec <= 0] disables
+    auto-resume. *)
+
+val liveness_recovery_backoff : int -> float
+(** Compute the exponential backoff delay for liveness recovery attempt [n]. *)
+
+val should_attempt_liveness_recovery :
+  now:float -> Keeper_registry.registry_entry -> bool
+(** Pure predicate: true when a Dead keeper passes the eligibility gate for
+    a liveness recovery attempt.  Exposed for tests. *)


### PR DESCRIPTION
## Summary
4번째 keeper_supervisor_types PR. 3 pure backoff/liveness helpers 이동.

- `next_auto_resume_after_sec` (9 LoC) — auto-pause backoff doubling
- `liveness_recovery_backoff` (5 LoC) — Dead keeper 지수 backoff
- `should_attempt_liveness_recovery` (15 LoC) — Dead-eligibility predicate

모두 pure. Env_config.KeeperSupervisor 의존 (cycle-free).

## Cumulative keeper_supervisor reduction (4 PRs)
- ml: **2632 → 2473 LoC (-6%)**
- mli: **228 → 175 LoC (-23%)**

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues intra-library split series.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)