### PR TITLE
refactor(keeper): callback_label_* constants → keeper_hooks_oas_types (#10)

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -30,13 +30,8 @@ let keeper_denied_tools =
 
 (* label_* string constants moved to Keeper_hooks_oas_types
    (intra-library file split, 2026-05-16). *)
-let callback_label_after_turn_sse_broadcast = "after_turn_sse_broadcast"
-let callback_label_post_tool_log_write = "post_tool_log_write"
-let callback_label_on_tool_executed = "on_tool_executed"
-let callback_label_on_error = "on_error"
-let callback_label_on_tool_error = "on_tool_error"
-let callback_label_pr_review_action_metrics_append = "pr_review_action_metrics_append"
-let callback_label_pr_work_action_metrics_append = "pr_work_action_metrics_append"
+(* callback_label_* constants moved to Keeper_hooks_oas_types
+   (intra-library file split, 2026-05-16). *)
 (* outcome_ok / outcome_error already moved to Keeper_hooks_oas_types in
    step 5; this duplicate block was left behind by accident and is now
    cleaned up. *)

--- a/lib/keeper/keeper_hooks_oas_types.ml
+++ b/lib/keeper/keeper_hooks_oas_types.ml
@@ -96,6 +96,15 @@ let key_duration_ms = "duration_ms"
 let key_channel = "channel"
 let key_error = "error"
 
+(** Callback name labels used as Prometheus + log identifiers. *)
+let callback_label_after_turn_sse_broadcast = "after_turn_sse_broadcast"
+let callback_label_post_tool_log_write = "post_tool_log_write"
+let callback_label_on_tool_executed = "on_tool_executed"
+let callback_label_on_error = "on_error"
+let callback_label_on_tool_error = "on_tool_error"
+let callback_label_pr_review_action_metrics_append = "pr_review_action_metrics_append"
+let callback_label_pr_work_action_metrics_append = "pr_work_action_metrics_append"
+
 type cost_status =
   | Cost_reported
   | Cost_known_free

--- a/lib/keeper/keeper_hooks_oas_types.mli
+++ b/lib/keeper/keeper_hooks_oas_types.mli
@@ -89,6 +89,15 @@ val key_error : string
 val key_ts : string
 val key_max_cost_usd : string
 
+(** Callback name labels used as Prometheus + log identifiers. *)
+val callback_label_after_turn_sse_broadcast : string
+val callback_label_post_tool_log_write : string
+val callback_label_on_tool_executed : string
+val callback_label_on_error : string
+val callback_label_on_tool_error : string
+val callback_label_pr_review_action_metrics_append : string
+val callback_label_pr_work_action_metrics_append : string
+
 type cost_status =
   | Cost_reported         (** Cost trusted because OAS reported it. *)
   | Cost_known_free       (** Runtime is structurally unmetered. *)


### PR DESCRIPTION
## Summary
10번째 keeper_hooks_oas_types PR. 7 callback name label 상수 SSOT 중앙화.

Prometheus + log identifiers (after_turn_sse_broadcast / post_tool_log_write / on_tool_executed / on_error / on_tool_error / pr_review_action_metrics_append / pr_work_action_metrics_append).

## Cumulative keeper_hooks_oas reduction (10 PRs)
- ml: **2762 → 2454 LoC (-11%)**
- mli: **321 → 222 LoC (-31%)**

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues intra-library split series.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)