### PR TITLE
[codex] fix keeper board post validation boundary

### DIFF
--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -157,53 +157,87 @@ let pass_result = function
   | _ -> "pass"
 ;;
 
+let validation_schema_of_json ~name json_schema : Agent_sdk.Types.tool_schema =
+  { name; description = ""; parameters = Tool_bridge.params_of_json_schema json_schema }
+;;
+
+let validation_exception_action ~name exn =
+  let error_text = Printexc.to_string exn in
+  let message =
+    Printf.sprintf
+      "Tool '%s' parameter validation failed before dispatch: %s"
+      name
+      error_text
+  in
+  emit_validation_telemetry ~tool:name ~result:"fail" ~reason:"validation_exception";
+  Log.error "%s" message;
+  Reject
+    { Tool_result.success = false
+    ; data =
+        `Assoc
+          [ "error", `String message
+          ; "validation", `String "oas_tool_middleware"
+          ; "exception", `String error_text
+          ]
+    ; legacy_message = message
+    ; tool_name = name
+    ; duration_ms = 0.0
+    ; failure_class = Some Tool_result.Runtime_failure
+    }
+;;
+
 let validation_action ?schema ~name ~args () : Tool_dispatch.pre_hook_action =
-  let lookup name =
+  try
+    let lookup name =
+      let schema =
+        match schema with
+        | Some schema -> Some schema
+        | None -> Tool_dispatch.lookup_schema name
+      in
+      Option.map (validation_schema_of_json ~name) schema
+    in
+    let hook = Agent_sdk.Tool_middleware.make_validation_hook ~lookup in
     let schema =
       match schema with
-      | Some schema -> Some schema
+      | Some _ as schema -> schema
       | None -> Tool_dispatch.lookup_schema name
     in
-    Option.map (Agent_sdk.Tool_middleware.tool_schema_of_json ~name) schema
-  in
-  let hook = Agent_sdk.Tool_middleware.make_validation_hook ~lookup in
-  let schema =
-    match schema with
-    | Some _ as schema -> schema
-    | None -> Tool_dispatch.lookup_schema name
-  in
-  let prepared_args = prepare_args ?schema ~name args in
-  match hook ~name ~args:prepared_args with
-  | Agent_sdk.Tool_middleware.Pass when not (Yojson.Safe.equal prepared_args args) ->
-    let reason = pass_reason ~schema ~args ~prepared_args in
-    let result = pass_result reason in
-    emit_validation_telemetry ~tool:name ~result ~reason;
-    Log.debug "tool_input_validation normalized args for %s" name;
-    Proceed prepared_args
-  | Agent_sdk.Tool_middleware.Pass ->
-    let reason = pass_reason ~schema ~args ~prepared_args in
-    let result = pass_result reason in
-    emit_validation_telemetry ~tool:name ~result ~reason;
-    Pass
-  | Agent_sdk.Tool_middleware.Proceed coerced ->
-    emit_validation_telemetry ~tool:name ~result:"pass" ~reason:"coerced";
-    Log.debug "tool_input_validation coerced args for %s" name;
-    Proceed coerced
-  | Agent_sdk.Tool_middleware.Reject { message; _ } ->
-    emit_validation_telemetry ~tool:name ~result:"fail" ~reason:"invalid_args";
-    Log.info "tool_input_validation rejected %s: %s" name message;
-    Reject
-      { Tool_result.success = false
-      ; data =
-          `Assoc [ "error", `String message; "validation", `String "oas_tool_middleware" ]
-      ; legacy_message = message
-      ; tool_name = name
-      ; duration_ms = 0.0
-      ; (* Input-schema / policy rejection — classify so the
-         dispatch-level metric label (failure_class) reflects the
-         actual category instead of bucketing as "unclassified". *)
-        failure_class = Some Tool_result.Policy_rejection
-      }
+    let prepared_args = prepare_args ?schema ~name args in
+    match hook ~name ~args:prepared_args with
+    | Agent_sdk.Tool_middleware.Pass when not (Yojson.Safe.equal prepared_args args) ->
+      let reason = pass_reason ~schema ~args ~prepared_args in
+      let result = pass_result reason in
+      emit_validation_telemetry ~tool:name ~result ~reason;
+      Log.debug "tool_input_validation normalized args for %s" name;
+      Proceed prepared_args
+    | Agent_sdk.Tool_middleware.Pass ->
+      let reason = pass_reason ~schema ~args ~prepared_args in
+      let result = pass_result reason in
+      emit_validation_telemetry ~tool:name ~result ~reason;
+      Pass
+    | Agent_sdk.Tool_middleware.Proceed coerced ->
+      emit_validation_telemetry ~tool:name ~result:"pass" ~reason:"coerced";
+      Log.debug "tool_input_validation coerced args for %s" name;
+      Proceed coerced
+    | Agent_sdk.Tool_middleware.Reject { message; _ } ->
+      emit_validation_telemetry ~tool:name ~result:"fail" ~reason:"invalid_args";
+      Log.info "tool_input_validation rejected %s: %s" name message;
+      Reject
+        { Tool_result.success = false
+        ; data =
+            `Assoc
+              [ "error", `String message; "validation", `String "oas_tool_middleware" ]
+        ; legacy_message = message
+        ; tool_name = name
+        ; duration_ms = 0.0
+        ; (* Input-schema / policy rejection — classify so the
+             dispatch-level metric label (failure_class) reflects the
+             actual category instead of bucketing as "unclassified". *)
+          failure_class = Some Tool_result.Policy_rejection
+        }
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> validation_exception_action ~name exn
 ;;
 
 let validate_args ?schema ~name ~args () =

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -378,6 +378,9 @@ let masc_goal_list_schema =
 let keeper_fs_edit_schema =
   find_schema_exn "keeper_fs_edit" Config.raw_all_tool_schemas
 
+let keeper_board_post_schema =
+  find_schema_exn "keeper_board_post" Config.raw_all_tool_schemas
+
 let assoc_string key json =
   match Yojson.Safe.Util.member key json with
   | `String value -> value
@@ -403,6 +406,59 @@ let test_registered_hook_keeper_fs_edit_patch_args () =
   Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
   Alcotest.(check bool) "args unchanged" true
     (Yojson.Safe.equal forwarded args)
+
+let keeper_board_post_sources_args =
+  `Assoc
+    [ "content", `String "Keeper board post validation regression"
+    ; "hearth", `String "ops"
+    ; ( "sources"
+      , `List
+          [ `Assoc
+              [ "url", `String "https://example.com/evidence"
+              ; "quote", `String "short supporting snippet"
+              ]
+          ] )
+    ; "judgment", `Assoc [ "summary", `String "sources array should pass" ]
+    ]
+
+let check_keeper_board_post_sources_preserved forwarded =
+  match Yojson.Safe.Util.member "sources" forwarded with
+  | `List [ `Assoc source_fields ] ->
+    Alcotest.(check (option string))
+      "source url preserved"
+      (Some "https://example.com/evidence")
+      (match List.assoc_opt "url" source_fields with
+       | Some (`String value) -> Some value
+       | _ -> None)
+  | other ->
+    Alcotest.failf
+      "expected sources array to be preserved, got %s"
+      (Yojson.Safe.to_string other)
+
+let test_validate_args_keeper_board_post_accepts_sources_array () =
+  match
+    Tool_input_validation.validate_args
+      ~schema:keeper_board_post_schema
+      ~name:"keeper_board_post"
+      ~args:keeper_board_post_sources_args
+      ()
+  with
+  | Ok forwarded -> check_keeper_board_post_sources_preserved forwarded
+  | Error result ->
+    Alcotest.failf
+      "expected keeper_board_post sources array to pass validation, got %s"
+      (Yojson.Safe.to_string result.Tool_result.data)
+
+let test_registered_hook_keeper_board_post_accepts_sources_array () =
+  let blocked, forwarded =
+    run_registered_hook
+      ~schema:keeper_board_post_schema
+      ~tool_name:"keeper_board_post"
+      ~args:keeper_board_post_sources_args
+      ()
+  in
+  Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
+  check_keeper_board_post_sources_preserved forwarded
 
 let validation_labels ~tool ~result ~reason =
   [ "tool", tool; "result", result; "reason", reason ]
@@ -784,8 +840,12 @@ let () =
         test_registered_hook_bypasses_empty_schema;
       Alcotest.test_case "keeper_fs_edit accepts patch args" `Quick
         test_registered_hook_keeper_fs_edit_patch_args;
+      Alcotest.test_case "keeper_board_post accepts sources array" `Quick
+        test_registered_hook_keeper_board_post_accepts_sources_array;
       Alcotest.test_case "direct validation uses explicit schema" `Quick
         test_validate_args_uses_explicit_schema_without_registry;
+      Alcotest.test_case "direct keeper_board_post accepts sources array" `Quick
+        test_validate_args_keeper_board_post_accepts_sources_array;
       Alcotest.test_case "masc_transition compat: to/note keys" `Quick
         test_registered_hook_transition_compat_to_and_note;
       Alcotest.test_case "masc_transition compat: status-like action value" `Quick


### PR DESCRIPTION
## Summary
- Route tool input validation through the same `Tool_bridge.params_of_json_schema` conversion used for the LLM-visible tool surface.
- Convert pre-dispatch validation exceptions into structured `Tool_result` failures so keeper tool calls do not disappear before audit/telemetry hooks run.
- Add regression coverage for `keeper_board_post` with `sources` array payloads through both direct validation and registered pre-hook paths.

## Root Cause
`keeper_board_post` was visible and called, but its schema includes non-scalar/union fields. The validation path used a different JSON-schema conversion than the tool surface path, so certain payloads could raise before dispatch. That bypassed the normal keeper tool lifecycle, making the call appear to vanish without `tool completed` or `.masc/tool_calls` evidence.

## Recurrence Prevention
- Validation and tool exposure now share the same schema bridge, so future schema additions do not split behavior between “tool appears callable” and “validation can execute it”.
- Validation exceptions are contained as structured tool errors, preserving lifecycle telemetry and making failures observable instead of silent.
- `keeper_board_post` array-source behavior is pinned in tests.

## Validation
- `git diff --check`
- `ocamlformat --check lib/tool_input_validation.ml test/test_tool_input_validation.ml`

Focused Dune target was attempted but blocked by the shared `/tmp/me-dune-local.lock`, held by other long-running local builds.