### PR TITLE
fix(voice): serialize external speak turns

### DIFF
--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -603,20 +603,21 @@ let attempt_tts_endpoint
         ; "priority", `Int priority
         ]
     in
-    (match
-       call_voice_mcp_endpoint
-         ~sw
-         ~clock
-         ~net
-         ~endpoint
-         ~tool_name:"agent_speak"
-         ~arguments:args
-     with
-     | Ok json ->
-       (match extract_mcp_result json with
-        | Ok data -> Ok (append_provider_metadata data endpoint)
-        | Error error -> Error error)
-     | Error error -> Error error)
+    with_voice_output_turn ~agent_id (fun () ->
+      match
+        call_voice_mcp_endpoint
+          ~sw
+          ~clock
+          ~net
+          ~endpoint
+          ~tool_name:"agent_speak"
+          ~arguments:args
+      with
+      | Ok json ->
+        (match extract_mcp_result json with
+         | Ok data -> Ok (append_provider_metadata data endpoint)
+         | Error error -> Error error)
+      | Error error -> Error error)
 ;;
 
 (** ============================================

--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -141,6 +141,9 @@ let log_error msg =
 let log_debug msg =
   Log.debug "%s %s" log_prefix msg
 
+let with_voice_output_turn ~agent_id:_ f =
+  Eio.Mutex.use_rw ~protect:true playback_mu f
+
 let split_path_env value =
   String.split_on_char ':' value
   |> List.filter (fun entry -> String.trim entry <> "")

--- a/lib/voice/voice_bridge_core.mli
+++ b/lib/voice/voice_bridge_core.mli
@@ -87,6 +87,11 @@ val client_for_uri_result :
 
 (** {1 Local playback} *)
 
+val with_voice_output_turn : agent_id:string -> (unit -> 'a) -> 'a
+(** Serialize a speaking turn for transports whose call includes audible output.
+    Direct TTS generation should stay outside this helper; local playback is
+    already serialized by {!run_local_playback}. *)
+
 val is_dedup_hit : agent_id:string -> message:string -> bool
 (** [true] iff [(agent_id, hash message)] matches the most recent
     playback within {!playback_dedup_window_sec}. Exposed so

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -285,6 +285,39 @@ let test_yield_meter_can_be_shared_across_fibers () =
   done
 ;;
 
+let test_voice_output_turn_serializes_speakers () =
+  with_eio_env
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let first_entered, notify_first_entered = Eio.Promise.create () in
+  let release_first, notify_release_first = Eio.Promise.create () in
+  let second_done, notify_second_done = Eio.Promise.create () in
+  let second_entered = Atomic.make false in
+  Eio.Fiber.fork ~sw (fun () ->
+    Voice_bridge_core.with_voice_output_turn ~agent_id:"first" (fun () ->
+      Eio.Promise.resolve notify_first_entered ();
+      Eio.Promise.await release_first));
+  Eio.Promise.await first_entered;
+  Eio.Fiber.fork ~sw (fun () ->
+    Voice_bridge_core.with_voice_output_turn ~agent_id:"second" (fun () ->
+      Atomic.set second_entered true;
+      Eio.Promise.resolve notify_second_done ()));
+  for _ = 1 to 10 do
+    Eio.Fiber.yield ()
+  done;
+  Alcotest.(check bool)
+    "second speaker waits while first holds the output turn"
+    false
+    (Atomic.get second_entered);
+  Eio.Promise.resolve notify_release_first ();
+  Eio.Promise.await second_done;
+  Alcotest.(check bool)
+    "second speaker enters after first releases"
+    true
+    (Atomic.get second_entered)
+;;
+
 let () =
   run
     "keeper_mutex_coverage"
@@ -320,6 +353,12 @@ let () =
             "yield meter can be shared across fibers"
             `Quick
             test_yield_meter_can_be_shared_across_fibers
+        ] )
+    ; ( "voice_bridge"
+      , [ test_case
+            "output turn serializes speakers"
+            `Quick
+            test_voice_output_turn_serializes_speakers
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Add a shared voice output-turn guard for transports whose speak call includes audible output.
- Wrap `voice_mcp` `agent_speak` delegation so multiple keepers do not issue overlapping external speak calls.
- Add a regression test that verifies the output turn mutex blocks a second speaker until the first releases.

## Verification
- `ocamlformat --check lib/voice/voice_bridge_core.ml lib/voice/voice_bridge_core.mli lib/voice/voice_bridge.ml test/test_keeper_mutex_coverage.ml`
- `git diff --check origin/main..HEAD`
- `scripts/dune-local.sh build test/test_keeper_mutex_coverage.exe` attempted, but local Dune wrapper was blocked by another long-running lock holder (`fix-keeper-24-resource-gates` build). CI should provide compile/test verification.