### PR TITLE
fix(tool_keeper): observe env-var parse fallback in cache_ttl_seconds

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -356,6 +356,17 @@ let metric_tool_metrics_persist_dropped =
 let metric_tool_keeper_cache_cas_conflicts =
   "masc_tool_keeper_cache_cas_conflicts_total"
 
+(* tool_keeper.cache_ttl_seconds env-var parse fallback observability.
+   Operator-supplied env var (e.g. MASC_KEEPER_LIST_CACHE_TTL_S) is
+   present but the value cannot be parsed as a non-negative float; the
+   helper silently coalesces to the per-caller default. Without this
+   counter the operator never learns the env var has no effect ("set
+   to 5s but cache still 2s" symptom). Closed-vocabulary labels:
+     env_var: the env var name (bounded to the handful of callers)
+     reason:  invalid_float | negative_or_nan *)
+let metric_tool_keeper_cache_ttl_parse_failures =
+  "masc_tool_keeper_cache_ttl_parse_failures_total"
+
 (* #9771: keeper turn-slot semaphore wait timeout counter.
 
    Production observed multiple keepers ([sangsu], [janitor],
@@ -1340,6 +1351,11 @@ let init () =
     metric_tool_keeper_cache_cas_conflicts
     "Total tool_keeper.cached_text_by_key Atomic CAS retry events. Each \
      increment corresponds to one extra compute() call. No labels."
+    Counter;
+  add
+    metric_tool_keeper_cache_ttl_parse_failures
+    "Total tool_keeper.cache_ttl_seconds env-var parse fallback events. \
+     Labels: env_var, reason in {invalid_float | negative_or_nan}."
     Counter;
   add
     Keeper_metrics.metric_keeper_turn_queue_depth

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -174,6 +174,12 @@ val metric_tool_metrics_persist_dropped : string
     Each increment corresponds to one extra [compute ()] call. No labels. *)
 val metric_tool_keeper_cache_cas_conflicts : string
 
+(** Counter for [tool_keeper.cache_ttl_seconds] env-var parse fallback events.
+    Increments when the operator-supplied env var is present but unparseable
+    or out-of-range, and the helper falls back to its default. Labels:
+    [env_var, reason] with reason in [invalid_float | negative_or_nan]. *)
+val metric_tool_keeper_cache_ttl_parse_failures : string
+
 (** #9771: counter for keeper turn-slot semaphore wait timeouts.
     Labels: [keeper, channel] with channel in
     [autonomous_queue_head | autonomous | turn]. *)

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -55,13 +55,37 @@ let empty_text_cache ~generation =
 
 let keeper_list_cache = Atomic.make (empty_text_cache ~generation:0)
 
+(* Env-var parse fallback observability: previously the [Some _ when ...] +
+   wildcard arm silently coalesced unparseable / negative / NaN values to
+   the per-caller default. Operators setting MASC_KEEPER_LIST_CACHE_TTL_S
+   with a unit suffix ("5s") or sign typo received default 2.0s with no
+   warning. We now log + bump a closed-vocabulary counter on the fallback
+   path while preserving the return value. *)
 let cache_ttl_seconds env_var ~default =
   match Sys.getenv_opt env_var with
-  | Some raw -> (
-      match Float.of_string_opt (String.trim raw) with
-      | Some value when Stdlib.Float.compare value 0.0 >= 0 -> value
-      | _ -> default)
   | None -> default
+  | Some raw ->
+      let trimmed = String.trim raw in
+      (match Float.of_string_opt trimmed with
+       | Some value when Stdlib.Float.compare value 0.0 >= 0 -> value
+       | Some _ ->
+           Prometheus.inc_counter
+             Prometheus.metric_tool_keeper_cache_ttl_parse_failures
+             ~labels:[ ("env_var", env_var); ("reason", "negative_or_nan") ]
+             ();
+           Log.Keeper.warn
+             "cache_ttl_seconds: %s=%S negative or NaN; using default %.3fs"
+             env_var trimmed default;
+           default
+       | None ->
+           Prometheus.inc_counter
+             Prometheus.metric_tool_keeper_cache_ttl_parse_failures
+             ~labels:[ ("env_var", env_var); ("reason", "invalid_float") ]
+             ();
+           Log.Keeper.warn
+             "cache_ttl_seconds: %s=%S not a float; using default %.3fs"
+             env_var trimmed default;
+           default)
 
 let keeper_list_cache_ttl_s () =
   cache_ttl_seconds "MASC_KEEPER_LIST_CACHE_TTL_S" ~default:2.0


### PR DESCRIPTION
## Summary

`tool_keeper.cache_ttl_seconds` silently coalesced unparseable / negative / NaN env-var values to the per-caller default. Operator setting `MASC_KEEPER_LIST_CACHE_TTL_S=5s` (unit suffix), `=-1`, or `=garbled` received default 2.0s with no log, no counter, no reason — "cache TTL set but cache still 2s" was the only symptom.

This widens the fallback into a typed two-arm split with closed-vocabulary observability:

| arm | reason label | trigger |
|-----|-------------|---------|
| `Some _` | `negative_or_nan` | parses as float but `< 0` or NaN |
| `None`   | `invalid_float`   | parse error (unit suffix, garbage, etc.) |

Each arm logs `Log.Keeper.warn` with env var name + raw value and bumps `masc_tool_keeper_cache_ttl_parse_failures_total{env_var, reason}`. **Return value unchanged** (still `default`) — caller behaviour preserved.

## Files

| file | change |
|------|--------|
| `lib/prometheus.mli` | new `metric_tool_keeper_cache_ttl_parse_failures` declaration |
| `lib/prometheus.ml`  | metric value + registry entry |
| `lib/tool_keeper.ml` | wildcard arm split into typed `Some _` / `None` with log+counter, plus `WORKAROUND`-style header comment explaining the visibility gap |

## Workaround Rejection Bar self-check 7/7

1. **telemetry-as-fix?** NO — parse failure was previously *unclassifiable* (operator couldn't tell whether env var was honoured). log+counter is the correct surface for "why default?", not a band-aid over a different fix.
2. **string classifier?** NO — typed `Float.of_string_opt` arms, no substring matching.
3. **N-of-M?** NO — single call site (`keeper_list_cache_ttl_s`), single function modified.
4. **catch-all added?** NO — the existing wildcard arm is *split* into a typed pair; catch-all removed, not added.
5. **cap/cooldown/dedup/repair?** NO.
6. **test backdoor?** NO.
7. **codemod-missing typo?** NO.

## Test plan

- [ ] `dune build --root . @check` — PASS locally
- [ ] Operator sets `MASC_KEEPER_LIST_CACHE_TTL_S=5s` (unit suffix) → expect `WARN cache_ttl_seconds: MASC_KEEPER_LIST_CACHE_TTL_S="5s" not a float; using default 2.000s` + counter increment with `reason=invalid_float`
- [ ] Operator sets `MASC_KEEPER_LIST_CACHE_TTL_S=-1` → expect `negative_or_nan` reason
- [ ] Operator sets `MASC_KEEPER_LIST_CACHE_TTL_S=3.5` → no warn, value used (unchanged path)

## RFC

Not required. `tool_keeper.ml` and `prometheus.ml` are not in the RFC-mandatory subsystem list (credential/identity, repo_manager, operator_control, dashboard credential-settings, .claude/hooks/, workflow docs).

Co-Authored-By: claude-opus-4-7 <noreply@anthropic.com>
