### PR TITLE
fix: route credential gh subprocesses through process plane

### DIFF
--- a/lib/repo_manager/credential_materializer.ml
+++ b/lib/repo_manager/credential_materializer.ml
@@ -26,26 +26,6 @@ let now_unix_ms () =
 
 let gh_hosts_yml = "hosts.yml"
 
-let close_fd_noerr fd =
-  try Unix.close fd with Unix.Unix_error _ -> ()
-
-let remember_fd slot fd =
-  slot := Some fd;
-  fd
-
-let close_registered_fd slot =
-  match !slot with
-  | None -> ()
-  | Some fd ->
-      close_fd_noerr fd;
-      slot := None
-
-let rec waitpid_no_intr flags pid =
-  try Unix.waitpid flags pid
-  with Unix.Unix_error (Unix.EINTR, _, _) -> waitpid_no_intr flags pid
-
-let waitpid_status_nointr_for_test pid = snd (waitpid_no_intr [] pid)
-
 let env_key kv =
   match String.index_opt kv '=' with
   | None -> kv
@@ -76,43 +56,24 @@ let gh_bundle_env ~gh_config_dir =
          "GH_PROMPT_DISABLED=1";
        ])
 
+let status_ok = function
+  | Unix.WEXITED 0 -> true
+  | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> false
+
 (** Run a [gh] command against the supplied [GH_CONFIG_DIR] and return
     whether it succeeded.  The child process receives a bundle-scoped
     environment only, so ambient GH_TOKEN/GITHUB_TOKEN values cannot
     make a stale bundle look materialized. *)
 let gh_command_ok ~gh_config_dir argv =
-  let devnull_in_ref = ref None in
-  let devnull_out_ref = ref None in
-  let cleanup () =
-    close_registered_fd devnull_in_ref;
-    close_registered_fd devnull_out_ref
-  in
   try
-    let devnull_in =
-      remember_fd devnull_in_ref
-        (Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0)
+    let full_argv = "gh" :: argv in
+    let status, _stdout, _stderr =
+      Process_eio.run_argv_with_status_split
+        ~env:(gh_bundle_env ~gh_config_dir)
+        full_argv
     in
-    let devnull_out =
-      remember_fd devnull_out_ref
-        (Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0o644)
-    in
-    let pid =
-      try
-        Some
-          (Unix.create_process_env "gh" (Array.of_list ("gh" :: argv))
-             (gh_bundle_env ~gh_config_dir)
-             devnull_in devnull_out devnull_out)
-      with Unix.Unix_error _ -> None
-    in
-    cleanup ();
-    match pid with
-    | None -> false
-    | Some pid -> (
-        match snd (waitpid_no_intr [] pid) with
-        | Unix.WEXITED 0 -> true
-        | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> false)
-  with Unix.Unix_error _ ->
-    cleanup ();
+    status_ok status
+  with _ ->
     false
 
 let hosts_yml_has_oauth_token ~gh_config_dir =
@@ -239,12 +200,6 @@ let compute_token_sha256_prefix ~gh_config_dir : string option =
    subprocess error) we return [None] and the gate stays silent — F-1
    is permissive in PR-C and only ratchets to strict in a follow-up. *)
 let read_operator_ambient_token () : string option =
-  let read_fd, write_fd = Unix.pipe ~cloexec:false () in
-  let devnull_err =
-    try Some (Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0o644)
-    with Unix.Unix_error _ -> None
-  in
-  let stderr_fd = Option.value devnull_err ~default:Unix.stderr in
   (* Strip any GH_CONFIG_DIR set in the parent so we read the operator
      ambient credential, not whatever the parent caller pointed at. *)
   let env =
@@ -255,35 +210,17 @@ let read_operator_ambient_token () : string option =
            && String.equal (String.sub kv 0 14) "GH_CONFIG_DIR="))
     |> Array.of_list
   in
-  let pid =
-    try
-      Some
-        (Unix.create_process_env "gh"
-           [| "gh"; "auth"; "token" |]
-           env Unix.stdin write_fd stderr_fd)
-    with Unix.Unix_error _ -> None
-  in
-  (try Unix.close write_fd with Unix.Unix_error _ -> ());
-  Option.iter
-    (fun fd -> try Unix.close fd with Unix.Unix_error _ -> ())
-    devnull_err;
-  match pid with
-  | None ->
-      (try Unix.close read_fd with Unix.Unix_error _ -> ());
-      None
-  | Some pid ->
-      let ic = Unix.in_channel_of_descr read_fd in
-      let buf = Buffer.create 128 in
-      (try
-         while true do Buffer.add_channel buf ic 64 done
-       with End_of_file -> ());
-      close_in_noerr ic;
-      let status = snd (waitpid_no_intr [] pid) in
-      (match status with
-       | Unix.WEXITED 0 ->
-           let token = String.trim (Buffer.contents buf) in
-           if String.equal token "" then None else Some token
-       | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> None)
+  try
+    let argv = [ "gh"; "auth"; "token" ] in
+    let status, stdout, _stderr =
+      Process_eio.run_argv_with_status_split ~env argv
+    in
+    if status_ok status
+    then
+      let token = String.trim stdout in
+      if String.equal token "" then None else Some token
+    else None
+  with _ -> None
 
 (** RFC-0019 PR-C §3.2 P1 — F-1 gate (permissive).
 
@@ -428,9 +365,10 @@ let rec mkdir_p path mode =
       function returns; the caller can rely on the returned [state]
       reflecting the actual on-disk outcome.
 
-    The function is synchronous (uses [Unix.create_process_env]); PR-C
-    will move it to [Process_eio.run_argv] alongside the keeper-side
-    lifecycle hooks. *)
+    The function routes through [Process_eio] so credential subprocesses
+    share timeout and FD-accounting policy with the rest of the command
+    plane without recording the credential-specific environment in
+    approval-gate telemetry. *)
 let provision_via_with_token ?credential_id ?identity_label
     ~gh_config_dir ~token () : (credential_state, string) result =
   match path_safe gh_config_dir with
@@ -446,66 +384,27 @@ let provision_via_with_token ?credential_id ?identity_label
             (Printf.sprintf
                "could not create gh_config_dir %S" gh_config_dir)
         else
-          let read_fd_ref = ref None in
-          let write_fd_ref = ref None in
-          let devnull_out_ref = ref None in
-          let cleanup_setup_fds () =
-            close_registered_fd read_fd_ref;
-            close_registered_fd write_fd_ref;
-            close_registered_fd devnull_out_ref
-          in
-          try
-            let read_fd, write_fd = Unix.pipe ~cloexec:false () in
-            let read_fd = remember_fd read_fd_ref read_fd in
-            let write_fd = remember_fd write_fd_ref write_fd in
-            (* The pipe's read end will be passed to the child; the write
-               end stays in the parent.  cloexec on read_fd would close it
-               before exec; we set cloexec=false then explicitly close
-               read_fd in the parent after fork. *)
-            let devnull_out =
-              remember_fd devnull_out_ref
-                (Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0o644)
-            in
-            let env = gh_bundle_env ~gh_config_dir in
-          let argv =
-            [|
-              "gh"; "auth"; "login";
-              "--with-token";
-              "--insecure-storage";
-              "--hostname"; "github.com";
-              "--git-protocol"; "https";
-            |]
-          in
-          let pid =
             try
-              Some
-                (Unix.create_process_env "gh" argv env read_fd devnull_out
-                   devnull_out)
-            with Unix.Unix_error _ -> None
-          in
-          (* Parent: close child's stdin read end *)
-          close_registered_fd read_fd_ref;
-          close_registered_fd devnull_out_ref;
-          match pid with
-          | None ->
-              close_registered_fd write_fd_ref;
-              Error
-                "failed to spawn `gh auth login --with-token` subprocess; \
-                 is gh installed and on PATH?"
-          | Some pid ->
-              (* Write token to child's stdin and close.  No logging,
-                 no string concatenation that could leak the token. *)
-              let oc = Unix.out_channel_of_descr write_fd in
-              (try
-                 output_string oc token;
-                 output_char oc '\n';
-                 close_out oc;
-                 write_fd_ref := None
-               with
-               | Sys_error _ ->
-                   close_out_noerr oc;
-                   write_fd_ref := None);
-              let status = snd (waitpid_no_intr [] pid) in
+              let env = gh_bundle_env ~gh_config_dir in
+              let argv =
+                [
+                  "gh";
+                  "auth";
+                  "login";
+                  "--with-token";
+                  "--insecure-storage";
+                  "--hostname";
+                  "github.com";
+                  "--git-protocol";
+                  "https";
+                ]
+              in
+              let status, _stdout, _stderr =
+                Process_eio.run_argv_with_stdin_and_status_split
+                  ~env
+                  ~stdin_content:(token ^ "\n")
+                  argv
+              in
               (match status with
                | Unix.WEXITED 0 ->
                    (* RFC-0008 F-2: relabel hosts.yml:user back to the
@@ -540,12 +439,8 @@ let provision_via_with_token ?credential_id ?identity_label
                      (Printf.sprintf
                         "gh auth login --with-token stopped by signal %d"
                         n))
-          with Unix.Unix_error (err, fn, arg) ->
-            cleanup_setup_fds ();
-            Error
-              (Printf.sprintf
-                 "failed to spawn `gh auth login --with-token`: %s(%s): %s"
-                 fn arg (Unix.error_message err))
-          | exn ->
-              cleanup_setup_fds ();
-              raise exn)
+            with Unix.Unix_error (err, fn, arg) ->
+              Error
+                (Printf.sprintf
+                   "failed to spawn `gh auth login --with-token`: %s(%s): %s"
+                   fn arg (Unix.error_message err)))

--- a/lib/repo_manager/credential_materializer.mli
+++ b/lib/repo_manager/credential_materializer.mli
@@ -31,11 +31,6 @@ val sha256_prefix : string -> string
     without redaction concerns yet long enough (48 bits) to make
     accidental collisions astronomically unlikely.  RFC-0019 §3.2 P1. *)
 
-val waitpid_status_nointr_for_test : int -> Unix.process_status
-(** Test hook for the credential subprocess reaper.  Production callers
-    use the internal helper through [verify_state], [f1_gate_check], and
-    [provision_via_with_token]. *)
-
 val compute_token_sha256_prefix : gh_config_dir:string -> string option
 (** [compute_token_sha256_prefix ~gh_config_dir] reads the
     [oauth_token:] line from [<gh_config_dir>/hosts.yml] and returns
@@ -80,8 +75,8 @@ val provision_via_with_token :
     (token leakage):
 
     - [token] is never logged, returned, captured, or echoed.
-    - [stdout]/[stderr] of the subprocess are redirected to [/dev/null]
-      so [gh] cannot leak a malformed-token diagnostic.
+    - [stdout]/[stderr] of the subprocess are ignored so [gh] cannot
+      leak a malformed-token diagnostic through this API.
     - [gh_config_dir] is rejected if it contains a [..] segment.
     - [gh] receives a bundle-local environment that scrubs ambient
       GH_TOKEN/GITHUB_TOKEN values and forces [--insecure-storage], so

--- a/lib/repo_manager/dune
+++ b/lib/repo_manager/dune
@@ -19,6 +19,7 @@
    masc_mcp.fs_compat
    masc_mcp.masc_exec
    masc_mcp.masc_log
+   masc_mcp.masc_process
    digestif
    yojson
    otoml

--- a/test/test_credential_materializer.ml
+++ b/test/test_credential_materializer.ml
@@ -629,53 +629,6 @@ let test_relabel_no_file () =
       Credential_materializer.relabel_hosts_yml
         ~gh_config_dir:dir ~identity_label:"x")
 
-let test_waitpid_status_nointr_reaps_after_signal () =
-  (* #13102 follow-up — replace fixed-sleep racing with deterministic
-     pipe synchronisation:
-
-     - Install the SIGUSR1 handler BEFORE fork so the parent's
-       reception slot is ready the moment the child is able to send;
-       the prior post-fork install left a window where a fast child
-       could trigger the default action.
-     - Use a pipe pair as a "parent has entered waitpid" handshake:
-       the parent writes 1 byte immediately before calling
-       [waitpid_status_nointr_for_test], the child blocks on read
-       until that byte arrives, then sends SIGUSR1 and exits.  This
-       removes all sleep-based timing assumptions.
-     - The child uses [Unix._exit] so it does not re-run parent
-       at_exit hooks (alcotest cleanup, PG connection teardown, …)
-       inside the forked process. *)
-  let pipe_read, pipe_write = Unix.pipe () in
-  let previous = Sys.signal Sys.sigusr1 (Sys.Signal_handle (fun _ -> ())) in
-  Fun.protect
-    ~finally:(fun () ->
-      Sys.set_signal Sys.sigusr1 previous;
-      (try Unix.close pipe_read with Unix.Unix_error _ -> ());
-      (try Unix.close pipe_write with Unix.Unix_error _ -> ()))
-    (fun () ->
-      let parent = Unix.getpid () in
-      match Unix.fork () with
-      | 0 ->
-          (try Unix.close pipe_write with Unix.Unix_error _ -> ());
-          let buf = Bytes.create 1 in
-          let _ = Unix.read pipe_read buf 0 1 in
-          (try Unix.close pipe_read with Unix.Unix_error _ -> ());
-          (try Unix.kill parent Sys.sigusr1
-           with Unix.Unix_error _ -> ());
-          Unix._exit 0
-      | pid ->
-          (try Unix.close pipe_read with Unix.Unix_error _ -> ());
-          let _ = Unix.write pipe_write (Bytes.of_string "\x01") 0 1 in
-          (try Unix.close pipe_write with Unix.Unix_error _ -> ());
-          (match Credential_materializer.waitpid_status_nointr_for_test pid with
-           | Unix.WEXITED 0 -> ()
-           | Unix.WEXITED n ->
-               Alcotest.failf "child exited with %d" n
-           | Unix.WSIGNALED n ->
-               Alcotest.failf "child signalled with %d" n
-           | Unix.WSTOPPED n ->
-               Alcotest.failf "child stopped with %d" n))
-
 let () =
   Alcotest.run "credential_materializer"
     [
@@ -705,11 +658,6 @@ let () =
         [
           Alcotest.test_case "add invokes ensure and roundtrips" `Quick
             test_credential_store_add_invokes_ensure;
-        ] );
-      ( "process reaping",
-        [
-          Alcotest.test_case "waitpid retries after signal interruption"
-            `Quick test_waitpid_status_nointr_reaps_after_signal;
         ] );
       ( "provisioner",
         [

--- a/test/test_credential_materializer_waitpid_eintr.ml
+++ b/test/test_credential_materializer_waitpid_eintr.ml
@@ -1,42 +1,19 @@
 (* test/test_credential_materializer_waitpid_eintr.ml
 
-   Regression guard for issue #13060 (EINTR escape from
-   [Unix.waitpid] in [lib/repo_manager/credential_materializer.ml]).
+   Regression guard for issue #13060 and the later command-plane
+   cutover. Credential materialization used to own subprocess pipes
+   and blocking [Unix.waitpid] calls directly. That fixed EINTR with a
+   local retry helper, but still left this module outside the shared
+   Process_eio timeout and FD-accounting plane.
 
-   Background.  Three blocking [Unix.waitpid [] pid] sites in the
-   credential materializer used to raise
-     [Unix.Unix_error (Unix.EINTR, "waitpid", "")]
-   whenever a Posix signal interrupted the wait.  Observed live at
-   ~5/hr on 2026-05-05 — every interruption surfaced as
-     [tools/call crashed: Unix_error EINTR waitpid]
-   for keeper_bash / docker shell / git command paths, contributing
-   to the stale_turn cycle.  PR #13088 wraps every blocking
-   [Unix.waitpid] in a [waitpid_no_intr] helper that retries on
-   EINTR (canonical Posix idiom, mirrors prior-art
-   [waitpid_blocking] in [lib/process/process_eio.ml]).
-
-   This test asserts the fix structurally — a future refactor that
-   re-introduces a bare [Unix.waitpid] in the file fails CI before
-   it can re-arm the EINTR escape.  Behavioural EINTR reproduction
-   is non-trivial (deterministically delivering signals to a child
-   during waitpid is racy), and the fix is a 1-line idiom with
-   established prior art, so the regression we guard against is
-   "wrap removed" — a substring/anchor check catches that cheaply.
-
-   This stanza re-adds the regression guard from the closed PR
-   #13068, with copilot-pull-request-reviewer's two outstanding
-   robustness comments folded in:
-
-   1. Source-path resolution candidates extended with deeper
-      "../../" / "../../../" fallbacks, and the failure message now
-      prints the candidate list so debugging under unusual dune
-      sandbox / CWD layouts is possible.
-   2. The [Unix.waitpid] occurrence count strips both OCaml
-      comments AND string literals before counting.  This protects
-      against a future log/error message that mentions "Unix.waitpid"
-      in a string from triggering a false positive, and against the
-      explanatory block comment in this module from triggering a
-      false positive on the source itself. *)
+   The invariant is now stronger: credential subprocesses must not use
+   direct Unix process primitives at all. They route through
+   [Process_eio.run_argv_with_status_split] for read-only gh probes and
+   [run_argv_with_stdin_and_status_split] for
+   [gh auth login --with-token]. This keeps token stdin handling local
+   to Process_eio and lets the global spawn guard account foreground
+   subprocess pressure without recording credential-specific env in
+   approval-gate telemetry. *)
 
 let read_file path =
   let ic = open_in path in
@@ -63,10 +40,10 @@ let assert_contains ~label haystack needle =
 
 (* Strip OCaml [(* ... *)] comments (nesting-aware) and OCaml
    string literals — both regular ["..."] (with [\\] escapes) and
-   quoted ["{|...|}"] / ["{tag|...|tag}"] forms — so that mentions
-   of [Unix.waitpid] inside comments or strings do not skew the
-   bare-call-site count below.  The output is a code-only view that
-   preserves all real expressions and identifiers. *)
+   quoted ["{|...|}"] / ["{tag|...|tag}"] forms — so mentions inside
+   comments or strings do not skew the structural call-site checks.
+   The output is a code-only view that preserves real expressions and
+   identifiers. *)
 let strip_comments_and_strings s =
   let n = String.length s in
   let buf = Buffer.create n in
@@ -154,76 +131,46 @@ let () =
             (cwd=%s, exe=%s, candidates=[%s])"
            (Sys.getcwd ()) exe (String.concat "; " candidates))
   in
-  (* Anchor 1: helper present.  Needle does not include parameters
-     so it matches both the original [waitpid_no_intr pid] form
-     (closed PR #13068) and the more general [waitpid_no_intr flags
-     pid] form that landed via #13088. *)
-  assert_contains
-    ~label:"waitpid_no_intr helper definition"
-    src
-    "let rec waitpid_no_intr";
-  (* Anchor 2: helper retries on EINTR specifically — not on any
-     [Unix_error].  Anchor on the invariant rather than on one
-     specific syntactic shape: the helper body must mention
-     [Unix.EINTR] (so the retry is EINTR-scoped, not "swallow every
-     Unix_error") and must contain a call back to [waitpid_no_intr]
-     (so EINTR actually loops rather than falling through).  The
-     code-only view (comments + strings stripped) keeps the
-     explanatory block comment from triggering a false positive on
-     the [Unix.EINTR] mention. *)
-  let code_only_for_eintr = strip_comments_and_strings src in
-  if not (count_substring ~needle:"Unix.EINTR" code_only_for_eintr >= 1) then
-    failwith
-      "expected helper body to mention [Unix.EINTR] (retry must be \
-       EINTR-scoped, not blanket Unix_error swallow) — see issue #13060";
-  if not
-       (count_substring ~needle:"waitpid_no_intr" code_only_for_eintr >= 2)
-  then
-    failwith
-      "expected at least one recursive call back to [waitpid_no_intr] \
-       inside its own body (retry on EINTR must actually loop) — \
-       see issue #13060";
-  (* Anchor 3: only one bare [Unix.waitpid] call may exist in the
-     module — the one inside [waitpid_no_intr].  We count after
-     stripping comments AND string literals so that:
-     * the explanatory block comment naming [Unix.waitpid] in this
-       module does not skew the count (false positive guard);
-     * a future log/error message that cites the API by name in a
-       string literal does not trip the test (false positive
-       guard).
-     The bare-token needle is intentional — it catches any
-     reintroduced bare call regardless of surrounding syntax
-     (including the bracket-less [Unix.waitpid flags pid] form used
-     by the current helper after #13088). *)
   let code_only = strip_comments_and_strings src in
-  let bare_waitpid = count_substring ~needle:"Unix.waitpid" code_only in
-  if bare_waitpid <> 1 then
+  let assert_absent needle =
+    let count = count_substring ~needle code_only in
+    if count <> 0 then
+      failwith
+        (Printf.sprintf
+           "expected no %s call sites in credential_materializer.ml; found %d"
+           needle count)
+  in
+  assert_absent "Unix.create_process";
+  assert_absent "Unix.create_process_env";
+  assert_absent "Unix.open_process";
+  assert_absent "Unix.waitpid";
+  assert_absent "Unix.pipe";
+  assert_contains
+    ~label:"read-only gh probes use Process_eio"
+    src
+    "Process_eio.run_argv_with_status_split";
+  assert_contains
+    ~label:"with-token provisioning uses Process_eio stdin API"
+    src
+    "Process_eio.run_argv_with_stdin_and_status_split";
+  let status_split_uses =
+    count_substring
+      ~needle:"Process_eio.run_argv_with_status_split"
+      code_only
+  in
+  if status_split_uses < 2 then
     failwith
       (Printf.sprintf
-         "expected exactly 1 [Unix.waitpid] use in code (inside \
-          waitpid_no_intr); found %d.  Every blocking waitpid in \
-          credential_materializer.ml must route through \
-          waitpid_no_intr — see issue #13060."
-         bare_waitpid);
-  (* Anchor 4: ≥3 distinct call sites route through
-     [waitpid_no_intr] — the only safe wrapper for blocking waitpid
-     in this module.  Anchor on the helper's identifier rather than
-     a specific tuple-discard syntax so a refactor like
-     [let _, status = waitpid_no_intr ... in ...] still passes.
-     The total count is "5 helper-name occurrences" =
-     1 [let rec waitpid_no_intr] + 1 recursive call + 3 caller
-     sites; the bare helper name appears in code only (comments and
-     strings already stripped above).  We require ≥5 occurrences
-     and subtract the 2 helper-internal references to derive the
-     ≥3 caller floor. *)
-  let helper_uses = count_substring ~needle:"waitpid_no_intr" code_only in
-  let caller_lower_bound = helper_uses - 2 in
-  if caller_lower_bound < 3 then
-    failwith
-      (Printf.sprintf
-         "expected ≥3 [waitpid_no_intr] caller invocations (total %d \
-          helper-name occurrences in code; subtract the [let rec] \
-          definition and the recursive EINTR call to get the caller \
-          floor).  See issue #13060."
-         helper_uses);
-  print_endline "test_credential_materializer_waitpid_eintr: OK"
+         "expected at least 2 read-only Process_eio status-split uses; found %d"
+         status_split_uses);
+  let stdin_status_split_uses =
+    count_substring
+      ~needle:"Process_eio.run_argv_with_stdin_and_status_split"
+      code_only
+  in
+  if stdin_status_split_uses < 1 then
+      failwith
+        (Printf.sprintf
+         "expected at least 1 stdin Process_eio status-split use; found %d"
+         stdin_status_split_uses);
+  print_endline "test_credential_materializer_process_plane: OK"


### PR DESCRIPTION
## Summary
- replace credential materializer direct Unix.create_process_env / Unix.pipe / Unix.waitpid handling with Process_eio status APIs
- keep with-token provisioning token delivery on stdin while ignoring subprocess stdout/stderr
- update the structural regression guard to reject direct Unix spawn/wait/pipe reintroduction

## Verification
- ocamlformat --check lib/repo_manager/dune lib/repo_manager/credential_materializer.ml lib/repo_manager/credential_materializer.mli test/test_credential_materializer.ml test/test_credential_materializer_waitpid_eintr.ml
- scripts/dune-local.sh build test/test_credential_materializer.exe test/test_credential_materializer_waitpid_eintr.exe
- ./_build/default/test/test_credential_materializer.exe
- ./_build/default/test/test_credential_materializer_waitpid_eintr.exe
- bash scripts/ci/check-determinism-contract.sh
- git diff --check