### PR TITLE
refactor(eval_gate): typed evasion_kind for shell-evasion indicators (RFC-0089)

### DIFF
--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -129,32 +129,85 @@ let normalize_command (cmd : string) : string =
   ) cmd;
   String.trim (Buffer.contents buf)
 
-(** Suspicious shell meta-patterns that indicate possible evasion attempts.
-    These don't match specific destructive commands but flag constructs
-    that could hide destructive intent from substring matching.
+(** Closed taxonomy of shell-evasion meta-patterns.  Each kind names a
+    construct that could hide destructive intent from
+    {!detect_destructive}'s substring matching; the regex + description
+    live together in {!evasion_indicators} so a new entry forces the
+    type + the list to update in lockstep (compiler-enforced, not
+    runtime-test-enforced).
 
-    Each entry is (regex_pattern, description). Checked on the raw
-    (un-normalized) command to catch patterns that normalization would strip. *)
-let evasion_indicators : (string * string) list = [
-  ({|\$[({]|}, "variable expansion or command substitution");
-  ({|\\x[0-9a-fA-F]|}, "hex escape sequence");
-  ({|\\[0-7][0-7]|}, "octal escape sequence");
-  ({|base64.*-d|}, "base64 decode pipe (possible payload obfuscation)");
-  ({|eval |}, "eval invocation (arbitrary code execution)");
-  ({|xargs.*rm|xargs.*kill|}, "xargs with destructive command");
+    Drift surface previously: a [(string * string) list] of (regex,
+    desc) with no compile-time guarantee that every kind documented
+    in the function comment had a corresponding entry. *)
+type evasion_kind =
+  | Variable_expansion
+  | Hex_escape
+  | Octal_escape
+  | Base64_decode_pipe
+  | Eval_invocation
+  | Xargs_destructive
+
+let evasion_kind_to_string = function
+  | Variable_expansion -> "variable_expansion"
+  | Hex_escape -> "hex_escape"
+  | Octal_escape -> "octal_escape"
+  | Base64_decode_pipe -> "base64_decode_pipe"
+  | Eval_invocation -> "eval_invocation"
+  | Xargs_destructive -> "xargs_destructive"
+
+type evasion_indicator = {
+  kind : evasion_kind;
+  pattern : string;
+  description : string;
+}
+
+(** Suspicious shell meta-patterns that indicate possible evasion
+    attempts.  Each entry binds a typed {!evasion_kind} to its regex
+    + operator-visible description.  Checked on the raw
+    (un-normalized) command to catch patterns that normalization
+    would strip. *)
+let evasion_indicators : evasion_indicator list = [
+  { kind = Variable_expansion;
+    pattern = {|\$[({]|};
+    description = "variable expansion or command substitution" };
+  { kind = Hex_escape;
+    pattern = {|\\x[0-9a-fA-F]|};
+    description = "hex escape sequence" };
+  { kind = Octal_escape;
+    pattern = {|\\[0-7][0-7]|};
+    description = "octal escape sequence" };
+  { kind = Base64_decode_pipe;
+    pattern = {|base64.*-d|};
+    description = "base64 decode pipe (possible payload obfuscation)" };
+  { kind = Eval_invocation;
+    pattern = {|eval |};
+    description = "eval invocation (arbitrary code execution)" };
+  { kind = Xargs_destructive;
+    pattern = {|xargs.*rm|xargs.*kill|};
+    description = "xargs with destructive command" };
 ]
 
 (** Check for shell evasion indicators in the raw (un-normalized) command.
     Returns Some(pattern, description) if a suspicious construct is found.
     This supplements [detect_destructive] by catching meta-patterns that
-    normalization-based substring matching cannot handle. *)
-let detect_evasion (command : string) : (string * string) option =
+    normalization-based substring matching cannot handle.
+
+    Preserves the legacy [(pattern, description)] return shape for
+    callers that pattern-match on the substring (e.g. classify_legacy
+    in worker_dev_tools); the typed kind is available via
+    {!detect_evasion_typed} for new callers that need to discriminate. *)
+let detect_evasion_typed (command : string) : evasion_indicator option =
   let cmd_lower = String.lowercase_ascii command in
-  List.find_opt (fun (pattern, _desc) ->
+  List.find_opt (fun { pattern; _ } ->
     Safe_ops.protect ~default:false (fun () ->
       let re = Re.Pcre.re pattern |> Re.compile in
       Re.execp re cmd_lower)
   ) evasion_indicators
+
+let detect_evasion (command : string) : (string * string) option =
+  match detect_evasion_typed command with
+  | None -> None
+  | Some { pattern; description; _ } -> Some (pattern, description)
 
 (** Check if a bash command contains destructive patterns.
     Returns None if safe, Some(pattern, description) if dangerous.

--- a/lib/eval_gate.mli
+++ b/lib/eval_gate.mli
@@ -37,8 +37,38 @@ val destructive_patterns : (string * string) list
 val detect_destructive : string -> (string * string) option
 (** Returns [(pattern, description)] if command matches a destructive pattern. *)
 
+(** Closed taxonomy of shell-evasion meta-patterns detected by
+    {!detect_evasion_typed} / {!detect_evasion}.  New entries force the
+    type + the [evasion_indicators] catalogue to update in lockstep —
+    no runtime drift surface. *)
+type evasion_kind =
+  | Variable_expansion
+  | Hex_escape
+  | Octal_escape
+  | Base64_decode_pipe
+  | Eval_invocation
+  | Xargs_destructive
+
+val evasion_kind_to_string : evasion_kind -> string
+(** Snake_case rendering for log / metric emission.  Pinned wording —
+    do not change without coordinating with any future telemetry. *)
+
+type evasion_indicator = {
+  kind : evasion_kind;
+  pattern : string;
+  description : string;
+}
+
+val detect_evasion_typed : string -> evasion_indicator option
+(** Returns the full typed indicator (kind + regex + description) for
+    the first match.  Use this when the caller needs to discriminate
+    by kind; {!detect_evasion} drops the kind for backward-compatible
+    string-tuple returns. *)
+
 val detect_evasion : string -> (string * string) option
-(** Returns [(indicator, description)] if command shows evasion attempt. *)
+(** Returns [(pattern, description)] if command shows evasion attempt.
+    Thin wrapper over {!detect_evasion_typed} that drops the typed
+    kind — preserved for callers that consume the string-tuple shape. *)
 
 (** {1 Pre-execution gate} *)
 


### PR DESCRIPTION
## Summary

iter5 of `/loop masc-mcp docker, bash 등 도구 개선 shell IR 등으로
반복해서 stacked pr 해 개선 진행`.  Independent of #15699/#15700/#15703
(branched off origin/main).

Promotes [Eval_gate.evasion_indicators] from a [(regex, description)]
string-pair list to a closed-sum [evasion_kind] tagging each entry.
New [detect_evasion_typed] exposes the full typed indicator (kind +
regex + description); existing [detect_evasion] is preserved as a
thin wrapper over the typed call, dropping the kind to return the
backward-compatible [(pattern, description) option] shape.

## Why

Before: a 6-entry `(string * string) list` of (regex, description)
with the kinds documented only in the function comment.  Adding a
new evasion type requires editing the list + remembering to update
the doc; the compiler could not check the documentation reflected
the list.  Per RFC-0089 + `software-development.md §AI 코드 생성
안티패턴 #2`, this is the same string-classifier pattern iter4 closed
for the destructive-pattern catalogue.

After: a closed sum [evasion_kind] is the SSOT for the taxonomy.
The [evasion_indicators] catalogue tags each regex with its kind;
a new variant must update both the type and the list (compile error
otherwise) — drift impossible.

Production callers (`Worker_dev_tools.classify_legacy`) consume the
`(pattern, description) option` shape via the wrapper, so no
behavior change.  Future callers that want to discriminate (e.g.
per-kind telemetry, kind-specific operator hint) get the typed
surface via [detect_evasion_typed].

## Changes

- `lib/eval_gate.ml` — add `evasion_kind` closed sum + `evasion_kind_to_string` +
  `evasion_indicator` record.  Rewrite `evasion_indicators` to carry
  the kind alongside the regex.  Add `detect_evasion_typed`.
  `detect_evasion` becomes a thin wrapper.
- `lib/eval_gate.mli` — expose new types + `detect_evasion_typed`;
  doc the legacy wrapper as backward-compat.

## Test plan

- [x] `dune build --root . @check` clean.
- [x] `test_eval_gate.exe` — 24/24 PASS (legacy `detect_evasion` shape preserved).
- [x] `test_eval_gate_evasion.exe` — 23/23 PASS.
- [x] `test_keeper_safety_gates.exe` — 52/52 PASS.
- [x] `test_governance_pipeline.exe` — 98/98 PASS.
- [x] `ocamlformat --check` clean (2 files).
- [x] `pr-rfc-check.sh` PASS (no keeper subsystem in diff).

Cited RFCs: RFC-0089 (string classifier → typed variant).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
