### PR TITLE
fix(tool-metrics-persist): Prometheus counter for write-queue overflow drops

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -337,6 +337,15 @@ let install_backend_mutex_observers () =
    Cardinality: ~50 × ~10 × 2 = ~1000 series, safe for Prometheus. *)
 let metric_tool_join_required_guard = "masc_tool_join_required_guard_total"
 
+(* tool_metrics_persist write queue overflow.
+   Counts JSONL records dropped because the bounded write queue is full.
+   No labels (single source). Existing in-memory [dropped_full_queue]
+   Atomic counter is summarised by sampled WARN (every 1024th drop);
+   this Prometheus counter exposes per-drop emission so alerting on
+   sustained pressure does not depend on log scraping. *)
+let metric_tool_metrics_persist_dropped =
+  "masc_tool_metrics_persist_dropped_total"
+
 (* #9771: keeper turn-slot semaphore wait timeout counter.
 
    Production observed multiple keepers ([sangsu], [janitor],
@@ -1297,6 +1306,11 @@ let init () =
     metric_tool_join_required_guard
     "Total join-required guard rejections before tool execution (labels: tool, \
      agent_name, reason=room_uninitialized|agent_not_joined)"
+    Counter;
+  add
+    metric_tool_metrics_persist_dropped
+    "Total JSONL records dropped by tool_metrics_persist because the bounded \
+     write queue is full. No labels."
     Counter;
   add
     Keeper_metrics.metric_keeper_turn_queue_depth

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -167,6 +167,9 @@ val metric_backend_mutex_held_sec : string
     [room_uninitialized | agent_not_joined]. *)
 val metric_tool_join_required_guard : string
 
+(** Counter for [tool_metrics_persist] write-queue overflow drops. No labels. *)
+val metric_tool_metrics_persist_dropped : string
+
 (** #9771: counter for keeper turn-slot semaphore wait timeouts.
     Labels: [keeper, channel] with channel in
     [autonomous_queue_head | autonomous | turn]. *)

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -123,12 +123,15 @@ let enqueue (result : Tool_result.t) =
         false))
   in
   if dropped_for_full_queue
-  then
+  then begin
+    Prometheus.inc_counter
+      Prometheus.metric_tool_metrics_persist_dropped ();
     let dropped = Atomic.fetch_and_add dropped_full_queue 1 + 1 in
     if dropped = 1 || dropped mod 1024 = 0 then
       Log.Metrics.warn
         "tool_metrics_persist: dropped %d record(s) because write queue is full"
         dropped
+  end
 
 (* ── Flush logic ────────────────────────────────────── *)
 


### PR DESCRIPTION
## Problem

`lib/tool_metrics_persist.ml:117-131` (`persist`) records JSONL to a bounded in-memory write queue (`write_queue_capacity = 4096`, line 72). When the queue is full, the record is dropped and an in-memory `Atomic.t` (`dropped_full_queue`, line 75) is incremented. A WARN is emitted only on the 1st drop and every 1024th drop afterwards (line 128).

**Silent path**: between threshold WARN events, drop pressure is invisible to metrics consumers. Operators alerting on sustained queue overflow must scrape logs — Prometheus shows zero signal.

## Fix

Add `Prometheus.metric_tool_metrics_persist_dropped` (counter, no labels — single source). Increment at every drop, in the same branch as the in-memory atomic counter. Existing log suppression (1, 1024, 2048, ...) preserved.

```diff
   if dropped_for_full_queue
-  then
+  then begin
+    Prometheus.inc_counter
+      Prometheus.metric_tool_metrics_persist_dropped ();
     let dropped = Atomic.fetch_and_add dropped_full_queue 1 + 1 in
     if dropped = 1 || dropped mod 1024 = 0 then
       Log.Metrics.warn
         "tool_metrics_persist: dropped %d record(s) because write queue is full"
         dropped
+  end
```

Plus metric definition in `lib/prometheus.{ml,mli}` + registration in `init ()`.

## Behaviour

Preserved. Drop policy itself is unchanged — the bounded queue is a deliberate backpressure boundary (durable tool-call logs remain the SoT, per the existing comment at line 115-116). Only adds *visibility* of the boundary's hit rate.

## Build

`dune build @check` PASS.

## Anti-pattern self-check (7/7)

- [x] Not telemetry-as-fix-in-the-rejection-sense — the *silent drop* is a deliberate boundary; the gap is *visibility* of the boundary's hit rate. The PR does not propose visibility as a substitute for closing the boundary
- [x] No string classifier — no labels
- [x] Not N-of-M — single drop site in this module
- [x] No new catch-all
- [x] No magic number / test backdoor / N-times-typo fix

## Source

Candidate surfaced by repo-wide silent-path Explore sweep on 2026-05-17.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>