### PR TITLE
feat(compact-policy): env-override for emergency_compact_ratio_threshold (V13)

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -12,8 +12,61 @@ open Keeper_context_core
     emergency, bypassing the continuity-reflection cooldown gate.
     Distinct from [ratio_gate] (per-keeper compaction threshold) and
     [handoff_threshold] (handoff gate); this is a safety floor that
-    prevents context overflow regardless of cooldown state (#5634). *)
-let emergency_compact_ratio_threshold = 0.8
+    prevents context overflow regardless of cooldown state (#5634).
+
+    Operator override: [MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD].
+    Default 0.8. Valid range [0.5, 0.99]; out-of-range falls back to
+    the default with a one-time warn (parse-correctness, not silent
+    coercion — a stale operator typo should not push the emergency
+    floor outside the policy envelope, but it also should not block
+    boot). The effective value is exposed via Prometheus gauge
+    {!Keeper_metrics.metric_keeper_emergency_compact_ratio_threshold}
+    so operators can see what the running process is actually using.
+
+    Read once at module init: keeper compact policy is a hot path and
+    re-reading env per gate call would be wasteful. Operator must
+    restart the process to change the threshold (consistent with
+    [context_ratio_hard_cap] and other compact knobs in
+    {!Env_config_keeper}). *)
+let emergency_compact_ratio_threshold : float =
+  let env_var = "MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD" in
+  let default_value = 0.8 in
+  let min_valid = 0.5 in
+  let max_valid = 0.99 in
+  let raw = Env_config_core.get_float ~default:default_value env_var in
+  let effective =
+    if (not (Float.is_finite raw)) || raw < min_valid || raw > max_valid
+    then (
+      (* Only warn when an explicit override was supplied and out of range;
+         silently accept the default fall-through case (raw = default_value
+         and default is in-range). *)
+      if not (Float.equal raw default_value)
+      then
+        Log.Harness.warn
+          "[compact_policy] %s=%f out of range [%.2f, %.2f]; falling back to default \
+           %.2f"
+          env_var
+          raw
+          min_valid
+          max_valid
+          default_value;
+      default_value)
+    else raw
+  in
+  (* Surface the effective value for operators via /metrics. Registered
+     here so the gauge exists from module init regardless of whether any
+     compaction has fired yet. *)
+  Prometheus.register_gauge
+    ~name:Keeper_metrics.metric_keeper_emergency_compact_ratio_threshold
+    ~help:
+      "Effective emergency compaction ratio threshold (env-overridable via \
+       MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD; clamped to [0.5, 0.99])."
+    ();
+  Prometheus.set_gauge
+    Keeper_metrics.metric_keeper_emergency_compact_ratio_threshold
+    effective;
+  effective
+;;
 
 (** Tool-heavy compaction thresholds.
     When message count exceeds [tool_heavy_msg_threshold] AND context

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -6,7 +6,13 @@
     Extracted from Keeper_exec_context as part of #4955 god-file split. *)
 
 (** Fraction of context window at which compaction is treated as an
-    emergency, bypassing the continuity-reflection cooldown gate. *)
+    emergency, bypassing the continuity-reflection cooldown gate.
+
+    Env override: [MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD]
+    (default 0.8, valid range \[0.5, 0.99\]; out-of-range falls back
+    to default with warn). Read once at module init; restart required
+    to change. Effective value is exported as Prometheus gauge
+    {!Keeper_metrics.metric_keeper_emergency_compact_ratio_threshold}. *)
 val emergency_compact_ratio_threshold : float
 
 (** Tool-heavy compaction gate: minimum message count before the

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -498,6 +498,14 @@ let metric_keeper_slot_yield_total = "masc_keeper_slot_yield_total"
 let metric_keeper_compactions = "masc_keeper_compactions_total"
 let metric_keeper_compaction_ratio_change = "masc_keeper_compaction_ratio_change"
 let metric_keeper_compaction_saved_tokens = "masc_keeper_compaction_saved_tokens_total"
+
+(* Effective emergency compaction ratio threshold (set once at module init
+   from [MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD], clamped [0.5,0.99]).
+   Gauge so operators can confirm the live value via /metrics without
+   restarting under instrumentation. *)
+let metric_keeper_emergency_compact_ratio_threshold =
+  "masc_keeper_emergency_compact_ratio_threshold"
+;;
 let metric_keeper_operator_compact = "masc_keeper_operator_compact_total"
 let metric_keeper_operator_clear = "masc_keeper_operator_clear_total"
 let metric_keeper_compaction_noop = "masc_keeper_compaction_noop_total"

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -251,6 +251,14 @@ val metric_keeper_slot_yield_total : string
 val metric_keeper_compactions : string
 val metric_keeper_compaction_ratio_change : string
 val metric_keeper_compaction_saved_tokens : string
+
+(** Effective emergency compaction ratio threshold, set once at module
+    init in {!Keeper_compact_policy} from the env override
+    [MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD] (default 0.8,
+    clamped to \[0.5, 0.99\]). Gauge so operators can confirm via
+    /metrics what value the running process actually uses without
+    restarting under instrumentation. *)
+val metric_keeper_emergency_compact_ratio_threshold : string
 val metric_keeper_operator_compact : string
 val metric_keeper_operator_clear : string
 val metric_keeper_compaction_noop : string


### PR DESCRIPTION
# V13 — Emergency Compact Ratio Threshold Env-Override

Closes V13 (MED severity) from `.tmp/memory-compacting-analysis.html`.

## Summary

`Keeper_compact_policy.emergency_compact_ratio_threshold` was a hardcoded `0.8` applied uniformly to every keeper regardless of model context window. Small-context models (9B / 32K) over-trigger emergency compaction; large-context models (200K+) under-trigger. Operators had no way to adjust without recompile.

This PR replaces the constant with a once-loaded env-overridable accessor:

- Env var: `MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD`
- Default: `0.8` (unchanged behavior when unset)
- Valid range: `[0.5, 0.99]`
- Out-of-range or non-finite input falls back to default with a one-time `Log.Harness.warn` (parse-correctness, not silent coercion)
- Effective value exposed via Prometheus gauge `masc_keeper_emergency_compact_ratio_threshold` so operators can confirm the live value via `/metrics`

## Reference

- V13 in `.tmp/memory-compacting-analysis.html`
- Iteration backlog: `.tmp/iteration-backlog.md` (iter 20)
- Hardcoded value originated in `#5634` (emergency floor extracted from cooldown gate)

## What changed

| File | Change |
|------|--------|
| `lib/keeper/keeper_compact_policy.ml` | Replace `let emergency_compact_ratio_threshold = 0.8` with module-init read from `Env_config_core.get_float` + clamp + warn + gauge set |
| `lib/keeper/keeper_compact_policy.mli` | Document env var, range, and gauge in doc comment (same `: float` surface; no signature change) |
| `lib/keeper/keeper_metrics.ml` | Add metric name constant `metric_keeper_emergency_compact_ratio_threshold` |
| `lib/keeper/keeper_metrics.mli` | Export the constant with doc comment |

## Behavior preservation

- Env unset → reads default `0.8` → identical to old constant.
- Env set to valid value in `[0.5, 0.99]` → uses that value.
- Env set to out-of-range or non-finite → warn + fall back to `0.8` (same as old hardcoded value).
- All call sites (`ratio >= emergency_compact_ratio_threshold` inside `decide_compaction`, plus two tests `test_keeper_compact_policy_pure.ml`, plus `test_keeper_lifecycle.ml` doc reference) read the same float — no API signature change.
- Read once at module init: hot path semantics unchanged (no per-gate env lookup overhead).

## Pattern chosen

Followed the existing `KeeperWatchdog.stale_threshold_sec` clamp+warn precedent in `lib/config/env_config_keeper.ml:670-683` and the gauge-from-constant precedent in `lib/prometheus.ml:3042` (`set_gauge metric_fd_warn_threshold ...`). No new SSOT mechanism introduced — used the existing `Env_config_core.get_float` helper rather than inventing a new `ContextCompact` field, because the value is keeper-policy-local and the .mli surface stays a plain `float`.

## Anti-pattern self-check (7/7)

| # | Pattern | Status | Reasoning |
|---|---------|--------|-----------|
| 1 | telemetry-as-fix only? | **NO** | Structural change: hardcoded constant → env-driven accessor. The gauge is a secondary visibility aid for the *already-fixed* parameter, not a counter-as-fix. |
| 2 | string/substring classifier? | **NO** | No new string matching; env var is parsed by existing typed `get_float`. |
| 3 | N-of-M? | **NO** | Single knob, single call site cluster, fully migrated in this PR. |
| 4 | catch-all `_ ->` added? | **NO** | No new `match` arms; the clamp is `(not finite) || raw < min || raw > max` — explicit predicate, not catch-all. |
| 5 | cap / cooldown / dedup / repair? | **Justified clamp, not symptom-suppression** | Clamp `[0.5, 0.99]` is part of typed parse outcome (an operator typo like `0.08` or `8.0` is a parse error, not a value to round-trip silently). Out-of-range falls back to default *and* emits warn — operator sees the problem in logs and via the gauge value vs. the env var they set. This is parse correctness, not repair: we do not retry, do not transparently rewrite, do not dedupe. |
| 6 | test backdoor (`set_X_for_test`)? | **NO** | No test setter exposed; tests already read the public `: float` surface and will see the same default 0.8. |
| 7 | repeat typo across N sites? | **NO** | Single site change in `keeper_compact_policy.ml`; no codemod-style sweep. |

## Validation

- `dune build --root . lib/keeper` → exit 0
- `dune build --root . lib` → exit 0
- `bash ~/me/scripts/pr-rfc-check.sh` → exit 0

## Out of scope

- Per-model dynamic threshold (would require model-context-window awareness in the policy module and is best done as a separate RFC; this PR gives operators the per-deployment knob they were missing).
- Reload-on-config-change (current pattern is process-restart, consistent with the rest of `Env_config_keeper`).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
