### PR TITLE
[codex] fix cascade model output caps in tier inference

### DIFF
--- a/lib/cascade/cascade_declarative_adapter.ml
+++ b/lib/cascade/cascade_declarative_adapter.ml
@@ -175,6 +175,20 @@ let supports_tool_choice_override_of_model_spec (spec : cascade_model_spec) =
   | None -> None
 ;;
 
+let max_output_tokens_of_model_spec (spec : cascade_model_spec) =
+  match spec.capabilities with
+  | Some capabilities -> capabilities.max_output_tokens
+  | None -> None
+;;
+
+let effective_max_tokens_for_model spec requested =
+  match requested, max_output_tokens_of_model_spec spec with
+  | Some configured, Some capability -> Some (min configured capability)
+  | Some configured, None -> Some configured
+  | None, Some capability -> Some capability
+  | None, None -> None
+;;
+
 let provider_config_from_declared_provider
     (provider : cascade_provider)
     (spec : cascade_model_spec)
@@ -184,6 +198,7 @@ let provider_config_from_declared_provider
   let supports_tool_choice_override =
     supports_tool_choice_override_of_model_spec spec
   in
+  let max_tokens = effective_max_tokens_for_model spec max_tokens in
   match provider.transport with
   | Http base_url ->
     let base_url = Masc_network_defaults.normalize_loopback_base_url base_url in

--- a/test/test_cascade_capability_gate.ml
+++ b/test/test_cascade_capability_gate.ml
@@ -333,6 +333,75 @@ target = "tier-group.strict_tool_candidates"
         ~provider_ceiling:ceiling resolved
       |> check_ok "narrowest failover value accepted" 8192)
 
+let test_resolve_tier_group_max_tokens_uses_model_capability_ceiling () =
+  let cascade_name =
+    Masc_mcp.Keeper_cascade_profile.Runtime_name
+      "tier-group.strict_tool_candidates"
+  in
+  with_temp_cascade_toml
+    {|
+[providers.runpod_mtp]
+protocol = "openai-http"
+endpoint = "https://example.test/v1"
+
+[providers.glm-coding]
+protocol = "openai-http"
+endpoint = "https://glm.example.test/v1"
+
+[models.qwen36-mtp]
+api-name = "qwen"
+max-context = 160000
+tools-support = true
+
+[models.qwen36-mtp.capabilities]
+max-output-tokens = 8192
+supports-tool-choice = true
+
+[models.glm-turbo]
+api-name = "glm-5-turbo"
+max-context = 128000
+tools-support = true
+
+[models.glm-turbo.capabilities]
+max-output-tokens = 16384
+supports-tool-choice = true
+
+[runpod_mtp.qwen36-mtp]
+is-default = true
+
+[runpod_mtp.qwen36-mtp.keeper]
+temperature = 0.3
+
+[glm-coding.glm-turbo]
+is-default = true
+
+[glm-coding.glm-turbo.keeper]
+max-output = 16384
+temperature = 0.3
+
+[tier.strict_tool_candidates]
+members = ["runpod_mtp.qwen36-mtp.keeper", "glm-coding.glm-turbo.keeper"]
+strategy = "failover"
+
+[tier-group.strict_tool_candidates]
+tiers = ["strict_tool_candidates"]
+strategy = "failover"
+
+[routes.keeper_turn]
+target = "tier-group.strict_tool_candidates"
+|}
+    (fun () ->
+      let ceiling = CR.max_output_tokens_ceiling_of_cascade_name cascade_name in
+      check (option int) "tier-group output ceiling" (Some 8192) ceiling;
+      let resolved =
+        CI.resolve_max_tokens ~cascade_name ~fallback:(fun () -> 65536)
+      in
+      check int "tier-group max_tokens follows model capability ceiling" 8192
+        resolved;
+      CI.validate_max_tokens_within_ceiling ~cascade_name
+        ~provider_ceiling:ceiling resolved
+      |> check_ok "model capability capped value accepted" 8192)
+
 let () =
   run "cascade_capability_gate" [
     "max_tokens_ceiling_validation", [
@@ -362,5 +431,9 @@ let () =
         "provider-derived max_tokens matches failover ceiling"
         `Quick
         test_resolve_provider_derived_max_tokens_matches_failover_ceiling;
+      test_case
+        "tier-group max_tokens uses model capability ceiling"
+        `Quick
+        test_resolve_tier_group_max_tokens_uses_model_capability_ceiling;
     ];
   ]

--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -225,6 +225,82 @@ strategy = "failover"
          "expected at least two candidates, got %d"
          (List.length candidates))
 
+let test_tier_group_inference_max_tokens_uses_model_capability () =
+  let toml =
+    {|
+[providers.runpod_mtp]
+protocol = "openai-http"
+endpoint = "https://example.test/v1"
+
+[providers.glm-coding]
+protocol = "openai-http"
+endpoint = "https://glm.example.test/v1"
+
+[models.qwen36-mtp]
+max-context = 160000
+api-name = "qwen"
+tools-support = true
+
+[models.qwen36-mtp.capabilities]
+max-output-tokens = 8192
+supports-tool-choice = true
+
+[models.glm-turbo]
+max-context = 128000
+api-name = "glm-5-turbo"
+tools-support = true
+
+[models.glm-turbo.capabilities]
+max-output-tokens = 16384
+supports-tool-choice = true
+
+[runpod_mtp.qwen36-mtp]
+is-default = true
+
+[runpod_mtp.qwen36-mtp.keeper]
+temperature = 0.3
+
+[glm-coding.glm-turbo]
+is-default = true
+
+[glm-coding.glm-turbo.keeper]
+max-output = 16384
+temperature = 0.3
+
+[tier.strict_tool_candidates]
+members = ["runpod_mtp.qwen36-mtp.keeper", "glm-coding.glm-turbo.keeper"]
+strategy = "failover"
+
+[tier-group.strict_tool_candidates]
+tiers = ["strict_tool_candidates"]
+strategy = "failover"
+|}
+  in
+  let snapshot = get_snapshot toml in
+  let strict = find_profile snapshot "tier-group.strict_tool_candidates" in
+  check
+    (option int)
+    "tier-group max_tokens follows narrowest model capability"
+    (Some 8192)
+    strict.Hotpath.inference_params.max_tokens;
+  match strict.Hotpath.candidates with
+  | qwen :: glm :: _ ->
+    check
+      (option int)
+      "qwen candidate inherits model output cap"
+      (Some 8192)
+      qwen.Hotpath.provider_cfg.Llm_provider.Provider_config.max_tokens;
+    check
+      (option int)
+      "glm candidate keeps alias cap"
+      (Some 16384)
+      glm.Hotpath.provider_cfg.Llm_provider.Provider_config.max_tokens
+  | candidates ->
+    fail
+      (Printf.sprintf
+         "expected at least two candidates, got %d"
+         (List.length candidates))
+
 let test_model_string_format () =
   let snapshot = get_snapshot valid_toml in
   let local = find_profile snapshot "tier.local" in
@@ -665,6 +741,10 @@ let () =
           "failover inference max_tokens uses narrowest candidate"
           `Quick
           test_failover_inference_max_tokens_uses_narrowest_candidate;
+        test_case
+          "tier-group max_tokens uses model capability"
+          `Quick
+          test_tier_group_inference_max_tokens_uses_model_capability;
         test_case "strategy preserved" `Quick test_strategy_preserved;
         test_case "probes field absent" `Quick test_probes_field_absent;
         test_case "ollama_max_concurrent" `Quick test_ollama_max_concurrent;


### PR DESCRIPTION
## Summary

- carry `models.*.capabilities.max-output-tokens` into declarative provider configs
- bound requested/provider-derived max tokens by the tighter of explicit config and model output capability
- add regression coverage for tier-group max token inference when the narrowest candidate only declares a model capability, not an alias `max-output`

## Root Cause

Live Qwen MTP candidates declared `max-output-tokens = 8192` at the model capability layer, but the declarative hotpath only propagated alias-level `max-output` into `Provider_config.max_tokens`. Tier-group inference therefore saw the GLM 16384 candidate as the narrowest positive budget, while the pre-dispatch ceiling parser separately saw the Qwen 8192 cap. That split produced repeated `max_tokens_ceiling_violation` before dispatch.

## Validation

- `git diff --check`
- `ocamlformat --check lib/cascade/cascade_declarative_adapter.ml test/test_cascade_declarative_hotpath.ml test/test_cascade_capability_gate.ml`

Focused Dune tests were attempted but not completed locally because the shared `/tmp/me-dune-local.lock` queue was saturated by other worktrees. CI should run the new `test_cascade_declarative_hotpath` and `test_cascade_capability_gate` coverage.