### PR TITLE
Clamp cascade max tokens to output ceiling

### DIFF
--- a/lib/cascade_inference.ml
+++ b/lib/cascade_inference.ml
@@ -121,12 +121,14 @@ let should_log_auto_max_tokens_clamp ~cascade_name ~source ~max_tokens ~ceiling 
 
     The narrowest ceiling is a property of cascade-internal fallback
     structure (multilane tier-groups can union members of differing output
-    budgets), so callers cannot infer it. The pre-dispatch validator
-    remains as a hard guard for non-positive budgets, invalid ceilings,
-    and stale values after a cascade reload. *)
-let cap_max_tokens_to_cascade_ceiling ~cascade_name ~source max_tokens =
-  match Cascade_runtime.max_output_tokens_ceiling_of_cascade_name cascade_name with
-  | Some ceiling when ceiling > 0 && max_tokens > ceiling ->
+    budgets), so callers cannot infer it.
+
+    Runtime overrides supplied by internal keeper callers should also flow
+    through this helper before the final pre-dispatch validator. The validator
+    remains as a hard guard for non-positive budgets and invalid ceilings. *)
+let cap_max_tokens_to_ceiling ~cascade_name ~source ~ceiling max_tokens =
+  if ceiling > 0 && max_tokens > ceiling
+  then (
     Cascade_metrics.on_max_tokens_clamped ();
     if should_log_auto_max_tokens_clamp ~cascade_name ~source ~max_tokens ~ceiling
     then
@@ -135,7 +137,13 @@ let cap_max_tokens_to_cascade_ceiling ~cascade_name ~source max_tokens =
          using ceiling; suppressing repeats for this tuple"
         (Keeper_cascade_profile.runtime_name_to_string cascade_name)
         max_tokens source ceiling;
-    ceiling
+    ceiling)
+  else max_tokens
+
+let cap_max_tokens_to_cascade_ceiling ~cascade_name ~source max_tokens =
+  match Cascade_runtime.max_output_tokens_ceiling_of_cascade_name cascade_name with
+  | Some ceiling ->
+    cap_max_tokens_to_ceiling ~cascade_name ~source ~ceiling max_tokens
   | _ -> max_tokens
 
 (** Resolve a max_tokens value: cascade config (capped) -> capped fallback. *)
@@ -151,7 +159,7 @@ let resolve_max_tokens
   | None ->
     cap_max_tokens_to_cascade_ceiling ~cascade_name ~source:"fallback" (fallback ())
 
-(** Validate max_tokens against provider ceilings before dispatch. *)
+(** Validate and clamp max_tokens against provider ceilings before dispatch. *)
 let validate_max_tokens_within_ceiling
     ~(cascade_name : Keeper_cascade_profile.runtime_name)
     ~(provider_ceiling : int option)
@@ -179,9 +187,12 @@ let validate_max_tokens_within_ceiling
     then violation ~reason:"provider_ceiling_not_positive" ~provider_ceiling:ceiling
     else if max_tokens > ceiling
     then
-      violation
-        ~reason:"requested_exceeds_provider_ceiling"
-        ~provider_ceiling:ceiling
+      Ok
+        (cap_max_tokens_to_ceiling
+           ~cascade_name
+           ~source:"pre_dispatch"
+           ~ceiling
+           max_tokens)
     else Ok max_tokens
 
 module For_testing = struct

--- a/lib/cascade_inference.mli
+++ b/lib/cascade_inference.mli
@@ -9,6 +9,9 @@
     2. cascade.toml "default_temperature" / "default_max_tokens"
     3. Caller-provided fallback
 
+    max_tokens values above the resolved cascade output ceiling are reduced to
+    that ceiling with a WARN.
+
     @since v2.128.0
     @since v2.149.0 — delegated to MASC Cascade_config *)
 
@@ -65,9 +68,9 @@ val cap_max_tokens_to_cascade_ceiling :
 (** Validate max_tokens against the provider ceiling before dispatch.
 
     If [provider_ceiling] is [Some ceiling] and [max_tokens > ceiling],
-    returns [Error _] instead of silently reducing the operator-supplied
-    budget. Also rejects non-positive [max_tokens] and non-positive
-    provider ceilings.
+    returns [Ok ceiling] and emits the same WARN/metric as resolution-time
+    clamping. Still rejects non-positive [max_tokens] and non-positive provider
+    ceilings.
 
     Cascade-config, fallback, and keeper runtime override values are clamped
     upstream by {!resolve_max_tokens} or

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -274,18 +274,17 @@ let run_turn
   in
   let meta = ctx.meta in
   let temperature = ctx.temperature in
-  let max_tokens = ctx.max_tokens in
   let max_output_ceiling =
     Cascade_runtime.max_output_tokens_ceiling_of_cascade_name cascade_name
   in
-  let pre_dispatch_max_tokens_error =
+  let max_tokens, pre_dispatch_max_tokens_error =
     match
       Cascade_inference.validate_max_tokens_within_ceiling
         ~cascade_name
         ~provider_ceiling:max_output_ceiling
-        max_tokens
+        ctx.max_tokens
     with
-    | Ok _ -> None
+    | Ok max_tokens -> max_tokens, None
     | Error internal_error ->
       let detail =
         Option.value
@@ -293,7 +292,8 @@ let run_turn
           (Cascade_error_classify.summary_of_masc_internal_error internal_error)
       in
       Log.Keeper.error "%s: %s" meta.name detail;
-      Some (Cascade_error_classify.sdk_error_of_masc_internal_error internal_error)
+      ( ctx.max_tokens,
+        Some (Cascade_error_classify.sdk_error_of_masc_internal_error internal_error) )
   in
   let context_injector = ctx.context_injector in
   let shared_context = ctx.shared_context in

--- a/test/test_cascade_capability_gate.ml
+++ b/test/test_cascade_capability_gate.ml
@@ -1,4 +1,4 @@
-(** test_cascade_capability_gate — Provider ceiling validation.
+(** test_cascade_capability_gate — Provider ceiling validation/clamping.
 
     Verifies TLA+ KeeperCoreTriad.CapabilityGate (S3 invariant):
     requested_max_tokens never exceeds provider ceiling before dispatch. *)
@@ -38,9 +38,9 @@ let check_ok label expected = function
   | Ok actual -> check int label expected actual
   | Error _ -> failf "expected Ok %d" expected
 
-let test_reject_above_ceiling () =
+let test_clamp_above_ceiling () =
   validate 65536
-  |> check_violation "requested_exceeds_provider_ceiling" 65536 40960
+  |> check_ok "above ceiling clamped to provider ceiling" 40960
 
 let test_allow_below_ceiling () =
   let result = validate ~provider_ceiling:(Some 131072) 32768 in
@@ -62,7 +62,7 @@ let test_reject_nonpositive_max_tokens () =
   validate 0 |> check_violation "max_tokens_not_positive" 0 40960
 
 let test_sdk_error_round_trip_preserves_structured_violation () =
-  match validate 65536 with
+  match validate 0 with
   | Ok _ -> fail "expected validation error"
   | Error internal_error ->
     let err = CE.sdk_error_of_masc_internal_error internal_error in
@@ -70,9 +70,9 @@ let test_sdk_error_round_trip_preserves_structured_violation () =
      | Some
          (CE.Max_tokens_ceiling_violation
             { requested_max_tokens; provider_ceiling; reason; _ }) ->
-       check int "requested round trip" 65536 requested_max_tokens;
+       check int "requested round trip" 0 requested_max_tokens;
        check int "ceiling round trip" 40960 provider_ceiling;
-       check string "reason round trip" "requested_exceeds_provider_ceiling" reason
+       check string "reason round trip" "max_tokens_not_positive" reason
      | _ -> fail "expected structured violation round trip")
 
 let write_file path body =
@@ -134,7 +134,7 @@ target = "tier.primary"
       check (option int) "output ceiling" (Some 8192) ceiling;
       CI.validate_max_tokens_within_ceiling ~cascade_name
         ~provider_ceiling:ceiling 65536
-      |> check_violation "requested_exceeds_provider_ceiling" 65536 8192)
+      |> check_ok "above output ceiling clamped" 8192)
 
 let test_public_cap_helper_clamps_caller_override_to_cascade_ceiling () =
   with_temp_cascade_toml
@@ -214,7 +214,7 @@ max-output = 64000
 temperature = 0.2
 
 [kimi_cli.kimi-cli-coding.tool_candidate]
-max-output = 16384
+max-output = 64000
 temperature = 0.2
 
 [tier.strict_tool_candidates]
@@ -443,7 +443,7 @@ target = "tier-group.strict_tool_candidates"
 let () =
   run "cascade_capability_gate" [
     "max_tokens_ceiling_validation", [
-      test_case "above ceiling -> rejected" `Quick test_reject_above_ceiling;
+      test_case "above ceiling -> clamped" `Quick test_clamp_above_ceiling;
       test_case "below ceiling -> accepted" `Quick test_allow_below_ceiling;
       test_case "equal ceiling -> accepted" `Quick test_allow_equal_ceiling;
       test_case "no ceiling -> accepted" `Quick test_allow_no_ceiling;


### PR DESCRIPTION
## Summary
- clamp cascade-config, fallback, and pre-dispatch max_tokens to the resolved output ceiling
- keep nonpositive budget/ceiling validation hard-fail behavior
- add/update capability-gate tests for clamp semantics and the Qwen 8192 ceiling case

## Verification
- ocamlformat --check lib/cascade_inference.ml lib/cascade_inference.mli lib/keeper/keeper_agent_run.ml test/test_cascade_capability_gate.ml
- git diff --check origin/main..HEAD
- scripts/dune-local.sh build test/test_cascade_capability_gate.exe and executable test passed before latest rebase; post-rebase Dune was queued behind an active full-build lock