### PR TITLE
fix(fd): wire Sandbox_exec slot at non-Docker spawn callsites (RFC-0101 PR-4)

### DIFF
--- a/lib/chronicle_ingest.ml
+++ b/lib/chronicle_ingest.ml
@@ -30,11 +30,12 @@ let run_git ~timeout_sec ~workdir args =
     let argv = [ "git"; "-C"; workdir; "--no-optional-locks" ] @ args in
     let raw_source = String.concat " " (List.map Filename.quote argv) in
     Some
-      (Masc_exec.Exec_gate.run_argv_with_status
-         ~actor:(Masc_exec.Agent_id.of_string "system/chronicle_ingest")
-         ~raw_source
-         ~summary:"chronicle git log ingestion"
-         ~timeout_sec argv)
+      (Fd_accountant.with_slot ~kind:Sandbox_exec (fun () ->
+         Masc_exec.Exec_gate.run_argv_with_status
+           ~actor:(Masc_exec.Agent_id.of_string "system/chronicle_ingest")
+           ~raw_source
+           ~summary:"chronicle git log ingestion"
+           ~timeout_sec argv))
 
 let run_git_output ~workdir args =
   match run_git ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Git_meta ()) ~workdir args with

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -354,14 +354,15 @@ let spawn ~agent_name ~prompt ?timeout_seconds ?working_dir () =
     try
       let raw_output, stderr_output, status =
         let status, stdout, stderr =
-          Masc_exec.Exec_gate.run_argv_with_stdin_and_status_split
-            ~actor:(Masc_exec.Agent_id.of_string "system/spawn")
-            ~raw_source
-            ~summary:"spawn agent cli"
-            ~timeout_sec:(float_of_int timeout)
-            ?cwd
-            ~stdin_content
-            cmd_args
+          Fd_accountant.with_slot ~kind:Sandbox_exec (fun () ->
+            Masc_exec.Exec_gate.run_argv_with_stdin_and_status_split
+              ~actor:(Masc_exec.Agent_id.of_string "system/spawn")
+              ~raw_source
+              ~summary:"spawn agent cli"
+              ~timeout_sec:(float_of_int timeout)
+              ?cwd
+              ~stdin_content
+              cmd_args)
         in
         (stdout, stderr, status)
       in

--- a/lib/tool_local_runtime_http.ml
+++ b/lib/tool_local_runtime_http.ml
@@ -62,12 +62,13 @@ let http_get_text_with_status_with_headers ?(timeout_sec = default_timeout_sec) 
       headers
   in
   let status, body =
-    Masc_exec.Exec_gate.run_argv_with_status
-      ~actor:(Masc_exec.Agent_id.of_string "tool/local_runtime")
-      ~raw_source:(String.concat " " (List.map Filename.quote argv))
-      ~summary:"tool local runtime http get"
-      ~timeout_sec:(Stdlib.Float.of_int (max 1 timeout_sec))
-      argv
+    Fd_accountant.with_slot ~kind:Sandbox_exec (fun () ->
+      Masc_exec.Exec_gate.run_argv_with_status
+        ~actor:(Masc_exec.Agent_id.of_string "tool/local_runtime")
+        ~raw_source:(String.concat " " (List.map Filename.quote argv))
+        ~summary:"tool local runtime http get"
+        ~timeout_sec:(Stdlib.Float.of_int (max 1 timeout_sec))
+        argv)
   in
   match status with
   | Unix.WEXITED 0 ->
@@ -111,12 +112,13 @@ let http_post_json_text_with_status_with_headers ~timeout_sec ?(headers = []) ~u
       headers
   in
   let status, body =
-    Masc_exec.Exec_gate.run_argv_with_status
-      ~actor:(Masc_exec.Agent_id.of_string "tool/local_runtime")
-      ~raw_source:(String.concat " " (List.map Filename.quote argv))
-      ~summary:"tool local runtime http post"
-      ~timeout_sec:(Stdlib.Float.of_int (max 1 timeout_sec))
-      argv
+    Fd_accountant.with_slot ~kind:Sandbox_exec (fun () ->
+      Masc_exec.Exec_gate.run_argv_with_status
+        ~actor:(Masc_exec.Agent_id.of_string "tool/local_runtime")
+        ~raw_source:(String.concat " " (List.map Filename.quote argv))
+        ~summary:"tool local runtime http post"
+        ~timeout_sec:(Stdlib.Float.of_int (max 1 timeout_sec))
+        argv)
   in
   match status with
   | Unix.WEXITED 0 ->

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -1681,29 +1681,30 @@ let make_shell_exec_with_allowlist
                let result =
                  try
                    let status, output =
-                     Eio.Time.with_timeout_exn clock timeout (fun () ->
-                       Eio.Switch.run
-                       @@ fun sw ->
-                       let stdout_r, stdout_w = Eio.Process.pipe ~sw proc_mgr in
-                       let proc =
-                         Eio.Process.spawn
-                           ~sw
-                           proc_mgr
-                           ~stdout:stdout_w
-                           [ "sh"; "-c"; wrapped_command ^ " 2>&1" ]
-                       in
-                       Eio.Flow.close stdout_w;
-                       (try
-                          Eio.Flow.copy stdout_r (Eio.Flow.buffer_sink buf);
-                          Eio.Flow.close stdout_r
-                        with
-                        | Eio.Cancel.Cancelled _ as e ->
-                          (try Eio.Flow.close stdout_r with
-                           | Eio.Cancel.Cancelled _ as ce -> raise ce
-                           | _ -> ());
-                          raise e);
-                       let status = Eio.Process.await proc in
-                       status, Buffer.contents buf)
+                     Fd_accountant.with_slot ~kind:Sandbox_exec (fun () ->
+                       Eio.Time.with_timeout_exn clock timeout (fun () ->
+                         Eio.Switch.run
+                         @@ fun sw ->
+                         let stdout_r, stdout_w = Eio.Process.pipe ~sw proc_mgr in
+                         let proc =
+                           Eio.Process.spawn
+                             ~sw
+                             proc_mgr
+                             ~stdout:stdout_w
+                             [ "sh"; "-c"; wrapped_command ^ " 2>&1" ]
+                         in
+                         Eio.Flow.close stdout_w;
+                         (try
+                            Eio.Flow.copy stdout_r (Eio.Flow.buffer_sink buf);
+                            Eio.Flow.close stdout_r
+                          with
+                          | Eio.Cancel.Cancelled _ as e ->
+                            (try Eio.Flow.close stdout_r with
+                             | Eio.Cancel.Cancelled _ as ce -> raise ce
+                             | _ -> ());
+                            raise e);
+                         let status = Eio.Process.await proc in
+                         status, Buffer.contents buf))
                    in
                    match status with
                    | `Exited 0 -> Ok { Agent_sdk.Types.content = output }

--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -35,12 +35,13 @@ let run_git_capture_lines_once ~workdir args =
     let argv = [ "git"; "-C"; workdir ] @ args in
     let raw_source = String.concat " " (List.map Filename.quote argv) in
     match
-      Masc_exec.Exec_gate.run_argv_with_status
-        ~actor:(Masc_exec.Agent_id.of_string "system/worktree_live_context")
-        ~raw_source
-        ~summary:"worktree live context git capture"
-        ~timeout_sec:(git_status_timeout_sec ())
-        argv
+      Fd_accountant.with_slot ~kind:Sandbox_exec (fun () ->
+        Masc_exec.Exec_gate.run_argv_with_status
+          ~actor:(Masc_exec.Agent_id.of_string "system/worktree_live_context")
+          ~raw_source
+          ~summary:"worktree live context git capture"
+          ~timeout_sec:(git_status_timeout_sec ())
+          argv)
     with
     | Unix.WEXITED 0, output ->
         Some


### PR DESCRIPTION
## Summary

RFC-0101 PR-2 (#15816) generalized `Docker_spawn_throttle` into a 4-kind `Fd_accountant`, but only the `Docker_spawn` arm was wired. The other three kinds (`Provider_http`, `Sandbox_exec`, `Log_writer`) were declared as variants with **zero call sites** — leaving Sandbox_exec spawn cost unbounded on the same `kern.maxfiles` ceiling that Docker_spawn shares.

Under cascade-failure storm (2026-05-16 ENFILE incident), non-Docker subprocess spawns (git, curl, sh -c) contributed to FD exhaustion alongside Docker class. Throttling `Docker_spawn` alone is necessary but not sufficient.

## Changes (6 wrap sites in 5 files, +60/-54)

Each callsite was already passing FDs (popen pipes or Eio.Process pipes) with no slot accounting. Wraps mirror the `Docker_spawn_throttle` pattern: hold slot from spawn through reap, release on completion.

- `lib/spawn.ml:357` — agent CLI spawn
- `lib/chronicle_ingest.ml:33` — git log ingestion
- `lib/worktree_live_context.ml:38` — worktree git capture
- `lib/tool_local_runtime_http.ml:65,115` — local runtime curl GET + POST
- `lib/worker_dev_tools.ml:1684` — `sh -c` worker exec via `Eio.Process.spawn`

## Out of scope (separate PRs)

- **`lib/coord/*`** — `masc_coord` sublibrary; `Fd_accountant` lives in `masc_mcp` main lib (circular dep). Needs leaf-extraction of `Fd_accountant` first (PR-5a).
- **`lib/repo_manager/repo_store.ml`** — same sublib constraint (PR-5a).
- **`lib/server/lsp_process_manager.ml`** — long-lived process; needs lifetime cost model, not spawn-rate model.
- **`oas/lib/llm_provider/backend_*.ml`** — Provider_http; already PR-3 merged via oas #1618.
- **`Log_writer` kind** — PR-5b, requires Microlog/JSONL audit.

## Verification

- `dune build @check`: passes
- `rg 'Fd_accountant\.with_slot.*Sandbox_exec'`: 6 sites in 5 files (matches diff)
- Build clean on `_build/default`, no warning regressions

## Known limitation (out of PR-4 scope)

`Fd_accountant._shared_pressure_mutex` is `Eio.Mutex` — not re-entrant. Nested `with_slot` of different kinds while `Keeper_fd_pressure.active ()` is true could deadlock. None of the new wrap sites are reachable from inside an existing `with_slot` frame, but the structural risk exists — track for RFC-0101 PR-6 hardening.

## Refs

- RFC-0101 (Active) — `docs/rfc/RFC-0101-fd-accountant-generic-pool.md`
- PR-2 #15816 (Fd_accountant scaffold merged)
- RFC body line: "(prereq #15727 + PR-2 #15816 + PR-3 oas #1618 merged; **PR-4/5/6 pending**)"
- 2026-05-16 storm root-fix series: #15678, #15727, #15728, #15762, #15769, #15773, #15816, #15843, #15872

RFC-WAIVED: no subsystem from `pr-rfc-check.sh` allowlist touched (spawn / chronicle / worktree_live_context / tool_local_runtime_http / worker_dev_tools). RFC-0101 already covers this work; this PR is a wiring extension of the merged scaffold.

## Test plan
- [ ] CI green on `dune build`, `dune runtest`
- [ ] Manual: 64-keeper fleet stress with cascade-failure injection — observe `Fd_accountant.in_flight Sandbox_exec` rises to cap (32) instead of unbounded
- [ ] No regression in non-stressed workloads (slot is uncontended at low concurrency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)