### PR TITLE
feat(masc_http_client): RFC-0107 Phase D.2b+D.2c — piaf pool + migration shim (13 callsites unchanged)

### DIFF
--- a/bin/main_stdio_eio.ml
+++ b/bin/main_stdio_eio.ml
@@ -26,7 +26,7 @@ let run_cmd base_path =
   let state, _remaining_work =
     Gc.ramp_up (fun () ->
       Server_runtime_bootstrap.create_server_state ~sw ~base_path ~clock
-        ~mono_clock ~net ~proc_mgr ~fs)
+        ~mono_clock ~net ~proc_mgr ~fs ~env ())
   in
   Server_runtime_bootstrap.bootstrap_server_state_blocking state;
   ignore (Server_bootstrap_loops.start_background_maintenance ~sw ~clock ~env state);

--- a/dune-project
+++ b/dune-project
@@ -43,6 +43,15 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
+  ; RFC-0107 Phase D — pooled keep-alive HTTP transport. piaf provides
+  ; per-endpoint persistent client (Client.t) + h1/h2 + Eio integration;
+  ; multi-host pool layer (Host_key map, idle eviction, TLS cache) is
+  ; built on top in lib/masc_http_client/pool.ml.  macOS install needs
+  ; brew openssl@3 + CPATH=/opt/homebrew/opt/openssl@3/include
+  ; LIBRARY_PATH=/opt/homebrew/opt/openssl@3/lib environment overrides
+  ; (upstream piaf 0.2.0 missing conf-libssl dependency on macOS arm64).
+  (piaf (>= 0.2.0))
+  (eio-ssl (>= 0.3.0))
   (agent_sdk (>= 0.195.0))
   (uri (>= 4.4))
   (tls (>= 2.0))

--- a/lib/eio_context/dune
+++ b/lib/eio_context/dune
@@ -6,4 +6,4 @@
  (modules eio_context)
  ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 enabled. Leaf util sublib.
  (flags (:standard -w +4))
- (libraries eio uri masc_log ca-certs tls tls-eio domain-name))
+ (libraries eio eio.unix uri masc_log ca-certs tls tls-eio domain-name))

--- a/lib/eio_context/eio_context.ml
+++ b/lib/eio_context/eio_context.ml
@@ -20,6 +20,12 @@ let current_net : eio_net option Atomic.t = Atomic.make None
 let current_clock : float Eio.Time.clock_ty Eio.Resource.t option Atomic.t = Atomic.make None
 let current_mono_clock : Eio.Time.Mono.ty Eio.Resource.t option Atomic.t = Atomic.make None
 let current_sw : Eio.Switch.t option Atomic.t = Atomic.make None
+(* RFC-0107 Phase D.2c — full Eio standard environment, required by
+   piaf [Client.create] (and any other API needing more than just
+   [net]/[clock]).  Set once at server bootstrap; read by long-lived
+   consumers like [Masc_http_client] that initialize their per-process
+   [Pool.t] lazily.  Same WORM atomic pattern as the other fields. *)
+let current_env : Eio_unix.Stdenv.base option Atomic.t = Atomic.make None
 let net_initialized : bool Atomic.t = Atomic.make false
 let with_test_env_lock = Eio.Mutex.create ()
 
@@ -70,6 +76,12 @@ let get_mono_clock_opt () =
 
 let set_switch sw =
   Atomic.set current_sw (Some sw)
+
+let set_env env =
+  Atomic.set current_env (Some env)
+
+let get_env_opt () : Eio_unix.Stdenv.base option =
+  Atomic.get current_env
 
 (* RFC-0107 §3.3 wiring — bind a turn-scoped switch on the *current fiber*
    (and all children forked inside [f]). On exit the binding is removed,

--- a/lib/eio_context/eio_context.mli
+++ b/lib/eio_context/eio_context.mli
@@ -24,6 +24,19 @@ val set_switch : Eio.Switch.t -> unit
 (** Set the global Eio switch (server root_sw). Written once at server
     bootstrap; survives until process exit. *)
 
+val set_env : Eio_unix.Stdenv.base -> unit
+(** Set the global Eio standard environment.  Required by long-lived
+    consumers that need more than [net]/[clock] (e.g. piaf
+    [Client.create] in [Masc_http_client.Pool]).  Written once at
+    server bootstrap. *)
+
+val get_env_opt : unit -> Eio_unix.Stdenv.base option
+(** Get the Eio standard environment if available.  Returns [None]
+    before [set_env] is called (test setup before [Eio_main.run] or
+    pre-bootstrap helper code).  Callers that need [env] must handle
+    this gracefully — see [Masc_http_client] for the lazy-init
+    pattern. *)
+
 val with_turn_switch : Eio.Switch.t -> (unit -> 'a) -> 'a
 (** [with_turn_switch sw f] binds [sw] as the turn-scoped switch on the
     *current fiber* and any fibers forked from inside [f]. Reads of

--- a/lib/masc_http_client/dune
+++ b/lib/masc_http_client/dune
@@ -4,4 +4,4 @@
  (public_name masc_mcp.http_client)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags (:standard -w +4))
- (libraries eio eio.unix cstruct cohttp cohttp-eio uri piaf))
+ (libraries eio eio.unix cstruct cohttp cohttp-eio uri piaf masc_mcp.masc_eio_context))

--- a/lib/masc_http_client/dune
+++ b/lib/masc_http_client/dune
@@ -4,4 +4,4 @@
  (public_name masc_mcp.http_client)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags (:standard -w +4))
- (libraries eio eio.unix cstruct cohttp cohttp-eio uri))
+ (libraries eio eio.unix cstruct cohttp cohttp-eio uri piaf))

--- a/lib/masc_http_client/masc_http_client.ml
+++ b/lib/masc_http_client/masc_http_client.ml
@@ -104,87 +104,63 @@ let with_optional_timeout ?clock ?timeout_sec f =
           Error (Printf.sprintf "timeout after %.1fs" timeout_sec))
   | _ -> f ()
 
-let post_sync ?clock ?timeout_sec ~net ?(https = None) ~url ~headers ~body () =
+(* ── Pool singleton ─────────────────────────────────────────────────
+
+   RFC-0107 Phase D.2c — the per-process [Pool.t] is lazy-initialized
+   on first use, reading [sw] and [env] from [Eio_context].  This
+   keeps the existing [post_sync] / [get_sync] / [get_response_sync]
+   signatures stable: 13 callsites in lib/ continue to pass [~net]
+   and optionally [?https], but those are now ignored (pool owns the
+   transport).  Once D.2c bis migrates [voice_bridge_core] +
+   [opentelemetry_client_cohttp_eio] off [make_closing_client],
+   [~net] and [~https] can be dropped from the public mli (planned
+   for D.2c.2 follow-up). *)
+let pool_ref : Pool.t option ref = ref None
+let pool_mu = Eio.Mutex.create ()
+
+let pool_init_error () =
+  Error
+    "masc_http_client: Eio_context.set_env not called — \
+     RFC-0107 Phase D pool cannot be initialized.  This indicates a \
+     bootstrap-order bug (Pool.request from before \
+     Server_runtime_bootstrap.create_server_state)."
+
+let with_pool f =
+  match !pool_ref with
+  | Some p -> f p
+  | None ->
+    Eio.Mutex.use_rw ~protect:false pool_mu (fun () ->
+      match !pool_ref with
+      | Some p -> f p
+      | None ->
+        (match Eio_context.get_switch_opt (), Eio_context.get_env_opt () with
+         | Some sw, Some env ->
+           let p = Pool.create ~sw ~env () in
+           pool_ref := Some p;
+           f p
+         | _ -> pool_init_error ()))
+
+let post_sync ?clock ?timeout_sec ~net:_ ?https:_ ~url ~headers ~body () =
   with_optional_timeout ?clock ?timeout_sec @@ fun () ->
-  try
-    Eio.Switch.run @@ fun sw ->
-    let client = make_closing_client ~sw ~net ~https in
-    let uri = Uri.of_string url in
-    let hdr =
-      Cohttp.Header.of_list (("connection", "close") :: headers)
-    in
-    let body_content = Eio.Flow.string_source body in
-    let resp, resp_body =
-      Cohttp_eio.Client.post client ~sw uri ~headers:hdr ~body:body_content
-    in
-    let code =
-      Cohttp.Response.status resp |> Cohttp.Code.code_of_status
-    in
-    let body_str =
-      let max_size = 8 * 1024 * 1024 in
-      let buf = Buffer.create 4096 in
-      let chunk = Cstruct.create 4096 in
-      let rec read_chunks () =
-        if Buffer.length buf > max_size then
-          raise (Failure (Printf.sprintf "masc_http_client: body size exceeds %d MB" (max_size / 1024 / 1024)))
-        else
-          match Eio.Flow.single_read resp_body chunk with
-          | n ->
-            Buffer.add_string buf (Cstruct.to_string ~off:0 ~len:n chunk);
-            Eio.Fiber.yield ();
-            read_chunks ()
-          | exception End_of_file -> Buffer.contents buf
-      in
-      read_chunks ()
-    in
-    Ok (code, body_str)
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn -> Error (Printexc.to_string exn)
+  with_pool @@ fun pool ->
+  match Pool.request pool ?clock ?timeout_seconds:timeout_sec
+          ~method_:`POST ~url ~headers ~body () with
+  | Ok { Pool.status; body; _ } -> Ok (status, body)
+  | Error e -> Error e
 
 (** GET with structured error handling. *)
-let get_response_sync ?clock ?timeout_sec ~net ?(https = None) ~url ~headers () =
+let get_response_sync ?clock ?timeout_sec ~net:_ ?https:_ ~url ~headers () =
   with_optional_timeout ?clock ?timeout_sec @@ fun () ->
-  try
-    Eio.Switch.run @@ fun sw ->
-    let client = make_closing_client ~sw ~net ~https in
-    let uri = Uri.of_string url in
-    let hdr =
-      Cohttp.Header.of_list (("connection", "close") :: headers)
-    in
-    let resp, resp_body =
-      Cohttp_eio.Client.get client ~sw ~headers:hdr uri
-    in
-    let code =
-      Cohttp.Response.status resp |> Cohttp.Code.code_of_status
-    in
-    let response_headers =
-      Cohttp.Response.headers resp |> Cohttp.Header.to_list
-    in
-    let body_str =
-      let max_size = 8 * 1024 * 1024 in
-      let buf = Buffer.create 4096 in
-      let chunk = Cstruct.create 4096 in
-      let rec read_chunks () =
-        if Buffer.length buf > max_size then
-          raise (Failure (Printf.sprintf "masc_http_client: body size exceeds %d MB" (max_size / 1024 / 1024)))
-        else
-          match Eio.Flow.single_read resp_body chunk with
-          | n ->
-            Buffer.add_string buf (Cstruct.to_string ~off:0 ~len:n chunk);
-            Eio.Fiber.yield ();
-            read_chunks ()
-          | exception End_of_file -> Buffer.contents buf
-      in
-      read_chunks ()
-    in
-    Ok { status = code; headers = response_headers; body = body_str }
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn -> Error (Printexc.to_string exn)
+  with_pool @@ fun pool ->
+  match Pool.request pool ?clock ?timeout_seconds:timeout_sec
+          ~method_:`GET ~url ~headers () with
+  | Ok { Pool.status; headers; body } ->
+    Ok { status; headers; body }
+  | Error e -> Error e
 
 (** GET with structured error handling. *)
-let get_sync ?clock ?timeout_sec ~net ?(https = None) ~url ~headers () =
-  match get_response_sync ?clock ?timeout_sec ~net ~https ~url ~headers () with
+let get_sync ?clock ?timeout_sec ~net ?https ~url ~headers () =
+  match get_response_sync ?clock ?timeout_sec ~net ?https ~url ~headers ()
+  with
   | Ok response -> Ok (response.status, response.body)
   | Error _ as error -> error

--- a/lib/masc_http_client/pool.ml
+++ b/lib/masc_http_client/pool.ml
@@ -321,7 +321,9 @@ let do_request t ?headers ?body ~method_ uri : (response, string) result =
          Ok { status; headers = headers_list; body = body_str })
 
 (* Optional wall-clock timeout race; mirrors masc_http_client pattern. *)
-let with_optional_timeout ?clock ?timeout_seconds f =
+let with_optional_timeout
+    (type a) ?clock ?timeout_seconds (f : unit -> (a, string) result) :
+  (a, string) result =
   match clock, timeout_seconds with
   | Some clock, Some t when t > 0.0 ->
     Eio.Fiber.first
@@ -331,7 +333,8 @@ let with_optional_timeout ?clock ?timeout_seconds f =
          Error (Printf.sprintf "Pool.request: timeout after %.1fs" t))
   | _ -> f ()
 
-let request t ?clock ?timeout_seconds ~method_ ~url ?headers ?body () =
+let request t ?(clock : [> float Eio.Time.clock_ty ] Eio.Resource.t option)
+    ?timeout_seconds ~method_ ~url ?headers ?body () =
   with_optional_timeout ?clock ?timeout_seconds @@ fun () ->
   let uri = Uri.of_string url in
   do_request t ?headers ?body ~method_ uri

--- a/lib/masc_http_client/pool.ml
+++ b/lib/masc_http_client/pool.ml
@@ -1,14 +1,24 @@
-(** RFC-0107 Phase D Connection Pool — implementation stub.
+(** RFC-0107 Phase D Connection Pool — piaf-backed implementation.
 
-    Phase D.2a places the type-correct stub so that downstream callers
-    (Phase D.2c migration shim, Phase D.2d tests) can compile against
-    the [Pool.t] / [Pool.request] / [Pool.with_connection] surface
-    before the piaf binding lands in D.2b.
+    Design constraints from RFC-0107 Phase D design note and Phase B
+    Prior Art research:
 
-    All public functions raise [Failure] until D.2b. The intent is to
-    fail fast and loud at runtime so a "stub-call-from-prod" cannot go
-    unnoticed; type-only consumers (modules that take a [Pool.t] in
-    function signatures without invoking it) build clean. *)
+    - piaf [Client.t] is per-endpoint (single host). Multi-host pool
+      ([Host_key -> queue]) is built here.
+    - Pool itself is process-lifetime, attached to a long-lived
+      [Eio.Switch] (typically server root_sw).
+    - Callback API ([request] / [with_connection]) over naked
+      acquire/release for type-level leak resistance (Eio #244
+      exactly-one-owner principle).
+    - No silent retry — caller decides. (RFC-0107 §"Workaround
+      Rejection Bar" anti-pattern.)
+
+    Sub-modules:
+    - [Host_key]: pure host identity (scheme, host, port) — pool key.
+    - [Idle_entry]: idle piaf [Client.t] + last_used timestamp.
+    - [Stats]: monotonically increasing counters for telemetry. *)
+
+(* ── Config ────────────────────────────────────────────────────── *)
 
 type config = {
   max_idle_per_host : int;
@@ -24,20 +34,221 @@ let default_config = {
   connect_timeout_seconds = 5.0;
 }
 
-(* Phase D.2b fills in the actual fields (Host_key -> piaf Client.t
-   queue, TLS context cache, eviction fiber stop signal, stats
-   counters). The current type body is deliberately empty so any
-   accidental field access fails at compile time. *)
-type t = unit
+(* ── Host_key ──────────────────────────────────────────────────── *)
 
-let stub_msg fn =
-  Failure
-    (Printf.sprintf
-       "Pool.%s: not implemented (RFC-0107 Phase D.2a stub; \
-        binding lands in D.2b)" fn)
+module Host_key = struct
+  type t = {
+    scheme : string;   (* "http" | "https" *)
+    host   : string;
+    port   : int;
+  }
 
-let create ~sw:_ ~net:_ ?https:_ ?config:_ () : t =
-  raise (stub_msg "create")
+  let compare a b =
+    match String.compare a.scheme b.scheme with
+    | 0 -> (match String.compare a.host b.host with
+            | 0 -> Int.compare a.port b.port
+            | n -> n)
+    | n -> n
+
+  let to_string k = Printf.sprintf "%s://%s:%d" k.scheme k.host k.port
+
+  let default_port = function "https" -> 443 | _ -> 80
+
+  let of_uri uri =
+    let scheme = Uri.scheme uri |> Option.value ~default:"http" in
+    let host = Uri.host uri |> Option.value ~default:"localhost" in
+    let port = Uri.port uri |> Option.value ~default:(default_port scheme) in
+    { scheme; host; port }
+end
+
+module Host_map = Map.Make (Host_key)
+
+(* ── Idle entry ────────────────────────────────────────────────── *)
+
+(* A reusable piaf Client.t parked on the pool's switch.  Each entry
+   carries its [last_used_ts] so the eviction fiber can age it out
+   after [idle_ttl_seconds].
+
+   piaf Client.t internals manage the underlying TCP/TLS socket and
+   are bound to the user-supplied [sw].  Because we create clients on
+   the pool's long-lived switch, parked entries survive turn
+   boundaries (RFC-0107 §3.3 hierarchy). *)
+type idle_entry = {
+  client      : Piaf.Client.t;
+  last_used_ts : float;
+}
+
+(* ── Stats counters (mutable refs) ─────────────────────────────── *)
+
+type stats_counters = {
+  mutable reuse_count_total  : int;
+  mutable evict_count_total  : int;
+  mutable create_count_total : int;
+  mutable inflight           : int;
+}
+
+let new_counters () =
+  { reuse_count_total = 0;
+    evict_count_total = 0;
+    create_count_total = 0;
+    inflight = 0; }
+
+(* ── Pool state ────────────────────────────────────────────────── *)
+
+(* [idle] is a per-host queue of reusable clients, newest-first (push
+   at head on release, pop from head on acquire — LIFO favors warmest
+   socket).  Protected by [mu] for race-free reads/writes from
+   multiple fibers.  [mu] is [Eio.Mutex] (poison-on-exception),
+   non-reentrant; we never call user callbacks while holding it. *)
+type t = {
+  sw       : Eio.Switch.t;
+  env      : Eio_unix.Stdenv.base;
+  config   : config;
+  mu       : Eio.Mutex.t;
+  mutable idle : idle_entry list Host_map.t;
+  stop     : bool Atomic.t;
+  counters : stats_counters;
+}
+
+(* Mutex-guarded read/write helpers.
+
+   We must NOT hold [mu] while calling piaf (network IO, may sleep).
+   Pattern: pick idle entry under lock → release lock → use entry. *)
+let with_mu t f =
+  Eio.Mutex.use_rw ~protect:false t.mu f
+
+(* ── Idle eviction fiber ───────────────────────────────────────── *)
+
+let evict_expired_entries t now =
+  with_mu t (fun () ->
+    let evicted_clients = ref [] in
+    let remaining =
+      Host_map.map (fun entries ->
+        List.filter (fun e ->
+          if now -. e.last_used_ts > t.config.idle_ttl_seconds
+          then begin
+            evicted_clients := e.client :: !evicted_clients;
+            t.counters.evict_count_total <- t.counters.evict_count_total + 1;
+            false
+          end else true
+        ) entries
+      ) t.idle
+    in
+    t.idle <- remaining;
+    !evicted_clients)
+  |> List.iter (fun c ->
+       try Piaf.Client.shutdown c
+       with _ -> () (* shutdown is best-effort; pool already dropped the ref *))
+
+let start_eviction_fiber t =
+  Eio.Fiber.fork ~sw:t.sw (fun () ->
+    let clock = Eio.Stdenv.clock t.env in
+    let rec loop () =
+      if Atomic.get t.stop then ()
+      else begin
+        Eio.Time.sleep clock (t.config.idle_ttl_seconds /. 2.0);
+        let now = Eio.Time.now clock in
+        (try evict_expired_entries t now
+         with _ -> ());
+        loop ()
+      end
+    in
+    loop ())
+
+(* ── create / shutdown ─────────────────────────────────────────── *)
+
+let create ~sw ~env ?(config = default_config) () : t =
+  let t = {
+    sw;
+    env;
+    config;
+    mu = Eio.Mutex.create ();
+    idle = Host_map.empty;
+    stop = Atomic.make false;
+    counters = new_counters ();
+  } in
+  (* Pool teardown: stop eviction fiber + close all idle clients on
+     switch release. In-flight requests outlive this via per-call
+     sub-switches. *)
+  Eio.Switch.on_release sw (fun () ->
+    Atomic.set t.stop true;
+    (* Snapshot+clear under lock; close outside lock. *)
+    let leftover =
+      with_mu t (fun () ->
+        let all = Host_map.fold
+                    (fun _ entries acc -> entries @ acc)
+                    t.idle []
+        in
+        t.idle <- Host_map.empty;
+        all)
+    in
+    List.iter (fun e ->
+      try Piaf.Client.shutdown e.client with _ -> ()
+    ) leftover);
+  start_eviction_fiber t;
+  t
+
+(* ── acquire / release ─────────────────────────────────────────── *)
+
+(* Try to take a warm client for [key]; returns [None] if the host's
+   queue is empty.  No network IO. *)
+let try_acquire_idle t key =
+  with_mu t (fun () ->
+    match Host_map.find_opt key t.idle with
+    | None | Some [] -> None
+    | Some (e :: rest) ->
+      let updated = if rest = [] then Host_map.remove key t.idle
+                    else Host_map.add key rest t.idle in
+      t.idle <- updated;
+      t.counters.reuse_count_total <- t.counters.reuse_count_total + 1;
+      Some e.client)
+
+(* Build a fresh piaf client.  Returns [Result] mirroring piaf's API
+   so callers can surface DNS/TCP/TLS failures distinctly. *)
+let create_fresh t uri =
+  match Piaf.Client.create ~sw:t.sw t.env uri with
+  | Ok c ->
+    t.counters.create_count_total <- t.counters.create_count_total + 1;
+    Ok c
+  | Error err ->
+    Error (Piaf.Error.to_string (err :> Piaf.Error.t))
+
+(* Count idle entries (host_map -> int). For [max_total_idle]. *)
+let count_idle t =
+  with_mu t (fun () ->
+    Host_map.fold (fun _ entries acc -> List.length entries + acc) t.idle 0)
+
+(* Park a client back into the pool, or close it if the pool is full
+   or marked stopped.  [close_only] forces close (used when the
+   request errored mid-flight and the connection is suspect). *)
+let release t key client ~close_only =
+  let now =
+    try Eio.Time.now (Eio.Stdenv.clock t.env)
+    with _ -> 0.0  (* if clock is gone we're tearing down anyway *)
+  in
+  let should_park =
+    not close_only
+    && not (Atomic.get t.stop)
+    && count_idle t < t.config.max_total_idle
+  in
+  if should_park then begin
+    let parked = ref false in
+    with_mu t (fun () ->
+      let existing = Host_map.find_opt key t.idle |> Option.value ~default:[] in
+      if List.length existing < t.config.max_idle_per_host then begin
+        let entry = { client; last_used_ts = now } in
+        t.idle <- Host_map.add key (entry :: existing) t.idle;
+        parked := true
+      end);
+    if not !parked then begin
+      (try Piaf.Client.shutdown client with _ -> ());
+      with_mu t (fun () ->
+        t.counters.evict_count_total <- t.counters.evict_count_total + 1)
+    end
+  end else
+    try Piaf.Client.shutdown client with _ -> ()
+
+(* ── Public request API ────────────────────────────────────────── *)
 
 type response = {
   status : int;
@@ -47,12 +258,93 @@ type response = {
 
 type http_method = [ `GET | `POST | `PUT | `DELETE | `HEAD | `PATCH ]
 
-let request _t ?clock:_ ?timeout_seconds:_ ~method_:_ ~url:_
-            ?headers:_ ?body:_ () : (response, string) result =
-  raise (stub_msg "request")
+let method_to_piaf : http_method -> Piaf.Method.t = function
+  | `GET    -> `GET
+  | `POST   -> `POST
+  | `PUT    -> `PUT
+  | `DELETE -> `DELETE
+  | `HEAD   -> `HEAD
+  | `PATCH  -> `Other "PATCH"
+
+let path_and_query uri =
+  let p = Uri.path uri in
+  let p = if p = "" then "/" else p in
+  match Uri.query uri with
+  | [] -> p
+  | _ -> p ^ "?" ^ Uri.encoded_of_query (Uri.query uri)
+
+(* Wrap a single request: acquire-or-create client, send, release.
+   Errors return [Error string]; the connection is dropped (close)
+   on error, parked on success. *)
+let do_request t ?headers ?body ~method_ uri : (response, string) result =
+  let key = Host_key.of_uri uri in
+  let host_origin = Uri.with_uri ~path:(Some "") ~query:None uri in
+  let acquired =
+    match try_acquire_idle t key with
+    | Some c -> Ok (c, `Reused)
+    | None ->
+      (match create_fresh t host_origin with
+       | Ok c -> Ok (c, `Fresh)
+       | Error e -> Error e)
+  in
+  match acquired with
+  | Error e -> Error e
+  | Ok (client, origin) ->
+    let path = path_and_query uri in
+    let body_piaf = Option.map Piaf.Body.of_string body in
+    t.counters.inflight <- t.counters.inflight + 1;
+    let result =
+      try
+        Piaf.Client.request client ?headers ?body:body_piaf
+          ~meth:(method_to_piaf method_) path
+      with exn -> Error (`Msg (Printexc.to_string exn))
+    in
+    t.counters.inflight <- t.counters.inflight - 1;
+    match result with
+    | Error err ->
+      (* Connection is suspect; close, do not park. *)
+      release t key client ~close_only:true;
+      let _ = origin in
+      Error (Piaf.Error.to_string (err :> Piaf.Error.t))
+    | Ok resp ->
+      let status = Piaf.Status.to_code (Piaf.Response.status resp) in
+      let headers_list =
+        Piaf.Response.headers resp |> Piaf.Headers.to_list
+      in
+      let body_result = Piaf.Body.to_string (Piaf.Response.body resp) in
+      (match body_result with
+       | Error err ->
+         release t key client ~close_only:true;
+         Error (Piaf.Error.to_string (err :> Piaf.Error.t))
+       | Ok body_str ->
+         release t key client ~close_only:false;
+         Ok { status; headers = headers_list; body = body_str })
+
+(* Optional wall-clock timeout race; mirrors masc_http_client pattern. *)
+let with_optional_timeout ?clock ?timeout_seconds f =
+  match clock, timeout_seconds with
+  | Some clock, Some t when t > 0.0 ->
+    Eio.Fiber.first
+      (fun () -> f ())
+      (fun () ->
+         Eio.Time.sleep clock t;
+         Error (Printf.sprintf "Pool.request: timeout after %.1fs" t))
+  | _ -> f ()
+
+let request t ?clock ?timeout_seconds ~method_ ~url ?headers ?body () =
+  with_optional_timeout ?clock ?timeout_seconds @@ fun () ->
+  let uri = Uri.of_string url in
+  do_request t ?headers ?body ~method_ uri
 
 let with_connection _t ~url:_ _f =
-  raise (stub_msg "with_connection")
+  (* Phase D.2c: streaming voice_bridge migration uses this.  For now
+     stub raises so that any accidental caller fails loudly; the
+     non-streaming [request] is the supported surface in D.2b. *)
+  raise (Failure "Pool.with_connection: not yet implemented \
+                  (RFC-0107 Phase D.2c — streaming voice_bridge \
+                  migration)")
+
+(* ── Stats ─────────────────────────────────────────────────────── *)
 
 type stats = {
   idle_per_host : (string * int) list;
@@ -63,5 +355,18 @@ type stats = {
   create_count_total : int;
 }
 
-let stats _t : stats =
-  raise (stub_msg "stats")
+let stats t : stats =
+  with_mu t (fun () ->
+    let idle_per_host =
+      Host_map.bindings t.idle
+      |> List.map (fun (k, v) -> Host_key.to_string k, List.length v)
+    in
+    let total_idle =
+      List.fold_left (fun acc (_, n) -> acc + n) 0 idle_per_host
+    in
+    { idle_per_host;
+      total_idle;
+      total_inflight = t.counters.inflight;
+      reuse_count_total = t.counters.reuse_count_total;
+      evict_count_total = t.counters.evict_count_total;
+      create_count_total = t.counters.create_count_total; })

--- a/lib/masc_http_client/pool.mli
+++ b/lib/masc_http_client/pool.mli
@@ -78,7 +78,7 @@ type http_method = [ `GET | `POST | `PUT | `DELETE | `HEAD | `PATCH ]
 
 val request :
   t ->
-  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   ?timeout_seconds:float ->
   method_:http_method ->
   url:string ->

--- a/lib/masc_http_client/pool.mli
+++ b/lib/masc_http_client/pool.mli
@@ -52,17 +52,17 @@ val default_config : config
 
 val create :
   sw:Eio.Switch.t ->
-  net:[> `Generic ] Eio.Net.ty Eio.Resource.t ->
-  ?https:
-    (Uri.t ->
-     [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t ->
-     [ `Close | `Flow | `R | `Shutdown | `Tls | `W ] Eio.Resource.t) ->
+  env:Eio_unix.Stdenv.base ->
   ?config:config ->
   unit ->
   t
 (** Initialize the pool on a long-lived switch (server root_sw). Idle
     connections close when [sw] closes; in-flight requests outlive
-    pool cleanup via per-call sub-switches. *)
+    pool cleanup via per-call sub-switches.
+
+    [env] is the full Eio standard environment, required by the piaf
+    transport (h1/h2 client creation). The pool keeps a reference and
+    issues [Piaf.Client.create ~sw env uri] internally on cache miss. *)
 
 (* ── Request API ───────────────────────────────────────────────── *)
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -249,6 +249,7 @@ let record_tool_policy_init_failure ~base_path msg =
   Log.Server.error "Fatal tool policy config load failure: %s" msg
 
 let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
+    ?env ()
     : Mcp_server.server_state =
   let input_base_path =
     match String.trim base_path with
@@ -263,6 +264,11 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   Eio_context.set_net net;
   Eio_context.set_clock clock;
   Eio_context.set_mono_clock mono_clock;
+  (* RFC-0107 Phase D.2c — record full Eio.Stdenv for piaf-backed
+     Pool in Masc_http_client.  Optional: tests / pre-bootstrap
+     callers may omit [env], in which case Pool falls back to a
+     stub (request returns Error). *)
+  Option.iter Eio_context.set_env env;
   force_jsonl_fallback_env ();
   ensure_default_oas_cascade_timeout_env ();
   Process_eio.init ~cwd_default:Eio.Path.(fs / base_path) ~proc_mgr ~clock;
@@ -1468,7 +1474,8 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       Agent_sdk_log_bridge.install ();
       Log.Server.info "Agent_sdk_log_bridge installed (agent_sdk.Log -> masc structured log)";
       let state =
-        create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
+        create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr
+          ~fs ~env ()
       in
       let format_catalog_validation_error label rejection =
         Printf.sprintf

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -43,7 +43,15 @@ val create_server_state :
   net:[> `Generic | `Unix] Eio.Net.ty Eio.Resource.t ->
   proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t ->
   fs:Eio.Fs.dir_ty Eio.Path.t ->
+  ?env:Eio_unix.Stdenv.base ->
+  unit ->
   Mcp_server.server_state
+(** [env] is optional for backwards compatibility with existing
+    [create_server_state] callers (tests, MCP execute contexts);
+    when supplied (server bootstrap path), it is recorded into
+    [Eio_context.set_env] so long-lived HTTP consumers like
+    [Masc_http_client.Pool] can lazy-init with the full
+    {!Eio_unix.Stdenv.base}.  RFC-0107 Phase D.2c. *)
 
 val runtime_path_diagnostics :
   ?input_base_path:string ->

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -25,6 +25,8 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
+  "piaf" {>= "0.2.0"}
+  "eio-ssl" {>= "0.3.0"}
   "agent_sdk" {>= "0.195.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1570,7 +1570,7 @@ let test_create_server_state_records_runtime_resolution () =
       Server_startup_state.reset ~backend_mode:"filesystem" ();
       ignore
         (Server_runtime_bootstrap.create_server_state ~sw ~base_path:dir ~clock
-           ~mono_clock ~net ~proc_mgr ~fs);
+           ~mono_clock ~net ~proc_mgr ~fs ());
       let json = Server_startup_state.to_yojson () in
       let open Yojson.Safe.Util in
       Alcotest.(check string) "create_server_state records config root"
@@ -1607,7 +1607,7 @@ let test_create_server_state_preserves_raw_input_base_path () =
       Server_startup_state.reset ~backend_mode:"filesystem" ();
       ignore
         (Server_runtime_bootstrap.create_server_state ~sw ~base_path:raw_input
-           ~clock ~mono_clock ~net ~proc_mgr ~fs);
+           ~clock ~mono_clock ~net ~proc_mgr ~fs ());
       let json = Server_startup_state.to_yojson () in
       let open Yojson.Safe.Util in
       Alcotest.(check string) "raw input base path preserved in diagnostics"
@@ -2156,7 +2156,7 @@ let test_sync_bootable_keeper_credentials_mints_keeper_alias_token () =
       Eio.Switch.run @@ fun sw ->
       let state =
         Server_runtime_bootstrap.create_server_state ~sw ~base_path:dir ~clock
-          ~mono_clock ~net ~proc_mgr ~fs
+          ~mono_clock ~net ~proc_mgr ~fs ()
       in
       Server_runtime_bootstrap.bootstrap_server_state_blocking state;
       Server_runtime_bootstrap.sync_bootable_keeper_credentials state;
@@ -2227,7 +2227,7 @@ let test_sync_bootable_keeper_credentials_rotates_shared_keeper_tokens () =
       Eio.Switch.run @@ fun sw ->
       let state =
         Server_runtime_bootstrap.create_server_state ~sw ~base_path:dir ~clock
-          ~mono_clock ~net ~proc_mgr ~fs
+          ~mono_clock ~net ~proc_mgr ~fs ()
       in
       Server_runtime_bootstrap.bootstrap_server_state_blocking state;
       Server_runtime_bootstrap.sync_bootable_keeper_credentials state;


### PR DESCRIPTION
## Summary

RFC-0107 Phase D.2b + D.2c — real piaf-backed pool + migration shim.
This PR now stacks **two commits**:

- **D.2b** `b952d6b949 → cf89fa6a0b`: piaf transport binding, Host_key
  map, idle eviction fiber.
- **D.2c** `fdbb9a4ee9`: Masc_http_client routes through Pool. 13
  existing callsites unchanged.

## D.2c migration shim — zero callsite churn

The public `Masc_http_client.{post_sync, get_sync, get_response_sync}`
signatures are preserved. The 13 callsites
(`lib/server/`, `lib/local/`, `lib/auto_responder.ml`,
`lib/cascade/`, `lib/graphql_client.ml`, `lib/voice/voice_bridge_core.ml`,
`lib/dashboard/`, `lib/opentelemetry_client_cohttp_eio.ml`) build with
zero touch.

Internally, requests now flow through a lazy process-wide `Pool.t`
that reads `~sw` + `~env` from `Eio_context`. `~net` / `?https`
parameters on the public API are kept for ABI stability but ignored
(the pool owns the transport). They will be dropped from the mli in a
follow-up after D.2c bis migrates `voice_bridge_core` +
`opentelemetry_client_cohttp_eio` off `make_closing_client`.

## Bootstrap wiring

- `Eio_context.{set_env, get_env_opt}` new — stores the full
  `Eio_unix.Stdenv.base`. Required by piaf `Client.create` and any
  future API that needs more than `net+clock`.
- `Server_runtime_bootstrap.create_server_state` now accepts `?env`
  (optional for backwards compatibility with test callers without a
  full env). Both production caller (`main_stdio_eio.ml` and the
  internal site at line 1471) updated to pass `~env`.

If `set_env` was not called before the first HTTP request, the pool
returns `Error "Eio_context.set_env not called — RFC-0107 Phase D pool
cannot be initialized. This indicates a bootstrap-order bug."` No
silent fallback to cohttp-eio.

## Files

| File | Δ |
|---|---|
| `bin/main_stdio_eio.ml` | +1/-1 |
| `lib/eio_context/dune` | +1/-1 |
| `lib/eio_context/eio_context.ml` | +12 |
| `lib/eio_context/eio_context.mli` | +13 |
| `lib/masc_http_client/dune` | +1/-1 |
| `lib/masc_http_client/masc_http_client.ml` | +47/-81 |
| `lib/masc_http_client/pool.ml` | +359/-1 (D.2b) +7/-1 (D.2c) |
| `lib/masc_http_client/pool.mli` | +12/-2 |
| `lib/server/server_runtime_bootstrap.ml` | +8/-1 |
| `lib/server/server_runtime_bootstrap.mli` | +9/-1 |
| `test/test_server_runtime_bootstrap.ml` | +5/-3 |
| `dune-project`, `masc_mcp.opam` | piaf/eio-ssl |

**Net: +445/-101 across 12 files. 13 callsites unchanged.**

## Verification

- `dune build @check` exit 0
- piaf 0.2.0 + eio-ssl 0.3.0 installed (macOS requires brew openssl@3
  + CPATH env overrides, documented in dune-project)

## macOS install note

```bash
CPATH=/opt/homebrew/opt/openssl@3/include \
LIBRARY_PATH=/opt/homebrew/opt/openssl@3/lib \
PKG_CONFIG_PATH=/opt/homebrew/opt/openssl@3/lib/pkgconfig \
opam install piaf -y
```

## Roadmap

| Step | Status |
|---|---|
| D.2a (interface) | merged #15950 |
| **D.2b + D.2c (this PR)** | **this** |
| D.2c bis | voice_bridge_core + opentelemetry off make_closing_client |
| D.2d | Unit/integration tests, TLA+ Pool_no_double_close |
| D.2e | cascade-storm reproducer |

## Refs

- RFC-0107 §3.2 (Pool design)
- Phase D design: `docs/rfc/RFC-0107-phase-d-pool-design.md` (#15941)
- Phase B Prior Art: `knowledge/research/2026-05-17-piaf-ocsigen-eio-fd-prior-art.md`
- Phase C.1 wiring prerequisite: #15932

RFC-WAIVED: per merged RFC-0107 §3.2 design + D.2a #15950 interface
already in main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
