### PR TITLE
fix(shell): keep quoted regex pipes out of command splitting

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -212,8 +212,56 @@ let has_process_substitution cmd =
   contains_substring cmd "<(" || contains_substring cmd ">("
 ;;
 
+type pipeline_quote_state = Pipeline_no_quote | Pipeline_single | Pipeline_double
+
 let split_pipeline_segments cmd =
-  let segments = String.split_on_char '|' cmd |> List.map String.trim in
+  let len = String.length cmd in
+  let buf = Buffer.create len in
+  let push_segment segments =
+    let segment = Buffer.contents buf |> String.trim in
+    Buffer.clear buf;
+    segment :: segments
+  in
+  let rec loop quote escaped i segments =
+    if i >= len
+    then List.rev (push_segment segments)
+    else if escaped
+    then (
+      Buffer.add_char buf cmd.[i];
+      loop quote false (i + 1) segments)
+    else
+      match quote, cmd.[i] with
+      | Pipeline_single, '\'' ->
+        Buffer.add_char buf cmd.[i];
+        loop Pipeline_no_quote false (i + 1) segments
+      | Pipeline_single, _ ->
+        Buffer.add_char buf cmd.[i];
+        loop quote false (i + 1) segments
+      | Pipeline_double, '"' ->
+        Buffer.add_char buf cmd.[i];
+        loop Pipeline_no_quote false (i + 1) segments
+      | Pipeline_double, '\\' ->
+        Buffer.add_char buf cmd.[i];
+        loop quote true (i + 1) segments
+      | Pipeline_double, _ ->
+        Buffer.add_char buf cmd.[i];
+        loop quote false (i + 1) segments
+      | Pipeline_no_quote, '\'' ->
+        Buffer.add_char buf cmd.[i];
+        loop Pipeline_single false (i + 1) segments
+      | Pipeline_no_quote, '"' ->
+        Buffer.add_char buf cmd.[i];
+        loop Pipeline_double false (i + 1) segments
+      | Pipeline_no_quote, '\\' ->
+        Buffer.add_char buf cmd.[i];
+        loop quote true (i + 1) segments
+      | Pipeline_no_quote, '|' ->
+        loop Pipeline_no_quote false (i + 1) (push_segment segments)
+      | Pipeline_no_quote, _ ->
+        Buffer.add_char buf cmd.[i];
+        loop quote false (i + 1) segments
+  in
+  let segments = loop Pipeline_no_quote false 0 [] in
   if List.exists (fun segment -> segment = "") segments
   then Error "Pipes must separate complete allowed commands."
   else Ok segments

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,6 +31,6 @@ lib/process/process_eio.ml:493
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1811 — dev-tools worker spawn. Wrapped by the
+# lib/worker_dev_tools.ml:1859 — dev-tools worker spawn. Wrapped by the
 # worker switch; bounded by the dev-tools session lifetime.
-lib/worker_dev_tools.ml:1811
+lib/worker_dev_tools.ml:1859

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -559,6 +559,28 @@ let () =
         match Worker_dev_tools.validate_command_coding "git log | head -5" with
         | Ok () -> ()
         | Error e -> Alcotest.fail ("should allow pipe: " ^ Worker_dev_tools.block_reason_to_string e));
+      Alcotest.test_case "keeps escaped pipe inside quoted rg pattern" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_command_coding
+            {|rg -n "task-259\|task-270\|task-272" repos/masc-mcp/.masc/backlog.json|}
+        with
+        | Ok () -> ()
+        | Error e ->
+          Alcotest.fail
+            ("escaped regex pipe should not start a new command: "
+             ^ Worker_dev_tools.block_reason_to_string e));
+      Alcotest.test_case "keeps literal pipe inside single-quoted grep pattern"
+        `Quick
+        (fun () ->
+          match
+            Worker_dev_tools.validate_command_coding
+              {|grep -E 'task-259|task-270' repos/masc-mcp/.masc/backlog.json|}
+          with
+          | Ok () -> ()
+          | Error e ->
+            Alcotest.fail
+              ("quoted regex pipe should not start a new command: "
+               ^ Worker_dev_tools.block_reason_to_string e));
       Alcotest.test_case "allows wrapper redirect" `Quick (fun () ->
         match
           Worker_dev_tools.validate_command_coding


### PR DESCRIPTION
Summary: make keeper bash pipeline splitting quote/escape-aware so rg/grep regex patterns with pipes stay inside the command instead of becoming blocked pseudo-commands like task-270\. Verification: ocamlformat --check lib/worker_dev_tools.ml test/test_worker_dev_tools.ml; git diff --check origin/main..HEAD; scripts/dune-local.sh build ./test/test_worker_dev_tools.exe; ./_build/default/test/test_worker_dev_tools.exe (146 tests).