### PR TITLE
docs(rfc-0004): record Phase A0.1 completion in RFC body

### DIFF
--- a/docs/rfc/RFC-0004-shared-contract-ocaml-ts.md
+++ b/docs/rfc/RFC-0004-shared-contract-ocaml-ts.md
@@ -27,6 +27,23 @@
 
 - Research synthesis: `~/me/knowledge/research/2026-05-17-dashboard-sse-ssot-state.md`
 - Quick win PR (workaround, 본 RFC 대체 트랙 X — 사용자 crash 차단 only): `fix/ide-context-lens-null-guard` 의 `ide-context-lens.ts:304/325` null guard
+
+### Phase A0.1 completion (2026-05-17)
+
+Track A 의 Phase A0.1 sprint (atd-based typed SSE envelope) 완료. 5 sub-PR + 1 closeout doc, 약 1.5 시간:
+
+| Sub-PR | PR # | 결과 |
+|---|---|---|
+| PR-1 | #15807 | atd schema + leaf lib + agent_started constructor + byte-equal PoC |
+| PR-2 | #15811 | AgentStarted cascade arm typed-routed |
+| PR-3 | #15824 | 5 simple-record arms (tool/turn) |
+| PR-4 | #15830 | 8 simple-record arms (handoff/context/replacement/slot) |
+| PR-3b | #15835 | agent_completed/agent_failed — variable-shape addendum 패턴 |
+| Closeout doc | #15841 | implementation plan Status → Completed |
+
+상세 sub-PR 매핑 + scope 조정 사유 (PR-3 split, `wrap_event` 보존) + verification harness (19 byte-equal tests) 는 `docs/rfc/0004-phase-a0-1-implementation-plan.md` §Completion summary 참조.
+
+**Track A 다음 단계 (Phase A0.2+)**: TypeScript decoder generation (atdgen-ts 또는 manual zod from `.atd`), golden-file replay 시스템, CLI emitter. `lib/sse_event/sse_event.atd` 를 SSOT 로 소비.
 - Track A 의 sprint 분할은 §Phase A0 끝 부분의 **A0.1~A0.5 표** 참조 (resume update 로 추가)
 
 ## Design Anchors


### PR DESCRIPTION
## Summary

RFC-0004 본문 (`RFC-0004-shared-contract-ocaml-ts.md`) 의 Status Note 에 Phase A0.1 completion sub-section 추가. Implementation plan (#15841) 의 Status 변경에 이어 RFC body 도 동기화합니다.

## What changes

- `docs/rfc/RFC-0004-shared-contract-ocaml-ts.md` 의 Resume note (2026-05-17) 뒤에 새 sub-section 추가
- 5 sub-PR + 1 closeout doc 매핑 표
- 상세 (sub-PR 매핑, scope 조정 사유, byte-equal harness shape) 는 implementation plan §Completion summary 로 cross-ref
- Phase A0.2+ 다음 단계 명시

## Why now

Implementation plan (#15841) 의 Status 만 Completed 로 갱신하면 RFC body 의 Resume note 가 *진행 중* 처럼 읽힘. 다음 세션이 RFC body 만 읽을 경우 sprint 종료를 인지 못 함. body + plan 둘 다 동기화 필요.

## Why body stays Draft

Track A (post-A0.1 work) 와 Track B (gRPC GetStatus thin slice) 가 아직 진행 중. Phase A0.1 sub-phase 만 Completed 표시. 전체 RFC Status 는 Draft 유지.

## Test plan

- Docs-only. 코드/테스트 영향 없음.

## Workaround Rejection Bar self-check

N/A — docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)