### PR TITLE
fix(ci): avoid draft guard waiting on sync CI gate

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -324,11 +324,16 @@ jobs:
               return latestCiGate;
             };
 
-            const ciGateRequiredForBypass =
-              verifiedBypassLabels.length > 0 ||
+            // A verified human bypass label is an approval signal, not a CI
+            // completion signal. On synchronize/labeled events the CI Gate job
+            // may not exist until the long Build and Test dependency finishes;
+            // waiting here makes this required guard fail before CI can report.
+            // Branch protection still requires CI Gate separately, so only
+            // unsafe ready/auto-merge boundary events need this guard to wait.
+            const ciGateRequiredForUnsafeBoundary =
               unsafeDraftBoundaryAction ||
               hasAutoMergeRequest;
-            if (ciGateRequiredForBypass) {
+            if (ciGateRequiredForUnsafeBoundary) {
               const latestCiGate = await waitForCiGate();
               if (
                 !latestCiGate ||


### PR DESCRIPTION
## Summary
- stop treating a verified human bypass label as a reason for PR Automation to wait for CI Gate on ordinary synchronize/labeled events
- keep CI Gate waiting for unsafe ready-for-review or auto-merge boundary events
- document why branch protection still owns CI completion enforcement

## Evidence
- Observed #16098 Draft Auto-Merge Guard fail after 10 minutes with: CI Gate is not completed successfully for head cda452803342dc0deef2545b30213e56c44adef3: missing
- CI workflow for the same head still had Build and Test in progress, so CI Gate had not been created yet
- Local: git diff --check
- Local: ruby YAML parse for .github/workflows/pr-automation.yml