### PR TITLE
fix(admission): expose Tool_resource_gate snapshot (PR-6 — PR-1 follow-up)

### DIFF
--- a/lib/admission_queue.ml
+++ b/lib/admission_queue.ml
@@ -228,6 +228,7 @@ let snapshot_json () =
   `Assoc
     [ "mode", `String "passthrough"
     ; "throttle_owner", `String "oas_cascade"
+    ; "local_tool_resource_gates", Tool_resource_gate.snapshot_json ()
     ; "max_concurrent", `Int s.max_concurrent
     ; "active", `Int s.active
     ; "available", `Int s.available


### PR DESCRIPTION
Follow-up to PR-1 (#15838, merged).

`lib/admission_queue.ml` 의 `snapshot_json` 에 `local_tool_resource_gates`
필드 1줄 추가. PR-1 의 process-local resource gate 상태를 기존 admission
snapshot consumer (/health, dashboard) 에게 가시화.

## 변경

```diff
   `Assoc
     [ "mode", `String "passthrough"
     ; "throttle_owner", `String "oas_cascade"
+    ; "local_tool_resource_gates", Tool_resource_gate.snapshot_json ()
     ; "max_concurrent", `Int s.max_concurrent
```

OAS admission (cascade 영역) 과 host-local gate (PR-1) 가 *같은 snapshot* 에
나타나면 operator 가 *어디서 backpressure 발생* 했는지 한번에 식별.

## 검증

- `ocamlformat --check`: PASS
- 본 변경은 *읽기 전용 snapshot* — 행위 무변경.

## Workaround rejection bar (self-check)

- [x] Single-line follow-up. PR-1 의 typed gate snapshot 노출만.
- [x] Not telemetry-as-fix (gate 자체가 reject — 본 PR 은 *snapshot 노출만*)

RFC-WAIVED: PR-1 의 follow-up. typed snapshot 노출.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>