### PR TITLE
refactor(keeper): tool_execution_summary + runtime_lane → keeper_hooks_oas_types (#5)

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -512,20 +512,8 @@ let oas_reported_cost (usage : Agent_sdk.Types.api_usage) : float =
   | Some _ -> 0.0
   | None -> 0.0
 
-type tool_execution_summary =
-  { tool_name : string
-  ; provider : string
-  ; outcome : string
-  ; duration_ms : float
-  }
-
-let tool_execution_summary ~tool_name ~model ~success ~duration_ms :
-    tool_execution_summary =
-  { tool_name
-  ; provider = runtime_lane_of_model model
-  ; outcome = if success then outcome_ok else outcome_error
-  ; duration_ms = max 0.0 duration_ms
-  }
+(* type tool_execution_summary + builder moved to Keeper_hooks_oas_types
+   (intra-library file split, 2026-05-16). *)
 
 let record_keeper_tool_duration_metric
     ~(keeper_name : string)

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -102,20 +102,10 @@ val record_usage_anomaly_metrics :
     [Keeper_hooks_oas.cost_status] etc. unchanged. *)
 include module type of Keeper_hooks_oas_types
 
-(** {1 Tool execution summary} *)
+(** {1 Tool execution summary}
 
-type tool_execution_summary = {
-  tool_name : string;
-  provider : string;
-  outcome : string;
-  duration_ms : float;
-}
-(** Per-tool-call record persisted in the keeper's trajectory. *)
-
-val tool_execution_summary :
-  tool_name:string ->
-  model:string -> success:bool -> duration_ms:float -> tool_execution_summary
-(** Build a [tool_execution_summary] from raw turn fields. *)
+    tool_execution_summary type + builder live in Keeper_hooks_oas_types
+    (intra-library file split, 2026-05-16). Re-exported via include. *)
 
 val record_keeper_tool_duration_metric :
   keeper_name:string -> tool_execution_summary -> unit

--- a/lib/keeper/keeper_hooks_oas_types.ml
+++ b/lib/keeper/keeper_hooks_oas_types.ml
@@ -3,6 +3,15 @@
 
     See keeper_hooks_oas_types.mli for rationale and contract. *)
 
+let outcome_ok = "ok"
+let outcome_error = "error"
+
+(** Keeper-facing telemetry uses a neutral runtime lane.  Concrete
+    provider/model identity belongs to OAS and lower-level cascade adapters. *)
+let runtime_lane_label = "runtime"
+
+let runtime_lane_of_model (_model : string) : string = runtime_lane_label
+
 type cost_status =
   | Cost_reported
   | Cost_known_free
@@ -160,3 +169,18 @@ let normalize_pr_review_action raw =
   match trimmed with
   | "COMMENT" | "APPROVE" | "REQUEST_CHANGES" | "REPLY" -> Some trimmed
   | _ -> None
+
+type tool_execution_summary =
+  { tool_name : string
+  ; provider : string
+  ; outcome : string
+  ; duration_ms : float
+  }
+
+let tool_execution_summary ~tool_name ~model ~success ~duration_ms :
+    tool_execution_summary =
+  { tool_name
+  ; provider = runtime_lane_of_model model
+  ; outcome = if success then outcome_ok else outcome_error
+  ; duration_ms = max 0.0 duration_ms
+  }

--- a/lib/keeper/keeper_hooks_oas_types.mli
+++ b/lib/keeper/keeper_hooks_oas_types.mli
@@ -92,3 +92,21 @@ type pr_work_action_metric_event = {
 val normalize_pr_review_action : string -> string option
 (** Internal: PR-review action label canonicalizer (COMMENT / APPROVE /
     REQUEST_CHANGES / REPLY). Exposed for keeper_hooks_oas.ml's parsers. *)
+
+val runtime_lane_label : string
+(** The neutral runtime lane label used by keeper telemetry where concrete
+    provider/model identity should not surface (consumed by many call sites
+    in keeper_hooks_oas.ml). *)
+
+type tool_execution_summary = {
+  tool_name : string;
+  provider : string;
+  outcome : string;
+  duration_ms : float;
+}
+(** Per-tool-call record persisted in the keeper's trajectory. *)
+
+val tool_execution_summary :
+  tool_name:string ->
+  model:string -> success:bool -> duration_ms:float -> tool_execution_summary
+(** Build a [tool_execution_summary] from raw turn fields. *)


### PR DESCRIPTION
## Summary
5번째 keeper_hooks_oas_types PR. tool_execution_summary 클러스터 + runtime_lane 상수 이동.

이동:
- outcome_ok, outcome_error (private string)
- runtime_lane_label (public, ~10 call sites in keeper_hooks_oas.ml)
- runtime_lane_of_model (private projection)
- type tool_execution_summary (public record)
- tool_execution_summary builder (public)

## Cumulative keeper_hooks_oas reduction (5 PRs)
- ml: **2762 → 2592 LoC (-6%)**
- mli: **321 → 234 LoC (-27%)**

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues intra-library split series.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)