### PR TITLE
[codex] persist captured CDAL proofs

### DIFF
--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -525,7 +525,9 @@ let run
         (r, None)
     in
     let run_total_duration_ms = run_duration_ms_since run_started_at in
-    (match proof_ref with Some ref_ -> ref_ := proof | None -> ());
+    (match proof_ref, proof with
+     | Some ref_, Some _ -> ref_ := proof
+     | _ -> ());
     let checkpoint =
       let ckpt =
         build_checkpoint ~session_id

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -98,9 +98,16 @@ let registry_progress_on_event ~record_turn_progress downstream event =
   Option.iter (fun cb -> cb event) downstream
 ;;
 
+let select_cdal_proof ~result_proof ~captured_proof =
+  match result_proof with
+  | Some _ -> result_proof
+  | None -> captured_proof
+;;
+
 module For_testing = struct
   let sse_event_progress_kind = sse_event_progress_kind
   let registry_progress_on_event = registry_progress_on_event
+  let select_cdal_proof = select_cdal_proof
 end
 ;;
 
@@ -521,6 +528,7 @@ let run_turn
           ])
       Keeper_runtime_manifest.Tool_surface_selected;
     let agent_ref : Agent_sdk.Agent.t option ref = ref None in
+    let proof_ref : Masc_mcp_cdal_runtime.Cdal_proof.t option ref = ref None in
     let initial_tool_surface = s.Keeper_run_tools.initial_tool_surface in
     let initial_tool_surface_blocker_ref =
       s.Keeper_run_tools.initial_tool_surface_blocker
@@ -827,6 +835,7 @@ let run_turn
                      ?on_yield
                      ?on_resume
                      ~agent_ref
+                     ~proof_ref
                      ?contract
                      ?cli_transport_overrides
                      ~allowed_paths:oas_allowed_paths
@@ -1466,7 +1475,11 @@ let run_turn
                      match saved_checkpoint_result with
                      | Error e -> Error e
                      | Ok saved_checkpoint ->
-                       (match result.proof with
+                       (match
+                          select_cdal_proof
+                            ~result_proof:result.proof
+                            ~captured_proof:!proof_ref
+                        with
                         | Some p ->
                           Keeper_turn_telemetry.log_keeper_proof ~keeper_name:meta.name p;
                           let store = Masc_mcp_cdal_runtime.Proof_store.default_config in

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -245,6 +245,12 @@ module For_testing : sig
       stamping. The wrapper is intentionally independent from cascade
       attempt-liveness mode so watchdog progress timeouts still observe
       healthy stream chunks when liveness enforcement is off. *)
+
+  val select_cdal_proof
+    :  result_proof:Masc_mcp_cdal_runtime.Cdal_proof.t option
+    -> captured_proof:Masc_mcp_cdal_runtime.Cdal_proof.t option
+    -> Masc_mcp_cdal_runtime.Cdal_proof.t option
+  (** Selects the proof used for keeper-side CDAL verdict persistence. *)
 end
 
 (** {1 Turn execution} *)

--- a/test/test_keeper_cdal_contract.ml
+++ b/test/test_keeper_cdal_contract.ml
@@ -4,6 +4,7 @@ open Masc_mcp
 module RC = Masc_mcp_cdal_runtime.Risk_contract
 module EM = Masc_mcp_cdal_runtime.Execution_mode
 module RK = Masc_mcp_cdal_runtime.Risk_class
+module CP = Masc_mcp_cdal_runtime.Cdal_proof
 
 let make_meta ?(name = "cdal-keeper") ?current_task_id () =
   let fields =
@@ -61,6 +62,39 @@ let check_json_list key expected json =
   | value -> failf "expected %s to be list, got %s" key (Yojson.Safe.to_string value)
 ;;
 
+let make_proof run_id : CP.t =
+  { schema_version = CP.schema_version_current
+  ; run_id
+  ; contract_id = "md5:test"
+  ; requested_execution_mode = EM.Execute
+  ; effective_execution_mode = EM.Execute
+  ; mode_decision_source = "passthrough"
+  ; risk_class = RK.Low
+  ; provider_snapshot =
+      { provider_name = "test"; model_id = "test-model"; api_version = None }
+  ; capability_snapshot =
+      { tools = []
+      ; mcp_servers = []
+      ; max_turns = 8
+      ; max_tokens = Some 4096
+      ; thinking_enabled = None
+      }
+  ; tool_trace_refs = []
+  ; raw_evidence_refs = []
+  ; checkpoint_ref = None
+  ; result_status = CP.Completed
+  ; started_at = 1000.0
+  ; ended_at = 1001.0
+  ; scope = None
+  }
+;;
+
+let check_selected_proof_run_id label expected selected =
+  match selected with
+  | Some proof -> check string label expected proof.CP.run_id
+  | None -> failf "expected %s proof" label
+;;
+
 let test_keeper_meta_projects_capture_only_contract () =
   let meta = make_meta ~current_task_id:"task-cdal-001" () in
   let contract = require_contract meta in
@@ -92,6 +126,23 @@ let test_contract_id_is_stable_for_same_meta () =
   check string "contract id" (RC.contract_id first) (RC.contract_id second)
 ;;
 
+let test_select_cdal_proof_prefers_result_proof () =
+  let result_proof = make_proof "result-proof" in
+  let captured_proof = make_proof "captured-proof" in
+  Keeper_agent_run.For_testing.select_cdal_proof
+    ~result_proof:(Some result_proof)
+    ~captured_proof:(Some captured_proof)
+  |> check_selected_proof_run_id "selected proof" "result-proof"
+;;
+
+let test_select_cdal_proof_falls_back_to_captured_proof () =
+  let captured_proof = make_proof "captured-proof" in
+  Keeper_agent_run.For_testing.select_cdal_proof
+    ~result_proof:None
+    ~captured_proof:(Some captured_proof)
+  |> check_selected_proof_run_id "selected proof" "captured-proof"
+;;
+
 let () =
   Alcotest.run
     "keeper_cdal_contract"
@@ -104,6 +155,16 @@ let () =
             "contract id stable for same keeper meta"
             `Quick
             test_contract_id_is_stable_for_same_meta
+        ] )
+    ; ( "run"
+      , [ test_case
+            "selects result proof before captured proof"
+            `Quick
+            test_select_cdal_proof_prefers_result_proof
+        ; test_case
+            "falls back to captured proof"
+            `Quick
+            test_select_cdal_proof_falls_back_to_captured_proof
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Thread keeper-run CDAL `proof_ref` through `Keeper_turn_driver.run_named`.
- Persist keeper-side CDAL verdicts from the selected proof, preferring `result.proof` and falling back to the captured cascade proof.
- Add focused tests for proof selection behavior.

## Root Cause
The live executor was creating CDAL proof artifacts with a task-scoped contract, but keeper-side verdict persistence only inspected `result.proof`. When the cascade path captured a proof without preserving it on the final result, the verdict ledger/log/activity path was skipped.

## Validation
- `ocamlformat -i lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run.mli lib/cascade/cascade_runner.ml test/test_keeper_cdal_contract.ml`
- `git diff --check`
- Attempted `scripts/dune-local.sh build test/test_keeper_cdal_contract.exe`, but local verification was blocked by an existing `/tmp/me-dune-local.lock` held by another long-running `dune build --root .` in `cascade-max-tokens-validator`.

Refs #15748