### PR TITLE
fix(keeper): prevent 64-keeper workload stampedes

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -205,6 +205,7 @@ type bash_shape_block =
   | Pipe_or_redirect
   | Chaining
   | Substitution
+  | Repo_wide_scan
 
 let string_contains_char s ch = String.exists (Char.equal ch) s
 let string_contains_substring s needle = String_util.contains_substring s needle
@@ -216,6 +217,126 @@ let has_malformed_dev_null_redirect_token scan_text =
     match String.trim (String.lowercase_ascii token) with
     | "0/dev/null" | "1/dev/null" | "2/dev/null" -> true
     | _ -> false)
+
+let strip_trailing_slashes text =
+  let rec loop i =
+    if i > 0 && Char.equal text.[i - 1] '/' then loop (i - 1) else i
+  in
+  let len = loop (String.length text) in
+  if len = String.length text then text else String.sub text 0 len
+
+let is_repo_wide_root text =
+  let text = String.trim text |> strip_trailing_slashes in
+  String.equal text "."
+  || String.equal text "./"
+  || String.equal text "repos"
+  || String.equal text "./repos"
+
+let is_scoped_read_root text =
+  let text = String.trim text |> strip_trailing_slashes in
+  String.starts_with ~prefix:"lib" text
+  || String.starts_with ~prefix:"test" text
+  || String.starts_with ~prefix:"bin" text
+  || String.starts_with ~prefix:"docs" text
+  || String.starts_with ~prefix:"src" text
+  || String.starts_with ~prefix:"repos/" text
+  || String.contains text '/'
+
+let option_consumes_next_arg text =
+  match text with
+  | "-e" | "-f" | "-g" | "-m" | "-t" | "--after-context" | "--before-context"
+  | "--context" | "--exclude" | "--exclude-dir" | "--glob" | "--include"
+  | "--max-count" | "--regexp" | "--type" | "--type-add" -> true
+  | _ -> false
+
+let rec non_option_args = function
+  | [] -> []
+  | arg :: _ :: rest when option_consumes_next_arg arg.text -> non_option_args rest
+  | arg :: rest when String.starts_with ~prefix:"--" arg.text ->
+    non_option_args rest
+  | arg :: rest
+    when String.length arg.text > 1 && Char.equal arg.text.[0] '-' ->
+    non_option_args rest
+  | arg :: rest -> arg.text :: non_option_args rest
+
+let grep_has_recursive_flag args =
+  List.exists
+    (fun arg ->
+       String.equal arg.text "-r"
+       || String.equal arg.text "-R"
+       ||
+       (String.length arg.text > 2
+        && Char.equal arg.text.[0] '-'
+        && not (String.starts_with ~prefix:"--" arg.text)
+        && String.exists (function 'r' | 'R' -> true | _ -> false) arg.text))
+    args
+
+let grep_is_repo_wide args =
+  if not (grep_has_recursive_flag args)
+  then false
+  else (
+    let positional = non_option_args args in
+    let paths =
+      match positional with
+      | _pattern :: paths -> paths
+      | [] -> []
+    in
+    paths = []
+    || List.exists is_repo_wide_root paths
+    || not (List.exists is_scoped_read_root paths))
+
+let find_is_repo_wide args =
+  match non_option_args args with
+  | root :: _ -> is_repo_wide_root root
+  | [] -> true
+
+let rg_has_files_mode args =
+  List.exists (fun arg -> String.equal arg.text "--files") args
+
+let rg_is_repo_wide args =
+  let positional = non_option_args args in
+  let paths =
+    if rg_has_files_mode args
+    then positional
+    else (
+      match positional with
+      | _pattern :: paths -> paths
+      | [] -> [])
+  in
+  paths = []
+  || List.exists is_repo_wide_root paths
+  || not (List.exists is_scoped_read_root paths)
+
+let git_log_all_is_repo_wide args =
+  match args with
+  | subcmd :: rest when String.equal subcmd.text "log" ->
+    List.exists (fun arg -> String.equal arg.text "--all") rest
+  | _ -> false
+
+let simple_command_is_repo_wide_scan words =
+  match strip_command_wrappers words with
+  | bin :: args ->
+    (match command_name bin.text with
+     | "grep" | "egrep" | "fgrep" -> grep_is_repo_wide args
+     | "find" -> find_is_repo_wide args
+     | "rg" -> rg_is_repo_wide args
+     | "git" -> git_log_all_is_repo_wide args
+     | _ -> false)
+  | [] -> false
+
+let rec command_has_repo_wide_scan cmd =
+  let words = shell_words_with_boundaries cmd in
+  let rec loop = function
+    | word :: rest when word.starts_command ->
+      simple_command_is_repo_wide_scan (word :: rest) || loop rest
+    | _ :: rest -> loop rest
+    | [] -> false
+  in
+  loop words
+  ||
+  match shell_c_payload words with
+  | Some payload -> command_has_repo_wide_scan payload
+  | None -> false
 
 let quote_aware_shape_scan_text cmd =
   let len = String.length cmd in
@@ -271,6 +392,8 @@ let raw_keeper_bash_shape_block cmd =
   let lower = String.lowercase_ascii scan_text in
   if string_contains_substring lower "gh pr checks"
   then Some Gh_pr_checks
+  else if command_has_repo_wide_scan cmd
+  then Some Repo_wide_scan
   else if has_malformed_dev_null_redirect_token scan_text
   then Some Pipe_or_redirect
   else if
@@ -313,7 +436,9 @@ let rec parsed_keeper_bash_shape_block = function
 
 let keeper_bash_shape_block cmd =
   let scan_text = quote_aware_shape_scan_text cmd in
-  if has_malformed_dev_null_redirect_token scan_text
+  if command_has_repo_wide_scan cmd
+  then Some Repo_wide_scan
+  else if has_malformed_dev_null_redirect_token scan_text
   then Some Pipe_or_redirect
   else
   match Masc_exec_bash_parser.Bash.parse_string cmd with
@@ -328,6 +453,7 @@ let bash_shape_block_tag = function
   | Pipe_or_redirect -> "pipe_or_redirect"
   | Chaining -> "chaining"
   | Substitution -> "substitution"
+  | Repo_wide_scan -> "repo_wide_scan"
 
 module For_testing = struct
   let elapsed_duration_ms = elapsed_duration_ms
@@ -352,6 +478,10 @@ let bash_shape_block_reason = function
   | Substitution ->
     "Command substitution is blocked before execution. Compute values in a \
      separate tool call and pass literal arguments."
+  | Repo_wide_scan ->
+    "Repo-wide recursive scans are blocked in raw keeper_bash. Under long \
+     running Keeper fleets they can stampede Docker bind mounts and exhaust \
+     host file descriptors."
 
 let bash_shape_block_hint = function
   | Gh_pr_checks ->
@@ -367,6 +497,10 @@ let bash_shape_block_hint = function
   | Substitution ->
     "Run the discovery command first, then use its literal result in a second \
      keeper_bash call."
+  | Repo_wide_scan ->
+    "Use keeper_shell op=rg/find with a scoped path such as lib/, test/, or a \
+     specific repos/REPO subdirectory; avoid scanning . or repos/ from raw \
+     bash."
 
 let bash_shape_block_alternatives = function
   | Gh_pr_checks ->
@@ -390,6 +524,12 @@ let bash_shape_block_alternatives = function
     [
       "keeper_bash cmd='rg --files lib'";
       "keeper_bash cmd='cat path/from/previous-step'";
+    ]
+  | Repo_wide_scan ->
+    [
+      "keeper_shell op=rg pattern=search-term path=lib";
+      "keeper_shell op=find path=lib name='*.ml'";
+      "keeper_bash cmd='git log --oneline -20'";
     ]
 
 let bash_shape_block_result ~cmd ~cmd_for_log ~env_snapshot block =

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -1398,7 +1398,12 @@ type snapshot_slot =
       { value : Yojson.Safe.t
       ; expires_at : float
       }
-  | Computing of { cond : Eio.Condition.t }
+  | Computing of
+      { cond : Eio.Condition.t
+      ; stale : Yojson.Safe.t option
+      ; started_at : float
+      ; stuck_warned : bool ref
+      }
 
 let _snapshot_table : (string, snapshot_slot) Hashtbl.t = Hashtbl.create 4
 let _snapshot_mu = Eio.Mutex.create ()
@@ -1445,10 +1450,11 @@ let _maybe_evict_snapshot () =
       (match !oldest_cached with
        | Some (key, _) -> Hashtbl.remove _snapshot_table key
        | None ->
-         (* Last resort: evict a Computing slot to enforce the cap *)
-         (match !any_key with
-          | Some key -> Hashtbl.remove _snapshot_table key
-          | None -> ())))
+         (* Never evict an in-flight compute to enforce the entry cap.  Under
+            64-keeper load, replacing a [Computing] slot starts duplicate
+            dashboard snapshots while the old one is still doing filesystem
+            work.  Temporary cache growth is cheaper than a compute stampede. *)
+         ignore !any_key)
 ;;
 
 let invalidate_snapshot_cache () =
@@ -1460,7 +1466,7 @@ let invalidate_snapshot_cache () =
           Hashtbl.fold
             (fun _key slot acc ->
                match slot with
-               | Computing { cond } -> cond :: acc
+               | Computing { cond; _ } -> cond :: acc
                | Cached _ -> acc)
             _snapshot_table
             []
@@ -1524,25 +1530,43 @@ let snapshot_json
           match Hashtbl.find_opt _snapshot_table cache_key with
           | Some (Cached { value; expires_at }) when Time_compat.now () < expires_at ->
             `Hit value
-          | Some (Computing { cond }) ->
-            if waited >= _max_wait_s
+          | Some (Computing { stale = Some value; _ }) -> `Hit value
+          | Some (Computing { started_at; stuck_warned; _ }) ->
+            if waited >= _max_wait_s && not !stuck_warned
             then (
-              (* Stuck compute — evict and take over *)
+              stuck_warned := true;
               Log.Dashboard.warn
-                "[snapshot_json] evicting stuck Computing slot for %s (%.1fs waited)"
+                "[snapshot_json] Computing slot still running for %s \
+                 (waited=%.1fs elapsed=%.1fs); keeping singleflight owner"
                 cache_key
-                waited;
-              Hashtbl.remove _snapshot_table cache_key;
-              Eio.Condition.broadcast cond;
-              let new_cond = Eio.Condition.create () in
-              _maybe_evict_snapshot ();
-              Hashtbl.replace _snapshot_table cache_key (Computing { cond = new_cond });
-              `Compute new_cond)
-            else `Wait
+                waited
+                (Time_compat.now () -. started_at));
+            `Wait
+          | Some (Cached { value; _ }) ->
+            let cond = Eio.Condition.create () in
+            _maybe_evict_snapshot ();
+            Hashtbl.replace
+              _snapshot_table
+              cache_key
+              (Computing
+                 { cond
+                 ; stale = Some value
+                 ; started_at = Time_compat.now ()
+                 ; stuck_warned = ref false
+                 });
+            `Compute cond
           | _ ->
             let cond = Eio.Condition.create () in
             _maybe_evict_snapshot ();
-            Hashtbl.replace _snapshot_table cache_key (Computing { cond });
+            Hashtbl.replace
+              _snapshot_table
+              cache_key
+              (Computing
+                 { cond
+                 ; stale = None
+                 ; started_at = Time_compat.now ()
+                 ; stuck_warned = ref false
+                 });
             `Compute cond)
       in
       match action with
@@ -1559,7 +1583,7 @@ let snapshot_json
            Eio.Mutex.use_rw ~protect:true _snapshot_mu (fun () ->
              (* Only write back if we still own the slot *)
              match Hashtbl.find_opt _snapshot_table cache_key with
-             | Some (Computing { cond = c }) when c == cond ->
+             | Some (Computing { cond = c; _ }) when c == cond ->
                _maybe_evict_snapshot ();
                Hashtbl.replace
                  _snapshot_table
@@ -1574,7 +1598,7 @@ let snapshot_json
            let bt = Printexc.get_raw_backtrace () in
            Eio.Mutex.use_rw ~protect:true _snapshot_mu (fun () ->
              match Hashtbl.find_opt _snapshot_table cache_key with
-             | Some (Computing { cond = c }) when c == cond ->
+             | Some (Computing { cond = c; _ }) when c == cond ->
                Hashtbl.remove _snapshot_table cache_key
              | Some (Cached _) -> ()
              | Some (Computing _) -> ()

--- a/lib/operator/operator_control_snapshot.mli
+++ b/lib/operator/operator_control_snapshot.mli
@@ -212,7 +212,12 @@ val remote_client_type_of_context : 'a context -> string
 
 type snapshot_slot =
   | Cached of { value : Yojson.Safe.t; expires_at : float }
-  | Computing of { cond : Eio.Condition.t }
+  | Computing of
+      { cond : Eio.Condition.t
+      ; stale : Yojson.Safe.t option
+      ; started_at : float
+      ; stuck_warned : bool ref
+      }
 
 val _snapshot_mu : Eio.Mutex.t
 val _snapshot_table : (string, snapshot_slot) Hashtbl.t

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -362,6 +362,37 @@ let test_keeper_bash_raw_shape_fallback_is_quote_aware () =
   Alcotest.(check (option string)) "single-quoted substitution is data" None
     (block_tag {|echo '$(date) > out'|})
 
+let test_keeper_bash_blocks_repo_wide_scans () =
+  let block_tag = Keeper_exec_shell.For_testing.keeper_bash_shape_block_tag in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check (option string))
+        ("repo-wide scan blocked: " ^ cmd)
+        (Some "repo_wide_scan")
+        (block_tag cmd))
+    [
+      {|grep -r "board_post" --include="*.ml" -l|};
+      {|find repos/ -type f -name "*.ml"|};
+      {|find . -type f -name "*.ml"|};
+      {|rg -l "keeper_board_post|board_post" repos/ --type ml|};
+      {|rg "board_post"|};
+      {|git log --all --oneline --grep board_post|};
+      {|bash -lc 'grep -ri "yojson" --include="*.ml" -l'|};
+    ];
+  List.iter
+    (fun cmd ->
+      Alcotest.(check (option string))
+        ("scoped scan allowed: " ^ cmd)
+        None
+        (block_tag cmd))
+    [
+      {|grep -r "board_post" lib|};
+      {|find lib -type f -name "*.ml"|};
+      {|rg -l "board_post" lib --type ml|};
+      {|rg --files lib|};
+      {|git log --oneline -20|};
+    ]
+
 let test_docker_blocks_nested_docker_command () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
@@ -1056,6 +1087,8 @@ let () =
         test_keeper_bash_shape_uses_shell_ir_for_quoted_literals;
       Alcotest.test_case "raw shape fallback is quote-aware" `Quick
         test_keeper_bash_raw_shape_fallback_is_quote_aware;
+      Alcotest.test_case "repo-wide scans blocked" `Quick
+        test_keeper_bash_blocks_repo_wide_scans;
       Alcotest.test_case "empty command blocked" `Quick test_empty_command;
       Alcotest.test_case "docker blocks nested docker command" `Quick
         test_docker_blocks_nested_docker_command;

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -71,6 +71,10 @@ let () =
           Alcotest.test_case "snapshot waiters share inflight result" `Quick
             Test_operator_control_snapshot
             .test_snapshot_waiters_share_inflight_result;
+          Alcotest.test_case "snapshot waiters use stale inflight result"
+            `Quick
+            Test_operator_control_snapshot
+            .test_snapshot_waiter_returns_stale_inflight_result;
           (* orchestra room core shape removed (CP purge) *)
           Alcotest.test_case "digest room pending confirm attention" `Quick
             Test_operator_control_snapshot

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -1011,7 +1011,13 @@ let test_snapshot_waiters_share_inflight_result () =
       Eio.Mutex.use_rw ~protect:true Operator_control_snapshot._snapshot_mu
         (fun () ->
           Hashtbl.replace Operator_control_snapshot._snapshot_table cache_key
-            (Operator_control_snapshot.Computing { cond }));
+            (Operator_control_snapshot.Computing
+               {
+                 cond;
+                 stale = None;
+                 started_at = Time_compat.now ();
+                 stuck_warned = ref false;
+               }));
       let waiter_a, resolve_waiter_a = Eio.Promise.create () in
       let waiter_b, resolve_waiter_b = Eio.Promise.create () in
       Eio.Fiber.fork ~sw (fun () ->
@@ -1052,6 +1058,63 @@ let test_snapshot_waiters_share_inflight_result () =
             | _ -> false)
       in
       Alcotest.(check bool) "healthy inflight slot not evicted" true cached_retained)
+
+let test_snapshot_waiter_returns_stale_inflight_result () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "owner"));
+      ignore (Coord.join config ~agent_name:"owner" ~capabilities:[] ());
+      Operator_control.invalidate_snapshot_cache ();
+      let ctx = operator_ctx env sw config "owner" in
+      ignore (Operator_control.snapshot_json ctx);
+      let cache_key =
+        Eio.Mutex.use_rw ~protect:true Operator_control_snapshot._snapshot_mu
+          (fun () ->
+            match
+              Hashtbl.to_seq_keys Operator_control_snapshot._snapshot_table
+              |> List.of_seq
+            with
+            | key :: _ -> key
+            | [] -> Alcotest.fail "expected primed snapshot cache key")
+      in
+      let cond = Eio.Condition.create () in
+      let stale =
+        `Assoc
+          [
+            ("trace_id", `String "stale-trace");
+            ("status", `String "stale");
+          ]
+      in
+      Eio.Mutex.use_rw ~protect:true Operator_control_snapshot._snapshot_mu
+        (fun () ->
+          Hashtbl.replace Operator_control_snapshot._snapshot_table cache_key
+            (Operator_control_snapshot.Computing
+               {
+                 cond;
+                 stale = Some stale;
+                 started_at = Time_compat.now () -. 120.0;
+                 stuck_warned = ref false;
+               }));
+      let returned = Operator_control.snapshot_json ctx in
+      Alcotest.(check string) "waiter got stale trace" "stale-trace"
+        Yojson.Safe.Util.(returned |> member "trace_id" |> to_string);
+      let still_computing =
+        Eio.Mutex.use_rw ~protect:true Operator_control_snapshot._snapshot_mu
+          (fun () ->
+            match
+              Hashtbl.find_opt Operator_control_snapshot._snapshot_table cache_key
+            with
+            | Some (Operator_control_snapshot.Computing _) -> true
+            | _ -> false)
+      in
+      Alcotest.(check bool) "stale waiter does not replace owner" true
+        still_computing)
 
 (* test_orchestra_room_core_shape removed (CP purge: Command_plane_orchestra deleted) *)
 


### PR DESCRIPTION
## Summary
- keep operator snapshot singleflight ownership intact under slow dashboard refreshes instead of evicting active Computing slots
- preserve stale snapshot values for waiters while a refresh is running
- block repo-wide recursive scans from raw keeper_bash and point keepers to scoped keeper_shell rg/find paths

## Root cause
The 2026-05-17 ENFILE wave was not just a missing FD gate. Logs showed slow dashboard/operator snapshots, OAS retry churn, and repeated raw Docker bash scans such as grep -r, find repos/, rg over repos/, and git log --all. In a 64-keeper, 48h workload model those paths can overlap and restart, creating a filesystem/Docker convoy before the FD guard trips.

## Validation
- ocamlformat --check lib/operator/operator_control_snapshot.ml lib/operator/operator_control_snapshot.mli lib/keeper/keeper_shell_bash.ml test/test_operator_control_snapshot.ml test/test_operator_control.ml test/test_keeper_bash_safety.ml
- git diff --check HEAD~1..HEAD

Local focused Dune build was attempted for test/test_keeper_bash_safety.exe and test/test_operator_control.exe, but another worktree held /tmp/me-dune-local.lock for several minutes. Leaving full compile/test proof to PR CI.