### PR TITLE
refactor(dashboard): health/backoff/JSON helpers → dashboard_http_keeper_types (1st step)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -10,44 +10,9 @@ open Keeper_status_bridge
 
 include Dashboard_http_keeper_detail
 
-(** Context-ratio thresholds for keeper health scoring.
-    These are distinct from Dashboard.ctx_* (compaction triggers) —
-    health scoring penalizes keepers approaching context limits.
-    Values sourced from [Env_config_keeper.DashboardHealth]. *)
-let health_ctx_critical = Env_config_keeper.DashboardHealth.ctx_critical
-let health_ctx_warn = Env_config_keeper.DashboardHealth.ctx_warn
-let health_penalty_critical = Env_config_keeper.DashboardHealth.penalty_critical
-let health_penalty_warn = Env_config_keeper.DashboardHealth.penalty_warn
-let runtime_warning_ctx_ratio =
-  Env_config_keeper.DashboardHealth.runtime_warning_ctx_ratio
-
-let live_keeper_cascade_name (raw : string) =
-  Keeper_cascade_profile.resolve_live raw
-
-(** Compute keeper health score (0-100). Pure function.
-    Inputs: restart_count, max_restarts, recent_crash_count,
-            is_dead, context_ratio (0.0-1.0). *)
-let compute_health_score
-    ~restart_count ~max_restarts ~recent_crash_count
-    ~is_dead ~context_ratio =
-  if is_dead then 0
-  else
-    let budget_penalty =
-      if max_restarts <= 0 then 0.0
-      else
-        let ratio = float_of_int restart_count /. float_of_int max_restarts in
-        Float.min 1.0 ratio *. 40.0
-    in
-    let crash_penalty =
-      Float.min 30.0 (float_of_int recent_crash_count *. 10.0)
-    in
-    let context_penalty =
-      if context_ratio > health_ctx_critical then health_penalty_critical
-      else if context_ratio > health_ctx_warn then health_penalty_warn
-      else 0.0
-    in
-    let raw = 100.0 -. budget_penalty -. crash_penalty -. context_penalty in
-    Int.max 0 (Int.min 100 (Float.to_int raw))
+(** Health constants + compute_health_score + live_keeper_cascade_name moved
+    to Dashboard_http_keeper_types (intra-library file split, 2026-05-16). *)
+include Dashboard_http_keeper_types
 
 (** Outcomes rollup: aggregate successes / failures / validation for a keeper.
 
@@ -210,30 +175,9 @@ let compute_outcomes_rollup
 (** Estimate seconds until Dead based on current restart_count and
     exponential backoff schedule. Returns None if already dead or
     restart_count >= max_restarts. *)
-let estimate_dead_eta_sec ~restart_count ~max_restarts =
-  if max_restarts <= 0 || restart_count >= max_restarts then None
-  else
-    let total = ref 0.0 in
-    for i = restart_count to max_restarts - 1 do
-      total := !total +. Keeper_supervisor.backoff_delay i
-    done;
-    Some !total
-
-let prompt_block_json key =
-  let resolved = Prompt_registry.resolve_prompt key in
-  `Assoc
-    [
-      ("key", `String key);
-      ("source", `String resolved.source);
-      ("text", `String resolved.effective);
-    ]
-
-let tokens_per_sec_json ~tokens ~latency_ms =
-  if tokens <= 0 || latency_ms <= 0 then `Null
-  else `Float ((float_of_int tokens *. 1000.0) /. float_of_int latency_ms)
-
-let last_latency_ms_json latency_ms =
-  if latency_ms <= 0 then `Null else `Int latency_ms
+(* estimate_dead_eta_sec / prompt_block_json / tokens_per_sec_json /
+   last_latency_ms_json moved to Dashboard_http_keeper_types
+   (intra-library file split, 2026-05-16). *)
 
 let json_string_list_member key json =
   match Yojson.Safe.Util.member key json with

--- a/lib/dashboard/dashboard_http_keeper_types.ml
+++ b/lib/dashboard/dashboard_http_keeper_types.ml
@@ -1,0 +1,61 @@
+(** Dashboard_http_keeper_types — pure helpers extracted from
+    Dashboard_http_keeper (2327 LoC godfile).
+
+    See dashboard_http_keeper_types.mli for rationale. *)
+
+let health_ctx_critical = Env_config_keeper.DashboardHealth.ctx_critical
+let health_ctx_warn = Env_config_keeper.DashboardHealth.ctx_warn
+let health_penalty_critical = Env_config_keeper.DashboardHealth.penalty_critical
+let health_penalty_warn = Env_config_keeper.DashboardHealth.penalty_warn
+let runtime_warning_ctx_ratio =
+  Env_config_keeper.DashboardHealth.runtime_warning_ctx_ratio
+
+let live_keeper_cascade_name (raw : string) =
+  Keeper_cascade_profile.resolve_live raw
+
+let compute_health_score
+    ~restart_count ~max_restarts ~recent_crash_count
+    ~is_dead ~context_ratio =
+  if is_dead then 0
+  else
+    let budget_penalty =
+      if max_restarts <= 0 then 0.0
+      else
+        let ratio = float_of_int restart_count /. float_of_int max_restarts in
+        Float.min 1.0 ratio *. 40.0
+    in
+    let crash_penalty =
+      Float.min 30.0 (float_of_int recent_crash_count *. 10.0)
+    in
+    let context_penalty =
+      if context_ratio > health_ctx_critical then health_penalty_critical
+      else if context_ratio > health_ctx_warn then health_penalty_warn
+      else 0.0
+    in
+    let raw = 100.0 -. budget_penalty -. crash_penalty -. context_penalty in
+    Int.max 0 (Int.min 100 (Float.to_int raw))
+
+let estimate_dead_eta_sec ~restart_count ~max_restarts =
+  if max_restarts <= 0 || restart_count >= max_restarts then None
+  else
+    let total = ref 0.0 in
+    for i = restart_count to max_restarts - 1 do
+      total := !total +. Keeper_supervisor.backoff_delay i
+    done;
+    Some !total
+
+let prompt_block_json key =
+  let resolved = Prompt_registry.resolve_prompt key in
+  `Assoc
+    [
+      ("key", `String key);
+      ("source", `String resolved.source);
+      ("text", `String resolved.effective);
+    ]
+
+let tokens_per_sec_json ~tokens ~latency_ms =
+  if tokens <= 0 || latency_ms <= 0 then `Null
+  else `Float ((float_of_int tokens *. 1000.0) /. float_of_int latency_ms)
+
+let last_latency_ms_json latency_ms =
+  if latency_ms <= 0 then `Null else `Int latency_ms

--- a/lib/dashboard/dashboard_http_keeper_types.mli
+++ b/lib/dashboard/dashboard_http_keeper_types.mli
@@ -1,0 +1,45 @@
+(** Dashboard_http_keeper_types — pure helpers extracted from
+    Dashboard_http_keeper (2327 LoC godfile).
+
+    Holds the health-scoring constants + compute_health_score +
+    backoff-eta + small JSON builders. State-touching dashboard renderers
+    remain in Dashboard_http_keeper. Re-included by that module so
+    existing callers continue to use [Dashboard_http_keeper.<helper>]
+    unchanged. *)
+
+val health_ctx_critical : float
+val health_ctx_warn : float
+val health_penalty_critical : float
+val health_penalty_warn : float
+val runtime_warning_ctx_ratio : float
+(** Dashboard health scoring thresholds, sourced from
+    [Env_config_keeper.DashboardHealth]. *)
+
+val live_keeper_cascade_name : string -> string
+(** Resolve a raw cascade name to its live (post-rotation) identifier. *)
+
+val compute_health_score :
+  restart_count:int ->
+  max_restarts:int ->
+  recent_crash_count:int ->
+  is_dead:bool ->
+  context_ratio:float ->
+  int
+(** Pure 0-100 health score for a keeper. Dead returns 0; otherwise
+    deducts budget / crash / context penalties from 100. *)
+
+val estimate_dead_eta_sec :
+  restart_count:int -> max_restarts:int -> float option
+(** Sum of supervisor backoff delays from [restart_count] up to
+    [max_restarts]. [None] when the budget is already exhausted. *)
+
+val prompt_block_json : string -> Yojson.Safe.t
+(** Pure: resolve a prompt key and emit the dashboard JSON record. *)
+
+val tokens_per_sec_json :
+  tokens:int -> latency_ms:int -> Yojson.Safe.t
+(** Pure: tokens-per-second JSON value; [`Null] when inputs are
+    non-positive. *)
+
+val last_latency_ms_json : int -> Yojson.Safe.t
+(** Pure: latency JSON value; [`Null] when input is non-positive. *)

--- a/scripts/check-variants.sh
+++ b/scripts/check-variants.sh
@@ -155,12 +155,12 @@ fi
 echo ""
 echo "=== Check 2: turn_phase (OCaml) vs KeeperCascadeLifecycle.tla domain ==="
 
-KR_ML="lib/keeper/keeper_registry.ml"
+KR_TYPES_ML="lib/keeper/keeper_registry_types.ml"
 KCL_TLA="specs/keeper-state-machine/KeeperCascadeLifecycle.tla"
 
-if [ -f "$KR_ML" ]; then
+if [ -f "$KR_TYPES_ML" ]; then
   # turn_phase constructors (strip "Turn_" prefix, lowercase for TLA+ comparison)
-  ocaml_turn_constructors=$(extract_ocaml_type "$KR_ML" "turn_phase")
+  ocaml_turn_constructors=$(extract_ocaml_type "$KR_TYPES_ML" "turn_phase")
   assert_contains_variant "OCaml(turn_phase)" "$ocaml_turn_constructors" "Turn_idle"
   assert_contains_variant "OCaml(turn_phase)" "$ocaml_turn_constructors" "Turn_prompting"
   ocaml_turn=$(echo "$ocaml_turn_constructors" \
@@ -181,10 +181,10 @@ if [ -f "$KR_ML" ]; then
       echo "INFO: ${KCL_TLA} not found — TLA+ turn_phase check skipped"
     fi
   else
-    echo "WARN: could not extract OCaml turn_phase from ${KR_ML}"
+    echo "WARN: could not extract OCaml turn_phase from ${KR_TYPES_ML}"
   fi
 else
-  echo "WARN: ${KR_ML} not found — turn_phase check skipped"
+  echo "WARN: ${KR_TYPES_ML} not found — turn_phase check skipped"
 fi
 
 # ── Check 3: cascade_state (OCaml) vs CascadeSet in TLA+ ────────────────────
@@ -192,8 +192,8 @@ fi
 echo ""
 echo "=== Check 3: cascade_state (OCaml) vs KeeperCascadeLifecycle.tla domain ==="
 
-if [ -f "$KR_ML" ]; then
-  ocaml_cascade=$(extract_ocaml_type "$KR_ML" "cascade_state" \
+if [ -f "$KR_TYPES_ML" ]; then
+  ocaml_cascade=$(extract_ocaml_type "$KR_TYPES_ML" "cascade_state" \
     | sed 's/Cascade_//' | tr '[:upper:]' '[:lower:]' | sort -u)
 
   if [ -n "$ocaml_cascade" ]; then


### PR DESCRIPTION
## Summary
dashboard_http_keeper.ml (2327 LoC godfile) decomposition 시작. 5번째 godfile 분해 시리즈.

이동:
- 5 health thresholds (health_ctx_critical/warn, health_penalty_critical/warn, runtime_warning_ctx_ratio)
- live_keeper_cascade_name
- compute_health_score (0-100 pure scoring)
- estimate_dead_eta_sec
- prompt_block_json + tokens_per_sec_json + last_latency_ms_json

## Cumulative dashboard_http_keeper reduction (1 PR, starting)
- ml: 2327 → 2270 LoC

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: intra-library file split, mirrors keeper_registry_types / keeper_supervisor_types / keeper_hooks_oas_types / server_dashboard_http_keeper_api_types pattern.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)