### PR TITLE
feat(cancel-safe): RFC-0106 P1 — migrate sandbox/shell option-returning catch-alls

### DIFF
--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -305,23 +305,27 @@ let git_metadata_timeout_sec = 2.0
 let max_live_git_enrichment_repos = 20
 
 let git_string_opt repo_path args =
-  try
-    let argv = "git" :: "-C" :: repo_path :: args in
-    let status, out =
-      Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git
-        ~raw_source:(String.concat " " argv)
-        ~summary:"keeper sandbox git metadata"
-        ~timeout_sec:git_metadata_timeout_sec
-        argv
-    in
-    match status with
-    | Unix.WEXITED 0 ->
-        let trimmed = String.trim out in
-        if String.equal trimmed "" then None else Some trimmed
-    | _ -> None
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ -> None
+  (* RFC-0106 P1: Cancelled re-raise centralised via Cancel_safe.protect.
+     The [_ -> None] silent default is pre-existing behaviour (git
+     metadata is treated as optional by callers) and is preserved
+     verbatim. Promoting it to a logged/counted failure is a separate
+     visibility concern outside this PR's migration scope. *)
+  Cancel_safe.protect
+    ~on_exn:(fun _ -> None)
+    (fun () ->
+      let argv = "git" :: "-C" :: repo_path :: args in
+      let status, out =
+        Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git
+          ~raw_source:(String.concat " " argv)
+          ~summary:"keeper sandbox git metadata"
+          ~timeout_sec:git_metadata_timeout_sec
+          argv
+      in
+      match status with
+      | Unix.WEXITED 0 ->
+          let trimmed = String.trim out in
+          if String.equal trimmed "" then None else Some trimmed
+      | _ -> None)
 
 let enrich_playground_repo_from_git
       ~(source : string) ~(repo_name : string) ~(repo_path : string)

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -724,10 +724,11 @@ let handle_keeper_bash
     | Error e -> error_json e
     | Ok cwd ->
     let env_snap =
-      try Some (Exec_core.snapshot_env ~cwd)
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | _ -> None
+      (* RFC-0106 P1: route Cancelled re-raise through Cancel_safe.protect.
+         Silent [_ -> None] preserved verbatim — env snapshot is optional. *)
+      Cancel_safe.protect
+        ~on_exn:(fun _ -> None)
+        (fun () -> Some (Exec_core.snapshot_env ~cwd))
     in
     let cached_result_json
           (entry : Masc_exec.Exec_cache.cache_entry) =


### PR DESCRIPTION
## Summary

Third Phase 1 migration of RFC-0106. Routes two option-returning catch-alls in the sandbox / shell subsystems through `Cancel_safe.protect`:

- `lib/keeper/keeper_sandbox_control.ml::git_string_opt` — wraps `Masc_exec.Exec_gate.run_argv_with_status` for git metadata enrichment.
- `lib/keeper/keeper_shell_bash.ml` — `Exec_core.snapshot_env` wrap inside the keeper-shell bash dispatch.

## Diff shape (both sites)

```diff
-  try ... with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ -> None
+  Cancel_safe.protect
+    ~on_exn:(fun _ -> None)
+    (fun () -> ...)
```

## Why the silent default survives

Both call sites treat the optional return value as "metadata unavailable":
- `git_string_opt` enrichment is opportunistic (used by `enrich_playground_repo_from_git`)
- `snapshot_env` is an optimisation hint

Promoting these to logged/counted failures is a legitimate visibility concern but a *separate decision* from this RFC-0106 migration. This PR preserves the silent default verbatim and adds inline comments documenting the contract. Future visibility-side PRs can audit the silent-default population without touching the Cancelled-discipline boundary.

## Build

`dune build @check` PASS. Net +5 LoC (added RFC-0106 reference comments).

## Anti-pattern self-check (7/7)

- [x] Not telemetry-as-fix — behaviour preserved verbatim
- [x] No string classifier
- [x] Not N-of-M — 2 sites total; remaining keeper sandbox/shell sites have different shapes (operator action handlers, identity flows) tracked separately
- [x] No new `_ -> false` catch-all — `on_exn` is caller-supplied, same silent default
- [x] No magic number / test backdoor / N-times-typo fix

## RFC subsystem gate

`bash ~/me/scripts/pr-rfc-check.sh` exit 0 — RFC-0106 reference present in code comments + commit body.

## Related

- RFC-0106 (PR #15894) — spec
- PR #15904 — P0 canary
- PR #15917 — P1.a process bg_task
- PR #15919 — P1.b transport http_respond
- This PR — P1.c sandbox/shell option-returning

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>