### PR TITLE
Relax stale fleet batch handling

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -500,16 +500,17 @@ let find_matching_rule
 
 (* ── Persistent audit log ────────────────────────────────── *)
 
-(* Eio.Mutex: audit store map and audit-IO are accessed from approval-flow
-   Eio fibers (single domain). Stdlib.Mutex with PTHREAD_MUTEX_ERRORCHECK
-   raises EDEADLK on fiber contention (memory: feedback_eio-mutex-vs-stdlib). *)
+(* Stdlib.Mutex: the store registry critical section only mutates an in-memory
+   hashtable and creates a Dated_jsonl handle. It is also used by synchronous
+   tests outside an Eio context, so an Eio mutex would either raise Get_context
+   or poison the registry after a recoverable store-creation failure. *)
 (** Dated JSONL audit trail for approval events.
     Stored at [<base_path>/.masc/audit-approvals/YYYY-MM/DD.jsonl].
     Dashboard and room-scoped keeper runs pass [base_path] explicitly so approval
     history stays with the room that made the decision. *)
-let audit_stores_mu = Eio.Mutex.create ()
+let audit_stores_mu = Stdlib.Mutex.create ()
 
-let audit_io_mu = Eio.Mutex.create ()
+let audit_io_mu = Stdlib.Mutex.create ()
 let audit_stores : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
 
 let audit_today_path base_dir =
@@ -523,35 +524,50 @@ let audit_today_path base_dir =
 ;;
 
 let get_audit_store ?base_path () =
-  let base =
-    match base_path with
-    | Some base -> base
-    | None -> Env_config_core.base_path ()
-  in
-  try
-    Eio.Mutex.use_rw ~protect:true audit_stores_mu (fun () ->
-      match Hashtbl.find_opt audit_stores base with
-      | Some store -> Some store
-      | None ->
-        let dir =
-          Filename.concat
-            (Common.masc_dir_from_base_path ~base_path:base)
-            "audit-approvals"
-        in
-        let store = Dated_jsonl.create ~base_dir:dir () in
-        Hashtbl.replace audit_stores base store;
-        Some store)
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
+  let report_failure exn =
+    Keeper_fd_pressure.note_exception ~site:"approval_audit.store_create" exn;
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_approval_queue_failures
-      ~labels:[ "keeper", "aggregate"; "site", Keeper_approval_queue_failure_site.(to_label Audit_store_create) ]
+      ~labels:
+        [ "keeper", "aggregate"
+        ; "site", Keeper_approval_queue_failure_site.(to_label Audit_store_create)
+        ]
       ();
     Log.Keeper.warn
       "approval_queue: audit store creation failed: %s"
       (Printexc.to_string exn);
     None
+  in
+  try
+    let base =
+      match base_path with
+      | Some base -> base
+      | None -> Env_config_core.base_path ()
+    in
+    match
+      Stdlib.Mutex.protect audit_stores_mu (fun () ->
+        try
+          Ok
+            (match Hashtbl.find_opt audit_stores base with
+             | Some store -> Some store
+             | None ->
+               let dir =
+                 Filename.concat
+                   (Common.masc_dir_from_base_path ~base_path:base)
+                   "audit-approvals"
+               in
+               let store = Dated_jsonl.create ~base_dir:dir () in
+               Hashtbl.replace audit_stores base store;
+               Some store)
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn -> Error exn)
+    with
+    | Ok store -> store
+    | Error exn -> report_failure exn
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> report_failure exn
 ;;
 
 let audit_approval_event
@@ -612,7 +628,7 @@ let audit_approval_event
          | Some value -> [ "auto_approved", `Bool value ]
          | None -> [])
     in
-    Eio.Mutex.use_rw ~protect:true audit_io_mu (fun () ->
+    Stdlib.Mutex.protect audit_io_mu (fun () ->
       try Fs_compat.append_jsonl (audit_today_path (Dated_jsonl.base_dir store)) json with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn -> record_queue_failure ~keeper_name ~site:"audit_append" ~id ~event_type exn)
@@ -647,21 +663,36 @@ let read_recent_audit ?base_path ?keeper_name ?(n = 20) () : Yojson.Safe.t list 
     match get_audit_store ?base_path () with
     | None -> []
     | Some store ->
-      let raw = Dated_jsonl.read_recent store (audit_scan_window ?keeper_name n) in
-      let filtered =
-        match keeper_name with
-        | None -> raw
-        | Some name ->
-          raw
-          |> List.filter (fun json ->
-            String.equal name (Safe_ops.json_string ~default:"" "keeper" json))
-      in
-      filtered |> List.rev |> List.filteri (fun idx _ -> idx < n))
+      try
+        let raw = Dated_jsonl.read_recent store (audit_scan_window ?keeper_name n) in
+        let filtered =
+          match keeper_name with
+          | None -> raw
+          | Some name ->
+            raw
+            |> List.filter (fun json ->
+              String.equal name (Safe_ops.json_string ~default:"" "keeper" json))
+        in
+        filtered |> List.rev |> List.filteri (fun idx _ -> idx < n)
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Keeper_fd_pressure.note_exception ~site:"approval_audit.read_recent" exn;
+        Prometheus.inc_counter
+          Keeper_metrics.metric_keeper_approval_queue_failures
+          ~labels:
+            [ "keeper",
+              Option.value ~default:"aggregate" keeper_name;
+              "site",
+              Keeper_approval_queue_failure_site.(to_label Audit_read_recent)
+            ]
+          ();
+        [])
 ;;
 
 module For_testing = struct
   let reset_audit_store () =
-    Eio.Mutex.use_rw ~protect:true audit_stores_mu (fun () -> Hashtbl.clear audit_stores)
+    Stdlib.Mutex.protect audit_stores_mu (fun () -> Hashtbl.clear audit_stores)
   ;;
 end
 

--- a/lib/keeper/keeper_approval_queue_failure_site.ml
+++ b/lib/keeper/keeper_approval_queue_failure_site.ml
@@ -6,6 +6,7 @@ type t =
   | Remember_rule
   | Approval_expired
   | Expire_callback
+  | Audit_read_recent
 
 let to_label = function
   | Upsert_rule_save -> "upsert_rule_save"
@@ -15,4 +16,5 @@ let to_label = function
   | Remember_rule -> "remember_rule"
   | Approval_expired -> "approval_expired"
   | Expire_callback -> "expire_callback"
+  | Audit_read_recent -> "audit_read_recent"
 ;;

--- a/lib/keeper/keeper_approval_queue_failure_site.mli
+++ b/lib/keeper/keeper_approval_queue_failure_site.mli
@@ -1,5 +1,5 @@
 (** Keeper_approval_queue_failure_site — closed sum for [site] label on
-    [metric_keeper_approval_queue_failures] (7 sites). *)
+    [metric_keeper_approval_queue_failures]. *)
 
 type t =
   | Upsert_rule_save
@@ -9,5 +9,6 @@ type t =
   | Remember_rule
   | Approval_expired
   | Expire_callback
+  | Audit_read_recent
 
 val to_label : t -> string

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -119,10 +119,9 @@ type blocker_class =
         majority cohort during a fleet stall (observed: 6/14 keepers
         in cohort=stale_turn_timeout, every meta showing null). *)
   | Stale_fleet_batch
-    (** Multiple keepers were stale-watchdog terminated inside the fleet
-        batch window. This mirrors [Keeper_registry.Stale_fleet_batch] so
-        keeper_meta and dashboard status can report the systemic blocker
-        instead of collapsing it to a generic turn timeout. *)
+    (** Legacy blocker class for pre-existing fleet-batch state. Current
+        fleet-batch detection is observation-only and should not stamp keeper
+        meta; stale keepers use their per-keeper watchdog blocker instead. *)
   | Sdk_max_turns_exceeded
   | Sdk_token_budget_exceeded
   | Sdk_cost_budget_exceeded

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -122,7 +122,6 @@ type t =
   | PresenceSyncFailures
   | SelfPreservationUniversal
   | StaleStormPaused
-  | StaleFleetBatchPaused
   | OasTimeoutBudgetLoopPaused
   | CycleExceptions
   | SnapshotWriteFailures
@@ -327,7 +326,6 @@ let to_string = function
   | PresenceSyncFailures -> "masc_keeper_presence_sync_failures_total"
   | SelfPreservationUniversal -> "masc_keeper_self_preservation_universal_total"
   | StaleStormPaused -> "masc_keeper_stale_storm_paused_total"
-  | StaleFleetBatchPaused -> "masc_keeper_stale_fleet_batch_paused_total"
   | OasTimeoutBudgetLoopPaused -> "masc_keeper_oas_timeout_budget_loop_paused_total"
   | CycleExceptions -> "masc_keeper_cycle_exceptions_total"
   | SnapshotWriteFailures -> "masc_keeper_snapshot_write_failures_total"
@@ -672,7 +670,6 @@ let metric_keeper_self_preservation_universal =
 ;;
 
 let metric_keeper_stale_storm_paused = "masc_keeper_stale_storm_paused_total"
-let metric_keeper_stale_fleet_batch_paused = "masc_keeper_stale_fleet_batch_paused_total"
 
 let metric_keeper_oas_timeout_budget_loop_paused =
   "masc_keeper_oas_timeout_budget_loop_paused_total"

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -114,7 +114,6 @@ type t =
   | PresenceSyncFailures
   | SelfPreservationUniversal
   | StaleStormPaused
-  | StaleFleetBatchPaused
   | OasTimeoutBudgetLoopPaused
   | CycleExceptions
   | SnapshotWriteFailures
@@ -388,7 +387,6 @@ val metric_keeper_room_init_failures : string
 val metric_keeper_presence_sync_failures : string
 val metric_keeper_self_preservation_universal : string
 val metric_keeper_stale_storm_paused : string
-val metric_keeper_stale_fleet_batch_paused : string
 val metric_keeper_oas_timeout_budget_loop_paused : string
 val metric_keeper_cycle_exceptions : string
 val metric_keeper_snapshot_write_failures : string

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -73,11 +73,10 @@ type failure_reason =
           investigate the underlying cascade/provider/fd issue before
           resuming the keeper. *)
   | Stale_fleet_batch of { distinct_count : int }
-  (** Latched when the stale watchdog observes several distinct keepers
-          terminating inside the fleet batch window. This is a systemic
-          cascade/provider/runtime signal, so the supervisor pauses affected
-          keepers with auto-resume backoff instead of restarting each keeper
-          independently into the same failure mode. *)
+  (** Legacy wire value for stale watchdog fleet-batch state. Current
+          fleet-batch detection is observation-only and must not create this
+          failure reason; if old runtime state still contains it, the
+          supervisor treats it like a restartable watchdog crash. *)
   | Oas_timeout_budget_loop of { count : int }
   (** Latched when the same keeper exhausts the OAS turn budget on
           consecutive cycles. This is a provider/cascade/runtime throughput

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -75,11 +75,10 @@ type failure_reason =
           investigate the underlying cascade/provider/fd issue before
           resuming the keeper. *)
   | Stale_fleet_batch of { distinct_count : int }
-      (** Latched when the stale watchdog observes several distinct keepers
-          terminating inside the fleet batch window. This is a systemic
-          cascade/provider/runtime signal, so the supervisor pauses affected
-          keepers with auto-resume backoff instead of restarting each keeper
-          independently into the same failure mode. *)
+      (** Legacy wire value for stale watchdog fleet-batch state. Current
+          fleet-batch detection is observation-only and must not create this
+          failure reason; if old runtime state still contains it, the
+          supervisor treats it like a restartable watchdog crash. *)
   | Oas_timeout_budget_loop of { count : int }
       (** Latched when the same keeper exhausts the OAS turn budget on
           consecutive cycles. This is a provider/cascade/runtime throughput
@@ -113,8 +112,8 @@ val stale_watchdog_failure_reason :
   prior:failure_reason option -> kill_class:stale_kill_class -> failure_reason option
 (** Preserve authoritative terminal failure reasons when the stale watchdog
     fires after a failed turn, but do not carry stale-watchdog cohort labels
-    across fresh watchdog kills. Storm/fleet labels are relatched only by the
-    current threshold or batch detector. *)
+    across fresh watchdog kills. Storm labels are relatched only by the current
+    per-keeper threshold; fleet-batch detection is observation-only. *)
 
 (** Pure control-flow signal for immediate fiber termination (RFC-0002).
     Carries no state — failure reason must be pre-stored via

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -321,12 +321,16 @@ let () =
    individually unless an operator notices.
 
    Track recent terminations across all keepers in a small bounded
-   window.  When the number of distinct keepers in the window
-   reaches the threshold we emit a fleet-tier ERROR, a Prometheus
-   counter labelled by the low-cardinality [batch_root_cause], and
-   latch the affected keepers into [Stale_fleet_batch].  The supervisor
-   then pauses/backs off those keepers instead of restarting each one
-   into the same systemic failure mode. *)
+   window.  When the number of distinct keepers in the window reaches
+   the threshold we emit a fleet-tier WARN and a Prometheus counter
+   labelled by the low-cardinality [batch_root_cause].
+
+   This is deliberately observation-only.  A fleet-wide stale burst is a
+   useful signal for operators and provider/cascade health, but it is not
+   itself a keeper terminal reason.  Keepers retain their per-keeper
+   watchdog reason so the supervisor can apply the normal restart/dead
+   budget instead of amplifying one shared upstream hiccup into a durable
+   fleet pause. *)
 let batch_window_sec = Env_config_keeper.KeeperWatchdog.batch_window_sec
 let batch_threshold = Env_config_keeper.KeeperWatchdog.batch_threshold
 let batch_terminations : (string * float) list Atomic.t = Atomic.make []
@@ -349,68 +353,6 @@ let reset_batch_terminations_for_test () =
   Atomic.set batch_terminations []
 
 let record_batch_termination_for_test = record_batch_termination
-
-let stamp_stale_fleet_batch_meta ~config ~keeper_name ~distinct_count
-    ~root_reason =
-  let base_path = config.Coord.base_path in
-  match Keeper_registry.get ~base_path keeper_name with
-  | None -> ()
-  | Some entry ->
-    let root_text =
-      root_reason
-      |> Option.map Keeper_registry.failure_reason_to_string
-      |> Option.value ~default:"none"
-    in
-    let blocker =
-      Printf.sprintf "stale_fleet_batch(distinct_count=%d root_cause=%s)"
-        distinct_count root_text
-    in
-    let meta =
-      { entry.meta with
-        runtime =
-          { entry.meta.runtime with
-            last_blocker =
-              Some (blocker_info_of_class
-                      ~detail:blocker Stale_fleet_batch);
-          };
-      }
-    in
-    (match
-       write_meta_with_merge
-         ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-         config meta
-     with
-     | Ok () -> ()
-     | Error err ->
-       Prometheus.inc_counter
-         Keeper_metrics.metric_keeper_write_meta_failures
-         ~labels:[("keeper", keeper_name); ("phase", "stale_fleet_batch_stamp")]
-         ();
-       Log.Keeper.warn
-         "%s: stale_fleet_batch meta stamp failed: %s"
-         keeper_name err)
-
-let latch_stale_fleet_batch_reasons ~config ~distinct_count keeper_names =
-  let base_path = config.Coord.base_path in
-  List.iter
-    (fun keeper_name ->
-       match Keeper_registry.get ~base_path keeper_name with
-       | None -> ()
-       | Some entry ->
-           (match entry.last_failure_reason with
-            | Some (Keeper_registry.Stale_fleet_batch { distinct_count = n })
-              when n >= distinct_count ->
-                ()
-            | root_reason ->
-                stamp_stale_fleet_batch_meta ~config ~keeper_name
-                  ~distinct_count ~root_reason;
-                Keeper_registry.set_failure_reason ~base_path keeper_name
-                  (Some
-                     (Keeper_registry.Stale_fleet_batch { distinct_count }))))
-    keeper_names
-
-let latch_stale_fleet_batch_reasons_for_test =
-  latch_stale_fleet_batch_reasons
 
 let effective_startup_grace_sec ~base_grace_sec ~poll_sec ~startup_warmup_sec =
   Float.max
@@ -804,8 +746,10 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                    escalation_threshold
                end
                end;
-               (* #10765 phase 2: fleet batch detection.  See module-level
-                  comment on [batch_terminations] for rationale. *)
+               (* Fleet batch detection is observation-only.  It must not
+                  rewrite per-keeper failure reasons or persist a blocker; the
+                  supervisor can restart each keeper under its normal budget
+                  while operators still get a fleet-wide signal. *)
                let batch = record_batch_termination meta.name now in
                if List.length batch >= batch_threshold then begin
                  let root_cause =
@@ -816,19 +760,16 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                    batch_root_cause_to_string root_cause
                  in
                  let distinct_count = List.length batch in
-                 latch_stale_fleet_batch_reasons ~config:ctx.config ~distinct_count
-                   batch;
                  Prometheus.inc_counter
                    Keeper_metrics.metric_keeper_stale_termination_batch
                    ~labels:[ ("root_cause", root_cause_label) ]
                    ();
-                 Log.Keeper.error
-                   "FLEET BATCH TERMINATION: %d distinct keepers \
+                 Log.Keeper.warn
+                   "FLEET STALE BURST: %d distinct keepers \
                     terminated in last %.0fs [%s] — systemic signal \
-                    root_cause=%s.  \
-                    Affected keepers are latched for auto-pause/backoff \
-                    instead of independent restart.  See #10765, #10474, \
-                    #10745."
+                    root_cause=%s.  Observation-only; keepers retain their \
+                    per-keeper watchdog reason and remain restart-eligible \
+                    under the normal supervisor budget."
                    distinct_count batch_window_sec
                    (String.concat ", " batch) root_cause_label
                end;

--- a/lib/keeper/keeper_stale_watchdog.mli
+++ b/lib/keeper/keeper_stale_watchdog.mli
@@ -61,10 +61,6 @@ val reset_batch_terminations_for_test : unit -> unit
 val record_batch_termination_for_test : string -> float -> string list
 (** Test-only wrapper around the fleet batch termination window. *)
 
-val latch_stale_fleet_batch_reasons_for_test :
-  config:Coord.config -> distinct_count:int -> string list -> unit
-(** Test-only wrapper for the batch failure-reason latch. *)
-
 val effective_startup_grace_sec :
      base_grace_sec:float
   -> poll_sec:float
@@ -111,5 +107,5 @@ val fork_stale_watchdog :
 
     On detection, sets [fiber_stop] and emits a stale broadcast. The
     supervisor's [sweep_and_recover] picks up the stopped fiber and restarts
-    with exponential backoff, unless a per-keeper stale storm or fleet batch
-    latch routes the keeper to auto-pause/backoff first. *)
+    with exponential backoff, unless a per-keeper stale storm routes the keeper
+    to auto-pause/backoff first. Fleet batch detection is observation-only. *)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -245,12 +245,10 @@ let launch_supervised_fiber
               crash recovery instead of a clean stop. When the stale
               watchdog sets fiber_stop + Stale_turn_timeout, the heartbeat
               loop exits normally but the supervisor must treat this as a
-              crash so sweep_and_recover restarts the keeper.
-              #10765 Phase 2: [Stale_termination_storm] and
-              [Stale_fleet_batch] also funnel through the crash path, but
-              [sweep_and_recover]'s [`Crashed] branch detects these variants
-              and routes to auto-pause instead of [to_restart], breaking the
-              restart-loop-back-to-stale cycle. *)
+              crash so sweep_and_recover restarts the keeper. Storm and
+              budget-loop cohorts still route to auto-pause; legacy
+              Stale_fleet_batch remains a watchdog signal but no longer
+              pauses the keeper. *)
              let watchdog_triggered =
                match Keeper_registry.get ~base_path meta.name with
                | Some e ->
@@ -1335,28 +1333,6 @@ let handle_stale_storm_pause
          count)
 ;;
 
-let handle_stale_fleet_batch_pause
-      (ctx : _ context)
-      (entry : Keeper_registry.registry_entry)
-      ~distinct_count
-  =
-  handle_crash_auto_pause
-    ctx
-    entry
-    ~reason_tag:"stale_fleet_batch"
-    ~metric_name:Keeper_metrics.metric_keeper_stale_fleet_batch_paused
-    ~lifecycle_detail:
-      (Printf.sprintf "stale_fleet_batch distinct_count=%d" distinct_count)
-    ~blocker_class:(Some Stale_fleet_batch)
-    ~log_message:
-      (Printf.sprintf
-         "STALE FLEET BATCH AUTO-PAUSED (distinct_keepers=%d in batch window). \
-          Supervisor will attempt self-healing auto-resume with exponential back-off \
-          instead of restarting each keeper into the same systemic failure mode (cascade \
-          dead, provider auth, fd leak, etc.). See #10765 / #10474 / #10745."
-         distinct_count)
-;;
-
 let handle_oas_timeout_budget_pause
       (ctx : _ context)
       (entry : Keeper_registry.registry_entry)
@@ -1444,12 +1420,6 @@ let sweep_and_recover (ctx : _ context) =
            once per storm, not once per sweep tick). *)
       handle_stale_storm_pause ctx entry ~count;
       to_unregister := entry :: !to_unregister
-    | Some (Keeper_registry.Stale_fleet_batch { distinct_count }) ->
-      (* Fleet batch detection means multiple keepers crossed the stale
-           watchdog together. Treating those as independent keeper crashes
-           immediately replays the batch. Pause/backoff instead. *)
-      handle_stale_fleet_batch_pause ctx entry ~distinct_count;
-      to_unregister := entry :: !to_unregister
     | Some (Keeper_registry.Oas_timeout_budget_loop { count }) ->
       (* Repeated OAS budget exhaustion means the active
            cascade/model is not producing within the turn budget.
@@ -1464,6 +1434,7 @@ let sweep_and_recover (ctx : _ context) =
     | Some (Keeper_registry.Heartbeat_consecutive_failures _)
     | Some (Keeper_registry.Turn_consecutive_failures _)
     | Some (Keeper_registry.Stale_turn_timeout _)
+    | Some (Keeper_registry.Stale_fleet_batch _)
     | Some (Keeper_registry.Provider_runtime_error _)
     | Some (Keeper_registry.Tool_required_unsatisfied _)
     | Some (Keeper_registry.Ambiguous_partial_commit _)
@@ -1512,9 +1483,9 @@ let sweep_and_recover (ctx : _ context) =
        [watchdog_stop_pending]. *)
     let stamp_cohort =
       match entry.last_failure_reason with
-      | Some (Keeper_registry.Stale_fleet_batch _) -> Some Stale_fleet_batch
       | Some (Keeper_registry.Oas_timeout_budget_loop _) -> Some Oas_timeout_budget
       | Some (Keeper_registry.Stale_turn_timeout _)
+      | Some (Keeper_registry.Stale_fleet_batch _)
       | Some (Keeper_registry.Stale_termination_storm _) -> Some Stale_turn_timeout
       (* Non-watchdog failure reasons do not seed a watchdog blocker_class. *)
       | Some (Keeper_registry.Heartbeat_consecutive_failures _)
@@ -2331,10 +2302,11 @@ let request_alive_but_stuck_recovery
      a watchdog stop.  The prior reason is captured in the log line
      for postmortem.
 
-     Idempotent: if the keeper is already in a watchdog cohort
+     Idempotent: if the keeper is already in an active watchdog cohort
      ([Stale_turn_timeout] / [Stale_termination_storm] /
-     [Stale_fleet_batch] / [Oas_timeout_budget_loop]), preserve it so we don't churn the
-     [stall_seconds] field on every poll. *)
+     [Oas_timeout_budget_loop]), preserve it so we don't churn the
+     [stall_seconds] field on every poll.  Legacy [Stale_fleet_batch] is not
+     preserved because fleet-batch detection is observation-only now. *)
   let prior_str =
     Option.map Keeper_registry.failure_reason_to_string current_entry.last_failure_reason
     |> Option.value ~default:"none"
@@ -2344,7 +2316,6 @@ let request_alive_but_stuck_recovery
     | Some
         ( Keeper_registry.Stale_turn_timeout _
         | Keeper_registry.Stale_termination_storm _
-        | Keeper_registry.Stale_fleet_batch _
         | Keeper_registry.Oas_timeout_budget_loop _ ) as kept -> kept
     (* Non-stale failure reasons (and no prior reason) are overwritten with
        a fresh [Stale_turn_timeout] carrying the current kill class.  Any new
@@ -2354,6 +2325,7 @@ let request_alive_but_stuck_recovery
     | Some (Keeper_registry.Provider_runtime_error _)
     | Some (Keeper_registry.Tool_required_unsatisfied _)
     | Some (Keeper_registry.Ambiguous_partial_commit _)
+    | Some (Keeper_registry.Stale_fleet_batch _)
     | Some Keeper_registry.Fiber_unresolved
     | Some (Keeper_registry.Exception _)
     | None -> Some (Keeper_registry.Stale_turn_timeout kill_class)

--- a/lib/keeper/keeper_turn_terminal_code.mli
+++ b/lib/keeper/keeper_turn_terminal_code.mli
@@ -37,8 +37,9 @@ type t =
   (** [Keeper_registry.Stale_termination_storm]: cohort window
           escalation threshold reached. *)
   | Stale_fleet_batch
-  (** [Keeper_registry.Stale_fleet_batch]: distinct keepers
-          terminated inside the fleet batch window. *)
+  (** [Keeper_registry.Stale_fleet_batch]: legacy fleet-batch wire value.
+      Current fleet-batch detection is observation-only; fresh watchdog kills
+      retain their per-keeper terminal code. *)
   | Oas_timeout_budget
   (** [Keeper_registry.Oas_timeout_budget_loop]: same keeper
           exhausted the OAS turn budget on consecutive cycles. *)

--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -95,21 +95,21 @@ let set_sidecar_failure_observer f =
 (* Observer for unexpected (non-EAGAIN/EWOULDBLOCK/EINTR/EOF)
    drain-pipe read errors.  Labels are closed-vocabulary:
    [fd_kind = "stdout" | "stderr"] (call-site tagged) and
-   [error_kind = "unix_error" | "other"] (typed match arm).
+   [err_kind = "unix_error" | "other"] (typed match arm).
    Cardinality bound: 2 × 2 = 4.  See top-level Prometheus
    module for the registered counter. *)
 let drain_failure_observer :
-    ((fd_kind:string -> error_kind:string -> unit) option) Atomic.t =
+    ((fd_kind:string -> err_kind:string -> unit) option) Atomic.t =
   Atomic.make None
 
 let set_drain_failure_observer f =
   Atomic.set drain_failure_observer (Some f)
 
-let observe_drain_failure ~fd_kind ~error_kind =
+let observe_drain_failure ~fd_kind ~err_kind =
   match Atomic.get drain_failure_observer with
   | None -> ()
   | Some observe ->
-      (try observe ~fd_kind ~error_kind with
+      (try observe ~fd_kind ~err_kind with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | observer_exn ->
            Log.Misc.warn "bg_task drain observer failed: %s"
@@ -291,13 +291,13 @@ let drain_fd_to_buf ~fd_kind buf fd =
           Log.Misc.warn
             "bg_task drain_fd_to_buf %s Unix_error in %s: %s"
             fd_kind fn (Unix.error_message errno);
-          observe_drain_failure ~fd_kind ~error_kind:"unix_error";
+          observe_drain_failure ~fd_kind ~err_kind:"unix_error";
           true
       | exception exn ->
           Log.Misc.warn
             "bg_task drain_fd_to_buf %s unexpected exception: %s"
             fd_kind (Printexc.to_string exn);
-          observe_drain_failure ~fd_kind ~error_kind:"other";
+          observe_drain_failure ~fd_kind ~err_kind:"other";
           true
   in
   loop ()

--- a/lib/process/bg_task.mli
+++ b/lib/process/bg_task.mli
@@ -129,7 +129,7 @@ val set_sidecar_failure_observer : (site:string -> exn -> unit) -> unit
     to avoid a lower-library dependency cycle. *)
 
 val set_drain_failure_observer :
-  (fd_kind:string -> error_kind:string -> unit) -> unit
+  (fd_kind:string -> err_kind:string -> unit) -> unit
 (** Install the process-local observer for unexpected (non-EAGAIN /
     EWOULDBLOCK / EINTR / EOF) errors raised by [Unix.read] inside
     [drain_fd_to_buf].  The top-level Prometheus module wires this to
@@ -137,7 +137,7 @@ val set_drain_failure_observer :
 
     Labels are closed-vocabulary and cardinality-bounded:
     - [fd_kind] is either ["stdout"] or ["stderr"] (call-site tagged).
-    - [error_kind] is either ["unix_error"] (a [Unix.Unix_error] that
+    - [err_kind] is either ["unix_error"] (a [Unix.Unix_error] that
       is neither EAGAIN/EWOULDBLOCK nor EINTR — e.g. EBADF, EIO,
       ENOMEM) or ["other"] (any other exception).
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -2177,11 +2177,6 @@ let init () =
     "Total keepers auto-paused due to stale termination storms. Labeled by keeper."
     Counter;
   add
-    Keeper_metrics.metric_keeper_stale_fleet_batch_paused
-    "Total keepers auto-paused due to fleet-wide stale termination batches. Labeled by \
-     keeper."
-    Counter;
-  add
     Keeper_metrics.metric_keeper_oas_timeout_budget_loop_paused
     "Total keepers auto-paused due to repeated OAS timeout budget exhaustion. Labeled by \
      keeper."
@@ -2565,9 +2560,9 @@ let init () =
      rate indicates the previous silent-EOF fallback would have hidden a \
      real read error and lost output between the error and process exit."
     Counter;
-  Bg_task.set_drain_failure_observer (fun ~fd_kind ~error_kind ->
+  Bg_task.set_drain_failure_observer (fun ~fd_kind ~err_kind ->
     inc_counter metric_bg_task_drain_unexpected_errors
-      ~labels:[ "fd_kind", fd_kind; "error_kind", error_kind ] ());
+      ~labels:[ "fd_kind", fd_kind; "error_kind", err_kind ] ());
   add
     metric_build_identity_probe_failures
     "Total build identity git probe failures. Labeled by \

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -5,7 +5,6 @@
 open Alcotest
 module Sup = Masc_mcp.Keeper_supervisor
 module Reg = Masc_mcp.Keeper_registry
-module Watchdog = Masc_mcp.Keeper_stale_watchdog
 module KT = Masc_mcp.Keeper_types
 module AQ = Masc_mcp.Keeper_approval_queue
 module KSM = Masc_mcp.Keeper_state_machine
@@ -62,16 +61,6 @@ let with_config_dir f =
       Unix.putenv "MASC_CONFIG_DIR" config_dir;
       Config_dir_resolver.reset ();
       f config_dir)
-
-let contains_substring haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  let rec loop index =
-    if index + needle_len > haystack_len then false
-    else if String.sub haystack index needle_len = needle then true
-    else loop (index + 1)
-  in
-  needle_len = 0 || loop 0
 
 let with_restart_launch_noop f =
   Sup.with_restart_launch_noop_for_test f
@@ -977,7 +966,7 @@ let test_stale_storm_pause_skips_restart () =
       check bool "registry entry unregistered after storm pause"
         false (Reg.is_registered ~base_path:config.base_path name))
 
-let test_stale_fleet_batch_pause_skips_restart () =
+let test_legacy_stale_fleet_batch_routes_to_restart_budget () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
@@ -990,21 +979,21 @@ let test_stale_fleet_batch_pause_skips_restart () =
     (fun () ->
       let config = Masc_mcp.Coord.default_config base_dir in
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
-      let name = "stale-fleet-batch-keeper" in
+      let name = "legacy-stale-fleet-batch-keeper" in
       let meta = make_meta name in
       (match KT.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
-      Eio.Promise.resolve reg.done_r (`Crashed "synthetic stale fleet batch");
+      Eio.Promise.resolve reg.done_r (`Crashed "legacy stale fleet batch");
+      let max_restarts =
+        Masc_mcp.Runtime_params.get
+          Masc_mcp.Governance_registry.keeper_supervisor_max_restarts
+      in
       Reg.restore_supervisor_state ~base_path:config.base_path name
-        ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
+        ~restart_count:max_restarts ~last_restart_ts:0.0 ~crash_log:[];
       Reg.set_failure_reason ~base_path:config.base_path name
         (Some (Reg.Stale_fleet_batch { distinct_count = 3 }));
-      let baseline_pause =
-        Masc_mcp.Prometheus.metric_total
-          "masc_keeper_stale_fleet_batch_paused_total"
-      in
       let baseline_dead =
         Masc_mcp.Prometheus.metric_total
           Masc_mcp.Keeper_metrics.metric_keeper_dead_total
@@ -1020,89 +1009,19 @@ let test_stale_fleet_batch_pause_skips_restart () =
         }
       in
       Sup.sweep_and_recover ctx;
-      let after_pause =
-        Masc_mcp.Prometheus.metric_total
-          "masc_keeper_stale_fleet_batch_paused_total"
-      in
       let after_dead =
         Masc_mcp.Prometheus.metric_total
           Masc_mcp.Keeper_metrics.metric_keeper_dead_total
       in
-      check (float 0.001) "stale_fleet_batch_paused counter incremented by 1"
-        (baseline_pause +. 1.0) after_pause;
-      check (float 0.001) "dead counter NOT incremented (batch is not death)"
-        baseline_dead after_dead;
+      check (float 0.001) "legacy fleet batch follows restart/dead budget"
+        (baseline_dead +. 1.0) after_dead;
       (match KT.read_meta config name with
        | Ok (Some m) ->
-           check bool "meta.paused = true after fleet batch pause"
-             true m.paused;
-           let blocker_detail =
-             match m.runtime.last_blocker with
-             | Some b -> b.detail
-             | None -> ""
-           in
-           check string "last_blocker records fleet batch"
-             "stale_fleet_batch" blocker_detail
-       | Ok None -> fail "meta missing after fleet batch pause"
+           check bool "meta.paused stays false for legacy fleet batch"
+             false m.paused
+       | Ok None -> fail "meta missing after legacy fleet batch"
        | Error err -> fail ("read_meta failed: " ^ err));
-      check bool "registry entry unregistered after fleet batch pause"
-        false (Reg.is_registered ~base_path:config.base_path name))
-
-let test_stale_fleet_batch_latch_marks_batch_members () =
-  Eio_main.run @@ fun env ->
-  ensure_fs env;
-  let base_dir = temp_dir () in
-  Fun.protect
-    ~finally:(fun () ->
-      Reg.clear ();
-      Masc_mcp.Keeper_runtime.reset_test_state base_dir;
-      Watchdog.reset_batch_terminations_for_test ();
-      cleanup_dir base_dir)
-    (fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
-      let names = [ "batch-a"; "batch-b"; "batch-provider" ] in
-      List.iter
-        (fun name ->
-           let meta = make_meta name in
-           (match KT.write_meta config meta with
-            | Ok () -> ()
-            | Error err -> fail err);
-           ignore (Reg.register ~base_path:config.base_path name meta))
-        names;
-      Reg.set_failure_reason ~base_path:config.base_path "batch-a"
-        (Some (Reg.Stale_turn_timeout (Reg.Idle_turn { stall_seconds = 305.0 })));
-      Reg.set_failure_reason ~base_path:config.base_path "batch-b"
-        (Some Reg.Fiber_unresolved);
-      Reg.set_failure_reason ~base_path:config.base_path "batch-provider"
-        (Some (Reg.Provider_runtime_error { code = "auth"; detail = "401" }));
-      Watchdog.latch_stale_fleet_batch_reasons_for_test
-        ~config ~distinct_count:3 names;
-      let reason name =
-        match Reg.get ~base_path:config.base_path name with
-        | Some entry -> entry.Reg.last_failure_reason
-        | None -> fail ("missing registry entry " ^ name)
-      in
-      (match reason "batch-a", reason "batch-b", reason "batch-provider" with
-       | Some (Reg.Stale_fleet_batch { distinct_count = a }),
-         Some (Reg.Stale_fleet_batch { distinct_count = b }),
-         Some (Reg.Stale_fleet_batch { distinct_count = c }) ->
-           check int "batch-a distinct_count" 3 a;
-           check int "batch-b distinct_count" 3 b;
-           check int "batch-provider distinct_count" 3 c
-       | _ -> fail "unexpected batch latch failure reasons");
-      (match KT.read_meta config "batch-provider" with
-       | Ok (Some m) ->
-           check bool "provider root cause remains in blocker text" true
-             (match m.runtime.last_blocker with
-              | Some b -> contains_substring b.detail "provider_runtime_error"
-              | None -> false);
-           check bool "provider blocker class is fleet batch" true
-             (match m.runtime.last_blocker with
-              | Some b -> b.klass = KT.Stale_fleet_batch
-              | None -> false)
-       | Ok None -> fail "batch-provider meta missing"
-       | Error err -> fail ("read_meta failed: " ^ err)))
+      ())
 
 let test_oas_timeout_budget_loop_pause_skips_restart () =
   Eio_main.run @@ fun env ->
@@ -1731,10 +1650,8 @@ let () =
     "stale_storm_phase2", [
       test_case "Stale_termination_storm skips restart, persists paused, increments counter" `Quick
         test_stale_storm_pause_skips_restart;
-      test_case "Stale_fleet_batch skips restart, persists paused, increments counter" `Quick
-        test_stale_fleet_batch_pause_skips_restart;
-      test_case "watchdog fleet batch latch marks batch members" `Quick
-        test_stale_fleet_batch_latch_marks_batch_members;
+      test_case "legacy Stale_fleet_batch follows restart budget" `Quick
+        test_legacy_stale_fleet_batch_routes_to_restart_budget;
       test_case "Oas_timeout_budget_loop skips restart, persists paused, increments counter" `Quick
         test_oas_timeout_budget_loop_pause_skips_restart;
       test_case "unresolved watchdog-stopped budget loop is reaped" `Quick


### PR DESCRIPTION
## Summary

- make stale fleet batch detection observation-only instead of auto-pausing affected keepers
- route legacy `Stale_fleet_batch` state through the normal restart/dead budget
- harden approval audit reads/store creation so dashboard trust enrichment does not throw on audit I/O or base-path guard failures
- rebase on current `origin/main` and keep the merged ratchet fixes for error-envelope helpers, comment terminator traps, proof-store layout, stringly labels, and permissive-default lint

## Product impact

Operators still get a fleet-wide stale burst signal, but the signal no longer amplifies an upstream provider/cascade hiccup into durable keeper pauses. Existing legacy `Stale_fleet_batch` runtime state remains readable and now follows the normal restart/dead budget.

## Evidence

- Live restart check after operator restart showed the active 8935 process is running the root checkout binary at commit `f7b6caea80`, so this PR head (`99d466fe7a`) is not active in the local server yet.
- Last-20-minute live log sweep after restart showed no `stale_fleet_batch` emission. Remaining WARN/ERRORs are Docker daemon cleanup warnings, individual `fiber_unresolved`/`stale_turn_timeout` keeper records, two missing local egress audit files, and a dashboard Neo4j identity cache domain warning.

## Review evidence

- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_supervisor.exe test/test_stale_kill_class.exe test/test_keeper_turn_terminal_code_byte_compat.exe test/test_hitl_approval.exe test/test_approval_callback_wired.exe`
- `./_build/default/test/test_keeper_supervisor.exe`
- `./_build/default/test/test_stale_kill_class.exe`
- `./_build/default/test/test_keeper_turn_terminal_code_byte_compat.exe`
- `./_build/default/test/test_approval_callback_wired.exe`
- `./_build/default/test/test_cdal_runtime_health_15748.exe`
- `./_build/default/test/sse_event_poc/test_sse_event_poc.exe`
- `env MASC_BASE_PATH= MASC_STORAGE_TYPE=filesystem ./_build/default/test/test_hitl_approval.exe test approval_queue 9,12,21-22 -e`
- `scripts/check-boundary-guard.sh`
- `scripts/stringly-boundary-ratchet.sh`
- `bash scripts/lint/no-unknown-permissive-default.sh`
- `bash scripts/lint/no-inline-error-envelope.sh`
- `bash scripts/lint/no-ocaml-comment-terminator-trap.sh`
- `scripts/ocaml-structure-ratchet.sh`

## Verification

- `scripts/dune-local.sh build test/test_keeper_supervisor.exe test/test_stale_kill_class.exe test/test_keeper_turn_terminal_code_byte_compat.exe test/test_hitl_approval.exe test/test_approval_callback_wired.exe`
- `./_build/default/test/test_keeper_supervisor.exe`
- `./_build/default/test/test_stale_kill_class.exe`
- `./_build/default/test/test_keeper_turn_terminal_code_byte_compat.exe`
- `./_build/default/test/test_approval_callback_wired.exe`
- `./_build/default/test/test_cdal_runtime_health_15748.exe`
- `./_build/default/test/sse_event_poc/test_sse_event_poc.exe`
- `env MASC_BASE_PATH= MASC_STORAGE_TYPE=filesystem ./_build/default/test/test_hitl_approval.exe test approval_queue 9,12,21-22 -e`
- `scripts/check-boundary-guard.sh`
- `scripts/stringly-boundary-ratchet.sh`
- `bash scripts/lint/no-unknown-permissive-default.sh`
- `bash scripts/lint/no-inline-error-envelope.sh`
- `bash scripts/lint/no-ocaml-comment-terminator-trap.sh`
- `scripts/ocaml-structure-ratchet.sh`

## Linked issue

Follow-up to live stale fleet batch noise investigation; no standalone GitHub issue filed before this hotfix PR.
