### PR TITLE
fix(keeper): preserve success model attribution

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -65,6 +65,14 @@ let provider_attempt_provenance_fields p =
   | Some source_cascade ->
       ("provider_source_cascade", `String source_cascade) :: base
 
+let success_selected_model_raw candidate =
+  Some (Cascade_runtime_candidate.model_health_key candidate)
+
+(* Error/rejected/exhausted observations intentionally leave the concrete
+   selected model absent. Downstream attribution uses candidate_models or the
+   cascade route for those outcomes. *)
+let error_selected_model_raw = None
+
 let health_error_kind label =
   Cascade_health_tracker.error_kind_of_string label
 
@@ -655,7 +663,7 @@ let run_named
         Cascade_legacy_runner.cascade_observation_with_metrics
           ~cascade_name:error_cascade_name
           ?strategy:!cascade_strategy_name_ref ~configured_labels
-          ~candidate_count ~selected_model_raw:None ~capture ()
+          ~candidate_count ~selected_model_raw:error_selected_model_raw ~capture ()
       in
       Cascade_legacy_runner.record_cascade ~keeper_name
         ~cascade_name:error_cascade_name
@@ -896,9 +904,7 @@ let run_named
           Cascade_legacy_runner.cascade_observation_with_metrics
             ~cascade_name:error_cascade_name
             ?strategy:!cascade_strategy_name_ref ~configured_labels
-            ~candidate_count
-            ~selected_model_raw:
-              (Some (Cascade_runtime_candidate.model_health_key candidate))
+            ~candidate_count ~selected_model_raw:(success_selected_model_raw candidate)
             ~capture ()
         in
         let result = { result with cascade_observation = Some observation } in
@@ -929,9 +935,7 @@ let run_named
              Cascade_legacy_runner.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
-               ~candidate_count
-               ~selected_model_raw:
-                 (Some (Cascade_runtime_candidate.model_health_key candidate))
+               ~candidate_count ~selected_model_raw:(success_selected_model_raw candidate)
                ~capture ()
            in
            let result = { result with cascade_observation = Some observation } in
@@ -958,7 +962,7 @@ let run_named
              Cascade_legacy_runner.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
-               ~candidate_count ~selected_model_raw:None
+               ~candidate_count ~selected_model_raw:error_selected_model_raw
                ~capture ()
            in
            Cascade_legacy_runner.record_cascade ~keeper_name
@@ -988,7 +992,8 @@ let run_named
              Cascade_legacy_runner.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
-               ~candidate_count ~selected_model_raw:None ~capture ()
+               ~candidate_count ~selected_model_raw:(success_selected_model_raw candidate)
+               ~capture ()
            in
            let result = { result with cascade_observation = Some observation } in
            Cascade_legacy_runner.record_cascade ~keeper_name
@@ -1117,7 +1122,7 @@ let run_named
                 Cascade_legacy_runner.cascade_observation_with_metrics
                   ~cascade_name:error_cascade_name
                   ?strategy:!cascade_strategy_name_ref ~configured_labels
-                  ~candidate_count ~selected_model_raw:None ~capture ()
+                  ~candidate_count ~selected_model_raw:error_selected_model_raw ~capture ()
               in
               Cascade_legacy_runner.record_cascade ~keeper_name
                 ~cascade_name:error_cascade_name
@@ -1139,7 +1144,7 @@ let run_named
              Cascade_legacy_runner.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
-               ~candidate_count ~selected_model_raw:None ~capture ()
+               ~candidate_count ~selected_model_raw:error_selected_model_raw ~capture ()
            in
            Cascade_legacy_runner.record_cascade ~keeper_name
              ~cascade_name:error_cascade_name
@@ -1199,7 +1204,7 @@ let run_named
       Cascade_legacy_runner.cascade_observation_with_metrics
         ~cascade_name:error_cascade_name
         ?strategy:!cascade_strategy_name_ref ~configured_labels
-        ~candidate_count ~selected_model_raw:None ~capture ()
+        ~candidate_count ~selected_model_raw:error_selected_model_raw ~capture ()
     in
     Cascade_legacy_runner.record_cascade ~keeper_name
       ~cascade_name:error_cascade_name
@@ -1282,4 +1287,5 @@ module For_testing = struct
   let checkpoint_after_attempt = checkpoint_after_attempt
   let missing_required_tool_names_after_lane_by_name =
     missing_required_tool_names_after_lane_by_name
+  let success_selected_model_raw = success_selected_model_raw
 end

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -218,4 +218,6 @@ module For_testing : sig
     required_tool_names:string list ->
     materialized_tool_names:string list ->
     string list
+
+  val success_selected_model_raw : Cascade_runtime_candidate.t -> string option
 end

--- a/test/dune
+++ b/test/dune
@@ -1799,3 +1799,8 @@
  (name test_rfc_0085_pr9_base_path_opt_purge)
  (modules test_rfc_0085_pr9_base_path_opt_purge)
  (libraries alcotest ast_grep))
+
+(test
+ (name test_success_model_attribution)
+ (modules test_success_model_attribution)
+ (libraries masc_test_deps))

--- a/test/test_success_model_attribution.ml
+++ b/test/test_success_model_attribution.ml
@@ -1,0 +1,103 @@
+open Alcotest
+
+module Candidate = Masc_mcp.Cascade_runtime_candidate
+module Driver = Masc_mcp.Keeper_turn_driver
+module Provider_config = Llm_provider.Provider_config
+
+let make_candidate () =
+  Provider_config.make
+    ~kind:Provider_config.OpenAI_compat
+    ~model_id:"qwen3.6-27b"
+    ~base_url:"https://example.invalid/v1"
+    ()
+  |> Candidate.of_provider_config
+
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0
+  then true
+  else (
+    let last = haystack_len - needle_len in
+    let rec loop idx =
+      idx <= last
+      && (String.equal (String.sub haystack idx needle_len) needle
+          || loop (idx + 1))
+    in
+    loop 0)
+
+let substring_index_opt haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0
+  then Some 0
+  else (
+    let last = haystack_len - needle_len in
+    let rec loop idx =
+      if idx > last
+      then None
+      else if String.equal (String.sub haystack idx needle_len) needle
+      then Some idx
+      else loop (idx + 1)
+    in
+    loop 0)
+
+let repo_root () =
+  let rec climb dir depth =
+    if depth > 8
+    then dir
+    else if Sys.file_exists (Filename.concat dir "lib")
+            && Sys.file_exists (Filename.concat dir "dune-project")
+    then dir
+    else climb (Filename.dirname dir) (depth + 1)
+  in
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root -> root
+  | None -> climb (Sys.getcwd ()) 0
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> In_channel.input_all ic)
+
+let test_success_helper_uses_model_health_key () =
+  let candidate = make_candidate () in
+  check
+    (option string)
+    "success attribution"
+    (Some (Candidate.model_health_key candidate))
+    (Driver.For_testing.success_selected_model_raw candidate)
+
+let test_unexpected_accept_branch_is_success_attributed () =
+  let source =
+    read_file (Filename.concat (repo_root ()) "lib/keeper/keeper_turn_driver.ml")
+  in
+  let branch_marker = "| Cascade_fsm.Accept _resp ->" in
+  let branch =
+    match substring_index_opt source branch_marker with
+    | None -> fail "missing Accept branch marker"
+    | Some idx ->
+      String.sub source idx (min 1800 (String.length source - idx))
+  in
+  check bool "branch marker present" true (contains_substring branch branch_marker);
+  check
+    bool
+    "unexpected Accept branch preserves candidate model attribution"
+    true
+    (contains_substring branch "success_selected_model_raw candidate")
+
+let () =
+  Alcotest.run
+    "success_model_attribution"
+    [ ( "keeper_turn_driver"
+      , [ test_case
+            "success helper returns model health key"
+            `Quick
+            test_success_helper_uses_model_health_key
+        ; test_case
+            "unexpected Accept success branch keeps selected model"
+            `Quick
+            test_unexpected_accept_branch_is_success_attributed
+        ] )
+    ]


### PR DESCRIPTION
## Summary

- preserve concrete model attribution for the unexpected `Accept` success branch in `Keeper_turn_driver`
- name the intentional error/rejected/exhausted `selected_model_raw=None` path so it is no longer an ambiguous N-of-M gap
- add a focused regression that pins success attribution to the candidate model health key

Refs #15530

## Validation

- `git diff --check origin/main...HEAD`
- `opam exec -- ocamlformat --check lib/keeper/keeper_turn_driver.ml lib/keeper/keeper_turn_driver.mli test/test_success_model_attribution.ml`
- `bash scripts/check-release-train-guard.sh --base origin/main --head HEAD`
- `env MASC_SKIP_PIN_CHECK=1 DUNE_LOCAL_JOBS=1 OCAMLPARAM=_,warn-error=-23 scripts/dune-local.sh build test/test_success_model_attribution.exe test/test_model_inference_metrics.exe`
- `env OCAMLPARAM=_,warn-error=-23 _build/default/test/test_success_model_attribution.exe`
- `env OCAMLPARAM=_,warn-error=-23 _build/default/test/test_model_inference_metrics.exe`
