### PR TITLE
refactor(dashboard): metric/list/decision helpers → dashboard_http_keeper_types (#3)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1203,12 +1203,8 @@ let execution_trust_dashboard_json (config : Coord.config) : Yojson.Safe.t =
     @ source_health_fields
         ~now ~exists ~entry_count ~latest_ts ?coverage_gap ())
 
-let nonempty_string_opt value =
-  let trimmed = String.trim value in
-  if trimmed = "" then None else Some trimmed
-
-let parse_json_line_opt line =
-  try Some (Yojson.Safe.from_string line) with Yojson.Json_error _ -> None
+(* nonempty_string_opt + parse_json_line_opt moved to
+   Dashboard_http_keeper_types (intra-library file split, 2026-05-16). *)
 
 let recent_keeper_metric_jsons (config : Coord.config) name =
   let metrics_store = Keeper_types.keeper_metrics_store config name in
@@ -1222,29 +1218,9 @@ let recent_keeper_metric_jsons (config : Coord.config) name =
   in
   List.filter_map parse_json_line_opt lines
 
-let metric_ts json =
-  Safe_ops.json_float ~default:0.0 "ts_unix" json
-
-let sort_by_latest_ts jsons =
-  List.sort
-    (fun left right -> Float.compare (metric_ts right) (metric_ts left))
-    jsons
-
-let string_member_nonempty key json =
-  Option.bind (Safe_ops.json_string_opt key json) nonempty_string_opt
-
-let int_member_fallback key json =
-  let usage = Yojson.Safe.Util.member "usage" json in
-  match Safe_ops.json_int_opt key usage with
-  | Some value -> Some value
-  | None -> Safe_ops.json_int_opt key json
-
-let rec take_list n xs =
-  if n <= 0 then []
-  else
-    match xs with
-    | [] -> []
-    | x :: rest -> x :: take_list (n - 1) rest
+(* metric_ts + sort_by_latest_ts + string_member_nonempty +
+   int_member_fallback + take_list moved to Dashboard_http_keeper_types
+   (intra-library file split, 2026-05-16). *)
 
 let recent_token_spend_json metrics =
   metrics
@@ -1729,31 +1705,8 @@ let keeper_config_json (config : Coord.config) (name : string)
 
     This closes the Phase-2 gap between runtime metrics (already in
     /api/v1/models/metrics) and per-agent spend (required by preview). *)
-let percentile_sorted_float (sorted : float array) (p : float) : float =
-  let n = Array.length sorted in
-  if n = 0 then 0.0
-  else
-    let rank = p /. 100.0 *. Float.of_int (n - 1) in
-    let lo = int_of_float (floor rank) in
-    let hi = min (lo + 1) (n - 1) in
-    let frac = rank -. Float.of_int lo in
-    sorted.(lo) *. (1.0 -. frac) +. sorted.(hi) *. frac
-
-let keeper_cost_metric_row_is_event (json : Yojson.Safe.t) : bool =
-  let field_equals key expected =
-    Safe_ops.json_string_opt key json
-    |> Option.map (fun value ->
-         String.equal
-           (String.lowercase_ascii (String.trim value))
-           expected)
-    |> Option.value ~default:false
-  in
-  (* Heartbeat status rows carry cumulative runtime usage snapshots, not
-     per-call spend samples.  Counting them here inflates dashboard cost. *)
-  not
-    (field_equals "channel" "heartbeat"
-     || field_equals "work_kind" "status_tick"
-     || field_equals "snapshot_source" "keeper_context_status")
+(* percentile_sorted_float + keeper_cost_metric_row_is_event moved to
+   Dashboard_http_keeper_types (intra-library file split, 2026-05-16). *)
 
 let keeper_cost_aggregates_json
     ~(config : Coord.config)
@@ -1865,7 +1818,8 @@ let keeper_cost_aggregates_json
   ]
 
 let k2_feed_limit limit = max 1 (min 200 limit)
-let keeper_decisions_dashboard_surface = "/api/v1/dashboard/keeper-decisions"
+(* keeper_decisions_dashboard_surface moved to Dashboard_http_keeper_types
+   (intra-library file split, 2026-05-16). *)
 
 let keeper_decisions_retention_json ~per_keeper_limit ~keeper_count =
   `Assoc
@@ -2006,11 +1960,8 @@ let k2_stable_id ~prefix ~keeper_name ~ts_unix ~raw =
   Printf.sprintf "%s-%s-%016Lx-%s"
     prefix keeper_name ms (String.sub hash 0 8)
 
-let memory_kind_for_log (kind : string) : string =
-  match String.lowercase_ascii (String.trim kind) with
-  | "progress" -> "episode"
-  | "goal" | "next" | "decision" -> "plan"
-  | _ -> "fact"
+(* memory_kind_for_log moved to Dashboard_http_keeper_types
+   (intra-library file split, 2026-05-16). *)
 
 let keeper_decisions_log_json
     ~(config : Coord.config)

--- a/lib/dashboard/dashboard_http_keeper_types.ml
+++ b/lib/dashboard/dashboard_http_keeper_types.ml
@@ -149,3 +149,66 @@ let source_health_fields ~now ~exists ~entry_count ~latest_ts ?coverage_gap () =
     ( "stale_reason",
       if stale_reason = "" then `Null else `String stale_reason );
   ]
+
+let nonempty_string_opt value =
+  let trimmed = String.trim value in
+  if trimmed = "" then None else Some trimmed
+
+let parse_json_line_opt line =
+  try Some (Yojson.Safe.from_string line) with Yojson.Json_error _ -> None
+
+let metric_ts json =
+  Safe_ops.json_float ~default:0.0 "ts_unix" json
+
+let sort_by_latest_ts jsons =
+  List.sort
+    (fun left right -> Float.compare (metric_ts right) (metric_ts left))
+    jsons
+
+let string_member_nonempty key json =
+  Option.bind (Safe_ops.json_string_opt key json) nonempty_string_opt
+
+let int_member_fallback key json =
+  let usage = Yojson.Safe.Util.member "usage" json in
+  match Safe_ops.json_int_opt key usage with
+  | Some value -> Some value
+  | None -> Safe_ops.json_int_opt key json
+
+let rec take_list n xs =
+  if n <= 0 then []
+  else
+    match xs with
+    | [] -> []
+    | x :: rest -> x :: take_list (n - 1) rest
+
+let percentile_sorted_float (sorted : float array) (p : float) : float =
+  let n = Array.length sorted in
+  if n = 0 then 0.0
+  else
+    let rank = p /. 100.0 *. Float.of_int (n - 1) in
+    let lo = int_of_float (floor rank) in
+    let hi = min (lo + 1) (n - 1) in
+    let frac = rank -. Float.of_int lo in
+    sorted.(lo) *. (1.0 -. frac) +. sorted.(hi) *. frac
+
+let keeper_cost_metric_row_is_event (json : Yojson.Safe.t) : bool =
+  let field_equals key expected =
+    Safe_ops.json_string_opt key json
+    |> Option.map (fun value ->
+         String.equal
+           (String.lowercase_ascii (String.trim value))
+           expected)
+    |> Option.value ~default:false
+  in
+  not
+    (field_equals "channel" "heartbeat"
+     || field_equals "work_kind" "status_tick"
+     || field_equals "snapshot_source" "keeper_context_status")
+
+let memory_kind_for_log (kind : string) : string =
+  match String.lowercase_ascii (String.trim kind) with
+  | "progress" -> "episode"
+  | "goal" | "next" | "decision" -> "plan"
+  | _ -> "fact"
+
+let keeper_decisions_dashboard_surface = "/api/v1/dashboard/keeper-decisions"

--- a/lib/dashboard/dashboard_http_keeper_types.ml
+++ b/lib/dashboard/dashboard_http_keeper_types.ml
@@ -193,12 +193,12 @@ let percentile_sorted_float (sorted : float array) (p : float) : float =
 
 let keeper_cost_metric_row_is_event (json : Yojson.Safe.t) : bool =
   let field_equals key expected =
-    Safe_ops.json_string_opt key json
-    |> Option.map (fun value ->
-         String.equal
-           (String.lowercase_ascii (String.trim value))
-           expected)
-    |> Option.value ~default:false
+    match Safe_ops.json_string_opt key json with
+    | Some value ->
+      String.equal
+        (String.lowercase_ascii (String.trim value))
+        expected
+    | None -> false
   in
   not
     (field_equals "channel" "heartbeat"

--- a/lib/dashboard/dashboard_http_keeper_types.mli
+++ b/lib/dashboard/dashboard_http_keeper_types.mli
@@ -74,3 +74,17 @@ val source_health_fields :
   ?coverage_gap:Yojson.Safe.t ->
   unit ->
   (string * Yojson.Safe.t) list
+
+(** {1 Internal metric / list / decision helpers} *)
+
+val nonempty_string_opt : string -> string option
+val parse_json_line_opt : string -> Yojson.Safe.t option
+val metric_ts : Yojson.Safe.t -> float
+val sort_by_latest_ts : Yojson.Safe.t list -> Yojson.Safe.t list
+val string_member_nonempty : string -> Yojson.Safe.t -> string option
+val int_member_fallback : string -> Yojson.Safe.t -> int option
+val take_list : int -> 'a list -> 'a list
+val percentile_sorted_float : float array -> float -> float
+val keeper_cost_metric_row_is_event : Yojson.Safe.t -> bool
+val memory_kind_for_log : string -> string
+val keeper_decisions_dashboard_surface : string


### PR DESCRIPTION
## Summary
3번째 dashboard_http_keeper_types PR. 10 pure helpers + 1 string constant.

이동:
- nonempty_string_opt / parse_json_line_opt / metric_ts / sort_by_latest_ts
- string_member_nonempty / int_member_fallback / take_list
- percentile_sorted_float (P50/P95 quantile)
- keeper_cost_metric_row_is_event (event row classifier)
- memory_kind_for_log (memory kind canonicalizer)
- keeper_decisions_dashboard_surface

## Cumulative dashboard_http_keeper reduction (3 PRs)
- ml: **2327 → 2126 LoC (-9%)**

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues intra-library split series.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)