### PR TITLE
feat(compact-policy): Prometheus counter for pair-repair fabrications (C1 MASC-side)

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -317,6 +317,26 @@ let compact_if_needed_typed
       ~labels:[ "keeper", meta.name ]
       ~delta:(float_of_int saved_tokens)
       ();
+    (* C1 (CRIT) from oas-internal-audit.html §6: surface pair-repair
+       fabrication counts via /metrics so operators can alert on rising
+       fabrication rate without grepping the JSONL [tool_pair_repair]
+       structured log block emitted below. Increment by *count*, not by 1,
+       so the counter reflects fabrication volume rather than call
+       frequency. Kind label is a closed 2-value vocabulary (no Printexc-
+       style unbounded label) — see iter 21 / PR #15788 for the same
+       pattern. The was_fabricated:true message-metadata half is
+       RFC-scope (touches MASC + OAS message-record shape) and deferred. *)
+    let bump_pair_repair kind count =
+      if count > 0
+      then
+        Prometheus.inc_counter
+          Keeper_metrics.metric_keeper_compaction_pair_repair_fabrications
+          ~labels:[ "keeper", meta.name; "kind", kind ]
+          ~delta:(float_of_int count)
+          ()
+    in
+    bump_pair_repair "downgraded_tool_use" pair_repair_stats.downgraded_tool_uses;
+    bump_pair_repair "downgraded_tool_result" pair_repair_stats.downgraded_tool_results;
     Log.emit
       Log.Info
       ~module_name:"Harness"

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -504,6 +504,10 @@ let metric_keeper_compactions = "masc_keeper_compactions_total"
 let metric_keeper_compaction_ratio_change = "masc_keeper_compaction_ratio_change"
 let metric_keeper_compaction_saved_tokens = "masc_keeper_compaction_saved_tokens_total"
 
+let metric_keeper_compaction_pair_repair_fabrications =
+  "masc_keeper_compaction_pair_repair_fabrications_total"
+;;
+
 (* Effective emergency compaction ratio threshold (set once at module init
    from [MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD], clamped [0.5,0.99]).
    Gauge so operators can confirm the live value via /metrics without

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -254,6 +254,39 @@ val metric_keeper_compactions : string
 val metric_keeper_compaction_ratio_change : string
 val metric_keeper_compaction_saved_tokens : string
 
+(** Total tool-call pair-repair downgrades observed at the compaction call
+    site (post-compact, after [Context_compact_oas.compact] +
+    [Agent_sdk.Context_reducer.reduce fold_reducer]) inside
+    {!Keeper_compact_policy}. Incremented by
+    [pair_repair_stats.downgraded_tool_uses] /
+    [.downgraded_tool_results] returned from
+    [Keeper_context_core.repair_broken_tool_call_pairs_with_stats].
+
+    Closes the Prometheus-counter half of C1 (CRIT) from
+    [oas-internal-audit.html §6]: the JSONL [tool_pair_repair] structured
+    log alone gave operators no [/metrics] view, so fabrication-rate
+    alerts required JSONL grep. This counter exposes the same numbers via
+    the standard Prometheus surface.
+
+    Labels:
+    - [keeper]: keeper name.
+    - [kind]: closed 2-value vocabulary —
+      {ul {- [downgraded_tool_use]: a [tool_use] block whose paired
+            [tool_result] was lost during compaction was rewritten to
+            plain text instead of fabricating a synthetic result.}
+          {- [downgraded_tool_result]: an orphan [tool_result] block was
+            rewritten to plain text instead of fabricating its parent
+            [tool_use].}}
+
+    Related: {!metric_keeper_tool_pair_repair} covers the keeper-reducer
+    site (pre-compact, inside [Keeper_run_tools]) with the same downgrade
+    semantics but a different label vocabulary
+    ([dangling_tool_use|orphan_tool_result]) tied to that site's
+    before/after diff. The [was_fabricated:true] message-record metadata
+    half of C1 is RFC-scope (touches message shape across MASC + OAS) and
+    deferred. *)
+val metric_keeper_compaction_pair_repair_fabrications : string
+
 (** Effective emergency compaction ratio threshold, set once at module
     init in {!Keeper_compact_policy} from the env override
     [MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD] (default 0.8,

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1389,6 +1389,19 @@ let init () =
      text instead of fabricating tool results. Labels: keeper, kind \
      (dangling_tool_use|orphan_tool_result), site."
     Counter;
+  (* C1 (CRIT) from oas-internal-audit.html §6: compaction call site
+     fabrication counter. Closes the Prometheus-counter half — the
+     was_fabricated:true message metadata half is RFC-scope. Kind label is
+     a closed 2-value vocabulary tied directly to pair_repair_stats from
+     Keeper_context_core.repair_broken_tool_call_pairs_with_stats. *)
+  add
+    Keeper_metrics.metric_keeper_compaction_pair_repair_fabrications
+    "Total tool-call pair-repair downgrades at the compaction call site \
+     (Keeper_compact_policy, after Context_compact_oas.compact + keeper fold reducer). \
+     Incremented by pair_repair_stats counts, not by 1, so operators alert on \
+     fabrication volume rather than call frequency. Labels: keeper, kind \
+     (downgraded_tool_use|downgraded_tool_result)."
+    Counter;
   (* K5: per-keeper tool-emission accumulator registry size.
      Updated by Keeper_tool_emission_hook on register/drop. *)
   add


### PR DESCRIPTION
## Summary

Closes the Prometheus-counter half of **C1 (CRIT)** from `.tmp/oas-internal-audit.html` §6: `lib/keeper/keeper_compact_policy.ml:296` calls `Keeper_context_core.repair_broken_tool_call_pairs_with_stats` after every compaction, but the returned `pair_repair_stats { downgraded_tool_uses; downgraded_tool_results }` were surfaced **only via JSONL audit log** (`tool_pair_repair` structured block + printf summary). There was **no `/metrics` view**, so operators had to grep JSONL to alert on fabrication rate.

This PR adds `masc_keeper_compaction_pair_repair_fabrications_total` with a closed 2-value `kind` vocabulary, ticked by the stats count at the compaction call site so the counter measures **fabrication volume**, not call frequency.

The audit mitigation quote was:

> "repair에서 fabrication 발생 시 Prometheus counter + structured log + `was_fabricated: true` metadata 부착"

The structured-log half is already done (`tool_pair_repair` block at `keeper_compact_policy.ml:336-342`). This PR closes the **Prometheus counter half**. The `was_fabricated: true` *message-record metadata* half is **RFC-scope** (touches message shape across MASC + OAS) and **deferred**.

## Scope

- Counter half of C1 only.
- `was_fabricated:true` per-message metadata — **deferred to future RFC** (message-record shape spans MASC + OAS).
- No behavior change: `pair_repair_stats` was already computed and surfaced via JSONL. This PR only adds an additional emit path (`/metrics`) for the same numbers.

## Changes

- `lib/keeper/keeper_metrics.{ml,mli}`: register `metric_keeper_compaction_pair_repair_fabrications` with doc comment describing the closed `kind` vocabulary and the RFC-scope deferral.
- `lib/prometheus.ml`: HELP-string registration alongside existing `metric_keeper_tool_pair_repair`.
- `lib/keeper/keeper_compact_policy.ml`: emit two `Prometheus.inc_counter` calls (one per kind, gated by `count > 0`) immediately after the existing `metric_keeper_compaction_saved_tokens` emit, using `~delta:(float_of_int count)` so the counter reflects volume rather than call frequency.

## Closed-vocabulary `kind` label

The `kind` label is a **closed 2-value vocabulary**:

- `downgraded_tool_use`: a `tool_use` block whose paired `tool_result` was lost during compaction was rewritten to plain text instead of fabricating a synthetic result.
- `downgraded_tool_result`: an orphan `tool_result` block was rewritten to plain text instead of fabricating its parent `tool_use`.

Both label values are hardcoded literals in a 2-line `bump_pair_repair` helper at the call site — there is **no dynamic stringification path** (no `Printexc.to_string`, no error-message-derived label, no user input). Cardinality is bounded at 2 per keeper. This follows the iter 21 / PR #15788 pattern for closed-vocabulary labels.

## Iter 1 / PR #15679 cross-reference

PR #15679 introduced `repair_broken_tool_call_pairs_with_stats` and the underlying `pair_repair_stats` record inside `Keeper_context_core`. That work surfaced the counts via JSONL only. This PR is the operator-visibility follow-up that exposes the same counts via Prometheus at the **compaction call site** specifically (the keeper-reducer site already has `metric_keeper_tool_pair_repair`, but with a different label vocabulary tied to that site's before/after diff).

## Build

```
dune build --root . lib/prometheus.ml lib/keeper
```

clean.

## Anti-pattern self-check (7/7)

1. **Telemetry-as-fix only?** — Partly yes: the counter is an *alarm*, not a *fix*. **Justified**: C1 in oas-internal-audit.html §6 specifically requested a Prometheus counter as one of three mitigations. The structured-log half is done. The `was_fabricated:true` *message-metadata* half is RFC-scope (touches message-record shape across MASC + OAS) and explicitly deferred to a future RFC. This PR closes the counter half cleanly without expanding scope. The repair itself (downgrade to plain text rather than fabricate synthetic results) **is** the fix and lives in `Keeper_context_core.repair_broken_tool_call_pairs_with_stats` from PR #15679 — this PR only surfaces its operating volume to operators.
2. **String classifier?** — **NO**. The `kind` label is a closed 2-value vocabulary hardcoded as two literal calls in the `bump_pair_repair` helper. No `starts_with`, no `String.contains`, no substring matching. Adding a new kind requires a code change.
3. **N-of-M?** — **NO**. Single call site (`lib/keeper/keeper_compact_policy.ml:296`). No "PR #X only fixed M of N sites" admission.
4. **Catch-all?** — **NO**. No `_ ->` added. The two-arm helper exhaustively maps the two `pair_repair_stats` fields.
5. **Cap / cooldown / dedup / repair?** — **NO**. This is a counter emit, not a backpressure mechanism.
6. **Test backdoor?** — **NO**. No `set_X_for_test` / `reset_for_test` exposure.
7. **Repeat typo / N-site fix?** — **NO**. Single site, single new constant.

## Files

- `lib/keeper/keeper_metrics.ml` — register constant.
- `lib/keeper/keeper_metrics.mli` — `val` + doc comment.
- `lib/prometheus.ml` — HELP-string `add Counter`.
- `lib/keeper/keeper_compact_policy.ml` — `bump_pair_repair` helper + 2 invocations.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
