### PR TITLE
fix(keeper_task_done): handler must enforce schema required `result` field

### DIFF
--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -426,28 +426,34 @@ let handle_keeper_task_tool
     let result_text = Safe_ops.json_string ~default:"" "result" args |> String.trim in
     if task_id = ""
     then error_json "task_id is required. Use the task_id you got from keeper_task_claim."
+    else if result_text = ""
+    then
+      (* Schema (tool_shard_types.ml:1447) declares [result] as a
+         required, minLength:1 field. Other agents verify completion
+         from this field, so an empty result hides the audit trail.
+         Previously the handler accepted an empty result and either
+         (a) silently passed non-strict tasks done with no summary or
+         (b) deferred the rejection to parse_handoff_context for
+         strict-contract tasks (where keepers received the confusing
+         "handoff_context.summary is required" message instead of a
+         keeper-vocabulary error). Enforce the schema here so the
+         error names the field the keeper actually sent. *)
+      error_json
+        "result is required. Audit trail: describe what you completed. \
+         Example: result='Refactored module X, all tests green, no flake'."
     else (
       (* Map keeper vocabulary (`result`) onto MASC domain typed
-         handoff_context.summary so that the action=done strict-contract
-         path can read the completion summary directly from a typed field
-         instead of relying on string-blob siblings. When [result] is
-         empty we omit handoff_context entirely; the downstream contract
-         check decides whether a summary is mandatory for this task. *)
-      let base_args =
+         handoff_context.summary so the action=done strict-contract
+         path can read the completion summary directly from a typed
+         field instead of relying on string-blob siblings. *)
+      let args_for_transition =
         [
           "task_id", `String task_id;
           "action", `String "done";
           "notes", `String result_text;
+          ( "handoff_context",
+            `Assoc [ "summary", `String result_text ] );
         ]
-      in
-      let args_for_transition =
-        if String.equal result_text "" then base_args
-        else
-          base_args
-          @ [
-              ( "handoff_context",
-                `Assoc [ "summary", `String result_text ] );
-            ]
       in
       let transition_result =
         Tool_task.handle_transition

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -1479,6 +1479,27 @@ let test_done_with_empty_task_id () =
     | _ -> fail "expected error for empty task_id")
 ;;
 
+(* Regression: keeper_task_done schema declares [result] as a
+   required minLength:1 field. The handler must reject an empty
+   result with a keeper-vocabulary error rather than silently
+   passing non-strict tasks done with no summary or deferring the
+   rejection to parse_handoff_context. *)
+let test_done_requires_result () =
+  with_room (fun config ->
+    let meta = make_test_meta () in
+    let result =
+      call_tool
+        config
+        meta
+        "keeper_task_done"
+        (`Assoc [ "task_id", `String "T-1"; "result", `String "" ])
+    in
+    let json = parse_json result in
+    match Yojson.Safe.Util.member "error" json with
+    | `String msg -> check bool "mentions result" true (contains_substring msg "result")
+    | _ -> fail "expected error for empty result")
+;;
+
 let test_done_with_nonexistent_id () =
   with_room (fun config ->
     let meta = make_test_meta () in
@@ -2137,6 +2158,7 @@ let () =
         ] )
     ; ( "done"
       , [ test_case "empty task_id returns error" `Quick test_done_with_empty_task_id
+        ; test_case "empty result returns error (schema enforcement)" `Quick test_done_requires_result
         ; test_case "nonexistent id returns error" `Quick test_done_with_nonexistent_id
         ; test_case "done after claim" `Quick test_done_after_claim
         ; test_case


### PR DESCRIPTION
## Summary

PR #15861 의 systematic sweep 후속. schema-handler mismatch 의 *마지막 cluster* — `keeper_task_done` 의 `result` field 가 schema 는 *required + minLength:1* 인데 handler 가 검증 안 함.

### Audit (systematic schema↔handler sweep, 직전 turn 결과)

| Tool | schema required minLength:1 | handler 검증 |
|---|---|---|
| `keeper_task_force_release` | `reason` | ✓ PR #15861 |
| `keeper_task_force_done` | `notes` | ✓ PR #15861 |
| `keeper_broadcast` | `message` | ✓ existing |
| `keeper_task_submit_for_verification` | `notes`, `pr_url` | ✓ PR #15834 |
| **`keeper_task_done`** | **`result`** | **✗ NOT validated (이 PR)** |
| `keeper_task_claim` | (none) | n/a |
| `keeper_task_create` | title (5), description (10) | length threshold motif, 별도 |

### Background

`tool_shard_types.ml:1447`:
\`\`\`ocaml
{ name = \"keeper_task_done\"
  ; description = \"...Other agents verify completion from the result field.\"
  ; input_schema = ...; required = [\"task_id\"; \"result\"]; result.minLength = 1
}
\`\`\`

Handler (keeper_exec_task.ml:424, PR #15834 머지 후):
\`\`\`ocaml
| \"keeper_task_done\" ->
  let task_id = ... in
  let result_text = ... in
  if task_id = \"\"
  then error_json \"task_id is required...\"
  else (
    let args_for_transition =
      if String.equal result_text \"\" then base_args  (* 빈 result 통과 *)
      else base_args @ [(\"handoff_context\", ...)]
    in
    ...
\`\`\`

### Symptom

- *Non-strict* task: 빈 result 로 silent done → audit trail 손실.
- *Strict-contract* task: `parse_handoff_context` 가 \"handoff_context.summary is required\" 로 reject → keeper 가 *result* 보냈는데 *summary* 에러 받음 (PR #15815 가 fix 한 vocab confusion 의 *wrapper-side* 버전).

### Fix

handler 가 schema 강제:

\`\`\`ocaml
else if result_text = \"\"
then error_json
  \"result is required. Audit trail: describe what you completed. \
   Example: result='Refactored module X, all tests green, no flake'.\"
else (
  let args_for_transition =
    [
      \"task_id\", `String task_id;
      \"action\", `String \"done\";
      \"notes\", `String result_text;
      (\"handoff_context\", `Assoc [\"summary\", `String result_text]);
    ]
  in
  ...
)
\`\`\`

이제 result_text 가 *항상 non-empty* 보장 → 기존의 `if result_text = \"\" then base_args else base_args @ [handoff_context]` 분기는 *deadcode*. 두 path 를 *한 path*로 collapse.

### Test

`test_done_requires_result` — empty result → error + 메시지에 \"result\" 포함. `test_force_done_requires_notes` (#15861) 와 동일 패턴.

### Behavioral risk

- 기존 dispatch test 5건 모두 *non-empty result* 보냄 (`\"done\"`, `\"completed\"`, `\"tests pass\"`, `\"completed by test\"`) → 회귀 없음.
- LLM 이 항상 schema 따라 호출하면 행위 변화 없음. 빈 result 보내던 *비정상* 호출만 reject.

## Workaround Rejection self-check

- counter-as-fix? ❌
- string classifier? ❌
- N-of-M? ❌ (systematic sweep 의 마지막 cluster 닫음)
- cap/cooldown/dedup/repair? ❌
- test backdoor? ❌
- silent failure 도입? ❌ (반대)

→ **root fix**. systematic audit-trail invariant 정렬.

## Why root, not band-aid

대안 1: parse_handoff_context 에서 더 친절한 error message. → keeper-side error 가 *handoff_context vocab* 으로 돌아오는 *근본* 문제 (vocab boundary 위반) 미해결.

대안 2 (이번 PR): handler 가 *keeper-vocab boundary* 에서 schema 강제. keeper 가 *자신이 보낸 field 이름*으로 error 받음 → diagnostic 명확.

## Test plan

- [ ] CI green
- [ ] `test_done_requires_result` pass
- [ ] 기존 6 done dispatch test 회귀 없음
- [ ] PR #15834 의 `test_done_maps_result_to_typed_handoff_summary` 회귀 없음 (result 보내므로)

## Related

- PR #15834 (MERGED) — keeper vocab → typed handoff_context
- PR #15815 (MERGED) — masc_transition entry/exit class strictness
- PR #15861 (MERGED) — force_release/force_done schema enforcement
- 이 세 PR + 본 PR 로 *keeper-task audit field* 5/5 schema-handler 일치
- 사용자 절대 원칙: legacy 박멸 + Parse, don't validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
