### PR TITLE
fix(dashboard): null guard for ide-context-lens label/surface

### DIFF
--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -301,7 +301,11 @@ function selectVisibleContextAnchors(
 function contextAnchorBuckets(anchor: IdeContextAnchor): ReadonlySet<ContextAnchorBucket> {
   const buckets = new Set<ContextAnchorBucket>()
   for (const link of anchor.route_links ?? []) {
-    const label = link.label.trim().toLowerCase()
+    // WORKAROUND: link.label TS 타입은 string (non-nullable) 이지만 SSE schema drift
+    // 시 stale store 가 null 을 통과시켜 .trim() 폭발 (dashboard IDE crash 사고
+    // 2026-05-17 console). 근본 해결: RFC-0004 Phase A0.4 (Zod payload nested 검증)
+    // 도입 시 null 자체가 표면에 못 들어옴 → 본 guard 제거.
+    const label = (link.label ?? '').trim().toLowerCase()
     if (label === 'goal') buckets.add('goal')
     else if (label === 'task') buckets.add('task')
     else if (label === 'board') buckets.add('board')
@@ -322,7 +326,8 @@ function contextAnchorBuckets(anchor: IdeContextAnchor): ReadonlySet<ContextAnch
     else if (label === 'keeper') buckets.add('keeper')
   }
 
-  const surface = anchor.surface.trim().toLowerCase()
+  // WORKAROUND: 같은 사유 (link.label null guard 위 참조). RFC-0004 Phase A0.4 도입 시 제거.
+  const surface = (anchor.surface ?? '').trim().toLowerCase()
   if (surface === 'lsp') buckets.add('lsp')
   else if (surface === 'line') buckets.add('line')
   else if (surface === 'goal') buckets.add('goal')


### PR DESCRIPTION
## Summary

- `dashboard/src/components/ide/ide-context-lens.ts:304/325` 의 `link.label.trim()` / `anchor.surface.trim()` 에 `?? ''` null coalescing 추가
- 2026-05-17 dashboard IDE crash (`TypeError: Cannot read properties of null (reading 'trim')` at `L` in `ide-context-lens-...js`) 직접 차단
- WORKAROUND 주석 으로 의도 + 근본 해결 트랙 (RFC-0004 Phase A0.4) 명시

## Why this is a workaround, not a root-fix

`IdeContextAnchor` 타입은 `surface: string` / `label: string` (non-nullable) 인데 SSE schema drift 시 `schemas/sse.ts:248` 의 `SSEMessageSchema` 가 payload 내부 nested object 를 무검증 → null 통과 → `.trim()` 폭발.

근본 해결: **RFC-0004 Track A Phase A0.4** — atd SSOT 기반 generated Zod 로 `SSEMessageSchema` 의 hand-coded `STRING_FIELDS`/`NUMBER_FIELDS`/`BOOLEAN_FIELDS` set 제거 + payload nested 자동 검증. 머지 시 본 PR 의 null guard 자체 제거.

Resume basis: `~/me/knowledge/research/2026-05-17-dashboard-sse-ssot-state.md`

## Workaround rejection bar check (CLAUDE.md §workaround)

- ✗ N-of-M 패치 — 해당 안 됨 (RFC-0004 가 root track)
- ✗ string 분류기 보강 — 해당 안 됨 (string match 추가 0)
- ✗ 텔레메트리-as-fix — 해당 안 됨
- ✓ production-blocking + 대체 RFC 명시 (`WORKAROUND:` 주석 + RFC-0004 Phase A0.4 cross-ref)

## Test plan

- [x] `pnpm typecheck` exit 0 (변경 파일)
- [x] `npx eslint dashboard/src/components/ide/ide-context-lens.ts` exit 0
- [x] `vitest run ide-context-lens.test.ts` 39/39 pass
- [ ] `vitest run ide-activity-panel.test.ts` — 1 baseline fail (`keeperTraceState.value.events` empty), `git stash` 검증으로 우리 변경 *무관* 확인. 별도 fix 필요
- [ ] 사용자 실측 — dashboard 새로고침 후 `TypeError` console 부재 확인 (재기동 후 진행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)