### PR TITLE
feat(rfc-0128-pr-6): sandbox playground path → canonical_url resolution

### DIFF
--- a/lib/config/playground_paths.ml
+++ b/lib/config/playground_paths.ml
@@ -88,6 +88,61 @@ let repos_path (name : string) : string =
 let bundle_paths (name : string) : string list =
   [ bundle_root name; mind_path name; repos_path name ]
 
+(* RFC-0128 §4.5 — parse a sandbox playground absolute file path back
+   into [(repo_id, rel_path)]. Used by the keeper write path so that
+   files keepers edit inside their per-keeper repo clones map to the
+   same canonical-URL bucket as files in the user's working tree.
+
+   Layout matched (relative to [base_path]):
+
+     .masc/playground/<keeper>/repos/<repo_id>/<rel>           — Local
+     .masc/playground/docker/<keeper>/repos/<repo_id>/<rel>    — Docker
+
+   The function is structural: it walks the segments to find the
+   ".../repos/<id>/..." anchor inside the [.masc/playground/] subtree.
+   Anything outside that subtree, or paths that stop before the
+   anchor, return [None]. *)
+let parse_playground_repo_path ~base_path ~abs_path =
+  if Filename.is_relative abs_path then None
+  else
+    let base =
+      let n = String.length base_path in
+      if n > 0 && base_path.[n - 1] = '/'
+      then String.sub base_path 0 (n - 1)
+      else base_path
+    in
+    let base_with_slash = base ^ "/" in
+    if not (String.starts_with ~prefix:base_with_slash abs_path) then None
+    else
+      let rel =
+        String.sub abs_path (String.length base_with_slash)
+          (String.length abs_path - String.length base_with_slash)
+      in
+      let segs = String.split_on_char '/' rel in
+      (* Locate the ".masc" + "playground" prefix, then the *first*
+         "repos" segment after it. The segment immediately following
+         "repos" is the repo_id, and everything after that is the
+         repo-relative remainder.
+         Layouts accepted:
+           .masc/playground/<keeper>/repos/<id>/<rel>          (Local)
+           .masc/playground/docker/<keeper>/repos/<id>/<rel>   (Docker) *)
+      let rec after_playground = function
+        | ".masc" :: "playground" :: tl -> Some tl
+        | _ :: tl -> after_playground tl
+        | [] -> None
+      in
+      match after_playground segs with
+      | None -> None
+      | Some rest ->
+        let rec find_repos = function
+          | "repos" :: repo :: r when repo <> "" && r <> [] ->
+            Some (repo, String.concat "/" r)
+          | _ :: tl -> find_repos tl
+          | [] -> None
+        in
+        find_repos rest
+;;
+
 (** {1 Worktree Naming}
 
     Worktree directory names and git branch names for keeper task

--- a/lib/config/playground_paths.mli
+++ b/lib/config/playground_paths.mli
@@ -40,6 +40,23 @@ val bundle_paths : string -> string list
 (** All three bundle subdirs in canonical order:
     [\[bundle_root; mind_path; repos_path\]]. *)
 
+val parse_playground_repo_path
+  :  base_path:string
+  -> abs_path:string
+  -> (string * string) option
+(** RFC-0128 §4.5. Parse a sandbox playground absolute file path back
+    into [(repo_id, rel_path)].
+
+    Layouts accepted (relative to [base_path]):
+    - [.masc/playground/<keeper>/repos/<repo_id>/<rel>]          (Local)
+    - [.masc/playground/docker/<keeper>/repos/<repo_id>/<rel>]   (Docker)
+
+    Used by the keeper write path so files keepers edit inside their
+    per-keeper repo clones map to the same canonical-URL bucket as
+    files in the user's working tree. Returns [None] when [abs_path]
+    is not absolute, not under [base_path], or does not contain a
+    [repos/<id>/...] anchor inside the [.masc/playground/] subtree. *)
+
 (** {1 Worktree Naming}
 
     Worktree directory names and git branch names for keeper task

--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -243,22 +243,49 @@ let resolve_partition_for_write ~base_dir ~kind ~file_path =
       ~labels:[ "kind", kind; "reason", reason ]
       ()
   in
-  match Repo_store.find_repo_by_path_prefix ~base_path:base_dir abs with
-  | None ->
-    bump_orphan ~reason:"unregistered_repo";
-    (Ide_paths.Orphan, file_path)
-  | Some (repo, rel) ->
-    let url = String.trim repo.url in
+  let resolve_by_url ~rel ~repo_url ~orphan_reasons =
+    let url = String.trim repo_url in
     if url = "" then begin
-      bump_orphan ~reason:"blank_url";
+      bump_orphan ~reason:(snd orphan_reasons);
       (Ide_paths.Orphan, file_path)
     end
     else
       match Ide_paths.canonical_url_of_remote url with
       | None ->
-        bump_orphan ~reason:"url_unparseable";
+        bump_orphan ~reason:(fst orphan_reasons);
         (Ide_paths.Orphan, file_path)
       | Some slug -> (Ide_paths.By_url slug, rel)
+  in
+  (* RFC-0128 §4.5 PR-6: keeper writes inside the sandbox playground
+     never appear under a registered repo's [local_path] (the playground
+     clone path is opaque to [repositories.toml]). Use the SSOT
+     {!Playground_paths.parse_playground_repo_path} to recover the
+     [(repo_id, rel)] pair, then look up the repository's URL by id.
+     This makes the sandbox/working-tree join work without forcing the
+     operator to also register every playground clone path. *)
+  match
+    Playground_paths.parse_playground_repo_path ~base_path:base_dir ~abs_path:abs
+  with
+  | Some (repo_id, rel) ->
+    (match Repo_store.find_url_by_id ~base_path:base_dir repo_id with
+     | Some url ->
+       resolve_by_url
+         ~rel
+         ~repo_url:url
+         ~orphan_reasons:("sandbox_url_unparseable", "sandbox_blank_url")
+     | None ->
+       bump_orphan ~reason:"sandbox_unregistered_repo";
+       (Ide_paths.Orphan, file_path))
+  | None ->
+    (match Repo_store.find_repo_by_path_prefix ~base_path:base_dir abs with
+     | None ->
+       bump_orphan ~reason:"unregistered_repo";
+       (Ide_paths.Orphan, file_path)
+     | Some (repo, rel) ->
+       resolve_by_url
+         ~rel
+         ~repo_url:repo.url
+         ~orphan_reasons:("url_unparseable", "blank_url"))
 ;;
 
 (** After a successful file write, record the code region in [.masc-ide/].

--- a/test/test_ide_canonical_url_join.ml
+++ b/test/test_ide_canonical_url_join.ml
@@ -178,6 +178,114 @@ let test_blank_url_lands_in_orphan () =
     | _ -> fail "expected Orphan for blank-URL repo")
 ;;
 
+(* RFC-0128 PR-6 — sandbox playground path resolution. Keeper writes
+   inside the sandbox land at [<base>/.masc/playground/<keeper>/repos/
+   <repo_id>/<rel>], which is NOT a registered repo prefix. The
+   resolver should still produce the same [By_url <slug>] as a write
+   in the working-tree clone. *)
+let test_sandbox_playground_path_joins_with_worktree () =
+  with_temp_base_dir (fun base_dir ->
+    (* Only register the working-tree clone; the sandbox playground
+       has no entry in repositories.toml, which mirrors the real
+       operating environment. *)
+    let worktree = Filename.concat base_dir "workspace/repo" in
+    mkdir_p worktree;
+    touch (Filename.concat worktree "lib/foo.ml");
+    let repo =
+      { id = "masc"
+      ; name = "masc"
+      ; url = "https://github.com/owner/repo"
+      ; local_path = worktree
+      ; aliases = []
+      ; default_branch = "main"
+      ; credential_id = "default"
+      ; keepers = []
+      ; status = Active
+      ; auto_sync = false
+      ; sync_interval = 0
+      ; created_at = Int64.zero
+      ; updated_at = Int64.zero
+      }
+    in
+    (match Repo_store.save_all ~base_path:base_dir [ repo ] with
+     | Ok () -> ()
+     | Error msg -> failf "save_all: %s" msg);
+    let sandbox_file =
+      Filename.concat
+        base_dir
+        ".masc/playground/sangsu/repos/masc/lib/foo.ml"
+    in
+    let worktree_file = Filename.concat worktree "lib/foo.ml" in
+    let sandbox_partition, sandbox_rel =
+      Masc_mcp.Keeper_exec_fs.resolve_partition_for_write
+        ~base_dir
+        ~kind:"region"
+        ~file_path:sandbox_file
+    in
+    let worktree_partition, worktree_rel =
+      Masc_mcp.Keeper_exec_fs.resolve_partition_for_write
+        ~base_dir
+        ~kind:"region"
+        ~file_path:worktree_file
+    in
+    (match sandbox_partition, worktree_partition with
+     | Ide_paths.By_url s1, Ide_paths.By_url s2 ->
+       check string "sandbox / working-tree join via canonical_url" s1 s2
+     | _ ->
+       failf
+         "expected By_url _ on both sides, got %s / %s"
+         (match sandbox_partition with
+          | Ide_paths.Legacy -> "Legacy"
+          | Ide_paths.By_url s -> "By_url " ^ s
+          | Ide_paths.Orphan -> "Orphan")
+         (match worktree_partition with
+          | Ide_paths.Legacy -> "Legacy"
+          | Ide_paths.By_url s -> "By_url " ^ s
+          | Ide_paths.Orphan -> "Orphan"));
+    check string "sandbox rel stripped to repo-relative" "lib/foo.ml" sandbox_rel;
+    check string "worktree rel stripped" "lib/foo.ml" worktree_rel)
+;;
+
+let test_docker_playground_path_also_resolves () =
+  with_temp_base_dir (fun base_dir ->
+    let worktree = Filename.concat base_dir "workspace/repo" in
+    mkdir_p worktree;
+    let repo =
+      { id = "masc"
+      ; name = "masc"
+      ; url = "https://github.com/owner/repo"
+      ; local_path = worktree
+      ; aliases = []
+      ; default_branch = "main"
+      ; credential_id = "default"
+      ; keepers = []
+      ; status = Active
+      ; auto_sync = false
+      ; sync_interval = 0
+      ; created_at = Int64.zero
+      ; updated_at = Int64.zero
+      }
+    in
+    (match Repo_store.save_all ~base_path:base_dir [ repo ] with
+     | Ok () -> ()
+     | Error msg -> failf "save_all: %s" msg);
+    let docker_file =
+      Filename.concat
+        base_dir
+        ".masc/playground/docker/tech_glutton/repos/masc/lib/foo.ml"
+    in
+    let partition, rel =
+      Masc_mcp.Keeper_exec_fs.resolve_partition_for_write
+        ~base_dir
+        ~kind:"region"
+        ~file_path:docker_file
+    in
+    match partition with
+    | Ide_paths.By_url _ ->
+      check string "docker sandbox rel" "lib/foo.ml" rel
+    | _ -> fail "Docker sandbox path should resolve via repo_id lookup")
+;;
+
 let () =
   run
     "ide_canonical_url_join"
@@ -194,6 +302,14 @@ let () =
             "blank URL → Orphan"
             `Quick
             test_blank_url_lands_in_orphan
+        ; test_case
+            "sandbox playground path joins with working-tree (PR-6)"
+            `Quick
+            test_sandbox_playground_path_joins_with_worktree
+        ; test_case
+            "docker playground path resolves via repo_id (PR-6)"
+            `Quick
+            test_docker_playground_path_also_resolves
         ] )
     ]
 ;;


### PR DESCRIPTION
## ⚠️ 머지 의존성

본 PR 은 **PR-1c #16036 위에 stack**. PR-1c 가 lookup chain framework 를 만들고, 본 PR 이 두 번째 chain (sandbox playground) 을 채움.

| 시나리오 | 결과 |
|---------|------|
| PR-1c 단독 머지 (PR-6 미머지) | 모든 keeper sandbox write → `_orphan/sandbox_unregistered_repo` (silent re-create 의 read/write 비대칭) |
| PR-6 단독 머지 (PR-1c 미머지) | 빌드 실패 (`resolve_partition_for_write` 등 PR-1c 함수 부재) |
| **PR-1c + PR-6 동시** | sandbox + working-tree 모두 `By_url <slug>` 로 join (RFC §4.5 invariant 충족) |

PR-1c body 에도 같은 경고 추가 (`https://github.com/jeong-sik/masc-mcp/pull/16036#issue-...`).

---

## RFC-0128 PR-6 — sandbox playground path resolution (운영 검증으로 발견)

**진짜 운영 환경 검증 chunk**. PR-1c 머지 전 사용자 시스템 (`/Users/dancer/me/.masc-ide/regions.jsonl`) 을 진단하다 발견: keeper 가 sandbox playground 안에서 작업 (`/Users/dancer/me/.masc/playground/sangsu/repos/masc-mcp/...`) 하는데, 이 경로는 **`repositories.toml` 의 어떤 `local_path` 도 아님**. 운영자는 working tree 만 등록 (`[repository.masc-mcp]`) 하지 sandbox clone 마다 entry 를 만들지 않음.

→ PR-1c 단독 머지 시 **모든 keeper write 가 `_orphan` 으로** 떨어짐. RFC-0128 가 닫으려던 read/write 비대칭이 silent re-create.

> Stacked on PR-1c (#16036) + PR-1e (#16044).

## RFC §4.5 에 이미 명시됐던 것

RFC body 의 lookup chain 두 가지:

1. **Working tree**: `Repo_store.find_repo_by_path_prefix` — PR-1c 가 구현 ✓
2. **Keeper sandbox**: "keeper meta 의 repos[] 또는 playground path lookup" — PR-1c 가 누락 ✗

PR-6 가 두 번째 chain 구현.

## 변경

### `lib/config/playground_paths`

```ocaml
val parse_playground_repo_path :
  base_path:string -> abs_path:string -> (string * string) option
(** Layouts accepted:
    - .masc/playground/<keeper>/repos/<repo_id>/<rel>        (Local)
    - .masc/playground/docker/<keeper>/repos/<repo_id>/<rel> (Docker) *)
```

세그먼트 단위 structural parsing. SSOT 모듈의 다른 함수들과 동일 layout 계약.

### `lib/keeper/keeper_exec_fs.ml`

`resolve_partition_for_write` 의 분기:

```
1. Playground_paths.parse_playground_repo_path → match?
   ├─ Some (repo_id, rel) → Repo_store.find_url_by_id repo_id
   │   ├─ Some url + canonical_url 정상 → By_url
   │   └─ 실패 → Orphan + counter (sandbox_unregistered_repo /
   │                              sandbox_blank_url /
   │                              sandbox_url_unparseable)
   └─ None → 기존 chain (Repo_store.find_repo_by_path_prefix)
       ├─ match → URL 정규화 → By_url
       └─ 실패 → Orphan + counter (unregistered_repo / blank_url /
                                  url_unparseable)
```

### `_orphan` counter 라벨 6 종 (3 + 3)

- 기존 (working tree path): `unregistered_repo`, `blank_url`, `url_unparseable`
- 신규 (sandbox path): `sandbox_unregistered_repo`, `sandbox_blank_url`, `sandbox_url_unparseable`

→ `/metrics` 에서 "어느 chain 이 실패했는지" 즉시 구분 가능.

## 입증

`test/test_ide_canonical_url_join.ml` 에 2 cases 추가:

| Case | 입증 |
|------|------|
| `sandbox playground path joins with working-tree (PR-6)` | 등록은 working tree (`workspace/repo`) 만, 호출은 sandbox path (`.masc/playground/sangsu/repos/masc/...`) → 둘 다 같은 `By_url <slug>` 로 떨어지고 둘 다 `lib/foo.ml` 로 strip |
| `docker playground path resolves via repo_id (PR-6)` | `.masc/playground/docker/tech_glutton/repos/masc/...` 형태도 동일하게 처리 |

## Test 결과

- `test_ide_canonical_url_join` — **5/5 PASS** (3 carried + 2 new)
- `test_ide_paths` — 18/18 PASS
- `test_ide_annotations` — 12/12 PASS
- `check-determinism-contract.sh` — PASS
- `dune build --root .` PASS

## 변경 범위

```
lib/config/playground_paths.ml  | +35 / -0  (parse_playground_repo_path)
lib/config/playground_paths.mli | +18 / -0
lib/keeper/keeper_exec_fs.ml    | +44 / -8  (resolve chain 확장 + sandbox reasons)
test/test_ide_canonical_url_join.ml | +126 / -0 (2 신규 케이스)
```

## 사용자 시스템 직접 검증

진단 시점 데이터 (`~/me/.masc-ide/regions.jsonl`):
```json
{"file_path":"/Users/dancer/me/.masc/playground/sangsu/repos/masc-mcp/lib/mcp_server_eio_execute.mli", ...}
```

`repositories.toml` 의 `[repository.masc]` (sandbox clone) 또는 `[repository.masc-mcp]` (working tree) 모두 이 sandbox path 의 prefix 가 아님. PR-1c 단독으로는 _orphan 행. PR-6 가 `repos/masc-mcp/` segment 를 잡아서 `repository.masc-mcp.url = git@github.com:jeong-sik/masc-mcp.git` 로 lookup → canonical_url → By_url 정상.

## Test plan

- [x] 5/5 단위 + 통합 tests PASS
- [x] DUNE_CACHE=disabled 전체 빌드 PASS
- [x] deterministic-boundary guard PASS
- [x] `bash ~/me/scripts/pr-rfc-check.sh` (flagged subsystem 미접촉)
- [ ] CI required checks (Draft)
- [ ] 운영 검증: 머지 후 사용자 환경에서 `~/me/.masc-ide/by-url/github.com_jeong-sik_masc-mcp/regions.jsonl` 에 keeper write 가 떨어지는지 확인

## Related

- RFC-0128 §4.5 (spec 이 명시한 두 번째 lookup chain, PR-1c 가 누락)
- PR-1c #16036 (parent — Working tree chain)
- PR-1e #16044 (parent — single-write 보강)
- 본 PR 의 발견은 *spec ↔ 구현 cross-check* 의 운영적 가치 예시: docs/구현 의 갭은 운영 환경에서만 보이는 경우 많음

Co-Authored-By: claude-opus-4-7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

