### PR TITLE
fix(keeper): expose room state in docker sandboxes

### DIFF
--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -92,6 +92,9 @@ let build_docker_argv ~image ~container_name ~base_path ~host_root ~croot
   @ Keeper_sandbox_runtime.docker_config_mount_args
       ~base_path
       ~container_root:croot
+  @ Keeper_sandbox_runtime.docker_room_state_mount_args
+      ~base_path
+      ~container_root:croot
   @ [
     image;
   ]

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -314,6 +314,68 @@ let docker_config_mount_args ~base_path ~container_root =
     ]
 ;;
 
+type room_state_mount_kind =
+  | Room_state_file
+  | Room_state_dir
+
+let docker_room_state_mounts =
+  [ Room_state_dir, "tasks"
+  ; Room_state_file, "tasks.json"
+  ; Room_state_file, "backlog.json"
+  ; Room_state_file, "board_posts.jsonl"
+  ; Room_state_file, "board_comments.jsonl"
+  ; Room_state_file, "board_votes.jsonl"
+  ; Room_state_file, "board_reactions.jsonl"
+  ; Room_state_file, "current_task"
+  ; Room_state_file, "goals.json"
+  ; Room_state_file, "goal_events.jsonl"
+  ; Room_state_file, "goal_verifications.json"
+  ]
+;;
+
+let room_state_path_available kind path =
+  try
+    match kind with
+    | Room_state_file -> Sys.file_exists path && not (Sys.is_directory path)
+    | Room_state_dir -> Sys.file_exists path && Sys.is_directory path
+  with
+  | Sys_error _ -> false
+;;
+
+let unique_preserving_order values =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | value :: rest ->
+      if List.mem value seen
+      then loop seen acc rest
+      else loop (value :: seen) (value :: acc) rest
+  in
+  loop [] [] values
+;;
+
+let docker_room_state_mount_specs ~base_path ~container_root =
+  let host_masc_root = Common.masc_dir_from_base_path ~base_path in
+  let container_masc_root = Filename.concat container_root Common.masc_dirname in
+  docker_room_state_mounts
+  |> List.concat_map (fun (kind, rel_path) ->
+    let host_path = Filename.concat host_masc_root rel_path in
+    if not (room_state_path_available kind host_path)
+    then []
+    else
+      [ Printf.sprintf
+          "%s:%s:ro"
+          host_path
+          (Filename.concat container_masc_root rel_path)
+      ; Printf.sprintf "%s:%s:ro" host_path host_path
+      ])
+  |> unique_preserving_order
+;;
+
+let docker_room_state_mount_args ~base_path ~container_root =
+  docker_room_state_mount_specs ~base_path ~container_root
+  |> List.concat_map (fun spec -> [ "-v"; spec ])
+;;
+
 let docker_config_env_args ~base_path ~container_root =
   let host_config_root = docker_config_host_root ~base_path in
   if not (docker_config_available host_config_root)

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -158,6 +158,23 @@ val docker_config_mount_args
   -> container_root:string
   -> string list
 
+(** Docker [-v ...] specs for the read-only room-state subset that keeper
+    task worktrees may read through their [.masc] link. This intentionally
+    excludes auth, credentials, locks, logs, metrics, and keeper private
+    state. Existing paths are mounted both under [<container_root>/.masc]
+    and at the original absolute [.masc] path so host-created worktree
+    symlinks remain readable inside Docker. *)
+val docker_room_state_mount_specs
+  :  base_path:string
+  -> container_root:string
+  -> string list
+
+(** Docker [-v ...] argv fragment for {!docker_room_state_mount_specs}. *)
+val docker_room_state_mount_args
+  :  base_path:string
+  -> container_root:string
+  -> string list
+
 (** Docker [--env ...] argv fragment that points sandboxed processes at
     the mounted config root. Returns [[]] when the host config root is absent. *)
 val docker_config_env_args

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -1012,6 +1012,9 @@ let run_docker_shell_command_with_status_internal
                        @ Keeper_sandbox_runtime.docker_config_mount_args
                            ~base_path:config.base_path
                            ~container_root
+                       @ Keeper_sandbox_runtime.docker_room_state_mount_args
+                           ~base_path:config.base_path
+                           ~container_root
                        @ network_args
                        @ cred_mounts
                        @ cred_envs

--- a/lib/keeper/keeper_task_worktree_lazy.ml
+++ b/lib/keeper/keeper_task_worktree_lazy.ml
@@ -57,12 +57,19 @@ let candidate_of_path ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta
       | None -> None
       | Some suffix ->
         (match Keeper_alerting_path.split_relative_components suffix with
-         | [ repo_name; ".worktrees"; worktree_name ]
+         | repo_name :: ".worktrees" :: worktree_name :: _
            when Coord_worktree.safe_repo_name repo_name
                 && String.equal
                      worktree_name
                      (Playground_paths.worktree_dir_name agent_name task_id) ->
-           Some { agent_name; task_id; repo_name; worktree_path = path }
+           let worktree_path =
+             Filename.concat
+               repos_dir
+               (Filename.concat
+                  repo_name
+                  (Filename.concat ".worktrees" worktree_name))
+           in
+           Some { agent_name; task_id; repo_name; worktree_path }
          | _ -> None))
 ;;
 

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -216,6 +216,9 @@ let start_container (t : t) ~(timeout_sec : float) =
            @ Keeper_sandbox_runtime.docker_config_mount_args
                ~base_path:t.config.base_path
                ~container_root:t.container_root
+           @ Keeper_sandbox_runtime.docker_room_state_mount_args
+               ~base_path:t.config.base_path
+               ~container_root:t.container_root
            @ identity_mounts
            @ network_args
            @ [ image; "sh"; "-lc"; "trap : TERM INT; while :; do sleep 3600; done" ]

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -532,6 +532,12 @@ let inline_path_flag_requires_existing_dir token =
   String.starts_with ~prefix:"--work-tree=" token
 ;;
 
+let command_materializes_path_arg = function
+  | "cat" | "find" | "grep" | "head" | "ls" | "nl" | "rg" | "sed" | "stat"
+  | "tail" | "wc" -> true
+  | _ -> false
+;;
+
 let path_is_existing_dir ?workdir path =
   let resolved = resolve_path ?base_dir:workdir path in
   try Sys.file_exists resolved && Sys.is_directory resolved with
@@ -916,6 +922,11 @@ let path_validation_tokens tokens =
 ;;
 
 let existing_dir_path_values cmd =
+  let command_name =
+    match tokenize_path_args cmd with
+    | command :: _ -> Filename.basename command.value
+    | [] -> ""
+  in
   let rec loop expect_existing_dir acc = function
     | [] -> List.rev acc
     | token :: rest ->
@@ -930,6 +941,12 @@ let existing_dir_path_values cmd =
         | Some _ -> loop false acc rest
         | None when is_path_flag token.value ->
           loop (path_flag_requires_existing_dir token.value) acc rest
+        | None
+          when command_materializes_path_arg command_name
+               && looks_like_path_token token.value
+               && not (token_has_unsafe_rewrite_syntax token)
+               && not token.globbed ->
+          loop false (token.value :: acc) rest
         | None -> loop false acc rest)
   in
   cmd |> tokenize_path_args |> path_validation_tokens |> loop false []

--- a/lib/worker_dev_tools.mli
+++ b/lib/worker_dev_tools.mli
@@ -92,12 +92,13 @@ val validate_command_paths
   -> string
   -> (unit, string) result
 
-(** Return path values in [cmd] that the shell validator treats as
-    existing-directory requirements (for example [git -C <dir>] and
-    [--work-tree=<dir>]).  Callers may use this to repair an expected
-    sandbox directory before delegating to {!validate_command_paths};
-    the validator remains the authority for blocking unsafe syntax and
-    out-of-sandbox paths. *)
+(** Return path values in [cmd] that should have their containing sandbox
+    materialized before execution. This includes explicit existing-directory
+    requirements (for example [git -C <dir>] and [--work-tree=<dir>]) and
+    path arguments to read/list/search commands such as [cat], [find], [ls],
+    and [rg]. Callers may use this to repair an expected sandbox directory
+    before delegating to {!validate_command_paths}; the validator remains
+    the authority for blocking unsafe syntax and out-of-sandbox paths. *)
 val existing_dir_path_values : string -> string list
 
 (** {1 Bash safety classifiers} *)

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -592,6 +592,36 @@ let test_docker_config_mount_and_env_args () =
        ~base_path:base
        ~container_root)
 
+let test_docker_room_state_mount_args_expose_safe_subset () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  let masc_root = Filename.concat base ".masc" in
+  ensure_dir (Filename.concat masc_root "tasks");
+  write_file (Filename.concat (Filename.concat masc_root "tasks") "backlog.json") "{}";
+  write_file (Filename.concat masc_root "board_posts.jsonl") "";
+  ensure_dir (Filename.concat masc_root "auth");
+  write_file (Filename.concat (Filename.concat masc_root "auth") "keeper.token") "secret";
+  let container_root = "/home/keeper/playground/minjae" in
+  let specs =
+    Keeper_sandbox_runtime.docker_room_state_mount_specs
+      ~base_path:base
+      ~container_root
+  in
+  let tasks_host = Filename.concat masc_root "tasks" in
+  let board_host = Filename.concat masc_root "board_posts.jsonl" in
+  Alcotest.(check bool) "mounts tasks under container .masc" true
+    (List.mem
+       (tasks_host ^ ":" ^ container_root ^ "/.masc/tasks:ro")
+       specs);
+  Alcotest.(check bool) "mounts tasks at absolute symlink target" true
+    (List.mem (tasks_host ^ ":" ^ tasks_host ^ ":ro") specs);
+  Alcotest.(check bool) "mounts board posts" true
+    (List.mem
+       (board_host ^ ":" ^ container_root ^ "/.masc/board_posts.jsonl:ro")
+       specs);
+  Alcotest.(check bool) "does not mount auth" false
+    (List.exists (fun spec -> contains_substring spec "/auth/") specs)
+
 let test_cleanup_stale_containers_removes_only_stale_masc_scope () =
   with_fake_docker fake_docker_cleanup_script @@ fun () ->
   let base = temp_dir () in
@@ -976,6 +1006,8 @@ let run_tests () =
             test_docker_masc_config_binding_pins_container_runtime_paths;
           Alcotest.test_case "docker config mount and env args" `Quick
             test_docker_config_mount_and_env_args;
+          Alcotest.test_case "docker room state mount exposes safe subset" `Quick
+            test_docker_room_state_mount_args_expose_safe_subset;
           Alcotest.test_case "managed label args include ttl" `Quick
             test_sandbox_container_label_args_include_managed_ttl;
           Alcotest.test_case "sandbox label args include owner scope" `Quick

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -922,6 +922,13 @@ let test_docker_shell_mounts_masc_config_runtime_paths () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
+  let masc_root =
+    Filename.concat config.Coord.base_path Common.masc_dirname
+  in
+  let tasks_host = Filename.concat masc_root "tasks" in
+  ensure_dir tasks_host;
+  write_file (Filename.concat tasks_host "backlog.json") "{}";
+  write_file (Filename.concat masc_root "board_posts.jsonl") "";
   let log_path = Filename.concat config.Coord.base_path "docker.log" in
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
@@ -961,7 +968,17 @@ let test_docker_shell_mounts_masc_config_runtime_paths () =
     Alcotest.(check bool) "container MASC_BASE_PATH pinned" true
       (contains_substring line ("MASC_BASE_PATH=" ^ container_root));
     Alcotest.(check bool) "container MASC_CONFIG_DIR pinned" true
-      (contains_substring line ("MASC_CONFIG_DIR=" ^ container_config_dir))
+      (contains_substring line ("MASC_CONFIG_DIR=" ^ container_config_dir));
+    Alcotest.(check bool) "room tasks mounted under container root" true
+      (contains_substring
+         line
+         (tasks_host ^ ":" ^ container_root ^ "/.masc/tasks:ro"));
+    Alcotest.(check bool) "room tasks mounted for worktree symlink target" true
+      (contains_substring
+         line
+         (tasks_host ^ ":" ^ tasks_host ^ ":ro"));
+    Alcotest.(check bool) "auth state not mounted" false
+      (contains_substring line "/.masc/auth/")
 
 let run_git_creds_docker_shell ~config ~meta ~playground ~log_path =
   ensure_github_identity_bundle ~config Masc_mcp.Keeper_gh_env.root_github_identity;

--- a/test/test_task_sandbox.ml
+++ b/test/test_task_sandbox.ml
@@ -355,6 +355,24 @@ let test_command_path_lazy_creates_current_task_worktree () =
        | Error msg -> fail ("validator should pass after lazy repair: " ^ msg)
        | Ok () -> ())
 
+let test_command_descendant_path_lazy_creates_current_task_worktree () =
+  with_lazy_worktree_fixture
+    (fun ~config ~meta ~clone_path ~task_id:_ ~worktree_name ~worktree_path ->
+       check bool "worktree initially missing" false (Sys.file_exists worktree_path);
+       let cmd = Printf.sprintf "cat .worktrees/%s/README.md" worktree_name in
+       (match
+          Keeper_task_worktree_lazy.ensure_command_existing_dirs
+            ~config
+            ~meta
+            ~cwd:clone_path
+            ~cmd
+        with
+        | Error msg -> fail ("expected lazy descendant repair, got: " ^ msg)
+        | Ok () -> ());
+       check bool "worktree created" true (Sys.is_directory worktree_path);
+       check bool "descendant file materialized" true
+         (Sys.file_exists (Filename.concat worktree_path "README.md")))
+
 let test_full_lifecycle () =
   let base = make_temp_dir () in
   let dir = base in
@@ -929,6 +947,8 @@ let () =
         test_resolve_write_cwd_lazy_creates_current_task_worktree;
       test_case "lazy_command_path_creates_current_task_worktree" `Quick
         test_command_path_lazy_creates_current_task_worktree;
+      test_case "lazy_command_descendant_path_creates_current_task_worktree" `Quick
+        test_command_descendant_path_lazy_creates_current_task_worktree;
       test_case "ambiguous_multi_repo_without_evidence" `Quick
         test_create_fails_ambiguous_multi_repo_without_evidence;
       test_case "infer_repo_from_task_repo_mentions" `Quick


### PR DESCRIPTION
## Summary
- mount a narrow read-only room-state subset into Docker keeper sandboxes so `.masc/tasks`, board, goal, and current-task reads stop failing while auth/credential/lock/log/private keeper state stays unmounted
- apply the mount to one-shot docker shell, turn-scoped docker runtime, and docker read paths
- repair current-task worktrees when commands point at a descendant file/path under the expected task worktree, not only the exact worktree root

## Root Cause
`Task_sandbox` creates `.masc` links for room-state reads, but Docker keepers only received the playground plus config mount. Runtime reads like `.masc/tasks/backlog.json` or worktree `.masc` symlink reads therefore resolved to paths that did not exist inside the container.

## Validation
- `opam exec -- ocamlformat --check ...`
- `git diff --check origin/main...HEAD`
- focused `scripts/dune-local.sh build test/test_task_sandbox.exe test/test_keeper_docker_read.exe test/test_keeper_shell_docker_route.exe` was attempted but skipped after the shared Dune lock was held by another long-running build for 40+ minutes; CI should be the build/test authority for this draft.

Fixes #15529