### PR TITLE
refactor: split keeper memory summary filter

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -171,6 +171,7 @@
   worker_container
   worker_container_runners
   ;; keeper_memory sub-modules
+  keeper_memory_policy_summary_filter
   keeper_memory_policy
   keeper_memory_bank
   keeper_memory_llm_summary

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -492,86 +492,8 @@ let cap_continuity_summary_text
    near-identical one. Strip backward-looking fields at prompt assembly so the
    LLM sees only forward-looking context (Goal, Next plan, Next, OpenQuestions,
    Constraints). Persistence still retains the full summary. *)
-let filter_forward_looking_summary (summary : string) : string =
-  let backward_labels = [ "Done"; "Progress"; "Decisions" ] in
-  let inert_next_markers =
-    [
-      "stay_silent";
-      "stay silent";
-      "wait for new actionable work";
-      "nothing to do";
-      "no actionable work";
-      "do nothing";
-      "all non-destructive actions exhausted";
-      "대기 유지";
-      "침묵";
-      "할 일 없음";
-      "아무것도 하지";
-    ]
-  in
-  let stale_tool_surface_markers =
-    [
-      "masc_* only";
-      "mcp__masc__ only";
-      "no keeper_* tools";
-      "no keeper tools";
-      "tool surface: masc";
-      "tool-surface: masc";
-    ]
-  in
-  let strip_labeled_value ~prefixes line =
-    let trimmed = String.trim line in
-    let rec loop = function
-      | [] -> None
-      | prefix :: rest -> (
-          match strip_prefix_ci ~prefix trimmed with
-          | Some value -> Some value
-          | None -> loop rest)
-    in
-    loop prefixes
-  in
-  let is_backward_line line =
-    let trimmed = String.trim line in
-    List.exists
-      (fun label ->
-        let prefix = label ^ ":" in
-        String.starts_with trimmed ~prefix)
-      backward_labels
-  in
-  let is_inert_next_line line =
-    match strip_labeled_value ~prefixes:[ "Next plan:"; "Next:" ] line with
-    | None -> false
-    | Some value ->
-        let payload = String.trim value in
-        payload <> ""
-        && List.exists
-             (fun marker -> String_util.contains_substring_ci payload marker)
-             inert_next_markers
-  in
-  let is_stale_tool_surface_line line =
-    let payload = String.trim line in
-    String_util.contains_substring_ci payload "tool"
-    && (List.exists
-          (fun marker -> String_util.contains_substring_ci payload marker)
-          stale_tool_surface_markers
-        || (String_util.contains_substring_ci payload "only"
-            && (String_util.contains_substring_ci payload "allowed tool"
-                || String_util.contains_substring_ci payload "available tool"
-                || String_util.contains_substring_ci payload "visible tool"
-                || String_util.contains_substring_ci payload "tool surface"
-                || String_util.contains_substring_ci payload "tool-surface")))
-  in
-  let kept =
-    summary
-    |> String.split_on_char '\n'
-    |> List.filter (fun line -> not (is_backward_line line))
-    |> List.filter (fun line -> not (is_inert_next_line line))
-    |> List.filter (fun line -> not (is_stale_tool_surface_line line))
-    |> List.filter (fun line -> String.trim line <> "")
-  in
-  match kept with
-  | [] -> ""
-  | _ -> String.concat "\n" kept
+let filter_forward_looking_summary =
+  Keeper_memory_policy_summary_filter.filter_forward_looking_summary
 
 let progress_markdown_of_snapshot
     ?generation

--- a/lib/keeper/keeper_memory_policy_summary_filter.ml
+++ b/lib/keeper/keeper_memory_policy_summary_filter.ml
@@ -1,0 +1,97 @@
+(** Forward-looking continuity summary filtering.
+
+    This module is deliberately string-only: it strips stale or backward-looking
+    rendered summary lines before prompt assembly without depending on the
+    keeper snapshot record type. *)
+
+let strip_prefix_ci ~(prefix : string) (s : string) : string option =
+  let s = String.trim s in
+  let plen = String.length prefix in
+  if String.length s < plen then None
+  else
+    let head = String.sub s 0 plen |> String.lowercase_ascii in
+    if head = String.lowercase_ascii prefix then
+      Some (String.sub s plen (String.length s - plen) |> String.trim)
+    else
+      None
+
+let filter_forward_looking_summary (summary : string) : string =
+  let backward_labels = [ "Done"; "Progress"; "Decisions" ] in
+  let inert_next_markers =
+    [
+      "stay_silent";
+      "stay silent";
+      "wait for new actionable work";
+      "nothing to do";
+      "no actionable work";
+      "do nothing";
+      "all non-destructive actions exhausted";
+      "대기 유지";
+      "침묵";
+      "할 일 없음";
+      "아무것도 하지";
+    ]
+  in
+  let stale_tool_surface_markers =
+    [
+      "masc_* only";
+      "mcp__masc__ only";
+      "no keeper_* tools";
+      "no keeper tools";
+      "tool surface: masc";
+      "tool-surface: masc";
+    ]
+  in
+  let strip_labeled_value ~prefixes line =
+    let trimmed = String.trim line in
+    let rec loop = function
+      | [] -> None
+      | prefix :: rest -> (
+          match strip_prefix_ci ~prefix trimmed with
+          | Some value -> Some value
+          | None -> loop rest)
+    in
+    loop prefixes
+  in
+  let is_backward_line line =
+    let trimmed = String.trim line in
+    List.exists
+      (fun label ->
+        let prefix = label ^ ":" in
+        String.starts_with trimmed ~prefix)
+      backward_labels
+  in
+  let is_inert_next_line line =
+    match strip_labeled_value ~prefixes:[ "Next plan:"; "Next:" ] line with
+    | None -> false
+    | Some value ->
+        let payload = String.trim value in
+        payload <> ""
+        && List.exists
+             (fun marker -> String_util.contains_substring_ci payload marker)
+             inert_next_markers
+  in
+  let is_stale_tool_surface_line line =
+    let payload = String.trim line in
+    String_util.contains_substring_ci payload "tool"
+    && (List.exists
+          (fun marker -> String_util.contains_substring_ci payload marker)
+          stale_tool_surface_markers
+        || (String_util.contains_substring_ci payload "only"
+            && (String_util.contains_substring_ci payload "allowed tool"
+                || String_util.contains_substring_ci payload "available tool"
+                || String_util.contains_substring_ci payload "visible tool"
+                || String_util.contains_substring_ci payload "tool surface"
+                || String_util.contains_substring_ci payload "tool-surface")))
+  in
+  let kept =
+    summary
+    |> String.split_on_char '\n'
+    |> List.filter (fun line -> not (is_backward_line line))
+    |> List.filter (fun line -> not (is_inert_next_line line))
+    |> List.filter (fun line -> not (is_stale_tool_surface_line line))
+    |> List.filter (fun line -> String.trim line <> "")
+  in
+  match kept with
+  | [] -> ""
+  | _ -> String.concat "\n" kept

--- a/lib/keeper/keeper_memory_policy_summary_filter.mli
+++ b/lib/keeper/keeper_memory_policy_summary_filter.mli
@@ -1,0 +1,6 @@
+(** Forward-looking continuity summary filtering.
+
+    Private helper for {!Keeper_memory_policy}; keeps the public API stable
+    while isolating prompt-facing string scrub rules from snapshot parsing. *)
+
+val filter_forward_looking_summary : string -> string


### PR DESCRIPTION
Stack slice 7 for godfile-zero decomposition.\n\nChanges:\n- Extract forward-looking continuity summary filtering into private Keeper_memory_policy_summary_filter.\n- Keep Keeper_memory_policy.filter_forward_looking_summary as the public alias.\n- Reduce lib/keeper/keeper_memory_policy.ml from 1030 to 952 lines.\n\nValidation:\n- ocamlformat --check lib/keeper/keeper_memory_policy.ml lib/keeper/keeper_memory_policy_summary_filter.ml lib/keeper/keeper_memory_policy_summary_filter.mli\n- git diff --check\n- bash scripts/lint/godfile-size-regression.sh\n- scripts/ocaml-structure-ratchet.sh --print\n\nDeferred:\n- scripts/dune-local.sh build lib/masc_mcp.cma test/test_continuity_forward_filter.exe was blocked by shared /tmp/me-dune-local.lock held by another worktree; CI check is expected to provide compile coverage.