### PR TITLE
fix(process): close setup fds on spawn failure

### DIFF
--- a/lib/cdal_runtime/autonomy_exec.ml
+++ b/lib/cdal_runtime/autonomy_exec.ml
@@ -185,17 +185,44 @@ let close_quietly fd =
 ;;
 
 let spawn_child ~sw config effective =
-  let stdin_fd = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0 in
-  let stdout_r, stdout_w = Unix.pipe ~cloexec:true () in
-  let stderr_r, stderr_w = Unix.pipe ~cloexec:true () in
-  (* Switch.on_release guarantees pipe close on cancellation or unexpected
-     raise. The previous Fun.protect + reader_started flag scheme had a
-     race: setting the flag preceded Eio.Fiber.fork, so a cancellation
-     between them orphaned the read end. close_quietly is idempotent with
-     drain_fd's own Fun.protect close — safe even when both fire. *)
-  Eio.Switch.on_release sw (fun () -> close_quietly stdout_r);
-  Eio.Switch.on_release sw (fun () -> close_quietly stderr_r);
+  let stdin_fd_ref = ref None in
+  let stdout_r_ref = ref None in
+  let stdout_w_ref = ref None in
+  let stderr_r_ref = ref None in
+  let stderr_w_ref = ref None in
+  let remember slot fd =
+    slot := Some fd;
+    fd
+  in
+  let close_registered slot =
+    match !slot with
+    | None -> ()
+    | Some fd ->
+      close_quietly fd;
+      slot := None
+  in
+  let cleanup_setup_fds () =
+    List.iter
+      close_registered
+      [ stdin_fd_ref; stdout_r_ref; stdout_w_ref; stderr_r_ref; stderr_w_ref ]
+  in
   try
+    let stdin_fd =
+      remember stdin_fd_ref (Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0)
+    in
+    let stdout_r, stdout_w = Unix.pipe ~cloexec:true () in
+    let stdout_r = remember stdout_r_ref stdout_r in
+    let stdout_w = remember stdout_w_ref stdout_w in
+    let stderr_r, stderr_w = Unix.pipe ~cloexec:true () in
+    let stderr_r = remember stderr_r_ref stderr_r in
+    let stderr_w = remember stderr_w_ref stderr_w in
+    (* Switch.on_release guarantees pipe close on cancellation or unexpected
+       raise. The previous Fun.protect + reader_started flag scheme had a
+       race: setting the flag preceded Eio.Fiber.fork, so a cancellation
+       between them orphaned the read end. close_quietly is idempotent with
+       drain_fd's own Fun.protect close — safe even when both fire. *)
+    Eio.Switch.on_release sw (fun () -> close_quietly stdout_r);
+    Eio.Switch.on_release sw (fun () -> close_quietly stderr_r);
     Unix.set_nonblock stdout_r;
     Unix.set_nonblock stderr_r;
     let env = build_env ~config in
@@ -209,20 +236,23 @@ let spawn_child ~sw config effective =
         stdout_w
         stderr_w
     in
-    close_quietly stdin_fd;
-    close_quietly stdout_w;
-    close_quietly stderr_w;
+    close_registered stdin_fd_ref;
+    close_registered stdout_w_ref;
+    close_registered stderr_w_ref;
+    stdout_r_ref := None;
+    stderr_r_ref := None;
     Ok (pid, stdout_r, stderr_r)
   with
   | Unix.Unix_error (err, fn, arg) ->
-    close_quietly stdin_fd;
-    close_quietly stdout_w;
-    close_quietly stderr_w;
+    cleanup_setup_fds ();
     Error
       (file_op_error
          ~op:"spawn"
          ~path:(argv_to_string effective)
          ~detail:(Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err)))
+  | exn ->
+    cleanup_setup_fds ();
+    raise exn
 ;;
 
 let spawn_result_promise ~sw fn =

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -732,11 +732,36 @@ let spawn_detached ~argv ~env ~cwd =
   match argv with
   | [] -> Error "spawn_detached: empty argv"
   | bin :: _ ->
+      let out_r_ref = ref None in
+      let out_w_ref = ref None in
+      let err_r_ref = ref None in
+      let err_w_ref = ref None in
+      let devnull_ref = ref None in
+      let remember slot fd =
+        slot := Some fd;
+        fd
+      in
+      let close_registered slot =
+        match !slot with
+        | None -> ()
+        | Some fd ->
+            close_quietly fd;
+            slot := None
+      in
+      let cleanup_setup_fds () =
+        List.iter close_registered
+          [ out_r_ref; out_w_ref; err_r_ref; err_w_ref; devnull_ref ]
+      in
       (try
          let out_r, out_w = Unix.pipe ~cloexec:true () in
+         let out_r = remember out_r_ref out_r in
+         let out_w = remember out_w_ref out_w in
          let err_r, err_w = Unix.pipe ~cloexec:true () in
+         let err_r = remember err_r_ref err_r in
+         let err_w = remember err_w_ref err_w in
          let devnull =
-           Unix.openfile "/dev/null" [ Unix.O_RDONLY; Unix.O_CLOEXEC ] 0
+           remember devnull_ref
+             (Unix.openfile "/dev/null" [ Unix.O_RDONLY; Unix.O_CLOEXEC ] 0)
          in
          (* Use fork/exec instead of create_process_env so the child
             can [setpgrp] before [execvpe].  OCaml's Unix module does
@@ -774,9 +799,11 @@ let spawn_detached ~argv ~env ~cwd =
             | _ -> Unix._exit 127)
          end else begin
            (* --- PARENT --- *)
-           Unix.close out_w;
-           Unix.close err_w;
-           Unix.close devnull;
+           close_registered out_w_ref;
+           close_registered err_w_ref;
+           close_registered devnull_ref;
+           out_r_ref := None;
+           err_r_ref := None;
            Ok
              {
                pid;
@@ -788,10 +815,12 @@ let spawn_detached ~argv ~env ~cwd =
          end
        with
        | Unix.Unix_error (err, fn, arg) ->
+           cleanup_setup_fds ();
            Error
              (Printf.sprintf "spawn_detached %s: %s (%s %s)"
                 bin (Unix.error_message err) fn arg)
        | exn ->
+           cleanup_setup_fds ();
            Error
              (Printf.sprintf "spawn_detached %s: %s" bin
                 (Printexc.to_string exn)))

--- a/lib/repo_manager/credential_materializer.ml
+++ b/lib/repo_manager/credential_materializer.ml
@@ -29,6 +29,17 @@ let gh_hosts_yml = "hosts.yml"
 let close_fd_noerr fd =
   try Unix.close fd with Unix.Unix_error _ -> ()
 
+let remember_fd slot fd =
+  slot := Some fd;
+  fd
+
+let close_registered_fd slot =
+  match !slot with
+  | None -> ()
+  | Some fd ->
+      close_fd_noerr fd;
+      slot := None
+
 let rec waitpid_no_intr flags pid =
   try Unix.waitpid flags pid
   with Unix.Unix_error (Unix.EINTR, _, _) -> waitpid_no_intr flags pid
@@ -70,24 +81,39 @@ let gh_bundle_env ~gh_config_dir =
     environment only, so ambient GH_TOKEN/GITHUB_TOKEN values cannot
     make a stale bundle look materialized. *)
 let gh_command_ok ~gh_config_dir argv =
-  let devnull_in = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0 in
-  let devnull_out = Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0o644 in
-  let pid =
-    try
-      Some
-        (Unix.create_process_env "gh" (Array.of_list ("gh" :: argv))
-           (gh_bundle_env ~gh_config_dir)
-           devnull_in devnull_out devnull_out)
-    with Unix.Unix_error _ -> None
+  let devnull_in_ref = ref None in
+  let devnull_out_ref = ref None in
+  let cleanup () =
+    close_registered_fd devnull_in_ref;
+    close_registered_fd devnull_out_ref
   in
-  close_fd_noerr devnull_in;
-  close_fd_noerr devnull_out;
-  match pid with
-  | None -> false
-  | Some pid -> (
-      match snd (waitpid_no_intr [] pid) with
-      | Unix.WEXITED 0 -> true
-      | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> false)
+  try
+    let devnull_in =
+      remember_fd devnull_in_ref
+        (Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0)
+    in
+    let devnull_out =
+      remember_fd devnull_out_ref
+        (Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0o644)
+    in
+    let pid =
+      try
+        Some
+          (Unix.create_process_env "gh" (Array.of_list ("gh" :: argv))
+             (gh_bundle_env ~gh_config_dir)
+             devnull_in devnull_out devnull_out)
+      with Unix.Unix_error _ -> None
+    in
+    cleanup ();
+    match pid with
+    | None -> false
+    | Some pid -> (
+        match snd (waitpid_no_intr [] pid) with
+        | Unix.WEXITED 0 -> true
+        | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> false)
+  with Unix.Unix_error _ ->
+    cleanup ();
+    false
 
 let hosts_yml_has_oauth_token ~gh_config_dir =
   let path = Filename.concat gh_config_dir gh_hosts_yml in
@@ -420,15 +446,27 @@ let provision_via_with_token ?credential_id ?identity_label
             (Printf.sprintf
                "could not create gh_config_dir %S" gh_config_dir)
         else
-          let read_fd, write_fd = Unix.pipe ~cloexec:false () in
-          (* The pipe's read end will be passed to the child; the write
-             end stays in the parent.  cloexec on read_fd would close it
-             before exec; we set cloexec=false then explicitly close
-             read_fd in the parent after fork. *)
-          let devnull_out =
-            Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0o644
-	          in
-	          let env = gh_bundle_env ~gh_config_dir in
+          let read_fd_ref = ref None in
+          let write_fd_ref = ref None in
+          let devnull_out_ref = ref None in
+          let cleanup_setup_fds () =
+            close_registered_fd read_fd_ref;
+            close_registered_fd write_fd_ref;
+            close_registered_fd devnull_out_ref
+          in
+          try
+            let read_fd, write_fd = Unix.pipe ~cloexec:false () in
+            let read_fd = remember_fd read_fd_ref read_fd in
+            let write_fd = remember_fd write_fd_ref write_fd in
+            (* The pipe's read end will be passed to the child; the write
+               end stays in the parent.  cloexec on read_fd would close it
+               before exec; we set cloexec=false then explicitly close
+               read_fd in the parent after fork. *)
+            let devnull_out =
+              remember_fd devnull_out_ref
+                (Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0o644)
+            in
+            let env = gh_bundle_env ~gh_config_dir in
           let argv =
             [|
               "gh"; "auth"; "login";
@@ -446,11 +484,11 @@ let provision_via_with_token ?credential_id ?identity_label
             with Unix.Unix_error _ -> None
           in
           (* Parent: close child's stdin read end *)
-          (try Unix.close read_fd with Unix.Unix_error _ -> ());
-          (try Unix.close devnull_out with Unix.Unix_error _ -> ());
+          close_registered_fd read_fd_ref;
+          close_registered_fd devnull_out_ref;
           match pid with
           | None ->
-              (try Unix.close write_fd with Unix.Unix_error _ -> ());
+              close_registered_fd write_fd_ref;
               Error
                 "failed to spawn `gh auth login --with-token` subprocess; \
                  is gh installed and on PATH?"
@@ -461,10 +499,12 @@ let provision_via_with_token ?credential_id ?identity_label
               (try
                  output_string oc token;
                  output_char oc '\n';
-                 close_out oc
+                 close_out oc;
+                 write_fd_ref := None
                with
                | Sys_error _ ->
-                   close_out_noerr oc);
+                   close_out_noerr oc;
+                   write_fd_ref := None);
               let status = snd (waitpid_no_intr [] pid) in
               (match status with
                | Unix.WEXITED 0 ->
@@ -499,4 +539,13 @@ let provision_via_with_token ?credential_id ?identity_label
                    Error
                      (Printf.sprintf
                         "gh auth login --with-token stopped by signal %d"
-                        n)))
+                        n))
+          with Unix.Unix_error (err, fn, arg) ->
+            cleanup_setup_fds ();
+            Error
+              (Printf.sprintf
+                 "failed to spawn `gh auth login --with-token`: %s(%s): %s"
+                 fn arg (Unix.error_message err))
+          | exn ->
+              cleanup_setup_fds ();
+              raise exn)

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -156,10 +156,11 @@ _print_lock_holders() {
 if _needs_dune_lock; then
   printf '[dune-local] waiting for lock %s\n' "$lock_path" >&2
   _print_lock_holders "$lock_path" "Dune"
+  env_cmd="${ENV_CMD:-/usr/bin/env}"
   if command -v lockf >/dev/null 2>&1; then
-    exec lockf -k "$lock_path" env MASC_DUNE_LOCK_HELD=1 "$script_path" "$@"
+    exec lockf -k "$lock_path" "$env_cmd" MASC_DUNE_LOCK_HELD=1 "$script_path" "$@"
   elif command -v flock >/dev/null 2>&1; then
-    exec flock "$lock_path" env MASC_DUNE_LOCK_HELD=1 "$script_path" "$@"
+    exec flock "$lock_path" "$env_cmd" MASC_DUNE_LOCK_HELD=1 "$script_path" "$@"
   else
     printf '[dune-local] warning: neither lockf nor flock found; running unlocked\n' >&2
     dune_lock_warning_emitted=1
@@ -204,8 +205,9 @@ if _needs_opam_lock; then
   if command -v lockf >/dev/null 2>&1; then
     if [[ "$opam_bounded_wait" = "1" ]]; then
       set +e
+      env_cmd="${ENV_CMD:-/usr/bin/env}"
       lockf -k -t "$opam_lock_timeout" "$opam_lock_path" \
-        env MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
+        "$env_cmd" MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
       status=$?
       set -e
       if [[ "$status" -eq 0 ]]; then
@@ -218,15 +220,17 @@ if _needs_opam_lock; then
       fi
       exit "$status"
     fi
-    exec lockf -k "$opam_lock_path" env MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
+    env_cmd="${ENV_CMD:-/usr/bin/env}"
+    exec lockf -k "$opam_lock_path" "$env_cmd" MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
   elif command -v flock >/dev/null 2>&1; then
     if [[ "$opam_bounded_wait" = "1" ]]; then
       # flock(1) honors -w/--timeout to bound the wait; without it the
       # mixed-lock-order deadlock the lockf branch above already handles
       # would resurface on flock-only hosts (Linux without lockf).
       set +e
+      env_cmd="${ENV_CMD:-/usr/bin/env}"
       flock -w "$opam_lock_timeout" "$opam_lock_path" \
-        env MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
+        "$env_cmd" MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
       status=$?
       set -e
       if [[ "$status" -eq 0 ]]; then
@@ -242,7 +246,8 @@ if _needs_opam_lock; then
       fi
       exit "$status"
     fi
-    exec flock "$opam_lock_path" env MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
+    env_cmd="${ENV_CMD:-/usr/bin/env}"
+    exec flock "$opam_lock_path" "$env_cmd" MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
   elif [[ "$dune_lock_warning_emitted" != "1" ]]; then
     # Skip the warning when the Dune-lock branch above already printed
     # an equivalent "neither lockf nor flock found" message in this

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -42,11 +42,12 @@ if [[ "${MASC_OPAM_LOCK:-1}" != "0" \
       && "${MASC_SKIP_OPAM_LOCK:-0}" != "1" \
       && "${MASC_OPAM_LOCK_HELD:-0}" != "1" ]]; then
   script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+  env_cmd="${ENV_CMD:-/usr/bin/env}"
   echo "[opam-pin] waiting for opam switch lock ${opam_lock_path}" >&2
   if command -v lockf >/dev/null 2>&1; then
-    exec lockf -k "$opam_lock_path" env MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
+    exec lockf -k "$opam_lock_path" "$env_cmd" MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
   elif command -v flock >/dev/null 2>&1; then
-    exec flock "$opam_lock_path" env MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
+    exec flock "$opam_lock_path" "$env_cmd" MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
   else
     echo "[opam-pin] WARN: neither lockf nor flock found; mutating opam switch unlocked" >&2
   fi


### PR DESCRIPTION
## Summary

- close partially-opened setup FDs when detached/background spawn setup fails under EMFILE/ENFILE pressure
- cover `Process_eio.spawn_detached`, CDAL `Autonomy_exec.spawn_child`, and GH credential materializer subprocess setup
- harden local lock wrapper re-exec to call `/usr/bin/env` explicitly instead of relying on `lockf ... env`

## Verification

- `ocamlformat --check lib/process/process_eio.ml lib/cdal_runtime/autonomy_exec.ml lib/repo_manager/credential_materializer.ml`
- `bash -n scripts/dune-local.sh`
- `bash -n scripts/opam-pin-external-deps.sh`
- `git diff --check`
- `scripts/ci/check-accept-fd-lifecycle.sh`
- `scripts/check-oas-pin.sh` (warns OAS main drift, fingerprint still matches)
- `lockf -k /tmp/masc-lockf-env-smoke /usr/bin/env TEST=ok /usr/bin/printenv TEST`
- `DUNE_CACHE=disabled dune build --root . --display quiet lib/process/masc_process.cmxa lib/cdal_runtime/masc_mcp_cdal_runtime.cmxa lib/repo_manager/repo_manager.cmxa -j 1`
- `DUNE_CACHE=disabled dune exec --root . --display quiet ./test/test_process_eio_detached.exe`
- `DUNE_CACHE=disabled dune exec --root . --display quiet ./test/test_credential_materializer.exe`
- `DUNE_CACHE=disabled dune exec --root . --display quiet ./test/test_cdal_runtime_health_15748.exe`

Notes: an earlier concurrent `dune exec` attempt in the same `_build` hung; rerunning the credential materializer test alone passed.
