### PR TITLE
fix(keeper): move docker runtime mounts out of playground

### DIFF
--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -243,8 +243,14 @@ let docker_nofile_args () =
   [ "--ulimit"; Printf.sprintf "nofile=%d:%d" limit limit ]
 ;;
 
+let container_masc_runtime_base ~container_root:_ = "/tmp/masc-runtime"
+
+let container_masc_dir ~container_root =
+  Filename.concat (container_masc_runtime_base ~container_root) Common.masc_dirname
+;;
+
 let container_masc_config_dir ~container_root =
-  Filename.concat (Filename.concat container_root Common.masc_dirname) "config"
+  Filename.concat (container_masc_dir ~container_root) "config"
 ;;
 
 let host_masc_config_dir ~base_path =
@@ -263,7 +269,7 @@ let docker_masc_config_mount_args ~base_path ~container_root =
 ;;
 
 let docker_masc_runtime_env_pairs ~container_root =
-  [ Env_config_core.base_path_env_key, container_root
+  [ Env_config_core.base_path_env_key, container_masc_runtime_base ~container_root
   ; Env_config_core.config_dir_env_key, container_masc_config_dir ~container_root
   ]
 ;;
@@ -300,7 +306,7 @@ let docker_config_host_root ~base_path =
 ;;
 
 let docker_config_container_root ~container_root =
-  Filename.concat (Filename.concat container_root Common.masc_dirname) "config"
+  container_masc_config_dir ~container_root
 ;;
 
 let docker_config_available host_config_root =
@@ -359,7 +365,10 @@ let unique_preserving_order values =
 
 let docker_room_state_mount_specs ~base_path ~container_root =
   let host_masc_root = Common.masc_dir_from_base_path ~base_path in
-  let container_masc_root = Filename.concat container_root Common.masc_dirname in
+  (* [container_root] is itself a bind-mounted playground. Mounting room-state
+     files inside it creates nested bind targets that Docker Desktop can resolve
+     through /run/host_virtiofs and reject as outside the container rootfs. *)
+  let container_masc_root = container_masc_dir ~container_root in
   docker_room_state_mounts
   |> List.concat_map (fun (kind, rel_path) ->
     let host_path = Filename.concat host_masc_root rel_path in
@@ -382,10 +391,11 @@ let docker_config_env_args ~base_path ~container_root =
   then []
   else
     let container_config_root = docker_config_container_root ~container_root in
+    let container_base_path = container_masc_runtime_base ~container_root in
     [ "--env"
-    ; "MASC_BASE_PATH=" ^ container_root
+    ; "MASC_BASE_PATH=" ^ container_base_path
     ; "--env"
-    ; "MASC_BASE_PATH_INPUT=" ^ container_root
+    ; "MASC_BASE_PATH_INPUT=" ^ container_base_path
     ; "--env"
     ; "MASC_CONFIG_DIR=" ^ container_config_root
     ]

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -118,14 +118,18 @@ val docker_network_args : Keeper_types.network_mode -> string list * string
     sandbox containers. *)
 val docker_nofile_args : unit -> string list
 
-(** Container-visible config root under the keeper playground. *)
+(** Container-visible MASC runtime base outside the keeper playground bind
+    mount. *)
+val container_masc_runtime_base : container_root:string -> string
+
+(** Container-visible config root under {!container_masc_runtime_base}. *)
 val container_masc_config_dir : container_root:string -> string
 
 (** Host-side config root for a MASC base path. *)
 val host_masc_config_dir : base_path:string -> string
 
 (** Docker [-v ...] spec that exposes [<base_path>/.masc/config] read-only
-    as [<container_root>/.masc/config]. *)
+    under {!container_masc_runtime_base}. *)
 val docker_masc_config_mount_spec : base_path:string -> container_root:string -> string
 
 (** Docker [-v ...] argv fragment for the MASC config bind mount. *)
@@ -147,23 +151,24 @@ val docker_user_env_args : unit -> string list
     [<base_path>/.masc/config]. *)
 val docker_config_host_root : base_path:string -> string
 
-(** Container-side config root under the keeper playground. *)
+(** Container-side config root under {!container_masc_runtime_base}. *)
 val docker_config_container_root : container_root:string -> string
 
 (** Docker [-v ...] argv fragment that exposes the active config root
-    read-only at [<container_root>/.masc/config]. Returns [[]] when the
-    host config root is absent. *)
+    read-only under {!container_masc_runtime_base}. Returns [[]] when the host
+    config root is absent. *)
 val docker_config_mount_args
   :  base_path:string
   -> container_root:string
   -> string list
 
 (** Docker [-v ...] specs for the read-only room-state subset that keeper
-    task worktrees may read through their container-side [.masc]
+    task worktrees may read through their container-side runtime [.masc]
     projection. This intentionally excludes auth, credentials, locks,
     logs, metrics, and keeper private state. Existing paths are mounted
-    only under [<container_root>/.masc]; host-absolute [.masc] targets
-    must never be used as Docker mount destinations. *)
+    outside [<container_root>] because that path is itself a bind-mounted
+    playground; host-absolute [.masc] targets must never be used as Docker
+    mount destinations. *)
 val docker_room_state_mount_specs
   :  base_path:string
   -> container_root:string

--- a/lib/keeper/keeper_sandbox_session_plan.mli
+++ b/lib/keeper/keeper_sandbox_session_plan.mli
@@ -89,7 +89,7 @@ type t
       ttl_sec-if-given); the edge adds [owner_pid] + [started_at].
     - [mounts] — the workspace volume ([host_root:container_root:rw]),
       the read-only MASC config mount
-      ([<base_path>/.masc/config:<container_root>/.masc/config:ro]),
+      ([<base_path>/.masc/config:<container-runtime-base>/.masc/config:ro]),
       followed by the two identity mounts
       ([<host_root>/.docker-identity/passwd:/etc/passwd:ro], [.../group:/etc/group:ro]).
     - [identity_files] — the [(passwd_path, passwd_content);

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -529,20 +529,20 @@ let test_docker_masc_config_binding_pins_container_runtime_paths () =
     (Keeper_sandbox_runtime.host_masc_config_dir ~base_path:base);
   Alcotest.(check string)
     "container config dir"
-    "/home/keeper/playground/minjae/.masc/config"
+    "/tmp/masc-runtime/.masc/config"
     (Keeper_sandbox_runtime.container_masc_config_dir ~container_root);
   Alcotest.(check (list string))
     "runtime env args"
     [ "--env"
-    ; "MASC_BASE_PATH=/home/keeper/playground/minjae"
+    ; "MASC_BASE_PATH=/tmp/masc-runtime"
     ; "--env"
-    ; "MASC_CONFIG_DIR=/home/keeper/playground/minjae/.masc/config"
+    ; "MASC_CONFIG_DIR=/tmp/masc-runtime/.masc/config"
     ]
     (Keeper_sandbox_runtime.docker_masc_runtime_env_args ~container_root);
   Alcotest.(check (list string))
     "config bind mount"
     [ "-v"
-    ; expected_host_config ^ ":/home/keeper/playground/minjae/.masc/config:ro"
+    ; expected_host_config ^ ":/tmp/masc-runtime/.masc/config:ro"
     ]
     (Keeper_sandbox_runtime.docker_masc_config_mount_args
        ~base_path:base
@@ -560,18 +560,18 @@ let test_docker_config_mount_and_env_args () =
     (Keeper_sandbox_runtime.docker_config_host_root ~base_path:base);
   Alcotest.(check (list string)) "default config mount"
     [ "-v"
-    ; config_root ^ ":" ^ container_root ^ "/.masc/config:ro"
+    ; config_root ^ ":/tmp/masc-runtime/.masc/config:ro"
     ]
     (Keeper_sandbox_runtime.docker_config_mount_args
        ~base_path:base
        ~container_root);
   Alcotest.(check (list string)) "default config env"
     [ "--env"
-    ; "MASC_BASE_PATH=" ^ container_root
+    ; "MASC_BASE_PATH=/tmp/masc-runtime"
     ; "--env"
-    ; "MASC_BASE_PATH_INPUT=" ^ container_root
+    ; "MASC_BASE_PATH_INPUT=/tmp/masc-runtime"
     ; "--env"
-    ; "MASC_CONFIG_DIR=" ^ container_root ^ "/.masc/config"
+    ; "MASC_CONFIG_DIR=/tmp/masc-runtime/.masc/config"
     ]
     (Keeper_sandbox_runtime.docker_config_env_args
        ~base_path:base
@@ -586,7 +586,7 @@ let test_docker_config_mount_and_env_args () =
     (Keeper_sandbox_runtime.docker_config_host_root ~base_path:base);
   Alcotest.(check (list string)) "override config mount"
     [ "-v"
-    ; override_root ^ ":" ^ container_root ^ "/.masc/config:ro"
+    ; override_root ^ ":/tmp/masc-runtime/.masc/config:ro"
     ]
     (Keeper_sandbox_runtime.docker_config_mount_args
        ~base_path:base
@@ -609,22 +609,30 @@ let test_docker_room_state_mount_args_expose_safe_subset () =
   in
   let tasks_host = Filename.concat masc_root "tasks" in
   let board_host = Filename.concat masc_root "board_posts.jsonl" in
-  Alcotest.(check bool) "mounts tasks under container .masc" true
+  Alcotest.(check bool) "mounts tasks under runtime .masc" true
     (List.mem
-       (tasks_host ^ ":" ^ container_root ^ "/.masc/tasks:ro")
+       (tasks_host ^ ":/tmp/masc-runtime/.masc/tasks:ro")
        specs);
   Alcotest.(check bool) "does not mount tasks at host absolute target" false
     (List.mem (tasks_host ^ ":" ^ tasks_host ^ ":ro") specs);
   Alcotest.(check bool) "mounts board posts" true
     (List.mem
-       (board_host ^ ":" ^ container_root ^ "/.masc/board_posts.jsonl:ro")
+       (board_host ^ ":/tmp/masc-runtime/.masc/board_posts.jsonl:ro")
        specs);
-  Alcotest.(check bool) "all targets stay under container .masc" true
+  Alcotest.(check bool) "all targets stay under runtime .masc" true
     (List.for_all
        (fun spec ->
          match String.split_on_char ':' spec with
          | [ _source; target; "ro" ] ->
-           String.starts_with ~prefix:(container_root ^ "/.masc/") target
+           String.starts_with ~prefix:"/tmp/masc-runtime/.masc/" target
+         | _ -> false)
+       specs);
+  Alcotest.(check bool) "no targets nested under playground bind mount" true
+    (List.for_all
+       (fun spec ->
+         match String.split_on_char ':' spec with
+         | [ _source; target; "ro" ] ->
+           not (String.starts_with ~prefix:(container_root ^ "/") target)
          | _ -> false)
        specs);
   Alcotest.(check bool) "does not mount auth" false

--- a/test/test_keeper_sandbox_session_plan.ml
+++ b/test/test_keeper_sandbox_session_plan.ml
@@ -81,7 +81,7 @@ let test_mounts_workspace_then_identity () =
     (list string)
     "workspace volume first, then config, passwd, group mounts"
     [ "/var/masc/alice:/keeper/alice:rw"
-    ; "/srv/masc/.masc/config:/keeper/alice/.masc/config:ro"
+    ; "/srv/masc/.masc/config:/tmp/masc-runtime/.masc/config:ro"
     ; "/var/masc/alice/.docker-identity/passwd:/etc/passwd:ro"
     ; "/var/masc/alice/.docker-identity/group:/etc/group:ro"
     ]
@@ -109,8 +109,8 @@ let test_env_overrides () =
     ; "USER", "keeper"
     ; "LOGNAME", "keeper"
     ; "SHELL", "/bin/sh"
-    ; "MASC_BASE_PATH", "/keeper/alice"
-    ; "MASC_CONFIG_DIR", "/keeper/alice/.masc/config"
+    ; "MASC_BASE_PATH", "/tmp/masc-runtime"
+    ; "MASC_CONFIG_DIR", "/tmp/masc-runtime/.masc/config"
     ]
     (Keeper_sandbox_session_plan.env_overrides p)
 ;;
@@ -140,8 +140,8 @@ let test_env_overrides_extra () =
       ; "USER", "keeper"
       ; "LOGNAME", "keeper"
       ; "SHELL", "/bin/sh"
-      ; "MASC_BASE_PATH", "/r"
-      ; "MASC_CONFIG_DIR", "/r/.masc/config"
+      ; "MASC_BASE_PATH", "/tmp/masc-runtime"
+      ; "MASC_CONFIG_DIR", "/tmp/masc-runtime/.masc/config"
       ; "FOO", "bar"
       ]
       (Keeper_sandbox_session_plan.env_overrides p)

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -969,14 +969,18 @@ let test_docker_shell_mounts_masc_config_runtime_paths () =
          line
          (host_config_dir ^ ":" ^ container_config_dir ^ ":ro"));
     Alcotest.(check bool) "container MASC_BASE_PATH pinned" true
-      (contains_substring line ("MASC_BASE_PATH=" ^ container_root));
+      (contains_substring line "MASC_BASE_PATH=/tmp/masc-runtime");
     Alcotest.(check bool) "container MASC_CONFIG_DIR pinned" true
       (contains_substring line ("MASC_CONFIG_DIR=" ^ container_config_dir));
     Alcotest.(check bool) "oneshot container has ttl label" true
       (contains_substring line "masc.mcp.ttl_sec=");
     Alcotest.(check bool) "oneshot cleanup attempts docker rm" true
       (contains_substring log "\nrm -f masc-keeper-");
-    Alcotest.(check bool) "room tasks mounted under container root" true
+    Alcotest.(check bool) "room tasks mounted under runtime root" true
+      (contains_substring
+         line
+         (tasks_host ^ ":/tmp/masc-runtime/.masc/tasks:ro"));
+    Alcotest.(check bool) "room tasks not nested under playground bind mount" false
       (contains_substring
          line
          (tasks_host ^ ":" ^ container_root ^ "/.masc/tasks:ro"));


### PR DESCRIPTION
## Summary

- move keeper Docker MASC runtime/config/room-state bind targets from the playground mount to `/tmp/masc-runtime/.masc`
- keep the writable playground mount at `container_root`, but stop nesting read-only room-state binds under it
- update Docker argv/env contract tests to assert room-state targets are not under the playground bind mount

## Why

Live keepers repeatedly reported OCI startup failures such as:

`mountpoint .../.masc/playground/<keeper>/.masc/<state-file> is outside of rootfs`

The failure pattern matches nested bind targets: `container_root` is already a bind-mounted playground, and the runtime file mounts were targeting `container_root/.masc/...`. Docker Desktop can resolve those targets through `/run/host_virtiofs`, outside runc's rootfs boundary.

## Verification

- `ocamlformat --check lib/keeper/keeper_sandbox_runtime.ml lib/keeper/keeper_sandbox_runtime.mli lib/keeper/keeper_sandbox_session_plan.mli test/test_keeper_docker_read.ml test/test_keeper_sandbox_session_plan.ml test/test_keeper_shell_docker_route.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_docker_read.exe test/test_keeper_sandbox_session_plan.exe test/test_keeper_shell_docker_route.exe`
- `./_build/default/test/test_keeper_docker_read.exe`
- `./_build/default/test/test_keeper_sandbox_session_plan.exe`
- `./_build/default/test/test_keeper_shell_docker_route.exe` with escalation because the local sandbox denied the macOS `sysctl` FD probe; rerun passed
- `bash scripts/ci/check-determinism-contract.sh`
