### PR TITLE
feat(eio_context): RFC-0107 Phase C.1 — turn-scoped fiber-local Switch wiring

### DIFF
--- a/lib/eio_context/eio_context.ml
+++ b/lib/eio_context/eio_context.ml
@@ -23,6 +23,17 @@ let current_sw : Eio.Switch.t option Atomic.t = Atomic.make None
 let net_initialized : bool Atomic.t = Atomic.make false
 let with_test_env_lock = Eio.Mutex.create ()
 
+(* RFC-0107 §3.3 / audit §10.5 — fiber-local turn switch.
+   Phase C.1 wiring: [keeper_agent_run.run_turn] wraps its body with
+   [with_turn_switch turn_sw]; reads of [get_switch_opt] from within
+   that scope (and forked children) return turn_sw, while reads from
+   outside (server/dashboard fibers — see audit §2.1, §10.2) fall
+   through to the global atomic [current_sw] = server root_sw.
+
+   Created once at module init via [Eio.Fiber.create_key]; the key
+   identity is what [with_binding] / [get] use to look up the value. *)
+let sw_key : Eio.Switch.t Eio.Fiber.key = Eio.Fiber.create_key ()
+
 let snapshot_state () =
   {
     net = Atomic.get current_net;
@@ -60,6 +71,20 @@ let get_mono_clock_opt () =
 let set_switch sw =
   Atomic.set current_sw (Some sw)
 
+(* RFC-0107 §3.3 wiring — bind a turn-scoped switch on the *current fiber*
+   (and all children forked inside [f]). On exit the binding is removed,
+   so subsequent fibers in the parent see the previous binding (or [None]).
+
+   Distinct from [set_switch] which writes the global atomic: this one is
+   fiber-local and *propagates with fork* (Eio.Fiber.with_binding contract),
+   so cascade attempts forked from inside [f] inherit [sw] automatically.
+
+   Caller contract: invoke from *inside* the body of an outer
+   [Eio.Switch.run] whose switch is [sw], so resources opened during [f]
+   that read [get_switch_opt ()] attach to [sw] and are released when the
+   outer switch closes. *)
+let with_turn_switch sw f = Eio.Fiber.with_binding sw_key sw f
+
 let with_test_env ~net ~clock ~mono_clock ~sw f =
   (* Test bodies may deliberately raise [Alcotest.Skip] or fail assertions.
      The state is restored in [finally], so use the non-poisoning lock helper:
@@ -82,7 +107,25 @@ let get_clock_opt () =
   Atomic.get current_clock
 
 let get_switch_opt () =
-  Atomic.get current_sw
+  (* RFC-0107 §3.3 / audit §10.5 — fiber-local first, then atomic fallback.
+
+     - Inside [with_turn_switch] (keeper_agent_run.run_turn body): returns
+       the turn_sw → resources opened during the turn attach to turn_sw
+       and are released when the turn ends.
+     - Outside any binding (server/dashboard fibers, bootstrap path —
+       audit §10.2, §10.6): returns the global atomic = server root_sw
+       → long-lived resources (gRPC heartbeat, dashboard fibers) survive
+       turn boundaries as intended.
+
+     [Eio.Fiber.get] raises if called outside any Eio fiber context
+     (e.g. test setup before [Eio_main.run]). In that case there is no
+     fiber-local state to consult, so we fall through to the atomic. *)
+  let from_fiber =
+    try Eio.Fiber.get sw_key with _ -> None
+  in
+  match from_fiber with
+  | Some _ as some_sw -> some_sw
+  | None -> Atomic.get current_sw
 
 let get_net () : (eio_net, string) result =
   match Atomic.get current_net with
@@ -100,7 +143,7 @@ let get_clock () : (float Eio.Time.clock_ty Eio.Resource.t, string) result =
       Error "Eio clock not initialized - ensure set_clock is called during server startup"
 
 let get_switch () : (Eio.Switch.t, string) result =
-  match Atomic.get current_sw with
+  match get_switch_opt () with
   | Some sw -> Ok sw
   | None ->
       Error "Eio switch not initialized - ensure set_switch is called during server startup"

--- a/lib/eio_context/eio_context.mli
+++ b/lib/eio_context/eio_context.mli
@@ -21,7 +21,23 @@ val get_mono_clock_opt : unit -> Eio.Time.Mono.ty Eio.Resource.t option
 (** Get the global Eio monotonic clock if available. *)
 
 val set_switch : Eio.Switch.t -> unit
-(** Set the global Eio switch. *)
+(** Set the global Eio switch (server root_sw). Written once at server
+    bootstrap; survives until process exit. *)
+
+val with_turn_switch : Eio.Switch.t -> (unit -> 'a) -> 'a
+(** [with_turn_switch sw f] binds [sw] as the turn-scoped switch on the
+    *current fiber* and any fibers forked from inside [f]. Reads of
+    [get_switch_opt] / [get_switch] from within that scope return [sw];
+    reads from outside the binding (server, dashboard, bootstrap fibers)
+    fall through to the global atomic set by [set_switch] (= server
+    root_sw).
+
+    Used by [keeper_agent_run.run_turn] to constrain resources opened
+    during a single turn to that turn's lifetime: when the outer
+    [Eio.Switch.run] closes, those resources are released, preventing
+    the FD accumulation observed in the 2026-05-16 ENFILE storm.
+
+    Reference: RFC-0107 §3.3, audit §10.5. *)
 
 val with_test_env :
   net:[> `Network | `Platform of [> `Generic | `Unix ]] Eio.Resource.t ->

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -256,6 +256,25 @@ let run_turn
   in
   Eio_guard.protect ~finally:safe_emit_turn_end
   @@ fun () ->
+  (* RFC-0107 §3.3 Phase C.1 wiring — turn-scoped Eio.Switch.
+     Resources opened during a turn (HTTP connections, sandbox exec
+     handles, retry sub-tasks via [Keeper_turn_driver_try_provider])
+     that read [Eio_context.get_switch_opt ()] now attach to [turn_sw],
+     not the server root_sw. When this [Eio.Switch.run] closes (turn
+     end, success or cancellation), those resources are released —
+     bounding per-turn FD growth.
+
+     Server/dashboard fibers that read [get_switch_opt] from *outside*
+     this binding are unaffected (audit §10.2): they have no
+     [Eio.Fiber] binding for [sw_key], so [get_switch_opt] falls
+     through to the global atomic = server root_sw.
+
+     The [with_turn_switch] binding propagates with [Eio.Fiber.fork]
+     children, so cascade attempts and tool invocations spawned inside
+     the turn body all see [turn_sw] automatically. *)
+  Eio.Switch.run @@ fun turn_sw ->
+  Eio_context.with_turn_switch turn_sw
+  @@ fun () ->
   let cascade_name_string = Keeper_cascade_profile.runtime_name_to_string cascade_name in
   (* Steps 0–4: inference params, session dir, checkpoint, base prompt,
      working context, checkpoint hygiene — all in Keeper_run_context. *)

--- a/specs/keeper-switch-hierarchy/KeeperFiberLocalSwitch-buggy.cfg
+++ b/specs/keeper-switch-hierarchy/KeeperFiberLocalSwitch-buggy.cfg
@@ -1,0 +1,29 @@
+\* Buggy model for KeeperFiberLocalSwitch.
+\* Expected: SafetyInvariant violated (specifically ServerResourcesOnRoot).
+\*
+\* Models a hypothetical world where audit §10.2 stops holding —
+\* server_binding is allowed to acquire "turn_sw" via ServerBindingLeak.
+\* A subsequent ServerForkDuringTurn would then attach to turn_sw,
+\* resurrecting the §5 race that Option 3 was designed to prevent.
+\*
+\* TLC must produce a counter-example trace:
+\*   1. KeeperStartTurn      → keeper_binding = "turn_sw"
+\*   2. ServerBindingLeak    → server_binding = "turn_sw"  (bug)
+\*   3. ServerForkDuringTurn → server resource attached to "turn_sw"
+\*                             → ServerResourcesOnRoot VIOLATED
+\*
+\* Acts as a regression sentinel: if a future refactor introduces a
+\* path that leaks turn binding into server fibers, this cfg fails
+\* fast and points exactly at the audit §10.2 invariant.
+
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    MaxTurns = 2
+    MaxResources = 2
+
+INVARIANTS
+    SafetyInvariant
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/keeper-switch-hierarchy/KeeperFiberLocalSwitch.cfg
+++ b/specs/keeper-switch-hierarchy/KeeperFiberLocalSwitch.cfg
@@ -1,0 +1,27 @@
+\* Clean model for KeeperFiberLocalSwitch (Option 3).
+\* Expected: Model checking completed. No error has been found.
+\*
+\* This is the proof that Option 3 is race-free under the SAME concurrent
+\* scenarios that broke Option 2 (KeeperSwitchHierarchy-buggy.cfg). The
+\* clean Next here INCLUDES ServerForkDuringTurn — the action that broke
+\* Phase C.0's Option 2 model. Under Option 3:
+\*   - server_binding stays "none" (audit §10.2)
+\*   - get_switch_opt for server falls through to atomic = root_sw
+\*   - server resource attaches to root_sw, not turn_sw
+\*   - safety invariant holds
+\*
+\* TLC must explore ServerForkDuringTurn states and NOT find a violation.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    MaxTurns = 2
+    MaxResources = 2
+
+INVARIANTS
+    TypeOK
+    SafetyInvariant
+    ServerBindingAlwaysNone
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/keeper-switch-hierarchy/KeeperFiberLocalSwitch.tla
+++ b/specs/keeper-switch-hierarchy/KeeperFiberLocalSwitch.tla
@@ -1,0 +1,244 @@
+---- MODULE KeeperFiberLocalSwitch ----
+\* RFC-0107 Phase C.1 — Eio.Fiber.with_binding (Option 3) race-freedom proof.
+\*
+\* Companion to KeeperSwitchHierarchy.tla (Phase C.0, Option 2 model).
+\* Where the Phase C.0 spec proved that Option 2 (atomic swap) is UNSAFE
+\* under ServerForkDuringTurn, this spec proves that Option 3 (fiber-local
+\* binding) is SAFE under the SAME race scenario — PROVIDED the audit §10.2
+\* structural separation invariant holds: server fibers have no fiber-local
+\* binding for sw_key.
+\*
+\* Runtime truth being modelled:
+\*   - Each FIBER has its own fiber-local binding state (None or Some sw_id).
+\*   - get_switch_opt logic:
+\*       Fiber.get sw_key  OR  Atomic.get current_sw
+\*     i.e. fiber-local first, atomic fallback.
+\*   - server fibers DO NOT call with_turn_switch → their binding stays None.
+\*     Reads always go to the atomic = server root_sw. (audit §10.2.)
+\*   - keeper fibers DO call with_turn_switch → their binding = turn_sw
+\*     during the turn body. Reads return turn_sw. After with_turn_switch
+\*     exits, the binding returns to None (Eio.Fiber.with_binding contract).
+\*
+\* The crucial property: with_turn_switch does NOT touch the global atomic.
+\* Server fibers reading get_switch_opt during a turn see root_sw via the
+\* atomic fallback, NOT turn_sw. The §5 race scenario is gone by design.
+\*
+\* This is the TLA+ Bug Model pattern (software-development.md):
+\*   - Clean cfg: ALL actions enabled (including ServerForkDuringTurn).
+\*     Invariant SafetyInvariant holds. No counter-example.
+\*   - Buggy cfg: ServerForkLeak action is added — a hypothetical world
+\*     where a server fiber's binding is set to turn_sw (violating audit
+\*     §10.2). Invariant SafetyInvariant is violated, showing that the
+\*     audit §10.2 structural separation is what carries the safety
+\*     argument. If a future refactor lets server fibers acquire a turn
+\*     binding, this buggy cfg becomes the actual production model.
+
+EXTENDS Naturals, FiniteSets, TLC
+
+CONSTANTS
+    MaxTurns,
+    MaxResources
+
+ASSUME MaxTurnsPos     == MaxTurns \in Nat /\ MaxTurns >= 1
+ASSUME MaxResourcesPos == MaxResources \in Nat /\ MaxResources >= 1
+
+(* ── Switch identity & state ───────────────────────────────────────── *)
+
+SwitchIds    == {"root_sw", "turn_sw"}
+SwitchStates == {"alive", "closed"}
+
+\* Fiber-local binding: server fibers have NoBinding; keeper fibers inside
+\* with_turn_switch have BoundTo(turn_sw). After exit, back to NoBinding.
+\* In TLC we model binding as a flat string: "none" | "turn_sw".
+BindingValues == {"none", "turn_sw"}
+
+(* ── State ─────────────────────────────────────────────────────────── *)
+
+VARIABLES
+    sw_state,            \* [SwitchIds -> SwitchStates]
+    current_sw_atomic,   \* SwitchIds — the GLOBAL atomic. In Option 3 this
+                         \* never changes after init: it stays root_sw for
+                         \* the server lifetime.
+    keeper_binding,      \* BindingValues — fiber-local for the keeper fiber
+    server_binding,      \* BindingValues — fiber-local for the server fiber
+    turn_phase,
+    turns_used,
+    resources
+
+vars == << sw_state, current_sw_atomic, keeper_binding, server_binding,
+           turn_phase, turns_used, resources >>
+
+(* ── Type invariant ────────────────────────────────────────────────── *)
+
+TypeOK ==
+    /\ sw_state \in [SwitchIds -> SwitchStates]
+    /\ current_sw_atomic \in SwitchIds
+    /\ keeper_binding \in BindingValues
+    /\ server_binding \in BindingValues
+    /\ turn_phase \in {"idle", "in_turn"}
+    /\ turns_used \in 0..MaxTurns
+    /\ \A r \in resources:
+         /\ r.id \in 0..(2 * MaxTurns * MaxResources)
+         /\ r.role \in {"server","keeper"}
+         /\ r.attached \in SwitchIds
+         /\ r.released \in BOOLEAN
+
+(* ── Initial state ─────────────────────────────────────────────────── *)
+
+Init ==
+    /\ sw_state = [s \in SwitchIds |-> IF s = "root_sw" THEN "alive" ELSE "closed"]
+    /\ current_sw_atomic = "root_sw"   \* WORM — Option 3 never overwrites
+    /\ keeper_binding = "none"
+    /\ server_binding = "none"          \* audit §10.2 invariant
+    /\ turn_phase = "idle"
+    /\ turns_used = 0
+    /\ resources = {}
+
+(* ── Helpers ───────────────────────────────────────────────────────── *)
+
+NextResourceId == Cardinality(resources)
+
+\* get_switch_opt for a fiber with binding [b]: fiber-local first, then
+\* atomic fallback. Models eio_context.ml line ~95.
+ResolveSwitch(b) ==
+    IF b = "none" THEN current_sw_atomic
+    ELSE b   \* binding is "turn_sw"
+
+(* ── Actions ───────────────────────────────────────────────────────── *)
+
+\* Server fiber forks a child. Server binding stays "none" (audit §10.2),
+\* so get_switch_opt resolves to current_sw_atomic = root_sw. Attached
+\* to root_sw → outlives any turn. CORRECT.
+ServerFork ==
+    /\ Cardinality(resources) < 2 * MaxTurns * MaxResources
+    /\ LET resolved == ResolveSwitch(server_binding) IN
+       resources' = resources \cup
+         {[id |-> NextResourceId, role |-> "server",
+           attached |-> resolved, released |-> FALSE]}
+    /\ UNCHANGED << sw_state, current_sw_atomic, keeper_binding,
+                    server_binding, turn_phase, turns_used >>
+
+\* Keeper enters run_turn:
+\*   Eio.Switch.run @@ fun turn_sw ->
+\*   Eio_context.with_turn_switch turn_sw @@ fun () -> ...
+\* turn_sw becomes "alive", keeper's fiber-local binding := turn_sw.
+\* IMPORTANT: the GLOBAL atomic is NOT modified (Option 3 design).
+KeeperStartTurn ==
+    /\ turn_phase = "idle"
+    /\ turns_used < MaxTurns
+    /\ turn_phase' = "in_turn"
+    /\ keeper_binding' = "turn_sw"
+    /\ sw_state' = [sw_state EXCEPT !["turn_sw"] = "alive"]
+    /\ UNCHANGED << current_sw_atomic, server_binding, turns_used, resources >>
+
+\* Keeper forks inside the turn. Reads its OWN binding → "turn_sw" →
+\* attaches to turn_sw. Forced release on KeeperEndTurn. Correct.
+KeeperFork ==
+    /\ turn_phase = "in_turn"
+    /\ Cardinality(resources) < 2 * MaxTurns * MaxResources
+    /\ LET resolved == ResolveSwitch(keeper_binding) IN
+       resources' = resources \cup
+         {[id |-> NextResourceId, role |-> "keeper",
+           attached |-> resolved, released |-> FALSE]}
+    /\ UNCHANGED << sw_state, current_sw_atomic, keeper_binding,
+                    server_binding, turn_phase, turns_used >>
+
+\* Keeper exits run_turn: with_turn_switch finally clears binding, then
+\* Eio.Switch.run closes turn_sw, forcibly releasing turn_sw resources.
+\* GLOBAL atomic still unchanged (Option 3).
+KeeperEndTurn ==
+    /\ turn_phase = "in_turn"
+    /\ turn_phase' = "idle"
+    /\ keeper_binding' = "none"
+    /\ sw_state' = [sw_state EXCEPT !["turn_sw"] = "closed"]
+    /\ turns_used' = turns_used + 1
+    /\ resources' =
+         { IF r.attached = "turn_sw" /\ ~r.released
+             THEN [r EXCEPT !.released = TRUE]
+             ELSE r
+           : r \in resources }
+    /\ UNCHANGED << current_sw_atomic, server_binding >>
+
+\* Voluntary release.
+ResourceRelease ==
+    \E r \in resources:
+       /\ ~r.released
+       /\ resources' = (resources \ {r}) \cup {[r EXCEPT !.released = TRUE]}
+       /\ UNCHANGED << sw_state, current_sw_atomic, keeper_binding,
+                       server_binding, turn_phase, turns_used >>
+
+\* SERVER fiber forks WHILE keeper is in turn. This is the §5 race
+\* scenario from KeeperSwitchHierarchy.tla. Under Option 3:
+\*   server_binding = "none" (audit §10.2 invariant) →
+\*   ResolveSwitch("none") = current_sw_atomic = "root_sw" →
+\*   server resource attaches to root_sw, NOT turn_sw.
+\* The race is gone by design. Resource survives turn end. SAFE.
+ServerForkDuringTurn ==
+    /\ turn_phase = "in_turn"
+    /\ Cardinality(resources) < 2 * MaxTurns * MaxResources
+    /\ LET resolved == ResolveSwitch(server_binding) IN
+       resources' = resources \cup
+         {[id |-> NextResourceId, role |-> "server",
+           attached |-> resolved, released |-> FALSE]}
+    /\ UNCHANGED << sw_state, current_sw_atomic, keeper_binding,
+                    server_binding, turn_phase, turns_used >>
+
+(* ── BUG action — audit §10.2 violation ────────────────────────────── *)
+
+\* A hypothetical refactor where the server fiber acquires a turn binding
+\* (e.g. via a careless callback that crosses the fiber tree boundary).
+\* This action shows what would happen if audit §10.2 STOPPED holding.
+\* server_binding := "turn_sw". A subsequent ServerForkDuringTurn would
+\* then attach to turn_sw → §5 race resurrected.
+\* Enabled only in the buggy cfg.
+ServerBindingLeak ==
+    /\ turn_phase = "in_turn"
+    /\ server_binding = "none"
+    /\ server_binding' = "turn_sw"
+    /\ UNCHANGED << sw_state, current_sw_atomic, keeper_binding,
+                    turn_phase, turns_used, resources >>
+
+(* ── Next ──────────────────────────────────────────────────────────── *)
+
+Next ==
+    \/ ServerFork
+    \/ KeeperStartTurn
+    \/ KeeperFork
+    \/ KeeperEndTurn
+    \/ ResourceRelease
+    \/ ServerForkDuringTurn
+
+NextBuggy ==
+    \/ Next
+    \/ ServerBindingLeak
+
+Spec      == Init /\ [][Next]_vars
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+(* ── Invariants ────────────────────────────────────────────────────── *)
+
+\* audit §10.2 structural invariant: server fibers never acquire a turn
+\* binding. This is the load-bearing assumption of Option 3 safety.
+ServerBindingAlwaysNone == server_binding = "none"
+
+\* Atomic is WORM: never overwritten after server bootstrap.
+AtomicWorm == current_sw_atomic = "root_sw"
+
+\* Every SERVER resource attaches to root_sw. Same as Phase C.0 spec but
+\* now this should hold UNDER ServerForkDuringTurn in the clean model.
+ServerResourcesOnRoot ==
+    \A r \in resources:
+       r.role = "server" => r.attached = "root_sw"
+
+\* No live resource is attached to a closed switch.
+NoLiveResourceOnClosedSwitch ==
+    \A r \in resources:
+       (~r.released) => sw_state[r.attached] = "alive"
+
+\* Combined safety: under audit §10.2, even the race scenario is safe.
+SafetyInvariant ==
+    /\ ServerResourcesOnRoot
+    /\ NoLiveResourceOnClosedSwitch
+    /\ AtomicWorm
+
+====

--- a/test/dune
+++ b/test/dune
@@ -33,6 +33,7 @@
         test_openai_compat_error_map
         test_read_drop_reason
         test_log_ring_encoder
+        test_eio_context_fiber_local
         test_keeper_turn_disposition
         test_keeper_turn_terminal_disposition_field
         test_attempt_state
@@ -287,6 +288,7 @@
           test_openai_compat_error_map
           test_read_drop_reason
           test_log_ring_encoder
+          test_eio_context_fiber_local
           test_keeper_turn_disposition
           test_keeper_turn_terminal_disposition_field
           test_attempt_state

--- a/test/test_eio_context_fiber_local.ml
+++ b/test/test_eio_context_fiber_local.ml
@@ -1,0 +1,147 @@
+(* RFC-0107 Phase C.1 wiring tests — Eio_context.with_turn_switch
+   fiber-local binding semantics.
+
+   Verifies the four properties that make Option (3) race-free per
+   audit §10.5:
+
+   1. Binding-scope. Inside [with_turn_switch turn_sw f], reads of
+      [get_switch_opt ()] return [Some turn_sw].
+   2. Atomic fallback. Outside any [with_turn_switch] scope (server /
+      bootstrap fibers), [get_switch_opt ()] returns the global atomic
+      set by [set_switch].
+   3. Fork propagation. A fiber forked from inside [with_turn_switch]
+      sees the same [turn_sw] (this is the Eio.Fiber.with_binding
+      contract: "propagated to any forked fibers").
+   4. Sibling isolation. A sibling fiber run with [Eio.Fiber.both] in
+      a separate branch does NOT see the binding from the other branch.
+
+   Property 4 is the audit §10.2 invariant in test form: server fibers
+   that are siblings of (or above) the keeper run_turn fiber tree must
+   not see turn_sw. This codifies the structural separation that makes
+   the §5 race scenario impossible. *)
+
+let test_get_switch_opt_returns_binding_inside_with_turn_switch () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun outer_sw ->
+  (* Establish a global atomic (= server root_sw) for fallback comparison. *)
+  Eio_context.set_switch outer_sw;
+  Eio.Switch.run @@ fun turn_sw ->
+  Eio_context.with_turn_switch turn_sw @@ fun () ->
+  match Eio_context.get_switch_opt () with
+  | Some sw ->
+    Alcotest.(check bool)
+      "fiber-local binding returns turn_sw, not outer_sw"
+      true
+      (sw == turn_sw)
+  | None ->
+    Alcotest.fail "get_switch_opt returned None inside with_turn_switch"
+
+let test_get_switch_opt_falls_through_to_atomic_outside_binding () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun root_sw ->
+  Eio_context.set_switch root_sw;
+  (* No with_turn_switch wrap → fiber-local is empty → atomic fallback. *)
+  match Eio_context.get_switch_opt () with
+  | Some sw ->
+    Alcotest.(check bool)
+      "outside binding, get_switch_opt returns root_sw atomic"
+      true
+      (sw == root_sw)
+  | None ->
+    Alcotest.fail "atomic was set but get_switch_opt returned None"
+
+let test_binding_propagates_to_forked_child () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun outer_sw ->
+  Eio_context.set_switch outer_sw;
+  Eio.Switch.run @@ fun turn_sw ->
+  Eio_context.with_turn_switch turn_sw @@ fun () ->
+  let child_saw = Atomic.make None in
+  Eio.Fiber.fork ~sw:turn_sw (fun () ->
+    Atomic.set child_saw (Eio_context.get_switch_opt ()));
+  (* Wait for the forked child to complete before leaving with_turn_switch.
+     Eio.Switch.run won't return until all fibers attached to turn_sw
+     finish, but the local atomic read needs to happen first. We use
+     yields to let the child run. *)
+  Eio.Fiber.yield ();
+  match Atomic.get child_saw with
+  | Some sw ->
+    Alcotest.(check bool)
+      "forked child inherits turn_sw binding (Fiber.with_binding contract)"
+      true
+      (sw == turn_sw)
+  | None ->
+    Alcotest.fail "forked child did not read fiber-local binding"
+
+let test_binding_does_not_leak_to_sibling_fiber () =
+  (* This is the structural separation invariant. If keeper run_turn
+     binds turn_sw on its own fiber, a sibling fiber (e.g. dashboard
+     server, board_dispatch) running concurrently via Eio.Fiber.both
+     must NOT see turn_sw — its [Fiber.get] returns None, falling
+     through to the atomic. *)
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun root_sw ->
+  Eio_context.set_switch root_sw;
+  Eio.Switch.run @@ fun turn_sw ->
+  let sibling_saw = Atomic.make None in
+  Eio.Fiber.both
+    (fun () ->
+       Eio_context.with_turn_switch turn_sw @@ fun () ->
+       Eio.Fiber.yield ())
+    (fun () ->
+       Eio.Fiber.yield ();
+       Atomic.set sibling_saw (Eio_context.get_switch_opt ()));
+  match Atomic.get sibling_saw with
+  | Some sw ->
+    (* Sibling must see root_sw (atomic fallback), not turn_sw. *)
+    Alcotest.(check bool)
+      "sibling fiber sees root_sw atomic, NOT the other branch's turn_sw"
+      true
+      (sw == root_sw && not (sw == turn_sw))
+  | None ->
+    Alcotest.fail "sibling fiber read None — atomic should be set"
+
+let test_binding_cleared_after_with_turn_switch_exits () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun root_sw ->
+  Eio_context.set_switch root_sw;
+  Eio.Switch.run @@ fun turn_sw ->
+  Eio_context.with_turn_switch turn_sw (fun () -> ());
+  (* After with_turn_switch returns, the binding should be gone. *)
+  match Eio_context.get_switch_opt () with
+  | Some sw ->
+    Alcotest.(check bool)
+      "after with_turn_switch exits, get_switch_opt falls back to atomic"
+      true
+      (sw == root_sw && not (sw == turn_sw))
+  | None ->
+    Alcotest.fail "atomic was set; fallback should have returned root_sw"
+
+let () =
+  Alcotest.run "eio_context_fiber_local"
+    [
+      ( "binding scope",
+        [
+          Alcotest.test_case "inside with_turn_switch → turn_sw"
+            `Quick
+            test_get_switch_opt_returns_binding_inside_with_turn_switch;
+          Alcotest.test_case "outside binding → atomic fallback"
+            `Quick
+            test_get_switch_opt_falls_through_to_atomic_outside_binding;
+          Alcotest.test_case "binding cleared after exit"
+            `Quick
+            test_binding_cleared_after_with_turn_switch_exits;
+        ] );
+      ( "fork propagation",
+        [
+          Alcotest.test_case "forked child inherits binding"
+            `Quick
+            test_binding_propagates_to_forked_child;
+        ] );
+      ( "structural separation (audit §10.2)",
+        [
+          Alcotest.test_case "sibling fiber does not see binding"
+            `Quick
+            test_binding_does_not_leak_to_sibling_fiber;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

RFC-0107 Phase C.1 — turn-scoped Eio.Switch wiring via fiber-local
binding (Option 3 from audit §10.5). Resources opened during a single
`run_turn` invocation now attach to a turn-scoped switch and are
released when the turn ends — bounding per-turn FD growth (root cause
of the 2026-05-16 ENFILE storm in this layer).

Builds on the Phase C.0 evidence merged in #15912.

## Design — Option 3 (`Eio.Fiber.with_binding`)

- New `Eio_context.with_turn_switch sw f` binds `sw` on the *current
  fiber* and its forked children. `get_switch_opt` now reads
  fiber-local first, falls through to the global atomic for
  server/dashboard/bootstrap fibers (which have no binding — audit
  §10.2 structural separation).
- `keeper_agent_run.run_turn` wraps its body with `Eio.Switch.run` +
  `with_turn_switch`. Cascade attempts forked inside the turn inherit
  the binding automatically.
- `keeper_keepalive.ml:369` (gRPC heartbeat) **unchanged** — it runs
  outside any turn (audit §10.6); fiber-local lookup returns `None` →
  atomic fallback → server root_sw → long-lived stream survives.

## Files

- `lib/eio_context/eio_context.ml(i)` — `sw_key` + `with_turn_switch`,
  fiber-local-first `get_switch_opt`
- `lib/keeper/keeper_agent_run.ml:257-275` — turn body wrap (1 line +
  indent + docstring)
- `specs/keeper-switch-hierarchy/KeeperFiberLocalSwitch.tla` (+ clean
  / buggy cfg) — TLA+ Bug Model proof
- `test/test_eio_context_fiber_local.ml` — unit + structural-separation
  tests (5 cases)

## Verification

**Tests** — `dune exec test/test_eio_context_fiber_local.exe`:
```
binding scope        0  inside with_turn_switch → turn_sw       OK
binding scope        1  outside binding → atomic fallback       OK
binding scope        2  binding cleared after with_turn_switch  OK
fork propagation     0  forked child inherits binding           OK
structural sep §10.2 0  sibling fiber does not see binding      OK
Test Successful in 0.004s. 5 tests run.
```

**TLA+ KeeperFiberLocalSwitch.tla**:
- Clean cfg: 194,955 distinct states, depth 21, no error in 04s.
  `ServerForkDuringTurn` — the action that violated Option 2 in the
  Phase C.0 spec — is now SAFE because `server_binding = "none"`
  resolves to the WORM atomic.
- Buggy cfg: invariant violated in 4 steps via hypothetical
  `ServerBindingLeak`. Acts as regression sentinel if audit §10.2
  stops holding.

**Build**: `dune build @check` PASS.

## Trade-offs & risks

- Adds `Eio.Fiber.with_binding` API surface — narrow, fiber-local,
  no global atomic mutation. Server/dashboard fibers untouched.
- `Fiber.get` may raise `Effect.Unhandled` if called outside any Eio
  fiber context (test setup, init). The `try ... with _` falls
  through to the atomic — conservative but correct semantics.
- 26 callsites of `get_switch_opt` were enumerated in audit §2 +
  §10.3 and classified turn-scoped vs server-scoped. 15 keeper-turn
  sites get turn_sw via fork propagation; 1 (`keeper_keepalive.ml`)
  + 9 server/dashboard sites get root_sw via atomic fallback. No
  callsite required modification.

## Refs

- RFC-0107 §3.3 (outbound HTTP stack consolidation, Phase C)
- Audit §10.5 (Option 3 decision), §10.2 (structural separation),
  §10.6 (keepalive caller chain)
- Phase C.0 PR: #15912
- Companion spec: `specs/keeper-switch-hierarchy/KeeperSwitchHierarchy.tla`
  (Phase C.0, Option 2 race model)

RFC-WAIVED: change is local to lib/eio_context + a 1-line wrap in
lib/keeper/keeper_agent_run.ml; RFC-0107 already merged as authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
