### PR TITLE
fix(board): enforce sub-board policy in add_comment (matches create_post)

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -1084,6 +1084,25 @@ let add_comment_with_status
                        (Comment_id.to_string existing.id);
                      Ok (`Dedup_hit existing)
                    | None ->
+                     (* PR #13490 enforced sub-board post policy for
+                        [create_post] but left [add_comment] unguarded —
+                        non-members could comment on [Members_only] /
+                        [Owner_only] sub-boards through any parent post in
+                        that sub-board. The author allowed predicate is
+                        the same one [create_post] uses, applied to the
+                        target post's [hearth].  We run this after the
+                        dedup check (mirroring [create_post]) so an
+                        author whose earlier comment is already on the
+                        post stays idempotent — only fresh attempts hit
+                        the policy gate. *)
+                     (match
+                        validate_sub_board_post_policy_unlocked
+                          store
+                          ~author_id
+                          ~hearth:post.hearth
+                      with
+                      | Error e -> Error e
+                      | Ok () ->
                      (* Check comment count using index after duplicate
                         detection so a retry of an existing comment remains
                         idempotent even on a full thread. *)
@@ -1138,7 +1157,7 @@ let add_comment_with_status
                       { post with reply_count = post.reply_count + 1; updated_at = now };
                     invalidate_post_caches store;
                     invalidate_comment_caches store;
-                    Ok (`Fresh comment))))
+                    Ok (`Fresh comment)))))
             in
             match board_result with
             | Ok (`Fresh comment) ->

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -1047,6 +1047,95 @@ let test_sub_board_owner_only_post_policy () =
    | Error e -> Alcotest.fail (Board.show_board_error e)
    | Ok _ -> ())
 
+(* Issue #16024 / task-314: PR #13490 enforced sub-board policy for
+   [create_post] but the matching gate in [add_comment] was missing,
+   so a non-member could comment on a Members_only sub-board through
+   any post that already lived in that sub-board.  These tests pin the
+   contract: comment policy mirrors post policy on the parent post's
+   hearth. *)
+
+let post_in_sub_board ~author ~slug ~content =
+  match
+    Board_dispatch.create_post ~author ~content
+      ~post_kind:Board.Human_post ~hearth:slug ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post -> Board.Post_id.to_string post.id
+
+let test_sub_board_members_only_comment_policy () =
+  ignore
+    (Board_dispatch.create_sub_board ~slug:"comment-policy-team"
+       ~name:"CommentPolicy" ~description:"" ~owner:"agent-owner"
+       ~members:["agent-member"] ~access:Board.Members_only ());
+  let post_id =
+    post_in_sub_board ~author:"agent-owner"
+      ~slug:"comment-policy-team" ~content:"seed post"
+  in
+  (match
+     Board_dispatch.add_comment ~post_id ~author:"agent-outsider"
+       ~content:"outsider reply" ()
+   with
+   | Error (Board.Validation_error _) -> ()
+   | Error e ->
+     Alcotest.fail ("unexpected error: " ^ Board.show_board_error e)
+   | Ok _ ->
+     Alcotest.fail
+       "expected members-only sub-board to reject outsider comment");
+  (match
+     Board_dispatch.add_comment ~post_id ~author:"agent-member"
+       ~content:"member reply" ()
+   with
+   | Error e -> Alcotest.fail (Board.show_board_error e)
+   | Ok _ -> ());
+  (match
+     Board_dispatch.add_comment ~post_id ~author:"agent-owner"
+       ~content:"owner reply" ()
+   with
+   | Error e -> Alcotest.fail (Board.show_board_error e)
+   | Ok _ -> ())
+
+let test_sub_board_owner_only_comment_policy () =
+  ignore
+    (Board_dispatch.create_sub_board ~slug:"comment-owner-space"
+       ~name:"CommentOwner" ~description:"" ~owner:"agent-owner"
+       ~members:["agent-member"] ~access:Board.Owner_only ());
+  let post_id =
+    post_in_sub_board ~author:"agent-owner"
+      ~slug:"comment-owner-space" ~content:"seed"
+  in
+  (match
+     Board_dispatch.add_comment ~post_id ~author:"agent-member"
+       ~content:"member reply" ()
+   with
+   | Error (Board.Validation_error _) -> ()
+   | Error e ->
+     Alcotest.fail ("unexpected error: " ^ Board.show_board_error e)
+   | Ok _ ->
+     Alcotest.fail
+       "expected owner-only sub-board to reject member comment");
+  (match
+     Board_dispatch.add_comment ~post_id ~author:"agent-owner"
+       ~content:"owner reply" ()
+   with
+   | Error e -> Alcotest.fail (Board.show_board_error e)
+   | Ok _ -> ())
+
+let test_sub_board_open_comment_policy_allows_anyone () =
+  ignore
+    (Board_dispatch.create_sub_board ~slug:"comment-open"
+       ~name:"CommentOpen" ~description:"" ~owner:"agent-owner"
+       ~access:Board.Open ());
+  let post_id =
+    post_in_sub_board ~author:"agent-owner"
+      ~slug:"comment-open" ~content:"seed"
+  in
+  (match
+     Board_dispatch.add_comment ~post_id ~author:"agent-random"
+       ~content:"random reply" ()
+   with
+   | Error e -> Alcotest.fail (Board.show_board_error e)
+   | Ok _ -> ())
+
 let test_sub_board_update () =
   let id =
     match Board_dispatch.create_sub_board ~slug:"update-target" ~name:"Before"
@@ -1216,6 +1305,9 @@ let () =
       Alcotest.test_case "members include owner" `Quick (with_eio test_sub_board_members_include_owner);
       Alcotest.test_case "members-only post policy" `Quick (with_eio test_sub_board_members_only_post_policy);
       Alcotest.test_case "owner-only post policy" `Quick (with_eio test_sub_board_owner_only_post_policy);
+      Alcotest.test_case "members-only comment policy" `Quick (with_eio test_sub_board_members_only_comment_policy);
+      Alcotest.test_case "owner-only comment policy" `Quick (with_eio test_sub_board_owner_only_comment_policy);
+      Alcotest.test_case "open sub-board allows non-member comment" `Quick (with_eio test_sub_board_open_comment_policy_allows_anyone);
       Alcotest.test_case "derived post count" `Quick (with_eio test_sub_board_post_count_projection);
       Alcotest.test_case "update" `Quick (with_eio test_sub_board_update);
       Alcotest.test_case "delete clears orphan hearth" `Quick (with_eio test_sub_board_delete_clears_orphan_hearth);


### PR DESCRIPTION
## Summary

Closes the comment-side gap left by PR #13490. Non-members could comment on `Members_only` / `Owner_only` sub-boards through any post that already lived there — the comment path skipped the policy gate that `create_post` already enforces. This PR runs the same `validate_sub_board_post_policy_unlocked` from `add_comment_with_status` and pins the contract with three Alcotest cases that mirror the existing post-policy tests.

## Symptom (observed)

Surfaced repeatedly on the `.masc` board on 2026-05-17:
- qa-king audit (`p-e3302e9f3a...`) directly named the missing call site.
- taskmaster dispatched task-316 to nick0cave; ramarama posts (`p-...`) flagged the bypass as a board-policy security gap.
- rondo design note (`p-...`) sketched a 1-2 function fix of the same shape.

## Root cause

`lib/board_core.ml:1057-1086` (current main): inside `add_comment_with_status`, the path from `Some post -> ...` jumps straight into dedup + capacity + create. `validate_sub_board_post_policy_unlocked` is never invoked, even though the post carries a `hearth` (sub-board slug) and the helper already exists at `lib/board_core.ml:567-583`.

## Fix

After the dedup check (same ordering as `create_post`, so retries of an existing comment remain idempotent), call `validate_sub_board_post_policy_unlocked store ~author_id ~hearth:post.hearth`. Non-member attempts now return `Validation_error`. Comments on `Open` sub-boards or `hearth = None` posts continue to pass.

## Tests

`test/test_board_dispatch.ml` adds three cases in the `sub_boards` group:

| Test | Asserts |
|------|---------|
| `members-only comment policy` | outsider rejected, member allowed, owner allowed |
| `owner-only comment policy` | member rejected, owner allowed |
| `open sub-board allows non-member comment` | regression guard — the new gate does not over-tighten `Open` access |

All three follow the shape of the existing `members-only post policy` / `owner-only post policy` tests.

## Out of scope

Listed in qa-king's PR #13490 follow-up audit:
- `Automation_post` / `System_post` policy variant tests.
- `members=[]` + `Members_only` edge case (owner-only behaviour by accident).
- Retroactive enforcement after a sub-board access change (Open → Members_only on already-posted authors).

Each is a separate test, not a code fix.

## Local checks

- Type checks (`dune build` for `lib/.masc_mcp.objs/native/masc_mcp__Board_core.cmx` and `Board_dispatch.cmx`) — pass.
- ocamlformat applied.
- Full `dune build @runtest` deferred to CI per `reference_masc_mcp_sandbox_config_unresolved_runtest.md`.

## Refs

- PR #13490 — original sub-board policy enforcement (`create_post` side).
- task-316 / task-314 on the .masc backlog (board dispatch notes).
- qa-king PR #13490 follow-up audit (P0 finding: `append_comment` not policy-gated).

🤖 Co-Authored-By: claude-opus-4-7 <noreply@anthropic.com>