### PR TITLE
fix(planning_eio): guard current_task path against directory corruption

### DIFF
--- a/lib/planning_eio.ml
+++ b/lib/planning_eio.ml
@@ -306,25 +306,93 @@ let set_deliverable (config : Coord.config) ~task_id ~content : (planning_contex
 let current_task_file (config : Coord.config) =
   Filename.concat (Coord_utils.masc_dir config) "current_task"
 
+(* Issue #16010: the planning [current_task] file has been observed as a
+   directory at runtime, after which every keeper claim path fails with
+   [Sys_error "Is a directory"]. Whatever process originally produced the
+   directory shape, this module owns the helper API and must remain
+   resilient: a single corrupt path on disk cannot wedge the entire
+   keeper fleet's claim/set/clear path.
+
+   The recovery contract here is small and local:
+   - reads return [None] (i.e. "no current task") and warn — never raise;
+   - writes quarantine the offending directory to [.masc/_trash/] with an
+     ISO-millisecond suffix so an operator can forensically inspect it,
+     then proceed to write the fresh file;
+   - clears prefer [Sys.rmdir] when the path is an empty directory and
+     fall back to logging a warn for non-empty corruption (the writer
+     path will quarantine it on the next [set_current_task]).
+*)
+
+let is_directory_path path =
+  try Sys.is_directory path with Sys_error _ -> false
+
+let quarantine_dir_under_trash (config : Coord.config) ~path ~op =
+  let trash_dir = Filename.concat (Coord_utils.masc_dir config) "_trash" in
+  ensure_dir trash_dir;
+  let stamp =
+    let t = Time_compat.now () in
+    let ms = int_of_float (t *. 1000.) mod 1000 in
+    let tm = Unix.gmtime t in
+    Printf.sprintf "%04d%02d%02dT%02d%02d%02dZ-%03d"
+      (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+      tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec ms
+  in
+  let dest =
+    Filename.concat trash_dir
+      (Printf.sprintf "current_task.%s" stamp)
+  in
+  try
+    Sys.rename path dest;
+    Log.Keeper.warn
+      "planning_eio.%s: current_task path was a directory; quarantined to %s"
+      op dest;
+    Ok dest
+  with
+  | Sys_error msg ->
+    Log.Keeper.warn
+      "planning_eio.%s: failed to quarantine directory at %s: %s"
+      op path msg;
+    Error msg
+
 (** Get current task_id for session *)
 let get_current_task (config : Coord.config) : string option =
   let path = current_task_file config in
-  if Sys.file_exists path then
-    Some (String.trim (read_file_content path))
-  else
+  if not (Sys.file_exists path) then None
+  else if is_directory_path path then begin
+    Log.Keeper.warn
+      "planning_eio.get_current_task: %s is a directory; treating as cleared"
+      path;
     None
+  end
+  else Some (String.trim (read_file_content path))
 
 (** Set current task_id for session *)
 let set_current_task (config : Coord.config) ~task_id : unit =
   let path = current_task_file config in
   ensure_dir (Filename.dirname path);
+  if is_directory_path path then
+    ignore (quarantine_dir_under_trash config ~path ~op:"set_current_task" : (string, string) result);
   write_file_content path task_id
 
 (** Clear current task *)
 let clear_current_task (config : Coord.config) : unit =
   let path = current_task_file config in
-  if Sys.file_exists path then
-    Sys.remove path
+  if not (Sys.file_exists path) then ()
+  else if is_directory_path path then begin
+    match Sys.readdir path with
+    | [||] ->
+      (try Unix.rmdir path with
+       | Unix.Unix_error _ as e ->
+         Log.Keeper.warn
+           "planning_eio.clear_current_task: rmdir %s failed: %s"
+           path (Printexc.to_string e))
+    | _ ->
+      Log.Keeper.warn
+        "planning_eio.clear_current_task: %s is a non-empty directory; \
+         leaving for set_current_task to quarantine"
+        path
+  end
+  else Sys.remove path
 
 (** Resolve task_id - use provided or fall back to current *)
 let resolve_task_id (config : Coord.config) ~task_id : (string, string) result =

--- a/test/test_planning_eio.ml
+++ b/test/test_planning_eio.ml
@@ -29,6 +29,18 @@ let teardown () =
 let make_config () : Coord.config =
   Coord.default_config !temp_dir
 
+let current_task_path config =
+  Filename.concat (Coord_utils.masc_dir config) "current_task"
+
+let trash_dir config =
+  Filename.concat (Coord_utils.masc_dir config) "_trash"
+
+let has_current_task_quarantine config =
+  if not (Sys.file_exists (trash_dir config)) then false
+  else
+    Sys.readdir (trash_dir config)
+    |> Array.exists (fun name -> String.starts_with ~prefix:"current_task." name)
+
 (* ===== Type Tests ===== *)
 
 let test_create_context () =
@@ -363,6 +375,41 @@ let test_session_context () =
   Planning_eio.clear_current_task config;
   check (option string) "current task cleared" None (Planning_eio.get_current_task config)
 
+let test_current_task_dir_read_is_cleared () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = make_config () in
+  let path = current_task_path config in
+  Unix.mkdir path 0o755;
+  check (option string) "directory current_task reads as none" None
+    (Planning_eio.get_current_task config);
+  check bool "directory remains for write-path quarantine" true
+    (Sys.file_exists path && Sys.is_directory path);
+  rm_rf path
+
+let test_set_current_task_quarantines_dir () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = make_config () in
+  let path = current_task_path config in
+  Unix.mkdir path 0o755;
+  Fs_compat.save_file (Filename.concat path "forensics.txt") "kept";
+  Planning_eio.set_current_task config ~task_id:"recovered-task";
+  check (option string) "recovered current task" (Some "recovered-task")
+    (Planning_eio.get_current_task config);
+  check bool "old directory quarantined" true
+    (has_current_task_quarantine config);
+  Planning_eio.clear_current_task config
+
+let test_clear_current_task_removes_empty_dir () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = make_config () in
+  let path = current_task_path config in
+  Unix.mkdir path 0o755;
+  Planning_eio.clear_current_task config;
+  check bool "empty directory removed" false (Sys.file_exists path)
+
 let test_resolve_task_id () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -434,6 +481,12 @@ let () =
     ];
     "session_context", [
       test_case "session_context" `Quick test_session_context;
+      test_case "current_task dir read is cleared" `Quick
+        test_current_task_dir_read_is_cleared;
+      test_case "set_current_task quarantines dir" `Quick
+        test_set_current_task_quarantines_dir;
+      test_case "clear_current_task removes empty dir" `Quick
+        test_clear_current_task_removes_empty_dir;
       test_case "resolve_task_id" `Quick test_resolve_task_id;
     ];
     "display", [


### PR DESCRIPTION
## Summary

Closes #16010. Makes the planning `current_task` helpers resilient when the on-disk path ends up as a directory, so one corrupt runtime path no longer wedges keeper claim/set/clear flows.

## Symptom

Observed on 2026-05-17 in the live `~/me/.masc` runtime: repeated `masc_claim_next` / `masc_transition` failures with `Sys_error` over `/Users/dancer/me/.masc/current_task` being a directory. The board/task stream tied this to blocked keeper claims and release/transition failures.

## Fix

- `get_current_task` now treats directory-shaped `current_task` as cleared and logs a warning instead of raising.
- `set_current_task` quarantines a directory-shaped `current_task` under `<masc_dir>/_trash/current_task.<timestamp>` and then writes the fresh file.
- `clear_current_task` removes an empty corrupt directory, warns on a non-empty one, and keeps the existing regular-file behavior.

## Tests

Added focused coverage in `test/test_planning_eio.ml`:

- `current_task dir read is cleared`
- `set_current_task quarantines dir`
- `clear_current_task removes empty dir`

## Local checks

- `ocamlformat --check lib/planning_eio.ml test/test_planning_eio.ml`
- `git diff --check`
- `bash scripts/ci/check-determinism-contract.sh`
- `scripts/dune-local.sh build test/test_planning_eio.exe`
- `./_build/default/test/test_planning_eio.exe` — 21 tests passed

## Out of scope

This PR hardens the helper API against the observed corrupt path shape. It does not prove which writer originally created the directory; that remains a separate writer-audit follow-up.
