### PR TITLE
fix(board): flush dirty via snapshot rewrite (RFC-0091 impl)

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -483,7 +483,14 @@ let rewrite_reactions store =
   with_persist_lock store (fun () -> save_reactions_jsonl content)
 ;;
 
-(** {1 Append Helpers} *)
+(** {1 Append Helpers}
+
+    RFC-0091: [append_post] / [append_comment] are *create-only fast paths*.
+    Callers must guarantee the post/comment has never been written before
+    (the create flow in this module satisfies that via the [Dedup_hit] check
+    above). Mutation/vote flushes MUST go through [save_jsonl_snapshot] in
+    [board_votes.flush_dirty], not these helpers — otherwise the JSONL grows
+    one line per mutation per id (the dup vector RFC-0091 closes). *)
 
 let append_post (p : post) =
   try

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -883,33 +883,21 @@ let reset_global_for_test () =
     load_persisted_sub_boards store;
     store)
 
-(** Flush any dirty state to disk. Call on shutdown to prevent data loss. *)
+(** Flush any dirty state to disk. Call on shutdown to prevent data loss.
+
+    RFC-0091 (board persistence path unification): mutation/vote flushes
+    write a full snapshot via [save_jsonl_snapshot] instead of replaying
+    the dirty list through [append_post]/[append_comment]. The previous
+    [List.iter append_post posts] grew [board_posts.jsonl] by one line per
+    vote/mutation per post, sharing the same .id, producing the dup vector
+    that motivated the RFC. The snapshot path was already canonical for
+    restart-load ([load_persisted_posts]), so promoting it to the
+    flush-write path makes [board_posts.jsonl] a true snapshot file with
+    one line per id and atomic rewrite semantics. *)
 let flush_dirty store =
-  let posts, comments, vote_log =
+  let had_dirty, vote_log =
     with_lock store (fun () ->
       let had_dirty = store.dirty_posts || store.dirty_comments in
-      let posts =
-        if store.dirty_posts then
-          Hashtbl.fold
-            (fun post_id () acc ->
-              match Hashtbl.find_opt store.posts post_id with
-              | Some post -> post :: acc
-              | None -> acc)
-            store.dirty_post_ids []
-        else
-          []
-      in
-      let comments =
-        if store.dirty_comments then
-          Hashtbl.fold
-            (fun comment_id () acc ->
-              match Hashtbl.find_opt store.comments comment_id with
-              | Some comment -> comment :: acc
-              | None -> acc)
-            store.dirty_comment_ids []
-        else
-          []
-      in
       Hashtbl.clear store.dirty_post_ids;
       Hashtbl.clear store.dirty_comment_ids;
       store.dirty_posts <- false;
@@ -918,11 +906,19 @@ let flush_dirty store =
       let vote_log =
         if had_dirty then Some (vote_log_jsonl store) else None
       in
-      (posts, comments, vote_log))
+      (had_dirty, vote_log))
   in
   with_persist_lock store (fun () ->
-      List.iter append_post posts;
-      List.iter append_comment comments;
+      if had_dirty then begin
+        let posts_jsonl = with_lock store (fun () -> posts_jsonl_snapshot store) in
+        let comments_jsonl =
+          with_lock store (fun () -> comments_jsonl_snapshot store)
+        in
+        save_jsonl_snapshot ~where:"flush_posts"
+          ~path:(persist_path ()) posts_jsonl;
+        save_jsonl_snapshot ~where:"flush_comments"
+          ~path:(comments_path ()) comments_jsonl
+      end;
       Option.iter save_vote_log_jsonl vote_log)
 
 


### PR DESCRIPTION
# fix(board): flush dirty via snapshot rewrite — RFC-0091 implementation

## What

Implements **RFC-0091** (board persistence path unification, PR #15705 Draft).

Single behavioral change: in `lib/board_votes.ml` `flush_dirty`, replace the
append-per-mutation path (`List.iter append_post posts` / `List.iter
append_comment comments`) with a full snapshot rewrite via
`save_jsonl_snapshot`. The snapshot path is already canonical for restart-load
(`load_persisted_posts` at `board_votes.ml:863, 878`) and was already used by
`rewrite_posts` at `board_votes.ml:848-851`. This commit promotes it to the
flush-write path as well.

## Why

`board_posts.jsonl` was growing by one line per vote/mutation per post,
sharing the same `.id`. Measured 2026-05-17 04:23:

- Full file: 208 lines / 180 unique ids = **13.46% dup ratio**.
- Last 100 posts: 13 unique ids with duplication up to **5×**.

Root cause (RFC-0091 §Root cause): two persistence paths existed for
`board_posts.jsonl` and no decision recorded for which is canonical. The
content-dedup at `board_core.ml:640-714` (`Dedup_hit`) only guarded the create
path; mutation/vote flushes bypassed it.

## Scope (gated on #15705)

- This PR is **Draft until #15705 (RFC) merges**. The RFC defines the
  contract; this PR is the 1-line behavioral switch the RFC §Recommendation
  Option D calls for.
- `vote_log` emission unchanged — `vote_log` is a genuine event log, not a
  snapshot; RFC-0091 scope excludes it.
- `append_post` / `append_comment` in `board_core.ml` are now documented as
  create-only fast paths (new docstring at `board_core.ml:486`).
  No call-site changes outside `flush_dirty`.

## Diff size

```
 lib/board_core.ml  |  9 ++++++++-
 lib/board_votes.ml | 50 +++++++++++++++++++++++---------------------------
 2 files changed, 31 insertions(+), 28 deletions(-)
```

## Build / Test

- `dune build lib/` clean.
- Snapshot helpers (`posts_jsonl_snapshot`, `comments_jsonl_snapshot`,
  `save_jsonl_snapshot`) already production-tested via `rewrite_posts` path.

## Follow-ups (out of scope)

- Optional one-shot historical cleanup behind `MASC_BOARD_DEDUP_ON_LOAD`
  flag — deferred per RFC-0091 §Follow-up.
- Read-side defensive dedup cleanup — later, not blocking.

## Workaround rejection bar (self-check)

- [x] Not telemetry-as-fix — actually changes write path
- [x] Not string/substring classifier
- [x] Not N-of-M — single canonical flush call site, fully closed
- [x] No catch-all
- [x] No cap/cooldown/dedup/repair — promotes existing canonical snapshot path,
      no new buffer

## Evidence

- Code: `lib/board_core.ml:486-496`, `lib/board_votes.ml:885-921`.
- Data: `~/me/.masc/board_posts.jsonl` 2026-05-17 04:23 measurement.
- Spec: `docs/rfc/RFC-0091-board-persistence-path-unification.md` (PR #15705).
- Prior analysis: `~/me/knowledge/research/2026-05-16-masc-board-repetition-taxonomy.md`.

Depends on #15705.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
