### PR TITLE
fix(cascade-http-probe): warn+counter on silent JSON parse drop (iter 29)

### DIFF
--- a/lib/cascade/cascade_http_probe.ml
+++ b/lib/cascade/cascade_http_probe.ml
@@ -161,14 +161,53 @@ let try_probe ~sw ~net ?clock ?timeout_s ?now url =
   with
   | Error _ -> None
   | Ok (status, body) when status = 200 ->
-    (match Yojson.Safe.from_string body with
-     | exception _ -> None
-     | json ->
+    (* Iter 29 (V07 follow-up): make malformed JSON probe responses
+       visible. Previously the [exception _ -> None] catch-all returned
+       [None] without log or counter, masking "endpoint up but emitting
+       bad JSON" as "endpoint down". Behavior preserved — we still
+       return [None]; the counter + warn exist so the two failure modes
+       can be told apart in production. [Eio.Cancel.Cancelled] is
+       re-raised so cancellation semantics are preserved. *)
+    let body_preview =
+      String.sub body 0 (min 200 (String.length body))
+    in
+    let parsed =
+      try Ok (Yojson.Safe.from_string body) with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | Yojson.Json_error msg -> Error (`Json_parse_error msg)
+      | exn -> Error (`Other exn)
+    in
+    (match parsed with
+     | Ok json ->
        (match parse_response ~now json with
         | None -> None
         | Some cap ->
           store_capacity ~url ~capacity:cap ~now;
-          Some cap))
+          Some cap)
+     | Error (`Json_parse_error msg) ->
+       Log.Cascade.warn
+         "[cascade-http-probe] dropping probe response from %s: \
+          malformed JSON (%s); body_preview=%S"
+         endpoint msg body_preview;
+       Prometheus.inc_counter
+         Keeper_metrics.metric_cascade_http_probe_json_parse_failures
+         ~labels:
+           [ ("error_kind", "yojson_parse_error")
+           ; ("probe_kind", "ollama_api_ps")
+           ]
+         ();
+       None
+     | Error (`Other exn) ->
+       Log.Cascade.warn
+         "[cascade-http-probe] dropping probe response from %s: %s; \
+          body_preview=%S"
+         endpoint (Printexc.to_string exn) body_preview;
+       Prometheus.inc_counter
+         Keeper_metrics.metric_cascade_http_probe_json_parse_failures
+         ~labels:
+           [ ("error_kind", "other"); ("probe_kind", "ollama_api_ps") ]
+         ();
+       None)
   | Ok _ -> None
 ;;
 

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -206,6 +206,7 @@ type t =
   | RecurringFailures
   | TurnCleanupFailures
   | MemoryBankLoadHistorySwallowedExceptions
+  | CascadeHttpProbeJsonParseFailures
 
 (** String conversion
 
@@ -414,6 +415,8 @@ let to_string = function
   | TurnCleanupFailures -> "masc_keeper_turn_cleanup_failures_total"
   | MemoryBankLoadHistorySwallowedExceptions ->
       "masc_keeper_memory_bank_load_history_swallowed_exceptions_total"
+  | CascadeHttpProbeJsonParseFailures ->
+      "masc_cascade_http_probe_json_parse_failures_total"
 ;;
 
 (** Backward-compatible string constants
@@ -932,4 +935,8 @@ let metric_keeper_session_cleanup_failures = "masc_keeper_session_cleanup_failur
 
 let metric_keeper_memory_bank_load_history_swallowed_exceptions =
   to_string MemoryBankLoadHistorySwallowedExceptions
+;;
+
+let metric_cascade_http_probe_json_parse_failures =
+  to_string CascadeHttpProbeJsonParseFailures
 ;;

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -198,6 +198,7 @@ type t =
   | RecurringFailures
   | TurnCleanupFailures
   | MemoryBankLoadHistorySwallowedExceptions
+  | CascadeHttpProbeJsonParseFailures
 
 val to_string : t -> string
 
@@ -609,6 +610,32 @@ val metric_keeper_session_cleanup_failures : string
     line); the counter exists so JSONL corruption / fs faults stop
     masking as "no history". *)
 val metric_keeper_memory_bank_load_history_swallowed_exceptions : string
+
+(** Counter for probe responses dropped by the silent JSON parse catch-all
+    in [Cascade_http_probe.try_probe]. Before this counter existed the
+    [match Yojson.Safe.from_string body with | exception _ -> None] branch
+    returned [None] without log/counter, leaving operators unable to
+    distinguish "endpoint down" from "endpoint up but emitting bad JSON".
+
+    Labels:
+    {ul
+    {- [error_kind] — closed 2-value vocabulary
+       \{[yojson_parse_error] | [other]\}. [yojson_parse_error] is
+       [Yojson.Json_error _]; [other] is the terminal bucket for any
+       other (non-[Eio.Cancel.Cancelled]) exception. Bounded by
+       constructor-level pattern match on the [exn] type, not a
+       substring scan on [Printexc.to_string].}
+    {- [probe_kind] — closed 1-value vocabulary \{[ollama_api_ps]\}.
+       Only one probe site exists in [cascade_http_probe.ml]; the label
+       is named after the [/api/ps] endpoint it targets.}}
+
+    Cardinality bound: 2 × 1 = 2 label combinations.
+    Behavior is unchanged (the probe still returns [None] on parse
+    failure); the counter and accompanying [Log.Cascade.warn] exist so
+    "endpoint up but JSON is garbage" stops being indistinguishable
+    from "endpoint down". *)
+val metric_cascade_http_probe_json_parse_failures : string
+
 val metric_keeper_path_resolver_identity_mismatch : string
 val metric_keeper_passive_loop_streak : string
 val metric_keeper_passive_loop_streak_exceeded : string


### PR DESCRIPTION
## Summary

Iter 29 atomic root-fix. `lib/cascade/cascade_http_probe.ml` previously dropped probe responses with malformed JSON silently — the `match Yojson.Safe.from_string body with | exception _ -> None` catch-all returned `None` without log or counter, leaving operators unable to distinguish "endpoint down" from "endpoint up but emitting bad JSON".

This change:

1. Adds `metric_cascade_http_probe_json_parse_failures` (variant `CascadeHttpProbeJsonParseFailures` + backward-compat string + `.mli` doc) in `lib/keeper/keeper_metrics.{ml,mli}`.
2. Replaces the silent catch-all in `try_probe` with a typed `try ... with` split that classifies failures into a closed 2-value `error_kind` vocab `{yojson_parse_error | other}` and re-raises `Eio.Cancel.Cancelled` so cancellation semantics are preserved.
3. Emits `Log.Cascade.warn` carrying the probe endpoint URL and a 200-byte `body_preview` so operators can see *what* the endpoint returned, not just *that* it was unparseable.

Behavior preserved: the probe still returns `None` on parse failure. Same closure pattern as iter 6 (`memory_jsonl.parse_line`, PR #15668), iter 21 (`Keeper_memory_recall.load_history_user_messages`, PR #15781), iter 28 (`mcp-ws` transport JSON parse path).

## Before / After

### Before (silent drop)

```ocaml
| Ok (status, body) when status = 200 ->
  (match Yojson.Safe.from_string body with
   | exception _ -> None         (* malformed JSON disappears silently *)
   | json ->
     (match parse_response ~now json with
      | None -> None
      | Some cap ->
        store_capacity ~url ~capacity:cap ~now;
        Some cap))
```

### After (typed split + warn + counter)

```ocaml
| Ok (status, body) when status = 200 ->
  let body_preview =
    String.sub body 0 (min 200 (String.length body))
  in
  let parsed =
    try Ok (Yojson.Safe.from_string body) with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | Yojson.Json_error msg -> Error (`Json_parse_error msg)
    | exn -> Error (`Other exn)
  in
  (match parsed with
   | Ok json -> (* same downstream as before *) ...
   | Error (`Json_parse_error msg) ->
     Log.Cascade.warn
       "[cascade-http-probe] dropping probe response from %s: \
        malformed JSON (%s); body_preview=%S"
       endpoint msg body_preview;
     Prometheus.inc_counter
       Keeper_metrics.metric_cascade_http_probe_json_parse_failures
       ~labels:
         [ ("error_kind", "yojson_parse_error")
         ; ("probe_kind", "ollama_api_ps") ]
       ();
     None
   | Error (`Other exn) ->
     Log.Cascade.warn
       "[cascade-http-probe] dropping probe response from %s: %s; \
        body_preview=%S"
       endpoint (Printexc.to_string exn) body_preview;
     Prometheus.inc_counter
       Keeper_metrics.metric_cascade_http_probe_json_parse_failures
       ~labels:
         [ ("error_kind", "other"); ("probe_kind", "ollama_api_ps") ]
       ();
     None)
```

## Cardinality

- `error_kind`: closed 2-value vocab `{yojson_parse_error | other}` by constructor-level pattern match on `exn` (no substring scan).
- `probe_kind`: closed 1-value vocab `{ollama_api_ps}` — `cascade_http_probe.ml` has exactly one probe site, targeting `/api/ps` per `Masc_network_defaults.ollama_api_ps_path`.

Total label combinations: 2 × 1 = **2**. The counter cannot balloon in-process memory as malformed bodies accumulate. Full `Printexc.to_string` detail is retained in the log body.

Body preview bound: ≤200 bytes (`String.sub body 0 (min 200 (String.length body))`).

## Iter 6 / 21 / 28 cross-references

| Iter | Site | PR | Status |
|---|---|---|---|
| 6 | `Memory_jsonl.parse_line` (lib/memory_jsonl.ml) | #15668 | MERGED |
| 21 | `Keeper_memory_recall.load_history_user_messages` (lib/keeper/keeper_memory_recall.ml) | #15781 | MERGED |
| 28 | `mcp-ws` transport JSON parse path | (prior iter) | MERGED |
| **29** | `Cascade_http_probe.try_probe` (lib/cascade/cascade_http_probe.ml) | **THIS PR** | Draft |

Same anti-pattern, same closure shape: typed-exception split + closed-vocab label + `Log.*.warn` + behavior-preserving `None` return.

## Anti-pattern self-check (7/7)

1. **telemetry-as-fix only?** — Partly yes (counter + warn). Justification: behavior preserved (still returns `None`); the counter exists so the failure mode becomes distinguishable from "endpoint down". This matches the iter 6/21/28 closure pattern explicitly endorsed for *visibility on existing silent paths*. The probe's contract (return `None` on any unhealthy/uninterpretable response) is preserved; what changes is operator observability, not control flow.
2. **string classifier?** — NO. Constructor-level pattern match on the `exn` type (`Yojson.Json_error` vs `Eio.Cancel.Cancelled` vs `exn`). No `String.starts_with` / substring scan / `Printexc.to_string`-based bucketing.
3. **N-of-M?** — NO. `grep -n "exception _ -> None" lib/cascade/cascade_http_probe.ml` shows exactly **1 site** (line 165). Single-site fix, no remaining sister sites in this file.
4. **catch-all added?** — NO. The original `| exception _ -> None` catch-all is **removed**; the `Error (`Other exn)` arm is bounded (constructor-distinguished from `Cancelled` and `Json_error`, both of which are handled explicitly).
5. **cap / cooldown / dedup / repair?** — NO. No rate-limit, no rolling dedup, no body normalization. Counter + log only.
6. **test backdoor?** — NO. No `set_*_for_test` / `reset_for_test` exposed.
7. **repeat typo / off-by-one in N sites?** — NO. Single-site fix.

## Single site fixed

1 site (line 165 of `lib/cascade/cascade_http_probe.ml`, `try_probe` function — the only probe in this module per `Http_probe` adapter).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
