### PR TITLE
feat(keeper): expose Pending.stash replacement and warn on drop

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -11,6 +11,7 @@
  keeper_paused_state_persist_phase
  keeper_bookkeeping_failure_kind
  keeper_checkpoint_failure_operation
+ keeper_compact_audit_stash_outcome
  keeper_profile_load_failure_site
  keeper_turn_cleanup_failure_site
  keeper_cascade_sync_failure_site

--- a/lib/keeper/keeper_compact_audit.ml
+++ b/lib/keeper/keeper_compact_audit.ml
@@ -318,6 +318,25 @@ let pair_events rows : pair_result list =
 
 (* ── Subscriber ────────────────────────────────────────────────── *)
 
+(* Observability counter for Pending.stash outcomes.  Without this,
+   a concurrent second Compaction_started for the same keeper would
+   silently overwrite the first one's (compaction_id, ts_unix); the
+   lost start surfaces later only as an Orphan_complete and operators
+   never learn about the race.  Closes the silent-failure gap flagged
+   in .tmp/memory-compacting-analysis.html V02. *)
+let () =
+  Prometheus.register_counter
+    ~name:Keeper_metrics.metric_keeper_compact_audit_stash
+    ~help:
+      "Total [Keeper_compact_audit.Pending.stash] calls, classified \
+       by label [outcome] (inserted | replaced_dropped).  Label \
+       [keeper] names the affected keeper.  Rising [replaced_dropped] \
+       means a second Compaction_started landed for the same keeper \
+       before the first one's Compaction_completed; the lost pair \
+       will surface as Orphan_complete in [pair_events]."
+    ()
+;;
+
 (* Per-keeper pending start: maps keeper_name → (compaction_id, ts_start).
    Needed because OAS events don't carry a compaction-scoped correlation. *)
 module Pending = struct
@@ -325,8 +344,39 @@ module Pending = struct
   let mu = Eio.Mutex.create ()
 
   let stash ~keeper_name ~compaction_id ~ts =
-    Eio.Mutex.use_rw ~protect:true mu (fun () ->
-      Hashtbl.replace tbl keeper_name (compaction_id, ts))
+    let outcome =
+      Eio.Mutex.use_rw ~protect:true mu (fun () ->
+        let outcome =
+          match Hashtbl.find_opt tbl keeper_name with
+          | None -> Keeper_compact_audit_stash_outcome.Inserted
+          | Some (previous_compaction_id, previous_ts_unix) ->
+              Keeper_compact_audit_stash_outcome.Replaced_dropped
+                { previous_compaction_id; previous_ts_unix }
+        in
+        Hashtbl.replace tbl keeper_name (compaction_id, ts);
+        outcome)
+    in
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_compact_audit_stash
+      ~labels:
+        [ ("keeper", keeper_name)
+        ; ( "outcome"
+          , Keeper_compact_audit_stash_outcome.to_label outcome )
+        ]
+      ();
+    match outcome with
+    | Keeper_compact_audit_stash_outcome.Inserted -> ()
+    | Keeper_compact_audit_stash_outcome.Replaced_dropped
+        { previous_compaction_id; previous_ts_unix } ->
+        Log.Keeper.warn
+          "keeper:%s compact_audit.Pending.stash dropped pending start \
+           (previous compaction_id=%s ts=%.3f) — second \
+           Compaction_started arrived before first one's \
+           Compaction_completed; lost pair will surface as \
+           Orphan_complete"
+          keeper_name
+          previous_compaction_id
+          previous_ts_unix
 
   let take ~keeper_name =
     Eio.Mutex.use_rw ~protect:true mu (fun () ->

--- a/lib/keeper/keeper_compact_audit_stash_outcome.ml
+++ b/lib/keeper/keeper_compact_audit_stash_outcome.ml
@@ -1,0 +1,11 @@
+type t =
+  | Inserted
+  | Replaced_dropped of {
+      previous_compaction_id : string;
+      previous_ts_unix : float;
+    }
+
+let to_label = function
+  | Inserted -> "inserted"
+  | Replaced_dropped _ -> "replaced_dropped"
+;;

--- a/lib/keeper/keeper_compact_audit_stash_outcome.mli
+++ b/lib/keeper/keeper_compact_audit_stash_outcome.mli
@@ -1,0 +1,30 @@
+(** Keeper_compact_audit_stash_outcome — closed sum naming the two
+    paths through [Keeper_compact_audit.Pending.stash].
+
+    The Pending table is keyed by [keeper_name] (not compaction_id)
+    because OAS Compaction_started events do not carry a
+    compaction-scoped correlation id.  When a second [Start] event for
+    the same keeper arrives before the first one's matching [Complete],
+    [Hashtbl.replace] silently overwrites the previous (compaction_id,
+    ts_unix) tuple.  The lost pair surfaces later only as an
+    [Orphan_complete] — operators never learn that two concurrent
+    compactions raced.
+
+    This outcome makes the replacement observable so a rising
+    [replaced_dropped] rate is the operational signal that
+    Compaction_started is firing twice for the same keeper without an
+    intervening Compaction_completed. *)
+
+type t =
+  | Inserted
+      (** No prior stash for this keeper.  Normal path. *)
+  | Replaced_dropped of {
+      previous_compaction_id : string;
+      previous_ts_unix : float;
+    }
+      (** A prior (compaction_id, ts_unix) was overwritten without ever
+          being [take]n.  The previous compaction's [Start] payload is
+          lost; its [Complete] (if it arrives) will appear as an
+          [Orphan_complete] in [pair_events]. *)
+
+val to_label : t -> string

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -672,6 +672,11 @@ let metric_keeper_thinking_persist_failures =
 ;;
 
 let metric_keeper_checkpoint_failures = "masc_keeper_checkpoint_failures_total"
+
+let metric_keeper_compact_audit_stash =
+  "masc_keeper_compact_audit_stash_total"
+;;
+
 let metric_keeper_memory_write_failures = "masc_keeper_memory_write_failures_total"
 let metric_keeper_memory_consolidations = "masc_keeper_memory_consolidations_total"
 

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -336,6 +336,15 @@ val metric_keeper_cascade_sync_failures : string
 val metric_keeper_local_discovery_failures : string
 val metric_keeper_thinking_persist_failures : string
 val metric_keeper_checkpoint_failures : string
+
+val metric_keeper_compact_audit_stash : string
+(** Counter for [Keeper_compact_audit.Pending.stash] outcomes.  Label
+    [outcome] is governed by {!Keeper_compact_audit_stash_outcome}.
+    A rising [replaced_dropped] rate means a second
+    Compaction_started event landed for the same keeper before the
+    first one's Compaction_completed arrived; the lost stash will
+    later surface only as an [Orphan_complete] in [pair_events]. *)
+
 val metric_keeper_memory_write_failures : string
 val metric_keeper_memory_consolidations : string
 val metric_keeper_write_meta_cycle_failures : string


### PR DESCRIPTION
## 목표

`Keeper_compact_audit.Pending.stash` 는 OAS Compaction_started 가 compaction-scoped correlation id 를 carry 하지 않아 keeper_name 으로만 키된다. 같은 keeper 에 대해 두 번째 Compaction_started 가 첫 번째 Compaction_completed 도착 전에 발생하면 `Hashtbl.replace` 가 silent 하게 (compaction_id, ts_unix) tuple 을 덮어쓴다. lost pair 는 나중에 `pair_events` 의 `Orphan_complete` 로만 surface 되며 race 발생 자체는 신호 없음. typed outcome + counter + warn 으로 가시화. 동작 변경 없음.

근거: `.tmp/memory-compacting-analysis.html` V02.

## 변경 파일

- `lib/keeper/keeper_compact_audit_stash_outcome.{ml,mli}` — `Inserted | Replaced_dropped of {previous_compaction_id; previous_ts_unix}` (payload carries dropped tuple)
- `lib/keeper/keeper_metrics.{ml,mli}` — `metric_keeper_compact_audit_stash`
- `lib/keeper/keeper_compact_audit.ml` — top-level `register_counter` + `Pending.stash` 재구성 (find_opt → outcome 분류 → replace, counter/log 는 mutex 바깥)
- `lib/dune` — `private_modules` 추가

## 로컬 검증

- `scripts/dune-local.sh build @lib/check` PASS
- 동작 보존: `Hashtbl.replace` 그대로, 가장 최신 stash 가 살아남음

## 가시화 결과

- `masc_keeper_compact_audit_stash_total{keeper, outcome=replaced_dropped}` rate 가 race 빈도
- Replaced_dropped warn 라인이 dropped compaction_id 와 ts 를 dump → 나중에 발생하는 Orphan_complete 와 cross-reference 가능

## 미검증 / 후속

- 진짜 fix: OAS Compaction_started 이벤트에 compaction-scoped correlation id 추가 (OAS 측 RFC 별도)
- Mutex critical section 밖에서 counter inc — lock ordering 충돌 회피 (deadlock potential reduction)

## Anti-pattern self-check

- telemetry-as-fix 만? ⚠️ 가시화 only. race 자체의 fix 는 OAS 측 protocol 변경 필요
- string 분류기? ✗ typed variant w/ payload
- N-of-M? ✗ stash 함수 단일 변경
- catch-all? ✗ exhaustive 2-way match

## RFC

`bash ~/me/scripts/pr-rfc-check.sh` exit=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)