### PR TITLE
fix(keeper): enforce single active task ownership

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -126,6 +126,30 @@ let transition_task_r
             | Masc_domain.Approve_verification | Masc_domain.Reject_verification
             | Masc_domain.Submit_pr_evidence ), _ -> Ok ()
         in
+        let* () =
+          (match action, task.task_status with
+          | Masc_domain.Claim, Masc_domain.Todo ->
+            (match
+               active_ownership_conflict_for_claim
+                 config
+                 ~agent_name
+                 ~requested_task_id:task_id
+                 backlog
+             with
+             | None -> Ok ()
+             | Some msg ->
+               Error (Masc_domain.Task (Masc_domain.Task_error.InvalidState msg)))
+          | ( Masc_domain.Claim
+            | Masc_domain.Start
+            | Masc_domain.Done_action
+            | Masc_domain.Cancel
+            | Masc_domain.Release
+            | Masc_domain.Submit_for_verification
+            | Masc_domain.Submit_pr_evidence
+            | Masc_domain.Approve_verification
+            | Masc_domain.Reject_verification ), _ -> Ok ())
+          [@warning "-4"]
+        in
         let now = now_iso () in
         let now_ts = Time_compat.now () in
         let action_s = Masc_domain.task_action_to_string action in

--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -73,6 +73,43 @@ let clear_stale_worktree_binding (task : Masc_domain.task) =
   | Some _ -> { task with worktree = None }
 ;;
 
+let active_owned_task_ids_for_agent config ~agent_name (backlog : Masc_domain.backlog)
+  =
+  backlog.tasks
+  |> List.filter_map (fun (task : Masc_domain.task) ->
+         match task.task_status with
+         | Claimed { assignee; _ } | InProgress { assignee; _ }
+           when Coord_task_classify.same_task_actor config assignee agent_name ->
+           Some task.id
+         | Todo
+         | Claimed _
+         | InProgress _
+         | AwaitingVerification _
+         | Done _
+         | Cancelled _ -> None)
+  |> List.sort_uniq String.compare
+;;
+
+let active_ownership_conflict_message ~agent_name ~requested_task_id task_ids =
+  Printf.sprintf
+    "Agent %s already owns active task(s): %s. Finish, release, or cancel them \
+     before claiming %s."
+    agent_name
+    (String.concat ", " task_ids)
+    requested_task_id
+;;
+
+let active_ownership_conflict_for_claim config ~agent_name ~requested_task_id
+    (backlog : Masc_domain.backlog) =
+  match
+    active_owned_task_ids_for_agent config ~agent_name backlog
+    |> List.filter (fun task_id -> not (String.equal task_id requested_task_id))
+  with
+  | [] -> None
+  | task_ids ->
+    Some (active_ownership_conflict_message ~agent_name ~requested_task_id task_ids)
+;;
+
 (** Claim task with file locking (TOCTOU prevention) *)
 let claim_task config ~agent_name ~task_id =
   ensure_initialized config;
@@ -90,6 +127,14 @@ let claim_task config ~agent_name ~task_id =
            let found = ref false in
            let already_claimed = ref None in
            let blocked_reason = ref None in
+           let ownership_conflict = ref None in
+           let active_conflict =
+             active_ownership_conflict_for_claim
+               config
+               ~agent_name
+               ~requested_task_id:task_id
+               backlog
+           in
            let new_tasks =
              List.map
                (fun (task : task) ->
@@ -102,6 +147,9 @@ let claim_task config ~agent_name ~task_id =
                      | None -> ());
                     match task.task_status with
                     | _ when !blocked_reason <> None -> task
+                    | Todo when Option.is_some active_conflict ->
+                      ownership_conflict := active_conflict;
+                      task
                     | Todo ->
                       let task =
                         task
@@ -128,6 +176,9 @@ let claim_task config ~agent_name ~task_id =
              match !blocked_reason with
              | Some r -> Printf.sprintf "Task %s blocked from re-claim: %s" task_id r
              | None ->
+               (match !ownership_conflict with
+                | Some msg -> msg
+                | None ->
                (match !already_claimed with
                 | Some other ->
                   Printf.sprintf "Task %s is already claimed by %s" task_id other
@@ -174,7 +225,7 @@ let claim_task config ~agent_name ~task_id =
                            (Masc_domain.Claimed
                               { assignee = agent_name; claimed_at = now_iso () })
                          ());
-                  Printf.sprintf "%s claimed %s" agent_name task_id))
+                  Printf.sprintf "%s claimed %s" agent_name task_id)))
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | e -> Printf.sprintf "Error: %s" (Printexc.to_string e)))
@@ -226,6 +277,26 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
              Error
                (Masc_domain.Task (Masc_domain.Task_error.InvalidState
                   (Printf.sprintf "Task %s is blocked from re-claim: %s" task_id r)))
+         in
+         let* () =
+           match task.task_status with
+           | Todo ->
+             (match
+                active_ownership_conflict_for_claim
+                  config
+                  ~agent_name
+                  ~requested_task_id:task_id
+                  backlog
+              with
+              | None -> Ok ()
+              | Some msg ->
+                Error
+                  (Masc_domain.Task (Masc_domain.Task_error.InvalidState msg)))
+           | Claimed _
+           | InProgress _
+           | AwaitingVerification _
+           | Done _
+           | Cancelled _ -> Ok ()
          in
          (* fold_left to find+transform in a single pass without mutable refs.
          Uses polymorphic variants for inline state tracking. *)

--- a/lib/coord/coord_task_claim.mli
+++ b/lib/coord/coord_task_claim.mli
@@ -24,6 +24,20 @@ val clear_stale_worktree_binding : Masc_domain.task -> Masc_domain.task
 (** Clears per-claim worktree metadata before a new owner claims a task or a
     released task returns to [Todo]. *)
 
+val active_owned_task_ids_for_agent :
+  config -> agent_name:string -> Masc_domain.backlog -> string list
+(** Active [Claimed] or [InProgress] tasks owned by [agent_name], using the
+    same canonical keeper/agent identity comparison as task transitions. *)
+
+val active_ownership_conflict_for_claim :
+  config ->
+  agent_name:string ->
+  requested_task_id:string ->
+  Masc_domain.backlog ->
+  string option
+(** Returns an operator-facing error when [agent_name] already owns a
+    different active task and tries to claim [requested_task_id]. *)
+
 (** {1 Task claiming} *)
 
 val claim_task :

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -504,13 +504,13 @@ let claim_next_r
          it before the original owner had a chance to finish.  AwaitingVerification
          is still excluded: it is no longer active implementation work for
          the claimant. *)
+        let active_owned_task_ids =
+          Coord_task.active_owned_task_ids_for_agent config ~agent_name backlog
+        in
         let previous_claim =
           List.find_opt
             (fun (t : Masc_domain.task) ->
-               match t.task_status with
-               | Claimed { assignee; _ } | InProgress { assignee; _ } ->
-                 String.equal assignee agent_name
-               | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> false)
+               List.mem t.id active_owned_task_ids)
             backlog.tasks
         in
         (match previous_claim with

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -529,6 +529,58 @@ let test_claim_next_runs_post_provision_hook () =
              !observed)))
 ;;
 
+let test_claim_next_preserves_existing_alias_owned_task () =
+  with_room (fun config ->
+    let _ =
+      Coord.join
+        config
+        ~agent_name:"keeper-coder-agent"
+        ~capabilities:[ "keeper"; "code" ]
+        ()
+    in
+    let _ =
+      Coord.add_task
+        config
+        ~title:"Already owned"
+        ~priority:1
+        ~description:"desc"
+    in
+    let _ =
+      Coord.add_task
+        config
+        ~title:"Still todo"
+        ~priority:1
+        ~description:"desc"
+    in
+    (match
+       Coord.claim_task_r
+         config
+         ~agent_name:"keeper-coder-agent"
+         ~task_id:"task-001"
+         ()
+     with
+     | Ok _ -> ()
+     | Error err ->
+       fail (Masc_domain.masc_error_to_string err));
+    (match Coord.claim_next_r config ~agent_name:"keeper-coder" () with
+     | Coord.Claim_next_claimed { task_id; message; _ } ->
+       check string "returns existing active task" "task-001" task_id;
+       check bool "message says already holds" true
+         (contains_substring message "already holds")
+     | Coord.Claim_next_no_unclaimed ->
+       fail "expected existing claim, got no_unclaimed"
+     | Coord.Claim_next_no_eligible { excluded_count } ->
+       fail
+         (Printf.sprintf
+            "expected existing claim, got no_eligible excluded=%d"
+            excluded_count)
+     | Coord.Claim_next_error err ->
+       fail (Printf.sprintf "claim_next failed: %s" err));
+    match task_by_title config "Still todo" with
+    | { Masc_domain.task_status = Masc_domain.Todo; _ } -> ()
+    | _ -> fail "alias claim_next must not claim a second active task")
+;;
+
 let test_stale_current_task_id_is_cleared_from_backlog () =
   with_room (fun config ->
     let task_id =
@@ -972,10 +1024,14 @@ let test_claim_does_not_cross_goal_when_all_scoped_tasks_unavailable () =
         ~description:"terminal"
     in
     let done_task = task_by_title config "Scoped already done" in
-    ignore (Coord.claim_task config ~agent_name:"other-agent" ~task_id:done_task.id);
+    ignore
+      (Coord.claim_task
+         config
+         ~agent_name:"other-done-agent"
+         ~task_id:done_task.id);
     transition_task_exn
       config
-      ~agent_name:"other-agent"
+      ~agent_name:"other-done-agent"
       ~task_id:done_task.id
       ~action:Masc_domain.Done_action
       ~notes:"done"
@@ -2067,6 +2123,10 @@ let () =
             "claim-next runs post-provision hook"
             `Quick
             test_claim_next_runs_post_provision_hook
+        ; test_case
+            "claim-next preserves existing alias-owned task"
+            `Quick
+            test_claim_next_preserves_existing_alias_owned_task
         ; test_case
             "stale current_task_id clears from backlog"
             `Quick

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1073,6 +1073,49 @@ let () = test "handle_claim_sets_planning_current_task" (fun () ->
   assert (Planning_eio.get_current_task ctx.config = Some "task-001")
 )
 
+let () = test "handle_claim_rejects_second_active_owned_task" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ =
+    Tool_task.handle_add_task
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc [ ("title", `String "First active task") ])
+  in
+  let _ =
+    Tool_task.handle_add_task
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc [ ("title", `String "Second active task") ])
+  in
+  let first =
+    Tool_task.handle_claim
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc [ ("task_id", `String "task-001") ])
+  in
+  if not first.Tool_result.success then failwith first.Tool_result.legacy_message;
+  let second =
+    Tool_task.handle_claim
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc [ ("task_id", `String "task-002") ])
+  in
+  assert (not second.Tool_result.success);
+  assert (str_contains second.Tool_result.legacy_message "already owns active task(s)");
+  let task_002 =
+    Coord.get_tasks_raw ctx.config
+    |> List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id "task-002")
+  in
+  match task_002 with
+  | Some { task_status = Masc_domain.Todo; _ } -> ()
+  | Some _ -> failwith "task-002 should remain todo"
+  | None -> failwith "task-002 missing"
+)
+
 let () = test "handle_claim_blocks_required_tools_without_server_surface" (fun () ->
   let ctx = make_test_ctx () in
   add_task_requiring_tools ctx ~title:"Needs bash" [ "keeper_bash" ];


### PR DESCRIPTION
Fixes #16011.

Summary:
- reject explicit second active task claims while an agent already owns claimed/in_progress work
- make claim_next_r preserve existing ownership using canonical keeper/agent identity instead of exact assignee string matching
- cover explicit second-claim rejection and alias-owned claim_next preservation with regression tests

Verification:
- opam exec -- ocamlformat --check lib/coord/coord_task_claim.ml lib/coord/coord_task_claim.mli lib/coord/coord_task_schedule.ml lib/coord/coord_task.ml test/test_tool_task_coverage.ml test/test_keeper_task_dispatch.ml
- git diff --check
- bash scripts/lint/no-ocaml-comment-terminator-trap.sh
- scripts/dune-local.sh build ./test/test_tool_task_coverage.exe ./test/test_keeper_task_dispatch.exe
- ./_build/default/test/test_tool_task_coverage.exe
- ./_build/default/test/test_keeper_task_dispatch.exe