### PR TITLE
fix(tool_input_validation): qualify Tool_dispatch.Reject (main build broken)

### DIFF
--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -161,7 +161,7 @@ let validation_schema_of_json ~name json_schema : Agent_sdk.Types.tool_schema =
   { name; description = ""; parameters = Tool_bridge.params_of_json_schema json_schema }
 ;;
 
-let validation_exception_action ~name exn =
+let validation_exception_action ~name exn : Tool_dispatch.pre_hook_action =
   let error_text = Printexc.to_string exn in
   let message =
     Printf.sprintf
@@ -171,7 +171,7 @@ let validation_exception_action ~name exn =
   in
   emit_validation_telemetry ~tool:name ~result:"fail" ~reason:"validation_exception";
   Log.error "%s" message;
-  Reject
+  Tool_dispatch.Reject
     { Tool_result.success = false
     ; data =
         `Assoc


### PR DESCRIPTION
## Summary

main currently fails to build:

\`\`\`
File \"lib/tool_input_validation.ml\", line 174, characters 2-8:
174 |   Reject
        ^^^^^^
Error: Unbound constructor Reject
\`\`\`

Introduced by #15833 \`fix keeper board post validation boundary\`.

## Root cause

\`validation_exception_action\` (new helper added in #15833) uses the unqualified
constructor \`Reject\`, but the function has no return-type annotation, so the
compiler cannot disambiguate it. The file does not \`open Tool_dispatch\`, and
the same file imports \`Agent_sdk.Tool_middleware.Reject\` (line 222) which has
a different shape, so an unqualified \`Reject\` is genuinely ambiguous /
unbound in this scope.

The sibling function \`validation_action\` (line 189) already carries
\`: Tool_dispatch.pre_hook_action\` and resolves its own \`Pass | Proceed | Reject\`
arms correctly. This PR mirrors that pattern on the new helper.

## Why annotation, not \`open\`

Adding \`open Tool_dispatch\` at the file top would *increase* ambiguity, not
reduce it: \`Tool_middleware.Reject\` and \`Tool_dispatch.Reject\` live in the
same file body (lines 222 and 225) and \`open\` would silently route lookups to
whichever opens last. Type annotation is the targeted root fix.

## What changed

| File | Diff | Notes |
|---|---|---|
| \`lib/tool_input_validation.ml\` | +2/-2 | (1) Return-type annotation on \`validation_exception_action\`. (2) Qualify \`Tool_dispatch.Reject\` |

No other file touched. No behavior change.

## RFC

Not a mandatory subsystem (\`tool_input_validation\` is not credential/identity/operator/sandbox/hooks/workflow). \`pr-rfc-check.sh\` exit 0.

## Test plan

- [x] \`dune build --root . @check\` — PASS (was failing on main before this fix)
- [x] No test added — surgical typing fix; behavior preserved

## Workaround rejection self-check (7/7)

1. telemetry-as-fix? **NO**, structural typing
2. string classifier? **NO**
3. N-of-M? **NO**, single site
4. catch-all added? **NO**
5. cap/cooldown/dedup/repair? **NO**
6. test backdoor? **NO**
7. repeat typo? **NO**

## Related

Companion fix in another PR: \`lib/tool_task.ml:906\` comment block contains
\`audit_keeper_*)\` which prematurely closes the OCaml \`(* ... *)\`. Separate
PR per maintainer preference.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)