### PR TITLE
refactor: split keeper cascade routing

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -151,6 +151,7 @@
   keeper_turn_driver_helpers
   keeper_turn_driver_try_provider
   keeper_turn_driver_wrappers
+  keeper_turn_cascade_budget_routing
   keeper_exec_context
   keeper_guards
   keeper_turn_setup

--- a/lib/dune
+++ b/lib/dune
@@ -171,6 +171,7 @@
   worker_container
   worker_container_runners
   ;; keeper_memory sub-modules
+  keeper_memory_policy_summary_filter
   keeper_memory_policy
   keeper_memory_bank
   keeper_memory_llm_summary

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -492,86 +492,8 @@ let cap_continuity_summary_text
    near-identical one. Strip backward-looking fields at prompt assembly so the
    LLM sees only forward-looking context (Goal, Next plan, Next, OpenQuestions,
    Constraints). Persistence still retains the full summary. *)
-let filter_forward_looking_summary (summary : string) : string =
-  let backward_labels = [ "Done"; "Progress"; "Decisions" ] in
-  let inert_next_markers =
-    [
-      "stay_silent";
-      "stay silent";
-      "wait for new actionable work";
-      "nothing to do";
-      "no actionable work";
-      "do nothing";
-      "all non-destructive actions exhausted";
-      "대기 유지";
-      "침묵";
-      "할 일 없음";
-      "아무것도 하지";
-    ]
-  in
-  let stale_tool_surface_markers =
-    [
-      "masc_* only";
-      "mcp__masc__ only";
-      "no keeper_* tools";
-      "no keeper tools";
-      "tool surface: masc";
-      "tool-surface: masc";
-    ]
-  in
-  let strip_labeled_value ~prefixes line =
-    let trimmed = String.trim line in
-    let rec loop = function
-      | [] -> None
-      | prefix :: rest -> (
-          match strip_prefix_ci ~prefix trimmed with
-          | Some value -> Some value
-          | None -> loop rest)
-    in
-    loop prefixes
-  in
-  let is_backward_line line =
-    let trimmed = String.trim line in
-    List.exists
-      (fun label ->
-        let prefix = label ^ ":" in
-        String.starts_with trimmed ~prefix)
-      backward_labels
-  in
-  let is_inert_next_line line =
-    match strip_labeled_value ~prefixes:[ "Next plan:"; "Next:" ] line with
-    | None -> false
-    | Some value ->
-        let payload = String.trim value in
-        payload <> ""
-        && List.exists
-             (fun marker -> String_util.contains_substring_ci payload marker)
-             inert_next_markers
-  in
-  let is_stale_tool_surface_line line =
-    let payload = String.trim line in
-    String_util.contains_substring_ci payload "tool"
-    && (List.exists
-          (fun marker -> String_util.contains_substring_ci payload marker)
-          stale_tool_surface_markers
-        || (String_util.contains_substring_ci payload "only"
-            && (String_util.contains_substring_ci payload "allowed tool"
-                || String_util.contains_substring_ci payload "available tool"
-                || String_util.contains_substring_ci payload "visible tool"
-                || String_util.contains_substring_ci payload "tool surface"
-                || String_util.contains_substring_ci payload "tool-surface")))
-  in
-  let kept =
-    summary
-    |> String.split_on_char '\n'
-    |> List.filter (fun line -> not (is_backward_line line))
-    |> List.filter (fun line -> not (is_inert_next_line line))
-    |> List.filter (fun line -> not (is_stale_tool_surface_line line))
-    |> List.filter (fun line -> String.trim line <> "")
-  in
-  match kept with
-  | [] -> ""
-  | _ -> String.concat "\n" kept
+let filter_forward_looking_summary =
+  Keeper_memory_policy_summary_filter.filter_forward_looking_summary
 
 let progress_markdown_of_snapshot
     ?generation

--- a/lib/keeper/keeper_memory_policy_summary_filter.ml
+++ b/lib/keeper/keeper_memory_policy_summary_filter.ml
@@ -1,0 +1,97 @@
+(** Forward-looking continuity summary filtering.
+
+    This module is deliberately string-only: it strips stale or backward-looking
+    rendered summary lines before prompt assembly without depending on the
+    keeper snapshot record type. *)
+
+let strip_prefix_ci ~(prefix : string) (s : string) : string option =
+  let s = String.trim s in
+  let plen = String.length prefix in
+  if String.length s < plen then None
+  else
+    let head = String.sub s 0 plen |> String.lowercase_ascii in
+    if head = String.lowercase_ascii prefix then
+      Some (String.sub s plen (String.length s - plen) |> String.trim)
+    else
+      None
+
+let filter_forward_looking_summary (summary : string) : string =
+  let backward_labels = [ "Done"; "Progress"; "Decisions" ] in
+  let inert_next_markers =
+    [
+      "stay_silent";
+      "stay silent";
+      "wait for new actionable work";
+      "nothing to do";
+      "no actionable work";
+      "do nothing";
+      "all non-destructive actions exhausted";
+      "대기 유지";
+      "침묵";
+      "할 일 없음";
+      "아무것도 하지";
+    ]
+  in
+  let stale_tool_surface_markers =
+    [
+      "masc_* only";
+      "mcp__masc__ only";
+      "no keeper_* tools";
+      "no keeper tools";
+      "tool surface: masc";
+      "tool-surface: masc";
+    ]
+  in
+  let strip_labeled_value ~prefixes line =
+    let trimmed = String.trim line in
+    let rec loop = function
+      | [] -> None
+      | prefix :: rest -> (
+          match strip_prefix_ci ~prefix trimmed with
+          | Some value -> Some value
+          | None -> loop rest)
+    in
+    loop prefixes
+  in
+  let is_backward_line line =
+    let trimmed = String.trim line in
+    List.exists
+      (fun label ->
+        let prefix = label ^ ":" in
+        String.starts_with trimmed ~prefix)
+      backward_labels
+  in
+  let is_inert_next_line line =
+    match strip_labeled_value ~prefixes:[ "Next plan:"; "Next:" ] line with
+    | None -> false
+    | Some value ->
+        let payload = String.trim value in
+        payload <> ""
+        && List.exists
+             (fun marker -> String_util.contains_substring_ci payload marker)
+             inert_next_markers
+  in
+  let is_stale_tool_surface_line line =
+    let payload = String.trim line in
+    String_util.contains_substring_ci payload "tool"
+    && (List.exists
+          (fun marker -> String_util.contains_substring_ci payload marker)
+          stale_tool_surface_markers
+        || (String_util.contains_substring_ci payload "only"
+            && (String_util.contains_substring_ci payload "allowed tool"
+                || String_util.contains_substring_ci payload "available tool"
+                || String_util.contains_substring_ci payload "visible tool"
+                || String_util.contains_substring_ci payload "tool surface"
+                || String_util.contains_substring_ci payload "tool-surface")))
+  in
+  let kept =
+    summary
+    |> String.split_on_char '\n'
+    |> List.filter (fun line -> not (is_backward_line line))
+    |> List.filter (fun line -> not (is_inert_next_line line))
+    |> List.filter (fun line -> not (is_stale_tool_surface_line line))
+    |> List.filter (fun line -> String.trim line <> "")
+  in
+  match kept with
+  | [] -> ""
+  | _ -> String.concat "\n" kept

--- a/lib/keeper/keeper_memory_policy_summary_filter.mli
+++ b/lib/keeper/keeper_memory_policy_summary_filter.mli
@@ -1,0 +1,6 @@
+(** Forward-looking continuity summary filtering.
+
+    Private helper for {!Keeper_memory_policy}; keeps the public API stable
+    while isolating prompt-facing string scrub rules from snapshot parsing. *)
+
+val filter_forward_looking_summary : string -> string

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -16,148 +16,18 @@ type cascade_execution = {
   max_tokens : int;
 }
 
-let public_profile_name name =
-  let name = String.trim name in
-  let tier_group_prefix = "tier-group." in
-  let tier_prefix = "tier." in
-  if String.starts_with ~prefix:tier_group_prefix name then
-    String.sub name (String.length tier_group_prefix)
-      (String.length name - String.length tier_group_prefix)
-  else if String.starts_with ~prefix:tier_prefix name then
-    String.sub name (String.length tier_prefix)
-      (String.length name - String.length tier_prefix)
-  else name
+let fail_open_rotation_cascades_from_catalog =
+  Keeper_turn_cascade_budget_routing.fail_open_rotation_cascades_from_catalog
 
-let fail_open_rotation_cascades_from_catalog
-    ?(excluded_targets : string list = [])
-    ~(catalog_names : string list)
-    ~(keeper_assignable : string list)
-    () =
-  if catalog_names = [] then None
-  else
-    let excluded_targets =
-      excluded_targets |> List.map public_profile_name |> dedupe_keep_order
-    in
-    let is_reserved_default name =
-      String.equal name (Keeper_config.default_cascade_name ())
-    in
-    let is_keeper_assignable name =
-      List.exists (String.equal name) keeper_assignable
-    in
-    let is_excluded name =
-      List.exists (String.equal (public_profile_name name)) excluded_targets
-    in
-    match
-      catalog_names
-      |> List.filter (fun name ->
-             (is_reserved_default name || is_keeper_assignable name)
-             && not (is_excluded name))
-      |> dedupe_keep_order
-    with
-    | [] -> None
-    | candidates -> Some candidates
+let active_fail_open_rotation_cascades =
+  Keeper_turn_cascade_budget_routing.active_fail_open_rotation_cascades
 
-let keeper_fail_open_route_uses =
-  [
-    Keeper_cascade_profile.Keeper_turn;
-    Keeper_cascade_profile.Phase_recovery;
-    Keeper_cascade_profile.Phase_buffer;
-    Keeper_cascade_profile.Tool_required;
-  ]
+let next_fail_open_cascade_for_turn =
+  Keeper_turn_cascade_budget_routing.next_fail_open_cascade_for_turn
 
-let is_keeper_fail_open_route_use use =
-  List.exists (( = ) use) keeper_fail_open_route_uses
-
-let route_target_for_use use =
-  try Some (Keeper_cascade_profile.cascade_name_for_use use |> public_profile_name)
-  with Failure _ -> None
-
-let active_fail_open_excluded_route_targets () =
-  let keeper_route_targets =
-    keeper_fail_open_route_uses
-    |> List.filter_map route_target_for_use
-    |> dedupe_keep_order
-  in
-  Cascade_routes.all_logical_uses
-  |> List.filter (fun use -> not (is_keeper_fail_open_route_use use))
-  |> List.filter_map route_target_for_use
-  |> List.filter (fun target ->
-         not (List.exists (String.equal target) keeper_route_targets))
-  |> dedupe_keep_order
-
-let active_fail_open_rotation_cascades () =
-  fail_open_rotation_cascades_from_catalog
-    ~excluded_targets:(active_fail_open_excluded_route_targets ())
-    ~catalog_names:(Keeper_cascade_profile.catalog_names ())
-    ~keeper_assignable:(Keeper_cascade_profile.keeper_catalog_names ())
-    ()
-
-let tool_required_rotation_cascade_name () =
-  try
-    Keeper_cascade_profile.cascade_name_for_use
-      Keeper_cascade_profile.Tool_required
-  with Failure _ -> Keeper_config.tool_use_strict_cascade_name
-
-let next_fail_open_cascade_for_turn
-    ?rotation_cascades
-    ~(base_cascade : string)
-    ~(effective_cascade : string)
-    ~(tool_requirement : Keeper_agent_tool_surface.tool_requirement)
-    ~(attempted_cascades : string list)
-    (err : Agent_sdk.Error.sdk_error) : EC.degraded_retry option =
-  let fallback_hint =
-    Keeper_cascade_profile.fallback_cascade_for effective_cascade
-  in
-  let rotation_cascades =
-    match tool_requirement, rotation_cascades with
-    | Keeper_agent_tool_surface.Required, Some _ ->
-      Some
-        (dedupe_keep_order
-           [ base_cascade; tool_required_rotation_cascade_name () ])
-    | _ -> rotation_cascades
-  in
-  EC.degraded_rotation_after_recoverable_error
-    ?rotation_cascades
-    ?fallback_hint
-    ~base_cascade ~effective_cascade ~tool_requirement
-    ~attempted_cascades err
-
-let sdk_error_kind = function
-  | Agent_sdk.Error.Api _ -> "api"
-  | Agent_sdk.Error.Agent _ -> "agent"
-  | Agent_sdk.Error.Mcp _ -> "mcp"
-  | Agent_sdk.Error.Config _ -> "config"
-  | Agent_sdk.Error.Serialization _ -> "serialization"
-  | Agent_sdk.Error.Io _ -> "io"
-  | Agent_sdk.Error.Orchestration _ -> "orchestration"
-  | Agent_sdk.Error.A2a _ -> "a2a"
-  | Agent_sdk.Error.Internal _ -> "internal"
-
-let record_turn_failure_stress
-    ~(meta : keeper_meta)
-    ~(is_auto_recoverable : bool)
-    ~(consecutive : int)
-    ~(threshold : int)
-    ~(err : Agent_sdk.Error.sdk_error)
-  : unit =
-  let room_id =
-    match meta.joined_room_ids with
-    | room_id :: _ -> room_id
-    | [] -> ""
-  in
-  Agent_stress.record {
-    agent_name = meta.name;
-    room_id;
-    kind =
-      Turn_failure {
-        consecutive;
-        threshold;
-        counted_toward_crash = not is_auto_recoverable;
-        recoverable = is_auto_recoverable;
-        error_kind = Some (Agent_stress.error_kind_of_string (sdk_error_kind err));
-      };
-    timestamp = Unix.gettimeofday ();
-  }
+let sdk_error_kind = Keeper_turn_cascade_budget_routing.sdk_error_kind
+let record_turn_failure_stress =
+  Keeper_turn_cascade_budget_routing.record_turn_failure_stress
 
 (* Retry guard floor: relaxed 30->15 (2026-04-27).
    Original 60s threshold (guard 30 + min 30) caused keeper cycle FAILED when

--- a/lib/keeper/keeper_turn_cascade_budget_routing.ml
+++ b/lib/keeper/keeper_turn_cascade_budget_routing.ml
@@ -1,0 +1,160 @@
+(** Fail-open cascade routing helpers for keeper turn budgeting. *)
+
+open Keeper_types
+open Keeper_exec_context
+module EC = Keeper_error_classify
+
+let public_profile_name name =
+  let name = String.trim name in
+  let tier_group_prefix = "tier-group." in
+  let tier_prefix = "tier." in
+  if String.starts_with ~prefix:tier_group_prefix name
+  then
+    String.sub
+      name
+      (String.length tier_group_prefix)
+      (String.length name - String.length tier_group_prefix)
+  else if String.starts_with ~prefix:tier_prefix name
+  then
+    String.sub
+      name
+      (String.length tier_prefix)
+      (String.length name - String.length tier_prefix)
+  else name
+
+let fail_open_rotation_cascades_from_catalog
+      ?(excluded_targets : string list = [])
+      ~(catalog_names : string list)
+      ~(keeper_assignable : string list)
+      ()
+  =
+  if catalog_names = []
+  then None
+  else (
+    let excluded_targets =
+      excluded_targets |> List.map public_profile_name |> dedupe_keep_order
+    in
+    let is_reserved_default name =
+      String.equal name (Keeper_config.default_cascade_name ())
+    in
+    let is_keeper_assignable name =
+      List.exists (String.equal name) keeper_assignable
+    in
+    let is_excluded name =
+      List.exists (String.equal (public_profile_name name)) excluded_targets
+    in
+    match
+      catalog_names
+      |> List.filter (fun name ->
+        (is_reserved_default name || is_keeper_assignable name)
+        && not (is_excluded name))
+      |> dedupe_keep_order
+    with
+    | [] -> None
+    | candidates -> Some candidates)
+
+let keeper_fail_open_route_uses =
+  [ Keeper_cascade_profile.Keeper_turn
+  ; Keeper_cascade_profile.Phase_recovery
+  ; Keeper_cascade_profile.Phase_buffer
+  ; Keeper_cascade_profile.Tool_required
+  ]
+
+let is_keeper_fail_open_route_use use =
+  List.exists (( = ) use) keeper_fail_open_route_uses
+
+let route_target_for_use use =
+  try Some (Keeper_cascade_profile.cascade_name_for_use use |> public_profile_name)
+  with
+  | Failure _ -> None
+
+let active_fail_open_excluded_route_targets () =
+  let keeper_route_targets =
+    keeper_fail_open_route_uses
+    |> List.filter_map route_target_for_use
+    |> dedupe_keep_order
+  in
+  Cascade_routes.all_logical_uses
+  |> List.filter (fun use -> not (is_keeper_fail_open_route_use use))
+  |> List.filter_map route_target_for_use
+  |> List.filter (fun target ->
+    not (List.exists (String.equal target) keeper_route_targets))
+  |> dedupe_keep_order
+
+let active_fail_open_rotation_cascades () =
+  fail_open_rotation_cascades_from_catalog
+    ~excluded_targets:(active_fail_open_excluded_route_targets ())
+    ~catalog_names:(Keeper_cascade_profile.catalog_names ())
+    ~keeper_assignable:(Keeper_cascade_profile.keeper_catalog_names ())
+    ()
+
+let tool_required_rotation_cascade_name () =
+  try
+    Keeper_cascade_profile.cascade_name_for_use Keeper_cascade_profile.Tool_required
+  with
+  | Failure _ -> Keeper_config.tool_use_strict_cascade_name
+
+let next_fail_open_cascade_for_turn
+      ?rotation_cascades
+      ~(base_cascade : string)
+      ~(effective_cascade : string)
+      ~(tool_requirement : Keeper_agent_tool_surface.tool_requirement)
+      ~(attempted_cascades : string list)
+      (err : Agent_sdk.Error.sdk_error)
+  : EC.degraded_retry option
+  =
+  let fallback_hint =
+    Keeper_cascade_profile.fallback_cascade_for effective_cascade
+  in
+  let rotation_cascades =
+    match tool_requirement, rotation_cascades with
+    | Keeper_agent_tool_surface.Required, Some _ ->
+      Some (dedupe_keep_order [ base_cascade; tool_required_rotation_cascade_name () ])
+    | _ -> rotation_cascades
+  in
+  EC.degraded_rotation_after_recoverable_error
+    ?rotation_cascades
+    ?fallback_hint
+    ~base_cascade
+    ~effective_cascade
+    ~tool_requirement
+    ~attempted_cascades
+    err
+
+let sdk_error_kind = function
+  | Agent_sdk.Error.Api _ -> "api"
+  | Agent_sdk.Error.Agent _ -> "agent"
+  | Agent_sdk.Error.Mcp _ -> "mcp"
+  | Agent_sdk.Error.Config _ -> "config"
+  | Agent_sdk.Error.Serialization _ -> "serialization"
+  | Agent_sdk.Error.Io _ -> "io"
+  | Agent_sdk.Error.Orchestration _ -> "orchestration"
+  | Agent_sdk.Error.A2a _ -> "a2a"
+  | Agent_sdk.Error.Internal _ -> "internal"
+
+let record_turn_failure_stress
+      ~(meta : keeper_meta)
+      ~(is_auto_recoverable : bool)
+      ~(consecutive : int)
+      ~(threshold : int)
+      ~(err : Agent_sdk.Error.sdk_error)
+  : unit
+  =
+  let room_id =
+    match meta.joined_room_ids with
+    | room_id :: _ -> room_id
+    | [] -> ""
+  in
+  Agent_stress.record
+    { agent_name = meta.name
+    ; room_id
+    ; kind =
+        Turn_failure
+          { consecutive
+          ; threshold
+          ; counted_toward_crash = not is_auto_recoverable
+          ; recoverable = is_auto_recoverable
+          ; error_kind = Some (Agent_stress.error_kind_of_string (sdk_error_kind err))
+          }
+    ; timestamp = Unix.gettimeofday ()
+    }

--- a/lib/keeper/keeper_turn_cascade_budget_routing.mli
+++ b/lib/keeper/keeper_turn_cascade_budget_routing.mli
@@ -1,0 +1,31 @@
+(** Fail-open cascade routing helpers for keeper turn budgeting. *)
+
+module EC = Keeper_error_classify
+
+val fail_open_rotation_cascades_from_catalog
+  :  ?excluded_targets:string list
+  -> catalog_names:string list
+  -> keeper_assignable:string list
+  -> unit
+  -> string list option
+
+val active_fail_open_rotation_cascades : unit -> string list option
+
+val next_fail_open_cascade_for_turn
+  :  ?rotation_cascades:string list
+  -> base_cascade:string
+  -> effective_cascade:string
+  -> tool_requirement:Keeper_agent_tool_surface.tool_requirement
+  -> attempted_cascades:string list
+  -> Agent_sdk.Error.sdk_error
+  -> EC.degraded_retry option
+
+val sdk_error_kind : Agent_sdk.Error.sdk_error -> string
+
+val record_turn_failure_stress
+  :  meta:Keeper_types.keeper_meta
+  -> is_auto_recoverable:bool
+  -> consecutive:int
+  -> threshold:int
+  -> err:Agent_sdk.Error.sdk_error
+  -> unit


### PR DESCRIPTION
## Summary
- Splits keeper fail-open cascade routing helpers into private module `Keeper_turn_cascade_budget_routing`.
- Keeps `Keeper_turn_cascade_budget` public functions as aliases so existing tests and `Keeper_unified_turn` imports remain unchanged.
- Reduces `lib/keeper/keeper_turn_cascade_budget.ml` from 1020 lines to 890 lines.

## Stack
Base: `codex/godfile-zero-05-sse-jsonrpc`

## Validation
- `ocamlformat --check lib/keeper/keeper_turn_cascade_budget.ml lib/keeper/keeper_turn_cascade_budget_routing.ml lib/keeper/keeper_turn_cascade_budget_routing.mli`
- `git diff --check`
- `bash scripts/lint/godfile-size-regression.sh`
- `scripts/ocaml-structure-ratchet.sh --print`

Focused Dune validation was deferred because the shared local Dune lock was held by other active worktrees during the available window.
