### PR TITLE
feat: account With_process subprocess helpers

### DIFF
--- a/lib/process/with_process.ml
+++ b/lib/process/with_process.ml
@@ -13,29 +13,39 @@
     raise [Failure "equal: abstract value"] when called on already-closed
     channels.  The close is best-effort; the primary contract is fd reclaim. *)
 
+type process_guard = { run : 'a. (unit -> 'a) -> 'a }
+
+let default_process_guard = { run = (fun f -> f ()) }
+let process_guard : process_guard Atomic.t = Atomic.make default_process_guard
+let set_process_guard guard = Atomic.set process_guard guard
+let reset_process_guard_for_testing () = Atomic.set process_guard default_process_guard
+let with_process_guard f = (Atomic.get process_guard).run f
+
 let close_best_effort ic =
   try let _ = (Unix.close_process_in ic : Unix.process_status) in ()
   with Unix.Unix_error _ | Sys_error _ | Failure _ -> ()
 
 let with_process_in cmd f =
-  let ic = Unix.open_process_in cmd in
-  match f ic with
-  | result ->
-      let status = Unix.close_process_in ic in
-      (result, status)
-  | exception exn ->
-      close_best_effort ic;
-      raise exn
+  with_process_guard (fun () ->
+      let ic = Unix.open_process_in cmd in
+      match f ic with
+      | result ->
+          let status = Unix.close_process_in ic in
+          (result, status)
+      | exception exn ->
+          close_best_effort ic;
+          raise exn)
 
 let with_process_args_in prog argv f =
-  let ic = Unix.open_process_args_in prog argv in
-  match f ic with
-  | result ->
-      let status = Unix.close_process_in ic in
-      (result, status)
-  | exception exn ->
-      close_best_effort ic;
-      raise exn
+  with_process_guard (fun () ->
+      let ic = Unix.open_process_args_in prog argv in
+      match f ic with
+      | result ->
+          let status = Unix.close_process_in ic in
+          (result, status)
+      | exception exn ->
+          close_best_effort ic;
+          raise exn)
 
 let drain_to_buffer ?(chunk = 4096) ic =
   let buf = Buffer.create chunk in

--- a/lib/process/with_process.mli
+++ b/lib/process/with_process.mli
@@ -1,5 +1,16 @@
 (** Exception-safe subprocess stdout capture — SSOT for #8538. *)
 
+type process_guard = { run : 'a. (unit -> 'a) -> 'a }
+(** Process-wide guard wrapped around [Unix.open_process_*] helpers.
+    Intended for resource accounting/admission control at the subprocess
+    lifetime boundary. *)
+
+val set_process_guard : process_guard -> unit
+(** Install a process-wide guard. The default guard runs directly. *)
+
+val reset_process_guard_for_testing : unit -> unit
+(** Restore the default direct guard. Intended for focused tests. *)
+
 val with_process_in :
   string -> (in_channel -> 'a) -> 'a * Unix.process_status
 (** [with_process_in cmd f] opens [cmd] via [Unix.open_process_in], passes

--- a/lib/server/fd_accountant.ml
+++ b/lib/server/fd_accountant.ml
@@ -104,9 +104,20 @@ let install_process_eio_sandbox_exec_guard () =
             f ())
     }
 
+let install_with_process_sandbox_exec_guard () =
+  With_process.set_process_guard
+    { With_process.run =
+        (fun f ->
+          if Eio_guard.is_ready () then
+            with_slot ~kind:Sandbox_exec f
+          else
+            f ())
+    }
+
 let () =
   install_dated_jsonl_log_writer_guard ();
-  install_process_eio_sandbox_exec_guard ()
+  install_process_eio_sandbox_exec_guard ();
+  install_with_process_sandbox_exec_guard ()
 
 (* In-flight count = configured cap minus current semaphore credits.
    Eio.Semaphore exposes [get_value] which returns the available credit

--- a/lib/server/fd_accountant.ml
+++ b/lib/server/fd_accountant.ml
@@ -57,6 +57,8 @@ let _shared_pressure_mutex = Eio.Mutex.create ()
 let held_kinds_key : kind list Eio.Fiber.key = Eio.Fiber.create_key ()
 
 let held_kinds () =
+  (* NDT-OK: fiber-local runtime state only prevents same-fiber slot
+     double-accounting; policy decisions stay outside this boundary. *)
   try Option.value ~default:[] (Eio.Fiber.get held_kinds_key)
   with _ -> []
 

--- a/lib/server/fd_accountant.mli
+++ b/lib/server/fd_accountant.mli
@@ -79,6 +79,13 @@ val install_process_eio_sandbox_exec_guard : unit -> unit
     installs it at load time; the explicit function exists for tests and future
     bootstrap code that resets process hooks. *)
 
+val install_with_process_sandbox_exec_guard : unit -> unit
+(** [install_with_process_sandbox_exec_guard ()] installs the process-wide
+    {!With_process} guard that accounts [Unix.open_process_*] helper calls as
+    {!Sandbox_exec} while {!Eio_guard} is ready. The slot covers the whole
+    subprocess lifetime: open, caller drain, and close. Before Eio startup, the
+    guard runs directly so pure test/module paths stay safe. *)
+
 type snapshot = {
   per_kind : (kind * int) list ;
       (** in-flight count per class (cap − available semaphore slots). *)

--- a/test/test_fd_accountant.ml
+++ b/test/test_fd_accountant.ml
@@ -197,6 +197,33 @@ let test_process_eio_run_argv_uses_sandbox_slot () =
       check int "Process_eio sandbox slot released" 0
         (kind_in_flight FA.Sandbox_exec))
 
+let test_with_process_uses_sandbox_slot () =
+  Eio_main.run @@ fun _env ->
+  Eio_guard.enable () ;
+  Fun.protect
+    ~finally:(fun () ->
+      With_process.reset_process_guard_for_testing () ;
+      Eio_guard.disable ())
+    (fun () ->
+      With_process.reset_process_guard_for_testing () ;
+      FA.install_with_process_sandbox_exec_guard () ;
+      let (observed, lines), status =
+        With_process.with_process_args_in "/bin/echo"
+          [| "/bin/echo" ; "with-process-slot" |]
+          (fun ic ->
+            let observed = kind_in_flight FA.Sandbox_exec in
+            (observed, With_process.drain_lines ic))
+      in
+      check int "With_process holds sandbox slot during callback" 1
+        observed ;
+      check (list string) "With_process stdout" [ "with-process-slot" ]
+        lines ;
+      (match status with
+      | Unix.WEXITED 0 -> ()
+      | _ -> Alcotest.fail "expected With_process child to exit 0") ;
+      check int "With_process sandbox slot released" 0
+        (kind_in_flight FA.Sandbox_exec))
+
 let () =
   Alcotest.run "Fd_accountant"
     [
@@ -233,5 +260,7 @@ let () =
         [
           test_case "Process_eio run_argv uses sandbox slot" `Quick
             test_process_eio_run_argv_uses_sandbox_slot ;
+          test_case "With_process uses sandbox slot" `Quick
+            test_with_process_uses_sandbox_slot ;
         ] ) ;
     ]

--- a/test/test_with_process_coverage.ml
+++ b/test/test_with_process_coverage.ml
@@ -84,6 +84,36 @@ let test_drain_to_buffer () =
   in
   check string "buffer contents" "ab\n" (Buffer.contents buf)
 
+let test_process_guard_wraps_helpers () =
+  let depth = Atomic.make 0 in
+  let high_water = Atomic.make 0 in
+  let update_high () =
+    let cur = Atomic.get depth in
+    let rec bump () =
+      let h = Atomic.get high_water in
+      if cur > h then
+        if Atomic.compare_and_set high_water h cur then () else bump ()
+    in
+    bump ()
+  in
+  WP.set_process_guard
+    { WP.run =
+        (fun f ->
+          Atomic.incr depth;
+          update_high ();
+          Fun.protect ~finally:(fun () -> Atomic.decr depth) f)
+    };
+  Fun.protect ~finally:WP.reset_process_guard_for_testing (fun () ->
+      let lines, _ =
+        WP.with_process_args_in "/bin/echo" [| "/bin/echo"; "guard" |]
+          WP.drain_lines
+      in
+      check (list string) "guarded stdout" [ "guard" ] lines;
+      let lines, _ = WP.with_process_in "printf guard2" WP.drain_lines in
+      check (list string) "guarded shell stdout" [ "guard2" ] lines;
+      check int "guard high-water" 1 (Atomic.get high_water);
+      check int "guard released" 0 (Atomic.get depth))
+
 let () =
   run "with_process"
     [
@@ -93,6 +123,9 @@ let () =
           test_case "drain_to_buffer fills buffer" `Quick
             test_drain_to_buffer;
         ] );
+      ( "guard",
+        [ test_case "process guard wraps helpers" `Quick
+            test_process_guard_wraps_helpers ] );
       ( "error_path",
         [
           test_case "Sys_error in callback closes pipe" `Quick


### PR DESCRIPTION
## Summary
- mark the fd accountant fiber-local slot cache as an explicit NDT boundary
- add a process-wide guard to With_process so Unix.open_process_* helpers can be accounted at the subprocess lifetime boundary
- install that guard from Fd_accountant as Sandbox_exec while Eio_guard is ready
- add focused coverage for direct With_process guards and Fd_accountant integration

## Verification
- ocamlformat --check lib/process/with_process.ml lib/process/with_process.mli lib/server/fd_accountant.ml lib/server/fd_accountant.mli test/test_with_process_coverage.ml test/test_fd_accountant.ml
- git diff --check origin/sandbox-runtime-plane-pr7-fd-accountant-ndt-comment...HEAD
- bash scripts/ci/check-determinism-contract.sh

## Note
- Local focused Dune build was attempted but blocked for an extended period by the shared dune-local lock held by other worktrees; CI is the active compile/test verification surface for this draft.