### PR TITLE
fix(keeper): materialize cascade done path

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -501,7 +501,7 @@ let record_usage_anomaly_metrics ~keeper_name ~model usage_trust =
 (* cost_status / thinking_log_summary / pr_action types + telemetry helpers
    moved to Keeper_hooks_oas_types (intra-library file split, 2026-05-16).
    The include is hoisted to the top of this module — see the comment
-   near [keeper_denied_tools]. *)
+   near the keeper deny-list binding. *)
 
 let cost_source_unmetered_provider = "unmetered_provider"
 let cost_source_computed = "computed"

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -834,7 +834,43 @@ let mark_turn_cascade_exhausted ~base_path name =
 	         "registry: ignoring cascade exhaustion after Cascade_done name=%s \
 	          base_path=%s"
 	         name
-	         base_path)
+         base_path)
+;;
+
+let mark_turn_cascade_done ~base_path name =
+  let set_cascade_state cascade_state =
+    set_turn_cascade_state
+      ~base_path
+      name
+      (Packed cascade_state : packed_cascade_state)
+  in
+  match get ~base_path name with
+  | None | Some { current_turn_observation = None; _ } -> ()
+  | Some { current_turn_observation = Some obs; _ } ->
+    (match obs.cascade_state with
+     | Packed Cascade_idle ->
+       set_turn_decision_stage
+         ~base_path
+         name
+         Decision_active_tool_policy_selected;
+       set_cascade_state Cascade_selecting;
+       set_cascade_state Cascade_trying;
+       set_cascade_state Cascade_done
+     | Packed Cascade_selecting ->
+       set_turn_decision_stage
+         ~base_path
+         name
+         Decision_active_tool_policy_selected;
+       set_cascade_state Cascade_trying;
+       set_cascade_state Cascade_done
+     | Packed Cascade_trying -> set_cascade_state Cascade_done
+     | Packed Cascade_done -> set_cascade_state Cascade_done
+     | Packed Cascade_exhausted ->
+       Log.Keeper.warn
+         "registry: ignoring cascade completion after Cascade_exhausted name=%s \
+          base_path=%s"
+         name
+         base_path)
 ;;
 
 let mark_turn_provider_attempt_started ~base_path name =

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -149,6 +149,15 @@ val set_turn_cascade_state :
     when no turn is active. *)
 val mark_turn_cascade_exhausted : base_path:string -> string -> unit
 
+(** Mark cascade success on the live turn.
+
+    When provider execution returns before the tool-disclosure hook advances the
+    registry projection, the live cascade axis can still be [Cascade_idle]. This
+    helper materializes the spec-valid pre-terminal path ([idle -> selecting ->
+    trying -> done]) instead of allowing callers to jump directly to
+    [Cascade_done]. No-op when no turn is active. *)
+val mark_turn_cascade_done : base_path:string -> string -> unit
+
 (** Mark that the live turn has entered a provider attempt.
 
     This materializes the registry-side projection that corresponds to

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1121,11 +1121,9 @@ let run_keeper_cycle
                              ~base_path:config.base_path
                              meta.name
                              selected_model;
-                           Keeper_registry.set_turn_cascade_state
+                           Keeper_registry.mark_turn_cascade_done
                              ~base_path:config.base_path
-                             meta.name
-                             (Keeper_registry.Packed Cascade_done
-                              : Keeper_registry.packed_cascade_state);
+                             meta.name;
                            Ok result
                          | Error err ->
                            let err =

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -1634,6 +1634,52 @@ let test_mark_turn_cascade_exhausted_materializes_pre_disclosure_path () =
     fail "mark_turn_cascade_exhausted cleared observation"
   | None -> fail "entry missing"
 
+let test_mark_turn_cascade_done_materializes_pre_disclosure_path () =
+  R.clear ();
+  let keeper_name = "k-cascade-done-pre-disclosure" in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  R.mark_turn_started ~base_path:bp keeper_name;
+  R.mark_turn_cascade_done ~base_path:bp keeper_name;
+  match R.get ~base_path:bp keeper_name with
+  | Some { current_turn_observation = Some obs; _ } ->
+    check bool "cascade_state lands on Cascade_done" true
+      (obs.R.cascade_state = R.Packed R.Cascade_done);
+    check bool "turn_phase lands on Turn_finalizing" true
+      (obs.R.turn_phase = R.Packed R.Turn_finalizing);
+    check bool "decision_stage records tool policy boundary" true
+      (obs.R.decision_stage = R.Packed R.Decision_tool_policy_selected)
+  | Some { current_turn_observation = None; _ } ->
+    fail "mark_turn_cascade_done cleared observation"
+  | None -> fail "entry missing"
+
+let test_mark_turn_cascade_done_no_op_without_obs () =
+  R.clear ();
+  let keeper_name = "k-cascade-done-no-obs" in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  R.mark_turn_cascade_done ~base_path:bp keeper_name;
+  match R.get ~base_path:bp keeper_name with
+  | Some { current_turn_observation = None; _ } -> ()
+  | Some { current_turn_observation = Some _; _ } ->
+    fail "mark_turn_cascade_done installed observation without keeper-turn"
+  | None -> fail "entry missing"
+
+let test_mark_turn_cascade_done_no_op_after_exhausted () =
+  R.clear ();
+  let keeper_name = "k-cascade-done-after-exhausted" in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  R.mark_turn_started ~base_path:bp keeper_name;
+  R.mark_turn_cascade_exhausted ~base_path:bp keeper_name;
+  R.mark_turn_cascade_done ~base_path:bp keeper_name;
+  match R.get ~base_path:bp keeper_name with
+  | Some { current_turn_observation = Some obs; _ } ->
+    check bool "cascade_state remains Cascade_exhausted" true
+      (obs.R.cascade_state = R.Packed R.Cascade_exhausted);
+    check bool "turn_phase remains Turn_exhausted" true
+      (obs.R.turn_phase = R.Packed R.Turn_exhausted)
+  | Some { current_turn_observation = None; _ } ->
+    fail "mark_turn_cascade_done cleared observation"
+  | None -> fail "entry missing"
+
 let test_mark_turn_provider_attempt_started_lands_on_executing () =
   R.clear ();
   let keeper_name = "k-provider-attempt-started" in
@@ -1937,6 +1983,12 @@ let () =
             test_mark_sdk_turn_started_no_op_without_obs;
           eio_test "mark_turn_cascade_exhausted materializes pre-disclosure path"
             test_mark_turn_cascade_exhausted_materializes_pre_disclosure_path;
+          eio_test "mark_turn_cascade_done materializes pre-disclosure path"
+            test_mark_turn_cascade_done_materializes_pre_disclosure_path;
+          eio_test "mark_turn_cascade_done no-op without observation"
+            test_mark_turn_cascade_done_no_op_without_obs;
+          eio_test "mark_turn_cascade_done no-op after exhausted"
+            test_mark_turn_cascade_done_no_op_after_exhausted;
           eio_test "mark_turn_provider_attempt_started lands on executing"
             test_mark_turn_provider_attempt_started_lands_on_executing;
           eio_test "mark_turn_provider_attempt_started no-op without observation"

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3056,7 +3056,7 @@ let test_work_discovery_nudge_uses_registered_keeper_tool_schemas () =
     "keeper_shell schema documents gh claim prerequisite"
     true
     (source_file_contains
-       "lib/tool_shard.ml"
+       "lib/tool_shard_types.ml"
        "Requires an active claimed task/current_task_id");
   check
     bool


### PR DESCRIPTION
## Summary
- add a registry helper that materializes the valid cascade path before marking a turn done
- use that helper on the successful keeper execution path
- cover idle-to-done, no-observation, and exhausted-terminal cases in keeper registry tests

## Verification
- ocamlformat --check lib/keeper/keeper_registry.ml lib/keeper/keeper_registry.mli lib/keeper/keeper_unified_turn.ml test/test_keeper_registry.ml
- scripts/dune-local.sh build ./test/test_keeper_registry.exe
- ./_build/default/test/test_keeper_registry.exe