### PR TITLE
fix(keeper): classify typed path-check prefixes

### DIFF
--- a/lib/keeper/keeper_failure_circuit_breaker.ml
+++ b/lib/keeper/keeper_failure_circuit_breaker.ml
@@ -51,16 +51,29 @@ type error_class =
   | Shell_exit_nonzero
   | Other
 
+module Path_check_error = Keeper_path_check_error
+
+let classify_path_check_prefix (error_msg : string) : error_class option =
+  match Path_check_error.parse_prefix error_msg with
+  | Some (Path_check_error.Cwd_not_directory _) -> Some Cwd_not_directory
+  | Some (Path_check_error.Path_outside_whitelist _) -> Some Path_not_allowed
+  | Some (Path_check_error.Path_syntax_blocked _) -> Some Other
+  | None -> None
+;;
+
 let classify_error (error_msg : string) : error_class =
   if String.length error_msg = 0 then Other
   else
-    let contains sub = String_util.contains_substring error_msg sub in
-    if contains "path_not_found" then Path_not_found
-    else if contains "path_not_in_allowed" || contains "path_outside_sandbox" then Path_not_allowed
-    else if contains "cwd_not_directory" then Cwd_not_directory
-    else if contains "No such file or directory" then Path_not_found
-    else if contains "exit" && contains "code" then Shell_exit_nonzero
-    else Other
+    match classify_path_check_prefix error_msg with
+    | Some cls -> cls
+    | None ->
+      let contains sub = String_util.contains_substring error_msg sub in
+      if contains "path_not_found" then Path_not_found
+      else if contains "path_not_in_allowed" || contains "path_outside_sandbox" then Path_not_allowed
+      else if contains "cwd_not_directory" then Cwd_not_directory
+      else if contains "No such file or directory" then Path_not_found
+      else if contains "exit" && contains "code" then Shell_exit_nonzero
+      else Other
 
 let error_class_to_string = function
   | Path_not_found -> "path_not_found"

--- a/test/test_circuit_breaker.ml
+++ b/test/test_circuit_breaker.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module CB = Masc_mcp.Keeper_failure_circuit_breaker
+module PCE = Masc_mcp.Keeper_path_check_error
 
 let contains haystack needle =
   let nl = String.length needle and hl = String.length haystack in
@@ -21,6 +22,26 @@ let test_classify_path_not_found () =
 let test_classify_path_not_allowed () =
   check bool "path_not_allowed" true
     (CB.classify_error "path_not_in_allowed_paths: /x" = CB.Path_not_allowed)
+
+let test_classify_typed_path_check_prefixes () =
+  let cwd_msg =
+    PCE.to_message (PCE.Cwd_not_directory { path = ".worktrees/missing"; hint = None })
+  in
+  check bool "typed cwd_not_directory prefix" true
+    (CB.classify_error cwd_msg = CB.Cwd_not_directory);
+  let blocked_msg =
+    PCE.to_message
+      (PCE.Path_outside_whitelist
+         { path = "/etc/passwd"; for_keeper_command = true })
+  in
+  check bool "typed path blocked prefix" true
+    (CB.classify_error blocked_msg = CB.Path_not_allowed);
+  let syntax_msg =
+    PCE.to_message
+      (PCE.Path_syntax_blocked { token = "'quoted'"; hint = None })
+  in
+  check bool "typed syntax prefix keeps existing coarse class" true
+    (CB.classify_error syntax_msg = CB.Other)
 
 let test_classify_other () =
   check bool "other" true
@@ -312,6 +333,8 @@ let () =
     "classify", [
       test_case "path_not_found" `Quick test_classify_path_not_found;
       test_case "path_not_allowed" `Quick test_classify_path_not_allowed;
+      test_case "typed path-check prefixes" `Quick
+        test_classify_typed_path_check_prefixes;
       test_case "other" `Quick test_classify_other;
     ];
     "signatures", [


### PR DESCRIPTION
## Summary

- Route `Keeper_failure_circuit_breaker.classify_error` through `Keeper_path_check_error.parse_prefix` before legacy substring fallback.
- Classify typed `cwd_not_directory:` as `Cwd_not_directory` and typed `Path blocked:` as `Path_not_allowed`.
- Keep typed `Path syntax blocked:` on the existing coarse `Other` class to avoid changing the hint semantics without a new error class.

Refs #15551 and #9521. This is the post-#15684 classifier migration slice, not the full worktree lifecycle fix.

## Validation

- `opam exec -- ocamlformat --check lib/keeper/keeper_failure_circuit_breaker.ml test/test_circuit_breaker.ml`
- `git diff --check`
- `bash scripts/check-release-train-guard.sh --base origin/main --head HEAD` (passes with existing pending-release warning)
- `env MASC_SKIP_PIN_CHECK=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_circuit_breaker.exe`
- `_build/default/test/test_circuit_breaker.exe` (28 tests)