### PR TITLE
[codex] Fix keeper tool alias lane checks

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -107,7 +107,7 @@ let note_turn_failures_preserved_after_heartbeat ~(ctx : _ context) ~(meta : kee
   in
   if turn_failures > 0
   then
-    Log.Keeper.info
+    Log.Keeper.debug
       "heartbeat healthy for %s; preserving %d turn failure(s) until a real \
        turn succeeds"
       meta.name
@@ -1058,10 +1058,8 @@ let run_keepalive_unified_turn
           else ""
         in
         let log_not_scheduled =
-          match turn_decision.verdict with
-          | Keeper_world_observation.Skip
-              { reasons = Keeper_world_observation.Scheduled_autonomous_disabled, [] } ->
-            Log.Keeper.debug
+          match cascade_backpressure, turn_decision.verdict with
+          | Cascade_admitted, Keeper_world_observation.Skip _ -> Log.Keeper.debug
           | _ -> Log.Keeper.info
         in
         log_not_scheduled

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -852,7 +852,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                  meta.name
              end
            | Some entry ->
-             Log.Keeper.info
+             Log.Keeper.debug
                "%s: watchdog: phase=%s (not Running, skipping)"
                meta.name
                (Keeper_state_machine.phase_to_string entry.phase)

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -58,11 +58,26 @@ let resolved_tool_lane_label ~effective_tools ~runtime_mcp_policy =
   | false, false, Some _ -> "runtime_mcp_connect_only"
   | false, false, None -> "none"
 
+let canonical_tool_support_name name =
+  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
+  match Keeper_tool_alias.public_masc_to_internal stripped with
+  | Some internal -> internal
+  | None ->
+    (match Keeper_tool_alias.route stripped with
+     | Some route -> route.internal_name
+     | None -> stripped)
+
 let missing_required_tool_names_after_lane_by_name ~required_tool_names
     ~materialized_tool_names =
+  let materialized = Hashtbl.create 32 in
+  List.iter
+    (fun name ->
+      Hashtbl.replace materialized (canonical_tool_support_name name) ())
+    materialized_tool_names;
   required_tool_names
   |> dedupe_keep_order
-  |> List.filter (fun name -> not (List.mem name materialized_tool_names))
+  |> List.filter (fun name ->
+       not (Hashtbl.mem materialized (canonical_tool_support_name name)))
 
 let missing_required_tool_names_after_lane ~required_tool_names ~effective_tools
     ~runtime_mcp_policy =

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -2000,7 +2000,23 @@ let test_required_tool_lane_missing_names () =
       ~required_tool_names:[ "keeper_task_done" ]
       ~materialized_tool_names:[ "keeper_task_done"; "read_file" ]
   in
-  Alcotest.(check (list string)) "all required tools materialized" [] satisfied
+  Alcotest.(check (list string)) "all required tools materialized" [] satisfied;
+  let public_alias_satisfied =
+    FT.missing_required_tool_names_after_lane_by_name
+      ~required_tool_names:[ "keeper_bash"; "keeper_shell"; "keeper_board_post" ]
+      ~materialized_tool_names:[ "Bash"; "Grep"; "masc_board_post" ]
+  in
+  Alcotest.(check (list string))
+    "public aliases satisfy internal required tools"
+    [] public_alias_satisfied;
+  let internal_satisfied =
+    FT.missing_required_tool_names_after_lane_by_name
+      ~required_tool_names:[ "Bash"; "Grep" ]
+      ~materialized_tool_names:[ "keeper_bash"; "keeper_shell" ]
+  in
+  Alcotest.(check (list string))
+    "internal tools satisfy public required aliases"
+    [] internal_satisfied
 
 let test_required_tool_lane_matrix_materialization () =
   let module FT = Masc_mcp.Keeper_turn_driver_helpers in


### PR DESCRIPTION
## Summary

Fixes keeper required-tool lane checks so public tool aliases and internal handler names satisfy each other before reporting `required_tool_lane_unavailable`.

## Root Cause

The required-tool lane verifier compared raw required tool names against raw materialized tool names. Runtime MCP/OAS materializes public aliases such as `Bash`, `Grep`, and `masc_board_post`, while keeper contracts can require internal names such as `keeper_bash`, `keeper_shell`, and `keeper_board_post`. That made an available lane look missing.

## Changes

- Canonicalize both required and materialized tool names through the low-dependency keeper alias table before comparison.
- Add regression coverage for public alias -> internal and internal -> public matching.
- Demote high-volume healthy skip logs from info to debug while preserving metrics/registry stamps and keeping backpressure at info.

## Validation

- `scripts/dune-local.sh exec ./test/test_keeper_runtime_manifest.exe -- test wiring 1` passed.
- `git diff --check` passed.
- Full `test_keeper_runtime_manifest` currently still fails on unrelated existing fixture/source-drift cases: `/runtime-trace` source needle mismatch and runtime fixture `accept_rejected`.