### PR TITLE
test(cascade): cover max_tokens clamp source tuple diagnostics

### DIFF
--- a/lib/cascade_inference.ml
+++ b/lib/cascade_inference.ml
@@ -130,7 +130,36 @@ let cap_auto_resolved_max_tokens ~cascade_name ~source max_tokens =
     ceiling
   | _ -> max_tokens
 
-(** Resolve a max_tokens value: cascade config -> capped fallback. *)
+let explicit_max_tokens_exceeds_seen : (string, unit) Hashtbl.t =
+  Hashtbl.create 16
+let explicit_max_tokens_exceeds_mutex = Mutex.create ()
+
+let explicit_max_tokens_exceeds_key ~cascade_name ~max_tokens ~ceiling =
+  Printf.sprintf
+    "%s\x1f%d\x1f%d"
+    (Keeper_cascade_profile.runtime_name_to_string cascade_name)
+    max_tokens
+    ceiling
+
+let should_log_explicit_max_tokens_exceeds ~cascade_name ~max_tokens ~ceiling =
+  let key = explicit_max_tokens_exceeds_key ~cascade_name ~max_tokens ~ceiling in
+  Mutex.protect explicit_max_tokens_exceeds_mutex (fun () ->
+    if Hashtbl.mem explicit_max_tokens_exceeds_seen key
+    then false
+    else (
+      Hashtbl.replace explicit_max_tokens_exceeds_seen key ();
+      true))
+
+(** Resolve a max_tokens value: cascade config -> capped fallback.
+
+    Source diagnosis (2026-05-17): when the cascade catalog returns an
+    explicit [max_tokens] that exceeds the narrowest member ceiling, the
+    downstream [validate_max_tokens_within_ceiling] hard-rejects with
+    [Max_tokens_ceiling_violation] *before* any tier failover runs. Earlier
+    revisions had no log between the explicit value and the hard-fail, so
+    operators saw the typed error but not which cascade catalog entry
+    produced the over-ceiling value. The dedup'd warn below makes that
+    source visible without changing behavior; the validator still hard-fails. *)
 let resolve_max_tokens
     ~(cascade_name : Keeper_cascade_profile.runtime_name)
     ~(fallback : unit -> int) : int =
@@ -138,7 +167,24 @@ let resolve_max_tokens
     Keeper_cascade_profile.runtime_name_to_string cascade_name
   in
   match (for_cascade ~name:cascade_name_string).max_tokens with
-  | Some t -> t
+  | Some t ->
+    (match
+       Cascade_runtime.max_output_tokens_ceiling_of_cascade_name cascade_name
+     with
+     | Some ceiling when ceiling > 0 && t > ceiling ->
+       if should_log_explicit_max_tokens_exceeds
+            ~cascade_name ~max_tokens:t ~ceiling
+       then
+         Log.warn ~ctx:"cascade"
+           "%s: explicit max_tokens=%d from cascade catalog inference_params \
+            exceeds narrowest member ceiling=%d; pre-dispatch validator will \
+            hard-fail (Max_tokens_ceiling_violation); fix by lowering the \
+            cascade catalog max_tokens or by splitting the tier so that the \
+            narrowest member matches the request; suppressing repeats for \
+            this tuple"
+           cascade_name_string t ceiling
+     | _ -> ());
+    t
   | None ->
     cap_auto_resolved_max_tokens ~cascade_name ~source:"fallback" (fallback ())
 
@@ -182,4 +228,11 @@ module For_testing = struct
 
   let should_log_auto_max_tokens_clamp =
     should_log_auto_max_tokens_clamp
+
+  let reset_explicit_max_tokens_exceeds_warnings () =
+    Mutex.protect explicit_max_tokens_exceeds_mutex (fun () ->
+      Hashtbl.clear explicit_max_tokens_exceeds_seen)
+
+  let should_log_explicit_max_tokens_exceeds =
+    should_log_explicit_max_tokens_exceeds
 end

--- a/lib/cascade_inference.mli
+++ b/lib/cascade_inference.mli
@@ -72,4 +72,12 @@ module For_testing : sig
     max_tokens:int ->
     ceiling:int ->
     bool
+
+  val reset_explicit_max_tokens_exceeds_warnings : unit -> unit
+
+  val should_log_explicit_max_tokens_exceeds :
+    cascade_name:Keeper_cascade_profile.runtime_name ->
+    max_tokens:int ->
+    ceiling:int ->
+    bool
 end

--- a/test/test_cascade_capability_gate.ml
+++ b/test/test_cascade_capability_gate.ml
@@ -243,6 +243,41 @@ let test_auto_max_tokens_clamp_warning_dedupes_by_tuple () =
        ~max_tokens:65536
        ~ceiling:8192)
 
+let test_explicit_max_tokens_exceeds_warning_dedupes_by_tuple () =
+  CI.For_testing.reset_explicit_max_tokens_exceeds_warnings ();
+  check
+    bool
+    "first tuple logs"
+    true
+    (CI.For_testing.should_log_explicit_max_tokens_exceeds
+       ~cascade_name
+       ~max_tokens:16384
+       ~ceiling:8192);
+  check
+    bool
+    "same tuple suppressed"
+    false
+    (CI.For_testing.should_log_explicit_max_tokens_exceeds
+       ~cascade_name
+       ~max_tokens:16384
+       ~ceiling:8192);
+  check
+    bool
+    "different ceiling logs"
+    true
+    (CI.For_testing.should_log_explicit_max_tokens_exceeds
+       ~cascade_name
+       ~max_tokens:16384
+       ~ceiling:4096);
+  check
+    bool
+    "different max_tokens logs"
+    true
+    (CI.For_testing.should_log_explicit_max_tokens_exceeds
+       ~cascade_name
+       ~max_tokens:32768
+       ~ceiling:8192)
+
 let test_resolve_provider_derived_max_tokens_matches_failover_ceiling () =
   with_temp_cascade_toml
     {|
@@ -358,6 +393,10 @@ let () =
         "automatic max_tokens clamp warning dedupes by tuple"
         `Quick
         test_auto_max_tokens_clamp_warning_dedupes_by_tuple;
+      test_case
+        "explicit max_tokens exceeds ceiling warning dedupes by tuple"
+        `Quick
+        test_explicit_max_tokens_exceeds_warning_dedupes_by_tuple;
       test_case
         "provider-derived max_tokens matches failover ceiling"
         `Quick


### PR DESCRIPTION
# fix(cascade): instrument explicit max_tokens > ceiling for source identification

## What

`lib/cascade_inference.ml:resolve_max_tokens` 의 *explicit path*
(`(for_cascade ~name).max_tokens = Some t`) 진입 시점에 dedup'd warn
log 추가. 이미 narrowest member ceiling 을 초과한 explicit 값이
하류 `validate_max_tokens_within_ceiling` 의 `Max_tokens_ceiling_violation`
hard-fail 전에 *operator-visible* 하게 emit 된다.

**행위 무변경** — hard-fail 그대로 유지, clamp 하지 않음.

## Why

오늘 (2026-05-17) 보고된 prod error:

```
{"kind":"max_tokens_ceiling_violation",
 "cascade_name":"tier-group.strict_tool_candidates",
 "requested_max_tokens":16384,
 "provider_ceiling":8192,
 "reason":"requested_exceeds_provider_ceiling"}
```

`tier-group.strict_tool_candidates` 의 narrowest member ceiling 은
`min(qwen36-35b-a3b-mtp=8192, qwen36-35b-a3b-mtp-local=8192,
glm-coding.glm-5-1=16384, glm-coding.glm-5-turbo=16384,
glm-coding.glm-5=32768, ...)` = **8192** (`cascade_runtime.ml:621-625`).

Explicit `max_tokens=16384` 의 source 가 어디인지 즉시 확인 가능한
log 없음:

- cascade.toml 의 `[cascade.X] max_tokens =` 명시 0건
- keeper config 의 max_tokens override 0건
- 즉 source 는 `Cascade_catalog_runtime.resolve_inference_params` 가
  반환하는 `profile.inference_params.max_tokens` — runtime catalog
  build 경로

기존 `cap_auto_resolved_max_tokens` (line 119-130) 는 *auto-resolved*
path 에서 warn + silent clamp 한다. *explicit* path 는 warn 없이
즉시 hard-fail. log gap 메움.

## Pre-dispatch hard-fail 의 비대칭 효과

- pre-dispatch validation 의 hard-fail = **tier failover trigger 도 안 됨**
- `validate_max_tokens_within_ceiling` 은 *narrowest member ceiling 8192*
  하나만 보고 fail → glm-coding.glm-5 (32768) 같은 member 가 *시도조차
  안 됨*
- evidence: nick0cave keeper turn 665 (2026-05-17 04:11Z) 는
  `completion_contract_violation:require_tool_use` 로 fail 후 자동
  failover (`tier-group.glm-coding-with-spark`, `routing_reason:"failing
  phase: cheap local recovery"`) 됐음. 즉 *post-dispatch* failure 는
  failover 작동. *pre-dispatch* validator 만 fail-everything.

본 PR 은 *log only* — failover semantic 변경은 별도 RFC 영역. 다만 이
log 가 source 식별하여 별도 RFC 의 motivation 명확화.

## 변경

| 파일 | 변경 |
|---|---|
| `lib/cascade_inference.ml` | `resolve_max_tokens` explicit path 에 ceiling check + dedup'd warn log. `should_log_explicit_max_tokens_exceeds` helper + state hashtable + mutex (auto path 의 `should_log_auto_max_tokens_clamp` pattern 그대로) |
| `lib/cascade_inference.mli` | `For_testing.reset_explicit_max_tokens_exceeds_warnings` + `should_log_explicit_max_tokens_exceeds` 노출 |
| `test/test_cascade_capability_gate.ml` | `test_explicit_max_tokens_exceeds_warning_dedupes_by_tuple` 추가 — 4 case (first/same-suppressed/diff-ceiling/diff-max_tokens) |

총 ~50 LoC.

## 검증

- `scripts/dune-local.sh build --root .` clean
- `scripts/dune-local.sh build test/test_cascade_capability_gate.exe --root .` clean
- `dune exec test/test_cascade_capability_gate.exe --root .` 통과 (4 신규 case 포함)

## Workaround rejection bar (self-check)

- [x] **Telemetry-as-fix 경계 line case**: 본 PR 은 *fix 가 아니라 source
  identification instrumentation*. error 자체 (Max_tokens_ceiling_violation
  hard-fail) 는 *typed boundary 가 정상 작동* 중이고 fix 가 아님. log 는
  *root cause 식별 단계* 의 *diagnosis enabler* — 다음 RFC 의 motivation.
  fix 와 log 를 *섞지 않음* (행위 무변경).
- [x] Not string/substring classifier
- [x] Not N-of-M
- [x] No catch-all
- [x] No cap/cooldown — 기존 hard-fail 유지

## Follow-up

| Topic | 상태 |
|---|---|
| Startup-time validator (모든 cascade iterate + ceiling 검증) | 별도 PR (이 PR 의 log 출력이 후속 PR 의 fix target 식별) |
| Resolution semantic (group min ceiling → per-attempt ceiling) | RFC 후보, 큰 변경 |
| `completion_contract_violation:require_tool_use` (nick0cave 4:11Z) | 별개 issue, 별도 PR |

RFC-WAIVED: cascade lib 영역 (keeper sandbox / credential / operator / dashboard / hooks 무수정). 본 PR 은 행위 무변경 log only.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
