### PR TITLE
fix(keeper): restore required_tool_candidates parameter (hotfix for #15850 regression)

### DIFF
--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -44,6 +44,7 @@ type turn_context =
   ; tool_surface_class : string option
   ; visible_tool_count : int option
   ; required_tools : string list option
+  ; required_tool_candidates : string list option
   ; missing_required_tools : string list option
   ; cascade_profile : string option
   }
@@ -70,6 +71,7 @@ let empty_turn_context =
   ; tool_surface_class = None
   ; visible_tool_count = None
   ; required_tools = None
+  ; required_tool_candidates = None
   ; missing_required_tools = None
   ; cascade_profile = None
   }
@@ -112,6 +114,7 @@ let set_turn_context
       ?tool_surface_class
       ?visible_tool_count
       ?required_tools
+      ?required_tool_candidates
       ?missing_required_tools
       ?cascade_profile
       ()
@@ -140,6 +143,7 @@ let set_turn_context
     ; tool_surface_class
     ; visible_tool_count
     ; required_tools
+    ; required_tool_candidates
     ; missing_required_tools
     ; cascade_profile
     }
@@ -194,6 +198,7 @@ let runtime_contract_json_for_call ~keeper_name ?model () =
     ?tool_surface_class:ctx.tool_surface_class
     ?visible_tool_count:ctx.visible_tool_count
     ?required_tools:ctx.required_tools
+    ?required_tool_candidates:ctx.required_tool_candidates
     ?missing_required_tools:ctx.missing_required_tools
     ?model:(optional_model model)
     ?cascade_profile:ctx.cascade_profile
@@ -608,6 +613,7 @@ let log_call
       ?tool_surface_class
       ?visible_tool_count
       ?required_tools
+      ?required_tool_candidates
       ?missing_required_tools
       ?cascade_profile
       ?result_bytes
@@ -743,6 +749,11 @@ let log_call
         | Some _ -> required_tools
         | None -> ctx.required_tools
       in
+      let required_tool_candidates =
+        match required_tool_candidates with
+        | Some _ -> required_tool_candidates
+        | None -> ctx.required_tool_candidates
+      in
       let missing_required_tools =
         match missing_required_tools with
         | Some _ -> missing_required_tools
@@ -874,6 +885,7 @@ let log_call
           ?tool_surface_class
           ?visible_tool_count
           ?required_tools
+          ?required_tool_candidates
           ?missing_required_tools
           ?model:model_opt
           ?cascade_profile

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -49,6 +49,7 @@ val set_turn_context :
   ?tool_surface_class:string ->
   ?visible_tool_count:int ->
   ?required_tools:string list ->
+  ?required_tool_candidates:string list ->
   ?missing_required_tools:string list ->
   ?cascade_profile:string ->
   unit ->
@@ -143,6 +144,7 @@ val log_call :
   ?tool_surface_class:string ->
   ?visible_tool_count:int ->
   ?required_tools:string list ->
+  ?required_tool_candidates:string list ->
   ?missing_required_tools:string list ->
   ?cascade_profile:string ->
   ?result_bytes:int ->


### PR DESCRIPTION
🚨 **Hotfix — main 빌드 깨짐**. Ready for immediate review.

## Root cause

PR-5 (#15850) 가 `fix-keeper-24-resource-gates` worktree (2026-05-15 base) 에서
`lib/keeper_tool_call_log.{ml,mli}` 를 *그대로 copy*. 그 copy 가 PR #15842
(\`feat: surface required-tool candidates\`, 2026-05-17 08:10 UTC 머지, #15850 의
*8분 전*) 의 변경을 *5 위치 모두 덮어씀*.

## Build failure

\`\`\`
File \"lib/keeper/keeper_run_tools.ml\", lines 1699-1734
Error: Keeper_tool_call_log.set_turn_context is applied to too many arguments
   ~required_tool_candidates:computed_surface.required_tool_candidate_names
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   This extra argument is not expected.
\`\`\`

main caller (PR #15842 의 일부) 는 \`~required_tool_candidates\` 전달, 
.mli/.ml signature (PR-5 copy 의 stale 버전) 는 그 파라미터 *없음*.

## Fix

PR #15842 의 5 변경 verbatim 재적용 (\`git show 116e2ff399 | git apply\`,
clean apply, conflict 없음):

| 위치 | 변경 |
|---|---|
| \`type turn_context\` | \`+ required_tool_candidates : string list option\` |
| \`empty_turn_context\` | \`+ required_tool_candidates = None\` |
| \`set_turn_context\` 시그니처 | \`+ ?required_tool_candidates\` |
| \`log_call\` | \`+ ?required_tool_candidates\` param + ctx fallback |
| \`runtime_contract_json_for_call\` | candidate list pass-through |
| \`set_turn_context\` .mli | \`+ ?required_tool_candidates: string list ->\` |

총 +14/-0 LoC (2 files).

## Lesson — 5-PR split 의 잘못

이번 5-PR split (PR-1~PR-6) 가 fix-keeper-24-resource-gates worktree (5/15 base)
의 변경을 main 으로 정제하려 했지만, **그 사이 main 이 진화한 부분을 silently
overwrite** 한 케이스. 본 hotfix 는 그 결과.

향후 PR split from in-flight worktree:
1. \`git fetch origin\` 후
2. *모든 copy 대상 파일* 에 대해 \`git log origin/main -- <file>\` 로 *최근
   변경 확인*, 또는 \`git diff origin/main <file>\` 로 *우리 copy 와 main
   차이* 확인
3. main 이 더 진화했으면 **3-way merge 또는 patch apply**, 단순 copy 금지

PR-3 (fd_pressure) skip 결정 패턴이 정답이었고, PR-5 의 retention 영역에도
같은 due diligence 가 필요했음.

## 검증

- \`ocamlformat --check\`: PASS
- \`scripts/dune-local.sh build --root . lib/keeper_tool_call_log.ml
  lib/keeper/keeper_run_tools.ml\`: 진행 중 (background)
- CI 가 source of truth

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>