### PR TITLE
fix(keeper): restore main server rebuild

### DIFF
--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -541,7 +541,7 @@ let apply_post_turn_lifecycle_with_resilience_handles
          compaction not applied — keeping ctx/checkpoint/metrics consistent. *)
       let effective_compaction_applied, compaction_failure_reason, effective_ctx, checkpoint =
         if not compaction_decided then (false, None, ctx, Some cp)
-        else
+        else (
           (* PR-J: lifecycle callbacks fire dispatch_keeper_phase_event,
              which can raise on transient registry contention or stale
              entry mismatches. The naked invocation here used to abort
@@ -594,6 +594,7 @@ let apply_post_turn_lifecycle_with_resilience_handles
                 ~labels:[("keeper", base_meta.name); ("phase", "compaction_save")]
                 ();
               (false, Some e, ctx, Some cp))
+        )
       in
       let after_tokens = token_count effective_ctx in
       let saved_tokens = max 0 (before_tokens - after_tokens) in


### PR DESCRIPTION
## Summary
- Closes #15915.
- Wraps the `keeper_post_turn` compaction `else` branch so `Cancel_safe.observe` and checkpoint persistence are parsed as the single else expression.
- Keeps the lifecycle recovery tuple shape intact when compaction is decided.

## Evidence
- `git diff --check`
- `env DUNE_CACHE=disabled dune build --root . --build-dir /private/tmp/masc-mcp-build-fix-main-rebuild-15915 bin/main_eio.exe -j 1 --display=short`

## Notes
- Latest `origin/main` already contains fixes for the earlier operator snapshot syntax error and the `Repo_wide_scan` shell match warning.
- This PR addresses the remaining current-main rebuild blocker that forced runtime restore onto the old 0.19.23 binary.
