### PR TITLE
fix: account Process_eio foreground spawns

### DIFF
--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -47,13 +47,22 @@ let observe_process_timeout argv ~timeout_sec =
     Log.Misc.warn "[Process_eio] timeout observer failed: %s"
       (Printexc.to_string exn)
 
+type spawn_guard = { run : 'a. (unit -> 'a) -> 'a }
+
+let default_spawn_guard = { run = (fun f -> f ()) }
+let spawn_guard : spawn_guard Atomic.t = Atomic.make default_spawn_guard
+let set_spawn_guard guard = Atomic.set spawn_guard guard
+let reset_spawn_guard_for_testing () = Atomic.set spawn_guard default_spawn_guard
+let with_spawn_guard f = (Atomic.get spawn_guard).run f
+
 let init ~cwd_default ~proc_mgr ~clock =
   Atomic.set runtime_state (Some { proc_mgr; clock; cwd_default })
 
 let is_initialized () = Option.is_some (Atomic.get runtime_state)
 
 let reset_for_testing () =
-  Atomic.set runtime_state None
+  Atomic.set runtime_state None;
+  reset_spawn_guard_for_testing ()
 
 let default_buffer_size = 1024
 
@@ -508,74 +517,78 @@ let spawn_and_drain_both ~sw pm ~cwd ?env ?stdin_source argv stdout_buf
 
 let run_argv ?(timeout_sec = default_timeout_sec) ?env (argv : string list) : string =
   Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv ~argv ?env ();
-  if not (is_initialized ()) then
-    run_unix_argv_fallback ~timeout_sec ?env argv
-  else
-    match get_proc_mgr (), get_clock (), get_cwd_default () with
-    | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
+  with_spawn_guard (fun () ->
+      if not (is_initialized ()) then
         run_unix_argv_fallback ~timeout_sec ?env argv
-    | Ok pm, Ok clk, Ok cwd ->
-        let buf = Buffer.create default_buffer_size in
-        let label = String.concat " " (List.map Filename.quote argv) in
-        try
-          Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
-              Eio.Switch.run (fun sw ->
-                  let status = spawn_and_drain_stdout ~sw pm ~cwd ?env argv buf in
-                  output_for_status ~status ~stdout:(Buffer.contents buf) ~stderr:""))
-        with
-        | Eio.Time.Timeout ->
-            Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
-              timeout_sec label;
-            observe_process_timeout argv ~timeout_sec;
-            process_error_output ~label
-              ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
-        | Eio.Cancel.Cancelled _ as exn -> raise exn
-        | exn ->
-            if should_retry_unix_fallback exn then (
-              Log.Misc.warn
-                "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
-                label (Printexc.to_string exn);
-              run_unix_argv_fallback ~timeout_sec ?env argv
-            ) else (
-              Log.Misc.error "[Process_eio] argv error: %s — %s" label
-                (Printexc.to_string exn);
-              process_error_output ~label ~reason:(reason_of_exn_for_output exn) ())
+      else
+        match get_proc_mgr (), get_clock (), get_cwd_default () with
+        | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
+            run_unix_argv_fallback ~timeout_sec ?env argv
+        | Ok pm, Ok clk, Ok cwd ->
+            let buf = Buffer.create default_buffer_size in
+            let label = String.concat " " (List.map Filename.quote argv) in
+            try
+              Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
+                  Eio.Switch.run (fun sw ->
+                      let status = spawn_and_drain_stdout ~sw pm ~cwd ?env argv buf in
+                      output_for_status ~status ~stdout:(Buffer.contents buf) ~stderr:""))
+            with
+            | Eio.Time.Timeout ->
+                Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
+                  timeout_sec label;
+                observe_process_timeout argv ~timeout_sec;
+                process_error_output ~label
+                  ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
+            | Eio.Cancel.Cancelled _ as exn -> raise exn
+            | exn ->
+                if should_retry_unix_fallback exn then (
+                  Log.Misc.warn
+                    "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
+                    label (Printexc.to_string exn);
+                  run_unix_argv_fallback ~timeout_sec ?env argv
+                ) else (
+                  Log.Misc.error "[Process_eio] argv error: %s — %s" label
+                    (Printexc.to_string exn);
+                  process_error_output ~label ~reason:(reason_of_exn_for_output exn) ()))
 
 let run_argv_with_stdin ?(timeout_sec = default_timeout_sec) ?env ~(stdin_content : string) (argv : string list) : string =
   Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv_with_stdin ~argv ?env ();
-  if not (is_initialized ()) then
-    run_unix_argv_with_stdin_fallback ~timeout_sec ?env ~stdin_content argv
-  else
-    match get_proc_mgr (), get_clock (), get_cwd_default () with
-    | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
+  with_spawn_guard (fun () ->
+      if not (is_initialized ()) then
         run_unix_argv_with_stdin_fallback ~timeout_sec ?env ~stdin_content argv
-    | Ok pm, Ok clk, Ok cwd ->
-        let buf = Buffer.create default_buffer_size in
-        let label = String.concat " " (List.map Filename.quote argv) in
-        let stdin_source = Eio.Flow.string_source stdin_content in
-        try
-          Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
-              Eio.Switch.run (fun sw ->
-                  let status = spawn_and_drain_stdout ~sw pm ~cwd ?env ~stdin_source argv buf in
-                  output_for_status ~status ~stdout:(Buffer.contents buf) ~stderr:""))
-        with
-        | Eio.Time.Timeout ->
-            Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
-              timeout_sec label;
-            observe_process_timeout argv ~timeout_sec;
-            process_error_output ~label
-              ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
-        | Eio.Cancel.Cancelled _ as exn -> raise exn
-        | exn ->
-            if should_retry_unix_fallback exn then (
-              Log.Misc.warn
-                "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
-                label (Printexc.to_string exn);
-              run_unix_argv_with_stdin_fallback ~timeout_sec ?env ~stdin_content argv
-            ) else (
-              Log.Misc.error "[Process_eio] argv error: %s — %s" label
-                (Printexc.to_string exn);
-              process_error_output ~label ~reason:(reason_of_exn_for_output exn) ())
+      else
+        match get_proc_mgr (), get_clock (), get_cwd_default () with
+        | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
+            run_unix_argv_with_stdin_fallback ~timeout_sec ?env ~stdin_content argv
+        | Ok pm, Ok clk, Ok cwd ->
+            let buf = Buffer.create default_buffer_size in
+            let label = String.concat " " (List.map Filename.quote argv) in
+            let stdin_source = Eio.Flow.string_source stdin_content in
+            try
+              Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
+                  Eio.Switch.run (fun sw ->
+                      let status =
+                        spawn_and_drain_stdout ~sw pm ~cwd ?env ~stdin_source argv buf
+                      in
+                      output_for_status ~status ~stdout:(Buffer.contents buf) ~stderr:""))
+            with
+            | Eio.Time.Timeout ->
+                Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
+                  timeout_sec label;
+                observe_process_timeout argv ~timeout_sec;
+                process_error_output ~label
+                  ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
+            | Eio.Cancel.Cancelled _ as exn -> raise exn
+            | exn ->
+                if should_retry_unix_fallback exn then (
+                  Log.Misc.warn
+                    "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
+                    label (Printexc.to_string exn);
+                  run_unix_argv_with_stdin_fallback ~timeout_sec ?env ~stdin_content argv
+                ) else (
+                  Log.Misc.error "[Process_eio] argv error: %s — %s" label
+                    (Printexc.to_string exn);
+                  process_error_output ~label ~reason:(reason_of_exn_for_output exn) ()))
 
 let run_argv_with_stdin_and_status_split
     ?(timeout_sec = default_timeout_sec)
@@ -584,62 +597,65 @@ let run_argv_with_stdin_and_status_split
     ~(stdin_content : string)
     (argv : string list) : Unix.process_status * string * string =
   Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv_with_stdin_and_status ~argv ?env ();
-  if not (is_initialized ()) then
-    run_unix_argv_with_stdin_and_status_split_fallback ~timeout_sec ?env ?cwd
-      ~stdin_content argv
-  else
-    match get_proc_mgr (), get_clock (), get_cwd_default () with
-    | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
-        run_unix_argv_with_stdin_and_status_split_fallback ~timeout_sec ?env ?cwd
-          ~stdin_content argv
-    | Ok pm, Ok clk, Ok default_cwd ->
-        let effective_cwd =
-          match cwd with
-          | None -> default_cwd
-          | Some dir -> Eio.Path.(default_cwd / dir)
-        in
-        let stdout_buf = Buffer.create default_buffer_size in
-        let stderr_buf = Buffer.create default_buffer_size in
-        let label = String.concat " " (List.map Filename.quote argv) in
-        let stdin_source = Eio.Flow.string_source stdin_content in
-        try
-          Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
-              let unix_status =
-                Eio.Switch.run (fun sw ->
-                    spawn_and_drain_both ~sw pm ~cwd:effective_cwd ?env
-                      ~stdin_source argv stdout_buf stderr_buf)
-              in
-              (unix_status, Buffer.contents stdout_buf, Buffer.contents stderr_buf))
-        with
-        | Eio.Time.Timeout ->
-            Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
-              timeout_sec label;
-            observe_process_timeout argv ~timeout_sec;
-            let timeout_status = Unix.WEXITED 124 in
-            let stdout = Buffer.contents stdout_buf in
-            let stderr = Buffer.contents stderr_buf in
-            let stderr =
-              if String.trim stdout = "" && String.trim stderr = "" then
-                process_error_output ~label
-                  ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
-              else stderr
+  with_spawn_guard (fun () ->
+      if not (is_initialized ()) then
+        run_unix_argv_with_stdin_and_status_split_fallback ~timeout_sec ?env
+          ?cwd ~stdin_content argv
+      else
+        match get_proc_mgr (), get_clock (), get_cwd_default () with
+        | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
+            run_unix_argv_with_stdin_and_status_split_fallback ~timeout_sec
+              ?env ?cwd ~stdin_content argv
+        | Ok pm, Ok clk, Ok default_cwd ->
+            let effective_cwd =
+              match cwd with
+              | None -> default_cwd
+              | Some dir -> Eio.Path.(default_cwd / dir)
             in
-            (timeout_status, stdout, stderr)
-        | Eio.Cancel.Cancelled _ as exn -> raise exn
-        | exn ->
-            if should_retry_unix_fallback exn then (
-              Log.Misc.warn
-                "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
-                label (Printexc.to_string exn);
-              run_unix_argv_with_stdin_and_status_split_fallback ~timeout_sec
-                ?env ?cwd ~stdin_content argv
-            ) else (
-              Log.Misc.error "[Process_eio] argv error: %s — %s" label
-                (Printexc.to_string exn);
-              ( Unix.WEXITED 127,
-                "",
-                process_error_output ~label
-                  ~reason:(reason_of_exn_for_output exn) () ))
+            let stdout_buf = Buffer.create default_buffer_size in
+            let stderr_buf = Buffer.create default_buffer_size in
+            let label = String.concat " " (List.map Filename.quote argv) in
+            let stdin_source = Eio.Flow.string_source stdin_content in
+            try
+              Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
+                  let unix_status =
+                    Eio.Switch.run (fun sw ->
+                        spawn_and_drain_both ~sw pm ~cwd:effective_cwd ?env
+                          ~stdin_source argv stdout_buf stderr_buf)
+                  in
+                  ( unix_status,
+                    Buffer.contents stdout_buf,
+                    Buffer.contents stderr_buf ))
+            with
+            | Eio.Time.Timeout ->
+                Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
+                  timeout_sec label;
+                observe_process_timeout argv ~timeout_sec;
+                let timeout_status = Unix.WEXITED 124 in
+                let stdout = Buffer.contents stdout_buf in
+                let stderr = Buffer.contents stderr_buf in
+                let stderr =
+                  if String.trim stdout = "" && String.trim stderr = "" then
+                    process_error_output ~label
+                      ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
+                  else stderr
+                in
+                (timeout_status, stdout, stderr)
+            | Eio.Cancel.Cancelled _ as exn -> raise exn
+            | exn ->
+                if should_retry_unix_fallback exn then (
+                  Log.Misc.warn
+                    "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
+                    label (Printexc.to_string exn);
+                  run_unix_argv_with_stdin_and_status_split_fallback
+                    ~timeout_sec ?env ?cwd ~stdin_content argv
+                ) else (
+                  Log.Misc.error "[Process_eio] argv error: %s — %s" label
+                    (Printexc.to_string exn);
+                  ( Unix.WEXITED 127,
+                    "",
+                    process_error_output ~label
+                      ~reason:(reason_of_exn_for_output exn) () )))
 
 let run_argv_with_stdin_and_status
     ?(timeout_sec = default_timeout_sec)
@@ -656,58 +672,63 @@ let run_argv_with_stdin_and_status
 let run_argv_with_status_split ?(timeout_sec = default_timeout_sec) ?env ?cwd
     (argv : string list) : Unix.process_status * string * string =
   Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv_with_status ~argv ?env ?cwd ();
-  if not (is_initialized ()) then
-    run_unix_argv_with_status_split_fallback ~timeout_sec ?env ?cwd argv
-  else
-    match get_proc_mgr (), get_clock (), get_cwd_default () with
-    | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
+  with_spawn_guard (fun () ->
+      if not (is_initialized ()) then
         run_unix_argv_with_status_split_fallback ~timeout_sec ?env ?cwd argv
-    | Ok pm, Ok clk, Ok default_cwd ->
-        let effective_cwd =
-          match cwd with
-          | None -> default_cwd
-          | Some dir -> Eio.Path.(default_cwd / dir)
-        in
-        let stdout_buf = Buffer.create default_buffer_size in
-        let stderr_buf = Buffer.create 256 in
-        let label = String.concat " " (List.map Filename.quote argv) in
-        try
-          Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
-              let unix_status =
-                Eio.Switch.run (fun sw ->
-                    spawn_and_drain_both ~sw pm ~cwd:effective_cwd ?env argv
-                      stdout_buf stderr_buf)
-              in
-              (unix_status, Buffer.contents stdout_buf, Buffer.contents stderr_buf))
-        with
-        | Eio.Time.Timeout ->
-            Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
-              timeout_sec label;
-            observe_process_timeout argv ~timeout_sec;
-            let timeout_status = Unix.WEXITED 124 in
-            let stdout = Buffer.contents stdout_buf in
-            let stderr = Buffer.contents stderr_buf in
-            let stderr =
-              if String.trim stdout = "" && String.trim stderr = "" then
-                process_error_output ~label
-                  ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
-              else stderr
+      else
+        match get_proc_mgr (), get_clock (), get_cwd_default () with
+        | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
+            run_unix_argv_with_status_split_fallback ~timeout_sec ?env ?cwd
+              argv
+        | Ok pm, Ok clk, Ok default_cwd ->
+            let effective_cwd =
+              match cwd with
+              | None -> default_cwd
+              | Some dir -> Eio.Path.(default_cwd / dir)
             in
-            (timeout_status, stdout, stderr)
-        | Eio.Cancel.Cancelled _ as exn -> raise exn
-        | exn ->
-            if should_retry_unix_fallback exn then (
-              Log.Misc.warn
-                "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
-                label (Printexc.to_string exn);
-              run_unix_argv_with_status_split_fallback ~timeout_sec ?env ?cwd argv
-            ) else (
-              Log.Misc.error "[Process_eio] argv error: %s — %s" label
-                (Printexc.to_string exn);
-              ( Unix.WEXITED 127,
-                "",
-                process_error_output ~label
-                  ~reason:(reason_of_exn_for_output exn) () ))
+            let stdout_buf = Buffer.create default_buffer_size in
+            let stderr_buf = Buffer.create 256 in
+            let label = String.concat " " (List.map Filename.quote argv) in
+            try
+              Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
+                  let unix_status =
+                    Eio.Switch.run (fun sw ->
+                        spawn_and_drain_both ~sw pm ~cwd:effective_cwd ?env
+                          argv stdout_buf stderr_buf)
+                  in
+                  ( unix_status,
+                    Buffer.contents stdout_buf,
+                    Buffer.contents stderr_buf ))
+            with
+            | Eio.Time.Timeout ->
+                Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
+                  timeout_sec label;
+                observe_process_timeout argv ~timeout_sec;
+                let timeout_status = Unix.WEXITED 124 in
+                let stdout = Buffer.contents stdout_buf in
+                let stderr = Buffer.contents stderr_buf in
+                let stderr =
+                  if String.trim stdout = "" && String.trim stderr = "" then
+                    process_error_output ~label
+                      ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
+                  else stderr
+                in
+                (timeout_status, stdout, stderr)
+            | Eio.Cancel.Cancelled _ as exn -> raise exn
+            | exn ->
+                if should_retry_unix_fallback exn then (
+                  Log.Misc.warn
+                    "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
+                    label (Printexc.to_string exn);
+                  run_unix_argv_with_status_split_fallback ~timeout_sec ?env
+                    ?cwd argv
+                ) else (
+                  Log.Misc.error "[Process_eio] argv error: %s — %s" label
+                    (Printexc.to_string exn);
+                  ( Unix.WEXITED 127,
+                    "",
+                    process_error_output ~label
+                      ~reason:(reason_of_exn_for_output exn) () )))
 
 let run_argv_with_status ?(timeout_sec = default_timeout_sec) ?env ?cwd
     (argv : string list) : Unix.process_status * string =

--- a/lib/process/process_eio.mli
+++ b/lib/process/process_eio.mli
@@ -38,6 +38,20 @@ val argv_program : string list -> string
     ["<empty>"] for an empty argv).  Exposed for tests and parity with
     the hook payload. *)
 
+(** {1 Spawn guard hook} *)
+
+type spawn_guard = { run : 'a. (unit -> 'a) -> 'a }
+(** Process-wide wrapper around foreground [run_argv*] subprocess calls.
+    The default guard runs the callback immediately. Higher-level runtimes can
+    install resource accounting/backpressure without making this lower
+    [masc_process] library depend on those policy modules. *)
+
+val set_spawn_guard : spawn_guard -> unit
+(** Install the process-wide foreground spawn guard. *)
+
+val reset_spawn_guard_for_testing : unit -> unit
+(** Restore the default no-op foreground spawn guard. *)
+
 val default_timeout_sec : float
 (** Default subprocess wall-clock budget shared by every [run_argv*],
     [run_unix_argv*_fallback], and [with_unix_capture] [?timeout_sec]

--- a/lib/server/fd_accountant.ml
+++ b/lib/server/fd_accountant.ml
@@ -54,14 +54,30 @@ let state_of kind = List.assoc kind _state_for_kind
    pattern from Docker_spawn_throttle (PR #15727). *)
 let _shared_pressure_mutex = Eio.Mutex.create ()
 
+let held_kinds_key : kind list Eio.Fiber.key = Eio.Fiber.create_key ()
+
+let held_kinds () =
+  try Option.value ~default:[] (Eio.Fiber.get held_kinds_key)
+  with _ -> []
+
+let holds_kind kind = List.exists (( = ) kind) (held_kinds ())
+
+let with_held_kind kind f =
+  Eio.Fiber.with_binding held_kinds_key (kind :: held_kinds ()) f
+
 let with_slot ~kind f =
-  let { sem ; _ } = state_of kind in
-  Eio.Semaphore.acquire sem ;
-  Eio.Switch.run @@ fun sw ->
-  Eio.Switch.on_release sw (fun () -> Eio.Semaphore.release sem) ;
-  if Keeper_fd_pressure.active () then
-    Eio.Mutex.use_rw ~protect:true _shared_pressure_mutex f
-  else f ()
+  if holds_kind kind then
+    f ()
+  else
+    let { sem ; _ } = state_of kind in
+    Eio.Semaphore.acquire sem ;
+    Eio.Switch.run @@ fun sw ->
+    Eio.Switch.on_release sw (fun () -> Eio.Semaphore.release sem) ;
+    let run () = with_held_kind kind f in
+    if Keeper_fd_pressure.active () then
+      Eio.Mutex.use_rw ~protect:true _shared_pressure_mutex run
+    else
+      run ()
 
 let configured_concurrency ~kind = (state_of kind).cap
 
@@ -76,7 +92,19 @@ let install_dated_jsonl_log_writer_guard () =
     else
       f ())
 
-let () = install_dated_jsonl_log_writer_guard ()
+let install_process_eio_sandbox_exec_guard () =
+  Process_eio.set_spawn_guard
+    { Process_eio.run =
+        (fun f ->
+          if Eio_guard.is_ready () then
+            with_slot ~kind:Sandbox_exec f
+          else
+            f ())
+    }
+
+let () =
+  install_dated_jsonl_log_writer_guard ();
+  install_process_eio_sandbox_exec_guard ()
 
 (* In-flight count = configured cap minus current semaphore credits.
    Eio.Semaphore exposes [get_value] which returns the available credit

--- a/lib/server/fd_accountant.mli
+++ b/lib/server/fd_accountant.mli
@@ -45,6 +45,11 @@ val with_slot : kind:kind -> (unit -> 'a) -> 'a
     additionally serialized against all in-flight callers across all
     kinds.
 
+    Nested calls for the same [kind] on the same Eio fiber are reentrant:
+    the inner call runs under the outer slot instead of consuming a second
+    semaphore credit. This lets low-level process guards and explicit
+    high-level wrappers coexist during migration.
+
     Exceptions from [f] propagate; the slot is always released
     (via [Eio.Switch.on_release]). *)
 
@@ -65,6 +70,14 @@ val install_dated_jsonl_log_writer_guard : unit -> unit
     runs the append directly so module-load and pure test paths stay safe. The
     module installs it at load time; the explicit function exists for tests and
     future bootstrap code that resets storage hooks. *)
+
+val install_process_eio_sandbox_exec_guard : unit -> unit
+(** [install_process_eio_sandbox_exec_guard ()] installs the process-wide
+    {!Process_eio} foreground spawn guard that accounts [run_argv*] calls as
+    {!Sandbox_exec} while {!Eio_guard} is ready. Before Eio startup, the guard
+    runs directly so module-load and pure fallback paths stay safe. The module
+    installs it at load time; the explicit function exists for tests and future
+    bootstrap code that resets process hooks. *)
 
 type snapshot = {
   per_kind : (kind * int) list ;

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -19,12 +19,12 @@
 # lib/bounded_proc/bounded_proc.ml:17  — the canonical helper itself.
 lib/bounded_proc/bounded_proc.ml:17
 
-# lib/process/process_eio.ml:457, 484 — `spawn_and_drain_{stdout,both}`.
+# lib/process/process_eio.ml:466, 493 — `spawn_and_drain_{stdout,both}`.
 # Private functions. Every caller (run_argv*, run_argv_with_status*,
 # run_argv_with_stdin*) wraps in `Eio.Time.with_timeout_exn clk timeout_sec`
-# + `Eio.Switch.run` (process_eio.ml:521-523, 557-559, 605-609, 674-678).
-lib/process/process_eio.ml:457
-lib/process/process_eio.ml:484
+# + `Eio.Switch.run` and the process-wide spawn guard.
+lib/process/process_eio.ml:466
+lib/process/process_eio.ml:493
 
 # lib/server/lsp_process_manager.ml:178 — LSP child process. Lifetime is
 # bound to the LSP session switch; idle eviction handled by the LSP

--- a/test/test_fd_accountant.ml
+++ b/test/test_fd_accountant.ml
@@ -122,6 +122,10 @@ let log_writer_in_flight () =
   let snapshot = FA.fd_snapshot () in
   List.assoc FA.Log_writer snapshot.per_kind
 
+let kind_in_flight kind =
+  let snapshot = FA.fd_snapshot () in
+  List.assoc kind snapshot.per_kind
+
 let wait_until ~clock ~attempts predicate =
   let rec loop remaining =
     if predicate () then true
@@ -131,6 +135,16 @@ let wait_until ~clock ~attempts predicate =
       loop (remaining - 1))
   in
   loop attempts
+
+let test_with_slot_reentrant_same_kind () =
+  Eio_main.run @@ fun _env ->
+  FA.with_slot ~kind:FA.Sandbox_exec (fun () ->
+      check int "outer sandbox slot held" 1
+        (kind_in_flight FA.Sandbox_exec) ;
+      FA.with_slot ~kind:FA.Sandbox_exec (fun () ->
+          check int "inner sandbox slot reuses outer slot" 1
+            (kind_in_flight FA.Sandbox_exec))) ;
+  check int "sandbox slot released" 0 (kind_in_flight FA.Sandbox_exec)
 
 let test_dated_jsonl_append_uses_log_writer_slot () =
   Eio_main.run @@ fun env ->
@@ -155,6 +169,34 @@ let test_dated_jsonl_append_uses_log_writer_slot () =
       in
       check int "log writer slot released" 0 (log_writer_in_flight ()))
 
+let test_process_eio_run_argv_uses_sandbox_slot () =
+  Eio_main.run @@ fun env ->
+  Eio_guard.enable () ;
+  Fun.protect
+    ~finally:(fun () ->
+      Process_eio.reset_for_testing () ;
+      Eio_guard.disable ())
+    (fun () ->
+      Process_eio.reset_for_testing () ;
+      Process_eio.init
+        ~cwd_default:(Eio.Stdenv.fs env)
+        ~proc_mgr:(Eio.Stdenv.process_mgr env)
+        ~clock:(Eio.Stdenv.clock env) ;
+      FA.install_process_eio_sandbox_exec_guard () ;
+      let clock = Eio.Stdenv.clock env in
+      let () =
+        Eio.Switch.run @@ fun sw ->
+        Eio.Fiber.fork ~sw (fun () ->
+            ignore
+              (Process_eio.run_argv_with_status ~timeout_sec:2.0
+                 [ "/bin/sleep"; "0.05" ])) ;
+        check bool "Process_eio holds sandbox slot while child runs" true
+          (wait_until ~clock ~attempts:100 (fun () ->
+               kind_in_flight FA.Sandbox_exec > 0))
+      in
+      check int "Process_eio sandbox slot released" 0
+        (kind_in_flight FA.Sandbox_exec))
+
 let () =
   Alcotest.run "Fd_accountant"
     [
@@ -172,6 +214,8 @@ let () =
           test_case "release on exception" `Quick
             test_with_slot_releases_on_exception ;
           test_case "cap bounds fan-in" `Quick test_cap_bounds_fan_in ;
+          test_case "reentrant same-kind slot" `Quick
+            test_with_slot_reentrant_same_kind ;
         ] ) ;
       ( "delegation",
         [
@@ -184,5 +228,10 @@ let () =
         [
           test_case "Dated_jsonl append uses slot" `Quick
             test_dated_jsonl_append_uses_log_writer_slot ;
+        ] ) ;
+      ( "process",
+        [
+          test_case "Process_eio run_argv uses sandbox slot" `Quick
+            test_process_eio_run_argv_uses_sandbox_slot ;
         ] ) ;
     ]

--- a/test/test_process_eio_coverage.ml
+++ b/test/test_process_eio_coverage.ml
@@ -41,6 +41,26 @@ let test_run_argv_with_status_fallback_includes_stderr_on_failure () =
   check bool "fallback stderr surfaced in output" true
     (contains output "stderr-fallback")
 
+let test_spawn_guard_wraps_foreground_run_argv () =
+  Process_eio.reset_for_testing ();
+  let calls = Atomic.make 0 in
+  Process_eio.set_spawn_guard
+    { Process_eio.run =
+        (fun f ->
+          Atomic.incr calls;
+          f ())
+    };
+  Fun.protect
+    ~finally:Process_eio.reset_spawn_guard_for_testing
+    (fun () ->
+      let status, output =
+        Process_eio.run_argv_with_status [ "/bin/echo"; "guarded" ]
+      in
+      let code = match status with Unix.WEXITED c -> c | _ -> 1 in
+      check int "guarded command exit code" 0 code;
+      check string "guarded command output" "guarded" (String.trim output);
+      check int "spawn guard called once" 1 (Atomic.get calls))
+
 let test_run_argv_with_stdin_fallback_preserves_input () =
   let output =
     Process_eio.run_argv_with_stdin ~stdin_content:"ping\n" [ "/bin/cat" ]
@@ -240,6 +260,8 @@ let () =
           test_case "argv-with-status-fallback-includes-stderr-on-failure"
             `Quick
             test_run_argv_with_status_fallback_includes_stderr_on_failure;
+          test_case "spawn-guard-wraps-foreground-run-argv" `Quick
+            test_spawn_guard_wraps_foreground_run_argv;
           test_case "argv-with-stdin-fallback-preserves-input" `Quick
             test_run_argv_with_stdin_fallback_preserves_input;
           test_case "argv-fallback-surfaces-spawn-error" `Quick


### PR DESCRIPTION
## Summary
- add a Process_eio foreground spawn guard hook so the lower masc_process library stays policy-free
- install the hook from Fd_accountant as Sandbox_exec while Eio_guard is ready
- make same-kind Fd_accountant slots reentrant on the current Eio fiber so explicit callsite wrappers and lower-level guards do not double-consume credits
- update the spawn-bounded ratchet allowlist for moved Process_eio spawn lines

## Verification
- git diff --check origin/main...HEAD
- ocamlformat --check lib/process/process_eio.ml lib/process/process_eio.mli lib/server/fd_accountant.ml lib/server/fd_accountant.mli test/test_fd_accountant.ml test/test_process_eio_coverage.ml
- bash scripts/lint-spawn-bounded.sh
- scripts/dune-local.sh build test/test_process_eio_coverage.exe test/test_fd_accountant.exe
- ./_build/default/test/test_fd_accountant.exe
- ./_build/default/test/test_process_eio_coverage.exe