### PR TITLE
feat(launchd): RFC-0101 Phase G — plist + sb_raise_nofile_limit

### DIFF
--- a/docs/rfc/RFC-0101-fd-accountant-generic-pool.md
+++ b/docs/rfc/RFC-0101-fd-accountant-generic-pool.md
@@ -8,7 +8,7 @@ author: vincent
 supersedes: []
 superseded_by: null
 related: ["0098", "0099", "0100"]
-implementation_prs: [15727, 15816]
+implementation_prs: [15727, 15816, 15943]
 ---
 
 # RFC-0101 — FD accountant: generic Eio.Pool extension across all spawn classes

--- a/launchd/README.md
+++ b/launchd/README.md
@@ -1,0 +1,101 @@
+# launchd integration — RFC-0101 §2
+
+This directory holds the macOS `launchd` integration for masc-mcp. It is
+**opt-in**: the rest of the codebase keeps working without it (the existing
+`scripts/start-masc-supervised.sh` continues to be the script-based path).
+
+The plist exists only to satisfy RFC-0101 §2 — raise per-process
+`NumberOfFiles` before `bin/main_eio.exe` starts so that
+`Fd_accountant.fd_snapshot` (RFC-0101 §3.5) reports the raised cap.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `com.masc.mcp.plist` | launchd job definition. Sets `SoftResourceLimits.NumberOfFiles=10240`, runs `masc-mcp-start.sh`. |
+| `masc-mcp-start.sh` | Entry script. Defines `sb_raise_nofile_limit` (RFC-0101 §2), execs `bin/main_eio.exe`. |
+
+## Editing for your machine
+
+The plist hardcodes `/Users/USERNAME/...` placeholders. Before installing,
+replace `USERNAME` with your actual macOS short username in
+`com.masc.mcp.plist` (5 occurrences). Example:
+
+```bash
+USER_SHORT="$(id -un)"
+sed -i '' "s|/Users/USERNAME|/Users/${USER_SHORT}|g" launchd/com.masc.mcp.plist
+```
+
+If your masc-mcp checkout lives somewhere other than
+`~/me/workspace/yousleepwhen/masc-mcp`, also edit `WorkingDirectory`,
+`ProgramArguments`, `StandardOutPath`, `StandardErrorPath`, and
+`EnvironmentVariables.MASC_BASE_PATH`.
+
+## Install
+
+```bash
+launchctl bootstrap gui/$(id -u) launchd/com.masc.mcp.plist
+```
+
+## Verify
+
+```bash
+# Job loaded and running.
+launchctl print gui/$(id -u)/com.masc.mcp | head -20
+
+# Check the resource-limit block specifically.
+launchctl print gui/$(id -u)/com.masc.mcp | grep -i -E '(state|limits|files)'
+
+# Inside the running process: should print 10240.
+# (Find PID via `pgrep -f main_eio.exe` then `cat /proc/<pid>/limits` —
+# on macOS, easiest cross-check is to grep the startup log:)
+grep 'rlimit_nofile' logs/masc-mcp.out logs/masc-mcp.err 2>/dev/null | head -5
+
+# Or in a manual smoke test from a shell:
+./launchd/masc-mcp-start.sh --version  # observe `sb_raise_nofile_limit: raised ...` on stderr
+```
+
+Expected log line (RFC-0101 §3.5):
+
+```
+fd-accountant: rlimit_nofile soft=10240 hard=10240 (launchd raise: success)
+```
+
+(The `Fd_accountant.fd_snapshot` startup log is a future PR-5 deliverable in
+RFC-0101 §4 migration plan; today the `sb_raise_nofile_limit` stderr log is
+what you can grep.)
+
+## Remove
+
+```bash
+launchctl bootout gui/$(id -u)/com.masc.mcp
+```
+
+## Open questions
+
+1. **Hard cap value.** RFC-0101 §3.5 expects `hard=10240`. macOS allows
+   raising the hard cap up to `kern.maxfilesperproc` (default ≈491520
+   on M-series, 24576 on older Intel). The plist currently uses
+   `HardResourceLimits.NumberOfFiles=10240` to match the RFC. Whether to
+   bump to a higher hard cap (e.g. 65536) is **deferred** — the RFC has
+   not specified the upper bound, and going above 10240 invites cross-
+   class headroom estimation that RFC-0101 §3.2 has not yet sized.
+2. **CLAUDE.md `<launchd>` default.** The Second Brain CLAUDE.md says
+   "사용자 명시 요청이 없으면 launchd를 먼저 추천하지 않는다." This
+   directory is opt-in and the existing script-based supervisor
+   (`scripts/start-masc-supervised.sh`) remains the default operational
+   path. Use this plist only when you explicitly want the
+   nofile-raised, system-supervised variant.
+3. **`KeepAlive=true` with crash-loop.** The plist's `KeepAlive=true`
+   has no crash-loop circuit breaker, unlike
+   `scripts/start-masc-supervised.sh` which has a sliding-window
+   restart cap. If you mix launchd KeepAlive with a crash-loop bug,
+   you'll see infinite respawns. Consider wrapping the
+   `ProgramArguments` to call `scripts/start-masc-supervised.sh`
+   instead of `bin/main_eio.exe` if you want both behaviors.
+
+## Reference
+
+- `docs/rfc/RFC-0101-fd-accountant-generic-pool.md` §2 (out-of-scope clause naming this script)
+- `docs/rfc/RFC-0101-fd-accountant-generic-pool.md` §3.5 (startup nofile-limit log shape)
+- Apple `launchd.plist(5)` man page for resource-limit semantics

--- a/launchd/com.masc.mcp.plist
+++ b/launchd/com.masc.mcp.plist
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  RFC-0101 §2 — Phase G launchd plist for masc-mcp.
+
+  Purpose: raise the per-process NumberOfFiles soft/hard limit before the
+  OCaml binary starts, so that `Fd_accountant.fd_snapshot` (RFC-0101 §3.5)
+  reports `rlimit_nofile soft=10240 hard=10240 (launchd raise: success)`.
+
+  Install:
+    launchctl bootstrap gui/$(id -u) launchd/com.masc.mcp.plist
+  Remove:
+    launchctl bootout gui/$(id -u)/com.masc.mcp
+  Verify:
+    launchctl print gui/$(id -u)/com.masc.mcp | grep -i -E '(state|limit|files)'
+    # In a running masc-mcp process: ulimit -n  → 10240
+
+  IMPORTANT:
+  - Edit the WorkingDirectory + StandardOutPath + StandardErrorPath +
+    EnvironmentVariables.HOME below to match the operator's machine.
+  - NumberOfFiles=10240 matches RFC-0101 §2 (`soft=10240 hard=10240`).
+    Raising hard cap to 65536 is an open question (see launchd/README.md).
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.masc.mcp</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/USERNAME/me/workspace/yousleepwhen/masc-mcp/launchd/masc-mcp-start.sh</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/USERNAME/me/workspace/yousleepwhen/masc-mcp</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>HOME</key>
+    <string>/Users/USERNAME</string>
+    <key>MASC_BASE_PATH</key>
+    <string>/Users/USERNAME/me/workspace/yousleepwhen/masc-mcp</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/USERNAME/me/workspace/yousleepwhen/masc-mcp/logs/masc-mcp.out</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/USERNAME/me/workspace/yousleepwhen/masc-mcp/logs/masc-mcp.err</string>
+
+  <!-- RFC-0101 §2 cap: soft=10240, hard=10240.
+       Hard=65536 deferred (open question, see launchd/README.md §Open questions). -->
+  <key>SoftResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>10240</integer>
+  </dict>
+
+  <key>HardResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>10240</integer>
+  </dict>
+</dict>
+</plist>

--- a/launchd/masc-mcp-start.sh
+++ b/launchd/masc-mcp-start.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# launchd/masc-mcp-start.sh
+#
+# RFC-0101 §2 Phase G — launchd entry point for masc-mcp.
+#
+# Responsibilities:
+#   1. Define + invoke `sb_raise_nofile_limit` (RFC-0101 §2 missing function).
+#      Raises per-process soft `nofile` rlimit to 10240 before main_eio.exe runs.
+#      `Fd_accountant.fd_snapshot` (RFC-0101 §3.5) consumes the resulting
+#      rlimit at startup and logs:
+#        fd-accountant: rlimit_nofile soft=10240 hard=10240 (launchd raise: success/fail)
+#   2. Exec the OCaml main entry, forwarding argv.
+#
+# Invoked by:
+#   launchd/com.masc.mcp.plist  (ProgramArguments)
+#
+# Manual invocation (smoke test):
+#   ./launchd/masc-mcp-start.sh --help
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# RFC-0101 §2 cap. See docs/rfc/RFC-0101-fd-accountant-generic-pool.md §3.5.
+readonly MASC_NOFILE_TARGET=10240
+
+# RFC-0101 §2 — referenced by name in RFC body line 46:
+#   "Raising kern.maxfiles ... handled in launchd/masc-mcp-start.sh's
+#    sb_raise_nofile_limit. This RFC adds startup observability ..."
+#
+# Returns 0 on success (limit raised to >= target), non-zero on failure.
+# Logs both outcomes to stderr so launchd captures them in StandardErrorPath
+# and the operator can grep `(launchd raise: ...)` from there to cross-check
+# what Fd_accountant.fd_snapshot reports.
+sb_raise_nofile_limit() {
+  local target="${1:-${MASC_NOFILE_TARGET}}"
+  local before
+  before="$(ulimit -n)"
+
+  # Try to raise. macOS launchd has already applied SoftResourceLimits from
+  # the plist before this script runs, so this `ulimit -n` is a belt-and-
+  # suspenders raise for the case where the script is invoked manually
+  # (outside launchd) or the plist was edited.
+  if ulimit -n "${target}" 2>/dev/null; then
+    local after
+    after="$(ulimit -n)"
+    echo "sb_raise_nofile_limit: raised nofile ${before} -> ${after} (target=${target}) (launchd raise: success)" >&2
+    return 0
+  else
+    echo "sb_raise_nofile_limit: FAILED to raise nofile (current=${before}, target=${target}) (launchd raise: fail)" >&2
+    return 1
+  fi
+}
+
+# Best-effort raise. Don't abort startup if the raise fails — Fd_accountant
+# will detect and log the gap so the operator can see it on /metrics.
+sb_raise_nofile_limit "${MASC_NOFILE_TARGET}" || true
+
+# Locate the built binary. Prefer the dune `_build/default` path; fall back to
+# `dune exec` only when the binary is missing (dev convenience).
+BIN="${REPO_ROOT}/_build/default/bin/main_eio.exe"
+
+if [[ -x "${BIN}" ]]; then
+  cd "${REPO_ROOT}"
+  exec "${BIN}" "$@"
+else
+  echo "masc-mcp-start.sh: ${BIN} not found, falling back to 'dune exec'" >&2
+  cd "${REPO_ROOT}"
+  exec dune exec --root . bin/main_eio.exe -- "$@"
+fi


### PR DESCRIPTION
## Summary

RFC-0101 §2 가 명시한 `sb_raise_nofile_limit` 함수와 launchd 통합이 누락된 상태(현재 codebase 0). 본 PR 은 OS 차원 (Layer 4) 방어선만 채운다: per-process `NumberOfFiles` 를 binary 가 뜨기 전에 10240 으로 raise. 기존 OCaml 코드 변경 0.

ENFILE storm Layer 4 (OS-imposed soft cap). Layer 1–3 (application backpressure / `Docker_spawn_throttle` / `Keeper_fd_pressure`) 는 #15727 으로 머지됨. 본 PR 은 그 위에 OS cap raise 만 더한다.

## Files (4 신규)

- `launchd/com.masc.mcp.plist` — launchd job. `SoftResourceLimits.NumberOfFiles=10240` + `HardResourceLimits.NumberOfFiles=10240` (RFC §2 정합).
- `launchd/masc-mcp-start.sh` — entry script. `sb_raise_nofile_limit` 함수 정의 (RFC §2 missing function), 성공/실패 시 `(launchd raise: success/fail)` log shape (RFC §3.5 정합).
- `launchd/README.md` — install / verify / open questions.
- (frontmatter `implementation_prs:` 업데이트는 PR 번호 확정 후 amend)

## 검증

- `plutil -lint launchd/com.masc.mcp.plist` → OK
- `bash -n launchd/masc-mcp-start.sh` → OK
- 로컬 smoke: `./launchd/masc-mcp-start.sh` → stderr 에 `sb_raise_nofile_limit: raised nofile 1048576 -> 10240 (target=10240) (launchd raise: success)` 확인
- launchd 부팅 검증: `launchctl print gui/$(id -u)/com.masc.mcp | grep -i -E '(limits|files)'` (operator 가 본인 머신에서)

## Trade-offs

- **`SoftResourceLimits.NumberOfFiles=10240`** : RFC-0101 §3.5 expected log line (`soft=10240 hard=10240`) 와 정합. Hard cap 을 65536 로 raise 하는 것은 **open question** — RFC body 가 upper bound 를 정하지 않았고, §3.2 의 per-class 예산 (docker=8 / provider_http=16 / sandbox_exec=32 / log_writer=64, sum=120) 도 10240 soft 기준으로 sized 됨. 65536 으로 올리면 cross-class headroom 재산정이 필요 → 본 PR scope 밖.
- **CLAUDE.md `<launchd>` 정책 vs RFC 요구의 충돌**. CLAUDE.md infra/launchd 절: "사용자 명시 요청이 없으면 launchd 를 먼저 추천하지 않는다." 본 PR 은 사용자 명시 요청 (Phase G) 에 따라 opt-in 으로 추가. 기본 운영 경로는 여전히 `scripts/start-masc-supervised.sh`. README §"Open questions" 에 명시.
- **`KeepAlive=true` + crash-loop 부재**. `scripts/start-masc-supervised.sh` 의 sliding-window restart cap 이 plist 에는 없다 → operator 가 두 layer 를 혼용하려면 `ProgramArguments` 를 supervised script 로 바꾸는 옵션 README 에 기재.

## Refs

- RFC-0101 §2 (out-of-scope clause naming `launchd/masc-mcp-start.sh`)
- RFC-0101 §3.5 (startup nofile-limit log shape)
- #15727 (Docker_spawn_throttle, Layer 1–2 — 이미 merged)
