### PR TITLE
test(pool): RFC-0107 Phase D.2d — Pool unit tests + TLA+ Pool_no_double_close

### DIFF
--- a/lib/masc_http_client/masc_http_client.ml
+++ b/lib/masc_http_client/masc_http_client.ml
@@ -164,3 +164,9 @@ let get_sync ?clock ?timeout_sec ~net ?https ~url ~headers () =
   with
   | Ok response -> Ok (response.status, response.body)
   | Error _ as error -> error
+
+(* RFC-0107 Phase D.2d — re-export Pool under Masc_http_client.Pool
+   so the test suite (and any direct consumer that wants the
+   typed surface rather than the legacy shim) can name it without
+   reaching into the wrapped library's mangled module path. *)
+module Pool = Pool

--- a/lib/masc_http_client/masc_http_client.mli
+++ b/lib/masc_http_client/masc_http_client.mli
@@ -124,3 +124,14 @@ val get_sync :
 (** [get_sync] is {!get_response_sync} with the response headers
     discarded — returns [Ok (status_code, body_string)] for callers
     that only care about status + body. *)
+
+(** {1 Typed pool surface — RFC-0107 Phase D}
+
+    Re-exports [Pool] (lib/masc_http_client/pool.mli) so callers and
+    tests can name the typed connection pool without reaching into
+    the wrapped module path. Most callers should keep using
+    [post_sync] / [get_sync] / [get_response_sync] which delegate
+    through the per-process [Pool.t] singleton internally; direct
+    [Pool.request] is reserved for code that needs typed responses
+    with header maps or non-default config. *)
+module Pool : module type of Pool

--- a/lib/masc_http_client/pool.ml
+++ b/lib/masc_http_client/pool.ml
@@ -56,7 +56,14 @@ module Host_key = struct
 
   let of_uri uri =
     let scheme = Uri.scheme uri |> Option.value ~default:"http" in
-    let host = Uri.host uri |> Option.value ~default:"localhost" in
+    (* [Uri.host] returns [Some ""] for URLs like "http:///path" instead
+       of [None] (empty authority section). Treat empty as missing so
+       downstream connect doesn't try to resolve "". *)
+    let host =
+      match Uri.host uri with
+      | Some "" | None -> "localhost"
+      | Some h -> h
+    in
     let port = Uri.port uri |> Option.value ~default:(default_port scheme) in
     { scheme; host; port }
 end
@@ -373,3 +380,9 @@ let stats t : stats =
       reuse_count_total = t.counters.reuse_count_total;
       evict_count_total = t.counters.evict_count_total;
       create_count_total = t.counters.create_count_total; })
+
+(* ── Test-only ─────────────────────────────────────────────────── *)
+
+module For_testing = struct
+  module Host_key = Host_key
+end

--- a/lib/masc_http_client/pool.mli
+++ b/lib/masc_http_client/pool.mli
@@ -128,3 +128,21 @@ type stats = {
 }
 
 val stats : t -> stats
+
+(** {1 Test-only — internal data structures}
+
+    Exposed for unit testing of the pure pieces (Host_key normalization,
+    config defaults) without requiring piaf integration. Do not call
+    from production code. *)
+module For_testing : sig
+  module Host_key : sig
+    type t = {
+      scheme : string;
+      host   : string;
+      port   : int;
+    }
+    val of_uri : Uri.t -> t
+    val to_string : t -> string
+    val compare : t -> t -> int
+  end
+end

--- a/specs/keeper-switch-hierarchy/Pool_no_double_close-buggy.cfg
+++ b/specs/keeper-switch-hierarchy/Pool_no_double_close-buggy.cfg
@@ -1,0 +1,31 @@
+\* Buggy model for Pool_no_double_close.
+\* Expected: NoDoubleClose violated (close_count goes to 2 via
+\* NaiveDoubleRelease action).
+\*
+\* Models the hypothetical world where the Pool API exposes naked
+\* acquire/release instead of callback-scoped with_connection/request.
+\* In that world, a caller can forget the callback discipline and
+\* call release twice on the same connection — the exact bug class
+\* Eio #244 documents.
+\*
+\* TLC must produce a counter-example trace:
+\*   1. CreateFresh        → Fresh
+\*   2. StartRequest       → InFlight
+\*   3. ReleaseAndClose    → Closed, close_count=1
+\*   4. NaiveDoubleRelease → close_count=2 (BUG)
+\*
+\* Acts as a regression sentinel: if the Pool API ever exposes a
+\* naked release/close, this cfg fails fast and points exactly at
+\* the structural invariant the callback API enforces.
+
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    MaxConnections = 2
+    MaxRequests = 3
+
+INVARIANTS
+    SafetyInvariant
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/keeper-switch-hierarchy/Pool_no_double_close.cfg
+++ b/specs/keeper-switch-hierarchy/Pool_no_double_close.cfg
@@ -1,0 +1,20 @@
+\* Clean model for Pool_no_double_close.
+\* Expected: Model checking completed. No error has been found.
+\*
+\* Verifies under the actual Pool FSM (CreateFresh, StartRequest,
+\* ReleaseToIdle, ReleaseAndClose, EvictIdle):
+\*   - close_count <= 1 for every connection (NoDoubleClose)
+\*   - state transitions follow Eio #244 exactly-one-owner discipline
+
+SPECIFICATION Spec
+
+CONSTANTS
+    MaxConnections = 2
+    MaxRequests = 3
+
+INVARIANTS
+    TypeOK
+    SafetyInvariant
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/keeper-switch-hierarchy/Pool_no_double_close.tla
+++ b/specs/keeper-switch-hierarchy/Pool_no_double_close.tla
@@ -1,0 +1,176 @@
+---- MODULE Pool_no_double_close ----
+\* RFC-0107 Phase D.2d — connection lifetime exactly-one-owner proof.
+\*
+\* Models the [Pool.t]'s per-connection lifecycle (lib/masc_http_client/pool.ml):
+\*   create_fresh  -> Idle | InFlight
+\*   acquire_idle  -> InFlight (was Idle)
+\*   release       -> Idle (parked) | Closed (close_only or full)
+\*   evict_expired -> Closed
+\*   shutdown_hook -> Closed (any state, on pool sw release)
+\*
+\* The load-bearing invariant: at any point in time, each connection
+\* identity has exactly one owner — Idle (the pool's queue), InFlight
+\* (the requesting fiber), or Closed (terminal).  No connection is
+\* simultaneously Idle and InFlight, no connection is Closed-then-
+\* used, no connection is Closed twice.
+\*
+\* Motivation: Eio #244 ("close: file descriptor used after calling
+\* close!") — Talex5 documents that double-close of a Unix FD is
+\* unsafe.  Our masc_http_client's connection:close workaround was
+\* the symptom; this spec proves the Pool's callback-API design
+\* (request/with_connection) makes double-close structurally
+\* impossible *under the proven invariant*.
+\*
+\* TLA+ Bug Model pattern:
+\*   - Clean cfg: SafetyInvariant holds (no double-close, no use after
+\*     close).  Pass.
+\*   - Buggy cfg: A NaiveDoubleRelease action is added — what happens
+\*     if the caller is allowed to release a connection twice (the
+\*     scenario an [acquire]/[release] API would admit if the user
+\*     mis-handled it).  Invariant violated.  This proves that the
+\*     callback API discipline (with_connection auto-releases) is
+\*     what carries the safety; relaxing it would resurrect the bug.
+
+EXTENDS Naturals, FiniteSets, TLC
+
+CONSTANTS
+    MaxConnections,   \* Upper bound on connections in the model.
+    MaxRequests       \* Upper bound on request operations.
+
+ASSUME MaxConnectionsPos == MaxConnections \in Nat /\ MaxConnections >= 1
+ASSUME MaxRequestsPos    == MaxRequests    \in Nat /\ MaxRequests    >= 1
+
+(* ── State spaces ──────────────────────────────────────────────── *)
+
+\* Connection state: pure FSM. New connections start "Fresh" (created
+\* but not yet attached to anything), transition to InFlight as the
+\* request executes, then to Idle (released back to pool) or Closed
+\* (released-with-close-only, or evicted, or pool shutdown).
+ConnStates == {"Fresh", "Idle", "InFlight", "Closed"}
+
+VARIABLES
+    conns,            \* [1..n] -> ConnStates
+    requests_done,    \* completed request count (bounds termination)
+    close_count       \* per-connection close counter (for invariant)
+
+vars == << conns, requests_done, close_count >>
+
+(* ── Type invariant ─────────────────────────────────────────────── *)
+
+TypeOK ==
+    /\ conns \in [1..MaxConnections -> ConnStates]
+    /\ requests_done \in 0..MaxRequests
+    /\ close_count \in [1..MaxConnections -> Nat]
+
+(* ── Initial state ─────────────────────────────────────────────── *)
+
+Init ==
+    /\ conns = [c \in 1..MaxConnections |-> "Closed"]
+                \* All conns start Closed (== not-yet-created).
+                \* Create_fresh transitions Closed → Fresh.
+    /\ requests_done = 0
+    /\ close_count = [c \in 1..MaxConnections |-> 0]
+
+(* ── Actions ───────────────────────────────────────────────────── *)
+
+\* Create a fresh connection for a Closed slot, transitioning it
+\* into Fresh.  A *new* connection identity is born here; we reset
+\* close_count for this slot so the per-lifetime invariant
+\* NoDoubleClose can be enforced (close_count counts closes within
+\* one connection's life, not across re-uses of the same slot
+\* identifier).
+CreateFresh(c) ==
+    /\ conns[c] = "Closed"
+    /\ conns' = [conns EXCEPT ![c] = "Fresh"]
+    /\ close_count' = [close_count EXCEPT ![c] = 0]
+    /\ UNCHANGED requests_done
+
+\* Start a request: take a Fresh or Idle connection InFlight. The
+\* request is counted *at start* so the TypeOK bound on requests_done
+\* matches the natural sequencing of StartRequest → Release*.
+StartRequest(c) ==
+    /\ conns[c] \in {"Fresh", "Idle"}
+    /\ requests_done < MaxRequests
+    /\ conns' = [conns EXCEPT ![c] = "InFlight"]
+    /\ requests_done' = requests_done + 1
+    /\ UNCHANGED close_count
+
+\* Successful release: return InFlight connection to Idle for reuse.
+\* This is [release ~close_only:false] when pool slot is available.
+ReleaseToIdle(c) ==
+    /\ conns[c] = "InFlight"
+    /\ conns' = [conns EXCEPT ![c] = "Idle"]
+    /\ UNCHANGED << requests_done, close_count >>
+
+\* Error release: connection is suspect, must close (not park).
+\* This is [release ~close_only:true].
+ReleaseAndClose(c) ==
+    /\ conns[c] = "InFlight"
+    /\ conns' = [conns EXCEPT ![c] = "Closed"]
+    /\ close_count' = [close_count EXCEPT ![c] = @ + 1]
+    /\ UNCHANGED requests_done
+
+\* Eviction fiber expires an Idle connection (idle_ttl passed).
+EvictIdle(c) ==
+    /\ conns[c] = "Idle"
+    /\ conns' = [conns EXCEPT ![c] = "Closed"]
+    /\ close_count' = [close_count EXCEPT ![c] = @ + 1]
+    /\ UNCHANGED requests_done
+
+(* ── Buggy action — exposed only in -buggy.cfg ─────────────────── *)
+
+\* Hypothetical: caller has a naked acquire/release API and calls
+\* release twice on the same connection. Increments close_count past
+\* 1 *without* the FSM being in the right state — modelling the
+\* "double Unix.close" bug from Eio #244.
+\*
+\* In our actual Pool implementation, this is structurally impossible:
+\* with_connection auto-releases on callback exit, and request runs
+\* the full lifecycle in one scope. The buggy cfg shows what would
+\* happen if we exposed naked acquire/release.
+NaiveDoubleRelease(c) ==
+    /\ conns[c] = "Closed"
+    /\ close_count[c] >= 1     \* already closed once
+    /\ close_count' = [close_count EXCEPT ![c] = @ + 1]
+    /\ UNCHANGED << conns, requests_done >>
+
+(* ── Next ──────────────────────────────────────────────────────── *)
+
+Next ==
+    \E c \in 1..MaxConnections:
+       \/ CreateFresh(c)
+       \/ StartRequest(c)
+       \/ ReleaseToIdle(c)
+       \/ ReleaseAndClose(c)
+       \/ EvictIdle(c)
+
+NextBuggy ==
+    \/ Next
+    \/ \E c \in 1..MaxConnections: NaiveDoubleRelease(c)
+
+Spec      == Init /\ [][Next]_vars
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+(* ── Invariants ────────────────────────────────────────────────── *)
+
+\* No connection is closed more than once. This is the Eio #244
+\* "exactly-one-owner" property: when a connection transitions to
+\* Closed (either via ReleaseAndClose, EvictIdle, or any future
+\* close path), close_count increments exactly once; never again.
+NoDoubleClose ==
+    \A c \in 1..MaxConnections: close_count[c] <= 1
+
+\* Closed connections do not transition back to InFlight without
+\* going through Fresh first (re-creation, not reuse-after-close).
+\* This is enforced by the FSM shape (StartRequest requires
+\* Fresh|Idle, not Closed).
+NoUseAfterClose ==
+    \A c \in 1..MaxConnections:
+       conns[c] = "Closed" => close_count[c] >= 0
+       \* trivially true given Init; the structural property is
+       \* enforced by StartRequest's guard.
+
+\* Combined safety: no double-close anywhere.
+SafetyInvariant == NoDoubleClose
+
+====

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -29,6 +29,8 @@
    (re_export masc_compression)
    (re_export masc_core)
    (re_export masc_eio_context)
+   ; RFC-0107 Phase D.2d — pool unit tests need access to Pool module.
+   (re_export masc_mcp.http_client)
    (re_export masc_log)
    (re_export masc_mcp)
    (re_export masc_mcp.oas_compat)

--- a/test/dune
+++ b/test/dune
@@ -57,6 +57,7 @@
   test_read_drop_reason
   test_log_ring_encoder
   test_eio_context_fiber_local
+  test_pool
   test_keeper_turn_disposition
   test_keeper_turn_terminal_disposition_field
   test_attempt_state
@@ -343,6 +344,7 @@
   test_read_drop_reason
   test_log_ring_encoder
   test_eio_context_fiber_local
+  test_pool
   test_keeper_turn_disposition
   test_keeper_turn_terminal_disposition_field
   test_attempt_state

--- a/test/test_pool.ml
+++ b/test/test_pool.ml
@@ -1,0 +1,184 @@
+(* RFC-0107 Phase D.2d — Pool unit tests.
+
+   Tests the pure, transport-independent pieces of the connection pool:
+   Host_key normalization, default_config sanity, response/stats type
+   shapes.  Live piaf integration (acquire/release lifecycle,
+   keep-alive reuse) is exercised in the D.2e cascade-storm reproducer.
+
+   The Pool_no_double_close TLA+ spec
+   ([specs/keeper-switch-hierarchy/Pool_no_double_close.tla])
+   complements these unit tests by model-checking the
+   exactly-one-owner invariant on connection lifetime, motivated by
+   Eio #244. *)
+
+module Host_key = Masc_http_client.Pool.For_testing.Host_key
+
+(* ── Host_key.of_uri normalization ───────────────────────────── *)
+
+let test_default_port_http () =
+  let key = Host_key.of_uri (Uri.of_string "http://example.com/path") in
+  Alcotest.(check int) "default port 80 for http" 80 key.port;
+  Alcotest.(check string) "scheme" "http" key.scheme;
+  Alcotest.(check string) "host" "example.com" key.host
+
+let test_default_port_https () =
+  let key = Host_key.of_uri (Uri.of_string "https://api.example.com/v1") in
+  Alcotest.(check int) "default port 443 for https" 443 key.port;
+  Alcotest.(check string) "scheme" "https" key.scheme
+
+let test_explicit_port_preserved () =
+  let key = Host_key.of_uri (Uri.of_string "http://example.com:8080/x") in
+  Alcotest.(check int) "explicit port preserved" 8080 key.port
+
+let test_missing_scheme_falls_back_to_http () =
+  let key = Host_key.of_uri (Uri.of_string "//example.com/x") in
+  Alcotest.(check string) "missing scheme -> http" "http" key.scheme
+
+let test_missing_host_falls_back_to_localhost () =
+  let key = Host_key.of_uri (Uri.of_string "http:///path") in
+  Alcotest.(check string) "missing host -> localhost" "localhost" key.host
+
+(* ── Host_key.compare — pool key identity ──────────────────────── *)
+
+let test_compare_equal_same_uri () =
+  let a = Host_key.of_uri (Uri.of_string "https://api.com/v1") in
+  let b = Host_key.of_uri (Uri.of_string "https://api.com/v2") in
+  Alcotest.(check int) "same scheme+host+port equal regardless of path"
+    0 (Host_key.compare a b)
+
+let test_compare_differs_on_scheme () =
+  let a = Host_key.of_uri (Uri.of_string "http://api.com:443/") in
+  let b = Host_key.of_uri (Uri.of_string "https://api.com:443/") in
+  Alcotest.(check bool) "scheme differs -> keys differ"
+    true (Host_key.compare a b <> 0)
+
+let test_compare_differs_on_port () =
+  let a = Host_key.of_uri (Uri.of_string "http://api.com:8080/") in
+  let b = Host_key.of_uri (Uri.of_string "http://api.com:9090/") in
+  Alcotest.(check bool) "port differs -> keys differ"
+    true (Host_key.compare a b <> 0)
+
+let test_compare_differs_on_host () =
+  let a = Host_key.of_uri (Uri.of_string "http://a.com/") in
+  let b = Host_key.of_uri (Uri.of_string "http://b.com/") in
+  Alcotest.(check bool) "host differs -> keys differ"
+    true (Host_key.compare a b <> 0)
+
+let test_to_string_format () =
+  let key = Host_key.of_uri (Uri.of_string "https://api.example.com:8443/x") in
+  Alcotest.(check string) "to_string format"
+    "https://api.example.com:8443" (Host_key.to_string key)
+
+(* ── default_config sanity ───────────────────────────────────── *)
+
+let test_default_config_max_idle_bounded () =
+  let c = Masc_http_client.Pool.default_config in
+  (* RFC-0101 §2: nofile cap 10240. Pool consumption must be a small
+     fraction. 256 max_total_idle is ~2.5% of the cap. *)
+  Alcotest.(check bool) "max_total_idle <= 1024 (rfc-0101 §2 budget)"
+    true (c.max_total_idle <= 1024);
+  Alcotest.(check bool) "max_idle_per_host <= max_total_idle"
+    true (c.max_idle_per_host <= c.max_total_idle);
+  Alcotest.(check bool) "max_idle_per_host >= 1"
+    true (c.max_idle_per_host >= 1)
+
+let test_default_config_idle_ttl_reasonable () =
+  let c = Masc_http_client.Pool.default_config in
+  Alcotest.(check bool) "idle_ttl_seconds > 0"
+    true (c.idle_ttl_seconds > 0.0);
+  Alcotest.(check bool) "idle_ttl_seconds <= 300s (5 min)"
+    true (c.idle_ttl_seconds <= 300.0)
+
+let test_default_config_connect_timeout_reasonable () =
+  let c = Masc_http_client.Pool.default_config in
+  Alcotest.(check bool) "connect_timeout_seconds > 0"
+    true (c.connect_timeout_seconds > 0.0);
+  Alcotest.(check bool) "connect_timeout_seconds <= 30s"
+    true (c.connect_timeout_seconds <= 30.0)
+
+(* ── http_method polymorphic variant exhaustiveness ──────────── *)
+
+let test_http_method_variants () =
+  (* Ensures the variant set hasn't drifted; if a new method is added
+     to the public mli, this test must be updated explicitly — making
+     drift visible at code review time. *)
+  let _exhaustive : Masc_http_client.Pool.http_method -> string = function
+    | `GET    -> "GET"
+    | `POST   -> "POST"
+    | `PUT    -> "PUT"
+    | `DELETE -> "DELETE"
+    | `HEAD   -> "HEAD"
+    | `PATCH  -> "PATCH"
+  in
+  Alcotest.(check string) "method variants stable" "GET"
+    (_exhaustive `GET)
+
+(* ── stats type shape — Prometheus consumer schema ───────────── *)
+
+let test_stats_zero_state_shape () =
+  (* When the pool is fresh, all counters are zero and there are no
+     idle entries. This locks in the shape the Phase D.4 metrics
+     exporter will consume. *)
+  let zero : Masc_http_client.Pool.stats = {
+    idle_per_host = [];
+    total_idle = 0;
+    total_inflight = 0;
+    reuse_count_total = 0;
+    evict_count_total = 0;
+    create_count_total = 0;
+  } in
+  Alcotest.(check int) "zero total_idle" 0 zero.total_idle;
+  Alcotest.(check int) "zero total_inflight" 0 zero.total_inflight;
+  Alcotest.(check (list (pair string int))) "empty idle_per_host"
+    [] zero.idle_per_host
+
+(* ── Runner ──────────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "pool"
+    [
+      ( "Host_key normalization",
+        [
+          Alcotest.test_case "default port 80 for http" `Quick
+            test_default_port_http;
+          Alcotest.test_case "default port 443 for https" `Quick
+            test_default_port_https;
+          Alcotest.test_case "explicit port preserved" `Quick
+            test_explicit_port_preserved;
+          Alcotest.test_case "missing scheme -> http" `Quick
+            test_missing_scheme_falls_back_to_http;
+          Alcotest.test_case "missing host -> localhost" `Quick
+            test_missing_host_falls_back_to_localhost;
+        ] );
+      ( "Host_key.compare",
+        [
+          Alcotest.test_case "same scheme+host+port equal" `Quick
+            test_compare_equal_same_uri;
+          Alcotest.test_case "scheme differs" `Quick
+            test_compare_differs_on_scheme;
+          Alcotest.test_case "port differs" `Quick
+            test_compare_differs_on_port;
+          Alcotest.test_case "host differs" `Quick
+            test_compare_differs_on_host;
+          Alcotest.test_case "to_string format" `Quick
+            test_to_string_format;
+        ] );
+      ( "default_config bounds (RFC-0101 §2)",
+        [
+          Alcotest.test_case "max_idle bounded" `Quick
+            test_default_config_max_idle_bounded;
+          Alcotest.test_case "idle_ttl reasonable" `Quick
+            test_default_config_idle_ttl_reasonable;
+          Alcotest.test_case "connect_timeout reasonable" `Quick
+            test_default_config_connect_timeout_reasonable;
+        ] );
+      ( "http_method exhaustiveness",
+        [
+          Alcotest.test_case "variants stable" `Quick
+            test_http_method_variants;
+        ] );
+      ( "stats type shape",
+        [
+          Alcotest.test_case "zero state" `Quick test_stats_zero_state_shape;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

RFC-0107 Phase D.2d — Pool unit tests + TLA+ Pool_no_double_close
spec. Stacks on top of the merged D.2a (#15950) and D.2b+D.2c
(#15965).

## Unit tests (`test/test_pool.ml`, 15/15 passing in 0.002s)

Pure transport-independent verification of the public Pool surface:

- **`Host_key.of_uri` normalization** (5 cases): default port 80
  for http, default 443 for https, explicit port preserved, missing
  scheme → http, missing host → localhost.
- **`Host_key.compare` exhaustive** (5 cases): equal scheme+host+port
  regardless of path; differs on scheme / port / host distinctly;
  `to_string` format `<scheme>://<host>:<port>`.
- **`default_config` bounds** (RFC-0101 §2 nofile cap budget):
  `max_total_idle ≤ 1024`, `max_idle_per_host ∈ [1, max_total_idle]`,
  `idle_ttl_seconds ∈ (0, 300]`, `connect_timeout ∈ (0, 30]`.
- **`http_method` exhaustiveness** drift-guard.
- **`stats` type shape** lock for Phase D.4 Prometheus exporter.

## Pool empty-host fix

`Uri.host` returns `Some ""` for URLs like `http:///path` (empty
authority section), not `None`. Pre-fix code passed that empty
string through `Option.value ~default:"localhost"` unchanged →
downstream connect would try to resolve `""`. Fixed by explicit
`Some "" | None → "localhost"` match in `Host_key.of_uri`.

Surfaced by the unit-test case `"missing host -> localhost"`.

## Module surface re-export

`Masc_http_client.{ml,mli}` now re-exports `Pool` as
`Masc_http_client.Pool` (module type alias) so tests and direct
consumers can name the typed surface without reaching into the
wrapped library's mangled module path.

`Pool.For_testing` submodule (mli) exposes `Host_key` for unit tests
only — production code must not call.

## TLA+ `Pool_no_double_close.tla` (Bug Model pattern)

**Clean cfg** (`Pool_no_double_close.cfg`): SafetyInvariant holds.
**67 distinct states**, depth 11, no error in <1s. Models the actual
Pool FSM:

```
CreateFresh → Fresh → StartRequest → InFlight →
  { ReleaseToIdle → Idle  (parked for reuse)
  | ReleaseAndClose → Closed  (suspect connection, close_count++)
  | EvictIdle → Closed  (idle_ttl expired)
  }
```

`CreateFresh` resets `close_count` per lifetime — slot re-use is
a NEW connection identity, not the same connection being closed
twice.

**Buggy cfg** (`Pool_no_double_close-buggy.cfg`): SafetyInvariant
violated in 4 steps via `NaiveDoubleRelease` action (modelling
naked acquire/release API). Trace:

```
1. CreateFresh         → Fresh
2. StartRequest        → InFlight
3. ReleaseAndClose     → Closed, close_count=1
4. NaiveDoubleRelease  → close_count=2  (BUG)
```

Regression sentinel: if the Pool API ever exposes naked
`release` / `close`, the buggy cfg fails fast and points exactly at
the structural invariant the callback API enforces.

**Motivation**: Eio #244 "exactly-one-owner" principle. Talex5's
`Unix.close` double-close panic. Our `masc_http_client`
`connection: close` workaround was the symptom; this spec proves
the callback-scoped API (`request`, `with_connection`) makes
double-close *structurally impossible*.

## Files (10 changed, +464/-1)

- `lib/masc_http_client/pool.ml` — empty-host fix + For_testing submodule
- `lib/masc_http_client/pool.mli` — For_testing submodule export
- `lib/masc_http_client/masc_http_client.{ml,mli}` — Pool re-export
- `specs/keeper-switch-hierarchy/Pool_no_double_close.{tla,cfg,-buggy.cfg}` (new)
- `test/test_pool.ml` (new, 15 tests)
- `test/dune`, `test/deps/dune` — register test_pool

## Verification

- `dune build @check` exit 0
- `dune exec test/test_pool.exe`: 15/15 pass in 0.002s
- TLC clean: 67 distinct states, no error
- TLC buggy: SafetyInvariant violated in 4 steps as expected

## Refs

- RFC-0107 §3.2 Pool design
- D.2a interface: #15950 (merged)
- D.2b+D.2c piaf transport + shim: #15965 (merged)
- Phase B Prior Art: knowledge/research/2026-05-17-piaf-ocsigen-eio-fd
  -prior-art.md
- TLA+ Bug Model pattern: software-development.md §"TLA+ Bug Model 패턴"

RFC-WAIVED: tests + TLA+ spec only; no production behavior change
beyond the empty-host fix (small UX defensive default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
