### PR TITLE
feat(masc_http_client): RFC-0107 Phase D.2a — Pool interface skeleton + stub

### DIFF
--- a/lib/masc_http_client/pool.ml
+++ b/lib/masc_http_client/pool.ml
@@ -1,0 +1,67 @@
+(** RFC-0107 Phase D Connection Pool — implementation stub.
+
+    Phase D.2a places the type-correct stub so that downstream callers
+    (Phase D.2c migration shim, Phase D.2d tests) can compile against
+    the [Pool.t] / [Pool.request] / [Pool.with_connection] surface
+    before the piaf binding lands in D.2b.
+
+    All public functions raise [Failure] until D.2b. The intent is to
+    fail fast and loud at runtime so a "stub-call-from-prod" cannot go
+    unnoticed; type-only consumers (modules that take a [Pool.t] in
+    function signatures without invoking it) build clean. *)
+
+type config = {
+  max_idle_per_host : int;
+  max_total_idle    : int;
+  idle_ttl_seconds  : float;
+  connect_timeout_seconds : float;
+}
+
+let default_config = {
+  max_idle_per_host = 8;
+  max_total_idle    = 256;
+  idle_ttl_seconds  = 60.0;
+  connect_timeout_seconds = 5.0;
+}
+
+(* Phase D.2b fills in the actual fields (Host_key -> piaf Client.t
+   queue, TLS context cache, eviction fiber stop signal, stats
+   counters). The current type body is deliberately empty so any
+   accidental field access fails at compile time. *)
+type t = unit
+
+let stub_msg fn =
+  Failure
+    (Printf.sprintf
+       "Pool.%s: not implemented (RFC-0107 Phase D.2a stub; \
+        binding lands in D.2b)" fn)
+
+let create ~sw:_ ~net:_ ?https:_ ?config:_ () : t =
+  raise (stub_msg "create")
+
+type response = {
+  status : int;
+  headers : (string * string) list;
+  body : string;
+}
+
+type http_method = [ `GET | `POST | `PUT | `DELETE | `HEAD | `PATCH ]
+
+let request _t ?clock:_ ?timeout_seconds:_ ~method_:_ ~url:_
+            ?headers:_ ?body:_ () : (response, string) result =
+  raise (stub_msg "request")
+
+let with_connection _t ~url:_ _f =
+  raise (stub_msg "with_connection")
+
+type stats = {
+  idle_per_host : (string * int) list;
+  total_idle : int;
+  total_inflight : int;
+  reuse_count_total : int;
+  evict_count_total : int;
+  create_count_total : int;
+}
+
+let stats _t : stats =
+  raise (stub_msg "stats")

--- a/lib/masc_http_client/pool.mli
+++ b/lib/masc_http_client/pool.mli
@@ -1,0 +1,130 @@
+(** RFC-0107 Phase D Connection Pool — interface skeleton.
+
+    Phase D.2a delivers the interface only; implementations raise
+    [Failure "Pool.<fn>: not implemented (Phase D.2b)"] until the piaf
+    binding lands in D.2b.
+
+    Design rationale lives in [docs/rfc/RFC-0107-phase-d-pool-design.md].
+    Critical findings absorbed from Phase B Prior Art research
+    ([knowledge/research/2026-05-17-piaf-ocsigen-eio-fd-prior-art.md]):
+
+    - piaf's [Client.t] is per-endpoint, not multi-host. We build the
+      [Host_key -> piaf Client.t queue] layer ourselves on top.
+    - cohttp upstream patch is not viable (issue #85 closed 2014, eio
+      not covered). piaf is the only rational transport choice.
+    - Eio #244 "exactly-one-owner" principle motivates the no-double-
+      release invariant enforced by the [request] / [with_connection]
+      callback API (no naked acquire / release exposed). *)
+
+(** Opaque per-process connection pool. Attaches to a long-lived
+    [Eio.Switch] (typically server root_sw via [Eio_context]). The pool
+    survives turn boundaries; per-host connection state evicts on
+    [idle_ttl]. *)
+type t
+
+(** Pool tuning parameters. Conservative defaults derived from
+    RFC-0101 §2 nofile cap (10240).
+
+    [max_idle_per_host]: bound on idle (reusable) connections kept per
+    {scheme, host, port} tuple after a request completes.
+
+    [max_total_idle]: bound on idle connections across all hosts. When
+    exceeded, the LRU host's oldest idle connection is evicted before
+    a new one is parked.
+
+    [idle_ttl_seconds]: idle connection's max age before eviction. A
+    pool fiber walks idle queues periodically; expired entries are
+    closed and dropped.
+
+    [connect_timeout_seconds]: max wait when establishing a fresh
+    connection. Surfaces as [Error "connect timeout ..."] to the
+    caller. *)
+type config = {
+  max_idle_per_host : int;
+  max_total_idle    : int;
+  idle_ttl_seconds  : float;
+  connect_timeout_seconds : float;
+}
+
+val default_config : config
+(** [{ max_idle_per_host = 8; max_total_idle = 256;
+       idle_ttl_seconds = 60.0; connect_timeout_seconds = 5.0 }]. *)
+
+val create :
+  sw:Eio.Switch.t ->
+  net:[> `Generic ] Eio.Net.ty Eio.Resource.t ->
+  ?https:
+    (Uri.t ->
+     [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t ->
+     [ `Close | `Flow | `R | `Shutdown | `Tls | `W ] Eio.Resource.t) ->
+  ?config:config ->
+  unit ->
+  t
+(** Initialize the pool on a long-lived switch (server root_sw). Idle
+    connections close when [sw] closes; in-flight requests outlive
+    pool cleanup via per-call sub-switches. *)
+
+(* ── Request API ───────────────────────────────────────────────── *)
+
+(** Typed HTTP response. Mirrors [Masc_http_client] response shape so
+    the migration shim is a one-line wrap. *)
+type response = {
+  status : int;
+  headers : (string * string) list;
+  body : string;
+}
+
+type http_method = [ `GET | `POST | `PUT | `DELETE | `HEAD | `PATCH ]
+
+val request :
+  t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  ?timeout_seconds:float ->
+  method_:http_method ->
+  url:string ->
+  ?headers:(string * string) list ->
+  ?body:string ->
+  unit ->
+  (response, string) result
+(** Scoped one-shot request. Acquires a connection from the per-host
+    pool (or creates one if the pool is empty / under
+    [max_idle_per_host]), issues the request, releases the connection
+    back to the pool for keep-alive reuse, and returns the typed
+    response.
+
+    Failure modes (all return [Error]):
+    - DNS / TCP / TLS failure during connect
+    - HTTP read error during reuse (pool drops the bad connection)
+    - timeout when [clock] and [timeout_seconds] are both provided
+
+    Notably absent: silent retry. If a reused connection fails, the
+    caller sees [Error] with the underlying reason. Caller decides
+    whether to retry — N-of-M silent retry is an
+    RFC-0107 §"Workaround Rejection Bar" anti-pattern. *)
+
+val with_connection :
+  t ->
+  url:string ->
+  (unit -> 'a) -> 'a
+(** Scoped low-level handle for streaming bodies (voice_bridge). The
+    callback runs with a connection borrowed from the pool; on return
+    (success or exception) the connection is released back to the
+    pool. Most callers should use [request] instead.
+
+    Phase D.2b will refine the callback signature to expose the
+    transport handle (piaf [Client.t] or equivalent). *)
+
+(* ── Telemetry ─────────────────────────────────────────────────── *)
+
+(** Non-mutating pool snapshot for Prometheus / dashboard. Phase D.4
+    wires this to the metrics layer. *)
+type stats = {
+  idle_per_host : (string * int) list;
+  total_idle : int;
+  total_inflight : int;
+  reuse_count_total : int;
+  evict_count_total : int;
+  create_count_total : int;
+}
+
+val stats : t -> stats


### PR DESCRIPTION
## Summary

RFC-0107 Phase D.2a — Connection pool **interface skeleton + stub**.
Type-correct surface so downstream work (D.2c migration shim, D.2d
tests, dependent PRs) compiles before the piaf transport binding
lands in D.2b.

## Design constraints absorbed (Phase B Prior Art)

From `knowledge/research/2026-05-17-piaf-ocsigen-eio-fd-prior-art.md`:

- **piaf is per-endpoint, not multi-host** — we build the `Host_key →
  piaf Client.t queue` layer ourselves. Pool LoC re-estimate ~600
  (up from ~400 in D.1).
- **cohttp upstream patch not viable** — issue #85 closed 2014,
  `cohttp-eio` not covered. piaf direct is the only rational choice.
- **Eio #244 exactly-one-owner** principle motivates callback API
  (`request` / `with_connection`) over naked acquire/release.

## Interface highlights (`lib/masc_http_client/pool.mli`)

- `Pool.t` opaque type — process-lifetime, attaches to server root_sw.
- `Pool.request` — typed one-shot, returns `(response, string) result`.
  Failure = caller's choice (no silent retry — RFC §"Workaround
  Rejection Bar" anti-pattern).
- `Pool.with_connection` — streaming callback for voice_bridge.
- `Pool.config` — `max_idle_per_host=8`, `max_total_idle=256`,
  `idle_ttl_seconds=60.0`, `connect_timeout_seconds=5.0`. Conservative
  defaults bounded by RFC-0101 §2 nofile cap.
- `Pool.stats` — non-mutating snapshot for Prometheus (Phase D.4).

## Stub policy

All public functions raise `Failure "Pool.<fn>: not implemented (Phase
D.2b)"`. Type body is `unit` so accidental field access fails at
compile time. Intent: type-only consumers compile clean; runtime stub
call fails fast and loud (no silent fallback).

## Files

- `lib/masc_http_client/pool.mli` — 121 lines, full interface
- `lib/masc_http_client/pool.ml` — 76 lines, stub bodies

## Verification

- `dune build lib/masc_http_client/` exit 0
- `dune build lib/eio_context/` exit 0
- Pre-existing main error in `test/test_start_masc_mcp_script.ml`
  (dangling `home_dir` from #15930) is **out of scope** of this PR

## Roadmap

| Step | Scope | Status |
|---|---|---|
| D.2a (this PR) | Interface + stub | done |
| D.2b | piaf opam dep + transport binding | next, needs user approval for opam dep |
| D.2c | Masc_http_client migration shim (13 callsites unchanged) | after D.2b |
| D.2d | Unit + integration tests + TLA+ Pool_no_double_close | after D.2c |
| D.2e | cascade-storm reproducer (16 keepers × 5 turn) | after D.2d |

## Refs

- RFC-0107 §3.2 (Connection pool)
- RFC-0107 Phase D design: docs/rfc/RFC-0107-phase-d-pool-design.md
  (PR #15941)
- Phase B Prior Art: knowledge/research/2026-05-17-piaf-ocsigen-eio-fd
  -prior-art.md (bundled in #15941)
- Phase C.1 wiring: PR #15932 (prerequisite for D.2c switch hierarchy)

RFC-WAIVED: skeleton + stub only, no production behavior change.
RFC-0107 authority already in main (#15912).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
