### PR TITLE
feat(cancel-safe): RFC-0106 P1 — migrate safe_respond_with_string to Cancel_safe.observe

### DIFF
--- a/lib/server/server_mcp_transport_http_respond.ml
+++ b/lib/server/server_mcp_transport_http_respond.ml
@@ -13,26 +13,31 @@ let safe_respond_with_string reqd response body =
      available.  The known-race arm (Failure path) keeps its compact
      one-line format because the failure mode is well-classified and
      the surrounding incident note already captures the diagnostic
-     intent — adding a backtrace there would just churn parsers. *)
-  try Httpun.Reqd.respond_with_string reqd response body
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | Failure msg ->
-      Log.Server.warn
-        "[mcp-http] respond_with_string skipped (reqd invalid state; \
-         2026-05-05 OAS cancel race): %s"
-        msg
-  | exn ->
-      let backtrace = Printexc.get_backtrace () in
-      let summary = Printexc.to_string exn in
-      if String.trim backtrace = "" then
-        Log.Server.warn
-          "[mcp-http] respond_with_string unexpected exception: %s"
-          summary
-      else
-        Log.Server.warn
-          "[mcp-http] respond_with_string unexpected exception: %s\n%s"
-          summary backtrace
+     intent — adding a backtrace there would just churn parsers.
+
+     RFC-0106 P1: routed via [Cancel_safe.observe] so the Cancelled
+     re-raise discipline lives in one place. The [Failure] arm is
+     preserved inside [on_exn] because it is a typed boundary
+     (2026-05-05 OAS cancel race), not a catch-all. *)
+  Cancel_safe.observe
+    ~on_exn:(function
+      | Failure msg ->
+          Log.Server.warn
+            "[mcp-http] respond_with_string skipped (reqd invalid state; \
+             2026-05-05 OAS cancel race): %s"
+            msg
+      | exn ->
+          let backtrace = Printexc.get_backtrace () in
+          let summary = Printexc.to_string exn in
+          if String.trim backtrace = "" then
+            Log.Server.warn
+              "[mcp-http] respond_with_string unexpected exception: %s"
+              summary
+          else
+            Log.Server.warn
+              "[mcp-http] respond_with_string unexpected exception: %s\n%s"
+              summary backtrace)
+    (fun () -> Httpun.Reqd.respond_with_string reqd response body)
 
 let mcp_headers = Server_mcp_transport_http_headers.mcp_headers
 


### PR DESCRIPTION
## Summary

Second Phase 1 migration of RFC-0106. Migrates the HTTP MCP response helper `safe_respond_with_string` (lib/server/server_mcp_transport_http_respond.ml) to `Cancel_safe.observe`.

The function is the transport-side sibling of the bg_task helpers (#15917): unit-returning callback wrapped in a catch-all that distinguishes a typed `Failure` race-arm from a generic backtrace-capturing arm.

## Diff shape

```diff
 let safe_respond_with_string reqd response body =
-  try Httpun.Reqd.respond_with_string reqd response body
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | Failure msg -> Log.Server.warn "...[OAS cancel race]: %s" msg
-  | exn ->
-      let backtrace = ... in
-      Log.Server.warn "...unexpected exception: %s\n%s" ...
+  Cancel_safe.observe
+    ~on_exn:(function
+      | Failure msg -> Log.Server.warn "...[OAS cancel race]: %s" msg
+      | exn ->
+          let backtrace = ... in
+          Log.Server.warn "...unexpected exception: %s\n%s" ...)
+    (fun () -> Httpun.Reqd.respond_with_string reqd response body)
```

## Why `Failure` arm survives

`Failure` is a typed constructor, not a string match. The 2026-05-05 OAS cancel race incident note documents this as a well-classified known-race boundary. Moving it inside `on_exn` preserves both the typed match and the diagnostic intent.

## Backtrace semantics

`Printexc.get_backtrace ()` returns the most-recent uncaught exception's trace. Inside `on_exn`, the trace from the failed `respond_with_string` call is still the most-recent one. Behaviour preserved.

## Build

`dune build @check` PASS. Net +5 LoC (added RFC-0106 reference comment; functional code roughly LoC-neutral).

## NOT migrated in this PR (deferred RFC-0106 P1 sites)

- `lib/server/server_mcp_transport_http.ml` (11 Cancelled-paired sites)
- `lib/server/server_mcp_transport_http_conn.ml` (3)
- `lib/server/server_mcp_transport_http_agui.ml` (8)
- `lib/server/server_mcp_transport_ws.ml` (2)
- `lib/server/server_webrtc_transport.ml` (3)

These will be migrated in subsequent P1 PRs grouped by file. Bulk migration in a single PR risks review surface explosion.

## Anti-pattern self-check (7/7)

- [x] Not telemetry-as-fix — behaviour preserved
- [x] No string classifier — `Failure msg` is a typed constructor match
- [x] Not N-of-M — 1 site in this file; other transport files tracked separately
- [x] No new catch-all — `on_exn` is caller-supplied
- [x] No magic number / test backdoor / N-times-typo fix

## Related

- RFC-0106 (PR #15894) — spec
- PR #15904 — P0 canary
- PR #15917 — P1 first (bg_task value-returning)
- This PR — P1 second (transport unit-returning)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>