### PR TITLE
feat(rfc-0128-pr-1b): Ide_paths.partition + signature extension

### DIFF
--- a/lib/ide/ide_annotations.ml
+++ b/lib/ide/ide_annotations.ml
@@ -1,4 +1,5 @@
-(** IDE annotation storage — CRUD backed by [.masc-ide/annotations.jsonl].
+(** IDE annotation storage — CRUD backed by [annotations.jsonl] in the
+    selected {!Ide_paths.partition} directory.
 
     In-memory compaction rewrites the store when tombstones exceed
     [COMPACT_THRESHOLD]. *)
@@ -7,13 +8,32 @@ open Ide_annotation_types
 
 let store_path ~base_dir = Ide_paths.store_path ~base_dir
 
-let annotations_file ~base_dir =
-  Filename.concat (store_path ~base_dir) "annotations.jsonl"
+let partition_dir ~base_dir partition =
+  Ide_paths.partition_store_dir ~base_dir partition
 ;;
 
-let ensure_store ~base_dir =
-  let path = store_path ~base_dir in
-  if not (Sys.file_exists path && Sys.is_directory path) then Unix.mkdir path 0o755
+let annotations_file_for ~base_dir partition =
+  Filename.concat (partition_dir ~base_dir partition) "annotations.jsonl"
+;;
+
+let annotations_file ~base_dir =
+  annotations_file_for ~base_dir Ide_paths.Legacy
+;;
+
+(* RFC-0128 §4.2: [_orphan/] and [by-url/<slug>/] live one or two
+   levels deeper than the legacy flat store. Recursive mkdir avoids
+   ENOENT when the parent chain has never been created. *)
+let rec ensure_dir path =
+  if path = "" || path = "/" || (Sys.file_exists path && Sys.is_directory path)
+  then ()
+  else (
+    ensure_dir (Filename.dirname path);
+    try Unix.mkdir path 0o755 with
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+;;
+
+let ensure_store ~base_dir ?(partition = Ide_paths.Legacy) () =
+  ensure_dir (partition_dir ~base_dir partition)
 ;;
 
 let compact_threshold = 0.2
@@ -52,13 +72,11 @@ let annotation_id json =
   | _ -> None
 ;;
 
-let load_all ~base_dir =
-  let path = annotations_file ~base_dir in
+let load_all_partition ~base_dir partition =
+  let path = annotations_file_for ~base_dir partition in
   if not (Sys.file_exists path)
   then []
   else
-    (* Streaming filter + decode — tombstone rejection happens during the
-       fold so the full JSONL list never lands in memory at once. *)
     Fs_compat.fold_jsonl_lines
       ~init:[]
       ~f:(fun acc ~line_no:_ j ->
@@ -72,8 +90,8 @@ let load_all ~base_dir =
     |> List.rev
 ;;
 
-let write_all ~base_dir annotations =
-  let path = annotations_file ~base_dir in
+let write_all_partition ~base_dir partition annotations =
+  let path = annotations_file_for ~base_dir partition in
   let jsons = List.map annotation_to_json annotations in
   let lines = List.map Yojson.Safe.to_string jsons in
   let tmp_path = path ^ ".tmp" in
@@ -89,6 +107,7 @@ let write_all ~base_dir annotations =
 
 let create
       ~base_dir
+      ?(partition = Ide_paths.Legacy)
       ~keeper_id
       ~file_path
       ~line_start
@@ -107,7 +126,7 @@ let create
       ?worker_run_id
       ()
   =
-  ensure_store ~base_dir;
+  ensure_store ~base_dir ~partition ();
   if file_path = ""
   then Error "file_path is required"
   else if line_start < 1 || line_end < line_start
@@ -138,13 +157,15 @@ let create
       ; updated_at_ms = ts
       }
     in
-    Fs_compat.append_jsonl (annotations_file ~base_dir) (annotation_to_json annotation);
+    Fs_compat.append_jsonl
+      (annotations_file_for ~base_dir partition)
+      (annotation_to_json annotation);
     Ok annotation)
 ;;
 
-let list ~base_dir ~filter =
-  ensure_store ~base_dir;
-  let all : annotation list = load_all ~base_dir in
+let list ~base_dir ?(partition = Ide_paths.Legacy) ~filter () =
+  ensure_store ~base_dir ~partition ();
+  let all : annotation list = load_all_partition ~base_dir partition in
   let by_file =
     match filter.file_path with
     | Some fp -> List.filter (fun (a : annotation) -> a.file_path = fp) all
@@ -180,31 +201,31 @@ let list ~base_dir ~filter =
   List.sort (fun a b -> Int64.compare b.created_at_ms a.created_at_ms) by_task
 ;;
 
-let compact ~base_dir =
-  let all = load_all ~base_dir in
-  write_all ~base_dir all
+let compact ~base_dir ?(partition = Ide_paths.Legacy) () =
+  let all = load_all_partition ~base_dir partition in
+  write_all_partition ~base_dir partition all
 ;;
 
-let delete ~base_dir ~id ~keeper_id =
-  ensure_store ~base_dir;
-  let all = load_all ~base_dir in
+let delete ~base_dir ?(partition = Ide_paths.Legacy) ~id ~keeper_id () =
+  ensure_store ~base_dir ~partition ();
+  let all = load_all_partition ~base_dir partition in
   match List.find_opt (fun a -> a.id = id && a.keeper_id = keeper_id) all with
   | None -> Error "annotation not found or keeper mismatch"
   | Some _ ->
     let ts = now_ms () in
-    Fs_compat.append_jsonl (annotations_file ~base_dir) (tombstone_json id keeper_id ts);
-    (* Streaming count — we only need cardinalities to compute the
-       compaction ratio, not the row list itself. *)
+    Fs_compat.append_jsonl
+      (annotations_file_for ~base_dir partition)
+      (tombstone_json id keeper_id ts);
     let tombstone_count =
       Fs_compat.fold_jsonl_lines
         ~init:0
         ~f:(fun acc ~line_no:_ j -> if is_tombstone j then acc + 1 else acc)
-        (annotations_file ~base_dir)
+        (annotations_file_for ~base_dir partition)
     in
     let total = List.length all + tombstone_count in
     if
       total > 0
       && float_of_int tombstone_count /. float_of_int total >= compact_threshold
-    then compact ~base_dir;
+    then compact ~base_dir ~partition ();
     Ok ()
 ;;

--- a/lib/ide/ide_annotations.mli
+++ b/lib/ide/ide_annotations.mli
@@ -1,25 +1,30 @@
-(** IDE annotation storage — CRUD backed by [.masc-ide/annotations.jsonl].
+(** IDE annotation storage — CRUD backed by [annotations.jsonl] inside
+    one of the {!Ide_paths.partition} directories.
 
-    Each project base maintains its own annotation store under
-    [base_dir/.masc-ide/].  The JSONL format is append-only with
-    in-memory compaction on read: deleted annotations are filtered out
-    and the file is rewritten when the tombstone ratio exceeds a threshold.
+    The JSONL format is append-only with in-memory compaction on read:
+    deleted annotations are filtered out and the file is rewritten
+    when the tombstone ratio exceeds a threshold.
 
-    Tombstoned rows are compacted back into the same JSONL file when the
-    tombstone ratio exceeds the threshold. *)
+    RFC-0128 §4.2: callers may select a {!Ide_paths.partition}
+    ([Legacy] / [By_url _] / [Orphan]) via the optional [?partition]
+    argument on every public function. PR-1b adds the parameter with
+    default [Legacy] so existing behaviour is unchanged. PR-1c moves
+    the keeper write path and HTTP read path to [By_url _]. *)
 
 open Ide_annotation_types
 
-(** [store_path ~base_dir] returns [base_dir/.masc-ide/]. *)
 val store_path : base_dir:string -> string
+(** [store_path ~base_dir] returns [base_dir/.masc-ide/] (the legacy
+    flat directory). For partition-aware paths see
+    {!Ide_paths.partition_store_dir}. *)
 
-(** Create [.masc-ide/] directory if absent. Idempotent. *)
-val ensure_store : base_dir:string -> unit
+val ensure_store : base_dir:string -> ?partition:Ide_paths.partition -> unit -> unit
+(** Create the partition's directory if absent. Idempotent. Default
+    [partition] is {!Ide_paths.Legacy}. *)
 
-(** Append a new annotation. Returns the created record with a fresh UUID [id]
-    and [created_at_ms] = [updated_at_ms] = current time. *)
 val create
   :  base_dir:string
+  -> ?partition:Ide_paths.partition
   -> keeper_id:string
   -> file_path:string
   -> line_start:int
@@ -38,18 +43,35 @@ val create
   -> ?worker_run_id:string
   -> unit
   -> (annotation, string) result
+(** Append a new annotation to the chosen partition. Default
+    [partition] is {!Ide_paths.Legacy}. *)
 
-(** Read all annotations for the given filter. Tombstoned entries are excluded.
-    Results are sorted by [created_at_ms] descending (newest first). *)
-val list : base_dir:string -> filter:annotation_filter -> annotation list
+val list
+  :  base_dir:string
+  -> ?partition:Ide_paths.partition
+  -> filter:annotation_filter
+  -> unit
+  -> annotation list
+(** Read all annotations for the chosen partition. Tombstoned entries
+    are excluded. Sorted by [created_at_ms] descending (newest first).
+    Default [partition] is {!Ide_paths.Legacy}. *)
 
-(** Soft-delete: append a tombstone record. Only the original [keeper_id] may
-    delete its own annotation. *)
-val delete : base_dir:string -> id:string -> keeper_id:string -> (unit, string) result
+val delete
+  :  base_dir:string
+  -> ?partition:Ide_paths.partition
+  -> id:string
+  -> keeper_id:string
+  -> unit
+  -> (unit, string) result
+(** Soft-delete: append a tombstone record. Only the original
+    [keeper_id] may delete its own annotation. The [?partition] must
+    match the one the annotation was created under. Default
+    [partition] is {!Ide_paths.Legacy}. *)
 
-(** Rewrite the annotation file excluding tombstones. Called automatically
-    when the tombstone ratio exceeds [COMPACT_THRESHOLD]. *)
-val compact : base_dir:string -> unit
+val compact : base_dir:string -> ?partition:Ide_paths.partition -> unit -> unit
+(** Rewrite the annotation file excluding tombstones. Called
+    automatically when the tombstone ratio exceeds [COMPACT_THRESHOLD].
+    Default [partition] is {!Ide_paths.Legacy}. *)
 
-(** Parse kind string, returning [None] for unknown values. *)
 val annotation_kind_of_string : string -> annotation_kind option
+(** Parse kind string, returning [None] for unknown values. *)

--- a/lib/ide/ide_paths.ml
+++ b/lib/ide/ide_paths.ml
@@ -1,3 +1,139 @@
 let store_subdir = ".masc-ide"
 
 let store_path ~base_dir = Filename.concat base_dir store_subdir
+
+let by_url_subdir = "by-url"
+let orphan_subdir = "_orphan"
+
+let by_url_path ~base_dir ~canonical_url =
+  Filename.concat (Filename.concat (store_path ~base_dir) by_url_subdir) canonical_url
+;;
+
+let orphan_path ~base_dir = Filename.concat (store_path ~base_dir) orphan_subdir
+
+(* RFC-0128 §4.1 — canonical URL slug derivation.
+
+   Accepted shapes:
+     - https://github.com/owner/repo
+     - https://github.com/owner/repo.git
+     - http://host/owner/repo
+     - ssh://git@host/owner/repo.git
+     - git@host:owner/repo.git
+     - git@host:owner/repo
+
+   Output: lowercase host + path joined by '_'. Returns None if input is
+   empty, lacks host or path, or any segment contains characters outside
+   [a-z0-9._-]. The slug is deterministic so the same upstream resolves
+   to the same bucket regardless of which transport the remote was
+   registered with. *)
+
+let starts_with ~prefix s =
+  let n = String.length prefix in
+  String.length s >= n && String.sub s 0 n = prefix
+;;
+
+let strip_prefix ~prefix s =
+  let n = String.length prefix in
+  String.sub s n (String.length s - n)
+;;
+
+let strip_suffix ~suffix s =
+  let ns = String.length s in
+  let nf = String.length suffix in
+  if ns >= nf && String.sub s (ns - nf) nf = suffix
+  then String.sub s 0 (ns - nf)
+  else s
+;;
+
+let split_host_path s =
+  match String.index_opt s '/' with
+  | None -> (s, "")
+  | Some i ->
+    let host = String.sub s 0 i in
+    let path = String.sub s (i + 1) (String.length s - i - 1) in
+    (host, path)
+;;
+
+(* SCP-style "user@host:path" → "host/path". Rewrite only when ':'
+   appears before the first '/' (otherwise ':' is path content). *)
+let normalize_scp_like s =
+  match String.index_opt s '@' with
+  | None -> s
+  | Some at ->
+    let after = String.sub s (at + 1) (String.length s - at - 1) in
+    (match String.index_opt after ':' with
+     | None -> s
+     | Some colon ->
+       (match String.index_opt after '/' with
+        | Some slash when slash < colon -> s
+        | _ ->
+          let host = String.sub after 0 colon in
+          let path = String.sub after (colon + 1) (String.length after - colon - 1) in
+          host ^ "/" ^ path))
+;;
+
+let strip_scheme s =
+  let candidates = [ "https://"; "http://"; "ssh://"; "git://" ] in
+  match List.find_opt (fun p -> starts_with ~prefix:p s) candidates with
+  | Some p -> strip_prefix ~prefix:p s
+  | None -> s
+;;
+
+(* Strip leading "user@" credential when it precedes the host. *)
+let strip_userinfo s =
+  match String.index_opt s '@' with
+  | None -> s
+  | Some at ->
+    (match String.index_opt s '/' with
+     | Some slash when slash < at -> s
+     | _ -> String.sub s (at + 1) (String.length s - at - 1))
+;;
+
+let is_slug_char c =
+  (c >= 'a' && c <= 'z')
+  || (c >= '0' && c <= '9')
+  || c = '_'
+  || c = '-'
+  || c = '.'
+;;
+
+let path_segment_to_slug seg =
+  if seg = "" then None
+  else if String.length seg >= 2 && String.sub seg 0 2 = ".."
+  then None
+  else if String.for_all is_slug_char seg
+  then Some seg
+  else None
+;;
+
+let canonical_url_of_remote raw =
+  let trimmed = String.trim raw in
+  if trimmed = "" then None
+  else
+    let s = String.lowercase_ascii trimmed in
+    let s = normalize_scp_like s in
+    let s = strip_scheme s in
+    let s = strip_userinfo s in
+    let host, path = split_host_path s in
+    if host = "" || path = "" then None
+    else
+      let path = strip_suffix ~suffix:".git" path in
+      let segments =
+        String.split_on_char '/' path |> List.filter (fun seg -> seg <> "")
+      in
+      if segments = [] then None
+      else
+        match path_segment_to_slug host with
+        | None -> None
+        | Some host_slug ->
+          let rec collect acc = function
+            | [] -> Some (List.rev acc)
+            | seg :: rest ->
+              (match path_segment_to_slug seg with
+               | None -> None
+               | Some s -> collect (s :: acc) rest)
+          in
+          (match collect [] segments with
+           | None -> None
+           | Some segs -> Some (String.concat "_" (host_slug :: segs)))
+;;

--- a/lib/ide/ide_paths.ml
+++ b/lib/ide/ide_paths.ml
@@ -11,6 +11,17 @@ let by_url_path ~base_dir ~canonical_url =
 
 let orphan_path ~base_dir = Filename.concat (store_path ~base_dir) orphan_subdir
 
+type partition =
+  | Legacy
+  | By_url of string
+  | Orphan
+
+let partition_store_dir ~base_dir = function
+  | Legacy -> store_path ~base_dir
+  | By_url slug -> by_url_path ~base_dir ~canonical_url:slug
+  | Orphan -> orphan_path ~base_dir
+;;
+
 (* RFC-0128 §4.1 — canonical URL slug derivation.
 
    Accepted shapes:

--- a/lib/ide/ide_paths.mli
+++ b/lib/ide/ide_paths.mli
@@ -31,6 +31,32 @@ val orphan_path : base_dir:string -> string
     Records whose canonical URL cannot be resolved land here so silent
     loss is impossible. *)
 
+type partition =
+  | Legacy
+  | By_url of string
+  | Orphan
+(** RFC-0128 §4.2 store partition selector.
+
+    [Legacy] selects the flat pre-RFC-0128 directory
+    [base_dir/.masc-ide/] (the historical location of
+    [annotations.jsonl] and [regions.jsonl]). New callers should not
+    pass this; it stays as the optional-arg default in PR-1b so
+    every existing call site keeps writing/reading where it used to,
+    and the cut-over to [By_url] happens in PR-1c.
+
+    [By_url slug] selects [base_dir/.masc-ide/by-url/<slug>/]. The
+    caller must obtain [slug] from {!canonical_url_of_remote}.
+
+    [Orphan] selects [base_dir/.masc-ide/_orphan/]. Used when the
+    caller knows a record cannot be assigned to a canonical URL
+    (reverse lookup failed). Silent loss is avoided by routing
+    failures here instead of dropping them. *)
+
+val partition_store_dir : base_dir:string -> partition -> string
+(** [partition_store_dir ~base_dir partition] returns the directory
+    that holds [annotations.jsonl] / [regions.jsonl] for the chosen
+    partition. Total. *)
+
 val canonical_url_of_remote : string -> string option
 (** [canonical_url_of_remote remote] normalises a git remote string
     into a host_path slug, e.g.

--- a/lib/ide/ide_paths.mli
+++ b/lib/ide/ide_paths.mli
@@ -5,10 +5,46 @@
     and HTTP query modules.
 
     Replaces the previously scattered [Filename.concat _ ".masc-ide"]
-    literal flagged in RFC-0084 §1.7 (Scattered hardcoded default). *)
+    literal flagged in RFC-0084 §1.7 (Scattered hardcoded default).
+
+    RFC-0128 §4.1, §4.2 extend this module with canonical-URL slug
+    derivation and partitioned store paths ([by-url/<slug>/],
+    [_orphan/]) so keeper writes from a sandbox clone and IDE reads
+    against the user's working tree can join on the same codebase
+    identity. The slug helpers are pure additions in PR-1a and have
+    zero callers until PR-1b/c wire them. *)
 
 val store_subdir : string
 (** The literal subdirectory name [".masc-ide"]. *)
 
 val store_path : base_dir:string -> string
 (** [store_path ~base_dir] returns [base_dir/.masc-ide]. *)
+
+val by_url_path : base_dir:string -> canonical_url:string -> string
+(** [by_url_path ~base_dir ~canonical_url] returns
+    [base_dir/.masc-ide/by-url/<canonical_url>]. The caller is
+    responsible for ensuring [canonical_url] is a slug returned from
+    [canonical_url_of_remote]. *)
+
+val orphan_path : base_dir:string -> string
+(** [orphan_path ~base_dir] returns [base_dir/.masc-ide/_orphan].
+    Records whose canonical URL cannot be resolved land here so silent
+    loss is impossible. *)
+
+val canonical_url_of_remote : string -> string option
+(** [canonical_url_of_remote remote] normalises a git remote string
+    into a host_path slug, e.g.
+    [https://github.com/jeong-sik/masc-mcp(.git)?] and
+    [git@github.com:jeong-sik/masc-mcp(.git)?] both produce
+    [Some "github.com_jeong-sik_masc-mcp"].
+
+    Returns [None] when:
+    - the input is empty
+    - it lacks a host
+    - it lacks a path
+    - any segment contains a character outside [a-z0-9._-]
+    - any segment begins with [..] (path traversal guard)
+
+    The function is total (never raises) and deterministic. The same
+    upstream resolves to the same slug regardless of which transport
+    the remote was registered with. *)

--- a/lib/ide/ide_region_tracker.ml
+++ b/lib/ide/ide_region_tracker.ml
@@ -102,11 +102,21 @@ let extract_region_from_full_file ~keeper_id ~file_path ~turn ~content =
 let is_file_write_tool name =
   name = "write_file" || name = "edit_file" || name = "apply_patch"
 
-let regions_file ~base_dir =
-  Filename.concat (Ide_paths.store_path ~base_dir) "regions.jsonl"
+let regions_file ~base_dir ?(partition = Ide_paths.Legacy) () =
+  Filename.concat (Ide_paths.partition_store_dir ~base_dir partition) "regions.jsonl"
 
-let append_region ~base_dir region =
-  Fs_compat.append_jsonl (regions_file ~base_dir) (region_to_json region)
+let rec ensure_dir path =
+  if path = "" || path = "/" || (Sys.file_exists path && Sys.is_directory path)
+  then ()
+  else (
+    ensure_dir (Filename.dirname path);
+    try Unix.mkdir path 0o755 with
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+
+let append_region ~base_dir ?(partition = Ide_paths.Legacy) region =
+  let path = regions_file ~base_dir ~partition () in
+  ensure_dir (Filename.dirname path);
+  Fs_compat.append_jsonl path (region_to_json region)
 
 let json_string_field key json =
   match json with
@@ -116,7 +126,7 @@ let json_string_field key json =
       | _ -> None)
   | _ -> None
 
-let ingest_tool_call ~base_dir ~keeper_id ~turn json =
+let ingest_tool_call ~base_dir ?(partition = Ide_paths.Legacy) ~keeper_id ~turn json =
   let tool_name =
     match json with
     | `Assoc fields -> (
@@ -159,4 +169,4 @@ let ingest_tool_call ~base_dir ~keeper_id ~turn json =
                 | Some (`String patch_text) -> extract_regions_from_diff ~keeper_id ~file_path:fp ~turn ~diff_text:patch_text
                 | _ -> [])
         in
-        List.iter (append_region ~base_dir) regions
+        List.iter (append_region ~base_dir ~partition) regions

--- a/lib/ide/ide_region_tracker.mli
+++ b/lib/ide/ide_region_tracker.mli
@@ -32,14 +32,32 @@ val extract_region_from_full_file :
 (** When a Keeper uses [write_file] with full content, the region is
     the entire file (lines 1 to line count of [content]). *)
 
-val regions_file : base_dir:string -> string
-(** Fixed append-only region store path under [.masc-ide/regions.jsonl]. *)
+val regions_file
+  :  base_dir:string
+  -> ?partition:Ide_paths.partition
+  -> unit
+  -> string
+(** Append-only region store path under the chosen
+    {!Ide_paths.partition}. Default [partition] is
+    {!Ide_paths.Legacy} (the pre-RFC-0128 flat
+    [base_dir/.masc-ide/regions.jsonl]). *)
 
-val append_region : base_dir:string -> code_region -> unit
-(** Append one region to [.masc-ide/regions.jsonl]. *)
+val append_region
+  :  base_dir:string
+  -> ?partition:Ide_paths.partition
+  -> code_region
+  -> unit
+(** Append one region to the chosen partition's [regions.jsonl].
+    Default [partition] is {!Ide_paths.Legacy}. *)
 
-val ingest_tool_call :
-  base_dir:string -> keeper_id:string -> turn:int -> Yojson.Safe.t -> unit
-(** Inspect a tool_call JSON record.  If it is a file-writing tool,
-    extract regions and append them to [.masc-ide/regions.jsonl].
-    Non-matching tool_calls are silently ignored. *)
+val ingest_tool_call
+  :  base_dir:string
+  -> ?partition:Ide_paths.partition
+  -> keeper_id:string
+  -> turn:int
+  -> Yojson.Safe.t
+  -> unit
+(** Inspect a tool_call JSON record. If it is a file-writing tool,
+    extract regions and append them to the chosen partition's
+    [regions.jsonl]. Non-matching tool_calls are silently ignored.
+    Default [partition] is {!Ide_paths.Legacy}. *)

--- a/lib/repo_manager/dune
+++ b/lib/repo_manager/dune
@@ -5,6 +5,7 @@
  (public_name masc_mcp.repo_manager)
  (modules
    repo_manager_types
+   repo_store_lookup
    repo_store
    repo_git
    credential_materializer

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -490,3 +490,71 @@ let register_discovered ~base_path =
   | registered ->
       let* () = save_all ~base_path (existing @ registered) in
       Ok registered
+
+(* RFC-0128 §4.5 — reverse lookups.
+
+   These two helpers return raw [url] / [repository] values; the caller
+   normalises the URL with [Ide_paths.canonical_url_of_remote] when it
+   needs a canonical slug. Splitting normalisation out of the lookup
+   keeps [repo_manager] free of a dependency on [masc_ide]. *)
+
+let find_url_by_id ~base_path id =
+  match find ~base_path id with
+  | Ok repo -> if repo.url = "" then None else Some repo.url
+  | Error _ -> None
+
+(* Strip trailing '/' to make prefix comparison robust. *)
+let strip_trailing_slash s =
+  let n = String.length s in
+  if n > 0 && s.[n - 1] = '/' then String.sub s 0 (n - 1) else s
+
+(* [is_path_prefix ~prefix path]: does [path] sit under [prefix] as a
+   directory ancestor, not merely a string prefix? Requires either
+   [path = prefix] or [path] starts with [prefix ^ "/"] to avoid
+   matching siblings like "/a/repos/masc" vs "/a/repos/masc-mirror". *)
+let is_path_prefix ~prefix path =
+  let prefix = strip_trailing_slash prefix in
+  let plen = String.length prefix in
+  if plen = 0 then false
+  else if String.length path = plen && path = prefix then true
+  else if String.length path > plen
+       && String.sub path 0 plen = prefix
+       && path.[plen] = '/'
+  then true
+  else false
+
+let rel_under_path ~prefix path =
+  let prefix = strip_trailing_slash prefix in
+  let plen = String.length prefix in
+  if String.length path = plen then ""
+  else String.sub path (plen + 1) (String.length path - plen - 1)
+
+let find_repo_by_path_prefix ~base_path abs_path =
+  match load_all ~base_path with
+  | Error _ -> None
+  | Ok repos ->
+    (* Longest-match wins. Two repositories rooted at /a/r and /a/r/sub
+       will both match a path under /a/r/sub/...; choose the one with
+       the longer local_path. *)
+    let candidates =
+      List.filter_map
+        (fun (repo : repository) ->
+          let local = local_path ~base_path repo in
+          if is_path_prefix ~prefix:local abs_path
+          then Some (repo, local, rel_under_path ~prefix:local abs_path)
+          else None)
+        repos
+    in
+    match candidates with
+    | [] -> None
+    | _ ->
+      let (best_repo, _, best_rel) =
+        List.fold_left
+          (fun ((_, best_local, _) as best) ((_, local, _) as candidate) ->
+            if String.length local > String.length best_local
+            then candidate
+            else best)
+          (List.hd candidates)
+          (List.tl candidates)
+      in
+      Some (best_repo, best_rel)

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -491,70 +491,10 @@ let register_discovered ~base_path =
       let* () = save_all ~base_path (existing @ registered) in
       Ok registered
 
-(* RFC-0128 §4.5 — reverse lookups.
+module Lookup = Repo_store_lookup.Make (struct
+  let load_all = load_all
+  let local_path = local_path
+end)
 
-   These two helpers return raw [url] / [repository] values; the caller
-   normalises the URL with [Ide_paths.canonical_url_of_remote] when it
-   needs a canonical slug. Splitting normalisation out of the lookup
-   keeps [repo_manager] free of a dependency on [masc_ide]. *)
-
-let find_url_by_id ~base_path id =
-  match find ~base_path id with
-  | Ok repo -> if repo.url = "" then None else Some repo.url
-  | Error _ -> None
-
-(* Strip trailing '/' to make prefix comparison robust. *)
-let strip_trailing_slash s =
-  let n = String.length s in
-  if n > 0 && s.[n - 1] = '/' then String.sub s 0 (n - 1) else s
-
-(* [is_path_prefix ~prefix path]: does [path] sit under [prefix] as a
-   directory ancestor, not merely a string prefix? Requires either
-   [path = prefix] or [path] starts with [prefix ^ "/"] to avoid
-   matching siblings like "/a/repos/masc" vs "/a/repos/masc-mirror". *)
-let is_path_prefix ~prefix path =
-  let prefix = strip_trailing_slash prefix in
-  let plen = String.length prefix in
-  if plen = 0 then false
-  else if String.length path = plen && path = prefix then true
-  else if String.length path > plen
-       && String.sub path 0 plen = prefix
-       && path.[plen] = '/'
-  then true
-  else false
-
-let rel_under_path ~prefix path =
-  let prefix = strip_trailing_slash prefix in
-  let plen = String.length prefix in
-  if String.length path = plen then ""
-  else String.sub path (plen + 1) (String.length path - plen - 1)
-
-let find_repo_by_path_prefix ~base_path abs_path =
-  match load_all ~base_path with
-  | Error _ -> None
-  | Ok repos ->
-    (* Longest-match wins. Two repositories rooted at /a/r and /a/r/sub
-       will both match a path under /a/r/sub/...; choose the one with
-       the longer local_path. *)
-    let candidates =
-      List.filter_map
-        (fun (repo : repository) ->
-          let local = local_path ~base_path repo in
-          if is_path_prefix ~prefix:local abs_path
-          then Some (repo, local, rel_under_path ~prefix:local abs_path)
-          else None)
-        repos
-    in
-    match candidates with
-    | [] -> None
-    | _ ->
-      let (best_repo, _, best_rel) =
-        List.fold_left
-          (fun ((_, best_local, _) as best) ((_, local, _) as candidate) ->
-            if String.length local > String.length best_local
-            then candidate
-            else best)
-          (List.hd candidates)
-          (List.tl candidates)
-      in
-      Some (best_repo, best_rel)
+let find_url_by_id = Lookup.find_url_by_id
+let find_repo_by_path_prefix = Lookup.find_repo_by_path_prefix

--- a/lib/repo_manager/repo_store.mli
+++ b/lib/repo_manager/repo_store.mli
@@ -62,3 +62,28 @@ val register_discovered : base_path:string -> (repository list, string) result
     This is the Week 8 migration helper: existing users with git
     repositories under their base path can call this once to populate
     [repositories.toml] without manual registration. *)
+
+val find_url_by_id : base_path:string -> repository_id -> string option
+(** RFC-0128 §4.5. [find_url_by_id ~base_path id] returns the raw [url]
+    field for the given repository, or [None] when the repository is
+    not registered or has an empty URL. The caller is expected to feed
+    the URL through [Ide_paths.canonical_url_of_remote] to obtain the
+    slug used by [.masc-ide/by-url/]. Splitting normalisation out of
+    the lookup keeps [repo_manager] free of a dependency on
+    [masc_ide]. *)
+
+val find_repo_by_path_prefix
+  :  base_path:string
+  -> string
+  -> (repository * string) option
+(** RFC-0128 §4.5. [find_repo_by_path_prefix ~base_path abs_path]
+    returns the repository whose resolved {!local_path} is a directory
+    ancestor of [abs_path], along with the repo-relative remainder
+    (empty when [abs_path] equals the repository root).
+
+    Selection rule: longest matching {!local_path} wins, so nested
+    registrations (e.g. parent repo and sub-repo) resolve to the
+    inner-most match. Returns [None] when no repository's local path
+    is an ancestor of [abs_path]. Sibling path collisions are avoided
+    by requiring a directory boundary (path equals prefix, or path
+    starts with [prefix ^ "/"]). *)

--- a/lib/repo_manager/repo_store_lookup.ml
+++ b/lib/repo_manager/repo_store_lookup.ml
@@ -1,0 +1,67 @@
+open Repo_manager_types
+
+module type Store = sig
+  val load_all : base_path:string -> (repository list, string) result
+  val local_path : base_path:string -> repository -> string
+end
+
+let strip_trailing_slash s =
+  let n = String.length s in
+  if n > 0 && s.[n - 1] = '/' then String.sub s 0 (n - 1) else s
+
+let is_path_prefix ~prefix path =
+  let prefix = strip_trailing_slash prefix in
+  let plen = String.length prefix in
+  if plen = 0 then false
+  else if String.length path = plen && String.equal path prefix then true
+  else
+    String.length path > plen
+    && String.equal (String.sub path 0 plen) prefix
+    && Char.equal path.[plen] '/'
+
+let rel_under_path ~prefix path =
+  let prefix = strip_trailing_slash prefix in
+  let plen = String.length prefix in
+  if String.length path = plen then ""
+  else String.sub path (plen + 1) (String.length path - plen - 1)
+
+let longest_local_path = function
+  | [] -> None
+  | first :: rest ->
+      Some
+        (List.fold_left
+           (fun ((_, best_local, _) as best) ((_, local, _) as candidate) ->
+             if String.length local > String.length best_local then candidate
+             else best)
+           first rest)
+
+module Make (Store : Store) = struct
+  let find_url_by_id ~base_path id =
+    match Store.load_all ~base_path with
+    | Error _ -> None
+    | Ok repos -> (
+        match
+          List.find_opt
+            (fun (repo : repository) -> String.equal repo.id id)
+            repos
+        with
+        | Some repo when not (String.equal repo.url "") -> Some repo.url
+        | Some _ | None -> None)
+
+  let find_repo_by_path_prefix ~base_path abs_path =
+    match Store.load_all ~base_path with
+    | Error _ -> None
+    | Ok repos ->
+        let candidates =
+          List.filter_map
+            (fun (repo : repository) ->
+              let local = Store.local_path ~base_path repo in
+              if is_path_prefix ~prefix:local abs_path then
+                Some (repo, local, rel_under_path ~prefix:local abs_path)
+              else None)
+            repos
+        in
+        candidates
+        |> longest_local_path
+        |> Option.map (fun (repo, _, rel) -> (repo, rel))
+end

--- a/lib/server/lsp_overlay_provider.ml
+++ b/lib/server/lsp_overlay_provider.ml
@@ -21,7 +21,7 @@ module Cache = struct
         let filter : annotation_filter =
           { file_path = Some file_path; keeper_id = None; goal_id = None; task_id = None }
         in
-        let annotations = Ide_annotations.list ~base_dir ~filter in
+        let annotations = Ide_annotations.list ~base_dir ~filter () in
         Hashtbl.replace tbl k annotations;
         annotations)
 

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -111,7 +111,7 @@ let add_routes router =
            | _ -> None
          in
          let filter = { Ide_annotation_types.file_path; keeper_id; goal_id; task_id } in
-         let annotations = Ide_annotations.list ~base_dir:base ~filter in
+         let annotations = Ide_annotations.list ~base_dir:base ~filter () in
          let json =
            `List (List.map Ide_annotation_types.annotation_to_json annotations)
          in
@@ -243,7 +243,7 @@ let add_routes router =
              (Yojson.Safe.to_string (json_error "Missing id or keeper_id"))
              reqd
          else (
-           match Ide_annotations.delete ~base_dir:base ~id ~keeper_id with
+           match Ide_annotations.delete ~base_dir:base ~id ~keeper_id () with
            | Ok () -> Http.Response.json ~status:`No_content ~request "{}" reqd
            | Error msg ->
              Http.Response.json

--- a/test/dune
+++ b/test/dune
@@ -131,6 +131,7 @@
   test_keeper_chat_store
   test_keeper_runtime_trust_snapshot
   test_ide_annotations
+  test_ide_paths
   test_keeper_runtime_manifest
   test_schema_surface_index
   test_keeper_accountability
@@ -416,6 +417,7 @@
   test_keeper_chat_store
   test_keeper_runtime_trust_snapshot
   test_ide_annotations
+  test_ide_paths
   test_keeper_runtime_manifest
   test_schema_surface_index
   test_keeper_accountability

--- a/test/test_ide_annotations.ml
+++ b/test/test_ide_annotations.ml
@@ -53,7 +53,7 @@ let load_regions base_dir =
       match Types.region_of_json json with
       | Ok region -> region :: acc
       | Error msg -> fail msg)
-    (Region.regions_file ~base_dir)
+    (Region.regions_file ~base_dir ())
   |> List.rev
 ;;
 
@@ -148,7 +148,7 @@ let test_create_lists_route_context () =
         ; task_id = None
         }
       in
-      (match Store.list ~base_dir ~filter with
+      (match Store.list ~base_dir ~filter () with
        | [ listed ] ->
          check string "id" created.id listed.id;
          check (option string) "listed comment" (Some "comment-1") listed.comment_id;
@@ -243,7 +243,7 @@ let test_region_tracker_writes_fixed_regions_file () =
               ; "content", `String "let x = 1\n"
               ] )
         ]);
-    check bool "fixed regions file exists" true (Sys.file_exists (Region.regions_file ~base_dir));
+    check bool "fixed regions file exists" true (Sys.file_exists (Region.regions_file ~base_dir ()));
     match load_regions base_dir with
     | [ region ] ->
       check string "file path" "lib/a.ml" region.Types.file_path;
@@ -275,7 +275,7 @@ let test_meta_sync_flush_writes_fixed_regions_file () =
     let state = Sync.flush_regions config state in
     let stats = Sync.get_stats state in
     check int "pending regions cleared" 0 stats.pending_region_count;
-    check bool "fixed regions file exists" true (Sys.file_exists (Region.regions_file ~base_dir));
+    check bool "fixed regions file exists" true (Sys.file_exists (Region.regions_file ~base_dir ()));
     match load_regions base_dir with
     | [ region ] ->
       check string "file path" "lib/b.ml" region.Types.file_path;
@@ -286,6 +286,166 @@ let test_meta_sync_flush_writes_fixed_regions_file () =
          check int "turn" 8 turn
        | Types.Manual _ -> fail "expected tool-call source")
     | rows -> failf "expected one region, got %d" (List.length rows))
+;;
+
+(* RFC-0128 §4.2 — partition-aware store routing. *)
+
+let make_filter () : Types.annotation_filter =
+  { file_path = None; keeper_id = None; goal_id = None; task_id = None }
+
+let create_in_partition ~base_dir ~partition ~kind ~content () =
+  Store.create
+    ~base_dir
+    ~partition
+    ~keeper_id:"sangsu"
+    ~file_path:"lib/foo.ml"
+    ~line_start:1
+    ~line_end:3
+    ~kind
+    ~content
+    ()
+;;
+
+let test_create_by_url_isolates_from_legacy () =
+  with_temp_dir (fun base_dir ->
+    let slug = "github.com_owner_repo" in
+    let _ =
+      create_in_partition
+        ~base_dir
+        ~partition:(Ide_paths.By_url slug)
+        ~kind:Types.Comment
+        ~content:"in by-url"
+        ()
+    in
+    let by_url =
+      Store.list
+        ~base_dir
+        ~partition:(Ide_paths.By_url slug)
+        ~filter:(make_filter ())
+        ()
+    in
+    let legacy = Store.list ~base_dir ~filter:(make_filter ()) () in
+    check int "by-url count" 1 (List.length by_url);
+    check int "legacy is empty" 0 (List.length legacy))
+;;
+
+let test_create_orphan_separates_from_by_url () =
+  with_temp_dir (fun base_dir ->
+    let slug = "github.com_owner_repo" in
+    let _ =
+      create_in_partition
+        ~base_dir
+        ~partition:Ide_paths.Orphan
+        ~kind:Types.Comment
+        ~content:"orphan record"
+        ()
+    in
+    let _ =
+      create_in_partition
+        ~base_dir
+        ~partition:(Ide_paths.By_url slug)
+        ~kind:Types.Comment
+        ~content:"by-url record"
+        ()
+    in
+    let by_url =
+      Store.list
+        ~base_dir
+        ~partition:(Ide_paths.By_url slug)
+        ~filter:(make_filter ())
+        ()
+    in
+    let orphan =
+      Store.list ~base_dir ~partition:Ide_paths.Orphan ~filter:(make_filter ()) ()
+    in
+    check int "by-url count" 1 (List.length by_url);
+    check int "orphan count" 1 (List.length orphan);
+    let by_url_content = (List.hd by_url).content in
+    let orphan_content = (List.hd orphan).content in
+    check string "by-url content" "by-url record" by_url_content;
+    check string "orphan content" "orphan record" orphan_content)
+;;
+
+let test_legacy_default_is_unchanged () =
+  with_temp_dir (fun base_dir ->
+    (* No ?partition argument → defaults to Legacy → writes to the
+       historical flat path. PR-1c will flip the keeper write path,
+       but until then existing behaviour MUST remain. *)
+    let _ =
+      Store.create
+        ~base_dir
+        ~keeper_id:"sangsu"
+        ~file_path:"lib/foo.ml"
+        ~line_start:1
+        ~line_end:3
+        ~kind:Types.Comment
+        ~content:"legacy default"
+        ()
+    in
+    let legacy_path =
+      Filename.concat
+        (Ide_paths.partition_store_dir ~base_dir Ide_paths.Legacy)
+        "annotations.jsonl"
+    in
+    check bool "legacy file exists" true (Sys.file_exists legacy_path);
+    let legacy = Store.list ~base_dir ~filter:(make_filter ()) () in
+    check int "legacy count" 1 (List.length legacy))
+;;
+
+let test_delete_partition_scoped () =
+  with_temp_dir (fun base_dir ->
+    let slug = "github.com_owner_repo" in
+    let by_url =
+      Result.get_ok
+        (create_in_partition
+           ~base_dir
+           ~partition:(Ide_paths.By_url slug)
+           ~kind:Types.Comment
+           ~content:"to delete"
+           ())
+    in
+    (* Delete in matching partition succeeds; same id in Legacy fails. *)
+    let in_legacy =
+      Store.delete
+        ~base_dir
+        ~partition:Ide_paths.Legacy
+        ~id:by_url.id
+        ~keeper_id:"sangsu"
+        ()
+    in
+    (match in_legacy with
+     | Ok () -> fail "Legacy delete must miss when annotation lives in By_url"
+     | Error _ -> ());
+    let in_by_url =
+      Store.delete
+        ~base_dir
+        ~partition:(Ide_paths.By_url slug)
+        ~id:by_url.id
+        ~keeper_id:"sangsu"
+        ()
+    in
+    (match in_by_url with
+     | Ok () -> ()
+     | Error msg -> failf "By_url delete failed: %s" msg))
+;;
+
+let test_region_append_by_url_isolates_from_legacy () =
+  with_temp_dir (fun base_dir ->
+    let slug = "github.com_owner_repo" in
+    let region : Types.code_region =
+      { keeper_id = "sangsu"
+      ; file_path = "lib/foo.ml"
+      ; line_start = 1
+      ; line_end = 5
+      ; source = Types.Tool_call { tool_name = "write_file"; turn = 0 }
+      ; timestamp_ms = 1L
+      }
+    in
+    Region.append_region ~base_dir ~partition:(Ide_paths.By_url slug) region;
+    let by_url_path = Region.regions_file ~base_dir ~partition:(Ide_paths.By_url slug) () in
+    let legacy_path = Region.regions_file ~base_dir () in
+    check bool "by-url regions exists" true (Sys.file_exists by_url_path);
+    check bool "legacy regions absent" false (Sys.file_exists legacy_path))
 ;;
 
 let () =
@@ -309,6 +469,28 @@ let () =
             "meta sync flush writes fixed regions.jsonl"
             `Quick
             test_meta_sync_flush_writes_fixed_regions_file
+        ] )
+    ; ( "partition (RFC-0128)"
+      , [ test_case
+            "create By_url isolates from Legacy"
+            `Quick
+            test_create_by_url_isolates_from_legacy
+        ; test_case
+            "Orphan and By_url are separate buckets"
+            `Quick
+            test_create_orphan_separates_from_by_url
+        ; test_case
+            "Legacy default is unchanged"
+            `Quick
+            test_legacy_default_is_unchanged
+        ; test_case
+            "delete is partition-scoped"
+            `Quick
+            test_delete_partition_scoped
+        ; test_case
+            "append_region By_url isolates from Legacy"
+            `Quick
+            test_region_append_by_url_isolates_from_legacy
         ] )
     ]
 ;;

--- a/test/test_ide_paths.ml
+++ b/test/test_ide_paths.ml
@@ -1,0 +1,160 @@
+(** Tests for [Ide_paths] — RFC-0128 §6.1 unit tests.
+
+    Verifies that {!Ide_paths.canonical_url_of_remote} is total,
+    deterministic, and produces the same slug regardless of which
+    transport the remote was registered with. *)
+
+open Alcotest
+
+module Paths = Ide_paths
+
+let check_some_slug ~expected ~input () =
+  match Paths.canonical_url_of_remote input with
+  | Some s -> check string ("slug for " ^ input) expected s
+  | None -> failf "expected Some %s for %s, got None" expected input
+;;
+
+let check_none ~input () =
+  match Paths.canonical_url_of_remote input with
+  | None -> ()
+  | Some s -> failf "expected None for %s, got Some %s" input s
+;;
+
+let test_https_simple () =
+  check_some_slug
+    ~expected:"github.com_jeong-sik_masc-mcp"
+    ~input:"https://github.com/jeong-sik/masc-mcp"
+    ()
+;;
+
+let test_https_dot_git () =
+  check_some_slug
+    ~expected:"github.com_jeong-sik_masc-mcp"
+    ~input:"https://github.com/jeong-sik/masc-mcp.git"
+    ()
+;;
+
+let test_http_scheme () =
+  check_some_slug
+    ~expected:"example.com_owner_repo"
+    ~input:"http://example.com/owner/repo"
+    ()
+;;
+
+let test_ssh_url () =
+  check_some_slug
+    ~expected:"github.com_jeong-sik_masc-mcp"
+    ~input:"ssh://git@github.com/jeong-sik/masc-mcp.git"
+    ()
+;;
+
+let test_scp_form () =
+  check_some_slug
+    ~expected:"github.com_jeong-sik_masc-mcp"
+    ~input:"git@github.com:jeong-sik/masc-mcp.git"
+    ()
+;;
+
+let test_scp_form_no_dot_git () =
+  check_some_slug
+    ~expected:"github.com_jeong-sik_masc-mcp"
+    ~input:"git@github.com:jeong-sik/masc-mcp"
+    ()
+;;
+
+let test_https_uppercase () =
+  (* RFC-0128 §4.1 rule 1: lowercase normalisation precedes parsing. *)
+  check_some_slug
+    ~expected:"github.com_jeong-sik_masc-mcp"
+    ~input:"HTTPS://GitHub.com/Jeong-Sik/MASC-MCP.GIT"
+    ()
+;;
+
+let test_nested_path () =
+  check_some_slug
+    ~expected:"gitlab.example.com_group_subgroup_repo"
+    ~input:"https://gitlab.example.com/group/subgroup/repo"
+    ()
+;;
+
+let test_join_invariant_https_ssh () =
+  (* RFC-0128 §4.1 invariant: same upstream in different transport
+     forms must produce the same slug. Without this property
+     sandbox/working-tree join across keepers cannot work. *)
+  let a = Paths.canonical_url_of_remote "https://github.com/jeong-sik/masc-mcp.git" in
+  let b = Paths.canonical_url_of_remote "git@github.com:jeong-sik/masc-mcp.git" in
+  let c = Paths.canonical_url_of_remote "ssh://git@github.com/jeong-sik/masc-mcp" in
+  check (option string) "https == scp" a b;
+  check (option string) "https == ssh-url" a c
+;;
+
+let test_empty () = check_none ~input:"" ()
+let test_whitespace () = check_none ~input:"   " ()
+let test_host_only () = check_none ~input:"https://github.com" ()
+let test_host_only_no_scheme () = check_none ~input:"github.com" ()
+
+let test_path_with_space () =
+  (* Space is not in [a-z0-9._-]. Reject rather than silently slug-replace. *)
+  check_none ~input:"https://github.com/foo bar/baz" ()
+;;
+
+let test_path_traversal () =
+  check_none ~input:"https://github.com/../etc/passwd" ()
+;;
+
+let test_segment_with_colon () =
+  (* ':' inside a path segment (after scp-form already disambiguated)
+     is not a slug character. *)
+  check_none ~input:"https://example.com/foo:bar/baz" ()
+;;
+
+(* Store path constructors. *)
+
+let test_by_url_path () =
+  let p =
+    Paths.by_url_path
+      ~base_dir:"/tmp/base"
+      ~canonical_url:"github.com_jeong-sik_masc-mcp"
+  in
+  check string
+    "by-url path layout"
+    "/tmp/base/.masc-ide/by-url/github.com_jeong-sik_masc-mcp"
+    p
+;;
+
+let test_orphan_path () =
+  check string
+    "orphan path layout"
+    "/tmp/base/.masc-ide/_orphan"
+    (Paths.orphan_path ~base_dir:"/tmp/base")
+;;
+
+let () =
+  run
+    "ide_paths"
+    [ ( "canonical_url_of_remote — accept"
+      , [ test_case "https simple" `Quick test_https_simple
+        ; test_case "https .git suffix" `Quick test_https_dot_git
+        ; test_case "http scheme" `Quick test_http_scheme
+        ; test_case "ssh:// URL" `Quick test_ssh_url
+        ; test_case "scp form" `Quick test_scp_form
+        ; test_case "scp form no .git" `Quick test_scp_form_no_dot_git
+        ; test_case "uppercase normalised" `Quick test_https_uppercase
+        ; test_case "nested path" `Quick test_nested_path
+        ; test_case "join invariant" `Quick test_join_invariant_https_ssh
+        ] )
+    ; ( "canonical_url_of_remote — reject"
+      , [ test_case "empty" `Quick test_empty
+        ; test_case "whitespace" `Quick test_whitespace
+        ; test_case "host only with scheme" `Quick test_host_only
+        ; test_case "host only no scheme" `Quick test_host_only_no_scheme
+        ; test_case "path with space" `Quick test_path_with_space
+        ; test_case "path traversal" `Quick test_path_traversal
+        ; test_case "segment with colon" `Quick test_segment_with_colon
+        ] )
+    ; ( "store path constructors"
+      , [ test_case "by_url_path" `Quick test_by_url_path
+        ; test_case "orphan_path" `Quick test_orphan_path
+        ] )
+    ]
+;;

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -468,6 +468,108 @@ let test_register_discovered_skips_existing () =
         | Error e -> Alcotest.fail ("second register failed: " ^ e)
         | Ok second ->
             Alcotest.(check int) "second count empty" 0 (List.length second))
+
+(* RFC-0128 §4.5 — reverse lookup tests. *)
+
+let with_two_absolute_repos f =
+  with_temp_base_path (fun base_path ->
+    init_empty_store base_path;
+    let masc_path = Filename.concat base_path "workspace/masc" in
+    let oas_path = Filename.concat base_path "workspace/oas" in
+    Unix.mkdir (Filename.concat base_path "workspace") 0o755;
+    Unix.mkdir masc_path 0o755;
+    Unix.mkdir oas_path 0o755;
+    let masc =
+      { (sample_repo "masc") with
+        url = "https://github.com/jeong-sik/masc-mcp"
+      ; local_path = masc_path
+      }
+    in
+    let oas =
+      { (sample_repo "oas") with
+        url = "https://github.com/jeong-sik/oas"
+      ; local_path = oas_path
+      }
+    in
+    (match Repo_store.save_all ~base_path [ masc; oas ] with
+     | Ok () -> ()
+     | Error e -> Alcotest.fail ("save_all: " ^ e));
+    f ~base_path ~masc_path ~oas_path)
+
+let test_find_url_by_id_known () =
+  with_two_absolute_repos (fun ~base_path ~masc_path:_ ~oas_path:_ ->
+    match Repo_store.find_url_by_id ~base_path "masc" with
+    | Some url ->
+      Alcotest.(check string)
+        "masc url"
+        "https://github.com/jeong-sik/masc-mcp"
+        url
+    | None -> Alcotest.fail "expected Some url for masc")
+
+let test_find_url_by_id_unknown () =
+  with_two_absolute_repos (fun ~base_path ~masc_path:_ ~oas_path:_ ->
+    match Repo_store.find_url_by_id ~base_path "nonexistent" with
+    | None -> ()
+    | Some s -> Alcotest.fail ("expected None for unknown, got: " ^ s))
+
+let test_find_repo_by_path_prefix_match () =
+  with_two_absolute_repos (fun ~base_path ~masc_path ~oas_path:_ ->
+    let abs = Filename.concat masc_path "lib/foo.ml" in
+    match Repo_store.find_repo_by_path_prefix ~base_path abs with
+    | Some (repo, rel) ->
+      Alcotest.(check string) "matched repo id" "masc" repo.id;
+      Alcotest.(check string) "relative path" "lib/foo.ml" rel
+    | None -> Alcotest.fail "expected match under masc_path")
+
+let test_find_repo_by_path_prefix_outside () =
+  with_two_absolute_repos (fun ~base_path ~masc_path:_ ~oas_path:_ ->
+    match Repo_store.find_repo_by_path_prefix ~base_path "/tmp/elsewhere.ml" with
+    | None -> ()
+    | Some (repo, _) ->
+      Alcotest.fail ("unexpected match: " ^ repo.id))
+
+let test_find_repo_by_path_prefix_sibling_not_matched () =
+  (* Sibling-style collision: /tmp/masc and /tmp/masc-mirror must not
+     match each other's paths. Guards against pure-substring prefix. *)
+  with_temp_base_path (fun base_path ->
+    init_empty_store base_path;
+    let workspace = Filename.concat base_path "workspace" in
+    Unix.mkdir workspace 0o755;
+    let masc = Filename.concat workspace "masc" in
+    let mirror = Filename.concat workspace "masc-mirror" in
+    Unix.mkdir masc 0o755;
+    Unix.mkdir mirror 0o755;
+    let r1 =
+      { (sample_repo "masc") with
+        url = "https://github.com/owner/masc"
+      ; local_path = masc
+      }
+    in
+    let r2 =
+      { (sample_repo "mirror") with
+        url = "https://github.com/owner/masc-mirror"
+      ; local_path = mirror
+      }
+    in
+    (match Repo_store.save_all ~base_path [ r1; r2 ] with
+     | Ok () -> ()
+     | Error e -> Alcotest.fail ("save_all: " ^ e));
+    let inside_mirror = Filename.concat mirror "lib/x.ml" in
+    match Repo_store.find_repo_by_path_prefix ~base_path inside_mirror with
+    | Some (repo, rel) ->
+      Alcotest.(check string) "must pick mirror, not masc" "mirror" repo.id;
+      Alcotest.(check string) "rel" "lib/x.ml" rel
+    | None -> Alcotest.fail "expected match under mirror")
+
+let test_find_repo_by_path_prefix_root () =
+  (* abs_path equals the repo's local_path itself → empty rel. *)
+  with_two_absolute_repos (fun ~base_path ~masc_path ~oas_path:_ ->
+    match Repo_store.find_repo_by_path_prefix ~base_path masc_path with
+    | Some (repo, rel) ->
+      Alcotest.(check string) "matched repo id" "masc" repo.id;
+      Alcotest.(check string) "empty rel at root" "" rel
+    | None -> Alcotest.fail "expected match at repo root")
+
 let () =
   Alcotest.run "Repo_store"
     [
@@ -539,5 +641,15 @@ let () =
             test_register_discovered_includes_legacy_root_repo;
           Alcotest.test_case "register_discovered skips existing" `Quick
             test_register_discovered_skips_existing;
+        ] );
+      ( "reverse_lookup (RFC-0128)",
+        [
+          Alcotest.test_case "find_url_by_id known" `Quick test_find_url_by_id_known;
+          Alcotest.test_case "find_url_by_id unknown" `Quick test_find_url_by_id_unknown;
+          Alcotest.test_case "path_prefix match" `Quick test_find_repo_by_path_prefix_match;
+          Alcotest.test_case "path_prefix outside" `Quick test_find_repo_by_path_prefix_outside;
+          Alcotest.test_case "path_prefix sibling-safe" `Quick
+            test_find_repo_by_path_prefix_sibling_not_matched;
+          Alcotest.test_case "path_prefix at repo root" `Quick test_find_repo_by_path_prefix_root;
         ] );
     ]


### PR DESCRIPTION
## RFC-0128 Phase 1 — PR-1b (signature extension)

[RFC-0128](https://github.com/jeong-sik/masc-mcp/tree/main/docs/rfc/RFC-0128-ide-canonical-url-partitioning.md) §4.2. Introduces `Ide_paths.partition` and threads `?partition:Ide_paths.partition` through every public function of `Ide_annotations` and `Ide_region_tracker`. **Behaviour 변경 없음** — 모든 기존 caller 가 인자를 안 줘서 `Legacy` 로 fallback. PR-1c 가 keeper write 와 HTTP read 를 `By_url _` 로 cut-over.

> Stacked on PR-1a (#16020). PR-1a 머지 후 자동 rebase 되어 중복 commit drop.
>
> RFC-0128 = #16014 (merged), originally proposed as RFC-0127 then renumbered at merge.

## 변경 시그너처

### `Ide_paths`

```ocaml
type partition =
  | Legacy            (* base_dir/.masc-ide/         — flat pre-RFC-0128 *)
  | By_url of string  (* base_dir/.masc-ide/by-url/<slug>/ *)
  | Orphan            (* base_dir/.masc-ide/_orphan/  — silent loss 회피 *)

val partition_store_dir : base_dir:string -> partition -> string
```

### `Ide_annotations`

| 함수 | 변경 |
|------|------|
| `create` | `?partition:Ide_paths.partition` 추가 (기존 terminal `()` 그대로) |
| `list` | `?partition` 추가 + terminal `()` 추가 (warning 16 회피) |
| `delete` | `?partition` 추가 + terminal `()` 추가 |
| `compact` | `?partition` + terminal `()` |
| `ensure_store` | `?partition` + terminal `()` |

### `Ide_region_tracker`

| 함수 | 변경 |
|------|------|
| `regions_file` | `?partition` + terminal `()` |
| `append_region` | `?partition` (region 이 positional 이라 terminal `()` 불필요) |
| `ingest_tool_call` | `?partition` (json positional 이라 terminal `()` 불필요) |

### Caller wiring (mechanical)

- `lib/server/server_ide_http.ml`: `list`/`delete` 호출에 `()` 추가
- `lib/server/lsp_overlay_provider.ml`: `list` 호출에 `()` 추가
- `test/test_ide_annotations.ml`: 3개 `regions_file` + 1개 `list` 호출에 `()` 추가

PR-1c 가 keeper write path / server_ide_http read path 의 caller 자체를 `By_url` 로 전환.

## RFC §4.2 invariant 입증

`test/test_ide_annotations.ml` 의 새 partition 그룹 5 cases:

| 테스트 | 입증하는 invariant |
|--------|-------------------|
| `create By_url isolates from Legacy` | `By_url _` 에 쓴 record 가 `Legacy` 에 안 보임 (분리) |
| `Orphan and By_url are separate buckets` | 세 partition 이 서로 join 안 함 |
| `Legacy default is unchanged` | 인자 안 주면 기존 flat path — PR-1b backward compat 검증 |
| `delete is partition-scoped` | partition mismatch 면 delete 가 miss |
| `append_region By_url isolates from Legacy` | region_tracker 도 같은 partitioning 적용 |

## Test 결과

- `test_ide_paths` — 18/18 PASS (PR-1a 회귀 없음)
- `test_ide_annotations` — 10/10 PASS (기존 5 + 새 partition 5)
- `test_repo_store` — 33/33 PASS (PR-1a 회귀 없음)
- `dune build --root .` PASS (전체 라이브러리)

## 변경 범위

```
lib/ide/ide_annotations.ml     | +95 / -38
lib/ide/ide_annotations.mli    | +49 / -29
lib/ide/ide_paths.ml           | +11 /  -0
lib/ide/ide_paths.mli          | +24 /  -0
lib/ide/ide_region_tracker.ml  | +16 /  -4
lib/ide/ide_region_tracker.mli | +24 /  -8
lib/server/lsp_overlay_provider.ml | +1 / -1
lib/server/server_ide_http.ml      | +2 / -2
test/test_ide_annotations.ml       | +141 / -3
```

## Test plan

- [x] `dune build --root .` PASS
- [x] 모든 ide / repo / annotations 단위 테스트 PASS
- [x] `bash ~/me/scripts/pr-rfc-check.sh` (flagged subsystem 미접촉)
- [ ] CI required checks (Draft 상태로 관찰)

## Related

- RFC-0128 (spec) — `docs/rfc/RFC-0128-ide-canonical-url-partitioning.md`
- PR-1a #16020 (helpers)
- PR-1c (예정) — keeper write / HTTP read 의 cut-over

Co-Authored-By: claude-opus-4-7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
