### PR TITLE
refactor(server): JSON helpers + manifest_row_matches → server_dashboard_http_keeper_api_types (#4)

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -315,40 +315,9 @@ let keeper_checkpoint_inventory_json
                    (Keeper_checkpoint_store.list_checkpoints ~session_dir)) );
           ] )
 
-let json_int_member_opt name json =
-  match Yojson.Safe.Util.member name json with
-  | `Int value -> Some value
-  | `Intlit raw -> int_of_string_opt raw
-  | _ -> None
-
-let json_string_member_opt name json =
-  match Yojson.Safe.Util.member name json with
-  | `String value -> Some value
-  | _ -> None
-
-let json_bool_member_opt name json =
-  match Yojson.Safe.Util.member name json with
-  | `Bool value -> Some value
-  | _ -> None
-
-let json_string_list_member name json =
-  match Yojson.Safe.Util.member name json with
-  | `List values ->
-    values
-    |> List.filter_map (function
-      | `String value when String.trim value <> "" -> Some value
-      | _ -> None)
-    |> Json_util.dedupe_keep_order
-  | _ -> []
-
-let json_string_opt = function
-  | Some value -> `String value
-  | None -> `Null
-
-let take_last limit values =
-  let len = List.length values in
-  if len <= limit then values
-  else List.filteri (fun idx _ -> idx >= len - limit) values
+(* Yojson member extractors + take_last list helper moved to
+   Server_dashboard_http_keeper_api_types (intra-library file split,
+   2026-05-16). *)
 
 let unique_present_paths paths =
   paths
@@ -367,14 +336,8 @@ let linked_artifact_json ~kind path =
       ("file_stat", stat_json_of_path path);
     ]
 
-let manifest_row_matches ?turn_id keeper_name trace_id
-    (row : Keeper_runtime_manifest.t) =
-  String.equal row.keeper_name keeper_name
-  && String.equal row.trace_id trace_id
-  &&
-  match turn_id with
-  | None -> true
-  | Some wanted -> row.keeper_turn_id = Some wanted
+(* manifest_row_matches moved to Server_dashboard_http_keeper_api_types
+   (intra-library file split, 2026-05-16). *)
 
 type runtime_manifest_scan =
   { path : string
@@ -691,14 +654,9 @@ let string_contains ~needle value =
     in
     loop 0
 
-let json_assoc_member_opt name json =
-  match Yojson.Safe.Util.member name json with
-  | `Assoc _ as value -> Some value
-  | _ -> None
-
-let json_string_value_opt = function
-  | `String value -> Some value
-  | _ -> None
+(* json_assoc_member_opt + json_string_value_opt moved to
+   Server_dashboard_http_keeper_api_types (intra-library file split,
+   2026-05-16). *)
 
 let tool_call_output_text_opt json =
   match Yojson.Safe.Util.member "output" json with

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -126,3 +126,56 @@ let extract_keeper_name_for_post req_path suffix =
       (String.sub req_path plen (String.length req_path - plen - slen))
   in
   if is_valid_keeper_name raw then raw else ""
+
+let json_int_member_opt name json =
+  match Yojson.Safe.Util.member name json with
+  | `Int value -> Some value
+  | `Intlit raw -> int_of_string_opt raw
+  | _ -> None
+
+let json_string_member_opt name json =
+  match Yojson.Safe.Util.member name json with
+  | `String value -> Some value
+  | _ -> None
+
+let json_bool_member_opt name json =
+  match Yojson.Safe.Util.member name json with
+  | `Bool value -> Some value
+  | _ -> None
+
+let json_string_list_member name json =
+  match Yojson.Safe.Util.member name json with
+  | `List values ->
+    values
+    |> List.filter_map (function
+      | `String value when String.trim value <> "" -> Some value
+      | _ -> None)
+    |> Json_util.dedupe_keep_order
+  | _ -> []
+
+let json_string_opt = function
+  | Some value -> `String value
+  | None -> `Null
+
+let take_last limit values =
+  let len = List.length values in
+  if len <= limit then values
+  else List.filteri (fun idx _ -> idx >= len - limit) values
+
+let json_assoc_member_opt name json =
+  match Yojson.Safe.Util.member name json with
+  | `Assoc _ as value -> Some value
+  | _ -> None
+
+let json_string_value_opt = function
+  | `String value -> Some value
+  | _ -> None
+
+let manifest_row_matches ?turn_id keeper_name trace_id
+    (row : Keeper_runtime_manifest.t) =
+  String.equal row.keeper_name keeper_name
+  && String.equal row.trace_id trace_id
+  &&
+  match turn_id with
+  | None -> true
+  | Some wanted -> row.keeper_turn_id = Some wanted

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -75,3 +75,27 @@ val is_valid_keeper_name : String.t -> bool
 val extract_keeper_name_for_post : string -> string -> string
 (** [extract_keeper_name_for_post path suffix]: variant used by the
     POST dispatcher. *)
+
+(** {1 Internal JSON / list helpers}
+
+    Pure Yojson member extractors + a small list utility, used across
+    keeper_dashboard_http_keeper_api.ml's many response-builder helpers.
+    Exposed here so the godfile keeps referencing them through include. *)
+
+val json_int_member_opt : string -> Yojson.Safe.t -> int option
+val json_string_member_opt : string -> Yojson.Safe.t -> string option
+val json_bool_member_opt : string -> Yojson.Safe.t -> bool option
+val json_string_list_member : string -> Yojson.Safe.t -> string list
+val json_string_opt : string option -> Yojson.Safe.t
+val take_last : int -> 'a list -> 'a list
+val json_assoc_member_opt : string -> Yojson.Safe.t -> Yojson.Safe.t option
+val json_string_value_opt : Yojson.Safe.t -> string option
+
+val manifest_row_matches :
+  ?turn_id:int ->
+  string ->
+  string ->
+  Keeper_runtime_manifest.t ->
+  bool
+(** Pure: true when the runtime-manifest row matches the given keeper_name +
+    trace_id (and optionally turn_id). *)


### PR DESCRIPTION
## Summary
4번째 server_dashboard_http_keeper_api_types PR. 9 pure helpers.

- 6 Yojson member extractors (json_int / string / bool / string_list / assoc / string_value)
- json_string_opt (option to JSON converter)
- take_last (list utility)
- manifest_row_matches (runtime manifest row predicate)

## Cumulative server_dashboard_http_keeper_api reduction (4 PRs)
- ml: 3136 → 2967 LoC (-5%)
- mli: 202 → 145 LoC (-28%)

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues intra-library split series.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)