### PR TITLE
feat(briefing-compactors): typed source variant for last_event provenance

### DIFF
--- a/lib/briefing_compactors/briefing_compactors.ml
+++ b/lib/briefing_compactors/briefing_compactors.ml
@@ -76,6 +76,10 @@ let compact_session_json session_json =
             ("task_title", string_json ~default:"not_recorded" (member_assoc "task_title" detail));
             ("result", string_json ~default:"not_recorded" ~max_len:160 (member_assoc "result" detail));
             ("reason", string_json ~default:"not_recorded" ~max_len:160 (member_assoc "reason" detail));
+            ("source",
+             `String
+               (Briefing_session_last_event_source.to_label
+                  Briefing_session_last_event_source.Recent_event_latest));
           ]
     | [] ->
         `Assoc
@@ -86,6 +90,10 @@ let compact_session_json session_json =
             ("task_title", `String "no recent session events");
             ("result", `String "not_recorded");
             ("reason", `String "not_recorded");
+            ("source",
+             `String
+               (Briefing_session_last_event_source.to_label
+                  Briefing_session_last_event_source.Fabricated_no_recent_events));
           ]
   in
   let communication_mode =

--- a/lib/briefing_compactors/briefing_session_last_event_source.ml
+++ b/lib/briefing_compactors/briefing_session_last_event_source.ml
@@ -1,0 +1,7 @@
+type t =
+  | Recent_event_latest
+  | Fabricated_no_recent_events
+
+let to_label = function
+  | Recent_event_latest -> "recent_event_latest"
+  | Fabricated_no_recent_events -> "fabricated_no_recent_events"

--- a/lib/briefing_compactors/briefing_session_last_event_source.mli
+++ b/lib/briefing_compactors/briefing_session_last_event_source.mli
@@ -1,0 +1,30 @@
+(** Briefing session [last_event] provenance marker.
+
+    {!Briefing_compactors.compact_session_json} synthesises the
+    [last_event] JSON object whether or not the input
+    [recent_events] list was empty.  Downstream consumers (dashboard,
+    operator handoff, debug dumps) cannot otherwise distinguish a
+    real "this is the most recent observed event" payload from a
+    placeholder "no events present, here is a sentinel".
+
+    This typed variant is the closed enumeration of those two
+    provenance paths, serialised into the [last_event.source] field
+    so consumers can branch on it without re-running discovery.
+
+    @since RFC-0058 follow-up / V14 audit (.tmp/memory-compacting-analysis.html) *)
+
+type t =
+  | Recent_event_latest
+      (** [recent_events] was non-empty; [last_event] mirrors the final
+          element.  Real data — caller may trust [event_type], [actor],
+          [ts_iso] as observed. *)
+  | Fabricated_no_recent_events
+      (** [recent_events] was empty.  [last_event] is a sentinel record
+          with [event_type="none"], [ts_iso="unknown"], [actor="unknown"],
+          [task_title="no recent session events"].  Caller must NOT
+          treat the fabricated fields as observations. *)
+
+val to_label : t -> string
+(** Lowercase JSON-string label used in [last_event.source].
+    Stable across releases — downstream filters depend on these
+    exact strings. *)

--- a/test/test_briefing_compactors.ml
+++ b/test/test_briefing_compactors.ml
@@ -313,9 +313,37 @@ let test_compact_session_last_event_empty_uses_sentinel () =
           assert (get "actor" = "unknown");
           assert (get "task_title" = "no recent session events");
           assert (get "result" = "not_recorded");
-          assert (get "reason" = "not_recorded")
+          assert (get "reason" = "not_recorded");
+          assert (get "source" = "fabricated_no_recent_events")
       | _ -> assert false)
   | _ -> assert false
+
+let test_compact_session_last_event_source_marker () =
+  (* Provenance marker: empty -> fabricated, non-empty -> recent_event_latest.
+     Downstream dashboards / handoff consumers depend on this discriminator
+     to skip sentinel records that look like real observations. *)
+  let s_empty = session_fixture ~recent:[] () in
+  let out_empty = C.compact_session_json s_empty in
+  let source_of out =
+    match out with
+    | `Assoc kv -> (
+        match List.assoc_opt "last_event" kv with
+        | Some (`Assoc le) -> (
+            match List.assoc_opt "source" le with
+            | Some (`String s) -> s
+            | _ -> "<missing>")
+        | _ -> "<no-last-event>")
+    | _ -> "<not-assoc>"
+  in
+  assert (source_of out_empty = "fabricated_no_recent_events");
+  let s_one =
+    session_fixture
+      ~recent:[ recent_event ~event_type:"observed" ~actor:"alice"
+                  ~task_title:"observed task" () ]
+      ()
+  in
+  let out_one = C.compact_session_json s_one in
+  assert (source_of out_one = "recent_event_latest")
 
 let test_compact_session_last_event_uses_latest () =
   (* When multiple recent_events present, last_event mirrors the
@@ -545,6 +573,7 @@ let () =
   test_compact_session_communication_summary_format ();
   test_compact_session_last_event_empty_uses_sentinel ();
   test_compact_session_last_event_uses_latest ();
+  test_compact_session_last_event_source_marker ();
   test_compact_session_goal_default_when_blank ();
   test_compact_keeper_strict_keys ();
   test_compact_keeper_max_len_truncation ();


### PR DESCRIPTION
## Summary

Closes V14 from `.tmp/memory-compacting-analysis.html` ("briefing JSON compaction fallback marker 누락").

`Briefing_compactors.compact_session_json` synthesises a `last_event` object whether or not the input `recent_events` list contains data. The two cases produced *structurally identical* JSON shapes — dashboard, handoff and debug consumers had no way to tell a real observation from a sentinel placeholder.

This PR adds `Briefing_session_last_event_source` (closed sum, 2 variants) and emits its lowercase label as a new `last_event.source` field. The leaf sublibrary `masc_mcp.briefing_compactors` stays dependency-clean (no Prometheus reach-in); wrapper-side counter aggregation is deferred to a follow-up per the iter 6/7 leaf-constraint pattern.

## Why typed variant, not bare string

If the labels were inlined as string literals in two places, a future "fix" that renames one branch (e.g. `"fabricated"` → `"sentinel"`) silently desynchronises the two emission sites and downstream filters miss half the records. The closed sum + `to_label` SSOT collapses that to a single point of change with compiler-enforced exhaustiveness when a third provenance path is added.

## RFC 인용 (agent_delegation §3)

Not in a mandatory subsystem (no credential/identity/operator/sandbox/hooks/workflow surface touched). `pr-rfc-check.sh` PASS exit 0.

## What changed

| File | Direction | Notes |
|---|---|---|
| `lib/briefing_compactors/briefing_session_last_event_source.{ml,mli}` | new | 2-variant closed sum + `to_label` stable string |
| `lib/briefing_compactors/briefing_compactors.ml` | +8 | `Recent_event_latest` on `latest :: _` branch, `Fabricated_no_recent_events` on `[]` branch |
| `test/test_briefing_compactors.ml` | +30/-1 | extend existing sentinel assertion + new `_source_marker` test pairing both branches |

No dune change — files picked up by `include_subdirs no` + flat library glob.

## Behavior change

| Caller | Before | After |
|---|---|---|
| `compact_session_json {recent_events: [a; b; c]}` | `last_event = {..., result, reason}` (6 keys) | same + `source = "recent_event_latest"` (7 keys) |
| `compact_session_json {recent_events: []}` | `last_event = {event_type:"none", ts_iso:"unknown", ...}` (6 keys, all sentinel) | same + `source = "fabricated_no_recent_events"` (7 keys) |

Field is purely additive. No existing test had a `last_event` strict-key assertion (only `compact_session_strict_keys` lists the *outer* keys — the inner `last_event` is treated as opaque by every other test).

## Test plan

- [x] `dune build --root . lib/briefing_compactors` — PASS
- [x] `dune exec --root . test/test_briefing_compactors.exe` — PASS (existing sentinel test + new marker test)
- [x] `dune exec --root . test/test_dashboard_mission_briefing.exe` — 12/12 PASS (regression check)

## Workaround rejection self-check

- [ ] telemetry-as-fix → **NO**, structural type discrimination (no counter introduced in this PR by design — leaf constraint)
- [ ] string classifier → **NO**, closed sum + single `to_label` SSOT; the strings are *output*, not classifier input
- [ ] N-of-M → **NO**, both branches updated in same PR
- [ ] catch-all `_ ->` added → **NO**, exhaustive 2-variant match
- [ ] cap/cooldown/dedup/repair → **NO**
- [ ] test backdoor → **NO**, uses public `compact_session_json` API
- [ ] repeat typo → **NO**

## Follow-up (not in this PR)

- Wrapper-side Prometheus counter `metric_briefing_session_last_event_source{source}` registered in `Keeper_metrics` once a non-leaf observer call site is identified (sibling of iter 6/7 leaf-counter split pattern)
- Other silent fallbacks in `compact_session_json` / `compact_keeper_json` (the per-field `~default:"unknown"` / `~default:"unassigned"` paths) — these are field-level and require a different decomposition; out of atomic scope here

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
