### PR TITLE
fix(keeper-memory-bank): warn+counter on swallowed load-history exceptions

### DIFF
--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -631,7 +631,23 @@ let load_history_user_messages ~(path : string) ~(max_n : int) : string list =
            then None
            else Some content
          else None
-       with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+           (* V07 (HIGH): make non-Cancel failures visible instead of
+              masking JSONL corruption / fs faults as "no history".
+              Behavior preserved — we still drop this line and return
+              [None]; only logging + counter are added. *)
+           let exn_class = Printexc.to_string exn in
+           Log.Keeper.warn
+             "load_history_user_messages: skipping line in %s: %s"
+             path exn_class;
+           Prometheus.inc_counter
+             Keeper_metrics
+             .metric_keeper_memory_bank_load_history_swallowed_exceptions
+             ~labels:[ ("exception_class", exn_class) ]
+             ();
+           None)
   |> take max_n
 
 (** Build recall candidates by merging checkpoint messages with history.jsonl.

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -202,6 +202,7 @@ type t =
   | PostTurnWireinFailures
   | RecurringFailures
   | TurnCleanupFailures
+  | MemoryBankLoadHistorySwallowedExceptions
 
 (** String conversion
 
@@ -404,6 +405,8 @@ let to_string = function
   | PostTurnWireinFailures -> "masc_keeper_post_turn_wirein_failures_total"
   | RecurringFailures -> "masc_keeper_recurring_failures_total"
   | TurnCleanupFailures -> "masc_keeper_turn_cleanup_failures_total"
+  | MemoryBankLoadHistorySwallowedExceptions ->
+      "masc_keeper_memory_bank_load_history_swallowed_exceptions_total"
 ;;
 
 (** Backward-compatible string constants
@@ -882,3 +885,7 @@ let metric_keeper_post_turn_wirein_failures =
 let metric_keeper_recurring_failures = "masc_keeper_recurring_failures_total"
 let metric_keeper_turn_cleanup_failures = "masc_keeper_turn_cleanup_failures_total"
 let metric_keeper_session_cleanup_failures = "masc_keeper_session_cleanup_failures_total"
+
+let metric_keeper_memory_bank_load_history_swallowed_exceptions =
+  to_string MemoryBankLoadHistorySwallowedExceptions
+;;

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -194,6 +194,7 @@ type t =
   | PostTurnWireinFailures
   | RecurringFailures
   | TurnCleanupFailures
+  | MemoryBankLoadHistorySwallowedExceptions
 
 val to_string : t -> string
 
@@ -510,6 +511,14 @@ val metric_keeper_post_turn_wirein_failures : string
 val metric_keeper_recurring_failures : string
 val metric_keeper_turn_cleanup_failures : string
 val metric_keeper_session_cleanup_failures : string
+
+(** Counter for non-Cancel exceptions silently swallowed by the
+    catch-all in [Keeper_memory_recall.load_history_user_messages].
+    Labels: [keeper] (when available), [exception_class] (from
+    [Printexc.to_string]). Behavior is unchanged (the function still
+    returns no row for the failing line); the counter exists so JSONL
+    corruption / fs faults stop masking as "no history". *)
+val metric_keeper_memory_bank_load_history_swallowed_exceptions : string
 val metric_keeper_path_resolver_identity_mismatch : string
 val metric_keeper_passive_loop_streak : string
 val metric_keeper_passive_loop_streak_exceeded : string


### PR DESCRIPTION
## Summary

Closes **V07 (HIGH)** from `.tmp/memory-compacting-analysis.html` — silent
exception swallow in `Keeper_memory_recall.load_history_user_messages`.

The previous catch-all (`| _ -> None`) masked JSONL corruption / fs faults
as a blank "no history" result, with no log line and no counter. This PR
adds visibility without changing behavior.

## What changed

| File | Change |
|------|--------|
| `lib/keeper/keeper_memory_recall.ml` | Replace `| _ -> None` with typed match: re-raise `Eio.Cancel.Cancelled`, log `Log.Keeper.warn` + inc counter on other exceptions, still return `None`. |
| `lib/keeper/keeper_metrics.ml` | Add `MemoryBankLoadHistorySwallowedExceptions` variant + `to_string` arm + backward-compat string constant. |
| `lib/keeper/keeper_metrics.mli` | Public surface: variant + `val metric_keeper_memory_bank_load_history_swallowed_exceptions : string` with doc comment. |

Metric name: `masc_keeper_memory_bank_load_history_swallowed_exceptions_total`
Labels: `exception_class` (from `Printexc.to_string`). Keeper name is
not in scope at this call site, so it is not added as a label (deferred
to a future propagation PR).

## Behavior preservation

- Return value is still `None` for the failing line. Callers see no
  difference in the recall pipeline.
- `Eio.Cancel.Cancelled` is re-raised first (unchanged from prior code).
- No try/catch widening, no retry, no input mutation.

## Test plan

- [x] `dune build --root . @lib/check` — PASS (exit 0).
- [ ] Runtime smoke: deliberately write a malformed line to a keeper
      `history.jsonl`, call recall, observe one `Log.Keeper.warn` + one
      Prometheus increment. *(Not in this PR — separate runtime
      validation task.)*

## Workaround rejection self-check (7 items)

1. **Telemetry-as-fix only?** Partly yes — the counter is an alarm.
   Justified: V07 explicitly asked for visibility on the silent swallow.
   Converting the function to `Result.t` (the proper root fix) is a
   broader signature change touching `Keeper_exec_memory` and
   `Keeper_agent_run`; deferring it keeps this PR atomic. The counter
   gives us the data to size that follow-up.
2. **String classifier added?** NO — `Printexc.to_string` is recorded
   as a label, never matched on substring.
3. **N-of-M patch?** NO — single call site.
4. **Catch-all `_ ->` added?** NO — the catch-all existed before. This
   PR keeps it but makes it observable. No new catch-all created.
5. **Cap / cooldown / dedup / repair?** NO — counter is uncapped, no
   demote, no sanitize.
6. **Test backdoor?** NO — no `set_*_for_test` / `reset_for_test`
   exposed.
7. **Repeat typo / off-by-one?** NO — no copy-paste sites.

## Anti-pattern alignment

`software-development.md §Workaround Rejection Bar` flags telemetry-only
PRs. This PR is acceptable under that gate because:
- The underlying loss path is acknowledged, not denied.
- Root-fix (`Result.t` return + caller handling) is named here as the
  next step; the counter is the audit trail to prioritize it.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
