### PR TITLE
feat(sse-event): RFC-0004 PR-3 migrate 5 tool/turn arms to typed events

### DIFF
--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -597,33 +597,47 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
     in
     Some (wrap ~event_type:"agent_failed" ~payload ~agent_name ~task_id ())
   | Agent_sdk.Event_bus.ToolCalled { agent_name; tool_name; _ } ->
-    let payload =
-      `Assoc [ "agent_name", `String agent_name; "tool_name", `String tool_name ]
-    in
-    Some (wrap ~event_type:"tool_called" ~payload ~agent_name ~tool_name ())
+    (* RFC-0004 Phase A0.1 PR-3 *)
+    Some
+      (Sse_event.tool_called
+         ~ts_unix:ts
+         ~correlation_id
+         ~run_id
+         ~agent_name
+         ~tool_name)
   | Agent_sdk.Event_bus.ToolCompleted { agent_name; tool_name; _ } ->
-    let payload =
-      `Assoc [ "agent_name", `String agent_name; "tool_name", `String tool_name ]
-    in
-    Some (wrap ~event_type:"tool_completed" ~payload ~agent_name ~tool_name ())
+    Some
+      (Sse_event.tool_completed
+         ~ts_unix:ts
+         ~correlation_id
+         ~run_id
+         ~agent_name
+         ~tool_name)
   | Agent_sdk.Event_bus.TurnStarted { agent_name; turn } ->
-    let payload = `Assoc [ "agent_name", `String agent_name; "turn", `Int turn ] in
-    Some (wrap ~event_type:"turn_started" ~payload ~agent_name ~turn ())
+    Some
+      (Sse_event.turn_started
+         ~ts_unix:ts
+         ~correlation_id
+         ~run_id
+         ~agent_name
+         ~turn)
   | Agent_sdk.Event_bus.TurnCompleted { agent_name; turn } ->
-    let payload = `Assoc [ "agent_name", `String agent_name; "turn", `Int turn ] in
-    Some (wrap ~event_type:"turn_completed" ~payload ~agent_name ~turn ())
+    Some
+      (Sse_event.turn_completed
+         ~ts_unix:ts
+         ~correlation_id
+         ~run_id
+         ~agent_name
+         ~turn)
   | Agent_sdk.Event_bus.TurnReady { agent_name; turn; tool_names } ->
-    let names_hash = Digest.to_hex (Digest.string (String.concat "\n" tool_names)) in
-    let payload =
-      `Assoc
-        [ "agent_name", `String agent_name
-        ; "turn", `Int turn
-        ; "count", `Int (List.length tool_names)
-        ; "names_hash", `String (String.sub names_hash 0 16)
-        ; "tool_names", `List (List.map (fun name -> `String name) tool_names)
-        ]
-    in
-    Some (wrap ~event_type:"turn_ready" ~payload ~agent_name ~turn ())
+    Some
+      (Sse_event.turn_ready
+         ~ts_unix:ts
+         ~correlation_id
+         ~run_id
+         ~agent_name
+         ~turn
+         ~tool_names)
   | Agent_sdk.Event_bus.HandoffRequested { from_agent; to_agent; reason } ->
     let payload =
       `Assoc

--- a/lib/sse_event/sse_event.atd
+++ b/lib/sse_event/sse_event.atd
@@ -15,3 +15,35 @@ type agent_started_payload = {
   agent_name: string;
   task_id: string;
 }
+
+(* PR-3 events: tool_called, tool_completed, turn_started,
+   turn_completed, turn_ready.  All simple records -- byte-equal
+   guaranteed by atdgen -j -j-std, verified in test_sse_event.ml. *)
+
+type tool_called_payload = {
+  agent_name: string;
+  tool_name: string;
+}
+
+type tool_completed_payload = {
+  agent_name: string;
+  tool_name: string;
+}
+
+type turn_started_payload = {
+  agent_name: string;
+  turn: int;
+}
+
+type turn_completed_payload = {
+  agent_name: string;
+  turn: int;
+}
+
+type turn_ready_payload = {
+  agent_name: string;
+  turn: int;
+  count: int;
+  names_hash: string;
+  tool_names: string list;
+}

--- a/lib/sse_event/sse_event.ml
+++ b/lib/sse_event/sse_event.ml
@@ -87,3 +87,150 @@ let agent_started
     }
     payload_json
 ;;
+
+(** Emit a [tool_called] envelope.  Matches cascade arm at
+    lib/cascade/cascade_event_bridge.ml:599-603 (pre-PR-3): envelope
+    populates ~agent_name ~tool_name; payload mirrors the same two
+    fields. *)
+let tool_called
+      ~(ts_unix : float)
+      ~(correlation_id : string)
+      ~(run_id : string)
+      ~(agent_name : string)
+      ~(tool_name : string)
+  : Yojson.Safe.t
+  =
+  let payload_json =
+    let p : Sse_event_t.tool_called_payload = { agent_name; tool_name } in
+    Yojson.Safe.from_string (Sse_event_j.string_of_tool_called_payload p)
+  in
+  wrap_envelope
+    { event_type = "tool_called"
+    ; ts_unix
+    ; correlation_id
+    ; run_id
+    ; agent_name = Some agent_name
+    ; task_id = None
+    ; turn = None
+    ; tool_name = Some tool_name
+    }
+    payload_json
+;;
+
+(** Emit a [tool_completed] envelope.  Same shape as [tool_called]. *)
+let tool_completed
+      ~(ts_unix : float)
+      ~(correlation_id : string)
+      ~(run_id : string)
+      ~(agent_name : string)
+      ~(tool_name : string)
+  : Yojson.Safe.t
+  =
+  let payload_json =
+    let p : Sse_event_t.tool_completed_payload = { agent_name; tool_name } in
+    Yojson.Safe.from_string (Sse_event_j.string_of_tool_completed_payload p)
+  in
+  wrap_envelope
+    { event_type = "tool_completed"
+    ; ts_unix
+    ; correlation_id
+    ; run_id
+    ; agent_name = Some agent_name
+    ; task_id = None
+    ; turn = None
+    ; tool_name = Some tool_name
+    }
+    payload_json
+;;
+
+(** Emit a [turn_started] envelope. *)
+let turn_started
+      ~(ts_unix : float)
+      ~(correlation_id : string)
+      ~(run_id : string)
+      ~(agent_name : string)
+      ~(turn : int)
+  : Yojson.Safe.t
+  =
+  let payload_json =
+    let p : Sse_event_t.turn_started_payload = { agent_name; turn } in
+    Yojson.Safe.from_string (Sse_event_j.string_of_turn_started_payload p)
+  in
+  wrap_envelope
+    { event_type = "turn_started"
+    ; ts_unix
+    ; correlation_id
+    ; run_id
+    ; agent_name = Some agent_name
+    ; task_id = None
+    ; turn = Some turn
+    ; tool_name = None
+    }
+    payload_json
+;;
+
+(** Emit a [turn_completed] envelope. *)
+let turn_completed
+      ~(ts_unix : float)
+      ~(correlation_id : string)
+      ~(run_id : string)
+      ~(agent_name : string)
+      ~(turn : int)
+  : Yojson.Safe.t
+  =
+  let payload_json =
+    let p : Sse_event_t.turn_completed_payload = { agent_name; turn } in
+    Yojson.Safe.from_string (Sse_event_j.string_of_turn_completed_payload p)
+  in
+  wrap_envelope
+    { event_type = "turn_completed"
+    ; ts_unix
+    ; correlation_id
+    ; run_id
+    ; agent_name = Some agent_name
+    ; task_id = None
+    ; turn = Some turn
+    ; tool_name = None
+    }
+    payload_json
+;;
+
+(** Emit a [turn_ready] envelope.  The wrapper computes [count] from
+    [List.length tool_names] and [names_hash] as the first 16 chars
+    of [Digest.to_hex (Digest.string (String.concat "\n" tool_names))],
+    matching cascade arm at cascade_event_bridge.ml:615-624 (pre-PR-3). *)
+let turn_ready
+      ~(ts_unix : float)
+      ~(correlation_id : string)
+      ~(run_id : string)
+      ~(agent_name : string)
+      ~(turn : int)
+      ~(tool_names : string list)
+  : Yojson.Safe.t
+  =
+  let names_hash =
+    Digest.to_hex (Digest.string (String.concat "\n" tool_names))
+  in
+  let payload_json =
+    let p : Sse_event_t.turn_ready_payload =
+      { agent_name
+      ; turn
+      ; count = List.length tool_names
+      ; names_hash = String.sub names_hash 0 16
+      ; tool_names
+      }
+    in
+    Yojson.Safe.from_string (Sse_event_j.string_of_turn_ready_payload p)
+  in
+  wrap_envelope
+    { event_type = "turn_ready"
+    ; ts_unix
+    ; correlation_id
+    ; run_id
+    ; agent_name = Some agent_name
+    ; task_id = None
+    ; turn = Some turn
+    ; tool_name = None
+    }
+    payload_json
+;;

--- a/lib/sse_event/sse_event.mli
+++ b/lib/sse_event/sse_event.mli
@@ -21,3 +21,44 @@ val agent_started
   -> agent_name:string
   -> task_id:string
   -> Yojson.Safe.t
+
+val tool_called
+  :  ts_unix:float
+  -> correlation_id:string
+  -> run_id:string
+  -> agent_name:string
+  -> tool_name:string
+  -> Yojson.Safe.t
+
+val tool_completed
+  :  ts_unix:float
+  -> correlation_id:string
+  -> run_id:string
+  -> agent_name:string
+  -> tool_name:string
+  -> Yojson.Safe.t
+
+val turn_started
+  :  ts_unix:float
+  -> correlation_id:string
+  -> run_id:string
+  -> agent_name:string
+  -> turn:int
+  -> Yojson.Safe.t
+
+val turn_completed
+  :  ts_unix:float
+  -> correlation_id:string
+  -> run_id:string
+  -> agent_name:string
+  -> turn:int
+  -> Yojson.Safe.t
+
+val turn_ready
+  :  ts_unix:float
+  -> correlation_id:string
+  -> run_id:string
+  -> agent_name:string
+  -> turn:int
+  -> tool_names:string list
+  -> Yojson.Safe.t

--- a/test/sse_event/test_sse_event.ml
+++ b/test/sse_event/test_sse_event.ml
@@ -90,6 +90,185 @@ let test_agent_started_byte_equal () =
   Alcotest.(check string) "agent_started typed == cascade baseline" baseline typed
 ;;
 
+(* === PR-3 byte-equal cases: tool_called, tool_completed, turn_started,
+   turn_completed, turn_ready === *)
+
+let common_ts = 1747460000.5
+let common_corr = "corr-001"
+let common_run = "run-001"
+
+let baseline_tool_called ~agent_name ~tool_name =
+  let payload =
+    `Assoc
+      [ "agent_name", `String agent_name; "tool_name", `String tool_name ]
+  in
+  baseline_wrap_event
+    ~ts:common_ts
+    ~correlation_id:common_corr
+    ~run_id:common_run
+    ~event_type:"tool_called"
+    ~payload
+    ~agent_name
+    ~tool_name
+    ()
+;;
+
+let baseline_tool_completed ~agent_name ~tool_name =
+  let payload =
+    `Assoc
+      [ "agent_name", `String agent_name; "tool_name", `String tool_name ]
+  in
+  baseline_wrap_event
+    ~ts:common_ts
+    ~correlation_id:common_corr
+    ~run_id:common_run
+    ~event_type:"tool_completed"
+    ~payload
+    ~agent_name
+    ~tool_name
+    ()
+;;
+
+let baseline_turn_started ~agent_name ~turn =
+  let payload =
+    `Assoc [ "agent_name", `String agent_name; "turn", `Int turn ]
+  in
+  baseline_wrap_event
+    ~ts:common_ts
+    ~correlation_id:common_corr
+    ~run_id:common_run
+    ~event_type:"turn_started"
+    ~payload
+    ~agent_name
+    ~turn
+    ()
+;;
+
+let baseline_turn_completed ~agent_name ~turn =
+  let payload =
+    `Assoc [ "agent_name", `String agent_name; "turn", `Int turn ]
+  in
+  baseline_wrap_event
+    ~ts:common_ts
+    ~correlation_id:common_corr
+    ~run_id:common_run
+    ~event_type:"turn_completed"
+    ~payload
+    ~agent_name
+    ~turn
+    ()
+;;
+
+let baseline_turn_ready ~agent_name ~turn ~tool_names =
+  let names_hash =
+    Digest.to_hex (Digest.string (String.concat "\n" tool_names))
+  in
+  let payload =
+    `Assoc
+      [ "agent_name", `String agent_name
+      ; "turn", `Int turn
+      ; "count", `Int (List.length tool_names)
+      ; "names_hash", `String (String.sub names_hash 0 16)
+      ; ( "tool_names"
+        , `List (List.map (fun name -> `String name) tool_names) )
+      ]
+  in
+  baseline_wrap_event
+    ~ts:common_ts
+    ~correlation_id:common_corr
+    ~run_id:common_run
+    ~event_type:"turn_ready"
+    ~payload
+    ~agent_name
+    ~turn
+    ()
+;;
+
+let test_tool_called_byte_equal () =
+  let baseline =
+    Yojson.Safe.to_string
+      (baseline_tool_called ~agent_name:"alpha" ~tool_name:"Read")
+  in
+  let typed =
+    Yojson.Safe.to_string
+      (Sse_event.tool_called
+         ~ts_unix:common_ts
+         ~correlation_id:common_corr
+         ~run_id:common_run
+         ~agent_name:"alpha"
+         ~tool_name:"Read")
+  in
+  Alcotest.(check string) "tool_called typed == baseline" baseline typed
+;;
+
+let test_tool_completed_byte_equal () =
+  let baseline =
+    Yojson.Safe.to_string
+      (baseline_tool_completed ~agent_name:"alpha" ~tool_name:"Read")
+  in
+  let typed =
+    Yojson.Safe.to_string
+      (Sse_event.tool_completed
+         ~ts_unix:common_ts
+         ~correlation_id:common_corr
+         ~run_id:common_run
+         ~agent_name:"alpha"
+         ~tool_name:"Read")
+  in
+  Alcotest.(check string) "tool_completed typed == baseline" baseline typed
+;;
+
+let test_turn_started_byte_equal () =
+  let baseline =
+    Yojson.Safe.to_string (baseline_turn_started ~agent_name:"alpha" ~turn:3)
+  in
+  let typed =
+    Yojson.Safe.to_string
+      (Sse_event.turn_started
+         ~ts_unix:common_ts
+         ~correlation_id:common_corr
+         ~run_id:common_run
+         ~agent_name:"alpha"
+         ~turn:3)
+  in
+  Alcotest.(check string) "turn_started typed == baseline" baseline typed
+;;
+
+let test_turn_completed_byte_equal () =
+  let baseline =
+    Yojson.Safe.to_string (baseline_turn_completed ~agent_name:"alpha" ~turn:3)
+  in
+  let typed =
+    Yojson.Safe.to_string
+      (Sse_event.turn_completed
+         ~ts_unix:common_ts
+         ~correlation_id:common_corr
+         ~run_id:common_run
+         ~agent_name:"alpha"
+         ~turn:3)
+  in
+  Alcotest.(check string) "turn_completed typed == baseline" baseline typed
+;;
+
+let test_turn_ready_byte_equal () =
+  let tool_names = [ "Read"; "Write"; "Bash"; "Edit" ] in
+  let baseline =
+    Yojson.Safe.to_string
+      (baseline_turn_ready ~agent_name:"alpha" ~turn:3 ~tool_names)
+  in
+  let typed =
+    Yojson.Safe.to_string
+      (Sse_event.turn_ready
+         ~ts_unix:common_ts
+         ~correlation_id:common_corr
+         ~run_id:common_run
+         ~agent_name:"alpha"
+         ~turn:3
+         ~tool_names)
+  in
+  Alcotest.(check string) "turn_ready typed == baseline" baseline typed
+;;
+
 let test_json_string_opt_empty_to_null () =
   (* Regression guard for the empty-string-coerced-to-null semantics
      that atd's default nullable does NOT express. *)
@@ -117,6 +296,13 @@ let () =
     [ ( "byte_equal"
       , [ Alcotest.test_case "agent_started full envelope" `Quick
             test_agent_started_byte_equal
+        ; Alcotest.test_case "tool_called" `Quick test_tool_called_byte_equal
+        ; Alcotest.test_case "tool_completed" `Quick
+            test_tool_completed_byte_equal
+        ; Alcotest.test_case "turn_started" `Quick test_turn_started_byte_equal
+        ; Alcotest.test_case "turn_completed" `Quick
+            test_turn_completed_byte_equal
+        ; Alcotest.test_case "turn_ready" `Quick test_turn_ready_byte_equal
         ] )
     ; ( "json_string_opt"
       , [ Alcotest.test_case "Some empty → null" `Quick


### PR DESCRIPTION
## Summary

RFC-0004 Phase A0.1 **PR-3** — 5 simple-record event migration.

| Event | Payload fields |
|---|---|
| `tool_called` | agent_name, tool_name |
| `tool_completed` | agent_name, tool_name |
| `turn_started` | agent_name, turn |
| `turn_completed` | agent_name, turn |
| `turn_ready` | agent_name, turn, count, names_hash, tool_names |

`turn_ready` 의 `count` / `names_hash` 는 wrapper 가 `tool_names` 에서 derive (callers 가 hash 재계산 안 함).

## Scope split (계획 변경)

원래 #15778 plan §4 의 PR-3 = 7 event (위 5개 + `agent_completed` + `agent_failed`).

분석 결과 `agent_completed_result_fields` (Ok/Error 분기 + Agent_sdk usage_fields) + `agent_failed_error_fields` (Keeper_agent_error + Keeper_turn_terminal_code) 가 cascade-local helper. Sse_event lib 에 옮기면 **Agent_sdk + keeper internals 전체 의존성 surface 가 leaf lib 에 유입** → typed event lib 의 leaf 정신 위반.

→ **agent_completed/failed 는 PR-3b** 로 분리. 별 design 결정 필요:
- (옵션 A) atd base record + caller-supplied `Yojson.Safe.t addendum`
- (옵션 B) atd polymorphic variant `Ok of ... | Error of ...` (Agent_sdk pin-bump 안티패턴 회피 필요)

## Test result (local)

```
$ dune build lib/sse_event/ lib/cascade/ test/sse_event/  PASS
$ _build/default/test/sse_event/test_sse_event.exe
  [OK]  byte_equal       0  agent_started full envelope    (PR-1)
  [OK]  byte_equal       1  tool_called                    (NEW)
  [OK]  byte_equal       2  tool_completed                 (NEW)
  [OK]  byte_equal       3  turn_started                   (NEW)
  [OK]  byte_equal       4  turn_completed                 (NEW)
  [OK]  byte_equal       5  turn_ready                     (NEW)
  [OK]  json_string_opt  0  Some empty → null
Test Successful in 0.002s. 7 tests run.
```

5 file, 443 insertions, 23 deletions.

## Files

- `lib/sse_event/sse_event.atd` — 5 record types
- `lib/sse_event/sse_event.ml` — 5 constructors (`turn_ready` derives count + names_hash)
- `lib/sse_event/sse_event.mli` — 5 vals
- `lib/cascade/cascade_event_bridge.ml` — 5 arms migrated (inline `Assoc → `Sse_event.<event>` calls)
- `test/sse_event/test_sse_event.ml` — 5 byte-equal cases + baseline_* helpers

## Lessons learned (commit message에도 포함)

- atd `(* ... *)` comment 안에 literal `*)` sub-string 금지 (parser 가 comment close 인식). `(tool_*, turn_*)` 형식이 cryptic line 19 syntax error 일으킴
- OCaml comment 도 같은 제약. test_sse_event.ml 의 comment에 같은 문제 재발
- turn_ready 의 hash derivation 은 wrapper 안에 흡수 — callers 가 매 site 마다 Digest 호출 반복 안 함

## Remaining

| PR | 작업 |
|---|---|
| **PR-3b** | agent_completed, agent_failed (variable-shape payload design) |
| **PR-4** | handoff_*, context_*, content_replacement_*, slot_scheduler_observed (8 event) |

RFC-WAIVED: PR-3 of #15778 plan §4 (scope adjusted to 5 events, agent_completed/failed split to PR-3b).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>