### PR TITLE
fix(cascade): define ollama_cloud_stable + provider_benchmark tier-groups

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -752,6 +752,23 @@ tiers = ["primary", "keeper_diverse", "__safe_lane"]
 strategy = "priority_tier"
 fallback = true
 
+[tier-group.ollama_cloud_stable]
+# Recovery target for cascade_exhausted on local Ollama lanes.
+# Referenced by keeper turn disposition (test_keeper_turn_disposition.ml:280)
+# and by error classifier fallback hints (test_keeper_error_classify_recoverable.ml:187).
+tiers = ["tier_medium", "primary", "__safe_lane"]
+strategy = "priority_tier"
+fallback = true
+
+[tier-group.provider_benchmark]
+# Sweep lane for full provider inventory performance measurement
+# (docs/CASCADE-ROUTES.md §sweep). Background only; isolated from
+# production fallback chains to avoid resource contention with live work.
+tiers = ["primary", "keeper_diverse", "__safe_lane"]
+strategy = "priority_tier"
+fallback = true
+keeper-assignable = false
+
 # ── Routes (logical usage → tier-group) ────────────────────────
 #
 # RFC-0058 §4 R6: route targets resolve to tier-groups, tiers,


### PR DESCRIPTION
## Summary

`tier-group.ollama_cloud_stable` and `tier-group.provider_benchmark` are referenced by code/docs/tests but were never defined in `config/cascade.toml`. Keepers routed to those targets fail with `cascade_exhausted` because `materialized_tier_group_tiers` silently returns `[]` for unknown groups (`lib/cascade/cascade_config.ml:982-988`).

This is Option B / PR-1 (data fix) from the 2026-05-17 cascade tier-group misroute investigation. Loader-side dead-reference invariant ships in PR-2.

## Background

Live `~/me/.masc/config/cascade.toml` had 5 tier-groups self-loop to `glm-coding-with-spark`. Two of those (`strict_tool_candidates`, `local_recovery`) were already recovered to their canonical self-names. The remaining two (`ollama_cloud_stable`, `provider_benchmark`) point at the wrong tier and have no SSOT definition to recover to — this PR adds them.

References that expect the definitions to exist:

| Location | Use |
|---|---|
| `test/test_keeper_turn_disposition.ml:280` | `cascade_exhausted` payload literal |
| `test/test_keeper_error_classify_recoverable.ml:187` | error-classifier fallback hint |
| `docs/CASCADE-ROUTES.md:198,232` | provider_benchmark sweep lane spec |
| `dashboard/src/components/telemetry-unified.test.ts:843` | `oas-tier-group.ollama_cloud_stable` agent name |

## Change

Both definitions follow the canonical `priority_tier` pattern used by sibling tier-groups:

```toml
[tier-group.ollama_cloud_stable]
tiers = ["tier_medium", "primary", "__safe_lane"]
strategy = "priority_tier"
fallback = true

[tier-group.provider_benchmark]
tiers = ["primary", "keeper_diverse", "__safe_lane"]
strategy = "priority_tier"
fallback = true
keeper-assignable = false
```

`provider_benchmark` is marked `keeper-assignable = false` to keep background sweeps from absorbing keeper turn capacity (per `docs/CASCADE-ROUTES.md` §245).

## Why this supersedes #15702 and #15706

- **#15702** added `tier-group.ollama_cloud_stable` but emitted `keeper-assignable = false` four times (TOML duplicate-key defect → Lint/CI fail).
- **#15706** added `tier-group.strict_tool_candidates`, `tier-group.glm-coding-with-spark`, `tier-group.runpod_mtp` — all three are already defined at line 331/341/488, causing TOML duplicate-table errors.

Both are workaround-pattern signatures (#1 telemetry-as-fix variant per `software-development.md`) — they patched the symptom without resolving the silent-failure source in the loader. PR-2 closes that loop.

## Test plan
- [ ] CI Lint passes (no TOML duplicate keys / duplicate tables)
- [ ] CI Build and Test passes
- [ ] `Detect Changed Surfaces` correctly identifies only config/cascade.toml
- [ ] Manual: cascade resolver returns non-empty tier list for both new groups (validated in PR-2 once loader invariant lands)

## Follow-ups
- PR-2: loader invariant — `materialized_tier_group_tiers` rejects unknown groups (cascade_config.ml + cascade_declarative_validator)
- User local config sync: `~/me/.masc/config/cascade.toml` 2 misroutes still point at glm-coding-with-spark; user-side merge after PR-1 lands

RFC-WAIVED: cascade.toml data fix (config-only, no schema/code change). Loader invariant follow-up will reference RFC-0058 §4 R6 and RFC-0027 capability lint context.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
