### PR TITLE
fix(keeper): flag reaction capacity shortfall

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -239,6 +239,62 @@ describe('dashboardHealthChips', () => {
     expect(chips[0]?.detail).toContain('blocker=reaction_capacity_below_target')
   })
 
+  it('does not treat non-FD fleet blocked counts as FD pressure', () => {
+    const chips = dashboardHealthChips({
+      connected: true,
+      counts: { keepers: 24, configured_keepers: 24 },
+      keepers: [],
+      runtimeResolution: {
+        status: 'ready',
+        warnings: [],
+        fleet_safety: {
+          keeper_fibers: 8,
+          paused_keepers: 0,
+          keeper_fleet_no_fibers: false,
+          keeper_fd_pressure: null,
+          keeper_fleet_safety: {
+            status: 'degraded',
+            reason: null,
+            blocker: 'reaction_capacity_below_target',
+            admission_blocked: null,
+            admission_blocked_keepers: null,
+            blocked_keepers: 24,
+            blocked_count: 24,
+            bootable_keeper_count: 24,
+            running_keeper_fiber_count: 8,
+            healthy_running_keeper_fiber_count: 8,
+            failing_keeper_fiber_count: 0,
+            executable_keeper_fiber_count: 8,
+            minimum_running_fibers: 2,
+            no_running_fibers: false,
+            no_executable_keeper_fibers: false,
+            low_running_fiber_margin: false,
+            reaction_capacity_below_target: true,
+            reaction_capacity_shortfall_count: 16,
+            executable_reaction_capacity_below_target: true,
+            executable_reaction_capacity_shortfall_count: 16,
+            paused_keeper_count: 0,
+            autoboot_enabled_keeper_count: 24,
+            paused_autoboot_enabled_keeper_count: 0,
+            effective_reaction_capacity_count: 8,
+            executable_reaction_capacity_count: 8,
+            target_reaction_capacity_count: 24,
+            operator_action_required: true,
+          },
+        },
+      } as any,
+      executionError: null,
+      loading: false,
+    })
+
+    expect(chips).toEqual([expect.objectContaining({
+      key: 'fleet-liveness-risk',
+      label: 'Fleet capacity degraded',
+      tone: 'warn',
+    })])
+    expect(chips[0]?.detail).not.toContain('FD pressure')
+  })
+
   it('surfaces fleet liveness risk when FD pressure blocks 24 keepers', () => {
     const chips = dashboardHealthChips({
       connected: true,

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -274,6 +274,69 @@ describe('dashboardHealthChips', () => {
     expect(chips[0]?.detail).toContain('blocking 24 keepers')
   })
 
+  it('prioritizes FD pressure over degraded capacity when both are present', () => {
+    const chips = dashboardHealthChips({
+      connected: true,
+      counts: { keepers: 24, configured_keepers: 24 },
+      keepers: [],
+      runtimeResolution: {
+        status: 'ready',
+        warnings: [],
+        fleet_safety: {
+          keeper_fibers: 8,
+          paused_keepers: 0,
+          keeper_fleet_no_fibers: false,
+          keeper_fd_pressure: {
+            status: 'blocked',
+            reason: 'fd_pressure',
+            admission_blocked: true,
+            admission_blocked_keepers: 24,
+            blocked_keepers: null,
+            blocked_count: null,
+          },
+          keeper_fleet_safety: {
+            status: 'degraded',
+            reason: null,
+            blocker: 'reaction_capacity_below_target',
+            admission_blocked: null,
+            admission_blocked_keepers: null,
+            blocked_keepers: null,
+            blocked_count: null,
+            bootable_keeper_count: 24,
+            running_keeper_fiber_count: 8,
+            healthy_running_keeper_fiber_count: 8,
+            failing_keeper_fiber_count: 0,
+            executable_keeper_fiber_count: 8,
+            minimum_running_fibers: 2,
+            no_running_fibers: false,
+            no_executable_keeper_fibers: false,
+            low_running_fiber_margin: false,
+            reaction_capacity_below_target: true,
+            reaction_capacity_shortfall_count: 16,
+            executable_reaction_capacity_below_target: true,
+            executable_reaction_capacity_shortfall_count: 16,
+            paused_keeper_count: 0,
+            autoboot_enabled_keeper_count: 24,
+            paused_autoboot_enabled_keeper_count: 0,
+            effective_reaction_capacity_count: 8,
+            executable_reaction_capacity_count: 8,
+            target_reaction_capacity_count: 24,
+            operator_action_required: true,
+          },
+        },
+      } as any,
+      executionError: null,
+      loading: false,
+    })
+
+    expect(chips).toEqual([expect.objectContaining({
+      key: 'fleet-liveness-risk',
+      label: 'Fleet liveness risk',
+      tone: 'bad',
+    })])
+    expect(chips[0]?.detail).toContain('blocking 24 keepers')
+  })
+
   it('surfaces reaction ledger cursor sweeps even when pending backlog is clear', () => {
     const chips = dashboardHealthChips({
       connected: true,

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -172,14 +172,11 @@ function keeperLooksPaused(keeper: Keeper): boolean {
   return keeper.paused === true || phase === 'paused' || stage === 'paused' || status === 'paused'
 }
 
-function fleetPressureBlockedKeepers(fleetSafety: DashboardFleetSafetyHealth): number {
+function fdPressureBlockedKeepers(fleetSafety: DashboardFleetSafetyHealth): number {
   const candidates = [
     fleetSafety.keeper_fd_pressure?.admission_blocked_keepers,
     fleetSafety.keeper_fd_pressure?.blocked_keepers,
     fleetSafety.keeper_fd_pressure?.blocked_count,
-    fleetSafety.keeper_fleet_safety?.admission_blocked_keepers,
-    fleetSafety.keeper_fleet_safety?.blocked_keepers,
-    fleetSafety.keeper_fleet_safety?.blocked_count,
   ].filter((value): value is number => typeof value === 'number' && Number.isFinite(value))
   return candidates.length > 0 ? Math.max(...candidates) : 0
 }
@@ -206,7 +203,7 @@ function fleetSafetyHealthChip(fleetSafety: DashboardFleetSafetyHealth | null): 
   const capacityShortfall = fleet?.reaction_capacity_shortfall_count ?? (
     targetCapacity != null && runningFibers != null ? Math.max(0, targetCapacity - runningFibers) : null
   )
-  const blocked = fleetPressureBlockedKeepers(fleetSafety)
+  const fdPressureBlocked = fdPressureBlockedKeepers(fleetSafety)
   if (fleetStatus === 'blocked' || (requiresAction && (runningFibers === 0 || noFibers === true))) {
     const capacityDetail = [
       `status=${fleetStatus ?? 'blocked'}`,
@@ -224,11 +221,11 @@ function fleetSafetyHealthChip(fleetSafety: DashboardFleetSafetyHealth | null): 
       tone: 'bad',
     }
   }
-  if (blocked >= 24) {
+  if (fdPressureBlocked >= 24) {
     return {
       key: 'fleet-liveness-risk',
       label: 'Fleet liveness risk',
-      detail: `FD pressure admission is blocking ${blocked} keepers; keeper turns may not start.`,
+      detail: `FD pressure admission is blocking ${fdPressureBlocked} keepers; keeper turns may not start.`,
       tone: 'bad',
     }
   }

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -224,6 +224,14 @@ function fleetSafetyHealthChip(fleetSafety: DashboardFleetSafetyHealth | null): 
       tone: 'bad',
     }
   }
+  if (blocked >= 24) {
+    return {
+      key: 'fleet-liveness-risk',
+      label: 'Fleet liveness risk',
+      detail: `FD pressure admission is blocking ${blocked} keepers; keeper turns may not start.`,
+      tone: 'bad',
+    }
+  }
   if (fleetStatus === 'degraded' || (requiresAction && capacityBelowTarget)) {
     const capacityDetail = [
       `status=${fleetStatus ?? 'degraded'}`,
@@ -239,14 +247,6 @@ function fleetSafetyHealthChip(fleetSafety: DashboardFleetSafetyHealth | null): 
       label: 'Fleet capacity degraded',
       detail: `${capacityDetail}; restore missing keeper fibers or confirm a reduced target capacity.`,
       tone: 'warn',
-    }
-  }
-  if (blocked >= 24) {
-    return {
-      key: 'fleet-liveness-risk',
-      label: 'Fleet liveness risk',
-      detail: `FD pressure admission is blocking ${blocked} keepers; keeper turns may not start.`,
-      tone: 'bad',
     }
   }
   if (fleetSafety.keeper_fleet_no_fibers === true || (fibers != null && fibers <= 1 && paused > 0)) {


### PR DESCRIPTION
## Summary

Replacement focused PR for issue #16047. The earlier draft PR #16050 branch was overwritten by an unrelated large diff after local verification, so this PR preserves the focused P0-D patch without force-pushing over other work.

- Degrade fleet health when healthy running reaction capacity is below target.
- Distinguish healthy running capacity from executable/failing capacity because `Failing` keepers can still execute turns.
- Surface dashboard warnings for partial capacity collapse, not only total zero-fiber collapse.

## Local verification

- `opam exec -- ocamlformat --check lib/server/server_routes_http_runtime.ml lib/server/server_routes_http_runtime.mli test/test_server_runtime_bootstrap.ml`
- `scripts/dune-local.sh build ./test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe test --quick-tests --show-errors bootstrap 33-36` -> 4 tests passed
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/dashboard-shell.test.ts src/store-normalizers.test.ts` -> 2 files, 18 tests passed
- `git diff --check`

Refs #16047.