### PR TITLE
feat: extract Agent_name_kind module from Mcp_server_eio_execute

### DIFF
--- a/lib/agent_name_kind.ml
+++ b/lib/agent_name_kind.ml
@@ -1,0 +1,16 @@
+(** Agent_name_kind — classifies agent name strings by origin.
+
+    Extracted from [Mcp_server_eio_execute] for reuse across modules.
+    Provides predicates for agent-name classification used during
+    join-state resolution and identity normalisation. *)
+
+(** [is_ephemeral name] is [true] when [name] starts with ["agent-"],
+    indicating a system-generated, non-stable identity. *)
+let is_ephemeral name =
+  String.starts_with name ~prefix:"agent-"
+
+(** [is_transient name] is [true] when [name] is either ephemeral
+    (system-generated) or a dictionary-generated rotation nickname. *)
+let is_transient name =
+  is_ephemeral name
+  || Nickname.is_dictionary_generated_nickname name

--- a/lib/agent_name_kind.mli
+++ b/lib/agent_name_kind.mli
@@ -1,0 +1,9 @@
+(** Agent_name_kind — classifies agent name strings by origin. *)
+
+(** [is_ephemeral name] is [true] when [name] starts with ["agent-"],
+    indicating a system-generated, non-stable identity. *)
+val is_ephemeral : string -> bool
+
+(** [is_transient name] is [true] when [name] is either ephemeral
+    (system-generated) or a dictionary-generated rotation nickname. *)
+val is_transient : string -> bool

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -82,18 +82,13 @@ let resolve_join_state ~room_initialized ~join_required ~agent_name ~base_path ~
       | Error _ -> false))
 ;;
 
-let is_ephemeral_agent_name name = String.starts_with name ~prefix:"agent-"
-
-let is_transient_agent_name name =
-  is_ephemeral_agent_name name || Nickname.is_dictionary_generated_nickname name
-;;
 
 let silent_auth_token_error_kind err =
   Auth_error_kind.to_string (Auth_error_kind.classify err)
 ;;
 
 let should_read_legacy_persisted_agent_name ~has_explicit_agent_name ~agent_name =
-  (not has_explicit_agent_name) && is_ephemeral_agent_name agent_name
+  (not has_explicit_agent_name) && Agent_name_kind.is_ephemeral agent_name
 ;;
 
 let caller_agent_name_from_arguments arguments =
@@ -369,7 +364,7 @@ let execute_tool_eio
        alias and let auth preflight reject it if the token does not
        authorize that identity. We only fall back to token ownership
        when the request did not explicitly name an agent. *)
-    | Some t when (not has_explicit_agent_name) && is_transient_agent_name agent_name ->
+    | Some t when (not has_explicit_agent_name) && Agent_name_kind.is_transient agent_name ->
       (match Auth.resolve_agent_from_token config.base_path ~token:t with
        | Ok resolved -> resolved
        | Error err ->


### PR DESCRIPTION
## Summary
Extracts agent name classification predicates into a dedicated module for reuse.

## Changes
- **New** `lib/agent_name_kind.ml`: `is_ephemeral` and `is_transient` predicates
- **New** `lib/agent_name_kind.mli`: public interface
- **Modified** `lib/mcp_server_eio_execute.ml`: removed inline definitions (lines 85-89), updated call sites to use `Agent_name_kind.is_ephemeral`/`Agent_name_kind.is_transient`

## Why
The `is_ephemeral_agent_name` and `is_transient_agent_name` predicates were inline in Mcp_server_eio_execute but are needed by other modules. Extracting them enables reuse without coupling.

Ref: task-240