### PR TITLE
feat(server): Session_lifecycle_event typed module (RFC-0099 PR-2)

### DIFF
--- a/lib/server/session_lifecycle_event.ml
+++ b/lib/server/session_lifecycle_event.ml
@@ -1,0 +1,206 @@
+type transport = SSE | WS | GRPC | WebRTC
+
+type evict_reason =
+  | Cap_exceeded
+  | Idle_timeout
+  | Backpressure
+  | Policy_revoked
+
+type close_reason =
+  | Client_disconnected
+  | Server_shutdown
+  | Server_error of string
+  | Evicted of evict_reason
+
+type t =
+  | Open of {
+      transport : transport ;
+      session_id : string ;
+      origin : string ;
+    }
+  | Upgrade of {
+      transport_from : transport ;
+      transport_to : transport ;
+      session_id : string ;
+    }
+  | Resume of {
+      transport : transport ;
+      session_id : string ;
+      last_event_id : string option ;
+      replayed : int ;
+    }
+  | Evict of {
+      transport : transport ;
+      session_id : string ;
+      reason : evict_reason ;
+    }
+  | Close of {
+      transport : transport ;
+      session_id : string ;
+      reason : close_reason ;
+    }
+
+let bus_topic = "session_lifecycle"
+
+let transport_to_string = function
+  | SSE -> "sse"
+  | WS -> "ws"
+  | GRPC -> "grpc"
+  | WebRTC -> "webrtc"
+
+let transport_of_string = function
+  | "sse" -> Some SSE
+  | "ws" -> Some WS
+  | "grpc" -> Some GRPC
+  | "webrtc" -> Some WebRTC
+  | _ -> None
+
+let evict_reason_to_string = function
+  | Cap_exceeded -> "cap_exceeded"
+  | Idle_timeout -> "idle_timeout"
+  | Backpressure -> "backpressure"
+  | Policy_revoked -> "policy_revoked"
+
+let evict_reason_of_string = function
+  | "cap_exceeded" -> Some Cap_exceeded
+  | "idle_timeout" -> Some Idle_timeout
+  | "backpressure" -> Some Backpressure
+  | "policy_revoked" -> Some Policy_revoked
+  | _ -> None
+
+let close_reason_kind = function
+  | Client_disconnected -> "client_disconnected"
+  | Server_shutdown -> "server_shutdown"
+  | Server_error _ -> "server_error"
+  | Evicted _ -> "evicted"
+
+let close_reason_to_yojson = function
+  | Client_disconnected ->
+      `Assoc [ ("kind", `String "client_disconnected") ]
+  | Server_shutdown -> `Assoc [ ("kind", `String "server_shutdown") ]
+  | Server_error detail ->
+      `Assoc
+        [ ("kind", `String "server_error") ; ("detail", `String detail) ]
+  | Evicted r ->
+      `Assoc
+        [
+          ("kind", `String "evicted") ;
+          ("evict_reason", `String (evict_reason_to_string r)) ;
+        ]
+
+let close_reason_of_yojson (j : Yojson.Safe.t) :
+    (close_reason, string) result =
+  let open Yojson.Safe.Util in
+  try
+    match j |> member "kind" |> to_string with
+    | "client_disconnected" -> Ok Client_disconnected
+    | "server_shutdown" -> Ok Server_shutdown
+    | "server_error" ->
+        let detail = j |> member "detail" |> to_string in
+        Ok (Server_error detail)
+    | "evicted" -> (
+        let r = j |> member "evict_reason" |> to_string in
+        match evict_reason_of_string r with
+        | Some er -> Ok (Evicted er)
+        | None -> Error (Printf.sprintf "unknown evict_reason: %s" r))
+    | other -> Error (Printf.sprintf "unknown close_reason kind: %s" other)
+  with Type_error (msg, _) -> Error msg
+
+let to_yojson = function
+  | Open { transport ; session_id ; origin } ->
+      `Assoc
+        [
+          ("kind", `String "open") ;
+          ("transport", `String (transport_to_string transport)) ;
+          ("session_id", `String session_id) ;
+          ("origin", `String origin) ;
+        ]
+  | Upgrade { transport_from ; transport_to ; session_id } ->
+      `Assoc
+        [
+          ("kind", `String "upgrade") ;
+          ("transport_from", `String (transport_to_string transport_from)) ;
+          ("transport_to", `String (transport_to_string transport_to)) ;
+          ("session_id", `String session_id) ;
+        ]
+  | Resume { transport ; session_id ; last_event_id ; replayed } ->
+      `Assoc
+        [
+          ("kind", `String "resume") ;
+          ("transport", `String (transport_to_string transport)) ;
+          ("session_id", `String session_id) ;
+          ( "last_event_id",
+            match last_event_id with
+            | Some id -> `String id
+            | None -> `Null ) ;
+          ("replayed", `Int replayed) ;
+        ]
+  | Evict { transport ; session_id ; reason } ->
+      `Assoc
+        [
+          ("kind", `String "evict") ;
+          ("transport", `String (transport_to_string transport)) ;
+          ("session_id", `String session_id) ;
+          ("reason", `String (evict_reason_to_string reason)) ;
+        ]
+  | Close { transport ; session_id ; reason } ->
+      `Assoc
+        [
+          ("kind", `String "close") ;
+          ("transport", `String (transport_to_string transport)) ;
+          ("session_id", `String session_id) ;
+          ("reason", close_reason_to_yojson reason) ;
+        ]
+
+let of_yojson (j : Yojson.Safe.t) : (t, string) result =
+  let open Yojson.Safe.Util in
+  try
+    let kind = j |> member "kind" |> to_string in
+    let transport_field name =
+      let s = j |> member name |> to_string in
+      match transport_of_string s with
+      | Some t -> Ok t
+      | None -> Error (Printf.sprintf "unknown transport: %s" s)
+    in
+    let session_id () = j |> member "session_id" |> to_string in
+    match kind with
+    | "open" ->
+        Result.bind (transport_field "transport") (fun transport ->
+            let origin = j |> member "origin" |> to_string in
+            Ok (Open { transport ; session_id = session_id () ; origin }))
+    | "upgrade" ->
+        Result.bind (transport_field "transport_from") (fun transport_from ->
+            Result.bind (transport_field "transport_to") (fun transport_to ->
+                Ok
+                  (Upgrade
+                     { transport_from ; transport_to ; session_id = session_id () })))
+    | "resume" ->
+        Result.bind (transport_field "transport") (fun transport ->
+            let last_event_id =
+              match j |> member "last_event_id" with
+              | `Null -> None
+              | `String s -> Some s
+              | _ -> None
+            in
+            let replayed = j |> member "replayed" |> to_int in
+            Ok
+              (Resume
+                 { transport ; session_id = session_id () ; last_event_id ; replayed }))
+    | "evict" ->
+        Result.bind (transport_field "transport") (fun transport ->
+            let reason_str = j |> member "reason" |> to_string in
+            match evict_reason_of_string reason_str with
+            | Some reason ->
+                Ok (Evict { transport ; session_id = session_id () ; reason })
+            | None ->
+                Error (Printf.sprintf "unknown evict_reason: %s" reason_str))
+    | "close" ->
+        Result.bind (transport_field "transport") (fun transport ->
+            Result.bind
+              (close_reason_of_yojson (j |> member "reason"))
+              (fun reason ->
+                Ok (Close { transport ; session_id = session_id () ; reason })))
+    | other -> Error (Printf.sprintf "unknown event kind: %s" other)
+  with Type_error (msg, _) -> Error msg
+
+let pp fmt t = Format.pp_print_string fmt (Yojson.Safe.to_string (to_yojson t))

--- a/lib/server/session_lifecycle_event.mli
+++ b/lib/server/session_lifecycle_event.mli
@@ -1,0 +1,92 @@
+(** Session lifecycle typed events (RFC-0099).
+
+    Published on the existing [Event_bus.Custom ("session_lifecycle",
+    json)] channel. Dashboard surfaces consume from there. Closed sum;
+    adding a new variant requires RFC-level discussion (same discipline
+    as {!Mcp_error_code}).
+
+    This module is {b wire-inert} at PR-2 — only the variant + JSON
+    encoding land. PR-3+ wire the publish calls from the SSE eviction
+    and lifecycle sites in {!Server_mcp_transport_http_sse}. *)
+
+type transport = SSE | WS | GRPC | WebRTC
+
+type evict_reason =
+  | Cap_exceeded
+      (** oldest-eviction triggered by [max_clients] cap. *)
+  | Idle_timeout
+      (** [cleanup_stale] crossed [MASC_TRANSPORT_IDLE_EVICT_SEC]. *)
+  | Backpressure
+      (** mailbox-full beyond drain grace, or {!Fd_accountant} pressure
+          escalation (RFC-0101 §3.6, 5 s sustained). *)
+  | Policy_revoked
+      (** auth / quota / admin action terminated the session. *)
+
+type close_reason =
+  | Client_disconnected
+  | Server_shutdown
+  | Server_error of string
+  | Evicted of evict_reason
+      (** mirror frame written after an [Evict] transition; the close
+          event echoes the eviction reason for log-trail completeness. *)
+
+type t =
+  | Open of {
+      transport : transport ;
+      session_id : string ;
+      origin : string ;
+    }
+  | Upgrade of {
+      transport_from : transport ;
+      transport_to : transport ;
+      session_id : string ;
+    }
+      (** transport upgrade within the same session (e.g. POST /mcp
+          chunked-JSON → SSE on long-running dispatch — RFC-0100 §3.2). *)
+  | Resume of {
+      transport : transport ;
+      session_id : string ;
+      last_event_id : string option ;
+      replayed : int ;
+          (** number of frames the ring-buffer replayed past
+              [last_event_id]. *)
+    }
+  | Evict of {
+      transport : transport ;
+      session_id : string ;
+      reason : evict_reason ;
+    }
+      (** server-policy termination. {b Always} paired with a
+          subsequent {!Close} carrying [Evicted reason] for log-trail
+          completeness. *)
+  | Close of {
+      transport : transport ;
+      session_id : string ;
+      reason : close_reason ;
+    }
+
+(** {1 Wire encoding} *)
+
+val transport_to_string : transport -> string
+val transport_of_string : string -> transport option
+
+val evict_reason_to_string : evict_reason -> string
+val evict_reason_of_string : string -> evict_reason option
+
+val close_reason_kind : close_reason -> string
+(** Short label for the close-reason variant; the [Server_error _]
+    payload travels in a separate [detail] field of the JSON encoding. *)
+
+val to_yojson : t -> Yojson.Safe.t
+(** Stable JSON encoding suitable for
+    [Event_bus.Custom ("session_lifecycle", json)]. The shape is pinned
+    by {!val:bus_topic} so dashboards can pattern-match a single topic
+    name. *)
+
+val of_yojson : Yojson.Safe.t -> (t, string) result
+
+val bus_topic : string
+(** Canonical [Event_bus.Custom] topic name. *)
+
+val pp : Format.formatter -> t -> unit
+(** Pretty-printer for tests and operator diagnostics. *)

--- a/test/dune
+++ b/test/dune
@@ -25,7 +25,7 @@
 
 ; Group 1: Pure synchronous tests
 (tests
- (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_mcp_error_code test_error_body_delegation test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
+ (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_mcp_error_code test_error_body_delegation test_session_lifecycle_event test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
         test_keeper_turn_terminal_code_byte_compat
         test_keeper_sdk_error_typed_bridge
         test_read_drop_reason
@@ -275,7 +275,7 @@
         test_chronicle_librarian
         test_alignment_score
         )
- (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_mcp_error_code test_error_body_delegation test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
+ (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_mcp_error_code test_error_body_delegation test_session_lifecycle_event test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_keeper_turn_terminal_code_byte_compat
           test_keeper_sdk_error_typed_bridge
           test_read_drop_reason

--- a/test/test_session_lifecycle_event.ml
+++ b/test/test_session_lifecycle_event.ml
@@ -1,0 +1,152 @@
+(** Round-trip + topic-stability tests for [Session_lifecycle_event.t]
+    (RFC-0099 PR-2).
+
+    Pins down the JSON encoding so dashboards / consumers can pattern
+    match on a stable shape. Adding a new variant requires touching
+    these tests, which forces RFC-level discussion (same discipline as
+    {!test_mcp_error_code} for RFC-0098). *)
+
+open Alcotest
+module E = Masc_mcp.Session_lifecycle_event
+
+let pp_evt fmt e = E.pp fmt e
+
+let evt_eq a b =
+  Yojson.Safe.to_string (E.to_yojson a)
+  = Yojson.Safe.to_string (E.to_yojson b)
+
+let evt : E.t Alcotest.testable = testable pp_evt evt_eq
+
+let round_trip e =
+  match E.of_yojson (E.to_yojson e) with
+  | Ok e' -> e'
+  | Error msg ->
+      Alcotest.failf "round-trip failed for %a: %s" pp_evt e msg
+
+let samples : E.t list =
+  [
+    Open { transport = SSE ; session_id = "s1" ; origin = "https://x" };
+    Open { transport = WS ; session_id = "s2" ; origin = "*" };
+    Upgrade
+      { transport_from = SSE ; transport_to = WS ; session_id = "s3" };
+    Resume
+      {
+        transport = SSE ;
+        session_id = "s4" ;
+        last_event_id = Some "evt-1234" ;
+        replayed = 7 ;
+      };
+    Resume
+      {
+        transport = WebRTC ;
+        session_id = "s5" ;
+        last_event_id = None ;
+        replayed = 0 ;
+      };
+    Evict { transport = SSE ; session_id = "s6" ; reason = Cap_exceeded };
+    Evict { transport = WS ; session_id = "s7" ; reason = Idle_timeout };
+    Evict
+      { transport = GRPC ; session_id = "s8" ; reason = Backpressure };
+    Evict
+      { transport = SSE ; session_id = "s9" ; reason = Policy_revoked };
+    Close
+      { transport = SSE ; session_id = "s10" ; reason = Client_disconnected };
+    Close
+      { transport = WS ; session_id = "s11" ; reason = Server_shutdown };
+    Close
+      {
+        transport = SSE ;
+        session_id = "s12" ;
+        reason = Server_error "boom" ;
+      };
+    Close
+      {
+        transport = SSE ;
+        session_id = "s13" ;
+        reason = Evicted Backpressure ;
+      };
+  ]
+
+let test_round_trip () =
+  List.iter (fun e -> check evt "round-trip" e (round_trip e)) samples
+
+let test_topic_stable () =
+  check string "bus topic SSOT" "session_lifecycle" E.bus_topic
+
+let test_transport_round_trip () =
+  List.iter
+    (fun t ->
+      let s = E.transport_to_string t in
+      match E.transport_of_string s with
+      | Some t' when t' = t -> ()
+      | Some _ -> Alcotest.failf "transport drift: %s" s
+      | None -> Alcotest.failf "transport_of_string None for %s" s)
+    [ E.SSE; WS; GRPC; WebRTC ]
+
+let test_evict_reason_round_trip () =
+  List.iter
+    (fun r ->
+      let s = E.evict_reason_to_string r in
+      match E.evict_reason_of_string s with
+      | Some r' when r' = r -> ()
+      | Some _ -> Alcotest.failf "evict_reason drift: %s" s
+      | None ->
+          Alcotest.failf "evict_reason_of_string None for %s" s)
+    [ E.Cap_exceeded; Idle_timeout; Backpressure; Policy_revoked ]
+
+let test_unknown_kind_rejected () =
+  let bad = `Assoc [ ("kind", `String "definitely_not_a_kind") ] in
+  match E.of_yojson bad with
+  | Error _ -> ()
+  | Ok _ ->
+      Alcotest.fail
+        "of_yojson should reject unknown kind rather than silently \
+         collapse"
+
+let test_unknown_transport_rejected () =
+  let bad =
+    `Assoc
+      [
+        ("kind", `String "open") ;
+        ("transport", `String "carrier_pigeon") ;
+        ("session_id", `String "s") ;
+        ("origin", `String "*") ;
+      ]
+  in
+  match E.of_yojson bad with
+  | Error _ -> ()
+  | Ok _ ->
+      Alcotest.fail
+        "of_yojson should reject unknown transport rather than \
+         silently collapse"
+
+let test_close_reason_kind_labels () =
+  let cases =
+    [
+      (E.Client_disconnected, "client_disconnected") ;
+      (E.Server_shutdown, "server_shutdown") ;
+      (E.Server_error "x", "server_error") ;
+      (E.Evicted E.Backpressure, "evicted") ;
+    ]
+  in
+  List.iter
+    (fun (r, expected) -> check string expected expected (E.close_reason_kind r))
+    cases
+
+let () =
+  Alcotest.run "Session_lifecycle_event"
+    [
+      ( "wire shape",
+        [
+          test_case "round-trip all variants" `Quick test_round_trip ;
+          test_case "bus_topic stable" `Quick test_topic_stable ;
+          test_case "transport round-trip" `Quick test_transport_round_trip ;
+          test_case "evict_reason round-trip" `Quick test_evict_reason_round_trip ;
+          test_case "close_reason kind labels" `Quick test_close_reason_kind_labels ;
+        ] ) ;
+      ( "rejection",
+        [
+          test_case "unknown kind" `Quick test_unknown_kind_rejected ;
+          test_case "unknown transport" `Quick test_unknown_transport_rejected ;
+        ] ) ;
+    ]


### PR DESCRIPTION
## Summary

PR-2 of [[RFC-0099]]. Adds the typed lifecycle event module to `lib/server/`. **Wire-inert** — no caller migration; PR-3 wires the existing SSE eviction/cleanup sites to publish on `Event_bus.Custom("session_lifecycle", ...)`.

## What ships

- `lib/server/session_lifecycle_event.ml(i)` — 5-variant closed sum (`Open` / `Upgrade` / `Resume` / `Evict` / `Close`) + 4-variant `evict_reason` + discriminated `close_reason` sum.
- `to_yojson` / `of_yojson` stable encoding with round-trip tests.
- `bus_topic` SSOT constant (`"session_lifecycle"`).
- `test/test_session_lifecycle_event.ml` — 7 cases: round-trip 13 variant samples, transport/reason round-trips, unknown-kind/transport rejection.

Local: **7/7 OK**, `dune build --root . lib/` silent OK.

## Workaround rejection self-check

- [x] Not telemetry-as-fix — typed event for propagation, not counter.
- [x] Not string-classifier — closed-sum variant throughout (`transport_of_string` returns `option`, no silent default).
- [x] Not N-of-M — single module + single test, no caller wiring yet.
- [x] No catch-all — `of_yojson` rejects unknown kind/transport explicitly.

## Out of scope (PR-3)

- Wiring publish calls from `server_mcp_transport_http_sse.ml` eviction sites
- Explicit close frames (`event: evicted`, WS codes 4001-4099, gRPC trailer, WebRTC datachannel close)
- Mailbox backpressure semantics

## RFC cross-reference

`docs/rfc/RFC-0099-session-lifecycle-typed-events.md` (#15795 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)