### PR TITLE
[RFC-0095 Phase 0] Streaming wire-up diagnostic trace

### DIFF
--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -235,17 +235,17 @@ let provider_config_preserving_http_transport
   in
   { complete_sync =
       (fun req ->
-        (* RFC-0094 Phase 0 diagnostic trace — verify which transport path is invoked
+        (* RFC-0095 Phase 0 diagnostic trace — verify which transport path is invoked
            per turn for each provider. Removed at Phase 0 closeout. *)
         Log.Misc.debug
-          "rfc0094-trace: cascade_runner http_transport.complete_sync invoked";
+          "rfc0095-trace: cascade_runner http_transport.complete_sync invoked";
         http_transport.complete_sync (patch_request req));
     complete_stream =
       (fun ?on_telemetry ~on_event req ->
-        (* RFC-0094 Phase 0 diagnostic trace — verify which transport path is invoked
+        (* RFC-0095 Phase 0 diagnostic trace — verify which transport path is invoked
            per turn for each provider. Removed at Phase 0 closeout. *)
         Log.Misc.debug
-          "rfc0094-trace: cascade_runner http_transport.complete_stream invoked";
+          "rfc0095-trace: cascade_runner http_transport.complete_stream invoked";
         http_transport.complete_stream ?on_telemetry ~on_event
           (patch_request req));
   }

--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -234,9 +234,18 @@ let provider_config_preserving_http_transport
     }
   in
   { complete_sync =
-      (fun req -> http_transport.complete_sync (patch_request req));
+      (fun req ->
+        (* RFC-0094 Phase 0 diagnostic trace — verify which transport path is invoked
+           per turn for each provider. Removed at Phase 0 closeout. *)
+        Log.Misc.debug
+          "rfc0094-trace: cascade_runner http_transport.complete_sync invoked";
+        http_transport.complete_sync (patch_request req));
     complete_stream =
       (fun ?on_telemetry ~on_event req ->
+        (* RFC-0094 Phase 0 diagnostic trace — verify which transport path is invoked
+           per turn for each provider. Removed at Phase 0 closeout. *)
+        Log.Misc.debug
+          "rfc0094-trace: cascade_runner http_transport.complete_stream invoked";
         http_transport.complete_stream ?on_telemetry ~on_event
           (patch_request req));
   }

--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -393,11 +393,11 @@ let parse_model (id : string) (tbl : Otoml.t)
                path);
            [])
     in
-    (* RFC-0094 Phase 0 diagnostic trace — capture model streaming flag at parse time
+    (* RFC-0095 Phase 0 diagnostic trace — capture model streaming flag at parse time
        (boot-once per model). Removed at Phase 0 closeout. *)
     Logs.debug (fun m ->
       m
-        "rfc0094-trace: parsed model id=%s api_name=%s streaming=%b"
+        "rfc0095-trace: parsed model id=%s api_name=%s streaming=%b"
         id
         api_name
         streaming);

--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -393,6 +393,14 @@ let parse_model (id : string) (tbl : Otoml.t)
                path);
            [])
     in
+    (* RFC-0094 Phase 0 diagnostic trace — capture model streaming flag at parse time
+       (boot-once per model). Removed at Phase 0 closeout. *)
+    Logs.debug (fun m ->
+      m
+        "rfc0094-trace: parsed model id=%s api_name=%s streaming=%b"
+        id
+        api_name
+        streaming);
     Ok
       { id
       ; api_name

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -331,7 +331,18 @@ let run_try_provider
     let provider_label = Cascade_runtime_candidate.provider_label candidate in
     let liveness_observer_opt =
       match liveness_mode with
-      | Cascade_attempt_liveness_config.Off -> None
+      | Cascade_attempt_liveness_config.Off ->
+        (* RFC-0094 Phase 0 diagnostic trace — capture Off-mode turns. Combined with
+           the existing Observe/Enforce-branch log below, this gives full visibility
+           into whether the streaming master switch is the gating factor for
+           openai_compat candidates. Removed at Phase 0 closeout. *)
+        Log.Misc.debug
+          "rfc0094-trace: liveness_mode=Off observer disabled cascade=%s provider=%s \
+           candidate=%s"
+          ctx.cascade_name
+          provider_label
+          candidate_key;
+        None
       | Cascade_attempt_liveness_config.Observe | Cascade_attempt_liveness_config.Enforce
         ->
         let resolved_budget =

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -332,12 +332,12 @@ let run_try_provider
     let liveness_observer_opt =
       match liveness_mode with
       | Cascade_attempt_liveness_config.Off ->
-        (* RFC-0094 Phase 0 diagnostic trace — capture Off-mode turns. Combined with
+        (* RFC-0095 Phase 0 diagnostic trace — capture Off-mode turns. Combined with
            the existing Observe/Enforce-branch log below, this gives full visibility
            into whether the streaming master switch is the gating factor for
            openai_compat candidates. Removed at Phase 0 closeout. *)
         Log.Misc.debug
-          "rfc0094-trace: liveness_mode=Off observer disabled cascade=%s provider=%s \
+          "rfc0095-trace: liveness_mode=Off observer disabled cascade=%s provider=%s \
            candidate=%s"
           ctx.cascade_name
           provider_label


### PR DESCRIPTION
## Summary

- RFC-0095 §5 (Phase 0) implementation — 3 debug-level trace points to determine which of H1/H2/H3 explains the `openai_compat` streaming gap (Prometheus chunk count = 0 vs `glm` = 5332).
- **Production behavior unchanged**: `Log.Misc.debug` / `Logs.debug` only; no production-visible effect unless debug logging is explicitly enabled.
- Related RFC PR: #15722 (RFC-0095 body).

## Trace points

| # | File:Line | Hypothesis | What it captures |
|---|---|---|---|
| 1 | `lib/cascade/cascade_runner.ml:236-242` | H1 | sync vs stream branch at the HTTP transport boundary — was `complete_sync` or `complete_stream` invoked per turn |
| 2 | `lib/cascade_decl/cascade_declarative_parser.ml:395` | H2 | model `streaming` flag value at parse time (boot-once per model spec) — anchors dead-read suspicion of cascade.toml `streaming = true` |
| 3 | `lib/keeper/keeper_turn_driver_try_provider.ml:332-336` | H3 | `liveness_mode=Off` branch annotation; complements the existing `Observe`/`Enforce` log at L340 to give full visibility on the master switch |

All three lines share the `rfc0095-trace:` prefix:

```bash
grep -h "rfc0095-trace" ~/me/.masc/logs/*.jsonl | sort -u
```

## Self-review (Best Programmer)

- **목표**: openai_compat path 에서 streaming 이 *왜* 동작 안 하는지 H1/H2/H3 가설 중 어느 것이 참인지 *측정* 으로 확정. Phase 1 fix scope 결정의 사전 조건.
- **변경 파일**: 3 개 `.ml` 파일, 총 30 insertions / 2 deletions. RFC body PR (#15722) 와 별개 — 본 PR 은 *코드 변경* 만 (RFC body 무변경).
- **로컬 검증**: `ocamlformat --check lib/cascade/cascade_runner.ml lib/cascade_decl/cascade_declarative_parser.ml lib/keeper/keeper_turn_driver_try_provider.ml` exit 0.
- **남은 미검증**: 실제 운영 환경에서 *trace 활성화* 후 5 분 트래픽 sample 수집 → grep 분석.

## Test plan

- [ ] CI lint/build 통과 (Phase 0 코드는 production behavior 무변경이라 functional regression 위험 없음)
- [ ] 머지 후 운영 환경에서 debug log 활성화 (`MASC_LOG_LEVEL=debug` 또는 동등) → 5 분 sangsu / imseonghan / jobsian_purist 트래픽 sample
- [ ] grep `rfc0095-trace` 결과를 RFC-0095 §4 표에 H1/H2/H3 outcome 으로 기록 → Phase 1 PR scope 결정

## Out of scope

- Phase 1 fix (가설 확정 후 별도 PR)
- Phase 2 regression test (`test/test_cascade_streaming_wire_up.ml`, Phase 1 머지 후)
- Trace 코드 *영구* 유지 — Phase 0 closeout 시 제거 또는 영구 metric 으로 승격 결정.

## RFC reference

- RFC body: docs/rfc/RFC-0095-openai-compat-streaming-wire-up.md (PR #15722, Draft)
- Hypothesis 정의: RFC-0095 §4 표
- Phase 0 scope: RFC-0095 §5 (no production behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)