### PR TITLE
fix(keeper): split required-tool route failures

### DIFF
--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -229,6 +229,7 @@ function blockerSourceLabel(source: GoalTreeNode['blocking_source']): string {
 function humanizeBlockingReason(reason: string): string {
   switch (reason) {
     case 'tool_required_unsatisfied': return '필요한 도구가 충족되지 않음'
+    case 'tool_route_recoverable_failure': return '도구 라우팅 복구 필요'
     case 'degraded_retry': return '재시도 중 (성능 저하)'
     case 'reaction_chain_break': return '반응 체인 단절'
     case 'awaiting_verification': return '검증 대기'

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -417,6 +417,7 @@ type operator_disposition_reason =
   | Reason_provider_runtime_error
   | Reason_internal_error
   | Reason_tool_required_unsatisfied
+  | Reason_tool_route_recoverable_failure
   | Reason_turn_livelock_blocked
   | Reason_cancelled
   | Reason_phase_skipped
@@ -431,6 +432,7 @@ let operator_disposition_reason_to_string = function
   | Reason_provider_runtime_error -> "provider_runtime_error"
   | Reason_internal_error -> "internal_error"
   | Reason_tool_required_unsatisfied -> "tool_required_unsatisfied"
+  | Reason_tool_route_recoverable_failure -> "tool_route_recoverable_failure"
   | Reason_turn_livelock_blocked -> "turn_livelock_blocked"
   | Reason_cancelled -> "cancelled"
   | Reason_phase_skipped -> "phase_skipped"
@@ -512,7 +514,7 @@ let operator_disposition (receipt : t)
     | Some "internal" -> true
     | Some _ | None -> false
   then Disp_pause_human, Reason_internal_error
-  else if
+  else
     let canonical_names names =
       names
       |> List.map Keeper_tool_disclosure.canonical_tool_name
@@ -544,63 +546,81 @@ let operator_disposition (receipt : t)
       && receipt.tool_contract_result = Contract_needs_execution_progress
       && (required_tools_satisfied || generic_claim_context_progress)
     in
-    receipt.tool_surface.tool_requirement = Required
-    && (List.mem
-          receipt.tool_contract_result
-          [ Contract_violated
-          ; Contract_unknown
-          ; Contract_needs_execution_progress
-          ; Contract_missing_required_tool_use
-          ; Contract_passive_only
-          ; Contract_claim_only_after_owned_task
-          ; Contract_tool_surface_mismatch
-          ; Contract_no_tool_capable_provider
-          ]
-        || receipt.tools_used = [])
-    && not ok_followup_progress
-  then Disp_pause_human, Reason_tool_required_unsatisfied
-  else if receipt.degraded_retry_applied || Option.is_some receipt.degraded_retry_cascade
-  then Disp_fail_open_next_cascade, Reason_degraded_retry
-  else if
-    receipt.cascade_fallback_applied
-    || receipt.cascade_outcome = Cascade_passed_to_next_model
-  then Disp_pass_next_model, Reason_cascade_fallback
-  (* "healthy" requires an explicit success signal: turn completed without
-     error AND cascade reached the configured terminal. Any other fallthrough
-     is an unmapped state — surface it as "unknown" so a new cascade_outcome
-     or terminal_reason_code does not silently display as "healthy" on the
-     dashboard. See #9900 and CLAUDE.md anti-pattern #2.
+    let required_tool_contract_unsatisfied =
+      receipt.tool_surface.tool_requirement = Required
+      && (List.mem
+            receipt.tool_contract_result
+            [ Contract_violated
+            ; Contract_unknown
+            ; Contract_needs_execution_progress
+            ; Contract_missing_required_tool_use
+            ; Contract_passive_only
+            ; Contract_claim_only_after_owned_task
+            ; Contract_tool_surface_mismatch
+            ; Contract_no_tool_capable_provider
+            ]
+          || receipt.tools_used = [])
+      && not ok_followup_progress
+    in
+    let required_tool_route_failure =
+      List.mem
+        receipt.tool_contract_result
+        [ Contract_tool_surface_mismatch; Contract_no_tool_capable_provider ]
+    in
+    if required_tool_contract_unsatisfied && required_tool_route_failure
+    then
+      if receipt.degraded_retry_applied || Option.is_some receipt.degraded_retry_cascade
+      then Disp_fail_open_next_cascade, Reason_tool_route_recoverable_failure
+      else if
+        receipt.cascade_fallback_applied
+        || receipt.cascade_outcome = Cascade_passed_to_next_model
+      then Disp_pass_next_model, Reason_tool_route_recoverable_failure
+      else Disp_pause_human, Reason_tool_route_recoverable_failure
+    else if required_tool_contract_unsatisfied
+    then Disp_pause_human, Reason_tool_required_unsatisfied
+    else if
+      receipt.degraded_retry_applied || Option.is_some receipt.degraded_retry_cascade
+    then Disp_fail_open_next_cascade, Reason_degraded_retry
+    else if
+      receipt.cascade_fallback_applied
+      || receipt.cascade_outcome = Cascade_passed_to_next_model
+    then Disp_pass_next_model, Reason_cascade_fallback
+    (* "healthy" requires an explicit success signal: turn completed without
+       error AND cascade reached the configured terminal. Any other fallthrough
+       is an unmapped state — surface it as "unknown" so a new cascade_outcome
+       or terminal_reason_code does not silently display as "healthy" on the
+       dashboard. See #9900 and CLAUDE.md anti-pattern #2.
 
-     Cancelled is split out from the legacy binary outcome so dashboards
-     and replay decoders can distinguish a user-initiated cancellation
-     from a true failure. Skipped corresponds to the TLA+ [PhaseGateSkip]
-     action: a turn that intentionally never dispatched, so cascade
-     never engaged. It is a successful no-op rather than a failure or
-     an unmapped state. Spec parity with [ReceiptOutcomeSet] in
-     [specs/keeper-turn-fsm/KeeperTurnFSM.tla]. *)
-  else (
-    match receipt.outcome with
-    | `Cancelled -> Disp_user_cancelled, Reason_cancelled
-    | `Skipped -> Disp_skipped, Reason_phase_skipped
-    | `Ok when receipt.cascade_outcome = Cascade_completed -> Disp_pass, Reason_healthy
-    | _ ->
-      Prometheus.inc_counter Keeper_metrics.metric_keeper_receipt_unmapped_disposition ();
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_execution_receipt_failures
-        ~labels:[ "keeper", receipt.keeper_name; "site", Keeper_execution_receipt_failure_site.(to_label Unmapped_disposition) ]
-        ();
-      Log.Keeper.warn
-        "operator_disposition: unmapped (outcome=%s cascade_outcome=%s \
-         terminal_reason=%s tool_contract_result=%s error_kind=%s) — investigate \
-         regression of #11651 silent-path fix"
-        (outcome_kind_to_string receipt.outcome)
-        (cascade_outcome_to_string receipt.cascade_outcome)
-        terminal_reason
-        (tool_contract_result_to_string receipt.tool_contract_result)
-        (Option.value
-           (Option.map error_kind_to_string receipt.error_kind)
-           ~default:"<none>");
-      Disp_unknown, Reason_unmapped_cascade_state)
+       Cancelled is split out from the legacy binary outcome so dashboards
+       and replay decoders can distinguish a user-initiated cancellation
+       from a true failure. Skipped corresponds to the TLA+ [PhaseGateSkip]
+       action: a turn that intentionally never dispatched, so cascade
+       never engaged. It is a successful no-op rather than a failure or
+       an unmapped state. Spec parity with [ReceiptOutcomeSet] in
+       [specs/keeper-turn-fsm/KeeperTurnFSM.tla]. *)
+    else (
+      match receipt.outcome with
+      | `Cancelled -> Disp_user_cancelled, Reason_cancelled
+      | `Skipped -> Disp_skipped, Reason_phase_skipped
+      | `Ok when receipt.cascade_outcome = Cascade_completed -> Disp_pass, Reason_healthy
+      | _ ->
+        Prometheus.inc_counter Keeper_metrics.metric_keeper_receipt_unmapped_disposition ();
+        Prometheus.inc_counter
+          Keeper_metrics.metric_keeper_execution_receipt_failures
+          ~labels:[ "keeper", receipt.keeper_name; "site", Keeper_execution_receipt_failure_site.(to_label Unmapped_disposition) ]
+          ();
+        Log.Keeper.warn
+          "operator_disposition: unmapped (outcome=%s cascade_outcome=%s \
+           terminal_reason=%s tool_contract_result=%s error_kind=%s) — investigate \
+           regression of #11651 silent-path fix"
+          (outcome_kind_to_string receipt.outcome)
+          (cascade_outcome_to_string receipt.cascade_outcome)
+          terminal_reason
+          (tool_contract_result_to_string receipt.tool_contract_result)
+          (Option.value
+             (Option.map error_kind_to_string receipt.error_kind)
+             ~default:"<none>");
+        Disp_unknown, Reason_unmapped_cascade_state)
 ;;
 
 let to_json (receipt : t) =

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -245,6 +245,7 @@ type operator_disposition_reason =
   | Reason_provider_runtime_error
   | Reason_internal_error
   | Reason_tool_required_unsatisfied
+  | Reason_tool_route_recoverable_failure
   | Reason_turn_livelock_blocked
   | Reason_cancelled
   | Reason_phase_skipped

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -151,8 +151,11 @@ let terminal_reason_from_receipt receipt =
     match operator_disposition, operator_disposition_reason, tool_contract_result with
     | Some "pause_human", Some "tool_required_unsatisfied", _
     | _, Some "tool_required_unsatisfied", _
+    | _, Some "tool_route_recoverable_failure", _
     | _, _, Some "needs_execution_progress"
     | _, _, Some "missing_required_tool_use"
+    | _, _, Some "tool_surface_mismatch"
+    | _, _, Some "no_tool_capable_provider"
     | _, _, Some "passive_only"
     | _, _, Some "violated" ->
         true

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -1108,7 +1108,7 @@ let composite_execution_tool_required execution =
     ]
   || string_opt_is_any
        (json_string "operator_disposition_reason" execution)
-       [ "tool_required_unsatisfied" ]
+       [ "tool_required_unsatisfied"; "tool_route_recoverable_failure" ]
 ;;
 
 let composite_execution_config_blocked execution =

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -115,26 +115,71 @@ let check_disp label receipt expected_disp expected_reason =
     (R.operator_disposition_reason_to_string reason)
 ;;
 
-(* === Bug class: tool_contract_result violations must pause_human ====== *)
+(* === Bug class: required-tool failures must keep route failures distinct == *)
 
-let violation_variants : (string * R.tool_contract_result) list =
+let human_required_violation_variants : (string * R.tool_contract_result) list =
   [ "violated", Contract_violated
   ; "unknown", Contract_unknown
   ; "needs_execution_progress", Contract_needs_execution_progress
   ; "missing_required_tool_use", Contract_missing_required_tool_use
   ; "passive_only", Contract_passive_only
   ; "claim_only_after_owned_task", Contract_claim_only_after_owned_task
-  ; "tool_surface_mismatch", Contract_tool_surface_mismatch
+  ]
+;;
+
+let route_failure_variants : (string * R.tool_contract_result) list =
+  [ "tool_surface_mismatch", Contract_tool_surface_mismatch
   ; "no_tool_capable_provider", Contract_no_tool_capable_provider
   ]
 ;;
 
-let test_pause_human_for_each_violation () =
+let test_pause_human_for_each_human_required_violation () =
   List.iter
     (fun (label, v) ->
        let r = mk_receipt ~tool_contract_result:v () in
        check_disp ("violation:" ^ label) r "pause_human" "tool_required_unsatisfied")
-    violation_variants
+    human_required_violation_variants
+;;
+
+let test_route_failure_uses_recoverable_reason () =
+  List.iter
+    (fun (label, v) ->
+       let r = mk_receipt ~tool_contract_result:v () in
+       check_disp
+         ("route_failure:" ^ label)
+         r
+         "pause_human"
+         "tool_route_recoverable_failure")
+    route_failure_variants
+;;
+
+let test_route_failure_passes_next_when_fallback_available () =
+  let r =
+    mk_receipt
+      ~cascade_fallback_applied:true
+      ~cascade_outcome:R.Cascade_passed_to_next_model
+      ~tool_contract_result:Contract_tool_surface_mismatch
+      ()
+  in
+  check_disp
+    "route_failure fallback"
+    r
+    "pass_next_model"
+    "tool_route_recoverable_failure"
+;;
+
+let test_route_failure_fail_open_when_degraded_retry_available () =
+  let r =
+    mk_receipt
+      ~degraded_retry_applied:true
+      ~tool_contract_result:Contract_no_tool_capable_provider
+      ()
+  in
+  check_disp
+    "route_failure degraded"
+    r
+    "fail_open_next_cascade"
+    "tool_route_recoverable_failure"
 ;;
 
 let test_pause_human_when_no_tools_used () =
@@ -660,9 +705,21 @@ let () =
     "keeper_pause_broadcast"
     [ ( "operator_disposition"
       , [ test_case
-            "all 8 contract violations -> pause_human"
+            "human required contract violations -> pause_human"
             `Quick
-            test_pause_human_for_each_violation
+            test_pause_human_for_each_human_required_violation
+        ; test_case
+            "route/tool-surface failures keep recoverable reason"
+            `Quick
+            test_route_failure_uses_recoverable_reason
+        ; test_case
+            "route/tool-surface fallback -> pass_next_model"
+            `Quick
+            test_route_failure_passes_next_when_fallback_available
+        ; test_case
+            "route/tool-surface degraded -> fail_open_next_cascade"
+            `Quick
+            test_route_failure_fail_open_when_degraded_retry_available
         ; test_case
             "tools_used=[] -> pause_human"
             `Quick


### PR DESCRIPTION
## Summary
- split tool route/surface failures out of the generic pause_human/tool_required_unsatisfied receipt reason
- preserve recoverable routing outcomes as pass_next_model/fail_open_next_cascade when fallback/degraded retry already exists
- keep dashboard/runtime attention surfaces recognizing the new tool_route_recoverable_failure reason

Fixes #15731

## Verification
- git diff --check origin/main
- opam exec -- ocamlformat --check lib/keeper/keeper_execution_receipt.ml lib/keeper/keeper_execution_receipt.mli lib/keeper/keeper_runtime_trust_snapshot.ml lib/server/server_dashboard_http.ml test/test_keeper_pause_broadcast.ml
- pnpm --dir dashboard exec tsc --noEmit --pretty false

## Not run locally
- scripts/dune-local.sh build test/test_keeper_pause_broadcast.exe test/test_dashboard_keeper_routes.exe test/test_dashboard_goals.exe was blocked by the shared /tmp/me-dune-local.lock queue; PR CI is the Dune verification surface.