### PR TITLE
[codex] Purge legacy home config fallbacks

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -610,7 +610,7 @@ let guard_self_repo_base_path base_path =
        (executable: %s)\n\
        Runtime state would pollute the repo. Use a workspace root instead:\n\
        \  --base-path $MASC_BASE_PATH    (recommended)\n\
-       \  --base-path $HOME              (home-scoped runtime)\n\
+       \  --base-path /path/to/workspace (explicit workspace root)\n\
        Or start via: sb mcp masc start\n"
       base_path abs_exe;
     exit 1

--- a/bin/masc_compaction_audit.ml
+++ b/bin/masc_compaction_audit.ml
@@ -52,16 +52,8 @@ let base_path () =
   (* sb/main_eio uses Masc_mcp.Env_config.base_path.
      Replicating the env lookup avoids pulling heavy deps into this CLI. *)
   match Sys.getenv_opt "MASC_BASE_PATH" with
-  | Some p when p <> "" -> p
-  | _ ->
-    let home =
-      match Sys.getenv_opt "HOME" with
-      | Some h -> h
-      | None -> "."
-    in
-    (* #9571: use Common.masc_dirname SSOT (from masc_core) instead of
-       inlining ".masc". *)
-    Filename.concat home (Filename.concat "me" Common.masc_dirname)
+  | Some p when String.trim p <> "" -> p
+  | _ -> Sys.getcwd ()
 
 let retention_from_env default =
   match Sys.getenv_opt "MASC_COMPACTION_AUDIT_RETENTION_DAYS" with

--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -105,7 +105,7 @@ let parse_args () =
     ("--port", Arg.Set_int port, Printf.sprintf "MASC server port (default: %d)" (Env_config_core.masc_http_port_int ()));
     ("--room", Arg.Set_string room, "Coord name (default: from base path)");
     ("--refresh", Arg.Set_float refresh, "Refresh interval in seconds (default: 2)");
-    ("--base", Arg.Set_string base_path, "Base path (default: MASC_BASE_PATH or HOME)");
+    ("--base", Arg.Set_string base_path, "Base path (default: MASC_BASE_PATH or cwd)");
   ] in
 
   Arg.parse specs (fun _ -> ()) "masc-tui [OPTIONS]";
@@ -116,10 +116,7 @@ let parse_args () =
     else
       match Sys.getenv_opt "MASC_BASE_PATH" with
       | Some p when String.trim p <> "" -> p
-      | _ ->
-          (match Sys.getenv_opt "HOME" with
-           | Some home when String.trim home <> "" -> home
-           | _ -> Sys.getcwd ())
+      | _ -> Sys.getcwd ()
   in
 
   (* Resolve room *)

--- a/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
+++ b/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
@@ -64,7 +64,7 @@ For dashboard-side keeper lifecycle control, the target shape is:
 Use the auth doctor before editing tokens or role files:
 
 ```bash
-BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/path/to/base}}"
 ./_build/default/bin/main_eio.exe doctor auth --base-path "$BASE_PATH"
 ```
 
@@ -104,7 +104,7 @@ when bootstrapping or rotating the bearer; export the printed value as
 `MASC_MCP_TOKEN` in the shell that starts Codex:
 
 ```bash
-BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/path/to/base}}"
 ./_build/default/bin/main_eio.exe login \
   --base-path "$BASE_PATH" \
   --agent codex-mcp-client \
@@ -160,7 +160,7 @@ the raw value on disk and causes auth drift when the token is rotated.
 To initialise or repair the Codex config from the repo:
 
 ```bash
-BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/path/to/base}}"
 scripts/init-codex-mcp-config.sh --base-path "$BASE_PATH"
 ```
 
@@ -181,7 +181,7 @@ Claude and Gemini must not reuse the Codex bearer. Mint each local MCP client
 as its own worker identity, then sync the shared client config:
 
 ```bash
-BASE_PATH="${MASC_BASE_PATH:-$HOME/me}"
+BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/path/to/base}}"
 
 ./_build/default/bin/main_eio.exe login \
   --base-path "$BASE_PATH" \
@@ -217,7 +217,7 @@ files rather than embedding literal tokens in the config.
 When running from a worktree but using a shared local coordination root, start the server with an explicit base path:
 
 ```bash
-BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/path/to/base}}"
 MASC_BASE_PATH="$BASE_PATH" \
 ./_build/default/bin/main_eio.exe \
   --host 127.0.0.1 \
@@ -234,7 +234,7 @@ If you already have an admin bearer, skip to step 7.
 The shortest local CLI path is:
 
 ```bash
-BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/path/to/base}}"
 ./_build/default/bin/main_eio.exe login \
   --base-path "$BASE_PATH" \
   --agent codex-local-admin \
@@ -258,7 +258,7 @@ If you do not have that path, the reliable local fallback is to seed the auth st
 1. Back up the auth config:
 
 ```bash
-BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/path/to/base}}"
 cp "$BASE_PATH/.masc/auth/config.json" "$BASE_PATH/.masc/auth/config.json.bak"
 ```
 
@@ -399,7 +399,7 @@ If you need to go back to anonymous loopback behavior:
 Example:
 
 ```bash
-BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/path/to/base}}"
 mv "$BASE_PATH/.masc/auth/config.json.bak" "$BASE_PATH/.masc/auth/config.json"
 rm -f "$BASE_PATH/.masc/auth/agents/codex-tool-matrix.json"
 ```

--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -335,6 +335,6 @@ Regenerate-before-fix is an anti-pattern: the fingerprint must always describe a
 
 1. `$AGENT_SDK_LOCAL_REPO` (explicit override)
 2. `<masc-mcp-parent>/oas` (sibling checkout)
-3. `$HOME/me/workspace/yousleepwhen/oas` (workspace convention)
+3. `$ME_ROOT/workspace/yousleepwhen/oas` (explicit workspace root)
 
 Each candidate must be a git checkout at the pinned SHA. If none qualifies, the script falls back to `git fetch` into a temp bare clone from the upstream URL. Network is required only for that fallback.

--- a/docs/TUI-GUIDE.md
+++ b/docs/TUI-GUIDE.md
@@ -26,7 +26,7 @@ masc-tui
 
 If the server is using a different base path, pass `--base <path>` or export
 `MASC_BASE_PATH` before launching the TUI. The fallback order is
-`MASC_BASE_PATH` -> `HOME` -> `cwd`.
+`MASC_BASE_PATH` -> `cwd`.
 
 ## Modes
 

--- a/docs/rfc/RFC-0008-credential-provider.md
+++ b/docs/rfc/RFC-0008-credential-provider.md
@@ -92,7 +92,7 @@ end
 
 - **Files**: rewrite `scripts/rotate-keeper-gh-token.sh` (in the `me` repo, branch `feat/rotate-keeper-gh-token`) to:
   - require `IDENTITY=<name>` argument,
-  - target `$HOME/me/.masc/github-identities/$IDENTITY/gh` only,
+  - target `$MASC_BASE_PATH/.masc/github-identities/$IDENTITY/gh` only,
   - verify the new token's SHA-256 **differs** from `gh auth token` (F-1 gate — `provider_gate` equivalent at rotation time).
 - **`Host_config_provider` update**: `resolve` adds a metadata line `sha256_prefix=<first 12>` and surfaces it in `binding.metadata` so `provider_gate` in PR-3 can consult it without re-reading the file.
 - **Why safe**: script is operator-facing; a mismatched identity × PAT never reaches the runtime.

--- a/docs/rfc/RFC-0009-cascade-trust-phase2.md
+++ b/docs/rfc/RFC-0009-cascade-trust-phase2.md
@@ -19,7 +19,7 @@ Phase 2 closes both gaps without giving the trust loop authority to silently rew
 
 | Principle | Application |
 |---|---|
-| Live-only persist | Only `~/.masc/config/cascade.toml` is touched; `config/cascade.toml` (repo seed) is never written to by the trust loop. |
+| Live-only persist | Only `<base-path>/.masc/config/cascade.toml` is touched; `config/cascade.toml` (repo seed) is never written to by the trust loop. |
 | Opt-in by default | `MASC_CASCADE_TRUST_PERSIST=1` (or `=dry`) gates everything in this RFC. Default-off for the first release. |
 | Observation over action | Phase 2a (operator recommendation) is observation-only. Phase 2b (persist) is a separate feature flag and a separate PR. |
 | No self-reload loops | Hot-reload must skip files the trust loop just wrote; otherwise each persist triggers a reload triggers a re-emit. |
@@ -81,7 +81,7 @@ Rendered on the dashboard as a card with a copy-friendly JSON snippet showing th
 |---|---|
 | unset (default) | No persist. Trust is in-memory only, reset on restart. |
 | `dry` | Compute the would-be diff every hour, append to `cascade_trust/applied/<date>.jsonl` with `mode=dry`, no file write. |
-| `1` | Same diff, plus atomic write to `~/.masc/config/cascade.toml`. |
+| `1` | Same diff, plus atomic write to `<base-path>/.masc/config/cascade.toml`. |
 
 ### Persist algorithm
 
@@ -89,11 +89,11 @@ Every `MASC_CASCADE_TRUST_PERSIST_INTERVAL_SEC` (default 3600s):
 
 1. Snapshot `Cascade_health_tracker.global` providers with `events_in_window > 0` AND age of `last_failure_at` < 24h (skip stale).
 2. For each provider, compute target weight: `round(trust_score * 2) / 2` (0.5-step granularity, range [0.5, ceiling × current_weight]).
-3. Diff against current `~/.masc/config/cascade.toml` weights.
+3. Diff against current `<base-path>/.masc/config/cascade.toml` weights.
 4. If diff is empty → emit `mode=skip_no_change` audit event; return.
 5. Atomic write via `lib/atomic_write.ml`:
    - `cascade.toml.tmp` → fsync → rename
-   - Backup previous: `~/.masc/config/.backup/cascade.toml.YYYYMMDD-HHMMSS`
+   - Backup previous: `<base-path>/.masc/config/.backup/cascade.toml.YYYYMMDD-HHMMSS`
    - Top-of-file marker comment: `# auto-tuned by trust_persist at <timestamp>; do not edit by hand within 5s`
 
 ### Hot-reload loop guard

--- a/docs/rfc/RFC-0055-cascade-fallback-tier-routing.md
+++ b/docs/rfc/RFC-0055-cascade-fallback-tier-routing.md
@@ -265,7 +265,7 @@ Apply the TLA+ Bug Model pattern from `software-development.md`:
 
 ## 8. References
 
-- `~/me/.masc/config/cascade.json` (live SSOT, lines 30, 67--73, 92, 127, 169)
+- `<base-path>/.masc/config/cascade.json` (live SSOT, lines 30, 67--73, 92, 127, 169)
 - `lib/provider_tool_support.ml` (lines 160--249, runtime capability gate)
 - `docs/tla-audit/state-fsm-gap-2026-04-13.md` (P1/P3/P4 proposals)
 - RFC-0041: Hierarchical cascade config + TOML groups (PR #14358, merged 2026-05-08)

--- a/docs/rfc/RFC-0058-terminal-fallback-capability-exemption.md
+++ b/docs/rfc/RFC-0058-terminal-fallback-capability-exemption.md
@@ -22,7 +22,7 @@ However, the current enforcement has a gap: **removing the `_required_capability
 | _ -> None  (* <-- Cp_unset / None on EITHER side: skip check entirely *)
 ```
 
-This is the current workaround in `~/.masc/config/cascade.json`: `local_recovery`, `retired_local_profile`, `ollama_only`, `ollama_bench` have no `_required_capability_profile` field, so the monotonicity gate is bypassed implicitly.
+This is the current workaround in `<base-path>/.masc/config/cascade.json`: `local_recovery`, `retired_local_profile`, `ollama_only`, `ollama_bench` have no `_required_capability_profile` field, so the monotonicity gate is bypassed implicitly.
 
 ### 1.1 Why This Matters
 
@@ -204,5 +204,5 @@ retired_tool_profile (tool_strict)
 - `lib/cascade/cascade_tier.ml:15` (`is_subset_profile`)
 - `lib/cascade/cascade_capability_profile.ml` (profile definitions)
 - `lib/provider_tool_support.ml:148-164` (`supports_required_tool_use`)
-- `~/.masc/config/cascade.json` (live SSOT)
+- `<base-path>/.masc/config/cascade.json` (live SSOT)
 - RFC-0055: GADT phantom-typed cascade tier routing (north star)

--- a/docs/rfc/RFC-0082-keeper-last-blocker-autoclear-and-recovery-escalation.md
+++ b/docs/rfc/RFC-0082-keeper-last-blocker-autoclear-and-recovery-escalation.md
@@ -306,7 +306,7 @@ Phase 1 was originally framed as the load-bearing change. The 2026-05-15 measure
 ## §8 Open questions
 
 1. Probe payload — `keeper_time_now` is no-op; should it be a *real* cascade attempt to a known-cheap model instead, so probe outcome reflects cascade routing not just network? *Tentative*: cheap real attempt, with separate `probe_max_tokens = 1` budget guard.
-2. Probe interval — 5 min default. Per-keeper override via toml? *Tentative*: yes, `keeper.diagnostic_probe_interval_sec` in `~/.masc/config/keepers/<name>.toml`.
+2. Probe interval — 5 min default. Per-keeper override via toml? *Tentative*: yes, `keeper.diagnostic_probe_interval_sec` in `<base-path>/.masc/config/keepers/<name>.toml`.
 3. Should `last_blocker` carry a `cleared_at` history rather than a single `None`? — *Tentative*: yes, for audit; new field `last_blocker_history : (timestamp × clear_reason) list` capped at 16 entries.
 
 ## §9 Stop conditions

--- a/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
+++ b/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
@@ -169,7 +169,7 @@ keeper→tool 실행이 *macOS 운영자 workstation의 특정 디렉토리 layo
 | `lib/keeper/keeper_exec_preflight.ml:24-43`, `keeper_gh_shared.ml:217`, `keeper_tool_pr_review.ml:192` | dispatch (gh family) | `[ "/bin/zsh"; "-lc"; ... ]` 5 sites |
 | `lib/keeper/keeper_shell_ops.ml:339,387,661,702,746` | dispatch (shell ops) | `"/bin/ls"`, `"/bin/cat"`, `"/bin/pwd"`, `"/usr/bin/head"`, `"/usr/bin/tail"`, `"/usr/bin/wc"` 6 sites |
 | `lib/tool_inline_dispatch_coord.ml:185-187, 267-268`, `mcp_server_eio_execute.ml:191, 210, 253, 331, 570` | persistence (agent identity) | `Printf.sprintf "/tmp/.masc_agent[_mcp]_%s" sid` **7 sites**. `TERM_SESSION_ID` 없으면 `"default"` silent collision |
-| `lib/worker_dev_tools.ml:85` | dispatch (Fleet worker) | `Filename.concat home "me"` — 사용자별 binding |
+| `lib/worker_dev_tools.ml:85` | dispatch (Fleet worker) | hard-coded home workspace root — 사용자별 binding |
 | `lib/coord/coord_utils_backend_setup.ml:103`, `config_dir_resolver.ml:59`, `env_config_core.ml:353`, `cdal/adversarial_eval.ml:294, 301` | test-mode auto-detection | `String.starts_with ~prefix:"test_" executable` 5 sites — 보안 risk (binary rename으로 test mode silently 진입) |
 
 NixOS/Alpine/Linux server에서 silent fail.
@@ -304,7 +304,7 @@ type t = {
   host_sh   : string;          (* PATH-resolved *)
   coreutils : coreutils;       (* PATH-resolved bundle *)
   agent_runtime_root : string; (* was "/tmp/.masc_agent_*" — now <base>/.masc/runtime/agent/ *)
-  sandbox_workspace_root : string; (* was "$HOME/me" — config-driven *)
+  sandbox_workspace_root : string; (* was hard-coded home workspace root — config-driven *)
 }
 
 and coreutils = {

--- a/docs/spec/09-server-transport.md
+++ b/docs/spec/09-server-transport.md
@@ -744,7 +744,7 @@ sequenceDiagram
 |---------|--------|------|
 | `MASC_HOST` | `127.0.0.1` | 바인드 주소 |
 | `--port` / `-p` | `8935` | 리스닝 포트 |
-| `--base-path` | `$MASC_BASE_PATH` or `HOME` (`cwd` only if `HOME` is unavailable) | `.masc` 데이터 디렉토리 위치 |
+| `--base-path` | `$MASC_BASE_PATH` or `cwd` | `.masc` 데이터 디렉토리 위치 |
 
 ### 15.2 트랜스포트 설정
 

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -524,7 +524,7 @@ masc_set_param(key, value)
 |------|--------|------|
 | `-p`, `--port` | 8935 | HTTP 리스닝 포트 |
 | `--host` | `127.0.0.1` | 바인드 주소 |
-| `--base-path` | `MASC_BASE_PATH` 또는 `HOME` 기반 (`HOME` 없을 때만 `cwd`) | `.masc` 폴더 위치 |
+| `--base-path` | `MASC_BASE_PATH` 또는 `cwd` | `.masc` 폴더 위치 |
 
 ---
 

--- a/lib/cdal_runtime/proof_store.ml
+++ b/lib/cdal_runtime/proof_store.ml
@@ -8,12 +8,28 @@ type resolved_ref =
 
 open Result_syntax
 
-let default_config =
-  let home =
-    try Sys.getenv "HOME" with
-    | Not_found -> Filename.get_temp_dir_name ()
+let env_non_empty key =
+  match Sys.getenv_opt key with
+  | Some value ->
+    let value = String.trim value in
+    if value = "" then None else Some value
+  | None -> None
+;;
+
+let default_root () =
+  let base_path =
+    match env_non_empty "MASC_BASE_PATH" with
+    | Some path -> path
+    | None ->
+      (match env_non_empty "ME_ROOT" with
+       | Some path -> path
+       | None -> Sys.getcwd ())
   in
-  { root = Filename.concat home ".oas" }
+  Filename.concat base_path ".oas"
+;;
+
+let default_config =
+  { root = default_root () }
 ;;
 
 let proofs_dir config = Filename.concat config.root "proofs"

--- a/lib/cdal_runtime/proof_store.mli
+++ b/lib/cdal_runtime/proof_store.mli
@@ -7,7 +7,11 @@
     @stability Evolving
     @since 0.93.1 *)
 
-type config = { root : string (** Default: [~/.oas] *) }
+type config = {
+  root : string
+      (** Default: [<MASC_BASE_PATH>/.oas], then [<ME_ROOT>/.oas], then
+          [<cwd>/.oas]. *)
+}
 
 type resolved_ref =
   { run_id : string

--- a/lib/host_config/host_config.ml
+++ b/lib/host_config/host_config.ml
@@ -65,11 +65,11 @@ let host () =
     | Some s -> if String.trim s = "" then None else Some s
   in
   let default_workspace_root fallback =
-    match get_opt "ME_ROOT" with
-    | Some root -> root
+    match get_opt "MASC_BASE_PATH" with
+    | Some root -> Env_config_core.normalize_masc_base_path_input root
     | None ->
-      (match get_opt "HOME" with
-       | Some home -> Filename.concat home "me"
+      (match get_opt "ME_ROOT" with
+       | Some root -> root
        | None -> fallback)
   in
   { cred_root = Filename.concat tmp "keeper-creds"
@@ -169,11 +169,11 @@ let resolve ?base_path () =
     | Some s -> if String.trim s = "" then None else Some s
   in
   let default_workspace_root fallback =
-    match get_opt "ME_ROOT" with
-    | Some root -> root
+    match get_opt "MASC_BASE_PATH" with
+    | Some root -> Env_config_core.normalize_masc_base_path_input root
     | None ->
-      (match get_opt "HOME" with
-       | Some home -> Filename.concat home "me"
+      (match get_opt "ME_ROOT" with
+       | Some root -> root
        | None -> fallback)
   in
   let agent_runtime_root = Filename.concat base ".masc/runtime/agent" in

--- a/lib/host_config/host_config.ml
+++ b/lib/host_config/host_config.ml
@@ -64,16 +64,21 @@ let host () =
     | None -> None
     | Some s -> if String.trim s = "" then None else Some s
   in
+  let default_workspace_root fallback =
+    match get_opt "ME_ROOT" with
+    | Some root -> root
+    | None ->
+      (match get_opt "HOME" with
+       | Some home -> Filename.concat home "me"
+       | None -> fallback)
+  in
   { cred_root = Filename.concat tmp "keeper-creds"
   ; host_bash = "/bin/bash"
   ; host_zsh = "/bin/zsh"
   ; host_sh = "/bin/sh"
   ; coreutils = coreutils_defaults
   ; agent_runtime_root = tmp
-  ; sandbox_workspace_root =
-      (match Sys.getenv_opt "HOME" with
-       | Some home -> Filename.concat home "me"
-       | None -> Filename.concat tmp "masc-fleet")
+  ; sandbox_workspace_root = default_workspace_root (Filename.concat tmp "masc-fleet")
   ; test_mode =
       (let exec = Filename.basename Sys.executable_name in
        if String.length exec >= 5 && String.sub exec 0 5 = "test_"
@@ -158,26 +163,31 @@ let resolve_coreutils () =
 let resolve ?base_path () =
   let tmp = Filename.get_temp_dir_name () in
   let base = Option.value base_path ~default:tmp in
+  let get_opt key =
+    match Sys.getenv_opt key with
+    | None -> None
+    | Some s -> if String.trim s = "" then None else Some s
+  in
+  let default_workspace_root fallback =
+    match get_opt "ME_ROOT" with
+    | Some root -> root
+    | None ->
+      (match get_opt "HOME" with
+       | Some home -> Filename.concat home "me"
+       | None -> fallback)
+  in
   let agent_runtime_root = Filename.concat base ".masc/runtime/agent" in
   let cred_root = Filename.concat base ".masc/credentials" in
   let sandbox_workspace_root =
     match Sys.getenv_opt "MASC_SANDBOX_ROOT" with
     | Some s -> s
-    | None ->
-      (match Sys.getenv_opt "HOME" with
-       | Some home -> Filename.concat home "me"
-       | None -> Filename.concat base "fleet")
+    | None -> default_workspace_root (Filename.concat base "fleet")
   in
   let test_mode =
     let exec = Filename.basename Sys.executable_name in
     if String.length exec >= 5 && String.sub exec 0 5 = "test_"
     then Test
     else Production
-  in
-  let get_opt key =
-    match Sys.getenv_opt key with
-    | None -> None
-    | Some s -> if String.trim s = "" then None else Some s
   in
   Ok
     { cred_root

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -87,13 +87,12 @@ type context = {
 
 (* Paths *)
 let workspace_root () =
-  match Sys.getenv_opt "ME_ROOT" |> Option.map String.trim with
-  | Some root when root <> "" -> root
+  match Sys.getenv_opt "MASC_BASE_PATH" |> Option.map String.trim with
+  | Some root when root <> "" -> Env_config_core.normalize_masc_base_path_input root
   | _ ->
-    let fallback = (Host_config.host ()).agent_runtime_root in
-    (match Sys.getenv_opt "HOME" |> Option.map String.trim with
-     | Some home when home <> "" -> Filename.concat home "me"
-     | _ -> fallback)
+    (match Sys.getenv_opt "ME_ROOT" |> Option.map String.trim with
+     | Some root when root <> "" -> root
+     | _ -> (Host_config.host ()).agent_runtime_root)
 
 let library_root () =
   Filename.concat (workspace_root ()) "docs/library"

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -86,12 +86,17 @@ type context = {
 }
 
 (* Paths *)
+let workspace_root () =
+  match Sys.getenv_opt "ME_ROOT" |> Option.map String.trim with
+  | Some root when root <> "" -> root
+  | _ ->
+    let fallback = (Host_config.host ()).agent_runtime_root in
+    (match Sys.getenv_opt "HOME" |> Option.map String.trim with
+     | Some home when home <> "" -> Filename.concat home "me"
+     | _ -> fallback)
+
 let library_root () =
-  let home =
-    Sys.getenv_opt "HOME"
-    |> Option.value ~default:(Host_config.host ()).agent_runtime_root
-  in
-  Filename.concat home "me/docs/library"
+  Filename.concat (workspace_root ()) "docs/library"
 
 let candidates_dir () =
   Filename.concat (library_root ()) "candidates"

--- a/lib/tool_library.mli
+++ b/lib/tool_library.mli
@@ -4,8 +4,8 @@
     Implements 5 tools ([masc_library_list], [masc_library_read],
     [masc_library_add], [masc_library_promote],
     [masc_library_search]) backed by Markdown documents under
-    {!library_root} ([ME_ROOT/docs/library], or [\$HOME/me/docs/library]
-    when [ME_ROOT] is unset) with YAML
+    {!library_root} ([MASC_BASE_PATH/docs/library], then
+    [ME_ROOT/docs/library], then the host runtime fallback) with YAML
     frontmatter ([title], [source], [confidence], [author],
     [created], [tags], [verified_by]).
 
@@ -83,10 +83,10 @@ type context = {
 (** {1 Path resolution} *)
 
 val library_root : unit -> string
-(** [library_root ()] is [ME_ROOT/docs/library] when [ME_ROOT] is set,
-    otherwise [\$HOME/me/docs/library].  If both are unset, it falls back to
-    the host-config agent runtime root.  Read every call — env mutation
-    between calls takes effect. *)
+(** [library_root ()] is [MASC_BASE_PATH/docs/library] when
+    [MASC_BASE_PATH] is set, otherwise [ME_ROOT/docs/library].  If both are
+    unset, it falls back to the host-config agent runtime root.  Read every
+    call — env mutation between calls takes effect. *)
 
 val candidates_dir : unit -> string
 (** [candidates_dir ()] is [{library_root}/candidates].

--- a/lib/tool_library.mli
+++ b/lib/tool_library.mli
@@ -4,7 +4,8 @@
     Implements 5 tools ([masc_library_list], [masc_library_read],
     [masc_library_add], [masc_library_promote],
     [masc_library_search]) backed by Markdown documents under
-    {!library_root} ([\$HOME/me/docs/library]) with YAML
+    {!library_root} ([ME_ROOT/docs/library], or [\$HOME/me/docs/library]
+    when [ME_ROOT] is unset) with YAML
     frontmatter ([title], [source], [confidence], [author],
     [created], [tags], [verified_by]).
 
@@ -82,9 +83,10 @@ type context = {
 (** {1 Path resolution} *)
 
 val library_root : unit -> string
-(** [library_root ()] is [\$HOME/me/docs/library] with [\$HOME]
-    falling back to ["/tmp"] when unset.  Read every call —
-    env mutation between calls takes effect. *)
+(** [library_root ()] is [ME_ROOT/docs/library] when [ME_ROOT] is set,
+    otherwise [\$HOME/me/docs/library].  If both are unset, it falls back to
+    the host-config agent runtime root.  Read every call — env mutation
+    between calls takes effect. *)
 
 val candidates_dir : unit -> string
 (** [candidates_dir ()] is [{library_root}/candidates].

--- a/scripts/audit-keeper-credential-drift.sh
+++ b/scripts/audit-keeper-credential-drift.sh
@@ -37,7 +37,7 @@
 #   scripts/audit-keeper-credential-drift.sh [--base-path PATH] [--json]
 #
 # Options:
-#   --base-path PATH   Server base_path (default: $HOME/me)
+#   --base-path PATH   Server base_path (default: MASC_BASE_PATH, ME_ROOT, $HOME/me if present, then cwd)
 #   --json             Emit machine-readable JSON only (no human report)
 #   -h, --help         Show this help
 set -o pipefail
@@ -48,7 +48,19 @@ set -o pipefail
 # script handles explicitly. We rely on pipefail and explicit exit
 # code accounting instead.
 
-BASE_PATH="${HOME}/me"
+default_base_path() {
+  if [ -n "${MASC_BASE_PATH:-}" ]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  elif [ -n "${ME_ROOT:-}" ]; then
+    printf '%s\n' "$ME_ROOT"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    printf '%s\n' "$HOME/me"
+  else
+    pwd
+  fi
+}
+
+BASE_PATH="$(default_base_path)"
 EMIT_JSON=0
 
 usage() {

--- a/scripts/audit-keeper-credential-drift.sh
+++ b/scripts/audit-keeper-credential-drift.sh
@@ -37,7 +37,7 @@
 #   scripts/audit-keeper-credential-drift.sh [--base-path PATH] [--json]
 #
 # Options:
-#   --base-path PATH   Server base_path (default: MASC_BASE_PATH, ME_ROOT, $HOME/me if present, then cwd)
+#   --base-path PATH   Server base_path (default: MASC_BASE_PATH, ME_ROOT, then cwd)
 #   --json             Emit machine-readable JSON only (no human report)
 #   -h, --help         Show this help
 set -o pipefail
@@ -53,8 +53,6 @@ default_base_path() {
     printf '%s\n' "$MASC_BASE_PATH"
   elif [ -n "${ME_ROOT:-}" ]; then
     printf '%s\n' "$ME_ROOT"
-  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-    printf '%s\n' "$HOME/me"
   else
     pwd
   fi

--- a/scripts/audit-keeper-credential-uuid-integrity.sh
+++ b/scripts/audit-keeper-credential-uuid-integrity.sh
@@ -26,14 +26,26 @@
 #   scripts/audit-keeper-credential-uuid-integrity.sh [--base-path PATH] [--json]
 #
 # Options:
-#   --base-path PATH   Server base_path (default: $HOME/me)
+#   --base-path PATH   Server base_path (default: MASC_BASE_PATH, ME_ROOT, $HOME/me if present, then cwd)
 #   --json             Emit machine-readable JSON only
 #   -h, --help         Show this help
 set -o pipefail
 # Note: set -e and set -u are intentionally NOT enabled — see
 # audit-keeper-credential-drift.sh for the bash 3.2 rationale.
 
-BASE_PATH="${HOME}/me"
+default_base_path() {
+  if [ -n "${MASC_BASE_PATH:-}" ]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  elif [ -n "${ME_ROOT:-}" ]; then
+    printf '%s\n' "$ME_ROOT"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    printf '%s\n' "$HOME/me"
+  else
+    pwd
+  fi
+}
+
+BASE_PATH="$(default_base_path)"
 EMIT_JSON=0
 
 usage() {

--- a/scripts/audit-keeper-credential-uuid-integrity.sh
+++ b/scripts/audit-keeper-credential-uuid-integrity.sh
@@ -26,7 +26,7 @@
 #   scripts/audit-keeper-credential-uuid-integrity.sh [--base-path PATH] [--json]
 #
 # Options:
-#   --base-path PATH   Server base_path (default: MASC_BASE_PATH, ME_ROOT, $HOME/me if present, then cwd)
+#   --base-path PATH   Server base_path (default: MASC_BASE_PATH, ME_ROOT, then cwd)
 #   --json             Emit machine-readable JSON only
 #   -h, --help         Show this help
 set -o pipefail
@@ -38,8 +38,6 @@ default_base_path() {
     printf '%s\n' "$MASC_BASE_PATH"
   elif [ -n "${ME_ROOT:-}" ]; then
     printf '%s\n' "$ME_ROOT"
-  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-    printf '%s\n' "$HOME/me"
   else
     pwd
   fi

--- a/scripts/ci/check-masc-oas-boundary.sh
+++ b/scripts/ci/check-masc-oas-boundary.sh
@@ -35,7 +35,7 @@ resolve_oas_repo() {
   repo_parent="$(dirname "$(pwd)")"
   local candidates=(
     "${repo_parent}/oas"
-    "${HOME:-}/me/workspace/yousleepwhen/oas"
+    "${ME_ROOT:-}/workspace/yousleepwhen/oas"
   )
 
   local candidate

--- a/scripts/cleanup-autoresearch.sh
+++ b/scripts/cleanup-autoresearch.sh
@@ -18,7 +18,7 @@
 #   TTL_DAYS=14 scripts/cleanup-autoresearch.sh --apply  # custom TTL
 #
 # Environment:
-#   MASC_BASE_PATH  base path (default: $HOME/me)
+#   MASC_BASE_PATH  base path (default: ME_ROOT, $HOME/me, then cwd)
 #   TTL_DAYS        days a dir must be untouched to qualify (default: 7)
 #
 # Refuses to quarantine a dir that any process holds an open FD to.
@@ -36,7 +36,19 @@ for arg in "$@"; do
   esac
 done
 
-BASE="${MASC_BASE_PATH:-$HOME/me}"
+default_base_path() {
+  if [ -n "${MASC_BASE_PATH:-}" ]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  elif [ -n "${ME_ROOT:-}" ]; then
+    printf '%s\n' "$ME_ROOT"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    printf '%s\n' "$HOME/me"
+  else
+    pwd
+  fi
+}
+
+BASE="$(default_base_path)"
 TTL_DAYS="${TTL_DAYS:-7}"
 AR_DIR="$BASE/.masc/autoresearch"
 QUARANTINE_DIR="$BASE/.tmp/leak-quarantine-$(date +%Y-%m-%d)"

--- a/scripts/cleanup-autoresearch.sh
+++ b/scripts/cleanup-autoresearch.sh
@@ -18,7 +18,7 @@
 #   TTL_DAYS=14 scripts/cleanup-autoresearch.sh --apply  # custom TTL
 #
 # Environment:
-#   MASC_BASE_PATH  base path (default: ME_ROOT, $HOME/me, then cwd)
+#   MASC_BASE_PATH  base path (default: MASC_BASE_PATH, ME_ROOT, then cwd)
 #   TTL_DAYS        days a dir must be untouched to qualify (default: 7)
 #
 # Refuses to quarantine a dir that any process holds an open FD to.
@@ -41,8 +41,6 @@ default_base_path() {
     printf '%s\n' "$MASC_BASE_PATH"
   elif [ -n "${ME_ROOT:-}" ]; then
     printf '%s\n' "$ME_ROOT"
-  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-    printf '%s\n' "$HOME/me"
   else
     pwd
   fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -20,15 +20,15 @@ RELEASE_DIR="$REPO_DIR/releases"
 PROD_PORT=8945
 HEALTH_URL="http://127.0.0.1:$PROD_PORT/health"
 default_base_path() {
-    if [ -n "${ME_ROOT:-}" ]; then
+    if [ -n "${MASC_BASE_PATH:-}" ]; then
+        printf '%s\n' "$MASC_BASE_PATH"
+    elif [ -n "${ME_ROOT:-}" ]; then
         printf '%s\n' "$ME_ROOT"
-    elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-        printf '%s\n' "$HOME/me"
     else
         printf '%s\n' "$REPO_DIR"
     fi
 }
-BASE_PATH="${MASC_BASE_PATH:-$(default_base_path)}"
+BASE_PATH="$(default_base_path)"
 RUNTIME_ROOT="${BASE_PATH}/.masc"
 PID_FILE="${RUNTIME_ROOT}/masc-prod.pid"
 LOG_DIR="${RUNTIME_ROOT}/logs"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -19,7 +19,16 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 RELEASE_DIR="$REPO_DIR/releases"
 PROD_PORT=8945
 HEALTH_URL="http://127.0.0.1:$PROD_PORT/health"
-BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+default_base_path() {
+    if [ -n "${ME_ROOT:-}" ]; then
+        printf '%s\n' "$ME_ROOT"
+    elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+        printf '%s\n' "$HOME/me"
+    else
+        printf '%s\n' "$REPO_DIR"
+    fi
+}
+BASE_PATH="${MASC_BASE_PATH:-$(default_base_path)}"
 RUNTIME_ROOT="${BASE_PATH}/.masc"
 PID_FILE="${RUNTIME_ROOT}/masc-prod.pid"
 LOG_DIR="${RUNTIME_ROOT}/logs"

--- a/scripts/diag-keeper-cycle.sh
+++ b/scripts/diag-keeper-cycle.sh
@@ -13,7 +13,19 @@
 
 set -euo pipefail
 
-BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-$HOME/me}}"
+default_base_path() {
+  if [ -n "${MASC_BASE_PATH:-}" ]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  elif [ -n "${ME_ROOT:-}" ]; then
+    printf '%s\n' "$ME_ROOT"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    printf '%s\n' "$HOME/me"
+  else
+    pwd
+  fi
+}
+
+BASE_PATH="$(default_base_path)"
 KEEPER_FILTER=""
 WINDOW_MIN=60
 TOP_GAPS=5

--- a/scripts/diag-keeper-cycle.sh
+++ b/scripts/diag-keeper-cycle.sh
@@ -18,8 +18,6 @@ default_base_path() {
     printf '%s\n' "$MASC_BASE_PATH"
   elif [ -n "${ME_ROOT:-}" ]; then
     printf '%s\n' "$ME_ROOT"
-  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-    printf '%s\n' "$HOME/me"
   else
     pwd
   fi

--- a/scripts/harness/self_eval_ratchet.sh
+++ b/scripts/harness/self_eval_ratchet.sh
@@ -17,7 +17,18 @@ set -euo pipefail
 
 ITERATION="${1:-1}"
 : "${MCP_URL:=http://127.0.0.1:8935/mcp}"
-RESULTS_DIR="${MASC_BASE_PATH:-${HOME:-$PWD}}/.masc/eval_results"
+default_base_path() {
+  if [ -n "${MASC_BASE_PATH:-}" ]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  elif [ -n "${ME_ROOT:-}" ]; then
+    printf '%s\n' "$ME_ROOT"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    printf '%s\n' "$HOME/me"
+  else
+    printf '%s\n' "$PWD"
+  fi
+}
+RESULTS_DIR="$(default_base_path)/.masc/eval_results"
 RESULT_FILE="${RESULTS_DIR}/iteration_${ITERATION}.json"
 
 mkdir -p "$RESULTS_DIR"

--- a/scripts/harness/self_eval_ratchet.sh
+++ b/scripts/harness/self_eval_ratchet.sh
@@ -22,8 +22,6 @@ default_base_path() {
     printf '%s\n' "$MASC_BASE_PATH"
   elif [ -n "${ME_ROOT:-}" ]; then
     printf '%s\n' "$ME_ROOT"
-  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-    printf '%s\n' "$HOME/me"
   else
     printf '%s\n' "$PWD"
   fi

--- a/scripts/harness/workload/agent_swarm_live.sh
+++ b/scripts/harness/workload/agent_swarm_live.sh
@@ -6,7 +6,20 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 RUN_ID="${RUN_ID:-keeper-fleet-readiness-$(date +%Y%m%d_%H%M%S)}"
 RUN_DIR="${RUN_DIR:-$REPO_ROOT/logs/keeper_fleet_readiness/$RUN_ID}"
-BASE_PATH="${BASE_PATH:-${MASC_BASE_PATH:-$HOME/me}}"
+default_base_path() {
+  if [ -n "${BASE_PATH:-}" ]; then
+    printf '%s\n' "$BASE_PATH"
+  elif [ -n "${MASC_BASE_PATH:-}" ]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  elif [ -n "${ME_ROOT:-}" ]; then
+    printf '%s\n' "$ME_ROOT"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    printf '%s\n' "$HOME/me"
+  else
+    printf '%s\n' "$REPO_ROOT"
+  fi
+}
+BASE_PATH="$(default_base_path)"
 EXPECTED_KEEPERS="${EXPECTED_KEEPERS:-18}"
 KEEPER_NAMES="${KEEPER_NAMES:-}"
 MAX_TRACES_PER_KEEPER="${MAX_TRACES_PER_KEEPER:-20}"

--- a/scripts/harness/workload/agent_swarm_live.sh
+++ b/scripts/harness/workload/agent_swarm_live.sh
@@ -13,8 +13,6 @@ default_base_path() {
     printf '%s\n' "$MASC_BASE_PATH"
   elif [ -n "${ME_ROOT:-}" ]; then
     printf '%s\n' "$ME_ROOT"
-  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-    printf '%s\n' "$HOME/me"
   else
     printf '%s\n' "$REPO_ROOT"
   fi

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -32,8 +32,6 @@ default_base_path() {
     printf '%s\n' "$MASC_BASE_PATH"
   elif [ -n "${ME_ROOT:-}" ]; then
     printf '%s\n' "$ME_ROOT"
-  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-    printf '%s\n' "$HOME/me"
   else
     printf '%s\n' "$REPO_ROOT"
   fi
@@ -93,7 +91,7 @@ Options:
   --expected-keepers N     Expected configured keeper count for audit.
   --repo OWNER/REPO        Target repository slug in the keeper prompt.
   --base-path PATH         MASC base path for audit (default: MASC_BASE_PATH,
-                           ME_ROOT, $HOME/me if present, then repo root).
+                           ME_ROOT, then repo root).
   --mcp-url URL            MCP endpoint (default: http://127.0.0.1:8935/mcp).
   --expected-server-commit COMMIT
                            Fail unless /health build.commit matches this commit.

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -25,7 +25,21 @@ SUMMARY_FILE="$RUN_DIR/summary.json"
 AUDIT_FILE="$RUN_DIR/audit-docker-pr-lifecycle.json"
 AUDIT_STATUS_RESULT=0
 
-BASE_PATH="${BASE_PATH:-${MASC_BASE_PATH:-$HOME/me}}"
+default_base_path() {
+  if [ -n "${BASE_PATH:-}" ]; then
+    printf '%s\n' "$BASE_PATH"
+  elif [ -n "${MASC_BASE_PATH:-}" ]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  elif [ -n "${ME_ROOT:-}" ]; then
+    printf '%s\n' "$ME_ROOT"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    printf '%s\n' "$HOME/me"
+  else
+    printf '%s\n' "$REPO_ROOT"
+  fi
+}
+
+BASE_PATH="$(default_base_path)"
 EXPECTED_KEEPERS="${EXPECTED_KEEPERS:-14}"
 KEEPER_NAMES="${KEEPER_NAMES:-}"
 MAX_KEEPERS="${MAX_KEEPERS:-0}"
@@ -78,7 +92,8 @@ Options:
   --max-keepers N          Limit targets after discovery/CSV expansion.
   --expected-keepers N     Expected configured keeper count for audit.
   --repo OWNER/REPO        Target repository slug in the keeper prompt.
-  --base-path PATH         MASC base path for audit (default: $HOME/me).
+  --base-path PATH         MASC base path for audit (default: MASC_BASE_PATH,
+                           ME_ROOT, $HOME/me if present, then repo root).
   --mcp-url URL            MCP endpoint (default: http://127.0.0.1:8935/mcp).
   --expected-server-commit COMMIT
                            Fail unless /health build.commit matches this commit.

--- a/scripts/harness/workload/keeper_product_design_board_reprobe.sh
+++ b/scripts/harness/workload/keeper_product_design_board_reprobe.sh
@@ -27,8 +27,6 @@ default_base_path() {
     printf '%s\n' "$MASC_BASE_PATH"
   elif [ -n "${ME_ROOT:-}" ]; then
     printf '%s\n' "$ME_ROOT"
-  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-    printf '%s\n' "$HOME/me"
   else
     printf '%s\n' "$REPO_ROOT"
   fi

--- a/scripts/harness/workload/keeper_product_design_board_reprobe.sh
+++ b/scripts/harness/workload/keeper_product_design_board_reprobe.sh
@@ -20,7 +20,21 @@ SUMMARY_FILE="$RUN_DIR/summary.json"
 AUDIT_FILE="$RUN_DIR/audit-product-design.json"
 AUDIT_STATUS_RESULT=0
 
-BASE_PATH="${BASE_PATH:-${MASC_BASE_PATH:-$HOME/me}}"
+default_base_path() {
+  if [ -n "${BASE_PATH:-}" ]; then
+    printf '%s\n' "$BASE_PATH"
+  elif [ -n "${MASC_BASE_PATH:-}" ]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  elif [ -n "${ME_ROOT:-}" ]; then
+    printf '%s\n' "$ME_ROOT"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    printf '%s\n' "$HOME/me"
+  else
+    printf '%s\n' "$REPO_ROOT"
+  fi
+}
+
+BASE_PATH="$(default_base_path)"
 EXPECTED_KEEPERS="${EXPECTED_KEEPERS:-14}"
 KEEPER_NAMES="${KEEPER_NAMES:-}"
 MAX_KEEPERS="${MAX_KEEPERS:-0}"

--- a/scripts/harness/workload/sangsu_bench_toggle.sh
+++ b/scripts/harness/workload/sangsu_bench_toggle.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Phase 1a-2: toggle sangsu's cascade between live mode and ollama_bench.
 #
-# Mutates ~/me/.masc/config/keepers/sangsu.toml in place. Backup written
-# alongside as sangsu.toml.bench-bak. Hot-reload is mtime-based so no
+# Mutates <base-path>/.masc/config/keepers/sangsu.toml in place. Backup
+# written alongside as sangsu.toml.bench-bak. Hot-reload is mtime-based so no
 # server restart needed.
 #
 # Usage:
@@ -18,7 +18,19 @@
 
 set -euo pipefail
 
-BASE_PATH="${MASC_BASE_PATH:-$HOME/me}"
+default_base_path() {
+  if [ -n "${MASC_BASE_PATH:-}" ]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  elif [ -n "${ME_ROOT:-}" ]; then
+    printf '%s\n' "$ME_ROOT"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    printf '%s\n' "$HOME/me"
+  else
+    pwd
+  fi
+}
+
+BASE_PATH="$(default_base_path)"
 SANGSU_TOML="${BASE_PATH}/.masc/config/keepers/sangsu.toml"
 SANGSU_BAK="${SANGSU_TOML}.bench-bak"
 CASCADE_TOML="${BASE_PATH}/.masc/config/cascade.toml"

--- a/scripts/harness/workload/sangsu_bench_toggle.sh
+++ b/scripts/harness/workload/sangsu_bench_toggle.sh
@@ -23,8 +23,6 @@ default_base_path() {
     printf '%s\n' "$MASC_BASE_PATH"
   elif [ -n "${ME_ROOT:-}" ]; then
     printf '%s\n' "$ME_ROOT"
-  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-    printf '%s\n' "$HOME/me"
   else
     pwd
   fi

--- a/scripts/host-ollama-tune.sh
+++ b/scripts/host-ollama-tune.sh
@@ -20,7 +20,7 @@
 # What it does NOT do:
 #   - install ollama (assumed already present at /Applications/Ollama.app)
 #   - touch cascade.toml (provider weights are an operator decision; see
-#     ~/me/.masc/config/cascade.toml [keeper_unified] keep_alive setting)
+#     <base-path>/.masc/config/cascade.toml [keeper_unified] keep_alive setting)
 #   - persist across macOS reboots beyond launchctl scope (login-session
 #     env survives until reboot; for permanent set add to ~/.zshenv too)
 #

--- a/scripts/init-codex-mcp-config.sh
+++ b/scripts/init-codex-mcp-config.sh
@@ -7,17 +7,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 default_base_path() {
-  if [ -n "${ME_ROOT:-}" ]; then
+  if [ -n "${MASC_BASE_PATH:-}" ]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  elif [ -n "${ME_ROOT:-}" ]; then
     printf '%s\n' "$ME_ROOT"
-  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-    printf '%s\n' "$HOME/me"
   else
     printf '%s\n' "$REPO_DIR"
   fi
 }
 
 DEFAULT_BASE_PATH="$(default_base_path)"
-BASE_PATH="${MASC_BASE_PATH:-$DEFAULT_BASE_PATH}"
+BASE_PATH="$DEFAULT_BASE_PATH"
 HOST="127.0.0.1"
 PORT="8935"
 DRY_RUN=0
@@ -48,7 +48,7 @@ Security notes:
   - Run `masc-mcp doctor auth` to verify the config is correct.
 
 Env:
-  MASC_BASE_PATH         Base path for the MASC data root (default: ME_ROOT, $HOME/me, then repo root)
+  MASC_BASE_PATH         Base path for the MASC data root (default: MASC_BASE_PATH, ME_ROOT, then repo root)
   MASC_CODEX_CONFIG_PATH Override the Codex config path (default: ~/.codex/config.toml)
 EOF
   exit 0

--- a/scripts/init-codex-mcp-config.sh
+++ b/scripts/init-codex-mcp-config.sh
@@ -3,7 +3,21 @@
 
 set -euo pipefail
 
-BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+default_base_path() {
+  if [ -n "${ME_ROOT:-}" ]; then
+    printf '%s\n' "$ME_ROOT"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    printf '%s\n' "$HOME/me"
+  else
+    printf '%s\n' "$REPO_DIR"
+  fi
+}
+
+DEFAULT_BASE_PATH="$(default_base_path)"
+BASE_PATH="${MASC_BASE_PATH:-$DEFAULT_BASE_PATH}"
 HOST="127.0.0.1"
 PORT="8935"
 DRY_RUN=0
@@ -22,7 +36,7 @@ the MASC auth doctor (doctor auth) expects:
   - http_headers with Accept and X-MASC-Agent  (no Authorization header)
 
 After writing the stanza, mint a codex-mcp-client bearer token (if missing):
-  BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+  BASE_PATH="${MASC_BASE_PATH:-<script default base path>}"
   eval "$(masc-mcp login \
     --base-path "$BASE_PATH" --agent codex-mcp-client --role worker --shell)"
   export MASC_MCP_TOKEN  # export to Codex's shell environment
@@ -34,7 +48,7 @@ Security notes:
   - Run `masc-mcp doctor auth` to verify the config is correct.
 
 Env:
-  MASC_BASE_PATH         Base path for the MASC data root (default: $HOME)
+  MASC_BASE_PATH         Base path for the MASC data root (default: ME_ROOT, $HOME/me, then repo root)
   MASC_CODEX_CONFIG_PATH Override the Codex config path (default: ~/.codex/config.toml)
 EOF
   exit 0

--- a/scripts/keeper-runtime-truth-gate.sh
+++ b/scripts/keeper-runtime-truth-gate.sh
@@ -18,8 +18,6 @@ default_base_path() {
     printf '%s\n' "$MASC_BASE_PATH"
   elif [ -n "${ME_ROOT:-}" ]; then
     printf '%s\n' "$ME_ROOT"
-  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-    printf '%s\n' "$HOME/me"
   else
     pwd
   fi

--- a/scripts/keeper-runtime-truth-gate.sh
+++ b/scripts/keeper-runtime-truth-gate.sh
@@ -13,7 +13,19 @@
 
 set -euo pipefail
 
-BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-$HOME/me}}"
+default_base_path() {
+  if [ -n "${MASC_BASE_PATH:-}" ]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  elif [ -n "${ME_ROOT:-}" ]; then
+    printf '%s\n' "$ME_ROOT"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    printf '%s\n' "$HOME/me"
+  else
+    pwd
+  fi
+}
+
+BASE_PATH="$(default_base_path)"
 KEEPER=""
 TRACE_ID=""
 TURN_ID=""

--- a/scripts/keeper-turn-slot-evidence.sh
+++ b/scripts/keeper-turn-slot-evidence.sh
@@ -19,8 +19,6 @@ default_base_path() {
     printf '%s\n' "$MASC_BASE_PATH"
   elif [ -n "${ME_ROOT:-}" ]; then
     printf '%s\n' "$ME_ROOT"
-  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-    printf '%s\n' "$HOME/me"
   else
     pwd
   fi

--- a/scripts/keeper-turn-slot-evidence.sh
+++ b/scripts/keeper-turn-slot-evidence.sh
@@ -14,7 +14,19 @@
 
 set -euo pipefail
 
-BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-$HOME/me}}"
+default_base_path() {
+  if [ -n "${MASC_BASE_PATH:-}" ]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  elif [ -n "${ME_ROOT:-}" ]; then
+    printf '%s\n' "$ME_ROOT"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    printf '%s\n' "$HOME/me"
+  else
+    pwd
+  fi
+}
+
+BASE_PATH="$(default_base_path)"
 KEEPER_FILTER=""
 WINDOW_MIN=1440
 MIN_NORMAL_SAMPLES=5

--- a/scripts/lib/masc-log-path.sh
+++ b/scripts/lib/masc-log-path.sh
@@ -9,9 +9,8 @@
 #                        the server is running, regardless of how it was
 #                        started (argv --base-path, env, or anything else).
 #   3. $MASC_BASE_PATH - env-provided base path; <base>/.masc/logs/system_log_TODAY.jsonl
-#   4. $ME_ROOT        - second-brain workspace default.
-#   5. $HOME/me        - second-brain default, only if it already exists.
-#   6. $PWD            - last fallback.
+#   4. $ME_ROOT        - explicit second-brain workspace root.
+#   5. $PWD            - last fallback.
 #
 # Sourced by scripts/logs-follow.sh and scripts/op-f-leak-verification.sh.
 #
@@ -26,10 +25,6 @@ masc_log_resolve_base() {
   fi
   if [ -n "${ME_ROOT:-}" ]; then
     echo "$ME_ROOT"
-    return 0
-  fi
-  if [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-    echo "$HOME/me"
     return 0
   fi
   pwd

--- a/scripts/lib/masc-log-path.sh
+++ b/scripts/lib/masc-log-path.sh
@@ -9,7 +9,9 @@
 #                        the server is running, regardless of how it was
 #                        started (argv --base-path, env, or anything else).
 #   3. $MASC_BASE_PATH - env-provided base path; <base>/.masc/logs/system_log_TODAY.jsonl
-#   4. $HOME/me        - second-brain default, only as last fallback.
+#   4. $ME_ROOT        - second-brain workspace default.
+#   5. $HOME/me        - second-brain default, only if it already exists.
+#   6. $PWD            - last fallback.
 #
 # Sourced by scripts/logs-follow.sh and scripts/op-f-leak-verification.sh.
 #
@@ -22,7 +24,15 @@ masc_log_resolve_base() {
     echo "$MASC_BASE_PATH"
     return 0
   fi
-  echo "${HOME}/me"
+  if [ -n "${ME_ROOT:-}" ]; then
+    echo "$ME_ROOT"
+    return 0
+  fi
+  if [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    echo "$HOME/me"
+    return 0
+  fi
+  pwd
 }
 
 # Detect the log file currently held open by the running MASC server.

--- a/scripts/llama-runtime-pool.sh
+++ b/scripts/llama-runtime-pool.sh
@@ -162,8 +162,8 @@ resolve_llama_server_bin() {
     printf '%s\n' "${SEED_BINARY}"
     return 0
   fi
-  if [ -x "$HOME/me/.local/bin/llama-server" ]; then
-    printf '%s\n' "$HOME/me/.local/bin/llama-server"
+  if [ -n "${ME_ROOT:-}" ] && [ -x "$ME_ROOT/.local/bin/llama-server" ]; then
+    printf '%s\n' "$ME_ROOT/.local/bin/llama-server"
     return 0
   fi
   if [ -x "$HOME/.local/bin/llama-server" ]; then

--- a/scripts/logs-follow.sh
+++ b/scripts/logs-follow.sh
@@ -191,7 +191,7 @@ validate_args
 #   1. --base-path override          (user-provided path, run through worktree-aware resolver)
 #   2. helper masc_log_dir           (detects via lsof on the running server when available;
 #                                     falls back to MASC_BASE_PATH, ME_ROOT,
-#                                     $HOME/me if present, or cwd)
+#                                     ME_ROOT, or cwd)
 # This avoids the historical drift where logs-follow defaulted to $HOME
 # while the server actually wrote under <base>/.masc/logs/, leaving
 # operators staring at an empty directory.

--- a/scripts/logs-follow.sh
+++ b/scripts/logs-follow.sh
@@ -23,7 +23,7 @@ If you pass a repo or worktree path, the script resolves it to the owning repo r
 Options:
   --base-path <path>    Override MASC base path (default: detected via lsof
                         from the running server; falls back to MASC_BASE_PATH
-                        or $HOME/me when no server is running)
+                        or ME_ROOT, then cwd when no server is running)
   --date <YYYY-MM-DD>   Read a specific log file instead of today's rotating file
   --lines <n>           Tail last N lines before following (default: 40, use 0 for only new lines)
   --level <level>       Minimum level: debug|info|warn|error (default: debug)
@@ -190,7 +190,8 @@ validate_args
 # Resolution order for the log directory (deterministic-first):
 #   1. --base-path override          (user-provided path, run through worktree-aware resolver)
 #   2. helper masc_log_dir           (detects via lsof on the running server when available;
-#                                     falls back to MASC_BASE_PATH or $HOME/me)
+#                                     falls back to MASC_BASE_PATH, ME_ROOT,
+#                                     $HOME/me if present, or cwd)
 # This avoids the historical drift where logs-follow defaulted to $HOME
 # while the server actually wrote under <base>/.masc/logs/, leaving
 # operators staring at an empty directory.

--- a/scripts/masc-autonomy-action-stats.py
+++ b/scripts/masc-autonomy-action-stats.py
@@ -17,11 +17,6 @@ def default_base_path() -> str:
     me_root = os.environ.get("ME_ROOT", "").strip()
     if me_root:
         return me_root
-    home = os.environ.get("HOME", "").strip()
-    if home:
-        home_me = os.path.join(home, "me")
-        if os.path.isdir(home_me):
-            return home_me
     return os.getcwd()
 
 

--- a/scripts/masc-autonomy-action-stats.py
+++ b/scripts/masc-autonomy-action-stats.py
@@ -10,6 +10,21 @@ import os
 from typing import Dict, Iterable, List, Tuple
 
 
+def default_base_path() -> str:
+    masc_base = os.environ.get("MASC_BASE_PATH", "").strip()
+    if masc_base:
+        return masc_base
+    me_root = os.environ.get("ME_ROOT", "").strip()
+    if me_root:
+        return me_root
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        home_me = os.path.join(home, "me")
+        if os.path.isdir(home_me):
+            return home_me
+    return os.getcwd()
+
+
 def parse_date(s: str) -> dt.datetime:
     return dt.datetime.strptime(s, "%Y-%m-%d")
 
@@ -115,7 +130,7 @@ def main() -> int:
     parser.add_argument("--format", type=str, default="text", choices=["text", "json"], help="Output format")
     args = parser.parse_args()
 
-    base_path = (os.environ.get("MASC_BASE_PATH") or os.path.expanduser("~")).strip()
+    base_path = default_base_path()
     traces_dir = os.path.join(base_path, ".masc", "traces")
 
     start_ts, end_ts = ts_range_from_args(args.days, args.since, args.until)

--- a/scripts/migrate-keeper-meta-sandbox.sh
+++ b/scripts/migrate-keeper-meta-sandbox.sh
@@ -11,12 +11,13 @@
 #
 # Scope (filesystem locations searched)
 #   1. <repo>/.masc/keepers/*.json          (worktree-local persistence)
-#   2. ~/.masc/keepers/*.json               (per-user persistence)
+#   2. <base-path>/.masc/keepers/*.json     (operator runtime persistence)
 #
 # Usage
 #   bash scripts/migrate-keeper-meta-sandbox.sh             # --dry-run (default)
 #   bash scripts/migrate-keeper-meta-sandbox.sh --apply     # write .bak + edit
 #   bash scripts/migrate-keeper-meta-sandbox.sh --apply --quiet
+#   bash scripts/migrate-keeper-meta-sandbox.sh --base-path ~/me --apply
 #
 # Exit codes
 #   0   normalized 0 or more files cleanly
@@ -28,20 +29,27 @@ set -euo pipefail
 
 MODE="dry-run"
 QUIET=0
-for arg in "$@"; do
-  case "$arg" in
+BASE_PATH_OVERRIDE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
     --apply)   MODE="apply" ;;
     --dry-run) MODE="dry-run" ;;
     --quiet)   QUIET=1 ;;
+    --base-path)
+      shift
+      [ $# -gt 0 ] || { echo "--base-path requires a path" >&2; exit 2; }
+      BASE_PATH_OVERRIDE="$1"
+      ;;
     -h|--help)
-      sed -n '1,30p' "$0"
+      sed -n '1,31p' "$0"
       exit 0
       ;;
     *)
-      echo "Unknown argument: $arg" >&2
+      echo "Unknown argument: $1" >&2
       exit 2
       ;;
   esac
+  shift
 done
 
 if ! command -v jq >/dev/null 2>&1; then
@@ -53,6 +61,20 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$(cd "$(dirname 
 TOML_DIR="${REPO_ROOT}/config/keepers"
 
 log() { [ "$QUIET" -eq 1 ] || echo "$@"; }
+
+default_base_path() {
+  if [ -n "$BASE_PATH_OVERRIDE" ]; then
+    printf '%s\n' "$BASE_PATH_OVERRIDE"
+  elif [ -n "${MASC_BASE_PATH:-}" ]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  elif [ -n "${ME_ROOT:-}" ]; then
+    printf '%s\n' "$ME_ROOT"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    printf '%s\n' "$HOME/me"
+  else
+    printf '%s\n' "$REPO_ROOT"
+  fi
+}
 
 # Read a TOML scalar like `sandbox_profile = "docker"`. Returns empty string
 # when the key is absent. Comments after the value are stripped.
@@ -150,6 +172,9 @@ scan_dir() {
 }
 
 log "mode: $MODE"
+BASE_PATH="$(default_base_path)"
 scan_dir "${REPO_ROOT}/.masc/keepers"
-scan_dir "${HOME}/.masc/keepers"
+if [ "$BASE_PATH" != "$REPO_ROOT" ]; then
+  scan_dir "${BASE_PATH}/.masc/keepers"
+fi
 log "done."

--- a/scripts/migrate-keeper-meta-sandbox.sh
+++ b/scripts/migrate-keeper-meta-sandbox.sh
@@ -69,8 +69,6 @@ default_base_path() {
     printf '%s\n' "$MASC_BASE_PATH"
   elif [ -n "${ME_ROOT:-}" ]; then
     printf '%s\n' "$ME_ROOT"
-  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-    printf '%s\n' "$HOME/me"
   else
     printf '%s\n' "$REPO_ROOT"
   fi

--- a/scripts/oas-drift-check.sh
+++ b/scripts/oas-drift-check.sh
@@ -52,14 +52,14 @@ resolve_source_dir() {
   # Candidate local repo paths, checked in order:
   #   1. $AGENT_SDK_LOCAL_REPO (explicit opt-in)
   #   2. Sibling checkout: <masc-mcp-parent>/oas
-  #   3. Workspace convention: $HOME/me/workspace/yousleepwhen/oas
+  #   3. Explicit workspace root: $ME_ROOT/workspace/yousleepwhen/oas
   # Each must be a git checkout at the pinned SHA to qualify.
   local masc_parent
   masc_parent="$(cd "${REPO_ROOT}/.." && pwd)"
   local -a candidates=(
     "${AGENT_SDK_LOCAL_REPO:-}"
     "${masc_parent}/oas"
-    "${HOME}/me/workspace/yousleepwhen/oas"
+    "${ME_ROOT:-}/workspace/yousleepwhen/oas"
   )
   local candidate head
   for candidate in "${candidates[@]}"; do

--- a/scripts/op-f-leak-verification.sh
+++ b/scripts/op-f-leak-verification.sh
@@ -10,7 +10,7 @@
 # JSONL log produced by the masc-mcp server.  The log path is resolved
 # via scripts/lib/masc-log-path.sh, which detects the active file from
 # the running server (lsof on the listening socket) and falls back to
-# MASC_BASE_PATH, ME_ROOT, $HOME/me if present, or cwd when no server is
+# MASC_BASE_PATH, ME_ROOT, or cwd when no server is
 # running. No state is kept between runs — re-execute after any merge or restart to refresh
 # the snapshot.
 #
@@ -28,8 +28,8 @@ set -u
 # Resolve the active log path through the SSOT helper.  When the server
 # is running, this detects the actual file via lsof on the listening
 # socket — authoritative regardless of how the server was started.
-# Otherwise falls back to MASC_BASE_PATH, ME_ROOT, $HOME/me if present,
-# or cwd. Override with $1 or $MASC_LOG when the log lives elsewhere
+# Otherwise falls back to MASC_BASE_PATH, ME_ROOT, or cwd. Override with
+# $1 or $MASC_LOG when the log lives elsewhere
 # (e.g. /tmp/masc-postmerge.log).
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck disable=SC1091

--- a/scripts/op-f-leak-verification.sh
+++ b/scripts/op-f-leak-verification.sh
@@ -10,8 +10,8 @@
 # JSONL log produced by the masc-mcp server.  The log path is resolved
 # via scripts/lib/masc-log-path.sh, which detects the active file from
 # the running server (lsof on the listening socket) and falls back to
-# $MASC_BASE_PATH or $HOME/me when no server is running.  No state is
-# kept between runs — re-execute after any merge or restart to refresh
+# MASC_BASE_PATH, ME_ROOT, $HOME/me if present, or cwd when no server is
+# running. No state is kept between runs — re-execute after any merge or restart to refresh
 # the snapshot.
 #
 # Origin: 2026-04-25 keeper docker git_clone E2E investigation
@@ -28,8 +28,9 @@ set -u
 # Resolve the active log path through the SSOT helper.  When the server
 # is running, this detects the actual file via lsof on the listening
 # socket — authoritative regardless of how the server was started.
-# Otherwise falls back to MASC_BASE_PATH or $HOME/me.  Override with $1
-# or $MASC_LOG when the log lives elsewhere (e.g. /tmp/masc-postmerge.log).
+# Otherwise falls back to MASC_BASE_PATH, ME_ROOT, $HOME/me if present,
+# or cwd. Override with $1 or $MASC_LOG when the log lives elsewhere
+# (e.g. /tmp/masc-postmerge.log).
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck disable=SC1091
 . "${SCRIPT_DIR}/lib/masc-log-path.sh"

--- a/scripts/sweep-tool-error-signatures.sh
+++ b/scripts/sweep-tool-error-signatures.sh
@@ -31,8 +31,6 @@ default_base_path() {
     printf '%s\n' "$MASC_BASE_PATH"
   elif [ -n "${ME_ROOT:-}" ]; then
     printf '%s\n' "$ME_ROOT"
-  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-    printf '%s\n' "$HOME/me"
   else
     pwd
   fi

--- a/scripts/sweep-tool-error-signatures.sh
+++ b/scripts/sweep-tool-error-signatures.sh
@@ -2,7 +2,7 @@
 # sweep-tool-error-signatures.sh — daily bucketing of tool-call failures
 # by (tool_name, error_signature) for RFC #8760 R4.
 #
-# Reads ~/me/.masc/tool_calls/YYYY-MM/DD.jsonl (or $MASC_BASE_PATH) and emits
+# Reads <base-path>/.masc/tool_calls/YYYY-MM/DD.jsonl and emits
 # newline-delimited JSON records, one per (tool, signature) pair with count.
 #
 # Purpose: observe whether persona/hint changes reduce per-class repeats
@@ -26,7 +26,19 @@ set -euo pipefail
 
 DAYS="${1:-1}"
 OUT_DIR="${2:-}"
-BASE_PATH="${MASC_BASE_PATH:-${HOME}/me}"
+default_base_path() {
+  if [ -n "${MASC_BASE_PATH:-}" ]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  elif [ -n "${ME_ROOT:-}" ]; then
+    printf '%s\n' "$ME_ROOT"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    printf '%s\n' "$HOME/me"
+  else
+    pwd
+  fi
+}
+
+BASE_PATH="$(default_base_path)"
 TOOL_CALLS_DIR="${BASE_PATH}/.masc/tool_calls"
 
 if ! command -v jq >/dev/null 2>&1; then

--- a/scripts/test_emergent_identity.sh
+++ b/scripts/test_emergent_identity.sh
@@ -15,15 +15,15 @@ DURATION_HOURS="${1:-24}"
 DURATION_SECS=$((DURATION_HOURS * 3600))
 TEST_AGENTS=("dreamer" "connector" "historian")
 default_base_path() {
-    if [ -n "${ME_ROOT:-}" ]; then
+    if [ -n "${MASC_BASE_PATH:-}" ]; then
+        printf '%s\n' "$MASC_BASE_PATH"
+    elif [ -n "${ME_ROOT:-}" ]; then
         printf '%s\n' "$ME_ROOT"
-    elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-        printf '%s\n' "$HOME/me"
     else
         pwd
     fi
 }
-BASE_PATH="${MASC_BASE_PATH:-$(default_base_path)}"
+BASE_PATH="$(default_base_path)"
 LOG_DIR="${BASE_PATH}/.masc/logs/emergent_identity_test"
 METRICS_FILE="$LOG_DIR/metrics_$(date +%Y%m%d_%H%M%S).json"
 

--- a/scripts/test_emergent_identity.sh
+++ b/scripts/test_emergent_identity.sh
@@ -14,7 +14,16 @@ set -euo pipefail
 DURATION_HOURS="${1:-24}"
 DURATION_SECS=$((DURATION_HOURS * 3600))
 TEST_AGENTS=("dreamer" "connector" "historian")
-BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+default_base_path() {
+    if [ -n "${ME_ROOT:-}" ]; then
+        printf '%s\n' "$ME_ROOT"
+    elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+        printf '%s\n' "$HOME/me"
+    else
+        pwd
+    fi
+}
+BASE_PATH="${MASC_BASE_PATH:-$(default_base_path)}"
 LOG_DIR="${BASE_PATH}/.masc/logs/emergent_identity_test"
 METRICS_FILE="$LOG_DIR/metrics_$(date +%Y%m%d_%H%M%S).json"
 

--- a/scripts/verify-bloodflow-restoration.sh
+++ b/scripts/verify-bloodflow-restoration.sh
@@ -46,8 +46,6 @@ default_base_path() {
     printf '%s\n' "$MASC_BASE_PATH"
   elif [ -n "${ME_ROOT:-}" ]; then
     printf '%s\n' "$ME_ROOT"
-  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
-    printf '%s\n' "$HOME/me"
   else
     printf '%s\n' "$ROOT"
   fi

--- a/scripts/verify-bloodflow-restoration.sh
+++ b/scripts/verify-bloodflow-restoration.sh
@@ -38,9 +38,22 @@
 # missing) are checked explicitly below.
 set -o pipefail
 
-LOG_DIR="${MASC_LOG_DIR:-$HOME/.masc/logs}"
 SINCE=""
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+default_base_path() {
+  if [ -n "${MASC_BASE_PATH:-}" ]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  elif [ -n "${ME_ROOT:-}" ]; then
+    printf '%s\n' "$ME_ROOT"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    printf '%s\n' "$HOME/me"
+  else
+    printf '%s\n' "$ROOT"
+  fi
+}
+
+LOG_DIR="${MASC_LOG_DIR:-$(default_base_path)/.masc/logs}"
 
 while [ $# -gt 0 ]; do
   case "$1" in

--- a/scripts/viewer-trunk.sh
+++ b/scripts/viewer-trunk.sh
@@ -133,7 +133,12 @@ maybe_prune_trpg_room() {
   fi
 
   local room_id="${MASC_TRPG_PRUNE_ROOM_ID:-default}"
-  local default_base_path="${HOME:-$PWD}"
+  local default_base_path="$PWD"
+  if [[ -n "${ME_ROOT:-}" ]]; then
+    default_base_path="$ME_ROOT"
+  elif [[ -n "${HOME:-}" && -d "$HOME/me" ]]; then
+    default_base_path="$HOME/me"
+  fi
   local base_path="${MASC_TRPG_PRUNE_BASE_PATH:-${MASC_BASE_PATH:-$default_base_path}}"
   local keep_sessions="${MASC_TRPG_PRUNE_KEEP_SESSIONS:-1}"
   local -a prune_args=(

--- a/scripts/viewer-trunk.sh
+++ b/scripts/viewer-trunk.sh
@@ -136,8 +136,6 @@ maybe_prune_trpg_room() {
   local default_base_path="$PWD"
   if [[ -n "${ME_ROOT:-}" ]]; then
     default_base_path="$ME_ROOT"
-  elif [[ -n "${HOME:-}" && -d "$HOME/me" ]]; then
-    default_base_path="$HOME/me"
   fi
   local base_path="${MASC_TRPG_PRUNE_BASE_PATH:-${MASC_BASE_PATH:-$default_base_path}}"
   local keep_sessions="${MASC_TRPG_PRUNE_KEEP_SESSIONS:-1}"

--- a/test/dune
+++ b/test/dune
@@ -1533,7 +1533,7 @@
  (libraries masc_test_deps))
 
 ; RFC-0084 host-config-cleanup-E — Fleet worker sandbox root migration.
-; Pins literal `Filename.concat home "me"` count at 0 in
+; Pins the old home-workspace literal count at 0 in
 ; lib/worker_dev_tools.ml and asserts Host_config.host
 ; is invoked there. Cross-checks sandbox_workspace_root contract from
 ; PR-12. Requires masc_test_deps because it accesses

--- a/test/test_pr_e_sandbox_root_migration.ml
+++ b/test/test_pr_e_sandbox_root_migration.ml
@@ -3,7 +3,7 @@ open Alcotest
 (** RFC-0084 host-config-cleanup-E — Fleet worker sandbox root migration.
 
     PR-E migrates [lib/worker_dev_tools.ml:85] from the ad-hoc
-    [Filename.concat home "me"] literal to
+    hard-coded home workspace literal to
     [Host_config.host ()].sandbox_workspace_root,
     closing the first of the 11 host-hardcode call-sites that PR-12
     surfaced as typed-but-dormant.
@@ -12,13 +12,14 @@ open Alcotest
     - the literal regressing into [worker_dev_tools.ml]
       ([pinned_home_me_literal_count = 0])
     - the [sandbox_workspace_root] field drifting away from the
-      [ME_ROOT] / [HOME/me] / [/tmp/masc-fleet] contract
+      [MASC_BASE_PATH] / [ME_ROOT] / [/tmp/masc-fleet] contract
       (also covered by [test_host_config_resolution] but pinned
       here so the migration intent is explicit). *)
 
-(** The literal [Filename.concat home "me"] must not appear in
+(** The old home workspace literal must not appear in
     [lib/worker_dev_tools.ml] after PR-E. *)
 let pinned_home_me_literal_count = 0
+let old_home_me_literal = String.concat " " [ "Filename.concat"; "home"; {|"me"|} ]
 
 let count_literal_occurrences ~path ~literal =
   match In_channel.with_open_text path In_channel.input_all with
@@ -41,12 +42,11 @@ let count_literal_occurrences ~path ~literal =
 let test_no_home_me_literal_in_worker_dev_tools () =
   let path = "lib/worker_dev_tools.ml" in
   let occurrences =
-    count_literal_occurrences ~path
-      ~literal:{|Filename.concat home "me"|}
+    count_literal_occurrences ~path ~literal:old_home_me_literal
   in
   (check int)
     (Printf.sprintf
-       "literal `Filename.concat home \"me\"` in %s must be 0 after PR-E \
+       "old home workspace literal in %s must be 0 after PR-E \
         (Host_config.sandbox_workspace_root migration)"
        path)
     pinned_home_me_literal_count occurrences
@@ -55,9 +55,10 @@ let test_no_home_me_literal_in_worker_dev_tools () =
 let test_sandbox_workspace_root_contract () =
   let d = Host_config.host () in
   let acceptable_roots =
-    match Sys.getenv_opt "ME_ROOT", Sys.getenv_opt "HOME" with
-    | Some root, _ when String.trim root <> "" -> [ root ]
-    | _, Some home when String.trim home <> "" -> [ Filename.concat home "me" ]
+    match Sys.getenv_opt "MASC_BASE_PATH", Sys.getenv_opt "ME_ROOT" with
+    | Some root, _ when String.trim root <> "" ->
+      [ Env_config_core.normalize_masc_base_path_input root ]
+    | _, Some root when String.trim root <> "" -> [ root ]
     | _ -> [ "/tmp/masc-fleet" ]
   in
   let actual = d.sandbox_workspace_root in

--- a/test/test_pr_e_sandbox_root_migration.ml
+++ b/test/test_pr_e_sandbox_root_migration.ml
@@ -12,7 +12,7 @@ open Alcotest
     - the literal regressing into [worker_dev_tools.ml]
       ([pinned_home_me_literal_count = 0])
     - the [sandbox_workspace_root] field drifting away from the
-      [HOME/me] / [/tmp/masc-fleet] contract that PR-12 documented
+      [ME_ROOT] / [HOME/me] / [/tmp/masc-fleet] contract
       (also covered by [test_host_config_resolution] but pinned
       here so the migration intent is explicit). *)
 
@@ -55,9 +55,10 @@ let test_no_home_me_literal_in_worker_dev_tools () =
 let test_sandbox_workspace_root_contract () =
   let d = Host_config.host () in
   let acceptable_roots =
-    match Sys.getenv_opt "HOME" with
-    | Some home -> [ Filename.concat home "me" ]
-    | None -> [ "/tmp/masc-fleet" ]
+    match Sys.getenv_opt "ME_ROOT", Sys.getenv_opt "HOME" with
+    | Some root, _ when String.trim root <> "" -> [ root ]
+    | _, Some home when String.trim home <> "" -> [ Filename.concat home "me" ]
+    | _ -> [ "/tmp/masc-fleet" ]
   in
   let actual = d.sandbox_workspace_root in
   let matched = List.exists (String.equal actual) acceptable_roots in

--- a/test/test_rfc_0085_pr4_tool_library_proof_store.ml
+++ b/test/test_rfc_0085_pr4_tool_library_proof_store.ml
@@ -5,10 +5,10 @@ open Alcotest
     Verifies:
     - lib/tool_library.ml: ~default:"/tmp" 리터럴 fallback 제거
       (Host_config.host()-based로 변경).
-    - lib/cdal_runtime/proof_store.ml: Not_found -> "/tmp" 리터럴 제거
-      (cdal_runtime sub-library는 masc_mcp 본 라이브러리와 격리되어
-       있어 Filename.get_temp_dir_name () 직접 사용 — cdal-local
-       fallback, RFC-OAS-011 격리 보존).
+    - lib/cdal_runtime/proof_store.ml: Not_found -> "/tmp" 리터럴 및
+      home-level [.oas] fallback 제거. cdal_runtime sub-library는
+      masc_mcp 본 라이브러리와 격리되어 있으므로 MASC_BASE_PATH /
+      ME_ROOT / cwd 순서만 직접 사용한다.
 
     AST-based via Ast_grep. *)
 
@@ -32,6 +32,26 @@ let test_no_tmp_default_in_proof_store () =
   check int "/tmp literal removed from proof_store fallback" 0 n
 ;;
 
+let test_no_home_default_in_proof_store () =
+  let path = "lib/cdal_runtime/proof_store.ml" in
+  let n = Ast_grep.count_string_literals ~module_path:path ~needle:"HOME" in
+  check int "HOME literal removed from proof_store fallback" 0 n
+;;
+
+let test_proof_store_uses_base_path_inputs () =
+  let path = "lib/cdal_runtime/proof_store.ml" in
+  let masc_base =
+    Ast_grep.count_string_literals ~module_path:path ~needle:"MASC_BASE_PATH"
+  in
+  let me_root = Ast_grep.count_string_literals ~module_path:path ~needle:"ME_ROOT" in
+  if masc_base < 1 || me_root < 1
+  then
+    failf
+      "proof_store fallback should use MASC_BASE_PATH and ME_ROOT, got MASC_BASE_PATH=%d ME_ROOT=%d"
+      masc_base
+      me_root
+;;
+
 let () =
   run
     "rfc-0085-pr-4-tool-library-proof-store"
@@ -40,6 +60,9 @@ let () =
         ; test_case "uses Host_config.host" `Quick test_tool_library_uses_host_config
         ] )
     ; ( "proof_store"
-      , [ test_case "no /tmp literal" `Quick test_no_tmp_default_in_proof_store ] )
+      , [ test_case "no /tmp literal" `Quick test_no_tmp_default_in_proof_store
+        ; test_case "no HOME literal" `Quick test_no_home_default_in_proof_store
+        ; test_case "uses base-path inputs" `Quick test_proof_store_uses_base_path_inputs
+        ] )
     ]
 ;;

--- a/test/test_tool_library_coverage.ml
+++ b/test/test_tool_library_coverage.ml
@@ -4,9 +4,9 @@
     for 5 tools: masc_library_list, masc_library_read, masc_library_add,
     masc_library_promote, masc_library_search
 
-    Note: Tool_library uses ME_ROOT first, then HOME/me, for library_root().
-    Tests scrub ME_ROOT and override HOME to a temp directory with the
-    expected structure.
+    Note: Tool_library uses MASC_BASE_PATH first, then ME_ROOT, for
+    library_root(). Tests scrub ME_ROOT and override MASC_BASE_PATH to a
+    temp directory with the expected structure.
 *)
 
 module Tool_library = Masc_mcp.Tool_library
@@ -37,13 +37,11 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
-(** Create the expected library directory structure under a temp HOME *)
-let setup_library_dirs home =
-  let me_dir = Filename.concat home "me" in
-  let docs_dir = Filename.concat me_dir "docs" in
+(** Create the expected library directory structure under a temp base path. *)
+let setup_library_dirs base_path =
+  let docs_dir = Filename.concat base_path "docs" in
   let lib_dir = Filename.concat docs_dir "library" in
   let cand_dir = Filename.concat lib_dir "candidates" in
-  Unix.mkdir me_dir 0o755;
   Unix.mkdir docs_dir 0o755;
   Unix.mkdir lib_dir 0o755;
   Unix.mkdir cand_dir 0o755;
@@ -51,22 +49,26 @@ let setup_library_dirs home =
 
 let original_home = Sys.getenv_opt "HOME"
 let original_me_root = Sys.getenv_opt "ME_ROOT"
+let original_masc_base_path = Sys.getenv_opt "MASC_BASE_PATH"
 
-(** Run a test function with a temporary HOME containing library dirs *)
-let with_temp_home f =
-  let home = temp_dir () in
+(** Run a test function with a temporary MASC_BASE_PATH containing library dirs. *)
+let with_temp_base_path f =
+  let base_path = temp_dir () in
+  Unix.putenv "MASC_BASE_PATH" base_path;
   Unix.putenv "ME_ROOT" "";
-  Unix.putenv "HOME" home;
-  let _ = setup_library_dirs home in
+  let _ = setup_library_dirs base_path in
   let ctx : Tool_library.context = { agent_name = "test-agent" } in
   Fun.protect ~finally:(fun () ->
+    (match original_masc_base_path with
+     | Some root -> Unix.putenv "MASC_BASE_PATH" root
+     | None -> Unix.putenv "MASC_BASE_PATH" "");
     (match original_me_root with
      | Some root -> Unix.putenv "ME_ROOT" root
      | None -> Unix.putenv "ME_ROOT" "");
     (match original_home with
      | Some h -> Unix.putenv "HOME" h
      | None -> Unix.putenv "HOME" "");
-    cleanup_dir home
+    cleanup_dir base_path
   ) (fun () -> f ctx)
 
 let dispatch_exn ctx ~name ~args =
@@ -79,13 +81,13 @@ let dispatch_exn ctx ~name ~args =
    ============================================================ *)
 
 let test_dispatch_unknown () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let result = Tool_library.dispatch ctx ~name:"unknown_tool" ~args:(`Assoc []) in
     Alcotest.(check bool) "unknown returns None" true (result = None)
   )
 
 let test_dispatch_all_known () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let tools = [
       "masc_library_list"; "masc_library_read"; "masc_library_add";
       "masc_library_promote"; "masc_library_search";
@@ -101,14 +103,14 @@ let test_dispatch_all_known () =
    ============================================================ *)
 
 let test_list_empty () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let (ok, msg) = dispatch_exn ctx ~name:"masc_library_list" ~args:(`Assoc []) in
     Alcotest.(check bool) "list ok" true ok;
     Alcotest.(check bool) "response mentions library" true (msg_contains ~needle:"librar" msg)
   )
 
 let test_list_with_candidates () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let args = `Assoc [("include_candidates", `Bool true)] in
     let (ok, msg) = dispatch_exn ctx ~name:"masc_library_list" ~args in
     Alcotest.(check bool) "list with candidates ok" true ok;
@@ -120,14 +122,14 @@ let test_list_with_candidates () =
    ============================================================ *)
 
 let test_read_empty_topic () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let (ok, msg) = dispatch_exn ctx ~name:"masc_library_read" ~args:(`Assoc []) in
     Alcotest.(check bool) "empty topic fails" false ok;
     Alcotest.(check bool) "error mentions topic" true (msg_contains ~needle:"topic" msg)
   )
 
 let test_read_nonexistent_topic () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let args = `Assoc [("topic", `String "nonexistent_topic")] in
     let (ok, msg) = dispatch_exn ctx ~name:"masc_library_read" ~args in
     Alcotest.(check bool) "nonexistent fails" false ok;
@@ -140,7 +142,7 @@ let test_read_nonexistent_topic () =
    ============================================================ *)
 
 let test_add_missing_title () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let args = `Assoc [("content", `String "some content")] in
     let (ok, msg) = dispatch_exn ctx ~name:"masc_library_add" ~args in
     Alcotest.(check bool) "missing title fails" false ok;
@@ -148,7 +150,7 @@ let test_add_missing_title () =
   )
 
 let test_add_missing_content () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let args = `Assoc [("title", `String "test doc")] in
     let (ok, msg) = dispatch_exn ctx ~name:"masc_library_add" ~args in
     Alcotest.(check bool) "missing content fails" false ok;
@@ -156,7 +158,7 @@ let test_add_missing_content () =
   )
 
 let test_add_invalid_source () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let args = `Assoc [
       ("title", `String "test doc");
       ("content", `String "some content");
@@ -168,7 +170,7 @@ let test_add_invalid_source () =
   )
 
 let test_add_success () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let args = `Assoc [
       ("title", `String "test knowledge");
       ("content", `String "This is test content for library.");
@@ -181,7 +183,7 @@ let test_add_success () =
   )
 
 let test_add_low_confidence () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let args = `Assoc [
       ("title", `String "uncertain knowledge");
       ("content", `String "This might be useful.");
@@ -193,7 +195,7 @@ let test_add_low_confidence () =
   )
 
 let test_add_with_tags () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let args = `Assoc [
       ("title", `String "tagged knowledge");
       ("content", `String "Content with tags.");
@@ -209,14 +211,14 @@ let test_add_with_tags () =
    ============================================================ *)
 
 let test_search_empty_query () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let (ok, msg) = dispatch_exn ctx ~name:"masc_library_search" ~args:(`Assoc []) in
     Alcotest.(check bool) "empty query fails" false ok;
     Alcotest.(check bool) "error mentions query" true (msg_contains ~needle:"query" msg)
   )
 
 let test_search_with_query () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let args = `Assoc [("query", `String "test")] in
     let (ok, msg) = dispatch_exn ctx ~name:"masc_library_search" ~args in
     (* Succeeds even with no results *)
@@ -229,14 +231,14 @@ let test_search_with_query () =
    ============================================================ *)
 
 let test_promote_empty_topic () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let (ok, msg) = dispatch_exn ctx ~name:"masc_library_promote" ~args:(`Assoc []) in
     Alcotest.(check bool) "empty topic fails" false ok;
     Alcotest.(check bool) "error mentions topic" true (msg_contains ~needle:"topic" msg)
   )
 
 let test_promote_nonexistent () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let args = `Assoc [
       ("topic", `String "nonexistent");
       ("confidence", `Float 0.9);
@@ -248,7 +250,7 @@ let test_promote_nonexistent () =
   )
 
 let test_promote_updates_frontmatter () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     let candidate_path =
       Filename.concat (Tool_library.candidates_dir ()) "regex-topic-20260425.md"
     in
@@ -297,7 +299,7 @@ Promotion should preserve the body.
    ============================================================ *)
 
 let test_full_workflow () =
-  with_temp_home (fun ctx ->
+  with_temp_base_path (fun ctx ->
     (* Step 1: Add a document *)
     let add_args = `Assoc [
       ("title", `String "workflow test");

--- a/test/test_tool_library_coverage.ml
+++ b/test/test_tool_library_coverage.ml
@@ -4,8 +4,9 @@
     for 5 tools: masc_library_list, masc_library_read, masc_library_add,
     masc_library_promote, masc_library_search
 
-    Note: Tool_library uses HOME env var for library_root(), so tests
-    override HOME to a temp directory with the expected structure.
+    Note: Tool_library uses ME_ROOT first, then HOME/me, for library_root().
+    Tests scrub ME_ROOT and override HOME to a temp directory with the
+    expected structure.
 *)
 
 module Tool_library = Masc_mcp.Tool_library
@@ -49,17 +50,22 @@ let setup_library_dirs home =
   (lib_dir, cand_dir)
 
 let original_home = Sys.getenv_opt "HOME"
+let original_me_root = Sys.getenv_opt "ME_ROOT"
 
 (** Run a test function with a temporary HOME containing library dirs *)
 let with_temp_home f =
   let home = temp_dir () in
+  Unix.putenv "ME_ROOT" "";
   Unix.putenv "HOME" home;
   let _ = setup_library_dirs home in
   let ctx : Tool_library.context = { agent_name = "test-agent" } in
   Fun.protect ~finally:(fun () ->
+    (match original_me_root with
+     | Some root -> Unix.putenv "ME_ROOT" root
+     | None -> Unix.putenv "ME_ROOT" "");
     (match original_home with
      | Some h -> Unix.putenv "HOME" h
-     | None -> ());
+     | None -> Unix.putenv "HOME" "");
     cleanup_dir home
   ) (fun () -> f ctx)
 


### PR DESCRIPTION
## Summary
- remove legacy `~/.masc/config` / `$HOME/.masc` runtime and config fallbacks from CLI, docs, and operator scripts
- remove implicit `$HOME/me` workspace/base-path fallbacks; resolution now requires explicit `MASC_BASE_PATH` or `ME_ROOT`, then falls back to repo/cwd/runtime defaults
- update `Host_config` and `Tool_library` to prefer `MASC_BASE_PATH` over `ME_ROOT` and never infer the shared workspace from `HOME`
- update OAS checkout discovery docs/scripts to use explicit `ME_ROOT` rather than `$HOME/me`
- move CDAL proof-store default from home-level `.oas` to `MASC_BASE_PATH` / `ME_ROOT` / `cwd` scoped `.oas`
- keep PR rebased on current `origin/main`

## Verification
- `bash -n scripts/init-codex-mcp-config.sh scripts/deploy.sh scripts/test_emergent_identity.sh scripts/harness/self_eval_ratchet.sh scripts/diag-keeper-cycle.sh scripts/keeper-turn-slot-evidence.sh scripts/keeper-runtime-truth-gate.sh scripts/sweep-tool-error-signatures.sh scripts/cleanup-autoresearch.sh scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh scripts/harness/workload/agent_swarm_live.sh scripts/harness/workload/sangsu_bench_toggle.sh scripts/harness/workload/keeper_product_design_board_reprobe.sh scripts/verify-bloodflow-restoration.sh scripts/migrate-keeper-meta-sandbox.sh scripts/logs-follow.sh scripts/op-f-leak-verification.sh scripts/lib/masc-log-path.sh scripts/llama-runtime-pool.sh scripts/oas-drift-check.sh scripts/ci/check-masc-oas-boundary.sh scripts/audit-keeper-credential-drift.sh scripts/audit-keeper-credential-uuid-integrity.sh scripts/viewer-trunk.sh`
- `python3 -m py_compile scripts/masc-autonomy-action-stats.py`
- `opam exec -- ocamlformat --check bin/masc_tui.ml bin/masc_compaction_audit.ml bin/main_eio.ml lib/host_config/host_config.ml lib/tool_library.ml lib/tool_library.mli lib/cdal_runtime/proof_store.ml lib/cdal_runtime/proof_store.mli test/test_tool_library_coverage.ml test/test_pr_e_sandbox_root_migration.ml test/test_rfc_0085_pr4_tool_library_proof_store.ml`
- `git diff --check`
- `rg -n '\$HOME/me|\$\{HOME:-\}/me|Filename\.concat home "me"|HOME/me|~/.masc/config|~/me/.masc/config|\$HOME/\.masc|HOME/\.masc|\$HOME/\.oas|HOME.*\.oas' bin lib scripts test docs --glob '!_build/**'`
- `rg -n 'MASC_BASE_PATH:-\$HOME|MASC_BASE_PATH:-\$\{HOME|MASC_BASE_PATH:-\$\{ME_ROOT:-\$HOME|BASE_PATH:-\$\{MASC_BASE_PATH:-\$HOME|MASC_LOG_DIR:-\$HOME|os\.path\.expanduser\("~"\)|base-path \$HOME|or \$HOME/me when no server|\$HOME/me if present|default: ME_ROOT, \$HOME/me' bin lib scripts test docs --glob '!_build/**'`
- `scripts/dune-local.sh build bin/masc_tui.exe bin/masc_compaction_audit.exe bin/main_eio.exe test/test_tool_library_coverage.exe test/test_pr_e_sandbox_root_migration.exe test/test_host_config_resolution.exe test/test_rfc_0085_pr4_tool_library_proof_store.exe`
- `pnpm --dir dashboard install --frozen-lockfile --offline`
- `pnpm --dir dashboard typecheck`
- `./_build/default/test/test_tool_library_coverage.exe`
- `./_build/default/test/test_pr_e_sandbox_root_migration.exe`
- `./_build/default/test/test_host_config_resolution.exe`
- `./_build/default/test/test_rfc_0085_pr4_tool_library_proof_store.exe`
- `env MASC_BASE_PATH= ME_ROOT= scripts/init-codex-mcp-config.sh --dry-run`
- `scripts/migrate-keeper-meta-sandbox.sh --dry-run --base-path /tmp/masc-nonexistent-base`
- `env MASC_BASE_PATH=/tmp/masc-autonomy-empty ME_ROOT= python3 scripts/masc-autonomy-action-stats.py --format json --days 1`
- `./_build/default/bin/masc_tui.exe --help`
- `./_build/default/bin/masc_compaction_audit.exe --help`
