### PR TITLE
fix(file_lock_eio): observe lock-table CAS retries (fiber contention)

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -466,6 +466,14 @@ let record_file_lock_attempt ~caller ~retries ~elapsed_s ~outcome =
 
 let () = Atomic.set File_lock_eio.on_lock_attempt_fn record_file_lock_attempt
 
+let record_file_lock_table_cas_retry () =
+  Prometheus.inc_counter
+    Prometheus.metric_file_lock_table_cas_retries
+    ()
+;;
+
+let () = Atomic.set File_lock_eio.on_cas_retry_fn record_file_lock_table_cas_retry
+
 let clear_agent_current_task_cache config ~task_id =
   let agents_path = agents_dir config in
   if path_exists config agents_path

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -38,17 +38,39 @@ let observe_lock_attempt ~caller ~retries ~started_at ~outcome =
   try (Atomic.get on_lock_attempt_fn) ~caller ~retries ~elapsed_s ~outcome
   with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
 
+(** Observability hook fired on every CAS retry inside [atomic_update*].
+    The lock table is a single shared [Atomic.t]; under high fiber
+    contention (many fibers concurrently calling [prune_stale_entries]
+    / [get_entry] for different paths) the retry rate is the precise
+    contention signal but was previously invisible.
+
+    Default no-op; [masc_process] cannot depend on [Prometheus]
+    (sub-library boundary), so emission is wired from the [masc_mcp]
+    root via this Atomic ref (mirrors [on_lock_attempt_fn] pattern). *)
+let on_cas_retry_fn : (unit -> unit) Atomic.t =
+  Atomic.make (fun () -> ())
+
+let observe_cas_retry () =
+  try (Atomic.get on_cas_retry_fn) ()
+  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
+
 let rec atomic_update atomic f =
   let old_val = Atomic.get atomic in
   let new_val = f old_val in
   if Atomic.compare_and_set atomic old_val new_val then ()
-  else atomic_update atomic f
+  else begin
+    observe_cas_retry ();
+    atomic_update atomic f
+  end
 
 let rec atomic_update_with_result atomic f =
   let old_val = Atomic.get atomic in
   let new_val, result = f old_val in
   if Atomic.compare_and_set atomic old_val new_val then result
-  else atomic_update_with_result atomic f
+  else begin
+    observe_cas_retry ();
+    atomic_update_with_result atomic f
+  end
 
 type lock_entry = {
   mu : Eio.Mutex.t;

--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -104,6 +104,16 @@ val on_lock_attempt_fn :
   (caller:string -> retries:int -> elapsed_s:float -> outcome:string -> unit)
     Atomic.t
 
+(** Observability hook fired on every CAS retry inside [atomic_update*].
+    The lock table is shared by [prune_stale_entries] and [get_entry];
+    high fiber contention (many fibers traversing the table for
+    different paths) drives retry rate, the precise contention signal
+    that was previously invisible. Wired at startup ([lib/coord.ml]) to
+    a no-label Prometheus counter ([masc_file_lock_table_cas_retries]).
+    [masc_process] cannot depend on [Prometheus] (sub-library
+    boundary), so emission goes through this Atomic ref. *)
+val on_cas_retry_fn : (unit -> unit) Atomic.t
+
 (** {1 Diagnostics} *)
 
 (** Current number of tracked lock paths. *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -356,6 +356,13 @@ let metric_tool_metrics_persist_dropped =
 let metric_tool_keeper_cache_cas_conflicts =
   "masc_tool_keeper_cache_cas_conflicts_total"
 
+(* File_lock_eio lock-table CAS retries (single shared atomic).
+   Bumped from [atomic_update] / [atomic_update_with_result] retry
+   branches via [on_cas_retry_fn] callback wired in coord.ml — the
+   masc_process sub-library cannot depend on Prometheus directly. *)
+let metric_file_lock_table_cas_retries =
+  "masc_file_lock_table_cas_retries_total"
+
 (* tool_keeper.cache_ttl_seconds env-var parse fallback observability.
    Operator-supplied env var (e.g. MASC_KEEPER_LIST_CACHE_TTL_S) is
    present but the value cannot be parsed as a non-negative float; the
@@ -1355,6 +1362,11 @@ let init () =
     metric_tool_keeper_cache_cas_conflicts
     "Total tool_keeper.cached_text_by_key Atomic CAS retry events. Each \
      increment corresponds to one extra compute() call. No labels."
+    Counter;
+  add
+    metric_file_lock_table_cas_retries
+    "Total File_lock_eio lock-table CAS retries across \
+     prune_stale_entries and get_entry. No labels."
     Counter;
   add
     metric_tool_keeper_cache_ttl_parse_failures

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -174,6 +174,14 @@ val metric_tool_metrics_persist_dropped : string
     Each increment corresponds to one extra [compute ()] call. No labels. *)
 val metric_tool_keeper_cache_cas_conflicts : string
 
+(** Counter for [File_lock_eio] lock-table CAS retries (both
+    [prune_stale_entries] and [get_entry] share the same single
+    [table] Atomic). Each increment corresponds to one extra
+    [Atomic.compare_and_set] failure under fiber contention.
+    Sustained non-zero rate indicates fan-out into the lock table
+    under load. No labels — only one shared atomic in the module. *)
+val metric_file_lock_table_cas_retries : string
+
 (** Counter for [tool_keeper.cache_ttl_seconds] env-var parse fallback events.
     Increments when the operator-supplied env var is present but unparseable
     or out-of-range, and the helper falls back to its default. Labels:


### PR DESCRIPTION
## Summary

`atomic_update` / `atomic_update_with_result` in `File_lock_eio` recursively retry on `Atomic.compare_and_set table` failure. Under fiber contention (many fibers concurrently traversing the shared lock table for different paths), retry rate is the precise contention signal — but was previously **invisible**. Performance degradation surfaced only as slow lock acquires (`masc_file_lock_acquire_seconds`), never as table-level CAS conflict count.

## Pattern (sublib boundary)

| | existing `on_lock_attempt_fn` | new `on_cas_retry_fn` |
|---|---|---|
| Signal | flock attempt outcome | atomic CAS retry |
| Default | no-op | no-op |
| Wired at | `lib/coord.ml:467` | `lib/coord.ml:476` (new) |
| Counter | `masc_file_lock_retries` (labelled) | `masc_file_lock_table_cas_retries_total` (no label) |

Mirrors the existing observability hook pattern verbatim — no new invention. `masc_process` cannot depend on `Prometheus` (sub-library cycle), so emission goes through Atomic ref callback.

## Cluster placement (RFC-0109 context)

This iter is deliberately **outside** the RFC-0109 silent-fallback spiral clusters (A wildcard / B Result.t / C JSON parse / D Cancelled / E WARN→counter / F env clamp). New cluster **G — fiber-contention signal**:

- No existing log/error exposes CAS retry rate
- The counter is the *first* observability surface, not a duplicate of a WARN log
- Distinct from counter-as-fix (RFC-0088 §1): no prior fix elsewhere is being substituted; the signal is genuinely new

## Files

| file | change |
|------|--------|
| `lib/process/file_lock_eio.ml(i)` | `on_cas_retry_fn` Atomic ref + `observe_cas_retry` helper; called in both `atomic_update*` retry branches |
| `lib/prometheus.ml(i)` | `metric_file_lock_table_cas_retries` no-label counter + registry entry |
| `lib/coord.ml` | `record_file_lock_table_cas_retry` + `Atomic.set` wiring (mirrors `on_lock_attempt_fn` line 467) |

## Workaround Rejection Bar self-check 7/7

1. **telemetry-as-fix?** GRAY — pure counter addition. Justified: CAS retry rate IS the primary signal of fiber contention; no prior log/error exposes it. New observability cluster, not a band-aid over an absent fix.
2. **string classifier?** NO.
3. **N-of-M?** NO — single helper pair, both retry branches covered atomically.
4. **catch-all added?** NO — `observe_cas_retry` uses the typed `Eio.Cancel.Cancelled` re-raise pattern.
5. **cap/cooldown/dedup/repair?** NO.
6. **test backdoor?** NO.
7. **codemod-missing typo?** NO.

## Test plan

- [ ] `dune build --root . @check` — PASS locally
- [ ] Inject artificial CAS contention (concurrent `get_entry` calls for many paths) → counter increments
- [ ] No contention → counter unchanged (callback no-op default unless coord.ml wired)
- [ ] Existing `on_lock_attempt_fn` behaviour unchanged

## RFC

Not required. `file_lock_eio.ml`, `prometheus.ml`, `coord.ml` are not in the RFC-mandatory subsystem list.

Co-Authored-By: claude-opus-4-7 <noreply@anthropic.com>
