### PR TITLE
refactor(dashboard): JSON + freshness helpers → dashboard_http_keeper_types (#2)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -179,30 +179,9 @@ let compute_outcomes_rollup
    last_latency_ms_json moved to Dashboard_http_keeper_types
    (intra-library file split, 2026-05-16). *)
 
-let json_string_list_member key json =
-  match Yojson.Safe.Util.member key json with
-  | `List items ->
-    items
-    |> List.filter_map (function
-         | `String value ->
-           let trimmed = String.trim value in
-           if trimmed = "" then None else Some trimmed
-         | _ -> None)
-  | _ -> []
-
-let json_string_member_opt key json =
-  match Yojson.Safe.Util.member key json with
-  | `String value when String.trim value <> "" -> Some value
-  | _ -> None
-
-let terminal_reason_code_of_decision_json json =
-  match json_string_member_opt "terminal_reason_code" json with
-  | Some _ as value -> value
-  | None ->
-    (match Yojson.Safe.Util.member "terminal_reason" json with
-     | `Assoc _ as terminal_reason ->
-       json_string_member_opt "code" terminal_reason
-     | _ -> None)
+(* json_string_list_member + json_string_member_opt +
+   terminal_reason_code_of_decision_json moved to
+   Dashboard_http_keeper_types (intra-library file split, 2026-05-16). *)
 
 let keeper_trust_json ?(include_receipt = false)
     (config : Coord.config) (meta : Keeper_types.keeper_meta) =
@@ -336,10 +315,9 @@ let keeper_trust_json ?(include_receipt = false)
           `Null );
     ]
 
-let execution_trust_source = "execution_receipt"
-let execution_trust_producer = "keeper_agent_run.execution_receipt"
-let execution_trust_dashboard_surface = "/api/v1/dashboard/execution-trust"
-let execution_trust_freshness_slo_s = 900.0
+(* execution_trust_source / _producer / _dashboard_surface / _freshness_slo_s
+   moved to Dashboard_http_keeper_types (intra-library file split,
+   2026-05-16). *)
 
 let execution_receipt_dir config keeper_name =
   Filename.concat
@@ -372,65 +350,9 @@ let count_execution_receipt_entries config keeper_names =
               0))
        0
 
-let max_ts_opt current candidate =
-  match current with
-  | Some existing when existing >= candidate -> current
-  | _ -> Some candidate
-
-let latest_receipt_ts_of_keeper_rows rows =
-  rows
-  |> List.fold_left
-       (fun acc row ->
-         match
-           Yojson.Safe.Util.member "trust" row
-           |> Yojson.Safe.Util.member "last_receipt_at"
-         with
-         | `String iso -> (
-             match Masc_domain.parse_iso8601_opt iso with
-             | Some ts -> max_ts_opt acc ts
-             | None -> acc)
-         | _ -> acc)
-       None
-
-let freshness_fields ~now latest_ts =
-  match latest_ts with
-  | Some ts ->
-    [
-      ("latest_ts_unix", `Float ts);
-      ("latest_ts_iso", `String (Masc_domain.iso8601_of_unix_seconds ts));
-      ("latest_age_s", `Float (max 0.0 (now -. ts)));
-    ]
-  | None ->
-    [
-      ("latest_ts_unix", `Null);
-      ("latest_ts_iso", `Null);
-      ("latest_age_s", `Null);
-    ]
-
-let source_health_fields ~now ~exists ~entry_count ~latest_ts ?coverage_gap () =
-  let health, stale_reason =
-    match coverage_gap with
-    | Some gap ->
-      ( "coverage_gap",
-        Safe_ops.json_string ~default:"coverage_gap" "stale_reason" gap )
-    | None ->
-      if not exists then ("missing", "store_missing")
-      else if entry_count = 0 then ("empty", "no_entries")
-      else
-        match latest_ts with
-        | None -> ("empty", "no_entries")
-        | Some ts ->
-          let latest_age_s = max 0.0 (now -. ts) in
-          if latest_age_s > execution_trust_freshness_slo_s then
-            ("stale", "freshness_slo_exceeded")
-          else
-            ("ok", "")
-  in
-  [
-    ("health", `String health);
-    ( "stale_reason",
-      if stale_reason = "" then `Null else `String stale_reason );
-  ]
+(* max_ts_opt / latest_receipt_ts_of_keeper_rows / freshness_fields /
+   source_health_fields moved to Dashboard_http_keeper_types
+   (intra-library file split, 2026-05-16). *)
 
 let execution_receipt_coverage_gaps config =
   Telemetry_coverage_gap.read_recent

--- a/lib/dashboard/dashboard_http_keeper_types.ml
+++ b/lib/dashboard/dashboard_http_keeper_types.ml
@@ -93,7 +93,7 @@ let execution_trust_freshness_slo_s = 900.0
 let max_ts_opt current candidate =
   match current with
   | Some existing when existing >= candidate -> current
-  | _ -> Some candidate
+  | Some _ | None -> Some candidate
 
 let latest_receipt_ts_of_keeper_rows rows =
   rows

--- a/lib/dashboard/dashboard_http_keeper_types.ml
+++ b/lib/dashboard/dashboard_http_keeper_types.ml
@@ -59,3 +59,93 @@ let tokens_per_sec_json ~tokens ~latency_ms =
 
 let last_latency_ms_json latency_ms =
   if latency_ms <= 0 then `Null else `Int latency_ms
+
+let json_string_list_member key json =
+  match Yojson.Safe.Util.member key json with
+  | `List items ->
+    items
+    |> List.filter_map (function
+         | `String value ->
+           let trimmed = String.trim value in
+           if trimmed = "" then None else Some trimmed
+         | _ -> None)
+  | _ -> []
+
+let json_string_member_opt key json =
+  match Yojson.Safe.Util.member key json with
+  | `String value when String.trim value <> "" -> Some value
+  | _ -> None
+
+let terminal_reason_code_of_decision_json json =
+  match json_string_member_opt "terminal_reason_code" json with
+  | Some _ as value -> value
+  | None ->
+    (match Yojson.Safe.Util.member "terminal_reason" json with
+     | `Assoc _ as terminal_reason ->
+       json_string_member_opt "code" terminal_reason
+     | _ -> None)
+
+let execution_trust_source = "execution_receipt"
+let execution_trust_producer = "keeper_agent_run.execution_receipt"
+let execution_trust_dashboard_surface = "/api/v1/dashboard/execution-trust"
+let execution_trust_freshness_slo_s = 900.0
+
+let max_ts_opt current candidate =
+  match current with
+  | Some existing when existing >= candidate -> current
+  | _ -> Some candidate
+
+let latest_receipt_ts_of_keeper_rows rows =
+  rows
+  |> List.fold_left
+       (fun acc row ->
+         match
+           Yojson.Safe.Util.member "trust" row
+           |> Yojson.Safe.Util.member "last_receipt_at"
+         with
+         | `String iso -> (
+             match Masc_domain.parse_iso8601_opt iso with
+             | Some ts -> max_ts_opt acc ts
+             | None -> acc)
+         | _ -> acc)
+       None
+
+let freshness_fields ~now latest_ts =
+  match latest_ts with
+  | Some ts ->
+    [
+      ("latest_ts_unix", `Float ts);
+      ("latest_ts_iso", `String (Masc_domain.iso8601_of_unix_seconds ts));
+      ("latest_age_s", `Float (max 0.0 (now -. ts)));
+    ]
+  | None ->
+    [
+      ("latest_ts_unix", `Null);
+      ("latest_ts_iso", `Null);
+      ("latest_age_s", `Null);
+    ]
+
+let source_health_fields ~now ~exists ~entry_count ~latest_ts ?coverage_gap () =
+  let health, stale_reason =
+    match coverage_gap with
+    | Some gap ->
+      ( "coverage_gap",
+        Safe_ops.json_string ~default:"coverage_gap" "stale_reason" gap )
+    | None ->
+      if not exists then ("missing", "store_missing")
+      else if entry_count = 0 then ("empty", "no_entries")
+      else
+        match latest_ts with
+        | None -> ("empty", "no_entries")
+        | Some ts ->
+          let latest_age_s = max 0.0 (now -. ts) in
+          if latest_age_s > execution_trust_freshness_slo_s then
+            ("stale", "freshness_slo_exceeded")
+          else
+            ("ok", "")
+  in
+  [
+    ("health", `String health);
+    ( "stale_reason",
+      if stale_reason = "" then `Null else `String stale_reason );
+  ]

--- a/lib/dashboard/dashboard_http_keeper_types.mli
+++ b/lib/dashboard/dashboard_http_keeper_types.mli
@@ -43,3 +43,34 @@ val tokens_per_sec_json :
 
 val last_latency_ms_json : int -> Yojson.Safe.t
 (** Pure: latency JSON value; [`Null] when input is non-positive. *)
+
+(** {1 Internal Yojson / freshness helpers}
+
+    Used by dashboard renderers and execution-trust health computations. *)
+
+val json_string_list_member : string -> Yojson.Safe.t -> string list
+val json_string_member_opt : string -> Yojson.Safe.t -> string option
+val terminal_reason_code_of_decision_json :
+  Yojson.Safe.t -> string option
+
+val execution_trust_source : string
+val execution_trust_producer : string
+val execution_trust_dashboard_surface : string
+val execution_trust_freshness_slo_s : float
+
+val max_ts_opt : float option -> float -> float option
+
+val latest_receipt_ts_of_keeper_rows :
+  Yojson.Safe.t list -> float option
+
+val freshness_fields :
+  now:float -> float option -> (string * Yojson.Safe.t) list
+
+val source_health_fields :
+  now:float ->
+  exists:bool ->
+  entry_count:int ->
+  latest_ts:float option ->
+  ?coverage_gap:Yojson.Safe.t ->
+  unit ->
+  (string * Yojson.Safe.t) list


### PR DESCRIPTION
## Summary
2번째 dashboard_http_keeper_types PR. 10 pure helpers + 4 execution-trust 상수.

- `json_string_list_member`, `json_string_member_opt`
- `terminal_reason_code_of_decision_json`
- 4 execution_trust constants (source / producer / dashboard_surface / freshness_slo_s)
- `max_ts_opt` (option-max combiner)
- `latest_receipt_ts_of_keeper_rows` (JSON row fold)
- `freshness_fields` (JSON age fields)
- `source_health_fields` (health classification)

## Cumulative dashboard_http_keeper reduction (2 PRs)
- ml: **2327 → 2188 LoC (-6%)**

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues intra-library split series.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)