### PR TITLE
fix(scripts): purge ME_ROOT/cwd silent fallback (RFC-0121 PR-5/6)

### DIFF
--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -95,10 +95,10 @@ GH_HOSTS_USER_RE = re.compile(r"^\s*user:\s*['\"]?([^'\"\s#]+)")
 ERROR_STATUSES = {"error", "failed", "failure", "timeout", "cancelled", "canceled"}
 
 
-def default_base_path() -> str:
-    return (
-        os.environ.get("MASC_BASE_PATH") or os.environ.get("ME_ROOT") or str(Path.cwd())
-    )
+def default_base_path() -> str | None:
+    # RFC-0121: MASC_BASE_PATH is the sole canonical source.
+    value = os.environ.get("MASC_BASE_PATH", "").strip()
+    return value or None
 
 
 @dataclass
@@ -2051,6 +2051,11 @@ def audit_keeper(
 
 
 def build_report(args: argparse.Namespace) -> dict[str, Any]:
+    if args.base_path is None:
+        raise SystemExit(
+            "Error: MASC_BASE_PATH is required (or pass --base-path PATH). "
+            "RFC-0121 forbids ME_ROOT/cwd fallback."
+        )
     base_path = Path(args.base_path).expanduser().resolve()
     config_dir = base_path / ".masc" / "config" / "keepers"
     if not config_dir.is_dir():
@@ -2298,7 +2303,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--base-path",
         default=default_base_path(),
-        help="MASC base path containing .masc (default: MASC_BASE_PATH, then ME_ROOT, then cwd)",
+        help="MASC base path containing .masc (required; reads MASC_BASE_PATH)",
     )
     parser.add_argument(
         "--expected-keepers",

--- a/scripts/keeper-github-identity-split.py
+++ b/scripts/keeper-github-identity-split.py
@@ -27,10 +27,10 @@ IDENTITY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 SECTION_RE = re.compile(r"^\s*\[[^\]]+\]\s*(?:#.*)?$")
 
 
-def default_base_path() -> str:
-    return (
-        os.environ.get("MASC_BASE_PATH") or os.environ.get("ME_ROOT") or str(Path.cwd())
-    )
+def default_base_path() -> str | None:
+    # RFC-0121: MASC_BASE_PATH is the sole canonical source.
+    value = os.environ.get("MASC_BASE_PATH", "").strip()
+    return value or None
 
 
 @dataclass(frozen=True)
@@ -47,7 +47,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--base-path",
         default=default_base_path(),
-        help="MASC base path containing .masc (default: MASC_BASE_PATH, then ME_ROOT, then cwd).",
+        help="MASC base path containing .masc (required; reads MASC_BASE_PATH).",
     )
     parser.add_argument(
         "--identity",
@@ -224,6 +224,11 @@ def apply_plan(
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
+    if args.base_path is None:
+        raise SystemExit(
+            "Error: MASC_BASE_PATH is required (or pass --base-path PATH). "
+            "RFC-0121 forbids ME_ROOT/cwd fallback."
+        )
     base_path = Path(args.base_path).expanduser().resolve()
     identities = [validate_identity(identity) for identity in args.identity]
     if len(set(identities)) < 2:

--- a/scripts/keeper-production-readiness-gate.py
+++ b/scripts/keeper-production-readiness-gate.py
@@ -23,10 +23,12 @@ from typing import Any
 ERROR_STATUSES = {"error", "failed", "failure", "timeout", "cancelled", "canceled"}
 
 
-def default_base_path() -> str:
-    return (
-        os.environ.get("MASC_BASE_PATH") or os.environ.get("ME_ROOT") or str(Path.cwd())
-    )
+def default_base_path() -> str | None:
+    # RFC-0121: MASC_BASE_PATH is the sole canonical source. No ME_ROOT
+    # alias, no cwd fallback. Argparse handles the None case by surfacing
+    # an explicit error rather than silently writing to the wrong root.
+    value = os.environ.get("MASC_BASE_PATH", "").strip()
+    return value or None
 
 
 @dataclass
@@ -822,7 +824,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--base-path",
         default=default_base_path(),
-        help="MASC base path containing .masc (default: MASC_BASE_PATH, then ME_ROOT, then cwd).",
+        help="MASC base path containing .masc (required; reads MASC_BASE_PATH).",
     )
     parser.add_argument(
         "--keeper", action="append", default=[], help="Keeper name to scan. Repeatable."
@@ -870,6 +872,11 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     thresholds = thresholds_from_args(args)
+    if args.base_path is None:
+        raise SystemExit(
+            "Error: MASC_BASE_PATH is required (or pass --base-path PATH). "
+            "RFC-0121 forbids ME_ROOT/cwd fallback."
+        )
     summary = evaluate(
         base_path=Path(args.base_path).expanduser(),
         keepers=args.keeper,

--- a/scripts/llama-runtime-pool.sh
+++ b/scripts/llama-runtime-pool.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-STATE_DIR="${MASC_LOCAL_RUNTIME_POOL_STATE_DIR:-${MASC_LLAMA_RUNTIME_POOL_STATE_DIR:-${TMPDIR:-/tmp}/masc-local-runtime-pool}}"
+STATE_DIR="${MASC_LOCAL_RUNTIME_POOL_STATE_DIR:-${TMPDIR:-/tmp}/masc-local-runtime-pool}"
 TARGET_SHARDS="${LLAMA_POOL_TARGET_SHARDS:-6}"
 BASE_HOST="${LLAMA_POOL_HOST:-127.0.0.1}"
 DEFAULT_PARALLEL="${LLAMA_POOL_PARALLEL:-12}"
@@ -160,10 +160,6 @@ resolve_llama_server_bin() {
   fi
   if [ -n "${SEED_BINARY:-}" ] && [ -x "${SEED_BINARY}" ]; then
     printf '%s\n' "${SEED_BINARY}"
-    return 0
-  fi
-  if [ -x "$HOME/.local/bin/llama-server" ]; then
-    printf '%s\n' "$HOME/.local/bin/llama-server"
     return 0
   fi
   discovered="$(type -P llama-server 2>/dev/null || true)"

--- a/scripts/masc-autonomy-action-stats.py
+++ b/scripts/masc-autonomy-action-stats.py
@@ -10,11 +10,10 @@ import os
 from typing import Dict, Iterable, List, Tuple
 
 
-def default_base_path() -> str:
+def default_base_path() -> str | None:
+    # RFC-0121: MASC_BASE_PATH is the sole canonical source.
     masc_base = os.environ.get("MASC_BASE_PATH", "").strip()
-    if masc_base:
-        return masc_base
-    return os.getcwd()
+    return masc_base or None
 
 
 def parse_date(s: str) -> dt.datetime:
@@ -123,6 +122,11 @@ def main() -> int:
     args = parser.parse_args()
 
     base_path = default_base_path()
+    if base_path is None:
+        raise SystemExit(
+            "Error: MASC_BASE_PATH is required. RFC-0121 forbids ME_ROOT/cwd "
+            "fallback; export MASC_BASE_PATH explicitly."
+        )
     traces_dir = os.path.join(base_path, ".masc", "traces")
 
     start_ts, end_ts = ts_range_from_args(args.days, args.since, args.until)


### PR DESCRIPTION
## Summary

RFC-0121 sprint **PR-5 of 6** (independent of PR-1..4 stack).

Closes the script-layer leg of the silent-fallback elimination. #16072 fixed the OCaml launcher; four Python admin scripts and one shell helper still routed through `MASC_BASE_PATH → ME_ROOT → cwd`. A keeper-readiness gate run without env vars set would evaluate against `./.masc/` relative to whatever directory the operator happened to be in.

## What changed

| File | Change |
|---|---|
| `scripts/keeper-production-readiness-gate.py` | `default_base_path()` reads `MASC_BASE_PATH` only; explicit `SystemExit` when unset |
| `scripts/keeper-github-identity-split.py` | same |
| `scripts/audit-keeper-fleet-readiness.py` | same |
| `scripts/masc-autonomy-action-stats.py` | same |
| `scripts/llama-runtime-pool.sh` | drop dead `MASC_LLAMA_RUNTIME_POOL_STATE_DIR` alias; remove `$HOME/.local/bin/llama-server` hard probe (PATH lookup follows one line below) |

## Out of scope (documented in commit body)

- `goal_loop_live_replay.py` — uses `expanduser` but already guards `None`/whitespace explicitly; expanduser there is user-input normalisation, not a fallback.
- `start-masc-mcp.sh` `MASC_BUILD_LOCK=/tmp/...` — acquired before base_path resolution, cannot live under `.masc/`; `/tmp` is legitimate process coordination.

## Verification

```
$ env -u MASC_BASE_PATH python3 scripts/keeper-production-readiness-gate.py
Error: MASC_BASE_PATH is required (or pass --base-path PATH). RFC-0121 forbids ME_ROOT/cwd fallback.

$ MASC_BASE_PATH=/Users/dancer/me python3 scripts/keeper-production-readiness-gate.py
keeper-production-readiness-gate: FAIL
  base_path: /Users/dancer/me
  ...
```

- [x] All 5 scripts pass `python3 -m ast.parse` / `bash -n`
- [x] OCaml `lib/` untouched
- [x] Builds unchanged (no `dune` impact)

## Stack

- PR-1 (merged-able) — accessor SSOT #16084
- **PR-5** (this) — script silent fallback purge
- PR-2 — repo_manager triangle (blocked on PR-1)
- PR-3 — host_config + server routes (blocked on PR-1)
- PR-4 — tool dispatch + telemetry (blocked on PR-1)
- PR-6 — docs sweep + CI gate (blocked on all)

Ref: `docs/rfc/RFC-0121-config-dir-resolution-single-active-root.md`
Inventory: `.tmp/path-ssot-remediation-plan.html`