### PR TITLE
fix(scripts): add Docker playground FD cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### Added
 - Documented RFC-0105's OpenAI-compatible boundary typed error mapping for tool validation and provider/runtime failure surfaces.
 - Added RFC-0106's cancel-safe `try`/`with` discipline draft for callback and cleanup paths.
+- Added Docker playground FD-hotspot operator tooling:
+  `scripts/docker-playground-fd-status.sh` surfaces worktree fanout and
+  `lsof` holders under `.masc/playground/docker`, while
+  `scripts/cleanup-docker-playground-worktrees.sh` dry-runs/applies
+  conservative stale clean worktree cleanup for #15931, with explicit
+  `--include-broken` handling for old non-git orphan directories.
 
 ### Fixed
 - Wired the `Sandbox_exec` slot at non-Docker spawn callsites and gated keeper admission on system FD pressure, so fleet startup respects host-level descriptor pressure.

--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -183,6 +183,57 @@ scripts/harness/workload/agent_swarm_live.sh
 - `logs/keeper_fleet_readiness/<run-id>/summary.md`
 - direct gate: `scripts/keeper-production-readiness-gate.py --json ...`
 
+### Docker Playground FD Hotspot
+
+macOS Docker Desktop can retain file descriptors for shared files under
+`.masc/playground/docker`. When stale keeper repo worktrees accumulate there,
+the hotspot can approach `kern.maxfilesperproc` even while MASC's own process
+FD count and `/health.status` look healthy.
+
+Inspect the current Docker playground fanout and any host process with open FDs
+inside it:
+
+```bash
+scripts/docker-playground-fd-status.sh --root ~/me/.masc/playground/docker
+```
+
+Review stale clean worktree candidates first:
+
+```bash
+scripts/cleanup-docker-playground-worktrees.sh \
+  --root ~/me/.masc/playground/docker \
+  --repo masc-mcp \
+  --days 7
+```
+
+Apply only after reviewing the `CANDID` lines:
+
+```bash
+scripts/cleanup-docker-playground-worktrees.sh \
+  --root ~/me/.masc/playground/docker \
+  --repo masc-mcp \
+  --days 7 \
+  --apply
+```
+
+The cleanup path is conservative: dry-run by default, skips dirty or
+runtime-referenced worktrees, removes clean git worktrees through
+`git worktree remove`, and leaves branches intact.
+
+If the dry-run reports `BROKEN` entries, review them separately. They are not
+removed unless the operator explicitly opts in:
+
+```bash
+scripts/cleanup-docker-playground-worktrees.sh \
+  --root ~/me/.masc/playground/docker \
+  --repo masc-mcp \
+  --days 7 \
+  --include-broken
+```
+
+Then apply with both `--include-broken` and `--apply` only after confirming the
+`BROKEN_CANDID` paths are stale orphan directories.
+
 대표 failure class:
 
 - `keeper_count < expected_keepers`

--- a/scripts/cleanup-docker-playground-worktrees.sh
+++ b/scripts/cleanup-docker-playground-worktrees.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# Conservatively remove stale keeper Docker playground worktrees.
+#
+# Docker Desktop on macOS can retain a large FD set for shared files under
+# .masc/playground/docker. Stale repo worktrees amplify that into a
+# per-process host FD hotspot even when MASC's own process FD count is low.
+#
+# Dry-run is the default. Use --apply only after reviewing CANDID lines.
+
+set -euo pipefail
+
+APPLY=0
+DAYS=7
+ROOT=""
+KEEPER_FILTER=""
+REPO_FILTER=""
+INCLUDE_BROKEN=0
+
+usage() {
+  cat <<'EOF'
+cleanup-docker-playground-worktrees.sh - stale Docker playground worktree GC
+
+Usage:
+  scripts/cleanup-docker-playground-worktrees.sh [--root PATH] [--days N]
+  scripts/cleanup-docker-playground-worktrees.sh --apply [--root PATH] [--days N]
+
+Options:
+  --root PATH     Docker playground root. Defaults to
+                  $MASC_BASE_PATH/.masc/playground/docker, then
+                  $HOME/me/.masc/playground/docker.
+  --days N        Candidate age threshold from last git commit. Default: 7.
+  --keeper NAME   Limit to one keeper directory under the Docker playground.
+  --repo NAME     Limit to one repo under <keeper>/repos/. Example: masc-mcp.
+  --apply         Remove candidates with git worktree remove.
+  --include-broken
+                  Also consider broken/non-git directories under
+                  <keeper>/repos/<repo>/.worktrees/ using filesystem mtime.
+                  Requires the same dry-run review flow; clean git worktrees
+                  still use git worktree remove.
+
+Safety:
+  - dry-run by default
+  - skips dirty worktrees and runtime-referenced paths
+  - skips broken git roots unless --include-broken is passed
+  - clean git worktrees remove through git worktree remove
+  - broken directories remove only with --apply --include-broken
+  - leaves branches intact
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply) APPLY=1; shift ;;
+    --days) DAYS="${2:-}"; shift 2 ;;
+    --root) ROOT="${2:-}"; shift 2 ;;
+    --keeper) KEEPER_FILTER="${2:-}"; shift 2 ;;
+    --repo) REPO_FILTER="${2:-}"; shift 2 ;;
+    --include-broken) INCLUDE_BROKEN=1; shift ;;
+    -h|--help|help) usage; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if ! [[ "$DAYS" =~ ^[0-9]+$ ]]; then
+  echo "--days must be a non-negative integer (got: $DAYS)" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$SCRIPT_DIR/lib/worktree-cleanup-guards.sh" ]; then
+  # shellcheck source=scripts/lib/worktree-cleanup-guards.sh
+  . "$SCRIPT_DIR/lib/worktree-cleanup-guards.sh"
+else
+  worktree_cleanup_is_runtime_referenced() { return 1; }
+fi
+
+if [ -z "$ROOT" ]; then
+  BASE="${MASC_BASE_PATH:-}"
+  if [ -z "$BASE" ] && [ -d "${HOME:-}/me/.masc" ]; then
+    BASE="${HOME}/me"
+  fi
+  if [ -z "$BASE" ]; then
+    echo "cannot infer playground root; pass --root PATH" >&2
+    exit 2
+  fi
+  ROOT="$BASE/.masc/playground/docker"
+fi
+
+ROOT="${ROOT%/}"
+NOW_TS=$(date +%s)
+CUTOFF_TS=$(( NOW_TS - DAYS * 86400 ))
+
+scanned=0
+candidates=0
+removed=0
+recent=0
+dirty=0
+active=0
+broken=0
+broken_candidates=0
+broken_removed=0
+failed=0
+
+if [ ! -d "$ROOT" ]; then
+  echo "Docker playground root missing: $ROOT"
+  echo "Summary (--root $ROOT --days $DAYS dry-run): scanned=0 candidates=0 removed=0 recent=0 dirty=0 active=0 broken=0 broken_candidates=0 broken_removed=0 failed=0"
+  exit 0
+fi
+
+path_mtime_ts() {
+  local path="$1"
+  if stat -f '%m' "$path" >/dev/null 2>&1; then
+    stat -f '%m' "$path"
+  else
+    stat -c '%Y' "$path"
+  fi
+}
+
+canonical_path() {
+  local path="$1"
+  (cd "$path" 2>/dev/null && pwd -P)
+}
+
+for keeper_dir in "$ROOT"/*; do
+  [ -d "$keeper_dir" ] || continue
+  keeper_name="$(basename "$keeper_dir")"
+  if [ -n "$KEEPER_FILTER" ] && [ "$keeper_name" != "$KEEPER_FILTER" ]; then
+    continue
+  fi
+  repos_dir="$keeper_dir/repos"
+  [ -d "$repos_dir" ] || continue
+
+  for repo_dir in "$repos_dir"/*; do
+    [ -d "$repo_dir" ] || continue
+    repo_name="$(basename "$repo_dir")"
+    if [ -n "$REPO_FILTER" ] && [ "$repo_name" != "$REPO_FILTER" ]; then
+      continue
+    fi
+    worktrees_dir="$repo_dir/.worktrees"
+    [ -d "$worktrees_dir" ] || continue
+
+    for wt_path in "$worktrees_dir"/*; do
+      [ -d "$wt_path" ] || continue
+      scanned=$((scanned + 1))
+
+      case "$wt_path" in
+        "$ROOT"/*/repos/*/.worktrees/*) ;;
+        *)
+          echo "BROKEN  $wt_path -- skipped (outside docker playground worktree shape)"
+          broken=$((broken + 1))
+          continue
+          ;;
+      esac
+
+      if git -C "$wt_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        git_top="$(git -C "$wt_path" rev-parse --show-toplevel 2>/dev/null || true)"
+        wt_real="$(canonical_path "$wt_path" || true)"
+        git_top_real=""
+        if [ -n "$git_top" ] && [ -d "$git_top" ]; then
+          git_top_real="$(canonical_path "$git_top" || true)"
+        fi
+      else
+        git_top_real=""
+        wt_real="$(canonical_path "$wt_path" || true)"
+      fi
+
+      if [ -z "$wt_real" ] || [ "$git_top_real" != "$wt_real" ]; then
+        if [ "$INCLUDE_BROKEN" -ne 1 ]; then
+          echo "BROKEN  $wt_path -- skipped (not a standalone readable git worktree; pass --include-broken to consider it)"
+          broken=$((broken + 1))
+          continue
+        fi
+
+        if ! last_ts="$(path_mtime_ts "$wt_path" 2>/dev/null)" || [ -z "$last_ts" ]; then
+          echo "BROKEN  $wt_path -- skipped (cannot read filesystem mtime)"
+          broken=$((broken + 1))
+          continue
+        fi
+
+        if [ "$last_ts" -ge "$CUTOFF_TS" ]; then
+          recent=$((recent + 1))
+          continue
+        fi
+
+        if worktree_cleanup_is_runtime_referenced "$wt_path"; then
+          echo "ACTIVE  keeper=$keeper_name repo=$repo_name path=$wt_path -- skipped"
+          active=$((active + 1))
+          continue
+        fi
+
+        age_days=$(( ( NOW_TS - last_ts ) / 86400 ))
+        broken_candidates=$((broken_candidates + 1))
+        if [ "$APPLY" -eq 1 ]; then
+          if rm -rf "$wt_path"; then
+            echo "BROKEN_REMOVED keeper=$keeper_name repo=$repo_name age_days=$age_days path=$wt_path"
+            broken_removed=$((broken_removed + 1))
+          else
+            echo "FAILED  keeper=$keeper_name repo=$repo_name path=$wt_path -- broken directory remove failed"
+            failed=$((failed + 1))
+          fi
+        else
+          echo "BROKEN_CANDID keeper=$keeper_name repo=$repo_name age_days=$age_days path=$wt_path"
+        fi
+        continue
+      fi
+
+      if ! last_ts="$(git -C "$wt_path" log -1 --format='%ct' 2>/dev/null)" \
+        || [ -z "$last_ts" ]; then
+        echo "BROKEN  $wt_path -- skipped (cannot read HEAD timestamp)"
+        broken=$((broken + 1))
+        continue
+      fi
+      if wt_mtime_ts="$(path_mtime_ts "$wt_path" 2>/dev/null)" \
+        && [ -n "$wt_mtime_ts" ] \
+        && [ "$wt_mtime_ts" -gt "$last_ts" ]; then
+        last_ts="$wt_mtime_ts"
+      fi
+
+      if [ "$last_ts" -ge "$CUTOFF_TS" ]; then
+        recent=$((recent + 1))
+        continue
+      fi
+
+      if [ -n "$(git -C "$wt_path" status --porcelain --untracked-files=normal --ignore-submodules=dirty 2>/dev/null)" ]; then
+        echo "DIRTY   keeper=$keeper_name repo=$repo_name path=$wt_path -- skipped"
+        dirty=$((dirty + 1))
+        continue
+      fi
+
+      if worktree_cleanup_is_runtime_referenced "$wt_path"; then
+        echo "ACTIVE  keeper=$keeper_name repo=$repo_name path=$wt_path -- skipped"
+        active=$((active + 1))
+        continue
+      fi
+
+      age_days=$(( ( NOW_TS - last_ts ) / 86400 ))
+      candidates=$((candidates + 1))
+
+      if [ "$APPLY" -eq 1 ]; then
+        if git -C "$repo_dir" worktree remove "$wt_path" 2>/dev/null; then
+          git -C "$repo_dir" worktree prune 2>/dev/null || true
+          echo "REMOVED keeper=$keeper_name repo=$repo_name age_days=$age_days path=$wt_path"
+          removed=$((removed + 1))
+        else
+          echo "FAILED  keeper=$keeper_name repo=$repo_name path=$wt_path -- git worktree remove failed"
+          failed=$((failed + 1))
+        fi
+      else
+        echo "CANDID  keeper=$keeper_name repo=$repo_name age_days=$age_days path=$wt_path"
+      fi
+    done
+  done
+done
+
+mode="dry-run"
+if [ "$APPLY" -eq 1 ]; then
+  mode="--apply"
+fi
+
+echo ""
+echo "Summary (--root $ROOT --days $DAYS $mode): scanned=$scanned candidates=$candidates removed=$removed recent=$recent dirty=$dirty active=$active broken=$broken broken_candidates=$broken_candidates broken_removed=$broken_removed failed=$failed"
+if [ "$APPLY" -ne 1 ]; then
+  echo "Pass --apply to remove the listed candidates."
+fi

--- a/scripts/docker-playground-fd-status.sh
+++ b/scripts/docker-playground-fd-status.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Report Docker playground worktree fanout and FD holders referencing it.
+
+set -euo pipefail
+
+ROOT=""
+LIMIT=20
+
+usage() {
+  cat <<'EOF'
+docker-playground-fd-status.sh - Docker playground FD hotspot visibility
+
+Usage:
+  scripts/docker-playground-fd-status.sh [--root PATH] [--limit N]
+
+Options:
+  --root PATH   Docker playground root. Defaults to
+                $MASC_BASE_PATH/.masc/playground/docker, then
+                $HOME/me/.masc/playground/docker.
+  --limit N     Number of FD holder rows to print. Default: 20.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --root) ROOT="${2:-}"; shift 2 ;;
+    --limit) LIMIT="${2:-}"; shift 2 ;;
+    -h|--help|help) usage; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+  echo "--limit must be a non-negative integer (got: $LIMIT)" >&2
+  exit 2
+fi
+
+if [ -z "$ROOT" ]; then
+  BASE="${MASC_BASE_PATH:-}"
+  if [ -z "$BASE" ] && [ -d "${HOME:-}/me/.masc" ]; then
+    BASE="${HOME}/me"
+  fi
+  if [ -z "$BASE" ]; then
+    echo "cannot infer playground root; pass --root PATH" >&2
+    exit 2
+  fi
+  ROOT="$BASE/.masc/playground/docker"
+fi
+
+ROOT="${ROOT%/}"
+
+worktrees_dirs=0
+worktree_entries=0
+
+if [ -d "$ROOT" ]; then
+  for keeper_dir in "$ROOT"/*; do
+    [ -d "$keeper_dir" ] || continue
+    repos_dir="$keeper_dir/repos"
+    [ -d "$repos_dir" ] || continue
+    for repo_dir in "$repos_dir"/*; do
+      [ -d "$repo_dir" ] || continue
+      worktrees_dir="$repo_dir/.worktrees"
+      [ -d "$worktrees_dir" ] || continue
+      worktrees_dirs=$((worktrees_dirs + 1))
+      for wt_path in "$worktrees_dir"/*; do
+        [ -d "$wt_path" ] || continue
+        worktree_entries=$((worktree_entries + 1))
+      done
+    done
+  done
+fi
+
+echo "root=$ROOT"
+echo "worktrees_dirs=$worktrees_dirs"
+echo "worktree_entries=$worktree_entries"
+
+if ! command -v lsof >/dev/null 2>&1; then
+  echo "fd_holders=unavailable (lsof not found)"
+  exit 0
+fi
+
+echo ""
+echo "Top FD holders referencing root:"
+if ! lsof -n -P +c 64 2>/dev/null \
+  | awk -v root="$ROOT/" '
+      NR > 1 {
+        name = $9
+        for (i = 10; i <= NF; i++) {
+          name = name " " $i
+        }
+        if (index(name, root) == 1) {
+          count[$2]++
+          cmd[$2] = $1
+          type_count[$2, $5]++
+        }
+      }
+      END {
+        for (pid in count) {
+          types = ""
+          for (key in type_count) {
+            split(key, parts, SUBSEP)
+            if (parts[1] == pid) {
+              types = types parts[2] "=" type_count[key] ","
+            }
+          }
+          sub(/,$/, "", types)
+          print count[pid], pid, cmd[pid], types
+        }
+      }' \
+  | sort -rn \
+  | head -n "$LIMIT"; then
+  echo "fd_holders=unavailable (lsof failed)"
+fi

--- a/test/dune
+++ b/test/dune
@@ -1434,6 +1434,8 @@
 
 (include stanzas/test_dune_local_script.inc)
 
+(include stanzas/test_docker_playground_gc_script.inc)
+
 (include stanzas/test_env_config_coord_git_local_timeout.inc)
 
 (include stanzas/test_env_config_dashboard_compute_timeouts.inc)

--- a/test/stanzas/test_docker_playground_gc_script.inc
+++ b/test/stanzas/test_docker_playground_gc_script.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_docker_playground_gc_script)
+ (modules test_docker_playground_gc_script)
+ (libraries alcotest unix))

--- a/test/test_docker_playground_gc_script.ml
+++ b/test/test_docker_playground_gc_script.ml
@@ -1,0 +1,232 @@
+open Alcotest
+
+let source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root -> root
+  | None -> Sys.getcwd ()
+
+let cleanup_script_path () =
+  Filename.concat (source_root ()) "scripts/cleanup-docker-playground-worktrees.sh"
+
+let status_script_path () =
+  Filename.concat (source_root ()) "scripts/docker-playground-fd-status.sh"
+
+let quote = Filename.quote
+
+let read_file path = In_channel.with_open_bin path In_channel.input_all
+
+let write_file path content =
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end
+    else Sys.remove path
+
+let rec mkdir_p path =
+  if path = "" || path = "." || path = "/" then ()
+  else if Sys.file_exists path then ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let run_shell ?(env = []) ~cwd cmd =
+  let env_prefix =
+    env
+    |> List.map (fun (k, v) -> Printf.sprintf "%s=%s" k (quote v))
+    |> String.concat " "
+  in
+  let full =
+    if env_prefix = ""
+    then Printf.sprintf "cd %s && %s" (quote cwd) cmd
+    else Printf.sprintf "cd %s && %s %s" (quote cwd) env_prefix cmd
+  in
+  let out = Filename.temp_file "docker-playground-gc-out" ".txt" in
+  let err = Filename.temp_file "docker-playground-gc-err" ".txt" in
+  let wrapped = Printf.sprintf "%s > %s 2> %s" full (quote out) (quote err) in
+  let code = Sys.command wrapped in
+  let stdout = read_file out in
+  let stderr = read_file err in
+  Sys.remove out;
+  Sys.remove err;
+  code, stdout, stderr
+
+let run_shell_ok ?(env = []) ~cwd cmd =
+  let code, stdout, stderr = run_shell ~env ~cwd cmd in
+  if code <> 0 then failf "command failed (%d): %s\n%s" code cmd stderr;
+  stdout, stderr
+
+let contains_substring haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec loop idx =
+    idx + nlen <= hlen
+    && (String.sub haystack idx nlen = needle || loop (idx + 1))
+  in
+  nlen = 0 || loop 0
+
+let init_repo repo_dir =
+  mkdir_p repo_dir;
+  ignore (run_shell_ok ~cwd:repo_dir "git init -q");
+  ignore (run_shell_ok ~cwd:repo_dir "git config user.email test@example.com");
+  ignore (run_shell_ok ~cwd:repo_dir "git config user.name Test");
+  write_file (Filename.concat repo_dir "README.md") "base\n";
+  ignore (run_shell_ok ~cwd:repo_dir "git add README.md");
+  ignore
+    (run_shell_ok
+       ~env:
+         [ "GIT_AUTHOR_DATE", "2000-01-01T00:00:00Z"
+         ; "GIT_COMMITTER_DATE", "2000-01-01T00:00:00Z"
+         ]
+       ~cwd:repo_dir
+       "git commit -q -m init")
+
+let mark_path_old ~cwd path =
+  ignore
+    (run_shell_ok ~cwd
+       (Printf.sprintf "touch -t 200001010000 %s" (quote path)))
+
+let test_scripts_are_syntax_valid () =
+  let cmd =
+    Printf.sprintf "bash -n %s && bash -n %s" (quote (cleanup_script_path ()))
+      (quote (status_script_path ()))
+  in
+  ignore (run_shell_ok ~cwd:(source_root ()) cmd)
+
+let test_dry_run_lists_stale_clean_worktree () =
+  with_temp_dir "docker-playground-gc-dry-run" (fun dir ->
+    let root = Filename.concat dir ".masc/playground/docker" in
+    let repo_dir = Filename.concat root "keeper-a/repos/masc-mcp" in
+    init_repo repo_dir;
+    mkdir_p (Filename.concat repo_dir ".worktrees");
+    let wt_path = Filename.concat repo_dir ".worktrees/stale-task" in
+    ignore
+      (run_shell_ok ~cwd:repo_dir
+         (Printf.sprintf "git worktree add -q -b stale-task %s" (quote wt_path)));
+    mark_path_old ~cwd:repo_dir wt_path;
+    let stdout, _ =
+      run_shell_ok ~cwd:(source_root ())
+        (Printf.sprintf "%s --root %s --days 1 --repo masc-mcp"
+           (quote (cleanup_script_path ()))
+           (quote root))
+    in
+    check bool "candidate listed" true (contains_substring stdout "CANDID");
+    check bool "dry-run reminder" true (contains_substring stdout "Pass --apply");
+    check bool "worktree retained" true (Sys.file_exists wt_path))
+
+let test_recent_checkout_of_old_commit_is_not_candidate () =
+  with_temp_dir "docker-playground-gc-recent" (fun dir ->
+    let root = Filename.concat dir ".masc/playground/docker" in
+    let repo_dir = Filename.concat root "keeper-a/repos/masc-mcp" in
+    init_repo repo_dir;
+    mkdir_p (Filename.concat repo_dir ".worktrees");
+    let wt_path = Filename.concat repo_dir ".worktrees/recent-task" in
+    ignore
+      (run_shell_ok ~cwd:repo_dir
+         (Printf.sprintf "git worktree add -q -b recent-task %s" (quote wt_path)));
+    let stdout, _ =
+      run_shell_ok ~cwd:(source_root ())
+        (Printf.sprintf "%s --root %s --days 1 --repo masc-mcp"
+           (quote (cleanup_script_path ()))
+           (quote root))
+    in
+    check bool "candidate not listed" false (contains_substring stdout "CANDID");
+    check bool "recent counted" true (contains_substring stdout "recent=1");
+    check bool "worktree retained" true (Sys.file_exists wt_path))
+
+let test_apply_removes_stale_clean_worktree () =
+  with_temp_dir "docker-playground-gc-apply" (fun dir ->
+    let root = Filename.concat dir ".masc/playground/docker" in
+    let repo_dir = Filename.concat root "keeper-a/repos/masc-mcp" in
+    init_repo repo_dir;
+    mkdir_p (Filename.concat repo_dir ".worktrees");
+    let wt_path = Filename.concat repo_dir ".worktrees/stale-task" in
+    ignore
+      (run_shell_ok ~cwd:repo_dir
+         (Printf.sprintf "git worktree add -q -b stale-task %s" (quote wt_path)));
+    mark_path_old ~cwd:repo_dir wt_path;
+    let stdout, _ =
+      run_shell_ok ~cwd:(source_root ())
+        (Printf.sprintf "%s --root %s --days 1 --repo masc-mcp --apply"
+           (quote (cleanup_script_path ()))
+           (quote root))
+    in
+    check bool "removed listed" true (contains_substring stdout "REMOVED");
+    check bool "worktree removed" false (Sys.file_exists wt_path))
+
+let test_apply_skips_dirty_worktree () =
+  with_temp_dir "docker-playground-gc-dirty" (fun dir ->
+    let root = Filename.concat dir ".masc/playground/docker" in
+    let repo_dir = Filename.concat root "keeper-a/repos/masc-mcp" in
+    init_repo repo_dir;
+    mkdir_p (Filename.concat repo_dir ".worktrees");
+    let wt_path = Filename.concat repo_dir ".worktrees/dirty-task" in
+    ignore
+      (run_shell_ok ~cwd:repo_dir
+         (Printf.sprintf "git worktree add -q -b dirty-task %s" (quote wt_path)));
+    write_file (Filename.concat wt_path "dirty.txt") "keep me\n";
+    mark_path_old ~cwd:repo_dir wt_path;
+    let stdout, _ =
+      run_shell_ok ~cwd:(source_root ())
+        (Printf.sprintf "%s --root %s --days 1 --repo masc-mcp --apply"
+           (quote (cleanup_script_path ()))
+           (quote root))
+    in
+    check bool "dirty listed" true (contains_substring stdout "DIRTY");
+    check bool "dirty worktree retained" true (Sys.file_exists wt_path))
+
+let test_include_broken_removes_old_non_git_directory () =
+  with_temp_dir "docker-playground-gc-broken" (fun dir ->
+    let root = Filename.concat dir ".masc/playground/docker" in
+    let broken_path =
+      Filename.concat root "keeper-a/repos/masc-mcp/.worktrees/broken-task"
+    in
+    mkdir_p broken_path;
+    write_file (Filename.concat broken_path "note.txt") "orphan\n";
+    mark_path_old ~cwd:dir broken_path;
+    let dry_stdout, _ =
+      run_shell_ok ~cwd:(source_root ())
+        (Printf.sprintf
+           "%s --root %s --days 1 --repo masc-mcp --include-broken"
+           (quote (cleanup_script_path ()))
+           (quote root))
+    in
+    check bool "broken candidate listed" true
+      (contains_substring dry_stdout "BROKEN_CANDID");
+    check bool "broken retained after dry-run" true (Sys.file_exists broken_path);
+    let apply_stdout, _ =
+      run_shell_ok ~cwd:(source_root ())
+        (Printf.sprintf
+           "%s --root %s --days 1 --repo masc-mcp --include-broken --apply"
+           (quote (cleanup_script_path ()))
+           (quote root))
+    in
+    check bool "broken removed listed" true
+      (contains_substring apply_stdout "BROKEN_REMOVED");
+    check bool "broken removed" false (Sys.file_exists broken_path))
+
+let () =
+  run "docker_playground_gc_script"
+    [ ( "script"
+      , [ test_case "syntax valid" `Quick test_scripts_are_syntax_valid
+        ; test_case "dry-run lists stale clean worktree" `Quick
+            test_dry_run_lists_stale_clean_worktree
+        ; test_case "recent checkout of old commit is not candidate" `Quick
+            test_recent_checkout_of_old_commit_is_not_candidate
+        ; test_case "apply removes stale clean worktree" `Quick
+            test_apply_removes_stale_clean_worktree
+        ; test_case "apply skips dirty worktree" `Quick test_apply_skips_dirty_worktree
+        ; test_case "include-broken removes old non-git directory" `Quick
+            test_include_broken_removes_old_non_git_directory
+        ] )
+    ]


### PR DESCRIPTION
## Summary
- Add Docker playground FD visibility via `scripts/docker-playground-fd-status.sh`.
- Add conservative stale Docker playground worktree cleanup with dry-run default, dirty/runtime-reference skips, and opt-in broken directory cleanup.
- Document the operator runbook and add fixture coverage for dry-run/apply/dirty/broken/recent checkout behavior.

## Evidence
- `scripts/nofile-status.sh`: soft open files 245760, hard unlimited, total lsof rows 22440; current host pressure is not active.
- `scripts/docker-playground-fd-status.sh --root /Users/dancer/me/.masc/playground/docker --limit 10`: worktrees_dirs=11, worktree_entries=157; no large current FD holder referencing the root.
- Dry-run on live root: scanned=155, candidates=62, recent=75, dirty=6, broken=12, removed=0.
- `bash -n scripts/cleanup-docker-playground-worktrees.sh`
- `bash -n scripts/docker-playground-fd-status.sh`
- `ocamlformat --check test/test_docker_playground_gc_script.ml`
- `git diff --check HEAD~1..HEAD`

Focused Dune validation was not run locally because `/tmp/me-dune-local.lock` is currently held by other active builds. This PR is draft until CI or a later focused local run compiles the new Alcotest fixture.

Addresses #15931.