### PR TITLE
fix(keeper): sharpen generic required tool gate

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -364,6 +364,32 @@ let has_turn_affordance expected turn_affordances =
 
 let has_task_claim_affordance = has_turn_affordance Task_claim
 
+let generic_required_actionable_tool_names ~(has_current_task : bool)
+    ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
+  let is_stay_silent name =
+    String.equal
+      (Keeper_tool_disclosure.canonical_tool_name name)
+      "keeper_stay_silent"
+  in
+  let can_recommend_tool name =
+    List.mem name allowed_tool_names
+    && Keeper_tool_disclosure.tool_name_can_satisfy_required_contract name
+    && not (is_stay_silent name)
+    && ((not has_current_task)
+        || not (Keeper_tool_disclosure.is_claim_context_tool_name name))
+  in
+  let preferred =
+    preferred_tool_names_for_turn_affordances turn_affordances
+    |> List.filter can_recommend_tool
+    |> Keeper_types.dedupe_keep_order
+  in
+  match preferred with
+  | _ :: _ -> preferred
+  | [] ->
+    allowed_tool_names
+    |> List.filter can_recommend_tool
+    |> Keeper_types.dedupe_keep_order
+
 let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
   let is_stay_silent name =
@@ -383,6 +409,17 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
          && ((not has_current_task)
              || not (Keeper_tool_disclosure.is_claim_context_tool_name name)))
       allowed_tool_names
+  in
+  let actionable_tool_names =
+    generic_required_actionable_tool_names ~has_current_task ~turn_affordances
+      ~allowed_tool_names
+  in
+  let exact_tool_choice_if_public = function
+    | [ name ] ->
+      (match Keeper_tool_alias.route name with
+       | Some _ -> Some (Agent_sdk.Types.Tool name)
+       | None -> None)
+    | [] | _ :: _ :: _ -> None
   in
   if has_turn_affordance Board_curation turn_affordances
      && List.exists
@@ -448,38 +485,20 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
        tools cannot advance an already-owned task, so forcing [Any] here
        creates an impossible contract and burns a retry. *)
     Agent_sdk.Types.Auto
-  else
-    (* Active task in progress: keep the strict gate.  The keeper is
-    expected to make progress via some tool call (board update,
-    task_update, task_done, etc.). *)
-    Agent_sdk.Types.Any
+  else (
+    match exact_tool_choice_if_public actionable_tool_names with
+    | Some tool_choice -> tool_choice
+    | None ->
+      (* Active task in progress: keep the strict gate.  The keeper is
+         expected to make progress via some tool call (board update,
+         task_update, task_done, etc.). *)
+      Agent_sdk.Types.Any)
 
 let generic_required_tool_candidate_names ~(has_current_task : bool)
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
-  let is_stay_silent name =
-    String.equal
-      (Keeper_tool_disclosure.canonical_tool_name name)
-      "keeper_stay_silent"
-  in
-  let can_recommend_tool name =
-    List.mem name allowed_tool_names
-    && Keeper_tool_disclosure.tool_name_can_satisfy_required_contract name
-    && not (is_stay_silent name)
-    && ((not has_current_task)
-        || not (Keeper_tool_disclosure.is_claim_context_tool_name name))
-  in
   let actionable_tools =
-    preferred_tool_names_for_turn_affordances turn_affordances
-    |> List.filter can_recommend_tool
-    |> Keeper_types.dedupe_keep_order
-  in
-  let actionable_tools =
-    match actionable_tools with
-    | [] ->
-        allowed_tool_names
-        |> List.filter can_recommend_tool
-        |> Keeper_types.dedupe_keep_order
-    | tools -> tools
+    generic_required_actionable_tool_names ~has_current_task ~turn_affordances
+      ~allowed_tool_names
   in
   actionable_tools
 ;;

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -191,6 +191,15 @@ val has_turn_affordance : turn_affordance -> string list -> bool
 
 val has_task_claim_affordance : string list -> bool
 
+(** Ordered executable candidates for generic required-tool gates.
+    Claim/context tools are excluded when the keeper already owns active work,
+    and passive status/read tools are never recommended. *)
+val generic_required_actionable_tool_names :
+  has_current_task:bool ->
+  turn_affordances:string list ->
+  allowed_tool_names:string list ->
+  string list
+
 (** Pick the model-facing [tool_choice] when the gate fires. *)
 val preferred_tool_choice_for_required_turn :
   has_current_task:bool ->

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -11377,11 +11377,48 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
        ()
    with
    | Agent_sdk.Types.Any -> ()
+  | other ->
+    fail
+      (Printf.sprintf
+         "expected Any for active-task keeper (must make progress), got %s"
+         (Agent_sdk.Types.show_tool_choice other)));
+  (match
+     choose
+       ~has_current_task:true
+       ~turn_affordances:[ "inspect_worktree_delta" ]
+       ~allowed_tool_names:[ "Bash"; "keeper_tasks_list" ]
+       ()
+   with
+   | Agent_sdk.Types.Tool "Bash" -> ()
    | other ->
      fail
        (Printf.sprintf
-          "expected Any for active-task keeper (must make progress), got %s"
+          "expected exact public Bash for single public generic required candidate, got \
+           %s"
           (Agent_sdk.Types.show_tool_choice other)));
+  (match
+     choose
+       ~has_current_task:true
+       ~turn_affordances:[ "inspect_worktree_delta" ]
+       ~allowed_tool_names:[ "keeper_pr_create"; "keeper_tasks_list" ]
+       ()
+   with
+   | Agent_sdk.Types.Any -> ()
+   | other ->
+     fail
+       (Printf.sprintf
+          "expected Any for single internal generic required candidate to avoid MCP \
+           raw-name mismatches, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
+  check
+    (list string)
+    "generic required candidates exclude claim after owned task"
+    [ "keeper_board_post" ]
+    (Surface.generic_required_actionable_tool_names
+       ~has_current_task:true
+       ~turn_affordances:[ "work_discovery" ]
+       ~allowed_tool_names:[ "keeper_task_claim"; "keeper_board_post";
+                             "keeper_tasks_list" ]);
   (* Claim/stay_silent cannot advance an already-owned task, so forcing Any
      here would create an impossible required-tool contract. *)
   match


### PR DESCRIPTION
## Summary
- factor generic required-gate actionable tool candidate selection into one helper
- reuse that candidate list for generic guidance and tool_choice decisions
- only force exact Tool(...) for a single public provider-facing alias, preserving Any for internal keeper/MCP names to avoid raw-name mismatch regressions
- add regression coverage for public Bash exact choice, internal keeper_pr_create staying Any, and owned-task claim exclusion

## Validation
- opam exec -- ocamlformat --check lib/keeper/keeper_agent_tool_surface.ml lib/keeper/keeper_agent_tool_surface.mli test/test_keeper_unified.ml
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build test/test_keeper_unified.exe attempted twice, blocked by shared /tmp/me-dune-local.lock held by .worktrees/cascade-max-tokens-validator/scripts/dune-local.sh build --root .

Refs #15542