### PR TITLE
[codex] Clarify keeper paused blocker surfaces

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -177,6 +177,64 @@ describe('dashboardHealthChips', () => {
     expect(chips[0]?.detail).toContain('resume selected paused keepers')
   })
 
+  it('labels an all-paused fleet as paused instead of blocked', () => {
+    const chips = dashboardHealthChips({
+      connected: true,
+      counts: { keepers: 3, configured_keepers: 3 },
+      keepers: [],
+      runtimeResolution: {
+        status: 'ready',
+        warnings: [],
+        fleet_safety: {
+          keeper_fibers: 0,
+          paused_keepers: 3,
+          keeper_fleet_no_fibers: true,
+          keeper_fd_pressure: null,
+          keeper_fleet_safety: {
+            status: 'blocked',
+            reason: null,
+            blocker: 'no_executable_keeper_fibers',
+            admission_blocked: null,
+            admission_blocked_keepers: null,
+            blocked_keepers: 3,
+            blocked_count: 3,
+            bootable_keeper_count: 3,
+            running_keeper_fiber_count: 0,
+            healthy_running_keeper_fiber_count: 0,
+            failing_keeper_fiber_count: 0,
+            executable_keeper_fiber_count: 0,
+            minimum_running_fibers: 2,
+            no_running_fibers: true,
+            no_executable_keeper_fibers: true,
+            low_running_fiber_margin: true,
+            reaction_capacity_below_target: true,
+            reaction_capacity_shortfall_count: 3,
+            executable_reaction_capacity_below_target: true,
+            executable_reaction_capacity_shortfall_count: 3,
+            paused_keeper_count: 3,
+            autoboot_enabled_keeper_count: 3,
+            paused_autoboot_enabled_keeper_count: 3,
+            effective_reaction_capacity_count: 0,
+            executable_reaction_capacity_count: 0,
+            target_reaction_capacity_count: 3,
+            operator_action_required: true,
+          },
+        },
+      } as any,
+      executionError: null,
+      loading: false,
+    })
+
+    expect(chips).toEqual([expect.objectContaining({
+      key: 'fleet-liveness-risk',
+      label: 'Fleet paused',
+      tone: 'warn',
+    })])
+    expect(chips[0]?.detail).toContain('paused_keeper_count=3')
+    expect(chips[0]?.detail).toContain('paused is lifecycle state')
+    expect(chips[0]?.detail).not.toContain('resume selected paused keepers')
+  })
+
   it('surfaces fleet capacity degradation when running fibers are below target', () => {
     const chips = dashboardHealthChips({
       connected: true,

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -235,6 +235,63 @@ describe('dashboardHealthChips', () => {
     expect(chips[0]?.detail).not.toContain('resume selected paused keepers')
   })
 
+  it('keeps mixed paused fleets blocked when autoboot keepers are still below target', () => {
+    const chips = dashboardHealthChips({
+      connected: true,
+      counts: { keepers: 16, configured_keepers: 16 },
+      keepers: [],
+      runtimeResolution: {
+        status: 'ready',
+        warnings: [],
+        fleet_safety: {
+          keeper_fibers: 0,
+          paused_keepers: 14,
+          keeper_fleet_no_fibers: true,
+          keeper_fd_pressure: null,
+          keeper_fleet_safety: {
+            status: 'blocked',
+            reason: null,
+            blocker: 'no_executable_keeper_fibers',
+            admission_blocked: null,
+            admission_blocked_keepers: null,
+            blocked_keepers: 16,
+            blocked_count: 16,
+            bootable_keeper_count: 2,
+            running_keeper_fiber_count: 0,
+            healthy_running_keeper_fiber_count: 0,
+            failing_keeper_fiber_count: 0,
+            executable_keeper_fiber_count: 0,
+            minimum_running_fibers: 2,
+            no_running_fibers: true,
+            no_executable_keeper_fibers: true,
+            low_running_fiber_margin: true,
+            reaction_capacity_below_target: true,
+            reaction_capacity_shortfall_count: 14,
+            executable_reaction_capacity_below_target: true,
+            executable_reaction_capacity_shortfall_count: 14,
+            paused_keeper_count: 14,
+            autoboot_enabled_keeper_count: 14,
+            paused_autoboot_enabled_keeper_count: 13,
+            effective_reaction_capacity_count: 0,
+            executable_reaction_capacity_count: 0,
+            target_reaction_capacity_count: 14,
+            operator_action_required: true,
+          },
+        },
+      } as any,
+      executionError: null,
+      loading: false,
+    })
+
+    expect(chips).toEqual([expect.objectContaining({
+      key: 'fleet-liveness-risk',
+      label: 'P0 fleet blocked',
+      tone: 'bad',
+    })])
+    expect(chips[0]?.detail).toContain('paused_autoboot_enabled_keeper_count=13')
+    expect(chips[0]?.detail).toContain('resume selected paused keepers')
+  })
+
   it('surfaces fleet capacity degradation when running fibers are below target', () => {
     const chips = dashboardHealthChips({
       connected: true,

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -204,6 +204,27 @@ function fleetSafetyHealthChip(fleetSafety: DashboardFleetSafetyHealth | null): 
     targetCapacity != null && runningFibers != null ? Math.max(0, targetCapacity - runningFibers) : null
   )
   const fdPressureBlocked = fdPressureBlockedKeepers(fleetSafety)
+  const pausedOnlyNoExecutable =
+    executableFibers === 0
+    && pausedKeepers > 0
+    && targetCapacity != null
+    && pausedKeepers >= targetCapacity
+  if (pausedOnlyNoExecutable) {
+    const capacityDetail = [
+      `status=${fleetStatus ?? 'paused'}`,
+      `running_keeper_fiber_count=${runningFibers ?? 0}`,
+      `executable_keeper_fiber_count=${executableFibers}`,
+      `paused_keeper_count=${pausedKeepers}`,
+      targetCapacity != null ? `target_reaction_capacity_count=${targetCapacity}` : null,
+      minimumRunning != null ? `minimum_running_fibers=${minimumRunning}` : null,
+    ].filter((item): item is string => item != null).join(', ')
+    return {
+      key: 'fleet-liveness-risk',
+      label: 'Fleet paused',
+      detail: `${capacityDetail}; paused is lifecycle state. Inspect row-level runtime blocker evidence before treating it as a blocker.`,
+      tone: 'warn',
+    }
+  }
   if (fleetStatus === 'blocked' || (requiresAction && (runningFibers === 0 || noFibers === true))) {
     const capacityDetail = [
       `status=${fleetStatus ?? 'blocked'}`,

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -194,6 +194,7 @@ function fleetSafetyHealthChip(fleetSafety: DashboardFleetSafetyHealth | null): 
     ?? fleet?.executable_reaction_capacity_count
     ?? runningFibers
   const pausedKeepers = fleet?.paused_keeper_count ?? paused
+  const pausedAutobootKeepers = fleet?.paused_autoboot_enabled_keeper_count ?? null
   const targetCapacity = fleet?.target_reaction_capacity_count ?? fleet?.autoboot_enabled_keeper_count ?? null
   const bootableKeepers = fleet?.bootable_keeper_count ?? null
   const minimumRunning = fleet?.minimum_running_fibers ?? null
@@ -206,15 +207,17 @@ function fleetSafetyHealthChip(fleetSafety: DashboardFleetSafetyHealth | null): 
   const fdPressureBlocked = fdPressureBlockedKeepers(fleetSafety)
   const pausedOnlyNoExecutable =
     executableFibers === 0
-    && pausedKeepers > 0
+    && pausedAutobootKeepers != null
+    && pausedAutobootKeepers > 0
     && targetCapacity != null
-    && pausedKeepers >= targetCapacity
+    && pausedAutobootKeepers >= targetCapacity
   if (pausedOnlyNoExecutable) {
     const capacityDetail = [
       `status=${fleetStatus ?? 'paused'}`,
       `running_keeper_fiber_count=${runningFibers ?? 0}`,
       `executable_keeper_fiber_count=${executableFibers}`,
       `paused_keeper_count=${pausedKeepers}`,
+      `paused_autoboot_enabled_keeper_count=${pausedAutobootKeepers}`,
       targetCapacity != null ? `target_reaction_capacity_count=${targetCapacity}` : null,
       minimumRunning != null ? `minimum_running_fibers=${minimumRunning}` : null,
     ].filter((item): item is string => item != null).join(', ')
@@ -231,6 +234,7 @@ function fleetSafetyHealthChip(fleetSafety: DashboardFleetSafetyHealth | null): 
       `running_keeper_fiber_count=${runningFibers ?? 0}`,
       executableFibers != null ? `executable_keeper_fiber_count=${executableFibers}` : null,
       `paused_keeper_count=${pausedKeepers}`,
+      pausedAutobootKeepers != null ? `paused_autoboot_enabled_keeper_count=${pausedAutobootKeepers}` : null,
       bootableKeepers != null ? `bootable_keeper_count=${bootableKeepers}` : null,
       targetCapacity != null ? `target_reaction_capacity_count=${targetCapacity}` : null,
       minimumRunning != null ? `minimum_running_fibers=${minimumRunning}` : null,

--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -45,4 +45,25 @@ describe('KeeperRuntimeAlertStrip', () => {
     expect(container.textContent).toContain('keeper_task_done')
     expect(container.textContent).toContain('누락')
   })
+
+  it('separates paused state from runtime blocker evidence', () => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, {
+      keeper: keeper({
+        paused: true,
+        keepalive_running: true,
+        needs_attention: true,
+        attention_reason: 'paused',
+        next_human_action: 'inspect_blocker_before_resume',
+        runtime_blocker_class: 'oas_timeout_budget',
+        runtime_blocker_summary: 'OAS budget timeout fired before the keeper hard timeout.',
+      }),
+    }))
+
+    expect(container.textContent).toContain('일시정지')
+    expect(container.textContent).toContain('일시정지 원인')
+    expect(container.textContent).toContain('OAS budget timeout fired before the keeper hard timeout.')
+    expect(container.textContent).toContain('원인 확인 후 재개')
+    expect(container.textContent).not.toContain('런타임 차단')
+    expect(container.textContent).not.toContain('주의 사유 · paused')
+  })
 })

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -14,6 +14,35 @@ import { keeperNeedsDiagnosticAttention, refreshAfterRuntimeAction } from './kee
 import { pauseKeeper, resumeKeeper, wakeKeeper } from '../api/keeper'
 import { showToast } from './common/toast'
 
+function attentionReasonLabel(reason: string | null, paused: boolean): string | null {
+  if (!reason) return null
+  if ((reason === 'paused' || reason === 'paused_blocked') && paused) return null
+  const labels: Record<string, string> = {
+    approval_pending: '승인 대기',
+    continue_gate_required: '계속 진행 승인 필요',
+    paused: '일시정지',
+    paused_blocked: '일시정지 원인 확인 필요',
+    runtime_blocked: '런타임 근거 확인 필요',
+    timeout_budget_exhausted: '타임아웃 예산 소진',
+    social_model_fallback: '소셜 모델 폴백',
+  }
+  return labels[reason] ?? reason
+}
+
+function nextHumanActionLabel(action: string | null): string | null {
+  if (!action) return null
+  const labels: Record<string, string> = {
+    approve_or_reject_continue: '계속 진행 승인 또는 거절',
+    inspect_blocker_before_resume: '원인 확인 후 재개',
+    inspect_runtime_blocker: '런타임 근거 확인',
+    inspect_timeout_budget: '타임아웃 예산 확인',
+    resolve_approval: '승인 요청 처리',
+    resume_or_review: '재개 또는 설정 검토',
+    review_social_model: '소셜 모델 설정 검토',
+  }
+  return labels[action] ?? action
+}
+
 export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const runtimeBlockerClass = keeper.runtime_blocker_class
   const runtimeBlocker = keeperRuntimeBlockerHint(keeper)
@@ -21,6 +50,9 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const socialFallbackActive = keeper.social_model_recognized === false
   const attentionReason = keeper.attention_reason?.trim() || null
   const nextHumanAction = keeper.next_human_action?.trim() || null
+  const pausedRuntimeBlocker = keeper.paused === true && runtimeBlockerClass != null
+  const attentionReasonText = attentionReasonLabel(attentionReason, keeper.paused === true)
+  const nextHumanActionText = nextHumanActionLabel(nextHumanAction)
   const sandboxTarget = keeper.sandbox_target?.trim() || keeper.sandbox_profile?.trim() || null
   const persistedPolicyCount = keeper.approval_policy_effective?.persisted_rules
   const goalLinkedTasks = keeper.goal_progress?.linked_task_count
@@ -227,14 +259,16 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
             `
           : runtimeBlockerClass
           ? html`
-              <${RuntimeBadge} tone="bad">
-                ${runtimeBlockerLabelText ?? '런타임 차단'}
+              <${RuntimeBadge} tone=${pausedRuntimeBlocker ? 'warn' : 'bad'}>
+                ${pausedRuntimeBlocker
+                  ? `일시정지 원인 · ${runtimeBlockerLabelText ?? '런타임 근거'}`
+                  : runtimeBlockerLabelText ?? '런타임 차단'}
               </${RuntimeBadge}>
               ${hasActivitySignal ? html`<span class="text-[var(--color-fg-muted)]">${renderActivitySignal()}</span>` : null}
             `
           : null}
         ${runtimeBlocker
-          ? html`<span><strong class="text-[var(--color-fg-secondary)]">런타임 차단</strong> · ${runtimeBlocker}</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">${pausedRuntimeBlocker ? '일시정지 원인' : '런타임 차단'}</strong> · ${runtimeBlocker}</span>`
           : null}
         ${blocker
           ? html`<span><${StrongSecondary}>차단 요인</${StrongSecondary}> · ${blocker}</span>`
@@ -244,8 +278,8 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
           : null}
         ${attentionReason === 'approval_pending' && isBlockedBeforeWorktree
           ? html`<${RuntimeBadge} tone="warn">워크트리 전 차단</${RuntimeBadge}>`
-          : attentionReason
-          ? html`<span><strong class="text-[var(--color-fg-secondary)]">주의 사유</strong> · ${attentionReason}</span>`
+          : attentionReasonText
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">주의 사유</strong> · ${attentionReasonText}</span>`
           : null}
         ${attentionReason === 'approval_pending' && pendingApprovalId
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">승인 ID</strong> · <code class="font-mono">${pendingApprovalId}</code></span>`
@@ -256,8 +290,8 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
         ${attentionReason === 'approval_pending' && pendingApprovalTaskId
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">작업</strong> · ${pendingApprovalTaskId}</span>`
           : null}
-        ${nextHumanAction
-          ? html`<span><strong class="text-[var(--color-fg-secondary)]">다음 액션</strong> · ${nextHumanAction}</span>`
+        ${nextHumanActionText
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">다음 액션</strong> · ${nextHumanActionText}</span>`
           : null}
         ${stopCause
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">정지 원인</strong> · ${stopCause.code}${stopCause.summary ? html` · ${stopCause.summary}` : null}</span>`

--- a/dashboard/src/components/mission-agent-cards.test.ts
+++ b/dashboard/src/components/mission-agent-cards.test.ts
@@ -70,7 +70,7 @@ describe('mission keeper runtime helpers', () => {
     } as Keeper
 
     expect(keeperRuntimeHint(keeper)).toBe(
-      'Mutating tools [keeper_fs_edit] committed before the turn timed out.',
+      '일시정지 원인 · Mutating tools [keeper_fs_edit] committed before the turn timed out.',
     )
   })
 
@@ -87,7 +87,7 @@ describe('mission keeper runtime helpers', () => {
     } as Keeper
 
     expect(keeperRuntimeHint(keeper)).toBe(
-      '계속 진행 승인 대기 · Mutating tools [keeper_fs_edit] committed before the turn timed out.',
+      '일시정지 원인 · 계속 진행 승인 대기 · Mutating tools [keeper_fs_edit] committed before the turn timed out.',
     )
   })
 

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -729,6 +729,8 @@ describe('normalizeKeepers lifecycle metrics', () => {
         status: 'idle',
         paused: true,
         keepalive_running: true,
+        pause_state: 'paused',
+        runtime_blocker_state: 'continue_gate',
         runtime_blocker_class: 'ambiguous_post_commit_timeout',
         runtime_blocker_summary:
           'Mutating tools [keeper_fs_edit] committed before the turn timed out.',
@@ -750,6 +752,8 @@ describe('normalizeKeepers lifecycle metrics', () => {
     expect(keeper).toMatchObject({
       paused: true,
       keepalive_running: true,
+      pause_state: 'paused',
+      runtime_blocker_state: 'continue_gate',
       runtime_blocker_class: 'ambiguous_post_commit_timeout',
       runtime_blocker_summary:
         'Mutating tools [keeper_fs_edit] committed before the turn timed out.',

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -560,6 +560,8 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
           typeof row.proactive_enabled === 'boolean' ? row.proactive_enabled : undefined,
         proactive_idle_sec: asNumber(row.proactive_idle_sec),
         proactive_cooldown_sec: asNumber(row.proactive_cooldown_sec),
+        pause_state: asString(row.pause_state) ?? null,
+        runtime_blocker_state: asString(row.runtime_blocker_state) ?? null,
         runtime_blocker_class: runtimeBlockerClass,
         runtime_blocker_summary: runtimeBlockerSummary,
         runtime_blocker_continue_gate:

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -334,7 +334,7 @@ export function keeperRecentActionLabel(
 export function keeperRuntimeHint(keeper: Keeper | null | undefined): string | null {
   if (!keeper) return null
   const runtimeBlocker = keeperRuntimeBlockerHint(keeper)
-  if (runtimeBlocker) return runtimeBlocker
+  if (runtimeBlocker) return keeper.paused ? `일시정지 원인 · ${runtimeBlocker}` : runtimeBlocker
   const socialFallback = socialModelFallbackHint(keeper)
   if (socialFallback) return socialFallback
   const blocker = keeper.last_blocker?.trim()

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -421,6 +421,8 @@ export const KEEPER_RUNTIME_BLOCKER_CLASSES = [
 ] as const
 
 export type KeeperRuntimeBlockerClass = (typeof KEEPER_RUNTIME_BLOCKER_CLASSES)[number]
+export type KeeperPauseState = 'active' | 'paused' | string
+export type KeeperRuntimeBlockerState = 'clear' | 'blocked' | 'continue_gate' | string
 
 export type StopCauseSource =
   | 'runtime_blocker_class'
@@ -897,6 +899,8 @@ export interface Keeper {
   proactive_enabled?: boolean
   proactive_idle_sec?: number
   proactive_cooldown_sec?: number
+  pause_state?: KeeperPauseState | null
+  runtime_blocker_state?: KeeperRuntimeBlockerState | null
   runtime_blocker_class?: KeeperRuntimeBlockerClass | null
   runtime_blocker_summary?: string | null
   runtime_blocker_continue_gate?: boolean | null

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -672,6 +672,18 @@ let runtime_blocker_fields_json (config : Coord_utils.config) (meta : keeper_met
     ]
 ;;
 
+let runtime_state_fields_json (config : Coord_utils.config) (meta : keeper_meta) =
+  let runtime_blocker = runtime_blocker_surface_opt config meta in
+  let pause_state = if meta.paused then "paused" else "active" in
+  let blocker_state =
+    match runtime_blocker with
+    | Some blocker when blocker.continue_gate -> "continue_gate"
+    | Some _ -> "blocked"
+    | None -> "clear"
+  in
+  [ "pause_state", `String pause_state; "runtime_blocker_state", `String blocker_state ]
+;;
+
 let attention_fields_json (config : Coord_utils.config) (meta : keeper_meta) =
   let pending_approval_count =
     Keeper_approval_queue.pending_count_for_keeper ~keeper_name:meta.name
@@ -688,7 +700,7 @@ let attention_fields_json (config : Coord_utils.config) (meta : keeper_meta) =
       | Some blocker when blocker.continue_gate ->
         true, Some "continue_gate_required", Some "approve_or_reject_continue"
       | Some _ when meta.paused ->
-        true, Some "paused_blocked", Some "inspect_runtime_blocker"
+        true, Some "paused", Some "inspect_blocker_before_resume"
       | Some blocker when is_timeout_budget_blocker_class blocker.blocker_class ->
         true, Some "timeout_budget_exhausted", Some "inspect_timeout_budget"
       | Some _ -> true, Some "runtime_blocked", Some "inspect_runtime_blocker"
@@ -835,6 +847,7 @@ let runtime_surface_json config (meta : keeper_meta) =
      ; "fiber_health", `String (Keeper_exec_status.string_of_fiber_health fiber_health)
      ]
      @ social_runtime_fields_json meta
+     @ runtime_state_fields_json config meta
      @ runtime_blocker_fields_json config meta
      @ attention_fields_json config meta)
 ;;

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -660,13 +660,19 @@ let test_runtime_surface_routes_paused_timeout_to_paused_action () =
       check string "runtime blocker class"
         "oas_timeout_budget"
         (runtime |> member "runtime_blocker_class" |> to_string);
+      check string "pause state"
+        "paused"
+        (runtime |> member "pause_state" |> to_string);
+      check string "runtime blocker state"
+        "blocked"
+        (runtime |> member "runtime_blocker_state" |> to_string);
       check bool "needs attention" true
         (runtime |> member "needs_attention" |> to_bool);
       check string "attention reason"
-        "paused_blocked"
+        "paused"
         (runtime |> member "attention_reason" |> to_string);
       check string "next human action"
-        "inspect_runtime_blocker"
+        "inspect_blocker_before_resume"
         (runtime |> member "next_human_action" |> to_string))
 
 let test_runtime_surface_exposes_redacted_resumable_cli_session_blocker () =


### PR DESCRIPTION
## Summary
- split keeper pause state from runtime blocker state in the server runtime surface
- show paused keeper blockers as pause reasons in dashboard UI instead of generic runtime blocked labels
- label all-paused fleets as paused instead of P0 blocked and preserve row-level blocker evidence

## Validation
- ocamlformat --check lib/keeper/keeper_status_bridge.ml test/test_keeper_exec_status.ml
- scripts/dune-local.sh build test/test_keeper_exec_status.exe
- _build/default/test/test_keeper_exec_status.exe
- pnpm exec tsc --noEmit --pretty false
- pnpm exec vitest run --config vitest.config.ts src/components/keeper-detail-alert-strip.test.ts src/components/dashboard-shell.test.ts src/components/mission-agent-cards.test.ts src/keeper-store-normalize.test.ts --no-file-parallelism --maxWorkers=1
- git diff --check

## Notes
- ESLint was attempted on touched frontend files, but the repo flat config ignores these files and reported warnings only, no lint errors.