### PR TITLE
fix(planning): stop current_task write after quarantine failure

### DIFF
--- a/lib/planning_eio.ml
+++ b/lib/planning_eio.ml
@@ -371,8 +371,15 @@ let set_current_task (config : Coord.config) ~task_id : unit =
   let path = current_task_file config in
   ensure_dir (Filename.dirname path);
   if is_directory_path path then
-    ignore (quarantine_dir_under_trash config ~path ~op:"set_current_task" : (string, string) result);
-  write_file_content path task_id
+    match quarantine_dir_under_trash config ~path ~op:"set_current_task" with
+    | Ok _ -> write_file_content path task_id
+    | Error msg ->
+      Log.Keeper.warn
+        "planning_eio.set_current_task: leaving directory in place after \
+         quarantine failure: %s"
+        msg
+  else
+    write_file_content path task_id
 
 (** Clear current task *)
 let clear_current_task (config : Coord.config) : unit =

--- a/lib/planning_eio.ml
+++ b/lib/planning_eio.ml
@@ -367,19 +367,27 @@ let get_current_task (config : Coord.config) : string option =
   else Some (String.trim (read_file_content path))
 
 (** Set current task_id for session *)
-let set_current_task (config : Coord.config) ~task_id : unit =
+let set_current_task (config : Coord.config) ~task_id : (unit, string) result =
   let path = current_task_file config in
   ensure_dir (Filename.dirname path);
   if is_directory_path path then
     match quarantine_dir_under_trash config ~path ~op:"set_current_task" with
-    | Ok _ -> write_file_content path task_id
+    | Ok _ ->
+      write_file_content path task_id;
+      Ok ()
     | Error msg ->
       Log.Keeper.warn
         "planning_eio.set_current_task: leaving directory in place after \
          quarantine failure: %s"
-        msg
-  else
-    write_file_content path task_id
+        msg;
+      Error
+        (Printf.sprintf
+           "failed to quarantine existing current_task directory at %s: %s"
+           path msg)
+  else begin
+    write_file_content path task_id;
+    Ok ()
+  end
 
 (** Clear current task *)
 let clear_current_task (config : Coord.config) : unit =

--- a/lib/planning_eio.mli
+++ b/lib/planning_eio.mli
@@ -118,9 +118,10 @@ val get_current_task : Coord.config -> string option
 (** [get_current_task config] returns the persisted current task
     id, or [None] when no current task is set. *)
 
-val set_current_task : Coord.config -> task_id:string -> unit
+val set_current_task : Coord.config -> task_id:string -> (unit, string) result
 (** [set_current_task config ~task_id] persists the current task
-    id.  Side effect only — no return value. *)
+    id, returning [Error _] when an existing directory cannot be
+    quarantined before the file write. *)
 
 val clear_current_task : Coord.config -> unit
 (** [clear_current_task config] removes the persisted current task

--- a/lib/tool_inline_dispatch_coord.ml
+++ b/lib/tool_inline_dispatch_coord.ml
@@ -139,12 +139,14 @@ let handle_start ~tool_name ~start_time (ctx : context) : tool_result option =
                   agent_name add_result))
         else begin
           let _claim_msg = Coord_task.claim_task active_config ~agent_name ~task_id in
-          Planning_eio.set_current_task active_config ~task_id;
-          Some
-            (Tool_result.ok ~tool_name ~start_time
-               (Printf.sprintf
-                  "masc_start complete: project scope set, joined as %s, task %s created+claimed+set as current."
-                  agent_name task_id))
+          match Planning_eio.set_current_task active_config ~task_id with
+          | Error msg -> Some (Tool_result.error ~tool_name ~start_time msg)
+          | Ok () ->
+              Some
+                (Tool_result.ok ~tool_name ~start_time
+                   (Printf.sprintf
+                      "masc_start complete: project scope set, joined as %s, task %s created+claimed+set as current."
+                      agent_name task_id))
         end
       end
 

--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -118,14 +118,14 @@ let handle_plan_set_task ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in
   if String.equal task_id "" then
     Tool_result.error ~tool_name ~start_time "task_id is required"
-  else begin
-    Planning_eio.set_current_task ctx.config ~task_id;
+  else match Planning_eio.set_current_task ctx.config ~task_id with
+  | Error e -> Tool_result.error ~tool_name ~start_time e
+  | Ok () ->
     let response = `Assoc [
       Plan_action_outcome.(status_field Set);
       ("current_task", `String task_id);
     ] in
     Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
-  end
 
 let handle_plan_get_task ~tool_name ~start_time ctx _args =
   match Planning_eio.get_current_task ctx.config with

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -183,7 +183,11 @@ let sync_planning_current_task_with_owned_task (ctx : context) =
            | Masc_domain.Cancelled _ -> None)
   in
   match owned_task with
-  | Some task_id -> Planning_eio.set_current_task ctx.config ~task_id
+  | Some task_id ->
+      (match Planning_eio.set_current_task ctx.config ~task_id with
+       | Ok () -> ()
+       | Error msg ->
+           Log.Task.warn "failed to sync planning current_task to %s: %s" task_id msg)
   | None -> Planning_eio.clear_current_task ctx.config
 
 let sync_keeper_current_task_binding (ctx : context) =

--- a/test/test_planning_eio.ml
+++ b/test/test_planning_eio.ml
@@ -41,6 +41,11 @@ let has_current_task_quarantine config =
     Sys.readdir (trash_dir config)
     |> Array.exists (fun name -> String.starts_with ~prefix:"current_task." name)
 
+let set_current_task_ok config ~task_id =
+  match Planning_eio.set_current_task config ~task_id with
+  | Ok () -> ()
+  | Error msg -> fail msg
+
 (* ===== Type Tests ===== *)
 
 let test_create_context () =
@@ -369,7 +374,7 @@ let test_session_context () =
   (* Initially no current task *)
   check (option string) "no current task" None (Planning_eio.get_current_task config);
   (* Set current task *)
-  Planning_eio.set_current_task config ~task_id:"session-test-task";
+  set_current_task_ok config ~task_id:"session-test-task";
   check (option string) "current task set" (Some "session-test-task") (Planning_eio.get_current_task config);
   (* Clear current task *)
   Planning_eio.clear_current_task config;
@@ -394,7 +399,7 @@ let test_set_current_task_quarantines_dir () =
   let path = current_task_path config in
   Unix.mkdir path 0o755;
   Fs_compat.save_file (Filename.concat path "forensics.txt") "kept";
-  Planning_eio.set_current_task config ~task_id:"recovered-task";
+  set_current_task_ok config ~task_id:"recovered-task";
   check (option string) "recovered current task" (Some "recovered-task")
     (Planning_eio.get_current_task config);
   check bool "old directory quarantined" true
@@ -410,15 +415,22 @@ let test_set_current_task_stops_when_quarantine_fails () =
   if Sys.file_exists trash then rm_rf trash;
   Unix.mkdir path 0o755;
   Fs_compat.save_file (Filename.concat path "forensics.txt") "kept";
-  Unix.mkdir trash 0o555;
+  if not (Sys.file_exists trash) then Unix.mkdir trash 0o755;
+  Unix.chmod trash 0o555;
   Fun.protect
     ~finally:(fun () ->
       if Sys.file_exists trash && Sys.is_directory trash then
         Unix.chmod trash 0o755;
-      rm_rf path;
-      rm_rf trash)
+      if Sys.file_exists path then rm_rf path;
+      if Sys.file_exists trash then rm_rf trash)
     (fun () ->
-      Planning_eio.set_current_task config ~task_id:"blocked-task";
+      (match Planning_eio.set_current_task config ~task_id:"blocked-task" with
+       | Ok () -> fail "expected set_current_task to fail"
+       | Error msg ->
+         check bool "error mentions quarantine failure" true
+           (String.starts_with
+              ~prefix:"failed to quarantine existing current_task directory"
+              msg));
       check bool "current_task remains a directory" true
         (Sys.file_exists path && Sys.is_directory path);
       check (option string) "failed quarantine does not write over directory" None
@@ -446,7 +458,7 @@ let test_resolve_task_id () =
    | Ok _ -> fail "Expected error when no current task"
    | Error _ -> ());
   (* Set current task, then resolve empty *)
-  Planning_eio.set_current_task config ~task_id:"current-fallback";
+  set_current_task_ok config ~task_id:"current-fallback";
   match Planning_eio.resolve_task_id config ~task_id:"" with
   | Ok id -> check string "fallback to current" "current-fallback" id
   | Error e -> fail (Printf.sprintf "Fallback resolution failed: %s" e)

--- a/test/test_planning_eio.ml
+++ b/test/test_planning_eio.ml
@@ -401,6 +401,29 @@ let test_set_current_task_quarantines_dir () =
     (has_current_task_quarantine config);
   Planning_eio.clear_current_task config
 
+let test_set_current_task_stops_when_quarantine_fails () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = make_config () in
+  let path = current_task_path config in
+  let trash = trash_dir config in
+  if Sys.file_exists trash then rm_rf trash;
+  Unix.mkdir path 0o755;
+  Fs_compat.save_file (Filename.concat path "forensics.txt") "kept";
+  Unix.mkdir trash 0o555;
+  Fun.protect
+    ~finally:(fun () ->
+      if Sys.file_exists trash && Sys.is_directory trash then
+        Unix.chmod trash 0o755;
+      rm_rf path;
+      rm_rf trash)
+    (fun () ->
+      Planning_eio.set_current_task config ~task_id:"blocked-task";
+      check bool "current_task remains a directory" true
+        (Sys.file_exists path && Sys.is_directory path);
+      check (option string) "failed quarantine does not write over directory" None
+        (Planning_eio.get_current_task config))
+
 let test_clear_current_task_removes_empty_dir () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -485,6 +508,8 @@ let () =
         test_current_task_dir_read_is_cleared;
       test_case "set_current_task quarantines dir" `Quick
         test_set_current_task_quarantines_dir;
+      test_case "set_current_task stops when quarantine fails" `Quick
+        test_set_current_task_stops_when_quarantine_fails;
       test_case "clear_current_task removes empty dir" `Quick
         test_clear_current_task_removes_empty_dir;
       test_case "resolve_task_id" `Quick test_resolve_task_id;

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -36,6 +36,12 @@ let assert_not_contains output unexpected =
     failwith (Printf.sprintf "unexpected substring %S in output:\n%s" unexpected output)
 ;;
 
+let set_current_task_ok config ~task_id =
+  match Planning_eio.set_current_task config ~task_id with
+  | Ok () -> ()
+  | Error msg -> failwith msg
+;;
+
 let with_env name value_opt f =
   let original = Sys.getenv_opt name in
   let restore () =
@@ -134,6 +140,22 @@ let write_agent_state config agent_name f =
 ;;
 
 let actual_test_agent_name config = Coord.resolve_agent_name config "test-agent"
+
+let force_claim_task config ~agent_name ~task_id =
+  let backlog = Coord.read_backlog config in
+  let tasks =
+    List.map
+      (fun (task : Types.task) ->
+        if String.equal task.id task_id
+        then
+          { task with
+            task_status = Types.Claimed { assignee = agent_name; claimed_at = "test" }
+          }
+        else task)
+      backlog.tasks
+  in
+  Coord.write_backlog config { backlog with tasks; version = backlog.version + 1 }
+;;
 
 (* Test dispatch returns None for unknown tool *)
 let () =
@@ -509,19 +531,20 @@ let () =
       Coord.add_task ctx.config ~title:"Secondary lane" ~priority:2 ~description:""
     in
     ignore (Coord.claim_task ctx.config ~agent_name:"test-agent" ~task_id:"task-001");
-    ignore (Coord.claim_task ctx.config ~agent_name:"test-agent" ~task_id:"task-002");
-    Planning_eio.set_current_task ctx.config ~task_id:"task-002";
+    let actual_name = actual_test_agent_name ctx.config in
+    force_claim_task ctx.config ~agent_name:actual_name ~task_id:"task-002";
+    set_current_task_ok ctx.config ~task_id:"task-002";
     (match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
      | Some { success; legacy_message = result } ->
        assert success;
-       assert (str_contains result "owned=task-001 | current=task-002");
-       assert (str_contains result "assigned_set=[task-001,task-002]");
-       assert (str_contains result "primary_owned=task-001");
-       assert (str_contains result "planning_current=task-002");
-       assert (str_contains result "current_is_assigned=yes");
-       assert (str_contains result "effective_current=task-002");
-       assert (str_contains result "drift_reason=secondary_assignment");
-       assert (str_contains result "claim_first_suppressed=yes");
+       assert_contains result "owned=task-001 | current=task-002";
+       assert_contains result "assigned_set=[task-001,task-002]";
+       assert_contains result "primary_owned=task-001";
+       assert_contains result "planning_current=task-002";
+       assert_contains result "current_is_assigned=yes";
+       assert_contains result "effective_current=task-002";
+       assert_contains result "drift_reason=secondary_assignment";
+       assert_contains result "claim_first_suppressed=yes";
        assert (not (str_contains result "task-002 is stale focus"))
      | None -> failwith "dispatch returned None");
     match
@@ -559,7 +582,7 @@ let () =
     ignore
       (Coord.add_task ctx.config ~title:"Stale current task" ~priority:3 ~description:"");
     ignore (Coord.claim_task ctx.config ~agent_name:"test-agent" ~task_id:"task-001");
-    Planning_eio.set_current_task ctx.config ~task_id:"task-002";
+    set_current_task_ok ctx.config ~task_id:"task-002";
     match
       Tool_coord.dispatch
         ctx
@@ -595,7 +618,7 @@ let () =
     ignore
       (Coord.add_task ctx.config ~title:"Stale current task" ~priority:3 ~description:"");
     ignore (Coord.claim_task ctx.config ~agent_name:"test-agent" ~task_id:"task-001");
-    Planning_eio.set_current_task ctx.config ~task_id:"task-002";
+    set_current_task_ok ctx.config ~task_id:"task-002";
     match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
     | Some { success; legacy_message = result } ->
       assert success;
@@ -619,7 +642,7 @@ let () =
     ignore (Auth.enable_auth ctx.config.base_path ~require_token:true ~agent_name:"admin");
     ignore
       (Coord.add_task ctx.config ~title:"Credentialed work" ~priority:3 ~description:"");
-    Planning_eio.set_current_task ctx.config ~task_id:"task-001";
+    set_current_task_ok ctx.config ~task_id:"task-001";
     match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
     | Some { success; legacy_message = result } ->
       assert success;
@@ -646,7 +669,7 @@ let () =
     ignore (Auth.enable_auth ctx.config.base_path ~require_token:true ~agent_name:"admin");
     ignore (Auth.ensure_internal_keeper_token ctx.config.base_path);
     ignore (Coord.add_task ctx.config ~title:"Keeper work" ~priority:3 ~description:"");
-    Planning_eio.set_current_task ctx.config ~task_id:"task-001";
+    set_current_task_ok ctx.config ~task_id:"task-001";
     match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
     | Some { success; legacy_message = result } ->
       assert success;
@@ -675,7 +698,7 @@ let () =
     ignore
       (Auth.enable_auth ctx.config.base_path ~require_token:true ~agent_name:"test-agent");
     ignore (Coord.add_task ctx.config ~title:"Unclaimed task" ~priority:3 ~description:"");
-    Planning_eio.set_current_task ctx.config ~task_id:"task-001";
+    set_current_task_ok ctx.config ~task_id:"task-001";
     match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
     | Some { success; legacy_message = result } ->
       assert success;
@@ -703,7 +726,7 @@ let () =
          ~priority:3
          ~description:"");
     ignore (Coord.claim_task ctx.config ~agent_name:"test-agent" ~task_id:"task-001");
-    Planning_eio.set_current_task ctx.config ~task_id:"task-001";
+    set_current_task_ok ctx.config ~task_id:"task-001";
     match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
     | Some { success; legacy_message = result } ->
       assert success;
@@ -737,7 +760,7 @@ let () =
             ~priority:3
             ~description:"");
        ignore (Coord.claim_task ctx.config ~agent_name:"test-agent" ~task_id:"task-001");
-       Planning_eio.set_current_task ctx.config ~task_id:"task-001";
+       set_current_task_ok ctx.config ~task_id:"task-001";
        ignore
          (Planning_eio.set_deliverable
             ctx.config


### PR DESCRIPTION
## Summary
- stop set_current_task before write_file_content when directory quarantine fails
- add regression coverage for failed quarantine leaving current_task as a directory

## Verification
- opam exec -- ocamlformat -i lib/planning_eio.ml test/test_planning_eio.ml
- git diff --check HEAD~1..HEAD
- targeted dune test not run yet: /tmp/me-dune-local.lock is currently held by another masc-mcp worktree build

Follow-up for review finding on merged PR #16022.