### PR TITLE
feat(compact-policy): keep_recent_tool_results meta field (V12)

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -210,7 +210,14 @@ let compact_if_needed_typed
     in
     (* Use OAS stub_tool_results instead of MASC's FoldCompleted —
          OAS owns context reduction, MASC is a consumer. *)
-    let fold_reducer = Agent_sdk.Context_reducer.stub_tool_results ~keep_recent:2 in
+    (* V12: per-keeper config replaces the prior hardcoded
+         [~keep_recent:2].  Default preserved via
+         [Keeper_config.default_keep_recent_tool_results] = 2 so
+         existing configs see no behavior change. *)
+    let fold_reducer =
+      Agent_sdk.Context_reducer.stub_tool_results
+        ~keep_recent:meta.compaction.keep_recent_tool_results
+    in
     let strategy_names =
       List.map Context_compact_oas.strategy_name strategies @ [ "StubToolResults" ]
     in

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -584,6 +584,42 @@ let normalize_compaction_token_gate (v : int) : int =
 let normalize_continuity_compaction_cooldown_sec (v : int) : int =
   clamp_int v ~min_v:0 ~max_v:172800
 
+(** Default number of recent tool results to keep verbatim during
+    OAS context compaction (consumed by
+    [Agent_sdk.Context_reducer.stub_tool_results ~keep_recent]).
+    Preserves prior hardcoded behavior in [keeper_compact_policy.ml]. *)
+let default_keep_recent_tool_results = 2
+
+(** Hard upper bound for operator-supplied [keep_recent_tool_results].
+    Values above this likely indicate operator typos (e.g. 5000); we
+    log a warn and clamp back to the safe default so a typo does not
+    silently disable compaction.  Lower bound is 0 (keep none). *)
+let keep_recent_tool_results_max = 50
+
+(** Validate and normalize [keep_recent_tool_results].
+    Returns the in-range value untouched, or [default_keep_recent_tool_results]
+    after logging a warn when the operator-supplied value is out of
+    [0, keep_recent_tool_results_max].  Caller context (keeper name)
+    is included in the warn for triage. *)
+let normalize_keep_recent_tool_results ?keeper_name (v : int) : int =
+  if v >= 0 && v <= keep_recent_tool_results_max
+  then v
+  else begin
+    let ctx =
+      match keeper_name with
+      | Some n -> Printf.sprintf " keeper=%s" n
+      | None -> ""
+    in
+    Log.Keeper.warn
+      "[compaction] keep_recent_tool_results=%d out of range [0,%d];%s \
+       clamping to default %d"
+      v
+      keep_recent_tool_results_max
+      ctx
+      default_keep_recent_tool_results;
+    default_keep_recent_tool_results
+  end
+
 let default_compaction_profile = "custom"
 
 let canonical_compaction_profile raw =

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -187,6 +187,20 @@ val normalize_compaction_message_gate : int -> int
 val normalize_compaction_token_gate : int -> int
 val normalize_continuity_compaction_cooldown_sec : int -> int
 
+(** Default number of recent tool results to keep verbatim during
+    OAS context compaction.  Preserves prior hardcoded [keep_recent:2]
+    behavior in [Keeper_compact_policy]. *)
+val default_keep_recent_tool_results : int
+
+(** Hard upper bound for operator-supplied
+    [keep_recent_tool_results] (typo guard). *)
+val keep_recent_tool_results_max : int
+
+(** Clamp [keep_recent_tool_results] to [[0, keep_recent_tool_results_max]].
+    Out-of-range values fall back to {!default_keep_recent_tool_results}
+    with a [Log.Keeper.warn] including [keeper_name] when supplied. *)
+val normalize_keep_recent_tool_results : ?keeper_name:string -> int -> int
+
 val normalize_proactive_idle_sec : int -> int
 val normalize_proactive_cooldown_sec : int -> int
 

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -16,6 +16,11 @@ type compaction_policy =
   ; token_gate : int
   ; cooldown_sec : int
   ; max_checkpoint_messages : int
+  ; keep_recent_tool_results : int
+    (* Verbatim tool-result tail length for OAS context compaction
+       (consumed by [Agent_sdk.Context_reducer.stub_tool_results
+       ~keep_recent]).  Default 2; parsers clamp to
+       [[0, Keeper_config.keep_recent_tool_results_max]]. *)
   }
 
 type proactive_policy =

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -38,6 +38,13 @@ type compaction_policy = {
   token_gate : int;
   cooldown_sec : int;
   max_checkpoint_messages : int;
+  keep_recent_tool_results : int;
+    (** Verbatim tool-result tail length passed to
+        [Agent_sdk.Context_reducer.stub_tool_results ~keep_recent].
+        Default
+        {!Keeper_config.default_keep_recent_tool_results} (2);
+        loader clamps to
+        [[0, Keeper_config.keep_recent_tool_results_max]]. *)
 }
 
 type proactive_policy = {

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -66,6 +66,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "compaction_token_gate", `Int m.compaction.token_gate
     ; "continuity_compaction_cooldown_sec", `Int m.compaction.cooldown_sec
     ; "max_checkpoint_messages", `Int m.compaction.max_checkpoint_messages
+    ; "keep_recent_tool_results", `Int m.compaction.keep_recent_tool_results
     ; "auto_handoff", `Bool m.auto_handoff
     ; "handoff_threshold", `Float m.handoff_threshold
     ; "handoff_cooldown_sec", `Int m.handoff_cooldown_sec

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -340,6 +340,13 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
           ; cooldown_sec = continuity_compaction_cooldown_sec
           ; max_checkpoint_messages =
               Safe_ops.json_int ~default:120 "max_checkpoint_messages" json
+          ; keep_recent_tool_results =
+              Keeper_config.normalize_keep_recent_tool_results
+                ~keeper_name
+                (Safe_ops.json_int
+                   ~default:Keeper_config.default_keep_recent_tool_results
+                   "keep_recent_tool_results"
+                   json)
           }
       ; pp_auto_handoff
       ; pp_handoff_threshold

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -502,6 +502,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
              keeper JSON still win.  See #7859. *)
           max_checkpoint_messages =
             Keeper_context_core.default_max_checkpoint_messages;
+          keep_recent_tool_results =
+            Keeper_config.default_keep_recent_tool_results;
         };
         auto_handoff;
         handoff_threshold;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -377,6 +377,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
           p.continuity_compaction_cooldown_sec_opt
         |> normalize_continuity_compaction_cooldown_sec;
       max_checkpoint_messages = old.compaction.max_checkpoint_messages;
+      keep_recent_tool_results = old.compaction.keep_recent_tool_results;
     };
     auto_handoff = Option.value ~default:old.auto_handoff p.auto_handoff_opt;
     handoff_threshold = Option.value ~default:old.handoff_threshold p.handoff_threshold_opt;

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -57,6 +57,11 @@ type compaction_policy = {
   token_gate: int;
   cooldown_sec: int;
   max_checkpoint_messages: int;
+  keep_recent_tool_results: int;
+    (** Verbatim tool-result tail length passed to
+        [Agent_sdk.Context_reducer.stub_tool_results ~keep_recent]
+        during OAS context compaction.  See
+        {!Keeper_meta_contract.compaction_policy} for full semantics. *)
 }
 
 type proactive_policy = {


### PR DESCRIPTION
## Summary

Closes V12 (MED) from `.tmp/memory-compacting-analysis.html`.

`Keeper_compact_policy.compute_and_apply` invoked `Agent_sdk.Context_reducer.stub_tool_results ~keep_recent:2` with `2` hardcoded at `lib/keeper/keeper_compact_policy.ml:213`. The `2` is policy, not invariant: a local 9B keeper with a 32K window benefits from a small tail; a 200K+ remote keeper sees over-pruning. The fix promotes the value to per-keeper `meta.compaction.keep_recent_tool_results`, parallel to existing `cooldown_sec` / `max_checkpoint_messages`.

## Record field added

`lib/keeper/keeper_meta_contract.ml:12-23` (and `.mli:34-48`):

```ocaml
type compaction_policy =
  { profile : string
  ; ratio_gate : float
  ; message_gate : int
  ; token_gate : int
  ; cooldown_sec : int
  ; max_checkpoint_messages : int
  ; keep_recent_tool_results : int   (* NEW *)
  }
```

Mirror declaration synced in `lib/keeper/keeper_types.mli:53-65` (kept identical to satisfy the existing `include module type of` constraint).

## Wiring

| Site | Path:Line | Change |
|---|---|---|
| Call site | `lib/keeper/keeper_compact_policy.ml:213-221` | `~keep_recent:2` → `~keep_recent:meta.compaction.keep_recent_tool_results` |
| Loader (JSON) | `lib/keeper/keeper_meta_json_parse.ml:344-350` | Reads `keep_recent_tool_results` (default 2), clamped via `Keeper_config.normalize_keep_recent_tool_results` |
| Serializer | `lib/keeper/keeper_meta_json.ml:69` | Emits `keep_recent_tool_results` |
| Creator default | `lib/keeper/keeper_turn_up_create.ml:505-506` | New keepers initialize to `Keeper_config.default_keep_recent_tool_results` (= 2) |
| Updater | `lib/keeper/keeper_turn_up_update.ml:380` | Preserves prior value across updates |
| Helpers | `lib/keeper/keeper_config.ml` (+ `.mli`) | `default_keep_recent_tool_results = 2`, `keep_recent_tool_results_max = 50`, `normalize_keep_recent_tool_results ?keeper_name` |

## Default preservation

`Keeper_config.default_keep_recent_tool_results = 2` matches the prior hardcoded literal. All existing on-disk keeper meta JSONs without the new field deserialize to `2` via `Safe_ops.json_int ~default:Keeper_config.default_keep_recent_tool_results`. Behavior is bit-for-bit unchanged until an operator opts in.

## Out-of-range handling

| Input `v` | Result | Logging |
|---|---|---|
| `0 ≤ v ≤ 50` | `v` (passthrough) | none |
| `v < 0` or `v > 50` | `2` (default) | `Log.Keeper.warn` with `keeper=<name>`, in-range bounds, supplied value |

Bound `50` is a typo guard (operator entering `5000` is corrected, not silently propagated). It is *not* symptom suppression: the only operational degradation prevented is "operator typo disables OAS prune by retaining the entire transcript verbatim".

## Anti-pattern self-check (7/7)

1. **Telemetry-as-fix only?** NO — structural change: magic number replaced by typed record field with parser-side validation. The added `Log.Keeper.warn` is a side effect of clamping, not the fix.
2. **String classifier?** NO — no string matching, prefix matching, or substring inspection added.
3. **N-of-M?** NO — single hardcoded site at `keeper_compact_policy.ml:213` migrated. The two other `stub_tool_results` call sites (`keeper_run_tools.ml:1893` with `~keep_recent:3`, `keeper_context_core.ml:1392` with `~keep_recent:1`) serve unrelated execution paths (tool history shaping during agent run, working-context shaping) and are intentionally left unchanged in this PR. A follow-up could promote those too, but bundling them here would over-scope V12.
4. **Catch-all `_ ->`?** NO — no new `match` branches.
5. **Cap / cooldown / dedup / repair?** The `[0, 50]` cap is typed parse validation analogous to `normalize_compaction_message_gate` (`[0, 5000]`) and `normalize_compaction_token_gate` (`[0, 5_000_000]`). It bounds an operator-supplied int at the protocol boundary; it does not suppress a downstream symptom.
6. **Test backdoor?** NO — no `set_X_for_test` / `reset_for_test`.
7. **Repeat typo / sweep?** NO — single-site replacement.

## Build status

- `dune build --root . lib/keeper` — exit 0
- `dune build --root . @check` — exit 0 (clean after syncing `keeper_types.mli`)
- `dune build --root .` — exit 0 (linker only emits `-lzstd` duplicate warning unrelated to this PR)

## Out of scope

- Promotion of `keep_recent:3` (`keeper_run_tools.ml:1893`) and `keep_recent:1` (`keeper_context_core.ml:1392`) — different reducers in different lifecycle phases. Tracked separately if telemetry indicates need.
- TOML `[keeper.compaction]` section: keeper TOML configs (`config/keepers/*.toml`) do not currently expose any `[keeper.compaction]` block — compaction policy is loaded from keeper-meta JSON (`Keeper_meta_json_parse`) and CLI-side `resolve_compaction_policy`. The field is wired through the JSON loader; if a future TOML schema is added, the field can flow through the same normalize helper.

## Files changed

- `lib/keeper/keeper_compact_policy.ml`
- `lib/keeper/keeper_config.ml`
- `lib/keeper/keeper_config.mli`
- `lib/keeper/keeper_meta_contract.ml`
- `lib/keeper/keeper_meta_contract.mli`
- `lib/keeper/keeper_meta_json.ml`
- `lib/keeper/keeper_meta_json_parse.ml`
- `lib/keeper/keeper_turn_up_create.ml`
- `lib/keeper/keeper_turn_up_update.ml`
- `lib/keeper/keeper_types.mli`

## Test plan

- [ ] CI green on `lib/keeper`
- [ ] Existing on-disk keeper meta JSONs without `keep_recent_tool_results` deserialize to `2` (default preservation)
- [ ] Operator-supplied `keep_recent_tool_results = 5000` clamps to `2` with `Log.Keeper.warn`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
