### PR TITLE
feat(sse-event): RFC-0004 PR-1 typed SSE event lib + AgentStarted byte-equal

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -86,9 +86,11 @@
   (bisect_ppx (and :with-test (>= 2.8)))
   (mtime (>= 2.0))
   (uuidm (>= 0.9))
-  ; RFC-0004 Phase A0.1 PoC (sse_event_poc sublib).  atdgen runs at
-  ; build-time (codegen for sse_event.atd → sse_event_{t,j}.{ml,mli});
-  ; atdgen-runtime is linked into the generated _j module.
+  ; RFC-0004 Phase A0.1 typed SSE event library (lib/sse_event/).
+  ; atdgen runs at build-time (codegen for sse_event.atd →
+  ; sse_event_{t,j}.{ml,mli}); atdgen-runtime is linked into the
+  ; generated _j module.  Promoted from sse_event_poc :with-test
+  ; gating once the typed lib became production-required (PR-1).
   (atdgen (and :build (>= 4.2.0)))
   (atdgen-runtime (>= 4.2.0))
   ; [neo4j_bolt_eio] removed: no caller in lib/ bin/ test/ since

--- a/lib/sse_event/dune
+++ b/lib/sse_event/dune
@@ -1,0 +1,20 @@
+(include_subdirs no)
+
+; RFC-0004 Phase A0.1 PR-1 — typed SSE event library.
+; Production lib (no (optional)).  Bridges atd-generated payload
+; types and the manual envelope wrap.  Callers will replace
+; cascade_event_bridge.native_event_to_json arms with these
+; constructors in PR-2 (agent_started/completed/failed migration).
+(library
+ (name sse_event)
+ (libraries yojson atdgen-runtime))
+
+(rule
+ (targets sse_event_t.ml sse_event_t.mli)
+ (deps sse_event.atd)
+ (action (run atdgen -t %{deps})))
+
+(rule
+ (targets sse_event_j.ml sse_event_j.mli)
+ (deps sse_event.atd)
+ (action (run atdgen -j -j-std %{deps})))

--- a/lib/sse_event/sse_event.atd
+++ b/lib/sse_event/sse_event.atd
@@ -1,0 +1,17 @@
+(* RFC-0004 Phase A0.1 PR-1 — typed SSE event payload schemas.
+
+   Scope: agent_started payload only.  Subsequent PRs extend with
+   agent_completed, agent_failed, tool_*, turn_*, handoff_*,
+   context_*, content_replacement_*, slot_scheduler_observed.
+
+   Envelope (type, event_type, ts_unix, correlation_id, run_id,
+   agent_name, task_id, turn, tool_name, payload) is wrapped by
+   [Sse_event.wrap_envelope] in [sse_event.ml] — keeping the
+   nullable-with-empty-string-coerced-to-null semantics of
+   [lib/cascade/cascade_event_bridge.json_string_opt] outside the
+   atd schema (atd's default nullable cannot express it). *)
+
+type agent_started_payload = {
+  agent_name: string;
+  task_id: string;
+}

--- a/lib/sse_event/sse_event.ml
+++ b/lib/sse_event/sse_event.ml
@@ -1,0 +1,89 @@
+(* RFC-0004 Phase A0.1 PR-1 — typed SSE event wrapper.
+
+   Bridges atd-generated payload types (see [Sse_event_t],
+   [Sse_event_j]) and the manual envelope wrap that replicates
+   [lib/cascade/cascade_event_bridge.wrap_event] (lines 507-531) +
+   [json_string_opt] (lines 25-27) semantics.
+
+   The envelope is intentionally hand-rolled in OCaml rather than
+   declared in atd because [json_string_opt] coerces [Some ""] to
+   [`Null] — atd's default nullable maps [Some ""] to [""]. A custom
+   atd JSON adapter could close the gap; PR-1 keeps the envelope
+   manual to ship the first event with zero adapter risk. *)
+
+(** Envelope metadata fields common to every SSE event.
+
+    Field semantics match [cascade_event_bridge.wrap_event]: optional
+    string fields use [json_string_opt] (empty string → null), and
+    [turn] uses plain [option fold] (None → null). *)
+type envelope_meta =
+  { event_type : string
+  ; ts_unix : float
+  ; correlation_id : string
+  ; run_id : string
+  ; agent_name : string option
+  ; task_id : string option
+  ; turn : int option
+  ; tool_name : string option
+  }
+
+(** Replicates [cascade_event_bridge.json_string_opt]:
+
+    - [Some "non-empty"] → [`String value]
+    - [Some "" \| Some "<whitespace>"] → [`Null]
+    - [None] → [`Null] *)
+let json_string_opt = function
+  | Some value when String.trim value <> "" -> `String value
+  | _ -> `Null
+;;
+
+(** Wrap a typed payload with the standard envelope.  Returns the
+    same field shape and order as [wrap_event] so its output is
+    byte-identical when serialized via [Yojson.Safe.to_string]. *)
+let wrap_envelope (meta : envelope_meta) (payload : Yojson.Safe.t) : Yojson.Safe.t =
+  `Assoc
+    [ "type", `String ("oas:" ^ meta.event_type)
+    ; "event_type", `String meta.event_type
+    ; "ts_unix", `Float meta.ts_unix
+    ; "correlation_id", `String meta.correlation_id
+    ; "run_id", `String meta.run_id
+    ; "agent_name", json_string_opt meta.agent_name
+    ; "task_id", json_string_opt meta.task_id
+    ; ( "turn"
+      , Option.fold ~none:`Null ~some:(fun value -> `Int value) meta.turn )
+    ; "tool_name", json_string_opt meta.tool_name
+    ; "payload", payload
+    ]
+;;
+
+(** Emit a full [agent_started] envelope as JSON.
+
+    [agent_name] and [task_id] in the envelope are populated from the
+    same values as the payload — this matches the
+    [cascade_event_bridge] AgentStarted arm at lines 556-560 which
+    passes [~agent_name ~task_id] to [wrap_event] alongside the
+    payload [`Assoc]. *)
+let agent_started
+      ~(ts_unix : float)
+      ~(correlation_id : string)
+      ~(run_id : string)
+      ~(agent_name : string)
+      ~(task_id : string)
+  : Yojson.Safe.t
+  =
+  let payload_json =
+    let p : Sse_event_t.agent_started_payload = { agent_name; task_id } in
+    Yojson.Safe.from_string (Sse_event_j.string_of_agent_started_payload p)
+  in
+  wrap_envelope
+    { event_type = "agent_started"
+    ; ts_unix
+    ; correlation_id
+    ; run_id
+    ; agent_name = Some agent_name
+    ; task_id = Some task_id
+    ; turn = None
+    ; tool_name = None
+    }
+    payload_json
+;;

--- a/lib/sse_event/sse_event.mli
+++ b/lib/sse_event/sse_event.mli
@@ -1,0 +1,23 @@
+(** RFC-0004 Phase A0.1 PR-1 — typed SSE event wrapper public interface. *)
+
+type envelope_meta =
+  { event_type : string
+  ; ts_unix : float
+  ; correlation_id : string
+  ; run_id : string
+  ; agent_name : string option
+  ; task_id : string option
+  ; turn : int option
+  ; tool_name : string option
+  }
+
+val json_string_opt : string option -> Yojson.Safe.t
+val wrap_envelope : envelope_meta -> Yojson.Safe.t -> Yojson.Safe.t
+
+val agent_started
+  :  ts_unix:float
+  -> correlation_id:string
+  -> run_id:string
+  -> agent_name:string
+  -> task_id:string
+  -> Yojson.Safe.t

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -60,8 +60,8 @@ depends: [
   "bisect_ppx" {with-test & >= "2.8"}
   "mtime" {>= "2.0"}
   "uuidm" {>= "0.9"}
-  "atdgen" {build & with-test & >= "4.2.0"}
-  "atdgen-runtime" {with-test & >= "4.2.0"}
+  "atdgen" {build & >= "4.2.0"}
+  "atdgen-runtime" {>= "4.2.0"}
   "opentelemetry" {>= "0.13"}
   "ambient-context-eio" {>= "0.2"}
   "crunch" {build & >= "4.0"}

--- a/test/sse_event/dune
+++ b/test/sse_event/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_sse_event)
+ (libraries sse_event alcotest yojson fmt))

--- a/test/sse_event/test_sse_event.ml
+++ b/test/sse_event/test_sse_event.ml
@@ -1,0 +1,126 @@
+(* RFC-0004 Phase A0.1 PR-1 — byte-equal envelope test.
+
+   Verifies that [Sse_event.agent_started] emits a JSON string that
+   is byte-identical to the [cascade_event_bridge.wrap_event] output
+   for the AgentStarted arm (lib/cascade/cascade_event_bridge.ml:
+   556-560 + wrap_event:507-531 + json_string_opt:25-27).
+
+   The baseline is hand-replicated below using the same algorithm as
+   wrap_event/json_string_opt — this avoids linking the heavy
+   cascade dependency chain (Agent_sdk, Eio, etc.) into the test
+   binary.  In PR-2 (cascade migration) we replace the cascade arm
+   itself, at which point the wrap_event replica below is removed
+   and the test pins against the cascade output directly. *)
+
+(* === Baseline replica: cascade_event_bridge.wrap_event + json_string_opt === *)
+
+let baseline_json_string_opt = function
+  | Some value when String.trim value <> "" -> `String value
+  | _ -> `Null
+;;
+
+let baseline_wrap_event
+      ~ts
+      ~correlation_id
+      ~run_id
+      ~event_type
+      ~payload
+      ?agent_name
+      ?task_id
+      ?turn
+      ?tool_name
+      ()
+  =
+  `Assoc
+    [ "type", `String ("oas:" ^ event_type)
+    ; "event_type", `String event_type
+    ; "ts_unix", `Float ts
+    ; "correlation_id", `String correlation_id
+    ; "run_id", `String run_id
+    ; "agent_name", baseline_json_string_opt agent_name
+    ; "task_id", baseline_json_string_opt task_id
+    ; ( "turn"
+      , Option.fold ~none:`Null ~some:(fun value -> `Int value) turn )
+    ; "tool_name", baseline_json_string_opt tool_name
+    ; "payload", payload
+    ]
+;;
+
+let baseline_agent_started ~ts ~correlation_id ~run_id ~agent_name ~task_id =
+  let payload =
+    `Assoc
+      [ "agent_name", `String agent_name; "task_id", `String task_id ]
+  in
+  baseline_wrap_event
+    ~ts
+    ~correlation_id
+    ~run_id
+    ~event_type:"agent_started"
+    ~payload
+    ~agent_name
+    ~task_id
+    ()
+;;
+
+(* === Tests === *)
+
+let test_agent_started_byte_equal () =
+  let ts = 1747460000.5 in
+  let correlation_id = "corr-001" in
+  let run_id = "run-001" in
+  let agent_name = "test_agent" in
+  let task_id = "task_42" in
+  let baseline =
+    Yojson.Safe.to_string
+      (baseline_agent_started ~ts ~correlation_id ~run_id ~agent_name ~task_id)
+  in
+  let typed =
+    Yojson.Safe.to_string
+      (Sse_event.agent_started
+         ~ts_unix:ts
+         ~correlation_id
+         ~run_id
+         ~agent_name
+         ~task_id)
+  in
+  Printf.printf "\n=== A0.1 PR-1 AgentStarted byte-equal ===\n";
+  Printf.printf "  baseline: %s\n" baseline;
+  Printf.printf "  typed:    %s\n" typed;
+  Printf.printf "  equal: %b\n" (String.equal baseline typed);
+  Alcotest.(check string) "agent_started typed == cascade baseline" baseline typed
+;;
+
+let test_json_string_opt_empty_to_null () =
+  (* Regression guard for the empty-string-coerced-to-null semantics
+     that atd's default nullable does NOT express. *)
+  Alcotest.(check (testable (Fmt.of_to_string Yojson.Safe.to_string) ( = )))
+    "Some \"\" → `Null"
+    `Null
+    (Sse_event.json_string_opt (Some ""));
+  Alcotest.(check (testable (Fmt.of_to_string Yojson.Safe.to_string) ( = )))
+    "Some \"  \" → `Null"
+    `Null
+    (Sse_event.json_string_opt (Some "  "));
+  Alcotest.(check (testable (Fmt.of_to_string Yojson.Safe.to_string) ( = )))
+    "Some \"text\" → `String"
+    (`String "text")
+    (Sse_event.json_string_opt (Some "text"));
+  Alcotest.(check (testable (Fmt.of_to_string Yojson.Safe.to_string) ( = )))
+    "None → `Null"
+    `Null
+    (Sse_event.json_string_opt None)
+;;
+
+let () =
+  Alcotest.run
+    "sse_event"
+    [ ( "byte_equal"
+      , [ Alcotest.test_case "agent_started full envelope" `Quick
+            test_agent_started_byte_equal
+        ] )
+    ; ( "json_string_opt"
+      , [ Alcotest.test_case "Some empty → null" `Quick
+            test_json_string_opt_empty_to_null
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

RFC-0004 Phase A0.1 **PR-1**. Implementation of #15778 plan §4 PR-1 row.

신규 `lib/sse_event/` typed SSE event library 도입 + 첫 event 인 AgentStarted 의 full envelope 가 기존 `cascade_event_bridge.wrap_event` 출력과 **byte-identical** 임을 입증.

## 변경 surface

| 파일 | LOC | 역할 |
|---|---|---|
| `lib/sse_event/sse_event.atd` | 18 | `agent_started_payload` atd record |
| `lib/sse_event/sse_event.ml` | 80 | `envelope_meta` + `wrap_envelope` + `agent_started` constructor |
| `lib/sse_event/sse_event.mli` | 22 | 공개 surface |
| `lib/sse_event/dune` | 17 | atdgen rule + production lib (no `(optional)`) |
| `test/sse_event/test_sse_event.ml` | 100 | byte-equal vs inline `wrap_event` 복제본 + `json_string_opt` regression guard |
| `test/sse_event/dune` | 3 | test wiring |
| `dune-project`, `masc_mcp.opam` | +3/-2 | atdgen / atdgen-runtime 주석 갱신 (이미 main depends) |

## Design 결정

### Envelope 가 atd 가 아닌 OCaml hand-rolled 인 이유

`cascade_event_bridge.json_string_opt` 의 동작:
```ocaml
Some "non-empty" → `String value
Some ""          → `Null      (* atd 의 default nullable 과 다름 *)
None             → `Null
```

atd `nullable` 은 `Some "" → ""` 으로 emit. byte-equal 충돌. 차후 PR 에서 `<json adapter.ocaml="...">` 으로 atd 화 가능하나 PR-1 은 zero-adapter risk path 우선.

대신 atd 는 *payload* (event-specific record) 에 한정. `agent_started_payload` = `{agent_name; task_id}` 같은 단순 record 는 byte-equal 통과 (PR-0 PoC #15778 입증).

## Test 결과 (로컬, dune --root .)

```
$ dune build lib/sse_event/ test/sse_event/
warning: option "-j-std" is deprecated.

$ _build/default/test/sse_event/test_sse_event.exe
Testing `sse_event'.
  [OK]  byte_equal       0   agent_started full envelope.
  [OK]  json_string_opt  0   Some empty → null.
Test Successful in 0.000s. 2 tests run.
```

byte-equal 결과:
```
baseline: {"type":"oas:agent_started","event_type":"agent_started",
           "ts_unix":1747460000.5,"correlation_id":"corr-001",
           "run_id":"run-001","agent_name":"test_agent",
           "task_id":"task_42","turn":null,"tool_name":null,
           "payload":{"agent_name":"test_agent","task_id":"task_42"}}
typed:    (byte-identical)
```

## 비범위 (Wave 1 후속 PR)

| PR | 작업 |
|---|---|
| **PR-2** | `cascade_event_bridge.native_event_to_json` AgentStarted arm migrate (`wrap_event` + inline `` `Assoc `` → `Sse_event.agent_started` 호출). 본 PR 의 inline baseline replica 제거 후 cascade 직접 baseline pin. |
| **PR-3** | agent_completed, agent_failed, tool_called/completed, turn_started/completed/ready (5 event) |
| **PR-4** | handoff_*, context_*, content_replacement_*, slot_scheduler_observed (8 event) |

각 PR 의 완료 기준: byte-equal golden test PASS + dune build PASS.

## Cross-ref

- #15745 — dashboard quick-win (MERGED, removal track = Phase A0.4)
- #15747 — RFC-0004 body resume (MERGED)
- #15778 — A0.1 implementation plan + PoC (MERGED, commit 9f11aacef3)
- jeong-sik/me#1125 — research synthesis (MERGED)
- #15804 — release bump 0.19.18 → 0.19.19 (Draft, separate)

## Test plan

- [ ] CI: `dune build @check`, `dune build @runtest`, lint, godfile size
- [ ] Self-review per Best Programmer (별도 commenter)
- [ ] PR-2 (cascade arm migrate) 진입 가능 상태

RFC-WAIVED: 이 PR 은 #15778 plan §4 PR-1 의 sequencing 충족.  새 RFC 불필요.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>