### PR TITLE
[codex] surface required-tool gate candidates

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -233,13 +233,14 @@ let keeper_trust_json ?(include_receipt = false)
     | Some receipt -> json_string_list_member "requested_tools" receipt
     | None -> []
   in
-  let required_tools, missing_required_tools =
+  let required_tools, required_tool_candidates, missing_required_tools =
     match latest_receipt with
     | Some receipt ->
         let surface = Yojson.Safe.Util.member "tool_surface" receipt in
         ( json_string_list_member "required_tools" surface,
+          json_string_list_member "required_tool_candidates" surface,
           json_string_list_member "missing_required_tools" surface )
-    | None -> [], []
+    | None -> [], [], []
   in
   let tools_used =
     match latest_receipt with
@@ -277,6 +278,9 @@ let keeper_trust_json ?(include_receipt = false)
       ("requested_tool_count", `Int (List.length requested_tools));
       ( "required_tools",
         `List (List.map (fun value -> `String value) required_tools) );
+      ( "required_tool_candidates",
+        `List (List.map (fun value -> `String value) required_tool_candidates)
+      );
       ( "missing_required_tools",
         `List (List.map (fun value -> `String value) missing_required_tools) );
       ("tools_used", `List (List.map (fun value -> `String value) tools_used));

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -519,6 +519,11 @@ let run_turn
                 (List.map
                    (fun name -> `String name)
                    acc.tool_surface.required_tool_names) );
+            ( "required_tool_candidate_names",
+              `List
+                (List.map
+                   (fun name -> `String name)
+                   acc.tool_surface.required_tool_candidate_names) );
             ( "missing_required_tool_names",
               `List
                 (List.map
@@ -1903,6 +1908,8 @@ let run_turn
              ; tool_gate_enabled = acc.tool_surface.tool_gate_enabled
              ; tool_surface_fallback_used = acc.tool_surface.tool_surface_fallback_used
              ; required_tools = acc.tool_surface.required_tool_names
+             ; required_tool_candidates =
+                 acc.tool_surface.required_tool_candidate_names
              ; missing_required_tools = acc.tool_surface.missing_required_tool_names
              }
          ; sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -58,6 +58,7 @@ type tool_surface_metrics =
   ; tool_gate_enabled : bool
   ; tool_surface_fallback_used : bool
   ; required_tool_names : string list
+  ; required_tool_candidate_names : string list
   ; missing_required_tool_names : string list
   ; config_root : string
   ; cascade_config_path : string option

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -130,6 +130,7 @@ type tool_surface_metrics =
   ; tool_gate_enabled : bool
   ; tool_surface_fallback_used : bool
   ; required_tool_names : string list
+  ; required_tool_candidate_names : string list
   ; missing_required_tool_names : string list
   ; config_root : string
   ; cascade_config_path : string option
@@ -156,6 +157,7 @@ type computed_tool_surface =
   ; tool_gate_requested : bool
   ; tool_surface_fallback_used : bool
   ; required_tool_names : string list
+  ; required_tool_candidate_names : string list
   ; missing_required_tool_names : string list
   ; lane : turn_lane
   ; query_text : string
@@ -452,7 +454,7 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
     task_update, task_done, etc.). *)
     Agent_sdk.Types.Any
 
-let generic_required_tool_gate_guidance ~(has_current_task : bool)
+let generic_required_tool_candidate_names ~(has_current_task : bool)
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
   let is_stay_silent name =
     String.equal
@@ -478,6 +480,17 @@ let generic_required_tool_gate_guidance ~(has_current_task : bool)
         |> List.filter can_recommend_tool
         |> Keeper_types.dedupe_keep_order
     | tools -> tools
+  in
+  actionable_tools
+;;
+
+let generic_required_tool_gate_guidance ~(has_current_task : bool)
+    ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
+  let actionable_tools =
+    generic_required_tool_candidate_names
+      ~has_current_task
+      ~turn_affordances
+      ~allowed_tool_names
   in
   let preview =
     actionable_tools

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -94,6 +94,7 @@ type tool_surface_metrics =
   ; tool_gate_enabled : bool
   ; tool_surface_fallback_used : bool
   ; required_tool_names : string list
+  ; required_tool_candidate_names : string list
   ; missing_required_tool_names : string list
   ; config_root : string
   ; cascade_config_path : string option
@@ -122,6 +123,7 @@ type computed_tool_surface =
   ; tool_gate_requested : bool
   ; tool_surface_fallback_used : bool
   ; required_tool_names : string list
+  ; required_tool_candidate_names : string list
   ; missing_required_tool_names : string list
   ; lane : turn_lane
   ; query_text : string
@@ -204,6 +206,16 @@ val generic_required_tool_gate_guidance :
   turn_affordances:string list ->
   allowed_tool_names:string list ->
   string
+
+(** Candidate tools a generic required-tool gate can recommend. This is
+    distinct from explicit [required_tool_names]: callers may satisfy a
+    generic gate with any execution-progress tool, while this list explains
+    the preferred candidates exposed to the model/operator. *)
+val generic_required_tool_candidate_names :
+  has_current_task:bool ->
+  turn_affordances:string list ->
+  allowed_tool_names:string list ->
+  string list
 
 (** Per-call [masc_keeper_msg.required_tools] is an explicit operator/harness
     contract for this turn. When present, it takes precedence over the keeper's

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -83,6 +83,7 @@ type tool_surface =
   ; tool_gate_enabled : bool
   ; tool_surface_fallback_used : bool
   ; required_tools : string list
+  ; required_tool_candidates : string list
   ; missing_required_tools : string list
   }
 
@@ -663,6 +664,7 @@ let to_json (receipt : t) =
            receipt.tool_surface.tool_surface_class)
       ~visible_tool_count:receipt.tool_surface.visible_tool_count
       ~required_tools:receipt.tool_surface.required_tools
+      ~required_tool_candidates:receipt.tool_surface.required_tool_candidates
       ~missing_required_tools:receipt.tool_surface.missing_required_tools
       ~cascade_profile:(cascade_name_to_string receipt.cascade_name)
       ()
@@ -730,6 +732,8 @@ let to_json (receipt : t) =
           ; ( "tool_surface_fallback_used"
             , `Bool receipt.tool_surface.tool_surface_fallback_used )
           ; "required_tools", list_json receipt.tool_surface.required_tools
+          ; ( "required_tool_candidates"
+            , list_json receipt.tool_surface.required_tool_candidates )
           ; ( "missing_required_tools"
             , list_json receipt.tool_surface.missing_required_tools )
           ] )
@@ -874,6 +878,8 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
           [ ( "result"
             , `String (tool_contract_result_to_string receipt.tool_contract_result) )
           ; "required_tools", list_json receipt.tool_surface.required_tools
+          ; ( "required_tool_candidates"
+            , list_json receipt.tool_surface.required_tool_candidates )
           ; ( "missing_required_tools"
             , list_json receipt.tool_surface.missing_required_tools )
           ; "visible_tool_count", `Int receipt.tool_surface.visible_tool_count

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -96,6 +96,7 @@ type tool_surface =
   ; tool_gate_enabled : bool
   ; tool_surface_fallback_used : bool
   ; required_tools : string list
+  ; required_tool_candidates : string list
   ; missing_required_tools : string list
   }
 

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -248,6 +248,7 @@ let prepare_agent_setup
         ; tool_gate_enabled = false
         ; tool_surface_fallback_used = false
         ; required_tool_names = []
+        ; required_tool_candidate_names = []
         ; missing_required_tool_names = []
         ; config_root
         ; cascade_config_path
@@ -1053,6 +1054,15 @@ let prepare_agent_setup
            not (List.mem canonical allowed_canonical_tool_names))
         required_tool_names
     in
+    let required_tool_candidate_names =
+      if tool_gate_requested && required_tool_names = []
+      then
+        generic_required_tool_candidate_names
+          ~has_current_task:(keeper_has_owned_active_task ())
+          ~turn_affordances
+          ~allowed_tool_names:all_allowed
+      else []
+    in
     let visible_tool_count = List.length all_allowed in
     let tool_surface_class : Keeper_agent_tool_surface.tool_surface_class =
       if visible_tool_count = 0
@@ -1097,6 +1107,7 @@ let prepare_agent_setup
     ; tool_gate_requested
     ; tool_surface_fallback_used
     ; required_tool_names
+    ; required_tool_candidate_names
     ; missing_required_tool_names
     ; lane
     ; query_text
@@ -1119,6 +1130,8 @@ let prepare_agent_setup
      ; tool_gate_enabled = initial_tool_surface.tool_gate_requested
      ; tool_surface_fallback_used = initial_tool_surface.tool_surface_fallback_used
      ; required_tool_names = initial_tool_surface.required_tool_names
+     ; required_tool_candidate_names =
+         initial_tool_surface.required_tool_candidate_names
      ; missing_required_tool_names = initial_tool_surface.missing_required_tool_names
      ; config_root
      ; cascade_config_path
@@ -1668,6 +1681,8 @@ let prepare_agent_setup
                    ; tool_surface_fallback_used =
                        computed_surface.tool_surface_fallback_used
                    ; required_tool_names = computed_surface.required_tool_names
+                   ; required_tool_candidate_names =
+                       computed_surface.required_tool_candidate_names
                    ; missing_required_tool_names =
                        computed_surface.missing_required_tool_names
                    ; config_root
@@ -1715,6 +1730,8 @@ let prepare_agent_setup
                        computed_surface.tool_surface_class)
                   ~visible_tool_count:(List.length all_allowed)
                   ~required_tools:computed_surface.required_tool_names
+                  ~required_tool_candidates:
+                    computed_surface.required_tool_candidate_names
                   ~missing_required_tools:computed_surface.missing_required_tool_names
                   ~cascade_profile:cascade_name_string
                   ();

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -220,7 +220,7 @@ let runtime_lane_opt = function
 let runtime_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
     ?session_id ?generation ?keeper_turn_id ?task_id ?goal_ids
     ?sandbox_profile ?sandbox_root ?allowed_paths ?network_mode ?approval_mode ?tool_surface_class
-    ?visible_tool_count ?required_tools ?missing_required_tools ?provider ?model
+    ?visible_tool_count ?required_tools ?required_tool_candidates ?missing_required_tools ?provider ?model
     ?cascade_profile () : Yojson.Safe.t =
   let provider = runtime_lane_opt provider in
   let model = runtime_lane_opt model in
@@ -242,6 +242,8 @@ let runtime_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
       ("tool_surface_class", string_opt_json tool_surface_class);
       ("visible_tool_count", int_opt_json visible_tool_count);
       ("required_tools", string_list_json (nonempty_list required_tools));
+      ( "required_tool_candidates",
+        string_list_json (nonempty_list required_tool_candidates) );
       ( "missing_required_tools",
         string_list_json (nonempty_list missing_required_tools) );
       ("provider", string_opt_json provider);

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -53,6 +53,7 @@ val runtime_contract_json_from_fields :
   ?tool_surface_class:string ->
   ?visible_tool_count:int ->
   ?required_tools:string list ->
+  ?required_tool_candidates:string list ->
   ?missing_required_tools:string list ->
   ?provider:string ->
   ?model:string ->

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -1008,13 +1008,14 @@ let execution_summary_json ~meta ~latest_receipt =
     | Some receipt -> json_string_list_member "unexpected_tools" receipt
     | None -> []
   in
-  let required_tools, missing_required_tools =
+  let required_tools, required_tool_candidates, missing_required_tools =
     match latest_receipt with
     | Some receipt ->
         let surface = json_member "tool_surface" receipt in
         ( json_string_list_member "required_tools" surface,
+          json_string_list_member "required_tool_candidates" surface,
           json_string_list_member "missing_required_tools" surface )
-    | None -> [], []
+    | None -> [], [], []
   in
   let cascade_json =
     match latest_receipt with
@@ -1050,6 +1051,7 @@ let execution_summary_json ~meta ~latest_receipt =
       ( "runtime_proof_status",
         Json_util.string_opt_to_json tool_contract_result );
       ("required_tools", string_list_json required_tools);
+      ("required_tool_candidates", string_list_json required_tool_candidates);
       ("missing_required_tools", string_list_json missing_required_tools);
       ("requested_tools", string_list_json requested_tools);
       ("tools_used", string_list_json tools_used);

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -219,6 +219,7 @@ let pre_dispatch_tool_surface : Keeper_execution_receipt.tool_surface =
   ; tool_gate_enabled = false
   ; tool_surface_fallback_used = false
   ; required_tools = []
+  ; required_tool_candidates = []
   ; missing_required_tools = []
   }
 ;;

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -44,6 +44,7 @@ type turn_context =
   ; tool_surface_class : string option
   ; visible_tool_count : int option
   ; required_tools : string list option
+  ; required_tool_candidates : string list option
   ; missing_required_tools : string list option
   ; cascade_profile : string option
   }
@@ -70,6 +71,7 @@ let empty_turn_context =
   ; tool_surface_class = None
   ; visible_tool_count = None
   ; required_tools = None
+  ; required_tool_candidates = None
   ; missing_required_tools = None
   ; cascade_profile = None
   }
@@ -112,6 +114,7 @@ let set_turn_context
       ?tool_surface_class
       ?visible_tool_count
       ?required_tools
+      ?required_tool_candidates
       ?missing_required_tools
       ?cascade_profile
       ()
@@ -140,6 +143,7 @@ let set_turn_context
     ; tool_surface_class
     ; visible_tool_count
     ; required_tools
+    ; required_tool_candidates
     ; missing_required_tools
     ; cascade_profile
     }
@@ -194,6 +198,7 @@ let runtime_contract_json_for_call ~keeper_name ?model () =
     ?tool_surface_class:ctx.tool_surface_class
     ?visible_tool_count:ctx.visible_tool_count
     ?required_tools:ctx.required_tools
+    ?required_tool_candidates:ctx.required_tool_candidates
     ?missing_required_tools:ctx.missing_required_tools
     ?model:(optional_model model)
     ?cascade_profile:ctx.cascade_profile
@@ -595,6 +600,7 @@ let log_call
       ?tool_surface_class
       ?visible_tool_count
       ?required_tools
+      ?required_tool_candidates
       ?missing_required_tools
       ?cascade_profile
       ?result_bytes
@@ -730,6 +736,11 @@ let log_call
         | Some _ -> required_tools
         | None -> ctx.required_tools
       in
+      let required_tool_candidates =
+        match required_tool_candidates with
+        | Some _ -> required_tool_candidates
+        | None -> ctx.required_tool_candidates
+      in
       let missing_required_tools =
         match missing_required_tools with
         | Some _ -> missing_required_tools
@@ -861,6 +872,7 @@ let log_call
           ?tool_surface_class
           ?visible_tool_count
           ?required_tools
+          ?required_tool_candidates
           ?missing_required_tools
           ?model:model_opt
           ?cascade_profile

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -49,6 +49,7 @@ val set_turn_context :
   ?tool_surface_class:string ->
   ?visible_tool_count:int ->
   ?required_tools:string list ->
+  ?required_tool_candidates:string list ->
   ?missing_required_tools:string list ->
   ?cascade_profile:string ->
   unit ->
@@ -141,6 +142,7 @@ val log_call :
   ?tool_surface_class:string ->
   ?visible_tool_count:int ->
   ?required_tools:string list ->
+  ?required_tool_candidates:string list ->
   ?missing_required_tools:string list ->
   ?cascade_profile:string ->
   ?result_bytes:int ->

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -805,6 +805,9 @@ let compact_receipt_tool_surface_json receipt =
       ; ( "required_tools"
         , Json_util.json_string_list (Json_util.get_string_list surface "required_tools")
         )
+      ; ( "required_tool_candidates"
+        , Json_util.json_string_list
+            (Json_util.get_string_list surface "required_tool_candidates") )
       ; "unexpected_tools", Json_util.json_string_list unexpected_tools
       ; "unexpected_tool_count", `Int (List.length unexpected_tools)
       ]

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1063,6 +1063,7 @@ let test_keeper_zombie_field_contracts () =
           tool_gate_enabled = true;
           tool_surface_fallback_used = false;
           required_tools = [ "Read" ];
+          required_tool_candidates = [];
           missing_required_tools = [];
         };
       sandbox_kind = Masc_mcp.Keeper_types.Local;

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -461,6 +461,7 @@ let append_execution_receipt
     ?(tool_contract_result : Lib.Keeper_execution_receipt.tool_contract_result =
       Contract_satisfied_completion)
     ?(stop_reason = Some Lib.Cascade_runner.Completed)
+    ?(required_tool_candidates = [])
     config ~keeper_name =
   let meta =
     match Lib.Keeper_types.read_meta config keeper_name with
@@ -499,6 +500,7 @@ let append_execution_receipt
           tool_gate_enabled = true;
           tool_surface_fallback_used = false;
           required_tools = [];
+          required_tool_candidates;
           missing_required_tools = [];
         };
       sandbox_kind =
@@ -778,7 +780,10 @@ let test_execution_trust_surfaces_latest_receipt () =
             Masc_mcp.Keeper_keepalive.stop_keepalive "sangsu")
           (fun () ->
             create_keeper env sw config "sangsu";
-            append_execution_receipt config ~keeper_name:"sangsu";
+            append_execution_receipt
+              ~required_tool_candidates:
+                [ "keeper_board_comment"; "keeper_board_post" ]
+              config ~keeper_name:"sangsu";
             let compact_json =
               Lib.Dashboard_http_keeper.keepers_dashboard_json
                 ~compact:true config
@@ -818,6 +823,10 @@ let test_execution_trust_surfaces_latest_receipt () =
               "satisfied_completion"
               (compact_row |> member "trust" |> member "tool_contract_result"
              |> to_string);
+            check (list string) "compact row exposes required tool candidates"
+              [ "keeper_board_comment"; "keeper_board_post" ]
+              (compact_row |> member "trust" |> member "required_tool_candidates"
+             |> to_list |> List.map to_string);
             check string "execution trust row preserves sandbox kind"
               "local"
               (trust_row |> member "trust" |> member "sandbox"
@@ -867,6 +876,10 @@ let test_execution_trust_surfaces_latest_receipt () =
             check int "execution trust row preserves unexpected tool count" 1
               (trust_row |> member "trust" |> member "unexpected_tool_count"
              |> to_int);
+            check (list string) "execution trust row preserves required candidates"
+              [ "keeper_board_comment"; "keeper_board_post" ]
+              (trust_row |> member "trust" |> member "required_tool_candidates"
+             |> to_list |> List.map to_string);
             let execution_json =
               Lib.Dashboard_execution.json
                 ~config
@@ -899,7 +912,12 @@ let test_execution_trust_surfaces_latest_receipt () =
              |> member "unexpected_tools" |> to_list |> List.map to_string);
             check int "execution row exposes unexpected tool count" 1
               (execution_row |> member "trust" |> member "execution_summary"
-             |> member "unexpected_tool_count" |> to_int))))
+             |> member "unexpected_tool_count" |> to_int);
+            check (list string) "execution row exposes required candidates"
+              [ "keeper_board_comment"; "keeper_board_post" ]
+              (execution_row |> member "trust" |> member "execution_summary"
+             |> member "required_tool_candidates" |> to_list
+             |> List.map to_string))))
 
 let test_dashboard_execution_queue_surfaces_keeper_runtime_trust () =
   let dir = test_dir () in

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -145,6 +145,7 @@ let append_keeper_receipt
           tool_gate_enabled = true;
           tool_surface_fallback_used = false;
           required_tools = [];
+          required_tool_candidates = [];
           missing_required_tools = [];
         };
       sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta;

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -741,6 +741,7 @@ let append_execution_receipt
     ?(degraded_retry_cascade =
       Some Masc_mcp.Keeper_config.local_recovery_cascade_name)
     ?(fallback_reason = Some Masc_mcp.Keeper_error_classify.Turn_timeout)
+    ?(required_tool_candidates = [])
     config ~keeper_name =
   let meta =
     match Masc_mcp.Keeper_types.read_meta config keeper_name with
@@ -783,6 +784,7 @@ let append_execution_receipt
           tool_gate_enabled = true;
           tool_surface_fallback_used = false;
           required_tools = [];
+          required_tool_candidates;
           missing_required_tools = [];
         };
       sandbox_kind =
@@ -1495,6 +1497,7 @@ let test_execution_trust_route_surfaces_trust_summary_fields () =
     ~degraded_retry_applied:false
     ~degraded_retry_cascade:None
     ~fallback_reason:None
+    ~required_tool_candidates:[ "keeper_board_comment"; "keeper_board_post" ]
     config ~keeper_name;
   let result =
     run_curl_get ~port ~path:"/api/v1/dashboard/execution-trust" ()
@@ -1543,6 +1546,11 @@ let test_execution_trust_route_surfaces_trust_summary_fields () =
   check int "route surfaces unexpected tool count" 1
     (row |> member "trust" |> member "execution_summary"
      |> member "unexpected_tool_count" |> to_int);
+  check (list string) "route surfaces required tool candidates"
+    [ "keeper_board_comment"; "keeper_board_post" ]
+    (row |> member "trust" |> member "execution_summary"
+     |> member "required_tool_candidates" |> to_list
+     |> List.map to_string);
   check bool "route surfaces latest causal event field" true
     (match row |> member "trust" |> member "latest_causal_event" with
      | `Null | `Assoc _ -> true
@@ -1585,7 +1593,9 @@ let test_composite_routes_surface_latest_execution_receipt () =
   in
   require_status "boot route registers keeper before composite read" 200 boot_result;
   wait_for_boot_receipt_side_effects config ~keeper_name;
-  append_execution_receipt config ~keeper_name;
+  append_execution_receipt
+    ~required_tool_candidates:[ "keeper_board_comment"; "keeper_board_post" ]
+    config ~keeper_name;
   let per_keeper_path =
     Printf.sprintf "/api/v1/keepers/%s/composite" keeper_name
   in
@@ -1628,6 +1638,10 @@ let test_composite_routes_surface_latest_execution_receipt () =
     [ "WebSearch" ]
     (execution |> member "tool_surface" |> member "unexpected_tools" |> to_list
      |> List.map to_string);
+  check (list string) "composite tool surface exposes required tool candidates"
+    [ "keeper_board_comment"; "keeper_board_post" ]
+    (execution |> member "tool_surface" |> member "required_tool_candidates"
+     |> to_list |> List.map to_string);
   let fleet = run_curl_get ~port ~path:"/api/v1/keepers/composite" () in
   require_status "fleet composite GET returns 200" 200 fleet;
   let fleet_json = Yojson.Safe.from_string fleet.body in

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -14,6 +14,7 @@ module U = Yojson.Safe.Util
 let mk_tool_surface
       ?(tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Required)
       ?(required_tools = [])
+      ?(required_tool_candidates = [])
       ?(missing_required_tools = [])
       ()
   : R.tool_surface
@@ -32,6 +33,7 @@ let mk_tool_surface
   ; tool_gate_enabled = true
   ; tool_surface_fallback_used = false
   ; required_tools
+  ; required_tool_candidates
   ; missing_required_tools
   }
 ;;
@@ -46,6 +48,7 @@ let mk_receipt
       ?(reported_tools = [])
       ?(requested_tools = [])
       ?(required_tools = [])
+      ?(required_tool_candidates = [])
       ?(missing_required_tools = [])
       ?(tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Required)
       ?(cascade_outcome : R.cascade_outcome = Cascade_completed)
@@ -78,7 +81,12 @@ let mk_receipt
   ; tools_used
   ; tool_contract_result
   ; tool_surface =
-      mk_tool_surface ~tool_requirement ~required_tools ~missing_required_tools ()
+      mk_tool_surface
+        ~tool_requirement
+        ~required_tools
+        ~required_tool_candidates
+        ~missing_required_tools
+        ()
   ; sandbox_kind = Masc_mcp.Keeper_types.Local
   ; sandbox_root = None
   ; network_mode = Masc_mcp.Keeper_types.Network_none
@@ -468,6 +476,7 @@ let test_broadcast_payload_carries_turn_diagnostics () =
       ~tools_used:[ "keeper_tasks_list"; "keeper_stay_silent" ]
       ~observed_tools:[ "keeper_tasks_list"; "keeper_stay_silent" ]
       ~required_tools:[ "keeper_shell"; "masc_worktree_create" ]
+      ~required_tool_candidates:[ "keeper_shell"; "keeper_bash" ]
       ~missing_required_tools:[ "keeper_shell" ]
       ~current_task_id:"task-102"
       ~stop_reason:Masc_mcp.Cascade_runner.Completed
@@ -509,6 +518,11 @@ let test_broadcast_payload_carries_turn_diagnostics () =
     "required tools"
     [ "keeper_shell"; "masc_worktree_create" ]
     (string_list_member "required_tools" contract);
+  check
+    (list string)
+    "required tool candidates"
+    [ "keeper_shell"; "keeper_bash" ]
+    (string_list_member "required_tool_candidates" contract);
   check
     (list string)
     "missing required tools"

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -205,6 +205,7 @@ let test_turn_context_fields_stored () =
       ~tool_surface_class:"execution"
       ~visible_tool_count:2
       ~required_tools:["keeper_bash"]
+      ~required_tool_candidates:["keeper_bash"; "keeper_shell"]
       ~missing_required_tools:["keeper_fs_edit"]
       ~cascade_profile:"tool_use_strict"
       ();
@@ -280,6 +281,11 @@ let test_turn_context_fields_stored () =
       ["keeper_bash"]
       Yojson.Safe.Util.(
         runtime_contract |> member "required_tools" |> to_list |> List.map to_string);
+    Alcotest.(check (list string)) "runtime_contract required_tool_candidates"
+      ["keeper_bash"; "keeper_shell"]
+      Yojson.Safe.Util.(
+        runtime_contract |> member "required_tool_candidates" |> to_list
+        |> List.map to_string);
     Alcotest.(check (list string)) "runtime_contract missing_required_tools"
       ["keeper_fs_edit"]
       Yojson.Safe.Util.(

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -11401,6 +11401,15 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
 
 let test_generic_required_tool_gate_guidance_names_action_tools () =
   let module Surface = Masc_mcp.Keeper_agent_tool_surface in
+  check
+    (list string)
+    "generic required gate exposes active candidate tools"
+    [ "keeper_board_comment"; "keeper_board_post" ]
+    (Surface.generic_required_tool_candidate_names
+       ~has_current_task:false
+       ~turn_affordances:[ "board_post_or_comment" ]
+       ~allowed_tool_names:
+         [ "keeper_tasks_list"; "keeper_board_comment"; "keeper_board_post" ]);
   let guidance =
     Surface.generic_required_tool_gate_guidance
       ~has_current_task:false


### PR DESCRIPTION
## Summary
- Adds generic required-tool candidate telemetry for `required_tool=true` turns when no explicit `required_tools` are present.
- Carries `required_tool_candidates` through execution receipts, runtime contracts, tool-call logs, operator broadcasts, compact dashboard surfaces, and execution-trust summaries.
- Adds focused coverage for candidate selection, runtime-contract persistence, operator broadcast payloads, and dashboard visibility.

## Why
Issue #15542's remaining live K2 class shows `required_tools=[]` and no tool call after the provider exhausts required-tool retry. This patch does not change the explicit required-tool contract; it makes the generic gate's preferred executable candidates visible so the next no-tool failure has actionable evidence.

## Validation
- `ocamlformat -i` on changed OCaml files
- `git diff --check origin/main...HEAD`
- Attempted `scripts/dune-local.sh build test/test_keeper_tool_call_log.exe` with 30s and 45s timeouts; both waited on `/tmp/me-dune-local.lock` and exited 124, so CI is the build verification surface for this draft.