### PR TITLE
fix(keeper): preflight docker mount source diagnostics

### DIFF
--- a/.ci/path-ssot-allowlist.txt
+++ b/.ci/path-ssot-allowlist.txt
@@ -28,6 +28,11 @@ lib/keeper/keeper_egress_audit.ml:54
 let default_local_path id = Filename.concat ".masc/repos" id
 Option.value ~default:(Filename.concat ".masc/repos" id)
 
+# Config_dir_resolver is the SSOT itself; these comment examples document the
+# bypass pattern the audit forbids outside this module.
+helpers instead of [Filename.concat base_path ".masc/..."] string-literal
+Layout SSOT: callers stop computing [Filename.concat base_path ".masc/X"]
+
 # Self-reference inside the audit script and RFC text.
 scripts/audit-path-ssot.sh
 docs/rfc/RFC-0121-config-dir-resolution-single-active-root.md

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 401 unique knobs across 8 modules.
+**Total**: 401 unique knobs across 9 modules.
 
-**Typed getter classification**: 6/236 tagged (`operator`: 6, `algorithm`: 0, `unclassified`: 230).
+**Typed getter classification**: 26/236 tagged (`operator`: 26, `algorithm`: 0, `unclassified`: 210).
 
 ## Env_config_core (30 knobs; typed classification 0/7)
 
@@ -99,19 +99,19 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 52 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 | `MASC_SSE_KEEPALIVE_SEC` | typed:float | unclassified | unclassified | 112 | SSE keepalive interval (seconds). Frequency of `: keepalive` frames on command-plane SSE streams. Clamped to >= 1.0 t... |
 
-## Env_config_keeper (106 knobs; typed classification 3/94)
+## Env_config_keeper (85 knobs; typed classification 3/74)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 360 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CASCADE_ATTEMPT_LIVENESS` | typed:string | unclassified | unclassified | 1070 |  |
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 800 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 912 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 913 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 914 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 915 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 918 |  |
-| `MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 513 | Maximum time a proactive keeper will wait in the MASC admission queue before abandoning the current OAS attempt. With... |
+| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 226 | Alert dedup window, clamped to >= 5s. Default: 60. |
+| `MASC_CASCADE_ATTEMPT_LIVENESS` | typed:string | unclassified | unclassified | 936 |  |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 666 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 778 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 779 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 780 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 781 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 784 |  |
+| `MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 379 | Maximum time a proactive keeper will wait in the MASC admission queue before abandoning the current OAS attempt. With... |
 | `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | unclassified | unclassified | 108 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | n/a | n/a | 105 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_HEARTH` | typed:string | unclassified | unclassified | 111 |  |
@@ -129,18 +129,11 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_ALERT_SLACK_DM_USER_ID` | typed:string | unclassified | unclassified | 127 |  |
 | `MASC_KEEPER_ALERT_SLACK_ENABLED` | feature_flag | n/a | n/a | 118 | Slack fanout configuration |
 | `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 120 | Slack fanout configuration |
-| `MASC_KEEPER_ALIVE_BUT_STUCK_DEDUP_TTL_SEC` | typed:float | unclassified | unclassified | 271 | Per-keeper dedup window (seconds): once a keeper is flagged the counter is incremented at most once per window, even ... |
-| `MASC_KEEPER_ALIVE_BUT_STUCK_ENABLED` | typed:bool | unclassified | unclassified | 239 | Signal for alive-but-stuck keepers (#12838) â€” keepers that are not Dead/Zombie and not paused, but whose [proactive... |
-| `MASC_KEEPER_ALIVE_BUT_STUCK_RECOVERY_ENABLED` | typed:bool | unclassified | unclassified | 247 | Queue a bounded recovery wakeup when [alive_but_stuck_scan] emits. The recovery uses the Event Layer queue plus [fibe... |
-| `MASC_KEEPER_ALIVE_BUT_STUCK_STALL_FLOOR_SEC` | typed:float | unclassified | unclassified | 264 | Hard floor (seconds) so keepers with very small cooldowns are not flagged after a few minutes of legitimate quiet.  T... |
-| `MASC_KEEPER_ALIVE_BUT_STUCK_STALL_MULTIPLIER` | typed:int | unclassified | unclassified | 254 | Multiplier on the keeper's own [proactive.cooldown_sec] before a stalled keeper is flagged.  Default: 10 (10 cooldown... |
-| `MASC_KEEPER_AUTONOMOUS_QUEUE_POLL_SEC` | typed:float | unclassified | unclassified | 308 | Autonomous-turn semaphore queue poll interval in seconds. Polled inside the autonomous-turn admission loop in {!Keepe... |
-| `MASC_KEEPER_AUTONOMOUS_SLOT_WAIT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 526 | Maximum time a scheduled autonomous keeper will wait for the local keeper turn gate before skipping the cycle. Reacti... |
-| `MASC_KEEPER_AUTO_RESUME_INITIAL_SEC` | typed:float | unclassified | unclassified | 190 | Initial auto-resume backoff delay after an auto-pause (seconds). On every successive auto-pause the delay doubles, ca... |
-| `MASC_KEEPER_AUTO_RESUME_MAX_SEC` | typed:float | unclassified | unclassified | 195 | Maximum auto-resume backoff delay (seconds).  Default: 86400 (24 hours). |
-| `MASC_KEEPER_BATCH_THRESHOLD` | typed:int | unclassified | unclassified | 745 | Number of distinct keepers terminating within [batch_window_sec] before emitting a fleet batch alert. Default: 5. |
-| `MASC_KEEPER_BATCH_WINDOW_SEC` | typed:float | unclassified | unclassified | 740 | Fleet batch-termination detection window in seconds. Default: 60. |
-| `MASC_KEEPER_BOARD_DEBOUNCE_SEC` | typed:float | unclassified | unclassified | 422 | Board-reactive wakeup debounce in seconds. Prevents rapid repeated wakeups from the same board post. Default: 60.0. R... |
+| `MASC_KEEPER_AUTONOMOUS_QUEUE_POLL_SEC` | typed:float | unclassified | unclassified | 174 | Autonomous-turn semaphore queue poll interval in seconds. Polled inside the autonomous-turn admission loop in {!Keepe... |
+| `MASC_KEEPER_AUTONOMOUS_SLOT_WAIT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 392 | Maximum time a scheduled autonomous keeper will wait for the local keeper turn gate before skipping the cycle. Reacti... |
+| `MASC_KEEPER_BATCH_THRESHOLD` | typed:int | unclassified | unclassified | 611 | Number of distinct keepers terminating within [batch_window_sec] before emitting a fleet batch alert. Default: 5. |
+| `MASC_KEEPER_BATCH_WINDOW_SEC` | typed:float | unclassified | unclassified | 606 | Fleet batch-termination detection window in seconds. Default: 60. |
+| `MASC_KEEPER_BOARD_DEBOUNCE_SEC` | typed:float | unclassified | unclassified | 288 | Board-reactive wakeup debounce in seconds. Prevents rapid repeated wakeups from the same board post. Default: 60.0. R... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
@@ -148,67 +141,79 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 966 | Comma-separated provider kind allowlist for every keeper cascade call. Values are OAS [Provider_config.string_of_prov... |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 640 | Stdout-idle timeout for CLI subprocess transports (Kimi CLI today; Claude Code / Gemini CLI / Codex CLI need an OAS u... |
-| `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 297 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
-| `MASC_KEEPER_DEAD_TTL_SEC` | typed:float | unclassified | unclassified | 175 | Dead tombstone TTL: seconds before Dead entries are cleaned up |
-| `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 316 | Enable keeper debug logging. Default: false. |
-| `MASC_KEEPER_DEGRADED_RETRY_SLOT_PHASE_BUDGET_SEC` | typed:float | Timeouts | operator | 1044 | Productive slot-phase budget (seconds).  PR #13120: when a cascade returns a recoverable error after the keeper has a... |
-| `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 322 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_DOCKER_CONTAINER` | typed:string | unclassified | unclassified | 852 | Docker container name for keeper playground execution. Env: [MASC_KEEPER_DOCKER_CONTAINER]. Default: "keeper-playgrou... |
-| `MASC_KEEPER_DOCKER_PLAYGROUND_ROOT` | typed:string | unclassified | unclassified | 862 | Container-side root under which keeper playground bundles are mounted. Host [<base_path>/.masc/playground/<keeper>/â€... |
-| `MASC_KEEPER_DOCKER_READ` | typed:bool | unclassified | unclassified | 908 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
-| `MASC_KEEPER_DOMAIN_POOL_ENABLED` | feature_flag | n/a | n/a | 147 | Route per-keeper supervise fork through the shared [Domain_pool] (RFC-0059 PR-7-pilot) instead of staying on the main... |
-| `MASC_KEEPER_ESCALATION_THRESHOLD` | typed:int | unclassified | unclassified | 735 | Number of stale terminations within [termination_window_sec] before escalating to [Stale_termination_storm]. Default: 5. |
-| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 754 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 762 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 365 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
-| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 437 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
-| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 650 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. With tool_ch... |
-| `MASC_KEEPER_LIVENESS_RECOVERY_BACKOFF_BASE_SEC` | typed:float | unclassified | unclassified | 217 | Base backoff delay (seconds) between liveness recovery attempts per keeper. Exponential: attempt 0 = base, 1 = 2*base... |
-| `MASC_KEEPER_LIVENESS_RECOVERY_BACKOFF_MAX_SEC` | typed:float | unclassified | unclassified | 225 | Maximum backoff delay cap (seconds) for liveness recovery. Default: 3600 (1 hour). |
-| `MASC_KEEPER_LIVENESS_RECOVERY_ENABLED` | typed:bool | unclassified | unclassified | 201 | Liveness Recovery Supervisor (#12801): enable auto-recovery of Dead keepers whose root cause has cleared.  Set to fal... |
-| `MASC_KEEPER_LIVENESS_RECOVERY_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 231 | Maximum total liveness recovery attempts per keeper before giving up permanently.  Default: 5. |
-| `MASC_KEEPER_LIVENESS_RECOVERY_MIN_DEAD_SEC` | typed:float | unclassified | unclassified | 208 | Minimum time (seconds) a keeper must have been Dead before a liveness recovery attempt is made.  Allows transient roo... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 406 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 789 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 413 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 452 | Max idle turns for scheduled autonomous keeper turns. With tool_choice=Any and max_turns=50, keepers have room to exp... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 459 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger â€” more ... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 380 | Maximum seconds since last successful room heartbeat before presence sync is required again. Floor = keepalive interv... |
-| `MASC_KEEPER_MAX_TRANSIENT_RETRIES` | typed:int | unclassified | unclassified | 992 | Maximum outer-loop retries after the initial attempt. Total attempts = 1 initial + max_transient_retries. Env: [MASC_... |
+| `MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 832 | Comma-separated provider kind allowlist for every keeper cascade call. Values are OAS [Provider_config.string_of_prov... |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 506 | Stdout-idle timeout for CLI subprocess transports (Kimi CLI today; Claude Code / Gemini CLI / Codex CLI need an OAS u... |
+| `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 163 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
+| `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 182 | Enable keeper debug logging. Default: false. |
+| `MASC_KEEPER_DEGRADED_RETRY_SLOT_PHASE_BUDGET_SEC` | typed:float | Timeouts | operator | 910 | Productive slot-phase budget (seconds).  PR #13120: when a cascade returns a recoverable error after the keeper has a... |
+| `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 188 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
+| `MASC_KEEPER_DOCKER_CONTAINER` | typed:string | unclassified | unclassified | 718 | Docker container name for keeper playground execution. Env: [MASC_KEEPER_DOCKER_CONTAINER]. Default: "keeper-playgrou... |
+| `MASC_KEEPER_DOCKER_PLAYGROUND_ROOT` | typed:string | unclassified | unclassified | 728 | Container-side root under which keeper playground bundles are mounted. Host [<base_path>/.masc/playground/<keeper>/â€... |
+| `MASC_KEEPER_DOCKER_READ` | typed:bool | unclassified | unclassified | 774 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
+| `MASC_KEEPER_ESCALATION_THRESHOLD` | typed:int | unclassified | unclassified | 601 | Number of stale terminations within [termination_window_sec] before escalating to [Stale_termination_storm]. Default: 5. |
+| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 620 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 628 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 231 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
+| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 303 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
+| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 516 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. With tool_ch... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 272 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 655 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 279 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 318 | Max idle turns for scheduled autonomous keeper turns. With tool_choice=Any and max_turns=50, keepers have room to exp... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 325 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger â€” more ... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 246 | Maximum seconds since last successful room heartbeat before presence sync is required again. Floor = keepalive interv... |
+| `MASC_KEEPER_MAX_TRANSIENT_RETRIES` | typed:int | unclassified | unclassified | 858 | Maximum outer-loop retries after the initial attempt. Total attempts = 1 initial + max_transient_retries. Env: [MASC_... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 78 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 81 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` | typed:int | unclassified | unclassified | 562 | Maximum turns per single OAS Agent.run call. Keeper resumes via checkpoint in the next keepalive cycle when {!Cascade... |
-| `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS` | typed:int | unclassified | unclassified | 585 |  |
-| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 543 | Per-call timeout in seconds for a single OAS Agent.run execution. Guards against indefinite LLM response waits within... |
-| `MASC_KEEPER_PAUSED_CLEANUP_TTL_SEC` | typed:float | unclassified | unclassified | 182 | Paused keeper file TTL: seconds before stale paused keeper meta files are removed from disk. Default: 86400 (24 hours). |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 772 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
-| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 343 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
-| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 352 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
-| `MASC_KEEPER_SELF_PRESERVATION_MIN_CANDIDATES` | typed:int | unclassified | unclassified | 171 | Self-preservation: minimum crashed candidates to trigger |
-| `MASC_KEEPER_SELF_PRESERVATION_RATIO` | typed:float | unclassified | unclassified | 166 | Self-preservation: ratio of crashed keepers to trigger suppression |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 429 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
-| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 390 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
-| `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 326 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 778 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 625 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
-| `MASC_KEEPER_SUPERVISOR_BACKOFF_BASE_S` | typed:float | unclassified | unclassified | 154 | Base delay for exponential backoff between restarts (seconds) |
-| `MASC_KEEPER_SUPERVISOR_BACKOFF_MAX_S` | typed:float | unclassified | unclassified | 157 | Maximum backoff delay cap (seconds) |
-| `MASC_KEEPER_SUPERVISOR_MAX_RESTARTS` | typed:int | unclassified | unclassified | 151 | Maximum restart attempts before declaring a keeper dead |
-| `MASC_KEEPER_SUPERVISOR_SWEEP_SEC` | typed:float | unclassified | unclassified | 160 | Interval between supervisor sweep runs (seconds) |
-| `MASC_KEEPER_SYMMETRIC_SANDBOX` | typed:bool | unclassified | unclassified | 900 | Legacy RFC-0006 Phase B-1 flag. Read-side containment now follows [sandbox_profile=docker] unconditionally. This gett... |
-| `MASC_KEEPER_TERMINATION_WINDOW_SEC` | typed:float | unclassified | unclassified | 730 | Sliding window for stale-termination escalation tracking. Default: 21600 (6 hours). |
-| `MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC` | typed:float | unclassified | unclassified | 998 | Base delay (seconds) for exponential backoff. Delay at attempt [n] is [base * 2^(n-1)]. Env: [MASC_KEEPER_TRANSIENT_B... |
-| `MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC` | typed:float | unclassified | unclassified | 1004 | Hard cap on backoff delay (seconds). Env: [MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC].  Default: 4.0. |
-| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 493 | Wall-clock timeout in seconds for a single unified turn (including all retries and cascade fallbacks). Prevents indef... |
-| `MASC_KEEPER_WATCHDOG_GRACE_SEC` | typed:float | unclassified | unclassified | 724 | Grace period after fiber start before idle-stale detection activates. Prevents false positives on server restart when... |
-| `MASC_KEEPER_WATCHDOG_NOOP_THRESHOLD` | typed:int | unclassified | unclassified | 716 | Consecutive noop turns before considering the keeper stuck in a failure loop. Must be >= 2. Default: 3. |
-| `MASC_KEEPER_WATCHDOG_POLL_SEC` | typed:float | unclassified | unclassified | 712 | Watchdog poll interval in seconds. Must be >= 5. Default: 30. |
-| `MASC_KEEPER_WATCHDOG_PROGRESS_SEC` | typed:float | Timeouts | operator | 697 | Seconds since the last in-turn progress signal before an active turn is considered mid-turn-stale. Default: 300 (5 mi... |
-| `MASC_KEEPER_WATCHDOG_STALE_SEC` | typed:float | unclassified | unclassified | 672 | Seconds since last turn before a Running keeper is considered idle-stale. Must be >= 60. Default: 300 (5 minutes). In... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 374 | Master switch. When true, successful Coord.heartbeat after a unified turn counts as presence proof, allowing the next... |
-| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 936 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` | typed:int | unclassified | unclassified | 428 | Maximum turns per single OAS Agent.run call. Keeper resumes via checkpoint in the next keepalive cycle when {!Cascade... |
+| `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS` | typed:int | unclassified | unclassified | 451 |  |
+| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 409 | Per-call timeout in seconds for a single OAS Agent.run execution. Guards against indefinite LLM response waits within... |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 638 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 209 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
+| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 218 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 295 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
+| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 256 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
+| `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 192 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 644 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 491 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
+| `MASC_KEEPER_SYMMETRIC_SANDBOX` | typed:bool | unclassified | unclassified | 766 | Legacy RFC-0006 Phase B-1 flag. Read-side containment now follows [sandbox_profile=docker] unconditionally. This gett... |
+| `MASC_KEEPER_TERMINATION_WINDOW_SEC` | typed:float | unclassified | unclassified | 596 | Sliding window for stale-termination escalation tracking. Default: 21600 (6 hours). |
+| `MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC` | typed:float | unclassified | unclassified | 864 | Base delay (seconds) for exponential backoff. Delay at attempt [n] is [base * 2^(n-1)]. Env: [MASC_KEEPER_TRANSIENT_B... |
+| `MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC` | typed:float | unclassified | unclassified | 870 | Hard cap on backoff delay (seconds). Env: [MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC].  Default: 4.0. |
+| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 359 | Wall-clock timeout in seconds for a single unified turn (including all retries and cascade fallbacks). Prevents indef... |
+| `MASC_KEEPER_WATCHDOG_GRACE_SEC` | typed:float | unclassified | unclassified | 590 | Grace period after fiber start before idle-stale detection activates. Prevents false positives on server restart when... |
+| `MASC_KEEPER_WATCHDOG_NOOP_THRESHOLD` | typed:int | unclassified | unclassified | 582 | Consecutive noop turns before considering the keeper stuck in a failure loop. Must be >= 2. Default: 3. |
+| `MASC_KEEPER_WATCHDOG_POLL_SEC` | typed:float | unclassified | unclassified | 578 | Watchdog poll interval in seconds. Must be >= 5. Default: 30. |
+| `MASC_KEEPER_WATCHDOG_PROGRESS_SEC` | typed:float | Timeouts | operator | 563 | Seconds since the last in-turn progress signal before an active turn is considered mid-turn-stale. Default: 300 (5 mi... |
+| `MASC_KEEPER_WATCHDOG_STALE_SEC` | typed:float | unclassified | unclassified | 538 | Seconds since last turn before a Running keeper is considered idle-stale. Must be >= 60. Default: 300 (5 minutes). In... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 240 | Master switch. When true, successful Coord.heartbeat after a unified turn counts as presence proof, allowing the next... |
+| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 802 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+
+## Env_config_keeper_supervisor (21 knobs; typed classification 20/20)
+
+| Env var | Kind | Category | Ops class | Line | Doc |
+|---|---|---|---|---|---|
+| `MASC_KEEPER_ALIVE_BUT_STUCK_DEDUP_TTL_SEC` | typed:float | Timeouts | operator | 153 | Per-keeper dedup window (seconds): once a keeper is flagged the counter is incremented at most once per window, even ... |
+| `MASC_KEEPER_ALIVE_BUT_STUCK_ENABLED` | typed:bool | Policies | operator | 119 | Signal for alive-but-stuck keepers (#12838): keepers that are not Dead/Zombie and not paused, but whose [proactive_rt... |
+| `MASC_KEEPER_ALIVE_BUT_STUCK_RECOVERY_ENABLED` | typed:bool | Policies | operator | 128 | Queue a bounded recovery wakeup when [alive_but_stuck_scan] emits. The recovery uses the Event Layer queue plus [fibe... |
+| `MASC_KEEPER_ALIVE_BUT_STUCK_STALL_FLOOR_SEC` | typed:float | Timeouts | operator | 145 | Hard floor (seconds) so keepers with very small cooldowns are not flagged after a few minutes of legitimate quiet.  T... |
+| `MASC_KEEPER_ALIVE_BUT_STUCK_STALL_MULTIPLIER` | typed:int | Thresholds | operator | 136 | Multiplier on the keeper's own [proactive.cooldown_sec] before a stalled keeper is flagged.  Default: 10 (10 cooldown... |
+| `MASC_KEEPER_AUTO_RESUME_INITIAL_SEC` | typed:float | Timeouts | operator | 64 | Initial auto-resume backoff delay after an auto-pause (seconds). On every successive auto-pause the delay doubles, ca... |
+| `MASC_KEEPER_AUTO_RESUME_MAX_SEC` | typed:float | Timeouts | operator | 70 | Maximum auto-resume backoff delay (seconds).  Default: 86400 (24 hours). @category Timeouts @ops_class operator |
+| `MASC_KEEPER_DEAD_TTL_SEC` | typed:float | Timeouts | operator | 47 | Dead tombstone TTL: seconds before Dead entries are cleaned up. @category Timeouts @ops_class operator |
+| `MASC_KEEPER_DOMAIN_POOL_ENABLED` | feature_flag | n/a | n/a | 12 | Route per-keeper supervise fork through the shared [Domain_pool] (RFC-0059 PR-7-pilot) instead of staying on the main... |
+| `MASC_KEEPER_LIVENESS_RECOVERY_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 95 | Base backoff delay (seconds) between liveness recovery attempts per keeper. Exponential: attempt 0 = base, 1 = 2*base... |
+| `MASC_KEEPER_LIVENESS_RECOVERY_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 104 | Maximum backoff delay cap (seconds) for liveness recovery. Default: 3600 (1 hour). @category Timeouts @ops_class oper... |
+| `MASC_KEEPER_LIVENESS_RECOVERY_ENABLED` | typed:bool | Policies | operator | 77 | Liveness Recovery Supervisor (#12801): enable auto-recovery of Dead keepers whose root cause has cleared.  Set to fal... |
+| `MASC_KEEPER_LIVENESS_RECOVERY_MAX_ATTEMPTS` | typed:int | Thresholds | operator | 111 | Maximum total liveness recovery attempts per keeper before giving up permanently.  Default: 5. @category Thresholds @... |
+| `MASC_KEEPER_LIVENESS_RECOVERY_MIN_DEAD_SEC` | typed:float | Timeouts | operator | 85 | Minimum time (seconds) a keeper must have been Dead before a liveness recovery attempt is made.  Allows transient roo... |
+| `MASC_KEEPER_PAUSED_CLEANUP_TTL_SEC` | typed:float | Timeouts | operator | 55 | Paused keeper file TTL: seconds before stale paused keeper meta files are removed from disk. Default: 86400 (24 hours... |
+| `MASC_KEEPER_SELF_PRESERVATION_MIN_CANDIDATES` | typed:int | Thresholds | operator | 42 | Self-preservation: minimum crashed candidates to trigger. @category Thresholds @ops_class operator |
+| `MASC_KEEPER_SELF_PRESERVATION_RATIO` | typed:float | Thresholds | operator | 36 | Self-preservation: ratio of crashed keepers to trigger suppression. @category Thresholds @ops_class operator |
+| `MASC_KEEPER_SUPERVISOR_BACKOFF_BASE_S` | typed:float | Timeouts | operator | 21 | Base delay for exponential backoff between restarts (seconds). @category Timeouts @ops_class operator |
+| `MASC_KEEPER_SUPERVISOR_BACKOFF_MAX_S` | typed:float | Timeouts | operator | 25 | Maximum backoff delay cap (seconds). @category Timeouts @ops_class operator |
+| `MASC_KEEPER_SUPERVISOR_MAX_RESTARTS` | typed:int | Thresholds | operator | 17 | Maximum restart attempts before declaring a keeper dead. @category Thresholds @ops_class operator |
+| `MASC_KEEPER_SUPERVISOR_SWEEP_SEC` | typed:float | Timeouts | operator | 29 | Interval between supervisor sweep runs (seconds). @category Timeouts @ops_class operator |
 
 ## Env_config_oas_bridge (3 knobs; typed classification 0/0)
 
@@ -366,96 +371,96 @@ the categorization roadmap. Newly-added typed getters in
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_A2A_DELEGATION_TIMEOUT_SEC` | string_literal | n/a | n/a | 958 |  |
-| `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 178 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 836 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 840 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 842 |  |
-| `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 380 |  |
-| `MASC_CHANNEL_GATE_DEDUP_MAX_ENTRIES` | string_literal | n/a | n/a | 456 |  |
-| `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 458 |  |
-| `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 460 |  |
-| `MASC_CHANNEL_GATE_SLOW_MS` | string_literal | n/a | n/a | 462 |  |
-| `MASC_CIRCUIT_COOLDOWN` | string_literal | n/a | n/a | 472 |  |
-| `MASC_CIRCUIT_FAILURE_WINDOW_SEC` | string_literal | n/a | n/a | 474 |  |
-| `MASC_CIRCUIT_THRESHOLD` | string_literal | n/a | n/a | 476 |  |
-| `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 382 |  |
-| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 390 |  |
-| `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 418 |  |
-| `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 494 |  |
-| `MASC_DECISION_LAYER_LEVEL` | string_literal | n/a | n/a | 496 |  |
-| `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 464 |  |
-| `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 371 |  |
-| `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 370 |  |
-| `MASC_DRIFT_THRESHOLD` | string_literal | n/a | n/a | 369 |  |
-| `MASC_ECONOMY_ENABLED` | string_literal | n/a | n/a | 545 |  |
-| `MASC_ECONOMY_FRUGAL_THRESHOLD` | string_literal | n/a | n/a | 547 |  |
-| `MASC_ECONOMY_HUSTLE_THRESHOLD` | string_literal | n/a | n/a | 549 |  |
-| `MASC_ECONOMY_INITIAL_BALANCE` | string_literal | n/a | n/a | 551 |  |
-| `MASC_ECONOMY_REPUTATION_MULTIPLIER` | string_literal | n/a | n/a | 553 |  |
-| `MASC_ECONOMY_REWARD_BOARD_POST` | string_literal | n/a | n/a | 555 |  |
-| `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 557 |  |
-| `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 559 |  |
-| `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 561 |  |
-| `MASC_FILE_LOCK_MAX_ENTRIES` | string_literal | n/a | n/a | 567 |  |
-| `MASC_FILE_LOCK_STALE_SEC` | string_literal | n/a | n/a | 569 |  |
-| `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 231 |  |
-| `MASC_GUARD_PENALTY_BETA` | string_literal | n/a | n/a | 363 |  |
-| `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 373 |  |
-| `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 372 |  |
-| `MASC_HTTP_HOST` | string_literal | n/a | n/a | 170 |  |
-| `MASC_HTTP_MAX_CONNECTIONS` | string_literal | n/a | n/a | 171 |  |
-| `MASC_IMESSAGE_STATUS_STALE_SEC` | string_literal | n/a | n/a | 466 |  |
-| `MASC_KEEPER_AUTONOMOUS_CONCURRENCY` | string_literal | n/a | n/a | 674 |  |
-| `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 321 |  |
-| `MASC_KEEPER_BOARD_LIST_CACHE_TTL_S` | string_literal | n/a | n/a | 639 |  |
-| `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 306 |  |
-| `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 308 |  |
-| `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 304 |  |
-| `MASC_KEEPER_COST_GATE_USD` | string_literal | n/a | n/a | 310 |  |
-| `MASC_KEEPER_LLM_RERANK_CASCADE` | string_literal | n/a | n/a | 740 |  |
-| `MASC_KEEPER_MAX_TOOL_ROUNDS` | string_literal | n/a | n/a | 319 |  |
-| `MASC_KEEPER_PROACTIVE_SIMILARITY` | string_literal | n/a | n/a | 329 |  |
-| `MASC_KEEPER_PROACTIVE_TEMP_HIGH` | string_literal | n/a | n/a | 327 |  |
-| `MASC_KEEPER_PROACTIVE_TEMP_LOW` | string_literal | n/a | n/a | 323 |  |
-| `MASC_KEEPER_PROACTIVE_TEMP_MID` | string_literal | n/a | n/a | 325 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN` | string_literal | n/a | n/a | 347 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 343 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_REPETITION` | string_literal | n/a | n/a | 341 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 345 |  |
-| `MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 337 |  |
-| `MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 339 |  |
-| `MASC_KEEPER_RULE_REFLECT_REPETITION` | string_literal | n/a | n/a | 335 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 744 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 746 |  |
-| `MASC_KEEPER_TOOL_COST_MAX_USD` | string_literal | n/a | n/a | 312 |  |
-| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 748 |  |
-| `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 700 |  |
-| `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 702 |  |
-| `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 315 |  |
-| `MASC_KEEPER_UNIFIED_MAX_TURNS` | string_literal | n/a | n/a | 317 |  |
-| `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 314 |  |
-| `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 374 |  |
-| `MASC_MAX_WRITE_SIZE_BYTES` | string_literal | n/a | n/a | 974 |  |
-| `MASC_NAMESPACE_TRUTH_COLD_SAFETY_MARGIN_S` | string_literal | n/a | n/a | 422 |  |
-| `MASC_NAMESPACE_TRUTH_COLD_TIMEOUT_S` | string_literal | n/a | n/a | 420 |  |
-| `MASC_NAMESPACE_TRUTH_SHELL_FIBER_TIMEOUT_S` | string_literal | n/a | n/a | 424 |  |
-| `MASC_NAMESPACE_TRUTH_WARM_TIMEOUT_S` | string_literal | n/a | n/a | 426 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 934 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 976 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 988 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 882 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 884 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 886 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 888 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 914 |  |
-| `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 296 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 950 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 952 |  |
-| `MASC_TLA_TRACE` | string_literal | n/a | n/a | 298 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 1020 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 1022 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 1024 |  |
-| `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 238 |  |
-| `MASC_WS_SLICE_INDEX_ENABLED` | string_literal | n/a | n/a | 241 |  |
+| `MASC_A2A_DELEGATION_TIMEOUT_SEC` | string_literal | n/a | n/a | 809 |  |
+| `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 687 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 691 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 693 |  |
+| `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 231 |  |
+| `MASC_CHANNEL_GATE_DEDUP_MAX_ENTRIES` | string_literal | n/a | n/a | 307 |  |
+| `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 309 |  |
+| `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 311 |  |
+| `MASC_CHANNEL_GATE_SLOW_MS` | string_literal | n/a | n/a | 313 |  |
+| `MASC_CIRCUIT_COOLDOWN` | string_literal | n/a | n/a | 323 |  |
+| `MASC_CIRCUIT_FAILURE_WINDOW_SEC` | string_literal | n/a | n/a | 325 |  |
+| `MASC_CIRCUIT_THRESHOLD` | string_literal | n/a | n/a | 327 |  |
+| `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 233 |  |
+| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 241 |  |
+| `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 269 |  |
+| `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 345 |  |
+| `MASC_DECISION_LAYER_LEVEL` | string_literal | n/a | n/a | 347 |  |
+| `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 315 |  |
+| `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 222 |  |
+| `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 221 |  |
+| `MASC_DRIFT_THRESHOLD` | string_literal | n/a | n/a | 220 |  |
+| `MASC_ECONOMY_ENABLED` | string_literal | n/a | n/a | 396 |  |
+| `MASC_ECONOMY_FRUGAL_THRESHOLD` | string_literal | n/a | n/a | 398 |  |
+| `MASC_ECONOMY_HUSTLE_THRESHOLD` | string_literal | n/a | n/a | 400 |  |
+| `MASC_ECONOMY_INITIAL_BALANCE` | string_literal | n/a | n/a | 402 |  |
+| `MASC_ECONOMY_REPUTATION_MULTIPLIER` | string_literal | n/a | n/a | 404 |  |
+| `MASC_ECONOMY_REWARD_BOARD_POST` | string_literal | n/a | n/a | 406 |  |
+| `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 408 |  |
+| `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 410 |  |
+| `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 412 |  |
+| `MASC_FILE_LOCK_MAX_ENTRIES` | string_literal | n/a | n/a | 418 |  |
+| `MASC_FILE_LOCK_STALE_SEC` | string_literal | n/a | n/a | 420 |  |
+| `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 82 |  |
+| `MASC_GUARD_PENALTY_BETA` | string_literal | n/a | n/a | 214 |  |
+| `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 224 |  |
+| `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 223 |  |
+| `MASC_HTTP_HOST` | string_literal | n/a | n/a | 21 |  |
+| `MASC_HTTP_MAX_CONNECTIONS` | string_literal | n/a | n/a | 22 |  |
+| `MASC_IMESSAGE_STATUS_STALE_SEC` | string_literal | n/a | n/a | 317 |  |
+| `MASC_KEEPER_AUTONOMOUS_CONCURRENCY` | string_literal | n/a | n/a | 525 |  |
+| `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 172 |  |
+| `MASC_KEEPER_BOARD_LIST_CACHE_TTL_S` | string_literal | n/a | n/a | 490 |  |
+| `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 157 |  |
+| `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 159 |  |
+| `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 155 |  |
+| `MASC_KEEPER_COST_GATE_USD` | string_literal | n/a | n/a | 161 |  |
+| `MASC_KEEPER_LLM_RERANK_CASCADE` | string_literal | n/a | n/a | 591 |  |
+| `MASC_KEEPER_MAX_TOOL_ROUNDS` | string_literal | n/a | n/a | 170 |  |
+| `MASC_KEEPER_PROACTIVE_SIMILARITY` | string_literal | n/a | n/a | 180 |  |
+| `MASC_KEEPER_PROACTIVE_TEMP_HIGH` | string_literal | n/a | n/a | 178 |  |
+| `MASC_KEEPER_PROACTIVE_TEMP_LOW` | string_literal | n/a | n/a | 174 |  |
+| `MASC_KEEPER_PROACTIVE_TEMP_MID` | string_literal | n/a | n/a | 176 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN` | string_literal | n/a | n/a | 198 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 194 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_REPETITION` | string_literal | n/a | n/a | 192 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 196 |  |
+| `MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 188 |  |
+| `MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 190 |  |
+| `MASC_KEEPER_RULE_REFLECT_REPETITION` | string_literal | n/a | n/a | 186 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 595 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 597 |  |
+| `MASC_KEEPER_TOOL_COST_MAX_USD` | string_literal | n/a | n/a | 163 |  |
+| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 599 |  |
+| `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 551 |  |
+| `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 553 |  |
+| `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 166 |  |
+| `MASC_KEEPER_UNIFIED_MAX_TURNS` | string_literal | n/a | n/a | 168 |  |
+| `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 165 |  |
+| `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 225 |  |
+| `MASC_MAX_WRITE_SIZE_BYTES` | string_literal | n/a | n/a | 825 |  |
+| `MASC_NAMESPACE_TRUTH_COLD_SAFETY_MARGIN_S` | string_literal | n/a | n/a | 273 |  |
+| `MASC_NAMESPACE_TRUTH_COLD_TIMEOUT_S` | string_literal | n/a | n/a | 271 |  |
+| `MASC_NAMESPACE_TRUTH_SHELL_FIBER_TIMEOUT_S` | string_literal | n/a | n/a | 275 |  |
+| `MASC_NAMESPACE_TRUTH_WARM_TIMEOUT_S` | string_literal | n/a | n/a | 277 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 785 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 827 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 839 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 733 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 735 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 737 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 739 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 765 |  |
+| `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 147 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 801 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 803 |  |
+| `MASC_TLA_TRACE` | string_literal | n/a | n/a | 149 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 871 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 873 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 875 |  |
+| `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 89 |  |
+| `MASC_WS_SLICE_INDEX_ENABLED` | string_literal | n/a | n/a | 92 |  |
 

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -600,8 +600,23 @@ let record_restart ~base_path name =
     { e with restart_count = e.restart_count + 1; last_restart_ts = Time_compat.now () })
 ;;
 
-let record_error ~base_path name err =
-  Log.Keeper.error "registry: recording error name=%s error=%s" name err;
+let record_error ~base_path ?details name err =
+  let details =
+    match details with
+    | Some _ as details -> details
+    | None ->
+      Keeper_sandbox_runtime.docker_mount_failure_details
+        ~base_path_hash:(Keeper_sandbox_runtime.base_path_hash base_path)
+        ~keeper_name:name
+        ~output:err
+        ()
+  in
+  (match details with
+   | Some details ->
+     Log.Keeper.emit Log.Error
+       ~details
+       (Printf.sprintf "registry: recording error name=%s error=%s" name err)
+   | None -> Log.Keeper.error "registry: recording error name=%s error=%s" name err);
   Keeper_fd_pressure.note_if_fd_exhaustion ~site:"keeper_registry.record_error" err;
   update_entry ~base_path name (fun e -> { e with last_error = Some err })
 ;;

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -93,7 +93,12 @@ val enrich_fiber_unresolved_outcome :
 val record_restart : base_path:string -> string -> unit
 
 (** Record an error message. *)
-val record_error : base_path:string -> string -> string -> unit
+val record_error :
+  base_path:string ->
+  ?details:Yojson.Safe.t ->
+  string ->
+  string ->
+  unit
 
 (** Clear the last recorded error for a keeper. *)
 val clear_error : base_path:string -> string -> unit

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -214,9 +214,11 @@ let find_char_from s ch pos =
 let max_docker_mount_path_log_len = 4096
 
 let docker_mount_failure_looks_daemon_originated output =
-  String_util.contains_substring output "Error response from daemon"
-  || String_util.contains_substring output "OCI runtime create failed"
-  || String_util.contains_substring output "runc create failed"
+  String_util.contains_substring output "error during container init"
+  &&
+  (String_util.contains_substring output "Error response from daemon"
+   || String_util.contains_substring output "OCI runtime create failed"
+   || String_util.contains_substring output "runc create failed")
 ;;
 
 let extract_quoted_value_after output marker =

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -200,6 +200,116 @@ let sanitize_label_value value =
     value
 ;;
 
+let find_char_from s ch pos =
+  let rec loop i =
+    if i >= String.length s
+    then None
+    else if Char.equal s.[i] ch
+    then Some i
+    else loop (i + 1)
+  in
+  loop pos
+;;
+
+let extract_quoted_value_after output marker =
+  match String_util.find_substring output marker with
+  | None -> None
+  | Some marker_at ->
+    let quote_at = marker_at + String.length marker in
+    if quote_at >= String.length output || not (Char.equal output.[quote_at] '"')
+    then None
+    else (
+      let value_start = quote_at + 1 in
+      let value_end =
+        match find_char_from output '"' value_start with
+        | Some i -> i
+        | None -> String.length output
+      in
+      if value_end <= value_start
+      then None
+      else Some (String.sub output value_start (value_end - value_start)))
+;;
+
+let docker_mount_failure_path output =
+  match extract_quoted_value_after output "error mounting " with
+  | Some _ as path -> path
+  | None -> extract_quoted_value_after output "mount_path="
+;;
+
+let docker_output_mentions_mount_failure output =
+  String_util.contains_substring_ci output "error mounting"
+  || Option.is_some (docker_mount_failure_path output)
+;;
+
+let docker_failure_output_for_log output =
+  if docker_output_mentions_mount_failure output
+  then Worker_dev_tools.truncate_for_log ~max_len:4096 output
+  else Worker_dev_tools.truncate_for_log output
+;;
+
+let optional_context_field key = function
+  | None -> []
+  | Some value when String.trim value = "" -> []
+  | Some value -> [ Printf.sprintf "%s=%S" key value ]
+;;
+
+let docker_mount_failure_context_suffix
+      ?base_path_hash
+      ?keeper_name
+      ?image
+      ?status_label
+      ?container_kind
+      ?network_label
+      output
+  =
+  match docker_mount_failure_path output with
+  | None -> ""
+  | Some mount_path ->
+    let fields =
+      [ "docker_mount_failure=true"; Printf.sprintf "mount_path=%S" mount_path ]
+      @ optional_context_field "base_path_hash" base_path_hash
+      @ optional_context_field "keeper" keeper_name
+      @ optional_context_field "image" image
+      @ optional_context_field "status" status_label
+      @ optional_context_field "container_kind" container_kind
+      @ optional_context_field "network" network_label
+    in
+    " " ^ String.concat " " fields
+;;
+
+let optional_json_string_field key = function
+  | None -> []
+  | Some value when String.trim value = "" -> []
+  | Some value -> [ key, `String value ]
+;;
+
+let docker_mount_failure_details
+      ?image
+      ?status_label
+      ?container_kind
+      ?network_label
+      ~base_path_hash
+      ~keeper_name
+      ~output
+      ()
+  =
+  match docker_mount_failure_path output with
+  | None -> None
+  | Some mount_path ->
+    Some
+      (`Assoc
+        ([ "event", `String "keeper_docker_mount_failure"
+         ; "mount_path", `String mount_path
+         ; "base_path_hash", `String base_path_hash
+         ; "keeper", `String keeper_name
+         ; "output_excerpt", `String (docker_failure_output_for_log output)
+         ]
+         @ optional_json_string_field "image" image
+         @ optional_json_string_field "status" status_label
+         @ optional_json_string_field "container_kind" container_kind
+         @ optional_json_string_field "network" network_label))
+;;
+
 let docker_label_args
       ?ttl_sec
       ?turn_id

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -213,6 +213,12 @@ let find_char_from s ch pos =
 
 let max_docker_mount_path_log_len = 4096
 
+let docker_mount_failure_looks_daemon_originated output =
+  String_util.contains_substring output "Error response from daemon"
+  || String_util.contains_substring output "OCI runtime create failed"
+  || String_util.contains_substring output "runc create failed"
+;;
+
 let extract_quoted_value_after output marker =
   match String_util.find_substring output marker with
   | None -> None
@@ -236,9 +242,12 @@ let extract_quoted_value_after output marker =
 ;;
 
 let docker_mount_failure_path output =
-  match extract_quoted_value_after output "error mounting " with
-  | Some _ as path -> path
-  | None -> extract_quoted_value_after output "mount_path="
+  if not (docker_mount_failure_looks_daemon_originated output)
+  then None
+  else (
+    match extract_quoted_value_after output "error mounting " with
+    | Some _ as path -> path
+    | None -> extract_quoted_value_after output "mount_path=")
 ;;
 
 let docker_output_mentions_mount_failure output =

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -211,6 +211,8 @@ let find_char_from s ch pos =
   loop pos
 ;;
 
+let max_docker_mount_path_log_len = 4096
+
 let extract_quoted_value_after output marker =
   match String_util.find_substring output marker with
   | None -> None
@@ -227,7 +229,10 @@ let extract_quoted_value_after output marker =
       in
       if value_end <= value_start
       then None
-      else Some (String.sub output value_start (value_end - value_start)))
+      else
+        let value_len = value_end - value_start in
+        let bounded_len = min value_len max_docker_mount_path_log_len in
+        Some (String.sub output value_start bounded_len))
 ;;
 
 let docker_mount_failure_path output =
@@ -237,8 +242,7 @@ let docker_mount_failure_path output =
 ;;
 
 let docker_output_mentions_mount_failure output =
-  String_util.contains_substring_ci output "error mounting"
-  || Option.is_some (docker_mount_failure_path output)
+  Option.is_some (docker_mount_failure_path output)
 ;;
 
 let docker_failure_output_for_log output =

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -107,6 +107,41 @@ val base_path_hash : string -> string
     [[A-Za-z0-9_.-]] to ['_']. Pure. *)
 val sanitize_label_value : string -> string
 
+(** Extract the failing host-side source path from Docker Desktop / OCI
+    mount errors such as [error mounting "/host_mnt/..."].  Also accepts
+    the [mount_path="..."] field emitted by MASC diagnostics. *)
+val docker_mount_failure_path : string -> string option
+
+(** Truncate Docker output for log storage.  Generic output keeps the
+    normal compact budget; OCI mount failures get a larger budget so the
+    mount source is not lost before [mount_path] is emitted. *)
+val docker_failure_output_for_log : string -> string
+
+(** Append stable key/value context for Docker mount failures.  Returns
+    [""] when [output] is not a mount failure. *)
+val docker_mount_failure_context_suffix :
+  ?base_path_hash:string ->
+  ?keeper_name:string ->
+  ?image:string ->
+  ?status_label:string ->
+  ?container_kind:string ->
+  ?network_label:string ->
+  string ->
+  string
+
+(** Structured log payload for Docker mount failures.  Returns [None]
+    when [output] is not a mount failure. *)
+val docker_mount_failure_details :
+  ?image:string ->
+  ?status_label:string ->
+  ?container_kind:string ->
+  ?network_label:string ->
+  base_path_hash:string ->
+  keeper_name:string ->
+  output:string ->
+  unit ->
+  Yojson.Safe.t option
+
 (** Docker network argv fragment and the MASC network label.  In
     particular, [Network_inherit] maps to [--network host] so the
     container shares the host network namespace (needed for

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -109,7 +109,9 @@ val sanitize_label_value : string -> string
 
 (** Extract the failing host-side source path from Docker Desktop / OCI
     mount errors such as [error mounting "/host_mnt/..."].  Also accepts
-    the [mount_path="..."] field emitted by MASC diagnostics. *)
+    the [mount_path="..."] field emitted by MASC diagnostics.  Returned
+    paths are bounded before they are logged or emitted as structured
+    diagnostics. *)
 val docker_mount_failure_path : string -> string option
 
 (** Truncate Docker output for log storage.  Generic output keeps the

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -119,6 +119,37 @@ let record_docker_exec_failure
   Keeper_registry.record_error ?details ~base_path:config.base_path meta.name message
 ;;
 
+let path_exists path =
+  try Sys.file_exists path with
+  | Sys_error _ -> false
+;;
+
+let path_is_directory path =
+  try Sys.is_directory path with
+  | Sys_error _ -> false
+;;
+
+let docker_mount_preflight_details
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~image
+      ~container_kind
+      ~network_label
+      ~mount_path
+      ~reason
+  =
+  `Assoc
+    [ "event", `String "keeper_docker_mount_preflight_failure"
+    ; "mount_path", `String mount_path
+    ; "base_path_hash", `String (Keeper_sandbox_runtime.base_path_hash config.base_path)
+    ; "keeper", `String meta.name
+    ; "image", `String image
+    ; "container_kind", `String container_kind
+    ; "network", `String network_label
+    ; "reason", `String reason
+    ]
+;;
+
 (* ── P12: Network egress policy ───────────────────────── *)
 
 let egress_policy_path ~(config : Coord.config) ~(meta : keeper_meta) =
@@ -579,7 +610,7 @@ let command_repos_path_hint cmd =
 
 let resolve_sandbox_root_git_cwd ~(config : Coord.config) ~(meta : keeper_meta) ~cwd ~cmd =
   let host_root =
-    keeper_playground_root ~config ~meta
+    Keeper_sandbox.host_root_abs_of_meta ~config meta
     |> Keeper_alerting_path.normalize_path_for_check
     |> Keeper_alerting_path.strip_trailing_slashes
   in
@@ -924,8 +955,8 @@ let run_docker_shell_command_with_status_internal
   let network_mode =
     if Env_config_keeper.KeeperSandbox.hard_mode () then Network_none else network_mode
   in
-  let sandbox_error message =
-    Keeper_registry.record_error ~base_path:config.base_path meta.name message;
+  let sandbox_error ?details message =
+    Keeper_registry.record_error ?details ~base_path:config.base_path meta.name message;
     Error message
   in
   if String.trim image = ""
@@ -982,17 +1013,8 @@ let run_docker_shell_command_with_status_internal
       (match fd_admission_error ~config with
        | Some err -> sandbox_error err
        | None ->
-      let _cleanup =
-        Keeper_sandbox_runtime.maybe_cleanup_stale_containers
-          ~base_path:config.base_path
-          ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Sandbox ())
-          ()
-      in
-      match ensure_keeper_sandbox_runtime ~timeout_sec with
-      | Error err -> sandbox_error err
-      | Ok seccomp_args ->
         let host_root =
-          keeper_playground_root ~config ~meta
+          Keeper_sandbox.host_root_abs_of_meta ~config meta
           |> Keeper_alerting_path.normalize_path_for_check
           |> Keeper_alerting_path.strip_trailing_slashes
         in
@@ -1021,18 +1043,72 @@ let run_docker_shell_command_with_status_internal
               let container_name = keeper_sandbox_container_name meta in
               let container_root = keeper_private_container_root meta in
               let container_cwd = docker_private_workspace_cwd ~config ~meta cwd in
-              (* Pre-flight: verify the host cwd exists before spawning a container.
-                 This avoids wasteful docker runs that inevitably fail when bash
-                 starts in a non-existent directory. *)
-              if not (Sys.file_exists cwd)
+              let network_args, network_label =
+                if git_creds_enabled
+                then [ "--network"; "bridge" ], "bridge"
+                else Keeper_sandbox_runtime.docker_network_args network_mode
+              in
+              (* Pre-flight: verify the bind source and host cwd before spawning a
+                 container. Missing bind sources otherwise fail inside Docker
+                 Desktop as opaque OCI mount errors and can degrade the daemon. *)
+              if not (path_exists host_root)
+              then
+                let details =
+                  docker_mount_preflight_details
+                    ~config
+                    ~meta
+                    ~image
+                    ~container_kind:"oneshot"
+                    ~network_label
+                    ~mount_path:host_root
+                    ~reason:"mount_source_not_found"
+                in
+                sandbox_error
+                  ~details
+                  (Printf.sprintf
+                     "docker_shell_failed: mount_source_not_found: mount_path=%S \
+                      base_path_hash=%S keeper=%S image=%S container_kind=%S \
+                      network=%S (host bind mount source does not exist; repair \
+                      the sandbox playground before docker run)"
+                     host_root
+                     (Keeper_sandbox_runtime.base_path_hash config.base_path)
+                     meta.name
+                     image
+                     "oneshot"
+                     network_label)
+              else if not (path_is_directory host_root)
+              then
+                let details =
+                  docker_mount_preflight_details
+                    ~config
+                    ~meta
+                    ~image
+                    ~container_kind:"oneshot"
+                    ~network_label
+                    ~mount_path:host_root
+                    ~reason:"mount_source_not_directory"
+                in
+                sandbox_error
+                  ~details
+                  (Printf.sprintf
+                     "docker_shell_failed: mount_source_not_directory: mount_path=%S \
+                      base_path_hash=%S keeper=%S image=%S container_kind=%S \
+                      network=%S (host bind mount source must be a directory)"
+                     host_root
+                     (Keeper_sandbox_runtime.base_path_hash config.base_path)
+                     meta.name
+                     image
+                     "oneshot"
+                     network_label)
+              else if not (path_exists cwd)
               then
                 sandbox_error
                   (Printf.sprintf
                      "docker_shell_failed: cwd_not_found: %s (host working directory \
                       does not exist; verify the relative path under your playground \
-                      before calling keeper_shell)"
+                     before calling keeper_shell)"
                      cwd)
-              else if not (Sys.is_directory cwd)
+              else if not (path_is_directory cwd)
               then
                 sandbox_error
                   (Printf.sprintf
@@ -1040,6 +1116,16 @@ let run_docker_shell_command_with_status_internal
                       be a directory, not a file)"
                      cwd)
               else (
+                let _cleanup =
+                  Keeper_sandbox_runtime.maybe_cleanup_stale_containers
+                    ~base_path:config.base_path
+                    ~timeout_sec:
+                      (Env_config_exec_timeout.timeout_sec ~caller:Sandbox ())
+                    ()
+                in
+                match ensure_keeper_sandbox_runtime ~timeout_sec with
+                | Error err -> sandbox_error err
+                | Ok seccomp_args ->
                 let prepared_gitdirs =
                   if git_creds_enabled && cmd_targets_git_or_gh cmd
                   then prepare_container_worktree_gitdirs ~host_root ~container_root
@@ -1076,11 +1162,6 @@ let run_docker_shell_command_with_status_internal
                 with
                 | Error err -> sandbox_error err
                 | Ok identity_mounts ->
-                  let network_args, network_label =
-                    if git_creds_enabled
-                    then [ "--network"; "bridge" ], "bridge"
-                    else Keeper_sandbox_runtime.docker_network_args network_mode
-                  in
                   let cred_result =
                     if not git_creds_enabled
                     then Ok ([], [])

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -19,8 +19,17 @@ let docker_exec_status_label = function
   | Unix.WSTOPPED n -> Printf.sprintf "stopped=%d" n
 ;;
 
-let docker_exec_failure_message ~image ~status ~output =
-  let truncated = Worker_dev_tools.truncate_for_log output in
+let docker_exec_failure_message_internal
+      ?base_path_hash
+      ?keeper_name
+      ?container_kind
+      ?network_label
+      ~image
+      ~status
+      ~output
+      ()
+  =
+  let truncated = Keeper_sandbox_runtime.docker_failure_output_for_log output in
   let output_label = if String.trim truncated = "" then "<no output>" else truncated in
   let missing_cwd_hint =
     if
@@ -32,12 +41,82 @@ let docker_exec_failure_message ~image ~status ~output =
        repos/<repo>/.worktrees/<task>)."
     else ""
   in
+  let mount_failure_context =
+    Keeper_sandbox_runtime.docker_mount_failure_context_suffix
+      ?base_path_hash
+      ?keeper_name
+      ~image
+      ~status_label:(docker_exec_status_label status)
+      ?container_kind
+      ?network_label
+      output
+  in
   Printf.sprintf
-    "sandbox docker exec failed (%s, %s): %s%s"
+    "sandbox docker exec failed (%s, %s): %s%s%s"
     image
     (docker_exec_status_label status)
     output_label
     missing_cwd_hint
+    mount_failure_context
+;;
+
+let docker_exec_failure_message ~image ~status ~output =
+  docker_exec_failure_message_internal ~image ~status ~output ()
+;;
+
+let docker_exec_failure_message_with_context
+      ~base_path_hash
+      ~keeper_name
+      ~container_kind
+      ~network_label
+      ~image
+      ~status
+      ~output
+  =
+  docker_exec_failure_message_internal
+    ~base_path_hash
+    ~keeper_name
+    ~container_kind
+    ~network_label
+    ~image
+    ~status
+    ~output
+    ()
+;;
+
+let record_docker_exec_failure
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~image
+      ~container_kind
+      ~network_label
+      ~status
+      ~output
+  =
+  let base_path_hash = Keeper_sandbox_runtime.base_path_hash config.base_path in
+  let status_label = docker_exec_status_label status in
+  let message =
+    docker_exec_failure_message_with_context
+      ~base_path_hash
+      ~keeper_name:meta.name
+      ~container_kind
+      ~network_label
+      ~image
+      ~status
+      ~output
+  in
+  let details =
+    Keeper_sandbox_runtime.docker_mount_failure_details
+      ~base_path_hash
+      ~keeper_name:meta.name
+      ~image
+      ~status_label
+      ~container_kind
+      ~network_label
+      ~output
+      ()
+  in
+  Keeper_registry.record_error ?details ~base_path:config.base_path meta.name message
 ;;
 
 (* ── P12: Network egress policy ───────────────────────── *)
@@ -1094,10 +1173,14 @@ let run_docker_shell_command_with_status_internal
                         in
                         if status <> Unix.WEXITED 0
                         then
-                          Keeper_registry.record_error
-                            ~base_path:config.base_path
-                            meta.name
-                            (docker_exec_failure_message ~image ~status ~output)
+                          record_docker_exec_failure
+                            ~config
+                            ~meta
+                            ~image
+                            ~container_kind:"oneshot"
+                            ~network_label
+                            ~status
+                            ~output
                         else if
                           git_creds_enabled
                           && String_util.contains_substring_ci cmd "git worktree"
@@ -1305,10 +1388,14 @@ let run_docker_hardened_bash
           | Ok (st, out) ->
             if st <> Unix.WEXITED 0
             then
-              Keeper_registry.record_error
-                ~base_path:config.base_path
-                meta.name
-                (docker_exec_failure_message ~image ~status:st ~output:out)
+              record_docker_exec_failure
+                ~config
+                ~meta
+                ~image
+                ~container_kind:"turn"
+                ~network_label:(network_mode_to_string network_mode)
+                ~status:st
+                ~output:out
             else Keeper_registry.clear_error ~base_path:config.base_path meta.name;
             let cwd_response =
               Keeper_cwd_response.docker

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -92,7 +92,7 @@ let format_docker_exec_error ~head_program ~st ~out =
       "docker_%s_failed: exit=%d output=%s"
       head_program
       code
-      (Worker_dev_tools.truncate_for_log out)
+      (Keeper_sandbox_runtime.docker_failure_output_for_log out)
   | Unix.WSIGNALED n -> Printf.sprintf "docker_%s_signaled: signal=%d" head_program n
   | Unix.WSTOPPED n -> Printf.sprintf "docker_%s_stopped: signal=%d" head_program n
 ;;
@@ -260,10 +260,31 @@ let start_container (t : t) ~(timeout_sec : float) =
                     "docker_container_inspect_failed (existence check): %s"
                     (Worker_dev_tools.truncate_for_log inspect_out)))
           | _ ->
+            let status_label =
+              match st with
+              | Unix.WEXITED code -> Printf.sprintf "exit=%d" code
+              | Unix.WSIGNALED signal -> Printf.sprintf "signal=%d" signal
+              | Unix.WSTOPPED signal -> Printf.sprintf "stopped=%d" signal
+            in
+            let base_path_hash =
+              Keeper_sandbox_runtime.base_path_hash t.config.base_path
+            in
+            let network_label = network_mode_to_string t.network_mode in
+            let mount_context =
+              Keeper_sandbox_runtime.docker_mount_failure_context_suffix
+                ~base_path_hash
+                ~keeper_name:t.meta.name
+                ~image
+                ~status_label
+                ~container_kind:"turn"
+                ~network_label
+                out
+            in
             Error
               (Printf.sprintf
-                 "docker_container_start_failed: %s"
-                 (Worker_dev_tools.truncate_for_log out)))))
+                 "docker_container_start_failed: %s%s"
+                 (Keeper_sandbox_runtime.docker_failure_output_for_log out)
+                 mount_context))))
 ;;
 
 let ensure_started (t : t) ~(timeout_sec : float) =

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -1511,6 +1511,23 @@ let test_docker_mount_failure_structured_details () =
     Alcotest.(check string) "container_kind" "turn" (field "container_kind");
     Alcotest.(check string) "network" "none" (field "network")
 
+let test_docker_mount_failure_path_is_bounded () =
+  let mount_path = "/host_mnt/" ^ String.make 5000 'x' in
+  let output = "OCI runtime create failed: error mounting \"" ^ mount_path ^ "\"" in
+  match Keeper_sandbox_runtime.docker_mount_failure_path output with
+  | None -> Alcotest.fail "expected bounded mount path"
+  | Some path ->
+    Alcotest.(check int) "bounded mount path length" 4096 (String.length path);
+    Alcotest.(check bool) "bounded path remains prefix" true
+      (String.starts_with ~prefix:path mount_path)
+
+let test_docker_mount_failure_requires_path () =
+  let output = "OCI runtime create failed: error mounting without quoted path" in
+  Alcotest.(check (option string)) "missing path is not a mount diagnostic" None
+    (Keeper_sandbox_runtime.docker_mount_failure_path output);
+  Alcotest.(check string) "missing path has no mount context" ""
+    (Keeper_sandbox_runtime.docker_mount_failure_context_suffix output)
+
 let () =
   Alcotest.run "Keeper_shell_docker_route"
     [
@@ -1567,6 +1584,12 @@ let () =
           Alcotest.test_case
             "docker mount failure emits structured details"
             `Quick test_docker_mount_failure_structured_details;
+          Alcotest.test_case
+            "docker mount failure path is bounded"
+            `Quick test_docker_mount_failure_path_is_bounded;
+          Alcotest.test_case
+            "docker mount failure requires extracted path"
+            `Quick test_docker_mount_failure_requires_path;
         ] );
       ( "docker_route_skipped",
         [

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -641,6 +641,47 @@ let test_bash_git_c_option_missing_dir_blocks_before_docker () =
   Alcotest.(check bool) "docker was not invoked" false
     (Sys.file_exists log_path)
 
+let test_bash_missing_playground_blocks_before_docker () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  let log_path = Filename.concat config.Coord.base_path "docker.log" in
+  let mount_source =
+    Keeper_sandbox.host_root_abs_of_meta ~config meta
+    |> Keeper_alerting_path.normalize_path_for_check
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  cleanup_dir playground;
+  with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+  let err =
+    match
+      Keeper_shell_docker.run_trusted_docker_shell_command_with_status
+      ~config
+      ~meta
+      ~cwd:playground
+      ~timeout_sec:5.0
+      ~cmd:"pwd"
+      ~git_creds_enabled:false
+      ~network_mode:Keeper_types.Network_inherit
+    with
+    | Ok _ -> Alcotest.fail "expected missing playground to block before docker"
+    | Error err -> err
+  in
+  Alcotest.(check bool)
+    "missing bind source is typed"
+    true
+    (contains_substring err "mount_source_not_found");
+  Alcotest.(check bool)
+    "full mount path is surfaced"
+    true
+    (contains_substring err mount_source);
+  Alcotest.(check bool)
+    "base path hash is surfaced"
+    true
+    (contains_substring err "base_path_hash=");
+  Alcotest.(check bool) "docker was not invoked" false (Sys.file_exists log_path)
+
 let test_bash_git_c_bare_worktrees_from_root_uses_single_repo () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
@@ -1638,6 +1679,9 @@ let () =
           Alcotest.test_case
             "docker shell mounts MASC config runtime paths"
             `Quick test_docker_shell_mounts_masc_config_runtime_paths;
+          Alcotest.test_case
+            "missing playground bind source blocks before docker"
+            `Quick test_bash_missing_playground_blocks_before_docker;
           Alcotest.test_case
             "git-creds mounts passwd entry for numeric uid"
             `Quick test_git_creds_mounts_numeric_user_identity;

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -13,6 +13,7 @@ module Keeper_exec_shell = Masc_mcp.Keeper_exec_shell
 module Keeper_registry = Masc_mcp.Keeper_registry
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
 module Keeper_sandbox_factory = Masc_mcp.Keeper_sandbox_factory
+module Keeper_sandbox_runtime = Masc_mcp.Keeper_sandbox_runtime
 module Keeper_shell_docker = Masc_mcp.Keeper_shell_docker
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
@@ -1449,6 +1450,67 @@ let test_bash_rewrites_host_path_command_for_docker () =
   Alcotest.(check bool) "command no longer leaks host playground path" false
     (response_mentions raw "output" playground)
 
+let test_docker_mount_failure_message_preserves_path () =
+  let mount_path =
+    "/host_mnt/Users/dancer/me/.masc/playground/docker/repos/masc-mcp/.worktrees/"
+    ^ String.make 320 'a'
+    ^ "/repo"
+  in
+  let output =
+    "docker: Error response from daemon: failed to create task for container: "
+    ^ "failed to create shim task: OCI runtime create failed: "
+    ^ "runc create failed: unable to start container process: "
+    ^ "error during container init: error mounting \""
+    ^ mount_path
+    ^ "\" to rootfs at \"/workspace\": stat "
+    ^ mount_path
+    ^ ": no such file or directory"
+  in
+  let message =
+    Keeper_shell_docker.docker_exec_failure_message
+      ~image:"masc-keeper-sandbox:local"
+      ~status:(Unix.WEXITED 125)
+      ~output
+  in
+  Alcotest.(check bool) "full mount path preserved" true
+    (contains_substring message mount_path);
+  Alcotest.(check bool) "mount marker emitted" true
+    (contains_substring message "docker_mount_failure=true");
+  Alcotest.(check bool) "status emitted" true
+    (contains_substring message "status=\"exit=125\"")
+
+let test_docker_mount_failure_structured_details () =
+  let mount_path =
+    "/host_mnt/Users/dancer/me/.masc/playground/docker/repos/oas/.worktrees/"
+    ^ String.make 280 'b'
+  in
+  let output =
+    "OCI runtime create failed: runc create failed: error during container init: "
+    ^ "error mounting \""
+    ^ mount_path
+    ^ "\" to rootfs"
+  in
+  match
+    Keeper_sandbox_runtime.docker_mount_failure_details
+      ~base_path_hash:"hash456"
+      ~keeper_name:"ramarama"
+      ~image:"masc-keeper-sandbox:local"
+      ~status_label:"exit=125"
+      ~container_kind:"turn"
+      ~network_label:"none"
+      ~output
+      ()
+  with
+  | None -> Alcotest.fail "expected structured docker mount failure details"
+  | Some json ->
+    let field name = Json.member name json |> Json.to_string in
+    Alcotest.(check string) "event" "keeper_docker_mount_failure" (field "event");
+    Alcotest.(check string) "mount_path" mount_path (field "mount_path");
+    Alcotest.(check string) "base_path_hash" "hash456" (field "base_path_hash");
+    Alcotest.(check string) "keeper" "ramarama" (field "keeper");
+    Alcotest.(check string) "container_kind" "turn" (field "container_kind");
+    Alcotest.(check string) "network" "none" (field "network")
+
 let () =
   Alcotest.run "Keeper_shell_docker_route"
     [
@@ -1499,6 +1561,12 @@ let () =
           Alcotest.test_case
             "docker keeper bash rewrites host paths before exec"
             `Quick test_bash_rewrites_host_path_command_for_docker;
+          Alcotest.test_case
+            "docker mount failure preserves full path"
+            `Quick test_docker_mount_failure_message_preserves_path;
+          Alcotest.test_case
+            "docker mount failure emits structured details"
+            `Quick test_docker_mount_failure_structured_details;
         ] );
       ( "docker_route_skipped",
         [

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -1528,6 +1528,16 @@ let test_docker_mount_failure_requires_path () =
   Alcotest.(check string) "missing path has no mount context" ""
     (Keeper_sandbox_runtime.docker_mount_failure_context_suffix output)
 
+let test_docker_mount_failure_requires_daemon_origin () =
+  let app_output = {|application stderr: error mounting "./fixtures" failed|} in
+  Alcotest.(check (option string)) "app output is not a mount diagnostic" None
+    (Keeper_sandbox_runtime.docker_mount_failure_path app_output);
+  Alcotest.(check string) "app output has no mount context" ""
+    (Keeper_sandbox_runtime.docker_mount_failure_context_suffix app_output);
+  let marker_output = {|mount_path="/tmp/user-output"|} in
+  Alcotest.(check (option string)) "marker-only output is not daemon-originated" None
+    (Keeper_sandbox_runtime.docker_mount_failure_path marker_output)
+
 let () =
   Alcotest.run "Keeper_shell_docker_route"
     [
@@ -1590,6 +1600,9 @@ let () =
           Alcotest.test_case
             "docker mount failure requires extracted path"
             `Quick test_docker_mount_failure_requires_path;
+          Alcotest.test_case
+            "docker mount failure requires daemon origin"
+            `Quick test_docker_mount_failure_requires_daemon_origin;
         ] );
       ( "docker_route_skipped",
         [

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -1513,7 +1513,11 @@ let test_docker_mount_failure_structured_details () =
 
 let test_docker_mount_failure_path_is_bounded () =
   let mount_path = "/host_mnt/" ^ String.make 5000 'x' in
-  let output = "OCI runtime create failed: error mounting \"" ^ mount_path ^ "\"" in
+  let output =
+    "OCI runtime create failed: error during container init: error mounting \""
+    ^ mount_path
+    ^ "\""
+  in
   match Keeper_sandbox_runtime.docker_mount_failure_path output with
   | None -> Alcotest.fail "expected bounded mount path"
   | Some path ->
@@ -1522,7 +1526,9 @@ let test_docker_mount_failure_path_is_bounded () =
       (String.starts_with ~prefix:path mount_path)
 
 let test_docker_mount_failure_requires_path () =
-  let output = "OCI runtime create failed: error mounting without quoted path" in
+  let output =
+    "OCI runtime create failed: error during container init: error mounting without quoted path"
+  in
   Alcotest.(check (option string)) "missing path is not a mount diagnostic" None
     (Keeper_sandbox_runtime.docker_mount_failure_path output);
   Alcotest.(check string) "missing path has no mount context" ""
@@ -1537,6 +1543,12 @@ let test_docker_mount_failure_requires_daemon_origin () =
   let marker_output = {|mount_path="/tmp/user-output"|} in
   Alcotest.(check (option string)) "marker-only output is not daemon-originated" None
     (Keeper_sandbox_runtime.docker_mount_failure_path marker_output)
+  ;
+  let app_oci_output =
+    {|application stderr: OCI runtime create failed: error mounting "./fixtures"|}
+  in
+  Alcotest.(check (option string)) "runtime-like app output lacks init origin" None
+    (Keeper_sandbox_runtime.docker_mount_failure_path app_oci_output)
 
 let () =
   Alcotest.run "Keeper_shell_docker_route"


### PR DESCRIPTION
## Summary
- preserve full Docker/OCI mount paths in keeper sandbox failure messages instead of losing them to generic truncation
- attach structured mount-failure details to keeper registry logs, including mount_path, base_path_hash, keeper, image, status, container_kind, and network
- refresh `docs/runtime-tunables.md` so the Env knob catalog drift gate stays clean after the branch's config split
- cover the regression in test_keeper_shell_docker_route

Fixes #16012

## Validation
- opam exec -- ocamlformat --check lib/keeper/keeper_sandbox_runtime.ml lib/keeper/keeper_sandbox_runtime.mli lib/keeper/keeper_registry.ml lib/keeper/keeper_registry.mli lib/keeper/keeper_shell_docker.ml lib/keeper/keeper_shell_docker.mli lib/keeper/keeper_turn_sandbox_runtime.ml test/test_keeper_shell_docker_route.ml
- git diff --check HEAD~1..HEAD
- DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build --force ./test/test_keeper_shell_docker_route.exe
- ./_build/default/test/test_keeper_shell_docker_route.exe
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh exec ./bin/env_knob_catalog.exe -- docs/runtime-tunables.md
- git diff --exit-code docs/runtime-tunables.md
