### PR TITLE
docs(release): sync v0.19.19 published truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ raw `opam exec -- dune ...` 은 의도적인 CI-parity 점검 때만. 평소 개
 | [docs/PRODUCT-REVIEW.md](docs/PRODUCT-REVIEW.md) | promise 단계별 현재 자세 |
 | [docs/spec/SPEC-INDEX.md](docs/spec/SPEC-INDEX.md) | spec suite |
 | [ROADMAP.md](ROADMAP.md) | 버전 / 릴리즈 / 활성 트랙 |
-| [CHANGELOG.md](CHANGELOG.md) | 버전별 변경 로그 (현재 v0.19.17) |
+| [CHANGELOG.md](CHANGELOG.md) | 버전별 변경 로그 (현재 v0.19.19) |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | 기여 — 사실상 저자 self-discipline 문서 |
 | [llms.txt](llms.txt) / [llms-full.txt](llms-full.txt) | 언어모델용 압축 front door |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Current package version: v0.19.19
 > Latest changelog entry: v0.19.19 (2026-05-17)
-> Latest published GitHub release: v0.19.17 (2026-05-15)
+> Latest published GitHub release: v0.19.19 (2026-05-17)
 > Updated: 2026-05-17
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -11,7 +11,7 @@ code_refs:
 
 > Current package version: v0.19.19
 > Latest changelog entry: v0.19.19 (2026-05-17)
-> Latest published GitHub release: v0.19.17 (2026-05-15)
+> Latest published GitHub release: v0.19.19 (2026-05-17)
 > Updated: 2026-05-17
 > Release line: pre-1.0 (`0.y.z`); legacy `v2.*` tags are frozen history
 


### PR DESCRIPTION
## Summary
- mark v0.19.19 as the latest published GitHub release in ROADMAP and Product Operating Plan
- update README changelog pointer to v0.19.19

## Verification
- scripts/check-version-truth.sh --tag v0.19.19
- bash scripts/check-doc-truth.sh
- bash scripts/check-release-train-guard.sh --base origin/main --head HEAD
- git diff --check