### PR TITLE
fix(fd): docker spawn throttle bounds host FD pressure

### DIFF
--- a/lib/docker_spawn_throttle.ml
+++ b/lib/docker_spawn_throttle.ml
@@ -15,13 +15,13 @@ let _degraded_mutex = Eio.Mutex.create ()
 
 let with_slot f =
   Eio.Semaphore.acquire _sem;
-  Fun.protect
-    ~finally:(fun () -> Eio.Semaphore.release _sem)
-    (fun () ->
-       if Keeper_fd_pressure.active () then
-         Eio.Mutex.use_rw ~protect:true _degraded_mutex f
-       else
-         f ())
+  Eio.Switch.run
+  @@ fun sw ->
+  Eio.Switch.on_release sw (fun () -> Eio.Semaphore.release _sem);
+  if Keeper_fd_pressure.active () then
+    Eio.Mutex.use_rw ~protect:true _degraded_mutex f
+  else
+    f ()
 ;;
 
 let effective_concurrency () =

--- a/lib/docker_spawn_throttle.ml
+++ b/lib/docker_spawn_throttle.ml
@@ -1,0 +1,31 @@
+(** See .mli for contract. *)
+
+let _max_concurrency =
+  match Sys.getenv_opt "MASC_DOCKER_SPAWN_CONCURRENCY" with
+  | Some s ->
+    (match int_of_string_opt (String.trim s) with
+     | Some n when n >= 1 && n <= 64 -> n
+     | _ -> 8)
+  | None -> 8
+;;
+
+let _sem = Eio.Semaphore.make _max_concurrency
+
+let _degraded_mutex = Eio.Mutex.create ()
+
+let with_slot f =
+  Eio.Semaphore.acquire _sem;
+  Fun.protect
+    ~finally:(fun () -> Eio.Semaphore.release _sem)
+    (fun () ->
+       if Keeper_fd_pressure.active () then
+         Eio.Mutex.use_rw ~protect:true _degraded_mutex f
+       else
+         f ())
+;;
+
+let effective_concurrency () =
+  if Keeper_fd_pressure.active () then 1 else _max_concurrency
+;;
+
+let configured_max () = _max_concurrency

--- a/lib/docker_spawn_throttle.mli
+++ b/lib/docker_spawn_throttle.mli
@@ -1,0 +1,44 @@
+(** Docker subprocess spawn throttle — bounds host FD pressure.
+
+    Each [docker run/exec/...] call on the macOS host consumes
+    host-side pipes/sockets and docker daemon FDs. Without an
+    orchestrator-level cap on concurrent spawns, N keepers hitting
+    a cascade-exhaustion storm can saturate the system FD ceiling
+    (kern.maxfiles, default 491_520).
+
+    Reference incident: 2026-05-16 18:08-18:15 ENFILE storm —
+    12+ keepers concurrently retried cascade tiers, each retry
+    spawned a fresh [docker run --rm], no backpressure existed at
+    the host layer.
+
+    Two layers:
+
+    {ol
+    {- Layer A — bounded concurrency via [Eio.Semaphore].
+       Effective cap configurable via [MASC_DOCKER_SPAWN_CONCURRENCY]
+       (default 8, range 1..64). Always on.}
+    {- Layer B — FD-aware serialization. When [Keeper_fd_pressure.active ()]
+       indicates the breaker is tripped, an additional global mutex
+       funnels all in-flight spawns through a single thread, giving
+       the cooldown room to drain. Engaged automatically.}}
+
+    Callers wrap their spawn invocation with [with_slot]; the helper
+    blocks until a slot is available. *)
+
+val with_slot : (unit -> 'a) -> 'a
+(** [with_slot f] acquires a docker-spawn slot, runs [f ()], releases
+    the slot, and returns [f]'s result. If [Keeper_fd_pressure.active ()]
+    is true at acquire time, [f] is also serialized against all other
+    in-flight callers.
+
+    Exceptions from [f] propagate; the slot is always released. *)
+
+val effective_concurrency : unit -> int
+(** [effective_concurrency ()] reports the current cap.
+    Returns [1] while [Keeper_fd_pressure.active ()] is true (degraded
+    serialization), the configured maximum otherwise. Observability
+    only — not a synchronization primitive. *)
+
+val configured_max : unit -> int
+(** [configured_max ()] reports the configured upper bound (post-env
+    resolution), independent of degraded state. *)

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -1017,14 +1017,15 @@ let run_docker_shell_command_with_status_internal
                         let status, output =
                           Eio_guard.protect ~finally:restore_gitdirs
                           @@ fun () ->
-                          Masc_exec.Exec_gate.run_argv_with_status
-                            ~actor:`Keeper_shell
-                            ~raw_source:(String.concat " " argv)
-                            ~summary:"keeper docker command"
-                            ~env:(Unix.environment ())
-                            ~cwd:(Sys.getcwd ())
-                            ~timeout_sec
-                            argv
+                          Docker_spawn_throttle.with_slot (fun () ->
+                            Masc_exec.Exec_gate.run_argv_with_status
+                              ~actor:`Keeper_shell
+                              ~raw_source:(String.concat " " argv)
+                              ~summary:"keeper docker command"
+                              ~env:(Unix.environment ())
+                              ~cwd:(Sys.getcwd ())
+                              ~timeout_sec
+                              argv)
                         in
                         if status <> Unix.WEXITED 0
                         then

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -403,14 +403,15 @@ let run_worker_spec ?clock_opt (spec : Worker_execution_spec.t)
          Worker_execution_spec.to_yojson spec |> Yojson.Safe.to_string
        in
        let result =
-         run_process_with_timeout
-           ~clock_opt
-           ~stdin_content
-           ~timeout_sec:effective_timeout_sec
-           ~prog:"docker"
-           ~argv:(docker_argv ~container_name:name spec)
-           ~env:(Unix.environment ())
-           ()
+         Docker_spawn_throttle.with_slot (fun () ->
+           run_process_with_timeout
+             ~clock_opt
+             ~stdin_content
+             ~timeout_sec:effective_timeout_sec
+             ~prog:"docker"
+             ~argv:(docker_argv ~container_name:name spec)
+             ~env:(Unix.environment ())
+             ())
        in
        persist_stderr_artifact spec result.stderr;
        match result.exit_code with

--- a/test/dune
+++ b/test/dune
@@ -109,6 +109,7 @@
         test_keeper_generation_lineage
         test_keeper_deliberation
         test_keeper_registry
+        test_docker_spawn_throttle
         test_keeper_supervisor
         test_keeper_alerting_path
         test_coord_eio_pure
@@ -351,6 +352,7 @@
           test_keeper_generation_lineage
           test_keeper_deliberation
           test_keeper_registry
+          test_docker_spawn_throttle
           test_keeper_supervisor
           test_keeper_alerting_path
           test_coord_eio_pure

--- a/test/test_docker_spawn_throttle.ml
+++ b/test/test_docker_spawn_throttle.ml
@@ -1,0 +1,93 @@
+(** test_docker_spawn_throttle — verifies the FD spawn cap.
+
+    Tests cover:
+    - Layer A: configured concurrency cap is respected under fan-in
+    - Layer B: fd_pressure trip degrades effective concurrency to 1 *)
+
+module DST = Masc_mcp.Docker_spawn_throttle
+module FD = Masc_mcp.Keeper_fd_pressure
+
+let with_eio f =
+  Eio_main.run (fun env -> ignore env; f ())
+
+let test_configured_max_in_range () =
+  let n = DST.configured_max () in
+  Alcotest.(check bool) "1 <= configured_max <= 64" true (n >= 1 && n <= 64)
+
+let test_concurrency_capped_under_fanin () =
+  (* Fire 32 fibers, each holding the slot briefly. Track peak in-flight.
+     Peak must not exceed configured_max. *)
+  FD.reset_for_tests ();
+  with_eio @@ fun () ->
+  let max_cap = DST.configured_max () in
+  let in_flight = Atomic.make 0 in
+  let peak = Atomic.make 0 in
+  let fan = 32 in
+  Eio.Switch.run @@ fun sw ->
+  let promises =
+    List.init fan (fun _ ->
+      Eio.Fiber.fork_promise ~sw (fun () ->
+        DST.with_slot (fun () ->
+          let now = Atomic.fetch_and_add in_flight 1 + 1 in
+          let rec bump_peak () =
+            let cur = Atomic.get peak in
+            if now > cur && not (Atomic.compare_and_set peak cur now)
+            then bump_peak ()
+          in
+          bump_peak ();
+          (* Yield so other fibers race for the slot. *)
+          Eio.Fiber.yield ();
+          ignore (Atomic.fetch_and_add in_flight (-1)))))
+  in
+  List.iter (fun p -> Eio.Promise.await_exn p) promises;
+  let observed = Atomic.get peak in
+  Alcotest.(check bool)
+    (Printf.sprintf "peak in-flight %d <= configured_max %d" observed max_cap)
+    true
+    (observed <= max_cap)
+
+let test_degraded_mode_serializes () =
+  (* Trip fd_pressure; effective_concurrency must report 1. *)
+  FD.reset_for_tests ();
+  FD.note ~site:"unit-test" ~detail:"too many open files in system" ();
+  Alcotest.(check bool) "FD.active is true after note" true (FD.active ());
+  Alcotest.(check int) "effective_concurrency = 1 while degraded" 1
+    (DST.effective_concurrency ());
+  FD.reset_for_tests ();
+  Alcotest.(check int)
+    "effective_concurrency restored after reset"
+    (DST.configured_max ())
+    (DST.effective_concurrency ())
+
+let test_exception_releases_slot () =
+  (* If f raises, the slot must still be released — verify by running
+     the cap-test after a raising call completes. *)
+  FD.reset_for_tests ();
+  with_eio @@ fun () ->
+  (try DST.with_slot (fun () -> failwith "intentional") with Failure _ -> ());
+  (* After the exception, a fresh fan-in must still complete (slots not leaked). *)
+  let fan = 16 in
+  let done_ = Atomic.make 0 in
+  Eio.Switch.run @@ fun sw ->
+  let promises =
+    List.init fan (fun _ ->
+      Eio.Fiber.fork_promise ~sw (fun () ->
+        DST.with_slot (fun () -> ignore (Atomic.fetch_and_add done_ 1))))
+  in
+  List.iter (fun p -> Eio.Promise.await_exn p) promises;
+  Alcotest.(check int) "all 16 completed" fan (Atomic.get done_)
+
+let () =
+  Alcotest.run
+    "docker_spawn_throttle"
+    [ ( "throttle"
+      , [ Alcotest.test_case "configured_max in range" `Quick
+            test_configured_max_in_range
+        ; Alcotest.test_case "concurrency capped under fan-in" `Quick
+            test_concurrency_capped_under_fanin
+        ; Alcotest.test_case "degraded mode serializes to 1" `Quick
+            test_degraded_mode_serializes
+        ; Alcotest.test_case "exception releases slot" `Quick
+            test_exception_releases_slot
+        ] )
+    ]


### PR DESCRIPTION
# fix(fd): docker spawn throttle bounds host FD pressure

## What

Adds `Docker_spawn_throttle` — orchestrator-level cap on concurrent
host-side `docker run/exec/...` invocations. Wraps the two heaviest
spawn sites:

- `lib/worker_runtime_docker.ml:run_worker_spec` (worker runtime dispatcher)
- `lib/keeper/keeper_shell_docker.ml:run_docker_shell_command_with_status` (per-turn keeper Bash sandbox)

## Why

2026-05-16 18:08-18:15 **ENFILE storm**: 12+ keepers concurrently
retried cascade tiers, each retry spawned a fresh `docker run --rm`,
no host-layer backpressure existed, system FD ceiling
(`kern.maxfiles` 491,520) was saturated. All `fstatat`/`execve`/`fork`
across unrelated subsystems failed simultaneously. ~10 min recovery.

PR #15678 fixed one source (autonomy_exec pipe leak via missing
`~cloexec:true`). This PR closes the structural fan-in gap.

## Design — two layers, one helper

| Layer | Mechanism | Engagement |
|---|---|---|
| **A** | `Eio.Semaphore` bounded concurrency. Cap configurable via `MASC_DOCKER_SPAWN_CONCURRENCY` (default 8, range 1..64). | Always on |
| **B** | Inner `Eio.Mutex` global serializer when `Keeper_fd_pressure.active ()` reports the breaker is tripped. | Automatic when cooldown active |

Layer B reuses the existing `Keeper_fd_pressure` module (detection +
60s cooldown) — no new detection logic, just composition.

## Why not just bump maxfiles

Raising `kern.maxfiles` masks the symptom. The relationship
`FD_cost ∝ spawn_rate × per_call_FDs` would still hold, and the next
storm at higher fan-in would re-saturate any new ceiling. RFC-0097
(separate PR) plans the structural fix at the *cost* layer
(persistent per-keeper container + `docker exec`).

## Scope intentionally narrow

- Wraps only the two heavy `docker run` sites.
- Lightweight bookkeeping calls (`docker info`/`inspect`/`ps`,
  `docker rm -f` cleanup) **not** wrapped. Capping cleanup risks
  container leaks; bookkeeping volume is negligible.
- No changes to retry logic, backoff, or cascade routing.

## Tests

`test/test_docker_spawn_throttle.ml` — 4 cases:

1. `configured_max` lies in `[1, 64]`
2. Peak in-flight under 32-fiber fan-in never exceeds `configured_max`
3. `Keeper_fd_pressure.note ()` → `effective_concurrency ()` returns 1
4. Exception from inner f releases the slot (no leak under failure)

`dune build --root .` clean.
`dune exec test/test_docker_spawn_throttle.exe --root .` → 4/4 OK.

## Workaround rejection bar (self-check)

- [x] Not telemetry-as-fix — actually bounds spawn rate
- [x] Not string/substring classifier — uses typed `Keeper_fd_pressure.active`
- [x] Not N-of-M — single helper, both heavy sites migrated together
- [x] No catch-all
- [x] **Layer A is cap-style** — but matches host FD physics (semaphore-shaped
  backpressure), not a symptom suppressor. Deprecation path defined in
  RFC-0097 (persistent container removes the spawn-rate variable entirely).

## Follow-ups

- **RFC-0097** (separate PR) — long-running sandbox per keeper.
  4-phase migration plan, opt-in via env flag.
- Once RFC-0097 phase 2 ships and proves stable, the cap becomes
  vestigial (kept as guardrail for container-creation bursts at boot).

## Evidence

- Incident log: `~/me/.masc/logs/system_log_2026-05-16.jsonl` 18:08-18:15Z
  (53 ENFILE entries across 12+ keepers).
- Detection module: `lib/keeper_fd_pressure.ml:36-46 is_fd_exhaustion_text`.
- Spawn sites: `lib/worker_runtime_docker.ml:394`,
  `lib/keeper/keeper_shell_docker.ml:976`.
- Adjacent fix: PR #15678 (autonomy_exec pipe leak).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
