### PR TITLE
refactor(server): option-list + claim helpers → server_dashboard_http_keeper_api_types (#7)

### DIFF
--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -273,7 +273,6 @@ module Metrics = struct
       ?(on_streaming_chunk = default_streaming_chunk) ()
       : Llm_provider.Metrics.t =
     {
-      Llm_provider.Metrics.noop with
       on_cache_hit;
       on_cache_miss;
       on_request_start;

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -625,16 +625,9 @@ let first_non_empty_string_list values =
   | Some values -> values
   | None -> []
 
-let first_string_opt values =
-  List.find_map (fun value -> value) values
-
-let first_int_opt values =
-  List.find_map (fun value -> value) values
-
-let string_has_prefix ~prefix value =
-  let prefix_len = String.length prefix in
-  String.length value >= prefix_len
-  && String.equal (String.sub value 0 prefix_len) prefix
+(* first_string_opt / first_int_opt / string_has_prefix moved to
+   Server_dashboard_http_keeper_api_types (intra-library file split,
+   2026-05-16). *)
 
 let string_contains ~needle value =
   let value = String.lowercase_ascii value in
@@ -658,38 +651,9 @@ let string_contains ~needle value =
    Server_dashboard_http_keeper_api_types (intra-library file split,
    2026-05-16). *)
 
-let claim_status_of_output output =
-  let result =
-    match json_string_member_opt "result" output with
-    | Some value -> String.trim value
-    | None -> ""
-  in
-  match json_assoc_member_opt "claimed_task" output with
-  | Some _ -> "claimed"
-  | None when string_has_prefix ~prefix:"No eligible tasks" result -> "no_eligible"
-  | None when string_has_prefix ~prefix:"No unclaimed tasks" result -> "no_unclaimed"
-  | None when string_has_prefix ~prefix:"Error:" result -> "error"
-  | None when result = "" -> "unknown"
-  | None -> "observed"
-
-let claim_scope_summary_absent =
-  `Assoc
-    [ ("present", `Bool false)
-    ; ("source", `String "keeper_task_claim_tool_call")
-    ; ("status", `String "not_observed")
-    ; ("result", `Null)
-    ; ("mode", `Null)
-    ; ("scoped", `Null)
-    ; ("active_goal_ids", `List [])
-    ; ("effective_goal_ids", `List [])
-    ; ("fallback_reason", `Null)
-    ; ("matched_goal_id", `Null)
-    ; ("excluded_count", `Null)
-    ; ("claimed_task_id", `Null)
-    ; ("claimed_goal_id", `Null)
-    ; ("trace_id", `Null)
-    ; ("keeper_turn_id", `Null)
-    ]
+(* claim_status_of_output + claim_scope_summary_absent moved to
+   Server_dashboard_http_keeper_api_types (intra-library file split,
+   2026-05-16). *)
 
 let claim_scope_summary_json ~keeper_name ~trace_id ?turn_id () =
   let entries = Keeper_tool_call_log.read_recent ~keeper_name ~n:200 () in

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -299,3 +299,47 @@ let tool_call_matches_trace ?turn_id ~keeper_name ~trace_id json =
       || json_int_member_opt "keeper_turn_id" contract = Some wanted
   in
   keeper_matches && trace_matches && turn_matches
+
+let first_string_opt values =
+  List.find_map (fun value -> value) values
+
+let first_int_opt values =
+  List.find_map (fun value -> value) values
+
+let string_has_prefix ~prefix value =
+  let prefix_len = String.length prefix in
+  String.length value >= prefix_len
+  && String.equal (String.sub value 0 prefix_len) prefix
+
+let claim_status_of_output output =
+  let result =
+    match json_string_member_opt "result" output with
+    | Some value -> String.trim value
+    | None -> ""
+  in
+  match json_assoc_member_opt "claimed_task" output with
+  | Some _ -> "claimed"
+  | None when string_has_prefix ~prefix:"No eligible tasks" result -> "no_eligible"
+  | None when string_has_prefix ~prefix:"No unclaimed tasks" result -> "no_unclaimed"
+  | None when string_has_prefix ~prefix:"Error:" result -> "error"
+  | None when result = "" -> "unknown"
+  | None -> "observed"
+
+let claim_scope_summary_absent =
+  `Assoc
+    [ ("present", `Bool false)
+    ; ("source", `String "keeper_task_claim_tool_call")
+    ; ("status", `String "not_observed")
+    ; ("result", `Null)
+    ; ("mode", `Null)
+    ; ("scoped", `Null)
+    ; ("active_goal_ids", `List [])
+    ; ("effective_goal_ids", `List [])
+    ; ("fallback_reason", `Null)
+    ; ("matched_goal_id", `Null)
+    ; ("excluded_count", `Null)
+    ; ("claimed_task_id", `Null)
+    ; ("claimed_goal_id", `Null)
+    ; ("trace_id", `Null)
+    ; ("keeper_turn_id", `Null)
+    ]

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -136,3 +136,18 @@ val tool_call_matches_trace :
   trace_id:string ->
   Yojson.Safe.t ->
   bool
+
+(** {1 Option list + string utilities} *)
+
+val first_string_opt : string option list -> string option
+val first_int_opt : int option list -> int option
+val string_has_prefix : prefix:string -> string -> bool
+
+(** {1 Claim tool-call summary} *)
+
+val claim_status_of_output : Yojson.Safe.t -> string
+(** Pure: classify a keeper_task_claim tool-call output JSON. *)
+
+val claim_scope_summary_absent : Yojson.Safe.t
+(** Pure constant: JSON record returned when no matching claim was
+    observed. *)


### PR DESCRIPTION
## Summary
7번째 server_dashboard_http_keeper_api_types PR. 5 pure helpers + 1 sentinel JSON 상수.

- `first_string_opt`, `first_int_opt` (option-list reducers)
- `string_has_prefix` (prefix check)
- `claim_status_of_output` (keeper_task_claim tool-call output classifier)
- `claim_scope_summary_absent` (sentinel JSON record)

## Cumulative server_dashboard_http_keeper_api reduction (7 PRs)
- ml: **3136 → 2807 LoC (-10%)**
- mli: 202 → 145 LoC (-28%)

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues intra-library split series.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)