### PR TITLE
docs(release): sync v0.19.22 published truth

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Current package version: v0.19.22
 > Latest changelog entry: v0.19.22 (2026-05-17)
-> Latest published GitHub release: v0.19.19 (2026-05-17)
+> Latest published GitHub release: v0.19.22 (2026-05-17)
 > Updated: 2026-05-17
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -11,7 +11,7 @@ code_refs:
 
 > Current package version: v0.19.22
 > Latest changelog entry: v0.19.22 (2026-05-17)
-> Latest published GitHub release: v0.19.19 (2026-05-17)
+> Latest published GitHub release: v0.19.22 (2026-05-17)
 > Updated: 2026-05-17
 > Release line: pre-1.0 (`0.y.z`); legacy `v2.*` tags are frozen history
 


### PR DESCRIPTION
## Summary
- update roadmap and product operating plan published-release truth to v0.19.22
- keep package/changelog version at v0.19.22

## Verification
- `gh release view v0.19.22 --json tagName,targetCommitish,publishedAt,url`
- `rg -n "Latest published GitHub release" ROADMAP.md docs/PRODUCT-OPERATING-PLAN.md`