### PR TITLE
ci: retry transient curl downloads in CI bootstrap

### DIFF
--- a/.github/actions/setup-ocaml-toolchain/action.yml
+++ b/.github/actions/setup-ocaml-toolchain/action.yml
@@ -99,7 +99,7 @@ runs:
         opam_url="https://github.com/ocaml/opam/releases/download/${opam_version}/opam-${opam_version}-${opam_arch}-linux"
 
         mkdir -p "${opam_dir}"
-        curl -L --fail "${opam_url}" -o "${opam_dir}/opam"
+        curl -L --fail --retry 3 --retry-delay 5 --retry-all-errors "${opam_url}" -o "${opam_dir}/opam"
         chmod +x "${opam_dir}/opam"
         export PATH="${opam_dir}:${PATH}"
         echo "${opam_dir}" >> "${GITHUB_PATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -994,7 +994,8 @@ jobs:
 
       - name: Download tla2tools.jar (pinned v1.8.0)
         run: |
-          curl -fsSL -o specs/keeper-state-machine/tla2tools.jar \
+          curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors \
+            -o specs/keeper-state-machine/tla2tools.jar \
             https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
 
       - name: Run TLA+ model checking

--- a/.github/workflows/tla-main.yml
+++ b/.github/workflows/tla-main.yml
@@ -72,7 +72,8 @@ jobs:
 
       - name: Download tla2tools.jar (pinned v1.8.0)
         run: |
-          curl -fsSL -o specs/keeper-state-machine/tla2tools.jar \
+          curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors \
+            -o specs/keeper-state-machine/tla2tools.jar \
             https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
 
       - name: Run TLA+ model checking (${{ matrix.shard.name }})

--- a/.github/workflows/tla-scheduled.yml
+++ b/.github/workflows/tla-scheduled.yml
@@ -45,7 +45,8 @@ jobs:
 
       - name: Download tla2tools.jar (pinned v1.8.0)
         run: |
-          curl -fsSL -o specs/keeper-state-machine/tla2tools.jar \
+          curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors \
+            -o specs/keeper-state-machine/tla2tools.jar \
             https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
 
       - name: Run TLA+ model checking


### PR DESCRIPTION
## Summary

Eliminate flaky CI failures caused by transient 502/503 from external CDN (github.com releases) on opam binary and tla2tools.jar downloads.

## Evidence

Observed on PR #15725 (RFC-0094 Phase 0, force-pushed):

\`\`\`
[setup-ocaml-toolchain] downloading opam binary from github.com/ocaml/opam/releases/...
curl: (22) The requested URL returned error: 502
##[error]Process completed with exit code 22.
\`\`\`

Lint job aborted at 39s on first download attempt with no retry. Same anti-pattern at 4 call sites:

| File | Line | Resource |
|------|------|----------|
| \`.github/actions/setup-ocaml-toolchain/action.yml\` | 102 | opam binary (every Lint/Health/Build run) |
| \`.github/workflows/ci.yml\` | 997 | tla2tools.jar (TLA+ Model Checking) |
| \`.github/workflows/tla-main.yml\` | 75 | tla2tools.jar (main push TLA+) |
| \`.github/workflows/tla-scheduled.yml\` | 48 | tla2tools.jar (scheduled TLA+) |

## Change

Apply identical \`--retry 3 --retry-delay 5 --retry-all-errors\` to all four \`curl\` calls.

- \`--retry-all-errors\` (curl 7.71+) covers HTTP 5xx and \`--fail\`-detected errors in addition to default connection errors. ubuntu-latest has curl 8.x.
- 4 sites changed in one PR to avoid the N-of-M anti-pattern (separate PRs per site would leave the same root cause unaddressed at the other sites).

## Risk

- Low. Successful downloads behave identically (no perf cost on the happy path).
- Worst case: a *persistently* unavailable upstream URL takes 3×5s = 15s longer to fail (vs. immediate fail). Acceptable trade-off for transient blips.
- No production code change. CI-only.

## Test plan

- [ ] CI on this PR passes (workflow yaml syntax + behaviour unchanged on happy path)
- [ ] If a future runner hits a 502, retry should now recover without manual rerun (observational, no synthetic injection)

## Out of scope

- \`deploy-railway.yml:91\` health check (loopback \`127.0.0.1\`, no external CDN involved — retry not applicable).
- \`grpcurl\` install via \`go install\` (different retry mechanism inside Go module fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)