### PR TITLE
feat(dashboard): promote Observatory to Monitor section (Activity Timeline)

### DIFF
--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -107,6 +107,7 @@ describe('monitoring navigation labels', () => {
     expect(labelFor('agents')).toBe('Agent Observatory')
     expect(labelFor('goal-loop')).toBe('Goal Navigator')
     expect(labelFor('fleet-health')).toBe('System Telemetry')
+    expect(labelFor('observatory')).toBe('Activity Timeline')
     expect(labelFor('journey')).toBeUndefined()
     expect(labelFor('cognition')).toBeUndefined()
   })
@@ -141,18 +142,21 @@ describe('monitoring navigation labels', () => {
     const ids = sections.map(item => item.id)
 
     expect(defaultParamsForTab('monitoring')).toEqual({ section: 'runtime' })
-    expect(ids).toEqual(['runtime', 'cascade-config', 'agents', 'goal-loop', 'fleet-health', 'doctor'])
+    expect(ids).toEqual([
+      'runtime', 'cascade-config', 'agents', 'goal-loop', 'fleet-health',
+      'doctor', 'observatory',
+    ])
     expect(ids).toContain('fleet-health')
     expect(ids).toContain('runtime')
     expect(ids).toContain('cascade-config')
     expect(ids).toContain('agents')
     expect(ids).toContain('goal-loop')
     expect(ids).toContain('doctor')
+    expect(ids).toContain('observatory')
     expect(ids).not.toContain('journey')
     expect(ids).not.toContain('cognition')
     // Legacy sections removed in Phase 1
     expect(ids).not.toContain('live')
-    expect(ids).not.toContain('observatory')
     expect(ids).not.toContain('git-graph')
     expect(ids).not.toContain('safe-autonomy')
     expect(ids).not.toContain('cost')
@@ -174,13 +178,14 @@ describe('monitoring navigation labels', () => {
     expect(sections[3]?.id).toBe('goal-loop')
     expect(sections[4]?.id).toBe('fleet-health')
     expect(sections[5]?.id).toBe('doctor')
+    expect(sections[6]?.id).toBe('observatory')
   })
 
   it('keeps diagnostic monitoring routes available but hidden from the sidebar', () => {
     const sections = sectionItemsForTab('monitoring')
     const hiddenIds = sections.filter(item => item.hidden).map(item => item.id)
 
-    expect(hiddenIds).toEqual(['journey', 'observatory', 'cognition'])
+    expect(hiddenIds).toEqual(['journey', 'cognition'])
   })
 
   it('monitoring sidebar labels are unique (no overloaded term like "런타임")', () => {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -215,13 +215,17 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     },
     {
       id: 'observatory',
-      label: 'Observatory',
+      // Renamed from 'Observatory' to disambiguate from 'Agent Observatory'
+      // (sibling section id=agents). Sidebar-label uniqueness is enforced by
+      // navigation.test.ts; the canonical section id remains 'observatory'.
+      label: 'Activity Timeline',
       description: 'Live collaboration and investigative timelines.',
       params: { section: 'observatory' },
-      // RFC-MASC-006 Phase 2a: kept as a hidden diagnostic surface, not yet promoted to main nav.
-      // Reachable via legacy redirects (monitoring:activity, monitoring:live) and direct URL.
-      // Remove hidden:true when Phase 2b drill-down is complete.
-      hidden: true,
+      // RFC-MASC-006 Phase 2b: 3-track timeline (events + tool-calls + metric)
+      // + cross-signal readout + ObservatoryActivityPanels (cascade waterfall,
+      // keeper phase timeline, derived analyses) are wired. Promoted to main
+      // nav 2026-05-17. Legacy redirects (monitoring:activity, monitoring:live)
+      // still resolve here.
     },
     {
       id: 'cognition',


### PR DESCRIPTION
## Summary

Observatory was wired but not navigable from the sidebar — buried behind RFC-MASC-006 Phase 2a `hidden: true` flag with an in-code comment "remove when Phase 2b drill-down is complete." Phase 2b is done; promote.

## What

- `hidden: true` removed from `monitoring → observatory` section
- Section ordering: `runtime, cascade-config, agents, goal-loop, fleet-health, doctor, observatory`
- **Sidebar label** renamed `Observatory` → `Activity Timeline`
  - Sibling section `id=agents` already labeled "Agent Observatory"
  - `navigation.test.ts` enforces sidebar-label uniqueness; reusing "Observatory" would fail that guard
  - Canonical section id remains `observatory` — no URL/redirect breakage
- Updated `hiddenIds` test assertion: `['journey', 'observatory', 'cognition']` → `['journey', 'cognition']`
- In-code comment updated to reflect Phase 2b completion + 2026-05-17 promotion date

## Why this was buried

The component is feature-complete:
- 3 tracks (events + tool-calls + metric trend) over a configurable time window
- Cross-signal hover readout
- Live mode (30s auto-refresh)
- `ObservatoryActivityPanels` lazy-mount (cascade waterfall + keeper phase timeline + derived analyses)
- Backend `valid_sections` already lists `observatory` (nav-event telemetry accepts the section)
- Legacy redirects `monitoring:activity` and `monitoring:live` route here

The only thing missing was the sidebar entry. Same pattern as cascade-config (#15729) and Doctor — "wiring exists, info exists, surface invisible."

## Trade-offs

- **More sections in Monitor sidebar (7 visible)**. If this gets crowded, consider grouping later (e.g., `Observability > {Live Runtime, Activity Timeline, ...}`). Not in scope here.
- **`Activity Timeline` is not a great name** for the *Observatory* concept (timeline + tracks + cross-signal). It's a compromise to avoid the "Observatory" collision. Open to suggestions in review.

## Verification

| Gate | Result |
|---|---|
| `pnpm typecheck` | pass |
| `pnpm vitest run navigation.test.ts` | 45/45 |
| `pnpm vitest run components/observatory` | 14/14 |

## Out of scope

- `journey` (Legacy execution-flow drill-down) — kept hidden, deliberate per existing in-code comment
- `cognition` (Keeper cognition drill-down) — kept hidden, no Phase-N readiness signal
- `observatory.test.ts` ordering tweaks — no test change needed; component logic unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)