### PR TITLE
fix(tool_task): make handoff_context.summary required only for exit-class actions

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -391,9 +391,46 @@ let synthesize_summary_from_siblings args =
       | Some s -> Some (truncate ~max_len:240 (first_line s))
       | None -> None
 
-let parse_handoff_context ~(agent_name : string) args =
+(* A transition's [handoff_context.summary] is only meaningful when the
+   action represents a *work-state exit* — the keeper is reporting the
+   outcome of work it did. Pure ownership transitions (Claim, Start)
+   have no outcome to summarize yet, so requiring a summary just makes
+   the LLM either invent one (degrading audit signal) or fail the call
+   entirely (the 2026-05-17 nick0cave production case).
+
+   Exit-class actions:
+     Done_action / Cancel / Release / Submit_for_verification /
+     Submit_pr_evidence / Approve_verification / Reject_verification
+   Entry-class actions (no summary required):
+     Claim / Start
+
+   This split is exhaustive over [Masc_domain.task_action]; adding a
+   new variant forces a compile-time decision here, not a runtime
+   permissive default. *)
+let transition_action_requires_summary : Masc_domain.task_action -> bool =
+  function
+  | Masc_domain.Done_action
+  | Masc_domain.Cancel
+  | Masc_domain.Release
+  | Masc_domain.Submit_for_verification
+  | Masc_domain.Submit_pr_evidence
+  | Masc_domain.Approve_verification
+  | Masc_domain.Reject_verification ->
+    true
+  | Masc_domain.Claim | Masc_domain.Start ->
+    false
+
+let parse_handoff_context ~(agent_name : string)
+    ~(action : Masc_domain.task_action) args =
+  let summary_required = transition_action_requires_summary action in
   match args |> member "handoff_context" with
-  | `Null -> Ok None
+  | `Null ->
+    (* No handoff_context object provided. For entry-class actions this
+       is the expected shape; for exit-class actions the caller's
+       strict-release / contract checks downstream will surface the
+       missing summary if the task contract demands it. We do not
+       fabricate an empty handoff_context here. *)
+    Ok None
   | (`Assoc _ as json) -> (
       match Masc_domain.task_handoff_context_of_yojson json with
       | Error error ->
@@ -407,12 +444,23 @@ let parse_handoff_context ~(agent_name : string) args =
             else summary
           in
           if String.equal summary "" then
-            Error
-              "handoff_context.summary is required (non-empty string). \
-               Example: {\"summary\": \"tests green, PR #123 pending review\", \
-               \"next_step\": \"wait for CI\", \"evidence_refs\": [\"PR#123\"]}. \
-               Alternatively pass a non-empty top-level 'notes' or 'reason' \
-               and it will be synthesized into summary automatically."
+            if summary_required then
+              Error
+                (Printf.sprintf
+                   "handoff_context.summary is required for action=%s \
+                    (non-empty string). Example: {\"summary\": \"tests \
+                    green, PR #123 pending review\", \"next_step\": \"wait \
+                    for CI\", \"evidence_refs\": [\"PR#123\"]}. \
+                    Alternatively pass a non-empty top-level 'notes' or \
+                    'reason' and it will be synthesized into summary \
+                    automatically."
+                   (Masc_domain.task_action_to_string action))
+            else
+              (* Entry-class action (claim/start) with an empty
+                 handoff_context object. The summary is meaningless at
+                 work entry; treat the empty context as absent rather
+                 than failing the call. *)
+              Ok None
           else
             Ok
               (Some
@@ -717,7 +765,10 @@ let handle_release ~tool_name ~start_time ctx args =
   let expected_version = get_int_opt args "expected_version" in
   let tasks = Coord.get_tasks_raw ctx.config in
   let task_opt = List.find_opt (fun (t : Masc_domain.task) -> String.equal t.id task_id) tasks in
-  let handoff_context = parse_handoff_context ~agent_name:ctx.agent_name args in
+  let handoff_context =
+    parse_handoff_context ~agent_name:ctx.agent_name
+      ~action:Masc_domain.Release args
+  in
   (match handoff_context with
    | Error error -> Tool_result.error ~tool_name ~start_time error
    | Ok handoff_context ->
@@ -913,7 +964,9 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
     | items -> Some items
   in
   let evaluator_cascade = get_string_opt args "evaluator_cascade" in
-  let handoff_context = parse_handoff_context ~agent_name:ctx.agent_name args in
+  let handoff_context =
+    parse_handoff_context ~agent_name:ctx.agent_name ~action args
+  in
   let expected_version = get_int_opt args "expected_version" in
   let force_raw = get_bool args "force" false in
   (* force=true requires admin privilege: initial_admin or Admin role *)

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -695,6 +695,87 @@ let () = test "handle_transition_release_prefers_notes_then_reason_for_synthesis
   | _ -> failwith "expected exactly one task"
 )
 
+(* Regression: 2026-05-17 nick0cave production case. masc_transition with
+   action=claim/start does not require [handoff_context.summary]; the LLM
+   has nothing to summarize at work entry. Previously the parser rejected
+   any empty summary regardless of action, which broke entry-class
+   transitions when the keeper did not invent a placeholder. *)
+let () = test "handle_transition_claim_does_not_require_summary" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ =
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [ ("title", `String "Entry-class action") ])
+  in
+  let result =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc
+        [
+          ("task_id", `String "task-001");
+          ("action", `String "claim");
+        ])
+  in
+  if not result.Tool_result.success then
+    failwith
+      ("claim must succeed without handoff_context.summary: "
+       ^ result.Tool_result.legacy_message)
+)
+
+let () = test "handle_transition_claim_with_empty_handoff_context_ok" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ =
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [ ("title", `String "Entry with empty context") ])
+  in
+  let result =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc
+        [
+          ("task_id", `String "task-001");
+          ("action", `String "claim");
+          (* Empty handoff_context object: keeper sent the shape but no
+             content. Entry-class action treats this as absent, not as
+             an error. *)
+          ("handoff_context", `Assoc [ ("summary", `String "") ]);
+        ])
+  in
+  if not result.Tool_result.success then
+    failwith
+      ("claim with empty handoff_context.summary must succeed: "
+       ^ result.Tool_result.legacy_message)
+)
+
+let () = test "handle_transition_done_still_requires_summary" (fun () ->
+  (* Exit-class action [done] keeps the strict summary contract.
+     Regression guard: the entry-class relaxation above must not leak
+     into exit-class actions. *)
+  let ctx = make_test_ctx () in
+  let _ =
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc
+        [
+          ("title", `String "Strict done task");
+          ("contract", `Assoc [ ("strict", `Bool true) ]);
+        ])
+  in
+  let _ =
+    Tool_task.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [ ("task_id", `String "task-001") ])
+  in
+  let result =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc
+        [
+          ("task_id", `String "task-001");
+          ("action", `String "done");
+          ("handoff_context", `Assoc [ ("summary", `String "") ]);
+        ])
+  in
+  assert (not result.Tool_result.success);
+  assert
+    (str_contains result.Tool_result.legacy_message
+       "handoff_context.summary is required for action=done")
+)
+
 let () = test "handle_transition_release_empty_summary_error_includes_example" (fun () ->
   let ctx = make_test_ctx () in
   let _ =


### PR DESCRIPTION
## Summary

Production case **2026-05-17 16:04:16Z** — keeper `nick0cave` failed `masc_transition(action=claim)` because `handoff_context.summary` was empty. `claim` is a work-entry action; the LLM has nothing to summarize at entry, so requiring a summary forces it to invent one (degrading audit signal) or fail entirely.

This PR makes `handoff_context.summary` required **only for exit-class actions**, where summary is the contract's outcome evidence.

## Root cause analysis

`parse_handoff_context` was action-agnostic — same all-or-nothing strictness for every `task_action`. The 2026-04-18 "synthesize_summary_from_siblings" fix (memory `handoff-2026-04-18-masc-tool-failure-investigation.md`) added a `notes`/`reason` fallback path but did **not** address the underlying contract shape. Per `instructions/software-development.md §AI 페어 프로그래밍 검증 규칙` rule #2 ("2번째 fix → 근본 수정"), this is the rooted fix.

## Contract split

```ocaml
let transition_action_requires_summary : Masc_domain.task_action -> bool =
  function
  | Done_action | Cancel | Release
  | Submit_for_verification | Submit_pr_evidence
  | Approve_verification | Reject_verification ->
    true   (* exit-class: summary is outcome evidence *)
  | Claim | Start ->
    false  (* entry-class: nothing to summarize yet *)
```

Exhaustive over `Masc_domain.task_action`. Adding a new variant forces a compile-time decision here — no runtime permissive default (per `instructions/software-development.md` Unknown→Permissive Default anti-pattern).

## What changes

- `parse_handoff_context` takes `~action : Masc_domain.task_action`
- Two call sites updated: `handle_release` (always `Release`), `handle_transition` (uses parsed action)
- Empty `handoff_context.summary` + entry-class action → `Ok None` (treated as absent, not error)
- Empty `handoff_context.summary` + exit-class action → existing strict error, now names the action: *"handoff_context.summary is required for action=done"*

## Tests (regression guards)

3 new tests in `test/test_tool_task_coverage.ml`:

| Test | Expectation |
|---|---|
| `handle_transition_claim_does_not_require_summary` | `action=claim` without `handoff_context` → ok |
| `handle_transition_claim_with_empty_handoff_context_ok` | `action=claim` + `handoff_context.summary=""` → ok (treated as absent) |
| `handle_transition_done_still_requires_summary` | `action=done` + empty summary → fails with action-named error |

Existing release-class tests preserved — error message still contains `"handoff_context.summary is required"` as substring.

## Trade-offs

- **No new tooling**: this is pure contract refinement. No new prompt guidance, no telemetry-as-fix, no string-classifier add.
- **`Start` is entry-class even though the task may be partially worked**: a `start` transition signals work *beginning*, not *progress*. Mid-work updates use other mechanisms (heartbeat, plan_update). If `Start` ever evolves to require summary, the exhaustive match here forces the decision.
- **Existing 2026-04-18 sibling-synthesis fallback retained** as a secondary path for callers who do provide `notes`/`reason` at exit-class — defense in depth, not the primary contract.

## Verification

- Local `dune build @check` not run (cross-worktree dune-project collision in shared `~/me`). **CI Build will gate.**
- Test additions follow existing `test_tool_task_coverage.ml` shape.

## Related

- Production failure logged 2026-05-17 16:04:16Z (`keeper:nick0cave`)
- Prior partial fix: `lib/tool_task.ml:362-392` `synthesize_summary_from_siblings` (2026-04-18)
- Memory `handoff-2026-04-18-masc-tool-failure-investigation.md`
- `instructions/software-development.md §AI 페어 프로그래밍 검증 규칙` rule #2 (2nd-fix root-fix mandate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)