### PR TITLE
feat(rfc-0126): PR-1 — cascade attempt provenance via keeper-meta slot

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -802,9 +802,10 @@ let run_turn
                  Keeper_llm_bridge.run_with_timeout_and_fallback
                    ~timeout_s:bridge_timeout_s
                    (fun () ->
-                   Keeper_turn_driver.run_named
-                     ~cascade_name:cascade_name_string
-                     ~keeper_name:meta.name
+                           Keeper_turn_driver.run_named
+                             ~cascade_name:cascade_name_string
+                             ~base_path:config.base_path
+                             ~keeper_name:meta.name
                      ?provider_filter
                      ~require_tool_choice_support
                      ~require_tool_support
@@ -1830,28 +1831,28 @@ let run_turn
                       with
                       | Error e -> Error (Agent_sdk.Error.Internal e)
                       | Ok response_text -> finalize_response_text response_text)))))
-	       in
-	       (match turn_result with
-	        | Ok _ -> ()
-	        | Error err ->
-	          let status, exception_kind =
-	            match err with
-	            | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _) ->
-	              "timeout", Some "outer_oas_timeout"
-	            | _ -> "error", Some "outer_oas_error"
-	          in
-	          Keeper_runtime_manifest
-	          .append_unfinished_provider_attempt_finished_best_effort
-	            ~site:"keeper_llm_bridge_terminal"
-	            config
-	            runtime_manifest_context
-	            ~status
-	            ~error:(Agent_sdk.Error.to_string err)
-	            ?exception_kind
-	            ());
-	       (match turn_result with
-	        | Ok _ -> ()
-	        | Error err ->
+               in
+               (match turn_result with
+                | Ok _ -> ()
+                | Error err ->
+                  let status, exception_kind =
+                    match err with
+                    | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _) ->
+                      "timeout", Some "outer_oas_timeout"
+                    | _ -> "error", Some "outer_oas_error"
+                  in
+                  Keeper_runtime_manifest
+                  .append_unfinished_provider_attempt_finished_best_effort
+                    ~site:"keeper_llm_bridge_terminal"
+                    config
+                    runtime_manifest_context
+                    ~status
+                    ~error:(Agent_sdk.Error.to_string err)
+                    ?exception_kind
+                    ());
+               (match turn_result with
+                | Ok _ -> ()
+                | Error err ->
           let oas_turn_count = !receipt_turn_count_ref in
           Keeper_agent_memory_episode.record_failure
             ~config

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -618,11 +618,17 @@ let record_keeper_crashed
   let reason = Keeper_registry.failure_reason_to_string failure_reason in
   if resolve_registry_done entry (`Crashed reason)
   then (
+    let outcome =
+      Keeper_registry.enrich_fiber_unresolved_outcome
+        ~base_path
+        ~keeper_name
+        reason
+    in
     Keeper_registry.set_failure_reason ~base_path keeper_name (Some failure_reason);
     Keeper_registry.dispatch_event_unit
       ~base_path
       keeper_name
-      (Keeper_state_machine.Fiber_terminated { outcome = reason });
+      (Keeper_state_machine.Fiber_terminated { outcome });
     Keeper_registry.record_crash ~base_path keeper_name (Time_compat.now ()) reason;
     Keeper_registry.record_error ~base_path keeper_name reason;
     publish_keeper_phase_lifecycle

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -311,6 +311,8 @@ let cascade_attempt_outcome_of_json = function
      | Some (`String "failure") ->
        (match List.assoc_opt "message" fields with
         | Some (`String message) -> Some (`Failure message)
+        (* DET-OK: legacy attempt rows encoded failure without a message;
+           keep the lossy historical record instead of dropping it. *)
         | _ -> Some (`Failure ""))
      | _ -> None)
   | `String "success" -> Some `Success

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -291,6 +291,80 @@ let blocker_info_of_json (json : Yojson.Safe.t) : blocker_info option =
   | _ -> None
 ;;
 
+type cascade_attempt_record =
+  { provider_id : string
+  ; http_status : int option
+  ; outcome : [ `Success | `Failure of string ]
+  ; timestamp : float
+  }
+
+let cascade_attempt_outcome_to_json = function
+  | `Success -> `Assoc [ "kind", `String "success" ]
+  | `Failure message ->
+    `Assoc [ "kind", `String "failure"; "message", `String message ]
+;;
+
+let cascade_attempt_outcome_of_json = function
+  | `Assoc fields ->
+    (match List.assoc_opt "kind" fields with
+     | Some (`String "success") -> Some `Success
+     | Some (`String "failure") ->
+       (match List.assoc_opt "message" fields with
+        | Some (`String message) -> Some (`Failure message)
+        | _ -> Some (`Failure ""))
+     | _ -> None)
+  | `String "success" -> Some `Success
+  | `String "failure" -> Some (`Failure "")
+  | _ -> None
+;;
+
+let cascade_attempt_record_to_json (record : cascade_attempt_record) : Yojson.Safe.t =
+  `Assoc
+    [ "provider_id", `String record.provider_id
+    ; ( "http_status"
+      , match record.http_status with
+        | Some status -> `Int status
+        | None -> `Null )
+    ; "outcome", cascade_attempt_outcome_to_json record.outcome
+    ; "timestamp", `Float record.timestamp
+    ]
+;;
+
+let cascade_attempt_record_of_json (json : Yojson.Safe.t)
+  : cascade_attempt_record option
+  =
+  match json with
+  | `Null -> None
+  | `Assoc fields ->
+    let provider_id =
+      match List.assoc_opt "provider_id" fields with
+      | Some (`String value) -> Some value
+      | _ -> None
+    in
+    let http_status =
+      match List.assoc_opt "http_status" fields with
+      | Some (`Int status) -> Some status
+      | Some `Null | None -> None
+      | _ -> None
+    in
+    let outcome =
+      match List.assoc_opt "outcome" fields with
+      | Some value -> cascade_attempt_outcome_of_json value
+      | None -> None
+    in
+    let timestamp =
+      match List.assoc_opt "timestamp" fields with
+      | Some (`Float value) -> Some value
+      | Some (`Int value) -> Some (float_of_int value)
+      | _ -> None
+    in
+    (match provider_id, outcome, timestamp with
+     | Some provider_id, Some outcome, Some timestamp ->
+       Some { provider_id; http_status; outcome; timestamp }
+     | _ -> None)
+  | _ -> None
+;;
+
 type usage_metrics =
   { total_turns : int
   ; total_input_tokens : int
@@ -327,6 +401,7 @@ type agent_runtime_state =
   ; last_active_desire : string
   ; last_current_intention : string
   ; last_blocker : blocker_info option
+  ; last_cascade_attempt : cascade_attempt_record option
   ; last_need : string
   }
 

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -229,6 +229,24 @@ val blocker_info_of_json : Yojson.Safe.t -> blocker_info option
     Returns [None] for [`Null] or any value whose [klass] field is
     absent / not recognisable. *)
 
+(** {1 Cascade attempt provenance} *)
+
+type cascade_attempt_record = {
+  provider_id : string;
+  http_status : int option;
+  outcome : [ `Success | `Failure of string ];
+  timestamp : float;
+}
+(** Last observed provider attempt for a keeper-managed cascade turn.
+    Persisted in [agent_runtime_state] so supervisor-only terminal
+    outcomes can still surface provider/HTTP context. *)
+
+val cascade_attempt_record_to_json :
+  cascade_attempt_record -> Yojson.Safe.t
+
+val cascade_attempt_record_of_json :
+  Yojson.Safe.t -> cascade_attempt_record option
+
 (** {1 Agent runtime state record} *)
 
 type agent_runtime_state = {
@@ -253,6 +271,7 @@ type agent_runtime_state = {
   last_active_desire : string;
   last_current_intention : string;
   last_blocker : blocker_info option;
+  last_cascade_attempt : cascade_attempt_record option;
   last_need : string;
 }
 

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -121,11 +121,15 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "last_social_transition_reason", `String rt.last_social_transition_reason
     ; "last_active_desire", `String rt.last_active_desire
     ; "last_current_intention", `String rt.last_current_intention
-    ; ( "last_blocker"
-      , match rt.last_blocker with
-        | Some info -> blocker_info_to_json info
-        | None -> `Null )
-    ; "last_need", `String rt.last_need
+	    ; ( "last_blocker"
+	      , match rt.last_blocker with
+	        | Some info -> blocker_info_to_json info
+	        | None -> `Null )
+	    ; ( "last_cascade_attempt"
+	      , match rt.last_cascade_attempt with
+	        | Some record -> cascade_attempt_record_to_json record
+	        | None -> `Null )
+	    ; "last_need", `String rt.last_need
     ; "paused", `Bool m.paused
     ; "auto_resume_after_sec", Json_util.float_opt_to_json m.auto_resume_after_sec
     ; "autoboot_enabled", `Bool m.autoboot_enabled
@@ -241,9 +245,10 @@ let fallback_canonical_keeper_meta_key_names =
   ; "last_speech_act"
   ; "last_social_transition_reason"
   ; "last_active_desire"
-  ; "last_current_intention"
-  ; "last_blocker"
-  ; "last_need"
+	  ; "last_current_intention"
+	  ; "last_blocker"
+	  ; "last_cascade_attempt"
+	  ; "last_need"
   ; "paused"
   ; "auto_resume_after_sec"
   ; "autoboot_enabled"

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -533,9 +533,17 @@ let parse_keeper_state
        | Some klass -> Some { klass; detail }
        | None -> None)
     | _ -> None
-  in
-  let last_need = cap_loaded (Safe_ops.json_string ~default:"" "last_need" json) in
-  let ps_paused = Safe_ops.json_bool ~default:false "paused" json in
+	  in
+	  let last_need = cap_loaded (Safe_ops.json_string ~default:"" "last_need" json) in
+	  let last_cascade_attempt =
+	    match json with
+	    | `Assoc fields ->
+	      (match List.assoc_opt "last_cascade_attempt" fields with
+	       | Some raw -> cascade_attempt_record_of_json raw
+	       | None -> None)
+	    | _ -> None
+	  in
+	  let ps_paused = Safe_ops.json_bool ~default:false "paused" json in
   let ps_auto_resume_after_sec = Safe_ops.json_float_opt "auto_resume_after_sec" json in
   let ps_autoboot_enabled = Safe_ops.json_bool ~default:true "autoboot_enabled" json in
   let ps_current_task_id =
@@ -576,10 +584,11 @@ let parse_keeper_state
       ; last_speech_act
       ; last_social_transition_reason
       ; last_active_desire
-      ; last_current_intention
-      ; last_blocker
-      ; last_need
-      }
+	      ; last_current_intention
+	      ; last_blocker
+	      ; last_cascade_attempt
+	      ; last_need
+	      }
   }
 ;;
 

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -440,6 +440,84 @@ let update_meta ~base_path name meta =
   update_entry ~base_path name (fun e -> { e with meta })
 ;;
 
+let cascade_attempt_merge ~(latest : keeper_meta) ~(caller : keeper_meta) =
+  { latest with
+    meta_version = latest.meta_version
+  ; runtime =
+      { latest.runtime with
+        last_cascade_attempt = caller.runtime.last_cascade_attempt
+      }
+  }
+;;
+
+let meta_for_cascade_attempt ~base_path ~keeper_name =
+  let config = Coord.default_config base_path in
+  match read_meta config keeper_name with
+  | Ok (Some meta) -> Some (config, meta)
+  | Ok None | Error _ ->
+    (match get ~base_path keeper_name with
+     | Some entry -> Some (config, entry.meta)
+     | None -> None)
+;;
+
+let record_cascade_attempt ~base_path ~keeper_name attempt =
+  try
+    let keeper_name = String.trim keeper_name in
+    if String.equal keeper_name ""
+    then ()
+    else
+      match meta_for_cascade_attempt ~base_path ~keeper_name with
+      | None -> ()
+      | Some (config, meta) ->
+        let caller =
+          { meta with
+            runtime = { meta.runtime with last_cascade_attempt = Some attempt }
+          }
+        in
+        ignore
+          (write_meta_with_merge
+             ~merge:cascade_attempt_merge
+             config
+             caller
+            : (unit, string) result)
+  with
+  | _ -> ()
+;;
+
+let cascade_attempt_suffix (attempt : cascade_attempt_record) =
+  let http =
+    match attempt.http_status with
+    | Some status -> string_of_int status
+    | None -> "none"
+  in
+  Printf.sprintf " provider=%s http=%s" attempt.provider_id http
+;;
+
+let last_cascade_attempt ~base_path ~keeper_name =
+  let keeper_name = String.trim keeper_name in
+  if String.equal keeper_name ""
+  then None
+  else
+    try
+      match meta_for_cascade_attempt ~base_path ~keeper_name with
+      | Some (_config, meta) -> meta.runtime.last_cascade_attempt
+      | None -> None
+    with
+    | _ -> None
+;;
+
+let enrich_fiber_unresolved_outcome ~base_path ~keeper_name outcome =
+  let fiber_unresolved =
+    failure_reason_to_string Fiber_unresolved
+  in
+  if not (String.equal outcome fiber_unresolved)
+  then outcome
+  else
+    match last_cascade_attempt ~base_path ~keeper_name with
+    | None -> outcome
+    | Some attempt -> outcome ^ cascade_attempt_suffix attempt
+;;
+
 let sync_meta_if_registered ~base_path name meta =
   let key = registry_key ~base_path name in
   let rec loop () =

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -506,16 +506,33 @@ let last_cascade_attempt ~base_path ~keeper_name =
     | _ -> None
 ;;
 
+(* Stale provenance threshold: cascade attempts older than this are not
+   attached to a fresh [fiber_unresolved] outcome (P1 review finding).
+   Long enough to span a normal keeper turn cascade chain; short enough
+   that a quiescent slot from a prior turn does not taint a new crash. *)
+let cascade_attempt_freshness_threshold_sec = 120.0
+
 let enrich_fiber_unresolved_outcome ~base_path ~keeper_name outcome =
-  let fiber_unresolved =
-    failure_reason_to_string Fiber_unresolved
-  in
+  let fiber_unresolved = failure_reason_to_string Fiber_unresolved in
   if not (String.equal outcome fiber_unresolved)
   then outcome
   else
     match last_cascade_attempt ~base_path ~keeper_name with
     | None -> outcome
-    | Some attempt -> outcome ^ cascade_attempt_suffix attempt
+    | Some attempt ->
+      (* P2 finding: only failure attempts explain a fiber_unresolved
+         outcome. A persisted success would otherwise inherit
+         [provider=... http=none] into a later failure label. *)
+      (match attempt.outcome with
+       | `Success -> outcome
+       | `Failure _ ->
+         (* P1 finding: gate enrichment on attempt freshness so a stale
+            slot from an earlier turn cannot taint a new crash. NDT-OK:
+            wall-clock comparison against persisted attempt timestamp. *)
+         let age = Unix.gettimeofday () -. attempt.timestamp in
+         if age > cascade_attempt_freshness_threshold_sec
+         then outcome
+         else outcome ^ cascade_attempt_suffix attempt)
 ;;
 
 let sync_meta_if_registered ~base_path name meta =

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -78,6 +78,17 @@ val all : ?base_path:string -> unit -> registry_entry list
 (** Update the meta for a registered keeper. No-op if not found. *)
 val update_meta : base_path:string -> string -> keeper_meta -> unit
 
+(** Persist the last cascade provider attempt in keeper runtime meta.
+    Best-effort: missing keepers or meta write failures are ignored. *)
+val record_cascade_attempt :
+  base_path:string -> keeper_name:string -> cascade_attempt_record -> unit
+
+(** Add [provider=<id> http=<status>] to [fiber_unresolved] outcomes when
+    keeper runtime meta has a recorded cascade attempt. Other outcomes are
+    returned unchanged. *)
+val enrich_fiber_unresolved_outcome :
+  base_path:string -> keeper_name:string -> string -> string
+
 (** Record a restart. Increments restart_count and updates last_restart_ts. *)
 val record_restart : base_path:string -> string -> unit
 

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -317,13 +317,19 @@ let launch_supervised_fiber
                      e.last_failure_reason
                    |> Option.value ~default:"stale_turn_timeout"
                  | None -> "stale_turn_timeout"
-               in
-               (match
-                  Keeper_registry.dispatch_event
-                    ~base_path
-                    meta.name
-                    (Keeper_state_machine.Fiber_terminated { outcome = reason })
-                with
+	               in
+	               let outcome =
+	                 Keeper_registry.enrich_fiber_unresolved_outcome
+	                   ~base_path
+	                   ~keeper_name:meta.name
+	                   reason
+	               in
+	               (match
+	                  Keeper_registry.dispatch_event
+	                    ~base_path
+	                    meta.name
+	                    (Keeper_state_machine.Fiber_terminated { outcome })
+	                with
                 | Ok _ -> ()
                 | Error e ->
                   Prometheus.inc_counter
@@ -396,15 +402,21 @@ let launch_supervised_fiber
                       e.last_failure_reason
                   | None -> Keeper_registry.Exception "fiber_crash (unregistered)")
                | _ -> Keeper_registry.Exception (Printexc.to_string exn)
-             in
-             let reason = Keeper_registry.failure_reason_to_string fr in
-             Keeper_registry.set_failure_reason ~base_path meta.name (Some fr);
-             (match
-                Keeper_registry.dispatch_event
-                  ~base_path
-                  meta.name
-                  (Keeper_state_machine.Fiber_terminated { outcome = reason })
-              with
+	             in
+	             let reason = Keeper_registry.failure_reason_to_string fr in
+	             let outcome =
+	               Keeper_registry.enrich_fiber_unresolved_outcome
+	                 ~base_path
+	                 ~keeper_name:meta.name
+	                 reason
+	             in
+	             Keeper_registry.set_failure_reason ~base_path meta.name (Some fr);
+	             (match
+	                Keeper_registry.dispatch_event
+	                  ~base_path
+	                  meta.name
+	                  (Keeper_state_machine.Fiber_terminated { outcome })
+	              with
               | Ok _ -> ()
               | Error e ->
                 Prometheus.inc_counter
@@ -463,12 +475,18 @@ let launch_supervised_fiber
                 Keeper_registry.mark_dead ~base_path meta.name ~at:(Time_compat.now ());
                 ignore (resolve_done (`Crashed "shutdown")))
               else (
-                let reason =
-                  Keeper_registry.failure_reason_to_string
-                    Keeper_registry.Fiber_unresolved
-                in
-                Keeper_registry.set_failure_reason
-                  ~base_path
+	                let reason =
+	                  Keeper_registry.failure_reason_to_string
+	                    Keeper_registry.Fiber_unresolved
+	                in
+	                let outcome =
+	                  Keeper_registry.enrich_fiber_unresolved_outcome
+	                    ~base_path
+	                    ~keeper_name:meta.name
+	                    reason
+	                in
+	                Keeper_registry.set_failure_reason
+	                  ~base_path
                   meta.name
                   (Some Keeper_registry.Fiber_unresolved);
                 (* 2026-05-05 fleet-stuck cycle: keeper meta runtime
@@ -525,10 +543,10 @@ let launch_supervised_fiber
                   ~reason
                   ~restart_count:rc;
                 Keeper_registry.record_error ~base_path meta.name reason;
-                Keeper_registry.dispatch_event_unit
-                  ~base_path
-                  meta.name
-                  (Keeper_state_machine.Fiber_terminated { outcome = reason });
+	                Keeper_registry.dispatch_event_unit
+	                  ~base_path
+	                  meta.name
+	                  (Keeper_state_machine.Fiber_terminated { outcome });
                 if resolve_done (`Crashed reason)
                 then
                   publish_phase_lifecycle
@@ -1618,13 +1636,19 @@ let sweep_and_recover (ctx : _ context) =
          "%s: force-released stale slots after watchdog crash: %s"
          entry.name
          summary);
-    if Keeper_registry.try_resolve_done entry (`Crashed msg)
-    then (
-      ignore
-        (Keeper_registry.dispatch_event_and_log
-           ~base_path
-           entry.name
-           (Keeper_state_machine.Fiber_terminated { outcome = msg }));
+	    if Keeper_registry.try_resolve_done entry (`Crashed msg)
+	    then (
+	      let outcome =
+	        Keeper_registry.enrich_fiber_unresolved_outcome
+	          ~base_path
+	          ~keeper_name:entry.name
+	          msg
+	      in
+	      ignore
+	        (Keeper_registry.dispatch_event_and_log
+	           ~base_path
+	           entry.name
+	           (Keeper_state_machine.Fiber_terminated { outcome }));
       let ts = Time_compat.now () in
       Keeper_registry.record_crash ~base_path entry.name ts msg;
       Keeper_registry.record_error ~base_path entry.name msg;

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -162,6 +162,7 @@ let runtime_candidate_label = "runtime"
     @since Phase 2 — MASC-driven cascade FSM *)
 let run_named
     ~cascade_name
+    ?base_path
     ?(keeper_name = "")
     ~goal
     ?provider_filter
@@ -554,15 +555,45 @@ let run_named
       |> append
     | _ -> ()
   in
-  let try_provider ?resume_checkpoint ?per_provider_timeout_s candidate =
-    Keeper_turn_driver_try_provider.run_try_provider
-      try_provider_ctx
-      ?resume_checkpoint
-      ?per_provider_timeout_s
-      candidate
-  in
-  let positive_finite_float = function
-    | value when Float.is_finite value && value > 0.0 -> Some value
+          let try_provider ?resume_checkpoint ?per_provider_timeout_s candidate =
+            Keeper_turn_driver_try_provider.run_try_provider
+              try_provider_ctx
+              ?resume_checkpoint
+              ?per_provider_timeout_s
+              candidate
+          in
+          let record_cascade_attempt candidate ?http_status ~outcome () =
+            match base_path with
+            | None -> ()
+            | Some base_path ->
+              if String.equal (String.trim keeper_name) ""
+              then ()
+              else
+                let record : Keeper_types.cascade_attempt_record =
+                  { provider_id = Cascade_runtime_candidate.provider_label candidate
+                  ; http_status
+                  ; outcome
+                  ; timestamp = Unix.gettimeofday ()
+                  }
+                in
+                Keeper_registry.record_cascade_attempt ~base_path ~keeper_name record
+          in
+          let http_status_of_provider_error = function
+            | Some (Provider_error.ServerError { code; _ }) -> Some code
+            | Some
+                (Provider_error.CapacityExhausted _
+                | Provider_error.RateLimit _
+                | Provider_error.AuthError
+                | Provider_error.InvalidRequest _
+                | Provider_error.CliWrappedHardQuota _
+                | Provider_error.CliWrappedMaxTurns _
+                | Provider_error.CliWrappedResumableSession _
+                | Provider_error.PermissionDenied _
+                | Provider_error.ModelNotFound)
+            | None -> None
+          in
+          let positive_finite_float = function
+            | value when Float.is_finite value && value > 0.0 -> Some value
     | _ -> None
   in
   let health_error_kind label =
@@ -942,11 +973,12 @@ let run_named
             ~capture ()
         in
         let result = { result with cascade_observation = Some observation } in
-        Cascade_legacy_runner.record_cascade ~keeper_name
-          ~cascade_name:error_cascade_name
-          ~outcome:`Success ~observation:(Some observation) ();
-        on_success ~provider_key:(Cascade_runtime_candidate.health_key candidate);
-        Ok result
+                Cascade_legacy_runner.record_cascade ~keeper_name
+                  ~cascade_name:error_cascade_name
+                  ~outcome:`Success ~observation:(Some observation) ();
+                record_cascade_attempt candidate ~outcome:`Success ();
+                on_success ~provider_key:(Cascade_runtime_candidate.health_key candidate);
+                Ok result
       | Ok result ->
         (* Response arrived but failed the cascade's [accept] predicate
            (empty body, schema gate, etc.).  Prior to 0.160.0 this
@@ -973,11 +1005,12 @@ let run_named
                ~capture ()
            in
            let result = { result with cascade_observation = Some observation } in
-           Cascade_legacy_runner.record_cascade ~keeper_name
-             ~cascade_name:error_cascade_name
-             ~outcome:`Success ~observation:(Some observation) ();
-           on_success ~provider_key:(Cascade_runtime_candidate.health_key candidate);
-           Ok result
+                   Cascade_legacy_runner.record_cascade ~keeper_name
+                     ~cascade_name:error_cascade_name
+                     ~outcome:`Success ~observation:(Some observation) ();
+                   record_cascade_attempt candidate ~outcome:`Success ();
+                   on_success ~provider_key:(Cascade_runtime_candidate.health_key candidate);
+                   Ok result
          | Cascade_fsm.Try_next { last_err = new_err } ->
            (* Demoted from WARN to INFO (task-239): cascade will retry the
               next tier.  Tagged [cascade-fallback] so dashboard filters
@@ -1030,11 +1063,12 @@ let run_named
                ~capture ()
            in
            let result = { result with cascade_observation = Some observation } in
-           Cascade_legacy_runner.record_cascade ~keeper_name
-             ~cascade_name:error_cascade_name
-             ~outcome:`Success ~observation:(Some observation) ();
-           on_success ~provider_key:(Cascade_runtime_candidate.health_key candidate);
-           Ok result)
+                   Cascade_legacy_runner.record_cascade ~keeper_name
+                     ~cascade_name:error_cascade_name
+                     ~outcome:`Success ~observation:(Some observation) ();
+                   record_cascade_attempt candidate ~outcome:`Success ();
+                   on_success ~provider_key:(Cascade_runtime_candidate.health_key candidate);
+                   Ok result)
       | Error sdk_err ->
         let sdk_err =
           match
@@ -1053,11 +1087,16 @@ let run_named
            state. *)
         let err_str = Agent_sdk.Error.to_string sdk_err in
         record_candidate_health_error candidate sdk_err;
-        let (_ : Provider_error.t option) =
-          emit_sdk_provider_error_metric ~cascade_name:error_cascade_name
-            ~provider:runtime_candidate_label sdk_err
-        in
-        let _ = err_str in
+                let provider_error =
+                  emit_sdk_provider_error_metric ~cascade_name:error_cascade_name
+                    ~provider:runtime_candidate_label sdk_err
+                in
+                record_cascade_attempt
+                  candidate
+                  ?http_status:(http_status_of_provider_error provider_error)
+                  ~outcome:(`Failure (Agent_sdk.Error.to_string sdk_err))
+                  ();
+                let _ = err_str in
         let cascade_outcome = sdk_error_to_cascade_outcome sdk_err in
         Option.iter
           (fun _ -> record_candidate_error candidate sdk_err)

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -573,7 +573,9 @@ let run_named
                   { provider_id = Cascade_runtime_candidate.provider_label candidate
                   ; http_status
                   ; outcome
-                  ; timestamp = Unix.gettimeofday ()
+                  ; timestamp =
+                      Unix.gettimeofday ()
+                      (* NDT-OK: external provider observation timestamp only. *)
                   }
                 in
                 Keeper_registry.record_cascade_attempt ~base_path ~keeper_name record

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -144,6 +144,7 @@ val apply_stream_idle_timeout_default : float option -> float option
 
 val run_named :
   cascade_name:string ->
+  ?base_path:string ->
   ?keeper_name:string ->
   goal:string ->
   ?provider_filter:string list ->

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -575,11 +575,12 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           noop_turn_count = 0;
           last_speech_act = "";
           last_social_transition_reason = "";
-          last_active_desire = "";
-          last_current_intention = "";
-          last_blocker = None;
-          last_need = "";
-        };
+	          last_active_desire = "";
+	          last_current_intention = "";
+	          last_blocker = None;
+	          last_cascade_attempt = None;
+	          last_need = "";
+	        };
       keeper_id = None;
       oas_env = p.profile_defaults.oas_env;
       meta_version = 0;

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -212,6 +212,19 @@ val blocker_info_of_class : ?detail:string -> blocker_class -> blocker_info
 val blocker_info_to_json : blocker_info -> Yojson.Safe.t
 val blocker_info_of_json : Yojson.Safe.t -> blocker_info option
 
+type cascade_attempt_record = Keeper_meta_contract.cascade_attempt_record = {
+  provider_id : string;
+  http_status : int option;
+  outcome : [ `Success | `Failure of string ];
+  timestamp : float;
+}
+
+val cascade_attempt_record_to_json :
+  cascade_attempt_record -> Yojson.Safe.t
+
+val cascade_attempt_record_of_json :
+  Yojson.Safe.t -> cascade_attempt_record option
+
 type agent_runtime_state = {
   usage: usage_metrics;
   compaction_rt: compaction_runtime;
@@ -234,6 +247,7 @@ type agent_runtime_state = {
   last_active_desire: string;
   last_current_intention: string;
   last_blocker: blocker_info option;
+  last_cascade_attempt: cascade_attempt_record option;
   last_need: string;
 }
 

--- a/test/dune
+++ b/test/dune
@@ -149,6 +149,7 @@
   test_keeper_rollover_gate
   test_keeper_generation_lineage
   test_keeper_deliberation
+  test_cascade_attempt_provenance
   test_keeper_registry
   test_keeper_fd_pressure_fleet
   test_docker_spawn_throttle
@@ -435,6 +436,7 @@
   test_keeper_rollover_gate
   test_keeper_generation_lineage
   test_keeper_deliberation
+  test_cascade_attempt_provenance
   test_keeper_registry
   test_keeper_fd_pressure_fleet
   test_docker_spawn_throttle

--- a/test/test_cascade_attempt_provenance.ml
+++ b/test/test_cascade_attempt_provenance.ml
@@ -1,0 +1,90 @@
+open Alcotest
+
+module KT = Masc_mcp.Keeper_types
+module Registry = Masc_mcp.Keeper_registry
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Array.iter (fun name -> rm_rf (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path)
+    else
+      Unix.unlink path
+
+let temp_base_path label =
+  let base =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-%s-%d-%06x" label (Unix.getpid ()) (Random.bits ()))
+  in
+  if Sys.file_exists base then rm_rf base;
+  Unix.mkdir base 0o755;
+  base
+
+let make_meta name =
+  let json =
+    `Assoc
+      [ "name", `String name
+      ; "agent_name", `String ("agent-" ^ name)
+      ; "trace_id", `String ("trace-test-" ^ name)
+      ; "goal", `String "test goal"
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error err -> fail ("make_meta failed: " ^ err)
+
+let outcome_to_string = function
+  | `Success -> "success"
+  | `Failure message -> "failure:" ^ message
+
+let test_record_cascade_attempt_round_trips_from_meta () =
+  let base_path = temp_base_path "cascade-attempt-provenance" in
+  Fun.protect
+    ~finally:(fun () ->
+      Registry.clear ();
+      rm_rf base_path)
+    (fun () ->
+      Registry.clear ();
+      let config = Masc_mcp.Coord.default_config base_path in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "cascade-attempt-test"));
+      let keeper_name = "provenance-keeper" in
+      (match KT.write_meta ~force:true config (make_meta keeper_name) with
+       | Ok () -> ()
+       | Error err -> fail ("initial write_meta failed: " ^ err));
+      let expected : KT.cascade_attempt_record =
+        { provider_id = "runpod_mtp"
+        ; http_status = Some 502
+        ; outcome = `Failure "GGML_ASSERT(logits!=nullptr)"
+        ; timestamp = 1_768_600_000.25
+        }
+      in
+      Registry.record_cascade_attempt
+        ~base_path:config.base_path
+        ~keeper_name
+        expected;
+      match KT.read_meta config keeper_name with
+      | Error err -> fail ("read_meta failed: " ^ err)
+      | Ok None -> fail "keeper meta missing after cascade attempt write"
+      | Ok (Some meta) ->
+        (match meta.runtime.last_cascade_attempt with
+         | None -> fail "last_cascade_attempt missing"
+         | Some actual ->
+           check string "provider_id" expected.provider_id actual.provider_id;
+           check (option int) "http_status" expected.http_status actual.http_status;
+           check string
+             "outcome"
+             (outcome_to_string expected.outcome)
+             (outcome_to_string actual.outcome);
+           check (float 0.000001) "timestamp" expected.timestamp actual.timestamp))
+
+let () =
+  run
+    "cascade_attempt_provenance"
+    [ ( "keeper-meta"
+      , [ test_case
+            "record_cascade_attempt persists all fields"
+            `Quick
+            test_record_cascade_attempt_round_trips_from_meta
+        ] )
+    ]


### PR DESCRIPTION
RFC PR: #16000
RFC: https://github.com/jeong-sik/masc-mcp/pull/16000

## Summary
- Add typed cascade_attempt_record and agent_runtime_state.last_cascade_attempt keeper-meta slot.
- Persist cascade attempt success/failure provenance from keeper_turn_driver via Keeper_registry.record_cascade_attempt.
- Read the meta slot at Fiber_terminated emission and enrich fiber_unresolved outcomes with provider/http.
- Add round-trip regression coverage for provider=runpod_mtp http=502 provenance.

## Files
15 files changed. Main surfaces: keeper_meta_contract, keeper_meta_json/_parse, keeper_registry, keeper_turn_driver, keeper_supervisor, keeper_keepalive, keeper_types, test/dune, test_cascade_attempt_provenance.

## Verification
- PASS: git diff --check
- PASS: dune clean --root . && dune build --root . @check
- PASS: dune exec --root . test/test_cascade_attempt_provenance.exe
- NOTE: dune build --root . @check clean failed because clean is not a build target; explicit dune clean + @check was used.
- BLOCKED: dune build --root . @runtest failed outside this PR in existing suite/static-source tests (for example test_keeper_bridge, test_pr_i_2e_bootstrap_loops_typed, RFC-0085 source-path sentinels) and ended with a Dune signal-watcher assertion.

## Scope
- PR-1 keeps Fiber_terminated variant unchanged; this is outcome-string enrichment only.
- Fast-fail/reordering, dashboard display, and variant widening remain out of scope.