### PR TITLE
fix(keeper): sweep cursor-covered reaction stimuli

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -86,6 +86,7 @@ type keeper_board_signal = {
   title : string;
   content : string;
   hearth : string option;
+  updated_at : float option;
 }
 
 type board_sse_event =
@@ -369,6 +370,7 @@ let create_post ~author ~content ?title ?body ~post_kind ?meta_json
               title = post.title;
               content = post.content;
               hearth = post.hearth;
+              updated_at = Some post.updated_at;
             };
           emit_board_sse_event
             (Post_created
@@ -480,6 +482,7 @@ let add_comment ~post_id ~author ~content ?parent_id
                   title = post.title;
                   content;
                   hearth = post.hearth;
+                  updated_at = Some post.updated_at;
                 }
           | Error e ->
               Log.BoardLog.warn "board signal skipped: get_post failed for %s: %s"

--- a/lib/board_dispatch.mli
+++ b/lib/board_dispatch.mli
@@ -44,6 +44,7 @@ type keeper_board_signal = {
   title : string;
   content : string;
   hearth : string option;
+  updated_at : float option;
 }
 
 type board_sse_event =

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -242,6 +242,8 @@ let board_signal_stimulus ~(reason : string) (signal : Board_dispatch.keeper_boa
       ; "title", `String signal.title
       ; "content", `String signal.content
       ; "hearth", (match signal.hearth with Some v -> `String v | None -> `Null)
+      ; ( "updated_at_unix"
+        , match signal.updated_at with Some v -> `Float v | None -> `Null )
       ; "wake_reason", `String reason
       ]
     |> Yojson.Safe.to_string

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -42,6 +42,22 @@ let option_json f = function
 
 let list_json values = `List (List.map (fun value -> `String value) values)
 
+let payload_field name payload =
+  try
+    match Yojson.Safe.from_string payload with
+    | `Assoc fields -> List.assoc_opt name fields
+    | _ -> None
+  with
+  | Yojson.Json_error _ -> None
+;;
+
+let payload_float_field name payload =
+  match payload_field name payload with
+  | Some (`Float value) -> Some value
+  | Some (`Int value) -> Some (float_of_int value)
+  | _ -> None
+;;
+
 let payload_preview payload =
   let limit = 512 in
   if String.length payload <= limit
@@ -112,6 +128,11 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
   let kind = stimulus_kind_of_event_queue stimulus in
   let stimulus_id = stimulus_id_of_event_queue stimulus in
   let recorded_at = Time_compat.now () in
+  let board_updated_at =
+    match kind with
+    | Board_signal -> payload_float_field "updated_at_unix" stimulus.payload
+    | Bootstrap | Alive_but_stuck_recovery | Unknown _ -> None
+  in
   `Assoc
     (base_fields
        ~record_kind:"stimulus"
@@ -126,6 +147,7 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
              ; "post_id", `String stimulus.post_id
              ; "urgency", `String (urgency_to_string stimulus.urgency)
              ; "arrived_at_unix", `Float stimulus.arrived_at
+             ; "board_updated_at_unix", option_json (fun value -> `Float value) board_updated_at
              ; "payload_preview", `String (payload_preview stimulus.payload)
              ] )
        ])
@@ -320,6 +342,12 @@ let nested_string_field outer inner json =
   | None -> None
 ;;
 
+let nested_float_field outer inner json =
+  match assoc_field outer json with
+  | Some nested -> float_field inner nested
+  | None -> None
+;;
+
 let option_string_json = function
   | Some value -> `String value
   | None -> `Null
@@ -342,6 +370,30 @@ let cap_list limit values =
   loop limit [] values
 ;;
 
+let compare_board_cursor_token (ts_a, post_id_a) (ts_b, post_id_b) =
+  let cmp = Float.compare ts_a ts_b in
+  if cmp <> 0 then cmp else String.compare post_id_a post_id_b
+;;
+
+let board_stimulus_token row =
+  match nested_string_field "stimulus" "kind" row with
+  | Some "board_signal" ->
+    let post_id =
+      match nested_string_field "stimulus" "post_id" row with
+      | Some value -> value
+      | None -> ""
+    in
+    (match nested_float_field "stimulus" "board_updated_at_unix" row with
+     | Some updated_at -> Some ((updated_at, post_id), false)
+     | None ->
+       (* Legacy rows written before board cursor tokens were persisted still
+          need a conservative replay path for live operator visibility. *)
+       (match nested_float_field "stimulus" "arrived_at_unix" row with
+        | Some arrived_at -> Some ((arrived_at, post_id), true)
+        | None -> None))
+  | _ -> None
+;;
+
 let summarize_rows ~keeper_name ~limit rows =
   let row_count = List.length rows in
   let stimulus_count = ref 0 in
@@ -355,7 +407,11 @@ let summarize_rows ~keeper_name ~limit rows =
   let latest_recorded_at = ref None in
   let latest_stimulus_id = ref None in
   let stimulus_seen = Hashtbl.create 16 in
+  let board_stimulus_tokens = Hashtbl.create 16 in
   let stimulus_order = ref [] in
+  let latest_board_cursor = ref None in
+  let cursor_swept_stimulus_count = ref 0 in
+  let legacy_cursor_swept_stimulus_count = ref 0 in
   let remember_stimulus stimulus_id =
     if not (Hashtbl.mem stimulus_seen stimulus_id) then begin
       Hashtbl.add stimulus_seen stimulus_id false;
@@ -365,6 +421,48 @@ let summarize_rows ~keeper_name ~limit rows =
   let mark_reacted stimulus_id =
     match Hashtbl.find_opt stimulus_seen stimulus_id with
     | Some _ -> Hashtbl.replace stimulus_seen stimulus_id true
+    | None -> ()
+  in
+  let mark_cursor_swept stimulus_id =
+    match Hashtbl.find_opt stimulus_seen stimulus_id with
+    | Some false ->
+      Hashtbl.replace stimulus_seen stimulus_id true;
+      incr cursor_swept_stimulus_count
+    | Some true | None -> ()
+  in
+  let mark_board_cursor_swept cursor_token =
+    Hashtbl.iter
+      (fun stimulus_id (stimulus_token, legacy_token) ->
+        if compare_board_cursor_token stimulus_token cursor_token <= 0 then begin
+          let before = Hashtbl.find_opt stimulus_seen stimulus_id in
+          mark_cursor_swept stimulus_id;
+          match before, Hashtbl.find_opt stimulus_seen stimulus_id with
+          | Some false, Some true when legacy_token ->
+            incr legacy_cursor_swept_stimulus_count
+          | _ -> ()
+        end)
+      board_stimulus_tokens
+  in
+  let note_board_cursor cursor_token =
+    (match !latest_board_cursor with
+     | Some latest when compare_board_cursor_token latest cursor_token >= 0 -> ()
+     | _ -> latest_board_cursor := Some cursor_token);
+    mark_board_cursor_swept cursor_token
+  in
+  let remember_board_stimulus row stimulus_id =
+    match board_stimulus_token row with
+    | Some (stimulus_token, legacy_token) ->
+      Hashtbl.replace board_stimulus_tokens stimulus_id (stimulus_token, legacy_token);
+      (match !latest_board_cursor with
+       | Some cursor_token
+         when compare_board_cursor_token stimulus_token cursor_token <= 0 ->
+         let before = Hashtbl.find_opt stimulus_seen stimulus_id in
+         mark_cursor_swept stimulus_id;
+         (match before, Hashtbl.find_opt stimulus_seen stimulus_id with
+          | Some false, Some true when legacy_token ->
+            incr legacy_cursor_swept_stimulus_count
+          | _ -> ())
+       | _ -> ())
     | None -> ()
   in
   let note_reaction_kind = function
@@ -386,7 +484,8 @@ let summarize_rows ~keeper_name ~limit rows =
       match string_field "record_kind" row, stimulus_id with
       | Some "stimulus", Some id ->
         incr stimulus_count;
-        remember_stimulus id
+        remember_stimulus id;
+        remember_board_stimulus row id
       | Some "reaction", Some id ->
         incr reaction_count;
         note_reaction_kind (nested_string_field "reaction" "kind" row);
@@ -394,13 +493,27 @@ let summarize_rows ~keeper_name ~limit rows =
       | Some "cursor_ack", Some id ->
         incr reaction_count;
         incr cursor_ack_count;
-        mark_reacted id
+        mark_reacted id;
+        (match nested_float_field "cursor" "cursor_ts" row with
+         | Some cursor_ts ->
+           let cursor_post_id =
+             nested_string_field "cursor" "post_id" row |> Option.value ~default:""
+           in
+           note_board_cursor (cursor_ts, cursor_post_id)
+         | None -> ())
       | Some "reaction", None ->
         incr reaction_count;
         note_reaction_kind (nested_string_field "reaction" "kind" row)
       | Some "cursor_ack", None ->
         incr reaction_count;
-        incr cursor_ack_count
+        incr cursor_ack_count;
+        (match nested_float_field "cursor" "cursor_ts" row with
+         | Some cursor_ts ->
+           let cursor_post_id =
+             nested_string_field "cursor" "post_id" row |> Option.value ~default:""
+           in
+           note_board_cursor (cursor_ts, cursor_post_id)
+         | None -> ())
       | _ -> ())
     rows;
   let pending_stimulus_ids =
@@ -432,6 +545,8 @@ let summarize_rows ~keeper_name ~limit rows =
     ; "terminal_reason_count", `Int !terminal_reason_count
     ; "operator_escalation_count", `Int !operator_escalation_count
     ; "unknown_reaction_count", `Int !unknown_reaction_count
+    ; "cursor_swept_stimulus_count", `Int !cursor_swept_stimulus_count
+    ; "legacy_cursor_swept_stimulus_count", `Int !legacy_cursor_swept_stimulus_count
     ; "pending_stimulus_count", `Int pending_stimulus_count
     ; ( "pending_stimulus_ids"
       , `List
@@ -460,6 +575,8 @@ let error_summary ~keeper_name ~limit error =
     ; "terminal_reason_count", `Int 0
     ; "operator_escalation_count", `Int 0
     ; "unknown_reaction_count", `Int 0
+    ; "cursor_swept_stimulus_count", `Int 0
+    ; "legacy_cursor_swept_stimulus_count", `Int 0
     ; "pending_stimulus_count", `Int 0
     ; "pending_stimulus_ids", `List []
     ; "latest_recorded_at_unix", `Null
@@ -553,6 +670,9 @@ let fleet_summary_json ~base_path ~keeper_names ~limit_per_keeper =
     ; "terminal_reason_count", `Int (total_int "terminal_reason_count")
     ; "operator_escalation_count", `Int (total_int "operator_escalation_count")
     ; "unknown_reaction_count", `Int (total_int "unknown_reaction_count")
+    ; "cursor_swept_stimulus_count", `Int (total_int "cursor_swept_stimulus_count")
+    ; ( "legacy_cursor_swept_stimulus_count"
+      , `Int (total_int "legacy_cursor_swept_stimulus_count") )
     ; "pending_stimulus_count", `Int pending_count
     ; "pending_by_keeper", `List pending_by_keeper
     ; "read_error_count", `Int read_error_count

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -731,6 +731,14 @@ let json_string_null_member name fields =
   | _ -> None
 ;;
 
+let json_float_null_member name fields =
+  match List.assoc_opt name fields with
+  | Some (`Float value) -> Some value
+  | Some (`Int value) -> Some (float_of_int value)
+  | Some `Null | None -> None
+  | _ -> None
+;;
+
 let board_signal_kind_of_string = function
   | "post_created" | "post" -> Some Board_dispatch.Board_post_created
   | "comment_added" | "comment" -> Some Board_dispatch.Board_comment_added
@@ -761,6 +769,7 @@ let board_signal_of_stimulus_payload payload =
               ; title
               ; content
               ; hearth = json_string_null_member "hearth" fields
+              ; updated_at = json_float_null_member "updated_at_unix" fields
               })
            (board_signal_kind_of_string kind)
        | _ -> None)
@@ -912,6 +921,7 @@ let collect_board_events_with_cursor_policy
              ; title = p.title
              ; content = p.content
              ; hearth = p.hearth
+             ; updated_at = Some p.updated_at
              }
            in
            let matched = board_signal_match ~continuity_summary ~meta ~signal in
@@ -955,6 +965,7 @@ let collect_board_events_with_cursor_policy
                ; title = p.title
                ; content = p.content
                ; hearth = p.hearth
+               ; updated_at = Some p.updated_at
                }
              in
              let matched = board_signal_match ~continuity_summary ~meta ~signal in

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -9,23 +9,29 @@ let with_temp_base f =
   f base_path
 ;;
 
-let board_payload ~post_id =
+let board_payload ?updated_at ~post_id () =
   `Assoc
-    [ "source", `String "board_signal"
-    ; "kind", `String "post_created"
-    ; "post_id", `String post_id
-    ; "author", `String "operator"
-    ; "title", `String "Ship reaction ledger"
-    ; "content", `String "Please react"
-    ]
+    ([ "source", `String "board_signal"
+     ; "kind", `String "post_created"
+     ; "post_id", `String post_id
+     ; "author", `String "operator"
+     ; "title", `String "Ship reaction ledger"
+     ; "content", `String "Please react"
+     ]
+     @
+     match updated_at with
+     | Some value -> [ "updated_at_unix", `Float value ]
+     | None -> [])
   |> Yojson.Safe.to_string
 ;;
 
-let board_stimulus ?(post_id = "post-42") () : Keeper_event_queue.stimulus =
+let board_stimulus ?(post_id = "post-42") ?updated_at () :
+  Keeper_event_queue.stimulus
+  =
   { post_id
   ; urgency = Immediate
   ; arrived_at = 1234.5
-  ; payload = board_payload ~post_id
+  ; payload = board_payload ?updated_at ~post_id ()
   }
 ;;
 
@@ -179,6 +185,84 @@ let test_summary_marks_unreacted_and_reacted_stimuli () =
     (reacted_summary |> member "turn_started_count" |> to_int)
 ;;
 
+let test_summary_cursor_ack_sweeps_covered_board_stimuli () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "cursor-sweep-keeper" in
+  let first = board_stimulus ~post_id:"post-1" ~updated_at:10.0 () in
+  let second = board_stimulus ~post_id:"post-2" ~updated_at:20.0 () in
+  let third = board_stimulus ~post_id:"post-3" ~updated_at:30.0 () in
+  List.iter
+    (Keeper_reaction_ledger.record_event_queue_stimulus ~base_path ~keeper_name)
+    [ first; second ];
+  Keeper_reaction_ledger.record_board_cursor_ack
+    ~base_path
+    ~keeper_name
+    ~cursor_ts:20.0
+    ~post_id:(Some "post-2")
+    ();
+  let swept_summary =
+    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check_member_string "cursor-swept summary status" "ok" "status" swept_summary;
+  check int "cursor-swept pending count" 0
+    (swept_summary |> member "pending_stimulus_count" |> to_int);
+  check int "cursor sweep count" 1
+    (swept_summary |> member "cursor_swept_stimulus_count" |> to_int);
+  Keeper_reaction_ledger.record_event_queue_stimulus ~base_path ~keeper_name third;
+  let future_summary =
+    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check_member_string "future stimulus remains degraded" "degraded" "status" future_summary;
+  check int "future pending count" 1
+    (future_summary |> member "pending_stimulus_count" |> to_int);
+  check string "future pending stimulus id" "board:post-3"
+    (future_summary
+     |> member "pending_stimulus_ids"
+     |> to_list
+     |> List.hd
+     |> to_string)
+;;
+
+let test_summary_cursor_ack_respects_post_id_tiebreaker () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "cursor-tiebreaker-keeper" in
+  let first = board_stimulus ~post_id:"post-1" ~updated_at:50.0 () in
+  let second = board_stimulus ~post_id:"post-2" ~updated_at:50.0 () in
+  List.iter
+    (Keeper_reaction_ledger.record_event_queue_stimulus ~base_path ~keeper_name)
+    [ first; second ];
+  Keeper_reaction_ledger.record_board_cursor_ack
+    ~base_path
+    ~keeper_name
+    ~cursor_ts:50.0
+    ~post_id:(Some "post-1")
+    ();
+  let partial_summary =
+    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check_member_string "partial cursor summary status" "degraded" "status" partial_summary;
+  check int "one post remains pending" 1
+    (partial_summary |> member "pending_stimulus_count" |> to_int);
+  check string "later same-timestamp post remains pending" "board:post-2"
+    (partial_summary
+     |> member "pending_stimulus_ids"
+     |> to_list
+     |> List.hd
+     |> to_string);
+  Keeper_reaction_ledger.record_board_cursor_ack
+    ~base_path
+    ~keeper_name
+    ~cursor_ts:50.0
+    ~post_id:(Some "post-2")
+    ();
+  let complete_summary =
+    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check_member_string "complete cursor summary status" "ok" "status" complete_summary;
+  check int "same timestamp posts cleared" 0
+    (complete_summary |> member "pending_stimulus_count" |> to_int)
+;;
+
 let () =
   run
     "keeper_reaction_ledger"
@@ -199,6 +283,14 @@ let () =
             "summary marks unreacted and reacted stimuli"
             `Quick
             test_summary_marks_unreacted_and_reacted_stimuli
+        ; test_case
+            "summary cursor ack sweeps covered board stimuli"
+            `Quick
+            test_summary_cursor_ack_sweeps_covered_board_stimuli
+        ; test_case
+            "summary cursor ack respects board post id tiebreaker"
+            `Quick
+            test_summary_cursor_ack_respects_post_id_tiebreaker
         ] )
     ]
 ;;

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -1537,6 +1537,7 @@ let test_board_signal_wakeup_ignores_unmatched_posts_without_opt_in () =
             title = post.title;
             content = post.content;
             hearth = post.hearth;
+            updated_at = Some post.updated_at;
           }
         in
         KK.wakeup_relevant_keeper_for_board_signal ~config signal;
@@ -1582,6 +1583,7 @@ let test_board_signal_wakeup_only_wakes_opted_in_scope_keeper () =
             title = post.title;
             content = post.content;
             hearth = post.hearth;
+            updated_at = Some post.updated_at;
           }
         in
         KK.wakeup_relevant_keeper_for_board_signal ~config signal;
@@ -1649,6 +1651,7 @@ let test_board_signal_wakeup_keeps_thread_reply_after_self_comment () =
             title = post.title;
             content = "There is a new question for you.";
             hearth = post.hearth;
+            updated_at = Some post.updated_at;
           }
         in
         KK.wakeup_relevant_keeper_for_board_signal ~config signal;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1029,6 +1029,59 @@ let test_health_json_surfaces_durable_paused_keepers () =
             true
             (reaction_ledger |> member "operator_action_required" |> to_bool)))
 
+let test_health_json_reaction_ledger_cursor_sweep_clears_pending () =
+  with_temp_dir "health-reaction-ledger-cursor-sweep" (fun dir ->
+    with_env "MASC_BASE_PATH" (Some dir) (fun () ->
+      Fun.protect
+        ~finally:(fun () ->
+          Server_auth.server_state := None;
+          Config_dir_resolver.reset ())
+        (fun () ->
+        Config_dir_resolver.reset ();
+        let state = Mcp_server.create_state ~base_path:dir in
+        Server_auth.server_state := Some state;
+        let config = state.Mcp_server.room_config in
+        write_keeper_meta_exn config
+          (make_keeper_meta ~name:"cursor-swept" ~trace_id:"trace-cursor" ());
+        let stimulus post_id updated_at : Keeper_event_queue.stimulus =
+          { post_id
+          ; urgency = Immediate
+          ; arrived_at = updated_at +. 10.0
+          ; payload =
+              Yojson.Safe.to_string
+                (`Assoc
+                   [ "source", `String "board_signal"
+                   ; "kind", `String "post_created"
+                   ; "post_id", `String post_id
+                   ; "updated_at_unix", `Float updated_at
+                   ])
+          }
+        in
+        List.iter
+          (Keeper_reaction_ledger.record_event_queue_stimulus
+             ~base_path:dir
+             ~keeper_name:"cursor-swept")
+          [ stimulus "health-post-1" 10.0; stimulus "health-post-2" 20.0 ];
+        Keeper_reaction_ledger.record_board_cursor_ack
+          ~base_path:dir
+          ~keeper_name:"cursor-swept"
+          ~cursor_ts:20.0
+          ~post_id:(Some "health-post-2")
+          ();
+        let request = Httpun.Request.create `GET "/health" in
+        let json = Server_routes_http_runtime.make_health_json request in
+        let open Yojson.Safe.Util in
+        let reaction_ledger = json |> member "keeper_reaction_ledger" in
+        Alcotest.(check string) "health cursor-swept reaction ledger ok"
+          "ok"
+          (reaction_ledger |> member "status" |> to_string);
+        Alcotest.(check int) "health cursor-swept pending stimuli" 0
+          (reaction_ledger |> member "pending_stimulus_count" |> to_int);
+        Alcotest.(check bool)
+          "health cursor-swept reaction ledger clears operator action"
+          false
+          (reaction_ledger |> member "operator_action_required" |> to_bool))))
+
 let test_health_json_surfaces_log_ring_summary () =
   Log.set_level Log.Info;
   Log.emit Log.Warn ~module_name:"HealthTest"
@@ -2590,6 +2643,9 @@ let () =
           Alcotest.test_case
             "health json surfaces durable paused keepers"
             `Quick test_health_json_surfaces_durable_paused_keepers;
+          Alcotest.test_case
+            "health json reaction ledger cursor sweep clears pending"
+            `Quick test_health_json_reaction_ledger_cursor_sweep_clears_pending;
           Alcotest.test_case "health json surfaces log ring summary" `Quick
             test_health_json_surfaces_log_ring_summary;
           Alcotest.test_case "readiness false before init" `Quick


### PR DESCRIPTION
## Summary

Fixes #15857.

Keeper Reaction Ledger now treats a board cursor acknowledgement as covering all board stimuli at or before the cursor token, instead of requiring an exact stimulus id match. This prevents already-processed board activity from staying pending forever after a later cursor ack.

## Changes

- Propagate board `updated_at` into keeper board-signal stimuli and persisted ledger rows.
- Summarize board stimulus tokens as `(board_updated_at_unix, post_id)` with legacy fallback to arrival time for old rows.
- Sweep cursor-covered board stimuli in ledger summary while preserving exact stimulus-id reaction matching.
- Expose `cursor_swept_stimulus_count` and `legacy_cursor_swept_stimulus_count` in summaries and fleet totals.
- Add regression coverage for cursor sweep, same-timestamp post id tiebreaking, and `/health` pending-stimulus status.

## Verification

- `env DUNE_CACHE=disabled dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/reaction-ledger-cursor-sweep-20260517 --display=short -j 2 test/test_keeper_reaction_ledger.exe test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_keeper_reaction_ledger.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 32`

Note: `origin/main` continued advancing during local verification; this branch was validated after the latest completed rebase at the time of push, then left as a draft PR for CI to verify against GitHub state.
