### PR TITLE
feat(cdal): surface runtime writer health

### DIFF
--- a/lib/cdal_runtime_health.ml
+++ b/lib/cdal_runtime_health.ml
@@ -1,0 +1,205 @@
+let null = `Null
+
+let float_opt_to_json = function
+  | None -> null
+  | Some value -> `Float value
+;;
+
+let time_opt_to_json = function
+  | None -> null
+  | Some value -> `String (Masc_domain.iso8601_of_unix_seconds value)
+;;
+
+let env_non_empty key =
+  match Sys.getenv_opt key with
+  | Some value ->
+    let value = String.trim value in
+    if String.equal value "" then None else Some value
+  | None -> None
+;;
+
+let is_dir path =
+  try Sys.is_directory path with
+  | Sys_error _ -> false
+;;
+
+let stat_mtime_if_dir path =
+  if is_dir path then Some (Unix.stat path).Unix.st_mtime else None
+;;
+
+let status_of_latest ~stale_age_seconds ~exists ~age_seconds =
+  if not exists
+  then "missing"
+  else
+    match age_seconds with
+    | None -> "missing"
+    | Some age when age > stale_age_seconds -> "dormant"
+    | Some _ -> "active"
+;;
+
+let age_seconds ~now = function
+  | None -> None
+  | Some ts -> Some (max 0.0 (now -. ts))
+;;
+
+let proof_root_default () = Masc_mcp_cdal_runtime.Proof_store.default_config.root
+
+let proof_root_candidates configured_root =
+  let maybe_home =
+    env_non_empty "HOME" |> Option.map (fun home -> Filename.concat home ".oas")
+  in
+  let maybe_me_root =
+    env_non_empty "ME_ROOT" |> Option.map (fun root -> Filename.concat root ".oas")
+  in
+  [ maybe_home; maybe_me_root ]
+  |> List.filter_map Fun.id
+  |> List.filter (fun root -> not (String.equal root configured_root))
+  |> List.sort_uniq String.compare
+;;
+
+let proof_store_root_json ~now ~stale_age_seconds root =
+  let proofs_dir = Filename.concat root "proofs" in
+  let latest_mtime = stat_mtime_if_dir proofs_dir in
+  let age_seconds = age_seconds ~now latest_mtime in
+  let exists = is_dir proofs_dir in
+  let status = status_of_latest ~stale_age_seconds ~exists ~age_seconds in
+  `Assoc
+    [ "root", `String root
+    ; "proofs_dir", `String proofs_dir
+    ; "exists", `Bool exists
+    ; "latest_activity_at", time_opt_to_json latest_mtime
+    ; "latest_activity_unix", float_opt_to_json latest_mtime
+    ; "age_seconds", float_opt_to_json age_seconds
+    ; "status", `String status
+    ]
+;;
+
+let assoc_string key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String value) -> Some value
+     | _ -> None)
+  | _ -> None
+;;
+
+let has_task_scope json = Option.is_some (assoc_string "_task_id" json)
+
+let task_scope_json ?base_dir ?(recent_limit = Env_config_runtime.Cdal.verdict_lookup_limit ()) ()
+  =
+  let ledger = Cdal_verdict_gate.ledger_health_report ?base_dir () in
+  let store = Dated_jsonl.create ~base_dir:ledger.base_dir () in
+  try
+    let recent = Dated_jsonl.read_recent store recent_limit in
+    let recent_rows = List.length recent in
+    let task_id_rows = List.fold_left (fun n row -> if has_task_scope row then n + 1 else n) 0 recent in
+    let status =
+      if recent_rows = 0
+      then "missing_ledger"
+      else if task_id_rows = 0
+      then "missing_task_scope"
+      else "present"
+    in
+    `Assoc
+      [ "status", `String status
+      ; "recent_limit", `Int recent_limit
+      ; "recent_rows", `Int recent_rows
+      ; "task_id_rows", `Int task_id_rows
+      ; "missing_task_scope", `Bool (recent_rows > 0 && task_id_rows = 0)
+      ]
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    `Assoc
+      [ "status", `String "error"
+      ; "recent_limit", `Int recent_limit
+      ; "recent_rows", `Int 0
+      ; "task_id_rows", `Int 0
+      ; "missing_task_scope", `Bool false
+      ; "error", `String (Printexc.to_string exn)
+      ]
+;;
+
+let ledger_json ?base_dir ~now ~stale_age_seconds () =
+  let report = Cdal_verdict_gate.ledger_health_report ?base_dir () in
+  let exists = report.Cdal_verdict_gate.total_files > 0 in
+  let status =
+    status_of_latest ~stale_age_seconds ~exists ~age_seconds:report.age_seconds
+  in
+  `Assoc
+    [ "base_dir", `String report.base_dir
+    ; "total_files", `Int report.total_files
+    ; "latest_mtime", float_opt_to_json report.latest_mtime
+    ; "latest_at", time_opt_to_json report.latest_mtime
+    ; "age_seconds", float_opt_to_json report.age_seconds
+    ; "status", `String status
+    ; "stale_age_seconds", `Float stale_age_seconds
+    ; "checked_at", `String (Masc_domain.iso8601_of_unix_seconds now)
+    ]
+;;
+
+let json_string_field key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String value) -> Some value
+     | _ -> None)
+  | _ -> None
+;;
+
+let writer_status ~ledger_status ~task_scope_status =
+  match ledger_status, task_scope_status with
+  | "missing", _ -> "missing"
+  | "dormant", _ -> "dormant"
+  | _, "missing_task_scope" -> "missing_task_scope"
+  | "active", "present" -> "active"
+  | _, "error" -> "error"
+  | _ -> "unknown"
+;;
+
+let proof_path_drift configured_json alternate_json =
+  let configured_status = json_string_field "status" configured_json in
+  let configured_inactive =
+    match configured_status with
+    | Some ("missing" | "dormant") -> true
+    | _ -> false
+  in
+  configured_inactive
+  &&
+  match alternate_json with
+  | `List roots ->
+    List.exists
+      (fun json ->
+         match json_string_field "status" json with
+         | Some ("active" | "dormant") -> true
+         | _ -> false)
+      roots
+  | _ -> false
+;;
+
+let snapshot_json ?base_dir ?proof_root ?(now = Time_compat.now ())
+    ?(stale_age_seconds = Cdal_verdict_gate.stale_age_seconds_default)
+    ?recent_limit () =
+  let ledger = ledger_json ?base_dir ~now ~stale_age_seconds () in
+  let task_scope = task_scope_json ?base_dir ?recent_limit () in
+  let configured_root = Option.value proof_root ~default:(proof_root_default ()) in
+  let configured_proof = proof_store_root_json ~now ~stale_age_seconds configured_root in
+  let alternate_proofs =
+    `List
+      (List.map
+         (proof_store_root_json ~now ~stale_age_seconds)
+         (proof_root_candidates configured_root))
+  in
+  let ledger_status = Option.value ~default:"unknown" (json_string_field "status" ledger) in
+  let task_scope_status =
+    Option.value ~default:"unknown" (json_string_field "status" task_scope)
+  in
+  let writer_status = writer_status ~ledger_status ~task_scope_status in
+  `Assoc
+    [ "writer_status", `String writer_status
+    ; "operator_action_required", `Bool (not (String.equal writer_status "active"))
+    ; "verdict_ledger", ledger
+    ; "task_scope", task_scope
+    ; "proof_store", configured_proof
+    ; "alternate_proof_stores", alternate_proofs
+    ; "proof_store_path_drift", `Bool (proof_path_drift configured_proof alternate_proofs)
+    ]
+;;

--- a/lib/cdal_runtime_health.mli
+++ b/lib/cdal_runtime_health.mli
@@ -1,0 +1,13 @@
+(** CDAL runtime health projection.
+
+    Surfaces whether the proof/verdict writer appears active, dormant,
+    missing, or still writing verdicts without task scope. *)
+
+val snapshot_json :
+  ?base_dir:string ->
+  ?proof_root:string ->
+  ?now:float ->
+  ?stale_age_seconds:float ->
+  ?recent_limit:int ->
+  unit ->
+  Yojson.Safe.t

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -168,6 +168,7 @@ let compute_outcomes_rollup
       ("cdal_gate", cdal_bucket Cdal_verdict_gate.strict_gate_label);
       ("cdal_gate_advisory",
         cdal_bucket Cdal_verdict_gate.advisory_gate_label);
+      ("cdal_runtime", Cdal_runtime_health.snapshot_json ~recent_limit:50 ());
       ("last_verdict_at", last_verdict_at);
     ]);
   ]

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -386,6 +386,7 @@ let make_health_json ?(listener = "http/1.1") request =
        so an operator can correlate with the cause encoded in their
        last_blocker_class. *)
     (key_paused_keepers, paused_keepers_json);
+    ("cdal", Cdal_runtime_health.snapshot_json ());
     ("keeper_config_parse_error_count",
      `Int keeper_config_parse_error_count);
     ( "keeper_config_parse_errors",

--- a/test/dune
+++ b/test/dune
@@ -1205,6 +1205,7 @@
 (include stanzas/test_audit_keeper_fleet_readiness.inc)
 (include stanzas/test_keeper_production_readiness_gate.inc)
 (include stanzas/test_cdal_ledger_health_10115.inc)
+(include stanzas/test_cdal_runtime_health_15748.inc)
 (include stanzas/test_channel_gate.inc)
 (include stanzas/test_channel_gate_discord_state.inc)
 (include stanzas/test_channel_gate_metrics.inc)

--- a/test/stanzas/test_cdal_runtime_health_15748.inc
+++ b/test/stanzas/test_cdal_runtime_health_15748.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_cdal_runtime_health_15748)
+ (modules test_cdal_runtime_health_15748)
+ (libraries masc_test_deps))

--- a/test/test_cdal_runtime_health_15748.ml
+++ b/test/test_cdal_runtime_health_15748.ml
@@ -1,0 +1,176 @@
+module H = Masc_mcp.Cdal_runtime_health
+
+let mkdir_p path =
+  let rec loop current parts =
+    match parts with
+    | [] -> ()
+    | part :: rest ->
+      let next = if String.equal current "" then part else Filename.concat current part in
+      (try Unix.mkdir next 0o755 with
+       | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+      loop next rest
+  in
+  let parts = String.split_on_char '/' path |> List.filter (fun s -> not (String.equal s "")) in
+  match Filename.is_relative path with
+  | true -> loop "" parts
+  | false -> loop "/" parts
+;;
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then begin
+      Array.iter (fun name -> rm_rf (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path
+    end
+    else Sys.remove path
+;;
+
+let with_temp_dir f =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-cdal-runtime-health-%06x" (Random.bits ()))
+  in
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> try rm_rf dir with _ -> ()) (fun () -> f dir)
+;;
+
+let write_ledger_row ~base_dir ?mtime row =
+  let month_dir = Filename.concat base_dir "2026-05" in
+  mkdir_p month_dir;
+  let path = Filename.concat month_dir "17.jsonl" in
+  let oc = open_out_gen [ Open_creat; Open_text; Open_append ] 0o644 path in
+  output_string oc (Yojson.Safe.to_string row ^ "\n");
+  close_out oc;
+  Option.iter (fun ts -> Unix.utimes path ts ts) mtime;
+  path
+;;
+
+let make_proof_root ?mtime root =
+  let proofs_dir = Filename.concat root "proofs" in
+  mkdir_p proofs_dir;
+  Option.iter (fun ts -> Unix.utimes proofs_dir ts ts) mtime;
+  proofs_dir
+;;
+
+let member_string key json =
+  match Yojson.Safe.Util.member key json with
+  | `String value -> value
+  | other ->
+    Alcotest.failf
+      "expected string field %s, got %s"
+      key
+      (Yojson.Safe.to_string other)
+;;
+
+let nested key json = Yojson.Safe.Util.member key json
+
+let test_missing_writer_status () =
+  with_temp_dir @@ fun dir ->
+  let base_dir = Filename.concat dir "cdal_verdicts" in
+  let proof_root = Filename.concat dir ".oas" in
+  let json =
+    H.snapshot_json
+      ~base_dir
+      ~proof_root
+      ~now:1000.0
+      ~stale_age_seconds:60.0
+      ~recent_limit:20
+      ()
+  in
+  Alcotest.(check string) "writer_status" "missing" (member_string "writer_status" json);
+  Alcotest.(check string)
+    "ledger status"
+    "missing"
+    (member_string "status" (nested "verdict_ledger" json))
+;;
+
+let test_missing_task_scope_status () =
+  with_temp_dir @@ fun dir ->
+  let base_dir = Filename.concat dir "cdal_verdicts" in
+  let proof_root = Filename.concat dir ".oas" in
+  ignore (write_ledger_row ~base_dir (`Assoc [ "run_id", `String "run-no-task" ]));
+  ignore (make_proof_root proof_root);
+  let json =
+    H.snapshot_json
+      ~base_dir
+      ~proof_root
+      ~now:(Time_compat.now ())
+      ~stale_age_seconds:60.0
+      ~recent_limit:20
+      ()
+  in
+  Alcotest.(check string)
+    "writer_status"
+    "missing_task_scope"
+    (member_string "writer_status" json);
+  Alcotest.(check string)
+    "task scope status"
+    "missing_task_scope"
+    (member_string "status" (nested "task_scope" json))
+;;
+
+let test_active_writer_status () =
+  with_temp_dir @@ fun dir ->
+  let base_dir = Filename.concat dir "cdal_verdicts" in
+  let proof_root = Filename.concat dir ".oas" in
+  ignore
+    (write_ledger_row
+       ~base_dir
+       (`Assoc [ "_task_id", `String "task-15748"; "run_id", `String "run-task" ]));
+  ignore (make_proof_root proof_root);
+  let json =
+    H.snapshot_json
+      ~base_dir
+      ~proof_root
+      ~now:(Time_compat.now ())
+      ~stale_age_seconds:60.0
+      ~recent_limit:20
+      ()
+  in
+  Alcotest.(check string) "writer_status" "active" (member_string "writer_status" json);
+  Alcotest.(check string)
+    "task scope status"
+    "present"
+    (member_string "status" (nested "task_scope" json))
+;;
+
+let test_dormant_writer_status () =
+  with_temp_dir @@ fun dir ->
+  let base_dir = Filename.concat dir "cdal_verdicts" in
+  let proof_root = Filename.concat dir ".oas" in
+  ignore
+    (write_ledger_row
+       ~base_dir
+       ~mtime:100.0
+       (`Assoc [ "_task_id", `String "task-old"; "run_id", `String "run-old" ]));
+  ignore (make_proof_root ~mtime:100.0 proof_root);
+  let json =
+    H.snapshot_json
+      ~base_dir
+      ~proof_root
+      ~now:1000.0
+      ~stale_age_seconds:60.0
+      ~recent_limit:20
+      ()
+  in
+  Alcotest.(check string) "writer_status" "dormant" (member_string "writer_status" json);
+  Alcotest.(check string)
+    "ledger status"
+    "dormant"
+    (member_string "status" (nested "verdict_ledger" json))
+;;
+
+let () =
+  Alcotest.run
+    "cdal_runtime_health_15748"
+    [ ( "writer_status"
+      , [ Alcotest.test_case "missing" `Quick test_missing_writer_status
+        ; Alcotest.test_case "missing task scope" `Quick test_missing_task_scope_status
+        ; Alcotest.test_case "active" `Quick test_active_writer_status
+        ; Alcotest.test_case "dormant" `Quick test_dormant_writer_status
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- Add `Cdal_runtime_health.snapshot_json` to classify CDAL writer state as `active`, `dormant`, `missing`, or `missing_task_scope`.
- Surface the snapshot on `/health` under `cdal` and in keeper dashboard validation under `cdal_runtime`.
- Include configured proof-store root, alternate proof roots, stale-age signals, and path-drift detection so dormant writer failures are visible without log spelunking.
- Add regression coverage for active, dormant, missing, and missing-task-scope writer states.

## Issue
- Part of #15748. This closes the runtime/dashboard surface gap, while final fresh-turn proof emission still needs verification after deployment/restart.

## CDAL Sweep Result
- Existing CDAL core surfaces did not show a regression in the focused sweep: types, loader, proof schema, risk contract, judge, verifiable markers, eval v1, keeper CDAL contract projection, friction projection, verdict gate, mode enforcer/resolver, ledger health, runtime health, verification FSM, and tool-task CDAL gate coverage all passed.
- Direct test execution covered 271 assertions across the CDAL/verifier-focused executable set.

## Validation
- `env DUNE_CACHE=disabled DUNE_JOBS=2 opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-cdal-runtime-health-15748 --build-dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-cdal-runtime-health-15748/_build_cdal_runtime_health test/test_cdal_types.exe test/test_cdal_loader.exe test/test_cdal_proof.exe test/test_cdal_risk_contract.exe test/test_cdal_judge.exe test/test_cdal_verifiable_markers.exe test/test_cdal_eval_v1.exe test/test_keeper_cdal_contract.exe test/test_cdal_friction_projection.exe test/test_cdal_verdict_gate.exe test/test_cdal_mode_enforcer.exe test/test_cdal_mode_resolver.exe test/test_cdal_ledger_health_10115.exe test/test_cdal_runtime_health_15748.exe test/test_verification_fsm.exe test/test_tool_task_coverage.exe`
- Direct run of the same 16 executables: 271 tests passed.
- `env DUNE_CACHE=disabled DUNE_JOBS=2 opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-cdal-runtime-health-15748 --build-dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-cdal-runtime-health-15748/_build_cdal_runtime_health test/test_cdal_runtime_health_15748.exe test/test_cdal_ledger_health_10115.exe bin/main_eio.exe`
- `opam exec -- ocamlformat --check lib/cdal_runtime_health.ml lib/cdal_runtime_health.mli lib/server/server_routes_http_runtime.ml lib/dashboard/dashboard_http_keeper.ml test/test_cdal_runtime_health_15748.ml`
- `git diff --check origin/main...HEAD`