### PR TITLE
Fix Eio fiber cancellation checks

### DIFF
--- a/lib/opentelemetry_client_cohttp_eio.ml
+++ b/lib/opentelemetry_client_cohttp_eio.ml
@@ -166,7 +166,7 @@ end = struct
          all exceptions (including Cancelled) and reports them as Error
          strings; without this check the exporter would log a spurious
          "export failed" instead of unwinding cancellation. *)
-      Eio.Cancel.check ();
+      Eio.Fiber.check ();
       Error
         (`Failure
            (spf

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -483,7 +483,7 @@ let single_voice_mcp_call ~net ~uri ~headers_list ~body_str =
        and reports them as an Error string; without this check the retry
        loop in [call_voice_mcp_endpoint] would sleep and re-attempt
        instead of unwinding cancellation immediately. *)
-    Eio.Cancel.check ();
+    Eio.Fiber.check ();
     Error (Printf.sprintf "Connection error: %s" e)
 ;;
 
@@ -722,7 +722,7 @@ let is_voice_server_available ~sw:_ ~clock ~net =
              fiber was cancelled. Masc_http_client.get_sync's piaf pool
              catches Cancelled as an Error string; without this check
              the availability probe would mask cancellation as Ok false. *)
-          Eio.Cancel.check ();
+          Eio.Fiber.check ();
           Log.Transport.warn "voice server check failed: %s" msg;
           voice_server_available := Some false;
           Ok false
@@ -1010,7 +1010,7 @@ let health_check ~sw:_ ~clock:_ ~net () =
          fiber was cancelled. Pool.do_request captures Cancelled as an
          Error string; without this check shutdown is reported as a
          normal "Not reachable" failure. *)
-      Eio.Cancel.check ();
+      Eio.Fiber.check ();
       Error (Printf.sprintf "Not reachable: %s" msg)
     | Ok { Masc_http_client.status; body = body_str; _ } ->
       if status >= 200 && status < 300


### PR DESCRIPTION
## Summary

- fix current main build failure from calling `Eio.Cancel.check ()`
- replace the low-level cancellation-context API with `Eio.Fiber.check ()`
- update all matching call sites in OTLP and voice bridge HTTP error paths

## Root Cause

`Eio.Cancel.check` expects an `Eio.Cancel.t`, while these call sites were trying to check the current fiber cancellation context with `()`. Current Eio exposes that operation as `Eio.Fiber.check ()`.

## Verification

- `env DUNE_CACHE=disabled dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/verify-main-build-16003 bin/main_eio.exe test/test_keeper_registry.exe`
- `./_build/default/test/test_keeper_registry.exe test basic 9 -e`
- `opam exec -- ocamlformat --check lib/opentelemetry_client_cohttp_eio.ml lib/voice/voice_bridge.ml`
- `git diff --check`
