### PR TITLE
fix(jsonl): stream large restore reads

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -122,14 +122,18 @@ let list_day_files month_path =
 
 (* ── Lines from a single file ─────────────────────────── *)
 
-let load_lines path =
-  if not (Fs_compat.file_exists path) then []
-  else
+let iter_non_empty_lines path f =
+  if Fs_compat.file_exists path then
     try
-      Fs_compat.load_file path
-      |> String.split_on_char '\n'
-      |> List.filter (fun l -> String.trim l <> "")
-    with Sys_error _ -> []
+      let ic = open_in_bin path in
+      Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+        try
+          while true do
+            let line = input_line ic in
+            if String.trim line <> "" then f line
+          done
+        with End_of_file -> ())
+    with Sys_error _ -> ()
 
 let count_non_empty_lines path =
   if not (Fs_compat.file_exists path) then 0
@@ -328,6 +332,43 @@ let read_recent_lines t n =
     !collected
   end
 
+let iter_json_file path f =
+  iter_non_empty_lines path (fun line ->
+    try f (Yojson.Safe.from_string line) with
+    | Yojson.Json_error _ -> ())
+
+let iter_all t f =
+  let months = list_month_dirs t.base_dir |> List.rev in
+  List.iter
+    (fun m ->
+       let month_path = Filename.concat t.base_dir m in
+       let days = list_day_files month_path |> List.rev in
+       List.iter
+         (fun d -> iter_json_file (Filename.concat month_path d) f)
+         days)
+    months
+
+let iter_range t ~since ~until f =
+  match parse_date since, parse_date until with
+  | None, _ | _, None -> ()
+  | Some (since_month, since_day), Some (until_month, until_day) ->
+    let months = list_month_dirs t.base_dir |> List.rev in
+    List.iter (fun m ->
+      if String.compare m since_month >= 0
+         && String.compare m until_month <= 0 then begin
+        let month_path = Filename.concat t.base_dir m in
+        let days = list_day_files month_path |> List.rev in
+        List.iter (fun d ->
+          let day_num = Filename.remove_extension d in
+          let dominated =
+            (m = since_month && String.compare day_num since_day < 0)
+            || (m = until_month && String.compare day_num until_day > 0)
+          in
+          if not dominated then iter_json_file (Filename.concat month_path d) f)
+          days
+      end)
+      months
+
 let count_entries t =
   let months = list_month_dirs t.base_dir in
   List.fold_left (fun total month ->
@@ -340,36 +381,9 @@ let count_entries t =
       ) 0 days
   ) 0 months
 let read_range t ~since ~until =
-  match parse_date since, parse_date until with
-  | None, _ | _, None -> []
-  | Some (since_month, since_day), Some (until_month, until_day) ->
-    let collected = ref [] in
-    let months = list_month_dirs t.base_dir |> List.rev in (* ascending *)
-    List.iter (fun m ->
-      if String.compare m since_month >= 0
-         && String.compare m until_month <= 0 then begin
-        let month_path = Filename.concat t.base_dir m in
-        let days = list_day_files month_path |> List.rev in (* ascending *)
-        List.iter (fun d ->
-          let day_num = Filename.remove_extension d in
-          let dominated =
-            (m = since_month && String.compare day_num since_day < 0)
-            || (m = until_month && String.compare day_num until_day > 0)
-          in
-          if not dominated then begin
-            let path = Filename.concat month_path d in
-            let lines = load_lines path in
-            List.iter (fun line ->
-              (try
-                 let json = Yojson.Safe.from_string line in
-                 collected := json :: !collected
-               with Yojson.Json_error _ -> ())
-            ) lines
-          end
-        ) days
-      end
-    ) months;
-    List.rev !collected
+  let collected = ref [] in
+  iter_range t ~since ~until (fun json -> collected := json :: !collected);
+  List.rev !collected
 
 let prune t ~days =
   let mutex = Atomic.get t.mutex in

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -34,6 +34,14 @@ val read_range : t -> since:string -> until:string -> Yojson.Safe.t list
     within [[since, until]] (inclusive, format ["YYYY-MM-DD"]).
     Result is in chronological order. *)
 
+val iter_all : t -> (Yojson.Safe.t -> unit) -> unit
+(** [iter_all t f] calls [f] for every parseable JSONL entry in chronological
+    order without loading a whole day-file into memory. Malformed rows are
+    skipped, matching {!read_recent} and {!read_range}. *)
+
+val iter_range : t -> since:string -> until:string -> (Yojson.Safe.t -> unit) -> unit
+(** Streaming variant of {!read_range}. Invalid dates iterate zero rows. *)
+
 val prune : t -> days:int -> int
 (** [prune t ~days] deletes day-files older than [days] days ago.
     Returns the number of files deleted.  Removes empty month directories. *)

--- a/lib/memory_jsonl/memory_jsonl.ml
+++ b/lib/memory_jsonl/memory_jsonl.ml
@@ -217,22 +217,31 @@ let parse_line (line : string) : (string * Yojson.Safe.t option * float) option 
         (snippet_of_line trimmed);
       None
 
-(** Read all lines from a session file.
-    Returns empty list if file does not exist.
-    Logs a warning if file exceeds [max_file_size]. *)
-let read_lines ~path : (string * Yojson.Safe.t option * float) list =
-  if not (Fs_compat.file_exists path) then []
-  else begin
-    (* Size guard *)
+(** Stream parsed rows from a session file.
+    Missing files produce zero rows. Logs a warning if the file exceeds
+    [max_file_size]. *)
+let warn_if_large_file path =
+  try
+    let stat = Unix.stat path in
+    let size = stat.Unix.st_size in
+    if size > max_file_size then
+      Log.Memory.warn "memory_jsonl: file %s is %d bytes (>50MB)" path size
+  with Unix.Unix_error _ -> ()
+
+let iter_lines ~path f =
+  if Fs_compat.file_exists path then begin
+    warn_if_large_file path;
     (try
-       let stat = Unix.stat path in
-       let size = stat.Unix.st_size in
-       if size > max_file_size then
-         Log.Memory.warn "memory_jsonl: file %s is %d bytes (>50MB)" path size
-     with Unix.Unix_error _ -> ());
-    let content = Fs_compat.load_file path in
-    let lines = String.split_on_char '\n' content in
-    List.filter_map parse_line lines
+       let ic = open_in_bin path in
+       Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+         try
+           while true do
+             match parse_line (input_line ic) with
+             | Some row -> f row
+             | None -> ()
+           done
+         with End_of_file -> ())
+     with Sys_error _ -> ())
   end
 
 (** Create a session-based JSONL [long_term_backend].
@@ -260,14 +269,11 @@ let make_backend_with_query_observer ~on_query_result ~base_dir ~agent_name
 
   let retrieve ~key =
     try
-      let entries = read_lines ~path in
-      (* Fold over all entries; last match wins (file is oldest-first) *)
-      let last_value = List.fold_left (fun acc (k, v, _ts) ->
-          if k = key then Some v else acc
-        ) None entries
-      in
+      let last_value = ref None in
+      iter_lines ~path (fun (k, v, _ts) ->
+        if k = key then last_value := Some v);
       (* Some (Some v) = value, Some None = tombstone, None = not found *)
-      match last_value with
+      match !last_value with
       | Some (Some v) -> Some v
       | Some None -> None  (* tombstone *)
       | None -> None       (* key never written *)
@@ -310,14 +316,13 @@ let make_backend_with_query_observer ~on_query_result ~base_dir ~agent_name
   let query ~prefix ~limit =
     let result =
       try
-        let entries = read_lines ~path in
         (* De-duplicate by key (latest wins), skip tombstones *)
         let tbl = Hashtbl.create 32 in
-        List.iter (fun (key, value, ts) ->
+        iter_lines ~path (fun (key, value, ts) ->
           if String.length key >= String.length prefix
              && String.sub key 0 (String.length prefix) = prefix then
             Hashtbl.replace tbl key (value, ts)
-        ) entries;
+        );
         (* Collect non-tombstone entries *)
         let results = Hashtbl.fold (fun key (value, ts) acc ->
           match value with

--- a/lib/tool_assignment_telemetry.ml
+++ b/lib/tool_assignment_telemetry.ml
@@ -341,18 +341,15 @@ let read_recent ~n : (tool_event list, string) Result.t =
 let warm_up () : unit =
   try
     let store = get_or_create_store () in
-    let jsons = Dated_jsonl.read_recent store 100_000 in
     let decode_failures = create_failure_acc () in
     Eio_guard.with_mutex index_mu (fun () ->
       Hashtbl.clear agent_index;
-      List.iter
-        (fun json ->
-          match event_of_json json with
-          | Ok (Assigned { assignment_id; agent_id; _ }) ->
-              Hashtbl.replace agent_index agent_id assignment_id
-          | Error msg -> add_decode_failure decode_failures msg
-          | _ -> ())
-        jsons);
+      Dated_jsonl.iter_all store (fun json ->
+        match event_of_json json with
+        | Ok (Assigned { assignment_id; agent_id; _ }) ->
+          Hashtbl.replace agent_index agent_id assignment_id
+        | Error msg -> add_decode_failure decode_failures msg
+        | _ -> ()));
     observe_decode_failures ~site:"warm_up_decode" decode_failures
   with
   | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -199,26 +199,24 @@ let restore ~base_path : int =
   let skipped = ref 0 in
   let first_skip_reason = ref None in
   (try
-     (* Read all available records (cap at 1M to avoid OOM on huge histories) *)
-     let jsons = Dated_jsonl.read_recent store 1_000_000 in
-     List.iter (fun json ->
+     Dated_jsonl.iter_all store (fun json ->
        match parse_record json with
        | Ok r ->
-         let result : Tool_result.t = {
-           tool_name = r.tool_name;
-           success = r.success;
-           duration_ms = r.duration_ms;
-           data = `Null;
-           legacy_message = "";
-           failure_class = None;
-         } in
+         let result : Tool_result.t =
+           { tool_name = r.tool_name
+           ; success = r.success
+           ; duration_ms = r.duration_ms
+           ; data = `Null
+           ; legacy_message = ""
+           ; failure_class = None
+           }
+         in
          Tool_metrics.record result;
          Stdlib.incr count
        | Error reason ->
          Stdlib.incr skipped;
          if Option.is_none !first_skip_reason then
-           first_skip_reason := Some reason
-     ) jsons;
+           first_skip_reason := Some reason);
      if !skipped > 0 then
        Log.Metrics.warn
          "tool_metrics_persist: skipped %d malformed restore record(s)%s"

--- a/test/test_dated_jsonl.ml
+++ b/test/test_dated_jsonl.ml
@@ -16,6 +16,8 @@ let tmpdir prefix =
 let make_json i =
   `Assoc [("i", `Int i); ("ts", `Float (Unix.gettimeofday ()))]
 
+let json_i json = Yojson.Safe.Util.(json |> member "i" |> to_int)
+
 (* ── append creates YYYY-MM/DD.jsonl ──────────────────── *)
 
 let test_append_creates_dated_file () =
@@ -178,6 +180,34 @@ let test_read_range_malformed () =
   let result = Dated_jsonl.read_range store ~since:"bad" ~until:"dates" in
   check int "malformed dates return empty" 0 (List.length result)
 
+let write_dated_file dir month day lines =
+  let month_dir = Filename.concat dir month in
+  Fs_compat.mkdir_p month_dir;
+  Fs_compat.append_file
+    (Filename.concat month_dir (day ^ ".jsonl"))
+    (String.concat "\n" lines ^ "\n")
+
+let test_iter_all_chronological_skips_malformed () =
+  let dir = tmpdir "dated_jsonl_iter_all" in
+  write_dated_file dir "2026-01" "01" [ {|{"i":1}|}; "not-json" ];
+  write_dated_file dir "2026-01" "02" [ {|{"i":2}|} ];
+  write_dated_file dir "2026-02" "01" [ {|{"i":3}|} ];
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  let seen = ref [] in
+  Dated_jsonl.iter_all store (fun json -> seen := json_i json :: !seen);
+  check (list int) "iter_all chronological" [ 1; 2; 3 ] (List.rev !seen)
+
+let test_iter_range_chronological () =
+  let dir = tmpdir "dated_jsonl_iter_range" in
+  write_dated_file dir "2026-01" "01" [ {|{"i":1}|} ];
+  write_dated_file dir "2026-01" "02" [ {|{"i":2}|} ];
+  write_dated_file dir "2026-02" "01" [ {|{"i":3}|} ];
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  let seen = ref [] in
+  Dated_jsonl.iter_range store ~since:"2026-01-02" ~until:"2026-02-01"
+    (fun json -> seen := json_i json :: !seen);
+  check (list int) "iter_range chronological" [ 2; 3 ] (List.rev !seen)
+
 (* ── prune removes old files ───────────────────────────── *)
 
 let test_prune () =
@@ -267,6 +297,9 @@ let () =
         [
           test_case "today range non-empty" `Quick test_read_range;
           test_case "malformed dates safe" `Quick test_read_range_malformed;
+          test_case "iter_all chronological" `Quick
+            test_iter_all_chronological_skips_malformed;
+          test_case "iter_range chronological" `Quick test_iter_range_chronological;
         ] );
       ( "prune",
         [

--- a/test/test_memory_jsonl_truncation.ml
+++ b/test/test_memory_jsonl_truncation.ml
@@ -22,6 +22,16 @@ let assoc_field name = function
   | `Assoc fields -> List.assoc_opt name fields
   | _ -> None
 
+let tmpdir prefix =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let require_ok = function
+  | Ok () -> ()
+  | Error msg -> Alcotest.fail msg
+
 let test_round_trip_small_assoc () =
   let payload : Yojson.Safe.t =
     `Assoc [("foo", `String "bar"); ("n", `Int 42)]
@@ -167,6 +177,35 @@ let test_marker_field_set () =
       true (assoc_field "_preview" marker <> None)
   | _ -> Alcotest.fail "parse_line failed"
 
+let test_backend_streaming_last_write_wins () =
+  let base_dir = tmpdir "memory-jsonl-streaming" in
+  let backend =
+    Memory_jsonl.make_backend
+      ~base_dir
+      ~agent_name:"agent"
+      ~session_id:"session"
+  in
+  require_ok (backend.persist ~key:"pref:first" (`String "old"));
+  require_ok (backend.persist ~key:"pref:first" (`String "new"));
+  require_ok (backend.persist ~key:"pref:second" (`String "two"));
+  require_ok (backend.remove ~key:"pref:first");
+  Alcotest.(check bool)
+    "tombstone wins on retrieve"
+    true
+    (Option.is_none (backend.retrieve ~key:"pref:first"));
+  Alcotest.(check (option string))
+    "second key survives"
+    (Some "two")
+    (match backend.retrieve ~key:"pref:second" with
+     | Some (`String value) -> Some value
+     | _ -> None);
+  let rows = backend.query ~prefix:"pref:" ~limit:10 in
+  Alcotest.(check int) "query skips tombstone" 1 (List.length rows);
+  Alcotest.(check (list string))
+    "query returns live key"
+    [ "pref:second" ]
+    (List.map fst rows)
+
 let () =
   Alcotest.run "memory_jsonl_truncation"
     [
@@ -189,5 +228,9 @@ let () =
           test_no_false_positive_on_truncated_field_with_bool_false;
         Alcotest.test_case "legacy bare String is not a marker" `Quick
           test_no_false_positive_on_bare_string;
+      ]);
+      ("backend", [
+        Alcotest.test_case "streaming read keeps last-write semantics" `Quick
+          test_backend_streaming_last_write_wins;
       ]);
     ]


### PR DESCRIPTION
## Summary
- add streaming Dated_jsonl iterators for chronological all/range scans
- switch memory JSONL retrieve/query to line streaming instead of whole-file loads
- restore tool metrics and assignment warm-up through streaming iterators instead of large read_recent lists

## Validation
- ocamlformat --check lib/dated_jsonl/dated_jsonl.ml lib/dated_jsonl/dated_jsonl.mli lib/memory_jsonl/memory_jsonl.ml lib/tool_metrics_persist.ml lib/tool_assignment_telemetry.ml test/test_dated_jsonl.ml test/test_memory_jsonl_truncation.ml
- git diff --check
- focused Dune targets were attempted but local Dune lock queue was held by other worktrees for >20 minutes, so CI is the build verification surface