### PR TITLE
feat(dashboard-briefing): Prometheus counter for last_event.source (#15777 follow-up)

### DIFF
--- a/lib/dashboard/dashboard_mission_briefing.ml
+++ b/lib/dashboard/dashboard_mission_briefing.ml
@@ -155,6 +155,36 @@ let compute_briefing_json ~actor_name ~config ~sw ~clock ~proc_mgr () =
       | _ -> []
     in
     let compact_sessions = take 3 (List.map Briefing_compactors.compact_session_json sessions) in
+    (* PR #15777 (V14) follow-up: emit Prometheus counter for the typed
+       [last_event.source] marker produced by [Briefing_compactors]. The
+       compactor lives in a dep-clean leaf sublib, so this wrapper-side
+       observer is where the Prometheus signal travels at the boundary.
+       The 2 SSOT labels come from
+       [Briefing_session_last_event_source.to_label]; the 3 defensive
+       labels guard against future regressions in the leaf module. *)
+    let classify_session_source raw =
+      match raw with
+      | "recent_event_latest" | "fabricated_no_recent_events" -> raw
+      | _ -> "unknown"
+    in
+    let observe_session_last_event_source session_json =
+      let source =
+        match session_json with
+        | `Assoc kv -> (
+            match List.assoc_opt "last_event" kv with
+            | Some (`Assoc le) -> (
+                match List.assoc_opt "source" le with
+                | Some (`String s) -> classify_session_source s
+                | _ -> "missing")
+            | _ -> "no_last_event")
+        | _ -> "not_assoc"
+      in
+      Prometheus.inc_counter
+        Keeper_metrics.metric_briefing_session_last_event_source
+        ~labels:[ ("source", source) ]
+        ()
+    in
+    List.iter observe_session_last_event_source compact_sessions;
     let compact_keepers = take 3 (List.map Briefing_compactors.compact_keeper_json keepers) in
     let agents_json = Coord.get_agents_raw config |> List.map Briefing_compactors.compact_agent_json in
     let compact_agents = take 5 agents_json in

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -789,6 +789,14 @@ let metric_keeper_lifecycle_callback_failures =
   "masc_keeper_lifecycle_callback_failures_total"
 ;;
 
+(* Counter for the [last_event.source] provenance marker emitted by
+   [Briefing_compactors.compact_session_json] (PR #15777, V14 follow-up).
+   Wrapper-side observer at [dashboard_mission_briefing] keeps the
+   [briefing_compactors] leaf sublib Prometheus-free. *)
+let metric_briefing_session_last_event_source =
+  "masc_briefing_session_last_event_source_total"
+;;
+
 let metric_keeper_event_bus_drain = "masc_keeper_event_bus_drain_total"
 
 let metric_keeper_supervisor_cleanup_failures =

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -512,6 +512,19 @@ val metric_keeper_turn_fsm_transitions : string
 val metric_keeper_turn_phase_duration : string
 val metric_keeper_lifecycle_transitions : string
 val metric_keeper_lifecycle_callback_failures : string
+
+val metric_briefing_session_last_event_source : string
+(** Counter for the [last_event.source] provenance marker emitted by
+    [Briefing_compactors.compact_session_json] (PR #15777, V14).
+    Label [source] uses a closed 5-value vocabulary:
+    - [recent_event_latest], [fabricated_no_recent_events]
+      (SSOT labels from {!Briefing_session_last_event_source.to_label})
+    - [missing], [no_last_event], [not_assoc]
+      (defensive guards against future regressions in the leaf module)
+    Emitted once per session per briefing at the
+    [dashboard_mission_briefing] wrapper. Cardinality bound:
+    [take 3] sessions per briefing × small briefing rate. *)
+
 val metric_keeper_event_bus_drain : string
 val metric_keeper_supervisor_cleanup_failures : string
 val metric_keeper_slot_force_released : string


### PR DESCRIPTION
## Summary

Wrapper-side Prometheus counter for the typed `last_event.source` provenance marker introduced in **PR #15777 (V14)**. The structural fix (closed 2-variant sum `Briefing_session_last_event_source` and `last_event.source` field emit) landed in #15777; the wrapper-side observability signal was explicitly deferred there because `lib/briefing_compactors/` is a dep-clean leaf sub-library kept Prometheus-free (precedent: iter 6/7).

This PR completes the iter-17 leaf-pending follow-up by adding the counter at the dashboard wrapper boundary — `lib/dashboard/dashboard_mission_briefing.ml` after the `compact_sessions` binding.

## Leaf-purity rationale (why the emit is wrapper-side)

`lib/briefing_compactors/` deliberately does not depend on `Prometheus` or `Keeper_metrics`. Adding the inc_counter inside `Briefing_compactors.compact_session_json` would pull those dependencies into the leaf sublib and break the deps-clean precedent set by earlier iterations.

Instead, the counter is emitted at the dashboard wrapper:
1. `Briefing_compactors.compact_session_json` produces a `Yojson.Safe.t` carrying the `last_event.source` SSOT label.
2. The wrapper (`dashboard_mission_briefing.ml:157`) holds the resulting `compact_sessions` list and already has access to `Prometheus` + `Keeper_metrics`.
3. `List.iter observe_session_last_event_source compact_sessions` inspects each session and emits one counter per session.

Signal travels at the boundary; leaf stays dependency-clean.

## Closed 5-value source label vocab + defensive-guard justification

```ocaml
let classify_session_source raw =
  match raw with
  | "recent_event_latest" | "fabricated_no_recent_events" -> raw
  | _ -> "unknown"
in
```

Plus 3 outer-match defensive branches for shape regressions: `"missing"`, `"no_last_event"`, `"not_assoc"`.

| Label | Origin | Notes |
|---|---|---|
| `recent_event_latest` | SSOT — `Briefing_session_last_event_source.to_label Recent_event_latest` | Expected (recent_events non-empty path) |
| `fabricated_no_recent_events` | SSOT — `Briefing_session_last_event_source.to_label Fabricated_no_recent_events` | Expected (recent_events empty path) |
| `unknown` | Defensive fallback in classifier | If leaf ever adds a 3rd variant without label update |
| `missing` | Outer defensive — `last_event.source` field absent | Guards against leaf dropping source field |
| `no_last_event` | Outer defensive — `last_event` field absent | Guards against leaf dropping last_event entirely |
| `not_assoc` | Outer defensive — session JSON is not an Assoc | Guards against shape regression in leaf |

Not a parsing classifier or open string-set — every branch is explicit and enumerated. The vocab is closed at 5 values plus the `unknown` fallback (6 total terminal labels).

## Cardinality bound argument

`compact_sessions = take 3 (...)` enforces ≤ 3 sessions per briefing. Briefing rate is bounded by `cache_ttl_sec` and request load. Per-emit label set has 6 possible values (5 enumerated + `unknown`). Cardinality risk is negligible.

## Anti-pattern self-check (7/7)

| # | Check | Verdict |
|---|---|---|
| 1 | telemetry-as-fix only? | **YES** — counter-only follow-up to iter-17 #15777 structural fix. Justified: structural fix already landed; this is the wrapper-side Prometheus signal that #15777 explicitly deferred per leaf-sublib purity (iter 6/7 precedent). |
| 2 | string classifier? | **YES (closed 5-value match).** Justified: 2 labels are SSOT-defined by `Briefing_session_last_event_source.to_label` (closed sum), 3 are defensive shape guards. Each branch explicit; not parsing free-text. |
| 3 | N-of-M? | NO — single emit site per session, single call site (`List.iter` over `compact_sessions`). |
| 4 | catch-all `_ ->`? | Present in defensive branches but maps to *closed terminal labels* (`"missing"`, `"no_last_event"`, `"not_assoc"`, `"unknown"`), not silent drops. |
| 5 | cap/cooldown/dedup/repair? | NO. |
| 6 | test backdoor? | NO. |
| 7 | repeat typo / off-by-one in N sites? | NO. |

## Files

- `lib/keeper/keeper_metrics.{ml,mli}` — registers `metric_briefing_session_last_event_source = "masc_briefing_session_last_event_source_total"` with explanatory doc comment (consistent with iter-17 doc pointing to keeper_metrics).
- `lib/dashboard/dashboard_mission_briefing.ml` — adds `classify_session_source` + `observe_session_last_event_source` + `List.iter` after `compact_sessions` binding (lines 158–187 of the new file).
- `lib/briefing_compactors/` — **untouched** (leaf purity preserved).

## Build

- `dune build --root . lib/dashboard` — clean.
- `dune build --root . @check` — clean.

## Cross-reference

- **PR #15777** (V14, iter 17): typed `last_event.source` marker + closed 2-variant `Briefing_session_last_event_source` SSOT.
- This PR closes the explicitly-deferred Prometheus observability item from #15777.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
