### PR TITLE
feat(dashboard): normalize keeper stop causes

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -83,6 +83,8 @@ function filterFleetRows(
     if (row.provider_label && row.provider_label.toLowerCase().includes(needle)) return true
     if (row.fallback_label && row.fallback_label.toLowerCase().includes(needle)) return true
     if (row.runtime_blocker_class && row.runtime_blocker_class.toLowerCase().includes(needle)) return true
+    if (row.stop_cause?.code.toLowerCase().includes(needle)) return true
+    if (row.stop_cause?.summary?.toLowerCase().includes(needle)) return true
     return false
   })
 }
@@ -445,15 +447,15 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                   ${row.decision_required
                     ? html`<span class="rounded-[var(--r-1)] bg-[var(--bad-10)] px-1.5 py-0.5 text-3xs text-[var(--bad-light)]">decision</span>`
                     : null}
-                  ${row.terminal_reason_code
+                  ${row.stop_cause
                     ? html`
                       <span
-                        class=${row.terminal_reason_severity === 'bad'
+                        class=${row.stop_cause.severity === 'bad'
                           ? 'rounded bg-[var(--bad-10)] px-1.5 py-0.5 text-3xs text-[var(--bad-light)]'
                           : 'rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs text-[var(--color-status-warn)]'}
-                        title=${row.runtime_trust_next_action ?? row.runtime_trust_reason ?? row.terminal_reason_code}
+                        title=${row.stop_cause.next_action ?? row.stop_cause.summary ?? row.runtime_trust_next_action ?? row.runtime_trust_reason ?? row.stop_cause.code}
                       >
-                        ${row.terminal_reason_code}
+                        ${row.stop_cause.code}
                       </span>
                     `
                     : null}

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -30,6 +30,7 @@ import {
   buildToolQualityMap,
   buildFleetRows,
   buildRuntimeWarnings,
+  EMPTY_TOOL_QUALITY,
   emptyState,
   type FleetRow,
 } from './fleet-telemetry-utils'
@@ -224,6 +225,30 @@ describe('buildFleetRows runtime labels', () => {
       cascade_label: 'oas-keeper_unified -> primary',
       provider_label: 'passed_to_next_model · 2 attempts · fallback',
       fallback_label: 'fallback · turn_timeout · 1 hops',
+    })
+  })
+
+  it('projects the keeper stop_cause into fleet rows', () => {
+    const [row] = buildFleetRows([
+      {
+        name: 'blocked-keeper',
+        status: 'active',
+        keepalive_running: true,
+        stop_cause: {
+          code: 'no_tool_capable_provider',
+          source: 'runtime_blocker_class',
+          label: 'no tool capable provider',
+          summary: 'no provider can satisfy required tools',
+          severity: 'warn',
+          next_action: 'inspect_provider_tool_contract',
+        },
+      },
+    ], EMPTY_TOOL_QUALITY)
+
+    expect(row?.stop_cause).toMatchObject({
+      code: 'no_tool_capable_provider',
+      source: 'runtime_blocker_class',
+      summary: 'no provider can satisfy required tools',
     })
   })
 })

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -1,8 +1,9 @@
 import type { DashboardExecutionTrustResponse, TelemetrySourceSummary, ToolQualityResponse } from '../api/dashboard'
 import type { DashboardNamespaceTruthResponse } from '../types'
 import { telemetrySourceLabel } from '../config/telemetry-sources'
-import type { Keeper } from '../types'
+import type { Keeper, StopCause } from '../types'
 import { formatElapsedCompact } from '../lib/format-time'
+import { normalizeStopCause } from '../lib/stop-cause'
 import {
   keeperActivityDisplay,
   type KeeperActivitySource,
@@ -40,6 +41,7 @@ export interface FleetRow {
   runtime_trust_attention?: boolean
   runtime_trust_reason?: string | null
   runtime_trust_next_action?: string | null
+  stop_cause?: StopCause | null
   terminal_reason_code?: string | null
   terminal_reason_severity?: string | null
   tool_audit_at: string | null
@@ -398,6 +400,16 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
           const recentTools = keeperRecentTools(keeper)
           const toolCalls = keeperToolCallCount(keeper, toolQualityForKeeper?.calls)
           const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
+          const stopCause = keeper.stop_cause ?? normalizeStopCause({
+            runtime_blocker_class: keeper.runtime_blocker_class ?? null,
+            runtime_blocker_summary: keeper.runtime_blocker_summary ?? keeper.last_blocker ?? null,
+            terminal_reason_code: keeper.trust?.latest_terminal_reason?.code ?? null,
+            terminal_reason_summary: keeper.trust?.latest_terminal_reason?.summary ?? null,
+            terminal_reason_severity: keeper.trust?.latest_terminal_reason?.severity ?? null,
+            terminal_reason_next_action: keeper.trust?.latest_terminal_reason?.next_action ?? null,
+            attention_reason: keeper.attention_reason ?? keeper.trust?.attention_reason ?? null,
+            next_action: keeper.next_human_action ?? keeper.trust?.latest_next_action ?? null,
+          })
           return {
             name: keeper.name,
             status: keeper.status ?? (keeper.keepalive_running ? 'active' : 'offline'),
@@ -436,6 +448,7 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
                 keeper.trust?.latest_next_action,
                 keeper.trust?.latest_terminal_reason?.next_action,
               ) ?? null,
+            stop_cause: stopCause,
             terminal_reason_code: keeper.trust?.latest_terminal_reason?.code ?? null,
             terminal_reason_severity: keeper.trust?.latest_terminal_reason?.severity ?? null,
             tool_audit_at: keeper.tool_audit_at ?? null,

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -38,6 +38,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
     || keeper.trust?.disposition_reason?.trim()
     || keeper.trust?.execution_summary?.mutation_guard_summary?.trim()
     || null
+  const stopCause = keeper.stop_cause ?? null
   const latestTerminalReason = keeper.trust?.latest_terminal_reason ?? null
   const latestTerminalCode = latestTerminalReason?.code?.trim() || null
   const latestTerminalSummary = latestTerminalReason?.summary?.trim() || null
@@ -115,6 +116,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
     || unexpectedTools.length > 0
     || missingRequiredTools.length > 0
     || Boolean(trustSummary)
+    || Boolean(stopCause)
     || Boolean(latestTerminalCode)
     || Boolean(latestNextAction)
     || shouldShowOperatorDispositionReason
@@ -257,7 +259,10 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
         ${nextHumanAction
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">다음 액션</strong> · ${nextHumanAction}</span>`
           : null}
-        ${latestTerminalCode
+        ${stopCause
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">정지 원인</strong> · ${stopCause.code}${stopCause.summary ? html` · ${stopCause.summary}` : null}</span>`
+          : null}
+        ${latestTerminalCode && latestTerminalCode !== stopCause?.code
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">종료 코드</strong> · ${latestTerminalCode}${latestTerminalSummary ? html` · ${latestTerminalSummary}` : null}</span>`
           : null}
         ${latestNextAction

--- a/dashboard/src/components/turn-fsm-detail-panel.ts
+++ b/dashboard/src/components/turn-fsm-detail-panel.ts
@@ -9,6 +9,7 @@ import {
   buildTurnFsmSpec,
   normalizeTurnFsmState,
 } from './keeper-fsm-specs'
+import { normalizeStopCause } from '../lib/stop-cause'
 
 type TurnChipTone = 'accent' | 'neutral' | 'warn' | 'err' | 'ok'
 
@@ -50,11 +51,13 @@ export function TurnFsmDetailPanel({ snapshot }: { snapshot: KeeperCompositeSnap
   )
   const projectedState = normalizeTurnFsmState(snapshot.turn_phase)
   const execution = snapshot.execution
-  const terminalReason =
-    execution?.terminal_reason_code
-    ?? execution?.stop_reason
-    ?? execution?.error?.kind
-    ?? null
+  const stopCause = execution
+    ? normalizeStopCause({
+        terminal_reason_code: execution.terminal_reason_code,
+        stop_reason: execution.stop_reason,
+        error_kind: execution.error?.kind,
+      })
+    : null
 
   return html`
     <section
@@ -81,8 +84,8 @@ export function TurnFsmDetailPanel({ snapshot }: { snapshot: KeeperCompositeSnap
       ${execution ? html`
         <div class="flex flex-wrap items-center gap-1.5 text-3xs" aria-label="latest turn receipt summary">
           <${StatusChip} tone=${turnFsmChipTone(terminalTone(execution.outcome))} uppercase=${false}>receipt ${execution.outcome ?? 'unknown'}</${StatusChip}>
-          ${terminalReason ? html`
-            <${StatusChip} tone=${turnFsmChipTone(terminalTone(execution.outcome))} uppercase=${false} class="font-mono">reason ${terminalReason}</${StatusChip}>
+          ${stopCause ? html`
+            <${StatusChip} tone=${turnFsmChipTone(terminalTone(execution.outcome))} uppercase=${false} class="font-mono" title=${stopCause.source}>reason ${stopCause.code}</${StatusChip}>
           ` : null}
           ${execution.tool_contract_result ? html`
             <${StatusChip} tone=${turnFsmChipTone(execution.tool_contract_result === 'violated' ? 'err' : 'neutral')} uppercase=${false} class="font-mono">tool ${execution.tool_contract_result}</${StatusChip}>

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -413,6 +413,37 @@ describe('normalizeKeepers lifecycle metrics', () => {
       },
       latest_next_action: 'inspect_timeout_budget',
     })
+    expect(keeper?.stop_cause).toMatchObject({
+      code: 'timeout_budget_exhausted',
+      source: 'terminal_reason_code',
+      summary: 'Turn budget exhausted after 15 turns',
+      next_action: 'inspect_timeout_budget',
+    })
+  })
+
+  it('prefers runtime blocker as the normalized stop cause for keeper detail', () => {
+    const [keeper] = normalizeKeepers([
+      {
+        name: 'blocked-keeper',
+        status: 'active',
+        runtime_blocker_class: 'turn_timeout',
+        runtime_blocker_summary: 'turn has not made progress',
+        trust: {
+          latest_terminal_reason: {
+            code: 'api_error_timeout',
+            source: 'execution_receipt',
+            severity: 'bad',
+            summary: 'provider timed out',
+          },
+        },
+      },
+    ])
+
+    expect(keeper?.stop_cause).toMatchObject({
+      code: 'turn_timeout',
+      source: 'runtime_blocker_class',
+      summary: 'turn has not made progress',
+    })
   })
 
   it('returns null latest_terminal_reason when code is missing', () => {

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -14,6 +14,7 @@ import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp 
 import { isOfflineStatus } from './lib/status-utils'
 import { keeperDisplayStatus } from './lib/keeper-runtime-display'
 import { asKeeperRuntimeBlockerClass } from './lib/runtime-blocker-class'
+import { normalizeStopCause } from './lib/stop-cause'
 import { contextThresholds } from './config/context-thresholds'
 import { normalizeKeeperDiagnostic } from './keeper-state'
 import type { CascadeRef } from './types'
@@ -507,6 +508,22 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
           : undefined
 
       const providerHealth: ProviderHealth | null = null
+      const runtimeBlockerClass = asKeeperRuntimeBlockerClass(row.runtime_blocker_class)
+      const runtimeBlockerSummary = asString(row.runtime_blocker_summary) ?? null
+      const trust = normalizeKeeperTrust(row.runtime_trust ?? row.trust)
+      const terminalReason = trust?.latest_terminal_reason ?? null
+      const nextHumanAction = asString(row.next_human_action) ?? null
+      const stopCause = normalizeStopCause({
+        stop_cause: row.stop_cause,
+        runtime_blocker_class: runtimeBlockerClass,
+        runtime_blocker_summary: runtimeBlockerSummary,
+        terminal_reason_code: terminalReason?.code ?? null,
+        terminal_reason_summary: terminalReason?.summary ?? null,
+        terminal_reason_severity: terminalReason?.severity ?? null,
+        terminal_reason_next_action: terminalReason?.next_action ?? null,
+        attention_reason: asString(row.attention_reason) ?? trust?.attention_reason ?? null,
+        next_action: nextHumanAction ?? trust?.next_human_action ?? trust?.latest_next_action ?? null,
+      })
 
       return {
         name,
@@ -543,17 +560,18 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
           typeof row.proactive_enabled === 'boolean' ? row.proactive_enabled : undefined,
         proactive_idle_sec: asNumber(row.proactive_idle_sec),
         proactive_cooldown_sec: asNumber(row.proactive_cooldown_sec),
-        runtime_blocker_class: asKeeperRuntimeBlockerClass(row.runtime_blocker_class),
-        runtime_blocker_summary: asString(row.runtime_blocker_summary) ?? null,
+        runtime_blocker_class: runtimeBlockerClass,
+        runtime_blocker_summary: runtimeBlockerSummary,
         runtime_blocker_continue_gate:
           typeof row.runtime_blocker_continue_gate === 'boolean'
             ? row.runtime_blocker_continue_gate
             : null,
+        stop_cause: stopCause,
         needs_attention:
           typeof row.needs_attention === 'boolean' ? row.needs_attention : null,
         attention_reason: asString(row.attention_reason) ?? null,
-        next_human_action: asString(row.next_human_action) ?? null,
-        trust: normalizeKeeperTrust(row.runtime_trust ?? row.trust),
+        next_human_action: nextHumanAction,
+        trust,
         active_goal_ids: asStringArray(row.active_goal_ids) ?? [],
         goal: asString(row.goal) ?? null,
         short_goal: asString(row.short_goal) ?? null,

--- a/dashboard/src/lib/stop-cause.ts
+++ b/dashboard/src/lib/stop-cause.ts
@@ -1,0 +1,109 @@
+import type { StopCause, StopCauseSource } from '../types'
+
+function text(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed === '' ? null : trimmed
+}
+
+function humanize(code: string): string {
+  return code
+    .replace(/[:._-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function coerceRawStopCause(raw: unknown): StopCause | null {
+  if (!isRecord(raw)) return null
+  const code = text(raw.code)
+  if (!code) return null
+  const source = text(raw.source) as StopCauseSource | null
+  return {
+    code,
+    source: source ?? 'terminal_reason_code',
+    label: text(raw.label) ?? humanize(code),
+    summary: text(raw.summary),
+    severity: text(raw.severity),
+    next_action: text(raw.next_action),
+  }
+}
+
+export interface StopCauseInput {
+  stop_cause?: unknown
+  runtime_blocker_class?: string | null
+  runtime_blocker_summary?: string | null
+  terminal_reason_code?: string | null
+  terminal_reason_summary?: string | null
+  terminal_reason_severity?: string | null
+  terminal_reason_next_action?: string | null
+  stop_reason?: string | null
+  error_kind?: string | null
+  attention_reason?: string | null
+  next_action?: string | null
+}
+
+function buildStopCause(
+  source: StopCauseSource,
+  code: string | null,
+  summary: string | null,
+  severity: string | null,
+  nextAction: string | null,
+): StopCause | null {
+  if (!code) return null
+  return {
+    code,
+    source,
+    label: humanize(code),
+    summary,
+    severity,
+    next_action: nextAction,
+  }
+}
+
+export function normalizeStopCause(input: StopCauseInput): StopCause | null {
+  const explicit = coerceRawStopCause(input.stop_cause)
+  if (explicit) return explicit
+
+  return (
+    buildStopCause(
+      'runtime_blocker_class',
+      text(input.runtime_blocker_class),
+      text(input.runtime_blocker_summary),
+      'warn',
+      text(input.next_action),
+    )
+    ?? buildStopCause(
+      'terminal_reason_code',
+      text(input.terminal_reason_code),
+      text(input.terminal_reason_summary),
+      text(input.terminal_reason_severity),
+      text(input.terminal_reason_next_action) ?? text(input.next_action),
+    )
+    ?? buildStopCause(
+      'stop_reason',
+      text(input.stop_reason),
+      null,
+      null,
+      text(input.next_action),
+    )
+    ?? buildStopCause(
+      'error_kind',
+      text(input.error_kind),
+      null,
+      'bad',
+      text(input.next_action),
+    )
+    ?? buildStopCause(
+      'attention_reason',
+      text(input.attention_reason),
+      null,
+      'warn',
+      text(input.next_action),
+    )
+  )
+}
+

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -68,12 +68,37 @@ describe('normalizeExecutionQueueItem', () => {
       id: 'keeper-sangsu',
       kind: 'keeper',
       terminal_reason_code: 'required_tool_use_unsatisfied',
+      stop_cause: {
+        code: 'required_tool_use_unsatisfied',
+        source: 'terminal_reason_code',
+      },
       runtime_trust: {
         needs_attention: true,
         latest_terminal_reason: {
           code: 'required_tool_use_unsatisfied',
           severity: 'bad',
         },
+      },
+    })
+  })
+
+  it('normalizes runtime blockers into execution row stop_cause before attention fallback', () => {
+    expect(normalizeExecutionQueueItem({
+      id: 'keeper-sangsu',
+      kind: 'keeper',
+      severity: 'bad',
+      status: 'blocked',
+      summary: 'keeper turn is blocked',
+      target_type: 'keeper',
+      target_id: 'sangsu',
+      runtime_blocker_class: 'no_tool_capable_provider',
+      runtime_blocker_summary: 'no provider can satisfy required tools',
+      attention_reason: 'tool_contract_failed',
+    })).toMatchObject({
+      stop_cause: {
+        code: 'no_tool_capable_provider',
+        source: 'runtime_blocker_class',
+        summary: 'no provider can satisfy required tools',
       },
     })
   })

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -1,5 +1,6 @@
 import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp } from './components/common/normalize'
 import { normalizeKeeperTrust } from './keeper-store-normalize'
+import { normalizeStopCause } from './lib/stop-cause'
 import type {
   Agent, Task, Message, ServerStatus,
   DashboardExecutionSummary, DashboardExecutionHandoff,
@@ -217,6 +218,10 @@ export function normalizeExecutionQueueItem(raw: unknown): DashboardExecutionQue
   if (!id || !summary || !targetType || !targetId || (kind !== 'session' && kind !== 'operation' && kind !== 'keeper')) {
     return null
   }
+  const runtimeTrust = normalizeKeeperTrust(raw.runtime_trust ?? raw.trust)
+  const terminalReason = runtimeTrust?.latest_terminal_reason ?? null
+  const terminalReasonCode =
+    asString(raw.terminal_reason_code) ?? terminalReason?.code ?? null
   return {
     id,
     kind,
@@ -230,8 +235,19 @@ export function normalizeExecutionQueueItem(raw: unknown): DashboardExecutionQue
     last_seen_at: asString(raw.last_seen_at) ?? null,
     attention_reason: asString(raw.attention_reason) ?? null,
     next_human_action: asString(raw.next_human_action) ?? null,
-    terminal_reason_code: asString(raw.terminal_reason_code) ?? null,
-    runtime_trust: normalizeKeeperTrust(raw.runtime_trust ?? raw.trust),
+    terminal_reason_code: terminalReasonCode,
+    stop_cause: normalizeStopCause({
+      stop_cause: raw.stop_cause,
+      runtime_blocker_class: asString(raw.runtime_blocker_class) ?? asString(raw.runtime_blocker) ?? null,
+      runtime_blocker_summary: asString(raw.runtime_blocker_summary) ?? null,
+      terminal_reason_code: terminalReasonCode,
+      terminal_reason_summary: terminalReason?.summary ?? null,
+      terminal_reason_severity: terminalReason?.severity ?? null,
+      terminal_reason_next_action: terminalReason?.next_action ?? null,
+      attention_reason: asString(raw.attention_reason) ?? null,
+      next_action: asString(raw.next_human_action) ?? runtimeTrust?.latest_next_action ?? null,
+    }),
+    runtime_trust: runtimeTrust,
     top_handoff: normalizeExecutionHandoff(raw.top_handoff),
     intervene_handoff: normalizeExecutionHandoff(raw.intervene_handoff),
     command_handoff: normalizeExecutionHandoff(raw.command_handoff),

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -422,6 +422,22 @@ export const KEEPER_RUNTIME_BLOCKER_CLASSES = [
 
 export type KeeperRuntimeBlockerClass = (typeof KEEPER_RUNTIME_BLOCKER_CLASSES)[number]
 
+export type StopCauseSource =
+  | 'runtime_blocker_class'
+  | 'terminal_reason_code'
+  | 'stop_reason'
+  | 'error_kind'
+  | 'attention_reason'
+
+export interface StopCause {
+  code: string
+  source: StopCauseSource
+  label: string
+  summary?: string | null
+  severity?: string | null
+  next_action?: string | null
+}
+
 export interface KeeperTrustLatestEvent {
   kind: string
   ts: string
@@ -884,6 +900,7 @@ export interface Keeper {
   runtime_blocker_class?: KeeperRuntimeBlockerClass | null
   runtime_blocker_summary?: string | null
   runtime_blocker_continue_gate?: boolean | null
+  stop_cause?: StopCause | null
   needs_attention?: boolean | null
   attention_reason?: string | null
   next_human_action?: string | null

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -1,4 +1,4 @@
-import type { Agent, BoardPost } from './core'
+import type { Agent, BoardPost, StopCause } from './core'
 import type { OperatorAttentionItem, OperatorRecommendedAction } from './dashboard-mission'
 import type { BoardMonitoring, GovernanceMonitoring, GovernanceDecisionItem, GovernanceTimelineEvent, GovernanceJudgeSummary, GovernanceJudgment, KeeperApprovalQueueItem, KeeperApprovalRule, PendingConfirmation, PendingConfirmSummary } from './governance'
 
@@ -328,6 +328,7 @@ export interface DashboardExecutionQueueItem {
   attention_reason?: string | null
   next_human_action?: string | null
   terminal_reason_code?: string | null
+  stop_cause?: StopCause | null
   runtime_trust?: GoalKeeperTrustSummary | null
   top_handoff?: DashboardExecutionHandoff | null
   intervene_handoff?: DashboardExecutionHandoff | null


### PR DESCRIPTION
## Summary
- Add a typed `stop_cause` projection for keeper, fleet, and execution queue rows.
- Normalize runtime blockers, terminal reasons, stop reasons, error kinds, and attention reasons through one priority order.
- Render the same stop cause in Fleet Telemetry, Keeper detail, and Turn FSM detail surfaces.

Refs #15731
Refs task-277

## Verification
- `git diff --check`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/keeper-store-normalize.test.ts src/store-normalizers.test.ts src/components/fleet-telemetry-utils.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`