### PR TITLE
docs(rfc): RFC-0107 Phase C.0 — Eio_context switch audit + TLA+ spec

### DIFF
--- a/docs/rfc/RFC-0107-eio-context-switch-audit.md
+++ b/docs/rfc/RFC-0107-eio-context-switch-audit.md
@@ -1,0 +1,200 @@
+---
+rfc: "0107"
+phase: C.0
+status: Evidence
+created: 2026-05-17
+supplement_of: RFC-0107
+---
+
+# RFC-0107 Phase C.0 — `Eio_context.get_switch_opt` global access audit
+
+> 본 문서는 RFC-0107 §3.3 (L3 Switch hierarchy) 의 *real complexity* 를 기록하기 위한 evidence supplement 다. 본문(`RFC-0107-outbound-http-stack-consolidation.md`) §3.3 작성 시 "run_turn 내부 fresh `Eio.Switch.run`" 한 줄로 처리됐으나, callsite inventory 결과 그 wrap *단독* 으로는 효과가 없음이 드러났다. wiring 결정은 Phase C.1 으로 분리하며 사용자 결정을 대기한다.
+
+## 1. 발견 요약
+
+- `lib/eio_context/eio_context.ml:84` `get_switch_opt ()` 가 `Atomic.t` 에 저장된 *전역 root switch* 를 반환.
+- callsite 26 개 (lib/ + bin/), 9 모듈에 분산. 모두 이 atomic 을 통해 switch 에 fiber/resource 를 attach.
+- 결과: `run_turn` body 를 `Eio.Switch.run` 으로 감싸도 *body 내부 호출 경로* 가 `get_switch_opt ()` 를 거치면 root switch 로 우회. **naïve wrap 무효**.
+
+## 2. Callsite inventory (26)
+
+`rg "Eio_context\.get_switch" lib/ bin/` 직접 측정 (2026-05-17).
+
+### 2.1 Server/dashboard 계열 — *root-lifetime intent*
+
+| 파일 | 라인 | 의도 |
+|---|---|---|
+| `lib/server/server_dashboard_http_runtime_info.ml` | 194 | runtime info 응답 시 background fetch 를 root_sw 에 fork |
+| `lib/server/server_dashboard_http_core.ml` | 1357 | dashboard HTTP route handler 가 child fiber 를 root_sw 에 attach |
+| `lib/server/server_routes_http_common.ml` | 88, 89 | route 공용 sw fallback |
+| `lib/server/server_dashboard_http_namespace_truth_support.ml` | 31 | namespace truth fetch — Some/None 분기만 |
+| `lib/dashboard/dashboard_mission_briefing.ml` | 269 | mission briefing background refresh |
+| `lib/dashboard/dashboard_cache.ml` | 314 | stale-while-revalidate fork (`.mli:14` 가 명시) |
+| `lib/board_dispatch.ml` | 184 | board task fork |
+| `lib/relation_materializer.ml` | 49 | relation materialization fork |
+
+총 **9 callsite**. 이들은 *root_sw 가 server 전체 lifetime 을 가짐* 을 전제로 fork. 만약 `current_sw` 가 turn_sw 로 swap 된 시점에 이 코드들이 동시 실행되면, 그들의 fiber 가 turn_sw 에 attach → turn 종료 시 *premature termination*.
+
+### 2.2 Cascade/keeper turn-scoped — *turn-lifetime intent*
+
+| 파일 | 라인 | 의도 |
+|---|---|---|
+| `lib/cascade/cascade_oas_runner.ml` | 23 | OAS runner sw fallback |
+| `lib/cascade/cascade_runtime.ml` | 177 | cascade fiber attachment |
+| `lib/cascade/cascade_catalog_runtime.ml` | 619 | catalog runtime fork |
+| `lib/keeper/keeper_run_tools.ml` | 781 | tool execution sw |
+| `lib/keeper/keeper_turn_liveness.ml` | 74 | liveness ping fork (turn 중에만 의미) |
+| `lib/keeper/keeper_exec_voice.ml` | 25 | voice exec |
+| `lib/keeper/keeper_unified_turn.ml` | 622 | event_bus subscription |
+| `lib/keeper/keeper_tag_dispatch.ml` | 14, 140, 160 | tool task dispatch — `Tool_task.config.sw` 에 직접 박힘 |
+| `lib/keeper/keeper_keepalive.ml` | 369 | grpc env keepalive |
+| `lib/keeper/keeper_exec_task.ml` | 345, 465, 499 | exec task sw |
+| `lib/keeper/keeper_memory_llm_summary.ml` | 216 | memory summary LLM fetch |
+
+총 **16 callsite**. 이들은 *turn 단위로 자르고 싶은* 작업이지만 *현재는 root_sw 에 매달림* (Phase C 문제 진앙). wrap 이 도입되고 위 §2.1 의 server 계열과 분리되면 이들은 자연스럽게 turn_sw 로 흡수됨.
+
+### 2.3 기타
+
+| 파일 | 라인 | 의도 |
+|---|---|---|
+| `lib/autoresearch_codegen.ml` | 117 | code generation fork — net+sw 동시 필요 |
+
+총 **1 callsite**.
+
+**합계**: 26 callsite, 9:16:1 = server : keeper-turn : misc.
+
+## 3. 기존 mechanism 재발견 — `with_test_env`
+
+`eio_context.ml:63-76` 에 이미 snapshot/restore 패턴 존재:
+
+```ocaml
+let with_test_env ~net ~clock ~mono_clock ~sw f =
+  Eio.Mutex.use_ro with_test_env_lock (fun () ->
+    let snapshot = snapshot_state () in
+    set_net net; set_clock clock; set_mono_clock mono_clock; set_switch sw;
+    Fun.protect ~finally:(fun () -> restore_state snapshot) f)
+```
+
+- 의도: 테스트 격리. 한 번에 4-field 전부 swap, `with_test_env_lock` 으로 swap-restore 윈도우 직렬화.
+- **race 한계**: swap 자체는 lock 안에서 직렬화되지만, lock *내부* 에서 `f` 가 실행되는 동안 *다른 fiber* 가 `get_switch_opt ()` 호출 시 swap 된 값을 봄. 단일 도메인 cooperative scheduling 에서도 fiber yield 가 일어나면 동시 가시성 발생.
+- 테스트는 보통 단일 fiber + 동기 실행이라 안전. 프로덕션 `run_turn` 같이 *동시 dashboard fiber 와 같이 도는 환경* 에서는 §2.1 의 9 callsite 가 turn_sw 를 잘못 잡음.
+
+## 4. 옵션 비교
+
+### Option (1) — Naïve wrap (skip)
+
+```ocaml
+let run_turn ... =
+  Eio.Switch.run @@ fun turn_sw ->
+    <body>
+```
+
+`<body>` 내부 fiber 가 `Eio_context.get_switch_opt ()` 호출 시 여전히 root_sw 반환 → **wrap 무효**. 거부.
+
+### Option (2) — `Eio_context.with_sw` (atomic swap, dynamic scope)
+
+```ocaml
+let with_sw sw f =
+  Eio.Mutex.use_ro with_test_env_lock (fun () ->
+    let prev = Atomic.get current_sw in
+    Atomic.set current_sw (Some sw);
+    Fun.protect ~finally:(fun () -> Atomic.set current_sw prev) f)
+
+(* run_turn *)
+Eio.Switch.run @@ fun turn_sw ->
+  Eio_context.with_sw turn_sw (fun () -> <body>)
+```
+
+- **장점**: 기반 mechanism 이 이미 (`with_test_env`) 있으므로 4-field 중 sw 만 분리해 노출하면 됨. ~50 LoC.
+- **race 위험**: §2.1 의 9 server/dashboard callsite 가 swap 윈도우 안에서 fork → premature termination. 단일 도메인이라도 fiber yield 가 일어나는 모든 await 지점에서 발생.
+- **mitigation**: §2.1 callsite 들을 *명시적 root_sw 보관 reference* 로 분리 (e.g., `Eio_context.root_sw_ref : Eio.Switch.t option ref`, 서버 시작 시 1회 set, swap 영향 없음). 추가 ~30 LoC + 9 callsite refactor.
+- **본질적 한계**: dynamic scope + global state. *원리적으로* 어디서 swap 발생 가능한지 caller 가 알 수 없어 디버깅 비용↑. 그러나 *현실적* 으로는 동작 가능.
+
+### Option (3) — Fiber-local storage (Eio.Fiber)
+
+Eio 0.x 기준 `Eio.Fiber.with_binding : 'a key -> 'a -> (unit -> 'b) -> 'b` 가 존재 (확인 필요, Phase C.1 에서 source 정독).
+
+```ocaml
+let sw_key : Eio.Switch.t Eio.Fiber.key = Eio.Fiber.create_key ()
+
+let get_switch_opt () =
+  match Eio.Fiber.get sw_key with
+  | Some sw -> Some sw
+  | None -> Atomic.get current_sw  (* fallback to root *)
+
+(* run_turn *)
+Eio.Switch.run @@ fun turn_sw ->
+  Eio.Fiber.with_binding sw_key turn_sw (fun () -> <body>)
+```
+
+- **장점**: race-free by construction. fiber 가 자기 binding 만 봄. dashboard fiber 가 root_sw 에 살아 있는 한 자기 binding (없으면 fallback) 으로 root_sw 만 봄.
+- **단점**: Eio.Fiber API 가 binding 을 지원하는지 (Eio 1.x) Phase C.1 확인 필요. 우리 cohttp-eio 6.1.1 + eio 0.x stack 에서 호환성 검증 필수.
+- **추가 비용**: 26 callsite 그대로 유지 (`get_switch_opt` 내부 구현만 변경). ~80 LoC + Eio 버전 확인.
+
+### Option (4) — 명시적 `~sw` propagation
+
+26 callsite 의 caller chain 을 따라 `~sw:Eio.Switch.t` 인자를 propagate. 각 함수 signature 변경.
+
+- **장점**: Eio 권고 best practice. 컴파일러가 누락 추적. anti-pattern (전역 atomic) 박멸.
+- **단점**: signature 변경 transitive closure 가 *수십~수백* 함수. 1-2주 작업. 별도 RFC.
+
+### Option (5) — Phase C 를 2 PR 로 분할 (★ 권장 ★)
+
+**Phase C.0 (이번 PR, ~반일)**: 본 audit note + TLA+ spec + RFC §3.3 amend. wiring 없음.
+
+**Phase C.1 (별도 PR, 결정 후)**: Option (2)/(3)/(4) 중 하나로 wiring.
+
+## 5. 추가 race 시나리오 (Option (2) 채택 시)
+
+T0: server 시작, root_sw set.
+T1: dashboard fiber A 가 dashboard_cache.ml:314 의 stale-while-revalidate fork 시작. `get_switch_opt()` 호출 — root_sw.
+T2: keeper fiber B 가 run_turn 시작, `with_sw turn_sw` 진입. `current_sw := turn_sw`.
+T3: dashboard fiber A 가 *T2 이후* 두 번째 child fork (예: nested SWR refresh). `get_switch_opt()` 호출 — **turn_sw** ← 버그.
+T4: run_turn 종료, `current_sw := root_sw`, `Eio.Switch.run` 종료, turn_sw close.
+T5: T3 에서 fork 된 child fiber 가 turn_sw 에 attach 된 채 살아남음 → `Cancelled` 또는 FD leak.
+
+이 시나리오는 §2.1 의 9 callsite 모두에 적용됨. 즉 *Option (2) 단독* 으로 wrap 도입하면 *새 종류의 버그* 가 생김. **Option (2) 채택 시 §2.1 callsite 9 개 root_sw_ref 분리 필수**.
+
+## 6. 권장 wiring 결정 (Phase C.1, 사용자 결정 대기)
+
+| | Option (2) atomic swap | Option (3) fiber-local | Option (4) explicit |
+|---|---|---|---|
+| 작업량 | 1-2일 (+ §2.1 refactor) | ~1일 (단 Eio.Fiber API 확인) | 1-2주 |
+| race-free | △ (mitigation 필요) | ✓ | ✓ |
+| 디버깅 cost | 중 | 저 | 저 |
+| Eio 권고 부합 | △ | ◯ | ◎ |
+| 후속 cleanup | §2.1 callsite 9개 refactor | 26 callsite 유지 가능 | 26 callsite 전부 변경 |
+| Phase D pool 도입과 충돌 | 없음 | 없음 | RFC-0107 critical path 와 동시 신규 surface |
+
+**Phase C.1 권장 순서**:
+1. **먼저 Option (3) 의 Eio.Fiber API 가용성 확인** (Eio 0.x vs 1.x). 가용하면 (3) 1순위.
+2. (3) 불가능 시 **Option (2) + §2.1 root_sw_ref 분리** 채택. 디버깅 부담은 audit note 로 documented.
+3. (4) 는 별도 long-term RFC 로 분리. RFC-0107 critical path (Phase D pool) 와 무관.
+
+## 7. Phase C.0 산출물
+
+본 PR 에 포함:
+1. `docs/rfc/RFC-0107-eio-context-switch-audit.md` (본 문서)
+2. `specs/keeper-switch-hierarchy/KeeperSwitchHierarchy.tla` + `.cfg` + `-buggy.cfg`
+3. `docs/rfc/RFC-0107-outbound-http-stack-consolidation.md` §3.3 amend (참조 추가)
+
+본 PR 에 *포함하지 않음*:
+- `keeper_agent_run.ml:196` 의 실제 wrap (Phase C.1)
+- `Eio_context.with_sw` 또는 fiber-local key 신규 API (Phase C.1)
+- 26 callsite refactor (Phase C.1 또는 별도 RFC)
+
+## 8. 기존 패턴 — `try_provider.ml:406`
+
+`lib/keeper/keeper_turn_driver_try_provider.ml:406` 의 `Eio.Switch.run (fun attempt_sw -> ...)` cascade attempt 패턴은 *작동 중*. 그 이유:
+
+- `attempt_sw` 가 *명시적 인자* 로 try_provider 내부 함수 chain 에 전달됨 (Option (4) 의 작은 사례).
+- 즉 **`get_switch_opt ()` 를 거치지 않음**.
+- run_turn 레벨에서 동일 패턴을 흉내내려면 *run_turn body 내부 모든 함수* 가 `~sw` 받아야 함 → Option (4) 의 scope.
+
+이 사실이 Option (3) (fiber-local) 의 매력을 높임 — 26 callsite 안 건드리고 attempt_sw 처럼 *암묵적 propagation* 만 추가.
+
+## 9. 결론
+
+- Phase C 의 "반일 작업" 가정은 *frame error*. 실제는 *전역 atomic vs fiber-local 결정* 이 핵심.
+- 본 Phase C.0 는 evidence + TLA+ spec 만 commit. wrap 실제 도입은 Phase C.1 에서 Option 결정 후.
+- **PR description 에 본 audit 첫 절 인용 + Option 결정 escalate 명시**.

--- a/docs/rfc/RFC-0107-outbound-http-stack-consolidation.md
+++ b/docs/rfc/RFC-0107-outbound-http-stack-consolidation.md
@@ -107,21 +107,34 @@ Contract:
 
 ### 3.3 L3 Switch hierarchy — `run_turn` fresh switch
 
+> **Phase C 복잡도 정정 (2026-05-17)**: 본 절은 초기에 "run_turn 본문을 `Eio.Switch.run` 으로 감싸기 — ~반일" 로 추정됐다. Phase C.0 audit 결과 (`RFC-0107-eio-context-switch-audit.md`) `lib/eio_context/eio_context.ml:84` `get_switch_opt ()` 가 **전역 atomic** 으로 root switch 를 반환하고, **26 callsite** (server/dashboard 9 + keeper-turn 16 + misc 1) 가 이걸 거치므로 naïve wrap 단독으로는 효과가 없음이 드러났다. 실제 wiring 은 별도 Phase C.1 PR 로 분리한다.
+
+**의도된 lifecycle**:
+
 ```ocaml
-(* lib/keeper/keeper_agent_run.ml:196 (Phase C) *)
+(* lib/keeper/keeper_agent_run.ml:196 — Phase C.1 (wiring) *)
 
 let run_turn ... =
   Eio.Switch.run @@ fun turn_sw ->
   (* turn 본체. retry 시 fresh sub-switch 는 try_provider:406 이 이미 보장.
-     turn_sw 는 turn 의 모든 FD 의 절대 상한 lifetime 으로 동작. *)
+     turn_sw 는 turn 의 모든 FD 의 절대 상한 lifetime 으로 동작.
+
+     주의: 단순 wrap 만으로는 부족하다. body 내부 호출이
+     Eio_context.get_switch_opt () 를 거치는 경우 root_sw 로 우회된다.
+     audit §4 의 Option (2)/(3)/(4) 중 결정 필요. *)
   ...
 ```
 
-Invariant (Phase C TLA+ spec):
+**Invariant (Phase C TLA+ spec — `specs/keeper-switch-hierarchy/`)**:
 - For any FD `f` opened during `run_turn`, `f ∈ turn_sw.resources` at any timepoint
 - After `run_turn` returns, `turn_sw.alive = false` ∧ `∀ f. f ∉ turn_sw.resources`
+- **추가 invariant**: `∀ r. r.role = server ⇒ r.attached = root_sw` — server/dashboard fiber 가 fork 한 자원은 *반드시* root_sw 에 attach. 이 invariant 가 buggy.cfg 에서 깨지는 race scenario 가 `ServerForkDuringTurn` (audit §5).
 
 `try_provider:406` 의 attempt switch 는 turn switch 의 *자식* 으로 nested — Eio Switch 가 부모-자식 lifecycle 을 정상 지원하므로 변경 불필요. 주석만 강화.
+
+**Phase C 분할**:
+- **Phase C.0** (본 RFC 와 함께 머지): audit doc + TLA+ spec (clean+buggy). wiring 없음.
+- **Phase C.1** (audit §6 결정 후): Option (2) atomic swap + §2.1 root_sw_ref 분리 *OR* Option (3) fiber-local *OR* Option (4) 명시적 ~sw propagation. critical path 가 아니므로 Phase D pool 머지를 차단하지 않는다.
 
 ### 3.4 L4 Sandbox transport — Docker HTTP API via UDS
 
@@ -146,7 +159,8 @@ sandbox_exec
 | A.0 | Prior Art deep-read | yes (prereq) |
 | A | RFC Draft + push | yes |
 | B | HTTP transport spike + 결정 | yes |
-| C | `run_turn` fresh Switch (TLA+ 포함) | yes (B 와 병행) |
+| C.0 | Audit + TLA+ spec (wiring 없음) | yes (본 RFC 와 함께) |
+| C.1 | run_turn wrap + Option (2/3/4) 결정 wiring | follow-up (critical path 아님) |
 | D | L2 Pool 도입 — user-visible ENFILE 종결 | yes |
 | E | Docker UDS + RFC-0097 활성화 | yes |
 | F | Fd_accountant retirement (30일 production soak 후) | no (long tail) |

--- a/specs/keeper-switch-hierarchy/KeeperSwitchHierarchy-buggy.cfg
+++ b/specs/keeper-switch-hierarchy/KeeperSwitchHierarchy-buggy.cfg
@@ -1,0 +1,36 @@
+\* Buggy model for KeeperSwitchHierarchy — models the Option (2) race scenario
+\* without §2.1 root_sw_ref mitigation.
+\* Expected: Invariant SafetyInvariant is violated.
+\*
+\* ServerForkDuringTurn is enabled (via NextBuggy). It models a SERVER fiber
+\* (dashboard, board_dispatch, etc — see audit §2.1) that reads
+\* Eio_context.get_switch_opt () WHILE keeper.run_turn is inside its with_sw
+\* turn_sw swap. The server child is attached to turn_sw → on KeeperEndTurn
+\* it is forcibly released (Eio.Switch closes resources) → premature
+\* termination of a fiber that should have lived for the server's whole
+\* lifetime.
+\*
+\* Concrete violation modes the model catches:
+\*   1. ServerResourcesOnRoot — server resource has attached = "turn_sw"
+\*      immediately after ServerForkDuringTurn fires.
+\*   2. (Cascade) NoLiveResourceOnClosedSwitch — once KeeperEndTurn fires,
+\*      that server resource is forcibly released but the FAIL is already
+\*      logged at step 1 in this model.
+\*
+\* Once Option (3) fiber-local OR §2.1 root_sw_ref mitigation is wired
+\* (Phase C.1), the ServerForkDuringTurn race becomes impossible because
+\* server fibers read their own binding / a dedicated atomic rather than
+\* the swapped current_sw. This cfg should fail until that wiring lands;
+\* keep as a regression sentinel afterwards.
+
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    MaxTurns = 2
+    MaxResources = 2
+
+INVARIANTS
+    SafetyInvariant
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/keeper-switch-hierarchy/KeeperSwitchHierarchy.cfg
+++ b/specs/keeper-switch-hierarchy/KeeperSwitchHierarchy.cfg
@@ -1,0 +1,24 @@
+\* Clean model for KeeperSwitchHierarchy.
+\* Expected: Model checking completed. No error has been found.
+\*
+\* Verifies under the CLEAN Next (no ServerForkDuringTurn race):
+\*   - TypeOK
+\*   - SafetyInvariant
+\*       \* ServerResourcesOnRoot (server forks happen only when turn idle,
+\*          so they read current_sw = root_sw)
+\*       \* NoLiveResourceOnClosedSwitch (keeper resources are auto-released
+\*          on KeeperEndTurn; server resources stay on root which is always
+\*          alive in this model)
+
+SPECIFICATION Spec
+
+CONSTANTS
+    MaxTurns = 2
+    MaxResources = 2
+
+INVARIANTS
+    TypeOK
+    SafetyInvariant
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/keeper-switch-hierarchy/KeeperSwitchHierarchy.tla
+++ b/specs/keeper-switch-hierarchy/KeeperSwitchHierarchy.tla
@@ -1,0 +1,196 @@
+---- MODULE KeeperSwitchHierarchy ----
+\* RFC-0107 Phase C.0 — Eio.Switch hierarchy model for keeper run_turn.
+\*
+\* Models the global Eio context (Eio_context.current_sw : Atomic.t) and
+\* the proposed Option (2) "with_sw" atomic-swap wrap for run_turn body.
+\*
+\* Runtime truth being modelled:
+\*   - On server startup, root_sw is set; current_sw := root_sw.
+\*   - Two fiber roles run concurrently:
+\*       * SERVER fibers (dashboard, board_dispatch, relation_materializer,
+\*         autoresearch_codegen) — fork child work that MUST attach to root_sw
+\*         (they outlive any single turn).
+\*       * KEEPER fibers — execute run_turn. Inside run_turn, with_sw swaps
+\*         current_sw := turn_sw, and resources created by keeper should
+\*         attach to turn_sw (so they die when the turn ends).
+\*   - Both roles read the *same global atomic* via get_switch_opt ().
+\*
+\* What this spec is FOR:
+\*   - Invariant ServerResourcesOnRoot: every resource created by a SERVER
+\*     fiber attaches to root_sw — never to turn_sw.
+\*   - Invariant KeeperResourcesScoped: keeper resources created inside a
+\*     turn attach to turn_sw, and after turn end either (a) the resource
+\*     is released, or (b) the switch they attach to remains alive (impossible
+\*     when turn_sw is closed → forces release).
+\*
+\* The *BUGGY* configuration (KeeperSwitchHierarchy-buggy.cfg) enables a
+\* ServerForkDuringTurn action that lets a SERVER fiber read current_sw
+\* *while it equals turn_sw*. The server resource then attaches to turn_sw
+\* and survives past turn end → ServerResourcesOnRoot violated. This is the
+\* concrete race that motivates Option (3) fiber-local or §2.1 root_sw_ref
+\* mitigation (see RFC-0107-eio-context-switch-audit.md §5).
+\*
+\* This is the TLA+ Bug Model pattern (software-development.md §"TLA+ Bug
+\* Model 패턴"): clean cfg must pass with no error; buggy cfg must violate
+\* the invariant in a small number of steps.
+
+EXTENDS Naturals, FiniteSets, TLC
+
+CONSTANTS
+    MaxTurns,        \* Upper bound on turns simulated.
+    MaxResources     \* Upper bound on resources created per role per turn.
+
+ASSUME MaxTurnsPos     == MaxTurns \in Nat /\ MaxTurns >= 1
+ASSUME MaxResourcesPos == MaxResources \in Nat /\ MaxResources >= 1
+
+(* ── Switch identity & state ───────────────────────────────────────── *)
+
+SwitchIds == {"root_sw", "turn_sw"}
+
+SwitchStates == {"alive", "closed"}
+
+(* ── Resource (FD) identity & attachment ───────────────────────────── *)
+
+\* role \in {"server","keeper"} — who created the resource.
+\* attached \in SwitchIds — which switch owns its lifetime.
+
+VARIABLES
+    sw_state,        \* [SwitchIds -> SwitchStates]
+    current_sw,      \* SwitchIds — the global atomic the runtime reads
+    turn_phase,      \* "idle" | "in_turn"
+    turns_used,      \* 0..MaxTurns — completed turn count
+    resources        \* set of [id: Nat, role: {"server","keeper"}, attached: SwitchIds, released: BOOLEAN]
+
+vars == << sw_state, current_sw, turn_phase, turns_used, resources >>
+
+(* ── Type invariant ────────────────────────────────────────────────── *)
+
+TypeOK ==
+    /\ sw_state \in [SwitchIds -> SwitchStates]
+    /\ current_sw \in SwitchIds
+    /\ turn_phase \in {"idle", "in_turn"}
+    /\ turns_used \in 0..MaxTurns
+    /\ \A r \in resources:
+         /\ r.id \in 0..(2 * MaxTurns * MaxResources)
+         /\ r.role \in {"server","keeper"}
+         /\ r.attached \in SwitchIds
+         /\ r.released \in BOOLEAN
+
+(* ── Initial state ─────────────────────────────────────────────────── *)
+
+Init ==
+    /\ sw_state = [s \in SwitchIds |-> IF s = "root_sw" THEN "alive" ELSE "closed"]
+    /\ current_sw = "root_sw"
+    /\ turn_phase = "idle"
+    /\ turns_used = 0
+    /\ resources = {}
+
+(* ── Helpers ───────────────────────────────────────────────────────── *)
+
+NextResourceId == Cardinality(resources)
+
+ResourcesOnSwitch(s) ==
+    { r \in resources : r.attached = s /\ ~r.released }
+
+(* ── Actions (clean / common) ──────────────────────────────────────── *)
+
+\* Server forks a child fiber. By the §2.1 intent, it MUST attach to root_sw.
+\* In the CLEAN model, server reads current_sw only when turn_phase = "idle"
+\* (guarded by some external invariant, e.g. fiber-local fallback). This is
+\* what Option (3) gives us automatically.
+ServerFork ==
+    /\ turn_phase = "idle"
+    /\ Cardinality(resources) < 2 * MaxTurns * MaxResources
+    /\ resources' = resources \cup
+         {[id |-> NextResourceId, role |-> "server",
+           attached |-> current_sw, released |-> FALSE]}
+    /\ UNCHANGED << sw_state, current_sw, turn_phase, turns_used >>
+
+\* Keeper enters run_turn: with_sw turn_sw (...). Atomic swap + open turn_sw.
+KeeperStartTurn ==
+    /\ turn_phase = "idle"
+    /\ turns_used < MaxTurns
+    /\ turn_phase' = "in_turn"
+    /\ current_sw' = "turn_sw"
+    /\ sw_state' = [sw_state EXCEPT !["turn_sw"] = "alive"]
+    /\ UNCHANGED << turns_used, resources >>
+
+\* Keeper forks inside turn. attaches to current_sw (= turn_sw under wrap).
+KeeperFork ==
+    /\ turn_phase = "in_turn"
+    /\ Cardinality(resources) < 2 * MaxTurns * MaxResources
+    /\ resources' = resources \cup
+         {[id |-> NextResourceId, role |-> "keeper",
+           attached |-> current_sw, released |-> FALSE]}
+    /\ UNCHANGED << sw_state, current_sw, turn_phase, turns_used >>
+
+\* Keeper exits run_turn: closes turn_sw, restores current_sw := root_sw.
+\* Any resource attached to turn_sw is *forcibly* released (Eio.Switch
+\* contract: resources cannot outlive switch). We model this by setting
+\* released := TRUE for all turn_sw resources.
+KeeperEndTurn ==
+    /\ turn_phase = "in_turn"
+    /\ turn_phase' = "idle"
+    /\ current_sw' = "root_sw"
+    /\ sw_state' = [sw_state EXCEPT !["turn_sw"] = "closed"]
+    /\ turns_used' = turns_used + 1
+    /\ resources' =
+         { IF r.attached = "turn_sw" /\ ~r.released
+             THEN [r EXCEPT !.released = TRUE]
+             ELSE r
+           : r \in resources }
+
+\* Voluntary release (e.g., HTTP request finished, FD closed cleanly).
+ResourceRelease ==
+    \E r \in resources:
+       /\ ~r.released
+       /\ resources' = (resources \ {r}) \cup {[r EXCEPT !.released = TRUE]}
+       /\ UNCHANGED << sw_state, current_sw, turn_phase, turns_used >>
+
+(* ── BUG action — race during turn ─────────────────────────────────── *)
+
+\* SERVER fiber forks WHILE keeper is in turn. Reads current_sw = turn_sw,
+\* attaches to turn_sw. Premature termination guaranteed when KeeperEndTurn
+\* fires. This is the concrete §5 race scenario in the audit note.
+ServerForkDuringTurn ==
+    /\ turn_phase = "in_turn"
+    /\ Cardinality(resources) < 2 * MaxTurns * MaxResources
+    /\ resources' = resources \cup
+         {[id |-> NextResourceId, role |-> "server",
+           attached |-> current_sw, released |-> FALSE]}
+    /\ UNCHANGED << sw_state, current_sw, turn_phase, turns_used >>
+
+(* ── Next ──────────────────────────────────────────────────────────── *)
+
+Next ==
+    \/ ServerFork
+    \/ KeeperStartTurn
+    \/ KeeperFork
+    \/ KeeperEndTurn
+    \/ ResourceRelease
+
+NextBuggy ==
+    \/ Next
+    \/ ServerForkDuringTurn
+
+Spec      == Init /\ [][Next]_vars
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+(* ── Invariants ────────────────────────────────────────────────────── *)
+
+\* Every SERVER resource attaches to root_sw. This is the §2.1 intent.
+ServerResourcesOnRoot ==
+    \A r \in resources:
+       r.role = "server" => r.attached = "root_sw"
+
+\* No live resource is attached to a closed switch.
+NoLiveResourceOnClosedSwitch ==
+    \A r \in resources:
+       (~r.released) => sw_state[r.attached] = "alive"
+
+\* Combined: the safety property we want.
+SafetyInvariant ==
+    /\ ServerResourcesOnRoot
+    /\ NoLiveResourceOnClosedSwitch
+
+====


### PR DESCRIPTION
## Summary

Phase C.0 evidence for RFC-0107 §3.3 (L3 Switch hierarchy). **No code wiring**.

- `docs/rfc/RFC-0107-eio-context-switch-audit.md` — inventory of all 26 `Eio_context.get_switch_opt ()` callsites (9 server/dashboard, 16 keeper-turn, 1 misc), 4 wiring options compared, race scenarios documented.
- `specs/keeper-switch-hierarchy/KeeperSwitchHierarchy.{tla,cfg,-buggy.cfg}` — TLA+ Bug Model. Clean: 29019 states, no error. Buggy: `SafetyInvariant` violated in 3 steps via `ServerForkDuringTurn` (the §5 race).
- `docs/rfc/RFC-0107-outbound-http-stack-consolidation.md` §3.3 amend — reflects real complexity, splits Phase C into C.0 (this PR) + C.1 (wiring, follow-up).

## Why this isn't the original "~half-day Phase C"

Initial RFC §3.3 assumed wrapping `run_turn` body in `Eio.Switch.run` was straightforward. Audit found `Eio_context.get_switch_opt ()` is a global `Atomic.t` (line 84 of `eio_context.ml`) with 26 callers across `lib/keeper/`, `lib/server/`, `lib/dashboard/`, `lib/cascade/`. A naïve wrap is bypassed — body fibers calling `get_switch_opt ()` see root_sw, not turn_sw.

## Phase C.1 decision required (deferred)

The audit §6 recommends:
1. Check Eio.Fiber API for fiber-local bindings (Option 3). If available, 1순위.
2. Else: Option 2 atomic swap + separate root_sw_ref for the 9 server/dashboard callsites.
3. Option 4 (explicit ~sw propagation) deferred to a long-term RFC.

Phase C.1 is **not on critical path** for RFC-0107 — Phase D pool merges independently.

## TLA+ verification

```
$ make check-clean CLEAN_CFGS=keeper-switch-hierarchy/KeeperSwitchHierarchy.cfg
OK    KeeperSwitchHierarchy                    (  6s)

$ make check-buggy BUGGY_CFGS=keeper-switch-hierarchy/KeeperSwitchHierarchy-buggy.cfg
OK    KeeperSwitchHierarchy-buggy (buggy)      (violation exit 12,   2s)
```

## Test plan

- [x] TLA+ clean spec passes
- [x] TLA+ buggy spec violates `SafetyInvariant`
- [x] Audit cites real callsite line numbers (`rg`-measured)
- [ ] Reviewer agrees Phase C.1 decision is deferred, not abandoned

## RFC discovery

Pure docs (RFC body + research/spec). No subsystem code touched. `RFC-WAIVED: docs-only RFC-0107 Phase C.0 evidence supplement`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)