### PR TITLE
refactor: share JSONL writer adapter

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -69,27 +69,6 @@ let create ~base_dir ?mutex ?retention_days () =
 
 let base_dir t = t.base_dir
 
-(* ── Date helpers ─────────────────────────────────────── *)
-
-(** Current UTC date decomposed into (month_dir, day_file). *)
-let today_parts () =
-  let open Unix in
-  let tm = gmtime (gettimeofday ()) in
-  let month = Printf.sprintf "%04d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1) in
-  let day = Printf.sprintf "%02d.jsonl" tm.tm_mday in
-  (month, day)
-
-let today_key () =
-  let month, day = today_parts () in
-  month ^ "/" ^ day
-
-(** Full path for today's JSONL file, creating dirs as needed. *)
-let today_path t =
-  let month, day = today_parts () in
-  let dir = Filename.concat t.base_dir month in
-  Fs_compat.mkdir_p dir;
-  Filename.concat dir day
-
 (** Parse ["YYYY-MM-DD"] into [("YYYY-MM", "DD")].
     Returns [None] for malformed strings. *)
 let parse_date s =
@@ -267,12 +246,12 @@ let append_inner t json =
      and fresh-fd-per-call. The PR-5 (#15928) inline [atomic_append_jsonl]
      was a pre-emptive duplicate of that guarantee — removed here. *)
   Eio.Mutex.use_ro mutex (fun () ->
-    let path = today_path t in
-    Fs_compat.append_jsonl path json;
+    let dated = Jsonl_writer.dated_path_now ~base_dir:t.base_dir in
+    Jsonl_writer.append_jsonl ~path:dated.path json;
     match t.retention_days with
     | None -> ()
     | Some days ->
-      let today = today_key () in
+      let today = dated.month_dir ^ "/" ^ dated.day_file in
       if not (Option.equal String.equal (Atomic.get t.last_prune_day) (Some today))
       then begin
         ignore (prune_unlocked t ~days : int);

--- a/lib/dated_jsonl/dune
+++ b/lib/dated_jsonl/dune
@@ -7,4 +7,4 @@
  ; live in the single (flags ...) stanza so the effective warning mask is
  ; not split across (flags)/(ocamlc_flags)/(ocamlopt_flags).
  (flags (:standard -w -32 -w +4))
- (libraries fs_compat eio unix yojson))
+ (libraries fs_compat jsonl_writer eio unix yojson))

--- a/lib/jsonl_writer/dune
+++ b/lib/jsonl_writer/dune
@@ -1,0 +1,8 @@
+(include_subdirs no)
+
+(library
+ (name jsonl_writer)
+ (public_name masc_mcp.jsonl_writer)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
+ (libraries fs_compat unix yojson))

--- a/lib/jsonl_writer/jsonl_writer.ml
+++ b/lib/jsonl_writer/jsonl_writer.ml
@@ -1,0 +1,30 @@
+type dated_path =
+  { base_dir : string
+  ; month_dir : string
+  ; day_file : string
+  ; path : string
+  }
+
+let ensure_dir = Fs_compat.mkdir_p
+
+let dated_path ~base_dir ~ts =
+  let tm = Unix.gmtime ts in
+  let month_dir =
+    Printf.sprintf "%04d-%02d" (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1)
+  in
+  let day_file = Printf.sprintf "%02d.jsonl" tm.Unix.tm_mday in
+  let path = Filename.concat (Filename.concat base_dir month_dir) day_file in
+  { base_dir; month_dir; day_file; path }
+
+let dated_path_now ~base_dir =
+  (* NDT-OK: this helper is the runtime write boundary for date-split JSONL;
+     deterministic callers use [dated_path ~ts] with an explicit timestamp. *)
+  dated_path ~base_dir ~ts:(Unix.gettimeofday ())
+
+let append_jsonl ~path json =
+  Fs_compat.append_jsonl path json
+
+let append_dated_jsonl ~base_dir ~ts json =
+  let dated = dated_path ~base_dir ~ts in
+  append_jsonl ~path:dated.path json;
+  dated

--- a/lib/jsonl_writer/jsonl_writer.mli
+++ b/lib/jsonl_writer/jsonl_writer.mli
@@ -1,0 +1,29 @@
+(** Shared JSONL writer primitives.
+
+    This module owns the low-level path layout and append primitive shared by
+    date-split JSONL stores. Domain modules still own their schemas, retention
+    policy, read models, and hash-chain semantics. *)
+
+type dated_path =
+  { base_dir : string
+  ; month_dir : string
+  ; day_file : string
+  ; path : string
+  }
+
+val ensure_dir : string -> unit
+(** Create a directory and its parents when missing. *)
+
+val dated_path : base_dir:string -> ts:float -> dated_path
+(** Return the [base_dir/YYYY-MM/DD.jsonl] path for a UTC timestamp. *)
+
+val dated_path_now : base_dir:string -> dated_path
+(** Return the dated path for the current UTC day. *)
+
+val append_jsonl : path:string -> Yojson.Safe.t -> unit
+(** Append one JSON value as a JSONL row using the common per-path writer. *)
+
+val append_dated_jsonl :
+  base_dir:string -> ts:float -> Yojson.Safe.t -> dated_path
+(** Append one JSON value to the timestamp-selected dated path and return the
+    path that was written. *)

--- a/lib/shared_audit/dune
+++ b/lib/shared_audit/dune
@@ -5,4 +5,4 @@
  (public_name masc_mcp.shared_audit)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags (:standard -w +4))
- (libraries unix yojson digestif digestif.c))
+ (libraries unix yojson digestif digestif.c jsonl_writer))

--- a/lib/shared_audit/store.ml
+++ b/lib/shared_audit/store.ml
@@ -3,24 +3,6 @@ type t = {
   mutable latest_hash : string option;
 }
 
-let format_path ~base_dir ~ts =
-  let tm = Unix.gmtime ts in
-  let yyyy_mm = Printf.sprintf "%04d-%02d" (tm.Unix.tm_year + 1900)
-                  (tm.Unix.tm_mon + 1)
-  in
-  let dd = Printf.sprintf "%02d" tm.Unix.tm_mday in
-  Filename.concat (Filename.concat base_dir yyyy_mm) (dd ^ ".jsonl")
-
-let rec mkdir_p dir =
-  if Sys.file_exists dir then ()
-  else begin
-    mkdir_p (Filename.dirname dir);
-    try Unix.mkdir dir 0o755
-    with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
-  end
-
-let ensure_dir_exists path = mkdir_p (Filename.dirname path)
-
 let parse_jsonl_line line =
   try Yojson.Safe.from_string line |> Envelope.of_json with
   | Yojson.Json_error msg -> Error msg
@@ -76,7 +58,7 @@ let load_latest_hash ~base_dir =
     find_in_months months
 
 let create ~base_dir =
-  if not (Sys.file_exists base_dir) then mkdir_p base_dir;
+  if not (Sys.file_exists base_dir) then Jsonl_writer.ensure_dir base_dir;
   let latest_hash = load_latest_hash ~base_dir in
   { base_dir; latest_hash }
 
@@ -84,12 +66,12 @@ let base_dir t = t.base_dir
 
 let append t ~category ~payload =
   let entry = Envelope.make ~category ~payload ~prev_hash:t.latest_hash in
-  let path = format_path ~base_dir:t.base_dir ~ts:entry.ts in
-  ensure_dir_exists path;
-  let oc = open_out_gen [Open_append; Open_creat; Open_wronly] 0o644 path in
-  output_string oc (Yojson.Safe.to_string (Envelope.to_json entry));
-  output_char oc '\n';
-  close_out oc;
+  ignore
+    (Jsonl_writer.append_dated_jsonl
+       ~base_dir:t.base_dir
+       ~ts:entry.ts
+       (Envelope.to_json entry)
+      : Jsonl_writer.dated_path);
   t.latest_hash <- Some (Envelope.hash_for_chain entry);
   entry
 

--- a/test/jsonl_writer/dune
+++ b/test/jsonl_writer/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_jsonl_writer)
+ (libraries alcotest jsonl_writer yojson unix))

--- a/test/jsonl_writer/test_jsonl_writer.ml
+++ b/test/jsonl_writer/test_jsonl_writer.ml
@@ -1,0 +1,74 @@
+open Alcotest
+
+let unique_temp_dir prefix =
+  let base = Filename.get_temp_dir_name () in
+  let suffix = Printf.sprintf "%s_%d_%d" prefix (Unix.getpid ()) (Random.bits ()) in
+  let dir = Filename.concat base suffix in
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm_rf path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path
+        |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  try rm_rf dir with
+  | _ -> ()
+
+let read_lines path =
+  let ic = open_in path in
+  Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+    let rec loop acc =
+      match input_line ic with
+      | line -> loop (line :: acc)
+      | exception End_of_file -> List.rev acc
+    in
+    loop [])
+
+let test_dated_path_uses_utc_layout () =
+  let dated = Jsonl_writer.dated_path ~base_dir:"/tmp/audit" ~ts:0.0 in
+  check string "base_dir" "/tmp/audit" dated.base_dir;
+  check string "month_dir" "1970-01" dated.month_dir;
+  check string "day_file" "01.jsonl" dated.day_file;
+  check string "path" "/tmp/audit/1970-01/01.jsonl" dated.path
+
+let test_append_dated_jsonl_writes_one_parseable_row () =
+  let dir = unique_temp_dir "jsonl_writer_dated" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let dated =
+      Jsonl_writer.append_dated_jsonl
+        ~base_dir:dir
+        ~ts:0.0
+        (`Assoc [ "kind", `String "adapter"; "n", `Int 1 ])
+    in
+    check string "month_dir" "1970-01" dated.month_dir;
+    check string "day_file" "01.jsonl" dated.day_file;
+    let lines = read_lines dated.path in
+    check int "one row" 1 (List.length lines);
+    match lines with
+    | [ line ] ->
+      let json = Yojson.Safe.from_string line in
+      check bool "round-trip"
+        true
+        (Yojson.Safe.equal
+           (`Assoc [ "kind", `String "adapter"; "n", `Int 1 ])
+           json)
+    | _ -> fail "expected exactly one JSONL row")
+
+let () =
+  Random.self_init ();
+  run
+    "Jsonl_writer"
+    [
+      ( "dated path",
+        [ test_case "uses UTC YYYY-MM/DD.jsonl layout" `Quick
+            test_dated_path_uses_utc_layout
+        ; test_case "append_dated_jsonl writes one parseable row" `Quick
+            test_append_dated_jsonl_writes_one_parseable_row
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Implements the first code-level migration slice for MASC `task-383`
under `goal-refactor-jsonl-substrate-20260518`.

- Adds a narrow `Jsonl_writer` adapter for the shared
  `base_dir/YYYY-MM/DD.jsonl` path layout and JSONL append primitive.
- Moves `Dated_jsonl.append` onto the adapter for path calculation and append.
- Moves `Shared_audit.Store.append` off its direct `open_out_gen` writer and
  onto the same dated JSONL adapter while preserving envelope hash-chain logic.
- Adds focused adapter tests for UTC date layout and parseable JSONL output.

This intentionally leaves store-specific semantics in their current modules:
`Dated_jsonl` still owns retention/read/range behavior, and `Shared_audit`
still owns envelope chaining and verification.

## Verification

- `scripts/dune-local.sh build test/jsonl_writer/test_jsonl_writer.exe test/shared_audit/test_shared_audit.exe test/test_dated_jsonl.exe`
- `./_build/default/test/jsonl_writer/test_jsonl_writer.exe`
- `./_build/default/test/shared_audit/test_shared_audit.exe`
- `./_build/default/test/test_dated_jsonl.exe`
- `ocamlformat --check lib/jsonl_writer/jsonl_writer.ml lib/jsonl_writer/jsonl_writer.mli lib/dated_jsonl/dated_jsonl.ml lib/shared_audit/store.ml test/jsonl_writer/test_jsonl_writer.ml`
- `git diff --cached --check`

## Notes

The initial MASC transition attempt for `task-383` hit a transient MCP
transport handshake error. GitHub evidence is attached here and will be
mirrored back to #16082.
