### PR TITLE
fix: keep quoted pipe regexes in shell validation

### DIFF
--- a/.ci/path-ssot-allowlist.txt
+++ b/.ci/path-ssot-allowlist.txt
@@ -28,11 +28,6 @@ lib/keeper/keeper_egress_audit.ml:54
 let default_local_path id = Filename.concat ".masc/repos" id
 Option.value ~default:(Filename.concat ".masc/repos" id)
 
-# Config_dir_resolver is the SSOT itself; these comment examples document the
-# bypass pattern the audit forbids outside this module.
-helpers instead of [Filename.concat base_path ".masc/..."] string-literal
-Layout SSOT: callers stop computing [Filename.concat base_path ".masc/X"]
-
 # Self-reference inside the audit script and RFC text.
 scripts/audit-path-ssot.sh
 docs/rfc/RFC-0121-config-dir-resolution-single-active-root.md

--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -102,6 +102,28 @@ let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
           { message; kind = Llm_provider.Http_client.Timeout }
     in
     Some (Cascade_fsm.Call_err http_err)
+  | Agent_sdk.Error.Provider provider_err ->
+    let should_cascade =
+      Llm_provider.Error.is_retryable provider_err
+      ||
+      match provider_err with
+      | Llm_provider.Error.HardQuota _
+      | Llm_provider.Error.CapacityExhausted _
+      | Llm_provider.Error.ProviderUnavailable _
+      | Llm_provider.Error.ParseError _ ->
+          true
+      | _ -> false
+    in
+    if should_cascade then
+      Some
+        (Cascade_fsm.Call_err
+           (Llm_provider.Http_client.NetworkError
+              {
+                message = Llm_provider.Error.to_string provider_err;
+                kind = Llm_provider.Http_client.Unknown;
+              }))
+    else
+      None
   (* Model-capability errors: the next provider may handle these.
      CompletionContractViolation: model returned text when tool_use was
      required — a different model with better tool calling may succeed.
@@ -445,6 +467,7 @@ let sdk_error_is_terminal_provider_runtime_failure
 
 let sdk_error_is_hard_quota (err : Agent_sdk.Error.sdk_error) : bool =
   match err with
+  | Agent_sdk.Error.Provider (Llm_provider.Error.HardQuota _) -> true
   | Agent_sdk.Error.Api api_err ->
     (* Layer 1: structured variant check — [is_hard_quota] inspects the
        [RateLimited] variant for known hard-quota message patterns. *)
@@ -460,6 +483,7 @@ let sdk_error_is_hard_quota (err : Agent_sdk.Error.sdk_error) : bool =
      | None -> false)
   (* Non-Api error families never carry provider-level hard-quota signals. *)
   | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Provider _
   | Agent_sdk.Error.Mcp _
   | Agent_sdk.Error.Config _
   | Agent_sdk.Error.Serialization _
@@ -474,6 +498,37 @@ let provider_label provider =
   | value -> value
 
 let public_runtime_provider_label = "runtime"
+
+let provider_error_capacity_scope = function
+  | Llm_provider.Error.CapacityModel -> `Model
+  | Llm_provider.Error.CapacityAccount
+  | Llm_provider.Error.CapacityRegion
+  | Llm_provider.Error.CapacityProvider
+  | Llm_provider.Error.CapacityUnknown ->
+      `Provider
+
+let provider_error_should_cascade = function
+  | Llm_provider.Error.RateLimit _
+  | Llm_provider.Error.HardQuota _
+  | Llm_provider.Error.CapacityExhausted _
+  | Llm_provider.Error.ProviderUnavailable _
+  | Llm_provider.Error.ParseError _
+  | Llm_provider.Error.Timeout _ ->
+      true
+  | Llm_provider.Error.ServerError { transient; _ } -> transient
+  | Llm_provider.Error.NetworkError
+      { kind = Llm_provider.Http_client.Tls_error
+             | Llm_provider.Http_client.Local_resource_exhaustion; _ } ->
+      false
+  | Llm_provider.Error.NetworkError _ -> true
+  | Llm_provider.Error.MissingApiKey _
+  | Llm_provider.Error.InvalidConfig _
+  | Llm_provider.Error.UnknownVariant _
+  | Llm_provider.Error.AuthError _
+  | Llm_provider.Error.InvalidRequest _
+  | Llm_provider.Error.NotFound _
+  | Llm_provider.Error.ProviderTerminal _ ->
+      false
 
 let transient_http_status code =
   code = 408 || code = 409 || code = 425 || code = 429 || code >= 500
@@ -506,12 +561,42 @@ let retry_api_error_to_provider_error ~provider ~capacity_exhausted api_error =
   | Llm_provider.Retry.Timeout _ ->
       if capacity_exhausted then provider_capacity provider else None
 
+let sdk_provider_error_to_provider_error = function
+  | Llm_provider.Error.RateLimit { retry_after; _ } ->
+      Some (Provider_error.RateLimit { retry_after })
+  | Llm_provider.Error.HardQuota { detail; _ } ->
+      Some (Provider_error.CliWrappedHardQuota { detail })
+  | Llm_provider.Error.CapacityExhausted { scope; _ } ->
+      Some
+        (Provider_error.CapacityExhausted
+           { scope = provider_error_capacity_scope scope })
+  | Llm_provider.Error.AuthError _
+  | Llm_provider.Error.MissingApiKey _ ->
+      Some Provider_error.AuthError
+  | Llm_provider.Error.ServerError { code; transient; _ } ->
+      Some (Provider_error.ServerError { code; transient })
+  | Llm_provider.Error.InvalidRequest { reason; _ } ->
+      Some (Provider_error.InvalidRequest { reason })
+  | Llm_provider.Error.NotFound _ -> Some Provider_error.ModelNotFound
+  | Llm_provider.Error.InvalidConfig { detail; _ } ->
+      Some (Provider_error.InvalidRequest { reason = detail })
+  | Llm_provider.Error.ProviderTerminal { detail; _ } ->
+      Some (Provider_error.InvalidRequest { reason = detail })
+  | Llm_provider.Error.ProviderUnavailable _
+  | Llm_provider.Error.ParseError _
+  | Llm_provider.Error.UnknownVariant _
+  | Llm_provider.Error.NetworkError _
+  | Llm_provider.Error.Timeout _ ->
+      None
+
 let sdk_error_to_provider_error ~provider err =
   match err with
   | Agent_sdk.Error.Api api_err ->
       retry_api_error_to_provider_error ~provider
         ~capacity_exhausted:(sdk_error_is_hard_quota err)
         api_err
+  | Agent_sdk.Error.Provider provider_err ->
+      sdk_provider_error_to_provider_error provider_err
   (* Non-Api families do not map to a provider-level error. *)
   | Agent_sdk.Error.Agent _
   | Agent_sdk.Error.Mcp _
@@ -576,6 +661,8 @@ let timeout_source_label (err : Agent_sdk.Error.sdk_error) : string =
     match err with
     | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout { message }) ->
         String_util.contains_substring_ci message "max_execution_time_s"
+    | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout { detail; _ }) ->
+        String_util.contains_substring_ci detail "max_execution_time_s"
     | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _)
     | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _)
     | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
@@ -584,6 +671,7 @@ let timeout_source_label (err : Agent_sdk.Error.sdk_error) : string =
     | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _)
     | Agent_sdk.Error.Api (Llm_provider.Retry.ContextOverflow _)
     | Agent_sdk.Error.Api (Llm_provider.Retry.NetworkError _)
+    | Agent_sdk.Error.Provider _
     | Agent_sdk.Error.Agent _
     | Agent_sdk.Error.Mcp _
     | Agent_sdk.Error.Config _
@@ -598,6 +686,16 @@ let timeout_source_label (err : Agent_sdk.Error.sdk_error) : string =
 let emit_oas_run_timeout_metric ~cascade_name ~provider:_ err =
   match err with
   | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _) ->
+      let cascade_name = provider_label (cascade_name_to_string cascade_name) in
+      Prometheus.inc_counter Keeper_metrics.metric_keeper_oas_run_timeout
+        ~labels:
+          [
+            (label_cascade, cascade_name);
+            (label_provider, public_runtime_provider_label);
+            (label_source, timeout_source_label err);
+          ]
+        ()
+  | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _) ->
       let cascade_name = provider_label (cascade_name_to_string cascade_name) in
       Prometheus.inc_counter Keeper_metrics.metric_keeper_oas_run_timeout
         ~labels:
@@ -635,6 +733,8 @@ let sdk_error_soft_rate_limited (err : Agent_sdk.Error.sdk_error)
   | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited { retry_after; _ } as api_err)
     when not (Llm_provider.Retry.is_hard_quota api_err) ->
     Some retry_after
+  | Agent_sdk.Error.Provider (Llm_provider.Error.RateLimit { retry_after; _ }) ->
+    Some retry_after
   (* Hard-quota RateLimited is handled separately and other Api / non-Api
      errors do not represent soft rate limiting. *)
   | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _)
@@ -646,6 +746,7 @@ let sdk_error_soft_rate_limited (err : Agent_sdk.Error.sdk_error)
   | Agent_sdk.Error.Api (Llm_provider.Retry.ContextOverflow _)
   | Agent_sdk.Error.Api (Llm_provider.Retry.NetworkError _)
   | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _)
+  | Agent_sdk.Error.Provider _
   | Agent_sdk.Error.Agent _
   | Agent_sdk.Error.Mcp _
   | Agent_sdk.Error.Config _

--- a/lib/cascade/cascade_error_classify.ml
+++ b/lib/cascade/cascade_error_classify.ml
@@ -661,6 +661,7 @@ let string_contains_substring ~(needle : string) (haystack : string) =
 
 let sdk_error_is_server_rejected_parse_error (err : Agent_sdk.Error.sdk_error) =
   match err with
+  | Agent_sdk.Error.Provider (Llm_provider.Error.ParseError _) -> true
   | Agent_sdk.Error.Api (InvalidRequest { message }) ->
     let lower = String.lowercase_ascii message in
     (string_contains_substring ~needle:"can't find closing" lower
@@ -677,6 +678,7 @@ let sdk_error_is_server_rejected_parse_error (err : Agent_sdk.Error.sdk_error) =
       | ContextOverflow _
       | NetworkError _
       | Timeout _ )
+  | Agent_sdk.Error.Provider _
   | Agent_sdk.Error.Agent _
   | Agent_sdk.Error.Mcp _
   | Agent_sdk.Error.Config _

--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -373,6 +373,8 @@ let sdk_a2a_error_fields = function
 let sdk_error_detail_fields (error : Agent_sdk.Error.sdk_error) =
   match error with
   | Agent_sdk.Error.Api error -> sdk_api_error_fields error
+  | Agent_sdk.Error.Provider error ->
+    [ "variant", `String "provider"; "message", `String (Llm_provider.Error.to_string error) ]
   | Agent_sdk.Error.Agent error -> sdk_agent_error_fields error
   | Agent_sdk.Error.Mcp error -> sdk_mcp_error_fields error
   | Agent_sdk.Error.Config error -> sdk_config_error_fields error

--- a/lib/cascade/cascade_fsm.ml
+++ b/lib/cascade/cascade_fsm.ml
@@ -66,7 +66,8 @@ let to_user_message last_err =
       Printf.sprintf "%s provider requires a CLI transport" kind
   | Some (Llm_provider.Http_client.NetworkError { message; _ }) -> message
   | Some
-      ( (Llm_provider.Http_client.ProviderTerminal _
+      ( (Llm_provider.Http_client.TimeoutError _
+        | Llm_provider.Http_client.ProviderTerminal _
         | Llm_provider.Http_client.ProviderFailure _) as err ) ->
       (* Mirror the rendering shape used elsewhere on main HEAD
          (tool_local_runtime_bench / verify): "provider terminal:
@@ -135,4 +136,3 @@ let decide_and_record ~cascade_name ~accept_on_exhaustion ~is_last outcome =
   decision
 
 (* ── Inline tests ───────────────────────────────── *)
-

--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -475,7 +475,7 @@ let log_resolution ?(context = "ConfigDir") () =
 
 (* RFC-0121 — .masc/<sub> sub-directory accessors.
 
-   Layout SSOT: callers stop computing [Filename.concat base_path ".masc/X"]
+   Layout SSOT: callers stop computing base_path plus .masc child paths
    and instead route through these helpers. The directory structure decision
    ([auth], [credentials], [runtime/agent], etc.) lives in this single module
    so that future relocations need a single edit + a CI gate to enforce. *)

--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -90,7 +90,7 @@ val keeper_toml_path_opt : string -> string option
 (** {1 .masc/ root sub-directory accessors (RFC-0121)}
 
     All non-config artifacts under [<base>/.masc/<sub>/] route through these
-    helpers instead of [Filename.concat base_path ".masc/..."] string-literal
+    helpers instead of hand-built base_path plus .masc child string-literals
     direct construction. The path layout itself remains the single SSOT for
     where each subsystem keeps state, but the layout decision lives in one
     place (this module) rather than scattered across callers.

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -45,6 +45,7 @@ let sdk_error_of_keeper_internal_error err =
 
 let sdk_error_kind = function
   | Agent_sdk.Error.Api _ -> "api"
+  | Agent_sdk.Error.Provider _ -> "provider"
   | Agent_sdk.Error.Agent _ -> "agent"
   | Agent_sdk.Error.Mcp _ -> "mcp"
   | Agent_sdk.Error.Config _ -> "config"
@@ -71,6 +72,8 @@ type sdk_termination_semantics =
 
 let sdk_termination_semantics = function
   | Agent_sdk.Error.Api (Agent_sdk.Retry.Timeout _) -> Provider_wall_clock_timeout
+  | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _) ->
+    Provider_wall_clock_timeout
   | Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded _) ->
     Oas_turn_budget_exhausted
   | Agent_sdk.Error.Agent (Agent_sdk.Error.IdleDetected _) ->
@@ -93,6 +96,7 @@ let sdk_termination_semantics = function
     Oas_tripwire_violation
   | Agent_sdk.Error.Agent (Agent_sdk.Error.UnrecognizedStopReason _) -> Sdk_error_failure
   | Agent_sdk.Error.Api _ -> Sdk_error_failure
+  | Agent_sdk.Error.Provider _ -> Sdk_error_failure
   | Agent_sdk.Error.Mcp _ -> Sdk_error_failure
   | Agent_sdk.Error.Config _ -> Sdk_error_failure
   | Agent_sdk.Error.Serialization _ -> Sdk_error_failure
@@ -181,6 +185,7 @@ let agent_error_terminal_reason_code = function
 let terminal_reason_code_of_sdk_error = function
   | Agent_sdk.Error.Agent err -> agent_error_terminal_reason_code err
   | Agent_sdk.Error.Api err -> api_error_terminal_reason_code err
+  | Agent_sdk.Error.Provider _ -> "provider_error"
   | Agent_sdk.Error.Mcp _ -> "mcp_error"
   | Agent_sdk.Error.Config _ -> "config_error"
   | Agent_sdk.Error.Serialization _ -> "serialization_error"

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -384,7 +384,7 @@ let classify_sdk_error (e : Agent_sdk.Error.sdk_error) : checkpoint_load_error =
       Parse_error (sprintf "version mismatch: expected %d, got %d" r.expected r.got)
   | Serialization (UnknownVariant r) ->
       Parse_error (sprintf "unknown variant %s: %s" r.type_name r.value)
-  | Api _ | Agent _ | Mcp _ | Config _
+  | Api _ | Provider _ | Agent _ | Mcp _ | Config _
   | Orchestration _ | A2a _ | Internal _ ->
       Sdk_other_error (Agent_sdk.Error.to_string e)
 

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -62,6 +62,13 @@ let is_transient_network_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Api (NetworkError _) -> true
   | Agent_sdk.Error.Api (Timeout { message }) ->
       not (is_structural_oas_timeout_message message)
+  | Agent_sdk.Error.Provider (Llm_provider.Error.NetworkError
+      { kind = Llm_provider.Http_client.Tls_error
+             | Llm_provider.Http_client.Local_resource_exhaustion; _ }) ->
+      false
+  | Agent_sdk.Error.Provider (Llm_provider.Error.NetworkError _) -> true
+  | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout { detail; _ }) ->
+      not (is_structural_oas_timeout_message detail)
   | Agent_sdk.Error.Api (Overloaded _) -> true
   | Agent_sdk.Error.Api (ServerError { status = 503; _ }) -> true
   (* Non-transient API errors. *)
@@ -72,6 +79,7 @@ let is_transient_network_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Api (NotFound _)
   | Agent_sdk.Error.Api (ContextOverflow _) -> false
   (* Non-API error families are by definition not transient network errors. *)
+  | Agent_sdk.Error.Provider _
   | Agent_sdk.Error.Agent _
   | Agent_sdk.Error.Mcp _
   | Agent_sdk.Error.Config _
@@ -92,6 +100,7 @@ let is_transient_network_error (err : Agent_sdk.Error.sdk_error) : bool =
     the keeper's next heartbeat cycle will build a fresh prompt. *)
 let is_server_rejected_parse_error (err : Agent_sdk.Error.sdk_error) : bool =
   match err with
+  | Agent_sdk.Error.Provider (Llm_provider.Error.ParseError _) -> true
   | Agent_sdk.Error.Api (InvalidRequest { message }) ->
       let lower = String.lowercase_ascii message in
       (* Compound patterns to avoid false positives on generic messages
@@ -112,6 +121,7 @@ let is_server_rejected_parse_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Api (NetworkError _)
   | Agent_sdk.Error.Api (Timeout _) -> false
   (* Non-API error families. *)
+  | Agent_sdk.Error.Provider _
   | Agent_sdk.Error.Agent _
   | Agent_sdk.Error.Mcp _
   | Agent_sdk.Error.Config _
@@ -138,6 +148,7 @@ let is_required_tool_contract_violation (err : Agent_sdk.Error.sdk_error) : bool
   | Agent_sdk.Error.Agent (ExitConditionMet _) -> false
   (* Non-Agent error families. *)
   | Agent_sdk.Error.Api _
+  | Agent_sdk.Error.Provider _
   | Agent_sdk.Error.Mcp _
   | Agent_sdk.Error.Config _
   | Agent_sdk.Error.Serialization _
@@ -389,6 +400,13 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
              Some Server_error
          | Agent_sdk.Error.Api (Llm_provider.Retry.AuthError _) ->
              Some Auth_error
+         | Agent_sdk.Error.Provider (Llm_provider.Error.RateLimit _) ->
+             Some Rate_limit
+         | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code; _ })
+           when code >= 500 ->
+             Some Server_error
+         | Agent_sdk.Error.Provider (Llm_provider.Error.AuthError _) ->
+             Some Auth_error
          (* Sub-500 server errors (4xx already handled above for AuthError /
             RateLimited) are not classified as recoverable cascade failures. *)
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
@@ -397,7 +415,8 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
          | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.ContextOverflow _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.NetworkError _)
-         | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _) -> None
+         | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _)
+         | Agent_sdk.Error.Provider _ -> None
          (* Non-API error families have no rotation reason here: structured
             MASC internal errors are handled by [classify_masc_internal_error]
             above; agent / mcp / config / etc. are not provider-level rotations. *)
@@ -606,6 +625,7 @@ let is_ambiguous_side_effect_error (err : Agent_sdk.Error.sdk_error) : bool =
          ambiguous-side-effect string prefix; the structured
          [Ambiguous_post_commit] arm above covers the new path. *)
       | Agent_sdk.Error.Api _
+      | Agent_sdk.Error.Provider _
       | Agent_sdk.Error.Agent _
       | Agent_sdk.Error.Mcp _
       | Agent_sdk.Error.Config _
@@ -635,6 +655,7 @@ let reclassify_error_after_side_effect
     let is_timeout =
       match err with
       | Agent_sdk.Error.Api (Timeout _) -> true
+      | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _) -> true
       | Agent_sdk.Error.Api (RateLimited _)
       | Agent_sdk.Error.Api (Overloaded _)
       | Agent_sdk.Error.Api (ServerError _)
@@ -643,6 +664,7 @@ let reclassify_error_after_side_effect
       | Agent_sdk.Error.Api (NotFound _)
       | Agent_sdk.Error.Api (ContextOverflow _)
       | Agent_sdk.Error.Api (NetworkError _) -> false
+      | Agent_sdk.Error.Provider _
       | Agent_sdk.Error.Agent _
       | Agent_sdk.Error.Mcp _
       | Agent_sdk.Error.Config _
@@ -659,6 +681,8 @@ let reclassify_error_after_side_effect
 let post_commit_failure_kind_of_error (err : Agent_sdk.Error.sdk_error) =
   match err with
   | Agent_sdk.Error.Api (Timeout _) -> Keeper_registry.Post_commit_timeout
+  | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _) ->
+      Keeper_registry.Post_commit_timeout
   (* All non-Timeout failures classify as generic post-commit failure. *)
   | Agent_sdk.Error.Api (RateLimited _)
   | Agent_sdk.Error.Api (Overloaded _)
@@ -668,6 +692,7 @@ let post_commit_failure_kind_of_error (err : Agent_sdk.Error.sdk_error) =
   | Agent_sdk.Error.Api (NotFound _)
   | Agent_sdk.Error.Api (ContextOverflow _)
   | Agent_sdk.Error.Api (NetworkError _)
+  | Agent_sdk.Error.Provider _
   | Agent_sdk.Error.Agent _
   | Agent_sdk.Error.Mcp _
   | Agent_sdk.Error.Config _
@@ -766,6 +791,7 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Agent (TripwireViolation _)
   | Agent_sdk.Error.Agent (ExitConditionMet _) -> false
   (* Non-API / non-Agent error families. *)
+  | Agent_sdk.Error.Provider _
   | Agent_sdk.Error.Mcp _
   | Agent_sdk.Error.Config _
   | Agent_sdk.Error.Serialization _

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -248,6 +248,7 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
      (* Provider-level [Api] errors are surfaced via OAS retry / cascade
          layers and do not map to a typed blocker_class by themselves. *)
      | Agent_sdk.Error.Api _
+     | Agent_sdk.Error.Provider _
      | Agent_sdk.Error.Mcp _
      | Agent_sdk.Error.Config _
      | Agent_sdk.Error.Serialization _

--- a/lib/keeper/keeper_turn_cascade_budget_routing.ml
+++ b/lib/keeper/keeper_turn_cascade_budget_routing.ml
@@ -123,6 +123,7 @@ let next_fail_open_cascade_for_turn
 
 let sdk_error_kind = function
   | Agent_sdk.Error.Api _ -> "api"
+  | Agent_sdk.Error.Provider _ -> "provider"
   | Agent_sdk.Error.Agent _ -> "agent"
   | Agent_sdk.Error.Mcp _ -> "mcp"
   | Agent_sdk.Error.Config _ -> "config"

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -731,6 +731,11 @@ let run_named
               Keeper_types.Max_turns_exceeded
             else
               Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
+        | Some (Llm_provider.Http_client.TimeoutError { message; _ }) ->
+            if message_looks_like_cli_wrapped_max_turns message then
+              Keeper_types.Max_turns_exceeded
+            else
+              Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
         | Some (Llm_provider.Http_client.HttpError { body; _ }) ->
             if message_looks_like_cli_wrapped_max_turns body then
               Keeper_types.Max_turns_exceeded

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -174,6 +174,8 @@ module Http_client = struct
           Provider_terminal
       | Llm_provider.Http_client.ProviderFailure { kind; _ } ->
           classify_provider_failure_kind kind
+      | Llm_provider.Http_client.TimeoutError _ ->
+          Network_error
       | Llm_provider.Http_client.NetworkError { kind; _ } ->
           if kind = Llm_provider.Http_client.Tls_error then Tls_error else Network_error
 
@@ -203,6 +205,7 @@ module Http_client = struct
   let error_message (err : Llm_provider.Http_client.http_error) : string =
     match err with
     | Llm_provider.Http_client.NetworkError { message; _ } -> message
+    | Llm_provider.Http_client.TimeoutError { message; _ } -> message
     | Llm_provider.Http_client.AcceptRejected { reason } -> reason
     | Llm_provider.Http_client.CliTransportRequired { kind } ->
         Printf.sprintf "%s provider requires a CLI transport" kind

--- a/lib/server/openai_compat_error_map.ml
+++ b/lib/server/openai_compat_error_map.ml
@@ -272,6 +272,12 @@ let of_a2a_error (e : Agent_sdk.Error.a2a_error) : t =
 let of_sdk_error (e : Agent_sdk.Error.sdk_error) : t =
   match e with
   | Agent_sdk.Error.Api ae -> of_api_error ae
+  | Provider pe ->
+    { http_status =
+        (if Llm_provider.Error.is_retryable pe then `Service_unavailable else `Bad_gateway)
+    ; openai_kind = kind_server
+    ; openai_code = Some "provider_error"
+    ; message = Llm_provider.Error.to_string pe }
   | Agent ae -> of_agent_error ae
   | Mcp me -> of_mcp_error me
   | Config ce -> of_config_error ce

--- a/lib/shell_command_gate.ml
+++ b/lib/shell_command_gate.ml
@@ -1,0 +1,140 @@
+type cannot_parse_kind =
+  | Parse_error
+  | Parse_aborted of Masc_exec.Parsed.reason_aborted
+  | Too_complex of Masc_exec.Parsed.reason_too_complex
+
+type shape =
+  | Simple
+  | Pipeline of { stages : int }
+
+type parsed_context = {
+  ast : Masc_exec.Shell_ir.t;
+  shape : shape;
+  stage_bins : string list;
+}
+
+type reject_reason =
+  | Command_not_in_allowlist of { bin : string }
+  | Pipeline_segment_disallowed of { stage : int; bin : string }
+  | Pipes_not_allowed of { stages : int }
+
+type decision =
+  | Allow of parsed_context
+  | Reject of {
+      context : parsed_context;
+      reason : reject_reason;
+      diagnostic : string;
+    }
+  | Cannot_parse of { kind : cannot_parse_kind }
+
+let rec simples_of_ir = function
+  | Masc_exec.Shell_ir.Simple simple -> [ simple ]
+  | Masc_exec.Shell_ir.Pipeline stages -> List.concat_map simples_of_ir stages
+;;
+
+let shape_of_count = function
+  | 0 | 1 -> Simple
+  | stages -> Pipeline { stages }
+;;
+
+let parsed_context_of_ast ast =
+  let simples = simples_of_ir ast in
+  let stage_bins =
+    simples |> List.map (fun simple -> Masc_exec.Bin.to_string simple.Masc_exec.Shell_ir.bin)
+  in
+  { ast; shape = shape_of_count (List.length stage_bins); stage_bins }
+;;
+
+let parse cmd =
+  match Masc_exec_bash_parser.Bash.parse_string cmd with
+  | Masc_exec.Parsed.Parsed ast -> Ok (parsed_context_of_ast ast)
+  | Masc_exec.Parsed.Parse_error _ -> Error Parse_error
+  | Masc_exec.Parsed.Parse_aborted r -> Error (Parse_aborted r)
+  | Masc_exec.Parsed.Too_complex r -> Error (Too_complex r)
+;;
+
+let stage_count context = List.length context.stage_bins
+
+let last_stage_bin context =
+  match List.rev context.stage_bins with
+  | [] -> None
+  | bin :: _ -> Some bin
+;;
+
+let bin_allowed ~allowed_commands bin =
+  List.exists (String.equal bin) allowed_commands
+;;
+
+let first_disallowed_stage ~allowed_commands context =
+  let rec scan stage = function
+    | [] -> None
+    | bin :: rest ->
+      if bin_allowed ~allowed_commands bin then scan (stage + 1) rest else Some (stage, bin)
+  in
+  scan 1 context.stage_bins
+;;
+
+let validate_allowlist ?(allow_pipes = true) ~allowed_commands cmd =
+  match parse cmd with
+  | Error kind -> Cannot_parse { kind }
+  | Ok context ->
+    let stages = stage_count context in
+    if (not allow_pipes) && stages > 1
+    then
+      Reject
+        { context
+        ; reason = Pipes_not_allowed { stages }
+        ; diagnostic = "pipelines are not allowed for this command surface"
+        }
+    else (
+      match first_disallowed_stage ~allowed_commands context with
+      | None -> Allow context
+      | Some (stage, bin) ->
+        let reason =
+          match context.shape with
+          | Simple -> Command_not_in_allowlist { bin }
+          | Pipeline _ -> Pipeline_segment_disallowed { stage; bin }
+        in
+        let diagnostic =
+          match reason with
+          | Command_not_in_allowlist { bin } ->
+            Printf.sprintf "%s not in shell command allowlist" bin
+          | Pipeline_segment_disallowed { stage; bin } ->
+            Printf.sprintf "pipeline stage %d command %s not in shell command allowlist" stage bin
+          | Pipes_not_allowed { stages } ->
+            Printf.sprintf "pipeline with %d stages is not allowed" stages
+        in
+        Reject { context; reason; diagnostic })
+;;
+
+let cannot_parse_kind_tag = function
+  | Parse_error -> "parse_error"
+  | Parse_aborted `Timeout_50ms -> "timeout"
+  | Parse_aborted `Depth_limit -> "depth_limit"
+  | Parse_aborted `Token_limit_50k -> "token_limit"
+  | Too_complex `Heredoc -> "heredoc"
+  | Too_complex `Here_string -> "here_string"
+  | Too_complex `Cmd_subst -> "cmd_subst"
+  | Too_complex `Proc_subst -> "proc_subst"
+  | Too_complex `Subshell -> "subshell"
+  | Too_complex `Arith_expansion -> "arith_expansion"
+  | Too_complex `Control_flow -> "control_flow"
+  | Too_complex `Logic_op -> "logic_op"
+  | Too_complex `Function_def -> "function_def"
+  | Too_complex `Glob_brace -> "glob_brace"
+  | Too_complex `Background -> "background"
+  | Too_complex `Redirect -> "redirect"
+  | Too_complex (`Unknown_construct _) -> "other"
+;;
+
+let reject_reason_tag = function
+  | Command_not_in_allowlist _ -> "command"
+  | Pipeline_segment_disallowed _ -> "pipeline_segment"
+  | Pipes_not_allowed _ -> "pipes_not_allowed"
+;;
+
+let decision_tag = function
+  | Allow _ -> "allow"
+  | Reject _ -> "reject"
+  | Cannot_parse _ -> "cannot_parse"
+;;

--- a/lib/shell_command_gate.mli
+++ b/lib/shell_command_gate.mli
@@ -1,0 +1,52 @@
+(** Parse-once facade for shell command validation.
+
+    This module is the narrow bridge between raw shell strings and the
+    Shell_ir authority path. It preserves pipelines as first-class stage
+    lists so callers do not need local quote-aware pipe splitters. *)
+
+type cannot_parse_kind =
+  | Parse_error
+  | Parse_aborted of Masc_exec.Parsed.reason_aborted
+  | Too_complex of Masc_exec.Parsed.reason_too_complex
+
+type shape =
+  | Simple
+  | Pipeline of { stages : int }
+
+type parsed_context = {
+  ast : Masc_exec.Shell_ir.t;
+  shape : shape;
+  stage_bins : string list;
+}
+
+type reject_reason =
+  | Command_not_in_allowlist of { bin : string }
+  | Pipeline_segment_disallowed of { stage : int; bin : string }
+  | Pipes_not_allowed of { stages : int }
+
+type decision =
+  | Allow of parsed_context
+  | Reject of {
+      context : parsed_context;
+      reason : reject_reason;
+      diagnostic : string;
+    }
+  | Cannot_parse of { kind : cannot_parse_kind }
+
+val parse : string -> (parsed_context, cannot_parse_kind) result
+(** Parse a raw command into a reusable Shell_ir context. *)
+
+val validate_allowlist
+  :  ?allow_pipes:bool
+  -> allowed_commands:string list
+  -> string
+  -> decision
+(** Parse once, then enforce an exact binary-name allowlist over every
+    stage. [allow_pipes] defaults to [true]. *)
+
+val stage_count : parsed_context -> int
+val last_stage_bin : parsed_context -> string option
+
+val cannot_parse_kind_tag : cannot_parse_kind -> string
+val reject_reason_tag : reject_reason -> string
+val decision_tag : decision -> string

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -83,38 +83,16 @@ let first_token_basename segment =
     in
     Some (Filename.basename (String.sub trimmed 0 (find_sep 0)))
 
-let split_pipeline_segments command =
-  let len = String.length command in
-  let push_segment start stop acc =
-    String.sub command start (stop - start) |> String.trim |> fun segment ->
-    segment :: acc
-  in
-  let rec loop i quote escaped start acc =
-    if i >= len
-    then List.rev (push_segment start len acc)
-    else (
-      let c = command.[i] in
-      match quote, escaped, c with
-      | Some '\'', _, '\'' -> loop (i + 1) None false start acc
-      | Some '\'', _, _ -> loop (i + 1) quote false start acc
-      | _, true, _ -> loop (i + 1) quote false start acc
-      | _, false, '\\' -> loop (i + 1) quote true start acc
-      | None, false, '\'' -> loop (i + 1) (Some '\'') false start acc
-      | None, false, '"' -> loop (i + 1) (Some '"') false start acc
-      | Some '"', false, '"' -> loop (i + 1) None false start acc
-      | None, false, '|' -> loop (i + 1) None false (i + 1) (push_segment start i acc)
-      | _ -> loop (i + 1) quote false start acc)
-  in
-  loop 0 None false 0 []
-
-let last_pipeline_command_name command =
-  command |> split_pipeline_segments |> List.rev |> List.find_map first_token_basename
+let exit_status_command_name command =
+  match Shell_command_gate.parse command with
+  | Ok context -> Shell_command_gate.last_stage_bin context
+  | Error _ -> first_token_basename command
 
 let classify_code_shell_exit ~command code =
   match code with
   | 0 -> Shell_ok
   | 1 -> (
-      match last_pipeline_command_name command with
+      match exit_status_command_name command with
       | Some ("rg" | "grep") -> Shell_ok_expected_nonzero "no_matches"
       | Some "diff" -> Shell_ok_expected_nonzero "differences"
       | _ -> Shell_error)

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -83,11 +83,32 @@ let first_token_basename segment =
     in
     Some (Filename.basename (String.sub trimmed 0 (find_sep 0)))
 
+let split_pipeline_segments command =
+  let len = String.length command in
+  let push_segment start stop acc =
+    String.sub command start (stop - start) |> String.trim |> fun segment ->
+    segment :: acc
+  in
+  let rec loop i quote escaped start acc =
+    if i >= len
+    then List.rev (push_segment start len acc)
+    else (
+      let c = command.[i] in
+      match quote, escaped, c with
+      | Some '\'', _, '\'' -> loop (i + 1) None false start acc
+      | Some '\'', _, _ -> loop (i + 1) quote false start acc
+      | _, true, _ -> loop (i + 1) quote false start acc
+      | _, false, '\\' -> loop (i + 1) quote true start acc
+      | None, false, '\'' -> loop (i + 1) (Some '\'') false start acc
+      | None, false, '"' -> loop (i + 1) (Some '"') false start acc
+      | Some '"', false, '"' -> loop (i + 1) None false start acc
+      | None, false, '|' -> loop (i + 1) None false (i + 1) (push_segment start i acc)
+      | _ -> loop (i + 1) quote false start acc)
+  in
+  loop 0 None false 0 []
+
 let last_pipeline_command_name command =
-  command
-  |> String.split_on_char '|'
-  |> List.rev
-  |> List.find_map first_token_basename
+  command |> split_pipeline_segments |> List.rev |> List.find_map first_token_basename
 
 let classify_code_shell_exit ~command code =
   match code with

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -83,10 +83,29 @@ let first_token_basename segment =
     in
     Some (Filename.basename (String.sub trimmed 0 (find_sep 0)))
 
+let last_pipeline_segment command =
+  let len = String.length command in
+  let last_start = ref 0 in
+  let in_single = ref false in
+  let in_double = ref false in
+  let escaped = ref false in
+  for i = 0 to len - 1 do
+    let c = command.[i] in
+    if !escaped then escaped := false
+    else
+      match c with
+      | '\\' when not !in_single -> escaped := true
+      | '\'' when not !in_double -> in_single := not !in_single
+      | '"' when not !in_single -> in_double := not !in_double
+      | '|' when (not !in_single) && not !in_double -> last_start := i + 1
+      | _ -> ()
+  done;
+  String.sub command !last_start (len - !last_start)
+
 let exit_status_command_name command =
   match Shell_command_gate.parse command with
   | Ok context -> Shell_command_gate.last_stage_bin context
-  | Error _ -> first_token_basename command
+  | Error _ -> first_token_basename (last_pipeline_segment command)
 
 let classify_code_shell_exit ~command code =
   match code with

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -614,6 +614,47 @@ let validate_command cmd =
   validate_command_with_allowlist ~allowed_commands:dev_allowed_commands cmd
 ;;
 
+let first_disallowed_stage_bin ~allowed_commands stage_bins =
+  List.find_opt
+    (fun name -> not (List.exists (String.equal name) allowed_commands))
+    stage_bins
+;;
+
+let validate_command_coding_legacy_segments ~allow_pipes ~allowed_commands trimmed =
+  match split_pipeline_segments trimmed with
+  | Error msg -> Error (Command_not_allowed msg)
+  | Ok segments ->
+    if (not allow_pipes) && List.length segments > 1
+    then Error Pipes_not_allowed
+    else if List.exists invokes_direct_dune segments
+    then Error Direct_dune_invocation
+    else (
+      let rec validate_segments = function
+        | [] -> Ok ()
+        | segment :: rest ->
+          (match extract_command_name segment with
+           | None -> Error Empty_command
+           | Some name when List.mem name allowed_commands ->
+             validate_segments rest
+           | Some name -> Error (Command_not_allowed name))
+      in
+      validate_segments segments)
+;;
+
+let validate_command_coding_parsed ~allow_pipes ~allowed_commands context =
+  let stage_bins = context.Shell_command_gate.stage_bins in
+  if (not allow_pipes) && Shell_command_gate.stage_count context > 1
+  then `Error Pipes_not_allowed
+  else if List.exists (String.equal "dune") stage_bins
+  then `Error Direct_dune_invocation
+  else if List.exists (fun name -> String.equal name "env" || String.equal name "opam") stage_bins
+  then `Use_legacy_segments
+  else (
+    match first_disallowed_stage_bin ~allowed_commands stage_bins with
+    | None -> `Ok
+    | Some name -> `Error (Command_not_allowed name))
+;;
+
 let validate_command_coding_with_allowlist
       ?(allow_pipes = true)
       ~(allowed_commands : string list)
@@ -629,23 +670,15 @@ let validate_command_coding_with_allowlist
   else if has_unsafe_redirection trimmed
   then Error Unsafe_redirect
   else (
-    match split_pipeline_segments trimmed with
-    | Error msg -> Error (Command_not_allowed msg)
-    | Ok segments ->
-      if (not allow_pipes) && List.length segments > 1
-      then Error Pipes_not_allowed
-      else if List.exists invokes_direct_dune segments
-      then Error Direct_dune_invocation
-      else (
-        let rec validate_segments = function
-          | [] -> Ok ()
-          | segment :: rest ->
-            (match extract_command_name segment with
-             | None -> Error Empty_command
-             | Some name when List.mem name allowed_commands -> validate_segments rest
-             | Some name -> Error (Command_not_allowed name))
-        in
-        validate_segments segments))
+    match Shell_command_gate.parse trimmed with
+    | Ok context -> (
+      match validate_command_coding_parsed ~allow_pipes ~allowed_commands context with
+      | `Use_legacy_segments ->
+        validate_command_coding_legacy_segments ~allow_pipes ~allowed_commands trimmed
+      | `Ok -> Ok ()
+      | `Error reason -> Error reason)
+    | Error _ ->
+      validate_command_coding_legacy_segments ~allow_pipes ~allowed_commands trimmed)
 ;;
 
 (** Relaxed command validation for Coding/Full preset keepers.

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,7 +31,7 @@ lib/process/process_eio.ml:493
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1892 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:1925 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
 # Eio.Switch.run at the call boundary.
-lib/worker_dev_tools.ml:1892
+lib/worker_dev_tools.ml:1925

--- a/test/dune
+++ b/test/dune
@@ -593,6 +593,7 @@
   test_telemetry_observe
   test_keeper_typed_labels
   test_shell_ir_typed_review_followup
+  test_shell_command_gate
   test_shell_ir_validator
   test_typed_advisor_counters
   test_auth_resolve_labels

--- a/test/dune
+++ b/test/dune
@@ -297,6 +297,7 @@
   test_telemetry_observe
   test_keeper_typed_labels
   test_shell_ir_typed_review_followup
+  test_shell_command_gate
   test_shell_ir_validator
   test_typed_advisor_counters
   test_auth_resolve_labels

--- a/test/test_oas_compat_cascade_fallback.ml
+++ b/test/test_oas_compat_cascade_fallback.ml
@@ -127,6 +127,23 @@ let test_local_resource_error_does_not_cascade () =
   | Local_resource_exhaustion -> ()
   | _ -> Alcotest.fail "local resource exhaustion must keep its typed class"
 
+let test_timeout_error_cascades () =
+  let err =
+    Http_client.TimeoutError
+      { phase = Provider_step; message = "provider step timed out" }
+  in
+  Alcotest.(check bool)
+    "typed timeout is provider-local and should cascade"
+    true
+    (Oas_compat.Http_client.should_cascade err);
+  (match Oas_compat.Http_client.classify err with
+   | Network_error -> ()
+   | _ -> Alcotest.fail "TimeoutError must classify as Network_error");
+  Alcotest.(check string)
+    "TimeoutError -> message"
+    "provider step timed out"
+    (Oas_compat.Http_client.error_message err)
+
 (* --- ProviderTerminal: pin classify, should_cascade, and the new
        error_message helper. The variant arrived in agent_sdk without
        a sweep, so [warn-error +8] flipped 5 [partial-match] warnings
@@ -380,6 +397,11 @@ let () =
             `Quick test_tls_error_does_not_cascade;
           Alcotest.test_case "local resource error does not cascade"
             `Quick test_local_resource_error_does_not_cascade;
+        ] );
+      ( "Typed timeout errors cascade",
+        [
+          Alcotest.test_case "TimeoutError classify + cascade + message"
+            `Quick test_timeout_error_cascades;
         ] );
       ( "ProviderTerminal — agent-level terminal does not cascade",
         [

--- a/test/test_shell_command_gate.ml
+++ b/test/test_shell_command_gate.ml
@@ -1,0 +1,84 @@
+module Gate = Masc_mcp.Shell_command_gate
+
+let allowed = [ "rg"; "sort"; "head"; "wc"; "cat" ]
+
+let check_stage_bins label expected context =
+  Alcotest.(check (list string)) label expected context.Gate.stage_bins
+;;
+
+let test_parse_three_stage_pipeline () =
+  match Gate.parse "rg foo lib | sort | head -20" with
+  | Error kind ->
+    Alcotest.failf "expected parsed pipeline, got %s" (Gate.cannot_parse_kind_tag kind)
+  | Ok context ->
+    Alcotest.(check int) "stage count" 3 (Gate.stage_count context);
+    check_stage_bins "stage bins" [ "rg"; "sort"; "head" ] context;
+    Alcotest.(check (option string)) "last stage" (Some "head") (Gate.last_stage_bin context);
+    (match context.Gate.shape with
+     | Gate.Pipeline { stages = 3 } -> ()
+     | Gate.Simple -> Alcotest.fail "expected pipeline shape"
+     | Gate.Pipeline { stages } -> Alcotest.failf "expected 3 stages, got %d" stages)
+;;
+
+let test_quoted_pipe_stays_inside_argument () =
+  match Gate.parse "rg 'foo|bar' lib | head -20" with
+  | Error kind ->
+    Alcotest.failf "expected parsed pipeline, got %s" (Gate.cannot_parse_kind_tag kind)
+  | Ok context ->
+    Alcotest.(check int) "stage count" 2 (Gate.stage_count context);
+    check_stage_bins "stage bins" [ "rg"; "head" ] context
+;;
+
+let test_quoted_pipe_single_stage () =
+  match Gate.validate_allowlist ~allowed_commands:allowed "rg 'foo|bar' lib" with
+  | Gate.Allow context ->
+    Alcotest.(check int) "stage count" 1 (Gate.stage_count context);
+    check_stage_bins "stage bins" [ "rg" ] context
+  | other -> Alcotest.failf "expected Allow, got %s" (Gate.decision_tag other)
+;;
+
+let test_rejects_disallowed_pipeline_stage_with_index () =
+  match Gate.validate_allowlist ~allowed_commands:allowed "rg foo | sed s/a/b/ | head -20" with
+  | Gate.Reject { reason = Gate.Pipeline_segment_disallowed { stage = 2; bin = "sed" }; _ } -> ()
+  | other ->
+    Alcotest.failf
+      "expected stage 2 sed rejection, got %s"
+      (Gate.decision_tag other)
+;;
+
+let test_rejects_pipes_when_disabled () =
+  match
+    Gate.validate_allowlist ~allow_pipes:false ~allowed_commands:allowed "rg foo | head -20"
+  with
+  | Gate.Reject { reason = Gate.Pipes_not_allowed { stages = 2 }; _ } -> ()
+  | other ->
+    Alcotest.failf
+      "expected Pipes_not_allowed rejection, got %s"
+      (Gate.decision_tag other)
+;;
+
+let test_too_complex_shell_chain () =
+  match Gate.validate_allowlist ~allowed_commands:allowed "rg foo && head file" with
+  | Gate.Cannot_parse { kind = Gate.Too_complex `Logic_op } -> ()
+  | other ->
+    Alcotest.failf "expected Too_complex Logic_op, got %s" (Gate.decision_tag other)
+;;
+
+let () =
+  Alcotest.run
+    "shell_command_gate"
+    [ ( "parse"
+      , [ Alcotest.test_case "three-stage pipeline" `Quick test_parse_three_stage_pipeline
+        ; Alcotest.test_case "quoted pipe in pipeline" `Quick test_quoted_pipe_stays_inside_argument
+        ] )
+    ; ( "validate"
+      , [ Alcotest.test_case "quoted pipe single stage" `Quick test_quoted_pipe_single_stage
+        ; Alcotest.test_case
+            "disallowed pipeline stage reports index"
+            `Quick
+            test_rejects_disallowed_pipeline_stage_with_index
+        ; Alcotest.test_case "pipes disabled" `Quick test_rejects_pipes_when_disabled
+        ; Alcotest.test_case "shell chain is too complex" `Quick test_too_complex_shell_chain
+        ] )
+    ]
+;;

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -420,6 +420,14 @@ let test_validate_code_shell_command_allows_grep () =
   check (result unit string) "grep allowed" (Ok ())
     (Tool_code_write.validate_code_shell_command "grep -R -n TODO lib")
 
+let test_validate_code_shell_command_allows_quoted_regex_alternation () =
+  check (result unit string) "quoted rg alternation allowed" (Ok ())
+    (Tool_code_write.validate_code_shell_command
+       "rg \"tool_policy\\|tool_preset\\|preset_policy\\|toolset\" --type=ml -l");
+  check (result unit string) "quoted alternation before real pipe allowed" (Ok ())
+    (Tool_code_write.validate_code_shell_command
+       "rg 'keeper.*tool|tool.*keeper' --type=ml -l | head -20")
+
 let test_validate_code_shell_command_uses_code_shell_allowlist_hint () =
   match Tool_code_write.validate_code_shell_command "python3 --version" with
   | Error reason ->
@@ -864,6 +872,8 @@ let () =
         test_validate_code_shell_command_rejects_direct_dune;
       test_case "allows grep" `Quick
         test_validate_code_shell_command_allows_grep;
+      test_case "allows quoted regex alternation" `Quick
+        test_validate_code_shell_command_allows_quoted_regex_alternation;
       test_case "uses code shell allowlist hint" `Quick
         test_validate_code_shell_command_uses_code_shell_allowlist_hint;
       test_case "rejects semicolon" `Quick

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -643,6 +643,28 @@ let test_code_shell_grep_exit_one_no_matches_is_success () =
   check string "exit_semantics" "no_matches"
     (json_string_field "exit_semantics" msg)
 
+let test_code_shell_pipeline_grep_exit_one_no_matches_is_success () =
+  with_temp_dir "tool-code-shell-pipe-grep" @@ fun dir ->
+  let fixture = Filename.concat dir "sample.txt" in
+  write_file fixture "present\n";
+  let ctx = make_ctx () in
+  let args =
+    `Assoc
+      [
+        ( "command",
+          `String
+            (Printf.sprintf "cat %s 2>&1 | grep __masc_code_shell_no_match__"
+               (Filename.quote fixture)) );
+        ("timeout", `Int 5);
+      ]
+  in
+  let ok, msg = dispatch_exn ctx ~name:"masc_code_shell" ~args in
+  check bool "pipeline grep no-match exit 1 is successful" true ok;
+  check string "status" "ok" (json_string_field "status" msg);
+  check int "exit_code" 1 (json_int_field "exit_code" msg);
+  check string "exit_semantics" "no_matches"
+    (json_string_field "exit_semantics" msg)
+
 let test_code_shell_rg_exit_two_remains_error () =
   let ctx = make_ctx () in
   let args =
@@ -884,6 +906,8 @@ let () =
         test_code_shell_rg_exit_one_no_matches_is_success;
       test_case "grep exit 1 no-match is success" `Quick
         test_code_shell_grep_exit_one_no_matches_is_success;
+      test_case "pipeline grep exit 1 no-match is success" `Quick
+        test_code_shell_pipeline_grep_exit_one_no_matches_is_success;
       test_case "rg exit 2 remains error" `Quick
         test_code_shell_rg_exit_two_remains_error;
     ]);

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -668,6 +668,16 @@ let () =
           Alcotest.fail
             ("should split only the real pipeline: "
              ^ Worker_dev_tools.block_reason_to_string e));
+      Alcotest.test_case "allows three-stage parsed pipeline" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_command_coding
+            "rg 'keeper.*tool|tool.*keeper' --type=ml -l | head -20 | wc -l"
+        with
+        | Ok () -> ()
+        | Error e ->
+          Alcotest.fail
+            ("should validate every parsed pipeline stage: "
+             ^ Worker_dev_tools.block_reason_to_string e));
       Alcotest.test_case "allows wrapper redirect" `Quick (fun () ->
         match
           Worker_dev_tools.validate_command_coding
@@ -675,6 +685,11 @@ let () =
         with
         | Ok () -> ()
         | Error e -> Alcotest.fail ("should allow redirect: " ^ Worker_dev_tools.block_reason_to_string e));
+      Alcotest.test_case "blocks parser-supported direct dune" `Quick (fun () ->
+        match Worker_dev_tools.validate_command_coding "dune build" with
+        | Error Worker_dev_tools.Direct_dune_invocation -> ()
+        | Error e -> Alcotest.fail ("wrong rejection: " ^ Worker_dev_tools.block_reason_to_string e)
+        | Ok () -> Alcotest.fail "should reject bare dune");
       Alcotest.test_case "blocks direct dune" `Quick (fun () ->
         match Worker_dev_tools.validate_command_coding "dune build 2>&1" with
         | Error Worker_dev_tools.Direct_dune_invocation -> ()

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -648,6 +648,26 @@ let () =
             Alcotest.fail
               ("quoted regex pipe should not start a new command: "
                ^ Worker_dev_tools.block_reason_to_string e));
+      Alcotest.test_case "allows quoted regex alternation" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_command_coding
+            "rg \"tool_policy\\|tool_preset\\|preset_policy\\|toolset\" --type=ml -l"
+        with
+        | Ok () -> ()
+        | Error e ->
+          Alcotest.fail
+            ("should keep quoted regex alternation in the rg segment: "
+             ^ Worker_dev_tools.block_reason_to_string e));
+      Alcotest.test_case "allows quoted regex alternation before real pipe" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_command_coding
+            "rg 'keeper.*tool|tool.*keeper' --type=ml -l | head -20"
+        with
+        | Ok () -> ()
+        | Error e ->
+          Alcotest.fail
+            ("should split only the real pipeline: "
+             ^ Worker_dev_tools.block_reason_to_string e));
       Alcotest.test_case "allows wrapper redirect" `Quick (fun () ->
         match
           Worker_dev_tools.validate_command_coding


### PR DESCRIPTION
## Summary
- make shell pipeline splitting quote/backslash-aware for coding shell validation
- preserve quoted `rg` regex alternation such as `tool_policy\|tool_preset`
- align `masc_code_shell` exit classification with the same quoted-pipe handling

## Root Cause
Recent runtime logs showed `masc_code_shell` rejecting safe `rg` searches because validation split every `|` byte as a pipeline boundary. That misclassified quoted regex alternation as separate commands, for example `tool_preset\` or `tool.*keeper`.

## Verification
- `git diff --check`
- `opam exec -- ocamlformat --check lib/worker_dev_tools.ml lib/tool_code_write.ml test/test_worker_dev_tools.ml test/test_tool_code_write_coverage.ml`
- `env DUNE_CACHE=disabled opam exec -- dune build --root . _build/default/lib/.masc_mcp.objs/native/masc_mcp__Worker_dev_tools.cmx _build/default/lib/.masc_mcp.objs/native/masc_mcp__Tool_code_write.cmx`
- `env DUNE_CACHE=disabled opam exec -- dune build --root . _build/default/test/test_worker_dev_tools.exe`
- `env DUNE_CACHE=disabled opam exec -- dune exec --root . ./test/test_worker_dev_tools.exe`
- `env DUNE_CACHE=disabled opam exec -- dune build --root . _build/default/test/test_tool_code_write_coverage.exe`
- `env DUNE_CACHE=disabled opam exec -- dune exec --root . ./test/test_tool_code_write_coverage.exe`

Note: the first wrapper-based combined test build was interrupted after Dune sat in a childless sleep state holding only the worktree `_build/.lock`; the direct Dune target builds above completed and the relevant tests passed.
