### PR TITLE
feat(shell_ir_validator): cannot_parse + reject sub-tag helpers (RFC-0092 dashboard prep)

### DIFF
--- a/lib/shell_ir_validator.ml
+++ b/lib/shell_ir_validator.ml
@@ -19,6 +19,29 @@ let advisory_tag = function
   | Reject _ -> "reject"
   | Cannot_parse _ -> "cannot_parse"
 
+let cannot_parse_kind_tag = function
+  | Parse_error -> "parse_error"
+  | Parse_aborted `Timeout_50ms -> "timeout"
+  | Parse_aborted `Depth_limit -> "depth_limit"
+  | Parse_aborted `Token_limit_50k -> "token_limit"
+  | Too_complex `Heredoc -> "heredoc"
+  | Too_complex `Here_string -> "here_string"
+  | Too_complex `Cmd_subst -> "cmd_subst"
+  | Too_complex `Proc_subst -> "proc_subst"
+  | Too_complex `Subshell -> "subshell"
+  | Too_complex `Arith_expansion -> "arith_expansion"
+  | Too_complex `Control_flow -> "control_flow"
+  | Too_complex `Logic_op -> "logic_op"
+  | Too_complex `Function_def -> "function_def"
+  | Too_complex `Glob_brace -> "glob_brace"
+  | Too_complex `Background -> "background"
+  | Too_complex `Redirect -> "redirect"
+  | Too_complex (`Unknown_construct _) -> "other"
+
+let reject_reason_tag = function
+  | Command_not_in_allowlist _ -> "command"
+  | Pipeline_segment_disallowed _ -> "pipeline_segment"
+
 let bin_in_allowlist ~allowlist (bin : Masc_exec.Bin.t) : bool =
   let name = Masc_exec.Bin.to_string bin in
   List.exists (String.equal name) allowlist

--- a/lib/shell_ir_validator.mli
+++ b/lib/shell_ir_validator.mli
@@ -59,3 +59,47 @@ val advisory_tag : advisory -> string
     [Allow -> "allow"], [Reject _ -> "reject"],
     [Cannot_parse _ -> "cannot_parse"].  Pin the wording — future
     dashboard rules grep on these literals. *)
+
+val cannot_parse_kind_tag : cannot_parse_kind -> string
+(** Stable snake_case sub-tag for the [Cannot_parse] arm.  Pinned
+    1:1 to the [too_complex_*] / [parse_*] field names in
+    {!Legendary_counters.snapshot} so a dashboard histogram of
+    typed-advisor bailouts can grep the same literals already used
+    by the substring-gate shadow counters:
+
+    {ul
+      {- [Parse_error -> "parse_error"]}
+      {- [Parse_aborted `Timeout_50ms -> "timeout"]}
+      {- [Parse_aborted `Depth_limit -> "depth_limit"]}
+      {- [Parse_aborted `Token_limit_50k -> "token_limit"]}
+      {- [Too_complex `Heredoc -> "heredoc"]}
+      {- [Too_complex `Here_string -> "here_string"]}
+      {- [Too_complex `Cmd_subst -> "cmd_subst"]}
+      {- [Too_complex `Proc_subst -> "proc_subst"]}
+      {- [Too_complex `Subshell -> "subshell"]}
+      {- [Too_complex `Arith_expansion -> "arith_expansion"]}
+      {- [Too_complex `Control_flow -> "control_flow"]}
+      {- [Too_complex `Logic_op -> "logic_op"]}
+      {- [Too_complex `Function_def -> "function_def"]}
+      {- [Too_complex `Glob_brace -> "glob_brace"]}
+      {- [Too_complex `Background -> "background"]}
+      {- [Too_complex `Redirect -> "redirect"]}
+      {- [Too_complex (`Unknown_construct _) -> "other"]}
+    }
+
+    Adding a new variant in {!Masc_exec.Parsed.reason_too_complex}
+    or [reason_aborted] forces an exhaustive-match update here at
+    compile time — the catch-all sits only on the
+    [`Unknown_construct] arm where the substring payload is already
+    free-form and not stable. *)
+
+val reject_reason_tag : reject_reason -> string
+(** Stable snake_case sub-tag for the [Reject] arm: pinpoints
+    whether the reject came from a single command or a pipeline
+    segment without leaking the offending binary name into the
+    metric label.  Pinned values:
+
+    {ul
+      {- [Command_not_in_allowlist _ -> "command"]}
+      {- [Pipeline_segment_disallowed _ -> "pipeline_segment"]}
+    } *)

--- a/test/test_shell_ir_validator.ml
+++ b/test/test_shell_ir_validator.ml
@@ -88,6 +88,72 @@ let test_advisory_tag_stable () =
     (V.advisory_tag (V.Cannot_parse { kind = V.Parse_error }))
 ;;
 
+let test_cannot_parse_kind_tag_pinned () =
+  (* Pin every wording: dashboards greppable on these literals.  Any
+     new variant added to Parsed.reason_too_complex / reason_aborted
+     forces an exhaustive-match update in cannot_parse_kind_tag so
+     this test does not have to enumerate the new arm to catch the
+     regression — the compile-time failure does. *)
+  let cases =
+    [ "parse_error", V.Parse_error
+    ; "timeout", V.Parse_aborted `Timeout_50ms
+    ; "depth_limit", V.Parse_aborted `Depth_limit
+    ; "token_limit", V.Parse_aborted `Token_limit_50k
+    ; "heredoc", V.Too_complex `Heredoc
+    ; "here_string", V.Too_complex `Here_string
+    ; "cmd_subst", V.Too_complex `Cmd_subst
+    ; "proc_subst", V.Too_complex `Proc_subst
+    ; "subshell", V.Too_complex `Subshell
+    ; "arith_expansion", V.Too_complex `Arith_expansion
+    ; "control_flow", V.Too_complex `Control_flow
+    ; "logic_op", V.Too_complex `Logic_op
+    ; "function_def", V.Too_complex `Function_def
+    ; "glob_brace", V.Too_complex `Glob_brace
+    ; "background", V.Too_complex `Background
+    ; "redirect", V.Too_complex `Redirect
+    ; "other", V.Too_complex (`Unknown_construct "future_thing")
+    ]
+  in
+  List.iter
+    (fun (expected, kind) ->
+      Alcotest.(check string)
+        (Printf.sprintf "%s tag" expected)
+        expected
+        (V.cannot_parse_kind_tag kind))
+    cases
+;;
+
+let test_reject_reason_tag_pinned () =
+  Alcotest.(check string)
+    "command tag"
+    "command"
+    (V.reject_reason_tag (V.Command_not_in_allowlist "x"));
+  Alcotest.(check string)
+    "pipeline_segment tag"
+    "pipeline_segment"
+    (V.reject_reason_tag (V.Pipeline_segment_disallowed "x"))
+;;
+
+let test_sub_tag_constant_under_binary_variation () =
+  (* Reject-reason sub-tag must be CONSTANT across different
+     offending binaries — the metric label is a fixed bucket name,
+     not a per-command string.  Pin by computing the tag for two
+     distinct bin names and asserting equality (plus equality to the
+     pinned literal). *)
+  let a = V.reject_reason_tag (V.Command_not_in_allowlist "rm") in
+  let b = V.reject_reason_tag (V.Command_not_in_allowlist "curl") in
+  Alcotest.(check string) "command tag a = pinned" "command" a;
+  Alcotest.(check string) "command tag b = pinned" "command" b;
+  let p1 =
+    V.reject_reason_tag (V.Pipeline_segment_disallowed "rm")
+  in
+  let p2 =
+    V.reject_reason_tag (V.Pipeline_segment_disallowed "curl")
+  in
+  Alcotest.(check string) "pipeline tag p1 = pinned" "pipeline_segment" p1;
+  Alcotest.(check string) "pipeline tag p2 = pinned" "pipeline_segment" p2
+;;
+
 let test_empty_allowlist_rejects_known_bin () =
   (* Empty allowlist must reject any simple command — the allowlist is
      the only allow source; an empty list means deny all. *)
@@ -137,5 +203,19 @@ let () =
     ; ( "advisory_tag"
       , [ Alcotest.test_case "stable wording" `Quick test_advisory_tag_stable ]
       )
+    ; ( "sub_tags"
+      , [ Alcotest.test_case
+            "cannot_parse_kind_tag pinned"
+            `Quick
+            test_cannot_parse_kind_tag_pinned
+        ; Alcotest.test_case
+            "reject_reason_tag pinned"
+            `Quick
+            test_reject_reason_tag_pinned
+        ; Alcotest.test_case
+            "sub tag constant under binary variation"
+            `Quick
+            test_sub_tag_constant_under_binary_variation
+        ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

`Shell_ir_validator`에 두 개의 stable snake_case sub-tag helper 추가:

- `cannot_parse_kind_tag : cannot_parse_kind -> string` — `Cannot_parse` 안의 17 variant (Parse_error / Parse_aborted x3 / Too_complex x13)을 dashboard greppable한 snake_case literal로 매핑. wording은 `Legendary_counters.snapshot`의 기존 `too_complex_*` / `parse_*` field 이름과 1:1 정합.
- `reject_reason_tag : reject_reason -> string` — `Reject` 안에서 single command vs pipeline segment 구별. metric label cardinality를 offending binary name에 의존하지 않도록 고정.

RFC-0092 dashboard histogram(향후 PR-3)의 building block. PR-2/PR-3와 의존성 없음 — 순수 additive surface.

## Why these helpers

Caller-side에서 `match` 반복으로 sub-tag을 뽑으면:
1. dashboard / route / log emitter마다 같은 case split 중복
2. `Parsed.reason_too_complex`에 새 variant 추가 시 모든 caller가 silent breakage (catch-all `_ -> "other"` 형태로 회피하기 쉬움)

모듈로 흡수하면 exhaustive-match를 single source에 묶음. 새 variant 추가 시 `cannot_parse_kind_tag`만 컴파일 에러로 알림.

## Stable wording (pin)

`cannot_parse_kind_tag`:
- `Parse_error` → `parse_error`
- `Parse_aborted` `Timeout_50ms / Depth_limit / Token_limit_50k` → `timeout / depth_limit / token_limit`
- `Too_complex` (13 known): `heredoc, here_string, cmd_subst, proc_subst, subshell, arith_expansion, control_flow, logic_op, function_def, glob_brace, background, redirect`
- `Too_complex (`Unknown_construct _)` → `other`

`reject_reason_tag`:
- `Command_not_in_allowlist _` → `command`
- `Pipeline_segment_disallowed _` → `pipeline_segment`

## Test plan

- [x] `dune build --root . @check` clean
- [x] `dune exec test/test_shell_ir_validator.exe` — 12/12 PASS (기존 9 + 신규 3)
- [x] `ocamlformat --check` clean

신규 테스트:
- `cannot_parse_kind_tag pinned` — 17 wording 전부 literal 비교
- `reject_reason_tag pinned` — 2 wording literal 비교
- `sub tag constant under binary variation` — bin name 변경해도 tag literal 불변

RFC-WAIVED: 순수 additive helper (Shell_ir_validator 모듈 내). keeper_sandbox / credential / dashboard 영역 미변경. RFC-0092 의 dashboard 단계 (§7 PR-3) building block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
