### PR TITLE
fix(cdal_runtime): close pipe FDs via Eio Switch + set cloexec

### DIFF
--- a/lib/cdal_runtime/autonomy_exec.ml
+++ b/lib/cdal_runtime/autonomy_exec.ml
@@ -179,14 +179,22 @@ let kill_child config pid =
   | Unix.Unix_error ((Unix.ESRCH | Unix.EPERM), _, _) -> ()
 ;;
 
-let spawn_child config effective =
+let close_quietly fd =
+  try Unix.close fd with
+  | Unix.Unix_error _ -> ()
+;;
+
+let spawn_child ~sw config effective =
   let stdin_fd = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0 in
-  let stdout_r, stdout_w = Unix.pipe () in
-  let stderr_r, stderr_w = Unix.pipe () in
-  let close_quietly fd =
-    try Unix.close fd with
-    | Unix.Unix_error _ -> ()
-  in
+  let stdout_r, stdout_w = Unix.pipe ~cloexec:true () in
+  let stderr_r, stderr_w = Unix.pipe ~cloexec:true () in
+  (* Switch.on_release guarantees pipe close on cancellation or unexpected
+     raise. The previous Fun.protect + reader_started flag scheme had a
+     race: setting the flag preceded Eio.Fiber.fork, so a cancellation
+     between them orphaned the read end. close_quietly is idempotent with
+     drain_fd's own Fun.protect close — safe even when both fire. *)
+  Eio.Switch.on_release sw (fun () -> close_quietly stdout_r);
+  Eio.Switch.on_release sw (fun () -> close_quietly stderr_r);
   try
     Unix.set_nonblock stdout_r;
     Unix.set_nonblock stderr_r;
@@ -208,9 +216,7 @@ let spawn_child config effective =
   with
   | Unix.Unix_error (err, fn, arg) ->
     close_quietly stdin_fd;
-    close_quietly stdout_r;
     close_quietly stdout_w;
-    close_quietly stderr_r;
     close_quietly stderr_w;
     Error
       (file_op_error
@@ -240,33 +246,24 @@ let await_result promise map_exn =
 let run ~sw ~clock ~config ~argv ~timeout_s =
   let t0 = Unix.gettimeofday () in
   let* effective = effective_argv ~config ~argv in
-  let* pid, stdout_r, stderr_r = spawn_child config effective in
-  let close_quietly fd =
-    try Unix.close fd with
-    | Unix.Unix_error _ -> ()
-  in
-  let stdout_reader_started = ref false in
-  let stderr_reader_started = ref false in
-  let completed = ref false in
+  let* pid, stdout_r, stderr_r = spawn_child ~sw config effective in
+  (* Pipe FDs are owned by [sw] via Switch.on_release in spawn_child.
+     Only the child lifecycle remains as a manual cleanup concern here.
+     [reaped] tracks whether waitpid has consumed the child, so the
+     finally clause only kills (and avoids a SIGKILL race) when needed. *)
+  let reaped = ref false in
   Fun.protect
-    ~finally:(fun () ->
-      if not !completed
-      then (
-        kill_child config pid;
-        if not !stdout_reader_started then close_quietly stdout_r;
-        if not !stderr_reader_started then close_quietly stderr_r))
+    ~finally:(fun () -> if not !reaped then kill_child config pid)
     (fun () ->
        let wait_promise =
          spawn_result_promise ~sw (fun () ->
            Eio_unix.run_in_systhread ~label:"autonomy-exec-waitpid" (fun () ->
              snd (Unix.waitpid [] pid)))
        in
-       stdout_reader_started := true;
        let stdout_promise =
          spawn_result_promise ~sw (fun () ->
            drain_fd ~limit:config.stdout_limit_bytes stdout_r)
        in
-       stderr_reader_started := true;
        let stderr_promise =
          spawn_result_promise ~sw (fun () ->
            drain_fd ~limit:config.stderr_limit_bytes stderr_r)
@@ -299,9 +296,8 @@ let run ~sw ~clock ~config ~argv ~timeout_s =
                  ~path:(string_of_int pid)
                  ~detail:(Printexc.to_string exn)))
          in
-         let result = capture_and_finish (status_of_unix_status unix_status) in
-         completed := true;
-         result
+         reaped := true;
+         capture_and_finish (status_of_unix_status unix_status)
        with
        | Eio.Time.Timeout ->
          kill_child config pid;
@@ -317,9 +313,8 @@ let run ~sw ~clock ~config ~argv ~timeout_s =
            | Ok (Unix.WEXITED _) -> None
            | Error _ -> None
          in
-         let result = capture_and_finish (Timed_out timed_out_signal) in
-         completed := true;
-         result
+         reaped := true;
+         capture_and_finish (Timed_out timed_out_signal)
        | Eio.Cancel.Cancelled _ as exn -> raise exn)
 ;;
 


### PR DESCRIPTION
# fix(cdal_runtime): close pipe FDs via Eio Switch + set cloexec

## Problem

`autonomy_exec.run` leaked pipe FDs at roughly **~500/hour** under steady masc-mcp load. Direct measurement on PID 85256 (4-minute-old daemon) showed 34 PIPE FDs out of 51 total, with zero live child processes and zero zombies — meaning the parent side of the pipe was orphaned, not the child.

Triggered investigation when `gh pr create` hit `EMFILE (Too many open files in system, os error 23)` after a recent reboot, with `launchctl limit maxfiles` at the macOS default soft cap of 256.

## Two root causes (one PR)

### 1. `Unix.pipe ()` without `~cloexec:true` (lib/cdal_runtime/autonomy_exec.ml:184-185)

Inconsistent with `lib/process/process_eio.ml:221,241,736,737` which uses `~cloexec:true` everywhere. Without the flag, the read end leaks into any grandchild process spawned by the child via `exec`, keeping the FD reachable beyond the parent's view.

### 2. Race in cleanup contract (lib/cdal_runtime/autonomy_exec.ml:248-272)

```ocaml
stdout_reader_started := true;
let stdout_promise = spawn_result_promise ~sw (fun () ->
  drain_fd ~limit:config.stdout_limit_bytes stdout_r)
```

The flag was set **before** `Eio.Fiber.fork`. If the switch was cancelled between the flag set and `drain_fd` actually executing, the parent's `Fun.protect` finally treated the fiber as "owner" and skipped close, while the fiber never entered `drain_fd`'s own `Fun.protect` to close. Result: orphaned read end.

This also violates the project rule in `instructions/software-development.md`: *"Eio에서는 Switch.run + Switch.on_release가 기본. Fun.protect는 finally 예외가 원래 예외를 덮을 수 있음"*.

## Fix

- `Unix.pipe ~cloexec:true ()` on both stdout/stderr pipes.
- Move close responsibility into `Eio.Switch.on_release sw` registered immediately after pipe creation. Switch guarantees close on normal exit, exception, and cancellation alike.
- Drop the `stdout_reader_started` / `stderr_reader_started` flags entirely — they only existed to mediate the broken ownership contract.
- Rename `completed` to `reaped` to reflect what it actually tracks (whether `waitpid` consumed the child; controls SIGKILL fallback only).

`drain_fd`'s own `Fun.protect` close is kept as idempotent backup; `close_quietly` swallows `EBADF` so double-close is harmless.

## Verification

- `dune build lib/cdal_runtime/` — clean
- `dune build lib/autoresearch/` (the only caller, `autoresearch_metric.ml:136`) — clean, public mli signature unchanged
- Existing inline tests preserved: `run captures stdout and stderr`, `run times out and returns Timed_out`, `run preserves switch cancellation`
- Production validation path: `lsof -p <masc-mcp> | awk '$5=="PIPE"' | wc -l` should stop growing across autonomy_exec invocations.

## Workaround rejection bar (self-check)

Per `CLAUDE.md` §workaround_rejection_bar — this PR is a genuine root fix:

- [x] Not telemetry-as-fix (actual close, not just "make leak visible")
- [x] Not string/substring classifier
- [x] Not N-of-M (entire leak path closed in one PR; only one `autonomy_exec.run` caller exists)
- [x] No catch-all `_ ->` added
- [x] No cap/cooldown/dedup/repair
- [x] No test backdoor

## Out of scope (separate issues)

- `lib/llm_metric_bridge.ml:441-462` record literal is missing the `on_tool_calls` field, so `bin/main_eio.exe` fails to build on **current origin/main** (independent of this PR). Likely from #15511 or a subsequent OAS agent_sdk bump that added the field without sweeping callers. CI's `Build and Test` is gated behind `Detect Changed Surfaces` (MEMORY.md `reference_masc_mcp_ci_build_test_skips`), which is why it was not caught. Should be tracked as a follow-up issue.
- `lib/repo_manager/credential_materializer.ml:216,423` uses `Unix.pipe ~cloexec:false ()` intentionally (parent passes the read end to a child via `Unix.create_process_env` for credential delivery). Worth a separate audit of close sites but not part of this leak.

## Evidence record

- Measurement: PID 85256, etime 04:04, RSS 766MB, 34/51 FDs = PIPE
- Comparison: `lib/process/process_eio.ml` uses `Eio.Process.pipe ~sw` or `Unix.pipe ~cloexec:true` everywhere — this fix brings `autonomy_exec` into pattern alignment.
- Confidence: High — fix follows OCaml/Eio invariant (`Switch.on_release` is the documented FD-cleanup idiom), variable code change, public API unchanged.

🤖 Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
