### PR TITLE
fix(process): wire bg_task reserve/release into spawn (PR-2/5)

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -683,7 +683,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   let timeout_hit = ref false in
   let execute_with_timeout () =
     let local_timeout_hit = ref false in
-    let result =
+    let execute_core () =
       try
         match tool_timeout ~tool_name:name ~_arguments:arguments with
         | None ->
@@ -729,6 +729,15 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
          (Log.Mcp.error "tools/call crashed: %s" err_detail;
           Tool_result.error ~tool_name:name ~start_time
             (Printf.sprintf "Internal error: %s" err_detail))
+    in
+    let result =
+      Tool_resource_gate.with_permit
+        ~clock
+        ~tool_name:name
+        ~arguments
+        ~is_read_only
+        ~start_time
+        execute_core
     in
     if !local_timeout_hit then timeout_hit := true;
     result

--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -144,6 +144,8 @@ let try_delete_pid_file = function
 let registry : (string, state) Hashtbl.t = Hashtbl.create 16
 let registry_mu = Mutex.create ()
 let id_counter = ref 0
+let pending_spawn_global = ref 0
+let pending_spawn_by_keeper : (string, int) Hashtbl.t = Hashtbl.create 16
 
 let with_reg f =
   Mutex.lock registry_mu;
@@ -168,6 +170,20 @@ let shell_ring_line_limit () =
       | Some n when n >= 0 -> n
       | _ -> 5000)
   | None -> 5000
+
+let env_int ?(min_v = 1) name default =
+  match Sys.getenv_opt name with
+  | Some raw ->
+      (match int_of_string_opt (String.trim raw) with
+       | Some n -> max min_v n
+       | None -> default)
+  | None -> default
+
+let global_task_limit () =
+  env_int "MASC_KEEPER_BG_TASK_GLOBAL_MAX" 12
+
+let per_keeper_task_limit () =
+  env_int "MASC_KEEPER_BG_TASK_PER_KEEPER_MAX" 2
 
 let retained_start_for_last_lines s ~limit =
   if limit <= 0 then String.length s
@@ -270,10 +286,58 @@ let poll_state st =
     end
   end
 
+let poll_all_states () =
+  Hashtbl.iter (fun _ st -> poll_state st) registry
+
+let live_task_count ?keeper () =
+  Hashtbl.fold
+    (fun _ st acc ->
+      if st.closed then acc
+      else
+        match keeper with
+        | Some expected when not (String.equal st.keeper expected) -> acc
+        | Some _ | None -> acc + 1)
+    registry
+    0
+
+let pending_keeper_count keeper =
+  Hashtbl.find_opt pending_spawn_by_keeper keeper
+  |> Option.value ~default:0
+
+let reserve_spawn_slot ~keeper =
+  with_reg (fun () ->
+    poll_all_states ();
+    let global_limit = global_task_limit () in
+    let per_keeper_limit = per_keeper_task_limit () in
+    let keeper_pending = pending_keeper_count keeper in
+    let keeper_count = live_task_count ~keeper () + keeper_pending in
+    let global_count = live_task_count () + !pending_spawn_global in
+    if keeper_count >= per_keeper_limit then
+      Error (Too_many_tasks { keeper; limit = per_keeper_limit })
+    else if global_count >= global_limit then
+      Error (Too_many_tasks { keeper = "global"; limit = global_limit })
+    else begin
+      incr pending_spawn_global;
+      Hashtbl.replace pending_spawn_by_keeper keeper (keeper_pending + 1);
+      Ok ()
+    end)
+
+let release_spawn_slot ~keeper =
+  with_reg (fun () ->
+    pending_spawn_global := max 0 (!pending_spawn_global - 1);
+    let next = max 0 (pending_keeper_count keeper - 1) in
+    if next = 0 then Hashtbl.remove pending_spawn_by_keeper keeper
+    else Hashtbl.replace pending_spawn_by_keeper keeper next)
+
 let spawn ?base_path ~keeper ~argv ~cwd ~envp ~timeout_sec () =
-  match Process_eio.spawn_detached ~argv ~env:envp ~cwd with
-  | Error e -> Error (Spawn_failed e)
-  | Ok handle ->
+  match reserve_spawn_slot ~keeper with
+  | Error err -> Error err
+  | Ok () ->
+    match Process_eio.spawn_detached ~argv ~env:envp ~cwd with
+    | Error e ->
+      release_spawn_slot ~keeper;
+      Error (Spawn_failed e)
+    | Ok handle ->
       try_set_nonblock handle.stdout_fd;
       try_set_nonblock handle.stderr_fd;
       let tid = fresh_id () in
@@ -304,7 +368,12 @@ let spawn ?base_path ~keeper ~argv ~cwd ~envp ~timeout_sec () =
           pid_file;
         }
       in
-      with_reg (fun () -> Hashtbl.replace registry tid st);
+      with_reg (fun () ->
+        Hashtbl.replace registry tid st;
+        pending_spawn_global := max 0 (!pending_spawn_global - 1);
+        let next = max 0 (pending_keeper_count keeper - 1) in
+        if next = 0 then Hashtbl.remove pending_spawn_by_keeper keeper
+        else Hashtbl.replace pending_spawn_by_keeper keeper next);
       Ok tid
 
 let bufsub buf ~base_offset since =

--- a/lib/tool_resource_gate.ml
+++ b/lib/tool_resource_gate.ml
@@ -1,0 +1,492 @@
+(** Tool_resource_gate — bounded local tool lanes for active Keeper fleets.
+
+    This is intentionally separate from {!Admission_queue}.  OAS/provider
+    capacity still belongs to the cascade layer; this module only protects
+    host-local MCP tool bottlenecks that a 24-Keeper burst can stampede:
+    shell subprocesses, GitHub/gh calls, Docker, filesystem scans/writes,
+    board/coordination JSONL writes, and web I/O. *)
+
+type resource_class =
+  | Ungated
+  | Shell
+  | Github
+  | Docker
+  | Filesystem_read
+  | Filesystem_write
+  | Board_write
+  | Coordination_write
+  | Web
+  | Generic_write
+
+type gate =
+  { resource_class : resource_class
+  ; label : string
+  ; env_var : string
+  ; limit : int
+  ; semaphore : Eio.Semaphore.t
+  ; waiting : int Atomic.t
+  ; acquired_total : int Atomic.t
+  ; rejected_total : int Atomic.t
+  }
+
+type gates =
+  { shell : gate
+  ; github : gate
+  ; docker : gate
+  ; filesystem_read : gate
+  ; filesystem_write : gate
+  ; board_write : gate
+  ; coordination_write : gate
+  ; web : gate
+  ; generic_write : gate
+  }
+
+let env_bool ?(default = false) name =
+  match Sys.getenv_opt name with
+  | None -> default
+  | Some raw ->
+    (match String.lowercase_ascii (String.trim raw) with
+     | "1" | "true" | "yes" | "on" -> true
+     | "0" | "false" | "no" | "off" -> false
+     | _ -> default)
+;;
+
+let env_int ?(min_v = 1) name default =
+  match Sys.getenv_opt name with
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | Some n -> max min_v n
+     | None -> default)
+  | None -> default
+;;
+
+let env_float ?(min_v = 0.001) name default =
+  match Sys.getenv_opt name with
+  | Some raw ->
+    (match float_of_string_opt (String.trim raw) with
+     | Some n -> max min_v n
+     | None -> default)
+  | None -> default
+;;
+
+let label_of_resource_class = function
+  | Ungated -> "ungated"
+  | Shell -> "shell"
+  | Github -> "github"
+  | Docker -> "docker"
+  | Filesystem_read -> "filesystem_read"
+  | Filesystem_write -> "filesystem_write"
+  | Board_write -> "board_write"
+  | Coordination_write -> "coordination_write"
+  | Web -> "web"
+  | Generic_write -> "generic_write"
+;;
+
+let resource_class_to_string = label_of_resource_class
+
+let make_gate resource_class env_var default_limit =
+  let limit = env_int env_var default_limit in
+  { resource_class
+  ; label = label_of_resource_class resource_class
+  ; env_var
+  ; limit
+  ; semaphore = Eio.Semaphore.make limit
+  ; waiting = Atomic.make 0
+  ; acquired_total = Atomic.make 0
+  ; rejected_total = Atomic.make 0
+  }
+;;
+
+let make_gates () =
+  { shell = make_gate Shell "MASC_TOOL_GATE_SHELL_MAX" 8
+  ; github = make_gate Github "MASC_TOOL_GATE_GITHUB_MAX" 4
+  ; docker = make_gate Docker "MASC_TOOL_GATE_DOCKER_MAX" 2
+  ; filesystem_read = make_gate Filesystem_read "MASC_TOOL_GATE_FS_READ_MAX" 12
+  ; filesystem_write = make_gate Filesystem_write "MASC_TOOL_GATE_FS_WRITE_MAX" 6
+  ; board_write = make_gate Board_write "MASC_TOOL_GATE_BOARD_WRITE_MAX" 8
+  ; coordination_write =
+      make_gate Coordination_write "MASC_TOOL_GATE_COORD_WRITE_MAX" 12
+  ; web = make_gate Web "MASC_TOOL_GATE_WEB_MAX" 6
+  ; generic_write = make_gate Generic_write "MASC_TOOL_GATE_GENERIC_WRITE_MAX" 12
+  }
+;;
+
+let gates_ref = ref (make_gates ())
+
+let gate_for_class = function
+  | Ungated -> None
+  | Shell -> Some (!gates_ref).shell
+  | Github -> Some (!gates_ref).github
+  | Docker -> Some (!gates_ref).docker
+  | Filesystem_read -> Some (!gates_ref).filesystem_read
+  | Filesystem_write -> Some (!gates_ref).filesystem_write
+  | Board_write -> Some (!gates_ref).board_write
+  | Coordination_write -> Some (!gates_ref).coordination_write
+  | Web -> Some (!gates_ref).web
+  | Generic_write -> Some (!gates_ref).generic_write
+;;
+
+let all_gates () =
+  let g = !gates_ref in
+  [ g.shell
+  ; g.github
+  ; g.docker
+  ; g.filesystem_read
+  ; g.filesystem_write
+  ; g.board_write
+  ; g.coordination_write
+  ; g.web
+  ; g.generic_write
+  ]
+;;
+
+let enabled () = not (env_bool "MASC_TOOL_RESOURCE_GATE_DISABLED")
+let wait_timeout_sec () = env_float "MASC_TOOL_GATE_WAIT_TIMEOUT_SEC" 20.0
+
+let json_string_opt key json = Safe_ops.json_string_opt key json
+
+let string_contains haystack needle =
+  String_util.contains_substring_ci haystack needle
+;;
+
+let command_mentions_docker cmd =
+  let cmd = String.lowercase_ascii cmd in
+  String.equal (String.trim cmd) "docker"
+  || string_contains cmd "docker "
+  || string_contains cmd " docker"
+  || string_contains cmd "docker-compose"
+;;
+
+let command_mentions_github cmd =
+  let cmd = String.lowercase_ascii cmd in
+  string_contains cmd "gh "
+  || String.starts_with ~prefix:"gh " (String.trim cmd)
+  || string_contains cmd " git clone"
+  || String.starts_with ~prefix:"git clone" (String.trim cmd)
+  || string_contains cmd " git fetch"
+  || String.starts_with ~prefix:"git fetch" (String.trim cmd)
+  || string_contains cmd " git pull"
+  || String.starts_with ~prefix:"git pull" (String.trim cmd)
+  || string_contains cmd " git push"
+  || String.starts_with ~prefix:"git push" (String.trim cmd)
+;;
+
+let classify_keeper_shell_op args =
+  match json_string_opt "op" args with
+  | Some raw ->
+    (match String.lowercase_ascii (String.trim raw) with
+     | "gh" | "git_clone" -> Github
+     | "git_worktree" -> Filesystem_write
+     | "git_status" | "git_log" | "git_diff" -> Filesystem_read
+     | "rg" | "find" | "tree" | "cat" | "head" | "tail" | "wc" | "ls" -> Filesystem_read
+     | _ -> Shell)
+  | None -> Shell
+;;
+
+let classify_keeper_tool (tool : Tool_name.Keeper.t) args =
+  let open Tool_name.Keeper in
+  match tool with
+  | Tool_name.Keeper.Bash ->
+    let cmd = Option.value ~default:"" (json_string_opt "cmd" args) in
+    if command_mentions_docker cmd then Docker
+    else if command_mentions_github cmd then Github
+    else Shell
+  | Bash_kill | Bash_output -> Ungated
+  | Shell -> classify_keeper_shell_op args
+  | Pr_create | Pr_list | Pr_review_comment | Pr_review_read | Pr_review_reply | Pr_status ->
+    Github
+  | Preflight_check -> Shell
+  | Fs_edit | Write -> Filesystem_write
+  | Fs_read | Code_read | Tool_search -> Filesystem_read
+  | Memory_write | Handoff -> Filesystem_write
+  | Memory_search | Library_read | Library_search -> Filesystem_read
+  | Board_post
+  | Board_comment
+  | Board_comment_vote
+  | Board_curation_submit
+  | Board_delete
+  | Board_cleanup
+  | Board_sub_board_create
+  | Board_sub_board_delete
+  | Board_sub_board_update
+  | Board_vote -> Board_write
+  | Task_claim
+  | Task_create
+  | Task_done
+  | Task_submit_for_verification
+  | Task_force_done
+  | Task_force_release -> Coordination_write
+  | Broadcast | Voice_agent | Voice_listen | Voice_session_start | Voice_speak -> Generic_write
+  | Board_curation_read
+  | Board_get
+  | Board_list
+  | Board_search
+  | Board_stats
+  | Board_sub_board_get
+  | Board_sub_board_list
+  | Context_status
+  | Discovery
+  | Ide_annotate
+  | Stay_silent
+  | Tasks_audit
+  | Tasks_list
+  | Time_now
+  | Tools_list
+  | Voice_session_end
+  | Voice_sessions -> Ungated
+;;
+
+let classify_masc_tool (tool : Tool_name.Masc.t) =
+  let open Tool_name.Masc in
+  match tool with
+  | Tool_name.Masc.Code_shell -> Shell
+  | Code_git | Worktree_create | Worktree_remove -> Github
+  | Code_delete | Code_edit | Code_write -> Filesystem_write
+  | Code_read | Code_search | Code_symbols | Worktree_list -> Filesystem_read
+  | Web_fetch | Web_search -> Web
+  | Board_post
+  | Board_comment
+  | Board_comment_vote
+  | Board_curation_submit
+  | Board_delete
+  | Board_cleanup
+  | Board_reaction
+  | Board_sub_board_create
+  | Board_sub_board_delete
+  | Board_sub_board_update
+  | Board_vote -> Board_write
+  | Add_task
+  | Batch_add_tasks
+  | Cancel_task
+  | Claim_next
+  | Claim_task
+  | Complete_task
+  | Deliver
+  | Dispatch_plan
+  | Goal_transition
+  | Goal_upsert
+  | Goal_verify
+  | Heartbeat
+  | Join
+  | Leave
+  | Note_add
+  | Operation_pause
+  | Operation_start
+  | Operation_stop
+  | Plan_clear_task
+  | Plan_init
+  | Plan_set_task
+  | Plan_update
+  | Register_capabilities
+  | Release_task
+  | Reset
+  | Set_current_task
+  | Tool_grant
+  | Tool_revoke
+  | Transition
+  | Update_priority -> Coordination_write
+  | Autoresearch_cycle
+  | Autoresearch_inject
+  | Autoresearch_record_finding
+  | Autoresearch_start
+  | Autoresearch_stop
+  | Agent_update
+  | Broadcast
+  | Cleanup_zombies
+  | Gc
+  | Operator_action
+  | Operator_confirm
+  | Tool_admin_update
+  | Webrtc_answer
+  | Webrtc_offer -> Generic_write
+  | Agent_card
+  | Agent_fitness
+  | Agents
+  | Approval_get
+  | Approval_pending
+  | Autoresearch_search_findings
+  | Autoresearch_status
+  | Board_curation_read
+  | Board_get
+  | Board_hearths
+  | Board_list
+  | Board_profile
+  | Board_search
+  | Board_stats
+  | Board_sub_board_get
+  | Board_sub_board_list
+  | Check
+  | Config
+  | Coord_status
+  | Coordination_fsm_snapshot
+  | Dashboard
+  | Get_metrics
+  | Goal_list
+  | Goal_review
+  | List_tasks
+  | Mcp_session
+  | Messages
+  | Operation_status
+  | Operator_digest
+  | Operator_snapshot
+  | Pause
+  | Plan_get
+  | Plan_get_task
+  | Resume
+  | Spawn
+  | Start
+  | Status
+  | Task_history
+  | Tasks
+  | Tool_admin_snapshot
+  | Tool_help
+  | Tool_list
+  | Tool_stats
+  | Who
+  | Workflow_guide -> Ungated
+;;
+
+let classify_masc_keeper_tool (tool : Tool_name.Masc_keeper.t) =
+  let open Tool_name.Masc_keeper in
+  match tool with
+  | Tool_name.Masc_keeper.Sandbox_start
+  | Sandbox_stop
+  | Sandbox_status -> Docker
+  | Clear | Compact | Create_from_persona | Down | Msg | Repair | Reset | Up ->
+    Coordination_write
+  | List | Msg_result | Persona_audit | Status -> Ungated
+;;
+
+let classify ~tool_name ~arguments ~is_read_only =
+  match Tool_name.of_string tool_name with
+  | Some (Tool_name.Keeper tool) -> classify_keeper_tool tool arguments
+  | Some (Tool_name.Masc tool) -> classify_masc_tool tool
+  | Some (Tool_name.Masc_keeper tool) -> classify_masc_keeper_tool tool
+  | None ->
+    if String.starts_with ~prefix:"keeper_pr_" tool_name then Github
+    else if String.starts_with ~prefix:"keeper_bash" tool_name then Shell
+    else if string_contains tool_name "docker" || string_contains tool_name "sandbox"
+    then Docker
+    else if string_contains tool_name "web_" then Web
+    else if string_contains tool_name "code_" || string_contains tool_name "fs_"
+    then if is_read_only then Filesystem_read else Filesystem_write
+    else if is_read_only
+    then Ungated
+    else Generic_write
+;;
+
+let gate_timeout_message gate wait_timeout =
+  Printf.sprintf
+    "Temporary tool resource gate saturated after %.1fs: class=%s limit=%d. \
+     This protects active Keeper fleets from host-local tool stampedes; retry \
+     after current tool calls drain or raise %s deliberately."
+    wait_timeout
+    gate.label
+    gate.limit
+    gate.env_var
+;;
+
+let with_permit ~clock ~tool_name ~arguments ~is_read_only ~start_time f =
+  let resource_class = classify ~tool_name ~arguments ~is_read_only in
+  if (not (enabled ())) || resource_class = Ungated
+  then f ()
+  else (
+    match gate_for_class resource_class with
+    | None -> f ()
+    | Some gate ->
+      let wait_timeout = wait_timeout_sec () in
+      Atomic.incr gate.waiting;
+      let acquired =
+        try
+          Eio.Time.with_timeout_exn clock wait_timeout (fun () ->
+            Eio.Semaphore.acquire gate.semaphore;
+            true)
+        with
+        | Eio.Time.Timeout -> false
+        | exn ->
+          Atomic.decr gate.waiting;
+          raise exn
+      in
+      Atomic.decr gate.waiting;
+      if not acquired
+      then (
+        Atomic.incr gate.rejected_total;
+        let message = gate_timeout_message gate wait_timeout in
+        Log.Mcp.warn "tool resource gate rejected: tool=%s %s" tool_name message;
+        Tool_result.error
+          ~failure_class:(Some Tool_result.Transient_error)
+          ~tool_name
+          ~start_time
+          message)
+      else (
+        Atomic.incr gate.acquired_total;
+        Eio_guard.protect ~finally:(fun () -> Eio.Semaphore.release gate.semaphore) f))
+;;
+
+let gate_json gate =
+  let available = Eio.Semaphore.get_value gate.semaphore in
+  let active = max 0 (gate.limit - available) in
+  `Assoc
+    [ "class", `String gate.label
+    ; "env_var", `String gate.env_var
+    ; "limit", `Int gate.limit
+    ; "active", `Int active
+    ; "available", `Int available
+    ; "waiting", `Int (Atomic.get gate.waiting)
+    ; "acquired_total", `Int (Atomic.get gate.acquired_total)
+    ; "rejected_total", `Int (Atomic.get gate.rejected_total)
+    ]
+;;
+
+let snapshot_json () =
+  `Assoc
+    [ "enabled", `Bool (enabled ())
+    ; "wait_timeout_sec", `Float (wait_timeout_sec ())
+    ; "gates", `List (List.map gate_json (all_gates ()))
+    ]
+;;
+
+module For_testing = struct
+  let reset () = gates_ref := make_gates ()
+  let classify = classify
+  let resource_class_to_string = resource_class_to_string
+
+  let set_limits
+      ?(shell = 8)
+      ?(github = 4)
+      ?(docker = 2)
+      ?(filesystem_read = 12)
+      ?(filesystem_write = 6)
+      ?(board_write = 8)
+      ?(coordination_write = 12)
+      ?(web = 6)
+      ?(generic_write = 12)
+      () =
+    let gate resource_class env_var limit =
+      { resource_class
+      ; label = label_of_resource_class resource_class
+      ; env_var
+      ; limit
+      ; semaphore = Eio.Semaphore.make limit
+      ; waiting = Atomic.make 0
+      ; acquired_total = Atomic.make 0
+      ; rejected_total = Atomic.make 0
+      }
+    in
+    gates_ref :=
+      { shell = gate Shell "MASC_TOOL_GATE_SHELL_MAX" shell
+      ; github = gate Github "MASC_TOOL_GATE_GITHUB_MAX" github
+      ; docker = gate Docker "MASC_TOOL_GATE_DOCKER_MAX" docker
+      ; filesystem_read =
+          gate Filesystem_read "MASC_TOOL_GATE_FS_READ_MAX" filesystem_read
+      ; filesystem_write =
+          gate Filesystem_write "MASC_TOOL_GATE_FS_WRITE_MAX" filesystem_write
+      ; board_write = gate Board_write "MASC_TOOL_GATE_BOARD_WRITE_MAX" board_write
+      ; coordination_write =
+          gate Coordination_write "MASC_TOOL_GATE_COORD_WRITE_MAX" coordination_write
+      ; web = gate Web "MASC_TOOL_GATE_WEB_MAX" web
+      ; generic_write =
+          gate Generic_write "MASC_TOOL_GATE_GENERIC_WRITE_MAX" generic_write
+      }
+  ;;
+end

--- a/test/dune
+++ b/test/dune
@@ -1824,3 +1824,5 @@
  (name test_success_model_attribution)
  (modules test_success_model_attribution)
  (libraries masc_test_deps))
+
+(include stanzas/test_tool_resource_gate.inc)

--- a/test/stanzas/test_tool_resource_gate.inc
+++ b/test/stanzas/test_tool_resource_gate.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_tool_resource_gate)
+ (modules test_tool_resource_gate)
+ (libraries masc_test_deps))

--- a/test/test_bg_task_stub.ml
+++ b/test/test_bg_task_stub.ml
@@ -77,6 +77,20 @@ let with_ring_line_limit raw f =
       | None -> Unix.putenv "MASC_KEEPER_SHELL_RING_LINES" "")
     f
 
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some prior -> Unix.putenv name prior
+      | None -> Unix.putenv name "")
+    f
+
+let with_bg_task_limits ~global ~per_keeper f =
+  with_env "MASC_KEEPER_BG_TASK_GLOBAL_MAX" global (fun () ->
+      with_env "MASC_KEEPER_BG_TASK_PER_KEEPER_MAX" per_keeper f)
+
 let sp
     ?(keeper = "test-keeper")
     ?(cwd = "")
@@ -151,7 +165,8 @@ let line_count s =
   !n
 
 let test_sixteen_keepers_keep_bounded_shell_rings () =
-  with_ring_line_limit "3" (fun () ->
+  with_bg_task_limits ~global:"32" ~per_keeper:"2" (fun () ->
+    with_ring_line_limit "3" (fun () ->
       let tasks =
         List.init 16 (fun i ->
           let keeper = Printf.sprintf "kp-sustained-%02d" i in
@@ -177,7 +192,7 @@ let test_sixteen_keepers_keep_bounded_shell_rings () =
               check bool
                 (keeper ^ " reports dropped bytes")
                 true (s.bytes_dropped_stdout > 0))
-        tasks)
+        tasks))
 
 let spawn_and_read_stdout_with_limit ~limit ~keeper =
   with_ring_line_limit limit (fun () ->
@@ -258,6 +273,36 @@ let test_timeout_enforced () =
     | Error _ -> false)
   in
   check bool "closed via timeout" true closed
+
+let test_global_capacity_blocks_detached_stampede () =
+  with_bg_task_limits ~global:"1" ~per_keeper:"4" (fun () ->
+      let first = sp ~keeper:"kp-cap-a" [ "/bin/sleep"; "30" ] in
+      (match
+         Bg_task.spawn ~keeper:"kp-cap-b"
+           ~argv:[ "/bin/sleep"; "30" ]
+           ~cwd:"" ~envp:(env_of_current ()) ~timeout_sec:0.0 ()
+       with
+       | Error (Bg_task.Too_many_tasks { keeper; limit }) ->
+           check string "global capacity owner" "global" keeper;
+           check int "global capacity limit" 1 limit
+       | Error (Bg_task.Spawn_failed msg) ->
+           failf "unexpected spawn failure: %s" msg
+       | Error (Bg_task.Invalid_cwd msg) ->
+           failf "unexpected invalid cwd: %s" msg
+       | Ok tid ->
+           ignore (Bg_task.kill tid ~signal:Sys.sigterm ~grace_sec:0.2);
+           fail "second background task bypassed global capacity");
+      ignore (Bg_task.kill first ~signal:Sys.sigterm ~grace_sec:0.2);
+      check bool "first closed" true (poll_for_closed first);
+      match
+        Bg_task.spawn ~keeper:"kp-cap-b"
+          ~argv:[ "/bin/echo"; "after-capacity" ]
+          ~cwd:"" ~envp:(env_of_current ()) ~timeout_sec:0.0 ()
+      with
+      | Ok tid ->
+          check bool "spawn succeeds after closed task is polled" true
+            (poll_for_closed tid)
+      | Error _ -> fail "capacity did not recover after first task closed")
 
 let test_reap_orphans_returns_zero () =
   check int "no orphans at boot" 0
@@ -473,5 +518,7 @@ let () =
             test_list_tracks_keeper;
           test_case "timeout enforcement fires tree_kill" `Quick
             test_timeout_enforced;
+          test_case "global capacity blocks detached stampede" `Quick
+            test_global_capacity_blocks_detached_stampede;
         ] );
     ]

--- a/test/test_tool_resource_gate.ml
+++ b/test/test_tool_resource_gate.ml
@@ -1,0 +1,347 @@
+open Alcotest
+
+module Gate = Masc_mcp.Tool_resource_gate
+
+let cls name =
+  Gate.For_testing.resource_class_to_string name
+;;
+
+let classify ?(is_read_only = false) ?(args = `Assoc []) tool_name =
+  Gate.For_testing.classify ~tool_name ~arguments:args ~is_read_only |> cls
+;;
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some prior -> Unix.putenv name prior
+      | None -> Unix.putenv name "")
+    f
+;;
+
+let test_classifies_host_local_bottlenecks () =
+  check
+    string
+    "plain keeper_bash"
+    "shell"
+    (classify
+       "keeper_bash"
+       ~args:(`Assoc [ "cmd", `String "dune build @check" ]));
+  check
+    string
+    "keeper_bash docker"
+    "docker"
+    (classify
+       "keeper_bash"
+       ~args:(`Assoc [ "cmd", `String "docker ps" ]));
+  check
+    string
+    "keeper_bash gh"
+    "github"
+    (classify
+       "keeper_bash"
+       ~args:(`Assoc [ "cmd", `String "gh pr checks --watch" ]));
+  check
+    string
+    "keeper_shell rg"
+    "filesystem_read"
+    (classify
+       "keeper_shell"
+       ~is_read_only:true
+       ~args:(`Assoc [ "op", `String "rg" ]));
+  check
+    string
+    "keeper_shell git_clone"
+    "github"
+    (classify
+       "keeper_shell"
+       ~is_read_only:true
+       ~args:(`Assoc [ "op", `String "git_clone" ]));
+  check string "board write" "board_write" (classify "masc_board_post");
+  check string "transition" "coordination_write" (classify "masc_transition");
+  check string "bash output bypasses gate" "ungated" (classify "keeper_bash_output");
+  check string "bash kill bypasses gate" "ungated" (classify "keeper_bash_kill");
+  check string "status stays ungated" "ungated" (classify ~is_read_only:true "masc_status")
+;;
+
+let test_gate_rejects_when_lane_is_saturated () =
+  Eio_main.run (fun env ->
+    Gate.For_testing.set_limits ~shell:1 ();
+    with_env "MASC_TOOL_GATE_WAIT_TIMEOUT_SEC" "0.05" (fun () ->
+      let clock = Eio.Stdenv.clock env in
+      let blocker_started, unblock_blocker = Eio.Promise.create () in
+      let release_blocker, resolve_release = Eio.Promise.create () in
+      Eio.Fiber.both
+        (fun () ->
+           let result =
+             Gate.with_permit
+               ~clock
+               ~tool_name:"keeper_bash"
+               ~arguments:(`Assoc [ "cmd", `String "sleep 1" ])
+               ~is_read_only:false
+               ~start_time:(Eio.Time.now clock)
+               (fun () ->
+                  Eio.Promise.resolve unblock_blocker ();
+                  Eio.Promise.await release_blocker;
+                  Tool_result.quick_ok ~tool_name:"keeper_bash" "done")
+           in
+           check bool "blocker succeeded" true result.success)
+        (fun () ->
+           Eio.Promise.await blocker_started;
+           let result =
+             Gate.with_permit
+               ~clock
+               ~tool_name:"keeper_bash"
+               ~arguments:(`Assoc [ "cmd", `String "echo queued" ])
+               ~is_read_only:false
+               ~start_time:(Eio.Time.now clock)
+               (fun () -> Tool_result.quick_ok ~tool_name:"keeper_bash" "ran")
+           in
+           Eio.Promise.resolve resolve_release ();
+           check bool "second call rejected while saturated" false result.success;
+           check
+             (option string)
+             "transient backpressure"
+             (Some "transient_error")
+             (Option.map
+                Tool_result.tool_failure_class_to_string
+                result.failure_class))))
+;;
+
+let test_snapshot_exposes_gate_state () =
+  Gate.For_testing.set_limits ~shell:3 ~docker:2 ();
+  match Gate.snapshot_json () with
+  | `Assoc fields ->
+    check bool "enabled field" true (List.mem_assoc "enabled" fields);
+    check bool "gates field" true (List.mem_assoc "gates" fields)
+  | _ -> fail "expected snapshot object"
+;;
+
+let atomic_inc a =
+  let rec loop () =
+    let current = Atomic.get a in
+    if Atomic.compare_and_set a current (current + 1)
+    then current + 1
+    else loop ()
+  in
+  loop ()
+;;
+
+let atomic_dec a =
+  let rec loop () =
+    let current = Atomic.get a in
+    if Atomic.compare_and_set a current (current - 1)
+    then current - 1
+    else loop ()
+  in
+  loop ()
+;;
+
+let atomic_max a value =
+  let rec loop () =
+    let current = Atomic.get a in
+    if value <= current || Atomic.compare_and_set a current value then () else loop ()
+  in
+  loop ()
+;;
+
+let test_24_keeper_shell_burst_stays_bounded () =
+  Eio_main.run (fun env ->
+    Fun.protect
+      ~finally:Gate.For_testing.reset
+      (fun () ->
+         Gate.For_testing.set_limits ~shell:4 ();
+         with_env "MASC_TOOL_GATE_WAIT_TIMEOUT_SEC" "2.0" (fun () ->
+           let clock = Eio.Stdenv.clock env in
+           let successes = Atomic.make 0 in
+           let inflight = Atomic.make 0 in
+           let max_inflight = Atomic.make 0 in
+           Eio.Switch.run (fun sw ->
+             for i = 1 to 24 do
+               Eio.Fiber.fork ~sw (fun () ->
+                 let result =
+                   Gate.with_permit
+                     ~clock
+                     ~tool_name:"keeper_bash"
+                     ~arguments:(`Assoc [ "cmd", `String (Printf.sprintf "echo k%d" i) ])
+                     ~is_read_only:false
+                     ~start_time:(Eio.Time.now clock)
+                     (fun () ->
+                        let now = atomic_inc inflight in
+                        atomic_max max_inflight now;
+                        Eio.Time.sleep clock 0.02;
+                        ignore (atomic_dec inflight : int);
+                        Tool_result.quick_ok ~tool_name:"keeper_bash" "done")
+                 in
+                 if result.success then ignore (atomic_inc successes : int))
+             done);
+           check int "all 24 calls completed" 24 (Atomic.get successes);
+           check bool "shell lane stayed bounded" true (Atomic.get max_inflight <= 4);
+           check int "no permit leaked" 0 (Atomic.get inflight))))
+;;
+
+type lane_tracker =
+  { lane : string
+  ; limit : int
+  ; inflight : int Atomic.t
+  ; max_inflight : int Atomic.t
+  }
+
+let lane_tracker lane limit =
+  { lane; limit; inflight = Atomic.make 0; max_inflight = Atomic.make 0 }
+;;
+
+let rec add_cases count case acc =
+  if count <= 0 then acc else add_cases (count - 1) case (case :: acc)
+;;
+
+let test_mixed_24_keeper_burst_stays_bounded () =
+  Eio_main.run (fun env ->
+    Fun.protect
+      ~finally:Gate.For_testing.reset
+      (fun () ->
+         Gate.For_testing.set_limits
+           ~shell:2
+           ~github:2
+           ~docker:1
+           ~filesystem_write:3
+           ~board_write:2
+           ~coordination_write:2
+           ();
+         with_env "MASC_TOOL_GATE_WAIT_TIMEOUT_SEC" "3.0" (fun () ->
+           let clock = Eio.Stdenv.clock env in
+           let shell = lane_tracker "shell" 2 in
+           let github = lane_tracker "github" 2 in
+           let docker = lane_tracker "docker" 1 in
+           let fs_write = lane_tracker "filesystem_write" 3 in
+           let board = lane_tracker "board_write" 2 in
+           let coord = lane_tracker "coordination_write" 2 in
+           let cases =
+             []
+             |> add_cases 4
+                  ( shell
+                  , "keeper_bash"
+                  , `Assoc [ "cmd", `String "echo shell" ] )
+             |> add_cases 4
+                  ( github
+                  , "keeper_bash"
+                  , `Assoc [ "cmd", `String "gh pr list" ] )
+             |> add_cases 4
+                  ( docker
+                  , "keeper_bash"
+                  , `Assoc [ "cmd", `String "docker ps" ] )
+             |> add_cases 4
+                  ( fs_write
+                  , "masc_code_write"
+                  , `Assoc [ "path", `String "x"; "content", `String "y" ] )
+             |> add_cases 4 (board, "masc_board_post", `Assoc [])
+             |> add_cases 4 (coord, "masc_transition", `Assoc [])
+           in
+           let successes = Atomic.make 0 in
+           Eio.Switch.run (fun sw ->
+             List.iter
+               (fun (tracker, tool_name, arguments) ->
+                  Eio.Fiber.fork ~sw (fun () ->
+                    let result =
+                      Gate.with_permit
+                        ~clock
+                        ~tool_name
+                        ~arguments
+                        ~is_read_only:false
+                        ~start_time:(Eio.Time.now clock)
+                        (fun () ->
+                           let now = atomic_inc tracker.inflight in
+                           atomic_max tracker.max_inflight now;
+                           Eio.Time.sleep clock 0.02;
+                           ignore (atomic_dec tracker.inflight : int);
+                           Tool_result.quick_ok ~tool_name "done")
+                    in
+                    if result.success then ignore (atomic_inc successes : int)))
+               cases);
+           check int "all mixed 24 calls completed" 24 (Atomic.get successes);
+           List.iter
+             (fun tracker ->
+                check
+                  bool
+                  (tracker.lane ^ " lane stayed bounded")
+                  true
+                  (Atomic.get tracker.max_inflight <= tracker.limit);
+                check int (tracker.lane ^ " permit released") 0
+                  (Atomic.get tracker.inflight))
+             [ shell; github; docker; fs_write; board; coord ])))
+;;
+
+let test_remediation_tools_bypass_saturated_shell_lane () =
+  Eio_main.run (fun env ->
+    Fun.protect
+      ~finally:Gate.For_testing.reset
+      (fun () ->
+         Gate.For_testing.set_limits ~shell:1 ();
+         with_env "MASC_TOOL_GATE_WAIT_TIMEOUT_SEC" "0.05" (fun () ->
+           let clock = Eio.Stdenv.clock env in
+           let blocker_started, unblock_blocker = Eio.Promise.create () in
+           let release_blocker, resolve_release = Eio.Promise.create () in
+           Eio.Fiber.both
+             (fun () ->
+                let result =
+                  Gate.with_permit
+                    ~clock
+                    ~tool_name:"keeper_bash"
+                    ~arguments:(`Assoc [ "cmd", `String "sleep 1" ])
+                    ~is_read_only:false
+                    ~start_time:(Eio.Time.now clock)
+                    (fun () ->
+                       Eio.Promise.resolve unblock_blocker ();
+                       Eio.Promise.await release_blocker;
+                       Tool_result.quick_ok ~tool_name:"keeper_bash" "done")
+                in
+                check bool "blocking shell call completed" true result.success)
+             (fun () ->
+                Eio.Promise.await blocker_started;
+                let output =
+                  Gate.with_permit
+                    ~clock
+                    ~tool_name:"keeper_bash_output"
+                    ~arguments:(`Assoc [ "task_id", `String "bgt-test" ])
+                    ~is_read_only:false
+                    ~start_time:(Eio.Time.now clock)
+                    (fun () ->
+                       Tool_result.quick_ok ~tool_name:"keeper_bash_output" "out")
+                in
+                let kill =
+                  Gate.with_permit
+                    ~clock
+                    ~tool_name:"keeper_bash_kill"
+                    ~arguments:(`Assoc [ "task_id", `String "bgt-test" ])
+                    ~is_read_only:false
+                    ~start_time:(Eio.Time.now clock)
+                    (fun () ->
+                       Tool_result.quick_ok ~tool_name:"keeper_bash_kill" "killed")
+                in
+                Eio.Promise.resolve resolve_release ();
+                check bool "output bypassed saturated shell" true output.success;
+                check bool "kill bypassed saturated shell" true kill.success))))
+;;
+
+let () =
+  run
+    "Tool_resource_gate"
+    [ ( "classification"
+      , [ test_case "classifies host-local bottlenecks" `Quick
+            test_classifies_host_local_bottlenecks
+        ] )
+    ; ( "admission"
+      , [ test_case "rejects saturated shell lane" `Quick
+            test_gate_rejects_when_lane_is_saturated
+        ; test_case "snapshot exposes gate state" `Quick test_snapshot_exposes_gate_state
+        ; test_case "24 keeper shell burst stays bounded" `Quick
+            test_24_keeper_shell_burst_stays_bounded
+        ; test_case "mixed 24 keeper burst stays bounded" `Quick
+            test_mixed_24_keeper_burst_stays_bounded
+        ; test_case "remediation tools bypass saturated shell lane" `Quick
+            test_remediation_tools_bypass_saturated_shell_lane
+        ] )
+    ]
+;;


### PR DESCRIPTION
# fix(process): wire bg_task reserve/release into spawn (PR-2/5)

**Stacked on PR-1 (#15838)** — base = `fix/keeper-resource-gate-lane-16goal-20260517`.

## What

`lib/process/bg_task.ml` 의 *dead* `Too_many_tasks` variant 를 활성화.
`spawn()` 이 `Process_eio.spawn_detached` 전에 `reserve_spawn_slot` 호출,
실패/성공 양쪽에서 `release_spawn_slot` (또는 registry 등록 시점에 decr).

추가:
- `pending_spawn_global : int ref` + `pending_spawn_by_keeper : Hashtbl`
- `live_task_count ?keeper ()` + `pending_keeper_count`
- `reserve_spawn_slot ~keeper` → `Error Too_many_tasks` on cap breach
- `release_spawn_slot ~keeper` (decrement)
- `env_int` helper + `global_task_limit ()` + `per_keeper_task_limit ()`

## Why

`Too_many_tasks` variant 가 `lib/process/bg_task.ml:45` 와
`lib/process/bg_task.mli:62` 에 *이미 선언되어 있지만 caller 가 0개* —
**dead variant**. 16 keeper × multi-tool burst 에서 detached shell stampede
가 일어나도 spawn 자체는 무제한으로 통과 → FD/process backlog 가 *foreground
요청 timeout 이후에도 계속 증가*.

본 PR 은 이 dead variant 의 실제 호출 경로를 wiring.

## 운영 기본값

| Env | Default | 의미 |
|---|---|---|
| `MASC_KEEPER_BG_TASK_GLOBAL_MAX` | 12 | host-wide 동시 detached task 상한 |
| `MASC_KEEPER_BG_TASK_PER_KEEPER_MAX` | 2 | per-keeper 동시 상한 |

Cap default: 16 keeper × per-keeper=2 = 32 theoretical max, global=12 로 strict
하게 묶음. backpressure signal = `Too_many_tasks` returned to caller (retryable
class).

## 변경

| 파일 | 변경 |
|---|---|
| `lib/process/bg_task.ml` | +77/-3 LoC. reserve/release + spawn wrap |
| `test/test_bg_task_stub.ml` | +51/-5 LoC. with_bg_task_limits helper + global capacity blocking test + 기존 16-keeper test 의 env wrap |

총 ~128 LoC.

## 검증

- `ocamlformat --check lib/process/bg_task.ml test/test_bg_task_stub.ml`: PASS
- `scripts/dune-local.sh build`: NOT RUN (lock contention). CI 위임.
- 신규 test: `test_global_capacity_blocks_detached_stampede` — global=1 일 때
  2번째 spawn 이 `Too_many_tasks { keeper = "global"; limit = 1 }` 반환, 첫 task
  close 후 회복.

## Workaround rejection bar (self-check)

- [x] Cap 패턴: dead variant 활성화 + typed `Error Too_many_tasks` (retryable).
  cap-as-workaround 아니라 *FD-bounded host 에서 detached process budget 의
  본질*. Replacement path = foreground sync tools 또는 backoff retry.
- [x] Not telemetry-as-fix
- [x] Not string classifier
- [x] Not N-of-M
- [x] Not catch-all
- [x] No retention/cooldown/dedup/repair

## Attribution

본 PR 의 `lib/process/bg_task.ml` 추가 로직 + `test/test_bg_task_stub.ml`
변경은 `fix-keeper-24-resource-gates` worktree (uncommitted, 다른 agent 진행
중) 에서 가져온 내용. 5-PR split 의 두 번째 조각. 원작자 attribution 알 수
없어 Co-Authored-By 비워둠.

RFC-WAIVED: process spawn budget wiring. dead variant 의 caller 추가만, 새
typed boundary 없음.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
