### PR TITLE
fix(ci): fail draft guard for all draft PRs

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -241,10 +241,12 @@ jobs:
               action === "ready_for_review" ||
               action === "auto_merge_enabled";
             // Keep the required Draft Auto-Merge Guard context red for
-            // agent-like PRs until a verified human approval label exists.
+            // every draft PR and agent-like PR until a verified human
+            // approval label exists.
             // A green draft-only check can be reused by a later ready/merge
             // race before the boundary event has a chance to fail closed.
             const approvalRequired =
+              current.isDraft ||
               looksAgentAuthored ||
               unsafeDraftBoundaryAction ||
               hasAutoMergeRequest ||

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -355,9 +355,9 @@ let test_pr_automation_draft_guard_contracts () =
   check bool "draft-only state does not suppress missing approval" true
     (file_not_contains_pattern ".github/workflows/pr-automation.yml"
        "(!safeDraftOnlyState &&");
-  check bool "agent-like PRs always require verified approval" true
+  check bool "draft PRs always require verified approval" true
     (file_contains_pattern ".github/workflows/pr-automation.yml"
-       "const approvalRequired =\n              looksAgentAuthored ||\n              unsafeDraftBoundaryAction ||\n              hasAutoMergeRequest ||");
+       "const approvalRequired =\n              current.isDraft ||\n              looksAgentAuthored ||\n              unsafeDraftBoundaryAction ||\n              hasAutoMergeRequest ||");
   check bool "pr automation has hard-stop label policy" true
     (file_contains_pattern ".github/workflows/pr-automation.yml"
        "hard-stop label present");


### PR DESCRIPTION
Fixes #15897.

## Summary
- keep Draft Auto-Merge Guard red for every draft PR until verified human approval exists
- update source guard ratchet so current.isDraft stays in approvalRequired

## Verification
- git diff --check origin/main...HEAD
- ocamlformat --check test/test_ci_hardening_source.ml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-automation.yml")'
- scripts/dune-local.sh build test/test_ci_hardening_source.exe
- _build/default/test/test_ci_hardening_source.exe test --quick-tests --compact --show-errors source_guard 2