### PR TITLE
fix(cascade): preserve tool choice overrides

### DIFF
--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -214,6 +214,10 @@ let request_runtime_fields_on_base_config
     response_format = req_config.response_format;
     output_schema = req_config.output_schema;
     cache_system_prompt = req_config.cache_system_prompt;
+    supports_tool_choice_override =
+      (match req_config.supports_tool_choice_override with
+       | Some _ as override -> override
+       | None -> base.supports_tool_choice_override);
     seed = req_config.seed;
   }
 
@@ -239,14 +243,21 @@ let provider_config_preserving_http_transport
 
 let transport_for_provider ~sw ~net ~provider_cfg ?runtime_mcp_policy
     ?cli_transport_overrides () =
-  match provider_cfg.Llm_provider.Provider_config.kind with
-  | Llm_provider.Provider_config.Ollama ->
-      Ok
-        (Some
-           (provider_config_preserving_http_transport ~sw ~net ~provider_cfg))
-  | _ ->
+  if
+    Llm_provider.Provider_config.is_subprocess_cli
+      provider_cfg.Llm_provider.Provider_config.kind
+  then
       non_http_transport_of_provider ~sw ~provider_cfg ?runtime_mcp_policy
         ?cli_transport_overrides ()
+  else
+    Ok
+      (Some
+         (provider_config_preserving_http_transport ~sw ~net ~provider_cfg))
+
+module For_testing = struct
+  let request_runtime_fields_on_base_config =
+    request_runtime_fields_on_base_config
+end
 
 (* ================================================================ *)
 (* Internal: event publishing                                        *)

--- a/lib/cascade/cascade_runner.mli
+++ b/lib/cascade/cascade_runner.mli
@@ -204,6 +204,13 @@ val make_per_call_switch_transport :
   (sw:Eio.Switch.t -> Llm_provider.Llm_transport.t) ->
   Llm_provider.Llm_transport.t
 
+module For_testing : sig
+  val request_runtime_fields_on_base_config :
+    base:Llm_provider.Provider_config.t ->
+    Llm_provider.Provider_config.t ->
+    Llm_provider.Provider_config.t
+end
+
 (** {1 Lifecycle / checkpoint helpers (re-exported)} *)
 
 val publish_lifecycle :

--- a/lib/cascade/cascade_wire_overlay.ml
+++ b/lib/cascade/cascade_wire_overlay.ml
@@ -5,28 +5,161 @@
 
 let auth_header_authorization = "Authorization"
 
+let api_key_from_env name =
+  match String.trim name with
+  | "" -> ""
+  | env_name ->
+    (match Sys.getenv_opt env_name with
+     | Some value -> value
+     | None -> "")
+;;
+
+let auth_headers_for_provider_cfg
+      ~(api_key : string)
+      (provider_cfg : Llm_provider.Provider_config.t)
+  =
+  let headers = provider_cfg.headers in
+  if String.trim api_key = ""
+  then headers
+  else (
+    match provider_cfg.kind with
+    | Anthropic | Kimi -> ("x-api-key", api_key) :: headers
+    | Gemini | Claude_code | Gemini_cli | Kimi_cli | Codex_cli -> headers
+    | OpenAI_compat | Ollama | Glm | DashScope ->
+      ("Authorization", "Bearer " ^ api_key) :: headers)
+;;
+
+let request_kind_of_provider_cfg (provider_cfg : Llm_provider.Provider_config.t) =
+  match provider_cfg.kind with
+  | Anthropic | Kimi -> Agent_sdk.Provider.Anthropic_messages
+  | OpenAI_compat
+  | Ollama
+  | Gemini
+  | Glm
+  | DashScope
+  | Claude_code
+  | Gemini_cli
+  | Kimi_cli
+  | Codex_cli -> Agent_sdk.Provider.Openai_chat_completions
+;;
+
+let agent_capabilities_of_llm_capabilities
+      (caps : Llm_provider.Capabilities.capabilities)
+  : Agent_sdk.Provider.capabilities
+  =
+  { max_context_tokens = caps.max_context_tokens
+  ; max_output_tokens = caps.max_output_tokens
+  ; supports_tools = caps.supports_tools
+  ; supports_tool_choice = caps.supports_tool_choice
+  ; supports_parallel_tool_calls = caps.supports_parallel_tool_calls
+  ; supports_runtime_mcp_tools = caps.supports_runtime_mcp_tools
+  ; supports_runtime_tool_events = caps.supports_runtime_tool_events
+  ; supports_reasoning = caps.supports_reasoning
+  ; supports_extended_thinking = caps.supports_extended_thinking
+  ; supports_reasoning_budget = caps.supports_reasoning_budget
+  ; thinking_control_format = caps.thinking_control_format
+  ; supports_response_format_json = caps.supports_response_format_json
+  ; supports_structured_output = caps.supports_structured_output
+  ; supports_multimodal_inputs = caps.supports_multimodal_inputs
+  ; supports_image_input = caps.supports_image_input
+  ; supports_audio_input = caps.supports_audio_input
+  ; supports_video_input = caps.supports_video_input
+  ; modality_priority = caps.modality_priority
+  ; supports_native_streaming = caps.supports_native_streaming
+  ; supports_system_prompt = caps.supports_system_prompt
+  ; supports_caching = caps.supports_caching
+  ; supports_prompt_caching = caps.supports_prompt_caching
+  ; prompt_cache_alignment = caps.prompt_cache_alignment
+  ; supports_top_k = caps.supports_top_k
+  ; supports_min_p = caps.supports_min_p
+  ; supports_seed = caps.supports_seed
+  ; supports_seed_with_images = caps.supports_seed_with_images
+  ; supports_computer_use = caps.supports_computer_use
+  ; supports_code_execution = caps.supports_code_execution
+  ; emits_usage_tokens = caps.emits_usage_tokens
+  ; supported_models = caps.supported_models
+  }
+;;
+
+let register_capability_overlay_provider
+      ~(name : string)
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+  =
+  let capabilities =
+    Agent_sdk.Provider_runtime_binding.capabilities_for_provider_config provider_cfg
+    |> agent_capabilities_of_llm_capabilities
+  in
+  Agent_sdk.Provider.register_provider
+    { name
+    ; request_kind = request_kind_of_provider_cfg provider_cfg
+    ; request_path = provider_cfg.request_path
+    ; capabilities
+    ; build_body =
+        (fun ~config:_ ~messages:_ ?tools:_ () ->
+           invalid_arg
+             "MASC cascade capability overlay providers require an injected \
+              Llm_transport")
+    ; parse_response =
+        (fun _ ->
+           invalid_arg
+             "MASC cascade capability overlay providers require an injected \
+              Llm_transport")
+    ; resolve =
+        (fun provider ->
+           let api_key =
+             match String.trim provider_cfg.api_key with
+             | "" -> api_key_from_env provider.Agent_sdk.Provider.api_key_env
+             | value -> value
+           in
+           Ok
+             ( provider_cfg.base_url
+             , api_key
+             , auth_headers_for_provider_cfg ~api_key provider_cfg ))
+    }
+;;
+
+let apply_capability_overlay
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      (provider : Agent_sdk.Provider.config)
+  =
+  match provider_cfg.supports_tool_choice_override with
+  | None -> provider
+  | Some _ ->
+    let name = Llm_provider.Provider_registry.provider_name_of_config provider_cfg in
+    let registry = Llm_provider.Provider_registry.default () in
+    (match Llm_provider.Provider_registry.find registry name with
+     | None -> provider
+     | Some _ ->
+       register_capability_overlay_provider ~name ~provider_cfg;
+       { provider with provider = Agent_sdk.Provider.Custom_registered { name } })
+;;
+
 let apply
       ~(provider_cfg : Llm_provider.Provider_config.t)
       (provider : Agent_sdk.Provider.config)
   : Agent_sdk.Provider.config
   =
-  match provider_cfg.kind, provider.provider with
-  | Llm_provider.Provider_config.OpenAI_compat, Agent_sdk.Provider.Local { base_url }
-    when not
-           (String.equal
-              provider_cfg.request_path
-              Masc_network_defaults.openai_chat_completions_path) ->
-    let api_key_trimmed = String.trim provider_cfg.api_key in
-    let auth_header =
-      if String.equal api_key_trimmed "" then None else Some auth_header_authorization
-    in
-    let static_token =
-      if String.equal api_key_trimmed "" then None else Some api_key_trimmed
-    in
-    { provider with
-      provider =
-        Agent_sdk.Provider.OpenAICompat
-          { base_url; auth_header; path = provider_cfg.request_path; static_token }
-    }
-  | _ -> provider
+  let provider =
+    match provider_cfg.kind, provider.provider with
+    | ( Llm_provider.Provider_config.OpenAI_compat
+      , Agent_sdk.Provider.Local { base_url } )
+      when not
+             (String.equal
+                provider_cfg.request_path
+                Masc_network_defaults.openai_chat_completions_path) ->
+      let api_key_trimmed = String.trim provider_cfg.api_key in
+      let auth_header =
+        if String.equal api_key_trimmed "" then None else Some auth_header_authorization
+      in
+      let static_token =
+        if String.equal api_key_trimmed "" then None else Some api_key_trimmed
+      in
+      { provider with
+        provider =
+          Agent_sdk.Provider.OpenAICompat
+            { base_url; auth_header; path = provider_cfg.request_path; static_token }
+      }
+    | _ -> provider
+  in
+  apply_capability_overlay ~provider_cfg provider
 ;;

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -501,7 +501,7 @@ let record_usage_anomaly_metrics ~keeper_name ~model usage_trust =
 (* cost_status / thinking_log_summary / pr_action types + telemetry helpers
    moved to Keeper_hooks_oas_types (intra-library file split, 2026-05-16).
    The include is hoisted to the top of this module — see the comment
-   near [keeper_denied_tools]. *)
+   near the keeper deny-list binding. *)
 
 let cost_source_unmetered_provider = "unmetered_provider"
 let cost_source_computed = "computed"

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3056,7 +3056,7 @@ let test_work_discovery_nudge_uses_registered_keeper_tool_schemas () =
     "keeper_shell schema documents gh claim prerequisite"
     true
     (source_file_contains
-       "lib/tool_shard.ml"
+       "lib/tool_shard_types.ml"
        "Requires an active claimed task/current_task_id");
   check
     bool

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2077,6 +2077,79 @@ let test_oas_worker_exec_build_installs_ollama_kind_preserving_transport () =
   | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)
 ;;
 
+let test_cascade_runner_request_patch_preserves_tool_choice_override () =
+  let base =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Glm
+      ~model_id:"glm-5.1"
+      ~base_url:"https://api.z.ai/api/coding/paas/v4"
+      ~supports_tool_choice_override:true
+      ()
+  in
+  let req =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"glm-5.1"
+      ~base_url:"http://agent-sdk-reconstructed.invalid/v1"
+      ~max_tokens:1234
+      ~tool_choice:Agent_sdk.Types.Any
+      ()
+  in
+  let patched =
+    Cascade_runner.For_testing.request_runtime_fields_on_base_config ~base req
+  in
+  Alcotest.(check string) "base url stays source of truth" base.base_url patched.base_url;
+  Alcotest.(check string) "model id stays source of truth" base.model_id patched.model_id;
+  Alcotest.(check (option int))
+    "runtime max_tokens comes from request"
+    req.max_tokens
+    patched.max_tokens;
+  Alcotest.(check bool)
+    "runtime tool_choice comes from request"
+    true
+    (patched.tool_choice = Some Agent_sdk.Types.Any);
+  Alcotest.(check (option bool))
+    "declared tool_choice support override survives request patch"
+    (Some true)
+    patched.supports_tool_choice_override
+;;
+
+let test_oas_worker_exec_build_applies_tool_choice_override_to_contract () =
+  let provider_cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Glm
+      ~model_id:"glm-5.1"
+      ~base_url:"https://api.z.ai/api/coding/paas/v4"
+      ~supports_tool_choice_override:true
+      ()
+  in
+  let config =
+    Cascade_runner.default_config
+      ~name:"oas-worker-glm-tool-choice-override"
+      ~provider_cfg
+      ~system_prompt:"system"
+      ~tools:[ make_noop_tool () ]
+  in
+  Eio.Switch.run
+  @@ fun sw ->
+  match Cascade_runner.build ~sw ~net:(require_test_net ()) ~config with
+  | Ok agent ->
+    let options = Agent_sdk.Agent.options agent in
+    Alcotest.(check bool)
+      "HTTP provider installs preserving transport"
+      true
+      (Option.is_some options.transport);
+    (match options.provider with
+     | Some provider ->
+       Alcotest.(check bool)
+         "contract capability sees declared tool_choice support"
+         true
+         (Agent_sdk.Provider.capabilities_for_config provider).supports_tool_choice
+     | None -> Alcotest.fail "expected provider options");
+    Agent_sdk.Agent.close agent
+  | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)
+;;
+
 let test_apply_stream_idle_timeout_default_passes_through_caller_value () =
   let provided = Some 7.5 in
   let result = Keeper_turn_driver.apply_stream_idle_timeout_default provided in
@@ -6509,6 +6582,14 @@ let () =
             "oas_worker installs native Ollama HTTP transport"
             `Quick
             test_oas_worker_exec_build_installs_ollama_kind_preserving_transport
+        ; Alcotest.test_case
+            "cascade request patch preserves tool_choice override"
+            `Quick
+            test_cascade_runner_request_patch_preserves_tool_choice_override
+        ; Alcotest.test_case
+            "oas_worker exposes tool_choice override to contract validation"
+            `Quick
+            test_oas_worker_exec_build_applies_tool_choice_override_to_contract
         ; Alcotest.test_case
             "apply_stream_idle_timeout_default passes Some through"
             `Quick


### PR DESCRIPTION
## Summary
- preserve supports_tool_choice_override when MASC patches Agent SDK HTTP requests back onto the cascade provider config
- install the provider-config-preserving HTTP transport for non-CLI HTTP providers, not only Ollama
- expose declared tool_choice support to Agent SDK contract validation via the MASC wire overlay

## Verification
- ocamlformat --check lib/cascade/cascade_runner.ml lib/cascade/cascade_runner.mli lib/cascade/cascade_wire_overlay.ml test/test_oas_worker.ml
- scripts/dune-local.sh build ./test/test_oas_worker.exe
- ./_build/default/test/test_oas_worker.exe