### PR TITLE
fix(ci): honor empty live PR label sets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1034,9 +1034,10 @@ jobs:
             else
               echo "::warning::Could not resolve live PR draft state; falling back to pull_request event payload."
             fi
-            live_labels="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || true)"
-            if [ -n "$live_labels" ]; then
+            if live_labels="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null)"; then
               export PR_LIVE_LABELS="$live_labels"
+            else
+              echo "::warning::Could not resolve live PR labels; falling back to pull_request event payload."
             fi
             # #10192: CI Gate runs that fire after auto-merge can
             # see the bypass label cleaned up by post-merge

--- a/scripts/ci/check-agent-draft-policy.sh
+++ b/scripts/ci/check-agent-draft-policy.sh
@@ -30,14 +30,24 @@ fi
 pr_is_draft="${PR_LIVE_IS_DRAFT:-${PR_IS_DRAFT:-false}}"
 pr_title="${PR_TITLE:-}"
 pr_head_ref="${PR_HEAD_REF:-}"
-pr_labels_csv="${PR_LIVE_LABELS:-${PR_LABELS:-}}"
 pr_live_state="${PR_LIVE_STATE:-}"
+if [[ "${PR_LIVE_LABELS+x}" == "x" ]]; then
+  pr_labels_csv="${PR_LIVE_LABELS}"
+  pr_live_labels_lookup=1
+else
+  pr_labels_csv="${PR_LABELS:-}"
+  pr_live_labels_lookup=0
+fi
 
 if [[ -n "${PR_LIVE_IS_DRAFT:-}" ]]; then
   echo "agent draft policy: using live PR draft state ${PR_LIVE_IS_DRAFT}"
 fi
-if [[ -n "${PR_LIVE_LABELS:-}" ]]; then
-  echo "agent draft policy: using live PR labels ${PR_LIVE_LABELS}"
+if [[ "$pr_live_labels_lookup" -eq 1 ]]; then
+  if [[ -n "$PR_LIVE_LABELS" ]]; then
+    echo "agent draft policy: using live PR labels ${PR_LIVE_LABELS}"
+  else
+    echo "agent draft policy: using live PR labels (none)"
+  fi
 fi
 
 lower() {
@@ -62,9 +72,11 @@ esac
 
 csv_has_label() {
   local csv="$1"
+  [[ -n "$csv" ]] || return 1
   local wanted
   wanted="$(lower "$2")"
   local item
+  local -a items=()
   IFS=',' read -r -a items <<<"$csv"
   for item in "${items[@]}"; do
     item="$(lower "$(printf '%s' "$item" | xargs)")"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -157,6 +157,9 @@ let test_ci_sync_and_asset_contracts () =
     (file_contains_pattern ".github/workflows/ci.yml" "PR_LIVE_IS_DRAFT");
   check bool "ci gate refreshes live labels" true
     (file_contains_pattern ".github/workflows/ci.yml" "PR_LIVE_LABELS");
+  check bool "ci gate exports empty live labels" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       {|if live_labels="$(gh pr view "$PR_NUMBER"|});
   (* #10192: ci gate must also pass live PR state to the
      policy script so already-merged PRs do not flip red. *)
   check bool "ci gate refreshes live PR state" true
@@ -235,6 +238,24 @@ let test_agent_draft_policy_script () =
        :: ("PR_LIVE_LABELS", "enhancement,human-approved-ready")
        :: ("PR_IS_DRAFT", "true")
        :: base));
+  check bool "live empty labels override stale event bypass" true
+    (run_agent_draft_policy
+       (("PR_LIVE_IS_DRAFT", "false")
+       :: ("PR_LIVE_LABELS", "")
+       :: ("PR_IS_DRAFT", "true")
+       :: ("PR_LABELS", "enhancement,human-approved-ready")
+       :: List.remove_assoc "PR_LABELS" base)
+    <> 0);
+  check int "live empty labels override stale hard-stop labels" 0
+    (run_agent_draft_policy
+       [
+         ("GITHUB_EVENT_NAME", "pull_request");
+         ("PR_IS_DRAFT", "false");
+         ("PR_TITLE", "fix: human authored branch");
+         ("PR_HEAD_REF", "feature/human-branch");
+         ("PR_LABELS", "do-not-merge");
+         ("PR_LIVE_LABELS", "");
+       ]);
   check bool "ready agent PR without bypass fails" true
     (run_agent_draft_policy (("PR_IS_DRAFT", "false") :: base) <> 0);
   check bool "ready feature PR with agent-pr label fails" true


### PR DESCRIPTION
## Summary

- export `PR_LIVE_LABELS` from CI Gate whenever the live label lookup succeeds, including the intentionally empty-label case
- make `check-agent-draft-policy.sh` distinguish an empty live label set from an unset live label lookup
- add regression coverage for empty live labels overriding stale event bypass and hard-stop labels

## Why

`CI Gate` could rerun from a stale `pull_request` payload after all labels were removed from a PR. Because the workflow only exported non-empty live labels, the policy script fell back to stale `PR_LABELS` and could keep failing on labels no longer present.

Refs #15138

## Validation

- `git diff --check origin/main...HEAD`
- `bash -n scripts/ci/check-agent-draft-policy.sh`
- `opam exec -- ocamlformat --check test/test_ci_hardening_source.ml`
- `env GITHUB_EVENT_NAME=pull_request PR_IS_DRAFT=false PR_TITLE='fix: human authored branch' PR_HEAD_REF=feature/human-branch PR_LABELS=do-not-merge PR_LIVE_LABELS= scripts/ci/check-agent-draft-policy.sh`
- `env GITHUB_EVENT_NAME=pull_request PR_IS_DRAFT=true PR_TITLE='fix: keep long turns visibly alive' PR_HEAD_REF=codex/keeper-process-evidence PR_LABELS=enhancement,human-approved-ready PR_LIVE_LABELS= scripts/ci/check-agent-draft-policy.sh` (expected failure)
- `env MASC_SKIP_PIN_CHECK=1 DUNE_LOCAL_JOBS=1 OCAMLPARAM=_,warn-error=-23 scripts/dune-local.sh build test/test_ci_hardening_source.exe`
- `env OCAMLPARAM=_,warn-error=-23 _build/default/test/test_ci_hardening_source.exe test source_guard 1`
- `bash scripts/check-release-train-guard.sh --base origin/main --head HEAD`

Note: the full `test_ci_hardening_source` binary still has unrelated pre-existing source-contract failures on current `origin/main`; the touched `agent draft policy script` case passes.
