### PR TITLE
feat(repo_manager,auth_resolve): route through Config_dir_resolver (RFC-0121 PR-2/6)

### DIFF
--- a/lib/auth_resolve.ml
+++ b/lib/auth_resolve.ml
@@ -60,7 +60,11 @@ let first_nonempty_env keys =
     keys
 
 let internal_keeper_token_hash_file ~base_path =
-  Filename.concat base_path ".masc/auth/internal_keeper.token.hash"
+  (* RFC-0121: layout SSOT via [Config_dir_resolver.auth_dir]; only the
+     filename portion stays here. *)
+  Filename.concat
+    (Config_dir_resolver.auth_dir ~base_path)
+    "internal_keeper.token.hash"
 
 let resolve ~base_path ~keeper_id ~provider_kind
     ~policy_requires_runtime_mcp =

--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -515,3 +515,6 @@ let credentials_toml_path ~base_path =
 
 let repositories_toml_path ~base_path =
   Filename.concat (masc_root ~base_path) "config/repositories.toml"
+
+let keeper_repo_mappings_toml_path ~base_path =
+  Filename.concat (masc_root ~base_path) "config/keeper_repo_mappings.toml"

--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -147,6 +147,10 @@ val repositories_toml_path : base_path:string -> string
 (** [<base_path>/.masc/config/repositories.toml]. Same caveat as
     [credentials_toml_path]. *)
 
+val keeper_repo_mappings_toml_path : base_path:string -> string
+(** [<base_path>/.masc/config/keeper_repo_mappings.toml]. Same caveat as
+    [credentials_toml_path]. *)
+
 val config_signature_exists : string -> bool
 (** [config_signature_exists dir] checks whether [dir] looks like a valid
     MASC config directory (has cascade.toml, prompts/, keepers/, or personas/). *)

--- a/lib/repo_manager/credential_store.ml
+++ b/lib/repo_manager/credential_store.ml
@@ -3,7 +3,10 @@ open Repo_manager_types
 let ( let* ) = Result.bind
 
 let creds_toml_path base_path =
-  Filename.concat base_path ".masc/config/credentials.toml"
+  (* RFC-0121: layout SSOT via [Config_dir_resolver]. Resolver helper
+     returns the same byte-string as the previous direct concat (covered
+     by test_rfc0121_credentials_toml). *)
+  Config_dir_resolver.credentials_toml_path ~base_path
 
 let default_credential =
   {

--- a/lib/repo_manager/dune
+++ b/lib/repo_manager/dune
@@ -17,6 +17,7 @@
  (flags (:standard -w +4))
  (libraries
    masc_mcp.config
+   masc_mcp.config_dir_resolver
    masc_mcp.fs_compat
    masc_mcp.masc_exec
    masc_mcp.masc_log

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -5,7 +5,8 @@ let ( let* ) = Result.bind
 let logged_mapping_errors : (string, unit) Hashtbl.t = Hashtbl.create 4
 
 let mappings_toml_path base_path =
-  Filename.concat base_path ".masc/config/keeper_repo_mappings.toml"
+  (* RFC-0121: layout SSOT via [Config_dir_resolver]. *)
+  Config_dir_resolver.keeper_repo_mappings_toml_path ~base_path
 
 let ensure_dir path =
   let rec loop dir =

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -3,11 +3,17 @@ open Repo_manager_types
 let ( let* ) = Result.bind
 
 let repos_toml_path base_path =
-  Filename.concat base_path ".masc/config/repositories.toml"
+  (* RFC-0121: layout SSOT via [Config_dir_resolver]. Byte-equal to the
+     previous direct concat (test_rfc0121_repositories_toml). *)
+  Config_dir_resolver.repositories_toml_path ~base_path
 
 let repositories_toml_exists base_path =
   Sys.file_exists (repos_toml_path base_path)
 
+(* NB: [default_local_path] returns a cwd-relative path because it is the
+   default value for the [local_path] field in repositories.toml; the
+   on-disk TOML representation is cwd/base-path-relative by design.
+   Resolver routing for this default is deferred — see RFC-0121 §6. *)
 let default_local_path id = Filename.concat ".masc/repos" id
 
 let now_unix_seconds () = Int64.of_float (Unix.time ())

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -494,6 +494,11 @@ let test_rfc0121_repositories_toml () =
     "/x/.masc/config/repositories.toml"
     (Config_dir_resolver.repositories_toml_path ~base_path:"/x")
 
+let test_rfc0121_keeper_repo_mappings_toml () =
+  check string "keeper_repo_mappings.toml under .masc/config"
+    "/x/.masc/config/keeper_repo_mappings.toml"
+    (Config_dir_resolver.keeper_repo_mappings_toml_path ~base_path:"/x")
+
 let test_rfc0121_masc_root_agrees_with_common () =
   (* SSOT bridge — resolver helper must produce the same path as the
      pre-existing [Common] helper that callers historically used. *)
@@ -577,6 +582,8 @@ let () =
             test_rfc0121_credentials_toml;
           test_case "repositories_toml under config" `Quick
             test_rfc0121_repositories_toml;
+          test_case "keeper_repo_mappings_toml under config" `Quick
+            test_rfc0121_keeper_repo_mappings_toml;
           test_case "masc_root agrees with Common" `Quick
             test_rfc0121_masc_root_agrees_with_common;
         ] );


### PR DESCRIPTION
## Summary

RFC-0121 sprint **PR-2 of 6**. Stacked on #16084 (PR-1 accessors).

Migrates 4 resolver-bypass sites in the credential / repo / auth surface to use the SSOT helpers introduced in PR-1. Adds one new accessor needed by the 4th site (kept self-contained rather than amending PR-1).

## Sites migrated

| File:line | Before | After |
|---|---|---|
| `credential_store.ml:5` | `Filename.concat base_path ".masc/config/credentials.toml"` | `Config_dir_resolver.credentials_toml_path ~base_path` |
| `repo_store.ml:5` | `".masc/config/repositories.toml"` | `Config_dir_resolver.repositories_toml_path` |
| `keeper_repo_mapping.ml:7` | `".masc/config/keeper_repo_mappings.toml"` | `Config_dir_resolver.keeper_repo_mappings_toml_path` (new) |
| `auth_resolve.ml:62` | `".masc/auth/internal_keeper.token.hash"` | `Config_dir_resolver.auth_dir` + local filename concat |

## Why this PR can change behaviour but doesn't

Behaviour is **byte-equal**. The resolver helpers were defined in PR-1 specifically to return the same strings the inline concat produced; the existing `masc_root agrees with Common` bridge test plus the new `keeper_repo_mappings_toml under config` test enforce this.

## Out of scope (documented inline)

`default_local_path` in `repo_store.ml:17` stays as `Filename.concat ".masc/repos" id`. It is a TOML *default value* for the `local_path` field — `repositories.toml` stores cwd/base-path-relative paths by design. Resolver routing for this default is an open question, captured as RFC-0121 §6 follow-up. An in-source comment now documents why.

## Verification

```
$ rg -n 'Filename\.concat[^"]+"\.masc/' lib/repo_manager/ lib/auth_resolve.ml
lib/repo_manager/repo_store.ml:17:let default_local_path id = ...   # intentional, documented

$ dune build --root . @check     # clean
$ dune exec test/test_config_dir_resolver.exe   # 37/37 OK (13 from PR-1 + 1 new + 23 existing)
```

- [x] @check clean
- [x] 37/37 resolver tests pass
- [x] One TOML-default site explicitly excluded with rationale

## Stack

- PR-1 #16084 (base) — resolver accessor SSOT
- **PR-2** (this, base = PR-1 branch) — repo_manager + auth_resolve
- PR-3 — host_config + server routes
- PR-4 — tool dispatch + telemetry
- PR-5 #16092 — script silent fallback purge (independent)
- PR-6 — docs sweep + CI gate