### PR TITLE
fix(keeper_exec_task): force_done/force_release handler must enforce schema audit fields

### DIFF
--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -218,9 +218,21 @@ let handle_keeper_task_tool
                 "action", `String action_hint ])
   | "keeper_task_force_release" ->
     let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
-    let reason = Safe_ops.json_string ~default:"" "reason" args in
+    let reason = Safe_ops.json_string ~default:"" "reason" args |> String.trim in
     if task_id = ""
     then error_json "task_id is required. Use the task_id from keeper_tasks_list or keeper_tasks_audit."
+    else if reason = ""
+    then
+      (* Schema (tool_shard_types.ml:1363) declares [reason] as a
+         required, minLength:1 field for audit-trail reasons: this is
+         an admin override of the normal release path and the operator
+         must record why. The previous implementation accepted an empty
+         reason and emitted "(reason: no reason given)" to the room,
+         which both contradicted the schema and left a silent audit
+         gap. Enforce the schema here. *)
+      error_json
+        "reason is required. Audit trail: record why this task is being \
+         force-released. Example: reason='assignee offline >10 min, no heartbeat'."
     else (
       let agent = keeper_agent_sender ~meta in
       let _ =
@@ -231,15 +243,27 @@ let handle_keeper_task_tool
             (Printf.sprintf
                "Force-releasing task %s (reason: %s)"
                task_id
-               (if reason = "" then "no reason given" else reason))
+               reason)
       in
       keeper_task_result_json
         (Coord.force_release_task_r config ~agent_name:agent ~task_id ()))
   | "keeper_task_force_done" ->
     let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
-    let notes = Safe_ops.json_string ~default:"" "notes" args in
+    let notes = Safe_ops.json_string ~default:"" "notes" args |> String.trim in
     if task_id = ""
     then error_json "task_id is required. Use the task_id from keeper_tasks_list or keeper_tasks_audit."
+    else if notes = ""
+    then
+      (* Schema (tool_shard_types.ml:1391) declares [notes] as a
+         required, minLength:1 field — this is an admin override of
+         the normal done path and the operator must record completion
+         evidence. The previous implementation accepted an empty
+         [notes] and silently passed it through to Coord, contradicting
+         the schema and leaving a silent audit gap. Enforce the
+         schema here. *)
+      error_json
+        "notes is required. Audit trail: record completion evidence. \
+         Example: notes='PR #12345 merged, all tests green'."
     else
       keeper_task_result_json
         (Coord.force_done_task_r

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -1858,6 +1858,47 @@ let test_submit_for_verification_maps_to_typed_handoff_evidence_refs () =
           fail "expected keeper_task_submit_for_verification to succeed")))
 ;;
 
+(* --- keeper_task_force_release / keeper_task_force_done dispatch tests --- *)
+
+(* Regression: keeper_task_force_release schema declares [reason] as
+   a required minLength:1 field for audit-trail. The handler must
+   reject an empty reason rather than fall through to a "no reason
+   given" broadcast (silent audit gap). *)
+let test_force_release_requires_reason () =
+  with_room (fun config ->
+    let meta = make_test_meta () in
+    let result =
+      call_tool
+        config
+        meta
+        "keeper_task_force_release"
+        (`Assoc [ "task_id", `String "T-1"; "reason", `String "" ])
+    in
+    let json = parse_json result in
+    match Yojson.Safe.Util.member "error" json with
+    | `String msg -> check bool "mentions reason" true (contains_substring msg "reason")
+    | _ -> fail "expected error for empty reason")
+;;
+
+(* Regression: keeper_task_force_done schema declares [notes] as a
+   required minLength:1 field. The handler must reject an empty
+   notes rather than silently pass through to Coord. *)
+let test_force_done_requires_notes () =
+  with_room (fun config ->
+    let meta = make_test_meta () in
+    let result =
+      call_tool
+        config
+        meta
+        "keeper_task_force_done"
+        (`Assoc [ "task_id", `String "T-1"; "notes", `String "" ])
+    in
+    let json = parse_json result in
+    match Yojson.Safe.Util.member "error" json with
+    | `String msg -> check bool "mentions notes" true (contains_substring msg "notes")
+    | _ -> fail "expected error for empty notes")
+;;
+
 (* --- keeper_tool_search tests --- *)
 
 let test_tool_search_empty_query_returns_error () =
@@ -2125,6 +2166,16 @@ let () =
             "notes/pr_url map to typed handoff_context fields"
             `Quick
             test_submit_for_verification_maps_to_typed_handoff_evidence_refs
+        ] )
+    ; ( "force_task"
+      , [ test_case
+            "force_release requires reason (schema enforcement)"
+            `Quick
+            test_force_release_requires_reason
+        ; test_case
+            "force_done requires notes (schema enforcement)"
+            `Quick
+            test_force_done_requires_notes
         ] )
     ; ( "keeper_tool_search"
       , [ test_case


### PR DESCRIPTION
## Summary

세션 keeper 예민함 색출 inventory 의 #3 (force_done audit trail gap) root fix. *schema-handler mismatch* 발견 + 양쪽 force tool 동시 정렬.

### Audit

| Tool | Schema 선언 (`tool_shard_types.ml`) | Handler 검증 (`keeper_exec_task.ml`) |
|---|---|---|
| `keeper_task_force_release` | `required=[task_id, reason]`, `reason.minLength=1` (line 1363) | task_id 만 검증, 빈 reason 시 `"(reason: no reason given)"` graceful fallback (line 234) |
| `keeper_task_force_done` | `required=[task_id, notes]`, `notes.minLength=1` (line 1391) | task_id 만 검증, 빈 notes silent passthrough (line 240) |

LLM 이 schema 안 지키면 handler 가 *조용히 통과* → schema 가 *false advertising*. 양 tool 다 admin override path 라 audit trail 가치 큼.

### Fix

두 핸들러 모두 schema 와 일치시킴:

```ocaml
(* force_release *)
else if reason = ""
then error_json "reason is required. Audit trail: record why this task is being \
                 force-released. Example: reason='assignee offline >10 min, no heartbeat'."

(* force_done *)
else if notes = ""
then error_json "notes is required. Audit trail: record completion evidence. \
                 Example: notes='PR #12345 merged, all tests green'."
```

`force_release` 의 `if reason = "" then "no reason given" else reason` 분기는 reason 이 *항상 non-empty* 보장되므로 제거.

### Test

`test/test_keeper_task_dispatch.ml` 회귀 가드 2 건 추가:

1. `test_force_release_requires_reason` — 빈 reason → error + 메시지에 "reason" 포함
2. `test_force_done_requires_notes` — 빈 notes → error + 메시지에 "notes" 포함

`test_submit_for_verification_requires_pr_url` 와 동일 패턴.

### Behavioral risk

- *keeper-facing surface 만* 영향. `Coord.force_release_task_r` / `Coord.force_done_task_r` 자체는 unchanged → supervisor / repair path 내부 caller 영향 0.
- LLM 이 *항상 schema 따라* 호출하면 행위 변화 없음. 빈 audit field 보내던 *비정상* 호출만 reject.
- Dashboard 에서 force_release/done 호출하는 UI 가 있다면 입력 필드 검증을 client-side 에도 확인 (이미 schema minLength 가 양쪽에서 declare 되어 있어 client validation 가능성 높음).

## Workaround Rejection self-check

- counter-as-fix? ❌
- string classifier? ❌
- N-of-M? ❌ (두 force tool 같은 PR 에서 닫음)
- cap/cooldown/dedup/repair? ❌
- test backdoor? ❌
- silent failure 도입? ❌ (반대 — silent passthrough 제거)

→ **root fix**. schema = handler invariant 강화.

## Why root, not band-aid

대안 1 (schema 만 완화): schema 의 required 에서 reason/notes 제거. → audit trail 의도 폐기. operator 가 *왜* override 했는지 추적 불가. *legacy 박멸* 정신 위반.

대안 2 (이번 PR): handler 가 schema 강제. *Parse, don't validate* (Alexis King) — 도구 진입 boundary 에서 invariant 확정. 내부 path 는 *항상 valid input* 가정 가능.

## Test plan

- [ ] CI green
- [ ] `test_force_release_requires_reason` pass
- [ ] `test_force_done_requires_notes` pass
- [ ] 기존 dispatch test 회귀 없음

## Related

- 세션 keeper 예민함 색출 inventory #3 (deferred from PR #15834 sweep)
- PR #15834 / #15836 (keeper vocab → typed handoff_context) 의 schema-consistency 정신 후속
- memory `software-development.md` "Parse, don't validate" 원칙
- 사용자 절대 원칙: legacy 박멸 + audit trail 강제

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
