### PR TITLE
feat(keeper-supervisor): RFC-0109 P4 opt-in keeper max-turn watchdog (Draft)

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -454,6 +454,32 @@ module Approval_janitor = struct
     get_float ~default:60.0 "MASC_APPROVAL_JANITOR_INTERVAL_SEC"
 end
 
+(** {1 Keeper Max-Turn Watchdog (RFC-0109 P4)}
+
+    Opt-in keeper-level wall-clock watchdog. Default disabled — opt-in
+    via [MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC]. Backward-compat
+    until an operator turns it on.
+
+    When enabled, the supervisor races each keeper's keepalive loop
+    against [Eio.Time.sleep clock t] via [Eio.Fiber.first]. Timer
+    expiry cancels the loop fiber and the registry is stamped with
+    [Stale_turn_timeout "max_turn_watchdog"], which the existing
+    [sweep_and_recover] crash-recovery path already understands.
+
+    Closes the sangsu / masc-improver mid_turn_no_progress class of
+    stucks without touching the existing stale_turn_timeout fast path
+    (which only detects in-turn no-progress, not "stuck for too long
+    in a single attempt"). *)
+module Keeper_max_turn_watchdog = struct
+  let timeout_sec_opt () =
+    let v =
+      get_float
+        ~default:0.0
+        "MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC"
+    in
+    if v > 0.0 then Some v else None
+end
+
 (** {1 Slot Scheduling} *)
 
 module Slot = struct

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -216,6 +216,28 @@ module Approval_janitor : sig
   val interval_seconds : float
 end
 
+(** {1 Keeper max-turn watchdog (RFC-0109 P4)} *)
+
+module Keeper_max_turn_watchdog : sig
+  val timeout_sec_opt : unit -> float option
+  (** [timeout_sec_opt ()] returns the keeper-level max-turn wall-clock
+      budget when [MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC] is set to
+      a positive number, or [None] when the env var is unset / zero /
+      negative.
+
+      When [Some t] is returned, the supervisor races each keeper's
+      [Keeper_keepalive.run_heartbeat_loop] against
+      [Eio.Time.sleep ctx.clock t] via [Eio.Fiber.first]. Timer expiry
+      cancels the keepalive fiber and stamps [Stale_turn_timeout
+      "max_turn_watchdog"] on the registry so [sweep_and_recover]
+      restarts the keeper instead of treating the cancellation as a
+      clean stop.
+
+      Default: [None] (disabled). Recommended live value: [600.0]
+      (10 minutes). Set lower for aggressive sangsu-style stuck
+      recovery, higher for long-running research keepers. *)
+end
+
 (** {1 Slot scheduling} *)
 
 module Slot : sig

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -235,12 +235,51 @@ let launch_supervised_fiber
       Eio_guard.protect
         (fun () ->
            try
-             Keeper_keepalive.run_heartbeat_loop
-               ~proactive_warmup_sec
-               ctx
-               meta
-               reg.fiber_stop
-               ~wakeup:reg.fiber_wakeup;
+             (* RFC-0109 P4: opt-in keeper-level max-turn watchdog.
+                When [MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC] is set
+                to a positive float, race the keepalive loop against
+                [Eio.Time.sleep ctx.clock t] via [Eio.Fiber.first].
+                Timer expiry stamps
+                [Stale_turn_timeout (In_turn_hung ...)] BEFORE the
+                timer fiber returns so the existing watchdog_triggered
+                branch (below) treats the cancellation as a crash and
+                [sweep_and_recover] restarts the keeper. Default
+                disabled — opt-in. *)
+             (match
+                Env_config_runtime.Keeper_max_turn_watchdog.timeout_sec_opt
+                  ()
+              with
+              | None ->
+                Keeper_keepalive.run_heartbeat_loop
+                  ~proactive_warmup_sec
+                  ctx
+                  meta
+                  reg.fiber_stop
+                  ~wakeup:reg.fiber_wakeup
+              | Some timeout_s ->
+                Eio.Fiber.first
+                  (fun () ->
+                    Eio.Time.sleep ctx.clock timeout_s;
+                    Keeper_registry.set_failure_reason
+                      ~base_path
+                      meta.name
+                      (Some
+                         (Keeper_registry.Stale_turn_timeout
+                            (Keeper_registry_types.In_turn_hung
+                               { active_seconds = timeout_s
+                               ; timeout_threshold = timeout_s
+                               })));
+                    Log.Keeper.warn
+                      "%s: max-turn watchdog fired after %.1fs (RFC-0109 P4)"
+                      meta.name
+                      timeout_s)
+                  (fun () ->
+                    Keeper_keepalive.run_heartbeat_loop
+                      ~proactive_warmup_sec
+                      ctx
+                      meta
+                      reg.fiber_stop
+                      ~wakeup:reg.fiber_wakeup));
              (* Check if watchdog set a failure reason that should trigger
               crash recovery instead of a clean stop. When the stale
               watchdog sets fiber_stop + Stale_turn_timeout, the heartbeat


### PR DESCRIPTION
## Summary

RFC-0109 Phase 4 — opt-in keeper-level max-turn watchdog. Wraps `Keeper_keepalive.run_heartbeat_loop` in `Eio.Fiber.first` race against `Eio.Time.sleep` when `MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC` is set to a positive float.

### Closes the gap exposed 2026-05-17

| keeper | blocker |
|---|---|
| sangsu | `stale_turn_timeout(mid_turn_no_progress active=312s since_progress=307s threshold=300s last=cascade_state)` |
| masc-improver | `oas_timeout_budget(budget_sec=276.85 source=adaptive_wall_clock_retry)` |

The existing `stale_turn_timeout` watchdog only catches *in-turn no-progress* above its 300s threshold. The orthogonal class — "stuck for too long across multiple turn attempts" — has no protector. This PR adds the missing layer.

### Behavior

```
match Env_config_runtime.Keeper_max_turn_watchdog.timeout_sec_opt () with
| None ->
  Keeper_keepalive.run_heartbeat_loop ...   (* existing path verbatim *)
| Some timeout_s ->
  Eio.Fiber.first
    (fun () ->
      Eio.Time.sleep ctx.clock timeout_s;
      Keeper_registry.set_failure_reason ~base_path meta.name
        (Some (Keeper_registry.Stale_turn_timeout
                 (Keeper_registry_types.In_turn_hung
                    { active_seconds = timeout_s
                    ; timeout_threshold = timeout_s })));
      Log.Keeper.warn \"%s: max-turn watchdog fired after %.1fs (RFC-0109 P4)\" meta.name timeout_s)
    (fun () -> Keeper_keepalive.run_heartbeat_loop ...)
```

When the timer wins:
1. Stamp `Stale_turn_timeout (In_turn_hung ...)` on the registry BEFORE returning.
2. Log warn line with the elapsed budget.
3. Race returns → keepalive fiber receives Cancel.
4. The supervisor's existing `watchdog_triggered` branch at line 254-272 reads `last_failure_reason = Some (Stale_turn_timeout _)` and dispatches `Fiber_terminated` → `sweep_and_recover`'s Crashed branch → restart.

### Why opt-in by default

`MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC` unset → `None` → existing path verbatim. Zero behavioral change for the fleet today. An operator enables per-environment after observing the fleet's natural turn-budget distribution.

Recommended live value: `600.0` (10 min). Lower for aggressive recovery, higher for long-running research keepers.

### Why reuse `Stale_turn_timeout (In_turn_hung ...)`

The existing watchdog branch (line 254-272) and the registry consumers are already exhaustive over `stale_kill_class`. Adding a new variant `Max_turn_watchdog` would require N-of-M migration across every consumer site. Reusing `In_turn_hung` preserves the type-driven exhaustiveness, while `failure_reason_to_string` already surfaces the `active_seconds`/`timeout_threshold` for diagnosis (memory: `feedback_exhaustive_match_sweep_type_plus_arm`).

### Files

| File | Change |
|---|---|
| `lib/config/env_config_runtime.mli` | +20 LoC — `module Keeper_max_turn_watchdog : sig val timeout_sec_opt : unit -> float option end` |
| `lib/config/env_config_runtime.ml`  | +22 LoC — `let timeout_sec_opt () = let v = get_float ~default:0.0 \"...\" in if v > 0.0 then Some v else None` |
| `lib/keeper/keeper_supervisor.ml` | +45 / -6 LoC — wraps line 237-243 keepalive call in opt-in race |

Total: ~93 LoC.

### Build / fmt

- `dune build --root . lib/config lib/keeper` PASS
- `dune build @fmt` PASS for the 3 modified files (no diff)

### Workaround signature self-check (RFC-0109 §7)

| Signature | Match? |
|---|---|
| Counter-as-fix | No — actively interrupts the stuck loop AND triggers restart |
| String classifier | No |
| N-of-M | No — single edit at the supervisor boundary; reuses existing `stale_kill_class` variant |
| Cap/cooldown/dedup/repair | Borderline — *bounded scope* is the canonical Eio idiom (RFC §3 quote); not a cap on retries or carrier value. The wall-clock budget is the only knob, sourced from a typed env getter |
| Test backdoor | No |

### Test plan

- [x] `dune build --root . lib/config lib/keeper` PASS
- [ ] Reviewer: confirm `Stale_turn_timeout (In_turn_hung ...)` reuse is appropriate (vs. adding a new variant)
- [ ] Reviewer: confirm `Keeper_registry.set_failure_reason` before the timer fiber returns is the right ordering (must precede the body's `watchdog_triggered` check)
- [ ] Reviewer: confirm `Log.Keeper.warn` format string matches the project's keeper log conventions
- [ ] Soak test: enable on a single keeper (e.g. `sangsu`) at `MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC=600`; observe `metric_keeper_oas_timeout_budget_watchdog_termination` trend + `stale_turn_timeout` event count

### Cross-references

- RFC body: `docs/rfc/RFC-0109-bounded-subprocess-discipline.md` §4.2 P4 (#15940)
- P0 helper: #15948 (`Bounded_proc.run_argv_with_timeout`)
- P1 ratchet: #15958 (CI lint for `Eio.Process.spawn` sites)
- P5 deprecation: deferred — `force_release_holder_for` removal after 30-day metric soak on `metric_keeper_oas_timeout_budget_watchdog_termination`

RFC-WAIVED: `lib/config/` + `lib/keeper/keeper_supervisor.ml` not in the agent_delegation RFC-required subsystem list. RFC-0109 (#15940) covers design rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)