### PR TITLE
feat(dashboard): expose Runtime Lens sandbox proof

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -226,6 +226,23 @@ describe('keeper runtime trace', () => {
             finished_count: 1,
             terminal_status: 'timeout',
           },
+          runtime_proof: {
+            source: 'keeper_tool_call_log',
+            status: 'pass',
+            matched_tool_call_count: 2,
+            successful_tool_call_count: 2,
+            failed_tool_call_count: 0,
+            tools: ['keeper_bash', 'keeper_pr_create'],
+            successful_tools: ['keeper_bash', 'keeper_pr_create'],
+            failed_tools: [],
+            sandbox_profiles: ['docker'],
+            network_modes: ['inherit'],
+            docker_visible: true,
+            git_credentials_enabled: true,
+            github_identity_materialized: true,
+            pr_create_observed: true,
+            latest_at: '2026-05-13T00:00:01Z',
+          },
         },
         swimlanes: {
           provider: {
@@ -262,6 +279,10 @@ describe('keeper runtime trace', () => {
     expect(result.runtime_lens.axes.tool_surface.visible_tool_count).toBeNull()
     expect(result.runtime_lens.axes.provider_lane.resolved).toBe(false)
     expect(result.runtime_lens.axes.provider_attempt.terminal_status).toBe('timeout')
+    expect(result.runtime_lens.axes.runtime_proof.status).toBe('pass')
+    expect(result.runtime_lens.axes.runtime_proof.docker_visible).toBe(true)
+    expect(result.runtime_lens.axes.runtime_proof.github_identity_materialized).toBe(true)
+    expect(result.runtime_lens.axes.runtime_proof.tools).toEqual(['keeper_bash', 'keeper_pr_create'])
     expect(result.runtime_lens.swimlanes.provider.terminal_status).toBe('timeout')
     expect(result.runtime_lens.swimlanes.memory_context.terminal_status).toBe('unknown')
     expect(result.runtime_lens.gaps.map(gap => gap.code)).toEqual(['required_tool_not_materialized'])

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -744,6 +744,24 @@ export interface KeeperRuntimeLensConfigDriftAxis {
   default_manifest_path: string | null
 }
 
+export interface KeeperRuntimeLensRuntimeProofAxis {
+  source: string
+  status: string
+  matched_tool_call_count: number
+  successful_tool_call_count: number
+  failed_tool_call_count: number
+  tools: string[]
+  successful_tools: string[]
+  failed_tools: string[]
+  sandbox_profiles: string[]
+  network_modes: string[]
+  docker_visible: boolean
+  git_credentials_enabled: boolean
+  github_identity_materialized: boolean
+  pr_create_observed: boolean
+  latest_at: string | null
+}
+
 export interface KeeperRuntimeLensContextAxis {
   context_injected_count: number
   context_compacted_event_count: number
@@ -765,6 +783,7 @@ export interface KeeperRuntimeLensAxes {
   provider_attempt: KeeperRuntimeLensProviderAttemptAxis
   claim_scope: KeeperRuntimeLensClaimScopeAxis
   config_drift: KeeperRuntimeLensConfigDriftAxis
+  runtime_proof: KeeperRuntimeLensRuntimeProofAxis
   context: KeeperRuntimeLensContextAxis
   memory: KeeperRuntimeLensMemoryAxis
 }
@@ -1078,6 +1097,27 @@ function parseRuntimeLensConfigDriftAxis(raw: unknown): KeeperRuntimeLensConfigD
   }
 }
 
+function parseRuntimeLensRuntimeProofAxis(raw: unknown): KeeperRuntimeLensRuntimeProofAxis {
+  const obj = isRecord(raw) ? raw : {}
+  return {
+    source: stringField(obj, 'source') || 'keeper_tool_call_log',
+    status: stringField(obj, 'status') || 'missing',
+    matched_tool_call_count: numberField(obj, 'matched_tool_call_count'),
+    successful_tool_call_count: numberField(obj, 'successful_tool_call_count'),
+    failed_tool_call_count: numberField(obj, 'failed_tool_call_count'),
+    tools: stringListField(obj, 'tools'),
+    successful_tools: stringListField(obj, 'successful_tools'),
+    failed_tools: stringListField(obj, 'failed_tools'),
+    sandbox_profiles: stringListField(obj, 'sandbox_profiles'),
+    network_modes: stringListField(obj, 'network_modes'),
+    docker_visible: obj.docker_visible === true,
+    git_credentials_enabled: obj.git_credentials_enabled === true,
+    github_identity_materialized: obj.github_identity_materialized === true,
+    pr_create_observed: obj.pr_create_observed === true,
+    latest_at: nullableStringField(obj, 'latest_at'),
+  }
+}
+
 function parseRuntimeLensContextAxis(raw: unknown): KeeperRuntimeLensContextAxis {
   const obj = isRecord(raw) ? raw : {}
   return {
@@ -1102,6 +1142,7 @@ function parseRuntimeLensAxes(raw: unknown): KeeperRuntimeLensAxes {
     provider_attempt: parseRuntimeLensProviderAttemptAxis(obj.provider_attempt),
     claim_scope: parseRuntimeLensClaimScopeAxis(obj.claim_scope),
     config_drift: parseRuntimeLensConfigDriftAxis(obj.config_drift),
+    runtime_proof: parseRuntimeLensRuntimeProofAxis(obj.runtime_proof),
     context: parseRuntimeLensContextAxis(obj.context),
     memory: parseRuntimeTraceMemory(obj.memory),
   }

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -519,6 +519,23 @@ describe('RuntimeLensSection', () => {
             active_config_root_source: null,
             default_manifest_path: null,
           },
+          runtime_proof: {
+            source: 'keeper_tool_call_log',
+            status: 'pass',
+            matched_tool_call_count: 2,
+            successful_tool_call_count: 2,
+            failed_tool_call_count: 0,
+            tools: ['keeper_bash', 'keeper_pr_create'],
+            successful_tools: ['keeper_bash', 'keeper_pr_create'],
+            failed_tools: [],
+            sandbox_profiles: ['docker'],
+            network_modes: ['inherit'],
+            docker_visible: true,
+            git_credentials_enabled: true,
+            github_identity_materialized: true,
+            pr_create_observed: true,
+            latest_at: '2026-05-13T00:00:01Z',
+          },
           context: {
             context_injected_count: 1,
             context_compacted_event_count: 1,
@@ -695,6 +712,16 @@ describe('RuntimeLensSection', () => {
     expect(screen.getByText('tool log artifacts')).toBeInTheDocument()
     expect(screen.getAllByText('1/1').length).toBeGreaterThan(1)
     expect(screen.getByText('0/1')).toBeInTheDocument()
+    expect(screen.getByText('runtime proof')).toBeInTheDocument()
+    expect(screen.getByText('pass / 2 calls')).toBeInTheDocument()
+    expect(screen.getByText('sandbox proof')).toBeInTheDocument()
+    expect(screen.getByText('docker')).toBeInTheDocument()
+    expect(screen.getByText('GitHub proof')).toBeInTheDocument()
+    expect(screen.getByText('git creds / identity materialized')).toBeInTheDocument()
+    expect(screen.getByText('proof tools')).toBeInTheDocument()
+    expect(screen.getByText('keeper_bash, keeper_pr_create')).toBeInTheDocument()
+    expect(screen.getByText('network proof')).toBeInTheDocument()
+    expect(screen.getByText('inherit')).toBeInTheDocument()
     expect(screen.getByText('provider attempts')).toBeInTheDocument()
     expect(screen.getAllByText('1/1').length).toBeGreaterThan(0)
     expect(screen.getByText('provider terminal')).toBeInTheDocument()

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -1007,6 +1007,7 @@ export function RuntimeLensSection({
   const lane = lens.axes.provider_lane
   const claim = lens.axes.claim_scope
   const drift = lens.axes.config_drift
+  const proof = lens.axes.runtime_proof
   const context = lens.axes.context
   const memory = lens.axes.memory
   const clock = lens.turn_clock
@@ -1034,6 +1035,14 @@ export function RuntimeLensSection({
         <${SignalRow} label="claim goals" value=${formatLensList(claim.effective_goal_ids)} />
         <${SignalRow} label="cascade drift" value=${drift.cascade_override ? `${drift.default_cascade_name ?? '-'} -> ${drift.live_cascade_name ?? '-'}` : drift.status} />
         <${SignalRow} label="override fields" value=${formatLensList(drift.override_fields)} />
+        <${SignalRow} label="runtime proof" value=${`${proof.status} / ${proof.matched_tool_call_count} calls`} />
+        <${SignalRow} label="sandbox proof" value=${proof.docker_visible ? formatLensList(proof.sandbox_profiles, 'docker') : 'not observed'} />
+        <${SignalRow}
+          label="GitHub proof"
+          value=${`${proof.git_credentials_enabled ? 'git creds' : 'no git creds'} / ${proof.github_identity_materialized ? 'identity materialized' : 'identity missing'}`}
+        />
+        <${SignalRow} label="proof tools" value=${formatLensList(proof.tools)} />
+        <${SignalRow} label="network proof" value=${formatLensList(proof.network_modes)} />
         <${SignalRow} label="context compaction" value=${`${context.context_compacted_count}/${context.context_compact_started_count}`} />
         <${SignalRow} label="memory flush" value=${`${memory.memory_flush_success_count}/${memory.memory_flush_error_count}`} />
         <${SignalRow} label="trace id" value=${compactToken(trace.trace_id)} />

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1057,6 +1057,217 @@ let runtime_lens_memory_terminal_status scan =
   then "context"
   else "empty"
 
+type runtime_lens_proof_acc =
+  { mutable matched_tool_call_count : int
+  ; mutable successful_tool_call_count : int
+  ; mutable failed_tool_call_count : int
+  ; mutable latest_ts : float option
+  ; mutable docker_visible : bool
+  ; mutable git_credentials_enabled : bool
+  ; mutable github_identity_materialized : bool
+  ; mutable pr_create_observed : bool
+  ; tools : (string, unit) Hashtbl.t
+  ; successful_tools : (string, unit) Hashtbl.t
+  ; failed_tools : (string, unit) Hashtbl.t
+  ; sandbox_profiles : (string, unit) Hashtbl.t
+  ; network_modes : (string, unit) Hashtbl.t
+  }
+
+let runtime_lens_proof_acc () =
+  { matched_tool_call_count = 0
+  ; successful_tool_call_count = 0
+  ; failed_tool_call_count = 0
+  ; latest_ts = None
+  ; docker_visible = false
+  ; git_credentials_enabled = false
+  ; github_identity_materialized = false
+  ; pr_create_observed = false
+  ; tools = Hashtbl.create 8
+  ; successful_tools = Hashtbl.create 8
+  ; failed_tools = Hashtbl.create 8
+  ; sandbox_profiles = Hashtbl.create 4
+  ; network_modes = Hashtbl.create 4
+  }
+
+let runtime_lens_set_add table value =
+  let value = String.trim value in
+  if value <> "" then Hashtbl.replace table value ()
+
+let runtime_lens_sorted_set table =
+  Hashtbl.fold (fun value () acc -> value :: acc) table []
+  |> List.sort_uniq String.compare
+
+let runtime_lens_update_latest_ts acc json =
+  let ts_opt =
+    match Yojson.Safe.Util.member "ts" json with
+    | `Float value -> Some value
+    | `Int value -> Some (Float.of_int value)
+    | _ -> None
+  in
+  match ts_opt with
+  | Some ts ->
+      acc.latest_ts <-
+        (match acc.latest_ts with
+         | Some previous when previous >= ts -> acc.latest_ts
+         | _ -> Some ts)
+  | None -> ()
+
+let rec runtime_lens_json_string_values field = function
+  | `Assoc fields ->
+      let direct =
+        match List.assoc_opt field fields with
+        | Some (`String value) -> [ value ]
+        | _ -> []
+      in
+      direct
+      @ List.concat_map
+          (fun (_, value) -> runtime_lens_json_string_values field value)
+          fields
+  | `List values -> List.concat_map (runtime_lens_json_string_values field) values
+  | _ -> []
+
+let rec runtime_lens_json_bool_values field = function
+  | `Assoc fields ->
+      let direct =
+        match List.assoc_opt field fields with
+        | Some (`Bool value) -> [ value ]
+        | _ -> []
+      in
+      direct
+      @ List.concat_map
+          (fun (_, value) -> runtime_lens_json_bool_values field value)
+          fields
+  | `List values -> List.concat_map (runtime_lens_json_bool_values field) values
+  | _ -> []
+
+let runtime_lens_has_string_field json field expected =
+  runtime_lens_json_string_values field json
+  |> List.exists (String.equal expected)
+
+let runtime_lens_has_true_field json field =
+  runtime_lens_json_bool_values field json |> List.exists Fun.id
+
+let runtime_lens_tool_text json =
+  let input = Yojson.Safe.Util.member "input" json |> Yojson.Safe.to_string in
+  let output = Option.value (tool_call_output_text_opt json) ~default:"" in
+  input ^ "\n" ^ output
+
+let runtime_lens_text_contains text needle =
+  string_contains ~needle text
+
+let runtime_lens_call_has_docker_proof json output_opt text =
+  json_string_member_opt "sandbox_profile" json = Some "docker"
+  || json_string_member_opt "sandbox_profile" (tool_call_runtime_contract json)
+     = Some "docker"
+  || runtime_lens_text_contains text "\"sandbox_profile\":\"docker\""
+  || runtime_lens_text_contains text "\"via\":\"docker\""
+  ||
+  match output_opt with
+  | Some output ->
+      runtime_lens_has_string_field output "sandbox_profile" "docker"
+      || runtime_lens_has_string_field output "via" "docker"
+  | None -> false
+
+let runtime_lens_call_has_git_credentials output_opt text =
+  runtime_lens_text_contains text "\"git_creds_enabled\":true"
+  ||
+  match output_opt with
+  | Some output -> runtime_lens_has_true_field output "git_creds_enabled"
+  | None -> false
+
+let runtime_lens_call_has_github_identity output_opt text =
+  let structured =
+    match output_opt with
+    | Some output ->
+        runtime_lens_has_string_field output "credential_scope" "keeper_identity"
+        &&
+        (runtime_lens_has_string_field output "git_identity_mode" "github_identity"
+         || runtime_lens_has_string_field output "state" "materialized")
+    | None -> false
+  in
+  structured
+  ||
+  (runtime_lens_text_contains text "\"credential_scope\":\"keeper_identity\""
+   &&
+   (runtime_lens_text_contains text "\"git_identity_mode\":\"github_identity\""
+    || runtime_lens_text_contains text
+         "\"credential_state\":{\"state\":\"materialized\""))
+
+let runtime_lens_collect_profile acc json =
+  let add_from table field source =
+    match json_string_member_opt field source with
+    | Some value -> runtime_lens_set_add table value
+    | None -> ()
+  in
+  add_from acc.sandbox_profiles "sandbox_profile" json;
+  add_from acc.sandbox_profiles "sandbox_profile" (tool_call_runtime_contract json);
+  add_from acc.network_modes "network_mode" json;
+  add_from acc.network_modes "network_mode" (tool_call_runtime_contract json)
+
+let runtime_lens_accumulate_tool_proof acc json =
+  acc.matched_tool_call_count <- acc.matched_tool_call_count + 1;
+  runtime_lens_update_latest_ts acc json;
+  let tool = Option.value (json_string_member_opt "tool" json) ~default:"unknown_tool" in
+  runtime_lens_set_add acc.tools tool;
+  if json_bool_member_opt "success" json = Some true then (
+    acc.successful_tool_call_count <- acc.successful_tool_call_count + 1;
+    runtime_lens_set_add acc.successful_tools tool)
+  else (
+    acc.failed_tool_call_count <- acc.failed_tool_call_count + 1;
+    runtime_lens_set_add acc.failed_tools tool);
+  if String.equal tool "keeper_pr_create" then acc.pr_create_observed <- true;
+  runtime_lens_collect_profile acc json;
+  let output_opt = parse_tool_output_json_opt json in
+  let text = runtime_lens_tool_text json in
+  if runtime_lens_call_has_docker_proof json output_opt text
+  then acc.docker_visible <- true;
+  if runtime_lens_call_has_git_credentials output_opt text
+  then acc.git_credentials_enabled <- true;
+  if runtime_lens_call_has_github_identity output_opt text
+  then acc.github_identity_materialized <- true
+
+let runtime_lens_runtime_proof_json ~keeper_name ~trace_id ?turn_id () =
+  let acc = runtime_lens_proof_acc () in
+  Keeper_tool_call_log.read_recent ~keeper_name ~n:200 ()
+  |> List.iter (fun json ->
+       if tool_call_matches_trace ?turn_id ~keeper_name ~trace_id json
+       then runtime_lens_accumulate_tool_proof acc json);
+  let status =
+    if
+      acc.docker_visible
+      && (acc.git_credentials_enabled || acc.github_identity_materialized)
+    then "pass"
+    else if
+      acc.matched_tool_call_count > 0
+      && (acc.docker_visible
+          || acc.git_credentials_enabled
+          || acc.github_identity_materialized)
+    then "warn"
+    else "missing"
+  in
+  `Assoc
+    [ ("source", `String "keeper_tool_call_log")
+    ; ("status", `String status)
+    ; ("matched_tool_call_count", `Int acc.matched_tool_call_count)
+    ; ("successful_tool_call_count", `Int acc.successful_tool_call_count)
+    ; ("failed_tool_call_count", `Int acc.failed_tool_call_count)
+    ; ("tools", json_string_list (runtime_lens_sorted_set acc.tools))
+    ; ( "successful_tools",
+        json_string_list (runtime_lens_sorted_set acc.successful_tools) )
+    ; ("failed_tools", json_string_list (runtime_lens_sorted_set acc.failed_tools))
+    ; ( "sandbox_profiles",
+        json_string_list (runtime_lens_sorted_set acc.sandbox_profiles) )
+    ; ("network_modes", json_string_list (runtime_lens_sorted_set acc.network_modes))
+    ; ("docker_visible", `Bool acc.docker_visible)
+    ; ("git_credentials_enabled", `Bool acc.git_credentials_enabled)
+    ; ("github_identity_materialized", `Bool acc.github_identity_materialized)
+    ; ("pr_create_observed", `Bool acc.pr_create_observed)
+    ; ( "latest_at",
+        match acc.latest_ts with
+        | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
+        | None -> `Null )
+    ]
+
 let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
   let ( tool_decision
       , lane_decision
@@ -1073,6 +1284,9 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
   in
   let claim_scope = claim_scope_summary_json ~keeper_name ~trace_id ?turn_id () in
   let config_drift = config_drift_summary_json ~config ~keeper_name in
+  let runtime_proof =
+    runtime_lens_runtime_proof_json ~keeper_name ~trace_id ?turn_id ()
+  in
   let gaps =
     runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan
   in
@@ -1226,6 +1440,7 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                 ] );
             ("claim_scope", claim_scope);
             ("config_drift", config_drift);
+            ("runtime_proof", runtime_proof);
             ( "context",
               `Assoc
                 [

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -1048,6 +1048,109 @@ let test_runtime_trace_lens_summarizes_tool_axis () =
         [ "required_tool_not_materialized"; "context_delta_missing" ]
         gaps)
 
+let test_runtime_trace_lens_surfaces_docker_github_sandbox_proof () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_tool_call_log.reset_for_testing ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      let keeper_name = "runtime-lens-proof" in
+      let trace_id = "trace-runtime-lens-proof" in
+      let keeper_turn_id = 12 in
+      Masc_mcp.Keeper_tool_call_log.reset_for_testing ();
+      Masc_mcp.Keeper_tool_call_log.init ~base_path:base_dir ();
+      append_manifest_or_fail config
+        (M.make ~ts:"2026-05-13T00:00:00Z" ~keeper_name
+           ~trace_id ~keeper_turn_id ~event:M.Turn_started ~status:"started" ());
+      append_manifest_or_fail config
+        (M.make ~ts:"2026-05-13T00:00:01Z" ~keeper_name
+           ~trace_id ~keeper_turn_id ~event:M.Turn_finished ~status:"finished" ());
+      Masc_mcp.Keeper_tool_call_log.log_call
+        ~keeper_name
+        ~tool_name:"keeper_bash"
+        ~input:
+          (`Assoc
+            [
+              ( "cmd",
+                `String
+                  "git clone https://github.com/jeong-sik/masc-mcp.git /workspace/masc-mcp"
+              );
+              ("git_creds_enabled", `Bool true);
+            ])
+        ~output_text:
+          {|{"ok":true,"sandbox_profile":"docker","via":"docker","git_creds_enabled":true}|}
+        ~success:true
+        ~duration_ms:1.0
+        ~trace_id
+        ~keeper_turn_id
+        ~sandbox_profile:"docker"
+        ~network_mode:"inherit"
+        ();
+      Masc_mcp.Keeper_tool_call_log.log_call
+        ~keeper_name
+        ~tool_name:"keeper_pr_create"
+        ~input:(`Assoc [ ("draft", `Bool true) ])
+        ~output_text:
+          {|{"ok":true,"sandbox_profile":"docker","via":"docker","credential":{"credential_scope":"keeper_identity","git_identity_mode":"github_identity","credential_state":{"state":"materialized"}},"url":"https://github.com/jeong-sik/masc-mcp/pull/1"}|}
+        ~success:true
+        ~duration_ms:1.0
+        ~trace_id
+        ~keeper_turn_id
+        ~sandbox_profile:"docker"
+        ~network_mode:"inherit"
+        ();
+      let status, json =
+        Masc_mcp.Server_dashboard_http_keeper_api.keeper_runtime_trace_json
+          config keeper_name ~trace_id ~turn_id:keeper_turn_id ()
+      in
+      Alcotest.(check string)
+        "runtime proof status"
+        "ok"
+        (match status with `OK -> "ok" | `Not_found -> "not_found");
+      let proof =
+        Yojson.Safe.Util.(
+          json |> member "runtime_lens" |> member "axes"
+          |> member "runtime_proof")
+      in
+      Alcotest.(check string)
+        "proof passes"
+        "pass"
+        Yojson.Safe.Util.(proof |> member "status" |> to_string);
+      Alcotest.(check int)
+        "proof matched tool calls"
+        2
+        (json_int_member "matched_tool_call_count" proof);
+      Alcotest.(check bool)
+        "proof sees docker"
+        true
+        (json_bool_member "docker_visible" proof);
+      Alcotest.(check bool)
+        "proof sees git credentials"
+        true
+        (json_bool_member "git_credentials_enabled" proof);
+      Alcotest.(check bool)
+        "proof sees github identity"
+        true
+        (json_bool_member "github_identity_materialized" proof);
+      Alcotest.(check bool)
+        "proof sees pr create"
+        true
+        (json_bool_member "pr_create_observed" proof);
+      Alcotest.(check (list string))
+        "proof sandbox profiles"
+        [ "docker" ]
+        (json_string_list_member "sandbox_profiles" proof);
+      Alcotest.(check (list string))
+        "proof network modes"
+        [ "inherit" ]
+        (json_string_list_member "network_modes" proof);
+      Alcotest.(check (list string))
+        "proof tools"
+        [ "keeper_bash"; "keeper_pr_create" ]
+        (json_string_list_member "tools" proof))
+
 let test_runtime_trace_lens_terminal_uses_latest_turn_without_turn_filter () =
   let base_dir = temp_dir () in
   Fun.protect
@@ -2542,6 +2645,10 @@ let () =
             `Quick test_runtime_trace_api_bounds_rows_but_counts_full_manifest;
           Alcotest.test_case "runtime trace lens summarizes tool axis" `Quick
             test_runtime_trace_lens_summarizes_tool_axis;
+          Alcotest.test_case
+            "runtime trace lens surfaces Docker GitHub sandbox proof"
+            `Quick
+            test_runtime_trace_lens_surfaces_docker_github_sandbox_proof;
           Alcotest.test_case
             "runtime trace lens terminal follows latest turn"
             `Quick


### PR DESCRIPTION
## Summary

- add a Runtime Lens `runtime_proof` axis backed by keeper tool-call logs
- summarize Docker-visible sandbox proof, GitHub credential materialization, proof tools, and network modes without exposing raw tool I/O
- render the proof rows in the keeper Runtime Lens and add parser/component/backend coverage

## Validation

- `opam exec -- ocamlformat --check lib/server/server_dashboard_http_keeper_api.ml test/test_keeper_runtime_manifest.ml`
- `MASC_SKIP_PIN_CHECK=1 DUNE_LOCAL_JOBS=1 OCAMLPARAM=_,warn-error=-23 scripts/dune-local.sh build test/test_keeper_runtime_manifest.exe`
- `env OCAMLPARAM=_,warn-error=-23 _build/default/test/test_keeper_runtime_manifest.exe test append 7`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/api/keeper.test.ts src/components/keeper-detail-runtime.test.ts --no-file-parallelism --maxWorkers=1`
- `git diff --check origin/main`

## Notes

Full `test_keeper_runtime_manifest.exe` still has pre-existing environment-sensitive runtime fixture failures in the provider turn cases; the new targeted Runtime Lens proof case passes.