### PR TITLE
ci(ocamlformat): early-exit for 0-file diffs + explicit opam cache

### DIFF
--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -25,20 +25,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up OCaml
-        uses: ocaml/setup-ocaml@v3
-        with:
-          ocaml-compiler: '5.2'
-
-      - name: Install ocamlformat
-        run: |
-          version=$(grep -E '^version' .ocamlformat | head -1 | awk -F= '{gsub(/[ \t]/,"",$2); print $2}')
-          if [ -z "$version" ]; then
-            echo "::error::no version pin in .ocamlformat"
-            exit 1
-          fi
-          opam install -y "ocamlformat.${version}"
-
+      # Move changed-file detection BEFORE OCaml setup so 0-file PRs skip the
+      # ~120s setup-ocaml + opam install entirely (paths filter already triggers
+      # on .ocamlformat or workflow yaml changes, where there may be no .ml diff).
       - name: Identify changed OCaml files
         id: changed
         run: |
@@ -58,6 +47,45 @@ jobs:
             echo "Changed OCaml files:"
             cat /tmp/changed-ocaml-files.txt
           fi
+
+      - name: Read ocamlformat version pin
+        id: pin
+        if: steps.changed.outputs.no_files != 'true'
+        run: |
+          set -euo pipefail
+          version=$(grep -E '^version' .ocamlformat | head -1 | awk -F= '{gsub(/[ \t]/,"",$2); print $2}')
+          if [ -z "$version" ]; then
+            echo "::error::no version pin in .ocamlformat"
+            exit 1
+          fi
+          echo "ocamlformat_version=$version" >> "$GITHUB_OUTPUT"
+
+      # Explicit cache scoped to ocamlformat version + ocaml-compiler + OS so a
+      # second run of any PR (or a PR after a previous PR populated the same
+      # ocamlformat version) reuses the opam switch instead of rebuilding it.
+      # Namespace is distinct from setup-ocaml-toolchain composite (different
+      # cache prefix), so no cross-contamination.
+      - name: Cache opam (ocamlformat)
+        if: steps.changed.outputs.no_files != 'true'
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.opam
+            ~/.local/share/opam
+          key: opam-ocamlformat-${{ steps.pin.outputs.ocamlformat_version }}-ocaml-5.2-${{ runner.os }}-v1
+          restore-keys: |
+            opam-ocamlformat-${{ steps.pin.outputs.ocamlformat_version }}-ocaml-5.2-${{ runner.os }}-
+
+      - name: Set up OCaml
+        if: steps.changed.outputs.no_files != 'true'
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: '5.2'
+
+      - name: Install ocamlformat
+        if: steps.changed.outputs.no_files != 'true'
+        run: |
+          opam install -y "ocamlformat.${{ steps.pin.outputs.ocamlformat_version }}"
 
       - name: Check formatting (changed files only)
         if: steps.changed.outputs.no_files != 'true'


### PR DESCRIPTION
## Summary

Reduce `ocamlformat-check` wall-clock for paths-filter-triggered PRs that change zero .ml/.mli files.

## Evidence (measured)

| Run | Workflow PR | ocamlformat-check time | Cache state |
|-----|-------------|----------------------:|-------------|
| Before (cold) | PR #15725 (3 .ml edits) | **134s** | empty |
| Before (warm, force-rerun) | PR #15725 | **138s** | `setup-ocaml@v3` internal cache populated → **no measurable benefit** |
| **After (this PR, yml-only)** | PR #15741 | **13s (~90% reduction)** | 0-file early-exit gate applied |

The cache step effect cannot be self-measured by this PR (yml-only ⇒ 0-file ⇒ cache step also if-gated). Verification of cache hit on a subsequent .ml-changing PR is the next measurement.

## Changes

1. **Identify changed files FIRST**: Move the diff step before OCaml setup. Gate setup/install/check on `no_files != 'true'`. 0-file PRs (paths-filter matches `.ocamlformat` or workflow yaml, no .ml diff) now exit in seconds instead of paying ~120s for nothing.

2. **Explicit `actions/cache@v5`**: Cache `~/.opam` keyed by ocamlformat version + ocaml-compiler + runner.os. Distinct namespace from `setup-ocaml-toolchain` composite (different cache prefix).

## Risk

- Low. Read-only PR-time CI improvement, no production code change.
- `setup-ocaml@v3` may detect existing opam state in `~/.opam` from cache restore and skip reinit. If it doesn't, worst case = cache step adds ~5s overhead with no benefit. Measurable on the first .ml-changing PR after merge.
- `paths` filter unchanged. Behavior on 0-file PRs is functionally equivalent: skip check, exit 0.

## Test plan

- [x] CI on this PR (yml-only) passes — ocamlformat-check at 13s confirms early-exit gate works
- [ ] CI 2nd run on a .ml-changing PR after merge shows reduced ocamlformat-check time vs current baseline (verifies cache effect)
- [ ] Cross-PR cache reuse measured on subsequent .ml-changing PR with same `.ocamlformat` pin

## Out of scope

- `Lint` (179s) and `Health` (190s) wall-clock — those already use `setup-ocaml-toolchain` composite with explicit cache; their wall-clock is dominated by `dune build @install --force`, not setup.
- `TLA+ Model Checking` (1323s) — intentional path-scope per ci.yml L970-974 ("stay path-scoped... so a spec violation introduced by a non-tla-path PR is detected on the next main run rather than persisting silently"). Narrowing it is a workaround risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)