### PR TITLE
fix(memory-jsonl): typed truncation marker preserves contract (V05)

### DIFF
--- a/lib/memory_jsonl/memory_jsonl.ml
+++ b/lib/memory_jsonl/memory_jsonl.ml
@@ -42,6 +42,25 @@ let ensure_dir ~base_dir ~agent_name =
 (** Get current timestamp as float. *)
 let now () = Time_compat.now ()
 
+(** Length of the inline preview embedded in the truncation marker (1 KB). *)
+let truncation_preview_len = 1024
+
+(** Classify a [Yojson.Safe.t] by its top-level constructor name.
+
+    Used by [encode_line] when constructing a truncation marker so
+    downstream decoders can recover what shape the original payload
+    had before serialisation exceeded [max_value_size]. *)
+let original_type_of_json (v : Yojson.Safe.t) : string =
+  match v with
+  | `Assoc _ -> "Assoc"
+  | `List _ -> "List"
+  | `String _ -> "String"
+  | `Int _ -> "Int"
+  | `Float _ -> "Float"
+  | `Bool _ -> "Bool"
+  | `Null -> "Null"
+  | `Intlit _ -> "Intlit"
+
 (** Encode a JSONL line. Truncates value if over [max_value_size]. *)
 let encode_line ~key ~(value : Yojson.Safe.t option) : string =
   let ts = now () in
@@ -50,34 +69,32 @@ let encode_line ~key ~(value : Yojson.Safe.t option) : string =
     | Some v ->
       let s = Yojson.Safe.to_string v in
       if String.length s > max_value_size then begin
-        (* TYPE CONTRACT VIOLATION: the original [value] is a
-           [Yojson.Safe.t] of caller-defined shape, but when it
-           exceeds [max_value_size] (1MB) we replace it with a
-           [`String] of the truncated serialisation.  Callers that
-           later decode this entry will see a [String] where they
-           expected an [Assoc]/[List]/etc and silently fail to parse
-           the structured content.  Warn loudly so operators correlate
-           "key X reads as garbled string" with "key X was truncated
-           on persist". *)
+        (* Iter 6 (PR #15668) added the warn line below.  Iter 25
+           closes the structural half by replacing the bare
+           [`String truncated] payload — which silently violated the
+           caller's value-type contract — with a typed-marker
+           [`Assoc] that downstream decoders can recognise via
+           [value_is_truncated_marker].  The marker carries the
+           original constructor name, the original byte size, and a
+           bounded preview so operators can correlate downstream
+           parse failures with truncation events on persist. *)
+        let original_type = original_type_of_json v in
         Log.Memory.warn
           "memory_jsonl: value for key=%s exceeds 1MB (%d bytes); \
-           truncating AND downgrading value type from %s to String — \
-           any structured decoder on this key will mis-parse on \
-           subsequent reads"
+           wrapping in typed truncation marker \
+           (_truncated:true, _original_type=%s) — decoders must \
+           branch via value_is_truncated_marker"
           key
           (String.length s)
-          (match v with
-           | `Assoc _ -> "Assoc"
-           | `List _ -> "List"
-           | `String _ -> "String"
-           | `Int _ -> "Int"
-           | `Float _ -> "Float"
-           | `Bool _ -> "Bool"
-           | `Null -> "Null"
-           | `Intlit _ -> "Intlit");
-        let truncated = String.sub s 0 max_value_size in
-        (* Wrap truncated string so it is valid JSON *)
-        `String truncated
+          original_type;
+        let preview_len = min (String.length s) truncation_preview_len in
+        let preview = String.sub s 0 preview_len in
+        `Assoc [
+          ("_truncated", `Bool true);
+          ("_original_type", `String original_type);
+          ("_original_size_bytes", `Int (String.length s));
+          ("_preview", `String preview);
+        ]
       end else v
   in
   let obj = `Assoc [
@@ -86,6 +103,62 @@ let encode_line ~key ~(value : Yojson.Safe.t option) : string =
     ("ts", `Float ts);
   ] in
   Yojson.Safe.to_string obj ^ "\n"
+
+(** Recognise a typed truncation marker produced by [encode_line] when
+    the serialised value exceeded [max_value_size].
+
+    A marker is an [`Assoc] whose [_truncated] field is exactly
+    [`Bool true].  Legacy bare-[`String] truncated entries written
+    before iter 25 will NOT be recognised — those continue to decode
+    as plain strings, which matches their existing handling on read.
+
+    Discrimination is purely structural (Yojson constructor + Bool
+    field equality) — no substring matching on payload content. *)
+let value_is_truncated_marker (v : Yojson.Safe.t) : bool =
+  match v with
+  | `Assoc fields ->
+    (match List.assoc_opt "_truncated" fields with
+     | Some (`Bool true) -> true
+     | _ -> false)
+  | _ -> false
+
+(** Return the inline preview (first ~[truncation_preview_len] bytes
+    of the original serialised payload) if [v] is a truncation
+    marker, [None] otherwise. *)
+let truncation_marker_preview (v : Yojson.Safe.t) : string option =
+  if not (value_is_truncated_marker v) then None
+  else
+    match v with
+    | `Assoc fields ->
+      (match List.assoc_opt "_preview" fields with
+       | Some (`String s) -> Some s
+       | _ -> None)
+    | _ -> None
+
+(** Return the original payload's top-level constructor name
+    ("Assoc"/"List"/"String"/...) if [v] is a truncation marker,
+    [None] otherwise. *)
+let truncation_marker_original_type (v : Yojson.Safe.t) : string option =
+  if not (value_is_truncated_marker v) then None
+  else
+    match v with
+    | `Assoc fields ->
+      (match List.assoc_opt "_original_type" fields with
+       | Some (`String s) -> Some s
+       | _ -> None)
+    | _ -> None
+
+(** Return the original payload's serialised byte size if [v] is a
+    truncation marker, [None] otherwise. *)
+let truncation_marker_original_size_bytes (v : Yojson.Safe.t) : int option =
+  if not (value_is_truncated_marker v) then None
+  else
+    match v with
+    | `Assoc fields ->
+      (match List.assoc_opt "_original_size_bytes" fields with
+       | Some (`Int n) -> Some n
+       | _ -> None)
+    | _ -> None
 
 (** Bound the snippet length we log when a JSONL line is malformed
     so a single huge garbled line cannot blow up the log file. *)

--- a/lib/memory_jsonl/memory_jsonl.mli
+++ b/lib/memory_jsonl/memory_jsonl.mli
@@ -5,6 +5,56 @@
     append-only; the latest entry per key wins on read. Tombstones
     (value=null) mark removals. *)
 
+val encode_line :
+  key:string ->
+  value:Yojson.Safe.t option ->
+  string
+(** [encode_line ~key ~value] returns the serialised JSONL line
+    (terminated with a newline) for the given (key, value) pair at
+    the current timestamp.
+
+    When the serialised [value] exceeds 1 MB it is replaced with a
+    typed truncation marker of shape
+    {[
+      `Assoc [
+        ("_truncated", `Bool true);
+        ("_original_type", `String "<Assoc|List|String|Int|Float|Bool|Null|Intlit>");
+        ("_original_size_bytes", `Int <bytes>);
+        ("_preview", `String "<first ~1KB of serialised payload>");
+      ]
+    ]}
+    Downstream decoders can recognise the marker via
+    {!value_is_truncated_marker} and branch explicitly. *)
+
+val parse_line :
+  string ->
+  (string * Yojson.Safe.t option * float) option
+(** [parse_line line] returns [Some (key, value, ts)] when [line] is
+    a well-formed JSONL record, [None] otherwise. Malformed lines are
+    logged at warn level with a bounded snippet. *)
+
+val value_is_truncated_marker : Yojson.Safe.t -> bool
+(** [value_is_truncated_marker v] is [true] iff [v] is the typed
+    truncation marker produced by {!encode_line} when the serialised
+    value exceeded 1 MB. Discriminated structurally by the
+    [`Assoc] constructor and a [_truncated] field equal to
+    [`Bool true] — no substring matching on payload. *)
+
+val truncation_marker_preview : Yojson.Safe.t -> string option
+(** [truncation_marker_preview v] returns [Some preview] (first
+    ~1 KB of the original serialised payload) when [v] is a
+    truncation marker, [None] otherwise. *)
+
+val truncation_marker_original_type : Yojson.Safe.t -> string option
+(** [truncation_marker_original_type v] returns the original
+    payload's top-level Yojson constructor name (e.g. ["Assoc"],
+    ["List"]) when [v] is a truncation marker, [None] otherwise. *)
+
+val truncation_marker_original_size_bytes : Yojson.Safe.t -> int option
+(** [truncation_marker_original_size_bytes v] returns the original
+    payload's serialised byte length when [v] is a truncation
+    marker, [None] otherwise. *)
+
 val make_backend :
   base_dir:string ->
   agent_name:string ->
@@ -18,8 +68,9 @@ val make_backend :
     return types ([persist]/[remove]/[batch_persist]) or as empty
     [retrieve]/[query] results.
 
-    Files exceeding 50 MB log a warning but are still read. Individual
-    values exceeding 1 MB are truncated and re-wrapped as JSON strings. *)
+    Files exceeding 50 MB log a warning. Individual values exceeding 1 MB
+    are replaced with a typed truncation marker (see {!encode_line} and
+    {!value_is_truncated_marker}). *)
 
 val make_backend_with_query_observer :
   on_query_result:(((string * Yojson.Safe.t) list, string) result -> unit) ->
@@ -32,4 +83,5 @@ val make_backend_with_query_observer :
     I/O failures without changing the OAS backend contract.
 
     Files exceeding 50 MB log a warning but are still read. Individual
-    values exceeding 1 MB are truncated and re-wrapped as JSON strings. *)
+    values exceeding 1 MB are replaced with a typed truncation marker
+    (see {!encode_line} and {!value_is_truncated_marker}). *)

--- a/test/dune
+++ b/test/dune
@@ -88,6 +88,7 @@
         test_keeper_wake_telemetry
         test_keeper_timing
         test_keeper_memory
+        test_memory_jsonl_truncation
         test_keeper_chat_store
         test_keeper_runtime_trust_snapshot
         test_ide_annotations
@@ -336,6 +337,7 @@
           test_keeper_wake_telemetry
           test_keeper_timing
           test_keeper_memory
+          test_memory_jsonl_truncation
           test_keeper_chat_store
           test_keeper_runtime_trust_snapshot
           test_ide_annotations

--- a/test/test_memory_jsonl_truncation.ml
+++ b/test/test_memory_jsonl_truncation.ml
@@ -1,0 +1,193 @@
+(* V05 (iter 25): Memory_jsonl typed truncation marker.
+
+   Validates the encoder+decoder contract introduced to close the
+   structural half of V05 (HIGH) from
+   .tmp/memory-compacting-analysis.html:
+
+   - encode_line preserves caller's value shape verbatim when the
+     serialised form is under [max_value_size] (1 MB).
+
+   - encode_line wraps >1MB values in a typed-marker [`Assoc]
+     {_truncated:true, _original_type, _original_size_bytes, _preview}
+     instead of a bare [`String], so downstream decoders can branch
+     explicitly via [value_is_truncated_marker] rather than mis-
+     parsing a fabricated string as a real payload.
+
+   - [value_is_truncated_marker] is structural (Yojson constructor +
+     Bool field equality) — no false positives on payloads that
+     happen to contain a [_truncated] field with non-Bool-true
+     value. *)
+
+let assoc_field name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+
+let test_round_trip_small_assoc () =
+  let payload : Yojson.Safe.t =
+    `Assoc [("foo", `String "bar"); ("n", `Int 42)]
+  in
+  let line = Memory_jsonl.encode_line ~key:"small" ~value:(Some payload) in
+  match Memory_jsonl.parse_line line with
+  | None -> Alcotest.fail "parse_line returned None on well-formed line"
+  | Some (key, Some decoded, _ts) ->
+    Alcotest.(check string) "key preserved" "small" key;
+    Alcotest.(check bool)
+      "decoded is not a truncation marker"
+      false
+      (Memory_jsonl.value_is_truncated_marker decoded);
+    Alcotest.(check string)
+      "payload byte-equal after round-trip"
+      (Yojson.Safe.to_string payload)
+      (Yojson.Safe.to_string decoded)
+  | Some (_, None, _) ->
+    Alcotest.fail "decoded value was None (tombstone) instead of Some payload"
+
+let test_truncation_wraps_large_assoc () =
+  (* Build an Assoc whose serialised form exceeds 1 MB.
+     Each `String` field is 4 KB; 300 fields -> ~1.2 MB serialised. *)
+  let big_string = String.make 4096 'x' in
+  let fields =
+    List.init 300 (fun i ->
+        (Printf.sprintf "field_%d" i, `String big_string))
+  in
+  let payload : Yojson.Safe.t = `Assoc fields in
+  let serialised_len = String.length (Yojson.Safe.to_string payload) in
+  Alcotest.(check bool)
+    "payload is actually larger than 1 MB"
+    true
+    (serialised_len > 1024 * 1024);
+  let line = Memory_jsonl.encode_line ~key:"big" ~value:(Some payload) in
+  match Memory_jsonl.parse_line line with
+  | None -> Alcotest.fail "parse_line returned None on truncated line"
+  | Some (_, None, _) ->
+    Alcotest.fail "decoded value was None (tombstone) on truncated payload"
+  | Some (key, Some decoded, _ts) ->
+    Alcotest.(check string) "key preserved on truncation" "big" key;
+    Alcotest.(check bool)
+      "decoded value is recognised as truncation marker"
+      true
+      (Memory_jsonl.value_is_truncated_marker decoded);
+    Alcotest.(check (option string))
+      "original_type recovered"
+      (Some "Assoc")
+      (Memory_jsonl.truncation_marker_original_type decoded);
+    Alcotest.(check (option int))
+      "original_size_bytes matches serialised length"
+      (Some serialised_len)
+      (Memory_jsonl.truncation_marker_original_size_bytes decoded);
+    (match Memory_jsonl.truncation_marker_preview decoded with
+     | None -> Alcotest.fail "preview missing on truncation marker"
+     | Some preview ->
+       Alcotest.(check int)
+         "preview length is exactly 1024 bytes (truncation_preview_len)"
+         1024
+         (String.length preview))
+
+let test_truncation_marker_original_type_list () =
+  (* Variant: original payload is a `List`, not an `Assoc`. *)
+  let big_string = String.make 4096 'y' in
+  let items = List.init 300 (fun _ -> `String big_string) in
+  let payload : Yojson.Safe.t = `List items in
+  let line = Memory_jsonl.encode_line ~key:"big_list" ~value:(Some payload) in
+  match Memory_jsonl.parse_line line with
+  | Some (_, Some decoded, _) ->
+    Alcotest.(check bool)
+      "marker detected"
+      true
+      (Memory_jsonl.value_is_truncated_marker decoded);
+    Alcotest.(check (option string))
+      "original_type = List"
+      (Some "List")
+      (Memory_jsonl.truncation_marker_original_type decoded)
+  | _ -> Alcotest.fail "parse_line failed on truncated List payload"
+
+let test_no_false_positive_on_truncated_field_with_non_bool_value () =
+  (* A real payload that happens to contain a [_truncated] field
+     whose value is NOT [`Bool true] must NOT be recognised as a
+     marker. *)
+  let payload : Yojson.Safe.t =
+    `Assoc [
+      ("_truncated", `String "no");
+      ("_original_type", `String "Assoc");
+      ("payload", `Int 7);
+    ]
+  in
+  Alcotest.(check bool)
+    "_truncated field with String value is NOT a marker"
+    false
+    (Memory_jsonl.value_is_truncated_marker payload);
+  Alcotest.(check (option string))
+    "original_type returns None on non-marker"
+    None
+    (Memory_jsonl.truncation_marker_original_type payload);
+  Alcotest.(check (option string))
+    "preview returns None on non-marker"
+    None
+    (Memory_jsonl.truncation_marker_preview payload)
+
+let test_no_false_positive_on_truncated_field_with_bool_false () =
+  let payload : Yojson.Safe.t =
+    `Assoc [
+      ("_truncated", `Bool false);
+      ("data", `String "real");
+    ]
+  in
+  Alcotest.(check bool)
+    "_truncated:false is NOT a marker"
+    false
+    (Memory_jsonl.value_is_truncated_marker payload)
+
+let test_no_false_positive_on_bare_string () =
+  (* Legacy bare-String truncated entries from before iter 25 must
+     not be reported as markers — callers continue to handle them
+     as plain strings, matching their existing behaviour. *)
+  let payload : Yojson.Safe.t = `String "legacy truncated content" in
+  Alcotest.(check bool)
+    "bare String is NOT a marker"
+    false
+    (Memory_jsonl.value_is_truncated_marker payload)
+
+let test_marker_field_set () =
+  (* Confirm the on-wire field shape matches the documented
+     contract — encoders/decoders in other repos can rely on these
+     exact field names. *)
+  let big = `Assoc (List.init 300 (fun i ->
+      (Printf.sprintf "f%d" i, `String (String.make 4096 'z'))))
+  in
+  let line = Memory_jsonl.encode_line ~key:"k" ~value:(Some big) in
+  match Memory_jsonl.parse_line line with
+  | Some (_, Some marker, _) ->
+    Alcotest.(check bool) "has _truncated"
+      true (assoc_field "_truncated" marker <> None);
+    Alcotest.(check bool) "has _original_type"
+      true (assoc_field "_original_type" marker <> None);
+    Alcotest.(check bool) "has _original_size_bytes"
+      true (assoc_field "_original_size_bytes" marker <> None);
+    Alcotest.(check bool) "has _preview"
+      true (assoc_field "_preview" marker <> None)
+  | _ -> Alcotest.fail "parse_line failed"
+
+let () =
+  Alcotest.run "memory_jsonl_truncation"
+    [
+      ("round-trip", [
+        Alcotest.test_case "small Assoc preserved verbatim" `Quick
+          test_round_trip_small_assoc;
+      ]);
+      ("truncation marker", [
+        Alcotest.test_case ">1MB Assoc wrapped in typed marker" `Quick
+          test_truncation_wraps_large_assoc;
+        Alcotest.test_case ">1MB List records original_type=List" `Quick
+          test_truncation_marker_original_type_list;
+        Alcotest.test_case "marker has the documented field set" `Quick
+          test_marker_field_set;
+      ]);
+      ("no false positives", [
+        Alcotest.test_case "_truncated:String is not a marker" `Quick
+          test_no_false_positive_on_truncated_field_with_non_bool_value;
+        Alcotest.test_case "_truncated:Bool false is not a marker" `Quick
+          test_no_false_positive_on_truncated_field_with_bool_false;
+        Alcotest.test_case "legacy bare String is not a marker" `Quick
+          test_no_false_positive_on_bare_string;
+      ]);
+    ]


### PR DESCRIPTION
## Summary — V05 (HIGH) structural close

Closes V05 (HIGH) from `.tmp/memory-compacting-analysis.html`: `Memory_jsonl.encode_line` previously replaced >1MB values with a bare ``` `String truncated ``` — a **type-contract violation**. Decoders (`parse_line` and any consumer reading `value : Yojson.Safe.t`) saw a `String` where they expected the caller's actual constructor (`Assoc`/`List`/`Int`/…) and silently mis-parsed subsequent reads.

Iter 6 (PR #15668) added the operator `Log.Memory.warn` line — that closed the *observability* half. **This PR closes the structural half**: the encoder now produces a typed marker `Assoc` that downstream decoders recognise via a public predicate.

## Before / After encoded JSON

### Before (V05 defect)

Caller writes:
```
let payload : Yojson.Safe.t = `Assoc [("a", `String <huge>); ("b", `Int 7)]
```
Persisted JSONL value field (>1MB total):
```json
{"key":"k","value":"{\"a\":\"xxxxxx... (truncated to 1MB) ...","ts":...}
```
On read, `value` is `` `String "{\"a\":\"xxxxxx..." ``. Caller's structural decoder (expecting `Assoc`) silently fails. No way to tell the difference from a real string payload.

### After (this PR)

Persisted JSONL value field:
```json
{
  "key": "k",
  "value": {
    "_truncated": true,
    "_original_type": "Assoc",
    "_original_size_bytes": 1572864,
    "_preview": "{\"a\":\"xxxxxx... (first 1024 bytes of original serialisation) ..."
  },
  "ts": ...
}
```
Decoder can branch:
```ocaml
match Memory_jsonl.parse_line line with
| Some (k, Some v, _ts) when Memory_jsonl.value_is_truncated_marker v ->
    (* fail-loud / surface-up: original payload exceeded 1MB on persist *)
    Log.Memory.warn "memory key=%s was truncated on persist (orig %d bytes)"
      k
      (Option.value ~default:(-1) (Memory_jsonl.truncation_marker_original_size_bytes v))
| Some (k, Some v, _ts) -> (* real payload — decode normally *)
| ...
```

## New public helpers (`lib/memory_jsonl/memory_jsonl.mli`)

- `val encode_line : key:string -> value:Yojson.Safe.t option -> string` — now exposed (was implicit).
- `val parse_line : string -> (string * Yojson.Safe.t option * float) option` — now exposed (was implicit).
- `val value_is_truncated_marker : Yojson.Safe.t -> bool` — structural predicate.
- `val truncation_marker_preview : Yojson.Safe.t -> string option`
- `val truncation_marker_original_type : Yojson.Safe.t -> string option`
- `val truncation_marker_original_size_bytes : Yojson.Safe.t -> int option`

Discrimination is purely structural: `Yojson.Safe.t` constructor `Assoc` + `_truncated` field equality with `Bool true`. **No substring matching on payload content.**

## Cross-reference — Iter 6 / PR #15668

PR #15668 added `Log.Memory.warn` to make the truncation visible to operators. That landed as a telemetry-only step — fully aware that the type-contract violation remained open. This PR finishes the job: the operator warn is preserved (wording updated to reflect the new shape), and the data path now produces a typed-marker the decoder can recognise.

## Legacy decode behaviour (intentional)

JSONL files written *before* this PR contain bare-`String` truncated entries on disk. Those continue to decode as plain `` `String "..." `` exactly as today — `value_is_truncated_marker` returns `false` on them, callers' existing handling is unchanged. No migration required. **No retroactive fix is possible without rewriting on-disk history; this PR establishes the invariant going forward.**

## Constraints respected

- `encode_line` signature unchanged (`~key -> ?value:Yojson.Safe.t option -> string`) → zero call-site churn.
- `max_value_size = 1 MB` constant unchanged.
- No edits to other backend modules (`memory_oas_bridge` etc.) — those are wrapper consumers; their adaptation (e.g. surfacing the marker to OAS read paths) is a follow-up.
- No leaf sublib dep expansion: `lib/memory_jsonl/dune` has no `prometheus`/`keeper_metrics` dep and **none was added**. A `metric_keeper_memory_jsonl_truncation_total` counter would be valuable but belongs to a wrapper-side PR. Iter 6/7/17 leaf-purity precedent followed.
- No credential / identity / operator / sandbox / hooks / workflow edits.
- No `git push --force`.

## Tests

New file `test/test_memory_jsonl_truncation.ml` (7 cases, all `Quick`, all pass):

| Suite | Case |
|------|------|
| round-trip | small Assoc preserved verbatim (byte-equal after encode→parse) |
| truncation marker | >1MB Assoc wrapped in typed marker (1.2 MB payload → marker with `_original_type=Assoc`, `_original_size_bytes=actual`, `_preview` exactly 1024 bytes) |
| truncation marker | >1MB List records `_original_type=List` |
| truncation marker | marker has all four documented fields |
| no false positives | `_truncated: "no"` (String) is NOT a marker |
| no false positives | `_truncated: false` (Bool false) is NOT a marker |
| no false positives | legacy bare `` `String `` (pre-fix on-disk shape) is NOT a marker |

Run: `dune exec test/test_memory_jsonl_truncation.exe` → `Test Successful. 7 tests run.`

Build: `dune build @check` → clean.

## 7/7 Anti-pattern self-check (software-development.md §워크어라운드 거부 기준)

1. ☑ **Not telemetry-as-fix**: warn line existed in iter 6 already. This PR produces a *typed structural shape* the decoder recognises — the fix is in the data path, not the log path.
2. ☑ **Not string classifier**: marker discrimination is `Yojson` constructor equality + `Bool true` field equality. No `String.starts_with`, no substring match, no prefix scan.
3. ☑ **Not N-of-M**: single encoder + single decoder helper module pair. All call sites of `encode_line` automatically benefit because the signature is unchanged.
4. ☑ **No new catch-all `_ ->`**: the helpers' `| _ -> false` / `| _ -> None` are **terminal closed-shape predicates** (the negation arm of a structural test), not silent-drop branches.
5. ☑ **Not cap/cooldown/dedup/repair**: the 1 MB cap existed *before* this PR. This PR does not change the cap; it makes the side-effect of hitting the cap *structurally observable*.
6. ☑ **No test backdoor**: tests use the public `encode_line` / `parse_line` / `value_is_truncated_marker` / `truncation_marker_*` surface. No `set_X_for_test`, no `reset_for_test`, no internal-state probe.
7. ☑ **Not a repeat typo / N-site identical fix**: single-site fix in a leaf module.

## Iter trail

iter 25 — 2026-05-17 — closes structural half of V05 (`.tmp/memory-compacting-analysis.html`). Iter 6 (PR #15668) closed the observability half.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
