### PR TITLE
test(keeper): update unified metrics fixture

### DIFF
--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3292,6 +3292,7 @@ let sample_tool_surface_metrics () : Masc_mcp.Keeper_agent_run.tool_surface_metr
   ; tool_surface_fallback_used = false
   ; required_tool_names = []
   ; missing_required_tool_names = []
+  ; required_tool_candidate_names = []
   ; config_root = ""
   ; cascade_config_path = None
   ; gemini_mcp_disabled = false


### PR DESCRIPTION
## Summary
- add required_tool_candidate_names to the unified keeper metrics test fixture
- keep the sample fixture aligned with Keeper_agent_run.tool_surface_metrics

## Verification
- git diff --check
- timeout 300 scripts/dune-local.sh build test/test_keeper_unified.exe