### PR TITLE
feat(rfc-0128-pr-2): read-side multi-source merge — Legacy + By_url

### DIFF
--- a/lib/ide/ide_annotations.ml
+++ b/lib/ide/ide_annotations.ml
@@ -135,8 +135,15 @@ let create
   then Error "content is required"
   else (
     let ts = now_ms () in
+    (* RFC-0128 PR-2: UUID minting is the non-determinism boundary.
+       Previous code captured a copy of the global RNG state without
+       advancing it, so consecutive uuid generations collided. Each
+       call now self-initialises a fresh state. Downstream consumers
+       treat the id as an opaque string identifier and never branch on
+       its value, so the non-determinism is contained at this site. *)
     let annotation =
-      { id = Uuidm.to_string (Uuidm.v4_gen (Random.get_state ()) ())
+      (* NDT-OK: see comment block above — uuid minting boundary. *)
+      { id = Uuidm.to_string (Uuidm.v4_gen (Random.State.make_self_init ()) ())
       ; file_path
       ; line_start
       ; line_end
@@ -163,9 +170,36 @@ let create
     Ok annotation)
 ;;
 
-let list ~base_dir ?(partition = Ide_paths.Legacy) ~filter () =
+(* RFC-0128 §5 — read-side de-duplication by annotation [id] (UUID).
+   When [merge_legacy = true], records living under the requested
+   partition take priority over Legacy ones with the same id. This
+   preserves the latest write while still surfacing pre-RFC-0128
+   data so the IDE does not appear to lose history at cut-over. *)
+let dedup_by_id_keeping_primary ~primary ~legacy =
+  let seen = Hashtbl.create 64 in
+  List.iter (fun (a : annotation) -> Hashtbl.replace seen a.id ()) primary;
+  let filtered_legacy =
+    List.filter (fun (a : annotation) -> not (Hashtbl.mem seen a.id)) legacy
+  in
+  primary @ filtered_legacy
+;;
+
+let list
+      ~base_dir
+      ?(partition = Ide_paths.Legacy)
+      ?(merge_legacy = false)
+      ~filter
+      ()
+  =
   ensure_store ~base_dir ~partition ();
-  let all : annotation list = load_all_partition ~base_dir partition in
+  let primary : annotation list = load_all_partition ~base_dir partition in
+  let all =
+    if merge_legacy && partition <> Ide_paths.Legacy
+    then
+      let legacy = load_all_partition ~base_dir Ide_paths.Legacy in
+      dedup_by_id_keeping_primary ~primary ~legacy
+    else primary
+  in
   let by_file =
     match filter.file_path with
     | Some fp -> List.filter (fun (a : annotation) -> a.file_path = fp) all

--- a/lib/ide/ide_annotations.mli
+++ b/lib/ide/ide_annotations.mli
@@ -49,12 +49,21 @@ val create
 val list
   :  base_dir:string
   -> ?partition:Ide_paths.partition
+  -> ?merge_legacy:bool
   -> filter:annotation_filter
   -> unit
   -> annotation list
 (** Read all annotations for the chosen partition. Tombstoned entries
     are excluded. Sorted by [created_at_ms] descending (newest first).
-    Default [partition] is {!Ide_paths.Legacy}. *)
+    Default [partition] is {!Ide_paths.Legacy}.
+
+    RFC-0128 §5 — when [merge_legacy = true] and [partition] is not
+    [Legacy], records from the Legacy flat store are merged into the
+    result. Conflicts on annotation [id] are resolved in favour of
+    the requested partition (the newer write wins). Default [false]
+    for forward compatibility; the HTTP read route opts in so the
+    cut-over to [By_url] does not appear to drop historical records.
+    No-op when [partition = Legacy]. *)
 
 val delete
   :  base_dir:string

--- a/lib/ide/ide_region_tracker.ml
+++ b/lib/ide/ide_region_tracker.ml
@@ -118,6 +118,70 @@ let append_region ~base_dir ?(partition = Ide_paths.Legacy) region =
   ensure_dir (Filename.dirname path);
   Fs_compat.append_jsonl path (region_to_json region)
 
+(* RFC-0128 §5 — read-side helpers. Regions are append-only; reads do
+   not mutate. The structural dedup key avoids treating a Legacy
+   record and its By_url cousin as two separate entries when both
+   files have the same write. *)
+
+let load_regions_from_path ?file_path path =
+  if not (Sys.file_exists path) then []
+  else
+    Fs_compat.fold_jsonl_lines
+      ~init:[]
+      ~f:(fun acc ~line_no:_ json ->
+        match region_of_json json with
+        | Ok (r : code_region) ->
+          (match file_path with
+           | None -> r :: acc
+           | Some fp -> if r.file_path = fp then r :: acc else acc)
+        | Error _ -> acc)
+      path
+    |> List.rev
+
+let region_key (r : code_region) =
+  let src_tag =
+    match r.source with
+    | Tool_call { tool_name; turn } ->
+      Printf.sprintf "tc:%s:%d" tool_name turn
+    | Manual { note } ->
+      Printf.sprintf "manual:%s" note
+  in
+  Printf.sprintf
+    "%s|%s|%d|%d|%Ld|%s"
+    r.keeper_id
+    r.file_path
+    r.line_start
+    r.line_end
+    r.timestamp_ms
+    src_tag
+
+let dedup_regions_keeping_primary ~primary ~legacy =
+  let seen = Hashtbl.create 64 in
+  List.iter (fun r -> Hashtbl.replace seen (region_key r) ()) primary;
+  let extra =
+    List.filter (fun r -> not (Hashtbl.mem seen (region_key r))) legacy
+  in
+  primary @ extra
+
+let read_regions
+      ~base_dir
+      ?(partition = Ide_paths.Legacy)
+      ?(merge_legacy = false)
+      ?file_path
+      ()
+  =
+  let primary =
+    load_regions_from_path ?file_path (regions_file ~base_dir ~partition ())
+  in
+  if merge_legacy && partition <> Ide_paths.Legacy then
+    let legacy =
+      load_regions_from_path
+        ?file_path
+        (regions_file ~base_dir ~partition:Ide_paths.Legacy ())
+    in
+    dedup_regions_keeping_primary ~primary ~legacy
+  else primary
+
 let json_string_field key json =
   match json with
   | `Assoc fields -> (

--- a/lib/ide/ide_region_tracker.mli
+++ b/lib/ide/ide_region_tracker.mli
@@ -61,3 +61,24 @@ val ingest_tool_call
     extract regions and append them to the chosen partition's
     [regions.jsonl]. Non-matching tool_calls are silently ignored.
     Default [partition] is {!Ide_paths.Legacy}. *)
+
+val read_regions
+  :  base_dir:string
+  -> ?partition:Ide_paths.partition
+  -> ?merge_legacy:bool
+  -> ?file_path:string
+  -> unit
+  -> code_region list
+(** Read regions from the chosen partition.
+
+    [?file_path] filters by [file_path] field; when omitted every
+    region is returned. Streaming-friendly: lines whose JSON does not
+    parse as a {!code_region} are silently skipped (matches the
+    forgiving semantics of the existing HTTP route).
+
+    RFC-0128 §5 — when [?merge_legacy = true] (default [false]) the
+    Legacy flat [regions.jsonl] is also read and deduplicated against
+    the primary partition. Regions have no identity column, so dedup
+    keys on the structural tuple
+    [(keeper_id, file_path, line_start, line_end, timestamp_ms, source)];
+    when all fields match the primary copy wins. *)

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -146,8 +146,18 @@ let add_routes router =
          in
          let filter = { Ide_annotation_types.file_path; keeper_id; goal_id; task_id } in
          let partition = resolve_partition_for_query ~state ~uri in
+         (* RFC-0128 §5 — the HTTP read route is the natural cut-over
+            point: the IDE has no way to ask for two stores explicitly,
+            so the server merges Legacy on its behalf. Once Phase 3
+            migrates the flat store into [by-url]/[_orphan], this flag
+            becomes a no-op. *)
          let annotations =
-           Ide_annotations.list ~base_dir:base ~partition ~filter ()
+           Ide_annotations.list
+             ~base_dir:base
+             ~partition
+             ~merge_legacy:true
+             ~filter
+             ()
          in
          let json =
            `List (List.map Ide_annotation_types.annotation_to_json annotations)
@@ -300,23 +310,20 @@ let add_routes router =
          let base, _source = resolve_workspace_base ~state ~uri in
          let file_path =
            match Uri.get_query_param uri "file_path" with
-           | Some p when p <> "" -> p
-           | _ -> ""
+           | Some p when p <> "" -> Some p
+           | _ -> None
          in
-         let store_dir = Ide_paths.store_path ~base_dir:base in
-         let path = Filename.concat store_dir "regions.jsonl" in
-         (* Streaming filter — file_path filter usually drops most lines,
-            and regions.jsonl grows append-only. fold_jsonl_lines avoids
-            the full-list materialisation that List.filter_map needed. *)
+         let partition = resolve_partition_for_query ~state ~uri in
+         (* RFC-0128 §5 — same cut-over rationale as the annotations
+            route: merge Legacy so pre-RFC-0128 regions stay visible
+            after the by-url migration. *)
          let regions =
-           Fs_compat.fold_jsonl_lines
-             ~init:[]
-             ~f:(fun acc ~line_no:_ j ->
-               match Ide_annotation_types.region_of_json j with
-               | Ok r when file_path = "" || r.file_path = file_path -> r :: acc
-               | _ -> acc)
-             path
-           |> List.rev
+           Ide_region_tracker.read_regions
+             ~base_dir:base
+             ~partition
+             ~merge_legacy:true
+             ?file_path
+             ()
          in
          let json = `List (List.map Ide_annotation_types.region_to_json regions) in
          Http.Response.json

--- a/test/test_ide_annotations.ml
+++ b/test/test_ide_annotations.ml
@@ -6,6 +6,14 @@ module Region = Ide_region_tracker
 module Sync = Ide_meta_sync
 module Lsp = Masc_mcp.Lsp_overlay_provider
 
+(* Ide_annotations.create generates ids via [Uuidm.v4_gen (Random.get_state ())].
+   [Random.get_state] returns a COPY of the global state, so two
+   close-succession calls without an explicit global advance produce
+   the same uuid and collide under merge dedup. The PR-2 merge tests
+   create two annotations in sequence, so seed the global state once
+   to make uuids deterministic-distinct across the run. *)
+let () = Random.self_init ()
+
 let route_annotation : Types.annotation =
   { id = "ann-route"
   ; file_path = "lib/keeper/keeper_exec_ide.ml"
@@ -505,6 +513,158 @@ let test_ingest_edit_file_content_fallback () =
     check int "edit_file content fallback emits one region" 1 (count_lines by_url_path))
 ;;
 
+(* RFC-0128 §5 PR-2 — read-side multi-source merge. *)
+
+let test_list_merge_legacy_surfaces_old_records () =
+  with_temp_dir (fun base_dir ->
+    let slug = "github.com_owner_repo" in
+    let _ =
+      create_in_partition
+        ~base_dir
+        ~partition:Ide_paths.Legacy
+        ~kind:Types.Comment
+        ~content:"legacy record"
+        ()
+    in
+    let _ =
+      create_in_partition
+        ~base_dir
+        ~partition:(Ide_paths.By_url slug)
+        ~kind:Types.Comment
+        ~content:"by-url record"
+        ()
+    in
+    let no_merge =
+      Store.list
+        ~base_dir
+        ~partition:(Ide_paths.By_url slug)
+        ~filter:(make_filter ())
+        ()
+    in
+    check int "no-merge sees only by-url" 1 (List.length no_merge);
+    let merged =
+      Store.list
+        ~base_dir
+        ~partition:(Ide_paths.By_url slug)
+        ~merge_legacy:true
+        ~filter:(make_filter ())
+        ()
+    in
+    check int "merge surfaces legacy + by-url" 2 (List.length merged))
+;;
+
+let test_list_merge_dedup_primary_wins () =
+  with_temp_dir (fun base_dir ->
+    let slug = "github.com_owner_repo" in
+    let by_url =
+      Result.get_ok
+        (create_in_partition
+           ~base_dir
+           ~partition:(Ide_paths.By_url slug)
+           ~kind:Types.Comment
+           ~content:"primary content"
+           ())
+    in
+    let legacy_clone =
+      Types.{ by_url with content = "legacy content (older)"; created_at_ms = 0L }
+    in
+    Fs_compat.append_jsonl
+      (Filename.concat
+         (Ide_paths.partition_store_dir ~base_dir Ide_paths.Legacy)
+         "annotations.jsonl")
+      (Types.annotation_to_json legacy_clone);
+    let merged =
+      Store.list
+        ~base_dir
+        ~partition:(Ide_paths.By_url slug)
+        ~merge_legacy:true
+        ~filter:(make_filter ())
+        ()
+    in
+    check int "no duplicate on id collision" 1 (List.length merged);
+    let winner = List.hd merged in
+    check string "primary content wins" "primary content" winner.content)
+;;
+
+let test_list_merge_noop_when_partition_is_legacy () =
+  with_temp_dir (fun base_dir ->
+    let _ =
+      create_in_partition
+        ~base_dir
+        ~partition:Ide_paths.Legacy
+        ~kind:Types.Comment
+        ~content:"only legacy"
+        ()
+    in
+    let merged =
+      Store.list
+        ~base_dir
+        ~partition:Ide_paths.Legacy
+        ~merge_legacy:true
+        ~filter:(make_filter ())
+        ()
+    in
+    check int "Legacy + merge is a single read" 1 (List.length merged))
+;;
+
+let test_read_regions_merge_legacy_surfaces_old () =
+  with_temp_dir (fun base_dir ->
+    let slug = "github.com_owner_repo" in
+    let mk_region ~ts ~src : Types.code_region =
+      { keeper_id = "sangsu"
+      ; file_path = "lib/foo.ml"
+      ; line_start = 1
+      ; line_end = 3
+      ; source = Types.Tool_call { tool_name = src; turn = 0 }
+      ; timestamp_ms = ts
+      }
+    in
+    Region.append_region
+      ~base_dir
+      ~partition:Ide_paths.Legacy
+      (mk_region ~ts:1L ~src:"write_file");
+    Region.append_region
+      ~base_dir
+      ~partition:(Ide_paths.By_url slug)
+      (mk_region ~ts:2L ~src:"edit_file");
+    let primary_only =
+      Region.read_regions ~base_dir ~partition:(Ide_paths.By_url slug) ()
+    in
+    let merged =
+      Region.read_regions
+        ~base_dir
+        ~partition:(Ide_paths.By_url slug)
+        ~merge_legacy:true
+        ()
+    in
+    check int "primary-only sees by-url only" 1 (List.length primary_only);
+    check int "merge sees both" 2 (List.length merged))
+;;
+
+let test_read_regions_dedup_structural_key () =
+  with_temp_dir (fun base_dir ->
+    let slug = "github.com_owner_repo" in
+    let region : Types.code_region =
+      { keeper_id = "sangsu"
+      ; file_path = "lib/foo.ml"
+      ; line_start = 1
+      ; line_end = 5
+      ; source = Types.Tool_call { tool_name = "write_file"; turn = 0 }
+      ; timestamp_ms = 1L
+      }
+    in
+    Region.append_region ~base_dir ~partition:Ide_paths.Legacy region;
+    Region.append_region ~base_dir ~partition:(Ide_paths.By_url slug) region;
+    let merged =
+      Region.read_regions
+        ~base_dir
+        ~partition:(Ide_paths.By_url slug)
+        ~merge_legacy:true
+        ()
+    in
+    check int "structural dedup collapses duplicates" 1 (List.length merged))
+;;
+
 let test_ingest_no_double_write () =
   with_temp_dir (fun base_dir ->
     let slug = "github.com_owner_repo" in
@@ -586,6 +746,26 @@ let () =
             "ingest no double-write across partitions (PR-1e)"
             `Quick
             test_ingest_no_double_write
+        ; test_case
+            "list merge_legacy surfaces old records (PR-2)"
+            `Quick
+            test_list_merge_legacy_surfaces_old_records
+        ; test_case
+            "list merge dedup — primary wins (PR-2)"
+            `Quick
+            test_list_merge_dedup_primary_wins
+        ; test_case
+            "list merge is no-op when partition=Legacy (PR-2)"
+            `Quick
+            test_list_merge_noop_when_partition_is_legacy
+        ; test_case
+            "read_regions merge_legacy surfaces old (PR-2)"
+            `Quick
+            test_read_regions_merge_legacy_surfaces_old
+        ; test_case
+            "read_regions structural dedup (PR-2)"
+            `Quick
+            test_read_regions_dedup_structural_key
         ] )
     ]
 ;;


### PR DESCRIPTION
## RFC-0128 Phase 2 — PR-2 (read-side merge)

[RFC-0128](https://github.com/jeong-sik/masc-mcp/blob/main/docs/rfc/RFC-0128-ide-canonical-url-partitioning.md) §5. Phase 1 이 keeper write 를 by-url 로 옮겼지만, 디스크에 누적된 모든 record 는 평면 Legacy 에 그대로 있음. merge 없이 cut-over 하면 IDE 입장에서 **history 가 사라진 것처럼 보임**.

PR-2 는 Legacy 와 함께 read 하는 merge path 를 추가하고 HTTP 두 라우트가 그 path 를 쓰도록 함. Phase 3 migration 이후엔 flag 가 no-op.

> Stacked on PR-1a (#16020) + PR-1b (#16028) + PR-1c (#16036) + PR-1e (#16044). 부모 머지 후 rebase 시 중복 commit drop.

## 변경

### `Ide_annotations`

```ocaml
val list :
  base_dir:string ->
  ?partition:Ide_paths.partition ->
  ?merge_legacy:bool ->        (* new *)
  filter:annotation_filter ->
  unit ->
  annotation list
```

`merge_legacy=true` + `partition <> Legacy` 면 Legacy 도 read 후 id 기준 dedup. id 충돌 시 primary 가 승리.

### `Ide_region_tracker` — 신규 `read_regions`

```ocaml
val read_regions :
  base_dir:string ->
  ?partition:Ide_paths.partition ->
  ?merge_legacy:bool ->
  ?file_path:string ->
  unit ->
  code_region list
```

Region 은 id 없음 → 구조적 key `(keeper_id, file_path, line_start, line_end, timestamp_ms, source)` 로 dedup.

### `server_ide_http`

- `/api/v1/ide/annotations`: `merge_legacy:true` 사용.
- `/api/v1/ide/regions`: 기존 inline `fold_jsonl_lines` block 을 `Ide_region_tracker.read_regions ~partition ~merge_legacy:true` 로 교체. 이전 코드는 `Ide_paths.store_path` (= Legacy) 만 봐서 PR-1c 이후 항상 비어있었음 — **부수 사고 fix**.

### 부수 fix — UUID 충돌 버그

`Ide_annotations.create` 의 기존 코드:
```ocaml
id = Uuidm.to_string (Uuidm.v4_gen (Random.get_state ()) ())
```

`Random.get_state ()` 은 global state 의 **copy** 를 반환. v4_gen 이 그 copy 에서 bits 를 소비하지만 global state 는 advance 안 됨. 그 결과 close-succession create 호출이 같은 UUID 생성. merge dedup 에서 두 record 가 한 record 로 collapse → 데이터 손실로 보임.

수정:
```ocaml
id = Uuidm.to_string (Uuidm.v4_gen (Random.State.make_self_init ()) ())
```

매 호출 entropy 로 자체 seed → 독립 UUID 보장.

`★ Note`: 본 버그는 partition 추가 *전부터* 있었지만 silent — annotations.jsonl 평면이 append-only 이고 read 가 dedup 없이 모두 surface 했기 때문. PR-2 의 dedup 이 도입되며 가시화 됨.

## RFC §5 invariant 입증

`test/test_ide_annotations.ml` 5 신규 케이스:

| Case | 입증 |
|------|------|
| `list merge_legacy surfaces old records (PR-2)` | Legacy + By_url 각 1 record → merge 결과 2 |
| `list merge dedup — primary wins (PR-2)` | 같은 id 의 record 가 양쪽에 → 1 record, By_url 의 content 유지 |
| `list merge is no-op when partition=Legacy (PR-2)` | partition=Legacy 면 merge_legacy 무시 (double-read 안 함) |
| `read_regions merge_legacy surfaces old (PR-2)` | Legacy + By_url region 각 1 → merge 결과 2 |
| `read_regions structural dedup (PR-2)` | 동일 region 양쪽에 → 1 record |

## Test 결과

- `test_ide_annotations` — **17/17 PASS** (12 carried + 5 new)
- `test_ide_paths` — 18/18 PASS
- `test_repo_store` — 33/33 PASS
- `test_ide_canonical_url_join` — 3/3 PASS
- `dune build --root .` PASS (DUNE_CACHE=disabled)

## 변경 범위

```
lib/ide/ide_annotations.ml     | +27 / -4   (merge_legacy + dedup + UUID fix)
lib/ide/ide_annotations.mli    | +11 / -2
lib/ide/ide_region_tracker.ml  | +66 / -0   (read_regions + helpers)
lib/ide/ide_region_tracker.mli | +18 / -0
lib/server/server_ide_http.ml  | +17 / -16  (regions route 재작성)
test/test_ide_annotations.ml   | +166 / -0  (5 신규 케이스)
```

## Test plan

- [x] `dune build --root .` PASS
- [x] 모든 단위 + 통합 테스트 PASS (DUNE_CACHE=disabled)
- [x] UUID 충돌 fix 로 인한 기존 회귀 0
- [x] `bash ~/me/scripts/pr-rfc-check.sh` (flagged subsystem 미접촉)
- [ ] CI required checks (Draft)
- [ ] 운영 검증: 머지 후 IDE 에서 pre-PR-1c 의 Legacy 데이터가 여전히 보이는지 확인

## Related

- RFC-0128 (spec) `docs/rfc/RFC-0128-ide-canonical-url-partitioning.md`
- PR-1a/b/c/e (#16020/#16028/#16036/#16044) — Phase 1 stack
- PR-3 (예정) — Phase 3 flat-file purge migration. Legacy 데이터를 by-url/_orphan 으로 옮기고 merge_legacy 를 제거.

Co-Authored-By: claude-opus-4-7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
