### PR TITLE
feat(rfc-0128-pr-1a): canonical_url_of_remote + Repo_store reverse lookup

### DIFF
--- a/lib/ide/ide_paths.ml
+++ b/lib/ide/ide_paths.ml
@@ -1,3 +1,139 @@
 let store_subdir = ".masc-ide"
 
 let store_path ~base_dir = Filename.concat base_dir store_subdir
+
+let by_url_subdir = "by-url"
+let orphan_subdir = "_orphan"
+
+let by_url_path ~base_dir ~canonical_url =
+  Filename.concat (Filename.concat (store_path ~base_dir) by_url_subdir) canonical_url
+;;
+
+let orphan_path ~base_dir = Filename.concat (store_path ~base_dir) orphan_subdir
+
+(* RFC-0128 §4.1 — canonical URL slug derivation.
+
+   Accepted shapes:
+     - https://github.com/owner/repo
+     - https://github.com/owner/repo.git
+     - http://host/owner/repo
+     - ssh://git@host/owner/repo.git
+     - git@host:owner/repo.git
+     - git@host:owner/repo
+
+   Output: lowercase host + path joined by '_'. Returns None if input is
+   empty, lacks host or path, or any segment contains characters outside
+   [a-z0-9._-]. The slug is deterministic so the same upstream resolves
+   to the same bucket regardless of which transport the remote was
+   registered with. *)
+
+let starts_with ~prefix s =
+  let n = String.length prefix in
+  String.length s >= n && String.sub s 0 n = prefix
+;;
+
+let strip_prefix ~prefix s =
+  let n = String.length prefix in
+  String.sub s n (String.length s - n)
+;;
+
+let strip_suffix ~suffix s =
+  let ns = String.length s in
+  let nf = String.length suffix in
+  if ns >= nf && String.sub s (ns - nf) nf = suffix
+  then String.sub s 0 (ns - nf)
+  else s
+;;
+
+let split_host_path s =
+  match String.index_opt s '/' with
+  | None -> (s, "")
+  | Some i ->
+    let host = String.sub s 0 i in
+    let path = String.sub s (i + 1) (String.length s - i - 1) in
+    (host, path)
+;;
+
+(* SCP-style "user@host:path" → "host/path". Rewrite only when ':'
+   appears before the first '/' (otherwise ':' is path content). *)
+let normalize_scp_like s =
+  match String.index_opt s '@' with
+  | None -> s
+  | Some at ->
+    let after = String.sub s (at + 1) (String.length s - at - 1) in
+    (match String.index_opt after ':' with
+     | None -> s
+     | Some colon ->
+       (match String.index_opt after '/' with
+        | Some slash when slash < colon -> s
+        | _ ->
+          let host = String.sub after 0 colon in
+          let path = String.sub after (colon + 1) (String.length after - colon - 1) in
+          host ^ "/" ^ path))
+;;
+
+let strip_scheme s =
+  let candidates = [ "https://"; "http://"; "ssh://"; "git://" ] in
+  match List.find_opt (fun p -> starts_with ~prefix:p s) candidates with
+  | Some p -> strip_prefix ~prefix:p s
+  | None -> s
+;;
+
+(* Strip leading "user@" credential when it precedes the host. *)
+let strip_userinfo s =
+  match String.index_opt s '@' with
+  | None -> s
+  | Some at ->
+    (match String.index_opt s '/' with
+     | Some slash when slash < at -> s
+     | _ -> String.sub s (at + 1) (String.length s - at - 1))
+;;
+
+let is_slug_char c =
+  (c >= 'a' && c <= 'z')
+  || (c >= '0' && c <= '9')
+  || c = '_'
+  || c = '-'
+  || c = '.'
+;;
+
+let path_segment_to_slug seg =
+  if seg = "" then None
+  else if String.length seg >= 2 && String.sub seg 0 2 = ".."
+  then None
+  else if String.for_all is_slug_char seg
+  then Some seg
+  else None
+;;
+
+let canonical_url_of_remote raw =
+  let trimmed = String.trim raw in
+  if trimmed = "" then None
+  else
+    let s = String.lowercase_ascii trimmed in
+    let s = normalize_scp_like s in
+    let s = strip_scheme s in
+    let s = strip_userinfo s in
+    let host, path = split_host_path s in
+    if host = "" || path = "" then None
+    else
+      let path = strip_suffix ~suffix:".git" path in
+      let segments =
+        String.split_on_char '/' path |> List.filter (fun seg -> seg <> "")
+      in
+      if segments = [] then None
+      else
+        match path_segment_to_slug host with
+        | None -> None
+        | Some host_slug ->
+          let rec collect acc = function
+            | [] -> Some (List.rev acc)
+            | seg :: rest ->
+              (match path_segment_to_slug seg with
+               | None -> None
+               | Some s -> collect (s :: acc) rest)
+          in
+          (match collect [] segments with
+           | None -> None
+           | Some segs -> Some (String.concat "_" (host_slug :: segs)))
+;;

--- a/lib/ide/ide_paths.mli
+++ b/lib/ide/ide_paths.mli
@@ -5,10 +5,46 @@
     and HTTP query modules.
 
     Replaces the previously scattered [Filename.concat _ ".masc-ide"]
-    literal flagged in RFC-0084 §1.7 (Scattered hardcoded default). *)
+    literal flagged in RFC-0084 §1.7 (Scattered hardcoded default).
+
+    RFC-0128 §4.1, §4.2 extend this module with canonical-URL slug
+    derivation and partitioned store paths ([by-url/<slug>/],
+    [_orphan/]) so keeper writes from a sandbox clone and IDE reads
+    against the user's working tree can join on the same codebase
+    identity. The slug helpers are pure additions in PR-1a and have
+    zero callers until PR-1b/c wire them. *)
 
 val store_subdir : string
 (** The literal subdirectory name [".masc-ide"]. *)
 
 val store_path : base_dir:string -> string
 (** [store_path ~base_dir] returns [base_dir/.masc-ide]. *)
+
+val by_url_path : base_dir:string -> canonical_url:string -> string
+(** [by_url_path ~base_dir ~canonical_url] returns
+    [base_dir/.masc-ide/by-url/<canonical_url>]. The caller is
+    responsible for ensuring [canonical_url] is a slug returned from
+    [canonical_url_of_remote]. *)
+
+val orphan_path : base_dir:string -> string
+(** [orphan_path ~base_dir] returns [base_dir/.masc-ide/_orphan].
+    Records whose canonical URL cannot be resolved land here so silent
+    loss is impossible. *)
+
+val canonical_url_of_remote : string -> string option
+(** [canonical_url_of_remote remote] normalises a git remote string
+    into a host_path slug, e.g.
+    [https://github.com/jeong-sik/masc-mcp(.git)?] and
+    [git@github.com:jeong-sik/masc-mcp(.git)?] both produce
+    [Some "github.com_jeong-sik_masc-mcp"].
+
+    Returns [None] when:
+    - the input is empty
+    - it lacks a host
+    - it lacks a path
+    - any segment contains a character outside [a-z0-9._-]
+    - any segment begins with [..] (path traversal guard)
+
+    The function is total (never raises) and deterministic. The same
+    upstream resolves to the same slug regardless of which transport
+    the remote was registered with. *)

--- a/lib/repo_manager/dune
+++ b/lib/repo_manager/dune
@@ -5,6 +5,7 @@
  (public_name masc_mcp.repo_manager)
  (modules
    repo_manager_types
+   repo_store_lookup
    repo_store
    repo_git
    credential_materializer

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -490,3 +490,71 @@ let register_discovered ~base_path =
   | registered ->
       let* () = save_all ~base_path (existing @ registered) in
       Ok registered
+
+(* RFC-0128 §4.5 — reverse lookups.
+
+   These two helpers return raw [url] / [repository] values; the caller
+   normalises the URL with [Ide_paths.canonical_url_of_remote] when it
+   needs a canonical slug. Splitting normalisation out of the lookup
+   keeps [repo_manager] free of a dependency on [masc_ide]. *)
+
+let find_url_by_id ~base_path id =
+  match find ~base_path id with
+  | Ok repo -> if repo.url = "" then None else Some repo.url
+  | Error _ -> None
+
+(* Strip trailing '/' to make prefix comparison robust. *)
+let strip_trailing_slash s =
+  let n = String.length s in
+  if n > 0 && s.[n - 1] = '/' then String.sub s 0 (n - 1) else s
+
+(* [is_path_prefix ~prefix path]: does [path] sit under [prefix] as a
+   directory ancestor, not merely a string prefix? Requires either
+   [path = prefix] or [path] starts with [prefix ^ "/"] to avoid
+   matching siblings like "/a/repos/masc" vs "/a/repos/masc-mirror". *)
+let is_path_prefix ~prefix path =
+  let prefix = strip_trailing_slash prefix in
+  let plen = String.length prefix in
+  if plen = 0 then false
+  else if String.length path = plen && path = prefix then true
+  else if String.length path > plen
+       && String.sub path 0 plen = prefix
+       && path.[plen] = '/'
+  then true
+  else false
+
+let rel_under_path ~prefix path =
+  let prefix = strip_trailing_slash prefix in
+  let plen = String.length prefix in
+  if String.length path = plen then ""
+  else String.sub path (plen + 1) (String.length path - plen - 1)
+
+let find_repo_by_path_prefix ~base_path abs_path =
+  match load_all ~base_path with
+  | Error _ -> None
+  | Ok repos ->
+    (* Longest-match wins. Two repositories rooted at /a/r and /a/r/sub
+       will both match a path under /a/r/sub/...; choose the one with
+       the longer local_path. *)
+    let candidates =
+      List.filter_map
+        (fun (repo : repository) ->
+          let local = local_path ~base_path repo in
+          if is_path_prefix ~prefix:local abs_path
+          then Some (repo, local, rel_under_path ~prefix:local abs_path)
+          else None)
+        repos
+    in
+    match candidates with
+    | [] -> None
+    | _ ->
+      let (best_repo, _, best_rel) =
+        List.fold_left
+          (fun ((_, best_local, _) as best) ((_, local, _) as candidate) ->
+            if String.length local > String.length best_local
+            then candidate
+            else best)
+          (List.hd candidates)
+          (List.tl candidates)
+      in
+      Some (best_repo, best_rel)

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -491,70 +491,10 @@ let register_discovered ~base_path =
       let* () = save_all ~base_path (existing @ registered) in
       Ok registered
 
-(* RFC-0128 §4.5 — reverse lookups.
+module Lookup = Repo_store_lookup.Make (struct
+  let load_all = load_all
+  let local_path = local_path
+end)
 
-   These two helpers return raw [url] / [repository] values; the caller
-   normalises the URL with [Ide_paths.canonical_url_of_remote] when it
-   needs a canonical slug. Splitting normalisation out of the lookup
-   keeps [repo_manager] free of a dependency on [masc_ide]. *)
-
-let find_url_by_id ~base_path id =
-  match find ~base_path id with
-  | Ok repo -> if repo.url = "" then None else Some repo.url
-  | Error _ -> None
-
-(* Strip trailing '/' to make prefix comparison robust. *)
-let strip_trailing_slash s =
-  let n = String.length s in
-  if n > 0 && s.[n - 1] = '/' then String.sub s 0 (n - 1) else s
-
-(* [is_path_prefix ~prefix path]: does [path] sit under [prefix] as a
-   directory ancestor, not merely a string prefix? Requires either
-   [path = prefix] or [path] starts with [prefix ^ "/"] to avoid
-   matching siblings like "/a/repos/masc" vs "/a/repos/masc-mirror". *)
-let is_path_prefix ~prefix path =
-  let prefix = strip_trailing_slash prefix in
-  let plen = String.length prefix in
-  if plen = 0 then false
-  else if String.length path = plen && path = prefix then true
-  else if String.length path > plen
-       && String.sub path 0 plen = prefix
-       && path.[plen] = '/'
-  then true
-  else false
-
-let rel_under_path ~prefix path =
-  let prefix = strip_trailing_slash prefix in
-  let plen = String.length prefix in
-  if String.length path = plen then ""
-  else String.sub path (plen + 1) (String.length path - plen - 1)
-
-let find_repo_by_path_prefix ~base_path abs_path =
-  match load_all ~base_path with
-  | Error _ -> None
-  | Ok repos ->
-    (* Longest-match wins. Two repositories rooted at /a/r and /a/r/sub
-       will both match a path under /a/r/sub/...; choose the one with
-       the longer local_path. *)
-    let candidates =
-      List.filter_map
-        (fun (repo : repository) ->
-          let local = local_path ~base_path repo in
-          if is_path_prefix ~prefix:local abs_path
-          then Some (repo, local, rel_under_path ~prefix:local abs_path)
-          else None)
-        repos
-    in
-    match candidates with
-    | [] -> None
-    | _ ->
-      let (best_repo, _, best_rel) =
-        List.fold_left
-          (fun ((_, best_local, _) as best) ((_, local, _) as candidate) ->
-            if String.length local > String.length best_local
-            then candidate
-            else best)
-          (List.hd candidates)
-          (List.tl candidates)
-      in
-      Some (best_repo, best_rel)
+let find_url_by_id = Lookup.find_url_by_id
+let find_repo_by_path_prefix = Lookup.find_repo_by_path_prefix

--- a/lib/repo_manager/repo_store.mli
+++ b/lib/repo_manager/repo_store.mli
@@ -62,3 +62,28 @@ val register_discovered : base_path:string -> (repository list, string) result
     This is the Week 8 migration helper: existing users with git
     repositories under their base path can call this once to populate
     [repositories.toml] without manual registration. *)
+
+val find_url_by_id : base_path:string -> repository_id -> string option
+(** RFC-0128 §4.5. [find_url_by_id ~base_path id] returns the raw [url]
+    field for the given repository, or [None] when the repository is
+    not registered or has an empty URL. The caller is expected to feed
+    the URL through [Ide_paths.canonical_url_of_remote] to obtain the
+    slug used by [.masc-ide/by-url/]. Splitting normalisation out of
+    the lookup keeps [repo_manager] free of a dependency on
+    [masc_ide]. *)
+
+val find_repo_by_path_prefix
+  :  base_path:string
+  -> string
+  -> (repository * string) option
+(** RFC-0128 §4.5. [find_repo_by_path_prefix ~base_path abs_path]
+    returns the repository whose resolved {!local_path} is a directory
+    ancestor of [abs_path], along with the repo-relative remainder
+    (empty when [abs_path] equals the repository root).
+
+    Selection rule: longest matching {!local_path} wins, so nested
+    registrations (e.g. parent repo and sub-repo) resolve to the
+    inner-most match. Returns [None] when no repository's local path
+    is an ancestor of [abs_path]. Sibling path collisions are avoided
+    by requiring a directory boundary (path equals prefix, or path
+    starts with [prefix ^ "/"]). *)

--- a/lib/repo_manager/repo_store_lookup.ml
+++ b/lib/repo_manager/repo_store_lookup.ml
@@ -1,0 +1,67 @@
+open Repo_manager_types
+
+module type Store = sig
+  val load_all : base_path:string -> (repository list, string) result
+  val local_path : base_path:string -> repository -> string
+end
+
+let strip_trailing_slash s =
+  let n = String.length s in
+  if n > 0 && s.[n - 1] = '/' then String.sub s 0 (n - 1) else s
+
+let is_path_prefix ~prefix path =
+  let prefix = strip_trailing_slash prefix in
+  let plen = String.length prefix in
+  if plen = 0 then false
+  else if String.length path = plen && String.equal path prefix then true
+  else
+    String.length path > plen
+    && String.equal (String.sub path 0 plen) prefix
+    && Char.equal path.[plen] '/'
+
+let rel_under_path ~prefix path =
+  let prefix = strip_trailing_slash prefix in
+  let plen = String.length prefix in
+  if String.length path = plen then ""
+  else String.sub path (plen + 1) (String.length path - plen - 1)
+
+let longest_local_path = function
+  | [] -> None
+  | first :: rest ->
+      Some
+        (List.fold_left
+           (fun ((_, best_local, _) as best) ((_, local, _) as candidate) ->
+             if String.length local > String.length best_local then candidate
+             else best)
+           first rest)
+
+module Make (Store : Store) = struct
+  let find_url_by_id ~base_path id =
+    match Store.load_all ~base_path with
+    | Error _ -> None
+    | Ok repos -> (
+        match
+          List.find_opt
+            (fun (repo : repository) -> String.equal repo.id id)
+            repos
+        with
+        | Some repo when not (String.equal repo.url "") -> Some repo.url
+        | Some _ | None -> None)
+
+  let find_repo_by_path_prefix ~base_path abs_path =
+    match Store.load_all ~base_path with
+    | Error _ -> None
+    | Ok repos ->
+        let candidates =
+          List.filter_map
+            (fun (repo : repository) ->
+              let local = Store.local_path ~base_path repo in
+              if is_path_prefix ~prefix:local abs_path then
+                Some (repo, local, rel_under_path ~prefix:local abs_path)
+              else None)
+            repos
+        in
+        candidates
+        |> longest_local_path
+        |> Option.map (fun (repo, _, rel) -> (repo, rel))
+end

--- a/test/dune
+++ b/test/dune
@@ -131,6 +131,7 @@
   test_keeper_chat_store
   test_keeper_runtime_trust_snapshot
   test_ide_annotations
+  test_ide_paths
   test_keeper_runtime_manifest
   test_schema_surface_index
   test_keeper_accountability
@@ -416,6 +417,7 @@
   test_keeper_chat_store
   test_keeper_runtime_trust_snapshot
   test_ide_annotations
+  test_ide_paths
   test_keeper_runtime_manifest
   test_schema_surface_index
   test_keeper_accountability

--- a/test/test_ide_paths.ml
+++ b/test/test_ide_paths.ml
@@ -1,0 +1,160 @@
+(** Tests for [Ide_paths] — RFC-0128 §6.1 unit tests.
+
+    Verifies that {!Ide_paths.canonical_url_of_remote} is total,
+    deterministic, and produces the same slug regardless of which
+    transport the remote was registered with. *)
+
+open Alcotest
+
+module Paths = Ide_paths
+
+let check_some_slug ~expected ~input () =
+  match Paths.canonical_url_of_remote input with
+  | Some s -> check string ("slug for " ^ input) expected s
+  | None -> failf "expected Some %s for %s, got None" expected input
+;;
+
+let check_none ~input () =
+  match Paths.canonical_url_of_remote input with
+  | None -> ()
+  | Some s -> failf "expected None for %s, got Some %s" input s
+;;
+
+let test_https_simple () =
+  check_some_slug
+    ~expected:"github.com_jeong-sik_masc-mcp"
+    ~input:"https://github.com/jeong-sik/masc-mcp"
+    ()
+;;
+
+let test_https_dot_git () =
+  check_some_slug
+    ~expected:"github.com_jeong-sik_masc-mcp"
+    ~input:"https://github.com/jeong-sik/masc-mcp.git"
+    ()
+;;
+
+let test_http_scheme () =
+  check_some_slug
+    ~expected:"example.com_owner_repo"
+    ~input:"http://example.com/owner/repo"
+    ()
+;;
+
+let test_ssh_url () =
+  check_some_slug
+    ~expected:"github.com_jeong-sik_masc-mcp"
+    ~input:"ssh://git@github.com/jeong-sik/masc-mcp.git"
+    ()
+;;
+
+let test_scp_form () =
+  check_some_slug
+    ~expected:"github.com_jeong-sik_masc-mcp"
+    ~input:"git@github.com:jeong-sik/masc-mcp.git"
+    ()
+;;
+
+let test_scp_form_no_dot_git () =
+  check_some_slug
+    ~expected:"github.com_jeong-sik_masc-mcp"
+    ~input:"git@github.com:jeong-sik/masc-mcp"
+    ()
+;;
+
+let test_https_uppercase () =
+  (* RFC-0128 §4.1 rule 1: lowercase normalisation precedes parsing. *)
+  check_some_slug
+    ~expected:"github.com_jeong-sik_masc-mcp"
+    ~input:"HTTPS://GitHub.com/Jeong-Sik/MASC-MCP.GIT"
+    ()
+;;
+
+let test_nested_path () =
+  check_some_slug
+    ~expected:"gitlab.example.com_group_subgroup_repo"
+    ~input:"https://gitlab.example.com/group/subgroup/repo"
+    ()
+;;
+
+let test_join_invariant_https_ssh () =
+  (* RFC-0128 §4.1 invariant: same upstream in different transport
+     forms must produce the same slug. Without this property
+     sandbox/working-tree join across keepers cannot work. *)
+  let a = Paths.canonical_url_of_remote "https://github.com/jeong-sik/masc-mcp.git" in
+  let b = Paths.canonical_url_of_remote "git@github.com:jeong-sik/masc-mcp.git" in
+  let c = Paths.canonical_url_of_remote "ssh://git@github.com/jeong-sik/masc-mcp" in
+  check (option string) "https == scp" a b;
+  check (option string) "https == ssh-url" a c
+;;
+
+let test_empty () = check_none ~input:"" ()
+let test_whitespace () = check_none ~input:"   " ()
+let test_host_only () = check_none ~input:"https://github.com" ()
+let test_host_only_no_scheme () = check_none ~input:"github.com" ()
+
+let test_path_with_space () =
+  (* Space is not in [a-z0-9._-]. Reject rather than silently slug-replace. *)
+  check_none ~input:"https://github.com/foo bar/baz" ()
+;;
+
+let test_path_traversal () =
+  check_none ~input:"https://github.com/../etc/passwd" ()
+;;
+
+let test_segment_with_colon () =
+  (* ':' inside a path segment (after scp-form already disambiguated)
+     is not a slug character. *)
+  check_none ~input:"https://example.com/foo:bar/baz" ()
+;;
+
+(* Store path constructors. *)
+
+let test_by_url_path () =
+  let p =
+    Paths.by_url_path
+      ~base_dir:"/tmp/base"
+      ~canonical_url:"github.com_jeong-sik_masc-mcp"
+  in
+  check string
+    "by-url path layout"
+    "/tmp/base/.masc-ide/by-url/github.com_jeong-sik_masc-mcp"
+    p
+;;
+
+let test_orphan_path () =
+  check string
+    "orphan path layout"
+    "/tmp/base/.masc-ide/_orphan"
+    (Paths.orphan_path ~base_dir:"/tmp/base")
+;;
+
+let () =
+  run
+    "ide_paths"
+    [ ( "canonical_url_of_remote — accept"
+      , [ test_case "https simple" `Quick test_https_simple
+        ; test_case "https .git suffix" `Quick test_https_dot_git
+        ; test_case "http scheme" `Quick test_http_scheme
+        ; test_case "ssh:// URL" `Quick test_ssh_url
+        ; test_case "scp form" `Quick test_scp_form
+        ; test_case "scp form no .git" `Quick test_scp_form_no_dot_git
+        ; test_case "uppercase normalised" `Quick test_https_uppercase
+        ; test_case "nested path" `Quick test_nested_path
+        ; test_case "join invariant" `Quick test_join_invariant_https_ssh
+        ] )
+    ; ( "canonical_url_of_remote — reject"
+      , [ test_case "empty" `Quick test_empty
+        ; test_case "whitespace" `Quick test_whitespace
+        ; test_case "host only with scheme" `Quick test_host_only
+        ; test_case "host only no scheme" `Quick test_host_only_no_scheme
+        ; test_case "path with space" `Quick test_path_with_space
+        ; test_case "path traversal" `Quick test_path_traversal
+        ; test_case "segment with colon" `Quick test_segment_with_colon
+        ] )
+    ; ( "store path constructors"
+      , [ test_case "by_url_path" `Quick test_by_url_path
+        ; test_case "orphan_path" `Quick test_orphan_path
+        ] )
+    ]
+;;

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -468,6 +468,108 @@ let test_register_discovered_skips_existing () =
         | Error e -> Alcotest.fail ("second register failed: " ^ e)
         | Ok second ->
             Alcotest.(check int) "second count empty" 0 (List.length second))
+
+(* RFC-0128 §4.5 — reverse lookup tests. *)
+
+let with_two_absolute_repos f =
+  with_temp_base_path (fun base_path ->
+    init_empty_store base_path;
+    let masc_path = Filename.concat base_path "workspace/masc" in
+    let oas_path = Filename.concat base_path "workspace/oas" in
+    Unix.mkdir (Filename.concat base_path "workspace") 0o755;
+    Unix.mkdir masc_path 0o755;
+    Unix.mkdir oas_path 0o755;
+    let masc =
+      { (sample_repo "masc") with
+        url = "https://github.com/jeong-sik/masc-mcp"
+      ; local_path = masc_path
+      }
+    in
+    let oas =
+      { (sample_repo "oas") with
+        url = "https://github.com/jeong-sik/oas"
+      ; local_path = oas_path
+      }
+    in
+    (match Repo_store.save_all ~base_path [ masc; oas ] with
+     | Ok () -> ()
+     | Error e -> Alcotest.fail ("save_all: " ^ e));
+    f ~base_path ~masc_path ~oas_path)
+
+let test_find_url_by_id_known () =
+  with_two_absolute_repos (fun ~base_path ~masc_path:_ ~oas_path:_ ->
+    match Repo_store.find_url_by_id ~base_path "masc" with
+    | Some url ->
+      Alcotest.(check string)
+        "masc url"
+        "https://github.com/jeong-sik/masc-mcp"
+        url
+    | None -> Alcotest.fail "expected Some url for masc")
+
+let test_find_url_by_id_unknown () =
+  with_two_absolute_repos (fun ~base_path ~masc_path:_ ~oas_path:_ ->
+    match Repo_store.find_url_by_id ~base_path "nonexistent" with
+    | None -> ()
+    | Some s -> Alcotest.fail ("expected None for unknown, got: " ^ s))
+
+let test_find_repo_by_path_prefix_match () =
+  with_two_absolute_repos (fun ~base_path ~masc_path ~oas_path:_ ->
+    let abs = Filename.concat masc_path "lib/foo.ml" in
+    match Repo_store.find_repo_by_path_prefix ~base_path abs with
+    | Some (repo, rel) ->
+      Alcotest.(check string) "matched repo id" "masc" repo.id;
+      Alcotest.(check string) "relative path" "lib/foo.ml" rel
+    | None -> Alcotest.fail "expected match under masc_path")
+
+let test_find_repo_by_path_prefix_outside () =
+  with_two_absolute_repos (fun ~base_path ~masc_path:_ ~oas_path:_ ->
+    match Repo_store.find_repo_by_path_prefix ~base_path "/tmp/elsewhere.ml" with
+    | None -> ()
+    | Some (repo, _) ->
+      Alcotest.fail ("unexpected match: " ^ repo.id))
+
+let test_find_repo_by_path_prefix_sibling_not_matched () =
+  (* Sibling-style collision: /tmp/masc and /tmp/masc-mirror must not
+     match each other's paths. Guards against pure-substring prefix. *)
+  with_temp_base_path (fun base_path ->
+    init_empty_store base_path;
+    let workspace = Filename.concat base_path "workspace" in
+    Unix.mkdir workspace 0o755;
+    let masc = Filename.concat workspace "masc" in
+    let mirror = Filename.concat workspace "masc-mirror" in
+    Unix.mkdir masc 0o755;
+    Unix.mkdir mirror 0o755;
+    let r1 =
+      { (sample_repo "masc") with
+        url = "https://github.com/owner/masc"
+      ; local_path = masc
+      }
+    in
+    let r2 =
+      { (sample_repo "mirror") with
+        url = "https://github.com/owner/masc-mirror"
+      ; local_path = mirror
+      }
+    in
+    (match Repo_store.save_all ~base_path [ r1; r2 ] with
+     | Ok () -> ()
+     | Error e -> Alcotest.fail ("save_all: " ^ e));
+    let inside_mirror = Filename.concat mirror "lib/x.ml" in
+    match Repo_store.find_repo_by_path_prefix ~base_path inside_mirror with
+    | Some (repo, rel) ->
+      Alcotest.(check string) "must pick mirror, not masc" "mirror" repo.id;
+      Alcotest.(check string) "rel" "lib/x.ml" rel
+    | None -> Alcotest.fail "expected match under mirror")
+
+let test_find_repo_by_path_prefix_root () =
+  (* abs_path equals the repo's local_path itself → empty rel. *)
+  with_two_absolute_repos (fun ~base_path ~masc_path ~oas_path:_ ->
+    match Repo_store.find_repo_by_path_prefix ~base_path masc_path with
+    | Some (repo, rel) ->
+      Alcotest.(check string) "matched repo id" "masc" repo.id;
+      Alcotest.(check string) "empty rel at root" "" rel
+    | None -> Alcotest.fail "expected match at repo root")
+
 let () =
   Alcotest.run "Repo_store"
     [
@@ -539,5 +641,15 @@ let () =
             test_register_discovered_includes_legacy_root_repo;
           Alcotest.test_case "register_discovered skips existing" `Quick
             test_register_discovered_skips_existing;
+        ] );
+      ( "reverse_lookup (RFC-0128)",
+        [
+          Alcotest.test_case "find_url_by_id known" `Quick test_find_url_by_id_known;
+          Alcotest.test_case "find_url_by_id unknown" `Quick test_find_url_by_id_unknown;
+          Alcotest.test_case "path_prefix match" `Quick test_find_repo_by_path_prefix_match;
+          Alcotest.test_case "path_prefix outside" `Quick test_find_repo_by_path_prefix_outside;
+          Alcotest.test_case "path_prefix sibling-safe" `Quick
+            test_find_repo_by_path_prefix_sibling_not_matched;
+          Alcotest.test_case "path_prefix at repo root" `Quick test_find_repo_by_path_prefix_root;
         ] );
     ]


### PR DESCRIPTION
## RFC-0128 Phase 1 — PR-1a (pure additions)

[RFC-0128](https://github.com/jeong-sik/masc-mcp/pull/16014) Phase 1 의 첫 chunk. **caller 변경 0**. 새 함수의 caller 0 인 채로 머지. PR-1b/c 에서 wire.

> **Renumbered note**: 원래 ledger 에서 0127 할당받았으나, merge 사이 RFC-0127 가 cascade-fast-fail (#16000) 에 점거 → 본 spec 은 #16014 머지 시점에 RFC-0128 로 renumber. branch 이름의 "0127" 은 cosmetic.

## 무엇이 추가됐나

### `lib/ide/ide_paths`

| 함수 | 역할 |
|------|------|
| `canonical_url_of_remote : string -> string option` | https / http / ssh:// / git@host:path → 소문자 host_path slug (`github.com_jeong-sik_masc-mcp`). `.git` 접미사 strip, `user@` credential strip, 경로 segment 가 `[a-z0-9._-]` 외 문자면 `None`, `..` traversal 차단 |
| `by_url_path ~base_dir ~canonical_url` | `<base>/.masc-ide/by-url/<slug>` |
| `orphan_path ~base_dir` | `<base>/.masc-ide/_orphan` |

### `lib/repo_manager/repo_store`

| 함수 | 역할 |
|------|------|
| `find_url_by_id ~base_path id` | repository_id → 등록된 raw `url` (없으면 `None`) |
| `find_repo_by_path_prefix ~base_path abs_path` | 가장 긴 prefix-match repository + repo-relative remainder. trailing-slash check 로 sibling 충돌 차단 (`/a/r/masc` vs `/a/r/masc-mirror` 분리) |

URL 정규화를 lookup 에서 분리 → `repo_manager` 가 `masc_ide` 에 의존 안 함. caller 가 PR-1c 에서 `find_url_by_id` → `canonical_url_of_remote` 로 합성.

## RFC §4.1 invariant

같은 upstream 의 다른 transport 표기가 같은 slug 으로 떨어져야 sandbox/working-tree join 이 작동. test 가 직접 입증:

```ocaml
let test_join_invariant_https_ssh () =
  let a = canonical_url_of_remote "https://github.com/jeong-sik/masc-mcp.git" in
  let b = canonical_url_of_remote "git@github.com:jeong-sik/masc-mcp.git" in
  let c = canonical_url_of_remote "ssh://git@github.com/jeong-sik/masc-mcp" in
  check (option string) "https == scp" a b;
  check (option string) "https == ssh-url" a c
```

## Test 결과

- `test_ide_paths` — 18/18 PASS (accept 9 + reject 7 + store path 2)
- `test_repo_store` — 33/33 PASS (기존 27 + 새 reverse_lookup 6)
- `test_ide_annotations` — 5/5 PASS (회귀 없음)

## Test plan

- [x] `dune build --root . lib/ide/ lib/repo_manager/` PASS
- [x] `test_ide_paths` 18/18 / `test_repo_store` 33/33 / `test_ide_annotations` 5/5 PASS
- [x] `bash ~/me/scripts/pr-rfc-check.sh` (flagged subsystem 미접촉)
- [ ] CI required checks (Draft 상태로 관찰)

## Related

- RFC-0128 #16014 (spec, MERGED 2026-05-18)
- RFC-0084 §1.7 의 연속 — directory name SSOT 화 위에 partitioning 추가

Co-Authored-By: claude-opus-4-7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
