### PR TITLE
feat(keeper-shell): wire Shell_ir_validator advisor flag-gated (RFC-0092 PR-2, stacked on #15708)

### DIFF
--- a/lib/gate_diff_types.ml
+++ b/lib/gate_diff_types.ml
@@ -138,3 +138,11 @@ let shadow_diff_log_enabled () =
   match Sys.getenv_opt "MASC_BASH_AST_SHADOW_LOG" with
   | Some ("1" | "true" | "TRUE" | "yes" | "on" | "log") -> true
   | _ -> false
+
+(* RFC-0092 Phase A advisor — typed parallel-validation log gate.
+   Default off; operator opt-in for the parity-measurement window
+   before the authority flip in Phase C. *)
+let typed_advisor_log_enabled () =
+  match Sys.getenv_opt "MASC_BASH_TYPED_ADVISOR" with
+  | Some ("1" | "true" | "TRUE" | "yes" | "on" | "log") -> true
+  | _ -> false

--- a/lib/gate_diff_types.mli
+++ b/lib/gate_diff_types.mli
@@ -136,3 +136,12 @@ val shadow_diff_log_enabled : unit -> bool
     of the documented truthy values: [1], [true], [TRUE], [yes],
     [on], [log].  Any other value (including unset) returns
     [false] — the gate logs nothing by default. *)
+
+val typed_advisor_log_enabled : unit -> bool
+(** RFC-0092 Phase A advisor opt-in.  Returns [true] iff the
+    [MASC_BASH_TYPED_ADVISOR] environment variable is set to one of
+    the documented truthy values: [1], [true], [TRUE], [yes], [on],
+    [log].  Default off — the typed-validation parity-measurement
+    counters do not increment until an operator opts in.  Phase C
+    will flip authority via a separate [MASC_BASH_TYPED_AUTHORITY]
+    flag in a follow-up PR. *)

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -338,6 +338,24 @@ let handle_keeper_bash
             (Worker_dev_tools.legacy_verdict_to_tag legacy)
             (Worker_dev_tools.shadow_verdict_to_tag shadow))
      end);
+    (* RFC-0092 Phase A — typed-validation advisor (behavior-neutral).
+       Flag-gated; emits a structured log line + per-bucket counter so
+       operators can measure parity vs the legacy substring gate
+       before the Phase C authority flip.  No allow/deny decision is
+       driven from the typed path at this stage. *)
+    (if Worker_dev_tools.typed_advisor_log_enabled () then begin
+       let advisory =
+         Shell_ir_validator.advise
+           ~cmd
+           ~allowlist:Worker_dev_tools.dev_allowed_commands
+       in
+       Legendary_counters.incr_typed_advisor advisory;
+       Log.Keeper.info
+         "typed_advisor keeper=%s cmd_hash=%s outcome=%s"
+         meta.name
+         (Worker_dev_tools.cmd_hash_for_log cmd)
+         (Shell_ir_validator.advisory_tag advisory)
+     end);
     (* Resolve cwd early — needed for playground detection before validation. *)
     match Keeper_shell_shared.resolve_keeper_shell_write_cwd ~config ~meta ~args with
     | Error e -> error_json e

--- a/lib/legendary_counters.ml
+++ b/lib/legendary_counters.ml
@@ -29,6 +29,15 @@ let too_complex_parse_error = Atomic.make 0
 let too_complex_parse_aborted = Atomic.make 0
 let too_complex_other = Atomic.make 0
 
+(* RFC-0092 Phase A typed-advisor parity counters.  Increment only
+   while [Gate_diff_types.typed_advisor_log_enabled ()] is true.
+   Three buckets mirror the [Shell_ir_validator.advisory] sum
+   exhaustively so a future variant is a compile error in
+   [incr_typed_advisor]. *)
+let typed_advisor_allow = Atomic.make 0
+let typed_advisor_reject = Atomic.make 0
+let typed_advisor_cannot_parse = Atomic.make 0
+
 let incr a = ignore (Atomic.fetch_and_add a 1)
 
 let incr_gate_diff (diff : Gate_diff_types.gate_diff) =
@@ -84,6 +93,15 @@ let incr_too_complex_by_tag tag =
   | "__parse_aborted__" -> incr too_complex_parse_aborted
   | _ -> incr too_complex_other
 
+(* RFC-0092 Phase A typed-advisor parity dispatch.  Exhaustive over
+   [Shell_ir_validator.advisory]; a new variant in the validator
+   forces an update here at compile time. *)
+let incr_typed_advisor (a : Shell_ir_validator.advisory) =
+  match a with
+  | Shell_ir_validator.Allow -> incr typed_advisor_allow
+  | Shell_ir_validator.Reject _ -> incr typed_advisor_reject
+  | Shell_ir_validator.Cannot_parse _ -> incr typed_advisor_cannot_parse
+
 let reset () =
   Atomic.set gate_diff_total 0;
   Atomic.set gate_diff_agree 0;
@@ -112,7 +130,10 @@ let reset () =
   Atomic.set gh_exit_type_mismatch 0;
   Atomic.set gh_exit_auth_failed 0;
   Atomic.set gh_exit_network 0;
-  Atomic.set gh_exit_unknown 0
+  Atomic.set gh_exit_unknown 0;
+  Atomic.set typed_advisor_allow 0;
+  Atomic.set typed_advisor_reject 0;
+  Atomic.set typed_advisor_cannot_parse 0
 
 type snapshot = {
   gate_diff_total : int;
@@ -143,6 +164,11 @@ type snapshot = {
   gh_exit_auth_failed : int;
   gh_exit_network : int;
   gh_exit_unknown : int;
+  (* RFC-0092 Phase A typed-advisor parity counters.  Increment only
+     while [Gate_diff_types.typed_advisor_log_enabled ()] is true. *)
+  typed_advisor_allow : int;
+  typed_advisor_reject : int;
+  typed_advisor_cannot_parse : int;
 }
 
 let snapshot () =
@@ -178,6 +204,9 @@ let snapshot () =
     gh_exit_auth_failed = Atomic.get gh_exit_auth_failed;
     gh_exit_network = Atomic.get gh_exit_network;
     gh_exit_unknown = Atomic.get gh_exit_unknown;
+    typed_advisor_allow = Atomic.get typed_advisor_allow;
+    typed_advisor_reject = Atomic.get typed_advisor_reject;
+    typed_advisor_cannot_parse = Atomic.get typed_advisor_cannot_parse;
   }
 
 let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
@@ -213,6 +242,9 @@ let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
     ("gh_exit_auth_failed", `Int s.gh_exit_auth_failed);
     ("gh_exit_network", `Int s.gh_exit_network);
     ("gh_exit_unknown", `Int s.gh_exit_unknown);
+    ("typed_advisor_allow", `Int s.typed_advisor_allow);
+    ("typed_advisor_reject", `Int s.typed_advisor_reject);
+    ("typed_advisor_cannot_parse", `Int s.typed_advisor_cannot_parse);
   ]
 
 let safe_ratio ~num ~den =

--- a/lib/legendary_counters.mli
+++ b/lib/legendary_counters.mli
@@ -44,6 +44,15 @@ val incr_too_complex_by_tag : string -> unit
     `Shadow_cannot_parse] — the per-reason buckets are a histogram
     refinement of that single bucket, not a replacement. *)
 
+val incr_typed_advisor : Shell_ir_validator.advisory -> unit
+(** RFC-0092 Phase A — record one typed-advisor outcome under its
+    bucket ([typed_advisor_allow] / [typed_advisor_reject] /
+    [typed_advisor_cannot_parse]).  Exhaustive over
+    [Shell_ir_validator.advisory]; a new variant in the validator
+    forces an update here at compile time.  Increment only while
+    [Gate_diff_types.typed_advisor_log_enabled ()] is true so an
+    operator running with the flag off pays zero cost. *)
+
 val reset : unit -> unit
 (** Zero every counter.  Used by tests; operators should not rely on
     this surface. *)
@@ -87,6 +96,11 @@ type snapshot = {
   gh_exit_auth_failed : int;
   gh_exit_network : int;
   gh_exit_unknown : int;
+  (* RFC-0092 Phase A typed-advisor parity counters.  Increment only
+     while [Gate_diff_types.typed_advisor_log_enabled ()] is true. *)
+  typed_advisor_allow : int;
+  typed_advisor_reject : int;
+  typed_advisor_cannot_parse : int;
 }
 
 val snapshot : unit -> snapshot

--- a/lib/worker_dev_tools.mli
+++ b/lib/worker_dev_tools.mli
@@ -42,6 +42,14 @@ type block_reason =
     {!Chain_or_redirect}, {!Injection}, etc.). *)
 val block_reason_to_string : block_reason -> string
 
+(** The default dev allowlist (cat, cargo, dune, git, rg, …).  Used by
+    {!validate_command} internally; exposed so RFC-0092 Phase A's
+    typed advisor ({!Shell_ir_validator.advise}) can mirror the legacy
+    gate's allowlist for parity measurement.  Order is the source of
+    truth; do not re-sort without confirming the typed advisor
+    consumers are tolerant. *)
+val dev_allowed_commands : string list
+
 (** Strict (allowlist + no shell metacharacters) validator used by the
     default [shell_exec] tool.  Rejects empty input, chaining, and any
     command outside the dev allowlist (rg / grep / dune / git / ...). *)

--- a/test/dune
+++ b/test/dune
@@ -248,6 +248,7 @@
         test_keeper_typed_labels
         test_shell_ir_typed_review_followup
         test_shell_ir_validator
+        test_typed_advisor_counters
         test_auth_resolve_labels
         test_keeper_classifier_helper
         test_persona_tool_reachability
@@ -495,6 +496,7 @@
           test_keeper_typed_labels
           test_shell_ir_typed_review_followup
           test_shell_ir_validator
+          test_typed_advisor_counters
           test_auth_resolve_labels
           test_keeper_classifier_helper
           test_persona_tool_reachability

--- a/test/test_typed_advisor_counters.ml
+++ b/test/test_typed_advisor_counters.ml
@@ -1,0 +1,142 @@
+(** Tests for RFC-0092 Phase A typed-advisor counter wiring.
+
+    Pins the contract that [Legendary_counters.incr_typed_advisor]
+    routes each [Shell_ir_validator.advisory] variant to the right
+    counter atom and that the snapshot/JSON shape includes the three
+    new fields under stable names operators / dashboards will grep. *)
+
+module L = Masc_mcp.Legendary_counters
+module V = Masc_mcp.Shell_ir_validator
+
+let test_initial_zero () =
+  L.reset ();
+  let s = L.snapshot () in
+  Alcotest.(check int) "typed_advisor_allow" 0 s.typed_advisor_allow;
+  Alcotest.(check int) "typed_advisor_reject" 0 s.typed_advisor_reject;
+  Alcotest.(check int)
+    "typed_advisor_cannot_parse"
+    0
+    s.typed_advisor_cannot_parse
+;;
+
+let test_allow_increments_allow () =
+  L.reset ();
+  L.incr_typed_advisor V.Allow;
+  L.incr_typed_advisor V.Allow;
+  let s = L.snapshot () in
+  Alcotest.(check int) "allow = 2" 2 s.typed_advisor_allow;
+  Alcotest.(check int) "reject = 0" 0 s.typed_advisor_reject;
+  Alcotest.(check int)
+    "cannot_parse = 0"
+    0
+    s.typed_advisor_cannot_parse
+;;
+
+let test_reject_increments_reject () =
+  L.reset ();
+  L.incr_typed_advisor
+    (V.Reject
+       { reason = V.Command_not_in_allowlist "foo"; diagnostic = "foo" });
+  let s = L.snapshot () in
+  Alcotest.(check int) "allow = 0" 0 s.typed_advisor_allow;
+  Alcotest.(check int) "reject = 1" 1 s.typed_advisor_reject;
+  Alcotest.(check int)
+    "cannot_parse = 0"
+    0
+    s.typed_advisor_cannot_parse
+;;
+
+let test_cannot_parse_increments_cannot_parse () =
+  L.reset ();
+  L.incr_typed_advisor (V.Cannot_parse { kind = V.Parse_error });
+  let s = L.snapshot () in
+  Alcotest.(check int)
+    "cannot_parse = 1"
+    1
+    s.typed_advisor_cannot_parse
+;;
+
+let test_reset_clears () =
+  L.incr_typed_advisor V.Allow;
+  L.incr_typed_advisor
+    (V.Reject
+       { reason = V.Command_not_in_allowlist "x"; diagnostic = "x" });
+  L.incr_typed_advisor (V.Cannot_parse { kind = V.Parse_error });
+  L.reset ();
+  let s = L.snapshot () in
+  Alcotest.(check int) "post-reset allow" 0 s.typed_advisor_allow;
+  Alcotest.(check int) "post-reset reject" 0 s.typed_advisor_reject;
+  Alcotest.(check int)
+    "post-reset cannot_parse"
+    0
+    s.typed_advisor_cannot_parse
+;;
+
+let test_json_shape () =
+  (* Operator dashboards / runbook greps depend on these exact field
+     names — pin them. *)
+  L.reset ();
+  L.incr_typed_advisor V.Allow;
+  let json = L.snapshot_to_json (L.snapshot ()) in
+  let s = Yojson.Safe.to_string json in
+  Alcotest.(check bool)
+    "has typed_advisor_allow"
+    true
+    (Astring.String.is_infix ~affix:"\"typed_advisor_allow\":1" s);
+  Alcotest.(check bool)
+    "has typed_advisor_reject"
+    true
+    (Astring.String.is_infix ~affix:"\"typed_advisor_reject\":0" s);
+  Alcotest.(check bool)
+    "has typed_advisor_cannot_parse"
+    true
+    (Astring.String.is_infix
+       ~affix:"\"typed_advisor_cannot_parse\":0"
+       s)
+;;
+
+let test_env_flag_default_off () =
+  (* Flag must be off by default — production observers should not
+     pay any cost until an operator explicitly opts in. *)
+  let prev = Sys.getenv_opt "MASC_BASH_TYPED_ADVISOR" in
+  Unix.putenv "MASC_BASH_TYPED_ADVISOR" "";
+  let off = Masc_mcp.Gate_diff_types.typed_advisor_log_enabled () in
+  Unix.putenv "MASC_BASH_TYPED_ADVISOR" "1";
+  let on = Masc_mcp.Gate_diff_types.typed_advisor_log_enabled () in
+  (match prev with
+   | None -> Unix.putenv "MASC_BASH_TYPED_ADVISOR" ""
+   | Some v -> Unix.putenv "MASC_BASH_TYPED_ADVISOR" v);
+  Alcotest.(check bool) "empty env → off" false off;
+  Alcotest.(check bool) "\"1\" env → on" true on
+;;
+
+let () =
+  Alcotest.run
+    "typed_advisor_counters"
+    [ ( "buckets"
+      , [ Alcotest.test_case "initial zero" `Quick test_initial_zero
+        ; Alcotest.test_case "Allow → allow" `Quick test_allow_increments_allow
+        ; Alcotest.test_case
+            "Reject → reject"
+            `Quick
+            test_reject_increments_reject
+        ; Alcotest.test_case
+            "Cannot_parse → cannot_parse"
+            `Quick
+            test_cannot_parse_increments_cannot_parse
+        ; Alcotest.test_case "reset clears" `Quick test_reset_clears
+        ] )
+    ; ( "json_shape"
+      , [ Alcotest.test_case
+            "three fields under stable names"
+            `Quick
+            test_json_shape
+        ] )
+    ; ( "env_flag"
+      , [ Alcotest.test_case
+            "default off, \"1\" turns on"
+            `Quick
+            test_env_flag_default_off
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

iter13 of `/loop` (user-selected via AskUserQuestion).  **PR-2 of
RFC-0092** stacked on `feature/rfc-0092-pr1-validator-module`
(PR #15708 → RFC-0092 → main).  Stack depth 3.

Wires the typed `Shell_ir_validator.advise` advisor into
`keeper_shell_bash.handle_keeper_bash` **behind the
`MASC_BASH_TYPED_ADVISOR` env flag (default off)**.  When operators
opt in, the advisor runs in parallel to the legacy substring gate,
emits a structured log line, and increments per-bucket counters for
the Phase B parity-measurement window.

**No behavior change** when the flag is off (production default).

## RFC-0092 §4.1 Phase A core

> In `keeper_shell_bash.handle_keeper_bash`, *after* the existing
> `Worker_dev_tools.validate_command` call, run
> `Shell_ir_validator.advise` and emit a structured log line + a
> new counter `Legendary_counters.incr_typed_advisor` partitioned
> by `advisory`.  **No behavior change.** Legacy gate decides; the
> advisor only logs.

This PR implements that paragraph verbatim.

## Changes

- `lib/gate_diff_types.{ml,mli}` — add
  `typed_advisor_log_enabled : unit -> bool` (mirror of the existing
  `shadow_diff_log_enabled` pattern).  Env flag
  `MASC_BASH_TYPED_ADVISOR` with the same truthy values as the
  shadow flag.
- `lib/worker_dev_tools.mli` — expose `dev_allowed_commands : string
  list` so the advisor can mirror the legacy gate's allowlist exactly
  (parity measurement requires identical allowlists; otherwise the
  divergence isn't meaningful).
- `lib/legendary_counters.{ml,mli}` — add 3 atoms
  (`typed_advisor_allow` / `typed_advisor_reject` /
  `typed_advisor_cannot_parse`) + `incr_typed_advisor :
  Shell_ir_validator.advisory -> unit` (exhaustive match).
  Snapshot record + JSON output extended with the 3 fields.
- `lib/keeper/keeper_shell_bash.ml` — flag-gated typed advisor call
  after the existing shadow-diff-log block.  ~17-line addition,
  matches the structure of the adjacent `MASC_BASH_AST_SHADOW_LOG`
  block.
- `test/test_typed_advisor_counters.ml` — 7 new tests.

## Test plan

- [x] `dune build --root . @check` clean.
- [x] `test_typed_advisor_counters.exe` — 7/7 PASS:
      - 4 bucket dispatch tests (initial zero, allow, reject,
        cannot_parse)
      - 1 reset test
      - 1 JSON shape test (operator dashboard / runbook compat)
      - 1 env flag default-off test (production safety)
- [x] `ocamlformat --check` clean (7 files).
- [x] PR-1's `test_shell_ir_validator.exe` 9/9 still PASS (no
      regression in validator surface).

## Workaround-rejection compliance (RFC-0092 §5)

- **Telemetry-as-fix (#1)**: this PR is *measurement* infrastructure.
  Phase A counts; Phase C (separate future PR) flips authority and
  closes the measurement window.  No silent data loss is widened.
- **Cap / cooldown / dedup**: none introduced.

## Stack context

```
main
  └─ rfc/0092-... (#15707)
        └─ feature/rfc-0092-pr1-validator-module (#15708)
              └─ feature/rfc-0092-pr2-bash-wire (THIS)
```

Merge order: #15707 → #15708 → this PR.

RFC-WAIVED: stacked diff inherits parent #15708 which cites RFC-0092 + RFC-0054.  This PR adds `MASC_BASH_TYPED_ADVISOR` flag-gated advisor call in `keeper_shell_bash.ml` — behavior-neutral when flag off (production default).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
