### PR TITLE
fix(keeper): normalize stderr devnull bash redirects

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -35,4 +35,7 @@ module For_testing = struct
 
   let raw_keeper_bash_shape_block_tag =
     Keeper_shell_bash.For_testing.raw_keeper_bash_shape_block_tag
+
+  let strip_stderr_dev_null_redirects =
+    Keeper_shell_bash.For_testing.strip_stderr_dev_null_redirects
 end

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -71,6 +71,7 @@ module For_testing : sig
   val elapsed_duration_ms : start_time:float -> end_time:float -> int
   val keeper_bash_shape_block_tag : string -> string option
   val raw_keeper_bash_shape_block_tag : string -> string option
+  val strip_stderr_dev_null_redirects : string -> string * bool
 end
 
 val handle_keeper_bash_output :

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -218,6 +218,94 @@ let has_malformed_dev_null_redirect_token scan_text =
     | "0/dev/null" | "1/dev/null" | "2/dev/null" -> true
     | _ -> false)
 
+let starts_with_at text ~pos ~prefix =
+  let len = String.length prefix in
+  pos + len <= String.length text
+  && String.equal (String.sub text pos len) prefix
+
+let strip_stderr_dev_null_redirects cmd =
+  let len = String.length cmd in
+  let buf = Buffer.create len in
+  let skip_spaces i =
+    let rec loop j =
+      if j < len && (Char.equal cmd.[j] ' ' || Char.equal cmd.[j] '\t')
+      then loop (j + 1)
+      else j
+    in
+    loop i
+  in
+  let is_redirect_target_boundary i =
+    i >= len
+    ||
+    match cmd.[i] with
+    | ' ' | '\t' | '\n' | '\r' | ';' | '&' | '|' -> true
+    | _ -> false
+  in
+  let skip_dev_null_after op_end =
+    let target_start = skip_spaces op_end in
+    let target_end = target_start + String.length "/dev/null" in
+    if starts_with_at cmd ~pos:target_start ~prefix:"/dev/null"
+       && is_redirect_target_boundary target_end
+    then Some target_end
+    else None
+  in
+  let stderr_dev_null_redirect_end i =
+    let compact_append_end = i + String.length "2>>/dev/null" in
+    let compact_write_end = i + String.length "2>/dev/null" in
+    if starts_with_at cmd ~pos:i ~prefix:"2>>/dev/null"
+       && is_redirect_target_boundary compact_append_end
+    then Some compact_append_end
+    else if starts_with_at cmd ~pos:i ~prefix:"2>/dev/null"
+            && is_redirect_target_boundary compact_write_end
+    then Some compact_write_end
+    else if starts_with_at cmd ~pos:i ~prefix:"2>>"
+    then skip_dev_null_after (i + 3)
+    else if starts_with_at cmd ~pos:i ~prefix:"2>"
+    then skip_dev_null_after (i + 2)
+    else None
+  in
+  let rec loop quote_state escaped stripped i =
+    if i >= len
+    then String.trim (Buffer.contents buf), stripped
+    else if escaped
+    then (
+      Buffer.add_char buf cmd.[i];
+      loop quote_state false stripped (i + 1))
+    else (
+      match quote_state, cmd.[i] with
+      | Single_quote, '\'' ->
+        Buffer.add_char buf cmd.[i];
+        loop No_quote false stripped (i + 1)
+      | Single_quote, _ ->
+        Buffer.add_char buf cmd.[i];
+        loop Single_quote false stripped (i + 1)
+      | Double_quote, '"' ->
+        Buffer.add_char buf cmd.[i];
+        loop No_quote false stripped (i + 1)
+      | Double_quote, '\\' ->
+        Buffer.add_char buf cmd.[i];
+        loop Double_quote true stripped (i + 1)
+      | Double_quote, _ ->
+        Buffer.add_char buf cmd.[i];
+        loop Double_quote false stripped (i + 1)
+      | No_quote, '\'' ->
+        Buffer.add_char buf cmd.[i];
+        loop Single_quote false stripped (i + 1)
+      | No_quote, '"' ->
+        Buffer.add_char buf cmd.[i];
+        loop Double_quote false stripped (i + 1)
+      | No_quote, '\\' ->
+        Buffer.add_char buf cmd.[i];
+        loop No_quote true stripped (i + 1)
+      | No_quote, _ ->
+        match stderr_dev_null_redirect_end i with
+        | Some next -> loop No_quote false true next
+        | None ->
+          Buffer.add_char buf cmd.[i];
+          loop No_quote false stripped (i + 1))
+  in
+  loop No_quote false false 0
+
 let strip_trailing_slashes text =
   let rec loop i =
     if i > 0 && Char.equal text.[i - 1] '/' then loop (i - 1) else i
@@ -388,6 +476,7 @@ let quote_aware_shape_scan_text cmd =
   loop No_quote false 0
 
 let raw_keeper_bash_shape_block cmd =
+  let cmd, _ = strip_stderr_dev_null_redirects cmd in
   let scan_text = quote_aware_shape_scan_text cmd in
   let lower = String.lowercase_ascii scan_text in
   if string_contains_substring lower "gh pr checks"
@@ -435,6 +524,7 @@ let rec parsed_keeper_bash_shape_block = function
     else None
 
 let keeper_bash_shape_block cmd =
+  let cmd, _ = strip_stderr_dev_null_redirects cmd in
   let scan_text = quote_aware_shape_scan_text cmd in
   if command_has_repo_wide_scan cmd
   then Some Repo_wide_scan
@@ -572,7 +662,12 @@ let handle_keeper_bash
       ~(args : Yojson.Safe.t)
       ()
   =
-  let cmd = Safe_ops.json_string ~default:"" "cmd" args |> String.trim in
+  let original_cmd =
+    Safe_ops.json_string ~default:"" "cmd" args |> String.trim
+  in
+  let cmd, stripped_stderr_dev_null =
+    strip_stderr_dev_null_redirects original_cmd
+  in
   let root = Keeper_alerting_path.project_root_of_config config in
   let cmd_for_log =
     cmd
@@ -656,6 +751,10 @@ let handle_keeper_bash
       direct_tool_command_block ~tool_policy_visible tool_name
     | None when cmd_contains_gh_pr_create cmd -> gh_pr_create_block ()
     | None -> begin
+    (if stripped_stderr_dev_null then
+       Log.Keeper.info
+         "keeper_bash normalized stderr /dev/null redirect: keeper=%s cmd=%s"
+         meta.name cmd_for_log);
     (* Tick 22: dark-launch shadow logger.  Runs
        [Worker_dev_tools.diff_command] side-by-side with the
        live gate and emits a structured line for every non-[Agree]

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -245,7 +245,7 @@ let strip_stderr_dev_null_redirects cmd =
     i = 0
     ||
     match cmd.[i - 1] with
-    | ' ' | '\t' | '\n' | '\r' | ';' | '&' | '|' -> true
+    | ' ' | '\t' | '\n' | '\r' | ';' | '|' -> true
     | _ -> false
   in
   let skip_dev_null_after op_end =
@@ -563,6 +563,8 @@ module For_testing = struct
 
   let raw_keeper_bash_shape_block_tag cmd =
     Option.map bash_shape_block_tag (raw_keeper_bash_shape_block cmd)
+
+  let strip_stderr_dev_null_redirects = strip_stderr_dev_null_redirects
 end
 
 let bash_shape_block_reason = function

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -241,6 +241,13 @@ let strip_stderr_dev_null_redirects cmd =
     | ' ' | '\t' | '\n' | '\r' | ';' | '&' | '|' -> true
     | _ -> false
   in
+  let is_redirect_start_boundary i =
+    i = 0
+    ||
+    match cmd.[i - 1] with
+    | ' ' | '\t' | '\n' | '\r' | ';' | '&' | '|' -> true
+    | _ -> false
+  in
   let skip_dev_null_after op_end =
     let target_start = skip_spaces op_end in
     let target_end = target_start + String.length "/dev/null" in
@@ -250,6 +257,9 @@ let strip_stderr_dev_null_redirects cmd =
     else None
   in
   let stderr_dev_null_redirect_end i =
+    if not (is_redirect_start_boundary i)
+    then None
+    else
     let compact_append_end = i + String.length "2>>/dev/null" in
     let compact_write_end = i + String.length "2>/dev/null" in
     if starts_with_at cmd ~pos:i ~prefix:"2>>/dev/null"

--- a/lib/keeper/keeper_shell_bash.mli
+++ b/lib/keeper/keeper_shell_bash.mli
@@ -17,4 +17,5 @@ module For_testing : sig
   val elapsed_duration_ms : start_time:float -> end_time:float -> int
   val keeper_bash_shape_block_tag : string -> string option
   val raw_keeper_bash_shape_block_tag : string -> string option
+  val strip_stderr_dev_null_redirects : string -> string * bool
 end

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -377,6 +377,19 @@ let test_keeper_bash_raw_shape_fallback_is_quote_aware () =
   Alcotest.(check (option string)) "single-quoted substitution is data" None
     (block_tag {|echo '$(date) > out'|})
 
+let test_stderr_dev_null_strip_preserves_post_background_redirect () =
+  let strip =
+    Keeper_exec_shell.For_testing.strip_stderr_dev_null_redirects
+  in
+  Alcotest.(check (pair string bool))
+    "pre-background redirect is normalized"
+    ("sleep 1 &", true)
+    (strip "sleep 1 2>/dev/null &");
+  Alcotest.(check (pair string bool))
+    "post-background redirect is preserved"
+    ("sleep 1 & 2>/dev/null", false)
+    (strip "sleep 1 & 2>/dev/null")
+
 let test_keeper_bash_blocks_repo_wide_scans () =
   let block_tag = Keeper_exec_shell.For_testing.keeper_bash_shape_block_tag in
   List.iter
@@ -1102,6 +1115,9 @@ let () =
         test_keeper_bash_shape_uses_shell_ir_for_quoted_literals;
       Alcotest.test_case "raw shape fallback is quote-aware" `Quick
         test_keeper_bash_raw_shape_fallback_is_quote_aware;
+      Alcotest.test_case "stderr devnull strip preserves post-background redirect"
+        `Quick
+        test_stderr_dev_null_strip_preserves_post_background_redirect;
       Alcotest.test_case "repo-wide scans blocked" `Quick
         test_keeper_bash_blocks_repo_wide_scans;
       Alcotest.test_case "empty command blocked" `Quick test_empty_command;

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -73,6 +73,7 @@ let test_shell_metachar_blocked () =
     "echo x && rm -rf /";
     "cat file > /etc/passwd";
     "cat < /etc/shadow";
+    "ls2>/dev/null";
     "echo `whoami`";
     "echo $HOME";
   ] in

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -335,6 +335,13 @@ let test_keeper_bash_shape_uses_shell_ir_for_quoted_literals () =
   Alcotest.(check (option string)) "real redirect blocks"
     (Some "pipe_or_redirect")
     (block_tag "cat < /tmp/x");
+  Alcotest.(check (option string)) "stderr dev-null redirect is normalized" None
+    (block_tag "ls repos/masc-mcp/.worktrees/ 2>/dev/null");
+  Alcotest.(check (option string)) "spaced stderr dev-null redirect is normalized" None
+    (block_tag "ls repos/masc-mcp/.worktrees/ 2> /dev/null");
+  Alcotest.(check (option string)) "stdout dev-null redirect still blocks"
+    (Some "pipe_or_redirect")
+    (block_tag "ls repos/masc-mcp/.worktrees/ >/dev/null");
   Alcotest.(check (option string)) "malformed stderr redirect token blocks"
     (Some "pipe_or_redirect")
     (block_tag "ls repos/masc-mcp/.worktrees/ 2/dev/null");
@@ -358,6 +365,11 @@ let test_keeper_bash_raw_shape_fallback_is_quote_aware () =
   Alcotest.(check (option string)) "real redirect still blocks"
     (Some "pipe_or_redirect")
     (block_tag "cat < /tmp/x");
+  Alcotest.(check (option string)) "stderr dev-null redirect is normalized" None
+    (block_tag "ls repos/masc-mcp/.worktrees/ 2>/dev/null");
+  Alcotest.(check (option string)) "stderr dev-null prefix is not stripped from longer target"
+    (Some "pipe_or_redirect")
+    (block_tag "ls repos/masc-mcp/.worktrees/ 2>/dev/nullfile");
   Alcotest.(check (option string)) "double-quoted substitution still blocks"
     (Some "substitution")
     (block_tag {|echo "$(date)"|});


### PR DESCRIPTION
## Summary
- Normalize unquoted stderr `/dev/null` suppression (`2>/dev/null`, `2> /dev/null`, `2>>/dev/null`) before keeper_bash shape validation and execution.
- Keep real pipes, stdout redirects, file redirects, malformed `2/dev/null`, and longer `/dev/null*` targets blocked.

## Product impact
- Reduces high-volume keeper_bash command-shape WARN/ERROR noise from common harmless stderr suppression habits without weakening file-write redirect policy.

## Evidence
- `ocamlformat --check lib/keeper/keeper_shell_bash.ml test/test_keeper_bash_safety.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_bash_safety.exe`
- `./_build/default/test/test_keeper_bash_safety.exe test edge 1 --show-errors --compact`
- `./_build/default/test/test_keeper_bash_safety.exe test edge 2 --show-errors --compact`
- `./_build/default/test/test_keeper_bash_safety.exe --compact`

## Review evidence
- Focused change in keeper_bash shape gate only.
- Existing redirect safety contract retained: stdout/file redirects still block.

## Linked issue
- Follow-up from live `/Users/dancer/me/.masc` WARN/ERROR measurement on 2026-05-18: `keeper_tool_policy_blocked` was the top recent category, with repeated `2>/dev/null` command-shape blocks.