### PR TITLE
refactor(keeper): pr_action metric event types → keeper_hooks_oas_types (#3)

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -558,67 +558,12 @@ let record_usage_anomaly_metrics ~keeper_name ~model usage_trust =
            ())
       reasons
 
-type cost_status =
-  | Cost_reported
-  | Cost_known_free
-  | Cost_no_tokens
-  | Cost_usage_missing
-  | Cost_usage_untrusted
-  | Cost_runtime_unknown
-  | Cost_oas_cost_unreported
-
-let cost_label_reported = "reported"
-let cost_label_known_free = "known_free"
-let cost_label_no_tokens = "no_tokens"
-let cost_label_usage_missing = "usage_missing"
-let cost_label_usage_untrusted = "usage_untrusted"
-let cost_label_runtime_unknown = "runtime_unknown"
-let cost_label_oas_cost_unreported = "oas_cost_unreported"
-
-let cost_reason_reported = "oas_reported_cost"
-let cost_reason_known_free = "known_structurally_unmetered_or_zero_price"
-let cost_reason_no_tokens = "no_billable_tokens"
-let cost_reason_usage_missing = "usage_missing"
-let cost_reason_usage_untrusted = "usage_untrusted"
-let cost_reason_runtime_unknown = "runtime_unknown"
-let cost_reason_oas_cost_unreported = "oas_cost_unreported"
+(** cost_status cluster moved to Keeper_hooks_oas_types
+    (intra-library file split, 2026-05-16). *)
+include Keeper_hooks_oas_types
 
 let cost_source_unmetered_provider = "unmetered_provider"
 let cost_source_computed = "computed"
-
-let cost_status_to_string = function
-  | Cost_reported -> cost_label_reported
-  | Cost_known_free -> cost_label_known_free
-  | Cost_no_tokens -> cost_label_no_tokens
-  | Cost_usage_missing -> cost_label_usage_missing
-  | Cost_usage_untrusted -> cost_label_usage_untrusted
-  | Cost_runtime_unknown -> cost_label_runtime_unknown
-  | Cost_oas_cost_unreported -> cost_label_oas_cost_unreported
-
-let cost_status_reason = function
-  | Cost_reported -> cost_reason_reported
-  | Cost_known_free -> cost_reason_known_free
-  | Cost_no_tokens -> cost_reason_no_tokens
-  | Cost_usage_missing -> cost_reason_usage_missing
-  | Cost_usage_untrusted -> cost_reason_usage_untrusted
-  | Cost_runtime_unknown -> cost_reason_runtime_unknown
-  | Cost_oas_cost_unreported -> cost_reason_oas_cost_unreported
-
-let cost_status_for_event
-    ~(runtime_unknown : bool)
-    ~(runtime_unmetered : bool)
-    ~(usage_missing : bool)
-    ~(usage_trusted : bool)
-    ~(input_tokens : int)
-    ~(output_tokens : int)
-    ~(cost_usd : float) =
-  if usage_missing then Cost_usage_missing
-  else if not usage_trusted then Cost_usage_untrusted
-  else if cost_usd > 0.0 then Cost_reported
-  else if input_tokens <= 0 && output_tokens <= 0 then Cost_no_tokens
-  else if runtime_unmetered then Cost_known_free
-  else if runtime_unknown then Cost_runtime_unknown
-  else Cost_oas_cost_unreported
 
 let oas_reported_cost (usage : Agent_sdk.Types.api_usage) : float =
   match usage.cost_usd with

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -492,40 +492,6 @@ let context_max_of_telemetry
   | Some { effective_context_window = Some n; _ } when n > 0 -> n
   | _ -> default_context_max
 
-type thinking_log_summary =
-  { thinking_present : bool
-  ; thinking_blocks : int
-  ; thinking_chars : int
-  ; redacted_thinking_blocks : int
-  ; thinking_kind : string
-  }
-
-let summarize_thinking_blocks content =
-  let thinking_blocks = ref 0 in
-  let thinking_chars = ref 0 in
-  let redacted_thinking_blocks = ref 0 in
-  List.iter
-    (function
-      | Agent_sdk.Types.Thinking { content; _ } ->
-          incr thinking_blocks;
-          thinking_chars := !thinking_chars + String.length content
-      | Agent_sdk.Types.RedactedThinking _ -> incr redacted_thinking_blocks
-      | _ -> ())
-    content;
-  let thinking_kind =
-    match !thinking_blocks > 0, !redacted_thinking_blocks > 0 with
-    | false, false -> "none"
-    | true, false -> "thinking"
-    | false, true -> "redacted"
-    | true, true -> "mixed"
-  in
-  { thinking_present = !thinking_blocks > 0 || !redacted_thinking_blocks > 0
-  ; thinking_blocks = !thinking_blocks
-  ; thinking_chars = !thinking_chars
-  ; redacted_thinking_blocks = !redacted_thinking_blocks
-  ; thinking_kind
-  }
-
 let classify_usage_trust ?usage ~model ~telemetry () =
   let _ = model in
   let usage_reported, usage =

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -1069,31 +1069,9 @@ let recent_tool_streak_count ?(within_sec = 900.0) ~(tool_name : string)
   in
   loop 0 (List.rev entries)
 
-type pr_review_action_metric_event = {
-  action : string;
-  pr_number : int option;
-  comment_id : int option;
-  success : bool;
-  route_via : string option;
-  credential : Yojson.Safe.t option;
-  identity_attestation : Yojson.Safe.t option;
-}
-
-type pr_work_action_metric_event = {
-  work_action : string;
-  work_source : string;
-  work_ref : string option;
-  pr_url : string option;
-  command : string option;
-  success : bool;
-  route_via : string option;
-}
-
-let normalize_pr_review_action raw =
-  let trimmed = String.trim raw |> String.uppercase_ascii in
-  match trimmed with
-  | "COMMENT" | "APPROVE" | "REQUEST_CHANGES" | "REPLY" -> Some trimmed
-  | _ -> None
+(* pr_review_action_metric_event / pr_work_action_metric_event /
+   normalize_pr_review_action moved to Keeper_hooks_oas_types
+   (intra-library file split, 2026-05-16). *)
 
 let json_int_opt key json = Safe_ops.json_int_opt key json
 

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -119,32 +119,13 @@ val record_usage_anomaly_metrics :
   keeper_name:string -> model:string -> Keeper_usage_trust.t -> unit
 (** Emit Prometheus counters for each anomaly category in the verdict. *)
 
-(** {1 Cost ledger} *)
+(** {1 Cost ledger}
 
-type cost_status =
-  | Cost_reported         (** Cost trusted because OAS reported it. *)
-  | Cost_known_free       (** Runtime is structurally unmetered. *)
-  | Cost_no_tokens        (** Usage carried zero tokens and no positive cost. *)
-  | Cost_usage_missing    (** OAS returned no usage record. *)
-  | Cost_usage_untrusted  (** Usage failed [classify_usage_trust]. *)
-  | Cost_runtime_unknown  (** Runtime owner could not be classified. *)
-  | Cost_oas_cost_unreported
-      (** OAS returned trusted billable usage but did not report cost. *)
-(** Per-event cost-ledger verdict. *)
-
-val cost_status_to_string : cost_status -> string
-(** Stable wire string for [cost_status]. *)
-
-val cost_status_reason : cost_status -> string
-(** Human-readable explanation for an operator log. *)
-
-val cost_status_for_event :
-  runtime_unknown:bool ->
-  runtime_unmetered:bool ->
-  usage_missing:bool ->
-  usage_trusted:bool ->
-  input_tokens:int -> output_tokens:int -> cost_usd:float -> cost_status
-(** Pure decision: which [cost_status] applies given the inputs above? *)
+    The cost_status ADT and its pure converters live in
+    Keeper_hooks_oas_types (intra-library file split, 2026-05-16).
+    Re-exported here so existing callers continue to use
+    [Keeper_hooks_oas.cost_status] etc. unchanged. *)
+include module type of Keeper_hooks_oas_types
 
 (** {1 Tool execution summary} *)
 

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -220,27 +220,8 @@ val recent_tool_streak_count :
   ?within_sec:float -> tool_name:string -> Yojson.Safe.t list -> int
 (** Count consecutive recent calls of [tool_name] in trajectory events. *)
 
-type pr_review_action_metric_event = {
-  action : string;
-  pr_number : int option;
-  comment_id : int option;
-  success : bool;
-  route_via : string option;
-  credential : Yojson.Safe.t option;
-  identity_attestation : Yojson.Safe.t option;
-}
-(** Parsed PR-review action telemetry derived from keeper tool I/O. *)
-
-type pr_work_action_metric_event = {
-  work_action : string;
-  work_source : string;
-  work_ref : string option;
-  pr_url : string option;
-  command : string option;
-  success : bool;
-  route_via : string option;
-}
-(** Parsed PR create/push/commit/add telemetry derived from keeper tool I/O. *)
+(** PR-review / PR-work metric event types live in Keeper_hooks_oas_types
+    (intra-library file split, 2026-05-16). Re-exported via include below. *)
 
 (** {1 Hook factory} *)
 

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -74,21 +74,8 @@ val context_max_of_telemetry :
   Agent_sdk.Types.inference_telemetry option -> int
 (** Provider-reported context window max, or [0] when telemetry omits it. *)
 
-type thinking_log_summary =
-  { thinking_present : bool
-  ; thinking_blocks : int
-  ; thinking_chars : int
-  ; redacted_thinking_blocks : int
-  ; thinking_kind : string
-  }
-(** Redacted metadata for provider thinking blocks.  [thinking_chars] counts
-    only non-redacted [Thinking.content] bytes; raw content is never included
-    in this summary. *)
-
-val summarize_thinking_blocks :
-  Agent_sdk.Types.content_block list -> thinking_log_summary
-(** Summarize thinking block presence for logs/metrics without exposing raw
-    thinking content. *)
+(** thinking_log_summary type + summarize_thinking_blocks moved to
+    Keeper_hooks_oas_types (intra-library file split, 2026-05-16). *)
 
 val redact_inference_telemetry_json : Yojson.Safe.t -> Yojson.Safe.t
 (** Redact provider/model identity fields from OAS inference telemetry while

--- a/lib/keeper/keeper_hooks_oas_types.ml
+++ b/lib/keeper/keeper_hooks_oas_types.ml
@@ -95,3 +95,29 @@ let summarize_thinking_blocks content =
   ; redacted_thinking_blocks = !redacted_thinking_blocks
   ; thinking_kind
   }
+
+type pr_review_action_metric_event = {
+  action : string;
+  pr_number : int option;
+  comment_id : int option;
+  success : bool;
+  route_via : string option;
+  credential : Yojson.Safe.t option;
+  identity_attestation : Yojson.Safe.t option;
+}
+
+type pr_work_action_metric_event = {
+  work_action : string;
+  work_source : string;
+  work_ref : string option;
+  pr_url : string option;
+  command : string option;
+  success : bool;
+  route_via : string option;
+}
+
+let normalize_pr_review_action raw =
+  let trimmed = String.trim raw |> String.uppercase_ascii in
+  match trimmed with
+  | "COMMENT" | "APPROVE" | "REQUEST_CHANGES" | "REPLY" -> Some trimmed
+  | _ -> None

--- a/lib/keeper/keeper_hooks_oas_types.ml
+++ b/lib/keeper/keeper_hooks_oas_types.ml
@@ -61,3 +61,37 @@ let cost_status_for_event
   else if runtime_unmetered then Cost_known_free
   else if runtime_unknown then Cost_runtime_unknown
   else Cost_oas_cost_unreported
+
+type thinking_log_summary =
+  { thinking_present : bool
+  ; thinking_blocks : int
+  ; thinking_chars : int
+  ; redacted_thinking_blocks : int
+  ; thinking_kind : string
+  }
+
+let summarize_thinking_blocks content =
+  let thinking_blocks = ref 0 in
+  let thinking_chars = ref 0 in
+  let redacted_thinking_blocks = ref 0 in
+  List.iter
+    (function
+      | Agent_sdk.Types.Thinking { content; _ } ->
+          incr thinking_blocks;
+          thinking_chars := !thinking_chars + String.length content
+      | Agent_sdk.Types.RedactedThinking _ -> incr redacted_thinking_blocks
+      | _ -> ())
+    content;
+  let thinking_kind =
+    match !thinking_blocks > 0, !redacted_thinking_blocks > 0 with
+    | false, false -> "none"
+    | true, false -> "thinking"
+    | false, true -> "redacted"
+    | true, true -> "mixed"
+  in
+  { thinking_present = !thinking_blocks > 0 || !redacted_thinking_blocks > 0
+  ; thinking_blocks = !thinking_blocks
+  ; thinking_chars = !thinking_chars
+  ; redacted_thinking_blocks = !redacted_thinking_blocks
+  ; thinking_kind
+  }

--- a/lib/keeper/keeper_hooks_oas_types.ml
+++ b/lib/keeper/keeper_hooks_oas_types.ml
@@ -1,0 +1,63 @@
+(** Keeper_hooks_oas_types — pure cost_status verdict ADT + converters
+    extracted from Keeper_hooks_oas (2762 LoC godfile).
+
+    See keeper_hooks_oas_types.mli for rationale and contract. *)
+
+type cost_status =
+  | Cost_reported
+  | Cost_known_free
+  | Cost_no_tokens
+  | Cost_usage_missing
+  | Cost_usage_untrusted
+  | Cost_runtime_unknown
+  | Cost_oas_cost_unreported
+
+let cost_label_reported = "reported"
+let cost_label_known_free = "known_free"
+let cost_label_no_tokens = "no_tokens"
+let cost_label_usage_missing = "usage_missing"
+let cost_label_usage_untrusted = "usage_untrusted"
+let cost_label_runtime_unknown = "runtime_unknown"
+let cost_label_oas_cost_unreported = "oas_cost_unreported"
+
+let cost_reason_reported = "oas_reported_cost"
+let cost_reason_known_free = "known_structurally_unmetered_or_zero_price"
+let cost_reason_no_tokens = "no_billable_tokens"
+let cost_reason_usage_missing = "usage_missing"
+let cost_reason_usage_untrusted = "usage_untrusted"
+let cost_reason_runtime_unknown = "runtime_unknown"
+let cost_reason_oas_cost_unreported = "oas_cost_unreported"
+
+let cost_status_to_string = function
+  | Cost_reported -> cost_label_reported
+  | Cost_known_free -> cost_label_known_free
+  | Cost_no_tokens -> cost_label_no_tokens
+  | Cost_usage_missing -> cost_label_usage_missing
+  | Cost_usage_untrusted -> cost_label_usage_untrusted
+  | Cost_runtime_unknown -> cost_label_runtime_unknown
+  | Cost_oas_cost_unreported -> cost_label_oas_cost_unreported
+
+let cost_status_reason = function
+  | Cost_reported -> cost_reason_reported
+  | Cost_known_free -> cost_reason_known_free
+  | Cost_no_tokens -> cost_reason_no_tokens
+  | Cost_usage_missing -> cost_reason_usage_missing
+  | Cost_usage_untrusted -> cost_reason_usage_untrusted
+  | Cost_runtime_unknown -> cost_reason_runtime_unknown
+  | Cost_oas_cost_unreported -> cost_reason_oas_cost_unreported
+
+let cost_status_for_event
+    ~(runtime_unknown : bool)
+    ~(runtime_unmetered : bool)
+    ~(usage_missing : bool)
+    ~(usage_trusted : bool)
+    ~(input_tokens : int)
+    ~(output_tokens : int)
+    ~(cost_usd : float) =
+  if usage_missing then Cost_usage_missing
+  else if not usage_trusted then Cost_usage_untrusted
+  else if cost_usd > 0.0 then Cost_reported
+  else if input_tokens <= 0 && output_tokens <= 0 then Cost_no_tokens
+  else if runtime_unmetered then Cost_known_free
+  else if runtime_unknown then Cost_runtime_unknown
+  else Cost_oas_cost_unreported

--- a/lib/keeper/keeper_hooks_oas_types.mli
+++ b/lib/keeper/keeper_hooks_oas_types.mli
@@ -37,3 +37,19 @@ val cost_status_for_event :
 val cost_label_usage_missing : string
 val cost_label_usage_untrusted : string
 val cost_label_oas_cost_unreported : string
+
+type thinking_log_summary =
+  { thinking_present : bool
+  ; thinking_blocks : int
+  ; thinking_chars : int
+  ; redacted_thinking_blocks : int
+  ; thinking_kind : string
+  }
+(** Redacted metadata for provider thinking blocks.  [thinking_chars] counts
+    only non-redacted [Thinking.content] bytes; raw content is never included
+    in this summary. *)
+
+val summarize_thinking_blocks :
+  Agent_sdk.Types.content_block list -> thinking_log_summary
+(** Summarize thinking block presence for logs/metrics without exposing raw
+    thinking content. *)

--- a/lib/keeper/keeper_hooks_oas_types.mli
+++ b/lib/keeper/keeper_hooks_oas_types.mli
@@ -1,0 +1,39 @@
+(** Keeper_hooks_oas_types — pure type definitions and helpers extracted
+    from Keeper_hooks_oas (2762 LoC godfile).
+
+    Holds the cost_status verdict ADT + its pure label/reason converters.
+    State-touching keeper_hooks_oas operations remain in Keeper_hooks_oas.
+    Re-included by Keeper_hooks_oas so existing callers continue to use
+    [Keeper_hooks_oas.cost_status] etc. unchanged. *)
+
+type cost_status =
+  | Cost_reported         (** Cost trusted because OAS reported it. *)
+  | Cost_known_free       (** Runtime is structurally unmetered. *)
+  | Cost_no_tokens        (** Usage carried zero tokens and no positive cost. *)
+  | Cost_usage_missing    (** OAS returned no usage record. *)
+  | Cost_usage_untrusted  (** Usage failed [classify_usage_trust]. *)
+  | Cost_runtime_unknown  (** Runtime owner could not be classified. *)
+  | Cost_oas_cost_unreported
+      (** OAS returned trusted billable usage but did not report cost. *)
+(** Per-event cost-ledger verdict. *)
+
+val cost_status_to_string : cost_status -> string
+(** Stable wire string for [cost_status]. *)
+
+val cost_status_reason : cost_status -> string
+(** Human-readable explanation for an operator log. *)
+
+val cost_status_for_event :
+  runtime_unknown:bool ->
+  runtime_unmetered:bool ->
+  usage_missing:bool ->
+  usage_trusted:bool ->
+  input_tokens:int -> output_tokens:int -> cost_usd:float -> cost_status
+(** Pure decision: which [cost_status] applies given the inputs above? *)
+
+(** Internal: cost-status wire labels exposed for keeper_hooks_oas's
+    [classify_cost_usd_source] which composes a string verdict separately
+    from [cost_status_to_string]. *)
+val cost_label_usage_missing : string
+val cost_label_usage_untrusted : string
+val cost_label_oas_cost_unreported : string

--- a/lib/keeper/keeper_hooks_oas_types.mli
+++ b/lib/keeper/keeper_hooks_oas_types.mli
@@ -53,3 +53,29 @@ val summarize_thinking_blocks :
   Agent_sdk.Types.content_block list -> thinking_log_summary
 (** Summarize thinking block presence for logs/metrics without exposing raw
     thinking content. *)
+
+type pr_review_action_metric_event = {
+  action : string;
+  pr_number : int option;
+  comment_id : int option;
+  success : bool;
+  route_via : string option;
+  credential : Yojson.Safe.t option;
+  identity_attestation : Yojson.Safe.t option;
+}
+(** Parsed PR-review action telemetry derived from keeper tool I/O. *)
+
+type pr_work_action_metric_event = {
+  work_action : string;
+  work_source : string;
+  work_ref : string option;
+  pr_url : string option;
+  command : string option;
+  success : bool;
+  route_via : string option;
+}
+(** Parsed PR create/push/commit/add telemetry derived from keeper tool I/O. *)
+
+val normalize_pr_review_action : string -> string option
+(** Internal: PR-review action label canonicalizer (COMMENT / APPROVE /
+    REQUEST_CHANGES / REPLY). Exposed for keeper_hooks_oas.ml's parsers. *)


### PR DESCRIPTION
## Summary
3번째 keeper_hooks_oas_types PR. 2 record types + 1 pure normalizer.

- type `pr_review_action_metric_event` (7 fields)
- type `pr_work_action_metric_event` (7 fields)
- `normalize_pr_review_action` — PR-review label canonicalizer

## Cumulative keeper_hooks_oas reduction (3 PRs)
- ml: **2762 → 2645 LoC (-4%)**
- mli: **321 → 268 LoC (-17%)**

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues intra-library split series.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)