### PR TITLE
fix(board): suppress dedup post fanout

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -577,7 +577,15 @@ let validate_sub_board_post_policy_unlocked store ~author_id ~hearth =
 
 (** {1 Post Operations} *)
 
-let create_post
+type create_post_outcome =
+  | Fresh_post of post
+  | Dedup_hit of post
+
+let post_of_create_post_outcome = function
+  | Fresh_post post | Dedup_hit post -> post
+;;
+
+let create_post_with_outcome
       store
       ~author
       ~content
@@ -587,10 +595,10 @@ let create_post
       ?meta_json
       ?(visibility = Internal)
       ?(ttl_hours = Limits.default_ttl_hours)
-      ?hearth
-      ?thread_id
-      ()
-  : (post, board_error) Result.t
+  ?hearth
+  ?thread_id
+  ()
+  : (create_post_outcome, board_error) Result.t
   =
   maybe_sweep store;
   (* Validate author *)
@@ -736,9 +744,42 @@ let create_post
          with
          | Ok _ -> ()
          | Error msg -> Log.BoardLog.warn "economy earn (post): %s" msg);
-        Ok post
-      | Ok (`Dedup_hit existing) -> Ok existing
+        Ok (Fresh_post post)
+      | Ok (`Dedup_hit existing) -> Ok (Dedup_hit existing)
       | Error _ as e -> e)
+;;
+
+let create_post
+      store
+      ~author
+      ~content
+      ?title
+      ?body
+      ~post_kind
+      ?meta_json
+      ?visibility
+      ?ttl_hours
+      ?hearth
+      ?thread_id
+      ()
+  =
+  match
+    create_post_with_outcome
+      store
+      ~author
+      ~content
+      ?title
+      ?body
+      ~post_kind
+      ?meta_json
+      ?visibility
+      ?ttl_hours
+      ?hearth
+      ?thread_id
+      ()
+  with
+  | Ok outcome -> Ok (post_of_create_post_outcome outcome)
+  | Error _ as err -> err
 ;;
 
 let get_post store ~post_id : (post, board_error) Result.t =

--- a/lib/board_core.mli
+++ b/lib/board_core.mli
@@ -189,6 +189,36 @@ val reaction_key
 
 (** {1 Post operations} *)
 
+(** Result of a create-post attempt before the legacy API folds it
+    back to just the persisted/found post.  Dispatch layers use this
+    to avoid re-emitting post-created fanout for receive-side dedup
+    hits. *)
+type create_post_outcome =
+  | Fresh_post of post
+  | Dedup_hit of post
+
+(** Extract the post carried by {!create_post_outcome}. *)
+val post_of_create_post_outcome : create_post_outcome -> post
+
+(** Creates a post and preserves whether the operation was fresh or a
+    receive-side dedup hit.  Same validation and persistence semantics as
+    {!create_post}; fresh posts append JSONL + earn credits, dedup hits
+    return the existing post without those side effects. *)
+val create_post_with_outcome
+  :  store
+  -> author:string
+  -> content:string
+  -> ?title:string
+  -> ?body:string
+  -> post_kind:post_kind
+  -> ?meta_json:Yojson.Safe.t
+  -> ?visibility:visibility
+  -> ?ttl_hours:int
+  -> ?hearth:string
+  -> ?thread_id:string
+  -> unit
+  -> (create_post_outcome, board_error) Result.t
+
 (** Creates a new post.  Validates [author] via
     {!Agent_id.of_string}, normalises [hearth] (lowercased +
     trimmed), folds the canonical [title / body / kind /

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -355,10 +355,10 @@ let create_post ~author ~content ?title ?body ~post_kind ?meta_json
   match backend () with
   | Jsonl store ->
       (match
-         Board.create_post store ~author ~content ?title ?body ~post_kind ?meta_json
-           ~visibility ~ttl_hours ?hearth ?thread_id ()
+         Board.create_post_with_outcome store ~author ~content ?title ?body
+           ~post_kind ?meta_json ~visibility ~ttl_hours ?hearth ?thread_id ()
        with
-      | Ok post as ok ->
+      | Ok (Board.Fresh_post post) ->
           let pid = Board.Post_id.to_string post.id in
           let auth = Board.Agent_id.to_string post.author in
           emit_keeper_board_signal
@@ -375,7 +375,8 @@ let create_post ~author ~content ?title ?body ~post_kind ?meta_json
                { post_id = pid; author = auth; title = post.title;
                  content = post.content; post_kind = post.post_kind;
                  hearth = post.hearth });
-          ok
+          Ok post
+      | Ok (Board.Dedup_hit post) -> Ok post
       | Error _ as err -> err)
 
 let get_post ~post_id =

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -106,6 +106,35 @@ let test_keeper_signal_hook_cancellation_propagates () =
    with Eio.Cancel.Cancelled _ -> raised := true);
   Alcotest.(check bool) "cancellation propagated" true !raised
 
+let test_dedup_hit_does_not_emit_post_created_fanout () =
+  let keeper_signals = ref 0 in
+  let sse_post_created = ref 0 in
+  Board_dispatch.set_keeper_board_signal_hook (fun _ -> incr keeper_signals);
+  Board_dispatch.set_board_sse_hook (function
+    | Board_dispatch.Post_created _ -> incr sse_post_created
+    | _ -> ());
+  let create () =
+    Board_dispatch.create_post ~author:"dedup-agent"
+      ~content:"same post body from one keeper turn"
+      ~post_kind:Board.Automation_post ~hearth:"keepers" ~thread_id:"turn-15650" ()
+  in
+  let first =
+    match create () with
+    | Ok post -> post
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let second =
+    match create () with
+    | Ok post -> post
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  Alcotest.(check string)
+    "dedup returns existing post"
+    (Board.Post_id.to_string first.id)
+    (Board.Post_id.to_string second.id);
+  Alcotest.(check int) "keeper signal emitted once" 1 !keeper_signals;
+  Alcotest.(check int) "SSE post_created emitted once" 1 !sse_post_created
+
 let test_structured_post_roundtrip () =
   let meta = `Assoc [("source", `String "keeper_autonomy")] in
   match Board_dispatch.create_post ~author:"sangsu"
@@ -1108,6 +1137,8 @@ let () =
         (with_eio test_keeper_signal_hook_failure_does_not_abort_create_post);
       Alcotest.test_case "keeper hook cancellation propagates" `Quick
         (with_eio test_keeper_signal_hook_cancellation_propagates);
+      Alcotest.test_case "dedup hit does not fan out post_created" `Quick
+        (with_eio test_dedup_hit_does_not_emit_post_created_fanout);
       Alcotest.test_case "structured roundtrip" `Quick (with_eio test_structured_post_roundtrip);
       Alcotest.test_case "SSE post_created includes post_kind" `Quick
         (with_eio test_board_sse_post_created_includes_post_kind);


### PR DESCRIPTION
## Summary

- expose a `Board.create_post_with_outcome` API so callers can tell fresh posts from receive-side dedup hits while keeping the legacy `create_post` return shape intact
- update `Board_dispatch.create_post` to emit keeper board signals and SSE `Post_created` only for fresh posts
- add a regression test proving a duplicate keeper-turn post returns the existing post without duplicate fanout

## Root cause

PR #15568 stopped duplicate JSONL appends and duplicate credit earns, but `Board_dispatch.create_post` still treated every successful create call as a new post. A dedup hit therefore returned `Ok post` and re-emitted keeper wake/SSE fanout even though storage had correctly reused the existing post.

Refs #15650.

## Validation

- `git diff --check`
- `opam exec -- ocamlformat --check lib/board_core.ml lib/board_core.mli lib/board_dispatch.ml test/test_board_dispatch.ml`

Focused local build is currently blocked before compiling this target by existing OAS pin drift on main:

```text
agent_sdk pin source is git+https://github.com/jeong-sik/oas.git#d88e2fe4f62519229b0f6069a0c1f7896316233a, expected git+https://github.com/jeong-sik/oas.git#94628a436bc17b8d839214bdb205bcee2d4c6d2a
[dune-local] agent_sdk pin drift detected -- aborting build
```

`check-oas-pin.sh` also currently fails with:

```text
failed to resolve upstream fix/ollama-parallel-tool-calls-20260517 SHA
```