### PR TITLE
fix(tool_task): unterminated comment from "_*)" closer

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -903,7 +903,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
          downstream task-handoff schema then had to recover via
          sibling synthesis or substring scanning. There is no
          in-repo reader of that [notes] blob — pr_url consumers
-         (keeper_tool_call_log, keeper_hooks_oas, audit_keeper_*)
+         (keeper_tool_call_log, keeper_hooks_oas, audit_keeper_...)
          already read pr_url as a typed field elsewhere — so the
          legacy blob is dead-on-write.
 


### PR DESCRIPTION
## Summary

PR #15836 hotfix. cleanup 주석 안의 \`audit_keeper_*)\` 가 *OCaml block-comment terminator* (\`*)\`) 로 lex 되어 line 906 에서 주석이 *예기치 않게 닫힘*. 그 다음 prose 가 OCaml source 로 parse 되며 다음과 같은 빌드 실패 유발:

\`\`\`
File \"lib/tool_task.ml\", line 907, characters 29-31:
Error: Syntax error
\`\`\`

(col 29-31 은 line 907 의 \`as\` 키워드 위치.)

### Root cause

OCaml 의 block-comment 는 *nested* + *lexer-active* — 주석 내부의 \`*)\` 는 무조건 종결자로 인식. PR #15836 cleanup 본문 line 905-906:

\`\`\`ocaml
         in-repo reader of that [notes] blob — pr_url consumers
         (keeper_tool_call_log, keeper_hooks_oas, audit_keeper_*)
                                                              ^^
                                                             여기서 주석 종결
\`\`\`

### Fix

\`audit_keeper_*\` glob suffix 를 \`audit_keeper_...\` ellipsis 로 치환. parenthesized list 안에 더 이상 \`*)\` 시퀀스가 없도록.

### 검증

- 1-char 변경, 의미 보존.
- \`rg '_\\\\*\\\\)' lib/\` → 0 결과 (다른 곳에 같은 안티-패턴 없음).
- 다른 \`*)\` 패턴 (`prometheus_test_*)`, etc.) 동일 위험 회피 위해 향후 RFC 또는 lint 후보.

## Test plan

- [ ] CI green (master build 회복)
- [ ] \`dune build\` 통과

## Related

- PR #15836 (MERGED) — legacy pr_url blob cleanup. 주석 도입 출처.
- 회귀 가드로 lint 추가 후보: \`rg '_\\\\*\\\\)' lib/\` pre-commit check (별도 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>