### PR TITLE
[codex] tag compaction pair-repair fabricated messages

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -331,8 +331,8 @@ let compact_if_needed_typed
        so the counter reflects fabrication volume rather than call
        frequency. Kind label is a closed 2-value vocabulary (no Printexc-
        style unbounded label) — see iter 21 / PR #15788 for the same
-       pattern. The was_fabricated:true message-metadata half is
-       RFC-scope (touches MASC + OAS message-record shape) and deferred. *)
+       pattern. The repaired messages also carry [was_fabricated=true] plus
+       bounded provenance under [Keeper_context_core.pair_repair_metadata_key]. *)
     let bump_pair_repair kind count =
       if count > 0
       then

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -499,6 +499,31 @@ let add_tool_pair_repair_stats left right =
 let tool_pair_repair_stats_changed stats =
   stats.downgraded_tool_uses > 0 || stats.downgraded_tool_results > 0
 
+let pair_repair_metadata_key = "masc.tool_pair_repair"
+
+let pair_repair_metadata_keys =
+  [ "was_fabricated"; "fabrication_source"; pair_repair_metadata_key ]
+
+let with_pair_repair_metadata ~kind ~count (msg : Agent_sdk.Types.message) =
+  let metadata =
+    List.filter
+      (fun (key, _) -> not (List.mem key pair_repair_metadata_keys))
+      msg.metadata
+  in
+  { msg with
+    metadata =
+      [ "was_fabricated", `Bool true
+      ; "fabrication_source", `String "tool_pair_repair"
+      ; ( pair_repair_metadata_key
+        , `Assoc
+            [ "version", `Int 1
+            ; "kind", `String kind
+            ; "count", `Int count
+            ] )
+      ]
+      @ metadata
+  }
+
 let repair_dangling_tool_use_messages_with_stats
     (messages : Agent_sdk.Types.message list)
     : Agent_sdk.Types.message list * tool_pair_repair_stats =
@@ -541,6 +566,9 @@ let repair_dangling_tool_use_messages_with_stats
           current.content
       in
       ( { current with content }
+        |> with_pair_repair_metadata
+             ~kind:"downgraded_tool_use"
+             ~count:!downgraded_tool_uses
       , { empty_tool_pair_repair_stats with
           downgraded_tool_uses = !downgraded_tool_uses
         } )
@@ -609,6 +637,9 @@ let repair_orphan_tool_result_messages_with_stats
                   msg.content
               in
               ( { msg with content }
+                |> with_pair_repair_metadata
+                     ~kind:"downgraded_tool_result"
+                     ~count:!downgraded_tool_results
               , { empty_tool_pair_repair_stats with
                   downgraded_tool_results = !downgraded_tool_results
                 } )

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -96,6 +96,10 @@ type tool_pair_repair_stats =
 
 val tool_pair_repair_stats_changed : tool_pair_repair_stats -> bool
 
+val pair_repair_metadata_key : string
+(** Message metadata key carrying bounded provenance for tool-pair repair
+    fabrications. Repaired messages also carry [was_fabricated=true]. *)
+
 (** Same repair as {!repair_broken_tool_call_pairs}, plus counters for
     ToolUse/ToolResult blocks downgraded to plain text. This keeps the
     repair path observable without changing the legacy return type. *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1398,9 +1398,9 @@ let init () =
      (dangling_tool_use|orphan_tool_result), site."
     Counter;
   (* C1 (CRIT) from oas-internal-audit.html §6: compaction call site
-     fabrication counter. Closes the Prometheus-counter half — the
-     was_fabricated:true message metadata half is RFC-scope. Kind label is
-     a closed 2-value vocabulary tied directly to pair_repair_stats from
+     fabrication counter. Repaired messages also carry was_fabricated:true
+     metadata plus bounded provenance. Kind label is a closed 2-value
+     vocabulary tied directly to pair_repair_stats from
      Keeper_context_core.repair_broken_tool_call_pairs_with_stats. *)
   add
     Keeper_metrics.metric_keeper_compaction_pair_repair_fabrications

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -293,6 +293,24 @@ let test_pair_repair_stats_count_downgrades () =
     (KC.tool_pair_repair_stats_changed stats);
   Alcotest.(check int) "dangling tool use downgraded" 1 stats.downgraded_tool_uses;
   Alcotest.(check int) "orphan tool result downgraded" 1 stats.downgraded_tool_results;
+  let repair_metadata =
+    List.filter_map
+      (fun (msg : Agent_sdk.Types.message) ->
+         match
+           ( List.assoc_opt "was_fabricated" msg.metadata
+           , List.assoc_opt KC.pair_repair_metadata_key msg.metadata )
+         with
+         | Some (`Bool true), Some (`Assoc fields) ->
+           (match List.assoc_opt "kind" fields, List.assoc_opt "count" fields with
+            | Some (`String kind), Some (`Int count) -> Some (kind, count)
+            | _ -> None)
+         | _ -> None)
+      repaired
+  in
+  Alcotest.(check (list (pair string int)))
+    "repaired messages carry fabrication metadata"
+    [ "downgraded_tool_use", 1; "downgraded_tool_result", 1 ]
+    repair_metadata;
   let has_structured_tool_block =
     List.exists
       (fun (msg : Agent_sdk.Types.message) ->


### PR DESCRIPTION
## Summary
- tag messages repaired by keeper tool-pair repair with `was_fabricated=true`
- attach bounded provenance under `masc.tool_pair_repair` with repair kind and count
- update compaction/metrics comments and the pair-repair regression test to assert the metadata

## Validation
- `ocamlformat --check lib/keeper/keeper_context_core.ml lib/keeper/keeper_context_core.mli lib/keeper/keeper_compact_policy.ml lib/prometheus.ml test/test_pbt_context_overflow.ml`
- `git diff --check`

## Not run
- `scripts/dune-local.sh build test/test_pbt_context_overflow.exe` did not complete locally because the repo-local Dune/opam lock was occupied by other active masc-mcp worktree builds. CI should run this target on the branch.
