### PR TITLE
docs(rfc-0128-pr-9): IDE store migration runbook for operators

### DIFF
--- a/docs/IDE-STORE-MIGRATION-RUNBOOK.md
+++ b/docs/IDE-STORE-MIGRATION-RUNBOOK.md
@@ -1,0 +1,225 @@
+# IDE Store Migration Runbook (RFC-0128)
+
+Operator runbook for the IDE store partitioning rollout introduced by
+[RFC-0128](rfc/RFC-0128-ide-canonical-url-partitioning.md). Covers
+the diagnosis path for the user-facing symptom *"IDE shows no keeper
+activity / no live information"* and the steps for the Phase 3
+migration.
+
+## TL;DR
+
+If your IDE looks empty after pulling the RFC-0128 PRs:
+
+1. Verify `~/.masc/config/repositories.toml` has an entry whose
+   `local_path` points at the working tree you opened in the IDE.
+2. Restart `main_eio` so the new entry is read.
+3. Open the IDE with `?repo_id=<that-id>`.
+
+If you have pre-RFC-0128 records (records written before the cut-over
+landed), run `masc-ide-migrate --base-path <project-root> --dry-run`
+to preview the partition split, then `--commit` (optionally with
+`--delete-legacy`) to fold them into the new layout.
+
+## Background
+
+Before RFC-0128 the IDE store lived at a single flat directory:
+`<base>/.masc-ide/{annotations,regions}.jsonl`. After RFC-0128 the
+store is partitioned by *canonical git URL*:
+
+```
+<base>/.masc-ide/
+  by-url/
+    github.com_jeong-sik_masc-mcp/
+      annotations.jsonl
+      regions.jsonl
+    github.com_jeong-sik_oas/
+      ...
+  _orphan/
+    annotations.jsonl
+    regions.jsonl
+```
+
+The canonical URL is derived from each registered repository's
+`url` field (see `Ide_paths.canonical_url_of_remote`). Two clones of
+the same upstream — for example the user's working tree and a
+keeper's sandbox clone — both resolve to the same slug, so a write
+by one is visible to the other.
+
+Records whose `file_path` cannot be matched to a registered
+repository land in `_orphan/`. The
+`masc_ide_orphan_writes_total` Prometheus counter exposes the rate
+so operators can spot misconfigured repositories.
+
+## Diagnosis path
+
+When the IDE looks empty, walk the layers in order. Each section
+includes the exact command and the expected output.
+
+### Layer 1 — Server is running where you think it is
+
+```sh
+ps aux | grep main_eio | grep -v grep
+```
+
+Confirm `--base-path` points at the project root that owns the
+`.masc/` and `.masc-ide/` you expect. Mixing two base paths on the
+same machine is the most common cause of "empty IDE" reports.
+
+### Layer 2 — Disk state of `.masc-ide/`
+
+```sh
+ls -la <base>/.masc-ide/
+find <base>/.masc-ide -type f
+```
+
+Expected layouts:
+
+| Files present | Interpretation |
+|---|---|
+| `regions.jsonl` / `annotations.jsonl` at top level | Pre-RFC-0128 legacy store. Run `masc-ide-migrate` to fold into `by-url/`. |
+| `by-url/<slug>/<file>` | Post-RFC-0128 cut-over. Healthy. |
+| `_orphan/<file>` | Records that could not be assigned to a repository. See Layer 3. |
+| Nothing | Server has not written yet (idle keeper) or is writing to a different base path (Layer 1). |
+
+### Layer 3 — `repositories.toml` mapping
+
+```sh
+grep -A6 '^\[repository\.' <base>/.masc/config/repositories.toml
+```
+
+For every clone you want the IDE to see, expect an entry whose
+`local_path` is the *absolute path of that clone*. The entry for the
+operator's working tree typically looks like:
+
+```toml
+[repository.masc-mcp]
+  name = "masc-mcp"
+  url = "git@github.com:jeong-sik/masc-mcp.git"
+  local_path = "/Users/<you>/workspace/.../masc-mcp"
+  status = "Active"
+  auto_sync = false
+```
+
+If the `url` is empty or unparseable, writes land in `_orphan` with
+counter label `blank_url` / `url_unparseable`. If the entry is
+missing entirely, writes land in `_orphan` with
+`unregistered_repo`. Keeper sandbox writes fall back to a second
+lookup chain (`Playground_paths.parse_playground_repo_path`) — see
+the RFC §4.5 for the contract.
+
+### Layer 4 — What is the keeper writing right now
+
+```sh
+tail -3 <base>/.masc-ide/regions.jsonl 2>/dev/null
+# or for the partitioned layout:
+tail -3 <base>/.masc-ide/by-url/<slug>/regions.jsonl
+```
+
+`file_path` falls into one of three shapes:
+
+| Shape | Meaning |
+|---|---|
+| `<base>/workspace/<owner>/<repo>/<rel>` | Operator working tree |
+| `<base>/.masc/playground/<keeper>/repos/<repo>/<rel>` | Local sandbox |
+| `<base>/.masc/playground/docker/<keeper>/repos/<repo>/<rel>` | Docker sandbox |
+
+The post-RFC-0128 write path strips this down to the repo-relative
+`<rel>` before persisting. If you see absolute paths in the JSONL
+after the cut-over, that PR is not yet on `main`.
+
+### Layer 5 — `/metrics` for the orphan counter
+
+```sh
+curl -s http://localhost:<port>/metrics | grep masc_ide_orphan_writes_total
+```
+
+Label values map directly to a fix:
+
+| `reason` | Fix |
+|---|---|
+| `unregistered_repo` | Add the working-tree repository to `repositories.toml` |
+| `blank_url` | Fill in the `url` field for the matching entry |
+| `url_unparseable` | Correct the `url` (must be parseable by `canonical_url_of_remote`) |
+| `sandbox_unregistered_repo` | Register the *upstream* in `repositories.toml` — the sandbox path resolves by `repo_id`, so the playground does not need its own entry |
+| `sandbox_blank_url` / `sandbox_url_unparseable` | Same as the non-sandbox variants, just observed via the sandbox lookup chain |
+
+## Phase 3 migration: `masc-ide-migrate`
+
+Once the partitioned layout is in production, run the migration to
+fold pre-cut-over records out of the flat store.
+
+### Step 1 — Dry run
+
+```sh
+masc-ide-migrate --base-path <project-root>
+```
+
+Output:
+
+```
+RFC-0128 §5 Phase 3 — flat-file purge migration
+  base path: /Users/<you>/...
+  mode:      DRY RUN (no files written)
+
+  annotations:
+    total       142
+    -> by-url   137
+    -> _orphan  5
+  regions:
+    total       89
+    -> by-url   85
+    -> _orphan  4
+
+Note: 9 record(s) routed to _orphan. Register the missing
+      repositories in .masc/config/repositories.toml ...
+```
+
+Inspect the orphan count. If it is non-zero, add the missing
+`repositories.toml` entries and re-run the dry run until the orphan
+column is what you expect.
+
+### Step 2 — Commit
+
+```sh
+masc-ide-migrate --base-path <project-root> --commit
+```
+
+Records are written to `by-url/<slug>/` and `_orphan/`. The Legacy
+flat files are *kept* so a read with `?merge_legacy=true` (the
+default for the HTTP route) still surfaces them — useful while
+verifying the migration.
+
+### Step 3 — Delete legacy
+
+```sh
+masc-ide-migrate --base-path <project-root> --commit --delete-legacy
+```
+
+Removes the flat `annotations.jsonl` / `regions.jsonl` after a
+successful migration. After this step, `merge_legacy` becomes a
+no-op.
+
+The migration is idempotent: re-running on an already-migrated store
+returns a zero-count report.
+
+## What is *not* in scope
+
+- Auto-migration on server boot. The data movement is irreversible
+  without a backup; explicit operator opt-in via this CLI is the only
+  way to commit it.
+- Removing the `merge_legacy` read flag. That happens in a later cycle
+  after Phase 3 has been verified in production.
+- Multi-base-path consolidation. Each `main_eio` instance owns its own
+  `.masc-ide/` tree; there is no cross-instance merge.
+
+## References
+
+- RFC-0128 spec: [`rfc/RFC-0128-ide-canonical-url-partitioning.md`](rfc/RFC-0128-ide-canonical-url-partitioning.md)
+- Library entry points: `lib/ide/ide_paths.ml`, `lib/ide/ide_annotations.ml`,
+  `lib/ide/ide_region_tracker.ml`, `lib/ide/ide_migration.ml`
+- CLI: `bin/masc_ide_migrate.ml`
+- Implementation PR stack: #16028 (helpers + signatures, MERGED),
+  #16036 (cut-over), #16040 (`excluded_dirs`), #16044
+  (single-write), #16049 (read merge), #16053 (migration),
+  #16055 (dead-code purge), #16058 (CLI), #16061 (sandbox path
+  lookup), #16062 (HTTP base alignment)


### PR DESCRIPTION
## RFC-0128 PR-9 — IDE store migration runbook for operators

RFC-0128 spec + 9 구현 PR 까지 진행. 그러나 operator-facing 실용 안내는 PR description 들과 agent memory 에 흩어져 있음. PR-9 가 repo `docs/` 에 단일 runbook 으로 통합. 코드 변경 0, origin/main 직접 기반 독립.

> docs-only PR. 다른 RFC-0128 PR 과 머지 순서 의존성 없음.

## 무엇이 추가됐나

### `docs/IDE-STORE-MIGRATION-RUNBOOK.md` (신규, 225 LoC)

기존 `docs/<NAME>-RUNBOOK.md` 패턴 (BENCHMARK, KEEPER-ACCOUNTABILITY 등) 따름.

| 섹션 | 내용 |
|------|------|
| **TL;DR** | "IDE 안 보임" 1분 해결: working tree entry + 서버 재기동 + `?repo_id=` 호출 |
| **Background** | RFC-0128 의 by-url 레이아웃 + canonical URL 의미 |
| **Diagnosis Layer 1** | `ps aux | grep main_eio` 로 `--base-path` 확인 |
| **Diagnosis Layer 2** | `.masc-ide/` 디스크 상태 (legacy / partitioned / orphan / 빈 케이스) |
| **Diagnosis Layer 3** | `repositories.toml` 매핑 검증, 실패 시 `_orphan` counter label 매핑 |
| **Diagnosis Layer 4** | keeper 가 *지금* 어떤 file_path 에 쓰는지 (working tree / Local sandbox / Docker sandbox 3 패턴) |
| **Diagnosis Layer 5** | `/metrics` 의 `masc_ide_orphan_writes_total` label 별 fix 매핑 |
| **Phase 3 migration** | `masc-ide-migrate` dry-run → commit → delete-legacy 3-step |
| **Out of scope** | auto-migration on boot, `merge_legacy` 제거 시기, multi-base-path |
| **References** | spec, lib 파일들, CLI, 모든 PR 번호 |

## 입력 출처 표

| 입력 | 출처 |
|------|------|
| 5-layer 진단 절차 | 본 cycle (2026-05-17~18) 의 운영 환경 진단 + agent memory `reference_masc_mcp_ide_diagnosis_runbook.md` |
| Counter label → fix 매핑 | PR-1c (3 label) + PR-6 (sandbox prefix 3 label 추가) |
| Phase 3 CLI 사용법 | PR-3 + PR-4 의 본문 + 수동 smoke test 결과 |
| Out-of-scope 항목 | RFC §7 Open questions + PR-3/PR-4 body |

## Test plan

- [x] 본문 markdown 렌더 확인 (코드 블록, 표, 링크)
- [x] cross-link 의 PR 번호 모두 실재 (#16028 / #16036 / #16040 / #16044 / #16049 / #16053 / #16055 / #16058 / #16061 / #16062)
- [x] 본문에 등장하는 함수/모듈 이름 모두 실재 (`Ide_paths.canonical_url_of_remote`, `Playground_paths.parse_playground_repo_path`, `masc_ide_orphan_writes_total`)
- [x] `bash ~/me/scripts/pr-rfc-check.sh` (docs-only, flagged subsystem 미접촉)
- [ ] CI required checks (Draft)

## Related

- RFC-0128 spec `docs/rfc/RFC-0128-ide-canonical-url-partitioning.md`
- agent memory `reference_masc_mcp_ide_diagnosis_runbook.md` (같은 내용의 agent-private 버전, 본 PR 로 operator-facing 화)
- 본 PR 의 가치 = *내부 학습 → 영구 운영 자산*. 다음 cycle 의 사용자가 같은 질문 ("왜 IDE 안 보임") 을 했을 때 첫 답 = "see docs/IDE-STORE-MIGRATION-RUNBOOK.md"

Co-Authored-By: claude-opus-4-7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
