### PR TITLE
feat(sse-event): RFC-0004 PR-3b migrate agent_completed/agent_failed with caller-supplied addendum

### DIFF
--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -564,6 +564,11 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
          ~agent_name
          ~task_id)
   | Agent_sdk.Event_bus.AgentCompleted { agent_name; task_id; elapsed; result } ->
+    (* RFC-0004 Phase A0.1 PR-3b: migrated to Sse_event.agent_completed
+       with a caller-supplied addendum.  The leaf event library stays
+       free of [Agent_sdk] dependencies -- [agent_completed_result_fields]
+       remains here because it closes over [Agent_sdk.Types.api_response]
+       and the cost-observation Prometheus side effect. *)
     (match result with
      | Ok (response : Agent_sdk.Types.api_response) ->
        let provider =
@@ -577,25 +582,25 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
        in
        observe_inference_cost ~provider ~model_bucket cost_usd
      | Error _ -> ());
-    let payload =
-      `Assoc
-        ([ "agent_name", `String agent_name
-         ; "task_id", `String task_id
-         ; "elapsed_s", `Float elapsed
-         ]
-         @ agent_completed_result_fields result)
-    in
-    Some (wrap ~event_type:"agent_completed" ~payload ~agent_name ~task_id ())
+    Some
+      (Sse_event.agent_completed
+         ~ts_unix:ts
+         ~correlation_id
+         ~run_id
+         ~agent_name
+         ~task_id
+         ~elapsed_s:elapsed
+         ~result_fields:(agent_completed_result_fields result))
   | Agent_sdk.Event_bus.AgentFailed { agent_name; task_id; error; elapsed } ->
-    let payload =
-      `Assoc
-        ([ "agent_name", `String agent_name
-         ; "task_id", `String task_id
-         ; "elapsed_s", `Float elapsed
-         ]
-         @ agent_failed_error_fields error)
-    in
-    Some (wrap ~event_type:"agent_failed" ~payload ~agent_name ~task_id ())
+    Some
+      (Sse_event.agent_failed
+         ~ts_unix:ts
+         ~correlation_id
+         ~run_id
+         ~agent_name
+         ~task_id
+         ~elapsed_s:elapsed
+         ~error_fields:(agent_failed_error_fields error))
   | Agent_sdk.Event_bus.ToolCalled { agent_name; tool_name; _ } ->
     (* RFC-0004 Phase A0.1 PR-3 *)
     Some

--- a/lib/sse_event/sse_event.atd
+++ b/lib/sse_event/sse_event.atd
@@ -106,3 +106,34 @@ type slot_scheduler_observed_payload = {
   queue_length: int;
   state: string;
 }
+
+(* PR-3b events: agent_completed, agent_failed.
+
+   These two events carry a variable-shape payload tail beyond the
+   three base fields (agent_name, task_id, elapsed_s).  The tail is
+   produced by cascade-local helpers that close over Agent_sdk
+   variant types (Agent_sdk.Types.api_response, Agent_sdk.Error.t,
+   Keeper_agent_error / Keeper_turn_terminal_code).
+
+   Bringing those variant types into a leaf event library would
+   force Agent_sdk dependency on the leaf -- the same boundary
+   violation that motivated splitting agent_completed / agent_failed
+   off of PR-3.
+
+   Design choice: atd encodes the three base fields only, and the
+   typed constructor in [Sse_event] accepts a caller-supplied
+   [(string * Yojson.Safe.t) list] addendum which is appended to
+   the atd record output.  Byte-equality with the previous inline
+   `Assoc-construction path is verified in test_sse_event.ml. *)
+
+type agent_completed_payload = {
+  agent_name: string;
+  task_id: string;
+  elapsed_s: float;
+}
+
+type agent_failed_payload = {
+  agent_name: string;
+  task_id: string;
+  elapsed_s: float;
+}

--- a/lib/sse_event/sse_event.ml
+++ b/lib/sse_event/sse_event.ml
@@ -481,3 +481,94 @@ let slot_scheduler_observed
     }
     payload_json
 ;;
+
+(** Append a caller-supplied addendum to an atd-emitted record JSON.
+
+    Used by [agent_completed] and [agent_failed] to splice the
+    cascade-local Result/Error projection ([result_fields] /
+    [error_fields]) onto the typed base record without forcing the
+    leaf event library to depend on [Agent_sdk] variant types.
+
+    Field order is [<base record fields in atd declaration order> @
+    <addendum>], which matches the previous inline `Assoc path in
+    [cascade_event_bridge.ml] and is the property the byte-equal
+    tests in [test_sse_event.ml] pin against. *)
+let merge_addendum_into_record
+      (record_json : Yojson.Safe.t)
+      (addendum : (string * Yojson.Safe.t) list)
+  : Yojson.Safe.t
+  =
+  match record_json with
+  | `Assoc base -> `Assoc (base @ addendum)
+  | _ ->
+    invalid_arg
+      "Sse_event.merge_addendum_into_record: atdgen record JSON must be `Assoc"
+;;
+
+(** Emit an [agent_completed] envelope.  The cascade arm in
+    [cascade_event_bridge.ml] retains its [observe_inference_cost]
+    side effect (Prometheus histogram) and invokes
+    [agent_completed_result_fields result] to project the
+    [Agent_sdk] [Result.t] into the [result_fields] addendum. *)
+let agent_completed
+      ~(ts_unix : float)
+      ~(correlation_id : string)
+      ~(run_id : string)
+      ~(agent_name : string)
+      ~(task_id : string)
+      ~(elapsed_s : float)
+      ~(result_fields : (string * Yojson.Safe.t) list)
+  : Yojson.Safe.t
+  =
+  let base_json =
+    let p : Sse_event_t.agent_completed_payload =
+      { agent_name; task_id; elapsed_s }
+    in
+    Yojson.Safe.from_string (Sse_event_j.string_of_agent_completed_payload p)
+  in
+  let payload_json = merge_addendum_into_record base_json result_fields in
+  wrap_envelope
+    { event_type = "agent_completed"
+    ; ts_unix
+    ; correlation_id
+    ; run_id
+    ; agent_name = Some agent_name
+    ; task_id = Some task_id
+    ; turn = None
+    ; tool_name = None
+    }
+    payload_json
+;;
+
+(** Emit an [agent_failed] envelope.  The cascade arm invokes
+    [agent_failed_error_fields error] to project the [Agent_sdk]
+    [Error.t] into the [error_fields] addendum. *)
+let agent_failed
+      ~(ts_unix : float)
+      ~(correlation_id : string)
+      ~(run_id : string)
+      ~(agent_name : string)
+      ~(task_id : string)
+      ~(elapsed_s : float)
+      ~(error_fields : (string * Yojson.Safe.t) list)
+  : Yojson.Safe.t
+  =
+  let base_json =
+    let p : Sse_event_t.agent_failed_payload =
+      { agent_name; task_id; elapsed_s }
+    in
+    Yojson.Safe.from_string (Sse_event_j.string_of_agent_failed_payload p)
+  in
+  let payload_json = merge_addendum_into_record base_json error_fields in
+  wrap_envelope
+    { event_type = "agent_failed"
+    ; ts_unix
+    ; correlation_id
+    ; run_id
+    ; agent_name = Some agent_name
+    ; task_id = Some task_id
+    ; turn = None
+    ; tool_name = None
+    }
+    payload_json
+;;

--- a/lib/sse_event/sse_event.mli
+++ b/lib/sse_event/sse_event.mli
@@ -137,3 +137,35 @@ val slot_scheduler_observed
   -> queue_length:int
   -> state:string
   -> Yojson.Safe.t
+
+(** [agent_completed] and [agent_failed] carry a variable-shape
+    payload tail beyond the three base fields ([agent_name],
+    [task_id], [elapsed_s]).  The tail comes from cascade-local
+    helpers ([agent_completed_result_fields] /
+    [agent_failed_error_fields]) that close over [Agent_sdk]
+    variant types.  To keep [Sse_event] free of [Agent_sdk]
+    dependencies, the caller projects the tail into a
+    [(string * Yojson.Safe.t) list] and passes it via
+    [~result_fields] / [~error_fields].  The list is appended to
+    the atd-emitted base record in declaration order, preserving
+    byte equality with the previous inline `Assoc-construction path. *)
+
+val agent_completed
+  :  ts_unix:float
+  -> correlation_id:string
+  -> run_id:string
+  -> agent_name:string
+  -> task_id:string
+  -> elapsed_s:float
+  -> result_fields:(string * Yojson.Safe.t) list
+  -> Yojson.Safe.t
+
+val agent_failed
+  :  ts_unix:float
+  -> correlation_id:string
+  -> run_id:string
+  -> agent_name:string
+  -> task_id:string
+  -> elapsed_s:float
+  -> error_fields:(string * Yojson.Safe.t) list
+  -> Yojson.Safe.t

--- a/test/sse_event/test_sse_event.ml
+++ b/test/sse_event/test_sse_event.ml
@@ -620,6 +620,195 @@ let test_slot_scheduler_observed_byte_equal () =
     typed
 ;;
 
+(* === PR-3b byte-equal cases: agent_completed (Ok + Error), agent_failed.
+
+   These three cases pin the caller-supplied-addendum splice path
+   (Sse_event.merge_addendum_into_record) against the pre-PR-3b
+   inline `Assoc construction in cascade_event_bridge.ml.  Field
+   order is [base record (atd declaration order) @ addendum]. *)
+
+let baseline_agent_completed ~agent_name ~task_id ~elapsed_s ~result_fields =
+  let payload =
+    `Assoc
+      ([ "agent_name", `String agent_name
+       ; "task_id", `String task_id
+       ; "elapsed_s", `Float elapsed_s
+       ]
+       @ result_fields)
+  in
+  baseline_wrap_event
+    ~ts:common_ts
+    ~correlation_id:common_corr
+    ~run_id:common_run
+    ~event_type:"agent_completed"
+    ~payload
+    ~agent_name
+    ~task_id
+    ()
+;;
+
+let baseline_agent_failed ~agent_name ~task_id ~elapsed_s ~error_fields =
+  let payload =
+    `Assoc
+      ([ "agent_name", `String agent_name
+       ; "task_id", `String task_id
+       ; "elapsed_s", `Float elapsed_s
+       ]
+       @ error_fields)
+  in
+  baseline_wrap_event
+    ~ts:common_ts
+    ~correlation_id:common_corr
+    ~run_id:common_run
+    ~event_type:"agent_failed"
+    ~payload
+    ~agent_name
+    ~task_id
+    ()
+;;
+
+let agent_completed_ok_fields : (string * Yojson.Safe.t) list =
+  (* Shape mirrors cascade_event_bridge.agent_completed_result_fields
+     for the Ok branch, including the usage tail.  Concrete values are
+     arbitrary -- the test pins the byte-equal property, not the
+     business meaning. *)
+  [ "success", `Bool true
+  ; "result", `String "ok"
+  ; "response_id", `String "resp_abc"
+  ; "model", `String "claude-opus-4-7"
+  ; "stop_reason", `String "end_turn"
+  ; "input_tokens", `Int 1234
+  ; "output_tokens", `Int 567
+  ; "cost_usd", `Float 0.0125
+  ]
+;;
+
+let agent_completed_error_fields : (string * Yojson.Safe.t) list =
+  [ "success", `Bool false
+  ; "result", `String "error"
+  ; "error", `String "MaxTurnsExceeded { turns = 20; limit = 20 }"
+  ; "usage_reported", `Bool false
+  ]
+;;
+
+let agent_failed_error_fields_sample : (string * Yojson.Safe.t) list =
+  [ "error", `String "MaxTurnsExceeded { turns = 20; limit = 20 }"
+  ; "error_domain", `String "max_turns"
+  ; "error_code", `String "max_turns_exceeded"
+  ; "error_retryable", `Bool false
+  ; ( "error_detail"
+    , `Assoc
+        [ "variant", `String "max_turns_exceeded"
+        ; "turns", `Int 20
+        ; "limit", `Int 20
+        ] )
+  ]
+;;
+
+let test_agent_completed_ok_byte_equal () =
+  let baseline =
+    Yojson.Safe.to_string
+      (baseline_agent_completed
+         ~agent_name:"alpha"
+         ~task_id:"task_42"
+         ~elapsed_s:3.5
+         ~result_fields:agent_completed_ok_fields)
+  in
+  let typed =
+    Yojson.Safe.to_string
+      (Sse_event.agent_completed
+         ~ts_unix:common_ts
+         ~correlation_id:common_corr
+         ~run_id:common_run
+         ~agent_name:"alpha"
+         ~task_id:"task_42"
+         ~elapsed_s:3.5
+         ~result_fields:agent_completed_ok_fields)
+  in
+  Alcotest.(check string)
+    "agent_completed (Ok) typed == baseline"
+    baseline
+    typed
+;;
+
+let test_agent_completed_error_byte_equal () =
+  let baseline =
+    Yojson.Safe.to_string
+      (baseline_agent_completed
+         ~agent_name:"alpha"
+         ~task_id:"task_42"
+         ~elapsed_s:3.5
+         ~result_fields:agent_completed_error_fields)
+  in
+  let typed =
+    Yojson.Safe.to_string
+      (Sse_event.agent_completed
+         ~ts_unix:common_ts
+         ~correlation_id:common_corr
+         ~run_id:common_run
+         ~agent_name:"alpha"
+         ~task_id:"task_42"
+         ~elapsed_s:3.5
+         ~result_fields:agent_completed_error_fields)
+  in
+  Alcotest.(check string)
+    "agent_completed (Error) typed == baseline"
+    baseline
+    typed
+;;
+
+let test_agent_failed_byte_equal () =
+  let baseline =
+    Yojson.Safe.to_string
+      (baseline_agent_failed
+         ~agent_name:"alpha"
+         ~task_id:"task_42"
+         ~elapsed_s:3.5
+         ~error_fields:agent_failed_error_fields_sample)
+  in
+  let typed =
+    Yojson.Safe.to_string
+      (Sse_event.agent_failed
+         ~ts_unix:common_ts
+         ~correlation_id:common_corr
+         ~run_id:common_run
+         ~agent_name:"alpha"
+         ~task_id:"task_42"
+         ~elapsed_s:3.5
+         ~error_fields:agent_failed_error_fields_sample)
+  in
+  Alcotest.(check string) "agent_failed typed == baseline" baseline typed
+;;
+
+let test_agent_completed_empty_addendum_byte_equal () =
+  (* Regression guard for the empty-addendum case -- byte-equal
+     property must hold even when [result_fields = []], confirming
+     the splice helper does not introduce trailing commas / spacing. *)
+  let baseline =
+    Yojson.Safe.to_string
+      (baseline_agent_completed
+         ~agent_name:"alpha"
+         ~task_id:"task_42"
+         ~elapsed_s:0.001
+         ~result_fields:[])
+  in
+  let typed =
+    Yojson.Safe.to_string
+      (Sse_event.agent_completed
+         ~ts_unix:common_ts
+         ~correlation_id:common_corr
+         ~run_id:common_run
+         ~agent_name:"alpha"
+         ~task_id:"task_42"
+         ~elapsed_s:0.001
+         ~result_fields:[])
+  in
+  Alcotest.(check string)
+    "agent_completed (empty addendum) typed == baseline"
+    baseline
+    typed
+;;
+
 let test_json_string_opt_empty_to_null () =
   (* Regression guard for the empty-string-coerced-to-null semantics
      that atd's default nullable does NOT express. *)
@@ -670,6 +859,13 @@ let () =
             test_content_replacement_kept_byte_equal
         ; Alcotest.test_case "slot_scheduler_observed" `Quick
             test_slot_scheduler_observed_byte_equal
+        ; Alcotest.test_case "agent_completed (Ok)" `Quick
+            test_agent_completed_ok_byte_equal
+        ; Alcotest.test_case "agent_completed (Error)" `Quick
+            test_agent_completed_error_byte_equal
+        ; Alcotest.test_case "agent_failed" `Quick test_agent_failed_byte_equal
+        ; Alcotest.test_case "agent_completed (empty addendum)" `Quick
+            test_agent_completed_empty_addendum_byte_equal
         ] )
     ; ( "json_string_opt"
       , [ Alcotest.test_case "Some empty → null" `Quick


### PR DESCRIPTION
## Summary

RFC-0004 Phase A0.1 PR-3b. Closes the variable-shape payload gap deferred from PR-3 (#15824). Migrates `AgentCompleted` + `AgentFailed` cascade arms to typed `Sse_event` constructors.

### Design choice — caller-supplied addendum

| Option | Verdict | Reason |
|---|---|---|
| A. atd polymorphic variant (`Ok of ... \| Error of ...`) | Rejected for PR-3b | Forces `Sse_event` to mirror `Agent_sdk` field schema → leaks `Agent_sdk` dep into leaf lib (same boundary the PR-3 split exists to preserve) |
| **B. atd base record + caller addendum `(string * Yojson.Safe.t) list`** | **Chosen** | Typed contract on 3 base fields; variable tail stays in caller. Same separation as PR-4 `SlotSchedulerObserved` (state variant→string in cascade arm) |
| C. Both-branches-optional record (`success: bool` + `*_ok: option` / `*_err: option`) | Rejected outright | Anti-pattern (illegal states representable). Parse-don't-validate violation |

Future migration to (A) is gated on a stable `Agent_sdk` surface — a separate RFC.

## Implementation

- `lib/sse_event/sse_event.atd`: 2 new base records (3 fields each: `agent_name`, `task_id`, `elapsed_s`)
- `lib/sse_event/sse_event.ml`:
  - Internal helper `merge_addendum_into_record` splices addendum after the atd record's `` `Assoc`` fields. `invalid_arg` guards the atdgen-record-must-be-`` `Assoc`` invariant
  - 2 typed constructors: `agent_completed ~result_fields`, `agent_failed ~error_fields`
- `lib/sse_event/sse_event.mli`: 2 vals + doc block explaining the design
- `lib/cascade/cascade_event_bridge.ml`: 2 arms migrated. AgentCompleted arm **retains** its `observe_inference_cost` Prometheus side effect on the Ok branch. `agent_completed_result_fields` / `agent_failed_error_fields` helpers remain in cascade (close over `Agent_sdk` / `Keeper_*` types)

## Verification — 4 NEW byte-equal cases

| Case | Addendum shape |
|---|---|
| agent_completed (Ok) | 8 fields: success, result, response_id, model, stop_reason, input_tokens, output_tokens, cost_usd |
| agent_completed (Error) | 4 fields: success, result, error, usage_reported |
| agent_failed | 5 fields including nested `` `Assoc`` (error_detail with variant tag) |
| agent_completed (empty addendum) | `[]` — regression guard for splice helper edge case |

**19/19 PASS** (`dune exec test/sse_event/test_sse_event.exe`): previous 15 + 4 new.
`dune build --root . lib/cascade` succeeds.

## Files

| File | LOC |
|---|---|
| lib/sse_event/sse_event.atd | +33 |
| lib/sse_event/sse_event.ml | +92 |
| lib/sse_event/sse_event.mli | +36 |
| lib/cascade/cascade_event_bridge.ml | ~30 churn |
| test/sse_event/test_sse_event.ml | +185 |

Total: 5 files, +373 / -18

## Test plan

- [ ] CI green
- [ ] Byte-equal tests pass in CI

## Workaround Rejection Bar self-check

| Signature | Status |
|---|---|
| 1. Counter-as-Fix (텔레메트리-as-fix) | N/A — no new counter |
| 2. String classifier 보강 | N/A — caller addendum is a typed list, not a string match |
| 3. N-of-M 패치 | **Closes** PR-3's deferred 2 sites; not "completed K of M sites" admission — the deferral was a design decision, now resolved |
| 6. Test backdoor | N/A — no `set_*_for_test` exposed |
| 7. Same typo N sites | N/A |

`invalid_arg` in the splice helper is an *invariant violation guard* (atdgen contract), not a workaround. The closest signature is checklist item 4 (catch-all addition), but here the `_` arm raises immediately — does **not** silently coerce / classify / dedupe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)