### PR TITLE
fix(keeper): escalate stay-silent loops

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -838,6 +838,7 @@ let run_keepalive_unified_turn
               | Board_signal -> "board_signal"
               | Bootstrap -> "bootstrap"
               | Alive_but_stuck_recovery -> "alive_but_stuck_recovery"
+              | Stay_silent_recovery -> "stay_silent_recovery"
               | Unsupported _ -> "unsupported"
             in
             Prometheus.inc_counter
@@ -868,6 +869,13 @@ let run_keepalive_unified_turn
             | Alive_but_stuck_recovery ->
               Log.Keeper.info
                 "turn entry: alive-but-stuck recovery stimulus consumed post_id=%s \
+                 (keeper=%s)"
+                stim.post_id
+                meta_after_triage.name;
+              []
+            | Stay_silent_recovery ->
+              Log.Keeper.warn
+                "turn entry: stay-silent recovery stimulus consumed post_id=%s \
                  (keeper=%s)"
                 stim.post_id
                 meta_after_triage.name;

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -874,7 +874,7 @@ let run_keepalive_unified_turn
                 meta_after_triage.name;
               []
             | Stay_silent_recovery ->
-              Log.Keeper.warn
+              Log.Keeper.info
                 "turn entry: stay-silent recovery stimulus consumed post_id=%s \
                  (keeper=%s)"
                 stim.post_id

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -394,6 +394,28 @@ let record_semaphore_wait_observation
     ~reasons:(semaphore_wait_observation_reasons ?phase_label ~kind ~channel ())
 ;;
 
+let record_recovery_stimulus_turn_started
+      ~(ctx : _ context)
+      ~keeper_name
+      (stimulus : Keeper_event_queue.stimulus)
+  =
+  try
+    Keeper_reaction_ledger.record_event_queue_reaction
+      ~base_path:ctx.config.base_path
+      ~keeper_name
+      ~reaction_kind:Keeper_reaction_ledger.Turn_started
+      stimulus
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Keeper.error
+      "turn entry: failed to persist recovery stimulus reaction post_id=%s \
+       (keeper=%s): %s"
+      stimulus.post_id
+      keeper_name
+      (Printexc.to_string exn)
+;;
+
 type cascade_backpressure_decision =
   | Cascade_admitted
   | Cascade_backpressured of {
@@ -872,6 +894,10 @@ let run_keepalive_unified_turn
                  (keeper=%s)"
                 stim.post_id
                 meta_after_triage.name;
+              record_recovery_stimulus_turn_started
+                ~ctx
+                ~keeper_name:meta_after_triage.name
+                stim;
               []
             | Stay_silent_recovery ->
               Log.Keeper.info
@@ -879,6 +905,10 @@ let run_keepalive_unified_turn
                  (keeper=%s)"
                 stim.post_id
                 meta_after_triage.name;
+              record_recovery_stimulus_turn_started
+                ~ctx
+                ~keeper_name:meta_after_triage.name
+                stim;
               []
             | Unsupported prefix ->
               Prometheus.inc_counter

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -99,6 +99,7 @@ type blocker_class =
   | Turn_timeout
   | Completion_contract_violation
   | No_tool_capable_provider
+  | Stay_silent_loop
   | Fiber_unresolved
     (** 2026-05-05: turn fiber finished without invoking [resolve_done]
         (cancelled mid-turn, raised an exception not handled by the
@@ -143,6 +144,7 @@ let blocker_class_to_string = function
   | Turn_timeout -> "turn_timeout"
   | Completion_contract_violation -> "completion_contract_violation"
   | No_tool_capable_provider -> "no_tool_capable_provider"
+  | Stay_silent_loop -> "stay_silent_loop"
   | Fiber_unresolved -> "fiber_unresolved"
   | Stale_turn_timeout -> "stale_turn_timeout"
   | Stale_fleet_batch -> "stale_fleet_batch"
@@ -168,6 +170,7 @@ let blocker_class_of_serialized_string = function
   | "turn_timeout" -> Some Turn_timeout
   | "completion_contract_violation" -> Some Completion_contract_violation
   | "no_tool_capable_provider" -> Some No_tool_capable_provider
+  | "stay_silent_loop" -> Some Stay_silent_loop
   | "fiber_unresolved" -> Some Fiber_unresolved
   | "stale_turn_timeout" -> Some Stale_turn_timeout
   | "stale_fleet_batch" -> Some Stale_fleet_batch

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -151,6 +151,7 @@ type blocker_class =
   | Turn_timeout
   | Completion_contract_violation
   | No_tool_capable_provider
+  | Stay_silent_loop
   | Fiber_unresolved
   | Stale_turn_timeout
   | Stale_fleet_batch

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -7,6 +7,7 @@ type stimulus_kind =
   | Board_signal
   | Bootstrap
   | Alive_but_stuck_recovery
+  | Stay_silent_recovery
   | Unknown of string
 
 type reaction_kind =
@@ -15,6 +16,7 @@ type reaction_kind =
   | Terminal_reason
   | Cursor_ack
   | Operator_escalation
+  | Supervisor_recovery_requested
   | Unknown_reaction of string
 
 let schema = "keeper.reaction_ledger.v1"
@@ -23,6 +25,7 @@ let stimulus_kind_to_string = function
   | Board_signal -> "board_signal"
   | Bootstrap -> "bootstrap"
   | Alive_but_stuck_recovery -> "alive_but_stuck_recovery"
+  | Stay_silent_recovery -> "stay_silent_recovery"
   | Unknown value -> value
 ;;
 
@@ -32,6 +35,7 @@ let reaction_kind_to_string = function
   | Terminal_reason -> "terminal_reason"
   | Cursor_ack -> "cursor_ack"
   | Operator_escalation -> "operator_escalation"
+  | Supervisor_recovery_requested -> "supervisor_recovery_requested"
   | Unknown_reaction value -> value
 ;;
 
@@ -42,13 +46,23 @@ let option_json f = function
 
 let list_json values = `List (List.map (fun value -> `String value) values)
 
-let payload_field name payload =
+let payload_json payload =
   try
-    match Yojson.Safe.from_string payload with
-    | `Assoc fields -> List.assoc_opt name fields
-    | _ -> None
+    Ok (Yojson.Safe.from_string payload)
   with
-  | Yojson.Json_error _ -> None
+  | Yojson.Json_error msg -> Error msg
+;;
+
+let payload_field name payload =
+  match payload_json payload with
+  | Ok (`Assoc fields) -> List.assoc_opt name fields
+  | Ok _ | Error _ -> None
+;;
+
+let payload_parse_error payload =
+  match payload_json payload with
+  | Ok _ -> None
+  | Error msg -> Some msg
 ;;
 
 let payload_float_field name payload =
@@ -73,6 +87,7 @@ let stimulus_kind_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
   | Board_signal -> Board_signal
   | Bootstrap -> Bootstrap
   | Alive_but_stuck_recovery -> Alive_but_stuck_recovery
+  | Stay_silent_recovery -> Stay_silent_recovery
   | Unsupported prefix -> Unknown prefix
 ;;
 
@@ -131,7 +146,13 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
   let board_updated_at =
     match kind with
     | Board_signal -> payload_float_field "updated_at_unix" stimulus.payload
-    | Bootstrap | Alive_but_stuck_recovery | Unknown _ -> None
+    | Bootstrap | Alive_but_stuck_recovery | Stay_silent_recovery | Unknown _ -> None
+  in
+  let parse_error =
+    match kind with
+    | Board_signal | Alive_but_stuck_recovery | Stay_silent_recovery ->
+      payload_parse_error stimulus.payload
+    | Bootstrap | Unknown _ -> None
   in
   `Assoc
     (base_fields
@@ -148,6 +169,7 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
              ; "urgency", `String (urgency_to_string stimulus.urgency)
              ; "arrived_at_unix", `Float stimulus.arrived_at
              ; "board_updated_at_unix", option_json (fun value -> `Float value) board_updated_at
+             ; "payload_parse_error", option_json (fun value -> `String value) parse_error
              ; "payload_preview", `String (payload_preview stimulus.payload)
              ] )
        ])
@@ -403,6 +425,9 @@ let summarize_rows ~keeper_name ~limit rows =
   let execution_receipt_count = ref 0 in
   let terminal_reason_count = ref 0 in
   let operator_escalation_count = ref 0 in
+  let supervisor_recovery_requested_count = ref 0 in
+  let unsupported_stimulus_count = ref 0 in
+  let payload_parse_error_count = ref 0 in
   let unknown_reaction_count = ref 0 in
   let latest_recorded_at = ref None in
   let latest_stimulus_id = ref None in
@@ -471,8 +496,24 @@ let summarize_rows ~keeper_name ~limit rows =
     | Some "execution_receipt" -> incr execution_receipt_count
     | Some "terminal_reason" -> incr terminal_reason_count
     | Some "operator_escalation" -> incr operator_escalation_count
+    | Some "supervisor_recovery_requested" -> incr supervisor_recovery_requested_count
     | Some _ -> incr unknown_reaction_count
     | None -> incr unknown_reaction_count
+  in
+  let note_stimulus_kind = function
+    | Some "board_signal"
+    | Some "bootstrap"
+    | Some "alive_but_stuck_recovery"
+    | Some "stay_silent_recovery" -> ()
+    | Some _ | None -> incr unsupported_stimulus_count
+  in
+  let note_payload_parse_error row =
+    match assoc_field "stimulus" row with
+    | Some stimulus_json ->
+      (match assoc_field "payload_parse_error" stimulus_json with
+       | Some (`String _) -> incr payload_parse_error_count
+       | _ -> ())
+    | None -> ()
   in
   List.iter
     (fun row ->
@@ -484,6 +525,8 @@ let summarize_rows ~keeper_name ~limit rows =
       match string_field "record_kind" row, stimulus_id with
       | Some "stimulus", Some id ->
         incr stimulus_count;
+        note_stimulus_kind (nested_string_field "stimulus" "kind" row);
+        note_payload_parse_error row;
         remember_stimulus id;
         remember_board_stimulus row id
       | Some "reaction", Some id ->
@@ -525,16 +568,22 @@ let summarize_rows ~keeper_name ~limit rows =
       | Some true | None -> false)
   in
   let pending_stimulus_count = List.length pending_stimulus_ids in
+  let degraded_signal_count =
+    pending_stimulus_count
+    + !unsupported_stimulus_count
+    + !payload_parse_error_count
+    + !unknown_reaction_count
+  in
   let status =
     if row_count = 0 then "empty"
-    else if pending_stimulus_count = 0 then "ok"
+    else if degraded_signal_count = 0 then "ok"
     else "degraded"
   in
   `Assoc
     [ "schema", `String summary_schema
     ; "keeper_name", `String keeper_name
     ; "status", `String status
-    ; "operator_action_required", `Bool (pending_stimulus_count > 0)
+    ; "operator_action_required", `Bool (degraded_signal_count > 0)
     ; "scanned_row_limit", `Int limit
     ; "row_count", `Int row_count
     ; "stimulus_count", `Int !stimulus_count
@@ -544,6 +593,9 @@ let summarize_rows ~keeper_name ~limit rows =
     ; "execution_receipt_count", `Int !execution_receipt_count
     ; "terminal_reason_count", `Int !terminal_reason_count
     ; "operator_escalation_count", `Int !operator_escalation_count
+    ; "supervisor_recovery_requested_count", `Int !supervisor_recovery_requested_count
+    ; "unsupported_stimulus_count", `Int !unsupported_stimulus_count
+    ; "payload_parse_error_count", `Int !payload_parse_error_count
     ; "unknown_reaction_count", `Int !unknown_reaction_count
     ; "cursor_swept_stimulus_count", `Int !cursor_swept_stimulus_count
     ; "legacy_cursor_swept_stimulus_count", `Int !legacy_cursor_swept_stimulus_count
@@ -574,6 +626,9 @@ let error_summary ~keeper_name ~limit error =
     ; "execution_receipt_count", `Int 0
     ; "terminal_reason_count", `Int 0
     ; "operator_escalation_count", `Int 0
+    ; "supervisor_recovery_requested_count", `Int 0
+    ; "unsupported_stimulus_count", `Int 0
+    ; "payload_parse_error_count", `Int 0
     ; "unknown_reaction_count", `Int 0
     ; "cursor_swept_stimulus_count", `Int 0
     ; "legacy_cursor_swept_stimulus_count", `Int 0
@@ -644,10 +699,18 @@ let fleet_summary_json ~base_path ~keeper_names ~limit_per_keeper =
       summaries
   in
   let pending_count = total_int "pending_stimulus_count" in
+  let unknown_reaction_count = total_int "unknown_reaction_count" in
+  let unsupported_stimulus_count = total_int "unsupported_stimulus_count" in
+  let payload_parse_error_count = total_int "payload_parse_error_count" in
   let row_count = total_int "row_count" in
   let status =
     if read_error_count > 0 then "unknown"
-    else if pending_count > 0 then "degraded"
+    else if
+      pending_count > 0
+      || unknown_reaction_count > 0
+      || unsupported_stimulus_count > 0
+      || payload_parse_error_count > 0
+    then "degraded"
     else if row_count = 0 then "empty"
     else if List.exists (fun summary -> summary_status summary = "degraded") summaries
     then "degraded"
@@ -657,7 +720,12 @@ let fleet_summary_json ~base_path ~keeper_names ~limit_per_keeper =
     [ "schema", `String fleet_summary_schema
     ; "status", `String status
     ; ( "operator_action_required"
-      , `Bool (read_error_count > 0 || pending_count > 0) )
+      , `Bool
+          (read_error_count > 0
+           || pending_count > 0
+           || unknown_reaction_count > 0
+           || unsupported_stimulus_count > 0
+           || payload_parse_error_count > 0) )
     ; "keeper_count", `Int (List.length keeper_names)
     ; "keeper_names", `List (List.map (fun value -> `String value) keeper_names)
     ; "scanned_row_limit_per_keeper", `Int limit_per_keeper
@@ -669,7 +737,10 @@ let fleet_summary_json ~base_path ~keeper_names ~limit_per_keeper =
     ; "execution_receipt_count", `Int (total_int "execution_receipt_count")
     ; "terminal_reason_count", `Int (total_int "terminal_reason_count")
     ; "operator_escalation_count", `Int (total_int "operator_escalation_count")
-    ; "unknown_reaction_count", `Int (total_int "unknown_reaction_count")
+    ; "supervisor_recovery_requested_count", `Int (total_int "supervisor_recovery_requested_count")
+    ; "unsupported_stimulus_count", `Int unsupported_stimulus_count
+    ; "payload_parse_error_count", `Int payload_parse_error_count
+    ; "unknown_reaction_count", `Int unknown_reaction_count
     ; "cursor_swept_stimulus_count", `Int (total_int "cursor_swept_stimulus_count")
     ; ( "legacy_cursor_swept_stimulus_count"
       , `Int (total_int "legacy_cursor_swept_stimulus_count") )

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -14,6 +14,7 @@ type stimulus_kind =
   | Board_signal
   | Bootstrap
   | Alive_but_stuck_recovery
+  | Stay_silent_recovery
   | Unknown of string
 
 type reaction_kind =
@@ -22,6 +23,7 @@ type reaction_kind =
   | Terminal_reason
   | Cursor_ack
   | Operator_escalation
+  | Supervisor_recovery_requested
   | Unknown_reaction of string
 
 val stimulus_kind_to_string : stimulus_kind -> string

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -78,6 +78,7 @@ let blocker_class_indicates_overflow (klass : blocker_class) : bool =
   | Turn_timeout
   | Completion_contract_violation
   | No_tool_capable_provider
+  | Stay_silent_loop
   | Fiber_unresolved
   | Stale_turn_timeout
   | Stale_fleet_batch

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -312,6 +312,7 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
     | Turn_timeout_after_queue_wait
     | Turn_timeout
     | Completion_contract_violation
+    | Stay_silent_loop
     | Fiber_unresolved
     | Stale_turn_timeout
     | Stale_fleet_batch
@@ -342,6 +343,7 @@ let runtime_blocker_surface_of_legacy_string reason cls =
   | Turn_timeout
   | Completion_contract_violation
   | No_tool_capable_provider
+  | Stay_silent_loop
   | Fiber_unresolved
   | Stale_turn_timeout
   | Stale_fleet_batch

--- a/lib/keeper/keeper_stay_silent_loop_detector.ml
+++ b/lib/keeper/keeper_stay_silent_loop_detector.ml
@@ -54,7 +54,7 @@ let record_turn ~keeper_name ~speech_act =
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_stay_silent_loop_detected
           ~labels:[ ("keeper", keeper_name) ] ();
-        Log.Keeper.warn
+        Log.Keeper.error
           "#9926 stay_silent loop detected keeper=%s streak=%d threshold=%d \
            — keeper is returning stay_silent repeatedly. Check preset \
            mismatch (#9926 proposal 1) or scheduler/backlog drift. \

--- a/lib/keeper/keeper_stay_silent_loop_detector.ml
+++ b/lib/keeper/keeper_stay_silent_loop_detector.ml
@@ -5,6 +5,11 @@ let default_threshold = 10
    not in [Sys.getenv_opt]. *)
 let threshold () = default_threshold
 
+type record_outcome =
+  | Normal
+  | Loop_detected of { streak : int; threshold : int }
+  | Loop_reset of { previous_streak : int; was_latched : bool }
+
 (* Per-keeper state: current streak + latched flag so the
    detected-counter only bumps once per loop episode, not on every
    turn while the keeper is stuck. *)
@@ -54,14 +59,18 @@ let record_turn ~keeper_name ~speech_act =
            — keeper is returning stay_silent repeatedly. Check preset \
            mismatch (#9926 proposal 1) or scheduler/backlog drift. \
            Counter will not re-fire until the streak resets via any \
-           non-stay_silent speech act."
-          keeper_name s.streak t
-      end
+          non-stay_silent speech act."
+          keeper_name s.streak t;
+        Loop_detected { streak = s.streak; threshold = t }
+      end else Normal
     end else begin
+      let previous_streak = s.streak in
+      let was_latched = s.detected_latched in
       if s.streak > 0 then
         update_streak_gauge keeper_name 0;
       s.streak <- 0;
-      s.detected_latched <- false
+      s.detected_latched <- false;
+      if previous_streak = 0 then Normal else Loop_reset { previous_streak; was_latched }
     end)
 
 let current_streak ~keeper_name =

--- a/lib/keeper/keeper_stay_silent_loop_detector.mli
+++ b/lib/keeper/keeper_stay_silent_loop_detector.mli
@@ -11,11 +11,12 @@
     closes the **observability** half so runtime can detect the
     loop instead of letting it burn silently in the background.
 
-    Pure in-memory; no file I/O. Single-domain Mutex since the
-    keeper lifecycle is serialised through the after-turn hook.
+    Pure in-memory; no file I/O. The caller owns durable recovery wiring
+    because it has access to keeper meta, registry, and base path.
 
-    Threshold source: env [MASC_STAY_SILENT_LOOP_THRESHOLD] with
-    default 10 (#9926 proposal 2).
+    Threshold source: code constant [10]. The retired
+    [MASC_STAY_SILENT_LOOP_THRESHOLD] env knob is intentionally ignored so
+    runtime behavior cannot drift per process.
 
     Observability contract:
     - [masc_keeper_stay_silent_streak{keeper=X}] gauge carries the
@@ -25,14 +26,20 @@
       threshold. Latched: does not increment again until the
       streak resets to 0.
     - A [Log.Keeper.warn] fires on first crossing, tagged [#9926].
-      Subsequent crossings only bump the metric. *)
+      The return value is [Loop_detected] only for that first crossing so
+      callers can stamp a blocker and enqueue recovery once per episode. *)
+
+type record_outcome =
+  | Normal
+  | Loop_detected of { streak : int; threshold : int }
+  | Loop_reset of { previous_streak : int; was_latched : bool }
 
 (** Update streak for [keeper_name] based on [speech_act] from the
     latest turn. [speech_act] is the string form already emitted by
     {!Masc_mcp.Keeper_social_model_types.speech_act_to_string} —
     we match on the literal ["stay_silent"] rather than the variant
     so this module does not couple to the social-model type. *)
-val record_turn : keeper_name:string -> speech_act:string -> unit
+val record_turn : keeper_name:string -> speech_act:string -> record_outcome
 
 (** Current consecutive stay_silent count for [keeper_name]. *)
 val current_streak : keeper_name:string -> int
@@ -44,7 +51,5 @@ val reset : keeper_name:string -> unit
 (** Reset all per-keeper state. Test-only. *)
 val reset_all_for_test : unit -> unit
 
-(** Threshold from env var [MASC_STAY_SILENT_LOOP_THRESHOLD]
-    (default 10). Re-read on every call; safe for test-time
-    [Unix.putenv]. *)
+(** Runtime threshold. *)
 val threshold : unit -> int

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -177,6 +177,7 @@ type blocker_class = Keeper_meta_contract.blocker_class =
   | Turn_timeout
   | Completion_contract_violation
   | No_tool_capable_provider
+  | Stay_silent_loop
   | Fiber_unresolved
   | Stale_turn_timeout
   | Stale_fleet_batch

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -17,12 +17,107 @@ include Keeper_unified_turn_types
 
 let runtime_lane_label = "runtime"
 
+let stay_silent_recovery_stimulus ~now ~keeper_name ~streak ~threshold =
+  let payload =
+    `Assoc
+      [ "source", `String "stay_silent_recovery"
+      ; "keeper", `String keeper_name
+      ; "streak", `Int streak
+      ; "threshold", `Int threshold
+      ; ( "message"
+        , `String
+            "stay_silent loop threshold crossed; run a recovery cycle instead of \
+             remaining silent" )
+      ]
+    |> Yojson.Safe.to_string
+  in
+  { Keeper_event_queue.post_id = "stay-silent-loop:" ^ keeper_name
+  ; urgency = Keeper_event_queue.Immediate
+  ; arrived_at = now
+  ; payload
+  }
+;;
 
+let mark_stay_silent_loop_detected ~(config : Coord.config) meta ~streak ~threshold =
+  let detail =
+    Printf.sprintf
+      "stay_silent loop detected: streak=%d threshold=%d; recovery stimulus queued"
+      streak
+      threshold
+  in
+  let failure_reason =
+    Keeper_registry.Tool_required_unsatisfied
+      { code = "stay_silent_loop"; detail }
+  in
+  Keeper_registry.set_failure_reason
+    ~base_path:config.base_path
+    meta.name
+    (Some failure_reason);
+  let stimulus =
+    stay_silent_recovery_stimulus
+      ~now:(Time_compat.now ())
+      ~keeper_name:meta.name
+      ~streak
+      ~threshold
+  in
+  Keeper_registry.enqueue_event ~base_path:config.base_path meta.name stimulus;
+  Keeper_registry.wakeup ~base_path:config.base_path meta.name;
+  (try
+     Keeper_reaction_ledger.record_event_queue_stimulus
+       ~base_path:config.base_path
+       ~keeper_name:meta.name
+       stimulus
+   with
+   | Eio.Cancel.Cancelled _ as exn -> raise exn
+   | exn ->
+     Log.Keeper.warn
+       "%s: failed to persist stay-silent recovery stimulus in reaction ledger: %s"
+       meta.name
+       (Printexc.to_string exn));
+  Log.Keeper.warn
+    "%s: stay_silent loop escalated to blocker and recovery stimulus \
+     (streak=%d threshold=%d)"
+    meta.name
+    streak
+    threshold;
+  Keeper_types.map_runtime
+    (fun rt ->
+       { rt with
+         last_blocker =
+           Some
+             (Keeper_meta_contract.blocker_info_of_class
+                ~detail
+                Keeper_types.Stay_silent_loop)
+       })
+    meta
+;;
 
-
-
-
-
+let clear_stay_silent_loop_if_recovered
+      ~(config : Coord.config)
+      meta
+      ~previous_streak
+      ~was_latched
+  =
+  if was_latched then begin
+    match Keeper_registry.get ~base_path:config.base_path meta.name with
+    | Some { Keeper_registry.last_failure_reason =
+               Some (Keeper_registry.Tool_required_unsatisfied { code; _ })
+           ; _
+           }
+      when String.equal code "stay_silent_loop" ->
+      Keeper_registry.set_failure_reason ~base_path:config.base_path meta.name None;
+      Log.Keeper.info
+        "%s: stay_silent loop recovered after non-silent turn \
+         (previous_streak=%d)"
+        meta.name
+        previous_streak
+    | _ -> ()
+  end;
+  match meta.runtime.last_blocker with
+  | Some { Keeper_meta_contract.klass = Keeper_types.Stay_silent_loop; _ } ->
+    Keeper_types.map_runtime (fun rt -> { rt with last_blocker = None }) meta
+  | _ -> meta
+;;
 
 let run_keeper_cycle
       ~(config : Coord.config)
@@ -2301,11 +2396,30 @@ let run_keeper_cycle
                   (* #9926: observe consecutive stay_silent turns to detect the
              masc-improver-style loop that burned 13.3h of LLM time on
              unclaimable backlog. Pure in-memory counter; fires a latched
-             warn + counter metric when the streak crosses
-             MASC_STAY_SILENT_LOOP_THRESHOLD (default 10). *)
-                  Keeper_stay_silent_loop_detector.record_turn
-                    ~keeper_name:updated_meta.Keeper_types.name
-                    ~speech_act:updated_meta.Keeper_types.runtime.last_speech_act;
+             warn + counter metric when the streak crosses the product
+             threshold (default 10). *)
+                  let updated_meta =
+                    match
+                      Keeper_stay_silent_loop_detector.record_turn
+                        ~keeper_name:updated_meta.Keeper_types.name
+                        ~speech_act:updated_meta.Keeper_types.runtime.last_speech_act
+                    with
+                    | Keeper_stay_silent_loop_detector.Normal -> updated_meta
+                    | Keeper_stay_silent_loop_detector.Loop_detected
+                        { streak; threshold } ->
+                      mark_stay_silent_loop_detected
+                        ~config
+                        updated_meta
+                        ~streak
+                        ~threshold
+                    | Keeper_stay_silent_loop_detector.Loop_reset
+                        { previous_streak; was_latched } ->
+                      clear_stay_silent_loop_if_recovered
+                        ~config
+                        updated_meta
+                        ~previous_streak
+                        ~was_latched
+                  in
                   (* #12799: observe consecutive passive-read turns to detect keepers
              stuck issuing only status/read tools without execution progress.
              Derive the dominant progress class from the tool names used this

--- a/lib/keeper_event_queue/keeper_event_queue.ml
+++ b/lib/keeper_event_queue/keeper_event_queue.ml
@@ -75,6 +75,7 @@ type stimulus_class =
   | Board_signal
   | Bootstrap
   | Alive_but_stuck_recovery
+  | Stay_silent_recovery
   | Unsupported of string
 
 let classify (s : stimulus) : stimulus_class =
@@ -87,6 +88,8 @@ let classify (s : stimulus) : stimulus_class =
   if String.equal s.payload "Keeper bootstrap signal" then Bootstrap
   else if has_prefix "{\"source\":\"alive_but_stuck_recovery\"" then
     Alive_but_stuck_recovery
+  else if has_prefix "{\"source\":\"stay_silent_recovery\"" then
+    Stay_silent_recovery
   (* Board signals carry JSON with "source":"board_signal". Lightweight
      prefix check avoids a full Yojson parse in the data layer. *)
   else if has_prefix "{\"source\":\"board_signal\"" then Board_signal

--- a/lib/keeper_event_queue/keeper_event_queue.mli
+++ b/lib/keeper_event_queue/keeper_event_queue.mli
@@ -72,6 +72,8 @@ type stimulus_class =
   | Bootstrap      (** Plain string "Keeper bootstrap signal" *)
   | Alive_but_stuck_recovery
       (** JSON payload with {"source":"alive_but_stuck_recovery", ...} *)
+  | Stay_silent_recovery
+      (** JSON payload with {"source":"stay_silent_recovery", ...} *)
   | Unsupported of string  (** Unrecognized: payload prefix (max 40 chars) for audit *)
 
 val classify : stimulus -> stimulus_class

--- a/reports/keeper-product-readiness-20260517.html
+++ b/reports/keeper-product-readiness-20260517.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Keeper Product Readiness Checkpoint - 2026-05-17</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #17202a;
+      --muted: #59636f;
+      --line: #c9d1d9;
+      --panel: #f7f9fb;
+      --ok: #1f7a4d;
+      --warn: #9a5b00;
+      --bad: #a4312a;
+      --accent: #245c8f;
+    }
+    body {
+      margin: 0;
+      font: 15px/1.5 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--ink);
+      background: white;
+    }
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 32px 24px 48px;
+    }
+    h1, h2, h3 { line-height: 1.2; margin: 0 0 12px; }
+    h1 { font-size: 28px; }
+    h2 { font-size: 20px; margin-top: 28px; padding-top: 20px; border-top: 1px solid var(--line); }
+    h3 { font-size: 16px; margin-top: 18px; }
+    p { margin: 0 0 12px; color: var(--muted); }
+    table { width: 100%; border-collapse: collapse; margin: 12px 0 20px; }
+    th, td { border: 1px solid var(--line); padding: 8px 10px; text-align: left; vertical-align: top; }
+    th { background: var(--panel); color: var(--ink); }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    pre {
+      overflow-x: auto;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 12px;
+      margin: 10px 0 18px;
+      color: #27313b;
+    }
+    .pill { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 12px; font-weight: 650; }
+    .ok { background: #dff3e8; color: var(--ok); }
+    .warn { background: #fff0cf; color: var(--warn); }
+    .bad { background: #f9dedb; color: var(--bad); }
+    .accent { color: var(--accent); font-weight: 650; }
+  </style>
+</head>
+<body>
+<main>
+  <h1>Keeper Product Readiness Checkpoint</h1>
+  <p><span class="accent">Date:</span> 2026-05-17. <span class="accent">Goal:</span> reach a basic product level where keepers do not die silently and repeated silence cannot remain invisible.</p>
+
+  <h2>Product Invariant</h2>
+  <table>
+    <thead>
+      <tr><th>Invariant</th><th>Expected runtime behavior</th><th>Status in this pass</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>No silent death</td>
+        <td>Admission denial, crash, watchdog, and dead phases must produce typed lifecycle, metric, or health/operator signal.</td>
+        <td><span class="pill warn">partially covered</span> Existing supervisor surfaces are strong; open queue still needs PR gate cleanup.</td>
+      </tr>
+      <tr>
+        <td>No repeated silence</td>
+        <td>Repeated <code>stay_silent</code> crosses from observation into blocker + recovery stimulus + operator visibility.</td>
+        <td><span class="pill ok">wired</span> Detector now returns typed outcomes and the turn path enqueues <code>stay_silent_recovery</code>.</td>
+      </tr>
+      <tr>
+        <td>No ledger blind spots</td>
+        <td>Unknown reaction kinds and malformed typed payloads degrade KRL summaries instead of disappearing.</td>
+        <td><span class="pill ok">wired</span> KRL summary now counts unsupported stimuli, unknown reactions, and typed payload parse errors.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Flowcharts</h2>
+  <h3>Keeper death and recovery</h3>
+  <pre>Boot/TOML
+  -> supervise_keepalive
+  -> spawn_slots_decision
+     -> deny: admission_denied + metric + health/operator blocked
+     -> permit: keeper fiber running
+        -> heartbeat / turn / receipt
+        -> crash, watchdog, or unresolved fiber?
+           -> no: continue
+           -> yes: sweep_and_recover
+              -> clearable within budget: relaunch
+              -> not clearable: Dead or Paused with blocker/operator action</pre>
+
+  <h3>Repeated stay_silent</h3>
+  <pre>Turn result
+  -> speech_act
+     -> non-silent: reset streak; clear stay_silent_loop blocker when it was latched
+     -> stay_silent: increment streak + gauge
+        -> below threshold: observe only
+        -> threshold crossed:
+           -> metric + warning
+           -> registry failure_reason = Tool_required_unsatisfied(stay_silent_loop)
+           -> meta blocker_class = stay_silent_loop
+           -> enqueue + wake stay_silent_recovery stimulus
+           -> KRL records typed stimulus</pre>
+
+  <h3>KRL degraded summary</h3>
+  <pre>Reaction ledger rows
+  -> summarize
+     -> pending stimulus: degraded + operator_action_required
+     -> unsupported stimulus kind: degraded + operator_action_required
+     -> malformed typed payload: degraded + operator_action_required
+     -> unknown reaction kind: degraded + operator_action_required
+     -> all stimuli reacted and no degraded rows: ok</pre>
+
+  <h2>Changed Runtime Surfaces</h2>
+  <table>
+    <thead>
+      <tr><th>Surface</th><th>Change</th><th>Operator effect</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>Keeper_stay_silent_loop_detector.record_turn</code></td>
+        <td>Returns <code>Normal</code>, <code>Loop_detected</code>, or <code>Loop_reset</code>.</td>
+        <td>Callers can take durable recovery action once per loop episode.</td>
+      </tr>
+      <tr>
+        <td><code>blocker_class</code></td>
+        <td>Adds <code>stay_silent_loop</code>.</td>
+        <td>Dashboard/runtime surfaces can distinguish silence loops from generic contract failure.</td>
+      </tr>
+      <tr>
+        <td><code>Keeper_event_queue.classify</code></td>
+        <td>Adds <code>Stay_silent_recovery</code> for <code>{"source":"stay_silent_recovery"}</code>.</td>
+        <td>Recovery wakeups are typed, not unsupported queue noise.</td>
+      </tr>
+      <tr>
+        <td><code>Keeper_reaction_ledger.summary_for_keeper</code></td>
+        <td>Counts unsupported stimuli, unknown reactions, and typed payload parse errors as degraded.</td>
+        <td>Malformed or legacy rows require operator attention instead of looking clean.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Verification Commands</h2>
+  <pre>scripts/dune-local.sh build \
+  test/test_stay_silent_loop_detector.exe \
+  test/test_keeper_reaction_ledger.exe \
+  test/test_keeper_event_queue.exe \
+  test/keeper_event_queue/test_keeper_event_queue.exe
+
+./_build/default/test/test_stay_silent_loop_detector.exe
+./_build/default/test/test_keeper_reaction_ledger.exe
+./_build/default/test/test_keeper_event_queue.exe
+./_build/default/test/keeper_event_queue/test_keeper_event_queue.exe
+
+git diff --check</pre>
+</main>
+</body>
+</html>

--- a/test/keeper_event_queue/test_keeper_event_queue.ml
+++ b/test/keeper_event_queue/test_keeper_event_queue.ml
@@ -121,6 +121,15 @@ let test_classify_alive_but_stuck_recovery () =
   | Alive_but_stuck_recovery -> ()
   | _ -> assert false
 
+let test_classify_stay_silent_recovery () =
+  let s =
+    make_stim "stay-silent-loop:k"
+      "{\"source\":\"stay_silent_recovery\",\"keeper\":\"k\",\"streak\":10}"
+  in
+  match classify s with
+  | Stay_silent_recovery -> ()
+  | _ -> assert false
+
 let () =
   test_empty ();
   test_enqueue_dequeue_fifo ();
@@ -132,4 +141,5 @@ let () =
   test_queue_overrides_policy ();
   test_dequeue_only_consumes_enqueued ();
   test_classify_alive_but_stuck_recovery ();
+  test_classify_stay_silent_recovery ();
   print_endline "Keeper_event_queue: all tests passed"

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -14,7 +14,8 @@ let () =
         | Bootstrap -> "Bootstrap"
         | Unsupported s -> "Unsupported("^s^")"
         | Board_signal -> "Board_signal"
-        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery")));
+        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery"
+        | Stay_silent_recovery -> "Stay_silent_recovery")));
 
   let live_comment_payload =
     {|{"source":"board_signal","kind":"comment","post_id":"p2","author":"alice","title":"Long board event","content":"this mirrors the long live payload that used to miss the prefix check","hearth":null,"wake_reason":"scope_message"}|}
@@ -30,7 +31,8 @@ let () =
         | Bootstrap -> "Bootstrap"
         | Unsupported s -> "Unsupported("^s^")"
         | Board_signal -> "Board_signal"
-        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery")));
+        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery"
+        | Stay_silent_recovery -> "Stay_silent_recovery")));
 
   (* --- classify: bootstrap --- *)
   let bootstrap_stim = {
@@ -45,7 +47,8 @@ let () =
         | Board_signal -> "Board_signal"
         | Unsupported s -> "Unsupported("^s^")"
         | Bootstrap -> "Bootstrap"
-        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery")));
+        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery"
+        | Stay_silent_recovery -> "Stay_silent_recovery")));
 
   (* --- classify: unsupported --- *)
   let unknown_stim = {
@@ -58,7 +61,12 @@ let () =
        Alcotest.fail "unsupported prefix should be truncated to 40 chars"
    | other ->
      Alcotest.fail (Printf.sprintf "expected Unsupported, got %s"
-       (match other with Board_signal -> "Board_signal" | Bootstrap -> "Bootstrap" | _ -> "other")));
+       (match other with
+        | Board_signal -> "Board_signal"
+        | Bootstrap -> "Bootstrap"
+        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery"
+        | Stay_silent_recovery -> "Stay_silent_recovery"
+        | Unsupported _ -> "Unsupported")));
 
   (* --- classify: malformed JSON is unsupported --- *)
   let broken_json = {
@@ -79,7 +87,23 @@ let () =
         | Board_signal -> "Board_signal"
         | Bootstrap -> "Bootstrap"
         | Unsupported _ -> "Unsupported"
-        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery")));
+        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery"
+        | Stay_silent_recovery -> "Stay_silent_recovery")));
+
+  let stay_silent_recovery_stim = {
+    post_id = "stay-silent-loop:k"; urgency = Immediate; arrived_at = 0.0;
+    payload = {|{"source":"stay_silent_recovery","keeper":"k","streak":10}|};
+  } in
+  (match classify stay_silent_recovery_stim with
+   | Stay_silent_recovery -> ()
+   | other ->
+     Alcotest.fail (Printf.sprintf "expected Stay_silent_recovery, got %s"
+       (match other with
+        | Board_signal -> "Board_signal"
+        | Bootstrap -> "Bootstrap"
+        | Unsupported s -> "Unsupported("^s^")"
+        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery"
+        | Stay_silent_recovery -> "Stay_silent_recovery")));
 
   (* --- queue operations preserved --- *)
   let q = empty in

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -35,6 +35,25 @@ let board_stimulus ?(post_id = "post-42") ?updated_at () :
   }
 ;;
 
+let stay_silent_recovery_stimulus ?(keeper_name = "silent-keeper") () :
+  Keeper_event_queue.stimulus
+  =
+  let payload =
+    `Assoc
+      [ "source", `String "stay_silent_recovery"
+      ; "keeper", `String keeper_name
+      ; "streak", `Int 10
+      ; "threshold", `Int 10
+      ]
+    |> Yojson.Safe.to_string
+  in
+  { post_id = "stay-silent-loop:" ^ keeper_name
+  ; urgency = Immediate
+  ; arrived_at = 1234.5
+  ; payload
+  }
+;;
+
 let check_member_string label expected key json =
   check string label expected (json |> member key |> to_string)
 ;;
@@ -263,6 +282,76 @@ let test_summary_cursor_ack_respects_post_id_tiebreaker () =
     (complete_summary |> member "pending_stimulus_count" |> to_int)
 ;;
 
+let test_stay_silent_recovery_stimulus_is_typed () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "silent-keeper" in
+  let stimulus = stay_silent_recovery_stimulus ~keeper_name () in
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    stimulus;
+  let row =
+    Keeper_reaction_ledger.read_recent_for_keeper ~base_path ~keeper_name ~limit:1
+    |> latest_row
+  in
+  check_member_string
+    "stay-silent stimulus kind"
+    "stay_silent_recovery"
+    "kind"
+    (row |> member "stimulus");
+  check string "stable stimulus prefix" "stimulus:"
+    (String.sub (row |> member "stimulus_id" |> to_string) 0 9)
+;;
+
+let test_unknown_reaction_degrades_summary () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "unknown-reaction-keeper" in
+  let stimulus = board_stimulus ~post_id:"post-unknown-reaction" () in
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    stimulus;
+  Keeper_reaction_ledger.record_event_queue_reaction
+    ~base_path
+    ~keeper_name
+    ~reaction_kind:(Keeper_reaction_ledger.Unknown_reaction "legacy_custom")
+    stimulus;
+  let summary =
+    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check_member_string "unknown reaction summary status" "degraded" "status" summary;
+  check bool "unknown reaction requires operator action" true
+    (summary |> member "operator_action_required" |> to_bool);
+  check int "unknown reaction counted" 1
+    (summary |> member "unknown_reaction_count" |> to_int);
+  check int "pending cleared by reaction row" 0
+    (summary |> member "pending_stimulus_count" |> to_int)
+;;
+
+let test_malformed_typed_payload_degrades_summary () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "malformed-payload-keeper" in
+  let stimulus =
+    { Keeper_event_queue.post_id = "bad-board"
+    ; urgency = Immediate
+    ; arrived_at = 1234.5
+    ; payload = {|{"source":"board_signal"|}
+    }
+  in
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    stimulus;
+  let summary =
+    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check_member_string "malformed payload summary status" "degraded" "status" summary;
+  check bool "malformed payload requires operator action" true
+    (summary |> member "operator_action_required" |> to_bool);
+  check int "payload parse error counted" 1
+    (summary |> member "payload_parse_error_count" |> to_int)
+;;
+
 let () =
   run
     "keeper_reaction_ledger"
@@ -291,6 +380,18 @@ let () =
             "summary cursor ack respects board post id tiebreaker"
             `Quick
             test_summary_cursor_ack_respects_post_id_tiebreaker
+        ; test_case
+            "stay-silent recovery stimulus is typed"
+            `Quick
+            test_stay_silent_recovery_stimulus_is_typed
+        ; test_case
+            "unknown reaction degrades summary"
+            `Quick
+            test_unknown_reaction_degrades_summary
+        ; test_case
+            "malformed typed payload degrades summary"
+            `Quick
+            test_malformed_typed_payload_degrades_summary
         ] )
     ]
 ;;

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -303,6 +303,37 @@ let test_stay_silent_recovery_stimulus_is_typed () =
     (String.sub (row |> member "stimulus_id" |> to_string) 0 9)
 ;;
 
+let test_stay_silent_recovery_reaction_clears_pending () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "silent-keeper" in
+  let stimulus = stay_silent_recovery_stimulus ~keeper_name () in
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    stimulus;
+  let pending_summary =
+    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check_member_string "pending recovery summary status" "degraded" "status" pending_summary;
+  check int "recovery stimulus pending" 1
+    (pending_summary |> member "pending_stimulus_count" |> to_int);
+  Keeper_reaction_ledger.record_event_queue_reaction
+    ~base_path
+    ~keeper_name
+    ~reaction_kind:Keeper_reaction_ledger.Turn_started
+    stimulus;
+  let reacted_summary =
+    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check_member_string "reacted recovery summary status" "ok" "status" reacted_summary;
+  check bool "reacted recovery needs no operator action" false
+    (reacted_summary |> member "operator_action_required" |> to_bool);
+  check int "recovery stimulus cleared" 0
+    (reacted_summary |> member "pending_stimulus_count" |> to_int);
+  check int "turn-start reaction counted" 1
+    (reacted_summary |> member "turn_started_count" |> to_int)
+;;
+
 let test_unknown_reaction_degrades_summary () =
   with_temp_base @@ fun base_path ->
   let keeper_name = "unknown-reaction-keeper" in
@@ -384,6 +415,10 @@ let () =
             "stay-silent recovery stimulus is typed"
             `Quick
             test_stay_silent_recovery_stimulus_is_typed
+        ; test_case
+            "stay-silent recovery reaction clears pending"
+            `Quick
+            test_stay_silent_recovery_reaction_clears_pending
         ; test_case
             "unknown reaction degrades summary"
             `Quick

--- a/test/test_stay_silent_loop_detector.ml
+++ b/test/test_stay_silent_loop_detector.ml
@@ -5,7 +5,7 @@
    - Streak resets to 0 on any non-stay_silent act
    - Detected-counter only bumps once per loop episode (latched)
    - Reset latches on streak reset
-   - Threshold env var honored
+   - Threshold is the product constant
    - Per-keeper isolation *)
 
 module D = Masc_mcp.Keeper_stay_silent_loop_detector
@@ -21,121 +21,115 @@ let detected_count keeper =
     "masc_keeper_stay_silent_loop_detected_total"
     ~labels:[ ("keeper", keeper) ] ()
 
-let set_threshold n =
-  Unix.putenv "MASC_STAY_SILENT_LOOP_THRESHOLD" (string_of_int n)
+let record_turn = D.record_turn
 
-let clear_threshold () =
-  Unix.putenv "MASC_STAY_SILENT_LOOP_THRESHOLD" ""
+let ignore_outcome = function
+  | D.Normal | D.Loop_detected _ | D.Loop_reset _ -> ()
 
 let test_streak_increments () =
   D.reset_all_for_test ();
   let k = "test-keeper-increments" in
-  D.record_turn ~keeper_name:k ~speech_act:"stay_silent";
+  record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome;
   Alcotest.(check int) "after 1" 1 (D.current_streak ~keeper_name:k);
-  D.record_turn ~keeper_name:k ~speech_act:"stay_silent";
-  D.record_turn ~keeper_name:k ~speech_act:"stay_silent";
+  record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome;
+  record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome;
   Alcotest.(check int) "after 3" 3 (D.current_streak ~keeper_name:k)
 
 let test_any_other_act_resets () =
   D.reset_all_for_test ();
   let k = "test-keeper-resets" in
   for _ = 1 to 5 do
-    D.record_turn ~keeper_name:k ~speech_act:"stay_silent"
+    record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome
   done;
   Alcotest.(check int) "pre-reset" 5 (D.current_streak ~keeper_name:k);
-  D.record_turn ~keeper_name:k ~speech_act:"declare";
+  (match record_turn ~keeper_name:k ~speech_act:"declare" with
+   | D.Loop_reset { previous_streak; was_latched } ->
+     Alcotest.(check int) "reset previous streak" 5 previous_streak;
+     Alcotest.(check bool) "reset was not latched" false was_latched
+   | D.Normal | D.Loop_detected _ -> Alcotest.fail "expected loop reset");
   Alcotest.(check int) "after declare" 0 (D.current_streak ~keeper_name:k);
-  D.record_turn ~keeper_name:k ~speech_act:"stay_silent";
+  record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome;
   Alcotest.(check int) "after new stay_silent" 1
     (D.current_streak ~keeper_name:k)
 
 let test_threshold_crossing_fires_counter () =
   D.reset_all_for_test ();
   let k = "test-keeper-threshold-fires" in
-  set_threshold 3;
   let before = detected_count k in
-  for _ = 1 to 2 do
-    D.record_turn ~keeper_name:k ~speech_act:"stay_silent"
+  for _ = 1 to D.threshold () - 1 do
+    record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome
   done;
-  Alcotest.(check (float 0.0001)) "no fire at 2" before
+  Alcotest.(check (float 0.0001)) "no fire before threshold" before
     (detected_count k);
-  D.record_turn ~keeper_name:k ~speech_act:"stay_silent";
-  Alcotest.(check (float 0.0001)) "fires at 3"
+  (match record_turn ~keeper_name:k ~speech_act:"stay_silent" with
+   | D.Loop_detected { streak; threshold } ->
+     Alcotest.(check int) "loop streak" threshold streak
+   | D.Normal | D.Loop_reset _ -> Alcotest.fail "expected loop detection at threshold");
+  Alcotest.(check (float 0.0001)) "fires at threshold"
     (before +. 1.0) (detected_count k);
-  clear_threshold ()
+  ()
 
 let test_latched_no_repeat_while_streak_grows () =
   D.reset_all_for_test ();
   let k = "test-keeper-latched" in
-  set_threshold 3;
   let before = detected_count k in
-  for _ = 1 to 10 do
-    D.record_turn ~keeper_name:k ~speech_act:"stay_silent"
+  for _ = 1 to D.threshold () + 7 do
+    record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome
   done;
-  Alcotest.(check (float 0.0001)) "latched: exactly +1 across 10 stay_silent"
-    (before +. 1.0) (detected_count k);
-  clear_threshold ()
+  Alcotest.(check (float 0.0001)) "latched: exactly +1 across long stay_silent run"
+    (before +. 1.0) (detected_count k)
 
 let test_latch_releases_on_reset_then_refires () =
   D.reset_all_for_test ();
   let k = "test-keeper-relatch" in
-  set_threshold 3;
   let before = detected_count k in
-  for _ = 1 to 5 do
-    D.record_turn ~keeper_name:k ~speech_act:"stay_silent"
+  for _ = 1 to D.threshold () + 2 do
+    record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome
   done;
   Alcotest.(check (float 0.0001)) "first loop fires once"
     (before +. 1.0) (detected_count k);
   (* Break the loop with a non-stay_silent act. *)
-  D.record_turn ~keeper_name:k ~speech_act:"declare";
+  (match record_turn ~keeper_name:k ~speech_act:"declare" with
+   | D.Loop_reset { was_latched; _ } ->
+     Alcotest.(check bool) "reset releases latched loop" true was_latched
+   | D.Normal | D.Loop_detected _ -> Alcotest.fail "expected latched loop reset");
   (* Start a second loop. *)
-  for _ = 1 to 5 do
-    D.record_turn ~keeper_name:k ~speech_act:"stay_silent"
+  for _ = 1 to D.threshold () + 2 do
+    record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome
   done;
   Alcotest.(check (float 0.0001)) "second loop fires once more"
-    (before +. 2.0) (detected_count k);
-  clear_threshold ()
+    (before +. 2.0) (detected_count k)
 
 let test_per_keeper_isolation () =
   D.reset_all_for_test ();
   let a = "test-keeper-A" in
   let b = "test-keeper-B" in
   for _ = 1 to 4 do
-    D.record_turn ~keeper_name:a ~speech_act:"stay_silent"
+    record_turn ~keeper_name:a ~speech_act:"stay_silent" |> ignore_outcome
   done;
-  D.record_turn ~keeper_name:b ~speech_act:"stay_silent";
+  record_turn ~keeper_name:b ~speech_act:"stay_silent" |> ignore_outcome;
   Alcotest.(check int) "A streak" 4 (D.current_streak ~keeper_name:a);
   Alcotest.(check int) "B streak" 1 (D.current_streak ~keeper_name:b);
   (* Resetting A's streak does not touch B. *)
-  D.record_turn ~keeper_name:a ~speech_act:"declare";
+  record_turn ~keeper_name:a ~speech_act:"declare" |> ignore_outcome;
   Alcotest.(check int) "A reset" 0 (D.current_streak ~keeper_name:a);
   Alcotest.(check int) "B unchanged" 1 (D.current_streak ~keeper_name:b)
 
-let test_threshold_env_default_is_10 () =
-  clear_threshold ();
+let test_threshold_constant_is_10 () =
   Alcotest.(check int) "default threshold" 10 (D.threshold ())
 
-let test_threshold_env_custom () =
-  set_threshold 25;
-  Alcotest.(check int) "custom 25" 25 (D.threshold ());
-  set_threshold 1;
-  Alcotest.(check int) "custom 1" 1 (D.threshold ());
-  clear_threshold ()
-
-let test_threshold_env_invalid_falls_through_to_default () =
+let test_threshold_env_is_ignored () =
+  Unix.putenv "MASC_STAY_SILENT_LOOP_THRESHOLD" "25";
+  Alcotest.(check int) "env ignored" 10 (D.threshold ());
   Unix.putenv "MASC_STAY_SILENT_LOOP_THRESHOLD" "notanumber";
   Alcotest.(check int) "non-numeric → default" 10 (D.threshold ());
-  Unix.putenv "MASC_STAY_SILENT_LOOP_THRESHOLD" "0";
-  Alcotest.(check int) "0 → default (not useful)" 10 (D.threshold ());
-  Unix.putenv "MASC_STAY_SILENT_LOOP_THRESHOLD" "-1";
-  Alcotest.(check int) "-1 → default" 10 (D.threshold ());
-  clear_threshold ()
+  Unix.putenv "MASC_STAY_SILENT_LOOP_THRESHOLD" ""
 
 let test_explicit_reset () =
   D.reset_all_for_test ();
   let k = "test-keeper-explicit-reset" in
   for _ = 1 to 5 do
-    D.record_turn ~keeper_name:k ~speech_act:"stay_silent"
+    record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome
   done;
   Alcotest.(check int) "pre explicit reset" 5
     (D.current_streak ~keeper_name:k);
@@ -169,13 +163,11 @@ let () =
           Alcotest.test_case "A and B independent"
             `Quick (with_eio test_per_keeper_isolation);
         ] );
-      ( "threshold env var",
+      ( "threshold policy",
         [
-          Alcotest.test_case "default 10"
-            `Quick (with_eio test_threshold_env_default_is_10);
-          Alcotest.test_case "custom values"
-            `Quick (with_eio test_threshold_env_custom);
-          Alcotest.test_case "invalid falls to default"
-            `Quick (with_eio test_threshold_env_invalid_falls_through_to_default);
+          Alcotest.test_case "constant 10"
+            `Quick (with_eio test_threshold_constant_is_10);
+          Alcotest.test_case "env var ignored"
+            `Quick (with_eio test_threshold_env_is_ignored);
         ] );
     ]


### PR DESCRIPTION
## Summary
- escalate repeated stay_silent from observability-only into a typed stay_silent_loop blocker, registry failure reason, recovery wakeup, and KRL stimulus
- add stay_silent_recovery event-queue/KRL classification and consume logging
- degrade KRL summaries for unsupported stimuli, malformed typed payloads, and unknown reactions
- archive the keeper product-readiness checkpoint as reports/keeper-product-readiness-20260517.html

## Verification
- git diff --check
- scripts/dune-local.sh build test/test_stay_silent_loop_detector.exe test/test_keeper_reaction_ledger.exe test/test_keeper_event_queue.exe test/keeper_event_queue/test_keeper_event_queue.exe
- ./_build/default/test/test_stay_silent_loop_detector.exe
- ./_build/default/test/test_keeper_reaction_ledger.exe
- ./_build/default/test/test_keeper_event_queue.exe
- ./_build/default/test/keeper_event_queue/test_keeper_event_queue.exe