### PR TITLE
fix(dashboard): gate worktree gh lookups

### DIFF
--- a/lib/dashboard/dashboard_worktree_status.ml
+++ b/lib/dashboard/dashboard_worktree_status.ml
@@ -115,6 +115,7 @@ let run_gh_pr_list_with_gate ?clock ~branch argv =
       ~tool_name:github_gate_tool_name
       ~arguments:(`Assoc [ "branch", `String branch ])
       ~is_read_only:true
+      ~wait_timeout_override_sec:0.05
       ~on_reject:(fun message ->
         Log.Dashboard.warn
           "dashboard_worktree_status.query_pr_for_branch: github lane saturated for %s: %s"

--- a/lib/dashboard/dashboard_worktree_status.ml
+++ b/lib/dashboard/dashboard_worktree_status.ml
@@ -79,7 +79,52 @@ let get_head_sha path =
 (** Try [gh pr list --head <branch> --json number,state --limit 1].
     Returns [(pr_number, pr_state)] on success; both [None] on failure
     (gh not installed, auth missing, not a GitHub repo). *)
-let query_pr_for_branch branch =
+let github_gate_tool_name = "dashboard_worktree_status.gh_pr_list"
+
+let query_pr_runner_for_tests : (string list -> string) option Atomic.t =
+  Atomic.make None
+;;
+
+let run_gh_pr_list_argv argv =
+  match Atomic.get query_pr_runner_for_tests with
+  | Some run -> run argv
+  | None ->
+    Masc_exec.Exec_gate.run_argv
+      ~actor:(Masc_exec.Agent_id.of_string "dashboard/worktree_status")
+      ~raw_source:(exec_gate_raw_source argv)
+      ~summary:"dashboard_worktree_status gh pr list"
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Gh_shared ())
+      argv
+;;
+
+let github_gate_clock = function
+  | Some clock -> Some clock
+  | None ->
+    (match Process_eio.get_clock () with
+     | Ok clock -> Some clock
+     | Error _ -> None)
+;;
+
+let run_gh_pr_list_with_gate ?clock ~branch argv =
+  let run () = run_gh_pr_list_argv argv in
+  match github_gate_clock clock with
+  | None -> run ()
+  | Some clock ->
+    Tool_resource_gate.with_permit_raw
+      ~clock
+      ~tool_name:github_gate_tool_name
+      ~arguments:(`Assoc [ "branch", `String branch ])
+      ~is_read_only:true
+      ~on_reject:(fun message ->
+        Log.Dashboard.warn
+          "dashboard_worktree_status.query_pr_for_branch: github lane saturated for %s: %s"
+          branch
+          message;
+        "[]")
+      run
+;;
+
+let query_pr_for_branch ?clock branch =
   if branch = ""
   then None, None
   else (
@@ -87,14 +132,7 @@ let query_pr_for_branch branch =
       let argv =
         [ "gh"; "pr"; "list"; "--head"; branch; "--json"; "number,state"; "--limit"; "1" ]
       in
-      let output =
-        Masc_exec.Exec_gate.run_argv
-          ~actor:(Masc_exec.Agent_id.of_string "dashboard/worktree_status")
-          ~raw_source:(exec_gate_raw_source argv)
-          ~summary:"dashboard_worktree_status gh pr list"
-          ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Gh_shared ())
-          argv
-      in
+      let output = run_gh_pr_list_with_gate ?clock ~branch argv in
       (* Output is a JSON array: [{"number":42,"state":"OPEN"}] or [] *)
       match Yojson.Safe.from_string (String.trim output) with
       | `List (`Assoc fields :: _) ->
@@ -119,6 +157,13 @@ let query_pr_for_branch branch =
         (Printexc.to_string exn);
       None, None)
 ;;
+
+module For_testing = struct
+  let query_pr_for_branch = query_pr_for_branch
+  let github_gate_tool_name = github_gate_tool_name
+  let set_query_pr_runner run = Atomic.set query_pr_runner_for_tests (Some run)
+  let clear_query_pr_runner () = Atomic.set query_pr_runner_for_tests None
+end
 
 (* ------------------------------------------------------------------ *)
 (* Keeper-attached detection                                            *)

--- a/lib/dashboard/dashboard_worktree_status.mli
+++ b/lib/dashboard/dashboard_worktree_status.mli
@@ -45,3 +45,14 @@ val sse_events : base_path:string -> string list
     terminal [event: done\\ndata: {}\\n\\n] sentinel.  The caller
     writes these sequentially to the streaming response body and then
     closes the writer. *)
+
+module For_testing : sig
+  val query_pr_for_branch
+    :  ?clock:float Eio.Time.clock_ty Eio.Resource.t
+    -> string
+    -> int option * string option
+
+  val github_gate_tool_name : string
+  val set_query_pr_runner : (string list -> string) -> unit
+  val clear_query_pr_runner : unit -> unit
+end

--- a/lib/tool_resource_gate.ml
+++ b/lib/tool_resource_gate.ml
@@ -403,7 +403,14 @@ let gate_timeout_message gate wait_timeout =
     gate.env_var
 ;;
 
-let with_permit_raw ~clock ~tool_name ~arguments ~is_read_only ~on_reject f =
+let with_permit_raw
+      ?wait_timeout_override_sec
+      ~clock
+      ~tool_name
+      ~arguments
+      ~is_read_only
+      ~on_reject
+      f =
   let resource_class = classify ~tool_name ~arguments ~is_read_only in
   if (not (enabled ())) || resource_class = Ungated
   then f ()
@@ -411,7 +418,11 @@ let with_permit_raw ~clock ~tool_name ~arguments ~is_read_only ~on_reject f =
     match gate_for_class resource_class with
     | None -> f ()
     | Some gate ->
-      let wait_timeout = wait_timeout_sec () in
+      let wait_timeout =
+        match wait_timeout_override_sec with
+        | Some seconds -> max 0.001 seconds
+        | None -> wait_timeout_sec ()
+      in
       Atomic.incr gate.waiting;
       let acquired =
         try

--- a/lib/tool_resource_gate.ml
+++ b/lib/tool_resource_gate.ml
@@ -380,6 +380,7 @@ let classify ~tool_name ~arguments ~is_read_only =
   | Some (Tool_name.Masc_keeper tool) -> classify_masc_keeper_tool tool
   | None ->
     if String.starts_with ~prefix:"keeper_pr_" tool_name then Github
+    else if String.equal tool_name "dashboard_worktree_status.gh_pr_list" then Github
     else if String.starts_with ~prefix:"keeper_bash" tool_name then Shell
     else if string_contains tool_name "docker" || string_contains tool_name "sandbox"
     then Docker

--- a/test/dune
+++ b/test/dune
@@ -2262,3 +2262,4 @@
  (libraries masc_test_deps))
 
 (include stanzas/test_tool_resource_gate.inc)
+(include stanzas/test_dashboard_worktree_status.inc)

--- a/test/stanzas/test_dashboard_worktree_status.inc
+++ b/test/stanzas/test_dashboard_worktree_status.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_dashboard_worktree_status)
+ (modules test_dashboard_worktree_status)
+ (libraries masc_test_deps))

--- a/test/test_dashboard_worktree_status.ml
+++ b/test/test_dashboard_worktree_status.ml
@@ -1,0 +1,99 @@
+open Alcotest
+
+module Worktree_status = Masc_mcp.Dashboard_worktree_status
+module Gate = Masc_mcp.Tool_resource_gate
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some prior -> Unix.putenv name prior
+      | None -> Unix.putenv name "")
+    f
+;;
+
+let with_query_runner run f =
+  Worktree_status.For_testing.set_query_pr_runner run;
+  Fun.protect
+    ~finally:Worktree_status.For_testing.clear_query_pr_runner
+    f
+;;
+
+let test_query_pr_for_branch_parses_runner_output () =
+  let invoked = Atomic.make false in
+  with_query_runner
+    (fun argv ->
+       Atomic.set invoked true;
+       check
+         (list string)
+         "argv"
+         [ "gh"
+         ; "pr"
+         ; "list"
+         ; "--head"
+         ; "feature/gate"
+         ; "--json"
+         ; "number,state"
+         ; "--limit"
+         ; "1"
+         ]
+         argv;
+       {|[{"number":42,"state":"OPEN"}]|})
+    (fun () ->
+       let pr_number, pr_state =
+         Worktree_status.For_testing.query_pr_for_branch "feature/gate"
+       in
+       check (option int) "pr number" (Some 42) pr_number;
+       check (option string) "pr state" (Some "open") pr_state;
+       check bool "runner invoked" true (Atomic.get invoked))
+;;
+
+let test_query_pr_for_branch_respects_github_gate () =
+  Eio_main.run (fun env ->
+    let clock = Eio.Stdenv.clock env in
+    Fun.protect
+      ~finally:Gate.For_testing.reset
+      (fun () ->
+         Gate.For_testing.set_limits ~github:1 ();
+         with_env "MASC_TOOL_GATE_WAIT_TIMEOUT_SEC" "0.01" (fun () ->
+           let invoked = Atomic.make false in
+           with_query_runner
+             (fun _argv ->
+                Atomic.set invoked true;
+                {|[{"number":99,"state":"OPEN"}]|})
+             (fun () ->
+                Gate.with_permit_raw
+                  ~clock
+                  ~tool_name:"keeper_pr_list"
+                  ~arguments:(`Assoc [])
+                  ~is_read_only:false
+                  ~on_reject:(fun message ->
+                    failf "unexpected outer github gate rejection: %s" message)
+                  (fun () ->
+                     let pr_number, pr_state =
+                       Worktree_status.For_testing.query_pr_for_branch
+                         ~clock
+                         "feature/saturated"
+                     in
+                     check (option int) "pr number omitted" None pr_number;
+                     check (option string) "pr state omitted" None pr_state;
+                     check bool "runner not invoked" false (Atomic.get invoked))))))
+;;
+
+let () =
+  run
+    "Dashboard_worktree_status"
+    [ ( "github_gate"
+      , [ test_case
+            "query_pr_for_branch parses runner output"
+            `Quick
+            test_query_pr_for_branch_parses_runner_output
+        ; test_case
+            "query_pr_for_branch respects saturated github gate"
+            `Quick
+            test_query_pr_for_branch_respects_github_gate
+        ] )
+    ]
+;;

--- a/test/test_tool_resource_gate.ml
+++ b/test/test_tool_resource_gate.ml
@@ -69,6 +69,11 @@ let test_classifies_host_local_bottlenecks () =
        ~args:(`Assoc [ "op", `String "future_op" ]));
   check string "board write" "board_write" (classify "masc_board_post");
   check string "transition" "coordination_write" (classify "masc_transition");
+  check
+    string
+    "dashboard worktree gh lookup"
+    "github"
+    (classify ~is_read_only:true "dashboard_worktree_status.gh_pr_list");
   check string "bash output bypasses gate" "ungated" (classify "keeper_bash_output");
   check string "bash kill bypasses gate" "ungated" (classify "keeper_bash_kill");
   check string "status stays ungated" "ungated" (classify ~is_read_only:true "masc_status")


### PR DESCRIPTION
## Summary
- Route dashboard worktree `gh pr list --head ...` lookups through `Tool_resource_gate` as a GitHub lane consumer.
- Preserve dashboard best-effort behavior by returning no PR metadata on gate saturation instead of failing the worktree status view.
- Add focused coverage for parser behavior, gate saturation, and resource classification.

## Evidence
- Issue: #16127
- MASC goal: `goal-world-reactivity-p1-dashboard-gh-gate-20260518`
- MASC task: `task-395`
- MASC board comment: `c-7431079fbedf02b5e7eb961836778797`

## Verification
- `opam exec -- ocamlformat --check lib/tool_resource_gate.ml lib/dashboard/dashboard_worktree_status.ml lib/dashboard/dashboard_worktree_status.mli test/test_tool_resource_gate.ml test/test_dashboard_worktree_status.ml`
- `env DUNE_CACHE=disabled dune build --root . --build-dir /private/tmp/masc-mcp-build-dashboard-gh-gate-16127 test/test_dashboard_worktree_status.exe test/test_tool_resource_gate.exe -j 1 --display=short`
- `/private/tmp/masc-mcp-build-dashboard-gh-gate-16127/default/test/test_dashboard_worktree_status.exe`
- `/private/tmp/masc-mcp-build-dashboard-gh-gate-16127/default/test/test_tool_resource_gate.exe`
- `git diff --check`
