### PR TITLE
refactor: split mcp tool timeout policy

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -90,6 +90,7 @@
  server_mcp_transport_http_respond
  server_mcp_transport_http_agui
  server_mcp_streaming_tools
+ mcp_server_eio_tool_timeout
   keeper_tool_registry
   keeper_tool_resolution
   keeper_tool_policy_config

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -554,97 +554,13 @@ let call_tool_with_readonly_retry
   in
   loop 1
 
-let coerce_tool_timeout_sec (raw_timeout_sec : float option) : float option =
-  match raw_timeout_sec with
-  | None -> None
-  | Some raw when raw <= 0.0 -> None
-  | Some raw ->
-      let raw_sec = int_of_float (Float.ceil raw) in
-      Some (float_of_int (max 5 (min 300 raw_sec)))
+type resolved_tool_timeout = Mcp_server_eio_tool_timeout.resolved_tool_timeout =
+  { timeout_sec : float
+  ; source_env : string option
+  }
 
-type resolved_tool_timeout = {
-  timeout_sec : float;
-  source_env : string option;
-}
-
-let tool_timeout_default_env = "MASC_TOOL_TIMEOUT_DEFAULT_SEC"
-let tool_timeout_board_env = "MASC_TOOL_TIMEOUT_BOARD_SEC"
-let tool_timeout_persona_generate_source =
-  "internal:masc_persona_generate_oas_budget"
-
-let default_tool_timeout_sec () =
-  Env_config_runtime.Tools.timeout_default_sec ()
-
-let board_write_tool_timeout_sec () =
-  Env_config_runtime.Tools.board_write_timeout_sec ()
-
-(* SSOT for which board tools mutate state lives in [Tool_board]'s
-   [tool_required_permission]: CanBroadcast (post/comment/vote/comment_vote/
-   reaction/curation_submit) and CanAdmin (delete/cleanup) are all writes.
-   Reads (list/get/stats/search/profile/hearths/curation_read) keep the global
-   default timeout. Keep this list in sync when new mutating board tools are
-   added. *)
-let is_board_write_tool_name = function
-  | "keeper_board_post"
-  | "keeper_board_comment"
-  | "keeper_board_vote"
-  | "keeper_board_comment_vote"
-  | "keeper_board_curation_submit"
-  | "keeper_board_delete"
-  | "keeper_board_cleanup"
-  | "masc_board_post"
-  | "masc_board_comment"
-  | "masc_board_vote"
-  | "masc_board_comment_vote"
-  | "masc_board_delete"
-  | "masc_board_cleanup"
-  | "masc_board_reaction"
-  | "masc_board_curation_submit" -> true
-  | _ -> false
-
-let tool_timeout ~(tool_name : string) ~(_arguments : Yojson.Safe.t) :
-    resolved_tool_timeout option =
-  match tool_name with
-  | "masc_keeper_msg" ->
-      (* No fixed timeout for keeper_msg. Keeper has its own internal limits
-         (max_turns, max_cost_usd, max_tokens) that control call duration.
-         A fixed external timeout conflicts with multi-turn tool-use loops. *)
-      None
-  | "masc_transition" ->
-      (* Transition can trigger anti-rationalization review on completion
-         paths. A fixed timeout can report a false error while the state
-         mutation continues in the background, leaving caller-visible status
-         out of sync with persisted task state. *)
-      None
-  | "masc_persona_generate" ->
-      (* Persona generation runs an OAS worker with its own 120s budget. Keep
-         the outer MCP tools/call timeout above that budget so callers see the
-         generation result or the OAS error instead of a premature MCP timeout. *)
-      Some
-        {
-          timeout_sec = 150.0;
-          source_env = Some tool_timeout_persona_generate_source;
-        }
-  | name when is_board_write_tool_name name ->
-      (* #10569: board writes can queue behind the JSONL persist mutex. Keep
-         them bounded, but avoid forcing them through the generic 60s budget
-         while persist-lock histograms identify queueing vs disk stall. *)
-      Some
-        {
-          timeout_sec = board_write_tool_timeout_sec ();
-          source_env = Some tool_timeout_board_env;
-        }
-  | _ ->
-      Some
-        {
-          timeout_sec = default_tool_timeout_sec ();
-          source_env = Some tool_timeout_default_env;
-        }
-
-(** Optional per-tool timeout to prevent long calls from starving the request loop. *)
-let tool_timeout_sec_opt ~(tool_name : string) ~(_arguments : Yojson.Safe.t) : float option =
-  tool_timeout ~tool_name ~_arguments
-  |> Option.map (fun timeout -> timeout.timeout_sec)
+let tool_timeout = Mcp_server_eio_tool_timeout.tool_timeout
+let tool_timeout_sec_opt = Mcp_server_eio_tool_timeout.tool_timeout_sec_opt
 
 (** Resolve managed agent tool call to canonical operation *)
 let resolve_managed_agent_call ?mcp_session_id params =

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -29,7 +29,7 @@
     [record_runtime_mcp_keeper_trajectory],
     [read_only_retry_limit], [is_retryable_message],
     [read_only_retry_wait], [call_tool_with_readonly_retry],
-    [coerce_tool_timeout_sec],
+    timeout policy delegated to [Mcp_server_eio_tool_timeout],
     [resolve_managed_agent_call]).
 
     [tool_profile] is referenced by {!handle_call_tool_eio}

--- a/lib/mcp_server_eio_tool_timeout.ml
+++ b/lib/mcp_server_eio_tool_timeout.ml
@@ -1,0 +1,83 @@
+(** Per-tool timeout policy for MCP [tools/call]. *)
+
+type resolved_tool_timeout =
+  { timeout_sec : float
+  ; source_env : string option
+  }
+
+let tool_timeout_default_env = "MASC_TOOL_TIMEOUT_DEFAULT_SEC"
+let tool_timeout_board_env = "MASC_TOOL_TIMEOUT_BOARD_SEC"
+let tool_timeout_persona_generate_source = "internal:masc_persona_generate_oas_budget"
+
+let default_tool_timeout_sec () = Env_config_runtime.Tools.timeout_default_sec ()
+
+let board_write_tool_timeout_sec () =
+  Env_config_runtime.Tools.board_write_timeout_sec ()
+;;
+
+(* SSOT for which board tools mutate state lives in [Tool_board]'s
+   [tool_required_permission]: CanBroadcast (post/comment/vote/comment_vote/
+   reaction/curation_submit) and CanAdmin (delete/cleanup) are all writes.
+   Reads (list/get/stats/search/profile/hearths/curation_read) keep the global
+   default timeout. Keep this list in sync when new mutating board tools are
+   added. *)
+let is_board_write_tool_name = function
+  | "keeper_board_post"
+  | "keeper_board_comment"
+  | "keeper_board_vote"
+  | "keeper_board_comment_vote"
+  | "keeper_board_curation_submit"
+  | "keeper_board_delete"
+  | "keeper_board_cleanup"
+  | "masc_board_post"
+  | "masc_board_comment"
+  | "masc_board_vote"
+  | "masc_board_comment_vote"
+  | "masc_board_delete"
+  | "masc_board_cleanup"
+  | "masc_board_reaction"
+  | "masc_board_curation_submit" -> true
+  | _ -> false
+;;
+
+let tool_timeout ~(tool_name : string) ~(_arguments : Yojson.Safe.t) :
+  resolved_tool_timeout option
+  =
+  match tool_name with
+  | "masc_keeper_msg" ->
+    (* No fixed timeout for keeper_msg. Keeper has its own internal limits
+       (max_turns, max_cost_usd, max_tokens) that control call duration.
+       A fixed external timeout conflicts with multi-turn tool-use loops. *)
+    None
+  | "masc_transition" ->
+    (* Transition can trigger anti-rationalization review on completion
+       paths. A fixed timeout can report a false error while the state
+       mutation continues in the background, leaving caller-visible status
+       out of sync with persisted task state. *)
+    None
+  | "masc_persona_generate" ->
+    (* Persona generation runs an OAS worker with its own 120s budget. Keep
+       the outer MCP tools/call timeout above that budget so callers see the
+       generation result or the OAS error instead of a premature MCP timeout. *)
+    Some { timeout_sec = 150.0; source_env = Some tool_timeout_persona_generate_source }
+  | name when is_board_write_tool_name name ->
+    (* #10569: board writes can queue behind the JSONL persist mutex. Keep
+       them bounded, but avoid forcing them through the generic 60s budget
+       while persist-lock histograms identify queueing vs disk stall. *)
+    Some
+      { timeout_sec = board_write_tool_timeout_sec ()
+      ; source_env = Some tool_timeout_board_env
+      }
+  | _ ->
+    Some
+      { timeout_sec = default_tool_timeout_sec ()
+      ; source_env = Some tool_timeout_default_env
+      }
+;;
+
+let tool_timeout_sec_opt ~(tool_name : string) ~(_arguments : Yojson.Safe.t) :
+  float option
+  =
+  tool_timeout ~tool_name ~_arguments
+  |> Option.map (fun timeout -> timeout.timeout_sec)
+;;

--- a/lib/mcp_server_eio_tool_timeout.mli
+++ b/lib/mcp_server_eio_tool_timeout.mli
@@ -1,0 +1,14 @@
+(** Per-tool timeout policy for [Mcp_server_eio_call_tool]. *)
+
+type resolved_tool_timeout =
+  { timeout_sec : float
+  ; source_env : string option
+  }
+
+val tool_timeout :
+  tool_name:string -> _arguments:Yojson.Safe.t -> resolved_tool_timeout option
+(** Returns the resolved timeout policy for a tool call. *)
+
+val tool_timeout_sec_opt :
+  tool_name:string -> _arguments:Yojson.Safe.t -> float option
+(** Returns only the timeout seconds from {!tool_timeout}. *)


### PR DESCRIPTION
Summary:
- Extract MCP tools/call timeout policy into Mcp_server_eio_tool_timeout.
- Preserve Mcp_server_eio_call_tool.tool_timeout_sec_opt for existing tests and callers.
- Reduce lib/mcp_server_eio_call_tool.ml from 1075 to 991 lines.

Validation:
- ocamlformat --check lib/mcp_server_eio_call_tool.ml lib/mcp_server_eio_call_tool.mli lib/mcp_server_eio_tool_timeout.ml lib/mcp_server_eio_tool_timeout.mli
- git diff --check
- bash scripts/lint/godfile-size-regression.sh
- scripts/ocaml-structure-ratchet.sh --print
- scripts/dune-local.sh build lib/masc_mcp.cma
- scripts/dune-local.sh build test/test_mcp_server_eio_call_tool.exe (passed before final rebase)
- ./_build/default/test/test_mcp_server_eio_call_tool.exe (13 tests passed before final rebase)

Note:
- Final rebase onto the restored stack head was conflict-free; lib/masc_mcp.cma passed afterward. The final focused test retry was blocked by external Dune lock queue, so CI is the current final proof surface for that step.