### PR TITLE
fix(task): preserve typed PR evidence

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -16,6 +16,32 @@ include Coord_task_classify
 include Coord_task_create
 include Coord_task_claim
 
+let action_persists_handoff_context = function
+  | Masc_domain.Release
+  | Masc_domain.Done_action
+  | Masc_domain.Submit_for_verification
+  | Masc_domain.Submit_pr_evidence ->
+    true
+  | Masc_domain.Claim
+  | Masc_domain.Start
+  | Masc_domain.Cancel
+  | Masc_domain.Approve_verification
+  | Masc_domain.Reject_verification ->
+    false
+
+let verification_submission_evidence_refs task handoff_context =
+  let contract_refs =
+    match task.contract with
+    | Some c -> c.verify_gate_evidence
+    | None -> []
+  in
+  let handoff_refs =
+    match handoff_context with
+    | Some (hc : Masc_domain.task_handoff_context) -> hc.evidence_refs
+    | None -> []
+  in
+  normalized_string_list (contract_refs @ handoff_refs)
+
 let transition_task_r
       config
       ~agent_name
@@ -229,9 +255,7 @@ let transition_task_r
             , Masc_domain.AwaitingVerification { assignee; verification_id; _ }
             , Some prepare ) ->
             let evidence_refs =
-              match task.contract with
-              | Some c -> c.verify_gate_evidence
-              | None -> []
+              verification_submission_evidence_refs task handoff_context
             in
             (match prepare ~task ~assignee ~verification_id ~evidence_refs with
              | Ok () -> Ok ()
@@ -520,16 +544,9 @@ let transition_task_r
                    { t with
                      task_status = new_status
                    ; handoff_context =
-                       (match action with
-                        | Masc_domain.Release -> handoff_context
-                        | Masc_domain.Claim
-                        | Masc_domain.Start
-                        | Masc_domain.Done_action
-                        | Masc_domain.Cancel
-                        | Masc_domain.Submit_for_verification
-                        | Masc_domain.Submit_pr_evidence
-                        | Masc_domain.Approve_verification
-                        | Masc_domain.Reject_verification -> None)
+                       (if action_persists_handoff_context action
+                        then handoff_context
+                        else None)
                    ; cycle_count
                    ; do_not_reclaim_reason
                    })
@@ -563,9 +580,9 @@ let transition_task_r
                ?notes:(trim_opt (Some notes))
                ?reason:(trim_opt (Some reason))
                ?handoff_context:
-                 (match handoff_context with
-                  | Some _ when action = Masc_domain.Release -> handoff_context
-                  | _ -> None)
+                 (if action_persists_handoff_context action
+                  then handoff_context
+                  else None)
                ());
           (match action with
            | Masc_domain.Claim ->
@@ -621,12 +638,23 @@ let transition_task_r
                         ]
                       | None -> []))
            | Masc_domain.Submit_for_verification | Masc_domain.Submit_pr_evidence ->
+             let payload =
+               `Assoc
+                 ([ "task_id", `String task_id ]
+                  @
+                  match handoff_context with
+                  | Some handoff_context ->
+                    [ ( "handoff_context"
+                      , Masc_domain.task_handoff_context_to_yojson handoff_context )
+                    ]
+                  | None -> [])
+             in
              emit_task_activity
                config
                ~agent_name
                ~task_id
                ~kind:(Event_kind.Task.to_string Event_kind.Task.Submit_for_verification)
-               ~payload:(`Assoc [ "task_id", `String task_id ])
+               ~payload
            | Masc_domain.Approve_verification ->
              emit_task_activity
                config

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -328,13 +328,41 @@ let notes_have_verification_artifact_ref notes =
   in
   has_github_pull || has_pr_shorthand || has_explicit_artifact
 
-let verification_submission_evidence_error ~notes =
-  if notes_have_verification_artifact_ref notes then None
+let non_empty_trimmed_strings values =
+  values
+  |> List.filter_map (fun value ->
+         let value = String.trim value in
+         if String.equal value "" then None else Some value)
+  |> List.sort_uniq String.compare
+
+let handoff_context_has_verification_artifact_ref = function
+  | Some (handoff_context : Masc_domain.task_handoff_context) ->
+      handoff_context.evidence_refs |> non_empty_trimmed_strings |> fun refs ->
+      refs <> []
+  | None -> false
+
+let verification_submission_evidence_error ~notes ~handoff_context =
+  if notes_have_verification_artifact_ref notes
+     || handoff_context_has_verification_artifact_ref handoff_context
+  then None
   else
     Some
       "submit_for_verification requires verification evidence: include pr_url \
        for the draft PR, a PR # reference, or an explicit \
        artifact/file/path/commit/branch reference in notes."
+
+let verification_evidence_refs_for_task (task : Masc_domain.task) =
+  let contract_refs =
+    match task.contract with
+    | Some contract -> contract.verify_gate_evidence
+    | None -> []
+  in
+  let handoff_refs =
+    match task.handoff_context with
+    | Some handoff_context -> handoff_context.evidence_refs
+    | None -> []
+  in
+  non_empty_trimmed_strings (contract_refs @ handoff_refs)
 
 let parse_task_contract args =
   match args |> member "contract" with
@@ -468,7 +496,7 @@ let parse_handoff_context ~(agent_name : string)
                    handoff_context with
                    summary;
                    evidence_refs =
-                     List.sort_uniq String.compare handoff_context.evidence_refs;
+                     non_empty_trimmed_strings handoff_context.evidence_refs;
                    updated_at = Some (Masc_domain.now_iso ());
                    updated_by = Some agent_name;
                  }))
@@ -1119,7 +1147,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
   let submit_evidence_error =
     match requested_action with
     | Masc_domain.Submit_for_verification | Masc_domain.Submit_pr_evidence ->
-      verification_submission_evidence_error ~notes
+      verification_submission_evidence_error ~notes ~handoff_context
     | Masc_domain.Claim
     | Masc_domain.Start
     | Masc_domain.Done_action
@@ -1257,9 +1285,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
           let tasks = Coord.get_tasks_raw ctx.config in
           (match List.find_opt (fun (t : Masc_domain.task) -> String.equal t.id task_id) tasks with
            | Some task ->
-             let evidence_refs = match task.contract with
-               | Some c -> c.verify_gate_evidence
-               | None -> [] in
+             let evidence_refs = verification_evidence_refs_for_task task in
              (match task.task_status with
               | Masc_domain.AwaitingVerification { verification_id; assignee; _ } ->
                 Verification_protocol.notify_submit_for_verification


### PR DESCRIPTION
## Summary
- Preserve typed handoff_context evidence for done, submit_for_verification, and submit_pr_evidence transitions instead of dropping it after normalization.
- Let submit evidence validation accept handoff_context.evidence_refs, so pr_url aliases normalized into typed evidence are not rejected as missing evidence.
- Pass persisted typed evidence refs into verification request/notification payloads alongside contract verify_gate_evidence.

## Root Cause
pr_url was normalized into handoff_context.evidence_refs, but the later evidence gate still checked only notes and Coord transition persistence cleared handoff_context for submit evidence actions. That made submit_pr_evidence fail or lose the typed PR reference before verifier handoff.

## Verification
- env DUNE_BUILD_DIR=/private/tmp/masc-mcp-submit-pr-evidence-fix-build DUNE_LOCAL_JOBS=1 DUNE_CACHE=disabled MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=0 scripts/dune-local.sh build test/test_tool_task_coverage.exe test/test_keeper_task_dispatch.exe
- /private/tmp/masc-mcp-submit-pr-evidence-fix-build/default/test/test_tool_task_coverage.exe (84 tests)
- /private/tmp/masc-mcp-submit-pr-evidence-fix-build/default/test/test_keeper_task_dispatch.exe (49 tests)
- git diff --check
- ocamlformat --check lib/tool_task.ml lib/coord/coord_task.ml