### PR TITLE
test(goal-loop): record current verify pipeline fixture

### DIFF
--- a/test/fixtures/goal_loop/verify-pipeline.current.external-claim.json
+++ b/test/fixtures/goal_loop/verify-pipeline.current.external-claim.json
@@ -1,0 +1,302 @@
+{
+  "gates": [
+    {
+      "category": "unit_tests",
+      "command": [
+        "dune",
+        "runtest",
+        "test/"
+      ],
+      "evidence": {
+        "reported": "not_supplied"
+      },
+      "gate_id": "unit_tests",
+      "reason": "unit_tests_not_run",
+      "status": "SKIPPED",
+      "summary": "Unit test command is mapped but no run evidence was supplied."
+    },
+    {
+      "category": "metric_verification",
+      "command": [
+        "sh",
+        "-c",
+        "jq '(.metrics // .).keeper_turn_success_rate' \"${GOAL_LOOP_METRICS_JSON:?set GOAL_LOOP_METRICS_JSON to production metric snapshot JSON}\""
+      ],
+      "evidence": {
+        "metric_name": "keeper_turn_success_rate",
+        "metric_snapshot_key": "keeper_turn_success_rate",
+        "metric_source": "GOAL_LOOP_METRICS_JSON (--metrics-json)",
+        "predicate": "> 0.95",
+        "prometheus_sources": [
+          "masc_keeper_turns_total"
+        ],
+        "value": null
+      },
+      "gate_id": "keeper_turn_success_rate_healthy",
+      "reason": "missing_metric_snapshot",
+      "status": "BLOCKED",
+      "summary": "keeper_turn_success_rate cannot be evaluated without a production metric snapshot."
+    },
+    {
+      "category": "regression_metric",
+      "command": [
+        "sh",
+        "-c",
+        "jq '(.metrics // .).keeper_skipping_turn_rate_5m' \"${GOAL_LOOP_METRICS_JSON:?set GOAL_LOOP_METRICS_JSON to production metric snapshot JSON}\""
+      ],
+      "evidence": {
+        "metric_name": "keeper_skipping_turn_rate_5m",
+        "metric_snapshot_key": "keeper_skipping_turn_rate_5m",
+        "metric_source": "GOAL_LOOP_METRICS_JSON (--metrics-json)",
+        "predicate": "== 0",
+        "prometheus_sources": [
+          "masc_keeper_semaphore_wait_timeout_total"
+        ],
+        "value": null
+      },
+      "gate_id": "no_semaphore_skip",
+      "reason": "missing_metric_snapshot",
+      "status": "BLOCKED",
+      "summary": "keeper_skipping_turn_rate_5m cannot be evaluated without a production metric snapshot."
+    },
+    {
+      "category": "regression_metric",
+      "command": [
+        "sh",
+        "-c",
+        "jq '(.metrics // .).pricing_catalog_miss_total' \"${GOAL_LOOP_METRICS_JSON:?set GOAL_LOOP_METRICS_JSON to production metric snapshot JSON}\""
+      ],
+      "evidence": {
+        "metric_name": "pricing_catalog_miss_total",
+        "metric_snapshot_key": "pricing_catalog_miss_total",
+        "metric_source": "GOAL_LOOP_METRICS_JSON (--metrics-json)",
+        "predicate": "== 0",
+        "prometheus_sources": [
+          "masc_pricing_catalog_miss_total"
+        ],
+        "value": null
+      },
+      "gate_id": "no_pricing_miss",
+      "reason": "missing_metric_snapshot",
+      "status": "BLOCKED",
+      "summary": "pricing_catalog_miss_total cannot be evaluated without a production metric snapshot."
+    },
+    {
+      "category": "regression_metric",
+      "command": [
+        "sh",
+        "-c",
+        "jq '(.metrics // .).persistence_utf8_repair_total' \"${GOAL_LOOP_METRICS_JSON:?set GOAL_LOOP_METRICS_JSON to production metric snapshot JSON}\""
+      ],
+      "evidence": {
+        "metric_name": "persistence_utf8_repair_total",
+        "metric_snapshot_key": "persistence_utf8_repair_total",
+        "metric_source": "GOAL_LOOP_METRICS_JSON (--metrics-json)",
+        "predicate": "== 0",
+        "prometheus_sources": [
+          "masc_persistence_utf8_repair_total"
+        ],
+        "value": null
+      },
+      "gate_id": "no_utf8_repair",
+      "reason": "missing_metric_snapshot",
+      "status": "BLOCKED",
+      "summary": "persistence_utf8_repair_total cannot be evaluated without a production metric snapshot."
+    },
+    {
+      "category": "regression_metric",
+      "command": [
+        "sh",
+        "-c",
+        "jq '(.metrics // .).recovery_strategy_executed_total_1h' \"${GOAL_LOOP_METRICS_JSON:?set GOAL_LOOP_METRICS_JSON to production metric snapshot JSON}\""
+      ],
+      "evidence": {
+        "metric_name": "recovery_strategy_executed_total_1h",
+        "metric_snapshot_key": "recovery_strategy_executed_total_1h",
+        "metric_source": "GOAL_LOOP_METRICS_JSON (--metrics-json)",
+        "predicate": "> 0",
+        "prometheus_sources": [],
+        "value": null
+      },
+      "gate_id": "recovery_executed",
+      "reason": "missing_metric_snapshot",
+      "status": "BLOCKED",
+      "summary": "recovery_strategy_executed_total_1h cannot be evaluated without a production metric snapshot."
+    },
+    {
+      "category": "regression_metric",
+      "command": [
+        "sh",
+        "-c",
+        "jq '(.metrics // .) | {admission_queue_depth, admission_queue_wait_ms}' \"${GOAL_LOOP_METRICS_JSON:?set GOAL_LOOP_METRICS_JSON to production metric snapshot JSON}\""
+      ],
+      "evidence": {
+        "admission_queue_depth": null,
+        "admission_queue_wait_ms": null,
+        "metric_source": "GOAL_LOOP_METRICS_JSON (--metrics-json)",
+        "predicate": "admission_queue_depth > 0 || admission_queue_wait_ms > 0",
+        "prometheus_sources": {
+          "admission_queue_depth": [
+            "masc_inference_queue_depth"
+          ],
+          "admission_queue_wait_ms": [
+            "masc_inference_queue_wait_seconds"
+          ]
+        }
+      },
+      "gate_id": "admission_backpressure_observed",
+      "reason": "missing_metric_snapshot",
+      "status": "BLOCKED",
+      "summary": "Admission backpressure cannot be evaluated without a metric snapshot."
+    },
+    {
+      "category": "metric_verification",
+      "command": [
+        "sh",
+        "-c",
+        "jq '(.metrics // .).dashboard_snapshot_latency_p99' \"${GOAL_LOOP_METRICS_JSON:?set GOAL_LOOP_METRICS_JSON to production metric snapshot JSON}\""
+      ],
+      "evidence": {
+        "metric_name": "dashboard_snapshot_latency_p99",
+        "metric_snapshot_key": "dashboard_snapshot_latency_p99",
+        "metric_source": "GOAL_LOOP_METRICS_JSON (--metrics-json)",
+        "predicate": "< 5.0",
+        "prometheus_sources": [
+          "masc_dashboard_snapshot_latency_seconds_bucket"
+        ],
+        "value": null
+      },
+      "gate_id": "dashboard_snapshot_latency_p99",
+      "reason": "missing_metric_snapshot",
+      "status": "BLOCKED",
+      "summary": "dashboard_snapshot_latency_p99 cannot be evaluated without a production metric snapshot."
+    },
+    {
+      "category": "orient_recheck",
+      "command": [
+        "dune",
+        "exec",
+        "orient.exe",
+        "--",
+        "--check-all"
+      ],
+      "evidence": {
+        "metric_name": "orient_recheck_still_present",
+        "metric_snapshot_key": "orient_recheck_still_present",
+        "metric_source": "GOAL_LOOP_METRICS_JSON (--metrics-json)",
+        "predicate": "== 0",
+        "prometheus_sources": [],
+        "value": null
+      },
+      "gate_id": "orient_recheck_no_still_present",
+      "reason": "missing_metric_snapshot",
+      "status": "BLOCKED",
+      "summary": "orient_recheck_still_present cannot be evaluated without a production metric snapshot."
+    },
+    {
+      "category": "orient_recheck",
+      "command": [
+        "dune",
+        "exec",
+        "orient.exe",
+        "--",
+        "--check-all"
+      ],
+      "evidence": {
+        "metric_name": "orient_recheck_new_finding",
+        "metric_snapshot_key": "orient_recheck_new_finding",
+        "metric_source": "GOAL_LOOP_METRICS_JSON (--metrics-json)",
+        "predicate": "== 0",
+        "prometheus_sources": [],
+        "value": null
+      },
+      "gate_id": "orient_recheck_no_new_finding",
+      "reason": "missing_metric_snapshot",
+      "status": "BLOCKED",
+      "summary": "orient_recheck_new_finding cannot be evaluated without a production metric snapshot."
+    },
+    {
+      "category": "tla_check",
+      "command": [
+        "scripts/tla-check.sh"
+      ],
+      "evidence": {
+        "prompt_spec": "TierRouting.tla",
+        "resolved_path": null,
+        "result_status": null
+      },
+      "gate_id": "tla_prompt_spec_tierrouting",
+      "reason": "prompt_tla_spec_missing",
+      "status": "BLOCKED",
+      "summary": "Prompt TLA spec TierRouting.tla is not present in specs/."
+    },
+    {
+      "category": "tla_check",
+      "command": [
+        "scripts/tla-check.sh"
+      ],
+      "evidence": {
+        "prompt_spec": "Validation.tla",
+        "resolved_path": null,
+        "result_status": null
+      },
+      "gate_id": "tla_prompt_spec_validation",
+      "reason": "prompt_tla_spec_missing",
+      "status": "BLOCKED",
+      "summary": "Prompt TLA spec Validation.tla is not present in specs/."
+    },
+    {
+      "category": "tla_check",
+      "command": [
+        "scripts/tla-check.sh"
+      ],
+      "evidence": {
+        "prompt_spec": "Liveness.tla",
+        "resolved_path": null,
+        "result_status": null
+      },
+      "gate_id": "tla_prompt_spec_liveness",
+      "reason": "prompt_tla_spec_missing",
+      "status": "BLOCKED",
+      "summary": "Prompt TLA spec Liveness.tla is not present in specs/."
+    },
+    {
+      "category": "log_verification",
+      "command": [
+        "scripts/verify_goal_loop_logs.py",
+        "--mode",
+        "log-contract",
+        "--must-contain",
+        "...",
+        "--must-not-contain",
+        "..."
+      ],
+      "evidence": {
+        "must_contain": [
+          "recovery_strategy_executed",
+          "provider_health_probe_completed",
+          "fallback_ladder_activated"
+        ],
+        "must_not_contain": [
+          "skipping turn.*semaphore wait",
+          "pricing_catalog_miss",
+          "persistence UTF-8 repaired",
+          "alive-but-stuck detected",
+          "Lenient_json fallback hit",
+          "archived credential.*starvation"
+        ]
+      },
+      "gate_id": "post_act_log_contract",
+      "reason": "missing_post_act_logs",
+      "status": "BLOCKED",
+      "summary": "Post-ACT production log contract was not evaluated."
+    }
+  ],
+  "gates_blocked": 13,
+  "gates_failed": 0,
+  "gates_passed": 0,
+  "gates_skipped": 1,
+  "gates_total": 14,
+  "schema_version": 1,
+  "status": "BLOCKED"
+}

--- a/test/test_goal_loop_verify_pipeline.py
+++ b/test/test_goal_loop_verify_pipeline.py
@@ -12,6 +12,13 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "goal_loop_verify_pipeline.py"
+CURRENT_VERIFY_PIPELINE_FIXTURE = (
+    REPO_ROOT
+    / "test"
+    / "fixtures"
+    / "goal_loop"
+    / "verify-pipeline.current.external-claim.json"
+)
 
 spec = importlib.util.spec_from_file_location("goal_loop_verify_pipeline", SCRIPT_PATH)
 assert spec is not None
@@ -72,6 +79,20 @@ class GoalLoopVerifyPipelineTest(unittest.TestCase):
             "prompt_tla_spec_missing",
         )
         self.assertEqual(by_id["post_act_log_contract"].reason, "missing_post_act_logs")
+
+    def test_current_fixture_matches_default_blocked_report(self) -> None:
+        report = goal_loop_verify_pipeline.build_pipeline_report(
+            repo_root=REPO_ROOT,
+            metrics_json=None,
+            tla_results=None,
+            log_paths=[],
+            unit_tests_passed=False,
+            unit_tests_failed=False,
+        )
+
+        expected = json.loads(goal_loop_verify_pipeline.report_to_json(report))
+        actual = json.loads(CURRENT_VERIFY_PIPELINE_FIXTURE.read_text(encoding="utf-8"))
+        self.assertEqual(actual, expected)
 
     def test_metric_snapshot_covers_required_production_gates(self) -> None:
         with tempfile.TemporaryDirectory() as raw_dir:


### PR DESCRIPTION
## Summary
- add the current bare GOAL LOOP Verify pipeline result as a repo-owned external-claim fixture
- pin the fixture against the default `goal_loop_verify_pipeline.py` report so drift is explicit
- verify that completion audit surfaces this fixture as `verify_pipeline_complete` rather than hiding the state

Fixes #13795

## Validation
- `jq empty test/fixtures/goal_loop/verify-pipeline.current.external-claim.json`
- `ruff format --check test/test_goal_loop_verify_pipeline.py`
- `ruff check test/test_goal_loop_verify_pipeline.py`
- `python3 -m py_compile test/test_goal_loop_verify_pipeline.py scripts/goal_loop_verify_pipeline.py`
- `python3 test/test_goal_loop_verify_pipeline.py`
- `npx pyright --outputjson test/test_goal_loop_verify_pipeline.py scripts/goal_loop_verify_pipeline.py`
- `python3 scripts/goal_loop_completion_audit.py - --verify-pipeline test/fixtures/goal_loop/verify-pipeline.current.external-claim.json --format text` with synthetic complete status; output blocks only on `verify_pipeline_complete`