### PR TITLE
refactor(gate): unify destructive-pattern catalogues into typed SSOT (RFC-0089)

### DIFF
--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -72,30 +72,17 @@ let tool_policy_of_config (config : gate_config) =
 (* Destructive pattern detection                                     *)
 (* ================================================================ *)
 
-(** Known destructive shell patterns.
-    Each entry is (pattern, description) — pattern is matched against
-    the command string after basic normalization. *)
-let destructive_patterns : (string * string) list = [
-  ("rm -rf", "recursive forced deletion");
-  ("rm -r", "recursive deletion");
-  ("rmdir", "directory removal");
-  ("drop table", "SQL table drop");
-  ("drop database", "SQL database drop");
-  ("truncate table", "SQL table truncate");
-  ("delete from", "SQL bulk delete");
-  ("git push --force", "force push");
-  ("git push -f", "force push");
-  ("git reset --hard", "hard reset");
-  ("git clean -f", "forced clean");
-  ("chmod 777", "world-writable permissions");
-  ("mkfs", "filesystem format");
-  ("> /dev/", "device write");
-  ("dd if=", "raw disk operation");
-  ("kill -9", "forced process kill");
-  ("pkill", "pattern-based process kill");
-  ("shutdown", "system shutdown");
-  ("reboot", "system reboot");
-]
+(** Known destructive shell patterns — derived from the SSOT in
+    [Gate_diff_types.destructive_patterns].  Drops the typed class
+    field because [detect_destructive] only needs (substring, desc)
+    for its return shape; callers that need the class go through
+    [Gate_diff_types.classify_destructive].  Sharing the source list
+    means a new entry must update one place, not two. *)
+let destructive_patterns : (string * string) list =
+  List.map
+    (fun { Gate_diff_types.pattern; description; class_ = _ } ->
+       pattern, description)
+    Gate_diff_types.destructive_patterns
 
 (** Normalize a command string for pattern matching.
     Strips inline single/double quotes and collapses whitespace.

--- a/lib/gate_diff_types.ml
+++ b/lib/gate_diff_types.ml
@@ -36,35 +36,46 @@ let destructive_class_to_string = function
   | Process_signal -> "process_signal"
   | System_control -> "system_control"
 
-(* Substring → class mapping.  Each entry mirrors one row in
-   [Eval_gate.destructive_patterns].  Order matters: longer
-   substrings come first so "rm -rf" matches before "rm -r". *)
-let destructive_class_substrings : (string * destructive_class) list = [
-  "rm -rf",            Recursive_delete;
-  "rm -r",             Recursive_delete;
-  "rmdir",             Recursive_delete;
-  "drop table",        Sql_destructive;
-  "drop database",     Sql_destructive;
-  "truncate table",    Sql_destructive;
-  "delete from",       Sql_destructive;
-  "git push --force",  Forced_git_mutation;
-  "git push -f",       Forced_git_mutation;
-  "git reset --hard",  Forced_git_mutation;
-  "git clean -f",      Forced_git_mutation;
-  "chmod 777",         Privilege_escalation;
-  "mkfs",              Filesystem_format;
-  "> /dev/",           Device_write;
-  "dd if=",            Device_write;
-  "kill -9",           Process_signal;
-  "pkill",             Process_signal;
-  "shutdown",          System_control;
-  "reboot",            System_control;
+type destructive_pattern = {
+  class_ : destructive_class;
+  pattern : string;
+  description : string;
+}
+
+(* SSOT for destructive shell patterns. [Eval_gate.destructive_patterns]
+   and [classify_destructive] both derive from this list — drift
+   between the legacy gate and the shadow classifier is impossible by
+   construction.
+
+   Order matters: longer substrings come first so "rm -rf" matches
+   before "rm -r" (both classify as Recursive_delete but the returned
+   substring differs). *)
+let destructive_patterns : destructive_pattern list = [
+  { class_ = Recursive_delete;     pattern = "rm -rf";           description = "recursive forced deletion" };
+  { class_ = Recursive_delete;     pattern = "rm -r";            description = "recursive deletion" };
+  { class_ = Recursive_delete;     pattern = "rmdir";            description = "directory removal" };
+  { class_ = Sql_destructive;      pattern = "drop table";       description = "SQL table drop" };
+  { class_ = Sql_destructive;      pattern = "drop database";    description = "SQL database drop" };
+  { class_ = Sql_destructive;      pattern = "truncate table";   description = "SQL table truncate" };
+  { class_ = Sql_destructive;      pattern = "delete from";      description = "SQL bulk delete" };
+  { class_ = Forced_git_mutation;  pattern = "git push --force"; description = "force push" };
+  { class_ = Forced_git_mutation;  pattern = "git push -f";      description = "force push" };
+  { class_ = Forced_git_mutation;  pattern = "git reset --hard"; description = "hard reset" };
+  { class_ = Forced_git_mutation;  pattern = "git clean -f";     description = "forced clean" };
+  { class_ = Privilege_escalation; pattern = "chmod 777";        description = "world-writable permissions" };
+  { class_ = Filesystem_format;    pattern = "mkfs";             description = "filesystem format" };
+  { class_ = Device_write;         pattern = "> /dev/";          description = "device write" };
+  { class_ = Device_write;         pattern = "dd if=";           description = "raw disk operation" };
+  { class_ = Process_signal;       pattern = "kill -9";          description = "forced process kill" };
+  { class_ = Process_signal;       pattern = "pkill";            description = "pattern-based process kill" };
+  { class_ = System_control;       pattern = "shutdown";         description = "system shutdown" };
+  { class_ = System_control;       pattern = "reboot";           description = "system reboot" };
 ]
 
 (* Delegates to [String_util.contains_substring_ci] (SSOT). Preserves
    the historical [sub = ""] -> true convention used by the original
    inline walker; the SSOT returns [false] for empty needle so we
-   guard here. [destructive_class_substrings] never carries an empty
+   guard here. [destructive_patterns] never carries an empty
    pattern, but the guard keeps the invariant explicit. *)
 let contains_sub_ci s sub =
   if sub = "" then true
@@ -74,9 +85,9 @@ let contains_sub_ci s sub =
    the literal substring that triggered.  [None] means "no known
    destructive pattern found". *)
 let classify_destructive cmd : (destructive_class * string) option =
-  List.find_map (fun (sub, cls) ->
-    if contains_sub_ci cmd sub then Some (cls, sub) else None)
-    destructive_class_substrings
+  List.find_map (fun { class_; pattern; description = _ } ->
+    if contains_sub_ci cmd pattern then Some (class_, pattern) else None)
+    destructive_patterns
 
 (* ================================================================ *)
 (* Legacy and shadow verdicts                                        *)

--- a/lib/gate_diff_types.mli
+++ b/lib/gate_diff_types.mli
@@ -41,22 +41,41 @@ val destructive_class_to_string : destructive_class -> string
     alerts grep on these literals.  Do not change without a
     coordinated metric-rename PR. *)
 
-val classify_destructive : string -> (destructive_class * string) option
-(** [classify_destructive cmd] returns the first matching
-    [(class, substring)] pair in declaration order, or [None] when
-    no destructive pattern matches.
+(** Single source of truth for one destructive shell pattern.  Carries
+    its substring (matched case-insensitively), its operator-visible
+    description, and its typed {!destructive_class}.  Replaces the
+    previously parallel [Eval_gate.destructive_patterns]
+    [(pattern, desc)] list and [destructive_class_substrings]
+    [(pattern, class)] list — both derive from this catalogue, so
+    drift between the legacy gate and the shadow classifier is
+    impossible by construction. *)
+type destructive_pattern = {
+  class_ : destructive_class;
+  pattern : string;
+  description : string;
+}
+
+val destructive_patterns : destructive_pattern list
+(** The canonical destructive-pattern catalogue.
 
     Order matters: longer substrings come first so [rm -rf] matches
     before [rm -r] (both classify as {!Recursive_delete} but the
-    returned substring differs).  The returned substring is suitable
-    for inclusion in an audit-log diagnostic — it is the literal
-    that triggered classification, not a description.
+    returned substring differs).
 
-    The substring set mirrors one row per pattern in
-    {!Eval_gate.destructive_patterns}.  Drift between the two lists
-    means the legacy gate and the shadow gate disagree by
-    construction — pinning the order at the contract seam keeps the
-    drift detectable.  Case-insensitive substring matching via
+    Length is pinned at 19 by [test_destructive_class.test_coverage_count]
+    — a new entry must update that count.  The list is the only
+    SSOT; [Eval_gate.destructive_patterns] and {!classify_destructive}
+    both walk this list, eliminating the previous drift surface
+    enforced only at runtime test time. *)
+
+val classify_destructive : string -> (destructive_class * string) option
+(** [classify_destructive cmd] returns the first matching
+    [(class, substring)] pair in declaration order over
+    {!destructive_patterns}, or [None] when no pattern matches.
+
+    The returned substring is suitable for inclusion in an audit-log
+    diagnostic — it is the literal that triggered classification,
+    not a description.  Case-insensitive substring matching via
     {!String_util.contains_substring_ci}. *)
 
 (** {1 Legacy and shadow verdicts} *)

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -272,9 +272,7 @@ module Metrics = struct
       ?(on_streaming_first_chunk = default_streaming_first_chunk)
       ?(on_streaming_chunk = default_streaming_chunk) ()
       : Llm_provider.Metrics.t =
-    {
-      Llm_provider.Metrics.noop with
-      on_cache_hit;
+    { on_cache_hit;
       on_cache_miss;
       on_request_start;
       on_request_end;


### PR DESCRIPTION
## Summary

iter4 of `/loop masc-mcp docker, bash 등 도구 개선 shell IR 등으로
반복해서 stacked pr 해 개선 진행`.  Independent of #15699/#15700 stack
(branched off origin/main, no shared symbol dependency).

Unifies the two previously-parallel destructive-pattern catalogues
into a single source of truth:

- `Eval_gate.destructive_patterns : (string * string) list` —
  pattern + description, 19 entries
- `Gate_diff_types.destructive_class_substrings : (string *
  destructive_class) list` — pattern + typed class, 19 entries

Both lists had to stay in sync; drift was caught only at runtime by
`test_destructive_class.test_all_patterns_classify` walking
`Eval_gate.destructive_patterns` and asserting
`Worker_dev_tools.classify_destructive` matches every entry.  Per
RFC-0089 + `software-development.md §AI 코드 생성 안티패턴`, a test
covenant guarding string-list drift is a **workaround #2** (lint w/
hardcoded phrase list), not a structural fix.

After this PR a single typed record `destructive_pattern = { class_;
pattern; description }` is the SSOT; both legacy and shadow callers
derive from it.  Drift becomes impossible by construction; the
covenant test still passes but is now a tautology asserting list
shape rather than guarding inter-file consistency.

## Changes

- `lib/gate_diff_types.{ml,mli}` — new `destructive_pattern` record
  type + `destructive_patterns : destructive_pattern list` SSOT (19
  entries).  `destructive_class_substrings` removed.
  `classify_destructive` now walks the typed SSOT directly.
- `lib/eval_gate.ml` — `destructive_patterns : (string * string) list`
  becomes derived via `List.map` over the SSOT.  Public surface
  preserved (callers using `(pattern, desc)` shape unchanged).
- `lib/oas_compat/oas_compat.ml` — drive-by fix of the pre-existing
  `useless-record-with` warning (warn-error +23) that was blocking
  origin/main builds in fresh worktrees.

## Drift surface eliminated

Before: two files (`eval_gate.ml` and `gate_diff_types.ml`) had to be
edited in lockstep when adding a destructive pattern.  A runtime test
caught the omission.

After: one file (`gate_diff_types.ml`).  The compiler enforces the
record shape; `Eval_gate.destructive_patterns` is auto-derived; no
human attention required.

## Test plan

- [x] `dune build --root . @check` clean.
- [x] `test_destructive_class.exe` — 6/6 PASS (every eval_gate pattern
      classifies + 19 patterns present + longest match + etc.).
- [x] `test_eval_gate.exe` — 24/24 PASS.
- [x] `test_gate_diff.exe` — 8/8 PASS.
- [x] `test_keeper_safety_gates.exe` — 52/52 PASS.
- [x] `ocamlformat --check` clean (4 files).
- [x] `pr-rfc-check.sh` PASS (no keeper subsystem in diff).

Cited RFCs: RFC-0089 (string classifier → typed variant — covenant
test replaced by structural unification).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
