### PR TITLE
fix(test): bash_history.append signature — Result.get_ok callers (hotfix #15955)

### DIFF
--- a/lib/exec/test/test_history_insight.ml
+++ b/lib/exec/test/test_history_insight.ml
@@ -32,7 +32,12 @@ let make_entry ~cmd ~success ~duration =
     BH.success }
 
 let append_entries dir name entries =
-  List.iter (BH.append ~base_path:dir ~keeper_name:name) entries
+  List.iter
+    (fun e ->
+      match BH.append ~base_path:dir ~keeper_name:name e with
+      | Ok () -> ()
+      | Error exn -> failwith (Printexc.to_string exn))
+    entries
 
 (* --- tests --- *)
 

--- a/test/test_exec_core.ml
+++ b/test/test_exec_core.ml
@@ -610,12 +610,14 @@ let with_p11_base_path f =
 let test_history_append_and_read () =
   with_p11_base_path @@ fun base_path ->
   let module H = Masc_exec.Bash_history in
-  H.append ~base_path ~keeper_name:"test-keeper"
-    { ts = 1000.0; cmd_hash = "abc123"; cmd_prefix = "git status";
-      semantic_kind = "Read"; duration_ms = 50; success = true };
-  H.append ~base_path ~keeper_name:"test-keeper"
-    { ts = 2000.0; cmd_hash = "def456"; cmd_prefix = "dune build";
-      semantic_kind = "Build"; duration_ms = 5000; success = false };
+  Result.get_ok
+    (H.append ~base_path ~keeper_name:"test-keeper"
+       { ts = 1000.0; cmd_hash = "abc123"; cmd_prefix = "git status";
+         semantic_kind = "Read"; duration_ms = 50; success = true });
+  Result.get_ok
+    (H.append ~base_path ~keeper_name:"test-keeper"
+       { ts = 2000.0; cmd_hash = "def456"; cmd_prefix = "dune build";
+         semantic_kind = "Build"; duration_ms = 5000; success = false });
   let results =
     H.suggest ~base_path ~keeper_name:"test-keeper" ~pattern:"git" ~limit:10
   in
@@ -641,10 +643,11 @@ let test_history_compaction () =
   with_p11_base_path @@ fun base_path ->
   let module H = Masc_exec.Bash_history in
   for i = 1 to 15 do
-    H.append ~base_path ~keeper_name:"compact-test"
-      { ts = float_of_int i; cmd_hash = string_of_int i;
-        cmd_prefix = "cmd" ^ string_of_int i;
-        semantic_kind = "Unknown"; duration_ms = 10; success = true }
+    Result.get_ok
+      (H.append ~base_path ~keeper_name:"compact-test"
+         { ts = float_of_int i; cmd_hash = string_of_int i;
+           cmd_prefix = "cmd" ^ string_of_int i;
+           semantic_kind = "Unknown"; duration_ms = 10; success = true })
   done;
   (* 15 entries is below max_entries (10000), so compact is a no-op *)
   H.compact ~base_path ~keeper_name:"compact-test";


### PR DESCRIPTION
## Summary

Main build is broken. #15955 (\`e6ea921f99\` decouple audit append failure from tool-call semantics) widened \`Bash_history.append\` return from \`unit\` to \`(unit, exn) result\` in \`lib/exec/bash_history.mli\`, but the **squash merge dropped the corresponding test updates** that were present in the PR head before merge.

\`\`\`
File \"lib/exec/test/test_history_insight.ml\", line 35, characters 12-56:
35 |   List.iter (BH.append ~base_path:dir ~keeper_name:name) entries
Error: This expression has type BH.history_entry -> (unit, exn) result
       but an expression was expected of type BH.history_entry -> unit

File \"test/test_exec_core.ml\", lines 613-615, characters 2-64:
Error (warning 10 [non-unit-statement]): this expression should have type unit.
\`\`\`

(Three sites in total: line 613, 616, 644 of test_exec_core.ml + line 35 of test_history_insight.ml.)

## Fix

Restore the test-side adapter pattern that #15955 head had before merge:

- \`test_history_insight.ml:34-40\` — \`List.iter\` with explicit \`match ... | Ok () -> () | Error exn -> failwith\` (audit error surfaces as Alcotest failure, no silent loss).
- \`test_exec_core.ml:610-618, 643-648\` — \`Result.get_ok (H.append ...)\` (Error -> Invalid_argument -> test failure).

## Why a separate PR (not a push to #15955)

Memory \`feedback_post_merge_push_check_required\` / workflow-pr.md §10:
> 병합된 PR 브랜치에 절대 push 하지 않는다. Squash merge 후 브랜치에 추가된 커밋은 main에 도달하지 않는다.

So a fresh branch + new PR is the correct recovery path for a squash-merge drop.

## Verification

- [x] \`dune build --root . @check\` clean

## Workaround Rejection Bar self-check 7/7

1. **telemetry-as-fix?** NO — restoring lost test wiring, not a counter band-aid.
2. **string classifier?** NO.
3. **N-of-M?** NO — all three drop sites covered (verified via \`rg \"H.append\" test/ lib/exec/test/\`).
4. **catch-all added?** NO — explicit \`Ok ()\`/\`Error exn\` arms.
5. **cap/cooldown/dedup?** NO.
6. **test backdoor?** NO — Result.get_ok / failwith are standard test patterns, not test-only API.
7. **codemod-missing typo?** NO — pattern applied uniformly at all three call sites.

## RFC

None — pure test-side fix for a squash-merge data loss. Not in any RFC-mandatory subsystem.

Co-Authored-By: claude-opus-4-7 <noreply@anthropic.com>