### PR TITLE
fix(dashboard): surface reaction ledger cursor sweeps

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -151,4 +151,79 @@ describe('dashboardHealthChips', () => {
     })])
     expect(chips[0]?.detail).toContain('blocking 24 keepers')
   })
+
+  it('surfaces reaction ledger cursor sweeps even when pending backlog is clear', () => {
+    const chips = dashboardHealthChips({
+      connected: true,
+      counts: { keepers: 2, configured_keepers: 2 },
+      keepers: [],
+      runtimeResolution: {
+        status: 'ready',
+        warnings: [],
+        fleet_safety: {
+          keeper_fibers: null,
+          paused_keepers: null,
+          keeper_fleet_no_fibers: null,
+          keeper_fd_pressure: null,
+          keeper_fleet_safety: null,
+          keeper_reaction_ledger: {
+            status: 'ok',
+            operator_action_required: false,
+            cursor_ack_count: 4,
+            cursor_swept_stimulus_count: 3,
+            legacy_cursor_swept_stimulus_count: 1,
+            pending_stimulus_count: 0,
+            read_error_count: 0,
+          },
+        },
+      } as any,
+      executionError: null,
+      loading: false,
+    })
+
+    expect(chips).toEqual([expect.objectContaining({
+      key: 'reaction-ledger',
+      label: 'Reaction ledger swept 4',
+      tone: 'ok',
+    })])
+    expect(chips[0]?.detail).toContain('cursor_swept=3')
+    expect(chips[0]?.detail).toContain('legacy_swept=1')
+  })
+
+  it('warns on real reaction ledger pending backlog', () => {
+    const chips = dashboardHealthChips({
+      connected: true,
+      counts: { keepers: 2, configured_keepers: 2 },
+      keepers: [],
+      runtimeResolution: {
+        status: 'ready',
+        warnings: [],
+        fleet_safety: {
+          keeper_fibers: null,
+          paused_keepers: null,
+          keeper_fleet_no_fibers: null,
+          keeper_fd_pressure: null,
+          keeper_fleet_safety: null,
+          keeper_reaction_ledger: {
+            status: 'degraded',
+            operator_action_required: true,
+            cursor_ack_count: 4,
+            cursor_swept_stimulus_count: 3,
+            legacy_cursor_swept_stimulus_count: 1,
+            pending_stimulus_count: 2,
+            read_error_count: 0,
+          },
+        },
+      } as any,
+      executionError: null,
+      loading: false,
+    })
+
+    expect(chips).toEqual([expect.objectContaining({
+      key: 'reaction-ledger',
+      label: 'Reaction ledger pending 2',
+      tone: 'warn',
+    })])
+    expect(chips[0]?.detail).toContain('pending=2')
+  })
 })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -3,7 +3,7 @@ import { signal } from '@preact/signals'
 import { lazy, Suspense } from 'preact/compat'
 import { useEffect } from 'preact/hooks'
 import type { RouteState, TabId } from '../types'
-import type { DashboardFleetSafetyHealth, DashboardRuntimeResolution, Keeper } from '../types'
+import type { DashboardFleetSafetyHealth, DashboardKeeperReactionLedgerHealth, DashboardRuntimeResolution, Keeper } from '../types'
 import { hashForRoute, navigate, route } from '../router'
 import { connected, reconnectCount, lastDisconnectedAt } from '../sse'
 import { dashboardWsOnlyEnabled } from '../dashboard-ws-cutover'
@@ -208,6 +208,50 @@ function fleetSafetyHealthChip(fleetSafety: DashboardFleetSafetyHealth | null): 
   return null
 }
 
+function ledgerCount(value: number | null | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+function reactionLedgerHealthChip(
+  ledger: DashboardKeeperReactionLedgerHealth | null | undefined,
+): DashboardHealthChip | null {
+  if (!ledger) return null
+  const pending = ledgerCount(ledger.pending_stimulus_count)
+  const cursorSwept = ledgerCount(ledger.cursor_swept_stimulus_count)
+  const legacySwept = ledgerCount(ledger.legacy_cursor_swept_stimulus_count)
+  const readErrors = ledgerCount(ledger.read_error_count)
+  const cursorAck = ledgerCount(ledger.cursor_ack_count)
+  const status = ledger.status ?? 'unknown'
+  const requiresAction = ledger.operator_action_required === true
+  const totalSwept = cursorSwept + legacySwept
+  if (!requiresAction && pending === 0 && readErrors === 0 && totalSwept === 0 && status !== 'degraded') {
+    return null
+  }
+  const tone: DashboardHealthChipTone = readErrors > 0
+    ? 'bad'
+    : requiresAction || pending > 0 || status === 'degraded'
+      ? 'warn'
+      : 'ok'
+  const label = pending > 0
+    ? `Reaction ledger pending ${pending}`
+    : totalSwept > 0
+      ? `Reaction ledger swept ${totalSwept}`
+      : `Reaction ledger ${status}`
+  return {
+    key: 'reaction-ledger',
+    label,
+    detail: [
+      `status=${status}`,
+      `pending=${pending}`,
+      `cursor_swept=${cursorSwept}`,
+      `legacy_swept=${legacySwept}`,
+      `cursor_ack=${cursorAck}`,
+      `read_errors=${readErrors}`,
+    ].join(', '),
+    tone,
+  }
+}
+
 export function dashboardHealthChips(input: DashboardHealthInput): DashboardHealthChip[] {
   const chips: DashboardHealthChip[] = []
   if (!input.connected) {
@@ -249,6 +293,11 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
   const fleetChip = fleetSafetyHealthChip(runtime?.fleet_safety ?? null)
   if (fleetChip) {
     chips.push(fleetChip)
+  }
+
+  const reactionLedgerChip = reactionLedgerHealthChip(runtime?.fleet_safety?.keeper_reaction_ledger)
+  if (reactionLedgerChip) {
+    chips.push(reactionLedgerChip)
   }
 
   const configured = input.counts?.configured_keepers ?? 0

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -167,6 +167,20 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
       keeper_fleet_safety: {
         blocked_keepers: 24,
       },
+      keeper_reaction_ledger: {
+        status: 'ok',
+        operator_action_required: false,
+        keeper_count: 2,
+        row_count: 8,
+        stimulus_count: 4,
+        reaction_count: 4,
+        cursor_ack_count: 2,
+        cursor_swept_stimulus_count: 3,
+        legacy_cursor_swept_stimulus_count: 1,
+        pending_stimulus_count: 0,
+        read_error_count: 0,
+        pending_by_keeper: [],
+      },
     }))
 
     expect(result?.fleet_safety).toMatchObject({
@@ -181,6 +195,47 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
       },
       keeper_fleet_safety: {
         blocked_keepers: 24,
+      },
+      keeper_reaction_ledger: {
+        status: 'ok',
+        cursor_ack_count: 2,
+        cursor_swept_stimulus_count: 3,
+        legacy_cursor_swept_stimulus_count: 1,
+        pending_stimulus_count: 0,
+        read_error_count: 0,
+      },
+    })
+  })
+
+  it('keeps reaction-ledger health even when other fleet safety fields are absent', () => {
+    const result = normalizeDashboardRuntimeResolution(runtimeResolutionRaw({
+      keeper_reaction_ledger: {
+        status: 'degraded',
+        operator_action_required: true,
+        pending_stimulus_count: 2,
+        cursor_swept_stimulus_count: 5,
+        legacy_cursor_swept_stimulus_count: 1,
+        pending_by_keeper: [{
+          keeper_name: 'keeper-a',
+          pending_stimulus_count: 2,
+          pending_stimulus_ids: ['p-1', 'p-2'],
+        }],
+      },
+    }))
+
+    expect(result?.fleet_safety).toMatchObject({
+      keeper_fibers: null,
+      keeper_reaction_ledger: {
+        status: 'degraded',
+        operator_action_required: true,
+        pending_stimulus_count: 2,
+        cursor_swept_stimulus_count: 5,
+        legacy_cursor_swept_stimulus_count: 1,
+        pending_by_keeper: [{
+          keeper_name: 'keeper-a',
+          pending_stimulus_count: 2,
+          pending_stimulus_ids: ['p-1', 'p-2'],
+        }],
       },
     })
   })

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -11,6 +11,8 @@ import type {
   DashboardConfigResolutionItem,
   DashboardFleetPressureHealth,
   DashboardFleetSafetyHealth,
+  DashboardKeeperReactionLedgerHealth,
+  DashboardKeeperReactionLedgerPendingKeeper,
   DashboardRuntimeDiagnostic,
   DashboardRuntimeResolution,
   KeeperRuntimeResolved,
@@ -635,18 +637,99 @@ function normalizeDashboardFleetPressureHealth(raw: unknown): DashboardFleetPres
   }
 }
 
+function normalizeDashboardKeeperReactionLedgerPendingKeeper(
+  raw: unknown,
+): DashboardKeeperReactionLedgerPendingKeeper | null {
+  if (!isRecord(raw)) return null
+  const keeperName = asString(raw.keeper_name)
+  const pendingStimulusCount = asNumber(raw.pending_stimulus_count)
+  if (!keeperName || pendingStimulusCount == null) return null
+  return {
+    keeper_name: keeperName,
+    pending_stimulus_count: pendingStimulusCount,
+    pending_stimulus_ids: asStringArray(raw.pending_stimulus_ids),
+  }
+}
+
+function normalizeDashboardKeeperReactionLedgerHealth(
+  raw: unknown,
+): DashboardKeeperReactionLedgerHealth | null {
+  if (!isRecord(raw)) return null
+  const status = asString(raw.status) ?? null
+  const operatorActionRequired = asBoolean(raw.operator_action_required) ?? null
+  const keeperCount = asNumber(raw.keeper_count)
+  const rowCount = asNumber(raw.row_count)
+  const stimulusCount = asNumber(raw.stimulus_count)
+  const reactionCount = asNumber(raw.reaction_count)
+  const turnStartedCount = asNumber(raw.turn_started_count)
+  const cursorAckCount = asNumber(raw.cursor_ack_count)
+  const executionReceiptCount = asNumber(raw.execution_receipt_count)
+  const terminalReasonCount = asNumber(raw.terminal_reason_count)
+  const operatorEscalationCount = asNumber(raw.operator_escalation_count)
+  const unknownReactionCount = asNumber(raw.unknown_reaction_count)
+  const cursorSweptStimulusCount = asNumber(raw.cursor_swept_stimulus_count)
+  const legacyCursorSweptStimulusCount = asNumber(raw.legacy_cursor_swept_stimulus_count)
+  const pendingStimulusCount = asNumber(raw.pending_stimulus_count)
+  const readErrorCount = asNumber(raw.read_error_count)
+  const pendingByKeeper = (Array.isArray(raw.pending_by_keeper) ? raw.pending_by_keeper : [])
+    .map(normalizeDashboardKeeperReactionLedgerPendingKeeper)
+    .filter((item): item is DashboardKeeperReactionLedgerPendingKeeper => item !== null)
+  if (
+    status == null
+    && operatorActionRequired == null
+    && keeperCount == null
+    && rowCount == null
+    && stimulusCount == null
+    && reactionCount == null
+    && turnStartedCount == null
+    && cursorAckCount == null
+    && executionReceiptCount == null
+    && terminalReasonCount == null
+    && operatorEscalationCount == null
+    && unknownReactionCount == null
+    && cursorSweptStimulusCount == null
+    && legacyCursorSweptStimulusCount == null
+    && pendingStimulusCount == null
+    && readErrorCount == null
+    && pendingByKeeper.length === 0
+  ) {
+    return null
+  }
+  return {
+    status,
+    operator_action_required: operatorActionRequired,
+    keeper_count: keeperCount ?? null,
+    row_count: rowCount ?? null,
+    stimulus_count: stimulusCount ?? null,
+    reaction_count: reactionCount ?? null,
+    turn_started_count: turnStartedCount ?? null,
+    cursor_ack_count: cursorAckCount ?? null,
+    execution_receipt_count: executionReceiptCount ?? null,
+    terminal_reason_count: terminalReasonCount ?? null,
+    operator_escalation_count: operatorEscalationCount ?? null,
+    unknown_reaction_count: unknownReactionCount ?? null,
+    cursor_swept_stimulus_count: cursorSweptStimulusCount ?? null,
+    legacy_cursor_swept_stimulus_count: legacyCursorSweptStimulusCount ?? null,
+    pending_stimulus_count: pendingStimulusCount ?? null,
+    read_error_count: readErrorCount ?? null,
+    pending_by_keeper: pendingByKeeper,
+  }
+}
+
 function normalizeDashboardFleetSafetyHealth(raw: Record<string, unknown>): DashboardFleetSafetyHealth | null {
   const keeperFibers = asNumber(raw.keeper_fibers)
   const pausedKeepers = asNumber(raw.paused_keepers)
   const noFibers = asBoolean(raw.keeper_fleet_no_fibers)
   const fdPressure = normalizeDashboardFleetPressureHealth(raw.keeper_fd_pressure)
   const fleetSafety = normalizeDashboardFleetPressureHealth(raw.keeper_fleet_safety)
+  const reactionLedger = normalizeDashboardKeeperReactionLedgerHealth(raw.keeper_reaction_ledger)
   if (
     keeperFibers == null
     && pausedKeepers == null
     && noFibers == null
     && fdPressure == null
     && fleetSafety == null
+    && reactionLedger == null
   ) {
     return null
   }
@@ -656,6 +739,7 @@ function normalizeDashboardFleetSafetyHealth(raw: Record<string, unknown>): Dash
     keeper_fleet_no_fibers: noFibers ?? null,
     keeper_fd_pressure: fdPressure,
     keeper_fleet_safety: fleetSafety,
+    keeper_reaction_ledger: reactionLedger,
   }
 }
 

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -125,6 +125,33 @@ export interface DashboardFleetSafetyHealth {
   keeper_fleet_no_fibers: boolean | null
   keeper_fd_pressure: DashboardFleetPressureHealth | null
   keeper_fleet_safety: DashboardFleetPressureHealth | null
+  keeper_reaction_ledger: DashboardKeeperReactionLedgerHealth | null
+}
+
+export interface DashboardKeeperReactionLedgerPendingKeeper {
+  keeper_name: string
+  pending_stimulus_count: number
+  pending_stimulus_ids: string[]
+}
+
+export interface DashboardKeeperReactionLedgerHealth {
+  status: string | null
+  operator_action_required: boolean | null
+  keeper_count: number | null
+  row_count: number | null
+  stimulus_count: number | null
+  reaction_count: number | null
+  turn_started_count: number | null
+  cursor_ack_count: number | null
+  execution_receipt_count: number | null
+  terminal_reason_count: number | null
+  operator_escalation_count: number | null
+  unknown_reaction_count: number | null
+  cursor_swept_stimulus_count: number | null
+  legacy_cursor_swept_stimulus_count: number | null
+  pending_stimulus_count: number | null
+  read_error_count: number | null
+  pending_by_keeper: DashboardKeeperReactionLedgerPendingKeeper[]
 }
 
 export interface DashboardFleetPressureHealth {


### PR DESCRIPTION
Closes #15895

Summary:
- Preserve keeper_reaction_ledger from dashboard shell runtime_resolution
- Show Reaction ledger swept/pending counts in the dashboard health strip
- Cover normalization and health-chip behavior with focused tests

Validation:
- pnpm vitest run --config vitest.config.ts src/store-normalizers.test.ts --no-file-parallelism --maxWorkers=1
- pnpm vitest run --config vitest.config.ts src/components/dashboard-shell.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck