### PR TITLE
fix(keeper): honor unified max tokens in oas_env

### DIFF
--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -67,9 +67,10 @@ OAS_GEMINI_NO_MCP = "1"
 OAS_GEMINI_APPROVAL_MODE = "plan"
 # Codex는 -c TOML override로만 제어 가능
 OAS_CODEX_CONFIG = "mcp_servers={},sandbox_mode=read-only"
+MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS = 8192
 ```
 
-키는 반드시 `^OAS_(CLAUDE|CODEX|GEMINI)_.+` 패턴에 맞아야 한다. 그 외 키(`PATH`, `LD_PRELOAD`, 임의 변수 등)는 silently 드롭되어 ambient env 주입을 차단한다. bool 값은 `true`→`"1"`, `false`→`"0"`으로 자동 변환된다.
+키는 반드시 `^OAS_(CLAUDE|CODEX|GEMINI)_.+` 또는 `^MASC_KEEPER_OAS_.+` 패턴에 맞아야 한다. `MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS`는 해당 keeper turn의 `max_tokens` fallback에도 반영된다. 그 외 키(`PATH`, `LD_PRELOAD`, 임의 변수 등)는 silently 드롭되어 ambient env 주입을 차단한다. bool 값은 `true`→`"1"`, `false`→`"0"`으로 자동 변환된다.
 
 ### 1.2 MASC --- 조정 레이어
 

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -500,12 +500,12 @@ val metric_keeper_summarizer_state_blocks_removed : string
 val metric_keeper_oas_env_key_rejections : string
 (** Counter for [Keeper_types_profile.extract_oas_env_from_doc]
     entries dropped because the suffix did not match the
-    [OAS_(CLAUDE|CODEX|GEMINI)_] / [MASC_KEEPER_OAS_] allowlist.
-    Each rejected key increments by one and produces a warn line
-    so operators can spot configuration mistakes or attempted
-    env-injection bypass.  Non-zero counts at startup mean the
-    keeper TOML contains [keeper.oas_env.<X>] keys that the
-    runtime silently ignored. *)
+    [OAS_(CLAUDE|CODEX|GEMINI)_] / [MASC_KEEPER_OAS_] prefix allowlist, apart
+    from a narrow legacy alias for the keeper unified max-token knob.  Each
+    rejected key increments by one and produces a warn line so operators can
+    spot configuration mistakes or attempted env-injection bypass.  Non-zero
+    counts at startup mean the keeper TOML contains [keeper.oas_env.<X>] keys
+    that the runtime silently ignored. *)
 
 val metric_keeper_continuity_ts_recovered : string
 (** Counter for the synthetic-ts recovery branch in

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -44,6 +44,7 @@ let prepare_run_context
   =
   let receipt_started_at = Masc_domain.now_iso () in
   let meta = Keeper_agent_tool_surface.sync_current_task_id_from_backlog ~config meta in
+  let profile_defaults = Keeper_types_profile.load_keeper_profile_defaults meta.name in
   (* 0. Resolve inference parameters via Cascade_inference *)
   let temperature =
     match temperature with
@@ -65,7 +66,14 @@ let prepare_run_context
           (* 8192 allows complex multi-tool reasoning per turn.
            Cloudflare tunnel 100s is no longer a constraint with
            streaming responses. *)
-        ~fallback:(fun () -> 8192)
+        ~fallback:(fun () ->
+          match
+            Keeper_types_profile.unified_max_tokens_override_of_oas_env
+              ~keeper_name:meta.name
+              profile_defaults.oas_env
+          with
+          | Some value -> value
+          | None -> 8192)
   in
   (* 0b. Create context injector for temporal awareness *)
   let injector_config = Masc_context_injector.default_config () in
@@ -90,7 +98,6 @@ let prepare_run_context
   in
   let loaded_checkpoint_present = Option.is_some ctx_opt in
   (* 3. Build base system prompt from meta *)
-  let profile_defaults = Keeper_types_profile.load_keeper_profile_defaults meta.name in
   let keeper_oas_context =
     Keeper_types_profile.keeper_oas_context_of_defaults profile_defaults
   in

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -581,9 +581,11 @@ let persona_profile_path_opt name =
 (* TOML -> keeper_profile_defaults conversion                        *)
 (* ================================================================ *)
 
-(** Scan a flat TOML doc for keys under [[keeper.oas_env]].  Only keys
-    matching ^(OAS_(CLAUDE|CODEX|GEMINI)_|MASC_KEEPER_OAS_) are accepted
-    — any other entries are dropped silently.  This guards against
+(** Scan a flat TOML doc for keys under [[keeper.oas_env]].  Only provider
+    OAS prefixes and [MASC_KEEPER_OAS_*] are accepted.  The legacy
+    [MASC_KEEPER_UNIFIED_MAX_TOKENS] key remains accepted as a narrow migration
+    alias for the canonical [MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS].  Any other
+    entries are dropped.  This guards against
     arbitrary process env injection via keeper TOML.  Values are coerced
     to strings via [string_of_toml_value_for_env] (bool → "1"/"0"), so
     integers and booleans in TOML map to the string shapes the OAS
@@ -598,21 +600,31 @@ let string_of_toml_value_for_env = function
 
 let oas_env_key_prefix = "keeper.oas_env."
 
+let oas_env_allowed_prefixes =
+  [ "OAS_CLAUDE_"; "OAS_CODEX_"; "OAS_GEMINI_"; "MASC_KEEPER_OAS_" ]
+
+let keeper_unified_max_tokens_oas_env_key =
+  "MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS"
+
+let legacy_keeper_unified_max_tokens_oas_env_key =
+  "MASC_KEEPER_UNIFIED_MAX_TOKENS"
+
+let oas_env_allowed_exact_keys =
+  [ legacy_keeper_unified_max_tokens_oas_env_key ]
+
 let oas_env_key_is_allowed suffix =
-  let allowed_prefixes =
-    [ "OAS_CLAUDE_"; "OAS_CODEX_"; "OAS_GEMINI_"; "MASC_KEEPER_OAS_" ]
-  in
-  List.exists
-    (fun p ->
-      String.length suffix > String.length p
-      && String.sub suffix 0 (String.length p) = p)
-    allowed_prefixes
+  List.mem suffix oas_env_allowed_exact_keys
+  || List.exists
+       (fun p ->
+         String.length suffix > String.length p
+         && String.sub suffix 0 (String.length p) = p)
+       oas_env_allowed_prefixes
 
 (* Observability for the env-key allowlist drop branch.  Previously
    any [keeper.oas_env.<X>] entry whose suffix did not match
-   [OAS_(CLAUDE|CODEX|GEMINI)_] or [MASC_KEEPER_OAS_] was filtered
-   out with no signal — operators could not tell whether a typo'd
-   key (e.g. [OAS_CLUADE_API_KEY]) had been silently ignored.
+   [OAS_(CLAUDE|CODEX|GEMINI)_] or [MASC_KEEPER_OAS_*] was filtered out with
+   no signal — operators could not tell whether a typo'd key
+   (e.g. [OAS_CLUADE_API_KEY]) had been silently ignored.
    Closes the silent-drop gap noted in
    .tmp/memory-compacting-analysis.html (oas_env allowlist drop). *)
 let () =
@@ -644,13 +656,41 @@ let extract_oas_env_from_doc (doc : Keeper_toml_loader.toml_doc)
           Log.Keeper.warn
             "keeper.oas_env: dropping key=%S — suffix %S not in \
              allowlist (OAS_CLAUDE_* | OAS_CODEX_* | OAS_GEMINI_* | \
-             MASC_KEEPER_OAS_*); fix the TOML or expand the allowlist"
+             MASC_KEEPER_OAS_<suffix>); fix the TOML or expand the allowlist"
             k suffix;
           ignore v;
           None
         end
       else None)
     doc
+
+let unified_max_tokens_override_of_oas_env ?keeper_name pairs =
+  let key, raw_opt =
+    match List.assoc_opt keeper_unified_max_tokens_oas_env_key pairs with
+    | Some raw -> keeper_unified_max_tokens_oas_env_key, Some raw
+    | None ->
+      ( legacy_keeper_unified_max_tokens_oas_env_key,
+        List.assoc_opt legacy_keeper_unified_max_tokens_oas_env_key pairs )
+  in
+  match raw_opt with
+  | None -> None
+  | Some raw ->
+    let trimmed = String.trim raw in
+    (match int_of_string_opt trimmed with
+     | Some value ->
+       let min_v = 256 in
+       let max_v = 262_144 in
+       Some (max min_v (min max_v value))
+     | None ->
+       let keeper =
+         match keeper_name with
+         | Some name -> name
+         | None -> "(unknown)"
+       in
+       Log.Keeper.warn
+         "keeper.oas_env: ignoring invalid %s=%S for keeper=%s; expected integer"
+         key raw keeper;
+       None)
 
 let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     : (keeper_profile_defaults, string) result =

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -447,6 +447,18 @@ let run_keeper_cycle
       (match None with
        | Some meta_after_skip -> Ok meta_after_skip
        | None ->
+         let profile_defaults =
+           Keeper_types_profile.load_keeper_profile_defaults meta.name
+         in
+         let keeper_unified_max_tokens_fallback () =
+           match
+             Keeper_types_profile.unified_max_tokens_override_of_oas_env
+               ~keeper_name:meta.name
+               profile_defaults.oas_env
+           with
+           | Some value -> value
+           | None -> Keeper_config.keeper_unified_max_tokens ()
+         in
          let build_cascade_execution ~(cascade_name : KCP.runtime_name)
            : (cascade_execution, Agent_sdk.Error.sdk_error) result
            =
@@ -475,7 +487,7 @@ let run_keeper_cycle
                 let raw_max_tokens =
                   Cascade_inference.resolve_max_tokens
                     ~cascade_name
-                    ~fallback:Keeper_config.keeper_unified_max_tokens
+                    ~fallback:keeper_unified_max_tokens_fallback
                 in
                 let max_output_ceiling =
                   Cascade_runtime.max_output_tokens_ceiling_of_cascade_name

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1547,6 +1547,7 @@ persona_name = "analyst"
 OAS_CLAUDE_STRICT_MCP = "1"
 OAS_GEMINI_NO_MCP = "1"
 OAS_CODEX_CONFIG = "mcp_servers={}"
+MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS = 8192
 |} in
   match TL.parse_toml input with
   | Error e -> fail e
@@ -1554,13 +1555,38 @@ OAS_CODEX_CONFIG = "mcp_servers={}"
     match KTP.profile_defaults_of_toml doc with
     | Error e -> fail e
     | Ok d ->
-      check int "oas_env count" 3 (List.length d.oas_env);
+      check int "oas_env count" 4 (List.length d.oas_env);
       check string "strict_mcp value"
         "1" (List.assoc "OAS_CLAUDE_STRICT_MCP" d.oas_env);
       check string "no_mcp value"
         "1" (List.assoc "OAS_GEMINI_NO_MCP" d.oas_env);
       check string "codex_config value"
-        "mcp_servers={}" (List.assoc "OAS_CODEX_CONFIG" d.oas_env)
+        "mcp_servers={}" (List.assoc "OAS_CODEX_CONFIG" d.oas_env);
+      check string "unified max tokens value"
+        "8192" (List.assoc "MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS" d.oas_env);
+      check (option int) "unified max tokens override"
+        (Some 8192)
+        (KTP.unified_max_tokens_override_of_oas_env d.oas_env)
+
+let test_oas_env_supports_legacy_unified_max_tokens_alias () =
+  let input = {|
+[keeper]
+persona_name = "analyst"
+[keeper.oas_env]
+MASC_KEEPER_UNIFIED_MAX_TOKENS = 4096
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    match KTP.profile_defaults_of_toml doc with
+    | Error e -> fail e
+    | Ok d ->
+      check int "legacy oas_env count" 1 (List.length d.oas_env);
+      check string "legacy unified max tokens value"
+        "4096" (List.assoc "MASC_KEEPER_UNIFIED_MAX_TOKENS" d.oas_env);
+      check (option int) "legacy unified max tokens override"
+        (Some 4096)
+        (KTP.unified_max_tokens_override_of_oas_env d.oas_env)
 
 let test_keeper_oas_context_demotes_gemini_no_mcp_to_plan () =
   let defaults =
@@ -1591,8 +1617,8 @@ let test_keeper_oas_context_preserves_explicit_gemini_approval_mode () =
     ctx.gemini_approval_mode_derived
 
 let test_oas_env_drops_non_oas_prefix () =
-  (* Guards against ambient env injection via keeper TOML: keys that
-     don't start with OAS_(CLAUDE|CODEX|GEMINI)_ are silently dropped. *)
+  (* Guards against ambient env injection via keeper TOML: arbitrary keys
+     outside the audited allowlist are silently dropped. *)
   let input = {|
 [keeper]
 persona_name = "analyst"
@@ -1600,6 +1626,7 @@ persona_name = "analyst"
 PATH = "/evil/bin:/usr/bin"
 LD_PRELOAD = "/tmp/hack.so"
 OAS_CLAUDE_STRICT_MCP = "1"
+MASC_KEEPER_AUTONOMOUS_MAX_TOKENS = "9999"
 RANDOM_VAR = "nope"
 |} in
   match TL.parse_toml input with
@@ -1611,6 +1638,8 @@ RANDOM_VAR = "nope"
       check int "only OAS_* survives" 1 (List.length d.oas_env);
       check bool "PATH dropped" false (List.mem_assoc "PATH" d.oas_env);
       check bool "LD_PRELOAD dropped" false (List.mem_assoc "LD_PRELOAD" d.oas_env);
+      check bool "unlisted keeper key dropped" false
+        (List.mem_assoc "MASC_KEEPER_AUTONOMOUS_MAX_TOKENS" d.oas_env);
       check bool "RANDOM_VAR dropped" false (List.mem_assoc "RANDOM_VAR" d.oas_env)
 
 let test_oas_env_absent_means_empty () =
@@ -1994,6 +2023,8 @@ let () =
         [
           test_case "parses allowed OAS_* keys" `Quick
             test_oas_env_parses_allowed_keys;
+          test_case "supports legacy unified max tokens alias" `Quick
+            test_oas_env_supports_legacy_unified_max_tokens_alias;
           test_case "demotes Gemini no-MCP runs to plan approval mode" `Quick
             test_keeper_oas_context_demotes_gemini_no_mcp_to_plan;
           test_case "preserves explicit Gemini approval mode" `Quick


### PR DESCRIPTION
## Summary

Fixes #16034.

- Keep `[keeper.oas_env]` closed by default, but allow the audited exact legacy key `MASC_KEEPER_UNIFIED_MAX_TOKENS`.
- Wire that exact key into keeper turn `max_tokens` fallback resolution so it is not merely accepted and then ignored.
- Document the allowed key shape and keep arbitrary `MASC_KEEPER_*` env injection blocked.

## Validation

- `ocamlformat --check lib/keeper/keeper_types_profile.ml lib/keeper/keeper_metrics.mli lib/keeper/keeper_unified_turn.ml lib/keeper/keeper_run_context.ml test/test_keeper_toml.ml`
- `git diff --check origin/main...HEAD`
- `env DUNE_JOBS=1 scripts/dune-local.sh build test/test_keeper_toml.exe`
- `./_build/default/test/test_keeper_toml.exe test oas_env`

## Notes

Full `test_keeper_toml.exe` still fails in this isolated worktree because the local `.masc/config` root is absent, leaving pre-existing cascade catalog fixture tests unable to resolve `cascade.toml`. The touched `oas_env` test group passes.
