### PR TITLE
fix(keeper): honor repo mapping in bash path validation

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -996,7 +996,12 @@ let handle_keeper_bash
              Keeper_task_worktree_lazy.ensure_command_existing_dirs ~config ~meta ~cwd ~cmd
            with
            | Error e -> Error e
-           | Ok () -> Worker_dev_tools.validate_command_paths ~workdir:cwd cmd
+           | Ok () ->
+             Worker_dev_tools.validate_command_paths
+               ~keeper_id:meta.name
+               ~base_path:root
+               ~workdir:cwd
+               cmd
           in
           match path_validation with
           | Error e -> error_json ~fields:["blocked_cmd", `String cmd_for_log] e

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -839,7 +839,12 @@ let run_docker_shell_command_with_status_internal
                ~cmd:validation_cmd
            with
            | Error e -> Error e
-           | Ok () -> Worker_dev_tools.validate_command_paths ~workdir:cwd validation_cmd)
+           | Ok () ->
+             Worker_dev_tools.validate_command_paths
+               ~keeper_id:meta.name
+               ~base_path:(Keeper_alerting_path.project_root_of_config config)
+               ~workdir:cwd
+               validation_cmd)
         else Ok ()
       in
       match path_validation with
@@ -1116,7 +1121,12 @@ let run_docker_with_git_bash
                ~cmd:validation_cmd
            with
            | Error e -> Error e
-           | Ok () -> Worker_dev_tools.validate_command_paths ~workdir:cwd validation_cmd
+           | Ok () ->
+             Worker_dev_tools.validate_command_paths
+               ~keeper_id:meta.name
+               ~base_path:(Keeper_alerting_path.project_root_of_config config)
+               ~workdir:cwd
+               validation_cmd
          in
          (match path_validation with
           | Error err -> sandbox_error_json (Printf.sprintf "%s [blocked_cmd=%s]" err validation_cmd)
@@ -1200,7 +1210,12 @@ let run_docker_hardened_bash
             ~cmd:validation_cmd
         with
         | Error e -> Error e
-        | Ok () -> Worker_dev_tools.validate_command_paths ~workdir:cwd validation_cmd
+        | Ok () ->
+          Worker_dev_tools.validate_command_paths
+            ~keeper_id:meta.name
+            ~base_path:(Keeper_alerting_path.project_root_of_config config)
+            ~workdir:cwd
+            validation_cmd
       in
       (match path_validation with
        | Error err -> sandbox_error_json (Printf.sprintf "%s [blocked_cmd=%s]" err validation_cmd)

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -105,8 +105,25 @@ let worktree_repo_root_of_workdir workdir =
     surfaces a documented fallback ([/tmp/masc-fleet]) which is allowed.
     This aligns the Fleet worker with the same SSOT that other keeper
     sandbox surfaces will migrate to in later cleanup PRs. *)
-let validate_path ?workdir path =
+let keeper_registered_repo_path_allowed ?keeper_id ?base_path path =
+  match keeper_id, base_path with
+  | Some keeper_id, Some base_path -> (
+    match Keeper_repo_mapping.repository_id_of_path ~base_path ~path with
+    | None -> false
+    | Some repository_id ->
+      (match
+         Keeper_repo_mapping.validate_access ~keeper_id ~repository_id ~base_path
+       with
+       | Ok () -> true
+       | Error _ -> false))
+  | _ -> false
+;;
+
+let validate_path ?keeper_id ?base_path ?workdir path =
   let resolved = resolve_path ?base_dir:workdir path in
+  let registered_repo_allowed =
+    keeper_registered_repo_path_allowed ?keeper_id ?base_path resolved
+  in
   match workdir with
   | Some wd ->
     let resolved_wd = resolve_path wd in
@@ -118,11 +135,13 @@ let validate_path ?workdir path =
     is_within_dir ~dir:(resolve_path "/tmp") resolved
     || is_within_dir ~dir:resolved_wd resolved
     || within_worktree_repo_root
+    || registered_repo_allowed
   | None ->
     let cfg = Host_config.host () in
     is_within_dir ~dir:(resolve_path "/tmp") resolved
     || is_within_dir ~dir:(resolve_path (Sys.getcwd ())) resolved
     || is_within_dir ~dir:(resolve_path cfg.sandbox_workspace_root) resolved
+    || registered_repo_allowed
 ;;
 
 let tool_error ?(recoverable = false) message : Agent_sdk.Types.tool_result =
@@ -916,12 +935,12 @@ let existing_dir_path_values cmd =
   cmd |> tokenize_path_args |> path_validation_tokens |> loop false []
 ;;
 
-let validate_command_paths ?workdir cmd =
+let validate_command_paths ?keeper_id ?base_path ?workdir cmd =
   match workdir with
   | None -> Ok ()
   | Some _ ->
       let validate_path_value ~requires_existing_dir token =
-        if not (validate_path ?workdir token.value)
+        if not (validate_path ?keeper_id ?base_path ?workdir token.value)
         then
           Error
             (Keeper_path_check_error.(

--- a/lib/worker_dev_tools.mli
+++ b/lib/worker_dev_tools.mli
@@ -79,11 +79,18 @@ val validate_command_coding_with_allowlist
   -> (unit, block_reason) result
 
 (** When [workdir] is supplied, gate every path-bearing token in [cmd]
-    against {!Path_compat.validate_path}.  Returns [Error msg] with the
-    rejected token (or a path-rewrite-syntax reminder) when a token
-    escapes [workdir].  Returns [Ok ()] unconditionally when
-    [workdir = None]. *)
-val validate_command_paths : ?workdir:string -> string -> (unit, string) result
+    against the shell path allowlist. Tokens may stay under [workdir],
+    [/tmp], the owning worktree repo root, or a registered repository path
+    allowed by {!Keeper_repo_mapping} when both [keeper_id] and [base_path]
+    are supplied. Returns [Error msg] with the rejected token (or a
+    path-rewrite-syntax reminder) when a token escapes the allowlist.
+    Returns [Ok ()] unconditionally when [workdir = None]. *)
+val validate_command_paths
+  :  ?keeper_id:string
+  -> ?base_path:string
+  -> ?workdir:string
+  -> string
+  -> (unit, string) result
 
 (** Return path values in [cmd] that the shell validator treats as
     existing-directory requirements (for example [git -C <dir>] and

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -18,6 +18,81 @@ let contains_substring s needle =
   in
   if n_len = 0 then true else loop 0
 
+let rec ensure_dir path =
+  if path = "" || path = "." || path = "/" || Sys.file_exists path then ()
+  else (
+    ensure_dir (Filename.dirname path);
+    Unix.mkdir path 0o755)
+
+let rec cleanup_path path =
+  if Sys.file_exists path then
+    match Unix.lstat path with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+      Array.iter
+        (fun name -> cleanup_path (Filename.concat path name))
+        (Sys.readdir path);
+      Unix.rmdir path
+    | _ -> Sys.remove path
+
+let registered_repo id local_path : Repo_manager_types.repository =
+  { id
+  ; name = id
+  ; url = "https://github.com/example/" ^ id ^ ".git"
+  ; local_path
+  ; aliases = []
+  ; default_branch = "main"
+  ; credential_id = ""
+  ; keepers = []
+  ; status = Repo_manager_types.Active
+  ; auto_sync = false
+  ; sync_interval = 0
+  ; created_at = 0L
+  ; updated_at = 0L
+  }
+
+let with_registered_repo_fixture f =
+  let base_path =
+    Filename.concat
+      (Sys.getcwd ())
+      (Printf.sprintf "_worker_dev_tools_repo_mapping_%d" (Unix.getpid ()))
+  in
+  let workdir = Filename.temp_file "wdt_repo_mapping_cwd_" "" in
+  Fun.protect
+    ~finally:(fun () ->
+      (try cleanup_path base_path with _ -> ());
+      try cleanup_path workdir with _ -> ())
+    (fun () ->
+       if Sys.file_exists base_path then cleanup_path base_path;
+       Sys.remove workdir;
+       Unix.mkdir workdir 0o755;
+       let repo_a_dir = Filename.concat base_path "repo-a" in
+       let repo_b_dir = Filename.concat base_path "repo-b" in
+       let target = Filename.concat repo_a_dir "lib/foo.ml" in
+       ensure_dir (Filename.dirname target);
+       ensure_dir repo_b_dir;
+       ensure_dir workdir;
+       (match
+          Repo_store.save_all
+            ~base_path
+            [ registered_repo "repo-a" repo_a_dir
+            ; registered_repo "repo-b" repo_b_dir
+            ]
+        with
+        | Ok () -> ()
+        | Error msg -> Alcotest.fail ("repo store setup failed: " ^ msg));
+       let save_mapping keeper_id repository_ids =
+         match
+           Keeper_repo_mapping.save_mapping
+             ~base_path
+             { keeper_id; repository_ids; github_credential_id = None }
+         with
+         | Ok () -> ()
+         | Error msg -> Alcotest.fail ("mapping setup failed: " ^ msg)
+       in
+       save_mapping "keeper-1" [ "repo-a" ];
+       save_mapping "keeper-2" [ "repo-b" ];
+       f ~base_path ~workdir ~target)
+
 (* --- Tool structure tests --- *)
 
 let test_tool_count () =
@@ -1105,6 +1180,61 @@ let () =
               | Error msg ->
                 Alcotest.fail
                   ("own repo path from worktree cwd rejected: " ^ msg)));
+      Alcotest.test_case
+        "registered repo path is blocked without keeper context"
+        `Quick
+        (fun () ->
+          with_registered_repo_fixture
+            (fun ~base_path:_ ~workdir ~target ->
+               match
+                 Worker_dev_tools.validate_command_paths
+                   ~workdir
+                   (Printf.sprintf "cat %s" target)
+               with
+               | Error msg ->
+                 Alcotest.(check bool)
+                   "outside path blocked"
+                   true
+                   (contains_substring msg "outside allowed directories")
+               | Ok () ->
+                 Alcotest.fail
+                   "registered repo path must still need keeper context"));
+      Alcotest.test_case
+        "registered repo path is allowed for mapped keeper"
+        `Quick
+        (fun () ->
+          with_registered_repo_fixture
+            (fun ~base_path ~workdir ~target ->
+               match
+                 Worker_dev_tools.validate_command_paths
+                   ~keeper_id:"keeper-1"
+                   ~base_path
+                   ~workdir
+                   (Printf.sprintf "cat %s" target)
+               with
+               | Ok () -> ()
+               | Error msg ->
+                 Alcotest.fail ("mapped repo path rejected: " ^ msg)));
+      Alcotest.test_case
+        "registered repo path is denied for mismatched keeper mapping"
+        `Quick
+        (fun () ->
+          with_registered_repo_fixture
+            (fun ~base_path ~workdir ~target ->
+               match
+                 Worker_dev_tools.validate_command_paths
+                   ~keeper_id:"keeper-2"
+                   ~base_path
+                   ~workdir
+                   (Printf.sprintf "cat %s" target)
+               with
+               | Error msg ->
+                 Alcotest.(check bool)
+                   "outside path blocked"
+                   true
+                   (contains_substring msg "outside allowed directories")
+               | Ok () ->
+                 Alcotest.fail "unmapped keeper must not inherit repo path access"));
       Alcotest.test_case "git -C missing worktree is cwd_not_directory"
         `Quick (fun () ->
           let workdir = Filename.temp_file "wdt_git_c_" "" in


### PR DESCRIPTION
## Summary

- Teach `Worker_dev_tools.validate_command_paths` to accept registered repository paths only when both keeper identity and base path are supplied and `Keeper_repo_mapping` allows that keeper for the target repo.
- Pass keeper identity/base path from keeper bash and Docker bash validation paths so own-repo absolute paths no longer fail solely because they are outside the current cwd/workdir allowlist.
- Add regression coverage that registered repo paths stay blocked without keeper context, pass for the mapped keeper, and remain blocked for a mismatched keeper mapping.

Refs #15545. This patches the split path-authority root cause; keep the issue open until live runtime confirms the 24h zero window.

## Validation

- `opam exec -- ocamlformat --check lib/worker_dev_tools.ml lib/worker_dev_tools.mli lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_shell_docker.ml test/test_worker_dev_tools.ml`
- `git diff --check origin/main...HEAD`
- `bash scripts/check-release-train-guard.sh --base origin/main --head HEAD` (passes with existing pending-release warning)
- `env MASC_SKIP_PIN_CHECK=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_worker_dev_tools.exe test/test_keeper_bash_safety.exe test/test_path_rewrite_validation.exe`
- `_build/default/test/test_worker_dev_tools.exe` (139 tests)
- `_build/default/test/test_keeper_bash_safety.exe` (43 tests)
- `_build/default/test/test_path_rewrite_validation.exe` (23 tests)