### PR TITLE
fix(oas_compat): drop redundant Metrics.noop with clause (warning 23)

### DIFF
--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -273,7 +273,6 @@ module Metrics = struct
       ?(on_streaming_chunk = default_streaming_chunk) ()
       : Llm_provider.Metrics.t =
     {
-      Llm_provider.Metrics.noop with
       on_cache_hit;
       on_cache_miss;
       on_request_start;


### PR DESCRIPTION
## Summary

main is failing `dune build @check` after #15667 with:

```
File "lib/oas_compat/oas_compat.ml", lines 275-290, characters 4-5:
Error (warning 23 [useless-record-with]): all the fields are explicitly listed in this record:
  the with clause is useless.
```

The `make` function builds a `Llm_provider.Metrics.t` value as `{ Llm_provider.Metrics.noop with <13 fields> }`. Since every field in the record is named, the `noop with` base is fully overwritten and OCaml flags the `with` clause as useless. With `-warn-error +23` (the project default), this is a hard build error.

## Change

Drop the `Llm_provider.Metrics.noop with` line. Net `-1 line, +0`. Behavior unchanged because every field was already assigned downstream.

## Evidence

- `dune build --root . @check` clean.
- `bash ~/me/scripts/pr-rfc-check.sh` exit 0.

## Why a separate PR

This emerged as a regression from #15667's Pin merge — every PR branching from current main now inherits the broken `oas_compat.ml`. Carving it out as a 1-line hotfix unblocks the FAILURE cascade across active PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
