### PR TITLE
fix(test): restore home_dir reference dropped by #15930 rename

### DIFF
--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -268,7 +268,7 @@ let test_realtime_transports_default_to_base_path_config_and_preserve_override (
           ~env:
             [
               ("FAKE_CAPTURE_FILE", capture_default);
-              ("HOME", home_dir);
+              ("HOME", ignored_dir);
               ("MASC_BASE_PATH", dir);
               ("MASC_CONFIG_DIR", "");
             ]


### PR DESCRIPTION
## Summary
- `test/test_start_masc_mcp_script.ml:271`에서 PR #15930이 `let home_dir`를 `let ignored_dir`로 rename하며 15줄 아래 한 군데 consumer를 못 바꿔 트리 전체 빌드가 `Error: Unbound value home_dir`로 깨졌습니다.
- 같은 함수 내 단 하나의 dangling 참조 (다른 함수들은 각자 자체 `let home_dir` 보유 — 영향 없음).
- 의도 보존: HOME을 `ignored_dir`로 가리켜 "HOME에 config가 있더라도 base-path config가 이긴다" 검증을 그대로 유지. PR #15930의 의미 변경 방향(=`ignored_dir`)에 정렬.

## Root cause
N-of-M rename leftover. Free-variable rename은 OCaml 컴파일러가 보통 잡지만, 함수-local scope에 변수가 살아있지 않으면 호출부에서 `Unbound value`로 터집니다. PR #15930 diff(lib + test 8개 파일)에서 같은 함수 본문 내 1군데만 미반영.

근거: \`git show 0fff4ea761 -- test/test_start_masc_mcp_script.ml\` — diff는 정의부 3줄만 교체, 271행 consumer 누락.

## Verification
- \`dune build --root . @check -j 4\` → exit 0, errors 0 (deprecation warning만)
- \`dune exec test/test_start_masc_mcp_script.exe\` → **19/19 PASS** (19.153s), 수정 함수 #1 \"realtime transports default to base path config and preserve override\" 포함
- \`bash ~/me/scripts/pr-rfc-check.sh\` → exit 0 (test 파일만 수정, 관련 subsystem 영향 없음)

## Test plan
- [x] 영향 받은 테스트 swap binding 후 PASS
- [x] 전체 트리 @check exit 0
- [ ] CI: build/test workflow 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>