### PR TITLE
feat(compact-audit): drain batch_size burst visibility (V17)

### DIFF
--- a/lib/keeper/keeper_compact_audit.ml
+++ b/lib/keeper/keeper_compact_audit.ml
@@ -520,6 +520,23 @@ let spawn_subscriber
   Eio.Switch.on_release sw (fun () ->
     Agent_sdk_metrics_bridge.unsubscribe bus sub);
   Eio.Fiber.fork ~sw (fun () ->
+    (* V17 (INFO) burst visibility: drain runs every [drain_interval_s]
+       (default 0.25s) and emits a per-call counter + bucketed batch-size
+       counter so operators can see lag building during 9-keeper
+       compaction storms before JSONL writes fall behind. The streak ref
+       is scoped to this fiber closure (per-subscription isolation) so
+       different subscribers don't share spike-dedup state. *)
+    let over_threshold_streak = ref 0 in
+    let batch_size_bucket_label size =
+      (* Closed-vocabulary bucket vocabulary. Boundaries reflect the
+         normal-load (~5-10/batch) → burst (100+/batch) transition. *)
+      if size = 0 then "0"
+      else if size < 10 then "1_9"
+      else if size < 50 then "10_49"
+      else if size < 100 then "50_99"
+      else if size < 500 then "100_499"
+      else "500_plus"
+    in
     let rec loop () =
       let batch = Agent_sdk_metrics_bridge.drain sub in
       List.iter
@@ -538,6 +555,31 @@ let spawn_subscriber
                Log.Keeper.warn "keeper_compact_audit: handle_event failed: %s"
                  (Printexc.to_string exn))
         batch;
+      (* V17 visibility: emit batch-size signal AFTER List.iter so the
+         counter reflects events processed (not pending), giving the
+         operator a true lag indicator. *)
+      let batch_size = List.length batch in
+      Prometheus.inc_counter
+        Keeper_metrics.metric_keeper_compact_audit_drain_batches
+        ();
+      Prometheus.inc_counter
+        Keeper_metrics.metric_keeper_compact_audit_drain_batch_size_bucket
+        ~labels:[("bucket", batch_size_bucket_label batch_size)]
+        ();
+      (* Streak-deduped WARN: log-spam protection during sustained burst.
+         Counter still fires every batch — only the WARN line is deduped.
+         This is observability shaping, not symptom suppression: cap /
+         back-pressure decisions remain operator policy. *)
+      if batch_size >= 100 then begin
+        incr over_threshold_streak;
+        if !over_threshold_streak = 1 || !over_threshold_streak mod 10 = 0
+        then
+          Log.Keeper.warn
+            "keeper_compact_audit: drain batch_size=%d (streak=%d) — burst, \
+             check 9-keeper compaction or JSONL writer lag"
+            batch_size !over_threshold_streak
+      end
+      else over_threshold_streak := 0;
       Eio.Time.sleep clock drain_interval_s;
       loop ()
     in

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -73,6 +73,8 @@ type t =
   | ProfileLoadFailures
   | CompactAuditFailures
   | CompactAuditRetentionParse
+  | CompactAuditDrainBatches
+  | CompactAuditDrainBatchSizeBucket
   | FsFailures
   | CrashPersistenceFailures
   | GenerationLineageFailures
@@ -273,6 +275,9 @@ let to_string = function
   | ProfileLoadFailures -> "masc_keeper_profile_load_failures_total"
   | CompactAuditFailures -> "masc_keeper_compact_audit_failures_total"
   | CompactAuditRetentionParse -> "masc_keeper_compact_audit_retention_parse_total"
+  | CompactAuditDrainBatches -> "masc_keeper_compact_audit_drain_batches_total"
+  | CompactAuditDrainBatchSizeBucket ->
+    "masc_keeper_compact_audit_drain_batch_size_bucket_total"
   | FsFailures -> "masc_keeper_fs_failures_total"
   | CrashPersistenceFailures -> "masc_keeper_crash_persistence_failures_total"
   | GenerationLineageFailures -> "masc_keeper_generation_lineage_failures_total"
@@ -553,6 +558,18 @@ let metric_keeper_compact_audit_failures = "masc_keeper_compact_audit_failures_t
 
 let metric_keeper_compact_audit_retention_parse =
   "masc_keeper_compact_audit_retention_parse_total"
+;;
+
+(* V17 burst visibility: per-drain-call counter and bucketed batch-size
+   counter for [keeper_compact_audit] subscriber. Labels for bucket are
+   closed-vocab {"0"|"1_9"|"10_49"|"50_99"|"100_499"|"500_plus"} to
+   avoid cardinality explosion. *)
+let metric_keeper_compact_audit_drain_batches =
+  "masc_keeper_compact_audit_drain_batches_total"
+;;
+
+let metric_keeper_compact_audit_drain_batch_size_bucket =
+  "masc_keeper_compact_audit_drain_batch_size_bucket_total"
 ;;
 
 let metric_keeper_fs_failures = "masc_keeper_fs_failures_total"

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -65,6 +65,8 @@ type t =
   | ProfileLoadFailures
   | CompactAuditFailures
   | CompactAuditRetentionParse
+  | CompactAuditDrainBatches
+  | CompactAuditDrainBatchSizeBucket
   | FsFailures
   | CrashPersistenceFailures
   | GenerationLineageFailures
@@ -323,6 +325,21 @@ val metric_keeper_compact_audit_retention_parse : string
     one of [parsed_ok | unset_default | parse_error | out_of_range]
     (see {!Keeper_compact_audit_retention_outcome}). Surfaces operator
     misconfiguration of [MASC_COMPACTION_AUDIT_RETENTION_DAYS]. *)
+
+val metric_keeper_compact_audit_drain_batches : string
+(** V17 burst visibility: incremented once per drain-loop iteration of the
+    [keeper_compact_audit] subscriber fiber. Combined with
+    {!metric_keeper_compact_audit_drain_batch_size_bucket}, operators can
+    compute mean batch size and bucket distribution to detect
+    9-keeper compaction storms before JSONL writes fall behind. *)
+
+val metric_keeper_compact_audit_drain_batch_size_bucket : string
+(** V17 burst visibility: bucketed counter labelled [bucket] with a
+    closed vocabulary of [0 | 1_9 | 10_49 | 50_99 | 100_499 | 500_plus].
+    Each drain-loop iteration bumps exactly one bucket label so operators
+    can detect lag building via
+    [rate(masc_keeper_compact_audit_drain_batch_size_bucket_total{bucket="100_499"}[5m])].
+    Closed vocab avoids cardinality explosion. *)
 
 val metric_keeper_fs_failures : string
 val metric_keeper_crash_persistence_failures : string

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1623,6 +1623,18 @@ let init () =
     "Total keeper compact audit failures (persist/prune/handle), labeled by keeper and \
      site"
     Counter;
+  (* V17 burst visibility: drain-loop observability for keeper_compact_audit. *)
+  add
+    Keeper_metrics.metric_keeper_compact_audit_drain_batches
+    "Total keeper compact_audit drain-loop iterations (used with drain_batch_size_bucket \
+     for mean batch size and burst detection)"
+    Counter;
+  add
+    Keeper_metrics.metric_keeper_compact_audit_drain_batch_size_bucket
+    "Keeper compact_audit drain batch size distribution. Closed-vocab bucket label: \
+     0|1_9|10_49|50_99|100_499|500_plus. Burst >= 100/batch indicates 9-keeper \
+     compaction storm or JSONL writer lag."
+    Counter;
   add
     Keeper_metrics.metric_keeper_fs_failures
     "Total keeper filesystem operation failures (ensure_dir/save_atomic), labeled by \


### PR DESCRIPTION
## Summary

Closes **V17 (INFO)** from `.tmp/memory-compacting-analysis.html`.

The `keeper_compact_audit` subscriber drain loop (`lib/keeper/keeper_compact_audit.ml`, ~line 522-544) runs every `drain_interval_s` (default `0.25s`) but emits **no batch-size signal**. Normal load is ~5-10 events/batch; a 9-keeper compaction storm can push 100+/batch, but operators only notice once JSONL writes start lagging behind.

V17 explicitly asks: "drain 후 batch 크기 metric. 임계 초과 시 warn."

## Changes

1. **`metric_keeper_compact_audit_drain_batches_total`** (counter) — bumped once per drain-loop iteration. Used together with the bucket counter to compute mean batch size.
2. **`metric_keeper_compact_audit_drain_batch_size_bucket_total`** (bucketed counter) — labelled `bucket` with closed vocab:
   - `0 | 1_9 | 10_49 | 50_99 | 100_499 | 500_plus`
3. **WARN on `batch_size >= 100`** with **streak-deduped emission** — first hit, then every 10th batch in a sustained streak. Streak counter resets when batch drops below threshold.
4. Variants added to `Keeper_metrics.t` + backward-compat string constants in `.ml` and `.mli` (existing pattern).
5. Registered in `Prometheus.init` with help strings describing the bucket vocab and operator query.

### Bucket strategy

**Bucket-counter** over `observe_histogram`. Rationale:
- Existing precedent: `metric_keeper_turn_latency_bucket_total`, `metric_keeper_semaphore_wait_seconds_bucket` use the same closed-vocab bucket pattern.
- `observe_histogram` exists in `prometheus.ml` but stores a cumulative sum (not per-bucket counters), which doesn't give per-bucket `rate()` queries.
- Closed vocab guarantees bounded cardinality — no risk of unbounded label growth (iter 21 pattern).

### Warn streak rationale (log-spam protection, NOT suppression)

- The **counter still fires every batch** — no metric is suppressed.
- Only the WARN log line is deduped: first entry, then every 10th over-threshold batch.
- This is observability shaping, not symptom suppression. Cap / back-pressure decisions remain operator policy.

### Threshold justification

- `100 / batch` × `(1 / 0.25s)` = `400 events/sec sustained`.
- Normal `keeper_compact_audit` traffic is `~5-10/batch` (single compaction emits Started + Completed). 100/batch implies ~10 concurrent compactions OR JSONL writer is dropping behind drain rate.
- Lower thresholds would trigger on transient bursts (e.g. boot-up surge). Higher would mask the 9-keeper storm V17 explicitly names.

### Per-subscription isolation

`over_threshold_streak` is a `ref` declared inside the `Eio.Fiber.fork` closure — **not** module-global. Multiple subscribers (if added in future) won't share dedup state.

## Anti-pattern self-check (7/7)

1. **telemetry-as-fix only?** — **YES**, intentionally. V17 is INFO-severity, explicitly asks for "batch 크기 metric". This is the work, not a workaround. No symptom is suppressed; the metric is the requested observability.
2. **string classifier added?** — **NO**. Bucket label is closed vocab (6 strings, ml-defined, no string match on data).
3. **N-of-M?** — **NO**. Single drain loop, single call site, atomic patch.
4. **catch-all `_ ->` added?** — **NO**. Bucket function uses explicit `if/else if` ladder over `int`; no `match` added.
5. **cap/cooldown/dedup/repair for symptom?** — **Streak dedup is on WARN ONLY**, not the counter. Counter fires every batch; only log line is deduped to prevent spam during sustained burst. Explicit comment in source. Not symptom suppression.
6. **test backdoor?** — **NO**. No `set_X_for_test` / `reset_for_test` introduced.
7. **repeat typo / off-by-one?** — **NO**. Bucket boundaries chosen once, documented in `.mli`.

## Verification

- `dune build --root . lib/keeper` — clean.
- `dune build --root . @check` — clean.
- `bash ~/me/scripts/pr-rfc-check.sh` — exit 0.

## Constraints respected

- `drain_interval_s = 0.25` unchanged.
- Event processing logic unchanged (no reorder, no drop).
- Streak ref scoped to fiber closure.
- No `git push --force`.
- No credential / identity / operator / sandbox / hooks / workflow edits.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
