### PR TITLE
fix(keeper): account docker read fallback spawns

### DIFF
--- a/lib/server/fd_accountant.ml
+++ b/lib/server/fd_accountant.ml
@@ -56,7 +56,9 @@ let _state_for_kind : (kind * slot_state) list =
 let state_of kind = List.assoc kind _state_for_kind
 
 (* Shared FD-pressure gate — when Keeper_fd_pressure.active () is true,
-   all top-level kinds serialize through one global slot. A semaphore keeps
+   all top-level kinds serialize through one global slot. Nested cross-kind
+   acquisitions skip this gate via [held_kinds] so a Docker-spawn path can
+   enter the sandbox-exec guard without deadlocking on itself. A semaphore keeps
    the long-lived Bg_task lifetime path on the same pressure gate as scoped
    tool calls while still allowing explicit release when the process closes. *)
 let _shared_pressure_gate = Eio.Semaphore.make 1

--- a/lib/server/fd_accountant.ml
+++ b/lib/server/fd_accountant.ml
@@ -57,13 +57,16 @@ let state_of kind = List.assoc kind _state_for_kind
 
 (* Shared FD-pressure gate — when Keeper_fd_pressure.active () is true,
    all top-level kinds serialize through one global slot. Nested cross-kind
-   acquisitions skip this gate via [held_kinds] so a Docker-spawn path can
-   enter the sandbox-exec guard without deadlocking on itself. A semaphore keeps
-   the long-lived Bg_task lifetime path on the same pressure gate as scoped
-   tool calls while still allowing explicit release when the process closes. *)
+   acquisitions skip this gate only while the parent slot scope is still
+   active; forked children that outlive the parent must re-enter the gate. A
+   semaphore keeps the long-lived Bg_task lifetime path on the same pressure
+   gate as scoped tool calls while still allowing explicit release when the
+   process closes. *)
 let _shared_pressure_gate = Eio.Semaphore.make 1
 
-let held_kinds_key : kind list Eio.Fiber.key = Eio.Fiber.create_key ()
+type held_kind = { kind : kind ; active : bool Atomic.t }
+
+let held_kinds_key : held_kind list Eio.Fiber.key = Eio.Fiber.create_key ()
 
 let held_kinds () =
   (* NDT-OK: fiber-local runtime state only prevents same-fiber slot
@@ -71,13 +74,14 @@ let held_kinds () =
   try Option.value ~default:[] (Eio.Fiber.get held_kinds_key)
   with _ -> []
 
-let holds_kind kind = List.exists (( = ) kind) (held_kinds ())
+let active_held_kinds () =
+  List.filter (fun held -> Atomic.get held.active) (held_kinds ())
 
-let with_held_kind kind f =
-  Eio.Fiber.with_binding held_kinds_key (kind :: held_kinds ()) f
+let holds_kind kind =
+  List.exists (fun held -> held.kind = kind) (active_held_kinds ())
 
 let pressure_gate_needed () =
-  Keeper_fd_pressure.active () && held_kinds () = []
+  Keeper_fd_pressure.active () && active_held_kinds () = []
 
 let acquire_pressure_gate_if_needed () =
   if not (pressure_gate_needed ())
@@ -99,7 +103,10 @@ let with_slot ~kind f =
     Eio.Switch.on_release sw release_pressure ;
     Eio.Semaphore.acquire sem ;
     Eio.Switch.on_release sw (fun () -> Eio.Semaphore.release sem) ;
-    with_held_kind kind f
+    let held = { kind ; active = Atomic.make true } in
+    Fun.protect
+      ~finally:(fun () -> Atomic.set held.active false)
+      (fun () -> Eio.Fiber.with_binding held_kinds_key (held :: held_kinds ()) f)
 
 let acquire_lifetime_slot ~kind () =
   let release_pressure = acquire_pressure_gate_if_needed () in

--- a/test/test_fd_accountant.ml
+++ b/test/test_fd_accountant.ml
@@ -152,7 +152,7 @@ let test_with_slot_reentrant_same_kind () =
       FA.with_slot ~kind:FA.Sandbox_exec (fun () ->
           check int "inner sandbox slot reuses outer slot" 1
             (kind_in_flight FA.Sandbox_exec))) ;
-	  check int "sandbox slot released" 0 (kind_in_flight FA.Sandbox_exec)
+  check int "sandbox slot released" 0 (kind_in_flight FA.Sandbox_exec)
 
 let test_with_slot_nested_cross_kind_under_fd_pressure () =
   Eio_main.run @@ fun _env ->
@@ -170,6 +170,44 @@ let test_with_slot_nested_cross_kind_under_fd_pressure () =
                 (kind_in_flight FA.Sandbox_exec))) ;
       check int "docker slot released" 0 (kind_in_flight FA.Docker_spawn) ;
       check int "sandbox slot released" 0 (kind_in_flight FA.Sandbox_exec))
+
+let test_forked_child_reenters_pressure_gate_after_parent_slot () =
+  Eio_main.run @@ fun env ->
+  Masc_mcp.Keeper_fd_pressure.reset_for_tests () ;
+  Fun.protect
+    ~finally:Masc_mcp.Keeper_fd_pressure.reset_for_tests
+    (fun () ->
+      Masc_mcp.Keeper_fd_pressure.note ~site:"fd_accountant_test"
+        ~detail:"too many open files" () ;
+      let clock = Eio.Stdenv.clock env in
+      let child_go = Atomic.make false in
+      let child_entered = Atomic.make false in
+      let blocker_running = Atomic.make false in
+      let release_blocker = Atomic.make false in
+      Eio.Switch.run @@ fun sw ->
+      FA.with_slot ~kind:FA.Docker_spawn (fun () ->
+          Eio.Fiber.fork ~sw (fun () ->
+              while not (Atomic.get child_go) do
+                Eio.Time.sleep clock 0.001
+              done ;
+              FA.with_slot ~kind:FA.Sandbox_exec (fun () ->
+                  Atomic.set child_entered true))) ;
+      Eio.Fiber.fork ~sw (fun () ->
+          FA.with_slot ~kind:FA.Provider_http (fun () ->
+              Atomic.set blocker_running true ;
+              while not (Atomic.get release_blocker) do
+                Eio.Time.sleep clock 0.001
+              done)) ;
+      check bool "blocker acquired pressure gate" true
+        (wait_until ~clock ~attempts:100 (fun () ->
+             Atomic.get blocker_running)) ;
+      Atomic.set child_go true ;
+      Eio.Time.sleep clock 0.01 ;
+      check bool "inherited child binding does not bypass pressure gate" false
+        (Atomic.get child_entered) ;
+      Atomic.set release_blocker true ;
+      check bool "child enters after pressure gate release" true
+        (wait_until ~clock ~attempts:100 (fun () -> Atomic.get child_entered)))
 
 let test_dated_jsonl_append_uses_log_writer_slot () =
   Eio_main.run @@ fun env ->
@@ -449,6 +487,8 @@ let () =
             test_with_slot_reentrant_same_kind ;
           test_case "nested cross-kind slot under FD pressure" `Quick
             test_with_slot_nested_cross_kind_under_fd_pressure ;
+          test_case "forked child re-enters pressure gate" `Quick
+            test_forked_child_reenters_pressure_gate_after_parent_slot ;
         ] ) ;
       ( "delegation",
         [

--- a/test/test_fd_accountant.ml
+++ b/test/test_fd_accountant.ml
@@ -152,7 +152,24 @@ let test_with_slot_reentrant_same_kind () =
       FA.with_slot ~kind:FA.Sandbox_exec (fun () ->
           check int "inner sandbox slot reuses outer slot" 1
             (kind_in_flight FA.Sandbox_exec))) ;
-  check int "sandbox slot released" 0 (kind_in_flight FA.Sandbox_exec)
+	  check int "sandbox slot released" 0 (kind_in_flight FA.Sandbox_exec)
+
+let test_with_slot_nested_cross_kind_under_fd_pressure () =
+  Eio_main.run @@ fun _env ->
+  Masc_mcp.Keeper_fd_pressure.reset_for_tests () ;
+  Fun.protect
+    ~finally:Masc_mcp.Keeper_fd_pressure.reset_for_tests
+    (fun () ->
+      Masc_mcp.Keeper_fd_pressure.note ~site:"fd_accountant_test"
+        ~detail:"too many open files" () ;
+      FA.with_slot ~kind:FA.Docker_spawn (fun () ->
+          check int "outer docker slot held" 1
+            (kind_in_flight FA.Docker_spawn) ;
+          FA.with_slot ~kind:FA.Sandbox_exec (fun () ->
+              check int "nested sandbox slot held" 1
+                (kind_in_flight FA.Sandbox_exec))) ;
+      check int "docker slot released" 0 (kind_in_flight FA.Docker_spawn) ;
+      check int "sandbox slot released" 0 (kind_in_flight FA.Sandbox_exec))
 
 let test_dated_jsonl_append_uses_log_writer_slot () =
   Eio_main.run @@ fun env ->
@@ -430,6 +447,8 @@ let () =
           test_case "cap bounds fan-in" `Quick test_cap_bounds_fan_in ;
           test_case "reentrant same-kind slot" `Quick
             test_with_slot_reentrant_same_kind ;
+          test_case "nested cross-kind slot under FD pressure" `Quick
+            test_with_slot_nested_cross_kind_under_fd_pressure ;
         ] ) ;
       ( "delegation",
         [

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -14,8 +14,8 @@ module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
 module Keeper_sandbox_runtime = Masc_mcp.Keeper_sandbox_runtime
-module Env_config_keeper = Env_config_keeper
 module Fd_accountant = Masc_mcp.Fd_accountant
+module Env_config_keeper = Env_config_keeper
 
 (* ── Helpers ─────────────────────────────────────────────────────── *)
 
@@ -71,18 +71,15 @@ let docker_spawn_in_flight () =
   let snapshot = Fd_accountant.fd_snapshot () in
   List.assoc Fd_accountant.Docker_spawn snapshot.per_kind
 
-let wait_until ~attempts predicate =
-  match Process_eio.get_clock () with
-  | Error msg -> Alcotest.fail msg
-  | Ok clock ->
-      let rec loop remaining =
-        if predicate () then true
-        else if remaining <= 0 then false
-        else (
-          Eio.Time.sleep clock 0.005;
-          loop (remaining - 1))
-      in
-      loop attempts
+let wait_until ~clock ~attempts predicate =
+  let rec loop remaining =
+    if predicate () then true
+    else if remaining <= 0 then false
+    else (
+      Eio.Time.sleep clock 0.001;
+      loop (remaining - 1))
+  in
+  loop attempts
 
 let rec ensure_dir path =
   if path = "" || path = "." || path = "/" then ()
@@ -325,20 +322,21 @@ exit 0\n"
 
 let fake_docker_slow_run_script =
   "#!/bin/sh\n\
+log_file=${KEEPER_DOCKER_LOG:-}\n\
 if [ \"$1\" = \"info\" ]; then\n\
   printf '[]\\n'\n\
   exit 0\n\
 fi\n\
-if [ \"$1\" != \"run\" ]; then\n\
-  printf 'unexpected docker invocation\\n' >&2\n\
-  exit 2\n\
+if [ \"$1\" = \"run\" ]; then\n\
+  if [ -n \"$log_file\" ]; then\n\
+    printf 'run-started\\n' >> \"$log_file\"\n\
+  fi\n\
+  sleep 0.2\n\
+  printf 'slow ok\\n'\n\
+  exit 0\n\
 fi\n\
-if [ -n \"${KEEPER_DOCKER_RUN_MARK:-}\" ]; then\n\
-  printf 'run-started\\n' > \"$KEEPER_DOCKER_RUN_MARK\"\n\
-fi\n\
-sleep 0.2\n\
-printf 'slow run ok\\n'\n\
-exit 0\n"
+printf 'unexpected docker invocation\\n' >&2\n\
+exit 2\n"
 
 let fake_docker_turn_runtime_script =
   "#!/bin/sh\n\
@@ -871,47 +869,49 @@ let test_run_command_preserves_bare_command_argv () =
       Alcotest.(check string) "preserves bare head argv"
         "head -n 1 /home/keeper/playground/minjae/mind/demo.txt\n" out
 
-let test_run_command_holds_docker_spawn_slot () =
+let test_run_command_fallback_uses_docker_spawn_slot ~clock () =
   with_fake_docker fake_docker_slow_run_script @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE" "" @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS" "false" @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_REQUIRE_USERNS" "false" @@ fun () ->
   let base, config, meta = setup_config "minjae" in
-  let run_mark = Filename.concat base "docker-run-started" in
+  let log_path = Filename.concat base "docker.log" in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
-  with_env "KEEPER_DOCKER_RUN_MARK" run_mark @@ fun () ->
+  with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   let result = ref None in
-  Eio.Switch.run @@ fun sw ->
-  Eio.Fiber.fork ~sw (fun () ->
-      result :=
-        Some
-          (Keeper_docker_read.run_command_in_container_with_status
-             ~config ~meta
-             ~command_argv:[ "cat"; "/home/keeper/playground/demo.txt" ]
-             ~max_bytes:4096 ~timeout_sec:5.0 ())) ;
-  Alcotest.(check bool) "fake docker run started" true
-    (wait_until ~attempts:100 (fun () -> Sys.file_exists run_mark)) ;
-  Alcotest.(check int) "docker spawn slot held by fallback run" 1
-    (docker_spawn_in_flight ()) ;
-  Alcotest.(check bool) "docker run finished" true
-    (wait_until ~attempts:200 (fun () ->
-         match !result with Some _ -> true | None -> false)) ;
+  Eio.Switch.run (fun sw ->
+      Eio.Fiber.fork ~sw (fun () ->
+          result :=
+            Some
+              (Keeper_docker_read.run_command_in_container_with_status
+                 ~config ~meta
+                 ~command_argv:
+                   [ "cat"; "/home/keeper/playground/minjae/mind/demo.txt" ]
+                 ~max_bytes:4096 ~timeout_sec:5.0 ()));
+      let run_started () =
+        Sys.file_exists log_path
+        && contains_substring (read_file log_path) "run-started"
+      in
+      Alcotest.(check bool)
+        "fallback docker run holds Docker_spawn slot after run starts"
+        true
+        (wait_until ~clock ~attempts:300 (fun () ->
+             run_started () && docker_spawn_in_flight () > 0)));
   (match !result with
-   | Some (Ok (Unix.WEXITED 0, out)) ->
-       Alcotest.(check string) "slow run output" "slow run ok\n" out
-   | Some (Ok (status, out)) ->
-       Alcotest.failf "unexpected status %s output=%s"
-         (match status with
-          | Unix.WEXITED code -> Printf.sprintf "exit=%d" code
-          | Unix.WSIGNALED n -> Printf.sprintf "signal=%d" n
-          | Unix.WSTOPPED n -> Printf.sprintf "stopped=%d" n)
-         out
+   | None -> Alcotest.fail "expected docker read command result"
    | Some (Error msg) ->
-       Alcotest.failf "expected slow docker run success, got %s" msg
-   | None -> Alcotest.fail "docker run fiber did not record result") ;
-  Alcotest.(check int) "docker spawn slot released" 0
-    (docker_spawn_in_flight ())
+       Alcotest.failf "expected docker read command success, got %s" msg
+   | Some (Ok (st, out)) ->
+       Alcotest.(check (pair string int)) "slow docker exits cleanly"
+         ("exit", 0)
+         (match st with
+          | Unix.WEXITED code -> ("exit", code)
+          | Unix.WSIGNALED code -> ("signaled", code)
+          | Unix.WSTOPPED code -> ("stopped", code));
+       Alcotest.(check string) "slow docker stdout" "slow ok\n" out);
+   Alcotest.(check int) "Docker_spawn slot released" 0
+     (docker_spawn_in_flight ())
 
 let test_turn_runtime_reuses_single_container () =
   with_fake_docker fake_docker_turn_runtime_script @@ fun () ->
@@ -1077,7 +1077,7 @@ let test_turn_runtime_relaxed_fs_omits_readonly_and_noexec () =
       Alcotest.(check bool) "relaxed runtime keeps tmpfs mount" true
         (contains_substring line "/tmp:rw,nosuid,nodev,size=")
 
-let run_tests () =
+let run_tests ~clock () =
   Alcotest.run "Keeper_docker_read"
     [
       ( "should_route_read",
@@ -1131,8 +1131,8 @@ let run_tests () =
             test_run_command_allows_configured_nonzero_exit;
           Alcotest.test_case "preserves bare command argv" `Quick
             test_run_command_preserves_bare_command_argv;
-          Alcotest.test_case "fallback run holds docker spawn slot"
-            `Quick test_run_command_holds_docker_spawn_slot;
+          Alcotest.test_case "fallback uses Docker_spawn slot" `Quick
+            (test_run_command_fallback_uses_docker_spawn_slot ~clock);
           Alcotest.test_case "default fs hardening helpers" `Quick
             test_default_fs_hardening_helpers;
           Alcotest.test_case "relaxed fs helpers" `Quick
@@ -1173,4 +1173,4 @@ let () =
     ~cwd_default:Eio.Path.(Eio.Stdenv.fs env / Sys.getcwd ())
     ~proc_mgr:(Eio.Stdenv.process_mgr env)
     ~clock:(Eio.Stdenv.clock env);
-  run_tests ()
+  run_tests ~clock:(Eio.Stdenv.clock env) ()


### PR DESCRIPTION
Fixes #16070

## Summary
- Wrap `keeper_docker_read` fallback `docker run` subprocesses in `Docker_spawn_throttle.with_slot`.
- Preserve the existing `Exec_gate` actor and policy boundary for the actual subprocess execution.
- Add a regression that uses a slow fake Docker runner to observe `Fd_accountant.Docker_spawn` in-flight after the fallback `run` starts, then verifies the slot is released.

## Verification
- `opam exec -- ocamlformat --check lib/keeper/keeper_docker_read.ml test/test_keeper_docker_read.ml`
- `git diff --check`
- `env DUNE_CACHE=disabled dune build --root . --build-dir /private/tmp/masc-mcp-build-docker-read-16070 test/test_keeper_docker_read.exe -j 1 --display=short`
- `/private/tmp/masc-mcp-build-docker-read-16070/default/test/test_keeper_docker_read.exe`

Note: the repo-local `scripts/dune-local.sh` wrapper was blocked by unrelated shared Dune lock holders, so the focused verification used an isolated build directory with `-j 1`.
