### PR TITLE
fix(cascade): honor provider runtime capabilities

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -689,15 +689,21 @@ let resolve_label_context (label : string) : int option =
 
 let filter_by_capabilities ~(pred : Llm_provider.Capabilities.capabilities -> bool)
     (providers : Llm_provider.Provider_config.t list) =
+  let legacy_capabilities_for_unbound_config (cfg : Llm_provider.Provider_config.t) =
+    match Llm_provider.Capabilities.for_model_id cfg.model_id with
+    | Some c -> c
+    | None ->
+      (match Llm_provider.Provider_registry.find default_registry cfg.model_id with
+       | Some entry -> entry.capabilities
+       | None -> Llm_provider.Capabilities.default_capabilities)
+  in
+  let capabilities_for_filter (cfg : Llm_provider.Provider_config.t) =
+    match Runtime_binding.binding_for_provider_config cfg with
+    | Some _ -> Runtime_binding.capabilities_for_provider_config cfg
+    | None -> legacy_capabilities_for_unbound_config cfg
+  in
   let satisfies (cfg : Llm_provider.Provider_config.t) =
-    let caps = match Llm_provider.Capabilities.for_model_id cfg.model_id with
-      | Some c -> c
-      | None ->
-        match Llm_provider.Provider_registry.find default_registry cfg.model_id with
-        | Some entry -> entry.capabilities
-        | None -> Llm_provider.Capabilities.default_capabilities
-    in
-    pred caps
+    pred (capabilities_for_filter cfg)
   in
   let filtered = List.filter satisfies providers in
   if filtered = [] then providers

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -437,10 +437,11 @@ val resolve_label_context : string -> int option
 
 (** Filter providers by a capability predicate.
 
-    Resolves capabilities per-model (via {!Llm_provider.Capabilities.for_model_id})
-    with registry-level fallback. Removes providers that do not satisfy
-    [pred]. If all providers would be removed, returns the original list
-    unchanged (let the provider return an API error).
+    Resolves capabilities from OAS runtime provider bindings for bound
+    provider configs. Truly unbound configs keep the legacy per-model
+    lookup with registry/default fallback. Removes providers that do not
+    satisfy [pred]. If all providers would be removed, returns the original
+    list unchanged (let the provider return an API error).
 
     Example: filter to providers supporting tools:
     {[ filter_by_capabilities ~pred:(fun c -> c.supports_tools) providers ]}

--- a/test/test_provider_capability_matrix.ml
+++ b/test/test_provider_capability_matrix.ml
@@ -182,6 +182,30 @@ let test_catalog_capabilities_drive_masc_projection () =
         "catalog disables inline tool choice"
         false caps.supports_inline_tool_choice)
 
+let test_cascade_filter_uses_provider_config_binding () =
+  with_provider_catalog catalog_disables_inline_tools_json (fun () ->
+      let disabled_by_catalog =
+        PC.make ~kind:PC.OpenAI_compat ~model_id:"unlisted-catalog-model"
+          ~base_url:"http://127.0.0.1:8123" ~request_path:"/v1/chat/completions" ()
+      in
+      let default_tool_capable =
+        PC.make ~kind:PC.OpenAI_compat ~model_id:"another-unlisted-model"
+          ~base_url:"http://127.0.0.1:9999" ~request_path:"/v1/chat/completions" ()
+      in
+      let filtered =
+        Cascade_config.filter_by_capabilities
+          ~pred:(fun caps -> caps.Llm_provider.Capabilities.supports_tools)
+          [ disabled_by_catalog; default_tool_capable ]
+      in
+      Alcotest.(check int)
+        "catalog-disabled provider is filtered"
+        1
+        (List.length filtered);
+      Alcotest.(check string)
+        "remaining provider"
+        default_tool_capable.PC.base_url
+        (List.hd filtered).PC.base_url)
+
 let () =
   Alcotest.run "provider_capability_matrix"
     [
@@ -205,5 +229,8 @@ let () =
           Alcotest.test_case
             "catalog capabilities drive MASC projection"
             `Quick test_catalog_capabilities_drive_masc_projection;
+          Alcotest.test_case
+            "cascade filter uses provider config binding"
+            `Quick test_cascade_filter_uses_provider_config_binding;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Make cascade capability filtering use OAS runtime provider bindings for bound provider configs.
- Preserve legacy per-model/registry/default fallback only for truly unbound configs.
- Add regression coverage for catalog-disabled tool capability filtering.

Refs #15731
Refs jeong-sik/oas#1612

## Verification
- `git diff --check`
- `dune build --root ... _build/default/lib/.masc_mcp.objs/byte/masc_mcp__Cascade_config.cmo`
- `dune build --root ... test/test_provider_capability_matrix.exe`
- `./_build/default/test/test_provider_capability_matrix.exe test catalog 1`
- `./_build/default/test/test_provider_capability_matrix.exe`