### PR TITLE
fix: guard Docker FD hotspots

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -776,6 +776,61 @@ type docker_shell_result =
    only to the run path, not to docker exec against a warm container. *)
 let docker_run_min_timeout_sec = 5.0
 
+let docker_cleanup_rm_timeout_sec () =
+  Env_config_sandbox.Shell_timeout.timeout_sec
+    ~bucket:Env_config_sandbox.Shell_timeout.Cleanup_rm
+    ()
+;;
+
+let docker_oneshot_ttl_sec ~timeout_sec =
+  timeout_sec +. docker_cleanup_rm_timeout_sec () +. 10.0
+;;
+
+let docker_rm_no_such_container text =
+  String_util.contains_substring_ci text "no such container"
+  || String_util.contains_substring_ci text "no such object"
+;;
+
+let cleanup_oneshot_container ~container_name =
+  let argv = Keeper_sandbox_runtime.docker_command_argv () @ [ "rm"; "-f"; container_name ] in
+  let status, output =
+    Docker_spawn_throttle.with_slot (fun () ->
+      Masc_exec.Exec_gate.run_argv_with_status
+        ~actor:`System_task_sandbox
+        ~raw_source:(String.concat " " argv)
+        ~summary:"keeper docker oneshot cleanup"
+        ~env:(Unix.environment ())
+        ~cwd:(Sys.getcwd ())
+        ~timeout_sec:(docker_cleanup_rm_timeout_sec ())
+        argv)
+  in
+  match status with
+  | Unix.WEXITED 0 -> ()
+  | _ when docker_rm_no_such_container output -> ()
+  | _ ->
+    Log.Keeper.warn
+      "docker oneshot cleanup failed for %s (status=%s, output=%s)"
+      container_name
+      (docker_exec_status_label status)
+      (Worker_dev_tools.truncate_for_log output)
+;;
+
+let fd_admission_error ~(config : Coord.config) =
+  let active_keepers = Keeper_registry.count_running ~base_path:config.base_path () in
+  match
+    Keeper_fd_pressure.admission_decision
+      ~active_keepers
+      ~starting_keepers:0
+      ()
+  with
+  | Keeper_fd_pressure.Admit -> None
+  | Keeper_fd_pressure.Block block ->
+    Some
+      (Printf.sprintf
+         "docker_shell_failed: fd_pressure: %s"
+         (Keeper_fd_pressure.admission_block_kind block))
+;;
+
 let run_docker_shell_command_with_status_internal
       ~validate_command_paths
       ~(config : Coord.config)
@@ -850,6 +905,9 @@ let run_docker_shell_command_with_status_internal
       match path_validation with
       | Error err -> sandbox_error (Printf.sprintf "%s [blocked_cmd=%s]" err cmd)
       | Ok () ->
+      (match fd_admission_error ~config with
+       | Some err -> sandbox_error err
+       | None ->
       let _cleanup =
         Keeper_sandbox_runtime.maybe_cleanup_stale_containers
           ~base_path:config.base_path
@@ -986,6 +1044,7 @@ let run_docker_shell_command_with_status_internal
                            ~keeper_name:meta.name
                            ~container_kind:"oneshot"
                            ~network_label
+                           ~ttl_sec:(docker_oneshot_ttl_sec ~timeout_sec)
                            ()
                        @ [ "-i"; "--user"; Printf.sprintf "%d:%d" uid gid ]
                        @ Keeper_sandbox_runtime.docker_sandbox_env_args
@@ -1023,7 +1082,10 @@ let run_docker_shell_command_with_status_internal
                      in
                      (try
                         let status, output =
-                          Eio_guard.protect ~finally:restore_gitdirs
+                          Eio_guard.protect
+                            ~finally:(fun () ->
+                              cleanup_oneshot_container ~container_name;
+                              restore_gitdirs ())
                           @@ fun () ->
                           Docker_spawn_throttle.with_slot (fun () ->
                             Masc_exec.Exec_gate.run_argv_with_status
@@ -1071,7 +1133,7 @@ let run_docker_shell_command_with_status_internal
                              "docker_shell_failed: unix_error: %s: %s(%s)"
                              (Unix.error_message code)
                              fn
-                             arg))))))
+                             arg)))))))
 ;;
 
 let run_docker_shell_command_with_status =

--- a/lib/keeper_fd_pressure.ml
+++ b/lib/keeper_fd_pressure.ml
@@ -35,6 +35,7 @@ let nofile_soft_limit_mutex = Stdlib.Mutex.create ()
 type system_fd_snapshot =
   { open_files : int
   ; max_files : int
+  ; max_files_per_process : int option
   }
 
 type system_fd_cache_entry =
@@ -57,6 +58,15 @@ type admission_block =
   | System_fd_budget_exhausted of
       { open_files : int
       ; max_files : int
+      ; remaining_files : int
+      ; required_headroom : int
+      ; projected_fds : int
+      ; active_keepers : int
+      ; starting_keepers : int
+      }
+  | Host_fd_hotspot_budget_exhausted of
+      { open_files : int
+      ; max_files_per_process : int
       ; remaining_files : int
       ; required_headroom : int
       ; projected_fds : int
@@ -248,8 +258,11 @@ let process_open_fd_count () =
 
 let parse_system_fd_snapshot lines =
   match List.filter_map (fun line -> int_of_string_opt (String.trim line)) lines with
+  | open_files :: max_files :: max_files_per_process :: _
+    when open_files >= 0 && max_files > 0 && max_files_per_process > 0 ->
+    Some { open_files; max_files; max_files_per_process = Some max_files_per_process }
   | open_files :: max_files :: _ when open_files >= 0 && max_files > 0 ->
-    Some { open_files; max_files }
+    Some { open_files; max_files; max_files_per_process = None }
   | _ -> None
 ;;
 
@@ -276,7 +289,7 @@ let detect_linux_system_fd_snapshot_now () =
          if String.equal field "" then None else int_of_string_opt field)
      with
      | open_files :: _unused_files :: max_files :: _ when open_files >= 0 && max_files > 0 ->
-       Some { open_files; max_files }
+       Some { open_files; max_files; max_files_per_process = None }
      | _ -> None)
   | None -> None
 ;;
@@ -292,7 +305,7 @@ let detect_darwin_system_fd_snapshot_now () =
         let lines, status =
           With_process.with_process_args_in
             "/usr/sbin/sysctl"
-            [| "sysctl"; "-n"; "kern.num_files"; "kern.maxfiles" |]
+            [| "sysctl"; "-n"; "kern.num_files"; "kern.maxfiles"; "kern.maxfilesperproc" |]
             With_process.drain_lines
         in
         match status with
@@ -375,6 +388,11 @@ let system_fd_headroom () =
   |> max (fd_headroom ())
 ;;
 
+let host_fd_hotspot_headroom () =
+  Env_config_core.get_int ~default:49152 "MASC_KEEPER_HOST_FD_HOTSPOT_HEADROOM"
+  |> max (system_fd_headroom ())
+;;
+
 let active_keeper_cap_for_soft_limit soft =
   let usable = max 0 (soft - fd_headroom ()) in
   max 1 (usable / fd_per_active_keeper ())
@@ -399,7 +417,7 @@ let projected_fd_budget
 
 let system_fd_budget_block system_fds ~projected_fds ~active_keepers ~starting_keepers =
   match system_fds with
-  | Some { open_files; max_files } ->
+  | Some { open_files; max_files; max_files_per_process } ->
     let remaining_files = max 0 (max_files - open_files) in
     let required_headroom = system_fd_headroom () in
     if remaining_files < required_headroom + projected_fds
@@ -414,7 +432,25 @@ let system_fd_budget_block system_fds ~projected_fds ~active_keepers ~starting_k
            ; active_keepers = max 0 active_keepers
            ; starting_keepers = max 0 starting_keepers
            })
-    else None
+    else (
+      match max_files_per_process with
+      | Some max_files_per_process when max_files_per_process > 0 ->
+        let remaining_files = max 0 (max_files_per_process - open_files) in
+        let required_headroom = host_fd_hotspot_headroom () in
+        if remaining_files < required_headroom + projected_fds
+        then
+          Some
+            (Host_fd_hotspot_budget_exhausted
+               { open_files
+               ; max_files_per_process
+               ; remaining_files
+               ; required_headroom
+               ; projected_fds
+               ; active_keepers = max 0 active_keepers
+               ; starting_keepers = max 0 starting_keepers
+               })
+        else None
+      | _ -> None)
   | None -> None
 ;;
 
@@ -505,6 +541,25 @@ let admission_block_to_json = function
       ; "active_keepers", `Int active_keepers
       ; "starting_keepers", `Int starting_keepers
       ]
+  | Host_fd_hotspot_budget_exhausted
+      { open_files
+      ; max_files_per_process
+      ; remaining_files
+      ; required_headroom
+      ; projected_fds
+      ; active_keepers
+      ; starting_keepers
+      } ->
+    `Assoc
+      [ "kind", `String "host_fd_hotspot_budget_exhausted"
+      ; "system_open_files", `Int open_files
+      ; "system_max_files_per_process", `Int max_files_per_process
+      ; "host_fd_hotspot_remaining", `Int remaining_files
+      ; "host_fd_hotspot_headroom", `Int required_headroom
+      ; "projected_fds", `Int projected_fds
+      ; "active_keepers", `Int active_keepers
+      ; "starting_keepers", `Int starting_keepers
+      ]
 ;;
 
 let admission_decision_to_json = function
@@ -517,6 +572,7 @@ let admission_block_kind = function
   | Fd_pressure_cooldown _ -> "fd_pressure_cooldown"
   | Projected_fd_budget_exhausted _ -> "projected_fd_budget_exhausted"
   | System_fd_budget_exhausted _ -> "system_fd_budget_exhausted"
+  | Host_fd_hotspot_budget_exhausted _ -> "host_fd_hotspot_budget_exhausted"
 ;;
 
 let runtime_state_json ?(soft_limit = process_nofile_soft_limit ())
@@ -548,14 +604,30 @@ let runtime_state_json ?(soft_limit = process_nofile_soft_limit ())
     | Some soft when soft > 0 -> `Int (active_keeper_cap_for_soft_limit soft)
     | _ -> `Null
   in
-  let system_open_files, system_max_files, system_fd_remaining, system_fd_utilization =
+  let ( system_open_files
+      , system_max_files
+      , system_fd_remaining
+      , system_fd_utilization
+      , system_max_files_per_process
+      , host_fd_hotspot_remaining
+      , host_fd_hotspot_probe_supported )
+    =
     match system_fds with
-    | Some { open_files; max_files } ->
+    | Some { open_files; max_files; max_files_per_process } ->
+      let max_files_per_process_json, hotspot_remaining, hotspot_supported =
+        match max_files_per_process with
+        | Some limit ->
+          `Int limit, `Int (max 0 (limit - open_files)), `Bool true
+        | None -> `Null, `Null, `Bool false
+      in
       ( `Int open_files
       , `Int max_files
       , `Int (max 0 (max_files - open_files))
-      , `Float (float_of_int open_files /. float_of_int max_files) )
-    | None -> `Null, `Null, `Null, `Null
+      , `Float (float_of_int open_files /. float_of_int max_files)
+      , max_files_per_process_json
+      , hotspot_remaining
+      , hotspot_supported )
+    | None -> `Null, `Null, `Null, `Null, `Null, `Null, `Bool false
   in
   `Assoc
     [ "status", `String status
@@ -570,6 +642,10 @@ let runtime_state_json ?(soft_limit = process_nofile_soft_limit ())
     ; "system_fd_utilization", system_fd_utilization
     ; "system_fd_headroom", `Int (system_fd_headroom ())
     ; "system_fd_probe_supported", `Bool (Option.is_some system_fds)
+    ; "system_max_files_per_process", system_max_files_per_process
+    ; "host_fd_hotspot_remaining", host_fd_hotspot_remaining
+    ; "host_fd_hotspot_headroom", `Int (host_fd_hotspot_headroom ())
+    ; "host_fd_hotspot_probe_supported", host_fd_hotspot_probe_supported
     ; "headroom", `Int (fd_headroom ())
     ; "fd_per_active_keeper", `Int (fd_per_active_keeper ())
     ; "min_nofile_for_24_keepers", `Int (min_nofile_for_24_keepers ())

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -107,8 +107,12 @@ let test_fd_pressure_system_admission () =
     ~finally:FD.reset_for_tests
     (fun () ->
       with_env "MASC_KEEPER_SYSTEM_FD_HEADROOM" "256" (fun () ->
-        let healthy = FD.{ open_files = 100; max_files = 10_000 } in
-        let pressured = FD.{ open_files = 9_500; max_files = 10_000 } in
+        let healthy =
+          FD.{ open_files = 100; max_files = 10_000; max_files_per_process = None }
+        in
+        let pressured =
+          FD.{ open_files = 9_500; max_files = 10_000; max_files_per_process = None }
+        in
         check bool "admits when system file table has headroom" true
           (FD.admit_start
              ~soft_limit:(Some 245_760)
@@ -147,6 +151,53 @@ let test_fd_pressure_system_admission () =
           (Json.member "system_open_files" json |> Json.to_int);
         check int "system file table remaining exposed" 500
           (Json.member "system_fd_remaining" json |> Json.to_int)))
+
+let test_fd_pressure_host_hotspot_admission () =
+  FD.reset_for_tests ();
+  Fun.protect
+    ~finally:FD.reset_for_tests
+    (fun () ->
+      with_env "MASC_KEEPER_SYSTEM_FD_HEADROOM" "0" (fun () ->
+      with_env "MASC_KEEPER_HOST_FD_HOTSPOT_HEADROOM" "1024" (fun () ->
+        let hotspot =
+          FD.
+            { open_files = 9_200
+            ; max_files = 1_000_000
+            ; max_files_per_process = Some 10_000
+            }
+        in
+        let decision =
+          FD.admission_decision
+            ~soft_limit:(Some 245_760)
+            ~open_fds:(Some 64)
+            ~system_fds:(Some hotspot)
+            ~active_keepers:2
+            ~starting_keepers:1
+            ()
+        in
+        check bool "blocks before host process fd hotspot" false (FD.admitted decision);
+        check string "host hotspot block kind" "host_fd_hotspot_budget_exhausted"
+          (match decision with
+           | FD.Block block -> FD.admission_block_kind block
+           | FD.Admit -> "admit");
+        let json =
+          FD.runtime_state_json
+            ~soft_limit:(Some 245_760)
+            ~open_fds:(Some 64)
+            ~system_fds:(Some hotspot)
+            ~active_keepers:2
+            ~starting_keepers:1
+            ~requested_keepers:24
+            ()
+        in
+        check string "runtime reason" "host_fd_hotspot_budget_exhausted"
+          (Json.member "reason" json |> Json.to_string);
+        check int "per-process limit exposed" 10_000
+          (Json.member "system_max_files_per_process" json |> Json.to_int);
+        check int "hotspot remaining exposed" 800
+          (Json.member "host_fd_hotspot_remaining" json |> Json.to_int);
+        check int "hotspot headroom exposed" 1024
+          (Json.member "host_fd_hotspot_headroom" json |> Json.to_int))))
 
 let test_fd_pressure_degraded_projection () =
   FD.reset_for_tests ();
@@ -2091,6 +2142,8 @@ let () =
             test_fd_pressure_proactive_admission;
           test_case "fd pressure system admission" `Quick
             test_fd_pressure_system_admission;
+          test_case "fd pressure host hotspot admission" `Quick
+            test_fd_pressure_host_hotspot_admission;
           test_case "fd pressure degraded projection" `Quick
             test_fd_pressure_degraded_projection;
           test_case "disk pressure classifiers" `Quick

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -222,7 +222,9 @@ let with_fake_docker script f =
   in
   Fun.protect ~finally:(fun () -> cleanup_dir dir) @@ fun () ->
   with_env "MASC_TEST_FAKE_DOCKER_PATH" docker_path @@ fun () ->
-  with_env "PATH" path f
+  with_env "PATH" path @@ fun () ->
+  with_env "MASC_KEEPER_SYSTEM_FD_HEADROOM" "0" @@ fun () ->
+  with_env "MASC_KEEPER_HOST_FD_HOTSPOT_HEADROOM" "0" f
 
 let with_tool_policy_config f =
   let project_root = Masc_test_deps.find_project_root () in
@@ -954,6 +956,7 @@ let test_docker_shell_mounts_masc_config_runtime_paths () =
      | Unix.WSIGNALED code -> Alcotest.failf "expected exit 0, signaled %d" code
      | Unix.WSTOPPED code -> Alcotest.failf "expected exit 0, stopped %d" code);
     let line = docker_run_line log_path in
+    let log = read_file log_path in
     let container_root = Keeper_sandbox.container_root meta.name in
     let host_config_dir =
       Filename.concat (Filename.concat config.Coord.base_path Common.masc_dirname) "config"
@@ -969,11 +972,15 @@ let test_docker_shell_mounts_masc_config_runtime_paths () =
       (contains_substring line ("MASC_BASE_PATH=" ^ container_root));
     Alcotest.(check bool) "container MASC_CONFIG_DIR pinned" true
       (contains_substring line ("MASC_CONFIG_DIR=" ^ container_config_dir));
+    Alcotest.(check bool) "oneshot container has ttl label" true
+      (contains_substring line "masc.mcp.ttl_sec=");
+    Alcotest.(check bool) "oneshot cleanup attempts docker rm" true
+      (contains_substring log "\nrm -f masc-keeper-");
     Alcotest.(check bool) "room tasks mounted under container root" true
       (contains_substring
          line
          (tasks_host ^ ":" ^ container_root ^ "/.masc/tasks:ro"));
-    Alcotest.(check bool) "room tasks mounted for worktree symlink target" true
+    Alcotest.(check bool) "room tasks not mounted at host absolute target" false
       (contains_substring
          line
          (tasks_host ^ ":" ^ tasks_host ^ ":ro"));


### PR DESCRIPTION
## Summary
- add Darwin maxfilesperproc visibility and a host FD hotspot admission block
- block Docker keeper shell runs when host FD hotspot pressure is active
- label one-shot Docker containers with TTL and best-effort rm cleanup after each run

## Root cause
MASC only considered its own process FD count and global file-table headroom. On macOS Docker Desktop, the Virtualization.framework process can hold nearly the per-process FD ceiling while MASC still reports a tiny own-process FD count, so keeper Docker one-shots can keep amplifying host FD pressure.

## Validation
- git diff --check
- DUNE_JOBS=1 scripts/dune-local.sh build test/test_keeper_registry.exe test/test_keeper_shell_docker_route.exe
- ./_build/default/test/test_keeper_registry.exe test --color=never --quick-tests basic
- ./_build/default/test/test_keeper_shell_docker_route.exe test --color=never