### PR TITLE
refactor(shadow-gate): drop legacy shadow_parse_outcome string aliases (iter3, stacked on #15699)

### DIFF
--- a/lib/gate_diff_types.ml
+++ b/lib/gate_diff_types.ml
@@ -7,8 +7,8 @@
     without pulling in the full command-validation tool surface.
 
     Classification functions that depend on worker_dev_tools internals
-    (validate_command, shadow_parse_outcome) remain in worker_dev_tools.ml
-    and use these types via [Gate_diff_types.t].
+    (validate_command, shadow_parse_outcome_kind) remain in
+    worker_dev_tools.ml and use these types via [Gate_diff_types.t].
 
     @since godsplit-safety — variant unification & godfile decomposition *)
 

--- a/lib/gate_diff_types.mli
+++ b/lib/gate_diff_types.mli
@@ -13,8 +13,8 @@
     (counters, telemetry) can reference the types without pulling in
     the full command-validation tool surface.  Classification functions
     that depend on [worker_dev_tools] internals (validate_command,
-    shadow_parse_outcome) stay in [worker_dev_tools.ml] and consume
-    these types via [Gate_diff_types.t].
+    shadow_parse_outcome_kind) stay in [worker_dev_tools.ml] and
+    consume these types via [Gate_diff_types.t].
 
     Both {!destructive_class} and {!gate_diff} are intentionally closed
     variants — adding a new class / outcome must touch every match
@@ -81,9 +81,9 @@ type parse_outcome_kind =
   | Too_complex of Masc_exec.Parsed.reason_too_complex
 
 val parse_outcome_kind_to_tag : parse_outcome_kind -> string
-(** Stable snake_case rendering. Matches the legacy
-    [shadow_parse_outcome] string surface byte-for-byte so log
-    aggregators / runbook greps continue to see the same tag set:
+(** Stable snake_case rendering for log / metric emission.
+    Operator dashboards and runbook greps depend on this exact
+    tag set:
     [Parsed_simple -> "parsed_simple"],
     [Parse_error -> "parse_error"],
     [Parse_aborted r -> "parse_aborted:<r>"],

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -1658,20 +1658,6 @@ let shadow_parse_outcome_kind (cmd : string) : parse_outcome_kind =
   | Masc_exec.Parsed.Too_complex r -> Too_complex r
 ;;
 
-(* Stable string rendering of the parse outcome — retained for log
-   emission and telemetry tags that already exist in operator
-   dashboards. Computes via the typed kind so the wording cannot
-   drift between this function and [Legendary_counters]. *)
-let shadow_parse_outcome (cmd : string) : string =
-  parse_outcome_kind_to_tag (shadow_parse_outcome_kind cmd)
-;;
-
-(* Legacy verdict ↔ shadow verdict cross-check.  Returns a tuple of
-   legacy allow/deny + shadow kind, so telemetry can spot "legacy
-   allows but shadow cannot parse" drift without needing two
-   separate call sites.  Intentionally side-effect free. *)
-let cross_check_command ~legacy cmd = legacy, shadow_parse_outcome_kind cmd
-
 (* Classification functions that depend on worker_dev_tools internals
    (validate_command, shadow_parse_outcome_kind). Types come from
    Gate_diff_types via [include Gate_diff_types] at the top. *)

--- a/lib/worker_dev_tools.mli
+++ b/lib/worker_dev_tools.mli
@@ -188,33 +188,17 @@ val make_readonly_tools
 (** {1 Shadow AST gate observability} *)
 
 (** Parse [cmd] with {!Masc_exec_bash_parser.Bash.parse_string} and
-    return the typed outcome — primary classification surface.
-    Downstream histogram dispatch consumes the variant exhaustively
-    so adding a new {!Masc_exec.Parsed.reason_too_complex} arm is a
-    compile-time forcing function, not a silent "other"-bucket
-    landing.  Never raises; the parser catches every internal
-    exception. *)
+    return the typed outcome — single classification surface for
+    shadow-gate observability.  Downstream histogram dispatch
+    consumes the variant exhaustively so adding a new
+    {!Masc_exec.Parsed.reason_too_complex} arm is a compile-time
+    forcing function, not a silent "other"-bucket landing.  Never
+    raises; the parser catches every internal exception.
+
+    Render to the string tag wording dashboards / runbook greps
+    track via {!Gate_diff_types.parse_outcome_kind_to_tag} at the
+    log / metric emission boundary. *)
 val shadow_parse_outcome_kind : string -> parse_outcome_kind
-
-(** Stable string rendering of {!shadow_parse_outcome_kind} — the
-    tag wording dashboards / runbook greps already track:
-
-    - ["parsed_simple"] — grammar accepts the command
-    - ["parse_error"] — Menhir/Lex error
-    - ["parse_aborted:<reason>"] — timeout/depth/token-limit
-    - ["too_complex:<reason>"] — recognised-but-unsupported construct
-
-    Computed via {!shadow_parse_outcome_kind} so the wording cannot
-    drift between this function and {!Legendary_counters}. *)
-val shadow_parse_outcome : string -> string
-
-(** Pair the supplied [legacy] verdict with the typed
-    {!shadow_parse_outcome_kind} for [cmd].  Polymorphic in [legacy] —
-    callers pass either the typed {!legacy_verdict} or the boolean
-    form used by older test sites.  Pure (no side effects); dashboards
-    consume the tuple to spot legacy/shadow drift without two parse
-    passes. *)
-val cross_check_command : legacy:'a -> string -> 'a * parse_outcome_kind
 
 (** Run both the legacy substring gate and the shadow AST gate on
     [cmd], returning their reconciliation outcome alongside both

--- a/test/test_shadow_parse.ml
+++ b/test/test_shadow_parse.ml
@@ -1,74 +1,67 @@
 (* Tick 12 (P5 reduced): shadow AST parse observation.
 
-   These tests pin the tag taxonomy that telemetry will histogram
-   during the prod-observation window before the regex allowlist is
-   actually replaced.  They do NOT assert any behavioural gate —
-   the legacy regex is still the authoritative path. *)
+   These tests pin the parse-outcome taxonomy that telemetry will
+   histogram during the prod-observation window before the regex
+   allowlist is actually replaced.  They do NOT assert any
+   behavioural gate — the legacy regex is still the authoritative
+   path. *)
 
 open Alcotest
 
-let tag cmd = Masc_mcp.Worker_dev_tools.shadow_parse_outcome cmd
+module W = Masc_mcp.Worker_dev_tools
+module G = Masc_mcp.Gate_diff_types
+
+let kind cmd = W.shadow_parse_outcome_kind cmd
 
 let test_simple_ls_parses () =
-  check string "plain ls is parsed_simple"
-    "parsed_simple" (tag "ls")
+  match kind "ls" with
+  | G.Parsed_simple -> ()
+  | other ->
+    fail ("expected Parsed_simple, got " ^ G.parse_outcome_kind_to_tag other)
 
 let test_simple_bin_with_arg_parses () =
-  check string "ls -l is parsed_simple"
-    "parsed_simple" (tag "ls -l")
+  match kind "ls -l" with
+  | G.Parsed_simple -> ()
+  | other ->
+    fail ("expected Parsed_simple, got " ^ G.parse_outcome_kind_to_tag other)
 
 let test_empty_command_is_parse_error () =
   (* An empty string does not match the grammar start symbol, so the
      parser surfaces it as Parse_error.  Regex allowlist would reject
      it earlier, but telemetry still captures the outcome. *)
-  match tag "" with
-  | "parse_error" -> ()
-  | other -> fail ("expected parse_error, got " ^ other)
+  match kind "" with
+  | G.Parse_error -> ()
+  | other ->
+    fail ("expected Parse_error, got " ^ G.parse_outcome_kind_to_tag other)
 
-let is_non_simple_tag t =
-  t = "parse_error"
-  || String.starts_with ~prefix:"too_complex" t
-  || String.starts_with ~prefix:"parse_aborted" t
+let is_non_simple = function
+  | G.Parsed_simple -> false
+  | G.Parse_error | G.Parse_aborted _ | G.Too_complex _ -> true
 
 let test_shell_chain_marks_unsupported () =
-  (* `a && b` is definitely not simple-command.  The parser either
-     surfaces Parse_error or Too_complex:* — both are valid signals
+  (* [a && b] is definitely not simple-command.  The parser either
+     surfaces Parse_error or Too_complex _ — both are valid signals
      that the string falls outside the current AST gate's coverage.
-     We accept either tag so the test does not fight parser-coverage
+     We accept either kind so the test does not fight parser-coverage
      upgrades (A1-PR-N) that may reclassify constructs. *)
-  let t = tag "ls && rm -rf /" in
-  if not (is_non_simple_tag t) then fail ("unexpected tag: " ^ t)
+  let k = kind "ls && rm -rf /" in
+  if not (is_non_simple k) then
+    fail ("unexpected kind: " ^ G.parse_outcome_kind_to_tag k)
 
 let test_pipe_parses () =
-  check string "pipe is parsed_simple" "parsed_simple" (tag "ls | wc -l")
-
-let test_cross_check_pairs_legacy_and_shadow () =
-  let legacy_ok = Ok () in
-  let legacy, shadow =
-    Masc_mcp.Worker_dev_tools.cross_check_command ~legacy:legacy_ok "ls"
-  in
-  (match legacy with Ok () -> () | Error _ -> fail "legacy preserved");
-  (* cross_check_command now returns the typed [parse_outcome_kind];
-     "ls" parses cleanly so the kind is [Parsed_simple]. *)
-  match shadow with
-  | Masc_mcp.Gate_diff_types.Parsed_simple -> ()
+  match kind "ls | wc -l" with
+  | G.Parsed_simple -> ()
   | other ->
-    fail
-      ("expected Parsed_simple, got "
-       ^ Masc_mcp.Gate_diff_types.parse_outcome_kind_to_tag other)
+    fail ("expected Parsed_simple, got " ^ G.parse_outcome_kind_to_tag other)
 
 let () =
   run "shadow_parse" [
     ("tagging", [
       test_case "simple ls" `Quick test_simple_ls_parses;
       test_case "simple bin with arg" `Quick test_simple_bin_with_arg_parses;
-      test_case "empty command tag" `Quick test_empty_command_is_parse_error;
+      test_case "empty command kind" `Quick test_empty_command_is_parse_error;
       test_case "shell chain unsupported" `Quick
         test_shell_chain_marks_unsupported;
       test_case "pipe parses" `Quick test_pipe_parses;
-    ]);
-    ("cross_check", [
-      test_case "cross_check preserves legacy result" `Quick
-        test_cross_check_pairs_legacy_and_shadow;
     ]);
   ]


### PR DESCRIPTION
## Summary

iter3 stacked on top of #15699 (`feature/keeper-bash-shell-ir`).  Deletes
two dead-by-design surfaces preserved as thin string aliases in iter2:

- `Worker_dev_tools.shadow_parse_outcome : string -> string` — last
  caller was `test_shadow_parse.ml` itself.
- `Worker_dev_tools.cross_check_command : legacy:'a -> string -> 'a *
  parse_outcome_kind` — last caller was the same test.

After iter2's typed migration these functions had zero production
consumers.  Per user absolute principle (`feedback_hardcoding_and_legacy_zero_tolerance`):
no shims, no transitional dual-write — legacy purged in the same PR
as the typed surface it shadowed.

## Changes

- `lib/worker_dev_tools.{ml,mli}` — remove `shadow_parse_outcome` and
  `cross_check_command`; `shadow_parse_outcome_kind` is the single
  classification surface.  Render to the string tag wording at log /
  metric emission boundary via
  `Gate_diff_types.parse_outcome_kind_to_tag`.
- `test/test_shadow_parse.ml` — migrate tag-string assertions to typed
  `parse_outcome_kind` pattern matches.  Pattern matches against
  `Parsed_simple` / `Parse_error` / etc. (full closed sum, exhaustive
  on `is_non_simple`).  Removed the `cross_check_command` test
  (function no longer exists).
- `lib/gate_diff_types.{ml,mli}` — refresh stale doc references that
  named the deleted function.

## Test plan

- [x] `dune build --root . @check` clean.
- [x] `test_shadow_parse.exe` — 5/5 PASS (was 6/6 with cross-check;
      cross-check removed).
- [x] `test_legendary_counters.exe` — 18/18 PASS (regression).
- [x] `test_gate_diff.exe` — 8/8 PASS (regression).
- [x] `ocamlformat --check` clean (5 files).

## Stack context

`/loop masc-mcp docker, bash 등 도구 개선 shell IR 등으로 반복해서
stacked pr 해 개선 진행` iter3.  Parent #15699 introduces
`parse_outcome_kind`; this iter completes the legacy purge by removing
the thin string aliases that survived iter2 review.  Merge order:
#15699 first, then this PR.  Worktree branched from
`feature/keeper-bash-shell-ir` HEAD.

Cited RFCs: RFC-0054 (Shell IR), RFC-0089 (string classifier → typed
variant — root-fix completion).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

RFC-WAIVED: stacked diff inherits parent #15699 (RFC-0054 + RFC-0089); this iter adds no new keeper_shell_bash changes — only deletes dead `Worker_dev_tools` string aliases plus test migration.
