### PR TITLE
docs(rfc-0058): phase 8 — cascade catalog partial parse resilience

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -98,7 +98,7 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | 0055 | Cascade Fallback Chain Capability-Tier Routing | Superseded | 340008ed7 2026-05-11 | superseded_by 0058 (per #14559 sweep) |
 | 0056 | Incremental Sub-Library Extraction from Flat masc_mcp Library | Active | f003c7421 2026-05-09 | Phase 0 머지 #14384 |
 | 0057 | Tool Descriptor Codegen — `[@@deriving tool]` via Build-Time Generation | Active | 6d11d2a67 2026-05-12 | Phase 0 머지 #14396 |
-| 0058 | Declarative Cascade Configuration (v2) | Active | 39dfa59c4 2026-05-11 | RFC-0058-declarative-cascade-config.md (main) + RFC-0058-phase-5-erase-provider-variant.md + RFC-0058-terminal-fallback-capability-exemption.md (amendment) — Phase 0/1/4/5.2a/9.1 머지 |
+| 0058 | Declarative Cascade Configuration (v2) | Active | (this PR) 2026-05-17 | RFC-0058-declarative-cascade-config.md (main) + RFC-0058-phase-5-erase-provider-variant.md + RFC-0058-terminal-fallback-capability-exemption.md (amendment) + RFC-0058-phase-8-cascade-catalog-partial-parse.md (catalog partial parse) — Phase 0/1/4/5.2a/9.1 머지 |
 | 0059 | IDE LSP Integration + Eio Domain/Actor Parallelism | Active | 340008ed7 2026-05-11 | Phase 2 PR-5/PR-6 closeout per #14559 |
 | 0061 | Cache-invalidation broadcast envelope | Implemented | 2699965d1 2026-05-10 | #14424 |
 | 0062 | Typed `Tool_result.t` + Typed `Sdk_*` Blocker Class | Active | 340008ed7 2026-05-11 | backfill per #14559 |

--- a/docs/rfc/RFC-0058-phase-8-cascade-catalog-partial-parse.md
+++ b/docs/rfc/RFC-0058-phase-8-cascade-catalog-partial-parse.md
@@ -1,0 +1,275 @@
+---
+rfc: "0058"
+title: "Cascade Catalog Partial Parse Resilience"
+status: Draft
+created: 2026-05-17
+updated: 2026-05-17
+author: vincent
+extends: "0058"
+supersedes: []
+superseded_by: null
+related: ["0042", "0027", "0066"]
+implementation_prs: []
+---
+
+# RFC-0058 Phase 8: Cascade Catalog Partial Parse Resilience
+
+| | |
+|---|---|
+| Status | Draft |
+| Depends-on | RFC-0058 §2.4 (Cross-reference validation at load time), Phase 5 (closed variant erase) |
+| Scope | `Cascade_declarative_hotpath.try_load_declarative` return shape; downstream `keeper_cascade_profile` validation; reserved-name fallback obsolescence |
+| Breaking | No — public API is widened (additive); existing `Ok snapshot` shape preserved |
+
+## 1. Problem
+
+cascade.toml has 4 well-formed `[tier-group.*]` entries (`runpod_mtp`, `local_mtp`, `ollama_cloud_stable`, `strict_tool_candidates`). 9 keeper .toml files reference them via `cascade_name = "tier-group.runpod_mtp"` etc.
+
+Server log (2026-05-17 12:29:43, masc-mcp-8935.log:562-686) — all 9 rejected at load time:
+
+```
+[WARN] [Keeper] toml_loader: skipping analyst.toml: ...
+  invalid cascade_name 'tier-group.ollama_cloud_stable' (
+    reserved: tier-group.glm-coding-with-spark, tier-group.strict_tool_candidates;
+    declarative cascade catalog invalid:
+      (Cascade_declarative_adapter.Provider_not_found "claude");
+      (Cascade_declarative_adapter.Binding_resolution_failed "claude.claude-api-sonnet");
+      ...
+  )
+```
+
+cascade.toml in mid-edit state held a stale `[claude.claude-api-sonnet]` binding pointing at a removed `[providers.claude]`. **One stale binding** invalidates the **entire catalog**. Once the catalog is `Error`, keeper toml validation drops to the `reserved_cascade_names` fallback list (2 entries), which excludes 3 of 4 production tier-groups in active use. 9 keepers fail to load even though every tier-group they reference is well-formed.
+
+### 1.1 Live trace — the cliff
+
+`lib/cascade/cascade_declarative_hotpath.ml` exposes:
+
+```ocaml
+val try_load_declarative :
+  string -> (decl_snapshot, adapter_error list) result option
+```
+
+— a binary `Ok snapshot | Error errors`. `lib/keeper/keeper_cascade_profile.ml:105-122` (`declarative_catalog_lookup_names`) forwards binary:
+
+```ocaml
+match Cascade_declarative_hotpath.try_load_declarative path with
+| Some (Ok snapshot) -> Ok (qualified_names_of_declarative_snapshot snapshot ...)
+| Some (Error errors) -> Error ("declarative cascade catalog invalid: " ^ rendered)
+```
+
+`lib/keeper/keeper_types_profile.ml:807-844` consumes that `Error` and drops to `reserved_cascade_names`. Three layers, each fail-closed, compose into total catastrophe for a single bad binding.
+
+### 1.2 Why this violates RFC-0058 §2.4
+
+RFC-0058 §2.4 states *"Cross-reference validation happens at load time."* The intent is *cross-reference invariants are detected at load, not at dispatch*. The current implementation interprets it as *the whole catalog is either invariant-clean or unusable*. A 1-binding error nullifies 11 valid bindings, 4 valid tier-groups, and 19 valid routes. That is not validation — that is fail-stop.
+
+### 1.3 Why `reserved_cascade_names` is also a smell, but not the root
+
+`lib/keeper/keeper_config.ml:35-43` hardcodes `phase_routing_cascade_names = [local_only_cascade_name; local_recovery_cascade_name]` and `tool_use_strict_cascade_name`. `keeper_types_profile.ml:47-50` unions them as `reserved_cascade_names`. These are used as a *safe minimal fallback* when the catalog `Error`-s, and as a fast-path skip in normal validation (line 803-805).
+
+Treating the reserved list as the root would lead to a workaround-class fix: *expand the reserved list to include all production tier-groups*. That is N-of-M (CLAUDE.md §workaround rejection bar): every new tier-group requires an OCaml edit, the SSOT moves *back* into code, and RFC-0058 §2.1 is violated more, not less.
+
+The reserved list is **legitimate as a phase-routing internal**, but **illegitimate as a fallback for missing catalog data**. The right fix is to make the catalog *not need* a hardcoded fallback. That requires Bug B's resolution: partial-parse.
+
+## 2. Root cause
+
+`try_load_declarative` returns a binary result. There is no representation of *partial success*. Every consumer downstream is forced to choose: trust everything, or trust nothing.
+
+The adapter (`lib/cascade/cascade_declarative_adapter.ml:255, 270, 392`) already *accumulates* `errors` in a `ref`, then converts to `Error errors` only at the boundary. Internally it is *already partial* — it builds whatever bindings/tiers/groups it can resolve, and records the rest as errors. The surface throws away the partial result if any error exists.
+
+Quote (`cascade_declarative_adapter.ml:268-273`):
+```ocaml
+| None ->
+    errors :=
+      Binding_resolution_failed (Printf.sprintf "%s.%s" ...) :: !errors;
+    None
+```
+
+— the `Some config` and `None` paths are already handled per-binding. The catalog **could** expose `{ valid_bindings; errors }` honestly. Today it collapses both into `Result`.
+
+## 3. Design
+
+### 3.1 Widen `try_load_declarative` return shape
+
+Add a new structured snapshot result alongside the existing binary one:
+
+```ocaml
+(* lib/cascade/cascade_declarative_hotpath.mli — NEW *)
+
+type partial_load_result = {
+  snapshot : decl_snapshot;
+  (** Always present. Contains whatever bindings/tiers/groups/routes
+      could be resolved. May be empty if every entry failed. *)
+  errors : Cascade_declarative_adapter.adapter_error list;
+  (** Per-entry errors. Empty list = clean parse. Non-empty = partial. *)
+}
+
+val try_load_partial : string -> partial_load_result option
+(** Replacement for [try_load_declarative]. Returns [None] only when the
+    file is not a declarative cascade catalog at all (e.g. legacy profile
+    format). When the file is a declarative catalog, returns
+    [Some { snapshot; errors }] — partial parses surface valid entries
+    in [snapshot] and report failed entries in [errors].
+
+    The [snapshot] obeys the invariant that every binding, tier, and
+    tier-group it contains is internally consistent (all cross-references
+    resolve). Entries with unresolved references are omitted, not
+    half-stitched.
+
+    [try_load_declarative] is retained for backward compatibility:
+    [Some (Ok _) | Some (Error _)] for callers that need binary semantics
+    (notably the boot-time gate at
+    [Cascade_catalog_runtime.validate_path_result], where a fully clean
+    parse is a deliberate hard requirement). *)
+```
+
+Internally `try_load_partial` walks the adapter's per-binding pipeline and stops *only* when there is no resolvable binding to seed the snapshot from. `Ok` is a degenerate case of `try_load_partial` with `errors = []`.
+
+### 3.2 Adapter-level partial invariant
+
+The adapter (`cascade_declarative_adapter.ml`) must preserve the invariant: **a tier-group surfaced in the snapshot has at least one resolvable member**. Tiers that resolve zero members are omitted from the snapshot and emitted as `Tier_group_empty` errors. This avoids the *half-stitched* failure mode (a tier-group with a dangling member reference that crashes at dispatch).
+
+Concretely:
+
+| Adapter unit | Resolves | Surfaces |
+|---|---|---|
+| Binding (`[<p>.<m>]`) | provider + model | self if both present; else `Provider_not_found` / `Model_not_found` |
+| Tier (`[tier.X]`) | member bindings | self if ≥1 member resolved; else `Tier_group_empty "tier.X"` |
+| Tier-group (`[tier-group.G]`) | tier references | self if ≥1 tier resolved; else `Tier_group_empty "tier-group.G"` |
+| Route (`[routes.R]`) | tier-group | self if tier-group resolved; else `Binding_resolution_failed "routes.R"` |
+
+The snapshot already has this shape internally; we change *exposure*, not *resolution semantics*.
+
+### 3.3 Downstream consumers
+
+| Consumer | Today | After |
+|---|---|---|
+| `declarative_public_catalog_names` (kcp.ml:81) | `Error` on any adapter error | `Ok names` from `partial_load_result.snapshot`; log errors to server log once per reload mtime |
+| `declarative_catalog_lookup_names` (kcp.ml:105) | same | same |
+| `catalog_names_for_validation` (kcp.ml:175) | `Error` on any adapter error | `Ok names` from valid subset; keeper toml validation now sees actual tier-groups |
+| `Cascade_catalog_runtime.validate_path_result` (boot gate) | hard fail on any error | **unchanged** — boot still requires clean catalog; partial only applies to live reload |
+| `keeper_types_profile.ml:807-844` fallback path | reached on every adapter error | reached *only* when catalog has zero resolvable entries; reserved list narrows back to *internal phase-routing only* |
+
+The boot-time gate stays strict deliberately: starting up with a broken config should still fail loudly. The change applies to **live reload** and **subsequent toml validation**, where the operator already has the system running and an edit drift should degrade gracefully.
+
+### 3.4 Reserved-name obsolescence
+
+Once `catalog_names_for_validation` returns the valid subset for partial catalogs:
+
+- `reserved_cascade_names` in `keeper_types_profile.ml:47-50` is still used as a *fast-path skip* (line 803-805). That role is fine — it short-circuits for phase-routing internal names (`tier.local_only`, `tier.local_recovery`, `tier-group.strict_tool_candidates`). These are RFC-0058-aligned: they are *names defined by RFC-0066* (phase routing), not vendor names hardcoded.
+- The *fallback* role at line 838-844 (`Error fallback_error` branch) becomes unreachable in practice, because `catalog_names_for_validation` now returns `Ok []` rather than `Error` when the catalog is degraded. Keeping the branch as defensive code is fine; treating it as the production load path is the bug.
+
+No code deletion is mandatory in Phase 8. The fallback becomes correct-but-irrelevant.
+
+## 4. Implementation phases
+
+### Phase 8.1 — Adapter partial surface (this RFC, PR-1)
+
+**Scope (smallest viable):** Add `try_load_partial` + `partial_load_result` to `cascade_declarative_hotpath.{ml,mli}`. Keep `try_load_declarative` as a thin wrapper that returns `Ok snapshot` when `errors = []` and `Error errors` otherwise.
+
+**Files:**
+- `lib/cascade/cascade_declarative_hotpath.ml` — new type, new function, refactor `try_load_declarative` to wrap it.
+- `lib/cascade/cascade_declarative_hotpath.mli` — expose `partial_load_result`, `try_load_partial`.
+
+**Tests:** `test/test_cascade_declarative_hotpath_partial.ml` — fixture with 1 stale binding + 4 valid tier-groups; assert `snapshot.profile_names` contains all 4 tier-group names; `errors` list contains exactly the 1 binding failure.
+
+**No downstream changes in PR-1.** This is a pure surface widening.
+
+### Phase 8.2 — Keeper validation consumes partial (PR-2)
+
+**Scope:** Switch `declarative_public_catalog_names` + `declarative_catalog_lookup_names` to call `try_load_partial` and treat non-empty `errors` as *log + degrade*, not *fail*.
+
+**Files:**
+- `lib/keeper/keeper_cascade_profile.ml:81-130` — replace match arms; emit `Log.Cascade.warn` per unique error per mtime via a small `Hashtbl.t` keyed on `(path, mtime)` to avoid log spam.
+
+**Tests:** `test/test_keeper_cascade_validation_partial.ml` — load cascade.toml with mid-edit drift; assert `catalog_names_for_validation` returns `Ok names` containing the production tier-groups; assert log entries record the dropped entries exactly once.
+
+### Phase 8.3 — Boot gate semantics (PR-3)
+
+**Scope:** Make `Cascade_catalog_runtime.validate_path_result` *explicit* about its strict mode. Document that boot remains all-or-nothing while live reload is partial. Add a `--cascade-allow-partial-boot` operator flag (off by default) for emergency boot with degraded config.
+
+**Files:**
+- `lib/cascade/cascade_catalog_runtime.ml` — flag gate.
+- `bin/server/server_runtime_bootstrap.ml` — flag wiring.
+- `docs/operator/cascade-degraded-mode.md` — operator runbook.
+
+**Skipped if 8.2 covers the live-reload need** without operator-facing boot relaxation. Phase 8.3 is *opt-in extension*, not required for the original 9-keeper-skip incident.
+
+## 5. Non-goals
+
+- Not changing `provider_kind` variant elimination (that is RFC-0058 Phase 5).
+- Not making *invalid binding repair* automatic (no fuzzy matching, no "did you mean"). The adapter reports the error; the operator fixes the toml.
+- Not expanding `reserved_cascade_names` to cover production tier-groups — explicitly rejected per CLAUDE.md §workaround rejection bar §3 (N-of-M abstraction absence).
+- Not changing dispatch-time behavior. Cascade at runtime still operates on the resolved snapshot; this RFC only changes which snapshot reaches the runtime when the source toml has partial errors.
+
+## 6. Verification
+
+### 6.1 Reproduction of the 2026-05-17 incident
+
+```bash
+# Setup: cascade.toml with a stale [claude.claude-api-sonnet] binding
+# but valid [tier-group.runpod_mtp] etc.
+
+# Before this RFC:
+$ sb masc keeper-list
+# 9 keepers (analyst, imseonghan, jobsian_purist, masc-improver,
+#  ramarama, sangsu, scholar, tech_glutton, velvet-hammer) skip on load.
+
+# After this RFC (Phase 8.1 + 8.2):
+$ sb masc keeper-list
+# 16 keepers load. Server log records:
+#   [WARN] [Cascade] catalog drift in cascade.toml mtime=...:
+#     Binding_resolution_failed "claude.claude-api-sonnet"
+#   (logged once per mtime)
+```
+
+### 6.2 Bug B is the only fix needed; Bug A is implicitly resolved
+
+Once Phase 8.2 lands:
+
+- Keeper toml validation reaches `catalog_names_for_validation` → `Ok [tier-group.runpod_mtp; tier-group.local_mtp; ...]`.
+- Reserved fallback branch (kcp_types_profile.ml:838-844) becomes unreachable on the production codepath. It remains as defensive code for the catastrophic case (catalog has zero resolvable entries, e.g. corrupted file).
+- No edit to `reserved_cascade_names` is required.
+
+This is **one fix, not two**. The earlier diagnosis treating Bug A as a separate concern was wrong — it would have led to a workaround-class expansion of the reserved list.
+
+### 6.3 Property — partial snapshot invariant
+
+`test/test_cascade_declarative_hotpath_partial.ml` asserts via property-based generation:
+
+```
+∀ catalog c:
+  let { snapshot; errors } = try_load_partial c in
+  every tier-group g in snapshot has ≥1 resolvable member
+  every tier t in snapshot has ≥1 resolvable binding
+  errors ∩ snapshot.profile_names = ∅
+```
+
+## 7. Migration
+
+No operator action required. cascade.toml schema unchanged. Existing keepers that were already loading continue to load. Keepers that were silently skipped due to upstream catalog errors begin loading on the next live reload after Phase 8.2.
+
+`try_load_declarative` is preserved as a backward-compat wrapper for the duration of Phase 8. Removal candidate after Phase 8.3 ships and no internal caller uses the binary form.
+
+## 8. Open questions
+
+- **Q: Should `Tier_group_empty` for *expected-to-be-empty during edit* tier-groups be elevated to error or silenced?** Tentative: keep as `WARN`, dedup by `(path, mtime, tier-group-name)`. Operators editing cascade.toml often leave temporarily empty groups; spamming the log obstructs the actual edit.
+- **Q: Boot gate — does `cascade-allow-partial-boot` introduce a footgun?** Tentative: yes, hence off-by-default. Operators using it must accept that some keepers will not auto-boot. The dashboard should reflect this via a banner. Phase 8.3 follow-up.
+- **Q: Hot-reload of `try_load_partial` — does it interact with the existing additive merge?** No: `try_load_partial` is a pure function of the file at a given path+mtime. The merge layer at `Cascade_catalog_runtime` continues to compare snapshots and swap atomically.
+
+## 9. References
+
+- `lib/cascade/cascade_declarative_hotpath.ml:32` — `decl_snapshot`
+- `lib/cascade/cascade_declarative_adapter.ml:17-24` — `adapter_error`
+- `lib/keeper/keeper_cascade_profile.ml:81-130` — current binary consumers
+- `lib/keeper/keeper_types_profile.ml:47-50, 803-844` — `reserved_cascade_names` site
+- `lib/keeper/keeper_config.ml:35-43` — phase routing cascade names (legitimate internal use)
+- `~/me/.masc/logs/masc-mcp-8935.log:562-686` — incident trace 2026-05-17 12:29:43
+- RFC-0058 §2.1, §2.4 — *Code never knows provider names*, *Cross-reference validation at load time*
+- CLAUDE.md §워크어라운드 거부 기준 §3 — N-of-M abstraction absence (basis for rejecting reserved-list expansion)
+
+## 10. Implementation log
+
+(Filled in as PRs land.)
+
+- 2026-05-17 — RFC body draft on `feat/rfc-0058-phase-8-cascade-toml-ssot`. PR-1 (Phase 8.1 adapter partial surface) in progress.

--- a/lib/cascade/cascade_declarative_hotpath.ml
+++ b/lib/cascade/cascade_declarative_hotpath.ml
@@ -134,20 +134,37 @@ let adapted_catalog_to_snapshot ~source_path (ac : adapted_catalog) :
 
 (* --- TOML loading --- *)
 
-let try_load_declarative (config_path : string) :
-    (decl_snapshot, adapter_error list) result option =
+type partial_load_result = {
+  snapshot : decl_snapshot;
+  errors : adapter_error list;
+}
+
+let try_load_partial (config_path : string) : partial_load_result option =
   match Cascade_declarative_parser.parse_file config_path with
   | Error _ -> None  (* not a 5-layer TOML *)
   | Ok cfg ->
     let catalog = adapt_config cfg in
     match adapted_catalog_to_snapshot ~source_path:config_path catalog with
     | Some snapshot ->
-      if List.length catalog.errors > 0 then
-        Some (Error catalog.errors)
-      else
-        Some (Ok snapshot)
+      Some { snapshot; errors = catalog.errors }
     | None ->
-      Some (Error catalog.errors)
+      (* No profile resolvable. Caller falls back to the legacy loader. *)
+      None
+
+let try_load_declarative (config_path : string) :
+    (decl_snapshot, adapter_error list) result option =
+  match try_load_partial config_path with
+  | None -> (
+    (* Preserve historical behavior: when no profile resolved but the
+       parse step itself produced adapter errors, surface them as Error
+       so the boot gate can still report the catalog state. *)
+    match Cascade_declarative_parser.parse_file config_path with
+    | Error _ -> None
+    | Ok cfg ->
+      let catalog = adapt_config cfg in
+      Some (Error catalog.errors))
+  | Some { snapshot; errors = [] } -> Some (Ok snapshot)
+  | Some { snapshot = _; errors } -> Some (Error errors)
 
 (* --- Route bindings --- *)
 

--- a/lib/cascade/cascade_declarative_hotpath.mli
+++ b/lib/cascade/cascade_declarative_hotpath.mli
@@ -60,13 +60,40 @@ val adapted_catalog_to_snapshot :
 
 (** {1 TOML loading} *)
 
+type partial_load_result = {
+  snapshot : decl_snapshot;
+  errors : Cascade_declarative_adapter.adapter_error list;
+}
+(** Result of a partial catalog load. [snapshot] always contains the
+    subset of profiles whose internal cross-references resolved
+    successfully. [errors] lists per-entry failures (unresolved
+    provider/model/binding/tier). [errors = []] is the all-clean case.
+
+    Surfacing both fields at the same time lets downstream callers (notably
+    keeper toml validation) accept the valid subset while logging the
+    failed entries — see RFC-0058 Phase 8. *)
+
+val try_load_partial : string -> partial_load_result option
+(** [try_load_partial config_path] attempts to parse a 5-layer TOML and
+    convert it to a partial snapshot.
+
+    Returns:
+    - [Some { snapshot; errors = [] }] — 5-layer TOML, all entries resolved
+    - [Some { snapshot; errors = e :: _ }] — 5-layer TOML, partial parse;
+      [snapshot] contains the resolvable subset
+    - [None] — not a 5-layer TOML (parse failed), or no entry resolvable
+      at all (caller should fall back to the legacy profile loader) *)
+
 val try_load_declarative :
   string ->
   (decl_snapshot,
     Cascade_declarative_adapter.adapter_error list)
   result option
-(** [try_load_declarative config_path] attempts to parse a 5-layer TOML
-    and convert it to a snapshot.
+(** Backward-compatible binary variant of {!try_load_partial}: collapses
+    a partial result to [Error] when any error is present, otherwise
+    returns [Ok snapshot]. Retained for boot-gate callers that require
+    all-or-nothing semantics (e.g.
+    [Cascade_catalog_runtime.validate_path_result]).
 
     Returns:
     - [Some (Ok snapshot)] — 5-layer TOML found and fully converted

--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -413,6 +413,88 @@ target = "tier-group.glm-coding-with-spark"
          "expected one provider config, got %d"
          (List.length cfgs))
 
+(* --- RFC-0058 Phase 8: partial parse --- *)
+
+(* Reproduces the 2026-05-17 keeper-skip incident: a stale [<ghost>.<m>]
+   binding referencing a removed provider used to invalidate the
+   entire catalog at the [try_load_declarative] surface, even though
+   well-formed tier-groups elsewhere in the file resolved cleanly.
+   See RFC-0058 Phase 8 §1. *)
+let partial_toml = {|
+[providers.ollama]
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+
+[models.qwen3]
+max-context = 32768
+api-name = "qwen3:8b"
+tools-support = true
+
+[ollama.qwen3]
+
+[tier.local]
+members = ["ollama.qwen3"]
+strategy = "failover"
+
+[tier-group.local-group]
+tiers = ["local"]
+strategy = "failover"
+
+# Stale binding — provider [providers.ghost] does not exist.
+# Before Phase 8 this single error invalidates the whole catalog.
+[ghost.ghost-model]
+max-concurrent = 1
+|}
+
+let write_temp_toml content =
+  let path = Filename.temp_file "rfc0058_phase8" ".toml" in
+  write_file path content;
+  path
+
+let test_try_load_partial_returns_snapshot_with_errors () =
+  let path = write_temp_toml partial_toml in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      match Hotpath.try_load_partial path with
+      | None ->
+        fail
+          "expected Some partial_load_result (catalog has resolvable \
+           tier-group.local-group), got None"
+      | Some { snapshot; errors } ->
+        check bool "snapshot has profiles" true
+          (List.length snapshot.Hotpath.profiles > 0);
+        check bool "errors recorded" true (List.length errors > 0);
+        let names = Hotpath.decl_snapshot_profile_names snapshot in
+        check bool
+          "tier-group.local-group surfaces in partial snapshot" true
+          (List.exists (fun n -> n = "tier-group.local-group") names))
+
+let test_try_load_declarative_collapses_partial_to_error () =
+  let path = write_temp_toml partial_toml in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      match Hotpath.try_load_declarative path with
+      | None -> fail "expected Some result"
+      | Some (Ok _) ->
+        fail
+          "backward-compat shim must surface Error when partial errors \
+           exist; got Ok"
+      | Some (Error errors) ->
+        check bool "binary shim reports errors" true
+          (List.length errors > 0))
+
+let test_try_load_partial_clean_has_no_errors () =
+  let path = write_temp_toml valid_toml in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      match Hotpath.try_load_partial path with
+      | None -> fail "expected Some for clean valid_toml"
+      | Some { snapshot = _; errors } ->
+        check int "clean parse has no errors" 0 (List.length errors))
+
 (* --- Test suite --- *)
 
 let () =
@@ -455,5 +537,20 @@ let () =
           "runtime resolution uses direct declarative Provider_config"
           `Quick
           test_runtime_resolution_uses_direct_declarative_provider_config;
+      ];
+      "phase8_partial_parse",
+      [
+        test_case
+          "try_load_partial surfaces snapshot + errors for partial catalog"
+          `Quick
+          test_try_load_partial_returns_snapshot_with_errors;
+        test_case
+          "try_load_declarative remains binary (Error on partial)"
+          `Quick
+          test_try_load_declarative_collapses_partial_to_error;
+        test_case
+          "try_load_partial clean parse has empty errors"
+          `Quick
+          test_try_load_partial_clean_has_no_errors;
       ];
     ]


### PR DESCRIPTION
## Summary

RFC-0058 Phase 8.1 — adapter surface widening to expose partial parse results from `Cascade_declarative_hotpath`. One stale binding (e.g. a `[claude.claude-api-sonnet]` entry referencing a removed `[providers.claude]`) used to invalidate the entire declarative catalog at the outermost surface, even though the adapter internally already resolves bindings/tiers/groups per-entry. This PR surfaces a `partial_load_result` so downstream callers can accept the valid subset while logging failed entries.

**No behavior change in this PR** — `try_load_partial` is added but no caller switches to it yet. Phase 8.2 (separate PR) switches `keeper_cascade_profile`'s validation helpers to consume the partial result and unblocks the 9-keeper-skip incident from 2026-05-17.

RFC-EXTEND: 0058

## Why

2026-05-17 incident — `~/me/.masc/logs/masc-mcp-8935.log:562-686`:

```
[WARN] [Keeper] toml_loader: skipping analyst.toml: ...
  invalid cascade_name 'tier-group.ollama_cloud_stable' (
    reserved: tier-group.glm-coding-with-spark, tier-group.strict_tool_candidates;
    declarative cascade catalog invalid:
      (Cascade_declarative_adapter.Provider_not_found "claude"); ...)
```

9 keepers (analyst, imseonghan, jobsian_purist, masc-improver, ramarama, sangsu, scholar, tech_glutton, velvet-hammer) skipped because one stale binding in cascade.toml collapsed `try_load_declarative` to `Error`. The validator dropped to a 2-name reserved fallback that excluded 3 production tier-groups.

The reserved-fallback expansion is the obvious wrong fix — N-of-M (CLAUDE.md §워크어라운드 거부 기준 §3): every new tier-group requires an OCaml edit, the SSOT moves back into code, RFC-0058 §2.1 violated more, not less. Rejected in RFC §1.3.

The right fix lives one layer up: the adapter is already partial-aware (`adapted_catalog_to_snapshot` builds a snapshot from the resolvable subset and accumulates per-entry errors). The outermost surface throws that partial result away. This PR stops that.

## RFC 인용 (agent_delegation §3)

- `docs/rfc/RFC-0058-declarative-cascade-config.md` — parent RFC, §2.1 *"Code never knows provider names"*, §2.4 *"Cross-reference validation at load time"*
- `docs/rfc/RFC-0058-phase-8-cascade-catalog-partial-parse.md` — this PR's body RFC (included in same PR)
- `docs/rfc/RFC-0042-keeper-terminal-code-closed-sum.md` — related closed-sum-type pattern
- `docs/rfc/RFC-0066-legacy-models-catalog-purge.md` — related catalog provenance lineage

`ls docs/rfc/` shows RFC-0058 main + phase-5 + terminal-fallback-amendment exist; this PR adds phase-8 as a new sub-doc per the multi-phase convention (README.md §정책).

## What changed

| File | Direction | Notes |
|---|---|---|
| `docs/rfc/RFC-0058-phase-8-cascade-catalog-partial-parse.md` | new | Phase 8 RFC body, Draft status |
| `docs/rfc/README.md` | edit | Append phase-8 sub-doc to RFC-0058 row, refresh Last activity |
| `lib/cascade/cascade_declarative_hotpath.mli` | +30/-1 | Add `partial_load_result` type, add `try_load_partial` |
| `lib/cascade/cascade_declarative_hotpath.ml` | +24/-7 | Implement `try_load_partial`; refactor `try_load_declarative` as a binary backward-compat shim |
| `test/test_cascade_declarative_hotpath.ml` | +97/-0 | 3 property tests in `phase8_partial_parse` group |

## Test plan

- [x] `dune build --root . lib/` passes
- [x] `dune build --root . test/test_cascade_declarative_hotpath.exe` passes
- [x] `dune exec --root . test/test_cascade_declarative_hotpath.exe` — 18/18 tests green (15 pre-existing + 3 new)
- [x] Phase 8.1 has zero callers — no downstream consumer switched, behavior identical
- [x] `try_load_declarative` retains binary semantics (test: `collapses_partial_to_error`)
- [x] Reproduction fixture (stale `[ghost.ghost-model]` + valid `[tier-group.local-group]`) — `try_load_partial` returns snapshot with tier-group present + errors list non-empty (test: `returns_snapshot_with_errors`)

## Workaround rejection self-check (CLAUDE.md §체크리스트 7항목)

- [ ] telemetry-as-fix: counter/log demote only → **NO**, structural surface widening
- [ ] string/substring classifier added → **NO**
- [ ] N-of-M (reserved list expansion) → **NO**, explicitly rejected in §1.3
- [ ] catch-all `_ ->` added → **NO**
- [ ] cap/cooldown/dedup/repair → **NO**
- [ ] test backdoor (`set_X_for_test`) → **NO**
- [ ] same typo/off-by-one fixed N times → **NO**, first occurrence

Clean. RFC scope explicitly anti-workaround per §1.3.

## Boot gate

`Cascade_catalog_runtime.validate_path_result` (boot gate) is **unchanged** — it still requires a clean catalog. Partial parse applies to *live reload + subsequent toml validation* only. Phase 8.3 (later, opt-in) introduces a `--cascade-allow-partial-boot` flag for the catastrophic-boot edge case. Out of scope here.

## Next steps

- Phase 8.2 (separate PR): switch `keeper_cascade_profile.{declarative_public_catalog_names, declarative_catalog_lookup_names, catalog_names_for_validation}` to consume `try_load_partial`. This is the PR that **actually unblocks** the 9 keepers — Phase 8.1 only widens the surface.
- Phase 8.3 (opt-in extension): operator flag for boot-time partial tolerance + dashboard banner. Skipped if 8.2 is sufficient operationally.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
