### PR TITLE
fix(dashboard): label runtime blockers as blocked

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -927,7 +927,7 @@ describe('dashboard goals decoding', () => {
           latest_execution_at: '2026-04-23T00:10:00Z',
           latest_receipt: { outcome: 'completed' },
           runtime_trust: {
-            disposition: 'Pause',
+            disposition: 'Blocked',
             disposition_reason: 'approval_waiting',
             needs_attention: true,
             attention_reason: 'approval_pending',
@@ -1007,7 +1007,7 @@ describe('dashboard goals decoding', () => {
 
     expect(result.linked_keepers[0]).toMatchObject({
       runtime_trust: {
-        disposition: 'Pause',
+        disposition: 'Blocked',
         disposition_reason: 'approval_waiting',
         needs_attention: true,
         attention_reason: 'approval_pending',

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -470,7 +470,7 @@ describe('fleetCellPresentation', () => {
     expect(cell.className).toContain('var(--bad-light)')
     expect(cell.title).toContain('KSM Running')
     expect(cell.title).toContain('runtime 정체')
-    expect(cell.title).toContain('operator pause: tool_required_unsatisfied')
+    expect(cell.title).toContain('blocked: tool_required_unsatisfied')
   })
 
   it('keeps non-KSM lanes tied to their raw FSM state', () => {
@@ -517,7 +517,7 @@ describe('buildRuntimeAssistPrompt', () => {
 
     expect(prompt).toContain('감독형 런타임 진단 요청: blocked')
     expect(prompt).toContain('cause=')
-    expect(prompt).toContain('operator pause: tool_required_unsatisfied')
+    expect(prompt).toContain('blocked: tool_required_unsatisfied')
     expect(prompt).toContain('evidence=')
     expect(prompt).toContain('"turn_lane":"tool_required"')
     expect(prompt).toContain('"visible_tool_count":0')

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -406,8 +406,8 @@ function blockingCause(snapshot: KeeperCompositeSnapshot): string {
   if (execution.operator_disposition === 'pause_human') {
     parts.push(
       execution.operator_disposition_reason
-        ? `operator pause: ${execution.operator_disposition_reason}`
-        : 'operator pause requested',
+        ? `blocked: ${execution.operator_disposition_reason}`
+        : 'blocked by operator disposition',
     )
   }
   if (execution.tool_contract_result === 'missing_required_tool_use') {
@@ -449,7 +449,7 @@ function blockingNextStep(snapshot: KeeperCompositeSnapshot): string {
     return 'provider timeout budget/cascade lane 확인'
   }
   if (execution.operator_disposition === 'pause_human') {
-    return 'operator gate/approval 상태와 최신 receipt 확인'
+    return 'blocker gate/approval 상태와 최신 receipt 확인'
   }
   if (execution.terminal_reason_code && execution.terminal_reason_code !== 'completed') {
     return `terminal=${execution.terminal_reason_code} receipt 확인`

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -193,7 +193,7 @@ function healthLabel(health: GoalTreeNode['health']): string {
 
 function trustDispositionLabel(disposition: string | null | undefined): string | null {
   if (!disposition) return null
-  return ({ Alert: '경보', Pause: '정지', Pass: '통과' } as Record<string, string>)[
+  return ({ Alert: '경보', Blocked: '차단', Pause: '정지', Pass: '통과' } as Record<string, string>)[
     disposition
   ] ?? disposition
 }
@@ -316,7 +316,7 @@ function keeperTrustDispositionClass(
 ): string {
   const disposition = trust?.disposition
   if (disposition === 'Alert') return 'border-bad/25 bg-bad/10 text-bad'
-  if (disposition === 'Pause' || trust?.needs_attention) {
+  if (disposition === 'Blocked' || disposition === 'Pause' || trust?.needs_attention) {
     return 'border-warn/25 bg-warn/10 text-warn'
   }
   if (disposition === 'Pass') return 'border-ok/25 bg-ok/10 text-ok'

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -161,13 +161,13 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const trustToneClass =
     trustDisposition === 'Alert'
       ? 'bg-[var(--bad-soft)] text-[var(--color-status-err)]'
-      : trustDisposition === 'Pause' || keeper.trust?.needs_attention
+      : trustDisposition === 'Blocked' || trustDisposition === 'Pause' || keeper.trust?.needs_attention
         ? 'bg-[var(--warn-14)] text-[var(--color-status-warn)]'
         : trustDisposition === 'Pass'
           ? 'bg-[var(--ok-10)] text-[var(--color-status-ok)]'
           : 'bg-[var(--color-bg-hover)] text-[var(--color-fg-secondary)]'
   const trustDispositionLabel = trustDisposition
-    ? ({ Alert: '경보', Pause: '정지', Pass: '통과' } as Record<string, string>)[
+    ? ({ Alert: '경보', Blocked: '차단', Pause: '정지', Pass: '통과' } as Record<string, string>)[
         trustDisposition
       ] ?? trustDisposition
     : null

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -305,7 +305,7 @@ describe('KeeperDetailPage', () => {
         next_eligible_at_s: null,
       },
       trust: {
-        disposition: 'Pause',
+        disposition: 'Blocked',
         disposition_reason: 'tool_required_unsatisfied',
         needs_attention: true,
       },

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -318,7 +318,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
         name: 'trust-keeper',
         status: 'active',
         trust: {
-          disposition: 'Pause',
+          disposition: 'Blocked',
           disposition_reason: 'approval_waiting',
           needs_attention: true,
           attention_reason: 'approval_pending',
@@ -351,7 +351,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
     ])
 
     expect(keeper?.trust).toMatchObject({
-      disposition: 'Pause',
+      disposition: 'Blocked',
       disposition_reason: 'approval_waiting',
       needs_attention: true,
       attention_reason: 'approval_pending',
@@ -465,7 +465,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
         name: 'runtime-trust-keeper',
         status: 'active',
         runtime_trust: {
-          disposition: 'Pause',
+          disposition: 'Blocked',
           operator_disposition: 'pause_human',
           operator_disposition_reason: 'required_tool_use_unsatisfied',
           needs_attention: true,
@@ -497,7 +497,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
     ])
 
     expect(keeper?.trust).toMatchObject({
-      disposition: 'Pause',
+      disposition: 'Blocked',
       operator_disposition: 'pause_human',
       operator_disposition_reason: 'required_tool_use_unsatisfied',
       needs_attention: true,

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -296,7 +296,7 @@ let terminal_reason_requires_attention trust =
 
 let trust_disposition_requires_attention trust =
   match lowercase_json_string "disposition" trust with
-  | Some ("alert" | "pause") -> true
+  | Some ("alert" | "blocked" | "pause") -> true
   | _ -> false
 ;;
 
@@ -314,7 +314,7 @@ let keeper_queue_severity keeper trust =
      | _ ->
        (match lowercase_json_string "disposition" trust with
         | Some "alert" -> "bad"
-        | Some "pause" -> "warn"
+        | Some ("blocked" | "pause") -> "warn"
         | _ ->
           if Option.is_some (string_field_opt "runtime_blocker_class" keeper)
           then "bad"

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -38,7 +38,7 @@ let keeper_runtime_trust_snapshot_json ~config ~(meta : Keeper_types.keeper_meta
       let error = Printexc.to_string exn in
       `Assoc
         [
-          ("disposition", `String "Pause");
+          ("disposition", `String "Blocked");
           ("disposition_reason", `String "runtime_trust_snapshot_unavailable");
           ("needs_attention", `Bool true);
           ("attention_reason", `String "runtime_trust_snapshot_unavailable");

--- a/lib/dashboard/dashboard_goals_types.ml
+++ b/lib/dashboard/dashboard_goals_types.ml
@@ -686,15 +686,23 @@ let display_disposition_of_receipt_json receipt =
       ("Pass", "phase_skipped", operator_disposition, operator_disposition_reason)
   | "pass_next_model" ->
       ("Pass", "cascade_fallback", operator_disposition, operator_disposition_reason)
+  | "blocked" | "blocked_runtime" ->
+      ( "Blocked",
+        reason "runtime_blocked",
+        operator_disposition,
+        operator_disposition_reason )
   | "pause_human" ->
-      ( "Pause",
+      ( "Blocked",
         reason "needs_human_attention",
         operator_disposition,
         operator_disposition_reason )
   | "fail_open_next_cascade" ->
-      ("Pause", reason "degraded_retry", operator_disposition, operator_disposition_reason)
+      ( "Blocked",
+        reason "degraded_retry",
+        operator_disposition,
+        operator_disposition_reason )
   | "user_cancelled" ->
-      ("Pause", reason "cancelled", operator_disposition, operator_disposition_reason)
+      ("Blocked", reason "cancelled", operator_disposition, operator_disposition_reason)
   | "alert_exhausted" ->
       ("Alert", reason "cascade_exhausted", operator_disposition, operator_disposition_reason)
   | "unknown" ->
@@ -1054,6 +1062,7 @@ let runtime_trust_from_receipt_fallback ~config ~(meta : Keeper_types.keeper_met
   let severity =
     match disposition with
     | "Pass" -> "ok"
+    | "Blocked" -> "warn"
     | "Pause" -> "warn"
     | _ -> "bad"
   in
@@ -1358,7 +1367,7 @@ let rec build_tree context goals goal =
                  (match trust_attention_reason trust with
                   | Some _ as reason -> reason
                   | None -> trust_disposition_reason trust)
-             | Some "Pause" when trust_needs_attention trust ->
+             | Some ("Blocked" | "Pause") when trust_needs_attention trust ->
                  (match trust_attention_reason trust with
                   | Some _ as reason -> reason
                   | None -> trust_disposition_reason trust)
@@ -1464,7 +1473,7 @@ let rec build_tree context goals goal =
              else
                match trust_disposition trust with
                | Some "Alert" -> true
-               | Some "Pause" -> trust_needs_attention trust
+               | Some ("Blocked" | "Pause") -> trust_needs_attention trust
                | _ -> false)
            direct_runtime_trusts)
   in

--- a/lib/dashboard/dashboard_goals_types.mli
+++ b/lib/dashboard/dashboard_goals_types.mli
@@ -204,8 +204,9 @@ val goal_fsm_to_json :
 (** {1 Operator-disposition normalizer (pure)} *)
 
 (** [display_disposition_of_receipt_json receipt] returns
-    [(severity, reason, raw_disposition, raw_reason)] where [severity]
-    is one of "Pass" | "Pause" | "Alert". *)
+    [(disposition, reason, raw_disposition, raw_reason)] where [disposition]
+    is one of "Pass" | "Blocked" | "Alert". Legacy "Pause" payloads are
+    still accepted by downstream readers. *)
 val display_disposition_of_receipt_json :
   Yojson.Safe.t -> string * string * string * string
 

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -512,7 +512,7 @@ let to_oas_approval_callback ?config ~governance_level ~keeper_name ?meta ?clock
                ?goal_ids
                ?runtime_contract
                ?selected_model
-               ~disposition:"Pause"
+               ~disposition:"Blocked"
                ~disposition_reason:"waiting_approval"
                ~risk_level
                ?clock

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -668,8 +668,8 @@ let disposition_of_snapshot ~pending_approval_count ~runtime_blocker_fields =
   let blocker_summary =
     assoc_string_opt "runtime_blocker_summary" runtime_blocker_fields
   in
-  if pending_approval_count > 0 then ("Pause", "waiting_approval")
-  else if continue_gate then ("Pause", "waiting_human_decision")
+  if pending_approval_count > 0 then ("Blocked", "waiting_approval")
+  else if continue_gate then ("Blocked", "waiting_human_decision")
   else
     match blocker_class, blocker_summary with
     | Some "cascade_exhausted", _ -> ("Alert", "cascade_exhausted")
@@ -683,6 +683,7 @@ let disposition_of_snapshot ~pending_approval_count ~runtime_blocker_fields =
 let operator_disposition_of_display ~disposition ~disposition_reason =
   match disposition with
   | "Pass" -> ("pass", disposition_reason)
+  | "Blocked" -> ("pause_human", disposition_reason)
   | "Pause" -> ("pause_human", disposition_reason)
   | "Alert" -> ("alert_exhausted", disposition_reason)
   | _ -> ("pause_human", disposition_reason)
@@ -698,12 +699,17 @@ let display_disposition_of_operator ~operator_disposition
   | "pass" -> ("Pass", "healthy")
   | "skipped" -> ("Pass", "phase_skipped")
   | "pass_next_model" -> ("Pass", "cascade_fallback")
-  | "pause_human" -> ("Pause", reason "needs_human_attention")
-  | "fail_open_next_cascade" -> ("Pause", reason "degraded_retry")
-  | "user_cancelled" -> ("Pause", reason "cancelled")
+  | "blocked" | "blocked_runtime" -> ("Blocked", reason "runtime_blocked")
+  | "pause_human" -> ("Blocked", reason "needs_human_attention")
+  | "fail_open_next_cascade" -> ("Blocked", reason "degraded_retry")
+  | "user_cancelled" -> ("Blocked", reason "cancelled")
   | "alert_exhausted" -> ("Alert", reason "cascade_exhausted")
   | "unknown" -> ("Alert", reason "unmapped_cascade_state")
   | _ -> ("Alert", reason "unmapped_operator_disposition")
+
+let display_disposition_requires_attention = function
+  | "Blocked" | "Pause" | "Alert" -> true
+  | _ -> false
 
 let receipt_operator_disposition receipt =
   match
@@ -1151,8 +1157,7 @@ let summary_json ~(config : Coord.config) ~(meta : keeper_meta) =
   in
   let needs_attention =
     assoc_bool_default "needs_attention" ~default:false attention_fields
-    || String.equal disposition "Pause"
-    || String.equal disposition "Alert"
+    || display_disposition_requires_attention disposition
   in
   let attention_reason =
     attention_reason_or_disposition ~needs_attention ~disposition_reason
@@ -1336,8 +1341,7 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
   in
   let needs_attention =
     assoc_bool_default "needs_attention" ~default:false attention_fields
-    || String.equal disposition "Pause"
-    || String.equal disposition "Alert"
+    || display_disposition_requires_attention disposition
   in
   let attention_reason =
     attention_reason_or_disposition ~needs_attention ~disposition_reason

--- a/lib/keeper_fd_pressure.ml
+++ b/lib/keeper_fd_pressure.ml
@@ -141,7 +141,7 @@ let degraded_trust_json ?now () =
   `Assoc
     [ "disposition", `String "Degraded"
     ; "disposition_reason", `String "fd_pressure"
-    ; "operator_disposition", `String "Pause"
+    ; "operator_disposition", `String "blocked_runtime"
     ; "operator_disposition_reason", `String "fd_pressure"
     ; "needs_attention", `Bool true
     ; "attention_reason", `String "fd_pressure"

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -857,7 +857,7 @@ let test_goal_detail_uses_receipt_disposition_for_required_tool_failure () =
         | [] -> fail "expected linked keeper detail"
       in
       let runtime_trust = linked_keeper |> member "runtime_trust" in
-      check string "receipt-derived disposition pauses" "Pause"
+      check string "receipt-derived disposition blocks" "Blocked"
         (runtime_trust |> member "disposition" |> to_string);
       check string "receipt-derived reason surfaced"
         "tool_required_unsatisfied"
@@ -1096,7 +1096,7 @@ let test_goal_detail_derives_attention_from_receipt_disposition () =
       let terminal_reason =
         runtime_trust |> member "latest_terminal_reason"
       in
-      check string "receipt disposition pauses" "Pause"
+      check string "receipt disposition blocks" "Blocked"
         (runtime_trust |> member "disposition" |> to_string);
       check string "receipt disposition fills attention reason"
         "tool_required_unsatisfied"
@@ -1158,7 +1158,7 @@ let () =
           test_case "goal detail surfaces keeper runtime trust and blockers"
             `Quick
             test_goal_detail_surfaces_keeper_runtime_trust_and_blockers;
-          test_case "goal detail pauses on required tool receipt failure"
+          test_case "goal detail blocks on required tool receipt failure"
             `Quick
             test_goal_detail_uses_receipt_disposition_for_required_tool_failure;
           test_case "goal tree tolerates null decision telemetry" `Quick

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -466,7 +466,7 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
       Alcotest.(check bool) "attention surfaced" true
         (keeper |> member "needs_attention" |> to_bool);
       let trust = keeper |> member "runtime_trust" in
-      Alcotest.(check string) "trust disposition pauses" "Pause"
+      Alcotest.(check string) "trust disposition blocks" "Blocked"
         (trust |> member "disposition" |> to_string);
       Alcotest.(check string) "operator reason preserved"
         "tool_required_unsatisfied"


### PR DESCRIPTION
## Summary
- Rename runtime-trust blocked/receipt-driven display state from `Pause` to `Blocked`.
- Preserve legacy `Pause` input handling and keep real keeper/operator pause controls unchanged.
- Update dashboard labels, fleet blocker copy, and regression expectations.

## Validation
- `scripts/dune-local.sh build test/test_dashboard_goals.exe test/test_operator_control.exe test/test_keeper_registry.exe`
- `./_build/default/test/test_dashboard_goals.exe`
- `env MASC_INCLUDE_OPERATOR_CONTROL=true ./_build/default/test/test_operator_control.exe`
- `./_build/default/test/test_keeper_registry.exe`
- `pnpm exec vitest run --config vitest.config.ts src/keeper-store-normalize.test.ts src/api/dashboard.test.ts src/components/keeper-detail.test.ts src/components/fleet-fsm-matrix.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`