### PR TITLE
fix(keeper): mark cancelled async messages terminal

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -309,6 +309,19 @@ let set_status request_id status =
     | None -> ())
 ;;
 
+let set_status_protected request_id status =
+  Eio.Cancel.protect (fun () -> set_status request_id status)
+;;
+
+let cancelled_lost_status exn =
+  Lost
+    { reason =
+        Printf.sprintf
+          "keeper_msg worker cancelled before terminal result: %s"
+          (Printexc.to_string exn)
+    }
+;;
+
 (** Submit a keeper_msg turn for async execution.
     Forks a background fiber on [sw], returns the request_id immediately. *)
 let submit ~sw ~base_path ~(f : unit -> tool_result) ~keeper_name : string =
@@ -328,20 +341,20 @@ let submit ~sw ~base_path ~(f : unit -> tool_result) ~keeper_name : string =
     Hashtbl.replace pending request_id entry;
     persist_entry entry);
   Eio.Fiber.fork_daemon ~sw (fun () ->
-    set_status request_id Running;
+    set_status_protected request_id Running;
     let result =
       try
         let ok, body = f () in
         Done { ok; body }
       with
-      | Eio.Cancel.Cancelled _ as e -> raise e
+      | Eio.Cancel.Cancelled _ as e -> cancelled_lost_status e
       | exn ->
         Done
           { ok = false
           ; body = Printf.sprintf "keeper_msg failed: %s" (Printexc.to_string exn)
           }
     in
-    set_status request_id result;
+    set_status_protected request_id result;
     `Stop_daemon);
   request_id
 ;;

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -31,8 +31,9 @@ type entry =
 
 (** [submit ~sw ~f ~keeper_name] forks a background daemon fiber on
     [sw] that runs [f] and stores the result. Returns the fresh
-    [request_id] synchronously. Cancellation of [sw] cancels the
-    fiber. *)
+    [request_id] synchronously. Cancellation of [sw] interrupts the
+    worker and records a terminal [Lost] state before stopping, so
+    pollers do not observe an indefinite [Running] request. *)
 val submit
   :  sw:Eio.Switch.t
   -> base_path:string

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -27,6 +27,37 @@ let wait_for_running request_id =
   loop 200
 ;;
 
+let wait_for_lost request_id =
+  let rec loop remaining =
+    match Keeper_msg_async.poll request_id with
+    | Some ({ status = Lost _; _ } as entry) -> entry
+    | _ when remaining <= 0 ->
+      failwith (Printf.sprintf "request %s did not become lost" request_id)
+    | _ ->
+      Eio.Fiber.yield ();
+      loop (remaining - 1)
+  in
+  loop 200
+;;
+
+let contains_substring ~needle value =
+  let needle_len = String.length needle in
+  let value_len = String.length value in
+  if needle_len = 0
+  then true
+  else if needle_len > value_len
+  then false
+  else (
+    let rec loop i =
+      if i + needle_len > value_len
+      then false
+      else if String.equal (String.sub value i needle_len) needle
+      then true
+      else loop (i + 1)
+    in
+    loop 0)
+;;
+
 let temp_dir prefix =
   let path = Filename.temp_file prefix "" in
   Sys.remove path;
@@ -141,6 +172,34 @@ let test_keeper_msg_async_marks_recovered_inflight_lost () =
   | None -> Alcotest.fail "expected persisted request"
 ;;
 
+let test_keeper_msg_async_marks_cancelled_worker_lost () =
+  with_eio_env
+  @@ fun _env ->
+  let request_id =
+    Eio.Switch.run
+    @@ fun sw ->
+    let never, _resolver = Eio.Promise.create () in
+    let request_id =
+      Keeper_msg_async.submit ~sw ~base_path:(temp_dir "keeper-msg-async-cancel-")
+        ~keeper_name:"cancelled" ~f:(fun () ->
+          Eio.Promise.await never;
+          true, "{}")
+    in
+    ignore (wait_for_running request_id : Keeper_msg_async.entry);
+    request_id
+  in
+  match wait_for_lost request_id with
+  | { Keeper_msg_async.status = Lost { reason }; completed_at = Some _; _ } ->
+    Alcotest.(check bool) "lost reason mentions cancellation" true
+      (contains_substring ~needle:"cancelled" (String.lowercase_ascii reason))
+  | { Keeper_msg_async.status = Lost _; completed_at = None; _ } ->
+    Alcotest.fail "expected cancelled request to have completed_at"
+  | entry ->
+    Alcotest.failf
+      "expected cancelled request to be lost, got %s"
+      (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status)
+;;
+
 let test_keeper_msg_async_gc_removes_stale_terminal_disk_record () =
   with_eio_env
   @@ fun _env ->
@@ -239,6 +298,10 @@ let () =
             "recover in-flight request as lost"
             `Quick
             test_keeper_msg_async_marks_recovered_inflight_lost
+        ; test_case
+            "cancelled worker is terminal lost"
+            `Quick
+            test_keeper_msg_async_marks_cancelled_worker_lost
         ; test_case
             "gc removes stale terminal disk record"
             `Quick


### PR DESCRIPTION
## Summary

- Mark cancelled `masc_keeper_msg` async workers as terminal `lost` instead of leaving request status at `running`.
- Persist terminal status under cancellation using `Eio.Cancel.protect`.
- Add a regression test for a cancelled worker exiting the switch scope.

## Product impact

Polling `masc_keeper_msg_result` no longer gets stuck forever when a keeper message worker is cancelled before producing a normal result.

## Evidence

- `scripts/dune-local.sh build test/test_keeper_mutex_coverage.exe`
- `./_build/default/test/test_keeper_mutex_coverage.exe` (8 tests passed)
- `git diff --check`

## Review evidence

- Verified the new cancellation case reports terminal `Lost` with `completed_at`.
- Verified existing disk recovery and GC tests still pass.

## Linked issue

- Follow-up from live Sangsu voice/keeper async investigation; no GitHub issue linked yet.
