### PR TITLE
[codex] Purge legacy path defaults

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -71,20 +71,7 @@ let mcp_protocol_version_default =
 
 let default_base_path = Server_mcp_transport_http.default_base_path
 
-let implicit_base_path_resolution_source () =
-  match (Host_config.from_env ()).home with
-  | Some home ->
-      let normalized_home =
-        Env_config.normalize_masc_base_path_input home
-      in
-      let normalized_default =
-        Env_config.normalize_masc_base_path_input (default_base_path ())
-      in
-      if String.equal normalized_home normalized_default then
-        "implicit_home"
-      else
-        "implicit_repo_root"
-  | None -> "implicit_repo_root"
+let implicit_base_path_resolution_source () = "implicit_base_path"
 
 let is_valid_protocol_version =
   Server_mcp_transport_http.is_valid_protocol_version
@@ -649,9 +636,7 @@ let run_cmd host port base_path =
     Env_config.strip_path_trailing_slashes (String.trim base_path)
   in
   guard_self_repo_base_path normalized_base_path;
-  if String.equal resolution_source "implicit_home"
-     || String.equal resolution_source "implicit_repo_root"
-  then begin
+  if String.equal resolution_source "implicit_base_path" then begin
     Printf.eprintf
       "[FATAL] Server refused to start with an implicit base path.\n\
        Resolution source: %s\n\

--- a/lib/host_config/host_config.mli
+++ b/lib/host_config/host_config.mli
@@ -49,8 +49,8 @@ type t =
             Maps to [<tmp>] from [host ()] and [<base_path>/.masc/runtime/agent]
             from [resolve]. *)
   ; sandbox_workspace_root : string
-        (** Fleet sandbox root.  Default [<HOME>/me] when [HOME] is
-            set, else [<tmp>/masc-fleet]. *)
+        (** Fleet sandbox root.  Defaults through [MASC_BASE_PATH], then
+            [ME_ROOT], then [<tmp>/masc-fleet] from [host ()]. *)
   ; test_mode : test_mode_kind
         (** Typed test-mode boundary. *)
   ; log_dir : string

--- a/lib/server/server_mcp_transport_http_session.mli
+++ b/lib/server/server_mcp_transport_http_session.mli
@@ -176,16 +176,13 @@ val get_protocol_version_for_session :
 
 val default_base_path : unit -> string
 (** Resolves the launcher-guard-aware default base path.
-    When the [MASC_BASE_PATH] env var is set, returns
-    [Sys.getcwd ()] (operator opted into project-local
-    artifacts).  Otherwise prefers [HOME] (then [Sys.getcwd ()]
-    fallback) and routes through
+    The server default starts from [Sys.getcwd ()] and routes through
     {!Coord_utils_backend_setup.resolve_server_default_base_path}.
 
-    The HOME-preference is intentional: a direct binary launch
-    from a checkout with its own [.masc] must NOT silently
-    inherit a stale parent [MASC_BASE_PATH].  Pinning at the
-    contract seam. *)
+    This intentionally avoids deriving the base path from [HOME]: a direct
+    binary launch from a checkout should keep artifacts under the visible
+    launch root unless the operator passes [--base-path] or [MASC_BASE_PATH].
+*)
 
 val query_param :
   Httpun.Request.t -> string -> string option

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -171,7 +171,7 @@ let validation_exception_action ~name exn =
   in
   emit_validation_telemetry ~tool:name ~result:"fail" ~reason:"validation_exception";
   Log.error "%s" message;
-  Reject
+  Tool_dispatch.Reject
     { Tool_result.success = false
     ; data =
         `Assoc
@@ -209,20 +209,20 @@ let validation_action ?schema ~name ~args () : Tool_dispatch.pre_hook_action =
       let result = pass_result reason in
       emit_validation_telemetry ~tool:name ~result ~reason;
       Log.debug "tool_input_validation normalized args for %s" name;
-      Proceed prepared_args
+      Tool_dispatch.Proceed prepared_args
     | Agent_sdk.Tool_middleware.Pass ->
       let reason = pass_reason ~schema ~args ~prepared_args in
       let result = pass_result reason in
       emit_validation_telemetry ~tool:name ~result ~reason;
-      Pass
+      Tool_dispatch.Pass
     | Agent_sdk.Tool_middleware.Proceed coerced ->
       emit_validation_telemetry ~tool:name ~result:"pass" ~reason:"coerced";
       Log.debug "tool_input_validation coerced args for %s" name;
-      Proceed coerced
+      Tool_dispatch.Proceed coerced
     | Agent_sdk.Tool_middleware.Reject { message; _ } ->
       emit_validation_telemetry ~tool:name ~result:"fail" ~reason:"invalid_args";
       Log.info "tool_input_validation rejected %s: %s" name message;
-      Reject
+      Tool_dispatch.Reject
         { Tool_result.success = false
         ; data =
             `Assoc
@@ -242,9 +242,9 @@ let validation_action ?schema ~name ~args () : Tool_dispatch.pre_hook_action =
 
 let validate_args ?schema ~name ~args () =
   match validation_action ?schema ~name ~args () with
-  | Pass -> Ok args
-  | Proceed coerced -> Ok coerced
-  | Reject result -> Error result
+  | Tool_dispatch.Pass -> Ok args
+  | Tool_dispatch.Proceed coerced -> Ok coerced
+  | Tool_dispatch.Reject result -> Error result
 ;;
 
 let register_pre_hook () =

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import shlex
 import sys
@@ -92,6 +93,12 @@ PR_CREATED_NUMBER_RE = re.compile(
 GH_PR_CREATE_RE = re.compile(r"\bgh\s+pr\s+create\b", re.IGNORECASE)
 GH_HOSTS_USER_RE = re.compile(r"^\s*user:\s*['\"]?([^'\"\s#]+)")
 ERROR_STATUSES = {"error", "failed", "failure", "timeout", "cancelled", "canceled"}
+
+
+def default_base_path() -> str:
+    return (
+        os.environ.get("MASC_BASE_PATH") or os.environ.get("ME_ROOT") or str(Path.cwd())
+    )
 
 
 @dataclass
@@ -1731,14 +1738,17 @@ def scan_persistent_work_evidence(
         for row in rows:
             links = row_links(row)
             if row_event(row) == "checkpoint_saved":
-                checkpoint_path = path_from_link(base_path, links.get("checkpoint_path"))
+                checkpoint_path = path_from_link(
+                    base_path, links.get("checkpoint_path")
+                )
                 if checkpoint_path is not None and checkpoint_path.is_file():
                     checkpoint_refs.add(
-                        "checkpoint:"
-                        f"{ref}:{path_label(base_path, checkpoint_path)}"
+                        f"checkpoint:{ref}:{path_label(base_path, checkpoint_path)}"
                     )
             if row_event(row) == "turn_finished":
-                tool_log_path = path_from_link(base_path, links.get("tool_call_log_path"))
+                tool_log_path = path_from_link(
+                    base_path, links.get("tool_call_log_path")
+                )
                 if (
                     tool_log_path is not None
                     and tool_log_path.is_file()
@@ -1751,8 +1761,7 @@ def scan_persistent_work_evidence(
                     )
                 ):
                     tool_call_log_refs.add(
-                        "tool_call_log:"
-                        f"{ref}:{path_label(base_path, tool_log_path)}"
+                        f"tool_call_log:{ref}:{path_label(base_path, tool_log_path)}"
                     )
 
     return PersistentWorkEvidence(
@@ -2032,14 +2041,10 @@ def audit_keeper(
         docker_pr_lifecycle_evidence=sorted(docker_pr_lifecycle_evidence),
         pr_evidence_refs=sorted(pr_creation_evidence.refs),
         pr_evidence_sources=sorted(pr_creation_evidence.sources),
-        provider_turn_evidence_refs=sorted(
-            persistent_work_evidence.provider_turn_refs
-        ),
+        provider_turn_evidence_refs=sorted(persistent_work_evidence.provider_turn_refs),
         checkpoint_evidence_refs=sorted(persistent_work_evidence.checkpoint_refs),
         history_evidence_refs=sorted(persistent_work_evidence.history_refs),
-        tool_call_log_evidence_refs=sorted(
-            persistent_work_evidence.tool_call_log_refs
-        ),
+        tool_call_log_evidence_refs=sorted(persistent_work_evidence.tool_call_log_refs),
         failures=failures,
         warnings=warnings,
     )
@@ -2070,7 +2075,8 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
             require_product_evidence=args.require_product_evidence,
             require_design_evidence=args.require_design_evidence,
             require_pr_surface_evidence=(
-                args.require_pr_surface_evidence or args.require_persistent_work_evidence
+                args.require_pr_surface_evidence
+                or args.require_persistent_work_evidence
             ),
             require_pr_review_evidence=args.require_pr_review_evidence,
             require_pr_create_evidence=(
@@ -2101,7 +2107,8 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
                 or args.require_persistent_work_evidence
             ),
             require_checkpoint_evidence=(
-                args.require_checkpoint_evidence or args.require_persistent_work_evidence
+                args.require_checkpoint_evidence
+                or args.require_persistent_work_evidence
             ),
             require_history_evidence=(
                 args.require_history_evidence or args.require_persistent_work_evidence
@@ -2290,8 +2297,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--base-path",
-        default=str(Path.home() / "me"),
-        help="MASC base path containing .masc (default: ~/me)",
+        default=default_base_path(),
+        help="MASC base path containing .masc (default: MASC_BASE_PATH, then ME_ROOT, then cwd)",
     )
     parser.add_argument(
         "--expected-keepers",

--- a/scripts/impact-analyzer.py
+++ b/scripts/impact-analyzer.py
@@ -12,8 +12,11 @@ Output:
     Markdown formatted PR comment with risk score and affected BDDs.
 
 Environment:
-    NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD (from ~/.zshenv via sb)
+    NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD (from shell env via sb)
+    Optional: MASC_SB_SCRIPT or SB_SCRIPT, otherwise ME_ROOT/scripts/sb,
+    MASC_WORKSPACE_ROOT/scripts/sb, or sb from PATH.
 """
+
 import os
 import sys
 import json
@@ -21,9 +24,18 @@ import subprocess
 from typing import List, Dict, Any
 from pathlib import Path
 
-# Neo4j client configuration
-NEO4J_CLIENT = Path.home() / "me" / "lib" / "ocaml" / "neo4j_client" / "_build" / "default" / "bin" / "main.exe"
-SB_SCRIPT = Path.home() / "me" / "scripts" / "sb"
+
+def resolve_sb_script() -> str:
+    explicit = os.environ.get("MASC_SB_SCRIPT") or os.environ.get("SB_SCRIPT")
+    if explicit:
+        return explicit
+    root = os.environ.get("ME_ROOT") or os.environ.get("MASC_WORKSPACE_ROOT")
+    if root:
+        return str(Path(root) / "scripts" / "sb")
+    return "sb"
+
+
+SB_SCRIPT = resolve_sb_script()
 
 # Risk weights by category
 CATEGORY_WEIGHTS = {
@@ -107,12 +119,14 @@ ORDER BY b.category DESC"""
     bdds = []
     for row in rows:
         if len(row) >= 4:
-            bdds.append({
-                "id": row[0],
-                "title": row[1] if row[1] else "",
-                "category": row[2] if row[2] else "UNKNOWN",
-                "quality": row[3] if row[3] else 0,
-            })
+            bdds.append(
+                {
+                    "id": row[0],
+                    "title": row[1] if row[1] else "",
+                    "category": row[2] if row[2] else "UNKNOWN",
+                    "quality": row[3] if row[3] else 0,
+                }
+            )
     return bdds
 
 
@@ -164,9 +178,7 @@ def get_risk_level(risk_score: int) -> tuple[str, str]:
 
 
 def format_pr_comment(
-    changed_files: List[str],
-    bdds: List[Dict[str, Any]],
-    risk: Dict[str, Any]
+    changed_files: List[str], bdds: List[Dict[str, Any]], risk: Dict[str, Any]
 ) -> str:
     """
     Format analysis as PR comment in markdown.
@@ -197,7 +209,7 @@ def format_pr_comment(
         for cat, count in sorted(
             risk["category_breakdown"].items(),
             key=lambda x: CATEGORY_WEIGHTS.get(x[0], 0),
-            reverse=True
+            reverse=True,
         ):
             emoji = ""
             if cat == "CRITICAL":
@@ -230,8 +242,7 @@ def format_pr_comment(
 
         quality = bdd.get("quality", 0)
         lines.append(
-            f"- {emoji} **{bdd['id']}**: {bdd['title']} "
-            f"({cat}, quality: {quality})"
+            f"- {emoji} **{bdd['id']}**: {bdd['title']} ({cat}, quality: {quality})"
         )
 
     if len(bdds) > 15:

--- a/scripts/keeper-github-identity-split.py
+++ b/scripts/keeper-github-identity-split.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import shutil
 import sys
@@ -26,6 +27,12 @@ IDENTITY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 SECTION_RE = re.compile(r"^\s*\[[^\]]+\]\s*(?:#.*)?$")
 
 
+def default_base_path() -> str:
+    return (
+        os.environ.get("MASC_BASE_PATH") or os.environ.get("ME_ROOT") or str(Path.cwd())
+    )
+
+
 @dataclass(frozen=True)
 class Assignment:
     keeper: str
@@ -39,8 +46,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--base-path",
-        default=str(Path.home() / "me"),
-        help="MASC base path containing .masc (default: ~/me).",
+        default=default_base_path(),
+        help="MASC base path containing .masc (default: MASC_BASE_PATH, then ME_ROOT, then cwd).",
     )
     parser.add_argument(
         "--identity",
@@ -92,16 +99,16 @@ def keeper_config_paths(base_path: Path, explicit_names: str) -> list[Path]:
     if not config_dir.is_dir():
         raise FileNotFoundError(f"keeper config dir not found: {config_dir}")
     if explicit_names.strip():
-        names = [
-            item.strip()
-            for item in explicit_names.split(",")
-            if item.strip()
-        ]
+        names = [item.strip() for item in explicit_names.split(",") if item.strip()]
         return [config_dir / f"{name}.toml" for name in names]
-    return sorted(path for path in config_dir.glob("*.toml") if path.name != "base.toml")
+    return sorted(
+        path for path in config_dir.glob("*.toml") if path.name != "base.toml"
+    )
 
 
-def build_plan(base_path: Path, identities: list[str], config_paths: list[Path]) -> list[Assignment]:
+def build_plan(
+    base_path: Path, identities: list[str], config_paths: list[Path]
+) -> list[Assignment]:
     plan: list[Assignment] = []
     for index, config_path in enumerate(config_paths):
         if not config_path.is_file():
@@ -137,7 +144,13 @@ def keeper_section_bounds(lines: list[str], path: Path) -> tuple[int, int]:
 
 
 def set_toml_string_field(
-    lines: list[str], *, path: Path, section_start: int, section_end: int, key: str, value: str
+    lines: list[str],
+    *,
+    path: Path,
+    section_start: int,
+    section_end: int,
+    key: str,
+    value: str,
 ) -> tuple[list[str], int]:
     pattern = re.compile(rf'^(\s*{re.escape(key)}\s*=\s*)".*?"(\s*(?:#.*)?)$')
     for idx in range(section_start + 1, section_end):
@@ -188,7 +201,9 @@ def default_backup_dir(base_path: Path) -> Path:
     return base_path / ".masc" / "backups" / f"keeper-identity-split-{stamp}"
 
 
-def apply_plan(base_path: Path, plan: list[Assignment], *, backup_dir: str, allow_missing: bool) -> Path:
+def apply_plan(
+    base_path: Path, plan: list[Assignment], *, backup_dir: str, allow_missing: bool
+) -> Path:
     missing = [item for item in plan if not item.credential_dir_exists]
     if missing and not allow_missing:
         names = ", ".join(sorted({item.github_identity for item in missing}))
@@ -196,7 +211,9 @@ def apply_plan(base_path: Path, plan: list[Assignment], *, backup_dir: str, allo
             "refusing --apply because identity GH config dirs are missing: "
             f"{names}. Provision bundles first or pass --allow-missing-bundles."
         )
-    backup_root = Path(backup_dir).expanduser() if backup_dir else default_backup_dir(base_path)
+    backup_root = (
+        Path(backup_dir).expanduser() if backup_dir else default_backup_dir(base_path)
+    )
     backup_root.mkdir(parents=True, exist_ok=False)
     for item in plan:
         path = Path(item.config_path)

--- a/scripts/keeper-production-readiness-gate.py
+++ b/scripts/keeper-production-readiness-gate.py
@@ -23,6 +23,12 @@ from typing import Any
 ERROR_STATUSES = {"error", "failed", "failure", "timeout", "cancelled", "canceled"}
 
 
+def default_base_path() -> str:
+    return (
+        os.environ.get("MASC_BASE_PATH") or os.environ.get("ME_ROOT") or str(Path.cwd())
+    )
+
+
 @dataclass
 class Thresholds:
     expected_keepers: int = 1
@@ -815,7 +821,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--base-path",
-        default=os.environ.get("MASC_BASE_PATH") or os.path.expanduser("~/me"),
+        default=default_base_path(),
+        help="MASC base path containing .masc (default: MASC_BASE_PATH, then ME_ROOT, then cwd).",
     )
     parser.add_argument(
         "--keeper", action="append", default=[], help="Keeper name to scan. Repeatable."

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -1,11 +1,13 @@
 import importlib.util
 import json
+import os
 import sys
 import tempfile
 import time
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 
 SCRIPT_PATH = (
@@ -26,6 +28,24 @@ def load_audit_module():
 
 
 audit = load_audit_module()
+
+
+class AuditKeeperFleetReadinessPathDefaultsTest(unittest.TestCase):
+    def test_default_base_path_uses_explicit_runtime_roots(self):
+        with (
+            tempfile.TemporaryDirectory() as masc_base,
+            tempfile.TemporaryDirectory() as me_root,
+        ):
+            with patch.dict(
+                os.environ,
+                {"MASC_BASE_PATH": masc_base, "ME_ROOT": me_root},
+                clear=True,
+            ):
+                self.assertEqual(audit.default_base_path(), masc_base)
+            with patch.dict(os.environ, {"ME_ROOT": me_root}, clear=True):
+                self.assertEqual(audit.default_base_path(), me_root)
+            with patch.dict(os.environ, {}, clear=True):
+                self.assertEqual(audit.default_base_path(), str(Path.cwd()))
 
 
 def audit_args(base_path: Path, expected_keepers: int):
@@ -170,7 +190,9 @@ def write_persistent_work_evidence(
 ) -> None:
     trace = f"trace-{keeper}"
     manifest_dir = root / ".masc" / "keepers" / keeper / "runtime-manifests"
-    checkpoint_path = root / ".masc" / "keepers" / keeper / "checkpoints" / "turn-1.json"
+    checkpoint_path = (
+        root / ".masc" / "keepers" / keeper / "checkpoints" / "turn-1.json"
+    )
     tool_log_path = root / ".masc" / "tool_calls" / "2026-05" / "15.jsonl"
     history_path = root / ".masc" / "traces" / trace / "history.jsonl"
     for path in (

--- a/test/test_keeper_github_identity_split.py
+++ b/test/test_keeper_github_identity_split.py
@@ -1,20 +1,22 @@
 import importlib.util
 import json
+import os
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 SCRIPT_PATH = (
-    Path(__file__).resolve().parents[1]
-    / "scripts"
-    / "keeper-github-identity-split.py"
+    Path(__file__).resolve().parents[1] / "scripts" / "keeper-github-identity-split.py"
 )
 
 
 def load_split_module():
-    spec = importlib.util.spec_from_file_location("keeper_github_identity_split", SCRIPT_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "keeper_github_identity_split", SCRIPT_PATH
+    )
     if spec is None or spec.loader is None:
         raise RuntimeError(f"failed to load {SCRIPT_PATH}")
     module = importlib.util.module_from_spec(spec)
@@ -46,6 +48,22 @@ def write_keeper(root: Path, name: str, identity: str = "anyang-keepers") -> Pat
 
 
 class KeeperGithubIdentitySplitTest(unittest.TestCase):
+    def test_default_base_path_uses_explicit_runtime_roots(self):
+        with (
+            tempfile.TemporaryDirectory() as masc_base,
+            tempfile.TemporaryDirectory() as me_root,
+        ):
+            with patch.dict(
+                os.environ,
+                {"MASC_BASE_PATH": masc_base, "ME_ROOT": me_root},
+                clear=True,
+            ):
+                self.assertEqual(split.default_base_path(), masc_base)
+            with patch.dict(os.environ, {"ME_ROOT": me_root}, clear=True):
+                self.assertEqual(split.default_base_path(), me_root)
+            with patch.dict(os.environ, {}, clear=True):
+                self.assertEqual(split.default_base_path(), str(Path.cwd()))
+
     def test_build_plan_distributes_identities(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -72,7 +90,9 @@ class KeeperGithubIdentitySplitTest(unittest.TestCase):
             alpha = write_keeper(root, "alpha")
             bundle = root / ".masc" / "github-identities" / "reviewer-keepers" / "gh"
             bundle.mkdir(parents=True)
-            plan = split.build_plan(root, ["reviewer-keepers", "anyang-keepers"], [alpha])
+            plan = split.build_plan(
+                root, ["reviewer-keepers", "anyang-keepers"], [alpha]
+            )
 
             backup_dir = split.apply_plan(
                 root, plan, backup_dir="", allow_missing=False

--- a/test/test_keeper_production_readiness_gate.py
+++ b/test/test_keeper_production_readiness_gate.py
@@ -1,9 +1,11 @@
 import importlib.util
 import json
+import os
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 SCRIPT_PATH = (
@@ -29,6 +31,22 @@ gate = load_gate_module()
 
 
 class KeeperProductionReadinessGateTest(unittest.TestCase):
+    def test_default_base_path_uses_explicit_runtime_roots(self):
+        with (
+            tempfile.TemporaryDirectory() as masc_base,
+            tempfile.TemporaryDirectory() as me_root,
+        ):
+            with patch.dict(
+                os.environ,
+                {"MASC_BASE_PATH": masc_base, "ME_ROOT": me_root},
+                clear=True,
+            ):
+                self.assertEqual(gate.default_base_path(), masc_base)
+            with patch.dict(os.environ, {"ME_ROOT": me_root}, clear=True):
+                self.assertEqual(gate.default_base_path(), me_root)
+            with patch.dict(os.environ, {}, clear=True):
+                self.assertEqual(gate.default_base_path(), str(Path.cwd()))
+
     def make_fixture(self):
         tmp = tempfile.TemporaryDirectory()
         root = Path(tmp.name)


### PR DESCRIPTION
## Summary
- remove remaining active `~/me` / HOME-derived defaults from keeper readiness and identity scripts; defaults now resolve `MASC_BASE_PATH -> ME_ROOT -> cwd`
- remove hard-coded `~/me/scripts/sb` from `impact-analyzer.py`; use explicit env, workspace root env, or `sb` from PATH
- replace stale `implicit_home` / `implicit_repo_root` base-path labels with a single non-HOME implicit label and update stale path-contract comments
- qualify `Tool_dispatch` pre-hook constructors to clear the focused build blocker observed in current main

## Verification
- legacy path scans: no matches for active `~/me`, `~/.masc/config`, `$HOME/.masc`, `$HOME/.oas`, repo-config fallback flag/state names, `implicit_home`, or executable-relative config fallback patterns
- `python3 -m py_compile scripts/impact-analyzer.py scripts/keeper-production-readiness-gate.py scripts/audit-keeper-fleet-readiness.py scripts/keeper-github-identity-split.py test/test_keeper_production_readiness_gate.py test/test_audit_keeper_fleet_readiness.py test/test_keeper_github_identity_split.py`
- `python3 test/test_keeper_production_readiness_gate.py` (7 tests)
- `python3 test/test_audit_keeper_fleet_readiness.py` (53 tests)
- `python3 test/test_keeper_github_identity_split.py` (4 tests)
- `ruff check ...` / `ruff format --check ...`
- `pyright --outputjson ...` (7 files, 0 errors)
- `opam exec -- ocamlformat --check bin/main_eio.ml lib/host_config/host_config.mli lib/server/server_mcp_transport_http_session.mli lib/tool_input_validation.ml`
- `git diff --check`

## Notes
- `scripts/dune-local.sh build bin/main_eio.exe` was attempted, but local Dune verification was blocked by an existing repo-wide `/tmp/me-dune-local.lock` holder from another long-running OAS build. The branch is draft pending CI/full Dune confirmation.