### PR TITLE
refactor(server): trajectory preview helpers → server_dashboard_http_keeper_api_types (#2)

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -188,34 +188,10 @@ let handle_keeper_tools_post state req reqd =
 (* keeper_post_route_kind + 5 routing helpers moved to
    Server_dashboard_http_keeper_api_types (see comment near top). *)
 
-let trim_to_opt (value : string) =
-  let trimmed = String.trim value in
-  if trimmed = "" then None else Some trimmed
-
-let truncate_text ~max_chars text =
-  let len = String.length text in
-  if len <= max_chars then text
-  else if max_chars <= 1 then String.sub text 0 (max 0 max_chars)
-  else
-    String_util.utf8_safe ~max_bytes:max_chars ~suffix:"…" text
-    |> String_util.to_string
-
-let latest_preview_of_messages (messages : Agent_sdk.Types.message list) =
-  messages
-  |> List.rev
-  |> List.find_map (fun (message : Agent_sdk.Types.message) ->
-       if message.role = Agent_sdk.Types.System then None
-       else
-         Agent_sdk.Types.text_of_message message
-         |> trim_to_opt
-         |> Option.map (truncate_text ~max_chars:180))
-
-let continuity_summary_of_messages (messages : Agent_sdk.Types.message list) =
-  match Keeper_memory_policy.latest_state_snapshot_from_messages messages with
-  | Some snapshot ->
-      Keeper_memory_policy.keeper_state_snapshot_to_summary_text snapshot
-      |> trim_to_opt
-  | None -> None
+(* Trajectory preview helpers (trim_to_opt / truncate_text /
+   latest_preview_of_messages / continuity_summary_of_messages) moved
+   to Server_dashboard_http_keeper_api_types
+   (intra-library file split, 2026-05-16). *)
 
 let stat_json_of_path (path : string) =
   try

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -6,19 +6,10 @@
 
 module Http = Http_server_eio
 
-(* ── Keeper route constants (SSOT) ────────────────────────────── *)
-
-let keeper_api_prefix = "/api/v1/keepers/"
-let keeper_suffix_tools = "/tools"
-let keeper_suffix_config = "/config"
-let keeper_suffix_boot = "/boot"
-let keeper_suffix_shutdown = "/shutdown"
-let keeper_suffix_reset = "/reset"
-let keeper_suffix_clear = "/clear"
-let keeper_suffix_checkpoints = "/checkpoints"
-let keeper_suffix_runtime_trace = "/runtime-trace"
-let keeper_suffix_directive = "/directive"
-let keeper_suffix_bdi_snapshot = "/bdi-snapshot"
+(* Keeper route constants + classifier moved to
+   Server_dashboard_http_keeper_api_types (intra-library file split,
+   2026-05-16). *)
+include Server_dashboard_http_keeper_api_types
 
 let dedupe_tool_names names =
   Json_util.dedupe_keep_order
@@ -194,74 +185,8 @@ let handle_keeper_tools_post state req reqd =
              Http.Response.json ~status:`Bad_request
                (Printf.sprintf {|{"error":"invalid json: %s"}|} (String.escaped e)) reqd))
 
-type keeper_post_route_kind =
-  | Keeper_post_tools
-  | Keeper_post_config
-  | Keeper_post_boot
-  | Keeper_post_shutdown
-  | Keeper_post_reset
-  | Keeper_post_clear
-  | Keeper_post_checkpoints
-  | Keeper_post_directive
-  | Keeper_post_unknown
-
-let classify_keeper_post_route req_path =
-  (* Hoist the prefix check out of the per-suffix loop and route both
-     comparisons through Stdlib's allocation-free [starts_with] /
-     [ends_with]. Old form ran [String.sub req_path 0 plen] once per
-     suffix candidate (8x) plus a fresh suffix [String.sub] each time —
-     up to 16 allocations per keeper API request. *)
-  if not (String.starts_with ~prefix:keeper_api_prefix req_path) then
-    Keeper_post_unknown
-  else
-    let plen = String.length keeper_api_prefix in
-    let tlen = String.length req_path in
-    let ends_with suffix =
-      tlen > plen + String.length suffix
-      && String.ends_with ~suffix req_path
-    in
-    if ends_with keeper_suffix_tools then Keeper_post_tools
-    else if ends_with keeper_suffix_config then Keeper_post_config
-    else if ends_with keeper_suffix_boot then Keeper_post_boot
-    else if ends_with keeper_suffix_shutdown then Keeper_post_shutdown
-    else if ends_with keeper_suffix_reset then Keeper_post_reset
-    else if ends_with keeper_suffix_clear then Keeper_post_clear
-    else if ends_with keeper_suffix_checkpoints then Keeper_post_checkpoints
-    else if ends_with keeper_suffix_directive then Keeper_post_directive
-    else Keeper_post_unknown
-
-let keeper_path_ends_with req_path suffix =
-  let plen = String.length keeper_api_prefix in
-  let tlen = String.length req_path in
-  let slen = String.length suffix in
-  tlen > plen + slen
-  && String.starts_with ~prefix:keeper_api_prefix req_path
-  && String.ends_with ~suffix req_path
-
-let extract_keeper_name_for_suffix req_path suffix =
-  let plen = String.length keeper_api_prefix in
-  let slen = String.length suffix in
-  let raw =
-    String.trim
-      (String.sub req_path plen (String.length req_path - plen - slen))
-  in
-  let valid =
-    String.length raw > 0
-    && String.length raw <= 128
-    && String.to_seq raw
-       |> Seq.for_all (fun c ->
-            (c >= 'a' && c <= 'z')
-            || (c >= 'A' && c <= 'Z')
-            || (c >= '0' && c <= '9')
-            || c = '_' || c = '-')
-  in
-  if valid then raw else ""
-
-let is_keeper_checkpoints_get_path req_path =
-  keeper_path_ends_with req_path keeper_suffix_checkpoints
-
-let is_keeper_runtime_trace_get_path req_path =
-  keeper_path_ends_with req_path keeper_suffix_runtime_trace
+(* keeper_post_route_kind + 5 routing helpers moved to
+   Server_dashboard_http_keeper_api_types (see comment near top). *)
 
 let trim_to_opt (value : string) =
   let trimmed = String.trim value in

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -77,21 +77,10 @@ val handle_keeper_tools_post :
     2026-05-16). Re-exported via include below. *)
 include module type of Server_dashboard_http_keeper_api_types
 
-(** {1 Trajectory preview helpers} *)
-
-val trim_to_opt : string -> string option
-(** Trim and return [None] if empty. *)
-
-val truncate_text : max_chars:int -> string -> string
-(** Truncate [text] to [max_chars] (UTF-8 safe). *)
-
-val latest_preview_of_messages :
-  Agent_sdk.Types.message list -> string option
-(** Latest assistant-text preview suitable for the dashboard list view. *)
-
-val continuity_summary_of_messages :
-  Agent_sdk.Types.message list -> string option
-(** Latest [STATE]-derived continuity summary in the message history. *)
+(** Trajectory preview helpers (trim_to_opt / truncate_text /
+    latest_preview_of_messages / continuity_summary_of_messages)
+    moved to Server_dashboard_http_keeper_api_types — re-exported via
+    [include module type of] above. *)
 
 (** {1 Checkpoint inventory} *)
 

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -70,35 +70,12 @@ val handle_keeper_tools_post :
   Httpun.Request.t -> Httpun.Reqd.t -> unit
 (** Handle [POST /tools] (tool-grant edits). *)
 
-(** {1 POST route classifier} *)
+(** {1 POST route classifier}
 
-type keeper_post_route_kind =
-  | Keeper_post_tools
-  | Keeper_post_config
-  | Keeper_post_boot
-  | Keeper_post_shutdown
-  | Keeper_post_reset
-  | Keeper_post_clear
-  | Keeper_post_checkpoints
-  | Keeper_post_directive
-  | Keeper_post_unknown
-(** Sub-route kind for a [POST /api/v1/keepers/<name>/...] path. *)
-
-val classify_keeper_post_route : string -> keeper_post_route_kind
-(** Map a request path to its [keeper_post_route_kind]. *)
-
-val keeper_path_ends_with : string -> string -> bool
-(** [keeper_path_ends_with suffix path]: helper used by the classifier. *)
-
-val extract_keeper_name_for_suffix : string -> string -> string
-(** [extract_keeper_name_for_suffix suffix path] returns the keeper name
-    from a path of shape [/api/v1/keepers/<name>/<suffix>]. *)
-
-val is_keeper_checkpoints_get_path : string -> bool
-(** [true] for [GET /api/v1/keepers/<name>/checkpoints] paths. *)
-
-val is_keeper_runtime_trace_get_path : string -> bool
-(** [true] for [GET /api/v1/keepers/<name>/runtime-trace] paths. *)
+    keeper_post_route_kind ADT + classifier + path helpers live in
+    Server_dashboard_http_keeper_api_types (intra-library file split,
+    2026-05-16). Re-exported via include below. *)
+include module type of Server_dashboard_http_keeper_api_types
 
 (** {1 Trajectory preview helpers} *)
 

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -1,0 +1,80 @@
+(** Server_dashboard_http_keeper_api_types — pure routing types + helpers
+    extracted from Server_dashboard_http_keeper_api (3136 LoC godfile).
+
+    See server_dashboard_http_keeper_api_types.mli for rationale. *)
+
+let keeper_api_prefix = "/api/v1/keepers/"
+let keeper_suffix_tools = "/tools"
+let keeper_suffix_config = "/config"
+let keeper_suffix_boot = "/boot"
+let keeper_suffix_shutdown = "/shutdown"
+let keeper_suffix_reset = "/reset"
+let keeper_suffix_clear = "/clear"
+let keeper_suffix_checkpoints = "/checkpoints"
+let keeper_suffix_runtime_trace = "/runtime-trace"
+let keeper_suffix_directive = "/directive"
+let keeper_suffix_bdi_snapshot = "/bdi-snapshot"
+
+type keeper_post_route_kind =
+  | Keeper_post_tools
+  | Keeper_post_config
+  | Keeper_post_boot
+  | Keeper_post_shutdown
+  | Keeper_post_reset
+  | Keeper_post_clear
+  | Keeper_post_checkpoints
+  | Keeper_post_directive
+  | Keeper_post_unknown
+
+let classify_keeper_post_route req_path =
+  if not (String.starts_with ~prefix:keeper_api_prefix req_path) then
+    Keeper_post_unknown
+  else
+    let plen = String.length keeper_api_prefix in
+    let tlen = String.length req_path in
+    let ends_with suffix =
+      tlen > plen + String.length suffix
+      && String.ends_with ~suffix req_path
+    in
+    if ends_with keeper_suffix_tools then Keeper_post_tools
+    else if ends_with keeper_suffix_config then Keeper_post_config
+    else if ends_with keeper_suffix_boot then Keeper_post_boot
+    else if ends_with keeper_suffix_shutdown then Keeper_post_shutdown
+    else if ends_with keeper_suffix_reset then Keeper_post_reset
+    else if ends_with keeper_suffix_clear then Keeper_post_clear
+    else if ends_with keeper_suffix_checkpoints then Keeper_post_checkpoints
+    else if ends_with keeper_suffix_directive then Keeper_post_directive
+    else Keeper_post_unknown
+
+let keeper_path_ends_with req_path suffix =
+  let plen = String.length keeper_api_prefix in
+  let tlen = String.length req_path in
+  let slen = String.length suffix in
+  tlen > plen + slen
+  && String.starts_with ~prefix:keeper_api_prefix req_path
+  && String.ends_with ~suffix req_path
+
+let extract_keeper_name_for_suffix req_path suffix =
+  let plen = String.length keeper_api_prefix in
+  let slen = String.length suffix in
+  let raw =
+    String.trim
+      (String.sub req_path plen (String.length req_path - plen - slen))
+  in
+  let valid =
+    String.length raw > 0
+    && String.length raw <= 128
+    && String.to_seq raw
+       |> Seq.for_all (fun c ->
+            (c >= 'a' && c <= 'z')
+            || (c >= 'A' && c <= 'Z')
+            || (c >= '0' && c <= '9')
+            || c = '_' || c = '-')
+  in
+  if valid then raw else ""
+
+let is_keeper_checkpoints_get_path req_path =
+  keeper_path_ends_with req_path keeper_suffix_checkpoints
+
+let is_keeper_runtime_trace_get_path req_path =
+  keeper_path_ends_with req_path keeper_suffix_runtime_trace

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -78,3 +78,32 @@ let is_keeper_checkpoints_get_path req_path =
 
 let is_keeper_runtime_trace_get_path req_path =
   keeper_path_ends_with req_path keeper_suffix_runtime_trace
+
+let trim_to_opt (value : string) =
+  let trimmed = String.trim value in
+  if trimmed = "" then None else Some trimmed
+
+let truncate_text ~max_chars text =
+  let len = String.length text in
+  if len <= max_chars then text
+  else if max_chars <= 1 then String.sub text 0 (max 0 max_chars)
+  else
+    String_util.utf8_safe ~max_bytes:max_chars ~suffix:"…" text
+    |> String_util.to_string
+
+let latest_preview_of_messages (messages : Agent_sdk.Types.message list) =
+  messages
+  |> List.rev
+  |> List.find_map (fun (message : Agent_sdk.Types.message) ->
+       if message.role = Agent_sdk.Types.System then None
+       else
+         Agent_sdk.Types.text_of_message message
+         |> trim_to_opt
+         |> Option.map (truncate_text ~max_chars:180))
+
+let continuity_summary_of_messages (messages : Agent_sdk.Types.message list) =
+  match Keeper_memory_policy.latest_state_snapshot_from_messages messages with
+  | Some snapshot ->
+      Keeper_memory_policy.keeper_state_snapshot_to_summary_text snapshot
+      |> trim_to_opt
+  | None -> None

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -50,3 +50,19 @@ val is_keeper_checkpoints_get_path : string -> bool
 
 val is_keeper_runtime_trace_get_path : string -> bool
 (** [true] for [GET /api/v1/keepers/<name>/runtime-trace] paths. *)
+
+(** {1 Trajectory preview helpers} *)
+
+val trim_to_opt : string -> string option
+(** Trim and return [None] if empty. *)
+
+val truncate_text : max_chars:int -> string -> string
+(** Truncate [text] to [max_chars] (UTF-8 safe). *)
+
+val latest_preview_of_messages :
+  Agent_sdk.Types.message list -> string option
+(** Latest assistant-text preview suitable for the dashboard list view. *)
+
+val continuity_summary_of_messages :
+  Agent_sdk.Types.message list -> string option
+(** Latest [STATE]-derived continuity summary in the message history. *)

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -1,0 +1,52 @@
+(** Server_dashboard_http_keeper_api_types — pure routing types + helpers
+    extracted from Server_dashboard_http_keeper_api (3136 LoC godfile).
+
+    Holds the [keeper_post_route_kind] ADT + path classification helpers
+    + URL prefix/suffix string constants. State-touching HTTP handlers
+    remain in Server_dashboard_http_keeper_api. Re-included by that module
+    so existing callers continue to use
+    [Server_dashboard_http_keeper_api.classify_keeper_post_route] etc.
+    unchanged. *)
+
+(** Path prefix shared by all keeper API endpoints. *)
+val keeper_api_prefix : string
+
+(** Per-route URL suffixes for the keeper API. *)
+val keeper_suffix_tools : string
+val keeper_suffix_config : string
+val keeper_suffix_boot : string
+val keeper_suffix_shutdown : string
+val keeper_suffix_reset : string
+val keeper_suffix_clear : string
+val keeper_suffix_checkpoints : string
+val keeper_suffix_runtime_trace : string
+val keeper_suffix_directive : string
+val keeper_suffix_bdi_snapshot : string
+
+type keeper_post_route_kind =
+  | Keeper_post_tools
+  | Keeper_post_config
+  | Keeper_post_boot
+  | Keeper_post_shutdown
+  | Keeper_post_reset
+  | Keeper_post_clear
+  | Keeper_post_checkpoints
+  | Keeper_post_directive
+  | Keeper_post_unknown
+(** Sub-route kind for a [POST /api/v1/keepers/<name>/...] path. *)
+
+val classify_keeper_post_route : string -> keeper_post_route_kind
+(** Map a request path to its [keeper_post_route_kind]. *)
+
+val keeper_path_ends_with : string -> string -> bool
+(** [keeper_path_ends_with path suffix]: helper used by the classifier. *)
+
+val extract_keeper_name_for_suffix : string -> string -> string
+(** [extract_keeper_name_for_suffix path suffix] returns the keeper name
+    from a path of shape [/api/v1/keepers/<name>/<suffix>]. *)
+
+val is_keeper_checkpoints_get_path : string -> bool
+(** [true] for [GET /api/v1/keepers/<name>/checkpoints] paths. *)
+
+val is_keeper_runtime_trace_get_path : string -> bool
+(** [true] for [GET /api/v1/keepers/<name>/runtime-trace] paths. *)


### PR DESCRIPTION
## Summary
2번째 server_dashboard_http_keeper_api_types PR. 4 trajectory preview pure helpers.

- `trim_to_opt` (trim + empty-to-None)
- `truncate_text` (UTF-8 safe truncation)
- `latest_preview_of_messages` (dashboard preview from message list)
- `continuity_summary_of_messages` ([STATE]-derived summary)

## Cumulative server_dashboard_http_keeper_api reduction (2 PRs)
- ml: 3136 → 3022 LoC (-4%)
- mli: 202 → 154 LoC (-24%)

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues intra-library split series.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)