### PR TITLE
feat(cascade): opt-in cold-boot partial tolerance flag (RFC-0058 phase 8.3)

### DIFF
--- a/docs/cascade/PARTIAL-BOOT-OPERATOR-RUNBOOK.md
+++ b/docs/cascade/PARTIAL-BOOT-OPERATOR-RUNBOOK.md
@@ -1,0 +1,89 @@
+# Cascade Partial-Boot Mode — Operator Runbook
+
+| | |
+|---|---|
+| RFC | RFC-0058 Phase 8.3 |
+| Env var | `MASC_CASCADE_PARTIAL_BOOT` |
+| Default | `false` |
+| Audience | Operator on-call, infra |
+
+## 1. What this mode does
+
+Normally, masc-mcp's boot-time cascade-catalog gate (`Cascade_catalog_runtime.validate_path_result`) refuses to start the server when `cascade.toml` contains *any* adapter-level error — e.g. a binding referencing a removed provider (`(Cascade_declarative_adapter.Provider_not_found "claude")`). The intent is fail-loud: a broken config is visible on boot rather than silently routing traffic through a degraded catalog.
+
+When `MASC_CASCADE_PARTIAL_BOOT=1`, that gate relaxes for the **adapter-error class only**:
+
+- **Parser-level errors** (toml unparseable, schema-shape violations): **still fatal**. Server refuses to boot. The Phase 8 partial-parse adapter cannot produce a snapshot from an unparseable file.
+- **Adapter-level errors** (resolvable on a per-binding basis, e.g. dangling `[<p>.<m>]` references): **tolerated** when a non-empty `decl_snapshot` is available. Server boots with the resolvable subset of profiles. A structured `Log.Misc.warn` (will migrate to `Log.Cascade.warn` once Phase 8.1.5 PR #15751 lands) emits per error.
+
+## 2. When to use it
+
+Use this mode when **all** of the following hold:
+
+1. Server is failing to boot with an `active cascade source could not be loaded` or `declarative cascade adapter error` rejection.
+2. Production keepers are blocked from running.
+3. The operator has confirmed that the resolvable subset of profiles is sufficient for the workload that must continue (e.g. a degraded cascade with one or two missing providers, where the remaining providers cover the active routes).
+4. A fix for the underlying `cascade.toml` is in progress but not yet ready to deploy.
+
+This is **emergency-only**. Not a steady-state mode.
+
+## 3. How to enable
+
+```bash
+# One-shot, single boot:
+MASC_CASCADE_PARTIAL_BOOT=1 ./bin/masc_server
+
+# Or in launchd / systemd:
+Environment="MASC_CASCADE_PARTIAL_BOOT=1"
+
+# Verify on next reload (after the fix lands, unset):
+unset MASC_CASCADE_PARTIAL_BOOT
+```
+
+Accepted truthy values: `"1"`, `"true"`, `"yes"` (case-insensitive, per `Env_config_core.get_bool`). Anything else is treated as `false`.
+
+## 4. What you'll see in the log
+
+Per adapter-level error, on every catalog reload (including initial boot):
+
+```
+[WARN] [Misc] partial-boot mode: declarative adapter error in /path/to/cascade.toml (continuing): (Cascade_declarative_adapter.Provider_not_found "claude")
+```
+
+The boot proceeds. Profile discovery returns the resolvable subset.
+
+If `MASC_CASCADE_PARTIAL_BOOT` is **not** set and adapter errors exist, the gate still rejects with the same error string surfaced in the rejection result. Logs in that case use `Log.Misc.warn` per error followed by `[CascadeProfileDiscovery] declarative parse error: ...`.
+
+## 5. Footguns
+
+| Risk | Mitigation |
+|---|---|
+| Operator leaves the flag on indefinitely → silent drift between intended and actual cascade routes | Periodic `Log.Misc.warn` on every reload while flag is active; check log volume on a daily cadence. |
+| Resolvable subset is empty (no profile resolves) but flag is set | Snapshot is `None`; boot still fails (gate falls through to the standard rejection path). The flag only tolerates partial, not total, failure. |
+| Routes reference a profile that *was* in the catalog but is *not* in the resolvable subset | `validate_path_result` still flags this via `cascade route targets missing profile %S`. The rejection path is unchanged for route-key / route-target errors. |
+| Dispatch hits a route whose binding was removed | Phase 8.4 (pending) will verify that the dispatch path either uses the resolvable subset only or fails-loud (no silent fallback to reserved). Until 8.4 lands, *expect dispatch failures* for any route whose binding was in the dropped errors set. |
+
+## 6. Rollback
+
+Unset the env var and restart:
+
+```bash
+unset MASC_CASCADE_PARTIAL_BOOT
+# launchd: edit plist, then `launchctl bootstrap ...` cycle
+# systemd: edit unit, then `systemctl daemon-reload && systemctl restart masc-mcp`
+```
+
+If the underlying `cascade.toml` is still broken, the server will refuse to boot again. That's the intended behavior.
+
+## 7. References
+
+- `docs/rfc/RFC-0058-phase-8-cascade-catalog-partial-parse.md` §4 Phase 8.3
+- `lib/cascade/cascade_catalog_runtime.ml:allow_partial_boot`
+- `lib/cascade/cascade_catalog_runtime.ml:validate_path_result`
+- `lib/cascade/cascade_catalog_runtime.ml:discover_profile_names`
+
+## 8. Follow-ups (not yet shipped)
+
+- **Phase 8.3.1** — dashboard banner showing partial-boot active + count of dropped entries.
+- **Phase 8.4** — dispatch-path tests against partial snapshot to verify no silent fallback.
+- **Phase 8.1.5** (PR #15751) — once merged, `Log.Misc.warn` calls in this runbook's example log lines migrate to `Log.Cascade.warn` for cleaner alerting routing.

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -22,36 +22,36 @@ the categorization roadmap. Newly-added typed getters in
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ADMIN_TOKEN` | string_literal | n/a | n/a | 453 | SSOT for auth env-var names (issue 8352). |
-| `MASC_AUTO_RESPOND` | string_literal | n/a | n/a | 521 | Raw MASC_AUTO_RESPOND value for mode parsing. |
+| `MASC_ADMIN_TOKEN` | string_literal | n/a | n/a | 450 | SSOT for auth env-var names (issue 8352). |
+| `MASC_AUTO_RESPOND` | string_literal | n/a | n/a | 518 | Raw MASC_AUTO_RESPOND value for mode parsing. |
 | `MASC_BASE_PATH` | string_literal | n/a | n/a | 282 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
 | `MASC_BASE_PATH_INPUT` | string_literal | n/a | n/a | 283 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
-| `MASC_BUILD_GIT_COMMIT` | string_literal | n/a | n/a | 515 | Git commit hash override for build identity. |
+| `MASC_BUILD_GIT_COMMIT` | string_literal | n/a | n/a | 512 | Git commit hash override for build identity. |
 | `MASC_CLUSTER_NAME` | string_literal | n/a | n/a | 228 |  |
-| `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 425 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
-| `MASC_DATA_DIR` | string_literal | n/a | n/a | 438 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
-| `MASC_GIT_FETCH_TIMEOUT_SEC` | string_literal | n/a | n/a | 478 | [git fetch origin] before worktree creation is network-bound and can stall behind a slow Docker bridge or a large rem... |
-| `MASC_GOVERNANCE_LEVEL` | string_literal | n/a | n/a | 491 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 422 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
+| `MASC_DATA_DIR` | string_literal | n/a | n/a | 435 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
+| `MASC_GIT_FETCH_TIMEOUT_SEC` | string_literal | n/a | n/a | 475 | [git fetch origin] before worktree creation is network-bound and can stall behind a slow Docker bridge or a large rem... |
+| `MASC_GOVERNANCE_LEVEL` | string_literal | n/a | n/a | 488 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_HOST` | string_literal | n/a | n/a | 199 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
 | `MASC_HTTP_BASE_URL` | string_literal | n/a | n/a | 241 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 | `MASC_HTTP_PORT` | string_literal | n/a | n/a | 200 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
-| `MASC_KEEPER_DEFAULT_SANDBOX_PROFILE` | typed:string | unclassified | unclassified | 548 | Default sandbox profile for keepers. Default: "local". Set to "docker" to default all keepers to containerized execut... |
-| `MASC_KEEPER_DESIRES` | typed:string | unclassified | unclassified | 543 | Default keeper desires (drive statement). Default: "". |
-| `MASC_KEEPER_NEEDS` | typed:string | unclassified | unclassified | 539 | Default keeper needs (operational requirements). Default: "". |
-| `MASC_KEEPER_SOCIAL_MODEL` | typed:string | unclassified | unclassified | 531 | Default social model for keepers. Default: "bdi_speech_v1". |
-| `MASC_KEEPER_WILL` | typed:string | unclassified | unclassified | 535 | Default keeper will (long-term intent). Default: "". |
-| `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 487 | SSOT for logging / observability env-var names (issue 8352). |
-| `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 488 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_KEEPER_DEFAULT_SANDBOX_PROFILE` | typed:string | unclassified | unclassified | 545 | Default sandbox profile for keepers. Default: "local". Set to "docker" to default all keepers to containerized execut... |
+| `MASC_KEEPER_DESIRES` | typed:string | unclassified | unclassified | 540 | Default keeper desires (drive statement). Default: "". |
+| `MASC_KEEPER_NEEDS` | typed:string | unclassified | unclassified | 536 | Default keeper needs (operational requirements). Default: "". |
+| `MASC_KEEPER_SOCIAL_MODEL` | typed:string | unclassified | unclassified | 528 | Default social model for keepers. Default: "bdi_speech_v1". |
+| `MASC_KEEPER_WILL` | typed:string | unclassified | unclassified | 532 | Default keeper will (long-term intent). Default: "". |
+| `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 484 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 485 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_MCP_URL` | string_literal | n/a | n/a | 242 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
-| `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 410 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
-| `MASC_PARSE_WARN` | string_literal | n/a | n/a | 490 | SSOT for logging / observability env-var names (issue 8352). |
-| `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 426 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
-| `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 525 | PubSub max messages per read. Default: 1000. |
-| `MASC_RELAY_CALIBRATION_ENABLED` | typed:bool | unclassified | unclassified | 448 | Whether relay token calibration is enabled. Default: true. |
-| `MASC_STORAGE_TYPE` | string_literal | n/a | n/a | 405 | SSOT for the MASC_STORAGE_TYPE env-var name (issue 8352). |
-| `MASC_TELEMETRY_ENABLED` | string_literal | n/a | n/a | 489 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 407 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
+| `MASC_PARSE_WARN` | string_literal | n/a | n/a | 487 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 423 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
+| `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 522 | PubSub max messages per read. Default: 1000. |
+| `MASC_RELAY_CALIBRATION_ENABLED` | typed:bool | unclassified | unclassified | 445 | Whether relay token calibration is enabled. Default: true. |
+| `MASC_STORAGE_TYPE` | string_literal | n/a | n/a | 402 | SSOT for the MASC_STORAGE_TYPE env-var name (issue 8352). |
+| `MASC_TELEMETRY_ENABLED` | string_literal | n/a | n/a | 486 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 341 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
-| `MASC_TOOL_AUTH_STRICT` | string_literal | n/a | n/a | 454 | SSOT for auth env-var names (issue 8352). |
+| `MASC_TOOL_AUTH_STRICT` | string_literal | n/a | n/a | 451 | SSOT for auth env-var names (issue 8352). |
 
 ## Env_config_exec_timeout (1 knobs; typed classification 0/0)
 

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -170,6 +170,21 @@ let render_declarative_adapter_error error =
     "declarative cascade adapter error: %s"
     (Cascade_declarative_adapter.show_adapter_error error)
 
+(* RFC-0058 Phase 8.3: operator opt-in flag for cold-boot tolerance of
+   partial cascade catalogs. Default is [false], preserving the existing
+   all-or-nothing boot semantics. When set, [validate_path_result] and
+   [discover_profile_names] surface the resolvable subset (via the
+   Phase 8.1 partial-aware adapter) instead of failing closed.
+
+   This is a footgun: leaving it on means operators may not notice
+   degraded cascade.toml until dispatch fails. The dashboard banner and
+   periodic WARN are the mitigations.
+
+   Env var: [MASC_CASCADE_PARTIAL_BOOT=1] (or "true"/"yes").
+   Default: false. *)
+let allow_partial_boot () =
+  Env_config_core.get_bool ~default:false "MASC_CASCADE_PARTIAL_BOOT"
+
 let load_declarative_catalog_info ~config_path =
   match Cascade_declarative_parser.parse_file config_path with
   | Error errors ->
@@ -230,6 +245,28 @@ let discover_profile_names ~config_path ~json : string list =
                false
              end
              else true)
+      |> List.sort_uniq String.compare
+  | Some { declarative_snapshot = Some _; declarative_profile_names = names;
+           declarative_errors = (_ :: _ as errs); _ }
+    when allow_partial_boot () ->
+      (* RFC-0058 Phase 8.3: opt-in partial-boot tolerance. Declarative
+         parser ran with adapter errors, but [MASC_CASCADE_PARTIAL_BOOT]
+         is set, so surface the resolvable subset of profiles and emit
+         a structured WARN per error. *)
+      Cascade_metrics.on_declarative_parse_error ();
+      List.iter
+        (fun err ->
+          Log.Misc.warn
+            "partial-boot mode: declarative adapter error \
+             (continuing with valid subset): %s"
+            (render_declarative_adapter_error err))
+        errs;
+      Cascade_metrics.on_profile_discovery ~path:"declarative_partial_boot";
+      names
+      |> List.filter (fun profile ->
+             not
+               (Cascade_config_loader.is_deprecated_logical_profile_name
+                  profile))
       |> List.sort_uniq String.compare
   | Some { declarative_errors = errs; _ } ->
       (* Declarative parser ran but produced adapter errors.  Do not fall
@@ -783,7 +820,38 @@ let validate_path_result ?sw ?net ~config_path () =
           List.map render_declarative_parse_error declarative_parse_errors
           @ List.map render_declarative_adapter_error declarative_errors
         in
-        if fatal_declarative_errors <> [] then
+        (* RFC-0058 Phase 8.3: partial-boot tolerance.
+
+           Parser-level errors (declarative_parse_errors) are always
+           fatal — the toml could not be tokenised, no snapshot exists.
+           Adapter-level errors (declarative_errors) are tolerable under
+           [MASC_CASCADE_PARTIAL_BOOT=1] iff a non-empty snapshot is
+           available.
+
+           When tolerated, we emit a structured WARN per error and fall
+           through to the normal profile-resolution path; the snapshot
+           already excludes unresolvable entries (Phase 8.1 invariant). *)
+        let parser_fatal =
+          declarative_parse_errors <> []
+        in
+        let adapter_only_errors =
+          declarative_parse_errors = [] && declarative_errors <> []
+        in
+        let tolerate_adapter_errors =
+          adapter_only_errors
+          && declarative_snapshot <> None
+          && allow_partial_boot ()
+        in
+        if tolerate_adapter_errors then
+          List.iter
+            (fun err ->
+              Log.Misc.warn
+                "partial-boot mode: declarative adapter error in %s \
+                 (continuing): %s"
+                source_path (render_declarative_adapter_error err))
+            declarative_errors;
+        if (parser_fatal || (adapter_only_errors && not tolerate_adapter_errors))
+           && fatal_declarative_errors <> [] then
           Error
             (rejection_of_path ~config_path:source_path ~attempted_mtime
                ~checked_at ~errors:fatal_declarative_errors ~profiles:[])

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -246,13 +246,18 @@ let discover_profile_names ~config_path ~json : string list =
              end
              else true)
       |> List.sort_uniq String.compare
-  | Some { declarative_snapshot = Some _; declarative_profile_names = names;
+  | Some { declarative_snapshot = Some snap;
            declarative_errors = (_ :: _ as errs); _ }
     when allow_partial_boot () ->
       (* RFC-0058 Phase 8.3: opt-in partial-boot tolerance. Declarative
          parser ran with adapter errors, but [MASC_CASCADE_PARTIAL_BOOT]
          is set, so surface the resolvable subset of profiles and emit
-         a structured WARN per error. *)
+         a structured WARN per error. Source names from the snapshot
+         (not [declarative_profile_names], which is built from
+         catalog.profiles before empty/unresolvable profiles are
+         removed). Otherwise route-target/default validation can pass
+         for profiles that are no longer in the snapshot, surfacing
+         only later as dispatch failures. *)
       Cascade_metrics.on_declarative_parse_error ();
       List.iter
         (fun err ->
@@ -262,7 +267,7 @@ let discover_profile_names ~config_path ~json : string list =
             (render_declarative_adapter_error err))
         errs;
       Cascade_metrics.on_profile_discovery ~path:"declarative_partial_boot";
-      names
+      Cascade_declarative_hotpath.decl_snapshot_profile_names snap
       |> List.filter (fun profile ->
              not
                (Cascade_config_loader.is_deprecated_logical_profile_name


### PR DESCRIPTION
## Summary

RFC-0058 Phase 8.3 — **closes gap 1 (HIGH)** from PR #15740 §11.1: boot gate stayed binary after Phase 8.1/8.2, so a stale cascade.toml binding still aborts cold-boot at `validate_path_result` before keeper validators run.

This PR adds an opt-in operator flag `MASC_CASCADE_PARTIAL_BOOT` that relaxes the boot gate for **adapter-level errors only**. Parser-level errors remain fatal. The flag defaults to `false`; existing all-or-nothing semantics are preserved for operators who don't set it.

RFC-EXTEND: 0058

## Why opt-in, not silent default

The fail-loud-on-boot intent of `validate_path_result` is sound: a broken `cascade.toml` should be visible on boot, not silently routing traffic through a degraded catalog. Phase 8.2 already covers the *live reload* path (operator can edit cascade.toml without dropping keepers). The cold-boot gap exists because, when the server is *down*, no live reload helps — the operator needs a way to bring up the server *with a known-broken config* to recover service quickly while fixing the toml.

Strict-by-default + explicit opt-in matches the existing pattern (`MASC_KEEPER_DOCKER_PLAYGROUND`, `MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED`). The dashboard banner (Phase 8.3.1) is the visibility partner — separate PR scope to keep this one small.

## RFC 인용 (agent_delegation §3)

- `docs/rfc/RFC-0058-phase-8-cascade-catalog-partial-parse.md` §4 Phase 8.3 (operator flag), §11.1 gap 1 (HIGH severity)
- RFC-EXTEND: 0058

`pr-rfc-check.sh` PASS.

## What changed

| File | Direction | Notes |
|---|---|---|
| `lib/cascade/cascade_catalog_runtime.ml` | +69/-1 | `let allow_partial_boot () = Env_config_core.get_bool ~default:false "MASC_CASCADE_PARTIAL_BOOT"`; new clause in `discover_profile_names` for partial-boot tolerance; rewrite the fatal-error guard in `validate_path_result` to separate parser-fatal from adapter-only and tolerate adapter-only under the flag. |
| `docs/cascade/PARTIAL-BOOT-OPERATOR-RUNBOOK.md` | new | Operator runbook — when to use, how to enable, log signatures, footguns, rollback. |

No test changes (rationale below).

## Boot-gate decision matrix (post-PR)

| Catalog state | Flag off (default) | Flag on |
|---|---|---|
| Clean toml, snapshot OK | Boot ✓ | Boot ✓ |
| Parser errors (unparseable toml) | **Reject** (correct) | **Reject** (correct — no snapshot possible) |
| Adapter errors only, snapshot empty | Reject | Reject (snapshot empty → falls through to standard rejection) |
| Adapter errors only, snapshot non-empty | **Reject** (HIGH severity case) | **Boot with valid subset + WARN per error** |
| Route key/target errors only | Reject (unchanged) | Reject (unchanged) |

Only the bolded case changes behavior.

## Logging

`Log.Misc.warn` is used (existing pattern in this module — lines 215, 242). Once PR #15751 (Phase 8.1.5: `Log.Cascade` namespace) merges, a follow-up sweep PR migrates these to `Log.Cascade.warn`. Stacking 8.3 on 8.1.5 was explicitly avoided to keep PR independence per `feedback_stacked_pr_merge_inversion` (MEMORY).

## Test plan

- [x] `dune build --root . lib/` passes
- [x] Phase 8 unit tests regression-free:
  - `test_cascade_declarative_hotpath.exe` — 18/18
  - `test_keeper_cascade_profile_partial.exe` — 3/3
- [ ] **Unit test for boot gate**: not added. Boot-gate paths require a live server process or fixture infrastructure that does not exist in the current test surface. Acceptance is operational: post-merge, set `MASC_CASCADE_PARTIAL_BOOT=1` and confirm server boots on a `cascade.toml` with a stale binding.

This test gap is acknowledged in RFC §11.4 operating principle ("load path / boot path / dispatch path — three separate axes"). The *load path* (`catalog_names_for_validation`) is unit-tested; the *boot path* (`validate_path_result`) is acceptance-tested operationally. Adding a `Cascade_catalog_runtime` fixture is a Phase 8.4 or later concern.

## Footgun mitigations (also in runbook §5)

| Risk | Mitigation |
|---|---|
| Operator leaves flag on indefinitely → silent drift | Periodic `WARN` on every reload while flag active; runbook §6 emphasizes "emergency-only, not steady-state" |
| Resolvable subset empty | Snapshot is `None`; boot still fails (gate falls through to standard rejection) — flag only tolerates partial, not total, failure |
| Routes reference dropped profile | Existing `cascade route targets missing profile %S` rejection path unchanged |
| Dispatch hits removed binding | Phase 8.4 (pending) verifies dispatch behavior. Until then, runbook warns to expect dispatch failures for affected routes |

## Workaround rejection self-check

- [ ] telemetry-as-fix → **NO**, functional behavior change (boot proceeds with valid subset)
- [ ] string classifier → **NO**
- [ ] N-of-M → **NO**, one flag, two call sites read it via shared `allow_partial_boot` accessor
- [ ] catch-all `_ ->` → **NO**, explicit match arms
- [ ] cap/cooldown/dedup/repair → **dedup is PR-B's scope** (8.1.5); this PR is structural relaxation, opt-in
- [ ] test backdoor → **NO**. `allow_partial_boot` reads env var; no `set_*_for_test` helper
- [ ] repeat typo → **NO**

## Pending follow-ups (covered by future PRs)

- **Phase 8.3.1** — dashboard banner reflecting partial-boot active state + dropped-entry count (UI scope, separate PR)
- **Phase 8.4** — PR-D, dispatch resolver partial invariants (test-only)
- **Phase 8.1.5 follow-up** — once PR #15751 merges, sweep `Log.Misc.warn` → `Log.Cascade.warn` in this file's new clauses

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
