### PR TITLE
feat(dashboard): promote Transport Health to Monitor section

### DIFF
--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -9,7 +9,7 @@ import { LoadingState } from './common/feedback-state'
 
 export type StatusSection =
   | 'observatory' | 'journey' | 'agents' | 'runtime' | 'cascade-config'
-  | 'goal-loop' | 'fleet-health' | 'doctor'
+  | 'goal-loop' | 'fleet-health' | 'doctor' | 'transport-health'
   | 'cognition'
 
 const LazyAgentsUnified = lazy(async () => ({
@@ -26,6 +26,9 @@ const LazyFleetHealthPanel = lazy(async () => ({
 }))
 const LazyDoctorPanel = lazy(async () => ({
   default: (await import('./doctor-panel')).DoctorPanel,
+}))
+const LazyTransportHealthPanel = lazy(async () => ({
+  default: (await import('./transport-health')).TransportHealthPanel,
 }))
 const LazyGoalLoopPanel = lazy(async () => ({
   default: (await import('./goal-loop-panel')).GoalLoopPanel,
@@ -60,6 +63,8 @@ export function sectionLabel(section: StatusSection): string {
       return 'Fleet Health'
     case 'doctor':
       return 'Doctor'
+    case 'transport-health':
+      return 'Transport Health'
     case 'cognition':
       return 'Cognition'
     case 'agents':
@@ -83,6 +88,8 @@ function renderSection(section: StatusSection) {
       return html`<${LazyFleetHealthPanel} />`
     case 'doctor':
       return html`<${LazyDoctorPanel} />`
+    case 'transport-health':
+      return html`<${LazyTransportHealthPanel} />`
     case 'cognition':
       return html`<${LazyCognitionPlane} />`
     case 'agents':
@@ -99,6 +106,7 @@ export function normalizeStatusSection(section: string | undefined): StatusSecti
     || section === 'goal-loop'
     || section === 'fleet-health'
     || section === 'doctor'
+    || section === 'transport-health'
     || section === 'cognition'
     || section === 'agents'
   ) return section

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -108,6 +108,7 @@ describe('monitoring navigation labels', () => {
     expect(labelFor('goal-loop')).toBe('Goal Navigator')
     expect(labelFor('fleet-health')).toBe('System Telemetry')
     expect(labelFor('observatory')).toBe('Activity Timeline')
+    expect(labelFor('transport-health')).toBe('Transport Health')
     expect(labelFor('journey')).toBeUndefined()
     expect(labelFor('cognition')).toBeUndefined()
   })
@@ -144,7 +145,7 @@ describe('monitoring navigation labels', () => {
     expect(defaultParamsForTab('monitoring')).toEqual({ section: 'runtime' })
     expect(ids).toEqual([
       'runtime', 'cascade-config', 'agents', 'goal-loop', 'fleet-health',
-      'doctor', 'observatory',
+      'doctor', 'transport-health', 'observatory',
     ])
     expect(ids).toContain('fleet-health')
     expect(ids).toContain('runtime')
@@ -152,6 +153,7 @@ describe('monitoring navigation labels', () => {
     expect(ids).toContain('agents')
     expect(ids).toContain('goal-loop')
     expect(ids).toContain('doctor')
+    expect(ids).toContain('transport-health')
     expect(ids).toContain('observatory')
     expect(ids).not.toContain('journey')
     expect(ids).not.toContain('cognition')
@@ -178,7 +180,8 @@ describe('monitoring navigation labels', () => {
     expect(sections[3]?.id).toBe('goal-loop')
     expect(sections[4]?.id).toBe('fleet-health')
     expect(sections[5]?.id).toBe('doctor')
-    expect(sections[6]?.id).toBe('observatory')
+    expect(sections[6]?.id).toBe('transport-health')
+    expect(sections[7]?.id).toBe('observatory')
   })
 
   it('keeps diagnostic monitoring routes available but hidden from the sidebar', () => {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -22,6 +22,7 @@ type SurfaceSectionId =
   | 'goal-loop'
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
   | 'doctor'         // Dedicated entry for /api/v1/dashboard/doctor (formerly buried inside Command → Operations → Inspector → "진단" sub-tab)
+  | 'transport-health' // Dedicated entry for /api/v1/dashboard/transport-health (was 5-hop buried inside Command → Operations → Inspector → "서버 설정" → ServerConfig → TransportHealthPanel)
   // command
   | 'operations'     // Phase 1+6: absorbs intervene + governance + inspector (Phase 7: connectors split out)
   // connectors (Phase 7: top-level surface — sidecar-driven channel bridges)
@@ -205,6 +206,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: 'Doctor',
       description: 'Sidecar and config doctor diagnostics.',
       params: { section: 'doctor' },
+    },
+    {
+      id: 'transport-health',
+      label: 'Transport Health',
+      description: 'SSE/gRPC/WebSocket/WebRTC transport state.',
+      params: { section: 'transport-health' },
     },
     {
       id: 'journey',

--- a/lib/dashboard/dashboard_nav_event.ml
+++ b/lib/dashboard/dashboard_nav_event.ml
@@ -35,6 +35,7 @@ let valid_sections =
       ; "goal-loop"
       ; "fleet-health"
       ; "doctor"
+      ; "transport-health"
       ] )
   ; "command", [ "operations" ]
   ; "connectors", [ "connector-status" ]


### PR DESCRIPTION
## Summary

`TransportHealthPanel` (SSE / gRPC / WebSocket / WebRTC live state from `/api/v1/dashboard/transport-health`) was buried **5 hops deep** in the sidebar:

`Command → Operations → Inspector chip → "서버 설정" sub-tab → ServerConfig → TransportHealthPanel`

Same buried-wiring anti-pattern as cascade-config (#15729), Doctor (in #15729), Observatory (#15742), and Cognition (#15749).

## What

- New `transport-health` SurfaceSectionId after `doctor`
- `LazyTransportHealthPanel` mount in `components/status.ts`
- Backend `valid_sections` allowlist adds `transport-health`
- Existing `ServerConfig` embed retained for backward-compat
- Label: `Transport Health`, description: `SSE/gRPC/WebSocket/WebRTC transport state.` (4 words, 0 commas — passes `navigation.test.ts` conciseness + uniqueness guards)

## Wiring evidence (already in place)

- `lib/server/server_routes_http_routes_dashboard.ml` exposes `/api/v1/dashboard/transport-health` (admin auth)
- `dashboard/src/api/transport-health.ts` — typed fetch + decoder + `TransportHealthData` schema
- `lib/fetch-scheduler.ts` integration
- SSE hydration via `lastEvent`
- Full panel UI: SSE, gRPC, WebSocket, WebRTC tones + queue pressure + hot-session table

## Verification

| Gate | Result |
|---|---|
| `pnpm typecheck` | pass |
| `pnpm vitest run navigation.test.ts` | 45/45 |
| `pnpm vitest run components/status` | 16/16 |
| `dune build @check` | not run locally (cross-worktree dune-project collision in shared `~/me`); **CI Build/TLA+ will gate** |

## Out of scope

- ServerConfig sub-tab cleanup (could now drop the buried embed; left for follow-up to keep PR diff tight)
- Other 0-caller orphan components (`PhaseConditionsPanel` already has 1 caller; helper functions in `transport-health.ts` exported for tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)