### PR TITLE
refactor(keeper): PR-UnifiedTurn-step6 — record_streaming_cancelled_observation to keeper_unified_turn_types

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -19,50 +19,6 @@ let runtime_lane_label = "runtime"
 
 
 
-let record_streaming_cancelled_observation
-      ~(config : Coord.config)
-      ~(run_meta : keeper_meta)
-      ~(run_generation : int)
-      ~(cascade_name : Keeper_execution_receipt.cascade_name)
-      ~(keeper_turn_id : int)
-      ()
-  : unit
-  =
-  let fiber_stop_set =
-    match Keeper_registry.get ~base_path:config.base_path run_meta.name with
-    | Some entry -> Atomic.get entry.fiber_stop
-    | None -> false
-  in
-  if fiber_stop_set
-  then
-    (* FSM: SupervisorRequestsStop — stop signal confirmed while streaming;
-       turn about to cancel cooperatively. *)
-    Keeper_turn_fsm.emit_transition
-      ~keeper_name:run_meta.name
-      ~turn_id:keeper_turn_id
-      ~prev:Keeper_turn_fsm.Streaming
-      Keeper_turn_fsm.Streaming;
-  let terminal_reason_code =
-    if fiber_stop_set then "supervisor_stop" else "external_cancel"
-  in
-  record_pre_dispatch_terminal_observation
-    ~config
-    ~meta:run_meta
-    ~generation:run_generation
-    ~cascade_name
-    ~outcome:`Cancelled
-    ~terminal_reason_code
-    ~activity_kind:"keeper.turn_cancelled"
-    ~trajectory_outcome:(Trajectory.Gated terminal_reason_code)
-    ~keeper_turn_id
-    ();
-  (* FSM: HonorStopSignal — cooperative cancel. *)
-  Keeper_turn_fsm.emit_transition
-    ~keeper_name:run_meta.name
-    ~turn_id:keeper_turn_id
-    ~prev:Keeper_turn_fsm.Streaming
-    (Keeper_turn_fsm.Cancelled Keeper_turn_fsm.Cancelled_supervisor_stop)
-;;
 
 
 

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -229,3 +229,52 @@ let record_turn_tool_events
        | _ -> ())
     events
 ;;
+
+(** Record the observation for a streaming turn that was cancelled
+    externally (supervisor stop or external cancel). FSM emits +
+    record_pre_dispatch_terminal_observation are *boundary* side
+    effects intentionally retained from the godfile. *)
+let record_streaming_cancelled_observation
+      ~(config : Coord.config)
+      ~(run_meta : Keeper_types.keeper_meta)
+      ~(run_generation : int)
+      ~(cascade_name : Keeper_execution_receipt.cascade_name)
+      ~(keeper_turn_id : int)
+      ()
+  : unit
+  =
+  let fiber_stop_set =
+    match Keeper_registry.get ~base_path:config.base_path run_meta.name with
+    | Some entry -> Atomic.get entry.fiber_stop
+    | None -> false
+  in
+  if fiber_stop_set
+  then
+    (* FSM: SupervisorRequestsStop — stop signal confirmed while streaming;
+       turn about to cancel cooperatively. *)
+    Keeper_turn_fsm.emit_transition
+      ~keeper_name:run_meta.name
+      ~turn_id:keeper_turn_id
+      ~prev:Keeper_turn_fsm.Streaming
+      Keeper_turn_fsm.Streaming;
+  let terminal_reason_code =
+    if fiber_stop_set then "supervisor_stop" else "external_cancel"
+  in
+  Keeper_turn_helpers.record_pre_dispatch_terminal_observation
+    ~config
+    ~meta:run_meta
+    ~generation:run_generation
+    ~cascade_name
+    ~outcome:`Cancelled
+    ~terminal_reason_code
+    ~activity_kind:"keeper.turn_cancelled"
+    ~trajectory_outcome:(Trajectory.Gated terminal_reason_code)
+    ~keeper_turn_id
+    ();
+  (* FSM: HonorStopSignal — cooperative cancel. *)
+  Keeper_turn_fsm.emit_transition
+    ~keeper_name:run_meta.name
+    ~turn_id:keeper_turn_id
+    ~prev:Keeper_turn_fsm.Streaming
+    (Keeper_turn_fsm.Cancelled Keeper_turn_fsm.Cancelled_supervisor_stop)
+;;

--- a/lib/keeper/keeper_unified_turn_types.mli
+++ b/lib/keeper/keeper_unified_turn_types.mli
@@ -72,3 +72,16 @@ val record_turn_tool_events :
   turn_tool_event_tracker ->
   Agent_sdk.Event_bus.event list ->
   unit
+
+(** Record the observation for a streaming turn cancelled externally.
+    Reads the fiber_stop flag from [Keeper_registry], emits FSM
+    transitions, and writes a terminal observation via
+    [Keeper_turn_helpers.record_pre_dispatch_terminal_observation]. *)
+val record_streaming_cancelled_observation :
+  config:Coord.config ->
+  run_meta:Keeper_types.keeper_meta ->
+  run_generation:int ->
+  cascade_name:Keeper_execution_receipt.cascade_name ->
+  keeper_turn_id:int ->
+  unit ->
+  unit


### PR DESCRIPTION
## Summary
- PR-UnifiedTurn-**step6** of RFC-0086 intra-library file split.
- Stacked on #15635 (step5).
- Moves **1 boundary helper, 44 LoC** to `keeper_unified_turn_types.ml(i)`.

## Detail
| Function | LoC | Role |
|---|---|---|
| `record_streaming_cancelled_observation` | 44 | reads fiber_stop atomic from `Keeper_registry`, emits 2 `Keeper_turn_fsm` transitions (SupervisorRequestsStop + HonorStopSignal), writes terminal observation via `Keeper_turn_helpers.record_pre_dispatch_terminal_observation` |

### Boundary pattern reused
dashboard_goals stack step11 (#15627) 에서 *boundary mutation* pattern 도입 — *순수 leaf 가 아니지만 결정론적 projection + IO-touched output* 인 helper 를 types 로 이동. 이번 PR 도 동일 — registry atomic read + FSM emit + observation 모두 *deterministic effect* 이며 외부 state 와 격리됨 (caller 가 base_path/meta 결정).

### Qualified-name discipline
`Keeper_turn_helpers.record_pre_dispatch_terminal_observation` 로 직접 참조 (step2/3/5 패턴 유지).

## LoC delta
- `keeper_unified_turn.ml`: 2809 → 2765 (-44, -1.6%)
- `keeper_unified_turn_types.ml`: 233 → 281 (+48)
- `keeper_unified_turn_types.mli`: 73 → 85 (+12)

godfile 누적: 3020 → 2765 LoC (-8.4%) over 6 PRs.

## RFC-0086 G1-G5 (local)
- G1 cycle: `dune build --root .` exit 0
- G2 mli external view: parent `keeper_unified_turn.mli` 미변경
- G3 새 catch-all: 0
- G4 dune green: ✓
- G5 caller delta: 0

## Test plan
- [ ] `dune build @check` (CI)
- [ ] `dune runtest` (CI)

RFC-WAIVED: docs/scaffolding only — intra-library file split, no architectural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)