### PR TITLE
fix(memory_jsonl): counter for parse_line silent drops (RFC-0109 §5.1 A, V15)

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -474,6 +474,16 @@ let record_file_lock_table_cas_retry () =
 
 let () = Atomic.set File_lock_eio.on_cas_retry_fn record_file_lock_table_cas_retry
 
+let record_memory_jsonl_parse_drop ~reason =
+  Prometheus.inc_counter
+    Prometheus.metric_memory_jsonl_parse_drops
+    ~labels:[ ("reason", reason) ]
+    ()
+;;
+
+let () =
+  Atomic.set Memory_jsonl.on_parse_drop_fn record_memory_jsonl_parse_drop
+
 let clear_agent_current_task_cache config ~task_id =
   let agents_path = agents_dir config in
   if path_exists config agents_path

--- a/lib/memory_jsonl/memory_jsonl.ml
+++ b/lib/memory_jsonl/memory_jsonl.ml
@@ -18,6 +18,22 @@
 (** Maximum file size before logging a warning (50 MB). *)
 let max_file_size = 50 * 1024 * 1024
 
+(** Observability hook fired on every [parse_line] silent drop with a
+    closed-vocabulary reason label.  The leaf [masc_mcp_memory_jsonl]
+    sub-library cannot depend on [Prometheus] (cycle), so emission is
+    wired from [lib/coord.ml] at startup via this Atomic ref (mirrors
+    [File_lock_eio.on_lock_attempt_fn] / [on_cas_retry_fn] pattern).
+
+    [reason] is one of [no_key | not_assoc | json_parse_error] — bounded
+    closed vocabulary.  Empty lines are intentionally not counted (file
+    end newlines are benign).  RFC-0109 §5.1 Option A canary. *)
+let on_parse_drop_fn : (reason:string -> unit) Atomic.t =
+  Atomic.make (fun ~reason:_ -> ())
+
+let observe_parse_drop ~reason =
+  try (Atomic.get on_parse_drop_fn) ~reason
+  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
+
 (** Maximum single value size before truncation (1 MB). *)
 let max_value_size = 1 * 1024 * 1024
 
@@ -202,12 +218,14 @@ let parse_line (line : string) : (string * Yojson.Safe.t option * float) option 
              "memory_jsonl: dropping JSONL line — [key] field missing \
               or not a string (snippet: %S)"
              (snippet_of_line trimmed);
+           observe_parse_drop ~reason:"no_key";
            None)
       | _ ->
         Log.Memory.warn
           "memory_jsonl: dropping JSONL line — top-level JSON is not \
            an Assoc record (snippet: %S)"
           (snippet_of_line trimmed);
+        observe_parse_drop ~reason:"not_assoc";
         None
     with Yojson.Json_error err ->
       Log.Memory.warn
@@ -215,6 +233,7 @@ let parse_line (line : string) : (string * Yojson.Safe.t option * float) option 
          (snippet: %S)"
         err
         (snippet_of_line trimmed);
+      observe_parse_drop ~reason:"json_parse_error";
       None
 
 (** Stream parsed rows from a session file.

--- a/lib/memory_jsonl/memory_jsonl.mli
+++ b/lib/memory_jsonl/memory_jsonl.mli
@@ -85,3 +85,16 @@ val make_backend_with_query_observer :
     Files exceeding 50 MB log a warning but are still read. Individual
     values exceeding 1 MB are replaced with a typed truncation marker
     (see {!encode_line} and {!value_is_truncated_marker}). *)
+
+(** Observability hook fired on every {!parse_line} silent drop with a
+    closed-vocabulary [reason] in [no_key | not_assoc | json_parse_error].
+    Empty lines are intentionally not counted (file-end newlines are
+    benign).
+
+    The leaf [masc_mcp_memory_jsonl] sub-library cannot depend on
+    [Prometheus] (cycle), so emission is wired from the [masc_mcp] root
+    at startup ([lib/coord.ml]) via this Atomic ref.  Mirrors the
+    [File_lock_eio.on_lock_attempt_fn] / [on_cas_retry_fn] pattern.
+
+    RFC-0109 §5.1 Option A canary for V15. *)
+val on_parse_drop_fn : (reason:string -> unit) Atomic.t

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -363,6 +363,15 @@ let metric_tool_keeper_cache_cas_conflicts =
 let metric_file_lock_table_cas_retries =
   "masc_file_lock_table_cas_retries_total"
 
+(* Memory_jsonl.parse_line silent drop counter (V15 / RFC-0109 §5.1
+   Option A).  Bumped from a callback wired in coord.ml — the
+   masc_mcp_memory_jsonl leaf sub-library cannot depend on Prometheus
+   directly (cycle).  Closed-vocabulary [reason] in
+   {no_key | not_assoc | json_parse_error}.  Empty lines benign,
+   not counted. *)
+let metric_memory_jsonl_parse_drops =
+  "masc_memory_jsonl_parse_drops_total"
+
 (* tool_keeper.cache_ttl_seconds env-var parse fallback observability.
    Operator-supplied env var (e.g. MASC_KEEPER_LIST_CACHE_TTL_S) is
    present but the value cannot be parsed as a non-negative float; the
@@ -1367,6 +1376,12 @@ let init () =
     metric_file_lock_table_cas_retries
     "Total File_lock_eio lock-table CAS retries across \
      prune_stale_entries and get_entry. No labels."
+    Counter;
+  add
+    metric_memory_jsonl_parse_drops
+    "Total Memory_jsonl.parse_line silent drop events. \
+     Labels: reason in {no_key | not_assoc | json_parse_error}. \
+     Empty lines not counted."
     Counter;
   add
     metric_tool_keeper_cache_ttl_parse_failures

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -182,6 +182,14 @@ val metric_tool_keeper_cache_cas_conflicts : string
     under load. No labels — only one shared atomic in the module. *)
 val metric_file_lock_table_cas_retries : string
 
+(** Counter for [Memory_jsonl.parse_line] silent drop events.
+    Closed-vocabulary labels: [reason] in
+    [no_key | not_assoc | json_parse_error].  Empty lines are
+    intentionally not counted.  Wired from [lib/coord.ml] via
+    [Memory_jsonl.on_parse_drop_fn].  RFC-0109 §5.1 Option A canary
+    for V15. *)
+val metric_memory_jsonl_parse_drops : string
+
 (** Counter for [tool_keeper.cache_ttl_seconds] env-var parse fallback events.
     Increments when the operator-supplied env var is present but unparseable
     or out-of-range, and the helper falls back to its default. Labels:


### PR DESCRIPTION
## Summary

`Memory_jsonl.parse_line` already emits `Log.Memory.warn` at every silent-drop branch (iter 6 / PR #15668), but operator-side monitoring had no aggregate counter — drop rate could only be observed by log scraping.

**RFC-0109 §6.1.b explicitly lists V15 as Phase 1 backlog** with §5.1 Option A mapping: closed-vocabulary `reason` label at each typed drop arm.

## Three typed drop reasons

| reason | source |
|---|---|
| `no_key` | `[key]` field missing or not a string |
| `not_assoc` | top-level JSON is not an `` `Assoc `` record |
| `json_parse_error` | `Yojson.Json_error` raised inside `from_string` |

Empty lines are benign (file-end newlines) and intentionally not counted. Behaviour preserved: `None` still returned, WARN still emitted; counter increments alongside.

## Sub-library boundary pattern (third reuse)

`masc_mcp_memory_jsonl` is a leaf sub-library that cannot depend on `Prometheus` directly (would create a cycle). Emission goes through `on_parse_drop_fn : (reason:string -> unit) Atomic.t` default no-op, wired at `lib/coord.ml` startup — verbatim mirror of:

1. `File_lock_eio.on_lock_attempt_fn` (existing — flock outcome)
2. `File_lock_eio.on_cas_retry_fn` (iter 46 — CAS retry contention)
3. **`Memory_jsonl.on_parse_drop_fn` (this PR)**

The leaf-sublib observability hook is now a codebase convention.

## Files

| file | change |
|------|--------|
| `lib/memory_jsonl/memory_jsonl.ml(i)` | `on_parse_drop_fn` Atomic ref + `observe_parse_drop` helper; three drop sites in `parse_line` call helper |
| `lib/prometheus.ml(i)` | `metric_memory_jsonl_parse_drops` with `reason` label + registry entry |
| `lib/coord.ml` | `record_memory_jsonl_parse_drop` + `Atomic.set` wiring |

## Workaround Rejection Bar self-check 7/7

1. **telemetry-as-fix?** GRAY — pure counter addition over existing WARN. **Justified**: V15 is explicitly enumerated in RFC-0109 §6.1.b Phase 1 backlog with §5.1 Option A mapping. The RFC document sanctions this exact pattern.
2. **string classifier?** NO — typed `reason` from three structurally distinct match arms.
3. **N-of-M?** NO — all three drop branches covered atomically.
4. **catch-all added?** NO — each drop arm uses a typed constructor pattern.
5. **cap/cooldown/dedup/repair?** NO.
6. **test backdoor?** NO.
7. **codemod-missing typo?** NO.

## Test plan

- [ ] `dune build --root . @check` — PASS locally
- [ ] Inject malformed JSONL line (missing key, non-object, bad json) → expect `reason` label increments distinctly + existing WARN log fires
- [ ] Normal lines → no counter, no WARN (unchanged)
- [ ] Empty lines → no counter (file-end benign)

## RFC

RFC-0109 (Draft, PR #15959) §6.1.b/§5.1 Option A. Not in pr-rfc-check mandatory subsystem list.

Co-Authored-By: claude-opus-4-7 <noreply@anthropic.com>
