### PR TITLE
feat(rfc-0126): PR-2 — provider health probe loop (Phase 3 wiring)

### DIFF
--- a/lib/cascade/provider_health.ml
+++ b/lib/cascade/provider_health.ml
@@ -1,0 +1,272 @@
+type health_state =
+  | Healthy
+  | Unhealthy of
+      { since : float
+      ; consecutive_failures : int
+      }
+
+type provider =
+  { provider_id : string
+  ; endpoint : string option
+  ; probe_interval_seconds : int
+  ; unhealthy_threshold : int
+  ; recovery_threshold : int
+  ; mu : Eio.Mutex.t
+  ; mutable state : health_state
+  ; mutable consecutive_failures : int
+  ; mutable consecutive_successes : int
+  }
+
+type t = { providers : (string, provider) Hashtbl.t }
+
+let active_ref : t option Atomic.t = Atomic.make None
+let set_active t = Atomic.set active_ref (Some t)
+let active () = Atomic.get active_ref
+
+let clamp_probe_interval seconds =
+  if seconds < 60 then 60 else seconds
+;;
+
+let make_provider
+    ~provider_id
+    ?endpoint
+    ~probe_interval_seconds
+    ~unhealthy_threshold
+    ~recovery_threshold
+    ()
+  =
+  { provider_id
+  ; endpoint
+  ; probe_interval_seconds = clamp_probe_interval probe_interval_seconds
+  ; unhealthy_threshold = max 1 unhealthy_threshold
+  ; recovery_threshold = max 1 recovery_threshold
+  ; mu = Eio.Mutex.create ()
+  ; state = Healthy
+  ; consecutive_failures = 0
+  ; consecutive_successes = 0
+  }
+;;
+
+let create_from_providers providers =
+  let table = Hashtbl.create (List.length providers) in
+  List.iter (fun provider -> Hashtbl.replace table provider.provider_id provider) providers;
+  { providers = table }
+;;
+
+let provider_of_decl
+    (decl : Cascade_declarative_types.cascade_provider)
+    (healthcheck : Cascade_declarative_types.cascade_provider_healthcheck)
+  =
+  if not healthcheck.enabled then None
+  else
+    Some
+      (make_provider
+         ~provider_id:decl.id
+         ?endpoint:healthcheck.endpoint
+         ~probe_interval_seconds:healthcheck.probe_interval_seconds
+         ~unhealthy_threshold:healthcheck.unhealthy_threshold
+         ~recovery_threshold:healthcheck.recovery_threshold
+         ())
+;;
+
+let config_path_for_coord (config : Coord.config) =
+  let inputs = Config_dir_resolver.inputs_from_env () in
+  let resolution =
+    Config_dir_resolver.resolve_with
+      { inputs with env_base_path = Some config.base_path }
+  in
+  if resolution.Config_dir_resolver.cascade_authoring.exists then
+    Some resolution.cascade_authoring.path
+  else
+    None
+;;
+
+let create config =
+  match config_path_for_coord config with
+  | None -> create_from_providers []
+  | Some path ->
+    (match Cascade_declarative_parser.parse_file path with
+     | Error errs ->
+       Log.Cascade.warn
+         "[provider-health] cascade.toml parse failed; probes disabled: %s"
+         (errs
+          |> List.map (fun (err : Cascade_declarative_parser.parse_error) ->
+                 Printf.sprintf "%s: %s" err.path err.message)
+          |> String.concat "; ");
+       create_from_providers []
+     | Ok cfg ->
+       cfg.providers
+       |> List.filter_map (fun provider ->
+              Option.bind provider.Cascade_declarative_types.healthcheck
+                (provider_of_decl provider))
+       |> create_from_providers)
+;;
+
+let key_prefix key =
+  match String.index_opt key ':' with
+  | Some idx -> String.sub key 0 idx
+  | None ->
+    (match String.index_opt key '@' with
+     | Some idx -> String.sub key 0 idx
+     | None -> key)
+;;
+
+let swapped_key key =
+  String.map
+    (function
+      | '-' -> '_'
+      | '_' -> '-'
+      | ch -> ch)
+    key
+;;
+
+let find_provider t provider_id =
+  let prefix = key_prefix provider_id in
+  [ provider_id; prefix; swapped_key provider_id; swapped_key prefix ]
+  |> List.find_map (fun key -> Hashtbl.find_opt t.providers key)
+;;
+
+let transition provider ~success =
+  Eio.Mutex.use_rw ~protect:true provider.mu (fun () ->
+    if success then begin
+      provider.consecutive_failures <- 0;
+      provider.consecutive_successes <- provider.consecutive_successes + 1;
+      match provider.state with
+      | Healthy -> ()
+      | Unhealthy _
+        when provider.consecutive_successes >= provider.recovery_threshold ->
+        provider.state <- Healthy
+      | Unhealthy _ -> ()
+    end else begin
+      provider.consecutive_successes <- 0;
+      provider.consecutive_failures <- provider.consecutive_failures + 1;
+      if provider.consecutive_failures >= provider.unhealthy_threshold then
+        provider.state
+        <- Unhealthy
+             {
+               since = Unix.gettimeofday ();
+               consecutive_failures = provider.consecutive_failures;
+             }
+    end)
+;;
+
+let is_healthy t ~provider_id =
+  match find_provider t provider_id with
+  | None -> true
+  | Some provider ->
+    Eio.Mutex.use_rw ~protect:true provider.mu (fun () ->
+      match provider.state with
+      | Healthy -> true
+      | Unhealthy _ -> false)
+;;
+
+let record_attempt_result t ~provider_id ~success ~http_status:_ =
+  match find_provider t provider_id with
+  | None -> ()
+  | Some provider -> transition provider ~success
+;;
+
+let snapshot t =
+  Hashtbl.fold
+    (fun provider_id provider acc ->
+       let state =
+         Eio.Mutex.use_rw ~protect:true provider.mu (fun () -> provider.state)
+       in
+       (provider_id, state) :: acc)
+    t.providers
+    []
+  |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+;;
+
+let filter_healthy t ~provider_id candidates =
+  let filtered =
+    List.filter
+      (fun candidate -> is_healthy t ~provider_id:(provider_id candidate))
+      candidates
+  in
+  match filtered with
+  | [] -> candidates
+  | _ -> filtered
+;;
+
+let probe_once ~clock ~net provider =
+  match provider.endpoint with
+  | None -> ()
+  | Some endpoint ->
+    (match
+       Masc_http_client.get_response_sync
+         ~clock
+         ~timeout_sec:5.0
+         ~net
+         ~url:endpoint
+         ~headers:[ "accept", "application/json" ]
+         ()
+     with
+     | Ok response ->
+       transition provider ~success:(response.Masc_http_client.status >= 200
+                                     && response.status < 300)
+     | Error message ->
+       Log.Cascade.warn
+         "[provider-health] probe failed provider=%s endpoint=%s error=%s"
+         provider.provider_id
+         endpoint
+         message;
+       transition provider ~success:false)
+;;
+
+let start_probe_fiber ~sw ~env t =
+  let running = Atomic.make true in
+  Eio.Switch.on_release sw (fun () -> Atomic.set running false);
+  let clock = Eio.Stdenv.clock env in
+  let net = Eio.Stdenv.net env in
+  Hashtbl.iter
+    (fun _ provider ->
+       match provider.endpoint with
+       | None ->
+         Log.Cascade.warn
+           "[provider-health] provider=%s has enabled healthcheck without endpoint; \
+            probe fiber not started"
+           provider.provider_id
+       | Some _ ->
+         Eio.Fiber.fork ~sw (fun () ->
+           while Atomic.get running do
+             (try probe_once ~clock ~net provider with
+              | Eio.Cancel.Cancelled _ as exn -> raise exn
+              | exn ->
+                Log.Cascade.warn
+                  "[provider-health] probe raised provider=%s error=%s"
+                  provider.provider_id
+                  (Printexc.to_string exn);
+                transition provider ~success:false);
+             Eio.Time.sleep clock (float_of_int provider.probe_interval_seconds)
+           done))
+    t.providers
+;;
+
+module For_testing = struct
+  type nonrec provider =
+    { provider_id : string
+    ; endpoint : string option
+    ; probe_interval_seconds : int
+    ; unhealthy_threshold : int
+    ; recovery_threshold : int
+    }
+
+  let create providers =
+    let make_for_test provider =
+      { provider_id = provider.provider_id
+      ; endpoint = provider.endpoint
+      ; probe_interval_seconds = max 1 provider.probe_interval_seconds
+      ; unhealthy_threshold = max 1 provider.unhealthy_threshold
+      ; recovery_threshold = max 1 provider.recovery_threshold
+      ; mu = Eio.Mutex.create ()
+      ; state = Healthy
+      ; consecutive_failures = 0
+      ; consecutive_successes = 0
+      }
+    in
+    providers |> List.map make_for_test |> create_from_providers
+  ;;
+
+  let clear_active () = Atomic.set active_ref None
+end

--- a/lib/cascade/provider_health.ml
+++ b/lib/cascade/provider_health.ml
@@ -144,6 +144,8 @@ let transition provider ~success =
         provider.state
         <- Unhealthy
              {
+               (* NDT-OK: provider health transitions stamp the external probe
+                  observation time; deterministic logic depends on counters. *)
                since = Unix.gettimeofday ();
                consecutive_failures = provider.consecutive_failures;
              }

--- a/lib/cascade/provider_health.ml
+++ b/lib/cascade/provider_health.ml
@@ -150,10 +150,10 @@ let transition provider ~success =
           match provider.state with
           | Unhealthy { since; _ } -> since
           | Healthy ->
+            Unix.gettimeofday ()
             (* NDT-OK: external probe observation time stamps the first
                Healthy→Unhealthy transition; deterministic logic depends
                on counters. *)
-            Unix.gettimeofday ()
         in
         provider.state
         <- Unhealthy

--- a/lib/cascade/provider_health.ml
+++ b/lib/cascade/provider_health.ml
@@ -140,15 +140,25 @@ let transition provider ~success =
     end else begin
       provider.consecutive_successes <- 0;
       provider.consecutive_failures <- provider.consecutive_failures + 1;
-      if provider.consecutive_failures >= provider.unhealthy_threshold then
+      if provider.consecutive_failures >= provider.unhealthy_threshold then begin
+        (* P2 review finding: preserve first-failure timestamp across
+           repeated failures so outage age (snapshot.since) measures the
+           true Healthy→Unhealthy transition instant, not the most recent
+           failure. Without this, dashboards and time-based thresholds
+           reset on every failure and never reach their cutoff. *)
+        let since =
+          match provider.state with
+          | Unhealthy { since; _ } -> since
+          | Healthy ->
+            (* NDT-OK: external probe observation time stamps the first
+               Healthy→Unhealthy transition; deterministic logic depends
+               on counters. *)
+            Unix.gettimeofday ()
+        in
         provider.state
         <- Unhealthy
-             {
-               (* NDT-OK: provider health transitions stamp the external probe
-                  observation time; deterministic logic depends on counters. *)
-               since = Unix.gettimeofday ();
-               consecutive_failures = provider.consecutive_failures;
-             }
+             { since; consecutive_failures = provider.consecutive_failures }
+      end
     end)
 ;;
 

--- a/lib/cascade/provider_health.mli
+++ b/lib/cascade/provider_health.mli
@@ -1,0 +1,42 @@
+type health_state =
+  | Healthy
+  | Unhealthy of
+      { since : float
+      ; consecutive_failures : int
+      }
+
+type t
+
+val create : Coord.config -> t
+
+val start_probe_fiber :
+  sw:Eio.Switch.t -> env:Eio_unix.Stdenv.base -> t -> unit
+(** Spawn one fiber per [providers.X.healthcheck enabled=true] block. *)
+
+val is_healthy : t -> provider_id:string -> bool
+
+val record_attempt_result :
+  t -> provider_id:string -> success:bool -> http_status:int option -> unit
+(** Feed in-band per-turn results; counts toward thresholds alongside probe results. *)
+
+val snapshot : t -> (string * health_state) list
+(** For dashboard / Prometheus gauge. *)
+
+val filter_healthy : t -> provider_id:('a -> string) -> 'a list -> 'a list
+(** Filter unhealthy candidates, failing open when all candidates would be removed. *)
+
+val set_active : t -> unit
+val active : unit -> t option
+
+module For_testing : sig
+  type provider =
+    { provider_id : string
+    ; endpoint : string option
+    ; probe_interval_seconds : int
+    ; unhealthy_threshold : int
+    ; recovery_threshold : int
+    }
+
+  val create : provider list -> t
+  val clear_active : unit -> unit
+end

--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -143,6 +143,77 @@ let parse_provider_log ~(path : string) (tbl : Otoml.t) : cascade_provider_log =
   }
 ;;
 
+let key_variants key =
+  let replace from_char to_char =
+    String.map (fun ch -> if Char.equal ch from_char then to_char else ch) key
+  in
+  let hyphenated = replace '_' '-' in
+  let underscored = replace '-' '_' in
+  if String.equal hyphenated underscored then [ key ] else [ hyphenated; underscored ]
+;;
+
+let find_string_opt_any tbl key =
+  key_variants key
+  |> List.find_map (fun key -> Otoml.find_opt tbl Otoml.get_string [ key ])
+;;
+
+let find_int_opt_any tbl key =
+  key_variants key
+  |> List.find_map (fun key -> Otoml.find_opt tbl Otoml.get_integer [ key ])
+;;
+
+let positive_int_field_any ~(path : string) tbl ~key ~default =
+  match find_int_opt_any tbl key with
+  | None -> default
+  | Some n when n > 0 -> n
+  | Some n ->
+    Logs.warn (fun m ->
+      m
+        "cascade_declarative_parser: %s.%s = %d — expected positive integer, \
+         using default %d"
+        path
+        key
+        n
+        default);
+    default
+;;
+
+let probe_interval_field ~(path : string) tbl =
+  match find_int_opt_any tbl "probe-interval-seconds" with
+  | None -> 60
+  | Some n when n >= 60 -> n
+  | Some n when n > 0 ->
+    Logs.warn (fun m ->
+      m
+        "cascade_declarative_parser: %s.probe-interval-seconds = %d — minimum is \
+         60s; clamping to 60"
+        path
+        n);
+    60
+  | Some n ->
+    Logs.warn (fun m ->
+      m
+        "cascade_declarative_parser: %s.probe-interval-seconds = %d — expected \
+         positive integer; using default 60"
+        path
+        n);
+    60
+;;
+
+let parse_provider_healthcheck ~(path : string) (tbl : Otoml.t)
+  : cascade_provider_healthcheck
+  =
+  let enabled = Otoml.find_or ~default:false tbl Otoml.get_boolean [ "enabled" ] in
+  { enabled
+  ; endpoint = find_string_opt_any tbl "endpoint"
+  ; probe_interval_seconds = probe_interval_field ~path tbl
+  ; unhealthy_threshold =
+      positive_int_field_any ~path tbl ~key:"unhealthy-threshold" ~default:3
+  ; recovery_threshold =
+      positive_int_field_any ~path tbl ~key:"recovery-threshold" ~default:1
+  }
+;;
+
 (** Parse a [providers.<id>.headers] sub-table into a sorted association
     list. Caller invokes only when the sub-table key exists, so the
     returned list distinguishes "declared but empty / all entries rejected"
@@ -228,6 +299,10 @@ let parse_provider (id : string) (tbl : Otoml.t)
       Otoml.find_opt tbl Fun.id [ "log" ]
       |> Option.map (parse_provider_log ~path:(path ^ ".log"))
     in
+    let healthcheck =
+      Otoml.find_opt tbl Fun.id [ "healthcheck" ]
+      |> Option.map (parse_provider_healthcheck ~path:(path ^ ".healthcheck"))
+    in
     let headers =
       match Otoml.find_opt tbl Fun.id [ "headers" ] with
       | None -> None
@@ -243,6 +318,7 @@ let parse_provider (id : string) (tbl : Otoml.t)
       ; credentials
       ; capabilities
       ; log
+      ; healthcheck
       ; headers
       }
 ;;

--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -33,6 +33,15 @@ type cascade_provider_log =
   }
 [@@deriving show, eq]
 
+type cascade_provider_healthcheck =
+  { enabled : bool
+  ; endpoint : string option
+  ; probe_interval_seconds : int
+  ; unhealthy_threshold : int
+  ; recovery_threshold : int
+  }
+[@@deriving show, eq]
+
 (** Per-provider runtime + behavioral capabilities — RFC-0058 §2.4 +
     Phase 5.1 (capability fields) + §3.2 Phase 5.6 (tool/event support).
 
@@ -107,6 +116,7 @@ type cascade_provider =
   ; credentials : cascade_credential option
   ; capabilities : cascade_capabilities option
   ; log : cascade_provider_log option
+  ; healthcheck : cascade_provider_healthcheck option
   ; headers : (string * string) list option
   }
 [@@deriving show, eq]

--- a/lib/cascade_decl/cascade_declarative_types.mli
+++ b/lib/cascade_decl/cascade_declarative_types.mli
@@ -41,6 +41,15 @@ type cascade_provider_log =
   }
 [@@deriving show, eq]
 
+type cascade_provider_healthcheck =
+  { enabled : bool
+  ; endpoint : string option
+  ; probe_interval_seconds : int
+  ; unhealthy_threshold : int
+  ; recovery_threshold : int
+  }
+[@@deriving show, eq]
+
 (** Per-provider runtime + behavioral capabilities — RFC-0058 §2.4 +
     Phase 5.1 (caller cutover prep, A.1) + §3.2 Phase 5.6 (tool/event support).
 
@@ -82,6 +91,10 @@ type cascade_provider =
     (** Optional operator-facing provider log tail. When enabled, the
       dashboard may read only this configured path for the provider; the
       request never accepts an arbitrary file path. *)
+  ; healthcheck : cascade_provider_healthcheck option
+    (** Optional active provider-health probe loop settings. When
+      [enabled=true], server startup probes [endpoint] and combines probe
+      outcomes with in-band cascade attempt results. *)
   ; headers : (string * string) list option
     (** Reserved schema (Phase 5.6 prep). Additional HTTP headers per
       provider, e.g. [("anthropic-version", "2023-06-01")] for Anthropic

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -342,6 +342,36 @@ let run_named
       tool_filtered_candidate_count
       local_prefiltered_candidate_count;
   let provider_attempt_provenance = base_provider_attempt_provenance in
+  let filter_provider_health_fail_open candidates =
+    match Provider_health.active () with
+    | None -> candidates
+    | Some health ->
+      Provider_health.filter_healthy health
+        ~provider_id:Cascade_runtime_candidate.health_key
+        candidates
+  in
+  let record_provider_health_result candidate ~success ~http_status =
+    match Provider_health.active () with
+    | None -> ()
+    | Some health ->
+      Provider_health.record_attempt_result health
+        ~provider_id:(Cascade_runtime_candidate.health_key candidate)
+        ~success
+        ~http_status
+  in
+  let record_provider_health_error candidate = function
+    | Provider_error.ServerError { code; _ } ->
+      record_provider_health_result candidate ~success:false ~http_status:(Some code)
+    | Provider_error.CapacityExhausted _
+    | Provider_error.RateLimit _
+    | Provider_error.AuthError
+    | Provider_error.InvalidRequest _
+    | Provider_error.CliWrappedHardQuota _
+    | Provider_error.CliWrappedMaxTurns _
+    | Provider_error.CliWrappedResumableSession _
+    | Provider_error.PermissionDenied _
+    | Provider_error.ModelNotFound -> ()
+  in
   match candidates with
   | [] ->
       let required_tool_names =
@@ -964,6 +994,7 @@ let run_named
          a single number, which would mislead strategy ranking. *)
       (match result with
       | Ok result when accept result.response ->
+        record_provider_health_result candidate ~success:true ~http_status:None;
         record_accepted_liveness_sample ();
         record_candidate_success candidate ~latency_ms:attempt_latency_ms result;
         (* FSM: Call_ok → Accept *)
@@ -997,6 +1028,7 @@ let run_named
           { response = result.response; reason } in
         (match Cascade_fsm.decide ~accept_on_exhaustion:false ~is_last outcome with
            | Cascade_fsm.Accept_on_exhaustion { response; _ } ->
+           record_provider_health_result candidate ~success:true ~http_status:None;
            record_accepted_liveness_sample ();
            record_candidate_success candidate ~latency_ms:attempt_latency_ms result;
            let observation =
@@ -1024,7 +1056,7 @@ let run_named
            (* The rejected response is not trusted progress.  Resuming
               from its checkpoint can turn a fallback provider into a
               replay of the rejected empty/schema-invalid turn. *)
-           try_cascade ?resume_checkpoint rest new_err
+           try_cascade ?resume_checkpoint (filter_provider_health_fail_open rest) new_err
          | Cascade_fsm.Exhausted _ ->
            record_candidate_health_rejected candidate ~reason;
            let observation =
@@ -1055,6 +1087,7 @@ let run_named
               real FSM contract violation, not a tunable. *)
            Cascade_metrics.on_cascade_invariant_violation ();
            Log.Misc.warn "cascade %s: unexpected Accept in Accept_rejected branch (runtime=%s)" cascade_name runtime_candidate_label;
+           record_provider_health_result candidate ~success:true ~http_status:None;
            record_accepted_liveness_sample ();
            record_candidate_success candidate ~latency_ms:attempt_latency_ms result;
            let observation =
@@ -1089,16 +1122,19 @@ let run_named
            state. *)
         let err_str = Agent_sdk.Error.to_string sdk_err in
         record_candidate_health_error candidate sdk_err;
-                let provider_error =
-                  emit_sdk_provider_error_metric ~cascade_name:error_cascade_name
-                    ~provider:runtime_candidate_label sdk_err
-                in
-                record_cascade_attempt
-                  candidate
-                  ?http_status:(http_status_of_provider_error provider_error)
-                  ~outcome:(`Failure (Agent_sdk.Error.to_string sdk_err))
-                  ();
-                let _ = err_str in
+        let provider_error =
+          emit_sdk_provider_error_metric
+            ~cascade_name:error_cascade_name
+            ~provider:runtime_candidate_label
+            sdk_err
+        in
+        record_cascade_attempt
+          candidate
+          ?http_status:(http_status_of_provider_error provider_error)
+          ~outcome:(`Failure (Agent_sdk.Error.to_string sdk_err))
+          ();
+        Option.iter (record_provider_health_error candidate) provider_error;
+        let _ = err_str in
         let cascade_outcome = sdk_error_to_cascade_outcome sdk_err in
         Option.iter
           (fun _ -> record_candidate_error candidate sdk_err)
@@ -1191,7 +1227,10 @@ let run_named
                 else
                   next_resume
               in
-              try_cascade ?resume_checkpoint:retry_resume_checkpoint rest new_err
+              try_cascade
+                ?resume_checkpoint:retry_resume_checkpoint
+                (filter_provider_health_fail_open rest)
+                new_err
             | Cascade_fsm.Exhausted _ ->
               let observation =
                 Cascade_legacy_runner.cascade_observation_with_metrics
@@ -1314,6 +1353,7 @@ let run_named
     let ordered =
       Cascade_strategy.order_candidates strategy
         ~adapter ~ctx:signal_ctx ~cycle:n candidates
+      |> filter_provider_health_fail_open
     in
     let last_cycle = n + 1 >= strategy.cycle.max_cycles in
     match ordered with

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1483,6 +1483,9 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr
           ~fs ~env ()
       in
+      let provider_health = Provider_health.create state.room_config in
+      Provider_health.set_active provider_health;
+      Provider_health.start_probe_fiber ~sw ~env provider_health;
       let format_catalog_validation_error label rejection =
         Printf.sprintf
           "%s: %s"

--- a/test/dune
+++ b/test/dune
@@ -1680,6 +1680,8 @@
 
 (include stanzas/test_process_eio_default_timeout.inc)
 
+(include stanzas/test_provider_health.inc)
+
 (include stanzas/test_provider_kind_resolution.inc)
 
 (include stanzas/test_release_train_guard_script.inc)

--- a/test/stanzas/test_provider_health.inc
+++ b/test/stanzas/test_provider_health.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_provider_health)
+ (modules test_provider_health)
+ (libraries masc_test_deps))

--- a/test/test_cascade_declarative_adapter.ml
+++ b/test/test_cascade_declarative_adapter.ml
@@ -630,6 +630,7 @@ let test_alias_parent_missing () =
           ; credentials = None
           ; capabilities = None
           ; log = None
+          ; healthcheck = None
           ; headers = None
           }
         ]
@@ -763,6 +764,7 @@ let test_duplicate_routes () =
           ; credentials = None
           ; capabilities = None
           ; log = None
+          ; healthcheck = None
           ; headers = None
           }
         ]

--- a/test/test_provider_health.ml
+++ b/test/test_provider_health.ml
@@ -1,0 +1,191 @@
+open Alcotest
+open Masc_mcp
+
+let provider ?endpoint ?(interval = 1) ?(unhealthy_threshold = 3)
+    ?(recovery_threshold = 2) provider_id
+  : Provider_health.For_testing.provider
+  =
+  { provider_id
+  ; endpoint
+  ; probe_interval_seconds = interval
+  ; unhealthy_threshold
+  ; recovery_threshold
+  }
+;;
+
+let find_free_port () =
+  let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close socket)
+    (fun () ->
+       Unix.setsockopt socket Unix.SO_REUSEADDR true;
+       (match Unix.bind socket (Unix.ADDR_INET (Unix.inet_addr_loopback, 0)) with
+        | () -> ()
+        | exception Unix.Unix_error ((Unix.EPERM | Unix.EACCES), "bind", _) ->
+          Alcotest.skip ());
+       match Unix.getsockname socket with
+       | Unix.ADDR_INET (_, port) -> port
+       | _ -> failwith "unexpected socket family")
+;;
+
+let start_flipping_server ~sw ~net ~port status_code =
+  let handler _conn _req body =
+    let _ = Eio.Buf_read.(of_flow ~max_size:1024 body |> take_all) in
+    let status = Atomic.get status_code |> Cohttp.Code.status_of_code in
+    Cohttp_eio.Server.respond_string ~status ~body:"ok" ()
+  in
+  let socket =
+    Eio.Net.listen net ~sw ~backlog:8 ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  let server = Cohttp_eio.Server.make ~callback:handler () in
+  Eio.Fiber.fork_daemon ~sw (fun () ->
+    Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()))
+;;
+
+let wait_until ~clock ~timeout_s predicate =
+  let deadline = Eio.Time.now clock +. timeout_s in
+  let rec loop () =
+    if predicate () then true
+    else if Eio.Time.now clock >= deadline then false
+    else begin
+      Eio.Time.sleep clock 0.05;
+      loop ()
+    end
+  in
+  loop ()
+;;
+
+let test_in_band_failure_threshold_marks_unhealthy () =
+  Eio_main.run @@ fun _env ->
+  let health =
+    Provider_health.For_testing.create
+      [ provider "runpod" ~unhealthy_threshold:3 ~recovery_threshold:2 ]
+  in
+  for _ = 1 to 3 do
+    Provider_health.record_attempt_result health ~provider_id:"runpod"
+      ~success:false ~http_status:(Some 502)
+  done;
+  check bool "provider unhealthy after threshold" false
+    (Provider_health.is_healthy health ~provider_id:"runpod")
+;;
+
+let test_in_band_recovery_threshold_marks_healthy () =
+  Eio_main.run @@ fun _env ->
+  let health =
+    Provider_health.For_testing.create
+      [ provider "runpod" ~unhealthy_threshold:3 ~recovery_threshold:2 ]
+  in
+  for _ = 1 to 3 do
+    Provider_health.record_attempt_result health ~provider_id:"runpod"
+      ~success:false ~http_status:(Some 502)
+  done;
+  for _ = 1 to 2 do
+    Provider_health.record_attempt_result health ~provider_id:"runpod"
+      ~success:true ~http_status:None
+  done;
+  check bool "provider healthy after recovery threshold" true
+    (Provider_health.is_healthy health ~provider_id:"runpod")
+;;
+
+let test_probe_loop_tracks_http_transition () =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  Eio_context.set_switch sw;
+  Eio_context.set_net net;
+  Eio_context.set_clock clock;
+  Eio_context.set_env env;
+  let port = find_free_port () in
+  let status_code = Atomic.make 502 in
+  start_flipping_server ~sw ~net ~port status_code;
+  let endpoint = Printf.sprintf "http://127.0.0.1:%d/health" port in
+  let health =
+    Provider_health.For_testing.create
+      [ provider "runpod" ~endpoint ~interval:1 ~unhealthy_threshold:2
+          ~recovery_threshold:2
+      ]
+  in
+  Provider_health.start_probe_fiber ~sw ~env health;
+  check bool "probe marks 502 unhealthy" true
+    (wait_until ~clock ~timeout_s:3.5 (fun () ->
+       not (Provider_health.is_healthy health ~provider_id:"runpod")));
+  Atomic.set status_code 200;
+  check bool "probe marks 200 healthy" true
+    (wait_until ~clock ~timeout_s:3.5 (fun () ->
+       Provider_health.is_healthy health ~provider_id:"runpod"))
+;;
+
+let test_filter_healthy_skips_unhealthy_candidate () =
+  Eio_main.run @@ fun _env ->
+  let health =
+    Provider_health.For_testing.create
+      [ provider "A" ~unhealthy_threshold:1 ~recovery_threshold:1
+      ; provider "B" ~unhealthy_threshold:1 ~recovery_threshold:1
+      ; provider "C" ~unhealthy_threshold:1 ~recovery_threshold:1
+      ]
+  in
+  Provider_health.record_attempt_result health ~provider_id:"A" ~success:false
+    ~http_status:(Some 502);
+  let filtered =
+    Provider_health.filter_healthy health ~provider_id:(fun x -> x) [ "A"; "B"; "C" ]
+  in
+  check (list string) "unhealthy A removed" [ "B"; "C" ] filtered
+;;
+
+let test_parser_clamps_probe_interval_to_minimum () =
+  let toml =
+    {|
+[providers.runpod]
+protocol = "openai-http"
+endpoint = "https://runpod.example/v1"
+
+[providers.runpod.healthcheck]
+enabled = true
+endpoint = "https://runpod.example/health"
+probe_interval_seconds = 1
+unhealthy_threshold = 2
+recovery_threshold = 2
+
+[models.qwen]
+api-name = "qwen"
+max-context = 32768
+
+[runpod.qwen]
+|}
+  in
+  let cfg =
+    match Cascade_declarative_parser.parse_string toml with
+    | Ok cfg -> cfg
+    | Error errs ->
+      errs
+      |> List.map (fun (err : Cascade_declarative_parser.parse_error) ->
+             Printf.sprintf "%s: %s" err.path err.message)
+      |> String.concat "; "
+      |> failwith
+  in
+  match cfg.providers with
+  | [ { Cascade_declarative_types.healthcheck = Some healthcheck; _ } ] ->
+    check int "probe interval clamped" 60 healthcheck.probe_interval_seconds
+  | _ -> failwith "expected one provider with healthcheck"
+;;
+
+let () =
+  run "provider_health"
+    [ ( "state"
+      , [ test_case "failures trip unhealthy threshold" `Quick
+            test_in_band_failure_threshold_marks_unhealthy
+        ; test_case "successes trip recovery threshold" `Quick
+            test_in_band_recovery_threshold_marks_healthy
+        ; test_case "candidate filter skips unhealthy provider" `Quick
+            test_filter_healthy_skips_unhealthy_candidate
+        ; test_case "parser clamps probe interval" `Quick
+            test_parser_clamps_probe_interval_to_minimum
+        ] )
+    ; ( "probe"
+      , [ test_case "probe fiber tracks 502 to 200 transition" `Quick
+            test_probe_loop_tracks_http_transition
+        ] )
+    ]
+;;


### PR DESCRIPTION
RFC body: #16000

## Edit sites
- `lib/cascade/provider_health.{ml,mli}`: typed health state, Eio.Mutex-protected per-provider state, in-band result recording, background probe fibers via existing `Masc_http_client`.
- `lib/cascade_decl/*`: parses `[providers.<id>.healthcheck]`, clamps `probe_interval_seconds < 60` with a config-load warning.
- `lib/server/server_runtime_bootstrap.ml`: creates the provider-health context at startup and starts long-lived probe fibers.
- `lib/keeper/keeper_turn_driver.ml`: filters unhealthy candidates fail-open and records successful attempts / `Provider_error.ServerError` attempts.
- `test/test_provider_health.ml`: threshold, recovery, candidate-filter, parser-clamp, and mock HTTP probe-loop coverage.

## Test summary
- PASS: `dune build --root . @check`
- PASS: `dune build --root . test/test_provider_health.exe && ./_build/default/test/test_provider_health.exe`
- NOTE: local probe-loop test is present but skipped in this sandbox because loopback bind returns EPERM/EACCES.
- NOTE: full `dune build --root . @runtest` is blocked by unrelated existing source-path/sandbox tests (`lib/oas_worker_exec.ml` missing rule, RFC-0085/0086 AST path tests, typed post-hook pin tests).

## Notes
- No new HTTP stack was added; probes use `Masc_http_client.get_response_sync`.
- Provider-health selection fails open when every candidate would be filtered.
- `pr-rfc-check.sh` was not present in this checkout; this draft cites RFC PR #16000 explicitly.
