### PR TITLE
fix(lint): update _*) allowlist line drift (1398 -> 1461) — CI unblocker

### DIFF
--- a/scripts/lint/no-ocaml-comment-terminator-trap.allowlist
+++ b/scripts/lint/no-ocaml-comment-terminator-trap.allowlist
@@ -7,5 +7,5 @@
 #
 # Audited 2026-05-17 (PR adding scripts/lint/no-ocaml-comment-terminator-trap.sh).
 
-lib/server/server_runtime_bootstrap.ml:1398
+lib/server/server_runtime_bootstrap.ml:1461
 lib/keeper/keeper_types_profile.ml:647


### PR DESCRIPTION
## Summary
- Single-line allowlist fix for `scripts/lint/no-ocaml-comment-terminator-trap.allowlist`.
- The `_*)` substring inside the string literal at `lib/server/server_runtime_bootstrap.ml` drifted from line 1398 → 1461 due to upstream code insertions, causing the `OCaml comment \`*)\` terminator trap` job to fail on every open PR (≥25 PRs affected).
- After fix: `bash scripts/lint/no-ocaml-comment-terminator-trap.sh` → `clean`.

## Root cause
`path:line` keying is brittle against unrelated edits. This PR only re-fixes the line number to unblock the queue.

## Follow-up
A separate RFC/PR should consider content-hash or AST-aware allowlist keying so line drift cannot silently re-fail CI. Not in scope here.

## Test plan
- [x] Local: `bash scripts/lint/no-ocaml-comment-terminator-trap.sh` returns `clean`
- [ ] CI: `OCaml comment \`*)\` terminator trap` job green