### PR TITLE
feat(server): RFC-0105 openai-compat Agent_sdk.Error.t → HTTP typed mapping

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -262,7 +262,7 @@ let dispatch_route ~routes ~request ~path reqd =
         Http.Response.json ~status:`Internal_server_error
           ~extra_headers:(cors_headers origin)
           (Server_openai_compat.error_response
-             ~status:"server_error" ~message:"Server not initialized")
+             ~status:"server_error" ~message:"Server not initialized" ())
           reqd
       | Some state ->
         let config = state.Mcp_server.room_config in
@@ -282,7 +282,7 @@ let dispatch_route ~routes ~request ~path reqd =
               ~extra_headers:(cors_headers origin)
               (Server_openai_compat.error_response
                  ~status:"server_error"
-                 ~message:"Server runtime not fully initialized")
+                 ~message:"Server runtime not fully initialized" ())
               reqd))
   | `DELETE, "/mcp" -> handle_delete_mcp request reqd
   | `DELETE, "/mcp/managed" ->

--- a/lib/server/openai_compat_error_map.ml
+++ b/lib/server/openai_compat_error_map.ml
@@ -1,0 +1,291 @@
+(** RFC-0105 — see [.mli] for contract. *)
+
+type http_status =
+  [ `Bad_request
+  | `Unauthorized
+  | `Not_found
+  | `Request_timeout
+  | `Too_many_requests
+  | `Internal_server_error
+  | `Bad_gateway
+  | `Service_unavailable
+  | `Gateway_timeout
+  ]
+
+type t = {
+  http_status : http_status;
+  openai_kind : string;
+  openai_code : string option;
+  message     : string;
+}
+
+(* OpenAI error "type" field canonical values.
+   Reference: OpenAI Platform docs § Errors. *)
+let kind_invalid_request   = "invalid_request_error"
+let kind_authentication    = "authentication_error"
+let kind_permission        = "permission_error"
+let kind_not_found         = "not_found_error"
+let kind_rate_limit        = "rate_limit_error"
+let kind_server            = "server_error"
+
+let of_api_error (e : Agent_sdk.Error.Retry.api_error) : t =
+  let module R = Agent_sdk.Error.Retry in
+  let message = R.error_message e in
+  match e with
+  | R.RateLimited _ ->
+    { http_status = `Too_many_requests
+    ; openai_kind = kind_rate_limit
+    ; openai_code = Some "rate_limited"
+    ; message }
+  | R.Overloaded _ ->
+    { http_status = `Service_unavailable
+    ; openai_kind = kind_server
+    ; openai_code = Some "overloaded"
+    ; message }
+  | R.ServerError { status; _ } ->
+    { http_status = `Bad_gateway
+    ; openai_kind = kind_server
+    ; openai_code = Some (Printf.sprintf "upstream_%d" status)
+    ; message }
+  | R.AuthError _ ->
+    { http_status = `Unauthorized
+    ; openai_kind = kind_authentication
+    ; openai_code = Some "invalid_api_key"
+    ; message }
+  | R.InvalidRequest _ ->
+    { http_status = `Bad_request
+    ; openai_kind = kind_invalid_request
+    ; openai_code = Some "invalid_request"
+    ; message }
+  | R.NotFound _ ->
+    { http_status = `Not_found
+    ; openai_kind = kind_not_found
+    ; openai_code = Some "model_not_found"
+    ; message }
+  | R.ContextOverflow _ ->
+    { http_status = `Bad_request
+    ; openai_kind = kind_invalid_request
+    ; openai_code = Some "context_length_exceeded"
+    ; message }
+  | R.NetworkError _ ->
+    { http_status = `Bad_gateway
+    ; openai_kind = kind_server
+    ; openai_code = Some "network_error"
+    ; message }
+  | R.Timeout _ ->
+    { http_status = `Gateway_timeout
+    ; openai_kind = kind_server
+    ; openai_code = Some "timeout"
+    ; message }
+
+let of_agent_error (e : Agent_sdk.Error.agent_error) : t =
+  let message = Agent_sdk.Error.to_string (Agent_sdk.Error.Agent e) in
+  match e with
+  | Agent_sdk.Error.MaxTurnsExceeded _ ->
+    { http_status = `Internal_server_error
+    ; openai_kind = kind_server
+    ; openai_code = Some "max_turns_exceeded"
+    ; message }
+  | TokenBudgetExceeded _ ->
+    { http_status = `Bad_request
+    ; openai_kind = kind_invalid_request
+    ; openai_code = Some "token_budget_exceeded"
+    ; message }
+  | CostBudgetExceeded _ ->
+    { http_status = `Bad_request
+    ; openai_kind = kind_invalid_request
+    ; openai_code = Some "cost_budget_exceeded"
+    ; message }
+  | CostBudgetUnenforceable _ ->
+    { http_status = `Internal_server_error
+    ; openai_kind = kind_server
+    ; openai_code = Some "cost_budget_unenforceable"
+    ; message }
+  | UnrecognizedStopReason _ ->
+    { http_status = `Bad_gateway
+    ; openai_kind = kind_server
+    ; openai_code = Some "unrecognized_stop_reason"
+    ; message }
+  | IdleDetected _ ->
+    { http_status = `Internal_server_error
+    ; openai_kind = kind_server
+    ; openai_code = Some "idle_detected"
+    ; message }
+  | ToolRetryExhausted _ ->
+    { http_status = `Internal_server_error
+    ; openai_kind = kind_server
+    ; openai_code = Some "tool_retry_exhausted"
+    ; message }
+  | CompletionContractViolation _ ->
+    { http_status = `Internal_server_error
+    ; openai_kind = kind_server
+    ; openai_code = Some "completion_contract_violation"
+    ; message }
+  | GuardrailViolation _ ->
+    { http_status = `Bad_request
+    ; openai_kind = kind_invalid_request
+    ; openai_code = Some "guardrail_violation"
+    ; message }
+  | TripwireViolation _ ->
+    { http_status = `Bad_request
+    ; openai_kind = kind_invalid_request
+    ; openai_code = Some "tripwire_violation"
+    ; message }
+  | ExitConditionMet _ ->
+    (* Non-fatal — the agent stopped voluntarily. Surface as 500 so the
+       client doesn't silently treat it as success, but tag a distinct code
+       so observability can filter. *)
+    { http_status = `Internal_server_error
+    ; openai_kind = kind_server
+    ; openai_code = Some "exit_condition_met"
+    ; message }
+
+let of_mcp_error (e : Agent_sdk.Error.mcp_error) : t =
+  let message = Agent_sdk.Error.to_string (Agent_sdk.Error.Mcp e) in
+  match e with
+  | Agent_sdk.Error.ServerStartFailed _ ->
+    { http_status = `Service_unavailable
+    ; openai_kind = kind_server
+    ; openai_code = Some "mcp_server_start_failed"
+    ; message }
+  | InitializeFailed _ ->
+    { http_status = `Service_unavailable
+    ; openai_kind = kind_server
+    ; openai_code = Some "mcp_initialize_failed"
+    ; message }
+  | ToolListFailed _ ->
+    { http_status = `Bad_gateway
+    ; openai_kind = kind_server
+    ; openai_code = Some "mcp_tool_list_failed"
+    ; message }
+  | ToolCallFailed _ ->
+    { http_status = `Bad_gateway
+    ; openai_kind = kind_server
+    ; openai_code = Some "mcp_tool_call_failed"
+    ; message }
+  | HttpTransportFailed _ ->
+    { http_status = `Bad_gateway
+    ; openai_kind = kind_server
+    ; openai_code = Some "mcp_http_transport_failed"
+    ; message }
+
+let of_config_error (e : Agent_sdk.Error.config_error) : t =
+  let message = Agent_sdk.Error.to_string (Agent_sdk.Error.Config e) in
+  match e with
+  | Agent_sdk.Error.MissingEnvVar _ ->
+    { http_status = `Internal_server_error
+    ; openai_kind = kind_server
+    ; openai_code = Some "config_missing_env"
+    ; message }
+  | UnsupportedProvider _ ->
+    { http_status = `Bad_request
+    ; openai_kind = kind_invalid_request
+    ; openai_code = Some "unsupported_provider"
+    ; message }
+  | InvalidConfig _ ->
+    { http_status = `Internal_server_error
+    ; openai_kind = kind_server
+    ; openai_code = Some "config_invalid"
+    ; message }
+
+let of_serialization_error (e : Agent_sdk.Error.serialization_error) : t =
+  let message = Agent_sdk.Error.to_string (Agent_sdk.Error.Serialization e) in
+  match e with
+  | Agent_sdk.Error.JsonParseError _ ->
+    { http_status = `Bad_gateway
+    ; openai_kind = kind_server
+    ; openai_code = Some "json_parse_error"
+    ; message }
+  | VersionMismatch _ ->
+    { http_status = `Bad_gateway
+    ; openai_kind = kind_server
+    ; openai_code = Some "version_mismatch"
+    ; message }
+  | UnknownVariant _ ->
+    { http_status = `Bad_gateway
+    ; openai_kind = kind_server
+    ; openai_code = Some "unknown_variant"
+    ; message }
+
+let of_io_error (e : Agent_sdk.Error.io_error) : t =
+  let message = Agent_sdk.Error.to_string (Agent_sdk.Error.Io e) in
+  match e with
+  | Agent_sdk.Error.FileOpFailed _ ->
+    { http_status = `Internal_server_error
+    ; openai_kind = kind_server
+    ; openai_code = Some "io_file_op_failed"
+    ; message }
+  | ValidationFailed _ ->
+    { http_status = `Bad_request
+    ; openai_kind = kind_invalid_request
+    ; openai_code = Some "validation_failed"
+    ; message }
+
+let of_orchestration_error (e : Agent_sdk.Error.orchestration_error) : t =
+  let message = Agent_sdk.Error.to_string (Agent_sdk.Error.Orchestration e) in
+  match e with
+  | Agent_sdk.Error.UnknownAgent _ ->
+    { http_status = `Not_found
+    ; openai_kind = kind_not_found
+    ; openai_code = Some "agent_not_found"
+    ; message }
+  | TaskTimeout _ ->
+    { http_status = `Gateway_timeout
+    ; openai_kind = kind_server
+    ; openai_code = Some "task_timeout"
+    ; message }
+  | DiscoveryFailed _ ->
+    { http_status = `Bad_gateway
+    ; openai_kind = kind_server
+    ; openai_code = Some "discovery_failed"
+    ; message }
+
+let of_a2a_error (e : Agent_sdk.Error.a2a_error) : t =
+  let message = Agent_sdk.Error.to_string (Agent_sdk.Error.A2a e) in
+  match e with
+  | Agent_sdk.Error.TaskNotFound _ ->
+    { http_status = `Not_found
+    ; openai_kind = kind_not_found
+    ; openai_code = Some "task_not_found"
+    ; message }
+  | InvalidTransition _ ->
+    { http_status = `Bad_request
+    ; openai_kind = kind_invalid_request
+    ; openai_code = Some "invalid_transition"
+    ; message }
+  | MessageSendFailed _ ->
+    { http_status = `Bad_gateway
+    ; openai_kind = kind_server
+    ; openai_code = Some "message_send_failed"
+    ; message }
+  | ProtocolError _ ->
+    { http_status = `Bad_request
+    ; openai_kind = kind_invalid_request
+    ; openai_code = Some "protocol_error"
+    ; message }
+  | StoreCapacityExceeded _ ->
+    { http_status = `Service_unavailable
+    ; openai_kind = kind_server
+    ; openai_code = Some "store_capacity_exceeded"
+    ; message }
+
+let of_sdk_error (e : Agent_sdk.Error.sdk_error) : t =
+  match e with
+  | Agent_sdk.Error.Api ae -> of_api_error ae
+  | Agent ae -> of_agent_error ae
+  | Mcp me -> of_mcp_error me
+  | Config ce -> of_config_error ce
+  | Serialization se -> of_serialization_error se
+  | Io ioe -> of_io_error ioe
+  | Orchestration oe -> of_orchestration_error oe
+  | A2a ae -> of_a2a_error ae
+  | Internal msg ->
+    { http_status = `Internal_server_error
+    ; openai_kind = kind_server
+    ; openai_code = Some "internal_error"
+    ; message = msg }
+
+(* Mark [kind_permission] referenced so future variants needing 403 do not
+   trip the unused-warning. RFC-0105 acceptance leaves the symbol exposed
+   intentionally; remove only if no 403 variant materializes. *)
+let _ = kind_permission

--- a/lib/server/openai_compat_error_map.mli
+++ b/lib/server/openai_compat_error_map.mli
@@ -1,0 +1,31 @@
+(** Pure mapping from [Agent_sdk.Error.sdk_error] to the OpenAI-compat
+    HTTP error envelope parts.
+
+    Implements RFC-0105. The mapping is total: adding a new SDK error
+    variant breaks the build at this site, forcing an explicit triage.
+
+    No I/O, no logging — those remain at the caller. *)
+
+(** HTTP status the OpenAI-compat surface should return for this error. *)
+type http_status =
+  [ `Bad_request           (** 400: validation, malformed input *)
+  | `Unauthorized          (** 401: auth missing / invalid *)
+  | `Not_found             (** 404: model / agent / task / resource not found *)
+  | `Request_timeout       (** 408: client-cancelled *)
+  | `Too_many_requests     (** 429: rate-limit / quota *)
+  | `Internal_server_error (** 500: unclassified backend failure *)
+  | `Bad_gateway           (** 502: upstream provider error *)
+  | `Service_unavailable   (** 503: provider unavailable / cascade exhausted *)
+  | `Gateway_timeout       (** 504: structural timeout *)
+  ]
+
+(** Structured mapping result. *)
+type t = {
+  http_status : http_status;
+  openai_kind : string;          (** OpenAI envelope "type" field *)
+  openai_code : string option;   (** OpenAI envelope "code" field (null when None) *)
+  message     : string;          (** Human-readable, derived from sdk_error *)
+}
+
+(** Total map function. Exhaustive over [Agent_sdk.Error.sdk_error]. *)
+val of_sdk_error : Agent_sdk.Error.sdk_error -> t

--- a/lib/server/server_openai_compat.ml
+++ b/lib/server/server_openai_compat.ml
@@ -17,15 +17,17 @@ let generate_completion_id () =
     (Random.bits () land 0x7FFFFFFF)
     (Random.bits () land 0x7FFFFFFF)
 
-(** Build an OpenAI-format error response JSON string. *)
-let error_response ~(status : string) ~(message : string) : string =
+(** Build an OpenAI-format error response JSON string.
+    [code] populates the envelope's typed code field (null when absent). *)
+let error_response ~(status : string) ?(code : string option) ~(message : string) () : string =
+  let code_json = match code with None -> `Null | Some c -> `String c in
   Yojson.Safe.to_string
     (`Assoc [
       ("error", `Assoc [
         ("message", `String message);
         ("type", `String status);
         ("param", `Null);
-        ("code", `Null);
+        ("code", code_json);
       ]);
     ])
 
@@ -98,9 +100,12 @@ let route_keeper ~config ~sw ~clock ~keeper_name ~message : (string, string) res
   else
     Error body
 
-(** Route to direct MASC named-cascade execution via [Keeper_turn_driver.run_named]. *)
+(** Route to direct MASC named-cascade execution via [Keeper_turn_driver.run_named].
+    RFC-0105: the [Error] tag carries the typed [Openai_compat_error_map.t]
+    mapping rather than a flattened [string], preserving HTTP status / kind / code
+    classification from the underlying [Agent_sdk.Error.t]. *)
 let route_cascade ~message ~system_prompt ~max_tokens ~temperature
-  : (string, string) result =
+  : (string, Openai_compat_error_map.t) result =
   let cascade_name =
     Keeper_cascade_profile.cascade_name_for_use
       Keeper_cascade_profile.Openai_compat
@@ -122,7 +127,7 @@ let route_cascade ~message ~system_prompt ~max_tokens ~temperature
   | Ok result ->
     Ok (Agent_sdk_response.text_of_response result.response)
   | Error err ->
-    Error (Agent_sdk.Error.to_string err)
+    Error (Openai_compat_error_map.of_sdk_error err)
 
 (** Handle a POST /v1/chat/completions request.
     Parses the OpenAI-format request body, routes to keeper or cascade,
@@ -144,13 +149,13 @@ let handle_chat_completions ~config ~sw ~clock (body : string)
     if model = "" then
       (`Bad_request,
        error_response ~status:"invalid_request_error"
-         ~message:"Missing or invalid 'model' field")
+         ~message:"Missing or invalid 'model' field" ())
     else
     match extract_user_message messages with
     | None ->
       (`Bad_request,
        error_response ~status:"invalid_request_error"
-         ~message:"No user message found in messages array")
+         ~message:"No user message found in messages array" ())
     | Some user_message ->
       (* Check if this is a keeper route *)
       let is_keeper_prefix =
@@ -163,9 +168,10 @@ let handle_chat_completions ~config ~sw ~clock (body : string)
         | Ok reply ->
           (`OK, completion_response ~model ~content:reply)
         | Error e ->
+          (* Keeper path: error remains string-typed upstream (out of RFC-0105 scope). *)
           (`Internal_server_error,
            error_response ~status:"server_error"
-             ~message:(Printf.sprintf "Keeper error: %s" e))
+             ~message:(Printf.sprintf "Keeper error: %s" e) ())
       end
       else begin
         (* Build system prompt from system messages *)
@@ -184,13 +190,17 @@ let handle_chat_completions ~config ~sw ~clock (body : string)
                 ~max_tokens ~temperature with
         | Ok reply ->
           (`OK, completion_response ~model ~content:reply)
-        | Error e ->
-          (`Internal_server_error,
-           error_response ~status:"server_error"
-             ~message:(Printf.sprintf "Cascade error: %s" e))
+        | Error mapped ->
+          (* RFC-0105: typed sdk_error → HTTP status / kind / code / message.
+             Replaces the prior blanket [`Internal_server_error / "server_error"`]. *)
+          let { Openai_compat_error_map.http_status; openai_kind; openai_code; message } = mapped in
+          (* Openai_compat_error_map.http_status is a closed subset of Httpun.Status.t —
+             upcast via :> coercion since polymorphic variant subtyping cannot infer. *)
+          ((http_status :> Httpun.Status.t),
+           error_response ~status:openai_kind ?code:openai_code ~message ())
       end
   with
   | Yojson.Json_error e ->
     (`Bad_request,
      error_response ~status:"invalid_request_error"
-       ~message:(Printf.sprintf "Invalid JSON: %s" e))
+       ~message:(Printf.sprintf "Invalid JSON: %s" e) ())

--- a/lib/server/server_openai_compat.mli
+++ b/lib/server/server_openai_compat.mli
@@ -16,8 +16,8 @@ val is_enabled : unit -> bool
     on this predicate before parsing the request body. *)
 
 val error_response :
-  status:string -> message:string -> string
-(** [error_response ~status ~message] returns the JSON-string
+  status:string -> ?code:string -> message:string -> unit -> string
+(** [error_response ~status ?code ~message ()] returns the JSON-string
     error envelope:
     {[
       `Assoc [
@@ -25,16 +25,17 @@ val error_response :
           ("message", `String message);
           ("type", `String status);
           ("param", `Null);
-          ("code", `Null);
+          ("code", match code with None -> `Null | Some c -> `String c);
         ])
       ]
     ]}
     The wire shape matches OpenAI's [errors.error] field structure
-    so OpenAI SDK clients parse it correctly.  The four-key
-    [error] sub-object is pinned at the contract seam — the
-    [param] / [code] fields are always [`Null] in our compat
-    layer (we do not yet differentiate per-field validation
-    errors). *)
+    so OpenAI SDK clients parse it correctly. RFC-0105: [code] is now
+    populated from [Openai_compat_error_map.t] when the upstream is a
+    typed [Agent_sdk.Error.sdk_error]; the legacy callers that omit
+    [code] continue to emit [`Null] for that field. The [param] field
+    remains pinned at [`Null] — per-field validation is not yet
+    differentiated. *)
 
 val handle_chat_completions :
   config:Coord.config ->

--- a/test/dune
+++ b/test/dune
@@ -28,6 +28,7 @@
  (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_mcp_error_code test_error_body_delegation test_session_lifecycle_event test_fd_accountant test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
         test_keeper_turn_terminal_code_byte_compat
         test_keeper_sdk_error_typed_bridge
+        test_openai_compat_error_map
         test_read_drop_reason
         test_log_ring_encoder
         test_keeper_turn_disposition
@@ -279,6 +280,7 @@
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_mcp_error_code test_error_body_delegation test_session_lifecycle_event test_fd_accountant test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_keeper_turn_terminal_code_byte_compat
           test_keeper_sdk_error_typed_bridge
+          test_openai_compat_error_map
           test_read_drop_reason
           test_log_ring_encoder
           test_keeper_turn_disposition

--- a/test/test_openai_compat_error_map.ml
+++ b/test/test_openai_compat_error_map.ml
@@ -1,0 +1,286 @@
+(** RFC-0105 — table-driven map verification for
+    [Openai_compat_error_map.of_sdk_error].
+
+    Each row asserts that a representative [sdk_error] variant produces
+    the documented (http_status, openai_kind, openai_code) triple. The
+    table is intentionally exhaustive over the 9 top-level [sdk_error]
+    constructors — exhaustiveness over sub-variants is enforced by the
+    OCaml compiler at the implementation site (no catch-all `_ ->`). *)
+
+module M = Masc_mcp.Openai_compat_error_map
+module E = Agent_sdk.Error
+
+(* Renders [http_status] tag literally for diff-readable Alcotest output. *)
+let http_status_to_string : M.http_status -> string = function
+  | `Bad_request -> "Bad_request"
+  | `Unauthorized -> "Unauthorized"
+  | `Not_found -> "Not_found"
+  | `Request_timeout -> "Request_timeout"
+  | `Too_many_requests -> "Too_many_requests"
+  | `Internal_server_error -> "Internal_server_error"
+  | `Bad_gateway -> "Bad_gateway"
+  | `Service_unavailable -> "Service_unavailable"
+  | `Gateway_timeout -> "Gateway_timeout"
+
+let check_mapping
+    ~label
+    ~(input : E.sdk_error)
+    ~(expected_status : M.http_status)
+    ~(expected_kind : string)
+    ~(expected_code : string option)
+    () =
+  let { M.http_status; openai_kind; openai_code; message = _ } =
+    M.of_sdk_error input
+  in
+  Alcotest.(check string)
+    (Printf.sprintf "%s: http_status" label)
+    (http_status_to_string expected_status)
+    (http_status_to_string http_status);
+  Alcotest.(check string)
+    (Printf.sprintf "%s: openai_kind" label)
+    expected_kind openai_kind;
+  Alcotest.(check (option string))
+    (Printf.sprintf "%s: openai_code" label)
+    expected_code openai_code
+
+let test_api_rate_limited () =
+  check_mapping
+    ~label:"Api RateLimited"
+    ~input:(E.Api (E.Retry.RateLimited
+      { retry_after = Some 30.0; message = "throttle" }))
+    ~expected_status:`Too_many_requests
+    ~expected_kind:"rate_limit_error"
+    ~expected_code:(Some "rate_limited") ()
+
+let test_api_auth () =
+  check_mapping
+    ~label:"Api AuthError"
+    ~input:(E.Api (E.Retry.AuthError { message = "bad token" }))
+    ~expected_status:`Unauthorized
+    ~expected_kind:"authentication_error"
+    ~expected_code:(Some "invalid_api_key") ()
+
+let test_api_not_found () =
+  check_mapping
+    ~label:"Api NotFound"
+    ~input:(E.Api (E.Retry.NotFound { message = "model missing" }))
+    ~expected_status:`Not_found
+    ~expected_kind:"not_found_error"
+    ~expected_code:(Some "model_not_found") ()
+
+let test_api_context_overflow () =
+  check_mapping
+    ~label:"Api ContextOverflow"
+    ~input:(E.Api (E.Retry.ContextOverflow
+      { message = "exceeds 128k"; limit = Some 128000 }))
+    ~expected_status:`Bad_request
+    ~expected_kind:"invalid_request_error"
+    ~expected_code:(Some "context_length_exceeded") ()
+
+let test_api_timeout () =
+  check_mapping
+    ~label:"Api Timeout"
+    ~input:(E.Api (E.Retry.Timeout { message = "took too long" }))
+    ~expected_status:`Gateway_timeout
+    ~expected_kind:"server_error"
+    ~expected_code:(Some "timeout") ()
+
+let test_api_server_error () =
+  check_mapping
+    ~label:"Api ServerError 502"
+    ~input:(E.Api (E.Retry.ServerError { status = 502; message = "bad gw" }))
+    ~expected_status:`Bad_gateway
+    ~expected_kind:"server_error"
+    ~expected_code:(Some "upstream_502") ()
+
+let test_agent_token_budget () =
+  check_mapping
+    ~label:"Agent TokenBudgetExceeded"
+    ~input:(E.Agent (E.TokenBudgetExceeded
+      { kind = "input"; used = 200_000; limit = 128_000 }))
+    ~expected_status:`Bad_request
+    ~expected_kind:"invalid_request_error"
+    ~expected_code:(Some "token_budget_exceeded") ()
+
+let test_agent_max_turns () =
+  check_mapping
+    ~label:"Agent MaxTurnsExceeded"
+    ~input:(E.Agent (E.MaxTurnsExceeded { turns = 10; limit = 5 }))
+    ~expected_status:`Internal_server_error
+    ~expected_kind:"server_error"
+    ~expected_code:(Some "max_turns_exceeded") ()
+
+let test_agent_guardrail () =
+  check_mapping
+    ~label:"Agent GuardrailViolation"
+    ~input:(E.Agent (E.GuardrailViolation
+      { validator = "content_safety"; reason = "blocked" }))
+    ~expected_status:`Bad_request
+    ~expected_kind:"invalid_request_error"
+    ~expected_code:(Some "guardrail_violation") ()
+
+let test_mcp_server_start () =
+  check_mapping
+    ~label:"Mcp ServerStartFailed"
+    ~input:(E.Mcp (E.ServerStartFailed
+      { command = "x"; detail = "boom" }))
+    ~expected_status:`Service_unavailable
+    ~expected_kind:"server_error"
+    ~expected_code:(Some "mcp_server_start_failed") ()
+
+let test_mcp_tool_call () =
+  check_mapping
+    ~label:"Mcp ToolCallFailed"
+    ~input:(E.Mcp (E.ToolCallFailed
+      { tool_name = "shell"; detail = "exit 1" }))
+    ~expected_status:`Bad_gateway
+    ~expected_kind:"server_error"
+    ~expected_code:(Some "mcp_tool_call_failed") ()
+
+let test_config_missing_env () =
+  check_mapping
+    ~label:"Config MissingEnvVar"
+    ~input:(E.Config (E.MissingEnvVar { var_name = "X" }))
+    ~expected_status:`Internal_server_error
+    ~expected_kind:"server_error"
+    ~expected_code:(Some "config_missing_env") ()
+
+let test_config_unsupported_provider () =
+  check_mapping
+    ~label:"Config UnsupportedProvider"
+    ~input:(E.Config (E.UnsupportedProvider { detail = "fake-llm" }))
+    ~expected_status:`Bad_request
+    ~expected_kind:"invalid_request_error"
+    ~expected_code:(Some "unsupported_provider") ()
+
+let test_serialization_parse () =
+  check_mapping
+    ~label:"Serialization JsonParseError"
+    ~input:(E.Serialization (E.JsonParseError { detail = "{}" }))
+    ~expected_status:`Bad_gateway
+    ~expected_kind:"server_error"
+    ~expected_code:(Some "json_parse_error") ()
+
+let test_io_validation () =
+  check_mapping
+    ~label:"Io ValidationFailed"
+    ~input:(E.Io (E.ValidationFailed { detail = "bad input" }))
+    ~expected_status:`Bad_request
+    ~expected_kind:"invalid_request_error"
+    ~expected_code:(Some "validation_failed") ()
+
+let test_orchestration_unknown_agent () =
+  check_mapping
+    ~label:"Orchestration UnknownAgent"
+    ~input:(E.Orchestration (E.UnknownAgent { name = "ghost" }))
+    ~expected_status:`Not_found
+    ~expected_kind:"not_found_error"
+    ~expected_code:(Some "agent_not_found") ()
+
+let test_orchestration_timeout () =
+  check_mapping
+    ~label:"Orchestration TaskTimeout"
+    ~input:(E.Orchestration (E.TaskTimeout { task_id = "t1" }))
+    ~expected_status:`Gateway_timeout
+    ~expected_kind:"server_error"
+    ~expected_code:(Some "task_timeout") ()
+
+let test_a2a_task_not_found () =
+  check_mapping
+    ~label:"A2a TaskNotFound"
+    ~input:(E.A2a (E.TaskNotFound { task_id = "t1" }))
+    ~expected_status:`Not_found
+    ~expected_kind:"not_found_error"
+    ~expected_code:(Some "task_not_found") ()
+
+let test_a2a_store_capacity () =
+  check_mapping
+    ~label:"A2a StoreCapacityExceeded"
+    ~input:(E.A2a (E.StoreCapacityExceeded { current = 1000; max = 500 }))
+    ~expected_status:`Service_unavailable
+    ~expected_kind:"server_error"
+    ~expected_code:(Some "store_capacity_exceeded") ()
+
+let test_internal () =
+  check_mapping
+    ~label:"Internal"
+    ~input:(E.Internal "unexpected condition")
+    ~expected_status:`Internal_server_error
+    ~expected_kind:"server_error"
+    ~expected_code:(Some "internal_error") ()
+
+(* Sanity: message field is non-empty for every variant tested above.
+   The of_sdk_error function should never produce an empty user-visible
+   message even for Internal variants. *)
+let test_message_nonempty () =
+  let samples : E.sdk_error list =
+    [ E.Api (E.Retry.RateLimited { retry_after = None; message = "x" })
+    ; E.Agent (E.IdleDetected { consecutive_idle_turns = 3 })
+    ; E.Mcp (E.InitializeFailed { detail = "boom" })
+    ; E.Config (E.InvalidConfig { field = "f"; detail = "d" })
+    ; E.Serialization (E.VersionMismatch { expected = 1; got = 2 })
+    ; E.Io (E.FileOpFailed { op = "read"; path = "/x"; detail = "y" })
+    ; E.Orchestration (E.DiscoveryFailed { url = "http://x"; detail = "z" })
+    ; E.A2a (E.ProtocolError { detail = "p" })
+    ; E.Internal ""  (* empty Internal still produces empty user message — documented *)
+    ]
+  in
+  let i = ref 0 in
+  List.iter (fun e ->
+    incr i;
+    let { M.message; _ } = M.of_sdk_error e in
+    let label = Printf.sprintf "sample %d message length" !i in
+    let _ = label in
+    let _ = message in
+    (* Internal "" is the only case where message may be "" — that's the
+       upstream contract.  Other variants should produce a non-empty
+       message via Agent_sdk.Error.to_string. *)
+    match e with
+    | E.Internal "" -> ()
+    | _ ->
+      Alcotest.(check bool) (Printf.sprintf "sample %d message non-empty" !i)
+        true (String.length message > 0)
+  ) samples
+
+let () =
+  Alcotest.run "openai_compat_error_map"
+    [ ( "api"
+      , [ Alcotest.test_case "RateLimited → 429"   `Quick test_api_rate_limited
+        ; Alcotest.test_case "AuthError → 401"     `Quick test_api_auth
+        ; Alcotest.test_case "NotFound → 404"      `Quick test_api_not_found
+        ; Alcotest.test_case "ContextOverflow → 400" `Quick test_api_context_overflow
+        ; Alcotest.test_case "Timeout → 504"       `Quick test_api_timeout
+        ; Alcotest.test_case "ServerError 502 → 502" `Quick test_api_server_error
+        ] )
+    ; ( "agent"
+      , [ Alcotest.test_case "TokenBudgetExceeded → 400" `Quick test_agent_token_budget
+        ; Alcotest.test_case "MaxTurnsExceeded → 500"    `Quick test_agent_max_turns
+        ; Alcotest.test_case "GuardrailViolation → 400"  `Quick test_agent_guardrail
+        ] )
+    ; ( "mcp"
+      , [ Alcotest.test_case "ServerStartFailed → 503" `Quick test_mcp_server_start
+        ; Alcotest.test_case "ToolCallFailed → 502"    `Quick test_mcp_tool_call
+        ] )
+    ; ( "config"
+      , [ Alcotest.test_case "MissingEnvVar → 500"      `Quick test_config_missing_env
+        ; Alcotest.test_case "UnsupportedProvider → 400" `Quick test_config_unsupported_provider
+        ] )
+    ; ( "serialization"
+      , [ Alcotest.test_case "JsonParseError → 502" `Quick test_serialization_parse
+        ] )
+    ; ( "io"
+      , [ Alcotest.test_case "ValidationFailed → 400" `Quick test_io_validation
+        ] )
+    ; ( "orchestration"
+      , [ Alcotest.test_case "UnknownAgent → 404"   `Quick test_orchestration_unknown_agent
+        ; Alcotest.test_case "TaskTimeout → 504"    `Quick test_orchestration_timeout
+        ] )
+    ; ( "a2a"
+      , [ Alcotest.test_case "TaskNotFound → 404"       `Quick test_a2a_task_not_found
+        ; Alcotest.test_case "StoreCapacityExceeded → 503" `Quick test_a2a_store_capacity
+        ] )
+    ; ( "internal"
+      , [ Alcotest.test_case "Internal → 500"     `Quick test_internal
+        ; Alcotest.test_case "Message non-empty"  `Quick test_message_nonempty
+        ] )
+    ]


### PR DESCRIPTION
## Summary

Implements [RFC-0105](https://github.com/jeong-sik/masc-mcp/blob/main/docs/rfc/RFC-0105-openai-compat-typed-error-mapping.md) (body merged in #15885) in a single surgical change. Closes the sole remaining lossful `Agent_sdk.Error.t` boundary in `lib/server/` identified by the RFC-0098 closeout follow-up audit.

## Before / After

**Before** (`server_openai_compat.ml:125`):
```ocaml
| Error err -> Error (Agent_sdk.Error.to_string err)   (* typed → string *)
```
Then flattened at the HTTP boundary:
```ocaml
| Error e ->
  (`Internal_server_error,                              (* always 500 *)
   error_response ~status:"server_error" ~message:...)  (* always server_error *)
```
With envelope `"code": null` hardcoded for every error.

**After**:
- `route_cascade : (string, Openai_compat_error_map.t) result` — typed Error tag.
- `Openai_compat_error_map.of_sdk_error` — pure total function, exhaustive over all 9 top-level `sdk_error` variants. No catch-all `_ ->`.
- `handle_chat_completions` consumes the typed mapping → per-variant `(http_status, openai_kind, openai_code, message)`.
- Envelope `code` field populated from typed `openai_code` (or `null` when absent).

## §5 Acceptance (RFC-0105)

- [x] `of_sdk_error` exhaustive: `rg "\| _ ->" lib/server/openai_compat_error_map.ml` → 0 matches
- [x] `route_cascade` signature widened: `(string, Openai_compat_error_map.t) result`
- [x] `handle_chat_completions` Error arm uses `mapped.http_status` (no `Internal_server_error` hardcode for cascade errors)
- [x] `error_response` envelope populates `code` field with `openai_code` when present
- [x] `rg -n "Agent_sdk.Error.to_string" lib/server/server_openai_compat.ml` → 0 matches
- [x] Table-driven Alcotest: 21/21 PASS, no mocks, pure map function

> Note on acceptance §5 item 5: the RFC body wrote `lib/server/` broadly. After implementation, `Agent_sdk.Error.to_string` appears 7× inside `lib/server/openai_compat_error_map.ml` itself — these are *intentional*, used to extract the SDK-provided message text for the structured `message` field of the typed mapping. They are not the lossful typed→string compression the RFC targets. Acceptance check therefore narrows to `server_openai_compat.ml`, which is 0. If reviewer prefers, a follow-up commit can clarify the RFC body wording.

## §8 Workaround signatures self-check

| Signature | Match? | Why |
|---|---|---|
| Counter-as-fix | No | Removes lossful boundary, doesn't instrument it |
| String classifier | No | Removes typed→string collapse, adds no string match |
| N-of-M | No | Single boundary, complete migration in one PR |
| Cap/cooldown/dedup/repair | No | No symptom suppression |
| Test backdoor | No | Pure map function, no test-only mutation |

## Test plan

- [x] `dune build --root . @check` — clean.
- [x] `dune exec --root . test/test_openai_compat_error_map.exe` — 21/21 PASS.
- [ ] Reviewer sanity check: pick any variant from each top-level family in the Alcotest table, confirm the `(http_status, openai_kind, openai_code)` triple matches OpenAI API conventions.
- [ ] Reviewer manual exercise: hit `/v1/chat/completions` with a deliberately invalid model name (e.g., `"nonexistent-model"`) — expect HTTP 404 + `{"error": {"type": "not_found_error", "code": "model_not_found", ...}}` rather than the previous HTTP 500 + `"server_error"`.

## Files

- `lib/server/openai_compat_error_map.{ml,mli}` (new, 264 LoC including module docs)
- `lib/server/server_openai_compat.ml` — `route_cascade` + `handle_chat_completions` + `error_response` (3 site)
- `lib/server/server_openai_compat.mli` — `error_response` signature widened to `?code` + `()` trailing
- `bin/main_eio.ml` — 2 callers of `error_response` get `()` suffix
- `test/dune` — `test_openai_compat_error_map` registered in Group 1
- `test/test_openai_compat_error_map.ml` (new, 21 Alcotest cases)

## Migration

- Single-commit, surgical. No env flag, no state migration, no flag.
- Rollback: revert the commit.
- Behavioral change for OpenAI-compat clients: errors that previously came back as HTTP 500 + `"server_error"` (e.g., rate-limit) will now return their semantically correct status (e.g., 429 + `"rate_limit_error"`). This is **not** breaking for clients that already implement the OpenAI client retry/error contract.

RFC-WAIVED: feature/server (`lib/server/` is not in `CLAUDE.md` agent_delegation subsystem list — no credential, no identity, no repo, no operator, no keeper/sandbox, no dashboard credential, no hooks, no workflow doc touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
