### PR TITLE
feat(sandbox): RFC-0107 Phase E step 1 — Docker UDS client skeleton (RFC-0097 In-progress)

### DIFF
--- a/docs/rfc/RFC-0097-keeper-sandbox-container-reuse.md
+++ b/docs/rfc/RFC-0097-keeper-sandbox-container-reuse.md
@@ -8,7 +8,7 @@ author: vincent
 supersedes: []
 superseded_by: null
 related: ["0042", "0107"]
-implementation_prs: []
+implementation_prs: ["#15991"]
 ---
 
 # RFC-0097 — Keeper sandbox container reuse

--- a/docs/rfc/RFC-0097-keeper-sandbox-container-reuse.md
+++ b/docs/rfc/RFC-0097-keeper-sandbox-container-reuse.md
@@ -1,22 +1,55 @@
 ---
 rfc: "0097"
 title: "Keeper sandbox container reuse (long-running sandbox per keeper)"
-status: Draft
+status: In-progress
 created: 2026-05-17
 updated: 2026-05-17
 author: vincent
 supersedes: []
 superseded_by: null
-related: ["0042"]
+related: ["0042", "0107"]
 implementation_prs: []
 ---
 
 # RFC-0097 — Keeper sandbox container reuse
 
-Status: Draft
+Status: In-progress (Phase E step 1 landed — skeleton + transport decision)
 Author: jeong-sik (vincent)
 Date: 2026-05-17
-Related: PR #15678 (autonomy_exec pipe FD root fix), PR #15722 (docker spawn throttle — adjacent backpressure).
+Related: PR #15678 (autonomy_exec pipe FD root fix), PR #15722 (docker spawn throttle — adjacent backpressure), RFC-0107 §3.4 (outbound HTTP stack — Docker UDS transport).
+
+## Phase E step 1 — landing note (2026-05-17)
+
+The first implementation increment landed alongside RFC-0107 Phase E step 1:
+
+- `lib/sandbox/docker_api.{mli,ml}` — interface for the UDS HTTP client
+  (`create`, `ping`, `container_create`, `container_start`,
+  `container_exec`, `container_remove`). All function bodies currently
+  `raise Failure` — type-correct skeleton, no production callers.
+- `lib/worker_runtime_docker.ml` and `lib/keeper/keeper_sandbox_runtime.ml`
+  carry an `(* RFC-0107 Phase E step 2 — branch on MASC_DOCKER_TRANSPORT
+  env flag here *)` marker at the docker-spawn dispatch site. The
+  legacy `docker run` / `docker exec` subprocess path stays as the
+  default.
+
+Step 2 (next) replaces the `Failure` stubs with an Eio + cohttp-eio
+implementation over `/var/run/docker.sock` and flips this RFC to
+`Active`. Open items deferred to step 2 (or follow-up RFC) below.
+
+### Step 1 decisions recorded
+
+- **Transport library**: `opam show docker-api` returns
+  `ocaml-docker 0.2.2` with `ocaml < 5` — *incompatible* with our 5.4
+  toolchain. We will not adopt it. The thin self-built wrapper above
+  is the path.
+- **HTTP framing**: `piaf` (the rest of RFC-0107's pool layer) has
+  `Scheme.t = HTTP | HTTPS` only — no `Unix` scheme. UDS therefore
+  stays *outside* `masc_http_pool`; step 2 layers HTTP/1.1 directly on
+  `Eio.Net.connect`'d flow, using `cohttp-eio`'s parser where
+  practical.
+- **Scope**: only the five endpoints above. Image pull / build, volume
+  mount surface, network management are *out of scope* and require an
+  explicit follow-up RFC before they enter the interface.
 
 ## Summary
 

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -34,6 +34,10 @@ let docker_command_argv () =
   | _ -> [ docker_command () ]
 ;;
 
+(* RFC-0107 Phase E step 2 — branch on MASC_DOCKER_TRANSPORT env flag here.
+   When set to "api", route through [Sandbox.Docker_api] (UDS HTTP) instead
+   of forking a [docker] subprocess; the subprocess path stays as the
+   transitional fallback. Default "subprocess" until step 2 lands. *)
 let run_docker_argv_with_status ~summary ~timeout_sec argv =
   Docker_spawn_throttle.with_slot (fun () ->
     Masc_exec.Exec_gate.run_argv_with_status

--- a/lib/sandbox/docker_api.ml
+++ b/lib/sandbox/docker_api.ml
@@ -1,0 +1,54 @@
+(** RFC-0107 Phase E step 1 — Docker UDS HTTP client skeleton.
+
+    All public entry points raise [Failure]. Step 2 will replace these
+    bodies with the actual Eio + cohttp-eio over UDS implementation.
+    Until then there are *zero* production callers — the corresponding
+    [worker_runtime_docker.ml] / [keeper_sandbox_runtime.ml] branches
+    stay on the legacy [docker run / docker exec] subprocess path. *)
+
+(* The skeleton uses a unit type by design (cf. RFC-0107 Phase D.2 —
+   "type-correct skeleton + runtime fail" pattern). Step 2 will replace
+   [t] with a record carrying the daemon endpoint flow, the parent
+   switch, and any per-connection HTTP state. *)
+type t = unit
+
+type exec_response =
+  { exit_code : int
+  ; stdout : string
+  ; stderr : string
+  }
+
+let not_implemented fn =
+  let msg =
+    Printf.sprintf
+      "Docker_api.%s: not yet implemented (RFC-0107 Phase E step 2 — HTTP \
+       transport over /var/run/docker.sock)"
+      fn
+  in
+  raise (Failure msg)
+;;
+
+let create ~sw:_ ~env:_ ?socket_path:_ () : t = not_implemented "create"
+let ping (_ : t) : (unit, string) result = not_implemented "ping"
+
+let container_create (_ : t) ~image:_ ?cmd:_ ?env:_ ()
+  : (string, string) result
+  =
+  not_implemented "container_create"
+;;
+
+let container_start (_ : t) ~container_id:_ : (unit, string) result =
+  not_implemented "container_start"
+;;
+
+let container_exec (_ : t) ~container_id:_ ~cmd:_ ?stdin:_ ()
+  : (exec_response, string) result
+  =
+  not_implemented "container_exec"
+;;
+
+let container_remove (_ : t) ~container_id:_ ?force:_ ()
+  : (unit, string) result
+  =
+  not_implemented "container_remove"
+;;

--- a/lib/sandbox/docker_api.mli
+++ b/lib/sandbox/docker_api.mli
@@ -1,0 +1,105 @@
+(** Docker daemon client over the Unix Domain Socket HTTP API.
+
+    RFC-0107 Phase E step 1 — skeleton + decision only. All functions
+    in [docker_api.ml] currently [raise Failure] and have no production
+    callers. Phase E step 2 will land the actual UDS HTTP transport
+    (see RFC-0107 §3.4 and RFC-0097 — container reuse).
+
+    Design intent (recorded here so the interface does not drift):
+
+    - Connection: connect to [/var/run/docker.sock] via
+      [Eio.Net.connect] (Eio gives us [Eio_unix.Net.unix-addr]). The
+      [piaf] library — used by the rest of RFC-0107 — does not support
+      a [`Unix] scheme in [Piaf.Scheme.t] (HTTP/HTTPS only), so the UDS
+      path stays outside [masc_http_pool]. We layer HTTP/1.1 framing
+      directly on the Eio flow, reusing [cohttp-eio]'s parser if the
+      shape allows; the fallback is a minimal handwritten request /
+      response loop.
+    - Concurrency: a single [t] holds one daemon endpoint. Multiple
+      requests *may* multiplex on the same socket via HTTP/1.1
+      pipelining or, more conservatively, via a per-request connect
+      (still no subprocess fork). RFC-0107 Phase E step 2 decides.
+    - Errors: every function returns [(_, string) result]. The string
+      is intended for [Error_event] / [logs/] only; do not pattern-match
+      on its contents. Structured error variants are deferred to step 2
+      once the real surface is known (cf. RFC-0042 — no string-as-tag).
+    - Scope: only the endpoints below. Image build, volume mount,
+      network management are out of scope for step 1 and will only be
+      added by an explicit RFC follow-up.
+
+    Subprocess fallback ([docker run] / [docker exec]) is unchanged.
+    Selection happens via [MASC_DOCKER_TRANSPORT] in
+    [worker_runtime_docker.ml] / [keeper_sandbox_runtime.ml] — wired in
+    step 2. *)
+
+type t
+(** Opaque handle to a Docker daemon over a UDS HTTP transport.
+    Closed when the parent [Eio.Switch.t] exits. *)
+
+type exec_response =
+  { exit_code : int
+  ; stdout : string
+  ; stderr : string
+  }
+(** Result of [container_exec]. The [exit_code] is the command's exit
+    status as reported by the daemon, not the daemon's own HTTP status. *)
+
+val create
+  :  sw:Eio.Switch.t
+  -> env:Eio_unix.Stdenv.base
+  -> ?socket_path:string
+  -> unit
+  -> t
+(** [create ~sw ~env ?socket_path ()] establishes the daemon endpoint.
+    [socket_path] defaults to ["/var/run/docker.sock"]. The handle is
+    bound to [sw] and any transport-level resources are released on
+    switch exit. *)
+
+val ping : t -> (unit, string) result
+(** [ping t] hits the daemon's [GET /_ping] endpoint for a liveness
+    probe. Returns [Ok ()] if the daemon answers ["OK"]. *)
+
+val container_create
+  :  t
+  -> image:string
+  -> ?cmd:string list
+  -> ?env:(string * string) list
+  -> unit
+  -> (string, string) result
+(** [container_create t ~image ?cmd ?env ()] posts to
+    [/containers/create] and returns the new container id. The
+    container is created in a stopped state; call [container_start]
+    next. Image must already be present on the daemon — image pull is
+    out of scope for step 1. *)
+
+val container_start
+  :  t
+  -> container_id:string
+  -> (unit, string) result
+(** [container_start t ~container_id] posts to
+    [/containers/<id>/start]. Idempotent on the daemon side: an
+    already-started container returns [Ok ()]. *)
+
+val container_exec
+  :  t
+  -> container_id:string
+  -> cmd:string list
+  -> ?stdin:string
+  -> unit
+  -> (exec_response, string) result
+(** [container_exec t ~container_id ~cmd ?stdin ()] runs [cmd] inside
+    the existing container via [/containers/<id>/exec] + [/exec/<id>/start].
+    Captures stdout/stderr and the command's exit code. This is the
+    primary surface that RFC-0097's container reuse activates: instead
+    of one [docker run] per turn, the same container handles N
+    [container_exec] calls. *)
+
+val container_remove
+  :  t
+  -> container_id:string
+  -> ?force:bool
+  -> unit
+  -> (unit, string) result
+(** [container_remove t ~container_id ?force ()] deletes the container
+    via [DELETE /containers/<id>]. With [?force:true] the daemon stops
+    a running container first. *)

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -100,6 +100,10 @@ let run_process_with_timeout
    share the global docker spawn throttle. The cleanup path used to bypass it,
    which meant a 64-worker cancellation/completion wave could still fan out
    [docker rm -f] even after the main [docker run] path was gated. *)
+(* RFC-0107 Phase E step 2 — branch on MASC_DOCKER_TRANSPORT env flag here.
+   When set to "api", route through [Sandbox.Docker_api] (UDS HTTP) instead
+   of forking a [docker] subprocess; the subprocess path stays as the
+   transitional fallback. Default "subprocess" until step 2 lands. *)
 let run_docker_process_with_throttle ?stdin_content ~clock_opt ~timeout_sec ~argv ~env () =
   Docker_spawn_throttle.with_slot (fun () ->
     run_process_with_timeout


### PR DESCRIPTION
## Summary

RFC-0107 Phase E step 1 — interface skeleton for the Docker UDS HTTP client and transport-library decision. Promotes RFC-0097 (keeper sandbox container reuse) from `Draft` to `In-progress`.

**No production behavior change.** All `lib/sandbox/docker_api.ml` entry points `raise Failure`, and there are zero callers. The legacy `docker run` / `docker exec` subprocess path (gated by `Docker_spawn_throttle`) stays unchanged as the default.

## Files

- `lib/sandbox/docker_api.{mli,ml}` (new): opaque `t`, `exec_response`, and `ping` / `container_create` / `container_start` / `container_exec` / `container_remove`. Type-correct skeleton per the RFC-0107 Phase D.2 pattern; all bodies raise `Failure "Docker_api.<fn>: not yet implemented (RFC-0107 Phase E step 2 — HTTP transport over /var/run/docker.sock)"`. `type t = unit` until step 2 replaces it with the real endpoint record.
- `lib/worker_runtime_docker.ml` + `lib/keeper/keeper_sandbox_runtime.ml`: one-comment marker `(* RFC-0107 Phase E step 2 — branch on MASC_DOCKER_TRANSPORT env flag here *)` at the docker spawn dispatch sites.
- `docs/rfc/RFC-0097-keeper-sandbox-container-reuse.md`: frontmatter `status: Draft` → `In-progress`, `related: ["0042", "0107"]`, and a landing note describing the step 1 decisions inline.

`lib/dune` already uses `(include_subdirs unqualified)`, so the new `lib/sandbox/` directory folds into the existing `masc_mcp` library — no `dune` edits needed.

## Decisions recorded

| Question | Decision | Evidence |
|---|---|---|
| Use opam `docker-api`? | **No** | `opam show docker-api` → `0.2.2` constraint `ocaml < 5`. Incompatible with our 5.4 toolchain. |
| Use `piaf` for UDS? | **No (Eio.Net direct)** | `piaf` 0.2.0 `Scheme.t = HTTP | HTTPS` only; no `Unix` scheme. Step 2 layers HTTP/1.1 on a raw `Eio.Net.connect`'d flow, reusing `cohttp-eio`'s parser if the shape allows; otherwise a minimal handwritten loop. UDS path therefore stays outside `masc_http_pool`. |
| Endpoint scope | **5 endpoints only** | `ping`, `container_create`, `container_start`, `container_exec`, `container_remove`. Image pull / build, volume mount, network management are out of scope and require an explicit follow-up RFC. |

## Verification

- `dune build --root . lib/masc_mcp.cma` → clean (library compiles).
- `@check` failures observed all live in `test/test_exec_core.ml` + `lib/exec/test/test_history_insight.ml` and stem from PR #15955 (`BH.append` signature change) — pre-existing on `origin/main`, **not caused by this change**.

## Next (Phase E step 2)

- Replace `Failure` stubs with `Eio.Net.connect` + cohttp-eio HTTP/1.1 over `/var/run/docker.sock`.
- Wire `MASC_DOCKER_TRANSPORT=api` branch at the two marker sites.
- Flip RFC-0097 to `Active`. Open items still deferred: socket-mount security policy, container lifecycle / pool / LRU vs explicit destroy, image build tar payload path.

## Test plan

- [x] `lib/sandbox/` compiles
- [x] `lib/masc_mcp.cma` builds
- [x] No production callers of `Docker_api.*` exist (`rg Docker_api lib/ bin/` returns only the new files)
- [x] `MASC_DOCKER_TRANSPORT` markers present at both spawn dispatch sites
- [x] RFC-0097 frontmatter and body updated

RFC-WAIVED: skeleton + decision only, no production behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)