### PR TITLE
Fix Docker room-state projection mounts

### DIFF
--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -362,11 +362,7 @@ let docker_room_state_mount_specs ~base_path ~container_root =
     if not (room_state_path_available kind host_path)
     then []
     else
-      [ Printf.sprintf
-          "%s:%s:ro"
-          host_path
-          (Filename.concat container_masc_root rel_path)
-      ; Printf.sprintf "%s:%s:ro" host_path host_path
+      [ Printf.sprintf "%s:%s:ro" host_path (Filename.concat container_masc_root rel_path)
       ])
   |> unique_preserving_order
 ;;

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -159,11 +159,11 @@ val docker_config_mount_args
   -> string list
 
 (** Docker [-v ...] specs for the read-only room-state subset that keeper
-    task worktrees may read through their [.masc] link. This intentionally
-    excludes auth, credentials, locks, logs, metrics, and keeper private
-    state. Existing paths are mounted both under [<container_root>/.masc]
-    and at the original absolute [.masc] path so host-created worktree
-    symlinks remain readable inside Docker. *)
+    task worktrees may read through their container-side [.masc]
+    projection. This intentionally excludes auth, credentials, locks,
+    logs, metrics, and keeper private state. Existing paths are mounted
+    only under [<container_root>/.masc]; host-absolute [.masc] targets
+    must never be used as Docker mount destinations. *)
 val docker_room_state_mount_specs
   :  base_path:string
   -> container_root:string

--- a/lib/task_sandbox.ml
+++ b/lib/task_sandbox.ml
@@ -90,6 +90,84 @@ let safe_is_directory path =
   | Sys_error _ -> false
 ;;
 
+let strip_trailing_slashes path =
+  let rec loop i =
+    if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i
+  in
+  let len = loop (String.length path) in
+  if len = String.length path then path else String.sub path 0 len
+;;
+
+let suffix_under ~prefix path =
+  let prefix = strip_trailing_slashes prefix in
+  let path = strip_trailing_slashes path in
+  if String.equal path prefix
+  then Some ""
+  else (
+    let prefix_with_sep = prefix ^ "/" in
+    if String.starts_with ~prefix:prefix_with_sep path
+    then
+      Some
+        (String.sub
+           path
+           (String.length prefix_with_sep)
+           (String.length path - String.length prefix_with_sep))
+    else None)
+;;
+
+let path_segments path =
+  path
+  |> String.split_on_char '/'
+  |> List.filter (fun segment -> String.trim segment <> "")
+;;
+
+let relative_masc_projection_target ~docker_host_root ~worktree_path =
+  match suffix_under ~prefix:docker_host_root worktree_path with
+  | None -> None
+  | Some "" -> Some Common.masc_dirname
+  | Some suffix ->
+    let ups = suffix |> path_segments |> List.map (fun _ -> "..") in
+    Some (String.concat "/" (ups @ [ Common.masc_dirname ]))
+;;
+
+let docker_masc_projection_dir ~config ~agent_name =
+  let repos_dir =
+    Coord_worktree.repos_dir_of_keeper config agent_name |> strip_trailing_slashes
+  in
+  Filename.concat (Filename.dirname repos_dir) Common.masc_dirname
+;;
+
+let ensure_dir_result path =
+  try
+    Fs_compat.mkdir_p path;
+    Ok ()
+  with
+  | Sys_error msg ->
+    Error (Printf.sprintf "mkdir failed: path=%s error=%s" path msg)
+  | Unix.Unix_error (e, _, _) ->
+    Error
+      (Printf.sprintf
+         "mkdir failed: path=%s error=%s"
+         path
+         (Unix.error_message e))
+;;
+
+let docker_masc_symlink_source ~config ~agent_name ~worktree_path =
+  let projection_dir = docker_masc_projection_dir ~config ~agent_name in
+  match ensure_dir_result projection_dir with
+  | Error _ as err -> err
+  | Ok () ->
+    let docker_host_root = Filename.dirname projection_dir in
+    (match relative_masc_projection_target ~docker_host_root ~worktree_path with
+     | Some target -> Ok target
+     | None ->
+       Error
+         (Printf.sprintf
+            "docker .masc projection failed: worktree=%s is outside host_root=%s"
+            worktree_path
+            docker_host_root))
+;;
+
 let host_worktree_path ~config ~agent_name ~task_id ~repo_name =
   let repo_root =
     Filename.concat (Coord_worktree.repos_dir_of_keeper config agent_name) repo_name
@@ -119,9 +197,10 @@ let resolve_created_worktree_path ~config ~agent_name ~task_id ~response_path ~r
          (Option.value host_candidate ~default:"<missing>"))
 ;;
 
-(** Symlink [.masc/] from the active runtime base into the worktree for read-only
-    access to room state. Idempotent: does nothing if link already exists. *)
-let symlink_masc ~base_path ~worktree_path =
+(** Symlink [.masc/] into the worktree for read-only room state access.
+    Docker keepers use a playground-local projection so the symlink remains
+    valid inside the container without host-absolute bind targets. *)
+let symlink_masc ~config ~base_path ~agent_name ~worktree_path =
   let masc_source = Common.masc_dir_from_base_path ~base_path in
   let masc_target = Common.masc_dir_from_base_path ~base_path:worktree_path in
   if not (safe_is_directory masc_source)
@@ -129,17 +208,25 @@ let symlink_masc ~base_path ~worktree_path =
   else if safe_file_exists masc_target
   then Ok ()
   else
-    try
-      Unix.symlink masc_source masc_target;
-      Ok ()
-    with
-    | Unix.Unix_error (e, _, _) ->
-      Error
-        (Printf.sprintf
-           "symlink .masc failed: source=%s target=%s error=%s"
-           masc_source
-           masc_target
-           (Unix.error_message e))
+    let source =
+      if Coord_worktree.keeper_uses_docker_sandbox ~config ~agent_name
+      then docker_masc_symlink_source ~config ~agent_name ~worktree_path
+      else Ok masc_source
+    in
+    match source with
+    | Error _ as err -> err
+    | Ok source ->
+      try
+        Unix.symlink source masc_target;
+        Ok ()
+      with
+      | Unix.Unix_error (e, _, _) ->
+        Error
+          (Printf.sprintf
+             "symlink .masc failed: source=%s target=%s error=%s"
+             source
+             masc_target
+             (Unix.error_message e))
 ;;
 
 let create ~config ~task_id ?(base_branch = "main") ?repo_name ~agent_name () =
@@ -174,7 +261,7 @@ let create ~config ~task_id ?(base_branch = "main") ?repo_name ~agent_name () =
               ~default:(Playground_paths.worktree_branch_name agent_name task_id)
        in
        (* Symlink .masc/ into the worktree *)
-       (match symlink_masc ~base_path ~worktree_path with
+       (match symlink_masc ~config ~base_path ~agent_name ~worktree_path with
         | Error e -> Error e
         | Ok () ->
           Ok { task_id; worktree_path; branch_name; created_at = Time_compat.now () }))

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -613,11 +613,19 @@ let test_docker_room_state_mount_args_expose_safe_subset () =
     (List.mem
        (tasks_host ^ ":" ^ container_root ^ "/.masc/tasks:ro")
        specs);
-  Alcotest.(check bool) "mounts tasks at absolute symlink target" true
+  Alcotest.(check bool) "does not mount tasks at host absolute target" false
     (List.mem (tasks_host ^ ":" ^ tasks_host ^ ":ro") specs);
   Alcotest.(check bool) "mounts board posts" true
     (List.mem
        (board_host ^ ":" ^ container_root ^ "/.masc/board_posts.jsonl:ro")
+       specs);
+  Alcotest.(check bool) "all targets stay under container .masc" true
+    (List.for_all
+       (fun spec ->
+         match String.split_on_char ':' spec with
+         | [ _source; target; "ro" ] ->
+           String.starts_with ~prefix:(container_root ^ "/.masc/") target
+         | _ -> false)
        specs);
   Alcotest.(check bool) "does not mount auth" false
     (List.exists (fun spec -> contains_substring spec "/auth/") specs)

--- a/test/test_task_sandbox.ml
+++ b/test/test_task_sandbox.ml
@@ -619,8 +619,18 @@ let test_create_resolves_docker_visible_path_to_host_worktree () =
         | Ok sb ->
           check string "returns host worktree path" expected_worktree sb.worktree_path;
           check bool "host worktree exists" true (Sys.file_exists sb.worktree_path);
-          check bool "linked .masc at host worktree" true
-            (Sys.file_exists (Filename.concat sb.worktree_path Common.masc_dirname));
+          let masc_link = Filename.concat sb.worktree_path Common.masc_dirname in
+          check bool "linked .masc at host worktree" true (Sys.file_exists masc_link);
+          check string "docker .masc link uses playground projection"
+            "../../../../.masc"
+            (Unix.readlink masc_link);
+          let docker_projection =
+            Filename.concat
+              (Filename.dirname (Filename.dirname docker_clone))
+              Common.masc_dirname
+          in
+          check bool "docker .masc projection exists" true
+            (Sys.file_exists docker_projection);
           ignore (Task_sandbox.cleanup ~config ~agent_name:"docker-agent" sb)))
 
 let test_create_fails_ambiguous_multi_repo_without_evidence () =


### PR DESCRIPTION
## Summary
- stop mounting room-state files back onto their host-absolute .masc paths inside Docker
- add a Docker keeper .masc projection symlink under the playground so worktree links stay container-visible
- update regression coverage for container-local mount targets and Docker worktree symlink projection

## Verification
- git diff --check
- scripts/dune-local.sh build test/test_keeper_docker_read.exe test/test_task_sandbox.exe
- ./_build/default/test/test_keeper_docker_read.exe
- ./_build/default/test/test_task_sandbox.exe