### PR TITLE
refactor: extract MCP actor injection reducer

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -81,6 +81,7 @@
  server_mcp_transport_http_session
  server_mcp_transport_http_headers
  server_mcp_request_context
+ server_mcp_actor_injection
  server_mcp_transport_http_sse
  server_mcp_transport_http_conn
  server_mcp_transport_http_respond

--- a/lib/server/server_mcp_actor_injection.ml
+++ b/lib/server/server_mcp_actor_injection.ml
@@ -1,0 +1,108 @@
+(** Inject or replace [_agent_name] in MCP [tools/call] arguments.
+    For authenticated dashboard sessions, the HTTP-layer token owner is the
+    canonical caller identity, so a stale browser-supplied [_agent_name]
+    must be overwritten. The legacy argument-scoped [token] is also removed
+    when HTTP auth is present so stale MCP bodies cannot override the
+    transport token. Legacy [agent_name] is left untouched because some tools
+    use it as a domain argument rather than caller identity. *)
+let inject_agent_name_into_body ?(rewrite_existing = false) ?(strip_token = false)
+    ~agent_name body_str =
+  try
+    let json = Yojson.Safe.from_string body_str in
+    let open Yojson.Safe.Util in
+    let method_name = member "method" json |> to_string_option in
+    match method_name with
+    | Some "tools/call" ->
+        let params = member "params" json in
+        let args = member "arguments" params in
+        let existing_agent =
+          Option.bind
+            (member "_agent_name" args |> to_string_option)
+            (fun value ->
+              let trimmed = String.trim value in
+              if String.equal trimmed "" then
+                None
+              else
+                Some trimmed)
+        in
+        let existing_legacy_agent =
+          Option.bind
+            (member "agent_name" args |> to_string_option)
+            (fun value ->
+              let trimmed = String.trim value in
+              if String.equal trimmed "" then
+                None
+              else
+                Some trimmed)
+        in
+        let new_args =
+          match args with
+          | `Assoc fields ->
+              let normalized_fields =
+                let fields =
+                  if rewrite_existing then
+                    List.filter
+                      (fun (key, _) -> not (String.equal key "_agent_name"))
+                      fields
+                  else
+                    fields
+                in
+                if strip_token then
+                  List.filter (fun (key, _) -> not (String.equal key "token")) fields
+                else
+                  fields
+              in
+              let should_inject =
+                rewrite_existing
+                || (Option.is_none existing_agent
+                   && Option.is_none existing_legacy_agent)
+              in
+              if should_inject then
+                `Assoc (("_agent_name", `String agent_name) :: normalized_fields)
+              else
+                args
+          | _ -> args
+        in
+        if new_args = args then
+          body_str
+        else
+          let new_params =
+            match params with
+            | `Assoc fields ->
+                `Assoc
+                  (List.map
+                     (fun (k, v) ->
+                       if k = "arguments" then
+                         (k, new_args)
+                       else
+                         (k, v))
+                     fields)
+            | _ -> params
+          in
+          let new_json =
+            match json with
+            | `Assoc fields ->
+                `Assoc
+                  (List.map
+                     (fun (k, v) ->
+                       if k = "params" then
+                         (k, new_params)
+                       else
+                         (k, v))
+                     fields)
+            | _ -> json
+          in
+          Yojson.Safe.to_string new_json
+    | _ -> body_str
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> body_str
+
+let reduce ~actor ~auth_token body_str =
+  match actor with
+  | None -> body_str
+  | Some agent ->
+      inject_agent_name_into_body
+        ~rewrite_existing:(Option.is_some auth_token)
+        ~strip_token:(Option.is_some auth_token)
+        ~agent_name:agent body_str

--- a/lib/server/server_mcp_actor_injection.mli
+++ b/lib/server/server_mcp_actor_injection.mli
@@ -1,0 +1,8 @@
+val inject_agent_name_into_body :
+  ?rewrite_existing:bool ->
+  ?strip_token:bool ->
+  agent_name:string ->
+  string ->
+  string
+
+val reduce : actor:string option -> auth_token:string option -> string -> string

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -191,91 +191,14 @@ let should_stream_post_tools_call request body_str accept_mode =
       | None -> false)
   | _ -> false
 
-(** Inject or replace [_agent_name] in MCP [tools/call] arguments.
-    For authenticated dashboard sessions, the HTTP-layer token owner is the
-    canonical caller identity, so a stale browser-supplied [_agent_name]
-    must be overwritten. The legacy argument-scoped [token] is also removed
-    when HTTP auth is present so stale MCP bodies cannot override the
-    transport token. Legacy [agent_name] is left untouched because some tools
-    use it as a domain argument rather than caller identity. *)
 let inject_agent_name_into_body ?(rewrite_existing = false) ?(strip_token = false)
     ~agent_name body_str =
-  try
-    let json = Yojson.Safe.from_string body_str in
-    let open Yojson.Safe.Util in
-    let method_name = member "method" json |> to_string_option in
-    match method_name with
-    | Some "tools/call" ->
-        let params = member "params" json in
-        let args = member "arguments" params in
-        let existing_agent =
-          Option.bind
-            (member "_agent_name" args |> to_string_option)
-            (fun value ->
-               let trimmed = String.trim value in
-               if String.equal trimmed "" then None else Some trimmed)
-        in
-        let existing_legacy_agent =
-          Option.bind
-            (member "agent_name" args |> to_string_option)
-            (fun value ->
-               let trimmed = String.trim value in
-               if String.equal trimmed "" then None else Some trimmed)
-        in
-        let new_args =
-          match args with
-          | `Assoc fields ->
-              let normalized_fields =
-                let fields =
-                  if rewrite_existing then
-                    List.filter
-                      (fun (key, _) -> not (String.equal key "_agent_name"))
-                      fields
-                  else
-                    fields
-                in
-                if strip_token then
-                  List.filter (fun (key, _) -> not (String.equal key "token"))
-                    fields
-                else
-                  fields
-              in
-              let should_inject =
-                rewrite_existing
-                || (Option.is_none existing_agent
-                    && Option.is_none existing_legacy_agent)
-              in
-              if should_inject then
-                `Assoc (("_agent_name", `String agent_name) :: normalized_fields)
-              else
-                args
-          | _ -> args
-        in
-        if new_args = args then body_str else
-          let new_params = match params with
-            | `Assoc fields ->
-                `Assoc (List.map (fun (k, v) ->
-                  if k = "arguments" then (k, new_args) else (k, v)) fields)
-            | _ -> params
-          in
-          let new_json = match json with
-            | `Assoc fields ->
-                `Assoc (List.map (fun (k, v) ->
-                  if k = "params" then (k, new_params) else (k, v)) fields)
-            | _ -> json
-          in
-          Yojson.Safe.to_string new_json
-    | _ -> body_str
-  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> body_str
+  Server_mcp_actor_injection.inject_agent_name_into_body ~rewrite_existing
+    ~strip_token ~agent_name body_str
 
 let body_with_canonical_http_actor ~base_path ~auth_token request body_str =
-  match Server_auth.dashboard_actor_for_request ~base_path request with
-  | None -> body_str
-  | Some agent ->
-      inject_agent_name_into_body
-        ~rewrite_existing:(Option.is_some auth_token)
-        ~strip_token:(Option.is_some auth_token)
-        ~agent_name:agent body_str
+  let actor = Server_auth.dashboard_actor_for_request ~base_path request in
+  Server_mcp_actor_injection.reduce ~actor ~auth_token body_str
 
 let handle_post_mcp ~deps ?(profile = Full) request reqd =
   (* Readiness gate: reject before session/auth if server state is not ready *)

--- a/test/test_mcp_session_coverage.ml
+++ b/test/test_mcp_session_coverage.ml
@@ -13,6 +13,7 @@ module Types = Masc_domain
 open Alcotest
 
 module Http_transport = Masc_mcp.Server_mcp_transport_http
+module Actor_injection = Masc_mcp.Server_mcp_actor_injection
 module Auth = Masc_mcp.Auth
 
 let setup_test_room () =
@@ -206,6 +207,29 @@ let test_inject_agent_name_rewrites_internal_actor_only () =
   check (option string) "preserves target agent_name" (Some "target-keeper")
     (member "agent_name" args |> to_string_option)
 
+let test_actor_injection_reducer_skips_absent_actor () =
+  let body =
+    {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_status","arguments":{"days":7}},"id":1}|}
+  in
+  check string "body unchanged without actor" body
+    (Actor_injection.reduce ~actor:None ~auth_token:(Some "token") body)
+
+let test_actor_injection_reducer_rewrites_with_http_auth () =
+  let body =
+    {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_keeper_status","arguments":{"_agent_name":"dashboard","token":"stale-token","name":"sangsu"}},"id":1}|}
+  in
+  let args =
+    Actor_injection.reduce ~actor:(Some "codex") ~auth_token:(Some "token") body
+    |> tool_arguments_of_body
+  in
+  let open Yojson.Safe.Util in
+  check (option string) "actor reducer rewrites _agent_name" (Some "codex")
+    (member "_agent_name" args |> to_string_option);
+  check (option string) "actor reducer strips stale token" None
+    (member "token" args |> to_string_option);
+  check (option string) "actor reducer preserves target name" (Some "sangsu")
+    (member "name" args |> to_string_option)
+
 let test_body_with_canonical_http_actor_uses_token_owner () =
   let dir = setup_test_room () in
   Fun.protect
@@ -366,6 +390,10 @@ let () =
         test_inject_agent_name_preserves_legacy_target_by_default;
       test_case "rewrite_existing only rewrites _agent_name" `Quick
         test_inject_agent_name_rewrites_internal_actor_only;
+      test_case "reducer skips absent actor" `Quick
+        test_actor_injection_reducer_skips_absent_actor;
+      test_case "reducer rewrites actor and strips token with http auth" `Quick
+        test_actor_injection_reducer_rewrites_with_http_auth;
       test_case "canonical http actor uses token owner" `Quick
         test_body_with_canonical_http_actor_uses_token_owner;
     ];


### PR DESCRIPTION
Part of #16080. MASC task-366. This stacked PR depends on #16137 and extracts dashboard actor/token body rewriting into Server_mcp_actor_injection while preserving Server_mcp_transport_http wrapper APIs. Verification: ocamlformat --check touched OCaml files; git diff --check; scripts/dune-local.sh build test/test_mcp_session_coverage.exe test/test_mcp_h1_h2_admission_parity.exe; ran both test binaries successfully.