### PR TITLE
fix: require approval gate for agent PR bypass

### DIFF
--- a/.github/workflows/approve-agent-pr.yml
+++ b/.github/workflows/approve-agent-pr.yml
@@ -17,9 +17,9 @@ name: Approve Agent PR
 #     click "Approve" in the GitHub UI before the job proceeds — this is
 #     an interactive gesture that cannot be automated with a bearer token.
 #   • After the environment gate is passed the `apply-approval` job adds
-#     the configured bypass label to the target PR using the Actions token,
-#     which records the Environment-approved deployment ID as part of the
-#     audit trail.
+#     the configured bypass label and removes configured hard-stop labels
+#     from the target PR using the Actions token, which records the
+#     Environment-approved deployment ID as part of the audit trail.
 #
 # SETUP (one-time, done in GitHub Settings):
 #   1. Go to Settings → Environments → New environment → "human-approval"
@@ -91,10 +91,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Add human-approved-ready bypass label
+      - name: Apply human-approved-ready bypass
         uses: actions/github-script@v9
         env:
           AGENT_DRAFT_GUARD_BYPASS_LABELS: ${{ vars.AGENT_DRAFT_GUARD_BYPASS_LABELS }}
+          AGENT_DRAFT_GUARD_HARD_STOP_LABELS: ${{ vars.AGENT_DRAFT_GUARD_HARD_STOP_LABELS }}
         with:
           script: |
             const prNumber = parseInt('${{ needs.await-human-approval.outputs.pr_number }}', 10);
@@ -110,6 +111,10 @@ jobs:
             // Use the first non-automation-prone bypass label.
             const automationProne = new Set(['allow-auto-merge']);
             const targetLabel = bypassLabels.find((l) => !automationProne.has(l.toLowerCase())) || 'human-approved-ready';
+            const hardStopLabels = (process.env.AGENT_DRAFT_GUARD_HARD_STOP_LABELS || 'do-not-merge')
+              .split(',')
+              .map((s) => s.trim())
+              .filter(Boolean);
 
             core.info(`Adding bypass label '${targetLabel}' to PR #${prNumber} after environment-gated human approval.`);
             await github.rest.issues.addLabels({
@@ -118,6 +123,24 @@ jobs:
               issue_number: prNumber,
               labels: [targetLabel],
             });
+            const removedHardStopLabels = [];
+            for (const label of hardStopLabels) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  name: label,
+                });
+                removedHardStopLabels.push(label);
+              } catch (error) {
+                if (error.status === 404) {
+                  core.info(`Hard-stop label '${label}' was not present on PR #${prNumber}.`);
+                } else {
+                  throw error;
+                }
+              }
+            }
 
             const actor = '${{ github.actor }}';
             const reason = '${{ inputs.reason }}';
@@ -127,6 +150,9 @@ jobs:
               `Human approval granted by @${actor} via credential-separated environment gate.`,
               '',
               `Bypass label \`${targetLabel}\` applied. Approval workflow run: ${runUrl}`,
+              ...(removedHardStopLabels.length > 0
+                ? [`Hard-stop label(s) removed: ${removedHardStopLabels.map((label) => `\`${label}\``).join(', ')}.`]
+                : ['No configured hard-stop labels were present.']),
               ...(reason ? ['', `Reason: ${reason}`] : []),
               '',
               'This approval was gated through the `human-approval` GitHub Environment, which requires',
@@ -138,4 +164,4 @@ jobs:
               issue_number: prNumber,
               body,
             });
-            core.info(`Bypass label '${targetLabel}' and approval comment added to PR #${prNumber}.`);
+            core.info(`Bypass label '${targetLabel}', hard-stop cleanup, and approval comment applied to PR #${prNumber}.`);

--- a/.github/workflows/approve-agent-pr.yml
+++ b/.github/workflows/approve-agent-pr.yml
@@ -144,19 +144,20 @@ jobs:
               'This approval was gated through the `human-approval` GitHub Environment, which requires',
               'an interactive reviewer approval that cannot be automated with a shared owner credential.',
             ].join('\n');
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body,
-            });
-            core.info(`Posted approval marker for PR #${prNumber}; applying bypass label '${targetLabel}'.`);
+            core.info(`Applying bypass label '${targetLabel}' to PR #${prNumber}.`);
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
               labels: [targetLabel],
             });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+            core.info(`Posted approval marker for PR #${prNumber} after applying bypass label '${targetLabel}'.`);
             const removedHardStopLabels = [];
             for (const label of hardStopLabels) {
               try {

--- a/.github/workflows/approve-agent-pr.yml
+++ b/.github/workflows/approve-agent-pr.yml
@@ -116,7 +116,41 @@ jobs:
               .map((s) => s.trim())
               .filter(Boolean);
 
-            core.info(`Adding bypass label '${targetLabel}' to PR #${prNumber} after environment-gated human approval.`);
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const currentLabels = (issue.labels || [])
+              .map((label) => (typeof label === 'string' ? label : label.name || ''))
+              .map((label) => label.trim())
+              .filter(Boolean);
+            const currentLabelSet = new Set(currentLabels.map((label) => label.toLowerCase()));
+            const presentHardStopLabels = hardStopLabels
+              .filter((label) => currentLabelSet.has(label.toLowerCase()));
+            const actor = '${{ github.actor }}';
+            const reason = '${{ inputs.reason }}';
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              '<!-- masc-human-approval-gate -->',
+              `Human approval granted by @${actor} via credential-separated environment gate.`,
+              '',
+              `Bypass label \`${targetLabel}\` authorized by approval workflow run: ${runUrl}`,
+              ...(presentHardStopLabels.length > 0
+                ? [`Hard-stop label(s) scheduled for removal: ${presentHardStopLabels.map((label) => `\`${label}\``).join(', ')}.`]
+                : ['No configured hard-stop labels were present.']),
+              ...(reason ? ['', `Reason: ${reason}`] : []),
+              '',
+              'This approval was gated through the `human-approval` GitHub Environment, which requires',
+              'an interactive reviewer approval that cannot be automated with a shared owner credential.',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+            core.info(`Posted approval marker for PR #${prNumber}; applying bypass label '${targetLabel}'.`);
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -142,26 +176,4 @@ jobs:
               }
             }
 
-            const actor = '${{ github.actor }}';
-            const reason = '${{ inputs.reason }}';
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = [
-              '<!-- masc-human-approval-gate -->',
-              `Human approval granted by @${actor} via credential-separated environment gate.`,
-              '',
-              `Bypass label \`${targetLabel}\` applied. Approval workflow run: ${runUrl}`,
-              ...(removedHardStopLabels.length > 0
-                ? [`Hard-stop label(s) removed: ${removedHardStopLabels.map((label) => `\`${label}\``).join(', ')}.`]
-                : ['No configured hard-stop labels were present.']),
-              ...(reason ? ['', `Reason: ${reason}`] : []),
-              '',
-              'This approval was gated through the `human-approval` GitHub Environment, which requires',
-              'an interactive reviewer approval that cannot be automated with a shared owner credential.',
-            ].join('\n');
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body,
-            });
             core.info(`Bypass label '${targetLabel}', hard-stop cleanup, and approval comment applied to PR #${prNumber}.`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1064,6 +1064,14 @@ jobs:
             if [ -n "$live_state" ]; then
               export PR_LIVE_STATE="$live_state"
             fi
+            approval_gate_present="$(
+              gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" --paginate \
+                --jq 'any(.[]; .user.type == "Bot" and ((.body // "") | contains("<!-- masc-human-approval-gate -->")) and ((.body // "") | contains("/actions/runs/")))' \
+                2>/dev/null || echo false
+            )"
+            if printf '%s\n' "$approval_gate_present" | grep -qx true; then
+              export PR_HUMAN_APPROVAL_GATE_PRESENT=true
+            fi
           fi
           scripts/ci/check-agent-draft-policy.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1065,39 +1065,104 @@ jobs:
               export PR_LIVE_STATE="$live_state"
             fi
             export PR_EFFECTIVE_LABELS="${PR_LIVE_LABELS:-$PR_LABELS}"
+            fetch_approval_comments() {
+              local output_file="$1"
+              local after=""
+              local page=""
+              : > "$output_file"
+              while :; do
+                local args=(-f owner="${GITHUB_REPOSITORY%/*}" -f repo="${GITHUB_REPOSITORY#*/}" -F number="$PR_NUMBER")
+                if [ -n "$after" ]; then
+                  args+=(-f after="$after")
+                else
+                  args+=(-F after=null)
+                fi
+                page="$(
+                  gh api graphql "${args[@]}" \
+                    -f query='
+                      query($owner: String!, $repo: String!, $number: Int!, $after: String) {
+                        repository(owner: $owner, name: $repo) {
+                          pullRequest(number: $number) {
+                            comments(first: 100, after: $after) {
+                              pageInfo { hasNextPage endCursor }
+                              nodes {
+                                body
+                                createdAt
+                                author { __typename login }
+                              }
+                            }
+                          }
+                        }
+                      }'
+                )"
+                printf '%s\n' "$page" | jq -c '.data.repository.pullRequest.comments.nodes[]' >> "$output_file"
+                if [ "$(printf '%s\n' "$page" | jq -r '.data.repository.pullRequest.comments.pageInfo.hasNextPage')" != "true" ]; then
+                  break
+                fi
+                after="$(printf '%s\n' "$page" | jq -r '.data.repository.pullRequest.comments.pageInfo.endCursor // ""')"
+                if [ -z "$after" ]; then
+                  break
+                fi
+              done
+            }
+            fetch_approval_label_events() {
+              local output_file="$1"
+              local after=""
+              local page=""
+              : > "$output_file"
+              while :; do
+                local args=(-f owner="${GITHUB_REPOSITORY%/*}" -f repo="${GITHUB_REPOSITORY#*/}" -F number="$PR_NUMBER")
+                if [ -n "$after" ]; then
+                  args+=(-f after="$after")
+                else
+                  args+=(-F after=null)
+                fi
+                page="$(
+                  gh api graphql "${args[@]}" \
+                    -f query='
+                      query($owner: String!, $repo: String!, $number: Int!, $after: String) {
+                        repository(owner: $owner, name: $repo) {
+                          pullRequest(number: $number) {
+                            timelineItems(first: 100, after: $after, itemTypes: [LABELED_EVENT, UNLABELED_EVENT]) {
+                              pageInfo { hasNextPage endCursor }
+                              nodes {
+                                __typename
+                                ... on LabeledEvent {
+                                  createdAt
+                                  label { name }
+                                }
+                                ... on UnlabeledEvent {
+                                  createdAt
+                                  label { name }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }'
+                )"
+                printf '%s\n' "$page" | jq -c '.data.repository.pullRequest.timelineItems.nodes[]' >> "$output_file"
+                if [ "$(printf '%s\n' "$page" | jq -r '.data.repository.pullRequest.timelineItems.pageInfo.hasNextPage')" != "true" ]; then
+                  break
+                fi
+                after="$(printf '%s\n' "$page" | jq -r '.data.repository.pullRequest.timelineItems.pageInfo.endCursor // ""')"
+                if [ -z "$after" ]; then
+                  break
+                fi
+              done
+            }
+            approval_gate_payload="$(
+              comments_file="$(mktemp "${RUNNER_TEMP:-/tmp}/masc-approval-comments.XXXXXX")"
+              events_file="$(mktemp "${RUNNER_TEMP:-/tmp}/masc-approval-label-events.XXXXXX")"
+              trap 'rm -f "$comments_file" "$events_file"' EXIT
+              fetch_approval_comments "$comments_file"
+              fetch_approval_label_events "$events_file"
+              jq -n --slurpfile comments "$comments_file" --slurpfile timeline "$events_file" \
+                '{data:{repository:{pullRequest:{comments:{nodes:$comments}, timelineItems:{nodes:$timeline}}}}}'
+            )" || approval_gate_payload=""
             approval_gate_present="$(
-              gh api graphql \
-                -f owner="${GITHUB_REPOSITORY%/*}" \
-                -f repo="${GITHUB_REPOSITORY#*/}" \
-                -F number="$PR_NUMBER" \
-                -f query='
-                  query($owner: String!, $repo: String!, $number: Int!) {
-                    repository(owner: $owner, name: $repo) {
-                      pullRequest(number: $number) {
-                        comments(last: 100) {
-                          nodes {
-                            body
-                            createdAt
-                            author { __typename login }
-                          }
-                        }
-                        timelineItems(last: 100, itemTypes: [LABELED_EVENT, UNLABELED_EVENT]) {
-                          nodes {
-                            __typename
-                            ... on LabeledEvent {
-                              createdAt
-                              label { name }
-                            }
-                            ... on UnlabeledEvent {
-                              createdAt
-                              label { name }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }' \
-                --jq '
+              if [ -n "$approval_gate_payload" ]; then
+                printf '%s\n' "$approval_gate_payload" | jq -r '
                   def csv($s):
                     ($s // "")
                     | split(",")
@@ -1131,8 +1196,10 @@ jobs:
                          and (($latest | event_kind) == "labeled")
                          and (($latest.createdAt | fromdateiso8601) as $label_ts |
                            marker_for($root; $label; $label_ts))))
-                ' \
-                2>/dev/null || echo false
+                ' 2>/dev/null || echo false
+              else
+                echo false
+              fi
             )"
             if printf '%s\n' "$approval_gate_present" | grep -qx true; then
               export PR_HUMAN_APPROVAL_GATE_PRESENT=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1174,13 +1174,14 @@ jobs:
                     elif .__typename == "UnlabeledEvent" then "unlabeled"
                     else ""
                     end;
-                  def marker_for($root; $label; $label_ts):
+                  def marker_for($root; $label; $label_ts; $previous_label_ts):
                     any($root.data.repository.pullRequest.comments.nodes[];
                       (.author.__typename == "Bot") and
                       ((.body // "") | contains("<!-- masc-human-approval-gate -->")) and
                       (((.body // "") | ascii_downcase) | contains("`" + $label + "`")) and
                       ((.body // "") | contains("/actions/runs/")) and
                       ((.createdAt | fromdateiso8601) as $comment_ts |
+                        (($previous_label_ts == null) or ($comment_ts > $previous_label_ts)) and
                         ($comment_ts >= $label_ts and $comment_ts <= ($label_ts + 300)))
                     );
                   . as $root
@@ -1191,11 +1192,16 @@ jobs:
                   | any($bypass_labels[]; . as $label |
                       ($present_labels | index($label)) and
                       (([$root.data.repository.pullRequest.timelineItems.nodes[]
-                         | select(event_label == $label)] | last) as $latest
+                         | select(event_label == $label)]) as $label_events
+                       | ($label_events | last) as $latest
                        | ($latest != null)
                          and (($latest | event_kind) == "labeled")
+                         and ((if ($label_events | length) > 1
+                               then ($label_events[($label_events | length) - 2].createdAt | fromdateiso8601)
+                               else null
+                               end) as $previous_label_ts
                          and (($latest.createdAt | fromdateiso8601) as $label_ts |
-                           marker_for($root; $label; $label_ts))))
+                           marker_for($root; $label; $label_ts; $previous_label_ts)))))
                 ' 2>/dev/null || echo false
               else
                 echo false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1200,8 +1200,8 @@ jobs:
                                then ($label_events[($label_events | length) - 2].createdAt | fromdateiso8601)
                                else null
                                end) as $previous_label_ts
-                         and (($latest.createdAt | fromdateiso8601) as $label_ts |
-                           marker_for($root; $label; $label_ts; $previous_label_ts)))))
+                              | (($latest.createdAt | fromdateiso8601) as $label_ts |
+                                  marker_for($root; $label; $label_ts; $previous_label_ts)))))
                 ' 2>/dev/null || echo false
               else
                 echo false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1181,7 +1181,7 @@ jobs:
                       (((.body // "") | ascii_downcase) | contains("`" + $label + "`")) and
                       ((.body // "") | contains("/actions/runs/")) and
                       ((.createdAt | fromdateiso8601) as $comment_ts |
-                        ($comment_ts >= ($label_ts - 300) and $comment_ts <= ($label_ts + 300)))
+                        ($comment_ts >= $label_ts and $comment_ts <= ($label_ts + 300)))
                     );
                   . as $root
                   |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1064,9 +1064,74 @@ jobs:
             if [ -n "$live_state" ]; then
               export PR_LIVE_STATE="$live_state"
             fi
+            export PR_EFFECTIVE_LABELS="${PR_LIVE_LABELS:-$PR_LABELS}"
             approval_gate_present="$(
-              gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" --paginate \
-                --jq 'any(.[]; .user.type == "Bot" and ((.body // "") | contains("<!-- masc-human-approval-gate -->")) and ((.body // "") | contains("/actions/runs/")))' \
+              gh api graphql \
+                -f owner="${GITHUB_REPOSITORY%/*}" \
+                -f repo="${GITHUB_REPOSITORY#*/}" \
+                -F number="$PR_NUMBER" \
+                -f query='
+                  query($owner: String!, $repo: String!, $number: Int!) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number: $number) {
+                        comments(last: 100) {
+                          nodes {
+                            body
+                            createdAt
+                            author { __typename login }
+                          }
+                        }
+                        timelineItems(last: 100, itemTypes: [LABELED_EVENT, UNLABELED_EVENT]) {
+                          nodes {
+                            __typename
+                            ... on LabeledEvent {
+                              createdAt
+                              label { name }
+                            }
+                            ... on UnlabeledEvent {
+                              createdAt
+                              label { name }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }' \
+                --jq '
+                  def csv($s):
+                    ($s // "")
+                    | split(",")
+                    | map(gsub("^\\s+|\\s+$"; "") | ascii_downcase | select(length > 0));
+                  def event_label:
+                    (.label.name // "" | ascii_downcase);
+                  def event_kind:
+                    if .__typename == "LabeledEvent" then "labeled"
+                    elif .__typename == "UnlabeledEvent" then "unlabeled"
+                    else ""
+                    end;
+                  def marker_for($root; $label; $label_ts):
+                    any($root.data.repository.pullRequest.comments.nodes[];
+                      (.author.__typename == "Bot") and
+                      ((.body // "") | contains("<!-- masc-human-approval-gate -->")) and
+                      (((.body // "") | ascii_downcase) | contains("`" + $label + "`")) and
+                      ((.body // "") | contains("/actions/runs/")) and
+                      ((.createdAt | fromdateiso8601) as $comment_ts |
+                        ($comment_ts >= ($label_ts - 300) and $comment_ts <= ($label_ts + 300)))
+                    );
+                  . as $root
+                  |
+                  (csv(env.PR_EFFECTIVE_LABELS)) as $present_labels
+                  | (csv(env.AGENT_DRAFT_GUARD_BYPASS_LABELS // "human-approved-ready")
+                     | map(select(. != "allow-auto-merge"))) as $bypass_labels
+                  | any($bypass_labels[]; . as $label |
+                      ($present_labels | index($label)) and
+                      (([$root.data.repository.pullRequest.timelineItems.nodes[]
+                         | select(event_label == $label)] | last) as $latest
+                       | ($latest != null)
+                         and (($latest | event_kind) == "labeled")
+                         and (($latest.createdAt | fromdateiso8601) as $label_ts |
+                           marker_for($root; $label; $label_ts))))
+                ' \
                 2>/dev/null || echo false
             )"
             if printf '%s\n' "$approval_gate_present" | grep -qx true; then

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -146,17 +146,19 @@ jobs:
               });
               return issueCommentsCache;
             };
-            const findApprovalGateAfter = async (label, labeledAt) => {
+            const findApprovalGateNear = async (label, labeledAt) => {
               const labeledAtMs = Date.parse(labeledAt || "");
               if (!Number.isFinite(labeledAtMs)) return undefined;
               const labelLiteral = `\`${label}\``;
+              const approvalGateWindowMs = 5 * 60 * 1000;
               const comments = await loadIssueComments();
               return [...comments].reverse().find((comment) => {
                 const body = comment.body || "";
                 const commentAtMs = Date.parse(comment.created_at || "");
                 return comment.user?.type === "Bot" &&
                   Number.isFinite(commentAtMs) &&
-                  commentAtMs >= labeledAtMs &&
+                  commentAtMs >= labeledAtMs - approvalGateWindowMs &&
+                  commentAtMs <= labeledAtMs + approvalGateWindowMs &&
                   body.includes(approvalGateMarker) &&
                   body.toLowerCase().includes(labelLiteral) &&
                   body.includes("/actions/runs/");
@@ -181,9 +183,9 @@ jobs:
                   bypassPolicyFailures.push(`${label}: latest event is ${latest.event}`);
                   unverifiedBypassLabels.push(label);
                 } else {
-                  const approvalGate = await findApprovalGateAfter(label, latest.created_at);
+                  const approvalGate = await findApprovalGateNear(label, latest.created_at);
                   if (!approvalGate) {
-                    bypassPolicyFailures.push(`${label}: missing environment-gated approval after latest label event`);
+                    bypassPolicyFailures.push(`${label}: missing environment-gated approval for latest label event`);
                     unverifiedBypassLabels.push(label);
                   } else {
                     verifiedBypassLabels.push(`${label} via environment gate`);

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -159,11 +159,13 @@ jobs:
                 const afterPreviousLabelCycle =
                   !Number.isFinite(previousLabelEventAtMs) ||
                   commentAtMs > previousLabelEventAtMs;
+                const withinCurrentLabelCycle =
+                  commentAtMs >= labeledAtMs &&
+                  commentAtMs <= labeledAtMs + approvalGateWindowMs;
                 return comment.user?.type === "Bot" &&
                   Number.isFinite(commentAtMs) &&
                   afterPreviousLabelCycle &&
-                  commentAtMs >= labeledAtMs - approvalGateWindowMs &&
-                  commentAtMs <= labeledAtMs + approvalGateWindowMs &&
+                  withinCurrentLabelCycle &&
                   body.includes(approvalGateMarker) &&
                   body.toLowerCase().includes(labelLiteral) &&
                   body.includes("/actions/runs/");

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -146,17 +146,22 @@ jobs:
               });
               return issueCommentsCache;
             };
-            const findApprovalGateNear = async (label, labeledAt) => {
+            const findApprovalGateNear = async (label, labeledAt, previousLabelEventAt) => {
               const labeledAtMs = Date.parse(labeledAt || "");
               if (!Number.isFinite(labeledAtMs)) return undefined;
+              const previousLabelEventAtMs = Date.parse(previousLabelEventAt || "");
               const labelLiteral = `\`${label}\``;
               const approvalGateWindowMs = 5 * 60 * 1000;
               const comments = await loadIssueComments();
               return [...comments].reverse().find((comment) => {
                 const body = comment.body || "";
                 const commentAtMs = Date.parse(comment.created_at || "");
+                const afterPreviousLabelCycle =
+                  !Number.isFinite(previousLabelEventAtMs) ||
+                  commentAtMs > previousLabelEventAtMs;
                 return comment.user?.type === "Bot" &&
                   Number.isFinite(commentAtMs) &&
+                  afterPreviousLabelCycle &&
                   commentAtMs >= labeledAtMs - approvalGateWindowMs &&
                   commentAtMs <= labeledAtMs + approvalGateWindowMs &&
                   body.includes(approvalGateMarker) &&
@@ -172,10 +177,12 @@ jobs:
                 per_page: 100
               });
               for (const label of presentBypassLabels) {
-                const latest = [...events].reverse().find((event) =>
+                const matchingEvents = events.filter((event) =>
                   (event.event === "labeled" || event.event === "unlabeled") &&
                   event.label?.name?.toLowerCase() === label
                 );
+                const latestIndex = matchingEvents.length - 1;
+                const latest = latestIndex >= 0 ? matchingEvents[latestIndex] : undefined;
                 if (!latest) {
                   bypassPolicyFailures.push(`${label}: no label event found`);
                   unverifiedBypassLabels.push(label);
@@ -183,7 +190,13 @@ jobs:
                   bypassPolicyFailures.push(`${label}: latest event is ${latest.event}`);
                   unverifiedBypassLabels.push(label);
                 } else {
-                  const approvalGate = await findApprovalGateNear(label, latest.created_at);
+                  const previousLabelEvent =
+                    latestIndex > 0 ? matchingEvents[latestIndex - 1] : undefined;
+                  const approvalGate = await findApprovalGateNear(
+                    label,
+                    latest.created_at,
+                    previousLabelEvent?.created_at
+                  );
                   if (!approvalGate) {
                     bypassPolicyFailures.push(`${label}: missing environment-gated approval for latest label event`);
                     unverifiedBypassLabels.push(label);

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -133,6 +133,7 @@ jobs:
             const presentBypassLabels = labels.filter((label) => bypassLabelSet.has(label));
             const bypassPolicyFailures = [];
             const verifiedBypassLabels = [];
+            const unverifiedBypassLabels = [];
             const approvalGateMarker = "<!-- masc-human-approval-gate -->";
             let issueCommentsCache = null;
             const loadIssueComments = async () => {
@@ -175,12 +176,15 @@ jobs:
                 );
                 if (!latest) {
                   bypassPolicyFailures.push(`${label}: no label event found`);
+                  unverifiedBypassLabels.push(label);
                 } else if (latest.event !== "labeled") {
                   bypassPolicyFailures.push(`${label}: latest event is ${latest.event}`);
+                  unverifiedBypassLabels.push(label);
                 } else {
                   const approvalGate = await findApprovalGateAfter(label, latest.created_at);
                   if (!approvalGate) {
                     bypassPolicyFailures.push(`${label}: missing environment-gated approval after latest label event`);
+                    unverifiedBypassLabels.push(label);
                   } else {
                     verifiedBypassLabels.push(`${label} via environment gate`);
                   }
@@ -312,6 +316,38 @@ jobs:
               softFailures.push(`${actionName}: ${summary}`);
               core.info(`Draft PR guard soft-failure (${actionName}): ${summary}`);
             };
+
+            for (const label of [...new Set(unverifiedBypassLabels)]) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: pullNumber,
+                  name: label
+                });
+                actions.push(`removed unverified bypass label ${label}`);
+              } catch (error) {
+                if (error?.status === 404) {
+                  recordSoftFailure(`remove unverified bypass label ${label}`, error);
+                } else {
+                  recordFailure(`remove unverified bypass label ${label}`, error);
+                }
+              }
+            }
+
+            if (unverifiedBypassLabels.length > 0 && hardStopLabels.length > 0) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: pullNumber,
+                  labels: hardStopLabels
+                });
+                actions.push(`reapplied hard-stop labels: ${hardStopLabels.join(", ")}`);
+              } catch (error) {
+                recordFailure("reapply hard-stop labels", error);
+              }
+            }
 
             const latestCiGateForHead = async () => {
               const checks = await github.rest.checks.listForRef({

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -133,6 +133,34 @@ jobs:
             const presentBypassLabels = labels.filter((label) => bypassLabelSet.has(label));
             const bypassPolicyFailures = [];
             const verifiedBypassLabels = [];
+            const approvalGateMarker = "<!-- masc-human-approval-gate -->";
+            let issueCommentsCache = null;
+            const loadIssueComments = async () => {
+              if (issueCommentsCache !== null) return issueCommentsCache;
+              issueCommentsCache = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: pullNumber,
+                per_page: 100
+              });
+              return issueCommentsCache;
+            };
+            const findApprovalGateAfter = async (label, labeledAt) => {
+              const labeledAtMs = Date.parse(labeledAt || "");
+              if (!Number.isFinite(labeledAtMs)) return undefined;
+              const labelLiteral = `\`${label}\``;
+              const comments = await loadIssueComments();
+              return [...comments].reverse().find((comment) => {
+                const body = comment.body || "";
+                const commentAtMs = Date.parse(comment.created_at || "");
+                return comment.user?.type === "Bot" &&
+                  Number.isFinite(commentAtMs) &&
+                  commentAtMs >= labeledAtMs &&
+                  body.includes(approvalGateMarker) &&
+                  body.toLowerCase().includes(labelLiteral) &&
+                  body.includes("/actions/runs/");
+              });
+            };
             if (presentBypassLabels.length > 0) {
               const events = await github.paginate(github.rest.issues.listEvents, {
                 owner,
@@ -145,18 +173,17 @@ jobs:
                   (event.event === "labeled" || event.event === "unlabeled") &&
                   event.label?.name?.toLowerCase() === label
                 );
-                const actor = latest?.actor;
-                const actorName = actor?.login?.toLowerCase();
                 if (!latest) {
                   bypassPolicyFailures.push(`${label}: no label event found`);
                 } else if (latest.event !== "labeled") {
                   bypassPolicyFailures.push(`${label}: latest event is ${latest.event}`);
-                } else if (actor?.type !== "User") {
-                  bypassPolicyFailures.push(`${label}: actor ${actor?.login || "(unknown)"} is ${actor?.type || "unknown"}, not User`);
-                } else if (!humanActors.includes(actorName)) {
-                  bypassPolicyFailures.push(`${label}: actor ${actor.login} is not in AGENT_DRAFT_GUARD_HUMAN_ACTORS`);
                 } else {
-                  verifiedBypassLabels.push(`${label} by ${actor.login}`);
+                  const approvalGate = await findApprovalGateAfter(label, latest.created_at);
+                  if (!approvalGate) {
+                    bypassPolicyFailures.push(`${label}: missing environment-gated approval after latest label event`);
+                  } else {
+                    verifiedBypassLabels.push(`${label} via environment gate`);
+                  }
                 }
               }
             }
@@ -438,12 +465,7 @@ jobs:
                   ]
                 : [])
             ].join("\n");
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number: pullNumber,
-              per_page: 100
-            });
+            const comments = await loadIssueComments();
             const existing = comments.find((comment) =>
               comment.user?.type === "Bot" && comment.body?.includes(marker)
             );

--- a/scripts/ci/check-agent-draft-policy.sh
+++ b/scripts/ci/check-agent-draft-policy.sh
@@ -110,6 +110,7 @@ if [[ "$looks_agent_authored" -eq 0 ]]; then
 fi
 
 bypass_present=0
+approval_gate_present="$(lower "${PR_HUMAN_APPROVAL_GATE_PRESENT:-false}")"
 IFS=',' read -r -a bypass_labels <<<"$bypass_labels_csv"
 for label in "${bypass_labels[@]}"; do
   label="$(printf '%s' "$label" | xargs)"
@@ -120,8 +121,12 @@ for label in "${bypass_labels[@]}"; do
   fi
   if csv_has_label "$pr_labels_csv" "$label"; then
     bypass_present=1
-    echo "agent draft policy: pass, bypass label present: ${label}"
-    break
+    if [[ "$approval_gate_present" == "true" || "$approval_gate_present" == "1" || "$approval_gate_present" == "yes" ]]; then
+      echo "agent draft policy: pass, bypass label present with environment-gated approval: ${label}"
+      break
+    fi
+    echo "::error title=Agent draft policy violation::agent-like PR '${pr_head_ref}' has bypass label ${label}, but lacks the environment-gated human approval marker."
+    exit 1
   fi
 done
 

--- a/scripts/pr-open.sh
+++ b/scripts/pr-open.sh
@@ -75,6 +75,13 @@ is_doc_path() {
   esac
 }
 
+is_agent_approval_label() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    human-approved-ready) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 ensure_agent_pr_label() {
   local exists
 
@@ -216,7 +223,7 @@ for f in "${changed_files[@]}"; do
   fi
 done
 
-labels=("agent-pr")
+labels=("agent-pr" "do-not-merge")
 if [[ $has_docs -eq 1 ]]; then
   labels+=("docs")
 fi
@@ -228,6 +235,10 @@ if [[ -n "$extra_labels" ]]; then
   IFS=',' read -r -a extra <<< "$extra_labels"
   for lb in "${extra[@]}"; do
     lb="$(echo "$lb" | xargs)"
+    if is_agent_approval_label "$lb"; then
+      echo "refusing to add '${lb}' from pr-open; use the Approve Agent PR workflow after human review" >&2
+      exit 1
+    fi
     [[ -n "$lb" ]] && labels+=("$lb")
   done
 fi

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -461,9 +461,12 @@ let test_pr_automation_draft_guard_contracts () =
   check bool "pr automation accepts workflow marker near latest label event" true
     (file_contains_pattern ".github/workflows/pr-automation.yml"
        "approvalGateWindowMs");
-  check bool "ci gate binds approval marker to current label event" true
+  check bool "ci gate paginates approval label events" true
     (file_contains_pattern ".github/workflows/ci.yml"
-       "timelineItems(last: 100, itemTypes: [LABELED_EVENT, UNLABELED_EVENT])");
+       "timelineItems(first: 100, after: $after, itemTypes: [LABELED_EVENT, UNLABELED_EVENT])");
+  check bool "ci gate paginates approval marker comments" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "comments(first: 100, after: $after)");
   check bool "pr automation tracks unverified bypass labels for cleanup" true
     (file_contains_pattern ".github/workflows/pr-automation.yml"
        "const unverifiedBypassLabels = []");

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -301,9 +301,17 @@ let test_agent_draft_policy_script () =
   check int "live bypass label overrides stale event labels" 0
     (run_agent_draft_policy
        (("PR_LIVE_IS_DRAFT", "false")
+       :: ("PR_HUMAN_APPROVAL_GATE_PRESENT", "true")
        :: ("PR_LIVE_LABELS", "enhancement,human-approved-ready")
        :: ("PR_IS_DRAFT", "true")
        :: base));
+  check bool "live bypass label without environment gate fails" true
+    (run_agent_draft_policy
+       (("PR_LIVE_IS_DRAFT", "false")
+       :: ("PR_LIVE_LABELS", "enhancement,human-approved-ready")
+       :: ("PR_IS_DRAFT", "true")
+       :: base)
+    <> 0);
   check bool "live empty labels override stale event bypass" true
     (run_agent_draft_policy
        (("PR_LIVE_IS_DRAFT", "false")
@@ -337,6 +345,7 @@ let test_agent_draft_policy_script () =
   check int "ready agent PR with bypass label passes" 0
     (run_agent_draft_policy
        (("PR_IS_DRAFT", "false")
+       :: ("PR_HUMAN_APPROVAL_GATE_PRESENT", "true")
        :: ("PR_LABELS", "enhancement,human-approved-ready")
        :: List.remove_assoc "PR_LABELS" base));
   check bool "hard-stop label overrides bypass label" true
@@ -348,6 +357,7 @@ let test_agent_draft_policy_script () =
   check int "draft agent PR with bypass label passes" 0
     (run_agent_draft_policy
        (("PR_IS_DRAFT", "true")
+       :: ("PR_HUMAN_APPROVAL_GATE_PRESENT", "true")
        :: ("PR_LABELS", "enhancement,human-approved-ready")
        :: List.remove_assoc "PR_LABELS" base));
   check int "ready non-agent PR passes" 0
@@ -433,6 +443,30 @@ let test_pr_automation_draft_guard_contracts () =
   check bool "pr automation rejects missing or pending CI Gate" true
     (file_contains_pattern ".github/workflows/pr-automation.yml"
        "CI Gate is not completed successfully for head");
+  check bool "ci gate exports environment approval marker" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "PR_HUMAN_APPROVAL_GATE_PRESENT=true");
+  check bool "ci policy requires environment-gated approval marker" true
+    (file_contains_pattern "scripts/ci/check-agent-draft-policy.sh"
+       "bypass label present with environment-gated approval");
+  check bool "pr automation verifies approval workflow marker" true
+    (file_contains_pattern ".github/workflows/pr-automation.yml"
+       "<!-- masc-human-approval-gate -->");
+  check bool "pr automation rejects direct approval label edits" true
+    (file_contains_pattern ".github/workflows/pr-automation.yml"
+       "missing environment-gated approval after latest label event");
+  check bool "pr-open defaults agent PRs to hard-stop label" true
+    (file_contains_pattern "scripts/pr-open.sh"
+       {|labels=("agent-pr" "do-not-merge")|});
+  check bool "pr-open refuses direct approval labels" true
+    (file_contains_pattern "scripts/pr-open.sh"
+       "refusing to add");
+  check bool "approval workflow removes hard-stop labels after gate" true
+    (file_contains_pattern ".github/workflows/approve-agent-pr.yml"
+       "removedHardStopLabels.push");
+  check bool "approval workflow reads configured hard-stop labels" true
+    (file_contains_pattern ".github/workflows/approve-agent-pr.yml"
+       "AGENT_DRAFT_GUARD_HARD_STOP_LABELS");
   check bool "pr automation no longer skips CI Gate startup race" true
     (file_not_contains_pattern ".github/workflows/pr-automation.yml"
        "skipping block on ${action} event");

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -455,6 +455,15 @@ let test_pr_automation_draft_guard_contracts () =
   check bool "pr automation rejects direct approval label edits" true
     (file_contains_pattern ".github/workflows/pr-automation.yml"
        "missing environment-gated approval after latest label event");
+  check bool "pr automation tracks unverified bypass labels for cleanup" true
+    (file_contains_pattern ".github/workflows/pr-automation.yml"
+       "const unverifiedBypassLabels = []");
+  check bool "pr automation removes unverified bypass labels" true
+    (file_contains_pattern ".github/workflows/pr-automation.yml"
+       "github.rest.issues.removeLabel");
+  check bool "pr automation reapplies hard-stop labels after bypass cleanup" true
+    (file_contains_pattern ".github/workflows/pr-automation.yml"
+       "reapplied hard-stop labels");
   check bool "pr-open defaults agent PRs to hard-stop label" true
     (file_contains_pattern "scripts/pr-open.sh"
        {|labels=("agent-pr" "do-not-merge")|});

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -434,10 +434,13 @@ let test_pr_automation_draft_guard_contracts () =
   check bool "draft PRs always require verified approval" true
     (file_contains_pattern ".github/workflows/pr-automation.yml"
        "const approvalRequired =\n              current.isDraft ||\n              looksAgentAuthored ||\n              unsafeDraftBoundaryAction ||\n              hasAutoMergeRequest ||");
-  check bool "human-approved bypass waits for current-head CI Gate" true
+  check bool "human-approved bypass does not wait for sync CI Gate" true
     (file_contains_pattern ".github/workflows/pr-automation.yml"
-       "const ciGateRequiredForBypass =\n              verifiedBypassLabels.length > 0 ||\n              unsafeDraftBoundaryAction ||\n              hasAutoMergeRequest");
-  check bool "pr automation polls CI Gate before allowing bypass" true
+       "const ciGateRequiredForUnsafeBoundary =\n              unsafeDraftBoundaryAction ||\n              hasAutoMergeRequest");
+  check bool "pr automation does not use verified bypass as CI wait condition" true
+    (file_not_contains_pattern ".github/workflows/pr-automation.yml"
+       "verifiedBypassLabels.length > 0 ||\n              unsafeDraftBoundaryAction");
+  check bool "pr automation polls CI Gate before unsafe boundary" true
     (file_contains_pattern ".github/workflows/pr-automation.yml"
        "const latestCiGate = await waitForCiGate()");
   check bool "pr automation rejects missing or pending CI Gate" true

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -457,7 +457,13 @@ let test_pr_automation_draft_guard_contracts () =
        "<!-- masc-human-approval-gate -->");
   check bool "pr automation rejects direct approval label edits" true
     (file_contains_pattern ".github/workflows/pr-automation.yml"
-       "missing environment-gated approval after latest label event");
+       "missing environment-gated approval for latest label event");
+  check bool "pr automation accepts workflow marker near latest label event" true
+    (file_contains_pattern ".github/workflows/pr-automation.yml"
+       "approvalGateWindowMs");
+  check bool "ci gate binds approval marker to current label event" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "timelineItems(last: 100, itemTypes: [LABELED_EVENT, UNLABELED_EVENT])");
   check bool "pr automation tracks unverified bypass labels for cleanup" true
     (file_contains_pattern ".github/workflows/pr-automation.yml"
        "const unverifiedBypassLabels = []");
@@ -2326,9 +2332,9 @@ let test_human_approval_credential_boundary_contracts () =
   check bool "approve-agent-pr workflow gates on human-approval environment" true
     (file_contains_pattern ".github/workflows/approve-agent-pr.yml"
        "environment: human-approval");
-  check bool "approve-agent-pr workflow applies bypass label after gate" true
+  check bool "approve-agent-pr workflow posts approval marker before bypass label" true
     (file_contains_pattern ".github/workflows/approve-agent-pr.yml"
-       "addLabels");
+       "Posted approval marker");
   check bool "approve-agent-pr workflow posts credential-boundary comment" true
     (file_contains_pattern ".github/workflows/approve-agent-pr.yml"
        "masc-human-approval-gate");


### PR DESCRIPTION
## Summary
- Require the environment-gated `Approve Agent PR` marker before `human-approved-ready` is accepted by PR automation.
- Teach CI Gate's agent draft policy to require the same marker instead of trusting a label alone.
- Default `scripts/pr-open.sh` agent PRs to `do-not-merge` and refuse direct `human-approved-ready` labels.

## Product impact
Reduces label churn and unsafe agent self-approval when agents share the repository owner's GitHub credential. Agent PRs stay draft + hard-stop by default until the explicit approval workflow is used.

## Evidence
- `bash -n scripts/ci/check-agent-draft-policy.sh scripts/pr-open.sh`
- `git diff --check origin/main...HEAD`
- `ocamlformat --check test/test_ci_hardening_source.ml`
- YAML parse: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/pr-automation.yml")'`
- Manual policy smoke:
  - bypass label without environment marker fails
  - bypass label with `PR_HUMAN_APPROVAL_GATE_PRESENT=true` passes
  - `do-not-merge` still fails even with the approval marker

## Review evidence
Local focused Dune build for `test/test_ci_hardening_source.exe` was not completed because `/tmp/me-dune-local.lock` was held by another long-running worktree build. CI is the build/test verification surface for this draft.

## Linked issue
Follow-up from agent PR label drift observed on #16069 and draft-guard failures on #16089.
