### PR TITLE
feat(rfc-0128-pr-1d): hide .masc-ide from workspace tree

### DIFF
--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -157,9 +157,14 @@ let json_response_with_source ~status ~source req reqd json =
 
 let is_digit c = c >= '0' && c <= '9'
 
+(* RFC-0128 §4.6 — [.masc-ide/] is keeper metadata about the
+   workspace, not workspace content. Listing it in the file tree
+   exposes the agent's annotation store to the user IDE as a regular
+   directory, which is a leak observed on 2026-05-17 against
+   [?repo_id=masc]. *)
 let excluded_dirs =
   [ ".git"; "node_modules"; "_build"; ".obsidian"; "__pycache__";
-    ".masc"; ".worktrees"; ".cache"; ".tmp"; "dist"; "build" ]
+    ".masc"; ".masc-ide"; ".worktrees"; ".cache"; ".tmp"; "dist"; "build" ]
 
 let default_tree_node_limit = 750
 let max_tree_node_limit = 2000

--- a/test/dune
+++ b/test/dune
@@ -310,6 +310,7 @@
   test_gh_api_classification
   test_stale_kill_class
   test_workspace_routes_keeper
+  test_workspace_tree_exclusions
   test_provider_capability_matrix
   test_effect_evidence_source_path
   test_cognitive_gravity
@@ -609,6 +610,7 @@
   test_keeper_turn_fsm_wired_sites
   test_effective_oas_env
   test_workspace_routes_keeper
+  test_workspace_tree_exclusions
   test_effect_evidence_source_path
   test_cognitive_gravity
   test_intentional_projection

--- a/test/test_workspace_tree_exclusions.ml
+++ b/test/test_workspace_tree_exclusions.ml
@@ -1,0 +1,102 @@
+(** RFC-0128 §4.6 — [.masc-ide/] must not appear in the workspace
+    file tree returned by [/api/v1/workspace/tree].
+
+    Before this PR, [scan_dir] excluded [.masc/] (the keeper
+    coordination store) but not [.masc-ide/] (the keeper annotation
+    store). With [?repo_id=<id>] resolving the workspace base to a
+    registered repository and the IDE seeding its file explorer from
+    the response, the agent's own annotation directory was leaking
+    into the file picker. This regression test pins
+    [.masc-ide/]-exclusion alongside the other internal dirs. *)
+
+open Alcotest
+
+module W = Masc_mcp.Server_routes_http_routes_workspace
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let with_temp_dir f =
+  let path = Filename.temp_file "rfc-0128-tree" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  Fun.protect ~finally:(fun () -> rm_rf path) (fun () -> f path)
+;;
+
+let mkdir_p path =
+  let rec loop p =
+    if p = "" || p = "/" || (Sys.file_exists p && Sys.is_directory p)
+    then ()
+    else (
+      loop (Filename.dirname p);
+      try Unix.mkdir p 0o755 with
+      | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+  in
+  loop path
+;;
+
+let touch path =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  close_out oc
+;;
+
+let path_of_node = function
+  | `Assoc fields ->
+    (match List.assoc_opt "path" fields with
+     | Some (`String s) -> s
+     | _ -> failwith "node missing path")
+  | _ -> failwith "node not an Assoc"
+;;
+
+let paths nodes = List.map path_of_node nodes
+
+let test_masc_ide_excluded () =
+  with_temp_dir (fun base ->
+    mkdir_p (Filename.concat base ".masc-ide/by-url/some_slug");
+    touch (Filename.concat base ".masc-ide/by-url/some_slug/annotations.jsonl");
+    touch (Filename.concat base "lib/bar.ml");
+    let nodes = W.scan_dir ~base ~depth:0 ~max_depth:3 ~max_nodes:200 [] base in
+    let ps = paths nodes in
+    let has_masc_ide = List.exists (fun p -> p = ".masc-ide" || String.length p > 10 && String.sub p 0 10 = ".masc-ide/") ps in
+    let has_lib = List.exists (fun p -> p = "lib" || p = "lib/bar.ml") ps in
+    check bool ".masc-ide must not appear in tree" false has_masc_ide;
+    check bool "lib must appear in tree" true has_lib)
+;;
+
+let test_other_internal_dirs_still_excluded () =
+  (* Defence-in-depth: verify the existing excluded entries did not
+     regress when [.masc-ide] was added to the list. *)
+  with_temp_dir (fun base ->
+    List.iter
+      (fun d -> mkdir_p (Filename.concat base d))
+      [ ".git"; ".masc"; "node_modules"; "_build"; ".worktrees" ];
+    touch (Filename.concat base "lib/bar.ml");
+    let nodes = W.scan_dir ~base ~depth:0 ~max_depth:2 ~max_nodes:200 [] base in
+    let ps = paths nodes in
+    List.iter
+      (fun forbidden ->
+        check bool (forbidden ^ " must not appear") false (List.mem forbidden ps))
+      [ ".git"; ".masc"; "node_modules"; "_build"; ".worktrees" ];
+    check bool "lib must appear in tree" true (List.exists (fun p -> p = "lib") ps))
+;;
+
+let () =
+  run
+    "workspace_tree_exclusions"
+    [ ( "RFC-0128 §4.6"
+      , [ test_case ".masc-ide is excluded from tree" `Quick test_masc_ide_excluded
+        ; test_case
+            "other internal dirs still excluded"
+            `Quick
+            test_other_internal_dirs_still_excluded
+        ] )
+    ]
+;;


### PR DESCRIPTION
## RFC-0128 Phase 1 — PR-1d (file-tree leak fix)

[RFC-0128](https://github.com/jeong-sik/masc-mcp/blob/main/docs/rfc/RFC-0128-ide-canonical-url-partitioning.md) §4.6. `[.masc-ide/]` 가 IDE 파일 트리에 노출되는 leak 을 차단. 사용자가 처음 보고한 증상 중 하나 (`.masc-ide` 가 `?repo_id=masc` 응답 depth 0 에 보였음) 의 직접 fix.

> 본 PR 은 origin/main 베이스의 독립 PR. PR-1a/1b/1c 와 stack 관계 없음 — `excluded_dirs` 리스트 한 줄 변경만이라 어디든 머지될 수 있음.

## 변경

### `lib/server/server_routes_http_routes_workspace.ml`

```ocaml
(* RFC-0128 §4.6 — [.masc-ide/] is keeper metadata about the
   workspace, not workspace content. Listing it in the file tree
   exposes the agent's annotation store to the user IDE as a regular
   directory, which is a leak observed on 2026-05-17 against
   [?repo_id=masc]. *)
let excluded_dirs =
  [ ".git"; "node_modules"; "_build"; ".obsidian"; "__pycache__";
    ".masc"; ".masc-ide"; ".worktrees"; ".cache"; ".tmp"; "dist"; "build" ]
```

토큰 한 개 추가 (`.masc-ide`). 로직 변경 없음.

### `test/test_workspace_tree_exclusions.ml` (신규)

`Server_routes_http_routes_workspace.scan_dir` 를 직접 호출하는 regression test:

| Case | 입증 |
|------|------|
| `.masc-ide is excluded from tree` | tmp 워크스페이스에 `.masc-ide/by-url/<slug>/annotations.jsonl` + `lib/bar.ml` 생성 → scan_dir 결과에 `.masc-ide` 없음, `lib` 있음 |
| `other internal dirs still excluded` | defence-in-depth: `.git` / `.masc` / `node_modules` / `_build` / `.worktrees` 가 list 추가 후에도 여전히 제외 |

## 영향 범위

- **사용자 가시 증상 (`.masc-ide` 가 IDE 파일 트리에 보임)**: 본 PR 로 닫힘.
- **Ide_meta_sync 가 Legacy partition 에 쓰는 문제**: 본 PR 범위 아님. follow-up. Ide_meta_sync.config 에 canonical_url 정보가 없어 partition 결정을 못 함. Phase 2 read-side merge 와 함께 처리.

## Test 결과

- `test_workspace_tree_exclusions` — 2/2 PASS (신규)
- `dune build --root .` PASS
- `DUNE_CACHE=disabled` 로 검증 (로컬 cache 이슈 회피)

## 변경 범위

```
lib/server/server_routes_http_routes_workspace.ml | +7 / -2 (주석 추가 + .masc-ide 토큰)
test/dune                                         | +2 / -0  (test 등록 — names + modules)
test/test_workspace_tree_exclusions.ml            | +101 / -0 (신규)
```

## Test plan

- [x] `dune build --root .` PASS
- [x] 신규 단위 테스트 2 cases PASS
- [x] 기존 5개 제외 디렉토리 회귀 없음
- [x] `bash ~/me/scripts/pr-rfc-check.sh` (flagged subsystem 미접촉)
- [ ] CI required checks (Draft)
- [ ] 사용자 검증: 서버 재기동 후 `?repo_id=...` 호출에 `.masc-ide` 사라짐 확인

## Related

- RFC-0128 (spec) `docs/rfc/RFC-0128-ide-canonical-url-partitioning.md`
- PR-1a/1b/1c (#16020/#16028/#16036) — stack 관계 없음. 본 PR 은 main 기반 독립.

Co-Authored-By: claude-opus-4-7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
