### PR TITLE
fix(lint): cdal_runtime_health uses Tool_args.error_assoc (T30 unblock)

### DIFF
--- a/lib/cdal_runtime_health.ml
+++ b/lib/cdal_runtime_health.ml
@@ -110,9 +110,8 @@ let task_scope_json ?base_dir ?(recent_limit = Env_config_runtime.Cdal.verdict_l
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
-    `Assoc
-      [ "status", `String "error"
-      ; "recent_limit", `Int recent_limit
+    Tool_args.error_assoc
+      [ "recent_limit", `Int recent_limit
       ; "recent_rows", `Int 0
       ; "task_id_rows", `Int 0
       ; "missing_task_scope", `Bool false


### PR DESCRIPTION
## Summary
- Replace inline `("status", \`String "error") :: fields` literal with `Tool_args.error_assoc fields` in `lib/cdal_runtime_health.ml`.
- The `No inline error-envelope literals (T30)` lint was failing on every open PR (≥25 affected) because main contained this violation.
- Structural fix (not allowlist extension) — preserves SSOT for error envelope shape via `Tool_args` helpers.

## Root cause
The exception branch in `cdal_health_state` built an `Assoc` literal whose first field is `"status", \`String "error"`. The T30 lint scans `lib/**/*.ml` for that exact pattern. The file is not in the allowlist (it is not a tool file but a health probe), so the lint rightly flags it.

## Why not allowlist
Per anti-workaround policy: string-classifier allowlist extension is a workaround. The structural fix uses the canonical helper `Tool_args.error_assoc` (also already used in `lib/tool_shard.ml`, `lib/server/server_dashboard_http.ml`, `lib/voice/voice_bridge.ml`).

## Test plan
- [x] Local: `bash scripts/lint/no-inline-error-envelope.sh` -> `OK`
- [ ] CI: T30 lint job green on this branch