### PR TITLE
fix(keeper): expose fleet fd safety health

### DIFF
--- a/lib/keeper_fd_pressure.ml
+++ b/lib/keeper_fd_pressure.ml
@@ -231,6 +231,94 @@ let admitted = function
   | Block _ -> false
 ;;
 
+let option_int_json = function
+  | Some value -> `Int value
+  | None -> `Null
+;;
+
+let admission_block_to_json = function
+  | Fd_pressure_cooldown remaining_sec ->
+    `Assoc
+      [ "kind", `String "fd_pressure_cooldown"
+      ; "remaining_sec", `Float remaining_sec
+      ]
+  | Projected_fd_budget_exhausted
+      { soft_limit; open_fds; active_keepers; starting_keepers; projected_fds } ->
+    `Assoc
+      [ "kind", `String "projected_fd_budget_exhausted"
+      ; "soft_limit", `Int soft_limit
+      ; "open_fds", option_int_json open_fds
+      ; "active_keepers", `Int active_keepers
+      ; "starting_keepers", `Int starting_keepers
+      ; "projected_fds", `Int projected_fds
+      ]
+;;
+
+let admission_decision_to_json = function
+  | Admit -> `Assoc [ "status", `String "admit"; "block", `Null ]
+  | Block block ->
+    `Assoc [ "status", `String "block"; "block", admission_block_to_json block ]
+;;
+
+let admission_block_kind = function
+  | Fd_pressure_cooldown _ -> "fd_pressure_cooldown"
+  | Projected_fd_budget_exhausted _ -> "projected_fd_budget_exhausted"
+;;
+
+let runtime_state_json ?(soft_limit = process_nofile_soft_limit ())
+    ?(open_fds = process_open_fd_count ()) ~active_keepers ~starting_keepers
+    ~requested_keepers () =
+  let active_keepers = max 0 active_keepers in
+  let starting_keepers = max 0 starting_keepers in
+  let requested_keepers = max 0 requested_keepers in
+  let target_keeper_count = max requested_keepers (active_keepers + starting_keepers) in
+  let projected_starting_keepers =
+    max starting_keepers (target_keeper_count - active_keepers)
+  in
+  let projected_fds =
+    projected_fd_budget ?open_fds ~active_keepers
+      ~starting_keepers:projected_starting_keepers ()
+  in
+  let admission_decision =
+    admission_decision ~soft_limit ~open_fds ~active_keepers
+      ~starting_keepers:projected_starting_keepers ()
+  in
+  let admission_blocked = not (admitted admission_decision) in
+  let status, reason =
+    match admission_decision with
+    | Admit -> "ok", `Null
+    | Block block -> "blocked", `String (admission_block_kind block)
+  in
+  let active_keeper_cap =
+    match soft_limit with
+    | Some soft when soft > 0 -> `Int (active_keeper_cap_for_soft_limit soft)
+    | _ -> `Null
+  in
+  `Assoc
+    [ "status", `String status
+    ; "reason", reason
+    ; "degraded", `Bool (active ())
+    ; "fd_pressure_remaining_sec", `Float (remaining_sec ())
+    ; "soft_limit", option_int_json soft_limit
+    ; "open_fds", option_int_json open_fds
+    ; "headroom", `Int (fd_headroom ())
+    ; "fd_per_active_keeper", `Int (fd_per_active_keeper ())
+    ; "min_nofile_for_24_keepers", `Int (min_nofile_for_24_keepers ())
+    ; "requested_keepers", `Int requested_keepers
+    ; "target_keeper_count", `Int target_keeper_count
+    ; "active_keepers", `Int active_keepers
+    ; "starting_keepers", `Int starting_keepers
+    ; "projected_starting_keepers", `Int projected_starting_keepers
+    ; "projected_fds", `Int projected_fds
+    ; "active_keeper_cap", active_keeper_cap
+    ; "admission_decision", admission_decision_to_json admission_decision
+    ; "admission_blocked", `Bool admission_blocked
+    ; ( "admission_blocked_keepers"
+      , if admission_blocked then `Int requested_keepers else `Null )
+    ; "operator_action_required", `Bool admission_blocked
+    ]
+;;
+
 let admit_start ?soft_limit ?open_fds ~active_keepers ~starting_keepers () =
   admitted (admission_decision ?soft_limit ?open_fds ~active_keepers ~starting_keepers ())
 ;;

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -536,31 +536,32 @@ let runtime_resolution_json (config : Coord.config) =
   in
   let status = if warnings = [] then "ready" else "warn" in
   `Assoc
-    [ "status", `String status
-    ; "warnings", `List (List.map (fun warning -> `String warning) warnings)
-    ; "base_path", path_item_json ~source:"input" base_path_input
-    ; "workspace_path", path_item_json ~source:"workspace" config.workspace_path
-    ; "resolved_base_path", path_item_json ~source:"resolved_base" config.base_path
-    ; "data_root", path_item_json ~source:"runtime_data" (Coord.masc_root_dir config)
-    ; "prompt_markdown_dir", path_item_json ~source:"prompt_registry" prompt_markdown_dir
-    ; ( "server_repo_path"
-      , match server_repo_path with
-        | Some path -> path_item_json ~source:"server_binary" path
-        | None ->
-          `Assoc
-            [ "path", `Null; "exists", `Bool false; "source", `String "server_binary" ] )
-    ; ( "server_repo_git_commit"
-      , Option.fold ~none:`Null ~some:(fun value -> `String value) server_repo_commit )
-    ; ( "workspace_git_commit"
-      , Option.fold ~none:`Null ~some:(fun value -> `String value) workspace_commit )
-    ; ( "resolved_base_git_commit"
-      , Option.fold ~none:`Null ~some:(fun value -> `String value) resolved_base_commit )
-    ; "source_mismatch", `Bool source_mismatch
-    ; "server_workspace_mismatch", `Bool server_workspace_mismatch
-    ; "diagnostics", diagnostics
-    ; ("keeper_runtime", Keeper_runtime_resolved.(current () |> to_yojson))
-    ; "build", Build_identity.to_yojson build
-    ]
+    ( [ "status", `String status
+      ; "warnings", `List (List.map (fun warning -> `String warning) warnings)
+      ; "base_path", path_item_json ~source:"input" base_path_input
+      ; "workspace_path", path_item_json ~source:"workspace" config.workspace_path
+      ; "resolved_base_path", path_item_json ~source:"resolved_base" config.base_path
+      ; "data_root", path_item_json ~source:"runtime_data" (Coord.masc_root_dir config)
+      ; "prompt_markdown_dir", path_item_json ~source:"prompt_registry" prompt_markdown_dir
+      ; ( "server_repo_path"
+        , match server_repo_path with
+          | Some path -> path_item_json ~source:"server_binary" path
+          | None ->
+            `Assoc
+              [ "path", `Null; "exists", `Bool false; "source", `String "server_binary" ] )
+      ; ( "server_repo_git_commit"
+        , Option.fold ~none:`Null ~some:(fun value -> `String value) server_repo_commit )
+      ; ( "workspace_git_commit"
+        , Option.fold ~none:`Null ~some:(fun value -> `String value) workspace_commit )
+      ; ( "resolved_base_git_commit"
+        , Option.fold ~none:`Null ~some:(fun value -> `String value) resolved_base_commit )
+      ; "source_mismatch", `Bool source_mismatch
+      ; "server_workspace_mismatch", `Bool server_workspace_mismatch
+      ; "diagnostics", diagnostics
+      ; ("keeper_runtime", Keeper_runtime_resolved.(current () |> to_yojson))
+      ; "build", Build_identity.to_yojson build
+      ]
+      @ Server_routes_http_runtime.keeper_fleet_runtime_resolution_fields () )
 ;;
 
 let dashboard_tools_http_json ?actor (config : Coord.config) : Yojson.Safe.t =

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -255,8 +255,18 @@ let bool_field name = function
   | _ -> false
 ;;
 
+(* Scope keeper counts to the active workspace's base_path so a running
+   keeper from another workspace cannot mask a local outage in fleet
+   safety. `bootable_keeper_count` is already derived from
+   `state.room_config`, so the running count must use the same scope. *)
+let current_room_base_path_opt () =
+  match current_server_state_opt () with
+  | Some state -> Some state.Mcp_server.room_config.base_path
+  | None -> None
+
 let keeper_fleet_runtime_resolution_fields () =
-  let keeper_fibers = Keeper_registry.count_running () in
+  let base_path = current_room_base_path_opt () in
+  let keeper_fibers = Keeper_registry.count_running ?base_path () in
   let paused_keepers_json = paused_keepers_health_json () in
   let fleet_safety =
     keeper_fleet_safety_health_json ~keeper_fibers ~paused_keepers_json
@@ -321,7 +331,8 @@ let make_health_json ?(listener = "http/1.1") request =
     else "none"
   in
   let key_paused_keepers = "paused_keepers" in
-  let keeper_fibers = Keeper_registry.count_running () in
+  let base_path = current_room_base_path_opt () in
+  let keeper_fibers = Keeper_registry.count_running ?base_path () in
   let paused_keepers_json = paused_keepers_health_json () in
   Tool_args.ok_assoc [
     ("server", `String "masc-mcp");

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -191,6 +191,86 @@ let paused_keepers_health_json () =
            durable_scan.read_errors) );
   ]
 
+let keeper_fleet_safety_health_json ~keeper_fibers ~paused_keepers_json =
+  let bootable_names =
+    match current_server_state_opt () with
+    | Some state ->
+        (try Keeper_runtime.bootable_keeper_names state.Mcp_server.room_config with
+         | Eio.Cancel.Cancelled _ as exn -> raise exn
+         | exn ->
+             Log.Keeper.warn
+               "health: failed to compute bootable keeper names: %s"
+               (Printexc.to_string exn);
+             [])
+    | None -> []
+  in
+  let bootable_count = List.length bootable_names in
+  let minimum_running_fibers =
+    if bootable_count <= 1 then bootable_count else 2
+  in
+  let no_running_fibers = bootable_count > 0 && keeper_fibers = 0 in
+  let low_running_fiber_margin =
+    bootable_count > 1 && keeper_fibers < minimum_running_fibers
+  in
+  let status =
+    if no_running_fibers then "blocked"
+    else if low_running_fiber_margin then "degraded"
+    else "ok"
+  in
+  let paused_total_count =
+    match paused_keepers_json with
+    | `Assoc fields ->
+        (match List.assoc_opt "count" fields with
+         | Some (`Int count) -> count
+         | _ -> 0)
+    | _ -> 0
+  in
+  `Assoc
+    [ "status", `String status
+    ; "bootable_keeper_count", `Int bootable_count
+    ; ( "bootable_keeper_names"
+      , `List (List.map (fun name -> `String name) bootable_names) )
+    ; "running_keeper_fiber_count", `Int keeper_fibers
+    ; "minimum_running_fibers", `Int minimum_running_fibers
+    ; "no_running_fibers", `Bool no_running_fibers
+    ; "low_running_fiber_margin", `Bool low_running_fiber_margin
+    ; "paused_keeper_count", `Int paused_total_count
+    ; ( "operator_action_required"
+      , `Bool (no_running_fibers || low_running_fiber_margin) )
+    ]
+
+let paused_keeper_count = function
+  | `Assoc fields ->
+      (match List.assoc_opt "count" fields with
+       | Some (`Int count) -> count
+       | _ -> 0)
+  | _ -> 0
+;;
+
+let bool_field name = function
+  | `Assoc fields ->
+      (match List.assoc_opt name fields with
+       | Some (`Bool value) -> value
+       | _ -> false)
+  | _ -> false
+;;
+
+let keeper_fleet_runtime_resolution_fields () =
+  let keeper_fibers = Keeper_registry.count_running () in
+  let paused_keepers_json = paused_keepers_health_json () in
+  let fleet_safety =
+    keeper_fleet_safety_health_json ~keeper_fibers ~paused_keepers_json
+  in
+  [ "keeper_fibers", `Int keeper_fibers
+  ; "paused_keepers", `Int (paused_keeper_count paused_keepers_json)
+  ; "keeper_fleet_no_fibers", `Bool (bool_field "no_running_fibers" fleet_safety)
+  ; ( "keeper_fd_pressure"
+    , Keeper_fd_pressure.runtime_state_json ~active_keepers:keeper_fibers
+        ~starting_keepers:0 ~requested_keepers:24 () )
+  ; "keeper_fleet_safety", fleet_safety
+  ]
+;;
+
 let make_health_json ?(listener = "http/1.1") request =
   let uptime_secs = int_of_float (Unix.gettimeofday () -. server_start_time) in
   let uptime_str =
@@ -241,6 +321,8 @@ let make_health_json ?(listener = "http/1.1") request =
     else "none"
   in
   let key_paused_keepers = "paused_keepers" in
+  let keeper_fibers = Keeper_registry.count_running () in
+  let paused_keepers_json = paused_keepers_health_json () in
   Tool_args.ok_assoc [
     ("server", `String "masc-mcp");
     ("version", `String build.release_version);
@@ -279,14 +361,20 @@ let make_health_json ?(listener = "http/1.1") request =
       ("live_words", `Int s.live_words);
       ("minor_heap_size", `Int (let c = Gc.get () in c.minor_heap_size));
     ]);
-    ("keeper_fibers", `Int (Keeper_registry.count_running ()));
+    ("keeper_fibers", `Int keeper_fibers);
+    ( "keeper_fd_pressure"
+    , Keeper_fd_pressure.runtime_state_json ~active_keepers:keeper_fibers
+        ~starting_keepers:0 ~requested_keepers:24 () );
+    ( "keeper_fleet_safety"
+    , keeper_fleet_safety_health_json ~keeper_fibers
+        ~paused_keepers_json );
     (* Paused-keeper visibility: a keeper with [meta.paused = true] does not
        run turns, and auto-paused keepers may no longer have a live registry
        entry. The dashboard "깨우기" button now auto-resumes paused keepers,
        but ops still need a quick count without scraping /metrics. List names
        so an operator can correlate with the cause encoded in their
        last_blocker_class. *)
-    (key_paused_keepers, paused_keepers_health_json ());
+    (key_paused_keepers, paused_keepers_json);
     ("keeper_config_parse_error_count",
      `Int keeper_config_parse_error_count);
     ( "keeper_config_parse_errors",

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -117,7 +117,8 @@ val make_health_json :
     [build] / [protocol] (default + listener + supported list) /
     [transport] / [paths] / [uptime] / [sse_clients] /
     [startup] / [subsystems] / [feature_flags] / [gc] /
-    [keeper_fibers] / [paused_keepers] /
+    [keeper_fibers] / [keeper_fd_pressure] / [keeper_fleet_safety] /
+    [paused_keepers] /
     [keeper_config_parse_error_count] / [keeper_config_parse_errors] /
     [keeper_config_unknown_key_count] / [keeper_config_unknown_keys] /
     [keeper_config_schema_status] / [keeper_config_schema_blocking] /
@@ -135,6 +136,19 @@ val make_health_json :
     does not disappear from [/health].  [read_error_count] surfaces
     corrupt durable meta instead of silently reporting a clean zero.
 
+    {2 keeper_fd_pressure and keeper_fleet_safety contract}
+
+    [keeper_fd_pressure] exposes the effective process [nofile] soft
+    limit, currently open FD count when available, projected 24-Keeper
+    budget, and the admission decision used by the FD guard.  This lets
+    operators distinguish "shell says the host limit is high" from the
+    actual runtime inherited by the server process.
+
+    [keeper_fleet_safety] compares configured bootable keepers with the
+    live keeper fiber count.  It reports [blocked] when bootable keepers
+    exist but no fiber is running, and [degraded] when multiple bootable
+    keepers exist but the running fiber count is below the safety margin.
+
     {2 lazy_task_boot_guard_fires_total contract (P2 silent-
     failure fix)}
 
@@ -144,6 +158,13 @@ val make_health_json :
     "ok"] while keepers had silently failed to start.  Pinning
     at the contract seam: a future "drop unused metric" PR
     must touch this. *)
+
+val keeper_fleet_runtime_resolution_fields : unit -> (string * Yojson.Safe.t) list
+(** [keeper_fleet_runtime_resolution_fields ()] returns the health/fleet
+    safety subset projected into [/api/v1/dashboard/shell]'s
+    [runtime_resolution].  It intentionally flattens
+    [paused_keepers] to a count for the dashboard shell health chip while
+    [/health] keeps the richer paused keeper object. *)
 
 val health_handler : Httpun.Request.t -> Httpun.Reqd.t -> unit
 (** [health_handler request reqd] writes

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -144,6 +144,22 @@ let test_dashboard_tools_projection () =
         (match runtime_resolution |> member "diagnostics" with
          | `List _ -> true
          | _ -> false);
+      check bool "runtime keeper_fibers surfaced" true
+        (match runtime_resolution |> member "keeper_fibers" with
+         | `Int _ -> true
+         | _ -> false);
+      check bool "runtime paused_keepers count surfaced" true
+        (match runtime_resolution |> member "paused_keepers" with
+         | `Int _ -> true
+         | _ -> false);
+      check bool "runtime keeper fd pressure surfaced" true
+        (match runtime_resolution |> member "keeper_fd_pressure" with
+         | `Assoc _ -> true
+         | _ -> false);
+      check bool "runtime keeper fleet safety surfaced" true
+        (match runtime_resolution |> member "keeper_fleet_safety" with
+         | `Assoc _ -> true
+         | _ -> false);
       check bool "build started_at surfaced" true
         (match runtime_resolution |> member "build" |> member "started_at" with
          | `String value -> String.length value > 0

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -120,6 +120,37 @@ let test_fd_pressure_degraded_projection () =
       check string "next human action" "restore_fd_headroom"
         (Json.member "next_human_action" trust |> Json.to_string))
 
+let test_fd_pressure_runtime_state_json () =
+  FD.reset_for_tests ();
+  let json =
+    FD.runtime_state_json
+      ~soft_limit:(Some 512)
+      ~open_fds:(Some 460)
+      ~active_keepers:2
+      ~starting_keepers:1
+      ~requested_keepers:24
+      ()
+  in
+  let decision = Json.member "admission_decision" json in
+  check int "runtime soft limit" 512
+    (Json.member "soft_limit" json |> Json.to_int);
+  check int "runtime requested keepers" 24
+    (Json.member "requested_keepers" json |> Json.to_int);
+  check int "runtime target keeper count" 24
+    (Json.member "target_keeper_count" json |> Json.to_int);
+  check int "runtime projected starting keepers" 22
+    (Json.member "projected_starting_keepers" json |> Json.to_int);
+  check string "runtime status" "blocked"
+    (Json.member "status" json |> Json.to_string);
+  check string "runtime admission blocks unsafe projection" "block"
+    (Json.member "status" decision |> Json.to_string);
+  check bool "runtime admission_blocked flag" true
+    (Json.member "admission_blocked" json |> Json.to_bool);
+  check int "runtime admission_blocked_keepers" 24
+    (Json.member "admission_blocked_keepers" json |> Json.to_int);
+  check bool "runtime operator action required" true
+    (Json.member "operator_action_required" json |> Json.to_bool)
+
 let test_bonsai_keepers_summary_uses_scoped_registry () =
   let base_path = temp_base_path "bonsai-summary" in
   let other_base_path = temp_base_path "bonsai-summary-other" in
@@ -1975,6 +2006,8 @@ let () =
             test_fd_pressure_proactive_admission;
           test_case "fd pressure degraded projection" `Quick
             test_fd_pressure_degraded_projection;
+          test_case "fd pressure runtime state json" `Quick
+            test_fd_pressure_runtime_state_json;
           eio_test "bonsai summary uses scoped registry"
             test_bonsai_keepers_summary_uses_scoped_registry;
           eio_test "register and get" test_register_and_get;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -972,6 +972,8 @@ let test_health_json_surfaces_durable_paused_keepers () =
           let json = Server_routes_http_runtime.make_health_json request in
           let open Yojson.Safe.Util in
           let paused = json |> member "paused_keepers" in
+          let fd_pressure = json |> member "keeper_fd_pressure" in
+          let fleet_safety = json |> member "keeper_fleet_safety" in
           let durable_names =
             paused |> member "durable_names" |> to_list |> List.map to_string
           in
@@ -985,7 +987,21 @@ let test_health_json_surfaces_durable_paused_keepers () =
           Alcotest.(check bool) "union excludes active durable keeper" false
             (List.exists (( = ) "durable-active") names);
           Alcotest.(check int) "durable read errors" 0
-            (paused |> member "read_error_count" |> to_int)))
+            (paused |> member "read_error_count" |> to_int);
+          Alcotest.(check int) "health exposes requested 24-keeper FD budget"
+            24
+            (fd_pressure |> member "requested_keepers" |> to_int);
+          Alcotest.(check int) "health exposes target 24-keeper FD budget" 24
+            (fd_pressure |> member "target_keeper_count" |> to_int);
+          ignore (fd_pressure |> member "status" |> to_string);
+          ignore (fd_pressure |> member "admission_blocked" |> to_bool);
+          ignore
+            (fd_pressure |> member "admission_decision" |> member "status" |> to_string);
+          Alcotest.(check int) "health exposes bootable keeper count" 1
+            (fleet_safety |> member "bootable_keeper_count" |> to_int);
+          Alcotest.(check int) "health exposes minimum running fibers" 1
+            (fleet_safety |> member "minimum_running_fibers" |> to_int);
+          ignore (fleet_safety |> member "status" |> to_string)))
 
 let test_health_json_surfaces_log_ring_summary () =
   Log.set_level Log.Info;


### PR DESCRIPTION
## Summary
- Expose `keeper_fd_pressure` and `keeper_fleet_safety` in `/health`.
- Project the 24-Keeper FD admission budget and surface top-level `admission_blocked` fields for the dashboard.
- Forward the same fleet safety subset into dashboard shell `runtime_resolution`.

Refs #15731

## Verification
- `git diff --check`
- `dune build --root ... _build/default/lib/.masc_mcp.objs/byte/masc_mcp__Keeper_fd_pressure.cmo _build/default/lib/.masc_mcp.objs/byte/masc_mcp__Server_routes_http_runtime.cmo _build/default/lib/.masc_mcp.objs/byte/masc_mcp__Server_dashboard_http_runtime_info.cmo`
- `dune build --root ... test/test_dashboard_tools.exe test/test_keeper_registry.exe test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_dashboard_tools.exe`
- `./_build/default/test/test_keeper_registry.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 31`