### PR TITLE
Remove ME_ROOT runtime fallback

### DIFF
--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -39,7 +39,7 @@ Scope:
 | `MASC_PERSONAS_DIR` | Explicit personas root override. | `Config_dir_resolver`, keeper/persona loading |
 | `MASC_STORAGE_TYPE` | Runtime backend selector. Only `filesystem` is active; PostgreSQL backend was removed. | bootstrap and backend setup |
 | `HOME` | Shell/user-home context for external tools and non-config artifact stores. | Host process environment |
-| `MASC_WORKSPACE_ROOT`, `ME_ROOT`, `DUNE_SOURCEROOT` | Workspace discovery, legacy repo fallback, some knowledge paths, `scripts/sb` resolution. | `Env_config_core`, `autoresearch_knowledge`, legacy paths |
+| `MASC_WORKSPACE_ROOT`, `DUNE_SOURCEROOT` | Workspace discovery and legacy repo fallback. | `Env_config_core`, `autoresearch_knowledge`, legacy paths |
 | `MASC_HOST`, `MASC_HTTP_PORT`, `MASC_HTTP_BASE_URL` | Bind address and derived HTTP endpoint identity. | HTTP/bootstrap/provider routing |
 | `MASC_ADMIN_TOKEN` | Privileged endpoint auth. | server auth |
 
@@ -287,11 +287,11 @@ Compatibility note:
   - `state.json`
   - `swarm.json`
   - `worktree/`
-- `<me_root>/.masc/autoresearch/findings/findings.jsonl`
+- `<base-path>/.masc/autoresearch/findings/findings.jsonl`
 
 Important outlier:
 
-- The findings store is resolved from `ME_ROOT` or `HOME`, not from the room-config runtime root.
+- The findings store should resolve from `MASC_BASE_PATH` or `HOME`, not from the room-config runtime root.
 - Legacy links from team-session artifacts to autoresearch loops may still exist.
 
 ### 3.6 Keepers
@@ -506,7 +506,6 @@ MASC_STORAGE_TYPE
 MASC_TELEMETRY_ENABLED
 MASC_TOOL_AUTH_STRICT
 MASC_WORKSPACE_ROOT
-ME_ROOT
 ```
 
 ### A.2 `env_config_runtime`
@@ -770,5 +769,5 @@ To regenerate the inventories:
 ```bash
 rg -oN '"MASC_[A-Z0-9_]+"' lib/config/env_config_core.ml lib/config/env_config_runtime.ml lib/config/env_config_governance.ml lib/config/env_config_keeper.ml | tr -d '"' | sort -u
 rg -oN '"MASC_[A-Z0-9_]+"' lib bin | tr -d '"' | sort -u
-rg -oN '"(LLAMA_[A-Z0-9_]+|OLLAMA_[A-Z0-9_]+|VOICE_MCP_[A-Z0-9_]+|ME_ROOT|HOME|DUNE_SOURCEROOT)"' lib bin | tr -d '"' | sort -u
+rg -oN '"(LLAMA_[A-Z0-9_]+|OLLAMA_[A-Z0-9_]+|VOICE_MCP_[A-Z0-9_]+|HOME|DUNE_SOURCEROOT)"' lib bin | tr -d '"' | sort -u
 ```

--- a/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
+++ b/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
@@ -64,7 +64,7 @@ For dashboard-side keeper lifecycle control, the target shape is:
 Use the auth doctor before editing tokens or role files:
 
 ```bash
-BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/path/to/base}}"
+BASE_PATH="${MASC_BASE_PATH:-/path/to/base}"
 ./_build/default/bin/main_eio.exe doctor auth --base-path "$BASE_PATH"
 ```
 
@@ -104,7 +104,7 @@ when bootstrapping or rotating the bearer; export the printed value as
 `MASC_MCP_TOKEN` in the shell that starts Codex:
 
 ```bash
-BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/path/to/base}}"
+BASE_PATH="${MASC_BASE_PATH:-/path/to/base}"
 ./_build/default/bin/main_eio.exe login \
   --base-path "$BASE_PATH" \
   --agent codex-mcp-client \
@@ -160,7 +160,7 @@ the raw value on disk and causes auth drift when the token is rotated.
 To initialise or repair the Codex config from the repo:
 
 ```bash
-BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/path/to/base}}"
+BASE_PATH="${MASC_BASE_PATH:-/path/to/base}"
 scripts/init-codex-mcp-config.sh --base-path "$BASE_PATH"
 ```
 
@@ -181,7 +181,7 @@ Claude and Gemini must not reuse the Codex bearer. Mint each local MCP client
 as its own worker identity, then sync the shared client config:
 
 ```bash
-BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/path/to/base}}"
+BASE_PATH="${MASC_BASE_PATH:-/path/to/base}"
 
 ./_build/default/bin/main_eio.exe login \
   --base-path "$BASE_PATH" \
@@ -217,7 +217,7 @@ files rather than embedding literal tokens in the config.
 When running from a worktree but using a shared local coordination root, start the server with an explicit base path:
 
 ```bash
-BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/path/to/base}}"
+BASE_PATH="${MASC_BASE_PATH:-/path/to/base}"
 MASC_BASE_PATH="$BASE_PATH" \
 ./_build/default/bin/main_eio.exe \
   --host 127.0.0.1 \
@@ -234,7 +234,7 @@ If you already have an admin bearer, skip to step 7.
 The shortest local CLI path is:
 
 ```bash
-BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/path/to/base}}"
+BASE_PATH="${MASC_BASE_PATH:-/path/to/base}"
 ./_build/default/bin/main_eio.exe login \
   --base-path "$BASE_PATH" \
   --agent codex-local-admin \
@@ -258,7 +258,7 @@ If you do not have that path, the reliable local fallback is to seed the auth st
 1. Back up the auth config:
 
 ```bash
-BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/path/to/base}}"
+BASE_PATH="${MASC_BASE_PATH:-/path/to/base}"
 cp "$BASE_PATH/.masc/auth/config.json" "$BASE_PATH/.masc/auth/config.json.bak"
 ```
 
@@ -399,7 +399,7 @@ If you need to go back to anonymous loopback behavior:
 Example:
 
 ```bash
-BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/path/to/base}}"
+BASE_PATH="${MASC_BASE_PATH:-/path/to/base}"
 mv "$BASE_PATH/.masc/auth/config.json.bak" "$BASE_PATH/.masc/auth/config.json"
 rm -f "$BASE_PATH/.masc/auth/agents/codex-tool-matrix.json"
 ```

--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -335,6 +335,5 @@ Regenerate-before-fix is an anti-pattern: the fingerprint must always describe a
 
 1. `$AGENT_SDK_LOCAL_REPO` (explicit override)
 2. `<masc-mcp-parent>/oas` (sibling checkout)
-3. `$ME_ROOT/workspace/yousleepwhen/oas` (explicit workspace root)
 
 Each candidate must be a git checkout at the pinned SHA. If none qualifies, the script falls back to `git fetch` into a temp bare clone from the upstream URL. Network is required only for that fallback.

--- a/infrastructure/launchd/com.jeong-sik.masc-mcp.plist
+++ b/infrastructure/launchd/com.jeong-sik.masc-mcp.plist
@@ -9,7 +9,7 @@
     <!-- NOTE: Paths below are machine-specific. Adjust for your setup:
          - ProgramArguments: path to start-masc-mcp.sh in the repo
          - StandardOutPath/StandardErrorPath: log directory
-         - ME_ROOT / MASC_BASE_PATH / WorkingDirectory: your ME_ROOT -->
+         - MASC_BASE_PATH / WorkingDirectory: your base path -->
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
@@ -43,8 +43,6 @@
     <dict>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin</string>
-        <key>ME_ROOT</key>
-        <string>/Users/dancer/me</string>
         <key>MASC_MCP_PORT</key>
         <string>8935</string>
         <key>MASC_BASE_PATH</key>

--- a/infrastructure/systemd/masc-mcp.service
+++ b/infrastructure/systemd/masc-mcp.service
@@ -28,7 +28,6 @@ User=masc
 Group=masc
 WorkingDirectory=/opt/masc-mcp
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
-Environment=ME_ROOT=/opt/masc-mcp
 Environment=MASC_BASE_PATH=/var/lib/masc-mcp
 Environment=MASC_CONFIG_DIR=/opt/masc-mcp/config
 Environment=MASC_MCP_PORT=8080

--- a/lib/cdal_runtime/proof_store.ml
+++ b/lib/cdal_runtime/proof_store.ml
@@ -20,10 +20,7 @@ let default_root () =
   let base_path =
     match env_non_empty "MASC_BASE_PATH" with
     | Some path -> path
-    | None ->
-      (match env_non_empty "ME_ROOT" with
-       | Some path -> path
-       | None -> Sys.getcwd ())
+    | None -> Sys.getcwd ()
   in
   Filename.concat base_path ".oas"
 ;;

--- a/lib/cdal_runtime/proof_store.mli
+++ b/lib/cdal_runtime/proof_store.mli
@@ -9,8 +9,7 @@
 
 type config = {
   root : string
-      (** Default: [<MASC_BASE_PATH>/.oas], then [<ME_ROOT>/.oas], then
-          [<cwd>/.oas]. *)
+      (** Default: [<MASC_BASE_PATH>/.oas], then [<cwd>/.oas]. *)
 }
 
 type resolved_ref =

--- a/lib/cdal_runtime_health.ml
+++ b/lib/cdal_runtime_health.ml
@@ -48,10 +48,7 @@ let proof_root_candidates configured_root =
   let maybe_home =
     env_non_empty "HOME" |> Option.map (fun home -> Filename.concat home ".oas")
   in
-  let maybe_me_root =
-    env_non_empty "ME_ROOT" |> Option.map (fun root -> Filename.concat root ".oas")
-  in
-  [ maybe_home; maybe_me_root ]
+  [ maybe_home ]
   |> List.filter_map Fun.id
   |> List.filter (fun root -> not (String.equal root configured_root))
   |> List.sort_uniq String.compare

--- a/lib/host_config/host_config.ml
+++ b/lib/host_config/host_config.ml
@@ -67,10 +67,7 @@ let host () =
   let default_workspace_root fallback =
     match get_opt "MASC_BASE_PATH" with
     | Some root -> Env_config_core.normalize_masc_base_path_input root
-    | None ->
-      (match get_opt "ME_ROOT" with
-       | Some root -> root
-       | None -> fallback)
+    | None -> fallback
   in
   { cred_root = Filename.concat tmp "keeper-creds"
   ; host_bash = "/bin/bash"
@@ -171,10 +168,7 @@ let resolve ?base_path () =
   let default_workspace_root fallback =
     match get_opt "MASC_BASE_PATH" with
     | Some root -> Env_config_core.normalize_masc_base_path_input root
-    | None ->
-      (match get_opt "ME_ROOT" with
-       | Some root -> root
-       | None -> fallback)
+    | None -> fallback
   in
   let agent_runtime_root = Filename.concat base ".masc/runtime/agent" in
   let cred_root = Filename.concat base ".masc/credentials" in

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -89,10 +89,7 @@ type context = {
 let workspace_root () =
   match Sys.getenv_opt "MASC_BASE_PATH" |> Option.map String.trim with
   | Some root when root <> "" -> Env_config_core.normalize_masc_base_path_input root
-  | _ ->
-    (match Sys.getenv_opt "ME_ROOT" |> Option.map String.trim with
-     | Some root when root <> "" -> root
-     | _ -> (Host_config.host ()).agent_runtime_root)
+  | _ -> (Host_config.host ()).agent_runtime_root
 
 let library_root () =
   Filename.concat (workspace_root ()) "docs/library"

--- a/lib/tool_library.mli
+++ b/lib/tool_library.mli
@@ -4,8 +4,8 @@
     Implements 5 tools ([masc_library_list], [masc_library_read],
     [masc_library_add], [masc_library_promote],
     [masc_library_search]) backed by Markdown documents under
-    {!library_root} ([MASC_BASE_PATH/docs/library], then
-    [ME_ROOT/docs/library], then the host runtime fallback) with YAML
+    {!library_root} ([MASC_BASE_PATH/docs/library], then the host
+    runtime fallback) with YAML
     frontmatter ([title], [source], [confidence], [author],
     [created], [tags], [verified_by]).
 
@@ -84,9 +84,8 @@ type context = {
 
 val library_root : unit -> string
 (** [library_root ()] is [MASC_BASE_PATH/docs/library] when
-    [MASC_BASE_PATH] is set, otherwise [ME_ROOT/docs/library].  If both are
-    unset, it falls back to the host-config agent runtime root.  Read every
-    call — env mutation between calls takes effect. *)
+    [MASC_BASE_PATH] is set, otherwise the host-config agent runtime root.
+    Read every call — env mutation between calls takes effect. *)
 
 val candidates_dir : unit -> string
 (** [candidates_dir ()] is [{library_root}/candidates].

--- a/scripts/audit-keeper-credential-drift.sh
+++ b/scripts/audit-keeper-credential-drift.sh
@@ -37,7 +37,7 @@
 #   scripts/audit-keeper-credential-drift.sh [--base-path PATH] [--json]
 #
 # Options:
-#   --base-path PATH   Server base_path (default: MASC_BASE_PATH, ME_ROOT, then cwd)
+#   --base-path PATH   Server base_path (default: MASC_BASE_PATH, then cwd)
 #   --json             Emit machine-readable JSON only (no human report)
 #   -h, --help         Show this help
 set -o pipefail
@@ -51,8 +51,6 @@ set -o pipefail
 default_base_path() {
   if [ -n "${MASC_BASE_PATH:-}" ]; then
     printf '%s\n' "$MASC_BASE_PATH"
-  elif [ -n "${ME_ROOT:-}" ]; then
-    printf '%s\n' "$ME_ROOT"
   else
     pwd
   fi

--- a/scripts/audit-keeper-credential-uuid-integrity.sh
+++ b/scripts/audit-keeper-credential-uuid-integrity.sh
@@ -26,7 +26,7 @@
 #   scripts/audit-keeper-credential-uuid-integrity.sh [--base-path PATH] [--json]
 #
 # Options:
-#   --base-path PATH   Server base_path (default: MASC_BASE_PATH, ME_ROOT, then cwd)
+#   --base-path PATH   Server base_path (default: MASC_BASE_PATH, then cwd)
 #   --json             Emit machine-readable JSON only
 #   -h, --help         Show this help
 set -o pipefail
@@ -36,8 +36,6 @@ set -o pipefail
 default_base_path() {
   if [ -n "${MASC_BASE_PATH:-}" ]; then
     printf '%s\n' "$MASC_BASE_PATH"
-  elif [ -n "${ME_ROOT:-}" ]; then
-    printf '%s\n' "$ME_ROOT"
   else
     pwd
   fi

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -44,11 +44,6 @@ ACTIVE_CMD_PGID=""
 ACTIVE_LOG_TAIL_PID=""
 CI_LAST_TIMEOUT_DIAG_DONE=0
 
-if [[ -n "${ME_ROOT:-}" ]]; then
-  export MASC_BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT}}"
-  export MASC_BASE_PATH_INPUT="${MASC_BASE_PATH_INPUT:-${MASC_BASE_PATH}}"
-fi
-
 iso_now() {
   date -u +"%Y-%m-%dT%H:%M:%SZ"
 }

--- a/scripts/ci/check-masc-oas-boundary.sh
+++ b/scripts/ci/check-masc-oas-boundary.sh
@@ -35,7 +35,6 @@ resolve_oas_repo() {
   repo_parent="$(dirname "$(pwd)")"
   local candidates=(
     "${repo_parent}/oas"
-    "${ME_ROOT:-}/workspace/yousleepwhen/oas"
   )
 
   local candidate

--- a/scripts/cleanup-autoresearch.sh
+++ b/scripts/cleanup-autoresearch.sh
@@ -18,7 +18,7 @@
 #   TTL_DAYS=14 scripts/cleanup-autoresearch.sh --apply  # custom TTL
 #
 # Environment:
-#   MASC_BASE_PATH  base path (default: MASC_BASE_PATH, ME_ROOT, then cwd)
+#   MASC_BASE_PATH  base path (default: MASC_BASE_PATH, then cwd)
 #   TTL_DAYS        days a dir must be untouched to qualify (default: 7)
 #
 # Refuses to quarantine a dir that any process holds an open FD to.
@@ -39,8 +39,6 @@ done
 default_base_path() {
   if [ -n "${MASC_BASE_PATH:-}" ]; then
     printf '%s\n' "$MASC_BASE_PATH"
-  elif [ -n "${ME_ROOT:-}" ]; then
-    printf '%s\n' "$ME_ROOT"
   else
     pwd
   fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,8 +22,6 @@ HEALTH_URL="http://127.0.0.1:$PROD_PORT/health"
 default_base_path() {
     if [ -n "${MASC_BASE_PATH:-}" ]; then
         printf '%s\n' "$MASC_BASE_PATH"
-    elif [ -n "${ME_ROOT:-}" ]; then
-        printf '%s\n' "$ME_ROOT"
     else
         printf '%s\n' "$REPO_DIR"
     fi

--- a/scripts/diag-keeper-cycle.sh
+++ b/scripts/diag-keeper-cycle.sh
@@ -16,8 +16,6 @@ set -euo pipefail
 default_base_path() {
   if [ -n "${MASC_BASE_PATH:-}" ]; then
     printf '%s\n' "$MASC_BASE_PATH"
-  elif [ -n "${ME_ROOT:-}" ]; then
-    printf '%s\n' "$ME_ROOT"
   else
     pwd
   fi

--- a/scripts/harness/self_eval_ratchet.sh
+++ b/scripts/harness/self_eval_ratchet.sh
@@ -20,8 +20,6 @@ ITERATION="${1:-1}"
 default_base_path() {
   if [ -n "${MASC_BASE_PATH:-}" ]; then
     printf '%s\n' "$MASC_BASE_PATH"
-  elif [ -n "${ME_ROOT:-}" ]; then
-    printf '%s\n' "$ME_ROOT"
   else
     printf '%s\n' "$PWD"
   fi

--- a/scripts/harness/workload/agent_swarm_live.sh
+++ b/scripts/harness/workload/agent_swarm_live.sh
@@ -11,8 +11,6 @@ default_base_path() {
     printf '%s\n' "$BASE_PATH"
   elif [ -n "${MASC_BASE_PATH:-}" ]; then
     printf '%s\n' "$MASC_BASE_PATH"
-  elif [ -n "${ME_ROOT:-}" ]; then
-    printf '%s\n' "$ME_ROOT"
   else
     printf '%s\n' "$REPO_ROOT"
   fi

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -30,8 +30,6 @@ default_base_path() {
     printf '%s\n' "$BASE_PATH"
   elif [ -n "${MASC_BASE_PATH:-}" ]; then
     printf '%s\n' "$MASC_BASE_PATH"
-  elif [ -n "${ME_ROOT:-}" ]; then
-    printf '%s\n' "$ME_ROOT"
   else
     printf '%s\n' "$REPO_ROOT"
   fi
@@ -91,7 +89,7 @@ Options:
   --expected-keepers N     Expected configured keeper count for audit.
   --repo OWNER/REPO        Target repository slug in the keeper prompt.
   --base-path PATH         MASC base path for audit (default: MASC_BASE_PATH,
-                           ME_ROOT, then repo root).
+                           then repo root).
   --mcp-url URL            MCP endpoint (default: http://127.0.0.1:8935/mcp).
   --expected-server-commit COMMIT
                            Fail unless /health build.commit matches this commit.

--- a/scripts/harness/workload/keeper_product_design_board_reprobe.sh
+++ b/scripts/harness/workload/keeper_product_design_board_reprobe.sh
@@ -25,8 +25,6 @@ default_base_path() {
     printf '%s\n' "$BASE_PATH"
   elif [ -n "${MASC_BASE_PATH:-}" ]; then
     printf '%s\n' "$MASC_BASE_PATH"
-  elif [ -n "${ME_ROOT:-}" ]; then
-    printf '%s\n' "$ME_ROOT"
   else
     printf '%s\n' "$REPO_ROOT"
   fi

--- a/scripts/harness/workload/sangsu_bench_toggle.sh
+++ b/scripts/harness/workload/sangsu_bench_toggle.sh
@@ -21,8 +21,6 @@ set -euo pipefail
 default_base_path() {
   if [ -n "${MASC_BASE_PATH:-}" ]; then
     printf '%s\n' "$MASC_BASE_PATH"
-  elif [ -n "${ME_ROOT:-}" ]; then
-    printf '%s\n' "$ME_ROOT"
   else
     pwd
   fi

--- a/scripts/init-codex-mcp-config.sh
+++ b/scripts/init-codex-mcp-config.sh
@@ -9,8 +9,6 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 default_base_path() {
   if [ -n "${MASC_BASE_PATH:-}" ]; then
     printf '%s\n' "$MASC_BASE_PATH"
-  elif [ -n "${ME_ROOT:-}" ]; then
-    printf '%s\n' "$ME_ROOT"
   else
     printf '%s\n' "$REPO_DIR"
   fi
@@ -48,7 +46,7 @@ Security notes:
   - Run `masc-mcp doctor auth` to verify the config is correct.
 
 Env:
-  MASC_BASE_PATH         Base path for the MASC data root (default: MASC_BASE_PATH, ME_ROOT, then repo root)
+  MASC_BASE_PATH         Base path for the MASC data root (default: MASC_BASE_PATH, then repo root)
   MASC_CODEX_CONFIG_PATH Override the Codex config path (default: ~/.codex/config.toml)
 EOF
   exit 0

--- a/scripts/keeper-runtime-truth-gate.sh
+++ b/scripts/keeper-runtime-truth-gate.sh
@@ -16,8 +16,6 @@ set -euo pipefail
 default_base_path() {
   if [ -n "${MASC_BASE_PATH:-}" ]; then
     printf '%s\n' "$MASC_BASE_PATH"
-  elif [ -n "${ME_ROOT:-}" ]; then
-    printf '%s\n' "$ME_ROOT"
   else
     pwd
   fi

--- a/scripts/keeper-turn-slot-evidence.sh
+++ b/scripts/keeper-turn-slot-evidence.sh
@@ -17,8 +17,6 @@ set -euo pipefail
 default_base_path() {
   if [ -n "${MASC_BASE_PATH:-}" ]; then
     printf '%s\n' "$MASC_BASE_PATH"
-  elif [ -n "${ME_ROOT:-}" ]; then
-    printf '%s\n' "$ME_ROOT"
   else
     pwd
   fi

--- a/scripts/lib/masc-log-path.sh
+++ b/scripts/lib/masc-log-path.sh
@@ -9,8 +9,7 @@
 #                        the server is running, regardless of how it was
 #                        started (argv --base-path, env, or anything else).
 #   3. $MASC_BASE_PATH - env-provided base path; <base>/.masc/logs/system_log_TODAY.jsonl
-#   4. $ME_ROOT        - explicit second-brain workspace root.
-#   5. $PWD            - last fallback.
+#   4. $PWD            - last fallback.
 #
 # Sourced by scripts/logs-follow.sh and scripts/op-f-leak-verification.sh.
 #
@@ -21,10 +20,6 @@
 masc_log_resolve_base() {
   if [ -n "${MASC_BASE_PATH:-}" ]; then
     echo "$MASC_BASE_PATH"
-    return 0
-  fi
-  if [ -n "${ME_ROOT:-}" ]; then
-    echo "$ME_ROOT"
     return 0
   fi
   pwd

--- a/scripts/llama-runtime-pool.sh
+++ b/scripts/llama-runtime-pool.sh
@@ -162,10 +162,6 @@ resolve_llama_server_bin() {
     printf '%s\n' "${SEED_BINARY}"
     return 0
   fi
-  if [ -n "${ME_ROOT:-}" ] && [ -x "$ME_ROOT/.local/bin/llama-server" ]; then
-    printf '%s\n' "$ME_ROOT/.local/bin/llama-server"
-    return 0
-  fi
   if [ -x "$HOME/.local/bin/llama-server" ]; then
     printf '%s\n' "$HOME/.local/bin/llama-server"
     return 0

--- a/scripts/logs-follow.sh
+++ b/scripts/logs-follow.sh
@@ -23,7 +23,7 @@ If you pass a repo or worktree path, the script resolves it to the owning repo r
 Options:
   --base-path <path>    Override MASC base path (default: detected via lsof
                         from the running server; falls back to MASC_BASE_PATH
-                        or ME_ROOT, then cwd when no server is running)
+                        or cwd when no server is running)
   --date <YYYY-MM-DD>   Read a specific log file instead of today's rotating file
   --lines <n>           Tail last N lines before following (default: 40, use 0 for only new lines)
   --level <level>       Minimum level: debug|info|warn|error (default: debug)
@@ -190,8 +190,7 @@ validate_args
 # Resolution order for the log directory (deterministic-first):
 #   1. --base-path override          (user-provided path, run through worktree-aware resolver)
 #   2. helper masc_log_dir           (detects via lsof on the running server when available;
-#                                     falls back to MASC_BASE_PATH, ME_ROOT,
-#                                     ME_ROOT, or cwd)
+#                                     falls back to MASC_BASE_PATH or cwd)
 # This avoids the historical drift where logs-follow defaulted to $HOME
 # while the server actually wrote under <base>/.masc/logs/, leaving
 # operators staring at an empty directory.

--- a/scripts/masc-autonomy-action-stats.py
+++ b/scripts/masc-autonomy-action-stats.py
@@ -14,9 +14,6 @@ def default_base_path() -> str:
     masc_base = os.environ.get("MASC_BASE_PATH", "").strip()
     if masc_base:
         return masc_base
-    me_root = os.environ.get("ME_ROOT", "").strip()
-    if me_root:
-        return me_root
     return os.getcwd()
 
 

--- a/scripts/migrate-keeper-meta-sandbox.sh
+++ b/scripts/migrate-keeper-meta-sandbox.sh
@@ -67,8 +67,6 @@ default_base_path() {
     printf '%s\n' "$BASE_PATH_OVERRIDE"
   elif [ -n "${MASC_BASE_PATH:-}" ]; then
     printf '%s\n' "$MASC_BASE_PATH"
-  elif [ -n "${ME_ROOT:-}" ]; then
-    printf '%s\n' "$ME_ROOT"
   else
     printf '%s\n' "$REPO_ROOT"
   fi

--- a/scripts/oas-drift-check.sh
+++ b/scripts/oas-drift-check.sh
@@ -52,14 +52,12 @@ resolve_source_dir() {
   # Candidate local repo paths, checked in order:
   #   1. $AGENT_SDK_LOCAL_REPO (explicit opt-in)
   #   2. Sibling checkout: <masc-mcp-parent>/oas
-  #   3. Explicit workspace root: $ME_ROOT/workspace/yousleepwhen/oas
   # Each must be a git checkout at the pinned SHA to qualify.
   local masc_parent
   masc_parent="$(cd "${REPO_ROOT}/.." && pwd)"
   local -a candidates=(
     "${AGENT_SDK_LOCAL_REPO:-}"
     "${masc_parent}/oas"
-    "${ME_ROOT:-}/workspace/yousleepwhen/oas"
   )
   local candidate head
   for candidate in "${candidates[@]}"; do

--- a/scripts/op-f-leak-verification.sh
+++ b/scripts/op-f-leak-verification.sh
@@ -10,7 +10,7 @@
 # JSONL log produced by the masc-mcp server.  The log path is resolved
 # via scripts/lib/masc-log-path.sh, which detects the active file from
 # the running server (lsof on the listening socket) and falls back to
-# MASC_BASE_PATH, ME_ROOT, or cwd when no server is
+# MASC_BASE_PATH or cwd when no server is
 # running. No state is kept between runs — re-execute after any merge or restart to refresh
 # the snapshot.
 #
@@ -28,7 +28,7 @@ set -u
 # Resolve the active log path through the SSOT helper.  When the server
 # is running, this detects the actual file via lsof on the listening
 # socket — authoritative regardless of how the server was started.
-# Otherwise falls back to MASC_BASE_PATH, ME_ROOT, or cwd. Override with
+# Otherwise falls back to MASC_BASE_PATH or cwd. Override with
 # $1 or $MASC_LOG when the log lives elsewhere
 # (e.g. /tmp/masc-postmerge.log).
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/sweep-tool-error-signatures.sh
+++ b/scripts/sweep-tool-error-signatures.sh
@@ -29,8 +29,6 @@ OUT_DIR="${2:-}"
 default_base_path() {
   if [ -n "${MASC_BASE_PATH:-}" ]; then
     printf '%s\n' "$MASC_BASE_PATH"
-  elif [ -n "${ME_ROOT:-}" ]; then
-    printf '%s\n' "$ME_ROOT"
   else
     pwd
   fi

--- a/scripts/test_emergent_identity.sh
+++ b/scripts/test_emergent_identity.sh
@@ -17,8 +17,6 @@ TEST_AGENTS=("dreamer" "connector" "historian")
 default_base_path() {
     if [ -n "${MASC_BASE_PATH:-}" ]; then
         printf '%s\n' "$MASC_BASE_PATH"
-    elif [ -n "${ME_ROOT:-}" ]; then
-        printf '%s\n' "$ME_ROOT"
     else
         pwd
     fi

--- a/scripts/verify-bloodflow-restoration.sh
+++ b/scripts/verify-bloodflow-restoration.sh
@@ -44,8 +44,6 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 default_base_path() {
   if [ -n "${MASC_BASE_PATH:-}" ]; then
     printf '%s\n' "$MASC_BASE_PATH"
-  elif [ -n "${ME_ROOT:-}" ]; then
-    printf '%s\n' "$ME_ROOT"
   else
     printf '%s\n' "$ROOT"
   fi

--- a/scripts/viewer-trunk.sh
+++ b/scripts/viewer-trunk.sh
@@ -134,9 +134,6 @@ maybe_prune_trpg_room() {
 
   local room_id="${MASC_TRPG_PRUNE_ROOM_ID:-default}"
   local default_base_path="$PWD"
-  if [[ -n "${ME_ROOT:-}" ]]; then
-    default_base_path="$ME_ROOT"
-  fi
   local base_path="${MASC_TRPG_PRUNE_BASE_PATH:-${MASC_BASE_PATH:-$default_base_path}}"
   local keep_sessions="${MASC_TRPG_PRUNE_KEEP_SESSIONS:-1}"
   local -a prune_args=(

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -162,9 +162,7 @@ is_absolute_path() {
 }
 
 default_base_path() {
-    if [ -n "${ME_ROOT:-}" ]; then
-        printf '%s\n' "$ME_ROOT"
-    elif [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
+    if [ -n "${HOME:-}" ] && [ -d "$HOME/me" ]; then
         printf '%s\n' "$HOME/me"
     else
         printf '%s\n' "$SCRIPT_DIR"
@@ -676,10 +674,8 @@ if [ "$BASE_PATH_EXPLICIT" = "1" ]; then
     BASE_PATH_RESOLUTION_SOURCE="explicit_cli"
 elif [ "$MASC_BASE_PATH_WAS_SET" = "1" ] && is_absolute_path "$BASE_PATH"; then
     BASE_PATH_RESOLUTION_SOURCE="explicit_env"
-elif [ -z "${MASC_BASE_PATH:-}" ] && [ -n "${ME_ROOT:-}" ] && [ "$BASE_PATH" = "$ME_ROOT" ]; then
-    BASE_PATH_RESOLUTION_SOURCE="implicit_me_root"
 elif [ -z "${MASC_BASE_PATH:-}" ] && [ -n "${HOME:-}" ] && [ "$BASE_PATH" = "$HOME/me" ]; then
-    BASE_PATH_RESOLUTION_SOURCE="implicit_me_root"
+    BASE_PATH_RESOLUTION_SOURCE="implicit_home_me"
 fi
 
 if [ "$PORT_EXPLICIT" != "1" ]; then

--- a/test/test_pr_e_sandbox_root_migration.ml
+++ b/test/test_pr_e_sandbox_root_migration.ml
@@ -12,7 +12,7 @@ open Alcotest
     - the literal regressing into [worker_dev_tools.ml]
       ([pinned_home_me_literal_count = 0])
     - the [sandbox_workspace_root] field drifting away from the
-      [MASC_BASE_PATH] / [ME_ROOT] / [/tmp/masc-fleet] contract
+      [MASC_BASE_PATH] / [/tmp/masc-fleet] contract
       (also covered by [test_host_config_resolution] but pinned
       here so the migration intent is explicit). *)
 
@@ -55,10 +55,9 @@ let test_no_home_me_literal_in_worker_dev_tools () =
 let test_sandbox_workspace_root_contract () =
   let d = Host_config.host () in
   let acceptable_roots =
-    match Sys.getenv_opt "MASC_BASE_PATH", Sys.getenv_opt "ME_ROOT" with
-    | Some root, _ when String.trim root <> "" ->
+    match Sys.getenv_opt "MASC_BASE_PATH" with
+    | Some root when String.trim root <> "" ->
       [ Env_config_core.normalize_masc_base_path_input root ]
-    | _, Some root when String.trim root <> "" -> [ root ]
     | _ -> [ "/tmp/masc-fleet" ]
   in
   let actual = d.sandbox_workspace_root in

--- a/test/test_rfc_0085_pr4_tool_library_proof_store.ml
+++ b/test/test_rfc_0085_pr4_tool_library_proof_store.ml
@@ -8,7 +8,7 @@ open Alcotest
     - lib/cdal_runtime/proof_store.ml: Not_found -> "/tmp" 리터럴 및
       home-level [.oas] fallback 제거. cdal_runtime sub-library는
       masc_mcp 본 라이브러리와 격리되어 있으므로 MASC_BASE_PATH /
-      ME_ROOT / cwd 순서만 직접 사용한다.
+      cwd 순서만 직접 사용한다.
 
     AST-based via Ast_grep. *)
 
@@ -38,18 +38,20 @@ let test_no_home_default_in_proof_store () =
   check int "HOME literal removed from proof_store fallback" 0 n
 ;;
 
-let test_proof_store_uses_base_path_inputs () =
+let test_proof_store_uses_base_path_input_only () =
   let path = "lib/cdal_runtime/proof_store.ml" in
   let masc_base =
     Ast_grep.count_string_literals ~module_path:path ~needle:"MASC_BASE_PATH"
   in
-  let me_root = Ast_grep.count_string_literals ~module_path:path ~needle:"ME_ROOT" in
-  if masc_base < 1 || me_root < 1
+  let legacy_me_root =
+    Ast_grep.count_string_literals ~module_path:path ~needle:(String.concat "" [ "ME"; "_ROOT" ])
+  in
+  if masc_base < 1 || legacy_me_root <> 0
   then
     failf
-      "proof_store fallback should use MASC_BASE_PATH and ME_ROOT, got MASC_BASE_PATH=%d ME_ROOT=%d"
+      "proof_store fallback should use MASC_BASE_PATH only, got MASC_BASE_PATH=%d legacy-root=%d"
       masc_base
-      me_root
+      legacy_me_root
 ;;
 
 let () =
@@ -62,7 +64,10 @@ let () =
     ; ( "proof_store"
       , [ test_case "no /tmp literal" `Quick test_no_tmp_default_in_proof_store
         ; test_case "no HOME literal" `Quick test_no_home_default_in_proof_store
-        ; test_case "uses base-path inputs" `Quick test_proof_store_uses_base_path_inputs
+        ; test_case
+            "uses base-path input only"
+            `Quick
+            test_proof_store_uses_base_path_input_only
         ] )
     ]
 ;;

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -68,7 +68,6 @@ let run_shell ?(env = []) ~cwd cmd =
   let scrubbed_env =
     [
       "MASC_STORAGE_TYPE";
-      "ME_ROOT";
       "MASC_KEEPER_BOOTSTRAP_ENABLED";
       "MASC_MCP_PORT";
       "MASC_HOST";

--- a/test/test_tool_library_coverage.ml
+++ b/test/test_tool_library_coverage.ml
@@ -4,8 +4,8 @@
     for 5 tools: masc_library_list, masc_library_read, masc_library_add,
     masc_library_promote, masc_library_search
 
-    Note: Tool_library uses MASC_BASE_PATH first, then ME_ROOT, for
-    library_root(). Tests scrub ME_ROOT and override MASC_BASE_PATH to a
+    Note: Tool_library uses MASC_BASE_PATH first for library_root().
+    Tests override MASC_BASE_PATH to a
     temp directory with the expected structure.
 *)
 
@@ -48,23 +48,18 @@ let setup_library_dirs base_path =
   (lib_dir, cand_dir)
 
 let original_home = Sys.getenv_opt "HOME"
-let original_me_root = Sys.getenv_opt "ME_ROOT"
 let original_masc_base_path = Sys.getenv_opt "MASC_BASE_PATH"
 
 (** Run a test function with a temporary MASC_BASE_PATH containing library dirs. *)
 let with_temp_base_path f =
   let base_path = temp_dir () in
   Unix.putenv "MASC_BASE_PATH" base_path;
-  Unix.putenv "ME_ROOT" "";
   let _ = setup_library_dirs base_path in
   let ctx : Tool_library.context = { agent_name = "test-agent" } in
   Fun.protect ~finally:(fun () ->
     (match original_masc_base_path with
      | Some root -> Unix.putenv "MASC_BASE_PATH" root
      | None -> Unix.putenv "MASC_BASE_PATH" "");
-    (match original_me_root with
-     | Some root -> Unix.putenv "ME_ROOT" root
-     | None -> Unix.putenv "ME_ROOT" "");
     (match original_home with
      | Some h -> Unix.putenv "HOME" h
      | None -> Unix.putenv "HOME" "");


### PR DESCRIPTION
## Summary
- remove ME_ROOT env fallback from MASC runtime/config path resolution, helper scripts, and deployment config
- keep MASC_BASE_PATH/--base-path as the runtime-root contract, with existing per-file cwd/repo/host fallbacks
- update tests and docs so the old private root env is not advertised as supported
- confirmed OAS has no exact ME_ROOT usage

## Verification
- rg -n '\bME_ROOT\b' in masc-mcp and oas returned no matches
- ocamlformat --check changed OCaml files
- bash -n changed shell scripts
- python3 -m py_compile scripts/masc-autonomy-action-stats.py
- git diff --check origin/main..HEAD