### PR TITLE
[codex] Consolidate dashboard goal and cascade surfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ logs/
 .trunk-lock/
 
 # Dashboard SPA (Vite)
+dashboard/node_modules
 dashboard/node_modules/
 dashboard/package-lock.json
 dashboard/bun.lock

--- a/dashboard/docs/consolidation/route-inventory.md
+++ b/dashboard/docs/consolidation/route-inventory.md
@@ -4,7 +4,7 @@
 **수집일**: 2026-04-14.
 **수집 방법**: `rg` 기반 정적 분석. section 문자열 리터럴이 있는 모든 파일.
 
-> **Status (2026-05-14)**: 아래 표는 consolidation 전 정적 스냅샷이다.
+> **Status (2026-05-17)**: 아래 표는 consolidation 전 정적 스냅샷이다.
 > Current Dashboard v1 navigation의 SSOT로 쓰지 않는다. 현재 SSOT는
 > `dashboard/src/config/navigation.ts`, `lib/dashboard/dashboard_surface_readiness.ml`,
 > `lib/dashboard/dashboard_nav_event.ml`이며, drift 검증은
@@ -12,24 +12,24 @@
 > `scripts/check-dashboard-nav-event-parity.sh`가 담당한다.
 >
 > [근거] `bash scripts/check-dashboard-surface-parity.sh`
-> (2026-05-14 KST, High) ->
-> `Dashboard surface parity OK: 21 canonical surfaces aligned between
+> (2026-05-17 KST, High) ->
+> `Dashboard surface parity OK: 25 canonical surfaces aligned between
 > navigation.ts and dashboard_surface_readiness.ml`.
 >
 > [근거] `bash scripts/check-dashboard-nav-event-parity.sh`
-> (2026-05-14 KST, High) ->
+> (2026-05-17 KST, High) ->
 > `dashboard nav-event allowlist parity: OK`.
 
-## Current Canonical Inventory (2026-05-14)
+## Current Canonical Inventory (2026-05-17)
 
 | Surface | Sections |
 |---------|----------|
 | `cockpit` | none; hidden surface |
 | `overview` | none |
-| `monitoring` | `runtime`, `agents`, `goal-loop`, `fleet-health`; hidden diagnostics: `journey`, `observatory`, `cognition` |
+| `monitoring` | `runtime`, `cascade-config`, `agents`, `fleet-health`, `doctor`, `transport-health`, `feature-health`, `observatory`, `cognition`; hidden diagnostics: `journey` |
 | `command` | `operations` |
 | `connectors` | `connector-status` |
-| `workspace` | `board`, `sub-boards`, `planning`, `repositories`, `verification` |
+| `workspace` | `board`, `sub-boards`, `moderation`, `planning`, `repositories`, `verification` |
 | `lab` | `tools`, `autoresearch`, `harness` |
 | `code` | `ide-shell` |
 | `logs` | none |
@@ -43,6 +43,8 @@ Retired sections are not canonical dashboard surfaces:
 - `monitoring:sessions`, `monitoring:telemetry`, `monitoring:fleet`,
   `monitoring:tool-quality`, `monitoring:governance`, `monitoring:metrics`,
   and `monitoring:fsm-hub` remain legacy redirect inputs only.
+- `monitoring:goal-loop` remains a legacy redirect input only. The canonical
+  home is `workspace:planning?view=goal-loop`.
 
 The historical tables below are kept to explain the consolidation work that
 led to the current route table.

--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -137,6 +137,10 @@ describe('cockpit entrypoint registry', () => {
       tab: 'monitoring',
       params: { section: 'runtime', view: 'cost' },
     })
+    expect(cockpitTargetForParams({ mode: 'Observe', tab: 'cascade' })).toEqual({
+      tab: 'monitoring',
+      params: { section: 'cascade-config' },
+    })
     expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'keeper-cognition' })).toEqual({
       tab: 'monitoring',
       params: { section: 'cognition', view: 'keeper' },

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -128,7 +128,7 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   {
     mode: 'observe',
     aliases: ['cascade'],
-    target: { tab: 'monitoring', params: { section: 'runtime', view: 'cascade' } },
+    target: { tab: 'monitoring', params: { section: 'cascade-config' } },
     coverage: 'covered',
   },
   {
@@ -185,7 +185,7 @@ export const COCKPIT_LEGACY_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'comms', aliases: ['cm-st', 'composer-state'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'state' } }, coverage: 'covered' },
 
   // Observe Plane legacy design subtabs.
-  { mode: 'observe', aliases: ['cs-list', 'cascade-list'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'cascade' } }, coverage: 'covered' },
+  { mode: 'observe', aliases: ['cs-list', 'cascade-list'], target: { tab: 'monitoring', params: { section: 'cascade-config' } }, coverage: 'covered' },
   { mode: 'observe', aliases: ['cs-deep', 'cascade-deep-dive'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'inspector', focus: 'deep-dive' } }, coverage: 'covered' },
   { mode: 'observe', aliases: ['cs-cmp', 'cascade-compare'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'inspector', focus: 'compare' } }, coverage: 'covered' },
   { mode: 'observe', aliases: ['au-led', 'audit-ledger'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'audit' } }, coverage: 'covered' },

--- a/dashboard/src/components/cognition-plane.test.ts
+++ b/dashboard/src/components/cognition-plane.test.ts
@@ -16,9 +16,6 @@ async function flushUi(): Promise<void> {
 async function loadPlane() {
   vi.resetModules()
   vi.doMock('../router', () => ({ route, navigate: navigateMock }))
-  vi.doMock('./agents-unified', () => ({
-    AgentsUnified: () => html`<div data-testid="agents-unified">AgentsUnified</div>`,
-  }))
   vi.doMock('./autoresearch', () => ({
     Autoresearch: () => html`<div data-testid="autoresearch">Autoresearch</div>`,
   }))
@@ -34,6 +31,11 @@ async function loadPlane() {
   vi.doMock('./memory-subsystems', () => ({
     MemorySubsystems: ({ focus }: { focus?: string }) =>
       html`<div data-testid="memory-subsystems" data-focus=${focus ?? ''}>MemorySubsystems</div>`,
+  }))
+  vi.doMock('./common/route-link', () => ({
+    RouteLink: ({ children, params }: { children?: unknown; params?: Record<string, string> }) => html`
+      <a data-testid="route-link" data-section=${params?.section ?? ''} data-view=${params?.view ?? ''}>${children}</a>
+    `,
   }))
   return import('./cognition-plane')
 }
@@ -55,12 +57,26 @@ describe('CognitionPlane', () => {
     vi.restoreAllMocks()
     vi.resetModules()
     vi.doUnmock('../router')
-    vi.doUnmock('./agents-unified')
     vi.doUnmock('./autoresearch')
     vi.doUnmock('./keeper-decisions-stream')
     vi.doUnmock('./keeper-cognition-inspector')
     vi.doUnmock('./keeper-token-stats')
     vi.doUnmock('./memory-subsystems')
+    vi.doUnmock('./common/route-link')
+  })
+
+  it('renders a cognition overview without embedding the agent roster', async () => {
+    route.value.params = { section: 'cognition' }
+    const { CognitionPlane } = await loadPlane()
+
+    render(html`<${CognitionPlane} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('Keeper')
+    expect(container.textContent).toContain('Agent Observatory')
+    expect(container.querySelector('[data-testid="agents-unified"]')).toBeNull()
+    expect(container.querySelector('[data-testid="keeper-token-stats"]')).toBeNull()
+    expect(container.querySelector('[data-section="agents"]')).not.toBeNull()
   })
 
   it('renders the keeper cognition inspector for the keeper view', async () => {
@@ -71,7 +87,7 @@ describe('CognitionPlane', () => {
     await flushUi()
 
     expect(container.querySelector('[data-testid="keeper-cognition-inspector"]')).not.toBeNull()
-    expect(container.querySelector('[data-testid="agents-unified"]')).toBeNull()
+    expect(container.querySelector('[data-section="agents"]')).toBeNull()
   })
 
   it('renders the live decisions stream for the decisions view', async () => {

--- a/dashboard/src/components/cognition-plane.ts
+++ b/dashboard/src/components/cognition-plane.ts
@@ -1,12 +1,12 @@
 import { html } from 'htm/preact'
 import { navigate, route } from '../router'
-import { AgentsUnified } from './agents-unified'
 import { Autoresearch } from './autoresearch'
 import { FilterChips } from './common/filter-chips'
 import { KeeperDecisionsStream } from './keeper-decisions-stream'
 import { KeeperCognitionInspector } from './keeper-cognition-inspector'
 import { KeeperTokenStats } from './keeper-token-stats'
 import { MemorySubsystems } from './memory-subsystems'
+import { RouteLink } from './common/route-link'
 
 type CognitionView =
   | 'overview'
@@ -56,6 +56,69 @@ function updateViewParam(view: CognitionView): void {
   navigate('monitoring', next)
 }
 
+const OVERVIEW_LINKS: Array<{
+  label: string
+  detail: string
+  params: Record<string, string>
+}> = [
+  {
+    label: 'Keeper',
+    detail: 'BDI, goals, and cognition focus',
+    params: { section: 'cognition', view: 'keeper' },
+  },
+  {
+    label: 'Token Stats',
+    detail: 'Keeper token budget and spend',
+    params: { section: 'cognition', view: 'token-stats' },
+  },
+  {
+    label: 'Decisions',
+    detail: 'Decision stream and rationale',
+    params: { section: 'cognition', view: 'decisions' },
+  },
+  {
+    label: 'Memory',
+    detail: 'Memory subsystem entries',
+    params: { section: 'cognition', view: 'memory' },
+  },
+  {
+    label: 'Episodes',
+    detail: 'Episode-focused memory view',
+    params: { section: 'cognition', view: 'episodes' },
+  },
+  {
+    label: 'Autoresearch',
+    detail: 'Research loop diagnostics',
+    params: { section: 'cognition', view: 'autoresearch' },
+  },
+]
+
+function CognitionOverview() {
+  return html`
+    <section class="grid gap-3 md:grid-cols-2" aria-label="Cognition overview">
+      ${OVERVIEW_LINKS.map(item => html`
+        <${RouteLink}
+          key=${item.label}
+          tab="monitoring"
+          params=${item.params}
+          class="min-w-0 rounded-[var(--r-1)] border border-card-border/70 bg-[var(--color-bg-surface)] p-3 transition-colors hover:border-[var(--color-border-strong)] hover:bg-[var(--color-bg-elevated)]"
+        >
+          <div class="text-sm font-semibold text-text-strong">${item.label}</div>
+          <div class="mt-1 text-xs text-text-muted">${item.detail}</div>
+        <//>
+      `)}
+      <${RouteLink}
+        tab="monitoring"
+        params=${{ section: 'agents' }}
+        class="min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] p-3 transition-colors hover:border-[var(--color-border-strong)] hover:bg-[var(--color-bg-elevated)] md:col-span-2"
+      >
+        <div class="text-sm font-semibold text-text-strong">Agent Observatory</div>
+        <div class="mt-1 text-xs text-text-muted">Roster, keepers, and FSM views live in one agent surface.</div>
+      <//>
+    </section>
+  `
+}
+
 export function CognitionPlane() {
   const view = currentView()
 
@@ -82,8 +145,7 @@ export function CognitionPlane() {
       ` : view === 'autoresearch' ? html`
         <${Autoresearch} />
       ` : html`
-        <${AgentsUnified} />
-        <${KeeperTokenStats} />
+        <${CognitionOverview} />
       `}
     </div>
   `

--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -58,6 +58,14 @@ describe('IdeActivityPanel', () => {
     expect(container.textContent).toContain('no keeper activity')
   })
 
+  it('treats a null active file as no active file', () => {
+    const container = document.createElement('div')
+    render(h(IdeActivityPanel, { activeFile: null }), container)
+
+    expect(container.querySelector('[role="region"]')?.getAttribute('aria-label')).toBe('EVENT TIMELINE')
+    expect(container.textContent).toContain('0 events · 0 keepers')
+  })
+
   it('renders file context from annotation and diff props', () => {
     const container = document.createElement('div')
     render(h(IdeActivityPanel, {

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -149,7 +149,7 @@ export interface IdeRunProgressGoal {
 }
 
 export interface IdeActivityPanelProps {
-  readonly activeFile?: string
+  readonly activeFile?: string | null
   readonly annotations?: ReadonlyArray<IdeAnnotation>
   readonly diffRows?: ReadonlyArray<UnifiedDiffRow>
   readonly pollMs?: number
@@ -339,11 +339,12 @@ function normalizedPollMs(value: number | undefined): number | null {
 
 export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
   const {
-    activeFile = '',
+    activeFile: rawActiveFile = '',
     annotations = EMPTY_ANNOTATIONS,
     diffRows = EMPTY_DIFF_ROWS,
     pollMs = 0,
   } = props
+  const activeFile = rawActiveFile ?? ''
   const store = useMemo(() => {
     const store = createRunActivityStore(DEFAULT_ROOM_ID)
     store.seed(EMPTY_ACTIVITY)

--- a/dashboard/src/components/planning-panel.test.ts
+++ b/dashboard/src/components/planning-panel.test.ts
@@ -37,6 +37,9 @@ vi.mock('./goals', () => ({
 vi.mock('./goals/goal-tree', () => ({
   GoalTree: () => html`<div data-testid="goal-tree">GoalTree</div>`,
 }))
+vi.mock('./goal-loop-panel', () => ({
+  GoalLoopPanel: () => html`<div data-testid="goal-loop-panel">GoalLoopPanel</div>`,
+}))
 vi.mock('./goals/task-detail-state', () => ({
   openTaskDetail: openTaskDetailMock,
 }))
@@ -73,10 +76,19 @@ describe('PlanningPanel', () => {
     expect(screen.queryByTestId('goal-tree')).toBeNull()
   })
 
-  it('renders FilterChips with 2 options', () => {
+  it('renders FilterChips with 3 planning options', () => {
     render(html`<${PlanningPanel} />`)
+    expect(screen.getByText('목표 루프')).toBeTruthy()
     expect(screen.getByText('목표 관리자')).toBeTruthy()
     expect(screen.getByText('백로그')).toBeTruthy()
+  })
+
+  it('renders GoalLoopPanel when view=goal-loop', () => {
+    setRoute('goal-loop')
+    render(html`<${PlanningPanel} />`)
+    expect(screen.getByTestId('goal-loop-panel')).toBeTruthy()
+    expect(screen.queryByTestId('goal-tree')).toBeNull()
+    expect(screen.queryByTestId('planning')).toBeNull()
   })
 
   it('falls back to goal-tree for unknown view', () => {

--- a/dashboard/src/components/planning-panel.ts
+++ b/dashboard/src/components/planning-panel.ts
@@ -1,5 +1,5 @@
 // Planning Panel — Phase 7 unified view for planning section.
-// FilterChips toggle between kanban (Planning) and goal-tree (GoalTree).
+// FilterChips toggle between goal-loop status, goal tree, and kanban.
 // Revives GoalTree which became dead code after Phase 1 removed the
 // standalone goals section.
 
@@ -11,6 +11,7 @@ import { coordinationFsmSnapshot, goals, tasks } from '../store'
 import { FilterChips } from './common/filter-chips'
 import { Planning } from './goals'
 import { GoalTree } from './goals/goal-tree'
+import { GoalLoopPanel } from './goal-loop-panel'
 import { PlanningFocusPanel } from './planning-focus-panel'
 import { openTaskDetail } from './goals/task-detail-state'
 import type {
@@ -20,9 +21,9 @@ import type {
   DashboardCoordinationFsmViolation,
 } from '../types'
 
-type PlanningView = 'default' | 'goal-tree'
+type PlanningView = 'default' | 'goal-tree' | 'goal-loop'
 
-const PLANNING_VIEWS: PlanningView[] = ['default', 'goal-tree']
+const PLANNING_VIEWS: PlanningView[] = ['default', 'goal-tree', 'goal-loop']
 
 function isPlanningView(v: string | undefined): v is PlanningView {
   return !!v && (PLANNING_VIEWS as string[]).includes(v)
@@ -34,6 +35,7 @@ const activeView = computed<PlanningView>(() => {
 })
 
 const VIEW_CHIPS: Array<{ key: PlanningView; label: string }> = [
+  { key: 'goal-loop', label: '목표 루프' },
   { key: 'goal-tree', label: '목표 관리자' },
   { key: 'default',   label: '백로그' },
 ]
@@ -275,7 +277,9 @@ export function PlanningPanel() {
       <${PlanningRouteFocusPanel} />
       <${CoordinationHealthPanel} />
       <${PlanningFocusPanel} />
-      ${view === 'goal-tree'
+      ${view === 'goal-loop'
+        ? html`<${GoalLoopPanel} />`
+      : view === 'goal-tree'
         ? html`<${GoalTree} />`
         : html`<${Planning} />`}
     </div>

--- a/dashboard/src/components/runtime-panel.test.ts
+++ b/dashboard/src/components/runtime-panel.test.ts
@@ -21,9 +21,6 @@ async function loadRuntimePanel() {
   vi.doMock('./prometheus-metrics', () => ({
     PrometheusMetrics: () => html`<div data-testid="prometheus">PrometheusMetrics</div>`,
   }))
-  vi.doMock('./cascade-config-panel', () => ({
-    CascadeConfigPanel: () => html`<div data-testid="cascade-config">CascadeConfigPanel</div>`,
-  }))
   vi.doMock('./verification-specs-panel', () => ({
     VerificationSpecsPanel: () => html`<div data-testid="verification-specs">VerificationSpecsPanel</div>`,
   }))
@@ -40,6 +37,11 @@ async function loadRuntimePanel() {
           html`<span data-testid="chip" data-key=${c.key}>${c.label}</span>`,
         )}
       </div>
+    `,
+  }))
+  vi.doMock('./common/route-link', () => ({
+    RouteLink: ({ children, params }: { children?: unknown; params?: Record<string, string> }) => html`
+      <a data-testid="route-link" data-section=${params?.section ?? ''}>${children}</a>
     `,
   }))
   return import('./runtime-panel')
@@ -64,21 +66,23 @@ describe('RuntimePanel', () => {
     vi.doUnmock('./oas-health-chip')
     vi.doUnmock('./runtime-monitor')
     vi.doUnmock('./prometheus-metrics')
-    vi.doUnmock('./cascade-config-panel')
     vi.doUnmock('./verification-specs-panel')
     vi.doUnmock('./cost-dashboard')
     vi.doUnmock('./cascade-inspector')
     vi.doUnmock('./common/filter-chips')
+    vi.doUnmock('./common/route-link')
   })
 
-  it('renders all 5 panels by default (Signal + collapsed Diagnostic/Raw)', async () => {
+  it('renders runtime panels by default and links cascade config to its canonical surface', async () => {
     route.value.params = {}
     const { RuntimePanel } = await loadRuntimePanel()
     render(html`<${RuntimePanel} />`, container)
     await flushUi()
 
     expect(container.textContent).toContain('OasHealthChip')
-    expect(container.textContent).toContain('CascadeConfigPanel')
+    expect(container.textContent).toContain('Open Cascade Config')
+    expect(container.querySelector('[data-testid="route-link"]')?.getAttribute('data-section')).toBe('cascade-config')
+    expect(container.textContent).not.toContain('CascadeConfigPanel')
     expect(container.textContent).toContain('RuntimeMonitor')
     expect(container.textContent).toContain('PrometheusMetrics')
     expect(container.textContent).toContain('VerificationSpecsPanel')
@@ -95,7 +99,6 @@ describe('RuntimePanel', () => {
     expect(oas?.closest('details')).toBeNull()
 
     const detailIds = [
-      'runtime-details-cascade',
       'runtime-details-providers',
       'runtime-details-prometheus',
       'runtime-details-verification',
@@ -109,14 +112,14 @@ describe('RuntimePanel', () => {
   })
 
   it('explicit drill-down views bypass progressive disclosure', async () => {
-    route.value.params = { view: 'cascade' }
+    route.value.params = { view: 'inspector' }
     const { RuntimePanel } = await loadRuntimePanel()
     render(html`<${RuntimePanel} />`, container)
     await flushUi()
 
-    const cascade = container.querySelector('[data-testid="cascade-config"]')
-    expect(cascade).not.toBeNull()
-    expect(cascade?.closest('details')).toBeNull()
+    const inspector = container.querySelector('[data-testid="cascade-inspector"]')
+    expect(inspector).not.toBeNull()
+    expect(inspector?.closest('details')).toBeNull()
   })
 
   it('renders only OasHealthChip and RuntimeMonitor for providers view', async () => {
@@ -148,17 +151,16 @@ describe('RuntimePanel', () => {
     await flushUi()
 
     const chips = container.querySelectorAll('[data-testid="chip"]')
-    expect(chips.length).toBe(10)
+    expect(chips.length).toBe(9)
     expect(chips[0]?.textContent).toBe('전체')
-    expect(chips[1]?.textContent).toBe('Cascade')
-    expect(chips[2]?.textContent).toBe('런타임')
-    expect(chips[3]?.textContent).toBe('비용 / 지연')
-    expect(chips[4]?.textContent).toBe('감사')
-    expect(chips[5]?.textContent).toBe('휴리스틱')
-    expect(chips[6]?.textContent).toBe('스트레스')
-    expect(chips[7]?.textContent).toBe('검사기')
-    expect(chips[8]?.textContent).toBe('메트릭')
-    expect(chips[9]?.textContent).toBe('형식검증')
+    expect(chips[1]?.textContent).toBe('런타임')
+    expect(chips[2]?.textContent).toBe('비용 / 지연')
+    expect(chips[3]?.textContent).toBe('감사')
+    expect(chips[4]?.textContent).toBe('휴리스틱')
+    expect(chips[5]?.textContent).toBe('스트레스')
+    expect(chips[6]?.textContent).toBe('검사기')
+    expect(chips[7]?.textContent).toBe('메트릭')
+    expect(chips[8]?.textContent).toBe('형식검증')
   })
 
   it('routes runtime diagnostic views through CostDashboard', async () => {

--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -1,16 +1,15 @@
 // RuntimePanel — Phase 4 runtime section with FilterChips toggle.
-// Wraps OasHealthChip, RuntimeMonitor, CascadeConfigPanel, PrometheusMetrics,
+// Wraps OasHealthChip, RuntimeMonitor, PrometheusMetrics,
 // VerificationSpecsPanel with view switching.
 //
 // Progressive-disclosure default view (density reduction, 2026-04):
 //   Signal layer     — OasHealthChip always expanded (summary StatCells)
-//   Diagnostic layer — Cascade, Providers & Models via CollapsibleSection (closed)
+//   Diagnostic layer — Providers & Models via CollapsibleSection (closed)
 //   Raw layer        — Prometheus metrics, Formal specs via CollapsibleSection (closed)
 // NN/g progressive disclosure: respect working-memory limits, defer detail.
 //
 // Explicit drill-down via FilterChips remains unchanged:
 //   default      — Signal strip + collapsed diagnostic/raw accordions
-//   cascade      — cascade config + health only (설정 ↔ 실측)
 //   providers    — OAS health chip + runtime monitor only
 //   cost         — model/keeper cost and latency only
 //   audit        — dashboard audit ledger
@@ -29,14 +28,13 @@ import { CollapsibleSection } from './common/collapsible'
 import { OasHealthChip } from './oas-health-chip'
 import { RuntimeMonitor } from './runtime-monitor'
 import { PrometheusMetrics } from './prometheus-metrics'
-import { CascadeConfigPanel } from './cascade-config-panel'
 import { VerificationSpecsPanel } from './verification-specs-panel'
 import { CostDashboard, type CostView } from './cost-dashboard'
 import { CascadeInspector } from './cascade-inspector'
+import { RouteLink } from './common/route-link'
 
 type RuntimeView =
   | 'default'
-  | 'cascade'
   | 'providers'
   | 'cost'
   | 'audit'
@@ -48,7 +46,6 @@ type RuntimeView =
 
 const RUNTIME_VIEWS: RuntimeView[] = [
   'default',
-  'cascade',
   'providers',
   'cost',
   'audit',
@@ -70,7 +67,6 @@ const activeView = computed<RuntimeView>(() => {
 
 const VIEW_CHIPS: Array<{ key: RuntimeView; label: string }> = [
   { key: 'default', label: '전체' },
-  { key: 'cascade', label: 'Cascade' },
   { key: 'providers', label: '런타임' },
   { key: 'cost', label: '비용 / 지연' },
   { key: 'audit', label: '감사' },
@@ -96,6 +92,31 @@ function updateViewParam(view: RuntimeView): void {
   )
 }
 
+function CascadeConfigCanonicalLink() {
+  return html`
+    <section
+      class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3"
+      aria-label="Cascade canonical surface"
+    >
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div class="min-w-0">
+          <div class="text-sm font-semibold text-text-strong">Cascade Config</div>
+          <div class="mt-1 max-w-2xl text-xs leading-relaxed text-text-muted">
+            Providers, models, and routing rules are managed in the dedicated Cascade Config surface.
+          </div>
+        </div>
+        <${RouteLink}
+          tab="monitoring"
+          params=${{ section: 'cascade-config' }}
+          class="inline-flex min-h-9 items-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-2 text-xs font-semibold text-text-strong transition-colors hover:border-[var(--color-border-strong)] hover:bg-[var(--color-bg-elevated)]"
+        >
+          Open Cascade Config
+        <//>
+      </div>
+    </section>
+  `
+}
+
 export function RuntimePanel() {
   const view = activeView.value
   const costView = costDiagnosticView(view)
@@ -108,9 +129,7 @@ export function RuntimePanel() {
         onChange=${updateViewParam}
       />
       <div class="grid gap-4">
-        ${view === 'cascade'
-          ? html`<${CascadeConfigPanel} />`
-        : view === 'providers'
+        ${view === 'providers'
           ? html`
             <${OasHealthChip} />
             <${RuntimeMonitor} />
@@ -125,9 +144,7 @@ export function RuntimePanel() {
           ? html`<${VerificationSpecsPanel} />`
         : html`
             <${OasHealthChip} />
-            <${CollapsibleSection} id="runtime-details-cascade" title="캐스케이드">
-              <${CascadeConfigPanel} />
-            <//>
+            <${CascadeConfigCanonicalLink} />
             <${CollapsibleSection} id="runtime-details-providers" title="런타임">
               <${RuntimeMonitor} />
             <//>

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -9,7 +9,7 @@ import { LoadingState } from './common/feedback-state'
 
 export type StatusSection =
   | 'observatory' | 'journey' | 'agents' | 'runtime' | 'cascade-config'
-  | 'goal-loop' | 'fleet-health' | 'doctor' | 'transport-health'
+  | 'fleet-health' | 'doctor' | 'transport-health'
   | 'feature-health'
   | 'cognition'
 
@@ -33,9 +33,6 @@ const LazyTransportHealthPanel = lazy(async () => ({
 }))
 const LazyFeatureHealth = lazy(async () => ({
   default: (await import('./feature-health')).FeatureHealth,
-}))
-const LazyGoalLoopPanel = lazy(async () => ({
-  default: (await import('./goal-loop-panel')).GoalLoopPanel,
 }))
 const LazyObservatory = lazy(async () => ({
   default: (await import('./observatory/observatory')).Observatory,
@@ -61,8 +58,6 @@ export function sectionLabel(section: StatusSection): string {
       return 'Runtime'
     case 'cascade-config':
       return 'Cascade Config'
-    case 'goal-loop':
-      return 'GOAL LOOP'
     case 'fleet-health':
       return 'Fleet Health'
     case 'doctor':
@@ -88,8 +83,6 @@ function renderSection(section: StatusSection) {
       return html`<${LazyRuntimePanel} />`
     case 'cascade-config':
       return html`<${LazyCascadeConfigPanel} />`
-    case 'goal-loop':
-      return html`<${LazyGoalLoopPanel} />`
     case 'fleet-health':
       return html`<${LazyFleetHealthPanel} />`
     case 'doctor':
@@ -111,7 +104,6 @@ export function normalizeStatusSection(section: string | undefined): StatusSecti
     || section === 'journey'
     || section === 'runtime'
     || section === 'cascade-config'
-    || section === 'goal-loop'
     || section === 'fleet-health'
     || section === 'doctor'
     || section === 'transport-health'

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -105,7 +105,6 @@ describe('monitoring navigation labels', () => {
 
     expect(labelFor('runtime')).toBe('Live Runtime')
     expect(labelFor('agents')).toBe('Agent Observatory')
-    expect(labelFor('goal-loop')).toBe('Goal Navigator')
     expect(labelFor('fleet-health')).toBe('System Telemetry')
     expect(labelFor('observatory')).toBe('Activity Timeline')
     expect(labelFor('transport-health')).toBe('Transport Health')
@@ -119,9 +118,8 @@ describe('monitoring navigation labels', () => {
     const descriptions = Object.fromEntries(sections.map(item => [item.id, item.description]))
 
     expect(descriptions).toMatchObject({
-      runtime: 'Live cascade routing and provider health.',
+      runtime: 'Provider health and runtime diagnostics.',
       agents: 'Live roster with fleet state capsules.',
-      'goal-loop': 'Active goals with blockers and next actions.',
       'fleet-health': 'System signals for tools and governance.',
     })
 
@@ -145,14 +143,13 @@ describe('monitoring navigation labels', () => {
 
     expect(defaultParamsForTab('monitoring')).toEqual({ section: 'runtime' })
     expect(ids).toEqual([
-      'runtime', 'cascade-config', 'agents', 'goal-loop', 'fleet-health',
+      'runtime', 'cascade-config', 'agents', 'fleet-health',
       'doctor', 'transport-health', 'feature-health', 'observatory', 'cognition',
     ])
     expect(ids).toContain('fleet-health')
     expect(ids).toContain('runtime')
     expect(ids).toContain('cascade-config')
     expect(ids).toContain('agents')
-    expect(ids).toContain('goal-loop')
     expect(ids).toContain('doctor')
     expect(ids).toContain('transport-health')
     expect(ids).toContain('feature-health')
@@ -179,13 +176,12 @@ describe('monitoring navigation labels', () => {
     expect(sections[0]?.id).toBe('runtime')
     expect(sections[1]?.id).toBe('cascade-config')
     expect(sections[2]?.id).toBe('agents')
-    expect(sections[3]?.id).toBe('goal-loop')
-    expect(sections[4]?.id).toBe('fleet-health')
-    expect(sections[5]?.id).toBe('doctor')
-    expect(sections[6]?.id).toBe('transport-health')
-    expect(sections[7]?.id).toBe('feature-health')
-    expect(sections[8]?.id).toBe('observatory')
-    expect(sections[9]?.id).toBe('cognition')
+    expect(sections[3]?.id).toBe('fleet-health')
+    expect(sections[4]?.id).toBe('doctor')
+    expect(sections[5]?.id).toBe('transport-health')
+    expect(sections[6]?.id).toBe('feature-health')
+    expect(sections[7]?.id).toBe('observatory')
+    expect(sections[8]?.id).toBe('cognition')
   })
 
   it('keeps diagnostic monitoring routes available but hidden from the sidebar', () => {
@@ -215,9 +211,11 @@ describe('workspace navigation labels', () => {
     const labelFor = (id: string) => sections.find(item => item.id === id)?.label
 
     expect(labelFor('planning')).toBe('Plans & Goals')
+    expect(labelFor('moderation')).toBe('Moderation')
     // goals is no longer a standalone section
     const ids = sections.map(item => item.id)
     expect(ids).not.toContain('goals')
+    expect(ids).toContain('moderation')
   })
 })
 
@@ -260,6 +258,12 @@ describe('normalizeRouteParams backward compat (RFC-MASC-006 Phase 0)', () => {
     expect(normalizeRouteParams('monitoring', { section: 'cost' })).toMatchObject({
       section: 'runtime',
       view: 'cost',
+    })
+  })
+
+  it('redirects legacy runtime cascade view to the dedicated cascade config surface', () => {
+    expect(normalizeRouteParams('monitoring', { section: 'runtime', view: 'cascade' })).toMatchObject({
+      section: 'cascade-config',
     })
   })
 
@@ -400,6 +404,7 @@ describe('consolidation redirects (Phase 1)', () => {
     ['fleet', {}, 'fleet-health', 'comparison', {}],
     ['fsm-hub', {}, 'agents', 'fsm', {}],
     ['metrics', {}, 'runtime', undefined, {}],
+    ['cascade', {}, 'cascade-config', undefined, {}],
   ])(
     'monitoring:%s → %s (view: %s) preserves params',
     (oldSection, extra, expectedSection, expectedView, preserved) => {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -19,7 +19,6 @@ type SurfaceSectionId =
   | 'cognition'
   | 'runtime'
   | 'cascade-config' // Dedicated entry for cascade.toml TOML editor (formerly buried inside runtime/cascade view)
-  | 'goal-loop'
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
   | 'doctor'         // Dedicated entry for /api/v1/dashboard/doctor (formerly buried inside Command → Operations → Inspector → "진단" sub-tab)
   | 'transport-health' // Dedicated entry for /api/v1/dashboard/transport-health (was 5-hop buried inside Command → Operations → Inspector → "서버 설정" → ServerConfig → TransportHealthPanel)
@@ -34,6 +33,7 @@ type SurfaceSectionId =
   // workspace
   | 'board'
   | 'sub-boards'     // Phase 2: SubBoard named spaces within the board
+  | 'moderation'     // Board moderation queue and actions
   | 'planning'       // Phase 1: absorbs goals
   | 'repositories'   // Multi-repository cockpit and keeper access mapping
   | 'verification'   // CDAL follow-up (#7531): Mission detail verification table
@@ -175,13 +175,13 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'runtime',
       label: 'Live Runtime',
-      description: 'Live cascade routing and provider health.',
+      description: 'Provider health and runtime diagnostics.',
       params: { section: 'runtime' },
     },
     {
       id: 'cascade-config',
       label: 'Cascade Config',
-      description: 'Live cascade.toml editor and diagnostics.',
+      description: 'Cascade providers, models and rules.',
       params: { section: 'cascade-config' },
     },
     {
@@ -189,12 +189,6 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: 'Agent Observatory',
       description: 'Live roster with fleet state capsules.',
       params: { section: 'agents' },
-    },
-    {
-      id: 'goal-loop',
-      label: 'Goal Navigator',
-      description: 'Active goals with blockers and next actions.',
-      params: { section: 'goal-loop' },
     },
     {
       id: 'fleet-health',
@@ -285,9 +279,15 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       params: { section: 'sub-boards' },
     },
     {
+      id: 'moderation',
+      label: 'Moderation',
+      description: 'Flagged board posts and moderation actions.',
+      params: { section: 'moderation' },
+    },
+    {
       id: 'planning',
       label: 'Plans & Goals',
-      description: 'Task kanban with the higher-level goal tree.',
+      description: 'Goal loop, goal tree, and task kanban.',
       params: { section: 'planning' },
     },
     {
@@ -391,6 +391,7 @@ export const SECTION_REDIRECTS: Record<TabSectionKey, SectionRedirect> = {
   'monitoring:metrics':      { section: 'runtime' },
   'monitoring:cascade-inspector': { section: 'runtime', view: 'inspector' },
   'monitoring:cost': { section: 'runtime', view: 'cost' },
+  'monitoring:cascade': { section: 'cascade-config' },
 
   // Dashboard consolidation Phase 1+6: command surface
   'command:intervene':    { section: 'operations' },
@@ -444,6 +445,11 @@ export function normalizeRouteParams(tabId: TabId, params: Record<string, string
 
   if (!validSectionIds(typedTabId).includes(next.section as SurfaceSectionId)) {
     next.section = defaultParamsForTab(tabId).section ?? ''
+  }
+
+  if (tabId === 'monitoring' && next.section === 'runtime' && next.view === 'cascade') {
+    next.section = 'cascade-config'
+    delete next.view
   }
 
   if (!(tabId === 'code' && next.section === 'ide-shell')) {

--- a/dashboard/src/router.test.ts
+++ b/dashboard/src/router.test.ts
@@ -68,6 +68,15 @@ describe('navigate', () => {
     expect(route.value.params.section).toBe('operations')
     expect(route.value.params.view).toBe('safety')
   })
+
+  it('redirects retired goal-loop links into planning goal-loop view', () => {
+    navigate('monitoring', { section: 'goal-loop', goal: 'goal-1' })
+    expect(route.value.tab).toBe('workspace')
+    expect(route.value.params.section).toBe('planning')
+    expect(route.value.params.view).toBe('goal-loop')
+    expect(route.value.params.goal).toBe('goal-1')
+  })
+
   it('maps cockpit Cognition design deep links into the production keeper surface', () => {
     window.location.hash = '#repo=viewer&branch=wt%2Fsangsu-smoke&mode=Cognition'
     window.dispatchEvent(new HashChangeEvent('hashchange'))

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -34,6 +34,11 @@ export const CROSS_SURFACE_SECTION_REDIRECTS: Record<TabSectionKey, CrossSurface
     section: 'operations',
     view: 'safety',
   },
+  'monitoring:goal-loop': {
+    tab: 'workspace',
+    section: 'planning',
+    view: 'goal-loop',
+  },
 }
 
 function isTabId(v: string | null | undefined): v is TabId {

--- a/lib/dashboard/dashboard_nav_event.ml
+++ b/lib/dashboard/dashboard_nav_event.ml
@@ -32,7 +32,6 @@ let valid_sections =
       ; "cognition"
       ; "runtime"
       ; "cascade-config"
-      ; "goal-loop"
       ; "fleet-health"
       ; "doctor"
       ; "transport-health"
@@ -40,7 +39,7 @@ let valid_sections =
       ] )
   ; "command", [ "operations" ]
   ; "connectors", [ "connector-status" ]
-  ; "workspace", [ "board"; "sub-boards"; "planning"; "repositories"; "verification" ]
+  ; "workspace", [ "board"; "sub-boards"; "moderation"; "planning"; "repositories"; "verification" ]
   ; "lab", [ "tools"; "autoresearch"; "harness" ]
   ; "code", [ "ide-shell" ]
   ]

--- a/lib/dashboard/dashboard_surface_readiness.ml
+++ b/lib/dashboard/dashboard_surface_readiness.ml
@@ -192,17 +192,6 @@ let all_entries =
       ~tool_name:"masc_operator_snapshot"
       ()
   ; entry
-      ~id:"monitoring.goal-loop"
-      ~label:"Goal Navigator"
-      ~exposure_status:"main"
-      ~hidden_from_nav:false
-      ~meets_main_gate:true
-      ~rationale:"Active goal-loop status with blockers and next actions."
-      ~route_hash:"#monitoring?section=goal-loop"
-      ~live_spotcheck:"/api/v1/dashboard/goal-loop/status"
-      ~tool_name:"masc_goal_status"
-      ()
-  ; entry
       ~id:"monitoring.fleet-health"
       ~label:"System Telemetry"
       ~exposure_status:"main"
@@ -324,12 +313,23 @@ let all_entries =
       ~tool_name:"masc_board_list"
       ()
   ; entry
+      ~id:"workspace.moderation"
+      ~label:"Moderation"
+      ~exposure_status:"main"
+      ~hidden_from_nav:false
+      ~meets_main_gate:true
+      ~rationale:"Board moderation queue and action surface."
+      ~route_hash:"#workspace?section=moderation"
+      ~live_spotcheck:"/api/v1/dashboard/board/moderation/queue"
+      ~tool_name:"masc_board_list"
+      ()
+  ; entry
       ~id:"workspace.planning"
       ~label:"Plans & Goals"
       ~exposure_status:"main"
       ~hidden_from_nav:false
       ~meets_main_gate:true
-      ~rationale:"Task kanban and goal tree planning surface."
+      ~rationale:"Goal loop, goal tree, and task kanban planning surface."
       ~route_hash:"#workspace?section=planning"
       ~live_spotcheck:"/api/v1/dashboard/planning"
       ~tool_name:"masc_plan_get"

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -136,11 +136,11 @@ check_json \
   "surface-readiness has canonical surface count" \
   "$BASE/api/v1/dashboard/surface-readiness" \
   "len(d.get('surfaces', []))" \
-  '^21$'
+  '^25$'
 check_json \
   "surface-readiness matches canonical surface ids" \
   "$BASE/api/v1/dashboard/surface-readiness" \
-  "sorted(s.get('id') for s in d.get('surfaces', [])) == sorted(['cockpit', 'overview', 'monitoring.runtime', 'monitoring.agents', 'monitoring.goal-loop', 'monitoring.fleet-health', 'monitoring.journey', 'monitoring.observatory', 'monitoring.cognition', 'command.operations', 'connectors.connector-status', 'workspace.board', 'workspace.sub-boards', 'workspace.planning', 'workspace.repositories', 'workspace.verification', 'lab.tools', 'lab.autoresearch', 'lab.harness', 'code.ide-shell', 'logs'])" \
+  "sorted(s.get('id') for s in d.get('surfaces', [])) == sorted(['cockpit', 'overview', 'monitoring.runtime', 'monitoring.cascade-config', 'monitoring.agents', 'monitoring.fleet-health', 'monitoring.doctor', 'monitoring.transport-health', 'monitoring.feature-health', 'monitoring.journey', 'monitoring.observatory', 'monitoring.cognition', 'command.operations', 'connectors.connector-status', 'workspace.board', 'workspace.sub-boards', 'workspace.moderation', 'workspace.planning', 'workspace.repositories', 'workspace.verification', 'lab.tools', 'lab.autoresearch', 'lab.harness', 'code.ide-shell', 'logs'])" \
   '^True$'
 check_json \
   "surface-readiness dropped retired surfaces" \


### PR DESCRIPTION
## Summary

- Move Goal Loop into the Workspace Planning surface and redirect the legacy Monitor route there.
- Make Cascade Config the canonical Provider + Model + Rule surface, leaving Runtime focused on diagnostics with a link to Cascade Config.
- Remove duplicated Agent Observatory rendering from the Cognition overview and expose it as a single linked surface.
- Fix the CODE IDE render error caused by a null active file path flowing into path normalization.
- Restore Workspace moderation in the navigation/readiness allowlists and refresh route inventory documentation.

## Validation

- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard exec vitest run src/config/navigation.test.ts src/router.test.ts src/cockpit-entrypoints.test.ts src/components/status.test.ts src/components/runtime-panel.test.ts src/components/cognition-plane.test.ts src/components/planning-panel.test.ts src/components/work.test.ts src/components/board/board-moderation-surface.test.ts src/components/goal-loop-panel.test.ts src/components/ide/ide-activity-panel.test.ts src/components/ide/ide-shell.test.ts src/components/ide/ide-presence-strip.test.ts --no-file-parallelism --maxWorkers=1` (`13 files / 208 tests`)
- `bash scripts/check-dashboard-surface-parity.sh --check`
- `bash scripts/check-dashboard-nav-event-parity.sh --check`
- `git diff --check`
- Playwright screenshot smoke for `http://127.0.0.1:5173/dashboard/#code?section=ide-shell`

## Notes

- Targeted OCaml executable checks were attempted but not completed locally because the shared `dune-local` lock was held by other worktrees. The dashboard surface/nav parity scripts passed.