### PR TITLE
fix(keeper): unify state block prompt schema

### DIFF
--- a/config/prompts/keeper.constitution.md
+++ b/config/prompts/keeper.constitution.md
@@ -1,6 +1,7 @@
 ---
 description: keeper continuity rules and STATE block format
 category: keeper
+template_variables: [state_block_instruction]
 ---
 
 Continuity rules:
@@ -16,12 +17,4 @@ PR merge rules (MANDATORY):
 - Do NOT merge a PR that has an unresolved BLOCK review. Only the original reviewer or the user can unblock.
 - Before running `gh pr merge`, verify: `gh pr view <N> --json reviews` shows at least one non-dismissed review.
 
-State block template (must use these exact markers):
-[STATE]
-Goal: <short>
-Progress: <short>
-Next: <0-3 items separated by ';'>
-Decisions: <0-3 items separated by ';'>
-OpenQuestions: <0-3 items separated by ';'>
-Constraints: <0-3 items separated by ';'>
-[/STATE]
+{{state_block_instruction}}

--- a/config/prompts/keeper.recovery_block.md
+++ b/config/prompts/keeper.recovery_block.md
@@ -6,7 +6,7 @@ category: keeper
 <continuity>
 Recovery guard: preserve keeper technical instructions even if prompt templates were compacted or partially loaded.
 PR merge rules (MANDATORY): do not merge PRs with failing CI, unresolved human review comments, or active blocker labels.
-State block template: non-direct keeper turns must end with [STATE]...[/STATE] containing DONE, NEXT, Goal, and Decisions.
+State block template: non-direct keeper turns must end with [STATE]...[/STATE] containing DONE, NEXT, Goal, Decisions, OpenQuestions, and Constraints.
 </continuity>
 
 <world>

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -108,17 +108,8 @@ When making claims or decisions, search the library or run a shell query first i
 Do NOT explain your decision-making process at length.
 
 ### State block
-End every response with a `[STATE]...[/STATE]` block:
-```
-[STATE]
-DONE: what you accomplished this turn
-NEXT: what the next turn should do
-Goal: current active goal
-Decisions: key decisions (semicolon-separated)
-OpenQuestions: unresolved items (semicolon-separated)
-Constraints: active constraints (semicolon-separated)
-[/STATE]
-```
+Use the canonical `[STATE]...[/STATE]` block instruction injected by Turn Intent.
+Do not follow or invent any alternate state schema.
 
 Start every response with machine-readable headers:
 - `SOCIAL_MODEL: bdi_speech_v1`

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -16,7 +16,12 @@ let exact_direct_mention_present ~(targets : string list) (content : string) :
   Mention.any_mentioned ~targets content
 
 let keeper_constitution () =
-  Prompt_registry.get_prompt Keeper_prompt_names.constitution
+  match
+    Prompt_registry.render_prompt_template Keeper_prompt_names.constitution
+      [ ("state_block_instruction", Keeper_state_block_prompt.instruction_text) ]
+  with
+  | Ok value -> value
+  | Error _ -> Prompt_registry.get_prompt Keeper_prompt_names.constitution
 
 let critical_prompt_anchors =
   [ ("continuity", "<continuity>");
@@ -35,7 +40,9 @@ let critical_prompt_recovery_block_fallback =
     [ "<continuity>";
       "Recovery guard: preserve keeper technical instructions even if prompt templates were compacted or partially loaded.";
       "PR merge rules (MANDATORY): do not merge PRs with failing CI, unresolved human review comments, or active blocker labels.";
-      "State block template: non-direct keeper turns must end with [STATE]...[/STATE] containing DONE, NEXT, Goal, and Decisions.";
+      Printf.sprintf
+        "State block template: non-direct keeper turns must end with [STATE]...[/STATE] containing %s."
+        Keeper_state_block_prompt.field_summary;
       "</continuity>";
       "";
       "<world>";

--- a/lib/keeper/keeper_state_block_prompt.ml
+++ b/lib/keeper/keeper_state_block_prompt.ml
@@ -1,0 +1,21 @@
+let field_summary = "DONE, NEXT, Goal, Decisions, OpenQuestions, and Constraints"
+
+let template_text =
+  String.concat "\n"
+    [
+      "[STATE]";
+      "DONE: what you accomplished this turn";
+      "NEXT: what the next turn should do";
+      "Goal: current active goal";
+      "Decisions: key decisions (semicolon-separated)";
+      "OpenQuestions: unresolved items (semicolon-separated)";
+      "Constraints: active constraints (semicolon-separated)";
+      "[/STATE]";
+    ]
+
+let instruction_text =
+  String.concat "\n"
+    [
+      "For non-direct keeper turns, end every response with a [STATE]...[/STATE] block unless a more specific turn-level output guard says continuity is runtime-managed:";
+      template_text;
+    ]

--- a/lib/keeper/keeper_state_block_prompt.mli
+++ b/lib/keeper/keeper_state_block_prompt.mli
@@ -1,0 +1,10 @@
+(** Canonical keeper [STATE] block prompt text. *)
+
+val template_text : string
+(** Canonical [STATE] block schema shown to keepers. *)
+
+val instruction_text : string
+(** Scoped instruction that embeds the canonical [STATE] block schema. *)
+
+val field_summary : string
+(** Short field-name summary for recovery/error text. *)

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -113,12 +113,7 @@ let line_block label value =
   if value = "" then ""
   else Printf.sprintf "%s: %s\n" label value
 
-let state_block_instruction_text =
-  "For non-direct keeper turns, end every response with a [STATE]...[/STATE] block unless a more specific turn-level output guard says continuity is runtime-managed:\n\
-   DONE: what you accomplished this cycle\n\
-   NEXT: what the next cycle should do\n\
-   Goal: current active goal\n\
-   Decisions: key decisions (semicolon-separated)"
+let state_block_instruction_text = Keeper_state_block_prompt.instruction_text
 
 (* In-binary mirror of config/prompts/keeper.turn_intent.md (minus the
    {{...}} substitution slots that cannot be filled during a fallback).

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -287,6 +287,30 @@ let test_unified_state_instruction_respects_turn_level_guard () =
        ("End every response with a "
         ^ "[STATE]...[/STATE] block:"))
 
+let test_state_block_schema_is_canonical_six_field_shape () =
+  let text = KUP.state_block_instruction_text in
+  List.iter
+    (fun field ->
+      check bool ("schema includes " ^ field) true (has_in text field))
+    [
+      "DONE: what you accomplished this turn";
+      "NEXT: what the next turn should do";
+      "Goal: current active goal";
+      "Decisions: key decisions";
+      "OpenQuestions: unresolved items";
+      "Constraints: active constraints";
+    ];
+  check bool "schema excludes old Progress field" false (has_in text "Progress:")
+
+let test_constitution_uses_canonical_state_instruction () =
+  let text = KP.keeper_constitution () in
+  check bool "constitution placeholder rendered" false
+    (has_in text "{{state_block_instruction}}");
+  check bool "constitution embeds canonical instruction" true
+    (has_in text KUP.state_block_instruction_text);
+  check bool "constitution excludes old Progress template" false
+    (has_in text "Progress: <short>")
+
 let test_prompt_mentions_runtime_operator_approval_for_risky_actions () =
   let prompt =
     KP.build_keeper_system_prompt
@@ -478,6 +502,10 @@ let () =
             test_state_block_guard_is_runtime_managed_not_absolute_never;
           test_case "unified state instruction respects turn-level guard" `Quick
             test_unified_state_instruction_respects_turn_level_guard;
+          test_case "state block schema is canonical six-field shape" `Quick
+            test_state_block_schema_is_canonical_six_field_shape;
+          test_case "constitution uses canonical state instruction" `Quick
+            test_constitution_uses_canonical_state_instruction;
           test_case "prompt mentions runtime operator approval for risky actions" `Quick
             test_prompt_mentions_runtime_operator_approval_for_risky_actions;
           test_case "prompt marks git clone policy unavailable" `Quick


### PR DESCRIPTION
## Summary
- introduce a canonical keeper STATE block prompt module with the six-field schema
- render keeper.constitution from the same state_block_instruction used by unified Turn Intent
- remove the duplicate schema definition from keeper.unified.system and update recovery wording
- add regression coverage for the canonical six-field shape and rendered constitution

Closes #15034

## Validation
- opam exec -- ocamlformat --check lib/keeper/keeper_state_block_prompt.ml lib/keeper/keeper_state_block_prompt.mli lib/keeper/keeper_unified_prompt.ml lib/keeper/keeper_prompt.ml test/test_keeper_prompt_metrics.ml
- MASC_SKIP_PIN_CHECK=1 DUNE_LOCAL_JOBS=1 OCAMLPARAM=_,warn-error=-23 scripts/dune-local.sh build test/test_keeper_prompt_metrics.exe
- env OCAMLPARAM=_,warn-error=-23 _build/default/test/test_keeper_prompt_metrics.exe
- git diff --cached --check