### PR TITLE
fix(coord_worktree): pass git_fetch_timeout_sec to git clone

### DIFF
--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -1136,8 +1136,13 @@ let auto_provision_sandbox_clone ~config ~agent_name ~repos_dir ~repo_name =
                          origin_url err)))
              | Ok () ->
                  let origin_url = normalize_github_clone_url origin_url in
+                 (* Network-bound clone: default local_op_timeout_sec (30s)
+                    aborts at ~25% on 6464-file repos (#9587 same root).
+                    Use the longer git_fetch_timeout_sec budget. *)
                  let status, output =
-                   run_argv_with_status [ "git"; "clone"; origin_url; clone_path ]
+                   run_argv_with_status
+                     ~timeout_sec:(Env_config_core.git_fetch_timeout_sec ())
+                     [ "git"; "clone"; origin_url; clone_path ]
                  in
                  if status <> Unix.WEXITED 0 then
                    Error


### PR DESCRIPTION
## Summary

Keeper sandbox auto-provision fails on `masc-mcp` clone because `coord_worktree.ml:1140` calls `git clone` without explicit `timeout_sec`, falling back to the local-op default (30s). On a 6464-file repo the clone aborts at ~25% (1616/6464 files updated).

The fetch path at line 1337 already migrated to `git_fetch_timeout_sec` (120s default) in #9587 and carries an explanatory comment. The clone path was the only remaining git-network site missed — N-of-M migration completion.

## Live log evidence

```
WARN  [Process_eio] Timeout after 30s: 'git' 'clone' 'https://github.com/jeong-sik/masc-mcp.git' '/Users/dancer/me/.masc/playground/echo/repos/masc-mcp'
ERROR tool masc_worktree_create returned error result: auto_provision_clone_failed: ... Updating files: 25% (1616/6464)
ERROR keeper:echo tool_error: masc_worktree_create — auto_provision_clone_failed
ERROR registry: recording crash name=rondo (and others)
```

Affected keepers observed: `echo`, `rondo`.

## Diff

```ocaml
+(* Network-bound clone: default local_op_timeout_sec (30s)
+   aborts at ~25% on 6464-file repos (#9587 same root).
+   Use the longer git_fetch_timeout_sec budget. *)
 let status, output =
-  run_argv_with_status [ "git"; "clone"; origin_url; clone_path ]
+  run_argv_with_status
+    ~timeout_sec:(Env_config_core.git_fetch_timeout_sec ())
+    [ "git"; "clone"; origin_url; clone_path ]
 in
```

## Test plan

- [ ] CI passes (no test changes; existing exec_gate harness covers signature)
- [ ] After merge, restart keepers and verify `masc_worktree_create` succeeds without 30s timeout

## Risk

Single timeout-arg passing. `MASC_GIT_FETCH_TIMEOUT_SEC` env override remains available (default 120s). Reversible.

## Future hardening (separate PRs)

1. **shallow clone** (`git clone --depth 1`) — reduces bytes transferred for sandbox use cases that don't need full history.
2. **Local cache** (`--reference` or `git worktree`) — for repeated keeper provisioning of the same repo.
3. **Migration audit**: `rg 'run_argv_with_status \\[ "git"; "(clone|fetch|push|pull|ls-remote)"' lib/` to lint future network-op-without-budget regressions.

🤖 /loop iteration #12 — surfaced by user keeper report ("shell repo clone 안된다고 난리임")

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>