### PR TITLE
feat(server): migrate 10 callers to respond_mcp_error + deprecate legacy (RFC-0098 PR-3)

### DIFF
--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -286,7 +286,7 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
       match auth_result with
       | Ok () -> Ok ()
       | Error msg ->
-          respond_mcp_auth_error ~deps request reqd ~session_id
+          respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps request reqd ~session_id
             ~protocol_version msg;
           Error ()
     in
@@ -353,7 +353,7 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
         match request_runtime_result deps with
         | Ok r -> Ok r
         | Error msg ->
-            respond_mcp_internal_error ~deps request reqd
+            respond_mcp_error ~code:Mcp_error_code.Internal_error ~deps request reqd
               ~session_id ~protocol_version msg;
             Error ()
       in
@@ -507,7 +507,7 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
                                 (match !inline_sse with
                                 | Some info ->
                                     stream_post_sse_json info
-                                      (mcp_internal_error_json ?id:response_id
+                                      (error_body ~code:Mcp_error_code.Internal_error ?id:response_id
                                          ("Internal error: "
                                         ^ Printexc.to_string exn));
                                     stream_post_sse_finish info
@@ -516,7 +516,7 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
                                       get_protocol_version_for_session ~session_id
                                         request
                                     in
-                                    respond_mcp_internal_error ~deps request reqd
+                                    respond_mcp_error ~code:Mcp_error_code.Internal_error ~deps request reqd
                                       ~session_id ~protocol_version
                                       ("Internal error: "
                                      ^ Printexc.to_string exn))))))))
@@ -574,7 +574,7 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
       | Ok () ->
       (match auth_result with
       | Error msg ->
-          respond_mcp_auth_error ~deps request reqd ~session_id
+          respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps request reqd ~session_id
             ~protocol_version ~extra_headers:legacy_headers msg
       | Ok () ->
       remember_mcp_profile session_id profile;
@@ -705,7 +705,7 @@ let handle_get_operator_mcp ~deps request reqd =
   let base_path = deps.get_base_path () in
   match deps.verify_operator_mcp_auth ~base_path request with
   | Error msg ->
-      respond_mcp_auth_error ~deps request reqd ~session_id ~protocol_version
+      respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps request reqd ~session_id ~protocol_version
         msg
   | Ok () ->
       handle_get_mcp ~deps ~profile:Operator_remote request reqd
@@ -741,13 +741,13 @@ let handle_post_messages ~deps request reqd =
       let base_path = deps.get_base_path () in
       (match deps.verify_mcp_auth ~base_path request with
       | Error msg ->
-          respond_mcp_auth_error ~deps request reqd ~session_id
+          respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps request reqd ~session_id
             ~protocol_version ~extra_headers:legacy_headers msg
       | Ok () ->
           Http.Request.read_body_async reqd (fun body_str ->
               match request_runtime_result deps with
               | Error msg ->
-                  respond_mcp_internal_error ~extra_headers:legacy_headers
+                  respond_mcp_error ~code:Mcp_error_code.Internal_error ~extra_headers:legacy_headers
                     ~deps request reqd ~session_id ~protocol_version msg
               | Ok runtime ->
                   let sw = runtime.sw in
@@ -791,7 +791,7 @@ let handle_delete_mcp ~deps ?(profile = Full) request reqd =
   | Error msg ->
       let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
       let protocol_version = get_protocol_version_for_session ~session_id request in
-      respond_mcp_auth_error ~deps request reqd ~session_id ~protocol_version
+      respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps request reqd ~session_id ~protocol_version
         msg
   | Ok () -> (
       match get_session_id_any request with

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -168,7 +168,7 @@ let handle_presence_events ~deps request reqd =
   let base_path = deps.get_base_path () in
   match deps.verify_mcp_observer_stream_auth ~base_path request with
   | Error msg ->
-      respond_mcp_auth_error ~deps request reqd ~session_id:raw_session_id
+      respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps request reqd ~session_id:raw_session_id
         ~protocol_version msg
   | Ok () -> (
       match check_sse_connect_guard session_id with

--- a/lib/server/server_mcp_transport_http_respond.mli
+++ b/lib/server/server_mcp_transport_http_respond.mli
@@ -43,14 +43,18 @@ val respond_mcp_auth_error :
   protocol_version:string ->
   string ->
   unit
+  [@@deprecated
+    "RFC-0098 PR-3: all in-tree callers migrated. Use \
+     [respond_mcp_error ~code:Mcp_error_code.Auth_error ...]. This \
+     wrapper is scheduled for removal in PR-4."]
 (** [respond_mcp_auth_error ?extra_headers ~deps request reqd
     ~session_id ~protocol_version msg] writes a JSON-RPC 2.0 error
     response with code [-32001] and HTTP status [401 Unauthorized].
 
-    {b RFC-0098 PR-2 (this PR)}: now delegates to {!respond_mcp_error}
-    with [~code:Auth_error]. New call sites SHOULD prefer
-    {!respond_mcp_error}. A follow-up PR-2.1 will migrate all in-tree
-    callers and add a [\[@@deprecated\]] alert.
+    {b RFC-0098 PR-3 (this PR)}: all in-tree callers migrated to
+    {!respond_mcp_error} with [~code:Mcp_error_code.Auth_error].
+    Function kept as [\[@@deprecated\]] alias; scheduled removal in
+    PR-4.
 
     The response always carries [www-authenticate: Bearer]; this is
     pinned because the MCP client SDKs key off the literal challenge
@@ -73,15 +77,20 @@ val respond_mcp_internal_error :
   protocol_version:string ->
   string ->
   unit
+  [@@deprecated
+    "RFC-0098 PR-3: all in-tree callers migrated. Use \
+     [respond_mcp_error ~code:Mcp_error_code.Internal_error ...] (or \
+     a more specific code variant). This wrapper is scheduled for \
+     removal in PR-4."]
 (** [respond_mcp_internal_error ?extra_headers ~deps request reqd
     ~session_id ~protocol_version msg] writes a JSON-RPC 2.0 error
     response with code [-32603] (the standard "Internal error" slot)
     and HTTP status [500 Internal Server Error].
 
-    {b RFC-0098 PR-2 (this PR)}: now delegates to {!respond_mcp_error}
-    with [~code:Internal_error]. New call sites SHOULD prefer
-    {!respond_mcp_error} and a more specific code variant where one
-    fits (e.g. [Provider_timeout], [Tool_dispatch_failure]).
+    {b RFC-0098 PR-3 (this PR)}: all in-tree callers migrated to
+    {!respond_mcp_error} with [~code:Mcp_error_code.Internal_error].
+    Function kept as [\[@@deprecated\]] alias; scheduled removal in
+    PR-4.
 
     Used as the catch-all for runtime failures the transport cannot
     classify more precisely.  The wording of [msg] is operator-visible
@@ -143,6 +152,10 @@ val respond_sse_rate_limited :
     the exact spelling. *)
 
 val mcp_internal_error_json : ?id:Yojson.Safe.t -> string -> Yojson.Safe.t
+  [@@deprecated
+    "RFC-0098 PR-3: all in-tree callers migrated. Use \
+     [error_body ~code:Mcp_error_code.Internal_error ...]. This \
+     wrapper is scheduled for removal in PR-4."]
 (** [mcp_internal_error_json ?id msg] returns a JSON-RPC 2.0 error
     object with code [-32603] (matching {!respond_mcp_internal_error})
     suitable for embedding in an SSE batch frame or a multi-response

--- a/test/test_error_body_delegation.ml
+++ b/test/test_error_body_delegation.ml
@@ -6,6 +6,13 @@
     JSON-RPC 2.0 §5.1, where the legacy hand-rolled bodies omitted
     the field. *)
 
+(* RFC-0098 PR-3: this test file is the SOLE remaining caller of the
+   deprecated legacy [mcp_internal_error_json] (asserts parity with
+   the SSOT [error_body]). Suppress the deprecation alert here only
+   — production code may not. PR-4 will remove both the legacy
+   function and this suppression. *)
+[@@@alert "-deprecated"]
+
 open Alcotest
 module R = Masc_mcp.Server_mcp_transport_http_respond
 module C = Masc_mcp.Mcp_error_code


### PR DESCRIPTION
## Summary

PR-3 of [[RFC-0098]] series. Migrates all 10 in-tree callers of the legacy factories to the typed-code SSOT introduced in PR-1 (#15759) and consolidated in PR-2 (#15776).

## Migration map

| File | Sites | From → To |
|---|---|---|
| \`lib/server/server_mcp_transport_http.ml\` | 9 | \`respond_mcp_{auth,internal}_error\` → \`respond_mcp_error ~code:...\`<br>\`mcp_internal_error_json\` → \`error_body ~code:Internal_error\` |
| \`lib/server/server_mcp_transport_http_agui.ml\` | 1 | \`respond_mcp_auth_error\` → \`respond_mcp_error ~code:Auth_error\` |

Verified: \`rg \"respond_mcp_(auth|internal)_error\\b|mcp_internal_error_json\\b\" lib/server/server_mcp_transport_http.ml lib/server/server_mcp_transport_http_agui.ml\` → empty.

## Deprecation

- \`lib/server/server_mcp_transport_http_respond.mli\`: all three legacy factories carry \`[@@deprecated]\` alerts naming PR-4 as removal date.
- \`test/test_error_body_delegation.ml\`: sole remaining caller of deprecated \`mcp_internal_error_json\`. File-scope \`[@@@alert "-deprecated"]\` suppression — scoped, justified, removed at PR-4 when test refactors.

## Wire bytes

**Unchanged** from PR-2 baseline. The SSOT's wire shape (id:null per JSON-RPC 2.0 §5.1) is already in main since PR-2. PR-3 is a pure refactor at the caller layer.

## Self-review (Best Programmer)

- **목표**: legacy 3 factory의 10개 caller를 typed SSOT로 migration, deprecation alerts wiring.
- **변경 파일**: 4 (caller .ml ×2, respond.mli, test).
- **로컬 검증**: \`dune build --root . lib/\` silent OK, delegation test 6/6, PR-1 regression test 7/7.
- **남은 미검증**: full @runtest CI, in-flight 다른 PR과의 충돌 가능성.

## Workaround rejection self-check

- [x] Not telemetry-as-fix — concrete refactor, no counter added.
- [x] Not string-classifier — typed \`Mcp_error_code.t\` discriminator throughout.
- [x] Not N-of-M — all 10 callers migrated in one PR.
- [x] No catch-all added.
- [x] No bypass added — \`[@@@alert "-deprecated"]\` scoped to single test file (the only one that legitimately tests the deprecated path), with named PR-4 removal.

## Workflow note

This is the **third** PR in this session that almost violated workflow-pr.md §10. Before push, verified \`gh pr view\` state for new branch (no race possible since fresh branch). Memory \`feedback_post_merge_push_check_required.md\` documents the recurring pattern.

## Out of scope (PR-4)

- Removal of \`respond_mcp_auth_error\` / \`respond_mcp_internal_error\` / \`mcp_internal_error_json\` from \`.ml/.mli\`.
- Removal of legacy-delegation test \`test_error_body_delegation.ml\` and its alert suppression.
- Wiring of \`Provider_timeout\` / \`Tool_dispatch_failure\` / \`Backpressure_shed\` (PR-3 audit found these have no surgical target in current code; deferred until real use case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)