### PR TITLE
fix: add missing tier-group.ollama_cloud_stable (task-259)

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -728,6 +728,10 @@ keeper-assignable = false
 tiers = ["tier_medium", "primary", "__safe_lane"]
 strategy = "priority_tier"
 fallback = true
+keeper-assignable = false
+keeper-assignable = false
+keeper-assignable = false
+keeper-assignable = false
 
 [tier-group.governance]
 tiers = ["governance", "__safe_lane"]

--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -724,6 +724,11 @@ strategy = "priority_tier"
 fallback = true
 keeper-assignable = false
 
+[tier-group.ollama_cloud_stable]
+tiers = ["tier_medium", "primary", "__safe_lane"]
+strategy = "priority_tier"
+fallback = true
+
 [tier-group.governance]
 tiers = ["governance", "__safe_lane"]
 strategy = "priority_tier"

--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -729,9 +729,6 @@ tiers = ["tier_medium", "primary", "__safe_lane"]
 strategy = "priority_tier"
 fallback = true
 keeper-assignable = false
-keeper-assignable = false
-keeper-assignable = false
-keeper-assignable = false
 
 [tier-group.governance]
 tiers = ["governance", "__safe_lane"]


### PR DESCRIPTION
## Fix: Add missing tier-group.ollama_cloud_stable

`cascade_exhausted` on `tier-group.ollama_cloud_stable` because the tier-group was never defined in `cascade.toml`.

### Change
Added `[tier-group.ollama_cloud_stable]` with fallback chain `tier_medium → primary → __safe_lane`, matching the pattern used for `glm-coding-with-spark` and `strict_tool_candidates` in task-244.

Closes task-259.