### PR TITLE
Expose FD accountant runtime JSON

### DIFF
--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -317,7 +317,7 @@ let current_room_base_path_opt () =
   | Some state -> Some state.Mcp_server.room_config.base_path
   | None -> None
 
-let keeper_fleet_runtime_resolution_fields () =
+let keeper_fleet_runtime_resolution_base_fields () =
   let base_path = current_room_base_path_opt () in
   let keeper_fibers = Keeper_registry.count_running ?base_path () in
   let paused_keepers_json = paused_keepers_health_json () in
@@ -334,6 +334,32 @@ let keeper_fleet_runtime_resolution_fields () =
   ; "keeper_fleet_safety", fleet_safety
   ; "keeper_reaction_ledger", reaction_ledger_json
   ]
+;;
+
+let fd_accountant_snapshot_json () =
+  let snapshot = Fd_accountant.fd_snapshot () in
+  let per_kind =
+    snapshot.per_kind
+    |> List.map (fun (kind, in_flight) ->
+      let kind_name = Fd_accountant.kind_to_string kind in
+      `Assoc
+        [ "kind", `String kind_name
+        ; "in_flight", `Int in_flight
+        ; "configured_concurrency", `Int (Fd_accountant.configured_concurrency ~kind)
+        ; "effective_concurrency", `Int (Fd_accountant.effective_concurrency ~kind)
+        ])
+  in
+  `Assoc
+    [ "fd_open", `Int snapshot.fd_open
+    ; "fd_limit", `Int snapshot.fd_limit
+    ; "pressure_active", `Bool snapshot.pressure_active
+    ; "per_kind", `List per_kind
+    ]
+;;
+
+let keeper_fleet_runtime_resolution_fields () =
+  keeper_fleet_runtime_resolution_base_fields ()
+  @ [ "fd_accountant", fd_accountant_snapshot_json () ]
 ;;
 
 let make_health_json ?(listener = "http/1.1") request =
@@ -432,6 +458,7 @@ let make_health_json ?(listener = "http/1.1") request =
     ( "keeper_fd_pressure"
     , Keeper_fd_pressure.runtime_state_json ~active_keepers:keeper_fibers
         ~starting_keepers:0 ~requested_keepers:24 () );
+    ("fd_accountant", fd_accountant_snapshot_json ());
     ( "keeper_fleet_safety"
     , keeper_fleet_safety_health_json ~keeper_fibers
         ~paused_keepers_json );

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -117,8 +117,8 @@ val make_health_json :
     [build] / [protocol] (default + listener + supported list) /
     [transport] / [paths] / [uptime] / [sse_clients] /
     [startup] / [subsystems] / [feature_flags] / [gc] /
-    [keeper_fibers] / [keeper_fd_pressure] / [keeper_fleet_safety] /
-    [keeper_reaction_ledger] / [paused_keepers] /
+    [keeper_fibers] / [keeper_fd_pressure] / [fd_accountant] /
+    [keeper_fleet_safety] / [keeper_reaction_ledger] / [paused_keepers] /
     [keeper_config_parse_error_count] / [keeper_config_parse_errors] /
     [keeper_config_unknown_key_count] / [keeper_config_unknown_keys] /
     [keeper_config_schema_status] / [keeper_config_schema_blocking] /
@@ -144,6 +144,11 @@ val make_health_json :
     decision used by the FD guard.  This lets operators distinguish "shell
     says the host limit is high" from the actual runtime inherited by the
     server process, and distinguish process-local EMFILE from host-wide ENFILE.
+
+    [fd_accountant] exposes the live resource accountant snapshot used by the
+    shared spawn/HTTP/log backpressure layer: process FD open/limit readings,
+    whether FD pressure is active, and each resource kind's in-flight,
+    configured-concurrency, and effective-concurrency counts.
 
     [keeper_fleet_safety] compares configured bootable keepers with the
     live keeper fiber count.  It reports [blocked] when bootable keepers
@@ -173,7 +178,9 @@ val keeper_fleet_runtime_resolution_fields : unit -> (string * Yojson.Safe.t) li
     [/health] keeps the richer paused keeper object.  The
     [keeper_reaction_ledger] field keeps the same summary object as
     [/health] so the dashboard can render pending durable stimuli without a
-    second endpoint. *)
+    second endpoint.  [fd_accountant] is also projected here so the dashboard
+    shell can show the same backpressure source as [/health] without scraping
+    Prometheus. *)
 
 val health_handler : Httpun.Request.t -> Httpun.Reqd.t -> unit
 (** [health_handler request reqd] writes

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -164,6 +164,17 @@ let test_dashboard_tools_projection () =
         (match runtime_resolution |> member "keeper_fd_pressure" with
          | `Assoc _ -> true
          | _ -> false);
+      check bool "runtime fd accountant surfaced" true
+        (match runtime_resolution |> member "fd_accountant" with
+         | `Assoc _ -> true
+         | _ -> false);
+      check int "runtime fd accountant kinds surfaced"
+        (List.length Lib.Fd_accountant.all_kinds)
+        (runtime_resolution
+         |> member "fd_accountant"
+         |> member "per_kind"
+         |> to_list
+         |> List.length);
       check bool "runtime keeper fleet safety surfaced" true
         (match runtime_resolution |> member "keeper_fleet_safety" with
          | `Assoc _ -> true

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -990,6 +990,7 @@ let test_health_json_surfaces_durable_paused_keepers () =
           let open Yojson.Safe.Util in
           let paused = json |> member "paused_keepers" in
           let fd_pressure = json |> member "keeper_fd_pressure" in
+          let fd_accountant = json |> member "fd_accountant" in
           let fleet_safety = json |> member "keeper_fleet_safety" in
           let reaction_ledger = json |> member "keeper_reaction_ledger" in
           let durable_names =
@@ -1015,6 +1016,27 @@ let test_health_json_surfaces_durable_paused_keepers () =
           ignore (fd_pressure |> member "admission_blocked" |> to_bool);
           ignore
             (fd_pressure |> member "admission_decision" |> member "status" |> to_string);
+          ignore (fd_accountant |> member "fd_open" |> to_int);
+          ignore (fd_accountant |> member "fd_limit" |> to_int);
+          ignore (fd_accountant |> member "pressure_active" |> to_bool);
+          let fd_accountant_per_kind =
+            fd_accountant |> member "per_kind" |> to_list
+          in
+          Alcotest.(check int) "health exposes all FD accountant kinds"
+            (List.length Fd_accountant.all_kinds)
+            (List.length fd_accountant_per_kind);
+          List.iter
+            (fun kind ->
+              let kind_name = Fd_accountant.kind_to_string kind in
+              let row =
+                fd_accountant_per_kind
+                |> List.find (fun row ->
+                  String.equal (row |> member "kind" |> to_string) kind_name)
+              in
+              ignore (row |> member "in_flight" |> to_int);
+              ignore (row |> member "configured_concurrency" |> to_int);
+              ignore (row |> member "effective_concurrency" |> to_int))
+            Fd_accountant.all_kinds;
           Alcotest.(check int) "health exposes bootable keeper count" 1
             (fleet_safety |> member "bootable_keeper_count" |> to_int);
           Alcotest.(check int) "health exposes minimum running fibers" 1


### PR DESCRIPTION
## Summary
- expose the FD accountant snapshot on `/health` as `fd_accountant`
- project the same snapshot into dashboard `runtime_resolution`
- pin the JSON contract with health/dashboard tests

## Verification
- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe test/test_dashboard_tools.exe test/test_prometheus_coverage.exe test/test_fd_accountant.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 33 --show-errors`
- `./_build/default/test/test_dashboard_tools.exe`
- `./_build/default/test/test_prometheus_coverage.exe`
- `./_build/default/test/test_fd_accountant.exe`

## Guard note
Created after enabling branch-protection admin enforcement for #15938. Keep draft + do-not-merge until the guard path is observed behaving correctly.