### PR TITLE
fix(worker): gate shell_exec spawns

### DIFF
--- a/lib/tool_resource_gate.ml
+++ b/lib/tool_resource_gate.ml
@@ -381,6 +381,7 @@ let classify ~tool_name ~arguments ~is_read_only =
   | None ->
     if String.starts_with ~prefix:"keeper_pr_" tool_name then Github
     else if String.starts_with ~prefix:"keeper_bash" tool_name then Shell
+    else if String.equal tool_name "shell_exec" then Shell
     else if string_contains tool_name "docker" || string_contains tool_name "sandbox"
     then Docker
     else if string_contains tool_name "web_" then Web

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -1840,73 +1840,94 @@ let make_shell_exec_with_allowlist
             in
             (try
                let started = Time_compat.now () in
-               let buf = Buffer.create 1024 in
-               let wrapped_command =
-                 match workdir with
-                 | Some dir when String.trim dir <> "" ->
-                   Printf.sprintf "cd %s && %s" (Filename.quote dir) command
-                 | _ -> command
+               let record_result ?error_message result =
+                 let duration_ms =
+                   int_of_float ((Time_compat.now () -. started) *. 1000.0)
+                 in
+                 Option.iter
+                   (fun (f : tool_exec_observer) ->
+                      let success = Result.is_ok result in
+                      if success
+                      then f ~tool_name:"shell_exec" ~success:true ~duration_ms ()
+                      else
+                        f
+                          ~tool_name:"shell_exec"
+                          ~success:false
+                          ~duration_ms
+                          ~error_kind:Shell_error
+                          ?error_message
+                          ())
+                   on_exec;
+                 result
                in
-               let result =
-                 try
-                   let status, output =
-                     Fd_accountant.with_slot ~kind:Sandbox_exec (fun () ->
-                       Eio.Time.with_timeout_exn clock timeout (fun () ->
-                         Eio.Switch.run
-                         @@ fun sw ->
-                         let stdout_r, stdout_w = Eio.Process.pipe ~sw proc_mgr in
-                         let proc =
-                           Eio.Process.spawn
-                             ~sw
-                             proc_mgr
-                             ~stdout:stdout_w
-                             [ "sh"; "-c"; wrapped_command ^ " 2>&1" ]
-                         in
-                         Eio.Flow.close stdout_w;
-                         (try
-                            Eio.Flow.copy stdout_r (Eio.Flow.buffer_sink buf);
-                            Eio.Flow.close stdout_r
-                          with
-                          | Eio.Cancel.Cancelled _ as e ->
-                            (try Eio.Flow.close stdout_r with
-                             | Eio.Cancel.Cancelled _ as ce -> raise ce
-                             | _ -> ());
-                            raise e);
-                         let status = Eio.Process.await proc in
-                         status, Buffer.contents buf))
-                   in
-                   match status with
-                   | `Exited 0 -> Ok { Agent_sdk.Types.content = output }
-                   | `Exited code ->
-                     tool_error (Printf.sprintf "Exit code %d:\n%s" code output)
-                   | `Signaled sig_num ->
-                     tool_error
-                       ~recoverable:(sig_num = Sys.sigterm)
-                       (Printf.sprintf "Killed by signal %d:\n%s" sig_num output)
-                 with
-                 | Eio.Time.Timeout ->
-                   let output = Buffer.contents buf in
-                   tool_error
-                     ~recoverable:true
-                     (Printf.sprintf "Timeout after %.0fs: %s\n%s" timeout command output)
-               in
-               let duration_ms =
-                 int_of_float ((Time_compat.now () -. started) *. 1000.0)
-               in
-               Option.iter
-                 (fun (f : tool_exec_observer) ->
-                    let success = Result.is_ok result in
-                    if success
-                    then f ~tool_name:"shell_exec" ~success:true ~duration_ms ()
-                    else
-                      f
-                        ~tool_name:"shell_exec"
-                        ~success:false
-                        ~duration_ms
-                        ~error_kind:Shell_error
-                        ())
-                 on_exec;
-               result
+               Tool_resource_gate.with_permit_raw
+                 ~clock
+                 ~tool_name:"shell_exec"
+                 ~arguments:input
+                 ~is_read_only:false
+                 ~on_reject:(fun message ->
+                   let message = "tool_resource_gate_saturated: " ^ message in
+                   record_result
+                     ~error_message:message
+                     (tool_error ~recoverable:true message))
+                 (fun () ->
+                    let buf = Buffer.create 1024 in
+                    let wrapped_command =
+                      match workdir with
+                      | Some dir when String.trim dir <> "" ->
+                        Printf.sprintf "cd %s && %s" (Filename.quote dir) command
+                      | _ -> command
+                    in
+                    let result =
+                      try
+                        let status, output =
+                          Fd_accountant.with_slot ~kind:Sandbox_exec (fun () ->
+                            Eio.Time.with_timeout_exn clock timeout (fun () ->
+                              Eio.Switch.run
+                              @@ fun sw ->
+                              let stdout_r, stdout_w =
+                                Eio.Process.pipe ~sw proc_mgr
+                              in
+                              let proc =
+                                Eio.Process.spawn
+                                  ~sw
+                                  proc_mgr
+                                  ~stdout:stdout_w
+                                  [ "sh"; "-c"; wrapped_command ^ " 2>&1" ]
+                              in
+                              Eio.Flow.close stdout_w;
+                              (try
+                                 Eio.Flow.copy stdout_r (Eio.Flow.buffer_sink buf);
+                                 Eio.Flow.close stdout_r
+                               with
+                               | Eio.Cancel.Cancelled _ as e ->
+                                 (try Eio.Flow.close stdout_r with
+                                  | Eio.Cancel.Cancelled _ as ce -> raise ce
+                                  | _ -> ());
+                                 raise e);
+                              let status = Eio.Process.await proc in
+                              status, Buffer.contents buf))
+                        in
+                        match status with
+                        | `Exited 0 -> Ok { Agent_sdk.Types.content = output }
+                        | `Exited code ->
+                          tool_error (Printf.sprintf "Exit code %d:\n%s" code output)
+                        | `Signaled sig_num ->
+                          tool_error
+                            ~recoverable:(sig_num = Sys.sigterm)
+                            (Printf.sprintf "Killed by signal %d:\n%s" sig_num output)
+                      with
+                      | Eio.Time.Timeout ->
+                        let output = Buffer.contents buf in
+                        tool_error
+                          ~recoverable:true
+                          (Printf.sprintf
+                             "Timeout after %.0fs: %s\n%s"
+                             timeout
+                             command
+                             output)
+                    in
+                    record_result result)
              with
              | Eio.Cancel.Cancelled _ as e -> raise e
              | exn ->

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,6 +31,7 @@ lib/process/process_eio.ml:493
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1859 — dev-tools worker spawn. Wrapped by the
-# worker switch; bounded by the dev-tools session lifetime.
-lib/worker_dev_tools.ml:1859
+# lib/worker_dev_tools.ml:1892 — dev-tools worker spawn. Wrapped by
+# Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
+# Eio.Switch.run at the call boundary.
+lib/worker_dev_tools.ml:1892

--- a/test/test_tool_resource_gate.ml
+++ b/test/test_tool_resource_gate.ml
@@ -71,6 +71,7 @@ let test_classifies_host_local_bottlenecks () =
   check string "transition" "coordination_write" (classify "masc_transition");
   check string "bash output bypasses gate" "ungated" (classify "keeper_bash_output");
   check string "bash kill bypasses gate" "ungated" (classify "keeper_bash_kill");
+  check string "worker shell_exec" "shell" (classify "shell_exec");
   check string "status stays ungated" "ungated" (classify ~is_read_only:true "masc_status")
 ;;
 

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -18,6 +18,16 @@ let contains_substring s needle =
   in
   if n_len = 0 then true else loop 0
 
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some prior -> Unix.putenv name prior
+      | None -> Unix.putenv name "")
+    f
+
 let rec ensure_dir path =
   if path = "" || path = "." || path = "/" || Sys.file_exists path then ()
   else (
@@ -483,6 +493,61 @@ let test_readonly_shell_exec_blocks_git () =
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "readonly shell should block git"
 
+let test_shell_exec_respects_resource_gate () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  Fun.protect
+    ~finally:Tool_resource_gate.For_testing.reset
+    (fun () ->
+       Tool_resource_gate.For_testing.set_limits ~shell:1 ();
+       with_env "MASC_TOOL_GATE_WAIT_TIMEOUT_SEC" "0.05" (fun () ->
+         let blocker_started, unblock_blocker = Eio.Promise.create () in
+         let release_blocker, resolve_release = Eio.Promise.create () in
+         Eio.Fiber.both
+           (fun () ->
+              let result =
+                Tool_resource_gate.with_permit
+                  ~clock
+                  ~tool_name:"keeper_bash"
+                  ~arguments:(`Assoc [ "cmd", `String "sleep 1" ])
+                  ~is_read_only:false
+                  ~start_time:(Eio.Time.now clock)
+                  (fun () ->
+                     Eio.Promise.resolve unblock_blocker ();
+                     Eio.Promise.await release_blocker;
+                     Tool_result.quick_ok ~tool_name:"keeper_bash" "released")
+              in
+              Alcotest.(check bool) "blocker acquired shell lane" true result.success)
+           (fun () ->
+              Eio.Promise.await blocker_started;
+              Fun.protect
+                ~finally:(fun () -> Eio.Promise.resolve resolve_release ())
+                (fun () ->
+                   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
+                   let tool = find_tool "shell_exec" tools in
+                   let result =
+                     Tool.execute tool
+                       (`Assoc [ "command", `String "echo gate-should-not-run" ])
+                   in
+                   match result with
+                   | Error { Agent_sdk.Types.message = msg; recoverable; _ } ->
+                     Alcotest.(check bool) "gate rejection is recoverable" true recoverable;
+                     Alcotest.(check bool)
+                       "message names resource gate saturation"
+                       true
+                       (contains_substring msg "tool_resource_gate_saturated");
+                     Alcotest.(check bool)
+                       "message names shell lane"
+                       true
+                       (contains_substring msg "class=shell")
+                   | Ok { Agent_sdk.Types.content = output } ->
+                     Alcotest.fail
+                       (Printf.sprintf
+                          "shell_exec bypassed saturated resource gate: %s"
+                          output)))))
+
 let test_workdir_enforcement () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -550,6 +615,8 @@ let () =
       Alcotest.test_case "missing param" `Quick test_shell_exec_missing_param;
       Alcotest.test_case "readonly shell blocks git" `Quick
         test_readonly_shell_exec_blocks_git;
+      Alcotest.test_case "resource gate saturation" `Quick
+        test_shell_exec_respects_resource_gate;
     ];
     "workdir", [
       Alcotest.test_case "workdir enforcement" `Quick test_workdir_enforcement;


### PR DESCRIPTION
## Summary

- classify `worker_dev_tools.shell_exec` as a `Tool_resource_gate` shell-lane consumer
- add `Tool_resource_gate.with_permit_raw` so non-`Tool_result.t` tool surfaces can share the same lane admission logic
- wrap `Worker_dev_tools` `shell_exec` process spawning before `Fd_accountant.with_slot` / `Eio.Process.spawn`
- add deterministic saturated-lane regression coverage

Closes #16122.

## Verification

- `opam exec -- ocamlformat --check lib/tool_resource_gate.ml lib/worker_dev_tools.ml test/test_tool_resource_gate.ml test/test_worker_dev_tools.ml`
- `env DUNE_CACHE=disabled dune build --root . --build-dir /private/tmp/masc-mcp-build-worker-shell-gate-16122 test/test_worker_dev_tools.exe test/test_tool_resource_gate.exe -j 1 --display=short`
- `/private/tmp/masc-mcp-build-worker-shell-gate-16122/default/test/test_worker_dev_tools.exe` (145 tests)
- `/private/tmp/masc-mcp-build-worker-shell-gate-16122/default/test/test_tool_resource_gate.exe` (6 tests)
- `git diff --check`

## MASC

- Goal: `goal-world-reactivity-p1-worker-shell-gate-20260518`
- Task: `task-391`
