### PR TITLE
Fix required tool lane alias matching

### DIFF
--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -146,6 +146,33 @@ let strip_mcp_masc_prefix name =
   else name
 ;;
 
+type canonical_resolution =
+  | Public_mcp of
+      { stripped : string
+      ; internal : string
+      }
+  | Public_alias of { internal : string }
+  | Internal of { canonical : string }
+  | Unknown
+
+let canonical_resolution name =
+  let stripped = strip_mcp_masc_prefix name in
+  match public_masc_to_internal stripped with
+  | Some internal -> Public_mcp { stripped; internal }
+  | None ->
+    (match route stripped with
+     | Some r -> Public_alias { internal = r.internal_name }
+     | None ->
+       if is_known_internal stripped then Internal { canonical = stripped } else Unknown)
+;;
+
+let canonical_internal_name name =
+  match canonical_resolution name with
+  | Public_mcp { internal; _ } | Public_alias { internal } -> Some internal
+  | Internal { canonical } -> Some canonical
+  | Unknown -> None
+;;
+
 (* ── Schema helpers (local) ──────────────────────────────────────── *)
 
 let property name typ description =

--- a/lib/keeper/keeper_tool_alias.mli
+++ b/lib/keeper/keeper_tool_alias.mli
@@ -69,6 +69,27 @@ val public_masc_to_internal : string -> string option
     present. *)
 val strip_mcp_masc_prefix : string -> string
 
+(** Pure canonical routing result for set-logic and routing callers that need
+    the same alias interpretation without emitting telemetry. *)
+type canonical_resolution =
+  | Public_mcp of
+      { stripped : string
+      ; internal : string
+      }
+  | Public_alias of { internal : string }
+  | Internal of { canonical : string }
+  | Unknown
+
+(** [canonical_resolution name] applies MCP-prefix stripping, public MCP
+    replacement, LLM-native alias routing, and known-internal detection. *)
+val canonical_resolution : string -> canonical_resolution
+
+(** [canonical_internal_name name] returns the internal keeper/MASC tool name
+    used for pure set-logic comparisons after applying the same public alias
+    and MCP-prefix routing rules used by runtime dispatch. [None] means the
+    name is not a recognised public, public-MCP, or internal tool. *)
+val canonical_internal_name : string -> string option
+
 (** {1 Public schemas} *)
 
 (** [public_input_schema public_name] returns the LLM-facing JSON schema

--- a/lib/keeper/keeper_tool_resolution.ml
+++ b/lib/keeper/keeper_tool_resolution.ml
@@ -193,13 +193,9 @@ type runtime_decision_outcome =
     [Keeper_tool_disclosure.canonical_tool_name] to this entry. PR-11
     removes the legacy wrapper in favour of this one. *)
 let runtime_decision name =
-  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
-  match Keeper_tool_alias.public_masc_to_internal stripped with
-  | Some internal -> Mcp_mapped { stripped; internal }
-  | None ->
-    (match Keeper_tool_alias.route stripped with
-     | Some r -> Route_hit { internal = r.internal_name }
-     | None ->
-       if Keeper_tool_alias.is_known_internal stripped
-       then Already_internal { canonical = stripped }
-       else Miss)
+  match Keeper_tool_alias.canonical_resolution name with
+  | Keeper_tool_alias.Public_mcp { stripped; internal } ->
+    Mcp_mapped { stripped; internal }
+  | Keeper_tool_alias.Public_alias { internal } -> Route_hit { internal }
+  | Keeper_tool_alias.Internal { canonical } -> Already_internal { canonical }
+  | Keeper_tool_alias.Unknown -> Miss

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -58,26 +58,35 @@ let resolved_tool_lane_label ~effective_tools ~runtime_mcp_policy =
   | false, false, Some _ -> "runtime_mcp_connect_only"
   | false, false, None -> "none"
 
-let canonical_tool_support_name name =
-  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
-  match Keeper_tool_alias.public_masc_to_internal stripped with
+let canonical_tool_name_for_lane_check name =
+  match Keeper_tool_alias.canonical_internal_name name with
   | Some internal -> internal
-  | None ->
-    (match Keeper_tool_alias.route stripped with
-     | Some route -> route.internal_name
-     | None -> stripped)
+  | None -> name
+
+let canonical_tool_names_for_lane_check names =
+  names |> List.map canonical_tool_name_for_lane_check |> dedupe_keep_order
+
+let dedupe_required_tool_names_for_lane_check names =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | name :: rest ->
+      let canonical = canonical_tool_name_for_lane_check name in
+      if List.mem canonical seen
+      then loop seen acc rest
+      else loop (canonical :: seen) (name :: acc) rest
+  in
+  loop [] [] names
 
 let missing_required_tool_names_after_lane_by_name ~required_tool_names
     ~materialized_tool_names =
-  let materialized = Hashtbl.create 32 in
-  List.iter
-    (fun name ->
-      Hashtbl.replace materialized (canonical_tool_support_name name) ())
-    materialized_tool_names;
+  let materialized_tool_names =
+    canonical_tool_names_for_lane_check materialized_tool_names
+  in
   required_tool_names
-  |> dedupe_keep_order
+  |> dedupe_required_tool_names_for_lane_check
   |> List.filter (fun name ->
-       not (Hashtbl.mem materialized (canonical_tool_support_name name)))
+       let canonical = canonical_tool_name_for_lane_check name in
+       not (List.mem canonical materialized_tool_names))
 
 let missing_required_tool_names_after_lane ~required_tool_names ~effective_tools
     ~runtime_mcp_policy =

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -230,6 +230,29 @@ let test_mcp_prefixed_keeper_internal_routes () =
     canonical
 ;;
 
+let test_alias_canonical_internal_name_for_set_logic () =
+  Alcotest.(check (option string))
+    "public Bash canonicalises to keeper_bash"
+    (Some "keeper_bash")
+    (Alias.canonical_internal_name "Bash");
+  Alcotest.(check (option string))
+    "public Grep canonicalises to keeper_shell"
+    (Some "keeper_shell")
+    (Alias.canonical_internal_name "Grep");
+  Alcotest.(check (option string))
+    "MCP-prefixed public MASC name canonicalises to internal keeper tool"
+    (Some "keeper_board_post")
+    (Alias.canonical_internal_name "mcp__masc__masc_board_post");
+  Alcotest.(check (option string))
+    "known internal name stays internal"
+    (Some "keeper_bash")
+    (Alias.canonical_internal_name "keeper_bash");
+  Alcotest.(check (option string))
+    "unknown name stays unknown"
+    None
+    (Alias.canonical_internal_name "Skill")
+;;
+
 let test_mcp_prefixed_public_masc_goal_tool_routes () =
   let canonical = Disclosure.canonical_tool_name "mcp__masc__masc_goal_list" in
   Alcotest.(check string)
@@ -750,6 +773,10 @@ let () =
             "mcp-prefixed keeper internal canonicalises to stripped"
             `Quick
             test_mcp_prefixed_keeper_internal_routes
+        ; Alcotest.test_case
+            "canonical internal name for set logic"
+            `Quick
+            test_alias_canonical_internal_name_for_set_logic
         ; Alcotest.test_case
             "mcp-prefixed public MASC goal tool canonicalises to stripped"
             `Quick


### PR DESCRIPTION
## Summary
- canonicalize required and materialized keeper tool names before lane-missing checks
- make Bash/Grep public aliases satisfy keeper_bash/keeper_shell required-tool contracts
- add regression coverage for alias/internal required-tool matching

## Root cause
The lane check compared required tool names and materialized tool names as raw strings. Runtime logs showed required internal names like keeper_bash and keeper_shell while the materialized LLM surface exposed public aliases like Bash and Grep, so the runtime incorrectly emitted required_tool_lane_unavailable and exhausted the cascade.

## Validation
- ocamlformat --check lib/keeper/keeper_turn_driver_helpers.ml test/test_keeper_runtime_manifest.ml
- scripts/dune-local.sh build test/test_keeper_runtime_manifest.exe
- ./_build/default/test/test_keeper_runtime_manifest.exe test wiring 1-2

Note: running the full test_keeper_runtime_manifest executable still shows existing runtime fixture failures in runtime 0/1 and wiring 0 with accept_rejected; the focused alias/lane regression cases pass.