### PR TITLE
fix(cascade): clamp max_tokens to cascade ceiling

### DIFF
--- a/lib/cascade/cascade_metrics.ml
+++ b/lib/cascade/cascade_metrics.ml
@@ -858,10 +858,12 @@ let metric_cascade_metrics_eviction =
 let on_cascade_metrics_eviction () =
   Prometheus.inc_counter metric_cascade_metrics_eviction ()
 
-(* Legacy iter-46 counter retained for metric compatibility.  DD-020
-   replaced runtime max_tokens clipping with a structured
-   [max_tokens_ceiling_violation] pre-dispatch error, so this counter
-   should stay at zero on current code paths. *)
+(* Counts max_tokens budgets reduced to the resolved cascade output ceiling.
+   DD-020 originally treated all over-ceiling budgets as structured
+   [max_tokens_ceiling_violation] errors.  The 2026-05-17 multilane cascade
+   rollout showed that internal cascade-config/fallback/keeper override
+   budgets must be normalized before dispatch because the narrowest failover
+   member can be lower than the caller-visible primary route. *)
 let metric_max_tokens_clamped = "masc_cascade_max_tokens_clamped_total"
 
 let on_max_tokens_clamped () =

--- a/lib/cascade/cascade_metrics.mli
+++ b/lib/cascade/cascade_metrics.mli
@@ -274,11 +274,10 @@ val on_cascade_metrics_eviction : unit -> unit
     [cascade_max_keys] or canonicalize synthesized names. *)
 
 val on_max_tokens_clamped : unit -> unit
-(** Tick when an automatically-derived max_tokens fallback is reduced to the
-    resolved cascade output ceiling. Repeated clamps are counted here even
-    when the corresponding WARN log is deduplicated. Explicit cascade.toml or
-    caller-provided over-ceiling values still use the structured
-    [max_tokens_ceiling_violation] pre-dispatch error instead. *)
+(** Tick when a cascade-config, fallback, or internal keeper override
+    max_tokens budget is reduced to the resolved cascade output ceiling.
+    Repeated clamps are counted here even when the corresponding WARN log is
+    deduplicated. *)
 
 val on_cascade_audit_failure : stage:string -> unit
 (** Tick the cascade-audit subsystem failure counter at

--- a/lib/cascade_inference.ml
+++ b/lib/cascade_inference.ml
@@ -113,24 +113,43 @@ let should_log_auto_max_tokens_clamp ~cascade_name ~source ~max_tokens ~ceiling 
   auto_max_tokens_clamp_key ~cascade_name ~source ~max_tokens ~ceiling
   |> mark_auto_max_tokens_clamp_seen
 
-(** Cap an automatically-derived max_tokens value to the narrowest output
-    ceiling in the resolved cascade. Explicit caller-provided overrides and
-    cascade.toml values stay hard rejected by the pre-dispatch validator. *)
-let cap_auto_resolved_max_tokens ~cascade_name ~source max_tokens =
+(** Cap a max_tokens value to the narrowest output ceiling in the resolved
+    cascade. Both auto-derived [fallback] values and cascade-config explicit
+    values are clamped here.
+
+    Rationale (2026-05-17, supersedes original DD-020 phrasing): with
+    multilane cascades (tier-groups whose [tiers] union members from groups
+    of differing output budgets), the *narrowest* ceiling is a property of
+    cascade-internal fallback structure that the caller has no clean way
+    to discover. Letting cascade-config values bypass this cap caused
+    fleet-wide [pre_dispatch_max_tokens_ceiling_violation] when a previously
+    16384-narrow cascade was unioned with an 8192-narrow secondary tier.
+    Clamping unifies the two sites; a deduplicated WARN preserves operator
+    visibility into the silent reduction.
+
+    Runtime overrides supplied by internal keeper callers should also flow
+    through this helper before the final pre-dispatch validator. The validator
+    remains as a hard guard for non-positive budgets, invalid ceilings, and
+    stale values after a cascade reload. *)
+let cap_max_tokens_to_cascade_ceiling ~cascade_name ~source max_tokens =
   match Cascade_runtime.max_output_tokens_ceiling_of_cascade_name cascade_name with
   | Some ceiling when ceiling > 0 && max_tokens > ceiling ->
     Cascade_metrics.on_max_tokens_clamped ();
     if should_log_auto_max_tokens_clamp ~cascade_name ~source ~max_tokens ~ceiling
     then
       Log.warn ~ctx:"cascade"
-        "%s: auto-resolved max_tokens=%d from %s exceeds output ceiling=%d; \
+        "%s: resolved max_tokens=%d from %s exceeds output ceiling=%d; \
          using ceiling; suppressing repeats for this tuple"
         (Keeper_cascade_profile.runtime_name_to_string cascade_name)
         max_tokens source ceiling;
     ceiling
   | _ -> max_tokens
 
-(** Resolve a max_tokens value: cascade config -> capped fallback. *)
+(** Backwards-compatible alias retained for any out-of-tree callers; new
+    code should call [cap_max_tokens_to_cascade_ceiling] directly. *)
+let cap_auto_resolved_max_tokens = cap_max_tokens_to_cascade_ceiling
+
+(** Resolve a max_tokens value: cascade config (capped) -> capped fallback. *)
 let resolve_max_tokens
     ~(cascade_name : Keeper_cascade_profile.runtime_name)
     ~(fallback : unit -> int) : int =
@@ -138,9 +157,10 @@ let resolve_max_tokens
     Keeper_cascade_profile.runtime_name_to_string cascade_name
   in
   match (for_cascade ~name:cascade_name_string).max_tokens with
-  | Some t -> t
+  | Some t ->
+    cap_max_tokens_to_cascade_ceiling ~cascade_name ~source:"cascade_config" t
   | None ->
-    cap_auto_resolved_max_tokens ~cascade_name ~source:"fallback" (fallback ())
+    cap_max_tokens_to_cascade_ceiling ~cascade_name ~source:"fallback" (fallback ())
 
 (** Validate max_tokens against provider ceilings before dispatch. *)
 let validate_max_tokens_within_ceiling
@@ -182,4 +202,19 @@ module For_testing = struct
 
   let should_log_auto_max_tokens_clamp =
     should_log_auto_max_tokens_clamp
+
+  let clamp_with_ceiling ~cascade_name ~source ~ceiling max_tokens =
+    match ceiling with
+    | Some c when c > 0 && max_tokens > c ->
+      Cascade_metrics.on_max_tokens_clamped ();
+      if should_log_auto_max_tokens_clamp
+           ~cascade_name ~source ~max_tokens ~ceiling:c
+      then
+        Log.warn ~ctx:"cascade"
+          "%s: resolved max_tokens=%d from %s exceeds output ceiling=%d; \
+           using ceiling; suppressing repeats for this tuple"
+          (Keeper_cascade_profile.runtime_name_to_string cascade_name)
+          max_tokens source c;
+      c
+    | _ -> max_tokens
 end

--- a/lib/cascade_inference.mli
+++ b/lib/cascade_inference.mli
@@ -41,12 +41,25 @@ val resolve_temperature :
 
 (** Resolve a max_tokens value with cascade config priority.
     Returns cascade config value if present, otherwise calls [fallback].
-    Fallback values are bounded to the resolved cascade's output ceiling when
-    one is available; cascade config values and explicit caller overrides are
-    validated outside this helper and are not silently reduced. *)
+    Both cascade config values and fallback values are bounded to the
+    resolved cascade's narrowest output ceiling when one is available;
+    silent reductions emit a deduplicated WARN per
+    (cascade, source, requested, ceiling) tuple. *)
 val resolve_max_tokens :
   cascade_name:Keeper_cascade_profile.runtime_name ->
   fallback:(unit -> int) ->
+  int
+
+(** Cap a max_tokens value to the resolved cascade's narrowest output ceiling.
+
+    Use this for internally supplied runtime overrides that bypass
+    {!resolve_max_tokens}. [source] is emitted in the deduplicated WARN and
+    metric context so operators can distinguish [cascade_config], [fallback],
+    and [caller_override] clamps. *)
+val cap_max_tokens_to_cascade_ceiling :
+  cascade_name:Keeper_cascade_profile.runtime_name ->
+  source:string ->
+  int ->
   int
 
 (** Validate max_tokens against the provider ceiling before dispatch.
@@ -56,7 +69,15 @@ val resolve_max_tokens :
     budget. Also rejects non-positive [max_tokens] and non-positive
     provider ceilings.
 
-    @since DD-020 *)
+    Cascade-config, fallback, and keeper runtime override values are clamped
+    upstream by {!resolve_max_tokens} or
+    {!cap_max_tokens_to_cascade_ceiling}, so a violation here indicates
+    either a non-positive budget, an invalid provider ceiling, or a cascade
+    reload between resolve and validate.
+
+    @since DD-020 (semantics revised 2026-05-17: cascade-config and fallback
+    values are silently clamped upstream; internal keeper overrides should
+    use the same clamp helper before dispatch.) *)
 val validate_max_tokens_within_ceiling :
   cascade_name:Keeper_cascade_profile.runtime_name ->
   provider_ceiling:int option ->
@@ -72,4 +93,15 @@ module For_testing : sig
     max_tokens:int ->
     ceiling:int ->
     bool
+
+  (** Pure clamp helper with an explicit ceiling — bypasses
+      [Cascade_runtime.max_output_tokens_ceiling_of_cascade_name] so unit
+      tests do not need a live cascade.toml on disk. Same arithmetic and
+      same WARN dedup behavior as [resolve_max_tokens]'s internal clamp. *)
+  val clamp_with_ceiling :
+    cascade_name:Keeper_cascade_profile.runtime_name ->
+    source:string ->
+    ceiling:int option ->
+    int ->
+    int
 end

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -54,7 +54,11 @@ let prepare_run_context
   in
   let max_tokens =
     match max_tokens with
-    | Some t -> t
+    | Some t ->
+      Cascade_inference.cap_max_tokens_to_cascade_ceiling
+        ~cascade_name
+        ~source:"caller_override"
+        t
     | None ->
       Cascade_inference.resolve_max_tokens
         ~cascade_name

--- a/test/dune
+++ b/test/dune
@@ -1191,6 +1191,7 @@
 (include stanzas/test_cascade_catalog_runtime_yojson.inc)
 (include stanzas/test_oas_worker_named_liveness_integration.inc)
 (include stanzas/test_cascade_capability_gate.inc)
+(include stanzas/test_cascade_inference_clamp.inc)
 (include stanzas/test_cascade_fsm.inc)
 (include stanzas/test_cascade_health_tracker.inc)
 (include stanzas/test_cascade_per_candidate_telemetry.inc)

--- a/test/stanzas/test_cascade_inference_clamp.inc
+++ b/test/stanzas/test_cascade_inference_clamp.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_cascade_inference_clamp)
+ (modules test_cascade_inference_clamp)
+ (libraries masc_test_deps))

--- a/test/test_cascade_capability_gate.ml
+++ b/test/test_cascade_capability_gate.ml
@@ -136,6 +136,44 @@ target = "tier.primary"
         ~provider_ceiling:ceiling 65536
       |> check_violation "requested_exceeds_provider_ceiling" 65536 8192)
 
+let test_public_cap_helper_clamps_caller_override_to_cascade_ceiling () =
+  with_temp_cascade_toml
+    {|
+[providers.remote]
+protocol = "openai-http"
+endpoint = "https://example.test/v1"
+
+[models.narrow]
+api-name = "remote-narrow"
+max-context = 200000
+tools-support = true
+
+[models.narrow.capabilities]
+max-output-tokens = 8192
+
+[remote.narrow]
+max-concurrent = 1
+
+[tier.primary]
+members = ["remote.narrow"]
+
+[routes.keeper_unified]
+target = "tier.primary"
+|}
+    (fun () ->
+      let ceiling = CR.max_output_tokens_ceiling_of_cascade_name cascade_name in
+      check (option int) "output ceiling" (Some 8192) ceiling;
+      let capped =
+        CI.cap_max_tokens_to_cascade_ceiling
+          ~cascade_name
+          ~source:"caller_override"
+          16384
+      in
+      check int "caller override capped to ceiling" 8192 capped;
+      CI.validate_max_tokens_within_ceiling ~cascade_name
+        ~provider_ceiling:ceiling capped
+      |> check_ok "capped caller override accepted" 8192)
+
 let test_resolve_max_tokens_caps_automatic_value_to_cascade_ceiling () =
   with_temp_cascade_toml
     {|
@@ -350,6 +388,10 @@ let () =
         "cascade output cap, not context window, gates max_tokens"
         `Quick
         test_cascade_output_cap_not_context_window;
+      test_case
+        "caller override clamp uses cascade output ceiling"
+        `Quick
+        test_public_cap_helper_clamps_caller_override_to_cascade_ceiling;
       test_case
         "automatic max_tokens respects mixed failover ceiling"
         `Quick

--- a/test/test_cascade_inference_clamp.ml
+++ b/test/test_cascade_inference_clamp.ml
@@ -1,0 +1,179 @@
+(** Unit tests for the cascade-config / fallback max_tokens clamp introduced
+    on 2026-05-17 to fix fleet-wide [pre_dispatch_max_tokens_ceiling_violation]
+    after the multilane cascade rollout (see PR body for incident timeline).
+
+    Tests target [Cascade_inference.For_testing.clamp_with_ceiling] so they
+    do not need a live cascade.toml on disk; the production helper
+    [resolve_max_tokens] composes the same clamp with the catalog-driven
+    ceiling lookup. *)
+
+open Masc_mcp
+
+let cascade name =
+  Masc_mcp.Keeper_cascade_profile.runtime_name_of_string name
+
+let reset () =
+  Cascade_inference.For_testing.reset_auto_max_tokens_clamp_warnings ()
+
+let test_no_ceiling_passes_through () =
+  reset ();
+  let out =
+    Cascade_inference.For_testing.clamp_with_ceiling
+      ~cascade_name:(cascade "tier-group.test_a")
+      ~source:"cascade_config"
+      ~ceiling:None
+      16384
+  in
+  Alcotest.(check int) "no ceiling -> requested returned unchanged" 16384 out
+
+let test_ceiling_above_request_passes_through () =
+  reset ();
+  let out =
+    Cascade_inference.For_testing.clamp_with_ceiling
+      ~cascade_name:(cascade "tier-group.test_b")
+      ~source:"cascade_config"
+      ~ceiling:(Some 32000)
+      16384
+  in
+  Alcotest.(check int) "request below ceiling -> unchanged" 16384 out
+
+let test_ceiling_at_request_passes_through () =
+  reset ();
+  let out =
+    Cascade_inference.For_testing.clamp_with_ceiling
+      ~cascade_name:(cascade "tier-group.test_c")
+      ~source:"cascade_config"
+      ~ceiling:(Some 16384)
+      16384
+  in
+  Alcotest.(check int) "request == ceiling -> unchanged" 16384 out
+
+let test_ceiling_below_request_clamps () =
+  reset ();
+  let out =
+    Cascade_inference.For_testing.clamp_with_ceiling
+      ~cascade_name:(cascade "tier-group.glm-coding-with-spark")
+      ~source:"cascade_config"
+      ~ceiling:(Some 8192)
+      16384
+  in
+  Alcotest.(check int)
+    "cascade_config 16384 vs ceiling 8192 -> clamped to ceiling"
+    8192 out
+
+let test_fallback_source_clamps () =
+  reset ();
+  let out =
+    Cascade_inference.For_testing.clamp_with_ceiling
+      ~cascade_name:(cascade "tier-group.test_d")
+      ~source:"fallback"
+      ~ceiling:(Some 8192)
+      16384
+  in
+  Alcotest.(check int) "fallback source also clamped" 8192 out
+
+let test_caller_override_source_clamps () =
+  reset ();
+  let out =
+    Cascade_inference.For_testing.clamp_with_ceiling
+      ~cascade_name:(cascade "tier-group.test_override")
+      ~source:"caller_override"
+      ~ceiling:(Some 8192)
+      16384
+  in
+  Alcotest.(check int) "caller override source also clamped" 8192 out
+
+let test_zero_ceiling_treated_as_no_ceiling () =
+  reset ();
+  let out =
+    Cascade_inference.For_testing.clamp_with_ceiling
+      ~cascade_name:(cascade "tier-group.test_e")
+      ~source:"cascade_config"
+      ~ceiling:(Some 0)
+      16384
+  in
+  Alcotest.(check int) "ceiling=0 treated as no ceiling, no clamp" 16384 out
+
+let test_negative_ceiling_treated_as_no_ceiling () =
+  reset ();
+  let out =
+    Cascade_inference.For_testing.clamp_with_ceiling
+      ~cascade_name:(cascade "tier-group.test_f")
+      ~source:"cascade_config"
+      ~ceiling:(Some (-1))
+      16384
+  in
+  Alcotest.(check int) "negative ceiling -> no clamp" 16384 out
+
+let test_warn_dedup_per_tuple () =
+  reset ();
+  let name = cascade "tier-group.test_g" in
+  let first =
+    Cascade_inference.For_testing.should_log_auto_max_tokens_clamp
+      ~cascade_name:name ~source:"cascade_config" ~max_tokens:16384 ~ceiling:8192
+  in
+  let second =
+    Cascade_inference.For_testing.should_log_auto_max_tokens_clamp
+      ~cascade_name:name ~source:"cascade_config" ~max_tokens:16384 ~ceiling:8192
+  in
+  Alcotest.(check bool) "first occurrence logs" true first;
+  Alcotest.(check bool) "duplicate suppressed" false second
+
+let test_warn_emits_distinct_source () =
+  reset ();
+  let name = cascade "tier-group.test_h" in
+  let cfg =
+    Cascade_inference.For_testing.should_log_auto_max_tokens_clamp
+      ~cascade_name:name ~source:"cascade_config" ~max_tokens:16384 ~ceiling:8192
+  in
+  let fb =
+    Cascade_inference.For_testing.should_log_auto_max_tokens_clamp
+      ~cascade_name:name ~source:"fallback" ~max_tokens:16384 ~ceiling:8192
+  in
+  Alcotest.(check bool) "cascade_config source logs" true cfg;
+  Alcotest.(check bool) "fallback source separately logs" true fb
+
+let test_warn_emits_distinct_caller_override_source () =
+  reset ();
+  let name = cascade "tier-group.test_i" in
+  let cfg =
+    Cascade_inference.For_testing.should_log_auto_max_tokens_clamp
+      ~cascade_name:name ~source:"cascade_config" ~max_tokens:16384 ~ceiling:8192
+  in
+  let override =
+    Cascade_inference.For_testing.should_log_auto_max_tokens_clamp
+      ~cascade_name:name ~source:"caller_override" ~max_tokens:16384
+      ~ceiling:8192
+  in
+  Alcotest.(check bool) "cascade_config source logs" true cfg;
+  Alcotest.(check bool) "caller_override source separately logs" true override
+
+let () =
+  Alcotest.run
+    "cascade_inference clamp"
+    [ ( "clamp"
+      , [ Alcotest.test_case "no ceiling -> passthrough" `Quick
+            test_no_ceiling_passes_through
+        ; Alcotest.test_case "ceiling above -> passthrough" `Quick
+            test_ceiling_above_request_passes_through
+        ; Alcotest.test_case "ceiling == request -> passthrough" `Quick
+            test_ceiling_at_request_passes_through
+        ; Alcotest.test_case "ceiling below -> clamp" `Quick
+            test_ceiling_below_request_clamps
+        ; Alcotest.test_case "fallback source clamp" `Quick
+            test_fallback_source_clamps
+        ; Alcotest.test_case "caller override source clamp" `Quick
+            test_caller_override_source_clamps
+        ; Alcotest.test_case "ceiling=0 -> no clamp" `Quick
+            test_zero_ceiling_treated_as_no_ceiling
+        ; Alcotest.test_case "negative ceiling -> no clamp" `Quick
+            test_negative_ceiling_treated_as_no_ceiling
+        ] )
+    ; ( "warn-dedup"
+      , [ Alcotest.test_case "per-tuple dedup" `Quick test_warn_dedup_per_tuple
+        ; Alcotest.test_case "distinct source emits separately" `Quick
+            test_warn_emits_distinct_source
+        ; Alcotest.test_case "caller override source emits separately" `Quick
+            test_warn_emits_distinct_caller_override_source
+        ] )
+    ]


### PR DESCRIPTION
## Summary
- clamp cascade-config and fallback max_tokens to the resolved cascade output ceiling before dispatch
- apply the same clamp to internal keeper caller overrides that bypass resolve_max_tokens
- keep max_tokens_ceiling_violation validation as the final guard for invalid budgets, bad ceilings, or stale cascade reloads
- add regression coverage for the 16384 requested / 8192 provider ceiling case and WARN de-dup source labels

## Validation
- opam exec -- ocamlformat --check lib/cascade_inference.ml lib/cascade_inference.mli lib/keeper/keeper_run_context.ml lib/cascade/cascade_metrics.ml lib/cascade/cascade_metrics.mli test/test_cascade_capability_gate.ml test/test_cascade_inference_clamp.ml
- git diff --check
- attempted scripts/dune-local.sh build test/test_cascade_capability_gate.exe test/test_cascade_inference_clamp.exe, but local Dune lock was held by other active worktree builds; relying on PR CI for focused Dune execution