### PR TITLE
refactor: split coord goal verification helpers

### DIFF
--- a/lib/coord_goals.ml
+++ b/lib/coord_goals.ml
@@ -299,18 +299,7 @@ let parse_optional_transition_action args field =
          ~received:(Yojson.Safe.to_string json))
 ;;
 
-let actor_must_be_operator action =
-  match action with
-  | Goal_phase.Operator_block
-  | Goal_phase.Operator_unblock
-  | Goal_phase.Approve_completion
-  | Goal_phase.Reject_completion -> true
-  | Goal_phase.Request_complete
-  | Goal_phase.Pause
-  | Goal_phase.Resume
-  | Goal_phase.Drop
-  | Goal_phase.Reopen -> false
-;;
+let actor_must_be_operator = Coord_goals_verification.actor_must_be_operator
 
 let validate_goal_completion_ready config ~goal_id ~override_note =
   match override_note with
@@ -377,100 +366,11 @@ let parse_optional_string_list args field =
          ~received:(Yojson.Safe.to_string json))
 ;;
 
-let goal_policy_nodes goals =
-  List.map
-    (fun (goal : Goal_store.goal) ->
-       { Goal_verification.goal_id = goal.id
-       ; parent_goal_id = goal.parent_goal_id
-       ; verifier_policy = goal.verifier_policy
-       })
-    goals
-;;
+let goal_policy_nodes = Coord_goals_verification.goal_policy_nodes
+let verification_summary_json = Coord_goals_verification.verification_summary_json
+let update_goal_phase = Coord_goals_verification.update_goal_phase
 
-let verification_summary_json
-      ?latest_request
-      (goal : Goal_store.goal)
-      (effective_policy : Goal_verification.policy_snapshot option)
-      (open_request : Goal_verification.goal_verification_request option)
-  =
-  let latest_request =
-    match latest_request with
-    | Some request -> Some request
-    | None -> open_request
-  in
-  let effective_policy_json =
-    match effective_policy with
-    | None -> `Null
-    | Some policy -> Goal_verification.policy_snapshot_to_yojson policy
-  in
-  let open_request_json =
-    match open_request with
-    | None -> `Null
-    | Some request -> Goal_verification.goal_verification_request_to_yojson request
-  in
-  let latest_request_json =
-    match latest_request with
-    | None -> `Null
-    | Some request -> Goal_verification.goal_verification_request_to_yojson request
-  in
-  let approve_count, reject_count, remaining_possible =
-    let summary_request =
-      match open_request with
-      | Some request -> Some request
-      | None -> latest_request
-    in
-    match summary_request with
-    | None -> 0, 0, 0
-    | Some request ->
-      ( Goal_verification.count_votes ~decision:Goal_verification.Approve request
-      , Goal_verification.count_votes ~decision:Goal_verification.Reject request
-      , Goal_verification.remaining_possible_votes request )
-  in
-  `Assoc
-    [ "phase", Goal_phase.to_yojson goal.phase
-    ; "effective_policy", effective_policy_json
-    ; "open_request", open_request_json
-    ; "latest_request", latest_request_json
-    ; "approve_count", `Int approve_count
-    ; "reject_count", `Int reject_count
-    ; "remaining_possible", `Int remaining_possible
-    ; "pending_verification_count", `Int (if Option.is_none open_request then 0 else 1)
-    ]
-;;
-
-let update_goal_phase
-      (ctx : context)
-      (goal : Goal_store.goal)
-      ~phase
-      ?note
-      ?active_verification_request_id
-      ?(clear_active_verification_request = false)
-      ()
-  =
-  let last_review_note, last_review_at =
-    match note with
-    | Some note -> Some note, Some (Masc_domain.now_iso ())
-    | None -> goal.last_review_note, goal.last_review_at
-  in
-  Goal_store.update_goal ctx.config ~goal_id:goal.id (fun current ->
-    { current with
-      phase
-    ; status = Goal_store.goal_status_of_phase phase
-    ; active_verification_request_id =
-        (if clear_active_verification_request
-         then None
-         else (
-           match active_verification_request_id with
-           | Some value -> Some value
-           | None -> current.active_verification_request_id))
-    ; last_review_note
-    ; last_review_at
-    })
-;;
-
-let emit_goal_event ctx ~goal_id ~event_type ~payload =
-  Goal_verification.emit_event ctx.config ~goal_id ~event_type ~payload
-;;
+let emit_goal_event = Coord_goals_verification.emit_goal_event
 
 let handle_goal_list ~tool_name ~start_time (ctx : context) args : Tool_result.t =
   match

--- a/lib/coord_goals_verification.ml
+++ b/lib/coord_goals_verification.ml
@@ -1,0 +1,109 @@
+(** Verification helpers for goal-management tool handlers. *)
+
+let goal_policy_nodes goals =
+  List.map
+    (fun (goal : Goal_store.goal) ->
+       { Goal_verification.goal_id = goal.id
+       ; parent_goal_id = goal.parent_goal_id
+       ; verifier_policy = goal.verifier_policy
+       })
+    goals
+;;
+
+let verification_summary_json
+      ?latest_request
+      (goal : Goal_store.goal)
+      (effective_policy : Goal_verification.policy_snapshot option)
+      (open_request : Goal_verification.goal_verification_request option)
+  =
+  let latest_request =
+    match latest_request with
+    | Some request -> Some request
+    | None -> open_request
+  in
+  let effective_policy_json =
+    match effective_policy with
+    | None -> `Null
+    | Some policy -> Goal_verification.policy_snapshot_to_yojson policy
+  in
+  let open_request_json =
+    match open_request with
+    | None -> `Null
+    | Some request -> Goal_verification.goal_verification_request_to_yojson request
+  in
+  let latest_request_json =
+    match latest_request with
+    | None -> `Null
+    | Some request -> Goal_verification.goal_verification_request_to_yojson request
+  in
+  let approve_count, reject_count, remaining_possible =
+    let summary_request =
+      match open_request with
+      | Some request -> Some request
+      | None -> latest_request
+    in
+    match summary_request with
+    | None -> 0, 0, 0
+    | Some request ->
+      ( Goal_verification.count_votes ~decision:Goal_verification.Approve request
+      , Goal_verification.count_votes ~decision:Goal_verification.Reject request
+      , Goal_verification.remaining_possible_votes request )
+  in
+  `Assoc
+    [ "phase", Goal_phase.to_yojson goal.phase
+    ; "effective_policy", effective_policy_json
+    ; "open_request", open_request_json
+    ; "latest_request", latest_request_json
+    ; "approve_count", `Int approve_count
+    ; "reject_count", `Int reject_count
+    ; "remaining_possible", `Int remaining_possible
+    ; "pending_verification_count", `Int (if Option.is_none open_request then 0 else 1)
+    ]
+;;
+
+let update_goal_phase
+      (ctx : Coord_types.context)
+      (goal : Goal_store.goal)
+      ~phase
+      ?note
+      ?active_verification_request_id
+      ?(clear_active_verification_request = false)
+      ()
+  =
+  let last_review_note, last_review_at =
+    match note with
+    | Some note -> Some note, Some (Masc_domain.now_iso ())
+    | None -> goal.last_review_note, goal.last_review_at
+  in
+  Goal_store.update_goal ctx.config ~goal_id:goal.id (fun current ->
+    { current with
+      phase
+    ; status = Goal_store.goal_status_of_phase phase
+    ; active_verification_request_id =
+        (if clear_active_verification_request
+         then None
+         else (
+           match active_verification_request_id with
+           | Some value -> Some value
+           | None -> current.active_verification_request_id))
+    ; last_review_note
+    ; last_review_at
+    })
+;;
+
+let actor_must_be_operator action =
+  match action with
+  | Goal_phase.Operator_block
+  | Goal_phase.Operator_unblock
+  | Goal_phase.Approve_completion
+  | Goal_phase.Reject_completion -> true
+  | Goal_phase.Request_complete
+  | Goal_phase.Pause
+  | Goal_phase.Resume
+  | Goal_phase.Drop
+  | Goal_phase.Reopen -> false
+;;
+
+let emit_goal_event ctx ~goal_id ~event_type ~payload =
+  Goal_verification.emit_event ctx.Coord_types.config ~goal_id ~event_type ~payload
+;;

--- a/lib/coord_goals_verification.mli
+++ b/lib/coord_goals_verification.mli
@@ -1,0 +1,29 @@
+(** Verification helpers for goal-management tool handlers. *)
+
+val goal_policy_nodes : Goal_store.goal list -> Goal_verification.goal_policy_node list
+
+val verification_summary_json
+  :  ?latest_request:Goal_verification.goal_verification_request
+  -> Goal_store.goal
+  -> Goal_verification.policy_snapshot option
+  -> Goal_verification.goal_verification_request option
+  -> Yojson.Safe.t
+
+val update_goal_phase
+  :  Coord_types.context
+  -> Goal_store.goal
+  -> phase:Goal_phase.t
+  -> ?note:string
+  -> ?active_verification_request_id:string
+  -> ?clear_active_verification_request:bool
+  -> unit
+  -> (Goal_store.goal, string) result
+
+val actor_must_be_operator : Goal_phase.action -> bool
+
+val emit_goal_event
+  :  Coord_types.context
+  -> goal_id:string
+  -> event_type:string
+  -> payload:Yojson.Safe.t
+  -> unit

--- a/lib/dune
+++ b/lib/dune
@@ -207,6 +207,7 @@
   tool_inline_dispatch_types
   tool_inline_dispatch_coord
   tool_inline_dispatch_comm
+  coord_goals_verification
   ;; tool_schema_dsl — shared JSON Schema builder (added by #3640)
   tool_schema_dsl
   tool_misc_transport


### PR DESCRIPTION
## Summary
- Extract goal verification summary / phase update helpers into `Coord_goals_verification`.
- Preserve the existing `Coord_goals` handler API.
- Reduce `lib/coord_goals.ml` from 1095 lines to 995 lines.

## Validation
- `ocamlformat --check lib/coord_goals.ml lib/coord_goals_verification.ml lib/coord_goals_verification.mli`
- `git diff --check`
- `bash scripts/lint/godfile-size-regression.sh`
- `scripts/ocaml-structure-ratchet.sh --print`
- `scripts/dune-local.sh build lib/masc_mcp.cma`
- `scripts/dune-local.sh build test/test_goal_tools.exe`
- `./_build/default/test/test_goal_tools.exe`

## Note
- First focused build attempt hit a transient Dune global cache cleanup error (`rmdir(.../dune_*_artifacts): Directory not empty`); immediate retry passed.
