### PR TITLE
fix(oas_compat): add on_tool_calls field to metric sink records

### DIFF
--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -42,6 +42,7 @@ let error_by_reason_metric = Prometheus.metric_llm_provider_errors_by_reason
 let retry_metric = Prometheus.metric_llm_provider_retries
 let input_tokens_metric = Prometheus.metric_llm_provider_input_tokens
 let output_tokens_metric = Prometheus.metric_llm_provider_output_tokens
+let tool_calls_metric = Prometheus.metric_llm_provider_tool_calls
 let circuit_state_metric = Prometheus.metric_llm_provider_circuit_state
 let streaming_first_chunk_metric =
   Prometheus.metric_llm_provider_streaming_first_chunk
@@ -254,6 +255,14 @@ let emit_token_usage ~provider ~model_id ~input_tokens ~output_tokens =
       ~delta:(Float.of_int output_tokens)
       ()
 
+let emit_tool_calls ~provider ~model_id ~count =
+  remember_provider ~model_id ~provider;
+  if count > 0 then
+    Prometheus.inc_counter tool_calls_metric
+      ~labels:[("provider", provider); ("model", model_id)]
+      ~delta:(Float.of_int count)
+      ()
+
 (** Validation outcome for a streaming or latency duration carried in
     milliseconds. Internal — kept out of [.mli] so callers stay
     byte-identical.
@@ -435,6 +444,7 @@ let emit_request_latency ?provider ~model_id ~latency_ms () =
     - [on_retry]        → masc_llm_provider_retries_total
     - [on_circuit_state] → masc_llm_provider_circuit_state
     - [on_token_usage]  → masc_llm_provider_{input,output}_tokens_total
+    - [on_tool_calls]   → masc_llm_provider_tool_calls_total
     - [on_streaming_first_chunk] → masc_llm_provider_streaming_first_chunk_seconds
     - [on_streaming_chunk] → masc_llm_provider_streaming_inter_chunk_seconds *)
 let make_sink () : Llm_provider.Metrics.t =
@@ -454,6 +464,7 @@ let make_sink () : Llm_provider.Metrics.t =
     ~on_retry:emit_retry
     ~on_circuit_state:emit_circuit_state
     ~on_token_usage:emit_token_usage
+    ~on_tool_calls:emit_tool_calls
     ~on_streaming_first_chunk:emit_streaming_first_chunk
     ~on_streaming_chunk:emit_streaming_chunk
     ()

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -252,6 +252,8 @@ module Metrics = struct
       =
     ()
 
+  let default_tool_calls ~provider:_ ~model_id:_ ~count:_ = ()
+
   let default_streaming_first_chunk ~provider:_ ~model_id:_ ~ttfrc_ms:_ = ()
 
   let default_streaming_chunk ~provider:_ ~model_id:_ ~chunk_index:_
@@ -266,6 +268,7 @@ module Metrics = struct
       ?(on_circuit_state = default_circuit_state)
       ?(on_capability_drop = default_capability_drop)
       ?(on_retry = default_retry) ?(on_token_usage = default_token_usage)
+      ?(on_tool_calls = default_tool_calls)
       ?(on_streaming_first_chunk = default_streaming_first_chunk)
       ?(on_streaming_chunk = default_streaming_chunk) ()
       : Llm_provider.Metrics.t =
@@ -281,6 +284,7 @@ module Metrics = struct
       on_capability_drop;
       on_retry;
       on_token_usage;
+      on_tool_calls;
       on_streaming_first_chunk;
       on_streaming_chunk;
     }

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -163,6 +163,7 @@ module Metrics : sig
        input_tokens:int ->
        output_tokens:int ->
        unit) ->
+    ?on_tool_calls:(provider:string -> model_id:string -> count:int -> unit) ->
     ?on_streaming_first_chunk:
       (provider:string -> model_id:string -> ttfrc_ms:float -> unit) ->
     ?on_streaming_chunk:

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -757,6 +757,7 @@ let metric_llm_provider_errors_by_reason = "masc_llm_provider_errors_by_reason_t
 let metric_llm_provider_retries = "masc_llm_provider_retries_total"
 let metric_llm_provider_input_tokens = "masc_llm_provider_input_tokens_total"
 let metric_llm_provider_output_tokens = "masc_llm_provider_output_tokens_total"
+let metric_llm_provider_tool_calls = "masc_llm_provider_tool_calls_total"
 let metric_llm_provider_circuit_state = "masc_llm_provider_circuit_state"
 let metric_fallback_triggered = "masc_fallback_triggered_total"
 
@@ -1528,6 +1529,10 @@ let init () =
   add
     metric_llm_provider_output_tokens
     "Total OAS LLM output tokens, labeled by provider and model"
+    Counter;
+  add
+    metric_llm_provider_tool_calls
+    "Total OAS LLM provider-emitted tool calls, labeled by provider and model"
     Counter;
   add
     metric_llm_provider_circuit_state

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -487,6 +487,7 @@ val metric_llm_provider_errors_by_reason : string
 val metric_llm_provider_retries : string
 val metric_llm_provider_input_tokens : string
 val metric_llm_provider_output_tokens : string
+val metric_llm_provider_tool_calls : string
 val metric_llm_provider_circuit_state : string
 
 (** §7.3.2 Zero Silent Failure measurement: aggregate counter for every

--- a/test/test_llm_metric_bridge.ml
+++ b/test/test_llm_metric_bridge.ml
@@ -45,6 +45,10 @@ let test_metric_names_stable () =
     "masc_llm_provider_output_tokens_total"
     Prom.metric_llm_provider_output_tokens;
   Alcotest.(check string)
+    "tool calls metric"
+    "masc_llm_provider_tool_calls_total"
+    Prom.metric_llm_provider_tool_calls;
+  Alcotest.(check string)
     "circuit state metric"
     "masc_llm_provider_circuit_state"
     Prom.metric_llm_provider_circuit_state;
@@ -93,6 +97,9 @@ let test_sink_records_oas_callbacks () =
   let before_output =
     metric Prom.metric_llm_provider_output_tokens ~labels:provider_model_labels
   in
+  let before_tool_calls =
+    metric Prom.metric_llm_provider_tool_calls ~labels:provider_model_labels
+  in
   let before_circuit_state =
     metric Prom.metric_llm_provider_circuit_state ~labels:circuit_labels
   in
@@ -115,6 +122,7 @@ let test_sink_records_oas_callbacks () =
     ~state:Llm_provider.Metrics.Circuit_open;
   sink.on_token_usage
     ~provider ~model_id ~input_tokens:17 ~output_tokens:23;
+  sink.on_tool_calls ~provider ~model_id ~count:3;
   sink.on_streaming_first_chunk ~provider ~model_id ~ttfrc_ms:25.0;
   sink.on_streaming_chunk ~provider ~model_id ~chunk_index:1 ~inter_chunk_ms:7.5;
   check_metric_delta "cache hit +1"
@@ -141,6 +149,9 @@ let test_sink_records_oas_callbacks () =
   check_metric_delta "output tokens +23"
     Prom.metric_llm_provider_output_tokens
     ~labels:provider_model_labels ~before:before_output ~delta:23.0;
+  check_metric_delta "tool calls +3"
+    Prom.metric_llm_provider_tool_calls
+    ~labels:provider_model_labels ~before:before_tool_calls ~delta:3.0;
   check_metric_delta "circuit state open"
     Prom.metric_llm_provider_circuit_state
     ~labels:circuit_labels ~before:before_circuit_state ~delta:1.0;


### PR DESCRIPTION
## Summary

`oas` pkg 0.193.16 added `on_tool_calls` to its `Llm_provider.Metrics.t` record type. Two masc-mcp consumers construct that record without the new field, breaking `dune build` on main:

```
File "lib/oas_compat/oas_compat.ml", lines 272-285, characters 4-5:
Error: Some record fields are undefined: on_tool_calls
File "lib/llm_metric_bridge.ml", lines 441-462, characters 2-3:
Error: Some record fields are undefined: on_tool_calls
```

This PR mirrors the minimum additions from PR #15669 (which contains the same fix bundled with 49 other changes) as a focused carve-out so main rebuilds immediately.

## Changes

- `lib/oas_compat/oas_compat.{ml,mli}` — optional `on_tool_calls` parameter on `make`, default no-op.
- `lib/llm_metric_bridge.ml` — wire `on_tool_calls` to new `masc_llm_provider_tool_calls_total` Prometheus counter via `emit_tool_calls`.
- `lib/prometheus.{ml,mli}` — register the new counter.
- `test/test_llm_metric_bridge.ml` — cover the new sink callback.

Net: 6 files, +33/-0.

## Evidence

- `dune build --root .` clean.
- `dune exec --root . test/test_llm_metric_bridge.exe` — 12/12 pass.
- `bash ~/me/scripts/pr-rfc-check.sh` — exit 0 (no credential/identity/operator subsystem touched).

## Coordination

PR #15669 will rebase to drop these files after this lands; the broader runtime-defect work in that PR is unaffected. Suggested order: merge this hotfix first → rebase #15669 → resolve any trivial drift.

## Review evidence

- Local build + focused test only. No cross-model review.
- Draft PR; relies on repository's `human-approved-ready` gate for promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
