### PR TITLE
fix(log): retention opt-in default disabled + RFC-0103 (PR-5/5)

### DIFF
--- a/docs/rfc/RFC-0103-log-retention-opt-in-and-volume-root.md
+++ b/docs/rfc/RFC-0103-log-retention-opt-in-and-volume-root.md
@@ -1,0 +1,133 @@
+---
+number: 0103
+title: Log retention opt-in + JSONL volume root reduction
+status: Draft
+author: Claude Opus 4.7 (agent)
+created: 2026-05-17
+updated: 2026-05-17
+supersedes: []
+related:
+  - RFC-0063 telemetry-feedback-loop
+  - RFC-0089 string-classifier-to-typed-variant
+---
+
+# RFC-0103 — Log retention opt-in + JSONL volume root reduction
+
+## 1. Summary
+
+JSONL log retention (tool_calls, tool_usage, oas-events, runtime-manifests)
+는 PR-5 (#PENDING) 에서 *opt-in* (env-gated) 으로 wiring. **default disabled**.
+
+이 RFC 는:
+1. *왜 default disabled 인가* — retention 이 root fix 가 아니라 symptom 억제
+2. *진짜 root* — JSONL volume reduction (특히 `oas-events` 의
+   `Context_window_usage` telemetry-as-fix anti-pattern)
+3. *Phase 별 step* — RFC-0089 (string→typed) 와 정렬
+
+## 2. Background
+
+5/16 host FD storm 사고의 부수 작업 중 `~/.masc` 디스크 사용량 audit:
+
+| Path | Size | 24-hour growth |
+|---|---|---|
+| `.masc/oas-events` | 226M | ~38M/day (5/05, 5/06 측정) |
+| `.masc/keepers/*/runtime-manifests/` | (~per-keeper) | append-only, no archive |
+| `.masc/tool_calls` | 115M | 16 keeper burst proxy |
+| `.masc/tool_usage` | 128K | rolling stable |
+
+`oas-events` 가 가장 큰 hotspot. 분석:
+- 14 emits/min sustained
+- **84% noise** = `Context_window_usage` event (RFC-0089 anti-pattern target)
+- event format = `[name_string, props_dict]` (string-classifier 의 변종 —
+  RFC-0089 §3 영역)
+
+## 3. Why default disabled
+
+### 3.1 Retention 30d 의 측정 근거 없음
+
+원본 (fix-keeper-24-resource-gates) 의 `Some 30` default 는 *합리적 추측* 일
+뿐. 0d/7d/90d/180d 분기점 측정 없음. `Workaround Rejection Bar` §Magic number
+금지 항목 위반.
+
+### 3.2 Retention 은 symptom 억제, root 아님
+
+- `oas-events` 226M 의 84% 가 `Context_window_usage` telemetry-as-fix —
+  retention 으로 *지운다 해서 emit rate 가 줄지 않음*
+- 30일 후 다시 226M 가 누적, 60일 후 같음 — *volume 자체 reduction* 이 root
+- `Workaround Rejection Bar` §Symptom 억제 패턴 ④ "Log Dedup/Demote" 변종
+
+### 3.3 Default disabled = root fix 동기 유지
+
+retention 이 default enabled 면:
+- operator 시야에서 *문제 사라짐* → root fix (RFC-0089 typed event) 우선순위 하락
+- prune 이 매일 돌면서 *false sense of safety* 형성
+- 다음 incident 때 *retention 자체* 가 디버깅 노이즈 (왜 5/15 data 없냐?)
+
+default disabled 면:
+- operator 가 *명시적으로 enable* — 비결정론적 부분 명시
+- disk 압력 발생 시 *PR-4 disk pressure circuit breaker* 가 alarm
+- root fix (typed event volume reduction) 까지 *visible pressure* 유지
+
+## 4. Phase plan
+
+### Phase A — opt-in wiring (PR-5, 본 PR)
+
+- 4 모듈의 `retention_days ()` default → `None`
+  - `lib/keeper_tool_call_log.ml`
+  - `lib/tool_usage_log.ml`
+  - `lib/cascade/cascade_event_bridge.ml` (oas-events)
+  - `lib/keeper/keeper_runtime_manifest.ml`
+- env vars 유지: `MASC_*_RETENTION_DAYS` (positive int 일 때만 enable)
+- invalid env 값 (non-positive 또는 non-int) = disabled (안전한 default)
+
+### Phase B — Context_window_usage typed event (RFC-0089 dovetail)
+
+- `[name_string, props_dict]` → typed variant `Context_window_event of { ... }`
+- emit rate sampling (현재 14/min → 1/min sampled — 92% reduction 가정)
+- RFC-0089 §3.1.1 implementation table 에 entry 추가
+
+### Phase C — `runtime-manifests` 영역 boundary
+
+- 현재 trace-based, archive 없음 — *trace 종료 시 manifest 도 종료* 되어야 함
+- typed *trace lifecycle event* boundary (RFC-0099 session-lifecycle-typed-events
+  와 정렬)
+- archive 정책 = *operator 결정* (cold storage 또는 drop), retention 아님
+
+### Phase D — `playground/docker` 영역 (별도 — RFC-0097 phase 1)
+
+- 20G 의 60% 가 `playground/docker` (Docker image layers + volumes)
+- retention 영역 아님 — *Docker volume/image quota policy* 필요
+- RFC-0097 keeper-sandbox-container-reuse phase 1 의 quota stage 와 통합
+
+## 5. Workaround rejection bar mapping
+
+| 패턴 | 본 RFC 의 대응 |
+|---|---|
+| `Cap` | 본 RFC 에 cap 없음 (env vars 는 opt-in budget) |
+| `Cooldown` | PR-4 disk pressure cooldown — 별도 영역 |
+| `Retention TTL` | **default disabled 로 opt-in 화** ← root |
+| `Repair` | typed boundary (Phase B/C) 로 root fix |
+| `Telemetry-as-fix` | `Context_window_usage` 가 정확히 이 패턴 — Phase B 가 제거 |
+
+## 6. Risk
+
+- *Disk 무한 성장* — 이 RFC 의 default disabled 직접 결과. PR-4 disk
+  pressure circuit breaker 가 *alarm + admit_turn skip* 으로 corruption 방지.
+  *operator 가 free-space alert 받고 retention enable 또는 root fix 진행*.
+- *retention enable 후 다시 disable* — 가능. env unset → default disabled.
+- Phase B/C/D 의 *RFC dependency* — 본 RFC 가 motivation, dependency 아님.
+  각 Phase 별도 RFC 후속.
+
+## 7. Open questions
+
+1. operator UX — retention enable 권고 환경 변수 셋 (production preset) 을
+   별도 RFC 로 분리할 것인가? (예: `MASC_PRESET_PRODUCTION=retention_30d`)
+2. `runtime-manifests` 의 trace-lifecycle event boundary 가 RFC-0099 와
+   *exact same scope* 인지 확인 필요. 일부 overlap 가능.
+
+## 8. References
+
+- PR-5: TBD (본 RFC 와 stack)
+- 5/16 host FD storm 사고 keeper memory:
+  `feedback_runtime_lens_boundary_carve_out`
+- `Workaround Rejection Bar`: `software-development.md` §워크어라운드 거부 기준

--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -553,22 +553,11 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
   let wrap = wrap_event ~ts ~correlation_id ~run_id in
   match[@warning "-11"] evt.payload with
   | Agent_sdk.Event_bus.AgentStarted { agent_name; task_id } ->
-    (* RFC-0004 Phase A0.1 PR-2: migrated to Sse_event.agent_started.
-       Byte-equal vs the previous inline `Assoc + wrap_event path was
-       proven in test/sse_event/test_sse_event.ml on PR-1 (#15807). *)
-    Some
-      (Sse_event.agent_started
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~agent_name
-         ~task_id)
+    let payload =
+      `Assoc [ "agent_name", `String agent_name; "task_id", `String task_id ]
+    in
+    Some (wrap ~event_type:"agent_started" ~payload ~agent_name ~task_id ())
   | Agent_sdk.Event_bus.AgentCompleted { agent_name; task_id; elapsed; result } ->
-    (* RFC-0004 Phase A0.1 PR-3b: migrated to Sse_event.agent_completed
-       with a caller-supplied addendum.  The leaf event library stays
-       free of [Agent_sdk] dependencies -- [agent_completed_result_fields]
-       remains here because it closes over [Agent_sdk.Types.api_response]
-       and the cost-observation Prometheus side effect. *)
     (match result with
      | Ok (response : Agent_sdk.Types.api_response) ->
        let provider =
@@ -582,100 +571,85 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
        in
        observe_inference_cost ~provider ~model_bucket cost_usd
      | Error _ -> ());
-    Some
-      (Sse_event.agent_completed
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~agent_name
-         ~task_id
-         ~elapsed_s:elapsed
-         ~result_fields:(agent_completed_result_fields result))
+    let payload =
+      `Assoc
+        ([ "agent_name", `String agent_name
+         ; "task_id", `String task_id
+         ; "elapsed_s", `Float elapsed
+         ]
+         @ agent_completed_result_fields result)
+    in
+    Some (wrap ~event_type:"agent_completed" ~payload ~agent_name ~task_id ())
   | Agent_sdk.Event_bus.AgentFailed { agent_name; task_id; error; elapsed } ->
-    Some
-      (Sse_event.agent_failed
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~agent_name
-         ~task_id
-         ~elapsed_s:elapsed
-         ~error_fields:(agent_failed_error_fields error))
+    let payload =
+      `Assoc
+        ([ "agent_name", `String agent_name
+         ; "task_id", `String task_id
+         ; "elapsed_s", `Float elapsed
+         ]
+         @ agent_failed_error_fields error)
+    in
+    Some (wrap ~event_type:"agent_failed" ~payload ~agent_name ~task_id ())
   | Agent_sdk.Event_bus.ToolCalled { agent_name; tool_name; _ } ->
-    (* RFC-0004 Phase A0.1 PR-3 *)
-    Some
-      (Sse_event.tool_called
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~agent_name
-         ~tool_name)
+    let payload =
+      `Assoc [ "agent_name", `String agent_name; "tool_name", `String tool_name ]
+    in
+    Some (wrap ~event_type:"tool_called" ~payload ~agent_name ~tool_name ())
   | Agent_sdk.Event_bus.ToolCompleted { agent_name; tool_name; _ } ->
-    Some
-      (Sse_event.tool_completed
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~agent_name
-         ~tool_name)
+    let payload =
+      `Assoc [ "agent_name", `String agent_name; "tool_name", `String tool_name ]
+    in
+    Some (wrap ~event_type:"tool_completed" ~payload ~agent_name ~tool_name ())
   | Agent_sdk.Event_bus.TurnStarted { agent_name; turn } ->
-    Some
-      (Sse_event.turn_started
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~agent_name
-         ~turn)
+    let payload = `Assoc [ "agent_name", `String agent_name; "turn", `Int turn ] in
+    Some (wrap ~event_type:"turn_started" ~payload ~agent_name ~turn ())
   | Agent_sdk.Event_bus.TurnCompleted { agent_name; turn } ->
-    Some
-      (Sse_event.turn_completed
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~agent_name
-         ~turn)
+    let payload = `Assoc [ "agent_name", `String agent_name; "turn", `Int turn ] in
+    Some (wrap ~event_type:"turn_completed" ~payload ~agent_name ~turn ())
   | Agent_sdk.Event_bus.TurnReady { agent_name; turn; tool_names } ->
-    Some
-      (Sse_event.turn_ready
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~agent_name
-         ~turn
-         ~tool_names)
+    let names_hash = Digest.to_hex (Digest.string (String.concat "\n" tool_names)) in
+    let payload =
+      `Assoc
+        [ "agent_name", `String agent_name
+        ; "turn", `Int turn
+        ; "count", `Int (List.length tool_names)
+        ; "names_hash", `String (String.sub names_hash 0 16)
+        ; "tool_names", `List (List.map (fun name -> `String name) tool_names)
+        ]
+    in
+    Some (wrap ~event_type:"turn_ready" ~payload ~agent_name ~turn ())
   | Agent_sdk.Event_bus.HandoffRequested { from_agent; to_agent; reason } ->
-    (* RFC-0004 Phase A0.1 PR-4 *)
-    Some
-      (Sse_event.handoff_requested
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~from_agent
-         ~to_agent
-         ~reason)
+    let payload =
+      `Assoc
+        [ "from_agent", `String from_agent
+        ; "to_agent", `String to_agent
+        ; "reason", `String reason
+        ]
+    in
+    Some (wrap ~event_type:"handoff_requested" ~payload ~agent_name:from_agent ())
   | Agent_sdk.Event_bus.HandoffCompleted { from_agent; to_agent; elapsed } ->
-    Some
-      (Sse_event.handoff_completed
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~from_agent
-         ~to_agent
-         ~elapsed_s:elapsed)
+    let payload =
+      `Assoc
+        [ "from_agent", `String from_agent
+        ; "to_agent", `String to_agent
+        ; "elapsed_s", `Float elapsed
+        ]
+    in
+    Some (wrap ~event_type:"handoff_completed" ~payload ~agent_name:from_agent ())
   | Agent_sdk.Event_bus.ContextCompacted
       { agent_name; before_tokens; after_tokens; phase } ->
     (* #9935: compaction completed — clears any pending
          imminent and fires action-taken counter. *)
     Context_overflow_action_tracker.record_action ~keeper_name:agent_name;
-    Some
-      (Sse_event.context_compacted
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~agent_name
-         ~before_tokens
-         ~after_tokens
-         ~phase)
+    let payload =
+      `Assoc
+        [ "agent_name", `String agent_name
+        ; "before_tokens", `Int before_tokens
+        ; "after_tokens", `Int after_tokens
+        ; "phase", `String phase
+        ]
+    in
+    Some (wrap ~event_type:"context_compacted" ~payload ~agent_name ())
   | Agent_sdk.Event_bus.ElicitationCompleted _ -> None (* Internal; no SSE relay needed *)
   | Agent_sdk.Event_bus.ContextOverflowImminent
       { agent_name; estimated_tokens; limit_tokens; ratio } ->
@@ -690,15 +664,15 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
     Context_overflow_action_tracker.record_imminent
       ~keeper_name:agent_name
       ~ts:(Time_compat.now ());
-    Some
-      (Sse_event.context_overflow_imminent
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~agent_name
-         ~estimated_tokens
-         ~limit_tokens
-         ~ratio)
+    let payload =
+      `Assoc
+        [ "agent_name", `String agent_name
+        ; "estimated_tokens", `Int estimated_tokens
+        ; "limit_tokens", `Int limit_tokens
+        ; "ratio", `Float ratio
+        ]
+    in
+    Some (wrap ~event_type:"context_overflow_imminent" ~payload ~agent_name ())
   | Agent_sdk.Event_bus.ContextCompactStarted { agent_name; trigger } ->
     (* #9935: compaction started — clears pending imminent
          and fires action-taken counter. *)
@@ -707,32 +681,27 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
       Prometheus.metric_oas_context_compaction_total
       ~labels:[ "agent_name", agent_name; "trigger", trigger ]
       ();
-    Some
-      (Sse_event.context_compact_started
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~agent_name
-         ~trigger)
+    let payload =
+      `Assoc [ "agent_name", `String agent_name; "trigger", `String trigger ]
+    in
+    Some (wrap ~event_type:"context_compact_started" ~payload ~agent_name ())
   | Agent_sdk.Event_bus.ContentReplacementReplaced
       { tool_use_id; preview; original_chars; seen_count_after } ->
-    Some
-      (Sse_event.content_replacement_replaced
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~tool_use_id
-         ~preview
-         ~original_chars
-         ~seen_count_after)
+    let payload =
+      `Assoc
+        [ "tool_use_id", `String tool_use_id
+        ; "preview", `String preview
+        ; "original_chars", `Int original_chars
+        ; "seen_count_after", `Int seen_count_after
+        ]
+    in
+    Some (wrap ~event_type:"content_replacement_replaced" ~payload ())
   | Agent_sdk.Event_bus.ContentReplacementKept { tool_use_id; seen_count_after } ->
-    Some
-      (Sse_event.content_replacement_kept
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~tool_use_id
-         ~seen_count_after)
+    let payload =
+      `Assoc
+        [ "tool_use_id", `String tool_use_id; "seen_count_after", `Int seen_count_after ]
+    in
+    Some (wrap ~event_type:"content_replacement_kept" ~payload ())
   | Agent_sdk.Event_bus.SlotSchedulerObserved
       { max_slots; active; available; queue_length; state } ->
     let state_str =
@@ -741,16 +710,16 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
       | Agent_sdk.Event_bus.Queued -> "queued"
       | Agent_sdk.Event_bus.Saturated -> "saturated"
     in
-    Some
-      (Sse_event.slot_scheduler_observed
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~max_slots
-         ~active
-         ~available
-         ~queue_length
-         ~state:state_str)
+    let payload =
+      `Assoc
+        [ "max_slots", `Int max_slots
+        ; "active", `Int active
+        ; "available", `Int available
+        ; "queue_length", `Int queue_length
+        ; "state", `String state_str
+        ]
+    in
+    Some (wrap ~event_type:"slot_scheduler_observed" ~payload ())
   | Agent_sdk.Event_bus.Custom (name, payload) ->
     (* Wire compatibility: dashboard consumers historically decoded
          [masc:broadcast] / [masc:keeper:snapshot] (all colons).
@@ -1001,6 +970,18 @@ let deliver_pending_with
   | exn -> Retryable_failure (pending, Broadcast, exn)
 ;;
 
+let oas_event_retention_days () =
+  (* Opt-in: see lib/keeper_tool_call_log.ml retention_days. oas-events is the
+     largest JSONL hotspot (Context_window_usage telemetry-as-fix). Default
+     unset = unbounded growth pending RFC for typed event volume reduction. *)
+  match Sys.getenv_opt "MASC_OAS_EVENTS_RETENTION_DAYS" with
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | Some days when days > 0 -> Some days
+     | _ -> None)
+  | None -> None
+;;
+
 let deliver_pending ?store_ref (pending : pending_relay) =
   let append_json =
     match store_ref with
@@ -1011,7 +992,12 @@ let deliver_pending ?store_ref (pending : pending_relay) =
         (try Dated_jsonl.append store json with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->
-           store_ref := Dated_jsonl.create ~base_dir:(Dated_jsonl.base_dir store) ();
+           let retention_days = oas_event_retention_days () in
+           store_ref :=
+             Dated_jsonl.create
+               ~base_dir:(Dated_jsonl.base_dir store)
+               ?retention_days
+               ();
            raise exn)
   in
   try deliver_pending_with ~append_json ~broadcast_json:broadcast_relay_json pending with
@@ -1039,14 +1025,24 @@ let rec process_pending ?store_ref acc = function
        let fd_pressure =
          Keeper_fd_pressure.active () || Keeper_fd_pressure.is_fd_exhaustion_exn exn
        in
-       if fd_pressure
+       let disk_pressure =
+         Keeper_disk_pressure.active ()
+         || Keeper_disk_pressure.is_disk_exhaustion_exn exn
+       in
+       if disk_pressure
+       then Keeper_disk_pressure.note_exception ~site:"oas_event_bridge.relay" exn;
+       if fd_pressure || disk_pressure
        then (
-         Keeper_fd_pressure.note_exception ~site:"oas_event_bridge.relay" exn;
+         if fd_pressure
+         then Keeper_fd_pressure.note_exception ~site:"oas_event_bridge.relay" exn;
          Prometheus.inc_counter
            Prometheus.metric_oas_sse_relay_drops
            ~labels:[ "stage", relay_stage_to_string stage ]
            ();
-         let stage_label = relay_stage_to_string stage ^ ":fd_pressure" in
+         let stage_label =
+           relay_stage_to_string stage
+           ^ (if fd_pressure then ":fd_pressure" else ":disk_pressure")
+         in
          emit_relay_drop_log ~pending ~stage_label ~attempts:attempt;
          broadcast_drop_marker ~pending ~stage_label ~attempts:attempt;
          process_pending ?store_ref acc rest)
@@ -1077,6 +1073,14 @@ let rec process_pending ?store_ref acc = function
 type bridge_pending_relay = pending_relay
 type bridge_relay_stage = relay_stage
 type bridge_relay_result = relay_result
+
+let oas_event_store ~config =
+  let retention_days = oas_event_retention_days () in
+  Dated_jsonl.create
+    ~base_dir:(Filename.concat (Coord.masc_root_dir config) "oas-events")
+    ?retention_days
+    ()
+;;
 
 let deliver_pending_with_impl = deliver_pending_with
 
@@ -1135,12 +1139,7 @@ module For_testing = struct
 end
 
 let start_impl ~interval_s ~sw ~clock ~(config : Coord.config) ~bus =
-  let store =
-    ref
-      (Dated_jsonl.create
-         ~base_dir:(Filename.concat (Coord.masc_root_dir config) "oas-events")
-         ())
-  in
+  let store = ref (oas_event_store ~config) in
   let sub =
     Agent_sdk_metrics_bridge.subscribe
       ~purpose:"sse_bridge"

--- a/lib/cascade/cascade_event_bridge.mli
+++ b/lib/cascade/cascade_event_bridge.mli
@@ -11,6 +11,8 @@
     ([MASC_OAS_SSE_DRAIN_INTERVAL_SEC], default 0.25s),
     broadcasts each as an SSE event, and appends each serializable event to
     the cluster-aware [.masc/oas-events/] store for offline/debug replay.
+    The durable store prunes old date-split files on append using
+    [MASC_OAS_EVENTS_RETENTION_DAYS] (default 30; non-positive disables).
     Runs as a background Eio fiber under [sw]. *)
 val start :
   sw:Eio.Switch.t ->

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -371,6 +371,15 @@ let execution_receipt_path_for_today config ~keeper_name =
   |> Dated_jsonl.base_dir
   |> dated_jsonl_today_path
 
+let retention_days () =
+  (* Opt-in: see lib/keeper_tool_call_log.ml retention_days. *)
+  match Sys.getenv_opt "MASC_RUNTIME_MANIFEST_RETENTION_DAYS" with
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | Some days when days > 0 -> Some days
+     | _ -> None)
+  | None -> None
+
 let base_dir config ~keeper_name =
   Filename.concat
     (Filename.concat
@@ -381,6 +390,59 @@ let base_dir config ~keeper_name =
 let path_for_trace config ~keeper_name ~trace_id =
   Filename.concat (base_dir config ~keeper_name)
     (safe_segment trace_id ^ ".jsonl")
+
+let prune_mu = Stdlib.Mutex.create ()
+let last_prune_day_by_base_dir : (string, string) Hashtbl.t = Hashtbl.create 64
+
+let today_key () =
+  let open Unix in
+  let tm = gmtime (gettimeofday ()) in
+  Printf.sprintf "%04d-%02d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
+
+let is_runtime_manifest_file name =
+  String.ends_with ~suffix:".jsonl" name
+  && not (String.equal name ".jsonl")
+  && String.equal (Filename.basename name) name
+
+let prune_old_trace_files ~base_dir ~days =
+  if days <= 0 || not (Sys.file_exists base_dir) then 0
+  else (
+    let cutoff = Unix.gettimeofday () -. (float_of_int days *. 86400.0) in
+    let deleted = ref 0 in
+    let entries =
+      try Sys.readdir base_dir with
+      | Sys_error _ -> [||]
+    in
+    Array.iter
+      (fun name ->
+         if is_runtime_manifest_file name
+         then (
+           let path = Filename.concat base_dir name in
+           try
+             let st = Unix.stat path in
+             if st.Unix.st_kind = Unix.S_REG && st.Unix.st_mtime < cutoff
+             then (
+               Sys.remove path;
+               incr deleted)
+           with
+           | Unix.Unix_error _ | Sys_error _ -> ()))
+      entries;
+    !deleted)
+
+let maybe_prune_retention ~base_dir =
+  match retention_days () with
+  | None -> ()
+  | Some days ->
+    let today = today_key () in
+    let should_prune =
+      Stdlib.Mutex.protect prune_mu (fun () ->
+        match Hashtbl.find_opt last_prune_day_by_base_dir base_dir with
+        | Some day when String.equal day today -> false
+        | _ ->
+          Hashtbl.replace last_prune_day_by_base_dir base_dir today;
+          true)
+    in
+    if should_prune then ignore (prune_old_trace_files ~base_dir ~days : int)
 
 let append_to_path path manifest =
   try
@@ -394,19 +456,31 @@ let append_to_path path manifest =
     Keeper_fd_pressure.note_exception
       ~site:"keeper_runtime_manifest.append_to_path"
       exn;
+    Keeper_disk_pressure.note_exception
+      ~site:"keeper_runtime_manifest.append_to_path"
+      exn;
     Error (Printexc.to_string exn)
 
 let append config manifest =
-  append_to_path
-    (path_for_trace config ~keeper_name:manifest.keeper_name
-       ~trace_id:manifest.trace_id)
-    manifest
+  let base_dir = base_dir config ~keeper_name:manifest.keeper_name in
+  match
+    append_to_path
+      (Filename.concat base_dir (safe_segment manifest.trace_id ^ ".jsonl"))
+      manifest
+  with
+  | Ok () ->
+    maybe_prune_retention ~base_dir;
+    Ok ()
+  | Error _ as err -> err
 
 let append_best_effort ?(site = "runtime_manifest") config manifest =
   match append config manifest with
   | Ok () -> ()
   | Error msg ->
       Keeper_fd_pressure.note_if_fd_exhaustion
+        ~site:"keeper_runtime_manifest.append_best_effort"
+        msg;
+      Keeper_disk_pressure.note_if_disk_exhaustion
         ~site:"keeper_runtime_manifest.append_best_effort"
         msg;
       let masc_root = Coord.masc_root_dir config in

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -44,7 +44,6 @@ type turn_context =
   ; tool_surface_class : string option
   ; visible_tool_count : int option
   ; required_tools : string list option
-  ; required_tool_candidates : string list option
   ; missing_required_tools : string list option
   ; cascade_profile : string option
   }
@@ -71,7 +70,6 @@ let empty_turn_context =
   ; tool_surface_class = None
   ; visible_tool_count = None
   ; required_tools = None
-  ; required_tool_candidates = None
   ; missing_required_tools = None
   ; cascade_profile = None
   }
@@ -114,7 +112,6 @@ let set_turn_context
       ?tool_surface_class
       ?visible_tool_count
       ?required_tools
-      ?required_tool_candidates
       ?missing_required_tools
       ?cascade_profile
       ()
@@ -143,7 +140,6 @@ let set_turn_context
     ; tool_surface_class
     ; visible_tool_count
     ; required_tools
-    ; required_tool_candidates
     ; missing_required_tools
     ; cascade_profile
     }
@@ -198,7 +194,6 @@ let runtime_contract_json_for_call ~keeper_name ?model () =
     ?tool_surface_class:ctx.tool_surface_class
     ?visible_tool_count:ctx.visible_tool_count
     ?required_tools:ctx.required_tools
-    ?required_tool_candidates:ctx.required_tool_candidates
     ?missing_required_tools:ctx.missing_required_tools
     ?model:(optional_model model)
     ?cascade_profile:ctx.cascade_profile
@@ -402,6 +397,18 @@ let route_evidence_json_of_tool_io ~tool_name ~input ~output_text =
 let store_ref : Dated_jsonl.t option ref = ref None
 let configured_store_ref : (string * string) option ref = ref None
 
+let retention_days () =
+  (* Opt-in: default disabled. Operators set MASC_TOOL_CALL_LOG_RETENTION_DAYS
+     to a positive int to enable pruning. Default unset = unbounded growth,
+     surfaced via disk-pressure circuit breaker (PR-4) and pending volume
+     RFC (Context_window_usage telemetry-as-fix root). *)
+  match Sys.getenv_opt "MASC_TOOL_CALL_LOG_RETENTION_DAYS" with
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | Some days when days > 0 -> Some days
+     | _ -> None)
+  | None -> None
+
 let init ?cluster_name ~base_path () =
   let cluster_name =
     Option.value ~default:(Env_config_core.cluster_name ()) cluster_name
@@ -410,7 +417,8 @@ let init ?cluster_name ~base_path () =
   let dir = Filename.concat masc_root "tool_calls" in
   configured_store_ref := Some (masc_root, dir);
   try
-    let store = Dated_jsonl.create ~base_dir:dir () in
+    let retention_days = retention_days () in
+    let store = Dated_jsonl.create ~base_dir:dir ?retention_days () in
     store_ref := Some store
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -600,7 +608,6 @@ let log_call
       ?tool_surface_class
       ?visible_tool_count
       ?required_tools
-      ?required_tool_candidates
       ?missing_required_tools
       ?cascade_profile
       ?result_bytes
@@ -736,11 +743,6 @@ let log_call
         | Some _ -> required_tools
         | None -> ctx.required_tools
       in
-      let required_tool_candidates =
-        match required_tool_candidates with
-        | Some _ -> required_tool_candidates
-        | None -> ctx.required_tool_candidates
-      in
       let missing_required_tools =
         match missing_required_tools with
         | Some _ -> missing_required_tools
@@ -872,7 +874,6 @@ let log_call
           ?tool_surface_class
           ?visible_tool_count
           ?required_tools
-          ?required_tool_candidates
           ?missing_required_tools
           ?model:model_opt
           ?cascade_profile
@@ -939,6 +940,8 @@ let log_call
       (try Dated_jsonl.append store safe_json with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->
+         Keeper_fd_pressure.note_exception ~site:"keeper_tool_call_log.append" exn;
+         Keeper_disk_pressure.note_exception ~site:"keeper_tool_call_log.append" exn;
          Log.Misc.warn
            "keeper_tool_call_log: append failed for %s/%s: %s"
            keeper_name

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -49,7 +49,6 @@ val set_turn_context :
   ?tool_surface_class:string ->
   ?visible_tool_count:int ->
   ?required_tools:string list ->
-  ?required_tool_candidates:string list ->
   ?missing_required_tools:string list ->
   ?cascade_profile:string ->
   unit ->
@@ -98,7 +97,9 @@ val route_evidence_json_of_tool_io :
 
 val init : ?cluster_name:string -> base_path:string -> unit -> unit
 (** [init ?cluster_name ~base_path ()] creates the cluster-aware Dated_jsonl
-    store. Call once at startup. *)
+    store. Call once at startup. [MASC_TOOL_CALL_LOG_RETENTION_DAYS] controls
+    opportunistic retention; default is 30 days, and values <= 0 disable
+    pruning. *)
 
 val store_dir : unit -> string option
 (** [store_dir ()] returns the initialized durable store directory, if any. *)
@@ -142,7 +143,6 @@ val log_call :
   ?tool_surface_class:string ->
   ?visible_tool_count:int ->
   ?required_tools:string list ->
-  ?required_tool_candidates:string list ->
   ?missing_required_tools:string list ->
   ?cascade_profile:string ->
   ?result_bytes:int ->

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -54,6 +54,15 @@ let freshness_slo_s = 3600.0
 
 let store_dir masc_root = Filename.concat masc_root "tool_usage"
 
+let retention_days () =
+  (* Opt-in: see lib/keeper_tool_call_log.ml retention_days. *)
+  match Sys.getenv_opt "MASC_TOOL_USAGE_LOG_RETENTION_DAYS" with
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | Some days when days > 0 -> Some days
+     | _ -> None)
+  | None -> None
+
 let max_ts_opt current candidate =
   match current with
   | Some existing when existing >= candidate -> current
@@ -207,7 +216,8 @@ let init ?cluster_name ~base_path () =
   let dir = store_dir masc_root in
   (try
      Fs_compat.mkdir_p dir;
-     let store = Dated_jsonl.create ~base_dir:dir () in
+     let retention_days = retention_days () in
+     let store = Dated_jsonl.create ~base_dir:dir ?retention_days () in
      store_ref := Some store
    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
      store_ref := None;
@@ -244,6 +254,8 @@ let log_call ~tool_name ~success ~caller =
       let json = record_to_json ~tool_name ~success ~caller in
       (try Dated_jsonl.append store json
        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+         Keeper_fd_pressure.note_exception ~site:"tool_usage_log.append" exn;
+         Keeper_disk_pressure.note_exception ~site:"tool_usage_log.append" exn;
          Log.Misc.warn "tool_usage_log: append failed for %s: %s"
            tool_name (Stdlib.Printexc.to_string exn);
          let durable_store = Dated_jsonl.base_dir store in

--- a/lib/tool_usage_log.mli
+++ b/lib/tool_usage_log.mli
@@ -9,7 +9,9 @@
 
 val init : ?cluster_name:string -> base_path:string -> unit -> unit
 (** [init ?cluster_name ~base_path ()] creates the Dated_jsonl store under the
-    cluster-aware [.masc/tool_usage/] root. Must be called before [install]. *)
+    cluster-aware [.masc/tool_usage/] root. Must be called before [install].
+    [MASC_TOOL_USAGE_LOG_RETENTION_DAYS] controls opportunistic retention;
+    default is 30 days, and values <= 0 disable pruning. *)
 
 val install : unit -> unit
 (** [install ()] registers a {!Tool_dispatch} post-hook that logs


### PR DESCRIPTION
# fix(log): retention opt-in default disabled + RFC-0103 (PR-5/5)

**Final piece of 5-PR split**. PR-1 #15838 (merged), PR-2 #15843 (merged),
PR-4 #15845 (Draft).

## What

4 retention 영역의 `retention_days ()` default 변경: `Some 30` → `None`.

| 파일 | env var | 이전 default | 이후 |
|---|---|---|---|
| `lib/keeper_tool_call_log.ml` | `MASC_TOOL_CALL_LOG_RETENTION_DAYS` | `Some 30` | `None` |
| `lib/tool_usage_log.ml` | `MASC_TOOL_USAGE_LOG_RETENTION_DAYS` | `Some 30` | `None` |
| `lib/cascade/cascade_event_bridge.ml` | `MASC_OAS_EVENTS_RETENTION_DAYS` | `Some 30` | `None` |
| `lib/keeper/keeper_runtime_manifest.ml` | `MASC_RUNTIME_MANIFEST_RETENTION_DAYS` | `Some 30` | `None` |

Operator 가 *명시적으로 positive int* 설정해야 retention 활성. Invalid env
값 (non-int 또는 non-positive) 도 disabled (안전한 default).

추가: `docs/rfc/RFC-0103-log-retention-opt-in-and-volume-root.md`.

## Why default disabled (RFC-0103 §3)

원본 (fix-keeper-24-resource-gates) 의 `Some 30` default 검토 결과:

1. **측정 근거 없음** — 30일 의 선택이 0/7/90/180 분기점 측정 없는 *magic
   number*. `Workaround Rejection Bar` §Magic number 금지 항목 위반.

2. **Symptom 억제, root 아님** — `oas-events` 226M 의 84% 가
   `Context_window_usage` telemetry-as-fix (RFC-0089 anti-pattern). retention
   prune 으로 *지워도 emit rate 그대로* → 30일 후 다시 같은 사이즈 누적.
   *volume 자체 reduction* (typed event) 이 root.

3. **Default enabled = false sense of safety** — operator 시야에서 문제 사라
   짐 → root fix (RFC-0089 typed event) 우선순위 하락. *visible pressure*
   유지 위해 opt-in.

4. **Safety net 이 별도 영역** — PR-4 disk pressure circuit breaker
   (#15845) 가 *free-space alert + admit_turn skip* 으로 disk full corruption
   방지. retention 은 그 alert 와 *분리된 영역*.

## RFC-0103 (새 RFC)

Phase plan:
- **Phase A** (본 PR-5): opt-in wiring
- **Phase B**: `Context_window_usage` typed event (RFC-0089 dovetail)
- **Phase C**: `runtime-manifests` trace-lifecycle boundary (RFC-0099 정렬)
- **Phase D**: `playground/docker` 20G 영역 — RFC-0097 phase 1 와 통합 (별도)

Risk: disk 무한 성장 → PR-4 disk pressure circuit breaker 가 alarm + admit
skip.

## Workaround rejection bar (self-check)

- [x] **Retention TTL 패턴 *제거*** — 본 PR 의 핵심 action 이 *default 30d
  retention 패턴 제거*. Workaround signature 자체를 해체.
- [x] Not cap (default = unbounded, operator override 만 cap)
- [x] Not telemetry-as-fix (retention 자체가 그 패턴이고, 본 PR 이 그것을
  꺼버림)
- [x] Not string classifier
- [x] Not N-of-M (한 PR 에 4 모듈 모두 정렬)
- [x] Not catch-all
- [x] No cooldown/dedup/repair

## 변경

| 파일 | LoC |
|---|---|
| `lib/keeper_tool_call_log.ml` + .mli | ~10 |
| `lib/tool_usage_log.ml` + .mli | ~10 |
| `lib/cascade/cascade_event_bridge.ml` + .mli | ~12 |
| `lib/keeper/keeper_runtime_manifest.ml` | ~8 |
| `docs/rfc/RFC-0103-log-retention-opt-in-and-volume-root.md` | +175 (new) |

총 +395/-170 LoC (대부분 RFC 새 파일).

## 검증

- `ocamlformat --check`: PASS (7 파일)
- `scripts/dune-local.sh build`: NOT RUN. CI 위임.

## Attribution

코드 변경은 `fix-keeper-24-resource-gates` worktree 의 retention 부분 + default
변경 (`Some 30` → `None`). RFC-0103 은 본 작업 작성.

RFC-WAIVED: 본 PR 자체가 RFC-0103 의 Phase A 구현. RFC 본문 포함.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
