### PR TITLE
fix(goal): keeper_goal_repair dedupe + janitor auto-stagnate threshold (P0)

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -413,6 +413,14 @@ module Goal_janitor = struct
       to be tight; a coarse sweep keeps the fleet log uncluttered. *)
   let interval_seconds =
     get_float ~default:3600.0 "MASC_GOAL_JANITOR_INTERVAL_SEC"
+
+  (** Stagnate threshold (days) for auto-generated goals.  Default: 7.
+      Auto-generated = title suffix [" (auto)"] from
+      [Keeper_goal_repair.goal_title_of_purpose].  Separate from the
+      manual [stagnant_days] (30) so keeper-repair leftovers do not
+      accumulate while operator-authored long-running goals survive. *)
+  let auto_stagnant_days () =
+    get_int ~default:7 "MASC_GOAL_JANITOR_AUTO_STAGNATE_DAYS"
 end
 
 (** {1 Approval Janitor}

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -205,6 +205,10 @@ end
 module Goal_janitor : sig
   val enabled : unit -> bool
   val interval_seconds : float
+  val auto_stagnant_days : unit -> int
+  (** [auto_stagnant_days ()] = [MASC_GOAL_JANITOR_AUTO_STAGNATE_DAYS]
+      or default [7].  Drops auto-generated Active goals (title suffix
+      [" (auto)"]) sooner than the 30-day manual threshold. *)
 end
 
 module Approval_janitor : sig

--- a/lib/goal/goal_janitor.ml
+++ b/lib/goal/goal_janitor.ml
@@ -12,6 +12,10 @@
 type sweep_config = {
   dropped_ttl_days : int;  (** Delete Dropped goals after this many days. Default 7. *)
   stagnant_days : int;     (** Drop Active goals with no update after this many days. Default 30. *)
+  auto_stagnant_days : int;
+      (** Drop auto-generated Active goals (title suffix " (auto)") with no
+          update after this many days. Default 7 — closes auto-goal accretion
+          from Keeper_goal_repair leftovers. *)
   orphan_task_escalation_age_seconds : int;
       (** Report unclaimed tasks without goal linkage after this age. Default 30 min. *)
 }
@@ -19,8 +23,25 @@ type sweep_config = {
 let default_config = {
   dropped_ttl_days = 7;
   stagnant_days = 30;
+  auto_stagnant_days = 7;
   orphan_task_escalation_age_seconds = 30 * 60;
 }
+
+let runtime_config () =
+  { default_config with
+    auto_stagnant_days =
+      Env_config_runtime.Goal_janitor.auto_stagnant_days ();
+  }
+
+(** Suffix produced by [Keeper_goal_repair.goal_title_of_purpose]: short
+    purpose ends in [" (auto)"], truncated purpose ends in [{e …}] +
+    [" (auto)"]. We accept both. *)
+let is_auto_generated_goal (g : Goal_store.goal) =
+  let ends_with ~suffix s =
+    let n = String.length s and m = String.length suffix in
+    n >= m && String.sub s (n - m) m = suffix
+  in
+  ends_with ~suffix:" (auto)" g.title
 
 type sweep_result = {
   purged : int;     (** Dropped goals deleted *)
@@ -47,6 +68,8 @@ let days_since_update (goal : Goal_store.goal) ~now =
   | None -> None
 
 (** Sweep goals: purge old Dropped, stagnate old Active.
+    Auto-generated goals (title suffix " (auto)") use the shorter
+    [auto_stagnant_days] threshold.
     Returns (updated_goals, sweep_result). Does NOT write state. *)
 let sweep_goals ~(config : sweep_config) (goals : Goal_store.goal list)
   : Goal_store.goal list * sweep_result =
@@ -54,6 +77,10 @@ let sweep_goals ~(config : sweep_config) (goals : Goal_store.goal list)
   let iso_now = Masc_domain.now_iso () in
   let purged = ref 0 in
   let stagnated = ref 0 in
+  let stagnate_threshold (g : Goal_store.goal) =
+    if is_auto_generated_goal g then config.auto_stagnant_days
+    else config.stagnant_days
+  in
   let result =
     goals |> List.filter_map (fun (g : Goal_store.goal) ->
       let age = days_since_update g ~now in
@@ -63,10 +90,11 @@ let sweep_goals ~(config : sweep_config) (goals : Goal_store.goal list)
         Log.Misc.info "[GoalJanitor] purge: %s (%s, dropped %d days ago)"
           g.id g.title d;
         None
-      | Goal_phase.Executing, Some d when d >= config.stagnant_days ->
+      | Goal_phase.Executing, Some d when d >= stagnate_threshold g ->
         incr stagnated;
-        Log.Misc.info "[GoalJanitor] stagnate: %s (%s, no update for %d days)"
-          g.id g.title d;
+        let kind = if is_auto_generated_goal g then "auto" else "manual" in
+        Log.Misc.info "[GoalJanitor] stagnate: %s (%s, %s, no update for %d days, threshold=%d)"
+          g.id g.title kind d (stagnate_threshold g);
         Some { g with
                phase = Goal_phase.Dropped;
                status = Goal_store.Dropped;

--- a/lib/goal/goal_janitor.mli
+++ b/lib/goal/goal_janitor.mli
@@ -4,7 +4,11 @@
     1. Purge: delete [Dropped] goals older than
        [dropped_ttl_days] (default 7).
     2. Stagnate: mark [Active] goals with no update after
-       [stagnant_days] (default 30) as [Dropped].
+       [stagnant_days] (default 30) as [Dropped].  Auto-generated
+       goals (title suffix [" (auto)"] or ["… (auto)"], produced by
+       {!Keeper_goal_repair}) use the shorter [auto_stagnant_days]
+       threshold (default 7) so the keeper-repair leftovers do not
+       accumulate.
     3. Orphan: remove [active_goal_ids] entries from each
        [keeper_meta] that reference non-existent goals in the Goal
        Store.
@@ -17,11 +21,31 @@
 type sweep_config = {
   dropped_ttl_days : int;  (** Delete Dropped goals after this many days. *)
   stagnant_days : int;     (** Drop Active goals with no update after this many days. *)
+  auto_stagnant_days : int;
+      (** Drop {b auto-generated} Active goals with no update after this many
+          days.  Auto-generated = title suffix [" (auto)"] or [{e … (auto)}]
+          (the {!Keeper_goal_repair.goal_title_of_purpose} contract).
+          Default 7 — short enough to keep keeper-repair leftovers from
+          accreting, long enough to survive a transient operator pause. *)
   orphan_task_escalation_age_seconds : int;
       (** Report unclaimed tasks without goal linkage after this age. *)
 }
 
 val default_config : sweep_config
+
+val runtime_config : unit -> sweep_config
+(** [runtime_config ()] returns {!default_config} with
+    [auto_stagnant_days] overridden by
+    [MASC_GOAL_JANITOR_AUTO_STAGNATE_DAYS] when present.  Used by the
+    server-side fiber and the dashboard-triggered sweep so operator
+    overrides land in both paths.  Tests should keep using
+    {!default_config} (or build a literal record) for determinism. *)
+
+val is_auto_generated_goal : Goal_store.goal -> bool
+(** [is_auto_generated_goal g] returns [true] when [g.title] carries
+    the [" (auto)"] or [{e … (auto)}] suffix produced by
+    {!Keeper_goal_repair.goal_title_of_purpose}.  Exposed for unit
+    tests of the auto-stagnate branch. *)
 
 (** {1 Result} *)
 

--- a/lib/keeper/keeper_goal_repair.ml
+++ b/lib/keeper/keeper_goal_repair.ml
@@ -8,10 +8,17 @@
 
     @since 2.237.0 *)
 
+type repair_source = [ `Created | `Reused ]
+
+let repair_source_to_string = function
+  | `Created -> "created"
+  | `Reused -> "reused"
+
 type repair_action = {
   keeper_name : string;
   goal_id : string;
   goal_title : string;
+  source : repair_source;
 }
 
 type repair_result = {
@@ -23,8 +30,12 @@ type repair_result = {
 let empty_result = { actions = []; skipped = []; errors = [] }
 
 let repair_result_to_yojson r =
+  let created = List.filter (fun a -> a.source = `Created) r.actions in
+  let reused  = List.filter (fun a -> a.source = `Reused)  r.actions in
   `Assoc [
     ("repaired", `Int (List.length r.actions));
+    ("created", `Int (List.length created));
+    ("reused", `Int (List.length reused));
     ("skipped", `Int (List.length r.skipped));
     ("errors", `Int (List.length r.errors));
     ("actions", `List (List.map (fun a ->
@@ -32,12 +43,28 @@ let repair_result_to_yojson r =
         ("keeper_name", `String a.keeper_name);
         ("goal_id", `String a.goal_id);
         ("goal_title", `String a.goal_title);
+        ("source", `String (repair_source_to_string a.source));
       ]) r.actions));
     ("skipped_details", `List (List.map (fun (n, reason) ->
       `Assoc [("name", `String n); ("reason", `String reason)]) r.skipped));
     ("error_details", `List (List.map (fun (n, err) ->
       `Assoc [("name", `String n); ("error", `String err)]) r.errors));
   ]
+
+(** Locate an existing non-terminal goal with the same auto-derived title.
+    Reuse path for repeated repairs of the same keeper purpose statement —
+    without this, every repair turn creates a fresh goal id even when the
+    purpose has not changed (auto-goal accretion, observed live 2026-05-17:
+    3 identical verifier goals across 10 days in Goal Store). *)
+let find_existing_auto_goal (config : Coord.config) ~(title : string)
+    : Goal_store.goal option =
+  let st = Goal_store.read_state config in
+  List.find_opt (fun (g : Goal_store.goal) ->
+    g.title = title
+    && (match g.phase with
+        | Goal_phase.Dropped | Goal_phase.Completed -> false
+        | _ -> true))
+    st.goals
 
 (** Derive a goal title from the keeper's purpose statement.
     Truncates to 120 chars and appends "(auto)" to mark it as generated. *)
@@ -69,8 +96,10 @@ let find_empty_goal_keepers (config : Coord.config) : string list =
     |> List.rev
   end
 
-(** Repair a single keeper: create goal + assign.
-    Returns [Ok action] on success, [Error msg] on failure. *)
+(** Repair a single keeper: either reuse an existing auto-goal with the
+    same derived title, or create a new one. Then assign to the keeper's
+    [active_goal_ids]. Returns [Ok action] on success, [Error msg] on
+    failure. *)
 let repair_keeper (config : Coord.config) (name : string) : (repair_action, string) result =
   match Keeper_types.read_meta config name with
   | Error e -> Error (Printf.sprintf "read_meta failed: %s" e)
@@ -81,25 +110,34 @@ let repair_keeper (config : Coord.config) (name : string) : (repair_action, stri
       Error "already has active_goal_ids"
     else begin
       let title = goal_title_of_purpose meta.goal in
-      match Goal_store.upsert_goal config ~title () with
-      | Error e ->
-          Error (Printf.sprintf "goal creation failed: %s" e)
-      | Ok (goal, `created) ->
-          let updated = { meta with active_goal_ids = [ goal.Goal_store.id ] } in
-          (match Keeper_types.write_meta config updated with
+      let assign_goal ~goal_id ~source =
+        let updated = { meta with active_goal_ids = [ goal_id ] } in
+        match Keeper_types.write_meta config updated with
+        | Error e ->
+            Prometheus.inc_counter
+              Keeper_metrics.metric_keeper_write_meta_failures
+              ~labels:[("keeper", name); ("phase", "goal_repair")]
+              ();
+            Error (Printf.sprintf "write_meta failed: %s" e)
+        | Ok () ->
+            Ok { keeper_name = name; goal_id; goal_title = title; source }
+      in
+      match find_existing_auto_goal config ~title with
+      | Some existing ->
+          assign_goal ~goal_id:existing.Goal_store.id ~source:`Reused
+      | None ->
+          (match Goal_store.upsert_goal config ~title () with
            | Error e ->
-               Prometheus.inc_counter
-                 Keeper_metrics.metric_keeper_write_meta_failures
-                 ~labels:[("keeper", name); ("phase", "goal_repair")]
-                 ();
-               Error (Printf.sprintf "write_meta failed: %s" e)
-           | Ok () ->
-               Ok { keeper_name = name; goal_id = goal.Goal_store.id; goal_title = title })
-      | Ok (_, `updated) ->
-          Error "unexpected update on new goal"
+               Error (Printf.sprintf "goal creation failed: %s" e)
+           | Ok (goal, `created) ->
+               assign_goal ~goal_id:goal.Goal_store.id ~source:`Created
+           | Ok (_, `updated) ->
+               Error "unexpected update on new goal")
     end
 
-(** Dry-run: returns what would be repaired without making changes. *)
+(** Dry-run: returns what would be repaired without making changes. The
+    [source] field on each action records whether the live repair would
+    [`Reused] an existing auto-goal or [`Created] a new one. *)
 let dry_run (config : Coord.config) : repair_result =
   let names = find_empty_goal_keepers config in
   List.fold_left (fun acc name ->
@@ -108,7 +146,17 @@ let dry_run (config : Coord.config) : repair_result =
     | Ok None -> { acc with skipped = (name, "meta not found") :: acc.skipped }
     | Ok (Some meta) ->
         let title = goal_title_of_purpose meta.goal in
-        { acc with actions = { keeper_name = name; goal_id = "(dry-run)"; goal_title = title } :: acc.actions }
+        let source =
+          match find_existing_auto_goal config ~title with
+          | Some _ -> `Reused
+          | None -> `Created
+        in
+        let goal_id =
+          match source with
+          | `Reused -> "(dry-run-reuse)"
+          | `Created -> "(dry-run-create)"
+        in
+        { acc with actions = { keeper_name = name; goal_id; goal_title = title; source } :: acc.actions }
   ) empty_result names
   |> fun r -> { actions = List.rev r.actions; skipped = List.rev r.skipped; errors = List.rev r.errors }
 

--- a/lib/keeper/keeper_goal_repair.mli
+++ b/lib/keeper/keeper_goal_repair.mli
@@ -16,13 +16,26 @@
 
     @since 2.237.0 *)
 
+type repair_source = [ `Created | `Reused ]
+(** Records whether {!run} {b created} a new goal or {b reused} an
+    existing auto-goal with the same derived title.  Reuse path closes
+    the auto-goal accretion observed live 2026-05-17 (Goal Store had 3
+    identical verifier-keeper goals across 10 days because each repair
+    turn minted a fresh id). *)
+
+val repair_source_to_string : repair_source -> string
+(** [repair_source_to_string s] returns ["created"] or ["reused"] —
+    the canonical wire form used in {!repair_result_to_yojson}. *)
+
 type repair_action = {
   keeper_name : string;
   goal_id : string;
   goal_title : string;
+  source : repair_source;
 }
-(** One repair entry.  [goal_id] is ["(dry-run)"] for {!dry_run}
-    actions and the actual goal id for {!run}. *)
+(** One repair entry.  [goal_id] is ["(dry-run-create)"] or
+    ["(dry-run-reuse)"] for {!dry_run} actions (the marker matches
+    {!field-source}), and the actual goal id for {!run}. *)
 
 type repair_result = {
   actions : repair_action list;
@@ -56,16 +69,19 @@ val repair_result_to_yojson : repair_result -> Yojson.Safe.t
 (** [repair_result_to_yojson r] renders the result as
     {[
       `Assoc [
-        ("repaired", `Int <count>);
+        ("repaired", `Int <count>);  (* actions length *)
+        ("created", `Int <count>);   (* dedupe miss *)
+        ("reused", `Int <count>);    (* dedupe hit  *)
         ("skipped", `Int <count>);
         ("errors", `Int <count>);
-        ("actions", `List [<repair_action>...]);
+        ("actions", `List [<repair_action>...]);  (* each carries [source] *)
         ("skipped_details", `List [<{name, reason}>...]);
         ("error_details", `List [<{name, error}>...]);
       ]
     ]}
-    The triple count + per-list detail shape is the dashboard
-    contract — operator runbooks read these field names verbatim. *)
+    The triple count + per-list detail shape plus the new
+    [created]/[reused] split is the dashboard contract — operator
+    runbooks read these field names verbatim. *)
 
 val dry_run : Coord.config -> repair_result
 (** [dry_run config] scans every keeper meta under
@@ -82,11 +98,16 @@ val run : Coord.config -> repair_result
     1. Derives a title from the keeper's purpose statement
        (truncated to 115 chars + ["… (auto)"] suffix; falls back to
        ["(unnamed keeper)"] when the purpose is empty).
-    2. Calls {!Goal_store.upsert_goal} which must report [`created]
+    2. {b Dedupe pass}: scans the Goal Store for an existing non-
+       terminal goal (phase ≠ [Dropped]/[Completed]) with the same
+       derived title.  If found, that goal id is reused and
+       {!field-source} is [`Reused].  Otherwise, calls
+       {!Goal_store.upsert_goal} which must report [`created]
        (an [`updated] response is treated as an error — repair
-       expects fresh-goal creation, not an existing-goal collision).
-    3. Writes the keeper meta with the new goal id assigned to
-       [active_goal_ids].
+       expects fresh-goal creation, not an existing-goal collision)
+       and {!field-source} is [`Created].
+    3. Writes the keeper meta with the (reused or new) goal id
+       assigned to [active_goal_ids].
 
     Side-effects:
     - Creates one goal record per repaired keeper.

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -688,7 +688,8 @@ let start_keeper_loops
       let rec loop () =
         Eio.Time.sleep clock interval;
         (try
-           let _result = Goal_janitor.run state.room_config in
+           let config = Goal_janitor.runtime_config () in
+           let _result = Goal_janitor.run ~config state.room_config in
            ()
          with
          | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -456,7 +456,8 @@ let add_delete_action_routes router =
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
          (fun state _agent_name _req reqd ->
          let config = state.Mcp_server.room_config in
-         let result = Goal_janitor.run config in
+         let sweep_config = Goal_janitor.runtime_config () in
+         let result = Goal_janitor.run ~config:sweep_config config in
          Http.Response.json ~compress:true ~request
            (Yojson.Safe.to_string
               (`Assoc [("ok", `Bool true);

--- a/test/test_goal_janitor.ml
+++ b/test/test_goal_janitor.ml
@@ -195,6 +195,43 @@ let test_prune_orphaned_ids () =
   check bool "g1 kept" true (List.mem "g1" pruned);
   check bool "g2 kept" true (List.mem "g2" pruned)
 
+let test_is_auto_generated_goal () =
+  let g_auto    = make_goal "g-a" "verifier persona (auto)" in
+  let g_manual  = make_goal "g-m" "RFC-0097 Phase 1 rollout" in
+  let g_unnamed = make_goal "g-u" "(unnamed keeper)" in
+  check bool "short (auto) suffix" true  (Goal_janitor.is_auto_generated_goal g_auto);
+  check bool "manual title"        false (Goal_janitor.is_auto_generated_goal g_manual);
+  check bool "(unnamed keeper) is not auto-suffixed" false
+    (Goal_janitor.is_auto_generated_goal g_unnamed)
+
+let test_auto_stagnate_short_threshold () =
+  with_room @@ fun config ->
+  (* auto-goal at 10d should drop (default auto_stagnant_days=7);
+     manual at 10d should NOT drop (default stagnant_days=30). *)
+  let g_auto   = make_goal ~status:Active ~days_ago:10 "g-a" "do things (auto)" in
+  let g_manual = make_goal ~status:Active ~days_ago:10 "g-m" "Manual long goal" in
+  Goal_store.write_state config
+    { version = 1; updated_at = Masc_domain.now_iso ();
+      goals = [g_auto; g_manual] };
+  let result = Goal_janitor.run config in
+  check int "1 auto stagnated" 1 result.stagnated;
+  let goals = Goal_store.list_goals config () in
+  let g_auto'   = List.find (fun (g : Goal_store.goal) -> g.id = "g-a") goals in
+  let g_manual' = List.find (fun (g : Goal_store.goal) -> g.id = "g-m") goals in
+  check string "auto-goal now Dropped" "dropped"
+    (match g_auto'.status with Dropped -> "dropped" | _ -> "not-dropped");
+  check string "manual goal still Active" "active"
+    (match g_manual'.status with Active -> "active" | _ -> "not-active")
+
+let test_auto_stagnate_below_threshold () =
+  with_room @@ fun config ->
+  let g_auto = make_goal ~status:Active ~days_ago:3 "g-a" "fresh purpose (auto)" in
+  Goal_store.write_state config
+    { version = 1; updated_at = Masc_domain.now_iso ();
+      goals = [g_auto] };
+  let result = Goal_janitor.run config in
+  check int "no stagnation below 7d" 0 result.stagnated
+
 let () =
   run "Goal_janitor" [
     "sweep", [
@@ -206,5 +243,12 @@ let () =
     ];
     "prune", [
       test_case "prune orphaned active_goal_ids" `Quick test_prune_orphaned_ids;
+    ];
+    "auto_threshold", [
+      test_case "is_auto_generated_goal" `Quick test_is_auto_generated_goal;
+      test_case "auto-goal stagnates at 10d (default 7d threshold)" `Quick
+        test_auto_stagnate_short_threshold;
+      test_case "auto-goal survives at 3d" `Quick
+        test_auto_stagnate_below_threshold;
     ];
   ]

--- a/test/test_keeper_goal_repair.ml
+++ b/test/test_keeper_goal_repair.ml
@@ -16,8 +16,16 @@ let test_goal_title_of_purpose () =
   in
   check bool "long ends with (auto)" true ends_with_auto
 
+let test_repair_source_to_string () =
+  let open Alcotest in
+  let module KGR = Masc_mcp.Keeper_goal_repair in
+  check string "created" "created" (KGR.repair_source_to_string `Created);
+  check string "reused"  "reused"  (KGR.repair_source_to_string `Reused)
+
 let () =
   Alcotest.run "Keeper_goal_repair"
     [ ("goal_title_of_purpose",
-       [ Alcotest.test_case "truncation" `Quick test_goal_title_of_purpose ])
+       [ Alcotest.test_case "truncation" `Quick test_goal_title_of_purpose ]);
+      ("repair_source",
+       [ Alcotest.test_case "to_string" `Quick test_repair_source_to_string ])
     ]


### PR DESCRIPTION
# fix(goal): keeper_goal_repair dedupe + janitor auto-stagnate threshold (P0)

P0 fix for **auto-goal accretion** observed live 2026-05-17 (Goal Store
70 goals, ~33 with `(auto)` suffix, 3 identical verifier-keeper goals
across 10 days). Two surgical changes that share the same root.

Reference: `knowledge/research/2026-05-17-cdal-goal-separation-deep-dive.html`
(jeong-sik/me PR #1130) §5 V2/V5 + §6 I1/I2.

## What

### I1 · `Keeper_goal_repair` dedupe (~50 LoC)

- New `repair_source = [`Created | `Reused]` variant in `repair_action`.
- New helper `find_existing_auto_goal ~title` — scans Goal Store for an
  existing **non-terminal** goal (phase ≠ Dropped/Completed) with the
  same derived title.
- `repair_keeper` reuses when found; creates only when not found.
- `dry_run` reports planned source as `(dry-run-reuse)` / `(dry-run-create)`.
- `repair_result_to_yojson` adds `created` + `reused` counts and
  `source` field per action (dashboard contract extension, not break —
  existing `repaired` field unchanged).

### I2 · `Goal_janitor` auto-stagnate threshold (~80 LoC + tests)

- `sweep_config.auto_stagnant_days` new field (default `7`).
- `sweep_goals` branches: title ends in `" (auto)"` → uses
  `auto_stagnant_days`; otherwise uses existing `stagnant_days` (30).
- New `Goal_janitor.runtime_config ()` — `default_config` overlaid with
  `MASC_GOAL_JANITOR_AUTO_STAGNATE_DAYS` env (caller-side env-aware
  helper, env_config_runtime unchanged in spirit).
- `server_bootstrap_loops.ml` periodic fiber + `server_dashboard_http_delete_actions.ml`
  manual sweep both use `runtime_config ()`.
- Public `Goal_janitor.is_auto_generated_goal : Goal_store.goal -> bool`
  for unit tests of the branch.

## Why default 7 for auto-stagnant_days

Janitor was **already running** (`server_bootstrap_loops.ml:683`
`fork_subsystem "goal_janitor"` since issue #10405 fix). Manual goals
need the 30d window — operator-authored goals can sit between sprints.
Auto-goals are leftovers from `Keeper_goal_repair` triggered every time
a keeper's `active_goal_ids` is empty; they have no operator-meaningful
content beyond the keeper purpose. 7 days is long enough that a
transient keeper restart doesn't drop the goal mid-recovery, short
enough that the Store doesn't accumulate.

## Operating defaults

| Env | Default | Meaning |
|---|---|---|
| `MASC_GOAL_JANITOR_AUTO_STAGNATE_DAYS` | `7` | Auto-goal stagnate threshold (days) |
| `MASC_GOAL_JANITOR_ENABLED` | `true` | (unchanged) |
| `MASC_GOAL_JANITOR_INTERVAL_SEC` | `3600` | (unchanged) |

## Tests

- `test_keeper_goal_repair.ml` + `repair_source_to_string` case.
- `test_goal_janitor.ml` + 3 cases:
  - `is_auto_generated_goal` (pure title test).
  - `auto-goal at 10d stagnates (default 7d threshold)`.
  - `auto-goal at 3d survives`.
- `ocamlformat --check`: PASS (10 files).
- `dune build --root . lib/goal lib/keeper lib/config lib/server`: see CI.

## Workaround rejection bar (self-check)

- [x] **Not telemetry-as-fix** — actually changes Goal Store contents (reuses
  existing id instead of minting new; drops auto-goals at 7d).
- [x] **Not string classifier** — `is_auto_generated_goal` is `endsWith
  " (auto)"` matching the **single canonical suffix** emitted by
  `Keeper_goal_repair.goal_title_of_purpose`. Same producer + same
  consumer, not stringly-typed classifier of external input.
- [x] **Not N-of-M** — both call sites of `Goal_janitor.run` (server
  bootstrap + dashboard delete) updated in this PR. No 2nd PR follows.
- [x] **Not catch-all** — exhaustive match on `repair_source` variant.
- [x] **Not cap/cooldown/repair workaround** — closes the root of
  auto-goal accretion (V2 + V5 in the research HTML).

## Attribution

Research and design: jeong-sik/me PR #1130 `knowledge/research/2026-05-17-cdal-goal-separation-deep-dive.html`.

RFC-WAIVED: `lib/goal/` + `lib/keeper/keeper_goal_repair*` — neither
in the agent_delegation RFC-required subsystem list
(`credential_*`/`keeper_gh_*`/`host_config_*`/`repo_manager/`/
`operator_control*`/`credential-settings`/`keeper-repo-mapping`/
`.claude/hooks/`/`instructions/workflow*`).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>