### PR TITLE
fix(keeper): keep workflow rejections out of circuit breaker

### DIFF
--- a/lib/keeper/keeper_exec_masc.ml
+++ b/lib/keeper/keeper_exec_masc.ml
@@ -19,7 +19,7 @@ let handle_keeper_autoresearch_tool
   match Tool_autoresearch.dispatch ctx ~name ~args with
   | Some result ->
       if result.success then Tool_result.message result
-      else error_json (Tool_result.message result)
+      else tool_result_error_json result
   | None -> error_json ~fields:[ "tool", `String name ] "unknown_autoresearch_tool"
 ;;
 
@@ -161,7 +161,7 @@ let handle_keeper_masc_tool
          | Some tr ->
            let ok = tr.success in
            let msg = Tool_result.message tr in
-           if ok then msg else error_json msg
+           if ok then msg else tool_result_error_json tr
          | None ->
            if Tool_dispatch.is_mcp_context_required name
            then
@@ -203,7 +203,7 @@ let handle_keeper_masc_tool
                 | Some tr when tr.Tool_result.success ->
                   tr.Tool_result.legacy_message
                 | Some tr ->
-                  error_json tr.Tool_result.legacy_message
+                  tool_result_error_json tr
                 | None ->
                   Yojson.Safe.to_string
                     (`Assoc
@@ -237,7 +237,7 @@ let handle_registered_keeper_tool
        | None -> None
        | Some tr ->
          let msg = Tool_result.message tr in
-         Some (if tr.success then msg else error_json msg))
+         Some (if tr.success then msg else tool_result_error_json tr))
   in
   match dispatch_registered_handler () with
   | Some _ as result -> result

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -8,10 +8,20 @@ let error_json ?(fields = []) (message : string) =
   Yojson.Safe.to_string (`Assoc (("error", `String message) :: fields))
 ;;
 
+let tool_result_error_json (tr : Tool_result.t) =
+  let fields =
+    match Tool_result.failure_class tr with
+    | None -> []
+    | Some cls ->
+      [ "failure_class", `String (Tool_result.tool_failure_class_to_string cls) ]
+  in
+  error_json ~fields (Tool_result.message tr)
+;;
+
 let tool_result_or_error (tr : Tool_result.t) =
   let ok = tr.success in
   let msg = Tool_result.message tr in
-  if ok then msg else error_json msg
+  if ok then msg else tool_result_error_json tr
 ;;
 
 (** Phase B PR-5 precursor (2026-04-28): the action mapping itself,

--- a/lib/keeper/keeper_exec_shared.mli
+++ b/lib/keeper/keeper_exec_shared.mli
@@ -10,6 +10,10 @@ val count_context_tokens : Keeper_types.working_context -> int
 (** Render an error JSON envelope: [{"error": <message>; ...fields}]. *)
 val error_json : ?fields:(string * Yojson.Safe.t) list -> string -> string
 
+(** Render a failed [Tool_result.t] as [error_json], preserving
+    [failure_class] for keeper-facing routing and diagnostics. *)
+val tool_result_error_json : Tool_result.t -> string
+
 (** [Tool_result.t] passes [msg] through on success; wraps it
     in [error_json] on failure. *)
 val tool_result_or_error : Tool_result.t -> string

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -234,6 +234,23 @@ let classify_tool_result_payload payload =
     | Ok _ -> Structured_success)
 ;;
 
+let failure_class_of_tool_result_payload payload =
+  match
+    Safe_ops.parse_json_safe
+      ~context:"Keeper_exec_tools.failure_class_of_tool_result_payload"
+      payload
+  with
+  | Ok json -> Safe_ops.json_string_opt "failure_class" json
+  | Error _ -> None
+;;
+
+let should_apply_circuit_breaker_to_failure_payload payload =
+  match failure_class_of_tool_result_payload payload with
+  | Some "workflow_rejection" -> false
+  | Some _
+  | None -> true
+;;
+
 let is_policy_gate_error raw_output =
   match
     Safe_ops.parse_json_safe ~context:"Keeper_exec_tools.is_policy_gate_error" raw_output
@@ -325,9 +342,13 @@ let execute_keeper_tool_call_with_outcome
       }
     | `Failure, Structured_error | `Failure, Structured_success | `Failure, Plain_text ->
       let raw_output =
-        Keeper_failure_circuit_breaker.maybe_enrich_error
-          ~keeper_name:meta.name
-          ~error_msg:result.raw_output
+        if should_apply_circuit_breaker_to_failure_payload result.raw_output
+        then
+          Keeper_failure_circuit_breaker.maybe_enrich_error
+            ~keeper_name:meta.name
+            ~error_msg:result.raw_output
+        else
+          result.raw_output
       in
       { raw_output
       ; outcome = `Failure

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -142,6 +142,15 @@ type executed_tool_result =
 (** Inspect a keeper tool result payload without applying side effects. *)
 val classify_tool_result_payload : string -> tool_result_payload
 
+(** Extract the optional [failure_class] field from a structured keeper
+    tool payload. Returns [None] for plain text or malformed JSON. *)
+val failure_class_of_tool_result_payload : string -> string option
+
+(** [false] when a failed tool payload is a business-rule workflow
+    rejection that should be shown to the keeper without opening the
+    repeated-failure circuit breaker. *)
+val should_apply_circuit_breaker_to_failure_payload : string -> bool
+
 (** Tag-based dispatch callback for masc_* tools without handler registry entries.
     Set at server init to [Keeper_tag_dispatch.dispatch]. Default: returns None.
     See #4579. *)

--- a/lib/tool_types/tool_result.ml
+++ b/lib/tool_types/tool_result.ml
@@ -81,6 +81,10 @@ let classify_from_dispatch_failure (message : string) : tool_failure_class =
   if
     contains_casefold message "awaiting_approval"
     || contains_casefold message "join required"
+    || contains_casefold message "Invalid task state"
+    || contains_casefold message "Invalid transition"
+    || contains_casefold message "Self-approval not allowed"
+    || contains_casefold message "Self-rejection not allowed"
   then Workflow_rejection
   else if
     contains_casefold message "egress_blocked"

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -64,6 +64,15 @@ let payload_kind = function
   | KET.Plain_text -> "plain_text"
   | KET.Malformed_structured _ -> "malformed_structured"
 
+let contains_substring text needle =
+  let text_len = String.length text in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    idx + needle_len <= text_len
+    && (String.sub text idx needle_len = needle || loop (idx + 1))
+  in
+  needle_len = 0 || loop 0
+
 let check_kind ~msg expected payload =
   check string msg expected
     (payload_kind (KET.classify_tool_result_payload payload))
@@ -481,6 +490,55 @@ let test_preflight_allows_work_discovery_disabled_with_current_task () =
       check string "current task exposed" "task-owned"
         Yojson.Safe.Util.(member "current_task_id" work_discovery |> to_string))
 
+let workflow_rejection_message =
+  "Invalid task state: Self-approval not allowed: verifier must be a different agent"
+
+let test_tool_result_classifies_task_fsm_rejections_as_workflow () =
+  let result =
+    Tool_result.error
+      ~tool_name:"masc_transition"
+      ~start_time:(Unix.gettimeofday ())
+      workflow_rejection_message
+  in
+  match Tool_result.failure_class result with
+  | Some Tool_result.Workflow_rejection -> ()
+  | Some cls ->
+    fail
+      (Printf.sprintf
+         "expected workflow_rejection, got %s"
+         (Tool_result.tool_failure_class_to_string cls))
+  | None -> fail "expected failure_class"
+
+let test_tool_result_or_error_preserves_failure_class () =
+  let result =
+    Tool_result.error
+      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~tool_name:"masc_transition"
+      ~start_time:(Unix.gettimeofday ())
+      workflow_rejection_message
+  in
+  let json = Yojson.Safe.from_string (KES.tool_result_or_error result) in
+  check string "failure_class" "workflow_rejection"
+    Yojson.Safe.Util.(member "failure_class" json |> to_string)
+
+let test_workflow_rejection_payload_skips_circuit_breaker () =
+  let workflow_payload =
+    KES.error_json
+      ~fields:[ "failure_class", `String "workflow_rejection" ]
+      workflow_rejection_message
+  in
+  let runtime_payload =
+    KES.error_json
+      ~fields:[ "failure_class", `String "runtime_failure" ]
+      "No such file or directory"
+  in
+  check (option string) "extracts workflow class" (Some "workflow_rejection")
+    (KET.failure_class_of_tool_result_payload workflow_payload);
+  check bool "workflow rejection does not trip circuit breaker" false
+    (KET.should_apply_circuit_breaker_to_failure_payload workflow_payload);
+  check bool "runtime failure still trips circuit breaker" true
+    (KET.should_apply_circuit_breaker_to_failure_payload runtime_payload)
+
 let registered_dispatch_probe_tool = "test_keeper_registered_dispatch_probe"
 
 let register_registered_dispatch_probe () =
@@ -498,6 +556,22 @@ let register_registered_dispatch_probe () =
                 ; ("tool", `String name)
                 ; ("route", `String "registered")
                 ]))))
+
+let workflow_rejection_probe_tool = "test_keeper_workflow_rejection_probe"
+
+let register_workflow_rejection_probe () =
+  Masc_mcp.Tool_dispatch.register_name_tag
+    ~tool_name:workflow_rejection_probe_tool
+    ~tag:Masc_mcp.Tool_dispatch.Mod_misc;
+  Masc_mcp.Tool_dispatch.register
+    ~tool_name:workflow_rejection_probe_tool
+    ~handler:(fun ~name ~args:_ ->
+      Some
+        (Tool_result.error
+           ~failure_class:(Some Tool_result.Workflow_rejection)
+           ~tool_name:name
+           ~start_time:(Unix.gettimeofday ())
+           workflow_rejection_message))
 
 let test_registered_tool_dispatch_without_masc_prefix () =
   register_registered_dispatch_probe ();
@@ -519,6 +593,27 @@ let test_registered_tool_dispatch_without_masc_prefix () =
           Yojson.Safe.Util.(member "tool" json |> to_string);
         check string "registered route" "registered"
           Yojson.Safe.Util.(member "route" json |> to_string))
+
+let test_registered_dispatch_preserves_workflow_failure_class () =
+  register_workflow_rejection_probe ();
+  with_exec_fixture "keeper_exec_registered_workflow_rejection"
+    (fun ~config ~meta ~ctx_work:_ ->
+      match
+        Masc_mcp.Keeper_exec_masc.handle_registered_keeper_tool
+          ~config
+          ~keeper_name:meta.name
+          ~name:workflow_rejection_probe_tool
+          ~args:(`Assoc [])
+      with
+      | None -> fail "expected registered keeper tool dispatch"
+      | Some raw ->
+        let json = Yojson.Safe.from_string raw in
+        check string "failure class preserved" "workflow_rejection"
+          Yojson.Safe.Util.(member "failure_class" json |> to_string);
+        check bool "error message preserved" true
+          (contains_substring
+             Yojson.Safe.Util.(member "error" json |> to_string)
+             "Self-approval"))
 
 (* ── Exec cache integration tests ──────────────────────────── *)
 
@@ -680,8 +775,16 @@ let () =
         test_preflight_reports_work_discovery_disabled_without_current_task;
       test_case "preflight allows disabled work discovery with current task" `Quick
         test_preflight_allows_work_discovery_disabled_with_current_task;
+      test_case "task FSM errors classify as workflow rejection" `Quick
+        test_tool_result_classifies_task_fsm_rejections_as_workflow;
+      test_case "tool_result_or_error preserves failure_class" `Quick
+        test_tool_result_or_error_preserves_failure_class;
+      test_case "workflow rejection skips circuit breaker" `Quick
+        test_workflow_rejection_payload_skips_circuit_breaker;
       test_case "registered dispatch does not require masc_ prefix" `Quick
         test_registered_tool_dispatch_without_masc_prefix;
+      test_case "registered dispatch preserves workflow failure class" `Quick
+        test_registered_dispatch_preserves_workflow_failure_class;
     ]);
     ("tool_not_allowed_counter", [
       test_case "increments for not_in_allow_set" `Quick


### PR DESCRIPTION
## Summary
- classify task FSM business-rule failures such as invalid transitions and self-approval as workflow_rejection
- preserve Tool_result failure_class in keeper-facing error JSON from registered/tag-dispatched tools
- skip keeper failure circuit-breaker enrichment for workflow_rejection payloads so invalid task lifecycle calls do not escalate into repeated other-failure trips

## Tests
- ocamlformat --check lib/tool_types/tool_result.ml lib/keeper/keeper_exec_shared.ml lib/keeper/keeper_exec_shared.mli lib/keeper/keeper_exec_masc.ml lib/keeper/keeper_exec_tools.ml lib/keeper/keeper_exec_tools.mli test/test_keeper_exec_tools.ml
- scripts/dune-local.sh build ./test/test_keeper_exec_tools.exe
- ./_build/default/test/test_keeper_exec_tools.exe test execute_keeper_tool_call_with_outcome --show-errors
- ./_build/default/test/test_keeper_exec_tools.exe