### PR TITLE
feat(keeper): instrument repair fabrication with typed counter and log

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -11,6 +11,7 @@
  keeper_paused_state_persist_phase
  keeper_bookkeeping_failure_kind
  keeper_checkpoint_failure_operation
+ keeper_repair_kind
  keeper_profile_load_failure_site
  keeper_turn_cleanup_failure_site
  keeper_cascade_sync_failure_site

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -481,8 +481,45 @@ let tool_use_text_of_block
   let input_json = Yojson.Safe.to_string input |> Inference_utils.sanitize_text_utf8 in
   Printf.sprintf "[tool use %s %s input=%s]" tool_name tool_use_id input_json
 
+(* Observability for [repair_broken_tool_call_pairs] fabrications.  Until
+   this counter existed, the repair functions silently downgraded
+   [ToolUse]/[ToolResult] blocks to plain [Text] whenever the matching
+   half had been dropped by compaction/cap/rollover — no log, no metric,
+   no way to tell whether the context reducer was breaking tool pairs at
+   1 in 1000 turns or 1 in 10.  Label [kind] is governed by
+   {!Keeper_repair_kind}. *)
+let () =
+  Prometheus.register_counter
+    ~name:Keeper_metrics.metric_keeper_repair_fabrications
+    ~help:
+      "Total tool-pair fabrications performed by \
+       [Keeper_context_core.repair_broken_tool_call_pairs] after \
+       compaction/cap/rollover dropped the matching half of a \
+       ToolUse/ToolResult pair.  Each increment counts one block \
+       downgraded to plain Text.  Label [kind] is \
+       'dangling_tool_use' (ToolUse without next ToolResult) or \
+       'orphan_tool_result' (ToolResult without previous ToolUse).  \
+       Closes the silent-failure gap flagged in \
+       .tmp/oas-internal-audit.html C1."
+    ()
+;;
+
+(* Sample at most one fabricated id per call to keep the log line bounded
+   while still giving operators a sniff-test trail.  Counter carries the
+   true total. *)
+let sample_first_dangling_tool_use_id (msg : Agent_sdk.Types.message)
+    ~(next_tool_result_ids : string list) : string option =
+  List.find_map
+    (function
+      | Agent_sdk.Types.ToolUse { id; _ }
+        when not (List.mem id next_tool_result_ids) -> Some id
+      | _ -> None)
+    msg.content
+
 let repair_dangling_tool_use_messages
     (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
+  let fabricated = ref 0 in
+  let first_sample_id : string option ref = ref None in
   let repair_with_next
       (current : Agent_sdk.Types.message)
       (next_opt : Agent_sdk.Types.message option) =
@@ -507,12 +544,16 @@ let repair_dangling_tool_use_messages
         current.content
     in
     if not has_dangling then current
-    else
+    else begin
+      if !first_sample_id = None then
+        first_sample_id :=
+          sample_first_dangling_tool_use_id current ~next_tool_result_ids;
       let content =
         List.map
           (function
             | Agent_sdk.Types.ToolUse { id; name; input }
               when not (List.mem id next_tool_result_ids) ->
+                incr fabricated;
                 Agent_sdk.Types.Text
                   (tool_use_text_of_block
                      ~tool_use_id:id ~tool_name:name ~input)
@@ -520,6 +561,7 @@ let repair_dangling_tool_use_messages
           current.content
       in
       { current with content }
+    end
   in
   let rec loop acc = function
     | [] -> List.rev acc
@@ -529,10 +571,26 @@ let repair_dangling_tool_use_messages
         let repaired = repair_with_next current (Some next) in
         loop (repaired :: acc) rest
   in
-  loop [] messages
+  let repaired = loop [] messages in
+  if !fabricated > 0 then begin
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_repair_fabrications
+      ~labels:[("kind", Keeper_repair_kind.(to_label Dangling_tool_use))]
+      ~delta:(float_of_int !fabricated)
+      ();
+    Log.Keeper.warn
+      "repair_dangling_tool_use_messages: fabricated %d Text block(s) \
+       (sample tool_use_id=%s) — context reducer dropped matching \
+       ToolResult half; investigate context_reducer strategy"
+      !fabricated
+      (Option.value !first_sample_id ~default:"<none>")
+  end;
+  repaired
 
 let repair_orphan_tool_result_messages
     (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
+  let fabricated = ref 0 in
+  let first_sample_id : string option ref = ref None in
   let rec loop prev acc = function
     | [] -> List.rev acc
     | msg :: rest ->
@@ -566,7 +624,22 @@ let repair_orphan_tool_result_messages
                 msg.content
             in
             if not has_orphan then msg
-            else
+            else begin
+              (* Observability bookkeeping: count strictly-orphaned blocks
+                 only so the metric reflects the true Anthropic-pairing
+                 violation count, even though the rewrite below downgrades
+                 every ToolResult in this message (preserving long-standing
+                 behaviour — separating that into a behaviour fix is a
+                 distinct PR). *)
+              List.iter
+                (function
+                  | Agent_sdk.Types.ToolResult { tool_use_id; _ }
+                    when not (List.mem tool_use_id prev_tool_use_ids) ->
+                      incr fabricated;
+                      if !first_sample_id = None then
+                        first_sample_id := Some tool_use_id
+                  | _ -> ())
+                msg.content;
               let content =
                 List.map
                   (function
@@ -577,10 +650,25 @@ let repair_orphan_tool_result_messages
                   msg.content
               in
               { msg with content }
+            end
         in
         loop (Some repaired) (repaired :: acc) rest
   in
-  loop None [] messages
+  let repaired = loop None [] messages in
+  if !fabricated > 0 then begin
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_repair_fabrications
+      ~labels:[("kind", Keeper_repair_kind.(to_label Orphan_tool_result))]
+      ~delta:(float_of_int !fabricated)
+      ();
+    Log.Keeper.warn
+      "repair_orphan_tool_result_messages: fabricated %d Text block(s) \
+       (sample tool_use_id=%s) — checkpoint dropped matching ToolUse \
+       predecessor; investigate checkpoint cap / message_gate"
+      !fabricated
+      (Option.value !first_sample_id ~default:"<none>")
+  end;
+  repaired
 
 let repair_broken_tool_call_pairs
     (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -672,6 +672,11 @@ let metric_keeper_thinking_persist_failures =
 ;;
 
 let metric_keeper_checkpoint_failures = "masc_keeper_checkpoint_failures_total"
+
+let metric_keeper_repair_fabrications =
+  "masc_keeper_repair_fabrications_total"
+;;
+
 let metric_keeper_memory_write_failures = "masc_keeper_memory_write_failures_total"
 let metric_keeper_memory_consolidations = "masc_keeper_memory_consolidations_total"
 

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -336,6 +336,15 @@ val metric_keeper_cascade_sync_failures : string
 val metric_keeper_local_discovery_failures : string
 val metric_keeper_thinking_persist_failures : string
 val metric_keeper_checkpoint_failures : string
+
+val metric_keeper_repair_fabrications : string
+(** Counter for [Keeper_context_core.repair_broken_tool_call_pairs]
+    fabrications.  Each increment marks one ToolUse or ToolResult block
+    downgraded to plain Text because the matching half was dropped by
+    compaction/cap/rollover.  Label [kind] is governed by
+    [Keeper_repair_kind].  A rising rate is the signal that the context
+    reducer is silently breaking tool pairs. *)
+
 val metric_keeper_memory_write_failures : string
 val metric_keeper_memory_consolidations : string
 val metric_keeper_write_meta_cycle_failures : string

--- a/lib/keeper/keeper_repair_kind.ml
+++ b/lib/keeper/keeper_repair_kind.ml
@@ -1,0 +1,8 @@
+type t =
+  | Dangling_tool_use
+  | Orphan_tool_result
+
+let to_label = function
+  | Dangling_tool_use -> "dangling_tool_use"
+  | Orphan_tool_result -> "orphan_tool_result"
+;;

--- a/lib/keeper/keeper_repair_kind.mli
+++ b/lib/keeper/keeper_repair_kind.mli
@@ -1,0 +1,29 @@
+(** Keeper_repair_kind — closed sum naming the two silent fabrications
+    performed by [Keeper_context_core.repair_broken_tool_call_pairs] when
+    Anthropic's tool_use/tool_result pairing invariant is violated after
+    compaction/cap/rollover.
+
+    These fabrications used to be invisible (no log, no metric); they run on
+    every compaction via [Keeper_compact_policy] and on every retry, so the
+    operational signal for "context reducer dropped the matching half of a
+    tool pair" was lost. This module gives each fabrication a stable label
+    so the [Prometheus] counter and [Log.Keeper] line keep typed contracts
+    instead of free-form strings.
+
+    Adding a new repair flavour MUST extend this type — exhaustive [match]
+    in [to_label] is the design intent. *)
+
+type t =
+  | Dangling_tool_use
+      (** A [ToolUse] block had no matching [ToolResult] in the next message;
+          we downgraded it to plain [Text] to keep the trail without
+          replaying tool metadata.  Emitted from
+          [Keeper_context_core.repair_dangling_tool_use_messages]. *)
+  | Orphan_tool_result
+      (** A [ToolResult] block referenced a [tool_use_id] absent from the
+          previous message; we downgraded it to plain [Text] so the
+          semantic output survives without triggering Anthropic's
+          pairing validation.  Emitted from
+          [Keeper_context_core.repair_orphan_tool_result_messages]. *)
+
+val to_label : t -> string


### PR DESCRIPTION
## 목표

`Keeper_context_core.repair_broken_tool_call_pairs` 가 silent 하게 ToolUse/ToolResult 블록을 Text로 강등하는 두 fabrication 지점에 typed counter + sample-id log 를 박는다. 동작 변경 없음 (observability only).

근거: `.tmp/oas-internal-audit.html` C1.

## 변경 파일

- `lib/keeper/keeper_repair_kind.{ml,mli}` — closed sum `Dangling_tool_use | Orphan_tool_result`
- `lib/keeper/keeper_metrics.{ml,mli}` — `metric_keeper_repair_fabrications`
- `lib/keeper/keeper_context_core.ml` — `register_counter` + 두 `repair_*` 함수에 inc/log
- `lib/dune` — `private_modules` 에 `keeper_repair_kind` 추가

## 로컬 검증

- `scripts/dune-local.sh build @lib/check` PASS
- 동작 변경 없음 확인: 원본 rewrite-all 의도-vs-구현 mismatch 보존, counter는 *strictly orphaned* 블록만 카운트

## 미검증 / 후속

- Property-based test for fabrication counting (별도 PR 권장 — inc_counter 는 글로벌 mutable state 라 isolated test 어려움)
- Fabrication 비율 임계 알람 (Prometheus alertmanager rule) — 카운터 누적 후 별도 RFC

## Anti-pattern self-check

- telemetry-as-fix 만? ⚠️ 가시화 목적. fix 결정은 측정값 누적 후 후속 RFC. behaviour 보존이라 `WORKAROUND` 라벨 불필요.
- string 분류기? ✗ typed variant
- N-of-M? ✗ 두 함수 모두 동일 PR
- catch-all `_->false` 추가? ✗
- magic number? ✗ metric name SSOT

## RFC

`bash ~/me/scripts/pr-rfc-check.sh` exit=0 (영향 파일 모두 RFC 의무 subsystem 외부).

🤖 Generated with [Claude Code](https://claude.com/claude-code)