### PR TITLE
fix(keeper): block bare dune from agent shells

### DIFF
--- a/lib/keeper/dev_exec_allowlist.ml
+++ b/lib/keeper/dev_exec_allowlist.ml
@@ -3,7 +3,7 @@ let dev =
   ; "cargo"
   ; "cmake"
   ; "cut"
-  ; "dune"
+  ; "dune-local.sh"
   ; "echo"
   ; "env"
   ; "file"

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -1089,6 +1089,8 @@ let handle_keeper_bash
              op=\"gh\" (e.g. keeper_shell op=gh cmd=\"pr list --state open\")."
           | Chain_or_redirect | Pipes_not_allowed | Unsafe_redirect ->
             "Use separate tool calls instead of chaining. Call keeper_bash once per command."
+          | Direct_dune_invocation ->
+            "Use scripts/dune-local.sh instead of bare dune so local builds share the machine-wide lock."
           | Injection | Process_substitution ->
             "Avoid shell metacharacters. Use keeper_shell with a specific op (rg, find, ls) instead."
           | Command_not_allowed _ ->
@@ -1106,6 +1108,10 @@ let handle_keeper_bash
           | Chain_or_redirect | Pipes_not_allowed | Unsafe_redirect ->
             [ "Break the pipeline into separate keeper_bash calls."
             ; "Save intermediate output to a file, then process it in the next call."
+            ]
+          | Direct_dune_invocation ->
+            [ "Run scripts/dune-local.sh build <target> from the repo root."
+            ; "Do not run bare dune build/test/exec in local agent shells."
             ]
           | Injection | Process_substitution ->
             [ "Use keeper_shell with a specific op (rg, find, ls) for structured queries."

--- a/lib/keeper/keeper_shell_shared.ml
+++ b/lib/keeper/keeper_shell_shared.ml
@@ -240,6 +240,14 @@ let diagnosis_of_block_reason reason =
                 Some "Run the first command, then pipe the output into \
                       the second keeper_bash call."
             ; tool_suggestion = None }
+  | Worker_dev_tools.Direct_dune_invocation ->
+      Some { Exec_core.rule_id = "direct_dune_blocked"
+            ; explanation =
+                "Bare dune bypasses scripts/dune-local.sh and can create \
+                 concurrent local builds that exhaust host file descriptors."
+            ; rewrite =
+                Some "Run scripts/dune-local.sh build <target> from the repo root."
+            ; tool_suggestion = Some "keeper_bash" }
   | Worker_dev_tools.Unsafe_redirect ->
       Some { Exec_core.rule_id = "command_redirect_blocked"
             ; explanation =

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -196,7 +196,7 @@ let bash_public_schema =
         "command"
         "string"
         "The shell command to execute. Single command only. No chaining (&&, ||, ;), \
-         pipes (|), or redirects (>, >>). Example: 'dune build', 'rg pattern lib/'."
+         pipes (|), or redirects (>, >>). Example: 'scripts/dune-local.sh build', 'rg pattern lib/'."
     ; property
         "description"
         "string"

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -49,7 +49,7 @@ let first_nonempty_line output =
 
 (* Shell command allowlist *)
 let allowed_shell_commands = [
-  "dune"; "make"; "npm"; "npx"; "node";
+  "dune-local.sh"; "make"; "npm"; "npx"; "node";
   "git"; "ls"; "cat"; "head"; "tail"; "wc";
   "rg"; "grep"; "find"; "diff"; "patch"; "mkdir";
   "opam"; "ocamlfind"; "tsc";
@@ -948,9 +948,9 @@ Use when removing generated, obsolete, or conflicting files during code work.";
     name = "masc_code_shell";
     description = "Run an allowlisted command in an allowed coding sandbox \
 (.worktrees/ or .masc/playground/). \
-Allowed: dune, make, npm, npx, node, git, ls, cat, head, tail, wc, rg, find, \
-diff, patch, mkdir, opam, ocamlfind, tsc. Use for building and testing code \
-in isolated worktrees. For unrestricted shell at project root, use keeper_bash. \
+Allowed: scripts/dune-local.sh, make, npm, npx, node, git, ls, cat, head, tail, \
+wc, rg, find, diff, patch, mkdir, opam, ocamlfind, tsc. Use for building and \
+testing code in isolated worktrees. For unrestricted shell at project root, use keeper_bash. \
 Returns exit_code and stdout (truncated at " ^ max_output_label ^ ").";
     input_schema = `Assoc [
       ("type", `String "object");

--- a/lib/tool_shard_types.ml
+++ b/lib/tool_shard_types.ml
@@ -865,7 +865,7 @@ let coding_keeper_bridge_tools : Masc_domain.tool_schema list =
         "Execute ONE shell command through the keeper_bash safety gates. No \
          chaining/control syntax (&&, ||, ;), command substitution, background \
          operators, or file redirects. Pipelines and fd-only redirects are accepted only \
-         when the active preset validator allows every segment. Good: cmd='dune build', \
+         when the active preset validator allows every segment. Good: cmd='scripts/dune-local.sh build', \
          cmd='ls -la lib/'. Bad: cmd='cd x && dune build', cmd='echo hi > out.txt'. Runs \
          in the keeper sandbox by default; use cwd to target an explicit allowed \
          directory. Paths resolve automatically — never include host storage prefixes \
@@ -887,7 +887,7 @@ let coding_keeper_bridge_tools : Masc_domain.tool_schema list =
                       ; ( "description"
                         , `String
                             "Single command only. No chaining/control syntax or file \
-                             redirects. Example: 'dune build', 'rg pattern lib/'" )
+                             redirects. Example: 'scripts/dune-local.sh build', 'rg pattern lib/'" )
                       ] )
                 ; ( "cwd"
                   , `Assoc

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -225,6 +225,80 @@ let split_shell_tokens cmd =
   |> List.filter (fun token -> token <> "")
 ;;
 
+let strip_wrapping_quotes token =
+  let len = String.length token in
+  if len >= 2
+  then (
+    let first = token.[0]
+    and last = token.[len - 1] in
+    if (first = '"' && last = '"') || (first = '\'' && last = '\'')
+    then String.sub token 1 (len - 2)
+    else token)
+  else token
+;;
+
+let basename_token token = Filename.basename (strip_wrapping_quotes token)
+
+let is_env_assignment token =
+  let token = strip_wrapping_quotes token in
+  match String.index_opt token '=' with
+  | Some idx ->
+    idx > 0
+    && not (String.contains (String.sub token 0 idx) '/')
+    && not (String.starts_with ~prefix:"-" token)
+  | None -> false
+;;
+
+let rec command_after_env_prefix = function
+  | [] -> None
+  | token :: rest ->
+    let token = strip_wrapping_quotes token in
+    if is_env_assignment token || token = "-" || token = "-i"
+    then command_after_env_prefix rest
+    else if token = "-u" || token = "--unset"
+    then (
+      match rest with
+      | _ :: rest -> command_after_env_prefix rest
+      | [] -> None)
+    else if String.starts_with ~prefix:"-u" token
+    then command_after_env_prefix rest
+    else Some (basename_token token)
+;;
+
+let opam_exec_command_name rest =
+  match rest with
+  | sub :: rest when String.equal (basename_token sub) "exec" ->
+    let rec find_command = function
+      | [] -> None
+      | "--" :: token :: _ -> Some (basename_token token)
+      | "--" :: [] -> None
+      | token :: rest ->
+        let token = strip_wrapping_quotes token in
+        if String.starts_with ~prefix:"-" token || is_env_assignment token
+        then find_command rest
+        else Some (basename_token token)
+    in
+    find_command rest
+  | [] -> Some "opam"
+  | _non_exec_subcommand :: _rest -> Some "opam"
+;;
+
+let segment_command_name segment =
+  match split_shell_tokens segment with
+  | [] -> None
+  | token :: rest -> (
+    match basename_token token with
+    | "env" -> command_after_env_prefix rest
+    | "opam" -> opam_exec_command_name rest
+    | name -> Some name)
+;;
+
+let invokes_direct_dune segment =
+  match segment_command_name segment with
+  | Some "dune" -> true
+  | _ -> false
+;;
+
 let is_digits_only s start stop =
   let rec loop i =
     if i >= stop
@@ -284,7 +358,7 @@ let extract_command_name cmd =
 
 (** Error hint for a blocked command.
 
-    A terse "'foo' is not allowed, allowed: dune, git..." drives the LLM
+    A terse "'foo' is not allowed, allowed: git, rg..." drives the LLM
     to retry variants of foo, including OCaml/Python syntax fragments
     ('let', 'sort', 'Keeper_agent_run.build_ctx_composition', etc.) —
     live log 2026-04-16 shows 12+ retries per ~3MB.
@@ -298,7 +372,7 @@ let extract_command_name cmd =
     The helper is a pure function of the tried command name and the
     optional caller-specific allowlist. *)
 let default_common_allowed_commands_hint =
-  "dune, git, rg, ls, cat, head, tail, grep, find, make, node, npm, \
+  "scripts/dune-local.sh, git, rg, ls, cat, head, tail, grep, find, make, node, npm, \
    python3, pytest, cargo, go"
 ;;
 
@@ -392,6 +466,7 @@ type block_reason =
   | Process_substitution
   | Unsafe_redirect
   | Pipes_not_allowed
+  | Direct_dune_invocation
   | Command_not_allowed of string
 
 let block_reason_to_string = function
@@ -399,23 +474,29 @@ let block_reason_to_string = function
   | Chain_or_redirect ->
     "Blocked: chaining (&&/||/;) and redirects (|/>) are not allowed. Run ONE command \
      per call. To change directory, use the `cwd` argument instead of `cd` — Good: \
-     cwd='repos/masc-mcp', cmd='dune build'. Bad:  cmd='cd repos/masc-mcp && dune \
+     cwd='repos/masc-mcp', cmd='scripts/dune-local.sh build'. Bad:  cmd='cd repos/masc-mcp && dune \
      build'. For pipelines like `rg foo | wc -l`, run the primary command and process \
      output at the LLM layer. To write files, use keeper_fs_edit."
   | Injection ->
     "Shell injection syntax (;, &&, standalone &, `, $) not allowed. Run ONE command per \
      call. To change directory, use the `cwd` argument — Good: cwd='repos/masc-mcp', \
-     cmd='dune build'. Bad:  cmd='cd repos/masc-mcp && dune build' or cmd='cmd1 ; cmd2'. \
+     cmd='scripts/dune-local.sh build'. Bad:  cmd='cd repos/masc-mcp && dune build' or cmd='cmd1 ; cmd2'. \
      Relative paths resolve from `cwd` (defaults to playground root). For file writes, \
      use keeper_fs_edit."
   | Process_substitution -> "Process substitution (<(...) or >(...)) is not allowed."
   | Unsafe_redirect ->
     "File redirects are not allowed. Only fd redirects like 2>&1 are permitted."
   | Pipes_not_allowed -> "Pipes are not allowed. Run one command per call."
+  | Direct_dune_invocation ->
+    "Direct `dune` is blocked in local agent shells because it bypasses \
+     scripts/dune-local.sh's machine-wide build lock and can trigger \
+     host-wide ENFILE/EMFILE pressure. Use `scripts/dune-local.sh build ...` \
+     from the repo root instead."
   | Command_not_allowed name -> command_blocked_hint name
 ;;
 
 let block_reason_to_string_with_allowlist ~allowed_commands = function
+  | Direct_dune_invocation -> block_reason_to_string Direct_dune_invocation
   | Command_not_allowed name -> command_blocked_hint ~allowed_commands name
   | reason -> block_reason_to_string reason
 ;;
@@ -426,6 +507,8 @@ let validate_command_with_allowlist ~allowed_commands cmd =
   then Error Empty_command
   else if contains_forbidden_shell_chars trimmed
   then Error Chain_or_redirect
+  else if invokes_direct_dune trimmed
+  then Error Direct_dune_invocation
   else (
     match extract_command_name trimmed with
     | None -> Error Empty_command
@@ -457,6 +540,8 @@ let validate_command_coding_with_allowlist
     | Ok segments ->
       if (not allow_pipes) && List.length segments > 1
       then Error Pipes_not_allowed
+      else if List.exists invokes_direct_dune segments
+      then Error Direct_dune_invocation
       else (
         let rec validate_segments = function
           | [] -> Ok ()
@@ -477,18 +562,6 @@ let validate_command_coding cmd =
     ~allow_pipes:true
     ~allowed_commands:dev_allowed_commands
     cmd
-;;
-
-let strip_wrapping_quotes token =
-  let len = String.length token in
-  if len >= 2
-  then (
-    let first = token.[0]
-    and last = token.[len - 1] in
-    if (first = '"' && last = '"') || (first = '\'' && last = '\'')
-    then String.sub token 1 (len - 2)
-    else token)
-  else token
 ;;
 
 let looks_like_url token =
@@ -1101,7 +1174,7 @@ let validate_command_paths ?keeper_id ?base_path ?workdir cmd =
 (** Check if a command performs write/mutating operations.
     Returns [true] for commands like [git push], [git commit],
     [make deploy], [npm publish], [mv], [cp], etc.
-    Read-only commands (git status, dune build, rg) return [false]. *)
+    Read-only commands (git status, rg) return [false]. *)
 let is_write_operation cmd =
   let parts = String.split_on_char ' ' (String.trim cmd) in
   match parts with
@@ -1570,7 +1643,7 @@ let make_file_write ?workdir ?on_exec () =
 ;;
 
 (* --- Attribution envelope conversion (Layer 1) ---
-   Shell command validation is a Det policy gate. The 7 block_reason
+   Shell command validation is a Det policy gate. The 8 block_reason
    variants map uniformly to Policy_failed (no transition involved —
    this is a pre-execution allow/deny check).
 
@@ -1585,6 +1658,7 @@ let block_reason_tag = function
   | Process_substitution -> "process_substitution"
   | Unsafe_redirect -> "unsafe_redirect"
   | Pipes_not_allowed -> "pipes_not_allowed"
+  | Direct_dune_invocation -> "direct_dune_invocation"
   | Command_not_allowed _ -> "command_not_allowed"
 ;;
 
@@ -1597,6 +1671,7 @@ let attribution_of_validation ~cmd (result : (unit, block_reason) result) : Attr
     let command_name =
       match br with
       | Command_not_allowed name -> Some name
+      | Direct_dune_invocation -> Some "dune"
       | _ -> None
     in
     let evidence : Yojson.Safe.t =

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -249,18 +249,47 @@ let is_env_assignment token =
   | None -> false
 ;;
 
+let rec skip_env_assignments = function
+  | [] -> None
+  | token :: rest ->
+    let token = strip_wrapping_quotes token in
+    if is_env_assignment token then skip_env_assignments rest
+    else Some (basename_token token)
+;;
+
 let rec command_after_env_prefix = function
   | [] -> None
   | token :: rest ->
     let token = strip_wrapping_quotes token in
     if is_env_assignment token || token = "-" || token = "-i"
+       || token = "--ignore-environment" || token = "-0" || token = "--null"
     then command_after_env_prefix rest
-    else if token = "-u" || token = "--unset"
+    else if token = "--" then skip_env_assignments rest
+    else if token = "-S" || token = "--split-string"
+    then (
+      match rest with
+      | arg :: rest -> (
+        match command_after_env_prefix (split_shell_tokens (strip_wrapping_quotes arg)) with
+        | Some _ as command -> command
+        | None -> command_after_env_prefix rest)
+      | [] -> None)
+    else if String.starts_with ~prefix:"--split-string=" token
+    then
+      let prefix = "--split-string=" in
+      let arg =
+        String.sub token (String.length prefix)
+          (String.length token - String.length prefix)
+      in
+      command_after_env_prefix (split_shell_tokens (strip_wrapping_quotes arg))
+    else if token = "-u" || token = "--unset" || token = "-C"
+            || token = "--chdir"
     then (
       match rest with
       | _ :: rest -> command_after_env_prefix rest
       | [] -> None)
     else if String.starts_with ~prefix:"-u" token
+            || String.starts_with ~prefix:"--unset=" token
+            || String.starts_with ~prefix:"--chdir=" token
     then command_after_env_prefix rest
     else Some (basename_token token)
 ;;
@@ -268,17 +297,34 @@ let rec command_after_env_prefix = function
 let opam_exec_command_name rest =
   match rest with
   | sub :: rest when String.equal (basename_token sub) "exec" ->
-    let rec find_command = function
+    let rec find_sentinel = function
       | [] -> None
       | "--" :: token :: _ -> Some (basename_token token)
       | "--" :: [] -> None
+      | _ :: rest -> find_sentinel rest
+    in
+    let rec find_command_without_sentinel = function
+      | [] -> None
       | token :: rest ->
         let token = strip_wrapping_quotes token in
-        if String.starts_with ~prefix:"-" token || is_env_assignment token
-        then find_command rest
+        if is_env_assignment token then find_command_without_sentinel rest
+        else if token = "--switch" || token = "--color" || token = "--root"
+                || token = "--cli"
+        then (
+          match rest with
+          | _ :: rest -> find_command_without_sentinel rest
+          | [] -> None)
+        else if String.starts_with ~prefix:"--switch=" token
+                || String.starts_with ~prefix:"--color=" token
+                || String.starts_with ~prefix:"--root=" token
+                || String.starts_with ~prefix:"--cli=" token
+                || String.starts_with ~prefix:"-" token
+        then find_command_without_sentinel rest
         else Some (basename_token token)
     in
-    find_command rest
+    (match find_sentinel rest with
+     | Some _ as command -> command
+     | None -> find_command_without_sentinel rest)
   | [] -> Some "opam"
   | _non_exec_subcommand :: _rest -> Some "opam"
 ;;

--- a/lib/worker_dev_tools.mli
+++ b/lib/worker_dev_tools.mli
@@ -34,6 +34,7 @@ type block_reason =
   | Process_substitution
   | Unsafe_redirect
   | Pipes_not_allowed
+  | Direct_dune_invocation
   | Command_not_allowed of string
 
 (** Render a {!block_reason} as the operator-visible error string
@@ -49,7 +50,7 @@ val block_reason_to_string_with_allowlist :
     passes a narrower allowlist than {!validate_command_coding}; otherwise
     the generic hint can name commands that the caller still rejects. *)
 
-(** The default dev allowlist (cat, cargo, dune, git, rg, …).  Used by
+(** The default dev allowlist (cat, cargo, dune-local.sh, git, rg, …).  Used by
     {!validate_command} internally; exposed so RFC-0092 Phase A's
     typed advisor ({!Shell_ir_validator.advise}) can mirror the legacy
     gate's allowlist for parity measurement.  Order is the source of
@@ -59,7 +60,9 @@ val dev_allowed_commands : string list
 
 (** Strict (allowlist + no shell metacharacters) validator used by the
     default [shell_exec] tool.  Rejects empty input, chaining, and any
-    command outside the dev allowlist (rg / grep / dune / git / ...). *)
+    command outside the dev allowlist (rg / grep / dune-local.sh / git / ...).
+    Bare [dune] is intentionally rejected; local agents must use
+    [scripts/dune-local.sh] so builds share the host-wide lock. *)
 val validate_command : string -> (unit, block_reason) result
 
 (** Relaxed validator for Coding/Full preset keepers.  Allows pipes
@@ -105,7 +108,7 @@ val existing_dir_path_values : string -> string list
 
 (** [true] iff the command performs a write/mutating operation
     (git push/commit, dune clean, npm publish, mv, cp, mkdir,
-    chmod, ...).  Read-only commands (git status, dune build, rg)
+    chmod, ...).  Read-only commands (git status, rg)
     return [false]. *)
 val is_write_operation : string -> bool
 

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,6 +31,6 @@ lib/process/process_eio.ml:493
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1690 — dev-tools worker spawn. Wrapped by the
+# lib/worker_dev_tools.ml:1765 — dev-tools worker spawn. Wrapped by the
 # worker switch; bounded by the dev-tools session lifetime.
-lib/worker_dev_tools.ml:1690
+lib/worker_dev_tools.ml:1765

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,6 +31,6 @@ lib/process/process_eio.ml:493
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1765 — dev-tools worker spawn. Wrapped by the
+# lib/worker_dev_tools.ml:1811 — dev-tools worker spawn. Wrapped by the
 # worker switch; bounded by the dev-tools session lifetime.
-lib/worker_dev_tools.ml:1765
+lib/worker_dev_tools.ml:1811

--- a/scripts/nofile-status.sh
+++ b/scripts/nofile-status.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'soft open files: %s\n' "$(ulimit -n 2>/dev/null || printf '?')"
+
+if command -v launchctl >/dev/null 2>&1; then
+  printf 'launchctl maxfiles: '
+  launchctl limit maxfiles 2>/dev/null | awk 'NR == 1 {print $2, $3}' || true
+fi
+
+sysctl_cmd=""
+if command -v sysctl >/dev/null 2>&1; then
+  sysctl_cmd="$(command -v sysctl)"
+elif [[ -x /usr/sbin/sysctl ]]; then
+  sysctl_cmd="/usr/sbin/sysctl"
+fi
+if [[ -n "${sysctl_cmd}" ]]; then
+  if sysctl_out="$("${sysctl_cmd}" kern.num_files kern.maxfiles kern.maxfilesperproc 2>/dev/null)"; then
+    printf '%s\n' "${sysctl_out}"
+  else
+    printf 'sysctl kern.num_files/kern.maxfiles: unavailable\n'
+  fi
+fi
+
+ps_available=0
+if ps -p "$$" -o pid= >/dev/null 2>&1; then
+  ps_available=1
+fi
+
+if command -v lsof >/dev/null 2>&1; then
+  tmp_lsof="$(mktemp "${TMPDIR:-/tmp}/masc-nofile-lsof.XXXXXX")"
+  if lsof -nP >"${tmp_lsof}" 2>/dev/null; then
+    total_rows="$(wc -l <"${tmp_lsof}" | tr -d ' ')"
+    printf 'total lsof rows: %s\n' "${total_rows}"
+    printf 'top fd holders:\n'
+    awk 'NR > 1 {count[$2]++; name[$2]=$1} END {for (pid in count) print count[pid], pid, name[pid]}' \
+      "${tmp_lsof}" \
+      | sort -nr \
+      | head -20
+    if [[ "${ps_available}" -eq 1 ]]; then
+      printf 'top fd holder commands:\n'
+      awk 'NR > 1 {count[$2]++} END {for (pid in count) print count[pid], pid}' "${tmp_lsof}" \
+        | sort -nr \
+        | head -10 \
+        | while read -r _count pid; do
+          ps -p "${pid}" -o pid=,ppid=,stat=,etime=,command= 2>/dev/null || true
+        done
+    else
+      printf 'top fd holder commands: unavailable (ps failed)\n'
+    fi
+  else
+    printf 'total lsof rows: unavailable (lsof failed)\n'
+  fi
+  rm -f "${tmp_lsof}"
+else
+  printf 'total lsof rows: unavailable (lsof missing)\n'
+fi
+
+printf 'dune/local-build processes:\n'
+if command -v pgrep >/dev/null 2>&1; then
+  if ! pgrep -fl 'dune build|dune test|dune exec|dune-local.sh|me-dune-local.lock'; then
+    if [[ "${ps_available}" -eq 1 ]]; then
+      ps ax -o pid=,command= 2>/dev/null \
+        | grep -E 'dune build|dune test|dune exec|dune-local.sh|me-dune-local.lock' \
+        | grep -v grep || true
+    else
+      printf 'dune/local-build processes: unavailable (pgrep and ps failed)\n'
+    fi
+  fi
+elif [[ "${ps_available}" -eq 1 ]]; then
+  ps ax -o pid=,command= 2>/dev/null \
+    | grep -E 'dune build|dune test|dune exec|dune-local.sh|me-dune-local.lock' \
+    | grep -v grep || true
+else
+  printf 'dune/local-build processes: unavailable (pgrep and ps failed)\n'
+fi
+
+printf 'repo-wide scan processes:\n'
+if [[ "${ps_available}" -eq 1 ]]; then
+  ps ax -o pid=,ppid=,stat=,etime=,command= 2>/dev/null \
+    | awk '
+        /(^|[[:space:]])(bfs|find)[[:space:]]/ &&
+        /masc-mcp/ &&
+        /-exec/ {
+          print
+        }' || true
+else
+  printf 'repo-wide scan processes: unavailable (ps failed)\n'
+fi
+
+printf 'potential bare dune bypasses:\n'
+if [[ "${ps_available}" -eq 1 ]]; then
+  ps ax -o pid=,ppid=,stat=,etime=,command= 2>/dev/null \
+    | awk '
+        /dune (build|test|exec)/ &&
+        $0 !~ /dune-local\.sh/ &&
+        $0 !~ /me-dune-local\.lock/ &&
+        $0 !~ /MASC_DUNE_LOCK_HELD=1/ {
+          print
+        }' || true
+else
+  printf 'potential bare dune bypasses: unavailable (ps failed)\n'
+fi

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -1,7 +1,7 @@
 (** Tests that keeper_bash blocks dangerous commands via allowlist.
 
     Validates:
-    1. Allowed commands (dune, git, rg, etc.) pass validation
+    1. Allowed commands (scripts/dune-local.sh, git, rg, etc.) pass validation
     2. Dangerous commands (rm, curl, kill, etc.) are blocked
     3. Shell metacharacters (;, |, &, etc.) are rejected
     4. Empty commands are rejected *)
@@ -23,7 +23,7 @@ let error_msg = function Error m -> Masc_mcp.Worker_dev_tools.block_reason_to_st
 
 let test_allowed_commands () =
   let allowed = [
-    "dune build";
+    "scripts/dune-local.sh build";
     "git status";
     "git log --oneline -5";
     "rg 'pattern' lib/";
@@ -43,6 +43,8 @@ let test_allowed_commands () =
 
 let test_blocked_commands () =
   let blocked = [
+    "dune build";
+    "opam exec -- dune build";
     "rm -rf /";
     "rm file.txt";
     "curl https://evil.com";
@@ -122,8 +124,8 @@ let test_read_ops_pass () =
     "git status";
     "git log --oneline -5";
     "git diff HEAD";
-    "dune build";
-    "dune exec test.exe";
+    "scripts/dune-local.sh build";
+    "scripts/dune-local.sh exec test.exe";
     "make test";
     "npm run build";
     "npm run dev";

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -385,7 +385,8 @@ let test_validate_code_shell_command_allows_pipe () =
      against the allowlist; dangerous metacharacters remain blocked. *)
   check (result unit string) "piped allowlisted commands accepted"
     (Ok ())
-    (Tool_code_write.validate_code_shell_command "dune build 2>&1 | tail -5")
+    (Tool_code_write.validate_code_shell_command
+       "scripts/dune-local.sh build 2>&1 | tail -5")
 
 let test_validate_code_shell_command_rejects_pipe_to_disallowed () =
   match
@@ -395,9 +396,17 @@ let test_validate_code_shell_command_rejects_pipe_to_disallowed () =
   | Ok () ->
       fail "expected pipe-to-disallowed-command to be rejected by allowlist"
 
-let test_validate_code_shell_command_allows_direct_build () =
-  check (result unit string) "direct build allowed" (Ok ())
-    (Tool_code_write.validate_code_shell_command "dune build 2>&1")
+let test_validate_code_shell_command_allows_dune_local_build () =
+  check (result unit string) "dune-local build allowed" (Ok ())
+    (Tool_code_write.validate_code_shell_command
+       "scripts/dune-local.sh build 2>&1")
+
+let test_validate_code_shell_command_rejects_direct_dune () =
+  match Tool_code_write.validate_code_shell_command "dune build 2>&1" with
+  | Error reason ->
+      check bool "reason mentions dune-local" true
+        (msg_contains ~needle:"scripts/dune-local.sh" reason)
+  | Ok () -> fail "expected bare dune to be rejected"
 
 let test_validate_code_shell_command_allows_grep () =
   check (result unit string) "grep allowed" (Ok ())
@@ -783,8 +792,10 @@ let () =
         test_validate_code_shell_command_allows_pipe;
       test_case "rejects pipe to disallowed command" `Quick
         test_validate_code_shell_command_rejects_pipe_to_disallowed;
-      test_case "allows direct build" `Quick
-        test_validate_code_shell_command_allows_direct_build;
+      test_case "allows dune-local build" `Quick
+        test_validate_code_shell_command_allows_dune_local_build;
+      Alcotest.test_case "rejects direct dune" `Quick
+        test_validate_code_shell_command_rejects_direct_dune;
       test_case "allows grep" `Quick
         test_validate_code_shell_command_allows_grep;
       test_case "uses code shell allowlist hint" `Quick

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -579,6 +579,22 @@ let () =
         | Error Worker_dev_tools.Direct_dune_invocation -> ()
         | Error e -> Alcotest.fail ("wrong rejection: " ^ Worker_dev_tools.block_reason_to_string e)
         | Ok () -> Alcotest.fail "should reject env-wrapped bare dune");
+      Alcotest.test_case "blocks env option wrapped direct dune" `Quick (fun () ->
+        List.iter
+          (fun cmd ->
+            match Worker_dev_tools.validate_command_coding cmd with
+            | Error Worker_dev_tools.Direct_dune_invocation -> ()
+            | Error e ->
+              Alcotest.fail
+                ("wrong rejection for " ^ cmd ^ ": "
+                 ^ Worker_dev_tools.block_reason_to_string e)
+            | Ok () -> Alcotest.fail ("should reject env-wrapped bare dune: " ^ cmd))
+          [
+            "env -- dune build";
+            "env -C repos/masc-mcp dune build";
+            "env --chdir repos/masc-mcp -- dune build";
+            "env -i -- DUNE_JOBS=1 dune build";
+          ]);
       Alcotest.test_case "blocks opam-exec direct dune" `Quick (fun () ->
         match
           Worker_dev_tools.validate_command_coding
@@ -587,6 +603,21 @@ let () =
         | Error Worker_dev_tools.Direct_dune_invocation -> ()
         | Error e -> Alcotest.fail ("wrong rejection: " ^ Worker_dev_tools.block_reason_to_string e)
         | Ok () -> Alcotest.fail "should reject opam-exec bare dune");
+      Alcotest.test_case "blocks opam exec option wrapped direct dune" `Quick (fun () ->
+        List.iter
+          (fun cmd ->
+            match Worker_dev_tools.validate_command_coding cmd with
+            | Error Worker_dev_tools.Direct_dune_invocation -> ()
+            | Error e ->
+              Alcotest.fail
+                ("wrong rejection for " ^ cmd ^ ": "
+                 ^ Worker_dev_tools.block_reason_to_string e)
+            | Ok () -> Alcotest.fail ("should reject opam-exec bare dune: " ^ cmd))
+          [
+            "opam exec --switch default -- dune build";
+            "opam exec --switch=default -- dune build";
+            "opam exec --color never -- dune build";
+          ]);
       Alcotest.test_case "blocks semicolon" `Quick (fun () ->
         match Worker_dev_tools.validate_command_coding "ls; rm -rf /" with
         | Error _ -> ()

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -559,10 +559,34 @@ let () =
         match Worker_dev_tools.validate_command_coding "git log | head -5" with
         | Ok () -> ()
         | Error e -> Alcotest.fail ("should allow pipe: " ^ Worker_dev_tools.block_reason_to_string e));
-      Alcotest.test_case "allows redirect" `Quick (fun () ->
-        match Worker_dev_tools.validate_command_coding "dune build 2>&1" with
+      Alcotest.test_case "allows wrapper redirect" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_command_coding
+            "scripts/dune-local.sh build 2>&1"
+        with
         | Ok () -> ()
         | Error e -> Alcotest.fail ("should allow redirect: " ^ Worker_dev_tools.block_reason_to_string e));
+      Alcotest.test_case "blocks direct dune" `Quick (fun () ->
+        match Worker_dev_tools.validate_command_coding "dune build 2>&1" with
+        | Error Worker_dev_tools.Direct_dune_invocation -> ()
+        | Error e -> Alcotest.fail ("wrong rejection: " ^ Worker_dev_tools.block_reason_to_string e)
+        | Ok () -> Alcotest.fail "should reject bare dune");
+      Alcotest.test_case "blocks env-wrapped direct dune" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_command_coding
+            "env DUNE_JOBS=1 dune build 2>&1"
+        with
+        | Error Worker_dev_tools.Direct_dune_invocation -> ()
+        | Error e -> Alcotest.fail ("wrong rejection: " ^ Worker_dev_tools.block_reason_to_string e)
+        | Ok () -> Alcotest.fail "should reject env-wrapped bare dune");
+      Alcotest.test_case "blocks opam-exec direct dune" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_command_coding
+            "opam exec -- dune build 2>&1"
+        with
+        | Error Worker_dev_tools.Direct_dune_invocation -> ()
+        | Error e -> Alcotest.fail ("wrong rejection: " ^ Worker_dev_tools.block_reason_to_string e)
+        | Ok () -> Alcotest.fail "should reject opam-exec bare dune");
       Alcotest.test_case "blocks semicolon" `Quick (fun () ->
         match Worker_dev_tools.validate_command_coding "ls; rm -rf /" with
         | Error _ -> ()
@@ -604,15 +628,18 @@ let () =
         | Error _ -> ()
         | Ok () -> Alcotest.fail "should block file input redirect");
       Alcotest.test_case "allows 2>&1 redirect" `Quick (fun () ->
-        match Worker_dev_tools.validate_command_coding "dune test 2>&1" with
+        match
+          Worker_dev_tools.validate_command_coding
+            "scripts/dune-local.sh test 2>&1"
+        with
         | Ok () -> ()
         | Error e -> Alcotest.fail ("should allow 2>&1: " ^ Worker_dev_tools.block_reason_to_string e));
       Alcotest.test_case "single-command contract rejects pipe" `Quick (fun () ->
         match
           Worker_dev_tools.validate_command_coding_with_allowlist
             ~allow_pipes:false
-            ~allowed_commands:["dune"; "git"; "head"]
-            "dune build 2>&1 | tail -5"
+            ~allowed_commands:["dune-local.sh"; "git"; "head"]
+            "scripts/dune-local.sh build 2>&1 | tail -5"
         with
         | Error Worker_dev_tools.Pipes_not_allowed -> ()
         | Error reason -> Alcotest.fail ("wrong rejection: " ^ Worker_dev_tools.block_reason_to_string reason)
@@ -621,8 +648,8 @@ let () =
         match
           Worker_dev_tools.validate_command_coding_with_allowlist
             ~allow_pipes:false
-            ~allowed_commands:["dune"; "git"; "head"]
-            "dune build 2>&1"
+            ~allowed_commands:["dune-local.sh"; "git"; "head"]
+            "scripts/dune-local.sh build 2>&1"
         with
         | Ok () -> ()
         | Error e -> Alcotest.fail ("should allow direct build with fd redirect: " ^ Worker_dev_tools.block_reason_to_string e));
@@ -631,7 +658,7 @@ let () =
           Worker_dev_tools.validate_command_coding_with_allowlist
             ~allow_pipes:false
             ~allowed_commands:["git"]
-            "dune build"
+            "scripts/dune-local.sh build"
         with
         | Error _ -> ()
         | Ok () -> Alcotest.fail "should reject command outside custom allowlist");
@@ -1400,7 +1427,7 @@ let () =
              | Some (`String s) -> Some s
              | _ -> None)
         | _ -> Alcotest.fail "evidence must be object");
-      Alcotest.test_case "all 7 block_reason variants → Policy_failed" `Quick
+      Alcotest.test_case "all 8 block_reason variants → Policy_failed" `Quick
         (fun () ->
         let variants =
           [
@@ -1410,6 +1437,7 @@ let () =
             Worker_dev_tools.Process_substitution;
             Worker_dev_tools.Unsafe_redirect;
             Worker_dev_tools.Pipes_not_allowed;
+            Worker_dev_tools.Direct_dune_invocation;
             Worker_dev_tools.Command_not_allowed "foo";
           ]
         in


### PR DESCRIPTION
## Summary

- reject direct `dune`/`env ... dune`/`opam exec -- dune` in local MASC agent shell validators
- allow `scripts/dune-local.sh` as the supported Dune entry point for keeper/code shells
- add `scripts/nofile-status.sh` for operator snapshots of nofile limits, lsof hot spots, Dune bypass processes, and repo-wide `bfs`/`find -exec` scans

## Why

Reopens #15946.

The FD recurrence was not a low host limit: the host is already at `ulimit -n=245760`. The repeated failure mode was agent shells launching bare `dune build --root ...` outside `/tmp/me-dune-local.lock`, which bypasses the existing serialization and can recreate ENFILE/EMFILE pressure.

While validating this patch, a separate live FD amplifier also appeared: a repo-wide `bfs ... masc-mcp -name dune -exec grep ...` scan held more than 20k directory FDs. That process was stopped locally, dropping total `lsof` rows from roughly 44.8k to roughly 24k. The status helper now prints top FD holder command lines when `ps` is available and flags repo-wide `bfs`/`find -exec` scans so this class is visible next time.

## Validation

- `git diff --check origin/main...HEAD`
- `ocamlformat --check lib/keeper/dev_exec_allowlist.ml lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_shell_shared.ml lib/keeper/keeper_tool_alias.ml lib/tool_code_write.ml lib/tool_shard_types.ml lib/worker_dev_tools.ml lib/worker_dev_tools.mli test/test_keeper_bash_safety.ml test/test_tool_code_write_coverage.ml test/test_worker_dev_tools.ml`
- `bash -n scripts/nofile-status.sh`
- `bash scripts/nofile-status.sh`
- `bash scripts/lint-spawn-bounded.sh`
- `bash scripts/ci/check-determinism-contract.sh`
- `env DUNE_JOBS=1 scripts/dune-local.sh build test/test_worker_dev_tools.exe test/test_tool_code_write_coverage.exe test/test_keeper_bash_safety.exe`
- `./_build/default/test/test_worker_dev_tools.exe`
- `./_build/default/test/test_tool_code_write_coverage.exe`

Note: `./_build/default/test/test_keeper_bash_safety.exe` reached the updated allowlist tests, then failed an unrelated environment-sensitive seccomp assertion because this sandbox reports `fd_pressure: system_fd_probe_unknown` before the seccomp path.
