### PR TITLE
Use shell command gate for code shell exit classification

### DIFF
--- a/lib/shell_command_gate.ml
+++ b/lib/shell_command_gate.ml
@@ -1,0 +1,140 @@
+type cannot_parse_kind =
+  | Parse_error
+  | Parse_aborted of Masc_exec.Parsed.reason_aborted
+  | Too_complex of Masc_exec.Parsed.reason_too_complex
+
+type shape =
+  | Simple
+  | Pipeline of { stages : int }
+
+type parsed_context = {
+  ast : Masc_exec.Shell_ir.t;
+  shape : shape;
+  stage_bins : string list;
+}
+
+type reject_reason =
+  | Command_not_in_allowlist of { bin : string }
+  | Pipeline_segment_disallowed of { stage : int; bin : string }
+  | Pipes_not_allowed of { stages : int }
+
+type decision =
+  | Allow of parsed_context
+  | Reject of {
+      context : parsed_context;
+      reason : reject_reason;
+      diagnostic : string;
+    }
+  | Cannot_parse of { kind : cannot_parse_kind }
+
+let rec simples_of_ir = function
+  | Masc_exec.Shell_ir.Simple simple -> [ simple ]
+  | Masc_exec.Shell_ir.Pipeline stages -> List.concat_map simples_of_ir stages
+;;
+
+let shape_of_count = function
+  | 0 | 1 -> Simple
+  | stages -> Pipeline { stages }
+;;
+
+let parsed_context_of_ast ast =
+  let simples = simples_of_ir ast in
+  let stage_bins =
+    simples |> List.map (fun simple -> Masc_exec.Bin.to_string simple.Masc_exec.Shell_ir.bin)
+  in
+  { ast; shape = shape_of_count (List.length stage_bins); stage_bins }
+;;
+
+let parse cmd =
+  match Masc_exec_bash_parser.Bash.parse_string cmd with
+  | Masc_exec.Parsed.Parsed ast -> Ok (parsed_context_of_ast ast)
+  | Masc_exec.Parsed.Parse_error _ -> Error Parse_error
+  | Masc_exec.Parsed.Parse_aborted r -> Error (Parse_aborted r)
+  | Masc_exec.Parsed.Too_complex r -> Error (Too_complex r)
+;;
+
+let stage_count context = List.length context.stage_bins
+
+let last_stage_bin context =
+  match List.rev context.stage_bins with
+  | [] -> None
+  | bin :: _ -> Some bin
+;;
+
+let bin_allowed ~allowed_commands bin =
+  List.exists (String.equal bin) allowed_commands
+;;
+
+let first_disallowed_stage ~allowed_commands context =
+  let rec scan stage = function
+    | [] -> None
+    | bin :: rest ->
+      if bin_allowed ~allowed_commands bin then scan (stage + 1) rest else Some (stage, bin)
+  in
+  scan 1 context.stage_bins
+;;
+
+let validate_allowlist ?(allow_pipes = true) ~allowed_commands cmd =
+  match parse cmd with
+  | Error kind -> Cannot_parse { kind }
+  | Ok context ->
+    let stages = stage_count context in
+    if (not allow_pipes) && stages > 1
+    then
+      Reject
+        { context
+        ; reason = Pipes_not_allowed { stages }
+        ; diagnostic = "pipelines are not allowed for this command surface"
+        }
+    else (
+      match first_disallowed_stage ~allowed_commands context with
+      | None -> Allow context
+      | Some (stage, bin) ->
+        let reason =
+          match context.shape with
+          | Simple -> Command_not_in_allowlist { bin }
+          | Pipeline _ -> Pipeline_segment_disallowed { stage; bin }
+        in
+        let diagnostic =
+          match reason with
+          | Command_not_in_allowlist { bin } ->
+            Printf.sprintf "%s not in shell command allowlist" bin
+          | Pipeline_segment_disallowed { stage; bin } ->
+            Printf.sprintf "pipeline stage %d command %s not in shell command allowlist" stage bin
+          | Pipes_not_allowed { stages } ->
+            Printf.sprintf "pipeline with %d stages is not allowed" stages
+        in
+        Reject { context; reason; diagnostic })
+;;
+
+let cannot_parse_kind_tag = function
+  | Parse_error -> "parse_error"
+  | Parse_aborted `Timeout_50ms -> "timeout"
+  | Parse_aborted `Depth_limit -> "depth_limit"
+  | Parse_aborted `Token_limit_50k -> "token_limit"
+  | Too_complex `Heredoc -> "heredoc"
+  | Too_complex `Here_string -> "here_string"
+  | Too_complex `Cmd_subst -> "cmd_subst"
+  | Too_complex `Proc_subst -> "proc_subst"
+  | Too_complex `Subshell -> "subshell"
+  | Too_complex `Arith_expansion -> "arith_expansion"
+  | Too_complex `Control_flow -> "control_flow"
+  | Too_complex `Logic_op -> "logic_op"
+  | Too_complex `Function_def -> "function_def"
+  | Too_complex `Glob_brace -> "glob_brace"
+  | Too_complex `Background -> "background"
+  | Too_complex `Redirect -> "redirect"
+  | Too_complex (`Unknown_construct _) -> "other"
+;;
+
+let reject_reason_tag = function
+  | Command_not_in_allowlist _ -> "command"
+  | Pipeline_segment_disallowed _ -> "pipeline_segment"
+  | Pipes_not_allowed _ -> "pipes_not_allowed"
+;;
+
+let decision_tag = function
+  | Allow _ -> "allow"
+  | Reject _ -> "reject"
+  | Cannot_parse _ -> "cannot_parse"
+;;

--- a/lib/shell_command_gate.mli
+++ b/lib/shell_command_gate.mli
@@ -1,0 +1,52 @@
+(** Parse-once facade for shell command validation.
+
+    This module is the narrow bridge between raw shell strings and the
+    Shell_ir authority path. It preserves pipelines as first-class stage
+    lists so callers do not need local quote-aware pipe splitters. *)
+
+type cannot_parse_kind =
+  | Parse_error
+  | Parse_aborted of Masc_exec.Parsed.reason_aborted
+  | Too_complex of Masc_exec.Parsed.reason_too_complex
+
+type shape =
+  | Simple
+  | Pipeline of { stages : int }
+
+type parsed_context = {
+  ast : Masc_exec.Shell_ir.t;
+  shape : shape;
+  stage_bins : string list;
+}
+
+type reject_reason =
+  | Command_not_in_allowlist of { bin : string }
+  | Pipeline_segment_disallowed of { stage : int; bin : string }
+  | Pipes_not_allowed of { stages : int }
+
+type decision =
+  | Allow of parsed_context
+  | Reject of {
+      context : parsed_context;
+      reason : reject_reason;
+      diagnostic : string;
+    }
+  | Cannot_parse of { kind : cannot_parse_kind }
+
+val parse : string -> (parsed_context, cannot_parse_kind) result
+(** Parse a raw command into a reusable Shell_ir context. *)
+
+val validate_allowlist
+  :  ?allow_pipes:bool
+  -> allowed_commands:string list
+  -> string
+  -> decision
+(** Parse once, then enforce an exact binary-name allowlist over every
+    stage. [allow_pipes] defaults to [true]. *)
+
+val stage_count : parsed_context -> int
+val last_stage_bin : parsed_context -> string option
+
+val cannot_parse_kind_tag : cannot_parse_kind -> string
+val reject_reason_tag : reject_reason -> string
+val decision_tag : decision -> string

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -83,38 +83,16 @@ let first_token_basename segment =
     in
     Some (Filename.basename (String.sub trimmed 0 (find_sep 0)))
 
-let split_pipeline_segments command =
-  let len = String.length command in
-  let push_segment start stop acc =
-    String.sub command start (stop - start) |> String.trim |> fun segment ->
-    segment :: acc
-  in
-  let rec loop i quote escaped start acc =
-    if i >= len
-    then List.rev (push_segment start len acc)
-    else (
-      let c = command.[i] in
-      match quote, escaped, c with
-      | Some '\'', _, '\'' -> loop (i + 1) None false start acc
-      | Some '\'', _, _ -> loop (i + 1) quote false start acc
-      | _, true, _ -> loop (i + 1) quote false start acc
-      | _, false, '\\' -> loop (i + 1) quote true start acc
-      | None, false, '\'' -> loop (i + 1) (Some '\'') false start acc
-      | None, false, '"' -> loop (i + 1) (Some '"') false start acc
-      | Some '"', false, '"' -> loop (i + 1) None false start acc
-      | None, false, '|' -> loop (i + 1) None false (i + 1) (push_segment start i acc)
-      | _ -> loop (i + 1) quote false start acc)
-  in
-  loop 0 None false 0 []
-
-let last_pipeline_command_name command =
-  command |> split_pipeline_segments |> List.rev |> List.find_map first_token_basename
+let exit_status_command_name command =
+  match Shell_command_gate.parse command with
+  | Ok context -> Shell_command_gate.last_stage_bin context
+  | Error _ -> first_token_basename command
 
 let classify_code_shell_exit ~command code =
   match code with
   | 0 -> Shell_ok
   | 1 -> (
-      match last_pipeline_command_name command with
+      match exit_status_command_name command with
       | Some ("rg" | "grep") -> Shell_ok_expected_nonzero "no_matches"
       | Some "diff" -> Shell_ok_expected_nonzero "differences"
       | _ -> Shell_error)

--- a/test/dune
+++ b/test/dune
@@ -297,6 +297,7 @@
   test_telemetry_observe
   test_keeper_typed_labels
   test_shell_ir_typed_review_followup
+  test_shell_command_gate
   test_shell_ir_validator
   test_typed_advisor_counters
   test_auth_resolve_labels

--- a/test/test_shell_command_gate.ml
+++ b/test/test_shell_command_gate.ml
@@ -1,0 +1,84 @@
+module Gate = Masc_mcp.Shell_command_gate
+
+let allowed = [ "rg"; "sort"; "head"; "wc"; "cat" ]
+
+let check_stage_bins label expected context =
+  Alcotest.(check (list string)) label expected context.Gate.stage_bins
+;;
+
+let test_parse_three_stage_pipeline () =
+  match Gate.parse "rg foo lib | sort | head -20" with
+  | Error kind ->
+    Alcotest.failf "expected parsed pipeline, got %s" (Gate.cannot_parse_kind_tag kind)
+  | Ok context ->
+    Alcotest.(check int) "stage count" 3 (Gate.stage_count context);
+    check_stage_bins "stage bins" [ "rg"; "sort"; "head" ] context;
+    Alcotest.(check (option string)) "last stage" (Some "head") (Gate.last_stage_bin context);
+    (match context.Gate.shape with
+     | Gate.Pipeline { stages = 3 } -> ()
+     | Gate.Simple -> Alcotest.fail "expected pipeline shape"
+     | Gate.Pipeline { stages } -> Alcotest.failf "expected 3 stages, got %d" stages)
+;;
+
+let test_quoted_pipe_stays_inside_argument () =
+  match Gate.parse "rg 'foo|bar' lib | head -20" with
+  | Error kind ->
+    Alcotest.failf "expected parsed pipeline, got %s" (Gate.cannot_parse_kind_tag kind)
+  | Ok context ->
+    Alcotest.(check int) "stage count" 2 (Gate.stage_count context);
+    check_stage_bins "stage bins" [ "rg"; "head" ] context
+;;
+
+let test_quoted_pipe_single_stage () =
+  match Gate.validate_allowlist ~allowed_commands:allowed "rg 'foo|bar' lib" with
+  | Gate.Allow context ->
+    Alcotest.(check int) "stage count" 1 (Gate.stage_count context);
+    check_stage_bins "stage bins" [ "rg" ] context
+  | other -> Alcotest.failf "expected Allow, got %s" (Gate.decision_tag other)
+;;
+
+let test_rejects_disallowed_pipeline_stage_with_index () =
+  match Gate.validate_allowlist ~allowed_commands:allowed "rg foo | sed s/a/b/ | head -20" with
+  | Gate.Reject { reason = Gate.Pipeline_segment_disallowed { stage = 2; bin = "sed" }; _ } -> ()
+  | other ->
+    Alcotest.failf
+      "expected stage 2 sed rejection, got %s"
+      (Gate.decision_tag other)
+;;
+
+let test_rejects_pipes_when_disabled () =
+  match
+    Gate.validate_allowlist ~allow_pipes:false ~allowed_commands:allowed "rg foo | head -20"
+  with
+  | Gate.Reject { reason = Gate.Pipes_not_allowed { stages = 2 }; _ } -> ()
+  | other ->
+    Alcotest.failf
+      "expected Pipes_not_allowed rejection, got %s"
+      (Gate.decision_tag other)
+;;
+
+let test_too_complex_shell_chain () =
+  match Gate.validate_allowlist ~allowed_commands:allowed "rg foo && head file" with
+  | Gate.Cannot_parse { kind = Gate.Too_complex `Logic_op } -> ()
+  | other ->
+    Alcotest.failf "expected Too_complex Logic_op, got %s" (Gate.decision_tag other)
+;;
+
+let () =
+  Alcotest.run
+    "shell_command_gate"
+    [ ( "parse"
+      , [ Alcotest.test_case "three-stage pipeline" `Quick test_parse_three_stage_pipeline
+        ; Alcotest.test_case "quoted pipe in pipeline" `Quick test_quoted_pipe_stays_inside_argument
+        ] )
+    ; ( "validate"
+      , [ Alcotest.test_case "quoted pipe single stage" `Quick test_quoted_pipe_single_stage
+        ; Alcotest.test_case
+            "disallowed pipeline stage reports index"
+            `Quick
+            test_rejects_disallowed_pipeline_stage_with_index
+        ; Alcotest.test_case "pipes disabled" `Quick test_rejects_pipes_when_disabled
+        ; Alcotest.test_case "shell chain is too complex" `Quick test_too_complex_shell_chain
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

Second PR in the Shell IR stacked sequence.

- removes `tool_code_write`'s local quote-aware pipeline splitter
- uses `Shell_command_gate.parse` and `Shell_command_gate.last_stage_bin` for code-shell exit classification
- keeps a conservative single-command fallback for parser-unsupported shapes

## Stack

Base PR: #16131 (`stack/shell-command-gate-pr1`)

This PR depends on the facade introduced by #16131 and deliberately avoids changing the broader command validation path yet. The next stack slice can move `Worker_dev_tools.validate_command_coding_with_allowlist` to the same parse-once gate.

## Validation

- `ocamlformat --check lib/tool_code_write.ml`
- `git diff --check`

Not completed locally:

- targeted Dune build

The shared `/tmp/me-dune-local.lock` is still held by active keeper builds, so this remains a draft with CI as the first compile signal for the stacked branch.
