### PR TITLE
feat(bounded_proc): RFC-0109 P0 SSOT helper for time-bounded subprocess (Draft)

### DIFF
--- a/lib/bounded_proc/bounded_proc.ml
+++ b/lib/bounded_proc/bounded_proc.ml
@@ -1,0 +1,43 @@
+(** RFC-0109 — Bounded subprocess discipline. *)
+
+type outcome =
+  | Done of Unix.process_status * string * string
+  | Timeout of float
+
+let run_argv_with_timeout ~clock ~process_mgr ~cwd ?env ?stdin_string
+    ~timeout_s argv =
+  let start = Eio.Time.now clock in
+  Eio.Switch.run @@ fun proc_sw ->
+  let stdout_buf = Buffer.create 4096 in
+  let stderr_buf = Buffer.create 1024 in
+  let stdout_r, stdout_w = Eio.Process.pipe ~sw:proc_sw process_mgr in
+  let stderr_r, stderr_w = Eio.Process.pipe ~sw:proc_sw process_mgr in
+  let stdin_source = Option.map Eio.Flow.string_source stdin_string in
+  let proc =
+    Eio.Process.spawn ~sw:proc_sw process_mgr ~cwd ?env
+      ?stdin:stdin_source ~stdout:stdout_w ~stderr:stderr_w argv
+  in
+  (* Close the write ends in the parent so EOF propagates to the drain
+     fibers once the child exits or is killed. *)
+  Eio.Flow.close stdout_w;
+  Eio.Flow.close stderr_w;
+  let drain_and_await () =
+    Eio.Fiber.both
+      (fun () ->
+        Eio.Flow.copy stdout_r (Eio.Flow.buffer_sink stdout_buf);
+        Eio.Flow.close stdout_r)
+      (fun () ->
+        Eio.Flow.copy stderr_r (Eio.Flow.buffer_sink stderr_buf);
+        Eio.Flow.close stderr_r);
+    let status =
+      match Eio.Process.await proc with
+      | `Exited n -> Unix.WEXITED n
+      | `Signaled n -> Unix.WSIGNALED n
+    in
+    Done (status, Buffer.contents stdout_buf, Buffer.contents stderr_buf)
+  in
+  let timeout () =
+    Eio.Time.sleep clock timeout_s;
+    Timeout (Eio.Time.now clock -. start)
+  in
+  Eio.Fiber.first timeout drain_and_await

--- a/lib/bounded_proc/bounded_proc.mli
+++ b/lib/bounded_proc/bounded_proc.mli
@@ -1,0 +1,57 @@
+(** RFC-0109 — Bounded subprocess discipline.
+
+    Run a single subprocess with a hard wall-clock bound and capture
+    stdout/stderr. The implementation relies on a single Eio invariant
+    quoted from
+    https://ocaml.org/p/eio/latest/doc/Eio/Process/index.html:
+
+    {v "The child process will be sent Sys.sigkill when the switch is
+       released." v}
+
+    A fresh [Eio.Switch.run] scope is opened inside the helper, so the
+    subprocess lifetime is decoupled from any long-lived caller switch.
+    When the timeout fiber wins the {!Eio.Fiber.first} race, the inner
+    switch ends and the kernel kills the process unconditionally — no
+    SIGTERM grace period, no Cancel propagation requirement. C-blocking
+    [Eio.Process.await] does not honour Eio cancellation by design
+    (see https://ocaml.org/p/eio/latest/doc/Eio/Cancel/index.html),
+    which is why scope termination is the only reliable termination
+    primitive available. *)
+
+(** Outcome of {!run_argv_with_timeout}. *)
+type outcome =
+  | Done of Unix.process_status * string * string
+      (** Process finished within the timeout. Fields are
+          [(status, stdout, stderr)]. *)
+  | Timeout of float
+      (** Timeout fiber won the race. Carries elapsed wall-clock
+          seconds. The subprocess has been SIGKILLed by Eio at the
+          point this constructor is observed. *)
+
+val run_argv_with_timeout :
+  clock:_ Eio.Time.clock ->
+  process_mgr:_ Eio.Process.mgr ->
+  cwd:Eio.Fs.dir_ty Eio.Path.t ->
+  ?env:string array ->
+  ?stdin_string:string ->
+  timeout_s:float ->
+  string list ->
+  outcome
+(** [run_argv_with_timeout ~clock ~process_mgr ~cwd ?env ?stdin_string
+    ~timeout_s argv] spawns [argv] under a fresh internal switch and
+    races the call against [Eio.Time.sleep clock timeout_s].
+
+    Returns {!Done} with the captured stdout/stderr if the process
+    finishes first, or {!Timeout} otherwise.
+
+    {b Invariants}:
+    - On {!Timeout}, the subprocess is guaranteed to be SIGKILLed by
+      the time this function returns (Eio.Process spec).
+    - The caller's ambient switch is not used for spawn — process
+      lifetime is bounded by [timeout_s], not by the caller.
+    - [stdin_string], when given, is wrapped in
+      {!Eio.Flow.string_source} and connected to the child's stdin.
+
+    Use this helper at any boundary that spawns an external process
+    whose runtime cannot be trusted to honour Eio cancellation (LLM
+    HTTPS clients, [docker exec]/[docker run], git/gh, ...). *)

--- a/lib/bounded_proc/dune
+++ b/lib/bounded_proc/dune
@@ -1,0 +1,10 @@
+(include_subdirs no)
+
+(library
+ (name bounded_proc)
+ (public_name masc_mcp.bounded_proc)
+ (modules bounded_proc)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags
+  (:standard -w +4))
+ (libraries eio eio.unix unix))

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,6 @@
 ; Test Environment Configuration
 ; Force filesystem backend to avoid external DB connection timeouts
+
 (env
  (_
   (env-vars
@@ -24,1068 +25,1199 @@
 ;   (test ...)  = single binary, special config needed
 
 ; Group 1: Pure synchronous tests
+
 (tests
- (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_mcp_error_code test_error_body_delegation test_session_lifecycle_event test_fd_accountant test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
-        test_streamable_http_upgrade
-        test_mcp_session_id_header
-        test_keeper_turn_terminal_code_byte_compat
-        test_keeper_sdk_error_typed_bridge
-        test_openai_compat_error_map
-        test_read_drop_reason
-        test_log_ring_encoder
-        test_eio_context_fiber_local
-        test_keeper_turn_disposition
-        test_keeper_turn_terminal_disposition_field
-        test_attempt_state
-        test_actor_mailbox
-        test_domain_pool
-        test_sse test_graphql_api
-        test_graphql_endpoint
-        test_subscriptions test_session test_progress test_spawn
-        test_validation test_response
-        test_channel_gate_connector_routes
-        test_sidecar_lifecycle_routes
-        test_channel_gate_imessage_state
-        test_dashboard
-        test_dashboard_branches
-        test_dashboard_perf
-        test_dashboard_tool_host_events
-        test_dashboard_nav_event
-        test_cdal_tool_id
-        test_tool_assignment_telemetry
-        test_dashboard_link_preview
-        test_gate_keeper_backend
-        test_transport_read_model
-        test_multi_room test_worktree_detection test_bounded test_mention
-        test_mention_dedup
-        test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
-        test_post_verifier
-        test_reward_advice_artifact
-        test_cascade_capability_profile
-        test_cascade_secondary_expand
-        test_keeper_hooks_oas_telemetry
-        test_masc_oas_bridge_timeout_guard
-        test_keeper_llm_bridge
-        test_agent_stress
-        test_keeper_tool_use_failure_counter
-        test_keeper_compaction_outcome_counter
-        test_keeper_sub_fsm_guards
-        test_keeper_cascade_tla_mirror
-        test_keeper_usage_trust_counter
-        test_llm_metric_bridge
-        test_cost_usd_source_attribution_10318
-        test_response_model_empty_10083
-        test_heuristic_theatre_audit
-        test_keeper_proactive_skip_counter
-        test_keeper_tool_selection_passive_streak
-        test_keeper_health_probe
-        test_oas_error_kind_counter
-        test_oas_empty_response_diagnostic
-        test_board_author_identity_10297
-        test_fsm_drift_counter
-        test_gc_sampler
-        test_process_timeout_counter
-        test_git_fetch_timeout_9587
-        test_inference_utils
-        test_auth_ambiguous_lookup_9786
-        test_auth_load_credential_of
-        test_keeper_wake_telemetry
-        test_keeper_timing
-        test_keeper_memory
-        test_memory_jsonl_truncation
-        test_keeper_chat_store
-        test_keeper_runtime_trust_snapshot
-        test_ide_annotations
-        test_keeper_runtime_manifest
-        test_schema_surface_index
-        test_keeper_accountability
-        test_reputation_ledger_v2
-        test_reputation_multi_dim
-        test_keeper_goal_repair
-        test_accountability_emit_skip_10314
-        test_keeper_exec_status
-        test_keeper_pause_broadcast
-        test_keeper_terminal_reason
-        test_keeper_adaptive_thinking
-        test_keeper_turn_intent
-        test_keeper_lifecycle
-        test_keeper_lifecycle_chaos
-        test_keeper_rollover_gate
-        test_keeper_generation_lineage
-        test_keeper_deliberation
-        test_keeper_registry
-        test_keeper_fd_pressure_fleet
-        test_docker_spawn_throttle
-        test_keeper_supervisor
-        test_keeper_alerting_path
-        test_coord_eio_pure
-        test_coord_telemetry_drop_non_eio
-        test_keeper_contract_classifier_pure
-        test_keeper_compact_policy_pure
-        test_heartbeat_smart
-        test_keeper_allowed_paths
-        test_keeper_repo_readiness
-        test_keeper_tool_surface_guard
-        test_keeper_benchmark_canary
-        test_keeper_pr_review
-        test_keeper_github_pr
-        test_playground_paths
-        test_keeper_llama_only
-        test_keeper_meta_cwd_resilience
-        test_metrics_rotation
-        test_tool_access_policy
-        test_tool_access_role
-        test_tool_token
-        test_tool_exposure
-        test_autonomy_liberation
-        test_keeper_unified
-        test_decision_pipeline
-        test_decision_pipeline_observer
-        test_keeper_composite_observer
-        test_keeper_fsm_edges
-        test_keeper_fsm_guard_actions
-        test_keeper_callback_hardening
-        test_keeper_behavioral_regime
-        test_keeper_toml
-        test_keeper_runtime_toml
-        test_keeper_tool_policy_config
-        test_keeper_tool_resolution
-        test_dispatch_disclosure_parity
-        test_coord_worktree_policy_path
-        test_claim_post_provision_hook
-        test_keeper_toml_config_validation
-        test_keeper_id
-        test_repo_store
-        test_chronicle_types
-        test_chronicle_ingest
-        test_chronicle_validate
-        test_credential_store
-        test_credential_materializer
-        test_keeper_repo_mapping
-        test_credential_provider_bridge
-        test_repo_sync
-        test_repo_git
-        test_repo_e2e
-        test_exec_core
-        test_exec_dispatch
-        test_keeper_bash_safety
-        test_keeper_bash_typed_input
-        test_hitl_approval
-        test_approval_callback_wired
-        test_keeper_discovered_tools
-        test_keeper_tool_affinity
-        test_keeper_tool_alias
-        test_keeper_sandbox_containment
-        test_keeper_transition_audit
-        test_keeper_shell_containment
-        test_keeper_shell_docker_route
-        test_keeper_shell_via_field
-        test_env_git_noninteractive
-        test_gh_exit_class
-        test_gh_exit_class_wiring
-        test_stay_silent_loop_detector
-        test_oas_compat_cascade_fallback
-        test_heuristic_metrics_boot_wireup
-        test_heuristic_metrics_periodic_flush_10348
-        test_cap_blocker_structured_error
-        test_context_overflow_action_tracker
-        test_keeper_fs_edit_patch
-        test_keeper_docker_read
-        test_keeper_path_ssot
-        test_keeper_egress_audit
-        test_keeper_github_read_only
-        test_worktree_live_context
-        test_git_graph_snapshot
-        test_worktree_status_single_flight_9632
-        test_tool_input_validation
-        test_failure_learnings_10325
-        test_agent_stress_emit_10341
-        test_autoresearch_codegen
-        test_autoresearch_oas_primitives
-        test_autoresearch_target_score
-        test_cdal_conformance
-        test_task_stage
-        test_ocaml_north_star_task_lifecycle
-        test_tool_blob_store
-        test_tool_bridge_externalize
-        test_keeper_artifact_hydrator
-        test_artifacts_endpoint
-        test_tool_output_washing_e2e
-        test_keeper_context_core_dedup
-        test_adversarial_eval
-        test_labeling
-        test_tool_deep_review
-        test_tool_call_quality_benchmark
-        test_keeper_prompt_metrics
-        test_keeper_reaction_ledger
-        test_cache_metrics_wiring
-        test_tool_surface_ssot
-        test_keeper_retrieval_quality
-        test_observability_redact
-        test_observability_provider_contracts
-        test_config_doctor
-        test_cascade_config_validity
-        test_cascade_routes_decoder
-        test_cascade_declarative_parser
-        test_cascade_declarative_validator
-        test_cascade_declarative_adapter
-        test_cascade_declarative_hotpath
-        test_keeper_cascade_profile_partial
-        test_doctor_dispatch
-        test_disk_hygiene_script
-        test_run_local_script
-        test_tool_prefilter
-        test_keeper_state_machine
-        test_keeper_state_machine_correspondence
-        test_keeper_state_machine_tla_correspondence
-        test_keeper_lifecycle_hooks
-        test_keeper_subprocess_registry
-        test_keeper_bg_task_cleanup
-        test_keeper_social_model_magentic_ledger_fsm
-        test_keeper_overflow_recovery
-        test_telemetry_unified
-        test_telemetry_error_occurred_wire_10358
-        test_keeper_topk_llm
-        test_warn_root_causes
-        test_memory_hooks
-        test_keeper_agent_memory_episode_activity
-        test_agent_stress_timeout_wire_10341
-        test_institution_episodes_failure_learnings_10325
-        test_institution_of_string_fail_closed
-        test_mid_turn_resume
-        test_lockfree_atomic
-        test_telemetry_observe
-        test_keeper_typed_labels
-        test_shell_ir_typed_review_followup
-        test_shell_ir_validator
-        test_typed_advisor_counters
-        test_auth_resolve_labels
-        test_keeper_classifier_helper
-        test_persona_tool_reachability
-        test_cascade_strategy_labels
-        test_turn_id_propagation
-        test_per_keeper_token_fallback
-        test_auth_strict_mode
-        test_keeper_turn_fsm_emit
-        test_keeper_event_queue
-        test_keeper_relevance_check
-        test_gh_api_classification
-        test_stale_kill_class
-        test_workspace_routes_keeper
-        test_provider_capability_matrix
-        test_effect_evidence_source_path
-        test_cognitive_gravity
-        test_intentional_projection
-        test_chronicle_event
-        test_chronicle_librarian
-        test_alignment_score
-        )
- (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_mcp_error_code test_error_body_delegation test_session_lifecycle_event test_fd_accountant test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
-          test_streamable_http_upgrade
-          test_mcp_session_id_header
-          test_keeper_turn_terminal_code_byte_compat
-          test_keeper_sdk_error_typed_bridge
-          test_openai_compat_error_map
-          test_read_drop_reason
-          test_log_ring_encoder
-          test_eio_context_fiber_local
-          test_keeper_turn_disposition
-          test_keeper_turn_terminal_disposition_field
-          test_attempt_state
-          test_actor_mailbox
-          test_domain_pool
-          test_sse test_graphql_api
-          test_graphql_endpoint
-          test_subscriptions test_session test_progress test_spawn
-          test_validation test_response
-          test_channel_gate_connector_routes
-        test_sidecar_lifecycle_routes
-          test_channel_gate_imessage_state
-          test_dashboard
-          test_dashboard_branches
-          test_dashboard_perf
-          test_dashboard_tool_host_events
-          test_dashboard_nav_event
-          test_cdal_tool_id
-          test_tool_assignment_telemetry
-          test_dashboard_link_preview
-          test_gate_keeper_backend
-          test_transport_read_model
-          test_multi_room test_worktree_detection test_bounded test_mention
-          test_mention_dedup
-          test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
-          test_post_verifier
-        test_reward_advice_artifact
-          test_cascade_capability_profile
-          test_cascade_secondary_expand
-          test_keeper_hooks_oas_telemetry
-          test_masc_oas_bridge_timeout_guard
-          test_keeper_llm_bridge
-          test_agent_stress
-          test_keeper_tool_use_failure_counter
-          test_keeper_compaction_outcome_counter
-          test_keeper_usage_trust_counter
-          test_llm_metric_bridge
-          test_cost_usd_source_attribution_10318
-          test_response_model_empty_10083
-          test_heuristic_theatre_audit
-          test_keeper_proactive_skip_counter
-          test_keeper_tool_selection_passive_streak
-          test_keeper_health_probe
-          test_oas_error_kind_counter
-          test_oas_empty_response_diagnostic
-          test_board_author_identity_10297
-          test_fsm_drift_counter
-          test_gc_sampler
-          test_process_timeout_counter
-          test_git_fetch_timeout_9587
-          test_inference_utils
-          test_auth_ambiguous_lookup_9786
-          test_auth_load_credential_of
-          test_keeper_wake_telemetry
-          test_keeper_timing
-          test_keeper_memory
-          test_memory_jsonl_truncation
-          test_keeper_chat_store
-          test_keeper_runtime_trust_snapshot
-          test_ide_annotations
-          test_keeper_runtime_manifest
-          test_schema_surface_index
-          test_keeper_accountability
-          test_reputation_ledger_v2
-          test_reputation_multi_dim
-          test_keeper_goal_repair
-          test_accountability_emit_skip_10314
-          test_keeper_exec_status
-          test_keeper_pause_broadcast
-          test_keeper_terminal_reason
-        test_keeper_adaptive_thinking
-          test_keeper_turn_intent
-          test_keeper_lifecycle
-          test_keeper_lifecycle_chaos
-          test_keeper_rollover_gate
-          test_keeper_generation_lineage
-          test_keeper_deliberation
-          test_keeper_registry
-          test_keeper_fd_pressure_fleet
-          test_docker_spawn_throttle
-          test_keeper_supervisor
-          test_keeper_alerting_path
-          test_coord_eio_pure
-          test_coord_telemetry_drop_non_eio
-          test_keeper_contract_classifier_pure
-          test_keeper_compact_policy_pure
-          test_heartbeat_smart
-          test_keeper_allowed_paths
-          test_keeper_repo_readiness
-          test_keeper_tool_surface_guard
-          test_keeper_benchmark_canary
-          test_keeper_pr_review
-          test_keeper_github_pr
-          test_playground_paths
-          test_keeper_llama_only
-          test_keeper_meta_cwd_resilience
-          test_metrics_rotation
-          test_tool_access_policy
-          test_tool_access_role
-          test_tool_token
-          test_tool_exposure
-          test_autonomy_liberation
-          test_keeper_unified
-          test_decision_pipeline
-          test_decision_pipeline_observer
-          test_keeper_composite_observer
-          test_keeper_fsm_edges
-          test_keeper_fsm_guard_actions
-          test_keeper_callback_hardening
-          test_keeper_behavioral_regime
-          test_keeper_toml
-          test_keeper_runtime_toml
-          test_keeper_tool_policy_config
-          test_keeper_tool_resolution
-          test_dispatch_disclosure_parity
-          test_coord_worktree_policy_path
-          test_claim_post_provision_hook
-          test_keeper_toml_config_validation
-          test_keeper_id
-          test_repo_store
-          test_chronicle_types
-          test_chronicle_ingest
-          test_chronicle_validate
-          test_credential_store
-          test_credential_materializer
-          test_keeper_repo_mapping
-          test_credential_provider_bridge
-          test_repo_sync
-          test_repo_git
-          test_repo_e2e
-          test_exec_core
-          test_exec_dispatch
-          test_keeper_bash_safety
-          test_keeper_bash_typed_input
-          test_hitl_approval
-          test_approval_callback_wired
-          test_keeper_discovered_tools
-          test_keeper_tool_affinity
-          test_keeper_tool_alias
-          test_keeper_sandbox_containment
-          test_keeper_transition_audit
-          test_keeper_shell_containment
-          test_keeper_shell_docker_route
-          test_keeper_shell_via_field
-          test_env_git_noninteractive
-          test_gh_exit_class
-          test_gh_exit_class_wiring
-          test_stay_silent_loop_detector
-          test_oas_compat_cascade_fallback
-          test_heuristic_metrics_boot_wireup
-          test_heuristic_metrics_periodic_flush_10348
-          test_cap_blocker_structured_error
-          test_context_overflow_action_tracker
-          test_keeper_fs_edit_patch
-          test_keeper_docker_read
-          test_keeper_path_ssot
-        test_keeper_egress_audit
-          test_keeper_github_read_only
-          test_worktree_live_context
-          test_git_graph_snapshot
-          test_worktree_status_single_flight_9632
-          test_tool_input_validation
-          test_failure_learnings_10325
-          test_agent_stress_emit_10341
-          test_autoresearch_codegen
-          test_autoresearch_oas_primitives
-          test_autoresearch_target_score
-          ; test_contract_risk removed (team session cleanup)
-          ; test_contract_composer removed (team session cleanup)
-          test_cdal_conformance
-          test_task_stage
-          test_ocaml_north_star_task_lifecycle
-          ; test_risk_digest removed (team session cleanup)
-          test_tool_blob_store
-          test_tool_bridge_externalize
-          test_keeper_artifact_hydrator
-          test_artifacts_endpoint
-          test_tool_output_washing_e2e
-          test_keeper_context_core_dedup
-          test_adversarial_eval
-          test_labeling
-          test_tool_deep_review
-          test_tool_call_quality_benchmark
-          test_keeper_prompt_metrics
-          test_keeper_reaction_ledger
-          test_cache_metrics_wiring
-          test_tool_surface_ssot
-          test_keeper_retrieval_quality
-          test_observability_redact
-          test_observability_provider_contracts
-          test_config_doctor
-          test_cascade_config_validity
-          test_cascade_routes_decoder
-          test_cascade_declarative_parser
-          test_cascade_declarative_validator
-          test_cascade_declarative_adapter
-          test_cascade_declarative_hotpath
-          test_keeper_cascade_profile_partial
-          test_doctor_dispatch
-          test_disk_hygiene_script
-          test_run_local_script
-          test_tool_prefilter
-          test_keeper_state_machine
-          test_keeper_state_machine_correspondence
-          test_keeper_state_machine_tla_correspondence
-          test_keeper_lifecycle_hooks
-          test_keeper_sub_fsm_guards
-          test_keeper_cascade_tla_mirror
-          test_keeper_subprocess_registry
-          test_keeper_bg_task_cleanup
-          test_keeper_social_model_magentic_ledger_fsm
-          test_keeper_overflow_recovery
-          test_telemetry_unified
-          test_telemetry_error_occurred_wire_10358
-          test_keeper_topk_llm
-          test_warn_root_causes
-          test_memory_hooks
-          test_keeper_agent_memory_episode_activity
-          test_agent_stress_timeout_wire_10341
-          test_institution_episodes_failure_learnings_10325
-          test_institution_of_string_fail_closed
-          test_mid_turn_resume
-          test_lockfree_atomic
-          test_telemetry_observe
-          test_keeper_typed_labels
-          test_shell_ir_typed_review_followup
-          test_shell_ir_validator
-          test_typed_advisor_counters
-          test_auth_resolve_labels
-          test_keeper_classifier_helper
-          test_persona_tool_reachability
-          test_cascade_strategy_labels
-          test_turn_id_propagation
-          test_per_keeper_token_fallback
-          test_auth_strict_mode
-          test_keeper_turn_fsm_emit
-          test_keeper_event_queue
-          test_keeper_relevance_check
-          test_gh_api_classification
-          test_actionable_path_action
-          test_stale_kill_class
-          test_provider_capability_matrix
-          test_provider_error
-          test_keeper_synthetic_marker
-          test_keeper_turn_fsm_wired_sites
-          test_effective_oas_env
-          test_workspace_routes_keeper
-          test_effect_evidence_source_path
-          test_cognitive_gravity
-          test_intentional_projection
-          test_chronicle_event
-          test_chronicle_librarian
-          test_alignment_score
-          )
+ (names
+  test_attribution
+  test_attribution_tagged
+  test_autoresearch_result_bridge
+  test_dashboard_attribution
+  test_dashboard_oas_bridge
+  test_masc_runtime_events
+  test_room
+  test_room_state_recovery
+  test_types
+  test_exec_tap
+  test_auth
+  test_auth_doctor
+  test_auth_error_kind
+  test_mcp_error_code
+  test_error_body_delegation
+  test_session_lifecycle_event
+  test_fd_accountant
+  test_auth_login
+  test_audit_log
+  test_governance_anomaly
+  test_http_negotiation
+  test_streamable_http_upgrade
+  test_mcp_session_id_header
+  test_keeper_turn_terminal_code_byte_compat
+  test_keeper_sdk_error_typed_bridge
+  test_openai_compat_error_map
+  test_read_drop_reason
+  test_log_ring_encoder
+  test_eio_context_fiber_local
+  test_keeper_turn_disposition
+  test_keeper_turn_terminal_disposition_field
+  test_attempt_state
+  test_actor_mailbox
+  test_domain_pool
+  test_sse
+  test_graphql_api
+  test_graphql_endpoint
+  test_subscriptions
+  test_session
+  test_progress
+  test_spawn
+  test_validation
+  test_response
+  test_channel_gate_connector_routes
+  test_sidecar_lifecycle_routes
+  test_channel_gate_imessage_state
+  test_dashboard
+  test_dashboard_branches
+  test_dashboard_perf
+  test_dashboard_tool_host_events
+  test_dashboard_nav_event
+  test_cdal_tool_id
+  test_tool_assignment_telemetry
+  test_dashboard_link_preview
+  test_gate_keeper_backend
+  test_transport_read_model
+  test_multi_room
+  test_worktree_detection
+  test_bounded
+  test_mention
+  test_mention_dedup
+  test_heartbeat_qw
+  test_sse_qw
+  test_sse_stream
+  test_agent_health
+  test_post_verifier
+  test_reward_advice_artifact
+  test_cascade_capability_profile
+  test_cascade_secondary_expand
+  test_keeper_hooks_oas_telemetry
+  test_masc_oas_bridge_timeout_guard
+  test_keeper_llm_bridge
+  test_agent_stress
+  test_keeper_tool_use_failure_counter
+  test_keeper_compaction_outcome_counter
+  test_keeper_sub_fsm_guards
+  test_keeper_cascade_tla_mirror
+  test_keeper_usage_trust_counter
+  test_llm_metric_bridge
+  test_cost_usd_source_attribution_10318
+  test_response_model_empty_10083
+  test_heuristic_theatre_audit
+  test_keeper_proactive_skip_counter
+  test_keeper_tool_selection_passive_streak
+  test_keeper_health_probe
+  test_oas_error_kind_counter
+  test_oas_empty_response_diagnostic
+  test_board_author_identity_10297
+  test_fsm_drift_counter
+  test_gc_sampler
+  test_process_timeout_counter
+  test_git_fetch_timeout_9587
+  test_inference_utils
+  test_auth_ambiguous_lookup_9786
+  test_auth_load_credential_of
+  test_keeper_wake_telemetry
+  test_keeper_timing
+  test_keeper_memory
+  test_memory_jsonl_truncation
+  test_keeper_chat_store
+  test_keeper_runtime_trust_snapshot
+  test_ide_annotations
+  test_keeper_runtime_manifest
+  test_schema_surface_index
+  test_keeper_accountability
+  test_reputation_ledger_v2
+  test_reputation_multi_dim
+  test_keeper_goal_repair
+  test_accountability_emit_skip_10314
+  test_keeper_exec_status
+  test_keeper_pause_broadcast
+  test_keeper_terminal_reason
+  test_keeper_adaptive_thinking
+  test_keeper_turn_intent
+  test_keeper_lifecycle
+  test_keeper_lifecycle_chaos
+  test_keeper_rollover_gate
+  test_keeper_generation_lineage
+  test_keeper_deliberation
+  test_keeper_registry
+  test_keeper_fd_pressure_fleet
+  test_docker_spawn_throttle
+  test_keeper_supervisor
+  test_keeper_alerting_path
+  test_coord_eio_pure
+  test_coord_telemetry_drop_non_eio
+  test_keeper_contract_classifier_pure
+  test_keeper_compact_policy_pure
+  test_heartbeat_smart
+  test_keeper_allowed_paths
+  test_keeper_repo_readiness
+  test_keeper_tool_surface_guard
+  test_keeper_benchmark_canary
+  test_keeper_pr_review
+  test_keeper_github_pr
+  test_playground_paths
+  test_keeper_llama_only
+  test_keeper_meta_cwd_resilience
+  test_metrics_rotation
+  test_tool_access_policy
+  test_tool_access_role
+  test_tool_token
+  test_tool_exposure
+  test_autonomy_liberation
+  test_keeper_unified
+  test_decision_pipeline
+  test_decision_pipeline_observer
+  test_keeper_composite_observer
+  test_keeper_fsm_edges
+  test_keeper_fsm_guard_actions
+  test_keeper_callback_hardening
+  test_keeper_behavioral_regime
+  test_keeper_toml
+  test_keeper_runtime_toml
+  test_keeper_tool_policy_config
+  test_keeper_tool_resolution
+  test_dispatch_disclosure_parity
+  test_coord_worktree_policy_path
+  test_claim_post_provision_hook
+  test_keeper_toml_config_validation
+  test_keeper_id
+  test_repo_store
+  test_chronicle_types
+  test_chronicle_ingest
+  test_chronicle_validate
+  test_credential_store
+  test_credential_materializer
+  test_keeper_repo_mapping
+  test_credential_provider_bridge
+  test_repo_sync
+  test_repo_git
+  test_repo_e2e
+  test_exec_core
+  test_exec_dispatch
+  test_keeper_bash_safety
+  test_keeper_bash_typed_input
+  test_hitl_approval
+  test_approval_callback_wired
+  test_keeper_discovered_tools
+  test_keeper_tool_affinity
+  test_keeper_tool_alias
+  test_keeper_sandbox_containment
+  test_keeper_transition_audit
+  test_keeper_shell_containment
+  test_keeper_shell_docker_route
+  test_keeper_shell_via_field
+  test_env_git_noninteractive
+  test_gh_exit_class
+  test_gh_exit_class_wiring
+  test_stay_silent_loop_detector
+  test_oas_compat_cascade_fallback
+  test_heuristic_metrics_boot_wireup
+  test_heuristic_metrics_periodic_flush_10348
+  test_cap_blocker_structured_error
+  test_context_overflow_action_tracker
+  test_keeper_fs_edit_patch
+  test_keeper_docker_read
+  test_keeper_path_ssot
+  test_keeper_egress_audit
+  test_keeper_github_read_only
+  test_worktree_live_context
+  test_git_graph_snapshot
+  test_worktree_status_single_flight_9632
+  test_tool_input_validation
+  test_failure_learnings_10325
+  test_agent_stress_emit_10341
+  test_autoresearch_codegen
+  test_autoresearch_oas_primitives
+  test_autoresearch_target_score
+  test_cdal_conformance
+  test_task_stage
+  test_ocaml_north_star_task_lifecycle
+  test_tool_blob_store
+  test_tool_bridge_externalize
+  test_keeper_artifact_hydrator
+  test_artifacts_endpoint
+  test_tool_output_washing_e2e
+  test_keeper_context_core_dedup
+  test_adversarial_eval
+  test_labeling
+  test_tool_deep_review
+  test_tool_call_quality_benchmark
+  test_keeper_prompt_metrics
+  test_keeper_reaction_ledger
+  test_cache_metrics_wiring
+  test_tool_surface_ssot
+  test_keeper_retrieval_quality
+  test_observability_redact
+  test_observability_provider_contracts
+  test_config_doctor
+  test_cascade_config_validity
+  test_cascade_routes_decoder
+  test_cascade_declarative_parser
+  test_cascade_declarative_validator
+  test_cascade_declarative_adapter
+  test_cascade_declarative_hotpath
+  test_keeper_cascade_profile_partial
+  test_doctor_dispatch
+  test_disk_hygiene_script
+  test_run_local_script
+  test_tool_prefilter
+  test_keeper_state_machine
+  test_keeper_state_machine_correspondence
+  test_keeper_state_machine_tla_correspondence
+  test_keeper_lifecycle_hooks
+  test_keeper_subprocess_registry
+  test_keeper_bg_task_cleanup
+  test_keeper_social_model_magentic_ledger_fsm
+  test_keeper_overflow_recovery
+  test_telemetry_unified
+  test_telemetry_error_occurred_wire_10358
+  test_keeper_topk_llm
+  test_warn_root_causes
+  test_memory_hooks
+  test_keeper_agent_memory_episode_activity
+  test_agent_stress_timeout_wire_10341
+  test_institution_episodes_failure_learnings_10325
+  test_institution_of_string_fail_closed
+  test_mid_turn_resume
+  test_lockfree_atomic
+  test_telemetry_observe
+  test_keeper_typed_labels
+  test_shell_ir_typed_review_followup
+  test_shell_ir_validator
+  test_typed_advisor_counters
+  test_auth_resolve_labels
+  test_keeper_classifier_helper
+  test_persona_tool_reachability
+  test_cascade_strategy_labels
+  test_turn_id_propagation
+  test_per_keeper_token_fallback
+  test_auth_strict_mode
+  test_keeper_turn_fsm_emit
+  test_keeper_event_queue
+  test_keeper_relevance_check
+  test_gh_api_classification
+  test_stale_kill_class
+  test_workspace_routes_keeper
+  test_provider_capability_matrix
+  test_effect_evidence_source_path
+  test_cognitive_gravity
+  test_intentional_projection
+  test_chronicle_event
+  test_chronicle_librarian
+  test_alignment_score)
+ (modules
+  test_attribution
+  test_attribution_tagged
+  test_autoresearch_result_bridge
+  test_dashboard_attribution
+  test_dashboard_oas_bridge
+  test_masc_runtime_events
+  test_room
+  test_room_state_recovery
+  test_types
+  test_exec_tap
+  test_auth
+  test_auth_doctor
+  test_auth_error_kind
+  test_mcp_error_code
+  test_error_body_delegation
+  test_session_lifecycle_event
+  test_fd_accountant
+  test_auth_login
+  test_audit_log
+  test_governance_anomaly
+  test_http_negotiation
+  test_streamable_http_upgrade
+  test_mcp_session_id_header
+  test_keeper_turn_terminal_code_byte_compat
+  test_keeper_sdk_error_typed_bridge
+  test_openai_compat_error_map
+  test_read_drop_reason
+  test_log_ring_encoder
+  test_eio_context_fiber_local
+  test_keeper_turn_disposition
+  test_keeper_turn_terminal_disposition_field
+  test_attempt_state
+  test_actor_mailbox
+  test_domain_pool
+  test_sse
+  test_graphql_api
+  test_graphql_endpoint
+  test_subscriptions
+  test_session
+  test_progress
+  test_spawn
+  test_validation
+  test_response
+  test_channel_gate_connector_routes
+  test_sidecar_lifecycle_routes
+  test_channel_gate_imessage_state
+  test_dashboard
+  test_dashboard_branches
+  test_dashboard_perf
+  test_dashboard_tool_host_events
+  test_dashboard_nav_event
+  test_cdal_tool_id
+  test_tool_assignment_telemetry
+  test_dashboard_link_preview
+  test_gate_keeper_backend
+  test_transport_read_model
+  test_multi_room
+  test_worktree_detection
+  test_bounded
+  test_mention
+  test_mention_dedup
+  test_heartbeat_qw
+  test_sse_qw
+  test_sse_stream
+  test_agent_health
+  test_post_verifier
+  test_reward_advice_artifact
+  test_cascade_capability_profile
+  test_cascade_secondary_expand
+  test_keeper_hooks_oas_telemetry
+  test_masc_oas_bridge_timeout_guard
+  test_keeper_llm_bridge
+  test_agent_stress
+  test_keeper_tool_use_failure_counter
+  test_keeper_compaction_outcome_counter
+  test_keeper_usage_trust_counter
+  test_llm_metric_bridge
+  test_cost_usd_source_attribution_10318
+  test_response_model_empty_10083
+  test_heuristic_theatre_audit
+  test_keeper_proactive_skip_counter
+  test_keeper_tool_selection_passive_streak
+  test_keeper_health_probe
+  test_oas_error_kind_counter
+  test_oas_empty_response_diagnostic
+  test_board_author_identity_10297
+  test_fsm_drift_counter
+  test_gc_sampler
+  test_process_timeout_counter
+  test_git_fetch_timeout_9587
+  test_inference_utils
+  test_auth_ambiguous_lookup_9786
+  test_auth_load_credential_of
+  test_keeper_wake_telemetry
+  test_keeper_timing
+  test_keeper_memory
+  test_memory_jsonl_truncation
+  test_keeper_chat_store
+  test_keeper_runtime_trust_snapshot
+  test_ide_annotations
+  test_keeper_runtime_manifest
+  test_schema_surface_index
+  test_keeper_accountability
+  test_reputation_ledger_v2
+  test_reputation_multi_dim
+  test_keeper_goal_repair
+  test_accountability_emit_skip_10314
+  test_keeper_exec_status
+  test_keeper_pause_broadcast
+  test_keeper_terminal_reason
+  test_keeper_adaptive_thinking
+  test_keeper_turn_intent
+  test_keeper_lifecycle
+  test_keeper_lifecycle_chaos
+  test_keeper_rollover_gate
+  test_keeper_generation_lineage
+  test_keeper_deliberation
+  test_keeper_registry
+  test_keeper_fd_pressure_fleet
+  test_docker_spawn_throttle
+  test_keeper_supervisor
+  test_keeper_alerting_path
+  test_coord_eio_pure
+  test_coord_telemetry_drop_non_eio
+  test_keeper_contract_classifier_pure
+  test_keeper_compact_policy_pure
+  test_heartbeat_smart
+  test_keeper_allowed_paths
+  test_keeper_repo_readiness
+  test_keeper_tool_surface_guard
+  test_keeper_benchmark_canary
+  test_keeper_pr_review
+  test_keeper_github_pr
+  test_playground_paths
+  test_keeper_llama_only
+  test_keeper_meta_cwd_resilience
+  test_metrics_rotation
+  test_tool_access_policy
+  test_tool_access_role
+  test_tool_token
+  test_tool_exposure
+  test_autonomy_liberation
+  test_keeper_unified
+  test_decision_pipeline
+  test_decision_pipeline_observer
+  test_keeper_composite_observer
+  test_keeper_fsm_edges
+  test_keeper_fsm_guard_actions
+  test_keeper_callback_hardening
+  test_keeper_behavioral_regime
+  test_keeper_toml
+  test_keeper_runtime_toml
+  test_keeper_tool_policy_config
+  test_keeper_tool_resolution
+  test_dispatch_disclosure_parity
+  test_coord_worktree_policy_path
+  test_claim_post_provision_hook
+  test_keeper_toml_config_validation
+  test_keeper_id
+  test_repo_store
+  test_chronicle_types
+  test_chronicle_ingest
+  test_chronicle_validate
+  test_credential_store
+  test_credential_materializer
+  test_keeper_repo_mapping
+  test_credential_provider_bridge
+  test_repo_sync
+  test_repo_git
+  test_repo_e2e
+  test_exec_core
+  test_exec_dispatch
+  test_keeper_bash_safety
+  test_keeper_bash_typed_input
+  test_hitl_approval
+  test_approval_callback_wired
+  test_keeper_discovered_tools
+  test_keeper_tool_affinity
+  test_keeper_tool_alias
+  test_keeper_sandbox_containment
+  test_keeper_transition_audit
+  test_keeper_shell_containment
+  test_keeper_shell_docker_route
+  test_keeper_shell_via_field
+  test_env_git_noninteractive
+  test_gh_exit_class
+  test_gh_exit_class_wiring
+  test_stay_silent_loop_detector
+  test_oas_compat_cascade_fallback
+  test_heuristic_metrics_boot_wireup
+  test_heuristic_metrics_periodic_flush_10348
+  test_cap_blocker_structured_error
+  test_context_overflow_action_tracker
+  test_keeper_fs_edit_patch
+  test_keeper_docker_read
+  test_keeper_path_ssot
+  test_keeper_egress_audit
+  test_keeper_github_read_only
+  test_worktree_live_context
+  test_git_graph_snapshot
+  test_worktree_status_single_flight_9632
+  test_tool_input_validation
+  test_failure_learnings_10325
+  test_agent_stress_emit_10341
+  test_autoresearch_codegen
+  test_autoresearch_oas_primitives
+  test_autoresearch_target_score
+  ; test_contract_risk removed (team session cleanup)
+  ; test_contract_composer removed (team session cleanup)
+  test_cdal_conformance
+  test_task_stage
+  test_ocaml_north_star_task_lifecycle
+  ; test_risk_digest removed (team session cleanup)
+  test_tool_blob_store
+  test_tool_bridge_externalize
+  test_keeper_artifact_hydrator
+  test_artifacts_endpoint
+  test_tool_output_washing_e2e
+  test_keeper_context_core_dedup
+  test_adversarial_eval
+  test_labeling
+  test_tool_deep_review
+  test_tool_call_quality_benchmark
+  test_keeper_prompt_metrics
+  test_keeper_reaction_ledger
+  test_cache_metrics_wiring
+  test_tool_surface_ssot
+  test_keeper_retrieval_quality
+  test_observability_redact
+  test_observability_provider_contracts
+  test_config_doctor
+  test_cascade_config_validity
+  test_cascade_routes_decoder
+  test_cascade_declarative_parser
+  test_cascade_declarative_validator
+  test_cascade_declarative_adapter
+  test_cascade_declarative_hotpath
+  test_keeper_cascade_profile_partial
+  test_doctor_dispatch
+  test_disk_hygiene_script
+  test_run_local_script
+  test_tool_prefilter
+  test_keeper_state_machine
+  test_keeper_state_machine_correspondence
+  test_keeper_state_machine_tla_correspondence
+  test_keeper_lifecycle_hooks
+  test_keeper_sub_fsm_guards
+  test_keeper_cascade_tla_mirror
+  test_keeper_subprocess_registry
+  test_keeper_bg_task_cleanup
+  test_keeper_social_model_magentic_ledger_fsm
+  test_keeper_overflow_recovery
+  test_telemetry_unified
+  test_telemetry_error_occurred_wire_10358
+  test_keeper_topk_llm
+  test_warn_root_causes
+  test_memory_hooks
+  test_keeper_agent_memory_episode_activity
+  test_agent_stress_timeout_wire_10341
+  test_institution_episodes_failure_learnings_10325
+  test_institution_of_string_fail_closed
+  test_mid_turn_resume
+  test_lockfree_atomic
+  test_telemetry_observe
+  test_keeper_typed_labels
+  test_shell_ir_typed_review_followup
+  test_shell_ir_validator
+  test_typed_advisor_counters
+  test_auth_resolve_labels
+  test_keeper_classifier_helper
+  test_persona_tool_reachability
+  test_cascade_strategy_labels
+  test_turn_id_propagation
+  test_per_keeper_token_fallback
+  test_auth_strict_mode
+  test_keeper_turn_fsm_emit
+  test_keeper_event_queue
+  test_keeper_relevance_check
+  test_gh_api_classification
+  test_actionable_path_action
+  test_stale_kill_class
+  test_provider_capability_matrix
+  test_provider_error
+  test_keeper_synthetic_marker
+  test_keeper_turn_fsm_wired_sites
+  test_effective_oas_env
+  test_workspace_routes_keeper
+  test_effect_evidence_source_path
+  test_cognitive_gravity
+  test_intentional_projection
+  test_chronicle_event
+  test_chronicle_librarian
+  test_alignment_score)
  (libraries masc_test_deps multimodal))
 
 ; Group 2: Property-based tests (QCheck)
+
 (tests
- (names test_pbt_mention test_pbt_validation test_pbt_text_processing test_pbt_context_overflow
-        test_keeper_state_machine_pbt test_telemetry_eio_pbt
-        test_metrics_store_eio_pbt test_prompt_registry_pbt
-        test_keeper_fsm_joints test_clean_only_bug_mirrors
-        test_keeper_phase_drift_contract test_event_priority_monotone_pbt)
- (modules test_pbt_mention test_pbt_validation test_pbt_text_processing test_pbt_context_overflow
-          test_keeper_state_machine_pbt test_telemetry_eio_pbt
-          test_metrics_store_eio_pbt test_prompt_registry_pbt
-          test_keeper_fsm_joints test_clean_only_bug_mirrors
-          test_keeper_phase_drift_contract test_event_priority_monotone_pbt)
+ (names
+  test_pbt_mention
+  test_pbt_validation
+  test_pbt_text_processing
+  test_pbt_context_overflow
+  test_keeper_state_machine_pbt
+  test_telemetry_eio_pbt
+  test_metrics_store_eio_pbt
+  test_prompt_registry_pbt
+  test_keeper_fsm_joints
+  test_clean_only_bug_mirrors
+  test_keeper_phase_drift_contract
+  test_event_priority_monotone_pbt)
+ (modules
+  test_pbt_mention
+  test_pbt_validation
+  test_pbt_text_processing
+  test_pbt_context_overflow
+  test_keeper_state_machine_pbt
+  test_telemetry_eio_pbt
+  test_metrics_store_eio_pbt
+  test_prompt_registry_pbt
+  test_keeper_fsm_joints
+  test_clean_only_bug_mirrors
+  test_keeper_phase_drift_contract
+  test_event_priority_monotone_pbt)
  (libraries masc_test_deps))
 
 ; Focused single-module tests
 
 ; Group 3: Eio-native tests (single-module, standard deps)
 ; Merged from ~100 individual (test ...) stanzas.
+
 (tests
  (names
-        test_runtime_params
-        test_config_dir_resolver
-        test_room_coverage
-        test_streamable_http
-        test_dashboard_rooms
-        test_dashboard_mission
-        test_dashboard_mission_briefing
-        ; test_command_plane_help removed (CP purge)
-
-        test_dashboard_cache
-        test_dashboard_execution
-        test_dashboard_http_core
-        test_dashboard_autoresearch
-        test_dashboard_harness_health
-        test_eval_feed
-        test_dashboard_tools
-        test_dashboard_verification
-        test_tool_quality_classify
-        test_tui_decode
-        test_dashboard_governance
-        test_dashboard_labels
-        test_dashboard_safe_autonomy
-        test_dashboard_keeper_feature_proof
-        test_dashboard_surface_readiness
-        test_activity_graph
-        test_masc_log
-        test_dashboard_namespace_truth
-        test_server_runtime_bootstrap
-        test_server_base_path_diagnostics
-        test_server_startup_takeover
-        test_keeper_meta_listing
-        test_keeper_meta_cas_retry
-        test_judge_diagnostics
-        test_judge_json_recovery
-        test_keeper_cli_mcp_config
-        test_board_vote_quarantine
-        test_keeper_identity_parse
-        test_keeper_identity_normalize
-        test_coord_join_fail_closed
-        test_keeper_personality_io_parse
-        test_keeper_personality_io_coerce
-        test_keeper_personality_io_validate
-        test_keeper_personality_io_compare
-        test_keeper_personality_io_render
-        test_keeper_identity_outcome_label
-        test_keeper_hash_algo
-        test_keeper_container_name
-        test_keeper_sandbox_oneshot_plan
-        test_keeper_sandbox_session_plan
-        test_docker_response
-        test_docker_client_mock
-        test_docker_client_real
-        test_sandbox_executor
-        test_sandbox_session_executor
-        test_keeper_backoff_policy
-        test_worker_runtime
-        test_capability_registry
-        test_tool_local_runtime_verify
-        test_tool_local_runtime_probe
-        test_board_ttl
-        test_worker_dev_tools
-        test_keeper_path_check_error
-        test_shadow_parse
-        test_destructive_class
-        test_path_rewrite_validation
-        test_board_content_dedup
-        test_gate_diff
-        test_legendary_counters
-        test_legendary_bash_bg_tasks_route
-        test_oas_integration
-        test_memory_oas_5tier
-        test_verifier_oas_bridge
-        test_oas_adapters
-        test_cache_eio
-        test_metrics_store_eio
-        test_planning_eio
-        test_thompson_sampling
-        test_safe_ops
-        test_json_util
-        test_process_eio_coverage
-        test_with_process_coverage
-        test_bg_task_stub
-        test_process_eio_detached
-        test_voice_runtime_overlay
-        test_worker_container_coverage
-        test_resilience
-        test_common
-        test_room_messages_raw
-        ; test_cp_cleanup, test_cp_search_fabric, test_cp_section_cache, test_cp_jsonl_tail removed (CP purge)
-        test_local_runtime_pool
-        test_keeper_tools_oas
-        test_keeper_tool_exposure
-        test_keeper_runtime_denylist
-        test_keeper_runtime_config_ssot
-        test_dashboard_render_timing_9766
-        test_dashboard_keeper_cost_aggregates
-        test_gh_command_blocked_message_10561
-        test_keeper_turn_timeout_default_10456
-        test_task_status_label_10421
-        test_task_completion_path_10449
-        test_task_cache_invariant_13397
-        test_filter_rejection_10474
-        test_sandbox_inspect_trim_10488
-        test_credential_alias_10440
-        test_credential_provider
-        test_cascade_trust
-        test_dashboard_k2_feeds
-        test_keeper_profile_normalize_10552
-        test_personality_field_diff_10269
-        test_toml_skip_dedup_10259
-        test_discovery_history_models_10404
-        test_masc_log_utc_filename_10392
-        test_keeper_task_dispatch
-        test_keeper_tag_dispatch
-        test_autoresearch_knowledge
-        test_mcp_server_eio
-        test_mcp_server_eio_call_tool
-        test_code_navigation_eio
-        test_backend
-        test_room_eio
-        test_http_server_eio
-        test_compression
-        test_fs_compat
-        test_concurrency_stress
-        test_eio_mutex_concurrency
-        test_eio_guard_yield_meter
-        test_board_dispatch
-        test_board_curation
-        test_board_fixture_detector
-        test_vote_ts_preservation_10086
-        test_board_karma_ledger
-
-        test_task_dispatch
-        test_drift_guard_core
-        test_verify_handoff_tool
-        test_memory_horizon_classifier
-        test_param_type_classifier
-        test_tool_contract_truth
-        test_file_lock_eio
-        test_error_logging_coverage
-        test_agent_identity
-        test_mcp_full_cycle
-        test_agent_registry_eio
-        test_identity_e2e
-        test_identity_edge_cases
-        test_verification
-        test_pulse
-        test_transport_metrics
-        test_adaptive_cache_ttl
-        test_keeper_compact_audit
-        test_keeper_telemetry_consumer
-        test_oas_bus_instrument
-        test_trajectory
-        test_eval_gate
-        test_eval_harness
-        test_tool_board_coverage
-        test_anti_rationalization_fail_mode
-        test_board_truncation_detection
-        ; test_proof_criteria removed (team session cleanup)
-        test_tool_registration_consistency
-        ; test_tree_index removed (CP purge)
-        test_tool_registry
-        test_tool_dispatch
-        test_tool_spec
-        test_typed_tool_masc
-        test_state_product
-        test_coordination_product
-        test_tool_result
-        test_tool_hooks
-        test_governance_pipeline
-        test_keeper_routine_allowlist
-        test_keeper_agent_isolation
-        test_sse_external_sub
-        test_ws_transport
-        test_webrtc_signaling
-        test_transport_integration
-        test_tool_metrics
-        test_tool_metrics_persist
-        test_model_inference_metrics
-        test_keeper_tool_call_log
-        test_tool_unified
-        test_build_identity
-        test_workflow_guide
-        test_agent_economy
-        test_lifecycle
-        test_auto_recall_activity_coverage
-        test_grpc_coordination
-        test_grpc_client
-        test_http_protocol_detect
-        test_keeper_safety_gates
-        test_keeper_guards
-        test_eval_gate_evasion
-        test_prompt_registry_defaults
-        test_keeper_prompt_external
-        test_keeper_recurring
-        test_cdal_types
-        test_cdal_loader
-        test_cdal_proof
-        test_cdal_risk_contract
-        test_cdal_judge
-        test_cdal_verifiable_markers
-        test_cdal_eval_v1
-        test_keeper_cdal_contract
-        test_cdal_friction_projection
-        test_cdal_verdict_gate
-        test_cdal_mode_enforcer
-        test_cdal_mode_resolver
-        test_verification_fsm
-        test_task_sandbox
-        test_governance_yojson_roundtrip
-        test_eval_calibration
-        test_goal_janitor
-        test_goal_tools
-        test_goal_upsert_fsm_bypass_10247
-        test_goal_store
-        test_goal_verification
-        test_string_util
-        test_set_util
-        test_board_core_payload
-        test_board_attachment_meta
-        test_board_moderation
-        test_voice_config)
+  test_runtime_params
+  test_config_dir_resolver
+  test_room_coverage
+  test_streamable_http
+  test_dashboard_rooms
+  test_dashboard_mission
+  test_dashboard_mission_briefing
+  ; test_command_plane_help removed (CP purge)
+  test_dashboard_cache
+  test_dashboard_execution
+  test_dashboard_http_core
+  test_dashboard_autoresearch
+  test_dashboard_harness_health
+  test_eval_feed
+  test_dashboard_tools
+  test_dashboard_verification
+  test_tool_quality_classify
+  test_tui_decode
+  test_dashboard_governance
+  test_dashboard_labels
+  test_dashboard_safe_autonomy
+  test_dashboard_keeper_feature_proof
+  test_dashboard_surface_readiness
+  test_activity_graph
+  test_masc_log
+  test_dashboard_namespace_truth
+  test_server_runtime_bootstrap
+  test_server_base_path_diagnostics
+  test_server_startup_takeover
+  test_keeper_meta_listing
+  test_keeper_meta_cas_retry
+  test_judge_diagnostics
+  test_judge_json_recovery
+  test_keeper_cli_mcp_config
+  test_board_vote_quarantine
+  test_keeper_identity_parse
+  test_keeper_identity_normalize
+  test_coord_join_fail_closed
+  test_keeper_personality_io_parse
+  test_keeper_personality_io_coerce
+  test_keeper_personality_io_validate
+  test_keeper_personality_io_compare
+  test_keeper_personality_io_render
+  test_keeper_identity_outcome_label
+  test_keeper_hash_algo
+  test_keeper_container_name
+  test_keeper_sandbox_oneshot_plan
+  test_keeper_sandbox_session_plan
+  test_docker_response
+  test_docker_client_mock
+  test_docker_client_real
+  test_sandbox_executor
+  test_sandbox_session_executor
+  test_keeper_backoff_policy
+  test_worker_runtime
+  test_capability_registry
+  test_tool_local_runtime_verify
+  test_tool_local_runtime_probe
+  test_board_ttl
+  test_worker_dev_tools
+  test_keeper_path_check_error
+  test_shadow_parse
+  test_destructive_class
+  test_path_rewrite_validation
+  test_board_content_dedup
+  test_gate_diff
+  test_legendary_counters
+  test_legendary_bash_bg_tasks_route
+  test_oas_integration
+  test_memory_oas_5tier
+  test_verifier_oas_bridge
+  test_oas_adapters
+  test_cache_eio
+  test_metrics_store_eio
+  test_planning_eio
+  test_thompson_sampling
+  test_safe_ops
+  test_json_util
+  test_process_eio_coverage
+  test_with_process_coverage
+  test_bg_task_stub
+  test_process_eio_detached
+  test_voice_runtime_overlay
+  test_worker_container_coverage
+  test_resilience
+  test_common
+  test_room_messages_raw
+  ; test_cp_cleanup, test_cp_search_fabric, test_cp_section_cache, test_cp_jsonl_tail removed (CP purge)
+  test_local_runtime_pool
+  test_keeper_tools_oas
+  test_keeper_tool_exposure
+  test_keeper_runtime_denylist
+  test_keeper_runtime_config_ssot
+  test_dashboard_render_timing_9766
+  test_dashboard_keeper_cost_aggregates
+  test_gh_command_blocked_message_10561
+  test_keeper_turn_timeout_default_10456
+  test_task_status_label_10421
+  test_task_completion_path_10449
+  test_task_cache_invariant_13397
+  test_filter_rejection_10474
+  test_sandbox_inspect_trim_10488
+  test_credential_alias_10440
+  test_credential_provider
+  test_cascade_trust
+  test_dashboard_k2_feeds
+  test_keeper_profile_normalize_10552
+  test_personality_field_diff_10269
+  test_toml_skip_dedup_10259
+  test_discovery_history_models_10404
+  test_masc_log_utc_filename_10392
+  test_keeper_task_dispatch
+  test_keeper_tag_dispatch
+  test_autoresearch_knowledge
+  test_mcp_server_eio
+  test_mcp_server_eio_call_tool
+  test_code_navigation_eio
+  test_backend
+  test_room_eio
+  test_http_server_eio
+  test_compression
+  test_fs_compat
+  test_concurrency_stress
+  test_eio_mutex_concurrency
+  test_eio_guard_yield_meter
+  test_board_dispatch
+  test_board_curation
+  test_board_fixture_detector
+  test_vote_ts_preservation_10086
+  test_board_karma_ledger
+  test_task_dispatch
+  test_drift_guard_core
+  test_verify_handoff_tool
+  test_memory_horizon_classifier
+  test_param_type_classifier
+  test_tool_contract_truth
+  test_file_lock_eio
+  test_error_logging_coverage
+  test_agent_identity
+  test_mcp_full_cycle
+  test_agent_registry_eio
+  test_identity_e2e
+  test_identity_edge_cases
+  test_verification
+  test_pulse
+  test_transport_metrics
+  test_adaptive_cache_ttl
+  test_keeper_compact_audit
+  test_keeper_telemetry_consumer
+  test_oas_bus_instrument
+  test_trajectory
+  test_eval_gate
+  test_eval_harness
+  test_tool_board_coverage
+  test_anti_rationalization_fail_mode
+  test_board_truncation_detection
+  ; test_proof_criteria removed (team session cleanup)
+  test_tool_registration_consistency
+  ; test_tree_index removed (CP purge)
+  test_tool_registry
+  test_tool_dispatch
+  test_tool_spec
+  test_typed_tool_masc
+  test_state_product
+  test_coordination_product
+  test_tool_result
+  test_tool_hooks
+  test_governance_pipeline
+  test_keeper_routine_allowlist
+  test_keeper_agent_isolation
+  test_sse_external_sub
+  test_ws_transport
+  test_webrtc_signaling
+  test_transport_integration
+  test_tool_metrics
+  test_tool_metrics_persist
+  test_model_inference_metrics
+  test_keeper_tool_call_log
+  test_tool_unified
+  test_build_identity
+  test_workflow_guide
+  test_agent_economy
+  test_lifecycle
+  test_auto_recall_activity_coverage
+  test_grpc_coordination
+  test_grpc_client
+  test_http_protocol_detect
+  test_keeper_safety_gates
+  test_keeper_guards
+  test_eval_gate_evasion
+  test_prompt_registry_defaults
+  test_keeper_prompt_external
+  test_keeper_recurring
+  test_cdal_types
+  test_cdal_loader
+  test_cdal_proof
+  test_cdal_risk_contract
+  test_cdal_judge
+  test_cdal_verifiable_markers
+  test_cdal_eval_v1
+  test_keeper_cdal_contract
+  test_cdal_friction_projection
+  test_cdal_verdict_gate
+  test_cdal_mode_enforcer
+  test_cdal_mode_resolver
+  test_verification_fsm
+  test_task_sandbox
+  test_governance_yojson_roundtrip
+  test_eval_calibration
+  test_goal_janitor
+  test_goal_tools
+  test_goal_upsert_fsm_bypass_10247
+  test_goal_store
+  test_goal_verification
+  test_string_util
+  test_set_util
+  test_board_core_payload
+  test_board_attachment_meta
+  test_board_moderation
+  test_voice_config)
  (modules
-        test_runtime_params
-        test_config_dir_resolver
-        test_room_coverage
-        test_streamable_http
-        test_dashboard_rooms
-        test_dashboard_mission
-        test_dashboard_mission_briefing
-        ; test_command_plane_help removed (CP purge)
-
-        test_dashboard_cache
-        test_dashboard_execution
-        test_dashboard_http_core
-        test_dashboard_autoresearch
-        test_dashboard_harness_health
-        test_eval_feed
-        test_dashboard_tools
-        test_dashboard_verification
-        test_tool_quality_classify
-        test_tui_decode
-        test_dashboard_governance
-        test_dashboard_labels
-        test_dashboard_safe_autonomy
-        test_dashboard_keeper_feature_proof
-        test_dashboard_surface_readiness
-        test_activity_graph
-        test_masc_log
-        test_dashboard_namespace_truth
-        test_server_runtime_bootstrap
-        test_server_base_path_diagnostics
-        test_server_startup_takeover
-        test_keeper_meta_listing
-        test_keeper_meta_cas_retry
-        test_judge_diagnostics
-        test_judge_json_recovery
-        test_keeper_cli_mcp_config
-        test_board_vote_quarantine
-        test_keeper_identity_parse
-        test_keeper_identity_normalize
-        test_coord_join_fail_closed
-        test_keeper_personality_io_parse
-        test_keeper_personality_io_coerce
-        test_keeper_personality_io_validate
-        test_keeper_personality_io_compare
-        test_keeper_personality_io_render
-        test_keeper_identity_outcome_label
-        test_keeper_hash_algo
-        test_keeper_container_name
-        test_keeper_sandbox_oneshot_plan
-        test_keeper_sandbox_session_plan
-        test_docker_response
-        test_docker_client_mock
-        test_docker_client_real
-        test_sandbox_executor
-        test_sandbox_session_executor
-        test_keeper_backoff_policy
-        test_worker_runtime
-        test_capability_registry
-        test_tool_local_runtime_verify
-        test_tool_local_runtime_probe
-        test_board_ttl
-        test_worker_dev_tools
-        test_keeper_path_check_error
-        test_shadow_parse
-        test_destructive_class
-        test_gate_diff
-        test_path_rewrite_validation
-        test_board_content_dedup
-        test_legendary_counters
-        test_legendary_bash_bg_tasks_route
-        test_oas_integration
-        test_memory_oas_5tier
-        test_verifier_oas_bridge
-        test_oas_adapters
-        test_cache_eio
-        test_metrics_store_eio
-        test_planning_eio
-        test_thompson_sampling
-        test_safe_ops
-        test_json_util
-        test_process_eio_coverage
-        test_with_process_coverage
-        test_bg_task_stub
-        test_process_eio_detached
-        test_voice_runtime_overlay
-        test_worker_container_coverage
-        test_resilience
-        test_common
-        test_room_messages_raw
-        ; test_cp_cleanup, test_cp_search_fabric, test_cp_section_cache, test_cp_jsonl_tail removed (CP purge)
-        test_local_runtime_pool
-        test_keeper_tools_oas
-        test_keeper_tool_exposure
-        test_keeper_runtime_denylist
-        test_keeper_runtime_config_ssot
-        test_dashboard_render_timing_9766
-        test_dashboard_keeper_cost_aggregates
-        test_gh_command_blocked_message_10561
-        test_keeper_turn_timeout_default_10456
-        test_task_status_label_10421
-        test_task_completion_path_10449
-        test_task_cache_invariant_13397
-        test_filter_rejection_10474
-        test_sandbox_inspect_trim_10488
-        test_credential_alias_10440
-        test_credential_provider
-        test_cascade_trust
-        test_dashboard_k2_feeds
-        test_keeper_profile_normalize_10552
-        test_personality_field_diff_10269
-        test_toml_skip_dedup_10259
-        test_discovery_history_models_10404
-        test_masc_log_utc_filename_10392
-        test_keeper_task_dispatch
-        test_keeper_tag_dispatch
-        test_autoresearch_knowledge
-        test_mcp_server_eio
-        test_mcp_server_eio_call_tool
-        test_code_navigation_eio
-        test_backend
-        test_room_eio
-        test_http_server_eio
-        test_compression
-        test_fs_compat
-        test_concurrency_stress
-        test_eio_mutex_concurrency
-        test_eio_guard_yield_meter
-        test_board_dispatch
-        test_board_curation
-        test_board_fixture_detector
-        test_vote_ts_preservation_10086
-        test_board_karma_ledger
-
-        test_task_dispatch
-        test_drift_guard_core
-        test_verify_handoff_tool
-        test_memory_horizon_classifier
-        test_param_type_classifier
-        test_tool_contract_truth
-        test_file_lock_eio
-        test_error_logging_coverage
-        test_agent_identity
-          test_mcp_full_cycle
-          test_agent_registry_eio
-          test_identity_e2e
-        test_identity_edge_cases
-        test_verification
-        test_pulse
-        test_transport_metrics
-        test_adaptive_cache_ttl
-        test_keeper_compact_audit
-        test_keeper_telemetry_consumer
-        test_oas_bus_instrument
-        test_trajectory
-        test_eval_gate
-        test_eval_harness
-        test_tool_board_coverage
-        test_anti_rationalization_fail_mode
-        test_board_truncation_detection
-        test_tool_registration_consistency
-        ; test_tree_index removed (CP purge)
-        test_tool_registry
-        test_tool_dispatch
-        test_tool_spec
-        test_typed_tool_masc
-        test_state_product
-        test_coordination_product
-        test_tool_result
-        test_tool_hooks
-        test_governance_pipeline
-        test_keeper_routine_allowlist
-        test_keeper_agent_isolation
-        test_sse_external_sub
-        test_ws_transport
-        test_webrtc_signaling
-        test_transport_integration
-        test_tool_metrics
-        test_tool_metrics_persist
-        test_model_inference_metrics
-        test_tool_unified
-        test_keeper_tool_call_log
-        test_build_identity
-        test_workflow_guide
-        test_agent_economy
-        test_lifecycle
-        test_auto_recall_activity_coverage
-        test_grpc_coordination
-        test_grpc_client
-        test_http_protocol_detect
-        test_keeper_safety_gates
-        test_keeper_guards
-        test_eval_gate_evasion
-        test_prompt_registry_defaults
-        test_keeper_prompt_external
-        test_keeper_recurring
-        test_cdal_types
-        test_cdal_loader
-        test_cdal_proof
-        test_cdal_risk_contract
-        test_cdal_judge
-        test_cdal_verifiable_markers
-        test_cdal_eval_v1
-        test_keeper_cdal_contract
-        test_cdal_friction_projection
-        test_cdal_verdict_gate
-        test_cdal_mode_enforcer
-        test_cdal_mode_resolver
-        test_verification_fsm
-        test_task_sandbox
-        test_governance_yojson_roundtrip
-        test_eval_calibration
-        test_goal_janitor
-        test_goal_tools
-        test_goal_upsert_fsm_bypass_10247
-        test_goal_store
-        test_goal_verification
-        test_string_util
-        test_set_util
-        test_board_core_payload
-        test_board_attachment_meta
-        test_board_moderation
-        test_voice_config)
+  test_runtime_params
+  test_config_dir_resolver
+  test_room_coverage
+  test_streamable_http
+  test_dashboard_rooms
+  test_dashboard_mission
+  test_dashboard_mission_briefing
+  ; test_command_plane_help removed (CP purge)
+  test_dashboard_cache
+  test_dashboard_execution
+  test_dashboard_http_core
+  test_dashboard_autoresearch
+  test_dashboard_harness_health
+  test_eval_feed
+  test_dashboard_tools
+  test_dashboard_verification
+  test_tool_quality_classify
+  test_tui_decode
+  test_dashboard_governance
+  test_dashboard_labels
+  test_dashboard_safe_autonomy
+  test_dashboard_keeper_feature_proof
+  test_dashboard_surface_readiness
+  test_activity_graph
+  test_masc_log
+  test_dashboard_namespace_truth
+  test_server_runtime_bootstrap
+  test_server_base_path_diagnostics
+  test_server_startup_takeover
+  test_keeper_meta_listing
+  test_keeper_meta_cas_retry
+  test_judge_diagnostics
+  test_judge_json_recovery
+  test_keeper_cli_mcp_config
+  test_board_vote_quarantine
+  test_keeper_identity_parse
+  test_keeper_identity_normalize
+  test_coord_join_fail_closed
+  test_keeper_personality_io_parse
+  test_keeper_personality_io_coerce
+  test_keeper_personality_io_validate
+  test_keeper_personality_io_compare
+  test_keeper_personality_io_render
+  test_keeper_identity_outcome_label
+  test_keeper_hash_algo
+  test_keeper_container_name
+  test_keeper_sandbox_oneshot_plan
+  test_keeper_sandbox_session_plan
+  test_docker_response
+  test_docker_client_mock
+  test_docker_client_real
+  test_sandbox_executor
+  test_sandbox_session_executor
+  test_keeper_backoff_policy
+  test_worker_runtime
+  test_capability_registry
+  test_tool_local_runtime_verify
+  test_tool_local_runtime_probe
+  test_board_ttl
+  test_worker_dev_tools
+  test_keeper_path_check_error
+  test_shadow_parse
+  test_destructive_class
+  test_gate_diff
+  test_path_rewrite_validation
+  test_board_content_dedup
+  test_legendary_counters
+  test_legendary_bash_bg_tasks_route
+  test_oas_integration
+  test_memory_oas_5tier
+  test_verifier_oas_bridge
+  test_oas_adapters
+  test_cache_eio
+  test_metrics_store_eio
+  test_planning_eio
+  test_thompson_sampling
+  test_safe_ops
+  test_json_util
+  test_process_eio_coverage
+  test_with_process_coverage
+  test_bg_task_stub
+  test_process_eio_detached
+  test_voice_runtime_overlay
+  test_worker_container_coverage
+  test_resilience
+  test_common
+  test_room_messages_raw
+  ; test_cp_cleanup, test_cp_search_fabric, test_cp_section_cache, test_cp_jsonl_tail removed (CP purge)
+  test_local_runtime_pool
+  test_keeper_tools_oas
+  test_keeper_tool_exposure
+  test_keeper_runtime_denylist
+  test_keeper_runtime_config_ssot
+  test_dashboard_render_timing_9766
+  test_dashboard_keeper_cost_aggregates
+  test_gh_command_blocked_message_10561
+  test_keeper_turn_timeout_default_10456
+  test_task_status_label_10421
+  test_task_completion_path_10449
+  test_task_cache_invariant_13397
+  test_filter_rejection_10474
+  test_sandbox_inspect_trim_10488
+  test_credential_alias_10440
+  test_credential_provider
+  test_cascade_trust
+  test_dashboard_k2_feeds
+  test_keeper_profile_normalize_10552
+  test_personality_field_diff_10269
+  test_toml_skip_dedup_10259
+  test_discovery_history_models_10404
+  test_masc_log_utc_filename_10392
+  test_keeper_task_dispatch
+  test_keeper_tag_dispatch
+  test_autoresearch_knowledge
+  test_mcp_server_eio
+  test_mcp_server_eio_call_tool
+  test_code_navigation_eio
+  test_backend
+  test_room_eio
+  test_http_server_eio
+  test_compression
+  test_fs_compat
+  test_concurrency_stress
+  test_eio_mutex_concurrency
+  test_eio_guard_yield_meter
+  test_board_dispatch
+  test_board_curation
+  test_board_fixture_detector
+  test_vote_ts_preservation_10086
+  test_board_karma_ledger
+  test_task_dispatch
+  test_drift_guard_core
+  test_verify_handoff_tool
+  test_memory_horizon_classifier
+  test_param_type_classifier
+  test_tool_contract_truth
+  test_file_lock_eio
+  test_error_logging_coverage
+  test_agent_identity
+  test_mcp_full_cycle
+  test_agent_registry_eio
+  test_identity_e2e
+  test_identity_edge_cases
+  test_verification
+  test_pulse
+  test_transport_metrics
+  test_adaptive_cache_ttl
+  test_keeper_compact_audit
+  test_keeper_telemetry_consumer
+  test_oas_bus_instrument
+  test_trajectory
+  test_eval_gate
+  test_eval_harness
+  test_tool_board_coverage
+  test_anti_rationalization_fail_mode
+  test_board_truncation_detection
+  test_tool_registration_consistency
+  ; test_tree_index removed (CP purge)
+  test_tool_registry
+  test_tool_dispatch
+  test_tool_spec
+  test_typed_tool_masc
+  test_state_product
+  test_coordination_product
+  test_tool_result
+  test_tool_hooks
+  test_governance_pipeline
+  test_keeper_routine_allowlist
+  test_keeper_agent_isolation
+  test_sse_external_sub
+  test_ws_transport
+  test_webrtc_signaling
+  test_transport_integration
+  test_tool_metrics
+  test_tool_metrics_persist
+  test_model_inference_metrics
+  test_tool_unified
+  test_keeper_tool_call_log
+  test_build_identity
+  test_workflow_guide
+  test_agent_economy
+  test_lifecycle
+  test_auto_recall_activity_coverage
+  test_grpc_coordination
+  test_grpc_client
+  test_http_protocol_detect
+  test_keeper_safety_gates
+  test_keeper_guards
+  test_eval_gate_evasion
+  test_prompt_registry_defaults
+  test_keeper_prompt_external
+  test_keeper_recurring
+  test_cdal_types
+  test_cdal_loader
+  test_cdal_proof
+  test_cdal_risk_contract
+  test_cdal_judge
+  test_cdal_verifiable_markers
+  test_cdal_eval_v1
+  test_keeper_cdal_contract
+  test_cdal_friction_projection
+  test_cdal_verdict_gate
+  test_cdal_mode_enforcer
+  test_cdal_mode_resolver
+  test_verification_fsm
+  test_task_sandbox
+  test_governance_yojson_roundtrip
+  test_eval_calibration
+  test_goal_janitor
+  test_goal_tools
+  test_goal_upsert_fsm_bypass_10247
+  test_goal_store
+  test_goal_verification
+  test_string_util
+  test_set_util
+  test_board_core_payload
+  test_board_attachment_meta
+  test_board_moderation
+  test_voice_config)
  (libraries masc_test_deps)
  (deps ../bin/main_eio.exe))
 
 ; Focused dashboard nudge feed projection.
+
 (test
  (name test_dashboard_operator_nudges)
  (modules test_dashboard_operator_nudges)
  (libraries masc_test_deps))
 
 ; Group 4: Coverage tests (generated by Agent Autonomy)
+
 (tests
- (names test_admission_queue_coverage
-        test_backend_coverage test_tools_coverage test_types_utils_coverage
-        test_tempo_coverage test_transport_coverage test_validation_coverage
-        test_dashboard_resilience_coverage
-        test_nickname_coverage test_level2_config_coverage
-        test_config_coverage
-        test_progress_coverage
-        test_mcp_protocol_coverage test_notify_coverage
-        test_mcp_session_coverage test_sse_coverage
-        test_credits_dashboard_coverage test_room_utils_coverage
-        test_orchestrator_coverage
-        test_web_dashboard_coverage test_auth_coverage
-        test_mention_coverage test_resilience_coverage
-        test_types_coverage test_spawn_coverage test_dashboard_coverage
-        test_rate_limit_coverage test_bounded_coverage test_session_coverage
-        test_cache_eio_coverage test_run_eio_coverage
-        test_handover_eio_coverage test_mcp_server_eio_coverage
-        test_http_server_eio_coverage test_telemetry_eio_coverage
-        test_room_git_coverage test_prometheus_coverage
-        test_auto_responder_coverage test_tool_plan_coverage
-        test_tool_worktree_coverage
-        test_tool_agent_coverage
-        test_tool_task_coverage test_tool_coord_coverage
-        test_tool_control_coverage test_tool_misc_coverage
-        test_ag_ui_coverage
-        test_tool_suspend_coverage test_tool_code_coverage
-        test_tool_code_write_coverage
-        test_tool_code_read_containment
-        test_tool_library_coverage test_tool_shard_coverage
-        test_context_compact_oas_coverage test_keeper_masc_bridge
-        test_anti_rationalization_coverage test_field_validation
-        test_tool_args_envelope
-        test_circuit_breaker)
- (modules test_admission_queue_coverage
-        test_backend_coverage test_tools_coverage test_types_utils_coverage
-        test_tempo_coverage test_transport_coverage test_validation_coverage
-        test_dashboard_resilience_coverage
-        test_nickname_coverage test_level2_config_coverage
-        test_config_coverage
-        test_progress_coverage
-        test_mcp_protocol_coverage test_notify_coverage
-        test_mcp_session_coverage test_sse_coverage
-        test_credits_dashboard_coverage test_room_utils_coverage
-        test_orchestrator_coverage
-        test_web_dashboard_coverage test_auth_coverage
-        test_mention_coverage test_resilience_coverage
-        test_types_coverage test_spawn_coverage test_dashboard_coverage
-        test_rate_limit_coverage test_bounded_coverage test_session_coverage
-        test_cache_eio_coverage test_run_eio_coverage
-        test_handover_eio_coverage test_mcp_server_eio_coverage
-        test_http_server_eio_coverage test_telemetry_eio_coverage
-        test_room_git_coverage test_prometheus_coverage
-        test_auto_responder_coverage test_tool_plan_coverage
-        test_tool_worktree_coverage
-        test_tool_agent_coverage
-        test_tool_task_coverage test_tool_coord_coverage
-        test_tool_control_coverage test_tool_misc_coverage
-        test_ag_ui_coverage
-        test_tool_suspend_coverage test_tool_code_coverage
-        test_tool_code_write_coverage
-        test_tool_code_read_containment
-        test_tool_library_coverage test_tool_shard_coverage
-        test_context_compact_oas_coverage test_keeper_masc_bridge
-        test_anti_rationalization_coverage test_field_validation
-        test_tool_args_envelope
-        test_circuit_breaker)
+ (names
+  test_admission_queue_coverage
+  test_backend_coverage
+  test_tools_coverage
+  test_types_utils_coverage
+  test_tempo_coverage
+  test_transport_coverage
+  test_validation_coverage
+  test_dashboard_resilience_coverage
+  test_nickname_coverage
+  test_level2_config_coverage
+  test_config_coverage
+  test_progress_coverage
+  test_mcp_protocol_coverage
+  test_notify_coverage
+  test_mcp_session_coverage
+  test_sse_coverage
+  test_credits_dashboard_coverage
+  test_room_utils_coverage
+  test_orchestrator_coverage
+  test_web_dashboard_coverage
+  test_auth_coverage
+  test_mention_coverage
+  test_resilience_coverage
+  test_types_coverage
+  test_spawn_coverage
+  test_dashboard_coverage
+  test_rate_limit_coverage
+  test_bounded_coverage
+  test_session_coverage
+  test_cache_eio_coverage
+  test_run_eio_coverage
+  test_handover_eio_coverage
+  test_mcp_server_eio_coverage
+  test_http_server_eio_coverage
+  test_telemetry_eio_coverage
+  test_room_git_coverage
+  test_prometheus_coverage
+  test_auto_responder_coverage
+  test_tool_plan_coverage
+  test_tool_worktree_coverage
+  test_tool_agent_coverage
+  test_tool_task_coverage
+  test_tool_coord_coverage
+  test_tool_control_coverage
+  test_tool_misc_coverage
+  test_ag_ui_coverage
+  test_tool_suspend_coverage
+  test_tool_code_coverage
+  test_tool_code_write_coverage
+  test_tool_code_read_containment
+  test_tool_library_coverage
+  test_tool_shard_coverage
+  test_context_compact_oas_coverage
+  test_keeper_masc_bridge
+  test_anti_rationalization_coverage
+  test_field_validation
+  test_tool_args_envelope
+  test_circuit_breaker)
+ (modules
+  test_admission_queue_coverage
+  test_backend_coverage
+  test_tools_coverage
+  test_types_utils_coverage
+  test_tempo_coverage
+  test_transport_coverage
+  test_validation_coverage
+  test_dashboard_resilience_coverage
+  test_nickname_coverage
+  test_level2_config_coverage
+  test_config_coverage
+  test_progress_coverage
+  test_mcp_protocol_coverage
+  test_notify_coverage
+  test_mcp_session_coverage
+  test_sse_coverage
+  test_credits_dashboard_coverage
+  test_room_utils_coverage
+  test_orchestrator_coverage
+  test_web_dashboard_coverage
+  test_auth_coverage
+  test_mention_coverage
+  test_resilience_coverage
+  test_types_coverage
+  test_spawn_coverage
+  test_dashboard_coverage
+  test_rate_limit_coverage
+  test_bounded_coverage
+  test_session_coverage
+  test_cache_eio_coverage
+  test_run_eio_coverage
+  test_handover_eio_coverage
+  test_mcp_server_eio_coverage
+  test_http_server_eio_coverage
+  test_telemetry_eio_coverage
+  test_room_git_coverage
+  test_prometheus_coverage
+  test_auto_responder_coverage
+  test_tool_plan_coverage
+  test_tool_worktree_coverage
+  test_tool_agent_coverage
+  test_tool_task_coverage
+  test_tool_coord_coverage
+  test_tool_control_coverage
+  test_tool_misc_coverage
+  test_ag_ui_coverage
+  test_tool_suspend_coverage
+  test_tool_code_coverage
+  test_tool_code_write_coverage
+  test_tool_code_read_containment
+  test_tool_library_coverage
+  test_tool_shard_coverage
+  test_context_compact_oas_coverage
+  test_keeper_masc_bridge
+  test_anti_rationalization_coverage
+  test_field_validation
+  test_tool_args_envelope
+  test_circuit_breaker)
  (libraries masc_test_deps))
 
 ; Special: Multi-module test suites
@@ -1097,6 +1229,7 @@
 ; test_failover_leader removed (CP purge)
 
 ; Keeper Tool Matrix — shared case modules as a library
+
 (library
  (name keeper_tool_matrix_cases_lib)
  (wrapped false)
@@ -1112,7 +1245,6 @@
 ; Special: Minimal dependency tests (CI scripts, governance)
 ; Special: Heartbeat/keeper minimal deps
 
-
 ; Executables (benchmarks, distributed tests, tools)
 
 ; test_cp_search_fabric_benchmark removed (CP purge)
@@ -1126,7 +1258,6 @@
  (name tool_call_quality_benchmark_cli)
  (modules tool_call_quality_benchmark_cli)
  (libraries masc_test_deps))
-
 
 (executable
  (name test_a12_e2e_demo)
@@ -1178,213 +1309,423 @@
 ; To add a new test: create test/stanzas/test_name.inc and
 ; add one (include stanzas/test_name.inc) line below,
 ; sorted alphabetically.
+
 (include stanzas/test_anti_rationalization_empty_liveness.inc)
+
 (include stanzas/test_anti_rationalization_gate2_advisory_10113.inc)
+
 (include stanzas/test_anti_rationalization_korean_10385.inc)
+
 (include stanzas/test_auth_bearer_mismatch_9786.inc)
+
 (include stanzas/test_auth_rotate_shared_tokens_10304.inc)
+
 (include stanzas/test_auth_token_uniqueness_audit.inc)
+
 (include stanzas/test_base_path_prod_guard.inc)
+
 (include stanzas/test_board_api_e2e.inc)
+
 (include stanzas/test_board_sse_canonical_event_type.inc)
+
 (include stanzas/test_briefing_compactors.inc)
+
 (include stanzas/test_briefing_gaps.inc)
+
 (include stanzas/test_briefing_json_helpers.inc)
+
 (include stanzas/test_briefing_sections.inc)
+
 (include stanzas/test_cascade_attempt_liveness.inc)
+
 (include stanzas/test_cascade_attempt_liveness_config.inc)
+
 (include stanzas/test_cascade_attempt_liveness_counters.inc)
+
 (include stanzas/test_cascade_attempt_liveness_observer.inc)
+
 (include stanzas/test_cascade_attempt_liveness_runtime.inc)
+
 (include stanzas/test_cascade_attempt_outer_wall.inc)
+
 (include stanzas/test_cascade_attempt_fsm_response_pins.inc)
+
 (include stanzas/test_cascade_catalog_runtime_yojson.inc)
+
 (include stanzas/test_oas_worker_named_liveness_integration.inc)
+
 (include stanzas/test_cascade_capability_gate.inc)
+
 (include stanzas/test_cascade_inference_clamp.inc)
+
 (include stanzas/test_cascade_fsm.inc)
+
 (include stanzas/test_cascade_health_tracker.inc)
+
 (include stanzas/test_cascade_per_candidate_telemetry.inc)
+
 (include stanzas/test_cascade_kimi_max_context_ssot.inc)
+
 (include stanzas/test_cascade_model_resolve.inc)
+
 (include stanzas/test_cascade_capacity_probe.inc)
+
 (include stanzas/test_cascade_diagnostic_probe.inc)
+
 (include stanzas/test_cascade_http_probe.inc)
+
 (include stanzas/test_cascade_runtime.inc)
+
 (include stanzas/test_cascade_strategy.inc)
+
 (include stanzas/test_cascade_trust_persist.inc)
+
 (include stanzas/test_audit_keeper_fleet_readiness.inc)
+
 (include stanzas/test_keeper_production_readiness_gate.inc)
+
 (include stanzas/test_cdal_ledger_health_10115.inc)
+
 (include stanzas/test_cdal_runtime_health_15748.inc)
+
 (include stanzas/test_channel_gate.inc)
+
 (include stanzas/test_channel_gate_discord_state.inc)
+
 (include stanzas/test_channel_gate_metrics.inc)
+
 (include stanzas/test_ci_hardening_source.inc)
+
 (include stanzas/test_ci_run_tests_script.inc)
+
 (include stanzas/test_codex_cli_omission_dedup_10097.inc)
+
 (include stanzas/test_context_max_observed_9953.inc)
+
 (include stanzas/test_continuity_forward_filter.inc)
+
 (include stanzas/test_coord_bootstrap.inc)
+
 (include stanzas/test_credential_materializer_waitpid_eintr.inc)
+
 (include stanzas/test_dashboard_feature_health.inc)
+
 (include stanzas/test_dashboard_goals.inc)
+
 (include stanzas/test_dashboard_governance_metrics.inc)
+
 (include stanzas/test_dashboard_keeper_metrics_10286.inc)
+
 (include stanzas/test_dashboard_keeper_routes.inc)
+
 (include stanzas/test_dashboard_tla_specs.inc)
+
 (include stanzas/test_dated_jsonl.inc)
+
 (include stanzas/test_dated_jsonl_mutex_registry_10372.inc)
+
 (include stanzas/test_distributed_lock_acquire_failed_counter.inc)
+
 (include stanzas/test_distributed_lock_backlog_namespace.inc)
+
 (include stanzas/test_distributed_lock_backoff_jitter_9645.inc)
+
 (include stanzas/test_dune_local_script.inc)
+
 (include stanzas/test_env_config_coord_git_local_timeout.inc)
+
 (include stanzas/test_env_config_dashboard_compute_timeouts.inc)
+
 (include stanzas/test_env_config_dashboard_execution_timeouts.inc)
+
 (include stanzas/test_env_config_dashboard_shell_prewarm.inc)
+
 (include stanzas/test_env_config_exec_timeout_10426.inc)
+
 (include stanzas/test_env_config_get_ratio.inc)
+
 (include stanzas/test_env_config_keeper_bootstrap_intervals.inc)
+
 (include stanzas/test_env_config_keeper_poll_intervals.inc)
+
 (include stanzas/test_env_config_nonneg.inc)
+
 (include stanzas/test_env_config_sandbox.inc)
+
 (include stanzas/test_env_config_sidecar_timeouts.inc)
+
 (include stanzas/test_env_config_voice_bridge_timeouts.inc)
+
 (include stanzas/test_event_kind.inc)
+
 (include stanzas/test_feature_flag_registry.inc)
+
 (include stanzas/test_fs_atomic_orphan_sweep_10130.inc)
+
 (include stanzas/test_fs_compat_append_jsonl_atomicity.inc)
+
 (include stanzas/test_fs_compat_home_guard.inc)
+
 (include stanzas/test_fsm_drift_per_agent_counter.inc)
+
 (include stanzas/test_gate_protocol.inc)
+
 (include stanzas/test_git_fetch_retry_script.inc)
+
 (include stanzas/test_goal_phase_awaiting_verification_10411.inc)
+
 (include stanzas/test_governance_cases_snapshot.inc)
+
 (include stanzas/test_governance_response_model_empty_9880.inc)
+
 (include stanzas/test_heartbeat_integration.inc)
+
 (include stanzas/test_http_pages_asset_read.inc)
+
 (include stanzas/test_heuristic_metrics_diagnostics.inc)
+
 (include stanzas/test_heuristic_metrics_scrub.inc)
+
+(include stanzas/test_bounded_proc.inc)
+
 (include stanzas/test_join_required_guard_counter.inc)
+
 (include stanzas/test_jsonl_atomic.inc)
+
 (include stanzas/test_k2_pipeline_e2e.inc)
+
 (include stanzas/test_k3_tool_pipeline_e2e.inc)
+
 (include stanzas/test_keeper_alerting_path_norms.inc)
+
 (include stanzas/test_keeper_auto_pause_blocker_persist_12683.inc)
+
 (include stanzas/test_keeper_blocker_class_completion_contract.inc)
+
 (include stanzas/test_keeper_agent_run_sandbox_source.inc)
+
 (include stanzas/test_keeper_autoboot_supervisor_start_10125.inc)
+
 (include stanzas/test_keeper_cascade_auto_pause_task074.inc)
+
 (include stanzas/test_keeper_cascade_routing.inc)
+
 (include stanzas/test_keeper_checkpoint_classify.inc)
+
 (include stanzas/test_keeper_compaction_noop_counter_9943.inc)
+
 (include stanzas/test_keeper_context_bounds_ssot.inc)
+
 (include stanzas/test_keeper_context_isolation.inc)
+
 (include stanzas/test_keeper_cwd_response.inc)
+
 (include stanzas/test_keeper_error_classify_recoverable.inc)
+
 (include stanzas/test_keeper_exec_shell_cwd_response.inc)
+
 (include stanzas/test_keeper_exec_tools.inc)
+
 (include stanzas/test_keeper_fs.inc)
+
 (include stanzas/test_keeper_fs_write_containment.inc)
+
 (include stanzas/test_keeper_gh_timeout_floor.inc)
+
 (include stanzas/test_keeper_identity_drift_counter.inc)
+
 (include stanzas/test_keeper_invariant.inc)
+
 (include stanzas/test_keeper_long_turn_9943.inc)
+
 (include stanzas/test_keeper_memory_bank_consensus_re_10399.inc)
+
 (include stanzas/test_keeper_meta_canonical_seed.inc)
+
 (include stanzas/test_keeper_meta_unknown_keys_warn.inc)
+
 (include stanzas/test_keeper_semaphore_wait_queue_head_clock.inc)
+
 (include stanzas/test_keeper_meta_heartbeat_retain_9733.inc)
+
 (include stanzas/test_keeper_meta_merge.inc)
+
 (include stanzas/test_keeper_mutex_coverage.inc)
+
 (include stanzas/test_keeper_ocaml_tla_correspondence.inc)
+
 (include stanzas/test_keeper_path_roots_leak_10349.inc)
+
 (include stanzas/test_keeper_passive_loop_detector.inc)
+
 (include stanzas/test_keeper_pause_silent_failure_source.inc)
+
 (include stanzas/test_keeper_paused_cas_retain_9733.inc)
+
 (include stanzas/test_keeper_personality_round_trip.inc)
+
 (include stanzas/test_keeper_post_turn_wirein_order.inc)
+
 (include stanzas/test_keeper_readonly_hints.inc)
+
 (include stanzas/test_keeper_receipt_authoritative.inc)
+
 (include stanzas/test_keeper_receipt_authoritative_matrix.inc)
+
 (include stanzas/test_keeper_receipt_outcome_tla_parity.inc)
+
 (include stanzas/test_keeper_semaphore_fairness.inc)
+
 (include stanzas/test_keeper_semaphore_wait_counter.inc)
+
 (include stanzas/test_keeper_shell_docker_cwd_response.inc)
+
 (include stanzas/test_keeper_state_snapshot_json.inc)
+
 (include stanzas/test_keeper_summarizer.inc)
+
 (include stanzas/test_keeper_supervisor_observability_10125.inc)
+
 (include stanzas/test_keeper_supervisor_write_meta_source.inc)
+
 (include stanzas/test_keeper_supervisor_finally_cancel_swallow.inc)
+
 (include stanzas/test_failing_minimum_essential.inc)
+
 (include stanzas/test_keeper_memory_write.inc)
+
 (include stanzas/test_keeper_tool_emission_hook.inc)
+
 (include stanzas/test_keeper_tool_matrix.inc)
+
 (include stanzas/test_keeper_tool_policy_paths.inc)
+
 (include stanzas/test_keeper_turn_fsm_tla_parity.inc)
+
 (include stanzas/test_keeper_unified_tool_event_order_source.inc)
+
 (include stanzas/test_keeper_turn_livelock_10121.inc)
+
 (include stanzas/test_keeper_turn_helpers_side_effect_metric.inc)
+
 (include stanzas/test_keeper_turn_slot_force_release.inc)
+
 (include stanzas/test_keeper_turn_slot_holders.inc)
+
 (include stanzas/test_keeper_turn_slot_release_cancel_safe.inc)
+
 (include stanzas/test_keeper_turn_up_create_meta_retry.inc)
+
 (include stanzas/test_local_review_script.inc)
+
 (include stanzas/test_magentic_ledger_cap.inc)
+
 (include stanzas/test_masc_dirname_ssot.inc)
+
 (include stanzas/test_masc_error_is_retryable.inc)
+
 (include stanzas/test_mcp_post_sse_e2e.inc)
+
 (include stanzas/test_mcp_tool_matrix.inc)
+
 (include stanzas/test_meta_cognition_snapshot.inc)
+
 (include stanzas/test_normalized_actor.inc)
+
 (include stanzas/test_oas_bridge_judge_callers_9629.inc)
+
 (include stanzas/test_oas_bridge_timeout_ssot_10094.inc)
+
 (include stanzas/test_oas_checkpoint_cancelled_never_absorbed.inc)
+
 (include stanzas/test_oas_timeout_budget_strike.inc)
+
 (include stanzas/test_oas_worker.inc)
+
 (include stanzas/test_oas_worker_exec_close_cancel_source.inc)
+
 (include stanzas/test_oas_worker_exec_cancel_cleanup.inc)
+
 (include stanzas/test_oas_worker_exec_checkpoint.inc)
+
 (include stanzas/test_openapi_api_e2e.inc)
+
 (include stanzas/test_masc_oas_bridge_cancel_boundary.inc)
+
 (include stanzas/test_operator_control.inc)
+
 (include stanzas/test_operator_mcp_e2e.inc)
+
 (include stanzas/test_otel_genai.inc)
+
 (include stanzas/test_otel_trace_context.inc)
+
 (include stanzas/test_personality_diff_summary_10269.inc)
+
 (include stanzas/test_personality_text_equal.inc)
+
 (include stanzas/test_phase2_self_preservation.inc)
+
 (include stanzas/test_pr_open_script.inc)
+
 (include stanzas/test_process_eio_default_timeout.inc)
+
 (include stanzas/test_provider_kind_resolution.inc)
+
 (include stanzas/test_release_train_guard_script.inc)
+
 (include stanzas/test_reqd_invalid_state_swallow.inc)
+
 (include stanzas/test_require_tool_use_violation_counter_10091.inc)
+
 (include stanzas/test_sandbox_clone_conflict.inc)
+
 (include stanzas/test_server_state_product.inc)
+
 (include stanzas/test_smart_heartbeat_keepalive.inc)
+
 (include stanzas/test_snapshot_size_cap.inc)
+
 (include stanzas/test_social_state_cap.inc)
+
 (include stanzas/test_social_state_cap_on_load.inc)
+
 (include stanzas/test_sse_storm_e2e.inc)
+
 (include stanzas/test_start_masc_mcp_script.inc)
+
 (include stanzas/test_supervisor_start_predicate.inc)
+
 (include stanzas/test_system_log_atomicity.inc)
+
 (include stanzas/test_telemetry_task_transition_10358.inc)
+
 (include stanzas/test_timeout_policy.inc)
+
 (include stanzas/test_timeout_policy_overshoot_counter.inc)
+
 (include stanzas/test_tla_literal_parity.inc)
+
 (include stanzas/test_tool_call_replay_harness.inc)
+
 (include stanzas/test_tool_diversity.inc)
+
 (include stanzas/test_tool_help_registry_shard_coverage_10101.inc)
+
 (include stanzas/test_tool_inline_dispatch.inc)
+
 (include stanzas/test_tool_name.inc)
+
 (include stanzas/test_tool_task_completion_example.inc)
+
 (include stanzas/test_trajectory_atomicity.inc)
+
 (include stanzas/test_transport_bridge_seal.inc)
+
 (include stanzas/test_work_as_heartbeat.inc)
+
 (include stanzas/test_worker_safety_gates.inc)
+
 (include stanzas/test_ws_standalone_close_payload.inc)
 
 (test
@@ -1423,6 +1764,7 @@
 ; drift in description text, enum ordering, or additionalProperties
 ; surfaces immediately. Single-stanza form (not Group 1) so dune
 ; picks up the new (test ...) without churning the 700+ name list.
+
 (test
  (name test_tool_descriptors_gen)
  (modules test_tool_descriptors_gen)
@@ -1439,6 +1781,7 @@
 ; update each pinned constant alongside the code fix in the same PR so that
 ; drift between code state and pinned evidence is caught by single-PR diff.
 ; Constants-only (no Masc_mcp lib dependency) — keeps tests fast and isolated.
+
 (test
  (name test_dispatch_telemetry_gap)
  (modules test_dispatch_telemetry_gap)
@@ -1458,6 +1801,7 @@
 ; Masc_keeper.t variants through to_string/of_string and pins the variant
 ; count so future additions surface in the diff. Requires masc_test_deps
 ; because it accesses Masc_mcp.Tool_name.* values directly.
+
 (test
  (name test_tool_name_exhaustive)
  (modules test_tool_name_exhaustive)
@@ -1468,6 +1812,7 @@
 ; invocation count, trace_id thunk callable, outcome label propagation,
 ; idempotent register_metrics, result passthrough). Requires masc_test_deps
 ; because it exercises Masc_mcp.Tool_telemetry.* directly.
+
 (test
  (name test_guarded_dispatch_telemetry)
  (modules test_guarded_dispatch_telemetry)
@@ -1476,6 +1821,7 @@
 ; RFC-0084 PR-4 — Tool_capability typed sum + Set tests. Verifies typed
 ; round-trip, all_kinds cardinality, check ~required ~granted semantics,
 ; and the bridge to legacy Tool_dispatch.is_* queries.
+
 (test
  (name test_tool_capability_typed)
  (modules test_tool_capability_typed)
@@ -1485,6 +1831,7 @@
 ; (no lib dependency): pins the outcome label vocabulary and wrap site
 ; count for mcp_server_eio_execute.ml:1065 + :1083 wraps. Real wrap
 ; behaviour is unit-tested in test_guarded_dispatch_telemetry (PR-3).
+
 (test
  (name test_mcp_telemetry)
  (modules test_mcp_telemetry)
@@ -1495,6 +1842,7 @@
 ; 100% per RFC-0084 §2.1 North Star. Constants-only: pins outcome vocab
 ; parity with PR-7 + PR-8, cumulative wrap site count (5), and the
 ; entries-covered = 3 invariant.
+
 (test
  (name test_tag_dispatch_typed)
  (modules test_tag_dispatch_typed)
@@ -1505,6 +1853,7 @@
 ; classify_result_option semantics, and string-vocab parity with
 ; PR-7/8/9 ("handled" / "no_handler"). Requires masc_test_deps because
 ; it accesses Masc_mcp.Dispatch_outcome.* directly.
+
 (test
  (name test_dispatch_outcome_total)
  (modules test_dispatch_outcome_total)
@@ -1515,6 +1864,7 @@
 ; entries (Tool_dispatch.dispatch and Tool_dispatch.dispatch_structured).
 ; PR-14 CI lint script converts these pins into a build-time check
 ; (ci/lint-no-direct-dispatch.sh).
+
 (test
  (name test_dispatch_legacy_removed)
  (modules test_dispatch_legacy_removed)
@@ -1525,6 +1875,7 @@
 ; is_test_mode typed semantics (Test/Production), resolve ~base_path
 ; relative roots, and hardcode site inventory count (11). Requires
 ; masc_test_deps because it accesses Host_config.* directly.
+
 (test
  (name test_host_config_resolution)
  (modules test_host_config_resolution)
@@ -1537,6 +1888,7 @@
 ; (Hybrid.full_names sorted per RFC-OAS-013 §2.4). Requires
 ; masc_test_deps because it accesses Masc_mcp.Keeper_disclosure_strategy.*
 ; directly.
+
 (test
  (name test_disclosure_strategy_config)
  (modules test_disclosure_strategy_config)
@@ -1549,6 +1901,7 @@
 ; sprint exit-criteria count (10), and workaround-rejection signatures
 ; (0 violations). Requires masc_test_deps because it asserts cardinality
 ; of Masc_mcp.Tool_capability.all_kinds + Dispatch_outcome.all_arms.
+
 (test
  (name test_telemetry_completeness)
  (modules test_telemetry_completeness)
@@ -1560,6 +1913,7 @@
 ; is invoked there. Cross-checks sandbox_workspace_root contract from
 ; PR-12. Requires masc_test_deps because it accesses
 ; Masc_mcp.Host_config.host.
+
 (test
  (name test_pr_e_sandbox_root_migration)
  (modules test_pr_e_sandbox_root_migration)
@@ -1571,6 +1925,7 @@
 ; (no executable_name param), and verifies Host_config.is_test_mode
 ; is called from the migrated site. Cross-checks is_test_mode round-trip.
 ; Requires masc_test_deps for Masc_mcp.Host_config.is_test_mode.
+
 (test
  (name test_pr_f_test_mode_migration)
  (modules test_pr_f_test_mode_migration)
@@ -1582,6 +1937,7 @@
 ; resolver only for Hybrid demote_on_error=true).  Compile-time check
 ; that Worker_oas.build_agent accepts ?disclosure_strategy.  Requires
 ; masc_test_deps for Masc_mcp.Keeper_disclosure_strategy.*.
+
 (test
  (name test_pr_g_disclosure_activation)
  (modules test_pr_g_disclosure_activation)
@@ -1591,6 +1947,7 @@
 ; Pins 0 occurrences of MASC_DISPATCH_V2 / v2_enabled / dispatch_v2_enabled
 ; across config/env/dispatch/unified surfaces.  Pure regression guard;
 ; no Masc_mcp dependency needed.
+
 (test
  (name test_pr_j_legacy_dispatch_v2_removed)
  (modules test_pr_j_legacy_dispatch_v2_removed)
@@ -1601,6 +1958,7 @@
 ; lib/keeper/host_config_provider.ml and verifies
 ; Host_config.host is invoked.  Cross-checks that
 ; Keeper_host_config_provider.cred_root equals the typed surface field.
+
 (test
  (name test_pr_a_cred_root_migration)
  (modules test_pr_a_cred_root_migration)
@@ -1611,6 +1969,7 @@
 ; lib/keeper/keeper_shell_ops.ml and exactly 1
 ; Host_config.host invocation (single binding at
 ; module-init time, not per call-site).
+
 (test
  (name test_pr_c_coreutils_migration)
  (modules test_pr_c_coreutils_migration)
@@ -1620,6 +1979,7 @@
 ; Pins 0 occurrences of /bin/bash and /bin/zsh literals across
 ; the 4 keeper consumer modules (1 bash + 3 zsh) and verifies one
 ; Host_config.host binding per consumer module.
+
 (test
  (name test_pr_b_shell_paths_migration)
  (modules test_pr_b_shell_paths_migration)
@@ -1629,6 +1989,7 @@
 ; strategy field + Worker_oas internal wirings.  Pins the type
 ; declaration shape and the 2 internal build_agent call-sites that
 ; thread ?disclosure_strategy:meta.disclosure_strategy.
+
 (test
  (name test_pr_h_disclosure_meta_wiring)
  (modules test_pr_h_disclosure_meta_wiring)
@@ -1638,6 +1999,7 @@
 ; Pins 0 occurrences of /tmp/.masc_agent[_mcp]_<sid> literals
 ; across mcp_server_eio_execute.ml + tool_inline_dispatch_coord.ml
 ; and exactly 1 Host_config.host binding per module.
+
 (test
  (name test_pr_d_agent_runtime_migration)
  (modules test_pr_d_agent_runtime_migration)
@@ -1648,6 +2010,7 @@
 ; [typed_post_hooks] / [run_typed_post_hooks] entries on
 ; Tool_dispatch, and verifies guarded_dispatch calls
 ; run_typed_post_hooks for every outcome arm.
+
 (test
  (name test_pr_i_1_typed_post_hook_surface)
  (modules test_pr_i_1_typed_post_hook_surface)
@@ -1656,6 +2019,7 @@
 ; RFC-0084 PR-I-2.a — Tool_metrics typed post-hook migration.
 ; Pins 0 legacy register_post_hook + exactly 1 typed register, and
 ; the (Handled, Some _) guard that preserves behaviour-equivalence.
+
 (test
  (name test_pr_i_2a_tool_metrics_typed)
  (modules test_pr_i_2a_tool_metrics_typed)
@@ -1663,12 +2027,14 @@
 
 ; RFC-0084 PR-I-2.b — Tool_usage_log typed post-hook migration.
 ; Same pins as PR-I-2.a but for lib/tool_usage_log.ml.
+
 (test
  (name test_pr_i_2b_tool_usage_log_typed)
  (modules test_pr_i_2b_tool_usage_log_typed)
  (libraries alcotest))
 
 ; RFC-0084 PR-I-2.c — otel_dispatch_hook typed post-hook migration.
+
 (test
  (name test_pr_i_2c_otel_hook_typed)
  (modules test_pr_i_2c_otel_hook_typed)
@@ -1677,6 +2043,7 @@
 ; RFC-0084 PR-I-2.d — Tool_output_validation transformer migration.
 ; Pins the move from register_post_hook (observer+mutator) to the
 ; dedicated set_result_transformer surface.
+
 (test
  (name test_pr_i_2d_output_validation_transformer)
  (modules test_pr_i_2d_output_validation_transformer)
@@ -1686,6 +2053,7 @@
 ; migration.  Last of 5 observer migrations.  Also pins the sum
 ; across all 5 known register_post_hook sites at 0 to lock in
 ; PR-I-3 readiness.
+
 (test
  (name test_pr_i_2e_bootstrap_loops_typed)
  (modules test_pr_i_2e_bootstrap_loops_typed)
@@ -1696,6 +2064,7 @@
 ; all of lib/, 0 declarations of legacy entries in the mli, and
 ; presence of the typed surface entries (register_typed_post_hook,
 ; run_typed_post_hooks, set_result_transformer).
+
 (test
  (name test_pr_i_3_legacy_post_hook_removed)
  (modules test_pr_i_3_legacy_post_hook_removed)
@@ -1705,12 +2074,14 @@
 ; log_dir/run_dir/policy_dir fields added, [@@deriving show, eq]
 ; applied to Host_config.t and Dispatch_outcome.t.  Uses AST-based
 ; ast_grep helper (compiler-libs.common) for structural verification.
+
 (test
  (name test_rfc_0085_pr1_host_config_legacy_purge)
  (modules test_rfc_0085_pr1_host_config_legacy_purge)
  (libraries alcotest ast_grep masc_mcp.host_config masc_mcp))
 
 ; RFC-0085 PR-2 — auto_responder log path absorbed into Host_config.log_dir.
+
 (test
  (name test_rfc_0085_pr2_auto_responder_log_dir)
  (modules test_rfc_0085_pr2_auto_responder_log_dir)
@@ -1718,6 +2089,7 @@
 
 ; RFC-0085 PR-3 — server runtime PID lock absorbed into Host_config.run_dir,
 ; and server bootstrap kept free of provider-specific OAS policy wiring.
+
 (test
  (name test_rfc_0085_pr3_server_runtime_paths)
  (modules test_rfc_0085_pr3_server_runtime_paths)
@@ -1725,12 +2097,14 @@
 
 ; RFC-0085 PR-6 — Host_config exposes env-derived path fields
 ; (base_path / config_dir / data_dir / personas_dir) + from_env alias.
+
 (test
  (name test_rfc_0085_pr6_host_config_from_env)
  (modules test_rfc_0085_pr6_host_config_from_env)
  (libraries alcotest masc_mcp.host_config unix))
 
 ; RFC-0085 PR-4 — tool_library + cdal proof_store /tmp fallback purge.
+
 (test
  (name test_rfc_0085_pr4_tool_library_proof_store)
  (modules test_rfc_0085_pr4_tool_library_proof_store)
@@ -1739,6 +2113,7 @@
 ; RFC-0085 PR-8 — config_dir_resolver + tool_code_write env-derived
 ; path reads routed through Host_config.from_env; Env_config_core
 ; config_dir_opt + personas_dir_opt removed.
+
 (test
  (name test_rfc_0085_pr8_config_dir_resolver_host_config)
  (modules test_rfc_0085_pr8_config_dir_resolver_host_config)
@@ -1747,6 +2122,7 @@
 ; RFC-0085 PR-7 — Retroactive AST test for retired_pg_env_keys +
 ; clear_retired_pg_envs deletion (#15468 user-identified legacy;
 ; shipped without a regression test; restored by #15495).
+
 (test
  (name test_rfc_0085_pr7_retired_pg_envs_purge)
  (modules test_rfc_0085_pr7_retired_pg_envs_purge)
@@ -1755,6 +2131,7 @@
 ; RFC-0086 — keeper namespace bulk promotion invariant.
 ; Pins G-A (Phase 2.A wave 1, #15474): every .ml/.mli under
 ; lib/keeper/ carries the keeper_ prefix.
+
 (test
  (name test_rfc_0086_keeper_namespace_invariant)
  (modules test_rfc_0086_keeper_namespace_invariant)
@@ -1763,6 +2140,7 @@
 ; RFC-0085 PR-18 — Retroactive AST test for execution_surfaces +
 ; namespace_truth rename (#15486 shipped without a regression test;
 ; restored by #15495).
+
 (test
  (name test_rfc_0085_pr18_execution_surfaces_rename)
  (modules test_rfc_0085_pr18_execution_surfaces_rename)
@@ -1770,6 +2148,7 @@
 
 ; RFC-0085 PR-17 — Retroactive AST test for 4 dead deletion + 2 rename
 ; (#15485 shipped without a regression test; restored by #15495).
+
 (test
  (name test_rfc_0085_pr17_dead_purge_and_rename)
  (modules test_rfc_0085_pr17_dead_purge_and_rename)
@@ -1777,6 +2156,7 @@
 
 ; RFC-0085 PR-16 — Retroactive AST test for dashboard_http_core rename
 ; (#15484 shipped without a regression test; restored by #15495).
+
 (test
  (name test_rfc_0085_pr16_dashboard_http_core_rename)
  (modules test_rfc_0085_pr16_dashboard_http_core_rename)
@@ -1784,6 +2164,7 @@
 
 ; RFC-0085 PR-15 — Retroactive AST test for tool_schemas_inline rename
 ; (#15483 shipped without a regression test; restored by #15495).
+
 (test
  (name test_rfc_0085_pr15_tool_schemas_inline_rename)
  (modules test_rfc_0085_pr15_tool_schemas_inline_rename)
@@ -1791,6 +2172,7 @@
 
 ; RFC-0085 PR-14 — dispatch / dispatch_structured / guarded_dispatch
 ; 3-step chain inlined; guarded_dispatch is the only dispatch entry.
+
 (test
  (name test_rfc_0085_pr14_dispatch_inline)
  (modules test_rfc_0085_pr14_dispatch_inline)
@@ -1798,6 +2180,7 @@
 
 ; RFC-0085 PR-13 — Underscore-prefix audit: 1 truly-dead deletion +
 ; 8 active rename across 7 modules.
+
 (test
  (name test_rfc_0085_pr13_underscore_rename)
  (modules test_rfc_0085_pr13_underscore_rename)
@@ -1806,12 +2189,14 @@
 ; RFC-0085 PR-12 — Tool_spec list bindings renamed (drop misleading
 ; _ prefix that signalled "unused" in OCaml but was wrong because the
 ; bindings are actively used by List.mem in the Tool_spec.register loop).
+
 (test
  (name test_rfc_0085_pr12_tool_spec_rename)
  (modules test_rfc_0085_pr12_tool_spec_rename)
  (libraries alcotest ast_grep))
 
 ; RFC-0085 PR-11 — Env_config_core deprecation mechanism removed.
+
 (test
  (name test_rfc_0085_pr11_deprecation_purge)
  (modules test_rfc_0085_pr11_deprecation_purge)
@@ -1820,13 +2205,16 @@
 ; RFC-0085 PR-10 — home + assets_dir env readers absorbed into
 ; Host_config.t; Env_config_core.assets_dir_opt fully removed,
 ; home_dir_opt demoted to file-private.
+
 (test
  (name test_rfc_0085_pr10_home_assets_purge)
  (modules test_rfc_0085_pr10_home_assets_purge)
  (libraries alcotest ast_grep masc_mcp.host_config))
+
 ; RFC-0085 PR-9 — Env_config_core.base_path_opt + base_path_raw_opt
 ; public-surface purge; 9 caller migrate to Host_config.from_env;
 ; Host_config.t gains base_path (normalised) + base_path_raw fields.
+
 (test
  (name test_rfc_0085_pr9_base_path_opt_purge)
  (modules test_rfc_0085_pr9_base_path_opt_purge)

--- a/test/stanzas/test_bounded_proc.inc
+++ b/test/stanzas/test_bounded_proc.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_bounded_proc)
+ (modules test_bounded_proc)
+ (libraries bounded_proc alcotest eio eio_main unix))

--- a/test/test_bounded_proc.ml
+++ b/test/test_bounded_proc.ml
@@ -1,0 +1,119 @@
+(** RFC-0109 P0: [Bounded_proc.run_argv_with_timeout] unit tests.
+
+    Four scenarios cover the helper's invariants:
+    1. Process exits cleanly within the timeout.
+    2. Timeout wins the race AND the OS-level process is terminated by
+       Eio's automatic SIGKILL on switch release.
+    3. stdout and stderr are captured separately.
+    4. stdin is delivered to the child. *)
+
+open Alcotest
+
+let with_env f =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let process_mgr = Eio.Stdenv.process_mgr env in
+  let cwd = Eio.Stdenv.cwd env in
+  f ~clock ~process_mgr ~cwd
+
+(* Process-existence probe: returns [true] when at least one running
+   process matches [argv_substring]. Uses [pgrep -f] which scans the
+   full argv line. We tolerate a small delay between SIGKILL delivery
+   and kernel cleanup by sleeping briefly before probing. *)
+let process_exists argv_substring =
+  Unix.sleepf 0.2;
+  let cmd =
+    Printf.sprintf "pgrep -f %s > /dev/null 2>&1"
+      (Filename.quote argv_substring)
+  in
+  match Unix.system cmd with
+  | Unix.WEXITED 0 -> true
+  | _ -> false
+
+let test_done_within_timeout () =
+  with_env @@ fun ~clock ~process_mgr ~cwd ->
+  let outcome =
+    Bounded_proc.run_argv_with_timeout ~clock ~process_mgr ~cwd
+      ~timeout_s:5.0 [ "echo"; "hello" ]
+  in
+  match outcome with
+  | Bounded_proc.Done (Unix.WEXITED 0, out, err) ->
+    check string "stdout captured" "hello\n" out;
+    check string "stderr empty" "" err
+  | Bounded_proc.Done (status, _, _) ->
+    failf "expected WEXITED 0, got %s"
+      (match status with
+       | Unix.WEXITED n -> Printf.sprintf "WEXITED %d" n
+       | Unix.WSIGNALED n -> Printf.sprintf "WSIGNALED %d" n
+       | Unix.WSTOPPED n -> Printf.sprintf "WSTOPPED %d" n)
+  | Bounded_proc.Timeout elapsed ->
+    failf "unexpected timeout after %.3fs" elapsed
+
+(* Sentinel string lets the post-timeout pgrep probe distinguish our
+   subprocess from unrelated [sleep] commands on the host. *)
+let test_timeout_kills_process () =
+  with_env @@ fun ~clock ~process_mgr ~cwd ->
+  let sentinel = "__bounded_proc_rfc0109_sentinel__" in
+  let outcome =
+    Bounded_proc.run_argv_with_timeout ~clock ~process_mgr ~cwd
+      ~timeout_s:0.5
+      [ "sh"; "-c"; Printf.sprintf "sleep 10 # %s" sentinel ]
+  in
+  (match outcome with
+   | Bounded_proc.Timeout elapsed ->
+     check (float 1.0) "timeout fired near requested budget" 0.5 elapsed
+   | Bounded_proc.Done _ ->
+     failf "expected Timeout, got Done");
+  check bool "OS process terminated after switch release" false
+    (process_exists sentinel)
+
+let test_stderr_capture () =
+  with_env @@ fun ~clock ~process_mgr ~cwd ->
+  let outcome =
+    Bounded_proc.run_argv_with_timeout ~clock ~process_mgr ~cwd
+      ~timeout_s:5.0
+      [ "sh"; "-c"; "echo out; echo err >&2" ]
+  in
+  match outcome with
+  | Bounded_proc.Done (Unix.WEXITED 0, out, err) ->
+    check string "stdout" "out\n" out;
+    check string "stderr" "err\n" err
+  | Bounded_proc.Done (status, _, _) ->
+    failf "expected WEXITED 0, got %s"
+      (match status with
+       | Unix.WEXITED n -> Printf.sprintf "WEXITED %d" n
+       | Unix.WSIGNALED n -> Printf.sprintf "WSIGNALED %d" n
+       | Unix.WSTOPPED n -> Printf.sprintf "WSTOPPED %d" n)
+  | Bounded_proc.Timeout elapsed ->
+    failf "unexpected timeout after %.3fs" elapsed
+
+let test_stdin_delivered () =
+  with_env @@ fun ~clock ~process_mgr ~cwd ->
+  let payload = "round-trip via stdin\n" in
+  let outcome =
+    Bounded_proc.run_argv_with_timeout ~clock ~process_mgr ~cwd
+      ~stdin_string:payload ~timeout_s:5.0 [ "cat" ]
+  in
+  match outcome with
+  | Bounded_proc.Done (Unix.WEXITED 0, out, _) ->
+    check string "stdin echoed back on stdout" payload out
+  | Bounded_proc.Done (status, _, _) ->
+    failf "expected WEXITED 0, got %s"
+      (match status with
+       | Unix.WEXITED n -> Printf.sprintf "WEXITED %d" n
+       | Unix.WSIGNALED n -> Printf.sprintf "WSIGNALED %d" n
+       | Unix.WSTOPPED n -> Printf.sprintf "WSTOPPED %d" n)
+  | Bounded_proc.Timeout elapsed ->
+    failf "unexpected timeout after %.3fs" elapsed
+
+let () =
+  run "Bounded_proc"
+    [ ( "run_argv_with_timeout"
+      , [ test_case "done within timeout" `Quick
+            test_done_within_timeout
+        ; test_case "timeout kills process" `Quick
+            test_timeout_kills_process
+        ; test_case "stderr captured" `Quick test_stderr_capture
+        ; test_case "stdin delivered" `Quick test_stdin_delivered
+        ] )
+    ]


### PR DESCRIPTION
## Summary

RFC-0109 Phase 0 (helper module + unit test). Adds `lib/bounded_proc/` SSOT for time-bounded subprocess execution. Standalone PR — no call-site migration in this scope.

### Why

Per RFC-0109 ([#15940](https://github.com/jeong-sik/masc-mcp/pull/15940)) § 2-3, the root cause of 2026-05-17 5/16 keeper `failure:run_error` (sangsu `mid_turn_no_progress 307s`, masc-improver `oas_timeout_budget 276s`) is that `lib/process/process_eio.ml:454-507` attaches subprocesses to the caller's long-lived switch, with no inner `Switch.run` scope and no `timeout_sec` parameter. Eio guarantees automatic `Sys.sigkill` only on switch release; a long-lived caller switch defers SIGKILL indefinitely. C-blocking `Eio.Process.await` does not honour `Eio.Cancel.Cancelled` (Eio.Cancel docs). Scope termination is therefore the only termination primitive Eio guarantees.

### API

```ocaml
type outcome =
  | Done of Unix.process_status * string * string
  | Timeout of float

val run_argv_with_timeout :
  clock:_ Eio.Time.clock ->
  process_mgr:_ Eio.Process.mgr ->
  cwd:Eio.Fs.dir_ty Eio.Path.t ->
  ?env:string array ->
  ?stdin_string:string ->
  timeout_s:float ->
  string list ->
  outcome
```

Internally opens a fresh `Eio.Switch.run`, spawns into it, then races `Eio.Time.sleep clock timeout_s` against a drain+await fiber with `Eio.Fiber.first`. When timeout wins, the `Switch.run` block exits → Eio sends `Sys.sigkill` (kernel-enforced, per https://ocaml.org/p/eio/latest/doc/Eio/Process/).

### Tests (4 / 4 PASS, 0.767s)

| # | Scenario | Assertion |
|---|---|---|
| 1 | `echo hello` within 5s timeout | `Done(WEXITED 0, \"hello\\n\", \"\")` |
| 2 | `sh -c 'sleep 10 # __sentinel__'` with 0.5s timeout | `Timeout _` + `pgrep -f __sentinel__` returns nothing (OS-level kill verified) |
| 3 | `sh -c 'echo out; echo err >&2'` | stdout/stderr captured separately |
| 4 | `cat` with stdin_string | payload round-trips on stdout |

Test 2 is the load-bearing assertion: it proves the Eio invariant ("switch release SIGKILLs the child") actually fires end-to-end, not just in theory.

### Build / fmt

- `dune build --root . lib/bounded_proc` PASS
- `dune build --root . test/test_bounded_proc.exe` PASS
- `dune build --root . @fmt` PASS (lib/bounded_proc/, test/dune clean after promote)

### Scope

- **In scope**: helper module + dune + mli + ml + 4 unit tests + test/dune registration via `stanzas/test_bounded_proc.inc` include (avoids the duplicate-stanza trap from PR #15907).
- **Out of scope**: any caller migration. Subsequent Phase PRs:
  - P1: `process_eio.spawn_and_drain_{stdout,both}` canary migration
  - P2: `keeper_docker_client_real` docker exec/run sites
  - P3: `cascade_event_bridge` LLM HTTPS attempt budgets
  - P4: `keeper_supervisor` outer max-turn watchdog
  - P5: `Keeper_turn_slot.force_release_holder_for` deprecation after 30-day metric soak

### Workaround signature self-check (RFC-0109 §7)

| Signature | Match? |
|---|---|
| Counter-as-fix | No — actually terminates the subprocess (Eio kernel-enforced) |
| String classifier | No |
| N-of-M | No — single helper, no callers migrated yet |
| Cap/cooldown/dedup/repair | No — bounded *scope* is the canonical Eio idiom; not a cap on retries or carrier value |
| Test backdoor | No — helper has no test-only path |

### Acceptance (RFC-0109 §5 P0)

- [x] `Bounded_proc.run_argv_with_timeout` Alcotest 4 cases PASS
- [x] `dune build --root . @check` PASS (full subset built)
- [x] `ocamlformat --check` PASS

### Test plan

- [ ] Reviewer: verify the 4-case test set covers the invariant set claimed in RFC §3
- [ ] Reviewer: confirm `pgrep` sentinel approach in test 2 is robust on the CI image (Linux + macOS)
- [ ] Reviewer: assess whether `?stdin_source:_ Eio.Flow.source` is needed for P1+ (current `?stdin_string` covers all current spawn_and_drain_* callers, but worth confirming before P2 starts)

### Cross-references

- RFC body: `docs/rfc/RFC-0109-bounded-subprocess-discipline.md` (PR #15940)
- RFC-0106 (cancel-safe try-with): orthogonal (0106 = don't swallow Cancelled; this RFC = kill via scope when Cancelled cannot arrive)
- RFC-0097 (container reuse, MERGED): solves spawn-churn root; this RFC solves spawned-process *lifetime* root

RFC-WAIVED: `lib/bounded_proc/` is a new helper, not in the agent_delegation RFC-mandatory subsystem list. RFC-0109 (#15940) covers design rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)