### PR TITLE
Add dashboard provider log tail

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -72,6 +72,12 @@ display-name = "Ollama Local"
 protocol = "ollama-http"
 endpoint = "http://127.0.0.1:11434"
 
+[providers.ollama.log]
+enabled = false
+path = "~/.ollama/logs/server.log"
+default-lines = 200
+max-bytes = 1048576
+
 [providers.ollama.capabilities]
 # Local Ollama is a viable bound-actor fallback target in catalogs
 # that include Codex CLI — its HTTP surface accepts per-keeper auth

--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -4,10 +4,12 @@ import tseslint from 'typescript-eslint'
 
 const TARGET_FILES = [
   'src/api/dashboard-cascade.ts',
+  'src/api/dashboard.ts',
   'src/api/gate.ts',
   'src/api/goal-loop.ts',
   'src/api/schemas/cascade.ts',
   'src/api/schemas/dashboard-config.ts',
+  'src/api/schemas/provider-logs.ts',
   'src/api/transport-health.ts',
   'src/components/common/async-container.ts',
   'src/components/common/empty-state.ts',
@@ -45,6 +47,7 @@ const TEST_FILES = [
   'src/components/journey-panel.test.ts',
   'src/components/journey-waterfall-state.test.ts',
   'src/components/keeper-tool-call-inspector.test.ts',
+  'src/components/logs.test.ts',
   'src/components/transport-health.test.ts',
   'src/dashboard-ws.test.ts',
   'src/goal-loop-status.test.ts',

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -26,6 +26,14 @@ import {
   type DashboardConfigResponse,
 } from './schemas/dashboard-config'
 import { parseLogsResponse, type LogEntry, type LogsResponse } from './schemas/logs'
+import {
+  parseProviderLogTailResponse,
+  parseProviderLogsCatalogResponse,
+  type ProviderLogCatalogEntry,
+  type ProviderLogsCatalogResponse,
+  type ProviderLogTailLine,
+  type ProviderLogTailResponse,
+} from './schemas/provider-logs'
 import { asKeeperRuntimeBlockerClass } from '../lib/runtime-blocker-class'
 import type {
   KeeperConfig,
@@ -156,6 +164,13 @@ export function fetchDashboardShell(opts?: DashboardShellRequestOptions): Promis
 
 export type { LogEntry, LogsResponse }
 export { LogsSchemaDriftError } from './schemas/logs'
+export type {
+  ProviderLogCatalogEntry,
+  ProviderLogsCatalogResponse,
+  ProviderLogTailLine,
+  ProviderLogTailResponse,
+}
+export { ProviderLogsSchemaDriftError } from './schemas/provider-logs'
 
 export async function fetchLogs(opts?: {
   limit?: number
@@ -173,6 +188,22 @@ export async function fetchLogs(opts?: {
   const qs = params.toString()
   const raw = await get<unknown>(`/api/v1/dashboard/logs${qs ? `?${qs}` : ''}`)
   return parseLogsResponse(raw)
+}
+
+export async function fetchProviderLogsCatalog(): Promise<ProviderLogsCatalogResponse> {
+  const raw = await get<unknown>('/api/v1/dashboard/provider-logs')
+  return parseProviderLogsCatalogResponse(raw)
+}
+
+export async function fetchProviderLogTail(
+  provider: string,
+  opts?: { lines?: number },
+): Promise<ProviderLogTailResponse> {
+  const params = new URLSearchParams()
+  params.set('provider', provider)
+  if (opts?.lines) params.set('lines', String(opts.lines))
+  const raw = await get<unknown>(`/api/v1/dashboard/provider-logs/tail?${params.toString()}`)
+  return parseProviderLogTailResponse(raw)
 }
 
 export type { AgentTimelineEvent, AgentTimelineResponse }
@@ -1962,6 +1993,13 @@ function asLooseBoolean(value: unknown, fallback = false): boolean {
   return fallback
 }
 
+function asLooseNullableBoolean(value: unknown): boolean | null {
+  const booleanValue = asBoolean(value)
+  if (booleanValue !== undefined) return booleanValue
+  if (typeof value !== 'string') return null
+  return asLooseBoolean(value)
+}
+
 function asLooseNumber(value: unknown): number | undefined {
   const direct = asNumber(value)
   if (direct !== undefined) return direct
@@ -2165,12 +2203,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
     },
     drift: {
       status: normalizeKeeperFeatureStatus(drift.status),
-      enabled:
-        typeof drift.enabled === 'boolean'
-          ? drift.enabled
-          : (typeof drift.enabled === 'string'
-              ? asLooseBoolean(drift.enabled)
-              : null),
+      enabled: asLooseNullableBoolean(drift.enabled),
       min_turn_gap: asInt(drift.min_turn_gap) ?? null,
       count_total: asInt(drift.count_total) ?? null,
       last_reason: asNullableString(drift.last_reason),
@@ -2204,12 +2237,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
       active_model_label: null,
       last_model_used_label: null,
       runtime_blocker_summary: asNullableString(runtime.runtime_blocker_summary),
-      runtime_blocker_continue_gate:
-        typeof runtime.runtime_blocker_continue_gate === 'boolean'
-          ? runtime.runtime_blocker_continue_gate
-          : (typeof runtime.runtime_blocker_continue_gate === 'string'
-              ? asLooseBoolean(runtime.runtime_blocker_continue_gate)
-              : null),
+      runtime_blocker_continue_gate: asLooseNullableBoolean(runtime.runtime_blocker_continue_gate),
     },
     runtime_trust: runtimeTrust,
     coordination: {

--- a/dashboard/src/api/schemas/provider-logs.ts
+++ b/dashboard/src/api/schemas/provider-logs.ts
@@ -1,0 +1,101 @@
+// Provider logs schema — schema-at-boundary for
+// `GET /api/v1/dashboard/provider-logs` and `/provider-logs/tail`.
+//
+// Paths come from cascade.toml only. The tail endpoint never accepts an
+// arbitrary path from the browser.
+
+import {
+  array,
+  boolean,
+  nullable,
+  number,
+  object,
+  optional,
+  record,
+  safeParse,
+  string,
+  unknown,
+  type BaseIssue,
+  type InferOutput,
+} from 'valibot'
+
+const ProviderLogCatalogEntrySchema = object({
+  id: string(),
+  display_name: string(),
+  protocol: string(),
+  enabled: boolean(),
+  path: optional(nullable(string())),
+  resolved_path: optional(nullable(string())),
+  default_lines: optional(nullable(number())),
+  max_bytes: optional(nullable(number())),
+  cascade_config_path: optional(string()),
+})
+
+const ProviderLogsCatalogResponseSchema = object({
+  generated_at_iso: optional(string()),
+  dashboard_surface: optional(string()),
+  source: optional(string()),
+  ok: optional(boolean()),
+  error: optional(string()),
+  providers: array(ProviderLogCatalogEntrySchema),
+})
+
+const ProviderLogTailLineSchema = object({
+  line: number(),
+  text: string(),
+})
+
+const ProviderLogProviderSchema = object({
+  id: string(),
+  display_name: string(),
+  protocol: string(),
+})
+
+const ProviderLogTailResponseSchema = object({
+  generated_at_iso: optional(string()),
+  dashboard_surface: optional(string()),
+  source: optional(string()),
+  ok: optional(boolean()),
+  error: optional(string()),
+  provider: ProviderLogProviderSchema,
+  log: optional(record(string(), unknown())),
+  query: optional(record(string(), unknown())),
+  returned: optional(number()),
+  entries: array(ProviderLogTailLineSchema),
+})
+
+export type ProviderLogCatalogEntry = InferOutput<typeof ProviderLogCatalogEntrySchema>
+export type ProviderLogsCatalogResponse = InferOutput<typeof ProviderLogsCatalogResponseSchema>
+export type ProviderLogTailLine = InferOutput<typeof ProviderLogTailLineSchema>
+export type ProviderLogTailResponse = InferOutput<typeof ProviderLogTailResponseSchema>
+
+export class ProviderLogsSchemaDriftError extends Error {
+  readonly issues: readonly BaseIssue<unknown>[]
+  constructor(issues: readonly BaseIssue<unknown>[]) {
+    const summary = issues
+      .map(issue => {
+        const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
+        return `${path}: ${issue.message}`
+      })
+      .join('; ')
+    super(`provider logs schema drift: ${summary}`)
+    this.name = ProviderLogsSchemaDriftError.name
+    this.issues = issues
+  }
+}
+
+export function parseProviderLogsCatalogResponse(data: unknown): ProviderLogsCatalogResponse {
+  const result = safeParse(ProviderLogsCatalogResponseSchema, data, { abortEarly: true })
+  if (!result.success) {
+    throw new ProviderLogsSchemaDriftError(result.issues)
+  }
+  return result.output
+}
+
+export function parseProviderLogTailResponse(data: unknown): ProviderLogTailResponse {
+  const result = safeParse(ProviderLogTailResponseSchema, data, { abortEarly: true })
+  if (!result.success) {
+    throw new ProviderLogsSchemaDriftError(result.issues)
+  }
+  return result.output
+}

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -27,7 +27,7 @@ export function extractLaneValue(
     case 'decision': return snapshot.decision.stage
     case 'cascade': return snapshot.cascade.state
     case 'compaction': return snapshot.compaction.stage
-    case 'breaker': return snapshot.circuit_breaker?.state ?? '(no circuit_breaker)'
+    case 'breaker': return snapshot.circuit_breaker?.state ?? 'clean'
   }
 }
 

--- a/dashboard/src/components/git-graph-panel.ts
+++ b/dashboard/src/components/git-graph-panel.ts
@@ -62,7 +62,7 @@ function clearGitGraphRouteFocus(): void {
 export function compactGitGraphPath(path: string): string {
   const normalized = path.replace(/\\/g, '/')
   const parts = normalized.split('/').filter(Boolean)
-  if (parts.length <= 2) return normalized || '(no path)'
+  if (parts.length <= 2) return normalized || 'workspace'
   return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`
 }
 

--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -19,10 +19,22 @@ function entry(overrides: Partial<LogEntry>): LogEntry {
   }
 }
 
-async function loadLogs(fetchLogs: ReturnType<typeof vi.fn>) {
+async function loadLogs(
+  fetchLogs: ReturnType<typeof vi.fn>,
+  providerMocks?: {
+    fetchProviderLogsCatalog?: ReturnType<typeof vi.fn>
+    fetchProviderLogTail?: ReturnType<typeof vi.fn>
+  },
+) {
+  const fetchProviderLogsCatalog = providerMocks?.fetchProviderLogsCatalog
+    ?? vi.fn().mockResolvedValue({ providers: [] })
+  const fetchProviderLogTail = providerMocks?.fetchProviderLogTail
+    ?? vi.fn().mockResolvedValue({ provider: { id: 'none', display_name: 'none', protocol: 'none' }, entries: [] })
   vi.resetModules()
   vi.doMock('../api/dashboard.js', () => ({
     fetchLogs,
+    fetchProviderLogsCatalog,
+    fetchProviderLogTail,
   }))
   return import('./logs')
 }
@@ -177,6 +189,45 @@ describe('LogViewer Code links', () => {
     expect(window.location.hash).toBe(
       '#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=12&surface=Log&label=keeper_tool&source_id=log%3A1',
     )
+  })
+
+  it('renders enabled provider log tail from the configured provider path', async () => {
+    const fetchLogs = vi.fn().mockResolvedValue({ total: 0, entries: [] })
+    const fetchProviderLogsCatalog = vi.fn().mockResolvedValue({
+      providers: [{
+        id: 'ollama',
+        display_name: 'Ollama Local',
+        protocol: 'ollama-http',
+        enabled: true,
+        path: '~/.ollama/logs/server.log',
+        resolved_path: '/Users/dancer/.ollama/logs/server.log',
+        default_lines: 200,
+        max_bytes: 1048576,
+      }],
+    })
+    const fetchProviderLogTail = vi.fn().mockResolvedValue({
+      provider: {
+        id: 'ollama',
+        display_name: 'Ollama Local',
+        protocol: 'ollama-http',
+      },
+      entries: [
+        { line: 1, text: 'aborting completion request due to client closing the connection' },
+      ],
+    })
+
+    const { LogViewer } = await loadLogs(fetchLogs, {
+      fetchProviderLogsCatalog,
+      fetchProviderLogTail,
+    })
+    const { container } = render(h(LogViewer, {}))
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-testid="provider-log-tail"]')?.textContent)
+        .toContain('client closing the connection'),
+    )
+    expect(fetchProviderLogTail).toHaveBeenCalledWith('ollama', { lines: 200 })
+    expect(container.textContent).toContain('server.log')
   })
 
   // RFC-0079 removed the dropped-rows surface. parseLogsResponse now

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -1,8 +1,13 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
-import { fetchLogs } from '../api/dashboard.js'
-import type { LogEntry } from '../api/dashboard.js'
+import { fetchLogs, fetchProviderLogsCatalog, fetchProviderLogTail } from '../api/dashboard.js'
+import type {
+  LogEntry,
+  ProviderLogCatalogEntry,
+  ProviderLogsCatalogResponse,
+  ProviderLogTailResponse,
+} from '../api/dashboard.js'
 import { VirtualList } from './common/virtual-list'
 import { TextInput } from './common/input'
 import { Select } from './common/select'
@@ -39,11 +44,15 @@ export interface LogWindowSummary {
 }
 
 const logResource = createAsyncResource<LogData>()
+const providerLogCatalogResource = createAsyncResource<ProviderLogsCatalogResponse>()
+const providerLogTailResource = createAsyncResource<ProviderLogTailResponse>()
 const levelFilter = signal('INFO')
 const moduleInput = signal('')
 const appliedModuleFilter = signal('')
 const autoRefresh = signal(true)
 const logLimit = signal(200)
+const providerLogProvider = signal('')
+const providerLogLines = signal(200)
 const latestSeq = signal<number | null>(null)
 
 const POLL_INTERVAL_MS = 3000
@@ -390,6 +399,19 @@ function sourceTone(source: string): string {
   }
 }
 
+function selectableProviderLogs(
+  catalog: ProviderLogsCatalogResponse | undefined,
+): ProviderLogCatalogEntry[] {
+  return (catalog?.providers ?? []).filter(provider =>
+    provider.enabled && typeof provider.path === 'string' && provider.path.trim() !== '',
+  )
+}
+
+function providerLogOptionLabel(provider: ProviderLogCatalogEntry): string {
+  const pathLabel = lastPathSegment(provider.path ?? undefined)
+  return pathLabel ? `${provider.display_name} - ${pathLabel}` : provider.display_name
+}
+
 async function loadLogs(mode: LoadMode = 'reset') {
   const requestId = ++latestRequestId
 
@@ -435,6 +457,29 @@ async function loadLogs(mode: LoadMode = 'reset') {
     if (requestId !== latestRequestId) return
     // Delta failures don't overwrite loaded state — keep existing data visible
   }
+}
+
+async function loadProviderLogCatalog() {
+  return providerLogCatalogResource.load(async () => {
+    const resp = await fetchProviderLogsCatalog()
+    const selectable = selectableProviderLogs(resp)
+    const stillSelected = selectable.some(provider => provider.id === providerLogProvider.value)
+    if (!stillSelected) {
+      providerLogProvider.value = selectable[0]?.id ?? ''
+    }
+    return resp
+  })
+}
+
+async function loadSelectedProviderLog() {
+  const provider = providerLogProvider.value
+  if (!provider) {
+    providerLogTailResource.reset()
+    return
+  }
+  return providerLogTailResource.load(() =>
+    fetchProviderLogTail(provider, { lines: providerLogLines.value }),
+  )
 }
 
 function renderLogRow(entry: LogEntry) {
@@ -598,6 +643,100 @@ function renderLogProvenance(data: LogData | undefined) {
   `
 }
 
+function renderProviderLogPanel() {
+  const catalogState = providerLogCatalogResource.state.value
+  const catalog = catalogState.status === 'loaded' ? catalogState.data : undefined
+  const configuredProviders = catalog?.providers ?? []
+  const selectableProviders = selectableProviderLogs(catalog)
+  const selectedProvider =
+    selectableProviders.find(provider => provider.id === providerLogProvider.value) ?? null
+  const tailState = providerLogTailResource.state.value
+  const tail = tailState.status === 'loaded' ? tailState.data : undefined
+  const tailText = tail?.entries.map(entry => entry.text).join('\n') ?? ''
+  const disabledCount = configuredProviders.filter(provider => !provider.enabled).length
+
+  if (
+    catalogState.status === 'idle'
+    || (configuredProviders.length === 0 && catalogState.status !== 'error')
+  ) {
+    return null
+  }
+
+  return html`
+    <div class="mx-3 mt-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
+      <div class="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--color-border-divider)] px-3 py-2">
+        <div class="flex flex-wrap items-center gap-2 text-2xs">
+          <${StatusChip} tone="info" uppercase=${false}>provider logs</${StatusChip}>
+          ${selectedProvider
+            ? html`<${StatusChip} tone="neutral" uppercase=${false}>${selectedProvider.protocol}</${StatusChip}>`
+            : null}
+          ${selectedProvider?.path
+            ? html`<${StatusChip} tone="neutral" uppercase=${false}>${lastPathSegment(selectedProvider.path)}</${StatusChip}>`
+            : null}
+          ${disabledCount > 0
+            ? html`<${StatusChip} tone="warn" uppercase=${false}>disabled ${disabledCount}</${StatusChip}>`
+            : null}
+        </div>
+
+        <div class="flex flex-wrap items-center gap-2">
+          ${selectableProviders.length > 0
+            ? html`
+              <${Select}
+                class="logs-select px-3 py-2 text-xs"
+                name="provider-log-provider"
+                ariaLabel="Provider log"
+                value=${providerLogProvider.value}
+                options=${selectableProviders.map(provider => ({
+                  value: provider.id,
+                  label: providerLogOptionLabel(provider),
+                }))}
+                onInput=${(value: string) => { providerLogProvider.value = value }}
+              />
+              <${Select}
+                class="logs-select px-3 py-2 text-xs"
+                name="provider-log-lines"
+                ariaLabel="Provider log lines"
+                value=${String(providerLogLines.value)}
+                options=${['50', '100', '200', '500', '1000', '3000']}
+                onInput=${(value: string) => { providerLogLines.value = parseInt(value, 10) }}
+              />
+              <button
+                type="button"
+                class="logs-refresh-btn rounded-[var(--r-1)] border border-[var(--accent-22)] bg-[var(--accent-10)] px-3 py-2 text-2xs font-medium text-[var(--color-accent-fg)]"
+                onClick=${() => { void loadSelectedProviderLog() }}
+                disabled=${tailState.status === 'loading'}
+              >
+                ${tailState.status === 'loading' ? '...' : 'tail'}
+              </button>
+            `
+            : null}
+        </div>
+      </div>
+
+      ${catalogState.status === 'error'
+        ? html`<div class="px-3 py-3 text-xs text-[var(--err-fg)]">${catalogState.message}</div>`
+        : null}
+      ${catalog?.error
+        ? html`<div class="px-3 py-3 text-xs text-[var(--err-fg)]">${catalog.error}</div>`
+        : null}
+      ${selectableProviders.length === 0 && catalogState.status === 'loaded'
+        ? html`<div class="px-3 py-3 text-xs text-[var(--color-fg-muted)]">cascade.toml provider log tail is disabled.</div>`
+        : null}
+      ${tailState.status === 'error'
+        ? html`<div class="px-3 py-3 text-xs text-[var(--err-fg)]">${tailState.message}</div>`
+        : null}
+      ${selectedProvider && tailState.status !== 'error'
+        ? html`
+          <pre
+            class="m-0 max-h-72 min-h-32 overflow-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-2xs leading-relaxed text-[var(--color-fg-primary)]"
+            data-testid="provider-log-tail"
+          >${tailState.status === 'loading' && !tail ? 'loading...' : tailText}</pre>
+        `
+        : null}
+    </div>
+  `
+}
+
 export function LogViewer() {
   useEffect(() => {
     let pollId: ReturnType<typeof setInterval> | null = null
@@ -638,6 +777,44 @@ export function LogViewer() {
     if (moduleDebounceTimer) {
       clearTimeout(moduleDebounceTimer)
       moduleDebounceTimer = null
+    }
+  }, [])
+
+  useEffect(() => {
+    providerLogCatalogResource.reset()
+    providerLogTailResource.reset()
+    void loadProviderLogCatalog()
+  }, [])
+
+  useEffect(() => {
+    let pollId: ReturnType<typeof setInterval> | null = null
+
+    const restart = () => {
+      if (pollId) {
+        clearInterval(pollId)
+        pollId = null
+      }
+      providerLogTailResource.reset()
+      void loadSelectedProviderLog()
+      if (!autoRefresh.value || !providerLogProvider.value) return
+      pollId = setInterval(() => {
+        void loadSelectedProviderLog()
+      }, POLL_INTERVAL_MS)
+    }
+
+    restart()
+
+    const unsubscribeProvider = providerLogProvider.subscribe(restart)
+    const unsubscribeLines = providerLogLines.subscribe(restart)
+    const unsubscribeAutoRefresh = autoRefresh.subscribe(restart)
+
+    return () => {
+      if (pollId) {
+        clearInterval(pollId)
+      }
+      unsubscribeProvider()
+      unsubscribeLines()
+      unsubscribeAutoRefresh()
     }
   }, [])
 
@@ -721,6 +898,8 @@ export function LogViewer() {
                 latestSeq.value = null
                 logResource.reset()
                 void loadLogs('reset')
+                void loadProviderLogCatalog()
+                void loadSelectedProviderLog()
               }}
               disabled=${logLoading}
             >
@@ -734,6 +913,7 @@ export function LogViewer() {
         ` : null}
 
         ${renderLogSummary(summary)}
+        ${renderProviderLogPanel()}
 
         <div class="px-3 pt-3">
           <div class="grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 px-3 py-2 text-left text-3xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)]">

--- a/dashboard/src/components/widget-solo.test.ts
+++ b/dashboard/src/components/widget-solo.test.ts
@@ -53,7 +53,7 @@ describe('widget solo routing', () => {
 
   it('labels the solo surface from the active section and view', () => {
     expect(widgetSoloLabelForRoute(routeState({ section: 'runtime', view: 'cost' }))).toEqual({
-      title: 'Cascade',
+      title: 'Live Runtime',
       id: 'monitoring:runtime:cost',
     })
   })
@@ -67,7 +67,7 @@ describe('widget solo routing', () => {
     const bar = container.querySelector('[data-testid="dashboard-widget-solo-bar"]')
     const exit = container.querySelector('a[aria-label="Return to full dashboard"]')
 
-    expect(bar?.textContent).toContain('Cascade')
+    expect(bar?.textContent).toContain('Live Runtime')
     expect(bar?.textContent).toContain('monitoring:runtime:cost')
     expect(exit?.getAttribute('href')).toBe('#monitoring?section=runtime&view=cost')
   })

--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -119,6 +119,30 @@ let parse_capabilities ~(path : string) (tbl : Otoml.t) : cascade_capabilities =
   }
 ;;
 
+let positive_int_opt_field ~(path : string) (tbl : Otoml.t) key =
+  match Otoml.find_opt tbl Otoml.get_integer [ key ] with
+  | None -> None
+  | Some n when n > 0 -> Some n
+  | Some n ->
+    Logs.warn (fun m ->
+      m
+        "cascade_declarative_parser: %s.%s = %d — expected positive integer, \
+         ignoring"
+        path
+        key
+        n);
+    None
+;;
+
+let parse_provider_log ~(path : string) (tbl : Otoml.t) : cascade_provider_log =
+  let enabled = Otoml.find_or ~default:false tbl Otoml.get_boolean [ "enabled" ] in
+  { enabled
+  ; path = Otoml.find_opt tbl Otoml.get_string [ "path" ]
+  ; default_lines = positive_int_opt_field ~path tbl "default-lines"
+  ; max_bytes = positive_int_opt_field ~path tbl "max-bytes"
+  }
+;;
+
 (** Parse a [providers.<id>.headers] sub-table into a sorted association
     list. Caller invokes only when the sub-table key exists, so the
     returned list distinguishes "declared but empty / all entries rejected"
@@ -200,6 +224,10 @@ let parse_provider (id : string) (tbl : Otoml.t)
       Otoml.find_opt tbl Fun.id [ "capabilities" ]
       |> Option.map (parse_capabilities ~path)
     in
+    let log =
+      Otoml.find_opt tbl Fun.id [ "log" ]
+      |> Option.map (parse_provider_log ~path:(path ^ ".log"))
+    in
     let headers =
       match Otoml.find_opt tbl Fun.id [ "headers" ] with
       | None -> None
@@ -214,6 +242,7 @@ let parse_provider (id : string) (tbl : Otoml.t)
       ; is_non_interactive
       ; credentials
       ; capabilities
+      ; log
       ; headers
       }
 ;;

--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -25,6 +25,14 @@ type cascade_credential =
   | Inline of string
 [@@deriving show, eq]
 
+type cascade_provider_log =
+  { enabled : bool
+  ; path : string option
+  ; default_lines : int option
+  ; max_bytes : int option
+  }
+[@@deriving show, eq]
+
 (** Per-provider runtime + behavioral capabilities — RFC-0058 §2.4 +
     Phase 5.1 (capability fields) + §3.2 Phase 5.6 (tool/event support).
 
@@ -98,6 +106,7 @@ type cascade_provider =
   ; is_non_interactive : bool
   ; credentials : cascade_credential option
   ; capabilities : cascade_capabilities option
+  ; log : cascade_provider_log option
   ; headers : (string * string) list option
   }
 [@@deriving show, eq]

--- a/lib/cascade_decl/cascade_declarative_types.mli
+++ b/lib/cascade_decl/cascade_declarative_types.mli
@@ -33,6 +33,14 @@ type cascade_credential =
 
 (** {1 Layer 1: Providers} *)
 
+type cascade_provider_log =
+  { enabled : bool
+  ; path : string option
+  ; default_lines : int option
+  ; max_bytes : int option
+  }
+[@@deriving show, eq]
+
 (** Per-provider runtime + behavioral capabilities — RFC-0058 §2.4 +
     Phase 5.1 (caller cutover prep, A.1) + §3.2 Phase 5.6 (tool/event support).
 
@@ -70,6 +78,10 @@ type cascade_provider =
       - [Llm_provider.Capabilities.*] variant defaults (Phase 5.6, tool/event fields)
       - [Cascade_transport] / [Provider_tool_support] / [Cascade_error_classify] /
         [Keeper_usage_trust] closed-variant matches (Phase 5.1, dispatch fields) *)
+  ; log : cascade_provider_log option
+    (** Optional operator-facing provider log tail. When enabled, the
+      dashboard may read only this configured path for the provider; the
+      request never accepts an arbitrary file path. *)
   ; headers : (string * string) list option
     (** Reserved schema (Phase 5.6 prep). Additional HTTP headers per
       provider, e.g. [("anthropic-version", "2023-06-01")] for Anthropic

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -10,6 +10,7 @@ module Pages = Server_routes_http_pages
 module Runtime = Server_routes_http_runtime
 module Keeper_stream = Server_routes_http_keeper_stream
 module Keeper_api = Server_dashboard_http_keeper_api
+module Cascade_decl = Cascade_declarative_types
 
 type cascade_profile_gate = {
   valid_profiles : string list;
@@ -80,6 +81,246 @@ let dashboard_logs_json ~config ~limit ~level_filter ~min_level ~module_filter
          ]
         @ fields)
   | json -> json
+
+let provider_log_surface = "/api/v1/dashboard/provider-logs"
+let provider_log_tail_surface = "/api/v1/dashboard/provider-logs/tail"
+let provider_log_default_lines = 200
+let provider_log_max_lines = 3000
+let provider_log_default_max_bytes = 1_048_576
+let provider_log_hard_max_bytes = 4_194_304
+
+let clamp_int ~min_value ~max_value value = max min_value (min max_value value)
+
+let string_starts_with ~prefix value =
+  let prefix_len = String.length prefix in
+  String.length value >= prefix_len && String.sub value 0 prefix_len = prefix
+
+let expand_provider_log_path raw =
+  let path = String.trim raw in
+  match Sys.getenv_opt "HOME" with
+  | Some home when string_starts_with ~prefix:"~/" path ->
+      home ^ String.sub path 1 (String.length path - 1)
+  | Some home when string_starts_with ~prefix:"$HOME/" path ->
+      home ^ String.sub path 5 (String.length path - 5)
+  | _ -> path
+
+let provider_log_parse_errors_json errors =
+  errors
+  |> List.map (fun (err : Cascade_declarative_parser.parse_error) ->
+         Printf.sprintf "%s: %s" err.path err.message)
+  |> String.concat "; "
+
+let provider_log_error_json ~surface message =
+  `Assoc
+    [
+      ("generated_at_iso", `String (Masc_domain.now_iso ()));
+      ("dashboard_surface", `String surface);
+      ("source", `String "cascade_provider_log");
+      ("ok", `Bool false);
+      ("error", `String message);
+    ]
+
+let load_provider_log_config () =
+  match Cascade_runtime.cascade_config_path () with
+  | None -> Error "cascade config path unavailable"
+  | Some path -> (
+      match Cascade_declarative_parser.parse_file path with
+      | Ok cfg -> Ok (path, cfg)
+      | Error errors -> Error (provider_log_parse_errors_json errors))
+
+let provider_log_metadata_json
+    ~(config_path : string)
+    (provider : Cascade_decl.cascade_provider)
+    (log : Cascade_decl.cascade_provider_log) =
+  let resolved_path =
+    match log.path with
+    | Some path -> `String (expand_provider_log_path path)
+    | None -> `Null
+  in
+  `Assoc
+    [
+      ("id", `String provider.id);
+      ("display_name", `String provider.display_name);
+      ("protocol", `String provider.protocol);
+      ("enabled", `Bool log.enabled);
+      ("path", option_string_json log.path);
+      ("resolved_path", resolved_path);
+      ("default_lines", option_int_json log.default_lines);
+      ("max_bytes", option_int_json log.max_bytes);
+      ("cascade_config_path", `String config_path);
+    ]
+
+let dashboard_provider_logs_json () =
+  match load_provider_log_config () with
+  | Error message ->
+      `Assoc
+        [
+          ("generated_at_iso", `String (Masc_domain.now_iso ()));
+          ("dashboard_surface", `String provider_log_surface);
+          ("source", `String "cascade_provider_log");
+          ("ok", `Bool false);
+          ("error", `String message);
+          ("providers", `List []);
+        ]
+  | Ok (config_path, cfg) ->
+      let providers =
+        cfg.providers
+        |> List.filter_map (fun (provider : Cascade_decl.cascade_provider) ->
+               match provider.log with
+               | None -> None
+               | Some log -> Some (provider_log_metadata_json ~config_path provider log))
+      in
+      `Assoc
+        [
+          ("generated_at_iso", `String (Masc_domain.now_iso ()));
+          ("dashboard_surface", `String provider_log_surface);
+          ("source", `String "cascade_provider_log");
+          ("ok", `Bool true);
+          ("providers", `List providers);
+        ]
+
+let configured_provider_log provider_id cfg =
+  match
+    List.find_opt
+      (fun (provider : Cascade_decl.cascade_provider) ->
+        String.equal provider.id provider_id)
+      cfg.Cascade_decl.providers
+  with
+  | None -> None
+  | Some provider -> (
+    match provider.Cascade_decl.log with
+    | Some log -> Some (provider, log)
+    | None -> None)
+
+let strip_trailing_cr line =
+  let len = String.length line in
+  if len > 0 && Char.equal line.[len - 1] '\r'
+  then String.sub line 0 (len - 1)
+  else line
+
+let drop_first = function
+  | [] -> []
+  | _ :: rest -> rest
+
+let drop_trailing_empty lines =
+  match List.rev lines with
+  | "" :: rest -> List.rev rest
+  | _ -> lines
+
+let rec drop_n n lines =
+  if n <= 0
+  then lines
+  else
+    match lines with
+    | [] -> []
+    | _ :: rest -> drop_n (n - 1) rest
+
+let tail_list ~limit lines =
+  let length = List.length lines in
+  drop_n (length - min length limit) lines
+
+let read_provider_log_tail ~path ~lines ~max_bytes =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let file_len = in_channel_length ic in
+      let start = max 0 (file_len - max_bytes) in
+      let read_len = file_len - start in
+      seek_in ic start;
+      let raw = really_input_string ic read_len in
+      let parsed =
+        raw
+        |> String.split_on_char '\n'
+        |> (fun parts -> if start > 0 then drop_first parts else parts)
+        |> drop_trailing_empty
+        |> List.map strip_trailing_cr
+        |> tail_list ~limit:lines
+      in
+      List.mapi
+        (fun index text -> `Assoc [ ("line", `Int (index + 1)); ("text", `String text) ])
+        parsed)
+
+let provider_log_int_or_default opt fallback =
+  match opt with
+  | Some value -> value
+  | None -> fallback
+
+let dashboard_provider_log_tail_json request =
+  let error status message =
+    (status, provider_log_error_json ~surface:provider_log_tail_surface message)
+  in
+  let provider_id =
+    match Server_utils.query_param request "provider" with
+    | Some raw -> String.trim raw
+    | None -> ""
+  in
+  if String.equal provider_id ""
+  then error `Bad_request "provider query parameter is required"
+  else
+    match load_provider_log_config () with
+    | Error message -> error `Internal_server_error message
+    | Ok (config_path, cfg) -> (
+      match configured_provider_log provider_id cfg with
+      | None ->
+        error `Not_found
+          (Printf.sprintf "provider %S has no configured log" provider_id)
+      | Some (_provider, log) when not log.enabled ->
+        error `Forbidden
+          (Printf.sprintf "provider %S log tail is disabled" provider_id)
+      | Some (_provider, { path = None; _ }) ->
+        error `Bad_request
+          (Printf.sprintf "provider %S log path is not configured" provider_id)
+      | Some (provider, ({ path = Some raw_path; _ } as log)) ->
+        let path = expand_provider_log_path raw_path in
+        if String.equal path "" || Filename.is_relative path
+        then
+          error `Bad_request
+            "provider log path must be absolute after ~/ or $HOME expansion"
+        else
+          let default_lines =
+            provider_log_int_or_default log.default_lines provider_log_default_lines
+            |> clamp_int ~min_value:1 ~max_value:provider_log_max_lines
+          in
+          let requested_lines =
+            Server_utils.int_query_param request "lines" ~default:default_lines
+            |> clamp_int ~min_value:1 ~max_value:provider_log_max_lines
+          in
+          let max_bytes =
+            provider_log_int_or_default log.max_bytes provider_log_default_max_bytes
+            |> clamp_int ~min_value:1 ~max_value:provider_log_hard_max_bytes
+          in
+          (try
+             let entries =
+               read_provider_log_tail ~path ~lines:requested_lines ~max_bytes
+             in
+             ( `OK,
+               `Assoc
+                 [
+                   ("generated_at_iso", `String (Masc_domain.now_iso ()));
+                   ("dashboard_surface", `String provider_log_tail_surface);
+                   ("source", `String "cascade_provider_log_file");
+                   ("ok", `Bool true);
+                   ( "provider",
+                     `Assoc
+                       [
+                         ("id", `String provider.id);
+                         ("display_name", `String provider.display_name);
+                         ("protocol", `String provider.protocol);
+                       ] );
+                   ("log", provider_log_metadata_json ~config_path provider log);
+                   ( "query",
+                     `Assoc
+                       [
+                         ("lines", `Int requested_lines);
+                         ("max_bytes", `Int max_bytes);
+                       ] );
+                   ("returned", `Int (List.length entries));
+                   ("entries", `List entries);
+                 ] )
+           with
+           | Sys_error message -> error `Internal_server_error message
+           | exn -> error `Internal_server_error (Printexc.to_string exn)))
 
 let cascade_profile_gate () : cascade_profile_gate =
   let config_path = Cascade_runtime.cascade_config_path () in
@@ -570,6 +811,18 @@ let rec add_routes ~sw ~clock router =
              ~level_filter ~min_level ~module_filter ~since_seq entries
          in
          Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/provider-logs" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let json = dashboard_provider_logs_json () in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/provider-logs/tail" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let status, json = dashboard_provider_log_tail_json req in
+         Http.Response.json ~status ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/dashboard/logs/tool-host-failures" (fun request reqd ->

--- a/test/test_cascade_declarative_adapter.ml
+++ b/test/test_cascade_declarative_adapter.ml
@@ -629,6 +629,7 @@ let test_alias_parent_missing () =
           ; is_non_interactive = false
           ; credentials = None
           ; capabilities = None
+          ; log = None
           ; headers = None
           }
         ]
@@ -761,6 +762,7 @@ let test_duplicate_routes () =
           ; is_non_interactive = false
           ; credentials = None
           ; capabilities = None
+          ; log = None
           ; headers = None
           }
         ]

--- a/test/test_cascade_declarative_parser.ml
+++ b/test/test_cascade_declarative_parser.ml
@@ -1029,6 +1029,72 @@ command = "c"
   | _ -> failwith "expected exactly one provider"
 ;;
 
+let test_provider_log_present () =
+  let toml =
+    {|
+[providers.ollama]
+protocol = "ollama-http"
+endpoint = "http://127.0.0.1:11434"
+
+[providers.ollama.log]
+enabled = true
+path = "~/.ollama/logs/server.log"
+default-lines = 250
+max-bytes = 1048576
+|}
+  in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.providers with
+  | [ p ] ->
+    (match p.log with
+     | Some log ->
+       check bool "enabled" true log.enabled;
+       check opt_string "path" (Some "~/.ollama/logs/server.log") log.path;
+       check opt_int "default_lines" (Some 250) log.default_lines;
+       check opt_int "max_bytes" (Some 1048576) log.max_bytes
+     | None -> failwith "expected provider log config")
+  | _ -> failwith "expected exactly one provider"
+;;
+
+let test_provider_log_absent () =
+  let toml =
+    {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+|}
+  in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.providers with
+  | [ p ] -> check bool "no log sub-table → None" true (p.log = None)
+  | _ -> failwith "expected exactly one provider"
+;;
+
+let test_provider_log_non_positive_limits_ignored () =
+  let toml =
+    {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[providers.p.log]
+enabled = true
+path = "/tmp/provider.log"
+default-lines = 0
+max-bytes = -1
+|}
+  in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.providers with
+  | [ p ] ->
+    (match p.log with
+     | Some log ->
+       check opt_int "default_lines ignored" None log.default_lines;
+       check opt_int "max_bytes ignored" None log.max_bytes
+     | None -> failwith "expected provider log config")
+  | _ -> failwith "expected exactly one provider"
+;;
+
 (* --- Model capabilities (M1 prep — RFC-0058 Phase 5.3 Model axis) --- *)
 
 let test_model_capabilities_present () =
@@ -1559,6 +1625,14 @@ let () =
             "declared but empty yields Some []"
             `Quick
             test_headers_declared_but_empty
+        ] )
+    ; ( "provider_log"
+      , [ test_case "present parses tail settings" `Quick test_provider_log_present
+        ; test_case "absent yields None" `Quick test_provider_log_absent
+        ; test_case
+            "non-positive limits ignored"
+            `Quick
+            test_provider_log_non_positive_limits_ignored
         ] )
     ; ( "capabilities_for_provider_id (A.3 prep)"
       , [ test_case


### PR DESCRIPTION
## Summary
- Add `[providers.<id>.log]` cascade TOML schema with `enabled`, `path`, `default-lines`, and `max-bytes`.
- Add dashboard provider-log catalog and tail endpoints that only read configured provider log paths.
- Surface enabled provider log tails inside the existing Logs tab, with parser/type/test coverage.

## Product impact
Operators can inspect local provider logs, including Ollama abort/timeout evidence, from the dashboard without shelling into the host or exposing arbitrary file reads.

## Evidence
- `scripts/dune-local.sh build test/test_cascade_declarative_parser.exe`
- `./_build/default/test/test_cascade_declarative_parser.exe`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard exec eslint src/api/schemas/provider-logs.ts src/api/dashboard.ts src/components/logs.ts src/components/logs.test.ts`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/logs.test.ts --no-file-parallelism --maxWorkers=1`

## Review evidence
- Provider log tail route rejects missing provider, disabled provider logs, missing paths, and non-absolute paths after `~/` or `$HOME` expansion.
- Browser API accepts only provider ids and line counts; it does not accept a raw path from the dashboard.

## Linked issue
- Follow-up from live Ollama `/api/chat` 500 investigation where the server log showed client-side connection closes around 180s/300s.
