### PR TITLE
fix(cdal): restore keeper contract capture

### DIFF
--- a/lib/keeper/keeper_cdal_contract.ml
+++ b/lib/keeper/keeper_cdal_contract.ml
@@ -1,4 +1,43 @@
-(* Team session contract system removed (#6107). *)
-let of_keeper_meta (_meta : Keeper_types.keeper_meta)
-    : Masc_mcp_cdal_runtime.Risk_contract.t option =
-  None
+module RC = Masc_mcp_cdal_runtime.Risk_contract
+module EM = Masc_mcp_cdal_runtime.Execution_mode
+module RK = Masc_mcp_cdal_runtime.Risk_class
+
+let string_list_to_json values =
+  `List (List.map (fun value -> `String value) values)
+;;
+
+let string_opt_to_json = function
+  | None -> `Null
+  | Some value -> `String value
+;;
+
+let task_id_opt_to_json = function
+  | None -> `Null
+  | Some task_id -> `String (Keeper_id.Task_id.to_string task_id)
+;;
+
+let of_keeper_meta (meta : Keeper_types.keeper_meta) : RC.t option =
+  let runtime_constraints : RC.runtime_constraints =
+    { requested_execution_mode = EM.Execute
+    ; risk_class = RK.Low
+    ; allowed_mutations = []
+    ; review_requirement = None
+    }
+  in
+  let eval_criteria =
+    `Assoc
+      [ "kind", `String "keeper_turn_capture_v1"
+      ; "keeper_name", `String meta.name
+      ; "agent_name", `String meta.agent_name
+      ; "sandbox_profile", `String (Keeper_types.sandbox_profile_to_string meta.sandbox_profile)
+      ; "network_mode", `String (Keeper_types.network_mode_to_string meta.network_mode)
+      ; "sandbox_image", string_opt_to_json meta.sandbox_image
+      ; "tool_access", Keeper_types.tool_access_to_json meta.tool_access
+      ; "tool_denylist", string_list_to_json meta.tool_denylist
+      ; "allowed_paths", string_list_to_json meta.allowed_paths
+      ; "active_goal_ids", string_list_to_json meta.active_goal_ids
+      ; "current_task_id_at_start", task_id_opt_to_json meta.current_task_id
+      ]
+  in
+  Some { RC.runtime_constraints; eval_criteria }
+;;

--- a/lib/keeper/keeper_cdal_contract.mli
+++ b/lib/keeper/keeper_cdal_contract.mli
@@ -1,5 +1,7 @@
-(** Risk-contract projection of a [keeper_meta].  Currently always
-    returns [None]; the prior contract derivation pipeline was
-    removed in #6107 and no replacement has been wired in. *)
+(** Risk-contract projection of a [keeper_meta].
+
+    Keeper turns use a capture-only contract: it asks CDAL/OAS to record
+    proof and effect evidence for the turn without adding an extra review
+    gate or tightening the keeper's already-configured tool policy. *)
 val of_keeper_meta :
   Keeper_types.keeper_meta -> Masc_mcp_cdal_runtime.Risk_contract.t option

--- a/test/dune
+++ b/test/dune
@@ -753,6 +753,7 @@
         test_cdal_judge
         test_cdal_verifiable_markers
         test_cdal_eval_v1
+        test_keeper_cdal_contract
         test_cdal_friction_projection
         test_cdal_verdict_gate
         test_cdal_mode_enforcer
@@ -974,6 +975,7 @@
         test_cdal_judge
         test_cdal_verifiable_markers
         test_cdal_eval_v1
+        test_keeper_cdal_contract
         test_cdal_friction_projection
         test_cdal_verdict_gate
         test_cdal_mode_enforcer

--- a/test/test_cdal_eval_v1.ml
+++ b/test/test_cdal_eval_v1.ml
@@ -259,6 +259,43 @@ let test_persist_explicit_base_dir_avoids_default_resolution () =
          (CL.load_error_to_string err))
 ;;
 
+let test_persist_task_id_envelope () =
+  let store, tmp = setup_store () in
+  let run_id = "persist-task-id-envelope" in
+  let contract = make_contract () in
+  let contract_id = Masc_mcp_cdal_runtime.Risk_contract.contract_id contract in
+  let proof = make_proof ~run_id ~contract_id () in
+  Masc_mcp_cdal_runtime.Proof_store.init_run store ~run_id;
+  Masc_mcp_cdal_runtime.Proof_store.write_manifest store ~run_id proof;
+  Masc_mcp_cdal_runtime.Proof_store.write_contract store ~run_id contract;
+  match CE.evaluate ~store proof with
+  | Verdict (v, _) ->
+    let base_dir = Filename.concat tmp "cdal_verdicts" in
+    Eio_main.run
+    @@ fun _env ->
+    CE.persist ~base_dir ~task_id:"task-cdal-123" v;
+    let verdict_store = Dated_jsonl.create ~base_dir () in
+    (match Dated_jsonl.read_recent verdict_store 1 with
+     | [ `Assoc fields ] ->
+       (match List.assoc_opt "_task_id" fields with
+        | Some (`String task_id) ->
+          Alcotest.(check string) "task id envelope" "task-cdal-123" task_id
+        | Some json ->
+          Alcotest.fail
+            (Printf.sprintf
+               "expected _task_id string, got %s"
+               (Yojson.Safe.to_string json))
+        | None -> Alcotest.fail "expected _task_id envelope field")
+     | rows ->
+       Alcotest.fail
+         (Printf.sprintf "expected one persisted row, got %d" (List.length rows)))
+  | Load_failure (err, _) ->
+    Alcotest.fail
+      (Printf.sprintf
+         "expected Verdict, got Load_failure: %s"
+         (CL.load_error_to_string err))
+;;
+
 (* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
@@ -281,6 +318,10 @@ let () =
             "persist explicit base_dir avoids default resolution"
             `Quick
             test_persist_explicit_base_dir_avoids_default_resolution
+        ; Alcotest.test_case
+            "persist task_id envelope"
+            `Quick
+            test_persist_task_id_envelope
         ] )
     ]
 ;;

--- a/test/test_keeper_cdal_contract.ml
+++ b/test/test_keeper_cdal_contract.ml
@@ -1,0 +1,109 @@
+open Alcotest
+open Masc_mcp
+
+module RC = Masc_mcp_cdal_runtime.Risk_contract
+module EM = Masc_mcp_cdal_runtime.Execution_mode
+module RK = Masc_mcp_cdal_runtime.Risk_class
+
+let make_meta ?(name = "cdal-keeper") ?current_task_id () =
+  let fields =
+    [ "name", `String name
+    ; "agent_name", `String (name ^ "-agent")
+    ; "trace_id", `String "cdal-contract-trace"
+    ; "sandbox_profile", `String "local"
+    ; "network_mode", `String "none"
+    ; "allowed_paths", `List [ `String "/workspace/project" ]
+    ; "active_goal_ids", `List [ `String "goal-cdal" ]
+    ; "tool_access", Keeper_types.tool_access_to_json (Keeper_types.Custom [ "keeper_bash" ])
+    ]
+  in
+  let fields =
+    match current_task_id with
+    | None -> fields
+    | Some task_id -> ("current_task_id", `String task_id) :: fields
+  in
+  match Masc_test_deps.meta_of_json_fixture (`Assoc fields) with
+  | Ok meta -> meta
+  | Error err -> failwith ("make_meta failed: " ^ err)
+;;
+
+let require_contract meta =
+  match Keeper_cdal_contract.of_keeper_meta meta with
+  | Some contract -> contract
+  | None -> fail "expected keeper CDAL contract"
+;;
+
+let member key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some value -> value
+     | None -> failf "missing JSON member %s" key)
+  | json -> failf "expected object while reading %s, got %s" key (Yojson.Safe.to_string json)
+;;
+
+let check_json_string key expected json =
+  match member key json with
+  | `String actual -> check string key expected actual
+  | value -> failf "expected %s to be string, got %s" key (Yojson.Safe.to_string value)
+;;
+
+let check_json_list key expected json =
+  match member key json with
+  | `List values ->
+    let actual =
+      List.map
+        (function
+          | `String value -> value
+          | value -> failf "expected %s entries to be strings, got %s" key (Yojson.Safe.to_string value))
+        values
+    in
+    check (list string) key expected actual
+  | value -> failf "expected %s to be list, got %s" key (Yojson.Safe.to_string value)
+;;
+
+let test_keeper_meta_projects_capture_only_contract () =
+  let meta = make_meta ~current_task_id:"task-cdal-001" () in
+  let contract = require_contract meta in
+  let constraints = contract.RC.runtime_constraints in
+  check string "requested mode" "execute" (EM.to_string constraints.requested_execution_mode);
+  check string "risk class" "low" (RK.to_string constraints.risk_class);
+  check (list string) "allowed mutations" [] constraints.allowed_mutations;
+  check (option string) "review requirement" None constraints.review_requirement;
+  let criteria = contract.RC.eval_criteria in
+  check_json_string "kind" "keeper_turn_capture_v1" criteria;
+  check_json_string "keeper_name" "cdal-keeper" criteria;
+  check_json_string "agent_name" "cdal-keeper-agent" criteria;
+  check_json_string "sandbox_profile" "local" criteria;
+  check_json_string "network_mode" "none" criteria;
+  check_json_string "current_task_id_at_start" "task-cdal-001" criteria;
+  check_json_list "allowed_paths" [ "/workspace/project" ] criteria;
+  check_json_list "active_goal_ids" [ "goal-cdal" ] criteria;
+  match member "tool_access" criteria with
+  | `Assoc _ as tool_access ->
+    check_json_string "kind" "custom" tool_access;
+    check_json_list "tools" [ "keeper_bash" ] tool_access
+  | value -> failf "expected tool_access object, got %s" (Yojson.Safe.to_string value)
+;;
+
+let test_contract_id_is_stable_for_same_meta () =
+  let meta = make_meta () in
+  let first = require_contract meta in
+  let second = require_contract meta in
+  check string "contract id" (RC.contract_id first) (RC.contract_id second)
+;;
+
+let () =
+  Alcotest.run
+    "keeper_cdal_contract"
+    [ ( "projection"
+      , [ test_case
+            "keeper meta projects capture-only contract"
+            `Quick
+            test_keeper_meta_projects_capture_only_contract
+        ; test_case
+            "contract id stable for same keeper meta"
+            `Quick
+            test_contract_id_is_stable_for_same_meta
+        ] )
+    ]
+;;

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -868,7 +868,7 @@ let () = test "handle_transition_verifier_allows_verdict_actions" (fun () ->
           [
             ("task_id", `String "task-001");
             ("action", `String "submit_for_verification");
-            ("notes", `String "ready for verifier");
+            ("notes", `String "artifact: verifier-evidence.json ready for verifier");
           ])
     in
     if not submit_result.Tool_result.success then

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -475,7 +475,7 @@ let test_claim_next_skips_pending_verification_tasks () =
     Coord.claim_next_r config ~agent_name:"other" ()
     |> expect_claim_next_no_unclaimed)
 
-let test_claim_next_skips_rejected_verification_tasks () =
+let test_claim_next_preserves_rejected_verification_owner_task () =
   with_temp_config ~fsm_enabled:true (fun config ->
     let task_1 = add_strict_task config in
     let task_2 = add_strict_task config in
@@ -499,9 +499,9 @@ let test_claim_next_skips_rejected_verification_tasks () =
      | Ok _ -> ()
      | Error e -> Alcotest.fail ("submit_verdict failed: " ^ e));
     Coord.claim_next_r config ~agent_name:"worker" ()
-    |> expect_claim_next_claimed ~task_id:task_2 ~released_task_id:(Some task_1);
+    |> expect_claim_next_claimed ~task_id:task_1 ~released_task_id:None;
     Coord.claim_next_r config ~agent_name:"other" ()
-    |> expect_claim_next_no_eligible)
+    |> expect_claim_next_claimed ~task_id:task_2 ~released_task_id:None)
 
 let test_claim_next_blocks_pending_requests_stored_only_under_masc_root () =
   with_temp_config ~fsm_enabled:true (fun config ->
@@ -711,8 +711,8 @@ let () =
         test_reject_prepare_failure_keeps_task_awaiting;
       Alcotest.test_case "claim_next skips pending verification tasks" `Quick
         test_claim_next_skips_pending_verification_tasks;
-      Alcotest.test_case "claim_next skips rejected verification tasks" `Quick
-        test_claim_next_skips_rejected_verification_tasks;
+      Alcotest.test_case "claim_next preserves rejected owner task" `Quick
+        test_claim_next_preserves_rejected_verification_owner_task;
       Alcotest.test_case ".masc pending verification blocks claim_next" `Quick
         test_claim_next_blocks_pending_requests_stored_only_under_masc_root;
       Alcotest.test_case "self-approval blocked" `Quick


### PR DESCRIPTION
## Summary

- Replace the keeper CDAL contract stub with a capture-only risk contract so CDAL-enabled keeper turns can produce proof/verdict artifacts again.
- Add regression coverage for keeper contract projection and `_task_id` verdict envelopes.
- Update verifier lifecycle coverage to match current policy: rejected owner tasks are preserved until explicit release, and `submit_for_verification` requires concrete evidence.

Refs #15748. This reconnects the keeper-side CDAL writer source and fixes the stale targeted tests. Live fresh-turn proof emission and dashboard active/dormant surfacing still need runtime confirmation before closing the whole incident.

## Validation

- `opam exec -- ocamlformat --check lib/keeper/keeper_cdal_contract.ml lib/keeper/keeper_cdal_contract.mli test/test_cdal_eval_v1.ml test/test_keeper_cdal_contract.ml test/test_tool_task_coverage.ml test/test_verification_fsm.ml`
- `git diff --check origin/main...HEAD`
- `bash scripts/check-release-train-guard.sh --base origin/main --head HEAD` (passes with existing pending-release warning)
- Direct isolated test executable runs passed:
  - `_build/default/test/test_keeper_cdal_contract.exe` (2 tests)
  - `_build/default/test/test_cdal_eval_v1.exe` (6 tests)
  - `_build/default/test/test_verification_fsm.exe` (20 tests)
  - `_build/default/test/test_tool_task_coverage.exe` (79 tests)

Note: a post-check wrapper rebuild was blocked by unrelated `/tmp/me-dune-local.lock` contention from another worktree; CI is the clean post-push build surface.