### PR TITLE
feat(keeper): instrument oas_env allowlist key rejections

### DIFF
--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -672,6 +672,11 @@ let metric_keeper_thinking_persist_failures =
 ;;
 
 let metric_keeper_checkpoint_failures = "masc_keeper_checkpoint_failures_total"
+
+let metric_keeper_oas_env_key_rejections =
+  "masc_keeper_oas_env_key_rejections_total"
+;;
+
 let metric_keeper_memory_write_failures = "masc_keeper_memory_write_failures_total"
 let metric_keeper_memory_consolidations = "masc_keeper_memory_consolidations_total"
 

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -336,6 +336,17 @@ val metric_keeper_cascade_sync_failures : string
 val metric_keeper_local_discovery_failures : string
 val metric_keeper_thinking_persist_failures : string
 val metric_keeper_checkpoint_failures : string
+
+val metric_keeper_oas_env_key_rejections : string
+(** Counter for [Keeper_types_profile.extract_oas_env_from_doc]
+    entries dropped because the suffix did not match the
+    [OAS_(CLAUDE|CODEX|GEMINI)_] / [MASC_KEEPER_OAS_] allowlist.
+    Each rejected key increments by one and produces a warn line
+    so operators can spot configuration mistakes or attempted
+    env-injection bypass.  Non-zero counts at startup mean the
+    keeper TOML contains [keeper.oas_env.<X>] keys that the
+    runtime silently ignored. *)
+
 val metric_keeper_memory_write_failures : string
 val metric_keeper_memory_consolidations : string
 val metric_keeper_write_meta_cycle_failures : string

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -608,6 +608,24 @@ let oas_env_key_is_allowed suffix =
       && String.sub suffix 0 (String.length p) = p)
     allowed_prefixes
 
+(* Observability for the env-key allowlist drop branch.  Previously
+   any [keeper.oas_env.<X>] entry whose suffix did not match
+   [OAS_(CLAUDE|CODEX|GEMINI)_] or [MASC_KEEPER_OAS_] was filtered
+   out with no signal — operators could not tell whether a typo'd
+   key (e.g. [OAS_CLUADE_API_KEY]) had been silently ignored.
+   Closes the silent-drop gap noted in
+   .tmp/memory-compacting-analysis.html (oas_env allowlist drop). *)
+let () =
+  Prometheus.register_counter
+    ~name:Keeper_metrics.metric_keeper_oas_env_key_rejections
+    ~help:
+      "Total keeper.oas_env.<X> entries rejected by the allowlist \
+       in [extract_oas_env_from_doc].  Each rejected key produces \
+       a warn line; non-zero counts at startup mean the TOML \
+       contains keys the runtime silently ignored."
+    ()
+;;
+
 let extract_oas_env_from_doc (doc : Keeper_toml_loader.toml_doc)
     : (string * string) list =
   let prefix_len = String.length oas_env_key_prefix in
@@ -619,7 +637,18 @@ let extract_oas_env_from_doc (doc : Keeper_toml_loader.toml_doc)
         let suffix = String.sub k prefix_len (String.length k - prefix_len) in
         if oas_env_key_is_allowed suffix then
           Option.map (fun sv -> (suffix, sv)) (string_of_toml_value_for_env v)
-        else None
+        else begin
+          Prometheus.inc_counter
+            Keeper_metrics.metric_keeper_oas_env_key_rejections
+            ();
+          Log.Keeper.warn
+            "keeper.oas_env: dropping key=%S — suffix %S not in \
+             allowlist (OAS_CLAUDE_* | OAS_CODEX_* | OAS_GEMINI_* | \
+             MASC_KEEPER_OAS_*); fix the TOML or expand the allowlist"
+            k suffix;
+          ignore v;
+          None
+        end
       else None)
     doc
 


### PR DESCRIPTION
## 목표

`Keeper_types_profile.extract_oas_env_from_doc` 가 allowlist (`OAS_CLAUDE_*` | `OAS_CODEX_*` | `OAS_GEMINI_*` | `MASC_KEEPER_OAS_*`) 외 키를 silent 하게 drop. 보안상 의도된 가드지만 operator 가 \"내 env 가 왜 안 먹혔지?\" 디버깅 시 신호 없음. counter + warn 으로 가시화. 동작 변경 없음 (rejection 그대로).

근거: `.tmp/memory-compacting-analysis.html` (oas_env allowlist drop).

## 변경 파일

- `lib/keeper/keeper_metrics.{ml,mli}` — `metric_keeper_oas_env_key_rejections`
- `lib/keeper/keeper_types_profile.ml` — register + reject branch 에 inc + warn (full key + suffix 포함)

## 로컬 검증

- `Keeper_types_profile.cmo` 타겟 PASS

## 가시화 결과

기존:
```
(silent drop, 환경 변수는 적용 안 되고 operator 는 모름)
```

이후:
```
keeper.oas_env: dropping key=\"keeper.oas_env.OAS_CLUADE_API_KEY\" — suffix \"OAS_CLUADE_API_KEY\" not in allowlist (OAS_CLAUDE_* | OAS_CODEX_* | OAS_GEMINI_* | MASC_KEEPER_OAS_*); fix the TOML or expand the allowlist

masc_keeper_oas_env_key_rejections_total  3
```

→ 즉시 typo 인지 가능.

## 미검증 / 후속

- per-suffix 라벨로 어떤 prefix 가 자주 typo 되는지 추적 (cardinality 주의 — 별도 RFC 후)
- TOML schema validator 통합 — 별도 PR

## Anti-pattern self-check

- telemetry-as-fix 만? ⚠️ 가시화 only. fix 자체는 operator 측 (TOML 정정 OR 의도된 무시 확인)
- string 분류기? ✗ 라벨 없음
- N-of-M? ✗ 단일 함수
- catch-all? ✗ 명시적 allowlist 분기
- magic number? ✗ allowlist 는 SSOT 상수

## RFC

`bash ~/me/scripts/pr-rfc-check.sh` exit=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)