### PR TITLE
fix(startup): parallelize safe lazy tasks

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1112,6 +1112,69 @@ let sync_bootable_keeper_credentials (state : Mcp_server.server_state) =
                agent_name outcome.token_hash_prefix detail))
     rotation_outcomes
 
+type lazy_startup_execution =
+  | Parallel
+  | Serial
+
+type lazy_startup_group = {
+  group_name : string;
+  execution : lazy_startup_execution;
+  task_names : string list;
+}
+
+let lazy_startup_plan ~has_legacy_traces =
+  let initial_groups =
+    [
+      {
+        group_name = "initialize";
+        execution = Parallel;
+        task_names =
+          [
+            "restore_sessions";
+            "reconcile_active_agents";
+            "prompt_bootstrap";
+            "keeper_history_migration";
+          ];
+      };
+      {
+        group_name = "tool_state";
+        execution = Serial;
+        task_names = [ "telemetry_warmup"; "tool_metrics_restore" ];
+      };
+    ]
+  in
+  let legacy_groups =
+    if has_legacy_traces then
+      [
+        {
+          group_name = "legacy_trace_migration";
+          execution = Serial;
+          task_names = [ "legacy_trace_dir_migration" ];
+        };
+      ]
+    else
+      []
+  in
+  let cleanup_groups =
+    [
+      {
+        group_name = "cleanup";
+        execution = Serial;
+        task_names =
+          [
+            "jsonl_prune";
+            "keeper_checkpoint_prune";
+            "auth_archive_prune";
+          ];
+      };
+    ]
+  in
+  initial_groups @ legacy_groups @ cleanup_groups
+
+let lazy_startup_task_names ~has_legacy_traces =
+  lazy_startup_plan ~has_legacy_traces
+  |> List.concat_map (fun group -> group.task_names)
+
 let bootstrap_prompt_state (state : Mcp_server.server_state) =
   Config_dir_resolver.log_warnings ~context:"ServerBootstrap" ();
   Config_dir_resolver.log_resolution ~context:"ServerBootstrap" ();
@@ -1589,35 +1652,56 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       let has_legacy_traces =
         Sys.file_exists (Filename.concat masc_root "perpetual")
       in
-      let tasks =
-        [
-          ("restore_sessions", fun () -> restore_persisted_sessions state);
-          ("reconcile_active_agents", fun () -> reconcile_active_agents_gauge state);
-          ("prompt_bootstrap", fun () -> bootstrap_prompt_state state);
-          ("telemetry_warmup", fun () -> warm_tool_registry_from_telemetry state);
-          ("tool_metrics_restore", fun () -> restore_tool_metrics_from_disk state);
-          ("keeper_history_migration", fun () -> startup_migrate_keeper_histories state);
-        ]
-        @ (if has_legacy_traces then
-             [("legacy_trace_dir_migration", fun () ->
-                 migrate_legacy_trace_dirs state)]
-           else [])
-        @ [
-          ("jsonl_prune", fun () -> startup_prune_jsonl state);
-          ( "keeper_checkpoint_prune",
-            fun () -> startup_prune_keeper_checkpoints state );
-          ( "auth_archive_prune",
-            fun () -> startup_prune_auth_archive state );
-          (* keeper_bootstrap removed: keeper_autoboot subsystem in
-             start_keeper_loops handles this in a dedicated fiber,
-             avoiding bootstrap contention with dashboard refresh loops. *)
-        ]
+      let task_fn = function
+        | "restore_sessions" -> fun () -> restore_persisted_sessions state
+        | "reconcile_active_agents" -> fun () ->
+            reconcile_active_agents_gauge state
+        | "prompt_bootstrap" -> fun () -> bootstrap_prompt_state state
+        | "keeper_history_migration" -> fun () ->
+            startup_migrate_keeper_histories state
+        | "telemetry_warmup" -> fun () ->
+            warm_tool_registry_from_telemetry state
+        | "tool_metrics_restore" -> fun () ->
+            restore_tool_metrics_from_disk state
+        | "legacy_trace_dir_migration" -> fun () ->
+            migrate_legacy_trace_dirs state
+        | "jsonl_prune" -> fun () -> startup_prune_jsonl state
+        | "keeper_checkpoint_prune" -> fun () ->
+            startup_prune_keeper_checkpoints state
+        | "auth_archive_prune" -> fun () -> startup_prune_auth_archive state
+        | task_name ->
+            raise
+              (Invalid_argument
+                 (Printf.sprintf "unknown lazy startup task: %s" task_name))
       in
-      let task_names = List.map fst tasks in
+      let task_names = lazy_startup_task_names ~has_legacy_traces in
+      let task_groups =
+        lazy_startup_plan ~has_legacy_traces
+        |> List.map (fun group ->
+               (group, List.map (fun name -> (name, task_fn name)) group.task_names))
+      in
+      let execution_to_string = function
+        | Parallel -> "parallel"
+        | Serial -> "serial"
+      in
+      let run_lazy_task_group (group, tasks) =
+        Log.Server.info
+          "lazy_task_group: starting %s (%s, %d tasks)"
+          group.group_name
+          (execution_to_string group.execution)
+          (List.length tasks);
+        (match group.execution with
+         | Parallel ->
+             Eio.Fiber.all
+               (List.map (fun task () -> run_lazy_task task) tasks)
+             |> ignore
+         | Serial -> List.iter run_lazy_task tasks);
+        Log.Server.info "lazy_task_group: finished %s" group.group_name
+      in
       Server_startup_state.activate_lazy
         ~backend_mode:(Coord.backend_name state.room_config)
         ~tasks:task_names;
-      Eio.Fiber.fork ~sw (fun () -> List.iter run_lazy_task tasks)
+      Eio.Fiber.fork ~sw (fun () -> List.iter run_lazy_task_group task_groups)
     in
     try
       Server_startup_state.mark_blocking ~backend_mode:initial_backend_mode;

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -69,6 +69,25 @@ val startup_prune_keeper_checkpoints : Mcp_server.server_state -> unit
 val startup_migrate_keeper_histories : Mcp_server.server_state -> unit
 val sync_bootable_keeper_credentials : Mcp_server.server_state -> unit
 
+type lazy_startup_execution =
+  | Parallel
+  | Serial
+
+type lazy_startup_group = {
+  group_name : string;
+  execution : lazy_startup_execution;
+  task_names : string list;
+}
+
+val lazy_startup_plan : has_legacy_traces:bool -> lazy_startup_group list
+(** Deterministic startup task grouping.  [Parallel] groups contain only
+    tasks whose stores are independent; [Serial] groups preserve ordering for
+    shared tool state and cleanup phases. *)
+
+val lazy_startup_task_names : has_legacy_traces:bool -> string list
+(** Flattened task names in the same dependency order used to activate
+    {!Server_startup_state}'s lazy task queue. *)
+
 (** {2 Codex MCP Client Auth} *)
 
 type codex_mcp_config_sync_status =

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1333,6 +1333,91 @@ let test_blocking_bootstrap_ignores_whitespace_legacy_room_dirs () =
         "whitespace room backlog does not promote into root" false
         root_backlog_promoted)
 
+let execution_label = function
+  | Server_runtime_bootstrap.Parallel -> "parallel"
+  | Server_runtime_bootstrap.Serial -> "serial"
+
+let check_lazy_group group ~name ~execution ~tasks =
+  Alcotest.(check string) "group name" name group.Server_runtime_bootstrap.group_name;
+  Alcotest.(check string)
+    (name ^ " execution")
+    execution
+    (execution_label group.Server_runtime_bootstrap.execution);
+  Alcotest.(check (list string))
+    (name ^ " tasks")
+    tasks
+    group.Server_runtime_bootstrap.task_names
+
+let test_lazy_startup_plan_groups_independent_tasks () =
+  let groups = Server_runtime_bootstrap.lazy_startup_plan ~has_legacy_traces:false in
+  Alcotest.(check (list string))
+    "group order"
+    [ "initialize"; "tool_state"; "cleanup" ]
+    (List.map
+       (fun group -> group.Server_runtime_bootstrap.group_name)
+       groups);
+  match groups with
+  | [ initialize; tool_state; cleanup ] ->
+      check_lazy_group initialize ~name:"initialize" ~execution:"parallel"
+        ~tasks:
+          [
+            "restore_sessions";
+            "reconcile_active_agents";
+            "prompt_bootstrap";
+            "keeper_history_migration";
+          ];
+      check_lazy_group tool_state ~name:"tool_state" ~execution:"serial"
+        ~tasks:[ "telemetry_warmup"; "tool_metrics_restore" ];
+      check_lazy_group cleanup ~name:"cleanup" ~execution:"serial"
+        ~tasks:
+          [ "jsonl_prune"; "keeper_checkpoint_prune"; "auth_archive_prune" ];
+      Alcotest.(check (list string))
+        "flattened task order"
+        [
+          "restore_sessions";
+          "reconcile_active_agents";
+          "prompt_bootstrap";
+          "keeper_history_migration";
+          "telemetry_warmup";
+          "tool_metrics_restore";
+          "jsonl_prune";
+          "keeper_checkpoint_prune";
+          "auth_archive_prune";
+        ]
+        (Server_runtime_bootstrap.lazy_startup_task_names
+           ~has_legacy_traces:false)
+  | _ -> Alcotest.fail "unexpected lazy startup group shape"
+
+let test_lazy_startup_plan_keeps_legacy_migration_serial () =
+  let groups = Server_runtime_bootstrap.lazy_startup_plan ~has_legacy_traces:true in
+  Alcotest.(check (list string))
+    "group order"
+    [ "initialize"; "tool_state"; "legacy_trace_migration"; "cleanup" ]
+    (List.map
+       (fun group -> group.Server_runtime_bootstrap.group_name)
+       groups);
+  match groups with
+  | [ _initialize; _tool_state; legacy_migration; _cleanup ] ->
+      check_lazy_group legacy_migration ~name:"legacy_trace_migration"
+        ~execution:"serial" ~tasks:[ "legacy_trace_dir_migration" ];
+      Alcotest.(check (list string))
+        "flattened task order includes legacy migration before cleanup"
+        [
+          "restore_sessions";
+          "reconcile_active_agents";
+          "prompt_bootstrap";
+          "keeper_history_migration";
+          "telemetry_warmup";
+          "tool_metrics_restore";
+          "legacy_trace_dir_migration";
+          "jsonl_prune";
+          "keeper_checkpoint_prune";
+          "auth_archive_prune";
+        ]
+        (Server_runtime_bootstrap.lazy_startup_task_names
+           ~has_legacy_traces:true)
+  | _ -> Alcotest.fail "unexpected legacy lazy startup group shape"
+
 let test_startup_state_json () =
   Server_startup_state.reset ~backend_mode:"postgres-native" ();
   Server_startup_state.mark_state_ready ~backend_mode:"postgres-native";
@@ -2632,6 +2717,10 @@ let () =
             "blocking bootstrap ignores whitespace legacy room dirs"
             `Quick
             test_blocking_bootstrap_ignores_whitespace_legacy_room_dirs;
+          Alcotest.test_case "lazy startup plan parallelizes independent tasks"
+            `Quick test_lazy_startup_plan_groups_independent_tasks;
+          Alcotest.test_case "lazy startup plan keeps legacy migration serial"
+            `Quick test_lazy_startup_plan_keeps_legacy_migration_serial;
           Alcotest.test_case "startup state json reports lazy failure" `Quick
             test_startup_state_json;
           Alcotest.test_case


### PR DESCRIPTION
## Summary
- split lazy startup into explicit parallel and serial groups
- run independent restore/reconcile/prompt/keeper-history tasks with Eio.Fiber.all
- keep tool-state restore, optional legacy trace migration, and cleanup phases serial
- expose the plan as a pure function and cover ordering with focused tests

Closes #15114

## Validation
- git diff --check origin/main..HEAD
- scripts/dune-local.sh build lib/.masc_mcp.objs/native/masc_mcp__Server_runtime_bootstrap.cmx test/test_server_runtime_bootstrap.exe
- ./_build/default/test/test_server_runtime_bootstrap.exe test --color=never --quick-tests bootstrap 28,29

Note: after rebasing onto the latest origin/main, the second local Dune rerun was blocked by another long-held dune-local lock; the pre-rebase focused build/test passed and the post-rebase diff check is clean.