### PR TITLE
fix(compact-policy): detect malformed env override before defaulting (Codex P2 follow-up #15782)

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -33,25 +33,47 @@ let emergency_compact_ratio_threshold : float =
   let default_value = 0.8 in
   let min_valid = 0.5 in
   let max_valid = 0.99 in
-  let raw = Env_config_core.get_float ~default:default_value env_var in
+  (* Read raw env directly (not Env_config_core.get_float ~default) so we can
+     distinguish three observable cases:
+       1. env unset           → silent default
+       2. env set & parses    → validate range; warn on out-of-range
+       3. env set & malformed → warn explicitly with distinct message
+     get_float ~default collapses (1) and (3) into the same float value,
+     making operator typos (e.g. "foo" or "0,9" with comma) indistinguishable
+     from the unset case. The subsequent Float.equal raw default_value check
+     then suppresses the warn path entirely. (Codex P2 review of PR #15782.) *)
   let effective =
-    if (not (Float.is_finite raw)) || raw < min_valid || raw > max_valid
-    then (
-      (* Only warn when an explicit override was supplied and out of range;
-         silently accept the default fall-through case (raw = default_value
-         and default is in-range). *)
-      if not (Float.equal raw default_value)
-      then
-        Log.Harness.warn
-          "[compact_policy] %s=%f out of range [%.2f, %.2f]; falling back to default \
-           %.2f"
-          env_var
-          raw
-          min_valid
-          max_valid
-          default_value;
-      default_value)
-    else raw
+    match Sys.getenv_opt env_var with
+    | None -> default_value
+    | Some raw ->
+      (match Float.of_string_opt (String.trim raw) with
+       | None ->
+         Log.Harness.warn
+           "[compact_policy] %s=%S is not a parseable float; falling back to default \
+            %.2f"
+           env_var
+           raw
+           default_value;
+         default_value
+       | Some parsed when not (Float.is_finite parsed) ->
+         Log.Harness.warn
+           "[compact_policy] %s=%s parsed to non-finite %f; falling back to default %.2f"
+           env_var
+           raw
+           parsed
+           default_value;
+         default_value
+       | Some parsed when parsed < min_valid || parsed > max_valid ->
+         Log.Harness.warn
+           "[compact_policy] %s=%f out of range [%.2f, %.2f]; falling back to default \
+            %.2f"
+           env_var
+           parsed
+           min_valid
+           max_valid
+           default_value;
+         default_value
+       | Some parsed -> parsed)
   in
   (* Surface the effective value for operators via /metrics. Registered
      here so the gauge exists from module init regardless of whether any


### PR DESCRIPTION
## Summary

Follows up #15782 (merged) addressing Codex P2.

PR #15782 (V13) added env-override for `emergency_compact_ratio_threshold` via `Env_config_core.get_float ~default:0.8`. Codex P2 review correctly identified a silent-failure path:

> "...parse failure is converted to 0.8 before validation. In that case the out-of-range/non-finite branch never runs, `Float.equal raw default_value` is true, and no warning is emitted, so operator typos are silently ignored and the process runs with an unintended threshold."

Concrete reproduction:
```
MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD=foo  # typo
# → get_float returns default 0.8
# → Float.equal raw 0.8 is true
# → warn skipped
# → operator never knows their typo was ignored, process uses 0.8 silently
```

Same path for `=0,9` (comma instead of period — Locale typo).

## Before / After

### Before (PR #15782 V13, current main)
```ocaml
let raw = Env_config_core.get_float ~default:default_value env_var in
let effective =
  if (not (Float.is_finite raw)) || raw < min_valid || raw > max_valid
  then (
    if not (Float.equal raw default_value)
    then Log.Harness.warn "[compact_policy] %s=%f out of range ..." ...;
    default_value)
  else raw
in
```

- `env unset` → `raw = 0.8` → silent default (correct)
- `env = "0.85"` → `raw = 0.85` → in-range, used (correct)
- `env = "foo"` → `get_float` swallows parse error, returns `0.8` → `Float.equal raw 0.8` true → warn SUPPRESSED, operator typo invisible (BUG)
- `env = "0,9"` → same as `foo` (Locale typo invisible) (BUG)
- `env = "1.5"` → `raw = 1.5` → out-of-range branch → warn fires → default (correct)
- `env = "nan"` → `get_float` likely returns 0.8 fallback (parse failure path same as `foo`) (BUG)

### After (this PR)
```ocaml
let effective =
  match Sys.getenv_opt env_var with
  | None -> default_value
  | Some raw ->
    (match Float.of_string_opt (String.trim raw) with
     | None -> warn "is not a parseable float"; default_value
     | Some parsed when not (Float.is_finite parsed) -> warn "parsed to non-finite"; default_value
     | Some parsed when parsed < min_valid || parsed > max_valid -> warn "out of range"; default_value
     | Some parsed -> parsed)
in
```

- `env unset` → `default_value`, no warn (UNCHANGED — normal path)
- `env = "0.85"` → `parsed = 0.85`, no warn (UNCHANGED — normal path)
- `env = "foo"` → warn **"is not a parseable float"** (NEW visibility)
- `env = "0,9"` → warn **"is not a parseable float"** (NEW visibility)
- `env = "1.5"` → warn **"out of range"** (UNCHANGED behavior, different message)
- `env = "nan"` / `"inf"` → warn **"parsed to non-finite"** (NEW — separately classified)

Three distinct warn messages so the symptom differs in operator logs.

## Why structural, not symptomatic

Replacing `get_float ~default` with `Sys.getenv_opt` + `Float.of_string_opt` is a **typed-outcome refactor**, not a workaround. The previous design conflated three observable states (unset / parse-fail / in-range-default) into a single float value; the post-state `Float.equal` check then attempted to recover the distinction and failed for the parse-fail case. The fix removes the conflation at the source.

## Anti-Pattern Self-Check (7/7)

1. [ ] **telemetry-as-fix only?** — NO. This is structural: three distinct error branches replace the silent-coerce-to-default path. Counters/gauges unchanged.
2. [ ] **string classifier added?** — NO. Only `Float.of_string_opt` typed parse on the raw string; no substring match, no prefix/suffix classifier.
3. [ ] **N-of-M patch?** — NO. Single env var, single call site, no migration debt.
4. [ ] **catch-all `_ ->` added?** — NO. Each `match` branch is explicit: `None`, `None` (of_string), `Some _ when not finite`, `Some _ when out of range`, `Some parsed`. No wildcards.
5. [ ] **cap/cooldown/dedup/repair to suppress symptom?** — NO. The default fallback IS the documented safety floor (per the module docstring); this PR adds visibility on malformed-env case — that's parse correctness, not symptom suppression.
6. [ ] **test backdoor exposed?** — NO. No `set_X_for_test` / `reset_for_test`.
7. [ ] **repeat typo N times?** — NO. No N-site fix.

All 7 PASS.

## Verification

- Build: `dune build --root . lib/keeper` → clean
- RFC check: `bash ~/me/scripts/pr-rfc-check.sh` → exit 0
- Behavior preserved on (a) env unset and (b) env in-range
- Behavior change on env set to malformed: now WARNS where it didn't before

## Test plan

- [ ] Run `MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD=foo` against a keeper process; observe new warn "is not a parseable float"
- [ ] Run `MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD=0,9` (comma); observe same warn (Locale typo now visible)
- [ ] Run `MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD=nan`; observe warn "parsed to non-finite"
- [ ] Run `MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD=1.5`; observe warn "out of range" (unchanged)
- [ ] Run without env set; observe no warn, default 0.8 used (unchanged)
- [ ] Run `MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD=0.85`; observe no warn, 0.85 used (unchanged)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
