### PR TITLE
refactor(server): JSON formatters + runtime trace redaction → server_dashboard_http_keeper_api_types (#5)

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -319,13 +319,8 @@ let keeper_checkpoint_inventory_json
    Server_dashboard_http_keeper_api_types (intra-library file split,
    2026-05-16). *)
 
-let unique_present_paths paths =
-  paths
-  |> List.filter_map (fun value ->
-       match value with
-       | Some path when String.trim path <> "" -> Some path
-       | _ -> None)
-  |> Json_util.dedupe_keep_order
+(* unique_present_paths moved to Server_dashboard_http_keeper_api_types
+   (intra-library file split, 2026-05-16). *)
 
 let linked_artifact_json ~kind path =
   `Assoc
@@ -1453,71 +1448,11 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
       ("gaps", `List (List.map runtime_lens_gap_json gaps));
     ]
 
-let provider_attempt_row_json (row : Keeper_runtime_manifest.t) =
-  let decision_string key = json_string_member_opt key row.decision in
-  `Assoc
-    [
-      ("ts", `String row.ts);
-      ("event", `String (Keeper_runtime_manifest.event_kind_to_string row.event));
-      ("cascade_name", json_string_opt row.cascade_name);
-      ("model_source", json_string_opt (decision_string "model_source"));
-      ( "resolved_model_source",
-        json_string_opt (decision_string "resolved_model_source") );
-      ("capability_source", json_string_opt (decision_string "capability_source"));
-      ("fallback_authority", json_string_opt (decision_string "fallback_authority"));
-      ( "provider_source_cascade",
-        json_string_opt (decision_string "provider_source_cascade") );
-      ("status", `String row.status);
-      ("error", json_string_opt (decision_string "error"));
-      ( "exception_kind",
-        json_string_opt (decision_string "exception_kind") );
-    ]
-
-let string_contains_substring haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  if needle_len = 0 then true
-  else if needle_len > haystack_len then false
-  else
-    let rec loop idx =
-      if idx + needle_len > haystack_len then false
-      else if String.sub haystack idx needle_len = needle then true
-      else loop (idx + 1)
-    in
-    loop 0
-
-let runtime_trace_keeps_provider_attempt_provenance_key = function
-  | "model_source"
-  | "resolved_model_source"
-  | "capability_source"
-  | "fallback_authority"
-  | "provider_source_cascade"
-  | "terminal_model_source"
-  | "terminal_resolved_model_source"
-  | "terminal_capability_source"
-  | "terminal_fallback_authority"
-  | "terminal_provider_source_cascade" ->
-    true
-  | _ -> false
-
-let runtime_trace_redacts_provider_model_key key =
-  let key = String.lowercase_ascii key in
-  (not (runtime_trace_keeps_provider_attempt_provenance_key key))
-  &&
-  (string_contains_substring key "provider"
-   || string_contains_substring key "model"
-   || String.equal key "configured_labels")
-
-let rec runtime_trace_public_json = function
-  | `Assoc fields ->
-      `Assoc
-        (fields
-        |> List.filter_map (fun (key, value) ->
-               if runtime_trace_redacts_provider_model_key key then None
-               else Some (key, runtime_trace_public_json value)))
-  | `List values -> `List (List.map runtime_trace_public_json values)
-  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _) as value ->
-      value
+(* provider_attempt_row_json + string_contains_substring +
+   runtime_trace_keeps_provider_attempt_provenance_key +
+   runtime_trace_redacts_provider_model_key + runtime_trace_public_json
+   moved to Server_dashboard_http_keeper_api_types
+   (intra-library file split, 2026-05-16). *)
 
 let runtime_manifest_public_json row =
   Keeper_runtime_manifest.to_json row

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -179,3 +179,77 @@ let manifest_row_matches ?turn_id keeper_name trace_id
   match turn_id with
   | None -> true
   | Some wanted -> row.keeper_turn_id = Some wanted
+
+let unique_present_paths paths =
+  paths
+  |> List.filter_map (fun value ->
+       match value with
+       | Some path when String.trim path <> "" -> Some path
+       | _ -> None)
+  |> Json_util.dedupe_keep_order
+
+let provider_attempt_row_json (row : Keeper_runtime_manifest.t) =
+  let decision_string key = json_string_member_opt key row.decision in
+  `Assoc
+    [
+      ("ts", `String row.ts);
+      ("event", `String (Keeper_runtime_manifest.event_kind_to_string row.event));
+      ("cascade_name", json_string_opt row.cascade_name);
+      ("model_source", json_string_opt (decision_string "model_source"));
+      ( "resolved_model_source",
+        json_string_opt (decision_string "resolved_model_source") );
+      ("capability_source", json_string_opt (decision_string "capability_source"));
+      ("fallback_authority", json_string_opt (decision_string "fallback_authority"));
+      ( "provider_source_cascade",
+        json_string_opt (decision_string "provider_source_cascade") );
+      ("status", `String row.status);
+      ("error", json_string_opt (decision_string "error"));
+      ( "exception_kind",
+        json_string_opt (decision_string "exception_kind") );
+    ]
+
+let string_contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 then true
+  else if needle_len > haystack_len then false
+  else
+    let rec loop idx =
+      if idx + needle_len > haystack_len then false
+      else if String.sub haystack idx needle_len = needle then true
+      else loop (idx + 1)
+    in
+    loop 0
+
+let runtime_trace_keeps_provider_attempt_provenance_key = function
+  | "model_source"
+  | "resolved_model_source"
+  | "capability_source"
+  | "fallback_authority"
+  | "provider_source_cascade"
+  | "terminal_model_source"
+  | "terminal_resolved_model_source"
+  | "terminal_capability_source"
+  | "terminal_fallback_authority"
+  | "terminal_provider_source_cascade" ->
+    true
+  | _ -> false
+
+let runtime_trace_redacts_provider_model_key key =
+  let key = String.lowercase_ascii key in
+  (not (runtime_trace_keeps_provider_attempt_provenance_key key))
+  &&
+  (string_contains_substring key "provider"
+   || string_contains_substring key "model"
+   || String.equal key "configured_labels")
+
+let rec runtime_trace_public_json = function
+  | `Assoc fields ->
+      `Assoc
+        (fields
+        |> List.filter_map (fun (key, value) ->
+               if runtime_trace_redacts_provider_model_key key then None
+               else Some (key, runtime_trace_public_json value)))
+  | `List values -> `List (List.map runtime_trace_public_json values)
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _) as value ->
+      value

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -99,3 +99,24 @@ val manifest_row_matches :
   bool
 (** Pure: true when the runtime-manifest row matches the given keeper_name +
     trace_id (and optionally turn_id). *)
+
+val unique_present_paths : string option list -> string list
+(** Pure: dedupe + trim filtered string list. *)
+
+val provider_attempt_row_json :
+  Keeper_runtime_manifest.t -> Yojson.Safe.t
+(** Pure: provider-attempt manifest row → JSON record. *)
+
+val string_contains_substring : string -> string -> bool
+(** Pure: naive substring presence test. *)
+
+val runtime_trace_keeps_provider_attempt_provenance_key : string -> bool
+(** Pure: allowlist for provider/model-related decision keys in
+    runtime-trace responses. *)
+
+val runtime_trace_redacts_provider_model_key : string -> bool
+(** Pure: redact-by-substring policy for the runtime-trace public surface. *)
+
+val runtime_trace_public_json : Yojson.Safe.t -> Yojson.Safe.t
+(** Pure: recursively redact provider/model identity fields from runtime
+    trace JSON before returning to external dashboards. *)


### PR DESCRIPTION
## Summary
5번째 server_dashboard_http_keeper_api_types PR. 6 pure helpers + redaction policy.

- `unique_present_paths`
- `provider_attempt_row_json`
- `string_contains_substring`
- `runtime_trace_keeps_provider_attempt_provenance_key` (allowlist)
- `runtime_trace_redacts_provider_model_key` (redact policy)
- `runtime_trace_public_json` (recursive Yojson redactor)

runtime_trace_* trio = provider/model identity redaction security boundary.

## Cumulative server_dashboard_http_keeper_api reduction (5 PRs)
- ml: **3136 → 2895 LoC (-8%)**
- mli: 202 → 145 LoC (-28%)

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues intra-library split series.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)