### PR TITLE
feat(server/openai_compat): RFC-0105 typed error boundary mapping

### DIFF
--- a/lib/server/server_openai_compat.mli
+++ b/lib/server/server_openai_compat.mli
@@ -64,8 +64,14 @@ val handle_chat_completions :
     |---|---|---|
     | Missing or empty [model] | `Bad_request` | `invalid_request_error` |
     | No user message in [messages] array | `Bad_request` | `invalid_request_error` |
-    | Keeper / cascade returned [Error] | `Internal_server_error` | `server_error` |
+    | Keeper route returned [Error] | `Internal_server_error` | `server_error` |
+    | Cascade returned [Error err] | per {!Openai_compat_error_map.of_sdk_error} | per same |
     | Body is not valid JSON | `Bad_request` | `invalid_request_error` |
+
+    The cascade row is the RFC-0105 boundary: HTTP status and OpenAI
+    [type]/[code] are derived from the typed {!Agent_sdk.Error.sdk_error}
+    variant rather than a blanket [`Internal_server_error] /
+    [server_error] flattening.
 
     {2 Field defaults}
 


### PR DESCRIPTION
## Summary

**Scope shrunk on rebase**: This PR is now a 7-line docstring update on `lib/server/server_openai_compat.mli` that documents the RFC-0105 boundary contract on the cascade row. The full typed-mapping implementation landed independently in **#15899** (`commit 1809ba3a60`, merged 2026-05-17, 42 leaf variants — superset of this branch's earlier 9-variant draft).

Rebasing `5bf6091794` onto `origin/main` with `-X ours` left only the `.mli` docstring delta. All other paths from the original draft are now identical to `main` (the merged #15899 contents).

### What this PR adds (net diff vs main)

| File | Change |
|---|---|
| `lib/server/server_openai_compat.mli` | +7 / -1: split "Keeper / cascade returned [Error]" into separate rows; add RFC-0105 boundary note pointing at `Openai_compat_error_map.of_sdk_error` |

No code changes. No test changes. No build impact.

### Rebase resolution

- 6 conflicts (3 add/add, 3 content) auto-resolved with `git rebase -X ours origin/main`.
- The 3 add/add files (`openai_compat_error_map.{ml,mli}`, `test_openai_compat_error_map.ml`) kept the `main` (#15899) versions — superset of this branch's 9-variant attempt.
- `test/dune` post-rebase had a duplicate `test_openai_compat_error_map` registration (PR added inline + main added separate line); inline addition manually removed.
- Lease: `force-with-lease=refs/heads/rfc/0105-openai-compat-error-map-impl:5bf6091794b3cc968319c839e15fab39ef4eddf8`.

### Out of scope (deferred follow-ups)

The original draft also proposed `\`Forbidden\`` (HTTP 403) variant + richer message formatting (retry_after, limit interpolation). These are **not** in `main` #15899 and not in this PR's final diff. Open a separate small PR if needed — low priority, not blocking RFC-0105 §5 acceptance.

### Acceptance

- [x] `dune build --root . @check` — docstring only, no behavioral change.
- [x] RFC-0105 §5 already met by #15899 (merged).

### Workaround signature check

| Signature | Match? |
|---|---|
| Counter-as-fix | No |
| String classifier | No |
| N-of-M | No |
| Cap/cooldown/dedup/repair | No |
| Test backdoor | No |

Pure documentation refinement on an existing typed boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
