### PR TITLE
refactor(cascade): lift legacy_runner worker tuning constants to SSOT

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -649,7 +649,7 @@ let review
                    ~masc_tools:[ report_review_verdict_schema ]
                    ~dispatch
                    ~max_turns:1
-                   ~temperature:Cascade_legacy_runner.deterministic_temperature
+                   ~temperature:Llm_provider.Constants.Inference_profile.deterministic.temperature
                    ~max_tokens:200
                    ~approval:Approval_callbacks.auto_approve
                    ?sw

--- a/lib/cascade/cascade_agent_context.ml
+++ b/lib/cascade/cascade_agent_context.ml
@@ -100,10 +100,10 @@ let default_config
   ; max_idle_turns = 3
   ; stream_idle_timeout_s = None
   ; max_execution_time_s = None
-  ; max_tokens = Cascade_legacy_runner.default_max_tokens
+  ; max_tokens = Llm_provider.Constants.Inference_profile.agent_default.max_tokens
   ; max_input_tokens = None
   ; max_cost_usd = None
-  ; temperature = Cascade_legacy_runner.default_temperature
+  ; temperature = Llm_provider.Constants.Inference_profile.agent_default.temperature
   ; hooks = None
   ; context_reducer = None
   ; guardrails = None

--- a/lib/cascade/cascade_legacy_runner.ml
+++ b/lib/cascade/cascade_legacy_runner.ml
@@ -8,33 +8,6 @@
     @since God file decomposition — extracted from oas_worker.ml *)
 
 (* ================================================================ *)
-(* Inference defaults — delegated to OAS Constants.Inference_profile. *)
-(* SSOT: agent_sdk/lib/llm_provider/constants.ml                     *)
-(* See jeong-sik/oas#598, jeong-sik/me#915.                         *)
-(* ================================================================ *)
-
-let default_temperature =
-  Llm_provider.Constants.Inference_profile.agent_default.temperature
-
-let default_max_tokens =
-  Llm_provider.Constants.Inference_profile.agent_default.max_tokens
-
-(** Deterministic temperature (0.0) for evaluation, verification, routing.
-    Delegates to OAS Inference_profile.deterministic. *)
-let deterministic_temperature =
-  Llm_provider.Constants.Inference_profile.deterministic.temperature
-
-(** Worker defaults — SSOT for worker_oas.ml + worker_container.ml.
-    temperature delegates to OAS Inference_profile.worker_default.
-    top_p/top_k/min_p are provider-specific sampling params (not in OAS profiles). *)
-let worker_temperature =
-  Llm_provider.Constants.Inference_profile.worker_default.temperature
-let worker_top_p = 0.95
-let worker_top_k = 20
-let worker_min_p = 0.0
-let worker_max_tool_calls_per_turn = 12
-
-(* ================================================================ *)
 (* Cascade types                                                     *)
 (* ================================================================ *)
 

--- a/lib/cascade/cascade_legacy_runner.mli
+++ b/lib/cascade/cascade_legacy_runner.mli
@@ -1,13 +1,7 @@
 (** Cascade_legacy_runner — cascade observation, metrics
     capture, and a single-actor cascade-counter store.
 
-    The .ml is 685 lines.  Splits into three concerns:
-    - {b Worker tuning constants}
-      ([default_temperature], [worker_temperature],
-      [worker_top_p], [worker_top_k],
-      [worker_max_tool_calls_per_turn]) consumed by
-      {!Worker_container.build_resume_config} and the
-      OAS-named worker path.
+    The .ml splits into two concerns:
     - {b Cascade observation}: the {!cascade_observation}
       record + companion attempt / fallback events,
       built per-turn in {!Keeper_turn_driver} via the
@@ -20,19 +14,15 @@
       callers do not contend on the in-memory counter
       maps.
 
-    Sister facade {!Oas_worker} does
-    [include Cascade_legacy_runner] to re-expose the constants
-    + observation type at the package boundary; this .mli
-    therefore pins the surface that
-    {!Cascade_legacy_runner.X} dotted callers and the
-    cascade-include consumer both rely on.
+    Dotted callers ({!Cascade_legacy_runner.X}) and the
+    cascade-include consumer rely on the surface pinned here.
 
     Internal helpers stay private at this boundary
     ([cascade_attempt] / [cascade_fallback_event] type
     bodies (exposed as part of {!cascade_observation}'s
     [attempts] / [fallback_events] fields with their full
     record shape),
-    [cascade_counter] type, [StringMap], [worker_min_p],
+    [cascade_counter] type, [StringMap],
     [cascade_max_keys], [create_cascade_counter],
     [cascade_eviction] type, [find_cascade_eviction_candidate],
     [display_provider_name_of_config], [strip_latest_suffix],
@@ -49,17 +39,6 @@
     [msg], [state] types, the [stream] queue,
     [handle_record], [handle_get_metrics], [run_actor],
     [cascade_metrics_json]). *)
-
-(** {1 Worker tuning constants} *)
-
-val default_temperature : float
-val default_max_tokens : int
-val deterministic_temperature : float
-
-val worker_temperature : float
-val worker_top_p : float
-val worker_top_k : int
-val worker_max_tool_calls_per_turn : int
 
 (** {1 Cascade observation types} *)
 

--- a/lib/cascade/cascade_worker_defaults.ml
+++ b/lib/cascade/cascade_worker_defaults.ml
@@ -1,0 +1,3 @@
+let top_p = 0.95
+let top_k = 20
+let max_tool_calls_per_turn = 12

--- a/lib/cascade/cascade_worker_defaults.mli
+++ b/lib/cascade/cascade_worker_defaults.mli
@@ -1,0 +1,18 @@
+(** Worker-only sampling defaults — provider-specific knobs that do not
+    belong in [Llm_provider.Constants.Inference_profile].
+
+    The OAS [Inference_profile] record exposes temperature / max_tokens /
+    thinking params but not provider-specific sampling cutoffs
+    (top_p / top_k) or the masc-mcp turn-level tool-call cap. This module
+    is the SSOT for those values.
+
+    Callers: [Worker_oas], [Worker_container]. *)
+
+(** Nucleus (top-p) sampling cutoff. *)
+val top_p : float
+
+(** Top-k sampling cutoff. *)
+val top_k : int
+
+(** Maximum number of tool calls a worker is allowed in one turn. *)
+val max_tool_calls_per_turn : int

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -175,8 +175,8 @@ let run_named
     ?(max_turns = 20)
     ?(max_idle_turns = 3)
     ?stream_idle_timeout_s
-    ?(temperature = Cascade_legacy_runner.default_temperature)
-    ?(max_tokens = Cascade_legacy_runner.default_max_tokens)
+    ?(temperature = Llm_provider.Constants.Inference_profile.agent_default.temperature)
+    ?(max_tokens = Llm_provider.Constants.Inference_profile.agent_default.max_tokens)
     ?max_input_tokens
     ?max_cost_usd
     ?wait_timeout_sec

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -22,8 +22,8 @@ let run_model_by_label
     ?(max_turns = 20)
     ?(max_idle_turns = 3)
     ?stream_idle_timeout_s
-    ?(temperature = Cascade_legacy_runner.default_temperature)
-    ?(max_tokens = Cascade_legacy_runner.default_max_tokens)
+    ?(temperature = Llm_provider.Constants.Inference_profile.agent_default.temperature)
+    ?(max_tokens = Llm_provider.Constants.Inference_profile.agent_default.max_tokens)
     ?max_input_tokens
     ?max_cost_usd
     ?wait_timeout_sec
@@ -105,8 +105,8 @@ let run_named_with_masc_tools
     ~(dispatch : name:string -> args:Yojson.Safe.t -> Tool_result.t)
     ?(max_turns = 20)
     ?stream_idle_timeout_s
-    ?(temperature = Cascade_legacy_runner.default_temperature)
-    ?(max_tokens = Cascade_legacy_runner.default_max_tokens)
+    ?(temperature = Llm_provider.Constants.Inference_profile.agent_default.temperature)
+    ?(max_tokens = Llm_provider.Constants.Inference_profile.agent_default.max_tokens)
     ?max_input_tokens
     ?max_cost_usd
     ?wait_timeout_sec
@@ -158,8 +158,8 @@ let run_model_with_masc_tools
     ~(dispatch : name:string -> args:Yojson.Safe.t -> Tool_result.t)
     ?(max_turns = 20)
     ?stream_idle_timeout_s
-    ?(temperature = Cascade_legacy_runner.default_temperature)
-    ?(max_tokens = Cascade_legacy_runner.default_max_tokens)
+    ?(temperature = Llm_provider.Constants.Inference_profile.agent_default.temperature)
+    ?(max_tokens = Llm_provider.Constants.Inference_profile.agent_default.max_tokens)
     ?max_input_tokens
     ?max_cost_usd
     ?wait_timeout_sec

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -456,9 +456,9 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
       system_prompt = Some system_prompt;
       max_tokens = Some (local_worker_max_tokens ());
       max_turns;
-      temperature = Some Cascade_legacy_runner.worker_temperature;
-      top_p = Some Cascade_legacy_runner.worker_top_p;
-      top_k = Some Cascade_legacy_runner.worker_top_k;
+      temperature = Some Llm_provider.Constants.Inference_profile.worker_default.temperature;
+      top_p = Some Cascade_worker_defaults.top_p;
+      top_k = Some Cascade_worker_defaults.top_k;
       (* min_p is effectively disabled (0.0) and some cloud providers
          reject the field itself even when the value is a no-op. *)
       min_p = None;
@@ -472,7 +472,7 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
     | None ->
         { Agent_sdk.Guardrails.tool_filter =
             Agent_sdk.Guardrails.AllowList (oas_tool_names tools);
-          max_tool_calls_per_turn = Some Cascade_legacy_runner.worker_max_tool_calls_per_turn;
+          max_tool_calls_per_turn = Some Cascade_worker_defaults.max_tool_calls_per_turn;
         }
   in
   let options =

--- a/lib/server/server_openai_compat.ml
+++ b/lib/server/server_openai_compat.ml
@@ -138,9 +138,9 @@ let handle_chat_completions ~config ~sw ~clock (body : string)
       | None -> `List []
     in
     let max_tokens = Safe_ops.json_int
-      ~default:Cascade_legacy_runner.default_max_tokens "max_tokens" json in
+      ~default:Llm_provider.Constants.Inference_profile.agent_default.max_tokens "max_tokens" json in
     let temperature = Safe_ops.json_float
-      ~default:Cascade_legacy_runner.default_temperature "temperature" json in
+      ~default:Llm_provider.Constants.Inference_profile.agent_default.temperature "temperature" json in
     if model = "" then
       (`Bad_request,
        error_response ~status:"invalid_request_error"

--- a/lib/server/server_openai_compat.mli
+++ b/lib/server/server_openai_compat.mli
@@ -70,8 +70,8 @@ val handle_chat_completions :
 
     | Field | Default |
     |---|---|
-    | [max_tokens] | {!Cascade_legacy_runner.default_max_tokens} |
-    | [temperature] | {!Cascade_legacy_runner.default_temperature} |
+    | [max_tokens] | {!Llm_provider.Constants.Inference_profile.agent_default}[.max_tokens] |
+    | [temperature] | {!Llm_provider.Constants.Inference_profile.agent_default}[.temperature] |
     | [system] (concat of all system messages) | empty string |
 
     {2 Response shape}

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -160,7 +160,7 @@ let probe_chat_completion_compatible
           ~kind:Llm_provider.Provider_config.OpenAI_compat
           ~model_id ~base_url:endpoint.url
           ~request_path:Masc_network_defaults.openai_chat_completions_path
-          ~max_tokens:1 ~temperature:Cascade_legacy_runner.deterministic_temperature ()
+          ~max_tokens:1 ~temperature:Llm_provider.Constants.Inference_profile.deterministic.temperature ()
       in
       let messages : Oas_types.message list =
         [

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -120,7 +120,7 @@ let verify (req : verification_request) : (verdict, string) result =
         ~masc_tools:[ report_verdict_schema ]
         ~dispatch
         ~max_turns:1
-        ~temperature:Cascade_legacy_runner.deterministic_temperature
+        ~temperature:Llm_provider.Constants.Inference_profile.deterministic.temperature
         ~max_tokens:200
         ~approval:Approval_callbacks.auto_approve
         ()

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -56,9 +56,9 @@ let agent_config_of_worker_meta
   ; system_prompt = Some system_prompt
   ; max_tokens = Some max_tokens
   ; max_turns = effective_max_turns meta
-  ; temperature = Some Cascade_legacy_runner.worker_temperature
-  ; top_p = Some Cascade_legacy_runner.worker_top_p
-  ; top_k = Some Cascade_legacy_runner.worker_top_k
+  ; temperature = Some Llm_provider.Constants.Inference_profile.worker_default.temperature
+  ; top_p = Some Cascade_worker_defaults.top_p
+  ; top_k = Some Cascade_worker_defaults.top_k
   ; (* min_p intentionally omitted: the constant is 0.0 (no-op) and some
        cloud providers (Groq, GLM) reject the field itself with
        "Invalid request: property 'min_p' is unsupported". OAS capability
@@ -159,7 +159,7 @@ let build_agent
     | None ->
       { Agent_sdk.Guardrails.tool_filter = AllowList tool_names
       ; max_tool_calls_per_turn =
-          Some Cascade_legacy_runner.worker_max_tool_calls_per_turn
+          Some Cascade_worker_defaults.max_tool_calls_per_turn
       }
   in
   let builder =
@@ -171,12 +171,12 @@ let build_agent
     | Some n -> Agent_sdk.Builder.with_max_tokens n b
     | None -> b)
     |> Agent_sdk.Builder.with_max_turns config.max_turns
-    |> Agent_sdk.Builder.with_temperature Cascade_legacy_runner.worker_temperature
-    |> Agent_sdk.Builder.with_top_p Cascade_legacy_runner.worker_top_p
-    |> Agent_sdk.Builder.with_top_k Cascade_legacy_runner.worker_top_k
+    |> Agent_sdk.Builder.with_temperature Llm_provider.Constants.Inference_profile.worker_default.temperature
+    |> Agent_sdk.Builder.with_top_p Cascade_worker_defaults.top_p
+    |> Agent_sdk.Builder.with_top_k Cascade_worker_defaults.top_k
     (* with_min_p intentionally omitted — see agent_config_of_worker_meta
-       above for the reason. The worker_min_p constant is 0.0 (a no-op)
-       and cloud providers (Groq, GLM) reject the field itself. *)
+       above for the reason. min_p of 0.0 is a no-op and cloud providers
+       (Groq, GLM) reject the field itself. *)
     |> Agent_sdk.Builder.with_enable_thinking
          (Option.value ~default:false meta.thinking_enabled)
     |> Agent_sdk.Builder.with_tool_choice Agent_sdk.Types.Auto


### PR DESCRIPTION
## Summary

`Cascade_legacy_runner` 박멸 작전 PR-A — **worker tuning constants를 실제 SSOT로 lift**.

분석 결과 `lib/cascade/cascade_legacy_runner.ml`은 "legacy"라는 이름과 달리 *deprecated annotation도, RFC supersession도 없는* 활성 모듈입니다. 한 PR로 일괄 박멸 불가하므로 3 PR 시퀀스로 분할:

- **PR-A (본 PR)**: worker tuning constants 7개 lift + dead `worker_min_p` 박멸 (12 caller)
- **PR-B**: observation/metrics builders → 신규 `Cascade_audit` 모듈
- **PR-C**: actor lifecycle + audit JSONL persistence → `Cascade_audit`. 모듈 *최종 삭제*.

본 PR이 머지되면 PR-B/C가 손대는 surface가 줄어듭니다.

## 박멸 대상 — 8 상수, 12 caller, 26 call site

### 상수의 *실제* SSOT 식별

`Cascade_legacy_runner`의 상수 중 4개는 *이미 `Llm_provider.Constants.Inference_profile`(OAS SSOT)로 delegate*하는 thin wrapper입니다. legacy 모듈에서 *재정의*하는 것 자체가 *문서적 거짓말* — caller가 OAS SSOT를 *직접* 참조하게 만드는 게 정확.

| 상수 | 이전 위치 | *실제* SSOT |
|---|---|---|
| `default_temperature` | wrapper | `Llm_provider.Constants.Inference_profile.agent_default.temperature` |
| `default_max_tokens` | wrapper | `Llm_provider.Constants.Inference_profile.agent_default.max_tokens` |
| `deterministic_temperature` | wrapper | `Llm_provider.Constants.Inference_profile.deterministic.temperature` |
| `worker_temperature` | wrapper | `Llm_provider.Constants.Inference_profile.worker_default.temperature` |
| `worker_top_p` | legacy 정의 (`0.95`) | 신규 `Cascade_worker_defaults.top_p` |
| `worker_top_k` | legacy 정의 (`20`) | 신규 `Cascade_worker_defaults.top_k` |
| `worker_max_tool_calls_per_turn` | legacy 정의 (`12`) | 신규 `Cascade_worker_defaults.max_tool_calls_per_turn` |
| `worker_min_p` | legacy 정의 (`0.0`), **caller 0** | **삭제** |

`worker_top_p / top_k / max_tool_calls_per_turn`는 *masc-mcp 자체의 SSOT*가 필요합니다 — legacy의 주석 자체가 *"provider-specific sampling params (not in OAS profiles)"*라고 명시. OAS `Inference_profile` 레코드 밖이 정확한 위치라서 작은 local 모듈로 분리.

`worker_min_p`는 caller 0 + 주석에 *"a no-op (0.0), cloud providers reject the field itself"*라고 명시된 *dead-by-design constant*. 직접 박멸.

## 변경 내역

| 파일 | 변경 |
|---|---|
| `lib/cascade/cascade_worker_defaults.ml(i)` (신규, 18 LoC) | 3 상수의 SSOT. docstring으로 *왜 OAS Inference_profile 밖인지* 명시 |
| `lib/cascade/cascade_legacy_runner.ml` | line 10-35의 상수 정의 + comment block 26 LoC 삭제 |
| `lib/cascade/cascade_legacy_runner.mli` | "Worker tuning constants" docstring 절 + 7 `val` 선언 제거. *존재하지 않는* `include Cascade_legacy_runner` aspirational comment 정정 (drift 청산). `worker_min_p` internal-helper reference 제거 |
| `lib/server/server_openai_compat.ml(i)` | 2 call site + mli docstring `{!Cascade_legacy_runner.X}` reference 4 정정 |
| `lib/keeper/keeper_turn_driver.ml` | 2 call site (`?default = ...`) |
| `lib/keeper/keeper_turn_driver_wrappers.ml` | 6 call site (3 wrapper 쌍) |
| `lib/cascade/cascade_agent_context.ml` | 2 call site |
| `lib/verifier_oas.ml`, `lib/tool_local_runtime_verify.ml`, `lib/anti_rationalization.ml` | 각 1 call site (`deterministic_temperature`) |
| `lib/worker_oas.ml` | 7 call site (worker_temp 2, top_p 2, top_k 2, max_tool_calls 1) + line 178 `worker_min_p` stale reference 정정 |
| `lib/local/worker_container.ml` | 4 call site (worker_temp / top_p / top_k / max_tool_calls 각 1) |

총: **2 신규 파일, 12 modified, +34/-82 net -48 LoC**.

## 의도와 안티-패턴 self-check (CLAUDE.md §워크어라운드 거부 기준)

| 시그니처 | 본 PR 해당 여부 |
|---|---|
| Telemetry-as-fix | ❌ |
| String/substring 분류기 보강 | ❌ |
| N-of-M 패치 | ❌ — G1 그룹의 12 caller / 26 call site *전수* 마이그레이션. 그룹 단위로 닫힘 |
| Catch-all 추가 | ❌ |
| Cap/cooldown/dedup/repair symptom 억제 | ❌ — 순수 SSOT 정렬 |
| Test backdoor 노출 | ❌ |
| **Transitional repair** (alias로 양쪽 공존) | ❌ — caller는 단일 path만 사용. legacy에서 정의 완전 삭제 |
| 같은 typo/off-by-one N번 fix | ❌ |

본 PR 자체는 *분할*되어 진행되지만, 분할은 *그룹 단위*입니다 (constants 그룹 100% 닫힘). 다음 PR-B/C는 *별 그룹*. 사용자 manifest의 *N-of-M 패치 거부*는 *동일 그룹 내 일부만 처리*를 거부하는 것이고, 본 PR은 G1 그룹을 *전수* 닫음.

## "Legacy" 이름의 함정 (Insight)

`Cascade_legacy_runner` 모듈명에 "legacy"가 들어있어 *deprecated*로 오해되기 쉽지만, docstring은:

> "@since God file decomposition — extracted from oas_worker.ml"

*god-file 분해* 산물이지 *deprecated*가 아닙니다. 분해 시점에 더 좋은 이름을 안 붙인 것이 *misnaming 기술 부채*입니다. 

또한 `.mli` 자체에 *"Sister facade {!Oas_worker} does [include Cascade_legacy_runner]"*라고 적혀있지만 `rg 'include Cascade_legacy_runner' lib/` 결과 *0건* — *aspirational comment / 문서 drift*입니다. 본 PR이 이것도 정정.

## Self-review

- 목표: G1 그룹(상수)을 SSOT로 정렬. legacy 모듈에서 *상수 surface 100% 박멸*.
- 변경 파일: 2 신규 + 12 modified.
- 로컬 검증:
  - `dune build --root . @check` ✅ EXIT=0
  - `rg 'Cascade_legacy_runner\.(default_temperature|default_max_tokens|deterministic_temperature|worker_temperature|worker_top_p|worker_top_k|worker_min_p|worker_max_tool_calls_per_turn)' lib/ bin/ test/` → **0 매치** (전수 이동 확인)
- 미검증:
  - test_oas_worker / test_keeper_unified는 PR-A에서 *함수적 변경 0* (단순 import 경로 이동)이라 회귀 없을 것으로 추정. CI 통과로 확정.

## 후속 (PR-B, PR-C)

- **PR-B (다음)**: observation/metrics builders (`cascade_metrics_for_candidates`, `cascade_observation_with_metrics`, `record_attempt_terminal`, `record_fallback_event`, `cascade_observation_to_json`) → 신규 `Cascade_audit` 모듈. keeper_turn_driver (~16 site) + dashboard_cascade. test_oas_worker A 카테고리 12 test 삭제, test_keeper_unified B 카테고리 3 test rewrite.
- **PR-C (마지막)**: actor lifecycle (`start_actor_if_needed`) + audit JSONL persistence (`record_cascade`) → `Cascade_audit`. `lib/cascade/cascade_legacy_runner.ml(i)` *완전 삭제*.

## RFC 매칭

- `pr-rfc-check.sh` 강제 영역 밖.
- 본 PR은 *기능적 변경 0* (상수 location lift only). RFC 불요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
