### PR TITLE
fix(keeper): re-raise Eio.Cancel.Cancelled in on_compaction_started callback

### DIFF
--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -557,6 +557,7 @@ let apply_post_turn_lifecycle_with_resilience_handles
           let () =
             try on_compaction_started ()
             with
+            | Eio.Cancel.Cancelled _ as e -> raise e
             | exn ->
                 Keeper_callback_failure.record ~base_dir ~meta:base_meta
                   ~callback:"on_compaction_started" exn


### PR DESCRIPTION
## Problem

`apply_post_turn_lifecycle_with_resilience_handles` (lib/keeper/keeper_post_turn.ml:557-563) wraps `on_compaction_started` in:

```ocaml
try on_compaction_started ()
with
| exn ->
    Keeper_callback_failure.record ~base_dir ~meta:base_meta
      ~callback:\"on_compaction_started\" exn
```

The catch-all `| exn ->` is documented as the \"keep-going-on-callback-failure\" policy for transient registry contention. But it also swallows `Eio.Cancel.Cancelled`, which is a *fiber-cancellation signal* — not a callback failure. When a switch is cancelling, this arm misclassifies the cancel exception as a callback fault and *continues* the post-turn lifecycle, violating Eio cancellation discipline.

## Fix

Add an explicit `Eio.Cancel.Cancelled _ as e -> raise e` arm *before* the catch-all. Behaviour for non-Cancelled exceptions is preserved (counter + warn + telemetry coverage-gap row continue via `Keeper_callback_failure.record`).

```diff
           let () =
             try on_compaction_started ()
             with
+            | Eio.Cancel.Cancelled _ as e -> raise e
             | exn ->
                 Keeper_callback_failure.record ~base_dir ~meta:base_meta
                   ~callback:\"on_compaction_started\" exn
           in
```

## Pairing audit

7 other `| exn ->` arms in this file (lines 151/212/281/351/813/848/940) are already preceded by a Cancelled re-raise arm. Line 560 was the only unpaired catch-all. Same root-fix shape as PR #15883 (bg_task drain) precedent.

## Anti-pattern self-check (7/7)

- [x] **Not telemetry-as-fix** — behaviour changes: Cancelled now propagates instead of being misclassified
- [x] **No string classifier** — typed constructor match on `Eio.Cancel.Cancelled`
- [x] **Not N-of-M** — only unpaired catch-all in the file (audited)
- [x] **No new `_ -> false` catch-all** — existing arm kept, only adds Cancelled arm
- [x] No magic number
- [x] No test backdoor
- [x] No N-times-typo fix

## Risk

Low. Single 1-line change. Build PASS (`dune build @check`). Affects only the rare case where a fiber is cancelled exactly during `on_compaction_started`; prior to this patch the cancellation would be silently absorbed and the lifecycle would proceed — now it propagates as Eio intends.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>