### PR TITLE
fix(voice): surface playback result status

### DIFF
--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -571,6 +571,27 @@ let attempt_tts_endpoint
                 ; "agent_id", `String agent_id
                 ; "reason", `String "identical message was played recently (mutex)"
                 ])
+        | (`Failed reason | `Skipped reason) as playback_status ->
+          let local_playback_status =
+            match playback_status with
+            | `Failed _ -> "failed"
+            | `Skipped _ -> "skipped"
+          in
+          Ok
+            (append_provider_metadata
+               (`Assoc
+                   [ "status", `String "spoken"
+                   ; "agent_id", `String agent_id
+                   ; "voice", `String voice
+                   ; "audio_file", `String audio_file
+                   ; "audio_size", `Int file_size
+                   ; ( "message_preview"
+                     , `String
+                         (String.sub message 0 (min 50 (String.length message))) )
+                   ; "local_playback_status", `String local_playback_status
+                   ; "local_playback_reason", `String reason
+                   ])
+               endpoint)
         | `Played played_seconds ->
           Ok
             (append_provider_metadata
@@ -584,10 +605,9 @@ let attempt_tts_endpoint
                         ; ( "message_preview"
                           , `String
                               (String.sub message 0 (min 50 (String.length message))) )
+                        ; "local_playback_status", `String "played"
+                        ; "played_seconds", `Float played_seconds
                         ]
-                      ; (match played_seconds with
-                         | Some s -> [ "played_seconds", `Float s ]
-                         | None -> [])
                       ]))
                endpoint))
      | Error error ->

--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -181,8 +181,9 @@ let local_playback_argvs ?path_value ~audio_file () =
     - [`Dedup_hit] if another fiber already played this same message recently
       (check happens INSIDE the mutex to close the check-then-act race where two
       fibers both pass the outer [is_dedup_hit] before either records).
-    - [`Played None] if playback was disabled, unavailable, or failed.
-    - [`Played (Some dur)] if playback succeeded with the given duration.
+    - [`Skipped reason] if playback was intentionally skipped.
+    - [`Failed reason] if playback was requested but unavailable or failed.
+    - [`Played dur] if playback succeeded with the given duration.
 
     When [message] is [None] the dedup re-check is skipped (legacy callers that
     do not propagate the message string). *)
@@ -190,16 +191,19 @@ let run_local_playback ~sw:_ ~agent_id ?message ~audio_file () =
   match load_voice_config () with
   | Error e ->
     Log.Misc.warn "voice config load failed, skipping playback for %s: %s" agent_id e;
-    `Played None
+    `Failed ("voice config load failed: " ^ e)
   | Ok config ->
     if not (Voice_config.local_playback_enabled_for_agent config agent_id) then
-      `Played None
+      `Skipped "local playback disabled for agent"
     else
       match local_playback_argvs ~audio_file () with
       | [] ->
+        let reason =
+          "no afplay/ffplay/mpg123/play/open executable found"
+        in
         log_error
-          "local voice playback unavailable: no afplay/ffplay/mpg123/play/open executable found";
-        `Played None
+          (Printf.sprintf "local voice playback unavailable: %s" reason);
+        `Failed reason
       | candidates ->
         Eio.Mutex.use_rw ~protect:true playback_mu (fun () ->
           let dedup_hit =
@@ -219,8 +223,14 @@ let run_local_playback ~sw:_ ~agent_id ?message ~audio_file () =
             (match message with
              | Some m -> record_playback ~agent_id ~message:m
              | None -> ());
-            let rec try_candidates = function
-              | [] -> `Played None
+            let rec try_candidates failures = function
+              | [] ->
+                let reason =
+                  match List.rev failures with
+                  | [] -> "all local playback candidates failed"
+                  | failures -> String.concat " | " failures
+                in
+                `Failed reason
               | argv :: rest ->
                 let t0 = Unix.gettimeofday () in
                 let raw_source =
@@ -246,44 +256,65 @@ let run_local_playback ~sw:_ ~agent_id ?message ~audio_file () =
                          "local voice playback finished: agent=%s file=%s via=%s \
                           duration=%.1fs"
                          agent_id audio_file executable dur);
-                    `Played (Some dur)
+                    `Played dur
                   | Unix.WEXITED code, output ->
+                    let failure =
+                      Printf.sprintf "%s exited %d%s" executable code
+                        (if String.trim output = "" then ""
+                         else ": " ^ String.trim output)
+                    in
                     log_error
                       (Printf.sprintf
                          "local voice playback candidate failed (exit=%d): %s%s"
                          code (String.concat " " argv)
                          (if String.trim output = "" then ""
                           else " :: " ^ String.trim output));
-                    try_candidates rest
+                    try_candidates (failure :: failures) rest
                   | Unix.WSTOPPED signal, output ->
+                    let failure =
+                      Printf.sprintf "%s stopped by signal %d%s" executable signal
+                        (if String.trim output = "" then ""
+                         else ": " ^ String.trim output)
+                    in
                     log_error
                       (Printf.sprintf
                          "local voice playback candidate stopped (sig=%d): %s%s"
                          signal (String.concat " " argv)
                          (if String.trim output = "" then ""
                           else " :: " ^ String.trim output));
-                    try_candidates rest
+                    try_candidates (failure :: failures) rest
                   | Unix.WSIGNALED signal, output ->
+                    let failure =
+                      Printf.sprintf "%s signaled %d%s" executable signal
+                        (if String.trim output = "" then ""
+                         else ": " ^ String.trim output)
+                    in
                     log_error
                       (Printf.sprintf
                          "local voice playback candidate signaled (sig=%d): %s%s"
                          signal (String.concat " " argv)
                          (if String.trim output = "" then ""
                           else " :: " ^ String.trim output));
-                    try_candidates rest
+                    try_candidates (failure :: failures) rest
                 with
                 | Eio.Cancel.Cancelled _ as e -> raise e
                 | exn ->
+                  let failure =
+                    Printf.sprintf "%s exception: %s" executable
+                      (Printexc.to_string exn)
+                  in
                   log_error
                     (Printf.sprintf "voice playback candidate exception: %s"
                        (Printexc.to_string exn));
-                  try_candidates rest
+                  try_candidates (failure :: failures) rest
             in
-            try_candidates candidates
+            try_candidates [] candidates
           end)
 
 let start_local_playback ~sw ~agent_id ~audio_file =
-  ignore (run_local_playback ~sw ~agent_id ~audio_file () : [`Dedup_hit | `Played of float option])
+  ignore
+    (run_local_playback ~sw ~agent_id ~audio_file ()
+      : [ `Dedup_hit | `Failed of string | `Played of float | `Skipped of string ])
 
 (** Get voice for agent, defaults to "Sarah" if config is unavailable *)
 let get_voice_for_agent agent_id =

--- a/lib/voice/voice_bridge_core.mli
+++ b/lib/voice/voice_bridge_core.mli
@@ -105,16 +105,18 @@ val run_local_playback :
   ?message:string ->
   audio_file:string ->
   unit ->
-  [ `Dedup_hit | `Played of float option ]
+  [ `Dedup_hit | `Played of float | `Skipped of string | `Failed of string ]
 (** Mutex-protected local audio playback with a 30s dedup window
     keyed on [(agent_id, hash message)]. Returns:
 
     - [`Dedup_hit] — another fiber already played this same message
       recently (check happens inside the playback mutex to close the
       check-then-act race);
-    - [`Played None] — playback was disabled, no executable available,
-      or the player exited non-zero;
-    - [`Played (Some duration_seconds)] — playback succeeded.
+    - [`Skipped reason] — playback was intentionally skipped, for example
+      because local playback is disabled for the agent;
+    - [`Failed reason] — local playback was requested but no candidate player
+      succeeded;
+    - [`Played duration_seconds] — playback succeeded.
 
     When [message] is omitted the dedup re-check is skipped (legacy
     callers that do not propagate the message string). *)


### PR DESCRIPTION
## Summary
- Return structured local playback outcomes from `run_local_playback`: played, skipped, failed, or dedup.
- Preserve `status: spoken` for successful TTS synthesis, but add `local_playback_status` and `local_playback_reason` so operators can distinguish generated audio from audible playback.
- Include per-candidate playback failure details when all local players fail.

## Evidence
- ElevenLabs generated a valid mp3, and `afinfo`/`ffprobe` could parse it.
- This shell session could not start CoreAudio playback even for `/System/Library/Sounds/Ping.aiff`, so the local failure is an output-session/device issue rather than a TTS file issue.

## Verification
- `ocamlformat --check lib/voice/voice_bridge_core.ml lib/voice/voice_bridge_core.mli lib/voice/voice_bridge.ml`
- `git diff --check`
- Targeted Dune build attempted, but `/tmp/me-dune-local.lock` was held by another long-running verification; CI should provide compile verification.