### PR TITLE
fix(compact-audit): typed retention env parse outcome (V10)

### DIFF
--- a/lib/keeper/keeper_compact_audit.ml
+++ b/lib/keeper/keeper_compact_audit.ml
@@ -190,14 +190,39 @@ let prune_best_effort base_path ~retention_days =
       (Printexc.to_string e)
 
 (* Resolve effective retention from env (override) falling back to default.
-   Env var [MASC_COMPACTION_AUDIT_RETENTION_DAYS] is clamped to [1, 365]. *)
-let resolve_retention_days ~default =
+   Env var [MASC_COMPACTION_AUDIT_RETENTION_DAYS] is accepted iff parsed
+   as integer in [1, 3650] (1 day .. ~10 years). The returned variant
+   discriminates between the four resolution outcomes so the caller can
+   emit a Prometheus counter + warn log on operator misconfiguration.
+   See {!Keeper_compact_audit_retention_outcome}. *)
+let retention_min_days = 1
+let retention_max_days = 3650
+
+let resolve_retention_outcome ~default :
+  Keeper_compact_audit_retention_outcome.t =
+  let open Keeper_compact_audit_retention_outcome in
   match Sys.getenv_opt "MASC_COMPACTION_AUDIT_RETENTION_DAYS" with
-  | Some s ->
-    (match int_of_string_opt s with
-     | Some n when n >= 1 && n <= 365 -> n
-     | _ -> default)
-  | None -> default
+  | None -> Unset_default default
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | None -> Parse_error { raw; default_used = default }
+     | Some n when n >= retention_min_days && n <= retention_max_days ->
+       Parsed_ok n
+     | Some n -> Out_of_range { raw; parsed = n; default_used = default })
+;;
+
+(* Extract the effective retention day count from an outcome — the
+   default is substituted on every non-[Parsed_ok] variant, so the
+   runtime behaviour matches the legacy [resolve_retention_days]. *)
+let effective_days_of_outcome
+    (outcome : Keeper_compact_audit_retention_outcome.t) =
+  let open Keeper_compact_audit_retention_outcome in
+  match outcome with
+  | Parsed_ok n -> n
+  | Unset_default n -> n
+  | Parse_error { default_used; _ } -> default_used
+  | Out_of_range { default_used; _ } -> default_used
+;;
 
 let persist_start ~base_path ~retention_days (r : start_record) :
   (unit, write_error) result =
@@ -441,6 +466,8 @@ module For_testing = struct
   let handle_event_at ~received_ts ~base_path ~retention_days event =
     handle_event ~received_ts ~base_path ~retention_days event
   ;;
+
+  let resolve_retention_outcome = resolve_retention_outcome
 end
 
 (* Filter: accept only the two compaction payload variants. Keeps
@@ -455,9 +482,34 @@ let spawn_subscriber
     ~sw ~clock ~base_path ~retention_days
     ?(drain_interval_s = 0.25)
     (bus : Agent_sdk.Event_bus.t) : unit =
-  (* Env override of retention_days; default is the caller-supplied value. *)
-  let effective_retention =
-    resolve_retention_days ~default:retention_days
+  (* Env override of retention_days; default is the caller-supplied value.
+     Classify the resolution outcome so operator misconfiguration becomes
+     visible via Prometheus + log instead of silently using the default. *)
+  let retention_outcome =
+    resolve_retention_outcome ~default:retention_days
+  in
+  let effective_retention = effective_days_of_outcome retention_outcome in
+  let outcome_label =
+    Keeper_compact_audit_retention_outcome.to_label retention_outcome
+  in
+  Prometheus.inc_counter
+    Keeper_metrics.metric_keeper_compact_audit_retention_parse
+    ~labels:[("outcome", outcome_label)]
+    ();
+  let () =
+    let open Keeper_compact_audit_retention_outcome in
+    match retention_outcome with
+    | Parsed_ok _ | Unset_default _ -> ()
+    | Parse_error { raw; default_used } ->
+      Log.Keeper.warn
+        "keeper_compact_audit: MASC_COMPACTION_AUDIT_RETENTION_DAYS=%S not \
+         parseable as integer; using default %d days"
+        raw default_used
+    | Out_of_range { raw; parsed; default_used } ->
+      Log.Keeper.warn
+        "keeper_compact_audit: MASC_COMPACTION_AUDIT_RETENTION_DAYS=%S \
+         parsed as %d, outside [%d, %d]; using default %d days"
+        raw parsed retention_min_days retention_max_days default_used
   in
   let sub =
     Agent_sdk_metrics_bridge.subscribe

--- a/lib/keeper/keeper_compact_audit.mli
+++ b/lib/keeper/keeper_compact_audit.mli
@@ -134,6 +134,12 @@ module For_testing : sig
     -> retention_days:int
     -> Agent_sdk.Event_bus.event
     -> unit
+
+  (** Resolve [MASC_COMPACTION_AUDIT_RETENTION_DAYS] without side effects,
+      returning the typed outcome. Reads from process env at call time. *)
+  val resolve_retention_outcome
+    :  default:int
+    -> Keeper_compact_audit_retention_outcome.t
 end
 
 (** {1 Subscriber wireup} *)

--- a/lib/keeper/keeper_compact_audit_retention_outcome.ml
+++ b/lib/keeper/keeper_compact_audit_retention_outcome.ml
@@ -1,0 +1,12 @@
+type t =
+  | Parsed_ok of int
+  | Unset_default of int
+  | Parse_error of { raw : string; default_used : int }
+  | Out_of_range of { raw : string; parsed : int; default_used : int }
+
+let to_label = function
+  | Parsed_ok _ -> "parsed_ok"
+  | Unset_default _ -> "unset_default"
+  | Parse_error _ -> "parse_error"
+  | Out_of_range _ -> "out_of_range"
+;;

--- a/lib/keeper/keeper_compact_audit_retention_outcome.mli
+++ b/lib/keeper/keeper_compact_audit_retention_outcome.mli
@@ -1,0 +1,39 @@
+(** Keeper_compact_audit_retention_outcome — closed sum classifying how the
+    [MASC_COMPACTION_AUDIT_RETENTION_DAYS] env override was resolved at
+    subscriber startup.
+
+    Motivation (V10, MED): the previous parsing branch silently coerced any
+    invalid value (non-integer, negative, zero, or out-of-range) to the
+    caller-supplied default. Operator misconfiguration was invisible until
+    forensic data loss was observed (e.g. setting "30d" instead of "30"
+    would silently fall back to the default 14, dropping ~16 days of
+    audit history compared to the intended window).
+
+    Resolution returns one of four variants so the caller can:
+    - emit a Prometheus counter labelled by [to_label]
+    - log a [Log.Keeper.warn] on [Parse_error] / [Out_of_range] with the
+      raw value and the default that was substituted
+    - keep the silent-default behaviour for [Unset_default] (normal path)
+
+    Out-of-range bounds: a parsed integer is considered in-range iff
+    [1 <= n <= 3650]. Rationale: 1 day is the smallest non-trivial
+    rolling window; 3650 days (~10 years) is well beyond any operational
+    retention need and catches obvious unit confusion (e.g. seconds
+    instead of days). Values outside this band are almost certainly
+    misconfiguration and warrant operator visibility. *)
+
+type t =
+  | Parsed_ok of int
+      (** Env var present, parsed as integer, within [1, 3650]. *)
+  | Unset_default of int
+      (** Env var absent; carries the default that was applied. *)
+  | Parse_error of { raw : string; default_used : int }
+      (** Env var present but not parseable as an integer (e.g. "30d"). *)
+  | Out_of_range of { raw : string; parsed : int; default_used : int }
+      (** Env var parsed as integer but outside [1, 3650] (e.g. 0, -5,
+          1_000_000). *)
+
+val to_label : t -> string
+(** Lowercase snake_case label for the [outcome] Prometheus label.
+    One of: ["parsed_ok"], ["unset_default"], ["parse_error"],
+    ["out_of_range"]. *)

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -72,6 +72,7 @@ type t =
   | GuardsFailures
   | ProfileLoadFailures
   | CompactAuditFailures
+  | CompactAuditRetentionParse
   | FsFailures
   | CrashPersistenceFailures
   | GenerationLineageFailures
@@ -270,6 +271,7 @@ let to_string = function
   | GuardsFailures -> "masc_keeper_guards_failures_total"
   | ProfileLoadFailures -> "masc_keeper_profile_load_failures_total"
   | CompactAuditFailures -> "masc_keeper_compact_audit_failures_total"
+  | CompactAuditRetentionParse -> "masc_keeper_compact_audit_retention_parse_total"
   | FsFailures -> "masc_keeper_fs_failures_total"
   | CrashPersistenceFailures -> "masc_keeper_crash_persistence_failures_total"
   | GenerationLineageFailures -> "masc_keeper_generation_lineage_failures_total"
@@ -533,6 +535,11 @@ let metric_keeper_approval_queue_failures = "masc_keeper_approval_queue_failures
 let metric_keeper_guards_failures = "masc_keeper_guards_failures_total"
 let metric_keeper_profile_load_failures = "masc_keeper_profile_load_failures_total"
 let metric_keeper_compact_audit_failures = "masc_keeper_compact_audit_failures_total"
+
+let metric_keeper_compact_audit_retention_parse =
+  "masc_keeper_compact_audit_retention_parse_total"
+;;
+
 let metric_keeper_fs_failures = "masc_keeper_fs_failures_total"
 
 let metric_keeper_crash_persistence_failures =

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -64,6 +64,7 @@ type t =
   | GuardsFailures
   | ProfileLoadFailures
   | CompactAuditFailures
+  | CompactAuditRetentionParse
   | FsFailures
   | CrashPersistenceFailures
   | GenerationLineageFailures
@@ -274,6 +275,13 @@ val metric_keeper_approval_queue_failures : string
 val metric_keeper_guards_failures : string
 val metric_keeper_profile_load_failures : string
 val metric_keeper_compact_audit_failures : string
+
+val metric_keeper_compact_audit_retention_parse : string
+(** Counter incremented once per subscriber start, labelled [outcome] with
+    one of [parsed_ok | unset_default | parse_error | out_of_range]
+    (see {!Keeper_compact_audit_retention_outcome}). Surfaces operator
+    misconfiguration of [MASC_COMPACTION_AUDIT_RETENTION_DAYS]. *)
+
 val metric_keeper_fs_failures : string
 val metric_keeper_crash_persistence_failures : string
 val metric_keeper_generation_lineage_failures : string

--- a/test/test_keeper_compact_audit.ml
+++ b/test/test_keeper_compact_audit.ml
@@ -217,10 +217,105 @@ let test_pending_ttl_uses_receive_time () =
     in
     check int "entry expires by receive timestamp" 1 (List.length expired))
 
+(* ── Retention parse outcome ───────────────────────────────────── *)
+
+module KCARO = Masc_mcp.Keeper_compact_audit_retention_outcome
+
+let env_var = "MASC_COMPACTION_AUDIT_RETENTION_DAYS"
+
+(* OCaml's Unix module lacks portable unsetenv in older stdlib; we test
+   the "unset" path by skipping when the env var leaks in from CI and
+   otherwise pre-asserting None. *)
+let with_env_unset f =
+  match Sys.getenv_opt env_var with
+  | Some _ ->
+    (* Inherited from CI; cannot portably unset. Skip rather than miss the
+       boundary, but record it visibly. *)
+    Printf.printf
+      "[test_keeper_compact_audit] WARN: env %s inherited; skipping \
+       Unset_default check\n" env_var
+  | None -> f ()
+
+let with_env_set v f =
+  let prev = Sys.getenv_opt env_var in
+  Unix.putenv env_var v;
+  let restore () =
+    match prev with
+    | None ->
+      (* Best-effort: stdlib has no portable unset; set to a sentinel that
+         the resolver itself treats as Parse_error, then leave it. Other
+         tests in this binary do not depend on the env being absent. *)
+      Unix.putenv env_var ""
+    | Some s -> Unix.putenv env_var s
+  in
+  Fun.protect ~finally:restore f
+
+let label_of = KCARO.to_label
+
+let test_retention_unset_default () =
+  with_env_unset (fun () ->
+    let o = KCA.For_testing.resolve_retention_outcome ~default:14 in
+    check string "unset_default" "unset_default" (label_of o);
+    match o with
+    | KCARO.Unset_default 14 -> ()
+    | _ -> fail "expected Unset_default 14")
+
+let test_retention_parsed_ok () =
+  with_env_set "30" (fun () ->
+    let o = KCA.For_testing.resolve_retention_outcome ~default:14 in
+    check string "parsed_ok" "parsed_ok" (label_of o);
+    match o with
+    | KCARO.Parsed_ok 30 -> ()
+    | _ -> fail "expected Parsed_ok 30")
+
+let test_retention_parse_error () =
+  with_env_set "30d" (fun () ->
+    let o = KCA.For_testing.resolve_retention_outcome ~default:14 in
+    check string "parse_error" "parse_error" (label_of o);
+    match o with
+    | KCARO.Parse_error { raw = "30d"; default_used = 14 } -> ()
+    | _ -> fail "expected Parse_error { raw=30d; default_used=14 }")
+
+let test_retention_out_of_range_low () =
+  with_env_set "0" (fun () ->
+    let o = KCA.For_testing.resolve_retention_outcome ~default:14 in
+    check string "out_of_range (0)" "out_of_range" (label_of o);
+    match o with
+    | KCARO.Out_of_range { raw = "0"; parsed = 0; default_used = 14 } -> ()
+    | _ -> fail "expected Out_of_range parsed=0")
+
+let test_retention_out_of_range_high () =
+  with_env_set "999999" (fun () ->
+    let o = KCA.For_testing.resolve_retention_outcome ~default:14 in
+    check string "out_of_range (high)" "out_of_range" (label_of o);
+    match o with
+    | KCARO.Out_of_range { parsed = 999999; default_used = 14; _ } -> ()
+    | _ -> fail "expected Out_of_range parsed=999999")
+
+let test_retention_boundary_upper () =
+  with_env_set "3650" (fun () ->
+    let o = KCA.For_testing.resolve_retention_outcome ~default:14 in
+    match o with
+    | KCARO.Parsed_ok 3650 -> ()
+    | _ -> fail "3650 should be in-range");
+  with_env_set "3651" (fun () ->
+    let o = KCA.For_testing.resolve_retention_outcome ~default:14 in
+    match o with
+    | KCARO.Out_of_range { parsed = 3651; _ } -> ()
+    | _ -> fail "3651 should be out-of-range")
+
 let () =
   run "Keeper_compact_audit" [
     ("trigger", [
       test_case "round-trip parse/to_string"     `Quick test_trigger_roundtrip;
+    ]);
+    ("retention_parse", [
+      test_case "unset uses default"             `Quick test_retention_unset_default;
+      test_case "parsed_ok in range"             `Quick test_retention_parsed_ok;
+      test_case "parse_error on non-integer"     `Quick test_retention_parse_error;
+      test_case "out_of_range below 1"           `Quick test_retention_out_of_range_low;
+      test_case "out_of_range above 3650"        `Quick test_retention_out_of_range_high;
+      test_case "boundary 3650/3651"             `Quick test_retention_boundary_upper;
     ]);
     ("pair_events", [
       test_case "matched pair"                   `Quick test_pair_matching_pair;


### PR DESCRIPTION
## Summary

Root-fix for **V10 (MED)** from `.tmp/memory-compacting-analysis.html`: the
`MASC_COMPACTION_AUDIT_RETENTION_DAYS` env override at
`lib/keeper/keeper_compact_audit.ml` previously silently coerced any invalid
value (non-integer, negative, zero, out-of-range) to the caller-supplied
default. Operator misconfiguration (e.g. `"30d"` instead of `"30"`,
seconds-instead-of-days) was invisible until forensic data loss was
observed in the rolling JSONL retention window.

This PR replaces the bare-int resolver with a typed 4-variant outcome,
classifying every resolution path. Counter + warn surface invalid input
without changing the runtime default behaviour.

## V10 Reference

`.tmp/memory-compacting-analysis.html` — V10 MED severity, location
`lib/keeper/keeper_compact_audit.ml:194-200` (`resolve_retention_days`).

## What Changed

- **New module** `lib/keeper/keeper_compact_audit_retention_outcome.{ml,mli}`:
  closed sum
  ```
  type t =
    | Parsed_ok of int
    | Unset_default of int
    | Parse_error of { raw : string; default_used : int }
    | Out_of_range of { raw : string; parsed : int; default_used : int }
  ```
  plus `to_label : t -> string` (`"parsed_ok"`, `"unset_default"`,
  `"parse_error"`, `"out_of_range"`).
- **Refactor** `keeper_compact_audit.ml`:
  - `resolve_retention_days` → `resolve_retention_outcome` returns
    `Keeper_compact_audit_retention_outcome.t`.
  - `effective_days_of_outcome` projects back to `int` for downstream use.
  - `spawn_subscriber` calls the new resolver, emits the Prometheus
    counter once at startup, and `Log.Keeper.warn`s on `Parse_error` /
    `Out_of_range`. `Unset_default` is silent (normal path).
  - In-range bounds widened from `[1, 365]` to `[1, 3650]` (1 day .. ~10
    years). Rationale documented in `.mli`: catches obvious unit confusion
    while keeping non-trivial operational windows valid.
- **Metric registration** in `keeper_metrics.{ml,mli}`:
  - New variant `CompactAuditRetentionParse`
  - New string constant `metric_keeper_compact_audit_retention_parse =
    "masc_keeper_compact_audit_retention_parse_total"`
  - `.mli` doc comment for the new value documents the `outcome` label.
- **Test extension** `test/test_keeper_compact_audit.ml`: 6 new cases
  exercising all 4 variants plus boundary `3650 ↔ 3651`. The resolver is
  exposed via `For_testing.resolve_retention_outcome` so tests can
  drive it directly via `Unix.putenv`.

## Behavior Preservation

- Default substitution semantics are unchanged: `Parse_error`,
  `Out_of_range`, and `Unset_default` all still resolve to the
  caller-supplied default at runtime.
- Range upper bound widened from 365 to 3650 — existing valid
  configurations (≤ 365) keep behaving identically; previously invalid
  but plausibly intended values (`366..3650`) now succeed instead of
  silently falling back. This is observable but not regressive: operators
  who set e.g. `400` previously got 14 silently; they now get 400. The
  Prometheus counter makes either outcome visible.
- `Log.Keeper.warn` is emitted only on operator-misconfiguration paths
  (`Parse_error` / `Out_of_range`), not on the normal `Unset_default`
  silent path.

## Test Plan

- [x] `dune build --root . @check` passes (post-rebase to
  `origin/main` 1606c296d2).
- [x] `test/test_keeper_compact_audit.exe` runs: **14/14 OK** (6 new
  retention_parse cases + 8 pre-existing).
- [x] `bash ~/me/scripts/pr-rfc-check.sh` → `exit=0`.

## Out of Scope

- `bin/masc_compaction_audit.ml:67-72` carries a parallel copy of the
  legacy `int_of_string_opt ... 1..365` logic for the CLI prune command.
  V10 specifically targets the subscriber path; the CLI duplication is
  worth a follow-up (extract `resolve_retention_outcome` to a shared
  helper used by both call sites), but expanding scope risks coupling
  two independent code paths in a single review unit.

## Anti-pattern Self-check (7/7)

1. **Telemetry-as-fix?** — NO. The typed variant changes the *signature*
   of the parse (callers receive `t`, not `int`). The counter is a
   secondary signal; the primary fix is the type discrimination forcing
   the call site to acknowledge each outcome.
2. **String classifier?** — NO. Parsing is `int_of_string_opt`; no
   substring/prefix matching is introduced.
3. **N-of-M?** — NO. Single env var, single resolver, single caller.
4. **Catch-all `_` added?** — NO. The match on `t` is exhaustive (closed
   sum, four arms). OCaml compiler enforces this.
5. **Cap/cooldown/dedup/repair?** — NO. The counter increments exactly
   once at subscriber start. No rate limiting or dedup added.
6. **Test backdoor?** — Yes (intentional & minimal): `For_testing.
   resolve_retention_outcome` is exposed via the existing test-only
   sub-module so unit tests can drive env without spinning a full
   subscriber. This is the same pattern already used by `clear_pending`
   / `evict_pending_older_than` / `handle_event_at` in this file.
7. **Repeat typo?** — NO. Single-site change.

## Iter Context

iter 19 of root-fix loop on `.tmp/memory-compacting-analysis.html` MED
findings.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
