### PR TITLE
Account Autonomy_exec child lifetimes in FD accountant

### DIFF
--- a/lib/cdal_runtime/autonomy_exec.ml
+++ b/lib/cdal_runtime/autonomy_exec.ml
@@ -58,10 +58,9 @@ type capture =
 
 type run_guard = { run : 'a. (unit -> 'a) -> 'a }
 
-let default_run_guard = { run = (fun f -> f ()) }
-let run_guard : run_guard Atomic.t = Atomic.make default_run_guard
+let run_guard : run_guard Atomic.t = Atomic.make { run = (fun f -> f ()) }
 let set_run_guard guard = Atomic.set run_guard guard
-let reset_run_guard_for_testing () = Atomic.set run_guard default_run_guard
+let reset_run_guard_for_testing () = Atomic.set run_guard { run = (fun f -> f ()) }
 let with_run_guard f = (Atomic.get run_guard).run f
 
 open Result_syntax
@@ -323,8 +322,7 @@ let run ~sw ~clock ~config ~argv ~timeout_s =
              ; stderr = stderr_capture.text
              ; stdout_truncated = stdout_capture.truncated
              ; stderr_truncated = stderr_capture.truncated
-             (* NDT-OK: elapsed wall time is boundary telemetry for a completed external child;
-                policy decisions use status and bounded captures. *)
+             (* NDT-OK: boundary telemetry only; policy uses status and bounded captures. *)
              ; elapsed_s = Unix.gettimeofday () -. t0
              }
          in
@@ -442,36 +440,6 @@ let%test_unit "run captures stdout and stderr" =
     assert (output.stderr = "err");
     assert (output.status = Exit_code 0)
   | Error err -> failwith (Error.to_string err)
-;;
-
-let%test_unit "run guard wraps child lifetime" =
-  reset_run_guard_for_testing ();
-  let calls = Atomic.make 0 in
-  set_run_guard
-    { run =
-        (fun f ->
-          Atomic.incr calls;
-          f ())
-    };
-  Fun.protect
-    ~finally:reset_run_guard_for_testing
-    (fun () ->
-       with_eio
-       @@ fun ~sw ~clock ->
-       let result =
-         run
-           ~sw
-           ~clock
-           ~config:default_config
-           ~argv:[ "/bin/echo"; "guarded" ]
-           ~timeout_s:2.0
-       in
-       match result with
-       | Ok output ->
-         assert (String.trim output.stdout = "guarded");
-         assert (output.status = Exit_code 0);
-         assert (Atomic.get calls = 1)
-       | Error err -> failwith (Error.to_string err))
 ;;
 
 let%test_unit "run times out and returns Timed_out" =

--- a/lib/cdal_runtime/autonomy_exec.ml
+++ b/lib/cdal_runtime/autonomy_exec.ml
@@ -56,6 +56,14 @@ type capture =
   ; truncated : bool
   }
 
+type run_guard = { run : 'a. (unit -> 'a) -> 'a }
+
+let default_run_guard = { run = (fun f -> f ()) }
+let run_guard : run_guard Atomic.t = Atomic.make default_run_guard
+let set_run_guard guard = Atomic.set run_guard guard
+let reset_run_guard_for_testing () = Atomic.set run_guard default_run_guard
+let with_run_guard f = (Atomic.get run_guard).run f
+
 open Result_syntax
 
 let argv_to_string argv = String.concat " " (List.map Filename.quote argv)
@@ -276,76 +284,79 @@ let await_result promise map_exn =
 let run ~sw ~clock ~config ~argv ~timeout_s =
   let t0 = Unix.gettimeofday () in
   let* effective = effective_argv ~config ~argv in
-  let* pid, stdout_r, stderr_r = spawn_child ~sw config effective in
-  (* Pipe FDs are owned by [sw] via Switch.on_release in spawn_child.
-     Only the child lifecycle remains as a manual cleanup concern here.
-     [reaped] tracks whether waitpid has consumed the child, so the
-     finally clause only kills (and avoids a SIGKILL race) when needed. *)
-  let reaped = ref false in
-  Fun.protect
-    ~finally:(fun () -> if not !reaped then kill_child config pid)
-    (fun () ->
-       let wait_promise =
-         spawn_result_promise ~sw (fun () ->
-           Eio_unix.run_in_systhread ~label:"autonomy-exec-waitpid" (fun () ->
-             snd (Unix.waitpid [] pid)))
-       in
-       let stdout_promise =
-         spawn_result_promise ~sw (fun () ->
-           drain_fd ~limit:config.stdout_limit_bytes stdout_r)
-       in
-       let stderr_promise =
-         spawn_result_promise ~sw (fun () ->
-           drain_fd ~limit:config.stderr_limit_bytes stderr_r)
-       in
-       let capture_and_finish status =
-         let* stdout_capture =
-           await_result stdout_promise (fun exn ->
-             file_op_error ~op:"read" ~path:"stdout" ~detail:(Printexc.to_string exn))
+  with_run_guard (fun () ->
+    let* pid, stdout_r, stderr_r = spawn_child ~sw config effective in
+    (* Pipe FDs are owned by [sw] via Switch.on_release in spawn_child.
+       Only the child lifecycle remains as a manual cleanup concern here.
+       [reaped] tracks whether waitpid has consumed the child, so the
+       finally clause only kills (and avoids a SIGKILL race) when needed. *)
+    let reaped = ref false in
+    Fun.protect
+      ~finally:(fun () -> if not !reaped then kill_child config pid)
+      (fun () ->
+         let wait_promise =
+           spawn_result_promise ~sw (fun () ->
+             Eio_unix.run_in_systhread ~label:"autonomy-exec-waitpid" (fun () ->
+               snd (Unix.waitpid [] pid)))
          in
-         let* stderr_capture =
-           await_result stderr_promise (fun exn ->
-             file_op_error ~op:"read" ~path:"stderr" ~detail:(Printexc.to_string exn))
+         let stdout_promise =
+           spawn_result_promise ~sw (fun () ->
+             drain_fd ~limit:config.stdout_limit_bytes stdout_r)
          in
-         Ok
-           { effective_argv = effective
-           ; status
-           ; stdout = stdout_capture.text
-           ; stderr = stderr_capture.text
-           ; stdout_truncated = stdout_capture.truncated
-           ; stderr_truncated = stderr_capture.truncated
-           ; elapsed_s = Unix.gettimeofday () -. t0
-           }
-       in
-       try
-         let* unix_status =
-           Eio.Time.with_timeout_exn clock timeout_s (fun () ->
-             await_result wait_promise (fun exn ->
-               file_op_error
-                 ~op:"waitpid"
-                 ~path:(string_of_int pid)
-                 ~detail:(Printexc.to_string exn)))
+         let stderr_promise =
+           spawn_result_promise ~sw (fun () ->
+             drain_fd ~limit:config.stderr_limit_bytes stderr_r)
          in
-         reaped := true;
-         capture_and_finish (status_of_unix_status unix_status)
-       with
-       | Eio.Time.Timeout ->
-         kill_child config pid;
-         let timed_out_signal =
-           match
-             await_result wait_promise (fun exn ->
-               file_op_error
-                 ~op:"waitpid"
-                 ~path:(string_of_int pid)
-                 ~detail:(Printexc.to_string exn))
-           with
-           | Ok (Unix.WSIGNALED signal | Unix.WSTOPPED signal) -> Some signal
-           | Ok (Unix.WEXITED _) -> None
-           | Error _ -> None
+         let capture_and_finish status =
+           let* stdout_capture =
+             await_result stdout_promise (fun exn ->
+               file_op_error ~op:"read" ~path:"stdout" ~detail:(Printexc.to_string exn))
+           in
+           let* stderr_capture =
+             await_result stderr_promise (fun exn ->
+               file_op_error ~op:"read" ~path:"stderr" ~detail:(Printexc.to_string exn))
+           in
+           Ok
+             { effective_argv = effective
+             ; status
+             ; stdout = stdout_capture.text
+             ; stderr = stderr_capture.text
+             ; stdout_truncated = stdout_capture.truncated
+             ; stderr_truncated = stderr_capture.truncated
+             (* NDT-OK: elapsed wall time is boundary telemetry for a completed external child;
+                policy decisions use status and bounded captures. *)
+             ; elapsed_s = Unix.gettimeofday () -. t0
+             }
          in
-         reaped := true;
-         capture_and_finish (Timed_out timed_out_signal)
-       | Eio.Cancel.Cancelled _ as exn -> raise exn)
+         try
+           let* unix_status =
+             Eio.Time.with_timeout_exn clock timeout_s (fun () ->
+               await_result wait_promise (fun exn ->
+                 file_op_error
+                   ~op:"waitpid"
+                   ~path:(string_of_int pid)
+                   ~detail:(Printexc.to_string exn)))
+           in
+           reaped := true;
+           capture_and_finish (status_of_unix_status unix_status)
+         with
+         | Eio.Time.Timeout ->
+           kill_child config pid;
+           let timed_out_signal =
+             match
+               await_result wait_promise (fun exn ->
+                 file_op_error
+                   ~op:"waitpid"
+                   ~path:(string_of_int pid)
+                   ~detail:(Printexc.to_string exn))
+             with
+             | Ok (Unix.WSIGNALED signal | Unix.WSTOPPED signal) -> Some signal
+             | Ok (Unix.WEXITED _) -> None
+             | Error _ -> None
+           in
+           reaped := true;
+           capture_and_finish (Timed_out timed_out_signal)
+         | Eio.Cancel.Cancelled _ as exn -> raise exn))
 ;;
 
 [@@@coverage off]
@@ -431,6 +442,36 @@ let%test_unit "run captures stdout and stderr" =
     assert (output.stderr = "err");
     assert (output.status = Exit_code 0)
   | Error err -> failwith (Error.to_string err)
+;;
+
+let%test_unit "run guard wraps child lifetime" =
+  reset_run_guard_for_testing ();
+  let calls = Atomic.make 0 in
+  set_run_guard
+    { run =
+        (fun f ->
+          Atomic.incr calls;
+          f ())
+    };
+  Fun.protect
+    ~finally:reset_run_guard_for_testing
+    (fun () ->
+       with_eio
+       @@ fun ~sw ~clock ->
+       let result =
+         run
+           ~sw
+           ~clock
+           ~config:default_config
+           ~argv:[ "/bin/echo"; "guarded" ]
+           ~timeout_s:2.0
+       in
+       match result with
+       | Ok output ->
+         assert (String.trim output.stdout = "guarded");
+         assert (output.status = Exit_code 0);
+         assert (Atomic.get calls = 1)
+       | Error err -> failwith (Error.to_string err))
 ;;
 
 let%test_unit "run times out and returns Timed_out" =

--- a/lib/cdal_runtime/autonomy_exec.mli
+++ b/lib/cdal_runtime/autonomy_exec.mli
@@ -48,6 +48,14 @@ type output =
   ; elapsed_s : float
   }
 
+type run_guard = { run : 'a. (unit -> 'a) -> 'a }
+(** Process-wide wrapper around {!run}'s child lifetime. The guard is
+    entered after argv/config validation and released only after spawn,
+    waitpid, timeout handling, and stdout/stderr drain complete. *)
+
+val set_run_guard : run_guard -> unit
+val reset_run_guard_for_testing : unit -> unit
+
 (** Shell-quoted rendering for logs and diagnostics. *)
 val argv_to_string : string list -> string
 

--- a/lib/server/fd_accountant.ml
+++ b/lib/server/fd_accountant.ml
@@ -161,15 +161,9 @@ let read_fd_limit () =
   | Some value -> value
   | None ->
     let value =
-      try
-        let chan = Unix.open_process_in "ulimit -n" in
-        let line = input_line chan in
-        let _ = Unix.close_process_in chan in
-        match int_of_string_opt (String.trim line) with
-        | Some n -> n
-        | None -> -1
-      with
-      | _ -> -1
+      match Keeper_fd_pressure.process_nofile_soft_limit () with
+      | Some n -> n
+      | None -> -1
     in
     Atomic.set fd_limit_cache (Some value);
     value

--- a/lib/server/fd_accountant.ml
+++ b/lib/server/fd_accountant.ml
@@ -114,10 +114,21 @@ let install_with_process_sandbox_exec_guard () =
             f ())
     }
 
+let install_autonomy_exec_sandbox_exec_guard () =
+  Masc_mcp_cdal_runtime.Autonomy_exec.set_run_guard
+    { Masc_mcp_cdal_runtime.Autonomy_exec.run =
+        (fun f ->
+          if Eio_guard.is_ready () then
+            with_slot ~kind:Sandbox_exec f
+          else
+            f ())
+    }
+
 let () =
   install_dated_jsonl_log_writer_guard ();
   install_process_eio_sandbox_exec_guard ();
-  install_with_process_sandbox_exec_guard ()
+  install_with_process_sandbox_exec_guard ();
+  install_autonomy_exec_sandbox_exec_guard ()
 
 (* In-flight count = configured cap minus current semaphore credits.
    Eio.Semaphore exposes [get_value] which returns the available credit

--- a/lib/server/fd_accountant.mli
+++ b/lib/server/fd_accountant.mli
@@ -86,6 +86,13 @@ val install_with_process_sandbox_exec_guard : unit -> unit
     subprocess lifetime: open, caller drain, and close. Before Eio startup, the
     guard runs directly so pure test/module paths stay safe. *)
 
+val install_autonomy_exec_sandbox_exec_guard : unit -> unit
+(** [install_autonomy_exec_sandbox_exec_guard ()] installs the process-wide
+    {!Masc_mcp_cdal_runtime.Autonomy_exec} guard that accounts autonomy-loop
+    child execution as {!Sandbox_exec} while {!Eio_guard} is ready. The slot
+    covers the whole child lifetime, including waitpid, timeout handling, and
+    stdout/stderr drain. *)
+
 type snapshot = {
   per_kind : (kind * int) list ;
       (** in-flight count per class (cap − available semaphore slots). *)

--- a/test/test_fd_accountant.ml
+++ b/test/test_fd_accountant.ml
@@ -224,6 +224,34 @@ let test_with_process_uses_sandbox_slot () =
       check int "With_process sandbox slot released" 0
         (kind_in_flight FA.Sandbox_exec))
 
+let test_autonomy_exec_run_uses_sandbox_slot () =
+  Eio_main.run @@ fun env ->
+  Eio_guard.enable () ;
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp_cdal_runtime.Autonomy_exec.reset_run_guard_for_testing () ;
+      Eio_guard.disable ())
+    (fun () ->
+      Masc_mcp_cdal_runtime.Autonomy_exec.reset_run_guard_for_testing () ;
+      FA.install_autonomy_exec_sandbox_exec_guard () ;
+      let clock = Eio.Stdenv.clock env in
+      let () =
+        Eio.Switch.run @@ fun sw ->
+        Eio.Fiber.fork ~sw (fun () ->
+            ignore
+              (Masc_mcp_cdal_runtime.Autonomy_exec.run
+                 ~sw
+                 ~clock
+                 ~config:Masc_mcp_cdal_runtime.Autonomy_exec.default_config
+                 ~argv:[ "/bin/sleep"; "0.05" ]
+                 ~timeout_s:2.0)) ;
+        check bool "Autonomy_exec holds sandbox slot while child runs" true
+          (wait_until ~clock ~attempts:100 (fun () ->
+               kind_in_flight FA.Sandbox_exec > 0))
+      in
+      check int "Autonomy_exec sandbox slot released" 0
+        (kind_in_flight FA.Sandbox_exec))
+
 let () =
   Alcotest.run "Fd_accountant"
     [
@@ -262,5 +290,7 @@ let () =
             test_process_eio_run_argv_uses_sandbox_slot ;
           test_case "With_process uses sandbox slot" `Quick
             test_with_process_uses_sandbox_slot ;
+          test_case "Autonomy_exec run uses sandbox slot" `Quick
+            test_autonomy_exec_run_uses_sandbox_slot ;
         ] ) ;
     ]

--- a/test/test_fd_accountant.ml
+++ b/test/test_fd_accountant.ml
@@ -41,6 +41,14 @@ let test_configured_within_bounds () =
           (FA.kind_to_string k) cap)
     FA.all_kinds
 
+let test_fd_limit_reuses_keeper_pressure_cache () =
+  let expected = 4242 in
+  Atomic.set
+    Masc_mcp.Keeper_fd_pressure.nofile_soft_limit_cache
+    (Masc_mcp.Keeper_fd_pressure.Resolved (Some expected));
+  let snapshot = FA.fd_snapshot () in
+  check int "fd_limit from Keeper_fd_pressure cache" expected snapshot.fd_limit
+
 let test_with_slot_runs_callback () =
   Eio_main.run @@ fun _env ->
   let result = FA.with_slot ~kind:Docker_spawn (fun () -> 42) in
@@ -261,6 +269,8 @@ let () =
           test_case "unknown rejected" `Quick test_kind_unknown_rejected ;
           test_case "cap within bounds" `Quick
             test_configured_within_bounds ;
+          test_case "fd limit reuses Keeper_fd_pressure cache" `Quick
+            test_fd_limit_reuses_keeper_pressure_cache ;
         ] ) ;
       ( "slot semantics",
         [


### PR DESCRIPTION
## Summary
- add a process-wide Autonomy_exec run guard that wraps the child execution lifetime after argv/config validation
- install the guard from Fd_accountant as Sandbox_exec while Eio_guard is ready
- make Fd_accountant fd_limit snapshots reuse Keeper_fd_pressure's single-flight nofile probe instead of spawning another shell
- cover Autonomy_exec slot accounting and fd_limit cache reuse in test_fd_accountant

## Verification
- ocamlformat --check lib/cdal_runtime/autonomy_exec.mli lib/cdal_runtime/autonomy_exec.ml lib/server/fd_accountant.mli lib/server/fd_accountant.ml test/test_fd_accountant.ml
- git diff --check
- bash scripts/ci/check-determinism-contract.sh
- python3 scripts/ci/check-fun-protect-finally-guard.py
- bash scripts/health_snapshot.sh --skip-build --baseline-ref origin/main --fail-on-lib-regression
- scripts/dune-local.sh build test/test_fd_accountant.exe @lib/cdal_runtime/runtest
- ./_build/default/test/test_fd_accountant.exe

## Notes
- Draft/do-not-merge while the broader sandbox runtime plane PR stack settles.
- This intentionally keeps cdal_runtime generic; MASC-specific FD accounting is installed from Fd_accountant.
