### PR TITLE
fix(sidecar): warn+counter on silent JSON parse drop in schema_field_types

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -598,6 +598,10 @@ let metric_ws_parse_cache_misses = "masc_ws_parse_cache_misses_total"
 let metric_server_mcp_ws_frame_json_parse_failures =
   "masc_server_mcp_ws_frame_json_parse_failures_total"
 ;;
+
+let metric_sidecar_schema_field_types_json_parse_failures =
+  "masc_sidecar_schema_field_types_json_parse_failures_total"
+;;
 let metric_ws_bytes_cache_hits = "masc_ws_bytes_cache_hits_total"
 let metric_ws_bytes_cache_misses = "masc_ws_bytes_cache_misses_total"
 let metric_ws_dashboard_hello_latency_seconds = "masc_ws_dashboard_hello_latency_seconds"
@@ -2900,6 +2904,13 @@ let init () =
     "WebSocket transport incoming-frame JSON parse failures (frame dropped). \
      Labels: error_kind={yojson_parse_error|other}. Iter 28 visibility \
      fix for previously-silent drops in parse_sse_dashboard_event."
+    Counter;
+  add
+    metric_sidecar_schema_field_types_json_parse_failures
+    "Sidecar HTTP route schema_field_types JSON parse failures (returns []). \
+     Labels: error_kind={json_parse_error|other}. Iter 31 visibility \
+     fix for previously-silent type-validation bypass on malformed schema \
+     JSON in server_routes_http_routes_sidecar.schema_field_types."
     Counter;
   add
     metric_ws_bytes_cache_hits

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -993,6 +993,16 @@ val metric_ws_bytes_cache_misses : string
     Labels: [error_kind = yojson_parse_error | other]. Iter 28. *)
 val metric_server_mcp_ws_frame_json_parse_failures : string
 
+(** Counter of sidecar HTTP route [schema_field_types] JSON parse
+    failures. Previously the catch-all returned [] silently, allowing
+    callers (e.g. [coerce_value] in TOML sidecar handlers) to proceed
+    with zero type information — a silent type-validation bypass on
+    malformed schema JSON. Behavior is preserved (still returns []);
+    operators now get a counter + warn log to distinguish
+    "schema missing" from "schema present but malformed".
+    Labels: [error_kind = json_parse_error | other]. Iter 31. *)
+val metric_sidecar_schema_field_types_json_parse_failures : string
+
 (** Histogram of dashboard/hello JSON-RPC processing latency in seconds.
     Labels: [outcome = success | error]. *)
 val metric_ws_dashboard_hello_latency_seconds : string

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -1099,7 +1099,44 @@ let schema_field_types ?base_path id : (string * declared_type) list =
             (fun (k, v) -> Option.map (fun typ -> k, typ) (parse_declared_type v))
             assoc
         | _ -> [])
-     | exception _ -> [])
+     (* Iter 31 (silent-drop visibility): previously a catch-all
+        [exception _ -> []] swallowed any Yojson failure. Returning []
+        here is a silent type-validation bypass — downstream callers
+        (e.g. [coerce_value] in TOML sidecar handlers) accept untyped
+        raw values. Behavior is preserved (we still return []); the
+        counter + warn now distinguish "schema present but malformed"
+        from "schema missing". [Eio.Cancel.Cancelled] is re-raised so
+        cancellation semantics are preserved. Closed error_kind vocab
+        keeps Prometheus label cardinality bounded.
+        Same pattern as iter 28 (#15820, mcp-ws transport) and iter 29
+        (#15840, cascade_http_probe). *)
+     | exception Eio.Cancel.Cancelled e -> raise (Eio.Cancel.Cancelled e)
+     | exception Yojson.Json_error msg ->
+       let preview_len = min 200 (String.length json_str) in
+       Log.Server.warn
+         "[sidecar.schema_field_types] id=%s json_parse_error: %s \
+          (body_preview=%S)"
+         id
+         msg
+         (String.sub json_str 0 preview_len);
+       Prometheus.inc_counter
+         Prometheus.metric_sidecar_schema_field_types_json_parse_failures
+         ~labels:[ "error_kind", "json_parse_error" ]
+         ();
+       []
+     | exception exn ->
+       let preview_len = min 200 (String.length json_str) in
+       Log.Server.warn
+         "[sidecar.schema_field_types] id=%s other: %s \
+          (body_preview=%S)"
+         id
+         (Printexc.to_string exn)
+         (String.sub json_str 0 preview_len);
+       Prometheus.inc_counter
+         Prometheus.metric_sidecar_schema_field_types_json_parse_failures
+         ~labels:[ "error_kind", "other" ]
+         ();
+       [])
 ;;
 
 let coerce_value (typ : declared_type) (raw : string) : (toml_value, string) result =


### PR DESCRIPTION
## Summary

Iter 31 atomic root-fix. `server_routes_http_routes_sidecar.schema_field_types` silently swallowed Yojson failures with `| exception _ -> []`, masking malformed schema JSON as "schema missing". Downstream callers (`coerce_value`, sidecar HTTP route handlers) then proceeded with *no type information*, allowing unvalidated value acceptance — a **silent type-validation bypass**.

Same pattern as **iter 28 (#15820, mcp-ws transport)** and **iter 29 (#15840, cascade_http_probe)** — silent JSON parse path visibility.

## Root cause + downstream impact

`lib/server/server_routes_http_routes_sidecar.ml:1090-1103`:

```ocaml
let schema_field_types ?base_path id : (string * declared_type) list =
  match fetch_schema ?base_path id with
  | Error _ -> []
  | Ok json_str ->
    (match Yojson.Safe.from_string json_str with
     | j -> (...) 
     | exception _ -> [])    (* silent: discards Yojson failure *)
```

- A schema that exists but emits malformed JSON returns `[]` — indistinguishable from "schema missing" to callers.
- Caller `schema_field_types ~base_path id` at line 1237 feeds `coerce_value`, which without per-field type information accepts whatever raw bytes are submitted.
- Result: a type-validation bypass that operators have **zero signal for** (no counter, no log).
- `Eio.Cancel.Cancelled` was also silently swallowed — cancellation semantics violated.

## Why typed split

- `| exception _ -> []` masks 3 distinct conditions: Yojson parse failure (recoverable, expected), cancellation (must propagate), other (unexpected — diagnostics needed).
- Closed `error_kind` vocab `{json_parse_error | other}` keeps Prometheus label cardinality bounded (= 2). No string-classifier escalation.
- `Eio.Cancel.Cancelled` destructure-rebuild (`| exception Eio.Cancel.Cancelled e -> raise (Eio.Cancel.Cancelled e)`) — `match | exception Pat as e` is not allowed inside `match` (iter 28 precedent: `lib/session.ml:350`).
- Behavior preserved: still returns `[]` on parse failure (caller convention) — this is **visibility only, not behavior change**.

## What changed

| File | Change |
|------|--------|
| `lib/prometheus.ml` | +`metric_sidecar_schema_field_types_json_parse_failures` constant + Counter registration |
| `lib/prometheus.mli` | +exported metric name with iter-31 doc comment |
| `lib/server/server_routes_http_routes_sidecar.ml` | Replace `\| exception _ -> []` with typed 3-arm split (Cancelled re-raise / Json_error warn+counter / other warn+counter), bounded ≤200B body_preview |

Total: +59 / -1 LoC.

## RFC

`server_routes_http_routes_sidecar.ml` is **not** in the mandatory RFC subsystem list (`credential/identity/operator/sandbox/hooks/workflow`). `bash ~/me/scripts/pr-rfc-check.sh` exits 0.

## Test plan

- [x] `dune build --root . lib/prometheus.ml` clean
- [x] `dune build --root . lib/server/server_routes_http_routes_sidecar.ml` clean
- [x] `dune build --root . @check` — unrelated pre-existing failure in `lib/keeper/keeper_run_tools.ml` (`required_tool_candidate_names` arg mismatch — same on origin/main baseline). My changes contribute zero new errors.
- [x] No new test added — existing sidecar tests exercise the success path; counter+warn are visibility-only side effects with no behavioral change.

## Anti-pattern self-check (7/7)

| # | Check | Result |
|---|---|---|
| 1 | Telemetry-as-fix only? | **Partly** — visibility for silent drop. Iter 6 / 21 / 28 / 29 precedent for visibility-of-silent-drop pattern. Behavior preserved (still `[]`); root reason that `[]` is wrong (untyped fallback in caller) is a separate concern tracked downstream. |
| 2 | String/substring classifier? | NO — typed `Yojson.Json_error` constructor match. |
| 3 | N-of-M? | NO — single site at line 1102. Line 1309 already has visible error response. |
| 4 | Catch-all added? | NO — existing catch-all replaced. |
| 5 | Cap/cooldown/dedup/repair? | NO. |
| 6 | Test backdoor? | NO. |
| 7 | Repeat typo / N-site duplication? | NO. |

## Cross-references

- Iter 28: PR #15820 (mcp-ws transport, same typed-split template)
- Iter 29: PR #15840 (cascade_http_probe, same typed-split template)
- Iter 6: memory_jsonl parse_line (earliest precedent for visibility of silent JSON parse drop)
- Iter 21: V07 memory_recall

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>