### PR TITLE
refactor(server): trajectory + manifest formatters → server_dashboard_http_keeper_api_types (#8)

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -36,40 +36,9 @@ let dedupe_thinking_lines (lines : Trajectory.trajectory_line list)
             true))
     lines
 
-let internal_history_json_to_trajectory_line (json : Yojson.Safe.t)
-    : Trajectory.trajectory_line option =
-  let source = Safe_ops.json_string ~default:"" "source" json in
-  let content = Safe_ops.json_string ~default:"" "content" json in
-  if source <> "internal_assistant" || String.trim content = "" then None
-  else
-    let ts =
-      match Safe_ops.json_float_opt "ts_unix" json with
-      | Some value when value > 0.0 -> value
-      | _ ->
-          match Safe_ops.json_float_opt "timestamp" json with
-          | Some value when value > 0.0 -> value
-          | _ -> 0.0
-    in
-    if ts <= 0.0 then None
-    else
-      let ts_iso =
-        match Safe_ops.json_string_opt "ts_iso" json with
-        | Some value when String.trim value <> "" -> value
-        | _ ->
-            match Safe_ops.json_string_opt "ts" json with
-            | Some value when String.trim value <> "" -> value
-            | _ -> Dashboard_utils.iso_of_unix ts
-      in
-      Some
-        (Trajectory.Thinking
-           {
-             ts;
-             ts_iso;
-             turn = Safe_ops.json_int ~default:0 "turn" json;
-             content;
-             content_length = String.length content;
-             redacted = Safe_ops.json_bool ~default:false "redacted" json;
-           })
+(* internal_history_json_to_trajectory_line moved to
+   Server_dashboard_http_keeper_api_types (intra-library file split,
+   2026-05-16). *)
 
 let read_internal_history_lines ~(config : Coord.config) ~(trace_id : string)
     : Trajectory.trajectory_line list =
@@ -1377,9 +1346,9 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
    moved to Server_dashboard_http_keeper_api_types
    (intra-library file split, 2026-05-16). *)
 
-let runtime_manifest_public_json row =
-  Keeper_runtime_manifest.to_json row
-  |> runtime_trace_public_json
+(* runtime_manifest_public_json moved to
+   Server_dashboard_http_keeper_api_types (intra-library file split,
+   2026-05-16). *)
 
 let provider_attempts_summary_json scan =
   let attempt_rows = queue_to_list scan.provider_attempt_rows in

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -343,3 +343,42 @@ let claim_scope_summary_absent =
     ; ("trace_id", `Null)
     ; ("keeper_turn_id", `Null)
     ]
+
+let internal_history_json_to_trajectory_line (json : Yojson.Safe.t)
+    : Trajectory.trajectory_line option =
+  let source = Safe_ops.json_string ~default:"" "source" json in
+  let content = Safe_ops.json_string ~default:"" "content" json in
+  if source <> "internal_assistant" || String.trim content = "" then None
+  else
+    let ts =
+      match Safe_ops.json_float_opt "ts_unix" json with
+      | Some value when value > 0.0 -> value
+      | _ ->
+          match Safe_ops.json_float_opt "timestamp" json with
+          | Some value when value > 0.0 -> value
+          | _ -> 0.0
+    in
+    if ts <= 0.0 then None
+    else
+      let ts_iso =
+        match Safe_ops.json_string_opt "ts_iso" json with
+        | Some value when String.trim value <> "" -> value
+        | _ ->
+            match Safe_ops.json_string_opt "ts" json with
+            | Some value when String.trim value <> "" -> value
+            | _ -> Dashboard_utils.iso_of_unix ts
+      in
+      Some
+        (Trajectory.Thinking
+           {
+             ts;
+             ts_iso;
+             turn = Safe_ops.json_int ~default:0 "turn" json;
+             content;
+             content_length = String.length content;
+             redacted = Safe_ops.json_bool ~default:false "redacted" json;
+           })
+
+let runtime_manifest_public_json row =
+  Keeper_runtime_manifest.to_json row
+  |> runtime_trace_public_json

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -151,3 +151,14 @@ val claim_status_of_output : Yojson.Safe.t -> string
 val claim_scope_summary_absent : Yojson.Safe.t
 (** Pure constant: JSON record returned when no matching claim was
     observed. *)
+
+val internal_history_json_to_trajectory_line :
+  Yojson.Safe.t -> Trajectory.trajectory_line option
+(** Pure: decode one [internal_assistant] history JSON line into a
+    [Trajectory.Thinking] record. Returns [None] when the line is missing
+    required fields or originates from a non-internal source. *)
+
+val runtime_manifest_public_json :
+  Keeper_runtime_manifest.t -> Yojson.Safe.t
+(** Pure: convert a manifest row to its public JSON, with provider/model
+    identity redaction applied. *)


### PR DESCRIPTION
## Summary
8번째 server_dashboard_http_keeper_api_types PR. 2 pure JSON formatters.

- `internal_history_json_to_trajectory_line` (internal_assistant JSON → Trajectory.Thinking)
- `runtime_manifest_public_json` (manifest row → public JSON with redaction)

## Cumulative server_dashboard_http_keeper_api reduction (8 PRs)
- ml: **3136 → 2776 LoC (-11%)**
- mli: 202 → 145 LoC (-28%)

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues intra-library split series.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)