### PR TITLE
Expose FD accountant metrics

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -698,6 +698,10 @@ let metric_agent_stale_total = "masc_agent_stale_total"
 (* Process-level FD gauges — used in init() and update_fd_gauges. *)
 let metric_open_fds = "masc_process_open_fds"
 let metric_fd_warn_threshold = "masc_process_fd_warn_threshold"
+let metric_fd_open = "masc_fd_open"
+let metric_fd_limit = "masc_fd_limit"
+let metric_fd_in_flight = "masc_fd_in_flight"
+let metric_fd_pressure_active = "masc_fd_pressure_active"
 
 (* Core counters / gauges — used outside init. *)
 let metric_mcp_requests = "masc_mcp_requests_total"
@@ -2385,6 +2389,22 @@ let init () =
     metric_fd_warn_threshold
     "Threshold above which open_fds triggers a one-shot WARN log."
     Gauge;
+  add
+    metric_fd_open
+    "Best-effort FD accountant observation of process-wide open file descriptors."
+    Gauge;
+  add
+    metric_fd_limit
+    "Best-effort FD accountant observation of the process RLIMIT_NOFILE soft cap."
+    Gauge;
+  add
+    metric_fd_in_flight
+    "Current in-flight FD-accounted operations by kind. Labels: kind."
+    Gauge;
+  add
+    metric_fd_pressure_active
+    "Whether the shared keeper FD-pressure breaker is active (1 active, 0 inactive)."
+    Gauge;
   (* Per-keeper turn outcome + token counters.  Labels are populated
      dynamically via inc_counter; no upfront registration needed.
      Covers issues #7495 (cost/token attribution) and #7519 (SLO). *)
@@ -3165,6 +3185,22 @@ let update_fd_gauges () =
     ~metric_open_fds
 ;;
 
+let update_fd_accountant_gauges () =
+  let snapshot = Fd_accountant.fd_snapshot () in
+  set_gauge metric_fd_open (float_of_int snapshot.fd_open);
+  set_gauge metric_fd_limit (float_of_int snapshot.fd_limit);
+  set_gauge
+    metric_fd_pressure_active
+    (if snapshot.pressure_active then 1.0 else 0.0);
+  List.iter
+    (fun (kind, in_flight) ->
+      set_gauge
+        metric_fd_in_flight
+        ~labels:[ "kind", Fd_accountant.kind_to_string kind ]
+        (float_of_int in_flight))
+    snapshot.per_kind
+;;
+
 let set_tool_schema_stats ~count ~approx_tokens =
   set_gauge metric_mcp_tool_schema_count (float_of_int count);
   set_gauge metric_mcp_tool_schema_tokens_approx (float_of_int approx_tokens)
@@ -3182,6 +3218,7 @@ let labels_to_string = Prometheus_format.labels_to_string
 let to_prometheus_text () =
   update_uptime ();
   update_fd_gauges ();
+  update_fd_accountant_gauges ();
   (* Snapshot (name, help, metric_type, value, labels) under the mutex so
      the render phase sees a consistent view even when concurrent fibers
      are still updating [metrics].  [m.value] is mutable so we copy it

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -431,6 +431,10 @@ val metric_mcp_tool_schema_tokens_approx : string
 
 (** {1 Core counters / gauges} *)
 
+val metric_fd_open : string
+val metric_fd_limit : string
+val metric_fd_in_flight : string
+val metric_fd_pressure_active : string
 val metric_mcp_requests : string
 val metric_llm_inference_duration : string
 

--- a/lib/server/fd_accountant.ml
+++ b/lib/server/fd_accountant.ml
@@ -93,15 +93,25 @@ let read_fd_open () =
   in
   try_dirs candidates
 
+let fd_limit_cache : int option Atomic.t = Atomic.make None
+
 let read_fd_limit () =
-  try
-    let chan = Unix.open_process_in "ulimit -n" in
-    let line = input_line chan in
-    let _ = Unix.close_process_in chan in
-    match int_of_string_opt (String.trim line) with
-    | Some n -> n
-    | None -> -1
-  with _ -> -1
+  match Atomic.get fd_limit_cache with
+  | Some value -> value
+  | None ->
+    let value =
+      try
+        let chan = Unix.open_process_in "ulimit -n" in
+        let line = input_line chan in
+        let _ = Unix.close_process_in chan in
+        match int_of_string_opt (String.trim line) with
+        | Some n -> n
+        | None -> -1
+      with
+      | _ -> -1
+    in
+    Atomic.set fd_limit_cache (Some value);
+    value
 
 type snapshot = {
   per_kind : (kind * int) list ;

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -291,6 +291,30 @@ let count_lines_with_prefix text prefix =
   |> List.length
 ;;
 
+let test_to_prometheus_text_has_fd_accountant_metrics () =
+  let text = Prometheus.to_prometheus_text () in
+  check
+    bool
+    "has fd open HELP"
+    true
+    (text_has_literal text ("# HELP " ^ Prometheus.metric_fd_open ^ " "));
+  check
+    bool
+    "has fd limit TYPE"
+    true
+    (text_has_literal text ("# TYPE " ^ Prometheus.metric_fd_limit ^ " gauge"));
+  check
+    bool
+    "has pressure active sample"
+    true
+    (text_has_literal text (Prometheus.metric_fd_pressure_active ^ " "));
+  check
+    int
+    "one in-flight sample per FD kind"
+    (List.length Masc_mcp.Fd_accountant.all_kinds)
+    (count_lines_with_prefix text (Prometheus.metric_fd_in_flight ^ "{kind="))
+;;
+
 let rec rm_rf path =
   if Sys.file_exists path
   then
@@ -878,6 +902,10 @@ let () =
         ; test_case "has TYPE" `Quick test_to_prometheus_text_has_type
         ; test_case "has uptime" `Quick test_to_prometheus_text_has_uptime
         ; test_case "has sse metrics" `Quick test_to_prometheus_text_has_sse_metrics
+        ; test_case
+            "has fd accountant metrics"
+            `Quick
+            test_to_prometheus_text_has_fd_accountant_metrics
         ; test_case "keeper metrics registered" `Quick test_keeper_metrics_registered
         ; test_case
             "new issue metrics registered (#12801/#12797/#12799)"


### PR DESCRIPTION
## Summary
- expose Fd_accountant snapshot gauges in Prometheus as masc_fd_open, masc_fd_limit, masc_fd_pressure_active, and masc_fd_in_flight{kind}
- refresh FD accountant gauges during /metrics export alongside existing process FD gauges
- cache the fd-limit lookup so metrics scrapes do not spawn a shell repeatedly

## Verification
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build test/test_fd_accountant.exe test/test_prometheus_coverage.exe
- ./_build/default/test/test_fd_accountant.exe
- ./_build/default/test/test_prometheus_coverage.exe

## Guard
- Created as draft and labeled do-not-merge because #15938 showed draft PRs can be merged unexpectedly.