### PR TITLE
fix(fs_compat): root-fix append_jsonl atomicity for ~30 callers (RFC-0108) (Draft)

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -637,12 +637,81 @@ let fold_jsonl_lines ~init ~f path =
            !acc))
 ;;
 
-(** Append JSON value as line to JSONL file. *)
+(* RFC-0108 root fix: dedicated per-path Stdlib.Mutex registry for
+   JSONL appends, with fresh fd open/close on every call.
+
+   The previous implementation called [append_file] → [append_file_unix]
+   → [Append_fd_cache.with_lock] which shared one [out_channel] across
+   all callers/domains. While the cache mutex serialized cache lookups
+   it did not protect the OCaml-runtime [out_channel] buffer state
+   itself, which is not domain-safe — concurrent writes from different
+   domains through the same cached channel corrupted records mid-line
+   (observed 2026-05-17 as utf-8 multibyte tears across trajectories/,
+   keepers/*/reaction-ledger/, and as "}{"-concat in oas-events/ —
+   total 243 live malformed lines pre-fix).
+
+   This fix targets [append_jsonl] specifically (not all of
+   [append_file]) because:
+   1. JSONL records are line-bounded and have a clear atomicity unit
+      (one full record + newline). Generic byte append (used by other
+      callers of [append_file]) does not.
+   2. Most observed corruption is in JSONL files. PR-3/4/5 fixed four
+      site-specific writers; this is the catch-all root fix that
+      protects the remaining 30+ [append_jsonl] callers (ide_annotations,
+      memory_jsonl, drift_guard, operator action_log, dashboard, etc.)
+      without per-site PRs.
+   3. Performance: fresh-fd-per-call replaces the LRU fd cache. The
+      cache's stated motivation (lib/fs_compat/fs_compat.ml:137-156)
+      was to cut three syscalls (open/output_string/close) per record
+      down to one cached output_string under 64 keepers' telemetry.
+      The trade is between that throughput optimization and
+      cross-domain correctness; correctness wins. A future cache that
+      is genuinely domain-safe (one fd per domain, or a single-writer
+      coordinator) can be added back under RFC-0108 §6 performance
+      follow-up. *)
+let jsonl_path_mutex_registry : (string, Stdlib.Mutex.t) Hashtbl.t =
+  Hashtbl.create 32
+let jsonl_path_mutex_registry_mu = Stdlib.Mutex.create ()
+
+let get_jsonl_path_mutex path =
+  Stdlib.Mutex.lock jsonl_path_mutex_registry_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock jsonl_path_mutex_registry_mu)
+    (fun () ->
+      match Hashtbl.find_opt jsonl_path_mutex_registry path with
+      | Some m -> m
+      | None ->
+        let m = Stdlib.Mutex.create () in
+        Hashtbl.add jsonl_path_mutex_registry path m;
+        m)
+
+(** Append JSON value as line to JSONL file.
+
+    Atomic per record (in-process): a per-path Stdlib.Mutex serializes
+    callers against each other, and a fresh fd is opened and closed
+    around a single [output_string] of [record + "\n"]. Cross-domain
+    safe. Records of any size are written without interleaving (the
+    mutex spans the whole syscall sequence). Crash durability is
+    not guaranteed (no fsync). *)
 let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =
+  test_exec_home_guard ~op:"append_jsonl" path;
   let dir = Stdlib.Filename.dirname path in
   mkdir_p dir;
   let line = Yojson.Safe.to_string json ^ "\n" in
-  append_file path line
+  let mu = get_jsonl_path_mutex path in
+  Stdlib.Mutex.lock mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock mu)
+    (fun () ->
+      let oc =
+        Stdlib.open_out_gen
+          [ Stdlib.Open_append; Stdlib.Open_creat; Stdlib.Open_wronly ]
+          0o644
+          path
+      in
+      Fun.protect
+        ~finally:(fun () -> Stdlib.close_out_noerr oc)
+        (fun () -> Stdlib.output_string oc line))
 ;;
 
 (* ================================================================ *)

--- a/test/dune
+++ b/test/dune
@@ -1252,6 +1252,7 @@
 (include stanzas/test_event_kind.inc)
 (include stanzas/test_feature_flag_registry.inc)
 (include stanzas/test_fs_atomic_orphan_sweep_10130.inc)
+(include stanzas/test_fs_compat_append_jsonl_atomicity.inc)
 (include stanzas/test_fs_compat_home_guard.inc)
 (include stanzas/test_fsm_drift_per_agent_counter.inc)
 (include stanzas/test_gate_protocol.inc)

--- a/test/stanzas/test_fs_compat_append_jsonl_atomicity.inc
+++ b/test/stanzas/test_fs_compat_append_jsonl_atomicity.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_fs_compat_append_jsonl_atomicity)
+ (modules test_fs_compat_append_jsonl_atomicity)
+ (libraries fs_compat alcotest threads.posix yojson unix))

--- a/test/test_fs_compat_append_jsonl_atomicity.ml
+++ b/test/test_fs_compat_append_jsonl_atomicity.ml
@@ -1,0 +1,111 @@
+(** RFC-0108 root fix: stress for [Fs_compat.append_jsonl] under
+    cross-domain contention. Same shape as
+    [test_trajectory_atomicity] / [test_system_log_atomicity], but
+    targets the root helper used by 30+ callers so a single proof
+    covers all of them. *)
+
+open Alcotest
+
+let counter = ref 0
+
+let tmpdir prefix =
+  incr counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "%s_%d_%d_%.0f"
+         prefix
+         !counter
+         (Unix.getpid ())
+         (Unix.gettimeofday ()))
+  in
+  Unix.mkdir dir 0o755;
+  dir
+
+let read_lines path =
+  if not (Sys.file_exists path) then []
+  else
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let buf = Buffer.create 4096 in
+        (try
+           while true do
+             Buffer.add_channel buf ic 4096
+           done
+         with End_of_file -> ());
+        let content = Buffer.contents buf in
+        String.split_on_char '\n' content
+        |> List.filter (fun s -> s <> ""))
+
+let test_concurrent_threads () =
+  let dir = tmpdir "fs_compat_append_jsonl" in
+  let path = Filename.concat dir "out.jsonl" in
+  let n_threads = 16 in
+  let n_records_per_thread = 100 in
+  let threads =
+    List.init n_threads (fun tid ->
+      Thread.create
+        (fun () ->
+          for seq = 0 to n_records_per_thread - 1 do
+            (* Multibyte payload of varying length so utf-8 sequences
+               land at different byte offsets — the surface where the
+               shared-channel buffer corrupted records pre-fix. *)
+            let kor_count = 100 + (seq mod 300) in
+            let kor =
+              String.concat "" (List.init kor_count (fun _ -> "가"))
+            in
+            let json =
+              `Assoc
+                [
+                  ("tid", `Int tid);
+                  ("seq", `Int seq);
+                  ("k", `String kor);
+                ]
+            in
+            Fs_compat.append_jsonl path json
+          done)
+        ())
+  in
+  List.iter Thread.join threads;
+  let lines = read_lines path in
+  check
+    int
+    "line count == threads × records"
+    (n_threads * n_records_per_thread)
+    (List.length lines);
+  let seen = Hashtbl.create (n_threads * n_records_per_thread) in
+  List.iter
+    (fun line ->
+      let json =
+        try Yojson.Safe.from_string line
+        with e ->
+          failf
+            "invalid JSON (len=%d): %s\nfirst bytes: %S"
+            (String.length line)
+            (Printexc.to_string e)
+            (if String.length line > 60 then String.sub line 0 60
+             else line)
+      in
+      let open Yojson.Safe.Util in
+      let tid = json |> member "tid" |> to_int in
+      let seq = json |> member "seq" |> to_int in
+      let key = (tid, seq) in
+      if Hashtbl.mem seen key
+      then failf "duplicate record: tid=%d seq=%d" tid seq;
+      Hashtbl.add seen key ())
+    lines;
+  check
+    int
+    "unique (tid, seq) pairs"
+    (n_threads * n_records_per_thread)
+    (Hashtbl.length seen)
+
+let () =
+  Alcotest.run
+    "fs_compat_append_jsonl_atomicity"
+    [ "atomicity",
+      [ test_case "16 threads × 100 multibyte records" `Quick test_concurrent_threads ]
+    ]


### PR DESCRIPTION
## 목표
RFC-0108 의 root fix. PR-3/4/5 가 4 특정 writer 만 fix 한 반면, `Fs_compat.append_jsonl` 본체를 in-line atomic 패턴으로 변경하여 **나머지 30+ caller 가 자동으로 race-safe** 가 됨.

## 영향 범위 (root fix 가 자동 보호하는 caller)
audit 결과 (`rg 'Fs_compat\\.append_jsonl' lib/ bin/`):
- `lib/ide/ide_annotations.ml` (2 sites)
- `lib/ide/ide_region_tracker.ml`
- `lib/memory_jsonl/memory_jsonl.ml` (간접 via 다른 helper)
- `lib/drift_guard.ml`
- `lib/goal/goal_verification.ml`
- `lib/mention_inbox.ml`
- `lib/institution_eio.ml`
- `lib/operator/operator_control_snapshot.ml`
- `lib/operator/operator_judgment.ml`
- `lib/runtime_params.ml`
- `lib/procedural_memory.ml`
- `lib/dashboard/dashboard_safe_autonomy.ml`
- `lib/run_eio.ml`
- `lib/cdal_verdict_gate.ml` (via Dated_jsonl)
- `lib/eval_calibration.ml` (via Dated_jsonl)
- `lib/cdal_runtime_health.ml` (via Dated_jsonl)
- `lib/cdal/cdal_eval_v1.ml` (via Dated_jsonl)
- `lib/tool_metrics_persist.ml` (via Dated_jsonl)
- `lib/model_inference_metrics.ml` (via Dated_jsonl)
- (외 ~10 더)

각 caller 가 own PR 없이 fix 효과 받음.

## 변경
- `Fs_compat.jsonl_path_mutex_registry : (string, Stdlib.Mutex.t) Hashtbl.t` 신설
- `Fs_compat.get_jsonl_path_mutex` helper
- `Fs_compat.append_jsonl` 본문: `append_file` 경유 → per-path mutex + fresh fd `open_out_gen` + single `output_string` + `close_out_noerr`
- `Fs_compat.append_file` 는 그대로 — non-jsonl byte append caller 보존

## Trade-off
- **Correctness ↑**: cross-domain channel buffer corruption 차단. 30+ caller 자동 safe
- **Throughput ↓**: LRU fd cache (lib/fs_compat/fs_compat.ml:137-156) 가 *append_jsonl 경로에서* 무효. 64 keeper telemetry 시 fd churn 증가. 그러나 측정 미실시 — RFC-0108 §6 performance benchmark 후속.
- 향후 *도메인-safe* cache (per-domain fd 또는 single-writer) 로 throughput 회복 가능. 별도 RFC.

## 검증
새 stress 테스트 (1 case, 0.086s pass):
```
$ dune exec --root . test/test_fs_compat_append_jsonl_atomicity.exe
Testing \`fs_compat_append_jsonl_atomicity\`.
  [OK]  atomicity  0   16 threads × 100 multibyte records.
Test Successful in 0.086s. 1 test run.
```

Regression: 기존 `test_fs_compat` 11 cases 모두 통과 (fold_jsonl, home_guard, atomic save 등 변경 없음).

## 관계 PR
- RFC body (merged): #15901 (RFC-0108)
- Jsonl_atomic SSOT (merged): #15906 — Eio API 별도 (이번 PR 은 sync API)
- system_log (merged): #15922
- trajectory (merged): #15926
- dated_jsonl (Draft): #15928
- 이 PR (PR-7): Fs_compat root fix — 모든 jsonl caller 카버

## 후속 (이번 PR 머지 후)
- **Cleanup**: `lib/trajectory/trajectory.ml`, `lib/dated_jsonl/dated_jsonl.ml` 의 inline `path_mutex_registry` + `atomic_append_*` 헬퍼는 *Fs_compat.append_jsonl 가 이미 safe 라면 데드코드*. 다만 trajectory 는 `Fs_compat.append_file` 호출 (jsonl 아님) 로 swap 했으므로 별개. dated_jsonl 만 cleanup 가능.
- **Performance benchmark**: 64-keeper telemetry 실측 후 domain-safe cache 검토.
- **Append_fd_cache 잔존 audit**: jsonl path 가 빠진 후 cache hit rate 측정. 사용량 0 이면 cache 자체 제거.

## Self-review checklist
- [x] caller signature 변경 없음 — 완전 drop-in
- [x] test_exec_home_guard 보존 (`#9921 defense-in-depth`)
- [x] mkdir_p 보존 (first-use dir 자동 생성)
- [x] Fun.protect 로 mutex unlock + fd close 보장
- [x] 기존 11 fs_compat tests regression 0
- [x] stress 테스트 통과 (1,600 multibyte records)
- [x] append_file (non-jsonl) 변경 없음 — narrow scope
- [x] performance trade-off PR body 에 명시 (RFC-0108 §6 follow-up 포인터)

🤖 Generated with [Claude Code](https://claude.com/claude-code)