### PR TITLE
fix(keeper): repair workload stampede compile

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -551,6 +551,7 @@ let bash_shape_block_result ~cmd ~cmd_for_log ~env_snapshot block =
                 (match block with
                  | Gh_pr_checks -> Some "keeper_pr_status"
                  | Pipe_or_redirect -> Some "keeper_shell"
+                 | Repo_wide_scan -> Some "keeper_shell"
                  | Chaining | Substitution -> None);
             })
        ~extra:

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -1454,7 +1454,7 @@ let _maybe_evict_snapshot () =
             64-keeper load, replacing a [Computing] slot starts duplicate
             dashboard snapshots while the old one is still doing filesystem
             work.  Temporary cache growth is cheaper than a compute stampede. *)
-         ignore !any_key)
+         ignore !any_key))
 ;;
 
 let invalidate_snapshot_cache () =


### PR DESCRIPTION
## Summary
- close the snapshot cache eviction branch introduced in #15892 so operator_control_snapshot.ml parses
- include the new Repo_wide_scan bash-shape variant in the diagnostic tool suggestion match

## Validation
- ocamlformat --check lib/operator/operator_control_snapshot.ml lib/keeper/keeper_shell_bash.ml
- git diff --check HEAD~1..HEAD

Focused Dune build caught the syntax error and then a warning-as-error partial match before this follow-up. A final focused build is currently blocked by other long-running dune-local holders under /tmp/me-dune-local.lock; PR CI should validate the follow-up.