### PR TITLE
fix(keeper): consume partial cascade catalog in validation helpers

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -98,7 +98,7 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | 0055 | Cascade Fallback Chain Capability-Tier Routing | Superseded | 340008ed7 2026-05-11 | superseded_by 0058 (per #14559 sweep) |
 | 0056 | Incremental Sub-Library Extraction from Flat masc_mcp Library | Active | f003c7421 2026-05-09 | Phase 0 머지 #14384 |
 | 0057 | Tool Descriptor Codegen — `[@@deriving tool]` via Build-Time Generation | Active | 6d11d2a67 2026-05-12 | Phase 0 머지 #14396 |
-| 0058 | Declarative Cascade Configuration (v2) | Active | 39dfa59c4 2026-05-11 | RFC-0058-declarative-cascade-config.md (main) + RFC-0058-phase-5-erase-provider-variant.md + RFC-0058-terminal-fallback-capability-exemption.md (amendment) — Phase 0/1/4/5.2a/9.1 머지 |
+| 0058 | Declarative Cascade Configuration (v2) | Active | (this PR) 2026-05-17 | RFC-0058-declarative-cascade-config.md (main) + RFC-0058-phase-5-erase-provider-variant.md + RFC-0058-terminal-fallback-capability-exemption.md (amendment) + RFC-0058-phase-8-cascade-catalog-partial-parse.md (catalog partial parse) — Phase 0/1/4/5.2a/9.1 머지 |
 | 0059 | IDE LSP Integration + Eio Domain/Actor Parallelism | Active | 340008ed7 2026-05-11 | Phase 2 PR-5/PR-6 closeout per #14559 |
 | 0061 | Cache-invalidation broadcast envelope | Implemented | 2699965d1 2026-05-10 | #14424 |
 | 0062 | Typed `Tool_result.t` + Typed `Sdk_*` Blocker Class | Active | 340008ed7 2026-05-11 | backfill per #14559 |

--- a/docs/rfc/RFC-0058-phase-8-cascade-catalog-partial-parse.md
+++ b/docs/rfc/RFC-0058-phase-8-cascade-catalog-partial-parse.md
@@ -1,0 +1,275 @@
+---
+rfc: "0058"
+title: "Cascade Catalog Partial Parse Resilience"
+status: Draft
+created: 2026-05-17
+updated: 2026-05-17
+author: vincent
+extends: "0058"
+supersedes: []
+superseded_by: null
+related: ["0042", "0027", "0066"]
+implementation_prs: []
+---
+
+# RFC-0058 Phase 8: Cascade Catalog Partial Parse Resilience
+
+| | |
+|---|---|
+| Status | Draft |
+| Depends-on | RFC-0058 §2.4 (Cross-reference validation at load time), Phase 5 (closed variant erase) |
+| Scope | `Cascade_declarative_hotpath.try_load_declarative` return shape; downstream `keeper_cascade_profile` validation; reserved-name fallback obsolescence |
+| Breaking | No — public API is widened (additive); existing `Ok snapshot` shape preserved |
+
+## 1. Problem
+
+cascade.toml has 4 well-formed `[tier-group.*]` entries (`runpod_mtp`, `local_mtp`, `ollama_cloud_stable`, `strict_tool_candidates`). 9 keeper .toml files reference them via `cascade_name = "tier-group.runpod_mtp"` etc.
+
+Server log (2026-05-17 12:29:43, masc-mcp-8935.log:562-686) — all 9 rejected at load time:
+
+```
+[WARN] [Keeper] toml_loader: skipping analyst.toml: ...
+  invalid cascade_name 'tier-group.ollama_cloud_stable' (
+    reserved: tier-group.glm-coding-with-spark, tier-group.strict_tool_candidates;
+    declarative cascade catalog invalid:
+      (Cascade_declarative_adapter.Provider_not_found "claude");
+      (Cascade_declarative_adapter.Binding_resolution_failed "claude.claude-api-sonnet");
+      ...
+  )
+```
+
+cascade.toml in mid-edit state held a stale `[claude.claude-api-sonnet]` binding pointing at a removed `[providers.claude]`. **One stale binding** invalidates the **entire catalog**. Once the catalog is `Error`, keeper toml validation drops to the `reserved_cascade_names` fallback list (2 entries), which excludes 3 of 4 production tier-groups in active use. 9 keepers fail to load even though every tier-group they reference is well-formed.
+
+### 1.1 Live trace — the cliff
+
+`lib/cascade/cascade_declarative_hotpath.ml` exposes:
+
+```ocaml
+val try_load_declarative :
+  string -> (decl_snapshot, adapter_error list) result option
+```
+
+— a binary `Ok snapshot | Error errors`. `lib/keeper/keeper_cascade_profile.ml:105-122` (`declarative_catalog_lookup_names`) forwards binary:
+
+```ocaml
+match Cascade_declarative_hotpath.try_load_declarative path with
+| Some (Ok snapshot) -> Ok (qualified_names_of_declarative_snapshot snapshot ...)
+| Some (Error errors) -> Error ("declarative cascade catalog invalid: " ^ rendered)
+```
+
+`lib/keeper/keeper_types_profile.ml:807-844` consumes that `Error` and drops to `reserved_cascade_names`. Three layers, each fail-closed, compose into total catastrophe for a single bad binding.
+
+### 1.2 Why this violates RFC-0058 §2.4
+
+RFC-0058 §2.4 states *"Cross-reference validation happens at load time."* The intent is *cross-reference invariants are detected at load, not at dispatch*. The current implementation interprets it as *the whole catalog is either invariant-clean or unusable*. A 1-binding error nullifies 11 valid bindings, 4 valid tier-groups, and 19 valid routes. That is not validation — that is fail-stop.
+
+### 1.3 Why `reserved_cascade_names` is also a smell, but not the root
+
+`lib/keeper/keeper_config.ml:35-43` hardcodes `phase_routing_cascade_names = [local_only_cascade_name; local_recovery_cascade_name]` and `tool_use_strict_cascade_name`. `keeper_types_profile.ml:47-50` unions them as `reserved_cascade_names`. These are used as a *safe minimal fallback* when the catalog `Error`-s, and as a fast-path skip in normal validation (line 803-805).
+
+Treating the reserved list as the root would lead to a workaround-class fix: *expand the reserved list to include all production tier-groups*. That is N-of-M (CLAUDE.md §workaround rejection bar): every new tier-group requires an OCaml edit, the SSOT moves *back* into code, and RFC-0058 §2.1 is violated more, not less.
+
+The reserved list is **legitimate as a phase-routing internal**, but **illegitimate as a fallback for missing catalog data**. The right fix is to make the catalog *not need* a hardcoded fallback. That requires Bug B's resolution: partial-parse.
+
+## 2. Root cause
+
+`try_load_declarative` returns a binary result. There is no representation of *partial success*. Every consumer downstream is forced to choose: trust everything, or trust nothing.
+
+The adapter (`lib/cascade/cascade_declarative_adapter.ml:255, 270, 392`) already *accumulates* `errors` in a `ref`, then converts to `Error errors` only at the boundary. Internally it is *already partial* — it builds whatever bindings/tiers/groups it can resolve, and records the rest as errors. The surface throws away the partial result if any error exists.
+
+Quote (`cascade_declarative_adapter.ml:268-273`):
+```ocaml
+| None ->
+    errors :=
+      Binding_resolution_failed (Printf.sprintf "%s.%s" ...) :: !errors;
+    None
+```
+
+— the `Some config` and `None` paths are already handled per-binding. The catalog **could** expose `{ valid_bindings; errors }` honestly. Today it collapses both into `Result`.
+
+## 3. Design
+
+### 3.1 Widen `try_load_declarative` return shape
+
+Add a new structured snapshot result alongside the existing binary one:
+
+```ocaml
+(* lib/cascade/cascade_declarative_hotpath.mli — NEW *)
+
+type partial_load_result = {
+  snapshot : decl_snapshot;
+  (** Always present. Contains whatever bindings/tiers/groups/routes
+      could be resolved. May be empty if every entry failed. *)
+  errors : Cascade_declarative_adapter.adapter_error list;
+  (** Per-entry errors. Empty list = clean parse. Non-empty = partial. *)
+}
+
+val try_load_partial : string -> partial_load_result option
+(** Replacement for [try_load_declarative]. Returns [None] only when the
+    file is not a declarative cascade catalog at all (e.g. legacy profile
+    format). When the file is a declarative catalog, returns
+    [Some { snapshot; errors }] — partial parses surface valid entries
+    in [snapshot] and report failed entries in [errors].
+
+    The [snapshot] obeys the invariant that every binding, tier, and
+    tier-group it contains is internally consistent (all cross-references
+    resolve). Entries with unresolved references are omitted, not
+    half-stitched.
+
+    [try_load_declarative] is retained for backward compatibility:
+    [Some (Ok _) | Some (Error _)] for callers that need binary semantics
+    (notably the boot-time gate at
+    [Cascade_catalog_runtime.validate_path_result], where a fully clean
+    parse is a deliberate hard requirement). *)
+```
+
+Internally `try_load_partial` walks the adapter's per-binding pipeline and stops *only* when there is no resolvable binding to seed the snapshot from. `Ok` is a degenerate case of `try_load_partial` with `errors = []`.
+
+### 3.2 Adapter-level partial invariant
+
+The adapter (`cascade_declarative_adapter.ml`) must preserve the invariant: **a tier-group surfaced in the snapshot has at least one resolvable member**. Tiers that resolve zero members are omitted from the snapshot and emitted as `Tier_group_empty` errors. This avoids the *half-stitched* failure mode (a tier-group with a dangling member reference that crashes at dispatch).
+
+Concretely:
+
+| Adapter unit | Resolves | Surfaces |
+|---|---|---|
+| Binding (`[<p>.<m>]`) | provider + model | self if both present; else `Provider_not_found` / `Model_not_found` |
+| Tier (`[tier.X]`) | member bindings | self if ≥1 member resolved; else `Tier_group_empty "tier.X"` |
+| Tier-group (`[tier-group.G]`) | tier references | self if ≥1 tier resolved; else `Tier_group_empty "tier-group.G"` |
+| Route (`[routes.R]`) | tier-group | self if tier-group resolved; else `Binding_resolution_failed "routes.R"` |
+
+The snapshot already has this shape internally; we change *exposure*, not *resolution semantics*.
+
+### 3.3 Downstream consumers
+
+| Consumer | Today | After |
+|---|---|---|
+| `declarative_public_catalog_names` (kcp.ml:81) | `Error` on any adapter error | `Ok names` from `partial_load_result.snapshot`; log errors to server log once per reload mtime |
+| `declarative_catalog_lookup_names` (kcp.ml:105) | same | same |
+| `catalog_names_for_validation` (kcp.ml:175) | `Error` on any adapter error | `Ok names` from valid subset; keeper toml validation now sees actual tier-groups |
+| `Cascade_catalog_runtime.validate_path_result` (boot gate) | hard fail on any error | **unchanged** — boot still requires clean catalog; partial only applies to live reload |
+| `keeper_types_profile.ml:807-844` fallback path | reached on every adapter error | reached *only* when catalog has zero resolvable entries; reserved list narrows back to *internal phase-routing only* |
+
+The boot-time gate stays strict deliberately: starting up with a broken config should still fail loudly. The change applies to **live reload** and **subsequent toml validation**, where the operator already has the system running and an edit drift should degrade gracefully.
+
+### 3.4 Reserved-name obsolescence
+
+Once `catalog_names_for_validation` returns the valid subset for partial catalogs:
+
+- `reserved_cascade_names` in `keeper_types_profile.ml:47-50` is still used as a *fast-path skip* (line 803-805). That role is fine — it short-circuits for phase-routing internal names (`tier.local_only`, `tier.local_recovery`, `tier-group.strict_tool_candidates`). These are RFC-0058-aligned: they are *names defined by RFC-0066* (phase routing), not vendor names hardcoded.
+- The *fallback* role at line 838-844 (`Error fallback_error` branch) becomes unreachable in practice, because `catalog_names_for_validation` now returns `Ok []` rather than `Error` when the catalog is degraded. Keeping the branch as defensive code is fine; treating it as the production load path is the bug.
+
+No code deletion is mandatory in Phase 8. The fallback becomes correct-but-irrelevant.
+
+## 4. Implementation phases
+
+### Phase 8.1 — Adapter partial surface (this RFC, PR-1)
+
+**Scope (smallest viable):** Add `try_load_partial` + `partial_load_result` to `cascade_declarative_hotpath.{ml,mli}`. Keep `try_load_declarative` as a thin wrapper that returns `Ok snapshot` when `errors = []` and `Error errors` otherwise.
+
+**Files:**
+- `lib/cascade/cascade_declarative_hotpath.ml` — new type, new function, refactor `try_load_declarative` to wrap it.
+- `lib/cascade/cascade_declarative_hotpath.mli` — expose `partial_load_result`, `try_load_partial`.
+
+**Tests:** `test/test_cascade_declarative_hotpath_partial.ml` — fixture with 1 stale binding + 4 valid tier-groups; assert `snapshot.profile_names` contains all 4 tier-group names; `errors` list contains exactly the 1 binding failure.
+
+**No downstream changes in PR-1.** This is a pure surface widening.
+
+### Phase 8.2 — Keeper validation consumes partial (PR-2)
+
+**Scope:** Switch `declarative_public_catalog_names` + `declarative_catalog_lookup_names` to call `try_load_partial` and treat non-empty `errors` as *log + degrade*, not *fail*.
+
+**Files:**
+- `lib/keeper/keeper_cascade_profile.ml:81-130` — replace match arms; emit `Log.Cascade.warn` per unique error per mtime via a small `Hashtbl.t` keyed on `(path, mtime)` to avoid log spam.
+
+**Tests:** `test/test_keeper_cascade_validation_partial.ml` — load cascade.toml with mid-edit drift; assert `catalog_names_for_validation` returns `Ok names` containing the production tier-groups; assert log entries record the dropped entries exactly once.
+
+### Phase 8.3 — Boot gate semantics (PR-3)
+
+**Scope:** Make `Cascade_catalog_runtime.validate_path_result` *explicit* about its strict mode. Document that boot remains all-or-nothing while live reload is partial. Add a `--cascade-allow-partial-boot` operator flag (off by default) for emergency boot with degraded config.
+
+**Files:**
+- `lib/cascade/cascade_catalog_runtime.ml` — flag gate.
+- `bin/server/server_runtime_bootstrap.ml` — flag wiring.
+- `docs/operator/cascade-degraded-mode.md` — operator runbook.
+
+**Skipped if 8.2 covers the live-reload need** without operator-facing boot relaxation. Phase 8.3 is *opt-in extension*, not required for the original 9-keeper-skip incident.
+
+## 5. Non-goals
+
+- Not changing `provider_kind` variant elimination (that is RFC-0058 Phase 5).
+- Not making *invalid binding repair* automatic (no fuzzy matching, no "did you mean"). The adapter reports the error; the operator fixes the toml.
+- Not expanding `reserved_cascade_names` to cover production tier-groups — explicitly rejected per CLAUDE.md §workaround rejection bar §3 (N-of-M abstraction absence).
+- Not changing dispatch-time behavior. Cascade at runtime still operates on the resolved snapshot; this RFC only changes which snapshot reaches the runtime when the source toml has partial errors.
+
+## 6. Verification
+
+### 6.1 Reproduction of the 2026-05-17 incident
+
+```bash
+# Setup: cascade.toml with a stale [claude.claude-api-sonnet] binding
+# but valid [tier-group.runpod_mtp] etc.
+
+# Before this RFC:
+$ sb masc keeper-list
+# 9 keepers (analyst, imseonghan, jobsian_purist, masc-improver,
+#  ramarama, sangsu, scholar, tech_glutton, velvet-hammer) skip on load.
+
+# After this RFC (Phase 8.1 + 8.2):
+$ sb masc keeper-list
+# 16 keepers load. Server log records:
+#   [WARN] [Cascade] catalog drift in cascade.toml mtime=...:
+#     Binding_resolution_failed "claude.claude-api-sonnet"
+#   (logged once per mtime)
+```
+
+### 6.2 Bug B is the only fix needed; Bug A is implicitly resolved
+
+Once Phase 8.2 lands:
+
+- Keeper toml validation reaches `catalog_names_for_validation` → `Ok [tier-group.runpod_mtp; tier-group.local_mtp; ...]`.
+- Reserved fallback branch (kcp_types_profile.ml:838-844) becomes unreachable on the production codepath. It remains as defensive code for the catastrophic case (catalog has zero resolvable entries, e.g. corrupted file).
+- No edit to `reserved_cascade_names` is required.
+
+This is **one fix, not two**. The earlier diagnosis treating Bug A as a separate concern was wrong — it would have led to a workaround-class expansion of the reserved list.
+
+### 6.3 Property — partial snapshot invariant
+
+`test/test_cascade_declarative_hotpath_partial.ml` asserts via property-based generation:
+
+```
+∀ catalog c:
+  let { snapshot; errors } = try_load_partial c in
+  every tier-group g in snapshot has ≥1 resolvable member
+  every tier t in snapshot has ≥1 resolvable binding
+  errors ∩ snapshot.profile_names = ∅
+```
+
+## 7. Migration
+
+No operator action required. cascade.toml schema unchanged. Existing keepers that were already loading continue to load. Keepers that were silently skipped due to upstream catalog errors begin loading on the next live reload after Phase 8.2.
+
+`try_load_declarative` is preserved as a backward-compat wrapper for the duration of Phase 8. Removal candidate after Phase 8.3 ships and no internal caller uses the binary form.
+
+## 8. Open questions
+
+- **Q: Should `Tier_group_empty` for *expected-to-be-empty during edit* tier-groups be elevated to error or silenced?** Tentative: keep as `WARN`, dedup by `(path, mtime, tier-group-name)`. Operators editing cascade.toml often leave temporarily empty groups; spamming the log obstructs the actual edit.
+- **Q: Boot gate — does `cascade-allow-partial-boot` introduce a footgun?** Tentative: yes, hence off-by-default. Operators using it must accept that some keepers will not auto-boot. The dashboard should reflect this via a banner. Phase 8.3 follow-up.
+- **Q: Hot-reload of `try_load_partial` — does it interact with the existing additive merge?** No: `try_load_partial` is a pure function of the file at a given path+mtime. The merge layer at `Cascade_catalog_runtime` continues to compare snapshots and swap atomically.
+
+## 9. References
+
+- `lib/cascade/cascade_declarative_hotpath.ml:32` — `decl_snapshot`
+- `lib/cascade/cascade_declarative_adapter.ml:17-24` — `adapter_error`
+- `lib/keeper/keeper_cascade_profile.ml:81-130` — current binary consumers
+- `lib/keeper/keeper_types_profile.ml:47-50, 803-844` — `reserved_cascade_names` site
+- `lib/keeper/keeper_config.ml:35-43` — phase routing cascade names (legitimate internal use)
+- `~/me/.masc/logs/masc-mcp-8935.log:562-686` — incident trace 2026-05-17 12:29:43
+- RFC-0058 §2.1, §2.4 — *Code never knows provider names*, *Cross-reference validation at load time*
+- CLAUDE.md §워크어라운드 거부 기준 §3 — N-of-M abstraction absence (basis for rejecting reserved-list expansion)
+
+## 10. Implementation log
+
+(Filled in as PRs land.)
+
+- 2026-05-17 — RFC body draft on `feat/rfc-0058-phase-8-cascade-toml-ssot`. PR-1 (Phase 8.1 adapter partial surface) in progress.

--- a/lib/cascade/cascade_declarative_hotpath.ml
+++ b/lib/cascade/cascade_declarative_hotpath.ml
@@ -134,20 +134,37 @@ let adapted_catalog_to_snapshot ~source_path (ac : adapted_catalog) :
 
 (* --- TOML loading --- *)
 
-let try_load_declarative (config_path : string) :
-    (decl_snapshot, adapter_error list) result option =
+type partial_load_result = {
+  snapshot : decl_snapshot;
+  errors : adapter_error list;
+}
+
+let try_load_partial (config_path : string) : partial_load_result option =
   match Cascade_declarative_parser.parse_file config_path with
   | Error _ -> None  (* not a 5-layer TOML *)
   | Ok cfg ->
     let catalog = adapt_config cfg in
     match adapted_catalog_to_snapshot ~source_path:config_path catalog with
     | Some snapshot ->
-      if List.length catalog.errors > 0 then
-        Some (Error catalog.errors)
-      else
-        Some (Ok snapshot)
+      Some { snapshot; errors = catalog.errors }
     | None ->
-      Some (Error catalog.errors)
+      (* No profile resolvable. Caller falls back to the legacy loader. *)
+      None
+
+let try_load_declarative (config_path : string) :
+    (decl_snapshot, adapter_error list) result option =
+  match try_load_partial config_path with
+  | None -> (
+    (* Preserve historical behavior: when no profile resolved but the
+       parse step itself produced adapter errors, surface them as Error
+       so the boot gate can still report the catalog state. *)
+    match Cascade_declarative_parser.parse_file config_path with
+    | Error _ -> None
+    | Ok cfg ->
+      let catalog = adapt_config cfg in
+      Some (Error catalog.errors))
+  | Some { snapshot; errors = [] } -> Some (Ok snapshot)
+  | Some { snapshot = _; errors } -> Some (Error errors)
 
 (* --- Route bindings --- *)
 

--- a/lib/cascade/cascade_declarative_hotpath.mli
+++ b/lib/cascade/cascade_declarative_hotpath.mli
@@ -60,13 +60,40 @@ val adapted_catalog_to_snapshot :
 
 (** {1 TOML loading} *)
 
+type partial_load_result = {
+  snapshot : decl_snapshot;
+  errors : Cascade_declarative_adapter.adapter_error list;
+}
+(** Result of a partial catalog load. [snapshot] always contains the
+    subset of profiles whose internal cross-references resolved
+    successfully. [errors] lists per-entry failures (unresolved
+    provider/model/binding/tier). [errors = []] is the all-clean case.
+
+    Surfacing both fields at the same time lets downstream callers (notably
+    keeper toml validation) accept the valid subset while logging the
+    failed entries — see RFC-0058 Phase 8. *)
+
+val try_load_partial : string -> partial_load_result option
+(** [try_load_partial config_path] attempts to parse a 5-layer TOML and
+    convert it to a partial snapshot.
+
+    Returns:
+    - [Some { snapshot; errors = [] }] — 5-layer TOML, all entries resolved
+    - [Some { snapshot; errors = e :: _ }] — 5-layer TOML, partial parse;
+      [snapshot] contains the resolvable subset
+    - [None] — not a 5-layer TOML (parse failed), or no entry resolvable
+      at all (caller should fall back to the legacy profile loader) *)
+
 val try_load_declarative :
   string ->
   (decl_snapshot,
     Cascade_declarative_adapter.adapter_error list)
   result option
-(** [try_load_declarative config_path] attempts to parse a 5-layer TOML
-    and convert it to a snapshot.
+(** Backward-compatible binary variant of {!try_load_partial}: collapses
+    a partial result to [Error] when any error is present, otherwise
+    returns [Ok snapshot]. Retained for boot-gate callers that require
+    all-or-nothing semantics (e.g.
+    [Cascade_catalog_runtime.validate_path_result]).
 
     Returns:
     - [Some (Ok snapshot)] — 5-layer TOML found and fully converted

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -78,6 +78,23 @@ let lookup_names_of_qualified_names names =
   (names @ List.map strip_declarative_profile_prefix names)
   |> List.sort_uniq String.compare
 
+(* RFC-0058 Phase 8.2: switch to [try_load_partial] so a single stale
+   binding does not invalidate the whole catalog. Adapter errors are
+   logged but the resolvable subset is still exposed to keeper toml
+   validation. See RFC-0058-phase-8-cascade-catalog-partial-parse.md §3.3. *)
+let log_partial_catalog_errors ~path
+    (errors : Cascade_declarative_adapter.adapter_error list) =
+  if errors <> [] then
+    let rendered =
+      errors
+      |> List.map Cascade_declarative_adapter.show_adapter_error
+      |> String.concat "; "
+    in
+    Log.Keeper.warn
+      "declarative cascade catalog has %d adapter error(s) in %s; \
+       surfacing valid subset to keeper validation: %s"
+      (List.length errors) path rendered
+
 let declarative_public_catalog_names ?config_path () =
   let path_opt =
     match config_path with
@@ -87,19 +104,13 @@ let declarative_public_catalog_names ?config_path () =
   match path_opt with
   | None -> Error "cascade catalog path is not resolved"
   | Some path -> (
-      match Cascade_declarative_hotpath.try_load_declarative path with
-      | Some (Ok snapshot) ->
+      match Cascade_declarative_hotpath.try_load_partial path with
+      | Some { snapshot; errors } ->
+          log_partial_catalog_errors ~path errors;
           let names = public_names_of_declarative_snapshot snapshot in
           if names = []
           then Error "declarative cascade catalog contains no profiles"
           else Ok names
-      | Some (Error errors) ->
-          let rendered =
-            errors
-            |> List.map Cascade_declarative_adapter.show_adapter_error
-            |> String.concat "; "
-          in
-          Error ("declarative cascade catalog invalid: " ^ rendered)
       | None -> Error "cascade.toml is not a declarative cascade catalog")
 
 let declarative_catalog_lookup_names ?config_path () =
@@ -111,8 +122,9 @@ let declarative_catalog_lookup_names ?config_path () =
   match path_opt with
   | None -> Error "cascade catalog path is not resolved"
   | Some path -> (
-      match Cascade_declarative_hotpath.try_load_declarative path with
-      | Some (Ok snapshot) ->
+      match Cascade_declarative_hotpath.try_load_partial path with
+      | Some { snapshot; errors } ->
+          log_partial_catalog_errors ~path errors;
           let names =
             qualified_names_of_declarative_snapshot snapshot
             |> lookup_names_of_qualified_names
@@ -120,13 +132,6 @@ let declarative_catalog_lookup_names ?config_path () =
           if names = []
           then Error "declarative cascade catalog contains no profiles"
           else Ok names
-      | Some (Error errors) ->
-          let rendered =
-            errors
-            |> List.map Cascade_declarative_adapter.show_adapter_error
-            |> String.concat "; "
-          in
-          Error ("declarative cascade catalog invalid: " ^ rendered)
       | None -> Error "cascade.toml is not a declarative cascade catalog")
 
 (** RFC-0066 Phase 2: prefer the live validated snapshot (declarative

--- a/test/dune
+++ b/test/dune
@@ -221,6 +221,7 @@
         test_cascade_declarative_validator
         test_cascade_declarative_adapter
         test_cascade_declarative_hotpath
+        test_keeper_cascade_profile_partial
         test_doctor_dispatch
         test_disk_hygiene_script
         test_run_local_script
@@ -466,6 +467,7 @@
           test_cascade_declarative_validator
           test_cascade_declarative_adapter
           test_cascade_declarative_hotpath
+          test_keeper_cascade_profile_partial
           test_doctor_dispatch
           test_disk_hygiene_script
           test_run_local_script

--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -413,6 +413,88 @@ target = "tier-group.glm-coding-with-spark"
          "expected one provider config, got %d"
          (List.length cfgs))
 
+(* --- RFC-0058 Phase 8: partial parse --- *)
+
+(* Reproduces the 2026-05-17 keeper-skip incident: a stale [<ghost>.<m>]
+   binding referencing a removed provider used to invalidate the
+   entire catalog at the [try_load_declarative] surface, even though
+   well-formed tier-groups elsewhere in the file resolved cleanly.
+   See RFC-0058 Phase 8 §1. *)
+let partial_toml = {|
+[providers.ollama]
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+
+[models.qwen3]
+max-context = 32768
+api-name = "qwen3:8b"
+tools-support = true
+
+[ollama.qwen3]
+
+[tier.local]
+members = ["ollama.qwen3"]
+strategy = "failover"
+
+[tier-group.local-group]
+tiers = ["local"]
+strategy = "failover"
+
+# Stale binding — provider [providers.ghost] does not exist.
+# Before Phase 8 this single error invalidates the whole catalog.
+[ghost.ghost-model]
+max-concurrent = 1
+|}
+
+let write_temp_toml content =
+  let path = Filename.temp_file "rfc0058_phase8" ".toml" in
+  write_file path content;
+  path
+
+let test_try_load_partial_returns_snapshot_with_errors () =
+  let path = write_temp_toml partial_toml in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      match Hotpath.try_load_partial path with
+      | None ->
+        fail
+          "expected Some partial_load_result (catalog has resolvable \
+           tier-group.local-group), got None"
+      | Some { snapshot; errors } ->
+        check bool "snapshot has profiles" true
+          (List.length snapshot.Hotpath.profiles > 0);
+        check bool "errors recorded" true (List.length errors > 0);
+        let names = Hotpath.decl_snapshot_profile_names snapshot in
+        check bool
+          "tier-group.local-group surfaces in partial snapshot" true
+          (List.exists (fun n -> n = "tier-group.local-group") names))
+
+let test_try_load_declarative_collapses_partial_to_error () =
+  let path = write_temp_toml partial_toml in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      match Hotpath.try_load_declarative path with
+      | None -> fail "expected Some result"
+      | Some (Ok _) ->
+        fail
+          "backward-compat shim must surface Error when partial errors \
+           exist; got Ok"
+      | Some (Error errors) ->
+        check bool "binary shim reports errors" true
+          (List.length errors > 0))
+
+let test_try_load_partial_clean_has_no_errors () =
+  let path = write_temp_toml valid_toml in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      match Hotpath.try_load_partial path with
+      | None -> fail "expected Some for clean valid_toml"
+      | Some { snapshot = _; errors } ->
+        check int "clean parse has no errors" 0 (List.length errors))
+
 (* --- Test suite --- *)
 
 let () =
@@ -455,5 +537,20 @@ let () =
           "runtime resolution uses direct declarative Provider_config"
           `Quick
           test_runtime_resolution_uses_direct_declarative_provider_config;
+      ];
+      "phase8_partial_parse",
+      [
+        test_case
+          "try_load_partial surfaces snapshot + errors for partial catalog"
+          `Quick
+          test_try_load_partial_returns_snapshot_with_errors;
+        test_case
+          "try_load_declarative remains binary (Error on partial)"
+          `Quick
+          test_try_load_declarative_collapses_partial_to_error;
+        test_case
+          "try_load_partial clean parse has empty errors"
+          `Quick
+          test_try_load_partial_clean_has_no_errors;
       ];
     ]

--- a/test/test_keeper_cascade_profile_partial.ml
+++ b/test/test_keeper_cascade_profile_partial.ml
@@ -1,0 +1,143 @@
+(** RFC-0058 Phase 8.2: keeper-side validation accepts partial catalogs.
+
+    Reproduces 2026-05-17 incident — a stale binding referencing a removed
+    provider used to make
+    [Keeper_cascade_profile.declarative_public_catalog_names] return
+    [Error "declarative cascade catalog invalid: ..."], dropping keeper
+    toml validation onto the [reserved_cascade_names] fallback. With the
+    Phase 8 partial-parse surface and Phase 8.2 caller switch, the same
+    fixture must surface the valid tier-group names via [Ok names].
+
+    @stability Internal *)
+
+open Alcotest
+
+module KCP = Masc_mcp.Keeper_cascade_profile
+
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+external test_unsetenv : string -> unit = "masc_test_unsetenv"
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> test_unsetenv name)
+    f
+
+(* Same shape as the 2026-05-17 cascade.toml mid-edit state: one stale
+   binding plus a valid tier-group. The valid tier-group must reach
+   the keeper validator. *)
+let partial_cascade_toml = {|
+[providers.ollama]
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+
+[models.qwen3]
+max-context = 32768
+api-name = "qwen3:8b"
+tools-support = true
+
+[ollama.qwen3]
+
+[tier.local]
+members = ["ollama.qwen3"]
+strategy = "failover"
+
+[tier-group.local-group]
+tiers = ["local"]
+strategy = "failover"
+
+# Stale binding — referenced provider absent.
+[ghost.ghost-model]
+max-concurrent = 1
+|}
+
+let with_temp_cascade_config toml f =
+  let root = Filename.temp_file "rfc0058_phase8_2" "" in
+  Sys.remove root;
+  Unix.mkdir root 0o700;
+  let config_dir = Filename.concat root "config" in
+  Unix.mkdir config_dir 0o700;
+  let cascade_path = Filename.concat config_dir "cascade.toml" in
+  write_file cascade_path toml;
+  let cleanup () =
+    Config_dir_resolver.reset ();
+    (try Sys.remove cascade_path with _ -> ());
+    (try Unix.rmdir config_dir with _ -> ());
+    (try Unix.rmdir root with _ -> ())
+  in
+  Config_dir_resolver.reset ();
+  Fun.protect
+    ~finally:cleanup
+    (fun () -> with_env "MASC_CONFIG_DIR" config_dir (fun () -> f cascade_path))
+
+(* The public API used by keeper toml validation
+   (see [Keeper_types_profile] cascade_name validation, line ~807). *)
+let test_catalog_names_for_validation_surface_partial () =
+  with_temp_cascade_config partial_cascade_toml (fun cascade_path ->
+    match KCP.catalog_names_for_validation ~config_path:cascade_path () with
+    | Error msg ->
+      fail
+        (Printf.sprintf
+           "keeper validator must accept partial catalog; got Error: %s"
+           msg)
+    | Ok names ->
+      (* This is the exact predicate that prevented the 9 keepers from
+         loading on 2026-05-17. Now it accepts the valid subset. *)
+      check bool "keeper validator accepts partial catalog" true
+        (List.length names > 0);
+      check bool "tier-group.local-group surfaces (qualified or stripped)" true
+        (List.exists
+           (fun n -> n = "tier-group.local-group" || n = "local-group")
+           names))
+
+(* [catalog_names] is the read-mostly accessor used by dashboard /
+   diagnostic surfaces. It must also surface valid subset. *)
+let test_catalog_names_surface_partial () =
+  with_temp_cascade_config partial_cascade_toml (fun cascade_path ->
+    let names = KCP.catalog_names ~config_path:cascade_path () in
+    check bool "catalog_names returns non-empty for partial" true
+      (List.length names > 0);
+    check bool "tier-group.local-group present" true
+      (List.exists (fun n -> n = "local-group") names))
+
+let test_catalog_names_result_surface_partial () =
+  with_temp_cascade_config partial_cascade_toml (fun cascade_path ->
+    match KCP.catalog_names_result ~config_path:cascade_path () with
+    | Error msg ->
+      fail
+        (Printf.sprintf
+           "catalog_names_result must return Ok for partial; got Error: %s"
+           msg)
+    | Ok names ->
+      check bool "result variant accepts partial" true
+        (List.length names > 0))
+
+let () =
+  run
+    "RFC-0058 Phase 8.2: Keeper-side partial catalog acceptance"
+    [
+      "partial_catalog_consumption",
+      [
+        test_case
+          "catalog_names_for_validation accepts partial (incident gate)"
+          `Quick
+          test_catalog_names_for_validation_surface_partial;
+        test_case
+          "catalog_names returns valid subset for partial"
+          `Quick
+          test_catalog_names_surface_partial;
+        test_case
+          "catalog_names_result returns Ok for partial"
+          `Quick
+          test_catalog_names_result_surface_partial;
+      ];
+    ]


### PR DESCRIPTION
## Summary

**Phase 8.2 of RFC-0058** — switch keeper-side cascade validation helpers (`declarative_public_catalog_names`, `declarative_catalog_lookup_names`) to consume the partial parse surface added in Phase 8.1 (PR #15733). This is the change that **actually unblocks** the 2026-05-17 9-keeper-skip incident; Phase 8.1 only widened the adapter surface without changing any caller.

**Stacked on PR #15733** (Phase 8.1). This PR's base branch is `feat/rfc-0058-phase-8-cascade-toml-ssot` (Phase 8.1). Merge order: 8.1 → 8.2.

RFC-EXTEND: 0058

## Why

The 2026-05-17 incident (server log `masc-mcp-8935.log:562-686`):

```
[WARN] [Keeper] toml_loader: skipping analyst.toml: ...
  invalid cascade_name 'tier-group.ollama_cloud_stable' (
    reserved: tier-group.glm-coding-with-spark, tier-group.strict_tool_candidates;
    declarative cascade catalog invalid:
      (Cascade_declarative_adapter.Provider_not_found "claude"); ...)
```

9 keepers (analyst, imseonghan, jobsian_purist, masc-improver, ramarama, sangsu, scholar, tech_glutton, velvet-hammer) skipped because `catalog_names_for_validation` returned `Error` whenever cascade.toml held even one unresolvable binding, and the validator dropped to a 2-name reserved fallback that excluded 3 production tier-groups (`runpod_mtp`, `local_mtp`, `ollama_cloud_stable`).

Phase 8.1 made the adapter surface a `partial_load_result` (snapshot + errors). This PR makes the keeper validators consume it:

- `declarative_public_catalog_names` — surface valid subset, log errors via `Log.Keeper.warn`
- `declarative_catalog_lookup_names` — same
- `catalog_names_for_validation` — flows through `declarative_catalog_lookup_names`, so it now accepts partial too

## RFC 인용 (agent_delegation §3)

- `docs/rfc/RFC-0058-declarative-cascade-config.md` — parent RFC
- `docs/rfc/RFC-0058-phase-8-cascade-catalog-partial-parse.md` — this RFC (introduced in #15733)
- `RFC-EXTEND: 0058`

`ls docs/rfc/` confirms the phase-8 sub-doc is present on this branch (inherited from base #15733).

## What changed

| File | Direction | Notes |
|---|---|---|
| `lib/keeper/keeper_cascade_profile.ml` | +24/-18 | Add `log_partial_catalog_errors`; switch two declarative helpers to `try_load_partial` |
| `test/test_keeper_cascade_profile_partial.ml` | new | 3 integration tests against the public API |
| `test/dune` | +2 | Register new test binary |

## Test plan

- [x] `dune build --root . lib/` passes
- [x] `dune exec test/test_keeper_cascade_profile_partial.exe` — 3/3 green
  - `catalog_names_for_validation accepts partial (incident gate)`
  - `catalog_names returns valid subset for partial`
  - `catalog_names_result returns Ok for partial`
- [x] `dune exec test/test_cascade_declarative_hotpath.exe` — 18/18 green (no Phase 8.1 regression)

## Workaround rejection self-check

- [ ] telemetry-as-fix → **NO**, the structural switch to partial is the fix; `Log.Keeper.warn` is incidental observability already used elsewhere in this module
- [ ] string/substring classifier → **NO**
- [ ] N-of-M → **NO**, two helper sites share a single `log_partial_catalog_errors` helper; no per-call-site copy
- [ ] catch-all `_ ->` → **NO**, only `Some {...}` and `None` arms
- [ ] cap/cooldown/dedup/repair → **NO**. Log dedup is deliberately deferred — adding it preemptively would be the §4 anti-pattern. If log volume becomes an operational problem after this PR ships, a separate PR can add `(path, mtime)`-keyed dedup with an `Atomic.t`-backed Hashtbl.
- [ ] test backdoor → **NO**. `?config_path` is the existing public API parameter, not a test backdoor.
- [ ] same fix N sites → **NO**. Single root, single PR.

## Boot gate (unchanged)

`Cascade_catalog_runtime.validate_path_result` still uses the binary `try_load_declarative` deliberately. Boot remains all-or-nothing. Phase 8.3 (later, separate RFC effort) introduces an opt-in `--cascade-allow-partial-boot` operator flag with a dashboard banner. Out of scope here.

## Merge order

1. **Merge PR #15733 first** (Phase 8.1, surface widening, zero callers — safe)
2. **Then this PR** (Phase 8.2, caller switch, behavior change)

This PR's commits are stacked on #15733's branch; once #15733 lands, this PR will need a rebase onto main (or admin-merge in sequence per masc-mcp's `feedback_masc_mcp_admin_merge_fast_track` pattern).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
