### PR TITLE
fix(coord): classify backlog lock exhaustion as transient

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -29,6 +29,10 @@ let action_persists_handoff_context = function
   | Masc_domain.Reject_verification ->
     false
 
+let flatten_lock_result = function
+  | Ok result -> result
+  | Error e -> Error e
+
 let verification_submission_evidence_refs task handoff_context =
   let contract_refs =
     match task.contract with
@@ -77,7 +81,7 @@ let transition_task_r
      prevent ambiguous identity mapping across keeper agent files. *)
   let agent_name = resolve_agent_name_strict config agent_name in
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
-  with_file_lock config backlog_path (fun () ->
+  with_file_lock_r config backlog_path (fun () ->
     try
       match read_backlog_r config with
       | Error msg -> Error (Masc_domain.System (Masc_domain.System_error.IoError msg))
@@ -846,6 +850,7 @@ let transition_task_r
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e ->
       Error (Masc_domain.System (Masc_domain.System_error.IoError (Printexc.to_string e))))
+  |> flatten_lock_result
 ;;
 
 (** Release task back to backlog - transition wrapper *)
@@ -914,7 +919,8 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Masc_domain.masc_
   else (
     let agent_name = resolve_agent_name_strict config agent_name in
     let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
-    with_file_lock config backlog_path (fun () ->
+    let result =
+      with_file_lock_r config backlog_path (fun () ->
       try
         match read_backlog_r config with
         | Error msg -> Error (Masc_domain.System (Masc_domain.System_error.IoError msg))
@@ -1059,7 +1065,9 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Masc_domain.masc_
       | Eio.Cancel.Cancelled _ as e -> raise e
       | e ->
         Error
-          (Masc_domain.System (Masc_domain.System_error.IoError (Printexc.to_string e)))))
+          (Masc_domain.System (Masc_domain.System_error.IoError (Printexc.to_string e))))
+    in
+    flatten_lock_result result)
 ;;
 
 (* Scheduling functions are in Coord_task_schedule.
@@ -1089,7 +1097,8 @@ let link_task_execution_artifacts_r
   then Error (Masc_domain.System Masc_domain.System_error.NotInitialized)
   else (
     let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
-    with_file_lock config backlog_path (fun () ->
+    let result =
+      with_file_lock_r config backlog_path (fun () ->
       try
         match read_backlog_r config with
         | Error msg -> Error (Masc_domain.System (Masc_domain.System_error.IoError msg))
@@ -1175,5 +1184,7 @@ let link_task_execution_artifacts_r
       | Eio.Cancel.Cancelled _ as e -> raise e
       | e ->
         Error
-          (Masc_domain.System (Masc_domain.System_error.IoError (Printexc.to_string e)))))
+          (Masc_domain.System (Masc_domain.System_error.IoError (Printexc.to_string e))))
+    in
+    flatten_lock_result result)
 ;;

--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -537,7 +537,9 @@ let with_distributed_lock_r ?clock config path key f : ('a, masc_error) result =
       ~key ~attempts:50;
     Error
       (System (System_error.IoError
-         (Printf.sprintf "Failed to acquire distributed lock for %s"
+         (Printf.sprintf
+            "Failed to acquire distributed lock for key: %s (path=%s, 50 attempts exhausted; transient contention, retry later)"
+            key
             path)))
   end
 

--- a/lib/coord/coord_utils_ops.mli
+++ b/lib/coord/coord_utils_ops.mli
@@ -128,7 +128,9 @@ val with_distributed_lock :
   (unit -> 'a) ->
   'a
 
-(** Result-returning variant of [with_distributed_lock]. *)
+(** Result-returning variant of [with_distributed_lock].  Exhausted
+    acquisition is returned as retryable [System_error.IoError] instead
+    of raising. *)
 val with_distributed_lock_r :
   ?clock:_ Eio.Time.clock ->
   config ->

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -787,18 +787,19 @@ let handle_claim_next ?agent_tool_names ~tool_name ~start_time ctx _args =
   let result =
     Coord.claim_next_r ctx.config ~agent_name:ctx.agent_name ?agent_tool_names ()
   in
-  let message = match result with
-    | Coord.Claim_next_claimed { message; task_id; _ } ->
-        sync_keeper_current_task_binding ctx;
-        sync_planning_current_task_with_owned_task ctx;
-        append_claim_observation message ~now:(Time_compat.now ())
-          ~agent_name:ctx.agent_name ~task_id
-    | Coord.Claim_next_no_unclaimed -> "No unclaimed tasks available"
-    | Coord.Claim_next_no_eligible { excluded_count; _ } ->
-        format_no_eligible ctx excluded_count
-    | Coord.Claim_next_error e -> Printf.sprintf "Error: %s" e
-  in
-  Tool_result.ok ~tool_name ~start_time message
+  match result with
+  | Coord.Claim_next_claimed { message; task_id; _ } ->
+    sync_keeper_current_task_binding ctx;
+    sync_planning_current_task_with_owned_task ctx;
+    append_claim_observation message ~now:(Time_compat.now ())
+      ~agent_name:ctx.agent_name ~task_id
+    |> Tool_result.ok ~tool_name ~start_time
+  | Coord.Claim_next_no_unclaimed ->
+    Tool_result.ok ~tool_name ~start_time "No unclaimed tasks available"
+  | Coord.Claim_next_no_eligible { excluded_count; _ } ->
+    Tool_result.ok ~tool_name ~start_time (format_no_eligible ctx excluded_count)
+  | Coord.Claim_next_error e ->
+    Tool_result.error ~tool_name ~start_time (Printf.sprintf "Error: %s" e)
 
 let handle_release ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in

--- a/lib/tool_types/tool_result.ml
+++ b/lib/tool_types/tool_result.ml
@@ -54,7 +54,11 @@ let classify_from_exception (exn : exn) : tool_failure_class =
   match exn with
   | Eio.Time.Timeout -> Transient_error
   | Eio.Cancel.Cancelled _ -> Transient_error
-  | Invalid_argument _ -> Policy_rejection
+  | Invalid_argument msg ->
+    if contains_casefold msg "Failed to acquire distributed lock"
+       || contains_casefold msg "distributed lock"
+    then Transient_error
+    else Policy_rejection
   | Failure msg ->
     if
       (* Some Failure messages carry diagnostic content worth classifying.
@@ -103,6 +107,9 @@ let classify_from_dispatch_failure (message : string) : tool_failure_class =
     || contains_casefold message "connection"
     || contains_casefold message "unavailable"
     || contains_casefold message "rate limit"
+    || contains_casefold message "Failed to acquire distributed lock"
+    || contains_casefold message "distributed lock"
+    || contains_casefold message "lock contention"
     || contains_casefold message "502"
     || contains_casefold message "503"
   then Transient_error

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -41,6 +41,39 @@ let test_error_plain_string () =
   | _ -> Alcotest.fail "expected String for non-JSON input"
 ;;
 
+let test_distributed_lock_dispatch_failure_is_transient () =
+  let r =
+    Tool_result.error
+      ~tool_name:"masc_transition"
+      ~start_time:0.0
+      "[SystemError] IO error: Failed to acquire distributed lock for key: tasks:.backlog (50 attempts exhausted)"
+  in
+  Alcotest.(check bool) "failure" false r.success;
+  Alcotest.(check string)
+    "failure class"
+    "transient_error"
+    (match Tool_result.failure_class r with
+     | Some cls -> Tool_result.tool_failure_class_to_string cls
+     | None -> "none")
+;;
+
+let test_distributed_lock_exception_is_transient () =
+  let r =
+    Tool_result.of_exn
+      ~tool_name:"masc_transition"
+      ~start_time:0.0
+      (Invalid_argument
+         "Failed to acquire distributed lock for key: tasks:.backlog (50 attempts exhausted)")
+  in
+  Alcotest.(check bool) "failure" false r.success;
+  Alcotest.(check string)
+    "failure class"
+    "transient_error"
+    (match Tool_result.failure_class r with
+     | Some cls -> Tool_result.tool_failure_class_to_string cls
+     | None -> "none")
+;;
+
 let test_ok_prefixed_json_response () =
   let start = 1000.0 in
   let r =
@@ -127,6 +160,14 @@ let () =
     [ ( "ok/error"
       , [ Alcotest.test_case "json response" `Quick test_ok_json_response
         ; Alcotest.test_case "plain string" `Quick test_error_plain_string
+        ; Alcotest.test_case
+            "distributed lock dispatch failure is transient"
+            `Quick
+            test_distributed_lock_dispatch_failure_is_transient
+        ; Alcotest.test_case
+            "distributed lock exception is transient"
+            `Quick
+            test_distributed_lock_exception_is_transient
         ; Alcotest.test_case
             "prefixed json response"
             `Quick

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1218,6 +1218,33 @@ let () =
     assert_task_claimed_by ctx ctx.agent_name;
     assert (Planning_eio.get_current_task ctx.config = Some "task-001"))
 
+let () =
+  test "handle_claim_next_reports_internal_errors_as_tool_failure" (fun () ->
+    let ctx = make_test_ctx () in
+    let add_result =
+      Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+        (`Assoc [ ("title", `String "Claim next internal error") ])
+    in
+    if not add_result.Tool_result.success then failwith add_result.Tool_result.legacy_message;
+    let corrupt path =
+      let oc = open_out path in
+      Fun.protect
+        ~finally:(fun () -> close_out_noerr oc)
+        (fun () -> output_string oc "{not valid json")
+    in
+    let backlog_path = Coord.backlog_path ctx.config in
+    corrupt backlog_path;
+    corrupt (backlog_path ^ ".last-good");
+    let result =
+      Tool_task.handle_claim_next
+        ~tool_name:"test_tool"
+        ~start_time:0.0
+        ctx
+        (`Assoc [])
+    in
+    assert (not result.Tool_result.success);
+    assert (str_contains result.Tool_result.legacy_message "Error:"))
+
 let () = test "handle_claim_next_ignores_keeper_preset_for_open_claims" (fun () ->
   let agent_name = "keeper-social-sync-agent" in
   let keeper_name = "social-sync" in


### PR DESCRIPTION
## Summary
- Return distributed backlog-lock acquisition exhaustion through typed Coord errors instead of uncaught Invalid_argument.
- Classify distributed-lock contention as transient/retryable in tool results.
- Make masc_claim_next internal claim errors return Tool_result.error instead of a successful Error: message.

## Verification
- ocamlformat --check lib/coord/coord_task.ml lib/coord/coord_utils_ops.ml lib/coord/coord_utils_ops.mli lib/tool_types/tool_result.ml lib/tool_task.ml test/test_tool_result.ml test/test_tool_task_coverage.ml
- git diff --check
- scripts/dune-local.sh build test/test_tool_result.exe test/test_tool_task_coverage.exe
- ./_build/default/test/test_tool_result.exe
- ./_build/default/test/test_tool_task_coverage.exe