### PR TITLE
refactor(keeper): alive_but_stuck detector → keeper_supervisor_types (#5)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -2221,36 +2221,6 @@ let liveness_recovery_scan (ctx : _ context) =
     production sample) without a separate code path.
 
     Returns [None] when not stuck.  Pure: no I/O, no global state. *)
-let detect_alive_but_stuck
-      ~now
-      ~stall_multiplier
-      ~stall_floor_sec
-      (entry : Keeper_registry.registry_entry)
-  : float option
-  =
-  let meta = entry.meta in
-  if meta.paused
-  then None
-  else if entry.phase <> Keeper_state_machine.Running
-  then None
-  else if meta.runtime.autonomous_turn_count <= 0
-  then
-    (* Brand-new keeper: not stuck, just hasn't started. *)
-    None
-  else (
-    let cooldown_sec = float_of_int meta.proactive.cooldown_sec in
-    let stall_threshold =
-      Float.max stall_floor_sec (cooldown_sec *. float_of_int stall_multiplier)
-    in
-    let last_proactive_ts = meta.runtime.proactive_rt.last_ts in
-    let reference_ts =
-      if last_proactive_ts > 0.0
-      then Float.max last_proactive_ts entry.started_at
-      else entry.started_at
-    in
-    let elapsed = now -. reference_ts in
-    if elapsed > stall_threshold then Some elapsed else None)
-;;
 
 (* Per-keeper dedup table for [alive_but_stuck_scan].  Bounds counter
    emission to one increment per [alive_but_stuck_dedup_ttl_sec] per
@@ -2268,15 +2238,6 @@ let alive_but_stuck_should_emit ~now ~dedup_ttl_sec name =
       true)
 ;;
 
-let alive_but_stuck_threshold
-      ~stall_multiplier
-      ~stall_floor_sec
-      (entry : Keeper_registry.registry_entry)
-  =
-  Float.max
-    stall_floor_sec
-    (float_of_int entry.meta.proactive.cooldown_sec *. float_of_int stall_multiplier)
-;;
 
 let set_alive_but_stuck_gauges
       ~(entry : Keeper_registry.registry_entry)

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -133,20 +133,8 @@ val credential_recovery_before_restart_for_test :
 
 (** {1 Alive-but-stuck detector (#12838)} *)
 
-val detect_alive_but_stuck :
-  now:float ->
-  stall_multiplier:int ->
-  stall_floor_sec:float ->
-  Keeper_registry.registry_entry ->
-  float option
-(** Pure detection: returns [Some elapsed_sec] when a non-Dead, non-paused
-    keeper has gone longer than
-    [max(stall_floor_sec, stall_multiplier * proactive.cooldown_sec)]
-    without a proactive turn while autonomous turns kept advancing.
-    Reference timestamp is the newer of [proactive_rt.last_ts] and
-    [entry.started_at] if proactive has fired, else [entry.started_at]
-    (covers the never-started case).  Returns [None] otherwise.  Exposed
-    for tests. *)
+(** detect_alive_but_stuck moved to Keeper_supervisor_types (intra-library
+    file split, 2026-05-16). Re-exported via include above. *)
 
 val alive_but_stuck_scan : 'a context -> unit
 (** Scan all keepers in [Keeper_registry].  For each keeper detected as

--- a/lib/keeper/keeper_supervisor_types.ml
+++ b/lib/keeper/keeper_supervisor_types.ml
@@ -162,3 +162,42 @@ let should_attempt_liveness_recovery ~now (entry : Keeper_registry.registry_entr
     | None -> false
     | Some dead_since -> now -. dead_since >= min_dead_sec)
 ;;
+
+let detect_alive_but_stuck
+      ~now
+      ~stall_multiplier
+      ~stall_floor_sec
+      (entry : Keeper_registry.registry_entry)
+  : float option
+  =
+  let meta = entry.meta in
+  if meta.paused
+  then None
+  else if entry.phase <> Keeper_state_machine.Running
+  then None
+  else if meta.runtime.autonomous_turn_count <= 0
+  then None
+  else (
+    let cooldown_sec = float_of_int meta.proactive.cooldown_sec in
+    let stall_threshold =
+      Float.max stall_floor_sec (cooldown_sec *. float_of_int stall_multiplier)
+    in
+    let last_proactive_ts = meta.runtime.proactive_rt.last_ts in
+    let reference_ts =
+      if last_proactive_ts > 0.0
+      then Float.max last_proactive_ts entry.started_at
+      else entry.started_at
+    in
+    let elapsed = now -. reference_ts in
+    if elapsed > stall_threshold then Some elapsed else None)
+;;
+
+let alive_but_stuck_threshold
+      ~stall_multiplier
+      ~stall_floor_sec
+      (entry : Keeper_registry.registry_entry)
+  =
+  Float.max
+    stall_floor_sec
+    (float_of_int entry.meta.proactive.cooldown_sec *. float_of_int stall_multiplier)
+;;

--- a/lib/keeper/keeper_supervisor_types.mli
+++ b/lib/keeper/keeper_supervisor_types.mli
@@ -86,3 +86,19 @@ val should_attempt_liveness_recovery :
   now:float -> Keeper_registry.registry_entry -> bool
 (** Pure predicate: true when a Dead keeper passes the eligibility gate for
     a liveness recovery attempt.  Exposed for tests. *)
+
+val detect_alive_but_stuck :
+  now:float ->
+  stall_multiplier:int ->
+  stall_floor_sec:float ->
+  Keeper_registry.registry_entry ->
+  float option
+(** Pure detection: returns [Some elapsed_sec] when a Running keeper has
+    exceeded its alive-but-stuck threshold. *)
+
+val alive_but_stuck_threshold :
+  stall_multiplier:int ->
+  stall_floor_sec:float ->
+  Keeper_registry.registry_entry ->
+  float
+(** Pure threshold computation for alive-but-stuck detection. *)


### PR DESCRIPTION
## Summary
5번째 keeper_supervisor_types PR. 2 pure detection helpers 이동.

- `detect_alive_but_stuck` (30 LoC) — Running keeper stall detection
- `alive_but_stuck_threshold` (9 LoC) — pure threshold computation

Side-effecting parts (Prometheus, Hashtbl dedup, Mutex) keeper_supervisor.ml 잔존.

## Cumulative keeper_supervisor reduction (5 PRs)
- ml: **2632 → 2433 LoC (-8%)**
- mli: **228 → 167 LoC (-27%)**

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues intra-library split series.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)