### PR TITLE
[codex] fix keeper autoboot TOML resync during boot discovery

### DIFF
--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -97,11 +97,19 @@ let declarative_autoboot_enabled_by_default name =
   | Some true | None -> true
 ;;
 
+let effective_autoboot_enabled name meta =
+  match (load_keeper_profile_defaults name).autoboot_enabled with
+  | Some value -> value
+  | None -> meta.autoboot_enabled
+;;
+
 let keepalive_keeper_names config =
   configured_keeper_names config
   |> List.filter_map (fun name ->
     match read_meta_file_path (keeper_meta_path config name) with
-    | Ok (Some meta) when (not meta.paused) && meta.autoboot_enabled -> Some meta.name
+    | Ok (Some meta)
+      when (not meta.paused) && effective_autoboot_enabled name meta ->
+        Some meta.name
     | Ok (Some _) -> None
     | Ok None -> if declarative_autoboot_enabled_by_default name then Some name else None
     | Error msg ->
@@ -132,7 +140,9 @@ let persistent_agent_names config =
   configured_keeper_names config
   |> List.filter_map (fun name ->
     match read_meta_file_path (keeper_meta_path config name) with
-    | Ok (Some meta) when (not meta.paused) && meta.autoboot_enabled -> Some meta.name
+    | Ok (Some meta)
+      when (not meta.paused) && effective_autoboot_enabled name meta ->
+        Some meta.name
     | Ok (Some _) -> None
     | Ok None -> None
     | Error msg ->

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -122,9 +122,14 @@ type autoboot_exclusion = {
 
 let autoboot_exclusion_reason config name =
   match read_meta_file_path (keeper_meta_path config name) with
-  | Ok (Some meta) when meta.paused -> Some "paused"
-  | Ok (Some meta) when not meta.autoboot_enabled -> Some "autoboot_disabled"
-  | Ok (Some _) -> None
+  | Ok (Some meta) ->
+    if meta.paused then Some "paused"
+    else
+      (match (load_keeper_profile_defaults name).autoboot_enabled with
+       | Some true -> None
+       | Some false -> Some "declarative_autoboot_disabled"
+       | None ->
+         if meta.autoboot_enabled then None else Some "autoboot_disabled")
   | Ok None ->
     (match (load_keeper_profile_defaults name).autoboot_enabled with
      | Some false -> Some "declarative_autoboot_disabled"

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -361,6 +361,44 @@ let test_bootable_keeper_names_skip_autoboot_disabled_meta () =
       check bool "autoboot disabled sangsu excluded from bootable list" false
         (List.mem "sangsu" names))
 
+let test_bootable_keeper_names_use_declarative_autoboot_true_over_stale_meta () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  with_clean_base_path_env @@ fun () ->
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Config_dir_resolver.reset ();
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      write_keeper_toml_exn ~autoboot_enabled:true config ~name:"verifier";
+      let config_root = Filename.concat (Coord.masc_root_dir config) "config" in
+      write_minimal_cascade_toml config_root;
+      Unix.putenv "MASC_CONFIG_DIR" config_root;
+      Config_dir_resolver.reset ();
+      write_keeper_meta_exn
+        ~autoboot_enabled:false config ~name:"verifier" ~trace_id:"trace-verifier";
+      let bootable_names = Keeper_runtime.bootable_keeper_names config in
+      check bool "declarative autoboot true restores bootable keeper" true
+        (List.mem "verifier" bootable_names);
+      let keepalive_names = Keeper_types.keepalive_keeper_names config in
+      check bool "declarative autoboot true restores keepalive keeper" true
+        (List.mem "verifier" keepalive_names);
+      let exclusions =
+        Keeper_runtime.autoboot_excluded_keeper_reasons config
+        |> List.map (fun Keeper_runtime.{ keeper_name; reason } ->
+          keeper_name, reason)
+      in
+      check (list (pair string string))
+        "declarative autoboot true clears stale disabled exclusion"
+        []
+        exclusions)
+
 let test_autoboot_exclusion_reasons_explain_skipped_keepers () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -1117,6 +1155,10 @@ let () =
             test_keeper_listing_ignores_sidecar_json_files;
           test_case "bootable list skips autoboot-disabled meta" `Quick
             test_bootable_keeper_names_skip_autoboot_disabled_meta;
+          test_case
+            "bootable list uses declarative autoboot true over stale meta"
+            `Quick
+            test_bootable_keeper_names_use_declarative_autoboot_true_over_stale_meta;
           test_case "autoboot exclusion reasons explain skipped keepers" `Quick
             test_autoboot_exclusion_reasons_explain_skipped_keepers;
           test_case "declarative autoboot-disabled keeper skips boot without meta"


### PR DESCRIPTION
## Summary
- Honor explicit keeper TOML autoboot defaults while computing bootable/keepalive keeper sets.
- Preserve durable JSON autoboot state only when TOML does not specify an override.
- Add regression coverage for stale `autoboot_enabled=false` meta being restored by declarative `autoboot_enabled=true`.

## Runtime evidence
- Live `verifier.toml` declares `autoboot_enabled = true` and `proactive_enabled = true`.
- Live durable `.masc/keepers/verifier.json` still had `autoboot_enabled=false`, `proactive_enabled=false`.
- `/health` reported `paused_keepers.count=0` but omitted verifier from `keeper_fleet_safety.bootable_keeper_names`, so verifier could not produce fresh CDAL verdict/proof rows after #15768.

## Verification
- `git diff --check`
- `ocamlformat --check lib/keeper/keeper_runtime.ml lib/keeper/keeper_meta_store.ml test/test_keeper_meta_listing.ml`
- Focused Dune build attempted with `scripts/dune-local.sh build test/test_keeper_meta_listing.exe`, but local `/tmp/me-dune-local.lock` was held by another worktree build; PR CI is the Dune verification surface.

Fixes #15748