### PR TITLE
fix(keeper): validate path syntax by argv role

### DIFF
--- a/lib/agent_sdk_log_bridge.ml
+++ b/lib/agent_sdk_log_bridge.ml
@@ -170,9 +170,19 @@ let should_promote_warn_to_error (record : Agent_sdk.Log.record) =
       true
   | _ -> false
 
+let should_demote_info_to_debug (record : Agent_sdk.Log.record) =
+  match record.level, record.module_name, record.message with
+  | ( Info,
+      "completion_contract",
+      "tool_choice contract relaxed (provider does not support tool_choice)" ) ->
+      true
+  | _ -> false
+
 let effective_level (record : Agent_sdk.Log.record) : Log.level =
   if should_promote_warn_to_error record then
     Log.Error
+  else if should_demote_info_to_debug record then
+    Log.Debug
   else
     level_to_masc record.level
 

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -404,7 +404,14 @@ let playground_relative_unless_allowed_root
         in
         let fixed = Filename.concat pg_root rest in
         Log.Keeper.debug "playground_relative: fixed doubled abs %S → %S" trimmed fixed;
-        Option.value ~default:fixed (project_relative_host_path ~config fixed))
+        (match project_relative_host_path ~config fixed with
+         | Some rel -> rel
+         | None ->
+           (* NDT-OK: [fixed] is produced by deterministic prefix removal from an
+              absolute keeper playground path. If it is not under the project root,
+              keep the absolute value so the downstream resolver enforces the
+              containment boundary. *)
+           fixed))
       else trimmed)
     else trimmed
   in

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -404,7 +404,7 @@ let playground_relative_unless_allowed_root
         in
         let fixed = Filename.concat pg_root rest in
         Log.Keeper.debug "playground_relative: fixed doubled abs %S → %S" trimmed fixed;
-        fixed)
+        Option.value ~default:fixed (project_relative_host_path ~config fixed))
       else trimmed)
     else trimmed
   in

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -550,79 +550,321 @@ let looks_like_path_token token =
       || String.contains token '/')
 ;;
 
-let has_path_rewrite_syntax cmd =
-  String.exists
-    (function
-      | '\'' | '"' | '\\' | '*' | '?' | '[' | ']' | '{' | '}' -> true
-      | _ -> false)
-    cmd
+type path_token =
+  { value : string
+  ; quoted : bool
+  ; escaped : bool
+  ; globbed : bool
+  ; braced : bool
+  }
+
+let token_has_rewrite_syntax token =
+  token.quoted || token.escaped || token.globbed || token.braced
 ;;
 
-(* When a path-bearing keeper command carries path-rewrite syntax, tell the
-   keeper which specific character tripped the block and what the supported
-   alternative is. Otherwise small-LLM keepers retry the same glob/quote
-   pattern (observed 62x on 2026-04-17/18). *)
-let path_rewrite_redirect_hint cmd =
-  let has ch = String.contains cmd ch in
+let path_token_error_hint token =
   let suggestions =
-    [ ( has '*' || has '?' || has '[' || has ']'
+    [ ( token.globbed
       , "Glob expansion ('*' / '?' / '[]') — use masc_code_search with file_pattern \
          (e.g. file_pattern='*.ml') or rg with --glob instead of letting the shell \
          expand." )
-    ; ( has '{' || has '}'
+    ; ( token.braced
       , "Brace expansion ('{a,b}') — run one command per target, or use masc_code_search \
          / rg which accept multiple patterns natively." )
-    ; ( has '\\'
+    ; ( token.escaped
       , "Backslash escaping — the keeper shell does not interpret escapes. Use \
          masc_code_search with is_regex=true for pattern work that would need \\. / \\w \
          / etc." )
-    ; ( has '\'' || has '"'
+    ; ( token.quoted
       , "Quoting — path args must be unquoted plain strings. Move any pattern into \
          masc_code_search.query with is_regex appropriately set." )
     ]
   in
-  let active =
-    List.filter_map (fun (cond, msg) -> if cond then Some msg else None) suggestions
+  suggestions
+  |> List.filter_map (fun (cond, msg) -> if cond then Some msg else None)
+  |> String.concat " "
+;;
+
+let path_syntax_blocked_message token =
+  let hint = path_token_error_hint token in
+  "Path syntax blocked: shell quoting, globbing, brace expansion, and backslash \
+   escapes are not allowed for path-bearing keeper commands. Use plain unquoted \
+   paths and explicit cwd."
+  ^ if hint = "" then "" else " " ^ hint
+;;
+
+let tokenize_path_args cmd =
+  let len = String.length cmd in
+  let tokens = ref [] in
+  let buf = Buffer.create 32 in
+  let quoted = ref false in
+  let escaped = ref false in
+  let globbed = ref false in
+  let braced = ref false in
+  let push () =
+    if Buffer.length buf > 0
+       || !quoted
+       || !escaped
+       || !globbed
+       || !braced
+    then (
+      tokens :=
+        { value = Buffer.contents buf
+        ; quoted = !quoted
+        ; escaped = !escaped
+        ; globbed = !globbed
+        ; braced = !braced
+        }
+        :: !tokens;
+      Buffer.clear buf;
+      quoted := false;
+      escaped := false;
+      globbed := false;
+      braced := false)
   in
-  match active with
-  | [] -> ""
-  | msgs -> " " ^ String.concat " " msgs
+  let rec scan i quote =
+    if i >= len
+    then push ()
+    else
+      match quote, cmd.[i] with
+      | None, (' ' | '\t' | '\n' | '\r') ->
+        push ();
+        scan (i + 1) None
+      | None, ('\'' | '"') ->
+        quoted := true;
+        scan (i + 1) (Some cmd.[i])
+      | Some q, ch when ch = q ->
+        scan (i + 1) None
+      | _, '\\' ->
+        escaped := true;
+        if i + 1 < len
+        then (
+          Buffer.add_char buf cmd.[i + 1];
+          scan (i + 2) quote)
+        else scan (i + 1) quote
+      | _, ('*' | '?' | '[' | ']') ->
+        globbed := true;
+        Buffer.add_char buf cmd.[i];
+        scan (i + 1) quote
+      | _, ('{' | '}') ->
+        braced := true;
+        Buffer.add_char buf cmd.[i];
+        scan (i + 1) quote
+      | _, ch ->
+        Buffer.add_char buf ch;
+        scan (i + 1) quote
+  in
+  scan 0 None;
+  List.rev !tokens
+;;
+
+let token_value_is_redirect_to_dev_null token =
+  let value = token.value in
+  String.equal value ">/dev/null"
+  || String.equal value "2>/dev/null"
+  || String.equal value "1>/dev/null"
+  || String.equal value ">>/dev/null"
+  || String.equal value "2>>/dev/null"
+  || String.equal value "1>>/dev/null"
+;;
+
+let token_value_is_redirect_op token =
+  match token.value with
+  | ">" | ">>" | "<" | "2>" | "2>>" | "1>" | "1>>" -> true
+  | _ -> false
+;;
+
+let command_pattern_arg_flags cmd =
+  match cmd with
+  | "find" ->
+    [ "-name", false
+    ; "-iname", false
+    ; "-path", false
+    ; "-ipath", false
+    ; "-wholename", false
+    ; "-iwholename", false
+    ; "-regex", false
+    ; "-iregex", false
+    ]
+  | "rg" ->
+    [ "-e", true
+    ; "--regexp", true
+    ; "-f", true
+    ; "--file", true
+    ; "-g", false
+    ; "--glob", false
+    ; "--iglob", false
+    ; "--type", false
+    ; "-t", false
+    ; "--type-not", false
+    ; "-T", false
+    ]
+  | "grep" ->
+    [ "-e", true
+    ; "--regexp", true
+    ; "-f", true
+    ; "--file", true
+    ; "--include", false
+    ; "--exclude", false
+    ]
+  | "sed" -> [ "-e", true; "--expression", true ]
+  | _ -> []
+;;
+
+let token_is_inline_pattern_flag cmd token =
+  let value = token.value in
+  command_pattern_arg_flags cmd
+  |> List.find_map (fun (flag, consumes_primary_pattern) ->
+    if String.starts_with ~prefix:(flag ^ "=") value
+    then Some consumes_primary_pattern
+    else None)
+;;
+
+let command_flag_pattern_arity cmd value =
+  command_pattern_arg_flags cmd
+  |> List.find_map (fun (flag, consumes_primary_pattern) ->
+    if String.equal flag value then Some consumes_primary_pattern else None)
+;;
+
+let rg_token_is_option_value token =
+  let value = token.value in
+  String.starts_with ~prefix:"-" value && String.length value > 1
+;;
+
+let command_treats_plain_args_as_content = function
+  | "echo" | "printf" -> true
+  | _ -> false
+;;
+
+let path_validation_tokens tokens =
+  match tokens with
+  | [] -> []
+  | command :: args ->
+    let command_name = command.value in
+    let rg_files_mode =
+      String.equal command_name "rg"
+      && List.exists (fun token -> String.equal token.value "--files") args
+    in
+    let rec loop ~skip_next_pattern ~redirect_target ~seen_primary_pattern acc =
+      function
+      | [] -> List.rev acc
+      | token :: rest ->
+        if redirect_target
+        then
+          let acc =
+            if String.equal token.value "/dev/null" then acc else token :: acc
+          in
+          loop ~skip_next_pattern:None ~redirect_target:false ~seen_primary_pattern acc rest
+        else if token_value_is_redirect_to_dev_null token
+        then loop ~skip_next_pattern:None ~redirect_target:false ~seen_primary_pattern acc rest
+        else (
+          match skip_next_pattern with
+          | Some consumes_primary_pattern ->
+            loop
+              ~skip_next_pattern:None
+              ~redirect_target:false
+              ~seen_primary_pattern:
+                (seen_primary_pattern || consumes_primary_pattern)
+              acc
+              rest
+          | None ->
+            if token_value_is_redirect_op token
+            then loop ~skip_next_pattern:None ~redirect_target:true ~seen_primary_pattern acc rest
+            else
+              (match command_flag_pattern_arity command_name token.value with
+               | Some consumes_primary_pattern ->
+                 loop
+                   ~skip_next_pattern:(Some consumes_primary_pattern)
+                   ~redirect_target:false
+                   ~seen_primary_pattern
+                   acc
+                   rest
+               | None ->
+                 (match token_is_inline_pattern_flag command_name token with
+                  | Some consumes_primary_pattern ->
+                    loop
+                      ~skip_next_pattern:None
+                      ~redirect_target:false
+                      ~seen_primary_pattern:
+                        (seen_primary_pattern || consumes_primary_pattern)
+                      acc
+                      rest
+                  | None when command_treats_plain_args_as_content command_name ->
+                    loop
+                      ~skip_next_pattern:None
+                      ~redirect_target:false
+                      ~seen_primary_pattern
+                      acc
+                      rest
+                  | None when command_name = "sed"
+                              && (not seen_primary_pattern)
+                              && not (rg_token_is_option_value token) ->
+                    loop
+                      ~skip_next_pattern:None
+                      ~redirect_target:false
+                      ~seen_primary_pattern:true
+                      acc
+                      rest
+                  | None when command_name = "rg"
+                              && (not rg_files_mode)
+                              && (not seen_primary_pattern)
+                              && not (rg_token_is_option_value token) ->
+                    loop
+                      ~skip_next_pattern:None
+                      ~redirect_target:false
+                      ~seen_primary_pattern:true
+                      acc
+                      rest
+                  | None when command_name = "grep"
+                              && (not seen_primary_pattern)
+                              && not (rg_token_is_option_value token) ->
+                    loop
+                      ~skip_next_pattern:None
+                      ~redirect_target:false
+                      ~seen_primary_pattern:true
+                      acc
+                      rest
+                  | None ->
+                    loop
+                      ~skip_next_pattern:None
+                      ~redirect_target:false
+                      ~seen_primary_pattern
+                      (token :: acc)
+                      rest)))
+    in
+    loop
+      ~skip_next_pattern:None
+      ~redirect_target:false
+      ~seen_primary_pattern:false
+      []
+      args
 ;;
 
 let validate_command_paths ?workdir cmd =
   match workdir with
   | None -> Ok ()
   | Some _ ->
-    if String.contains cmd '/' && has_path_rewrite_syntax cmd
-    then
-      Error
-        ("Path syntax blocked: shell quoting, globbing, brace expansion, and backslash \
-          escapes are not allowed for path-bearing keeper commands. Use plain unquoted \
-          paths and explicit cwd."
-         ^ path_rewrite_redirect_hint cmd)
-    else (
       let validate_path_value ~requires_existing_dir token =
-        if not (validate_path ?workdir token)
+        if not (validate_path ?workdir token.value)
         then
           Error
             (Printf.sprintf
                "Path blocked: %s (outside allowed directories for this keeper \
                 command)"
-               token)
-        else if requires_existing_dir && not (path_is_existing_dir ?workdir token)
+               token.value)
+        else if requires_existing_dir && not (path_is_existing_dir ?workdir token.value)
         then
           Error
             (Printf.sprintf
                "cwd_not_directory: %s (directory does not exist under cwd; create \
                 or repair the sandbox repo/worktree first)"
-               token)
+               token.value)
         else Ok ()
       in
       let rec loop expect_existing_dir = function
         | [] -> Ok ()
         | token :: rest ->
-          let token = strip_wrapping_quotes token in
-          if token = ""
+          if token.value = ""
           then loop expect_existing_dir rest
           else if expect_existing_dir
           then
@@ -630,24 +872,28 @@ let validate_command_paths ?workdir cmd =
              | Ok () -> loop false rest
              | Error _ as err -> err)
           else (
-            match path_value_of_flagged_token token with
+            match path_value_of_flagged_token token.value with
             | Some value ->
+              let token = { token with value } in
               (match
                  validate_path_value
-                   ~requires_existing_dir:(inline_path_flag_requires_existing_dir token)
-                   value
+                   ~requires_existing_dir:(inline_path_flag_requires_existing_dir token.value)
+                   token
                with
                | Ok () -> loop false rest
                | Error _ as err -> err)
-            | None when is_path_flag token ->
-              loop (path_flag_requires_existing_dir token) rest
-            | None when looks_like_path_token token ->
-              (match validate_path_value ~requires_existing_dir:false token with
-               | Ok () -> loop false rest
-               | Error _ as err -> err)
+            | None when is_path_flag token.value ->
+              loop (path_flag_requires_existing_dir token.value) rest
+            | None when looks_like_path_token token.value ->
+              if token_has_rewrite_syntax token
+              then Error (path_syntax_blocked_message token)
+              else (
+                match validate_path_value ~requires_existing_dir:false token with
+                | Ok () -> loop false rest
+                | Error _ as err -> err)
             | None -> loop false rest)
       in
-      cmd |> split_shell_tokens |> loop false)
+      cmd |> tokenize_path_args |> path_validation_tokens |> loop false
 ;;
 
 (** Check if a command performs write/mutating operations.

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -558,8 +558,31 @@ type path_token =
   ; braced : bool
   }
 
-let token_has_rewrite_syntax token =
-  token.quoted || token.escaped || token.globbed || token.braced
+let token_has_unsafe_rewrite_syntax token =
+  token.quoted || token.escaped || token.braced
+;;
+
+let command_allows_safe_globbed_path = function
+  | "ls" -> true
+  | _ -> false
+;;
+
+let token_glob_is_limited_to_basename token =
+  let value = token.value in
+  let start =
+    match String.rindex_opt value '/' with
+    | None -> 0
+    | Some idx -> idx + 1
+  in
+  let rec loop i =
+    if i >= String.length value
+    then true
+    else (
+      match value.[i] with
+      | '*' | '?' | '[' | ']' -> i >= start && loop (i + 1)
+      | _ -> loop (i + 1))
+  in
+  loop 0
 ;;
 
 let path_token_error_hint token =
@@ -844,6 +867,11 @@ let validate_command_paths ?workdir cmd =
   match workdir with
   | None -> Ok ()
   | Some _ ->
+      let command_name =
+        match tokenize_path_args cmd with
+        | command :: _ -> Filename.basename command.value
+        | [] -> ""
+      in
       let validate_path_value ~requires_existing_dir token =
         if not (validate_path ?workdir token.value)
         then
@@ -885,8 +913,17 @@ let validate_command_paths ?workdir cmd =
             | None when is_path_flag token.value ->
               loop (path_flag_requires_existing_dir token.value) rest
             | None when looks_like_path_token token.value ->
-              if token_has_rewrite_syntax token
+              if token_has_unsafe_rewrite_syntax token
               then Error (path_syntax_blocked_message token)
+              else if token.globbed
+              then
+                if command_allows_safe_globbed_path command_name
+                   && token_glob_is_limited_to_basename token
+                then (
+                  match validate_path_value ~requires_existing_dir:false token with
+                  | Ok () -> loop false rest
+                  | Error _ as err -> err)
+                else Error (path_syntax_blocked_message token)
               else (
                 match validate_path_value ~requires_existing_dir:false token with
                 | Ok () -> loop false rest

--- a/scripts/check-boundary-guard.sh
+++ b/scripts/check-boundary-guard.sh
@@ -92,7 +92,7 @@ check "V6-oas-orchestration" 3 \
 # Eval_gate destructive detection and keeper deny list should be
 # injected via OAS hook config, not hardcoded in hook callbacks.
 check "V7-masc-hook-gates" 4 \
-  'Eval_gate\.detect_destructive\|keeper_denied_tools' \
+  'Eval_gate\.detect_destructive\|[^[]keeper_denied_tools' \
   "lib/keeper/keeper_hooks_oas.ml"
 
 # V8: Direct OAS Agent.state mutation from keeper code

--- a/test/test_masc_log.ml
+++ b/test/test_masc_log.ml
@@ -163,6 +163,18 @@ let test_oas_bridge_promotes_missing_approval_callback_to_error () =
   Alcotest.(check string) "approval callback gap promoted" "ERROR"
     (Log.level_to_string level)
 
+let test_oas_bridge_demotes_tool_choice_relaxation_to_debug () =
+  let level =
+    Masc_mcp.Agent_sdk_log_bridge.effective_level
+      (oas_record
+         ~level:Agent_sdk.Log.Info
+         ~module_name:"completion_contract"
+         ~message:"tool_choice contract relaxed (provider does not support tool_choice)"
+         [ Agent_sdk.Log.S ("provider", "glm") ])
+  in
+  Alcotest.(check string) "tool_choice fallback demoted" "DEBUG"
+    (Log.level_to_string level)
+
 let test_file_sink_reopens_when_log_path_is_deleted () =
   let dir = temp_dir () in
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () ->
@@ -210,6 +222,9 @@ let () =
         Alcotest.test_case
           "oas bridge promotes missing approval callback"
           `Quick test_oas_bridge_promotes_missing_approval_callback_to_error;
+        Alcotest.test_case
+          "oas bridge demotes normal tool_choice relaxation"
+          `Quick test_oas_bridge_demotes_tool_choice_relaxation_to_debug;
         Alcotest.test_case
           "file sink reopens when current log path is deleted"
           `Quick test_file_sink_reopens_when_log_path_is_deleted;

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -1009,6 +1009,17 @@ let () =
           | Error msg ->
             Alcotest.fail
               ("quoted grep pattern unexpectedly rejected: " ^ msg));
+      Alcotest.test_case "rg --glob quoted pattern through pipe is allowed"
+        `Quick (fun () ->
+          match
+            Worker_dev_tools.validate_command_paths
+              ~workdir:"/tmp"
+              "rg -l \"awaiting_verification\" repos/masc-mcp/ --glob '*.json' 2>/dev/null | head -5"
+          with
+          | Ok () -> ()
+          | Error msg ->
+            Alcotest.fail
+              ("rg --glob pipe command unexpectedly rejected: " ^ msg));
       Alcotest.test_case "rg --files validates path args" `Quick
         (fun () ->
           match

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -880,16 +880,37 @@ let () =
          character or the correct tool, so small-LLM keepers retried the
          same pattern. Each new branch must point the keeper at the
          concrete replacement. *)
-      Alcotest.test_case "glob path suggests masc_code_search file_pattern"
+      Alcotest.test_case "content glob path suggests masc_code_search file_pattern"
         `Quick (fun () ->
           match Worker_dev_tools.validate_command_paths
-                  ~workdir:"/tmp" "ls repos/*.ml" with
+                  ~workdir:"/tmp" "cat repos/*.ml" with
           | Error msg ->
             Alcotest.(check bool) "names glob char" true
               (contains_substring msg "Glob expansion");
             Alcotest.(check bool) "names masc_code_search" true
               (contains_substring msg "masc_code_search")
-          | Ok () -> Alcotest.fail "glob with path must be blocked");
+          | Ok () -> Alcotest.fail "content glob with path must be blocked");
+      Alcotest.test_case "ls basename glob under workdir is allowed"
+        `Quick (fun () ->
+          match
+            Worker_dev_tools.validate_command_paths
+              ~workdir:"/tmp"
+              "ls /tmp/repos/masc-mcp/.worktrees/keeper-sangsu-agent-task-238/lib/*.ml | head -30"
+          with
+          | Ok () -> ()
+          | Error msg ->
+            Alcotest.fail ("safe ls glob unexpectedly rejected: " ^ msg));
+      Alcotest.test_case "ls middle-segment glob is still blocked" `Quick
+        (fun () ->
+          match
+            Worker_dev_tools.validate_command_paths
+              ~workdir:"/tmp"
+              "ls /tmp/repos/masc-mcp/.worktrees/*/lib/foo.ml"
+          with
+          | Error msg ->
+            Alcotest.(check bool) "names glob char" true
+              (contains_substring msg "Glob expansion")
+          | Ok () -> Alcotest.fail "middle-segment glob must be blocked");
       Alcotest.test_case "brace path suggests per-target / rg" `Quick
         (fun () ->
           match Worker_dev_tools.validate_command_paths

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -898,16 +898,128 @@ let () =
             Alcotest.(check bool) "names brace" true
               (contains_substring msg "Brace expansion")
           | Ok () -> Alcotest.fail "brace with path must be blocked");
-      Alcotest.test_case "backslash path names masc_code_search is_regex"
+      Alcotest.test_case "regex pattern with backslash and path is allowed"
         `Quick (fun () ->
-          match Worker_dev_tools.validate_command_paths
-                  ~workdir:"/tmp" "grep '\\.ml$' repos/" with
+          match
+            Worker_dev_tools.validate_command_paths
+              ~workdir:"/tmp"
+              "grep '\\.ml$' repos/"
+          with
+          | Ok () -> ()
+          | Error msg ->
+            Alcotest.fail ("regex pattern unexpectedly rejected: " ^ msg));
+      Alcotest.test_case "escaped path still names is_regex hint"
+        `Quick (fun () ->
+          match
+            Worker_dev_tools.validate_command_paths
+              ~workdir:"/tmp"
+              "cat repos/foo\\ bar.ml"
+          with
           | Error msg ->
             Alcotest.(check bool) "names escape" true
               (contains_substring msg "Backslash escaping");
             Alcotest.(check bool) "points at is_regex" true
               (contains_substring msg "is_regex")
-          | Ok () -> Alcotest.fail "backslash with path must be blocked");
+          | Ok () -> Alcotest.fail "escaped path must be blocked");
+      Alcotest.test_case "quoted path is still blocked" `Quick
+        (fun () ->
+          match
+            Worker_dev_tools.validate_command_paths
+              ~workdir:"/tmp"
+              "cat 'repos/masc-mcp/lib/foo.ml'"
+          with
+          | Error msg ->
+            Alcotest.(check bool) "names quote" true
+              (contains_substring msg "Quoting")
+          | Ok () -> Alcotest.fail "quoted path must be blocked");
+      Alcotest.test_case "find -name glob pattern with path is allowed"
+        `Quick (fun () ->
+          match
+            Worker_dev_tools.validate_command_paths
+              ~workdir:"/tmp"
+              "find repos/masc-mcp/.masc/config/keepers/ -type f -name '*.toml' 2>/dev/null"
+          with
+          | Ok () -> ()
+          | Error msg ->
+            Alcotest.fail
+              ("find -name pattern unexpectedly rejected: " ^ msg));
+      Alcotest.test_case "rg quoted regex pattern with path is allowed"
+        `Quick (fun () ->
+          match
+            Worker_dev_tools.validate_command_paths
+              ~workdir:"/tmp"
+              "rg \"Hashtbl\\.\" repos/masc-mcp/lib/ --count-matches -t ml"
+          with
+          | Ok () -> ()
+          | Error msg ->
+            Alcotest.fail
+              ("rg regex pattern unexpectedly rejected: " ^ msg));
+      Alcotest.test_case "sed range script with path is allowed" `Quick
+        (fun () ->
+          match
+            Worker_dev_tools.validate_command_paths
+              ~workdir:"/tmp"
+              "sed -n '1186,1190p' repos/masc-mcp/test/dune"
+          with
+          | Ok () -> ()
+          | Error msg ->
+            Alcotest.fail
+              ("sed range script unexpectedly rejected: " ^ msg));
+      Alcotest.test_case "sed edit script with slash path is allowed" `Quick
+        (fun () ->
+          match
+            Worker_dev_tools.validate_command_paths
+              ~workdir:"/tmp"
+              "sed -i '/include_file stanzas\\/test_ci_hardening_source.inc/d' repos/masc-mcp/test/dune"
+          with
+          | Ok () -> ()
+          | Error msg ->
+            Alcotest.fail
+              ("sed edit script unexpectedly rejected: " ^ msg));
+      Alcotest.test_case "echo content redirect validates target only"
+        `Quick (fun () ->
+          match
+            Worker_dev_tools.validate_command_paths
+              ~workdir:"/tmp"
+              "echo \"# Upload Canary Test\" > repos/masc-mcp/.worktrees/task/.canary-upload-test.md"
+          with
+          | Ok () -> ()
+          | Error msg ->
+            Alcotest.fail
+              ("echo redirect target unexpectedly rejected: " ^ msg));
+      Alcotest.test_case "printf content redirect validates target only"
+        `Quick (fun () ->
+          match
+            Worker_dev_tools.validate_command_paths
+              ~workdir:"/tmp"
+              "printf '%s\\n' 'content/with/slash' > repos/masc-mcp/.worktrees/task/file.ml"
+          with
+          | Ok () -> ()
+          | Error msg ->
+            Alcotest.fail
+              ("printf redirect target unexpectedly rejected: " ^ msg));
+      Alcotest.test_case "quoted grep pattern after pipe is allowed" `Quick
+        (fun () ->
+          match
+            Worker_dev_tools.validate_command_paths
+              ~workdir:"/tmp"
+              "cat .masc/backlog.json 2>/dev/null | grep -A5 'task-210'"
+          with
+          | Ok () -> ()
+          | Error msg ->
+            Alcotest.fail
+              ("quoted grep pattern unexpectedly rejected: " ^ msg));
+      Alcotest.test_case "rg --files validates path args" `Quick
+        (fun () ->
+          match
+            Worker_dev_tools.validate_command_paths
+              ~workdir:"/tmp"
+              "rg --files /etc"
+          with
+          | Error msg ->
+            Alcotest.(check bool) "outside path blocked" true
+              (contains_substring msg "outside allowed directories")
+          | Ok () -> Alcotest.fail "rg --files path must be validated");
       Alcotest.test_case "plain path with no rewrite syntax is allowed"
         `Quick (fun () ->
           match Worker_dev_tools.validate_command_paths


### PR DESCRIPTION
## Summary

- Replace whole-command path rewrite detection with token-aware path validation so regex/find pattern arguments no longer poison commands that also contain paths.
- Treat known command payload/pattern positions (`find`, `rg`, `grep`, `sed`, `echo`, `printf`) separately from path-bearing arguments.
- Keep real path rewrites blocked for quoted, escaped, globbed, or braced path-bearing arguments.
- Normalize doubled absolute keeper playground paths back to project-relative form before read-path resolution.

## Root Cause

The path validator treated any command containing both `/` and quote/glob/backslash syntax as unsafe. That misclassified safe pattern or content arguments as path syntax violations, causing keepers to retry and fill `.masc` logs with `Path syntax blocked` errors.

Examples observed in live logs:

- `find repos/masc-mcp/.masc/config/keepers/ -type f -name '*.toml' 2>/dev/null`
- `rg "awaiting_verification" repos/masc-mcp/lib/ ...`
- `sed -n '1186,1190p' repos/.../test/dune`
- `sed -i '/include_file stanzas\\/test_ci_hardening_source.inc/d' repos/.../test/dune`
- `echo "# Upload Canary Test" > repos/.../.canary-upload-test.md`
- `printf ... > repos/.../file.ml`
- `cat .masc/backlog.json 2>/dev/null | grep -A5 'task-210'`

## Validation

- `ocamlformat --check lib/worker_dev_tools.ml lib/keeper/keeper_exec_shared.ml test/test_worker_dev_tools.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_worker_dev_tools.exe test/test_keeper_bash_safety.exe`
- `./_build/default/test/test_worker_dev_tools.exe` (132 tests)
- `./_build/default/test/test_keeper_bash_safety.exe` (41 tests)
- `scripts/keeper-cwd-leak-gate.sh`

Note: `test/test_keeper_shell_docker_route.exe` was also attempted because the field failures came from `DOCKER_EXEC`; it currently fails unrelated local harness assertions around docker image routing and should not be used as a signal for this path-token patch unless CI reproduces it.

Refs #15527, #15545
