### PR TITLE
fix(masc_log): serialize system_log JSONL writes (RFC-0108) (Draft)

### DIFF
--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -283,15 +283,44 @@ module Ring = struct
       end
     end
 
+  (* RFC-0108: serialize the JSONL append under a single mutex
+     critical section so concurrent fibers (or domains) cannot
+     interleave bytes from different records.  Pre-fix, the three-
+     call sequence [output_string oc json; output_char oc '\n';
+     flush oc] left a race window between the JSON and the newline —
+     observed on 2026-05-17 as ["}{"]-concat lines in
+     [.masc/logs/system_log_2026-05-17.jsonl:3498] and [:4635].
+
+     [Stdlib.Mutex] is sufficient here because [Ring.init_file_sink]
+     runs before [Eio_main.run] (see [bin/main_eio.ml]); the writer
+     therefore cannot assume an Eio scheduler is available and must
+     work from non-Eio contexts (e.g. [at_exit]).  The mutex protects
+     the single global [file_channel], so one lock covers the whole
+     write path. Building the [json + "\n"] payload as a single
+     string before [output_string] also keeps the kernel-visible
+     write boundary at record granularity (the channel buffer is
+     flushed once per record).
+
+     [rotate_if_needed] runs outside the mutex on purpose — it only
+     mutates [file_channel] when the date rolls, and recursing into
+     the mutex there would deadlock.  Reading [!file_channel] inside
+     the lock means a rotate racing with a write sees whichever
+     channel is current; the worst case is one record on the
+     about-to-rotate channel, which is harmless. *)
+  let sink_mutex = Stdlib.Mutex.create ()
+
   let write_to_sink entry_json =
     rotate_if_needed ();
-    match !file_channel with
-    | Some oc ->
-        output_string oc (Yojson.Safe.to_string entry_json);
-        output_char oc '\n';
-        (* flush on warn/error for timely persistence *)
-        protect ~default:() (fun () -> flush oc)
-    | None -> ()
+    Stdlib.Mutex.lock sink_mutex;
+    Fun.protect
+      ~finally:(fun () -> Stdlib.Mutex.unlock sink_mutex)
+      (fun () ->
+        match !file_channel with
+        | Some oc ->
+            let line = Yojson.Safe.to_string entry_json ^ "\n" in
+            output_string oc line;
+            protect ~default:() (fun () -> flush oc)
+        | None -> ())
 
   exception Entry_decode_error of string
 

--- a/test/dune
+++ b/test/dune
@@ -1367,6 +1367,7 @@
 (include stanzas/test_sse_storm_e2e.inc)
 (include stanzas/test_start_masc_mcp_script.inc)
 (include stanzas/test_supervisor_start_predicate.inc)
+(include stanzas/test_system_log_atomicity.inc)
 (include stanzas/test_telemetry_task_transition_10358.inc)
 (include stanzas/test_timeout_policy.inc)
 (include stanzas/test_timeout_policy_overshoot_counter.inc)

--- a/test/stanzas/test_system_log_atomicity.inc
+++ b/test/stanzas/test_system_log_atomicity.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_system_log_atomicity)
+ (modules test_system_log_atomicity)
+ (libraries masc_log alcotest threads.posix yojson unix))

--- a/test/test_system_log_atomicity.ml
+++ b/test/test_system_log_atomicity.ml
@@ -1,0 +1,109 @@
+(** RFC-0108: system_log writer atomicity stress (in-line Stdlib.Mutex fix).
+
+    Drives [Log.Ring.push] from many concurrent OCaml threads against a
+    real file sink, then re-reads the file and asserts every line is
+    parseable JSON.  Pre-fix the 3-syscall write
+    [output_string + output_char + flush] left a race window that
+    surfaced as ["}{"]-concat lines under contention; this test
+    reproduces the contention and the post-fix sink must yield zero
+    malformed lines. *)
+
+open Alcotest
+
+let counter = ref 0
+
+let tmpdir prefix =
+  incr counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "%s_%d_%d_%.0f"
+         prefix
+         !counter
+         (Unix.getpid ())
+         (Unix.gettimeofday ()))
+  in
+  Unix.mkdir dir 0o755;
+  dir
+
+let today_path dir =
+  let tm = Unix.gmtime (Unix.gettimeofday ()) in
+  let date =
+    Printf.sprintf
+      "%04d-%02d-%02d"
+      (tm.tm_year + 1900)
+      (tm.tm_mon + 1)
+      tm.tm_mday
+  in
+  Filename.concat dir (Printf.sprintf "system_log_%s.jsonl" date)
+
+let read_lines path =
+  if not (Sys.file_exists path) then []
+  else
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let buf = Buffer.create 4096 in
+        (try
+           while true do
+             Buffer.add_channel buf ic 4096
+           done
+         with End_of_file -> ());
+        let content = Buffer.contents buf in
+        String.split_on_char '\n' content
+        |> List.filter (fun s -> s <> ""))
+
+(* ── 16 threads × 500 records — same race surface that produced
+   "}{"-concat lines on 2026-05-17 (logs/system_log_2026-05-17.jsonl
+   lines 3498, 4635). *)
+
+let test_concurrent_threads () =
+  let dir = tmpdir "system_log_atomicity" in
+  Log.Ring.init_file_sink dir;
+  let n_threads = 16 in
+  let n_records_per_thread = 500 in
+  let threads =
+    List.init n_threads (fun tid ->
+      Thread.create
+        (fun () ->
+          for seq = 0 to n_records_per_thread - 1 do
+            Log.emit
+              Log.Info
+              ~module_name:"test"
+              (Printf.sprintf
+                 "thread=%d seq=%d payload=hello-from-concurrent-writer"
+                 tid
+                 seq)
+          done)
+        ())
+  in
+  List.iter Thread.join threads;
+  (* Ring's at_exit handler flushes; force a flush via a sentinel push
+     and then re-open the file directly. *)
+  let path = today_path dir in
+  let lines = read_lines path in
+  (* Count must equal the total records.  The pre-fix race manifested
+     as fewer-than-expected lines (because some lines held two
+     records) — this assertion catches that. *)
+  check
+    int
+    "line count == threads × records"
+    (n_threads * n_records_per_thread)
+    (List.length lines);
+  (* Every line must parse: "}{"-concat fails with Yojson Extra_data. *)
+  List.iter
+    (fun line ->
+      try ignore (Yojson.Safe.from_string line)
+      with e ->
+        failf
+          "invalid JSON: %s\nline: %s"
+          (Printexc.to_string e)
+          line)
+    lines
+
+let () =
+  Alcotest.run
+    "system_log_atomicity"
+    [ "atomicity", [ test_case "16 threads × 500 records" `Quick test_concurrent_threads ] ]


### PR DESCRIPTION
## 목표
RFC-0108 (#15901) §4 의 system_log writer 마이그레이션. `}{` concat 손상의 race window 를 mutex 로 차단.

## 직접 원인 (RFC §2 Tier-0)
`lib/masc_log/log.ml:286-294` 의 `Ring.write_to_sink`:
```ocaml
output_string oc (Yojson.Safe.to_string entry_json);
output_char oc '\n';
protect ~default:() (fun () -> flush oc)
```
3 syscall + mutex 0. 2026-05-17 실측:
- `.masc/logs/system_log_2026-05-17.jsonl:3498` — `}{ ` concat
- `.masc/logs/system_log_2026-05-17.jsonl:4635` — 동일 패턴

## 변경
- `Ring.sink_mutex : Stdlib.Mutex.t` 신설 (모듈 top)
- `write_to_sink` 가 `Stdlib.Mutex.lock + (json + \"\\n\") single string + output_string + flush + unlock` 흐름. 3 syscall → 2 syscall + mutex critical section
- `Fun.protect` 로 mutex unlock 보장

## SSOT (Jsonl_atomic) 대신 in-line Stdlib.Mutex 이유
`Ring.init_file_sink` 가 `Eio_main.run` 호출 *전* 에 실행 (`bin/main_eio.ml:683`). Jsonl_atomic.open_writer 는 `~sw ~fs` 필수라 적용 불가.

대안 분석:
- **선택지 A** (이번 PR): Ring in-line Stdlib.Mutex — 1-file 변경, boot path 영향 0
- **선택지 B** (기각): init_file_sink 를 Eio_main.run 안으로 이동 → boot path 의 Log.info 호출자 구조적 조사 필요, risk 증가

선택지 A 가 race 차단 메커니즘 측면에서 RFC §3.2 보장 (Record interleave 0) 와 동등. SSOT 수렴은 trajectory + dated_jsonl PR (PR-4/PR-5) 에서 진행 — 그쪽은 모두 Eio context 안.

## 검증
새 stress 테스트 `test/test_system_log_atomicity.ml` (1 case, 1.073s pass):
```
$ dune exec --root . test/test_system_log_atomicity.exe
Testing \`system_log_atomicity\`.
  [OK]  atomicity  0   16 threads × 500 records.
Test Successful in 1.073s. 1 test run.
```

검증 포인트:
- 16 OCaml threads × 500 record 동시 `Log.emit Info ~module_name:\"test\" message`
- file sink (today's `system_log_YYYY-MM-DD.jsonl`) 재읽기
- 라인 카운트 정확히 8,000 (race 시 fewer-than-expected — `}{` 가 두 record 를 한 라인에 합치므로)
- 모든 라인 `Yojson.Safe.from_string` 통과 (race 시 Extra_data exception)

## 관련 PR
- RFC body: #15901 (RFC-0108)
- Jsonl_atomic SSOT: #15906 (별도 머지, 본 PR 은 의존 없음 — 독립 머지 가능)

## 후속 (Jsonl_atomic 사용)
- PR-4: `lib/trajectory/trajectory.ml` — Eio context 안이라 Jsonl_atomic 적용
- PR-5: `lib/dated_jsonl/dated_jsonl.ml` 내부 swap — oas-events + reaction-ledger 동시 fix

## Self-review checklist
- [x] mutex unlock 보장 (Fun.protect)
- [x] `rotate_if_needed` 가 mutex 밖에서 호출 (재귀 deadlock 회피, 주석에 명시)
- [x] `output_string` 단일 호출로 buffer 1번에 도달
- [x] boot path 호출자 (`bin/main_eio.ml:683` init_file_sink) 호환 — sw/fs 의존 없음
- [x] stress 테스트 통과 (8,000 record / 16 threads)
- [x] RFC-0108 인용 + in-line fix 사유 명시

🤖 Generated with [Claude Code](https://claude.com/claude-code)