### PR TITLE
feat(cancel-safe): RFC-0106 P0 — Cancel_safe helper + canary migration

### DIFF
--- a/lib/cancel_safe/cancel_safe.ml
+++ b/lib/cancel_safe/cancel_safe.ml
@@ -1,0 +1,7 @@
+let protect ~on_exn f =
+  try f ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> on_exn exn
+
+let observe ~on_exn f = protect ~on_exn f

--- a/lib/cancel_safe/cancel_safe.mli
+++ b/lib/cancel_safe/cancel_safe.mli
@@ -1,0 +1,23 @@
+(** Cancel-safe try-with discipline. RFC-0106.
+
+    Catch-all handlers ([try ... with | exn -> ...]) silently absorb
+    [Eio.Cancel.Cancelled] which must propagate to the surrounding
+    switch for proper fiber tree unwind. These combinators are the
+    SSOT site that re-raises Cancelled; everything else flows through
+    [on_exn]. *)
+
+val protect : on_exn:(exn -> 'a) -> (unit -> 'a) -> 'a
+(** [protect ~on_exn f] runs [f ()] and re-raises [Eio.Cancel.Cancelled]
+    verbatim. Any other exception is passed to [on_exn], whose return
+    value becomes the result of the [protect] call.
+
+    Use this when the failure path must produce a value (record an
+    outcome, return a default, lift to [Result], etc.). [on_exn] must
+    not re-raise the [exn] argument unchanged — that would defeat the
+    purpose of using a combinator. To re-raise selectively, match on
+    the exception inside [on_exn] and raise as needed. *)
+
+val observe : on_exn:(exn -> unit) -> (unit -> unit) -> unit
+(** [observe ~on_exn f] is [protect ~on_exn f] specialised for callbacks
+    whose result is [unit]. Typical use: lifecycle observers that must
+    record a failure but continue the surrounding workflow. *)

--- a/lib/cancel_safe/dune
+++ b/lib/cancel_safe/dune
@@ -1,0 +1,8 @@
+(include_subdirs no)
+(library
+ (name masc_cancel_safe)
+ (public_name masc_mcp.cancel_safe)
+ (wrapped false)
+ (modules cancel_safe)
+ (flags (:standard -w +4))
+ (libraries eio))

--- a/lib/dune
+++ b/lib/dune
@@ -404,6 +404,8 @@
    masc_compression
    ;; Eio context (extracted sub-library)
    masc_eio_context
+   ;; Cancel-safe try-with combinators (RFC-0106 P0)
+   masc_cancel_safe
    ;; Backend storage (extracted sub-library)
    masc_backend
    ;; Process execution + file locking (extracted sub-library)

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -554,14 +554,13 @@ let apply_post_turn_lifecycle_with_resilience_handles
              docs/architecture/actor-mailbox-pattern.md for the
              reasoning behind the keep-going-on-callback-failure
              policy. *)
-          let () =
-            try on_compaction_started ()
-            with
-            | Eio.Cancel.Cancelled _ as e -> raise e
-            | exn ->
-                Keeper_callback_failure.record ~base_dir ~meta:base_meta
-                  ~callback:"on_compaction_started" exn
-          in
+          (* RFC-0106 P0 canary: use Cancel_safe.observe so Cancelled
+             propagates without per-site discipline drift. *)
+          Cancel_safe.observe
+            ~on_exn:(fun exn ->
+              Keeper_callback_failure.record ~base_dir ~meta:base_meta
+                ~callback:"on_compaction_started" exn)
+            on_compaction_started;
           let session =
             create_session ~session_id:(Keeper_id.Trace_id.to_string base_meta.runtime.trace_id) ~base_dir
           in


### PR DESCRIPTION
## Summary

Implements RFC-0106 Phase 0: adds the `Cancel_safe.protect` / `Cancel_safe.observe` helper combinators and migrates the canary site.

- New leaf sublib `lib/cancel_safe/` (`masc_cancel_safe`) — depends on `eio` only.
- `Cancel_safe.protect ~on_exn f`: re-raises `Eio.Cancel.Cancelled` verbatim, passes other exceptions to `on_exn`.
- `Cancel_safe.observe ~on_exn f`: same shape specialised for unit-returning callbacks.
- Canary migration: `lib/keeper/keeper_post_turn.ml:557` `on_compaction_started` callback now uses `Cancel_safe.observe` instead of the manual paired arm added in PR #15887.

## Behaviour

Preserved. The `Keeper_callback_failure.record` call inside `~on_exn` is identical to the previous catch-all body. Cancellation propagation is enabled by the same `Eio.Cancel.Cancelled _ -> raise` pattern, now centralised.

## Build

`dune build @check` PASS.

## Files

- `lib/cancel_safe/dune` — leaf sublib, `(wrapped false)`, depends on `eio`, warning 4 enabled
- `lib/cancel_safe/cancel_safe.ml` — 6 LoC implementation
- `lib/cancel_safe/cancel_safe.mli` — typed interface with docstrings
- `lib/dune` — `masc_cancel_safe` added to `(libraries)` next to `masc_eio_context`
- `lib/keeper/keeper_post_turn.ml` — canary migration (-9/+7)

## Anti-pattern self-check (7/7)

- [x] Not telemetry-as-fix — Cancelled propagation was already enabled by PR #15887; this PR removes per-site discipline drift risk
- [x] No string classifier — typed constructor match centralised
- [x] Not N-of-M — single canary site; RFC-0106 Phase 1 governs the ladder
- [x] No new `_ -> false` catch-all — `on_exn` is caller-supplied
- [x] No magic number / test backdoor / N-times-typo fix

## Related

- RFC-0106 (PR #15894 merged) — spec
- PR #15883 — bg_task drain typed split precedent
- PR #15887 — canary site's previous manual paired-arm form

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>