### PR TITLE
fix(keeper): lazily repair missing task worktrees

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -91,6 +91,7 @@
    keeper_exec_fs
    keeper_exec_ide
    keeper_shell_docker
+   keeper_task_worktree_lazy
    keeper_egress_audit
    keeper_shell_gh_context
    keeper_shell_bg_task

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -112,6 +112,7 @@ type t =
   | DecisionAuditFlushFailures
   | OasCancel
   | ClaimAutoProvision
+  | TaskWorktreeLazyRepair
   | TomlInvalid
   | PersonaDriftMissing
   | RoomInitFailures
@@ -310,6 +311,7 @@ let to_string = function
   | DecisionAuditFlushFailures -> "masc_keeper_decision_audit_flush_failures_total"
   | OasCancel -> "masc_keeper_oas_cancel_total"
   | ClaimAutoProvision -> "masc_keeper_claim_auto_provision_total"
+  | TaskWorktreeLazyRepair -> "masc_keeper_task_worktree_lazy_repair_total"
   | TomlInvalid -> "masc_keeper_toml_invalid_total"
   | PersonaDriftMissing -> "masc_keeper_persona_drift_missing_total"
   | RoomInitFailures -> "masc_keeper_room_init_failures_total"
@@ -615,6 +617,9 @@ let metric_keeper_decision_audit_flush_failures =
 
 let metric_keeper_oas_cancel = "masc_keeper_oas_cancel_total"
 let metric_keeper_claim_auto_provision = "masc_keeper_claim_auto_provision_total"
+let metric_keeper_task_worktree_lazy_repair =
+  "masc_keeper_task_worktree_lazy_repair_total"
+;;
 let metric_keeper_toml_invalid = "masc_keeper_toml_invalid_total"
 let metric_keeper_persona_drift_missing = "masc_keeper_persona_drift_missing_total"
 let metric_keeper_room_init_failures = "masc_keeper_room_init_failures_total"

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -104,6 +104,7 @@ type t =
   | DecisionAuditFlushFailures
   | OasCancel
   | ClaimAutoProvision
+  | TaskWorktreeLazyRepair
   | TomlInvalid
   | PersonaDriftMissing
   | RoomInitFailures
@@ -312,6 +313,7 @@ val metric_keeper_reconcile_failures : string
 val metric_keeper_decision_audit_flush_failures : string
 val metric_keeper_oas_cancel : string
 val metric_keeper_claim_auto_provision : string
+val metric_keeper_task_worktree_lazy_repair : string
 val metric_keeper_toml_invalid : string
 val metric_keeper_persona_drift_missing : string
 val metric_keeper_room_init_failures : string

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -735,10 +735,17 @@ let handle_keeper_bash
              ~env_snapshot:env_snap
              ())
       | Ok () ->
-        (
-            (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd with
-             | Error e -> error_json ~fields:["blocked_cmd", `String cmd_for_log] e
-             | Ok () ->
+        begin
+          let path_validation =
+           match
+             Keeper_task_worktree_lazy.ensure_command_existing_dirs ~config ~meta ~cwd ~cmd
+           with
+           | Error e -> Error e
+           | Ok () -> Worker_dev_tools.validate_command_paths ~workdir:cwd cmd
+          in
+          match path_validation with
+          | Error e -> error_json ~fields:["blocked_cmd", `String cmd_for_log] e
+          | Ok () ->
                if write_enabled
                   && Worker_dev_tools.is_write_operation cmd then
                  Log.Keeper.info "WRITE_AUDIT: keeper=%s cwd=%s cmd=%s playground=%b"
@@ -1034,6 +1041,7 @@ let handle_keeper_bash
                        | Some entry -> cached_result_json entry
                        | None -> run_uncached ())
                     | None -> run_uncached ())
-               end))
+               end
+        end
   end)
 ;;

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -831,7 +831,15 @@ let run_docker_shell_command_with_status_internal
           let validation_cmd =
             rewrite_docker_command_paths_for_host_validation ~config ~meta cmd
           in
-          Worker_dev_tools.validate_command_paths ~workdir:cwd validation_cmd
+          (match
+             Keeper_task_worktree_lazy.ensure_command_existing_dirs
+               ~config
+               ~meta
+               ~cwd
+               ~cmd:validation_cmd
+           with
+           | Error e -> Error e
+           | Ok () -> Worker_dev_tools.validate_command_paths ~workdir:cwd validation_cmd)
         else Ok ()
       in
       match path_validation with
@@ -1098,7 +1106,18 @@ let run_docker_with_git_bash
          let validation_cmd =
            rewrite_docker_command_paths_for_host_validation ~config ~meta cmd
          in
-         (match Worker_dev_tools.validate_command_paths ~workdir:cwd validation_cmd with
+         let path_validation =
+           match
+             Keeper_task_worktree_lazy.ensure_command_existing_dirs
+               ~config
+               ~meta
+               ~cwd
+               ~cmd:validation_cmd
+           with
+           | Error e -> Error e
+           | Ok () -> Worker_dev_tools.validate_command_paths ~workdir:cwd validation_cmd
+         in
+         (match path_validation with
           | Error err -> sandbox_error_json (Printf.sprintf "%s [blocked_cmd=%s]" err validation_cmd)
           | Ok () ->
            let _ = turn_sandbox_runtime in
@@ -1171,7 +1190,18 @@ let run_docker_hardened_bash
       let validation_cmd =
         rewrite_docker_command_paths_for_host_validation ~config ~meta cmd
       in
-      (match Worker_dev_tools.validate_command_paths ~workdir:cwd validation_cmd with
+      let path_validation =
+        match
+          Keeper_task_worktree_lazy.ensure_command_existing_dirs
+            ~config
+            ~meta
+            ~cwd
+            ~cmd:validation_cmd
+        with
+        | Error e -> Error e
+        | Ok () -> Worker_dev_tools.validate_command_paths ~workdir:cwd validation_cmd
+      in
+      (match path_validation with
        | Error err -> sandbox_error_json (Printf.sprintf "%s [blocked_cmd=%s]" err validation_cmd)
        | Ok () ->
       (match turn_sandbox_runtime, network_mode with

--- a/lib/keeper/keeper_shell_shared.ml
+++ b/lib/keeper/keeper_shell_shared.ml
@@ -411,7 +411,16 @@ let resolve_keeper_shell_write_cwd
   match resolved with
   | Error _ as err -> err
   | Ok cwd when Fs_compat.file_exists cwd && Sys.is_directory cwd -> Ok cwd
-  | Ok cwd -> Error (Printf.sprintf "cwd_not_directory: %s" cwd)
+  | Ok cwd ->
+    (match Keeper_task_worktree_lazy.ensure_path ~site:"write_cwd" ~config ~meta ~path:cwd with
+     | Ok Keeper_task_worktree_lazy.Created
+     | Ok Keeper_task_worktree_lazy.Already_present ->
+       if Fs_compat.file_exists cwd && Sys.is_directory cwd
+       then Ok cwd
+       else Error (Printf.sprintf "cwd_not_directory: %s" cwd)
+     | Ok Keeper_task_worktree_lazy.Not_current_task_worktree ->
+       Error (Printf.sprintf "cwd_not_directory: %s" cwd)
+     | Error msg -> Error msg)
 
 (* Docker playground path mapping: host → container.
    Host:      <base_path>/.masc/playground/<keeper>/repos/X

--- a/lib/keeper/keeper_task_worktree_lazy.ml
+++ b/lib/keeper/keeper_task_worktree_lazy.ml
@@ -1,0 +1,176 @@
+type ensure_outcome =
+  | Already_present
+  | Created
+  | Not_current_task_worktree
+
+type candidate =
+  { agent_name : string
+  ; task_id : string
+  ; repo_name : string
+  ; worktree_path : string
+  }
+
+let safe_is_dir path =
+  try Fs_compat.file_exists path && Sys.is_directory path with
+  | Sys_error _ -> false
+;;
+
+let normalize path = Keeper_alerting_path.normalize_path_for_check_stripped path
+
+let suffix_under ~prefix path =
+  let prefix = Keeper_alerting_path.strip_trailing_slashes prefix in
+  let path = Keeper_alerting_path.strip_trailing_slashes path in
+  if String.equal path prefix
+  then Some ""
+  else (
+    let prefix_with_sep = prefix ^ "/" in
+    if String.starts_with ~prefix:prefix_with_sep path
+    then
+      Some
+        (String.sub path (String.length prefix_with_sep)
+           (String.length path - String.length prefix_with_sep))
+    else None)
+;;
+
+let unique_nonempty values =
+  List.fold_left
+    (fun acc value ->
+       let value = String.trim value in
+       if value = "" || List.mem value acc then acc else acc @ [ value ])
+    []
+    values
+;;
+
+let current_task_id_string (meta : Keeper_types.keeper_meta) =
+  Option.map Keeper_id.Task_id.to_string meta.current_task_id
+;;
+
+let candidate_of_path ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) path =
+  match current_task_id_string meta with
+  | None -> None
+  | Some task_id ->
+    let path = normalize path in
+    unique_nonempty [ meta.agent_name; meta.name ]
+    |> List.find_map (fun agent_name ->
+      let repos_dir = Coord_worktree.repos_dir_of_keeper config agent_name |> normalize in
+      match suffix_under ~prefix:repos_dir path with
+      | None -> None
+      | Some suffix ->
+        (match Keeper_alerting_path.split_relative_components suffix with
+         | [ repo_name; ".worktrees"; worktree_name ]
+           when Coord_worktree.safe_repo_name repo_name
+                && String.equal
+                     worktree_name
+                     (Playground_paths.worktree_dir_name agent_name task_id) ->
+           Some { agent_name; task_id; repo_name; worktree_path = path }
+         | _ -> None))
+;;
+
+let observe ~(meta : Keeper_types.keeper_meta) ~site ~outcome =
+  Prometheus.inc_counter
+    Keeper_metrics.metric_keeper_task_worktree_lazy_repair
+    ~labels:[ "outcome", outcome; "site", site; "keeper", meta.name ]
+    ()
+;;
+
+let inconsistent candidate msg =
+  Printf.sprintf
+    "sandbox_state_inconsistent: task worktree auto-create failed path=%s repo=%s \
+     task_id=%s agent=%s: %s"
+    candidate.worktree_path
+    candidate.repo_name
+    candidate.task_id
+    candidate.agent_name
+    msg
+;;
+
+let ensure_candidate ~site ~config ~meta candidate =
+  observe ~meta ~site ~outcome:"attempt";
+  Log.Keeper.info
+    "keeper:%s lazy task worktree repair: site=%s agent=%s task=%s repo=%s path=%s"
+    meta.name
+    site
+    candidate.agent_name
+    candidate.task_id
+    candidate.repo_name
+    candidate.worktree_path;
+  match
+    Task_sandbox.create
+      ~config
+      ~task_id:candidate.task_id
+      ~base_branch:"auto"
+      ~repo_name:candidate.repo_name
+      ~agent_name:candidate.agent_name
+      ()
+  with
+  | Ok sandbox when safe_is_dir candidate.worktree_path ->
+    observe ~meta ~site ~outcome:"created";
+    Log.Keeper.info
+      "keeper:%s lazy task worktree repair created path=%s returned_path=%s"
+      meta.name
+      candidate.worktree_path
+      sandbox.Task_sandbox.worktree_path;
+    Ok Created
+  | Ok sandbox ->
+    let msg =
+      Printf.sprintf
+        "created path mismatch; expected path still missing, returned_path=%s"
+        sandbox.Task_sandbox.worktree_path
+    in
+    observe ~meta ~site ~outcome:"error";
+    Error (inconsistent candidate msg)
+  | Error msg when safe_is_dir candidate.worktree_path ->
+    observe ~meta ~site ~outcome:"created_concurrently";
+    Log.Keeper.info
+      "keeper:%s lazy task worktree repair observed concurrent create path=%s after \
+       error=%s"
+      meta.name
+      candidate.worktree_path
+      msg;
+    Ok Created
+  | Error msg ->
+    observe ~meta ~site ~outcome:"error";
+    Log.Keeper.warn
+      "keeper:%s lazy task worktree repair failed: site=%s agent=%s task=%s repo=%s \
+       path=%s error=%s"
+      meta.name
+      site
+      candidate.agent_name
+      candidate.task_id
+      candidate.repo_name
+      candidate.worktree_path
+      msg;
+    Error (inconsistent candidate msg)
+;;
+
+let ensure_path ~site ~config ~meta ~path =
+  let path = normalize path in
+  if safe_is_dir path
+  then Ok Already_present
+  else (
+    match candidate_of_path ~config ~meta path with
+    | None -> Ok Not_current_task_worktree
+    | Some candidate -> ensure_candidate ~site ~config ~meta candidate)
+;;
+
+let host_path_of_command_value ~cwd value =
+  let value = String.trim value in
+  if value = ""
+  then value
+  else if Filename.is_relative value
+  then Filename.concat cwd value
+  else value
+;;
+
+let ensure_command_existing_dirs ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta)
+      ~cwd ~cmd =
+  let rec loop = function
+    | [] -> Ok ()
+    | value :: rest ->
+      let path = host_path_of_command_value ~cwd value in
+      (match ensure_path ~site:"command_path" ~config ~meta ~path with
+       | Error _ as err -> err
+       | Ok _ -> loop rest)
+  in
+  loop (Worker_dev_tools.existing_dir_path_values cmd)
+;;

--- a/lib/keeper/keeper_task_worktree_lazy.mli
+++ b/lib/keeper/keeper_task_worktree_lazy.mli
@@ -1,0 +1,34 @@
+(** Lazy repair for current-task keeper worktrees.
+
+    The claim hook eagerly provisions a task worktree when it has enough
+    repository context, but keeper shell calls can still arrive with a cwd or
+    [git -C] target under [repos/<repo>/.worktrees/<keeper>-<task>] after the
+    directory was never created or was removed.  This module recognizes only
+    the current task's canonical worktree path and asks {!Task_sandbox} to
+    create that worktree before the path validator rejects it as a missing
+    directory. *)
+
+type ensure_outcome =
+  | Already_present
+  | Created
+  | Not_current_task_worktree
+
+val ensure_path :
+  site:string ->
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  path:string ->
+  (ensure_outcome, string) result
+(** Ensure [path] when it is exactly the current task worktree directory.
+    Non-matching paths return [Ok Not_current_task_worktree] so the normal
+    path validator can render the final error. *)
+
+val ensure_command_existing_dirs :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  cwd:string ->
+  cmd:string ->
+  (unit, string) result
+(** Inspect [cmd] for existing-directory path requirements such as
+    [git -C <dir>] and lazily repair matching current-task worktrees relative
+    to [cwd]. *)

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -915,6 +915,26 @@ let path_validation_tokens tokens =
       args
 ;;
 
+let existing_dir_path_values cmd =
+  let rec loop expect_existing_dir acc = function
+    | [] -> List.rev acc
+    | token :: rest ->
+      if token.value = ""
+      then loop expect_existing_dir acc rest
+      else if expect_existing_dir
+      then loop false (token.value :: acc) rest
+      else (
+        match path_value_of_flagged_token token.value with
+        | Some value when inline_path_flag_requires_existing_dir token.value ->
+          loop false (value :: acc) rest
+        | Some _ -> loop false acc rest
+        | None when is_path_flag token.value ->
+          loop (path_flag_requires_existing_dir token.value) acc rest
+        | None -> loop false acc rest)
+  in
+  cmd |> tokenize_path_args |> path_validation_tokens |> loop false []
+;;
+
 let validate_command_paths ?workdir cmd =
   match workdir with
   | None -> Ok ()

--- a/lib/worker_dev_tools.mli
+++ b/lib/worker_dev_tools.mli
@@ -70,6 +70,14 @@ val validate_command_coding_with_allowlist
     [workdir = None]. *)
 val validate_command_paths : ?workdir:string -> string -> (unit, string) result
 
+(** Return path values in [cmd] that the shell validator treats as
+    existing-directory requirements (for example [git -C <dir>] and
+    [--work-tree=<dir>]).  Callers may use this to repair an expected
+    sandbox directory before delegating to {!validate_command_paths};
+    the validator remains the authority for blocking unsafe syntax and
+    out-of-sandbox paths. *)
+val existing_dir_path_values : string -> string list
+
 (** {1 Bash safety classifiers} *)
 
 (** [true] iff the command performs a write/mutating operation

--- a/test/test_task_sandbox.ml
+++ b/test/test_task_sandbox.ml
@@ -10,6 +10,9 @@ open Alcotest
 
 module Task_sandbox = Masc_mcp.Task_sandbox
 module Coord = Masc_mcp.Coord
+module Keeper_shell_shared = Masc_mcp.Keeper_shell_shared
+module Keeper_task_worktree_lazy = Masc_mcp.Keeper_task_worktree_lazy
+module Worker_dev_tools = Masc_mcp.Worker_dev_tools
 
 (* ============================================================
    Helpers
@@ -259,6 +262,98 @@ let write_tasks config tasks =
   let backlog = Coord.read_backlog config in
   Coord.write_backlog config
     { Masc_domain.tasks = tasks; last_updated = Masc_domain.now_iso (); version = backlog.version + 1 }
+
+let make_meta_with_current_task ~name ~task_id =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+          [ "name", `String name
+          ; "agent_name", `String name
+          ; "trace_id", `String ("trace-" ^ name)
+          ; "goal", `String "lazy worktree test"
+          ; "current_task_id", `String task_id
+          ])
+  with
+  | Ok meta -> meta
+  | Error err -> fail ("meta fixture failed: " ^ err)
+
+let with_lazy_worktree_fixture f =
+  let base = make_temp_dir () in
+  let dir = base in
+  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
+  let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
+  Fun.protect
+    ~finally:(fun () ->
+      (match saved_base with
+       | Some v -> Unix.putenv "MASC_BASE_PATH" v
+       | None -> Unix.putenv "MASC_BASE_PATH" "");
+      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
+    (fun () ->
+      Eio_main.run (fun env ->
+        Fs_compat.set_fs (Eio.Stdenv.fs env);
+        run_cmd (Printf.sprintf "git init -q -b main %s" (Filename.quote dir));
+        let proc_mgr = Eio.Stdenv.process_mgr env in
+        let clock = Eio.Stdenv.clock env in
+        let cwd = Eio.Stdenv.cwd env in
+        Process_eio.init ~cwd_default:cwd ~proc_mgr ~clock;
+
+        Unix.putenv "MASC_BASE_PATH" dir;
+        let config = Coord.default_config dir in
+        let _msg = Coord.init config ~agent_name:None in
+        let agent_name = "lazy-agent" in
+        let _join = Coord.join config ~agent_name ~capabilities:[ "test" ] () in
+        let source_repo =
+          setup_named_repo_with_file ~base_path:dir ~repo_name:"masc-mcp"
+            ~file_path:"README.md"
+        in
+        let clone_path =
+          seed_playground_clone ~base_path:dir ~agent_name ~source_repo
+        in
+        let task_id = "task-lazy" in
+        let worktree_name = Playground_paths.worktree_dir_name agent_name task_id in
+        let worktree_path =
+          Filename.concat clone_path (Filename.concat ".worktrees" worktree_name)
+        in
+        let meta = make_meta_with_current_task ~name:agent_name ~task_id in
+        f ~config ~meta ~clone_path ~task_id ~worktree_name ~worktree_path))
+
+let test_resolve_write_cwd_lazy_creates_current_task_worktree () =
+  with_lazy_worktree_fixture
+    (fun ~config ~meta ~clone_path:_ ~task_id:_ ~worktree_name ~worktree_path ->
+       check bool "worktree initially missing" false (Sys.file_exists worktree_path);
+       let args =
+         `Assoc
+           [ ( "cwd"
+             , `String (Printf.sprintf "repos/masc-mcp/.worktrees/%s" worktree_name)
+             )
+           ]
+       in
+       match Keeper_shell_shared.resolve_keeper_shell_write_cwd ~config ~meta ~args with
+       | Error msg -> fail ("expected lazy cwd repair, got: " ^ msg)
+       | Ok cwd ->
+         check string "resolved cwd" worktree_path cwd;
+         check bool "worktree created" true (Sys.is_directory cwd);
+         check bool ".masc linked" true
+           (Sys.file_exists (Filename.concat cwd Common.masc_dirname)))
+
+let test_command_path_lazy_creates_current_task_worktree () =
+  with_lazy_worktree_fixture
+    (fun ~config ~meta ~clone_path ~task_id:_ ~worktree_name ~worktree_path ->
+       check bool "worktree initially missing" false (Sys.file_exists worktree_path);
+       let cmd = Printf.sprintf "git -C .worktrees/%s status -sb" worktree_name in
+       (match
+          Keeper_task_worktree_lazy.ensure_command_existing_dirs
+            ~config
+            ~meta
+            ~cwd:clone_path
+            ~cmd
+        with
+        | Error msg -> fail ("expected lazy command-path repair, got: " ^ msg)
+        | Ok () -> ());
+       check bool "worktree created" true (Sys.is_directory worktree_path);
+       match Worker_dev_tools.validate_command_paths ~workdir:clone_path cmd with
+       | Error msg -> fail ("validator should pass after lazy repair: " ^ msg)
+       | Ok () -> ())
 
 let test_full_lifecycle () =
   let base = make_temp_dir () in
@@ -830,6 +925,10 @@ let () =
         test_create_infers_repo_from_task_file_evidence;
       test_case "docker_visible_path_resolves_to_host" `Quick
         test_create_resolves_docker_visible_path_to_host_worktree;
+      test_case "lazy_write_cwd_creates_current_task_worktree" `Quick
+        test_resolve_write_cwd_lazy_creates_current_task_worktree;
+      test_case "lazy_command_path_creates_current_task_worktree" `Quick
+        test_command_path_lazy_creates_current_task_worktree;
       test_case "ambiguous_multi_repo_without_evidence" `Quick
         test_create_fails_ambiguous_multi_repo_without_evidence;
       test_case "infer_repo_from_task_repo_mentions" `Quick


### PR DESCRIPTION
## Summary

- add a keeper task-worktree lazy repair path for missing current-task worktrees
- repair both `cwd=repos/<repo>/.worktrees/<keeper>-<task>` and validator-required command paths such as `git -C .worktrees/<keeper>-<task>`
- emit `masc_keeper_task_worktree_lazy_repair_total` with `outcome/site/keeper` labels and structured keeper logs
- keep non-current-task or non-canonical paths on the existing `cwd_not_directory` path

## Root cause

#15551 M3 is a lifecycle race: keeper shell validation can see the canonical current-task worktree path before the per-task worktree exists. The validator then reports `cwd_not_directory` even though the path is recoverable from `current_task_id`, the repo segment, and the keeper name.

This PR recognizes only the exact current-task worktree shape under the keeper sandbox repo clone, then delegates creation to `Task_sandbox.create`. If the path is unrelated, missing `current_task_id`, mismatched to the task, or not a safe repo segment, validation proceeds unchanged.

Refs #15551.

## Validation

- `git diff --check`
- `opam exec -- ocamlformat --check lib/worker_dev_tools.ml lib/worker_dev_tools.mli lib/keeper/keeper_task_worktree_lazy.ml lib/keeper/keeper_task_worktree_lazy.mli lib/keeper/keeper_shell_shared.ml lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_shell_docker.ml lib/keeper/keeper_metrics.ml lib/keeper/keeper_metrics.mli test/test_task_sandbox.ml`
- `env MASC_SKIP_PIN_CHECK=1 DUNE_LOCAL_JOBS=1 OCAMLPARAM=_,warn-error=-23 scripts/dune-local.sh build test/test_task_sandbox.exe test/test_worker_dev_tools.exe test/test_keeper_shell_docker_route.exe`
- `env OCAMLPARAM=_,warn-error=-23 _build/default/test/test_task_sandbox.exe`
- `env OCAMLPARAM=_,warn-error=-23 _build/default/test/test_worker_dev_tools.exe`

## Note

`env OCAMLPARAM=_,warn-error=-23 _build/default/test/test_keeper_shell_docker_route.exe test docker_route_contract 4` still fails in this local environment at the pre-existing root GH identity bundle assertion (`root GH identity bundle mounted`), before this PR's lazy worktree path is exercised.
