### PR TITLE
test: align verifier lifecycle expectations

### DIFF
--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -868,7 +868,7 @@ let () = test "handle_transition_verifier_allows_verdict_actions" (fun () ->
           [
             ("task_id", `String "task-001");
             ("action", `String "submit_for_verification");
-            ("notes", `String "ready for verifier");
+            ("notes", `String "ready for verifier; path:test/test_tool_task_coverage.ml");
           ])
     in
     if not submit_result.Tool_result.success then

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -475,7 +475,7 @@ let test_claim_next_skips_pending_verification_tasks () =
     Coord.claim_next_r config ~agent_name:"other" ()
     |> expect_claim_next_no_unclaimed)
 
-let test_claim_next_skips_rejected_verification_tasks () =
+let test_claim_next_preserves_rejected_verification_tasks () =
   with_temp_config ~fsm_enabled:true (fun config ->
     let task_1 = add_strict_task config in
     let task_2 = add_strict_task config in
@@ -499,9 +499,9 @@ let test_claim_next_skips_rejected_verification_tasks () =
      | Ok _ -> ()
      | Error e -> Alcotest.fail ("submit_verdict failed: " ^ e));
     Coord.claim_next_r config ~agent_name:"worker" ()
-    |> expect_claim_next_claimed ~task_id:task_2 ~released_task_id:(Some task_1);
+    |> expect_claim_next_claimed ~task_id:task_1 ~released_task_id:None;
     Coord.claim_next_r config ~agent_name:"other" ()
-    |> expect_claim_next_no_eligible)
+    |> expect_claim_next_claimed ~task_id:task_2 ~released_task_id:None)
 
 let test_claim_next_blocks_pending_requests_stored_only_under_masc_root () =
   with_temp_config ~fsm_enabled:true (fun config ->
@@ -711,8 +711,8 @@ let () =
         test_reject_prepare_failure_keeps_task_awaiting;
       Alcotest.test_case "claim_next skips pending verification tasks" `Quick
         test_claim_next_skips_pending_verification_tasks;
-      Alcotest.test_case "claim_next skips rejected verification tasks" `Quick
-        test_claim_next_skips_rejected_verification_tasks;
+      Alcotest.test_case "claim_next preserves rejected verification tasks" `Quick
+        test_claim_next_preserves_rejected_verification_tasks;
       Alcotest.test_case ".masc pending verification blocks claim_next" `Quick
         test_claim_next_blocks_pending_requests_stored_only_under_masc_root;
       Alcotest.test_case "self-approval blocked" `Quick


### PR DESCRIPTION
## Summary

- Align `claim_next` verification FSM coverage with the current #10421 preservation policy: rejected verification returns the original worker task instead of implicitly releasing it.
- Add verifier submission evidence to the tool-task verifier action test so it satisfies the current `submit_for_verification` evidence gate.

Refs #15748. This only fixes the stale verifier lifecycle test expectations; the CDAL writer reconnection remains a separate slice.

## Validation

- `opam exec -- ocamlformat --check test/test_verification_fsm.ml test/test_tool_task_coverage.ml`
- `git diff --check origin/main...HEAD`
- `bash scripts/check-release-train-guard.sh --base origin/main --head HEAD` (passes with existing pending-release warning)
- `env MASC_SKIP_PIN_CHECK=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_verification_fsm.exe test/test_tool_task_coverage.exe`
- `_build/default/test/test_verification_fsm.exe` (20 tests)
- `_build/default/test/test_tool_task_coverage.exe` (79 tests)