### PR TITLE
feat(keeper-shell): wire Shell_ir_validator advisor flag-gated (RFC-0092 PR-2, supersedes #15710)

### DIFF
--- a/lib/gate_diff_types.ml
+++ b/lib/gate_diff_types.ml
@@ -187,3 +187,11 @@ let shadow_diff_log_enabled () =
   match Sys.getenv_opt "MASC_BASH_AST_SHADOW_LOG" with
   | Some ("1" | "true" | "TRUE" | "yes" | "on" | "log") -> true
   | _ -> false
+
+(* RFC-0092 Phase A advisor — typed parallel-validation log gate.
+   Default off; operator opt-in for the parity-measurement window
+   before the authority flip in Phase C. *)
+let typed_advisor_log_enabled () =
+  match Sys.getenv_opt "MASC_BASH_TYPED_ADVISOR" with
+  | Some ("1" | "true" | "TRUE" | "yes" | "on" | "log") -> true
+  | _ -> false

--- a/lib/gate_diff_types.mli
+++ b/lib/gate_diff_types.mli
@@ -183,3 +183,12 @@ val shadow_diff_log_enabled : unit -> bool
     of the documented truthy values: [1], [true], [TRUE], [yes],
     [on], [log].  Any other value (including unset) returns
     [false] — the gate logs nothing by default. *)
+
+val typed_advisor_log_enabled : unit -> bool
+(** RFC-0092 Phase A advisor opt-in.  Returns [true] iff the
+    [MASC_BASH_TYPED_ADVISOR] environment variable is set to one of
+    the documented truthy values: [1], [true], [TRUE], [yes], [on],
+    [log].  Default off — the typed-validation parity-measurement
+    counters do not increment until an operator opts in.  Phase C
+    will flip authority via a separate [MASC_BASH_TYPED_AUTHORITY]
+    flag in a follow-up PR. *)

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -546,6 +546,24 @@ let handle_keeper_bash
             (Worker_dev_tools.legacy_verdict_to_tag legacy)
             (Worker_dev_tools.shadow_verdict_to_tag shadow))
      end);
+    (* RFC-0092 Phase A — typed-validation advisor (behavior-neutral).
+       Flag-gated; emits a structured log line + per-bucket counter so
+       operators can measure parity vs the legacy substring gate
+       before the Phase C authority flip.  No allow/deny decision is
+       driven from the typed path at this stage. *)
+    (if Worker_dev_tools.typed_advisor_log_enabled () then begin
+       let advisory =
+         Shell_ir_validator.advise
+           ~cmd
+           ~allowlist:Worker_dev_tools.dev_allowed_commands
+       in
+       Legendary_counters.incr_typed_advisor advisory;
+       Log.Keeper.info
+         "typed_advisor keeper=%s cmd_hash=%s outcome=%s"
+         meta.name
+         (Worker_dev_tools.cmd_hash_for_log cmd)
+         (Shell_ir_validator.advisory_tag advisory)
+     end);
     (* Resolve cwd early — needed for playground detection before validation. *)
     match Keeper_shell_shared.resolve_keeper_shell_write_cwd ~config ~meta ~args with
     | Error e -> error_json e

--- a/lib/legendary_counters.ml
+++ b/lib/legendary_counters.ml
@@ -29,6 +29,15 @@ let too_complex_parse_error = Atomic.make 0
 let too_complex_parse_aborted = Atomic.make 0
 let too_complex_other = Atomic.make 0
 
+(* RFC-0092 Phase A typed-advisor parity counters.  Increment only
+   while [Gate_diff_types.typed_advisor_log_enabled ()] is true.
+   Three buckets mirror the [Shell_ir_validator.advisory] sum
+   exhaustively so a future variant is a compile error in
+   [incr_typed_advisor]. *)
+let typed_advisor_allow = Atomic.make 0
+let typed_advisor_reject = Atomic.make 0
+let typed_advisor_cannot_parse = Atomic.make 0
+
 let incr a = ignore (Atomic.fetch_and_add a 1)
 
 let incr_gate_diff (diff : Gate_diff_types.gate_diff) =
@@ -83,6 +92,15 @@ let incr_too_complex_parse_error () = incr too_complex_parse_error
 let incr_too_complex_parse_aborted (_r : Masc_exec.Parsed.reason_aborted) =
   incr too_complex_parse_aborted
 
+(* RFC-0092 Phase A typed-advisor parity dispatch.  Exhaustive over
+   [Shell_ir_validator.advisory]; a new variant in the validator
+   forces an update here at compile time. *)
+let incr_typed_advisor (a : Shell_ir_validator.advisory) =
+  match a with
+  | Shell_ir_validator.Allow -> incr typed_advisor_allow
+  | Shell_ir_validator.Reject _ -> incr typed_advisor_reject
+  | Shell_ir_validator.Cannot_parse _ -> incr typed_advisor_cannot_parse
+
 let reset () =
   Atomic.set gate_diff_total 0;
   Atomic.set gate_diff_agree 0;
@@ -111,7 +129,10 @@ let reset () =
   Atomic.set gh_exit_type_mismatch 0;
   Atomic.set gh_exit_auth_failed 0;
   Atomic.set gh_exit_network 0;
-  Atomic.set gh_exit_unknown 0
+  Atomic.set gh_exit_unknown 0;
+  Atomic.set typed_advisor_allow 0;
+  Atomic.set typed_advisor_reject 0;
+  Atomic.set typed_advisor_cannot_parse 0
 
 type snapshot = {
   gate_diff_total : int;
@@ -142,6 +163,11 @@ type snapshot = {
   gh_exit_auth_failed : int;
   gh_exit_network : int;
   gh_exit_unknown : int;
+  (* RFC-0092 Phase A typed-advisor parity counters.  Increment only
+     while [Gate_diff_types.typed_advisor_log_enabled ()] is true. *)
+  typed_advisor_allow : int;
+  typed_advisor_reject : int;
+  typed_advisor_cannot_parse : int;
 }
 
 let snapshot () =
@@ -177,6 +203,9 @@ let snapshot () =
     gh_exit_auth_failed = Atomic.get gh_exit_auth_failed;
     gh_exit_network = Atomic.get gh_exit_network;
     gh_exit_unknown = Atomic.get gh_exit_unknown;
+    typed_advisor_allow = Atomic.get typed_advisor_allow;
+    typed_advisor_reject = Atomic.get typed_advisor_reject;
+    typed_advisor_cannot_parse = Atomic.get typed_advisor_cannot_parse;
   }
 
 let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
@@ -212,6 +241,9 @@ let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
     ("gh_exit_auth_failed", `Int s.gh_exit_auth_failed);
     ("gh_exit_network", `Int s.gh_exit_network);
     ("gh_exit_unknown", `Int s.gh_exit_unknown);
+    ("typed_advisor_allow", `Int s.typed_advisor_allow);
+    ("typed_advisor_reject", `Int s.typed_advisor_reject);
+    ("typed_advisor_cannot_parse", `Int s.typed_advisor_cannot_parse);
   ]
 
 let safe_ratio ~num ~den =

--- a/lib/legendary_counters.mli
+++ b/lib/legendary_counters.mli
@@ -60,6 +60,15 @@ val incr_too_complex_parse_aborted : Masc_exec.Parsed.reason_aborted -> unit
     into [too_complex_parse_aborted]; per-reason breakdown would be a
     separate metric-rename PR. *)
 
+val incr_typed_advisor : Shell_ir_validator.advisory -> unit
+(** RFC-0092 Phase A — record one typed-advisor outcome under its
+    bucket ([typed_advisor_allow] / [typed_advisor_reject] /
+    [typed_advisor_cannot_parse]).  Exhaustive over
+    [Shell_ir_validator.advisory]; a new variant in the validator
+    forces an update here at compile time.  Increment only while
+    [Gate_diff_types.typed_advisor_log_enabled ()] is true so an
+    operator running with the flag off pays zero cost. *)
+
 val reset : unit -> unit
 (** Zero every counter.  Used by tests; operators should not rely on
     this surface. *)
@@ -103,6 +112,11 @@ type snapshot = {
   gh_exit_auth_failed : int;
   gh_exit_network : int;
   gh_exit_unknown : int;
+  (* RFC-0092 Phase A typed-advisor parity counters.  Increment only
+     while [Gate_diff_types.typed_advisor_log_enabled ()] is true. *)
+  typed_advisor_allow : int;
+  typed_advisor_reject : int;
+  typed_advisor_cannot_parse : int;
 }
 
 val snapshot : unit -> snapshot

--- a/lib/worker_dev_tools.mli
+++ b/lib/worker_dev_tools.mli
@@ -49,6 +49,14 @@ val block_reason_to_string_with_allowlist :
     passes a narrower allowlist than {!validate_command_coding}; otherwise
     the generic hint can name commands that the caller still rejects. *)
 
+(** The default dev allowlist (cat, cargo, dune, git, rg, …).  Used by
+    {!validate_command} internally; exposed so RFC-0092 Phase A's
+    typed advisor ({!Shell_ir_validator.advise}) can mirror the legacy
+    gate's allowlist for parity measurement.  Order is the source of
+    truth; do not re-sort without confirming the typed advisor
+    consumers are tolerant. *)
+val dev_allowed_commands : string list
+
 (** Strict (allowlist + no shell metacharacters) validator used by the
     default [shell_exec] tool.  Rejects empty input, chaining, and any
     command outside the dev allowlist (rg / grep / dune / git / ...). *)

--- a/test/dune
+++ b/test/dune
@@ -248,6 +248,7 @@
         test_keeper_typed_labels
         test_shell_ir_typed_review_followup
         test_shell_ir_validator
+        test_typed_advisor_counters
         test_auth_resolve_labels
         test_keeper_classifier_helper
         test_persona_tool_reachability
@@ -495,6 +496,7 @@
           test_keeper_typed_labels
           test_shell_ir_typed_review_followup
           test_shell_ir_validator
+          test_typed_advisor_counters
           test_auth_resolve_labels
           test_keeper_classifier_helper
           test_persona_tool_reachability

--- a/test/test_typed_advisor_counters.ml
+++ b/test/test_typed_advisor_counters.ml
@@ -1,0 +1,142 @@
+(** Tests for RFC-0092 Phase A typed-advisor counter wiring.
+
+    Pins the contract that [Legendary_counters.incr_typed_advisor]
+    routes each [Shell_ir_validator.advisory] variant to the right
+    counter atom and that the snapshot/JSON shape includes the three
+    new fields under stable names operators / dashboards will grep. *)
+
+module L = Masc_mcp.Legendary_counters
+module V = Masc_mcp.Shell_ir_validator
+
+let test_initial_zero () =
+  L.reset ();
+  let s = L.snapshot () in
+  Alcotest.(check int) "typed_advisor_allow" 0 s.typed_advisor_allow;
+  Alcotest.(check int) "typed_advisor_reject" 0 s.typed_advisor_reject;
+  Alcotest.(check int)
+    "typed_advisor_cannot_parse"
+    0
+    s.typed_advisor_cannot_parse
+;;
+
+let test_allow_increments_allow () =
+  L.reset ();
+  L.incr_typed_advisor V.Allow;
+  L.incr_typed_advisor V.Allow;
+  let s = L.snapshot () in
+  Alcotest.(check int) "allow = 2" 2 s.typed_advisor_allow;
+  Alcotest.(check int) "reject = 0" 0 s.typed_advisor_reject;
+  Alcotest.(check int)
+    "cannot_parse = 0"
+    0
+    s.typed_advisor_cannot_parse
+;;
+
+let test_reject_increments_reject () =
+  L.reset ();
+  L.incr_typed_advisor
+    (V.Reject
+       { reason = V.Command_not_in_allowlist "foo"; diagnostic = "foo" });
+  let s = L.snapshot () in
+  Alcotest.(check int) "allow = 0" 0 s.typed_advisor_allow;
+  Alcotest.(check int) "reject = 1" 1 s.typed_advisor_reject;
+  Alcotest.(check int)
+    "cannot_parse = 0"
+    0
+    s.typed_advisor_cannot_parse
+;;
+
+let test_cannot_parse_increments_cannot_parse () =
+  L.reset ();
+  L.incr_typed_advisor (V.Cannot_parse { kind = V.Parse_error });
+  let s = L.snapshot () in
+  Alcotest.(check int)
+    "cannot_parse = 1"
+    1
+    s.typed_advisor_cannot_parse
+;;
+
+let test_reset_clears () =
+  L.incr_typed_advisor V.Allow;
+  L.incr_typed_advisor
+    (V.Reject
+       { reason = V.Command_not_in_allowlist "x"; diagnostic = "x" });
+  L.incr_typed_advisor (V.Cannot_parse { kind = V.Parse_error });
+  L.reset ();
+  let s = L.snapshot () in
+  Alcotest.(check int) "post-reset allow" 0 s.typed_advisor_allow;
+  Alcotest.(check int) "post-reset reject" 0 s.typed_advisor_reject;
+  Alcotest.(check int)
+    "post-reset cannot_parse"
+    0
+    s.typed_advisor_cannot_parse
+;;
+
+let test_json_shape () =
+  (* Operator dashboards / runbook greps depend on these exact field
+     names — pin them. *)
+  L.reset ();
+  L.incr_typed_advisor V.Allow;
+  let json = L.snapshot_to_json (L.snapshot ()) in
+  let s = Yojson.Safe.to_string json in
+  Alcotest.(check bool)
+    "has typed_advisor_allow"
+    true
+    (Astring.String.is_infix ~affix:"\"typed_advisor_allow\":1" s);
+  Alcotest.(check bool)
+    "has typed_advisor_reject"
+    true
+    (Astring.String.is_infix ~affix:"\"typed_advisor_reject\":0" s);
+  Alcotest.(check bool)
+    "has typed_advisor_cannot_parse"
+    true
+    (Astring.String.is_infix
+       ~affix:"\"typed_advisor_cannot_parse\":0"
+       s)
+;;
+
+let test_env_flag_default_off () =
+  (* Flag must be off by default — production observers should not
+     pay any cost until an operator explicitly opts in. *)
+  let prev = Sys.getenv_opt "MASC_BASH_TYPED_ADVISOR" in
+  Unix.putenv "MASC_BASH_TYPED_ADVISOR" "";
+  let off = Masc_mcp.Gate_diff_types.typed_advisor_log_enabled () in
+  Unix.putenv "MASC_BASH_TYPED_ADVISOR" "1";
+  let on = Masc_mcp.Gate_diff_types.typed_advisor_log_enabled () in
+  (match prev with
+   | None -> Unix.putenv "MASC_BASH_TYPED_ADVISOR" ""
+   | Some v -> Unix.putenv "MASC_BASH_TYPED_ADVISOR" v);
+  Alcotest.(check bool) "empty env → off" false off;
+  Alcotest.(check bool) "\"1\" env → on" true on
+;;
+
+let () =
+  Alcotest.run
+    "typed_advisor_counters"
+    [ ( "buckets"
+      , [ Alcotest.test_case "initial zero" `Quick test_initial_zero
+        ; Alcotest.test_case "Allow → allow" `Quick test_allow_increments_allow
+        ; Alcotest.test_case
+            "Reject → reject"
+            `Quick
+            test_reject_increments_reject
+        ; Alcotest.test_case
+            "Cannot_parse → cannot_parse"
+            `Quick
+            test_cannot_parse_increments_cannot_parse
+        ; Alcotest.test_case "reset clears" `Quick test_reset_clears
+        ] )
+    ; ( "json_shape"
+      , [ Alcotest.test_case
+            "three fields under stable names"
+            `Quick
+            test_json_shape
+        ] )
+    ; ( "env_flag"
+      , [ Alcotest.test_case
+            "default off, \"1\" turns on"
+            `Quick
+            test_env_flag_default_off
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

#15710 (RFC-0092 PR-2 keeper_shell_bash wire) auto-closed on 2026-05-17 02:37 UTC when its base `feature/rfc-0092-pr1-validator-module` was deleted after PR-1 (#15708) squash-merged to main. memory `feedback_stacked_pr_auto_close_recovery`의 정확한 케이스.

이 PR은 #15710의 동일 변경(cherry-pick + merge conflict 해결)을 **main 기준**으로 재오픈. 스택 깊이 0.

## Cherry-pick conflict 해결 노트

main이 base였던 #15708 머지 이후 두 surface가 추가되어 location conflict 발생 (의미 충돌 아님):

1. `lib/legendary_counters.mli` — main에 `incr_too_complex_parse_error` / `incr_too_complex_parse_aborted` 추가됨. PR-2의 `incr_typed_advisor`와 함께 보존.
2. `lib/worker_dev_tools.mli` — main에 `block_reason_to_string_with_allowlist` 추가됨. PR-2의 `dev_allowed_commands` 노출과 함께 보존.

두 변경 모두 별개 surface 추가라 코드 의미 충돌 없음. 양쪽 선언 모두 유지.

## RFC-0092 Phase A 본체 (#15710과 동일)

- `lib/gate_diff_types.{ml,mli}` — `typed_advisor_log_enabled : unit -> bool` (`MASC_BASH_TYPED_ADVISOR` env, default OFF).
- `lib/worker_dev_tools.mli` — `dev_allowed_commands` 노출 (parity 측정용).
- `lib/legendary_counters.{ml,mli}` — 3 atom + `incr_typed_advisor` + snapshot record 3 필드 + JSON shape.
- `lib/keeper/keeper_shell_bash.ml` — flag-gated advisor block (behavior-neutral; allow/deny decision 없음, log + counter만).
- `test/test_typed_advisor_counters.ml` — 7 tests: bucket routing, reset, JSON shape, env-flag default-off invariant.

## Test plan

- [x] `git cherry-pick d82a103e21` + conflict 해결 (legendary_counters.mli + worker_dev_tools.mli)
- [x] `dune build --root . @check` clean
- [x] `dune exec test/test_typed_advisor_counters.exe` — 7/7 PASS
- [x] Flag default OFF — production observers는 opt-in 전까지 비용 0

RFC-WAIVED: 본 PR은 #15710의 main 기준 재오픈. #15710은 #15708 squash merge 이후 GitHub auto-close된 stacked PR으로, 동일 변경에 대한 RFC waiver는 #15710의 본문(RFC-0092 docs PR #15707에서 §4.1 PR-2로 명시)에서 이미 적용됨. keeper_shell_bash 영역 변경이지만 behavior-neutral (counter + log만, gate decision 미변경).

Supersedes closed #15710.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
