### PR TITLE
feat(dashboard): surface fleet liveness risk

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -88,4 +88,67 @@ describe('dashboardHealthChips', () => {
       tone: 'ok',
     })])
   })
+
+  it('surfaces fleet liveness risk when health shows stalled fibers with paused keepers', () => {
+    const chips = dashboardHealthChips({
+      connected: true,
+      counts: { keepers: 2, configured_keepers: 2 },
+      keepers: [],
+      runtimeResolution: {
+        status: 'ready',
+        warnings: [],
+        fleet_safety: {
+          keeper_fibers: 1,
+          paused_keepers: 3,
+          keeper_fleet_no_fibers: null,
+          keeper_fd_pressure: null,
+          keeper_fleet_safety: null,
+        },
+      } as any,
+      executionError: null,
+      loading: false,
+    })
+
+    expect(chips).toEqual([expect.objectContaining({
+      key: 'fleet-liveness-risk',
+      label: 'Fleet liveness risk',
+      tone: 'bad',
+    })])
+    expect(chips[0]?.detail).toContain('keeper_fibers=1')
+  })
+
+  it('surfaces fleet liveness risk when FD pressure blocks 24 keepers', () => {
+    const chips = dashboardHealthChips({
+      connected: true,
+      counts: { keepers: 24, configured_keepers: 24 },
+      keepers: [],
+      runtimeResolution: {
+        status: 'ready',
+        warnings: [],
+        fleet_safety: {
+          keeper_fibers: 8,
+          paused_keepers: 0,
+          keeper_fleet_no_fibers: null,
+          keeper_fd_pressure: {
+            status: 'blocked',
+            reason: 'fd_pressure',
+            admission_blocked: true,
+            admission_blocked_keepers: 24,
+            blocked_keepers: null,
+            blocked_count: null,
+          },
+          keeper_fleet_safety: null,
+        },
+      } as any,
+      executionError: null,
+      loading: false,
+    })
+
+    expect(chips).toEqual([expect.objectContaining({
+      key: 'fleet-liveness-risk',
+      label: 'Fleet liveness risk',
+      tone: 'bad',
+    })])
+    expect(chips[0]?.detail).toContain('blocking 24 keepers')
+  })
 })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -3,7 +3,7 @@ import { signal } from '@preact/signals'
 import { lazy, Suspense } from 'preact/compat'
 import { useEffect } from 'preact/hooks'
 import type { RouteState, TabId } from '../types'
-import type { DashboardRuntimeResolution, Keeper } from '../types'
+import type { DashboardFleetSafetyHealth, DashboardRuntimeResolution, Keeper } from '../types'
 import { hashForRoute, navigate, route } from '../router'
 import { connected, reconnectCount, lastDisconnectedAt } from '../sse'
 import { dashboardWsOnlyEnabled } from '../dashboard-ws-cutover'
@@ -172,6 +172,42 @@ function keeperLooksPaused(keeper: Keeper): boolean {
   return keeper.paused === true || phase === 'paused' || stage === 'paused' || status === 'paused'
 }
 
+function fleetPressureBlockedKeepers(fleetSafety: DashboardFleetSafetyHealth): number {
+  const candidates = [
+    fleetSafety.keeper_fd_pressure?.admission_blocked_keepers,
+    fleetSafety.keeper_fd_pressure?.blocked_keepers,
+    fleetSafety.keeper_fd_pressure?.blocked_count,
+    fleetSafety.keeper_fleet_safety?.admission_blocked_keepers,
+    fleetSafety.keeper_fleet_safety?.blocked_keepers,
+    fleetSafety.keeper_fleet_safety?.blocked_count,
+  ].filter((value): value is number => typeof value === 'number' && Number.isFinite(value))
+  return candidates.length > 0 ? Math.max(...candidates) : 0
+}
+
+function fleetSafetyHealthChip(fleetSafety: DashboardFleetSafetyHealth | null): DashboardHealthChip | null {
+  if (!fleetSafety) return null
+  const fibers = fleetSafety.keeper_fibers
+  const paused = fleetSafety.paused_keepers ?? 0
+  const blocked = fleetPressureBlockedKeepers(fleetSafety)
+  if (blocked >= 24) {
+    return {
+      key: 'fleet-liveness-risk',
+      label: 'Fleet liveness risk',
+      detail: `FD pressure admission is blocking ${blocked} keepers; keeper turns may not start.`,
+      tone: 'bad',
+    }
+  }
+  if (fleetSafety.keeper_fleet_no_fibers === true || (fibers != null && fibers <= 1 && paused > 0)) {
+    return {
+      key: 'fleet-liveness-risk',
+      label: 'Fleet liveness risk',
+      detail: `keeper_fibers=${fibers ?? 0}, paused_keepers=${paused}; keeper fleet may be stalled.`,
+      tone: 'bad',
+    }
+  }
+  return null
+}
+
 export function dashboardHealthChips(input: DashboardHealthInput): DashboardHealthChip[] {
   const chips: DashboardHealthChip[] = []
   if (!input.connected) {
@@ -208,6 +244,11 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
       detail: 'One or more keeper rows are paused; board/tool activity may look quiet.',
       tone: 'warn',
     })
+  }
+
+  const fleetChip = fleetSafetyHealthChip(runtime?.fleet_safety ?? null)
+  if (fleetChip) {
+    chips.push(fleetChip)
   }
 
   const configured = input.counts?.configured_keepers ?? 0

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -1,6 +1,32 @@
 import { describe, expect, it } from 'vitest'
 
-import { normalizeExecutionQueueItem, normalizeExecutionSessionBrief, normalizeMessage } from './store-normalizers'
+import {
+  normalizeDashboardRuntimeResolution,
+  normalizeExecutionQueueItem,
+  normalizeExecutionSessionBrief,
+  normalizeMessage,
+} from './store-normalizers'
+
+const configItem = { path: '/tmp/masc', source: 'test', exists: true }
+const build = {
+  release_version: 'dev',
+  started_at: '2026-05-17T00:00:00Z',
+  uptime_seconds: 12,
+}
+
+function runtimeResolutionRaw(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    status: 'ready',
+    warnings: [],
+    base_path: configItem,
+    workspace_path: configItem,
+    resolved_base_path: configItem,
+    data_root: configItem,
+    prompt_markdown_dir: configItem,
+    build,
+    ...overrides,
+  }
+}
 
 describe('normalizeExecutionSessionBrief', () => {
   it('promotes legacy room-only payloads to namespace while keeping the room alias', () => {
@@ -91,6 +117,46 @@ describe('normalizeMessage', () => {
       from: 'sangsu',
       content: 'handoff ready',
       room: 'keeper-room',
+    })
+  })
+})
+
+describe('normalizeDashboardRuntimeResolution fleet safety', () => {
+  it('keeps old runtime payloads compatible when fleet safety fields are absent', () => {
+    const result = normalizeDashboardRuntimeResolution(runtimeResolutionRaw())
+
+    expect(result?.fleet_safety).toBeNull()
+  })
+
+  it('parses optional health fleet-safety fields type-safely', () => {
+    const result = normalizeDashboardRuntimeResolution(runtimeResolutionRaw({
+      keeper_fibers: 1,
+      paused_keepers: 3,
+      keeper_fleet_no_fibers: false,
+      keeper_fd_pressure: {
+        status: 'blocked',
+        reason: 'fd_pressure',
+        admission_blocked: true,
+        admission_blocked_keepers: 24,
+      },
+      keeper_fleet_safety: {
+        blocked_keepers: 24,
+      },
+    }))
+
+    expect(result?.fleet_safety).toMatchObject({
+      keeper_fibers: 1,
+      paused_keepers: 3,
+      keeper_fleet_no_fibers: false,
+      keeper_fd_pressure: {
+        status: 'blocked',
+        reason: 'fd_pressure',
+        admission_blocked: true,
+        admission_blocked_keepers: 24,
+      },
+      keeper_fleet_safety: {
+        blocked_keepers: 24,
+      },
     })
   })
 })

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -8,6 +8,8 @@ import type {
   DashboardExecutionContinuityBrief,
   DashboardConfigResolution,
   DashboardConfigResolutionItem,
+  DashboardFleetPressureHealth,
+  DashboardFleetSafetyHealth,
   DashboardRuntimeDiagnostic,
   DashboardRuntimeResolution,
   KeeperRuntimeResolved,
@@ -577,6 +579,67 @@ export function normalizeDashboardRuntimeResolution(
       .filter((item): item is DashboardRuntimeDiagnostic => item !== null),
     build,
     keeper_runtime: normalizeKeeperRuntimeResolved(raw.keeper_runtime),
+    fleet_safety: normalizeDashboardFleetSafetyHealth(raw),
+  }
+}
+
+function normalizeDashboardFleetPressureHealth(raw: unknown): DashboardFleetPressureHealth | null {
+  if (!isRecord(raw)) return null
+  const status = asString(raw.status) ?? asString(raw.state) ?? null
+  const reason = asString(raw.reason) ?? asString(raw.message) ?? null
+  const admissionBlocked = asBoolean(raw.admission_blocked)
+    ?? asBoolean(raw.admission_blocks)
+    ?? null
+  const admissionBlockedKeepers = asNumber(raw.admission_blocked_keepers)
+    ?? asNumber(raw.admission_blocked_count)
+    ?? null
+  const blockedKeepers = asNumber(raw.blocked_keepers)
+    ?? asNumber(raw.keepers_blocked)
+    ?? null
+  const blockedCount = asNumber(raw.blocked_count)
+    ?? asNumber(raw.blocked)
+    ?? null
+  if (
+    status == null
+    && reason == null
+    && admissionBlocked == null
+    && admissionBlockedKeepers == null
+    && blockedKeepers == null
+    && blockedCount == null
+  ) {
+    return null
+  }
+  return {
+    status,
+    reason,
+    admission_blocked: admissionBlocked,
+    admission_blocked_keepers: admissionBlockedKeepers,
+    blocked_keepers: blockedKeepers,
+    blocked_count: blockedCount,
+  }
+}
+
+function normalizeDashboardFleetSafetyHealth(raw: Record<string, unknown>): DashboardFleetSafetyHealth | null {
+  const keeperFibers = asNumber(raw.keeper_fibers)
+  const pausedKeepers = asNumber(raw.paused_keepers)
+  const noFibers = asBoolean(raw.keeper_fleet_no_fibers)
+  const fdPressure = normalizeDashboardFleetPressureHealth(raw.keeper_fd_pressure)
+  const fleetSafety = normalizeDashboardFleetPressureHealth(raw.keeper_fleet_safety)
+  if (
+    keeperFibers == null
+    && pausedKeepers == null
+    && noFibers == null
+    && fdPressure == null
+    && fleetSafety == null
+  ) {
+    return null
+  }
+  return {
+    keeper_fibers: keeperFibers ?? null,
+    paused_keepers: pausedKeepers ?? null,
+    keeper_fleet_no_fibers: noFibers ?? null,
+    keeper_fd_pressure: fdPressure,
+    keeper_fleet_safety: fleetSafety,
   }
 }
 

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -116,6 +116,24 @@ export interface DashboardRuntimeResolution {
   diagnostics: DashboardRuntimeDiagnostic[]
   build: ServerBuildIdentity
   keeper_runtime: KeeperRuntimeResolved | null
+  fleet_safety: DashboardFleetSafetyHealth | null
+}
+
+export interface DashboardFleetSafetyHealth {
+  keeper_fibers: number | null
+  paused_keepers: number | null
+  keeper_fleet_no_fibers: boolean | null
+  keeper_fd_pressure: DashboardFleetPressureHealth | null
+  keeper_fleet_safety: DashboardFleetPressureHealth | null
+}
+
+export interface DashboardFleetPressureHealth {
+  status: string | null
+  reason: string | null
+  admission_blocked: boolean | null
+  admission_blocked_keepers: number | null
+  blocked_keepers: number | null
+  blocked_count: number | null
 }
 
 export interface DashboardShellResponse {


### PR DESCRIPTION
## Summary
- Normalize optional fleet safety fields from dashboard shell `runtime_resolution`.
- Add a Fleet liveness risk health chip for stalled keeper fibers and 24-Keeper FD admission blocking.
- Keep old dashboard payloads compatible when fleet safety fields are absent.

Refs #15731
Depends on #15762 for backend fleet-safety fields.

## Verification
- `git diff --check`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/dashboard-shell.test.ts src/store-normalizers.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`