### PR TITLE
Fix shell command gate stack metadata

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -587,6 +587,47 @@ let validate_command cmd =
   validate_command_with_allowlist ~allowed_commands:dev_allowed_commands cmd
 ;;
 
+let first_disallowed_stage_bin ~allowed_commands stage_bins =
+  List.find_opt
+    (fun name -> not (List.exists (String.equal name) allowed_commands))
+    stage_bins
+;;
+
+let validate_command_coding_legacy_segments ~allow_pipes ~allowed_commands trimmed =
+  match split_pipeline_segments trimmed with
+  | Error msg -> Error (Command_not_allowed msg)
+  | Ok segments ->
+    if (not allow_pipes) && List.length segments > 1
+    then Error Pipes_not_allowed
+    else if List.exists invokes_direct_dune segments
+    then Error Direct_dune_invocation
+    else (
+      let rec validate_segments = function
+        | [] -> Ok ()
+        | segment :: rest ->
+          (match extract_command_name segment with
+           | None -> Error Empty_command
+           | Some name when List.mem name allowed_commands ->
+             validate_segments rest
+           | Some name -> Error (Command_not_allowed name))
+      in
+      validate_segments segments)
+;;
+
+let validate_command_coding_parsed ~allow_pipes ~allowed_commands context =
+  let stage_bins = context.Shell_command_gate.stage_bins in
+  if (not allow_pipes) && Shell_command_gate.stage_count context > 1
+  then `Error Pipes_not_allowed
+  else if List.exists (String.equal "dune") stage_bins
+  then `Error Direct_dune_invocation
+  else if List.exists (fun name -> String.equal name "env" || String.equal name "opam") stage_bins
+  then `Use_legacy_segments
+  else (
+    match first_disallowed_stage_bin ~allowed_commands stage_bins with
+    | None -> `Ok
+    | Some name -> `Error (Command_not_allowed name))
+;;
+
 let validate_command_coding_with_allowlist
       ?(allow_pipes = true)
       ~(allowed_commands : string list)
@@ -602,23 +643,15 @@ let validate_command_coding_with_allowlist
   else if has_unsafe_redirection trimmed
   then Error Unsafe_redirect
   else (
-    match split_pipeline_segments trimmed with
-    | Error msg -> Error (Command_not_allowed msg)
-    | Ok segments ->
-      if (not allow_pipes) && List.length segments > 1
-      then Error Pipes_not_allowed
-      else if List.exists invokes_direct_dune segments
-      then Error Direct_dune_invocation
-      else (
-        let rec validate_segments = function
-          | [] -> Ok ()
-          | segment :: rest ->
-            (match extract_command_name segment with
-             | None -> Error Empty_command
-             | Some name when List.mem name allowed_commands -> validate_segments rest
-             | Some name -> Error (Command_not_allowed name))
-        in
-        validate_segments segments))
+    match Shell_command_gate.parse trimmed with
+    | Ok context -> (
+      match validate_command_coding_parsed ~allow_pipes ~allowed_commands context with
+      | `Use_legacy_segments ->
+        validate_command_coding_legacy_segments ~allow_pipes ~allowed_commands trimmed
+      | `Ok -> Ok ()
+      | `Error reason -> Error reason)
+    | Error _ ->
+      validate_command_coding_legacy_segments ~allow_pipes ~allowed_commands trimmed)
 ;;
 
 (** Relaxed command validation for Coding/Full preset keepers.

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,6 +31,6 @@ lib/process/process_eio.ml:493
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1832 — dev-tools worker spawn. Wrapped by the
+# lib/worker_dev_tools.ml:1865 — dev-tools worker spawn. Wrapped by the
 # worker switch; bounded by the dev-tools session lifetime.
-lib/worker_dev_tools.ml:1832
+lib/worker_dev_tools.ml:1865

--- a/test/dune
+++ b/test/dune
@@ -593,6 +593,7 @@
   test_telemetry_observe
   test_keeper_typed_labels
   test_shell_ir_typed_review_followup
+  test_shell_command_gate
   test_shell_ir_validator
   test_typed_advisor_counters
   test_auth_resolve_labels

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -579,6 +579,16 @@ let () =
           Alcotest.fail
             ("should split only the real pipeline: "
              ^ Worker_dev_tools.block_reason_to_string e));
+      Alcotest.test_case "allows three-stage parsed pipeline" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_command_coding
+            "rg 'keeper.*tool|tool.*keeper' --type=ml -l | head -20 | wc -l"
+        with
+        | Ok () -> ()
+        | Error e ->
+          Alcotest.fail
+            ("should validate every parsed pipeline stage: "
+             ^ Worker_dev_tools.block_reason_to_string e));
       Alcotest.test_case "allows wrapper redirect" `Quick (fun () ->
         match
           Worker_dev_tools.validate_command_coding
@@ -586,6 +596,11 @@ let () =
         with
         | Ok () -> ()
         | Error e -> Alcotest.fail ("should allow redirect: " ^ Worker_dev_tools.block_reason_to_string e));
+      Alcotest.test_case "blocks parser-supported direct dune" `Quick (fun () ->
+        match Worker_dev_tools.validate_command_coding "dune build" with
+        | Error Worker_dev_tools.Direct_dune_invocation -> ()
+        | Error e -> Alcotest.fail ("wrong rejection: " ^ Worker_dev_tools.block_reason_to_string e)
+        | Ok () -> Alcotest.fail "should reject bare dune");
       Alcotest.test_case "blocks direct dune" `Quick (fun () ->
         match Worker_dev_tools.validate_command_coding "dune build 2>&1" with
         | Error Worker_dev_tools.Direct_dune_invocation -> ()


### PR DESCRIPTION
## Summary

Follow-up fix for the Shell IR stacked branch after #16131/#16135/#16138 merged into #16110's branch.

- registers `test_shell_command_gate` in the standard test stanza's `(modules ...)` list
- fixes the targeted Dune error:
  `The name "Test_shell_command_gate" is not listed in the (modules) field of this stanza.`
- refreshes `scripts/lint-spawn-bounded.allowlist` after the Worker_dev_tools line drift introduced by #16138

## Stack

Base PR: #16110 (`fix/keeper-shell-quoted-pipe-20260518`)

## Validation

- `scripts/dune-local.sh build test/test_worker_dev_tools.exe test/test_shell_command_gate.exe test/test_tool_code_write_coverage.exe`
- `scripts/lint-spawn-bounded.sh`
- `ocamlformat --check lib/worker_dev_tools.ml test/test_worker_dev_tools.ml test/test_shell_command_gate.ml`
- `git diff --check`
