### PR TITLE
chore(fs_compat): remove redundant inline atomic helpers from dated_jsonl + trajectory (RFC-0108) (Draft)

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -253,70 +253,19 @@ let prune_unlocked t ~days =
 
 (* ── Public API ───────────────────────────────────────── *)
 
-(* RFC-0108: in-line per-path Stdlib.Mutex + fresh fd open/close on
-   every append.  Replaces the prior [Fs_compat.append_jsonl] path
-   whose LRU [Append_fd_cache] shared one [out_channel] across all
-   callers/domains; observed 2026-05-17 as 38 line-tear / "}{"-concat
-   failures in [.masc/oas-events/2026-04/22.jsonl] (12), [23.jsonl]
-   (4), [24.jsonl] (2), [25.jsonl] (20), plus 114 utf-8 multibyte
-   tears in [keepers/*/reaction-ledger/2026-05/17.jsonl] (11 files).
-
-   Same hypothesis as RFC-0108 PR-4 (lib/trajectory/trajectory.ml):
-   OCaml [out_channel] buffer state is not domain-safe, so the
-   Append_fd_cache mutex protected the cache lookup but not the
-   buffer mutations from concurrent domains writing through the same
-   cached channel.  Fresh fd per call sidesteps that entirely.
-
-   The pre-existing [Eio.Mutex.use_ro] still wraps this body so
-   fiber-level serialization plus retention-prune ordering are
-   preserved.  The new per-path Stdlib.Mutex registry is a second
-   line of defence and the actual cross-domain barrier: it lives in
-   this module so it does not share state with Fs_compat. *)
-let path_mutex_registry : (string, Stdlib.Mutex.t) Hashtbl.t =
-  Hashtbl.create 16
-let path_mutex_registry_mu = Stdlib.Mutex.create ()
-
-let get_path_mutex path =
-  Stdlib.Mutex.lock path_mutex_registry_mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock path_mutex_registry_mu)
-    (fun () ->
-      match Hashtbl.find_opt path_mutex_registry path with
-      | Some m -> m
-      | None ->
-        let m = Stdlib.Mutex.create () in
-        Hashtbl.add path_mutex_registry path m;
-        m)
-
-let atomic_append_jsonl path json =
-  let line = Yojson.Safe.to_string json ^ "\n" in
-  (* Ensure parent directory exists. mkdir_p is a no-op when already
-     present; we cannot rely on [today_path]'s caller to have created
-     the YYYY-MM dir on first use. *)
-  Fs_compat.mkdir_p (Filename.dirname path);
-  let mu = get_path_mutex path in
-  Stdlib.Mutex.lock mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock mu)
-    (fun () ->
-      let oc =
-        Stdlib.open_out_gen
-          [ Stdlib.Open_append; Stdlib.Open_creat; Stdlib.Open_wronly ]
-          0o644
-          path
-      in
-      Fun.protect
-        ~finally:(fun () -> Stdlib.close_out_noerr oc)
-        (fun () -> Stdlib.output_string oc line))
-
 let append t json =
   let mutex = Atomic.get t.mutex in
   (* [use_ro] serializes file appends without poisoning the shared mutex on
      IO failure, so retry paths can keep using the same registry entry.
-     [use_rw] would poison on any exception regardless of [~protect]. *)
+     [use_rw] would poison on any exception regardless of [~protect].
+
+     [Fs_compat.append_jsonl] (post-RFC-0108 #15936) already provides
+     per-path cross-domain atomicity via its own Stdlib.Mutex registry
+     and fresh-fd-per-call. The PR-5 (#15928) inline [atomic_append_jsonl]
+     was a pre-emptive duplicate of that guarantee — removed here. *)
   Eio.Mutex.use_ro mutex (fun () ->
     let path = today_path t in
-    atomic_append_jsonl path json;
+    Fs_compat.append_jsonl path json;
     match t.retention_days with
     | None -> ()
     | Some days ->

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -226,66 +226,11 @@ let trajectory_path (masc_root : string) (keeper_name : string) (trace_id : stri
 let ensure_dir path =
   Fs_compat.mkdir_p path
 
-(* RFC-0108: per-path Stdlib.Mutex + fresh-fd open/close on every
-   append.  Replaces the prior [Fs_compat.append_file] path whose LRU
-   [Append_fd_cache] shared one [out_channel] across domains; observed
-   2026-05-17 ~89 utf-8 multibyte-tear lines across the
-   trajectories/{analyst,imseonghan,sangsu,ramarama,issue_king,…}
-   files (e.g. analyst/trace-1778241201559-69ff8.jsonl:161 cut on byte
-   0x97 in mid-record).  The shared-channel hypothesis: OCaml's
-   [out_channel] buffer state is not domain-safe, so two domains both
-   write-through the cached channel can interleave bytes within a
-   record even with the Append_fd_cache mutex held.
-
-   Fix shape: a per-path Stdlib.Mutex (registry lives in the trajectory
-   module so it doesn't share state with Fs_compat) covers the entire
-   [open + output_string + close] sequence.  Fresh fd per call means no
-   shared OCaml buffer ever sees concurrent writers.  Stdlib.Mutex is
-   used (not Eio.Mutex) because the call sites
-   [record_runtime_mcp_keeper_trajectory] in
-   lib/mcp_server_eio_call_tool.ml:357 and the persist paths in
-   lib/keeper/keeper_agent_run.ml do not thread [~sw ~fs] down to here.
-   Threading sw/fs through to use the Eio-based [Jsonl_atomic.append]
-   SSOT (lib/jsonl_atomic/) is a follow-up refactor — it would touch
-   3+ caller signatures and is independent of the race-cancel guarantee.
-
-   The payload is built as [json + "\n"] before the syscall so a single
-   [output_string] reaches the channel buffer at record granularity.
-   File mode [Open_append] makes the kernel place the bytes at end-of-
-   file atomically up to PIPE_BUF; with the per-path mutex held no
-   other writer of the same path can interleave even for larger
-   records, because every other call is blocked at the mutex before
-   it opens the fd. *)
-let path_mutex_registry : (string, Stdlib.Mutex.t) Hashtbl.t = Hashtbl.create 16
-let path_mutex_registry_mu = Stdlib.Mutex.create ()
-
-let get_path_mutex path =
-  Stdlib.Mutex.lock path_mutex_registry_mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock path_mutex_registry_mu)
-    (fun () ->
-      match Hashtbl.find_opt path_mutex_registry path with
-      | Some m -> m
-      | None ->
-        let m = Stdlib.Mutex.create () in
-        Hashtbl.add path_mutex_registry path m;
-        m)
-
-let atomic_append_line path line =
-  let mu = get_path_mutex path in
-  Stdlib.Mutex.lock mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock mu)
-    (fun () ->
-      let oc =
-        Stdlib.open_out_gen
-          [ Stdlib.Open_append; Stdlib.Open_creat; Stdlib.Open_wronly ]
-          0o644
-          path
-      in
-      Fun.protect
-        ~finally:(fun () -> Stdlib.close_out_noerr oc)
-        (fun () -> Stdlib.output_string oc line))
+(* RFC-0108: the inline per-path Stdlib.Mutex + fresh-fd helper
+   (PR-4 #15926) is removed here. [Fs_compat.append_jsonl] (post-RFC-0108
+   #15936) now provides the equivalent per-path cross-domain guarantee
+   via its own registry, so the trajectory-local copy is redundant.
+   Calls below delegate directly. *)
 
 let append_entry ?runtime_contract ?action_radius ~(masc_root : string)
     ~(keeper_name : string) ~(trace_id : string) (entry : tool_call_entry) :
@@ -294,8 +239,7 @@ let append_entry ?runtime_contract ?action_radius ~(masc_root : string)
   ensure_dir dir;
   let path = trajectory_path masc_root keeper_name trace_id in
   let json = entry_to_json ?runtime_contract ?action_radius entry in
-  let line = Yojson.Safe.to_string json ^ "\n" in
-  atomic_append_line path line
+  Fs_compat.append_jsonl path json
 
 (** Append a thinking block entry to the JSONL trajectory file. *)
 let append_thinking ~(masc_root : string) ~(keeper_name : string) ~(trace_id : string)
@@ -304,8 +248,7 @@ let append_thinking ~(masc_root : string) ~(keeper_name : string) ~(trace_id : s
   ensure_dir dir;
   let path = trajectory_path masc_root keeper_name trace_id in
   let json = thinking_entry_to_json entry in
-  let line = Yojson.Safe.to_string json ^ "\n" in
-  atomic_append_line path line
+  Fs_compat.append_jsonl path json
 
 (** Write a trajectory summary line (appended after session ends). *)
 let append_summary ~(masc_root : string) ~(keeper_name : string) ~(trace_id : string)
@@ -326,8 +269,7 @@ let append_summary ~(masc_root : string) ~(keeper_name : string) ~(trace_id : st
     ("started_at", `Float traj.started_at);
     ("ended_at", `Float traj.ended_at);
   ] in
-  let line = Yojson.Safe.to_string summary ^ "\n" in
-  atomic_append_line path line
+  Fs_compat.append_jsonl path summary
 
 (* ================================================================ *)
 (* Trajectory accumulator (mutable, per-session)                    *)


### PR DESCRIPTION
## 목표
RFC-0108 sprint 의 architectural cleanup. PR #15936 가 머지되어 `Fs_compat.append_jsonl` 가 cross-domain atomic 보장 제공 → PR-4 #15926 + PR-5 #15928 의 *inline 중복* 헬퍼 제거.

## 변경 (diff: +15 / -124 = **-109 LoC**)

**lib/dated_jsonl/dated_jsonl.ml** (-58 LoC):
- `path_mutex_registry`, `path_mutex_registry_mu` 제거
- `get_path_mutex`, `atomic_append_jsonl` 제거
- `append` body: `atomic_append_jsonl path json` → `Fs_compat.append_jsonl path json`
- `Eio.Mutex.use_ro` wrapper 보존 (retention-prune ordering 유지)

**lib/trajectory/trajectory.ml** (-51 LoC):
- `path_mutex_registry`, `path_mutex_registry_mu` 제거
- `get_path_mutex`, `atomic_append_line` 제거
- 3 함수 (`append_entry`, `append_thinking`, `append_summary`):
  - `let line = Yojson.Safe.to_string json ^ "\n" in atomic_append_line path line` 
  - → `Fs_compat.append_jsonl path json` (직렬화+\n도 Fs_compat 가 처리)

## 검증
모든 관련 테스트 통과:
```
test_dated_jsonl                            17 cases  0.020s
test_dated_jsonl_mutex_registry_10372        6 cases  0.020s
test_trajectory                             32 cases  0.162s
test_trajectory_atomicity                    1 case   0.146s  (16 threads × 100 multibyte)
                                            ─────────
                                            56 cases  PASS
```

특히 `test_trajectory_atomicity` (16 threads × 100 multibyte records → 0 malformed) 가 통과 — Fs_compat.append_jsonl 에 위임 후에도 cross-domain race 보장 유지 증명.

## 의존성
- **이미 머지된** PR #15936 (`Fs_compat.append_jsonl` root-fix) 만 의존. main 에 있음.
- PR #15949 (Draft, `Fs_compat.append_file` + cache removal) 와는 **독립** scope. 두 PR 어느 쪽이 먼저 머지되어도 무관.

## 자매 PR
- #15922 system_log (MERGED) — 영향 없음 (Ring.write_to_sink 의 자체 sink_mutex 패턴 유지, boot path constraint)
- #15926 trajectory (MERGED) — 본 PR 에서 cleanup
- #15928 dated_jsonl (MERGED) — 본 PR 에서 cleanup
- #15936 append_jsonl root-fix (MERGED) — 본 PR 이 의존
- #15949 append_file + cache 제거 (Draft) — 독립

## Architectural 의미
RFC-0108 sprint 가 evolution 으로 끝남:
1. **국소 fix** (PR-3/4/5): 4 writer 별로 race 차단
2. **Root fix** (#15936): Fs_compat.append_jsonl 자체 fix → ~30+ caller 자동 안전
3. **Cleanup** (이 PR): 중복 inline helper 제거 → SSOT 수렴
4. **Cache removal** (#15949): Append_fd_cache 완전 제거 → root cause 의 surface 자체 제거

코드는 *줄어들고* 안전성은 *늘어남*. RFC-0108 의 §3 \"SSOT 수렴\" 목표가 sync API 측면에서 실현됨.

## Self-review checklist
- [x] PR #15936 (의존) main 머지 확인
- [x] dated_jsonl Eio.Mutex 보존 (retention prune 순서 유지)
- [x] trajectory line construction (`json ^ \"\\n\"`) 자동 처리 (append_jsonl 내부)
- [x] 56 tests 회귀 없음
- [x] 16 threads × 100 multibyte stress 통과 — race 보장 유지 입증
- [x] PR #15949 와 독립 scope — 어느 쪽 먼저 머지되든 무관

🤖 Generated with [Claude Code](https://claude.com/claude-code)