### PR TITLE
fix(keeper): treat code-search no-match as shell success

### DIFF
--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -64,6 +64,41 @@ let validate_code_shell_command (command : string) : (unit, string) Result.t =
        (Worker_dev_tools.block_reason_to_string_with_allowlist
           ~allowed_commands:allowed_shell_commands)
 
+type code_shell_exit_status =
+  | Shell_ok
+  | Shell_ok_expected_nonzero of string
+  | Shell_error
+
+let first_token_basename segment =
+  let trimmed = String.trim segment in
+  if String.equal trimmed "" then None
+  else
+    let len = String.length trimmed in
+    let rec find_sep i =
+      if i >= len then len
+      else
+        match trimmed.[i] with
+        | ' ' | '\t' -> i
+        | _ -> find_sep (i + 1)
+    in
+    Some (Filename.basename (String.sub trimmed 0 (find_sep 0)))
+
+let last_pipeline_command_name command =
+  command
+  |> String.split_on_char '|'
+  |> List.rev
+  |> List.find_map first_token_basename
+
+let classify_code_shell_exit ~command code =
+  match code with
+  | 0 -> Shell_ok
+  | 1 -> (
+      match last_pipeline_command_name command with
+      | Some ("rg" | "grep") -> Shell_ok_expected_nonzero "no_matches"
+      | Some "diff" -> Shell_ok_expected_nonzero "differences"
+      | _ -> Shell_error)
+  | _ -> Shell_error
+
 let git_common_root path =
   try
     match
@@ -686,16 +721,28 @@ let handle_code_shell ~tool_name ~start_time ctx args =
              in
              match Masc_exec.Exec_gate.run_argv_with_status ~actor:`Tool_local_runtime ~raw_source:(String.concat " " full_cmd) ~summary:"shell command execution" ~timeout_sec:safe_timeout full_cmd with
              | Unix.WEXITED code, output ->
-                 let response = `Assoc [
-                   ("status", `String (if code = 0 then "ok" else "error"));
-                   ("exit_code", `Int code);
-                   ("output", `String (truncate_output output));
-                   ("command", `String command);
-                   ("agent", `String ctx.agent_name);
-                 ] in
-                 (if code = 0
-                  then fun msg -> Tool_result.ok ~tool_name ~start_time msg
-                  else fun msg -> Tool_result.error ~tool_name ~start_time msg)
+                 let exit_status = classify_code_shell_exit ~command code in
+                 let response_fields =
+                   [
+                     ( "status",
+                       `String (match exit_status with Shell_error -> "error" | _ -> "ok") );
+                     ("exit_code", `Int code);
+                     ("output", `String (truncate_output output));
+                     ("command", `String command);
+                     ("agent", `String ctx.agent_name);
+                   ]
+                   @
+                   match exit_status with
+                   | Shell_ok_expected_nonzero reason ->
+                       [ ("exit_semantics", `String reason) ]
+                   | Shell_ok | Shell_error -> []
+                 in
+                 let response = `Assoc response_fields in
+                 (match exit_status with
+                  | Shell_ok | Shell_ok_expected_nonzero _ ->
+                      fun msg -> Tool_result.ok ~tool_name ~start_time msg
+                  | Shell_error ->
+                      fun msg -> Tool_result.error ~tool_name ~start_time msg)
                    (Yojson.Safe.pretty_to_string response)
              | _, output ->
                  Tool_result.error ~tool_name ~start_time (Printf.sprintf "Command failed: %s" (truncate_output output)))

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -27,6 +27,14 @@ let json_string_field key text =
      | _ -> fail ("missing JSON string field: " ^ key))
   | _ -> fail "expected JSON object"
 
+let json_int_field key text =
+  match Yojson.Safe.from_string text with
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`Int value) -> value
+     | _ -> fail ("missing JSON int field: " ^ key))
+  | _ -> fail "expected JSON object"
+
 let tool_code_write_policy_load_failure_metric () =
   Prometheus.metric_value_or_zero
     Masc_mcp.Keeper_metrics.metric_keeper_tool_policy_failures
@@ -574,6 +582,64 @@ let test_code_shell_missing_docker_cwd_reports_worktree_hint () =
   check bool "error suggests worktree creation" true
     (contains "masc_worktree_create" msg)
 
+let test_code_shell_rg_exit_one_no_matches_is_success () =
+  with_temp_dir "tool-code-shell-rg" @@ fun dir ->
+  let fixture = Filename.concat dir "sample.ml" in
+  write_file fixture "let present = 1\n";
+  let ctx = make_ctx () in
+  let args =
+    `Assoc
+      [
+        ( "command",
+          `String
+            (Printf.sprintf "rg __masc_code_shell_16015_no_match__ %s"
+               (Filename.quote fixture)) );
+        ("timeout", `Int 5);
+      ]
+  in
+  let ok, msg = dispatch_exn ctx ~name:"masc_code_shell" ~args in
+  check bool "rg no-match exit 1 is a successful empty result" true ok;
+  check string "status" "ok" (json_string_field "status" msg);
+  check int "exit_code" 1 (json_int_field "exit_code" msg);
+  check string "exit_semantics" "no_matches"
+    (json_string_field "exit_semantics" msg)
+
+let test_code_shell_grep_exit_one_no_matches_is_success () =
+  with_temp_dir "tool-code-shell-grep" @@ fun dir ->
+  let fixture = Filename.concat dir "sample.txt" in
+  write_file fixture "present\n";
+  let ctx = make_ctx () in
+  let args =
+    `Assoc
+      [
+        ( "command",
+          `String
+            (Printf.sprintf "grep __masc_code_shell_16015_no_match__ %s"
+               (Filename.quote fixture)) );
+        ("timeout", `Int 5);
+      ]
+  in
+  let ok, msg = dispatch_exn ctx ~name:"masc_code_shell" ~args in
+  check bool "grep no-match exit 1 is a successful empty result" true ok;
+  check string "status" "ok" (json_string_field "status" msg);
+  check int "exit_code" 1 (json_int_field "exit_code" msg);
+  check string "exit_semantics" "no_matches"
+    (json_string_field "exit_semantics" msg)
+
+let test_code_shell_rg_exit_two_remains_error () =
+  let ctx = make_ctx () in
+  let args =
+    `Assoc
+      [
+        ("command", `String "rg --regexp [");
+        ("timeout", `Int 5);
+      ]
+  in
+  let ok, msg = dispatch_exn ctx ~name:"masc_code_shell" ~args in
+  check bool "rg syntax error stays failed" false ok;
+  check string "status" "error" (json_string_field "status" msg);
+  check int "exit_code" 2 (json_int_field "exit_code" msg)
+
 let test_code_git_missing_docker_cwd_reports_worktree_hint () =
   let base_path = fresh_base_path () in
   let config = make_config base_path in
@@ -793,6 +859,12 @@ let () =
         test_validate_code_shell_command_rejects_semicolon;
       test_case "missing docker cwd reports worktree hint" `Quick
         test_code_shell_missing_docker_cwd_reports_worktree_hint;
+      test_case "rg exit 1 no-match is success" `Quick
+        test_code_shell_rg_exit_one_no_matches_is_success;
+      test_case "grep exit 1 no-match is success" `Quick
+        test_code_shell_grep_exit_one_no_matches_is_success;
+      test_case "rg exit 2 remains error" `Quick
+        test_code_shell_rg_exit_two_remains_error;
     ]);
     ("per_agent_containment_6527_iter6", [
       test_case "writable_path allows own playground" `Quick


### PR DESCRIPTION
## Summary
- classify masc_code_shell exit 1 from rg/grep as successful no-match semantics
- classify diff exit 1 as successful differences semantics while keeping exit 2+ as errors
- add dispatch coverage proving rg/grep no-match success and rg syntax errors still fail

Closes #16015

## Verification
- scripts/dune-local.sh build ./test/test_tool_code_write_coverage.exe
- ./_build/default/test/test_tool_code_write_coverage.exe
- opam exec -- ocamlformat --check lib/tool_code_write.ml test/test_tool_code_write_coverage.ml
- git diff --check
- bash scripts/lint/no-ocaml-comment-terminator-trap.sh