### PR TITLE
fix(keeper): gate voice tools by policy

### DIFF
--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -338,6 +338,21 @@ let resolve_policy_group ~(fallback : string list) (group_name : string) : strin
           group_name (List.length fallback);
         fallback)
 
+let keeper_voice_tool_names () =
+  resolve_policy_group
+    ~fallback:
+      [ "keeper_voice_speak"
+      ; "keeper_voice_listen"
+      ; "keeper_voice_agent"
+      ; "keeper_voice_sessions"
+      ; "keeper_voice_session_start"
+      ; "keeper_voice_session_end"
+      ]
+    "voice"
+
+let voice_tools_allowed_by_policy (meta : keeper_meta) =
+  if meta.policy_voice_enabled then keeper_voice_tool_names () else []
+
 (** Optional tools that require explicit opt-in via also_allow.
     Reads [groups.optional] from tool_policy.toml; falls back to
     hardcoded list when config is absent. *)
@@ -394,17 +409,25 @@ let preset_allowlist preset =
         [])
 
 let tool_policy_of_meta (meta : keeper_meta) =
+  let voice_tools = keeper_voice_tool_names () in
+  let policy_voice_allow =
+    if meta.policy_voice_enabled then voice_tools else []
+  in
+  let policy_voice_deny =
+    if meta.policy_voice_enabled then [] else voice_tools
+  in
   let allow =
     match meta.tool_access with
     | Preset { preset; also_allow } ->
         Tool_access_policy.Names
-          (preset_allowlist preset @ keeper_safe_inline_tools @ also_allow)
+          (preset_allowlist preset @ keeper_safe_inline_tools @ also_allow
+           @ policy_voice_allow)
     | Custom allowlist ->
-        Tool_access_policy.Names allowlist
+        Tool_access_policy.Names (allowlist @ policy_voice_allow)
   in
   {
     Tool_access_policy.allow;
-    deny = Tool_access_policy.Names meta.tool_denylist;
+    deny = Tool_access_policy.Names (meta.tool_denylist @ policy_voice_deny);
   }
 
 module StringSet = Set.Make (String)
@@ -424,7 +447,9 @@ let tool_name_set names =
 let tool_access_lookup_of_meta (meta : keeper_meta) =
   let candidate_names =
     dedupe_tool_names
-      (keeper_base_candidate_tool_names () @ explicit_optional_candidate_tool_names meta)
+      (keeper_base_candidate_tool_names ()
+       @ explicit_optional_candidate_tool_names meta
+       @ voice_tools_allowed_by_policy meta)
   in
   let candidate_set = tool_name_set candidate_names in
   let allow_names =

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -445,9 +445,21 @@ let tool_name_set names =
   List.fold_left (fun acc name -> StringSet.add name acc) StringSet.empty names
 
 let tool_access_lookup_of_meta (meta : keeper_meta) =
+  (* keeper_base_candidate_tool_names already pulls [groups.voice] from
+     tool_policy.toml via all_group_tools, so disabling
+     policy_voice_enabled must subtract voice tools here — otherwise they
+     remain in candidate_set and stay discoverable via filter_by_universe
+     even though they are dropped from allow_set. *)
+  let base = keeper_base_candidate_tool_names () in
+  let base_after_voice_policy =
+    if meta.policy_voice_enabled then base
+    else
+      let voice_set = tool_name_set (keeper_voice_tool_names ()) in
+      List.filter (fun name -> not (StringSet.mem name voice_set)) base
+  in
   let candidate_names =
     dedupe_tool_names
-      (keeper_base_candidate_tool_names ()
+      (base_after_voice_policy
        @ explicit_optional_candidate_tool_names meta
        @ voice_tools_allowed_by_policy meta)
   in

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -124,6 +124,36 @@ let test_default_has_no_legacy_governance_tools () =
   check bool "case brief submit removed" false (has_tool "masc_case_brief_submit" tools)
 ;;
 
+let voice_tools =
+  [ "keeper_voice_speak"
+  ; "keeper_voice_listen"
+  ; "keeper_voice_agent"
+  ; "keeper_voice_sessions"
+  ; "keeper_voice_session_start"
+  ; "keeper_voice_session_end"
+  ]
+;;
+
+let test_voice_policy_enabled_exposes_voice_tools () =
+  let meta =
+    make_meta ~policy_voice_enabled:true ~preset:Keeper_types.Coding ()
+  in
+  let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  List.iter
+    (fun name -> check bool (name ^ " exposed") true (has_tool name tools))
+    voice_tools
+;;
+
+let test_voice_policy_disabled_hides_voice_tools () =
+  let meta =
+    make_meta ~policy_voice_enabled:false ~preset:Keeper_types.Social ()
+  in
+  let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  List.iter
+    (fun name -> check bool (name ^ " hidden") false (has_tool name tools))
+    voice_tools
+;;
+
 let test_coding_preset_hides_autoresearch_tools () =
   let meta = make_meta ~preset:Keeper_types.Coding () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
@@ -1196,6 +1226,14 @@ let () =
             "legacy governance tools removed"
             `Quick
             test_default_has_no_legacy_governance_tools
+        ; test_case
+            "voice policy enabled exposes voice tools"
+            `Quick
+            test_voice_policy_enabled_exposes_voice_tools
+        ; test_case
+            "voice policy disabled hides voice tools"
+            `Quick
+            test_voice_policy_disabled_hides_voice_tools
         ; test_case
             "coding preset hides autoresearch tools"
             `Quick


### PR DESCRIPTION
## Summary
- Make `policy_voice_enabled=true` expose the keeper voice tool group even for presets such as `coding` that do not include the voice group.
- Make `policy_voice_enabled=false` deny voice tools even if a preset includes the voice group.
- Add regression coverage for both enabled and disabled voice policy behavior.

## Verification
- `scripts/dune-local.sh build test/test_keeper_tool_exposure.exe`
- `./_build/default/test/test_keeper_tool_exposure.exe`
- `ocamlformat --check lib/keeper/keeper_tool_policy.ml test/test_keeper_tool_exposure.ml`
- `git diff --check origin/main..HEAD`