### PR TITLE
Block malformed dev-null redirects in keeper Bash

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -209,6 +209,14 @@ type bash_shape_block =
 let string_contains_char s ch = String.exists (Char.equal ch) s
 let string_contains_substring s needle = String_util.contains_substring s needle
 
+let has_malformed_dev_null_redirect_token scan_text =
+  scan_text
+  |> String.split_on_char ' '
+  |> List.exists (fun token ->
+    match String.trim (String.lowercase_ascii token) with
+    | "0/dev/null" | "1/dev/null" | "2/dev/null" -> true
+    | _ -> false)
+
 let quote_aware_shape_scan_text cmd =
   let len = String.length cmd in
   let buf = Buffer.create len in
@@ -263,6 +271,8 @@ let raw_keeper_bash_shape_block cmd =
   let lower = String.lowercase_ascii scan_text in
   if string_contains_substring lower "gh pr checks"
   then Some Gh_pr_checks
+  else if has_malformed_dev_null_redirect_token scan_text
+  then Some Pipe_or_redirect
   else if
     string_contains_char scan_text '|'
     || string_contains_char scan_text '>'
@@ -302,6 +312,10 @@ let rec parsed_keeper_bash_shape_block = function
     else None
 
 let keeper_bash_shape_block cmd =
+  let scan_text = quote_aware_shape_scan_text cmd in
+  if has_malformed_dev_null_redirect_token scan_text
+  then Some Pipe_or_redirect
+  else
   match Masc_exec_bash_parser.Bash.parse_string cmd with
   | Masc_exec.Parsed.Parsed ir -> parsed_keeper_bash_shape_block ir
   | Masc_exec.Parsed.Parse_error _

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -333,6 +333,11 @@ let test_keeper_bash_shape_uses_shell_ir_for_quoted_literals () =
   Alcotest.(check (option string)) "real redirect blocks"
     (Some "pipe_or_redirect")
     (block_tag "cat < /tmp/x");
+  Alcotest.(check (option string)) "malformed stderr redirect token blocks"
+    (Some "pipe_or_redirect")
+    (block_tag "ls repos/masc-mcp/.worktrees/ 2/dev/null");
+  Alcotest.(check (option string)) "quoted malformed redirect token is data" None
+    (block_tag {|echo "2/dev/null"|});
   Alcotest.(check (option string)) "real gh pr checks blocks"
     (Some "gh_pr_checks")
     (block_tag "gh pr checks 15659 --repo jeong-sik/masc-mcp");


### PR DESCRIPTION
## Summary
- Block unquoted malformed dev-null redirect tokens such as `2/dev/null` before keeper_bash reaches Docker execution.
- Preserve quoted `2/dev/null` as data and cover the regression in keeper Bash safety tests.

## Why
The keeper log showed `ls repos/masc-mcp/.worktrees/ 2/dev/null`, which is almost certainly a malformed `2>/dev/null` redirect. Existing shape guards catch real redirects, but this typo was treated as a normal argv path and produced a noisy sandbox error. This keeps that class in the command-shape guard instead.

## Validation
- `ocamlformat --check lib/keeper/keeper_shell_bash.ml test/test_keeper_bash_safety.ml`
- `git diff --check origin/main..HEAD`
- Tried `scripts/dune-local.sh build test/test_keeper_bash_safety.exe`, but the shared `/tmp/me-dune-local.lock` was held by long-running unrelated Dune jobs; leaving full compile verification to PR CI.