### PR TITLE
feat(jsonl_atomic): RFC-0108 SSOT atomic JSONL append writer + tests (Draft)

### DIFF
--- a/lib/jsonl_atomic/dune
+++ b/lib/jsonl_atomic/dune
@@ -1,0 +1,8 @@
+(include_subdirs no)
+(library
+ (name jsonl_atomic)
+ (public_name masc_mcp.jsonl_atomic)
+ (modules jsonl_atomic)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
+ (libraries eio eio.unix unix yojson))

--- a/lib/jsonl_atomic/jsonl_atomic.ml
+++ b/lib/jsonl_atomic/jsonl_atomic.ml
@@ -7,40 +7,66 @@ type t = {
   mutable closed : bool;
 }
 
-(* Per-path Eio.Mutex registry. Keyed by absolute or canonical path
-   string. Two writers for the same path share the same mutex; the
-   sink (fd) is per-writer. *)
+(* Per-path Eio.Mutex registry. Keyed by the *canonicalized* path so
+   that two writers naming the same file through different spellings
+   (e.g. ["logs/out.jsonl"] vs ["./logs/out.jsonl"], or with
+   intervening ["a/../b"] segments) share the same mutex. The sink
+   (fd) is per-writer. *)
 let mutex_registry : (string, Eio.Mutex.t) Hashtbl.t = Hashtbl.create 16
 let mutex_registry_mu = Stdlib.Mutex.create ()
 
-let get_or_create_mutex path =
+(* Resolve ["." ] and [".."] segments without requiring file existence
+   (so [open_writer] can canonicalize before the file is created).
+   Relative paths are anchored at the process cwd at call time. This
+   collapses the common spelling variants flagged by Codex review of
+   PR #15906; symlink resolution is intentionally out of scope (would
+   need [realpath] which fails on missing paths). *)
+let canonicalize_path path =
+  let absolute =
+    if Filename.is_relative path
+    then Filename.concat (Sys.getcwd ()) path
+    else path
+  in
+  let parts = String.split_on_char '/' absolute in
+  let acc =
+    List.fold_left
+      (fun acc seg ->
+        match seg, acc with
+        | "", [] -> [""] (* preserve leading "/" *)
+        | "", _ -> acc (* squash "//" *)
+        | ".", _ -> acc
+        | "..", _ :: tl -> tl
+        | "..", [] -> []
+        | s, _ -> s :: acc)
+      []
+      parts
+  in
+  let joined = String.concat "/" (List.rev acc) in
+  if joined = "" then "/" else joined
+
+let get_or_create_mutex key =
   Stdlib.Mutex.lock mutex_registry_mu;
   Fun.protect
     ~finally:(fun () -> Stdlib.Mutex.unlock mutex_registry_mu)
     (fun () ->
-      match Hashtbl.find_opt mutex_registry path with
+      match Hashtbl.find_opt mutex_registry key with
       | Some m -> m
       | None ->
         let m = Eio.Mutex.create () in
-        Hashtbl.add mutex_registry path m;
+        Hashtbl.add mutex_registry key m;
         m)
 
-(* Recursive mkdir. Pure Unix to avoid Fs_compat dependency cycle
-   (Fs_compat may transition to use Jsonl_atomic later). *)
-let rec mkdir_p_unix dir =
-  if dir = "" || dir = "." || dir = "/" then ()
-  else
-    try Unix.mkdir dir 0o755
-    with
-    | Unix.Unix_error (Unix.EEXIST, _, _) -> ()
-    | Unix.Unix_error (Unix.ENOENT, _, _) ->
-      mkdir_p_unix (Filename.dirname dir);
-      (try Unix.mkdir dir 0o755 with
-       | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
-
 let open_writer ~sw ~fs ~path =
+  (* Create parent directories *within the provided fs root* — using
+     [Eio.Path.mkdirs] on the fs-scoped path matches how [open_out]
+     below resolves the same path. The previous [Unix.mkdir] sibling
+     resolved against process cwd, which is wrong for scoped fs
+     handles (flagged by Codex review of PR #15906). *)
   let dir = Filename.dirname path in
-  if dir <> "" && dir <> "." && dir <> "/" then mkdir_p_unix dir;
+  if dir <> "" && dir <> "." && dir <> "/" then begin
+    let eio_dir = Eio.Path.(fs / dir) in
+    try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 eio_dir with _ -> ()
+  end;
   let eio_path = Eio.Path.(fs / path) in
   let sink =
     Eio.Path.open_out
@@ -51,7 +77,7 @@ let open_writer ~sw ~fs ~path =
   in
   {
     path;
-    mutex = get_or_create_mutex path;
+    mutex = get_or_create_mutex (canonicalize_path path);
     sink;
     closed = false;
   }

--- a/lib/jsonl_atomic/jsonl_atomic.ml
+++ b/lib/jsonl_atomic/jsonl_atomic.ml
@@ -1,0 +1,77 @@
+(** RFC-0107: in-process atomic JSONL append writer. *)
+
+type t = {
+  path : string;
+  mutex : Eio.Mutex.t;
+  sink : Eio.File.rw_ty Eio.Resource.t;
+  mutable closed : bool;
+}
+
+(* Per-path Eio.Mutex registry. Keyed by absolute or canonical path
+   string. Two writers for the same path share the same mutex; the
+   sink (fd) is per-writer. *)
+let mutex_registry : (string, Eio.Mutex.t) Hashtbl.t = Hashtbl.create 16
+let mutex_registry_mu = Stdlib.Mutex.create ()
+
+let get_or_create_mutex path =
+  Stdlib.Mutex.lock mutex_registry_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock mutex_registry_mu)
+    (fun () ->
+      match Hashtbl.find_opt mutex_registry path with
+      | Some m -> m
+      | None ->
+        let m = Eio.Mutex.create () in
+        Hashtbl.add mutex_registry path m;
+        m)
+
+(* Recursive mkdir. Pure Unix to avoid Fs_compat dependency cycle
+   (Fs_compat may transition to use Jsonl_atomic later). *)
+let rec mkdir_p_unix dir =
+  if dir = "" || dir = "." || dir = "/" then ()
+  else
+    try Unix.mkdir dir 0o755
+    with
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+    | Unix.Unix_error (Unix.ENOENT, _, _) ->
+      mkdir_p_unix (Filename.dirname dir);
+      (try Unix.mkdir dir 0o755 with
+       | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+
+let open_writer ~sw ~fs ~path =
+  let dir = Filename.dirname path in
+  if dir <> "" && dir <> "." && dir <> "/" then mkdir_p_unix dir;
+  let eio_path = Eio.Path.(fs / path) in
+  let sink =
+    Eio.Path.open_out
+      ~sw
+      ~append:true
+      ~create:(`If_missing 0o644)
+      eio_path
+  in
+  {
+    path;
+    mutex = get_or_create_mutex path;
+    sink;
+    closed = false;
+  }
+
+let append t json =
+  if t.closed then Error (`Io "writer closed")
+  else
+    Eio.Mutex.use_ro t.mutex (fun () ->
+      try
+        let line = Yojson.Safe.to_string json ^ "\n" in
+        Eio.Flow.copy_string line t.sink;
+        Ok ()
+      with
+      | Eio.Io _ as exn -> Error (`Io (Printexc.to_string exn))
+      | exn -> Error (`Io (Printexc.to_string exn)))
+
+let close t =
+  if not t.closed then begin
+    t.closed <- true;
+    (* Eio.Resource.close releases the fd. Idempotent on the resource
+       side too, but we guard with [t.closed] for cheap short-circuit. *)
+    try Eio.Resource.close t.sink with _ -> ()
+  end

--- a/lib/jsonl_atomic/jsonl_atomic.mli
+++ b/lib/jsonl_atomic/jsonl_atomic.mli
@@ -1,0 +1,46 @@
+(** RFC-0107: in-process atomic JSONL append writer.
+
+    A {!t} is an append writer for a single JSONL file. Multiple writers
+    for the same path share a single [Eio.Mutex.t] via a per-path
+    registry, so calls to {!append} from any fiber or domain are
+    serialized against each other.
+
+    Each {!append} call:
+    - Serializes [record + "\n"] into a single string in memory.
+    - Acquires the per-path Eio.Mutex (fiber + domain safe).
+    - Writes the full string to the underlying append-mode sink. Eio's
+      [Flow.copy_string] retries short writes internally, so the entire
+      buffer is delivered before the mutex is released — no other writer
+      can interleave bytes from a different record into the same line,
+      regardless of record size (PIPE_BUF threshold is not relevant
+      because the mutex spans the whole write).
+
+    Cross-process race protection is out of scope (RFC-0107 §6). *)
+
+type t
+(** Opaque handle. *)
+
+val open_writer :
+  sw:Eio.Switch.t ->
+  fs:[> Eio.Fs.dir_ty ] Eio.Resource.t * string ->
+  path:string ->
+  t
+(** [open_writer ~sw ~fs ~path] returns a writer for [path]. The
+    parent directory is created if missing. The underlying fd is owned
+    by [sw] and is closed when [sw] ends (or earlier via {!close}).
+
+    Calling [open_writer] twice for the same [path] returns two
+    distinct handles that share the same per-path mutex — concurrent
+    appends through either handle remain serialized. *)
+
+val append : t -> Yojson.Safe.t -> (unit, [`Io of string]) result
+(** [append t json] appends [json] as a single JSONL line. Returns
+    [Error] on IO failure; never raises for IO. The closure of [t]
+    after a previous {!close} returns [Error (`Io "writer closed")]. *)
+
+val close : t -> unit
+(** Idempotent. Marks the writer closed and releases the fd via the
+    underlying Eio resource. Does not remove the mutex from the
+    registry — a subsequent {!open_writer} for the same path will
+    reuse the existing mutex so any handles still held by other code
+    stay correctly serialized. *)

--- a/lib/jsonl_atomic/jsonl_atomic.mli
+++ b/lib/jsonl_atomic/jsonl_atomic.mli
@@ -26,12 +26,20 @@ val open_writer :
   path:string ->
   t
 (** [open_writer ~sw ~fs ~path] returns a writer for [path]. The
-    parent directory is created if missing. The underlying fd is owned
-    by [sw] and is closed when [sw] ends (or earlier via {!close}).
+    parent directory is created via [Eio.Path.mkdirs] within the
+    provided [fs] root (so scoped filesystem handles work
+    correctly). The underlying fd is owned by [sw] and is closed when
+    [sw] ends (or earlier via {!close}).
 
-    Calling [open_writer] twice for the same [path] returns two
-    distinct handles that share the same per-path mutex — concurrent
-    appends through either handle remain serialized. *)
+    Calling [open_writer] twice for the same effective path returns
+    two distinct handles that share the same per-path mutex —
+    concurrent appends through either handle remain serialized. The
+    mutex key is the canonicalized form of [path] (relative paths
+    are anchored at the process cwd at call time, and ["."] / [".."]
+    segments are resolved), so different spellings of the same file
+    share serialization. Symlink resolution is *not* applied — two
+    paths whose only difference is a symlink hop are treated as
+    distinct. *)
 
 val append : t -> Yojson.Safe.t -> (unit, [`Io of string]) result
 (** [append t json] appends [json] as a single JSONL line. Returns

--- a/test/dune
+++ b/test/dune
@@ -1258,6 +1258,7 @@
 (include stanzas/test_heuristic_metrics_diagnostics.inc)
 (include stanzas/test_heuristic_metrics_scrub.inc)
 (include stanzas/test_join_required_guard_counter.inc)
+(include stanzas/test_jsonl_atomic.inc)
 (include stanzas/test_k2_pipeline_e2e.inc)
 (include stanzas/test_k3_tool_pipeline_e2e.inc)
 (include stanzas/test_keeper_alerting_path_norms.inc)

--- a/test/stanzas/test_jsonl_atomic.inc
+++ b/test/stanzas/test_jsonl_atomic.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_jsonl_atomic)
+ (modules test_jsonl_atomic)
+ (libraries jsonl_atomic alcotest eio eio_main yojson unix))

--- a/test/test_jsonl_atomic.ml
+++ b/test/test_jsonl_atomic.ml
@@ -249,6 +249,47 @@ let test_two_handles_share_mutex () =
       with e -> failf "invalid JSON: %s" (Printexc.to_string e))
     lines
 
+(* ── Scenario 5: path spellings collapse to one mutex (Codex P1 #15906) ── *)
+
+let test_path_spelling_collapse () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let dir = tmpdir "jsonl_atomic_spelling" in
+  (* Same file via two different spellings: with and without a "./"
+     prefix on the leading segment. canonicalize_path should fold
+     them into the same registry key, so the two writers serialize
+     against each other. *)
+  let path_a = Filename.concat dir "out.jsonl" in
+  let path_b = Filename.concat (Filename.concat dir ".") "out.jsonl" in
+  let fs = Eio.Stdenv.fs env in
+  let wa = Jsonl_atomic.open_writer ~sw ~fs ~path:path_a in
+  let wb = Jsonl_atomic.open_writer ~sw ~fs ~path:path_b in
+  let n = 500 in
+  Eio.Fiber.both
+    (fun () ->
+      for i = 0 to n - 1 do
+        match Jsonl_atomic.append wa (`Assoc [("h", `String "a"); ("i", `Int i)]) with
+        | Ok () -> ()
+        | Error (`Io m) -> failwith m
+      done)
+    (fun () ->
+      for i = 0 to n - 1 do
+        match Jsonl_atomic.append wb (`Assoc [("h", `String "b"); ("i", `Int i)]) with
+        | Ok () -> ()
+        | Error (`Io m) -> failwith m
+      done);
+  Jsonl_atomic.close wa;
+  Jsonl_atomic.close wb;
+  let lines = read_lines path_a in
+  check int "both spellings wrote to one file" (2 * n) (List.length lines);
+  (* And every line is valid JSON — if the two spellings had used
+     different mutexes, race-induced corruption would surface here. *)
+  List.iter
+    (fun line ->
+      try ignore (Yojson.Safe.from_string line)
+      with e -> failf "invalid JSON: %s" (Printexc.to_string e))
+    lines
+
 let () =
   Alcotest.run
     "jsonl_atomic"
@@ -259,5 +300,6 @@ let () =
           test_case "PIPE_BUF-exceeding records" `Quick test_large_records;
           test_case "multibyte boundary stress" `Quick test_multibyte_boundary;
           test_case "two handles share mutex" `Quick test_two_handles_share_mutex;
+          test_case "path spellings collapse" `Quick test_path_spelling_collapse;
         ] );
     ]

--- a/test/test_jsonl_atomic.ml
+++ b/test/test_jsonl_atomic.ml
@@ -1,0 +1,263 @@
+(** RFC-0107 tests: in-process atomic JSONL append.
+
+    Three stress scenarios. Each constructs a fresh tmp file, drives a
+    concurrent workload, then re-reads the file and asserts every line
+    is parseable JSON. Any race-induced corruption (the 2026-05-17
+    pre-fix symptoms: `}{` concat or utf-8 byte tear) surfaces as a
+    [Yojson.Safe.from_string] failure. *)
+
+open Alcotest
+
+let counter = ref 0
+
+let tmpdir prefix =
+  incr counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "%s_%d_%d_%.0f"
+         prefix
+         !counter
+         (Unix.getpid ())
+         (Unix.gettimeofday ()))
+  in
+  Unix.mkdir dir 0o755;
+  dir
+
+let read_lines path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let buf = Buffer.create 4096 in
+      (try
+         while true do
+           Buffer.add_channel buf ic 4096
+         done
+       with End_of_file -> ());
+      let content = Buffer.contents buf in
+      String.split_on_char '\n' content
+      |> List.filter (fun s -> s <> ""))
+
+(* ── Scenario 1: 16 fibers × 1000 small records concurrent ────── *)
+
+let test_concurrent_fibers () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let dir = tmpdir "jsonl_atomic_concurrent" in
+  let path = Filename.concat dir "out.jsonl" in
+  let writer =
+    Jsonl_atomic.open_writer ~sw ~fs:(Eio.Stdenv.fs env) ~path
+  in
+  let n_fibers = 16 in
+  let n_records_per_fiber = 1000 in
+  let jobs =
+    List.init n_fibers (fun fid () ->
+      for seq = 0 to n_records_per_fiber - 1 do
+        let json =
+          `Assoc
+            [
+              ("fiber", `Int fid);
+              ("seq", `Int seq);
+              ("payload", `String "hello world");
+            ]
+        in
+        match Jsonl_atomic.append writer json with
+        | Ok () -> ()
+        | Error (`Io msg) -> failwith ("append failed: " ^ msg)
+      done)
+  in
+  Eio.Fiber.all jobs;
+  Jsonl_atomic.close writer;
+  let lines = read_lines path in
+  check
+    int
+    "line count == fibers × records"
+    (n_fibers * n_records_per_fiber)
+    (List.length lines);
+  (* Every line must parse, and we must see every (fiber, seq) exactly once. *)
+  let seen = Hashtbl.create (n_fibers * n_records_per_fiber) in
+  List.iter
+    (fun line ->
+      let json =
+        try Yojson.Safe.from_string line
+        with e ->
+          failf
+            "invalid JSON: %s\nline: %s"
+            (Printexc.to_string e)
+            line
+      in
+      let open Yojson.Safe.Util in
+      let fid = json |> member "fiber" |> to_int in
+      let seq = json |> member "seq" |> to_int in
+      let key = (fid, seq) in
+      if Hashtbl.mem seen key
+      then failf "duplicate record: fiber=%d seq=%d" fid seq;
+      Hashtbl.add seen key ())
+    lines;
+  check
+    int
+    "unique (fiber, seq) pairs"
+    (n_fibers * n_records_per_fiber)
+    (Hashtbl.length seen)
+
+(* ── Scenario 2: PIPE_BUF-exceeding records (4 KB each) ──────── *)
+
+let test_large_records () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let dir = tmpdir "jsonl_atomic_large" in
+  let path = Filename.concat dir "out.jsonl" in
+  let writer =
+    Jsonl_atomic.open_writer ~sw ~fs:(Eio.Stdenv.fs env) ~path
+  in
+  (* Each record's serialized form is ~4 KB — well past macOS PIPE_BUF
+     (512 B) and Linux PIPE_BUF (4 KB). *)
+  let payload = String.make 4000 'A' in
+  let n_fibers = 8 in
+  let n_records_per_fiber = 125 in (* 8 × 125 = 1000 total *)
+  let jobs =
+    List.init n_fibers (fun fid () ->
+      for seq = 0 to n_records_per_fiber - 1 do
+        let json =
+          `Assoc
+            [
+              ("fiber", `Int fid);
+              ("seq", `Int seq);
+              ("payload", `String payload);
+            ]
+        in
+        match Jsonl_atomic.append writer json with
+        | Ok () -> ()
+        | Error (`Io msg) -> failwith ("append failed: " ^ msg)
+      done)
+  in
+  Eio.Fiber.all jobs;
+  Jsonl_atomic.close writer;
+  let lines = read_lines path in
+  check
+    int
+    "all large records present"
+    (n_fibers * n_records_per_fiber)
+    (List.length lines);
+  List.iter
+    (fun line ->
+      let json =
+        try Yojson.Safe.from_string line
+        with e ->
+          failf "invalid JSON (len=%d): %s" (String.length line)
+            (Printexc.to_string e)
+      in
+      let open Yojson.Safe.Util in
+      let p = json |> member "payload" |> to_string in
+      check int "payload length preserved" 4000 (String.length p))
+    lines
+
+(* ── Scenario 3: multi-byte boundary stress (한글 padding) ───── *)
+
+let test_multibyte_boundary () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let dir = tmpdir "jsonl_atomic_multibyte" in
+  let path = Filename.concat dir "out.jsonl" in
+  let writer =
+    Jsonl_atomic.open_writer ~sw ~fs:(Eio.Stdenv.fs env) ~path
+  in
+  (* "가" is 3 bytes in UTF-8 (EA B0 80). Build records whose length
+     sweeps a window across PIPE_BUF boundaries so multibyte sequences
+     are routinely at the edges where a tearing writer would split
+     them. *)
+  let n_fibers = 16 in
+  let n_records_per_fiber = 100 in (* 1600 total *)
+  let make_payload seq =
+    (* Mix of ASCII padding + Korean characters; length varies with seq
+       to hit different byte offsets. *)
+    let kor_count = 100 + (seq mod 300) in
+    let kor = String.concat "" (List.init kor_count (fun _ -> "가")) in
+    let ascii = String.make (seq mod 17) 'x' in
+    ascii ^ kor
+  in
+  let jobs =
+    List.init n_fibers (fun fid () ->
+      for seq = 0 to n_records_per_fiber - 1 do
+        let json =
+          `Assoc
+            [
+              ("fiber", `Int fid);
+              ("seq", `Int seq);
+              ("k", `String (make_payload seq));
+            ]
+        in
+        match Jsonl_atomic.append writer json with
+        | Ok () -> ()
+        | Error (`Io msg) -> failwith ("append failed: " ^ msg)
+      done)
+  in
+  Eio.Fiber.all jobs;
+  Jsonl_atomic.close writer;
+  let lines = read_lines path in
+  check
+    int
+    "all multibyte records present"
+    (n_fibers * n_records_per_fiber)
+    (List.length lines);
+  (* Parse each line — utf-8 tear surfaces as Yojson exception. *)
+  List.iter
+    (fun line ->
+      try ignore (Yojson.Safe.from_string line)
+      with e ->
+        failf
+          "invalid JSON (len=%d): %s\nfirst bytes: %S"
+          (String.length line)
+          (Printexc.to_string e)
+          (if String.length line > 80 then String.sub line 0 80
+           else line))
+    lines
+
+(* ── Bonus: shared mutex across two writer handles ───────────── *)
+
+let test_two_handles_share_mutex () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let dir = tmpdir "jsonl_atomic_two_handles" in
+  let path = Filename.concat dir "out.jsonl" in
+  let fs = Eio.Stdenv.fs env in
+  let w1 = Jsonl_atomic.open_writer ~sw ~fs ~path in
+  let w2 = Jsonl_atomic.open_writer ~sw ~fs ~path in
+  let n = 500 in
+  Eio.Fiber.both
+    (fun () ->
+      for i = 0 to n - 1 do
+        match Jsonl_atomic.append w1 (`Assoc [("h", `Int 1); ("i", `Int i)]) with
+        | Ok () -> ()
+        | Error (`Io m) -> failwith m
+      done)
+    (fun () ->
+      for i = 0 to n - 1 do
+        match Jsonl_atomic.append w2 (`Assoc [("h", `Int 2); ("i", `Int i)]) with
+        | Ok () -> ()
+        | Error (`Io m) -> failwith m
+      done);
+  Jsonl_atomic.close w1;
+  Jsonl_atomic.close w2;
+  let lines = read_lines path in
+  check int "all records from both handles" (2 * n) (List.length lines);
+  List.iter
+    (fun line ->
+      try ignore (Yojson.Safe.from_string line)
+      with e -> failf "invalid JSON: %s" (Printexc.to_string e))
+    lines
+
+let () =
+  Alcotest.run
+    "jsonl_atomic"
+    [
+      ( "atomicity",
+        [
+          test_case "16 fibers × 1000 records" `Quick test_concurrent_fibers;
+          test_case "PIPE_BUF-exceeding records" `Quick test_large_records;
+          test_case "multibyte boundary stress" `Quick test_multibyte_boundary;
+          test_case "two handles share mutex" `Quick test_two_handles_share_mutex;
+        ] );
+    ]


### PR DESCRIPTION
## 목표
RFC-0108 (#15901, renumbered from 0107) §3 의 `Jsonl_atomic` SSOT 모듈을 신설. 4 writer 마이그레이션 PR (system_log / trajectories / dated_jsonl) 의 *prerequisite*. caller 0 이므로 독립 머지 가능.

## 동시성 보장 (in-process)
- **Per-path Eio.Mutex registry (canonicalized key)** — 동일 path 에 대한 두 writer 핸들이 같은 mutex 공유, fiber + 도메인 양쪽 직렬화. `./X` 와 `X` 같은 spelling 차이는 `canonicalize_path` 로 fold (Codex review #15906 P1-2 fix)
- **fs-scoped mkdir** — parent directory 는 `Eio.Path.mkdirs` 로 fs root 안에서 생성 (Codex review #15906 P1-1 fix)
- **Single critical-section write** — `record + "\n"` 직렬화 후 `Eio.Flow.copy_string` 한 번 호출. short-write retry 는 Eio 내부 처리. mutex 가 write 전체를 감싸므로 PIPE_BUF (macOS 512B / Linux 4KB) 초과 record 도 안전
- **Cross-process 는 비목표** (RFC-0108 §6)

## 변경 파일
- `lib/jsonl_atomic/dune` (신규)
- `lib/jsonl_atomic/jsonl_atomic.mli` (신규)
- `lib/jsonl_atomic/jsonl_atomic.ml` (신규)
- `test/stanzas/test_jsonl_atomic.inc` (신규)
- `test/test_jsonl_atomic.ml` (신규)
- `test/dune` (stanza include 1 줄)

## 검증
로컬 worktree 빌드 + 실행 결과 (post P1 fixes):
```
$ dune exec --root . test/test_jsonl_atomic.exe
Testing `jsonl_atomic'.
  [OK]  atomicity  0   16 fibers × 1000 records.
  [OK]  atomicity  1   PIPE_BUF-exceeding records.
  [OK]  atomicity  2   multibyte boundary stress.
  [OK]  atomicity  3   two handles share mutex.
  [OK]  atomicity  4   path spellings collapse.
Test Successful in 6.799s. 5 tests run.
```

5 stress 시나리오:
1. **16 fibers × 1000 records** — 16,000 record 동시 append, line count 정확 + 모든 (fiber, seq) 쌍 unique (race 시 duplicate 또는 deletion 감지)
2. **PIPE_BUF-exceeding** — 4 KB record × 1000, payload 길이 보존 검증
3. **Multibyte boundary** — 한글 record 1,600 개 (길이 다양화로 utf-8 경계 sweep), decode error 0
4. **Two handles share mutex** — 같은 path 에 두 writer 핸들 동시 append, 모든 record 라인 valid
5. **Path spellings collapse** — `./X` 와 `X` 두 spelling 동시 append, 같은 mutex 통해 직렬화 (Codex P1-2 검증)

## 리뷰 대응
2 P1 (chatgpt-codex-connector):
- ✅ mkdir within fs scope — `Eio.Path.mkdirs` 로 교체 (commit `ddd9e5fab5`)
- ✅ Canonicalize mutex key — `canonicalize_path` 신설 + 검증 테스트 추가 (commit `ddd9e5fab5`)
- Thread resolved 둘 다

## RFC
- Body PR: #15901 (RFC-0108 Draft, renumbered from 0107 due to PR #15900 collision)
- 본 PR 은 RFC §4 mig plan 의 **prerequisite** — caller 없이 머지 가능, 후속 PR-3/4/5 가 이 모듈에 의존

## 후속
- PR-3: `lib/masc_log/log.ml` Ring.write_to_sink 마이그레이션 (`}{` concat 직접 차단)
- PR-4: `lib/trajectory/trajectory.ml` 3 함수 마이그레이션
- PR-5: `lib/dated_jsonl/dated_jsonl.ml` 내부 swap (oas-events + reaction-ledger 동시 fix)

## Self-review checklist
- [x] `.mli` 인터페이스 frozen — `open_writer/append/close` 3 함수만 노출
- [x] 인터페이스 docstring 에 동시성 보장 + canonicalization semantics 명시
- [x] 비목표 (cross-process, symlink resolution) 명시
- [x] 단위 테스트 5종 모두 통과
- [x] dune `(flags (:standard -w +4))` 일관 (RFC-0071 §3.4 Phase 5 ratchet)
- [x] caller 0 — 머지 시 기존 코드 동작 변경 없음
- [x] Codex P1 리뷰 2건 대응 완료 + thread resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)