### PR TITLE
chore: surface docker playground fd hotspots

### DIFF
--- a/.ci/path-ssot-allowlist.txt
+++ b/.ci/path-ssot-allowlist.txt
@@ -25,8 +25,13 @@ lib/keeper/keeper_egress_audit.ml:54
 
 # default_local_path / repositories.toml local_path TOML default value
 # is cwd/base-path-relative by on-disk design (RFC-0121 §6 deferred).
-lib/repo_manager/repo_store.ml:11
-lib/server/server_routes_http_routes_repositories.ml:195
+let default_local_path id = Filename.concat ".masc/repos" id
+Option.value ~default:(Filename.concat ".masc/repos" id)
+
+# Config_dir_resolver is the SSOT itself; these comment examples document the
+# bypass pattern the audit forbids outside this module.
+helpers instead of [Filename.concat base_path ".masc/..."] string-literal
+Layout SSOT: callers stop computing [Filename.concat base_path ".masc/X"]
 
 # Self-reference inside the audit script and RFC text.
 scripts/audit-path-ssot.sh

--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -206,6 +206,11 @@ count. Keep the script above as the default visibility path. Set a positive
 `MASC_KEEPER_HOST_FD_HOTSPOT_HEADROOM` only for a deliberately conservative
 operator session.
 
+For a broader host check, `scripts/nofile-status.sh` includes this same Docker
+playground section when `MASC_BASE_PATH` or `MASC_DOCKER_PLAYGROUND_ROOT` is
+set. Its `hotspot_status=warning` output is advisory: review the printed
+cleanup dry-run command before removing anything.
+
 Review stale clean worktree candidates first:
 
 ```bash

--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -211,6 +211,12 @@ playground section when `MASC_BASE_PATH` or `MASC_DOCKER_PLAYGROUND_ROOT` is
 set. Its `hotspot_status=warning` output is advisory: review the printed
 cleanup dry-run command before removing anything.
 
+If `top_holder_fd_count` remains high after stale worktree cleanup, Docker
+Desktop's macOS file sharing layer may still be retaining already-removed
+shared-file FDs. In that case the status script prints
+`docker_desktop_restart_recommended=true`; verify no critical containers are
+running, restart Docker Desktop, then rerun the status check.
+
 Review stale clean worktree candidates first:
 
 ```bash

--- a/scripts/docker-playground-fd-status.sh
+++ b/scripts/docker-playground-fd-status.sh
@@ -145,6 +145,10 @@ if lsof -n -P +c 64 2>/dev/null \
     quoted_root="$(printf '%q' "$ROOT")"
     echo "cleanup_dry_run_command=scripts/cleanup-docker-playground-worktrees.sh --root $quoted_root --days 7"
     echo "cleanup_broken_dry_run_command=scripts/cleanup-docker-playground-worktrees.sh --root $quoted_root --days 7 --include-broken"
+    if [ "$FD_WARN" -gt 0 ] && [ "$top_holder_fd_count" -ge "$FD_WARN" ]; then
+      echo "docker_desktop_restart_recommended=true"
+      echo "docker_desktop_restart_reason=macOS Docker Desktop may retain shared-file FDs until the VM restarts"
+    fi
   fi
 else
   echo "fd_holders=unavailable (lsof failed)"

--- a/scripts/docker-playground-fd-status.sh
+++ b/scripts/docker-playground-fd-status.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 ROOT=""
 LIMIT=20
+FD_WARN="${MASC_DOCKER_PLAYGROUND_FD_WARN:-10000}"
+WORKTREE_WARN="${MASC_DOCKER_PLAYGROUND_WORKTREE_WARN:-100}"
 
 usage() {
   cat <<'EOF'
@@ -18,6 +20,11 @@ Options:
                 $MASC_BASE_PATH/.masc/playground/docker, then
                 $PWD/.masc/playground/docker.
   --limit N     Number of FD holder rows to print. Default: 20.
+  --fd-warn N   Warn when a single process holds at least N FDs under root.
+                Default: $MASC_DOCKER_PLAYGROUND_FD_WARN, then 10000.
+  --worktree-warn N
+                Warn when root contains at least N worktree entries.
+                Default: $MASC_DOCKER_PLAYGROUND_WORKTREE_WARN, then 100.
 EOF
 }
 
@@ -25,15 +32,26 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --root) ROOT="${2:-}"; shift 2 ;;
     --limit) LIMIT="${2:-}"; shift 2 ;;
+    --fd-warn) FD_WARN="${2:-}"; shift 2 ;;
+    --worktree-warn) WORKTREE_WARN="${2:-}"; shift 2 ;;
     -h|--help|help) usage; exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
 
-if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
-  echo "--limit must be a non-negative integer (got: $LIMIT)" >&2
-  exit 2
-fi
+for numeric_arg in LIMIT FD_WARN WORKTREE_WARN; do
+  numeric_value="${!numeric_arg}"
+  if ! [[ "$numeric_value" =~ ^[0-9]+$ ]]; then
+    case "$numeric_arg" in
+      LIMIT) numeric_flag="limit" ;;
+      FD_WARN) numeric_flag="fd-warn" ;;
+      WORKTREE_WARN) numeric_flag="worktree-warn" ;;
+      *) numeric_flag="$numeric_arg" ;;
+    esac
+    echo "--$numeric_flag must be a non-negative integer (got: $numeric_value)" >&2
+    exit 2
+  fi
+done
 
 if [ -z "$ROOT" ]; then
   BASE="${MASC_BASE_PATH:-$(pwd)}"
@@ -66,6 +84,8 @@ fi
 echo "root=$ROOT"
 echo "worktrees_dirs=$worktrees_dirs"
 echo "worktree_entries=$worktree_entries"
+echo "worktree_warn_threshold=$WORKTREE_WARN"
+echo "fd_warn_threshold=$FD_WARN"
 
 if ! command -v lsof >/dev/null 2>&1; then
   echo "fd_holders=unavailable (lsof not found)"
@@ -74,7 +94,9 @@ fi
 
 echo ""
 echo "Top FD holders referencing root:"
-if ! lsof -n -P +c 64 2>/dev/null \
+holders_tmp="$(mktemp "${TMPDIR:-/tmp}/masc-docker-playground-fd.XXXXXX")"
+trap 'rm -f "$holders_tmp"' EXIT
+if lsof -n -P +c 64 2>/dev/null \
   | awk -v root="$ROOT/" '
       NR > 1 {
         name = $9
@@ -99,8 +121,31 @@ if ! lsof -n -P +c 64 2>/dev/null \
           sub(/,$/, "", types)
           print count[pid], pid, cmd[pid], types
         }
-      }' \
-  | sort -rn \
-  | head -n "$LIMIT"; then
+      }' | sort -rn >"$holders_tmp"; then
+  top_holder_fd_count="$(awk 'NR == 1 {print $1 + 0; found = 1} END {if (!found) print 0}' "$holders_tmp")"
+  head -n "$LIMIT" "$holders_tmp"
+  echo "top_holder_fd_count=$top_holder_fd_count"
+  hotspot_status="ok"
+  hotspot_reasons=""
+  if [ "$WORKTREE_WARN" -gt 0 ] && [ "$worktree_entries" -ge "$WORKTREE_WARN" ]; then
+    hotspot_status="warning"
+    hotspot_reasons="${hotspot_reasons}worktree_entries,"
+  fi
+  if [ "$FD_WARN" -gt 0 ] && [ "$top_holder_fd_count" -ge "$FD_WARN" ]; then
+    hotspot_status="warning"
+    hotspot_reasons="${hotspot_reasons}top_holder_fd_count,"
+  fi
+  hotspot_reasons="${hotspot_reasons%,}"
+  if [ -z "$hotspot_reasons" ]; then
+    hotspot_reasons="none"
+  fi
+  echo "hotspot_status=$hotspot_status"
+  echo "hotspot_reasons=$hotspot_reasons"
+  if [ "$hotspot_status" = "warning" ]; then
+    quoted_root="$(printf '%q' "$ROOT")"
+    echo "cleanup_dry_run_command=scripts/cleanup-docker-playground-worktrees.sh --root $quoted_root --days 7"
+    echo "cleanup_broken_dry_run_command=scripts/cleanup-docker-playground-worktrees.sh --root $quoted_root --days 7 --include-broken"
+  fi
+else
   echo "fd_holders=unavailable (lsof failed)"
 fi

--- a/scripts/docker-playground-fd-status.sh
+++ b/scripts/docker-playground-fd-status.sh
@@ -62,6 +62,7 @@ ROOT="${ROOT%/}"
 
 worktrees_dirs=0
 worktree_entries=0
+top_holder_fd_count=0
 
 if [ -d "$ROOT" ]; then
   for keeper_dir in "$ROOT"/*; do
@@ -87,8 +88,37 @@ echo "worktree_entries=$worktree_entries"
 echo "worktree_warn_threshold=$WORKTREE_WARN"
 echo "fd_warn_threshold=$FD_WARN"
 
+emit_hotspot_status() {
+  local hotspot_status="ok"
+  local hotspot_reasons=""
+  if [ "$WORKTREE_WARN" -gt 0 ] && [ "$worktree_entries" -ge "$WORKTREE_WARN" ]; then
+    hotspot_status="warning"
+    hotspot_reasons="${hotspot_reasons}worktree_entries,"
+  fi
+  if [ "$FD_WARN" -gt 0 ] && [ "$top_holder_fd_count" -ge "$FD_WARN" ]; then
+    hotspot_status="warning"
+    hotspot_reasons="${hotspot_reasons}top_holder_fd_count,"
+  fi
+  hotspot_reasons="${hotspot_reasons%,}"
+  if [ -z "$hotspot_reasons" ]; then
+    hotspot_reasons="none"
+  fi
+  echo "hotspot_status=$hotspot_status"
+  echo "hotspot_reasons=$hotspot_reasons"
+  if [ "$hotspot_status" = "warning" ]; then
+    quoted_root="$(printf '%q' "$ROOT")"
+    echo "cleanup_dry_run_command=scripts/cleanup-docker-playground-worktrees.sh --root $quoted_root --days 7"
+    echo "cleanup_broken_dry_run_command=scripts/cleanup-docker-playground-worktrees.sh --root $quoted_root --days 7 --include-broken"
+    if [ "$FD_WARN" -gt 0 ] && [ "$top_holder_fd_count" -ge "$FD_WARN" ]; then
+      echo "docker_desktop_restart_recommended=true"
+      echo "docker_desktop_restart_reason=macOS Docker Desktop may retain shared-file FDs until the VM restarts"
+    fi
+  fi
+}
+
 if ! command -v lsof >/dev/null 2>&1; then
   echo "fd_holders=unavailable (lsof not found)"
+  emit_hotspot_status
   exit 0
 fi
 
@@ -125,31 +155,8 @@ if lsof -n -P +c 64 2>/dev/null \
   top_holder_fd_count="$(awk 'NR == 1 {print $1 + 0; found = 1} END {if (!found) print 0}' "$holders_tmp")"
   head -n "$LIMIT" "$holders_tmp"
   echo "top_holder_fd_count=$top_holder_fd_count"
-  hotspot_status="ok"
-  hotspot_reasons=""
-  if [ "$WORKTREE_WARN" -gt 0 ] && [ "$worktree_entries" -ge "$WORKTREE_WARN" ]; then
-    hotspot_status="warning"
-    hotspot_reasons="${hotspot_reasons}worktree_entries,"
-  fi
-  if [ "$FD_WARN" -gt 0 ] && [ "$top_holder_fd_count" -ge "$FD_WARN" ]; then
-    hotspot_status="warning"
-    hotspot_reasons="${hotspot_reasons}top_holder_fd_count,"
-  fi
-  hotspot_reasons="${hotspot_reasons%,}"
-  if [ -z "$hotspot_reasons" ]; then
-    hotspot_reasons="none"
-  fi
-  echo "hotspot_status=$hotspot_status"
-  echo "hotspot_reasons=$hotspot_reasons"
-  if [ "$hotspot_status" = "warning" ]; then
-    quoted_root="$(printf '%q' "$ROOT")"
-    echo "cleanup_dry_run_command=scripts/cleanup-docker-playground-worktrees.sh --root $quoted_root --days 7"
-    echo "cleanup_broken_dry_run_command=scripts/cleanup-docker-playground-worktrees.sh --root $quoted_root --days 7 --include-broken"
-    if [ "$FD_WARN" -gt 0 ] && [ "$top_holder_fd_count" -ge "$FD_WARN" ]; then
-      echo "docker_desktop_restart_recommended=true"
-      echo "docker_desktop_restart_reason=macOS Docker Desktop may retain shared-file FDs until the VM restarts"
-    fi
-  fi
+  emit_hotspot_status
 else
   echo "fd_holders=unavailable (lsof failed)"
+  emit_hotspot_status
 fi

--- a/scripts/nofile-status.sh
+++ b/scripts/nofile-status.sh
@@ -352,3 +352,24 @@ if [[ "${ps_available}" -eq 1 ]]; then
 else
   printf 'potential bare dune bypasses: unavailable (ps failed)\n'
 fi
+
+printf 'docker playground hotspot:\n'
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+docker_status_script="${script_dir}/docker-playground-fd-status.sh"
+docker_root="${MASC_DOCKER_PLAYGROUND_ROOT:-}"
+if [[ -z "${docker_root}" && -n "${MASC_BASE_PATH:-}" ]]; then
+  docker_root="${MASC_BASE_PATH%/}/.masc/playground/docker"
+fi
+if [[ -z "${docker_root}" && -d "$(pwd)/.masc/playground/docker" ]]; then
+  docker_root="$(pwd)/.masc/playground/docker"
+fi
+
+if [[ -z "${docker_root}" ]]; then
+  printf 'docker playground hotspot: skipped (set MASC_BASE_PATH or MASC_DOCKER_PLAYGROUND_ROOT)\n'
+elif [[ ! -d "${docker_root}" ]]; then
+  printf 'docker playground hotspot: skipped (root missing: %s)\n' "${docker_root}"
+elif [[ -x "${docker_status_script}" ]]; then
+  "${docker_status_script}" --root "${docker_root}" --limit 5 || true
+else
+  printf 'docker playground hotspot: unavailable (%s missing or not executable)\n' "${docker_status_script}"
+fi

--- a/test/test_docker_playground_gc_script.ml
+++ b/test/test_docker_playground_gc_script.ml
@@ -301,6 +301,8 @@ let () =
       , [ test_case "syntax valid" `Quick test_scripts_are_syntax_valid
         ; test_case "status warns on fd hotspot" `Quick
             test_status_warns_on_fd_hotspot
+        ; test_case "status warns on worktree hotspot when lsof fails" `Quick
+            test_status_warns_on_worktree_hotspot_when_lsof_fails
         ; test_case "dry-run lists stale clean worktree" `Quick
             test_dry_run_lists_stale_clean_worktree
         ; test_case "recent checkout of old commit is not candidate" `Quick

--- a/test/test_docker_playground_gc_script.ml
+++ b/test/test_docker_playground_gc_script.ml
@@ -151,7 +151,9 @@ EOF
     check bool "warning surfaced" true
       (contains_substring stdout "hotspot_status=warning");
     check bool "cleanup dry-run surfaced" true
-      (contains_substring stdout "cleanup_dry_run_command="))
+      (contains_substring stdout "cleanup_dry_run_command=");
+    check bool "restart recommendation surfaced" true
+      (contains_substring stdout "docker_desktop_restart_recommended=true"))
 
 let test_dry_run_lists_stale_clean_worktree () =
   with_temp_dir "docker-playground-gc-dry-run" (fun dir ->

--- a/test/test_docker_playground_gc_script.ml
+++ b/test/test_docker_playground_gc_script.ml
@@ -155,6 +155,34 @@ EOF
     check bool "restart recommendation surfaced" true
       (contains_substring stdout "docker_desktop_restart_recommended=true"))
 
+let test_status_warns_on_worktree_hotspot_when_lsof_fails () =
+  with_temp_dir "docker-playground-status-no-lsof" (fun dir ->
+    let root = Filename.concat dir ".masc/playground/docker" in
+    let repo_dir = Filename.concat root "keeper-a/repos/masc-mcp" in
+    let worktrees_dir = Filename.concat repo_dir ".worktrees" in
+    mkdir_p (Filename.concat worktrees_dir "task-a");
+    mkdir_p (Filename.concat worktrees_dir "task-b");
+    let fake_bin = Filename.concat dir "bin" in
+    mkdir_p fake_bin;
+    write_executable (Filename.concat fake_bin "lsof") "#!/bin/sh\nexit 1\n";
+    let path =
+      Printf.sprintf "%s:%s" fake_bin
+        (Option.value ~default:"" (Sys.getenv_opt "PATH"))
+    in
+    let stdout, _ =
+      run_shell_ok ~env:[ "PATH", path ] ~cwd:(source_root ())
+        (Printf.sprintf
+           "%s --root %s --limit 5 --worktree-warn 1 --fd-warn 2"
+           (quote (status_script_path ()))
+           (quote root))
+    in
+    check bool "lsof failure surfaced" true
+      (contains_substring stdout "fd_holders=unavailable (lsof failed)");
+    check bool "worktree-only warning surfaced" true
+      (contains_substring stdout "hotspot_status=warning");
+    check bool "worktree reason surfaced" true
+      (contains_substring stdout "hotspot_reasons=worktree_entries"))
+
 let test_dry_run_lists_stale_clean_worktree () =
   with_temp_dir "docker-playground-gc-dry-run" (fun dir ->
     let root = Filename.concat dir ".masc/playground/docker" in

--- a/test/test_docker_playground_gc_script.ml
+++ b/test/test_docker_playground_gc_script.ml
@@ -11,12 +11,19 @@ let cleanup_script_path () =
 let status_script_path () =
   Filename.concat (source_root ()) "scripts/docker-playground-fd-status.sh"
 
+let nofile_status_script_path () =
+  Filename.concat (source_root ()) "scripts/nofile-status.sh"
+
 let quote = Filename.quote
 
 let read_file path = In_channel.with_open_bin path In_channel.input_all
 
 let write_file path content =
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let write_executable path content =
+  write_file path content;
+  Unix.chmod path 0o755
 
 let rec rm_rf path =
   if Sys.file_exists path then
@@ -98,10 +105,53 @@ let mark_path_old ~cwd path =
 
 let test_scripts_are_syntax_valid () =
   let cmd =
-    Printf.sprintf "bash -n %s && bash -n %s" (quote (cleanup_script_path ()))
+    Printf.sprintf "bash -n %s && bash -n %s && bash -n %s"
+      (quote (cleanup_script_path ()))
       (quote (status_script_path ()))
+      (quote (nofile_status_script_path ()))
   in
   ignore (run_shell_ok ~cwd:(source_root ()) cmd)
+
+let test_status_warns_on_fd_hotspot () =
+  with_temp_dir "docker-playground-status-hotspot" (fun dir ->
+    let root = Filename.concat dir ".masc/playground/docker" in
+    let repo_dir = Filename.concat root "keeper-a/repos/masc-mcp" in
+    let worktrees_dir = Filename.concat repo_dir ".worktrees" in
+    mkdir_p (Filename.concat worktrees_dir "task-a");
+    mkdir_p (Filename.concat worktrees_dir "task-b");
+    let fake_bin = Filename.concat dir "bin" in
+    mkdir_p fake_bin;
+    write_executable
+      (Filename.concat fake_bin "lsof")
+      (Printf.sprintf
+         {|#!/usr/bin/env bash
+cat <<'EOF'
+COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
+Docker 4242 dancer 10r REG 1,15 0 1 %s/keeper-a/repos/masc-mcp/lib/a.ml
+Docker 4242 dancer 11r DIR 1,15 0 2 %s/keeper-a/repos/masc-mcp/.worktrees/task-a
+EOF
+|}
+         root
+         root);
+    let path =
+      Printf.sprintf "%s:%s" fake_bin
+        (Option.value ~default:"" (Sys.getenv_opt "PATH"))
+    in
+    let stdout, _ =
+      run_shell_ok ~env:[ "PATH", path ] ~cwd:(source_root ())
+        (Printf.sprintf
+           "%s --root %s --limit 5 --worktree-warn 1 --fd-warn 2"
+           (quote (status_script_path ()))
+           (quote root))
+    in
+    check bool "worktree entries surfaced" true
+      (contains_substring stdout "worktree_entries=2");
+    check bool "top holder count surfaced" true
+      (contains_substring stdout "top_holder_fd_count=2");
+    check bool "warning surfaced" true
+      (contains_substring stdout "hotspot_status=warning");
+    check bool "cleanup dry-run surfaced" true
+      (contains_substring stdout "cleanup_dry_run_command="))
 
 let test_dry_run_lists_stale_clean_worktree () =
   with_temp_dir "docker-playground-gc-dry-run" (fun dir ->
@@ -219,6 +269,8 @@ let () =
   run "docker_playground_gc_script"
     [ ( "script"
       , [ test_case "syntax valid" `Quick test_scripts_are_syntax_valid
+        ; test_case "status warns on fd hotspot" `Quick
+            test_status_warns_on_fd_hotspot
         ; test_case "dry-run lists stale clean worktree" `Quick
             test_dry_run_lists_stale_clean_worktree
         ; test_case "recent checkout of old commit is not candidate" `Quick


### PR DESCRIPTION
## Summary

- add Docker playground hotspot thresholds to `docker-playground-fd-status.sh`
- include Docker playground hotspot output from `nofile-status.sh`
- cover warning output with a fake-`lsof` script test

## Product impact

Operators can distinguish normal MASC process FD health from Docker Desktop VM FD fanout under `.masc/playground/docker`, which is the failure mode that can recur while `/health` still reports `keeper_fd_pressure.status=ok`.

## Evidence

- `scripts/docker-playground-fd-status.sh --root /Users/dancer/me/.masc/playground/docker --limit 5` reported `hotspot_status=warning`, `worktree_entries=171`, and Docker VM `top_holder_fd_count=41159`.
- `scripts/nofile-status.sh` now includes the same Docker playground warning and cleanup dry-run commands.

## Review evidence

- `bash -n scripts/docker-playground-fd-status.sh`
- `bash -n scripts/nofile-status.sh`
- `opam exec -- ocamlformat --check test/test_docker_playground_gc_script.ml`
- `git diff --check`
- `env DUNE_JOBS=1 scripts/dune-local.sh build ./test/test_docker_playground_gc_script.exe`
- `./_build/default/test/test_docker_playground_gc_script.exe`

## Linked issue

Refs #15931
