### PR TITLE
fix: slot dated JSONL appends through FD accountant

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -21,6 +21,9 @@ type t = {
   last_prune_day : string option Atomic.t;
 }
 
+let default_append_guard f = f ()
+let append_guard : ((unit -> unit) -> unit) Atomic.t = Atomic.make default_append_guard
+
 let mutex_registry : (string, Eio.Mutex.t Atomic.t) Hashtbl.t = Hashtbl.create 16
 let mutex_registry_mu = Stdlib.Mutex.create ()
 
@@ -253,7 +256,7 @@ let prune_unlocked t ~days =
 
 (* ── Public API ───────────────────────────────────────── *)
 
-let append t json =
+let append_inner t json =
   let mutex = Atomic.get t.mutex in
   (* [use_ro] serializes file appends without poisoning the shared mutex on
      IO failure, so retry paths can keep using the same registry entry.
@@ -275,6 +278,11 @@ let append t json =
         ignore (prune_unlocked t ~days : int);
         Atomic.set t.last_prune_day (Some today)
       end)
+
+let append t json =
+  (Atomic.get append_guard) (fun () -> append_inner t json)
+
+let set_append_guard guard = Atomic.set append_guard guard
 
 let read_recent t n =
   if n <= 0 then []
@@ -407,6 +415,8 @@ module For_testing = struct
   let registry_size () =
     Stdlib.Mutex.protect mutex_registry_mu (fun () ->
       Hashtbl.length mutex_registry)
+
+  let reset_append_guard () = Atomic.set append_guard default_append_guard
 end
 
 (* Duplicate count_entries removed — canonical definition at line 225 *)

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -21,6 +21,12 @@ val append : t -> Yojson.Safe.t -> unit
 (** Append [json] to today's [DD.jsonl] inside [YYYY-MM/].
     Creates directories as needed.  Thread-safe via internal mutex. *)
 
+val set_append_guard : ((unit -> unit) -> unit) -> unit
+(** [set_append_guard guard] installs a process-wide wrapper around
+    {!append}.  The default guard runs the callback immediately.  Higher-level
+    runtimes can install resource accounting/backpressure without making this
+    low-level storage library depend on those policy modules. *)
+
 val read_recent : t -> int -> Yojson.Safe.t list
 (** [read_recent t n] returns the newest [n] entries in chronological order
     (oldest first).  Scans day-files from newest to oldest, stops early. *)
@@ -71,4 +77,6 @@ module For_testing : sig
   val registry_size : unit -> int
   (** Number of distinct [base_dir] keys currently held by the
       file-scope mutex registry. *)
+
+  val reset_append_guard : unit -> unit
 end

--- a/lib/server/fd_accountant.ml
+++ b/lib/server/fd_accountant.ml
@@ -69,6 +69,15 @@ let effective_concurrency ~kind =
   if Keeper_fd_pressure.active () then 1
   else (state_of kind).cap
 
+let install_dated_jsonl_log_writer_guard () =
+  Dated_jsonl.set_append_guard (fun f ->
+    if Eio_guard.is_ready () then
+      with_slot ~kind:Log_writer f
+    else
+      f ())
+
+let () = install_dated_jsonl_log_writer_guard ()
+
 (* In-flight count = configured cap minus current semaphore credits.
    Eio.Semaphore exposes [get_value] which returns the available credit
    count; in-flight = cap − available. *)

--- a/lib/server/fd_accountant.mli
+++ b/lib/server/fd_accountant.mli
@@ -58,6 +58,14 @@ val configured_concurrency : kind:kind -> int
 (** [configured_concurrency ~kind] returns the env-configured cap
     irrespective of current pressure state. *)
 
+val install_dated_jsonl_log_writer_guard : unit -> unit
+(** [install_dated_jsonl_log_writer_guard ()] installs the process-wide
+    {!Dated_jsonl} append guard that accounts date-split JSONL writes as
+    {!Log_writer} while {!Eio_guard} is ready. Before Eio startup, the guard
+    runs the append directly so module-load and pure test paths stay safe. The
+    module installs it at load time; the explicit function exists for tests and
+    future bootstrap code that resets storage hooks. *)
+
 type snapshot = {
   per_kind : (kind * int) list ;
       (** in-flight count per class (cap − available semaphore slots). *)

--- a/test/test_fd_accountant.ml
+++ b/test/test_fd_accountant.ml
@@ -12,6 +12,12 @@ open Alcotest
 module FA = Masc_mcp.Fd_accountant
 module DST = Masc_mcp.Docker_spawn_throttle
 
+let tmpdir prefix =
+  Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "%s_%d_%.0f" prefix (Unix.getpid ())
+       (Unix.gettimeofday ()))
+
 let test_kind_round_trip () =
   List.iter
     (fun k ->
@@ -112,6 +118,43 @@ let test_snapshot_shape () =
   check bool "pressure_active mirrors Keeper_fd_pressure" expected
     s.pressure_active
 
+let log_writer_in_flight () =
+  let snapshot = FA.fd_snapshot () in
+  List.assoc FA.Log_writer snapshot.per_kind
+
+let wait_until ~clock ~attempts predicate =
+  let rec loop remaining =
+    if predicate () then true
+    else if remaining <= 0 then false
+    else (
+      Eio.Time.sleep clock 0.001 ;
+      loop (remaining - 1))
+  in
+  loop attempts
+
+let test_dated_jsonl_append_uses_log_writer_slot () =
+  Eio_main.run @@ fun env ->
+  Eio_guard.enable () ;
+  let dir = tmpdir "fd_accountant_dated_jsonl_log_writer" in
+  Fs_compat.mkdir_p dir ;
+  Fs_compat.set_fs (Eio.Stdenv.fs env) ;
+  Fun.protect ~finally:Eio_guard.disable (fun () ->
+      Dated_jsonl.For_testing.reset_append_guard () ;
+      FA.install_dated_jsonl_log_writer_guard () ;
+      let store = Dated_jsonl.create ~base_dir:dir () in
+      let mutex = Dated_jsonl.For_testing.mutex store in
+      let clock = Eio.Stdenv.clock env in
+      let () =
+        Eio.Switch.run @@ fun sw ->
+        Eio.Mutex.use_rw ~protect:true mutex (fun () ->
+            Eio.Fiber.fork ~sw (fun () ->
+                Dated_jsonl.append store (`Assoc [ ("i", `Int 1) ])) ;
+            check bool "append waits while holding log writer slot" true
+              (wait_until ~clock ~attempts:100 (fun () ->
+                   log_writer_in_flight () > 0)))
+      in
+      check int "log writer slot released" 0 (log_writer_in_flight ()))
+
 let () =
   Alcotest.run "Fd_accountant"
     [
@@ -137,4 +180,9 @@ let () =
         ] ) ;
       ( "snapshot",
         [ test_case "shape" `Quick test_snapshot_shape ] ) ;
+      ( "log writer",
+        [
+          test_case "Dated_jsonl append uses slot" `Quick
+            test_dated_jsonl_append_uses_log_writer_slot ;
+        ] ) ;
     ]


### PR DESCRIPTION
## Summary
- add a Dated_jsonl append guard hook so low-level storage stays independent of FD policy
- install the FD accountant Log_writer guard from the main runtime layer, with Eio_guard readiness fallback before Eio startup
- add a regression test proving Dated_jsonl.append holds and releases the Log_writer slot

## Verification
- git diff --check origin/main...HEAD
- ocamlformat --check lib/dated_jsonl/dated_jsonl.ml lib/dated_jsonl/dated_jsonl.mli lib/server/fd_accountant.ml lib/server/fd_accountant.mli test/test_fd_accountant.ml test/test_dated_jsonl.ml
- scripts/dune-local.sh build test/test_dated_jsonl.exe test/test_fd_accountant.exe
- ./_build/default/test/test_fd_accountant.exe
- ./_build/default/test/test_dated_jsonl.exe