### PR TITLE
test(cascade): partial snapshot dispatch invariants (RFC-0058 phase 8.4)

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -22,36 +22,36 @@ the categorization roadmap. Newly-added typed getters in
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ADMIN_TOKEN` | string_literal | n/a | n/a | 453 | SSOT for auth env-var names (issue 8352). |
-| `MASC_AUTO_RESPOND` | string_literal | n/a | n/a | 521 | Raw MASC_AUTO_RESPOND value for mode parsing. |
+| `MASC_ADMIN_TOKEN` | string_literal | n/a | n/a | 450 | SSOT for auth env-var names (issue 8352). |
+| `MASC_AUTO_RESPOND` | string_literal | n/a | n/a | 518 | Raw MASC_AUTO_RESPOND value for mode parsing. |
 | `MASC_BASE_PATH` | string_literal | n/a | n/a | 282 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
 | `MASC_BASE_PATH_INPUT` | string_literal | n/a | n/a | 283 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
-| `MASC_BUILD_GIT_COMMIT` | string_literal | n/a | n/a | 515 | Git commit hash override for build identity. |
+| `MASC_BUILD_GIT_COMMIT` | string_literal | n/a | n/a | 512 | Git commit hash override for build identity. |
 | `MASC_CLUSTER_NAME` | string_literal | n/a | n/a | 228 |  |
-| `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 425 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
-| `MASC_DATA_DIR` | string_literal | n/a | n/a | 438 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
-| `MASC_GIT_FETCH_TIMEOUT_SEC` | string_literal | n/a | n/a | 478 | [git fetch origin] before worktree creation is network-bound and can stall behind a slow Docker bridge or a large rem... |
-| `MASC_GOVERNANCE_LEVEL` | string_literal | n/a | n/a | 491 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 422 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
+| `MASC_DATA_DIR` | string_literal | n/a | n/a | 435 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
+| `MASC_GIT_FETCH_TIMEOUT_SEC` | string_literal | n/a | n/a | 475 | [git fetch origin] before worktree creation is network-bound and can stall behind a slow Docker bridge or a large rem... |
+| `MASC_GOVERNANCE_LEVEL` | string_literal | n/a | n/a | 488 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_HOST` | string_literal | n/a | n/a | 199 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
 | `MASC_HTTP_BASE_URL` | string_literal | n/a | n/a | 241 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 | `MASC_HTTP_PORT` | string_literal | n/a | n/a | 200 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
-| `MASC_KEEPER_DEFAULT_SANDBOX_PROFILE` | typed:string | unclassified | unclassified | 548 | Default sandbox profile for keepers. Default: "local". Set to "docker" to default all keepers to containerized execut... |
-| `MASC_KEEPER_DESIRES` | typed:string | unclassified | unclassified | 543 | Default keeper desires (drive statement). Default: "". |
-| `MASC_KEEPER_NEEDS` | typed:string | unclassified | unclassified | 539 | Default keeper needs (operational requirements). Default: "". |
-| `MASC_KEEPER_SOCIAL_MODEL` | typed:string | unclassified | unclassified | 531 | Default social model for keepers. Default: "bdi_speech_v1". |
-| `MASC_KEEPER_WILL` | typed:string | unclassified | unclassified | 535 | Default keeper will (long-term intent). Default: "". |
-| `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 487 | SSOT for logging / observability env-var names (issue 8352). |
-| `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 488 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_KEEPER_DEFAULT_SANDBOX_PROFILE` | typed:string | unclassified | unclassified | 545 | Default sandbox profile for keepers. Default: "local". Set to "docker" to default all keepers to containerized execut... |
+| `MASC_KEEPER_DESIRES` | typed:string | unclassified | unclassified | 540 | Default keeper desires (drive statement). Default: "". |
+| `MASC_KEEPER_NEEDS` | typed:string | unclassified | unclassified | 536 | Default keeper needs (operational requirements). Default: "". |
+| `MASC_KEEPER_SOCIAL_MODEL` | typed:string | unclassified | unclassified | 528 | Default social model for keepers. Default: "bdi_speech_v1". |
+| `MASC_KEEPER_WILL` | typed:string | unclassified | unclassified | 532 | Default keeper will (long-term intent). Default: "". |
+| `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 484 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 485 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_MCP_URL` | string_literal | n/a | n/a | 242 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
-| `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 410 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
-| `MASC_PARSE_WARN` | string_literal | n/a | n/a | 490 | SSOT for logging / observability env-var names (issue 8352). |
-| `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 426 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
-| `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 525 | PubSub max messages per read. Default: 1000. |
-| `MASC_RELAY_CALIBRATION_ENABLED` | typed:bool | unclassified | unclassified | 448 | Whether relay token calibration is enabled. Default: true. |
-| `MASC_STORAGE_TYPE` | string_literal | n/a | n/a | 405 | SSOT for the MASC_STORAGE_TYPE env-var name (issue 8352). |
-| `MASC_TELEMETRY_ENABLED` | string_literal | n/a | n/a | 489 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 407 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
+| `MASC_PARSE_WARN` | string_literal | n/a | n/a | 487 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 423 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
+| `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 522 | PubSub max messages per read. Default: 1000. |
+| `MASC_RELAY_CALIBRATION_ENABLED` | typed:bool | unclassified | unclassified | 445 | Whether relay token calibration is enabled. Default: true. |
+| `MASC_STORAGE_TYPE` | string_literal | n/a | n/a | 402 | SSOT for the MASC_STORAGE_TYPE env-var name (issue 8352). |
+| `MASC_TELEMETRY_ENABLED` | string_literal | n/a | n/a | 486 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 341 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
-| `MASC_TOOL_AUTH_STRICT` | string_literal | n/a | n/a | 454 | SSOT for auth env-var names (issue 8352). |
+| `MASC_TOOL_AUTH_STRICT` | string_literal | n/a | n/a | 451 | SSOT for auth env-var names (issue 8352). |
 
 ## Env_config_exec_timeout (1 knobs; typed classification 0/0)
 

--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -495,6 +495,148 @@ let test_try_load_partial_clean_has_no_errors () =
       | Some { snapshot = _; errors } ->
         check int "clean parse has no errors" 0 (List.length errors))
 
+(* --- RFC-0058 Phase 8.4: dispatch-path partial invariants ---
+
+   These tests strengthen the snapshot invariants that downstream
+   dispatch (Cascade_catalog_runtime.known_profile_names,
+   lookup_active_profile, etc.) relies on. The runtime dispatch path
+   reads [snapshot.profiles] without re-checking per-member
+   resolvability — so if the adapter ever exposed a half-stitched tier
+   (e.g. tier-group referencing an unresolvable tier) in the snapshot,
+   dispatch would crash or fall through to reserved without warning.
+
+   Phase 8.1's adapted_profile_to_profile + adapted_catalog_to_snapshot
+   already enforce these invariants via [List.filter_map] +
+   [None when provider_configs = []]. These tests mechanize that
+   guarantee so a future refactor of the adapter cannot silently
+   weaken it.
+
+   See RFC-0058-phase-8-cascade-catalog-partial-parse.md §6.4. *)
+
+(* Catalog with two tiers: one fully resolvable, one with all members
+   referencing missing bindings. A tier-group composes both. The fully
+   unresolvable tier must NOT appear in the snapshot; the tier-group
+   surfaces because it has at least one resolvable tier. *)
+let mixed_tier_resolvability_toml = {|
+[providers.ollama]
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+
+[models.qwen3]
+max-context = 32768
+api-name = "qwen3:8b"
+tools-support = true
+
+[ollama.qwen3]
+
+[tier.good]
+members = ["ollama.qwen3"]
+strategy = "failover"
+
+[tier.bad]
+members = ["ghost.ghost-model"]
+strategy = "failover"
+
+[tier-group.mixed]
+tiers = ["good", "bad"]
+strategy = "failover"
+|}
+
+let test_partial_snapshot_excludes_zero_member_tiers () =
+  let path = write_temp_toml mixed_tier_resolvability_toml in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      match Hotpath.try_load_partial path with
+      | None -> fail "expected Some partial result (mixed tier resolvability)"
+      | Some { snapshot; errors } ->
+        let names = Hotpath.decl_snapshot_profile_names snapshot in
+        check bool "errors recorded for bad tier" true (List.length errors > 0);
+        check bool "tier.good in snapshot" true
+          (List.exists (fun n -> n = "tier.good") names);
+        check bool "tier.bad excluded from snapshot (zero resolvable members)"
+          true
+          (not (List.exists (fun n -> n = "tier.bad") names));
+        check bool "tier-group.mixed surfaces (one good tier suffices)" true
+          (List.exists (fun n -> n = "tier-group.mixed") names))
+
+let test_partial_snapshot_errors_disjoint_from_profile_names () =
+  let path = write_temp_toml mixed_tier_resolvability_toml in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      match Hotpath.try_load_partial path with
+      | None -> fail "expected Some result"
+      | Some { snapshot; errors } ->
+        let names = Hotpath.decl_snapshot_profile_names snapshot in
+        (* Error subjects (provider/model names mentioned in the errors)
+           must not appear as profile names. The snapshot exposes only
+           resolved entries; failed bindings/tiers are reported in
+           [errors], never half-published as profiles.
+
+           This is the invariant downstream dispatch (lookup_active_profile)
+           relies on: a name in [snapshot.profiles] always points at a
+           fully resolved profile. *)
+        let error_subjects =
+          errors
+          |> List.filter_map (function
+              | Adapter.Provider_not_found s -> Some s
+              | Adapter.Model_not_found s -> Some s
+              | Adapter.Tier_group_empty s -> Some s
+              | _ -> None)
+        in
+        List.iter (fun subject ->
+          check bool
+            (Printf.sprintf "error subject %S not in snapshot profile_names"
+               subject)
+            false
+            (List.exists (fun n -> n = subject) names))
+          error_subjects)
+
+(* Catalog where every tier-group member is unresolvable. Snapshot must
+   be None (or the tier-group must be excluded from a non-empty snapshot
+   produced by other valid profiles). *)
+let all_tiers_unresolvable_toml = {|
+[providers.ollama]
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+
+[models.qwen3]
+max-context = 32768
+api-name = "qwen3:8b"
+tools-support = true
+
+[ollama.qwen3]
+
+[tier.lone-good]
+members = ["ollama.qwen3"]
+strategy = "failover"
+
+[tier.all-bad]
+members = ["ghost.a", "ghost.b"]
+strategy = "failover"
+
+[tier-group.doomed]
+tiers = ["all-bad"]
+strategy = "failover"
+|}
+
+let test_tier_group_with_all_unresolvable_tiers_excluded () =
+  let path = write_temp_toml all_tiers_unresolvable_toml in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+      match Hotpath.try_load_partial path with
+      | None -> fail "expected Some result (tier.lone-good is resolvable)"
+      | Some { snapshot; errors = _ } ->
+        let names = Hotpath.decl_snapshot_profile_names snapshot in
+        check bool "tier.lone-good in snapshot" true
+          (List.exists (fun n -> n = "tier.lone-good") names);
+        check bool "tier-group.doomed not in snapshot (all tiers fail)" true
+          (not (List.exists (fun n -> n = "tier-group.doomed") names));
+        check bool "tier.all-bad not in snapshot (zero members)" true
+          (not (List.exists (fun n -> n = "tier.all-bad") names)))
+
 (* --- Test suite --- *)
 
 let () =
@@ -552,5 +694,20 @@ let () =
           "try_load_partial clean parse has empty errors"
           `Quick
           test_try_load_partial_clean_has_no_errors;
+      ];
+      "phase8_4_dispatch_invariants",
+      [
+        test_case
+          "partial snapshot excludes zero-member tiers"
+          `Quick
+          test_partial_snapshot_excludes_zero_member_tiers;
+        test_case
+          "errors disjoint from profile_names"
+          `Quick
+          test_partial_snapshot_errors_disjoint_from_profile_names;
+        test_case
+          "tier-group with all unresolvable tiers excluded"
+          `Quick
+          test_tier_group_with_all_unresolvable_tiers_excluded;
       ];
     ]

--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -577,13 +577,24 @@ let test_partial_snapshot_errors_disjoint_from_profile_names () =
            This is the invariant downstream dispatch (lookup_active_profile)
            relies on: a name in [snapshot.profiles] always points at a
            fully resolved profile. *)
+        (* Exhaustive over Adapter.adapter_error. Subjects that name a
+           binding-like entity (provider/model/binding/alias/tier-group)
+           must not appear as snapshot profile_names. Strategy_mismatch
+           carries a tier name, Duplicate_route a route name, Internal an
+           internal message — none of those are binding subjects, so they
+           are excluded explicitly. Catch-all removed to force review on
+           new variants. *)
         let error_subjects =
           errors
           |> List.filter_map (function
-              | Adapter.Provider_not_found s -> Some s
-              | Adapter.Model_not_found s -> Some s
+              | Adapter.Provider_not_found s
+              | Adapter.Model_not_found s
+              | Adapter.Binding_resolution_failed s
+              | Adapter.Alias_resolution_failed s
               | Adapter.Tier_group_empty s -> Some s
-              | _ -> None)
+              | Adapter.Strategy_mismatch _
+              | Adapter.Duplicate_route _
+              | Adapter.Internal _ -> None)
         in
         List.iter (fun subject ->
           check bool


### PR DESCRIPTION
## Summary

RFC-0058 Phase 8.4 — **closes gap 2 (MEDIUM)** from PR #15740 §11.1: the dispatch path (`Cascade_catalog_runtime.known_profile_names`, `lookup_active_profile`, etc.) had no test coverage against partial snapshots produced by `try_load_partial`.

**Test-only PR**. Three property tests verifying invariants the adapter already enforces in code (via `List.filter_map` in `adapted_profile_to_profile` and the `[] -> None` guard in `adapted_catalog_to_snapshot`).

If a future refactor weakens these invariants, downstream dispatch would receive half-stitched tiers — tier-groups referencing unresolvable tiers, or `profile_names` whose underlying bindings failed. These tests fail-loud when that happens.

RFC-EXTEND: 0058

## What this is *not*

Not a full runtime-dispatch integration test. A full `Cascade_catalog_runtime` activation + `known_profile_names` lookup against a partial active snapshot requires fixture infrastructure that does not exist in the current test surface. That broader scope is deferred (RFC §6.4 follow-up).

These tests target the **upstream invariant** that dispatch depends on: dispatch reads `snapshot.profiles` without re-checking per-member resolvability, so the invariant must hold at the snapshot boundary. That is the higher-leverage assertion point.

## RFC 인용 (agent_delegation §3)

- `docs/rfc/RFC-0058-phase-8-cascade-catalog-partial-parse.md` §6.4 (dispatch invariant, pending), §11.1 gap 2 (MEDIUM)
- RFC-EXTEND: 0058

`pr-rfc-check.sh` PASS.

## Test cases (`phase8_4_dispatch_invariants` group)

| # | Name | Fixture | Assertion |
|---|---|---|---|
| 1 | partial snapshot excludes zero-member tiers | `tier.good` valid + `tier.bad` (all members unresolvable) + `tier-group.mixed` references both | `tier.good` in snapshot; `tier.bad` excluded; `tier-group.mixed` in snapshot (one good tier suffices) |
| 2 | errors disjoint from `profile_names` | same as #1 | No provider/model/tier-group name appearing in `errors` also appears in `snapshot.profile_names`. This is the contract `lookup_active_profile` relies on: a name in the snapshot always points at a fully resolved profile |
| 3 | tier-group with all unresolvable tiers excluded | `tier.lone-good` valid + `tier.all-bad` unresolvable + `tier-group.doomed` references only `all-bad` | `tier.lone-good` in snapshot; `tier-group.doomed` excluded (zero resolvable tiers); `tier.all-bad` excluded |

All three pass on current `main`. The adapter already implements these invariants; this PR mechanizes them so a regression surfaces immediately.

## What changed

| File | Direction | Notes |
|---|---|---|
| `test/test_cascade_declarative_hotpath.ml` | +157 | Two new fixture toml strings (`mixed_tier_resolvability_toml`, `all_tiers_unresolvable_toml`); three test functions; one new test_case group `phase8_4_dispatch_invariants` registered in Alcotest run |

No source / dune changes.

## Verification

- [x] `dune build test/test_cascade_declarative_hotpath.exe` passes
- [x] `dune exec test/test_cascade_declarative_hotpath.exe` — **21/21**:
  - 15 pre-existing (snapshot, edge_cases, routes, introspection, runtime groups)
  - 3 from Phase 8.1 (`phase8_partial_parse`)
  - **3 new from Phase 8.4** (`phase8_4_dispatch_invariants`)

## Closure of Phase 8 self-review gaps

With this PR, all 6 gaps from PR #15740 §11.1 are addressed:

| # | Gap | Severity | Closed by |
|---|---|---|---|
| 1 | Boot gate binary | HIGH | PR #15758 (Phase 8.3 — `MASC_CASCADE_PARTIAL_BOOT` flag) |
| 2 | Dispatch partial untested | MEDIUM | **This PR (Phase 8.4)** |
| 3 | Log.Cascade namespace missing | LOW | PR #15751 (Phase 8.1.5) |
| 4 | No log dedup | LOW | PR #15751 (Phase 8.1.5) |
| 5 | §1.3 reserved analysis inaccurate | LOW | PR #15740 (RFC amend) |
| 6 | §6 "9 keeper unblock" overclaim | LOW | PR #15740 (RFC amend) |

After this PR + PR-B (#15751) + PR-C (#15758) all merge, Phase 8 is functionally complete. Phase 8.3.1 (dashboard banner) remains as a UI-only follow-up.

## Workaround rejection self-check

- [ ] telemetry-as-fix → **NO**, tests not a counter
- [ ] string classifier → **NO**
- [ ] N-of-M → **NO**, three property tests for three distinct invariants
- [ ] catch-all `_ ->` → **NO**
- [ ] cap/cooldown/dedup/repair → **NO**
- [ ] test backdoor → **NO**, uses public API (`try_load_partial`, `decl_snapshot_profile_names`)
- [ ] repeat typo → **NO**

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
