### PR TITLE
Relax disk admission percent floor

### DIFF
--- a/lib/keeper_disk_pressure.ml
+++ b/lib/keeper_disk_pressure.ml
@@ -28,8 +28,10 @@ type admission_block =
       { path : string
       ; available_bytes : int
       ; min_free_bytes : int
+      ; effective_min_free_bytes : int
       ; available_percent : float
       ; min_free_percent : float
+      ; percent_floor_max_bytes : int
       }
 
 type admission_decision =
@@ -143,8 +145,32 @@ let min_free_percent () =
   env_float_clamped "MASC_KEEPER_DISK_MIN_FREE_PERCENT" ~default:5.0 ~min_v:0.1
 ;;
 
+let percent_floor_max_bytes () =
+  (* Keep the percent floor from scaling into hundreds of GiB on multi-TiB
+     volumes. The explicit min_free knobs remain the operator-facing tuning
+     surface; this cap is a guardrail against over-strict defaults. *)
+  40 * 1024 * 1024 * 1024
+;;
+
 let snapshot_ttl_sec () =
   env_float_clamped "MASC_KEEPER_DISK_SNAPSHOT_TTL_SEC" ~default:30.0 ~min_v:1.0
+;;
+
+let percent_floor_bytes s ~min_free_percent =
+  if s.total_bytes <= 0
+  then 0
+  else
+    float_of_int s.total_bytes *. min_free_percent /. 100.0
+    |> ceil
+    |> int_of_float
+;;
+
+let effective_min_free_bytes s ~min_free_bytes ~min_free_percent =
+  let percent_floor_max_bytes = percent_floor_max_bytes () in
+  let capped_percent_floor =
+    min (percent_floor_bytes s ~min_free_percent) percent_floor_max_bytes
+  in
+  max min_free_bytes capped_percent_floor
 ;;
 
 let rec nearest_existing_path path =
@@ -242,15 +268,21 @@ let admission_decision_of_snapshot ?now snapshot =
     | Snapshot s ->
       let min_free_bytes = min_free_bytes () in
       let min_free_percent = min_free_percent () in
-      if s.available_bytes < min_free_bytes || s.available_percent < min_free_percent
+      let percent_floor_max_bytes = percent_floor_max_bytes () in
+      let effective_min_free_bytes =
+        effective_min_free_bytes s ~min_free_bytes ~min_free_percent
+      in
+      if s.available_bytes < effective_min_free_bytes
       then
         Block
           (Disk_free_space_low
              { path = s.path
              ; available_bytes = s.available_bytes
              ; min_free_bytes
+             ; effective_min_free_bytes
              ; available_percent = s.available_percent
              ; min_free_percent
+             ; percent_floor_max_bytes
              })
       else Admit)
 ;;
@@ -296,14 +328,23 @@ let admission_block_to_json = function
       ; "detail", `String detail
       ]
   | Disk_free_space_low
-      { path; available_bytes; min_free_bytes; available_percent; min_free_percent } ->
+      { path
+      ; available_bytes
+      ; min_free_bytes
+      ; effective_min_free_bytes
+      ; available_percent
+      ; min_free_percent
+      ; percent_floor_max_bytes
+      } ->
     `Assoc
       [ "tag", `String "disk_free_space_low"
       ; "path", `String path
       ; "available_bytes", `Int available_bytes
       ; "min_free_bytes", `Int min_free_bytes
+      ; "effective_min_free_bytes", `Int effective_min_free_bytes
       ; "available_percent", `Float available_percent
       ; "min_free_percent", `Float min_free_percent
+      ; "percent_floor_max_bytes", `Int percent_floor_max_bytes
       ]
 ;;
 
@@ -333,6 +374,7 @@ let snapshot_json ?now ~masc_root () =
     ; "masc_root", `String masc_root
     ; "min_free_bytes", `Int (min_free_bytes ())
     ; "min_free_percent", `Float (min_free_percent ())
+    ; "percent_floor_max_bytes", `Int (percent_floor_max_bytes ())
     ; "snapshot_ttl_sec", `Float (snapshot_ttl_sec ())
     ; "filesystem", snapshot_result_to_json snapshot
     ; "admission", admission_decision_to_json (admission_decision_of_snapshot ?now snapshot)

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -287,16 +287,22 @@ let test_fd_pressure_degraded_projection () =
 
 let gib n = n * 1024 * 1024 * 1024
 
-let disk_snapshot ?(available_bytes = gib 40) () =
+let disk_snapshot ?(total_bytes = gib 100) ?(available_bytes = gib 40) () =
+  let used_bytes = max 0 (total_bytes - available_bytes) in
   Disk.Snapshot
     { path = "/tmp"
     ; filesystem = "/dev/test"
-    ; total_bytes = gib 100
-    ; used_bytes = gib 60
+    ; total_bytes
+    ; used_bytes
     ; available_bytes
-    ; capacity_percent = 60.0
+    ; capacity_percent =
+        (if total_bytes <= 0
+         then 0.0
+         else float_of_int used_bytes /. float_of_int total_bytes *. 100.0)
     ; available_percent =
-        (float_of_int available_bytes /. float_of_int (gib 100)) *. 100.0
+        (if total_bytes <= 0
+         then 0.0
+         else float_of_int available_bytes /. float_of_int total_bytes *. 100.0)
     ; mounted_on = "/"
     }
 
@@ -322,6 +328,14 @@ let test_disk_pressure_proactive_admission () =
           with_env "MASC_KEEPER_DISK_MIN_FREE_PERCENT" "5.0" (fun () ->
               check bool "admits filesystem with disk headroom" true
                 (Disk.admission_decision_of_snapshot (disk_snapshot ()) |> disk_admitted);
+              check bool "admits large filesystem above capped percent floor" true
+                (Disk.admission_decision_of_snapshot
+                   (disk_snapshot ~total_bytes:(gib 4096) ~available_bytes:(gib 52) ())
+                 |> disk_admitted);
+              check bool "blocks large filesystem below capped percent floor" false
+                (Disk.admission_decision_of_snapshot
+                   (disk_snapshot ~total_bytes:(gib 4096) ~available_bytes:(gib 30) ())
+                 |> disk_admitted);
               check bool "blocks filesystem below disk floor" false
                 (Disk.admission_decision_of_snapshot
                    (disk_snapshot ~available_bytes:(gib 1) ())


### PR DESCRIPTION
## Summary

- cap the percent-derived disk free-space floor so large volumes do not require hundreds of GiB free
- keep existing `MASC_KEEPER_DISK_MIN_FREE_BYTES` / `MASC_KEEPER_DISK_MIN_FREE_PERCENT` knobs unchanged
- add regression coverage for a 4 TiB filesystem with 52 GiB free being admitted and 30 GiB being blocked

## Runtime evidence

- local restart at `2026-05-17T14:09:15Z` ran commit `1dc7d7a36a` with base path `/Users/dancer/me`
- `/Users/dancer/me` had 52 GiB available on a 3.6 TiB volume, but keeper autoboot was denied with `disk_admission_blocked`
- post-restart keepers were blocked before launch: `ramarama`, `sangsu`, `tech_glutton`

## Verification

- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_registry.exe`
- `./_build/default/test/test_keeper_registry.exe test basic 9 -e`
- `opam exec -- ocamlformat --check lib/keeper_disk_pressure.ml test/test_keeper_registry.ml`
- `git diff --check`
