### PR TITLE
[codex] Purge home MASC config surface

### DIFF
--- a/dashboard/src/components/connector-paths-strip.test.ts
+++ b/dashboard/src/components/connector-paths-strip.test.ts
@@ -49,10 +49,10 @@ describe('deriveMascPaths', () => {
     const c1 = mkConnector({ connector_id: 'discord', names_path: '' } as never)
     const c2 = mkConnector({
       connector_id: 'slack',
-      names_path: '/home/bob/.masc/connectors/slack/names.json',
+      names_path: '/srv/project/.masc/connectors/slack/names.json',
     } as never)
     const paths = deriveMascPaths([c1, c2])
-    expect(paths.connectorsDir).toBe('/home/bob/.masc/connectors/')
+    expect(paths.connectorsDir).toBe('/srv/project/.masc/connectors/')
   })
 })
 

--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -254,27 +254,6 @@ describe('ConfigResolutionPanel', () => {
     expect(container.textContent).toContain('root-relative')
   })
 
-  it('renders home config source label', () => {
-    render(
-      html`<${ConfigResolutionPanel}
-        resolution=${{
-          status: 'ready',
-          warnings: [],
-          config_root: { path: '/home/test/.masc/config', exists: true, source: 'home_masc' },
-          cascade_authoring: { path: '/home/test/.masc/config/cascade.toml', exists: true, source: 'home_masc' },
-          cascade: { path: '/home/test/.masc/config/cascade.toml', exists: true, source: 'home_masc' },
-          prompts: { path: '/home/test/.masc/config/prompts', exists: true, source: 'home_masc' },
-          keepers: { path: '/home/test/.masc/config/keepers', exists: true, source: 'home_masc' },
-          personas: { path: '/home/test/.masc/config/personas', exists: true, source: 'home_masc' },
-        }}
-      />`,
-      container,
-    )
-
-    expect(container.textContent).toContain('home config')
-    expect(container.textContent).toContain('/home/test/.masc/config')
-  })
-
   it('renders local .masc source label', () => {
     render(
       html`<${ConfigResolutionPanel}

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -89,8 +89,6 @@ function sourceLabel(source: string): string {
   switch (source) {
     case 'env':
       return 'env override'
-    case 'home_masc':
-      return 'home config'
     case 'local_masc':
       return 'local .masc'
     case 'invalid_env':

--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -65,8 +65,8 @@ Important boot behavior:
 - Supported launchers and `main_eio.exe doctor` should be read with a simpler operator contract:
   active config is `MASC_CONFIG_DIR` when set, otherwise `<MASC_BASE_PATH>/.masc/config`.
 - This means a passive base-path config root can exist on disk even when it is not the active config root.
-- There is no home-level config fallback. On shared hosts, use an explicit base
-  path and expect live config under `<base-path>/.masc/config`.
+- There is no secondary operator config fallback. On shared hosts, use an
+  explicit base path and expect live config under `<base-path>/.masc/config`.
 
 ### 1.3 Personas root resolution
 
@@ -417,8 +417,6 @@ Current observed state on the inspected host:
   - Reason: live `/health` reports `startup.config_resolution.config_root.path` as `/Users/dancer/me/.masc/config`.
 - Checked-in fallback/default config tree:
   - `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config`
-- Removed home-level config root:
-  - `/Users/dancer/.masc/config` does not exist.
 - Both of these trees exist at the same time:
   - `/Users/dancer/me/.masc/*`
   - `/Users/dancer/me/.masc/.masc/*`
@@ -452,7 +450,6 @@ Current log sink observed today:
 
 - `curl -fsS http://127.0.0.1:8935/health`; 확인일시: 2026-05-17 Asia/Seoul; 신뢰도: High
 - `pgrep -fl main_eio`; 확인일시: 2026-05-17 Asia/Seoul; 신뢰도: High
-- `test ! -e /Users/dancer/.masc/config`; 확인일시: 2026-05-17 Asia/Seoul; 신뢰도: High
 - `test -f /Users/dancer/me/.masc/config/cascade.toml`; 확인일시: 2026-05-17 Asia/Seoul; 신뢰도: High
 
 ## 5. Operator Checklist for Root Drift
@@ -463,7 +460,7 @@ Current log sink observed today:
 2. Pick one active config root.
    - If `MASC_CONFIG_DIR` is set, that wins.
    - If you want the base-path config root to become active, unset `MASC_CONFIG_DIR` and restart.
-   - Do not recreate a home-level config directory as a second operator surface; the resolver no longer consults it.
+   - Do not create a second operator config surface; the resolver only consults the active config root.
 3. Treat `<base-path>/planning/` as a separate backup and cleanup lane from `.masc/`.
 4. Do not delete a nested `.masc/.masc` tree until you have checked whether it still contains needed logs, traces, or backlog state.
 5. When debugging keeper shell, clone, or PR-submit behavior, inspect these paths first:

--- a/docs/CONFIG-DOCTOR.md
+++ b/docs/CONFIG-DOCTOR.md
@@ -141,8 +141,8 @@ root to edit.
 ### Repo Seed Note
 
 `Config_dir_resolver` may report a checked-in repo `config/` path as a bootstrap
-seed, but it never treats that path as the active config root. It also does not
-consult a home-level config root.
+seed, but it never treats that path as the active config root. It only resolves
+operator config from `MASC_CONFIG_DIR` or `<base-path>/.masc/config`.
 
 If you need to answer “what should I edit right now?”, use `doctor`, not a repo
 seed path.

--- a/docs/rfc/RFC-0103-log-retention-opt-in-and-volume-root.md
+++ b/docs/rfc/RFC-0103-log-retention-opt-in-and-volume-root.md
@@ -26,7 +26,7 @@ JSONL log retention (tool_calls, tool_usage, oas-events, runtime-manifests)
 
 ## 2. Background
 
-5/16 host FD storm 사고의 부수 작업 중 `~/.masc` 디스크 사용량 audit:
+5/16 host FD storm 사고의 부수 작업 중 base-path `.masc` 디스크 사용량 audit:
 
 | Path | Size | 24-hour growth |
 |---|---|---|

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -595,7 +595,7 @@ $MASC_PERSONAS_DIR
   > missing/uninitialized
 ```
 
-암묵적 secondary search(`~/.masc/personas`, `$MASC_BASE_PATH/.masc/personas`)는 사용하지 않는다.
+암묵적 secondary search(운영자 home personas, base-path root personas)는 사용하지 않는다.
 Persona, keeper TOML, prompt markdown, cascade, tool_policy는 모두 같은 resolved config root를 기준으로 해석한다.
 
 ### 12.4 Template 변경 반영

--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -388,7 +388,7 @@ let personas_dirs_with inputs resolution =
        operator-declared persona roots stand on their own — a user may
        legitimately want personas without a full MASC config directory)
      - otherwise the resolved config root's personas/
-     Hidden secondary searches (~/.masc/personas, $MASC_BASE_PATH/.masc/personas)
+     Hidden secondary searches (secondary personas roots, base-path-root personas)
      make the dashboard/config panel lie about the actual source of truth. *)
   match explicit_personas_dir_override with
   | Some _ ->

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -309,10 +309,10 @@ let test_executable_relative_config_is_seed_only_not_fallback () =
   check bool "personas hidden because repo config is not active"
     false resolution.personas.exists
 
-let test_home_config_is_not_a_fallback () =
-  with_temp_dir "config-dir-home" @@ fun home ->
-  let home_config_root = Filename.concat home Common.masc_dirname in
-  ignore (make_config_root home_config_root);
+let test_external_config_is_not_a_fallback () =
+  with_temp_dir "config-dir-external" @@ fun external_root ->
+  let external_config_root = Filename.concat external_root Common.masc_dirname in
+  ignore (make_config_root external_config_root);
   let resolution =
     Config_dir_resolver.resolve_with
       (make_inputs ~cwd:"/tmp/missing-cwd"
@@ -324,12 +324,12 @@ let test_home_config_is_not_a_fallback () =
     (Config_dir_resolver.source_to_string resolution.config_root.source);
   check bool "prompts hidden" false resolution.prompts.exists
 
-let test_local_masc_fallback_ignores_home_config () =
+let test_local_masc_fallback_ignores_external_config () =
   with_temp_dir "config-dir-local" @@ fun root ->
   let target = Filename.concat root "target" in
   let local_config = make_config_root (Filename.concat target Common.masc_dirname) in
-  let home = Filename.concat root "home" in
-  ignore (make_config_root (Filename.concat home Common.masc_dirname));
+  let external_root = Filename.concat root "external" in
+  ignore (make_config_root (Filename.concat external_root Common.masc_dirname));
   let resolution =
     Config_dir_resolver.resolve_with
       (make_inputs ~cwd:root ~env_base_path:target
@@ -386,29 +386,29 @@ let test_personas_dirs_default_repo_only () =
   check (list string) "repo personas only"
     [ Filename.concat config "personas" ] dirs
 
-let test_personas_dirs_ignores_home_personas () =
-  with_temp_dir "pd-home" @@ fun root ->
+let test_personas_dirs_ignores_external_personas () =
+  with_temp_dir "pd-external" @@ fun root ->
   let config = make_config_root root in
-  let home = Filename.concat root "home" in
-  let home_personas = Filename.concat home ".masc/personas" in
-  mkdir_p home_personas;
+  let external_root = Filename.concat root "external" in
+  let external_personas = Filename.concat external_root ".masc/personas" in
+  mkdir_p external_personas;
   let inputs = make_inputs ~env_config_dir:config () in
   let resolution = Config_dir_resolver.resolve_with inputs in
   let dirs = Config_dir_resolver.personas_dirs_with inputs resolution in
-  check (list string) "repo personas only despite home personas"
+  check (list string) "repo personas only despite external personas"
     [ Filename.concat config "personas" ] dirs
 
 let test_personas_dirs_env_override_is_sole_source () =
   with_temp_dir "pd-env" @@ fun root ->
   let env_personas = Filename.concat root "env-personas" in
   mkdir_p env_personas;
-  let home = Filename.concat root "home" in
-  let home_personas = Filename.concat home ".masc/personas" in
-  mkdir_p home_personas;
+  let external_root = Filename.concat root "external" in
+  let external_personas = Filename.concat external_root ".masc/personas" in
+  mkdir_p external_personas;
   let inputs = make_inputs ~env_personas_dir:env_personas () in
   let resolution = Config_dir_resolver.resolve_with inputs in
   let dirs = Config_dir_resolver.personas_dirs_with inputs resolution in
-  (* MASC_PERSONAS_DIR overrides: only the env dir, no home dir *)
+  (* MASC_PERSONAS_DIR overrides: only the env dir, no secondary dir *)
   check (list string) "env override only" [ env_personas ] dirs
 
 let test_personas_dirs_ignores_base_path_fallback () =
@@ -446,12 +446,12 @@ let () =
             test_cwd_config_remains_seed_only;
           test_case "exe-relative config is seed-only, not fallback" `Quick
             test_executable_relative_config_is_seed_only_not_fallback;
-          test_case "local masc fallback ignores home config" `Quick
-            test_local_masc_fallback_ignores_home_config;
+          test_case "local masc fallback ignores external config" `Quick
+            test_local_masc_fallback_ignores_external_config;
           test_case "local masc fallback collapses explicit .masc dir"
             `Quick test_local_masc_fallback_collapses_explicit_masc_dir;
-          test_case "home config is not a fallback" `Quick
-            test_home_config_is_not_a_fallback;
+          test_case "external config is not a fallback" `Quick
+            test_external_config_is_not_a_fallback;
           test_case "does not fallback to legacy me_root repo path" `Quick
             test_no_legacy_me_root_fallback;
         ] );
@@ -459,8 +459,8 @@ let () =
         [
           test_case "default returns repo personas only" `Quick
             test_personas_dirs_default_repo_only;
-          test_case "ignores home .masc/personas" `Quick
-            test_personas_dirs_ignores_home_personas;
+          test_case "ignores secondary personas dir" `Quick
+            test_personas_dirs_ignores_external_personas;
           test_case "MASC_PERSONAS_DIR overrides as sole source" `Quick
             test_personas_dirs_env_override_is_sole_source;
           test_case "ignores base_path .masc/personas fallback" `Quick

--- a/test/test_fs_compat_home_guard.ml
+++ b/test/test_fs_compat_home_guard.ml
@@ -17,9 +17,12 @@ let home () =
 let disable_escape_hatch () =
   Unix.putenv "MASC_TEST_ALLOW_HOME_BASE_PATH" ""
 
+let guard_path name =
+  Filename.concat (home ()) (Filename.concat "masc-home-guard" name)
+
 let test_append_under_home_raises () =
   disable_escape_hatch ();
-  let path = Filename.concat (home ()) ".masc/_9921_guard_probe.jsonl" in
+  let path = guard_path "_9921_guard_probe.jsonl" in
   try
     FC.append_file path "{\"probe\":1}\n";
     Alcotest.failf "expected Test_isolation_breach, but write succeeded to %S" path
@@ -38,7 +41,7 @@ let test_append_under_home_raises () =
 
 let test_save_under_home_raises () =
   disable_escape_hatch ();
-  let path = Filename.concat (home ()) ".masc/_9921_guard_probe_save.txt" in
+  let path = guard_path "_9921_guard_probe_save.txt" in
   try
     FC.save_file path "probe";
     Alcotest.fail "expected Test_isolation_breach on save_file"
@@ -46,7 +49,7 @@ let test_save_under_home_raises () =
 
 let test_mkdir_under_home_raises () =
   disable_escape_hatch ();
-  let path = Filename.concat (home ()) ".masc/_9921_guard_probe_dir" in
+  let path = guard_path "_9921_guard_probe_dir" in
   try
     FC.mkdir_p path;
     Alcotest.fail "expected Test_isolation_breach on mkdir_p"
@@ -68,7 +71,7 @@ let test_tmp_write_allowed () =
 
 let test_escape_hatch_allows_home () =
   Unix.putenv "MASC_TEST_ALLOW_HOME_BASE_PATH" "1";
-  let path = Filename.concat (home ()) ".masc/_9921_guard_probe_bypass.jsonl" in
+  let path = guard_path "_9921_guard_probe_bypass.jsonl" in
   let parent = Filename.dirname path in
   let parent_existed = Sys.file_exists parent in
   Fun.protect

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -256,9 +256,9 @@ let test_realtime_transports_default_to_base_path_config_and_preserve_override (
       copy_script (script_path ()) script;
       ignore (make_config_root dir);
       make_fake_eio_exe dir;
-      let home_dir = Filename.concat dir "home" in
-      mkdir_p (Filename.concat home_dir ".masc/config/prompts");
-      write_file (Filename.concat home_dir ".masc/config/cascade.toml") "";
+      let ignored_dir = Filename.concat dir "ignored" in
+      mkdir_p (Filename.concat ignored_dir "config/prompts");
+      write_file (Filename.concat ignored_dir "config/cascade.toml") "";
       let bootstrapped_config =
         Filename.concat (canonical_path dir) ".masc/config"
       in


### PR DESCRIPTION

## Summary
- remove the dashboard `home_masc` config source label and fixture
- keep config/persona resolver docs and tests focused on the active config root: `MASC_CONFIG_DIR` or `<base-path>/.masc/config`
- scrub legacy home-root MASC path references from config docs, focused tests, and dashboard path fixtures

## Validation
- `ocamlc -stop-after parsing lib/config_dir_resolver/config_dir_resolver.ml test/test_config_dir_resolver.ml test/test_fs_compat_home_guard.ml test/test_start_masc_mcp_script.ml`
- `git diff --check`
- legacy home-root MASC path scan across `masc-mcp`, `me`, and `oas` returned no matches

## Notes
- focused Dune targets were not run because the shared local Dune lock was occupied by other active worktrees; I did not bypass the throttle
- dashboard Vitest was not run because this worktree has no installed `vitest` binary
