### PR TITLE
fix(planning_eio): guard current_task directory corruption

### DIFF
--- a/lib/planning_eio.ml
+++ b/lib/planning_eio.ml
@@ -306,25 +306,119 @@ let set_deliverable (config : Coord.config) ~task_id ~content : (planning_contex
 let current_task_file (config : Coord.config) =
   Filename.concat (Coord_utils.masc_dir config) "current_task"
 
+(* The planning [current_task] path must be a file, but runtime state can be
+   corrupted by external writers. Keep these helpers total for directory-shaped
+   corruption so one bad path cannot wedge keeper claim/transition flows. *)
+
+let is_directory_path path =
+  try Sys.is_directory path with Sys_error _ -> false
+
+let quarantine_dir_under_trash (config : Coord.config) ~path ~op =
+  let trash_dir = Filename.concat (Coord_utils.masc_dir config) "_trash" in
+  ensure_dir trash_dir;
+  let stamp =
+    let t = Time_compat.now () in
+    let ms = int_of_float (t *. 1000.) mod 1000 in
+    let tm = Unix.gmtime t in
+    Printf.sprintf "%04d%02d%02dT%02d%02d%02dZ-%03d"
+      (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+      tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec ms
+  in
+  let dest =
+    Filename.concat trash_dir
+      (Printf.sprintf "current_task.%s.%d" stamp (Unix.getpid ()))
+  in
+  try
+    Sys.rename path dest;
+    Log.Keeper.warn
+      "planning_eio.%s: current_task path was a directory; quarantined to %s"
+      op dest;
+    Ok dest
+  with
+  | Sys_error msg ->
+    Log.Keeper.warn
+      "planning_eio.%s: failed to quarantine directory at %s: %s"
+      op path msg;
+    Error msg
+
+let remove_empty_current_task_dir ~path ~op =
+  try
+    match Sys.readdir path with
+    | [||] ->
+      (try
+         Unix.rmdir path;
+         true
+       with
+       | Unix.Unix_error _ as e ->
+         Log.Keeper.warn
+           "planning_eio.%s: rmdir %s failed: %s"
+           op path (Printexc.to_string e);
+         false)
+    | _ ->
+      Log.Keeper.warn
+        "planning_eio.%s: %s is a non-empty directory; leaving it in place"
+        op path;
+      false
+  with
+  | Sys_error msg ->
+    Log.Keeper.warn
+      "planning_eio.%s: failed to inspect directory at %s: %s"
+      op path msg;
+    false
+
 (** Get current task_id for session *)
 let get_current_task (config : Coord.config) : string option =
   let path = current_task_file config in
-  if Sys.file_exists path then
-    Some (String.trim (read_file_content path))
-  else
+  if not (Sys.file_exists path) then None
+  else if is_directory_path path then begin
+    Log.Keeper.warn
+      "planning_eio.get_current_task: %s is a directory; treating as cleared"
+      path;
     None
+  end
+  else
+    try Some (String.trim (read_file_content path)) with
+    | Sys_error msg when is_directory_path path ->
+      Log.Keeper.warn
+        "planning_eio.get_current_task: %s became a directory during read: %s"
+        path msg;
+      None
 
 (** Set current task_id for session *)
 let set_current_task (config : Coord.config) ~task_id : unit =
   let path = current_task_file config in
   ensure_dir (Filename.dirname path);
-  write_file_content path task_id
+  if is_directory_path path then begin
+    match quarantine_dir_under_trash config ~path ~op:"set_current_task" with
+    | Ok _ -> ()
+    | Error _ ->
+      ignore
+        (remove_empty_current_task_dir ~path ~op:"set_current_task" : bool)
+  end;
+  if is_directory_path path then
+    Log.Keeper.warn
+      "planning_eio.set_current_task: %s is still a directory; current_task left unset"
+      path
+  else
+    try write_file_content path task_id with
+    | Sys_error msg when is_directory_path path ->
+      Log.Keeper.warn
+        "planning_eio.set_current_task: %s became a directory during write: %s"
+        path msg
 
 (** Clear current task *)
 let clear_current_task (config : Coord.config) : unit =
   let path = current_task_file config in
-  if Sys.file_exists path then
-    Sys.remove path
+  if not (Sys.file_exists path) then ()
+  else if is_directory_path path then
+    ignore
+      (remove_empty_current_task_dir ~path ~op:"clear_current_task" : bool)
+  else
+    try Sys.remove path with
+    | Sys_error msg when is_directory_path path ->
+      Log.Keeper.warn
+        "planning_eio.clear_current_task: %s became a directory during remove: %s"
+        path msg
 
 (** Resolve task_id - use provided or fall back to current *)
 let resolve_task_id (config : Coord.config) ~task_id : (string, string) result =

--- a/test/test_planning_eio.ml
+++ b/test/test_planning_eio.ml
@@ -29,6 +29,22 @@ let teardown () =
 let make_config () : Coord.config =
   Coord.default_config !temp_dir
 
+let current_task_path config =
+  Filename.concat (Coord_utils.masc_dir config) "current_task"
+
+let ensure_masc_dir config =
+  let dir = Coord_utils.masc_dir config in
+  if not (Sys.file_exists dir) then Unix.mkdir dir 0o755
+
+let trash_dir config =
+  Filename.concat (Coord_utils.masc_dir config) "_trash"
+
+let has_current_task_quarantine config =
+  if not (Sys.file_exists (trash_dir config)) then false
+  else
+    Sys.readdir (trash_dir config)
+    |> Array.exists (fun name -> String.starts_with ~prefix:"current_task." name)
+
 (* ===== Type Tests ===== *)
 
 let test_create_context () =
@@ -363,6 +379,44 @@ let test_session_context () =
   Planning_eio.clear_current_task config;
   check (option string) "current task cleared" None (Planning_eio.get_current_task config)
 
+let test_current_task_dir_read_is_cleared () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = make_config () in
+  let path = current_task_path config in
+  ensure_masc_dir config;
+  Unix.mkdir path 0o755;
+  check (option string) "directory current_task reads as none" None
+    (Planning_eio.get_current_task config);
+  check bool "directory remains for write-path quarantine" true
+    (Sys.file_exists path && Sys.is_directory path);
+  rm_rf path
+
+let test_set_current_task_quarantines_dir () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = make_config () in
+  let path = current_task_path config in
+  ensure_masc_dir config;
+  Unix.mkdir path 0o755;
+  Fs_compat.save_file (Filename.concat path "forensics.txt") "kept";
+  Planning_eio.set_current_task config ~task_id:"recovered-task";
+  check (option string) "recovered current task" (Some "recovered-task")
+    (Planning_eio.get_current_task config);
+  check bool "old directory quarantined" true
+    (has_current_task_quarantine config);
+  Planning_eio.clear_current_task config
+
+let test_clear_current_task_removes_empty_dir () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = make_config () in
+  let path = current_task_path config in
+  ensure_masc_dir config;
+  Unix.mkdir path 0o755;
+  Planning_eio.clear_current_task config;
+  check bool "empty directory removed" false (Sys.file_exists path)
+
 let test_resolve_task_id () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -434,6 +488,12 @@ let () =
     ];
     "session_context", [
       test_case "session_context" `Quick test_session_context;
+      test_case "current_task dir read is cleared" `Quick
+        test_current_task_dir_read_is_cleared;
+      test_case "set_current_task quarantines dir" `Quick
+        test_set_current_task_quarantines_dir;
+      test_case "clear_current_task removes empty dir" `Quick
+        test_clear_current_task_removes_empty_dir;
       test_case "resolve_task_id" `Quick test_resolve_task_id;
     ];
     "display", [


### PR DESCRIPTION
## Summary
- make Planning_eio current_task helpers tolerate directory-shaped corruption
- quarantine directory entries on set, treat directory reads as cleared, and make clear remove empty dirs without crashing
- add regression coverage for read/set/clear recovery cases

## Verification
- opam exec -- ocamlformat --check lib/planning_eio.ml test/test_planning_eio.ml
- git diff --check
- scripts/dune-local.sh build ./test/test_planning_eio.exe
- ./_build/default/test/test_planning_eio.exe

Live rescue: removed empty /Users/dancer/me/.masc/current_task directory; runtime recreated it as a file and keeper_task_claim resumed successfully.

Closes #16010