### PR TITLE
Make repository discovery shell-free

### DIFF
--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -128,6 +128,12 @@ let get_branches ~repository =
   | Ok lines -> Ok lines
   | Error msg -> Error msg
 
+let get_origin_url ~local_path =
+  match run_git ~cwd:local_path [ "remote"; "get-url"; "origin" ] with
+  | Ok (url :: _) -> Ok url
+  | Ok [] -> Error "git remote get-url origin returned no output"
+  | Error msg -> Error msg
+
 let get_recent_commits ~repository ~branch ~limit =
   match
     run_git ~cwd:repository.local_path

--- a/lib/repo_manager/repo_git.mli
+++ b/lib/repo_manager/repo_git.mli
@@ -19,6 +19,10 @@ val get_branches :
   repository:repository -> (string list, string) result
 (** [get_branches ~repository] returns all local and remote branch names. *)
 
+val get_origin_url : local_path:string -> (string, string) result
+(** [get_origin_url ~local_path] returns the configured [origin] remote URL
+    for the repository at [local_path]. *)
+
 val get_recent_commits :
   repository:repository -> branch:string -> limit:int -> (string list, string) result
 (** [get_recent_commits ~repository ~branch ~limit] returns the most recent

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -313,6 +313,12 @@ let slugify_id s =
     s
 
 let is_directory path = try Sys.is_directory path with Sys_error _ -> false
+
+let is_symlink path =
+  try (Unix.lstat path).st_kind = Unix.S_LNK
+  with Unix.Unix_error _ | Sys_error _ -> false
+
+let is_real_directory path = is_directory path && not (is_symlink path)
 let is_hidden_name name = String.length name > 0 && Char.equal name.[0] '.'
 
 let discover_git_dirs ~base_path =
@@ -320,7 +326,8 @@ let discover_git_dirs ~base_path =
   let rec scan_dir ~depth dir acc =
     let git_dir = Filename.concat dir ".git" in
     let acc =
-      if depth + 1 <= max_git_depth && is_directory git_dir then git_dir :: acc else acc
+      if depth + 1 <= max_git_depth && is_real_directory git_dir then git_dir :: acc
+      else acc
     in
     if depth >= max_git_depth - 1 then acc
     else
@@ -334,12 +341,12 @@ let discover_git_dirs ~base_path =
             acc
           else
             let child = Filename.concat dir name in
-            if is_directory child then scan_dir ~depth:(depth + 1) child acc
+            if is_real_directory child then scan_dir ~depth:(depth + 1) child acc
             else acc)
         acc
         entries
   in
-  if is_directory base_path then List.rev (scan_dir ~depth:0 base_path [])
+  if is_real_directory base_path then List.rev (scan_dir ~depth:0 base_path [])
   else []
 
 (* Pure path normalization fallback for environments where the path does

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -312,14 +312,35 @@ let slugify_id s =
       | _ -> '-')
     s
 
-let run_read_line cmd =
-  try
-    let ic = Unix.open_process_in cmd in
-    Fun.protect
-      ~finally:(fun () -> ignore (Unix.close_process_in ic))
-      (fun () ->
-        try Ok (input_line ic) with End_of_file -> Error "no output")
-  with Sys_error msg -> Error msg
+let is_directory path = try Sys.is_directory path with Sys_error _ -> false
+let is_hidden_name name = String.length name > 0 && Char.equal name.[0] '.'
+
+let discover_git_dirs ~base_path =
+  let max_git_depth = 4 in
+  let rec scan_dir ~depth dir acc =
+    let git_dir = Filename.concat dir ".git" in
+    let acc =
+      if depth + 1 <= max_git_depth && is_directory git_dir then git_dir :: acc else acc
+    in
+    if depth >= max_git_depth - 1 then acc
+    else
+      let entries =
+        try Sys.readdir dir with Sys_error _ | Unix.Unix_error _ -> [||]
+      in
+      Array.fold_left
+        (fun acc name ->
+          if String.equal name "." || String.equal name ".." || is_hidden_name name
+          then
+            acc
+          else
+            let child = Filename.concat dir name in
+            if is_directory child then scan_dir ~depth:(depth + 1) child acc
+            else acc)
+        acc
+        entries
+  in
+  if is_directory base_path then List.rev (scan_dir ~depth:0 base_path [])
+  else []
 
 (* Pure path normalization fallback for environments where the path does
    not exist on disk yet (Unix.realpath would raise) or Unix is
@@ -384,25 +405,7 @@ let discover_repositories ~base_path =
             canonical_path (local_path ~base_path:abs_base_path r))
     | Error _ -> []
   in
-  let git_dirs =
-    try
-      let cmd =
-        Printf.sprintf "find %s -maxdepth 4 -name \".git\" -type d 2>/dev/null"
-          (Filename.quote abs_base_path)
-      in
-      let ic = Unix.open_process_in cmd in
-      Fun.protect
-        ~finally:(fun () -> ignore (Unix.close_process_in ic))
-        (fun () ->
-          let rec read_lines acc =
-            match input_line ic with
-            | line -> read_lines (line :: acc)
-            | exception End_of_file -> List.rev acc
-          in
-          read_lines [])
-    with
-    | Sys_error _ | Unix.Unix_error _ | Failure _ -> []
-  in
+  let git_dirs = discover_git_dirs ~base_path:abs_base_path in
   let has_hidden_segment_under_base path =
     if String.equal path abs_base_path then false
     else
@@ -438,11 +441,7 @@ let discover_repositories ~base_path =
         if has_hidden_segment_under_base abs_repo_dir then None
         else if List.exists (String.equal abs_repo_dir) existing_paths then None
         else
-          let url_cmd =
-            Printf.sprintf "git -C %s remote get-url origin 2>/dev/null"
-              (Filename.quote abs_repo_dir)
-          in
-          match run_read_line url_cmd with
+          match Repo_git.get_origin_url ~local_path:abs_repo_dir with
           | Ok url ->
               let name = Filename.basename abs_repo_dir in
               let id = slugify_id name in

--- a/lib/repo_manager/repo_store.mli
+++ b/lib/repo_manager/repo_store.mli
@@ -46,6 +46,8 @@ val discover_repositories : base_path:string -> (repository list, string) result
 (** [discover_repositories ~base_path] scans [base_path] for git repositories
     (directories containing [.git] up to depth 4) and returns a list of
     candidate {!repository} records inferred from their [origin] remote URL.
+    Discovery walks the filesystem directly and resolves remotes through the
+    repository git runner, avoiding shell [find] fan-out.
 
     Directories under [.masc/] and repositories already registered in
     [repositories.toml] are excluded. This function is read-only and is

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -305,6 +305,25 @@ let test_discover_finds_grouped_workspace_repos () =
             Alcotest.(check string) "id" "oas" repo.id;
             Alcotest.(check string) "local_path" (canonical_path repo_dir) repo.local_path)
 
+let test_discover_keeps_depth_cap () =
+  if not (git_available ()) then Alcotest.skip ()
+  else
+    with_temp_base_path (fun base_path ->
+        let a = Filename.concat base_path "a" in
+        let b = Filename.concat a "b" in
+        let c = Filename.concat b "c" in
+        let d = Filename.concat c "d" in
+        Unix.mkdir a 0o755;
+        Unix.mkdir b 0o755;
+        Unix.mkdir c 0o755;
+        Unix.mkdir d 0o755;
+        init_git_repo d "https://github.com/test/too-deep";
+        match Repo_store.discover_repositories ~base_path with
+        | Error e -> Alcotest.fail ("discover failed: " ^ e)
+        | Ok repos ->
+            Alcotest.(check int) "ignores repo beyond max depth" 0
+              (List.length repos))
+
 let test_discover_ignores_hidden_dirs () =
   if not (git_available ()) then Alcotest.skip ()
   else
@@ -623,6 +642,8 @@ let () =
           Alcotest.test_case "ignores .masc repos" `Quick test_discover_ignores_masc_dir;
           Alcotest.test_case "finds grouped workspace repos" `Quick
             test_discover_finds_grouped_workspace_repos;
+          Alcotest.test_case "keeps max depth cap" `Quick
+            test_discover_keeps_depth_cap;
           Alcotest.test_case "ignores hidden dirs" `Quick
             test_discover_ignores_hidden_dirs;
           Alcotest.test_case "relative base path keeps visible repos" `Quick

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -12,6 +12,19 @@ let contains_substring s needle =
   in
   if n_len = 0 then true else loop 0
 
+let is_symlink path =
+  try (Unix.lstat path).st_kind = Unix.S_LNK
+  with Unix.Unix_error _ | Sys_error _ -> false
+
+let rec rm_rf path =
+  if Sys.file_exists path || is_symlink path then
+    if is_symlink path then Unix.unlink path
+    else if Sys.is_directory path then begin
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
 let with_temp_base_path f =
   let dir = Filename.temp_file "repo_store_test" "" in
   Sys.remove dir;
@@ -20,18 +33,7 @@ let with_temp_base_path f =
   Unix.mkdir config_dir 0o755;
   let config_subdir = Filename.concat config_dir "config" in
   Unix.mkdir config_subdir 0o755;
-  Fun.protect
-    ~finally:(fun () ->
-      let rec rm_rf path =
-        if Sys.file_exists path then
-          if Sys.is_directory path then begin
-            Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
-            Unix.rmdir path
-          end else
-            Sys.remove path
-      in
-      rm_rf dir)
-    (fun () -> f dir)
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
 let sample_repo id =
   {
@@ -338,6 +340,26 @@ let test_discover_ignores_hidden_dirs () =
         | Ok repos ->
             Alcotest.(check int) "ignores hidden directory repo" 0
               (List.length repos))
+
+let test_discover_ignores_symlink_dirs () =
+  if not (git_available ()) then Alcotest.skip ()
+  else
+    with_temp_base_path (fun base_path ->
+        let outside = Filename.temp_file "repo_store_outside" "" in
+        Sys.remove outside;
+        Unix.mkdir outside 0o755;
+        Fun.protect
+          ~finally:(fun () -> rm_rf outside)
+          (fun () ->
+            init_git_repo outside "https://github.com/test/outside";
+            let link = Filename.concat base_path "linked-outside" in
+            (try Unix.symlink outside link
+             with Unix.Unix_error _ -> Alcotest.skip ());
+            match Repo_store.discover_repositories ~base_path with
+            | Error e -> Alcotest.fail ("discover failed: " ^ e)
+            | Ok repos ->
+                Alcotest.(check int) "ignores symlink directory repo" 0
+                  (List.length repos)))
 
 let test_discover_relative_base_path_keeps_visible_repos () =
   if not (git_available ()) then Alcotest.skip ()
@@ -646,6 +668,8 @@ let () =
             test_discover_keeps_depth_cap;
           Alcotest.test_case "ignores hidden dirs" `Quick
             test_discover_ignores_hidden_dirs;
+          Alcotest.test_case "ignores symlink dirs" `Quick
+            test_discover_ignores_symlink_dirs;
           Alcotest.test_case "relative base path keeps visible repos" `Quick
             test_discover_relative_base_path_keeps_visible_repos;
           Alcotest.test_case "skips registered repos" `Quick test_discover_skips_registered;


### PR DESCRIPTION
## Summary
- replace repository discovery's shell `find` fan-out with a bounded native directory walk
- resolve discovered repo origins through `Repo_git.get_origin_url`, keeping git calls on the existing Exec_gate/Process_eio path
- preserve the depth cap and add coverage for the max-depth boundary

## Verification
- ocamlformat --check lib/repo_manager/repo_store.ml lib/repo_manager/repo_store.mli lib/repo_manager/repo_git.ml lib/repo_manager/repo_git.mli test/test_repo_store.ml
- git diff --check
- bash scripts/health_snapshot.sh --skip-build --baseline-ref origin/main --fail-on-lib-regression
- scripts/dune-local.sh build test/test_repo_store.exe
- ./_build/default/test/test_repo_store.exe

## Notes
- The Dune build/test above passed before the final conflict-free rebase onto latest origin/main. After the rebase, local Dune was blocked by other worktree lock holders, so CI is the post-rebase build surface.
- Draft/do-not-merge while the broader resource-management PR stack settles.
