### PR TITLE
[codex] Drop keeper health legacy alias

### DIFF
--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -2,9 +2,7 @@
    See [.mli] for TLA+ modeling notes.
 
    RFC-0041 Phase B2: migrated from per-cascade (string) cache keys to
-   per-keeper, per-item (string * string) keys. The old [is_healthy]
-   remains as a backward-compatible alias that checks whether ANY item
-   for the keeper is healthy. *)
+   per-keeper, per-item (string * string) keys. *)
 
 type health_status =
   | Unknown
@@ -45,36 +43,13 @@ let record_item_result ~keeper_name ~item_id ~success =
   set_item_health ~keeper_name ~item_id status
 ;;
 
-(* ------------------------------------------------------------------ *)
-(* Backward-compatible per-keeper health (deprecated)                 *)
-(* ------------------------------------------------------------------ *)
-
-(** [is_healthy ~keeper_name] returns true if ANY item for this keeper
-    is Healthy. This is the backward-compatible alias for code that
-    hasn't migrated to per-item health checks yet.
-
-    Deprecated: use [is_item_healthy] for RFC-0041 per-item routing. *)
-let is_healthy ~keeper_name =
-  Eio.Mutex.use_ro health_cache_mu (fun () ->
-    let found = ref false in
-    Hashtbl.iter
-      (fun (kn, _item_id) (status, _ts) ->
-         if String.equal kn keeper_name
-         then (
-           match status with
-           | Healthy -> found := true
-           | _ -> ()))
-      health_cache;
-    !found)
-;;
-
-let set_health ~keeper_name status =
+let set_cascade_status ~cascade_name status =
   Eio.Mutex.use_rw ~protect:true health_cache_mu (fun () ->
-    Hashtbl.replace health_cache (keeper_name, "") (status, Time_compat.now ()))
+    Hashtbl.replace health_cache (cascade_name, "") (status, Time_compat.now ()))
 ;;
 
 (** [get_cascade_status ~cascade_name] reads the cascade-level entry
-    written by [set_health]/[run_once].  Three-valued:
+    written by [run_once].  Three-valued:
       - [Healthy]    : last probe saw the cascade at < threshold ratio.
       - [Unhealthy r]: last probe saw the cascade at >= threshold ratio.
       - [Unknown]    : probe never wrote this cascade (e.g. boot before
@@ -166,16 +141,14 @@ let run_once ~base_path =
   List.iter
     (fun (cascade, healthy) ->
        let status = if healthy then Healthy else Unhealthy "failure_ratio" in
-       (* Cache keyed by cascade name so ResumeFromPause can look it up.
-         Uses empty item_id for backward compat. *)
-       set_health ~keeper_name:cascade status)
+       set_cascade_status ~cascade_name:cascade status)
     results
 ;;
 
 let rec probe_loop ~base_path ~interval_sec ~clock () =
   (* Cancel-aware: Safe_ops.protect re-raises Eio.Cancel.Cancelled and swallows
      other exceptions so a transient registry I/O failure cannot kill the fiber
-     and freeze [is_healthy] at [false] forever. *)
+     and leave cascade status stale forever. *)
   Safe_ops.protect ~default:() (fun () -> run_once ~base_path);
   Eio.Time.sleep clock interval_sec;
   probe_loop ~base_path ~interval_sec ~clock ()

--- a/lib/keeper/keeper_health_probe.mli
+++ b/lib/keeper/keeper_health_probe.mli
@@ -29,17 +29,6 @@ val set_item_health : keeper_name:string -> item_id:string -> health_status -> u
     state based on turn outcome. Success -> Healthy, Failure -> Unhealthy. *)
 val record_item_result : keeper_name:string -> item_id:string -> success:bool -> unit
 
-(** {1 Backward-compatible per-keeper health (deprecated)} *)
-
-(** [is_healthy ~keeper_name] returns true if ANY item for this keeper
-    is Healthy. Deprecated: use [is_item_healthy] for per-item routing.
-    Kept for existing callers that haven't migrated yet. *)
-val is_healthy : keeper_name:string -> bool
-
-(** [set_health ~keeper_name status] sets health for the legacy
-    per-cascade key. Kept for the background probe fiber. *)
-val set_health : keeper_name:string -> health_status -> unit
-
 (** {1 Phase-based health predicate} *)
 
 (** [is_terminal_unhealthy phase] returns true only for terminal
@@ -72,16 +61,16 @@ val max_failed_allowed_for_cascade : total:int -> int
 val check_cascade_health : base_path:string -> (string * bool) list
 
 (** [get_cascade_status ~cascade_name] returns the cached cascade-level
-    [health_status] written by [run_once]/[set_health].  Unlike
-    [is_healthy], this preserves the [Unknown] case so the supervisor's
-    auto-resume guard can distinguish "no probe data yet" from
+    [health_status] written by [run_once].  This preserves the [Unknown]
+    case so the supervisor's auto-resume guard can distinguish
+    "no probe data yet" from
     "probe observed restart pressure" and treat the former
     permissively.
 
     Background: prior to wiring this distinction, the supervisor's
-    Phase 3.5 guard called [is_healthy] which collapsed [Unknown] and
-    [Unhealthy] to [false] — turning the boot-time cold-cache window
-    into a permanent auto-resume lockout for every cascade. *)
+    Phase 3.5 guard collapsed [Unknown] and [Unhealthy] to the same
+    boolean result — turning the boot-time cold-cache window into a
+    permanent auto-resume lockout for every cascade. *)
 val get_cascade_status : cascade_name:string -> health_status
 
 (** [run_once ~base_path] runs [check_cascade_health] and writes the

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1388,9 +1388,9 @@ let sweep_and_recover (ctx : _ context) =
   let base_path = ctx.config.base_path in
   (* Refresh the cascade health cache before Phase 3.5 reads it.  Without this
      call the cache stayed cold (PR #14146 introduced the cache and
-     [Phase 3.5] guard but never wired a writer), so [is_healthy] returned
-     [false] for every cascade and silently disabled auto-resume across the
-     fleet.  [run_once] is a registry scan — bounded, no I/O — so running it
+     [Phase 3.5] guard but never wired a writer), so every cascade looked
+     unhealthy and auto-resume was silently disabled across the fleet.
+     [run_once] is a registry scan — bounded, no I/O — so running it
      inline on every 30 s sweep is cheap.  [Safe_ops.protect] keeps a
      transient registry exception from killing the sweep. *)
   Safe_ops.protect ~default:() (fun () -> Keeper_health_probe.run_once ~base_path);

--- a/test/test_keeper_health_probe.ml
+++ b/test/test_keeper_health_probe.ml
@@ -30,13 +30,6 @@ let test_get_cascade_status_default_unknown () =
     (H.get_cascade_status ~cascade_name:"never-written-cascade-xyz")
 ;;
 
-let test_is_healthy_unknown () =
-  Alcotest.(check bool)
-    "is_healthy on uninitialized keeper = false"
-    false
-    (Masc_mcp.Keeper_health_probe.is_healthy ~keeper_name:"k1-never-set")
-;;
-
 let test_check_cascade_health_all_healthy () =
   let base_dir = Filename.temp_file "probe-" "" in
   Sys.remove base_dir;
@@ -142,7 +135,6 @@ let () =
             "default_status_is_unknown"
             `Quick
             test_get_cascade_status_default_unknown
-        ; Alcotest.test_case "is_healthy_unknown_compat" `Quick test_is_healthy_unknown
         ] )
     ; ( "cascade"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary
- remove the deprecated `Keeper_health_probe.is_healthy` public alias and its compatibility-only test
- stop exposing `set_health` from the probe module; keep cascade status writes private via `set_cascade_status`
- update supervisor/probe comments to describe the current `get_cascade_status` path without the removed boolean alias

## Verification
- targeted scan returned no matches for `Keeper_health_probe.is_healthy`, `Keeper_health_probe.set_health`, `val is_healthy`, `val set_health`, or the removed compatibility test label
- `opam exec -- ocamlformat --check lib/keeper/keeper_health_probe.ml lib/keeper/keeper_health_probe.mli lib/keeper/keeper_supervisor.ml test/test_keeper_health_probe.ml`
- `git diff --check origin/main..HEAD`

## Notes
- `scripts/dune-local.sh build test/test_keeper_health_probe.exe` and then `scripts/dune-local.sh build lib/keeper/keeper_health_probe.cmi` were attempted, but local verification was blocked by repo-wide Dune/opam locks held by other long-running worktrees. This PR is draft pending CI/Dune confirmation.