### PR TITLE
fix(ci): reduce stale PR check backlog

### DIFF
--- a/.github/workflows/ci-cancel-closed-pr.yml
+++ b/.github/workflows/ci-cancel-closed-pr.yml
@@ -9,14 +9,18 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: closed-pr-ci-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   cancel-pr-ci:
-    name: Cancel closed PR CI
+    name: Cancel closed PR checks
     runs-on: ubuntu-latest
     timeout-minutes: 2
 
     steps:
-      - name: Cancel in-flight pull_request CI for the closed PR head
+      - name: Cancel in-flight pull_request checks for the closed PR head
         env:
           GH_TOKEN: ${{ github.token }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -27,7 +31,6 @@ jobs:
           for status in queued in_progress pending; do
             gh run list \
               --repo "$GITHUB_REPOSITORY" \
-              --workflow ci.yml \
               --event pull_request \
               --branch "$PR_HEAD_REF" \
               --status "$status" \

--- a/.github/workflows/fun-protect-finalizer-check.yml
+++ b/.github/workflows/fun-protect-finalizer-check.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: fun-protect-finalizer-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fun-protect-finalizer:
     name: Fun.protect finalizer guard

--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -19,6 +19,16 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Supersede older guard bundles for the same PR. Keep main pushes
+  # uncancelled so every merge still gets its own regression signal.
+  group: >-
+    fundamental-check-${{
+      github.event_name == 'push' && github.ref_name == 'main' && github.sha
+      || github.event.pull_request.number || github.ref
+    }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   no-roadmap-stale-hardcoding:
     name: Hardcoded model prefix

--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -12,6 +12,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: ocamlformat-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ocamlformat-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-axis-check.yml
+++ b/.github/workflows/pr-axis-check.yml
@@ -10,6 +10,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: pr-axis-check-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/rfc-enforcer.yml
+++ b/.github/workflows/rfc-enforcer.yml
@@ -7,6 +7,10 @@ on:
       - 'docs/design/**'
   workflow_dispatch:
 
+concurrency:
+  group: rfc-enforcer-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   enforce:
     runs-on: ubuntu-latest

--- a/.github/workflows/rfc-number-collision-check.yml
+++ b/.github/workflows/rfc-number-collision-check.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: rfc-number-collision-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check-numbering:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- add per-PR concurrency groups to small PR guard workflows that previously stacked superseded runs
- keep `Fundamental Check` main-push runs SHA-scoped so merge verification is not collapsed
- widen closed-PR cleanup from only `ci.yml` to all matching `pull_request` runs for the closed PR head SHA

## Why

`#15672` shows PR checks stuck in queued/pending states across CI, Fundamental Check, PR Axis, format, and related guard workflows. Some were superseded by newer PR events or belonged to PR heads that were already closed, but the repo only canceled a narrow subset.

Fixes #15672.

## Validation

- `bash scripts/lint/yaml-syntax.sh`
- `git diff --check`
