### PR TITLE
refactor(keeper): 3 pure helpers → keeper_registry_types (clean reconstruction of #15570)

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -53,12 +53,6 @@ let decr_running_count_clamped () =
 
     Pattern follows #7011 (executor_pool) and #7013 (runtime_state). *)
 
-let registry_key ~base_path name =
-  if String.contains name '\x1f'
-  then invalid_arg (Printf.sprintf "keeper name contains unit separator: %s" name);
-  base_path ^ "\x1f" ^ name
-;;
-
 let put_entry key entry =
   let rec loop () =
     let current = Atomic.get registry in
@@ -514,15 +508,6 @@ let set_last_correlation_id ~base_path name cid =
   update_entry ~base_path name (fun e -> { e with last_event_bus_correlation = Some cid })
 ;;
 
-let turn_phase_of_cascade_state (s : packed_cascade_state) : packed_turn_phase =
-  match s with
-  | Packed Cascade_idle -> Packed Turn_prompting
-  | Packed Cascade_selecting -> Packed Turn_routing
-  | Packed Cascade_trying -> Packed Turn_executing
-  | Packed Cascade_done -> Packed Turn_finalizing
-  | Packed Cascade_exhausted -> Packed Turn_exhausted
-;;
-
 let broadcast_composite_changed ~name ~ts_unix =
   try
     let json =
@@ -565,25 +550,6 @@ let record_phase_broadcast_failure ~name exn =
     "registry: keeper_phase_changed broadcast failed name=%s err=%s"
     name
     (Printexc.to_string exn)
-;;
-
-let completed_turn_outcome_of_observation (obs : turn_observation)
-  : Keeper_transition_audit.completed_turn_outcome
-  =
-  (* P1 silent-failure fix: the previous wildcard `| _ -> Turn_failed`
-     meant that adding a new variant to either ADT (decision_stage or
-     cascade_state) would silently fall through to Turn_failed without
-     a compile error.  Spelling out every variant lets the OCaml
-     exhaustiveness checker catch missing cases at build time. *)
-  match obs.decision_stage with
-  | Packed Decision_gate_rejected -> Keeper_transition_audit.Turn_gate_rejected
-  | Packed (Decision_undecided | Decision_guard_ok | Decision_tool_policy_selected) ->
-    (match obs.cascade_state with
-     | Packed Cascade_done -> Keeper_transition_audit.Turn_substantive
-     | Packed Cascade_idle
-     | Packed Cascade_selecting
-     | Packed Cascade_trying
-     | Packed Cascade_exhausted -> Keeper_transition_audit.Turn_failed)
 ;;
 
 let update_current_turn e f =

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -1029,3 +1029,32 @@ let try_resolve_done entry value =
      | Invalid_argument _ -> false)
 ;;
 
+
+let registry_key ~base_path name =
+  if String.contains name '\x1f'
+  then invalid_arg (Printf.sprintf "keeper name contains unit separator: %s" name);
+  base_path ^ "\x1f" ^ name
+;;
+
+let turn_phase_of_cascade_state (s : packed_cascade_state) : packed_turn_phase =
+  match s with
+  | Packed Cascade_idle -> Packed Turn_prompting
+  | Packed Cascade_selecting -> Packed Turn_routing
+  | Packed Cascade_trying -> Packed Turn_executing
+  | Packed Cascade_done -> Packed Turn_finalizing
+  | Packed Cascade_exhausted -> Packed Turn_exhausted
+;;
+
+let completed_turn_outcome_of_observation (obs : turn_observation)
+  : Keeper_transition_audit.completed_turn_outcome
+  =
+  match obs.decision_stage with
+  | Packed Decision_gate_rejected -> Keeper_transition_audit.Turn_gate_rejected
+  | Packed (Decision_undecided | Decision_guard_ok | Decision_tool_policy_selected) ->
+    (match obs.cascade_state with
+     | Packed Cascade_done -> Keeper_transition_audit.Turn_substantive
+     | Packed Cascade_idle
+     | Packed Cascade_selecting
+     | Packed Cascade_trying
+     | Packed Cascade_exhausted -> Keeper_transition_audit.Turn_failed)
+;;

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -619,3 +619,16 @@ and completed_turn_observation = {
     Returns [false] if another fiber won the resolve race. *)
 val try_resolve_done :
   registry_entry -> [ `Stopped | `Crashed of string ] -> bool
+
+(** Compose registry key from base path and name.
+    Raises [Invalid_argument] if [name] contains the unit-separator byte. *)
+val registry_key : base_path:string -> string -> string
+
+(** GADT witness mapping from cascade state to turn phase. *)
+val turn_phase_of_cascade_state : packed_cascade_state -> packed_turn_phase
+
+(** Classify turn observation into a completed-turn outcome.
+    Exhaustive match — adding a new variant to [decision_stage] or
+    [cascade_state] forces a compile error here. *)
+val completed_turn_outcome_of_observation :
+  turn_observation -> Keeper_transition_audit.completed_turn_outcome


### PR DESCRIPTION
## Summary
Reconstructs #15570 on current `origin/main` HEAD. Moves 3 internal helpers from `keeper_registry.ml` to `keeper_registry_types.ml`:

- `registry_key` (5 LoC) — base_path \\x1f name string composition
- `turn_phase_of_cascade_state` (8 LoC) — GADT witness mapping
- `completed_turn_outcome_of_observation` (18 LoC) — turn outcome classification, exhaustive variant match preserved

All callers live inside `keeper_registry.ml` and reach the moved functions via the existing `include Keeper_registry_types` pattern — no caller edits required.

## Why a new PR instead of rebasing #15570
#15570's branch carried stacked diff from earlier splits (cumulative `keeper_unified_turn.ml` +257 LoC, `keeper_hooks_oas_types.ml/.mli` deletions). After winner squashes absorbed those splits into main, rebasing #15570 produced `unique-vs-main=41` line-level conflict in `keeper_hooks_oas.ml` that did not correspond to this PR's stated intent. Reconstructing on current main isolates the original 31-LoC helper extraction cleanly.

## Test plan
- [x] `dune build --root . @check` — clean
- [ ] CI

RFC-WAIVED: continues incremental helper extraction series, no credential/identity/auth/operator/sandbox/dashboard/hooks/workflow surfaces touched.

Supersedes #15570.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>