### PR TITLE
fix(keeper_registry): unregister must signal watchdog fibers to stop

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -387,14 +387,29 @@ let unregister ~base_path name =
     let updated = StringMap.remove key current in
     if not (Atomic.compare_and_set registry current updated) then loop () else before
   in
+  let signal_fibers_to_stop entry =
+    (* The watchdog and heartbeat fibers hold their own reference to
+       [entry] via the closure they were forked with, so removing the
+       entry from the registry map does not stop them. Without an
+       explicit fiber_stop signal they continue to tick, observing
+       [Keeper_registry.get = None] on every subsequent poll, and
+       either spam "registry entry NOT FOUND" warnings (242+ events
+       observed in prod, 2026-05-17) or rely on the heartbeat-paused
+       latch to self-stop. Make unregister authoritative: when the
+       entry leaves the registry, the fibers that watched it stop. *)
+    Atomic.set entry.fiber_stop true;
+    Atomic.set entry.fiber_wakeup true
+  in
   match loop () with
   | Some entry when entry.phase = Running ->
+    signal_fibers_to_stop entry;
     decr_running_count_clamped ();
     Log.Keeper.debug
       "registry: unregistered running keeper name=%s running_count=%d"
       name
       (Atomic.get running_count_atomic)
   | Some entry ->
+    signal_fibers_to_stop entry;
     Log.Keeper.debug
       "registry: unregistered non-running keeper name=%s state=%s"
       name

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -537,6 +537,26 @@ let test_unregister () =
   R.unregister ~base_path:bp "k2";
   check bool "gone after" true (Option.is_none (R.get ~base_path:bp "k2"))
 
+(* Regression: unregister must signal the watchdog/heartbeat fibers
+   forked alongside the entry to exit, otherwise they keep polling
+   the now-absent entry and either spam
+   "registry entry NOT FOUND" warnings or rely on the paused latch
+   to self-stop (242+ events observed in prod, 2026-05-17). *)
+let test_unregister_signals_fiber_stop () =
+  R.clear ();
+  let _registered = R.register ~base_path:bp "k-fiber-stop" (make_meta "k-fiber-stop") in
+  let entry =
+    match R.get ~base_path:bp "k-fiber-stop" with
+    | Some e -> e
+    | None -> fail "expected entry to exist after register"
+  in
+  check bool "fiber_stop initially false"   false (Atomic.get entry.fiber_stop);
+  check bool "fiber_wakeup initially false" false (Atomic.get entry.fiber_wakeup);
+  R.unregister ~base_path:bp "k-fiber-stop";
+  check bool "fiber_stop set after unregister"   true (Atomic.get entry.fiber_stop);
+  check bool "fiber_wakeup set after unregister" true (Atomic.get entry.fiber_wakeup);
+  check bool "entry gone from registry" true (Option.is_none (R.get ~base_path:bp "k-fiber-stop"))
+
 let test_all () =
   R.clear ();
   let _e1 = R.register ~base_path:bp "a" (make_meta "a") in
@@ -2045,6 +2065,7 @@ let () =
           eio_test "completed turns replay from default store"
             test_completed_turns_replay_from_default_store;
           eio_test "unregister" test_unregister;
+          eio_test "unregister signals fiber stop" test_unregister_signals_fiber_stop;
           eio_test "all" test_all;
           eio_test "update meta" test_update_meta;
           eio_test "set state" test_set_state;


### PR DESCRIPTION
## Summary

prod observability gap 진단 + root fix.

**증상**: `[WARN] watchdog: registry entry NOT FOUND` 로그가 24일 system log batch에서 **242건** 누적 (가장 큰 single-event cluster). 사용자 task tracker #5.

**진단**:

1. `Keeper_registry.unregister` (lib/keeper/keeper_registry.ml:381) 는 registry map 에서 entry 만 제거.
2. 해당 keeper 와 함께 fork 된 *watchdog* / *heartbeat* fiber 는 *closure 로* entry 레퍼런스를 들고 있음. unregister 후에도 살아있음.
3. 매 tick 마다 `Keeper_registry.get ~name` → `None`.
4. `keeper_stale_watchdog.ml:843` 의 `should_warn_missing_registry` 분기:
   - `persisted_paused = Some true` → 조용히 stop (line 848 `request_watchdog_stop`)
   - `Some false` 또는 `None` && `captured_paused = false` → **WARN 만, 계속 polling**
5. → 매 poll 마다 WARN 1건. 242건 spam.

`unregister` 외 entry-removal path audit 결과 — `StringMap.remove` 가 registry atomic 에 닿는 사이트 1건뿐 (orphan_drop_state 는 별도 atomic). 즉 unregister 가 *유일한 invariant violation 지점*.

**Fix** (lib/keeper/keeper_registry.ml):

```ocaml
let signal_fibers_to_stop entry =
  Atomic.set entry.fiber_stop true;
  Atomic.set entry.fiber_wakeup true
in
match loop () with
| Some entry when entry.phase = Running ->
  signal_fibers_to_stop entry;  (* + *)
  decr_running_count_clamped ();
  ...
| Some entry ->
  signal_fibers_to_stop entry;  (* + *)
  ...
| None -> ...
```

CAS 가 *unregister 의 sole winner* 보장 → 시그널은 정확히 1회 발화. watchdog_loop (keeper_stale_watchdog.ml:462) 가 다음 tick 시작에서 `Atomic.get reg.fiber_stop = true` 인식 → exit.

**Test** (`test/test_keeper_registry.ml`):

`test_unregister_signals_fiber_stop` — `R.register` → `R.unregister` → entry 의 fiber_stop / fiber_wakeup atomic 둘 다 true 검증.

## Workaround Rejection self-check

- counter-as-fix? ❌ (counter 추가 없음, 실제 lifecycle 종결)
- string classifier? ❌
- N-of-M? ❌ (sole entry-removal path 닫음)
- cap/cooldown/dedup/repair? ❌ (정상 invariant 강화)
- test backdoor? ❌

→ **root fix**. memory `software-development.md §워크어라운드 거부 기준` 통과.

## Why root, not band-aid

대안 1 (안전망 only): `keeper_stale_watchdog.ml` 의 None+not paused 분기에서 WARN 후 stop. → counter-as-fix + symptom 억제. *왜 entry 가 없는데 fiber 가 살아있는가* 라는 근본 invariant 위반 무시.

대안 2 (이번 PR): unregister 가 *map 제거 + 시그널* 동시 수행 = *invariant 강화*. registry map 에 없는 keeper 의 watchdog fiber 는 *반드시* stop 상태. 자명한 contract.

## Expected impact

- 242건/24일 → 0 (또는 race window 의 *최대 1건/keeper* — 다음 tick 전 unregister 신호 처리되므로 사실상 0)
- WARN spam 제거로 system_log noise 정리 (~5% 차지)
- 고아 watchdog fiber 으로 인한 fd / memory leak 잠재 위험 제거

## Test plan

- [ ] CI green
- [ ] `test_unregister_signals_fiber_stop` pass
- [ ] 기존 `test_unregister` 회귀 없음
- [ ] dune build clean (lint-ocaml-comment-terminator guard 미머지 시 본 PR 영향 없음)

## Related

- task tracker #5 (watchdog: registry entry NOT FOUND 진단)
- memory `software-development.md §AI 페어 프로그래밍 검증 규칙` (3-Try Rule + root cause)
- memory `feedback_keeper_hallucinated_audit_cascade` (인용 시 직접 측정 — 본 PR audit 은 직접 grep)
- 사용자 절대 원칙: legacy 박멸 + transitional repair 거부

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
