### PR TITLE
fix(keeper): unblock patch edits for docker worktrees

### DIFF
--- a/lib/tool_shard_types.ml
+++ b/lib/tool_shard_types.ml
@@ -635,10 +635,13 @@ let filesystem_tools : Masc_domain.tool_schema list =
     }
   ; { name = "keeper_fs_edit"
     ; description =
-        "Write or append to a file. path and content REQUIRED (both non-empty). mode: \
-         'overwrite' (default) or 'append'. Good: path='lib/foo.ml', content='let x = \
-         1'. Bad: path='', content=''. Bad: mode='create' (use overwrite). Creates \
-         parent dirs."
+        "Write, append, or patch a file. path is required. For mode='overwrite' \
+         (default) or 'append', content is required and non-empty. For mode='patch', \
+         old_string and new_string are required; old_string must match exactly once \
+         unless replace_all=true. Good overwrite: path='lib/foo.ml', content='let x = \
+         1'. Good patch: path='lib/foo.ml', mode='patch', old_string='old', \
+         new_string='new'. Bad: path='', content=''. Bad: mode='create' (use \
+         overwrite). Creates parent dirs."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -654,6 +657,21 @@ let filesystem_tools : Masc_domain.tool_schema list =
                       [ "type", `String "string"
                       ; "description", `String "File content to write"
                       ] )
+                ; ( "old_string"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; "description", `String "Patch mode substring to replace"
+                      ] )
+                ; ( "new_string"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; "description", `String "Patch mode replacement substring"
+                      ] )
+                ; ( "replace_all"
+                  , `Assoc
+                      [ "type", `String "boolean"
+                      ; "description", `String "Patch every occurrence instead of exactly one"
+                      ] )
                 ; (* Issue #8490: derive from local mirror that tracks
            [Keeper_exec_fs.valid_fs_write_mode_strings]. *)
                   ( "mode"
@@ -665,7 +683,7 @@ let filesystem_tools : Masc_domain.tool_schema list =
                       ; "description", `String "Write mode (default: overwrite)"
                       ] )
                 ] )
-          ; "required", `List [ `String "path"; `String "content" ]
+          ; "required", `List [ `String "path" ]
           ]
     }
   ; { name = "keeper_ide_annotate"

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -19,6 +19,10 @@ let temp_dir () =
   Unix.mkdir path 0o755;
   path
 
+let realpath_or_self path =
+  try Unix.realpath path with
+  | Unix.Unix_error _ -> path
+
 let cleanup_dir dir =
   let rec rm path =
     if Sys.file_exists path then
@@ -44,6 +48,12 @@ let write_text_file path content =
   Fun.protect
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
+
+let read_text_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> Stdlib.really_input_string ic (in_channel_length ic))
 
 let run_shell_ok ~cwd cmd =
   let quoted_cwd = Filename.quote cwd in
@@ -731,6 +741,68 @@ let test_write_preflight_accepts_docker_container_repo_path () =
             "let before = 2\n"
             (Masc_test_deps.read_file file_path))))
 
+let test_write_preflight_accepts_sandbox_relative_repo_path () =
+  prime_keeper_bridge ();
+  let dir = temp_dir () |> realpath_or_self in
+  let keeper_name = "nick0cave" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_registry.unregister ~base_path:dir keeper_name;
+      cleanup_dir dir)
+    (fun () ->
+      run_shell_ok ~cwd:dir "git init --quiet";
+      let rel_path =
+        "repos/masc-mcp/.worktrees/keeper-nick0cave-agent-task-240/lib/foo.ml"
+      in
+      let file_path =
+        Filename.concat
+          dir
+          (Filename.concat ".masc/playground/docker/nick0cave" rel_path)
+      in
+      let keeper_config =
+        Filename.concat dir ".masc/config/keepers/nick0cave.toml"
+      in
+      ensure_dir (Filename.dirname keeper_config);
+      write_text_file keeper_config "[keeper]\nsandbox_profile = \"docker\"\n";
+      ensure_dir (Filename.dirname file_path);
+      write_text_file file_path "let x = 1\n";
+      run_with_fs (fun () ->
+        let config = Coord.default_config dir in
+        let meta =
+          make_meta
+            ~name:keeper_name
+            ~sandbox_profile:Masc_mcp.Keeper_types.Docker
+            ~tool_access:(Masc_mcp.Keeper_types.Custom [ "masc_code_edit" ])
+            ()
+        in
+        ignore (Masc_mcp.Keeper_registry.register ~base_path:dir keeper_name meta);
+        let raw =
+          Masc_mcp.Keeper_exec_masc.handle_keeper_masc_tool
+            ~config
+            ~keeper_name
+            ~name:"masc_code_edit"
+            ~args:
+              (`Assoc
+                [ "path", `String rel_path
+                ; "old_string", `String "let x = 1"
+                ; "new_string", `String "let x = 2"
+                ; "replace_all", `Bool false
+                ])
+        in
+        let json = Yojson.Safe.from_string raw in
+        (match Yojson.Safe.Util.member "error" json with
+         | `Null -> ()
+         | `String err ->
+           Alcotest.failf "masc_code_edit should pass write preflight, got: %s" err
+         | other ->
+           Alcotest.failf
+             "unexpected error shape: %s"
+             (Yojson.Safe.to_string other));
+        Alcotest.(check string)
+          "file edited"
+          "let x = 2\n"
+          (read_text_file file_path)))
+
 let test_schemas_match_names () =
   prime_keeper_bridge ();
   let meta =
@@ -869,6 +941,9 @@ let () =
           Alcotest.test_case
             "write preflight accepts Docker container repo path" `Quick
             test_write_preflight_accepts_docker_container_repo_path;
+          Alcotest.test_case
+            "write preflight accepts sandbox-relative repo path" `Quick
+            test_write_preflight_accepts_sandbox_relative_repo_path;
         ] );
       ( "consistency",
         [

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -375,10 +375,34 @@ let masc_transition_schema =
 let masc_goal_list_schema =
   find_schema_exn "masc_goal_list" Tool_schemas_coord_extra.schemas
 
+let keeper_fs_edit_schema =
+  find_schema_exn "keeper_fs_edit" Config.raw_all_tool_schemas
+
 let assoc_string key json =
   match Yojson.Safe.Util.member key json with
   | `String value -> value
   | _ -> failwith ("expected string field: " ^ key)
+
+let test_registered_hook_keeper_fs_edit_patch_args () =
+  let args =
+    `Assoc
+      [ "path", `String "repos/masc-mcp/.worktrees/task/lib/foo.ml"
+      ; "mode", `String "patch"
+      ; "old_string", `String "let x = 1"
+      ; "new_string", `String "let x = 2"
+      ; "replace_all", `Bool false
+      ]
+  in
+  let blocked, forwarded =
+    run_registered_hook
+      ~schema:keeper_fs_edit_schema
+      ~tool_name:"keeper_fs_edit"
+      ~args
+      ()
+  in
+  Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
+  Alcotest.(check bool) "args unchanged" true
+    (Yojson.Safe.equal forwarded args)
 
 let validation_labels ~tool ~result ~reason =
   [ "tool", tool; "result", result; "reason", reason ]
@@ -758,6 +782,8 @@ let () =
         test_registered_hook_bypasses_unknown_tool;
       Alcotest.test_case "empty schema bypasses validation" `Quick
         test_registered_hook_bypasses_empty_schema;
+      Alcotest.test_case "keeper_fs_edit accepts patch args" `Quick
+        test_registered_hook_keeper_fs_edit_patch_args;
       Alcotest.test_case "direct validation uses explicit schema" `Quick
         test_validate_args_uses_explicit_schema_without_registry;
       Alcotest.test_case "masc_transition compat: to/note keys" `Quick


### PR DESCRIPTION
## Summary
- accept `keeper_fs_edit` patch-mode inputs without requiring unrelated `content`
- keep the Docker container-path `masc_code_edit` regression and add a `repos/...` sandbox-relative write regression

## Why
Live keeper logs showed `keeper_fs_edit` patch calls rejected by schema validation with `"content": MISSING`, even though the handler supports `mode="patch"` via `old_string`/`new_string`. The same live task also needed proof that Docker keepers can write task worktree files through `masc_code_edit` using the sandbox-visible `repos/...` path.

## Evidence
- ocamlformat --check lib/tool_shard_types.ml test/test_tool_input_validation.ml lib/keeper/keeper_exec_masc.ml test/test_keeper_masc_bridge.ml
- scripts/dune-local.sh build ./test/test_tool_input_validation.exe ./test/test_keeper_masc_bridge.exe
- ./_build/default/test/test_tool_input_validation.exe
- ./_build/default/test/test_keeper_masc_bridge.exe test dispatch 3
- ./_build/default/test/test_keeper_masc_bridge.exe test dispatch 4
- git diff --check origin/main...HEAD
- scripts/check-boundary-guard.sh
