### PR TITLE
fix(board-dispatch): Prometheus counter for flusher actor startup outcomes

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -206,6 +206,10 @@ let ensure_flusher_actor store =
                 in
                 match exn with
                 | Invalid_argument msg when String.equal msg "Switch finished!" ->
+                    Prometheus.inc_counter
+                      Prometheus.metric_board_dispatch_flusher_start_outcomes
+                      ~labels:[ ("outcome", "switch_finished") ]
+                      ();
                     Log.BoardLog.warn
                       "Skipping board flusher actor startup on finished switch"
                 | _ -> raise exn
@@ -214,9 +218,14 @@ let ensure_flusher_actor store =
               sleep_flusher_start_backoff
                 ~attempt:(flusher_start_cas_retries - attempts_left);
               loop (attempts_left - 1)
-            end else
+            end else begin
+              Prometheus.inc_counter
+                Prometheus.metric_board_dispatch_flusher_start_outcomes
+                ~labels:[ ("outcome", "cas_exhausted") ]
+                ();
               Log.BoardLog.warn
                 "Board flusher actor startup CAS contention exhausted; retrying on next backend access"
+            end
       in
       loop flusher_start_cas_retries
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -799,6 +799,20 @@ let metric_anti_rationalization_excuse_pattern =
 ;;
 
 let metric_board_truncated_posts = "masc_board_truncated_posts_total"
+
+(* Board flusher actor startup outcome.
+   Closed-vocab label [outcome]:
+     [switch_finished] — start_flusher_actor raised
+       Invalid_argument "Switch finished!"; the warn at the swallow
+       site has no Prometheus signal otherwise.
+     [cas_exhausted] — flusher_start_cas_retries exhausted under
+       contention; current state stays Active(_, false), next backend
+       access retries.
+   Cardinality: 2 series.  No success label — a non-event would imply
+   either steady-state idle or in-flight start, neither of which is a
+   useful counter increment. *)
+let metric_board_dispatch_flusher_start_outcomes =
+  "masc_board_dispatch_flusher_start_outcomes_total"
 let metric_cascade_strategy_decisions = "masc_cascade_strategy_decisions_total"
 let metric_cascade_capacity_events = "masc_cascade_capacity_events_total"
 
@@ -2287,6 +2301,13 @@ let init () =
   add
     metric_board_truncated_posts
     "Total board posts truncated due to size limits"
+    Counter;
+  add
+    metric_board_dispatch_flusher_start_outcomes
+    "Total board flusher actor startup non-success outcomes (label \
+     outcome=switch_finished|cas_exhausted). switch_finished = \
+     start_flusher_actor raised Invalid_argument \"Switch finished!\"; \
+     cas_exhausted = backend_state CAS retries depleted under contention."
     Counter;
   add
     Keeper_metrics.metric_keeper_quantitative_claim_rejections

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -511,6 +511,11 @@ val metric_fallback_triggered : string
     fallback classes. *)
 val metric_board_truncated_posts : string
 
+(** Counter for board flusher actor startup non-success outcomes.
+    Closed-vocab label [outcome]: [switch_finished | cas_exhausted].
+    Cardinality: 2 series. *)
+val metric_board_dispatch_flusher_start_outcomes : string
+
 val metric_anti_rationalization_fallback : string
 
 (** #10113: per-pattern + per-decision counter for the gate 2


### PR DESCRIPTION
## Problem

`ensure_flusher_actor` in `lib/board_dispatch.ml` has two non-success paths that emit only WARN — no Prometheus signal:

1. `start_flusher_actor` raises `Invalid_argument "Switch finished!"` → WARN at line 209-210
2. `flusher_start_cas_retries` exhausted under contention → WARN at line 218-219

Operators relying on metrics see no signal for either case. The two outcomes have different operational meanings (switch teardown race vs CAS contention bound) that should be distinguishable in dashboards / alerts.

## Fix

Adds `Prometheus.metric_board_dispatch_flusher_start_outcomes` with closed-vocab label `outcome ∈ {switch_finished, cas_exhausted}`. Cardinality 2 series. Emitted at the two WARN sites only — success path (`Active(_,false) → Active(_,true)`) is implicit in the state transition and does not need a counter.

```diff
                 match exn with
                 | Invalid_argument msg when String.equal msg "Switch finished!" ->
+                    Prometheus.inc_counter
+                      Prometheus.metric_board_dispatch_flusher_start_outcomes
+                      ~labels:[ ("outcome", "switch_finished") ] ();
                     Log.BoardLog.warn ...
                 | _ -> raise exn
             else if attempts_left > 0 then begin
               ...
-            end else
+            end else begin
+              Prometheus.inc_counter
+                Prometheus.metric_board_dispatch_flusher_start_outcomes
+                ~labels:[ ("outcome", "cas_exhausted") ] ();
               Log.BoardLog.warn ...
+            end
```

## Behaviour

Preserved. WARN log policy unchanged. Cancelled re-raise discipline preserved (already routed via `| _ -> raise exn` for non-`Invalid_argument`).

## Build

`dune build @check` PASS.

## Anti-pattern self-check (7/7)

- [x] Not telemetry-as-fix in the rejection sense — each outcome represents a real operational state; the counter is not used to paper over a different root cause
- [x] Not a string classifier — 2-value closed vocab
- [x] Not N-of-M — 2 emit sites in the same function, both covered
- [x] No new catch-all
- [x] No magic number / test backdoor / N-times-typo fix

## Source

Silent-path Explore sweep 2026-05-17 (Candidate 2 of 3, verified against current main).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>