### PR TITLE
refactor(tool_shard): pure helpers + permission classifiers → tool_shard_types (#2)

### DIFF
--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -555,15 +555,8 @@ let board_tools : Masc_domain.tool_schema list =
   ]
 ;;
 
-let select_named_schemas (names : string list) (schemas : Masc_domain.tool_schema list)
-  : Masc_domain.tool_schema list
-  =
-  names
-  |> List.filter_map (fun name ->
-    List.find_opt
-      (fun (schema : Masc_domain.tool_schema) -> String.equal schema.name name)
-      schemas)
-;;
+(* select_named_schemas moved to Tool_shard_types
+   (intra-library file split, 2026-05-16). *)
 
 let filesystem_tools : Masc_domain.tool_schema list =
   [ { name = "keeper_fs_read"
@@ -1829,16 +1822,8 @@ let agent_shards_mutex = Stdlib.Mutex.create ()
 (** Default shards for a new keeper.
     Autoresearch is intentionally opt-in through the explicit shard or
     a preset/tool policy group. *)
-let default_shard_names : string list =
-  [ "base"
-  ; "board"
-  ; "filesystem"
-  ; "shell"
-  ; "library"
-  ; "taskboard"
-  ; "coding"
-  ]
-;;
+(* default_shard_names moved to Tool_shard_types
+   (intra-library file split, 2026-05-16). *)
 
 let get_agent_shards (agent_name : string) : string list =
   Stdlib.Mutex.protect agent_shards_mutex (fun () ->
@@ -2047,22 +2032,9 @@ let execute (tool_name : string) (arguments : Yojson.Safe.t) : bool * Yojson.Saf
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
-let tool_spec_read_only = [ "masc_tool_list" ]
-let tool_spec_destructive = [ "masc_tool_grant"; "masc_tool_revoke" ]
-
-let tool_required_permission = function
-  | "masc_tool_list" -> Some Masc_domain.CanReadState
-  | "masc_tool_grant" | "masc_tool_revoke" -> Some Masc_domain.CanAdmin
-  | _ -> None
-;;
-
-let tool_effect_domain name =
-  match Tool_name.of_string name with
-  | Some (Tool_name.Masc Tool_name.Masc.Tool_list) -> Some Tool_catalog.Read_only
-  | Some (Tool_name.Masc (Tool_name.Masc.Tool_grant | Tool_name.Masc.Tool_revoke)) ->
-    Some Tool_catalog.Masc_coordination
-  | _ -> None
-;;
+(* tool_spec_read_only / tool_spec_destructive / tool_required_permission /
+   tool_effect_domain moved to Tool_shard_types (intra-library file split,
+   2026-05-16). *)
 
 let () =
   List.iter

--- a/lib/tool_shard_types.ml
+++ b/lib/tool_shard_types.ml
@@ -45,3 +45,41 @@ type shard =
   }
 
 module StringMap = Map.Make (String)
+
+let select_named_schemas (names : string list) (schemas : Masc_domain.tool_schema list)
+  : Masc_domain.tool_schema list
+  =
+  names
+  |> List.filter_map (fun name ->
+    List.find_opt
+      (fun (schema : Masc_domain.tool_schema) -> String.equal schema.name name)
+      schemas)
+;;
+
+let default_shard_names : string list =
+  [ "base"
+  ; "board"
+  ; "filesystem"
+  ; "shell"
+  ; "library"
+  ; "taskboard"
+  ; "coding"
+  ]
+;;
+
+let tool_spec_read_only = [ "masc_tool_list" ]
+let tool_spec_destructive = [ "masc_tool_grant"; "masc_tool_revoke" ]
+
+let tool_required_permission = function
+  | "masc_tool_list" -> Some Masc_domain.CanReadState
+  | "masc_tool_grant" | "masc_tool_revoke" -> Some Masc_domain.CanAdmin
+  | _ -> None
+;;
+
+let tool_effect_domain name =
+  match Tool_name.of_string name with
+  | Some (Tool_name.Masc Tool_name.Masc.Tool_list) -> Some Tool_catalog.Read_only
+  | Some (Tool_name.Masc (Tool_name.Masc.Tool_grant | Tool_name.Masc.Tool_revoke)) ->
+    Some Tool_catalog.Masc_coordination
+  | _ -> None
+;;

--- a/lib/tool_shard_types.mli
+++ b/lib/tool_shard_types.mli
@@ -42,3 +42,23 @@ type shard = {
 }
 
 module StringMap : Map.S with type key = string
+
+(** {1 Schema selection + agent shard helpers} *)
+
+val select_named_schemas :
+  string list -> Masc_domain.tool_schema list -> Masc_domain.tool_schema list
+(** Pure: pick the named schemas (in input order) from the given pool. *)
+
+val default_shard_names : string list
+(** Pure: the 7 shards granted to a fresh agent. *)
+
+val tool_spec_read_only : string list
+val tool_spec_destructive : string list
+
+val tool_required_permission :
+  string -> Masc_domain.permission option
+(** Pure: required keeper permission for invoking a Tool_shard MASC tool. *)
+
+val tool_effect_domain :
+  string -> Tool_catalog.effect_domain option
+(** Pure: tool-catalog effect-domain classification for a Tool_shard MASC tool. *)


### PR DESCRIPTION
## Summary
2번째 tool_shard_types PR. 6 pure helpers + 2 string list constants.

- `select_named_schemas` (schema picker)
- `default_shard_names` (7-shard fresh agent grants)
- `tool_spec_read_only`, `tool_spec_destructive`
- `tool_required_permission` (Masc_domain.permission classifier)
- `tool_effect_domain` (Tool_catalog.effect_domain classifier)

## Cumulative tool_shard reduction (2 PRs)
- ml: **2165 → 2058 LoC (-5%)**

## Workaround self-audit + G1-G5: clean
`RFC-WAIVED: continues intra-library split series.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)