### PR TITLE
feat(cascade): RFC-0004 PR-2 migrate AgentStarted arm to Sse_event

### DIFF
--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -553,10 +553,16 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
   let wrap = wrap_event ~ts ~correlation_id ~run_id in
   match[@warning "-11"] evt.payload with
   | Agent_sdk.Event_bus.AgentStarted { agent_name; task_id } ->
-    let payload =
-      `Assoc [ "agent_name", `String agent_name; "task_id", `String task_id ]
-    in
-    Some (wrap ~event_type:"agent_started" ~payload ~agent_name ~task_id ())
+    (* RFC-0004 Phase A0.1 PR-2: migrated to Sse_event.agent_started.
+       Byte-equal vs the previous inline `Assoc + wrap_event path was
+       proven in test/sse_event/test_sse_event.ml on PR-1 (#15807). *)
+    Some
+      (Sse_event.agent_started
+         ~ts_unix:ts
+         ~correlation_id
+         ~run_id
+         ~agent_name
+         ~task_id)
   | Agent_sdk.Event_bus.AgentCompleted { agent_name; task_id; elapsed; result } ->
     (match result with
      | Ok (response : Agent_sdk.Types.api_response) ->

--- a/lib/dune
+++ b/lib/dune
@@ -308,6 +308,12 @@
    ;; lib/dashboard_eval_feed/. 178+59 LoC, deps: stdlib + Yojson +
    ;; agent_sdk + masc_core (Json_util/Safe_ops).
    masc_mcp.dashboard_eval_feed
+   ;; RFC-0004 Phase A0.1 PR-1 — Typed SSE event lib (lib/sse_event/).
+   ;; atdgen-generated payload types + hand-rolled envelope wrap that
+   ;; mirrors cascade_event_bridge.wrap_event/json_string_opt
+   ;; semantics.  PR-2 onwards: cascade_event_bridge arms call into
+   ;; Sse_event.<event>_constructor instead of inline `Assoc.
+   masc_mcp.sse_event
    ;; RFC-0056 Phase 1F — Memory_jsonl leaf module extracted to
    ;; lib/memory_jsonl/. 219+22 LoC, deps: stdlib + Yojson + Eio +
    ;; agent_sdk + fs_compat + time_compat + masc_log. OAS Memory

--- a/lib/sse_event/dune
+++ b/lib/sse_event/dune
@@ -7,6 +7,7 @@
 ; constructors in PR-2 (agent_started/completed/failed migration).
 (library
  (name sse_event)
+ (public_name masc_mcp.sse_event)
  (libraries yojson atdgen-runtime))
 
 (rule


### PR DESCRIPTION
## Summary

RFC-0004 Phase A0.1 **PR-2** — first production call site of the typed SSE event library (PR-1 #15807).

`cascade_event_bridge.native_event_to_json` 의 `AgentStarted` arm 을 inline `` `Assoc `` + `wrap_event` path 에서 `Sse_event.agent_started` 호출로 교체.

## 변경 surface

| 파일 | 변경 |
|---|---|
| `lib/sse_event/dune` | `(public_name masc_mcp.sse_event)` 추가 — main lib 가 link 가능하도록 |
| `lib/dune` | `(libraries)` 에 `masc_mcp.sse_event` 추가 |
| `lib/cascade/cascade_event_bridge.ml` | AgentStarted arm: 5줄 inline 조립 → `Sse_event.agent_started ~ts_unix:ts ~correlation_id ~run_id ~agent_name ~task_id` 호출 |

3 file, 17 insertions, 4 deletions.

## Byte-equal 보장

PR-1 에서 추가한 `test/sse_event/test_sse_event.ml` 은 `Sse_event.agent_started` 출력을 cascade `wrap_event` + `json_string_opt` 의 inline replica baseline 과 byte-equal 비교.

이번 migration 후에도:
```
$ dune build --root . lib/sse_event/ lib/cascade/ test/sse_event/  ✓
$ _build/default/test/sse_event/test_sse_event.exe
  [OK]  byte_equal      0  agent_started full envelope.
  [OK]  json_string_opt 0  Some empty → null.
Test Successful in 0.001s. 2 tests run.
```

즉 cascade 가 emit 하는 JSON 은 마이그레이션 전후 byte-identical. SSE consumer (dashboard, OAS, persistence) 영향 0.

## N-of-M antipattern 회피

PR-1 머지 직후 `lib/sse_event/` 가 caller 0 (dead code). 본 PR (PR-2) 가 그 caller 를 만듦.

CLAUDE.md `software-development.md` §AI 코드 생성 안티패턴 §4 "N-of-M 패치" — 동일 변환을 여러 사이트에서 따로 하는 패턴 회피. AgentStarted 1 site 만 이번 PR 에서 마이그레이션 + 나머지 15 site 의 sequencing (PR-3, PR-4) 가 #15778 plan §4 에 명시.

## 비범위

- **PR-3**: agent_completed, agent_failed, tool_called/completed, turn_started/completed/ready (5 event)
- **PR-4**: handoff_*, context_*, content_replacement_*, slot_scheduler_observed (8 event)

각 event 의 payload schema 도 `sse_event.atd` 에 추가. envelope 의 nullable handling 은 `Sse_event.wrap_envelope` 가 이미 제공 (PR-1).

## Test plan

- [ ] CI: dune build @check, @runtest, lint, godfile size
- [ ] `test_sse_event byte_equal/agent_started` PASS 유지
- [ ] CI 의 cascade 관련 integration test 영향 없음 확인

RFC-WAIVED: PR-2 of #15778 plan §4.  Plan merged (commit 9f11aacef3).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>