### PR TITLE
feat(cancel-safe): RFC-0106 P1 — migrate bg_task sidecar helpers to Cancel_safe.protect

### DIFF
--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -514,12 +514,12 @@ let list_with_started_at ~keeper =
 (* Directory walk helpers — avoid Filename.Infix / extra deps. *)
 
 let safe_readdir dir =
-  try Array.to_list (Sys.readdir dir) with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
+  Cancel_safe.protect
+    ~on_exn:(fun exn ->
       if Sys.file_exists dir then
         observe_sidecar_failure ~site:"readdir" exn;
-      []
+      [])
+    (fun () -> Array.to_list (Sys.readdir dir))
 
 let is_dir p =
   try (Unix.stat p).Unix.st_kind = Unix.S_DIR with
@@ -529,32 +529,31 @@ let is_dir p =
       false
 
 let read_pid_file path =
-  try
-    let ic = open_in path in
-    Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
-      let input_line_opt ic =
-        try Some (input_line ic) with End_of_file -> None
-      in
-      let pid_line = input_line_opt ic in
-      let pgid_line = input_line_opt ic in
-      let parse_int line =
-        Option.bind (Option.map String.trim line) int_of_string_opt
-      in
-      match parse_int pid_line, parse_int pgid_line with
-      | Some pid, Some pgid -> Some (pid, pgid)
-      | _ ->
-          observe_sidecar_failure ~site:"read_parse"
-            (Failure (Printf.sprintf "invalid PID sidecar: %s" path));
-          None)
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
+  Cancel_safe.protect
+    ~on_exn:(fun exn ->
       if Sys.file_exists path then
         observe_sidecar_failure ~site:"read"
           (Failure
              (Printf.sprintf "read PID sidecar %s: %s" path
                 (Printexc.to_string exn)));
-      None
+      None)
+    (fun () ->
+      let ic = open_in path in
+      Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+        let input_line_opt ic =
+          try Some (input_line ic) with End_of_file -> None
+        in
+        let pid_line = input_line_opt ic in
+        let pgid_line = input_line_opt ic in
+        let parse_int line =
+          Option.bind (Option.map String.trim line) int_of_string_opt
+        in
+        match parse_int pid_line, parse_int pgid_line with
+        | Some pid, Some pgid -> Some (pid, pgid)
+        | _ ->
+            observe_sidecar_failure ~site:"read_parse"
+              (Failure (Printf.sprintf "invalid PID sidecar: %s" path));
+            None))
 
 let pid_is_live pid =
   try Unix.kill pid 0; true

--- a/lib/process/dune
+++ b/lib/process/dune
@@ -6,4 +6,4 @@
  (modules process_eio file_lock_eio exec_tap with_process bg_task)
  ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on.
  (flags (:standard -w +4))
- (libraries masc_core masc_log time_compat eio eio.unix unix threads))
+ (libraries masc_core masc_log time_compat masc_cancel_safe eio eio.unix unix threads))


### PR DESCRIPTION
## Summary

First Phase 1 migration of RFC-0106 (spec #15894, P0 #15904). Migrates two value-returning catch-all helpers in `lib/process/bg_task.ml` to `Cancel_safe.protect`:

- `safe_readdir` — `Sys.readdir` wrapper returning `string list`
- `read_pid_file` — PID sidecar parser returning `(int * int) option`

Both previously used the manual paired-arm form:

```ocaml
try ... with
| Eio.Cancel.Cancelled _ as e -> raise e
| exn -> ...
```

which is the exact target shape of `Cancel_safe.protect`. Migration centralises the Cancelled re-raise discipline; per-site arm drift risk eliminated.

## Diff shape (safe_readdir)

```diff
 let safe_readdir dir =
-  try Array.to_list (Sys.readdir dir) with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-      if Sys.file_exists dir then
-        observe_sidecar_failure ~site:"readdir" exn;
-      []
+  Cancel_safe.protect
+    ~on_exn:(fun exn ->
+      if Sys.file_exists dir then
+        observe_sidecar_failure ~site:"readdir" exn;
+      [])
+    (fun () -> Array.to_list (Sys.readdir dir))
```

## Behaviour

Preserved. `on_exn` body is byte-equivalent to the prior catch-all body; Cancelled propagation is identical.

## Build

`dune build @check` PASS. Net -1 LoC.

## Scope (NOT migrated in this PR)

- `is_dir` (line 524) — catch-all delegates Cancelled discrimination to `observe_sidecar_failure`, a different (correct but indirect) discipline. Migration of indirect-Cancelled sites is a separate concern.
- `observe_drain_failure` callback wrap (line 112) and `observe_sidecar_failure` inner observer wrap (line 127) — observer-of-observer pattern, not a value-returning surface.
- `drain_fd_to_buf` `match | exception` form (line 274) — already typed-exhaustive with Unix_error split; would *lose* typing to migrate.

Subsequent P1 PRs will pick up: keeper lifecycle / transport / sandbox / fd accountant.

## Files

- `lib/process/dune` — `masc_cancel_safe` added to libraries
- `lib/process/bg_task.ml` — 2 helpers migrated, +25/-26 LoC

## Anti-pattern self-check (7/7)

- [x] Not telemetry-as-fix — behaviour preserved; migration centralises an existing invariant
- [x] No string classifier
- [x] Not N-of-M — 2 sites in same file with same shape; remaining sites have different shapes
- [x] No new catch-all — `on_exn` is caller-supplied
- [x] No magic number / test backdoor / N-times-typo fix

## Related

- RFC-0106 (PR #15894 merged) — spec
- PR #15904 — P0 canary migration (callback / unit / `Cancel_safe.observe`)
- This PR — P1 first migration (value / `Cancel_safe.protect`)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>