### PR TITLE
fix(fd): guard bare dune and disable host hotspot false blocks

### DIFF
--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -234,6 +234,36 @@ scripts/cleanup-docker-playground-worktrees.sh \
 Then apply with both `--include-broken` and `--apply` only after confirming the
 `BROKEN_CANDID` paths are stale orphan directories.
 
+### Local Dune FD Containment
+
+Local OCaml verification must go through the repo wrapper:
+
+```bash
+scripts/dune-local.sh build <target>
+```
+
+The wrapper serializes local Dune builds across worktrees. Shared server
+startup (`start-masc-mcp.sh`) also routes rebuilds through this wrapper. A direct
+`dune build`, `dune test`, or `dune exec` bypasses that machine-wide lock and
+can recreate host-wide FD pressure even when every cooperative build uses
+`DUNE_JOBS=1`.
+
+Inspect live pressure and bypasses:
+
+```bash
+scripts/nofile-status.sh
+```
+
+`potential bare dune bypasses` should be `none`. If a row appears, stop that
+process and rerun the command via `scripts/dune-local.sh`. New wrapper
+invocations fail fast while a live unwrapped Dune process exists, unless the
+operator explicitly sets `MASC_DUNE_ALLOW_BARE_DUNE=1` for a one-off emergency.
+
+`orphaned dune-local lock waiters` should also be `none`. A PPID 1 `lockf` or
+`flock` row is no longer attached to the agent session that started it; after
+confirming it is not the current lock holder, terminate the orphaned waiter so it
+does not take the Dune lock later and extend the local build queue.
+
 대표 failure class:
 
 - `keeper_count < expected_keepers`

--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -245,9 +245,9 @@ scripts/dune-local.sh build <target>
 The wrapper serializes local Dune builds across worktrees. Shared server
 startup (`start-masc-mcp.sh`), local production deploys, and the contract
 harness bootstrap also route rebuilds through this wrapper. A direct `dune
-build`, `dune test`, or `dune exec` bypasses that machine-wide lock and can
-recreate host-wide FD pressure even when every cooperative build uses
-`DUNE_JOBS=1`.
+build`, `dune test`, `dune exec`, or `dune clean` bypasses that machine-wide
+lock and can recreate host-wide FD pressure or mutate `_build` outside the
+shared lock even when every cooperative build uses `DUNE_JOBS=1`.
 
 Inspect live pressure and bypasses:
 

--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -243,9 +243,10 @@ scripts/dune-local.sh build <target>
 ```
 
 The wrapper serializes local Dune builds across worktrees. Shared server
-startup (`start-masc-mcp.sh`) also routes rebuilds through this wrapper. A direct
-`dune build`, `dune test`, or `dune exec` bypasses that machine-wide lock and
-can recreate host-wide FD pressure even when every cooperative build uses
+startup (`start-masc-mcp.sh`), local production deploys, and the contract
+harness bootstrap also route rebuilds through this wrapper. A direct `dune
+build`, `dune test`, or `dune exec` bypasses that machine-wide lock and can
+recreate host-wide FD pressure even when every cooperative build uses
 `DUNE_JOBS=1`.
 
 Inspect live pressure and bypasses:

--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -260,6 +260,18 @@ process and rerun the command via `scripts/dune-local.sh`. New wrapper
 invocations fail fast while a live unwrapped Dune process exists, unless the
 operator explicitly sets `MASC_DUNE_ALLOW_BARE_DUNE=1` for a one-off emergency.
 
+When a misbehaving session is repeatedly spawning unwrapped local builds, use an
+explicit remediation mode instead of running full `lsof` dumps:
+
+```bash
+scripts/nofile-status.sh --kill-bare-dune
+scripts/nofile-status.sh --watch 2 --kill-bare-dune --kill-repo-scans
+```
+
+The kill flags only target rows already classified by the status script:
+unwrapped Dune bypasses and broad `find`/`bfs` scans over `~/me` or `masc-mcp`.
+Wrapped `scripts/dune-local.sh` builds remain visible but are not terminated.
+
 `orphaned dune-local lock waiters` should also be `none`. A PPID 1 `lockf` or
 `flock` row is no longer attached to the agent session that started it; after
 confirming it is not the current lock holder, terminate the orphaned waiter so it

--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -197,6 +197,15 @@ inside it:
 scripts/docker-playground-fd-status.sh --root "$MASC_BASE_PATH/.masc/playground/docker"
 ```
 
+The runtime admission guard keeps Docker playground hotspot blocking disabled by
+default (`MASC_KEEPER_HOST_FD_HOTSPOT_HEADROOM=0`). The macOS system probe
+reports `kern.num_files`, which is host-wide, not a per-process Docker Desktop
+FD count; using it as a hard per-process hotspot proxy can false-block normal
+runtime when `kern.maxfilesperproc` is merely near the current host-wide file
+count. Keep the script above as the default visibility path. Set a positive
+`MASC_KEEPER_HOST_FD_HOTSPOT_HEADROOM` only for a deliberately conservative
+operator session.
+
 Review stale clean worktree candidates first:
 
 ```bash

--- a/lib/keeper_fd_pressure.ml
+++ b/lib/keeper_fd_pressure.ml
@@ -397,8 +397,10 @@ let system_fd_headroom () =
 ;;
 
 let host_fd_hotspot_headroom () =
-  Env_config_core.get_int ~default:49152 "MASC_KEEPER_HOST_FD_HOTSPOT_HEADROOM"
-  |> max (system_fd_headroom ())
+  Env_config_core.get_int ~default:0 "MASC_KEEPER_HOST_FD_HOTSPOT_HEADROOM" |> max 0
+;;
+
+let host_fd_hotspot_blocking_enabled () = host_fd_hotspot_headroom () > 0
 ;;
 
 let active_keeper_cap_for_soft_limit soft =
@@ -445,7 +447,7 @@ let system_fd_budget_block system_fds ~projected_fds ~active_keepers ~starting_k
       | Some max_files_per_process when max_files_per_process > 0 ->
         let remaining_files = max 0 (max_files_per_process - open_files) in
         let required_headroom = host_fd_hotspot_headroom () in
-        if remaining_files < required_headroom + projected_fds
+        if required_headroom > 0 && remaining_files < required_headroom + projected_fds
         then
           Some
             (Host_fd_hotspot_budget_exhausted
@@ -681,6 +683,7 @@ let runtime_state_json ?(soft_limit = process_nofile_soft_limit ())
     ; "system_max_files_per_process", system_max_files_per_process
     ; "host_fd_hotspot_remaining", host_fd_hotspot_remaining
     ; "host_fd_hotspot_headroom", `Int (host_fd_hotspot_headroom ())
+    ; "host_fd_hotspot_blocking_enabled", `Bool (host_fd_hotspot_blocking_enabled ())
     ; "host_fd_hotspot_probe_supported", host_fd_hotspot_probe_supported
     ; "headroom", `Int (fd_headroom ())
     ; "fd_per_active_keeper", `Int (fd_per_active_keeper ())

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -74,7 +74,7 @@ wait_port_free() {
 if [ "$SKIP_BUILD" = false ]; then
     echo "==> Building MASC MCP..." >&2
     cd "$REPO_DIR"
-    dune build --root "$REPO_DIR" bin/main_eio.exe 2>&1
+    "$REPO_DIR/scripts/dune-local.sh" build bin/main_eio.exe 2>&1
     echo "    Build complete." >&2
 fi
 

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -181,9 +181,62 @@ _list_unwrapped_dune_processes() {
           return 0
         }
 
-        function is_dune_command(text) {
-          return text ~ /^([^[:space:]]*\/)?dune[[:space:]]+(build|test|exec|runtest)([[:space:]]|$)/ ||
-                 text ~ /^([^[:space:]]*\/)?opam[[:space:]]+exec[[:space:]].*[[:space:]]dune[[:space:]]+(build|test|exec|runtest)([[:space:]]|$)/
+        function basename(token, parts, n) {
+          n = split(token, parts, "/")
+          return parts[n]
+        }
+
+        function is_dune_global_option_with_value(token) {
+          return token == "--root" ||
+                 token == "--workspace" ||
+                 token == "--profile" ||
+                 token == "--build-dir" ||
+                 token == "--display" ||
+                 token == "--cache" ||
+                 token == "--sandbox" ||
+                 token == "--instrument-with" ||
+                 token == "-p" ||
+                 token == "-x" ||
+                 token == "-j"
+        }
+
+        function is_dune_global_option_eq(token) {
+          return token ~ /^--(root|workspace|profile|build-dir|display|cache|sandbox|instrument-with)=/
+        }
+
+        function dune_subcommand_index(argc, argv, dune_index, i, token) {
+          i = dune_index + 1
+          while (i <= argc) {
+            token = argv[i]
+            if (is_dune_global_option_eq(token)) {
+              i++
+            } else if (is_dune_global_option_with_value(token)) {
+              i += 2
+            } else if (token == "build" || token == "test" || token == "exec" || token == "runtest") {
+              return i
+            } else {
+              return 0
+            }
+          }
+          return 0
+        }
+
+        function is_dune_command(text, argv, argc, i) {
+          argc = split(text, argv, /[[:space:]]+/)
+          if (argc < 2) {
+            return 0
+          }
+          if (basename(argv[1]) == "dune") {
+            return dune_subcommand_index(argc, argv, 1) > 0
+          }
+          if (basename(argv[1]) == "opam" && argv[2] == "exec") {
+            for (i = 3; i <= argc; i++) {
+              if (basename(argv[i]) == "dune") {
+                return dune_subcommand_index(argc, argv, i) > 0
+              }
+            }
+          }
+          return 0
         }
 
         END {

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -25,6 +25,7 @@ Set MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=seconds to bound opam-lock wait after the 
 Set MASC_DUNE_LOCK_DIAG=0 to suppress best-effort lock holder diagnostics.
 Set MASC_DUNE_DRY_RUN=1 to print the command without running it.
 Set MASC_DUNE_ALLOW_LIVE_BUILD_LOCK=1 to wait behind a live _build/.lock holder.
+Set MASC_DUNE_ALLOW_BARE_DUNE=1 to run despite a live Dune process outside this wrapper.
 Set MASC_SKIP_PIN_CHECK=1 to skip the agent_sdk pin guard.
 Set MASC_SKIP_DEPS_CHECK=1 to skip the core-deps installed guard.
 Set MASC_SKIP_OCAML_VERSION_CHECK=1 to skip the OCaml minimum version guard.
@@ -150,6 +151,69 @@ _print_lock_holders() {
   done <<< "$pids"
 }
 
+_list_unwrapped_dune_processes() {
+  command -v ps >/dev/null 2>&1 || return 0
+
+  ps ax -o pid=,ppid=,command= 2>/dev/null \
+    | awk '
+        /^[[:space:]]*[0-9]+[[:space:]]+[0-9]+[[:space:]]+/ {
+          pid = $1
+          ppid = $2
+          $1 = ""
+          $2 = ""
+          sub(/^[[:space:]]+/, "", $0)
+          parent[pid] = ppid
+          cmd[pid] = $0
+        }
+
+        function has_wrapper_ancestor(pid, cur, depth) {
+          cur = pid
+          depth = 0
+          while ((cur in cmd) && depth < 64) {
+            if (cmd[cur] ~ /dune-local[.]sh/ ||
+                cmd[cur] ~ /me-dune-local[.]lock/ ||
+                cmd[cur] ~ /MASC_DUNE_LOCK_HELD=1/) {
+              return 1
+            }
+            cur = parent[cur]
+            depth++
+          }
+          return 0
+        }
+
+        function is_dune_command(text) {
+          return text ~ /^([^[:space:]]*\/)?dune[[:space:]]+(build|test|exec|runtest)([[:space:]]|$)/ ||
+                 text ~ /^([^[:space:]]*\/)?opam[[:space:]]+exec[[:space:]].*[[:space:]]dune[[:space:]]+(build|test|exec|runtest)([[:space:]]|$)/
+        }
+
+        END {
+          for (pid in cmd) {
+            if (is_dune_command(cmd[pid]) && !has_wrapper_ancestor(pid)) {
+              printf "%s %s %s\n", pid, parent[pid], cmd[pid]
+            }
+          }
+        }'
+}
+
+_check_unwrapped_dune_processes() {
+  [[ "${GITHUB_ACTIONS:-}" != "true" ]] || return 0
+  [[ "${MASC_DUNE_DRY_RUN:-0}" != "1" ]] || return 0
+  [[ "${MASC_DUNE_ALLOW_BARE_DUNE:-0}" != "1" ]] || return 0
+  [[ "${_subcommand}" != "clean" ]] || return 0
+
+  local rows
+  rows="$(_list_unwrapped_dune_processes || true)"
+  [[ -n "$rows" ]] || return 0
+
+  printf '[dune-local] live Dune process outside scripts/dune-local.sh detected:\n' >&2
+  printf '%s\n' "$rows" | sed 's/^/[dune-local]   /' >&2
+  printf '[dune-local] refusing to start another local build while the machine-wide Dune lock is bypassed\n' >&2
+  printf '[dune-local] stop the bare Dune process, rerun it via scripts/dune-local.sh, or set MASC_DUNE_ALLOW_BARE_DUNE=1 to proceed anyway\n' >&2
+  exit 75
+}
+
+_check_unwrapped_dune_processes
+
 # Acquire the build throttle before the opam-switch lock.  The opam lock is
 # intentionally held while the active build uses the shared switch, but queued
 # builds must not hold it while waiting for the Dune throttle; otherwise stale
@@ -167,6 +231,8 @@ if _needs_dune_lock; then
     dune_lock_warning_emitted=1
   fi
 fi
+
+_check_unwrapped_dune_processes
 
 _needs_opam_lock() {
   [[ "${GITHUB_ACTIONS:-}" != "true" ]] || return 1

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -187,7 +187,7 @@ _list_unwrapped_dune_processes() {
         }
 
         function is_dune_subcommand(token) {
-          return token == "build" || token == "test" || token == "exec" || token == "runtest"
+          return token == "build" || token == "test" || token == "exec" || token == "runtest" || token == "clean"
         }
 
         function is_dune_option(token) {

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -186,34 +186,27 @@ _list_unwrapped_dune_processes() {
           return parts[n]
         }
 
-        function is_dune_global_option_with_value(token) {
-          return token == "--root" ||
-                 token == "--workspace" ||
-                 token == "--profile" ||
-                 token == "--build-dir" ||
-                 token == "--display" ||
-                 token == "--cache" ||
-                 token == "--sandbox" ||
-                 token == "--instrument-with" ||
-                 token == "-p" ||
-                 token == "-x" ||
-                 token == "-j"
+        function is_dune_subcommand(token) {
+          return token == "build" || token == "test" || token == "exec" || token == "runtest"
         }
 
-        function is_dune_global_option_eq(token) {
-          return token ~ /^--(root|workspace|profile|build-dir|display|cache|sandbox|instrument-with)=/
+        function is_dune_option(token) {
+          return token ~ /^--[[:alnum:]][[:alnum:]_-]*(=.*)?$/ ||
+                 token ~ /^-[[:alnum:]][[:alnum:]_-]*$/
         }
 
         function dune_subcommand_index(argc, argv, dune_index, i, token) {
           i = dune_index + 1
           while (i <= argc) {
             token = argv[i]
-            if (is_dune_global_option_eq(token)) {
-              i++
-            } else if (is_dune_global_option_with_value(token)) {
-              i += 2
-            } else if (token == "build" || token == "test" || token == "exec" || token == "runtest") {
+            if (is_dune_subcommand(token)) {
               return i
+            } else if (token ~ /^--[[:alnum:]][[:alnum:]_-]*=/) {
+              i++
+            } else if (is_dune_option(token) && i + 1 <= argc && !is_dune_subcommand(argv[i + 1]) && argv[i + 1] !~ /^-/) {
+              i += 2
+            } else if (is_dune_option(token)) {
+              i++
             } else {
               return 0
             }

--- a/scripts/harness/contract/run_all.sh
+++ b/scripts/harness/contract/run_all.sh
@@ -48,7 +48,9 @@ build_server_exe() {
   echo "[bootstrap] server executable missing; building"
   (
     cd "$ROOT_DIR"
-    if command -v opam >/dev/null 2>&1; then
+    if [[ -x "$ROOT_DIR/scripts/dune-local.sh" ]]; then
+      "$ROOT_DIR/scripts/dune-local.sh" build ./bin/main_eio.exe
+    elif command -v opam >/dev/null 2>&1; then
       opam exec -- dune build --root . ./bin/main_eio.exe
     else
       dune build --root . ./bin/main_eio.exe

--- a/scripts/harness/contract/run_all.sh
+++ b/scripts/harness/contract/run_all.sh
@@ -48,10 +48,10 @@ build_server_exe() {
   echo "[bootstrap] server executable missing; building"
   (
     cd "$ROOT_DIR"
-    if command -v opam >/dev/null 2>&1; then
-      opam exec -- dune build --root . ./bin/main_eio.exe
-    elif [[ -x "$ROOT_DIR/scripts/dune-local.sh" ]]; then
+    if [[ -x "$ROOT_DIR/scripts/dune-local.sh" ]]; then
       "$ROOT_DIR/scripts/dune-local.sh" build ./bin/main_eio.exe
+    elif command -v opam >/dev/null 2>&1; then
+      opam exec -- dune build --root . ./bin/main_eio.exe
     else
       dune build --root . ./bin/main_eio.exe
     fi

--- a/scripts/harness/contract/run_all.sh
+++ b/scripts/harness/contract/run_all.sh
@@ -48,10 +48,10 @@ build_server_exe() {
   echo "[bootstrap] server executable missing; building"
   (
     cd "$ROOT_DIR"
-    if [[ -x "$ROOT_DIR/scripts/dune-local.sh" ]]; then
-      "$ROOT_DIR/scripts/dune-local.sh" build ./bin/main_eio.exe
-    elif command -v opam >/dev/null 2>&1; then
+    if command -v opam >/dev/null 2>&1; then
       opam exec -- dune build --root . ./bin/main_eio.exe
+    elif [[ -x "$ROOT_DIR/scripts/dune-local.sh" ]]; then
+      "$ROOT_DIR/scripts/dune-local.sh" build ./bin/main_eio.exe
     else
       dune build --root . ./bin/main_eio.exe
     fi

--- a/scripts/nofile-status.sh
+++ b/scripts/nofile-status.sh
@@ -3,6 +3,17 @@ set -euo pipefail
 
 printf 'soft open files: %s\n' "$(ulimit -n 2>/dev/null || printf '?')"
 
+truncate_rows() {
+  local max="${MASC_NOFILE_COMMAND_MAX:-240}"
+  awk -v max="${max}" '{
+    if (max > 0 && length($0) > max) {
+      print substr($0, 1, max) "..."
+    } else {
+      print
+    }
+  }'
+}
+
 if command -v launchctl >/dev/null 2>&1; then
   printf 'launchctl maxfiles: '
   launchctl limit maxfiles 2>/dev/null | awk 'NR == 1 {print $2, $3}' || true
@@ -43,7 +54,8 @@ if command -v lsof >/dev/null 2>&1; then
         | sort -nr \
         | head -10 \
         | while read -r _count pid; do
-          ps -p "${pid}" -o pid=,ppid=,stat=,etime=,command= 2>/dev/null || true
+          ps -p "${pid}" -o pid=,ppid=,stat=,etime=,command= 2>/dev/null \
+            | truncate_rows || true
         done
     else
       printf 'top fd holder commands: unavailable (ps failed)\n'
@@ -57,20 +69,22 @@ else
 fi
 
 printf 'dune/local-build processes:\n'
-if command -v pgrep >/dev/null 2>&1; then
-  if ! pgrep -fl 'dune build|dune test|dune exec|dune-local.sh|me-dune-local.lock'; then
-    if [[ "${ps_available}" -eq 1 ]]; then
-      ps ax -o pid=,command= 2>/dev/null \
-        | grep -E 'dune build|dune test|dune exec|dune-local.sh|me-dune-local.lock' \
-        | grep -v grep || true
-    else
-      printf 'dune/local-build processes: unavailable (pgrep and ps failed)\n'
-    fi
+if [[ "${ps_available}" -eq 1 ]]; then
+  dune_rows="$(
+    ps ax -o pid=,ppid=,stat=,etime=,command= 2>/dev/null \
+      | awk '
+          /dune-local[.]sh/ ||
+          /me-dune-local[.]lock/ ||
+          /(^|[[:space:]\/])dune([[:space:]]|$)/ ||
+          /(^|[[:space:]\/])opam[[:space:]]+exec[[:space:]].*([[:space:]\/])dune([[:space:]]|$)/ {
+            print
+          }' || true
+  )"
+  if [[ -n "${dune_rows}" ]]; then
+    printf '%s\n' "${dune_rows}" | truncate_rows
+  else
+    printf 'none\n'
   fi
-elif [[ "${ps_available}" -eq 1 ]]; then
-  ps ax -o pid=,command= 2>/dev/null \
-    | grep -E 'dune build|dune test|dune exec|dune-local.sh|me-dune-local.lock' \
-    | grep -v grep || true
 else
   printf 'dune/local-build processes: unavailable (pgrep and ps failed)\n'
 fi
@@ -88,7 +102,7 @@ if [[ "${ps_available}" -eq 1 ]]; then
           }' || true
   )"
   if [[ -n "${orphan_waiters}" ]]; then
-    printf '%s\n' "${orphan_waiters}"
+    printf '%s\n' "${orphan_waiters}" | truncate_rows
   else
     printf 'none\n'
   fi
@@ -104,7 +118,8 @@ if [[ "${ps_available}" -eq 1 ]]; then
         /masc-mcp/ &&
         /-exec/ {
           print
-        }' || true
+        }' \
+    | truncate_rows || true
 else
   printf 'repo-wide scan processes: unavailable (ps failed)\n'
 fi
@@ -145,9 +160,62 @@ if [[ "${ps_available}" -eq 1 ]]; then
             return 0
           }
 
-          function is_dune_command(text) {
-            return text ~ /^([^[:space:]]*\/)?dune[[:space:]]+(build|test|exec|runtest)([[:space:]]|$)/ ||
-                   text ~ /^([^[:space:]]*\/)?opam[[:space:]]+exec[[:space:]].*[[:space:]]dune[[:space:]]+(build|test|exec|runtest)([[:space:]]|$)/
+          function basename(token, parts, n) {
+            n = split(token, parts, "/")
+            return parts[n]
+          }
+
+          function is_dune_global_option_with_value(token) {
+            return token == "--root" ||
+                   token == "--workspace" ||
+                   token == "--profile" ||
+                   token == "--build-dir" ||
+                   token == "--display" ||
+                   token == "--cache" ||
+                   token == "--sandbox" ||
+                   token == "--instrument-with" ||
+                   token == "-p" ||
+                   token == "-x" ||
+                   token == "-j"
+          }
+
+          function is_dune_global_option_eq(token) {
+            return token ~ /^--(root|workspace|profile|build-dir|display|cache|sandbox|instrument-with)=/
+          }
+
+          function dune_subcommand_index(argc, argv, dune_index, i, token) {
+            i = dune_index + 1
+            while (i <= argc) {
+              token = argv[i]
+              if (is_dune_global_option_eq(token)) {
+                i++
+              } else if (is_dune_global_option_with_value(token)) {
+                i += 2
+              } else if (token == "build" || token == "test" || token == "exec" || token == "runtest") {
+                return i
+              } else {
+                return 0
+              }
+            }
+            return 0
+          }
+
+          function is_dune_command(text, argv, argc, i) {
+            argc = split(text, argv, /[[:space:]]+/)
+            if (argc < 2) {
+              return 0
+            }
+            if (basename(argv[1]) == "dune") {
+              return dune_subcommand_index(argc, argv, 1) > 0
+            }
+            if (basename(argv[1]) == "opam" && argv[2] == "exec") {
+              for (i = 3; i <= argc; i++) {
+                if (basename(argv[i]) == "dune") {
+                  return dune_subcommand_index(argc, argv, i) > 0
+                }
+              }
+            }
+            return 0
           }
 
           END {
@@ -159,7 +227,7 @@ if [[ "${ps_available}" -eq 1 ]]; then
           }' || true
   )"
   if [[ -n "${bare_dune_rows}" ]]; then
-    printf '%s\n' "${bare_dune_rows}"
+    printf '%s\n' "${bare_dune_rows}" | truncate_rows
   else
     printf 'none\n'
   fi

--- a/scripts/nofile-status.sh
+++ b/scripts/nofile-status.sh
@@ -75,6 +75,27 @@ else
   printf 'dune/local-build processes: unavailable (pgrep and ps failed)\n'
 fi
 
+printf 'orphaned dune-local lock waiters:\n'
+if [[ "${ps_available}" -eq 1 ]]; then
+  orphan_waiters="$(
+    ps ax -o pid=,ppid=,stat=,etime=,command= 2>/dev/null \
+      | awk '
+          $2 == 1 &&
+          /dune-local[.]sh/ &&
+          /me-dune-local[.]lock/ &&
+          /(^|[[:space:]\/])(lockf|flock)([[:space:]]|$)/ {
+            print
+          }' || true
+  )"
+  if [[ -n "${orphan_waiters}" ]]; then
+    printf '%s\n' "${orphan_waiters}"
+  else
+    printf 'none\n'
+  fi
+else
+  printf 'orphaned dune-local lock waiters: unavailable (ps failed)\n'
+fi
+
 printf 'repo-wide scan processes:\n'
 if [[ "${ps_available}" -eq 1 ]]; then
   ps ax -o pid=,ppid=,stat=,etime=,command= 2>/dev/null \
@@ -90,14 +111,58 @@ fi
 
 printf 'potential bare dune bypasses:\n'
 if [[ "${ps_available}" -eq 1 ]]; then
-  ps ax -o pid=,ppid=,stat=,etime=,command= 2>/dev/null \
-    | awk '
-        /dune (build|test|exec)/ &&
-        $0 !~ /dune-local\.sh/ &&
-        $0 !~ /me-dune-local\.lock/ &&
-        $0 !~ /MASC_DUNE_LOCK_HELD=1/ {
-          print
-        }' || true
+  bare_dune_rows="$(
+    ps ax -o pid=,ppid=,stat=,etime=,command= 2>/dev/null \
+      | awk '
+          /^[[:space:]]*[0-9]+[[:space:]]+[0-9]+[[:space:]]+/ {
+            pid = $1
+            ppid = $2
+            stat = $3
+            etime = $4
+            $1 = ""
+            $2 = ""
+            $3 = ""
+            $4 = ""
+            sub(/^[[:space:]]+/, "", $0)
+            parent[pid] = ppid
+            state[pid] = stat
+            elapsed[pid] = etime
+            cmd[pid] = $0
+          }
+
+          function has_wrapper_ancestor(pid, cur, depth) {
+            cur = pid
+            depth = 0
+            while ((cur in cmd) && depth < 64) {
+              if (cmd[cur] ~ /dune-local[.]sh/ ||
+                  cmd[cur] ~ /me-dune-local[.]lock/ ||
+                  cmd[cur] ~ /MASC_DUNE_LOCK_HELD=1/) {
+                return 1
+              }
+              cur = parent[cur]
+              depth++
+            }
+            return 0
+          }
+
+          function is_dune_command(text) {
+            return text ~ /^([^[:space:]]*\/)?dune[[:space:]]+(build|test|exec|runtest)([[:space:]]|$)/ ||
+                   text ~ /^([^[:space:]]*\/)?opam[[:space:]]+exec[[:space:]].*[[:space:]]dune[[:space:]]+(build|test|exec|runtest)([[:space:]]|$)/
+          }
+
+          END {
+            for (pid in cmd) {
+              if (is_dune_command(cmd[pid]) && !has_wrapper_ancestor(pid)) {
+                printf "%s %s %s %s %s\n", pid, parent[pid], state[pid], elapsed[pid], cmd[pid]
+              }
+            }
+          }' || true
+  )"
+  if [[ -n "${bare_dune_rows}" ]]; then
+    printf '%s\n' "${bare_dune_rows}"
+  else
+    printf 'none\n'
+  fi
 else
   printf 'potential bare dune bypasses: unavailable (ps failed)\n'
 fi

--- a/scripts/nofile-status.sh
+++ b/scripts/nofile-status.sh
@@ -165,34 +165,27 @@ if [[ "${ps_available}" -eq 1 ]]; then
             return parts[n]
           }
 
-          function is_dune_global_option_with_value(token) {
-            return token == "--root" ||
-                   token == "--workspace" ||
-                   token == "--profile" ||
-                   token == "--build-dir" ||
-                   token == "--display" ||
-                   token == "--cache" ||
-                   token == "--sandbox" ||
-                   token == "--instrument-with" ||
-                   token == "-p" ||
-                   token == "-x" ||
-                   token == "-j"
+          function is_dune_subcommand(token) {
+            return token == "build" || token == "test" || token == "exec" || token == "runtest"
           }
 
-          function is_dune_global_option_eq(token) {
-            return token ~ /^--(root|workspace|profile|build-dir|display|cache|sandbox|instrument-with)=/
+          function is_dune_option(token) {
+            return token ~ /^--[[:alnum:]][[:alnum:]_-]*(=.*)?$/ ||
+                   token ~ /^-[[:alnum:]][[:alnum:]_-]*$/
           }
 
           function dune_subcommand_index(argc, argv, dune_index, i, token) {
             i = dune_index + 1
             while (i <= argc) {
               token = argv[i]
-              if (is_dune_global_option_eq(token)) {
-                i++
-              } else if (is_dune_global_option_with_value(token)) {
-                i += 2
-              } else if (token == "build" || token == "test" || token == "exec" || token == "runtest") {
+              if (is_dune_subcommand(token)) {
                 return i
+              } else if (token ~ /^--[[:alnum:]][[:alnum:]_-]*=/) {
+                i++
+              } else if (is_dune_option(token) && i + 1 <= argc && !is_dune_subcommand(argv[i + 1]) && argv[i + 1] !~ /^-/) {
+                i += 2
+              } else if (is_dune_option(token)) {
+                i++
               } else {
                 return 0
               }

--- a/scripts/nofile-status.sh
+++ b/scripts/nofile-status.sh
@@ -112,14 +112,23 @@ fi
 
 printf 'repo-wide scan processes:\n'
 if [[ "${ps_available}" -eq 1 ]]; then
-  ps ax -o pid=,ppid=,stat=,etime=,command= 2>/dev/null \
-    | awk '
-        /(^|[[:space:]])(bfs|find)[[:space:]]/ &&
-        /masc-mcp/ &&
-        /-exec/ {
-          print
-        }' \
-    | truncate_rows || true
+  scan_rows="$(
+    ps ax -o pid=,ppid=,stat=,etime=,command= 2>/dev/null \
+      | awk '
+          /(^|[[:space:]])(bfs|find)[[:space:]]/ &&
+          (/\/Users\/dancer([[:space:]]|\/|$)/ ||
+           /\/Users\/dancer\/me([[:space:]]|\/|$)/ ||
+           /masc-mcp/ ||
+           /~\/me/ ||
+           /[[:space:]]~([[:space:]]|\/|$)/) {
+            print
+          }' || true
+  )"
+  if [[ -n "${scan_rows}" ]]; then
+    printf '%s\n' "${scan_rows}" | truncate_rows
+  else
+    printf 'none\n'
+  fi
 else
   printf 'repo-wide scan processes: unavailable (ps failed)\n'
 fi

--- a/scripts/nofile-status.sh
+++ b/scripts/nofile-status.sh
@@ -1,6 +1,82 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+kill_bare_dune="${MASC_NOFILE_KILL_BARE_DUNE:-0}"
+kill_repo_scans="${MASC_NOFILE_KILL_REPO_SCANS:-0}"
+watch_mode=0
+watch_interval="${MASC_NOFILE_WATCH_INTERVAL:-5}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/nofile-status.sh [options]
+
+Options:
+  --kill-bare-dune    SIGTERM unwrapped Dune processes reported as bypasses.
+  --kill-repo-scans   SIGTERM broad find/bfs scans over ~/me or masc-mcp.
+  --kill-risky        Enable both kill options above.
+  --watch [seconds]   Repeat until interrupted. Defaults to 5 seconds.
+  --once              Run one snapshot even when invoked from watch mode.
+  -h, --help          Show this help.
+
+Environment:
+  MASC_NOFILE_KILL_BARE_DUNE=1
+  MASC_NOFILE_KILL_REPO_SCANS=1
+  MASC_NOFILE_WATCH_INTERVAL=5
+  MASC_NOFILE_COMMAND_MAX=240
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --kill-bare-dune)
+      kill_bare_dune=1
+      ;;
+    --kill-repo-scans)
+      kill_repo_scans=1
+      ;;
+    --kill-risky)
+      kill_bare_dune=1
+      kill_repo_scans=1
+      ;;
+    --watch)
+      watch_mode=1
+      if [[ "${2:-}" =~ ^[0-9]+$ ]]; then
+        watch_interval="$2"
+        shift
+      fi
+      ;;
+    --once)
+      watch_mode=0
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'nofile-status: unknown option: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ "${watch_mode}" -eq 1 ]]; then
+  if [[ ! "${watch_interval}" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'nofile-status: --watch interval must be a positive integer, got %q\n' \
+      "${watch_interval}" >&2
+    exit 2
+  fi
+  while true; do
+    printf '\n# nofile-status %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    MASC_NOFILE_KILL_BARE_DUNE="${kill_bare_dune}" \
+      MASC_NOFILE_KILL_REPO_SCANS="${kill_repo_scans}" \
+      MASC_NOFILE_WATCH_INTERVAL="${watch_interval}" \
+      "$0" --once
+    sleep "${watch_interval}"
+  done
+fi
+
 printf 'soft open files: %s\n' "$(ulimit -n 2>/dev/null || printf '?')"
 
 truncate_rows() {
@@ -12,6 +88,43 @@ truncate_rows() {
       print
     }
   }'
+}
+
+bool_enabled() {
+  case "${1:-0}" in
+    1 | true | TRUE | yes | YES | on | ON)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+terminate_rows() {
+  local label="$1"
+  local rows="$2"
+  local enabled="$3"
+  local pids
+
+  if [[ -z "${rows}" ]] || ! bool_enabled "${enabled}"; then
+    return
+  fi
+
+  pids="$(
+    printf '%s\n' "${rows}" \
+      | awk '$1 ~ /^[0-9]+$/ {print $1}' \
+      | sort -n \
+      | tr '\n' ' '
+  )"
+  if [[ -z "${pids// }" ]]; then
+    return
+  fi
+
+  printf '%s remediation: SIGTERM pid(s): %s\n' "${label}" "${pids}"
+  for pid in ${pids}; do
+    kill "${pid}" 2>/dev/null || true
+  done
 }
 
 if command -v launchctl >/dev/null 2>&1; then
@@ -126,6 +239,7 @@ if [[ "${ps_available}" -eq 1 ]]; then
   )"
   if [[ -n "${scan_rows}" ]]; then
     printf '%s\n' "${scan_rows}" | truncate_rows
+    terminate_rows "repo-wide scan processes" "${scan_rows}" "${kill_repo_scans}"
   else
     printf 'none\n'
   fi
@@ -230,6 +344,8 @@ if [[ "${ps_available}" -eq 1 ]]; then
   )"
   if [[ -n "${bare_dune_rows}" ]]; then
     printf '%s\n' "${bare_dune_rows}" | truncate_rows
+    terminate_rows "potential bare dune bypasses" "${bare_dune_rows}" \
+      "${kill_bare_dune}"
   else
     printf 'none\n'
   fi

--- a/scripts/nofile-status.sh
+++ b/scripts/nofile-status.sh
@@ -289,7 +289,7 @@ if [[ "${ps_available}" -eq 1 ]]; then
           }
 
           function is_dune_subcommand(token) {
-            return token == "build" || token == "test" || token == "exec" || token == "runtest"
+            return token == "build" || token == "test" || token == "exec" || token == "runtest" || token == "clean"
           }
 
           function is_dune_option(token) {

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -89,18 +89,28 @@ is_stale_dune_artifact_log() {
         "$log_file"
 }
 
+run_dune_local() {
+    local wrapper="$SCRIPT_DIR/scripts/dune-local.sh"
+    if [ ! -x "$wrapper" ]; then
+        echo "Error: local Dune wrapper missing or not executable: $wrapper" >&2
+        echo "Run builds through scripts/dune-local.sh so local agents share the machine-wide Dune lock." >&2
+        return 127
+    fi
+    env DUNE_LOCAL_JOBS="$DUNE_JOBS" "$wrapper" "$@"
+}
+
 dune_build_with_stale_retry() {
     local target="$1"
     local label="$2"
     local log_file=""
 
     if ! log_file="$(make_startup_temp_log 2>/dev/null)"; then
-        dune build -j "$DUNE_JOBS" --root "$SCRIPT_DIR" "$target" 1>&2
+        run_dune_local build "$target" 1>&2
         return $?
     fi
 
     local first_status=0
-    if dune build -j "$DUNE_JOBS" --root "$SCRIPT_DIR" "$target" >"$log_file" 2>&1; then
+    if run_dune_local build "$target" >"$log_file" 2>&1; then
         cat "$log_file" >&2
         rm -f "$log_file"
         return 0
@@ -116,13 +126,13 @@ dune_build_with_stale_retry() {
 
     cat "$log_file" >&2
     echo "[startup] Stale Dune artifacts detected while building $label; running dune clean and retrying once." >&2
-    if ! dune clean --root "$SCRIPT_DIR" 1>&2; then
+    if ! run_dune_local clean 1>&2; then
         echo "[startup] Dune clean failed after stale artifact detection; run: dune clean --root $SCRIPT_DIR" >&2
         rm -f "$log_file"
         return "$first_status"
     fi
 
-    if dune build -j "$DUNE_JOBS" --root "$SCRIPT_DIR" "$target" >"$log_file" 2>&1; then
+    if run_dune_local build "$target" >"$log_file" 2>&1; then
         cat "$log_file" >&2
         rm -f "$log_file"
         return 0

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -96,7 +96,7 @@ run_dune_local() {
         echo "Run builds through scripts/dune-local.sh so local agents share the machine-wide Dune lock." >&2
         return 127
     fi
-    env DUNE_LOCAL_JOBS="$DUNE_JOBS" "$wrapper" "$@"
+    env DUNE_LOCAL_JOBS="$DUNE_JOBS" DUNE_JOBS="$DUNE_JOBS" "$wrapper" "$@"
 }
 
 dune_build_with_stale_retry() {

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -708,15 +708,9 @@ let test_local_dune_fd_containment_contracts () =
   check bool "deploy script builds through dune-local wrapper" true
     (file_contains_pattern "scripts/deploy.sh"
        "\"$REPO_DIR/scripts/dune-local.sh\" build bin/main_eio.exe");
-  check bool "contract harness keeps opam build path before wrapper fallback" true
-    (match
-       ( file_pattern_position "scripts/harness/contract/run_all.sh"
-           "opam exec -- dune build --root . ./bin/main_eio.exe"
-       , file_pattern_position "scripts/harness/contract/run_all.sh"
-           "\"$ROOT_DIR/scripts/dune-local.sh\" build ./bin/main_eio.exe" )
-     with
-     | Some opam_pos, Some wrapper_pos -> opam_pos < wrapper_pos
-     | _ -> false);
+  check bool "contract harness prefers dune-local wrapper" true
+    (file_contains_pattern "scripts/harness/contract/run_all.sh"
+       "\"$ROOT_DIR/scripts/dune-local.sh\" build ./bin/main_eio.exe");
   check bool "nofile status surfaces bare dune bypasses" true
     (file_contains_pattern "scripts/nofile-status.sh"
        "potential bare dune bypasses");

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -722,6 +722,14 @@ let test_local_dune_fd_containment_contracts () =
        "/\\/Users\\/dancer");
   check bool "nofile bare detector handles dune global options" true
     (file_contains_pattern "scripts/nofile-status.sh" "dune_subcommand_index");
+  check bool "nofile status can terminate bare dune bypasses" true
+    (file_contains_pattern "scripts/nofile-status.sh"
+       "MASC_NOFILE_KILL_BARE_DUNE");
+  check bool "nofile status can terminate broad repo scans" true
+    (file_contains_pattern "scripts/nofile-status.sh"
+       "MASC_NOFILE_KILL_REPO_SCANS");
+  check bool "nofile status has watch mode" true
+    (file_contains_pattern "scripts/nofile-status.sh" "--watch");
   check bool "dune-local blocks live bare dune by default" true
     (file_contains_pattern "scripts/dune-local.sh"
        "MASC_DUNE_ALLOW_BARE_DUNE")

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -708,12 +708,23 @@ let test_local_dune_fd_containment_contracts () =
   check bool "deploy script builds through dune-local wrapper" true
     (file_contains_pattern "scripts/deploy.sh"
        "\"$REPO_DIR/scripts/dune-local.sh\" build bin/main_eio.exe");
-  check bool "contract harness prefers dune-local wrapper" true
-    (file_contains_pattern "scripts/harness/contract/run_all.sh"
-       "\"$ROOT_DIR/scripts/dune-local.sh\" build ./bin/main_eio.exe");
+  check bool "contract harness keeps opam build path before wrapper fallback" true
+    (match
+       ( file_pattern_position "scripts/harness/contract/run_all.sh"
+           "opam exec -- dune build --root . ./bin/main_eio.exe"
+       , file_pattern_position "scripts/harness/contract/run_all.sh"
+           "\"$ROOT_DIR/scripts/dune-local.sh\" build ./bin/main_eio.exe" )
+     with
+     | Some opam_pos, Some wrapper_pos -> opam_pos < wrapper_pos
+     | _ -> false);
   check bool "nofile status surfaces bare dune bypasses" true
     (file_contains_pattern "scripts/nofile-status.sh"
        "potential bare dune bypasses");
+  check bool "nofile status truncates long commands" true
+    (file_contains_pattern "scripts/nofile-status.sh"
+       "MASC_NOFILE_COMMAND_MAX");
+  check bool "nofile bare detector handles dune global options" true
+    (file_contains_pattern "scripts/nofile-status.sh" "dune_subcommand_index");
   check bool "dune-local blocks live bare dune by default" true
     (file_contains_pattern "scripts/dune-local.sh"
        "MASC_DUNE_ALLOW_BARE_DUNE")

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -717,6 +717,9 @@ let test_local_dune_fd_containment_contracts () =
   check bool "nofile status truncates long commands" true
     (file_contains_pattern "scripts/nofile-status.sh"
        "MASC_NOFILE_COMMAND_MAX");
+  check bool "nofile status surfaces broad repo scans" true
+    (file_contains_pattern "scripts/nofile-status.sh"
+       "/\\/Users\\/dancer");
   check bool "nofile bare detector handles dune global options" true
     (file_contains_pattern "scripts/nofile-status.sh" "dune_subcommand_index");
   check bool "dune-local blocks live bare dune by default" true

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -704,6 +704,20 @@ let test_oas_pin_source_contracts () =
     (file_contains_pattern "scripts/opam-pin-external-deps.sh"
        "print_opam_lock_holder")
 
+let test_local_dune_fd_containment_contracts () =
+  check bool "deploy script builds through dune-local wrapper" true
+    (file_contains_pattern "scripts/deploy.sh"
+       "\"$REPO_DIR/scripts/dune-local.sh\" build bin/main_eio.exe");
+  check bool "contract harness prefers dune-local wrapper" true
+    (file_contains_pattern "scripts/harness/contract/run_all.sh"
+       "\"$ROOT_DIR/scripts/dune-local.sh\" build ./bin/main_eio.exe");
+  check bool "nofile status surfaces bare dune bypasses" true
+    (file_contains_pattern "scripts/nofile-status.sh"
+       "potential bare dune bypasses");
+  check bool "dune-local blocks live bare dune by default" true
+    (file_contains_pattern "scripts/dune-local.sh"
+       "MASC_DUNE_ALLOW_BARE_DUNE")
+
 let test_doc_truth_guard_contracts () =
   check bool "doc truth script protects spec index front door wording" true
     (file_contains_pattern "scripts/check-doc-truth.sh"
@@ -2476,6 +2490,8 @@ let () =
            test_case "health and ci diagnostics" `Quick test_health_and_ci_runner_diagnostics;
            test_case "release truth contracts" `Quick test_release_truth_contracts;
            test_case "oas pin source contracts" `Quick test_oas_pin_source_contracts;
+           test_case "local dune FD containment contracts" `Quick
+             test_local_dune_fd_containment_contracts;
            test_case "doc truth guard contracts" `Quick test_doc_truth_guard_contracts;
            test_case "storage truth guard contracts" `Quick
              test_storage_truth_guard_contracts;

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -406,6 +406,7 @@ if [ "${1:-}" = "ax" ]; then
  111 1 dune exec --root . test/test_config_dir_resolver.exe
  112 1 dune --root . build
  113 1 opam exec -- dune --build-dir _build test
+ 114 1 dune clean --root .
  222 333 dune build --root wrapped-worktree
  333 1 lockf -k /tmp/me-dune-local.lock /usr/bin/env MASC_DUNE_LOCK_HELD=1 scripts/dune-local.sh build
 PS
@@ -434,6 +435,8 @@ let test_bare_dune_bypass_aborts_before_dune () =
         (contains_substring stderr "dune --root . build");
       check bool "reports opam exec dune with leading global option" true
         (contains_substring stderr "opam exec -- dune --build-dir _build test");
+      check bool "reports bare dune clean" true
+        (contains_substring stderr "dune clean --root .");
       check bool "does not report wrapped child" false
         (contains_substring stderr "wrapped-worktree");
       check bool "dune was not invoked" false (Sys.file_exists dune_log))

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -404,6 +404,8 @@ let write_bare_dune_ps bin_dir =
 if [ "${1:-}" = "ax" ]; then
   cat <<'PS'
  111 1 dune exec --root . test/test_config_dir_resolver.exe
+ 112 1 dune --root . build
+ 113 1 opam exec -- dune --build-dir _build test
  222 333 dune build --root wrapped-worktree
  333 1 lockf -k /tmp/me-dune-local.lock /usr/bin/env MASC_DUNE_LOCK_HELD=1 scripts/dune-local.sh build
 PS
@@ -428,6 +430,10 @@ let test_bare_dune_bypass_aborts_before_dune () =
       check bool "reports bare dune command" true
         (contains_substring stderr
            "dune exec --root . test/test_config_dir_resolver.exe");
+      check bool "reports dune with leading global option" true
+        (contains_substring stderr "dune --root . build");
+      check bool "reports opam exec dune with leading global option" true
+        (contains_substring stderr "opam exec -- dune --build-dir _build test");
       check bool "does not report wrapped child" false
         (contains_substring stderr "wrapped-worktree");
       check bool "dune was not invoked" false (Sys.file_exists dune_log))

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -397,6 +397,56 @@ exit 1
         (contains_substring stderr "bare `dune` process");
       check bool "dune was not invoked" false (Sys.file_exists dune_log))
 
+let write_bare_dune_ps bin_dir =
+  write_executable
+    (Filename.concat bin_dir "ps")
+    {|#!/bin/sh
+if [ "${1:-}" = "ax" ]; then
+  cat <<'PS'
+ 111 1 dune exec --root . test/test_config_dir_resolver.exe
+ 222 333 dune build --root wrapped-worktree
+ 333 1 lockf -k /tmp/me-dune-local.lock /usr/bin/env MASC_DUNE_LOCK_HELD=1 scripts/dune-local.sh build
+PS
+  exit 0
+fi
+exit 1
+|}
+
+let test_bare_dune_bypass_aborts_before_dune () =
+  with_temp_dir "dune-local-bare-dune-bypass" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:0
+          ~pin_check_stderr_msg:"pin ok"
+      in
+      write_bare_dune_ps bin_dir;
+      let code, _stdout, stderr =
+        run_dune_local dir bin_dir ~unset_env:[ "GITHUB_ACTIONS" ] "build"
+      in
+      check int "exits tempfail on bare dune bypass" 75 code;
+      check bool "reports unwrapped Dune" true
+        (contains_substring stderr "outside scripts/dune-local.sh");
+      check bool "reports bare dune command" true
+        (contains_substring stderr
+           "dune exec --root . test/test_config_dir_resolver.exe");
+      check bool "does not report wrapped child" false
+        (contains_substring stderr "wrapped-worktree");
+      check bool "dune was not invoked" false (Sys.file_exists dune_log))
+
+let test_bare_dune_bypass_can_be_overridden () =
+  with_temp_dir "dune-local-bare-dune-override" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:0
+          ~pin_check_stderr_msg:"pin ok"
+      in
+      write_bare_dune_ps bin_dir;
+      let code, _stdout, _stderr =
+        run_dune_local dir bin_dir
+          ~env:[ ("MASC_DUNE_ALLOW_BARE_DUNE", "1") ]
+          ~unset_env:[ "GITHUB_ACTIONS" ] "build"
+      in
+      check int "exits zero when bare dune guard is overridden" 0 code;
+      check bool "dune was invoked" true (Sys.file_exists dune_log))
+
 let test_opam_lockf_reexec_env_passthrough () =
   with_temp_dir "dune-local-opam-lockf" (fun dir ->
       let bin_dir, dune_log =
@@ -1110,6 +1160,10 @@ let () =
             test_dune_lock_wait_reports_holder;
           test_case "live build-dir lock aborts before Dune" `Quick
             test_live_build_lock_aborts_before_dune;
+          test_case "bare Dune bypass aborts before Dune" `Quick
+            test_bare_dune_bypass_aborts_before_dune;
+          test_case "MASC_DUNE_ALLOW_BARE_DUNE=1 bypasses bare Dune guard"
+            `Quick test_bare_dune_bypass_can_be_overridden;
           test_case "opam lockf reexec propagates env" `Quick
             test_opam_lockf_reexec_env_passthrough;
           test_case "opam lock timeout releases Dune lock" `Quick

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -224,7 +224,6 @@ let test_fd_pressure_host_hotspot_admission () =
     ~finally:FD.reset_for_tests
     (fun () ->
       with_env "MASC_KEEPER_SYSTEM_FD_HEADROOM" "0" (fun () ->
-      with_env "MASC_KEEPER_HOST_FD_HOTSPOT_HEADROOM" "1024" (fun () ->
         let hotspot =
           FD.
             { open_files = 9_200
@@ -232,6 +231,34 @@ let test_fd_pressure_host_hotspot_admission () =
             ; max_files_per_process = Some 10_000
             }
         in
+        let default_decision =
+          FD.admission_decision
+            ~soft_limit:(Some 245_760)
+            ~open_fds:(Some 64)
+            ~system_fds:(Some hotspot)
+            ~active_keepers:2
+            ~starting_keepers:1
+            ()
+        in
+        check bool "default host hotspot signal is advisory" true
+          (FD.admitted default_decision);
+        let default_json =
+          FD.runtime_state_json
+            ~soft_limit:(Some 245_760)
+            ~open_fds:(Some 64)
+            ~system_fds:(Some hotspot)
+            ~active_keepers:2
+            ~starting_keepers:1
+            ~requested_keepers:24
+            ()
+        in
+        check string "default runtime still ok" "ok"
+          (Json.member "status" default_json |> Json.to_string);
+        check int "default hotspot headroom disabled" 0
+          (Json.member "host_fd_hotspot_headroom" default_json |> Json.to_int);
+        check bool "default hotspot blocking disabled" false
+          (Json.member "host_fd_hotspot_blocking_enabled" default_json |> Json.to_bool);
+        with_env "MASC_KEEPER_HOST_FD_HOTSPOT_HEADROOM" "1024" (fun () ->
         let decision =
           FD.admission_decision
             ~soft_limit:(Some 245_760)
@@ -263,7 +290,9 @@ let test_fd_pressure_host_hotspot_admission () =
         check int "hotspot remaining exposed" 800
           (Json.member "host_fd_hotspot_remaining" json |> Json.to_int);
         check int "hotspot headroom exposed" 1024
-          (Json.member "host_fd_hotspot_headroom" json |> Json.to_int))))
+          (Json.member "host_fd_hotspot_headroom" json |> Json.to_int);
+        check bool "hotspot blocking enabled" true
+          (Json.member "host_fd_hotspot_blocking_enabled" json |> Json.to_bool))))
 
 let test_fd_pressure_degraded_projection () =
   FD.reset_for_tests ();

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -199,6 +199,17 @@ esac
 |}
        (quote state_file) (quote clean_marker))
 
+let write_fake_dune_local ~path ~log_file =
+  write_executable path
+    (Printf.sprintf
+       {|
+#!/bin/sh
+set -eu
+printf 'dune-local %%s\n' "$*" >> %s
+exec dune "$@"
+|}
+       (quote log_file))
+
 let make_fake_stdio_eio_exe repo_root =
   let exe_path =
     Filename.concat repo_root "_build/default/bin/main_stdio_eio.exe"
@@ -716,17 +727,23 @@ let test_stale_dune_artifacts_are_cleaned_and_retried () =
   with_temp_dir "start-masc-script-stale-dune" (fun dir ->
       with_temp_dir "start-masc-stale-dune-fake-bin" (fun fake_bin ->
           let script = Filename.concat dir "start-masc-mcp.sh" in
+          let scripts_dir = Filename.concat dir "scripts" in
           let dune_state = Filename.concat dir "dune-build-count.txt" in
           let clean_marker = Filename.concat dir "dune-clean-ran.txt" in
+          let dune_local_log = Filename.concat dir "dune-local-calls.txt" in
           let capture = Filename.concat dir "captured-stale-dune.txt" in
           copy_script (script_path ()) script;
           ignore (make_config_root dir);
+          mkdir_p scripts_dir;
           mkdir_p fake_bin;
           write_executable (Filename.concat fake_bin "opam")
             "#!/bin/sh\nexit 0\n";
           write_fake_dune_stale_then_success
             ~path:(Filename.concat fake_bin "dune")
             ~state_file:dune_state ~clean_marker;
+          write_fake_dune_local
+            ~path:(Filename.concat scripts_dir "dune-local.sh")
+            ~log_file:dune_local_log;
           let code, stdout, stderr =
             run_shell ~cwd:dir
               ~env:
@@ -747,6 +764,12 @@ let test_stale_dune_artifacts_are_cleaned_and_retried () =
                "FAKE_EXE_MARKER=eio-after-stale-retry");
           check bool "dune clean ran before retry" true
             (Sys.file_exists clean_marker);
+          let dune_local_calls = read_file dune_local_log in
+          check bool "startup build uses dune-local wrapper" true
+            (contains_substring dune_local_calls
+               "dune-local build bin/main_eio.exe");
+          check bool "stale cleanup uses dune-local wrapper" true
+            (contains_substring dune_local_calls "dune-local clean");
           check bool "original stale artifact error preserved" true
             (contains_substring stderr
                "make inconsistent assumptions over implementation Agent_sdk__Context_reducer");

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -205,7 +205,7 @@ let write_fake_dune_local ~path ~log_file =
        {|
 #!/bin/sh
 set -eu
-printf 'dune-local %%s\n' "$*" >> %s
+printf 'dune-local %%s DUNE_JOBS=%%s DUNE_LOCAL_JOBS=%%s\n' "$*" "${DUNE_JOBS:-}" "${DUNE_LOCAL_JOBS:-}" >> %s
 exec dune "$@"
 |}
        (quote log_file))
@@ -750,6 +750,7 @@ let test_stale_dune_artifacts_are_cleaned_and_retried () =
                 [
                   ("FAKE_CAPTURE_FILE", capture);
                   ("MASC_BASE_PATH", dir);
+                  ("MASC_DUNE_JOBS", "2");
                   ("PATH", fake_bin ^ ":" ^ Sys.getenv "PATH");
                 ]
               (Printf.sprintf "%s --http --port 9971 --base-path %s"
@@ -768,6 +769,9 @@ let test_stale_dune_artifacts_are_cleaned_and_retried () =
           check bool "startup build uses dune-local wrapper" true
             (contains_substring dune_local_calls
                "dune-local build bin/main_eio.exe");
+          check bool "startup forwards DUNE_JOBS into wrapper under CI" true
+            (contains_substring dune_local_calls
+               "DUNE_JOBS=2 DUNE_LOCAL_JOBS=2");
           check bool "stale cleanup uses dune-local wrapper" true
             (contains_substring dune_local_calls "dune-local clean");
           check bool "original stale artifact error preserved" true


### PR DESCRIPTION
## Summary
- make scripts/dune-local.sh fail fast when live Dune processes are running outside the wrapper
- make scripts/nofile-status.sh report bare Dune bypasses with ancestry-aware filtering
- document the local Dune FD containment workflow

Related: #15946

## Root cause
The machine-wide dune-local lock only protects cooperative builds. Direct dune build/test/exec invocations from another session can still compile concurrently and recreate host FD pressure.

## Validation
- bash -n scripts/dune-local.sh
- bash -n scripts/nofile-status.sh
- opam exec -- ocamlformat --check test/test_dune_local_script.ml
- git diff --check
- env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_dune_local_script.exe -> exits 75 and lists the current unwrapped dune exec/build processes
- env scripts/nofile-status.sh -> after stopping the two unwrapped Dune offenders, reports potential bare dune bypasses: none

Focused Dune binary build was intentionally not run because the host had live unwrapped Dune processes and queued local builds; adding another build would have amplified the FD incident this patch is preventing.