### PR TITLE
feat(server): chunked first-flush for POST /mcp JSON response (RFC-0100 PR-2)

### DIFF
--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -44,6 +44,38 @@ let safe_respond_with_string reqd response body =
         "[mcp-http-post] respond_with_string unexpected exception: %s"
         (Printexc.to_string exn)
 
+(* RFC-0100 PR-2: chunked first-flush variant of safe_respond_with_string.
+   Writes [body] via [Httpun.Reqd.respond_with_streaming] so the response
+   uses [Transfer-Encoding: chunked] framing instead of
+   [Content-Length: N]. Body bytes and headers (other than transfer-encoding /
+   content-length) are byte-identical to the non-chunked form, so well-behaved
+   JSON clients are unaffected.
+
+   The 50 ms first-flush budget is implicit at PR-2 — current sync code
+   paths compute the body in well under 50 ms, so the first (and only)
+   chunk flushes immediately. The placeholder-stub flow for slow paths
+   is RFC-0100 PR-3's auto-upgrade work, not this PR.
+
+   Same race-safe wrapping as {!safe_respond_with_string} — the
+   2026-05-05 OAS cancel-race exception class is caught and downgraded
+   to a WARN. *)
+let safe_respond_chunked reqd response body =
+  try
+    let writer = Httpun.Reqd.respond_with_streaming reqd response in
+    Httpun.Body.Writer.write_string writer body ;
+    Httpun.Body.Writer.close writer
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | Failure msg ->
+      Log.Server.warn
+        "[mcp-http-post] respond_chunked skipped (reqd invalid state; \
+         2026-05-05 OAS cancel race): %s"
+        msg
+  | exn ->
+      Log.Server.warn
+        "[mcp-http-post] respond_chunked unexpected exception: %s"
+        (Printexc.to_string exn)
+
 let body_jsonrpc_method = Server_mcp_transport_http_headers.body_jsonrpc_method
 
 let sse_prime_event = Server_mcp_transport_http_headers.sse_prime_event
@@ -487,11 +519,19 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
                                     safe_respond_with_string reqd response
                                       body
                                 | json ->
+                                    (* RFC-0100 PR-2: chunked first-flush.
+                                       Body bytes + Content-Type identical
+                                       to pre-PR behaviour; only the
+                                       framing changes (content-length →
+                                       transfer-encoding: chunked).
+                                       Well-behaved JSON clients are
+                                       unaffected; this opt-out can be
+                                       re-introduced via env knob if a
+                                       legacy client surface needs it. *)
                                     let body = Yojson.Safe.to_string json in
                                     let headers =
                                       Httpun.Headers.of_list
-                                        (("content-length",
-                                          string_of_int (String.length body))
+                                        (("transfer-encoding", "chunked")
                                         :: accept_warn_headers
                                         @ json_headers ~deps session_id
                                             protocol_version origin)
@@ -499,8 +539,7 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
                                     let response =
                                       Httpun.Response.create ~headers `OK
                                     in
-                                    safe_respond_with_string reqd response
-                                      body
+                                    safe_respond_chunked reqd response body
                             with
                             | Eio.Cancel.Cancelled _ as e -> raise e
                             | exn ->


### PR DESCRIPTION
## Summary

Switch the `POST /mcp` success-path JSON response from `Content-Length: N` framing to `Transfer-Encoding: chunked`. Body bytes and all other headers are byte-identical to the pre-PR shape — only HTTP framing changes. Well-behaved JSON clients consume it transparently.

## Scope (RFC-0100 §4 PR-2)

| Change | What |
|---|---|
| New helper | `safe_respond_chunked` mirrors the race-safe wrapping of `safe_respond_with_string` (2026-05-05 OAS cancel-race exception caught + downgraded to WARN) but uses `Httpun.Reqd.respond_with_streaming` for chunked framing |
| Wire | Main JSON success branch in `handle_post_mcp` (when neither `wants_streaming_post` nor `wants_sse` is true) sets `transfer-encoding: chunked` instead of `content-length: N` and uses `safe_respond_chunked` |
| Untouched | All other response sites (auth errors, validation errors, `Accepted` empty body, SSE responses) — short terminal responses gain nothing from chunked framing |

## 50ms first-flush budget

At PR-2 the budget is **implicit**: current sync code paths compute the JSON body in well under 50ms, so the first (and only) chunk flushes immediately. The placeholder-stub flow for slow paths (`{\"result\":{\"_streaming\":true}}` followed by continuation chunks) is RFC-0100 PR-3's auto-upgrade work, not this PR.

## What this PR does NOT do (per RFC §4)

- ❌ Auto-upgrade to SSE on long-running tool/LLM streaming dispatch (PR-3)
- ❌ `Mcp-Session-Id` response header generation (PR-3)
- ❌ `Last-Event-ID` resume + `Deprecation`/`Sunset` headers on `GET /sse` (PR-4)

## Verification

- [x] `dune build --root . @lib/server/all` silent OK
- [ ] Integration: `scripts/harness/transport/first_byte_latency.sh` (RFC §5; P50 ≤ 30ms / P95 ≤ 50ms first-byte) — separate deliverable, not in this PR
- [ ] CI

Unit-test coverage is limited because `Httpun.Reqd.t` requires a full request context; behavioural verification needs the integration harness.

## Build note

`dune build @check` currently blocked by pre-existing main breakage in `lib/keeper/keeper_run_tools.ml` (PR #15848 follow-up) and `test/test_keeper_tool_call_log.ml`. Both unrelated to this diff — my changes are confined to `lib/server/server_mcp_transport_http.ml`. CI will reflect the same once main is unbroken.

## Wire-shape risk (RFC §6 trade-off)

Misbehaved clients that parse the response as one fixed buffer (rare — HTTP/1.1 requires chunked support) need an upgrade. An opt-out env knob path is reserved for a hot-fix follow-up if needed, not introduced here.

## Related
- [[RFC-0100]] PR-1 #15798 (body, merged).
- Composes with [[RFC-0098]] (envelope shape unchanged) and [[RFC-0099]] (transport edge — independent layer).

RFC-WAIVED: scope is narrow framing change (content-length → transfer-encoding: chunked) on the success path only; body bytes + Content-Type unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)