### PR TITLE
fix(keeper): start supervisor for due auto pauses

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -150,6 +150,37 @@ let autoboot_excluded_keeper_reasons config =
        | Some reason -> Some { keeper_name = name; reason }
        | None -> None)
 
+let auto_recoverable_paused_keeper_names ?now config =
+  let now =
+    match now with
+    | Some value -> value
+    | None ->
+      (* NDT-OK: cold-start supervisor admission uses wall-clock pause age to decide whether the recovery sweep must run. *)
+      Unix.gettimeofday ()
+  in
+  configured_keeper_names config
+  |> List.filter_map (fun name ->
+       match read_meta_file_path (keeper_meta_path config name) with
+       | Ok (Some meta)
+         when meta.paused
+              &&
+              (match (load_keeper_profile_defaults name).autoboot_enabled with
+               | Some value -> value
+               | None -> meta.autoboot_enabled)
+              && Keeper_supervisor_types.paused_meta_auto_resume_due ~now meta ->
+         Some meta.name
+       | Ok (Some _) | Ok None -> None
+       | Error msg ->
+         Prometheus.inc_counter
+           Keeper_metrics.metric_keeper_meta_read_failures
+           ~labels:[ ("keeper", name); ("site", "auto_recoverable_paused_read") ]
+           ();
+         Log.Keeper.warn
+           "auto_recoverable_paused_keeper_names: meta read failed for %s: %s"
+           name
+           msg;
+         None)
+
 (* PR-3b1: convert a credential lookup name to its canonical
    keeper-<n>-agent form when it refers to a bootable keeper.
    Non-keeper names (dashboard, admin, codex-mcp-client, ...) are
@@ -900,6 +931,7 @@ let existing_keepalive_bootstrap_done : (string, unit) Hashtbl.t =
 
 let has_boot_entries config =
   bootable_keeper_names config <> []
+  || auto_recoverable_paused_keeper_names config <> []
 
 (* #10125: extracted predicate so it can be unit-tested without
    spinning up an Eio + Pulse runtime.  See [maybe_start_supervisor_sweep]

--- a/lib/keeper/keeper_runtime.mli
+++ b/lib/keeper/keeper_runtime.mli
@@ -55,6 +55,13 @@ val bootable_keeper_names : Coord.config -> string list
 val autoboot_excluded_keeper_reasons : Coord.config -> autoboot_exclusion list
 (** Configured keepers skipped by autoboot with operator-facing reason labels. *)
 
+val auto_recoverable_paused_keeper_names : ?now:float -> Coord.config -> string list
+(** Configured, autoboot-enabled keepers that are currently paused but whose
+    supervisor-owned auto-resume timer has elapsed.  These keepers remain
+    excluded from {!bootable_keeper_names} until the supervisor clears
+    [paused=false], but they are enough reason to start the supervisor sweep on
+    cold boot. *)
+
 val canonicalize_if_keeper : Coord.config -> string -> string
 (** [canonicalize_if_keeper config name] returns [keeper-<n>-agent]
     when [name] (bare or already canonical) refers to a configured

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1907,9 +1907,7 @@ let sweep_and_recover (ctx : _ context) =
     else (
       match read_meta ctx.config name with
       | Ok (Some meta)
-        when meta.paused
-             && Option.is_some meta.auto_resume_after_sec
-             && (not (paused_meta_requires_reconcile_recovery meta))
+        when Keeper_supervisor_types.paused_meta_auto_resume_due ~now meta
              && not (Keeper_approval_queue.has_pending_for_keeper ~keeper_name:meta.name)
         ->
         let cascade_name = Keeper_types.cascade_name_of_meta meta in

--- a/lib/keeper/keeper_supervisor_types.ml
+++ b/lib/keeper/keeper_supervisor_types.ml
@@ -119,6 +119,18 @@ let paused_meta_requires_reconcile_recovery (meta : keeper_meta) =
   | None -> false
 ;;
 
+let paused_meta_auto_resume_due ~now (meta : keeper_meta) =
+  if (not meta.paused) || paused_meta_requires_reconcile_recovery meta
+  then false
+  else
+    match meta.auto_resume_after_sec with
+    | None -> false
+    | Some resume_after_sec ->
+      (match Coord_resilience.Time.parse_iso8601_opt meta.updated_at with
+       | Some paused_ts -> paused_ts > 0.0 && now -. paused_ts >= resume_after_sec
+       | None -> false)
+;;
+
 let cohort_key_of_reason = Keeper_registry.failure_reason_cohort_key
 
 let stale_turn_timeout_cohort_key =

--- a/lib/keeper/keeper_supervisor_types.mli
+++ b/lib/keeper/keeper_supervisor_types.mli
@@ -61,6 +61,13 @@ val paused_meta_requires_reconcile_recovery : keeper_meta -> bool
 (** Internal: predicate identifying paused metas whose last_blocker class
     requires reconcile-recovery rather than straight resume. *)
 
+val paused_meta_auto_resume_due : now:float -> keeper_meta -> bool
+(** True when [meta] is an auto-paused keeper whose self-healing backoff has
+    elapsed.  Intentional/operator pauses ([auto_resume_after_sec = None])
+    and reconcile-gated pauses are excluded.  This pure predicate deliberately
+    does not inspect cascade health or approval queues; callers that can see
+    those runtime surfaces must still apply them before mutating state. *)
+
 val cohort_key_of_reason : Keeper_registry.failure_reason option -> string
 (** Map a structured failure_reason to a cohort key for self-preservation grouping. *)
 

--- a/lib/keeper_fd_pressure.ml
+++ b/lib/keeper_fd_pressure.ml
@@ -6,8 +6,10 @@
     low-cardinality circuit breaker that can be tripped from central error
     sites and consulted by turn/spawn scheduling. It checks both the process
     [nofile] budget and, when available, the host kernel's global file-table
-    budget because ENFILE can fire while the MASC server's own FD count is
-    still low.
+    budget when available because ENFILE can fire while the MASC server's own
+    FD count is still low. System probe failures remain telemetry-only: a
+    sandbox or restricted host must not block keeper launches after the direct
+    process nofile budget has passed.
 
     Fleet baseline (2026-05-17): default capacity targets 64 active keepers
     (= 64 * fd_per_active_keeper + fd_headroom). The previous default named
@@ -505,12 +507,7 @@ let admission_decision
              })
       else
         (match system_fds with
-         | None ->
-           probe_unknown_block
-             ~probe:"system_fd"
-             ~projected_fds
-             ~active_keepers
-             ~starting_keepers
+         | None -> Admit
          | Some _ ->
            (match
               system_fd_budget_block system_fds ~projected_fds ~active_keepers

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -151,7 +151,7 @@ let test_fd_pressure_probe_unknown_admission () =
       ~starting_keepers:1
       ()
   in
-  check_block_kind "system fd probe unknown" "system_fd_probe_unknown" system_unknown;
+  check bool "system fd probe unknown stays advisory" true (FD.admitted system_unknown);
   let runtime =
     FD.runtime_state_json
       ~soft_limit:(Some 245_760)
@@ -162,9 +162,9 @@ let test_fd_pressure_probe_unknown_admission () =
       ~requested_keepers:24
       ()
   in
-  check string "runtime exposes probe-unknown reason" "system_fd_probe_unknown"
-    (Json.member "reason" runtime |> Json.to_string);
-  check bool "runtime marks admission blocked" true
+  check bool "runtime exposes system probe unsupported" false
+    (Json.member "system_fd_probe_supported" runtime |> Json.to_bool);
+  check bool "runtime does not block on system probe unknown" false
     (Json.member "admission_blocked" runtime |> Json.to_bool)
 
 let test_fd_pressure_system_admission () =

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -6,6 +6,7 @@ open Alcotest
 module Sup = Masc_mcp.Keeper_supervisor
 module Reg = Masc_mcp.Keeper_registry
 module KT = Masc_mcp.Keeper_types
+module KR = Masc_mcp.Keeper_runtime
 module AQ = Masc_mcp.Keeper_approval_queue
 module KSM = Masc_mcp.Keeper_state_machine
 module KLH = Masc_mcp.Keeper_lifecycle_hooks
@@ -61,6 +62,17 @@ let with_config_dir f =
       Unix.putenv "MASC_CONFIG_DIR" config_dir;
       Config_dir_resolver.reset ();
       f config_dir)
+
+let write_keeper_toml config_dir ~name =
+  write_file
+    (Filename.concat (Filename.concat config_dir "keepers") (name ^ ".toml"))
+    (Printf.sprintf
+       {|
+[keeper]
+name = "%s"
+goal = "test keeper"
+|}
+       name)
 
 let with_restart_launch_noop f =
   Sup.with_restart_launch_noop_for_test f
@@ -1314,9 +1326,11 @@ let test_auto_resume_after_sec_doubles_on_repause () =
 
 (* Test: Phase 3.5 sweep auto-resumes a keeper whose timer has elapsed. *)
 let test_sweep_auto_resumes_after_backoff () =
+  with_restart_launch_noop @@ fun () ->
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
+  with_config_dir @@ fun config_dir ->
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
@@ -1327,6 +1341,7 @@ let test_sweep_auto_resumes_after_backoff () =
       let config = Masc_mcp.Coord.default_config base_dir in
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
       let name = "auto-resume-keeper" in
+      write_keeper_toml config_dir ~name;
       (* Simulate a keeper paused 2h ago with a 1h (3600s) auto-resume
          delay.  Since 7200 > 3600 the sweep should clear [paused]. *)
       let two_hours_ago =
@@ -1345,6 +1360,8 @@ let test_sweep_auto_resumes_after_backoff () =
       (match KT.write_meta config paused_meta with
        | Ok () -> ()
        | Error err -> fail err);
+      check bool "precondition: paused keeper is not bootable" false
+        (List.mem name (KR.bootable_keeper_names config));
       let baseline_auto_resume =
         Masc_mcp.Prometheus.metric_total
           Masc_mcp.Keeper_metrics.metric_keeper_auto_resumed_total
@@ -1367,9 +1384,15 @@ let test_sweep_auto_resumes_after_backoff () =
              false m.paused;
            (* auto_resume_after_sec is retained (ready for next pause). *)
            check bool "auto_resume_after_sec retained for next cycle"
-             true (Option.is_some m.auto_resume_after_sec)
+             true (Option.is_some m.auto_resume_after_sec);
+           check bool "last_blocker cleared after auto-resume" true
+             (Option.is_none m.runtime.last_blocker)
        | Ok None -> fail "meta missing after auto-resume"
        | Error err -> fail ("read_meta failed: " ^ err));
+      check bool "auto-resumed keeper re-enters bootable set" true
+        (List.mem name (KR.bootable_keeper_names config));
+      check bool "auto-resumed keeper is reconciled into registry" true
+        (Reg.is_registered ~base_path:config.base_path name);
       let after_auto_resume =
         Masc_mcp.Prometheus.metric_total
           Masc_mcp.Keeper_metrics.metric_keeper_auto_resumed_total
@@ -1383,6 +1406,7 @@ let test_operator_pause_not_auto_resumed () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
+  with_config_dir @@ fun config_dir ->
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
@@ -1393,6 +1417,7 @@ let test_operator_pause_not_auto_resumed () =
       let config = Masc_mcp.Coord.default_config base_dir in
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
       let name = "operator-paused-keeper" in
+      write_keeper_toml config_dir ~name;
       (* Paused 2h ago with NO auto_resume_after_sec (operator pause). *)
       let two_hours_ago =
         let t = Unix.gmtime (Unix.time () -. 7200.0) in
@@ -1410,6 +1435,8 @@ let test_operator_pause_not_auto_resumed () =
       (match KT.write_meta config paused_meta with
        | Ok () -> ()
        | Error err -> fail err);
+      check bool "precondition: operator pause is not bootable" false
+        (List.mem name (KR.bootable_keeper_names config));
       let baseline_auto_resume =
         Masc_mcp.Prometheus.metric_total
           Masc_mcp.Keeper_metrics.metric_keeper_auto_resumed_total
@@ -1432,6 +1459,10 @@ let test_operator_pause_not_auto_resumed () =
              true m.paused
        | Ok None -> fail "meta missing"
        | Error err -> fail ("read_meta failed: " ^ err));
+      check bool "operator pause remains out of bootable set" false
+        (List.mem name (KR.bootable_keeper_names config));
+      check bool "operator pause is not reconciled into registry" false
+        (Reg.is_registered ~base_path:config.base_path name);
       let after_auto_resume =
         Masc_mcp.Prometheus.metric_total
           Masc_mcp.Keeper_metrics.metric_keeper_auto_resumed_total

--- a/test/test_supervisor_start_predicate.ml
+++ b/test/test_supervisor_start_predicate.ml
@@ -23,6 +23,8 @@ open Alcotest
 
 module Coord = Masc_mcp.Coord
 module KR = Masc_mcp.Keeper_runtime
+module KT = Masc_mcp.Keeper_types
+module Reg = Masc_mcp.Keeper_registry
 
 let rec rm_rf path =
   if Sys.file_exists path then
@@ -33,7 +35,70 @@ let rec rm_rf path =
     else
       Sys.remove path
 
-let with_temp_masc_dir f =
+let rec mkdir_p path =
+  if path = "" || path = "." || path = "/" then ()
+  else if Sys.file_exists path then ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let write_file path content =
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name ""
+
+let write_keeper_toml config_root ~name =
+  let keepers_dir = Filename.concat config_root "keepers" in
+  mkdir_p keepers_dir;
+  write_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    (Printf.sprintf
+       {|
+[keeper]
+name = "%s"
+goal = "test keeper"
+|}
+       name)
+
+let iso_of_unix ts =
+  let t = Unix.gmtime ts in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (t.tm_year + 1900)
+    (t.tm_mon + 1)
+    t.tm_mday
+    t.tm_hour
+    t.tm_min
+    t.tm_sec
+
+let make_meta ?(paused = false) ?auto_resume_after_sec ?updated_at name =
+  let json =
+    `Assoc
+      [ ("name", `String name)
+      ; ("agent_name", `String ("keeper-" ^ name ^ "-agent"))
+      ; ("trace_id", `String ("trace-" ^ name))
+      ; ("goal", `String "test")
+      ; ("sandbox_profile", `String "local")
+      ; ("network_mode", `String "inherit")
+      ]
+  in
+  match KT.meta_of_json json with
+  | Error err -> fail ("meta_of_json failed: " ^ err)
+  | Ok meta ->
+    { meta with
+      paused
+    ; auto_resume_after_sec
+    ; updated_at = Option.value ~default:meta.updated_at updated_at
+    }
+
+let write_meta_exn config meta =
+  match KT.write_meta config meta with
+  | Ok () -> ()
+  | Error err -> fail ("write_meta failed: " ^ err)
+
+let with_temp_masc_dir ?(keeper_names = [ "operator" ]) f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base =
@@ -43,10 +108,20 @@ let with_temp_masc_dir f =
   in
   Unix.mkdir base 0o755;
   let config = Coord.default_config base in
+  let config_root = Filename.concat (Coord.masc_root_dir config) "config" in
+  let original_config_dir = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  mkdir_p config_root;
+  List.iter (fun name -> write_keeper_toml config_root ~name) keeper_names;
+  Unix.putenv "MASC_CONFIG_DIR" config_root;
+  Config_dir_resolver.reset ();
   ignore (Coord.init config ~agent_name:None);
   Fun.protect
     ~finally:(fun () ->
       ignore (Coord.reset config);
+      Reg.clear ();
+      KR.reset_test_state base;
+      restore_env "MASC_CONFIG_DIR" original_config_dir;
+      Config_dir_resolver.reset ();
       rm_rf base)
     (fun () -> f config)
 
@@ -93,6 +168,44 @@ let test_predicate_total_on_defaulted_stats () =
     let _ : bool = KR.should_start_supervisor_sweep ~config ~stats in
     ())
 
+let test_due_auto_recoverable_paused_keeper_starts_sweep () =
+  with_temp_masc_dir ~keeper_names:[ "auto-due" ] (fun config ->
+    let now = Unix.time () in
+    write_meta_exn config
+      (make_meta
+         ~paused:true
+         ~auto_resume_after_sec:60.0
+         ~updated_at:(iso_of_unix (now -. 120.0))
+         "auto-due");
+    let stats =
+      KR.{ scanned = 0; started = 0; stale = 0; recovering = 0 }
+    in
+    check bool "paused keeper is not bootable yet" false
+      (List.mem "auto-due" (KR.bootable_keeper_names config));
+    check (list string) "paused keeper is auto-recoverable"
+      [ "auto-due" ]
+      (KR.auto_recoverable_paused_keeper_names ~now config);
+    check bool "due auto-recoverable pause starts supervisor sweep" true
+      (KR.should_start_supervisor_sweep ~config ~stats))
+
+let test_operator_paused_only_does_not_start_sweep () =
+  with_temp_masc_dir ~keeper_names:[ "manual-only" ] (fun config ->
+    let now = Unix.time () in
+    write_meta_exn config
+      (make_meta
+         ~paused:true
+         ~updated_at:(iso_of_unix (now -. 7200.0))
+         "manual-only");
+    let stats =
+      KR.{ scanned = 0; started = 0; stale = 0; recovering = 0 }
+    in
+    check bool "operator-paused keeper is not bootable" false
+      (List.mem "manual-only" (KR.bootable_keeper_names config));
+    check (list string) "operator pause is not auto-recoverable" []
+      (KR.auto_recoverable_paused_keeper_names ~now config);
+    check bool "operator pause alone does not start sweep" false
+      (KR.should_start_supervisor_sweep ~config ~stats))
+
 let () =
   run "supervisor_start_predicate_10125" [
     "predicate", [
@@ -102,5 +215,9 @@ let () =
         test_started_gt_zero_starts_sweep_without_enabled;
       test_case "predicate is total on defaulted stats (no raise)" `Quick
         test_predicate_total_on_defaulted_stats;
+      test_case "due auto-recoverable paused keeper starts sweep" `Quick
+        test_due_auto_recoverable_paused_keeper_starts_sweep;
+      test_case "operator-paused keeper alone does not start sweep" `Quick
+        test_operator_paused_only_does_not_start_sweep;
     ];
   ]


### PR DESCRIPTION
## Summary

- Starts the keeper supervisor sweep when the only configured keepers are durable paused keepers whose supervisor-owned auto-resume timer is already due.
- Factors the auto-resume due predicate into `Keeper_supervisor_types.paused_meta_auto_resume_due`.
- Keeps intentional/operator pauses excluded: `auto_resume_after_sec = None` remains non-recoverable and does not make the supervisor start.
- Strengthens supervisor tests so auto-resumed keepers re-enter the bootable/reconcile path, while operator-paused keepers remain out.

## Context

This continues #15961 after #15998. PR #15998 made the stopped-fleet contract visible in `/health` and the dashboard. This PR addresses the next failure mode: on cold start, `should_start_supervisor_sweep` previously depended on `bootable_keeper_names`. If every configured keeper was paused, `bootable_keeper_names` was empty, so the sweep that would clear due auto-pauses might never start.

## Verification

- `git diff --check origin/main...HEAD`
- `ocamlformat --check lib/keeper/keeper_runtime.ml lib/keeper/keeper_runtime.mli lib/keeper/keeper_supervisor.ml lib/keeper/keeper_supervisor_types.ml lib/keeper/keeper_supervisor_types.mli test/test_keeper_supervisor.ml test/test_supervisor_start_predicate.ml`
- `scripts/ci/check-determinism-contract.sh`

Focused local Dune build was attempted:

- `scripts/dune-local.sh build test/test_supervisor_start_predicate.exe test/test_keeper_supervisor.exe`

It did not reach these test targets because current local `origin/main` compilation stops in untouched files:

- `lib/opentelemetry_client_cohttp_eio.ml:169`: `Eio.Cancel.check ();` expected `Eio__core.Cancel.t`
- `lib/voice/voice_bridge.ml:486`: same `Eio.Cancel.check ();` type error

## Follow-up

Issue #15961 should remain open until CI verifies this PR and runtime evidence confirms durable auto-pauses converge without touching intentional operator pauses.
