### PR TITLE
Use shell command gate for worker coding validation

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -587,6 +587,47 @@ let validate_command cmd =
   validate_command_with_allowlist ~allowed_commands:dev_allowed_commands cmd
 ;;
 
+let first_disallowed_stage_bin ~allowed_commands stage_bins =
+  List.find_opt
+    (fun name -> not (List.exists (String.equal name) allowed_commands))
+    stage_bins
+;;
+
+let validate_command_coding_legacy_segments ~allow_pipes ~allowed_commands trimmed =
+  match split_pipeline_segments trimmed with
+  | Error msg -> Error (Command_not_allowed msg)
+  | Ok segments ->
+    if (not allow_pipes) && List.length segments > 1
+    then Error Pipes_not_allowed
+    else if List.exists invokes_direct_dune segments
+    then Error Direct_dune_invocation
+    else (
+      let rec validate_segments = function
+        | [] -> Ok ()
+        | segment :: rest ->
+          (match extract_command_name segment with
+           | None -> Error Empty_command
+           | Some name when List.mem name allowed_commands ->
+             validate_segments rest
+           | Some name -> Error (Command_not_allowed name))
+      in
+      validate_segments segments)
+;;
+
+let validate_command_coding_parsed ~allow_pipes ~allowed_commands context =
+  let stage_bins = context.Shell_command_gate.stage_bins in
+  if (not allow_pipes) && Shell_command_gate.stage_count context > 1
+  then `Error Pipes_not_allowed
+  else if List.exists (String.equal "dune") stage_bins
+  then `Error Direct_dune_invocation
+  else if List.exists (fun name -> String.equal name "env" || String.equal name "opam") stage_bins
+  then `Use_legacy_segments
+  else (
+    match first_disallowed_stage_bin ~allowed_commands stage_bins with
+    | None -> `Ok
+    | Some name -> `Error (Command_not_allowed name))
+;;
+
 let validate_command_coding_with_allowlist
       ?(allow_pipes = true)
       ~(allowed_commands : string list)
@@ -602,23 +643,15 @@ let validate_command_coding_with_allowlist
   else if has_unsafe_redirection trimmed
   then Error Unsafe_redirect
   else (
-    match split_pipeline_segments trimmed with
-    | Error msg -> Error (Command_not_allowed msg)
-    | Ok segments ->
-      if (not allow_pipes) && List.length segments > 1
-      then Error Pipes_not_allowed
-      else if List.exists invokes_direct_dune segments
-      then Error Direct_dune_invocation
-      else (
-        let rec validate_segments = function
-          | [] -> Ok ()
-          | segment :: rest ->
-            (match extract_command_name segment with
-             | None -> Error Empty_command
-             | Some name when List.mem name allowed_commands -> validate_segments rest
-             | Some name -> Error (Command_not_allowed name))
-        in
-        validate_segments segments))
+    match Shell_command_gate.parse trimmed with
+    | Ok context -> (
+      match validate_command_coding_parsed ~allow_pipes ~allowed_commands context with
+      | `Use_legacy_segments ->
+        validate_command_coding_legacy_segments ~allow_pipes ~allowed_commands trimmed
+      | `Ok -> Ok ()
+      | `Error reason -> Error reason)
+    | Error _ ->
+      validate_command_coding_legacy_segments ~allow_pipes ~allowed_commands trimmed)
 ;;
 
 (** Relaxed command validation for Coding/Full preset keepers.

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -579,6 +579,16 @@ let () =
           Alcotest.fail
             ("should split only the real pipeline: "
              ^ Worker_dev_tools.block_reason_to_string e));
+      Alcotest.test_case "allows three-stage parsed pipeline" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_command_coding
+            "rg 'keeper.*tool|tool.*keeper' --type=ml -l | head -20 | wc -l"
+        with
+        | Ok () -> ()
+        | Error e ->
+          Alcotest.fail
+            ("should validate every parsed pipeline stage: "
+             ^ Worker_dev_tools.block_reason_to_string e));
       Alcotest.test_case "allows wrapper redirect" `Quick (fun () ->
         match
           Worker_dev_tools.validate_command_coding
@@ -586,6 +596,11 @@ let () =
         with
         | Ok () -> ()
         | Error e -> Alcotest.fail ("should allow redirect: " ^ Worker_dev_tools.block_reason_to_string e));
+      Alcotest.test_case "blocks parser-supported direct dune" `Quick (fun () ->
+        match Worker_dev_tools.validate_command_coding "dune build" with
+        | Error Worker_dev_tools.Direct_dune_invocation -> ()
+        | Error e -> Alcotest.fail ("wrong rejection: " ^ Worker_dev_tools.block_reason_to_string e)
+        | Ok () -> Alcotest.fail "should reject bare dune");
       Alcotest.test_case "blocks direct dune" `Quick (fun () ->
         match Worker_dev_tools.validate_command_coding "dune build 2>&1" with
         | Error Worker_dev_tools.Direct_dune_invocation -> ()


### PR DESCRIPTION
## Summary

Third PR in the Shell IR stacked sequence.

- routes parser-supported Coding/Full command validation through `Shell_command_gate`
- keeps legacy segment validation only for parser-unsupported shapes and `env`/`opam` wrappers that preserve direct-dune detection semantics
- adds Worker_dev_tools coverage for a three-stage parsed pipeline and parser-supported bare `dune` rejection

## Stack

Base PR: #16135 (`stack/tool-code-write-gate-pr2`)

This PR does not delete the legacy Worker_dev_tools pipeline splitter yet. It narrows its use to compatibility fallback while Shell IR becomes authoritative for parser-supported commands.

## Validation

- `ocamlformat --check lib/worker_dev_tools.ml test/test_worker_dev_tools.ml`
- `git diff --check`

Not completed locally:

- targeted Dune build

The shared `/tmp/me-dune-local.lock` is still held by active keeper builds, so this remains a draft with CI as the first compile signal for the stacked branch.
