### PR TITLE
fix(build): keep cancel-safe callback sequencing typed

### DIFF
--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -556,11 +556,13 @@ let apply_post_turn_lifecycle_with_resilience_handles
              policy. *)
           (* RFC-0106 P0 canary: use Cancel_safe.observe so Cancelled
              propagates without per-site discipline drift. *)
-          Cancel_safe.observe
-            ~on_exn:(fun exn ->
-              Keeper_callback_failure.record ~base_dir ~meta:base_meta
-                ~callback:"on_compaction_started" exn)
-            on_compaction_started;
+          let () =
+            Cancel_safe.observe
+              ~on_exn:(fun exn ->
+                Keeper_callback_failure.record ~base_dir ~meta:base_meta
+                  ~callback:"on_compaction_started" exn)
+              on_compaction_started
+          in
           let session =
             create_session ~session_id:(Keeper_id.Trace_id.to_string base_meta.runtime.trace_id) ~base_dir
           in


### PR DESCRIPTION
## Summary
- keep the `Cancel_safe.observe` canary callback as an explicit unit binding so the compaction save branch still returns its expected tuple
- this repairs the current main `bin/main_eio.exe` build break exposed after RFC-0106 landed

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-operator-snapshot-evict-paren --build-dir /private/tmp/masc-mcp-build-fix-operator-snapshot-evict-paren bin/main_eio.exe -j 1
- scripts/check-version-truth.sh
- bash scripts/check-doc-truth.sh
- git diff --check origin/main...HEAD