### PR TITLE
feat(keeper): add reaction ledger receipts

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -916,7 +916,28 @@ let append (config : Coord.config) (receipt : t) =
   let store =
     Keeper_types_support.keeper_execution_receipt_store config receipt.keeper_name
   in
-  Dated_jsonl.append store (to_json receipt);
+  let receipt_json = to_json receipt in
+  Dated_jsonl.append store receipt_json;
+  (try
+     Keeper_reaction_ledger.record_execution_receipt_reaction
+       config
+       ~keeper_name:receipt.keeper_name
+       ~trace_id:receipt.trace_id
+       ?turn_count:receipt.turn_count
+       ~current_task_id:receipt.current_task_id
+       ~goal_ids:receipt.goal_ids
+       ~outcome:(outcome_kind_to_tla_receipt receipt.outcome)
+       ~terminal_reason_code:receipt.terminal_reason_code
+       ~receipt_json
+       ()
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+     Log.Keeper.warn
+       "%s: reaction ledger receipt append failed trace_id=%s: %s"
+       receipt.keeper_name
+       receipt.trace_id
+       (Printexc.to_string exn));
   let disposition, reason = operator_disposition receipt in
   if needs_operator_broadcast disposition
   then (

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -1,0 +1,285 @@
+type cursor =
+  { cursor_ts : float
+  ; post_id : string option
+  }
+
+type stimulus_kind =
+  | Board_signal
+  | Bootstrap
+  | Alive_but_stuck_recovery
+  | Unknown of string
+
+type reaction_kind =
+  | Turn_started
+  | Execution_receipt
+  | Terminal_reason
+  | Cursor_ack
+  | Operator_escalation
+  | Unknown_reaction of string
+
+let schema = "keeper.reaction_ledger.v1"
+
+let stimulus_kind_to_string = function
+  | Board_signal -> "board_signal"
+  | Bootstrap -> "bootstrap"
+  | Alive_but_stuck_recovery -> "alive_but_stuck_recovery"
+  | Unknown value -> value
+;;
+
+let reaction_kind_to_string = function
+  | Turn_started -> "turn_started"
+  | Execution_receipt -> "execution_receipt"
+  | Terminal_reason -> "terminal_reason"
+  | Cursor_ack -> "cursor_ack"
+  | Operator_escalation -> "operator_escalation"
+  | Unknown_reaction value -> value
+;;
+
+let option_json f = function
+  | Some value -> f value
+  | None -> `Null
+;;
+
+let list_json values = `List (List.map (fun value -> `String value) values)
+
+let payload_preview payload =
+  let limit = 512 in
+  if String.length payload <= limit
+  then payload
+  else String.sub payload 0 limit ^ "...[truncated]"
+;;
+
+let digest_id prefix payload = prefix ^ ":" ^ Digest.to_hex (Digest.string payload)
+let board_stimulus_id ~post_id = "board:" ^ post_id
+
+let stimulus_kind_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
+  match Keeper_event_queue.classify stimulus with
+  | Board_signal -> Board_signal
+  | Bootstrap -> Bootstrap
+  | Alive_but_stuck_recovery -> Alive_but_stuck_recovery
+  | Unsupported prefix -> Unknown prefix
+;;
+
+let stimulus_id_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
+  match stimulus_kind_of_event_queue stimulus with
+  | Board_signal -> board_stimulus_id ~post_id:stimulus.post_id
+  | kind ->
+    digest_id
+      "stimulus"
+      (String.concat
+         "|"
+         [ stimulus.post_id
+         ; stimulus_kind_to_string kind
+         ; Printf.sprintf "%.6f" stimulus.arrived_at
+         ; stimulus.payload
+         ])
+;;
+
+let urgency_to_string = function
+  | Keeper_event_queue.Immediate -> "immediate"
+  | Normal -> "normal"
+  | Low -> "low"
+;;
+
+let store_dir ~masc_root ~keeper_name =
+  Filename.concat
+    (Filename.concat (Filename.concat masc_root "keepers") keeper_name)
+    "reaction-ledger"
+;;
+
+let store_for_base_path ~base_path ~keeper_name =
+  Dated_jsonl.create
+    ~base_dir:(store_dir ~masc_root:(Common.masc_dir_from_base_path ~base_path) ~keeper_name)
+    ()
+;;
+
+let store_for_config config ~keeper_name =
+  Dated_jsonl.create
+    ~base_dir:(store_dir ~masc_root:(Coord.masc_root_dir config) ~keeper_name)
+    ()
+;;
+
+let base_fields ~record_kind ~event_id ~keeper_name ~recorded_at =
+  [ "schema", `String schema
+  ; "record_kind", `String record_kind
+  ; "event_id", `String event_id
+  ; "keeper_name", `String keeper_name
+  ; "recorded_at_unix", `Float recorded_at
+  ]
+;;
+
+let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
+  let kind = stimulus_kind_of_event_queue stimulus in
+  let stimulus_id = stimulus_id_of_event_queue stimulus in
+  let recorded_at = Time_compat.now () in
+  `Assoc
+    (base_fields
+       ~record_kind:"stimulus"
+       ~event_id:(digest_id "krl" (stimulus_id ^ "|stimulus"))
+       ~keeper_name
+       ~recorded_at
+     @ [ "stimulus_id", `String stimulus_id
+       ; ( "stimulus"
+         , `Assoc
+             [ "kind", `String (stimulus_kind_to_string kind)
+             ; "source", `String "keeper_event_queue"
+             ; "post_id", `String stimulus.post_id
+             ; "urgency", `String (urgency_to_string stimulus.urgency)
+             ; "arrived_at_unix", `Float stimulus.arrived_at
+             ; "payload_preview", `String (payload_preview stimulus.payload)
+             ] )
+       ])
+;;
+
+let record_event_queue_stimulus ~base_path ~keeper_name stimulus =
+  Dated_jsonl.append
+    (store_for_base_path ~base_path ~keeper_name)
+    (stimulus_json ~keeper_name stimulus)
+;;
+
+let event_queue_reaction_json ~keeper_name ~reaction_kind stimulus =
+  let stimulus_id = stimulus_id_of_event_queue stimulus in
+  let recorded_at = Time_compat.now () in
+  `Assoc
+    (base_fields
+       ~record_kind:"reaction"
+       ~event_id:
+         (digest_id
+            "krl"
+            (String.concat
+               "|"
+               [ stimulus_id
+               ; reaction_kind_to_string reaction_kind
+               ; Printf.sprintf "%.6f" recorded_at
+               ]))
+       ~keeper_name
+       ~recorded_at
+     @ [ "stimulus_id", `String stimulus_id
+       ; ( "reaction"
+         , `Assoc
+             [ "kind", `String (reaction_kind_to_string reaction_kind)
+             ; "source", `String "keeper_event_queue"
+             ; "post_id", `String stimulus.post_id
+             ; "stimulus_kind", `String (stimulus_kind_to_string (stimulus_kind_of_event_queue stimulus))
+             ] )
+       ])
+;;
+
+let record_event_queue_reaction ~base_path ~keeper_name ~reaction_kind stimulus =
+  Dated_jsonl.append
+    (store_for_base_path ~base_path ~keeper_name)
+    (event_queue_reaction_json ~keeper_name ~reaction_kind stimulus)
+;;
+
+let cursor_json { cursor_ts; post_id } =
+  `Assoc
+    [ "scope", `String "board"
+    ; "cursor_ts", `Float cursor_ts
+    ; "post_id", option_json (fun value -> `String value) post_id
+    ]
+;;
+
+let record_board_cursor_ack
+      ~base_path
+      ~keeper_name
+      ?stimulus_id
+      ~cursor_ts
+      ~post_id
+      ()
+  =
+  let cursor = { cursor_ts; post_id } in
+  let stimulus_id =
+    match stimulus_id, post_id with
+    | Some value, _ -> value
+    | None, Some post_id -> board_stimulus_id ~post_id
+    | None, None -> digest_id "cursor" (Printf.sprintf "%.6f" cursor_ts)
+  in
+  let recorded_at = Time_compat.now () in
+  let json =
+    `Assoc
+      (base_fields
+         ~record_kind:"cursor_ack"
+         ~event_id:
+           (digest_id
+              "krl"
+              (String.concat
+                 "|"
+                 [ stimulus_id; "cursor_ack"; Printf.sprintf "%.6f" cursor_ts ]))
+         ~keeper_name
+         ~recorded_at
+       @ [ "stimulus_id", `String stimulus_id
+         ; "cursor", cursor_json cursor
+         ; ( "reaction"
+           , `Assoc
+               [ "kind", `String (reaction_kind_to_string Cursor_ack)
+               ; "source", `String "keeper_world_observation.board_cursor"
+               ; "cursor_acked", `Bool true
+               ] )
+         ])
+  in
+  Dated_jsonl.append (store_for_base_path ~base_path ~keeper_name) json
+;;
+
+let receipt_reaction_kind ~terminal_reason_code =
+  let trimmed = String.trim terminal_reason_code in
+  if trimmed = "" || String.equal trimmed "completed"
+  then Execution_receipt
+  else Terminal_reason
+;;
+
+let record_execution_receipt_reaction
+      config
+      ~keeper_name
+      ~trace_id
+      ?turn_count
+      ~current_task_id
+      ~goal_ids
+      ~outcome
+      ~terminal_reason_code
+      ~receipt_json
+      ()
+  =
+  let reaction_kind = receipt_reaction_kind ~terminal_reason_code in
+  let recorded_at = Time_compat.now () in
+  let stimulus_id =
+    match current_task_id with
+    | Some task_id -> "task:" ^ task_id
+    | None -> digest_id "turn" (keeper_name ^ "|" ^ trace_id)
+  in
+  let json =
+    `Assoc
+      (base_fields
+         ~record_kind:"reaction"
+         ~event_id:
+           (digest_id
+              "krl"
+              (String.concat
+                 "|"
+                 [ stimulus_id
+                 ; trace_id
+                 ; reaction_kind_to_string reaction_kind
+                 ; Printf.sprintf "%.6f" recorded_at
+                 ]))
+         ~keeper_name
+         ~recorded_at
+       @ [ "stimulus_id", `String stimulus_id
+         ; ( "reaction"
+           , `Assoc
+               [ "kind", `String (reaction_kind_to_string reaction_kind)
+               ; "source", `String "keeper_execution_receipt"
+               ; "trace_id", `String trace_id
+               ; "turn_count", option_json (fun value -> `Int value) turn_count
+               ; "current_task_id", option_json (fun value -> `String value) current_task_id
+               ; "goal_ids", list_json goal_ids
+               ; "outcome", `String outcome
+               ; "terminal_reason_code", `String terminal_reason_code
+               ; "receipt", receipt_json
+               ] )
+         ])
+  in
+  Dated_jsonl.append (store_for_config config ~keeper_name) json
+;;
+
+let read_recent_for_keeper ~base_path ~keeper_name ~limit =
+  Dated_jsonl.read_recent (store_for_base_path ~base_path ~keeper_name) limit
+;;

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -1,0 +1,77 @@
+(** Durable keeper stimulus -> reaction ledger.
+
+    This is the runtime mirror for the KeeperReactionLiveness L1/L5
+    contract: queue-visible stimuli, turn reactions, execution receipts, and
+    board cursor acknowledgements are written to a replayable JSONL store under
+    [.masc/keepers/<keeper>/reaction-ledger/YYYY-MM/DD.jsonl]. *)
+
+type cursor =
+  { cursor_ts : float
+  ; post_id : string option
+  }
+
+type stimulus_kind =
+  | Board_signal
+  | Bootstrap
+  | Alive_but_stuck_recovery
+  | Unknown of string
+
+type reaction_kind =
+  | Turn_started
+  | Execution_receipt
+  | Terminal_reason
+  | Cursor_ack
+  | Operator_escalation
+  | Unknown_reaction of string
+
+val stimulus_kind_to_string : stimulus_kind -> string
+val reaction_kind_to_string : reaction_kind -> string
+
+val board_stimulus_id : post_id:string -> string
+(** Stable id for board-originated stimuli. *)
+
+val stimulus_id_of_event_queue : Keeper_event_queue.stimulus -> string
+(** Stable id derived from the event queue stimulus payload. *)
+
+val record_event_queue_stimulus :
+  base_path:string -> keeper_name:string -> Keeper_event_queue.stimulus -> unit
+(** Append a [record_kind="stimulus"] row for an enqueued stimulus. *)
+
+val record_event_queue_reaction :
+  base_path:string ->
+  keeper_name:string ->
+  reaction_kind:reaction_kind ->
+  Keeper_event_queue.stimulus ->
+  unit
+(** Append a [record_kind="reaction"] row tied to an event queue stimulus. *)
+
+val record_board_cursor_ack :
+  base_path:string ->
+  keeper_name:string ->
+  ?stimulus_id:string ->
+  cursor_ts:float ->
+  post_id:string option ->
+  unit ->
+  unit
+(** Append a durable cursor acknowledgement. Callers should write this before
+    advancing the in-memory board cursor so every cursor advance has a replayable
+    ack row. *)
+
+val record_execution_receipt_reaction :
+  Coord.config ->
+  keeper_name:string ->
+  trace_id:string ->
+  ?turn_count:int ->
+  current_task_id:string option ->
+  goal_ids:string list ->
+  outcome:string ->
+  terminal_reason_code:string ->
+  receipt_json:Yojson.Safe.t ->
+  unit ->
+  unit
+(** Append a reaction row that links a turn execution receipt back into the
+    keeper reaction ledger. *)
+
+val read_recent_for_keeper :
+  base_path:string -> keeper_name:string -> limit:int -> Yojson.Safe.t list
+(** Read the newest rows for tests and dashboards. *)

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1962,7 +1962,20 @@ let enqueue_event ~base_path name stimulus =
       let next = Keeper_event_queue.enqueue cur stimulus in
       if not (Atomic.compare_and_set entry.event_queue cur next) then loop ()
     in
-    loop ()
+    loop ();
+    (try
+       Keeper_reaction_ledger.record_event_queue_stimulus
+         ~base_path
+         ~keeper_name:name
+         stimulus
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Log.Keeper.warn
+         "registry: reaction ledger stimulus append failed name=%s post_id=%s: %s"
+         name
+         stimulus.Keeper_event_queue.post_id
+         (Printexc.to_string exn))
 ;;
 
 let event_queue_snapshot ~base_path name =
@@ -1980,7 +1993,24 @@ let dequeue_event ~base_path name =
       match Keeper_event_queue.dequeue cur with
       | None -> None
       | Some (stim, rest) ->
-        if Atomic.compare_and_set entry.event_queue cur rest then Some stim else loop ()
+        if Atomic.compare_and_set entry.event_queue cur rest
+        then (
+          (try
+             Keeper_reaction_ledger.record_event_queue_reaction
+               ~base_path
+               ~keeper_name:name
+               ~reaction_kind:Keeper_reaction_ledger.Turn_started
+               stim
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+             Log.Keeper.warn
+               "registry: reaction ledger dequeue append failed name=%s post_id=%s: %s"
+               name
+               stim.Keeper_event_queue.post_id
+               (Printexc.to_string exn));
+          Some stim)
+        else loop ()
     in
     loop ()
 ;;
@@ -1992,7 +2022,27 @@ let drain_board_events ?window_sec ~base_path name =
     let rec loop () =
       let cur = Atomic.get entry.event_queue in
       let board, rest = Keeper_event_queue.drain_board_window ?window_sec cur in
-      if Atomic.compare_and_set entry.event_queue cur rest then board else loop ()
+      if Atomic.compare_and_set entry.event_queue cur rest
+      then (
+        List.iter
+          (fun stim ->
+             try
+               Keeper_reaction_ledger.record_event_queue_reaction
+                 ~base_path
+                 ~keeper_name:name
+                 ~reaction_kind:Keeper_reaction_ledger.Turn_started
+                 stim
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
+               Log.Keeper.warn
+                 "registry: reaction ledger board drain append failed name=%s post_id=%s: %s"
+                 name
+                 stim.Keeper_event_queue.post_id
+                 (Printexc.to_string exn))
+          board;
+        board)
+      else loop ()
     in
     loop ()
 ;;

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -987,6 +987,13 @@ let collect_board_events_with_cursor_policy
                (ts, post_id)
                (fst base_cursor, Option.value ~default:"" (snd base_cursor))
              > 0 ->
+        Keeper_reaction_ledger.record_board_cursor_ack
+          ~base_path
+          ~keeper_name:meta.name
+          ~stimulus_id:(Keeper_reaction_ledger.board_stimulus_id ~post_id)
+          ~cursor_ts:ts
+          ~post_id:(Some post_id)
+          ();
         Keeper_registry.set_board_cursor ~base_path meta.name ts (Some post_id)
       | Some (ts, post_id) ->
         Log.Keeper.debug

--- a/test/dune
+++ b/test/dune
@@ -211,6 +211,7 @@
         test_tool_deep_review
         test_tool_call_quality_benchmark
         test_keeper_prompt_metrics
+        test_keeper_reaction_ledger
         test_cache_metrics_wiring
         test_tool_surface_ssot
         test_keeper_retrieval_quality
@@ -460,6 +461,7 @@
           test_tool_deep_review
           test_tool_call_quality_benchmark
           test_keeper_prompt_metrics
+          test_keeper_reaction_ledger
           test_cache_metrics_wiring
           test_tool_surface_ssot
           test_keeper_retrieval_quality

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -1,0 +1,161 @@
+open Alcotest
+open Masc_mcp
+open Yojson.Safe.Util
+
+let with_temp_base f =
+  let base_path = Filename.temp_file "masc-krl-" "" in
+  Sys.remove base_path;
+  Unix.mkdir base_path 0o755;
+  f base_path
+;;
+
+let board_payload ~post_id =
+  `Assoc
+    [ "source", `String "board_signal"
+    ; "kind", `String "post_created"
+    ; "post_id", `String post_id
+    ; "author", `String "operator"
+    ; "title", `String "Ship reaction ledger"
+    ; "content", `String "Please react"
+    ]
+  |> Yojson.Safe.to_string
+;;
+
+let board_stimulus ?(post_id = "post-42") () : Keeper_event_queue.stimulus =
+  { post_id
+  ; urgency = Immediate
+  ; arrived_at = 1234.5
+  ; payload = board_payload ~post_id
+  }
+;;
+
+let check_member_string label expected key json =
+  check string label expected (json |> member key |> to_string)
+;;
+
+let latest_row rows =
+  match List.rev rows with
+  | row :: _ -> row
+  | [] -> fail "expected at least one reaction ledger row"
+;;
+
+let test_event_queue_stimulus_and_turn_reaction () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "ledger-keeper" in
+  let stimulus = board_stimulus () in
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    stimulus;
+  Keeper_reaction_ledger.record_event_queue_reaction
+    ~base_path
+    ~keeper_name
+    ~reaction_kind:Keeper_reaction_ledger.Turn_started
+    stimulus;
+  let rows =
+    Keeper_reaction_ledger.read_recent_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check int "two rows persisted" 2 (List.length rows);
+  let stimulus_row = List.nth rows 0 in
+  check_member_string "stimulus schema" "keeper.reaction_ledger.v1" "schema" stimulus_row;
+  check_member_string "stimulus record kind" "stimulus" "record_kind" stimulus_row;
+  check_member_string "board stimulus id" "board:post-42" "stimulus_id" stimulus_row;
+  check_member_string
+    "stimulus kind"
+    "board_signal"
+    "kind"
+    (stimulus_row |> member "stimulus");
+  let reaction_row = List.nth rows 1 in
+  check_member_string "reaction record kind" "reaction" "record_kind" reaction_row;
+  check_member_string "reaction stimulus id" "board:post-42" "stimulus_id" reaction_row;
+  check_member_string
+    "reaction kind"
+    "turn_started"
+    "kind"
+    (reaction_row |> member "reaction")
+;;
+
+let test_cursor_ack_is_replayable_state_entry () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "cursor-keeper" in
+  Keeper_reaction_ledger.record_board_cursor_ack
+    ~base_path
+    ~keeper_name
+    ~cursor_ts:5678.25
+    ~post_id:(Some "post-99")
+    ();
+  let row =
+    Keeper_reaction_ledger.read_recent_for_keeper ~base_path ~keeper_name ~limit:1
+    |> latest_row
+  in
+  check_member_string "cursor ack record kind" "cursor_ack" "record_kind" row;
+  check_member_string "cursor ack stimulus id" "board:post-99" "stimulus_id" row;
+  check (float 0.0001) "cursor timestamp" 5678.25
+    (row |> member "cursor" |> member "cursor_ts" |> to_float);
+  check_member_string "cursor post id" "post-99" "post_id" (row |> member "cursor");
+  check bool "cursor acked" true
+    (row |> member "reaction" |> member "cursor_acked" |> to_bool)
+;;
+
+let test_execution_receipt_links_to_reaction_ledger () =
+  with_temp_base @@ fun base_path ->
+  let config = Coord.default_config base_path in
+  let keeper_name = "receipt-keeper" in
+  let receipt_json =
+    `Assoc
+      [ "schema", `String "keeper.execution_receipt.v1"
+      ; "trace_id", `String "trace-1"
+      ; "outcome", `String "receipt_failed"
+      ; "terminal_reason_code", `String "tool_contract_violation"
+      ]
+  in
+  Keeper_reaction_ledger.record_execution_receipt_reaction
+    config
+    ~keeper_name
+    ~trace_id:"trace-1"
+    ~turn_count:7
+    ~current_task_id:(Some "task-275")
+    ~goal_ids:[ "goal-world-reactivity-p0-20260517" ]
+    ~outcome:"receipt_failed"
+    ~terminal_reason_code:"tool_contract_violation"
+    ~receipt_json
+    ();
+  let row =
+    Keeper_reaction_ledger.read_recent_for_keeper ~base_path ~keeper_name ~limit:1
+    |> latest_row
+  in
+  check_member_string "receipt reaction record kind" "reaction" "record_kind" row;
+  check_member_string "receipt reaction stimulus id" "task:task-275" "stimulus_id" row;
+  let reaction = row |> member "reaction" in
+  check_member_string "terminal reaction kind" "terminal_reason" "kind" reaction;
+  check_member_string
+    "terminal reason"
+    "tool_contract_violation"
+    "terminal_reason_code"
+    reaction;
+  check_member_string
+    "embedded receipt schema"
+    "keeper.execution_receipt.v1"
+    "schema"
+    (reaction |> member "receipt")
+;;
+
+let () =
+  run
+    "keeper_reaction_ledger"
+    [ ( "ledger"
+      , [ test_case
+            "event queue stimulus and turn reaction are durable"
+            `Quick
+            test_event_queue_stimulus_and_turn_reaction
+        ; test_case
+            "cursor ack is replayable state entry"
+            `Quick
+            test_cursor_ack_is_replayable_state_entry
+        ; test_case
+            "execution receipt links to reaction ledger"
+            `Quick
+            test_execution_receipt_links_to_reaction_ledger
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- add a durable Keeper Reaction Ledger under .masc/keepers/<keeper>/reaction-ledger
- record event-queue stimuli, turn-start reactions, execution-receipt reactions, and cursor-ack rows
- write board cursor ack rows before advancing the in-memory board cursor for task-275 / goal-world-reactivity-p0-20260517

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_reaction_ledger.ml lib/keeper/keeper_reaction_ledger.mli lib/keeper/keeper_registry.ml lib/keeper/keeper_world_observation.ml lib/keeper/keeper_execution_receipt.ml test/test_keeper_reaction_ledger.ml
- MASC_SKIP_PIN_CHECK=1 DUNE_LOCAL_JOBS=1 OCAMLPARAM=_,warn-error=-23 scripts/dune-local.sh build test/test_keeper_reaction_ledger.exe
- env OCAMLPARAM=_,warn-error=-23 _build/default/test/test_keeper_reaction_ledger.exe
- git diff --cached --check