### PR TITLE
feat(host_config,server,shutdown): route .masc paths through resolver (RFC-0121 PR-3/6)

### DIFF
--- a/lib/host_config/dune
+++ b/lib/host_config/dune
@@ -25,4 +25,8 @@
   ; Host_config a true leaf below masc_coord.  Reverse migration of
   ; coord_utils_backend_setup callers becomes possible because
   ; masc_coord can now depend on masc_mcp.host_config without cycling.
-  masc_mcp.config))
+  masc_mcp.config
+  ; RFC-0121: derive .masc/<sub> paths via Common helpers. We cannot
+  ; depend on masc_mcp.config_dir_resolver here because the resolver
+  ; itself depends on host_config for test-mode + env reads.
+  masc_core))

--- a/lib/host_config/host_config.ml
+++ b/lib/host_config/host_config.ml
@@ -170,8 +170,15 @@ let resolve ?base_path () =
     | Some root -> Env_config_core.normalize_masc_base_path_input root
     | None -> fallback
   in
-  let agent_runtime_root = Filename.concat base ".masc/runtime/agent" in
-  let cred_root = Filename.concat base ".masc/credentials" in
+  (* RFC-0121: layout derives from [Common.masc_dir_from_base_path].
+     Cannot use [Config_dir_resolver] here — that module depends on us
+     for test-mode + env reads, so the reverse dep would cycle. Layout
+     remains single-sourced from [Common], and the resolver helpers
+     [agent_runtime_dir] / [credentials_dir] are kept byte-equal so
+     external callers route through the resolver SSOT. *)
+  let masc_root = Common.masc_dir_from_base_path ~base_path:base in
+  let agent_runtime_root = Filename.concat masc_root "runtime/agent" in
+  let cred_root = Filename.concat masc_root "credentials" in
   let sandbox_workspace_root =
     match Sys.getenv_opt "MASC_SANDBOX_ROOT" with
     | Some s -> s

--- a/lib/server/server_routes_http_routes_credentials.ml
+++ b/lib/server/server_routes_http_routes_credentials.ml
@@ -107,8 +107,9 @@ let credential_of_json (json : Yojson.Safe.t) :
   | _ -> Error "expected JSON object body"
 
 let default_github_gh_config_dir ~base_path ~credential_id =
+  (* RFC-0121: layout SSOT via [Config_dir_resolver]. *)
   Filename.concat
-    (Filename.concat base_path ".masc/github-identities")
+    (Config_dir_resolver.github_identities_dir ~base_path)
     (Filename.concat credential_id "gh")
 
 let apply_base_path_defaults ~base_path

--- a/lib/server/server_routes_http_routes_repositories.ml
+++ b/lib/server/server_routes_http_routes_repositories.ml
@@ -192,6 +192,8 @@ let parse_repository_json body_str =
                 name = inferred_name;
                 url;
                 local_path =
+                  (* RFC-0121 §6 deferred: same TOML-default cwd-relative
+                     semantics as Repo_store.default_local_path. *)
                   Option.value ~default:(Filename.concat ".masc/repos" id)
                     raw_local_path;
                 aliases;

--- a/lib/shutdown_hooks.ml
+++ b/lib/shutdown_hooks.ml
@@ -135,7 +135,8 @@ let run_all () =
        "[Shutdown] tmp cleanup skipped: MASC_BASE_PATH=%s is not absolute"
        base_path
    | Some base_path ->
-     let tmp_dir = Filename.concat base_path ".masc/tmp" in
+     (* RFC-0121: layout SSOT via [Config_dir_resolver]. *)
+     let tmp_dir = Config_dir_resolver.tmp_dir ~base_path in
      (match Unix.lstat tmp_dir with
       | exception Unix.Unix_error _ -> ()
       | st when st.Unix.st_kind = Unix.S_DIR -> cleanup_dir tmp_dir


### PR DESCRIPTION
## Summary

RFC-0121 sprint **PR-3 of 6**. Stacked on #16084 (PR-1 accessors).

Migrates 4 resolver-bypass sites in `host_config` / server credential / server repo / shutdown layers.

## Sites migrated

| File:line | Before | After |
|---|---|---|
| `host_config.ml:173-174` | `Filename.concat base ".masc/runtime/agent"` + `".masc/credentials"` | derived via `Common.masc_dir_from_base_path` (see note below) |
| `server_routes_http_routes_credentials.ml:111` | `".masc/github-identities"` | `Config_dir_resolver.github_identities_dir` |
| `shutdown_hooks.ml:138` | `".masc/tmp"` | `Config_dir_resolver.tmp_dir` |
| `server_routes_http_routes_repositories.ml:195` | `".masc/repos/<id>"` (TOML default) | unchanged + RFC-0121 §6 deferred comment |

## Cycle workaround in host_config

`Config_dir_resolver` already depends on `host_config` for test-mode detection and env reads. A reverse dep would cycle the libraries, so `host_config` cannot call the resolver directly. Instead it routes through `Common.masc_dir_from_base_path` (which the resolver's own helpers also wrap), preserving layout SSOT — the resolver's `agent_runtime_dir` / `credentials_dir` remain byte-equal so every external caller still ends up at the same on-disk path.

Long-term fix is to break the resolver's host_config dep (separate RFC), which lets `host_config` join the resolver SSOT directly. Captured.

## Verification

```
$ rg -n 'Filename\.concat[^"]+"\.masc' lib/host_config/ lib/server/server_routes_http_routes_{credentials,repositories}.ml lib/shutdown_hooks.ml
lib/server/server_routes_http_routes_repositories.ml:197 — TOML default, documented

$ dune build --root . @check     # clean
```

- [x] @check clean
- [x] 4 sites → 1 intentional TOML-default
- [x] Cycle issue captured in commit body + RFC-0121

## Stack

- PR-1 #16084 (base)
- PR-2 #16096 (stacked on PR-1) — repo_manager + auth_resolve
- **PR-3** (this, stacked on PR-1) — host_config + server + shutdown
- PR-4 — tool dispatch + telemetry
- PR-5 #16092 (independent)
- PR-6 — docs + CI gate