### PR TITLE
fix(keeper): allow own-repo paths from worktree cwd

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -67,6 +67,32 @@ let resolve_path ?base_dir path =
 (** Check whether [path] is exactly [dir] or a descendant of [dir]. *)
 let is_within_dir ~dir path = path = dir || String.starts_with ~prefix:(dir ^ "/") path
 
+let substring_index s needle =
+  let s_len = String.length s in
+  let n_len = String.length needle in
+  let rec loop i =
+    if n_len = 0 then Some 0
+    else if i + n_len > s_len then None
+    else if String.sub s i n_len = needle then Some i
+    else loop (i + 1)
+  in
+  loop 0
+;;
+
+let git_metadata_exists dir =
+  Sys.file_exists (Filename.concat dir ".git")
+;;
+
+let worktree_repo_root_of_workdir workdir =
+  let marker = "/.worktrees/" in
+  let resolved_workdir = resolve_path workdir in
+  match substring_index resolved_workdir marker with
+  | None -> None
+  | Some idx ->
+    let repo_root = String.sub resolved_workdir 0 idx in
+    if repo_root <> "" && git_metadata_exists repo_root then Some repo_root else None
+;;
+
 (** Path allowlist. When workdir is set, restrict to workdir + /tmp only.
     When unset, allow /tmp, cwd subtree, and the documented sandbox workspace
     root from [Host_config.sandbox_workspace_root].
@@ -84,8 +110,14 @@ let validate_path ?workdir path =
   match workdir with
   | Some wd ->
     let resolved_wd = resolve_path wd in
+    let within_worktree_repo_root =
+      match worktree_repo_root_of_workdir wd with
+      | None -> false
+      | Some repo_root -> is_within_dir ~dir:(resolve_path repo_root) resolved
+    in
     is_within_dir ~dir:(resolve_path "/tmp") resolved
     || is_within_dir ~dir:resolved_wd resolved
+    || within_worktree_repo_root
   | None ->
     let cfg = Host_config.host () in
     is_within_dir ~dir:(resolve_path "/tmp") resolved

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -1059,6 +1059,52 @@ let () =
           | Ok () -> ()
           | Error msg ->
             Alcotest.fail ("plain path unexpectedly rejected: " ^ msg));
+      Alcotest.test_case
+        "absolute own-repo path is allowed from repo worktree cwd"
+        `Quick
+        (fun () ->
+          let repo_root =
+            Filename.concat
+              (Sys.getcwd ())
+              "_worker_dev_tools_repo_worktree_allow"
+          in
+          let target = Filename.concat repo_root "lib/foo.ml" in
+          let workdir = Filename.concat repo_root ".worktrees/task" in
+          let rec mkdir_p path =
+            if path = "" || path = "." || path = "/" then ()
+            else if Sys.file_exists path then ()
+            else (
+              mkdir_p (Filename.dirname path);
+              Unix.mkdir path 0o755)
+          in
+          let rec cleanup path =
+            if Sys.file_exists path then
+              match Unix.lstat path with
+              | { Unix.st_kind = Unix.S_DIR; _ } ->
+                Array.iter
+                  (fun name -> cleanup (Filename.concat path name))
+                  (Sys.readdir path);
+                Unix.rmdir path
+              | _ -> Sys.remove path
+          in
+          Fun.protect
+            ~finally:(fun () -> try cleanup repo_root with _ -> ())
+            (fun () ->
+              mkdir_p (Filename.dirname target);
+              mkdir_p workdir;
+              Out_channel.with_open_text (Filename.concat repo_root ".git")
+                (fun oc -> output_string oc "gitdir: .git/worktrees/task\n");
+              Out_channel.with_open_text target
+                (fun oc -> output_string oc "let x = 1\n");
+              match
+                Worker_dev_tools.validate_command_paths
+                  ~workdir
+                  (Printf.sprintf "cat %s" target)
+              with
+              | Ok () -> ()
+              | Error msg ->
+                Alcotest.fail
+                  ("own repo path from worktree cwd rejected: " ^ msg)));
       Alcotest.test_case "git -C missing worktree is cwd_not_directory"
         `Quick (fun () ->
           let workdir = Filename.temp_file "wdt_git_c_" "" in


### PR DESCRIPTION
## Summary

- when `worker_dev_tools` validates a command with `workdir` inside `REPO/.worktrees/<task>`, also allow paths under that Git repo root
- require `.git` metadata at the inferred repo root before widening the allowlist
- add a regression test for a keeper/worktree cwd reading an absolute own-repo `lib/...` path

## Root Cause

The keeper path validator treated `workdir` as the only non-`/tmp` allowed subtree. A keeper running from `repos/masc-mcp/.worktrees/<task>` could therefore be denied when it read a normal own-repo path such as `repos/masc-mcp/lib/...`, even though both paths belong to the same sandboxed repo.

Refs #15545.

## Validation

- `git diff --check`
- `opam exec -- ocamlformat --check lib/worker_dev_tools.ml test/test_worker_dev_tools.ml`

Attempted focused build:

- `scripts/dune-local.sh build test/test_worker_dev_tools.exe` stops at the known OAS pin drift currently tracked by #15691/#15696.
- `MASC_SKIP_PIN_CHECK=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_worker_dev_tools.exe` then reaches the known `lib/oas_compat/oas_compat.ml` warning-23 failure that #15691 fixes.

So this PR is draft and should be validated again after #15691 lands.