### PR TITLE
feat(keeper): expose continuity-snapshot outcome and warn on silent miss

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -11,6 +11,7 @@
  keeper_paused_state_persist_phase
  keeper_bookkeeping_failure_kind
  keeper_checkpoint_failure_operation
+ keeper_continuity_snapshot_outcome
  keeper_profile_load_failure_site
  keeper_turn_cleanup_failure_site
  keeper_cascade_sync_failure_site

--- a/lib/keeper/keeper_continuity_snapshot_outcome.ml
+++ b/lib/keeper/keeper_continuity_snapshot_outcome.ml
@@ -1,0 +1,10 @@
+type t =
+  | From_state_block
+  | From_structured_checkpoint
+  | Missing_no_snapshot
+
+let to_label = function
+  | From_state_block -> "from_state_block"
+  | From_structured_checkpoint -> "from_structured_checkpoint"
+  | Missing_no_snapshot -> "missing_no_snapshot"
+;;

--- a/lib/keeper/keeper_continuity_snapshot_outcome.mli
+++ b/lib/keeper/keeper_continuity_snapshot_outcome.mli
@@ -1,0 +1,33 @@
+(** Keeper_continuity_snapshot_outcome — closed sum naming the three paths
+    out of {!Keeper_post_turn}'s [apply_continuity_summary].
+
+    The function used to expose only one boolean: "did the snapshot get
+    persisted, yes/no".  When it returned [None] (no [STATE] block, no
+    structured working_context fallback) it silently returned [meta]
+    unchanged.  That [None] branch is load-bearing because
+    [meta.runtime.last_continuity_update_ts] only advances on the
+    [Some] path, and the reflection-cooldown gate in
+    {!Keeper_compact_policy} uses [last_continuity_update_ts] to decide
+    whether compaction is allowed (line 68-79).  An LLM that stops
+    emitting [STATE] therefore silently traps the cooldown until ratio
+    hits the emergency threshold.
+
+    This typed outcome makes each path observable so operators can tell
+    "missing snapshot" from "structured fallback used" and tie that to
+    cooldown stalls. *)
+
+type t =
+  | From_state_block
+      (** [latest_state_snapshot_from_messages] returned [Some].  The LLM
+          emitted a parseable [STATE] block this turn. *)
+  | From_structured_checkpoint
+      (** [STATE] block was absent but the OAS checkpoint
+          [working_context] yielded a snapshot.  Cooldown advances. *)
+  | Missing_no_snapshot
+      (** Both paths returned [None].  [meta] is returned unchanged and
+          [last_continuity_update_ts] is *not* advanced — the cooldown
+          gate stays at its previous timestamp.  Rising rate of this
+          variant is the operational signal that LLM-side [STATE]
+          emission has regressed. *)
+
+val to_label : t -> string

--- a/lib/keeper/keeper_continuity_snapshot_outcome.mli
+++ b/lib/keeper/keeper_continuity_snapshot_outcome.mli
@@ -7,8 +7,8 @@
     unchanged.  That [None] branch is load-bearing because
     [meta.runtime.last_continuity_update_ts] only advances on the
     [Some] path, and the reflection-cooldown gate in
-    {!Keeper_compact_policy} uses [last_continuity_update_ts] to decide
-    whether compaction is allowed (line 68-79).  An LLM that stops
+    {!Keeper_compact_policy} uses [last_continuity_update_ts] in its
+    compaction-age calculation.  An LLM that stops
     emitting [STATE] therefore silently traps the cooldown until ratio
     hits the emergency threshold.
 

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -672,6 +672,11 @@ let metric_keeper_thinking_persist_failures =
 ;;
 
 let metric_keeper_checkpoint_failures = "masc_keeper_checkpoint_failures_total"
+
+let metric_keeper_continuity_snapshot_outcomes =
+  "masc_keeper_continuity_snapshot_outcomes_total"
+;;
+
 let metric_keeper_memory_write_failures = "masc_keeper_memory_write_failures_total"
 let metric_keeper_memory_consolidations = "masc_keeper_memory_consolidations_total"
 

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -336,6 +336,16 @@ val metric_keeper_cascade_sync_failures : string
 val metric_keeper_local_discovery_failures : string
 val metric_keeper_thinking_persist_failures : string
 val metric_keeper_checkpoint_failures : string
+
+val metric_keeper_continuity_snapshot_outcomes : string
+(** Counter for [Keeper_post_turn.apply_continuity_summary] outcomes.
+    Each turn that runs the post-turn lifecycle increments this exactly
+    once with the [outcome] label governed by
+    {!Keeper_continuity_snapshot_outcome}.  A rising rate of the
+    [missing_no_snapshot] label is the operational signal that LLM-side
+    [STATE] emission has regressed and the compaction cooldown gate
+    will be silently trapped until ratio hits the emergency threshold. *)
+
 val metric_keeper_memory_write_failures : string
 val metric_keeper_memory_consolidations : string
 val metric_keeper_write_meta_cycle_failures : string

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -52,6 +52,24 @@ open Keeper_types
 open Keeper_memory
 open Keeper_context_core
 
+(* Observability for [apply_continuity_summary] outcomes.  Without this
+   counter, the [Missing_no_snapshot] branch silently returns [meta]
+   unchanged and [last_continuity_update_ts] never advances, trapping
+   the reflection-cooldown gate in {!Keeper_compact_policy} until ratio
+   crosses [emergency_compact_ratio_threshold].  Closes the silent
+   coupling flagged in .tmp/memory-compacting-analysis.html V01. *)
+let () =
+  Prometheus.register_counter
+    ~name:Keeper_metrics.metric_keeper_continuity_snapshot_outcomes
+    ~help:
+      "Total [apply_continuity_summary] outcomes per turn, classified by \
+       label [outcome] (from_state_block | from_structured_checkpoint | \
+       missing_no_snapshot).  Rising [missing_no_snapshot] rate means \
+       LLM-side [STATE] emission regressed and compaction cooldown is \
+       silently trapped."
+    ()
+;;
+
 type compaction_event = {
   attempted : bool;
   applied : bool;
@@ -403,11 +421,39 @@ let apply_post_turn_lifecycle_with_resilience_handles
           | None -> None)
       | None -> None
     in
-    let snapshot =
-      match latest_state_snapshot_from_messages (messages_of_context ctx) with
-      | Some _ as snapshot -> snapshot
-      | None -> structured_snapshot
+    let state_block_snapshot =
+      latest_state_snapshot_from_messages (messages_of_context ctx)
     in
+    let snapshot, outcome =
+      match state_block_snapshot with
+      | Some _ as snap ->
+          snap, Keeper_continuity_snapshot_outcome.From_state_block
+      | None ->
+          (match structured_snapshot with
+           | Some _ as snap ->
+               snap, Keeper_continuity_snapshot_outcome.From_structured_checkpoint
+           | None ->
+               None, Keeper_continuity_snapshot_outcome.Missing_no_snapshot)
+    in
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_continuity_snapshot_outcomes
+      ~labels:
+        [ ("keeper", meta.name)
+        ; ("outcome", Keeper_continuity_snapshot_outcome.to_label outcome)
+        ]
+      ();
+    (match outcome with
+     | Keeper_continuity_snapshot_outcome.Missing_no_snapshot ->
+         (* Warn only on the silent-failure branch.  Successful paths are
+            counted by the metric without flooding the log. *)
+         Log.Keeper.warn
+           "keeper:%s apply_continuity_summary: no [STATE] block and no \
+            structured working_context fallback; last_continuity_update_ts \
+            held at previous value — reflection cooldown stays trapped until \
+            ratio reaches emergency threshold"
+           meta.name
+     | Keeper_continuity_snapshot_outcome.From_state_block
+     | Keeper_continuity_snapshot_outcome.From_structured_checkpoint -> ());
     match snapshot with
     | None -> meta
     | Some snapshot ->


### PR DESCRIPTION
## 목표

`Keeper_post_turn.apply_continuity_summary` 의 [STATE] parse 실패 + 구조화된 fallback 부재 케이스(`None` → `meta` 그대로 반환)가 silent 하게 `last_continuity_update_ts` 진행을 막는다. 이것이 `Keeper_compact_policy:68-79` 의 reflection-cooldown 게이트를 silent 하게 trap. typed outcome + counter + Missing branch warn 으로 가시화. 동작 변경 없음.

근거: `.tmp/memory-compacting-analysis.html` V01.

## 변경 파일

- `lib/keeper/keeper_continuity_snapshot_outcome.{ml,mli}` — closed sum `From_state_block | From_structured_checkpoint | Missing_no_snapshot`
- `lib/keeper/keeper_metrics.{ml,mli}` — `metric_keeper_continuity_snapshot_outcomes`
- `lib/keeper/keeper_post_turn.ml` — top-level `register_counter` + outcome 분기 + inc + Missing 시 warn
- `lib/dune` — `private_modules` 에 `keeper_continuity_snapshot_outcome` 추가

## 로컬 검증

- `scripts/dune-local.sh build @lib/check` PASS
- 동작 보존: `match snapshot with | None -> meta` 그대로 유지 — counter 만 추가

## 가시화 결과

- `masc_keeper_continuity_snapshot_outcomes_total{keeper, outcome=missing_no_snapshot}` 누적 rate 가 LLM-side [STATE] 누락 회귀의 신호
- Missing branch 의 warn 라인이 \"cooldown 막힘\" 디버깅을 즉시 가능하게 함

## 미검증 / 후속

- Missing branch 시 `last_continuity_update_ts` 를 small advance 시킬지 (design 질문 — 별도 RFC)
- High-cardinality keeper 라벨 → fleet-scale 에서는 `persona` 로 down-sample 필요

## Anti-pattern self-check

- telemetry-as-fix 만? ⚠️ 가시화 only. behaviour fix 는 design 결정 필요
- string 분류기? ✗ typed variant
- N-of-M? ✗ outcome 분류가 한 함수 안 exhaustive
- catch-all? ✗ 3-way exhaustive match

## RFC

`bash ~/me/scripts/pr-rfc-check.sh` exit=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)