### PR TITLE
feat(server): delegate legacy respond_mcp_* to Mcp_error_code SSOT (RFC-0098 PR-2)

### DIFF
--- a/lib/server/server_mcp_transport_http_respond.ml
+++ b/lib/server/server_mcp_transport_http_respond.ml
@@ -38,49 +38,96 @@ let mcp_headers = Server_mcp_transport_http_headers.mcp_headers
 
 let json_headers = Server_mcp_transport_http_headers.json_headers
 
-let respond_mcp_auth_error ?(extra_headers = []) ~(deps : Server_mcp_transport_http_types.deps) request reqd ~session_id
-    ~protocol_version msg =
+(* RFC-0097 — typed SSOT for transport-boundary error envelopes.
+   New code should call [respond_mcp_error] with the typed
+   [Mcp_error_code.t] variant; the per-code factories below remain
+   as [@@deprecated] thin delegations during the migration window. *)
+
+(** Pure-JSON body builder shared by [respond_mcp_error] and
+    [mcp_internal_error_json]. Splitting it out makes the wire-shape
+    diffable and testable without instantiating an [Httpun.Reqd.t]. *)
+let error_body ?(id = `Null) ?data ~(code : Mcp_error_code.t) msg :
+    Yojson.Safe.t =
+  let error_fields =
+    let base =
+      [
+        ("code", `Int (Mcp_error_code.to_wire_code code));
+        ("message", `String msg);
+      ]
+    in
+    match data with Some d -> base @ [ ("data", d) ] | None -> base
+  in
+  `Assoc
+    [
+      ("jsonrpc", `String "2.0");
+      ("id", id);
+      ("error", `Assoc error_fields);
+    ]
+
+let respond_mcp_error ?(extra_headers = []) ?data ?id
+    ~(deps : Server_mcp_transport_http_types.deps) request reqd ~session_id
+    ~protocol_version ~(code : Mcp_error_code.t) msg =
   let origin = deps.get_origin request in
+  let id_for_body = Option.value ~default:`Null id in
   let body =
-    Yojson.Safe.to_string
-      (`Assoc
-        [
-          ("jsonrpc", `String "2.0");
-          ( "error",
-            `Assoc
-              [ ("code", `Int (-32001)); ("message", `String msg) ] );
-        ])
+    Yojson.Safe.to_string (error_body ~id:id_for_body ?data ~code msg)
+  in
+  (* Constructors qualified explicitly (Mcp_error_code.Auth_error rather
+     than bare Auth_error) — consistent with #15759 P1 review on the
+     legacy path; defence-in-depth against future loss of the
+     [~(code : Mcp_error_code.t)] type annotation or relocation. *)
+  let per_code_headers : (string * string) list =
+    match code with
+    | Mcp_error_code.Auth_error -> [ ("www-authenticate", "Bearer") ]
+    | Mcp_error_code.Not_ready -> [ ("retry-after", "2") ]
+    | Mcp_error_code.Backpressure_shed -> [ ("retry-after", "1") ]
+    | _ -> []
   in
   let headers =
     Httpun.Headers.of_list
       ((("content-length", string_of_int (String.length body))
-       :: ("www-authenticate", "Bearer")
-       :: extra_headers)
+       :: per_code_headers)
+      @ extra_headers
       @ json_headers ~deps session_id protocol_version origin)
   in
-  let response = Httpun.Response.create ~headers `Unauthorized in
+  let response =
+    Httpun.Response.create ~headers (Mcp_error_code.to_http_status code)
+  in
   safe_respond_with_string reqd response body
 
-let respond_mcp_internal_error ?(extra_headers = []) ~(deps : Server_mcp_transport_http_types.deps) request reqd
-    ~session_id ~protocol_version msg =
-  let origin = deps.get_origin request in
-  let body =
-    Yojson.Safe.to_string
-      (`Assoc
-        [
-          ("jsonrpc", `String "2.0");
-          ( "error",
-            `Assoc
-              [ ("code", `Int (-32603)); ("message", `String msg) ] );
-        ])
-  in
-  let headers =
-    Httpun.Headers.of_list
-      ((("content-length", string_of_int (String.length body)) :: extra_headers)
-      @ json_headers ~deps session_id protocol_version origin)
-  in
-  let response = Httpun.Response.create ~headers `Internal_server_error in
-  safe_respond_with_string reqd response body
+(* RFC-0097 PR-2 — thin delegations.
+
+   Wire-byte differences vs PR-1 baseline (documented intentional):
+
+   - JSON body now includes ["id": null] per JSON-RPC 2.0 §5.1 (error
+     responses MUST echo the request id or null when it cannot be
+     parsed). Previous bodies omitted the field — a spec violation
+     grandfathered until this PR.
+
+   - Headers: per-code header ordering is now [content-length ::
+     per-code :: extra :: json_headers] (was [content-length ::
+     per-code :: extra @ json_headers] for auth, equivalent here;
+     [content-length :: extra @ json_headers] for internal, with no
+     per-code header — equivalent here).
+
+   Out of PR-2 scope: [respond_not_ready] retains its bespoke
+   implementation because it runs before [session_id] /
+   [protocol_version] / [json_headers] are available (literal
+   [content-type: application/json] + raw [cors_headers] only).
+   PR-2.1 will introduce a sibling [respond_mcp_error_pre_ready] or
+   widen [respond_mcp_error] to handle the pre-runtime case. *)
+
+let respond_mcp_auth_error ?(extra_headers = [])
+    ~(deps : Server_mcp_transport_http_types.deps) request reqd ~session_id
+    ~protocol_version msg =
+  respond_mcp_error ~extra_headers ~deps request reqd ~session_id
+    ~protocol_version ~code:Mcp_error_code.Auth_error msg
+
+let respond_mcp_internal_error ?(extra_headers = [])
+    ~(deps : Server_mcp_transport_http_types.deps) request reqd ~session_id
+    ~protocol_version msg =
+  respond_mcp_error ~extra_headers ~deps request reqd ~session_id
+    ~protocol_version ~code:Mcp_error_code.Internal_error msg
 
 let respond_not_ready ~(deps : Server_mcp_transport_http_types.deps) request reqd =
   let origin = deps.get_origin request in
@@ -137,62 +184,7 @@ let respond_sse_rate_limited ~(deps : Server_mcp_transport_http_types.deps) ~ori
   safe_respond_with_string reqd response body
 
 let mcp_internal_error_json ?id msg =
-  `Assoc
-    [
-      ("jsonrpc", `String "2.0");
-      ("id", Option.value ~default:`Null id);
-      ("error", `Assoc [ ("code", `Int (-32603)); ("message", `String msg) ]);
-    ]
-
-(* RFC-0098 — typed SSOT for transport-boundary error envelopes. The
-   legacy factories above are intentionally untouched in PR-1 to
-   guarantee byte-exact wire on existing call paths; PR-2 migrates
-   them to delegations and documents the wire change (adding id:null
-   per JSON-RPC 2.0 §5.1). *)
-let respond_mcp_error ?(extra_headers = []) ?data ?id
-    ~(deps : Server_mcp_transport_http_types.deps) request reqd ~session_id
-    ~protocol_version ~(code : Mcp_error_code.t) msg =
-  let origin = deps.get_origin request in
-  let error_fields =
-    let base =
-      [
-        ("code", `Int (Mcp_error_code.to_wire_code code));
-        ("message", `String msg);
-      ]
-    in
-    match data with Some d -> base @ [ ("data", d) ] | None -> base
-  in
-  let body =
-    Yojson.Safe.to_string
-      (`Assoc
-        [
-          ("jsonrpc", `String "2.0");
-          (* DET-OK: JSON-RPC response id is request-bound wire data; absent id maps to protocol null at this HTTP boundary. *)
-          ("id", Option.value ~default:`Null id);
-          ("error", `Assoc error_fields);
-        ])
-  in
-  (* Constructors qualified explicitly (Mcp_error_code.Auth_error rather
-     than bare Auth_error) so the match is robust to future loss of the
-     [~(code : Mcp_error_code.t)] type annotation or to relocation of
-     the function. Bare constructors would compile today via OCaml's
-     type-directed disambiguation but the reviewer's defence-in-depth
-     concern (PR #15759 codex P1) is well-taken. *)
-  let per_code_headers : (string * string) list =
-    match code with
-    | Mcp_error_code.Auth_error -> [ ("www-authenticate", "Bearer") ]
-    | Mcp_error_code.Not_ready -> [ ("retry-after", "2") ]
-    | Mcp_error_code.Backpressure_shed -> [ ("retry-after", "1") ]
-    | _ -> []
-  in
-  let headers =
-    Httpun.Headers.of_list
-      ((("content-length", string_of_int (String.length body))
-       :: per_code_headers)
-      @ extra_headers
-      @ json_headers ~deps session_id protocol_version origin)
-  in
-  let response =
-    Httpun.Response.create ~headers (Mcp_error_code.to_http_status code)
-  in
-  safe_respond_with_string reqd response body
+  (* RFC-0097 PR-2: delegate to error_body SSOT. The duplicate
+     respond_mcp_error definition that lived here on the legacy path is
+     removed — PR-2's SSOT-using definition is at L67. *)
+  error_body ?id ~code:Mcp_error_code.Internal_error msg

--- a/lib/server/server_mcp_transport_http_respond.mli
+++ b/lib/server/server_mcp_transport_http_respond.mli
@@ -47,13 +47,22 @@ val respond_mcp_auth_error :
     ~session_id ~protocol_version msg] writes a JSON-RPC 2.0 error
     response with code [-32001] and HTTP status [401 Unauthorized].
 
+    {b RFC-0097 PR-2 (this PR)}: now delegates to {!respond_mcp_error}
+    with [~code:Auth_error]. New call sites SHOULD prefer
+    {!respond_mcp_error}. A follow-up PR-2.1 will migrate all in-tree
+    callers and add a [\[@@deprecated\]] alert.
+
     The response always carries [www-authenticate: Bearer]; this is
     pinned because the MCP client SDKs key off the literal challenge
     string when deciding whether to re-prompt for a token.  A future
     "support digest auth" change must extend the contract explicitly.
 
     [extra_headers] are prepended (operator-visible HTTP headers),
-    {!json_headers} append.  The function never raises. *)
+    {!json_headers} append.  The function never raises.
+
+    {b RFC-0097 PR-2 wire-byte change}: response body now contains
+    [["id":null]] per JSON-RPC 2.0 §5.1 (was previously omitted —
+    spec violation). *)
 
 val respond_mcp_internal_error :
   ?extra_headers:(string * string) list ->
@@ -69,10 +78,19 @@ val respond_mcp_internal_error :
     response with code [-32603] (the standard "Internal error" slot)
     and HTTP status [500 Internal Server Error].
 
+    {b RFC-0097 PR-2 (this PR)}: now delegates to {!respond_mcp_error}
+    with [~code:Internal_error]. New call sites SHOULD prefer
+    {!respond_mcp_error} and a more specific code variant where one
+    fits (e.g. [Provider_timeout], [Tool_dispatch_failure]).
+
     Used as the catch-all for runtime failures the transport cannot
     classify more precisely.  The wording of [msg] is operator-visible
     in JSON bodies — callers should keep it stable across builds so
-    grep alerts remain valid. *)
+    grep alerts remain valid.
+
+    {b RFC-0097 PR-2 wire-byte change}: response body now contains
+    [["id":null]] per JSON-RPC 2.0 §5.1 (was previously omitted —
+    spec violation). *)
 
 val respond_not_ready :
   deps:Server_mcp_transport_http_types.deps ->
@@ -130,7 +148,28 @@ val mcp_internal_error_json : ?id:Yojson.Safe.t -> string -> Yojson.Safe.t
     suitable for embedding in an SSE batch frame or a multi-response
     array.  When [id] is omitted, the field is set to [`Null] (per
     JSON-RPC 2.0 §5.1 — error responses must echo back the request id
-    or [null] when it cannot be parsed). *)
+    or [null] when it cannot be parsed).
+
+    {b RFC-0097 PR-2}: now delegates to {!error_body} with
+    [~code:Internal_error]. Wire bytes unchanged. *)
+
+val error_body :
+  ?id:Yojson.Safe.t ->
+  ?data:Yojson.Safe.t ->
+  code:Mcp_error_code.t ->
+  string ->
+  Yojson.Safe.t
+(** [error_body ?id ?data ~code msg] builds a JSON-RPC 2.0 error
+    object suitable for either a stand-alone response body or
+    embedding in an SSE batch / multi-response array. Splitting it
+    out makes the wire shape diffable and testable without
+    instantiating an [Httpun.Reqd.t].
+
+    Defaults: [id = `Null] (per JSON-RPC 2.0 §5.1), no [data] field.
+
+    Used internally by {!respond_mcp_error}; exposed here for callers
+    that build SSE batch frames (the {!mcp_internal_error_json}
+    use-case generalised to any {!Mcp_error_code.t}). *)
 
 val respond_mcp_error :
   ?extra_headers:(string * string) list ->

--- a/test/dune
+++ b/test/dune
@@ -25,7 +25,7 @@
 
 ; Group 1: Pure synchronous tests
 (tests
- (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_mcp_error_code test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
+ (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_mcp_error_code test_error_body_delegation test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
         test_keeper_turn_terminal_code_byte_compat
         test_keeper_sdk_error_typed_bridge
         test_read_drop_reason
@@ -273,7 +273,7 @@
         test_chronicle_librarian
         test_alignment_score
         )
- (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_mcp_error_code test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
+ (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_mcp_error_code test_error_body_delegation test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_keeper_turn_terminal_code_byte_compat
           test_keeper_sdk_error_typed_bridge
           test_read_drop_reason

--- a/test/test_error_body_delegation.ml
+++ b/test/test_error_body_delegation.ml
@@ -1,0 +1,141 @@
+(** Wire-shape assertions for RFC-0097 PR-2 delegation.
+
+    Pins down the JSON body produced by {!error_body} (the SSOT
+    introduced in PR-2) and documents the wire-byte change vs the
+    pre-PR-2 baseline: error responses now carry [["id": null]] per
+    JSON-RPC 2.0 §5.1, where the legacy hand-rolled bodies omitted
+    the field. *)
+
+open Alcotest
+module R = Masc_mcp.Server_mcp_transport_http_respond
+module C = Masc_mcp.Mcp_error_code
+
+(* JSON equality with stable key order: compare normalised string
+   forms. Yojson does not guarantee key order, but Yojson.Safe outputs
+   keys in insertion order; both sides build the assoc in the same
+   shape, so [Yojson.Safe.to_string] gives byte-comparable output. *)
+let json_eq (a : Yojson.Safe.t) (b : Yojson.Safe.t) =
+  Yojson.Safe.to_string a = Yojson.Safe.to_string b
+
+let pp_json fmt j = Format.pp_print_string fmt (Yojson.Safe.to_string j)
+let json_testable : Yojson.Safe.t Alcotest.testable = testable pp_json json_eq
+
+let test_error_body_includes_id_null_by_default () =
+  let body = R.error_body ~code:C.Internal_error "boom" in
+  let expected =
+    `Assoc
+      [
+        ("jsonrpc", `String "2.0");
+        ("id", `Null);
+        ( "error",
+          `Assoc
+            [
+              ("code", `Int (-32603));
+              ("message", `String "boom");
+            ] );
+      ]
+  in
+  check json_testable "id:null present per JSON-RPC 2.0 §5.1" expected body
+
+let test_error_body_echoes_request_id () =
+  let body =
+    R.error_body ~id:(`Int 42) ~code:C.Method_not_found "no such method"
+  in
+  let expected =
+    `Assoc
+      [
+        ("jsonrpc", `String "2.0");
+        ("id", `Int 42);
+        ( "error",
+          `Assoc
+            [
+              ("code", `Int (-32601));
+              ("message", `String "no such method");
+            ] );
+      ]
+  in
+  check json_testable "id echoes back when supplied" expected body
+
+let test_error_body_includes_data_when_supplied () =
+  let data = `Assoc [ ("provider", `String "anthropic"); ("budget_ms", `Int 30000) ] in
+  let body =
+    R.error_body ~data ~code:C.Provider_timeout "upstream stalled"
+  in
+  let expected =
+    `Assoc
+      [
+        ("jsonrpc", `String "2.0");
+        ("id", `Null);
+        ( "error",
+          `Assoc
+            [
+              ("code", `Int (-32003));
+              ("message", `String "upstream stalled");
+              ("data", data);
+            ] );
+      ]
+  in
+  check json_testable "data field included when supplied" expected body
+
+let test_mcp_internal_error_json_now_typed () =
+  (* The legacy [mcp_internal_error_json] is a thin delegation. It
+     must produce the same wire bytes as [error_body
+     ~code:Internal_error] — that is the PR-2 contract. *)
+  let via_legacy = R.mcp_internal_error_json "explosion" in
+  let via_ssot = R.error_body ~code:C.Internal_error "explosion" in
+  check json_testable "mcp_internal_error_json == error_body Internal_error"
+    via_ssot via_legacy
+
+let test_mcp_internal_error_json_with_id () =
+  let via_legacy = R.mcp_internal_error_json ~id:(`Int 7) "oops" in
+  let via_ssot = R.error_body ~id:(`Int 7) ~code:C.Internal_error "oops" in
+  check json_testable "mcp_internal_error_json ~id == error_body ~id"
+    via_ssot via_legacy
+
+let test_wire_byte_change_documented () =
+  (* Documents the intentional wire-byte change introduced by PR-2:
+     the response body now contains "id":null where it previously did
+     not. This is a one-way contract change — bumping for spec
+     compliance. *)
+  let pr1_baseline_no_id =
+    `Assoc
+      [
+        ("jsonrpc", `String "2.0");
+        ( "error",
+          `Assoc
+            [
+              ("code", `Int (-32001));
+              ("message", `String "Unauthorized");
+            ] );
+      ]
+  in
+  let pr2_with_id_null = R.error_body ~code:C.Auth_error "Unauthorized" in
+  let differ = Yojson.Safe.to_string pr1_baseline_no_id
+            <> Yojson.Safe.to_string pr2_with_id_null in
+  if not differ then
+    Alcotest.fail
+      "PR-2 should differ from PR-1 baseline by adding id:null; if this \
+       fails, the wire change was reverted unintentionally"
+
+let () =
+  Alcotest.run "Error_body_delegation"
+    [
+      ( "error_body wire shape",
+        [
+          test_case "id:null by default" `Quick
+            test_error_body_includes_id_null_by_default;
+          test_case "id echoes when supplied" `Quick
+            test_error_body_echoes_request_id;
+          test_case "data field when supplied" `Quick
+            test_error_body_includes_data_when_supplied;
+        ] );
+      ( "legacy delegation",
+        [
+          test_case "mcp_internal_error_json delegates" `Quick
+            test_mcp_internal_error_json_now_typed;
+          test_case "mcp_internal_error_json ~id delegates" `Quick
+            test_mcp_internal_error_json_with_id;
+          test_case "PR-2 wire-byte change is intentional" `Quick
+            test_wire_byte_change_documented;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

**Stacks on #15759** (RFC-0097 PR-1). Migrates the body-builder hand-rolls in `server_mcp_transport_http_respond.ml` to thin delegations calling the new `Mcp_error_code`-typed SSOT.

## What ships

| Item | Change |
|---|---|
| `error_body : ?id ?data ~code msg -> Yojson.Safe.t` | New pure JSON builder (SSOT for error envelope shape). Splitting it out keeps wire shape testable without `Httpun.Reqd.t`. |
| `respond_mcp_auth_error` | Now delegates: `respond_mcp_error ~code:Auth_error` |
| `respond_mcp_internal_error` | Now delegates: `respond_mcp_error ~code:Internal_error` |
| `mcp_internal_error_json` | Now delegates: `error_body ~code:Internal_error` |
| `respond_not_ready` | **Kept bespoke** — runs before `json_headers`/`session_id` available. Migration deferred to PR-2.1. |

## Wire-byte change (intentional, documented)

Response bodies via the three delegated functions now include **`"id": null`** per JSON-RPC 2.0 §5.1 (error responses MUST echo the request id or null). The pre-PR-2 bodies omitted the field — a long-standing spec violation now fixed at the chokepoint.

`test_error_body_delegation.ml::test_wire_byte_change_documented` asserts the difference is real (regression guard against silent revert).

## Out of scope (deferred to PR-2.1)

- `[@@deprecated]` alerts on legacy factories. Adding them now would escalate 13 caller sites in `server_mcp_transport_http.ml` + `server_mcp_transport_http_agui.ml` to build errors. Doc comments point new code at `respond_mcp_error`; alerts wired after callers migrate.
- Migration of those 13 caller sites to direct `respond_mcp_error` calls.

## Self-review (Best Programmer)

- **목표**: legacy 4 factory를 typed SSOT로 통합. PR-2는 *byte-changing* (id:null 추가) — 의도된 변경.
- **변경 파일**: 4 (respond.ml/mli, test/dune, new test).
- **로컬 검증**:
  - `dune build --root . lib/` → 통과 (silent)
  - `dune exec test/test_error_body_delegation.exe` → **6/6 OK**
  - `dune exec test/test_mcp_error_code.exe` → **7/7 OK** (PR-1 regression 없음)
- **남은 미검증**: full `@runtest` (CI), 13 caller deprecation migration (PR-2.1).

## Workaround rejection self-check

- [x] Not telemetry-as-fix — actual code consolidation, not measurement.
- [x] Not string/substring — typed `Mcp_error_code.t` discriminator.
- [x] Not N-of-M — explicit out-of-scope (13 callers) with named follow-up PR.
- [x] Wire-byte change is *spec-compliance*, not workaround — `id:null` aligns with JSON-RPC 2.0 §5.1.

## Test plan

- [ ] CI `dune build @runtest` green.
- [ ] CI `No inline ok/error-envelope literals` ratchet unaffected (delegations use typed `Mcp_error_code.to_wire_code`, not literal integer).
- [ ] Reviewer confirms wire-byte change against PR-1 baseline assertion in test.
- [ ] PR-2.1 follow-up migrates 13 callers + adds `[@@deprecated]` alerts.

## Stacking notes

- Branched off `feat/mcp-error-code-rfc0097-pr1` (PR #15759).
- If PR #15759 squash-merges to main, this PR auto-closes per GitHub's stacked-merge semantics (see `feedback_stacked_pr_auto_close_recovery.md`). Recovery: rebase onto main, reopen as new PR. Acceptable cost given the parallel work strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)