### PR TITLE
fix(task): stop keepers clobbering planning current task

### DIFF
--- a/lib/keeper/keeper_identity.mli
+++ b/lib/keeper/keeper_identity.mli
@@ -11,6 +11,7 @@ val keeper_git_email : keeper_name:string -> string
 val git_env_for_keeper : keeper_name:string -> string array
 
 val keeper_name_from_agent_name : string -> string option
+val is_keeper_agent_alias : string -> bool
 val canonical_keeper_name_from_agent_name : string -> string option
 val canonical_keeper_name : string -> string option
 

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -159,11 +159,40 @@ let validate_task_id task_id =
 
 let is_registered_keeper_agent_alias_name config agent_name =
   let agent_name = String.trim agent_name in
+  let keeper_name_variants keeper_name =
+    let map_sep ~from_ch ~to_ch value =
+      String.map (fun c -> if Char.equal c from_ch then to_ch else c) value
+    in
+    let separator_variants value =
+      Json_util.dedupe_keep_order
+        [
+          value;
+          map_sep ~from_ch:('_') ~to_ch:('-') value;
+          map_sep ~from_ch:('-') ~to_ch:('_') value;
+        ]
+    in
+    let generated_type_variants value =
+      if Nickname.is_dictionary_generated_nickname value then
+        match Nickname.extract_agent_type value with
+        | Some agent_type when Keeper_config.validate_name agent_type ->
+            separator_variants agent_type
+        | _ -> []
+      else []
+    in
+    let base_variants = separator_variants keeper_name in
+    Json_util.dedupe_keep_order
+      (base_variants @ List.concat_map generated_type_variants base_variants)
+  in
+  let registered_keeper_name keeper_name =
+    keeper_name_variants keeper_name
+    |> List.exists (fun name ->
+           Option.is_some
+             (Keeper_registry.get ~base_path:config.Coord.base_path name))
+  in
   match Keeper_identity.canonical_keeper_name_from_agent_name agent_name with
   | Some keeper_name ->
       Keeper_identity.is_keeper_agent_alias agent_name
-      && Option.is_some
-           (Keeper_registry.get ~base_path:config.Coord.base_path keeper_name)
+      && registered_keeper_name keeper_name
   | None -> false
 
 let sync_planning_current_task_with_owned_task (ctx : context) =

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -158,19 +158,7 @@ let validate_task_id task_id =
   else Ok task_id
 
 let is_keeper_agent_alias_name agent_name =
-  let trimmed = String.trim agent_name in
-  let has_wrapped_name ~prefix ~suffix =
-    let plen = String.length prefix in
-    let slen = String.length suffix in
-    let len = String.length trimmed in
-    len > plen + slen
-    && String.starts_with ~prefix trimmed
-    && String.ends_with ~suffix trimmed
-  in
-  has_wrapped_name ~prefix:"keeper-" ~suffix:"-agent"
-  || has_wrapped_name ~prefix:"keeper_" ~suffix:"_agent"
-  || has_wrapped_name ~prefix:"keeper-" ~suffix:"_agent"
-  || has_wrapped_name ~prefix:"keeper_" ~suffix:"-agent"
+  Keeper_identity.is_keeper_agent_alias (String.trim agent_name)
 
 let sync_planning_current_task_with_owned_task (ctx : context) =
   let actual_name =

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -157,8 +157,14 @@ let validate_task_id task_id =
   if String.equal task_id "" then Error (Masc_domain.Task (Masc_domain.Task_error.InvalidId "empty task ID"))
   else Ok task_id
 
-let is_keeper_agent_alias_name agent_name =
-  Keeper_identity.is_keeper_agent_alias (String.trim agent_name)
+let is_registered_keeper_agent_alias_name config agent_name =
+  let agent_name = String.trim agent_name in
+  match Keeper_identity.canonical_keeper_name_from_agent_name agent_name with
+  | Some keeper_name ->
+      Keeper_identity.is_keeper_agent_alias agent_name
+      && Option.is_some
+           (Keeper_registry.get ~base_path:config.Coord.base_path keeper_name)
+  | None -> false
 
 let sync_planning_current_task_with_owned_task (ctx : context) =
   let actual_name =
@@ -171,8 +177,8 @@ let sync_planning_current_task_with_owned_task (ctx : context) =
         ctx.agent_name
   in
   if
-    is_keeper_agent_alias_name ctx.agent_name
-    || is_keeper_agent_alias_name actual_name
+    is_registered_keeper_agent_alias_name ctx.config ctx.agent_name
+    || is_registered_keeper_agent_alias_name ctx.config actual_name
   then ()
   else
     let matches_you assignee =

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -157,38 +157,57 @@ let validate_task_id task_id =
   if String.equal task_id "" then Error (Masc_domain.Task (Masc_domain.Task_error.InvalidId "empty task ID"))
   else Ok task_id
 
+let is_keeper_agent_alias_name agent_name =
+  let trimmed = String.trim agent_name in
+  let has_wrapped_name ~prefix ~suffix =
+    let plen = String.length prefix in
+    let slen = String.length suffix in
+    let len = String.length trimmed in
+    len > plen + slen
+    && String.starts_with ~prefix trimmed
+    && String.ends_with ~suffix trimmed
+  in
+  has_wrapped_name ~prefix:"keeper-" ~suffix:"-agent"
+  || has_wrapped_name ~prefix:"keeper_" ~suffix:"_agent"
+  || has_wrapped_name ~prefix:"keeper-" ~suffix:"_agent"
+  || has_wrapped_name ~prefix:"keeper_" ~suffix:"-agent"
+
 let sync_planning_current_task_with_owned_task (ctx : context) =
-  let actual_name =
-    try Coord.resolve_agent_name ctx.config ctx.agent_name
-    with
-    | Sys_error _ | Yojson.Json_error _ -> ctx.agent_name
-    | exn ->
-        Log.Task.warn "resolve_agent_name failed for %s: %s" ctx.agent_name
-          (Stdlib.Printexc.to_string exn);
-        ctx.agent_name
-  in
-  let matches_you assignee =
-    String.equal assignee ctx.agent_name || String.equal assignee actual_name
-  in
-  let owned_task =
-    Coord.get_tasks_raw ctx.config
-    |> List.find_map (fun (task : Masc_domain.task) ->
-           match task.task_status with
-           | Masc_domain.Claimed { assignee; _ }
-           | Masc_domain.InProgress { assignee; _ } ->
-               if matches_you assignee then Some task.id else None
-           | Masc_domain.Todo
-           | Masc_domain.AwaitingVerification _
-           | Masc_domain.Done _
-           | Masc_domain.Cancelled _ -> None)
-  in
-  match owned_task with
-  | Some task_id ->
-      (match Planning_eio.set_current_task ctx.config ~task_id with
-       | Ok () -> ()
-       | Error msg ->
-           Log.Task.warn "failed to sync planning current_task to %s: %s" task_id msg)
-  | None -> Planning_eio.clear_current_task ctx.config
+  if is_keeper_agent_alias_name ctx.agent_name
+  then ()
+  else
+    let actual_name =
+      try Coord.resolve_agent_name ctx.config ctx.agent_name
+      with
+      | Sys_error _ | Yojson.Json_error _ -> ctx.agent_name
+      | exn ->
+          Log.Task.warn "resolve_agent_name failed for %s: %s" ctx.agent_name
+            (Stdlib.Printexc.to_string exn);
+          ctx.agent_name
+    in
+    let matches_you assignee =
+      String.equal assignee ctx.agent_name || String.equal assignee actual_name
+    in
+    let owned_task =
+      Coord.get_tasks_raw ctx.config
+      |> List.find_map (fun (task : Masc_domain.task) ->
+             match task.task_status with
+             | Masc_domain.Claimed { assignee; _ }
+             | Masc_domain.InProgress { assignee; _ } ->
+                 if matches_you assignee then Some task.id else None
+             | Masc_domain.Todo
+             | Masc_domain.AwaitingVerification _
+             | Masc_domain.Done _
+             | Masc_domain.Cancelled _ -> None)
+    in
+    match owned_task with
+    | Some task_id ->
+        (match Planning_eio.set_current_task ctx.config ~task_id with
+         | Ok () -> ()
+         | Error msg ->
+             Log.Task.warn "failed to sync planning current_task to %s: %s"
+               task_id msg)
+    | None -> Planning_eio.clear_current_task ctx.config
 
 let sync_keeper_current_task_binding (ctx : context) =
   Keeper_current_task_reconcile.sync_current_task_id_for_agent_name

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -173,18 +173,20 @@ let is_keeper_agent_alias_name agent_name =
   || has_wrapped_name ~prefix:"keeper_" ~suffix:"-agent"
 
 let sync_planning_current_task_with_owned_task (ctx : context) =
-  if is_keeper_agent_alias_name ctx.agent_name
+  let actual_name =
+    try Coord.resolve_agent_name ctx.config ctx.agent_name
+    with
+    | Sys_error _ | Yojson.Json_error _ -> ctx.agent_name
+    | exn ->
+        Log.Task.warn "resolve_agent_name failed for %s: %s" ctx.agent_name
+          (Stdlib.Printexc.to_string exn);
+        ctx.agent_name
+  in
+  if
+    is_keeper_agent_alias_name ctx.agent_name
+    || is_keeper_agent_alias_name actual_name
   then ()
   else
-    let actual_name =
-      try Coord.resolve_agent_name ctx.config ctx.agent_name
-      with
-      | Sys_error _ | Yojson.Json_error _ -> ctx.agent_name
-      | exn ->
-          Log.Task.warn "resolve_agent_name failed for %s: %s" ctx.agent_name
-            (Stdlib.Printexc.to_string exn);
-          ctx.agent_name
-    in
     let matches_you assignee =
       String.equal assignee ctx.agent_name || String.equal assignee actual_name
     in

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1163,6 +1163,86 @@ let () = test "keeper_alias_claim_does_not_clobber_planning_current_task" (fun (
   assert result.Tool_result.success;
   assert (Planning_eio.get_current_task ctx.config = Some "task-001"))
 
+let () = test "keeper_generated_alias_claim_does_not_clobber_planning_current_task" (fun () ->
+  let ctx = make_test_ctx_with_agent "codex-mcp-client" in
+  let _ =
+    Tool_task.handle_add_task
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc [ ("title", `String "Operator task") ])
+  in
+  let _ =
+    Tool_task.handle_add_task
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc [ ("title", `String "Keeper task") ])
+  in
+  (match Planning_eio.set_current_task ctx.config ~task_id:"task-001" with
+   | Ok () -> ()
+   | Error msg -> failwith ("failed to seed current_task: " ^ msg));
+  ignore
+    (Coord.join ctx.config ~agent_name:"keeper-executor-agent"
+       ~capabilities:[] ());
+  ignore
+    (Coord.join ctx.config ~agent_name:"keeper-executor-warm-raven-agent"
+       ~capabilities:[] ());
+  register_test_keeper ctx ~keeper_name:"executor"
+    ~agent_name:"keeper-executor-agent";
+  let keeper_ctx =
+    { ctx with Tool_task.agent_name = "keeper-executor-warm-raven-agent" }
+  in
+  let result =
+    Tool_task.handle_claim
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      keeper_ctx
+      (`Assoc [ ("task_id", `String "task-002") ])
+  in
+  assert result.Tool_result.success;
+  assert (Planning_eio.get_current_task ctx.config = Some "task-001"))
+
+let () = test "keeper_separator_alias_claim_does_not_clobber_planning_current_task" (fun () ->
+  let ctx = make_test_ctx_with_agent "codex-mcp-client" in
+  let _ =
+    Tool_task.handle_add_task
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc [ ("title", `String "Operator task") ])
+  in
+  let _ =
+    Tool_task.handle_add_task
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc [ ("title", `String "Keeper task") ])
+  in
+  (match Planning_eio.set_current_task ctx.config ~task_id:"task-001" with
+   | Ok () -> ()
+   | Error msg -> failwith ("failed to seed current_task: " ^ msg));
+  ignore
+    (Coord.join ctx.config ~agent_name:"keeper-tech-glutton-agent"
+       ~capabilities:[] ());
+  ignore
+    (Coord.join ctx.config ~agent_name:"keeper-tech_glutton-agent"
+       ~capabilities:[] ());
+  register_test_keeper ctx ~keeper_name:"tech-glutton"
+    ~agent_name:"keeper-tech-glutton-agent";
+  let keeper_ctx =
+    { ctx with Tool_task.agent_name = "keeper-tech_glutton-agent" }
+  in
+  let result =
+    Tool_task.handle_claim
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      keeper_ctx
+      (`Assoc [ ("task_id", `String "task-002") ])
+  in
+  assert result.Tool_result.success;
+  assert (Planning_eio.get_current_task ctx.config = Some "task-001"))
+
 let () = test "keeper_shaped_non_keeper_claim_updates_planning_current_task" (fun () ->
   let ctx = make_test_ctx_with_agent "codex-mcp-client" in
   let _ =

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1073,6 +1073,41 @@ let () = test "handle_claim_sets_planning_current_task" (fun () ->
   assert (Planning_eio.get_current_task ctx.config = Some "task-001")
 )
 
+let () = test "keeper_claim_does_not_clobber_planning_current_task" (fun () ->
+  let ctx = make_test_ctx_with_agent "codex-mcp-client" in
+  let _ =
+    Tool_task.handle_add_task
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc [ ("title", `String "Operator task") ])
+  in
+  let _ =
+    Tool_task.handle_add_task
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc [ ("title", `String "Keeper task") ])
+  in
+  (match Planning_eio.set_current_task ctx.config ~task_id:"task-001" with
+   | Ok () -> ()
+   | Error msg -> failwith ("failed to seed current_task: " ^ msg));
+  ignore
+    (Coord.join ctx.config ~agent_name:"keeper-executor-agent"
+       ~capabilities:[] ());
+  let keeper_ctx =
+    { ctx with Tool_task.agent_name = "keeper-executor-agent" }
+  in
+  let result =
+    Tool_task.handle_claim
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      keeper_ctx
+      (`Assoc [ ("task_id", `String "task-002") ])
+  in
+  assert result.Tool_result.success;
+  assert (Planning_eio.get_current_task ctx.config = Some "task-001"))
+
 let () = test "handle_claim_rejects_second_active_owned_task" (fun () ->
   let ctx = make_test_ctx () in
   let _ =

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1108,6 +1108,41 @@ let () = test "keeper_claim_does_not_clobber_planning_current_task" (fun () ->
   assert result.Tool_result.success;
   assert (Planning_eio.get_current_task ctx.config = Some "task-001"))
 
+let () = test "keeper_alias_claim_does_not_clobber_planning_current_task" (fun () ->
+  let ctx = make_test_ctx_with_agent "codex-mcp-client" in
+  let _ =
+    Tool_task.handle_add_task
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc [ ("title", `String "Operator task") ])
+  in
+  let _ =
+    Tool_task.handle_add_task
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc [ ("title", `String "Keeper task") ])
+  in
+  (match Planning_eio.set_current_task ctx.config ~task_id:"task-001" with
+   | Ok () -> ()
+   | Error msg -> failwith ("failed to seed current_task: " ^ msg));
+  ignore
+    (Coord.join ctx.config ~agent_name:"keeper-executor-agent"
+       ~capabilities:[] ());
+  let keeper_ctx =
+    { ctx with Tool_task.agent_name = "keeper-executor" }
+  in
+  let result =
+    Tool_task.handle_claim
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      keeper_ctx
+      (`Assoc [ ("task_id", `String "task-002") ])
+  in
+  assert result.Tool_result.success;
+  assert (Planning_eio.get_current_task ctx.config = Some "task-001"))
+
 let () = test "handle_claim_rejects_second_active_owned_task" (fun () ->
   let ctx = make_test_ctx () in
   let _ =

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -89,6 +89,22 @@ let add_task_requiring_tools ctx ~title tools =
   in
   if not result.Tool_result.success then failwith result.Tool_result.legacy_message
 
+let register_test_keeper ctx ~keeper_name ~agent_name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [
+          ("name", `String keeper_name);
+          ("agent_name", `String agent_name);
+          ("trace_id", `String ("test-trace-" ^ keeper_name));
+        ])
+  with
+  | Ok meta ->
+      ignore
+        (Keeper_registry.register_offline ~base_path:ctx.Tool_task.config.Coord.base_path
+           keeper_name meta)
+  | Error e -> failwith ("failed to build keeper meta: " ^ e)
+
 let set_only_task_do_not_reclaim_reason ctx reason =
   let config = ctx.Tool_task.config in
   let backlog = Coord.read_backlog config in
@@ -1095,6 +1111,8 @@ let () = test "keeper_claim_does_not_clobber_planning_current_task" (fun () ->
   ignore
     (Coord.join ctx.config ~agent_name:"keeper-executor-agent"
        ~capabilities:[] ());
+  register_test_keeper ctx ~keeper_name:"executor"
+    ~agent_name:"keeper-executor-agent";
   let keeper_ctx =
     { ctx with Tool_task.agent_name = "keeper-executor-agent" }
   in
@@ -1130,6 +1148,8 @@ let () = test "keeper_alias_claim_does_not_clobber_planning_current_task" (fun (
   ignore
     (Coord.join ctx.config ~agent_name:"keeper-executor-agent"
        ~capabilities:[] ());
+  register_test_keeper ctx ~keeper_name:"executor"
+    ~agent_name:"keeper-executor-agent";
   let keeper_ctx =
     { ctx with Tool_task.agent_name = "keeper-executor" }
   in
@@ -1142,6 +1162,41 @@ let () = test "keeper_alias_claim_does_not_clobber_planning_current_task" (fun (
   in
   assert result.Tool_result.success;
   assert (Planning_eio.get_current_task ctx.config = Some "task-001"))
+
+let () = test "keeper_shaped_non_keeper_claim_updates_planning_current_task" (fun () ->
+  let ctx = make_test_ctx_with_agent "codex-mcp-client" in
+  let _ =
+    Tool_task.handle_add_task
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc [ ("title", `String "Operator task") ])
+  in
+  let _ =
+    Tool_task.handle_add_task
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc [ ("title", `String "Spoofed keeper task") ])
+  in
+  (match Planning_eio.set_current_task ctx.config ~task_id:"task-001" with
+   | Ok () -> ()
+   | Error msg -> failwith ("failed to seed current_task: " ^ msg));
+  ignore
+    (Coord.join ctx.config ~agent_name:"keeper-spoof-agent"
+       ~capabilities:[] ());
+  let spoof_ctx =
+    { ctx with Tool_task.agent_name = "keeper-spoof-agent" }
+  in
+  let result =
+    Tool_task.handle_claim
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      spoof_ctx
+      (`Assoc [ ("task_id", `String "task-002") ])
+  in
+  assert result.Tool_result.success;
+  assert (Planning_eio.get_current_task ctx.config = Some "task-002"))
 
 let () = test "handle_claim_rejects_second_active_owned_task" (fun () ->
   let ctx = make_test_ctx () in


### PR DESCRIPTION
## Summary
- keep keeper task transitions from rewriting the shared planning current_task file
- preserve existing current_task sync for normal MCP/client agents
- add regression coverage for a keeper claim not clobbering an operator current_task

## Verification
- opam exec -- ocamlformat --check lib/tool_task.ml test/test_tool_task_coverage.ml
- git diff --check origin/main..HEAD
- scripts/dune-local.sh build ./test/test_tool_task_coverage.exe
- ./_build/default/test/test_tool_task_coverage.exe