### PR TITLE
[codex] split health build identity

### DIFF
--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -2,9 +2,20 @@
 
 type t =
   { release_version : string
+  ; binary_version : string
+  ; repo_version : string option [@default None]
   ; commit : string option [@default None]
+  ; commit_source : string option [@default None]
   ; commit_unix_ts : float option [@default None]
   ; commit_age_seconds : int option [@default None]
+  ; binary_commit : string option [@default None]
+  ; binary_commit_source : string option [@default None]
+  ; binary_commit_unix_ts : float option [@default None]
+  ; binary_commit_age_seconds : int option [@default None]
+  ; repo_head_commit : string option [@default None]
+  ; repo_head_commit_source : string option [@default None]
+  ; repo_head_commit_unix_ts : float option [@default None]
+  ; repo_head_commit_age_seconds : int option [@default None]
   ; executable_path : string [@default ""]
   ; executable_dir : string [@default ""]
   ; repo_root : string option [@default None]
@@ -140,6 +151,41 @@ let probe_repo_root () =
   |> List.find_map find_git_root
 ;;
 
+let parse_dune_project_version raw =
+  raw
+  |> String.split_on_char '\n'
+  |> List.find_map (fun line ->
+    let line = String.trim line in
+    let prefix = "(version " in
+    if String.starts_with ~prefix line && String.ends_with ~suffix:")" line
+    then
+      String.sub
+        line
+        (String.length prefix)
+        (String.length line - String.length prefix - String.length ")")
+      |> trim_to_option
+    else None)
+;;
+
+let read_file path =
+  try
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () -> really_input_string ic (in_channel_length ic))
+    |> fun contents -> Some contents
+  with
+  | Sys_error _ -> None
+  | exn ->
+    Log.Identity.warn "build_identity read_file %s failed: %s" path (Printexc.to_string exn);
+    None
+;;
+
+let probe_repo_version repo_root =
+  let dune_project = Filename.concat repo_root "dune-project" in
+  Option.bind (read_file dune_project) parse_dune_project_version
+;;
+
 let decimal_digits_only s =
   String.length s > 0 && String.for_all (fun c -> c >= '0' && c <= '9') s
 ;;
@@ -234,37 +280,82 @@ let resolve_commit ~env_value ~probe =
   | None -> probe ()
 ;;
 
+type commit_resolution =
+  { commit : string option
+  ; commit_source : string option
+  ; binary_commit : string option
+  ; binary_commit_source : string option
+  ; repo_head_commit : string option
+  ; repo_head_commit_source : string option
+  }
+
+let build_env_commit_source = "env:MASC_BUILD_GIT_COMMIT"
+let runtime_repo_head_source = "runtime_repo_head"
+
+let resolve_commit_details ~env_value ~probe =
+  let binary_commit = Option.bind env_value trim_to_option in
+  let repo_head_commit = probe () in
+  let commit, commit_source =
+    match binary_commit, repo_head_commit with
+    | Some commit, _ -> Some commit, Some build_env_commit_source
+    | None, Some commit -> Some commit, Some runtime_repo_head_source
+    | None, None -> None, None
+  in
+  { commit
+  ; commit_source
+  ; binary_commit
+  ; binary_commit_source = Option.map (fun _ -> build_env_commit_source) binary_commit
+  ; repo_head_commit
+  ; repo_head_commit_source = Option.map (fun _ -> runtime_repo_head_source) repo_head_commit
+  }
+;;
+
+let age_seconds ~now ts_opt =
+  match ts_opt with
+  | None -> None
+  | Some ts ->
+    let age = now -. ts in
+    if Float.is_finite age then Some (max 0 (int_of_float age)) else None
+;;
+
 let started_at_unix = Unix.gettimeofday ()
 let started_at_iso = iso8601_of_unix started_at_unix
 let resolved_executable_path = executable_path ()
 let resolved_executable_dir = Filename.dirname resolved_executable_path
 
-(** Commit hash — eagerly resolved at startup.
+(** Commit hashes — eagerly resolved at startup.
     Not using [Eio.Lazy] because this is called from tests without Eio context.
     Env var check + git probe are fast and side-effect-free. *)
-let commit =
-  resolve_commit
+let commit_resolution =
+  resolve_commit_details
     ~env_value:(Env_config_core.build_git_commit_opt ())
     ~probe:probe_git_commit
 ;;
 
 let resolved_repo_root = probe_repo_root ()
 let repo_root () = resolved_repo_root
-let commit_unix_ts = probe_commit_unix_ts commit
+let repo_version = Option.bind resolved_repo_root probe_repo_version
+let commit_unix_ts = probe_commit_unix_ts commit_resolution.commit
+let binary_commit_unix_ts = probe_commit_unix_ts commit_resolution.binary_commit
+let repo_head_commit_unix_ts = probe_commit_unix_ts commit_resolution.repo_head_commit
 
 let current () =
   let now = Unix.gettimeofday () in
-  let commit_age_seconds =
-    match commit_unix_ts with
-    | None -> None
-    | Some ts ->
-      let age = now -. ts in
-      if Float.is_finite age then Some (max 0 (int_of_float age)) else None
-  in
   { release_version = Version.version
-  ; commit
+  ; binary_version = Version.version
+  ; repo_version
+  ; commit = commit_resolution.commit
+  ; commit_source = commit_resolution.commit_source
   ; commit_unix_ts
-  ; commit_age_seconds
+  ; commit_age_seconds = age_seconds ~now commit_unix_ts
+  ; binary_commit = commit_resolution.binary_commit
+  ; binary_commit_source = commit_resolution.binary_commit_source
+  ; binary_commit_unix_ts
+  ; binary_commit_age_seconds = age_seconds ~now binary_commit_unix_ts
+  ; repo_head_commit = commit_resolution.repo_head_commit
+  ; repo_head_commit_source = commit_resolution.repo_head_commit_source
+  ; repo_head_commit_unix_ts
+  ; repo_head_commit_age_seconds = age_seconds ~now repo_head_commit_unix_ts
   ; executable_path = resolved_executable_path
   ; executable_dir = resolved_executable_dir
   ; repo_root = resolved_repo_root

--- a/lib/build_identity.mli
+++ b/lib/build_identity.mli
@@ -1,24 +1,47 @@
 (** Build identity for the running server process.
 
     Captures release version, git commit, start time, and uptime.
-    Commit is resolved at startup from [MASC_BUILD_GIT_COMMIT] env var
-    or by probing the git repository. *)
+    [commit] is kept as a backwards-compatible field, but callers that
+    need binary freshness must inspect [binary_commit] / [commit_source]
+    rather than treating a runtime git probe as compile-time proof. *)
 
 type t = {
   release_version : string;
+  binary_version : string;
+    (** Alias for [release_version], named explicitly for callers that
+        compare the running executable against [repo_version]. *)
+  repo_version : string option;
+    (** Package version read from the runtime checkout's [dune-project],
+        when available.  This is runtime repo truth, not binary truth. *)
   commit : string option;
+    (** Backwards-compatible identity field.  Uses [binary_commit] when
+        [MASC_BUILD_GIT_COMMIT] is set, otherwise falls back to
+        [repo_head_commit].  Inspect [commit_source] before using this as
+        deploy proof. *)
+  commit_source : string option;
+    (** [Some "env:MASC_BUILD_GIT_COMMIT"] when [commit] came from the
+        build env override, [Some "runtime_repo_head"] when it came from
+        probing the current checkout, [None] when unknown. *)
   commit_unix_ts : float option;
-    (** Unix timestamp of the resolved git commit (probed at startup
-        via [git log -1 --format=%ct <commit>]).  [None] when commit
-        could not be resolved or git probe failed.  Exposed on
-        [/health] so operators / dashboards can compute
-        [now - commit_unix_ts] and surface stale-binary deploy gaps
-        without an external git fetch from the dashboard side. *)
+    (** Unix timestamp of [commit].  Kept for compatibility; prefer the
+        source-specific timestamp fields below. *)
   commit_age_seconds : int option;
-    (** Convenience field: [Some (now - commit_unix_ts)] when both
-        are available, [None] otherwise.  Recomputed on every
-        [current ()] call so the value tracks wall clock as the
-        process keeps running on a stale binary. *)
+    (** Age of [commit_unix_ts].  Kept for compatibility; prefer
+        [binary_commit_age_seconds] for binary freshness. *)
+  binary_commit : string option;
+    (** Commit supplied by [MASC_BUILD_GIT_COMMIT], when available.  This is
+        the only commit field that operators should use as binary-build
+        identity in this module. *)
+  binary_commit_source : string option;
+  binary_commit_unix_ts : float option;
+  binary_commit_age_seconds : int option;
+  repo_head_commit : string option;
+    (** Current checkout HEAD probed at runtime from [repo_root], when
+        available.  Useful operational context, but not proof that the
+        executable was built from this commit. *)
+  repo_head_commit_source : string option;
+  repo_head_commit_unix_ts : float option;
+  repo_head_commit_age_seconds : int option;
   executable_path : string;
     (** Absolute best-effort path to the running executable.  Exposed on
         [/health] so operators can distinguish a root-lane binary from a
@@ -50,6 +73,20 @@ val resolve_commit :
 (** Resolve commit hash from env var or probe function.
     Exposed for testing. *)
 
+type commit_resolution = {
+  commit : string option;
+  commit_source : string option;
+  binary_commit : string option;
+  binary_commit_source : string option;
+  repo_head_commit : string option;
+  repo_head_commit_source : string option;
+}
+
+val resolve_commit_details :
+  env_value:string option -> probe:(unit -> string option) -> commit_resolution
+(** Resolve the compatibility [commit] plus the source-specific binary/env
+    and runtime repo-head fields.  Exposed for testing. *)
+
 val pick_repo_candidates :
   exe_dir:string -> cwd:string -> string list
 (** Ordered list of directories to probe for a git repo. Places [exe_dir]
@@ -60,6 +97,9 @@ val pick_repo_candidates :
 val parse_commit_unix_ts_output : string -> float option
 (** Parse raw [git log -1 --format=%ct] output. Pure — exposed for unit
     testing. *)
+
+val parse_dune_project_version : string -> string option
+(** Parse the top-level [(version ...)] field from [dune-project] contents. *)
 
 module For_testing : sig
   val observe_probe_failure : site:string -> exn -> unit

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -425,7 +425,8 @@ let dashboard_runtime_probe_http_json ?(force = false) () =
 
 let runtime_resolution_json (config : Coord.config) =
   let build = Build_identity.current () in
-  let runtime_commit = build.commit in
+  let runtime_commit = build.binary_commit in
+  let runtime_commit_known = Option.is_some runtime_commit in
   let server_repo_path = Build_identity.repo_root () in
   let server_repo_commit = Option.bind server_repo_path git_rev_parse_short in
   let workspace_commit = git_rev_parse_short config.workspace_path in
@@ -473,6 +474,14 @@ let runtime_resolution_json (config : Coord.config) =
         source_label
         source_commit
       :: acc)
+    else acc
+  in
+  let add_binary_commit_unknown_warning acc =
+    if (not runtime_commit_known) && Option.is_some build.repo_head_commit
+    then
+      "Runtime binary commit is unknown; build.repo_head_commit is only the \
+       current checkout HEAD and must not be treated as rebuild proof."
+      :: acc
     else acc
   in
   let add_server_workspace_mismatch_warning acc =
@@ -527,6 +536,7 @@ let runtime_resolution_json (config : Coord.config) =
   let warnings =
     []
     |> add_source_mismatch_warning
+    |> add_binary_commit_unknown_warning
     |> add_server_workspace_mismatch_warning
     |> add_prompt_dir_mismatch_warning
     |> add_signal_warning
@@ -551,6 +561,10 @@ let runtime_resolution_json (config : Coord.config) =
               [ "path", `Null; "exists", `Bool false; "source", `String "server_binary" ] )
       ; ( "server_repo_git_commit"
         , Option.fold ~none:`Null ~some:(fun value -> `String value) server_repo_commit )
+      ; ( "runtime_binary_git_commit"
+        , Option.fold ~none:`Null ~some:(fun value -> `String value) runtime_commit )
+      ; ( "runtime_repo_head_git_commit"
+        , Option.fold ~none:`Null ~some:(fun value -> `String value) build.repo_head_commit )
       ; ( "workspace_git_commit"
         , Option.fold ~none:`Null ~some:(fun value -> `String value) workspace_commit )
       ; ( "resolved_base_git_commit"

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -97,6 +97,15 @@ let agent_card_json request =
             ( "commit",
               Option.fold ~none:`Null ~some:(fun value -> `String value)
                 build.commit );
+            ( "commit_source",
+              Option.fold ~none:`Null ~some:(fun value -> `String value)
+                build.commit_source );
+            ( "binary_commit",
+              Option.fold ~none:`Null ~some:(fun value -> `String value)
+                build.binary_commit );
+            ( "repo_head_commit",
+              Option.fold ~none:`Null ~some:(fun value -> `String value)
+                build.repo_head_commit );
             ("started_at", `String build.started_at);
             ("uptime_seconds", `Int build.uptime_seconds);
           ] );

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1552,22 +1552,19 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       Log.Server.info "Bootstrap completed in %.1fs" (t2 -. t1);
       (* 2026-05-05 deploy-gap audit (#12943 follow-up): warn loudly when
          the running binary is more than [stale_threshold_hours] behind
-         the resolved git commit timestamp.  The 2026-05-05 fleet-stuck
-         recurrence chain spent 7 prompt cycles before noticing the
-         server had been running an 8-hour-old build.  /health already
-         exposes [build.commit_age_seconds]; this WARN forces the same
-         signal into the operator-visible startup log so the next deploy
-         gap is caught at restart instead of after the next outage. *)
+         the build-env commit timestamp.  Runtime repo HEAD is intentionally
+         ignored here: it is checkout truth, not proof that this executable
+         was rebuilt from that commit. *)
       let stale_threshold_hours = 12 in
       let build = Build_identity.current () in
-      (match build.commit_age_seconds with
-       | Some age when age > stale_threshold_hours * 3600 ->
+      (match build.binary_commit, build.binary_commit_age_seconds with
+       | Some binary_commit, Some age when age > stale_threshold_hours * 3600 ->
          let hours = age / 3600 in
          Log.Server.warn
            "Server binary commit %s is %d hours old (>%dh threshold). \
             Rebuild + restart recommended to pick up newer fixes; see \
-            /health build.commit_age_seconds."
-           (Option.value build.commit ~default:"<unknown>")
+            /health build.binary_commit_age_seconds."
+           binary_commit
            hours stale_threshold_hours
        | _ -> ());
       Server_bootstrap_loops.install_tooling ~governance_level state;

--- a/test/test_build_identity.ml
+++ b/test/test_build_identity.ml
@@ -20,6 +20,40 @@ let test_resolve_commit_uses_probe_when_env_missing () =
   in
   Alcotest.(check (option string)) "probe used" (Some "deadbeef") commit
 
+let test_resolve_commit_details_splits_env_and_repo_head () =
+  let details =
+    Build_identity.resolve_commit_details
+      ~env_value:(Some " abc12345 ")
+      ~probe:(fun () -> Some "deadbeef")
+  in
+  Alcotest.(check (option string)) "compat commit uses env"
+    (Some "abc12345") details.commit;
+  Alcotest.(check (option string)) "commit source is env"
+    (Some "env:MASC_BUILD_GIT_COMMIT") details.commit_source;
+  Alcotest.(check (option string)) "binary commit uses env"
+    (Some "abc12345") details.binary_commit;
+  Alcotest.(check (option string)) "binary source is env"
+    (Some "env:MASC_BUILD_GIT_COMMIT") details.binary_commit_source;
+  Alcotest.(check (option string)) "repo head still surfaced"
+    (Some "deadbeef") details.repo_head_commit;
+  Alcotest.(check (option string)) "repo head source"
+    (Some "runtime_repo_head") details.repo_head_commit_source
+
+let test_resolve_commit_details_marks_repo_head_fallback () =
+  let details =
+    Build_identity.resolve_commit_details
+      ~env_value:None
+      ~probe:(fun () -> Some "deadbeef")
+  in
+  Alcotest.(check (option string)) "compat commit falls back to repo head"
+    (Some "deadbeef") details.commit;
+  Alcotest.(check (option string)) "commit source is repo head"
+    (Some "runtime_repo_head") details.commit_source;
+  Alcotest.(check (option string)) "binary commit absent" None
+    details.binary_commit;
+  Alcotest.(check (option string)) "repo head commit present"
+    (Some "deadbeef") details.repo_head_commit
+
 let test_current_started_at_is_stable () =
   let first = Build_identity.current () in
   Unix.sleepf 0.01;
@@ -32,6 +66,16 @@ let test_current_json_exposes_runtime_binary_identity () =
   let current = Build_identity.current () in
   let json = Build_identity.to_yojson current in
   let open Yojson.Safe.Util in
+  Alcotest.(check bool) "binary version populated" true
+    (String.length (json |> member "binary_version" |> to_string) > 0);
+  Alcotest.(check bool) "repo version field present" true
+    (match json |> member "repo_version" with `Null | `String _ -> true | _ -> false);
+  Alcotest.(check bool) "commit source field present" true
+    (match json |> member "commit_source" with `Null | `String _ -> true | _ -> false);
+  Alcotest.(check bool) "binary commit field present" true
+    (match json |> member "binary_commit" with `Null | `String _ -> true | _ -> false);
+  Alcotest.(check bool) "repo head commit field present" true
+    (match json |> member "repo_head_commit" with `Null | `String _ -> true | _ -> false);
   Alcotest.(check bool) "executable path populated" true
     (String.length (json |> member "executable_path" |> to_string) > 0);
   Alcotest.(check bool) "executable dir populated" true
@@ -103,6 +147,14 @@ let test_parse_commit_unix_ts_output () =
         (Build_identity.parse_commit_unix_ts_output raw))
     [ "nan"; "inf"; "-1"; "1.0"; "1e9"; "0x660b7d80"; "4102444801" ]
 
+let test_parse_dune_project_version () =
+  Alcotest.(check (option string)) "version parsed"
+    (Some "0.19.20")
+    (Build_identity.parse_dune_project_version
+       "(lang dune 3.22)\n\n(name masc_mcp)\n(version 0.19.20)\n");
+  Alcotest.(check (option string)) "missing version" None
+    (Build_identity.parse_dune_project_version "(lang dune 3.22)\n")
+
 let build_identity_probe_failure_count site =
   Prometheus.metric_value_or_zero
     Prometheus.metric_build_identity_probe_failures
@@ -148,6 +200,11 @@ let () =
             test_resolve_commit_prefers_env;
           Alcotest.test_case "resolve commit falls back to probe" `Quick
             test_resolve_commit_uses_probe_when_env_missing;
+          Alcotest.test_case "resolve commit details splits env and repo head"
+            `Quick test_resolve_commit_details_splits_env_and_repo_head;
+          Alcotest.test_case
+            "resolve commit details marks repo head fallback" `Quick
+            test_resolve_commit_details_marks_repo_head_fallback;
           Alcotest.test_case "current started_at stable" `Quick
             test_current_started_at_is_stable;
           Alcotest.test_case "current JSON exposes runtime binary identity" `Quick
@@ -163,6 +220,8 @@ let () =
             test_pick_repo_candidates_not_sorted_alphabetically;
           Alcotest.test_case "parse commit timestamp output" `Quick
             test_parse_commit_unix_ts_output;
+          Alcotest.test_case "parse dune-project version" `Quick
+            test_parse_dune_project_version;
           Alcotest.test_case "probe failure observer increments metric" `Quick
             test_probe_failure_observer_increments_metric;
           Alcotest.test_case "git status failure increments metric" `Quick

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -121,6 +121,14 @@ let test_dashboard_tools_projection () =
         (match runtime_resolution |> member "source_mismatch" with
          | `Bool _ -> true
          | _ -> false);
+      check bool "runtime binary git commit surfaced" true
+        (match runtime_resolution |> member "runtime_binary_git_commit" with
+         | `Null | `String _ -> true
+         | _ -> false);
+      check bool "runtime repo head git commit surfaced" true
+        (match runtime_resolution |> member "runtime_repo_head_git_commit" with
+         | `Null | `String _ -> true
+         | _ -> false);
       let server_workspace_mismatch =
         match runtime_resolution |> member "server_workspace_mismatch" with
         | `Bool value -> value

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1808,6 +1808,14 @@ let test_health_json_build_exposes_runtime_binary_identity () =
   let json = Runtime.make_health_json request in
   let open Yojson.Safe.Util in
   let build = json |> member "build" in
+  check bool "build binary version populated" true
+    (String.length (build |> member "binary_version" |> to_string) > 0);
+  check bool "build commit source field present" true
+    (match build |> member "commit_source" with `Null | `String _ -> true | _ -> false);
+  check bool "build binary commit field present" true
+    (match build |> member "binary_commit" with `Null | `String _ -> true | _ -> false);
+  check bool "build repo head commit field present" true
+    (match build |> member "repo_head_commit" with `Null | `String _ -> true | _ -> false);
   check bool "build executable path populated" true
     (String.length (build |> member "executable_path" |> to_string) > 0);
   check bool "build executable dir populated" true


### PR DESCRIPTION
## Summary
- split /health build identity into binary/env commit and runtime repo HEAD fields
- keep build.commit for compatibility but add commit_source so dashboards stop treating repo HEAD as rebuild proof
- surface runtime_binary_git_commit/runtime_repo_head_git_commit in dashboard runtime resolution and only use binary commit age for stale-binary warnings

Fixes #15854

## Validation
- git diff --check origin/main...HEAD
- dune build --root . --build-dir /private/tmp/masc-mcp-health-15854-rebased lib/.masc_mcp.objs/native/masc_mcp__Build_identity.cmx lib/.masc_mcp.objs/native/masc_mcp__Server_routes_http_runtime.cmx lib/.masc_mcp.objs/native/masc_mcp__Server_runtime_bootstrap.cmx lib/.masc_mcp.objs/native/masc_mcp__Server_dashboard_http_runtime_info.cmx -j 1

## Notes
- Full suite was not run locally because this host currently has launchctl maxfiles soft=256 for GUI/launchd sessions, causing repeated FD pressure under parallel Dune. Shell/kernel limits are high, but launchctl live host default still needs sudo application.