### PR TITLE
fix(cascade): clamp cascade-config & caller-override max_tokens to narrowest ceiling

### DIFF
--- a/lib/cascade/cascade_metrics.ml
+++ b/lib/cascade/cascade_metrics.ml
@@ -858,10 +858,12 @@ let metric_cascade_metrics_eviction =
 let on_cascade_metrics_eviction () =
   Prometheus.inc_counter metric_cascade_metrics_eviction ()
 
-(* Legacy iter-46 counter retained for metric compatibility.  DD-020
-   replaced runtime max_tokens clipping with a structured
-   [max_tokens_ceiling_violation] pre-dispatch error, so this counter
-   should stay at zero on current code paths. *)
+(* Counts max_tokens budgets reduced to the resolved cascade output ceiling.
+   DD-020 originally treated all over-ceiling budgets as structured
+   [max_tokens_ceiling_violation] errors.  The 2026-05-17 multilane cascade
+   rollout showed that internal cascade-config/fallback/keeper override
+   budgets must be normalized before dispatch because the narrowest failover
+   member can be lower than the caller-visible primary route. *)
 let metric_max_tokens_clamped = "masc_cascade_max_tokens_clamped_total"
 
 let on_max_tokens_clamped () =

--- a/lib/cascade/cascade_metrics.mli
+++ b/lib/cascade/cascade_metrics.mli
@@ -274,11 +274,10 @@ val on_cascade_metrics_eviction : unit -> unit
     [cascade_max_keys] or canonicalize synthesized names. *)
 
 val on_max_tokens_clamped : unit -> unit
-(** Tick when an automatically-derived max_tokens fallback is reduced to the
-    resolved cascade output ceiling. Repeated clamps are counted here even
-    when the corresponding WARN log is deduplicated. Explicit cascade.toml or
-    caller-provided over-ceiling values still use the structured
-    [max_tokens_ceiling_violation] pre-dispatch error instead. *)
+(** Tick when a cascade-config, fallback, or internal keeper override
+    max_tokens budget is reduced to the resolved cascade output ceiling.
+    Repeated clamps are counted here even when the corresponding WARN log is
+    deduplicated. *)
 
 val on_cascade_audit_failure : stage:string -> unit
 (** Tick the cascade-audit subsystem failure counter at

--- a/lib/cascade_inference.ml
+++ b/lib/cascade_inference.ml
@@ -113,24 +113,43 @@ let should_log_auto_max_tokens_clamp ~cascade_name ~source ~max_tokens ~ceiling 
   auto_max_tokens_clamp_key ~cascade_name ~source ~max_tokens ~ceiling
   |> mark_auto_max_tokens_clamp_seen
 
-(** Cap an automatically-derived max_tokens value to the narrowest output
-    ceiling in the resolved cascade. Explicit caller-provided overrides and
-    cascade.toml values stay hard rejected by the pre-dispatch validator. *)
-let cap_auto_resolved_max_tokens ~cascade_name ~source max_tokens =
+(** Cap a max_tokens value to the narrowest output ceiling in the resolved
+    cascade. Both auto-derived [fallback] values and cascade-config explicit
+    values are clamped here.
+
+    Rationale (2026-05-17, supersedes original DD-020 phrasing): with
+    multilane cascades (tier-groups whose [tiers] union members from groups
+    of differing output budgets), the *narrowest* ceiling is a property of
+    cascade-internal fallback structure that the caller has no clean way
+    to discover. Letting cascade-config values bypass this cap caused
+    fleet-wide [pre_dispatch_max_tokens_ceiling_violation] when a previously
+    16384-narrow cascade was unioned with an 8192-narrow secondary tier.
+    Clamping unifies the two sites; a deduplicated WARN preserves operator
+    visibility into the silent reduction.
+
+    Runtime overrides supplied by internal keeper callers should also flow
+    through this helper before the final pre-dispatch validator. The validator
+    remains as a hard guard for non-positive budgets, invalid ceilings, and
+    stale values after a cascade reload. *)
+let cap_max_tokens_to_cascade_ceiling ~cascade_name ~source max_tokens =
   match Cascade_runtime.max_output_tokens_ceiling_of_cascade_name cascade_name with
   | Some ceiling when ceiling > 0 && max_tokens > ceiling ->
     Cascade_metrics.on_max_tokens_clamped ();
     if should_log_auto_max_tokens_clamp ~cascade_name ~source ~max_tokens ~ceiling
     then
       Log.warn ~ctx:"cascade"
-        "%s: auto-resolved max_tokens=%d from %s exceeds output ceiling=%d; \
+        "%s: resolved max_tokens=%d from %s exceeds output ceiling=%d; \
          using ceiling; suppressing repeats for this tuple"
         (Keeper_cascade_profile.runtime_name_to_string cascade_name)
         max_tokens source ceiling;
     ceiling
   | _ -> max_tokens
 
-(** Resolve a max_tokens value: cascade config -> capped fallback. *)
+(** Backwards-compatible alias retained for any out-of-tree callers; new
+    code should call [cap_max_tokens_to_cascade_ceiling] directly. *)
+let cap_auto_resolved_max_tokens = cap_max_tokens_to_cascade_ceiling
+
+(** Resolve a max_tokens value: cascade config (capped) -> capped fallback. *)
 let resolve_max_tokens
     ~(cascade_name : Keeper_cascade_profile.runtime_name)
     ~(fallback : unit -> int) : int =
@@ -138,9 +157,10 @@ let resolve_max_tokens
     Keeper_cascade_profile.runtime_name_to_string cascade_name
   in
   match (for_cascade ~name:cascade_name_string).max_tokens with
-  | Some t -> t
+  | Some t ->
+    cap_max_tokens_to_cascade_ceiling ~cascade_name ~source:"cascade_config" t
   | None ->
-    cap_auto_resolved_max_tokens ~cascade_name ~source:"fallback" (fallback ())
+    cap_max_tokens_to_cascade_ceiling ~cascade_name ~source:"fallback" (fallback ())
 
 (** Validate max_tokens against provider ceilings before dispatch. *)
 let validate_max_tokens_within_ceiling
@@ -182,4 +202,19 @@ module For_testing = struct
 
   let should_log_auto_max_tokens_clamp =
     should_log_auto_max_tokens_clamp
+
+  let clamp_with_ceiling ~cascade_name ~source ~ceiling max_tokens =
+    match ceiling with
+    | Some c when c > 0 && max_tokens > c ->
+      Cascade_metrics.on_max_tokens_clamped ();
+      if should_log_auto_max_tokens_clamp
+           ~cascade_name ~source ~max_tokens ~ceiling:c
+      then
+        Log.warn ~ctx:"cascade"
+          "%s: resolved max_tokens=%d from %s exceeds output ceiling=%d; \
+           using ceiling; suppressing repeats for this tuple"
+          (Keeper_cascade_profile.runtime_name_to_string cascade_name)
+          max_tokens source c;
+      c
+    | _ -> max_tokens
 end

--- a/lib/cascade_inference.mli
+++ b/lib/cascade_inference.mli
@@ -41,12 +41,25 @@ val resolve_temperature :
 
 (** Resolve a max_tokens value with cascade config priority.
     Returns cascade config value if present, otherwise calls [fallback].
-    Fallback values are bounded to the resolved cascade's output ceiling when
-    one is available; cascade config values and explicit caller overrides are
-    validated outside this helper and are not silently reduced. *)
+    Both cascade config values and fallback values are bounded to the
+    resolved cascade's narrowest output ceiling when one is available;
+    silent reductions emit a deduplicated WARN per
+    (cascade, source, requested, ceiling) tuple. *)
 val resolve_max_tokens :
   cascade_name:Keeper_cascade_profile.runtime_name ->
   fallback:(unit -> int) ->
+  int
+
+(** Cap a max_tokens value to the resolved cascade's narrowest output ceiling.
+
+    Use this for internally supplied runtime overrides that bypass
+    {!resolve_max_tokens}. [source] is emitted in the deduplicated WARN and
+    metric context so operators can distinguish [cascade_config], [fallback],
+    and [caller_override] clamps. *)
+val cap_max_tokens_to_cascade_ceiling :
+  cascade_name:Keeper_cascade_profile.runtime_name ->
+  source:string ->
+  int ->
   int
 
 (** Validate max_tokens against the provider ceiling before dispatch.
@@ -56,7 +69,15 @@ val resolve_max_tokens :
     budget. Also rejects non-positive [max_tokens] and non-positive
     provider ceilings.
 
-    @since DD-020 *)
+    Cascade-config, fallback, and keeper runtime override values are clamped
+    upstream by {!resolve_max_tokens} or
+    {!cap_max_tokens_to_cascade_ceiling}, so a violation here indicates
+    either a non-positive budget, an invalid provider ceiling, or a cascade
+    reload between resolve and validate.
+
+    @since DD-020 (semantics revised 2026-05-17: cascade-config and fallback
+    values are silently clamped upstream; internal keeper overrides should
+    use the same clamp helper before dispatch.) *)
 val validate_max_tokens_within_ceiling :
   cascade_name:Keeper_cascade_profile.runtime_name ->
   provider_ceiling:int option ->
@@ -72,4 +93,15 @@ module For_testing : sig
     max_tokens:int ->
     ceiling:int ->
     bool
+
+  (** Pure clamp helper with an explicit ceiling — bypasses
+      [Cascade_runtime.max_output_tokens_ceiling_of_cascade_name] so unit
+      tests do not need a live cascade.toml on disk. Same arithmetic and
+      same WARN dedup behavior as [resolve_max_tokens]'s internal clamp. *)
+  val clamp_with_ceiling :
+    cascade_name:Keeper_cascade_profile.runtime_name ->
+    source:string ->
+    ceiling:int option ->
+    int ->
+    int
 end

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -54,7 +54,11 @@ let prepare_run_context
   in
   let max_tokens =
     match max_tokens with
-    | Some t -> t
+    | Some t ->
+      Cascade_inference.cap_max_tokens_to_cascade_ceiling
+        ~cascade_name
+        ~source:"caller_override"
+        t
     | None ->
       Cascade_inference.resolve_max_tokens
         ~cascade_name

--- a/test/dune
+++ b/test/dune
@@ -1191,6 +1191,7 @@
 (include stanzas/test_cascade_catalog_runtime_yojson.inc)
 (include stanzas/test_oas_worker_named_liveness_integration.inc)
 (include stanzas/test_cascade_capability_gate.inc)
+(include stanzas/test_cascade_inference_clamp.inc)
 (include stanzas/test_cascade_fsm.inc)
 (include stanzas/test_cascade_health_tracker.inc)
 (include stanzas/test_cascade_per_candidate_telemetry.inc)

--- a/test/stanzas/test_cascade_inference_clamp.inc
+++ b/test/stanzas/test_cascade_inference_clamp.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_cascade_inference_clamp)
+ (modules test_cascade_inference_clamp)
+ (libraries masc_test_deps))

--- a/test/test_cascade_capability_gate.ml
+++ b/test/test_cascade_capability_gate.ml
@@ -136,6 +136,44 @@ target = "tier.primary"
         ~provider_ceiling:ceiling 65536
       |> check_violation "requested_exceeds_provider_ceiling" 65536 8192)
 
+let test_public_cap_helper_clamps_caller_override_to_cascade_ceiling () =
+  with_temp_cascade_toml
+    {|
+[providers.remote]
+protocol = "openai-http"
+endpoint = "https://example.test/v1"
+
+[models.narrow]
+api-name = "remote-narrow"
+max-context = 200000
+tools-support = true
+
+[models.narrow.capabilities]
+max-output-tokens = 8192
+
+[remote.narrow]
+max-concurrent = 1
+
+[tier.primary]
+members = ["remote.narrow"]
+
+[routes.keeper_unified]
+target = "tier.primary"
+|}
+    (fun () ->
+      let ceiling = CR.max_output_tokens_ceiling_of_cascade_name cascade_name in
+      check (option int) "output ceiling" (Some 8192) ceiling;
+      let capped =
+        CI.cap_max_tokens_to_cascade_ceiling
+          ~cascade_name
+          ~source:"caller_override"
+          16384
+      in
+      check int "caller override capped to ceiling" 8192 capped;
+      CI.validate_max_tokens_within_ceiling ~cascade_name
+        ~provider_ceiling:ceiling capped
+      |> check_ok "capped caller override accepted" 8192)
+
 let test_resolve_max_tokens_caps_automatic_value_to_cascade_ceiling () =
   with_temp_cascade_toml
     {|
@@ -350,6 +388,10 @@ let () =
         "cascade output cap, not context window, gates max_tokens"
         `Quick
         test_cascade_output_cap_not_context_window;
+      test_case
+        "caller override clamp uses cascade output ceiling"
+        `Quick
+        test_public_cap_helper_clamps_caller_override_to_cascade_ceiling;
       test_case
         "automatic max_tokens respects mixed failover ceiling"
         `Quick

--- a/test/test_cascade_inference_clamp.ml
+++ b/test/test_cascade_inference_clamp.ml
@@ -1,0 +1,179 @@
+(** Unit tests for the cascade-config / fallback max_tokens clamp introduced
+    on 2026-05-17 to fix fleet-wide [pre_dispatch_max_tokens_ceiling_violation]
+    after the multilane cascade rollout (see PR body for incident timeline).
+
+    Tests target [Cascade_inference.For_testing.clamp_with_ceiling] so they
+    do not need a live cascade.toml on disk; the production helper
+    [resolve_max_tokens] composes the same clamp with the catalog-driven
+    ceiling lookup. *)
+
+open Masc_mcp
+
+let cascade name =
+  Masc_mcp.Keeper_cascade_profile.runtime_name_of_string name
+
+let reset () =
+  Cascade_inference.For_testing.reset_auto_max_tokens_clamp_warnings ()
+
+let test_no_ceiling_passes_through () =
+  reset ();
+  let out =
+    Cascade_inference.For_testing.clamp_with_ceiling
+      ~cascade_name:(cascade "tier-group.test_a")
+      ~source:"cascade_config"
+      ~ceiling:None
+      16384
+  in
+  Alcotest.(check int) "no ceiling -> requested returned unchanged" 16384 out
+
+let test_ceiling_above_request_passes_through () =
+  reset ();
+  let out =
+    Cascade_inference.For_testing.clamp_with_ceiling
+      ~cascade_name:(cascade "tier-group.test_b")
+      ~source:"cascade_config"
+      ~ceiling:(Some 32000)
+      16384
+  in
+  Alcotest.(check int) "request below ceiling -> unchanged" 16384 out
+
+let test_ceiling_at_request_passes_through () =
+  reset ();
+  let out =
+    Cascade_inference.For_testing.clamp_with_ceiling
+      ~cascade_name:(cascade "tier-group.test_c")
+      ~source:"cascade_config"
+      ~ceiling:(Some 16384)
+      16384
+  in
+  Alcotest.(check int) "request == ceiling -> unchanged" 16384 out
+
+let test_ceiling_below_request_clamps () =
+  reset ();
+  let out =
+    Cascade_inference.For_testing.clamp_with_ceiling
+      ~cascade_name:(cascade "tier-group.glm-coding-with-spark")
+      ~source:"cascade_config"
+      ~ceiling:(Some 8192)
+      16384
+  in
+  Alcotest.(check int)
+    "cascade_config 16384 vs ceiling 8192 -> clamped to ceiling"
+    8192 out
+
+let test_fallback_source_clamps () =
+  reset ();
+  let out =
+    Cascade_inference.For_testing.clamp_with_ceiling
+      ~cascade_name:(cascade "tier-group.test_d")
+      ~source:"fallback"
+      ~ceiling:(Some 8192)
+      16384
+  in
+  Alcotest.(check int) "fallback source also clamped" 8192 out
+
+let test_caller_override_source_clamps () =
+  reset ();
+  let out =
+    Cascade_inference.For_testing.clamp_with_ceiling
+      ~cascade_name:(cascade "tier-group.test_override")
+      ~source:"caller_override"
+      ~ceiling:(Some 8192)
+      16384
+  in
+  Alcotest.(check int) "caller override source also clamped" 8192 out
+
+let test_zero_ceiling_treated_as_no_ceiling () =
+  reset ();
+  let out =
+    Cascade_inference.For_testing.clamp_with_ceiling
+      ~cascade_name:(cascade "tier-group.test_e")
+      ~source:"cascade_config"
+      ~ceiling:(Some 0)
+      16384
+  in
+  Alcotest.(check int) "ceiling=0 treated as no ceiling, no clamp" 16384 out
+
+let test_negative_ceiling_treated_as_no_ceiling () =
+  reset ();
+  let out =
+    Cascade_inference.For_testing.clamp_with_ceiling
+      ~cascade_name:(cascade "tier-group.test_f")
+      ~source:"cascade_config"
+      ~ceiling:(Some (-1))
+      16384
+  in
+  Alcotest.(check int) "negative ceiling -> no clamp" 16384 out
+
+let test_warn_dedup_per_tuple () =
+  reset ();
+  let name = cascade "tier-group.test_g" in
+  let first =
+    Cascade_inference.For_testing.should_log_auto_max_tokens_clamp
+      ~cascade_name:name ~source:"cascade_config" ~max_tokens:16384 ~ceiling:8192
+  in
+  let second =
+    Cascade_inference.For_testing.should_log_auto_max_tokens_clamp
+      ~cascade_name:name ~source:"cascade_config" ~max_tokens:16384 ~ceiling:8192
+  in
+  Alcotest.(check bool) "first occurrence logs" true first;
+  Alcotest.(check bool) "duplicate suppressed" false second
+
+let test_warn_emits_distinct_source () =
+  reset ();
+  let name = cascade "tier-group.test_h" in
+  let cfg =
+    Cascade_inference.For_testing.should_log_auto_max_tokens_clamp
+      ~cascade_name:name ~source:"cascade_config" ~max_tokens:16384 ~ceiling:8192
+  in
+  let fb =
+    Cascade_inference.For_testing.should_log_auto_max_tokens_clamp
+      ~cascade_name:name ~source:"fallback" ~max_tokens:16384 ~ceiling:8192
+  in
+  Alcotest.(check bool) "cascade_config source logs" true cfg;
+  Alcotest.(check bool) "fallback source separately logs" true fb
+
+let test_warn_emits_distinct_caller_override_source () =
+  reset ();
+  let name = cascade "tier-group.test_i" in
+  let cfg =
+    Cascade_inference.For_testing.should_log_auto_max_tokens_clamp
+      ~cascade_name:name ~source:"cascade_config" ~max_tokens:16384 ~ceiling:8192
+  in
+  let override =
+    Cascade_inference.For_testing.should_log_auto_max_tokens_clamp
+      ~cascade_name:name ~source:"caller_override" ~max_tokens:16384
+      ~ceiling:8192
+  in
+  Alcotest.(check bool) "cascade_config source logs" true cfg;
+  Alcotest.(check bool) "caller_override source separately logs" true override
+
+let () =
+  Alcotest.run
+    "cascade_inference clamp"
+    [ ( "clamp"
+      , [ Alcotest.test_case "no ceiling -> passthrough" `Quick
+            test_no_ceiling_passes_through
+        ; Alcotest.test_case "ceiling above -> passthrough" `Quick
+            test_ceiling_above_request_passes_through
+        ; Alcotest.test_case "ceiling == request -> passthrough" `Quick
+            test_ceiling_at_request_passes_through
+        ; Alcotest.test_case "ceiling below -> clamp" `Quick
+            test_ceiling_below_request_clamps
+        ; Alcotest.test_case "fallback source clamp" `Quick
+            test_fallback_source_clamps
+        ; Alcotest.test_case "caller override source clamp" `Quick
+            test_caller_override_source_clamps
+        ; Alcotest.test_case "ceiling=0 -> no clamp" `Quick
+            test_zero_ceiling_treated_as_no_ceiling
+        ; Alcotest.test_case "negative ceiling -> no clamp" `Quick
+            test_negative_ceiling_treated_as_no_ceiling
+        ] )
+    ; ( "warn-dedup"
+      , [ Alcotest.test_case "per-tuple dedup" `Quick test_warn_dedup_per_tuple
+        ; Alcotest.test_case "distinct source emits separately" `Quick
+            test_warn_emits_distinct_source
+        ; Alcotest.test_case "caller override source emits separately" `Quick
+            test_warn_emits_distinct_caller_override_source
+        ] )
+    ]


### PR DESCRIPTION
## Summary

2026-05-17 12:54~13:49 KST 사이 cascade.toml에 multilane 양방향 fallback 도입(`[tier-group.glm-coding-with-spark]`의 `tiers`를 `["glm-coding-with-spark", "strict_tool_candidates"]`로 union) 직후 fleet-wide 차단 사고가 발생했습니다. 5 keeper(nick0cave, analyst, sangsu, executor, qa-king)가 `pre_dispatch_max_tokens_ceiling_violation` + `pause_human`로 stuck. 본 PR은 그 사고의 **코드 root-fix**입니다.

근본 원인: 한 cascade에 대해 **upstream resolver**(`Cascade_inference.resolve_max_tokens`)와 **pre-dispatch validator**(`Cascade_inference.validate_max_tokens_within_ceiling`)가 *비대칭 정책*을 사용했습니다.

- resolver: cascade-config `Some t` 경로 → **그대로 반환** (cap 없음)
- resolver: cascade-config `None` 경로(fallback) → `cap_auto_resolved_max_tokens`로 narrowest ceiling으로 cap
- validator: narrowest ceiling 초과 → **hard reject** + `Max_tokens_ceiling_violation`

multilane cascade가 도입되기 *전*에는 caller가 cascade의 narrowest를 어느 정도 짐작할 수 있어 `Some t = narrowest`로 정렬됐습니다. multilane 도입 후 cascade의 narrowest가 **cascade-internal fallback structure에 의해 결정되는 implementation detail**이 됐고, caller-측에서 짐작할 수 없게 됐습니다. 결과: `Some 16384 > narrowest 8192`로 validator가 hard reject.

## 정책 변경 (DD-020 semantics revision)

다음 세 경로 *모두*를 narrowest ceiling으로 silent clamp하되, dedup된 WARN으로 가시성 보존:

1. `resolve_max_tokens`의 cascade-config `Some t` → `cap_max_tokens_to_cascade_ceiling ~source:"cascade_config"` (변경됨)
2. `resolve_max_tokens`의 fallback `None` 경로 → `cap_max_tokens_to_cascade_ceiling ~source:"fallback"` (이름만 변경, 동작 동일)
3. caller-supplied override (`keeper_run_context.ml` 외 4 caller) → `cap_max_tokens_to_cascade_ceiling ~source:"caller_override"` (신규)

validator(`validate_max_tokens_within_ceiling`)는 *stale state guard*로 남습니다: cascade reload between resolve and validate, 비양성 값, 비양성 ceiling만 hard reject.

DD-020 원래 의도("operator-supplied budget을 silent reduce하지 않는다")는 *multilane 이전*의 implicit 전제 위에 있었습니다. multilane이 narrowest를 internal detail로 만든 이상 silent clamp + WARN이 의미론적으로 올바른 선택입니다. 새 RFC 파일 대신 `cascade_inference.mli`의 docstring + `cascade_metrics.mli` counter 주석 + 본 PR body로 정책 변경을 박아둡니다(DD-020 자체가 코드 주석 형식 정책이라 동일 채널 update).

## 변경 내역

| 파일 | 변경 |
|---|---|
| `lib/cascade_inference.ml` | `cap_auto_resolved_max_tokens` → `cap_max_tokens_to_cascade_ceiling`로 의미명 변경 (기존 이름은 backward-compat alias로 유지). `resolve_max_tokens`의 `Some t` 경로가 이제 cap 통과. For_testing에 `clamp_with_ceiling` 추가 (Cascade_runtime 의존성 없는 unit-testable helper). |
| `lib/cascade_inference.mli` | `cap_max_tokens_to_cascade_ceiling` public API로 노출(caller_override 경로용). `resolve_max_tokens` / `validate_max_tokens_within_ceiling` docstring을 새 정책에 맞춰 갱신. `For_testing.clamp_with_ceiling` 노출. |
| `lib/cascade/cascade_metrics.mli` | `on_max_tokens_clamped` 주석을 새 source 집합(cascade_config / fallback / internal keeper override)에 맞춰 갱신. |
| `lib/keeper/keeper_run_context.ml` | caller-supplied `Some t` 경로가 이제 `cap_max_tokens_to_cascade_ceiling ~source:"caller_override"` 통과. 4 caller 중 가장 high-frequency 경로. (남은 3 caller — keeper_unified_turn / autoresearch_codegen / dashboard_provider_runs — 는 `resolve_max_tokens`만 사용하므로 자동으로 새 cap을 받음.) |
| `test/test_cascade_inference_clamp.ml` (신규) | 11 unit test: passthrough / clamp / 비양성 ceiling / WARN dedup / source distinguish. 6/11이 새 정책의 핵심 invariant. |
| `test/test_cascade_capability_gate.ml` | 기존 12 test가 새 source label 반영. 회귀 없음. |
| `test/dune` + `test/stanzas/test_cascade_inference_clamp.inc` | 새 테스트 등록. |

## 의도와 안티-패턴 self-check (CLAUDE.md §워크어라운드 거부 기준)

| 시그니처 | 본 PR 해당 여부 |
|---|---|
| Telemetry-as-fix (counter-as-fix) | ❌ counter는 *기존* dedup-WARN과 정렬한 visibility 보조. 실제 fix는 cap 정책 |
| String/substring 분류기 보강 | ❌ source label은 enum-ish, 분류기 아님 |
| N-of-M 패치 | ❌ 4 caller 모두 새 cap 경로 통과 (직접 + resolve_max_tokens 경유) |
| Catch-all 추가 | ❌ `match max_tokens with | Some t -> ... | None -> ...` 그대로, `_` 없음 |
| Cap/cooldown/dedup/repair symptom 억제 | ⚠ "cap" 단어가 들어가지만 — *물리적 ceiling*에 대한 cap, symptom suppression이 아님. validator의 reject가 *symptom 발현*이었고, cap이 *근원적 정렬*. dedup WARN은 시그널 가시성 보조 |
| Test backdoor 노출 | ⚠ `For_testing.clamp_with_ceiling` — mli에 명시적 test-only docstring + Cascade_runtime mock 없이 unit test 가능하게 하는 *진짜* 보조. backdoor 아님 |
| 같은 typo/off-by-one N번 fix | ❌ 한 결정의 일관 적용 |

## Self-review

- 목표: fleet-wide pre_dispatch_max_tokens_ceiling_violation 재발 방지. 새 multilane cascade를 도입할 때마다 같은 violation이 발생하지 않도록 정책 level에서 정렬.
- 변경 파일: 4 lib + 1 mli + 1 test/dune + 2 test (1 신규)
- 로컬 검증:
  - `dune build --root . @check` ✅ EXIT=0
  - `test_cascade_inference_clamp` (신규): **11/11 PASS** in 7ms
  - `test_cascade_capability_gate` (기존 회귀): **12/12 PASS** in 34ms
- 미검증:
  - 4 caller 중 keeper_unified_turn / autoresearch_codegen / dashboard_provider_runs는 이미 `resolve_max_tokens`만 사용하므로 자동 보호. 그러나 명시적 caller_override path를 추가하는 후속 PR을 작성할 때까지 *암묵*에 의존.
  - 실제 fleet 5 keeper resume까지의 end-to-end 검증은 *binary 재시작 + cascade reload* 필요. 본 PR이 머지/배포된 후 별도 운영 검증.

## RFC 매칭

- 본 변경은 cascade subsystem이지만 `pr-rfc-check.sh` 강제 영역(credential / identity / repo_manager / operator / sandbox / hooks / workflow)에 포함되지 않습니다.
- DD-020 정책은 RFC 파일이 아닌 *코드 주석/mli 인용*만 존재(`rg DD-020 docs/rfc/` empty). 동일 채널(주석/mli docstring)을 update.
- 새 RFC 파일을 별도 생성하지 않은 이유: DD-020 정책 자체가 코드-주석 형식이고, 새 정책 명세는 mli docstring + 본 PR body로 충분히 박힘. 만약 별도 RFC가 필요해지면 추후 backfill.

## 미해결 / 후속

- **운영 복구**: 5 paused keeper(nick0cave, analyst, sangsu, executor, qa-king)를 `POST /api/v1/keepers/<name>/directive {"action":"resume"}`로 일괄 resume. **본 PR이 binary로 적용된 후**(`dune build && server restart`) 실행해야 재차단 안 됨.
- **3 caller 명시적 caller_override 경로**: keeper_unified_turn.ml:381, autoresearch_codegen.ml:158, dashboard_provider_runs.ml:552 — `resolve_max_tokens` 사용이라 자동 cap을 받지만, *직접 caller_override*를 받는 경로가 있다면 keeper_run_context.ml처럼 명시 cap을 통과시켜야 함. 별도 audit 후 PR.
- **cascade.toml 정정**: `[tier-group.glm-coding-with-spark]`의 `tiers`를 단일 tier로 되돌리는 선택은 *본 PR 머지 후*에는 *불필요*. multilane 의도가 유지되면서 violation은 발생하지 않음.

## 운영 적용 단계 (사용자 승인 후)

1. PR 머지
2. `~/me/workspace/yousleepwhen/masc-mcp` 본 worktree에서 `dune build`
3. `~/me/.masc/config/cascade.toml`은 *그대로 유지* (multilane 그대로)
4. MASC server (`:8935`) 재시작 — fleet impact 있음, 사용자 승인 필요
5. 5 keeper resume: `for k in nick0cave analyst sangsu executor qa-king; do curl -sX POST http://127.0.0.1:8935/api/v1/keepers/$k/directive -H 'Content-Type: application/json' -d '{"action":"resume"}'; done`
6. 30분 후 fleet에 동일 violation 재발 없음 확인 (`grep pre_dispatch_max_tokens_ceiling_violation ~/me/.masc/keepers/*/execution-receipts/2026-05/17.jsonl | wc -l` 정체)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
