### PR TITLE
feat(rfc-0128-pr-1e): single-write keeper regions — drop Ide_meta_sync, content fallback

### DIFF
--- a/lib/ide/ide_region_tracker.ml
+++ b/lib/ide/ide_region_tracker.ml
@@ -156,17 +156,39 @@ let ingest_tool_call ~base_dir ?(partition = Ide_paths.Legacy) ~keeper_id ~turn 
     match file_path with
     | None -> ()
     | Some fp ->
+        (* Region-extraction priority per tool_name:
+             write_file → "content" → full-file region.
+             edit_file / apply_patch → "diff" or "patch" hunks (preferred,
+               preserves the changed line ranges only) → fall back to
+               "content" full-file region when only the post-edit
+               content is available.
+           RFC-0128 PR-1e: the content fallback for edit_file/apply_patch
+           used to be served by Ide_meta_sync.flush_regions, which wrote
+           to the Legacy partition and produced a double-write against the
+           by-url partition once PR-1c routed ingest_tool_call. Moving the
+           fallback into ingest_tool_call lets us drop the meta_sync call
+           site so all keeper write records land in a single, consistent
+           partition bucket. *)
+        let extract_full_file () =
+          match List.assoc_opt "content" arguments with
+          | Some (`String content) ->
+            [ extract_region_from_full_file ~keeper_id ~file_path:fp ~turn ~content ]
+          | _ -> []
+        in
         let regions =
-          if tool_name = "write_file" then
-            match List.assoc_opt "content" arguments with
-            | Some (`String content) -> [extract_region_from_full_file ~keeper_id ~file_path:fp ~turn ~content]
-            | _ -> []
+          if tool_name = "write_file" then extract_full_file ()
           else
             match List.assoc_opt "diff" arguments with
-            | Some (`String diff_text) -> extract_regions_from_diff ~keeper_id ~file_path:fp ~turn ~diff_text
-            | _ -> (
-                match List.assoc_opt "patch" arguments with
-                | Some (`String patch_text) -> extract_regions_from_diff ~keeper_id ~file_path:fp ~turn ~diff_text:patch_text
-                | _ -> [])
+            | Some (`String diff_text) ->
+              extract_regions_from_diff ~keeper_id ~file_path:fp ~turn ~diff_text
+            | _ ->
+              (match List.assoc_opt "patch" arguments with
+               | Some (`String patch_text) ->
+                 extract_regions_from_diff
+                   ~keeper_id
+                   ~file_path:fp
+                   ~turn
+                   ~diff_text:patch_text
+               | _ -> extract_full_file ())
         in
         List.iter (append_region ~base_dir ~partition) regions

--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -1,7 +1,6 @@
 open Keeper_types
 open Keeper_exec_shared
 open Ide_region_tracker
-open Ide_meta_sync
 
 (* Issue #8490: Variant SSOT for fs write mode. Adding a constructor
    forces compilation in [fs_write_mode_to_string] and
@@ -293,34 +292,14 @@ let track_write_region
     | Some Patch -> "edit_file"
     | _ -> "write_file"
   in
-  (* IDE meta sync: persist to .masc-ide/index.jsonl. Wrap in the same
-     log-and-continue pattern as Ide_region_tracker.ingest_tool_call below
-     so a mkdir/open_out/failwith inside Ide_meta_sync never blocks the
-     write path. *)
-  (try
-     let meta_config = { Ide_meta_sync.default_config with base_path = base_dir } in
-     let diff_text = None in
-     let state = Ide_meta_sync.initial_state in
-     let state =
-       Ide_meta_sync.on_tool_call_complete
-         meta_config
-         state
-         ~keeper_id:keeper_name
-         ~turn
-         ~tool_name
-         ~file_path
-         ~diff_text
-         ~full_content:(Some content)
-     in
-     let _state = Ide_meta_sync.flush_regions meta_config state in
-     ()
-   with
-   | exn ->
-     Log.Keeper.warn
-       "IDE meta sync failed for keeper=%s path=%s: %s"
-       keeper_name
-       file_path
-       (Printexc.to_string exn));
+  (* RFC-0128 PR-1e: the Ide_meta_sync invocation that used to live here
+     wrote to the Legacy partition (server base_path) while
+     Ide_region_tracker.ingest_tool_call below now writes to the
+     resolved partition (PR-1c). That produced a double-write of the
+     same region into two different bucket layouts. The full-file
+     region fallback meta_sync was carrying for edit_file/apply_patch
+     is now served directly by ingest_tool_call (see the [extract_full_file]
+     fallback in Ide_region_tracker), so we drop this path entirely. *)
   let arguments =
     let fields = [ "path", `String rel_file_path; "content", `String content ] in
     match fs_write_mode_of_string_opt mode_raw with

--- a/test/test_ide_annotations.ml
+++ b/test/test_ide_annotations.ml
@@ -448,6 +448,93 @@ let test_region_append_by_url_isolates_from_legacy () =
     check bool "legacy regions absent" false (Sys.file_exists legacy_path))
 ;;
 
+(* RFC-0128 PR-1e — content fallback + single-write invariant.
+
+   Before PR-1e, edit_file tool_calls with no diff/patch argument
+   produced zero regions in Ide_region_tracker.ingest_tool_call. The
+   missing record was previously synthesised by Ide_meta_sync.flush_regions,
+   which wrote to the Legacy partition while ingest_tool_call (post
+   PR-1c) wrote to the resolved partition — a double-write of the
+   same region across two buckets. PR-1e moves the content fallback
+   into ingest_tool_call itself and removes the meta_sync call site
+   from track_write_region, restoring a single source of truth. *)
+
+let count_lines path =
+  if not (Sys.file_exists path) then 0
+  else (
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let n = ref 0 in
+        try
+          while true do
+            ignore (input_line ic);
+            incr n
+          done;
+          !n
+        with End_of_file -> !n))
+;;
+
+let test_ingest_edit_file_content_fallback () =
+  with_temp_dir (fun base_dir ->
+    let slug = "github.com_owner_repo" in
+    (* edit_file with only path + content (no diff, no patch). Before
+       PR-1e this dropped regions silently. *)
+    let json =
+      `Assoc
+        [ "name", `String "edit_file"
+        ; "arguments"
+        , `Assoc
+            [ "path", `String "lib/foo.ml"
+            ; "content", `String "line one\nline two\nline three\n"
+            ; "old_string", `String "line one"
+            ; "new_string", `String "LINE ONE"
+            ]
+        ]
+    in
+    Region.ingest_tool_call
+      ~base_dir
+      ~partition:(Ide_paths.By_url slug)
+      ~keeper_id:"sangsu"
+      ~turn:1
+      json;
+    let by_url_path =
+      Region.regions_file ~base_dir ~partition:(Ide_paths.By_url slug) ()
+    in
+    check int "edit_file content fallback emits one region" 1 (count_lines by_url_path))
+;;
+
+let test_ingest_no_double_write () =
+  with_temp_dir (fun base_dir ->
+    let slug = "github.com_owner_repo" in
+    (* The same tool_call must produce exactly one region in the chosen
+       partition and zero in Legacy. Regression guard for the
+       meta_sync/ingest double-write that PR-1e closed. *)
+    let json =
+      `Assoc
+        [ "name", `String "write_file"
+        ; "arguments"
+        , `Assoc
+            [ "path", `String "lib/foo.ml"
+            ; "content", `String "alpha\nbeta\ngamma\n"
+            ]
+        ]
+    in
+    Region.ingest_tool_call
+      ~base_dir
+      ~partition:(Ide_paths.By_url slug)
+      ~keeper_id:"sangsu"
+      ~turn:0
+      json;
+    let by_url_path =
+      Region.regions_file ~base_dir ~partition:(Ide_paths.By_url slug) ()
+    in
+    let legacy_path = Region.regions_file ~base_dir () in
+    check int "by-url has one region" 1 (count_lines by_url_path);
+    check int "legacy has zero regions" 0 (count_lines legacy_path))
+;;
+
 let () =
   run
     "ide_annotations"
@@ -491,6 +578,14 @@ let () =
             "append_region By_url isolates from Legacy"
             `Quick
             test_region_append_by_url_isolates_from_legacy
+        ; test_case
+            "edit_file ingest content fallback emits one region (PR-1e)"
+            `Quick
+            test_ingest_edit_file_content_fallback
+        ; test_case
+            "ingest no double-write across partitions (PR-1e)"
+            `Quick
+            test_ingest_no_double_write
         ] )
     ]
 ;;


### PR DESCRIPTION
## RFC-0128 Phase 1 — PR-1e (single-write 보강)

PR-1d body 에서 deferred 으로 표기했던 **double-write 불일치** 해소. PR-1c 가 `Ide_region_tracker.ingest_tool_call` 을 `By_url` partition 으로 라우팅했지만, **같은 함수 안 `Ide_meta_sync.flush_regions`** 가 여전히 `config.base_path` (Legacy) 로 떨어져서 keeper write 마다 같은 region 이 두 곳에 작성됨.

> Stacked on PR-1a (#16020) + PR-1b (#16028) + PR-1c (#16036). PR-1d (#16040) 와는 무관 (다른 파일).

## Root cause

`Ide_meta_sync` 가 `edit_file` / `apply_patch` 에 대해 full-file region 을 생성하는 코드를 갖고 있었음. `ingest_tool_call` 은 같은 도구를 받았을 때 `diff` / `patch` 필드만 보고 없으면 region 을 **drop**. 그래서 meta_sync 가 그 gap 을 메우고 있었던 것. 두 경로가 같은 record 를 만들지만 partition 이 다른 게 PR-1c 이후의 문제.

## 변경

### `lib/ide/ide_region_tracker.ml`

`ingest_tool_call` 에 `extract_full_file ()` 헬퍼 추가 + `edit_file` / `apply_patch` 의 fallback:

```ocaml
let extract_full_file () =
  match List.assoc_opt "content" arguments with
  | Some (`String content) ->
    [ extract_region_from_full_file ~keeper_id ~file_path:fp ~turn ~content ]
  | _ -> []
in
let regions =
  if tool_name = "write_file" then extract_full_file ()
  else
    match List.assoc_opt "diff" arguments with
    | Some (`String diff_text) -> extract_regions_from_diff ...
    | _ ->
      (match List.assoc_opt "patch" arguments with
       | Some (`String patch_text) -> extract_regions_from_diff ...
       | _ -> extract_full_file ())   (* PR-1e: was [] before *)
in
```

### `lib/keeper/keeper_exec_fs.ml`

`track_write_region` 에서 `Ide_meta_sync` 호출 전체 블록 (`default_config`, `initial_state`, `on_tool_call_complete`, `flush_regions`) 제거. `open Ide_meta_sync` 도 함께 제거. `ingest_tool_call` 한 호출이 모든 mode 를 cover.

`Ide_meta_sync` 모듈 자체는 그대로 둠 (caller 0 인 채로). 다음 PR 에서 cleanup 후보.

## RFC §4.2 invariant 입증

`test/test_ide_annotations.ml` 에 2 cases 추가:

| Case | 입증 |
|------|------|
| `edit_file ingest content fallback emits one region (PR-1e)` | `edit_file` JSON (path + content + old/new, **no diff**) → `By_url` 에 region 1개. PR-1e 전엔 0. |
| `ingest no double-write across partitions (PR-1e)` | `write_file` 한 호출 → `By_url` 1개, `Legacy` 0개. meta_sync 재유입 회귀 가드. |

## Test 결과

- `test_ide_annotations` — **12/12 PASS** (10 carried + 2 new)
- `test_ide_paths` — 18/18 PASS
- `test_repo_store` — 33/33 PASS
- `test_ide_canonical_url_join` — 3/3 PASS
- `dune build --root .` PASS (DUNE_CACHE=disabled)

## 변경 범위

```
lib/ide/ide_region_tracker.ml | +27 / -7   (content fallback 헬퍼 + 주석)
lib/keeper/keeper_exec_fs.ml  | -25 / +12  (meta_sync 블록 제거)
test/test_ide_annotations.ml  | +101 / -0  (2 신규 케이스 + count_lines 헬퍼)
```

## 의도적 비범위

- **`Ide_meta_sync` 모듈 삭제**: caller 0 이지만 동일 PR 에서 같이 지우면 review surface 가 두 배. dead-code 정리는 별도 PR.
- **`extract_regions_from_diff` 의 정밀도**: 현재 PR-1e 의 content fallback 은 *full-file region 1개* 를 생성. diff 모드의 hunk-단위 region 과 다름. 동치는 아님. meta_sync 가 만들던 것과 정확히 같음 (회귀 없음).

## Test plan

- [x] 전체 ide / repo / annotation suites green (DUNE_CACHE=disabled)
- [x] edit_file fallback 직접 입증
- [x] no-double-write 직접 입증
- [x] `bash ~/me/scripts/pr-rfc-check.sh` (flagged subsystem 미접촉)
- [ ] CI required checks (Draft)

## Related

- RFC-0128 (spec) `docs/rfc/RFC-0128-ide-canonical-url-partitioning.md`
- PR-1a #16020 / PR-1b #16028 / PR-1c #16036 (stack 부모)
- PR-1d #16040 (orthogonal — file-tree leak)

Co-Authored-By: claude-opus-4-7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
