### PR TITLE
fix(dated_jsonl): per-path mutex + fresh fd for JSONL appends (RFC-0108) (Draft)

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -253,6 +253,62 @@ let prune_unlocked t ~days =
 
 (* ── Public API ───────────────────────────────────────── *)
 
+(* RFC-0108: in-line per-path Stdlib.Mutex + fresh fd open/close on
+   every append.  Replaces the prior [Fs_compat.append_jsonl] path
+   whose LRU [Append_fd_cache] shared one [out_channel] across all
+   callers/domains; observed 2026-05-17 as 38 line-tear / "}{"-concat
+   failures in [.masc/oas-events/2026-04/22.jsonl] (12), [23.jsonl]
+   (4), [24.jsonl] (2), [25.jsonl] (20), plus 114 utf-8 multibyte
+   tears in [keepers/*/reaction-ledger/2026-05/17.jsonl] (11 files).
+
+   Same hypothesis as RFC-0108 PR-4 (lib/trajectory/trajectory.ml):
+   OCaml [out_channel] buffer state is not domain-safe, so the
+   Append_fd_cache mutex protected the cache lookup but not the
+   buffer mutations from concurrent domains writing through the same
+   cached channel.  Fresh fd per call sidesteps that entirely.
+
+   The pre-existing [Eio.Mutex.use_ro] still wraps this body so
+   fiber-level serialization plus retention-prune ordering are
+   preserved.  The new per-path Stdlib.Mutex registry is a second
+   line of defence and the actual cross-domain barrier: it lives in
+   this module so it does not share state with Fs_compat. *)
+let path_mutex_registry : (string, Stdlib.Mutex.t) Hashtbl.t =
+  Hashtbl.create 16
+let path_mutex_registry_mu = Stdlib.Mutex.create ()
+
+let get_path_mutex path =
+  Stdlib.Mutex.lock path_mutex_registry_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock path_mutex_registry_mu)
+    (fun () ->
+      match Hashtbl.find_opt path_mutex_registry path with
+      | Some m -> m
+      | None ->
+        let m = Stdlib.Mutex.create () in
+        Hashtbl.add path_mutex_registry path m;
+        m)
+
+let atomic_append_jsonl path json =
+  let line = Yojson.Safe.to_string json ^ "\n" in
+  (* Ensure parent directory exists. mkdir_p is a no-op when already
+     present; we cannot rely on [today_path]'s caller to have created
+     the YYYY-MM dir on first use. *)
+  Fs_compat.mkdir_p (Filename.dirname path);
+  let mu = get_path_mutex path in
+  Stdlib.Mutex.lock mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock mu)
+    (fun () ->
+      let oc =
+        Stdlib.open_out_gen
+          [ Stdlib.Open_append; Stdlib.Open_creat; Stdlib.Open_wronly ]
+          0o644
+          path
+      in
+      Fun.protect
+        ~finally:(fun () -> Stdlib.close_out_noerr oc)
+        (fun () -> Stdlib.output_string oc line))
+
 let append t json =
   let mutex = Atomic.get t.mutex in
   (* [use_ro] serializes file appends without poisoning the shared mutex on
@@ -260,7 +316,7 @@ let append t json =
      [use_rw] would poison on any exception regardless of [~protect]. *)
   Eio.Mutex.use_ro mutex (fun () ->
     let path = today_path t in
-    Fs_compat.append_jsonl path json;
+    atomic_append_jsonl path json;
     match t.retention_days with
     | None -> ()
     | Some days ->


### PR DESCRIPTION
## 목표
RFC-0108 §4 PR-5 (마지막). `Dated_jsonl.append` 내부에서 `Fs_compat.append_jsonl` → in-line per-path Stdlib.Mutex + fresh fd 로 swap. oas-events + reaction-ledger 두 카테고리를 동시에 fix (둘 다 같은 코드 path).

## 손상 evidence (2026-05-17)
- `.masc/oas-events/2026-04/22.jsonl` — 12 lines (`}{` concat + `Invalid \\escape`)
- `.masc/oas-events/2026-04/23.jsonl` — 4 lines
- `.masc/oas-events/2026-04/24.jsonl` — 2 lines
- `.masc/oas-events/2026-04/25.jsonl` — 20 lines
- `.masc/keepers/*/reaction-ledger/2026-05/17.jsonl` — 114 utf-8 multibyte tears across 11 files

## 변경
- `Dated_jsonl.path_mutex_registry : (string, Stdlib.Mutex.t) Hashtbl.t` 신설 (per-path mutex, module-local)
- `Dated_jsonl.atomic_append_jsonl path json` 헬퍼: per-path mutex + `open_out_gen` fresh fd + `output_string` + `close_out_noerr`
- `Dated_jsonl.append` 본문에서 `Fs_compat.append_jsonl path json` → `atomic_append_jsonl path json` swap
- 기존 `Eio.Mutex.use_ro` wrapper 그대로 유지 (fiber-level + retention-prune ordering 보존)
- caller signature 변경 0 — pure internal swap

## 진단 (RFC §2 + PR-4 hypothesis 동일)
PR-4 #15926 와 같은 hypothesis: OCaml `out_channel` buffer 가 도메인-safe 가 아니고 `Append_fd_cache` 의 cache 공유가 cross-domain race. Fresh fd per call 이 그 surface 차단.

## 검증 (regression 0)
```
$ dune exec --root . test/test_dated_jsonl.exe
... [17 OK] ...
Test Successful in 0.114s. 17 tests run.

$ dune exec --root . test/test_dated_jsonl_mutex_registry_10372.exe
... [6 OK] ...
Test Successful in 0.093s. 6 tests run.
```

기존 17 + 6 = 23 cases 모두 통과 (concurrent append + mutex registry identity + retention prune 등). Race 차단 mechanism 은 PR-4 #15926 의 `test_trajectory_atomicity` (16 threads × 100 multibyte records → 0 malformed) 가 같은 코드 패턴으로 입증.

## 자매 PR
- RFC body (merged): #15901
- Jsonl_atomic SSOT (merged): #15906
- system_log mutex (merged): #15922
- trajectory mutex (Draft): #15926

이 PR-5 머지 시 4 카테고리 손상 source 모두 차단 완료 — RFC-0108 §5 verification gate 만 남음.

## 후속 (architectural cleanup)
- 본 PR + PR-4 의 in-line mutex 패턴이 *trajectory.ml + dated_jsonl.ml* 에 중복. 공통 helper module (`lib/jsonl_sync/` 또는 lib/jsonl_atomic 의 sync API 확장) 로 추출 가능. 별도 PR.
- `Fs_compat.append_jsonl` deprecate — 본 PR 머지 후 caller 0 일 가능성. grep 후 별도 PR로 제거.

## Self-review checklist
- [x] caller signature 변경 없음 — drop-in 호환
- [x] Eio.Mutex.use_ro wrapper 보존 (retention-prune ordering 안전)
- [x] per-path Stdlib.Mutex registry 모듈 local (Fs_compat 와 격리)
- [x] Fun.protect 로 mutex unlock + fd close 보장
- [x] 기존 23 test regression 0
- [x] mkdir_p 로 first-use 시 YYYY-MM 디렉토리 자동 생성 (이전 Fs_compat.append_file 가 해주던 부분 보존)
- [x] RFC-0108 §3.2 보장 (Record interleave 0, partial-write 0) 달성

🤖 Generated with [Claude Code](https://claude.com/claude-code)