### PR TITLE
feat(scripts): RFC-0109 Phase 2 P0 — acknowledged-scan baseline

### DIFF
--- a/scripts/silent-fallback-acknowledged.sh
+++ b/scripts/silent-fallback-acknowledged.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# silent-fallback-acknowledged.sh — RFC-0109 Phase 2 P0 infrastructure.
+#
+# Lists every [@@silent_fallback_acknowledged "..."] attribute occurrence
+# in the OCaml codebase.  Currently 0 sites — the attribute name is
+# reserved for the Phase 2 ppxlib lint described in
+# docs/rfc/RFC-0109-silent-fallback-discipline.md §6.2.
+#
+# Until Phase 2 is implemented, this script gives a baseline count and a
+# `rg`-style table that PR review can quote.  When Phase 2 lints, the
+# lint's "acknowledged" lookup MUST be byte-identical to this scan so
+# review and lint never diverge.
+#
+# Output: one site per line:
+#   <file>:<line>: <attribute body>
+# Exit 0 = scan completed (regardless of count).
+# Use the trailing "total: N" line as the count.
+#
+# Limitations vs Phase 2 lint:
+#   - regex-only; does not validate that the attribute attaches to a
+#     [Pexp_match] / [Pexp_try] node (Phase 2 ppxlib will).
+#   - sees the literal string only, so a renamed attribute is invisible.
+#   - cannot enforce attribute *placement* on a wildcard arm.
+#
+# These limitations are intentional: a regex baseline gives operators a
+# count today without paying the ppxlib build cost.  Phase 2 supersedes.
+
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel)"
+ATTR_NAME="silent_fallback_acknowledged"
+
+cd "$REPO_ROOT"
+
+# Match the OCaml attribute forms:
+#   [@@silent_fallback_acknowledged "..."]
+#   [@@@silent_fallback_acknowledged "..."]   (floating)
+#   [@silent_fallback_acknowledged "..."]     (item-attached)
+# Restrict the rationale string to non-quote chars so a stray quote does
+# not eat the rest of the line.
+PATTERN="\\[@@?@?${ATTR_NAME}[[:space:]]+\"[^\"]*\"\\]"
+
+count=0
+if rg --line-number --no-heading --color=never "$PATTERN" lib/ bin/ test/ 2>/dev/null > /tmp/silent_fallback_hits.$$; then
+  while IFS= read -r line; do
+    echo "$line"
+    count=$((count + 1))
+  done < /tmp/silent_fallback_hits.$$
+fi
+rm -f /tmp/silent_fallback_hits.$$
+
+echo "---"
+echo "total: ${count}"
+echo "attribute_name: ${ATTR_NAME}"
+echo "rfc: docs/rfc/RFC-0109-silent-fallback-discipline.md §6.2"


### PR DESCRIPTION
## Summary

RFC-0109 Phase 2 P0 — reserves the `[@@silent_fallback_acknowledged "..."]` OCaml attribute name and ships a regex-based scan script so PR review can list current deferral markers without paying the ppxlib build cost yet.

Currently **0 sites**. The attribute becomes claimable starting from this PR.

## Why a regex baseline before ppxlib

| concern | answer |
|---|---|
| Why not skip straight to ppxlib? | Building ppxlib AST visitor against 0 markers = dead infrastructure. The attribute *name* must be reserved first so future deferral PRs can use it. |
| Won't regex be noisy? | The script matches the literal attribute form, not arbitrary `_ -> default` patterns. 0 → N transition is precise (no false positives on a unique attribute name). |
| What does Phase 2 lint add later? | AST attachment check: ppxlib verifies the attribute attaches to a `Pexp_match` / `Pexp_try` wildcard arm. Phase 2 PR will declare this script as `supersedes` target. |

## Output format (Phase 2 lint must preserve byte-identity)

```
<file>:<line>: <attribute body>
---
total: N
attribute_name: silent_fallback_acknowledged
rfc: docs/rfc/RFC-0109-silent-fallback-discipline.md §6.2
```

The header comment explicitly enumerates the regex script's limitations so reviewers do not over-trust the count.

## Files

| file | change |
|------|--------|
| `scripts/silent-fallback-acknowledged.sh` | new, +55 lines, executable |

No OCaml code change, no test change, no Prometheus metric, no dune update.

## Self-check 3/3 (RFC-0109 anti-pattern bar)

1. **telemetry-as-fix?** GRAY — script measures, does not enforce. **Justified**: explicit Phase 2 prerequisite, standalone use limited to PR review aid, Phase 2 PR references this script as `supersedes` target.
2. **dead infrastructure?** NO — 0 sites today, but the attribute name becomes claimable starting from this PR. Defers no fix; enables forward marking.
3. **spiral accumulation?** NO — script is forward-looking RFC-0109 Phase 2 P0, not yet another silent-path counter PR.

## Test plan

- [x] `bash scripts/silent-fallback-acknowledged.sh` runs locally, exit 0, outputs `total: 0`
- [ ] After this PR merges, any subsequent PR adding `[@@silent_fallback_acknowledged "..."]` shows up in the script's output

## RFC

RFC-0109 (Draft, #15959) §6.2 Phase 2 P0. Not in pr-rfc-check mandatory subsystem list. Pure scripts/ addition.

Co-Authored-By: claude-opus-4-7 <noreply@anthropic.com>
