### PR TITLE
cleanup(tool_task): remove legacy pr_url -> notes string blob

### DIFF
--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -449,14 +449,9 @@ let handle_keeper_task_tool
     then error_json "pr_url is required. Include the PR opened for this task."
     else (
       (* Map keeper vocabulary (notes + pr_url) onto MASC domain typed
-         handoff_context fields: notes -> summary, [pr_url] -> evidence_refs.
-         Previously these were concatenated into a single [notes] blob
-         ("notes\nPR: pr_url") which lost the structural separation and
-         left strict-contract callers without a typed evidence_refs list
-         to inspect. We continue to send the legacy concatenated [notes]
-         too for backward compatibility with any downstream reader that
-         still expects it, but the canonical signal is now the typed
-         handoff_context. *)
+         handoff_context fields: notes -> summary, [pr_url] ->
+         evidence_refs. The previous concat blob
+         ("notes\nPR: pr_url") had no in-repo reader and is removed. *)
       let handoff_context =
         `Assoc
           [
@@ -477,7 +472,7 @@ let handle_keeper_task_tool
              [
                "task_id", `String task_id;
                "action", `String "submit_for_verification";
-               "notes", `String (notes ^ "\nPR: " ^ pr_url);
+               "notes", `String notes;
                "handoff_context", handoff_context;
              ])
       in

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -897,22 +897,52 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
         else
           List.filter (fun (k, _) -> not (String.equal k "to") || not (has "action")) kvs
       in
+      (* Transport-level alias [pr_url] is hoisted into the typed
+         [handoff_context.evidence_refs] list. Previously this aliased
+         into a "PR: <url>" string blob inside [notes], which the
+         downstream task-handoff schema then had to recover via
+         sibling synthesis or substring scanning. There is no
+         in-repo reader of that [notes] blob — pr_url consumers
+         (keeper_tool_call_log, keeper_hooks_oas, audit_keeper_*)
+         already read pr_url as a typed field elsewhere — so the
+         legacy blob is dead-on-write.
+
+         Merge semantics: if a [handoff_context] object is already
+         present in args, append pr_url to its [evidence_refs]
+         (preserving any existing refs). Otherwise inject a new
+         minimal handoff_context = { evidence_refs = [pr_url] }. *)
       let kvs =
         match List.find_opt (fun (k, _) -> String.equal k "pr_url") kvs with
         | Some (_, `String pr_url) when not (String.equal pr_url "") ->
             let kvs = List.filter (fun (k, _) -> not (String.equal k "pr_url")) kvs in
-            let kvs =
-              match List.find_opt (fun (k, _) -> String.equal k "notes") kvs with
-              | Some (_, `String notes) ->
-                  List.map
-                    (fun (k, v) ->
-                      if String.equal k "notes"
-                      then ("notes", `String (notes ^ "\nPR: " ^ pr_url))
-                      else (k, v))
-                    kvs
-              | _ -> kvs @ [ ("notes", `String ("PR: " ^ pr_url)) ]
+            let merge_pr_url_into_handoff (hc : Yojson.Safe.t) : Yojson.Safe.t =
+              match hc with
+              | `Assoc hc_fields ->
+                let existing_refs =
+                  match List.assoc_opt "evidence_refs" hc_fields with
+                  | Some (`List xs) -> xs
+                  | _ -> []
+                in
+                let new_refs = existing_refs @ [ `String pr_url ] in
+                let hc_fields =
+                  List.filter
+                    (fun (k, _) -> not (String.equal k "evidence_refs"))
+                    hc_fields
+                  @ [ "evidence_refs", `List new_refs ]
+                in
+                `Assoc hc_fields
+              | _ -> `Assoc [ "evidence_refs", `List [ `String pr_url ] ]
             in
-            kvs
+            (match List.find_opt (fun (k, _) -> String.equal k "handoff_context") kvs with
+             | Some _ ->
+               List.map
+                 (fun (k, v) ->
+                   if String.equal k "handoff_context"
+                   then ("handoff_context", merge_pr_url_into_handoff v)
+                   else (k, v))
+                 kvs
+             | None ->
+               kvs @ [ "handoff_context", merge_pr_url_into_handoff `Null ])
         | Some _ -> List.filter (fun (k, _) -> not (String.equal k "pr_url")) kvs
         | None -> kvs
       in

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1253,6 +1253,76 @@ let () = test "transition_submit_for_verification_rejects_todo_pr_evidence" (fun
     assert_task_todo ctx)
 )
 
+(* Regression: the transport-level [pr_url] alias must be hoisted onto
+   the typed [handoff_context.evidence_refs] domain, not concatenated
+   into the [notes] string blob. *)
+let () = test "transition_normalize_pr_url_into_typed_handoff_context" (fun () ->
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
+    let ctx = make_test_ctx_with_agent "codex-mcp-client" in
+    add_task_requiring_tools ctx ~title:"Typed pr_url normalize" [ "keeper_bash" ];
+    let pr_url = "https://github.com/jeong-sik/masc-mcp/pull/77777" in
+    let submit_result =
+      Tool_task.handle_transition
+        ~agent_tool_names:[ "masc_status"; "masc_transition" ]
+        ~tool_name:"test_tool" ~start_time:0.0
+        ctx
+        (`Assoc
+          [
+            ("task_id", `String "task-001");
+            ("action", `String "submit_pr_evidence");
+            ("pr_url", `String pr_url);
+            ("notes", `String "evidence available");
+          ])
+    in
+    if not submit_result.Tool_result.success then
+      failwith submit_result.Tool_result.legacy_message;
+    let task = only_task ctx in
+    match task.handoff_context with
+    | Some hc ->
+      assert (List.mem pr_url hc.evidence_refs)
+    | None -> failwith "expected handoff_context to receive pr_url evidence")
+)
+
+(* Regression: when a caller supplies both [pr_url] and an explicit
+   [handoff_context] object, normalize_args must append pr_url to the
+   existing [evidence_refs] list rather than overwrite it or fall back
+   to the notes blob. *)
+let () = test "transition_normalize_pr_url_merges_into_existing_handoff_context" (fun () ->
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
+    let ctx = make_test_ctx_with_agent "codex-mcp-client" in
+    add_task_requiring_tools ctx ~title:"pr_url merge" [ "keeper_bash" ];
+    let existing_ref = "logs/run-42.json" in
+    let pr_url = "https://github.com/jeong-sik/masc-mcp/pull/88888" in
+    let submit_result =
+      Tool_task.handle_transition
+        ~agent_tool_names:[ "masc_status"; "masc_transition" ]
+        ~tool_name:"test_tool" ~start_time:0.0
+        ctx
+        (`Assoc
+          [
+            ("task_id", `String "task-001");
+            ("action", `String "submit_pr_evidence");
+            ("pr_url", `String pr_url);
+            ("notes", `String "evidence available");
+            ( "handoff_context",
+              `Assoc
+                [
+                  ("summary", `String "tests pass");
+                  ("evidence_refs", `List [ `String existing_ref ]);
+                ] );
+          ])
+    in
+    if not submit_result.Tool_result.success then
+      failwith submit_result.Tool_result.legacy_message;
+    let task = only_task ctx in
+    match task.handoff_context with
+    | Some hc ->
+      assert (List.mem existing_ref hc.evidence_refs);
+      assert (List.mem pr_url hc.evidence_refs);
+      assert (String.equal hc.summary "tests pass")
+    | None -> failwith "expected handoff_context to be persisted")
+)
+
 let () = test "transition_submit_pr_evidence_accepts_todo_pr_evidence_without_required_tool" (fun () ->
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
     let ctx = make_test_ctx_with_agent "codex-mcp-client" in


### PR DESCRIPTION
## Summary

PR #15834 follow-up. legacy `notes ^ \"\\nPR: \" ^ pr_url` string blob 을 *싹 밀어버린다* — typed `handoff_context.evidence_refs` 채널로 완전 이전.

### Audit

\`rg '\\\\nPR:' lib/ test/\` 으로 in-repo reader 전수 조사한 결과 **0건**. legacy blob 은 *write-only dead pattern*:

| 위치 | 종류 | Before |
|---|---|---|
| `lib/tool_task.ml` normalize_args (line 900-918) | transport-level alias writer | pr_url → \`notes ^ \"\\nPR: \" ^ pr_url\` |
| `lib/keeper/keeper_exec_task.ml` line 480 | wrapper writer (#15834 BC 유지분) | 동일 concat |

pr_url 을 *읽는* 코드는 모두 *typed* field 에서 읽음:
- `lib/keeper_tool_call_log.ml:374` — `add_string \"pr_url\" pr_url`
- `lib/keeper/keeper_hooks_oas.ml:1128/1133/1138` — `string_field_opt \"pr_url\"`, nested under `result`/`route_evidence`
- `test/test_audit_keeper_fleet_readiness.py` — Python audit, typed evidence schema

\`test/test_pr_open_script.ml:228,282\` 의 \`\"PR: ...\"\` substring 검증은 *shell script stdout* 대상 — lib 코드 무관, 유지.

### Changes

**`lib/tool_task.ml` `normalize_args`**:
- Before: `pr_url` 키가 transport-level 로 들어오면 → `notes` 필드에 `\"\\nPR: ...\"` 합치기 (또는 `\"PR: ...\"` 새 notes 생성)
- After: `pr_url` 키 → typed `handoff_context.evidence_refs` 로 흡수
  - 기존 `handoff_context` 가 args 에 있으면 → `evidence_refs` list 에 append (기존 ref 보존)
  - 없으면 → minimal `handoff_context = { evidence_refs = [pr_url] }` 주입
- `notes` 는 caller 가 보낸 그대로 손대지 않음

**`lib/keeper/keeper_exec_task.ml` keeper_task_submit_for_verification**:
- Before: \`\"notes\", \`String (notes ^ \"\\nPR: \" ^ pr_url)\` (#15834 BC)
- After: \`\"notes\", \`String notes\` — concat 제거. typed handoff_context 만이 canonical pr_url 채널.

### Regression tests

`test/test_tool_task_coverage.ml` 에 회귀 가드 2건 신규:

1. `transition_normalize_pr_url_into_typed_handoff_context` — pr_url 단독 transport → `task.handoff_context.evidence_refs` 에 흡수 확인
2. `transition_normalize_pr_url_merges_into_existing_handoff_context` — 기존 handoff_context 와 pr_url 동시 → evidence_refs 에 append (기존 ref 보존), summary 보존

기존 PR #15834 회귀 가드 2건 (`test_done_maps_result_to_typed_handoff_summary`, `test_submit_for_verification_maps_to_typed_handoff_evidence_refs`) 도 본 PR 변경 후 그대로 통과 예상 (wrapper 가 명시적으로 handoff_context 보내므로 normalize_args 의 pr_url merge 미트리거).

### Why drop legacy completely

- *Dead-on-write*: in-repo reader 0건.
- *유저 절대 원칙*: 하드코딩/legacy 박멸. transitional repair 거부.
- *Self-fulfilling 회피*: blob 이 main 에 남아있으면 AI 가 *합리적 선례* 로 학습 → 또 다른 string-blob alias 가 누적될 가능성.

## Test plan

- [ ] CI green
- [ ] `transition_normalize_pr_url_into_typed_handoff_context` pass
- [ ] `transition_normalize_pr_url_merges_into_existing_handoff_context` pass
- [ ] 기존 #15834 가드 2건 회귀 없음
- [ ] `test_tool_task_coverage.ml` 의 \`transition_submit_*_pr_evidence_*\` 행위 회귀 없음 (blob 내용 검증 안 하므로 통과 예상)

## Related

- PR #15834 (MERGED, 2026-05-17 07:48:51Z, sha 9b228638) — typed mapping 도입
- 본 PR — legacy blob *싹 제거*. 사용자 명시 요청 \"legacy 숙청 싹 밀어도 됨\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>