### PR TITLE
Fix CDAL verifier gate ordering

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -506,6 +506,21 @@ let task_has_persisted_contract = function
   | Some (task : Masc_domain.task) -> Option.is_some task.contract
   | None -> false
 
+let task_has_strict_persisted_contract = function
+  | Some ({ contract = Some { strict = true; _ }; _ } : Masc_domain.task) ->
+    true
+  | _ -> false
+
+let contract_requires_verification (contract : Masc_domain.task_contract) =
+  Stdlib.List.length contract.completion_contract > 0
+  || Stdlib.List.length contract.required_evidence > 0
+  || Stdlib.List.length contract.verify_gate_evidence > 0
+
+let task_requires_verification = function
+  | Some ({ contract = Some contract; _ } : Masc_domain.task) ->
+    contract_requires_verification contract
+  | _ -> false
+
 let strict_release_requires_handoff = function
   | Some ({ contract = Some contract; _ } : Masc_domain.task) -> contract.strict
   | _ -> false
@@ -1080,8 +1095,17 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
   let completion_owned_by_caller =
     force || can_review_completion ~task_opt ~agent_name:ctx.agent_name
   in
+  let done_redirects_to_verification =
+    (=) action Masc_domain.Done_action
+    && Env_config_runtime.Verification.fsm_enabled ()
+    && completion_owned_by_caller
+    && task_requires_verification task_opt
+  in
   let persisted_gate_rejection =
-    if (=) action Masc_domain.Done_action && not force then
+    if (=) action Masc_domain.Done_action
+       && not force
+       && not done_redirects_to_verification
+    then
       if not completion_owned_by_caller then
         None
       else if task_has_persisted_contract task_opt then
@@ -1126,19 +1150,17 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
      above; this replaces Gate 2.5 (substring match) with real
      measurement by the verifier. See issue #7598. *)
   let action =
-    if (=) action Masc_domain.Done_action
-       && Env_config_runtime.Verification.fsm_enabled ()
-       && completion_owned_by_caller
-    then
+    if done_redirects_to_verification then
       match task_opt with
       | Some task ->
         (match task.contract with
-         | Some contract
-           when Stdlib.List.length contract.completion_contract > 0 || Stdlib.List.length contract.required_evidence > 0 ->
+         | Some contract when contract_requires_verification contract ->
            Log.Task.info
              "[verifier-gate] redirecting Done→Submit_for_verification task=%s agent=%s contract_items=%d"
              task_id ctx.agent_name
-             (List.length contract.completion_contract + List.length contract.required_evidence);
+             (List.length contract.completion_contract
+              + List.length contract.required_evidence
+              + List.length contract.verify_gate_evidence);
            Masc_domain.Submit_for_verification
          | _ -> action)
       | None -> action
@@ -1230,6 +1252,18 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
     | Masc_domain.Submit_pr_evidence ->
       None
   in
+  let verifier_approve_gate_rejection =
+    if (=) action Masc_domain.Approve_verification
+       && task_has_strict_persisted_contract task_opt
+    then
+      persisted_contract_rejection ~ctx ~task_opt ~notes
+    else
+      None
+  in
+  match verifier_approve_gate_rejection with
+  | Some reason ->
+    Tool_result.error ~tool_name ~start_time reason
+  | None ->
   let rec try_transition attempt =
     match submit_evidence_error with
     | Some reason ->

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -1554,6 +1554,7 @@ let test_done_after_claim () =
 ;;
 
 let test_done_respects_persisted_cdal_gate () =
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "false") (fun () ->
   with_env "MASC_CDAL_GATE_ENABLED" (Some "true") (fun () ->
     with_room (fun config ->
       let meta = make_test_meta () in
@@ -1584,13 +1585,13 @@ let test_done_respects_persisted_cdal_gate () =
           "mentions CDAL verdict"
           true
           (Astring.String.is_infix ~affix:"CDAL verdict" error)
-      | _ -> fail "expected strict contract gate rejection"))
+      | _ -> fail "expected strict contract gate rejection")))
 ;;
 
 let test_done_redirects_to_verification_fsm () =
   ensure_rng ();
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
-    with_env "MASC_CDAL_GATE_ENABLED" (Some "false") (fun () ->
+    with_env "MASC_CDAL_GATE_ENABLED" (Some "true") (fun () ->
       with_room (fun config ->
         let meta = make_test_meta () in
         let contract = strict_contract ~verify_gate_evidence:[ "output.json" ] () in

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -425,7 +425,8 @@ let () = test "handle_batch_add_tasks_injects_default_verification_contracts" (f
 let () = test "handle_done_uses_persisted_contract_gate" (fun () ->
   (* MASC_CDAL_GATE_ENABLED default flipped to [true] in v0.9.5 (PR #7579).
      With gate enabled + strict contract + no persisted verdict, handle_done
-     must be blocked with a gate rejection message. *)
+     must be blocked with a gate rejection message on the direct Done path. *)
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "false") (fun () ->
   let ctx = make_test_ctx () in
   let _ =
     Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
@@ -456,7 +457,45 @@ let () = test "handle_done_uses_persisted_contract_gate" (fun () ->
   if not (str_contains result_done.Tool_result.legacy_message "CDAL verdict") then
     failwith
       (Printf.sprintf "expected CDAL gate rejection message, got: %s" result_done.Tool_result.legacy_message)
-)
+))
+
+let () = test "handle_done_redirects_to_verification_before_cdal_gate" (fun () ->
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
+    with_env "MASC_CDAL_GATE_ENABLED" (Some "true") (fun () ->
+      with_env "MASC_DATA_DIR" (Some (make_temp_dir "masc-cdal-empty")) (fun () ->
+        let ctx = make_test_ctx () in
+        let _ =
+          Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+            (`Assoc
+              [
+                ("title", `String "Strict verifier task");
+                ( "contract",
+                  `Assoc
+                    [
+                      ("strict", `Bool true);
+                      ( "completion_contract",
+                        `List [ `String "deliverable-ready" ] );
+                      ("required_evidence", `List [ `String "run_deliverable" ]);
+                    ] );
+              ])
+        in
+        let _ =
+          Tool_task.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx
+            (`Assoc [ ("task_id", `String "task-001") ])
+        in
+        let result_done =
+          Tool_task.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx
+            (`Assoc
+              [
+                ("task_id", `String "task-001");
+                ( "notes",
+                  `String
+                    "Implemented deliverable-ready output and captured run_deliverable evidence." );
+              ])
+        in
+        if not result_done.Tool_result.success then
+          failwith result_done.Tool_result.legacy_message;
+        assert_task_awaiting_verification_by ctx "test-agent"))))
 
 (* Advisory contract (strict=false): CDAL gate must still record an attribution
    event so the dashboard has a verification trace, but must NOT block the
@@ -464,6 +503,7 @@ let () = test "handle_done_uses_persisted_contract_gate" (fun () ->
    안 보인다" — strict=false tasks used to bypass the gate entirely, leaving
    no audit trail. *)
 let () = test "handle_done_advisory_contract_records_attribution" (fun () ->
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "false") (fun () ->
   Dashboard_attribution.reset ();
   let ctx = make_test_ctx_with_agent "advisory-agent" in
   let _ =
@@ -510,7 +550,7 @@ let () = test "handle_done_advisory_contract_records_attribution" (fun () ->
     failwith
       "advisory recording must not leak into the strict cdal_verdict \
        bucket"
-)
+))
 
 let () = test "handle_transition_release_requires_handoff_for_strict_task" (fun () ->
   let ctx = make_test_ctx () in
@@ -968,6 +1008,61 @@ let () = test "handle_transition_verifier_allows_verdict_actions" (fun () ->
     match (only_task worker_ctx).Masc_domain.task_status with
     | Masc_domain.Done _ -> ()
     | _ -> failwith "expected verifier approval to complete task"))
+
+let () = test "handle_transition_approve_enforces_strict_cdal_gate" (fun () ->
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
+    with_env "MASC_CDAL_GATE_ENABLED" (Some "true") (fun () ->
+      with_env "MASC_DATA_DIR" (Some (make_temp_dir "masc-cdal-empty")) (fun () ->
+        let worker_ctx = make_test_ctx_with_agent "worker" in
+        let verifier_ctx = { worker_ctx with Tool_task.agent_name = "verifier" } in
+        let _ =
+          Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0
+            worker_ctx
+            (`Assoc
+              [
+                ("title", `String "Strict verifier approval");
+                ( "contract",
+                  `Assoc
+                    [
+                      ("strict", `Bool true);
+                      ("completion_contract", `List [ `String "tests pass" ]);
+                    ] );
+              ])
+        in
+        let _ =
+          Coord.claim_task worker_ctx.config ~agent_name:"worker"
+            ~task_id:"task-001"
+        in
+        let submit =
+          Coord.transition_task_r worker_ctx.config ~agent_name:"worker"
+            ~task_id:"task-001" ~action:Masc_domain.Submit_for_verification
+            ()
+        in
+        (match submit with
+         | Ok _ -> ()
+         | Error err ->
+           failwith
+             ("submit_for_verification failed: "
+              ^ Masc_domain.masc_error_to_string err));
+        let result =
+          Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0
+            verifier_ctx
+            (`Assoc
+              [
+                ("task_id", `String "task-001");
+                ("action", `String "approve");
+                ("notes", `String "evidence verified");
+              ])
+        in
+        if result.Tool_result.success then
+          failwith "expected strict CDAL gate to block verifier approval";
+        if not (str_contains result.Tool_result.legacy_message "CDAL verdict")
+        then
+          failwith
+            (Printf.sprintf "expected CDAL gate rejection, got: %s"
+               result.Tool_result.legacy_message);
+        assert_task_awaiting_verification_by worker_ctx "worker"))))
+
 let () = test "handle_claim_sets_planning_current_task" (fun () ->
   let ctx = make_test_ctx () in
   let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("title", `String "Claim direct")]) in


### PR DESCRIPTION
## Summary
- let strict contract tasks enter the verifier FSM before CDAL verdict gating when done is redirected to submit_for_verification
- enforce strict CDAL verdict gating on verifier approve, which is the actual FSM path to Done
- add regression coverage for CDAL gate plus verifier FSM default-on interaction in Tool_task and keeper dispatch

## Verification
- env DUNE_BUILD_DIR=/private/tmp/masc-mcp-cdal-audit-build DUNE_LOCAL_JOBS=1 DUNE_CACHE=disabled MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=0 scripts/dune-local.sh build test/test_tool_task_coverage.exe test/test_keeper_task_dispatch.exe test/test_verification_fsm.exe test/test_cdal_verdict_gate.exe
- /private/tmp/masc-mcp-cdal-audit-build/default/test/test_tool_task_coverage.exe
- /private/tmp/masc-mcp-cdal-audit-build/default/test/test_keeper_task_dispatch.exe
- /private/tmp/masc-mcp-cdal-audit-build/default/test/test_verification_fsm.exe
- /private/tmp/masc-mcp-cdal-audit-build/default/test/test_cdal_verdict_gate.exe
- Broader CDAL audit before final rebase also passed: test_keeper_cdal_contract.exe, test_cdal_runtime_health_15748.exe, test_cdal_eval_v1.exe, test_cdal_proof.exe, test_cdal_mode_resolver.exe, test_cdal_mode_enforcer.exe, test_cdal_conformance.exe