### PR TITLE
Bound quick-suite CI step timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -608,6 +608,10 @@ jobs:
       - name: Run tests (quick suite)
         id: quick_suite
         continue-on-error: true
+        # scripts/ci-run-tests.sh has its own 1200s timeout and diagnostics,
+        # but this step-level bound keeps a stuck timeout/diagnostic path from
+        # holding the shared runner for the full Build and Test job budget.
+        timeout-minutes: 25
         env:
           ME_ROOT: /tmp/me
           ALCOTEST_QUICK_TESTS: "1"


### PR DESCRIPTION
## Summary
- add a 25-minute GitHub Actions step timeout to Run tests (quick suite)
- keep the existing scripts/ci-run-tests.sh 1200s internal timeout and diagnostics as the primary failure signal
- prevent a stuck timeout/diagnostic path from holding the shared Build and Test runner for the full 60-minute job budget

## Verification
- git diff --check
- bash scripts/lint/yaml-syntax.sh

## Notes
- Draft/do-not-merge while we observe the current quick-suite stalls.
- This is a CI resource bound only; it does not change the quick-suite command or test selection.