### PR TITLE
feat(dashboard): promote Feature Flags to Monitor section

### DIFF
--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -10,6 +10,7 @@ import { LoadingState } from './common/feedback-state'
 export type StatusSection =
   | 'observatory' | 'journey' | 'agents' | 'runtime' | 'cascade-config'
   | 'goal-loop' | 'fleet-health' | 'doctor' | 'transport-health'
+  | 'feature-health'
   | 'cognition'
 
 const LazyAgentsUnified = lazy(async () => ({
@@ -29,6 +30,9 @@ const LazyDoctorPanel = lazy(async () => ({
 }))
 const LazyTransportHealthPanel = lazy(async () => ({
   default: (await import('./transport-health')).TransportHealthPanel,
+}))
+const LazyFeatureHealth = lazy(async () => ({
+  default: (await import('./feature-health')).FeatureHealth,
 }))
 const LazyGoalLoopPanel = lazy(async () => ({
   default: (await import('./goal-loop-panel')).GoalLoopPanel,
@@ -65,6 +69,8 @@ export function sectionLabel(section: StatusSection): string {
       return 'Doctor'
     case 'transport-health':
       return 'Transport Health'
+    case 'feature-health':
+      return 'Feature Flags'
     case 'cognition':
       return 'Cognition'
     case 'agents':
@@ -90,6 +96,8 @@ function renderSection(section: StatusSection) {
       return html`<${LazyDoctorPanel} />`
     case 'transport-health':
       return html`<${LazyTransportHealthPanel} />`
+    case 'feature-health':
+      return html`<${LazyFeatureHealth} />`
     case 'cognition':
       return html`<${LazyCognitionPlane} />`
     case 'agents':
@@ -107,6 +115,7 @@ export function normalizeStatusSection(section: string | undefined): StatusSecti
     || section === 'fleet-health'
     || section === 'doctor'
     || section === 'transport-health'
+    || section === 'feature-health'
     || section === 'cognition'
     || section === 'agents'
   ) return section

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -109,6 +109,7 @@ describe('monitoring navigation labels', () => {
     expect(labelFor('fleet-health')).toBe('System Telemetry')
     expect(labelFor('observatory')).toBe('Activity Timeline')
     expect(labelFor('transport-health')).toBe('Transport Health')
+    expect(labelFor('feature-health')).toBe('Feature Flags')
     expect(labelFor('cognition')).toBe('Keeper Cognition')
     expect(labelFor('journey')).toBeUndefined()
   })
@@ -145,7 +146,7 @@ describe('monitoring navigation labels', () => {
     expect(defaultParamsForTab('monitoring')).toEqual({ section: 'runtime' })
     expect(ids).toEqual([
       'runtime', 'cascade-config', 'agents', 'goal-loop', 'fleet-health',
-      'doctor', 'transport-health', 'observatory', 'cognition',
+      'doctor', 'transport-health', 'feature-health', 'observatory', 'cognition',
     ])
     expect(ids).toContain('fleet-health')
     expect(ids).toContain('runtime')
@@ -154,6 +155,7 @@ describe('monitoring navigation labels', () => {
     expect(ids).toContain('goal-loop')
     expect(ids).toContain('doctor')
     expect(ids).toContain('transport-health')
+    expect(ids).toContain('feature-health')
     expect(ids).toContain('observatory')
     expect(ids).toContain('cognition')
     expect(ids).not.toContain('journey')
@@ -181,8 +183,9 @@ describe('monitoring navigation labels', () => {
     expect(sections[4]?.id).toBe('fleet-health')
     expect(sections[5]?.id).toBe('doctor')
     expect(sections[6]?.id).toBe('transport-health')
-    expect(sections[7]?.id).toBe('observatory')
-    expect(sections[8]?.id).toBe('cognition')
+    expect(sections[7]?.id).toBe('feature-health')
+    expect(sections[8]?.id).toBe('observatory')
+    expect(sections[9]?.id).toBe('cognition')
   })
 
   it('keeps diagnostic monitoring routes available but hidden from the sidebar', () => {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -23,6 +23,7 @@ type SurfaceSectionId =
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
   | 'doctor'         // Dedicated entry for /api/v1/dashboard/doctor (formerly buried inside Command → Operations → Inspector → "진단" sub-tab)
   | 'transport-health' // Dedicated entry for /api/v1/dashboard/transport-health (was 5-hop buried inside Command → Operations → Inspector → "서버 설정" → ServerConfig → TransportHealthPanel)
+  | 'feature-health' // Dedicated entry for /api/v1/dashboard/feature-health (was 4-hop buried inside Command → Operations → Inspector → "피처 플래그" sub-tab)
   // command
   | 'operations'     // Phase 1+6: absorbs intervene + governance + inspector (Phase 7: connectors split out)
   // connectors (Phase 7: top-level surface — sidecar-driven channel bridges)
@@ -212,6 +213,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: 'Transport Health',
       description: 'SSE/gRPC/WebSocket/WebRTC transport state.',
       params: { section: 'transport-health' },
+    },
+    {
+      id: 'feature-health',
+      label: 'Feature Flags',
+      description: 'Feature flag rollout and health snapshot.',
+      params: { section: 'feature-health' },
     },
     {
       id: 'journey',

--- a/lib/dashboard/dashboard_nav_event.ml
+++ b/lib/dashboard/dashboard_nav_event.ml
@@ -36,6 +36,7 @@ let valid_sections =
       ; "fleet-health"
       ; "doctor"
       ; "transport-health"
+      ; "feature-health"
       ] )
   ; "command", [ "operations" ]
   ; "connectors", [ "connector-status" ]


### PR DESCRIPTION
## Summary

`FeatureHealth` (311 LoC, `/api/v1/dashboard/feature-health`) was buried 4 hops deep: `Command → Operations → Inspector chip → "피처 플래그" sub-tab`. Same anti-pattern as cascade-config, doctor, observatory, cognition, transport-health — wiring complete, sidebar exposure missing.

## What

- New `feature-health` SurfaceSectionId after `doctor`
- `LazyFeatureHealth` mount in `components/status.ts`
- Backend `valid_sections` allowlist adds `feature-health`
- Existing LabInspector "피처 플래그" sub-tab kept for backward-compat URLs
- Label: `Feature Flags`, description: `Feature flag rollout and health snapshot.` (6 words, 0 commas — passes navigation.test.ts conciseness guards)

## Monitor sidebar density note

Monitor will now show **8 visible sections** (with this PR + #15749 cognition + #15754 transport-health all merged):
`runtime, cascade-config, agents, goal-loop, fleet-health, doctor, transport-health, feature-health, observatory, (+cognition)`

This is approaching the limit where a 2-level grouping ("Live Ops" / "Diagnostics" / "Cognition") would be worth considering. **Out of scope here**; flagging for a follow-up IA pass once the in-flight promotions land.

## Verification

| Gate | Result |
|---|---|
| `pnpm typecheck` | pass |
| `pnpm vitest run navigation.test.ts` | 45/45 |
| `dune build @check` | not run locally; CI will gate |

🤖 Generated with [Claude Code](https://claude.com/claude-code)