### PR TITLE
fix(tools): dedupe extended schema inventory

### DIFF
--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -6,9 +6,21 @@
 
 open Masc_domain
 
+module StringSet = Set.Make (String)
+
 let retired_front_door_schema_names =
   [
   ]
+
+let dedupe_schemas_by_name (schemas : tool_schema list) =
+  let unique, _ =
+    List.fold_left
+      (fun (acc, seen) (schema : tool_schema) ->
+        if StringSet.mem schema.name seen then (acc, seen)
+        else (schema :: acc, StringSet.add schema.name seen))
+      ([], StringSet.empty) schemas
+  in
+  List.rev unique
 
 let filter_retired_front_door_schemas (schemas : tool_schema list) =
   List.filter
@@ -43,6 +55,7 @@ let all_schemas_extended =
     @ Keeper_types.schemas
     @ Tool_local_runtime.schemas @ Tool_shard.schemas
     @ Tool_autoresearch.schemas)
+  |> dedupe_schemas_by_name
 
 (** Get tool by name *)
 let find_tool name =


### PR DESCRIPTION
## Summary
- Dedupe `Tools.all_schemas_extended` by tool name after assembling generated and hand-written schema lists.
- Keeps first occurrence order so existing `find_tool` behavior remains stable while restoring the schema uniqueness invariant.

Fixes #15269.

## Validation
- `opam exec -- ocamlformat --check lib/tools.ml`
- `git diff --check`
- `bash scripts/check-release-train-guard.sh --base origin/main --head HEAD` (OK, existing release-train warning: base 0.19.18 ahead of tag v0.19.17)

## Notes
- Reproduced current `main`: `test_keeper_masc_bridge.exe` passes 33 tests; `test_tools_coverage.exe` still failed `schema_structure/unique_names` with 119 names vs 109 unique names.
- Focused Dune validation for this patch was attempted but blocked by the shared `/tmp/me-dune-local.lock`, held by an unrelated live worktree build (`fix-keeper-24-resource-gates/scripts/dune-local.sh build test/test_tool_resource_gate.exe`). CI should provide the Dune verification surface for this draft.