### PR TITLE
feat(rfc-0128-pr-1c): keeper write + HTTP read cut-over to By_url partition

### DIFF
--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -216,10 +216,63 @@ let raise_fs_edit_error ?fields message =
   raise (Fs_edit_error (error_json ?fields message))
 ;;
 
+(* RFC-0128 §4.5 — resolve an absolute or base-relative file_path to
+   a partition + repo-relative path. Three outcomes:
+
+   1. [Repo_store.find_repo_by_path_prefix] hits AND the repo's [url]
+      normalises via [Ide_paths.canonical_url_of_remote] → [By_url slug]
+      bucket + the repo-relative [rel_path].
+   2. [Repo_store.find_repo_by_path_prefix] hits but the URL is blank or
+      unparseable → [Orphan] + original path. Counter labelled
+      [reason=blank_url] or [reason=url_unparseable].
+   3. No registered repo contains this path → [Orphan] + original path.
+      Counter labelled [reason=unregistered_repo].
+
+   The keeper write path is fire-and-forget; this resolver also never
+   raises — failures during [load_all] degrade to [Orphan] silently
+   with the [reason=unregistered_repo] label so the operator can see
+   how often it happens. *)
+let resolve_partition_for_write ~base_dir ~kind ~file_path =
+  let abs =
+    if Filename.is_relative file_path
+    then Filename.concat base_dir file_path
+    else file_path
+  in
+  let bump_orphan ~reason =
+    Prometheus.inc_counter
+      Keeper_metrics.metric_ide_orphan_writes
+      ~labels:[ "kind", kind; "reason", reason ]
+      ()
+  in
+  match Repo_store.find_repo_by_path_prefix ~base_path:base_dir abs with
+  | None ->
+    bump_orphan ~reason:"unregistered_repo";
+    (Ide_paths.Orphan, file_path)
+  | Some (repo, rel) ->
+    let url = String.trim repo.url in
+    if url = "" then begin
+      bump_orphan ~reason:"blank_url";
+      (Ide_paths.Orphan, file_path)
+    end
+    else
+      match Ide_paths.canonical_url_of_remote url with
+      | None ->
+        bump_orphan ~reason:"url_unparseable";
+        (Ide_paths.Orphan, file_path)
+      | Some slug -> (Ide_paths.By_url slug, rel)
+;;
+
 (** After a successful file write, record the code region in [.masc-ide/].
     Fire-and-forget: errors are logged but never block the write path.
     Uses [Ide_region_tracker.ingest_tool_call] which silently ignores
-    non-file-write tools. *)
+    non-file-write tools.
+
+    RFC-0128 §4.5: the partition is resolved per-write from the
+    [file_path] so sandbox-clone keeper writes and working-tree IDE
+    reads see the same [By_url <slug>] bucket. When the path cannot
+    be resolved to a registered repo the record goes to
+    [.masc-ide/_orphan/] and the [masc_ide_orphan_writes_total]
+    counter increments. *)
 let track_write_region
       ~config
       ~keeper_name
@@ -232,6 +285,9 @@ let track_write_region
       ()
   =
   let base_dir = Keeper_alerting_path.project_root_of_config config in
+  let partition, rel_file_path =
+    resolve_partition_for_write ~base_dir ~kind:"region" ~file_path
+  in
   let tool_name =
     match fs_write_mode_of_string_opt mode_raw with
     | Some Patch -> "edit_file"
@@ -266,7 +322,7 @@ let track_write_region
        file_path
        (Printexc.to_string exn));
   let arguments =
-    let fields = [ "path", `String file_path; "content", `String content ] in
+    let fields = [ "path", `String rel_file_path; "content", `String content ] in
     match fs_write_mode_of_string_opt mode_raw with
     | Some Patch ->
       `Assoc
@@ -277,6 +333,7 @@ let track_write_region
   try
     Ide_region_tracker.ingest_tool_call
       ~base_dir
+      ~partition
       ~keeper_id:keeper_name
       ~turn
       tool_call_json

--- a/lib/keeper/keeper_exec_fs.mli
+++ b/lib/keeper/keeper_exec_fs.mli
@@ -1,5 +1,27 @@
 (** Keeper filesystem tool handlers — read and edit. *)
 
+val resolve_partition_for_write
+  :  base_dir:string
+  -> kind:string
+  -> file_path:string
+  -> Ide_paths.partition * string
+(** RFC-0128 §4.5. Reverse-lookup helper used by [track_write_region]
+    to decide which {!Ide_paths.partition} bucket a keeper write
+    belongs to and what its repo-relative file path is. Exposed for
+    testing so the sandbox/working-tree join invariant can be
+    verified directly.
+
+    Returns:
+    - [(By_url slug, rel_path)] when the file lives under a registered
+      repository whose [url] normalises via
+      {!Ide_paths.canonical_url_of_remote}. [rel_path] is the path
+      relative to that repository's [local_path].
+    - [(Orphan, original_path)] otherwise. Increments
+      [masc_ide_orphan_writes_total] with the failure reason label
+      ([unregistered_repo] / [blank_url] / [url_unparseable]).
+
+    [kind] selects the metric label ([annotation] or [region]). *)
+
 (** Issue #8490: Variant SSOT for fs write mode. Mirror in
     [Tool_shard.fs_write_mode_enum_strings] (cycle avoidance, sync
     regression test catches drift). *)

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -538,6 +538,12 @@ let metric_keeper_tool_underused_allowed_count =
 let metric_keeper_tool_underused_allowed = "masc_keeper_tool_underused_allowed"
 let metric_keeper_path_rejection = "masc_keeper_path_rejection_total"
 
+(* RFC-0128 §4.2 — counter for records that could not be assigned to a
+   canonical-URL bucket and landed in [.masc-ide/_orphan/]. Labels:
+   [kind = "annotation" | "region"], [reason = "unregistered_repo"
+   | "blank_url" | "url_unparseable"]. *)
+let metric_ide_orphan_writes = "masc_ide_orphan_writes_total"
+
 let metric_keeper_path_resolver_identity_mismatch =
   "masc_keeper_path_resolver_identity_mismatch_total"
 ;;

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -308,6 +308,12 @@ val metric_keeper_tool_underused_allowed_count : string
 val metric_keeper_tool_underused_allowed : string
 val metric_keeper_path_rejection : string
 val metric_keeper_path_resolver_identity_mismatch : string
+
+val metric_ide_orphan_writes : string
+(** RFC-0128 §4.2 — increments when an IDE annotation/region write
+    cannot be assigned to a canonical-URL bucket and lands in
+    [.masc-ide/_orphan/]. Counter labels:
+    [kind = "annotation" | "region"], [reason]. *)
 val metric_keeper_heartbeat_successes : string
 val metric_keeper_heartbeat_failures : string
 val metric_keeper_cleanup_tracking_failures : string

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -2699,6 +2699,12 @@ let init () =
     "Keeper path rejections (sandbox escape / outside roots). Labels: kind."
     Counter;
   add
+    Keeper_metrics.metric_ide_orphan_writes
+    "RFC-0128 §4.2: IDE annotation/region writes that landed in \
+     .masc-ide/_orphan/ because the canonical URL could not be resolved. \
+     Labels: kind (annotation | region), reason."
+    Counter;
+  add
     Keeper_metrics.metric_keeper_provider_cooldown_remaining_sec
     "Provider cooldown remaining seconds. Labels: keeper, provider."
     Gauge;

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -34,6 +34,40 @@ let resolve_workspace_base ~state ~uri =
     ~keeper_param:(Uri.get_query_param uri "keeper")
 ;;
 
+(* RFC-0128 §4.5 — resolve the partition for a query.
+
+   Priority:
+     1. [?canonical_url=...] explicit override (still re-normalised so a
+        misspelt query falls back to Legacy rather than silently
+        creating a new bucket).
+     2. [?repo_id=...] → lookup repo.url in [Repo_store] → normalise.
+     3. Default → [Legacy] so traffic that has not been updated to use
+        either parameter keeps reading the historical flat store.
+
+   PR-1d removes the [Legacy] fallback once the data migration runs. *)
+let resolve_partition_for_query ~state ~uri =
+  let project_base = base_path_of_state state in
+  let from_canonical =
+    match Uri.get_query_param uri "canonical_url" with
+    | Some s when String.trim s <> "" -> Ide_paths.canonical_url_of_remote s
+    | _ -> None
+  in
+  let from_repo_id () =
+    match Uri.get_query_param uri "repo_id" with
+    | Some id when String.trim id <> "" ->
+      (match Repo_store.find_url_by_id ~base_path:project_base id with
+       | Some url -> Ide_paths.canonical_url_of_remote url
+       | None -> None)
+    | _ -> None
+  in
+  match from_canonical with
+  | Some slug -> Ide_paths.By_url slug
+  | None ->
+    (match from_repo_id () with
+     | Some slug -> Ide_paths.By_url slug
+     | None -> Ide_paths.Legacy)
+;;
+
 let json_error message = `Assoc [ "ok", `Bool false; "error", `String message ]
 let json_ok data = `Assoc [ "ok", `Bool true; "data", data ]
 
@@ -111,7 +145,10 @@ let add_routes router =
            | _ -> None
          in
          let filter = { Ide_annotation_types.file_path; keeper_id; goal_id; task_id } in
-         let annotations = Ide_annotations.list ~base_dir:base ~filter () in
+         let partition = resolve_partition_for_query ~state ~uri in
+         let annotations =
+           Ide_annotations.list ~base_dir:base ~partition ~filter ()
+         in
          let json =
            `List (List.map Ide_annotation_types.annotation_to_json annotations)
          in
@@ -174,9 +211,11 @@ let add_routes router =
              let session_id = find_string "session_id" in
              let operation_id = find_string "operation_id" in
              let worker_run_id = find_string "worker_run_id" in
+             let partition = resolve_partition_for_query ~state ~uri in
              (match
                 Ide_annotations.create
                   ~base_dir:base
+                  ~partition
                   ~keeper_id
                   ~file_path
                   ~line_start
@@ -243,7 +282,8 @@ let add_routes router =
              (Yojson.Safe.to_string (json_error "Missing id or keeper_id"))
              reqd
          else (
-           match Ide_annotations.delete ~base_dir:base ~id ~keeper_id () with
+           let partition = resolve_partition_for_query ~state ~uri in
+           match Ide_annotations.delete ~base_dir:base ~partition ~id ~keeper_id () with
            | Ok () -> Http.Response.json ~status:`No_content ~request "{}" reqd
            | Error msg ->
              Http.Response.json

--- a/test/dune
+++ b/test/dune
@@ -132,6 +132,7 @@
   test_keeper_runtime_trust_snapshot
   test_ide_annotations
   test_ide_paths
+  test_ide_canonical_url_join
   test_keeper_runtime_manifest
   test_schema_surface_index
   test_keeper_accountability
@@ -419,6 +420,7 @@
   test_keeper_runtime_trust_snapshot
   test_ide_annotations
   test_ide_paths
+  test_ide_canonical_url_join
   test_keeper_runtime_manifest
   test_schema_surface_index
   test_keeper_accountability

--- a/test/test_ide_canonical_url_join.ml
+++ b/test/test_ide_canonical_url_join.ml
@@ -1,0 +1,199 @@
+(** RFC-0128 §6.3 integration test — sandbox keeper write at one
+    clone of a repository joins, via canonical URL slug, with an IDE
+    read at a different clone of the same upstream.
+
+    Setup:
+      base_dir/
+        .masc/config/repositories.toml
+          [repository.sandbox]   url=https://github.com/owner/repo
+                                 local_path = base_dir/sandbox/repos/repo
+          [repository.worktree]  url=git@github.com:owner/repo.git
+                                 local_path = base_dir/workspace/repo
+        sandbox/repos/repo/lib/foo.ml
+        workspace/repo/lib/foo.ml
+
+    Invariant: when the keeper "writes" inside the sandbox clone, the
+    record must be retrievable when the IDE reads from the working
+    tree clone — both must resolve to the same [By_url <slug>]
+    partition. The repo URLs use different transports (HTTPS vs SSH)
+    on purpose to also exercise the normalisation join test from
+    {!Ide_paths.canonical_url_of_remote}. *)
+
+open Alcotest
+open Repo_manager_types
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let with_temp_base_dir f =
+  let path = Filename.temp_file "rfc0128-join" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf path) (fun () -> f path)
+;;
+
+let rec mkdir_p path =
+  if path = "" || path = "/" || (Sys.file_exists path && Sys.is_directory path)
+  then ()
+  else (
+    mkdir_p (Filename.dirname path);
+    try Unix.mkdir path 0o755 with
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+;;
+
+let touch path =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  close_out oc
+;;
+
+let test_sandbox_write_joins_with_worktree_read () =
+  with_temp_base_dir (fun base_dir ->
+    (* 1. Build two clones of the same upstream. *)
+    let sandbox_root = Filename.concat base_dir "sandbox/repos/repo" in
+    let worktree_root = Filename.concat base_dir "workspace/repo" in
+    mkdir_p sandbox_root;
+    mkdir_p worktree_root;
+    touch (Filename.concat sandbox_root "lib/foo.ml");
+    touch (Filename.concat worktree_root "lib/foo.ml");
+    (* 2. Register both in repositories.toml. Different transports on
+       purpose so the canonical_url normalisation is also tested in
+       the join path. *)
+    let repo_https =
+      { id = "sandbox"
+      ; name = "sandbox"
+      ; url = "https://github.com/owner/repo"
+      ; local_path = sandbox_root
+      ; aliases = []
+      ; default_branch = "main"
+      ; credential_id = "default"
+      ; keepers = []
+      ; status = Active
+      ; auto_sync = false
+      ; sync_interval = 0
+      ; created_at = Int64.zero
+      ; updated_at = Int64.zero
+      }
+    in
+    let repo_ssh =
+      { repo_https with
+        id = "worktree"
+      ; name = "worktree"
+      ; url = "git@github.com:owner/repo.git"
+      ; local_path = worktree_root
+      }
+    in
+    (match Repo_store.save_all ~base_path:base_dir [ repo_https; repo_ssh ] with
+     | Ok () -> ()
+     | Error msg -> failf "save_all: %s" msg);
+    (* 3. resolve_partition_for_write at a sandbox path. *)
+    let sandbox_file = Filename.concat sandbox_root "lib/foo.ml" in
+    let sandbox_partition, sandbox_rel =
+      Masc_mcp.Keeper_exec_fs.resolve_partition_for_write
+        ~base_dir
+        ~kind:"region"
+        ~file_path:sandbox_file
+    in
+    let worktree_file = Filename.concat worktree_root "lib/foo.ml" in
+    let worktree_partition, worktree_rel =
+      Masc_mcp.Keeper_exec_fs.resolve_partition_for_write
+        ~base_dir
+        ~kind:"region"
+        ~file_path:worktree_file
+    in
+    (* 4. Invariant — both resolve to the same By_url slug. *)
+    (match sandbox_partition, worktree_partition with
+     | Ide_paths.By_url s1, Ide_paths.By_url s2 ->
+       check string "join invariant — same slug" s1 s2
+     | _ ->
+       failf
+         "expected By_url _ on both sides, got %s / %s"
+         (match sandbox_partition with
+          | Ide_paths.Legacy -> "Legacy"
+          | Ide_paths.By_url s -> "By_url " ^ s
+          | Ide_paths.Orphan -> "Orphan")
+         (match worktree_partition with
+          | Ide_paths.Legacy -> "Legacy"
+          | Ide_paths.By_url s -> "By_url " ^ s
+          | Ide_paths.Orphan -> "Orphan"));
+    (* 5. rel_path is the repo-relative remainder in both cases. *)
+    check string "sandbox rel_path stripped" "lib/foo.ml" sandbox_rel;
+    check string "worktree rel_path stripped" "lib/foo.ml" worktree_rel)
+;;
+
+let test_unregistered_path_lands_in_orphan () =
+  with_temp_base_dir (fun base_dir ->
+    let elsewhere = Filename.concat base_dir "elsewhere/foo.ml" in
+    let partition, original =
+      Masc_mcp.Keeper_exec_fs.resolve_partition_for_write
+        ~base_dir
+        ~kind:"region"
+        ~file_path:elsewhere
+    in
+    (match partition with
+     | Ide_paths.Orphan -> ()
+     | _ -> fail "expected Orphan for unregistered path");
+    check string "rel_path passes through unchanged" elsewhere original)
+;;
+
+let test_blank_url_lands_in_orphan () =
+  with_temp_base_dir (fun base_dir ->
+    let local = Filename.concat base_dir "blank/repo" in
+    mkdir_p local;
+    let repo =
+      { id = "blank"
+      ; name = "blank"
+      ; url = "" (* registered but no URL *)
+      ; local_path = local
+      ; aliases = []
+      ; default_branch = "main"
+      ; credential_id = "default"
+      ; keepers = []
+      ; status = Active
+      ; auto_sync = false
+      ; sync_interval = 0
+      ; created_at = Int64.zero
+      ; updated_at = Int64.zero
+      }
+    in
+    (match Repo_store.save_all ~base_path:base_dir [ repo ] with
+     | Ok () -> ()
+     | Error msg -> failf "save_all: %s" msg);
+    let file = Filename.concat local "lib/foo.ml" in
+    let partition, _ =
+      Masc_mcp.Keeper_exec_fs.resolve_partition_for_write
+        ~base_dir
+        ~kind:"region"
+        ~file_path:file
+    in
+    match partition with
+    | Ide_paths.Orphan -> ()
+    | _ -> fail "expected Orphan for blank-URL repo")
+;;
+
+let () =
+  run
+    "ide_canonical_url_join"
+    [ ( "RFC-0128 §6.3"
+      , [ test_case
+            "sandbox write joins with working-tree read"
+            `Quick
+            test_sandbox_write_joins_with_worktree_read
+        ; test_case
+            "unregistered path → Orphan"
+            `Quick
+            test_unregistered_path_lands_in_orphan
+        ; test_case
+            "blank URL → Orphan"
+            `Quick
+            test_blank_url_lands_in_orphan
+        ] )
+    ]
+;;


### PR DESCRIPTION
## ⚠️ 머지 순서 경고 (post-hoc, 2026-05-18)

운영 환경 진단 후 발견: **본 PR 단독 머지 시 사용자 환경의 모든 keeper write 가 `_orphan` 으로 떨어짐**.

### 원인

PR-1c 의 `resolve_partition_for_write` 는 RFC §4.5 의 **첫 번째 lookup chain** (`Repo_store.find_repo_by_path_prefix`) 만 구현. **두 번째 chain** ("keeper meta 의 repos[] 또는 playground path lookup") 누락.

실제 keeper 의 file_path 모양:
```
/Users/dancer/me/.masc/playground/sangsu/repos/masc-mcp/lib/mcp_server_eio_execute.mli
```

`repositories.toml` 의 `[repository.masc-mcp]` entry 는 `local_path = /Users/dancer/me/workspace/yousleepwhen/masc-mcp` (working tree). sandbox playground path 는 어떤 `local_path` 의 prefix 도 아니므로 **모든 keeper write 가 `_orphan + sandbox_unregistered_repo` counter** 에 떨어짐.

### 해결

[PR-6 #16061](https://github.com/jeong-sik/masc-mcp/pull/16061) 가 `Playground_paths.parse_playground_repo_path` 추가 + `resolve_partition_for_write` 에 두 번째 chain 구현. **본 PR (#16036) 머지 시 PR-6 (#16061) 도 같이 머지 권장**.

PR-6 가 PR-1c 위에 stack 되어있으므로 PR-1c 머지 후 PR-6 가 main 으로 rebase 되면 즉시 적용.

---

## RFC-0128 Phase 1 — PR-1c (cut-over)

[RFC-0128](https://github.com/jeong-sik/masc-mcp/blob/main/docs/rfc/RFC-0128-ide-canonical-url-partitioning.md) §4.5. **본 PR 이 사용자가 본 증상의 실제 해결**: keeper sandbox write 와 working-tree IDE read 가 같은 `By_url <slug>` bucket 에서 만남. resolution 실패 record 는 `_orphan/` + counter 로 silent loss 가시화.

> Stacked on PR-1a (#16020) + PR-1b (#16028). 두 PR 의 commit 이 base 에 cherry-pick 됨. 부모 머지 후 rebase 시 중복 commit drop.

## 변경 요지

### `lib/keeper/keeper_exec_fs`

| 함수 | 역할 |
|------|------|
| `resolve_partition_for_write ~base_dir ~kind ~file_path` (new, exposed for testing) | abs/rel path → `(partition, rel_path)`. `Repo_store.find_repo_by_path_prefix` 로 repo lookup → `Ide_paths.canonical_url_of_remote` 로 정규화. 실패 시 `Orphan` + counter +1 (`reason=unregistered_repo`/`blank_url`/`url_unparseable`) |
| `track_write_region` (updated) | resolved partition 을 `Ide_region_tracker.ingest_tool_call` 에 전달 + tool_call JSON 의 `path` 필드를 **repo-relative 로 strip** |

### `lib/server/server_ide_http`

| 함수 | 역할 |
|------|------|
| `resolve_partition_for_query ~state ~uri` (new) | HTTP 요청 → partition. 우선순위: `?canonical_url=` (정규화 재확인) → `?repo_id=` (Repo_store.find_url_by_id) → `Legacy` fallback |
| `list` / `create` / `delete` (updated) | resolved partition 을 `Ide_annotations.*` 호출에 전달 |

### `lib/keeper/keeper_metrics` + `lib/prometheus`

`masc_ide_orphan_writes_total` counter 신규 등록. Labels: `kind=annotation|region`, `reason=unregistered_repo|blank_url|url_unparseable`. `/metrics` 에 silent-loss rate 노출.

## RFC §4.5 invariant 입증

`test/test_ide_canonical_url_join.ml` — 새 integration suite 3 cases:

**핵심 invariant** (`sandbox write joins with working-tree read`):

```ocaml
(* 같은 upstream 의 두 clone 을 다른 transport URL 로 등록 *)
let repo_https = { ...; url = "https://github.com/owner/repo"
                 ; local_path = sandbox_root } in
let repo_ssh   = { ...; url = "git@github.com:owner/repo.git"
                 ; local_path = worktree_root } in
save_all ~base_path:base_dir [ repo_https; repo_ssh ];

(* 두 다른 clone 에서 resolve → 같은 slug *)
let s1, r1 = resolve_partition_for_write ~base_dir
               ~kind:"region" ~file_path:sandbox_file in
let s2, r2 = resolve_partition_for_write ~base_dir
               ~kind:"region" ~file_path:worktree_file in

(* 두 결과 모두 By_url <같은 slug> + 같은 repo-relative path *)
match s1, s2 with
| By_url x, By_url y -> check string "same slug" x y
| _ -> fail "expected By_url _ on both sides";
check string "sandbox rel" "lib/foo.ml" r1;
check string "worktree rel" "lib/foo.ml" r2
```

## Test 결과

- `test_ide_paths` — 18/18 PASS
- `test_ide_annotations` — 10/10 PASS (PR-1b 회귀 없음)
- `test_repo_store` — 33/33 PASS
- `test_ide_canonical_url_join` — 3/3 PASS (신규)
- `dune build --root .` PASS (전체)
- **Pre-existing**: `test_keeper_fs_write_containment` 가 PR-1c 변경 *전부터* fail (origin/main + PR-1b base 에서도 동일 fail). 본 PR 책임 아님 — 별도 issue 로 분리 권장.

> Note: 로컬 dune cache 가 stale signature 를 잡고 있어 `DUNE_CACHE=disabled` 로 검증함. CI 의 fresh build 에서는 영향 없음.

## 변경 범위

```
lib/keeper/keeper_exec_fs.ml      | +73 / -3
lib/keeper/keeper_exec_fs.mli     | +23 / -0
lib/keeper/keeper_metrics.ml      | +7  / -0
lib/keeper/keeper_metrics.mli     | +7  / -0
lib/prometheus.ml                 | +6  / -0
lib/server/server_ide_http.ml     | +43 / -1
test/dune                         | +2  / -0  (test_ide_canonical_url_join 등록)
test/test_ide_canonical_url_join.ml | +181 / -0 (신규)
```

## Test plan

- [x] `dune build --root .` PASS
- [x] 모든 신규 + 기존 IDE/repo 테스트 PASS
- [x] sandbox/working-tree join invariant integration test PASS
- [x] `_orphan` 3-reason 모두 path coverage
- [ ] CI required checks (Draft 상태로 관찰)
- [ ] 사용자 검증: 본인 환경에서 `~/me/.masc/config/repositories.toml` 에 working tree entry 추가 → 서버 reload → IDE 에 keeper 활동 표시 확인

## Related

- RFC-0128 (spec) `docs/rfc/RFC-0128-ide-canonical-url-partitioning.md`
- PR-1a #16020 (helpers)
- PR-1b #16028 (signature extension)
- PR-1d (예정) — `.masc-ide` 를 `excluded_dirs` 추가 + Ide_meta_sync 도 partition 인지

Co-Authored-By: claude-opus-4-7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

