### PR TITLE
test: pin MCP H1/H2 admission parity

### DIFF
--- a/.ci/path-ssot-allowlist.txt
+++ b/.ci/path-ssot-allowlist.txt
@@ -28,6 +28,11 @@ lib/keeper/keeper_egress_audit.ml:54
 let default_local_path id = Filename.concat ".masc/repos" id
 Option.value ~default:(Filename.concat ".masc/repos" id)
 
+# Config_dir_resolver is the SSOT itself; these comment examples document the
+# bypass pattern the audit forbids outside this module.
+helpers instead of [Filename.concat base_path ".masc/..."] string-literal
+Layout SSOT: callers stop computing [Filename.concat base_path ".masc/X"]
+
 # Self-reference inside the audit script and RFC text.
 scripts/audit-path-ssot.sh
 docs/rfc/RFC-0121-config-dir-resolution-single-active-root.md

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 401 unique knobs across 8 modules.
+**Total**: 401 unique knobs across 9 modules.
 
-**Typed getter classification**: 6/236 tagged (`operator`: 6, `algorithm`: 0, `unclassified`: 230).
+**Typed getter classification**: 26/236 tagged (`operator`: 26, `algorithm`: 0, `unclassified`: 210).
 
 ## Env_config_core (30 knobs; typed classification 0/7)
 
@@ -99,19 +99,19 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 52 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 | `MASC_SSE_KEEPALIVE_SEC` | typed:float | unclassified | unclassified | 112 | SSE keepalive interval (seconds). Frequency of `: keepalive` frames on command-plane SSE streams. Clamped to >= 1.0 t... |
 
-## Env_config_keeper (106 knobs; typed classification 3/94)
+## Env_config_keeper (85 knobs; typed classification 3/74)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 360 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CASCADE_ATTEMPT_LIVENESS` | typed:string | unclassified | unclassified | 1070 |  |
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 800 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 912 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 913 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 914 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 915 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 918 |  |
-| `MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 513 | Maximum time a proactive keeper will wait in the MASC admission queue before abandoning the current OAS attempt. With... |
+| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 226 | Alert dedup window, clamped to >= 5s. Default: 60. |
+| `MASC_CASCADE_ATTEMPT_LIVENESS` | typed:string | unclassified | unclassified | 936 |  |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 666 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 778 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 779 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 780 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 781 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 784 |  |
+| `MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 379 | Maximum time a proactive keeper will wait in the MASC admission queue before abandoning the current OAS attempt. With... |
 | `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | unclassified | unclassified | 108 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | n/a | n/a | 105 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_HEARTH` | typed:string | unclassified | unclassified | 111 |  |
@@ -129,18 +129,11 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_ALERT_SLACK_DM_USER_ID` | typed:string | unclassified | unclassified | 127 |  |
 | `MASC_KEEPER_ALERT_SLACK_ENABLED` | feature_flag | n/a | n/a | 118 | Slack fanout configuration |
 | `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 120 | Slack fanout configuration |
-| `MASC_KEEPER_ALIVE_BUT_STUCK_DEDUP_TTL_SEC` | typed:float | unclassified | unclassified | 271 | Per-keeper dedup window (seconds): once a keeper is flagged the counter is incremented at most once per window, even ... |
-| `MASC_KEEPER_ALIVE_BUT_STUCK_ENABLED` | typed:bool | unclassified | unclassified | 239 | Signal for alive-but-stuck keepers (#12838) â€” keepers that are not Dead/Zombie and not paused, but whose [proactive... |
-| `MASC_KEEPER_ALIVE_BUT_STUCK_RECOVERY_ENABLED` | typed:bool | unclassified | unclassified | 247 | Queue a bounded recovery wakeup when [alive_but_stuck_scan] emits. The recovery uses the Event Layer queue plus [fibe... |
-| `MASC_KEEPER_ALIVE_BUT_STUCK_STALL_FLOOR_SEC` | typed:float | unclassified | unclassified | 264 | Hard floor (seconds) so keepers with very small cooldowns are not flagged after a few minutes of legitimate quiet.  T... |
-| `MASC_KEEPER_ALIVE_BUT_STUCK_STALL_MULTIPLIER` | typed:int | unclassified | unclassified | 254 | Multiplier on the keeper's own [proactive.cooldown_sec] before a stalled keeper is flagged.  Default: 10 (10 cooldown... |
-| `MASC_KEEPER_AUTONOMOUS_QUEUE_POLL_SEC` | typed:float | unclassified | unclassified | 308 | Autonomous-turn semaphore queue poll interval in seconds. Polled inside the autonomous-turn admission loop in {!Keepe... |
-| `MASC_KEEPER_AUTONOMOUS_SLOT_WAIT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 526 | Maximum time a scheduled autonomous keeper will wait for the local keeper turn gate before skipping the cycle. Reacti... |
-| `MASC_KEEPER_AUTO_RESUME_INITIAL_SEC` | typed:float | unclassified | unclassified | 190 | Initial auto-resume backoff delay after an auto-pause (seconds). On every successive auto-pause the delay doubles, ca... |
-| `MASC_KEEPER_AUTO_RESUME_MAX_SEC` | typed:float | unclassified | unclassified | 195 | Maximum auto-resume backoff delay (seconds).  Default: 86400 (24 hours). |
-| `MASC_KEEPER_BATCH_THRESHOLD` | typed:int | unclassified | unclassified | 745 | Number of distinct keepers terminating within [batch_window_sec] before emitting a fleet batch alert. Default: 5. |
-| `MASC_KEEPER_BATCH_WINDOW_SEC` | typed:float | unclassified | unclassified | 740 | Fleet batch-termination detection window in seconds. Default: 60. |
-| `MASC_KEEPER_BOARD_DEBOUNCE_SEC` | typed:float | unclassified | unclassified | 422 | Board-reactive wakeup debounce in seconds. Prevents rapid repeated wakeups from the same board post. Default: 60.0. R... |
+| `MASC_KEEPER_AUTONOMOUS_QUEUE_POLL_SEC` | typed:float | unclassified | unclassified | 174 | Autonomous-turn semaphore queue poll interval in seconds. Polled inside the autonomous-turn admission loop in {!Keepe... |
+| `MASC_KEEPER_AUTONOMOUS_SLOT_WAIT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 392 | Maximum time a scheduled autonomous keeper will wait for the local keeper turn gate before skipping the cycle. Reacti... |
+| `MASC_KEEPER_BATCH_THRESHOLD` | typed:int | unclassified | unclassified | 611 | Number of distinct keepers terminating within [batch_window_sec] before emitting a fleet batch alert. Default: 5. |
+| `MASC_KEEPER_BATCH_WINDOW_SEC` | typed:float | unclassified | unclassified | 606 | Fleet batch-termination detection window in seconds. Default: 60. |
+| `MASC_KEEPER_BOARD_DEBOUNCE_SEC` | typed:float | unclassified | unclassified | 288 | Board-reactive wakeup debounce in seconds. Prevents rapid repeated wakeups from the same board post. Default: 60.0. R... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
@@ -148,67 +141,79 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 966 | Comma-separated provider kind allowlist for every keeper cascade call. Values are OAS [Provider_config.string_of_prov... |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 640 | Stdout-idle timeout for CLI subprocess transports (Kimi CLI today; Claude Code / Gemini CLI / Codex CLI need an OAS u... |
-| `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 297 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
-| `MASC_KEEPER_DEAD_TTL_SEC` | typed:float | unclassified | unclassified | 175 | Dead tombstone TTL: seconds before Dead entries are cleaned up |
-| `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 316 | Enable keeper debug logging. Default: false. |
-| `MASC_KEEPER_DEGRADED_RETRY_SLOT_PHASE_BUDGET_SEC` | typed:float | Timeouts | operator | 1044 | Productive slot-phase budget (seconds).  PR #13120: when a cascade returns a recoverable error after the keeper has a... |
-| `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 322 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_DOCKER_CONTAINER` | typed:string | unclassified | unclassified | 852 | Docker container name for keeper playground execution. Env: [MASC_KEEPER_DOCKER_CONTAINER]. Default: "keeper-playgrou... |
-| `MASC_KEEPER_DOCKER_PLAYGROUND_ROOT` | typed:string | unclassified | unclassified | 862 | Container-side root under which keeper playground bundles are mounted. Host [<base_path>/.masc/playground/<keeper>/â€... |
-| `MASC_KEEPER_DOCKER_READ` | typed:bool | unclassified | unclassified | 908 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
-| `MASC_KEEPER_DOMAIN_POOL_ENABLED` | feature_flag | n/a | n/a | 147 | Route per-keeper supervise fork through the shared [Domain_pool] (RFC-0059 PR-7-pilot) instead of staying on the main... |
-| `MASC_KEEPER_ESCALATION_THRESHOLD` | typed:int | unclassified | unclassified | 735 | Number of stale terminations within [termination_window_sec] before escalating to [Stale_termination_storm]. Default: 5. |
-| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 754 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 762 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 365 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
-| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 437 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
-| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 650 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. With tool_ch... |
-| `MASC_KEEPER_LIVENESS_RECOVERY_BACKOFF_BASE_SEC` | typed:float | unclassified | unclassified | 217 | Base backoff delay (seconds) between liveness recovery attempts per keeper. Exponential: attempt 0 = base, 1 = 2*base... |
-| `MASC_KEEPER_LIVENESS_RECOVERY_BACKOFF_MAX_SEC` | typed:float | unclassified | unclassified | 225 | Maximum backoff delay cap (seconds) for liveness recovery. Default: 3600 (1 hour). |
-| `MASC_KEEPER_LIVENESS_RECOVERY_ENABLED` | typed:bool | unclassified | unclassified | 201 | Liveness Recovery Supervisor (#12801): enable auto-recovery of Dead keepers whose root cause has cleared.  Set to fal... |
-| `MASC_KEEPER_LIVENESS_RECOVERY_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 231 | Maximum total liveness recovery attempts per keeper before giving up permanently.  Default: 5. |
-| `MASC_KEEPER_LIVENESS_RECOVERY_MIN_DEAD_SEC` | typed:float | unclassified | unclassified | 208 | Minimum time (seconds) a keeper must have been Dead before a liveness recovery attempt is made.  Allows transient roo... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 406 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 789 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 413 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 452 | Max idle turns for scheduled autonomous keeper turns. With tool_choice=Any and max_turns=50, keepers have room to exp... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 459 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger â€” more ... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 380 | Maximum seconds since last successful room heartbeat before presence sync is required again. Floor = keepalive interv... |
-| `MASC_KEEPER_MAX_TRANSIENT_RETRIES` | typed:int | unclassified | unclassified | 992 | Maximum outer-loop retries after the initial attempt. Total attempts = 1 initial + max_transient_retries. Env: [MASC_... |
+| `MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 832 | Comma-separated provider kind allowlist for every keeper cascade call. Values are OAS [Provider_config.string_of_prov... |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 506 | Stdout-idle timeout for CLI subprocess transports (Kimi CLI today; Claude Code / Gemini CLI / Codex CLI need an OAS u... |
+| `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 163 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
+| `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 182 | Enable keeper debug logging. Default: false. |
+| `MASC_KEEPER_DEGRADED_RETRY_SLOT_PHASE_BUDGET_SEC` | typed:float | Timeouts | operator | 910 | Productive slot-phase budget (seconds).  PR #13120: when a cascade returns a recoverable error after the keeper has a... |
+| `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 188 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
+| `MASC_KEEPER_DOCKER_CONTAINER` | typed:string | unclassified | unclassified | 718 | Docker container name for keeper playground execution. Env: [MASC_KEEPER_DOCKER_CONTAINER]. Default: "keeper-playgrou... |
+| `MASC_KEEPER_DOCKER_PLAYGROUND_ROOT` | typed:string | unclassified | unclassified | 728 | Container-side root under which keeper playground bundles are mounted. Host [<base_path>/.masc/playground/<keeper>/â€... |
+| `MASC_KEEPER_DOCKER_READ` | typed:bool | unclassified | unclassified | 774 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
+| `MASC_KEEPER_ESCALATION_THRESHOLD` | typed:int | unclassified | unclassified | 601 | Number of stale terminations within [termination_window_sec] before escalating to [Stale_termination_storm]. Default: 5. |
+| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 620 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 628 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 231 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
+| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 303 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
+| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 516 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. With tool_ch... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 272 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 655 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 279 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 318 | Max idle turns for scheduled autonomous keeper turns. With tool_choice=Any and max_turns=50, keepers have room to exp... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 325 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger â€” more ... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 246 | Maximum seconds since last successful room heartbeat before presence sync is required again. Floor = keepalive interv... |
+| `MASC_KEEPER_MAX_TRANSIENT_RETRIES` | typed:int | unclassified | unclassified | 858 | Maximum outer-loop retries after the initial attempt. Total attempts = 1 initial + max_transient_retries. Env: [MASC_... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 78 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 81 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` | typed:int | unclassified | unclassified | 562 | Maximum turns per single OAS Agent.run call. Keeper resumes via checkpoint in the next keepalive cycle when {!Cascade... |
-| `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS` | typed:int | unclassified | unclassified | 585 |  |
-| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 543 | Per-call timeout in seconds for a single OAS Agent.run execution. Guards against indefinite LLM response waits within... |
-| `MASC_KEEPER_PAUSED_CLEANUP_TTL_SEC` | typed:float | unclassified | unclassified | 182 | Paused keeper file TTL: seconds before stale paused keeper meta files are removed from disk. Default: 86400 (24 hours). |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 772 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
-| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 343 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
-| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 352 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
-| `MASC_KEEPER_SELF_PRESERVATION_MIN_CANDIDATES` | typed:int | unclassified | unclassified | 171 | Self-preservation: minimum crashed candidates to trigger |
-| `MASC_KEEPER_SELF_PRESERVATION_RATIO` | typed:float | unclassified | unclassified | 166 | Self-preservation: ratio of crashed keepers to trigger suppression |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 429 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
-| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 390 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
-| `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 326 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 778 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 625 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
-| `MASC_KEEPER_SUPERVISOR_BACKOFF_BASE_S` | typed:float | unclassified | unclassified | 154 | Base delay for exponential backoff between restarts (seconds) |
-| `MASC_KEEPER_SUPERVISOR_BACKOFF_MAX_S` | typed:float | unclassified | unclassified | 157 | Maximum backoff delay cap (seconds) |
-| `MASC_KEEPER_SUPERVISOR_MAX_RESTARTS` | typed:int | unclassified | unclassified | 151 | Maximum restart attempts before declaring a keeper dead |
-| `MASC_KEEPER_SUPERVISOR_SWEEP_SEC` | typed:float | unclassified | unclassified | 160 | Interval between supervisor sweep runs (seconds) |
-| `MASC_KEEPER_SYMMETRIC_SANDBOX` | typed:bool | unclassified | unclassified | 900 | Legacy RFC-0006 Phase B-1 flag. Read-side containment now follows [sandbox_profile=docker] unconditionally. This gett... |
-| `MASC_KEEPER_TERMINATION_WINDOW_SEC` | typed:float | unclassified | unclassified | 730 | Sliding window for stale-termination escalation tracking. Default: 21600 (6 hours). |
-| `MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC` | typed:float | unclassified | unclassified | 998 | Base delay (seconds) for exponential backoff. Delay at attempt [n] is [base * 2^(n-1)]. Env: [MASC_KEEPER_TRANSIENT_B... |
-| `MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC` | typed:float | unclassified | unclassified | 1004 | Hard cap on backoff delay (seconds). Env: [MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC].  Default: 4.0. |
-| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 493 | Wall-clock timeout in seconds for a single unified turn (including all retries and cascade fallbacks). Prevents indef... |
-| `MASC_KEEPER_WATCHDOG_GRACE_SEC` | typed:float | unclassified | unclassified | 724 | Grace period after fiber start before idle-stale detection activates. Prevents false positives on server restart when... |
-| `MASC_KEEPER_WATCHDOG_NOOP_THRESHOLD` | typed:int | unclassified | unclassified | 716 | Consecutive noop turns before considering the keeper stuck in a failure loop. Must be >= 2. Default: 3. |
-| `MASC_KEEPER_WATCHDOG_POLL_SEC` | typed:float | unclassified | unclassified | 712 | Watchdog poll interval in seconds. Must be >= 5. Default: 30. |
-| `MASC_KEEPER_WATCHDOG_PROGRESS_SEC` | typed:float | Timeouts | operator | 697 | Seconds since the last in-turn progress signal before an active turn is considered mid-turn-stale. Default: 300 (5 mi... |
-| `MASC_KEEPER_WATCHDOG_STALE_SEC` | typed:float | unclassified | unclassified | 672 | Seconds since last turn before a Running keeper is considered idle-stale. Must be >= 60. Default: 300 (5 minutes). In... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 374 | Master switch. When true, successful Coord.heartbeat after a unified turn counts as presence proof, allowing the next... |
-| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 936 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` | typed:int | unclassified | unclassified | 428 | Maximum turns per single OAS Agent.run call. Keeper resumes via checkpoint in the next keepalive cycle when {!Cascade... |
+| `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS` | typed:int | unclassified | unclassified | 451 |  |
+| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 409 | Per-call timeout in seconds for a single OAS Agent.run execution. Guards against indefinite LLM response waits within... |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 638 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 209 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
+| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 218 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 295 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
+| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 256 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
+| `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 192 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 644 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 491 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
+| `MASC_KEEPER_SYMMETRIC_SANDBOX` | typed:bool | unclassified | unclassified | 766 | Legacy RFC-0006 Phase B-1 flag. Read-side containment now follows [sandbox_profile=docker] unconditionally. This gett... |
+| `MASC_KEEPER_TERMINATION_WINDOW_SEC` | typed:float | unclassified | unclassified | 596 | Sliding window for stale-termination escalation tracking. Default: 21600 (6 hours). |
+| `MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC` | typed:float | unclassified | unclassified | 864 | Base delay (seconds) for exponential backoff. Delay at attempt [n] is [base * 2^(n-1)]. Env: [MASC_KEEPER_TRANSIENT_B... |
+| `MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC` | typed:float | unclassified | unclassified | 870 | Hard cap on backoff delay (seconds). Env: [MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC].  Default: 4.0. |
+| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 359 | Wall-clock timeout in seconds for a single unified turn (including all retries and cascade fallbacks). Prevents indef... |
+| `MASC_KEEPER_WATCHDOG_GRACE_SEC` | typed:float | unclassified | unclassified | 590 | Grace period after fiber start before idle-stale detection activates. Prevents false positives on server restart when... |
+| `MASC_KEEPER_WATCHDOG_NOOP_THRESHOLD` | typed:int | unclassified | unclassified | 582 | Consecutive noop turns before considering the keeper stuck in a failure loop. Must be >= 2. Default: 3. |
+| `MASC_KEEPER_WATCHDOG_POLL_SEC` | typed:float | unclassified | unclassified | 578 | Watchdog poll interval in seconds. Must be >= 5. Default: 30. |
+| `MASC_KEEPER_WATCHDOG_PROGRESS_SEC` | typed:float | Timeouts | operator | 563 | Seconds since the last in-turn progress signal before an active turn is considered mid-turn-stale. Default: 300 (5 mi... |
+| `MASC_KEEPER_WATCHDOG_STALE_SEC` | typed:float | unclassified | unclassified | 538 | Seconds since last turn before a Running keeper is considered idle-stale. Must be >= 60. Default: 300 (5 minutes). In... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 240 | Master switch. When true, successful Coord.heartbeat after a unified turn counts as presence proof, allowing the next... |
+| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 802 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+
+## Env_config_keeper_supervisor (21 knobs; typed classification 20/20)
+
+| Env var | Kind | Category | Ops class | Line | Doc |
+|---|---|---|---|---|---|
+| `MASC_KEEPER_ALIVE_BUT_STUCK_DEDUP_TTL_SEC` | typed:float | Timeouts | operator | 153 | Per-keeper dedup window (seconds): once a keeper is flagged the counter is incremented at most once per window, even ... |
+| `MASC_KEEPER_ALIVE_BUT_STUCK_ENABLED` | typed:bool | Policies | operator | 119 | Signal for alive-but-stuck keepers (#12838): keepers that are not Dead/Zombie and not paused, but whose [proactive_rt... |
+| `MASC_KEEPER_ALIVE_BUT_STUCK_RECOVERY_ENABLED` | typed:bool | Policies | operator | 128 | Queue a bounded recovery wakeup when [alive_but_stuck_scan] emits. The recovery uses the Event Layer queue plus [fibe... |
+| `MASC_KEEPER_ALIVE_BUT_STUCK_STALL_FLOOR_SEC` | typed:float | Timeouts | operator | 145 | Hard floor (seconds) so keepers with very small cooldowns are not flagged after a few minutes of legitimate quiet.  T... |
+| `MASC_KEEPER_ALIVE_BUT_STUCK_STALL_MULTIPLIER` | typed:int | Thresholds | operator | 136 | Multiplier on the keeper's own [proactive.cooldown_sec] before a stalled keeper is flagged.  Default: 10 (10 cooldown... |
+| `MASC_KEEPER_AUTO_RESUME_INITIAL_SEC` | typed:float | Timeouts | operator | 64 | Initial auto-resume backoff delay after an auto-pause (seconds). On every successive auto-pause the delay doubles, ca... |
+| `MASC_KEEPER_AUTO_RESUME_MAX_SEC` | typed:float | Timeouts | operator | 70 | Maximum auto-resume backoff delay (seconds).  Default: 86400 (24 hours). @category Timeouts @ops_class operator |
+| `MASC_KEEPER_DEAD_TTL_SEC` | typed:float | Timeouts | operator | 47 | Dead tombstone TTL: seconds before Dead entries are cleaned up. @category Timeouts @ops_class operator |
+| `MASC_KEEPER_DOMAIN_POOL_ENABLED` | feature_flag | n/a | n/a | 12 | Route per-keeper supervise fork through the shared [Domain_pool] (RFC-0059 PR-7-pilot) instead of staying on the main... |
+| `MASC_KEEPER_LIVENESS_RECOVERY_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 95 | Base backoff delay (seconds) between liveness recovery attempts per keeper. Exponential: attempt 0 = base, 1 = 2*base... |
+| `MASC_KEEPER_LIVENESS_RECOVERY_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 104 | Maximum backoff delay cap (seconds) for liveness recovery. Default: 3600 (1 hour). @category Timeouts @ops_class oper... |
+| `MASC_KEEPER_LIVENESS_RECOVERY_ENABLED` | typed:bool | Policies | operator | 77 | Liveness Recovery Supervisor (#12801): enable auto-recovery of Dead keepers whose root cause has cleared.  Set to fal... |
+| `MASC_KEEPER_LIVENESS_RECOVERY_MAX_ATTEMPTS` | typed:int | Thresholds | operator | 111 | Maximum total liveness recovery attempts per keeper before giving up permanently.  Default: 5. @category Thresholds @... |
+| `MASC_KEEPER_LIVENESS_RECOVERY_MIN_DEAD_SEC` | typed:float | Timeouts | operator | 85 | Minimum time (seconds) a keeper must have been Dead before a liveness recovery attempt is made.  Allows transient roo... |
+| `MASC_KEEPER_PAUSED_CLEANUP_TTL_SEC` | typed:float | Timeouts | operator | 55 | Paused keeper file TTL: seconds before stale paused keeper meta files are removed from disk. Default: 86400 (24 hours... |
+| `MASC_KEEPER_SELF_PRESERVATION_MIN_CANDIDATES` | typed:int | Thresholds | operator | 42 | Self-preservation: minimum crashed candidates to trigger. @category Thresholds @ops_class operator |
+| `MASC_KEEPER_SELF_PRESERVATION_RATIO` | typed:float | Thresholds | operator | 36 | Self-preservation: ratio of crashed keepers to trigger suppression. @category Thresholds @ops_class operator |
+| `MASC_KEEPER_SUPERVISOR_BACKOFF_BASE_S` | typed:float | Timeouts | operator | 21 | Base delay for exponential backoff between restarts (seconds). @category Timeouts @ops_class operator |
+| `MASC_KEEPER_SUPERVISOR_BACKOFF_MAX_S` | typed:float | Timeouts | operator | 25 | Maximum backoff delay cap (seconds). @category Timeouts @ops_class operator |
+| `MASC_KEEPER_SUPERVISOR_MAX_RESTARTS` | typed:int | Thresholds | operator | 17 | Maximum restart attempts before declaring a keeper dead. @category Thresholds @ops_class operator |
+| `MASC_KEEPER_SUPERVISOR_SWEEP_SEC` | typed:float | Timeouts | operator | 29 | Interval between supervisor sweep runs (seconds). @category Timeouts @ops_class operator |
 
 ## Env_config_oas_bridge (3 knobs; typed classification 0/0)
 
@@ -366,96 +371,96 @@ the categorization roadmap. Newly-added typed getters in
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_A2A_DELEGATION_TIMEOUT_SEC` | string_literal | n/a | n/a | 958 |  |
-| `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 178 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 836 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 840 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 842 |  |
-| `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 380 |  |
-| `MASC_CHANNEL_GATE_DEDUP_MAX_ENTRIES` | string_literal | n/a | n/a | 456 |  |
-| `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 458 |  |
-| `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 460 |  |
-| `MASC_CHANNEL_GATE_SLOW_MS` | string_literal | n/a | n/a | 462 |  |
-| `MASC_CIRCUIT_COOLDOWN` | string_literal | n/a | n/a | 472 |  |
-| `MASC_CIRCUIT_FAILURE_WINDOW_SEC` | string_literal | n/a | n/a | 474 |  |
-| `MASC_CIRCUIT_THRESHOLD` | string_literal | n/a | n/a | 476 |  |
-| `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 382 |  |
-| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 390 |  |
-| `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 418 |  |
-| `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 494 |  |
-| `MASC_DECISION_LAYER_LEVEL` | string_literal | n/a | n/a | 496 |  |
-| `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 464 |  |
-| `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 371 |  |
-| `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 370 |  |
-| `MASC_DRIFT_THRESHOLD` | string_literal | n/a | n/a | 369 |  |
-| `MASC_ECONOMY_ENABLED` | string_literal | n/a | n/a | 545 |  |
-| `MASC_ECONOMY_FRUGAL_THRESHOLD` | string_literal | n/a | n/a | 547 |  |
-| `MASC_ECONOMY_HUSTLE_THRESHOLD` | string_literal | n/a | n/a | 549 |  |
-| `MASC_ECONOMY_INITIAL_BALANCE` | string_literal | n/a | n/a | 551 |  |
-| `MASC_ECONOMY_REPUTATION_MULTIPLIER` | string_literal | n/a | n/a | 553 |  |
-| `MASC_ECONOMY_REWARD_BOARD_POST` | string_literal | n/a | n/a | 555 |  |
-| `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 557 |  |
-| `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 559 |  |
-| `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 561 |  |
-| `MASC_FILE_LOCK_MAX_ENTRIES` | string_literal | n/a | n/a | 567 |  |
-| `MASC_FILE_LOCK_STALE_SEC` | string_literal | n/a | n/a | 569 |  |
-| `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 231 |  |
-| `MASC_GUARD_PENALTY_BETA` | string_literal | n/a | n/a | 363 |  |
-| `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 373 |  |
-| `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 372 |  |
-| `MASC_HTTP_HOST` | string_literal | n/a | n/a | 170 |  |
-| `MASC_HTTP_MAX_CONNECTIONS` | string_literal | n/a | n/a | 171 |  |
-| `MASC_IMESSAGE_STATUS_STALE_SEC` | string_literal | n/a | n/a | 466 |  |
-| `MASC_KEEPER_AUTONOMOUS_CONCURRENCY` | string_literal | n/a | n/a | 674 |  |
-| `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 321 |  |
-| `MASC_KEEPER_BOARD_LIST_CACHE_TTL_S` | string_literal | n/a | n/a | 639 |  |
-| `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 306 |  |
-| `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 308 |  |
-| `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 304 |  |
-| `MASC_KEEPER_COST_GATE_USD` | string_literal | n/a | n/a | 310 |  |
-| `MASC_KEEPER_LLM_RERANK_CASCADE` | string_literal | n/a | n/a | 740 |  |
-| `MASC_KEEPER_MAX_TOOL_ROUNDS` | string_literal | n/a | n/a | 319 |  |
-| `MASC_KEEPER_PROACTIVE_SIMILARITY` | string_literal | n/a | n/a | 329 |  |
-| `MASC_KEEPER_PROACTIVE_TEMP_HIGH` | string_literal | n/a | n/a | 327 |  |
-| `MASC_KEEPER_PROACTIVE_TEMP_LOW` | string_literal | n/a | n/a | 323 |  |
-| `MASC_KEEPER_PROACTIVE_TEMP_MID` | string_literal | n/a | n/a | 325 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN` | string_literal | n/a | n/a | 347 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 343 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_REPETITION` | string_literal | n/a | n/a | 341 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 345 |  |
-| `MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 337 |  |
-| `MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 339 |  |
-| `MASC_KEEPER_RULE_REFLECT_REPETITION` | string_literal | n/a | n/a | 335 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 744 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 746 |  |
-| `MASC_KEEPER_TOOL_COST_MAX_USD` | string_literal | n/a | n/a | 312 |  |
-| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 748 |  |
-| `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 700 |  |
-| `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 702 |  |
-| `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 315 |  |
-| `MASC_KEEPER_UNIFIED_MAX_TURNS` | string_literal | n/a | n/a | 317 |  |
-| `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 314 |  |
-| `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 374 |  |
-| `MASC_MAX_WRITE_SIZE_BYTES` | string_literal | n/a | n/a | 974 |  |
-| `MASC_NAMESPACE_TRUTH_COLD_SAFETY_MARGIN_S` | string_literal | n/a | n/a | 422 |  |
-| `MASC_NAMESPACE_TRUTH_COLD_TIMEOUT_S` | string_literal | n/a | n/a | 420 |  |
-| `MASC_NAMESPACE_TRUTH_SHELL_FIBER_TIMEOUT_S` | string_literal | n/a | n/a | 424 |  |
-| `MASC_NAMESPACE_TRUTH_WARM_TIMEOUT_S` | string_literal | n/a | n/a | 426 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 934 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 976 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 988 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 882 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 884 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 886 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 888 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 914 |  |
-| `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 296 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 950 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 952 |  |
-| `MASC_TLA_TRACE` | string_literal | n/a | n/a | 298 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 1020 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 1022 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 1024 |  |
-| `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 238 |  |
-| `MASC_WS_SLICE_INDEX_ENABLED` | string_literal | n/a | n/a | 241 |  |
+| `MASC_A2A_DELEGATION_TIMEOUT_SEC` | string_literal | n/a | n/a | 809 |  |
+| `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 687 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 691 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 693 |  |
+| `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 231 |  |
+| `MASC_CHANNEL_GATE_DEDUP_MAX_ENTRIES` | string_literal | n/a | n/a | 307 |  |
+| `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 309 |  |
+| `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 311 |  |
+| `MASC_CHANNEL_GATE_SLOW_MS` | string_literal | n/a | n/a | 313 |  |
+| `MASC_CIRCUIT_COOLDOWN` | string_literal | n/a | n/a | 323 |  |
+| `MASC_CIRCUIT_FAILURE_WINDOW_SEC` | string_literal | n/a | n/a | 325 |  |
+| `MASC_CIRCUIT_THRESHOLD` | string_literal | n/a | n/a | 327 |  |
+| `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 233 |  |
+| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 241 |  |
+| `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 269 |  |
+| `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 345 |  |
+| `MASC_DECISION_LAYER_LEVEL` | string_literal | n/a | n/a | 347 |  |
+| `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 315 |  |
+| `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 222 |  |
+| `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 221 |  |
+| `MASC_DRIFT_THRESHOLD` | string_literal | n/a | n/a | 220 |  |
+| `MASC_ECONOMY_ENABLED` | string_literal | n/a | n/a | 396 |  |
+| `MASC_ECONOMY_FRUGAL_THRESHOLD` | string_literal | n/a | n/a | 398 |  |
+| `MASC_ECONOMY_HUSTLE_THRESHOLD` | string_literal | n/a | n/a | 400 |  |
+| `MASC_ECONOMY_INITIAL_BALANCE` | string_literal | n/a | n/a | 402 |  |
+| `MASC_ECONOMY_REPUTATION_MULTIPLIER` | string_literal | n/a | n/a | 404 |  |
+| `MASC_ECONOMY_REWARD_BOARD_POST` | string_literal | n/a | n/a | 406 |  |
+| `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 408 |  |
+| `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 410 |  |
+| `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 412 |  |
+| `MASC_FILE_LOCK_MAX_ENTRIES` | string_literal | n/a | n/a | 418 |  |
+| `MASC_FILE_LOCK_STALE_SEC` | string_literal | n/a | n/a | 420 |  |
+| `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 82 |  |
+| `MASC_GUARD_PENALTY_BETA` | string_literal | n/a | n/a | 214 |  |
+| `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 224 |  |
+| `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 223 |  |
+| `MASC_HTTP_HOST` | string_literal | n/a | n/a | 21 |  |
+| `MASC_HTTP_MAX_CONNECTIONS` | string_literal | n/a | n/a | 22 |  |
+| `MASC_IMESSAGE_STATUS_STALE_SEC` | string_literal | n/a | n/a | 317 |  |
+| `MASC_KEEPER_AUTONOMOUS_CONCURRENCY` | string_literal | n/a | n/a | 525 |  |
+| `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 172 |  |
+| `MASC_KEEPER_BOARD_LIST_CACHE_TTL_S` | string_literal | n/a | n/a | 490 |  |
+| `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 157 |  |
+| `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 159 |  |
+| `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 155 |  |
+| `MASC_KEEPER_COST_GATE_USD` | string_literal | n/a | n/a | 161 |  |
+| `MASC_KEEPER_LLM_RERANK_CASCADE` | string_literal | n/a | n/a | 591 |  |
+| `MASC_KEEPER_MAX_TOOL_ROUNDS` | string_literal | n/a | n/a | 170 |  |
+| `MASC_KEEPER_PROACTIVE_SIMILARITY` | string_literal | n/a | n/a | 180 |  |
+| `MASC_KEEPER_PROACTIVE_TEMP_HIGH` | string_literal | n/a | n/a | 178 |  |
+| `MASC_KEEPER_PROACTIVE_TEMP_LOW` | string_literal | n/a | n/a | 174 |  |
+| `MASC_KEEPER_PROACTIVE_TEMP_MID` | string_literal | n/a | n/a | 176 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN` | string_literal | n/a | n/a | 198 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 194 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_REPETITION` | string_literal | n/a | n/a | 192 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 196 |  |
+| `MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 188 |  |
+| `MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 190 |  |
+| `MASC_KEEPER_RULE_REFLECT_REPETITION` | string_literal | n/a | n/a | 186 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 595 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 597 |  |
+| `MASC_KEEPER_TOOL_COST_MAX_USD` | string_literal | n/a | n/a | 163 |  |
+| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 599 |  |
+| `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 551 |  |
+| `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 553 |  |
+| `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 166 |  |
+| `MASC_KEEPER_UNIFIED_MAX_TURNS` | string_literal | n/a | n/a | 168 |  |
+| `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 165 |  |
+| `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 225 |  |
+| `MASC_MAX_WRITE_SIZE_BYTES` | string_literal | n/a | n/a | 825 |  |
+| `MASC_NAMESPACE_TRUTH_COLD_SAFETY_MARGIN_S` | string_literal | n/a | n/a | 273 |  |
+| `MASC_NAMESPACE_TRUTH_COLD_TIMEOUT_S` | string_literal | n/a | n/a | 271 |  |
+| `MASC_NAMESPACE_TRUTH_SHELL_FIBER_TIMEOUT_S` | string_literal | n/a | n/a | 275 |  |
+| `MASC_NAMESPACE_TRUTH_WARM_TIMEOUT_S` | string_literal | n/a | n/a | 277 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 785 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 827 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 839 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 733 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 735 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 737 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 739 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 765 |  |
+| `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 147 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 801 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 803 |  |
+| `MASC_TLA_TRACE` | string_literal | n/a | n/a | 149 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 871 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 873 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 875 |  |
+| `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 89 |  |
+| `MASC_WS_SLICE_INDEX_ENABLED` | string_literal | n/a | n/a | 92 |  |
 

--- a/lib/dune
+++ b/lib/dune
@@ -85,6 +85,7 @@
  server_mcp_transport_http_types
  server_mcp_transport_http_session
  server_mcp_transport_http_headers
+ server_mcp_request_context
  server_mcp_transport_http_sse
  server_mcp_transport_http_conn
  server_mcp_transport_http_respond

--- a/lib/dune
+++ b/lib/dune
@@ -86,6 +86,7 @@
  server_mcp_transport_http_session
  server_mcp_transport_http_headers
  server_mcp_request_context
+ server_mcp_actor_injection
  server_mcp_transport_http_sse
  server_mcp_transport_http_conn
  server_mcp_transport_http_respond

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -448,6 +448,25 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                      @ mcp_headers session_id
                                          protocol_version)
                              | Ok () ->
+                             let is_known =
+                               session_was_provided
+                               && Server_mcp_transport_http.is_known_session
+                                    session_id
+                             in
+                             (match
+                                Server_mcp_transport_http.validate_session_known
+                                  ~session_was_provided ~is_known body_str
+                              with
+                              | Error msg ->
+                                  let new_session_id = Mcp_session.generate () in
+                                  let body = json_rpc_error (-32600) msg in
+                                  h2_respond_json h2_reqd body
+                                    ~status:`Not_found
+                                    ~extra_headers:
+                                      (cors
+                                      @ mcp_headers new_session_id
+                                          protocol_version)
+                              | Ok () ->
                              let accept_mode =
                                Server_mcp_transport_http_headers
                                .classify_mcp_accept_for_body httpun_request body_str
@@ -504,7 +523,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                          ~extra_headers:mcp_hdrs
                                    | json ->
                                        let body = Yojson.Safe.to_string json in
-                                       h2_respond_json h2_reqd body ~extra_headers:mcp_hdrs)))))
+                                       h2_respond_json h2_reqd body ~extra_headers:mcp_hdrs))))))
 
       | `DELETE, "/mcp/operator" ->
           h2_respond_removed_surface h2_reqd ~surface:"operator_remote" ~extra_headers:cors

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -390,13 +390,10 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           h2_respond_removed_surface h2_reqd ~surface:"operator_remote" ~extra_headers:cors
 
       | `POST, "/mcp" | `POST, "/" | `POST, "/mcp/managed" ->
-          let session_was_provided = Option.is_some session_id_opt in
           let session_id = match session_id_opt with
             | Some id -> id
             | None -> Mcp_session.generate ()
           in
-          let auth_token = auth_token_from_request httpun_request in
-          let protocol_version = get_protocol_version_for_session ~session_id httpun_request in
           let profile =
             if String.equal path "/mcp/managed"
             then Server_mcp_transport_http.Managed_agent
@@ -407,6 +404,17 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             | Some s -> s.Mcp_server.room_config.base_path
             | None -> default_base_path ()
           in
+          let context =
+            Server_mcp_request_context.make ~session_id_opt
+              ~generated_session_id:session_id
+              ~auth_token:(auth_token_from_request httpun_request)
+              ~protocol_version:
+                (get_protocol_version_for_session ~session_id httpun_request)
+              ~origin ~base_path
+          in
+          let session_id = context.session_id in
+          let auth_token = context.auth_token in
+          let protocol_version = context.protocol_version in
           let auth_result =
             match profile with
             | Server_mcp_transport_http.Full
@@ -435,11 +443,16 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                      | Ok _cred_opt ->
                          h2_read_body h2_reqd (fun body_str ->
                              match
-                               Server_mcp_transport_http
-                               .validate_session_requirement
-                                 ~session_was_provided body_str
+                               Server_mcp_request_context.decide_post_body
+                                 ~request:httpun_request ~context
+                                 ~session_is_known:
+                                   (Server_mcp_transport_http.is_known_session
+                                      session_id)
+                                 body_str
                              with
-                             | Error msg ->
+                             | Error
+                                 (Server_mcp_request_context.Session_required msg)
+                               ->
                                  let body = json_rpc_error (-32600) msg in
                                  h2_respond_json h2_reqd body
                                    ~status:`Bad_request
@@ -447,17 +460,9 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                      (cors
                                      @ mcp_headers session_id
                                          protocol_version)
-                             | Ok () ->
-                             let is_known =
-                               session_was_provided
-                               && Server_mcp_transport_http.is_known_session
-                                    session_id
-                             in
-                             (match
-                                Server_mcp_transport_http.validate_session_known
-                                  ~session_was_provided ~is_known body_str
-                              with
-                              | Error msg ->
+                             | Error
+                                 (Server_mcp_request_context.Unknown_session msg)
+                               ->
                                   let new_session_id = Mcp_session.generate () in
                                   let body = json_rpc_error (-32600) msg in
                                   h2_respond_json h2_reqd body
@@ -466,23 +471,15 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                       (cors
                                       @ mcp_headers new_session_id
                                           protocol_version)
-                              | Ok () ->
-                             let accept_mode =
-                               Server_mcp_transport_http_headers
-                               .classify_mcp_accept_for_body httpun_request body_str
-                             in
-                             match accept_mode with
-                             | Http_negotiation.Rejected ->
-                                 let body =
-                                   json_rpc_error (-32600)
-                                     "Invalid Accept header: must include application/json and text/event-stream. \
-                                      Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility."
-                                 in
+                             | Error
+                                 (Server_mcp_request_context.Invalid_accept msg)
+                               ->
+                                 let body = json_rpc_error (-32600) msg in
                                  h2_respond_json h2_reqd body ~status:`Bad_request
                                    ~extra_headers:(cors @ mcp_headers session_id protocol_version)
-                             | accept_mode ->
+                             | Ok post_context ->
                                  let accept_warn_headers =
-                                   legacy_accept_warning_headers accept_mode
+                                   post_context.accept_warn_headers
                                  in
                                  with_server_state h2_reqd (fun state ->
                                    let profile =
@@ -490,7 +487,8 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                    in
                                    let body_with_agent =
                                      Server_mcp_transport_http.body_with_canonical_http_actor
-                                       ~base_path ~auth_token httpun_request body_str
+                                       ~base_path ~auth_token httpun_request
+                                       post_context.body_str
                                    in
                                    let internal_keeper_runtime =
                                      Server_auth.is_verified_internal_keeper_request
@@ -502,7 +500,10 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                        ~internal_keeper_runtime state
                                        body_with_agent
                                    in
-                                   (match protocol_version_from_body body_str with
+                                   (match
+                                      protocol_version_from_body
+                                        post_context.body_str
+                                    with
                                    | Some v -> remember_protocol_version session_id v
                                    | None -> ());
                                    let protocol_version =
@@ -523,7 +524,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                          ~extra_headers:mcp_hdrs
                                    | json ->
                                        let body = Yojson.Safe.to_string json in
-                                       h2_respond_json h2_reqd body ~extra_headers:mcp_hdrs))))))
+                                       h2_respond_json h2_reqd body ~extra_headers:mcp_hdrs)))))
 
       | `DELETE, "/mcp/operator" ->
           h2_respond_removed_surface h2_reqd ~surface:"operator_remote" ~extra_headers:cors

--- a/lib/server/server_mcp_actor_injection.ml
+++ b/lib/server/server_mcp_actor_injection.ml
@@ -1,0 +1,108 @@
+(** Inject or replace [_agent_name] in MCP [tools/call] arguments.
+    For authenticated dashboard sessions, the HTTP-layer token owner is the
+    canonical caller identity, so a stale browser-supplied [_agent_name]
+    must be overwritten. The legacy argument-scoped [token] is also removed
+    when HTTP auth is present so stale MCP bodies cannot override the
+    transport token. Legacy [agent_name] is left untouched because some tools
+    use it as a domain argument rather than caller identity. *)
+let inject_agent_name_into_body ?(rewrite_existing = false) ?(strip_token = false)
+    ~agent_name body_str =
+  try
+    let json = Yojson.Safe.from_string body_str in
+    let open Yojson.Safe.Util in
+    let method_name = member "method" json |> to_string_option in
+    match method_name with
+    | Some "tools/call" ->
+        let params = member "params" json in
+        let args = member "arguments" params in
+        let existing_agent =
+          Option.bind
+            (member "_agent_name" args |> to_string_option)
+            (fun value ->
+              let trimmed = String.trim value in
+              if String.equal trimmed "" then
+                None
+              else
+                Some trimmed)
+        in
+        let existing_legacy_agent =
+          Option.bind
+            (member "agent_name" args |> to_string_option)
+            (fun value ->
+              let trimmed = String.trim value in
+              if String.equal trimmed "" then
+                None
+              else
+                Some trimmed)
+        in
+        let new_args =
+          match args with
+          | `Assoc fields ->
+              let normalized_fields =
+                let fields =
+                  if rewrite_existing then
+                    List.filter
+                      (fun (key, _) -> not (String.equal key "_agent_name"))
+                      fields
+                  else
+                    fields
+                in
+                if strip_token then
+                  List.filter (fun (key, _) -> not (String.equal key "token")) fields
+                else
+                  fields
+              in
+              let should_inject =
+                rewrite_existing
+                || (Option.is_none existing_agent
+                   && Option.is_none existing_legacy_agent)
+              in
+              if should_inject then
+                `Assoc (("_agent_name", `String agent_name) :: normalized_fields)
+              else
+                args
+          | _ -> args
+        in
+        if new_args = args then
+          body_str
+        else
+          let new_params =
+            match params with
+            | `Assoc fields ->
+                `Assoc
+                  (List.map
+                     (fun (k, v) ->
+                       if k = "arguments" then
+                         (k, new_args)
+                       else
+                         (k, v))
+                     fields)
+            | _ -> params
+          in
+          let new_json =
+            match json with
+            | `Assoc fields ->
+                `Assoc
+                  (List.map
+                     (fun (k, v) ->
+                       if k = "params" then
+                         (k, new_params)
+                       else
+                         (k, v))
+                     fields)
+            | _ -> json
+          in
+          Yojson.Safe.to_string new_json
+    | _ -> body_str
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> body_str
+
+let reduce ~actor ~auth_token body_str =
+  match actor with
+  | None -> body_str
+  | Some agent ->
+      inject_agent_name_into_body
+        ~rewrite_existing:(Option.is_some auth_token)
+        ~strip_token:(Option.is_some auth_token)
+        ~agent_name:agent body_str

--- a/lib/server/server_mcp_actor_injection.mli
+++ b/lib/server/server_mcp_actor_injection.mli
@@ -1,0 +1,8 @@
+val inject_agent_name_into_body :
+  ?rewrite_existing:bool ->
+  ?strip_token:bool ->
+  agent_name:string ->
+  string ->
+  string
+
+val reduce : actor:string option -> auth_token:string option -> string -> string

--- a/lib/server/server_mcp_request_context.ml
+++ b/lib/server/server_mcp_request_context.ml
@@ -10,6 +10,8 @@ type t = {
 let make ~session_id_opt ~generated_session_id ~auth_token ~protocol_version
     ~origin ~base_path =
   let session_was_provided = Option.is_some session_id_opt in
+  (* NDT-OK: HTTP ingress supplies [generated_session_id] only when the client
+     omitted Mcp-Session-Id; persisted state still records the resolved value. *)
   let session_id = Option.value ~default:generated_session_id session_id_opt in
   { session_id; session_was_provided; auth_token; protocol_version; origin; base_path }
 

--- a/lib/server/server_mcp_request_context.ml
+++ b/lib/server/server_mcp_request_context.ml
@@ -1,0 +1,56 @@
+type t = {
+  session_id : string;
+  session_was_provided : bool;
+  auth_token : string option;
+  protocol_version : string;
+  origin : string;
+  base_path : string;
+}
+
+let make ~session_id_opt ~generated_session_id ~auth_token ~protocol_version
+    ~origin ~base_path =
+  let session_was_provided = Option.is_some session_id_opt in
+  let session_id = Option.value ~default:generated_session_id session_id_opt in
+  { session_id; session_was_provided; auth_token; protocol_version; origin; base_path }
+
+type post_body_decision = {
+  body_str : string;
+  accept_mode : Mcp_transport_protocol.Http_negotiation.accept_mode;
+  accept_warn_headers : (string * string) list;
+}
+
+type post_body_rejection =
+  | Session_required of string
+  | Unknown_session of string
+  | Invalid_accept of string
+
+let invalid_accept_message =
+  "Invalid Accept header: must include application/json and text/event-stream. \
+   Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility."
+
+let decide_post_body ~request ~context ~session_is_known body_str =
+  match
+    Server_mcp_transport_http_protocol.validate_session_requirement
+      ~session_was_provided:context.session_was_provided body_str
+  with
+  | Error msg -> Error (Session_required msg)
+  | Ok () -> (
+      let is_known = context.session_was_provided && session_is_known in
+      match
+        Server_mcp_transport_http_protocol.validate_session_known
+          ~session_was_provided:context.session_was_provided ~is_known body_str
+      with
+      | Error msg -> Error (Unknown_session msg)
+      | Ok () -> (
+          match
+            Server_mcp_transport_http_headers.classify_mcp_accept_for_body request
+              body_str
+          with
+          | Mcp_transport_protocol.Http_negotiation.Rejected ->
+              Error (Invalid_accept invalid_accept_message)
+          | accept_mode ->
+              let accept_warn_headers =
+                Server_mcp_transport_http_headers.legacy_accept_warning_headers
+                  accept_mode
+              in
+              Ok { body_str; accept_mode; accept_warn_headers }))

--- a/lib/server/server_mcp_request_context.mli
+++ b/lib/server/server_mcp_request_context.mli
@@ -1,0 +1,37 @@
+type t = {
+  session_id : string;
+  session_was_provided : bool;
+  auth_token : string option;
+  protocol_version : string;
+  origin : string;
+  base_path : string;
+}
+
+val make :
+  session_id_opt:string option ->
+  generated_session_id:string ->
+  auth_token:string option ->
+  protocol_version:string ->
+  origin:string ->
+  base_path:string ->
+  t
+
+type post_body_decision = {
+  body_str : string;
+  accept_mode : Mcp_transport_protocol.Http_negotiation.accept_mode;
+  accept_warn_headers : (string * string) list;
+}
+
+type post_body_rejection =
+  | Session_required of string
+  | Unknown_session of string
+  | Invalid_accept of string
+
+val invalid_accept_message : string
+
+val decide_post_body :
+  request:Httpun.Request.t ->
+  context:t ->
+  session_is_known:bool ->
+  string ->
+  (post_body_decision, post_body_rejection) result

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -283,16 +283,23 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
     respond_not_ready ~deps request reqd
   else
   let session_id_opt = get_session_id_any request in
-  let session_was_provided = Option.is_some session_id_opt in
   let session_id =
     match session_id_opt with
     | Some sid -> sid
     | None -> Mcp_session.generate ()
   in
-  let auth_token = deps.auth_token_from_request request in
-  let protocol_version = get_protocol_version_for_session ~session_id request in
-  let origin = deps.get_origin request in
-  let base_path = deps.get_base_path () in
+  let context =
+    Server_mcp_request_context.make ~session_id_opt
+      ~generated_session_id:session_id
+      ~auth_token:(deps.auth_token_from_request request)
+      ~protocol_version:(get_protocol_version_for_session ~session_id request)
+      ~origin:(deps.get_origin request) ~base_path:(deps.get_base_path ())
+  in
+  let session_id = context.session_id in
+  let auth_token = context.auth_token in
+  let protocol_version = context.protocol_version in
+  let origin = context.origin in
+  let base_path = context.base_path in
   let auth_result =
     match profile with
     | Full | Managed_agent ->
@@ -349,12 +356,14 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
     in
     Ok (Http.Request.read_body_async reqd (fun body_str ->
       ignore (
-        let* () =
+      let* post_context =
         match
-          validate_session_requirement ~session_was_provided body_str
+          Server_mcp_request_context.decide_post_body ~request ~context
+            ~session_is_known:(is_known_session session_id)
+            body_str
         with
-        | Ok () -> Ok ()
-        | Error msg ->
+        | Ok decision -> Ok decision
+        | Error (Server_mcp_request_context.Session_required msg) ->
             let body =
               Printf.sprintf
                 {|{"jsonrpc":"2.0","error":{"code":-32600,"message":%s},"id":null}|}
@@ -370,25 +379,7 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
               (Httpun.Response.create ~headers `Bad_request)
               body;
             Error ()
-      in
-      let* () =
-        (* RFC-0100 PR-3 — Q3 default. If the client echoed an
-           [Mcp-Session-Id] the server has no protocol-version state
-           for, respond [404 Not Found] with a freshly minted
-           [Mcp-Session-Id] header so the client re-handshakes via
-           [initialize] instead of silently riding on a phantom
-           session. The handshake methods are exempt: [initialize]
-           legitimately mints the state we are about to check for,
-           and [ping] / [notifications/initialized] are allowed
-           without a known session per the existing contract. *)
-        let is_known =
-          session_was_provided && is_known_session session_id
-        in
-        match
-          validate_session_known ~session_was_provided ~is_known body_str
-        with
-        | Ok () -> Ok ()
-        | Error msg ->
+        | Error (Server_mcp_request_context.Unknown_session msg) ->
             let new_session_id = Mcp_session.generate () in
             let body =
               Printf.sprintf
@@ -405,14 +396,7 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
               (Httpun.Response.create ~headers `Not_found)
               body;
             Error ()
-      in
-      let accept_mode =
-        Server_mcp_transport_http_headers.classify_mcp_accept_for_body
-          request body_str
-      in
-      let* accept_mode =
-        match accept_mode with
-        | Http_negotiation.Rejected ->
+        | Error (Server_mcp_request_context.Invalid_accept msg) ->
             let body =
               Yojson.Safe.to_string
                 (`Assoc
@@ -422,9 +406,7 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
                       `Assoc
                         [
                           ("code", `Int (-32600));
-                          ( "message",
-                            `String
-                              "Invalid Accept header: must include application/json and text/event-stream. Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility." );
+                          ("message", `String msg);
                         ] );
                   ])
             in
@@ -436,11 +418,9 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
             let response = Httpun.Response.create ~headers `Bad_request in
             safe_respond_with_string reqd response body;
             Error ()
-        | _ -> Ok accept_mode
       in
-      let accept_warn_headers =
-        legacy_accept_warning_headers accept_mode
-      in
+      let accept_mode = post_context.accept_mode in
+      let accept_warn_headers = post_context.accept_warn_headers in
       let* runtime =
         match request_runtime_result deps with
         | Ok r -> Ok r

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -191,91 +191,14 @@ let should_stream_post_tools_call request body_str accept_mode =
       | None -> false)
   | _ -> false
 
-(** Inject or replace [_agent_name] in MCP [tools/call] arguments.
-    For authenticated dashboard sessions, the HTTP-layer token owner is the
-    canonical caller identity, so a stale browser-supplied [_agent_name]
-    must be overwritten. The legacy argument-scoped [token] is also removed
-    when HTTP auth is present so stale MCP bodies cannot override the
-    transport token. Legacy [agent_name] is left untouched because some tools
-    use it as a domain argument rather than caller identity. *)
 let inject_agent_name_into_body ?(rewrite_existing = false) ?(strip_token = false)
     ~agent_name body_str =
-  try
-    let json = Yojson.Safe.from_string body_str in
-    let open Yojson.Safe.Util in
-    let method_name = member "method" json |> to_string_option in
-    match method_name with
-    | Some "tools/call" ->
-        let params = member "params" json in
-        let args = member "arguments" params in
-        let existing_agent =
-          Option.bind
-            (member "_agent_name" args |> to_string_option)
-            (fun value ->
-               let trimmed = String.trim value in
-               if String.equal trimmed "" then None else Some trimmed)
-        in
-        let existing_legacy_agent =
-          Option.bind
-            (member "agent_name" args |> to_string_option)
-            (fun value ->
-               let trimmed = String.trim value in
-               if String.equal trimmed "" then None else Some trimmed)
-        in
-        let new_args =
-          match args with
-          | `Assoc fields ->
-              let normalized_fields =
-                let fields =
-                  if rewrite_existing then
-                    List.filter
-                      (fun (key, _) -> not (String.equal key "_agent_name"))
-                      fields
-                  else
-                    fields
-                in
-                if strip_token then
-                  List.filter (fun (key, _) -> not (String.equal key "token"))
-                    fields
-                else
-                  fields
-              in
-              let should_inject =
-                rewrite_existing
-                || (Option.is_none existing_agent
-                    && Option.is_none existing_legacy_agent)
-              in
-              if should_inject then
-                `Assoc (("_agent_name", `String agent_name) :: normalized_fields)
-              else
-                args
-          | _ -> args
-        in
-        if new_args = args then body_str else
-          let new_params = match params with
-            | `Assoc fields ->
-                `Assoc (List.map (fun (k, v) ->
-                  if k = "arguments" then (k, new_args) else (k, v)) fields)
-            | _ -> params
-          in
-          let new_json = match json with
-            | `Assoc fields ->
-                `Assoc (List.map (fun (k, v) ->
-                  if k = "params" then (k, new_params) else (k, v)) fields)
-            | _ -> json
-          in
-          Yojson.Safe.to_string new_json
-    | _ -> body_str
-  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> body_str
+  Server_mcp_actor_injection.inject_agent_name_into_body ~rewrite_existing
+    ~strip_token ~agent_name body_str
 
 let body_with_canonical_http_actor ~base_path ~auth_token request body_str =
-  match Server_auth.dashboard_actor_for_request ~base_path request with
-  | None -> body_str
-  | Some agent ->
-      inject_agent_name_into_body
-        ~rewrite_existing:(Option.is_some auth_token)
-        ~strip_token:(Option.is_some auth_token)
-        ~agent_name:agent body_str
+  let actor = Server_auth.dashboard_actor_for_request ~base_path request in
+  Server_mcp_actor_injection.reduce ~actor ~auth_token body_str
 
 let handle_post_mcp ~deps ?(profile = Full) request reqd =
   (* Readiness gate: reject before session/auth if server state is not ready *)

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -246,6 +246,10 @@ let add_routes ~port ~host router =
   |> Http.Router.post "/mcp" handle_post_mcp
   |> Http.Router.post "/mcp/managed"
        (handle_post_mcp ~profile:Server_mcp_transport_http.Managed_agent)
+  |> Http.Router.add ~path:"/mcp" ~methods:[`DELETE]
+       ~handler:handle_delete_mcp
+  |> Http.Router.add ~path:"/mcp/managed" ~methods:[`DELETE]
+       ~handler:(handle_delete_mcp ~profile:Server_mcp_transport_http.Managed_agent)
   |> Http.Router.post "/webrtc/offer"
        (webrtc_signaling_handler
           ~tool_name:"masc_webrtc_offer"

--- a/test/dune
+++ b/test/dune
@@ -50,6 +50,7 @@
   test_audit_log
   test_governance_anomaly
   test_http_negotiation
+  test_mcp_h1_h2_admission_parity
   test_streamable_http_upgrade
   test_mcp_session_id_header
   test_keeper_turn_terminal_code_byte_compat
@@ -343,6 +344,7 @@
   test_audit_log
   test_governance_anomaly
   test_http_negotiation
+  test_mcp_h1_h2_admission_parity
   test_streamable_http_upgrade
   test_mcp_session_id_header
   test_keeper_turn_terminal_code_byte_compat

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module Transport = Masc_mcp.Server_mcp_transport_http
+module Request_context = Masc_mcp.Server_mcp_request_context
 module Headers = Masc_mcp.Server_mcp_transport_http_headers
 module Negotiation = Mcp_transport_protocol.Http_negotiation
 
@@ -46,6 +47,83 @@ let assert_accept_mode label expected actual =
     | _ -> false
   in
   check bool label true same
+
+let context ?(session_id = "ctx-session") ?(session_was_provided = true) () =
+  Request_context.make
+    ~session_id_opt:(if session_was_provided then Some session_id else None)
+    ~generated_session_id:session_id ~auth_token:None
+    ~protocol_version:"2025-11-25" ~origin:"*" ~base_path:"/tmp/masc-test"
+
+let test_request_context_make_records_session_source () =
+  let supplied =
+    Request_context.make ~session_id_opt:(Some "supplied-session")
+      ~generated_session_id:"generated-session" ~auth_token:(Some "token")
+      ~protocol_version:"2025-11-25" ~origin:"https://example.test"
+      ~base_path:"/tmp/base"
+  in
+  check string "supplied session wins" "supplied-session" supplied.session_id;
+  check bool "supplied flag" true supplied.session_was_provided;
+  check (option string) "auth token" (Some "token") supplied.auth_token;
+  check string "protocol version" "2025-11-25" supplied.protocol_version;
+  check string "origin" "https://example.test" supplied.origin;
+  check string "base path" "/tmp/base" supplied.base_path;
+  let generated =
+    Request_context.make ~session_id_opt:None
+      ~generated_session_id:"generated-session" ~auth_token:None
+      ~protocol_version:"2025-11-25" ~origin:"*" ~base_path:"/tmp/base"
+  in
+  check string "generated fallback" "generated-session" generated.session_id;
+  check bool "generated flag" false generated.session_was_provided
+
+let test_request_context_decides_post_body () =
+  let streamable_request =
+    request ~headers:[ ("accept", "application/json, text/event-stream") ] "/mcp"
+  in
+  let json_only_request =
+    request ~headers:[ ("accept", "application/json") ] "/mcp"
+  in
+  (match
+     Request_context.decide_post_body ~request:streamable_request
+       ~context:(context ()) ~session_is_known:true (body "tools/call")
+   with
+  | Ok decision ->
+      assert_accept_mode "streamable decision" Negotiation.Streamable
+        decision.accept_mode;
+      check (list (pair string string)) "no warning headers" []
+        decision.accept_warn_headers
+  | Error _ -> fail "streamable known session should pass");
+  (match
+     Request_context.decide_post_body ~request:streamable_request
+       ~context:(context ~session_was_provided:false ()) ~session_is_known:false
+       (body "tools/call")
+   with
+  | Error (Request_context.Session_required msg) ->
+      check bool "session required message" true (String.length msg > 0)
+  | Ok _ -> fail "missing session should reject tools/call"
+  | Error _ -> fail "missing session should use Session_required");
+  (match
+     Request_context.decide_post_body ~request:streamable_request
+       ~context:(context ()) ~session_is_known:false (body "tools/call")
+   with
+  | Error (Request_context.Unknown_session msg) ->
+      check bool "unknown session message" true (String.length msg > 0)
+  | Ok _ -> fail "unknown session should reject tools/call"
+  | Error _ -> fail "unknown session should use Unknown_session");
+  (match
+     Request_context.decide_post_body ~request:json_only_request
+       ~context:(context ()) ~session_is_known:true (body "tools/call")
+   with
+  | Error (Request_context.Invalid_accept msg) ->
+      check string "invalid accept message" Request_context.invalid_accept_message
+        msg
+  | Ok _ -> fail "json-only request should reject tools/call"
+  | Error _ -> fail "json-only request should use Invalid_accept");
+  (match
+     Request_context.decide_post_body ~request:streamable_request
+       ~context:(context ()) ~session_is_known:false initialize_body
+   with
+  | Ok _ -> ()
+  | Error _ -> fail "unknown session should still permit initialize")
 
 let test_shared_post_admission_matrix () =
   assert_result_ok "initialize may mint a fresh session"
@@ -114,9 +192,7 @@ let test_h1_h2_post_route_wiring_parity () =
       assert_contains ("H1 " ^ label) ~needle h1;
       assert_contains ("H2 " ^ label) ~needle h2)
     [
-      ("checks session requirement", "validate_session_requirement");
-      ("checks unknown supplied session", "validate_session_known");
-      ("classifies body-aware Accept", "classify_mcp_accept_for_body");
+      ("uses shared POST request context", "Server_mcp_request_context.decide_post_body");
       ("injects canonical HTTP actor", "body_with_canonical_http_actor");
       ("forwards internal keeper runtime", "is_verified_internal_keeper_request");
     ];
@@ -156,6 +232,10 @@ let () =
     [
       ( "shared-admission-matrix",
         [
+          test_case "request context records pre-body state" `Quick
+            test_request_context_make_records_session_source;
+          test_case "request context decides POST body admission" `Quick
+            test_request_context_decides_post_body;
           test_case "POST shared predicate matrix" `Quick
             test_shared_post_admission_matrix;
           test_case "protocol and DELETE predicate matrix" `Quick

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -1,0 +1,171 @@
+open Alcotest
+
+module Transport = Masc_mcp.Server_mcp_transport_http
+module Headers = Masc_mcp.Server_mcp_transport_http_headers
+module Negotiation = Mcp_transport_protocol.Http_negotiation
+
+let source_file rel =
+  let path = Filename.concat (Sys.getcwd ()) rel in
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let len = in_channel_length ic in
+      really_input_string ic len)
+
+let contains ~needle haystack =
+  String.length needle = 0 || String_util.contains_substring haystack needle
+
+let assert_contains label ~needle source =
+  check bool label true (contains ~needle source)
+
+let request ?(headers = []) ?(meth = `POST) target =
+  Httpun.Request.create ~headers:(Httpun.Headers.of_list headers) meth target
+
+let body method_ =
+  Printf.sprintf {|{"jsonrpc":"2.0","id":1,"method":"%s","params":{}}|} method_
+
+let initialize_body =
+  {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"parity-test","version":"0.1"}}}|}
+
+let assert_result_ok label = function
+  | Ok () -> ()
+  | Error msg -> failf "%s expected Ok, got Error %S" label msg
+
+let assert_result_error label = function
+  | Ok () -> failf "%s expected Error, got Ok" label
+  | Error msg -> check bool (label ^ " message is not empty") true (String.length msg > 0)
+
+let assert_accept_mode label expected actual =
+  let same =
+    match (expected, actual) with
+    | Negotiation.Streamable, Negotiation.Streamable
+    | Negotiation.Legacy_accepted, Negotiation.Legacy_accepted
+    | Negotiation.Rejected, Negotiation.Rejected ->
+        true
+    | _ -> false
+  in
+  check bool label true same
+
+let test_shared_post_admission_matrix () =
+  assert_result_ok "initialize may mint a fresh session"
+    (Transport.validate_session_requirement ~session_was_provided:false
+       initialize_body);
+  assert_result_error "tools/call requires a session id"
+    (Transport.validate_session_requirement ~session_was_provided:false
+       (body "tools/call"));
+  assert_result_ok "known session passes Q3"
+    (Transport.validate_session_known ~session_was_provided:true ~is_known:true
+       (body "tools/call"));
+  assert_result_error "unknown session blocks tools/call"
+    (Transport.validate_session_known ~session_was_provided:true ~is_known:false
+       (body "tools/call"));
+  assert_result_ok "unknown session still permits initialize"
+    (Transport.validate_session_known ~session_was_provided:true ~is_known:false
+       initialize_body);
+  let streamable_request =
+    request ~headers:[ ("accept", "application/json, text/event-stream") ] "/mcp"
+  in
+  let json_only_request =
+    request ~headers:[ ("accept", "application/json") ] "/mcp"
+  in
+  assert_accept_mode "streamable Accept remains admitted" Negotiation.Streamable
+    (Headers.classify_mcp_accept_for_body streamable_request (body "tools/call"));
+  assert_accept_mode "json-only Accept is rejected for requests" Negotiation.Rejected
+    (Headers.classify_mcp_accept_for_body json_only_request (body "tools/call"));
+  assert_accept_mode "json-only notifications remain legacy-compatible"
+    Negotiation.Legacy_accepted
+    (Headers.classify_mcp_accept_for_body json_only_request
+       {|{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}|})
+
+let test_shared_protocol_and_delete_matrix () =
+  let session_id = "h1-h2-parity-protocol-session" in
+  Fun.protect
+    ~finally:(fun () -> Transport.forget_mcp_session session_id)
+    (fun () ->
+      Transport.remember_protocol_version session_id "2025-11-25";
+      assert_result_ok "missing protocol header preserves continuity"
+        (Transport.validate_protocol_version_continuity ~session_id
+           (request "/mcp"));
+      assert_result_error "mismatched protocol header is rejected"
+        (Transport.validate_protocol_version_continuity ~session_id
+           (request
+              ~headers:[ ("mcp-protocol-version", "2025-03-26") ]
+              "/mcp")));
+  let delete_session = "h1-h2-parity-delete-session" in
+  Fun.protect
+    ~finally:(fun () -> Transport.forget_mcp_session delete_session)
+    (fun () ->
+      Transport.remember_mcp_profile delete_session Transport.Full;
+      assert_result_ok "matching DELETE profile passes"
+        (Transport.validate_mcp_session_delete_profile ~profile:Transport.Full
+           delete_session);
+      assert_result_error "mismatched DELETE profile is rejected"
+        (Transport.validate_mcp_session_delete_profile
+           ~profile:Transport.Managed_agent delete_session));
+  check (option string) "DELETE without session has no admission id" None
+    (Transport.get_session_id_any (request ~meth:`DELETE "/mcp"))
+
+let test_h1_h2_post_route_wiring_parity () =
+  let h1 = source_file "lib/server/server_mcp_transport_http.ml" in
+  let h2 = source_file "lib/server/server_h2_gateway.ml" in
+  List.iter
+    (fun (label, needle) ->
+      assert_contains ("H1 " ^ label) ~needle h1;
+      assert_contains ("H2 " ^ label) ~needle h2)
+    [
+      ("checks session requirement", "validate_session_requirement");
+      ("checks unknown supplied session", "validate_session_known");
+      ("classifies body-aware Accept", "classify_mcp_accept_for_body");
+      ("injects canonical HTTP actor", "body_with_canonical_http_actor");
+      ("forwards internal keeper runtime", "is_verified_internal_keeper_request");
+    ];
+  assert_contains "H1 unknown supplied session returns not found"
+    ~needle:"Httpun.Response.create ~headers `Not_found" h1;
+  assert_contains "H2 unknown supplied session returns not found"
+    ~needle:"~status:`Not_found" h2
+
+let test_h1_h2_delete_route_wiring_parity () =
+  let h1 = source_file "lib/server/server_mcp_transport_http.ml" in
+  let h1_routes = source_file "lib/server/server_routes_http_routes_frontend.ml" in
+  let h2 = source_file "lib/server/server_h2_gateway.ml" in
+  assert_contains "H1 exposes DELETE /mcp route"
+    ~needle:{|Http.Router.add ~path:"/mcp" ~methods:[`DELETE]|}
+    h1_routes;
+  assert_contains "H1 exposes DELETE /mcp/managed route"
+    ~needle:{|Http.Router.add ~path:"/mcp/managed" ~methods:[`DELETE]|}
+    h1_routes;
+  assert_contains "H2 exposes DELETE /mcp route"
+    ~needle:{|`DELETE, "/mcp" | `DELETE, "/mcp/managed" ->|}
+    h2;
+  List.iter
+    (fun (label, needle) ->
+      assert_contains ("H1 DELETE " ^ label) ~needle h1;
+      assert_contains ("H2 DELETE " ^ label) ~needle h2)
+    [
+      ("verifies MCP auth", "verify_mcp_auth ~base_path");
+      ("checks session profile", "validate_mcp_session_delete_profile");
+      ("checks protocol continuity", "validate_protocol_version_continuity");
+      ("forgets session after termination", "forget_mcp_session session_id");
+    ]
+
+let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  run "mcp_h1_h2_admission_parity"
+    [
+      ( "shared-admission-matrix",
+        [
+          test_case "POST shared predicate matrix" `Quick
+            test_shared_post_admission_matrix;
+          test_case "protocol and DELETE predicate matrix" `Quick
+            test_shared_protocol_and_delete_matrix;
+        ] );
+      ( "route-wiring",
+        [
+          test_case "H1/H2 POST route uses the same admission gates" `Quick
+            test_h1_h2_post_route_wiring_parity;
+          test_case "H1/H2 DELETE route uses the same admission gates" `Quick
+            test_h1_h2_delete_route_wiring_parity;
+        ] );
+    ]

--- a/test/test_mcp_session_coverage.ml
+++ b/test/test_mcp_session_coverage.ml
@@ -13,6 +13,7 @@ module Types = Masc_domain
 open Alcotest
 
 module Http_transport = Masc_mcp.Server_mcp_transport_http
+module Actor_injection = Masc_mcp.Server_mcp_actor_injection
 module Auth = Masc_mcp.Auth
 
 let setup_test_room () =
@@ -206,6 +207,29 @@ let test_inject_agent_name_rewrites_internal_actor_only () =
   check (option string) "preserves target agent_name" (Some "target-keeper")
     (member "agent_name" args |> to_string_option)
 
+let test_actor_injection_reducer_skips_absent_actor () =
+  let body =
+    {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_status","arguments":{"days":7}},"id":1}|}
+  in
+  check string "body unchanged without actor" body
+    (Actor_injection.reduce ~actor:None ~auth_token:(Some "token") body)
+
+let test_actor_injection_reducer_rewrites_with_http_auth () =
+  let body =
+    {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_keeper_status","arguments":{"_agent_name":"dashboard","token":"stale-token","name":"sangsu"}},"id":1}|}
+  in
+  let args =
+    Actor_injection.reduce ~actor:(Some "codex") ~auth_token:(Some "token") body
+    |> tool_arguments_of_body
+  in
+  let open Yojson.Safe.Util in
+  check (option string) "actor reducer rewrites _agent_name" (Some "codex")
+    (member "_agent_name" args |> to_string_option);
+  check (option string) "actor reducer strips stale token" None
+    (member "token" args |> to_string_option);
+  check (option string) "actor reducer preserves target name" (Some "sangsu")
+    (member "name" args |> to_string_option)
+
 let test_body_with_canonical_http_actor_uses_token_owner () =
   let dir = setup_test_room () in
   Fun.protect
@@ -366,6 +390,10 @@ let () =
         test_inject_agent_name_preserves_legacy_target_by_default;
       test_case "rewrite_existing only rewrites _agent_name" `Quick
         test_inject_agent_name_rewrites_internal_actor_only;
+      test_case "reducer skips absent actor" `Quick
+        test_actor_injection_reducer_skips_absent_actor;
+      test_case "reducer rewrites actor and strips token with http auth" `Quick
+        test_actor_injection_reducer_rewrites_with_http_auth;
       test_case "canonical http actor uses token owner" `Quick
         test_body_with_canonical_http_actor_uses_token_owner;
     ];


### PR DESCRIPTION
## Summary
- add H1/H2 MCP admission parity fixtures for POST and DELETE gates
- align H2 POST /mcp with H1 unknown-session Q3 rejection before dispatch
- expose H1 DELETE /mcp and /mcp/managed routes to match the advertised and H2 session termination surface

## Verification
- scripts/dune-local.sh build test/test_mcp_h1_h2_admission_parity.exe test/test_http_negotiation.exe test/test_mcp_session_id_header.exe test/test_streamable_http_upgrade.exe
- ./_build/default/test/test_mcp_h1_h2_admission_parity.exe
- ./_build/default/test/test_http_negotiation.exe
- ./_build/default/test/test_mcp_session_id_header.exe
- ./_build/default/test/test_streamable_http_upgrade.exe
- ocamlformat --check lib/server/server_h2_gateway.ml lib/server/server_routes_http_routes_frontend.ml test/test_mcp_h1_h2_admission_parity.ml
- git diff --check origin/main..HEAD

Refs #16080
MASC task: task-364