### PR TITLE
fix(keeper_task): map keeper vocabulary onto typed handoff_context

### DIFF
--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -403,6 +403,28 @@ let handle_keeper_task_tool
     if task_id = ""
     then error_json "task_id is required. Use the task_id you got from keeper_task_claim."
     else (
+      (* Map keeper vocabulary (`result`) onto MASC domain typed
+         handoff_context.summary so that the action=done strict-contract
+         path can read the completion summary directly from a typed field
+         instead of relying on string-blob siblings. When [result] is
+         empty we omit handoff_context entirely; the downstream contract
+         check decides whether a summary is mandatory for this task. *)
+      let base_args =
+        [
+          "task_id", `String task_id;
+          "action", `String "done";
+          "notes", `String result_text;
+        ]
+      in
+      let args_for_transition =
+        if String.equal result_text "" then base_args
+        else
+          base_args
+          @ [
+              ( "handoff_context",
+                `Assoc [ "summary", `String result_text ] );
+            ]
+      in
       let transition_result =
         Tool_task.handle_transition
           ~tool_name:"keeper_task_done"
@@ -412,12 +434,7 @@ let handle_keeper_task_tool
             agent_name = keeper_agent_sender ~meta;
             sw = Eio_context.get_switch_opt ();
           }
-          (`Assoc
-             [
-               "task_id", `String task_id;
-               "action", `String "done";
-               "notes", `String result_text;
-             ])
+          (`Assoc args_for_transition)
       in
       keeper_tool_result_json ~ok:transition_result.Tool_result.success ~message:transition_result.Tool_result.legacy_message)
   | "keeper_task_submit_for_verification" ->
@@ -431,6 +448,22 @@ let handle_keeper_task_tool
     else if pr_url = ""
     then error_json "pr_url is required. Include the PR opened for this task."
     else (
+      (* Map keeper vocabulary (notes + pr_url) onto MASC domain typed
+         handoff_context fields: notes -> summary, [pr_url] -> evidence_refs.
+         Previously these were concatenated into a single [notes] blob
+         ("notes\nPR: pr_url") which lost the structural separation and
+         left strict-contract callers without a typed evidence_refs list
+         to inspect. We continue to send the legacy concatenated [notes]
+         too for backward compatibility with any downstream reader that
+         still expects it, but the canonical signal is now the typed
+         handoff_context. *)
+      let handoff_context =
+        `Assoc
+          [
+            "summary", `String notes;
+            "evidence_refs", `List [ `String pr_url ];
+          ]
+      in
       let transition_result =
         Tool_task.handle_transition
           ~tool_name:"keeper_task_submit_for_verification"
@@ -445,6 +478,7 @@ let handle_keeper_task_tool
                "task_id", `String task_id;
                "action", `String "submit_for_verification";
                "notes", `String (notes ^ "\nPR: " ^ pr_url);
+               "handoff_context", handoff_context;
              ])
       in
       keeper_tool_result_json ~ok:transition_result.Tool_result.success ~message:transition_result.Tool_result.legacy_message)

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -1753,6 +1753,111 @@ let test_submit_for_verification_transitions_task () =
         | _ -> fail "expected keeper_task_submit_for_verification to succeed")))
 ;;
 
+(* Regression: keeper_task_done must map [result] onto the typed
+   [handoff_context.summary] domain field, not just dump it into [notes]
+   as an untyped blob. Previously a [result] sent by a keeper would be
+   forwarded as [notes] only, and strict-contract callers had to rely on
+   the [parse_handoff_context] sibling-synthesis fallback to recover a
+   summary — keeping the vocabulary translation implicit and causing
+   keeper-facing error messages to surface as "handoff_context.summary
+   is required" even though the keeper had supplied [result]. *)
+let test_done_maps_result_to_typed_handoff_summary () =
+  with_room (fun config ->
+    let meta = make_test_meta () in
+    let _ =
+      Coord.add_task
+        config
+        ~title:"Vocab translation task"
+        ~priority:1
+        ~description:"verify result -> handoff_context.summary"
+    in
+    let task_id = (only_task config).id in
+    ignore (call_tool config meta "keeper_task_claim" (`Assoc []));
+    let result =
+      call_tool
+        config
+        meta
+        "keeper_task_done"
+        (`Assoc
+            [ "task_id", `String task_id
+            ; "result", `String "refactored module, all tests green"
+            ])
+    in
+    let json = parse_json result in
+    match Yojson.Safe.Util.member "ok" json with
+    | `Bool true ->
+      let task = only_task config in
+      (match task.handoff_context with
+       | Some hc ->
+         check
+           string
+           "result mapped to typed handoff_context.summary"
+           "refactored module, all tests green"
+           hc.summary
+       | None ->
+         fail "expected handoff_context to be populated after keeper_task_done")
+    | _ -> fail "expected keeper_task_done to succeed for non-strict contract")
+;;
+
+(* Regression: keeper_task_submit_for_verification must map [notes] +
+   [pr_url] onto the typed handoff_context fields [summary] and
+   [evidence_refs], not concatenate them into a single [notes] string
+   blob. The previous shape ("notes\nPR: pr_url") lost the structural
+   separation and left downstream consumers without a typed
+   evidence_refs list. *)
+let test_submit_for_verification_maps_to_typed_handoff_evidence_refs () =
+  ensure_rng ();
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
+    with_env "MASC_CDAL_GATE_ENABLED" (Some "false") (fun () ->
+      with_room (fun config ->
+        let meta = make_test_meta () in
+        let contract = strict_contract ~verify_gate_evidence:[ "pr_url" ] () in
+        let _ =
+          Coord.add_task
+            ~contract
+            config
+            ~title:"Vocab translation submit task"
+            ~priority:1
+            ~description:"verify notes/pr_url -> typed handoff_context"
+        in
+        let task_id = (only_task config).id in
+        ignore (call_tool config meta "keeper_task_claim" (`Assoc []));
+        let pr_url = "https://github.com/jeong-sik/masc-mcp/pull/12345" in
+        let result =
+          call_tool
+            config
+            meta
+            "keeper_task_submit_for_verification"
+            (`Assoc
+                [ "task_id", `String task_id
+                ; "notes", `String "tests pass locally"
+                ; "pr_url", `String pr_url
+                ])
+        in
+        let json = parse_json result in
+        match Yojson.Safe.Util.member "ok" json with
+        | `Bool true ->
+          let task = only_task config in
+          (match task.handoff_context with
+           | Some hc ->
+             check
+               string
+               "notes mapped to typed handoff_context.summary"
+               "tests pass locally"
+               hc.summary;
+             check
+               (list string)
+               "pr_url mapped to typed handoff_context.evidence_refs"
+               [ pr_url ]
+               hc.evidence_refs
+           | None ->
+             fail
+               "expected handoff_context to be populated after \
+                keeper_task_submit_for_verification")
+        | _ ->
+          fail "expected keeper_task_submit_for_verification to succeed")))
+;;
+
 (* --- keeper_tool_search tests --- *)
 
 let test_tool_search_empty_query_returns_error () =
@@ -2005,6 +2110,10 @@ let () =
             "default contract redirects to verification FSM"
             `Quick
             test_done_redirects_default_contract_task_to_verification_fsm
+        ; test_case
+            "result maps to typed handoff_context.summary"
+            `Quick
+            test_done_maps_result_to_typed_handoff_summary
         ] )
     ; ( "submit_for_verification"
       , [ test_case "requires pr_url" `Quick test_submit_for_verification_requires_pr_url
@@ -2012,6 +2121,10 @@ let () =
             "transitions task"
             `Quick
             test_submit_for_verification_transitions_task
+        ; test_case
+            "notes/pr_url map to typed handoff_context fields"
+            `Quick
+            test_submit_for_verification_maps_to_typed_handoff_evidence_refs
         ] )
     ; ( "keeper_tool_search"
       , [ test_case


### PR DESCRIPTION
## Summary

`keeper_task_done` 과 `keeper_task_submit_for_verification` wrapper가 keeper-facing 어휘(`result`, `notes`, `pr_url`)를 *typed* `Masc_domain.task_handoff_context` field로 매핑하지 않고 *untyped string blob*(`notes`)으로 forward 하던 vocabulary-translation gap을 닫는다.

PR #15815 의 후속 — #15815 가 `masc_transition` *직접 호출* path 의 action-aware strictness 를 fix 했다면, 본 PR 은 *keeper wrapper* path 의 typed mapping gap 을 fix.

### 증상 (motif: nick0cave 와 동일 종류의 sensitivity)

1. keeper 가 `keeper_task_done(task_id, result="…")` 호출
2. wrapper 가 `result` 를 `notes` 로만 forward (handoff_context 미생성)
3. strict contract 면 transition layer 가 *sibling synthesis fallback* 으로 summary 를 회수 시도
4. fallback 실패 시 keeper 에게 `handoff_context.summary is required` error 가 *`masc_transition`* 이름으로 회신 — keeper 입장에선 `result` 보냈는데 왜 `summary` 인지 vocab confusion

`keeper_task_submit_for_verification` 도 같은 motif: `notes` 와 `pr_url` 을 `notes ^ \"\\nPR: \" ^ pr_url` 으로 concat 해 string blob 으로 forward 했고, typed `evidence_refs: string list` 자리에 정보가 흐를 곳이 없었다.

### Fix

| Path | Before | After |
|---|---|---|
| `keeper_task_done` | `notes = result` 만 | `notes = result` + (result 비어있지 않으면) `handoff_context = { summary = result }` |
| `keeper_task_submit_for_verification` | `notes = notes ^ \"\\nPR: \" ^ pr_url` 만 | 동일 legacy notes 유지(BC) + `handoff_context = { summary = notes; evidence_refs = [pr_url] }` typed mapping |

빈 `result` 는 `keeper_task_done` 에서 그대로 통과 (non-strict contract 동작 unchanged). `submit_for_verification` 은 이미 `notes`/`pr_url` strict required 라 항상 typed mapping 활성.

### Test

`test/test_keeper_task_dispatch.ml` 에 회귀 가드 2건 추가:

1. `test_done_maps_result_to_typed_handoff_summary` — `keeper_task_done` 후 `task.handoff_context.summary == result_text`.
2. `test_submit_for_verification_maps_to_typed_handoff_evidence_refs` — submit 후 `summary == notes` AND `evidence_refs == [pr_url]`.

run-list 등록 완료 (`done` group + `submit_for_verification` group).

### 검증

- 로컬 `dune build @check` 미실행 (cross-worktree dune-project collision — memory `reference_masc_mcp_dune_local_lock_contention.md`). CI gate 의존.
- behavioral regression risk: 기존 `notes` blob 은 그대로 forward 하므로 downstream reader 변경 없음. typed handoff_context 추가 채널만 신규.

## Test plan

- [ ] CI green
- [ ] `test_done_maps_result_to_typed_handoff_summary` pass
- [ ] `test_submit_for_verification_maps_to_typed_handoff_evidence_refs` pass
- [ ] strict contract 테스트(`test_done_respects_persisted_cdal_gate`, `test_submit_for_verification_transitions_task`) 회귀 없음

## Related

- Stack-independent of PR #15815 (둘 다 `origin/main` base, 다른 파일).
- 사용자 명시 요청 \"keeper 예민함 색출\" 결과 top-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>