### PR TITLE
fix(test): show dune-local lock holders

### DIFF
--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -22,6 +22,7 @@ Set MASC_DUNE_THROTTLE=0 to bypass the local lock.
 Set MASC_OPAM_LOCK=0 or MASC_SKIP_OPAM_LOCK=1 to bypass the shared opam switch lock.
 Set MASC_OPAM_LOCK_PATH=/path/to/lock to override the shared opam lock path.
 Set MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=seconds to bound opam-lock wait after the Dune lock (0 = wait forever).
+Set MASC_DUNE_LOCK_DIAG=0 to suppress best-effort lock holder diagnostics.
 Set MASC_DUNE_DRY_RUN=1 to print the command without running it.
 Set MASC_SKIP_PIN_CHECK=1 to skip the agent_sdk pin guard.
 Set MASC_SKIP_DEPS_CHECK=1 to skip the core-deps installed guard.
@@ -124,12 +125,37 @@ _needs_dune_lock() {
   return 0
 }
 
+_print_lock_holders() {
+  local lock_file="$1"
+  local label="$2"
+  [[ "${MASC_DUNE_LOCK_DIAG:-1}" != "0" ]] || return 0
+  command -v lsof >/dev/null 2>&1 || return 0
+  command -v ps >/dev/null 2>&1 || return 0
+
+  local pids
+  pids="$(lsof -t "$lock_file" 2>/dev/null | sort -u || true)"
+  [[ -n "$pids" ]] || return 0
+
+  printf '[dune-local] %s lock holder(s):\n' "$label" >&2
+  local pid row
+  while IFS= read -r pid; do
+    [[ "$pid" =~ ^[0-9]+$ ]] || continue
+    row="$(ps -p "$pid" -o pid=,ppid=,stat=,etime=,command= 2>/dev/null || true)"
+    if [[ -n "$row" ]]; then
+      printf '[dune-local]   %s\n' "$row" >&2
+    else
+      printf '[dune-local]   pid=%s (process exited before ps snapshot)\n' "$pid" >&2
+    fi
+  done <<< "$pids"
+}
+
 # Acquire the build throttle before the opam-switch lock.  The opam lock is
 # intentionally held while the active build uses the shared switch, but queued
 # builds must not hold it while waiting for the Dune throttle; otherwise stale
 # worktrees can block pin repair before they are actually compiling.
 if _needs_dune_lock; then
   printf '[dune-local] waiting for lock %s\n' "$lock_path" >&2
+  _print_lock_holders "$lock_path" "Dune"
   if command -v lockf >/dev/null 2>&1; then
     exec lockf -k "$lock_path" env MASC_DUNE_LOCK_HELD=1 "$script_path" "$@"
   elif command -v flock >/dev/null 2>&1; then
@@ -153,6 +179,7 @@ _needs_opam_lock() {
 
 if _needs_opam_lock; then
   printf '[dune-local] waiting for opam switch lock %s\n' "$opam_lock_path" >&2
+  _print_lock_holders "$opam_lock_path" "opam switch"
   # Apply the bounded-wait deadlock guard whenever this invocation is
   # already holding the Dune lock AND the operator opted in by setting
   # MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=<positive integer>. Default is

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -301,6 +301,60 @@ exec "$@"
         (contains_substring lock_log opam_lock_path);
       check bool "dune was invoked" true (Sys.file_exists dune_log))
 
+let test_dune_lock_wait_reports_holder () =
+  with_temp_dir "dune-local-lock-diag" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:0
+          ~pin_check_stderr_msg:"pin ok"
+      in
+      let dune_lock_path = Filename.concat dir "dune-local.lock" in
+      let lockf_log = Filename.concat dir "lockf-calls.log" in
+      write_executable
+        (Filename.concat bin_dir "lockf")
+        (Printf.sprintf
+           {|#!/bin/sh
+printf 'argv=%%s\n' "$*" >> %s
+while [ "${1#-}" != "$1" ]; do
+  case "$1" in
+    -t) shift 2 ;;
+    *) shift ;;
+  esac
+done
+shift
+exec "$@"
+|}
+           (quote lockf_log));
+      write_executable
+        (Filename.concat bin_dir "lsof")
+        (Printf.sprintf
+           {|#!/bin/sh
+if [ "${1:-}" = "-t" ] && [ "${2:-}" = %s ]; then
+  printf '1234\n'
+  exit 0
+fi
+exit 1
+|}
+           (quote dune_lock_path));
+      write_executable
+        (Filename.concat bin_dir "ps")
+        {|#!/bin/sh
+if [ "${1:-}" = "-p" ] && [ "${2:-}" = "1234" ]; then
+  printf ' 1234 999 S 00:42 fake-dune-holder --target test\n'
+  exit 0
+fi
+exit 1
+|};
+      let code, _stdout, stderr =
+        run_dune_local dir bin_dir ~unset_env:[ "GITHUB_ACTIONS" ] "build"
+      in
+      check int "exits zero through lockf reexec" 0 code;
+      check bool "reports Dune lock holders" true
+        (contains_substring stderr "Dune lock holder(s)");
+      check bool "reports holder command" true
+        (contains_substring stderr "fake-dune-holder --target test");
+      check bool "dune was invoked after reexec" true
+        (Sys.file_exists dune_log))
+
 let test_opam_lockf_reexec_env_passthrough () =
   with_temp_dir "dune-local-opam-lockf" (fun dir ->
       let bin_dir, dune_log =
@@ -1010,6 +1064,8 @@ let () =
             test_github_actions_bypasses_pin_guard;
           test_case "opam absent skips pin guard" `Quick
             test_opam_absent_skips_pin_guard;
+          test_case "Dune lock wait reports holder" `Quick
+            test_dune_lock_wait_reports_holder;
           test_case "opam lockf reexec propagates env" `Quick
             test_opam_lockf_reexec_env_passthrough;
           test_case "opam lock timeout releases Dune lock" `Quick


### PR DESCRIPTION
## Summary
- Add best-effort holder diagnostics before `scripts/dune-local.sh` blocks on the shared Dune or opam lock.
- Print holder PID/PPID/state/elapsed/command via `lsof -t` + `ps` when available.
- Add a fake-bin regression test that verifies lock waits surface the holder command.

Fixes #15191.

## Validation
- `bash -n scripts/dune-local.sh`
- `opam exec -- ocamlformat --check test/test_dune_local_script.ml`
- `git diff --check`
- `bash scripts/check-release-train-guard.sh --base origin/main --head HEAD` (OK, existing release-train warning: base 0.19.18 ahead of tag v0.19.17)
- Live smoke while `/tmp/me-dune-local.lock` was held: `env MASC_SKIP_PIN_CHECK=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_dune_local_script.exe` printed `Dune lock holder(s)` plus the holder command; the queued validation process was then killed before it could remain blocked.

## Notes
- Full focused Dune execution is currently blocked by unrelated live Dune lock holders on this machine, so CI is the authoritative executable validation for this draft.