### PR TITLE
fix(bg_task): typed split for drain_fd_to_buf silent error swallow (iter 30)

### DIFF
--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -92,6 +92,29 @@ let sidecar_failure_observer :
 let set_sidecar_failure_observer f =
   Atomic.set sidecar_failure_observer (Some f)
 
+(* Observer for unexpected (non-EAGAIN/EWOULDBLOCK/EINTR/EOF)
+   drain-pipe read errors.  Labels are closed-vocabulary:
+   [fd_kind = "stdout" | "stderr"] (call-site tagged) and
+   [error_kind = "unix_error" | "other"] (typed match arm).
+   Cardinality bound: 2 × 2 = 4.  See top-level Prometheus
+   module for the registered counter. *)
+let drain_failure_observer :
+    ((fd_kind:string -> error_kind:string -> unit) option) Atomic.t =
+  Atomic.make None
+
+let set_drain_failure_observer f =
+  Atomic.set drain_failure_observer (Some f)
+
+let observe_drain_failure ~fd_kind ~error_kind =
+  match Atomic.get drain_failure_observer with
+  | None -> ()
+  | Some observe ->
+      (try observe ~fd_kind ~error_kind with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | observer_exn ->
+           Log.Misc.warn "bg_task drain observer failed: %s"
+             (Printexc.to_string observer_exn))
+
 let observe_sidecar_failure ~site exn =
   match exn with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -220,9 +243,35 @@ let trim_buffer_to_ring buf base_offset =
     base_offset + drop_len
   end
 
-(* [drain_fd_to_buf buf fd] reads every byte currently available on
-   [fd] without blocking. Returns [true] if EOF was observed. *)
-let drain_fd_to_buf buf fd =
+(* [drain_fd_to_buf ~fd_kind buf fd] reads every byte currently
+   available on [fd] without blocking. Returns [true] if EOF was
+   observed.
+
+   The previous implementation collapsed every non-EAGAIN/EINTR
+   exception into a permissive [true] (EOF), silently misreporting
+   genuine read errors (EBADF, EIO, ENOMEM, ENOSPC, …) as clean
+   close.  This typed split:
+
+   - Re-raises [Eio.Cancel.Cancelled] so cancellation propagates
+     through the enclosing switch.
+   - Splits [Unix.Unix_error] (anything that isn't EAGAIN /
+     EWOULDBLOCK / EINTR) into a distinct arm: tick the
+     drain-failure counter with [error_kind = "unix_error"] and a
+     bounded warn naming the [errno].  EBADF/EIO/ENOMEM are the
+     most likely realistic failure modes here and are forensically
+     valuable.
+   - Final arm: any other exception ticks with
+     [error_kind = "other"] and a bounded warn carrying
+     [Printexc.to_string] in the log body only (closed-vocab
+     label).
+
+   Returning [true] in the failure arms preserves the existing
+   operational behavior (the caller advances [stdout_eof] /
+   [stderr_eof] and eventually closes the FD).  This is a
+   deliberate conservative choice — flipping it to [false] would
+   change reap semantics and belongs in a future RFC, not in this
+   visibility patch. *)
+let drain_fd_to_buf ~fd_kind buf fd =
   let chunk = Bytes.create 4096 in
   let rec loop () =
     let readable =
@@ -237,7 +286,19 @@ let drain_fd_to_buf buf fd =
       | n -> Buffer.add_subbytes buf chunk 0 n; loop ()
       | exception Unix.Unix_error ((Unix.EAGAIN | Unix.EWOULDBLOCK), _, _) -> false
       | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
-      | exception _ -> true
+      | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+      | exception Unix.Unix_error (errno, fn, _) ->
+          Log.Misc.warn
+            "bg_task drain_fd_to_buf %s Unix_error in %s: %s"
+            fd_kind fn (Unix.error_message errno);
+          observe_drain_failure ~fd_kind ~error_kind:"unix_error";
+          true
+      | exception exn ->
+          Log.Misc.warn
+            "bg_task drain_fd_to_buf %s unexpected exception: %s"
+            fd_kind (Printexc.to_string exn);
+          observe_drain_failure ~fd_kind ~error_kind:"other";
+          true
   in
   loop ()
 
@@ -247,13 +308,19 @@ let poll_state st =
   if st.closed then ()
   else begin
     if not st.stdout_eof then begin
-      let eof = drain_fd_to_buf st.stdout_buf st.handle.stdout_fd in
+      let eof =
+        drain_fd_to_buf ~fd_kind:"stdout"
+          st.stdout_buf st.handle.stdout_fd
+      in
       st.stdout_base_offset <-
         trim_buffer_to_ring st.stdout_buf st.stdout_base_offset;
       st.stdout_eof <- eof
     end;
     if not st.stderr_eof then begin
-      let eof = drain_fd_to_buf st.stderr_buf st.handle.stderr_fd in
+      let eof =
+        drain_fd_to_buf ~fd_kind:"stderr"
+          st.stderr_buf st.handle.stderr_fd
+      in
       st.stderr_base_offset <-
         trim_buffer_to_ring st.stderr_buf st.stderr_base_offset;
       st.stderr_eof <- eof

--- a/lib/process/bg_task.mli
+++ b/lib/process/bg_task.mli
@@ -128,6 +128,22 @@ val set_sidecar_failure_observer : (site:string -> exn -> unit) -> unit
     [masc_bg_task_sidecar_failures_total]; [bg_task] keeps the hook here
     to avoid a lower-library dependency cycle. *)
 
+val set_drain_failure_observer :
+  (fd_kind:string -> error_kind:string -> unit) -> unit
+(** Install the process-local observer for unexpected (non-EAGAIN /
+    EWOULDBLOCK / EINTR / EOF) errors raised by [Unix.read] inside
+    [drain_fd_to_buf].  The top-level Prometheus module wires this to
+    [masc_bg_task_drain_unexpected_errors_total].
+
+    Labels are closed-vocabulary and cardinality-bounded:
+    - [fd_kind] is either ["stdout"] or ["stderr"] (call-site tagged).
+    - [error_kind] is either ["unix_error"] (a [Unix.Unix_error] that
+      is neither EAGAIN/EWOULDBLOCK nor EINTR — e.g. EBADF, EIO,
+      ENOMEM) or ["other"] (any other exception).
+
+    Cancellation ([Eio.Cancel.Cancelled]) is re-raised inside the
+    drain loop and never reaches the observer. *)
+
 val reap_orphans : base_path:string -> int
 (** Startup hook: read PID files under \`.masc/keeper/*/bg/*.pid\`,
     SIGKILL any pgroup whose leader is no longer in the live task

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -907,6 +907,14 @@ let metric_runtime_ollama_probe_generate_skips =
 
 let metric_process_timeout = "masc_process_timeout_total"
 let metric_bg_task_sidecar_failures = "masc_bg_task_sidecar_failures_total"
+(* iter 30: typed split for [Bg_task.drain_fd_to_buf] silent error
+   swallow.  Previously every non-EAGAIN/EWOULDBLOCK/EINTR exception
+   was collapsed into a permissive EOF, hiding real read errors
+   (EBADF, EIO, ENOMEM, …).  Labels are closed-vocabulary:
+   [fd_kind = stdout | stderr] × [error_kind = unix_error | other],
+   cardinality 4. *)
+let metric_bg_task_drain_unexpected_errors =
+  "masc_bg_task_drain_unexpected_errors_total"
 let metric_build_identity_probe_failures = "masc_build_identity_probe_failures_total"
 let metric_distributed_lock_acquire_failed = "masc_distributed_lock_acquire_failed_total"
 
@@ -2451,6 +2459,17 @@ let init () =
     Counter;
   Bg_task.set_sidecar_failure_observer (fun ~site _exn ->
     inc_counter metric_bg_task_sidecar_failures ~labels:[ "site", site ] ());
+  add
+    metric_bg_task_drain_unexpected_errors
+    "Total unexpected (non-EAGAIN/EWOULDBLOCK/EINTR/EOF) errors raised by \
+     Unix.read inside Bg_task.drain_fd_to_buf. Labeled by \
+     fd_kind=stdout|stderr and error_kind=unix_error|other. A non-zero \
+     rate indicates the previous silent-EOF fallback would have hidden a \
+     real read error and lost output between the error and process exit."
+    Counter;
+  Bg_task.set_drain_failure_observer (fun ~fd_kind ~error_kind ->
+    inc_counter metric_bg_task_drain_unexpected_errors
+      ~labels:[ "fd_kind", fd_kind; "error_kind", error_kind ] ());
   add
     metric_build_identity_probe_failures
     "Total build identity git probe failures. Labeled by \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -824,6 +824,17 @@ val metric_process_timeout : string
     [site] = [write | read | read_parse | readdir | is_dir | unlink]. *)
 val metric_bg_task_sidecar_failures : string
 
+(** iter 30: unexpected (non-EAGAIN / EWOULDBLOCK / EINTR / EOF)
+    errors raised by [Unix.read] inside [Bg_task.drain_fd_to_buf].
+    Replaces the previous silent-EOF catch-all that hid genuine read
+    errors (EBADF, EIO, ENOMEM, …) and lost any output between the
+    error and process exit.  Labels are closed-vocabulary and
+    cardinality-bounded:
+    - [fd_kind] = [stdout | stderr] (call-site tagged).
+    - [error_kind] = [unix_error | other] (typed match arm).
+    Total cardinality: 4. *)
+val metric_bg_task_drain_unexpected_errors : string
+
 (** Build identity git probe failures. Labels:
     [site] = [commit_ts_git_capture | commit_ts_git_status | commit_ts_parse]. *)
 val metric_build_identity_probe_failures : string


### PR DESCRIPTION
## Summary

`lib/process/bg_task.ml` line 240 had `| exception _ -> true` — a permissive default that silently reported EOF on *any* unexpected `Unix.read` error (EBADF, EIO, ENOMEM, ENOSPC, …). `poll_state` then advanced `stdout_eof`/`stderr_eof` and ultimately `closed`, releasing the FDs and *permanently dropping any output between the error and process exit*. This is the same OAS #555 "Unknown → Permissive Default" anti-pattern that produced iter 28 / iter 29.

## Root fix (single atomic)

Replace the catch-all with a typed split:

- `Eio.Cancel.Cancelled _ as e -> raise e` — preserve cancellation
- `Unix.Unix_error (errno, fn, _)` — bounded warn naming syscall + errno, counter tick with `error_kind = \"unix_error\"`
- Final `exn` terminal — bounded warn with `Printexc.to_string` in log body only, counter tick with `error_kind = \"other\"`

`fd_kind` (\`stdout\`/\`stderr\`) tagged at the two `poll_state` call sites. Cardinality bound: 2 × 2 = 4.

Returning `true` is a *deliberate conservative choice* — flipping to `false` is semantically more correct for transient errors but risks infinite polling on permanently broken FDs (EBADF). The right separation requires a typed errno classifier RFC; out of scope for this visibility patch.

## What changed

| File | Diff | Notes |
|---|---|---|
| `lib/process/bg_task.ml` | +73 / -3 | Typed split + `fd_kind` parameter + observer indirection |
| `lib/process/bg_task.mli` | +16 / -0 | `set_drain_failure_observer` exposed (mirrors `set_sidecar_failure_observer`) |
| `lib/prometheus.ml` | +19 / -0 | New constant + `Counter.add` + observer wiring in `init ()` |
| `lib/prometheus.mli` | +11 / -0 | Constant exposed + docstring |

Observer indirection (`set_drain_failure_observer`) keeps the leaf `bg_task` library Prometheus-free — same pattern as the existing `set_sidecar_failure_observer`.

## Same-pattern precedent

- **iter 28** PR #15820 (mcp-ws transport silent JSON parse) — MERGED
- **iter 29** PR #15840 (cascade_http_probe silent JSON parse) — MERGED
- **iter 31** PR #15866 (sidecar schema_field_types silent JSON parse) — MERGED

This is the third silent-fd / silent-parse class in the same audit pass.

## RFC

Not a mandatory subsystem (\`lib/process/bg_task.ml\` is not credential/identity/operator/sandbox/hooks/workflow). \`pr-rfc-check.sh\` exit 0.

## Test plan

- [x] \`dune build --root . @check\` — clean (rebased onto current origin/main)
- [x] No new test required; behavior preserved on normal paths
- [ ] Counter visibility: \`curl /metrics | grep bg_task_drain\` after a process with deliberate FD close (post-merge soak)

## Anti-pattern self-check (7/7)

1. Telemetry-as-fix? **Partly** (visibility for silent drop); iter 6/21/28/29/31 precedent.
2. String classifier? **NO** — typed \`Unix.Unix_error\` constructor match.
3. N-of-M? **NO** — single function, single observer site.
4. Catch-all added? **NO** — existing \`_\` *replaced* with 3 typed arms.
5. Cap/cooldown/dedup/repair? **NO**.
6. Test backdoor? **NO**.
7. Repeat typo? **NO**.

## Recovery context

This PR is a *takeover* of an orphaned background agent (iter 30) whose work completed (~119 LoC across 4 files, full 7/7 self-check satisfied) but whose commit/push step stalled in a previous session. After 75+ minutes silent, the worktree (\`.worktrees/fix/bg-task-drain-fd-silent-visibility\`) was discovered to contain valid uncommitted output. Rebased onto current origin/main, build verified, then committed/pushed by the current session. Zero work lost.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)