### PR TITLE
fix(tool-keeper): Prometheus counter for cached_text_by_key CAS conflicts

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -346,6 +346,16 @@ let metric_tool_join_required_guard = "masc_tool_join_required_guard_total"
 let metric_tool_metrics_persist_dropped =
   "masc_tool_metrics_persist_dropped_total"
 
+(* tool_keeper.cached_text_by_key CAS conflicts.
+   Incremented once per recursive retry caused by an
+   [Atomic.compare_and_set cache_ref] failure in the helper.  Each
+   conflict triggers a second [compute ()] call, so sustained non-zero
+   rate is a recompute-amplification signal.  No labels: the helper is
+   currently used only for keeper_list_cache; add a cache label if a
+   second caller is introduced. *)
+let metric_tool_keeper_cache_cas_conflicts =
+  "masc_tool_keeper_cache_cas_conflicts_total"
+
 (* #9771: keeper turn-slot semaphore wait timeout counter.
 
    Production observed multiple keepers ([sangsu], [janitor],
@@ -1311,6 +1321,11 @@ let init () =
     metric_tool_metrics_persist_dropped
     "Total JSONL records dropped by tool_metrics_persist because the bounded \
      write queue is full. No labels."
+    Counter;
+  add
+    metric_tool_keeper_cache_cas_conflicts
+    "Total tool_keeper.cached_text_by_key Atomic CAS retry events. Each \
+     increment corresponds to one extra compute() call. No labels."
     Counter;
   add
     Keeper_metrics.metric_keeper_turn_queue_depth

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -170,6 +170,10 @@ val metric_tool_join_required_guard : string
 (** Counter for [tool_metrics_persist] write-queue overflow drops. No labels. *)
 val metric_tool_metrics_persist_dropped : string
 
+(** Counter for [tool_keeper.cached_text_by_key] Atomic CAS retry events.
+    Each increment corresponds to one extra [compute ()] call. No labels. *)
+val metric_tool_keeper_cache_cas_conflicts : string
+
 (** #9771: counter for keeper turn-slot semaphore wait timeouts.
     Labels: [keeper, channel] with channel in
     [autonomous_queue_head | autonomous | turn]. *)

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -90,7 +90,11 @@ let rec cached_text_by_key cache_ref ~key ~ttl_s compute =
         }
       in
       if Atomic.compare_and_set cache_ref cache next then value
-      else cached_text_by_key cache_ref ~key ~ttl_s compute
+      else begin
+        Prometheus.inc_counter
+          Prometheus.metric_tool_keeper_cache_cas_conflicts ();
+        cached_text_by_key cache_ref ~key ~ttl_s compute
+      end
 
 module For_testing = struct
   let reset_keeper_list_cache () =


### PR DESCRIPTION
## Problem

`cached_text_by_key cache_ref ~key ~ttl_s compute` (lib/tool_keeper.ml:75-93) is a tail-recursive cache helper. On `Atomic.compare_and_set` failure at line 92, it re-invokes itself — which calls `compute ()` again. Sustained CAS contention amplifies the recompute cost.

No Prometheus signal exists for the retry rate. Operators cannot detect cache thrash (e.g., 10+ keepers invalidating `keeper_list_cache` simultaneously) until it manifests as p99 latency on the call site.

## Fix

Adds `Prometheus.metric_tool_keeper_cache_cas_conflicts` (no labels). Incremented once per retry, before the recursive call.

```diff
       if Atomic.compare_and_set cache_ref cache next then value
-      else cached_text_by_key cache_ref ~key ~ttl_s compute
+      else begin
+        Prometheus.inc_counter
+          Prometheus.metric_tool_keeper_cache_cas_conflicts ();
+        cached_text_by_key cache_ref ~key ~ttl_s compute
+      end
```

No labels: the helper is currently used only for `keeper_list_cache`. If a second caller is introduced, add a `cache` label at that time (avoid speculative cardinality now).

## Behaviour

Preserved. Lock-free CAS-retry semantics unchanged.

## Build

`dune build @check` PASS.

## Anti-pattern self-check (7/7)

- [x] Not telemetry-as-fix in the rejection sense — CAS-retry is correct lock-free OCaml semantics; the gap is *visibility of amplification cost*
- [x] No string classifier — no labels
- [x] Not N-of-M — single retry site in the helper
- [x] No new catch-all
- [x] No magic number / test backdoor / N-times-typo fix

## Source

Silent-path Explore sweep 2026-05-17 (Candidate 3 of 3, verified). Pairs with #15909 (Candidate 1, MERGED) and #15911 (Candidate 2, Draft).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>