### PR TITLE
feat(rfc-0107): Phase D.4 — Prometheus exporter for piaf connection pool

### DIFF
--- a/lib/masc_http_client/masc_http_client.ml
+++ b/lib/masc_http_client/masc_http_client.ml
@@ -165,6 +165,12 @@ let get_sync ?clock ?timeout_sec ~net ?https ~url ~headers () =
   | Ok response -> Ok (response.status, response.body)
   | Error _ as error -> error
 
+(* RFC-0107 Phase D.4 — read-only accessor on the per-process pool
+   singleton.  Returns [None] before the first HTTP call (pool not
+   yet lazy-initialized) so callers like [Pool_metrics] can no-op
+   instead of forcing the pool open just to read zeros. *)
+let pool_singleton_opt () : Pool.t option = !pool_ref
+
 (* RFC-0107 Phase D.2d — re-export Pool under Masc_http_client.Pool
    so the test suite (and any direct consumer that wants the
    typed surface rather than the legacy shim) can name it without

--- a/lib/masc_http_client/masc_http_client.mli
+++ b/lib/masc_http_client/masc_http_client.mli
@@ -135,3 +135,11 @@ val get_sync :
     [Pool.request] is reserved for code that needs typed responses
     with header maps or non-default config. *)
 module Pool : module type of Pool
+
+val pool_singleton_opt : unit -> Pool.t option
+(** [pool_singleton_opt ()] returns the per-process [Pool.t] if it
+    has been lazy-initialized by a prior HTTP call, [None] otherwise.
+    Read-only accessor for telemetry consumers (Phase D.4 Prometheus
+    exporter); does not trigger pool initialization.  Callers that
+    need the pool initialized should issue a request through
+    [post_sync] / [get_sync] / [get_response_sync] instead. *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -412,6 +412,16 @@ let metric_fd_limit = "masc_fd_limit"
 let metric_fd_in_flight = "masc_fd_in_flight"
 let metric_fd_pressure_active = "masc_fd_pressure_active"
 
+(* RFC-0107 Phase D.4 — piaf-backed connection pool gauges/counters.
+   Names are owned by [Pool_metrics] (lib/server/pool_metrics.ml).
+   Re-aliased here so [init] can register them in the central registry
+   without reaching into the masc_http_client library. *)
+let metric_pool_idle_total = Pool_metrics.metric_idle_total
+let metric_pool_inflight_total = Pool_metrics.metric_inflight_total
+let metric_pool_reuse_total = Pool_metrics.metric_reuse_total
+let metric_pool_evict_total = Pool_metrics.metric_evict_total
+let metric_pool_create_total = Pool_metrics.metric_create_total
+
 (* Core counters / gauges — used outside init. *)
 let metric_mcp_requests = "masc_mcp_requests_total"
 let metric_llm_inference_duration = "masc_llm_inference_duration_seconds"
@@ -2125,6 +2135,30 @@ let init () =
     metric_fd_pressure_active
     "Whether the shared keeper FD-pressure breaker is active (1 active, 0 inactive)."
     Gauge;
+  (* RFC-0107 Phase D.4 — piaf connection pool metrics.  Snapshot
+     pushed by [update_pool_metrics_gauges] inside [to_prometheus_text]. *)
+  add
+    metric_pool_idle_total
+    "Idle (reusable) connections held by the piaf-backed HTTP pool. \
+     With label [host=\"scheme://host:port\"] this is the per-endpoint \
+     count; the unlabelled time series is the across-host total."
+    Gauge;
+  add
+    metric_pool_inflight_total
+    "Currently in-flight HTTP requests checked out of the piaf-backed pool."
+    Gauge;
+  add
+    metric_pool_reuse_total
+    "Cumulative count of pooled connection reuses (keep-alive hits)."
+    Counter;
+  add
+    metric_pool_evict_total
+    "Cumulative count of pooled connections evicted by idle-TTL or LRU cap."
+    Counter;
+  add
+    metric_pool_create_total
+    "Cumulative count of fresh piaf [Client.t] connections created on pool miss."
+    Counter;
   (* Per-keeper turn outcome + token counters.  Labels are populated
      dynamically via inc_counter; no upfront registration needed.
      Covers issues #7495 (cost/token attribution) and #7519 (SLO). *)
@@ -2935,10 +2969,29 @@ let text_metric_type = function
 let type_to_string metric_type = Prometheus_text.type_to_string (text_metric_type metric_type)
 let labels_to_string = Prometheus_format.labels_to_string
 
+let update_pool_metrics_gauges () =
+  match Pool_metrics.current_snapshot () with
+  | None -> ()
+  | Some stats ->
+    set_gauge metric_pool_inflight_total (float_of_int stats.total_inflight);
+    List.iter
+      (fun (host, idle) ->
+        set_gauge
+          metric_pool_idle_total
+          ~labels:[ "host", host ]
+          (float_of_int idle))
+      stats.idle_per_host;
+    set_gauge metric_pool_idle_total (float_of_int stats.total_idle);
+    set_gauge metric_pool_reuse_total (float_of_int stats.reuse_count_total);
+    set_gauge metric_pool_evict_total (float_of_int stats.evict_count_total);
+    set_gauge metric_pool_create_total (float_of_int stats.create_count_total)
+;;
+
 let to_prometheus_text () =
   update_uptime ();
   update_fd_gauges ();
   update_fd_accountant_gauges ();
+  update_pool_metrics_gauges ();
   (* Snapshot (name, help, metric_type, value, labels) under the mutex so
      the render phase sees a consistent view even when concurrent fibers
      are still updating [metrics].  [m.value] is mutable so we copy it

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -2969,18 +2969,41 @@ let text_metric_type = function
 let type_to_string metric_type = Prometheus_text.type_to_string (text_metric_type metric_type)
 let labels_to_string = Prometheus_format.labels_to_string
 
+(* Track host labels seen in previous scrapes so we can zero out gauges
+   for hosts that disappeared from the pool. Without this, an evicted
+   host's last non-zero idle value would persist in the registry forever
+   and the metrics table would grow unboundedly with every unique host
+   seen. Set is module-local: only [update_pool_metrics_gauges] reads
+   or writes it, and [to_prometheus_text]'s mutex serialises calls. *)
+let pool_idle_seen_hosts : (string, unit) Hashtbl.t = Hashtbl.create 16
+
 let update_pool_metrics_gauges () =
   match Pool_metrics.current_snapshot () with
   | None -> ()
   | Some stats ->
     set_gauge metric_pool_inflight_total (float_of_int stats.total_inflight);
+    let current_hosts = List.map fst stats.idle_per_host in
+    let current_set = List.fold_left (fun acc h -> Hashtbl.replace acc h (); acc)
+                        (Hashtbl.create (List.length current_hosts)) current_hosts in
+    (* Zero out gauges for hosts that disappeared since the last scrape. *)
+    Hashtbl.iter
+      (fun host () ->
+        if not (Hashtbl.mem current_set host)
+        then set_gauge metric_pool_idle_total ~labels:[ "host", host ] 0.0)
+      pool_idle_seen_hosts;
+    (* Write current values + remember them for the next scrape. *)
     List.iter
       (fun (host, idle) ->
         set_gauge
           metric_pool_idle_total
           ~labels:[ "host", host ]
-          (float_of_int idle))
+          (float_of_int idle);
+        Hashtbl.replace pool_idle_seen_hosts host ())
       stats.idle_per_host;
+    (* Drop evicted hosts from the seen-set so we stop tracking them. *)
+    Hashtbl.filter_map_inplace
+      (fun host () -> if Hashtbl.mem current_set host then Some () else None)
+      pool_idle_seen_hosts;
     set_gauge metric_pool_idle_total (float_of_int stats.total_idle);
     set_gauge metric_pool_reuse_total (float_of_int stats.reuse_count_total);
     set_gauge metric_pool_evict_total (float_of_int stats.evict_count_total);

--- a/lib/server/pool_metrics.ml
+++ b/lib/server/pool_metrics.ml
@@ -1,0 +1,26 @@
+(** RFC-0107 Phase D.4 — Prometheus exporter for [Masc_http_client.Pool].
+
+    Read-only adapter: owns the metric name constants and exposes a
+    snapshot accessor over [Masc_http_client.pool_singleton_opt].  The
+    actual Prometheus [set_gauge] calls live in {!Prometheus} (see
+    [update_pool_metrics_gauges] there) to avoid a Prometheus ↔
+    Pool_metrics module cycle. *)
+
+let metric_idle_total = "masc_pool_idle_total"
+let metric_inflight_total = "masc_pool_inflight_total"
+let metric_reuse_total = "masc_pool_reuse_total"
+let metric_evict_total = "masc_pool_evict_total"
+let metric_create_total = "masc_pool_create_total"
+
+let current_snapshot () =
+  match Masc_http_client.pool_singleton_opt () with
+  | None -> None
+  | Some pool -> Some (Masc_http_client.Pool.stats pool)
+
+let register () =
+  (* Idempotent: metric registration happens in [Prometheus.init].
+     This entry point exists so bootstrap can express the dependency
+     order explicitly; we touch the snapshot once so a misconfigured
+     pool surfaces during startup instead of at first scrape. *)
+  let _ : Masc_http_client.Pool.stats option = current_snapshot () in
+  ()

--- a/lib/server/pool_metrics.mli
+++ b/lib/server/pool_metrics.mli
@@ -1,0 +1,54 @@
+(** RFC-0107 Phase D.4 — Prometheus exporter for the piaf-backed
+    connection pool defined in {!Masc_http_client.Pool}.
+
+    Read-only adapter: snapshots [Pool.stats] and pushes 5 metric
+    families to the Prometheus registry on each scrape.  The pool
+    itself is not modified; the lazy singleton is observed via
+    {!Masc_http_client.pool_singleton_opt}.
+
+    Metric names (no shared prefix beyond [masc_pool_]):
+    - [masc_pool_idle_total] (gauge, label [host="scheme://host:port"])
+    - [masc_pool_inflight_total] (gauge)
+    - [masc_pool_reuse_total] (counter)
+    - [masc_pool_evict_total] (counter)
+    - [masc_pool_create_total] (counter)
+
+    The cumulative counters use [Pool.stats.*_total] snapshot values
+    written directly via [Prometheus.set_gauge] on Counter-typed
+    metrics; the metric_type registered in {!Prometheus.init} controls
+    text-format rendering (TYPE counter), so the cumulative-monotonic
+    invariant holds as long as [Pool] never resets its counters. *)
+
+(** {1 Metric name constants} *)
+
+val metric_idle_total : string
+(** [masc_pool_idle_total] — gauge labelled by host. *)
+
+val metric_inflight_total : string
+(** [masc_pool_inflight_total] — gauge, single time series. *)
+
+val metric_reuse_total : string
+(** [masc_pool_reuse_total] — counter, single time series. *)
+
+val metric_evict_total : string
+(** [masc_pool_evict_total] — counter, single time series. *)
+
+val metric_create_total : string
+(** [masc_pool_create_total] — counter, single time series. *)
+
+(** {1 Snapshot accessor} *)
+
+val current_snapshot : unit -> Masc_http_client.Pool.stats option
+(** [current_snapshot ()] returns the live pool snapshot via
+    {!Masc_http_client.pool_singleton_opt}.  Returns [None] when the
+    pool has not been lazy-initialized yet (no HTTP traffic since
+    process start). *)
+
+(** {1 Prometheus integration} *)
+
+val register : unit -> unit
+(** [register ()] is the explicit bootstrap hook.  Metric registration
+    itself happens at module-load time inside {!Prometheus.init}, so
+    [register] is idempotent and currently a no-op beyond a one-shot
+    snapshot warm-up.  Kept as the public bootstrap API per
+    RFC-0107 Phase D.4 §"register entry point". *)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -323,6 +323,12 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   in
   Server_startup_state.note_runtime_resolution ~path_diagnostics
     ~config_resolution;
+  (* RFC-0107 Phase D.4 — wire piaf connection pool Prometheus exporter.
+     Metric registration itself runs at [Prometheus] module load; this
+     call is the explicit dependency-order anchor and warms the snapshot
+     accessor so a misconfigured pool surfaces here rather than at first
+     [/metrics] scrape. *)
+  Pool_metrics.register ();
   state
 
 let runtime_path_diagnostics ?input_base_path (state : Mcp_server.server_state) =

--- a/test/dune
+++ b/test/dune
@@ -1804,6 +1804,15 @@
 ; count so future additions surface in the diff. Requires masc_test_deps
 ; because it accesses Masc_mcp.Tool_name.* values directly.
 
+; RFC-0107 Phase D.4 — Pool_metrics Prometheus exporter regression test.
+; Pins the 5 metric name constants, register () idempotency, and the
+; /metrics text contains the metric families with correct TYPE lines.
+
+(test
+ (name test_pool_metrics)
+ (modules test_pool_metrics)
+ (libraries masc_test_deps))
+
 (test
  (name test_tool_name_exhaustive)
  (modules test_tool_name_exhaustive)

--- a/test/test_pool_metrics.ml
+++ b/test/test_pool_metrics.ml
@@ -1,0 +1,116 @@
+(** RFC-0107 Phase D.4 — Pool_metrics exporter regression test.
+
+    Pinned-name + scrape-shape checks for the piaf connection pool
+    Prometheus exporter.  Verifies:
+
+    - Five metric name constants stay stable (Grafana dashboards pin
+      these names).
+    - [register ()] is idempotent and does not raise.
+    - [current_snapshot ()] returns [None] before the pool is
+      lazy-initialized (no HTTP traffic from the test).
+    - [Prometheus.to_prometheus_text ()] emits all five metric
+      families with the correct TYPE lines once the metrics are
+      registered.
+*)
+
+open Alcotest
+module PM = Masc_mcp.Pool_metrics
+
+let metric_names = [
+  PM.metric_idle_total, "masc_pool_idle_total";
+  PM.metric_inflight_total, "masc_pool_inflight_total";
+  PM.metric_reuse_total, "masc_pool_reuse_total";
+  PM.metric_evict_total, "masc_pool_evict_total";
+  PM.metric_create_total, "masc_pool_create_total";
+]
+
+let test_metric_name_constants () =
+  List.iter
+    (fun (actual, expected) ->
+      check string (Printf.sprintf "metric name %s" expected) expected actual)
+    metric_names
+
+let test_register_idempotent () =
+  PM.register ();
+  PM.register ();
+  PM.register ()
+  (* No exception => pass. *)
+
+let test_current_snapshot_none_when_pool_uninit () =
+  (* In a unit-test context with no prior HTTP traffic, the pool
+     singleton has not been initialized, so the snapshot accessor
+     returns [None].  This is the "no-op" invariant relied on by
+     [Prometheus.update_pool_metrics_gauges]. *)
+  (match PM.current_snapshot () with
+   | None -> ()
+   | Some _ -> fail "pool snapshot should be None before first HTTP call")
+
+let metric_lines_for name text =
+  text
+  |> String.split_on_char '\n'
+  |> List.filter (fun line ->
+       (* Look for "# TYPE <name> ..." or "<name>{...} <value>" /
+          "<name> <value>" — both anchor on the same prefix. *)
+       String.length line >= String.length name
+       && (
+         let prefix_match s =
+           let plen = String.length s in
+           String.length line >= plen
+           && String.sub line 0 plen = s
+         in
+         prefix_match ("# TYPE " ^ name)
+         || prefix_match (name ^ " ")
+         || prefix_match (name ^ "{")))
+
+let test_to_prometheus_text_contains_metric_families () =
+  let text = Masc_mcp.Prometheus.to_prometheus_text () in
+  List.iter
+    (fun (_, name) ->
+      let lines = metric_lines_for name text in
+      check bool
+        (Printf.sprintf "/metrics output contains %s" name)
+        true
+        (List.length lines > 0))
+    metric_names
+
+let test_inflight_is_gauge_type () =
+  (* TYPE line discipline: idle/inflight should render as gauge,
+     reuse/evict/create as counter.  Pin a representative for each
+     bucket so render-time drift is caught. *)
+  let text = Masc_mcp.Prometheus.to_prometheus_text () in
+  let contains needle =
+    let nlen = String.length needle in
+    let len = String.length text in
+    let rec scan i =
+      if i + nlen > len then false
+      else if String.sub text i nlen = needle then true
+      else scan (i + 1)
+    in
+    scan 0
+  in
+  check bool "inflight_total is gauge" true
+    (contains "# TYPE masc_pool_inflight_total gauge");
+  check bool "reuse_total is counter" true
+    (contains "# TYPE masc_pool_reuse_total counter");
+  check bool "create_total is counter" true
+    (contains "# TYPE masc_pool_create_total counter")
+
+let () =
+  run "Pool_metrics" [
+    "name constants", [
+      test_case "metric names stable" `Quick test_metric_name_constants;
+    ];
+    "register", [
+      test_case "register is idempotent" `Quick test_register_idempotent;
+    ];
+    "snapshot", [
+      test_case "current_snapshot None before HTTP traffic" `Quick
+        test_current_snapshot_none_when_pool_uninit;
+    ];
+    "prometheus integration", [
+      test_case "to_prometheus_text contains all 5 metric families" `Quick
+        test_to_prometheus_text_contains_metric_families;
+      test_case "metric TYPE lines match gauge/counter intent" `Quick
+        test_inflight_is_gauge_type;
+    ];
+  ]


### PR DESCRIPTION
## Summary

RFC-0107 Phase D.4. Adds a read-only Prometheus adapter over `Masc_http_client.Pool.stats` so the piaf-backed connection pool (merged in Phase D.2c) becomes observable. The pool itself is untouched: `lib/masc_http_client/pool.ml` is read via `Pool.stats` only — no API changes.

Five metric families exported on `/metrics`:

| Metric | Type | Labels |
|---|---|---|
| `masc_pool_idle_total` | gauge | `host="scheme://host:port"` (also aggregate, unlabelled) |
| `masc_pool_inflight_total` | gauge | — |
| `masc_pool_reuse_total` | counter | — |
| `masc_pool_evict_total` | counter | — |
| `masc_pool_create_total` | counter | — |

## Wiring

- **`Masc_http_client.pool_singleton_opt`** — read-only accessor on the lazy pool ref. Returns `None` until the first HTTP call so the exporter no-ops on startup instead of forcing pool init just to read zeros.
- **`lib/server/pool_metrics.{ml,mli}`** — owns the metric name constants, exposes `current_snapshot ()` and `register ()`. No Prometheus dependency to avoid a `Prometheus ↔ Pool_metrics` module cycle.
- **`lib/prometheus.ml`** — registers the 5 metrics in `init()` and calls the new `update_pool_metrics_gauges ()` inside `to_prometheus_text ()`, mirroring the existing `update_fd_accountant_gauges ()` pattern.
- **`lib/server/server_runtime_bootstrap.ml`** — calls `Pool_metrics.register ()` at the tail of `create_server_state` for explicit dependency-order anchoring; registration itself is idempotent because metric `add` happens at `Prometheus` module load.

## Layout deviation from spec

Spec called for `pool_metrics.ml` under `lib/masc_http_client/`, but `Prometheus` lives in the `masc_mcp` library which already depends on `masc_http_client`. Placing `pool_metrics.ml` inside `masc_http_client` would either invert the dep direction or force a callback-ref dance. Mirroring the `fd_accountant` pattern (`lib/server/fd_accountant.ml` + integration in `lib/prometheus.ml`) keeps the read-only direction clean. First build attempt produced exactly this cycle (`Prometheus → Pool_metrics → Prometheus`); the chosen layout breaks it cleanly.

## Test plan

- [x] `dune build --root . @check` exit 0
- [x] `test/test_pool_metrics.ml` — 5/5 PASS
  - metric name constants stable (Grafana dashboard pin)
  - `register ()` idempotent
  - `current_snapshot ()` returns `None` before first HTTP call
  - `to_prometheus_text ()` contains all 5 metric families
  - TYPE lines render as `gauge` / `counter` correctly
- [x] `test_prometheus_coverage` 64/64 still PASS (no regression in shared registry)
- [x] `test_masc_http_client` 2/2 still PASS (singleton accessor doesn't disturb the closing-client path)
- [ ] D.5 cascade-storm reproducer to read these gauges (out of scope here)
- [ ] Dashboard tile consuming the new metrics (RFC-0107 Phase D step "D.4 dashboard tile" — separate PR)

## Anti-pattern self-check (workaround rejection bar)

- No telemetry-as-fix: this *is* telemetry, the pool itself is unchanged.
- No string classifier added.
- No N-of-M migration: all 5 stats fields are exported in one pass.
- No catch-all match arm added.
- No cap/cooldown/dedup/repair.
- No test backdoor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>