### PR TITLE
feat(dashboard): promote cascade.toml editor to dedicated nav section

### DIFF
--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -8,7 +8,8 @@ import { route } from '../router'
 import { LoadingState } from './common/feedback-state'
 
 export type StatusSection =
-  | 'observatory' | 'journey' | 'agents' | 'runtime' | 'goal-loop' | 'fleet-health'
+  | 'observatory' | 'journey' | 'agents' | 'runtime' | 'cascade-config'
+  | 'goal-loop' | 'fleet-health'
   | 'cognition'
 
 const LazyAgentsUnified = lazy(async () => ({
@@ -16,6 +17,9 @@ const LazyAgentsUnified = lazy(async () => ({
 }))
 const LazyRuntimePanel = lazy(async () => ({
   default: (await import('./runtime-panel')).RuntimePanel,
+}))
+const LazyCascadeConfigPanel = lazy(async () => ({
+  default: (await import('./cascade-config-panel')).CascadeConfigPanel,
 }))
 const LazyFleetHealthPanel = lazy(async () => ({
   default: (await import('./fleet-health-panel')).FleetHealthPanel,
@@ -45,6 +49,8 @@ export function sectionLabel(section: StatusSection): string {
       return 'Journey'
     case 'runtime':
       return 'Runtime'
+    case 'cascade-config':
+      return 'Cascade Config'
     case 'goal-loop':
       return 'GOAL LOOP'
     case 'fleet-health':
@@ -64,6 +70,8 @@ function renderSection(section: StatusSection) {
       return html`<${LazyJourneyPanel} />`
     case 'runtime':
       return html`<${LazyRuntimePanel} />`
+    case 'cascade-config':
+      return html`<${LazyCascadeConfigPanel} />`
     case 'goal-loop':
       return html`<${LazyGoalLoopPanel} />`
     case 'fleet-health':
@@ -80,6 +88,7 @@ export function normalizeStatusSection(section: string | undefined): StatusSecti
     section === 'observatory'
     || section === 'journey'
     || section === 'runtime'
+    || section === 'cascade-config'
     || section === 'goal-loop'
     || section === 'fleet-health'
     || section === 'cognition'

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -9,7 +9,7 @@ import { LoadingState } from './common/feedback-state'
 
 export type StatusSection =
   | 'observatory' | 'journey' | 'agents' | 'runtime' | 'cascade-config'
-  | 'goal-loop' | 'fleet-health'
+  | 'goal-loop' | 'fleet-health' | 'doctor'
   | 'cognition'
 
 const LazyAgentsUnified = lazy(async () => ({
@@ -23,6 +23,9 @@ const LazyCascadeConfigPanel = lazy(async () => ({
 }))
 const LazyFleetHealthPanel = lazy(async () => ({
   default: (await import('./fleet-health-panel')).FleetHealthPanel,
+}))
+const LazyDoctorPanel = lazy(async () => ({
+  default: (await import('./doctor-panel')).DoctorPanel,
 }))
 const LazyGoalLoopPanel = lazy(async () => ({
   default: (await import('./goal-loop-panel')).GoalLoopPanel,
@@ -55,6 +58,8 @@ export function sectionLabel(section: StatusSection): string {
       return 'GOAL LOOP'
     case 'fleet-health':
       return 'Fleet Health'
+    case 'doctor':
+      return 'Doctor'
     case 'cognition':
       return 'Cognition'
     case 'agents':
@@ -76,6 +81,8 @@ function renderSection(section: StatusSection) {
       return html`<${LazyGoalLoopPanel} />`
     case 'fleet-health':
       return html`<${LazyFleetHealthPanel} />`
+    case 'doctor':
+      return html`<${LazyDoctorPanel} />`
     case 'cognition':
       return html`<${LazyCognitionPlane} />`
     case 'agents':
@@ -91,6 +98,7 @@ export function normalizeStatusSection(section: string | undefined): StatusSecti
     || section === 'cascade-config'
     || section === 'goal-loop'
     || section === 'fleet-health'
+    || section === 'doctor'
     || section === 'cognition'
     || section === 'agents'
   ) return section

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -141,9 +141,10 @@ describe('monitoring navigation labels', () => {
     const ids = sections.map(item => item.id)
 
     expect(defaultParamsForTab('monitoring')).toEqual({ section: 'runtime' })
-    expect(ids).toEqual(['runtime', 'agents', 'goal-loop', 'fleet-health'])
+    expect(ids).toEqual(['runtime', 'cascade-config', 'agents', 'goal-loop', 'fleet-health'])
     expect(ids).toContain('fleet-health')
     expect(ids).toContain('runtime')
+    expect(ids).toContain('cascade-config')
     expect(ids).toContain('agents')
     expect(ids).toContain('goal-loop')
     expect(ids).not.toContain('journey')
@@ -167,9 +168,10 @@ describe('monitoring navigation labels', () => {
   it('puts the operator story first before drill-down status surfaces', () => {
     const sections = visibleSectionItemsForTab('monitoring')
     expect(sections[0]?.id).toBe('runtime')
-    expect(sections[1]?.id).toBe('agents')
-    expect(sections[2]?.id).toBe('goal-loop')
-    expect(sections[3]?.id).toBe('fleet-health')
+    expect(sections[1]?.id).toBe('cascade-config')
+    expect(sections[2]?.id).toBe('agents')
+    expect(sections[3]?.id).toBe('goal-loop')
+    expect(sections[4]?.id).toBe('fleet-health')
   })
 
   it('keeps diagnostic monitoring routes available but hidden from the sidebar', () => {

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -141,12 +141,13 @@ describe('monitoring navigation labels', () => {
     const ids = sections.map(item => item.id)
 
     expect(defaultParamsForTab('monitoring')).toEqual({ section: 'runtime' })
-    expect(ids).toEqual(['runtime', 'cascade-config', 'agents', 'goal-loop', 'fleet-health'])
+    expect(ids).toEqual(['runtime', 'cascade-config', 'agents', 'goal-loop', 'fleet-health', 'doctor'])
     expect(ids).toContain('fleet-health')
     expect(ids).toContain('runtime')
     expect(ids).toContain('cascade-config')
     expect(ids).toContain('agents')
     expect(ids).toContain('goal-loop')
+    expect(ids).toContain('doctor')
     expect(ids).not.toContain('journey')
     expect(ids).not.toContain('cognition')
     // Legacy sections removed in Phase 1
@@ -172,6 +173,7 @@ describe('monitoring navigation labels', () => {
     expect(sections[2]?.id).toBe('agents')
     expect(sections[3]?.id).toBe('goal-loop')
     expect(sections[4]?.id).toBe('fleet-health')
+    expect(sections[5]?.id).toBe('doctor')
   })
 
   it('keeps diagnostic monitoring routes available but hidden from the sidebar', () => {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -21,6 +21,7 @@ type SurfaceSectionId =
   | 'cascade-config' // Dedicated entry for cascade.toml TOML editor (formerly buried inside runtime/cascade view)
   | 'goal-loop'
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
+  | 'doctor'         // Dedicated entry for /api/v1/dashboard/doctor (formerly buried inside Command → Operations → Inspector → "진단" sub-tab)
   // command
   | 'operations'     // Phase 1+6: absorbs intervene + governance + inspector (Phase 7: connectors split out)
   // connectors (Phase 7: top-level surface — sidecar-driven channel bridges)
@@ -198,6 +199,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: 'System Telemetry',
       description: 'System signals for tools and governance.',
       params: { section: 'fleet-health' },
+    },
+    {
+      id: 'doctor',
+      label: 'Doctor',
+      description: 'Sidecar and config doctor diagnostics.',
+      params: { section: 'doctor' },
     },
     {
       id: 'journey',

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -18,6 +18,7 @@ type SurfaceSectionId =
   | 'agents'
   | 'cognition'
   | 'runtime'
+  | 'cascade-config' // Dedicated entry for cascade.toml TOML editor (formerly buried inside runtime/cascade view)
   | 'goal-loop'
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
   // command
@@ -173,6 +174,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: 'Live Runtime',
       description: 'Live cascade routing and provider health.',
       params: { section: 'runtime' },
+    },
+    {
+      id: 'cascade-config',
+      label: 'Cascade Config',
+      description: 'Live cascade.toml editor and diagnostics.',
+      params: { section: 'cascade-config' },
     },
     {
       id: 'agents',

--- a/lib/dashboard/dashboard_nav_event.ml
+++ b/lib/dashboard/dashboard_nav_event.ml
@@ -31,6 +31,7 @@ let valid_sections =
       ; "agents"
       ; "cognition"
       ; "runtime"
+      ; "cascade-config"
       ; "goal-loop"
       ; "fleet-health"
       ] )

--- a/lib/dashboard/dashboard_nav_event.ml
+++ b/lib/dashboard/dashboard_nav_event.ml
@@ -34,6 +34,7 @@ let valid_sections =
       ; "cascade-config"
       ; "goal-loop"
       ; "fleet-health"
+      ; "doctor"
       ] )
   ; "command", [ "operations" ]
   ; "connectors", [ "connector-status" ]


### PR DESCRIPTION
## §1 문제
`cascade-config-panel.ts` 안의 `CascadeRawConfigEditor`는 *이미 존재* (line 1048~)하고 backend POST `/api/v1/cascade/config/raw`까지 wire 되어 있지만, 도달 경로가 *3-hop 매장*:

`Monitor (tab) → Live Runtime (section) → 스크롤 → CollapsibleSection "캐스케이드" 펼침 → 페이지 하단 CascadeConfigPanel 내부 editor`

또는 `view=cascade` filter chip (in-page) 클릭. Nav text나 sidebar에 *editor* 단어가 없어 사용자가 dashboard에서 *cascade.toml 편집 진입점을 못 찾음*.

## §2 변경
Monitor sub-nav에 **`Cascade Config`** 별도 entry 신설. `CascadeConfigPanel`을 RuntimePanel chrome (FilterChips/OAS health/Prometheus/Verification 등) *없이* 직접 mount.

| File | 변경 |
|---|---|
| `dashboard/src/config/navigation.ts` | `SurfaceSectionId += 'cascade-config'`, `DASHBOARD_SECTION_ITEMS.monitoring`에 `runtime` 바로 뒤 새 item |
| `dashboard/src/components/status.ts` | `StatusSection += 'cascade-config'`, lazy import, `sectionLabel`/`renderSection`/`normalizeStatusSection` 케이스 추가 |
| `dashboard/src/config/navigation.test.ts` | 2개 ordered-list assertion에 `cascade-config` 삽입 |

## §3 로컬 검증
- `pnpm typecheck` exit 0
- `pnpm vitest run --config vitest.config.ts src/config/navigation.test.ts` — 45/45 pass
- `pnpm vitest run --config vitest.config.ts src/components/status` — 16/16 pass

## §4 미검증
- 실제 dashboard 띄워서 새 nav item 클릭 → CascadeConfigPanel 렌더 시각 확인 (CI나 staging에서 검증 권장).
- POST 실제 호출 — backend `/api/v1/cascade/config/raw`가 `Masc_domain.CanAdmin` permission 요구하므로 admin token 없으면 save 시 401 에러. UI 메시지 (`Failed to save: …`)로 표시됨 — 기존 panel 동작 그대로.

## §5 트레이드오프
- 같은 `CascadeConfigPanel`이 `Live Runtime > 캐스케이드` CollapsibleSection에도 여전히 render. **의도된 중복**: 기존 북마크/URL 보존. 동일 panel을 두 surface에서 보이는 churn 비용이 문제되면 follow-up으로 RuntimePanel default view에서 `<CollapsibleSection title="캐스케이드"><CascadeConfigPanel /></CollapsibleSection>` 제거 가능.
- 새 section item을 `runtime` 바로 뒤(2번째)에 둠 — nav 순서가 `[runtime, cascade-config, agents, goal-loop, fleet-health]`. operator workflow 상 cascade가 agents보다 위라는 판단. ordering 선호 다르면 한 줄 swap.

## §6 RFC 연결 없음
Dashboard 표면 노출 변경만, RFC subsystem (credential/operator/keeper sandbox/auth) 무관. `bash ~/me/scripts/pr-rfc-check.sh` 대상 외.

## §7 보안/리스크
- Frontend 변경만, backend POST 동작/auth 변경 없음.
- Editor가 더 *발견 가능*해진다는 게 risk surface가 아니라 *기능 정상 작동의 결과*. 누구든 nav 클릭 후 panel 들어가도 save에는 admin auth가 필요 (기존 unchanged).
- Suspense fallback ("Loading Cascade Config...") 동작. 빈 panel 또는 로딩 실패 시 LoadingState 컴포넌트가 처리.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>


---

## Update: Doctor panel surface promotion (+ nav-event allowlist sync)

Second buried-wiring fix in same PR (2026-05-17, commit `7b138882`):

### Why

`/api/v1/dashboard/doctor` envelope (sidecar + config doctor diagnostics) + `docs/DOCTOR-ARCHITECTURE.md` + 366-LoC `DoctorPanel` all exist, but the panel is buried at:

`Command → Operations → Inspector chip → "진단" sub-tab` (4-hop)

Search-engine of the dashboard sidebar has no "doctor"/"진단" keyword reachable.

### What

- `Monitor → Doctor` direct nav section (2-hop)
- Backend `valid_sections` allowlist gains `doctor` (without it, frontend nav-event POST is rejected → telemetry blind to the surface)
- Same allowlist also gains `cascade-config` (originally missing from the cascade-config promotion commit — silent telemetry gap fixed here in the same trip)
- Existing LabInspector `진단` sub-tab retained for backward-compat URLs

### Verification

| Gate | Result |
|---|---|
| `pnpm typecheck` | pass |
| `pnpm vitest run navigation.test.ts` | 45/45 |
| `pnpm vitest run components/status` | 16/16 |
| `dune build @check` | pass |
| `dune exec test/test_dashboard_nav_event.exe` | 14/14 |
