### PR TITLE
fix(keeper): degrade dashboard reads under fd pressure

### DIFF
--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -1005,7 +1005,21 @@ let rec process_pending ?store_ref acc = function
      | Delivered -> process_pending ?store_ref acc rest
      | Retryable_failure (pending, stage, exn) ->
        let attempt = pending.attempts + 1 in
-       if attempt >= relay_max_attempts
+       let fd_pressure =
+         Keeper_fd_pressure.active () || Keeper_fd_pressure.is_fd_exhaustion_exn exn
+       in
+       if fd_pressure
+       then (
+         Keeper_fd_pressure.note_exception ~site:"oas_event_bridge.relay" exn;
+         Prometheus.inc_counter
+           Prometheus.metric_oas_sse_relay_drops
+           ~labels:[ "stage", relay_stage_to_string stage ]
+           ();
+         let stage_label = relay_stage_to_string stage ^ ":fd_pressure" in
+         emit_relay_drop_log ~pending ~stage_label ~attempts:attempt;
+         broadcast_drop_marker ~pending ~stage_label ~attempts:attempt;
+         process_pending ?store_ref acc rest)
+       else if attempt >= relay_max_attempts
        then (
          Prometheus.inc_counter
            Prometheus.metric_oas_sse_relay_drops

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -46,7 +46,11 @@ let messages_safe config =
 let assoc_upsert fields key value = (key, value) :: List.remove_assoc key fields
 
 let compact_keeper_trust_json ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) =
-  let runtime_trust = Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta in
+  let runtime_trust =
+    if Keeper_fd_pressure.active ()
+    then Keeper_fd_pressure.degraded_trust_json ()
+    else Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
+  in
   let member key = Yojson.Safe.Util.member key runtime_trust in
   `Assoc
     [ "disposition", member "disposition"

--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -209,6 +209,7 @@ let take n lst =
   aux [] n lst
 
 let now_iso () = Masc_domain.now_iso ()
+let fd_pressure_fields () = Keeper_fd_pressure.projection_fields ()
 
 let requests_json ?base_path ?task_id ?limit () : Yojson.Safe.t =
   let limit = clamp_limit limit in
@@ -216,11 +217,12 @@ let requests_json ?base_path ?task_id ?limit () : Yojson.Safe.t =
   let filtered = filter_by_task_id all task_id in
   let sorted = sort_desc filtered in
   let trimmed = take limit sorted in
-  `Assoc [
-    ("updated_at", `String (now_iso ()));
-    ("total", `Int (List.length filtered));
-    ("requests", `List (List.map request_to_json trimmed));
-  ]
+  `Assoc
+    ([ ("updated_at", `String (now_iso ()))
+     ; ("total", `Int (List.length filtered))
+     ; ("requests", `List (List.map request_to_json trimmed))
+     ]
+     @ fd_pressure_fields ())
 
 (* ── Summary projection ─────────────────────────────── *)
 
@@ -281,15 +283,17 @@ let summary_json ?base_path ?recent () : Yojson.Safe.t =
     |> take recent
     |> List.map rejection_row_json
   in
-  `Assoc [
-    ("updated_at", `String (now_iso ()));
-    ("total", `Int total);
-    ("by_status", `Assoc [
-      ("pending", `Int !pending);
-      ("approved", `Int !approved);
-      ("rejected", `Int !rejected);
-      (* timed_out reserved for future state-machine variant; always 0 today *)
-      ("timed_out", `Int 0);
-    ]);
-    ("recent_rejections", `List recent_rejections);
-  ]
+  `Assoc
+    ([ ("updated_at", `String (now_iso ()))
+     ; ("total", `Int total)
+     ; ( "by_status"
+       , `Assoc
+           [ ("pending", `Int !pending)
+           ; ("approved", `Int !approved)
+           ; ("rejected", `Int !rejected)
+           ; (* timed_out reserved for future state-machine variant; always 0 today *)
+             ("timed_out", `Int 0)
+           ] )
+     ; ("recent_rejections", `List recent_rejections)
+     ]
+     @ fd_pressure_fields ())

--- a/lib/keeper_fd_pressure.ml
+++ b/lib/keeper_fd_pressure.ml
@@ -92,6 +92,34 @@ let remaining_sec ?now () =
   max 0.0 (Atomic.get cooldown_until -. now)
 ;;
 
+let projection_fields ?now () =
+  let degraded = active ?now () in
+  [ "degraded", `Bool degraded
+  ; "degraded_reason", (if degraded then `String "fd_pressure" else `Null)
+  ; "fd_pressure_remaining_sec", `Float (remaining_sec ?now ())
+  ]
+;;
+
+let degraded_projection_json ?now () = `Assoc (projection_fields ?now ())
+
+let degraded_trust_json ?now () =
+  `Assoc
+    [ "disposition", `String "Degraded"
+    ; "disposition_reason", `String "fd_pressure"
+    ; "operator_disposition", `String "Pause"
+    ; "operator_disposition_reason", `String "fd_pressure"
+    ; "needs_attention", `Bool true
+    ; "attention_reason", `String "fd_pressure"
+    ; "next_human_action", `String "restore_fd_headroom"
+    ; "approval", `Null
+    ; "execution", `Null
+    ; "pending_approval_count", `Null
+    ; "latest_terminal_reason", `Null
+    ; "latest_next_action", `String "restore_fd_headroom"
+    ; "latest_causal_event", degraded_projection_json ?now ()
+    ]
+;;
+
 let reset_for_tests () =
   Atomic.set cooldown_until 0.0;
   Atomic.set last_log_at 0.0;

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -128,6 +128,19 @@ let keeper_runtime_identity_fields (meta : Keeper_types.keeper_meta) =
   ]
 ;;
 
+let degraded_keeper_runtime_identity_fields (meta : Keeper_types.keeper_meta) =
+  let cascade_name = non_empty_trimmed_string_opt (Keeper_types.cascade_name_of_meta meta) in
+  let cascade_json = string_option_to_json cascade_name in
+  [ "cascade_name", cascade_json
+  ; "cascade_canonical", cascade_json
+  ; "selected_cascade_canonical", cascade_json
+  ; "primary_model", `Null
+  ; "active_model", `Null
+  ; "active_model_label", `Null
+  ; "last_model_used_label", `Null
+  ]
+;;
+
 type action_result_status =
   | ActionOk
   | ActionError
@@ -543,7 +556,11 @@ let compact_keeper_runtime_trust_json
       ~(config : Coord.config)
       ~(meta : Keeper_types.keeper_meta)
   =
-  let runtime_trust = Keeper_runtime_trust_snapshot.summary_json ~config ~meta in
+  let runtime_trust =
+    if Keeper_fd_pressure.active ()
+    then Keeper_fd_pressure.degraded_trust_json ()
+    else Keeper_runtime_trust_snapshot.summary_json ~config ~meta
+  in
   let member key = Yojson.Safe.Util.member key runtime_trust in
   `Assoc
     [ "disposition", member "disposition"
@@ -558,6 +575,41 @@ let compact_keeper_runtime_trust_json
     ; "latest_next_action", member "latest_next_action"
     ; "latest_causal_event", member "latest_causal_event"
     ]
+;;
+
+let degraded_keeper_snapshot_row (meta : Keeper_types.keeper_meta) =
+  let runtime_trust = Keeper_fd_pressure.degraded_trust_json () in
+  let fd_fields = Keeper_fd_pressure.projection_fields () in
+  `Assoc
+    ([ "runtime_class", `String "keeper"
+     ; "pipeline_stage", `String "degraded"
+     ; "phase", `String "degraded"
+     ; "name", `String meta.name
+     ; "agent_name", `String meta.agent_name
+     ; ( "trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id) )
+     ; "goal", `String meta.goal
+     ; "short_goal", `String meta.short_goal
+     ; "mid_goal", `String meta.mid_goal
+     ; "long_goal", `String meta.long_goal
+     ; "status", `String "degraded"
+     ; "agent", `Null
+     ; "generation", `Int meta.runtime.generation
+     ; "turn_count", `Int meta.runtime.usage.total_turns
+     ; "paused", `Bool meta.paused
+     ; "keepalive_running", `Bool false
+     ; "last_model_used", `Null
+     ; "next_model_hint", `Null
+     ; ( "active_goal_ids"
+       , `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids) )
+     ; "recent_activity", `List []
+     ; "runtime_trust", runtime_trust
+     ; "trust", runtime_trust
+     ; "diagnostic", Keeper_fd_pressure.degraded_projection_json ()
+     ; "updated_at", `String meta.updated_at
+     ; "created_at", `String meta.created_at
+     ]
+     @ degraded_keeper_runtime_identity_fields meta
+     @ fd_fields)
 ;;
 
 let keepers_json
@@ -577,6 +629,8 @@ let keepers_json
      construction can cause memory spikes during dashboard refresh. *)
   let n = List.length names in
   let results = Array.make n None in
+  let fd_degraded = Keeper_fd_pressure.active () in
+  let keeper_sem = if fd_degraded then Eio.Semaphore.make 1 else _keeper_sem in
   Eio.Fiber.all
     (List.mapi
        (fun idx name () ->
@@ -588,11 +642,11 @@ let keepers_json
             half exceeds the same 500ms threshold used by the outer
             [timed] helper, keeping the log quiet on healthy snapshots. *)
           let t_wait_start = Time_compat.now () in
-          Eio.Semaphore.acquire _keeper_sem;
+          Eio.Semaphore.acquire keeper_sem;
           let t_work_start = Time_compat.now () in
           let wait_ms = (t_work_start -. t_wait_start) *. 1000.0 in
           Eio.Switch.on_release keeper_sw (fun () ->
-            Eio.Semaphore.release _keeper_sem;
+            Eio.Semaphore.release keeper_sem;
             let work_ms = (Time_compat.now () -. t_work_start) *. 1000.0 in
             if work_ms > 500.0 || wait_ms > 500.0
             then
@@ -636,7 +690,11 @@ let keepers_json
                 | Error _ | Ok None -> None
                 | Ok (Some meta) ->
                   dt_meta := Time_compat.now () -. t0;
-                  if lightweight && meta.paused
+                  if fd_degraded
+                  then (
+                    emit_timing_log (Time_compat.now () -. t_work_start);
+                    Some (degraded_keeper_snapshot_row meta))
+                  else if lightweight && meta.paused
                   then (
                     let t_ph = Time_compat.now () in
                     let phase_str =

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -343,11 +343,26 @@ let list_requests base_path =
       ~detail
   in
   let dir = verifications_dir base_path in
-  if not (Sys.file_exists dir) then
+  if Keeper_fd_pressure.active ()
+  then []
+  else
+    let dir_exists =
+      try Sys.file_exists dir with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Keeper_fd_pressure.note_exception ~site:"verification.list_requests.exists" exn;
+        report_drop
+          ~reason:Safe_ops.persistence_read_drop_reason_list_dir_error
+          ~path:dir
+          ~detail:(Printexc.to_string exn);
+        false
+    in
+    if not dir_exists then
     []
   else
     match Safe_ops.list_dir_safe dir with
     | Error detail ->
+      Keeper_fd_pressure.note_if_fd_exhaustion ~site:"verification.list_requests" detail;
       report_drop ~reason:Safe_ops.persistence_read_drop_reason_list_dir_error ~path:dir ~detail;
       []
     | Ok files ->

--- a/test/test_dashboard_verification.ml
+++ b/test/test_dashboard_verification.ml
@@ -13,6 +13,7 @@ let () = Mirage_crypto_rng_unix.use_default ()
 module V = Masc_mcp.Verification
 module D = Masc_mcp.Dashboard_verification
 module CU = Coord_utils
+module FD = Masc_mcp.Keeper_fd_pressure
 
 (* ── Fixture helpers ────────────────────────────────── *)
 
@@ -349,6 +350,42 @@ let int_field name j =
   | `Int n -> n
   | _ -> Alcotest.fail (Printf.sprintf "%s not int" name)
 
+let bool_field name j =
+  match member name j with
+  | `Bool value -> value
+  | _ -> Alcotest.fail (Printf.sprintf "%s not bool" name)
+
+let test_requests_and_summary_degrade_under_fd_pressure () =
+  with_temp_base_path (fun base_path ->
+    let _ =
+      create_pending_request
+        ~base_path
+        ~task_id:"task-fd-pressure"
+        ~worker:"keeper-alpha"
+        ~criteria:[ V.Custom "must not scan under FD pressure" ]
+        ~evidence:[ "ref-fd" ]
+    in
+    FD.reset_for_tests ();
+    FD.note ~site:"test" ~detail:"Too many open files in system" ();
+    Fun.protect
+      ~finally:FD.reset_for_tests
+      (fun () ->
+        let requests = D.requests_json () in
+        Alcotest.(check int) "requests total degraded" 0 (int_field "total" requests);
+        Alcotest.(check bool)
+          "requests degraded flag"
+          true
+          (bool_field "degraded" requests);
+        (match member "requests" requests with
+         | `List [] -> ()
+         | _ -> Alcotest.fail "requests should be empty during fd pressure");
+        let summary = D.summary_json () in
+        Alcotest.(check int) "summary total degraded" 0 (int_field "total" summary);
+        Alcotest.(check bool)
+          "summary degraded flag"
+          true
+          (bool_field "degraded" summary)))
+
 let test_summary_empty () =
   with_temp_base_path (fun _base_path ->
     let j = D.summary_json () in
@@ -432,6 +469,8 @@ let () =
         test_requests_json_ignores_legacy_root_entries;
       Alcotest.test_case "conflict triage fields" `Quick
         test_requests_json_surfaces_conflict_triage_fields;
+      Alcotest.test_case "fd pressure degraded projection" `Quick
+        test_requests_and_summary_degrade_under_fd_pressure;
     ];
     "summary_json", [
       Alcotest.test_case "empty base_path" `Quick test_summary_empty;

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -100,6 +100,26 @@ let test_fd_pressure_proactive_admission () =
        ~active_keepers:8
        ())
 
+let test_fd_pressure_degraded_projection () =
+  FD.reset_for_tests ();
+  Fun.protect
+    ~finally:FD.reset_for_tests
+    (fun () ->
+      FD.note ~site:"test" ~detail:"Too many open files in system" ();
+      check bool "pressure active" true (FD.active ());
+      let projection = `Assoc (FD.projection_fields ()) in
+      check bool "projection degraded" true
+        (Json.member "degraded" projection |> Json.to_bool);
+      check string "projection reason" "fd_pressure"
+        (Json.member "degraded_reason" projection |> Json.to_string);
+      let trust = FD.degraded_trust_json () in
+      check string "degraded disposition" "Degraded"
+        (Json.member "disposition" trust |> Json.to_string);
+      check bool "needs attention" true
+        (Json.member "needs_attention" trust |> Json.to_bool);
+      check string "next human action" "restore_fd_headroom"
+        (Json.member "next_human_action" trust |> Json.to_string))
+
 let test_bonsai_keepers_summary_uses_scoped_registry () =
   let base_path = temp_base_path "bonsai-summary" in
   let other_base_path = temp_base_path "bonsai-summary-other" in
@@ -1805,6 +1825,8 @@ let () =
             test_fd_pressure_nofile_cap;
           test_case "fd pressure proactive admission" `Quick
             test_fd_pressure_proactive_admission;
+          test_case "fd pressure degraded projection" `Quick
+            test_fd_pressure_degraded_projection;
           eio_test "bonsai summary uses scoped registry"
             test_bonsai_keepers_summary_uses_scoped_registry;
           eio_test "register and get" test_register_and_get;


### PR DESCRIPTION
## What changed

- Add a shared FD-pressure degraded projection in `Keeper_fd_pressure`.
- Make operator/dashboard keeper trust views return degraded placeholders instead of scanning trust/profile/audit files while FD pressure is active.
- Make verification listing skip heavy `.masc/verifications` scans while FD pressure is active.
- Drop OAS event bridge relay failures immediately under FD pressure instead of retrying and amplifying filesystem I/O.
- Add focused tests for degraded FD projection and verification dashboard behavior.

## Why

The live `.masc` logs showed a system-wide FD pressure cascade: dashboard snapshots, verification reads, runtime manifests, event relay retries, and cost/coverage writes all kept opening files after `EMFILE/ENFILE`, turning the original pressure into a wider outage.

This change makes FD pressure an explicit degraded mode for read-heavy surfaces so the process can preserve headroom and show the operator a clear recovery state.

## Validation

- `ocamlformat --check lib/keeper_fd_pressure.ml lib/operator/operator_control_snapshot.ml lib/dashboard/dashboard_execution.ml lib/dashboard/dashboard_verification.ml lib/verification.ml lib/cascade/cascade_event_bridge.ml test/test_keeper_registry.ml test/test_dashboard_verification.ml`
- `git diff --check`

Focused Dune validation is currently blocked by the repo/OAS pin boundary on this host:

- `scripts/opam-pin-external-deps.sh --install` refuses to downgrade the shared `agent_sdk` floor from `0.193.16` to this branch's `0.193.15`.
- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build ./test/test_keeper_registry.exe ./test/test_dashboard_verification.exe` reaches compile and then fails in pre-existing pin mismatch code: `lib/oas_compat/oas_compat.ml` expects `on_tool_calls` from the installed `agent_sdk`.

The code is intentionally kept draft until the MASC branch is rebased onto the current OAS pin flow or CI runs with its pinned dependency set.
