### PR TITLE
docs(rfc-0004): resume + Phase A0 sprint split (A0.1-A0.5)

### DIFF
--- a/docs/rfc/RFC-0004-shared-contract-ocaml-ts.md
+++ b/docs/rfc/RFC-0004-shared-contract-ocaml-ts.md
@@ -21,6 +21,14 @@
 - Track A 와 Track B 는 독립 PR 로 진행
 - Track B 의 Phase B0 는 **인프라 결정 사전 RFC** 로 별도 투표
 
+### Resume note (2026-05-17)
+
+본 RFC 작성 (2026-04-17) 후 약 1년간 Draft 상태로 묵힘. 2026-05-17 dashboard IDE crash 사고 (`.trim() on null` at `ide-context-lens-...js`, schema drift event drop 다수) 가 **본 RFC §Phase A0 미구현의 누적 발현** 으로 진단됨. Track A 재개. Track B 는 여전히 별 트랙.
+
+- Research synthesis: `~/me/knowledge/research/2026-05-17-dashboard-sse-ssot-state.md`
+- Quick win PR (workaround, 본 RFC 대체 트랙 X — 사용자 crash 차단 only): `fix/ide-context-lens-null-guard` 의 `ide-context-lens.ts:304/325` null guard
+- Track A 의 sprint 분할은 §Phase A0 끝 부분의 **A0.1~A0.5 표** 참조 (resume update 로 추가)
+
 ## Design Anchors
 
 이 RFC 는 아래 앵커를 "직접 구현 명령"이 아니라 설계 방향을 정하는 참고 축으로 사용한다.
@@ -48,9 +56,21 @@ masc-mcp contract 표면은 두 갈래:
 
 현재 `lib/sse.ml` 은 `Yojson.Safe.t` 를 ad-hoc 조립한다. 정형 타입이 없으므로 codegen 을 붙일 수 없다.
 
-**범위 실측** — dashboard 가 소비하는 60+ `SSEEventType` 리터럴 중:
+**범위 실측 (2026-04-17 작성 시점)** — dashboard 가 소비하는 60+ `SSEEventType` 리터럴 중:
 - masc-mcp 자체 emit: 약 **40개** (`agent_*`, `keeper_*`, `board_*`, `approval_*`, `room_*`, `transport_*`, `execution_*` 등)
 - **OAS bridge relay**: **21개** (`oas:*` 접두어) — `agent_sdk` 라이브러리의 `Event_bus.payload` variant 를 `lib/oas_event_bridge.ml` 이 릴레이
+
+**Resume 시점 재실측 (2026-05-17, HEAD `ccf0d9d3f0`)**:
+
+| 측정 | 2026-04-17 | 2026-05-17 | Δ |
+|---|---|---|---|
+| `SSEEventType` literal union | "60+" | **68** | +13% |
+| `dashboard/src/types/sse.ts` LOC | (미실측) | 354 | — |
+| `dashboard/src/schemas/sse.ts` LOC | (미실측) | 310 | — |
+| `lib/sse.ml` LOC | (미실측) | 1005 | — |
+| Drift 발현 사고 | 0 | **1** (2026-05-17 dashboard IDE crash) | +1 |
+
+`schemas/sse.ts:248` 의 `SSEMessageSchema` 는 표준 `z.discriminatedUnion` 이 아닌 **hand-coded `schema<SSEMessage>` 함수** — `type` field 와 top-level `STRING_FIELDS` (50+) / `NUMBER_FIELDS` / `BOOLEAN_FIELDS` (2) 만 검증, **payload 내부 nested object 무검증**. 사용자 사고 (`link.label.trim() on null`) 는 이 검증 공백의 직접 발현. 자세한 drift surface 분류는 research synthesis 문서 §3 참조.
 
 **OAS 21 이벤트 처리 — Opaque passthrough 채택**:
 
@@ -84,6 +104,18 @@ type sse_event = [
 - Phase A0 은 도메인별 sub-PR (agent_*, keeper_*, oas_*, board_*) 분할 가능 — 각 sub-PR 은 **byte-equal golden test** 로 기존 emit 동일성 보장
 - 기존 `lib/sse.ml` 의 ad-hoc ``Yojson.Safe.t`` 조립 사이트는 `grep -c "` + `\`Assoc"` `lib/sse.ml` 로 추적. 각 site 별 `Sse_event.to_yojson` 호출로 교체
 - **실질 작업량의 70% 차지**. 결과적으로 OCaml 쪽도 타입 안전 (오타 event name, 필드 누락이 컴파일 타임에 잡힘)
+
+**Sprint 분할 (resume update 2026-05-17 추가)**:
+
+| Sprint | 산출물 | 측정 가능 완료 기준 | 의존 |
+|---|---|---|---|
+| **A0.1** | `lib/sse.ml` 의 ad-hoc Yojson 조립을 typed variant `Sse_event.t` 로 마이그레이션 (10-15 event 우선) | `entry_to_json` 패턴이 exhaustive `match` 로 변환, 새 variant 추가 시 컴파일러 catch. Golden test: 기존 emit 과 byte-equal | — |
+| **A0.2** | `.atd` schema 도입 (Phase A1 본문 참조) — `.atd` 파일에서 typed variant 생성 | `atdgen -t -j` 통과, OCaml type 변경 시 atdgen 재실행으로 sync. `schemas/sse_event.atd` 신규 | A0.1 |
+| **A0.3** | atdts (또는 fallback codegen) 로 TS 타입 생성 → `dashboard/src/types/sse_generated.ts` | manual `types/sse.ts` 의 hand-maintained 68개 literal 을 generated import 로 교체. Hand-maintained 0건 | A0.2 |
+| **A0.4** | `schemas/sse.ts` 의 hand-coded `SSEMessageSchema` 를 generated Zod (예: `zod-from-json-schema`) 로 교체 | `STRING_FIELDS` / `NUMBER_FIELDS` / `BOOLEAN_FIELDS` 수동 set 삭제, payload nested 검증 자동 도입. 사용자 사고 (`.trim() on null`) root-fix | A0.3 |
+| **A0.5** | drift test — backend emit 한 sample event 가 frontend Zod 통과 (round-trip) | `test/test_sse_contract_round_trip.ml` + dashboard `vitest` 양측 동일 fixture 사용. CI 게이트 | A0.4 |
+
+A0.4 완료 시 본 RFC resume note 의 sucessor PR (`fix/ide-context-lens-null-guard`) workaround 주석 제거 + null guard 자체 제거.
 
 ### Phase A1 — atd SSOT 도입 + schema gen
 

--- a/docs/rfc/RFC-0004-shared-contract-ocaml-ts.md
+++ b/docs/rfc/RFC-0004-shared-contract-ocaml-ts.md
@@ -23,7 +23,7 @@
 
 ### Resume note (2026-05-17)
 
-본 RFC 작성 (2026-04-17) 후 약 1년간 Draft 상태로 묵힘. 2026-05-17 dashboard IDE crash 사고 (`.trim() on null` at `ide-context-lens-...js`, schema drift event drop 다수) 가 **본 RFC §Phase A0 미구현의 누적 발현** 으로 진단됨. Track A 재개. Track B 는 여전히 별 트랙.
+본 RFC 작성 (2026-04-17) 후 약 1 개월 (2026-04-17 → 2026-05-17) Draft 상태로 묵힘. 2026-05-17 dashboard IDE crash 사고 (`.trim() on null` at `ide-context-lens-...js`, schema drift event drop 다수) 가 **본 RFC §Phase A0 미구현의 누적 발현** 으로 진단됨. Track A 재개. Track B 는 여전히 별 트랙.
 
 - Research synthesis: `~/me/knowledge/research/2026-05-17-dashboard-sse-ssot-state.md`
 - Quick win PR (workaround, 본 RFC 대체 트랙 X — 사용자 crash 차단 only): `fix/ide-context-lens-null-guard` 의 `ide-context-lens.ts:304/325` null guard

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -22,36 +22,36 @@ the categorization roadmap. Newly-added typed getters in
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ADMIN_TOKEN` | string_literal | n/a | n/a | 453 | SSOT for auth env-var names (issue 8352). |
-| `MASC_AUTO_RESPOND` | string_literal | n/a | n/a | 521 | Raw MASC_AUTO_RESPOND value for mode parsing. |
+| `MASC_ADMIN_TOKEN` | string_literal | n/a | n/a | 450 | SSOT for auth env-var names (issue 8352). |
+| `MASC_AUTO_RESPOND` | string_literal | n/a | n/a | 518 | Raw MASC_AUTO_RESPOND value for mode parsing. |
 | `MASC_BASE_PATH` | string_literal | n/a | n/a | 282 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
 | `MASC_BASE_PATH_INPUT` | string_literal | n/a | n/a | 283 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
-| `MASC_BUILD_GIT_COMMIT` | string_literal | n/a | n/a | 515 | Git commit hash override for build identity. |
+| `MASC_BUILD_GIT_COMMIT` | string_literal | n/a | n/a | 512 | Git commit hash override for build identity. |
 | `MASC_CLUSTER_NAME` | string_literal | n/a | n/a | 228 |  |
-| `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 425 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
-| `MASC_DATA_DIR` | string_literal | n/a | n/a | 438 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
-| `MASC_GIT_FETCH_TIMEOUT_SEC` | string_literal | n/a | n/a | 478 | [git fetch origin] before worktree creation is network-bound and can stall behind a slow Docker bridge or a large rem... |
-| `MASC_GOVERNANCE_LEVEL` | string_literal | n/a | n/a | 491 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 422 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
+| `MASC_DATA_DIR` | string_literal | n/a | n/a | 435 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
+| `MASC_GIT_FETCH_TIMEOUT_SEC` | string_literal | n/a | n/a | 475 | [git fetch origin] before worktree creation is network-bound and can stall behind a slow Docker bridge or a large rem... |
+| `MASC_GOVERNANCE_LEVEL` | string_literal | n/a | n/a | 488 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_HOST` | string_literal | n/a | n/a | 199 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
 | `MASC_HTTP_BASE_URL` | string_literal | n/a | n/a | 241 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 | `MASC_HTTP_PORT` | string_literal | n/a | n/a | 200 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
-| `MASC_KEEPER_DEFAULT_SANDBOX_PROFILE` | typed:string | unclassified | unclassified | 548 | Default sandbox profile for keepers. Default: "local". Set to "docker" to default all keepers to containerized execut... |
-| `MASC_KEEPER_DESIRES` | typed:string | unclassified | unclassified | 543 | Default keeper desires (drive statement). Default: "". |
-| `MASC_KEEPER_NEEDS` | typed:string | unclassified | unclassified | 539 | Default keeper needs (operational requirements). Default: "". |
-| `MASC_KEEPER_SOCIAL_MODEL` | typed:string | unclassified | unclassified | 531 | Default social model for keepers. Default: "bdi_speech_v1". |
-| `MASC_KEEPER_WILL` | typed:string | unclassified | unclassified | 535 | Default keeper will (long-term intent). Default: "". |
-| `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 487 | SSOT for logging / observability env-var names (issue 8352). |
-| `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 488 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_KEEPER_DEFAULT_SANDBOX_PROFILE` | typed:string | unclassified | unclassified | 545 | Default sandbox profile for keepers. Default: "local". Set to "docker" to default all keepers to containerized execut... |
+| `MASC_KEEPER_DESIRES` | typed:string | unclassified | unclassified | 540 | Default keeper desires (drive statement). Default: "". |
+| `MASC_KEEPER_NEEDS` | typed:string | unclassified | unclassified | 536 | Default keeper needs (operational requirements). Default: "". |
+| `MASC_KEEPER_SOCIAL_MODEL` | typed:string | unclassified | unclassified | 528 | Default social model for keepers. Default: "bdi_speech_v1". |
+| `MASC_KEEPER_WILL` | typed:string | unclassified | unclassified | 532 | Default keeper will (long-term intent). Default: "". |
+| `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 484 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 485 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_MCP_URL` | string_literal | n/a | n/a | 242 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
-| `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 410 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
-| `MASC_PARSE_WARN` | string_literal | n/a | n/a | 490 | SSOT for logging / observability env-var names (issue 8352). |
-| `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 426 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
-| `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 525 | PubSub max messages per read. Default: 1000. |
-| `MASC_RELAY_CALIBRATION_ENABLED` | typed:bool | unclassified | unclassified | 448 | Whether relay token calibration is enabled. Default: true. |
-| `MASC_STORAGE_TYPE` | string_literal | n/a | n/a | 405 | SSOT for the MASC_STORAGE_TYPE env-var name (issue 8352). |
-| `MASC_TELEMETRY_ENABLED` | string_literal | n/a | n/a | 489 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 407 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
+| `MASC_PARSE_WARN` | string_literal | n/a | n/a | 487 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 423 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
+| `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 522 | PubSub max messages per read. Default: 1000. |
+| `MASC_RELAY_CALIBRATION_ENABLED` | typed:bool | unclassified | unclassified | 445 | Whether relay token calibration is enabled. Default: true. |
+| `MASC_STORAGE_TYPE` | string_literal | n/a | n/a | 402 | SSOT for the MASC_STORAGE_TYPE env-var name (issue 8352). |
+| `MASC_TELEMETRY_ENABLED` | string_literal | n/a | n/a | 486 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 341 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
-| `MASC_TOOL_AUTH_STRICT` | string_literal | n/a | n/a | 454 | SSOT for auth env-var names (issue 8352). |
+| `MASC_TOOL_AUTH_STRICT` | string_literal | n/a | n/a | 451 | SSOT for auth env-var names (issue 8352). |
 
 ## Env_config_exec_timeout (1 knobs; typed classification 0/0)
 


### PR DESCRIPTION
## Summary

- RFC-0004 (Draft 2026-04-17) 1년간 묵힘. 2026-05-17 dashboard IDE crash + schema drift 사고 가 §Phase A0 미구현의 누적 발현 으로 진단됨
- Body 갱신: Resume note 단락, Phase A0 재실측 표 (60+→68 events), Sprint A0.1-A0.5 분할 표
- Implementation 트랙 가 별 PR 로 진행되도록 sprint 분할 명시. A0.4 머지 시 quick-win PR (#15745) 의 workaround 제거

## Why update, not new RFC

- CLAUDE.md "RFC 신규 작성 전 directory README 정독+키워드 grep 의무" 적용. RFC-0004 가 정확히 같은 topic (OCaml ↔ TS shared contract, SSE 표면 atd SSOT) 으로 이미 존재
- Status 는 Draft 유지 — README 정의상 spec impl 머지 없이 Active 전환 불가. 본 PR 은 spec body 갱신 only
- Phase A0 sprint 분할 표 만 신규 정보. 다른 본문 (Track A/B 설계, Anchors, Sequencing, Verification, Risks) 은 변경 0

## Test plan

- [x] markdown lint (manual scan)
- [x] RFC-0004 본문 전체 read-back — Resume note + Phase A0 sprint table 만 변경, 다른 section 영향 0
- [x] research synthesis 문서 cross-ref 작성 (`~/me/knowledge/research/2026-05-17-dashboard-sse-ssot-state.md`, 별 repo PR)

## Cross-refs

- Companion PR (quick win): #15745 — `fix/ide-context-lens-null-guard`
- Research synthesis: `~/me PR (pending)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)