### PR TITLE
docs(rfc): RFC-0107 Phase D step 1 — Connection pool interface design

### DIFF
--- a/docs/rfc/RFC-0107-phase-d-pool-design.md
+++ b/docs/rfc/RFC-0107-phase-d-pool-design.md
@@ -266,3 +266,66 @@ Phase D step 2 가 그 결정 위에 구현.
 - **자체 FD 회계 시스템 (X)** — RFC-0101 의 `Fd_accountant` 와 별개.
   pool 의 stats 는 reuse/evict/create counter 만, throttle 없음. Phase
   F retirement gate 의 measurement.
+
+## 8. Phase B Prior Art findings — design 정정 (2026-05-17 후속)
+
+Phase B 의 `knowledge/research/2026-05-17-piaf-ocsigen-eio-fd-prior-art.md`
+가 본 design 의 두 가지 가정을 정정한다.
+
+### 8.1 정정 — piaf 는 multi-host pool *이 아니다*
+
+본 design §3 가 "piaf 가 이미 구현" 으로 기술한 부분은 *부정확*:
+
+> From `piaf.mli`: "A client instance represents a connection to a
+> **single remote endpoint**, and the remaining functions in this module
+> will issue requests to that endpoint only."
+
+piaf `Client.t` 는 *per-endpoint persistent client* — single-host
+keep-alive + redirect-aware reconnect. `Host → Pool[Connection]` 자료
+구조는 piaf 가 **제공하지 않는다**. 다음 항목들도 piaf 에 없음:
+- `idle_ttl_seconds` (idle eviction)
+- `max_idle_per_host`, `max_total_idle`
+- per-host TLS context cache
+
+### 8.2 정정 — cohttp upstream patch 후보 reject
+
+ocaml-cohttp issue #85 는 **2014 closed** 됐고 resolution 은
+`cohttp-lwt` + `cohttp-async` 한정. `cohttp-eio` 는 inherit 받지 않았으며
+별도의 open FD-hygiene 이슈 (#965 / #1121 / #676) 가 진행 중. 따라서
+RFC-0107 §3.1 의 후보 (b) "cohttp-eio + 자체 upstream patch" 는
+실현 가능 path 가 없다. **piaf 직진이 유일한 합리적 후보**.
+
+### 8.3 D.1 → D.2 sizing 재조정
+
+위 두 finding 의 결과로 D.2 작업량이 *증가* 한다:
+
+| 항목 | D.1 가정 | B 후 정정 |
+|---|---|---|
+| pool 자료구조 | piaf 가 제공 → thin wrapper | 자체 구현 (`Host_key → piaf Client.t queue`) |
+| idle eviction fiber | piaf 가 제공 | 자체 구현 (Eio fiber on pool's root_sw) |
+| per-host TLS context | piaf 가 캐싱 | 자체 캐시 (Eio_context 의 `_https_connector_cache` 확장 또는 pool 내장) |
+| pool 의 unit type | raw FD | `piaf Client.t` (FD ownership 은 piaf+Eio.Switch 에 위임) |
+
+**D.2 LoC re-estimate**: 400 → **600** (host map + eviction fiber +
+TLS cache 추가). 13 callsite 마이그레이션은 동일.
+
+§7 의 "Anti-prior-art — 자체 connection pool 재구현 (X)" 도 정정:
+*"piaf 가 single-host keep-alive 를 제공하므로 그 위에 multi-host pool
+layer (host map + eviction) 만 build. 자체 single-host 재구현은 여전히
+거부."* — 즉 **single-host keep-alive 는 piaf 에 위임, multi-host pool
+은 자체 build** 가 정확한 경계.
+
+### 8.4 Eio #244 인용 추가 (TLA+ motivation)
+
+B finding §"Eio #244 — exactly-one-owner 원칙" 이 우리 design 에
+직접 인용 가능:
+
+> Talex5 본인이 `Unix.close` 이중 close 패닉을 만나 `accept_fork` API
+> shape 을 바꿔서 해결. 우리 masc-mcp 의 `connection: close` 강제
+> 워크어라운드와 cohttp-eio #965 가 같은 버그 class.
+
+D.2 에서 추가할 TLA+ spec `Pool_no_double_close.tla` 의 motivation
+으로 차용. 본 spec 은 `Pool.release` 가 connection 을 *idle queue 로
+반환* 하는 경로와 *close 하는* 경로 사이의 exclusive choice 를
+모델링하여 같은 connection 의 release+release 또는 release+close 가
+불가능함을 증명한다.

--- a/docs/rfc/RFC-0107-phase-d-pool-design.md
+++ b/docs/rfc/RFC-0107-phase-d-pool-design.md
@@ -1,0 +1,268 @@
+---
+rfc: "0107"
+phase: D
+status: Design
+created: 2026-05-17
+supplement_of: RFC-0107
+implementation_prs: []
+---
+
+# RFC-0107 Phase D — Connection pool design (interface-first)
+
+본 문서는 Phase D 의 *interface-first design* 단계 산출물이다. 구현은
+Phase B (HTTP transport spike) 의 결정 후 이 interface 위에 transport
+binding 을 채워 넣는다. Interface 자체는 transport-agnostic 으로
+설계해서 `piaf` 와 `cohttp-eio + manual patch` 사이의 선택이 바뀌어도
+callsite 변경이 없도록 한다.
+
+## 1. Callsite inventory (masc-mcp 내부)
+
+`Cohttp_eio.Client.*` 직접 호출 (5 callsites — *3 in masc_http_client 본
+체, 2 in voice_bridge*):
+
+| 파일:라인 | 호출 | 형태 |
+|---|---|---|
+| `lib/masc_http_client/masc_http_client.ml:70` | `Cohttp_eio.Client.make_generic connect` | factory (in module) |
+| `lib/masc_http_client/masc_http_client.ml:118` | `Cohttp_eio.Client.post client ~sw uri ...` | per-call |
+| `lib/masc_http_client/masc_http_client.ml:156` | `Cohttp_eio.Client.get client ~sw ~headers uri` | per-call |
+| `lib/voice/voice_bridge.ml:461` | `Cohttp_eio.Client.post ~sw ~body ~headers client uri` | shared client |
+| `lib/voice/voice_bridge.ml:701, 990` | `Cohttp_eio.Client.get ~sw:inner_sw client uri` | shared client |
+
+`Masc_http_client.*` 간접 호출 (8 callsites):
+
+| 파일:라인 | API |
+|---|---|
+| `lib/server/server_dashboard_http_link_preview.ml:350` | `get_response_sync` |
+| `lib/local/worker_container_types.ml:184` | `post_sync` |
+| `lib/voice/voice_bridge_core.ml:118` | `make_closing_client` |
+| `lib/auto_responder.ml:226` | `post_sync` |
+| `lib/cascade/cascade_http_probe.ml:154` | `get_sync` |
+| `lib/graphql_client.ml:181` | `post_sync` |
+| `lib/opentelemetry_client_cohttp_eio.ml:147` | `make_closing_client` |
+
+**합계: 13 callsites** in masc-mcp. (OAS 별도 repo 는 본 Phase 범위 외.)
+
+## 2. Current anti-pattern (per call, 모든 sync 호출자 동일)
+
+```ocaml
+Eio.Switch.run @@ fun sw ->
+let client = make_closing_client ~sw ~net ~https in    (* (1) new client *)
+let hdr = Cohttp.Header.of_list (("connection", "close") :: headers) in  (* (2) force close *)
+let resp, resp_body = Cohttp_eio.Client.get client ~sw ~headers:hdr uri in
+(* (3) manual flow tracking via on_release *)
+(* (4) switch exit closes the socket — no reuse *)
+```
+
+문제:
+- **(1)** 매 호출 새 TCP/TLS handshake → latency + FD spike
+- **(2)** `connection: close` 강제 → keep-alive 0 건
+- **(3)** `tracked_flows` ref + `on_release` callback — workaround
+  for cohttp-eio 6.1.1 socket-not-closed bug (`masc_http_client.ml:13`
+  주석)
+- **(4)** Fresh switch per call — pool 자체가 attach 할 long-lived
+  switch 없음
+
+(3) 은 Phase C.1 의 turn-scoped switch 가 wiring 된 *이후*에도 여전히
+필요한데 — Phase D 의 pool 이 자체 long-lived switch (server root_sw)
+에 attach 하면 wrapper 의 (3) 은 사라진다 (pool 이 reuse 하므로
+release 시 close 하지 않음).
+
+## 3. Pool design (transport-agnostic interface)
+
+핵심 결정: **opaque `Pool.t`** + **`with_connection`** callback API.
+`acquire`/`release` 같은 명시적 lifetime API 대신 scoped callback.
+근거: callsite 가 acquire 후 잊으면 leak. callback 은 type 차원에서
+release 보장.
+
+### 3.1 interface skeleton
+
+```ocaml
+(* lib/masc_http_client/pool.mli — Phase D design draft *)
+
+type t
+(** Opaque per-process connection pool. Attaches to a long-lived
+    Eio.Switch (typically server root_sw via Eio_context). Pool itself
+    survives turn boundaries; *per-host* connection state evicts on
+    idle_ttl. *)
+
+type config = {
+  max_idle_per_host : int;
+  max_total_idle    : int;
+  idle_ttl_seconds  : float;
+  connect_timeout_seconds : float;
+}
+
+val default_config : config
+(** Conservative defaults derived from RFC-0101 §2 nofile cap (10240):
+    - max_idle_per_host = 8
+    - max_total_idle    = 256   (= 10240 * 0.025, well under cap)
+    - idle_ttl_seconds  = 60.0
+    - connect_timeout_seconds = 5.0 *)
+
+val create :
+  sw:Eio.Switch.t ->
+  net:[> `Generic ] Eio.Net.ty Eio.Resource.t ->
+  ?https:(Uri.t ->
+          [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t ->
+          [ `Close | `Flow | `R | `Shutdown | `Tls | `W ] Eio.Resource.t) ->
+  ?config:config ->
+  unit ->
+  t
+(** Initialize the pool on a long-lived switch (server root_sw). The pool
+    closes idle connections when [sw] closes; in-flight requests outlive
+    pool cleanup via per-call sub-switches. *)
+
+(* ── Request API ─────────────────────────────────────────────────────── *)
+
+type response = {
+  status : int;
+  headers : (string * string) list;
+  body : string;
+}
+(** Mirrors current [Masc_http_client.response]. *)
+
+val request :
+  t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  ?timeout_seconds:float ->
+  method_:[ `GET | `POST | `PUT | `DELETE | `HEAD | `PATCH ] ->
+  url:string ->
+  ?headers:(string * string) list ->
+  ?body:string ->
+  unit ->
+  (response, string) result
+(** High-level scoped call. Acquires a connection from the per-host pool
+    (or creates one if the pool is empty / under max_idle_per_host),
+    issues the request, releases the connection back to the pool for
+    keep-alive reuse, and returns the typed response. Pool semantics:
+
+    - Same scheme+host+port → same pool slot, connection reused.
+    - Connection acquired but no slot available within max_idle_per_host
+      → creates a fresh transient connection that is *closed on release*
+      instead of returned.
+    - idle_ttl_seconds expired → connection evicted before reuse,
+      replaced by a fresh handshake.
+    - connection error during reuse → caller sees Error; pool drops
+      that connection and surfaces the error (no silent retry — caller
+      decides). *)
+
+val with_connection :
+  t ->
+  url:string ->
+  ((* low-level handle — transport-specific. Phase D step 2 (post-B):
+      either piaf [Piaf.Client.t] or our own [Cohttp_eio.Client.t] +
+      socket-tracking wrapper. Exposed only for streaming callsites
+      (voice_bridge). Most callers should use [request]. *)
+   unit -> 'a) -> 'a
+(** Scoped low-level handle. Released to pool on return. Streaming
+    callers (response body iteration spanning multiple Eio.Fiber.yield)
+    use this; one-shot callers use [request]. *)
+
+(* ── Telemetry ──────────────────────────────────────────────────────── *)
+
+type stats = {
+  idle_per_host : (string * int) list;   (* host -> idle count *)
+  total_idle : int;
+  total_inflight : int;
+  reuse_count_total : int;
+  evict_count_total : int;
+  create_count_total : int;
+}
+
+val stats : t -> stats
+(** Non-mutating snapshot for Prometheus exporter / dashboard. *)
+```
+
+### 3.2 Migration shim — Masc_http_client unchanged
+
+`Masc_http_client.{post_sync,get_sync,get_response_sync}` 는
+*signature 그대로* 유지하되 내부적으로 process-wide singleton
+`Pool.t` 를 lazy 생성하여 `Pool.request` 로 위임. 13 callsites 코드
+변경 0. 점진적으로 callsite 가 `Pool.request` 로 직접 마이그레이션
+가능.
+
+```ocaml
+let pool : Pool.t Lazy.t = lazy (
+  let sw = Eio_context.get_switch_opt ()  (* server root_sw 가져오기 *)
+           |> Option.get_exn_or "Masc_http_client: Eio_context not initialized" in
+  let net = Eio_context.get_net_opt () |> Option.get_exn_or "net not init" in
+  let https = Eio_context.get_https_connector_result () |> Result.get_or in
+  Pool.create ~sw ~net ~https ()
+)
+
+let post_sync ?clock ?timeout_sec ~net:_ ?(https=None)
+              ~url ~headers ~body () =
+  let _ = https in  (* connector now lives in pool *)
+  Pool.request (Lazy.force pool)
+    ?clock ?timeout_seconds:timeout_sec
+    ~method_:`POST ~url ~headers ~body ()
+  |> Result.map (fun {Pool.status; body; _} -> (status, body))
+```
+
+cohttp-eio 의 socket-not-closed bug 는 pool 안에서 *reuse* 되므로 무관
+해진다. release 시 close 안 함. 만약 connection 이 error 상태면 그때
+명시적 close (drop from pool).
+
+### 3.3 Switch hierarchy — Phase C.1 와의 결합
+
+Phase C.1 이 wiring 한 `with_turn_switch` 와의 관계:
+
+- **Pool 자체**: `Pool.create ~sw:root_sw` — 서버 lifetime. idle
+  connection 이 turn boundary 를 가로질러 살아남는다.
+- **Per-request fiber**: `Pool.request` 내부에서 short-lived sub-switch
+  를 열어 fiber spawn 한다. sub-switch 가 turn_sw (있으면) 또는
+  root_sw (없으면) 의 child. 자동.
+- **In-flight cancellation**: turn_sw 가 닫히면 (turn end /
+  cancellation) sub-switch 도 닫혀 in-flight request 가 취소된다.
+  Connection 자체는 pool 의 root_sw 에 attach 되어 idle 로 돌아간다.
+- **idle_ttl eviction**: pool 의 background fiber 가 idle 통계 모니터.
+  pool 의 root_sw 에 attach.
+
+### 3.4 4-axis 측정 (Phase B spike 결과와 연결)
+
+본 interface 위에 piaf 와 cohttp-eio-patched 두 구현을 plug-in 가능.
+Phase B 의 4-axis bench (fd-peak, RPS, TLS handshake count, switch-clean
+exit) 가 *동일 interface* 위에서 비교 → 결과를 RFC §3.1 에 인용 →
+Phase D step 2 가 그 결정 위에 구현.
+
+## 4. Phase D 단계
+
+| Step | Scope | Dependencies | LoC estimate |
+|---|---|---|---|
+| **D.1 (이 PR)** | interface design + skeleton mli + design 노트 | Phase C.1 머지 | ~150 (mli + 노트) |
+| **D.2** | piaf wrapper or cohttp patched 구현 + 13 callsite migration (shim 유지) | D.1 + Phase B 결과 | ~400 |
+| **D.3** | stream callsite migration (voice_bridge 2개) | D.2 | ~80 |
+| **D.4** | Prometheus export + dashboard tile | D.2 | ~120 |
+| **D.5** | cascade-storm reproducer (16 keepers × 5 turn) — fd 평탄 검증 | D.2 + D.4 | ~150 |
+
+## 5. Trade-offs & open questions
+
+| 항목 | 결정 또는 open |
+|---|---|
+| acquire/release vs callback | **callback** (`with_connection`, `request`) — leak resistant |
+| Pool lifetime | **server root_sw** — pool 자체는 process-lifetime |
+| connection error 시 retry | **caller 결정** (pool 은 connection drop 만 함) — silent retry 는 N-of-M anti-pattern 위험 |
+| per-host TLS context cache | piaf 가 이미 함 (Phase B 확인) — cohttp 직접 구현 시 우리가 더해야 함 |
+| HTTP/2 지원 | **out-of-scope** (RFC §2 non-goal). piaf 는 무료로 받지만 callsite 가 h1 가정 |
+| max_idle_per_host = 8 정당화 | RFC-0101 §2 nofile=10240 cap, 256 server slots × 8 idle = 2048, safe |
+| OAS repo 마이그레이션 | **out-of-scope of Phase D**. masc-mcp 13 callsites 만. OAS 는 동등 interface 후속 PR |
+
+## 6. 검증
+
+- D.2 의 cascade-storm reproducer: 16 keepers × 5 turn, `lsof -p <pid>`
+  peak measurement. RFC-0101 throttle 비활성화 상태에서 < 256 FD peak
+  목표.
+- D.3 voice_bridge stream callsite: 기존 streaming behavior 유지
+  (수동 read_chunks loop) + connection 재사용 확인.
+- D.5 30-day production sample (Phase F retirement gate 의 입력).
+
+## 7. Anti-patterns 명시적 거부
+
+본 design 은 RFC-0107 §"Anti-prior-art" 와 정합:
+- **자체 connection pool 재구현 (X)** — piaf 가 이미 구현. cohttp
+  fork 경로 시에도 piaf 의 pool 모듈 reference.
+- **자체 Switch 추상화 wrapper (X)** — Phase C.1 의 `with_turn_switch`
+  로 충분. pool 은 그 위에 binding 안 들고 직접 Eio.Switch 사용.
+- **자체 FD 회계 시스템 (X)** — RFC-0101 의 `Fd_accountant` 와 별개.
+  pool 의 stats 는 reuse/evict/create counter 만, throttle 없음. Phase
+  F retirement gate 의 measurement.

--- a/knowledge/research/2026-05-17-piaf-ocsigen-eio-fd-prior-art.md
+++ b/knowledge/research/2026-05-17-piaf-ocsigen-eio-fd-prior-art.md
@@ -1,0 +1,282 @@
+---
+title: RFC-0107 Prior Art — piaf / Ocsigen-Eio / cohttp keep-alive / Eio FD safety
+date: 2026-05-17
+relates_to: RFC-0107
+status: research
+confidence: medium-high (5/5 references fetched, 2 only partially)
+---
+
+# 1. Five references summarized
+
+| # | Source | Fetch | One-line takeaway | RFC-0107 section mapping |
+|---|---|---|---|---|
+| 1 | piaf (anmonteiro) GitHub source + `piaf.mli` | OK (full read of `lib/client.ml`, `lib/connection.ml`, `lib/config.ml`, `lib/piaf.mli`) | piaf has **no multi-host connection pool**; `Client.t` is a *per-endpoint* persistent client whose lifetime is bound to a user-supplied Switch. Idle eviction / `idle_ttl` / `max_idle` do not exist. | §3.1 transport candidate, §3.2 L2 pool design (we have to build pool *on top of* piaf; we do not get it for free) |
+| 2 | Tarides Ocsigen→Eio announcement (2025-03-13) | Partial (announcement only, no technical retrospective) | The 2025-03-13 post is an *announcement*, not a retrospective. The substantive Eio-migration tooling lessons live in the 2026-03-05 follow-up `ciao-lwt` post. | §1.3 Switch hierarchy gap (only thin signal) |
+| 2b | Tarides ciao-lwt follow-up (2026-03-05) | OK | Main concrete lesson: **implicit forks** are the dominant Lwt→Eio migration trap; type-checker is the principal validator. No concrete FD-leak / Switch-hierarchy bug stories yet. | §1.3 (weak — implicit-fork pattern ≠ our FD-pinning bug, but adjacent) |
+| 3 | ocaml-cohttp issue #85 "Support HTTP Keep-Alive" | OK | **Closed 2014.** Resolved for `cohttp-lwt` + `cohttp-async` only (PR #88, rgrinberg + avsm). `cohttp-eio` is **not** covered — see §4 for the open cohttp-eio FD/close issues. | §3.1 — `cohttp-eio upstream patch` candidate is **not viable**: keep-alive work is finished, cohttp-eio inherited none of it |
+| 4 | Eio issue #244 "close: file descriptor used after calling close!" | OK (header + body via `gh api`, comments thread empty/locked) | **Server-side bug** in `Eio.Net.accept_fork` (Eio 0.3, June 2022), closed 2022-07-01 via PR #245. Talex5 author. Workaround quoted verbatim: *"avoid manually closing the socket (there's no very good reason to continue handling a connection after closing it)"* | §1.2 — supports our hypothesis that Eio's response to "FD used after close" is structural (own the close path), not lock-the-FD. Phase C TLA+ motivation. |
+| 5 | Eio.Switch official docs | OK | Five axioms cleanly quoted (see §6). The key invariant is "**The resource cannot outlive its switch.**" on_release runs LIFO, under `Cancel.protect`, after all child fibers finish. | §3 axiom for every L2/L3 design |
+
+# 2. piaf — switch-lifetime-bound *per-endpoint* client (not a pool)
+
+## 2.1 What piaf actually is
+
+From `lib/piaf.mli` (verbatim):
+
+> There are two options for issuing requests with Piaf:
+>   + client: useful if multiple requests are going to be sent to the remote endpoint, avoids setting up a TCP connection for each request. Or if HTTP/1.0, you can think of this as effectively a connection manager.
+>   + oneshot: issues a single request and tears down the underlying connection once the request is done. Useful for isolated requests.
+
+And the `Client.create` doc says:
+
+> A client instance represents a connection to a **single remote endpoint**, and the remaining functions in this module will issue requests to that endpoint only.
+
+Translation: piaf gives **single-host keep-alive** + **redirect-aware reconnect**, not a `Host → Pool[Connection]` data structure.
+
+## 2.2 The Client.t shape (`lib/client.ml:38`)
+
+```ocaml
+type t =
+  { mutable conn : Connection.t  (* single connection, mutated on reconnect *)
+  ; env : Eio_unix.Stdenv.base
+  ; sw : Switch.t                 (* captured user switch *)
+  }
+```
+
+Pool semantics live in `reuse_or_set_up_new_connection` (client.ml:~190) and key off two flags:
+
+- `conn.persistent : bool` — set from `Request.persistent_connection request` on every `call`, then later refreshed from `Response.persistent_connection response`. Inherits `Connection: close` semantics from httpun/h2.
+- `Http_impl.is_closed` — checked before reuse.
+
+The decision tree:
+
+```
+if (not persistent) || is_closed connection
+  then change_connection  (* fork shutdown + open new *)
+else if equal_without_resolving info new_info
+  then reuse                (* same host/port/scheme *)
+else if equal info new_info (* after DNS *)
+  then reuse
+else
+  change_connection
+```
+
+**Critical**: this is per `Client.t`, not a global pool. If you want a host → N connections pool, you must wrap `Client.t` yourself.
+
+## 2.3 Switch lifetime binding (the part RFC-0107 actually needs)
+
+piaf binds resources to switches in two places:
+
+1. **`Client.create ~sw env uri`** captures the user's `Switch.t` into `t.sw`. All forked work (`Fiber.fork ~sw:t.sw`) — including async shutdown of stale connections during redirects (`change_connection`, client.ml:~165) — is bound to it.
+2. **`Eio.Net.connect ~sw network address`** in `Connection.connect` (connection.ml:~190) binds the socket FD to the same switch.
+
+This means: when the user-provided switch finishes, *all* live FDs from this client are released by Eio. piaf does no manual `Eio.Flow.close` on the FD in the happy path — it relies on the switch contract (§6). `shutdown_conn` calls `Http_impl.shutdown` (which closes the underlying gluten runtime), but Eio's switch is still the FD's owner of record.
+
+## 2.4 Idle eviction / TLS context caching: **absent**
+
+- `Config.t` (config.ml:38–105, verbatim full struct read) has **no** `idle_ttl`, `max_idle`, `keep_alive_timeout`, `pool_size` fields. The closest fields are `connect_timeout : float`, `buffer_size`, `body_buffer_size`.
+- TLS context: `Openssl.connect` is called *per connection open* in `create_https_connection` (client.ml:~75). The returned `ssl_ctx` rides inside `Connection.t`. There is no `Ssl.Context.t` cache at the Client layer — each new TCP connect rebuilds it.
+
+## 2.5 h1 + h2 + ALPN + WebSocket
+
+- h1: `lib/http1.ml` (httpun)
+- h2: `lib/http2.ml` (h2 library)
+- ALPN: `Versions.ALPN`, negotiated in `create_https_connection`
+- WebSocket: `Ws` module + `Client.ws_upgrade` (yes, present)
+- h2c upgrade: `Config.h2c_upgrade`
+
+Pro: full protocol surface, including h2 multiplexing (we'd benefit on /v1/messages, /v1/responses).
+
+Con: SSL stack is openssl (via `eio-ssl` + native bindings). Adds a transitive on `eio-ssl`, `openssl` C lib. Compare to `mirage-crypto` / `tls` (pure OCaml) used by `http-mirage-client`.
+
+## 2.6 Activity
+
+- Last release: 0.2.0 (2024-09-06). ~256 commits on master. Active maintainer (anmonteiro = author of httpun, h2, gluten). Not abandoned.
+- Open issues search for `pool`, `keep-alive idle`, `connection pool` returned **zero** hits — confirming piaf does not advertise itself as a pool library.
+
+# 3. Tarides Ocsigen → Eio: signal vs noise
+
+## 3.1 What we got
+
+| Post | Date | Useful for RFC-0107? |
+|---|---|---|
+| "We're Moving Ocsigen from Lwt to Eio!" | 2025-03-13 | No technical content — pure announcement. Names Eliom / Js_of_ocaml / Ocsigen Server / Lwt as migration scope. Funded by NLnet / NGI Zero Core. |
+| "Announcing `ciao-lwt`" | 2026-03-05 | Some signal: the dominant migration pitfall is **implicit forks** (Lwt promises that get scheduled by `bind` rather than an explicit `fork`). Repo: github.com/tarides/ciao-lwt. |
+
+## 3.2 What's missing (and why)
+
+Neither post documents:
+- Switch hierarchy bugs
+- FD leak patterns uncovered during migration
+- Connection-pool design lessons
+- Concrete cancellation propagation mistakes
+
+The 2026-03-05 post explicitly says "Your resulting code will likely not typecheck" — implying that they're treating the OCaml compiler as the primary correctness gate, not a retrospective on runtime failures.
+
+**Implication for RFC-0107 §1.3**: We cannot lean heavily on Tarides as prior art for our specific Switch-hierarchy / FD-pinning concerns. The ciao-lwt repo source itself may contain transformation rules worth a Phase C revisit. **확인 필요**: read `github.com/tarides/ciao-lwt` source for any "wrap in Switch.run" or "attach to switch" rewrite rules.
+
+# 4. cohttp issue #85 status (as of 2026-05-17)
+
+**Status: CLOSED 2014-era. Keep-alive landed for cohttp-lwt + cohttp-async only.**
+
+Verbatim comment thread from `gh issue view 85`:
+
+1. rgrinberg: *"I believe the lwt server Keep-Alive so this only applies to the Async backend"*
+2. rgrinberg (correction): *"cohttp/lwt only supports keep-alive behaviour against http 1.1 clients. It does not respect 'connection: keep-alive' from http 1.0 clients. It also does not send 'connection: close' headers when it should."*
+3. rgrinberg: *"P.S. I'm making an attempt to make the async backend support persistent connections at #88..."*
+4. avsm: *"#88 has been merged now, but we still need to add some keep-alive test cases"*
+5. rgrinberg: *"Some tests have been added as well now."*
+
+PR #88 was merged. Issue closed.
+
+**Why this is not enough for cohttp-eio**: `cohttp-eio` is a newer (2022+) backend, written independently from cohttp-lwt/async. Adjacent open issues confirm cohttp-eio's client side has no keep-alive and active FD-handling problems:
+
+| Issue | State | Date | Summary |
+|---|---|---|---|
+| #965 cohttp-eio: "handle used after calling close" | OPEN | 2023-02-02, 12 comments | FD-after-close panics on body > a few KB; smondet repro. Mirrors masc-mcp's `connection: close` workaround. |
+| #1121 cohttp-eio `expert` mode doesn't allow closing of the stream | OPEN | 2026-03-01 | `Eio.Buf_read` has no close, workaround = `exception Die`. |
+| #676 How to close connections? (cohttp client) | OPEN | 2022-01-02 | Long-standing close-API gap. |
+| #1101 cohttp-eio: take executor pool instead of creating domains | CLOSED | 2024-12-29 | Pool of *domains*, not connections. |
+
+**Decision unblocked**: `cohttp-eio upstream patch` is **not viable** as our L1 transport for RFC-0107. We would inherit known open FD bugs and zero keep-alive. piaf direct.
+
+**Confidence**: HIGH (issue #85 comment thread fully fetched; #965/1121 metadata fetched).
+
+# 5. Eio issue #244 — Unix FD safety, ground truth
+
+## 5.1 What the issue actually says
+
+Verbatim body from `gh api repos/ocaml-multicore/eio/issues/244`:
+
+> In Eio 0.3 `accept_fork` always closes then socket when the function returns. However, the function is supposed to be allowed to close it itself first if it wants to. This results errors such as:
+>
+> &nbsp;&nbsp;&nbsp;&nbsp;`Error handling connection: Cancelled: Invalid_argument("close: file descriptor used after calling close!")`
+>
+> A work-around is to avoid manually closing the socket (there's no very good reason to continue handling a connection after closing it).
+
+Closed: 2022-07-01 via PR #245. Author: talex5 (Eio lead).
+
+## 5.2 What it actually demonstrates (the part useful for RFC-0107)
+
+The `Invalid_argument("close: file descriptor used after calling close!")` exception is **OCaml's `Unix.close` panicking on double-close**. The user (talex5 himself, who maintains both Eio and the cohttp-eio shim) hit it because the Eio scheduler was closing the FD that user code had already closed.
+
+This is the *exact same* error class as the cohttp-eio #965 bug ("handle used after calling close"). The fix wasn't "add a guard around close" — it was changing the `accept_fork` API so the scheduler *does not pre-emptively close*.
+
+## 5.3 Implications for libraries wrapping raw Unix sockets
+
+The pattern Eio enforces, post-#244:
+
+1. **Exactly one owner** per FD. Either the scheduler closes it (on switch finish) or user code closes it explicitly, never both.
+2. **No double-close panic recovery**. There is no `try Unix.close fd with _ -> ()` pattern endorsed by Eio — instead, the API surface is shaped so it never happens.
+3. **Talex5 quote on the workaround** (verbatim above): *"A work-around is to avoid manually closing the socket (there's no very good reason to continue handling a connection after closing it)."*
+
+## 5.4 What's NOT in the issue (caveat)
+
+The originally hypothesised statement *"OCaml's Unix module is not safe, possible to leak FDs"* is **not present verbatim in issue #244**. That phrasing may come from talex5's Eio README or talks (Eio README WebFetch attempt did not surface it either — see §6 caveat). For RFC-0107 quoting purposes, we should attribute the FD-ownership rule to:
+
+- `Eio.Switch` doc (§6 below) — formal invariant
+- Eio issue #244 — concrete bug + endorsed workaround
+- *Not* to a "Unix module is unsafe" quote (확인 필요 — likely a talk/discussion comment, not in headline docs)
+
+## 5.5 Phase C TLA+ spec motivation
+
+We can cite Eio #244 directly as the *prior art* for "exactly-one-owner" as a TLA+ invariant. The state-space we'd model:
+
+```
+FdOwnership ∈ [fd → {SchedulerOwned, UserOwned, Closed}]
+NoDoubleClose ≡ ∀ fd : owner state transitions never go Closed → Closed
+ExactlyOneCloser ≡ Cardinality({s ∈ History : s closes fd}) ≤ 1
+```
+
+This is materially the same property Eio's design enforces operationally via Switch.
+
+# 6. Eio.Switch contract — resource lifetime axiom
+
+Verbatim from the Eio.Switch ocamldoc:
+
+| Property | Quote |
+|---|---|
+| Lifetime invariant | **"The resource cannot outlive its switch."** |
+| `run` signature | `val run : ?name:string -> (t -> 'a) -> 'a` |
+| `run` contract | "When `fn` finishes, `run` waits for all fibers registered with the switch to finish, and then releases all attached resources." |
+| `on_release` ordering | "Release handlers are run in LIFO order, in series." |
+| `on_release` execution timing | "Hooks run once `t`'s main function has returned and all fibers have finished." |
+| `on_release` cancellation immunity | "They execute within `Cancel.protect`, preventing cancellation interruption during cleanup." |
+| Cancellation propagation | "[`fail`] cancels all fibers attached to the switch and, once they have exited, reports the error." It "ensures that the switch's cancellation context is cancelled, to encourage all fibers to exit as soon as possible." |
+| Outlasting parent switch | Prevented by API shape: resources "require a switch to be provided when they are created"; functions cannot return resources whose switch finishes first. |
+
+**Caveat**: the broader README-level Eio docs ("Switches and resources" section, full `rationale.md`) could not be fetched with our tools (WebFetch returned summarised/truncated content for GitHub source pages). The 7 quotes above all originate from the ocamldoc page `ocaml-multicore.github.io/eio/eio/Eio/Switch/index.html`.
+
+## 6.1 RFC-0107 axiom mapping
+
+| RFC-0107 design choice | Eio.Switch backing |
+|---|---|
+| L1 transport must accept a `~sw` argument | "resource cannot outlive its switch" — every FD must have a switch |
+| L2 pool's `acquire` returns a connection bound to a *child switch* | `Switch.run` nesting; child switch finishes before parent → connection cleanup deterministic |
+| L3 client API never returns an FD past the user's `Switch.run` boundary | API shape rule (§6 bottom row) |
+| Backpressure / cancellation | `fail` propagates structurally; we lean on `Cancel.protect` for the release path |
+
+# 7. RFC-0107 §3.1 transport candidate ranking (informed by §2–§6)
+
+| 후보 | h1 / h2 / ws | per-host KA | TLS context caching | switch-clean exit | dependencies | recommendation |
+|---|---|---|---|---|---|---|
+| **piaf 0.2.0** | h1 + h2 + ws + h2c + ALPN | YES (single conn, redirect-aware) | NO (per-connect) | YES (sw threaded through) | httpun, h2, gluten, eio-ssl, openssl C | **DEFAULT L1 candidate**. We build pool/idle eviction/TLS-ctx cache *on top* (L2). Mature maintainer, no abandoned issue queue, full HTTP/2 we need for Anthropic. |
+| **cohttp-eio + upstream patch** | h1 only (cohttp-eio); h2 separate library | NO (open issues #676/#965/#1121, no roadmap) | N/A | UNRELIABLE (double-close bug class) | mirage-cohttp ecosystem | **REJECT**. Issue #85 keep-alive work is closed but only covers lwt/async backends; cohttp-eio has known FD-hygiene bugs (§4 table). |
+| **http_eio (experimental)** | varies | unclear | N/A | unclear | n/a | **REJECT** (experimental, no production uptake, drops upstream-pressure leverage) — confirm in Phase C if surfaced. 확인 필요: no canonical "http_eio" library was found in our searches, this name may be a placeholder. |
+| **http-mirage-client (robur)** | h1 + h2 via paf+h2 | host-pinned, MirageOS-flavoured | mirage-crypto-based | YES (mirage style) | mirage stack | **DEFER**. Cleaner TLS story (no openssl C), but MirageOS-shaped API; mismatches our Eio-direct calling convention. Re-evaluate if `eio-ssl` proves a pain. |
+
+**Decision**: piaf 0.2.0 as L1. RFC-0107 §3.2 (L2 pool) must build:
+1. `Host_key.t = { host : string; port : int; scheme : Scheme.t }` → `(Client.t * idle_since : float) Eio.Stream.t` (or queue).
+2. `idle_ttl` field on our pool config; eviction fiber that closes Client.t whose `idle_since` exceeds TTL.
+3. `Ssl.Context.t` cache, since piaf rebuilds per connect.
+4. `Switch.t` per pool-entry (child of user's switch), so `Pool.release` can `Switch.fail` to evict.
+
+# 8. Anti-prior-art (피해야 할 패턴)
+
+Patterns that surface in §2–§6 and that RFC-0107 must NOT replicate:
+
+1. **자체 connection pool 재구현**
+   - Don't write a per-piaf-Client.t custom pool layer that ignores piaf's own redirect-reconnect logic. Use `Client.t` as the *unit* in the pool and let piaf own intra-host state.
+   - Don't add a second FD-ownership owner. Piaf already owns the FD via the user's `~sw`. Our pool wrapper *attaches a child switch*, never closes the FD directly.
+
+2. **자체 Switch 추상화 wrapper**
+   - Don't invent a `Pool_switch` type. Use `Eio.Switch.t` directly; if we need richer events (idle-timer firing → close), add an `Eio.Condition` or fiber, not a new type.
+   - Don't bypass `Switch.run`'s LIFO `on_release` ordering with manual cleanup queues.
+
+3. **자체 FD 회계 시스템**
+   - Don't track FDs by integer ID. Eio's typed `Eio.Net.stream_socket` *is* the accounting unit. Our metrics (`fd_high_watermark`, `connections_idle`) should derive from pool-entry counts, not from `getrlimit` polling.
+   - Don't add `try Unix.close fd with _ -> ()` defensive code. Eio #244's lesson: shape the API so the single owner is unambiguous.
+
+4. **`cohttp-eio` 기반 keep-alive 시도**
+   - Wasted move (§4). Issue #85 is closed; cohttp-eio has not inherited it; #965/#676/#1121 are open and the failure mode mirrors our existing `connection: close` workaround in `lib/masc_http_client/masc_http_client.ml:13`.
+
+5. **TLS handshake per request**
+   - Don't accept piaf's per-connect `Openssl.connect` as the steady state. Cache `Ssl_ctx` at L2; only rebuild on cert/CA rotation.
+
+6. **자체 텔레메트리-as-fix counters around FD lifecycle**
+   - Per `software-development.md` §워크어라운드 거부 기준 / signature #1: a `fd_double_close_counter` is a workaround, not a fix. The Phase C TLA+ spec (`NoDoubleClose`) is the structural answer.
+
+---
+
+## Appendix A — Fetch status table
+
+| Ref | URL | Method | Result |
+|---|---|---|---|
+| piaf README | github.com/anmonteiro/piaf | WebFetch | OK (truncated, sufficient) |
+| piaf source | raw.githubusercontent.com/.../master/lib/{client,connection,config,piaf.mli,http_impl}.ml | `curl -o` then read | OK (full files, primary evidence source) |
+| Tarides 2025-03-13 | tarides.com/blog/2025-03-13-... | WebFetch | OK (announcement, low signal) |
+| Tarides 2026-03-05 ciao-lwt | tarides.com/blog/2026-03-05-... | WebFetch | OK (some signal — implicit forks) |
+| Tarides blog index | tarides.com/blog | WebFetch | OK (surfaced the 2026-03-05 follow-up) |
+| cohttp #85 | gh api / gh issue view | gh CLI | OK (full comment thread, 5 comments) |
+| cohttp-eio adjacent issues | gh issue list | gh CLI | OK (titles + dates) |
+| Eio #244 | gh api repos/ocaml-multicore/eio/issues/244 | gh CLI | OK (body verbatim; comments endpoint returned empty — talex5 self-closed via PR #245) |
+| Eio.Switch docs | ocaml-multicore.github.io/eio/eio/Eio/Switch/index.html | WebFetch | OK (7 verbatim quotes obtained) |
+| Eio rationale.md | github.com/.../doc/rationale.md | WebFetch | PARTIAL (focused on 4 design topics, not on FD safety wording) |
+| Eio README "Switches and resources" | github.com/.../README.md | WebFetch | PARTIAL (could not surface verbatim "resource cannot outlive its switch" wording at README level — confirmed only in Switch ocamldoc) |
+
+## Appendix B — Items requiring future verification (확인 필요)
+
+1. *"OCaml's Unix module is not safe"* phrasing: probably a talex5 talk/discussion comment, not in headline docs. If RFC-0107 wants to cite it, find the original (eio mailing list, Discuss thread, or RWO talk transcript).
+2. `http_eio` as a candidate library: no canonical project surfaced under this name. If RFC body has it, replace with concrete name or drop.
+3. `ciao-lwt` source-level transformation rules: the blog hints at "wrap with explicit fork" but does not enumerate. Phase C may benefit from reading `github.com/tarides/ciao-lwt` rules/AST directly.
+4. piaf 0.2.0 → 0.3.x roadmap: anmonteiro/piaf may have unreleased master-branch features (we read `master`, not a tag). Cross-check before pinning a specific opam version in Phase D.


### PR DESCRIPTION
## Summary

RFC-0107 Phase D step 1 — Connection pool **interface-only design**.
Defers implementation to D.2 (after Phase B HTTP transport spike) so
the chosen transport (piaf vs cohttp-eio-patched) binds to a stable
interface without callsite churn.

## Design highlights

- **13 callsite inventory** (5 direct cohttp + 8 Masc_http_client
  indirect) — all share the same 4-step anti-pattern (fresh switch
  + `connection: close` + manual flow tracking + tracked_flows ref).
- **opaque `Pool.t` + scoped callback** (`with_connection`,
  `request`) — leak-resistant over acquire/release. callsite cannot
  forget to release.
- **Migration shim**: `Masc_http_client.{post_sync,get_sync,...}`
  signatures unchanged; internals delegate to lazy process-wide
  `Pool.t`. 13 callsites change 0 on D.2 merge.
- **Switch hierarchy** integration with Phase C.1: pool binds to server
  root_sw (long-lived idle connections); per-request sub-switches
  inherit turn_sw via fiber-local for in-flight cancellation.
- **Phase D substages**: D.1 (this) → D.2 transport binding + 13 callsite
  migration → D.3 stream callers (voice_bridge) → D.4 telemetry →
  D.5 cascade-storm reproducer.

## Files

- `docs/rfc/RFC-0107-phase-d-pool-design.md` — 268 lines, design only.

No code changes. Implementation lands in D.2.

## Trade-offs

- callback over acquire/release: type-level leak prevention vs API
  surface (`with_connection` exposes low-level handle only for stream
  callers).
- N-of-M retry **rejected**: pool drops bad connection, surfaces error;
  caller decides whether to retry. Avoids RFC-0107
  §"Workaround Rejection Bar" silent-retry anti-pattern.
- HTTP/2: out-of-scope (RFC §2 non-goal). piaf gets it free but
  callsites assume h1.
- OAS repo migration: out-of-scope of Phase D. masc-mcp only.

## Refs

- RFC-0107 §3.2 (Connection pool)
- Phase B spike (HTTP transport choice) — incoming
- Phase C.1 PR #15932 (turn-scoped switch wiring) — prerequisite

RFC-WAIVED: design doc only, no code; 268 added lines all in docs/rfc/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
