### PR TITLE
fix(mcp-ws): warn+counter on silent JSON parse drop (iter 28)

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -594,6 +594,10 @@ let metric_grpc_events_dropped = "masc_grpc_events_dropped_total"
 let metric_ws_sessions = "masc_ws_sessions_total"
 let metric_ws_parse_cache_hits = "masc_ws_parse_cache_hits_total"
 let metric_ws_parse_cache_misses = "masc_ws_parse_cache_misses_total"
+
+let metric_server_mcp_ws_frame_json_parse_failures =
+  "masc_server_mcp_ws_frame_json_parse_failures_total"
+;;
 let metric_ws_bytes_cache_hits = "masc_ws_bytes_cache_hits_total"
 let metric_ws_bytes_cache_misses = "masc_ws_bytes_cache_misses_total"
 let metric_ws_dashboard_hello_latency_seconds = "masc_ws_dashboard_hello_latency_seconds"
@@ -2890,6 +2894,12 @@ let init () =
   add
     metric_ws_parse_cache_misses
     "WS dashboard delta parse cache misses (fresh JSON parse required)"
+    Counter;
+  add
+    metric_server_mcp_ws_frame_json_parse_failures
+    "WebSocket transport incoming-frame JSON parse failures (frame dropped). \
+     Labels: error_kind={yojson_parse_error|other}. Iter 28 visibility \
+     fix for previously-silent drops in parse_sse_dashboard_event."
     Counter;
   add
     metric_ws_bytes_cache_hits

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -987,6 +987,12 @@ val metric_ws_parse_cache_misses : string
 val metric_ws_bytes_cache_hits : string
 val metric_ws_bytes_cache_misses : string
 
+(** Counter of WebSocket transport incoming-frame JSON parse failures.
+    Frame is dropped (parse_sse_dashboard_event returns None) but
+    operators now have a counter + warn log.
+    Labels: [error_kind = yojson_parse_error | other]. Iter 28. *)
+val metric_server_mcp_ws_frame_json_parse_failures : string
+
 (** Histogram of dashboard/hello JSON-RPC processing latency in seconds.
     Labels: [outcome = success | error]. *)
 val metric_ws_dashboard_hello_latency_seconds : string

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -550,7 +550,30 @@ let parse_sse_dashboard_event sse_event =
       | None -> None
       | Some json_body ->
         match Yojson.Safe.from_string json_body with
-        | exception _ -> None
+        | exception (Yojson.Json_error msg) ->
+            (* Iter 28: previously silently dropped — now emit a counter
+               and a warn with a size-bounded body preview so operators
+               can detect malformed frames from clients. Behavior is
+               preserved (still returns None). *)
+            let preview_len = min 200 (String.length json_body) in
+            Log.Server.warn
+              "[mcp-ws] dropping incoming frame: malformed JSON (%s); \
+               body_preview=%s"
+              msg
+              (String.sub json_body 0 preview_len);
+            Transport_metrics.inc_ws_frame_json_parse_failure
+              ~error_kind:"yojson_parse_error";
+            None
+        | exception Eio.Cancel.Cancelled e -> raise (Eio.Cancel.Cancelled e)
+        | exception exn ->
+            let preview_len = min 200 (String.length json_body) in
+            Log.Server.warn
+              "[mcp-ws] dropping incoming frame: %s; body_preview=%s"
+              (Printexc.to_string exn)
+              (String.sub json_body 0 preview_len);
+            Transport_metrics.inc_ws_frame_json_parse_failure
+              ~error_kind:"other";
+            None
         | `Assoc fields as event_json -> (
             match List.assoc_opt "type" fields with
             | Some (`String event_type) ->

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -143,6 +143,16 @@ let inc_ws_parse_cache_miss () =
   Prometheus.inc_counter Prometheus.metric_ws_parse_cache_misses ()
 ;;
 
+(** Iter 28 visibility fix — counter for previously-silent JSON parse
+    drops in parse_sse_dashboard_event. Closed 2-value error_kind
+    vocab keeps Prometheus label cardinality bounded. *)
+let inc_ws_frame_json_parse_failure ~error_kind =
+  Prometheus.inc_counter
+    Prometheus.metric_server_mcp_ws_frame_json_parse_failures
+    ~labels:[ "error_kind", error_kind ]
+    ()
+;;
+
 let inc_ws_bytes_cache_hit () =
   Prometheus.inc_counter Prometheus.metric_ws_bytes_cache_hits ()
 ;;

--- a/lib/transport_metrics.mli
+++ b/lib/transport_metrics.mli
@@ -187,6 +187,13 @@ val inc_ws_parse_cache_hit : unit -> unit
 (** Increments [masc_ws_parse_cache_misses_total]. *)
 val inc_ws_parse_cache_miss : unit -> unit
 
+(** Increments [masc_server_mcp_ws_frame_json_parse_failures_total] for a
+    silent-drop visibility event in [parse_sse_dashboard_event].
+    [error_kind] must be one of the closed vocab values
+    [{"yojson_parse_error"; "other"}] — keeps Prometheus cardinality
+    bounded. Iter 28. *)
+val inc_ws_frame_json_parse_failure : error_kind:string -> unit
+
 (** Increments [masc_ws_bytes_cache_hits_total]. *)
 val inc_ws_bytes_cache_hit : unit -> unit
 


### PR DESCRIPTION
## Summary

Iter 28 atomic root-fix for silent JSON parse drop in `lib/server/server_mcp_transport_ws.ml::parse_sse_dashboard_event`. The WebSocket transport caught `Yojson.Safe.from_string` exceptions with a bare `| exception _ -> None`, leaving operators with **no signal** when clients send malformed frames — making "why are some events lost?" undebuggable.

This mirrors the closure pattern from:
- **Iter 6**: memory_jsonl `parse_line` silent drop → counter + warn
- **Iter 21**: V07 `memory_recall` load_history silent exception → counter + warn

## Before / After

**Before** (`lib/server/server_mcp_transport_ws.ml:553`):
```ocaml
match Yojson.Safe.from_string json_body with
| exception _ -> None
| `Assoc fields as event_json -> ...
```

**After**:
```ocaml
match Yojson.Safe.from_string json_body with
| exception (Yojson.Json_error msg) ->
    let preview_len = min 200 (String.length json_body) in
    Log.Server.warn
      "[mcp-ws] dropping incoming frame: malformed JSON (%s); body_preview=%s"
      msg
      (String.sub json_body 0 preview_len);
    Transport_metrics.inc_ws_frame_json_parse_failure
      ~error_kind:"yojson_parse_error";
    None
| exception Eio.Cancel.Cancelled e -> raise (Eio.Cancel.Cancelled e)
| exception exn ->
    let preview_len = min 200 (String.length json_body) in
    Log.Server.warn
      "[mcp-ws] dropping incoming frame: %s; body_preview=%s"
      (Printexc.to_string exn)
      (String.sub json_body 0 preview_len);
    Transport_metrics.inc_ws_frame_json_parse_failure
      ~error_kind:"other";
    None
| `Assoc fields as event_json -> ...
```

## Cardinality Bound Argument

The `error_kind` Prometheus label is a **closed 2-value vocabulary**:
- `yojson_parse_error` (typed match on `Yojson.Json_error`)
- `other` (bounded terminal fallback)

This mirrors iter 21's cardinality discipline — no `Printexc`-as-label risk. The exception *message* is logged (variable text) but the *metric label* is fixed enum. Body preview is hard-bounded at 200 bytes via `String.sub … (min 200 (String.length …))` — no full-body logging to avoid leaking client payload.

`Eio.Cancel.Cancelled` is re-raised (destructure-and-rebuild form mirroring `lib/session.ml:350`, since `as e` is not allowed in `match | exception` position).

## Files Touched

| File | Change |
|---|---|
| `lib/prometheus.ml` | Add `metric_server_mcp_ws_frame_json_parse_failures` constant + registration |
| `lib/prometheus.mli` | Expose the metric name |
| `lib/transport_metrics.ml` | Add `inc_ws_frame_json_parse_failure ~error_kind` helper |
| `lib/transport_metrics.mli` | Expose helper with closed vocab in docstring |
| `lib/server/server_mcp_transport_ws.ml` | Replace `| exception _ -> None` with typed split |

Behavior preserved — still returns `None` on parse failure; the audit-style root-fix is **visibility** of previously-silent drops, matching the iter 6 / iter 21 closure pattern.

Build: `dune build --root . @check` clean.

## Anti-Pattern Self-Check (7/7)

1. **Telemetry-as-fix only?** — Partly. Counter+warn add visibility; behavior preserved (still returns `None`). Per iter 6/21 precedent, *visibility of silent drops* is the legitimate root-fix shape here. The drop itself is correct (malformed JSON cannot be dispatched); silence was the bug.
2. **String classifier?** — NO. Pattern match on exception constructor (`Yojson.Json_error`). Label is closed enum, not derived from message text.
3. **N-of-M?** — NO. Single emit site (the one `from_string` in this module).
4. **Catch-all added?** — Explicit terminal `| exception exn ->` with bounded `other` label. Eio.Cancel.Cancelled re-raise preserved before terminal. This is *narrower* than the prior `| exception _ -> None` and replaces it.
5. **Cap/cooldown/dedup/repair?** — NO.
6. **Test backdoor?** — NO.
7. **Repeat typo?** — NO.

## Cross-Reference

- Iter 6: memory_jsonl parse_line silent drop visibility (same pattern)
- Iter 21: V07 memory_recall load_history silent exception (same pattern, cardinality bound established)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
