### PR TITLE
Slot provider HTTP calls through FD accountant

### DIFF
--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -221,6 +221,19 @@ let request_runtime_fields_on_base_config
     seed = req_config.seed;
   }
 
+let provider_http_slot_transport
+    (transport : Llm_provider.Llm_transport.t)
+  : Llm_provider.Llm_transport.t =
+  { complete_sync =
+      (fun req ->
+        Fd_accountant.with_slot ~kind:Provider_http (fun () ->
+          transport.complete_sync req));
+    complete_stream =
+      (fun ?on_telemetry ~on_event req ->
+        Fd_accountant.with_slot ~kind:Provider_http (fun () ->
+          transport.complete_stream ?on_telemetry ~on_event req));
+  }
+
 let provider_config_preserving_http_transport
     ~sw
     ~net
@@ -233,14 +246,15 @@ let provider_config_preserving_http_transport
         request_runtime_fields_on_base_config ~base:provider_cfg req.config;
     }
   in
-  { complete_sync =
+  provider_http_slot_transport
+    { complete_sync =
       (fun req ->
         (* RFC-0095 Phase 0 diagnostic trace — verify which transport path is invoked
            per turn for each provider. Removed at Phase 0 closeout. *)
         Log.Misc.debug
           "rfc0095-trace: cascade_runner http_transport.complete_sync invoked";
         http_transport.complete_sync (patch_request req));
-    complete_stream =
+      complete_stream =
       (fun ?on_telemetry ~on_event req ->
         (* RFC-0095 Phase 0 diagnostic trace — verify which transport path is invoked
            per turn for each provider. Removed at Phase 0 closeout. *)
@@ -248,7 +262,7 @@ let provider_config_preserving_http_transport
           "rfc0095-trace: cascade_runner http_transport.complete_stream invoked";
         http_transport.complete_stream ?on_telemetry ~on_event
           (patch_request req));
-  }
+    }
 
 let transport_for_provider ~sw ~net ~provider_cfg ?runtime_mcp_policy
     ?cli_transport_overrides () =
@@ -266,6 +280,8 @@ let transport_for_provider ~sw ~net ~provider_cfg ?runtime_mcp_policy
 module For_testing = struct
   let request_runtime_fields_on_base_config =
     request_runtime_fields_on_base_config
+
+  let provider_http_slot_transport = provider_http_slot_transport
 end
 
 (* ================================================================ *)

--- a/lib/cascade/cascade_runner.mli
+++ b/lib/cascade/cascade_runner.mli
@@ -209,6 +209,9 @@ module For_testing : sig
     base:Llm_provider.Provider_config.t ->
     Llm_provider.Provider_config.t ->
     Llm_provider.Provider_config.t
+
+  val provider_http_slot_transport :
+    Llm_provider.Llm_transport.t -> Llm_provider.Llm_transport.t
 end
 
 (** {1 Lifecycle / checkpoint helpers (re-exported)} *)

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2514,6 +2514,38 @@ let require_fd_leak_delta_at_most ~label ~maximum actual =
   then Alcotest.failf "%s: expected fd delta <= %d, got %d" label maximum actual
 ;;
 
+let provider_http_in_flight () =
+  let snapshot = Fd_accountant.fd_snapshot () in
+  List.assoc Fd_accountant.Provider_http snapshot.per_kind
+;;
+
+let test_provider_http_transport_uses_fd_accountant_slot () =
+  Eio_main.run @@ fun _env ->
+  let request = mock_completion_request () in
+  let response = Ok (mock_api_response ()) in
+  let sync_observed_slot = ref false in
+  let stream_observed_slot = ref false in
+  let transport =
+    { Llm_provider.Llm_transport.complete_sync =
+        (fun _req ->
+          sync_observed_slot := provider_http_in_flight () > 0;
+          { Llm_provider.Llm_transport.response; latency_ms = Some 0 })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ _req ->
+          stream_observed_slot := provider_http_in_flight () > 0;
+          response)
+    }
+  in
+  let wrapped = Cascade_runner.For_testing.provider_http_slot_transport transport in
+  Alcotest.(check int) "provider http starts idle" 0 (provider_http_in_flight ());
+  ignore (wrapped.complete_sync request);
+  Alcotest.(check bool) "sync call ran under provider http slot" true !sync_observed_slot;
+  Alcotest.(check int) "provider http sync slot released" 0 (provider_http_in_flight ());
+  ignore (wrapped.complete_stream ~on_event:(fun _ -> ()) request);
+  Alcotest.(check bool) "stream call ran under provider http slot" true !stream_observed_slot;
+  Alcotest.(check int) "provider http stream slot released" 0 (provider_http_in_flight ())
+;;
+
 let test_make_per_call_switch_transport_releases_cli_fd_resources () =
   let request = mock_completion_request () in
   let leaking_delta =
@@ -6657,6 +6689,10 @@ let () =
             "CLI transports release fd resources per call"
             `Quick
             test_make_per_call_switch_transport_releases_cli_fd_resources
+        ; Alcotest.test_case
+            "HTTP transports use provider FD slot"
+            `Quick
+            test_provider_http_transport_uses_fd_accountant_slot
         ; Alcotest.test_case
             "invalid explicit model label is rejected"
             `Quick


### PR DESCRIPTION
## Summary
- wrap MASC-created provider HTTP transports with `Fd_accountant.Provider_http`
- keep sync and streaming provider calls slotted for the duration of the HTTP completion
- add a regression test proving provider HTTP in-flight count rises inside sync/stream calls and releases after return

## Verification
- `git diff --check origin/main...HEAD`
- `ocamlformat --check lib/cascade/cascade_runner.ml lib/cascade/cascade_runner.mli test/test_oas_worker.ml`
- `scripts/dune-local.sh build test/test_oas_worker.exe test/test_fd_accountant.exe`
- `./_build/default/test/test_oas_worker.exe test resume_config 20 --show-errors`
- `./_build/default/test/test_fd_accountant.exe`

## Guard note
Draft-only with `do-not-merge` while #15938 guard behavior is observed under admin-enforced branch protection.