### PR TITLE
[codex] fail closed schema-less tool validation

### DIFF
--- a/docs/spec/00-glossary.md
+++ b/docs/spec/00-glossary.md
@@ -318,13 +318,13 @@ Streamable HTTP 엔드포인트에서 노출되는 도구 집합의 프로필: `
 O(1) Hashtbl 기반의 중앙 도구 라우팅 레지스트리. 각 Tool 모듈이 클로저를 등록하고, 호출 시 이름으로 O(1) 조회하여 실행한다. Pre-hook/Post-hook 체인을 지원한다. `-> lib/tool_dispatch.mli`
 
 **Handler**
-도구 호출 처리 함수의 통합 타입: `name:string -> args:Yojson.Safe.t -> (bool * string) option`. `None`은 해당 핸들러가 이 도구를 모르는 경우를 나타낸다. `-> lib/tool_dispatch.mli`
+도구 호출 처리 함수의 통합 타입: `name:string -> args:Yojson.Safe.t -> Tool_result.t option`. `None`은 해당 핸들러가 이 도구를 모르는 경우를 나타낸다. `-> lib/tool_dispatch.mli`
 
 **Pre-hook**
-도구 핸들러 실행 전 호출되는 가로채기 함수. `None` 반환 시 진행, `Some result` 반환 시 핸들러를 건너뛰고 단축 반환한다. Governance Pipeline이 pre-hook으로 설치된다. `-> lib/tool_dispatch.mli`
+도구 핸들러 실행 전 호출되는 가로채기 함수. `Pass`는 진행, `Proceed args`는 정규화/강제 변환 후 진행, `Reject result`는 핸들러를 건너뛰고 단축 반환한다. Governance Pipeline과 input validation이 pre-hook으로 설치된다. `-> lib/tool_dispatch.mli`
 
 **Post-hook**
-도구 핸들러 실행 후 호출되는 변환 함수. 결과를 수신하여 (변환된) 결과를 반환한다. `-> lib/tool_dispatch.mli`
+도구 핸들러 실행 후 호출되는 typed 관찰 hook. 결과 변환은 별도 `result_transformer`가 담당한다. `-> lib/tool_dispatch.mli`
 
 **Module Tag**
 도구 이름에서 담당 모듈로의 O(1) 2-level 디스패치를 위한 태그. 시작 시 도구 이름 -> 모듈 태그 매핑이 구축되고, 호출 시 태그로 모듈 컨텍스트를 lazy 생성한다. `-> lib/tool_dispatch.mli`

--- a/docs/spec/02-types-and-invariants.md
+++ b/docs/spec/02-types-and-invariants.md
@@ -356,22 +356,27 @@ Result alias: `type 'a masc_result = ('a, masc_error) result`
 ### 4.1 Handler
 
 ```ocaml
-type handler = name:string -> args:Yojson.Safe.t -> (bool * string) option
+type handler = name:string -> args:Yojson.Safe.t -> Tool_result.t option
 ```
 
-모든 MCP 도구 호출은 이 시그니처로 통일된다. `None`을 반환하면 "이 핸들러가 해당 도구를 모른다"는 의미다.
+모든 MCP 도구 호출은 typed `Tool_result.t` 시그니처로 통일된다. `None`을 반환하면 "이 핸들러가 해당 도구를 모른다"는 의미다.
 
 ### 4.2 Hooks
 
 ```ocaml
-type pre_hook = name:string -> args:Yojson.Safe.t -> Tool_result.t option
-(* None -> 진행, Some result -> 핸들러를 건너뛰고 즉시 반환 *)
+type pre_hook_action =
+  | Pass
+  | Proceed of Yojson.Safe.t
+  | Reject of Tool_result.t
 
-type post_hook = Tool_result.t -> Tool_result.t
-(* 핸들러 결과를 변환하거나 관찰 *)
+type pre_hook = name:string -> args:Yojson.Safe.t -> pre_hook_action
+(* Pass -> 진행, Proceed -> args 교체 후 진행, Reject -> 즉시 반환 *)
+
+type post_hook_typed = Dispatch_outcome.t -> Tool_result.t option -> unit
+(* typed outcome 관찰 전용. 결과 변환은 result_transformer가 담당한다. *)
 ```
 
-실행 순서: pre_hooks -> handler -> post_hooks.
+실행 순서: telemetry span -> pre_hooks -> handler -> result_transformer -> typed_post_hooks.
 
 ### 4.3 Module Tag (2-level dispatch)
 
@@ -407,7 +412,7 @@ type t = {
 }
 ```
 
-레거시 `(bool * string)` 튜플은 `wrap ~tool_name ~start_time`으로 변환된다. `to_legacy`로 역변환이 가능하다.
+도구 핸들러는 `Tool_result.t`를 직접 반환한다. 기존 `(bool * string)` 튜플 기반 dispatch 계약은 제거됐고, 문자열 메시지는 호환 필드 `legacy_message`에만 남는다.
 
 ---
 

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -17,11 +17,13 @@ module Float = Stdlib.Float
 
 (** OAS boundary adapter for tool results, schemas, and tool definitions.
 
-    MASC tools use [(bool * string)] internally (success flag + message).
-    OAS uses [Agent_sdk.Types.tool_result = (tool_output, tool_error) Result.t].
+    MASC dispatch uses typed [Tool_result.t] internally.  Some older leaf
+    helpers still expose [(bool * string)] locally; this module is the boundary
+    adapter that converts those leaf results to/from
+    [Agent_sdk.Types.tool_result = (tool_output, tool_error) Result.t].
 
-    This module converts at the OAS boundary only — internal MASC
-    tool handlers keep their existing convention unchanged.
+    Central [Tool_dispatch.handler] implementations should return
+    [Tool_result.t] directly rather than reintroducing tuple dispatch.
 
     @since 2.95.1 — result conversion
     @since 2.110.0 — schema conversion + OAS Tool.t creation

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -19,13 +19,10 @@ val register_module : schemas:Masc_domain.tool_schema list -> handler:handler ->
 
 (** {1 Dispatch} *)
 
-(* RFC-0084 PR-11 — [val dispatch] removed from the public mli surface.
-   External callers MUST use [guarded_dispatch] (see below) which wraps
-   the same handler-registry path with [Tool_telemetry.with_span] and
-   the pre-hook chain. [dispatch] remains in [tool_dispatch.ml] as a
-   private implementation detail used by [guarded_dispatch] internally;
-   PR-14 lint asserts the public surface has zero callers of [dispatch]
-   in [lib/] and [bin/]. *)
+(* RFC-0084 PR-11/14 — [dispatch] and [dispatch_structured] were removed from
+   the public surface and the file-private chain. External callers MUST use
+   [guarded_dispatch], which owns telemetry, pre-hooks, handler execution,
+   result transformation, and typed post-hook fan-out. *)
 
 val mint_token : name:string -> (Tool_token.t, string) Result.t
 (** Mint a [Tool_token.t] validated against both tag and handler registries.
@@ -126,47 +123,17 @@ val run_typed_post_hooks :
     [Handled] arm, [None] otherwise).  Sole observer-side dispatch
     seam after PR-I-3 retired the legacy [run_post_hooks]. *)
 
-(* RFC-0084 PR-11 — [val dispatch_structured] removed from the public mli
-   surface. PR-7~9 migration verified external callers = 0 (rg in lib/ +
-   bin/). [dispatch_structured] remains in [tool_dispatch.ml] as a
-   private implementation detail invoked exclusively by
-   [guarded_dispatch] to run the pre-hook chain. *)
-
 val guarded_dispatch
   :  token:Tool_token.t
   -> args:Yojson.Safe.t
   -> unit
   -> Tool_result.t option
-(** RFC-0084 §2.2 — Single dispatch entry with 4-tuple telemetry.
+(** RFC-0084 §2.2 — Single dispatch entry with 4-label telemetry.
 
-    Wraps [dispatch] with [Tool_telemetry.with_span], so every
-    invocation emits an OTel span, a Prometheus counter increment, and a
-    [trace_id] thunk available to the handler. The audit emission slot is
-    filled by callers based on the returned [Tool_result.t option]; PR-10
-    will unify audit emission via a typed [Dispatch_outcome.t].
-
-    PR-3 introduces this entry. No callers migrate in this PR. Migration
-    plan: PR-7 keeper turn, PR-8 MCP server, PR-9 tag-dispatch fallback.
-    PR-11 removes [dispatch] and [dispatch_structured] in favour of this
-    single path. *)
-
-val guarded_dispatch
-  :  token:Tool_token.t
-  -> args:Yojson.Safe.t
-  -> unit
-  -> Tool_result.t option
-(** RFC-0084 §2.2 — Single dispatch entry with 4-tuple telemetry.
-
-    Wraps [dispatch] with [Tool_telemetry.with_span], so every
-    invocation emits an OTel span, a Prometheus counter increment, and a
-    [trace_id] thunk available to the handler. The audit emission slot is
-    filled by callers based on the returned [Tool_result.t option]; PR-10
-    will unify audit emission via a typed [Dispatch_outcome.t].
-
-    PR-3 introduces this entry. No callers migrate in this PR. Migration
-    plan: PR-7 keeper turn, PR-8 MCP server, PR-9 tag-dispatch fallback.
-    PR-11 removes [dispatch] and [dispatch_structured] in favour of this
-    single path. *)
+    Owns [Tool_telemetry.with_span], the pre-hook chain, handler lookup,
+    exception capture, result transformation, and typed post-hook fan-out.
+    The dispatch return is typed [Tool_result.t option]; the old
+    [dispatch]/[dispatch_structured] entry points are gone. *)
 
 (** {1 Introspection} *)
 

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -26,7 +26,8 @@ module Float = Stdlib.Float
 (** Register input validation as a Tool_dispatch pre-hook.
     Must be called after all tool schemas are registered (server init).
 
-    Tools without a registered schema are allowed through (permissive). *)
+    Tools without a registered schema are rejected fail-closed.  Empty
+    schemas are accepted only for empty/no-arg calls. *)
 let is_internal_marker_key key = String.length key > 0 && Char.equal key.[0] '_'
 
 let strip_internal_marker_args (args : Yojson.Safe.t) : Yojson.Safe.t =
@@ -129,6 +130,11 @@ let schema_has_properties = function
   | _ -> false
 ;;
 
+let empty_tool_args = function
+  | `Null | `Assoc [] -> true
+  | _ -> false
+;;
+
 let emit_validation_telemetry ~tool ~result ~reason =
   Prometheus.inc_counter
     Prometheus.metric_tool_input_validation
@@ -146,19 +152,32 @@ let emit_validation_telemetry ~tool ~result ~reason =
 
 let pass_reason ~schema ~args ~prepared_args =
   match schema with
-  | None -> "missing_schema"
   | Some schema when not (schema_has_properties schema) -> "empty_schema"
   | Some _ when not (Yojson.Safe.equal prepared_args args) -> "normalized"
   | Some _ -> "valid"
-;;
-
-let pass_result = function
-  | "missing_schema" | "empty_schema" -> "bypass"
-  | _ -> "pass"
+  | None -> "missing_schema"
 ;;
 
 let validation_schema_of_json ~name json_schema : Agent_sdk.Types.tool_schema =
   { name; description = ""; parameters = Tool_bridge.params_of_json_schema json_schema }
+;;
+
+let reject_validation ~name ~reason ~message =
+  emit_validation_telemetry ~tool:name ~result:"fail" ~reason;
+  Log.info "tool_input_validation rejected %s: %s" name message;
+  Tool_dispatch.Reject
+    { Tool_result.success = false
+    ; data =
+        `Assoc
+          [ "error", `String message
+          ; "validation", `String "oas_tool_middleware"
+          ; "reason", `String reason
+          ]
+    ; legacy_message = message
+    ; tool_name = name
+    ; duration_ms = 0.0
+    ; failure_class = Some Tool_result.Policy_rejection
+    }
 ;;
 
 let validation_exception_action ~name exn : Tool_dispatch.pre_hook_action =
@@ -188,32 +207,65 @@ let validation_exception_action ~name exn : Tool_dispatch.pre_hook_action =
 
 let validation_action ?schema ~name ~args () : Tool_dispatch.pre_hook_action =
   try
-    let lookup name =
-      let schema =
-        match schema with
-        | Some schema -> Some schema
-        | None -> Tool_dispatch.lookup_schema name
-      in
-      Option.map (validation_schema_of_json ~name) schema
-    in
-    let hook = Agent_sdk.Tool_middleware.make_validation_hook ~lookup in
     let schema =
       match schema with
       | Some _ as schema -> schema
       | None -> Tool_dispatch.lookup_schema name
     in
     let prepared_args = prepare_args ?schema ~name args in
-    match hook ~name ~args:prepared_args with
+    match schema with
+    | None ->
+      reject_validation
+        ~name
+        ~reason:"missing_schema"
+        ~message:
+          (Printf.sprintf
+             "Tool '%s' has no registered input schema; refusing schema-less dispatch"
+             name)
+    | Some schema when not (schema_has_properties schema) ->
+      let required = required_names schema in
+      if required <> []
+      then
+        reject_validation
+          ~name
+          ~reason:"malformed_schema"
+          ~message:
+            (Printf.sprintf
+               "Tool '%s' schema declares required fields without input properties"
+               name)
+      else if empty_tool_args prepared_args
+      then (
+        emit_validation_telemetry ~tool:name ~result:"pass" ~reason:"empty_schema";
+        if Yojson.Safe.equal prepared_args args
+        then Tool_dispatch.Pass
+        else Tool_dispatch.Proceed prepared_args)
+      else
+        reject_validation
+          ~name
+          ~reason:"empty_schema_args"
+          ~message:
+            (Printf.sprintf
+               "Tool '%s' declares no input fields but received arguments"
+               name)
+    | Some schema ->
+      let lookup lookup_name =
+        let schema_opt =
+          if String.equal lookup_name name
+          then Some schema
+          else Tool_dispatch.lookup_schema lookup_name
+        in
+        Option.map (validation_schema_of_json ~name:lookup_name) schema_opt
+      in
+      let hook = Agent_sdk.Tool_middleware.make_validation_hook ~lookup in
+      (match hook ~name ~args:prepared_args with
     | Agent_sdk.Tool_middleware.Pass when not (Yojson.Safe.equal prepared_args args) ->
-      let reason = pass_reason ~schema ~args ~prepared_args in
-      let result = pass_result reason in
-      emit_validation_telemetry ~tool:name ~result ~reason;
+      let reason = pass_reason ~schema:(Some schema) ~args ~prepared_args in
+      emit_validation_telemetry ~tool:name ~result:"pass" ~reason;
       Log.debug "tool_input_validation normalized args for %s" name;
       Tool_dispatch.Proceed prepared_args
     | Agent_sdk.Tool_middleware.Pass ->
-      let reason = pass_reason ~schema ~args ~prepared_args in
-      let result = pass_result reason in
-      emit_validation_telemetry ~tool:name ~result ~reason;
+      let reason = pass_reason ~schema:(Some schema) ~args ~prepared_args in
+      emit_validation_telemetry ~tool:name ~result:"pass" ~reason;
       Tool_dispatch.Pass
     | Agent_sdk.Tool_middleware.Proceed coerced ->
       emit_validation_telemetry ~tool:name ~result:"pass" ~reason:"coerced";
@@ -235,6 +287,7 @@ let validation_action ?schema ~name ~args () : Tool_dispatch.pre_hook_action =
              actual category instead of bucketing as "unclassified". *)
           failure_class = Some Tool_result.Policy_rejection
         }
+      )
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> validation_exception_action ~name exn

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -7,9 +7,15 @@ module KE = Masc_mcp.Keeper_exec_tools
 module Types = Masc_domain
 
 (** Helper: create a minimal tool_schema for registration. *)
-let make_schema name =
+let make_schema ?(props = []) name =
+  let prop_entries =
+    List.map
+      (fun (field, type_name) -> field, `Assoc [ "type", `String type_name ])
+      props
+  in
   { Masc_domain.name; description = "test tool " ^ name;
-    input_schema = `Assoc [("type", `String "object")] }
+    input_schema =
+      `Assoc [ "type", `String "object"; "properties", `Assoc prop_entries ] }
 
 (** Helper: a handler that returns a successful result with "ok:<name>". *)
 let echo_handler ~name ~args:_ = Some (Tool_result.quick_ok ~tool_name:name ("ok:" ^ name))
@@ -17,12 +23,16 @@ let echo_handler ~name ~args:_ = Some (Tool_result.quick_ok ~tool_name:name ("ok
 (** Helper: a handler that returns (false, "fail"). *)
 let fail_handler ~name:_ ~args:_ = Some (Tool_result.quick_error "fail")
 
-(** Helper: register a tool in both handler and tag registries.
-    mint_token validates against tag_registry, so tests that mint
-    must register in both. *)
-let register_full ~tool_name ~handler =
+(** Helper: register a tool in handler, tag, and schema registries.
+    The validation pre-hook is fail-closed for schema-less tools. *)
+let register_full ?schema ~tool_name ~handler () =
+  let schema =
+    match schema with
+    | Some schema -> schema
+    | None -> make_schema tool_name
+  in
   Tool_dispatch.register ~tool_name ~handler;
-  Tool_dispatch.register_name_tag ~tool_name ~tag:Mod_misc
+  Tool_dispatch.register_module_tag ~schemas:[schema] ~tag:Mod_misc
 
 let () =
   let open Alcotest in
@@ -32,7 +42,7 @@ let () =
         [
           test_case "register single tool and dispatch" `Quick (fun () ->
               let tool = "__test_dispatch_single" in
-              register_full ~tool_name:tool ~handler:echo_handler;
+              register_full ~tool_name:tool ~handler:echo_handler ();
               let token = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
               let result = Tool_dispatch.guarded_dispatch ~token ~args:`Null () in
               check bool "found" true (Option.is_some result);
@@ -53,7 +63,7 @@ let () =
                   [ "__test_bulk_a"; "__test_bulk_b"; "__test_bulk_c" ]
               in
               Tool_dispatch.register_module ~schemas ~handler:echo_handler;
-              List.iter (fun s -> Tool_dispatch.register_name_tag ~tool_name:s.Masc_domain.name ~tag:Mod_misc) schemas;
+              Tool_dispatch.register_module_tag ~schemas ~tag:Mod_misc;
               List.iter
                 (fun name ->
                   check bool (name ^ " registered") true
@@ -74,12 +84,12 @@ let () =
         [
           test_case "re-register replaces handler" `Quick (fun () ->
               let tool = "__test_dispatch_replace" in
-              register_full ~tool_name:tool ~handler:echo_handler;
+              register_full ~tool_name:tool ~handler:echo_handler ();
               let token1 = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
               let result1 = Option.get (Tool_dispatch.guarded_dispatch ~token:token1 ~args:`Null ()) in
               let ok1 = result1.success in
               check bool "first ok" true ok1;
-              register_full ~tool_name:tool ~handler:fail_handler;
+              register_full ~tool_name:tool ~handler:fail_handler ();
               let token2 = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
               let result2 = Option.get (Tool_dispatch.guarded_dispatch ~token:token2 ~args:`Null ()) in
               let ok2 = result2.success in
@@ -204,7 +214,11 @@ let () =
                 received_args := args;
                 Some (Tool_result.quick_ok "captured")
               in
-              register_full ~tool_name:tool ~handler:capture_handler;
+              register_full
+                ~tool_name:tool
+                ~schema:(make_schema ~props:[ "key", "string" ] tool)
+                ~handler:capture_handler
+                ();
               let test_args = `Assoc [("key", `String "value")] in
               let token = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
               let _ = Tool_dispatch.guarded_dispatch ~token ~args:test_args () in
@@ -212,12 +226,12 @@ let () =
         ] );
       ( "handler_exception_safety",
         [
-          test_case "throwing handler returns error tuple" `Quick (fun () ->
+          test_case "throwing handler returns typed error" `Quick (fun () ->
               let tool = "__test_dispatch_throw" in
               let throwing_handler ~name:_ ~args:_ =
                 failwith "boom"
               in
-              register_full ~tool_name:tool ~handler:throwing_handler;
+              register_full ~tool_name:tool ~handler:throwing_handler ();
               let token = match Tool_dispatch.mint_token ~name:tool with Ok t -> t | Error e -> Alcotest.fail e in
               let result = Tool_dispatch.guarded_dispatch ~token ~args:`Null () in
               check bool "still returns Some" true (Option.is_some result);
@@ -231,9 +245,9 @@ let () =
       ( "did_you_mean_9784",
         [
           test_case "find_similar_names returns close match" `Quick (fun () ->
-              register_full ~tool_name:"__sim_masc_claim_next" ~handler:echo_handler;
-              register_full ~tool_name:"__sim_masc_add_task" ~handler:echo_handler;
-              register_full ~tool_name:"__sim_masc_join" ~handler:echo_handler;
+              register_full ~tool_name:"__sim_masc_claim_next" ~handler:echo_handler ();
+              register_full ~tool_name:"__sim_masc_add_task" ~handler:echo_handler ();
+              register_full ~tool_name:"__sim_masc_join" ~handler:echo_handler ();
               let suggestions =
                 Tool_dispatch.find_similar_names
                   ~query:"__sim_masc_claim_task" ()
@@ -253,6 +267,7 @@ let () =
                 register_full
                   ~tool_name:(Printf.sprintf "__limit_test_tool_%d" i)
                   ~handler:echo_handler
+                  ()
               done;
               let suggestions =
                 Tool_dispatch.find_similar_names ~limit:2
@@ -261,7 +276,7 @@ let () =
               check bool "at most 2 returned" true
                 (List.length suggestions <= 2));
           test_case "all_registered_names enumerates registry" `Quick (fun () ->
-              register_full ~tool_name:"__enum_check_xyz" ~handler:echo_handler;
+              register_full ~tool_name:"__enum_check_xyz" ~handler:echo_handler ();
               let all = Tool_dispatch.all_registered_names () in
               check bool "contains registered name" true
                 (List.mem "__enum_check_xyz" all));

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -243,13 +243,60 @@ let test_extra_fields_allowed () =
   | Proceed _ -> ()
   | Reject r -> Alcotest.fail (Yojson.Safe.to_string r.data)
 
-let test_empty_schema_passes () =
+let test_empty_schema_allows_empty_args () =
   let schema = `Assoc [] in
-  let args = `Assoc [("anything", `String "goes")] in
-  match validate_via_oas ~tool_name:"test" ~schema ~args with
-  | Pass -> ()  (* empty params -> Pass *)
-  | Proceed _ -> Alcotest.fail "Empty schema should Pass"
-  | Reject r -> Alcotest.fail (Yojson.Safe.to_string r.data)
+  match
+    Tool_input_validation.validate_args
+      ~schema
+      ~name:"__tool_input_validation_empty_schema_empty_args"
+      ~args:(`Assoc [])
+      ()
+  with
+  | Ok (`Assoc []) -> ()
+  | Ok forwarded ->
+    Alcotest.failf
+      "expected empty args to pass unchanged, got %s"
+      (Yojson.Safe.to_string forwarded)
+  | Error result ->
+    Alcotest.failf
+      "expected empty schema with empty args to pass, got %s"
+      (Yojson.Safe.to_string result.Tool_result.data)
+
+let test_empty_schema_rejects_arguments () =
+  let schema = `Assoc [] in
+  match
+    Tool_input_validation.validate_args
+      ~schema
+      ~name:"__tool_input_validation_empty_schema_rejects_args"
+      ~args:(`Assoc [ "anything", `String "goes" ])
+      ()
+  with
+  | Error result ->
+    let msg = Yojson.Safe.to_string result.Tool_result.data in
+    Alcotest.(check bool) "reason is empty_schema_args" true
+      (string_contains msg "empty_schema_args")
+  | Ok forwarded ->
+    Alcotest.failf
+      "expected empty schema with arguments to fail, got %s"
+      (Yojson.Safe.to_string forwarded)
+
+let test_required_without_properties_rejects_schema () =
+  let schema = `Assoc [ "required", `List [ `String "name" ] ] in
+  match
+    Tool_input_validation.validate_args
+      ~schema
+      ~name:"__tool_input_validation_malformed_schema"
+      ~args:(`Assoc [])
+      ()
+  with
+  | Error result ->
+    let msg = Yojson.Safe.to_string result.Tool_result.data in
+    Alcotest.(check bool) "reason is malformed_schema" true
+      (string_contains msg "malformed_schema")
+  | Ok forwarded ->
+    Alcotest.failf
+      "expected malformed schema to fail, got %s"
+      (Yojson.Safe.to_string forwarded)
 
 let test_schema_union_type_does_not_raise () =
   let schema =
@@ -321,7 +368,7 @@ let test_registered_hook_keeps_noop_as_pass () =
   Alcotest.(check bool) "args unchanged" true
     (Yojson.Safe.equal forwarded args)
 
-let test_registered_hook_bypasses_unknown_tool () =
+let test_registered_hook_rejects_unknown_tool () =
   let args = `Assoc [("count", `String "42")] in
   let blocked, forwarded =
     run_registered_hook
@@ -329,11 +376,17 @@ let test_registered_hook_bypasses_unknown_tool () =
       ~args
       ()
   in
-  Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
-  Alcotest.(check bool) "args unchanged" true
-    (Yojson.Safe.equal forwarded args)
+  Alcotest.(check bool) "blocked" true (Option.is_some blocked);
+  Alcotest.(check bool) "args unchanged on rejection" true
+    (Yojson.Safe.equal forwarded args);
+  match blocked with
+  | Some result ->
+    let msg = Yojson.Safe.to_string result.Tool_result.data in
+    Alcotest.(check bool) "reason is missing_schema" true
+      (string_contains msg "missing_schema")
+  | None -> Alcotest.fail "expected missing-schema rejection"
 
-let test_registered_hook_bypasses_empty_schema () =
+let test_registered_hook_rejects_empty_schema_arguments () =
   let args = `Assoc [("anything", `String "goes")] in
   let blocked, forwarded =
     run_registered_hook
@@ -342,9 +395,27 @@ let test_registered_hook_bypasses_empty_schema () =
       ~args
       ()
   in
+  Alcotest.(check bool) "blocked" true (Option.is_some blocked);
+  Alcotest.(check bool) "args unchanged on rejection" true
+    (Yojson.Safe.equal forwarded args);
+  match blocked with
+  | Some result ->
+    let msg = Yojson.Safe.to_string result.Tool_result.data in
+    Alcotest.(check bool) "reason is empty_schema_args" true
+      (string_contains msg "empty_schema_args")
+  | None -> Alcotest.fail "expected empty-schema argument rejection"
+
+let test_registered_hook_allows_empty_schema_without_arguments () =
+  let args = `Assoc [] in
+  let blocked, forwarded =
+    run_registered_hook
+      ~schema:(`Assoc [])
+      ~tool_name:"__tool_input_validation_registered_empty_no_args"
+      ~args
+      ()
+  in
   Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
-  Alcotest.(check bool) "args unchanged" true
-    (Yojson.Safe.equal forwarded args)
+  Alcotest.(check bool) "args unchanged" true (Yojson.Safe.equal forwarded args)
 
 let test_validate_args_uses_explicit_schema_without_registry () =
   Tool_dispatch.clear_hooks ();
@@ -483,7 +554,7 @@ let attr_string key attrs =
   | Some (`String value) -> Some value
   | _ -> None
 
-let test_validation_telemetry_records_pass_fail_and_bypass () =
+let test_validation_telemetry_records_pass_and_fail_counters () =
   let valid_tool = "__tool_input_validation_metric_valid" in
   let valid_schema = make_schema [ "count", "integer" ] in
   check_validation_metric_increment
@@ -544,7 +615,7 @@ let test_validation_telemetry_records_pass_fail_and_bypass () =
   let missing_tool = "__tool_input_validation_metric_missing_schema" in
   check_validation_metric_increment
     ~tool:missing_tool
-    ~result:"bypass"
+    ~result:"fail"
     ~reason:"missing_schema"
     (fun () ->
        match
@@ -553,30 +624,30 @@ let test_validation_telemetry_records_pass_fail_and_bypass () =
            ~args:(`Assoc [ "count", `String "not-validated" ])
            ()
        with
-       | Ok _ -> ()
-       | Error result ->
+       | Error _ -> ()
+       | Ok forwarded ->
          Alcotest.fail
            (Printf.sprintf
-              "expected missing schema bypass, got %s"
-              (Yojson.Safe.to_string result.Tool_result.data)));
+              "expected missing schema failure, got %s"
+              (Yojson.Safe.to_string forwarded)));
   let empty_tool = "__tool_input_validation_metric_empty_schema" in
   check_validation_metric_increment
     ~tool:empty_tool
-    ~result:"bypass"
+    ~result:"pass"
     ~reason:"empty_schema"
     (fun () ->
        match
          Tool_input_validation.validate_args
            ~schema:(`Assoc [])
            ~name:empty_tool
-           ~args:(`Assoc [ "anything", `String "goes" ])
+           ~args:(`Assoc [])
            ()
        with
        | Ok _ -> ()
        | Error result ->
          Alcotest.fail
            (Printf.sprintf
-              "expected empty schema bypass, got %s"
+              "expected empty schema no-arg pass, got %s"
               (Yojson.Safe.to_string result.Tool_result.data)))
 
 let test_validation_telemetry_records_normalized_transition () =
@@ -817,13 +888,18 @@ let () =
       Alcotest.test_case "null args no required" `Quick test_null_args_no_required;
       Alcotest.test_case "null args with required" `Quick test_null_args_with_required;
       Alcotest.test_case "extra fields allowed" `Quick test_extra_fields_allowed;
-      Alcotest.test_case "empty schema passes" `Quick test_empty_schema_passes;
+      Alcotest.test_case "empty schema allows empty args" `Quick
+        test_empty_schema_allows_empty_args;
+      Alcotest.test_case "empty schema rejects arguments" `Quick
+        test_empty_schema_rejects_arguments;
+      Alcotest.test_case "required without properties rejects schema" `Quick
+        test_required_without_properties_rejects_schema;
       Alcotest.test_case "schema union type does not raise" `Quick
         test_schema_union_type_does_not_raise;
     ]);
     ("telemetry", [
-      Alcotest.test_case "records pass, fail, and bypass counters" `Quick
-        test_validation_telemetry_records_pass_fail_and_bypass;
+      Alcotest.test_case "records pass and fail counters" `Quick
+        test_validation_telemetry_records_pass_and_fail_counters;
       Alcotest.test_case "records normalized transition counter" `Quick
         test_validation_telemetry_records_normalized_transition;
       Alcotest.test_case "emits OTel validation event" `Quick
@@ -834,10 +910,12 @@ let () =
         test_registered_hook_coerces_args;
       Alcotest.test_case "no-op coercion stays pass" `Quick
         test_registered_hook_keeps_noop_as_pass;
-      Alcotest.test_case "unknown tool bypasses validation" `Quick
-        test_registered_hook_bypasses_unknown_tool;
-      Alcotest.test_case "empty schema bypasses validation" `Quick
-        test_registered_hook_bypasses_empty_schema;
+      Alcotest.test_case "unknown tool rejects validation" `Quick
+        test_registered_hook_rejects_unknown_tool;
+      Alcotest.test_case "empty schema rejects arguments" `Quick
+        test_registered_hook_rejects_empty_schema_arguments;
+      Alcotest.test_case "empty schema allows empty args" `Quick
+        test_registered_hook_allows_empty_schema_without_arguments;
       Alcotest.test_case "keeper_fs_edit accepts patch args" `Quick
         test_registered_hook_keeper_fs_edit_patch_args;
       Alcotest.test_case "keeper_board_post accepts sources array" `Quick


### PR DESCRIPTION
## Summary

- Make `Tool_input_validation` reject schema-less tool calls fail-closed instead of recording a bypass and letting them through.
- Allow empty/no-arg schemas only when the call has no user arguments; reject empty schemas with arguments and malformed schemas with required fields but no properties.
- Update dispatch tests to register schemas with direct handlers, remove duplicate `guarded_dispatch` mli surface text, and refresh tool dispatch docs away from legacy tuple contracts.

## Why

The remaining legacy boundary was not the central handler type anymore; it was the permissive validation path. A registered handler without schema could still bypass input validation entirely. This PR turns that into an explicit typed `Tool_result.Policy_rejection` before dispatch.

## Validation

- `ocamlformat --check lib/tool_input_validation.ml lib/tool_dispatch.mli lib/tool_bridge.ml test/test_tool_input_validation.ml test/test_tool_dispatch.ml`
- `git diff --check HEAD~1..HEAD`
- `MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1 scripts/dune-local.sh build test/test_tool_input_validation.exe test/test_tool_dispatch.exe test/test_typed_tool_masc.exe`
- `./_build/default/test/test_tool_input_validation.exe` — 38 tests passed
- `./_build/default/test/test_tool_dispatch.exe` — 25 tests passed
- `./_build/default/test/test_typed_tool_masc.exe` — 16 tests passed

Note: local Dune/opam wrapper locks were held by unrelated long-running builds, so the focused build used the worktree-local `_build` while skipping the shared lock/pin/deps guards.