### PR TITLE
docs(changelog): complete 0.19.23 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@
 ### Changed
 - Promoted the RFC-0099 / RFC-0101 closeout docs to Active after the session-close and FD-accountant runtime lanes merged.
 - Bumped the downstream OAS `agent_sdk` pin to `main@79262f37` (`v0.195.0`) and raised the dependency floor to `agent_sdk >= 0.195.0`, covering the OAS body-timeout release wave.
+- Updated the unified keeper metrics fixture for the latest tool-candidate and health fields.
+- Removed the policy tool known-name adapter now that unified tool resolution owns the current path.
 
 ### Fixed
 - Streamed large JSONL restore reads and removed the keeper-health legacy alias now that callers use the current health fields.
+- Split binary build identity from repository checkout identity in `/health`, so stale executables no longer masquerade as the current checkout.
 
 ## [0.19.22] - 2026-05-17
 


### PR DESCRIPTION
## Summary
- Complete the 0.19.23 changelog entry for PRs that merged just before the release truth bump.
- Add notes for the binary/repo build identity split, unified keeper metrics fixture update, and policy tool known-name adapter removal.

## Validation
- scripts/check-version-truth.sh
- bash scripts/check-doc-truth.sh
- git diff --check