### PR TITLE
fix(keeper-memory-recall): bound exception_class label cardinality (Codex P1 follow-up #15781)

### DIFF
--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -637,15 +637,25 @@ let load_history_user_messages ~(path : string) ~(max_n : int) : string list =
            (* V07 (HIGH): make non-Cancel failures visible instead of
               masking JSONL corruption / fs faults as "no history".
               Behavior preserved — we still drop this line and return
-              [None]; only logging + counter are added. *)
-           let exn_class = Printexc.to_string exn in
+              [None]; only logging + counter are added.
+
+              Codex P1 follow-up: the [exception_class] label is now a
+              4-value closed sum from [Keeper_memory_recall_exn_class]
+              (constructor-level match on the [exn] type, not a
+              substring scan on [Printexc.to_string]) so the metric
+              cardinality is bounded. The full error string is still
+              emitted to the log body. *)
+           let exn_detail = Printexc.to_string exn in
+           let exn_label =
+             Keeper_memory_recall_exn_class.(to_label (classify exn))
+           in
            Log.Keeper.warn
              "load_history_user_messages: skipping line in %s: %s"
-             path exn_class;
+             path exn_detail;
            Prometheus.inc_counter
              Keeper_metrics
              .metric_keeper_memory_bank_load_history_swallowed_exceptions
-             ~labels:[ ("exception_class", exn_class) ]
+             ~labels:[ ("exception_class", exn_label) ]
              ();
            None)
   |> take max_n

--- a/lib/keeper/keeper_memory_recall_exn_class.ml
+++ b/lib/keeper/keeper_memory_recall_exn_class.ml
@@ -1,0 +1,19 @@
+type t =
+  | Yojson_parse_error
+  | Io_error
+  | Type_error
+  | Other
+
+let classify : exn -> t = function
+  | Yojson.Json_error _ -> Yojson_parse_error
+  | Sys_error _ | Unix.Unix_error _ -> Io_error
+  | Failure _ | Yojson.Safe.Util.Type_error _ -> Type_error
+  | _ -> Other
+;;
+
+let to_label = function
+  | Yojson_parse_error -> "yojson_parse_error"
+  | Io_error -> "io_error"
+  | Type_error -> "type_error"
+  | Other -> "other"
+;;

--- a/lib/keeper/keeper_memory_recall_exn_class.mli
+++ b/lib/keeper/keeper_memory_recall_exn_class.mli
@@ -1,0 +1,45 @@
+(** Keeper_memory_recall_exn_class — closed sum for the [exception_class]
+    label on [metric_keeper_memory_bank_load_history_swallowed_exceptions].
+
+    Bounds the Prometheus label cardinality of the swallowed-exception
+    counter emitted from [Keeper_memory_recall.load_history_user_messages].
+
+    The previous implementation (PR #15781) passed [Printexc.to_string exn]
+    directly as the label value. That string carries exception-specific
+    detail (byte offsets, file paths, payload fragments from
+    [Yojson.Json_error]; per-syscall context from [Unix.Unix_error]; raw
+    [Failure] messages) so each distinct exception instance created a new
+    Prometheus time-series. Codex P1 flagged this as unbounded label
+    cardinality / balloonable in-process metric memory.
+
+    [classify] is a *constructor-level* pattern match on the OCaml [exn]
+    type, not a substring scan on [Printexc.to_string] output, so adding
+    a new mapping is type-checked, not text-heuristic. The full error
+    string is still emitted to the log line; only the *label* is bounded.
+*)
+
+type t =
+  | Yojson_parse_error
+      (** Matches [Yojson.Json_error _] — malformed JSON syntax in a
+          history.jsonl line. *)
+  | Io_error
+      (** Matches [Sys_error _] and [Unix.Unix_error _] — filesystem
+          / OS-level read failures. *)
+  | Type_error
+      (** Matches [Failure _] (raised by [to_string_option] / similar
+          conversion helpers) and [Yojson.Safe.Util.Type_error _]
+          (raised by [member]/[to_string] when the JSON shape is
+          wrong). *)
+  | Other
+      (** Terminal bucket — any exception not covered by the above
+          variants. Bounded by construction (single value). *)
+
+val classify : exn -> t
+(** Map an OCaml exception to its closed classification. The match
+    discriminates on the [exn] constructor; no string sniffing. *)
+
+val to_label : t -> string
+(** Render the classification as the wire label value used by
+    Prometheus. Returns one of the lowercase strings
+    {[ "yojson_parse_error" ]}, {[ "io_error" ]}, {[ "type_error" ]},
+    {[ "other" ]}. *)

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -522,10 +522,21 @@ val metric_keeper_session_cleanup_failures : string
 
 (** Counter for non-Cancel exceptions silently swallowed by the
     catch-all in [Keeper_memory_recall.load_history_user_messages].
-    Labels: [keeper] (when available), [exception_class] (from
-    [Printexc.to_string]). Behavior is unchanged (the function still
-    returns no row for the failing line); the counter exists so JSONL
-    corruption / fs faults stop masking as "no history". *)
+    Labels: [keeper] (when available), [exception_class] — a closed
+    4-value vocabulary from [Keeper_memory_recall_exn_class.to_label]:
+    {ul
+    {- [yojson_parse_error] — [Yojson.Json_error _]}
+    {- [io_error] — [Sys_error _] / [Unix.Unix_error _]}
+    {- [type_error] — [Failure _] / [Yojson.Safe.Util.Type_error _]}
+    {- [other] — terminal bucket for any other exception}}
+    Bounded cardinality by construction (constructor-level pattern
+    match on the [exn] type, not a substring scan on
+    [Printexc.to_string]) so the metric cannot balloon in-process
+    memory as malformed lines accumulate. Full [Printexc.to_string]
+    detail is retained in the [Log.Keeper.warn] body. Behavior is
+    unchanged (the function still returns no row for the failing
+    line); the counter exists so JSONL corruption / fs faults stop
+    masking as "no history". *)
 val metric_keeper_memory_bank_load_history_swallowed_exceptions : string
 val metric_keeper_path_resolver_identity_mismatch : string
 val metric_keeper_passive_loop_streak : string


### PR DESCRIPTION
## Summary

Follows up #15781 (merged) addressing Codex P1: **unbounded label cardinality** on `metric_keeper_memory_bank_load_history_swallowed_exceptions`.

### Codex P1 (verbatim)

> "...repeated malformed history lines can grow time-series and in-process metric memory without bound. Please map exceptions to a closed vocabulary for the label and keep the full error string only in logs."

### Root cause

PR #15781 wired the `exception_class` Prometheus label to `Printexc.to_string exn`. That string carries exception-specific detail:

- `Yojson.Json_error` → byte offset + message fragment
- `Sys_error` / `Unix.Unix_error` → file path + per-syscall context
- `Failure` / `Yojson.Safe.Util.Type_error` → raw payload-derived text

Every distinct exception instance creates a new Prometheus time-series. Process metric memory grows unbounded as malformed history.jsonl lines accumulate.

### Fix

Introduce `lib/keeper/keeper_memory_recall_exn_class.{ml,mli}` — a closed 4-value sum:

| Variant | Constructor pattern | Label wire value |
|---|---|---|
| `Yojson_parse_error` | `Yojson.Json_error _` | `"yojson_parse_error"` |
| `Io_error` | `Sys_error _` \| `Unix.Unix_error _` | `"io_error"` |
| `Type_error` | `Failure _` \| `Yojson.Safe.Util.Type_error _` | `"type_error"` |
| `Other` | terminal catch-all | `"other"` |

`classify : exn -> t` is a **constructor-level pattern match on the OCaml `exn` type**, not a substring/regex scan on `Printexc.to_string` text. Adding a new mapping is type-checked, not text-heuristic.

Wire site change in `lib/keeper/keeper_memory_recall.ml::load_history_user_messages`:

```ocaml
(* before — unbounded *)
let exn_class = Printexc.to_string exn in
... ~labels:[ ("exception_class", exn_class) ] ()

(* after — bounded to 4 values *)
let exn_detail = Printexc.to_string exn in
let exn_label =
  Keeper_memory_recall_exn_class.(to_label (classify exn))
in
Log.Keeper.warn
  "load_history_user_messages: skipping line in %s: %s"
  path exn_detail;
... ~labels:[ ("exception_class", exn_label) ] ()
```

Per Codex guidance: **full error string stays in `Log.Keeper.warn` body**; only the *Prometheus label* is bounded.

### Before / After cardinality

| | Label value space | Series-per-process upper bound |
|---|---|---|
| Before (V07) | range of `Printexc.to_string exn` → unbounded | unbounded |
| After | `{yojson_parse_error, io_error, type_error, other}` × keeper-label | 4 × `\|keepers\|` |

### Files touched

```
 lib/keeper/keeper_memory_recall.ml             | ~13 ±
 lib/keeper/keeper_memory_recall_exn_class.ml   | new (20 LoC)
 lib/keeper/keeper_memory_recall_exn_class.mli  | new (45 LoC interface + doc)
 lib/keeper/keeper_metrics.mli                  | doc rewrite (~+12 / -4)
```

`dune build --root . @check` — clean.

### Anti-pattern self-check (7/7)

1. **Telemetry-as-fix only?** — **NO.** This is a *structural* classifier that turns an unbounded problem into a bounded one *by type*. The metric was not removed; its label codomain was constrained.
2. **String classifier?** — **NO, explicitly.** `classify` matches on the OCaml `exn` *constructor* (`Yojson.Json_error _`, `Sys_error _`, `Unix.Unix_error _`, `Failure _`, `Yojson.Safe.Util.Type_error _`), **not on `Printexc.to_string exn` text**. No substring/regex/`starts_with`. This is the inverse anti-pattern: an exhaustive constructor match replaces a free-form string.
3. **N-of-M?** — **NO.** Single emit site (`load_history_user_messages`'s catch-all arm). The classifier is the only consumer.
4. **Catch-all `_ ->` added?** — `Other` is a *terminal, explicit variant* of the closed sum. Bounded by construction (single value). This is the correct exhaustive-match terminus, not a sparse FSM `_ -> false` skip.
5. **Cap / cooldown / dedup / repair?** — **NO.** No throttling, no demotion, no message rewrite. The metric still increments on every exception; only the label coordinate is folded into a 4-value alphabet.
6. **Test backdoor (`set_X_for_test` / `reset_for_test`)?** — **NO.** Classifier is pure; no module-level state.
7. **Repeat typo / N-site fix?** — **NO.** Single emit site, single classifier, no other replicas in the codebase (`rg "Printexc.to_string exn" lib/` of this PR site is the only occurrence used as a metric label).

### Verification

- `dune build --root . @check` — clean (re-run after rebase onto latest origin/main).
- `bash ~/me/scripts/pr-rfc-check.sh` → exit 0 (no RFC-gated subsystem touched).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
