### PR TITLE
fix(cdal): preserve required evidence in verification

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -32,7 +32,7 @@ let action_persists_handoff_context = function
 let verification_submission_evidence_refs task handoff_context =
   let contract_refs =
     match task.contract with
-    | Some c -> c.verify_gate_evidence
+    | Some c -> c.verify_gate_evidence @ c.required_evidence
     | None -> []
   in
   let handoff_refs =

--- a/lib/coord/coord_task_classify.ml
+++ b/lib/coord/coord_task_classify.ml
@@ -323,6 +323,8 @@ let ensure_task_contract_for_verification ?contract ~title ~description () =
   let verify_gate_evidence =
     if base.verify_gate_evidence <> []
     then base.verify_gate_evidence
+    else if base.required_evidence <> []
+    then base.required_evidence
     else default_verification_evidence_refs
   in
   normalize_task_contract

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -16,9 +16,9 @@
    - [criteria]: the operator-facing "must be true" statements →
      [task.contract.completion_contract] wrapped in [Verification.Custom].
    - [evidence_refs]: the artefact list the verifier expects to see →
-     [task.contract.verify_gate_evidence], passed in by the caller at
-     [tool_task.ml] so this function does not reach into task.contract
-   twice for different fields. *)
+     [task.contract.verify_gate_evidence] plus required evidence refs,
+     passed in by the caller at [coord_task.ml] so this function does
+     not reach into task.contract twice for different fields. *)
 type submit_request_spec =
   { criteria : Verification.criterion list
   ; output : Yojson.Safe.t
@@ -106,10 +106,13 @@ let warn_contract_gap (task : Masc_domain.task) =
        "[verification-submit] task=%s has no contract — completion_contract \
         and evidence will be empty in the verification record"
        task.id
-   | Some c when c.completion_contract = [] && c.verify_gate_evidence = [] ->
+   | Some c
+     when c.completion_contract = []
+          && c.required_evidence = []
+          && c.verify_gate_evidence = [] ->
      Log.Task.warn
        "[verification-submit] task=%s has a contract but both \
-       completion_contract and verify_gate_evidence are empty"
+       completion_contract and verification evidence are empty"
        task.id
    | Some _ -> ())
 

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -77,6 +77,33 @@ let add_strict_task config =
   | Some t -> t.id
   | None -> Alcotest.fail "new task not found after add_task"
 
+let add_required_evidence_only_task config =
+  let existing_ids =
+    Coord.read_backlog config
+    |> fun backlog -> List.map (fun (t : Masc_domain.task) -> t.id) backlog.tasks
+  in
+  let contract : Masc_domain.task_contract = {
+    strict = true;
+    completion_contract = [];
+    required_tools = [];
+    required_evidence = ["artifact://coverage.json"];
+    inspect_gate_evidence = [];
+    verify_gate_evidence = [];
+    links = { operation_id = None; session_id = None; autoresearch_loop_id = None };
+  } in
+  let _msg =
+    Coord.add_task ~contract config ~title:"required evidence only"
+      ~priority:3 ~description:"requires a named evidence artifact"
+  in
+  let backlog = Coord.read_backlog config in
+  match
+    List.find_opt
+      (fun (t : Masc_domain.task) -> not (List.mem t.id existing_ids))
+      backlog.tasks
+  with
+  | Some t -> t.id
+  | None -> Alcotest.fail "new task not found after add_task"
+
 let claim_and_start config agent_name task_id =
   let _ = Coord.transition_task_r config ~agent_name ~task_id
     ~action:Masc_domain.Claim () in
@@ -280,6 +307,34 @@ let test_submit_populates_criteria_from_completion_contract () =
     in
     Alcotest.(check (list string)) "evidence_refs from verify_gate_evidence"
       ["output.json"] persisted_refs)
+
+let test_submit_uses_required_evidence_when_verify_refs_empty () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let task_id = add_required_evidence_only_task config in
+    claim_and_start config "worker" task_id;
+    let captured_refs = ref None in
+    let result =
+      Coord.transition_task_r
+        config
+        ~agent_name:"worker"
+        ~task_id
+        ~action:Masc_domain.Submit_for_verification
+        ~notes:"implementation complete"
+        ~prepare_verification_request:
+          (fun ~task:_ ~assignee:_ ~verification_id:_ ~evidence_refs ->
+             captured_refs := Some evidence_refs;
+             Ok ())
+        ()
+    in
+    (match result with
+     | Ok _ -> ()
+     | Error e ->
+       Alcotest.fail
+         (Printf.sprintf "submit failed: %s" (Masc_domain.show_masc_error e)));
+    Alcotest.(check (list string))
+      "required_evidence carried to verification refs"
+      ["artifact://coverage.json"]
+      (Option.value ~default:[] !captured_refs))
 
 let test_submit_marks_conflict_triage_when_deliverable_claims_completion () =
   with_temp_config ~fsm_enabled:true (fun config ->
@@ -699,6 +754,8 @@ let () =
         `Quick test_submit_prepare_failure_keeps_task_in_progress;
       Alcotest.test_case "submit splits criteria/evidence by contract field"
         `Quick test_submit_populates_criteria_from_completion_contract;
+      Alcotest.test_case "submit carries required_evidence into verifier refs"
+        `Quick test_submit_uses_required_evidence_when_verify_refs_empty;
       Alcotest.test_case "submit marks conflict triage from completed deliverable"
         `Quick test_submit_marks_conflict_triage_when_deliverable_claims_completion;
       Alcotest.test_case "cross-agent approve moves to done" `Quick


### PR DESCRIPTION
## Summary

- Preserve explicit `required_evidence` when normalizing task contracts for verification.
- Pass both `verify_gate_evidence` and `required_evidence` into verification submit evidence refs.
- Add a regression test covering required-evidence-only contracts.

## Root Cause

Tasks with explicit `required_evidence` but empty `verify_gate_evidence` could be normalized with generic default verifier refs, and the submit path only forwarded `verify_gate_evidence` plus handoff refs. That meant verifier-facing evidence refs could lose the concrete required evidence named by the task contract.

## Validation

- `ocamlformat --check lib/coord/coord_task_classify.ml lib/coord/coord_task.ml lib/verification_protocol.ml test/test_verification_fsm.ml`
- `git diff --check origin/main..HEAD`
- `scripts/dune-local.sh build test/test_verification_fsm.exe`
- `/private/tmp/masc-mcp-cdal-required-evidence-build/default/test/test_verification_fsm.exe` (21 tests)

Additional checks run before the final rebase while fixing current-main compile blockers encountered during verification:

- `test_keeper_bash_safety.exe` (44 tests)
- `test_keeper_lifecycle.exe` (56 tests)
- `test_operator_control.exe` (66 tests, 1 skipped)