### PR TITLE
fix(keeper): surface OAS repair and bus diagnostics

### DIFF
--- a/lib/agent_sdk_metrics_bridge.ml
+++ b/lib/agent_sdk_metrics_bridge.ml
@@ -56,7 +56,7 @@ let update_gauge_for purpose value =
 ;;
 
 let subscribe ~purpose ?(filter = Agent_sdk.Event_bus.accept_all) bus =
-  let sub = Agent_sdk.Event_bus.subscribe ~filter bus in
+  let sub = Agent_sdk.Event_bus.subscribe ~filter ~purpose bus in
   let t = { sub; purpose; filter; depth = ref 0; warned_above_threshold = ref false } in
   with_registry (fun () -> registry := t :: !registry);
   update_gauge_for purpose 0;

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -178,7 +178,7 @@ let compact_if_needed_typed
      | Eio.Cancel.Cancelled _ as e -> raise e
      | exn ->
        Log.Harness.warn "[pre_compact] sse broadcast failed: %s" (Printexc.to_string exn));
-    let messages =
+    let messages, pair_repair_stats =
       let msgs_after_compact =
         (* Issue #8597 #1: dropped [~system_prompt] arg — compact
                ignored it (system prompt already present in messages
@@ -189,7 +189,7 @@ let compact_if_needed_typed
       let msgs_after_fold =
         Agent_sdk.Context_reducer.reduce fold_reducer msgs_after_compact
       in
-      Keeper_context_core.repair_broken_tool_call_pairs msgs_after_fold
+      Keeper_context_core.repair_broken_tool_call_pairs_with_stats msgs_after_fold
     in
     let compacted_ctx =
       sync_oas_context
@@ -229,12 +229,22 @@ let compact_if_needed_typed
             ; "after_tokens", `Int new_tok_count
             ; "saved_messages", `Int saved_messages
             ; "saved_tokens", `Int saved_tokens
+            ; ( "tool_pair_repair"
+              , `Assoc
+                  [ ( "downgraded_tool_uses"
+                    , `Int pair_repair_stats.downgraded_tool_uses )
+                  ; ( "downgraded_tool_results"
+                    , `Int pair_repair_stats.downgraded_tool_results )
+                  ] )
             ])
       (Printf.sprintf
-         "post_compact keeper=%s trigger=%s saved_tokens=%d"
+         "post_compact keeper=%s trigger=%s saved_tokens=%d pair_repair_tool_uses=%d \
+          pair_repair_tool_results=%d"
          meta.name
          trigger_human
-         saved_tokens);
+         saved_tokens
+         pair_repair_stats.downgraded_tool_uses
+         pair_repair_stats.downgraded_tool_results);
     compacted_ctx, Some trigger, decision
 ;;
 

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -481,8 +481,27 @@ let tool_use_text_of_block
   let input_json = Yojson.Safe.to_string input |> Inference_utils.sanitize_text_utf8 in
   Printf.sprintf "[tool use %s %s input=%s]" tool_name tool_use_id input_json
 
-let repair_dangling_tool_use_messages
-    (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
+type tool_pair_repair_stats =
+  { downgraded_tool_uses : int
+  ; downgraded_tool_results : int
+  }
+
+let empty_tool_pair_repair_stats =
+  { downgraded_tool_uses = 0; downgraded_tool_results = 0 }
+
+let add_tool_pair_repair_stats left right =
+  { downgraded_tool_uses =
+      left.downgraded_tool_uses + right.downgraded_tool_uses
+  ; downgraded_tool_results =
+      left.downgraded_tool_results + right.downgraded_tool_results
+  }
+
+let tool_pair_repair_stats_changed stats =
+  stats.downgraded_tool_uses > 0 || stats.downgraded_tool_results > 0
+
+let repair_dangling_tool_use_messages_with_stats
+    (messages : Agent_sdk.Types.message list)
+    : Agent_sdk.Types.message list * tool_pair_repair_stats =
   let repair_with_next
       (current : Agent_sdk.Types.message)
       (next_opt : Agent_sdk.Types.message option) =
@@ -506,38 +525,49 @@ let repair_dangling_tool_use_messages
           | Agent_sdk.Types.Audio _ -> false)
         current.content
     in
-    if not has_dangling then current
+    if not has_dangling then (current, empty_tool_pair_repair_stats)
     else
+      let downgraded_tool_uses = ref 0 in
       let content =
         List.map
           (function
             | Agent_sdk.Types.ToolUse { id; name; input }
               when not (List.mem id next_tool_result_ids) ->
+                incr downgraded_tool_uses;
                 Agent_sdk.Types.Text
                   (tool_use_text_of_block
                      ~tool_use_id:id ~tool_name:name ~input)
             | other -> other)
           current.content
       in
-      { current with content }
+      ( { current with content }
+      , { empty_tool_pair_repair_stats with
+          downgraded_tool_uses = !downgraded_tool_uses
+        } )
   in
-  let rec loop acc = function
-    | [] -> List.rev acc
+  let rec loop acc_stats acc = function
+    | [] -> List.rev acc, acc_stats
     | [ current ] ->
-        List.rev (repair_with_next current None :: acc)
+        let repaired, repair_stats = repair_with_next current None in
+        List.rev (repaired :: acc), add_tool_pair_repair_stats acc_stats repair_stats
     | current :: ((next :: _) as rest) ->
-        let repaired = repair_with_next current (Some next) in
-        loop (repaired :: acc) rest
+        let repaired, repair_stats = repair_with_next current (Some next) in
+        loop (add_tool_pair_repair_stats acc_stats repair_stats) (repaired :: acc) rest
   in
-  loop [] messages
+  loop empty_tool_pair_repair_stats [] messages
 
-let repair_orphan_tool_result_messages
-    (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
-  let rec loop prev acc = function
-    | [] -> List.rev acc
+let repair_dangling_tool_use_messages messages =
+  fst (repair_dangling_tool_use_messages_with_stats messages)
+
+let repair_orphan_tool_result_messages_with_stats
+    (messages : Agent_sdk.Types.message list)
+    : Agent_sdk.Types.message list * tool_pair_repair_stats =
+  let rec loop acc_stats prev acc = function
+    | [] -> List.rev acc, acc_stats
     | msg :: rest ->
-        let repaired =
-          if not (has_tool_result_block msg) then msg
+        let repaired, stats =
+          if not (has_tool_result_block msg) then
+            (msg, empty_tool_pair_repair_stats)
           else
             let prev_tool_use_ids =
               match prev with
@@ -565,28 +595,41 @@ let repair_orphan_tool_result_messages
                   | Agent_sdk.Types.Audio _ -> false)
                 msg.content
             in
-            if not has_orphan then msg
+            if not has_orphan then (msg, empty_tool_pair_repair_stats)
             else
+              let downgraded_tool_results = ref 0 in
               let content =
                 List.map
                   (function
                     | Agent_sdk.Types.ToolResult { tool_use_id; content; json; _ } ->
+                        incr downgraded_tool_results;
                         Agent_sdk.Types.Text
                           (tool_result_text_of_block ~tool_use_id ~content ~json)
                     | other -> other)
                   msg.content
               in
-              { msg with content }
+              ( { msg with content }
+              , { empty_tool_pair_repair_stats with
+                  downgraded_tool_results = !downgraded_tool_results
+                } )
         in
-        loop (Some repaired) (repaired :: acc) rest
+        loop (add_tool_pair_repair_stats acc_stats stats) (Some repaired) (repaired :: acc) rest
   in
-  loop None [] messages
+  loop empty_tool_pair_repair_stats None [] messages
+
+let repair_orphan_tool_result_messages messages =
+  fst (repair_orphan_tool_result_messages_with_stats messages)
+
+let repair_broken_tool_call_pairs_with_stats
+    (messages : Agent_sdk.Types.message list)
+    : Agent_sdk.Types.message list * tool_pair_repair_stats =
+  let messages, dangling_stats = repair_dangling_tool_use_messages_with_stats messages in
+  let messages, orphan_stats = repair_orphan_tool_result_messages_with_stats messages in
+  messages, add_tool_pair_repair_stats dangling_stats orphan_stats
 
 let repair_broken_tool_call_pairs
     (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
-  messages
-  |> repair_dangling_tool_use_messages
-  |> repair_orphan_tool_result_messages
+  fst (repair_broken_tool_call_pairs_with_stats messages)
 
 let serialize_context (ctx : working_context) : string =
   let json = `Assoc [

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -89,6 +89,19 @@ val text_of_history_jsonl_json : Yojson.Safe.t -> string
 val repair_broken_tool_call_pairs :
   Agent_sdk.Types.message list -> Agent_sdk.Types.message list
 
+type tool_pair_repair_stats =
+  { downgraded_tool_uses : int
+  ; downgraded_tool_results : int
+  }
+
+val tool_pair_repair_stats_changed : tool_pair_repair_stats -> bool
+
+(** Same repair as {!repair_broken_tool_call_pairs}, plus counters for
+    ToolUse/ToolResult blocks downgraded to plain text. This keeps the
+    repair path observable without changing the legacy return type. *)
+val repair_broken_tool_call_pairs_with_stats :
+  Agent_sdk.Types.message list -> Agent_sdk.Types.message list * tool_pair_repair_stats
+
 (** {1 Context (de)serialization} *)
 
 val serialize_context : working_context -> string

--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -438,28 +438,25 @@ let emit_request_latency ?provider ~model_id ~latency_ms () =
     - [on_streaming_first_chunk] → masc_llm_provider_streaming_first_chunk_seconds
     - [on_streaming_chunk] → masc_llm_provider_streaming_inter_chunk_seconds *)
 let make_sink () : Llm_provider.Metrics.t =
-  {
-    on_cache_hit = emit_cache_hit;
-    on_cache_miss = emit_cache_miss;
-    on_request_start = emit_request_start;
-    on_http_status =
-      (fun ~provider ~model_id ~status ->
-        emit_http_status ~provider ~model_id ~status);
-    on_request_end =
-      (fun ~model_id ~latency_ms ->
-        match latency_ms with
-        | Some latency_ms -> emit_request_latency ~model_id ~latency_ms ()
-        | None -> ());
-    on_capability_drop =
-      (fun ~model_id ~field ->
-        emit_capability_drop ~model_id ~field);
-    on_error = (fun ~model_id ~error -> emit_error ~model_id ~error);
-    on_retry = emit_retry;
-    on_circuit_state = emit_circuit_state;
-    on_token_usage = emit_token_usage;
-    on_streaming_first_chunk = emit_streaming_first_chunk;
-    on_streaming_chunk = emit_streaming_chunk;
-  }
+  Oas_compat.Metrics.make
+    ~on_cache_hit:emit_cache_hit
+    ~on_cache_miss:emit_cache_miss
+    ~on_request_start:emit_request_start
+    ~on_http_status:(fun ~provider ~model_id ~status ->
+      emit_http_status ~provider ~model_id ~status)
+    ~on_request_end:(fun ~model_id ~latency_ms ->
+      match latency_ms with
+      | Some latency_ms -> emit_request_latency ~model_id ~latency_ms ()
+      | None -> ())
+    ~on_capability_drop:(fun ~model_id ~field ->
+      emit_capability_drop ~model_id ~field)
+    ~on_error:(fun ~model_id ~error -> emit_error ~model_id ~error)
+    ~on_retry:emit_retry
+    ~on_circuit_state:emit_circuit_state
+    ~on_token_usage:emit_token_usage
+    ~on_streaming_first_chunk:emit_streaming_first_chunk
+    ~on_streaming_chunk:emit_streaming_chunk
+    ()
 
 (** Install the sink as the process-wide default.  Idempotent — calling
     [install ()] multiple times overwrites the previous sink with a

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -270,6 +270,7 @@ module Metrics = struct
       ?(on_streaming_chunk = default_streaming_chunk) ()
       : Llm_provider.Metrics.t =
     {
+      Llm_provider.Metrics.noop with
       on_cache_hit;
       on_cache_miss;
       on_request_start;

--- a/test/test_oas_bus_instrument.ml
+++ b/test/test_oas_bus_instrument.ml
@@ -41,6 +41,18 @@ let test_subscribe_tracks_purpose () =
     check int "unsubscribe clears tracking"
       (-1) (I.For_testing.current_depth ~purpose:"test_sub_a"))
 
+let test_subscribe_forwards_purpose_to_oas_stats () =
+  I.For_testing.reset ();
+  run_eio (fun ~sw:_ ~env:_ ->
+    let bus = mk_bus () in
+    let h = I.subscribe ~purpose:"compact_audit" bus in
+    let stats = Agent_sdk.Event_bus.stats bus in
+    (match stats.subscriptions with
+     | [ sub_stats ] ->
+       check (option string) "oas purpose" (Some "compact_audit") sub_stats.purpose
+     | _ -> fail "expected one OAS subscription");
+    I.unsubscribe bus h)
+
 let test_publish_increments_matching_depth () =
   I.For_testing.reset ();
   run_eio (fun ~sw:_ ~env:_ ->
@@ -157,6 +169,8 @@ let () =
     ("backpressure", [
       test_case "subscribe tracks purpose" `Quick
         test_subscribe_tracks_purpose;
+      test_case "subscribe forwards purpose to OAS stats" `Quick
+        test_subscribe_forwards_purpose_to_oas_stats;
       test_case "publish increments matching depth" `Quick
         test_publish_increments_matching_depth;
       test_case "drain decrements depth" `Quick

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -27,6 +27,7 @@
 
 module UT = Masc_mcp.Keeper_unified_turn
 module EC = Masc_mcp.Keeper_error_classify
+module KC = Masc_mcp.Keeper_context_core
 
 (* ── Generators ──────────────────────────────────────────── *)
 
@@ -248,6 +249,60 @@ let test_pair_repair_integration () =
        | _ -> false)
   end
 
+let user_text text : Agent_sdk.Types.message =
+  { role = Agent_sdk.Types.User
+  ; content = [ Agent_sdk.Types.Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+
+let assistant_tool_use id name : Agent_sdk.Types.message =
+  { role = Agent_sdk.Types.Assistant
+  ; content = [ Agent_sdk.Types.ToolUse { id; name; input = `Null } ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+
+let user_tool_result id content : Agent_sdk.Types.message =
+  { role = Agent_sdk.Types.User
+  ; content =
+      [ Agent_sdk.Types.ToolResult
+          { tool_use_id = id; content; is_error = false; json = None }
+      ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+
+let test_pair_repair_stats_count_downgrades () =
+  let messages =
+    [ user_text "q"
+    ; assistant_tool_use "dangling" "calc"
+    ; user_text "interrupt"
+    ; user_tool_result "orphan" "late"
+    ]
+  in
+  let repaired, stats = KC.repair_broken_tool_call_pairs_with_stats messages in
+  Alcotest.(check bool)
+    "repair stats changed"
+    true
+    (KC.tool_pair_repair_stats_changed stats);
+  Alcotest.(check int) "dangling tool use downgraded" 1 stats.downgraded_tool_uses;
+  Alcotest.(check int) "orphan tool result downgraded" 1 stats.downgraded_tool_results;
+  let has_structured_tool_block =
+    List.exists
+      (fun (msg : Agent_sdk.Types.message) ->
+         List.exists
+           (function
+             | Agent_sdk.Types.ToolUse _ | Agent_sdk.Types.ToolResult _ -> true
+             | _ -> false)
+           msg.content)
+      repaired
+  in
+  Alcotest.(check bool) "structured tool blocks removed" false has_structured_tool_block
+
 (* ── Gospel-style specification (documentation) ────────── *)
 (*
    @gospel — formal specification (Ortac runtime not available on 5.4)
@@ -283,5 +338,7 @@ let () =
         test_cap_message_tokens_integration;
       Alcotest.test_case "local pair repair integrated in reducer chain" `Quick
         test_pair_repair_integration;
+      Alcotest.test_case "pair repair stats count downgrades" `Quick
+        test_pair_repair_stats_count_downgrades;
     ]);
   ]


### PR DESCRIPTION
## Summary
- forward MASC subscriber purpose into OAS Event_bus stats so OAS-native backpressure telemetry can identify `compact_audit`
- add `repair_broken_tool_call_pairs_with_stats` and emit post-compaction downgrade counts for ToolUse/ToolResult repairs
- route the LLM metric sink through `Oas_compat.Metrics.make` for the local OAS metrics bridge

Companion OAS PR: https://github.com/jeong-sik/oas/pull/1611 (merged)
Follow-up OAS pin bump PR: https://github.com/jeong-sik/masc-mcp/pull/15691

## Verification
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_oas_bus_instrument.exe test/test_pbt_context_overflow.exe`
- `./_build/default/test/test_oas_bus_instrument.exe` (7 tests)
- `./_build/default/test/test_pbt_context_overflow.exe` (7 tests)

Note: this PR merged before the downstream OAS pin bump. The pin/fingerprint/doc update is split into #15691.