### PR TITLE
refactor: share MCP request context

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -80,6 +80,7 @@
  server_mcp_transport_http_types
  server_mcp_transport_http_session
  server_mcp_transport_http_headers
+ server_mcp_request_context
  server_mcp_transport_http_sse
  server_mcp_transport_http_conn
  server_mcp_transport_http_respond

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -390,13 +390,10 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           h2_respond_removed_surface h2_reqd ~surface:"operator_remote" ~extra_headers:cors
 
       | `POST, "/mcp" | `POST, "/" | `POST, "/mcp/managed" ->
-          let session_was_provided = Option.is_some session_id_opt in
           let session_id = match session_id_opt with
             | Some id -> id
             | None -> Mcp_session.generate ()
           in
-          let auth_token = auth_token_from_request httpun_request in
-          let protocol_version = get_protocol_version_for_session ~session_id httpun_request in
           let profile =
             if String.equal path "/mcp/managed"
             then Server_mcp_transport_http.Managed_agent
@@ -407,6 +404,17 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             | Some s -> s.Mcp_server.room_config.base_path
             | None -> default_base_path ()
           in
+          let context =
+            Server_mcp_request_context.make ~session_id_opt
+              ~generated_session_id:session_id
+              ~auth_token:(auth_token_from_request httpun_request)
+              ~protocol_version:
+                (get_protocol_version_for_session ~session_id httpun_request)
+              ~origin ~base_path
+          in
+          let session_id = context.session_id in
+          let auth_token = context.auth_token in
+          let protocol_version = context.protocol_version in
           let auth_result =
             match profile with
             | Server_mcp_transport_http.Full
@@ -435,11 +443,16 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                      | Ok _cred_opt ->
                          h2_read_body h2_reqd (fun body_str ->
                              match
-                               Server_mcp_transport_http
-                               .validate_session_requirement
-                                 ~session_was_provided body_str
+                               Server_mcp_request_context.decide_post_body
+                                 ~request:httpun_request ~context
+                                 ~session_is_known:
+                                   (Server_mcp_transport_http.is_known_session
+                                      session_id)
+                                 body_str
                              with
-                             | Error msg ->
+                             | Error
+                                 (Server_mcp_request_context.Session_required msg)
+                               ->
                                  let body = json_rpc_error (-32600) msg in
                                  h2_respond_json h2_reqd body
                                    ~status:`Bad_request
@@ -447,17 +460,9 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                      (cors
                                      @ mcp_headers session_id
                                          protocol_version)
-                             | Ok () ->
-                             let is_known =
-                               session_was_provided
-                               && Server_mcp_transport_http.is_known_session
-                                    session_id
-                             in
-                             (match
-                                Server_mcp_transport_http.validate_session_known
-                                  ~session_was_provided ~is_known body_str
-                              with
-                              | Error msg ->
+                             | Error
+                                 (Server_mcp_request_context.Unknown_session msg)
+                               ->
                                   let new_session_id = Mcp_session.generate () in
                                   let body = json_rpc_error (-32600) msg in
                                   h2_respond_json h2_reqd body
@@ -466,23 +471,15 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                       (cors
                                       @ mcp_headers new_session_id
                                           protocol_version)
-                              | Ok () ->
-                             let accept_mode =
-                               Server_mcp_transport_http_headers
-                               .classify_mcp_accept_for_body httpun_request body_str
-                             in
-                             match accept_mode with
-                             | Http_negotiation.Rejected ->
-                                 let body =
-                                   json_rpc_error (-32600)
-                                     "Invalid Accept header: must include application/json and text/event-stream. \
-                                      Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility."
-                                 in
+                             | Error
+                                 (Server_mcp_request_context.Invalid_accept msg)
+                               ->
+                                 let body = json_rpc_error (-32600) msg in
                                  h2_respond_json h2_reqd body ~status:`Bad_request
                                    ~extra_headers:(cors @ mcp_headers session_id protocol_version)
-                             | accept_mode ->
+                             | Ok post_context ->
                                  let accept_warn_headers =
-                                   legacy_accept_warning_headers accept_mode
+                                   post_context.accept_warn_headers
                                  in
                                  with_server_state h2_reqd (fun state ->
                                    let profile =
@@ -490,7 +487,8 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                    in
                                    let body_with_agent =
                                      Server_mcp_transport_http.body_with_canonical_http_actor
-                                       ~base_path ~auth_token httpun_request body_str
+                                       ~base_path ~auth_token httpun_request
+                                       post_context.body_str
                                    in
                                    let internal_keeper_runtime =
                                      Server_auth.is_verified_internal_keeper_request
@@ -502,7 +500,10 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                        ~internal_keeper_runtime state
                                        body_with_agent
                                    in
-                                   (match protocol_version_from_body body_str with
+                                   (match
+                                      protocol_version_from_body
+                                        post_context.body_str
+                                    with
                                    | Some v -> remember_protocol_version session_id v
                                    | None -> ());
                                    let protocol_version =
@@ -523,7 +524,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                          ~extra_headers:mcp_hdrs
                                    | json ->
                                        let body = Yojson.Safe.to_string json in
-                                       h2_respond_json h2_reqd body ~extra_headers:mcp_hdrs))))))
+                                       h2_respond_json h2_reqd body ~extra_headers:mcp_hdrs)))))
 
       | `DELETE, "/mcp/operator" ->
           h2_respond_removed_surface h2_reqd ~surface:"operator_remote" ~extra_headers:cors

--- a/lib/server/server_mcp_request_context.ml
+++ b/lib/server/server_mcp_request_context.ml
@@ -1,0 +1,56 @@
+type t = {
+  session_id : string;
+  session_was_provided : bool;
+  auth_token : string option;
+  protocol_version : string;
+  origin : string;
+  base_path : string;
+}
+
+let make ~session_id_opt ~generated_session_id ~auth_token ~protocol_version
+    ~origin ~base_path =
+  let session_was_provided = Option.is_some session_id_opt in
+  let session_id = Option.value ~default:generated_session_id session_id_opt in
+  { session_id; session_was_provided; auth_token; protocol_version; origin; base_path }
+
+type post_body_decision = {
+  body_str : string;
+  accept_mode : Mcp_transport_protocol.Http_negotiation.accept_mode;
+  accept_warn_headers : (string * string) list;
+}
+
+type post_body_rejection =
+  | Session_required of string
+  | Unknown_session of string
+  | Invalid_accept of string
+
+let invalid_accept_message =
+  "Invalid Accept header: must include application/json and text/event-stream. \
+   Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility."
+
+let decide_post_body ~request ~context ~session_is_known body_str =
+  match
+    Server_mcp_transport_http_protocol.validate_session_requirement
+      ~session_was_provided:context.session_was_provided body_str
+  with
+  | Error msg -> Error (Session_required msg)
+  | Ok () -> (
+      let is_known = context.session_was_provided && session_is_known in
+      match
+        Server_mcp_transport_http_protocol.validate_session_known
+          ~session_was_provided:context.session_was_provided ~is_known body_str
+      with
+      | Error msg -> Error (Unknown_session msg)
+      | Ok () -> (
+          match
+            Server_mcp_transport_http_headers.classify_mcp_accept_for_body request
+              body_str
+          with
+          | Mcp_transport_protocol.Http_negotiation.Rejected ->
+              Error (Invalid_accept invalid_accept_message)
+          | accept_mode ->
+              let accept_warn_headers =
+                Server_mcp_transport_http_headers.legacy_accept_warning_headers
+                  accept_mode
+              in
+              Ok { body_str; accept_mode; accept_warn_headers }))

--- a/lib/server/server_mcp_request_context.mli
+++ b/lib/server/server_mcp_request_context.mli
@@ -1,0 +1,37 @@
+type t = {
+  session_id : string;
+  session_was_provided : bool;
+  auth_token : string option;
+  protocol_version : string;
+  origin : string;
+  base_path : string;
+}
+
+val make :
+  session_id_opt:string option ->
+  generated_session_id:string ->
+  auth_token:string option ->
+  protocol_version:string ->
+  origin:string ->
+  base_path:string ->
+  t
+
+type post_body_decision = {
+  body_str : string;
+  accept_mode : Mcp_transport_protocol.Http_negotiation.accept_mode;
+  accept_warn_headers : (string * string) list;
+}
+
+type post_body_rejection =
+  | Session_required of string
+  | Unknown_session of string
+  | Invalid_accept of string
+
+val invalid_accept_message : string
+
+val decide_post_body :
+  request:Httpun.Request.t ->
+  context:t ->
+  session_is_known:bool ->
+  string ->
+  (post_body_decision, post_body_rejection) result

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -283,16 +283,23 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
     respond_not_ready ~deps request reqd
   else
   let session_id_opt = get_session_id_any request in
-  let session_was_provided = Option.is_some session_id_opt in
   let session_id =
     match session_id_opt with
     | Some sid -> sid
     | None -> Mcp_session.generate ()
   in
-  let auth_token = deps.auth_token_from_request request in
-  let protocol_version = get_protocol_version_for_session ~session_id request in
-  let origin = deps.get_origin request in
-  let base_path = deps.get_base_path () in
+  let context =
+    Server_mcp_request_context.make ~session_id_opt
+      ~generated_session_id:session_id
+      ~auth_token:(deps.auth_token_from_request request)
+      ~protocol_version:(get_protocol_version_for_session ~session_id request)
+      ~origin:(deps.get_origin request) ~base_path:(deps.get_base_path ())
+  in
+  let session_id = context.session_id in
+  let auth_token = context.auth_token in
+  let protocol_version = context.protocol_version in
+  let origin = context.origin in
+  let base_path = context.base_path in
   let auth_result =
     match profile with
     | Full | Managed_agent ->
@@ -349,12 +356,14 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
     in
     Ok (Http.Request.read_body_async reqd (fun body_str ->
       ignore (
-        let* () =
+      let* post_context =
         match
-          validate_session_requirement ~session_was_provided body_str
+          Server_mcp_request_context.decide_post_body ~request ~context
+            ~session_is_known:(is_known_session session_id)
+            body_str
         with
-        | Ok () -> Ok ()
-        | Error msg ->
+        | Ok decision -> Ok decision
+        | Error (Server_mcp_request_context.Session_required msg) ->
             let body =
               Printf.sprintf
                 {|{"jsonrpc":"2.0","error":{"code":-32600,"message":%s},"id":null}|}
@@ -370,25 +379,7 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
               (Httpun.Response.create ~headers `Bad_request)
               body;
             Error ()
-      in
-      let* () =
-        (* RFC-0100 PR-3 — Q3 default. If the client echoed an
-           [Mcp-Session-Id] the server has no protocol-version state
-           for, respond [404 Not Found] with a freshly minted
-           [Mcp-Session-Id] header so the client re-handshakes via
-           [initialize] instead of silently riding on a phantom
-           session. The handshake methods are exempt: [initialize]
-           legitimately mints the state we are about to check for,
-           and [ping] / [notifications/initialized] are allowed
-           without a known session per the existing contract. *)
-        let is_known =
-          session_was_provided && is_known_session session_id
-        in
-        match
-          validate_session_known ~session_was_provided ~is_known body_str
-        with
-        | Ok () -> Ok ()
-        | Error msg ->
+        | Error (Server_mcp_request_context.Unknown_session msg) ->
             let new_session_id = Mcp_session.generate () in
             let body =
               Printf.sprintf
@@ -405,14 +396,7 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
               (Httpun.Response.create ~headers `Not_found)
               body;
             Error ()
-      in
-      let accept_mode =
-        Server_mcp_transport_http_headers.classify_mcp_accept_for_body
-          request body_str
-      in
-      let* accept_mode =
-        match accept_mode with
-        | Http_negotiation.Rejected ->
+        | Error (Server_mcp_request_context.Invalid_accept msg) ->
             let body =
               Yojson.Safe.to_string
                 (`Assoc
@@ -422,9 +406,7 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
                       `Assoc
                         [
                           ("code", `Int (-32600));
-                          ( "message",
-                            `String
-                              "Invalid Accept header: must include application/json and text/event-stream. Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility." );
+                          ("message", `String msg);
                         ] );
                   ])
             in
@@ -436,11 +418,9 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
             let response = Httpun.Response.create ~headers `Bad_request in
             safe_respond_with_string reqd response body;
             Error ()
-        | _ -> Ok accept_mode
       in
-      let accept_warn_headers =
-        legacy_accept_warning_headers accept_mode
-      in
+      let accept_mode = post_context.accept_mode in
+      let accept_warn_headers = post_context.accept_warn_headers in
       let* runtime =
         match request_runtime_result deps with
         | Ok r -> Ok r

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module Transport = Masc_mcp.Server_mcp_transport_http
+module Request_context = Masc_mcp.Server_mcp_request_context
 module Headers = Masc_mcp.Server_mcp_transport_http_headers
 module Negotiation = Mcp_transport_protocol.Http_negotiation
 
@@ -46,6 +47,83 @@ let assert_accept_mode label expected actual =
     | _ -> false
   in
   check bool label true same
+
+let context ?(session_id = "ctx-session") ?(session_was_provided = true) () =
+  Request_context.make
+    ~session_id_opt:(if session_was_provided then Some session_id else None)
+    ~generated_session_id:session_id ~auth_token:None
+    ~protocol_version:"2025-11-25" ~origin:"*" ~base_path:"/tmp/masc-test"
+
+let test_request_context_make_records_session_source () =
+  let supplied =
+    Request_context.make ~session_id_opt:(Some "supplied-session")
+      ~generated_session_id:"generated-session" ~auth_token:(Some "token")
+      ~protocol_version:"2025-11-25" ~origin:"https://example.test"
+      ~base_path:"/tmp/base"
+  in
+  check string "supplied session wins" "supplied-session" supplied.session_id;
+  check bool "supplied flag" true supplied.session_was_provided;
+  check (option string) "auth token" (Some "token") supplied.auth_token;
+  check string "protocol version" "2025-11-25" supplied.protocol_version;
+  check string "origin" "https://example.test" supplied.origin;
+  check string "base path" "/tmp/base" supplied.base_path;
+  let generated =
+    Request_context.make ~session_id_opt:None
+      ~generated_session_id:"generated-session" ~auth_token:None
+      ~protocol_version:"2025-11-25" ~origin:"*" ~base_path:"/tmp/base"
+  in
+  check string "generated fallback" "generated-session" generated.session_id;
+  check bool "generated flag" false generated.session_was_provided
+
+let test_request_context_decides_post_body () =
+  let streamable_request =
+    request ~headers:[ ("accept", "application/json, text/event-stream") ] "/mcp"
+  in
+  let json_only_request =
+    request ~headers:[ ("accept", "application/json") ] "/mcp"
+  in
+  (match
+     Request_context.decide_post_body ~request:streamable_request
+       ~context:(context ()) ~session_is_known:true (body "tools/call")
+   with
+  | Ok decision ->
+      assert_accept_mode "streamable decision" Negotiation.Streamable
+        decision.accept_mode;
+      check (list (pair string string)) "no warning headers" []
+        decision.accept_warn_headers
+  | Error _ -> fail "streamable known session should pass");
+  (match
+     Request_context.decide_post_body ~request:streamable_request
+       ~context:(context ~session_was_provided:false ()) ~session_is_known:false
+       (body "tools/call")
+   with
+  | Error (Request_context.Session_required msg) ->
+      check bool "session required message" true (String.length msg > 0)
+  | Ok _ -> fail "missing session should reject tools/call"
+  | Error _ -> fail "missing session should use Session_required");
+  (match
+     Request_context.decide_post_body ~request:streamable_request
+       ~context:(context ()) ~session_is_known:false (body "tools/call")
+   with
+  | Error (Request_context.Unknown_session msg) ->
+      check bool "unknown session message" true (String.length msg > 0)
+  | Ok _ -> fail "unknown session should reject tools/call"
+  | Error _ -> fail "unknown session should use Unknown_session");
+  (match
+     Request_context.decide_post_body ~request:json_only_request
+       ~context:(context ()) ~session_is_known:true (body "tools/call")
+   with
+  | Error (Request_context.Invalid_accept msg) ->
+      check string "invalid accept message" Request_context.invalid_accept_message
+        msg
+  | Ok _ -> fail "json-only request should reject tools/call"
+  | Error _ -> fail "json-only request should use Invalid_accept");
+  (match
+     Request_context.decide_post_body ~request:streamable_request
+       ~context:(context ()) ~session_is_known:false initialize_body
+   with
+  | Ok _ -> ()
+  | Error _ -> fail "unknown session should still permit initialize")
 
 let test_shared_post_admission_matrix () =
   assert_result_ok "initialize may mint a fresh session"
@@ -114,9 +192,7 @@ let test_h1_h2_post_route_wiring_parity () =
       assert_contains ("H1 " ^ label) ~needle h1;
       assert_contains ("H2 " ^ label) ~needle h2)
     [
-      ("checks session requirement", "validate_session_requirement");
-      ("checks unknown supplied session", "validate_session_known");
-      ("classifies body-aware Accept", "classify_mcp_accept_for_body");
+      ("uses shared POST request context", "Server_mcp_request_context.decide_post_body");
       ("injects canonical HTTP actor", "body_with_canonical_http_actor");
       ("forwards internal keeper runtime", "is_verified_internal_keeper_request");
     ];
@@ -156,6 +232,10 @@ let () =
     [
       ( "shared-admission-matrix",
         [
+          test_case "request context records pre-body state" `Quick
+            test_request_context_make_records_session_source;
+          test_case "request context decides POST body admission" `Quick
+            test_request_context_decides_post_body;
           test_case "POST shared predicate matrix" `Quick
             test_shared_post_admission_matrix;
           test_case "protocol and DELETE predicate matrix" `Quick


### PR DESCRIPTION
Part of #16080. MASC task-365. This stacked PR depends on #16137 and extracts pre-body MCP request context plus POST body admission decisions into Server_mcp_request_context so H1 and H2 keep one shared logic path. Verification: ocamlformat --check touched OCaml files; git diff --check; scripts/dune-local.sh build test/test_mcp_h1_h2_admission_parity.exe test/test_http_negotiation.exe test/test_mcp_session_id_header.exe test/test_streamable_http_upgrade.exe; ran all four test binaries successfully.