### PR TITLE
feat(keeper): surface reaction ledger health

### DIFF
--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -283,3 +283,279 @@ let record_execution_receipt_reaction
 let read_recent_for_keeper ~base_path ~keeper_name ~limit =
   Dated_jsonl.read_recent (store_for_base_path ~base_path ~keeper_name) limit
 ;;
+
+let assoc_field name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+;;
+
+let string_field name json =
+  match assoc_field name json with
+  | Some (`String value) -> Some value
+  | _ -> None
+;;
+
+let float_field name json =
+  match assoc_field name json with
+  | Some (`Float value) -> Some value
+  | Some (`Int value) -> Some (float_of_int value)
+  | _ -> None
+;;
+
+let int_field name json =
+  match assoc_field name json with
+  | Some (`Int value) -> value
+  | _ -> 0
+;;
+
+let bool_field name json =
+  match assoc_field name json with
+  | Some (`Bool value) -> value
+  | _ -> false
+;;
+
+let nested_string_field outer inner json =
+  match assoc_field outer json with
+  | Some nested -> string_field inner nested
+  | None -> None
+;;
+
+let option_string_json = function
+  | Some value -> `String value
+  | None -> `Null
+;;
+
+let option_float_json = function
+  | Some value -> `Float value
+  | None -> `Null
+;;
+
+let summary_schema = "keeper.reaction_ledger.summary.v1"
+let fleet_summary_schema = "keeper.reaction_ledger.fleet_summary.v1"
+
+let cap_list limit values =
+  let rec loop remaining acc = function
+    | [] -> List.rev acc
+    | _ when remaining <= 0 -> List.rev acc
+    | value :: rest -> loop (remaining - 1) (value :: acc) rest
+  in
+  loop limit [] values
+;;
+
+let summarize_rows ~keeper_name ~limit rows =
+  let row_count = List.length rows in
+  let stimulus_count = ref 0 in
+  let reaction_count = ref 0 in
+  let turn_started_count = ref 0 in
+  let cursor_ack_count = ref 0 in
+  let execution_receipt_count = ref 0 in
+  let terminal_reason_count = ref 0 in
+  let operator_escalation_count = ref 0 in
+  let unknown_reaction_count = ref 0 in
+  let latest_recorded_at = ref None in
+  let latest_stimulus_id = ref None in
+  let stimulus_seen = Hashtbl.create 16 in
+  let stimulus_order = ref [] in
+  let remember_stimulus stimulus_id =
+    if not (Hashtbl.mem stimulus_seen stimulus_id) then begin
+      Hashtbl.add stimulus_seen stimulus_id false;
+      stimulus_order := stimulus_id :: !stimulus_order
+    end
+  in
+  let mark_reacted stimulus_id =
+    match Hashtbl.find_opt stimulus_seen stimulus_id with
+    | Some _ -> Hashtbl.replace stimulus_seen stimulus_id true
+    | None -> ()
+  in
+  let note_reaction_kind = function
+    | Some "turn_started" -> incr turn_started_count
+    | Some "cursor_ack" -> incr cursor_ack_count
+    | Some "execution_receipt" -> incr execution_receipt_count
+    | Some "terminal_reason" -> incr terminal_reason_count
+    | Some "operator_escalation" -> incr operator_escalation_count
+    | Some _ -> incr unknown_reaction_count
+    | None -> incr unknown_reaction_count
+  in
+  List.iter
+    (fun row ->
+      (match float_field "recorded_at_unix" row with
+       | Some value -> latest_recorded_at := Some value
+       | None -> ());
+      let stimulus_id = string_field "stimulus_id" row in
+      latest_stimulus_id := stimulus_id;
+      match string_field "record_kind" row, stimulus_id with
+      | Some "stimulus", Some id ->
+        incr stimulus_count;
+        remember_stimulus id
+      | Some "reaction", Some id ->
+        incr reaction_count;
+        note_reaction_kind (nested_string_field "reaction" "kind" row);
+        mark_reacted id
+      | Some "cursor_ack", Some id ->
+        incr reaction_count;
+        incr cursor_ack_count;
+        mark_reacted id
+      | Some "reaction", None ->
+        incr reaction_count;
+        note_reaction_kind (nested_string_field "reaction" "kind" row)
+      | Some "cursor_ack", None ->
+        incr reaction_count;
+        incr cursor_ack_count
+      | _ -> ())
+    rows;
+  let pending_stimulus_ids =
+    !stimulus_order
+    |> List.rev
+    |> List.filter (fun id ->
+      match Hashtbl.find_opt stimulus_seen id with
+      | Some false -> true
+      | Some true | None -> false)
+  in
+  let pending_stimulus_count = List.length pending_stimulus_ids in
+  let status =
+    if row_count = 0 then "empty"
+    else if pending_stimulus_count = 0 then "ok"
+    else "degraded"
+  in
+  `Assoc
+    [ "schema", `String summary_schema
+    ; "keeper_name", `String keeper_name
+    ; "status", `String status
+    ; "operator_action_required", `Bool (pending_stimulus_count > 0)
+    ; "scanned_row_limit", `Int limit
+    ; "row_count", `Int row_count
+    ; "stimulus_count", `Int !stimulus_count
+    ; "reaction_count", `Int !reaction_count
+    ; "turn_started_count", `Int !turn_started_count
+    ; "cursor_ack_count", `Int !cursor_ack_count
+    ; "execution_receipt_count", `Int !execution_receipt_count
+    ; "terminal_reason_count", `Int !terminal_reason_count
+    ; "operator_escalation_count", `Int !operator_escalation_count
+    ; "unknown_reaction_count", `Int !unknown_reaction_count
+    ; "pending_stimulus_count", `Int pending_stimulus_count
+    ; ( "pending_stimulus_ids"
+      , `List
+          (List.map
+             (fun value -> `String value)
+             (cap_list 8 pending_stimulus_ids)) )
+    ; "latest_recorded_at_unix", option_float_json !latest_recorded_at
+    ; "latest_stimulus_id", option_string_json !latest_stimulus_id
+    ; "read_error", `Null
+    ]
+;;
+
+let error_summary ~keeper_name ~limit error =
+  `Assoc
+    [ "schema", `String summary_schema
+    ; "keeper_name", `String keeper_name
+    ; "status", `String "unknown"
+    ; "operator_action_required", `Bool true
+    ; "scanned_row_limit", `Int limit
+    ; "row_count", `Int 0
+    ; "stimulus_count", `Int 0
+    ; "reaction_count", `Int 0
+    ; "turn_started_count", `Int 0
+    ; "cursor_ack_count", `Int 0
+    ; "execution_receipt_count", `Int 0
+    ; "terminal_reason_count", `Int 0
+    ; "operator_escalation_count", `Int 0
+    ; "unknown_reaction_count", `Int 0
+    ; "pending_stimulus_count", `Int 0
+    ; "pending_stimulus_ids", `List []
+    ; "latest_recorded_at_unix", `Null
+    ; "latest_stimulus_id", `Null
+    ; "read_error", `String error
+    ]
+;;
+
+let summary_for_keeper ~base_path ~keeper_name ~limit =
+  try
+    read_recent_for_keeper ~base_path ~keeper_name ~limit
+    |> summarize_rows ~keeper_name ~limit
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> error_summary ~keeper_name ~limit (Printexc.to_string exn)
+;;
+
+let summary_status json =
+  match string_field "status" json with
+  | Some value -> value
+  | None -> "unknown"
+;;
+
+let summary_read_error_count json =
+  match assoc_field "read_error" json with
+  | Some (`String _) -> 1
+  | _ -> 0
+;;
+
+let fleet_summary_json ~base_path ~keeper_names ~limit_per_keeper =
+  let keeper_names = List.sort_uniq String.compare keeper_names in
+  let summaries =
+    List.map
+      (fun keeper_name -> summary_for_keeper ~base_path ~keeper_name ~limit:limit_per_keeper)
+      keeper_names
+  in
+  let total_int name =
+    List.fold_left (fun acc summary -> acc + int_field name summary) 0 summaries
+  in
+  let pending_by_keeper =
+    List.filter_map
+      (fun summary ->
+        let pending_count = int_field "pending_stimulus_count" summary in
+        if pending_count = 0
+        then None
+        else
+          Some
+            (`Assoc
+               [ "keeper_name"
+               , (match string_field "keeper_name" summary with
+                  | Some value -> `String value
+                  | None -> `String "unknown")
+               ; "pending_stimulus_count", `Int pending_count
+               ; ( "pending_stimulus_ids"
+                 , match assoc_field "pending_stimulus_ids" summary with
+                   | Some value -> value
+                   | None -> `List [] )
+               ]))
+      summaries
+  in
+  let read_error_count =
+    List.fold_left
+      (fun acc summary -> acc + summary_read_error_count summary)
+      0
+      summaries
+  in
+  let pending_count = total_int "pending_stimulus_count" in
+  let row_count = total_int "row_count" in
+  let status =
+    if read_error_count > 0 then "unknown"
+    else if pending_count > 0 then "degraded"
+    else if row_count = 0 then "empty"
+    else if List.exists (fun summary -> summary_status summary = "degraded") summaries
+    then "degraded"
+    else "ok"
+  in
+  `Assoc
+    [ "schema", `String fleet_summary_schema
+    ; "status", `String status
+    ; ( "operator_action_required"
+      , `Bool (read_error_count > 0 || pending_count > 0) )
+    ; "keeper_count", `Int (List.length keeper_names)
+    ; "keeper_names", `List (List.map (fun value -> `String value) keeper_names)
+    ; "scanned_row_limit_per_keeper", `Int limit_per_keeper
+    ; "row_count", `Int row_count
+    ; "stimulus_count", `Int (total_int "stimulus_count")
+    ; "reaction_count", `Int (total_int "reaction_count")
+    ; "turn_started_count", `Int (total_int "turn_started_count")
+    ; "cursor_ack_count", `Int (total_int "cursor_ack_count")
+    ; "execution_receipt_count", `Int (total_int "execution_receipt_count")
+    ; "terminal_reason_count", `Int (total_int "terminal_reason_count")
+    ; "operator_escalation_count", `Int (total_int "operator_escalation_count")
+    ; "unknown_reaction_count", `Int (total_int "unknown_reaction_count")
+    ; "pending_stimulus_count", `Int pending_count
+    ; "pending_by_keeper", `List pending_by_keeper
+    ; "read_error_count", `Int read_error_count
+    ; "keepers", `List summaries
+    ]
+;;

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -75,3 +75,16 @@ val record_execution_receipt_reaction :
 val read_recent_for_keeper :
   base_path:string -> keeper_name:string -> limit:int -> Yojson.Safe.t list
 (** Read the newest rows for tests and dashboards. *)
+
+val summary_for_keeper :
+  base_path:string -> keeper_name:string -> limit:int -> Yojson.Safe.t
+(** Summarize the recent ledger rows for a keeper.  The summary is intentionally
+    derived from the durable JSONL rows so an operator can see a stimulus that
+    has not yet produced a turn/reaction/cursor acknowledgement. *)
+
+val fleet_summary_json :
+  base_path:string ->
+  keeper_names:string list ->
+  limit_per_keeper:int ->
+  Yojson.Safe.t
+(** Summarize recent reaction-ledger state for a bounded keeper fleet. *)

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -239,6 +239,50 @@ let keeper_fleet_safety_health_json ~keeper_fibers ~paused_keepers_json =
       , `Bool (no_running_fibers || low_running_fiber_margin) )
     ]
 
+let take limit values =
+  let rec loop remaining acc = function
+    | [] -> List.rev acc
+    | _ when remaining <= 0 -> List.rev acc
+    | value :: rest -> loop (remaining - 1) (value :: acc) rest
+  in
+  loop limit [] values
+;;
+
+let keeper_reaction_ledger_health_json () =
+  match current_server_state_opt () with
+  | None ->
+    `Assoc
+      [ "schema", `String "keeper.reaction_ledger.fleet_summary.v1"
+      ; "status", `String "unavailable"
+      ; "operator_action_required", `Bool false
+      ; "keeper_count", `Int 0
+      ; "keeper_names", `List []
+      ; "scanned_row_limit_per_keeper", `Int 20
+      ; "row_count", `Int 0
+      ; "stimulus_count", `Int 0
+      ; "reaction_count", `Int 0
+      ; "pending_stimulus_count", `Int 0
+      ; "pending_by_keeper", `List []
+      ; "read_error_count", `Int 0
+      ; "keepers", `List []
+      ]
+  | Some state ->
+    let config = state.Mcp_server.room_config in
+    let keeper_names =
+      try Keeper_types.keeper_names config |> sorted_unique_strings |> take 64 with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+        Log.Keeper.warn
+          "health: failed to compute keeper reaction ledger names: %s"
+          (Printexc.to_string exn);
+        []
+    in
+    Keeper_reaction_ledger.fleet_summary_json
+      ~base_path:config.base_path
+      ~keeper_names
+      ~limit_per_keeper:20
+;;
+
 let paused_keeper_count = function
   | `Assoc fields ->
       (match List.assoc_opt "count" fields with
@@ -268,6 +312,7 @@ let keeper_fleet_runtime_resolution_fields () =
   let base_path = current_room_base_path_opt () in
   let keeper_fibers = Keeper_registry.count_running ?base_path () in
   let paused_keepers_json = paused_keepers_health_json () in
+  let reaction_ledger_json = keeper_reaction_ledger_health_json () in
   let fleet_safety =
     keeper_fleet_safety_health_json ~keeper_fibers ~paused_keepers_json
   in
@@ -278,6 +323,7 @@ let keeper_fleet_runtime_resolution_fields () =
     , Keeper_fd_pressure.runtime_state_json ~active_keepers:keeper_fibers
         ~starting_keepers:0 ~requested_keepers:24 () )
   ; "keeper_fleet_safety", fleet_safety
+  ; "keeper_reaction_ledger", reaction_ledger_json
   ]
 ;;
 
@@ -334,6 +380,7 @@ let make_health_json ?(listener = "http/1.1") request =
   let base_path = current_room_base_path_opt () in
   let keeper_fibers = Keeper_registry.count_running ?base_path () in
   let paused_keepers_json = paused_keepers_health_json () in
+  let reaction_ledger_json = keeper_reaction_ledger_health_json () in
   Tool_args.ok_assoc [
     ("server", `String "masc-mcp");
     ("version", `String build.release_version);
@@ -379,6 +426,7 @@ let make_health_json ?(listener = "http/1.1") request =
     ( "keeper_fleet_safety"
     , keeper_fleet_safety_health_json ~keeper_fibers
         ~paused_keepers_json );
+    ("keeper_reaction_ledger", reaction_ledger_json);
     (* Paused-keeper visibility: a keeper with [meta.paused = true] does not
        run turns, and auto-paused keepers may no longer have a live registry
        entry. The dashboard "깨우기" button now auto-resumes paused keepers,

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -118,7 +118,7 @@ val make_health_json :
     [transport] / [paths] / [uptime] / [sse_clients] /
     [startup] / [subsystems] / [feature_flags] / [gc] /
     [keeper_fibers] / [keeper_fd_pressure] / [keeper_fleet_safety] /
-    [paused_keepers] /
+    [keeper_reaction_ledger] / [paused_keepers] /
     [keeper_config_parse_error_count] / [keeper_config_parse_errors] /
     [keeper_config_unknown_key_count] / [keeper_config_unknown_keys] /
     [keeper_config_schema_status] / [keeper_config_schema_blocking] /
@@ -149,6 +149,11 @@ val make_health_json :
     exist but no fiber is running, and [degraded] when multiple bootable
     keepers exist but the running fiber count is below the safety margin.
 
+    [keeper_reaction_ledger] summarizes recent durable stimulus -> reaction
+    rows per keeper.  It reports [degraded] when a persisted stimulus has no
+    later reaction/cursor/receipt row in the scanned window, making a stopped
+    reaction chain visible without scraping keeper-local JSONL files.
+
     {2 lazy_task_boot_guard_fires_total contract (P2 silent-
     failure fix)}
 
@@ -164,7 +169,10 @@ val keeper_fleet_runtime_resolution_fields : unit -> (string * Yojson.Safe.t) li
     safety subset projected into [/api/v1/dashboard/shell]'s
     [runtime_resolution].  It intentionally flattens
     [paused_keepers] to a count for the dashboard shell health chip while
-    [/health] keeps the richer paused keeper object. *)
+    [/health] keeps the richer paused keeper object.  The
+    [keeper_reaction_ledger] field keeps the same summary object as
+    [/health] so the dashboard can render pending durable stimuli without a
+    second endpoint. *)
 
 val health_handler : Httpun.Request.t -> Httpun.Reqd.t -> unit
 (** [health_handler request reqd] writes

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -160,6 +160,10 @@ let test_dashboard_tools_projection () =
         (match runtime_resolution |> member "keeper_fleet_safety" with
          | `Assoc _ -> true
          | _ -> false);
+      check bool "runtime keeper reaction ledger surfaced" true
+        (match runtime_resolution |> member "keeper_reaction_ledger" with
+         | `Assoc _ -> true
+         | _ -> false);
       check bool "build started_at surfaced" true
         (match runtime_resolution |> member "build" |> member "started_at" with
          | `String value -> String.length value > 0

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -140,6 +140,45 @@ let test_execution_receipt_links_to_reaction_ledger () =
     (reaction |> member "receipt")
 ;;
 
+let test_summary_marks_unreacted_and_reacted_stimuli () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "summary-keeper" in
+  let stimulus = board_stimulus ~post_id:"post-summary" () in
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    stimulus;
+  let pending_summary =
+    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check_member_string "pending summary status" "degraded" "status" pending_summary;
+  check bool "pending summary asks for operator visibility" true
+    (pending_summary |> member "operator_action_required" |> to_bool);
+  check int "pending stimulus count" 1
+    (pending_summary |> member "pending_stimulus_count" |> to_int);
+  check string "pending stimulus id" "board:post-summary"
+    (pending_summary
+     |> member "pending_stimulus_ids"
+     |> to_list
+     |> List.hd
+     |> to_string);
+  Keeper_reaction_ledger.record_event_queue_reaction
+    ~base_path
+    ~keeper_name
+    ~reaction_kind:Keeper_reaction_ledger.Turn_started
+    stimulus;
+  let reacted_summary =
+    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check_member_string "reacted summary status" "ok" "status" reacted_summary;
+  check bool "reacted summary clears operator action" false
+    (reacted_summary |> member "operator_action_required" |> to_bool);
+  check int "reacted pending stimulus count" 0
+    (reacted_summary |> member "pending_stimulus_count" |> to_int);
+  check int "turn started count" 1
+    (reacted_summary |> member "turn_started_count" |> to_int)
+;;
+
 let () =
   run
     "keeper_reaction_ledger"
@@ -156,6 +195,10 @@ let () =
             "execution receipt links to reaction ledger"
             `Quick
             test_execution_receipt_links_to_reaction_ledger
+        ; test_case
+            "summary marks unreacted and reacted stimuli"
+            `Quick
+            test_summary_marks_unreacted_and_reacted_stimuli
         ] )
     ]
 ;;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -968,12 +968,30 @@ let test_health_json_surfaces_durable_paused_keepers () =
           write_keeper_meta_exn config
             (make_keeper_meta ~name:"durable-active" ~trace_id:"trace-active"
                ~paused:false ());
+          let ledger_stimulus : Keeper_event_queue.stimulus =
+            { post_id = "health-post-1"
+            ; urgency = Immediate
+            ; arrived_at = 1234.5
+            ; payload =
+                Yojson.Safe.to_string
+                  (`Assoc
+                     [ "source", `String "board_signal"
+                     ; "kind", `String "post_created"
+                     ; "post_id", `String "health-post-1"
+                     ])
+            }
+          in
+          Keeper_reaction_ledger.record_event_queue_stimulus
+            ~base_path:dir
+            ~keeper_name:"durable-active"
+            ledger_stimulus;
           let request = Httpun.Request.create `GET "/health" in
           let json = Server_routes_http_runtime.make_health_json request in
           let open Yojson.Safe.Util in
           let paused = json |> member "paused_keepers" in
           let fd_pressure = json |> member "keeper_fd_pressure" in
           let fleet_safety = json |> member "keeper_fleet_safety" in
+          let reaction_ledger = json |> member "keeper_reaction_ledger" in
           let durable_names =
             paused |> member "durable_names" |> to_list |> List.map to_string
           in
@@ -1001,7 +1019,15 @@ let test_health_json_surfaces_durable_paused_keepers () =
             (fleet_safety |> member "bootable_keeper_count" |> to_int);
           Alcotest.(check int) "health exposes minimum running fibers" 1
             (fleet_safety |> member "minimum_running_fibers" |> to_int);
-          ignore (fleet_safety |> member "status" |> to_string)))
+          ignore (fleet_safety |> member "status" |> to_string);
+          Alcotest.(check string) "health reaction ledger degraded"
+            "degraded"
+            (reaction_ledger |> member "status" |> to_string);
+          Alcotest.(check int) "health reaction ledger pending stimuli" 1
+            (reaction_ledger |> member "pending_stimulus_count" |> to_int);
+          Alcotest.(check bool) "health reaction ledger asks for operator action"
+            true
+            (reaction_ledger |> member "operator_action_required" |> to_bool)))
 
 let test_health_json_surfaces_log_ring_summary () =
   Log.set_level Log.Info;


### PR DESCRIPTION
## Summary

- Add durable Reaction Ledger summary JSON derived from keeper-local JSONL rows.
- Surface `keeper_reaction_ledger` through `/health` and dashboard `runtime_resolution`.
- Mark pending persisted stimuli as `degraded` with `operator_action_required=true` so a stopped reaction chain is visible without scraping `.masc/keepers/*/reaction-ledger`.

## Verification

- `git diff --check origin/main...HEAD` passed after latest rebase.
- `scripts/dune-local.sh build test/test_keeper_reaction_ledger.exe test/test_server_runtime_bootstrap.exe test/test_dashboard_tools.exe` passed before the final rebase.
- `./_build/default/test/test_keeper_reaction_ledger.exe` passed: 4 tests.
- `./_build/default/test/test_dashboard_tools.exe` passed: 4 tests.
- `./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 31` passed: 1 test.

Note: after the final rebase, a different worktree held the shared `dune-local` lock with a long-running build, so the post-rebase focused rebuild is left to PR CI. The rebase was conflict-free and `git diff --check origin/main...HEAD` passed.
