### PR TITLE
feat(cancel-safe): RFC-0106 P1.d — migrate keeper_fd_pressure host probes to Cancel_safe.protect

### DIFF
--- a/lib/keeper_fd_pressure.ml
+++ b/lib/keeper_fd_pressure.ml
@@ -197,19 +197,21 @@ let reset_for_tests () =
    Stdlib.Mutex is intentional here: this helper can run before an Eio context
    exists, and the protected section is a one-shot host-limit probe. *)
 let detect_nofile_soft_limit_now () =
-  try
-    let lines, status =
-      With_process.with_process_args_in
-        "/bin/sh"
-        [| "sh"; "-c"; "ulimit -n" |]
-        With_process.drain_lines
-    in
-    match status, lines with
-    | Unix.WEXITED 0, line :: _ -> int_of_string_opt (String.trim line)
-    | _ -> None
-  with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | _ -> None
+  (* RFC-0106 P1: one-shot host-limit probe; silent _ -> None is the
+     pre-existing fallback when ulimit is unavailable.  Cancelled
+     re-raise centralised via Cancel_safe.protect. *)
+  Cancel_safe.protect
+    ~on_exn:(fun _ -> None)
+    (fun () ->
+      let lines, status =
+        With_process.with_process_args_in
+          "/bin/sh"
+          [| "sh"; "-c"; "ulimit -n" |]
+          With_process.drain_lines
+      in
+      match status, lines with
+      | Unix.WEXITED 0, line :: _ -> int_of_string_opt (String.trim line)
+      | _ -> None)
 ;;
 
 let process_nofile_soft_limit () =
@@ -283,19 +285,19 @@ let detect_darwin_system_fd_snapshot_now () =
   if not (Sys.file_exists "/System/Library/CoreServices/SystemVersion.plist")
   then None
   else
-    try
-      let lines, status =
-        With_process.with_process_args_in
-          "/usr/sbin/sysctl"
-          [| "sysctl"; "-n"; "kern.num_files"; "kern.maxfiles" |]
-          With_process.drain_lines
-      in
-      match status with
-      | Unix.WEXITED 0 -> parse_system_fd_snapshot lines
-      | _ -> None
-    with
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | _ -> None
+    (* RFC-0106 P1: darwin-only sysctl probe; silent _ -> None preserved. *)
+    Cancel_safe.protect
+      ~on_exn:(fun _ -> None)
+      (fun () ->
+        let lines, status =
+          With_process.with_process_args_in
+            "/usr/sbin/sysctl"
+            [| "sysctl"; "-n"; "kern.num_files"; "kern.maxfiles" |]
+            With_process.drain_lines
+        in
+        match status with
+        | Unix.WEXITED 0 -> parse_system_fd_snapshot lines
+        | _ -> None)
 ;;
 
 let detect_system_fd_snapshot_now () =


### PR DESCRIPTION
## Summary

Fourth Phase 1 migration of RFC-0106, **completing the original 4-subsystem set** (process / transport / sandbox-shell / fd accountant).

Migrates two option-returning host-limit probes in `lib/keeper_fd_pressure.ml`:

- `detect_nofile_soft_limit_now` (line 199) — `ulimit -n` probe
- `detect_darwin_system_fd_snapshot_now` (line 282) — Darwin `sysctl kern.num_files` probe

Both used the canonical paired-arm shape `try ... with | Cancelled _ -> raise | _ -> None` now routed via `Cancel_safe.protect ~on_exn:(fun _ -> None)`.

## Important: `process_nofile_soft_limit` deliberately NOT migrated

Lines 215-235 have a *Cancelled-side-effect* shape:

```ocaml
try
  let detected = detect_nofile_soft_limit_now () in
  Atomic.set nofile_soft_limit_cache (Resolved detected);
  detected
with
| Eio.Cancel.Cancelled _ as exn ->
  Atomic.set nofile_soft_limit_cache Uninitialized;
  raise exn
```

The Cancelled arm performs **cache-state cleanup before re-raising** — intentional invariant preservation (cache must not stay `In_flight` after cancellation). `Cancel_safe.protect` re-raises Cancelled without invoking `on_exn`, so this site cannot use the helper as-is.

Adding a `~on_cancel` hook to run cleanup before re-raise is a Phase 2 RFC concern (separate spec needed). For now, this site stays manual with an explicit comment.

## Build

`dune build @check` PASS. Net +2 LoC (RFC-0106 inline references).

## Subsystem coverage (4/4 of RFC-0106 §3.3 P1 set)

| Phase | Subsystem | PR | State |
|---|---|---|---|
| Spec | RFC body | #15894 | MERGED |
| P0 | canary (keeper post_turn) | #15904 | MERGED |
| P1.a | process (bg_task) | #15917 | MERGED |
| P1.b | transport (http_respond) | #15919 | MERGED |
| P1.c | sandbox/shell | #15920 | MERGED |
| **P1.d** | **fd accountant** | **this** | Draft |

## Anti-pattern self-check (7/7)

- [x] Not telemetry-as-fix — behaviour preserved
- [x] No string classifier
- [x] Not N-of-M — 2 sites migrated, 1 deferred with explicit cleanup-shape reason; PR body documents the boundary
- [x] No new catch-all
- [x] No magic number / test backdoor / N-times-typo fix

## Next steps (subsequent P1 PRs, not this one)

- Remaining `lib/server/server_mcp_transport_http*.ml` paired-arm sites (~27 across 5 files)
- Additional `lib/keeper/` sites that fit `protect`/`observe` (excluding cleanup-shape sites)
- Phase 2 ppxlib AST lint (separate RFC-0106 §3.3 step)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>