### PR TITLE
fix(keeper): preflight unhealthy local runtimes

### DIFF
--- a/lib/cascade/cascade_declarative_adapter.ml
+++ b/lib/cascade/cascade_declarative_adapter.ml
@@ -186,6 +186,7 @@ let provider_config_from_declared_provider
   in
   match provider.transport with
   | Http base_url ->
+    let base_url = Masc_network_defaults.normalize_loopback_base_url base_url in
     (match provider_kind_for_http_provider ?registry_entry provider with
      | Some kind ->
        let request_path =

--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -399,6 +399,42 @@ let runtime_urls candidates =
          let base_url = candidate.provider_cfg.base_url in
          if base_url = "" then None else Some base_url)
 
+let local_runtime_url candidate =
+  if not (Llm_provider.Provider_config.is_local candidate.provider_cfg)
+  then None
+  else
+    candidate.provider_cfg.base_url
+    |> trim_nonempty
+    |> Option.map Masc_network_defaults.normalize_loopback_base_url
+
+let local_runtime_urls candidates =
+  candidates
+  |> List.filter_map local_runtime_url
+  |> Json_util.dedupe_keep_order
+
+let endpoint_health_lookup endpoint_health url =
+  let normalized_url = Masc_network_defaults.normalize_loopback_base_url url in
+  List.find_map
+    (fun (endpoint_url, healthy) ->
+      let endpoint_url =
+        Masc_network_defaults.normalize_loopback_base_url endpoint_url
+      in
+      if String.equal endpoint_url normalized_url then Some healthy else None)
+    endpoint_health
+
+let filter_unhealthy_local_runtime_urls ~endpoint_health candidates =
+  let kept_rev, dropped =
+    List.fold_left
+      (fun (kept, dropped) candidate ->
+        match local_runtime_url candidate with
+        | Some url when endpoint_health_lookup endpoint_health url = Some false ->
+            kept, url :: dropped
+        | _ -> candidate :: kept, dropped)
+      ([], [])
+      candidates
+  in
+  List.rev kept_rev, dropped |> List.rev |> Json_util.dedupe_keep_order
+
 let http_probe_urls candidates =
   candidates |> List.filter_map (fun candidate -> candidate.http_probe_url)
 

--- a/lib/cascade/cascade_runtime_candidate.mli
+++ b/lib/cascade/cascade_runtime_candidate.mli
@@ -103,6 +103,17 @@ val capacity_key : t -> string
 val capacity_keys : t list -> string list
 
 val runtime_urls : t list -> string list
+val local_runtime_urls : t list -> string list
+(** Normalized, de-duplicated loopback-aware URLs for local HTTP runtime
+    candidates only. *)
+
+val filter_unhealthy_local_runtime_urls :
+  endpoint_health:(string * bool) list -> t list -> t list * string list
+(** Drop local runtime candidates whose normalized endpoint appears in
+    [endpoint_health] with [false]. Unknown endpoints are kept so a
+    partial discovery result does not become a hard config failure.
+    Returns the filtered candidates and the de-duplicated dropped URLs. *)
+
 val http_probe_urls : t list -> string list
 val register_http_probe_capable : max_concurrent:int -> t -> unit
 

--- a/lib/config/masc_network_defaults.ml
+++ b/lib/config/masc_network_defaults.ml
@@ -120,6 +120,42 @@ let is_loopback_host_opt = function
   | Some host -> is_loopback_host host
   | None -> false
 
+let trim_trailing_slashes value =
+  let len = String.length value in
+  let rec last_non_slash i =
+    if i < 0 || value.[i] <> '/' then i else last_non_slash (i - 1)
+  in
+  let last = last_non_slash (len - 1) in
+  if last = len - 1 then value else String.sub value 0 (last + 1)
+
+let normalize_loopback_host host =
+  let trimmed = String.trim host in
+  let normalized = String.lowercase_ascii trimmed in
+  match normalized with
+  | "localhost" -> masc_http_default_host
+  | _ -> (
+      match Ipaddr.of_string normalized with
+      | Ok ip -> (
+          match ip with
+          | Ipaddr.V6 addr ->
+              if Ipaddr.V6.compare addr Ipaddr.V6.localhost = 0 then
+                masc_http_default_host
+              else trimmed
+          | Ipaddr.V4 _ -> trimmed)
+      | Error _ -> trimmed)
+
+let normalize_loopback_base_url base_url =
+  let trimmed = String.trim base_url |> trim_trailing_slashes in
+  let uri = Uri.of_string trimmed in
+  match Uri.host uri with
+  | Some host ->
+      let normalized_host = normalize_loopback_host host in
+      if String.equal normalized_host host then trimmed
+      else
+        Uri.with_host uri (Some normalized_host)
+        |> Uri.to_string |> trim_trailing_slashes
+  | None -> trimmed
+
 (** Default port for the dashboard's Vite dev server.  Used by
     [Server_auth.default_loopback_dev_mutation_origins] to whitelist
     the frontend dev origin on each loopback variant. *)

--- a/lib/config/masc_network_defaults.mli
+++ b/lib/config/masc_network_defaults.mli
@@ -78,6 +78,12 @@ val is_loopback_host : string -> bool
 (** Convenience for [Uri.host]-style inputs. [None] → [false]. *)
 val is_loopback_host_opt : string option -> bool
 
+val normalize_loopback_base_url : string -> string
+(** Strip trailing slashes from [base_url] and canonicalize loopback
+    aliases that can resolve to IPv6-only sockets in client libraries:
+    ["localhost"] and [[::1]] become {!masc_http_default_host}. Remote
+    hosts and IPv4 literals are preserved. *)
+
 (** {1 Vite dev frontend} *)
 
 val vite_dev_default_port : int

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -288,8 +288,31 @@ let run_named
   let tool_filtered_candidates =
     Cascade_runtime_candidate.of_provider_configs tool_filtered_candidate_cfgs
   in
+  let local_endpoint_health =
+    match Cascade_runtime_candidate.local_runtime_urls tool_filtered_candidates with
+    | [] -> []
+    | endpoints ->
+      Llm_provider.Discovery.refresh_and_sync ~sw ~net ~endpoints
+      |> List.map (fun (status : Llm_provider.Discovery.endpoint_status) ->
+             status.url, status.healthy)
+  in
+  let local_prefiltered_candidates, unhealthy_local_endpoints =
+    Cascade_runtime_candidate.filter_unhealthy_local_runtime_urls
+      ~endpoint_health:local_endpoint_health
+      tool_filtered_candidates
+  in
+  let local_prefiltered_candidate_count =
+    List.length local_prefiltered_candidates
+  in
+  if unhealthy_local_endpoints <> [] then
+    Log.Misc.warn
+      "cascade %s: preflight skipped %d unhealthy local endpoint(s) before \
+       provider dispatch: [%s]"
+      cascade_name
+      (List.length unhealthy_local_endpoints)
+      (String.concat ", " unhealthy_local_endpoints);
   let health_filtered_candidates =
-    tool_filtered_candidates
+    local_prefiltered_candidates
     |> List.filter
          (fun candidate ->
             match Cascade_runtime_candidate.first_health_cooldown candidate with
@@ -303,7 +326,7 @@ let run_named
   let health_filtered_candidate_count = List.length health_filtered_candidates in
   let candidates, health_cooldown_fail_open =
     fail_open_health_filtered_candidates
-      ~tool_filtered_candidates
+      ~tool_filtered_candidates:local_prefiltered_candidates
       ~health_filtered_candidates
   in
   if health_cooldown_fail_open then
@@ -311,11 +334,12 @@ let run_named
       "cascade %s: all tool-capable candidates are in health/cooldown; \
        fail-open to surface provider result instead of no_providers_available \
        configured_label_count=%d original_candidate_count=%d \
-       tool_filtered_candidate_count=%d"
+       tool_filtered_candidate_count=%d local_prefiltered_candidate_count=%d"
       cascade_name
       configured_label_count
       original_candidate_count
-      tool_filtered_candidate_count;
+      tool_filtered_candidate_count
+      local_prefiltered_candidate_count;
   let provider_attempt_provenance = base_provider_attempt_provenance in
   match candidates with
   | [] ->
@@ -343,19 +367,20 @@ let run_named
         | Tool_capability_empty ->
           "no tool-capable providers after capability filter"
         | Provider_unavailable ->
-          "providers unavailable after health/cooldown filter"
+          "providers unavailable after local preflight/health/cooldown filter"
       in
       Log.Misc.error
         "cascade %s: %s; classification=%s configured_label_count=%d \
          original_candidate_count=%d tool_filtered_candidate_count=%d \
-         health_filtered_candidate_count=%d require_tool_choice_support=%b \
-         require_tool_support=%b"
+         local_prefiltered_candidate_count=%d health_filtered_candidate_count=%d \
+         require_tool_choice_support=%b require_tool_support=%b"
         cascade_name
         exhaustion_summary
         classification_code
         configured_label_count
         original_candidate_count
         tool_filtered_candidate_count
+        local_prefiltered_candidate_count
         health_filtered_candidate_count
         require_tool_choice_support
         require_tool_support;
@@ -404,6 +429,15 @@ let run_named
                     ("candidate_count", `Int original_candidate_count);
                     ( "tool_filtered_candidate_count",
                       `Int tool_filtered_candidate_count );
+                    ( "local_prefiltered_candidate_count",
+                      `Int local_prefiltered_candidate_count );
+                    ( "unhealthy_local_endpoint_count",
+                      `Int (List.length unhealthy_local_endpoints) );
+                    ( "unhealthy_local_endpoints",
+                      `List
+                        (List.map
+                           (fun endpoint -> `String endpoint)
+                           unhealthy_local_endpoints) );
                     ( "health_filtered_candidate_count",
                       `Int health_filtered_candidate_count );
                     ( "rejected_candidate_count",

--- a/test/test_cascade_http_probe.ml
+++ b/test/test_cascade_http_probe.ml
@@ -32,6 +32,20 @@ let test_is_ollama_url_negative () =
   check bool "empty → not ollama" false
     (P.is_ollama_url "")
 
+let test_normalize_loopback_base_url () =
+  check string "localhost canonicalizes to IPv4 loopback"
+    "http://127.0.0.1:11434"
+    (Masc_network_defaults.normalize_loopback_base_url
+       "http://localhost:11434/");
+  check string "IPv6 loopback canonicalizes to IPv4 loopback"
+    "http://127.0.0.1:11434"
+    (Masc_network_defaults.normalize_loopback_base_url
+       "http://[::1]:11434/");
+  check string "remote host preserved"
+    "https://gpu.example.com:11434/v1"
+    (Masc_network_defaults.normalize_loopback_base_url
+       "https://gpu.example.com:11434/v1/")
+
 (* ── parse_response ─────────────────────────────────────────── *)
 
 let test_parse_response_one_loaded () =
@@ -156,6 +170,8 @@ let () =
     "is_ollama_url", [
       test_case "positive matches" `Quick test_is_ollama_url_positive;
       test_case "negative cases" `Quick test_is_ollama_url_negative;
+      test_case "loopback base URL canonicalization" `Quick
+        test_normalize_loopback_base_url;
     ];
     "Http_probe URL registry", [
       test_case "ollama_default_url registered at load" `Quick

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -2182,6 +2182,45 @@ let test_health_filter_fail_open_preserves_tool_capable_candidates () =
     candidates;
   Alcotest.(check bool) "no fallback without tool-capable candidates" false fail_open
 
+let provider_config ?(kind = Llm_provider.Provider_config.OpenAI_compat)
+    ~model_id ~base_url () =
+  Llm_provider.Provider_config.make ~kind ~model_id ~base_url ()
+
+let test_local_preflight_filters_unhealthy_local_endpoints () =
+  let module C = Masc_mcp.Cascade_runtime_candidate in
+  let ollama =
+    provider_config ~kind:Llm_provider.Provider_config.Ollama
+      ~model_id:"gemma4:e2b" ~base_url:"http://localhost:11434/" ()
+  in
+  let cloud =
+    provider_config ~model_id:"glm-5-turbo"
+      ~base_url:"https://api.example.com/v1" ()
+  in
+  let candidates = C.of_provider_configs [ ollama; cloud ] in
+  Alcotest.(check (list string))
+    "local endpoint is normalized for discovery"
+    [ "http://127.0.0.1:11434" ]
+    (C.local_runtime_urls candidates);
+  let filtered, dropped =
+    C.filter_unhealthy_local_runtime_urls
+      ~endpoint_health:[ ("http://127.0.0.1:11434", false) ]
+      candidates
+  in
+  Alcotest.(check int) "unhealthy local candidate is dropped" 1
+    (List.length filtered);
+  Alcotest.(check (list string))
+    "dropped endpoint is normalized"
+    [ "http://127.0.0.1:11434" ]
+    dropped;
+  let filtered, dropped =
+    C.filter_unhealthy_local_runtime_urls
+      ~endpoint_health:[ ("http://127.0.0.1:11434", true) ]
+      candidates
+  in
+  Alcotest.(check int) "healthy local endpoint is kept" 2
+    (List.length filtered);
+  Alcotest.(check (list string)) "nothing dropped when healthy" [] dropped
+
 let test_keeper_cascade_engine_boundary () =
   let module E = Masc_mcp.Keeper_cascade_engine in
   let engine = E.keeper_managed in
@@ -2553,6 +2592,9 @@ let () =
             "health filter fail-open preserves tool-capable candidates"
             `Quick
             test_health_filter_fail_open_preserves_tool_capable_candidates;
+          Alcotest.test_case
+            "local preflight drops unhealthy local endpoints"
+            `Quick test_local_preflight_filters_unhealthy_local_endpoints;
           Alcotest.test_case "keeper cascade engine boundary is typed"
             `Quick test_keeper_cascade_engine_boundary;
           Alcotest.test_case "keeper hot path avoids OAS Complete_cascade"


### PR DESCRIPTION
## Summary
- normalize loopback provider base URLs so localhost/[::1] cascade endpoints use 127.0.0.1 consistently
- add opaque candidate-level local runtime preflight that drops discovery-unhealthy local endpoints before provider dispatch
- record local preflight counters/endpoints in pre-dispatch manifest decisions

## Verification
- scripts/dune-local.sh build test/test_keeper_runtime_manifest.exe test/test_cascade_http_probe.exe
- _build/default/test/test_cascade_http_probe.exe
- _build/default/test/test_keeper_runtime_manifest.exe (new local preflight case passed; existing wiring static assertion still fails on lib/server/server_dashboard_http_keeper_api.ml missing /runtime-trace)