### PR TITLE
feat: account background task fd lifetime

### DIFF
--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -180,6 +180,10 @@ let release_lifetime_guard st =
       st.release_lifetime_guard <- None;
       release ()
 
+let close_task_fds st =
+  Safe_ops.protect ~default:() (fun () -> Unix.close st.handle.stdout_fd);
+  Safe_ops.protect ~default:() (fun () -> Unix.close st.handle.stderr_fd)
+
 let mark_process_finished st status =
   if Option.is_none st.status then st.status <- Some status;
   release_lifetime_guard st
@@ -196,21 +200,26 @@ let with_reg f =
   | v -> Mutex.unlock registry_mu; v
   | exception e -> Mutex.unlock registry_mu; raise e
 
-let start_exit_watcher st =
-  let _watcher =
-    Thread.create
-      (let rec wait () =
-        match Unix.waitpid [] st.handle.pid with
-        | _, status -> with_reg (fun () -> mark_process_finished st status)
-        | exception Unix.Unix_error (Unix.EINTR, _, _) -> wait ()
-        | exception Unix.Unix_error (Unix.ECHILD, _, _) ->
-            with_reg (fun () -> release_lifetime_guard st)
-        | exception exn -> observe_sidecar_failure ~site:"waitpid" exn
-       in
-       wait)
-      ()
-  in
+let default_exit_watcher_thread_create f =
+  let _watcher = Thread.create f () in
   ()
+
+let exit_watcher_thread_create = Atomic.make default_exit_watcher_thread_create
+let set_exit_watcher_thread_create_for_testing f = Atomic.set exit_watcher_thread_create f
+let reset_exit_watcher_thread_create_for_testing () =
+  Atomic.set exit_watcher_thread_create default_exit_watcher_thread_create
+
+let start_exit_watcher st =
+  (Atomic.get exit_watcher_thread_create)
+    (let rec wait () =
+       match Unix.waitpid [] st.handle.pid with
+       | _, status -> with_reg (fun () -> mark_process_finished st status)
+       | exception Unix.Unix_error (Unix.EINTR, _, _) -> wait ()
+       | exception Unix.Unix_error (Unix.ECHILD, _, _) ->
+           with_reg (fun () -> release_lifetime_guard st)
+       | exception exn -> observe_sidecar_failure ~site:"waitpid" exn
+     in
+     wait)
 
 let fresh_id () =
   with_reg (fun () ->
@@ -381,13 +390,12 @@ let poll_state st =
 	       | _, s -> mark_process_finished st s
 	       | exception _ -> ())
     end;
-    if st.status <> None && st.stdout_eof && st.stderr_eof then begin
-	      st.closed <- true;
-	      Safe_ops.protect ~default:() (fun () -> Unix.close st.handle.stdout_fd);
-	      Safe_ops.protect ~default:() (fun () -> Unix.close st.handle.stderr_fd);
-	      try_delete_pid_file st.pid_file
-	    end
-  end
+	    if st.status <> None && st.stdout_eof && st.stderr_eof then begin
+		      st.closed <- true;
+		      close_task_fds st;
+		      try_delete_pid_file st.pid_file
+		    end
+	  end
 
 let poll_all_states () =
   Hashtbl.iter (fun _ st -> poll_state st) registry
@@ -431,6 +439,15 @@ let release_spawn_slot ~keeper =
     let next = max 0 (pending_keeper_count keeper - 1) in
     if next = 0 then Hashtbl.remove pending_spawn_by_keeper keeper
     else Hashtbl.replace pending_spawn_by_keeper keeper next)
+
+let cleanup_failed_registered_spawn ~tid st =
+  Safe_ops.protect ~default:() (fun () ->
+    Process_eio.tree_kill ~pgid:st.handle.pgid ~signal:Sys.sigterm ~grace_sec:0.2);
+  with_reg (fun () ->
+    Hashtbl.remove registry tid;
+    release_lifetime_guard st);
+  close_task_fds st;
+  try_delete_pid_file st.pid_file
 
 let spawn ?base_path ~keeper ~argv ~cwd ~envp ~timeout_sec () =
   match reserve_spawn_slot ~keeper with
@@ -496,8 +513,20 @@ let spawn ?base_path ~keeper ~argv ~cwd ~envp ~timeout_sec () =
 	                let next = max 0 (pending_keeper_count keeper - 1) in
 	                if next = 0 then Hashtbl.remove pending_spawn_by_keeper keeper
 	                else Hashtbl.replace pending_spawn_by_keeper keeper next);
-	            start_exit_watcher st;
-	            Ok tid)
+		            (try
+		               start_exit_watcher st;
+		               Ok tid
+		             with
+		             | Eio.Cancel.Cancelled _ as e ->
+		                 cleanup_failed_registered_spawn ~tid st;
+		                 raise e
+		             | exn ->
+		                 cleanup_failed_registered_spawn ~tid st;
+		                 Error
+		                   (Spawn_failed
+		                      (Printf.sprintf
+		                         "bg_task exit watcher start failed: %s"
+		                         (Printexc.to_string exn)))))
 
 let bufsub buf ~base_offset since =
   let len = Buffer.length buf in

--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -199,12 +199,15 @@ let with_reg f =
 let start_exit_watcher st =
   let _watcher =
     Thread.create
-      (fun () ->
+      (let rec wait () =
         match Unix.waitpid [] st.handle.pid with
         | _, status -> with_reg (fun () -> mark_process_finished st status)
+        | exception Unix.Unix_error (Unix.EINTR, _, _) -> wait ()
         | exception Unix.Unix_error (Unix.ECHILD, _, _) ->
             with_reg (fun () -> release_lifetime_guard st)
-        | exception exn -> observe_sidecar_failure ~site:"waitpid" exn)
+        | exception exn -> observe_sidecar_failure ~site:"waitpid" exn
+       in
+       wait)
       ()
   in
   ()

--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -68,7 +68,16 @@ type state = {
   pid_file : string option;
       (** Full path to the persistence sidecar when
           [~base_path] was supplied at spawn. Deleted on close/kill. *)
+  mutable release_lifetime_guard : (unit -> unit) option;
 }
+
+type lifetime_guard = { acquire : unit -> (unit -> unit) }
+
+let default_lifetime_guard = { acquire = (fun () -> fun () -> ()) }
+let lifetime_guard : lifetime_guard Atomic.t = Atomic.make default_lifetime_guard
+let set_lifetime_guard guard = Atomic.set lifetime_guard guard
+let reset_lifetime_guard_for_testing () = Atomic.set lifetime_guard default_lifetime_guard
+let acquire_lifetime_guard () = (Atomic.get lifetime_guard).acquire ()
 
 (* Tick 7: PID-file helpers. Path convention:
      <base_path>/.masc/keeper/<keeper>/bg/<task_id>.pid
@@ -163,6 +172,13 @@ let delete_pid_file path =
 let try_delete_pid_file = function
   | None -> ()
   | Some path -> ignore (delete_pid_file path : bool)
+
+let release_lifetime_guard st =
+  match st.release_lifetime_guard with
+  | None -> ()
+  | Some release ->
+      st.release_lifetime_guard <- None;
+      release ()
 
 let registry : (string, state) Hashtbl.t = Hashtbl.create 16
 let registry_mu = Mutex.create ()
@@ -349,7 +365,8 @@ let poll_state st =
       st.closed <- true;
       Safe_ops.protect ~default:() (fun () -> Unix.close st.handle.stdout_fd);
       Safe_ops.protect ~default:() (fun () -> Unix.close st.handle.stderr_fd);
-      try_delete_pid_file st.pid_file
+      try_delete_pid_file st.pid_file;
+      release_lifetime_guard st
     end
   end
 
@@ -400,48 +417,65 @@ let spawn ?base_path ~keeper ~argv ~cwd ~envp ~timeout_sec () =
   match reserve_spawn_slot ~keeper with
   | Error err -> Error err
   | Ok () ->
-    match Process_eio.spawn_detached ~argv ~env:envp ~cwd with
-    | Error e ->
-      release_spawn_slot ~keeper;
-      Error (Spawn_failed e)
-    | Ok handle ->
-      try_set_nonblock handle.stdout_fd;
-      try_set_nonblock handle.stderr_fd;
-      let tid = fresh_id () in
-      let pid_file =
-        match base_path with
-        | None | Some "" -> None
-        | Some bp ->
-            let path = pid_file_of ~base_path:bp ~keeper ~task_id:tid in
-            try_write_pid_file path
-              ~pid:handle.pid
-              ~pgid:handle.pgid
-              ~started_at:handle.started_at;
-            Some path
-      in
-      let st =
-        {
-          handle;
-          keeper;
-          timeout_sec;
-          stdout_buf = Buffer.create 4096;
-          stderr_buf = Buffer.create 4096;
-          stdout_base_offset = 0;
-          stderr_base_offset = 0;
-          status = None;
-          closed = false;
-          stdout_eof = false;
-          stderr_eof = false;
-          pid_file;
-        }
-      in
-      with_reg (fun () ->
-        Hashtbl.replace registry tid st;
-        pending_spawn_global := max 0 (!pending_spawn_global - 1);
-        let next = max 0 (pending_keeper_count keeper - 1) in
-        if next = 0 then Hashtbl.remove pending_spawn_by_keeper keeper
-        else Hashtbl.replace pending_spawn_by_keeper keeper next);
-      Ok tid
+    let release_lifetime_guard =
+      try Ok (acquire_lifetime_guard ()) with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+          release_spawn_slot ~keeper;
+          Error
+            (Spawn_failed
+               (Printf.sprintf "bg_task lifetime guard acquire failed: %s"
+                  (Printexc.to_string exn)))
+    in
+    (match release_lifetime_guard with
+    | Error err -> Error err
+    | Ok release_lifetime_guard ->
+        match Process_eio.spawn_detached ~argv ~env:envp ~cwd with
+        | Error e ->
+            release_lifetime_guard ();
+            release_spawn_slot ~keeper;
+            Error (Spawn_failed e)
+        | Ok handle ->
+            try_set_nonblock handle.stdout_fd;
+            try_set_nonblock handle.stderr_fd;
+            let tid = fresh_id () in
+            let pid_file =
+              match base_path with
+              | None | Some "" -> None
+              | Some bp ->
+                  let path =
+                    pid_file_of ~base_path:bp ~keeper ~task_id:tid
+                  in
+                  try_write_pid_file path
+                    ~pid:handle.pid
+                    ~pgid:handle.pgid
+                    ~started_at:handle.started_at;
+                  Some path
+            in
+            let st =
+              {
+                handle;
+                keeper;
+                timeout_sec;
+                stdout_buf = Buffer.create 4096;
+                stderr_buf = Buffer.create 4096;
+                stdout_base_offset = 0;
+                stderr_base_offset = 0;
+                status = None;
+                closed = false;
+                stdout_eof = false;
+                stderr_eof = false;
+                pid_file;
+                release_lifetime_guard = Some release_lifetime_guard;
+              }
+            in
+            with_reg (fun () ->
+                Hashtbl.replace registry tid st;
+                pending_spawn_global := max 0 (!pending_spawn_global - 1);
+                let next = max 0 (pending_keeper_count keeper - 1) in
+                if next = 0 then Hashtbl.remove pending_spawn_by_keeper keeper
+                else Hashtbl.replace pending_spawn_by_keeper keeper next);
+            Ok tid)
 
 let bufsub buf ~base_offset since =
   let len = Buffer.length buf in

--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -180,6 +180,10 @@ let release_lifetime_guard st =
       st.release_lifetime_guard <- None;
       release ()
 
+let mark_process_finished st status =
+  if Option.is_none st.status then st.status <- Some status;
+  release_lifetime_guard st
+
 let registry : (string, state) Hashtbl.t = Hashtbl.create 16
 let registry_mu = Mutex.create ()
 let id_counter = ref 0
@@ -191,6 +195,19 @@ let with_reg f =
   match f () with
   | v -> Mutex.unlock registry_mu; v
   | exception e -> Mutex.unlock registry_mu; raise e
+
+let start_exit_watcher st =
+  let _watcher =
+    Thread.create
+      (fun () ->
+        match Unix.waitpid [] st.handle.pid with
+        | _, status -> with_reg (fun () -> mark_process_finished st status)
+        | exception Unix.Unix_error (Unix.ECHILD, _, _) ->
+            with_reg (fun () -> release_lifetime_guard st)
+        | exception exn -> observe_sidecar_failure ~site:"waitpid" exn)
+      ()
+  in
+  ()
 
 let fresh_id () =
   with_reg (fun () ->
@@ -344,30 +361,29 @@ let poll_state st =
     (match st.status with
      | Some _ -> ()
      | None ->
-         (match Unix.waitpid [ Unix.WNOHANG ] st.handle.pid with
-          | 0, _ -> ()
-          | _, s -> st.status <- Some s
-          | exception Unix.Unix_error (Unix.ECHILD, _, _) ->
-              st.status <- Some (Unix.WEXITED 0)
-          | exception _ -> ()));
+	         (match Unix.waitpid [ Unix.WNOHANG ] st.handle.pid with
+	          | 0, _ -> ()
+	          | _, s -> mark_process_finished st s
+	          | exception Unix.Unix_error (Unix.ECHILD, _, _) ->
+	              mark_process_finished st (Unix.WEXITED 0)
+	          | exception _ -> ()));
     if st.status = None
        && st.timeout_sec > 0.0
        && Unix.gettimeofday () -. st.handle.started_at > st.timeout_sec
     then begin
       Process_eio.tree_kill ~pgid:st.handle.pgid
         ~signal:Sys.sigterm ~grace_sec:2.0;
-      (match Unix.waitpid [ Unix.WNOHANG ] st.handle.pid with
-       | 0, _ -> ()
-       | _, s -> st.status <- Some s
-       | exception _ -> ())
+	      (match Unix.waitpid [ Unix.WNOHANG ] st.handle.pid with
+	       | 0, _ -> ()
+	       | _, s -> mark_process_finished st s
+	       | exception _ -> ())
     end;
     if st.status <> None && st.stdout_eof && st.stderr_eof then begin
-      st.closed <- true;
-      Safe_ops.protect ~default:() (fun () -> Unix.close st.handle.stdout_fd);
-      Safe_ops.protect ~default:() (fun () -> Unix.close st.handle.stderr_fd);
-      try_delete_pid_file st.pid_file;
-      release_lifetime_guard st
-    end
+	      st.closed <- true;
+	      Safe_ops.protect ~default:() (fun () -> Unix.close st.handle.stdout_fd);
+	      Safe_ops.protect ~default:() (fun () -> Unix.close st.handle.stderr_fd);
+	      try_delete_pid_file st.pid_file
+	    end
   end
 
 let poll_all_states () =
@@ -417,11 +433,13 @@ let spawn ?base_path ~keeper ~argv ~cwd ~envp ~timeout_sec () =
   match reserve_spawn_slot ~keeper with
   | Error err -> Error err
   | Ok () ->
-    let release_lifetime_guard =
-      try Ok (acquire_lifetime_guard ()) with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-          release_spawn_slot ~keeper;
+	    let release_lifetime_guard =
+	      try Ok (acquire_lifetime_guard ()) with
+	      | Eio.Cancel.Cancelled _ as e ->
+	          release_spawn_slot ~keeper;
+	          raise e
+	      | exn ->
+	          release_spawn_slot ~keeper;
           Error
             (Spawn_failed
                (Printf.sprintf "bg_task lifetime guard acquire failed: %s"
@@ -472,10 +490,11 @@ let spawn ?base_path ~keeper ~argv ~cwd ~envp ~timeout_sec () =
             with_reg (fun () ->
                 Hashtbl.replace registry tid st;
                 pending_spawn_global := max 0 (!pending_spawn_global - 1);
-                let next = max 0 (pending_keeper_count keeper - 1) in
-                if next = 0 then Hashtbl.remove pending_spawn_by_keeper keeper
-                else Hashtbl.replace pending_spawn_by_keeper keeper next);
-            Ok tid)
+	                let next = max 0 (pending_keeper_count keeper - 1) in
+	                if next = 0 then Hashtbl.remove pending_spawn_by_keeper keeper
+	                else Hashtbl.replace pending_spawn_by_keeper keeper next);
+	            start_exit_watcher st;
+	            Ok tid)
 
 let bufsub buf ~base_offset since =
   let len = Buffer.length buf in

--- a/lib/process/bg_task.mli
+++ b/lib/process/bg_task.mli
@@ -135,6 +135,14 @@ val set_lifetime_guard : lifetime_guard -> unit
 val reset_lifetime_guard_for_testing : unit -> unit
 (** Restore the default no-op guard. Intended for focused tests. *)
 
+val set_exit_watcher_thread_create_for_testing : ((unit -> unit) -> unit) -> unit
+(** Install a process-local exit watcher thread starter. Intended for focused
+    tests that simulate [Thread.create] failure after a detached process has
+    spawned. *)
+
+val reset_exit_watcher_thread_create_for_testing : unit -> unit
+(** Restore the default [Thread.create]-backed exit watcher starter. *)
+
 val set_sidecar_failure_observer : (site:string -> exn -> unit) -> unit
 (** Install the process-local observer for PID sidecar persistence
     failures.  The top-level Prometheus module wires this to

--- a/lib/process/bg_task.mli
+++ b/lib/process/bg_task.mli
@@ -125,8 +125,9 @@ val list_with_started_at : keeper:string -> (task_id * float) list
 type lifetime_guard = { acquire : unit -> (unit -> unit) }
 (** Process-wide guard for long-lived background task resources.
     [acquire ()] runs before {!Process_eio.spawn_detached}; the returned
-    release callback is held until the task reaches [closed = true] and
-    stdout/stderr read FDs have been closed. *)
+    release callback is held until the task process exits or is reaped.
+    stdout/stderr read FDs may remain open until the next {!read} drains
+    and closes the final snapshot. *)
 
 val set_lifetime_guard : lifetime_guard -> unit
 (** Install a process-wide lifetime guard. The default guard is a no-op. *)

--- a/lib/process/bg_task.mli
+++ b/lib/process/bg_task.mli
@@ -122,6 +122,18 @@ val list_with_started_at : keeper:string -> (task_id * float) list
     wall-clock elapsed time without consulting the child process or
     reading the PID file. *)
 
+type lifetime_guard = { acquire : unit -> (unit -> unit) }
+(** Process-wide guard for long-lived background task resources.
+    [acquire ()] runs before {!Process_eio.spawn_detached}; the returned
+    release callback is held until the task reaches [closed = true] and
+    stdout/stderr read FDs have been closed. *)
+
+val set_lifetime_guard : lifetime_guard -> unit
+(** Install a process-wide lifetime guard. The default guard is a no-op. *)
+
+val reset_lifetime_guard_for_testing : unit -> unit
+(** Restore the default no-op guard. Intended for focused tests. *)
+
 val set_sidecar_failure_observer : (site:string -> exn -> unit) -> unit
 (** Install the process-local observer for PID sidecar persistence
     failures.  The top-level Prometheus module wires this to

--- a/lib/server/fd_accountant.ml
+++ b/lib/server/fd_accountant.ml
@@ -87,6 +87,14 @@ let with_slot ~kind f =
     else
       run ()
 
+let acquire_lifetime_slot ~kind () =
+  let { sem ; _ } = state_of kind in
+  Eio.Semaphore.acquire sem;
+  let released = Atomic.make false in
+  fun () ->
+    if Atomic.compare_and_set released false true then
+      Eio.Semaphore.release sem
+
 let configured_concurrency ~kind = (state_of kind).cap
 
 let effective_concurrency ~kind =
@@ -130,11 +138,22 @@ let install_autonomy_exec_sandbox_exec_guard () =
             f ())
     }
 
+let install_bg_task_sandbox_exec_guard () =
+  Bg_task.set_lifetime_guard
+    { Bg_task.acquire =
+        (fun () ->
+          if Eio_guard.is_ready () then
+            acquire_lifetime_slot ~kind:Sandbox_exec ()
+          else
+            fun () -> ())
+    }
+
 let () =
   install_dated_jsonl_log_writer_guard ();
   install_process_eio_sandbox_exec_guard ();
   install_with_process_sandbox_exec_guard ();
-  install_autonomy_exec_sandbox_exec_guard ()
+  install_autonomy_exec_sandbox_exec_guard ();
+  install_bg_task_sandbox_exec_guard ()
 
 (* In-flight count = configured cap minus current semaphore credits.
    Eio.Semaphore exposes [get_value] which returns the available credit

--- a/lib/server/fd_accountant.ml
+++ b/lib/server/fd_accountant.ml
@@ -55,10 +55,11 @@ let _state_for_kind : (kind * slot_state) list =
 
 let state_of kind = List.assoc kind _state_for_kind
 
-(* Shared FD-pressure mutex — when Keeper_fd_pressure.active () is
-   true, all kinds serialize through one global gate. Reuses the
-   pattern from Docker_spawn_throttle (PR #15727). *)
-let _shared_pressure_mutex = Eio.Mutex.create ()
+(* Shared FD-pressure gate — when Keeper_fd_pressure.active () is true,
+   all top-level kinds serialize through one global slot. A semaphore keeps
+   the long-lived Bg_task lifetime path on the same pressure gate as scoped
+   tool calls while still allowing explicit release when the process closes. *)
+let _shared_pressure_gate = Eio.Semaphore.make 1
 
 let held_kinds_key : kind list Eio.Fiber.key = Eio.Fiber.create_key ()
 
@@ -73,27 +74,43 @@ let holds_kind kind = List.exists (( = ) kind) (held_kinds ())
 let with_held_kind kind f =
   Eio.Fiber.with_binding held_kinds_key (kind :: held_kinds ()) f
 
+let pressure_gate_needed () =
+  Keeper_fd_pressure.active () && held_kinds () = []
+
+let acquire_pressure_gate_if_needed () =
+  if not (pressure_gate_needed ())
+  then fun () -> ()
+  else (
+    Eio.Semaphore.acquire _shared_pressure_gate;
+    let released = Atomic.make false in
+    fun () ->
+      if Atomic.compare_and_set released false true then
+        Eio.Semaphore.release _shared_pressure_gate)
+
 let with_slot ~kind f =
   if holds_kind kind then
     f ()
   else
+    let release_pressure = acquire_pressure_gate_if_needed () in
     let { sem ; _ } = state_of kind in
-    Eio.Semaphore.acquire sem ;
     Eio.Switch.run @@ fun sw ->
+    Eio.Switch.on_release sw release_pressure ;
+    Eio.Semaphore.acquire sem ;
     Eio.Switch.on_release sw (fun () -> Eio.Semaphore.release sem) ;
-    let run () = with_held_kind kind f in
-    if Keeper_fd_pressure.active () then
-      Eio.Mutex.use_rw ~protect:true _shared_pressure_mutex run
-    else
-      run ()
+    with_held_kind kind f
 
 let acquire_lifetime_slot ~kind () =
+  let release_pressure = acquire_pressure_gate_if_needed () in
   let { sem ; _ } = state_of kind in
-  Eio.Semaphore.acquire sem;
+  (try Eio.Semaphore.acquire sem with
+   | exn ->
+     release_pressure ();
+     raise exn);
   let released = Atomic.make false in
   fun () ->
-    if Atomic.compare_and_set released false true then
-      Eio.Semaphore.release sem
+    if Atomic.compare_and_set released false true then (
+      Eio.Semaphore.release sem;
+      release_pressure ())
 
 let configured_concurrency ~kind = (state_of kind).cap
 

--- a/lib/server/fd_accountant.mli
+++ b/lib/server/fd_accountant.mli
@@ -58,6 +58,13 @@ val with_slot : kind:kind -> (unit -> 'a) -> 'a
     Exceptions from [f] propagate; the slot is always released
     (via [Eio.Switch.on_release]). *)
 
+val acquire_lifetime_slot : kind:kind -> unit -> (unit -> unit)
+(** [acquire_lifetime_slot ~kind ()] acquires a [kind]-typed slot and
+    returns an idempotent release callback. This is for resources whose FD
+    lifetime intentionally outlives the spawning call, such as background
+    shell tasks. The release callback must be invoked exactly when the
+    underlying FDs are closed; double invocation is ignored. *)
+
 val effective_concurrency : kind:kind -> int
 (** [effective_concurrency ~kind] returns the current cap.
     Returns [1] while [Keeper_fd_pressure.active ()] is true
@@ -97,6 +104,12 @@ val install_autonomy_exec_sandbox_exec_guard : unit -> unit
     child execution as {!Sandbox_exec} while {!Eio_guard} is ready. The slot
     covers the whole child lifetime, including waitpid, timeout handling, and
     stdout/stderr drain. *)
+
+val install_bg_task_sandbox_exec_guard : unit -> unit
+(** [install_bg_task_sandbox_exec_guard ()] installs the process-wide
+    {!Bg_task} lifetime guard that accounts detached background shell tasks as
+    {!Sandbox_exec} while {!Eio_guard} is ready. The slot is held until
+    [Bg_task] observes task closure and closes stdout/stderr FDs. *)
 
 type snapshot = {
   per_kind : (kind * int) list ;

--- a/test/test_bg_task_stub.ml
+++ b/test/test_bg_task_stub.ml
@@ -274,6 +274,24 @@ let test_timeout_enforced () =
   in
   check bool "closed via timeout" true closed
 
+let test_lifetime_guard_released_on_close () =
+  let acquired = ref 0 in
+  let released = ref 0 in
+  Bg_task.set_lifetime_guard
+    { Bg_task.acquire =
+        (fun () ->
+          incr acquired;
+          fun () -> incr released)
+    };
+  Fun.protect ~finally:Bg_task.reset_lifetime_guard_for_testing (fun () ->
+      let tid =
+        sp ~keeper:"kp-lifetime-guard" [ "/bin/echo"; "guarded" ]
+      in
+      check int "guard acquired at spawn" 1 !acquired;
+      check int "guard not released before close" 0 !released;
+      check bool "task closed" true (poll_for_closed tid);
+      check int "guard released on close" 1 !released)
+
 let test_global_capacity_blocks_detached_stampede () =
   with_bg_task_limits ~global:"1" ~per_keeper:"4" (fun () ->
       let first = sp ~keeper:"kp-cap-a" [ "/bin/sleep"; "30" ] in
@@ -518,6 +536,8 @@ let () =
             test_list_tracks_keeper;
           test_case "timeout enforcement fires tree_kill" `Quick
             test_timeout_enforced;
+          test_case "lifetime guard releases on task close" `Quick
+            test_lifetime_guard_released_on_close;
           test_case "global capacity blocks detached stampede" `Quick
             test_global_capacity_blocks_detached_stampede;
         ] );

--- a/test/test_bg_task_stub.ml
+++ b/test/test_bg_task_stub.ml
@@ -285,12 +285,50 @@ let test_lifetime_guard_released_on_close () =
     };
   Fun.protect ~finally:Bg_task.reset_lifetime_guard_for_testing (fun () ->
       let tid =
-        sp ~keeper:"kp-lifetime-guard" [ "/bin/echo"; "guarded" ]
+        sp ~keeper:"kp-lifetime-guard" [ "/bin/sleep"; "1" ]
       in
       check int "guard acquired at spawn" 1 !acquired;
       check int "guard not released before close" 0 !released;
+      ignore (Bg_task.kill tid ~signal:Sys.sigterm ~grace_sec:0.2);
       check bool "task closed" true (poll_for_closed tid);
       check int "guard released on close" 1 !released)
+
+let test_exit_watcher_failure_rolls_back_spawn () =
+  let acquired = ref 0 in
+  let released = ref 0 in
+  Bg_task.set_lifetime_guard
+    { Bg_task.acquire =
+        (fun () ->
+          incr acquired;
+          fun () -> incr released)
+    };
+  Bg_task.set_exit_watcher_thread_create_for_testing (fun _ ->
+      raise (Failure "thread budget exhausted"));
+  Fun.protect
+    ~finally:(fun () ->
+      Bg_task.reset_exit_watcher_thread_create_for_testing ();
+      Bg_task.reset_lifetime_guard_for_testing ())
+    (fun () ->
+      match
+        Bg_task.spawn ~keeper:"kp-exit-watch-fail"
+          ~argv:[ "/bin/sleep"; "10" ]
+          ~cwd:"" ~envp:(env_of_current ()) ~timeout_sec:0.0 ()
+      with
+      | Error (Bg_task.Spawn_failed msg) ->
+          check bool "spawn reports exit watcher failure" true
+            (String_util.contains_substring msg "exit watcher start failed");
+          check int "guard acquired" 1 !acquired;
+          check int "guard released on rollback" 1 !released;
+          check (list string) "registry rollback removes task" []
+            (List.map Bg_task.task_id_to_string
+               (Bg_task.list ~keeper:"kp-exit-watch-fail"))
+      | Error (Bg_task.Too_many_tasks _) ->
+          fail "unexpected capacity failure"
+      | Error (Bg_task.Invalid_cwd msg) ->
+          failf "unexpected invalid cwd: %s" msg
+      | Ok tid ->
+          ignore (Bg_task.kill tid ~signal:Sys.sigterm ~grace_sec:0.2);
+          fail "spawn succeeded despite exit watcher failure")
 
 let test_global_capacity_blocks_detached_stampede () =
   with_bg_task_limits ~global:"1" ~per_keeper:"4" (fun () ->
@@ -538,6 +576,8 @@ let () =
             test_timeout_enforced;
           test_case "lifetime guard releases on task close" `Quick
             test_lifetime_guard_released_on_close;
+          test_case "exit watcher failure rolls back spawn" `Quick
+            test_exit_watcher_failure_rolls_back_spawn;
           test_case "global capacity blocks detached stampede" `Quick
             test_global_capacity_blocks_detached_stampede;
         ] );

--- a/test/test_fd_accountant.ml
+++ b/test/test_fd_accountant.ml
@@ -346,6 +346,69 @@ let test_bg_task_lifetime_serializes_under_fd_pressure () =
         (wait_until ~clock ~attempts:200 (fun () ->
            kind_in_flight FA.Sandbox_exec = 0)))
 
+let test_bg_task_lifetime_releases_after_exit_without_read () =
+  Eio_main.run @@ fun env ->
+  Eio_guard.enable () ;
+  Fun.protect
+    ~finally:(fun () ->
+      Bg_task.reset_lifetime_guard_for_testing () ;
+      Eio_guard.disable ())
+    (fun () ->
+      Bg_task.reset_lifetime_guard_for_testing () ;
+      FA.install_bg_task_sandbox_exec_guard () ;
+      let tid =
+        match
+          Bg_task.spawn ~keeper:"fd-accountant-exit-watch"
+            ~argv:[ "/bin/sleep"; "0.01" ]
+            ~cwd:"" ~envp:(Unix.environment ()) ~timeout_sec:0.0 ()
+        with
+        | Ok tid -> tid
+        | Error _ -> Alcotest.fail "Bg_task spawn failed"
+      in
+      check int "Bg_task holds sandbox slot after spawn" 1
+        (kind_in_flight FA.Sandbox_exec) ;
+      let clock = Eio.Stdenv.clock env in
+      check bool "Bg_task sandbox slot releases after process exit" true
+        (wait_until ~clock ~attempts:500 (fun () ->
+           kind_in_flight FA.Sandbox_exec = 0)) ;
+      ignore (Bg_task.read tid ~since_stdout:0 ~since_stderr:0))
+
+let test_bg_task_cancelled_lifetime_acquire_releases_pending_slot () =
+  Eio_main.run @@ fun env ->
+  let keeper = "fd-accountant-cancelled-acquire" in
+  Fun.protect
+    ~finally:Bg_task.reset_lifetime_guard_for_testing
+    (fun () ->
+      Bg_task.set_lifetime_guard
+        { Bg_task.acquire =
+            (fun () -> raise (Eio.Cancel.Cancelled (Failure "synthetic")))
+        } ;
+      for _ = 1 to 2 do
+        try
+          ignore
+            (Bg_task.spawn ~keeper ~argv:[ "/bin/sleep"; "0.01" ]
+               ~cwd:"" ~envp:(Unix.environment ()) ~timeout_sec:0.0 ())
+        with
+        | Eio.Cancel.Cancelled _ -> ()
+      done ;
+      Bg_task.reset_lifetime_guard_for_testing () ;
+      let tid =
+        match
+          Bg_task.spawn ~keeper ~argv:[ "/bin/sleep"; "0.01" ]
+            ~cwd:"" ~envp:(Unix.environment ()) ~timeout_sec:0.0 ()
+        with
+        | Ok tid -> tid
+        | Error (Bg_task.Too_many_tasks _) ->
+            Alcotest.fail "cancelled lifetime acquire leaked pending slot"
+        | Error _ -> Alcotest.fail "Bg_task spawn failed"
+      in
+      let clock = Eio.Stdenv.clock env in
+      check bool "Bg_task closes after cancelled acquire recovery" true
+        (wait_until ~clock ~attempts:500 (fun () ->
+           match Bg_task.read tid ~since_stdout:0 ~since_stderr:0 with
+           | Ok snapshot -> snapshot.closed
+           | Error _ -> false)))
+
 let () =
   Alcotest.run "Fd_accountant"
     [
@@ -392,5 +455,9 @@ let () =
             test_bg_task_uses_sandbox_lifetime_slot ;
           test_case "Bg_task lifetime serializes under FD pressure" `Quick
             test_bg_task_lifetime_serializes_under_fd_pressure ;
+          test_case "Bg_task lifetime releases after process exit" `Quick
+            test_bg_task_lifetime_releases_after_exit_without_read ;
+          test_case "Bg_task cancelled lifetime acquire releases pending slot" `Quick
+            test_bg_task_cancelled_lifetime_acquire_releases_pending_slot ;
         ] ) ;
     ]

--- a/test/test_fd_accountant.ml
+++ b/test/test_fd_accountant.ml
@@ -290,6 +290,62 @@ let test_bg_task_uses_sandbox_lifetime_slot () =
       check int "Bg_task sandbox slot released on close" 0
         (kind_in_flight FA.Sandbox_exec))
 
+let test_bg_task_lifetime_serializes_under_fd_pressure () =
+  Eio_main.run @@ fun env ->
+  Eio_guard.enable () ;
+  Masc_mcp.Keeper_fd_pressure.reset_for_tests () ;
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_fd_pressure.reset_for_tests () ;
+      Bg_task.reset_lifetime_guard_for_testing () ;
+      Eio_guard.disable ())
+    (fun () ->
+      Bg_task.reset_lifetime_guard_for_testing () ;
+      FA.install_bg_task_sandbox_exec_guard () ;
+      Masc_mcp.Keeper_fd_pressure.note ~site:"fd_accountant_test"
+        ~detail:"too many open files" () ;
+      let clock = Eio.Stdenv.clock env in
+      let first =
+        match
+          Bg_task.spawn ~keeper:"fd-accountant-pressure-a"
+            ~argv:[ "/bin/sleep"; "0.05" ]
+            ~cwd:"" ~envp:(Unix.environment ()) ~timeout_sec:0.0 ()
+        with
+        | Ok tid -> tid
+        | Error _ -> Alcotest.fail "first Bg_task spawn failed"
+      in
+      check int "first Bg_task holds sandbox slot" 1
+        (kind_in_flight FA.Sandbox_exec) ;
+      let second_started = Atomic.make false in
+      Eio.Switch.run @@ fun sw ->
+      Eio.Fiber.fork ~sw (fun () ->
+          match
+            Bg_task.spawn ~keeper:"fd-accountant-pressure-b"
+              ~argv:[ "/bin/sleep"; "0.01" ]
+              ~cwd:"" ~envp:(Unix.environment ()) ~timeout_sec:0.0 ()
+          with
+          | Ok tid ->
+              Atomic.set second_started true ;
+              ignore
+                (wait_until ~clock ~attempts:200 (fun () ->
+                   match Bg_task.read tid ~since_stdout:0 ~since_stderr:0 with
+                   | Ok snapshot -> snapshot.closed
+                   | Error _ -> false))
+          | Error _ -> Alcotest.fail "second Bg_task spawn failed") ;
+      Eio.Time.sleep clock 0.005 ;
+      check bool "second Bg_task waits for pressure slot" false
+        (Atomic.get second_started) ;
+      check bool "first Bg_task eventually closes" true
+        (wait_until ~clock ~attempts:200 (fun () ->
+           match Bg_task.read first ~since_stdout:0 ~since_stderr:0 with
+           | Ok snapshot -> snapshot.closed
+           | Error _ -> false)) ;
+      check bool "second Bg_task starts after pressure slot release" true
+        (wait_until ~clock ~attempts:200 (fun () -> Atomic.get second_started)) ;
+      check bool "Bg_task sandbox slots eventually release" true
+        (wait_until ~clock ~attempts:200 (fun () ->
+           kind_in_flight FA.Sandbox_exec = 0)))
+
 let () =
   Alcotest.run "Fd_accountant"
     [
@@ -334,5 +390,7 @@ let () =
             test_autonomy_exec_run_uses_sandbox_slot ;
           test_case "Bg_task uses sandbox lifetime slot" `Quick
             test_bg_task_uses_sandbox_lifetime_slot ;
+          test_case "Bg_task lifetime serializes under FD pressure" `Quick
+            test_bg_task_lifetime_serializes_under_fd_pressure ;
         ] ) ;
     ]

--- a/test/test_fd_accountant.ml
+++ b/test/test_fd_accountant.ml
@@ -260,6 +260,36 @@ let test_autonomy_exec_run_uses_sandbox_slot () =
       check int "Autonomy_exec sandbox slot released" 0
         (kind_in_flight FA.Sandbox_exec))
 
+let test_bg_task_uses_sandbox_lifetime_slot () =
+  Eio_main.run @@ fun env ->
+  Eio_guard.enable () ;
+  Fun.protect
+    ~finally:(fun () ->
+      Bg_task.reset_lifetime_guard_for_testing () ;
+      Eio_guard.disable ())
+    (fun () ->
+      Bg_task.reset_lifetime_guard_for_testing () ;
+      FA.install_bg_task_sandbox_exec_guard () ;
+      let tid =
+        match
+          Bg_task.spawn ~keeper:"fd-accountant-bg-task"
+            ~argv:[ "/bin/sleep"; "0.05" ]
+            ~cwd:"" ~envp:(Unix.environment ()) ~timeout_sec:0.0 ()
+        with
+        | Ok tid -> tid
+        | Error _ -> Alcotest.fail "Bg_task spawn failed"
+      in
+      check int "Bg_task holds sandbox slot after spawn" 1
+        (kind_in_flight FA.Sandbox_exec) ;
+      let clock = Eio.Stdenv.clock env in
+      check bool "Bg_task eventually closes" true
+        (wait_until ~clock ~attempts:200 (fun () ->
+             match Bg_task.read tid ~since_stdout:0 ~since_stderr:0 with
+             | Ok snapshot -> snapshot.closed
+             | Error _ -> false)) ;
+      check int "Bg_task sandbox slot released on close" 0
+        (kind_in_flight FA.Sandbox_exec))
+
 let () =
   Alcotest.run "Fd_accountant"
     [
@@ -302,5 +332,7 @@ let () =
             test_with_process_uses_sandbox_slot ;
           test_case "Autonomy_exec run uses sandbox slot" `Quick
             test_autonomy_exec_run_uses_sandbox_slot ;
+          test_case "Bg_task uses sandbox lifetime slot" `Quick
+            test_bg_task_uses_sandbox_lifetime_slot ;
         ] ) ;
     ]


### PR DESCRIPTION
## Summary
- add a Bg_task lifetime guard hook for detached background task resources
- add an idempotent Fd_accountant lifetime lease and install it as Sandbox_exec for Bg_task while Eio is ready
- hold the slot until Bg_task observes task closure and closes stdout/stderr read FDs
- cover the low-level guard and Fd_accountant integration in focused tests

## Verification
- ocamlformat --check lib/process/bg_task.ml lib/process/bg_task.mli lib/server/fd_accountant.ml lib/server/fd_accountant.mli test/test_bg_task_stub.ml test/test_fd_accountant.ml
- git diff --check origin/main...HEAD
- bash scripts/ci/check-determinism-contract.sh
- scripts/dune-local.sh build test/test_bg_task_stub.exe test/test_fd_accountant.exe
- ./_build/default/test/test_fd_accountant.exe
- ./_build/default/test/test_bg_task_stub.exe

## Note
- Running both test binaries concurrently produced one timing failure in the pre-existing background capacity test; the same bg_task binary passed when rerun alone. These background process tests should be treated as sequential.