### PR TITLE
refactor(keeper): usage/board/stop_reason helpers → keeper_hooks_oas_types (#6)

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -132,26 +132,9 @@ let runtime_lane_of_model (_model : string) : string = runtime_lane_label
 (* Inference telemetry redaction moved to Keeper_hooks_oas_types
    (intra-library file split, 2026-05-16). *)
 
-let usage_has_tokens (usage : Agent_sdk.Types.api_usage) =
-  usage.input_tokens > 0
-  || usage.output_tokens > 0
-  || usage.cache_creation_input_tokens > 0
-  || usage.cache_read_input_tokens > 0
-
-let is_keeper_board_write_tool_name tool_name =
-  match Tool_name.Keeper.of_string tool_name with
-  | Some tool -> Tool_name.Keeper.is_board_write tool
-  | None -> false
-
-let current_keeper_model meta =
-  let _ = meta in
-  runtime_lane_label
-
-let stop_reason_label_end_turn = "end_turn"
-let stop_reason_label_tool_use = "tool_use"
-let stop_reason_label_max_tokens = "max_tokens"
-let stop_reason_label_stop_sequence = "stop_sequence"
-let stop_reason_label_unknown = "unknown"
+(* usage_has_tokens / is_keeper_board_write_tool_name / current_keeper_model
+   / stop_reason_label_* moved to Keeper_hooks_oas_types (intra-library
+   file split, 2026-05-16). *)
 
 let stop_reason_to_label = function
   | Agent_sdk.Types.EndTurn -> stop_reason_label_end_turn
@@ -353,14 +336,7 @@ let alias_response_model_metric =
 let empty_response_content_metric =
   Prometheus.metric_after_turn_response_content_empty
 
-let zero_usage : Agent_sdk.Types.api_usage =
-  {
-    input_tokens = 0;
-    output_tokens = 0;
-    cache_creation_input_tokens = 0;
-    cache_read_input_tokens = 0;
-    cost_usd = None;
-  }
+(* zero_usage moved to Keeper_hooks_oas_types (intra-library file split). *)
 
 let telemetry_has_canonical_model_id
     (telemetry : Agent_sdk.Types.inference_telemetry option) =

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -14,18 +14,8 @@ val keeper_denied_tools : string list
 (** Tool names that are always denied for keeper-bound execution
     regardless of cascade or persona policy. *)
 
-val usage_has_tokens : Agent_sdk.Types.api_usage -> bool
-(** [true] when the usage record carries a non-zero token count. *)
-
-(** {1 Pre-tool gate integration} *)
-
-val is_keeper_board_write_tool_name : string -> bool
-(** [true] when the tool writes to the shared MASC board; subject to
-    extra guard rules. *)
-
-val current_keeper_model : Keeper_types.keeper_meta -> string
-(** Neutral runtime lane used for keeper-facing tool-call telemetry.
-    Concrete provider/model identity is OAS-owned. *)
+(** usage_has_tokens / is_keeper_board_write_tool_name / current_keeper_model
+    moved to Keeper_hooks_oas_types (intra-library file split, 2026-05-16). *)
 
 val render_pre_tool_gate_output :
   Keeper_guards.gate_decision_event -> string

--- a/lib/keeper/keeper_hooks_oas_types.ml
+++ b/lib/keeper/keeper_hooks_oas_types.ml
@@ -184,3 +184,33 @@ let tool_execution_summary ~tool_name ~model ~success ~duration_ms :
   ; outcome = if success then outcome_ok else outcome_error
   ; duration_ms = max 0.0 duration_ms
   }
+
+let usage_has_tokens (usage : Agent_sdk.Types.api_usage) =
+  usage.input_tokens > 0
+  || usage.output_tokens > 0
+  || usage.cache_creation_input_tokens > 0
+  || usage.cache_read_input_tokens > 0
+
+let is_keeper_board_write_tool_name tool_name =
+  match Tool_name.Keeper.of_string tool_name with
+  | Some tool -> Tool_name.Keeper.is_board_write tool
+  | None -> false
+
+let current_keeper_model meta =
+  let _ = meta in
+  runtime_lane_label
+
+let stop_reason_label_end_turn = "end_turn"
+let stop_reason_label_tool_use = "tool_use"
+let stop_reason_label_max_tokens = "max_tokens"
+let stop_reason_label_stop_sequence = "stop_sequence"
+let stop_reason_label_unknown = "unknown"
+
+let zero_usage : Agent_sdk.Types.api_usage =
+  {
+    input_tokens = 0;
+    output_tokens = 0;
+    cache_creation_input_tokens = 0;
+    cache_read_input_tokens = 0;
+    cost_usd = None;
+  }

--- a/lib/keeper/keeper_hooks_oas_types.mli
+++ b/lib/keeper/keeper_hooks_oas_types.mli
@@ -110,3 +110,26 @@ val tool_execution_summary :
   tool_name:string ->
   model:string -> success:bool -> duration_ms:float -> tool_execution_summary
 (** Build a [tool_execution_summary] from raw turn fields. *)
+
+val usage_has_tokens : Agent_sdk.Types.api_usage -> bool
+(** [true] when the usage record carries a non-zero token count. *)
+
+val is_keeper_board_write_tool_name : string -> bool
+(** [true] when the tool writes to the shared MASC board; subject to
+    extra guard rules. *)
+
+val current_keeper_model : Keeper_types.keeper_meta -> string
+(** Neutral runtime lane used for keeper-facing tool-call telemetry.
+    Concrete provider/model identity is OAS-owned. *)
+
+(** Internal: stop-reason string labels exposed for keeper_hooks_oas.ml
+    consumers that emit them across multiple call sites. *)
+val stop_reason_label_end_turn : string
+val stop_reason_label_tool_use : string
+val stop_reason_label_max_tokens : string
+val stop_reason_label_stop_sequence : string
+val stop_reason_label_unknown : string
+
+val zero_usage : Agent_sdk.Types.api_usage
+(** Internal: zero-token api_usage sentinel used by classify_usage_trust
+    when telemetry is missing. *)


### PR DESCRIPTION
## Summary
6번째 keeper_hooks_oas_types PR. 5 pure helpers + 5 stop_reason labels + zero_usage sentinel.

이동:
- `usage_has_tokens` (api_usage predicate)
- `is_keeper_board_write_tool_name` (Tool_name.Keeper lookup)
- `current_keeper_model` (returns runtime_lane_label)
- 5 stop_reason_label_* constants (end_turn / tool_use / max_tokens / stop_sequence / unknown)
- zero_usage api_usage record sentinel

## Cumulative keeper_hooks_oas reduction (6 PRs)
- ml: **2762 → 2568 LoC (-7%)**
- mli: **321 → 222 LoC (-31%)**

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues intra-library split series.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)