### PR TITLE
[codex] Fix cascade config editor payload

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -128,17 +128,22 @@ interface RawConfigModeSummary {
 function rawConfigModeSummary(
   raw: Pick<
     CascadeRawConfigResponse,
-    'source_path'
+    'source_editable' | 'source_path'
   > | null,
 ): RawConfigModeSummary {
   const sourcePath = raw?.source_path ?? 'cascade.toml'
+  const editable = raw !== null && raw.source_editable !== false
   return {
     title: 'Active Cascade Source',
     primary:
-      `현재 active source는 ${sourcePath} 입니다. 원본 cascade.toml 내용은 dashboard API에서 redaction됩니다.`,
+      editable
+        ? `현재 active source는 ${sourcePath} 입니다.`
+        : `현재 active source는 ${sourcePath} 이지만 읽기 전용 상태입니다.`,
     secondary:
-      '프로필, 후보 label, weight, health, validation 상태만 노출됩니다.',
-    saveLabel: '저장 비활성',
+      editable
+        ? '수정 후 저장하면 서버가 TOML을 검증하고 cascade snapshot을 다시 불러옵니다.'
+        : '소스 파일을 읽을 수 없어 프로필, 후보 label, weight, health, validation 상태만 노출됩니다.',
+    saveLabel: editable ? '저장' : '저장 비활성',
   }
 }
 

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -445,15 +445,17 @@ let raw_config_json () =
            msg;
          "", Some msg)
   in
-  let _ = source_text, raw_json, materialization_error in
   `Assoc
     [ "updated_at", `String (now_iso ())
     ; "source_kind", `String (Cascade_toml_materializer.source_kind_to_string source.kind)
     ; "source_path", `String source.source_path
-    ; "source_editable", `Bool false
-    ; "source_text", `String ""
-    ; "raw_json", `String ""
-    ; "materialization_error", `Null
+    ; "source_editable", `Bool (Option.is_none !source_read_error)
+    ; "source_text", `String source_text
+    ; "raw_json", `String raw_json
+    ; ( "materialization_error"
+      , match materialization_error with
+        | Some msg -> `String msg
+        | None -> `Null )
     ]
 ;;
 

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -25,9 +25,55 @@ let cleanup_dir dir =
   in
   if Sys.file_exists dir then rm dir
 
+let write_file path content =
+  let oc = open_out_bin path in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () -> output_string oc content)
+
+let with_config_dir config_root f =
+  let prev = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  Fun.protect
+    ~finally:(fun () ->
+      (match prev with
+       | Some value -> Unix.putenv "MASC_CONFIG_DIR" value
+       | None -> Unix.putenv "MASC_CONFIG_DIR" "");
+      Config_dir_resolver.reset ())
+    (fun () ->
+      Unix.putenv "MASC_CONFIG_DIR" config_root;
+      Config_dir_resolver.reset ();
+      f ())
+
 let setup_room config =
   (* Use Coord.init to properly initialize MASC *)
   ignore (Lib.Coord.init config ~agent_name:(Some "test-agent"))
+
+let test_raw_cascade_config_exposes_editable_source () =
+  let dir = test_dir () in
+  let source_text = "comment = \"dashboard-visible-sentinel\"\n" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      write_file (Filename.concat dir "cascade.toml") source_text;
+      with_config_dir dir @@ fun () ->
+      let open Yojson.Safe.Util in
+      let json = Lib.Dashboard_cascade.raw_config_json () in
+      Alcotest.(check bool)
+        "source editable"
+        true
+        (json |> member "source_editable" |> to_bool);
+      Alcotest.(check string)
+        "source text"
+        source_text
+        (json |> member "source_text" |> to_string);
+      Alcotest.(check bool)
+        "raw JSON materialized from source"
+        true
+        (contains (json |> member "raw_json" |> to_string) "dashboard-visible-sentinel");
+      match json |> member "materialization_error" with
+      | `Null -> ()
+      | other ->
+        Alcotest.failf
+          "unexpected materialization_error: %s"
+          (Yojson.Safe.to_string other))
 
 (* ===== format_section Tests ===== *)
 
@@ -284,6 +330,9 @@ let section_tests = [
   "tasks section empty", `Quick, test_tasks_section_empty;
   "messages section empty", `Quick, test_messages_section_empty;
   "worktrees section empty", `Quick, test_worktrees_section_empty;
+  ( "raw cascade config exposes editable source",
+    `Quick,
+    test_raw_cascade_config_exposes_editable_source );
 ]
 
 let keepers_tests = [


### PR DESCRIPTION
## Summary

Fixes the cascade config editor surface so the dashboard receives and renders the active `cascade.toml` source instead of an empty, read-only payload.

## Root Cause

`Dashboard_cascade.raw_config_json` read `cascade.toml` and materialized JSON, but then discarded both values and returned `source_editable=false`, `source_text=""`, `raw_json=""`, and `materialization_error=null`. The UI correctly treated that response as read-only/empty, so the cascade config feature appeared missing.

## Changes

- Return the real `source_text`, rendered `raw_json`, and materialization error from `/api/v1/cascade/config/raw`.
- Mark the source editable when the active TOML source can be read.
- Update the cascade config panel copy/button state so editable sources show a usable save action.
- Add an OCaml regression test for the raw cascade config payload contract.

## Validation

- `scripts/dune-local.sh build test/test_dashboard.exe`
- `./_build/default/test/test_dashboard.exe` (18 tests)
- `ocamlformat --check lib/dashboard_cascade.ml test/test_dashboard.ml`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/api/schemas/cascade.test.ts src/api/dashboard-cascade.test.ts src/config/navigation.test.ts src/components/status.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec eslint src/components/cascade-config-panel.ts`
- `git diff --check origin/main...HEAD`
- Rendered Playwright check against `#monitoring?section=cascade-config`: editor populated with source text, not read-only, save button enabled after edit.