### PR TITLE
[codex] Drop policy tool known-name adapter

### DIFF
--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -226,8 +226,6 @@ let unresolved_tool_message ~label ~name =
       Some (Printf.sprintf "%s: tool '%s' unresolved: tried [%s]"
               label name (Keeper_tool_resolution.string_of_tried tried))
 
-let is_known_policy_tool_name = Keeper_tool_resolution.is_known_policy_tool_name
-
 (* Shortcut: if the caller's [base_path] already points at a project root
    that has [base_path/config/tool_policy.toml], prefer that directly.
    This is the common case when callers pass the result of

--- a/lib/keeper/keeper_tool_policy_config.mli
+++ b/lib/keeper/keeper_tool_policy_config.mli
@@ -19,12 +19,6 @@ type preset_resolution =
     Returns [Error msg] if the file is missing or malformed. *)
 val load : base_path:string -> (t, string) result
 
-(** True when [name] is valid in [tool_policy.toml]. This checks the full
-    keeper-facing policy surface, including static tag-dispatch tools and OAS
-    core tools that are not direct handler-registry entries. Exposed for
-    policy-validation tests. *)
-val is_known_policy_tool_name : string -> bool
-
 (** Resolve a preset name to its tool name list.
     Shard-backed groups are resolved via [Tool_shard] at call time.
     MASC tools are filtered through [masc_filter] if provided.

--- a/lib/keeper/keeper_tool_resolution.ml
+++ b/lib/keeper/keeper_tool_resolution.ml
@@ -1,13 +1,12 @@
-(** Keeper_tool_resolution — unified resolution behind the 15-fold OR membership check.
+(** Keeper_tool_resolution — unified policy tool-name resolution.
 
-    RFC-0080 Phase 2 shim. Wraps the existing sources behind a single [resolve]
-    function that returns a typed [resolution]. Every call site that previously
-    used [is_known_policy_tool_name] now goes through [resolve].
+    RFC-0080 Phase 2. Wraps the existing policy admission sources behind a
+    single [resolve] function that returns a typed [resolution].
 
-    Behaviour: identical short-circuit order as the original 15-fold OR in
-    [Keeper_tool_policy_config.is_known_policy_tool_name]. The first source
-    that admits the name determines the [tried_source] tag. If none admit,
-    all tried sources are collected in [Unknown.tried].
+    Behaviour: preserve the short-circuit order of the original policy
+    admission chain. The first source that admits the name determines the
+    [tried_source] tag. If none admit, all tried sources are collected in
+    [Unknown.tried].
 
     @since 2.219.0 — RFC-0080 *)
 
@@ -118,13 +117,6 @@ let resolve name =
         check_surfaces surfaces_to_check
       end
   end
-
-(* ── Legacy adapter ───────────────────────────────────────────────── *)
-
-let is_known_policy_tool_name name =
-  match resolve name with
-  | Resolved _ | Alias_to _ -> true
-  | Unknown _ -> false
 
 (* ── Phase 5: full-probe (no short-circuit) ────────────────────────── *)
 

--- a/lib/keeper/keeper_tool_resolution.mli
+++ b/lib/keeper/keeper_tool_resolution.mli
@@ -29,10 +29,6 @@ type resolution =
     Short-circuits on first hit, same order as the original 15-fold OR. *)
 val resolve : string -> resolution
 
-(** Legacy adapter: [true] if resolved or aliased, [false] if unknown.
-    Drop-in replacement for [Keeper_tool_policy_config.is_known_policy_tool_name]. *)
-val is_known_policy_tool_name : string -> bool
-
 (** Human-readable label for a single source. *)
 val string_of_tried_source : tried_source -> string
 

--- a/test/test_keeper_tool_policy_config.ml
+++ b/test/test_keeper_tool_policy_config.ml
@@ -139,34 +139,6 @@ masc_tools = ["keeper_fs_write", "keeper_fs_delete", "masc_status"]
       | Some KTPC.All_candidates -> fail "legacy preset should be explicit subset"
       | None -> fail "legacy preset missing")
 
-let test_policy_validation_knows_static_and_oas_core_tools () =
-  check bool "keeper static tag tool is known" true
-    (KTPC.is_known_policy_tool_name "keeper_board_post");
-  check bool "keeper shell alias target is known" true
-    (KTPC.is_known_policy_tool_name "keeper_shell");
-  check bool "keeper bash alias target is known" true
-    (KTPC.is_known_policy_tool_name "keeper_bash");
-  check bool "keeper public Bash alias is known" true
-    (KTPC.is_known_policy_tool_name "Bash");
-  check bool "keeper public Read alias is known" true
-    (KTPC.is_known_policy_tool_name "Read");
-  check bool "keeper task done is known" true
-    (KTPC.is_known_policy_tool_name "keeper_task_done");
-  check bool "keeper time tool is known" true
-    (KTPC.is_known_policy_tool_name "keeper_time_now");
-  check bool "masc static tag tool is known" true
-    (KTPC.is_known_policy_tool_name "masc_status");
-  check bool "mcp-prefixed masc tool is known" true
-    (KTPC.is_known_policy_tool_name "mcp__masc__masc_status");
-  check bool "masc code git tool is known" true
-    (KTPC.is_known_policy_tool_name "masc_code_git");
-  check bool "OAS core tool is known" true
-    (KTPC.is_known_policy_tool_name "extend_turns");
-  check bool "typed task completion tool is known" true
-    (KTPC.is_known_policy_tool_name "masc_complete_task");
-  check bool "unknown tool is not known" false
-    (KTPC.is_known_policy_tool_name "__missing_tool")
-
 (* ── preset_can_satisfy tests ───────────────────────────────── *)
 
 let load_config () =
@@ -250,8 +222,6 @@ let () =
             test_load_anchors_resolution_to_base_path_over_cwd_candidate;
           test_case "normalizes legacy fs tool names" `Quick
             test_load_normalizes_legacy_fs_tool_names;
-          test_case "policy validation accepts static and OAS core tools" `Quick
-            test_policy_validation_knows_static_and_oas_core_tools;
         ] );
       ( "preset_can_satisfy",
         [

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -69,19 +69,35 @@ let test_alias_masc_to_internal () =
       fail (Printf.sprintf "masc_board_post should resolve, got Unknown (tried: %s)"
               (TR.string_of_tried tried))
 
-(* ── is_known_policy_tool_name legacy adapter ── *)
+(* ── Policy validation surface ── *)
 
-let test_legacy_adapter_known () =
-  check bool "keeper_bash is known" true
-    (TR.is_known_policy_tool_name "keeper_bash");
-  check bool "Bash is known" true
-    (TR.is_known_policy_tool_name "Bash");
-  check bool "masc_status is known" true
-    (TR.is_known_policy_tool_name "masc_status")
+let resolves name =
+  match TR.resolve name with
+  | TR.Resolved _ | TR.Alias_to _ -> true
+  | TR.Unknown _ -> false
 
-let test_legacy_adapter_unknown () =
-  check bool "__missing_tool is not known" false
-    (TR.is_known_policy_tool_name "__missing_tool")
+let policy_validation_tool_names =
+  [ "keeper_board_post"
+  ; "keeper_shell"
+  ; "keeper_bash"
+  ; "Bash"
+  ; "Read"
+  ; "keeper_task_done"
+  ; "keeper_time_now"
+  ; "masc_status"
+  ; "mcp__masc__masc_status"
+  ; "masc_code_git"
+  ; "extend_turns"
+  ; "masc_complete_task"
+  ]
+
+let test_policy_validation_known_tools_resolve () =
+  List.iter
+    (fun name -> check bool (name ^ " resolves") true (resolves name))
+    policy_validation_tool_names
+
+let test_policy_validation_unknown_tool_misses () =
+  check bool "__missing_tool misses" false (resolves "__missing_tool")
 
 (* ── Phase 4: 88×15 Matrix — every tool_policy.toml tool resolves ── *)
 
@@ -201,9 +217,9 @@ let () =
         test_case "masc_code_git resolves via surface" `Quick test_surface_admits_masc_code_git;
         test_case "masc_board_post resolves via alias" `Quick test_alias_masc_to_internal;
       ]
-    ; "legacy_adapter", [
-        test_case "known tools return true" `Quick test_legacy_adapter_known;
-        test_case "unknown tools return false" `Quick test_legacy_adapter_unknown;
+    ; "policy_validation", [
+        test_case "known tools resolve" `Quick test_policy_validation_known_tools_resolve;
+        test_case "unknown tools miss" `Quick test_policy_validation_unknown_tool_misses;
       ]
     ; "matrix", [
         test_case "all policy tools resolve" `Quick test_all_policy_tools_resolve;


### PR DESCRIPTION
## Summary

- remove the public `is_known_policy_tool_name` compatibility adapter from `Keeper_tool_resolution` and `Keeper_tool_policy_config`
- keep policy validation coverage on the typed `Keeper_tool_resolution.resolve` API
- remove wrapper-only assertions from `test_keeper_tool_policy_config`

## Validation

- `rg -n "is_known_policy_tool_name|Legacy adapter" lib test -S` (0 matches)
- `opam exec -- ocamlformat --check lib/keeper/keeper_tool_resolution.ml lib/keeper/keeper_tool_resolution.mli lib/keeper/keeper_tool_policy_config.ml lib/keeper/keeper_tool_policy_config.mli test/test_keeper_tool_resolution.ml test/test_keeper_tool_policy_config.ml`
- `git diff --check HEAD~1 HEAD`
- `scripts/dune-local.sh build test/test_keeper_tool_resolution.exe test/test_keeper_tool_policy_config.exe`
- `./_build/default/test/test_keeper_tool_resolution.exe`
- `./_build/default/test/test_keeper_tool_policy_config.exe`