### PR TITLE
[codex] Bound workspace repo discovery scan

### DIFF
--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -341,8 +341,8 @@ let safe_file_exists path =
   | Sys_error _ -> false
 
 let safe_is_dir path =
-  try Sys.file_exists path && Sys.is_directory path with
-  | Sys_error _ -> false
+  try (Unix.stat path).st_kind = Unix.S_DIR with
+  | Unix.Unix_error _ | Sys_error _ -> false
 
 let safe_repo_name name =
   name <> "" && name <> "." && name <> ".."
@@ -370,6 +370,11 @@ let is_git_clone candidate =
   safe_is_dir candidate
   &&
   match git_marker_kind (Filename.concat candidate ".git") with
+  | `Directory | `File -> true
+  | `Missing -> false
+
+let has_git_marker root =
+  match git_marker_kind (Filename.concat root ".git") with
   | `Directory | `File -> true
   | `Missing -> false
 
@@ -867,8 +872,10 @@ let score_repo_candidate config ~(task : task) ~tokens ~path_hints candidate =
    ([workspace_repo_not_found_error] / [workspace_repo_ambiguous_error]
    / [partial_clone_error]) stay near [auto_provision_sandbox_clone]
    since [infer_task_repo_name] does not produce them. *)
-let workspace_repo_matches ~search_root ~repo_name =
-  let max_dirs = 4000 in
+let workspace_repo_matches ~search_root ~repo_name ?(max_dirs = 4000)
+    ?(max_entries = 20000) () =
+  let max_dirs = max 0 max_dirs in
+  let max_entries = max 0 max_entries in
   let max_matches = 8 in
   let preferred_dir_name = function
     | "workspace" | "workspaces" | "repos" | "projects" | "src" -> true
@@ -893,8 +900,10 @@ let workspace_repo_matches ~search_root ~repo_name =
   let queue = Queue.create () in
   Queue.add search_root queue;
   let dirs_seen = ref 0 in
+  let entries_seen = ref 0 in
   while
     !dirs_seen < max_dirs
+    && !entries_seen < max_entries
     && Queue.length queue > 0
     && List.length !matches < max_matches
   do
@@ -911,12 +920,20 @@ let workspace_repo_matches ~search_root ~repo_name =
       entries;
     Array.iter
       (fun entry ->
-         if List.length !matches < max_matches then
+         if
+           !entries_seen < max_entries
+           && List.length !matches < max_matches
+           && not (skip_dir_name entry)
+         then begin
+           incr entries_seen;
            let path = Filename.concat dir entry in
-           if entry = repo_name && is_git_clone path then
-             matches := path :: !matches;
-           if safe_is_dir path && not (skip_dir_name entry) then
-             Queue.add path queue)
+           if safe_is_dir path then begin
+             let is_git_repo_dir = has_git_marker path in
+             if entry = repo_name && is_git_repo_dir then
+               matches := path :: !matches;
+             if not is_git_repo_dir then Queue.add path queue
+           end
+         end)
       entries
   done;
   List.sort_uniq String.compare !matches
@@ -969,6 +986,7 @@ let infer_task_repo_name config ~agent_name ~task_id =
                 |> List.filter_map (fun name ->
                        match
                          workspace_repo_matches ~search_root ~repo_name:name
+                           ()
                        with
                        | [ _ ] -> Some name
                        | _ -> None)
@@ -1097,7 +1115,7 @@ let normalize_origin_remote_to_https root =
 
 let auto_provision_sandbox_clone ~config ~agent_name ~repos_dir ~repo_name =
   let search_root = project_root config in
-  match workspace_repo_matches ~search_root ~repo_name with
+  match workspace_repo_matches ~search_root ~repo_name () with
   | [] ->
       Error
         (workspace_repo_not_found_error ~agent_name ~repos_dir ~repo_name

--- a/lib/coord/coord_worktree.mli
+++ b/lib/coord/coord_worktree.mli
@@ -223,9 +223,16 @@ val partial_clone_error : clone_path:string -> msg:string -> Masc_domain.masc_er
 (** {1 Workspace repo discovery} *)
 
 val workspace_repo_matches :
-  search_root:String.t -> repo_name:string -> String.t list
+  search_root:String.t ->
+  repo_name:string ->
+  ?max_dirs:int ->
+  ?max_entries:int ->
+  unit ->
+  String.t list
 (** Return absolute paths of every directory under [search_root] whose
-    basename equals [repo_name] and which looks like a git checkout. *)
+    basename equals [repo_name] and which looks like a git checkout.
+    [max_dirs] and [max_entries] bound fallback discovery so wide workspaces
+    cannot monopolize the server domain. *)
 
 val git_origin_url : string -> string option
 (** [git -C root config --get remote.origin.url], or [None] if unset. *)

--- a/lib/keeper/keeper_repo_readiness.ml
+++ b/lib/keeper/keeper_repo_readiness.ml
@@ -145,7 +145,7 @@ let inspect
   else if not (safe_is_dir clone_path) then
     let workspace_matches =
       Coord_worktree.workspace_repo_matches ~search_root:project_root
-        ~repo_name:derived_repo_name
+        ~repo_name:derived_repo_name ()
     in
     (match workspace_matches with
      | [ source_root ] ->

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -256,7 +256,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
          ───────────────────────────────────────────────────────────────────── *)
       | `GET, "/health" ->
           let body =
-            Server_routes_http_runtime.make_health_json ~listener:"h2" httpun_request
+            Server_routes_http_runtime.make_health_response_json ~listener:"h2" httpun_request
             |> Yojson.Safe.to_string
           in
           h2_respond_json h2_reqd body ~extra_headers:cors

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -147,6 +147,8 @@ let health_path_diagnostics () =
         ~effective_base_path ~effective_masc_root ()
 
 let health_uptime_secs () =
+  (* NDT-OK: /health exposes wall-clock process uptime for operators; no
+     persisted state transition or scheduler decision depends on this value. *)
   int_of_float (Unix.gettimeofday () -. server_start_time)
 
 let health_uptime_string uptime_secs =

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -146,6 +146,62 @@ let health_path_diagnostics () =
         ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
         ~effective_base_path ~effective_masc_root ()
 
+let health_uptime_secs () =
+  int_of_float (Unix.gettimeofday () -. server_start_time)
+
+let health_uptime_string uptime_secs =
+  if uptime_secs < 60 then Printf.sprintf "%ds" uptime_secs
+  else if uptime_secs < 3600 then
+    Printf.sprintf "%dm %ds" (uptime_secs / 60) (uptime_secs mod 60)
+  else Printf.sprintf "%dh %dm" (uptime_secs / 3600) ((uptime_secs mod 3600) / 60)
+
+let protocol_json ~listener =
+  `Assoc
+    [
+      ("default", `String mcp_protocol_version_default);
+      ("listener", `String listener);
+      ( "supported",
+        `List (List.map (fun v -> `String v) mcp_protocol_versions) );
+    ]
+
+let quick_gc_json () =
+  (* Keep health probes cheap under live keeper load. [Gc.stat] can force a
+     full major-cycle sync across domains; [Gc.quick_stat] exposes the same
+     operator-facing counters without walking the heap. *)
+  let s = Gc.quick_stat () in
+  `Assoc
+    [
+      ("minor_collections", `Int s.minor_collections);
+      ("major_collections", `Int s.major_collections);
+      ("compactions", `Int s.compactions);
+      ("heap_words", `Int s.heap_words);
+      ("live_words", `Int s.live_words);
+      ("minor_heap_size", `Int (let c = Gc.get () in c.minor_heap_size));
+    ]
+
+let make_health_probe_json ?(listener = "http/1.1") request =
+  let uptime_secs = health_uptime_secs () in
+  let build = Build_identity.current () in
+  Tool_args.ok_assoc
+    [
+      ("server", `String "masc-mcp");
+      ("version", `String build.release_version);
+      ("release_version", `String build.release_version);
+      ("build", Build_identity.to_yojson build);
+      ("health_detail", `String "probe");
+      ("full_health_url", `String "/health?full=1");
+      ("protocol", protocol_json ~listener);
+      ("transport", transport_json request);
+      ("http_listener", Transport_metrics.http_listener_json ());
+      ("paths", Server_base_path_diagnostics.to_yojson (health_path_diagnostics ()));
+      ("uptime", `String (health_uptime_string uptime_secs));
+      ("sse_clients", `Int (Sse.client_count ()));
+      ("startup", Server_startup_state.to_yojson ());
+      ("subsystems", Subsystem_health.to_yojson ());
+      ("logs", Log.Ring.summary_json ());
+      ("gc", quick_gc_json ());
+    ]
+
 type paused_keeper_scan = {
   names : string list;
   autoboot_enabled_names : string list;
@@ -524,13 +580,18 @@ let keeper_fleet_runtime_resolution_fields () =
   @ [ "fd_accountant", fd_accountant_snapshot_json () ]
 ;;
 
+let cdal_health_json () =
+  try Cdal_runtime_health.snapshot_json () with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+      Tool_args.error_assoc
+        [
+          ("component", `String "cdal");
+          ("error", `String (Printexc.to_string exn));
+        ]
+
 let make_health_json ?(listener = "http/1.1") request =
-  let uptime_secs = int_of_float (Unix.gettimeofday () -. server_start_time) in
-  let uptime_str =
-    if uptime_secs < 60 then Printf.sprintf "%ds" uptime_secs
-    else if uptime_secs < 3600 then Printf.sprintf "%dm %ds" (uptime_secs / 60) (uptime_secs mod 60)
-    else Printf.sprintf "%dh %dm" (uptime_secs / 3600) ((uptime_secs mod 3600) / 60)
-  in
+  let uptime_secs = health_uptime_secs () in
   let build = Build_identity.current () in
   let keeper_config_parse_errors =
     try Keeper_types_profile.keeper_toml_config_errors () with
@@ -583,18 +644,12 @@ let make_health_json ?(listener = "http/1.1") request =
     ("version", `String build.release_version);
     ("release_version", `String build.release_version);
     ("build", Build_identity.to_yojson build);
-    ( "protocol",
-      `Assoc
-        [
-          ("default", `String mcp_protocol_version_default);
-          ("listener", `String listener);
-          ( "supported",
-            `List (List.map (fun v -> `String v) mcp_protocol_versions) );
-        ] );
+    ("health_detail", `String "full");
+    ("protocol", protocol_json ~listener);
     ("transport", transport_json request);
     ("http_listener", Transport_metrics.http_listener_json ());
     ("paths", Server_base_path_diagnostics.to_yojson (health_path_diagnostics ()));
-    ("uptime", `String uptime_str);
+    ("uptime", `String (health_uptime_string uptime_secs));
     ("sse_clients", `Int (Sse.client_count ()));
     ("startup", Server_startup_state.to_yojson ());
     ("subsystems", Subsystem_health.to_yojson ());
@@ -605,17 +660,7 @@ let make_health_json ?(listener = "http/1.1") request =
     ("logs", Log.Ring.summary_json ());
     ("feature_flags", let features = Dashboard_feature_health.get_all_features () in
       Dashboard_feature_health.overview_json features);
-    (* Keep /health cheap under live keeper load. [Gc.stat] can force a
-       full major-cycle sync across domains; [Gc.quick_stat] exposes the
-       same operator-facing counters without walking the heap. *)
-    ("gc", let s = Gc.quick_stat () in `Assoc [
-      ("minor_collections", `Int s.minor_collections);
-      ("major_collections", `Int s.major_collections);
-      ("compactions", `Int s.compactions);
-      ("heap_words", `Int s.heap_words);
-      ("live_words", `Int s.live_words);
-      ("minor_heap_size", `Int (let c = Gc.get () in c.minor_heap_size));
-    ]);
+    ("gc", quick_gc_json ());
     ("keeper_fibers", `Int keeper_fibers);
     ( "keeper_fd_pressure"
     , Keeper_fd_pressure.runtime_state_json ~active_keepers:keeper_fibers
@@ -632,7 +677,7 @@ let make_health_json ?(listener = "http/1.1") request =
        so an operator can correlate with the cause encoded in their
        last_blocker_class. *)
     (key_paused_keepers, paused_keepers_json);
-    ("cdal", Cdal_runtime_health.snapshot_json ());
+    ("cdal", cdal_health_json ());
     ("keeper_config_parse_error_count",
      `Int keeper_config_parse_error_count);
     ( "keeper_config_parse_errors",
@@ -665,10 +710,17 @@ let make_health_json ?(listener = "http/1.1") request =
              (Prometheus.metric_total "masc_lazy_task_boot_guard_fired_total")));
   ]
 
+let full_health_requested request =
+  Server_utils.bool_query_param request "full" ~default:false
+
+let make_health_response_json ?(listener = "http/1.1") request =
+  if full_health_requested request then make_health_json ~listener request
+  else make_health_probe_json ~listener request
+
 (** Health check handler *)
 let health_handler request reqd =
   Http.Response.json
-    (Yojson.Safe.to_string (make_health_json request))
+    (Yojson.Safe.to_string (make_health_response_json request))
     reqd
 
 (** Liveness probe: responds 200 as soon as the HTTP accept loop is running.

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -107,9 +107,11 @@ val health_path_diagnostics :
 
 val make_health_json :
   ?listener:string -> Httpun.Request.t -> Yojson.Safe.t
-(** [make_health_json ?listener request] builds the full
-    [/health] JSON body.  [listener] defaults to ["http/1.1"]
-    and is overridden to ["h2"] by the H2 gateway.
+(** [make_health_json ?listener request] builds the full health diagnostics
+    JSON body.  [listener] defaults to ["http/1.1"] and is overridden to
+    ["h2"] by the H2 gateway.  The public [/health] route uses
+    {!make_health_response_json}; callers request this full body with
+    [/health?full=1].
 
     {2 Top-level keys (operator-visible contract)}
 
@@ -177,6 +179,21 @@ val make_health_json :
     at the contract seam: a future "drop unused metric" PR
     must touch this. *)
 
+val make_health_probe_json :
+  ?listener:string -> Httpun.Request.t -> Yojson.Safe.t
+(** [make_health_probe_json ?listener request] builds the cheap default
+    [/health] probe body.  It keeps liveness/readiness-facing fields such as
+    [startup], [paths], [transport], [logs], and quick GC counters, but skips
+    durable keeper scans, reaction-ledger JSONL reads, config TOML scans, and
+    CDAL ledger inspection. *)
+
+val make_health_response_json :
+  ?listener:string -> Httpun.Request.t -> Yojson.Safe.t
+(** [make_health_response_json ?listener request] is the public [/health]
+    renderer.  It returns {!make_health_probe_json} by default and upgrades to
+    {!make_health_json} only when the request query contains [full=1] /
+    [full=true]. *)
+
 val keeper_fleet_runtime_resolution_fields : unit -> (string * Yojson.Safe.t) list
 (** [keeper_fleet_runtime_resolution_fields ()] returns the health/fleet
     safety subset projected into [/api/v1/dashboard/shell]'s
@@ -190,8 +207,8 @@ val keeper_fleet_runtime_resolution_fields : unit -> (string * Yojson.Safe.t) li
     Prometheus. *)
 
 val health_handler : Httpun.Request.t -> Httpun.Reqd.t -> unit
-(** [health_handler request reqd] writes
-    {!make_health_json} as the response body. *)
+(** [health_handler request reqd] writes {!make_health_response_json} as the
+    response body. *)
 
 val liveness_handler : Httpun.Request.t -> Httpun.Reqd.t -> unit
 (** [liveness_handler request reqd] always responds [200] as

--- a/test/test_keeper_repo_readiness.ml
+++ b/test/test_keeper_repo_readiness.ml
@@ -130,6 +130,10 @@ let create_wide_workspace_storm ~base_path ~count =
     Unix.mkdir (Filename.concat root (Printf.sprintf "aa-%04d" i)) 0o755
   done
 
+let init_git_repo path =
+  mkdir_p path;
+  run_ok ~cwd:path "git init -q --initial-branch=main"
+
 let set_workspace_origin_to_github ~repo =
   run_ok ~cwd:repo
     "git remote set-url origin https://github.com/jeong-sik/masc-mcp.git"
@@ -312,6 +316,20 @@ let test_auto_provisionable_workspace_repo_before_wide_workspace_storm () =
   check string "workspace repo match" repo
     Yojson.Safe.Util.(json |> member "workspace_repo_match" |> to_string)
 
+let test_workspace_repo_matches_skips_git_clone_internals () =
+  let base_path = temp_dir "masc-repo-match-budget" in
+  let adjacent_repo = Filename.concat base_path "workspace/aaa-repo" in
+  let target_repo = Filename.concat base_path "workspace/z-team/target" in
+  init_git_repo adjacent_repo;
+  for i = 0 to 20 do
+    Unix.mkdir (Filename.concat adjacent_repo (Printf.sprintf "aa-%02d" i)) 0o755
+  done;
+  init_git_repo target_repo;
+  check (list string) "matches target without scanning adjacent repo internals"
+    [ target_repo ]
+    (Coord_worktree.workspace_repo_matches ~max_entries:8
+       ~search_root:base_path ~repo_name:"target" ())
+
 let () =
   Random.self_init ();
   run "Keeper_repo_readiness"
@@ -331,5 +349,7 @@ let () =
           `Quick test_auto_provisionable_workspace_repo_before_hidden_dir_storm;
         test_case "auto provisionable workspace repo before wide workspace storm"
           `Quick test_auto_provisionable_workspace_repo_before_wide_workspace_storm;
+        test_case "workspace repo scan skips git clone internals" `Quick
+          test_workspace_repo_matches_skips_git_clone_internals;
       ];
     ]

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1163,6 +1163,34 @@ let test_health_json_surfaces_log_ring_summary () =
     (latest |> member "details" = `Null);
   ignore (logs |> member "file_sink" |> member "enabled" |> to_bool)
 
+let test_health_response_default_is_light_probe () =
+  let request = Httpun.Request.create `GET "/health" in
+  let json = Server_routes_http_runtime.make_health_response_json request in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "default health detail" "probe"
+    (json |> member "health_detail" |> to_string);
+  Alcotest.(check string) "full health pointer" "/health?full=1"
+    (json |> member "full_health_url" |> to_string);
+  Alcotest.(check bool) "startup stays on default health" true
+    (match json |> member "startup" with `Assoc _ -> true | _ -> false);
+  Alcotest.(check bool) "paths stay on default health" true
+    (match json |> member "paths" with `Assoc _ -> true | _ -> false);
+  Alcotest.(check bool) "default health skips reaction ledger" true
+    (json |> member "keeper_reaction_ledger" = `Null);
+  Alcotest.(check bool) "default health skips cdal snapshot" true
+    (json |> member "cdal" = `Null)
+
+let test_health_response_full_query_keeps_diagnostics () =
+  let request = Httpun.Request.create `GET "/health?full=1" in
+  let json = Server_routes_http_runtime.make_health_response_json request in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "full health detail" "full"
+    (json |> member "health_detail" |> to_string);
+  Alcotest.(check bool) "full health keeps reaction ledger" true
+    (match json |> member "keeper_reaction_ledger" with `Assoc _ -> true | _ -> false);
+  Alcotest.(check bool) "full health keeps cdal snapshot" true
+    (match json |> member "cdal" with `Assoc _ -> true | _ -> false)
+
 let test_migrate_resident_keeper_dirs_promotes_valid_meta () =
   with_temp_dir "startup-legacy-keepers" (fun dir ->
       let state = Mcp_server.create_state ~base_path:dir in
@@ -2791,6 +2819,10 @@ let () =
             `Quick test_health_json_reaction_ledger_cursor_sweep_clears_pending;
           Alcotest.test_case "health json surfaces log ring summary" `Quick
             test_health_json_surfaces_log_ring_summary;
+          Alcotest.test_case "default health response is light probe" `Quick
+            test_health_response_default_is_light_probe;
+          Alcotest.test_case "full health query keeps diagnostics" `Quick
+            test_health_response_full_query_keeps_diagnostics;
           Alcotest.test_case "readiness false before init" `Quick
             test_startup_state_readiness_before_init;
           Alcotest.test_case "readiness true after init" `Quick


### PR DESCRIPTION
## Summary

Bounds workspace repository discovery so keeper repo-readiness and worktree auto-provisioning cannot monopolize the server domain while scanning large workspace roots. Also keeps the public `/health` route cheap by default so local dashboard/runtime probes do not synchronously scan durable keeper/CDAL JSONL state.

## Root Cause

Live sampling of the slow `127.0.0.1:8935` process showed the main thread pinned in `Coord_worktree.workspace_repo_matches -> safe_is_dir -> stat`. The scanner walked broad workspace trees, called `Sys.file_exists` plus `Sys.is_directory` for entries, and could descend into already-discovered git checkout internals, blocking even `/health` from producing a first byte.

After applying the scan fix and running this branch's binary, `/health` exposed a second problem: the route was a full diagnostics renderer. It synchronously built paused-keeper durable state, keeper reaction-ledger JSONL summaries, config scans, and CDAL ledger health. That is useful operator detail, but it is too heavy for the default liveness-style route under live keeper load.

## Changes

- Replace `safe_is_dir` with a single `Unix.stat` directory check.
- Add `max_entries` alongside the existing directory budget for workspace discovery.
- Skip ignored directories before stat calls.
- Stop descending into git checkout directories once their `.git` marker is found.
- Add a regression test that verifies a tight entry budget still finds a target repo without scanning adjacent git clone internals.
- Split `/health` rendering:
  - default `/health` returns a lightweight probe with startup, path, transport, log-ring, and quick GC fields;
  - `/health?full=1` preserves the previous full diagnostics payload;
  - CDAL full-health failures are contained in the `cdal` JSON object instead of failing the whole health response.

## Validation

- `git diff --check`
- `ocamlformat --check lib/server/server_routes_http_runtime.ml lib/server/server_routes_http_runtime.mli lib/server/server_h2_gateway.ml test/test_server_runtime_bootstrap.ml`
- `scripts/dune-local.sh build test/test_keeper_repo_readiness.exe`
- `./_build/default/test/test_keeper_repo_readiness.exe`
- `scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 33-37 --compact --show-errors`
- `scripts/dune-local.sh build bin/main_eio.exe`
- `bash scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD`

## Live 8935 Evidence

Ran this branch's rebuilt binary from:

`/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-workspace-repo-scan-bounds-20260518/_build/default/bin/main_eio.exe`

Measured on `127.0.0.1:8935`:

- `/health`: `http=200 start=0.001488 total=0.001886 size=5384`
- `/api/v1/dashboard/shell`: `http=200 start=0.002234 total=0.002698 size=20400`
- `/health?full=1`: `http=200 start=0.295011 total=0.295414 size=19128`

The lightweight health JSON reports `health_detail="probe"` and points to `/health?full=1`; the full JSON reports `health_detail="full"`. A post-fix sample of the live process no longer contains `Coord_worktree`, `workspace_repo_matches`, or `safe_is_dir` frames.
