### PR TITLE
fix(keeper): choose current task from active ownership

### DIFF
--- a/lib/keeper/keeper_current_task_reconcile.ml
+++ b/lib/keeper/keeper_current_task_reconcile.ml
@@ -35,7 +35,12 @@ let task_id_of_owned_active_task ~(keeper_name : string) (task : Masc_domain.tas
       keeper_name task.id msg;
     None
 
-let owned_active_task_ids_for_meta ~(config : Coord.config)
+type owned_active_task =
+  { task_id : Keeper_id.Task_id.t
+  ; task : Masc_domain.task
+  }
+
+let owned_active_tasks_for_meta ~(config : Coord.config)
     ~(meta : Keeper_types.keeper_meta) =
   let names = resolved_agent_names ~config ~agent_name:meta.agent_name in
   let matches assignee = List.mem assignee names in
@@ -47,16 +52,13 @@ let owned_active_task_ids_for_meta ~(config : Coord.config)
          | Masc_domain.InProgress { assignee; _ }
            when matches assignee ->
              task_id_of_owned_active_task ~keeper_name:meta.name task
+             |> Option.map (fun task_id -> { task_id; task })
          | Masc_domain.Claimed _
          | Masc_domain.InProgress _
          | Masc_domain.AwaitingVerification _
          | Masc_domain.Todo
          | Masc_domain.Done _
          | Masc_domain.Cancelled _ -> None)
-    |> List.sort_uniq (fun a b ->
-         String.compare
-           (Keeper_id.Task_id.to_string a)
-           (Keeper_id.Task_id.to_string b))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
@@ -69,16 +71,49 @@ let owned_active_task_ids_for_meta ~(config : Coord.config)
       meta.name (Printexc.to_string exn);
     []
 
+let active_status_rank = function
+  | Masc_domain.InProgress _ -> 0
+  | Masc_domain.Claimed _ -> 1
+  | Masc_domain.AwaitingVerification _
+  | Masc_domain.Todo
+  | Masc_domain.Done _
+  | Masc_domain.Cancelled _ -> 2
+
+let current_task_rank (meta : Keeper_types.keeper_meta) task_id =
+  match meta.current_task_id with
+  | Some current when Keeper_id.Task_id.equal current task_id -> 0
+  | Some _ | None -> 1
+
+let compare_owned_active_task ~(meta : Keeper_types.keeper_meta) a b =
+  let cmp = compare (current_task_rank meta a.task_id) (current_task_rank meta b.task_id) in
+  if cmp <> 0
+  then cmp
+  else (
+    let cmp = compare (active_status_rank a.task.task_status) (active_status_rank b.task.task_status) in
+    if cmp <> 0
+    then cmp
+    else (
+      let cmp = compare a.task.priority b.task.priority in
+      if cmp <> 0
+      then cmp
+      else (
+        let cmp = String.compare a.task.created_at b.task.created_at in
+        if cmp <> 0
+        then cmp
+        else
+          String.compare
+            (Keeper_id.Task_id.to_string a.task_id)
+            (Keeper_id.Task_id.to_string b.task_id))))
+
 let owned_active_task_id_for_meta ~(config : Coord.config)
     ~(meta : Keeper_types.keeper_meta) =
-  match owned_active_task_ids_for_meta ~config ~meta with
-  | [ task_id ] -> Some task_id
+  match owned_active_tasks_for_meta ~config ~meta with
+  | [ { task_id; _ } ] -> Some task_id
   | [] -> None
-  | task_ids ->
-    Log.Keeper.warn
-      "keeper:%s has %d active owned tasks; leaving current_task_id unset until one task is explicit"
-      meta.name (List.length task_ids);
-    None
+  | tasks ->
+    (match List.sort (compare_owned_active_task ~meta) tasks with
+     | selected :: _ -> Some selected.task_id
+     | [] -> None)
 
 let merge_current_task_id ~(latest : Keeper_types.keeper_meta)
     ~(caller : Keeper_types.keeper_meta) =

--- a/lib/keeper/keeper_current_task_reconcile.mli
+++ b/lib/keeper/keeper_current_task_reconcile.mli
@@ -1,9 +1,12 @@
 (** Reconcile keeper [current_task_id] with active backlog ownership. *)
 
-(** Find the single active task a keeper owns.
+(** Find the deterministic active task a keeper should treat as current.
 
     Only [Claimed] and [InProgress] tasks are active bindings. Tasks awaiting
-    verification have left the keeper's execution lane and clear the binding. *)
+    verification have left the keeper's execution lane and clear the binding.
+    If multiple active tasks remain, reconciliation keeps an existing active
+    [current_task_id], otherwise it chooses a stable task by status, priority,
+    creation time, and task id. *)
 val owned_active_task_id_for_meta :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -81,6 +81,23 @@ let set_task_created_at_by_title config ~title ~created_at =
   Coord.write_backlog config { backlog with tasks; version = backlog.version + 1 }
 ;;
 
+let set_task_status_by_title config ~title ~task_status =
+  let backlog = Coord.read_backlog config in
+  let seen = ref false in
+  let tasks =
+    List.map
+      (fun (task : Masc_domain.task) ->
+         if String.equal task.title title
+         then (
+           seen := true;
+           { task with task_status })
+         else task)
+      backlog.tasks
+  in
+  if not !seen then failwith (Printf.sprintf "task not found: %s" title);
+  Coord.write_backlog config { backlog with tasks; version = backlog.version + 1 }
+;;
+
 let transition_task_exn ?notes config ~agent_name ~task_id ~action () =
   match Coord.transition_task_r config ~agent_name ~task_id ~action ?notes () with
   | Ok _ -> ()
@@ -636,6 +653,108 @@ let test_run_context_uses_reconciled_current_task_id () =
         "run context exposes reconciled current_task_id"
         None
         (current_task_id_string ctx.Keeper_run_context.meta)))
+;;
+
+let test_multiple_active_tasks_selects_deterministic_current_task () =
+  with_room (fun config ->
+    let meta = make_test_meta ~name:"multi-task-keeper" () in
+    with_registered_keeper config meta (fun () ->
+      ignore
+        (Coord.add_task
+           config
+           ~title:"Older low priority"
+           ~priority:4
+           ~description:"older active work");
+      ignore
+        (Coord.add_task
+           config
+           ~title:"Newer high priority"
+           ~priority:1
+           ~description:"newer active work");
+      set_task_created_at_by_title
+        config
+        ~title:"Older low priority"
+        ~created_at:"2026-05-01T00:00:00Z";
+      set_task_created_at_by_title
+        config
+        ~title:"Newer high priority"
+        ~created_at:"2026-05-02T00:00:00Z";
+      set_task_status_by_title
+        config
+        ~title:"Older low priority"
+        ~task_status:
+          (Masc_domain.Claimed
+             { assignee = meta.agent_name; claimed_at = "2026-05-01T00:01:00Z" });
+      set_task_status_by_title
+        config
+        ~title:"Newer high priority"
+        ~task_status:
+          (Masc_domain.Claimed
+             { assignee = meta.agent_name; claimed_at = "2026-05-02T00:01:00Z" });
+      (match Keeper_types.write_meta config meta with
+       | Ok () -> ()
+       | Error msg -> fail msg);
+      let high_priority_task = task_by_title config "Newer high priority" in
+      let synced =
+        Keeper_agent_tool_surface.sync_current_task_id_from_backlog ~config meta
+      in
+      check
+        (option string)
+        "highest priority active task selected"
+        (Some high_priority_task.id)
+        (current_task_id_string synced)))
+;;
+
+let test_multiple_active_tasks_preserves_existing_current_task () =
+  with_room (fun config ->
+    let base_meta = make_test_meta ~name:"sticky-task-keeper" () in
+    with_registered_keeper config base_meta (fun () ->
+      ignore
+        (Coord.add_task
+           config
+           ~title:"Sticky current"
+           ~priority:5
+           ~description:"active current work");
+      ignore
+        (Coord.add_task
+           config
+           ~title:"Competing current"
+           ~priority:1
+           ~description:"active competing work");
+      let sticky = task_by_title config "Sticky current" in
+      let sticky_task_id =
+        match Keeper_id.Task_id.of_string sticky.id with
+        | Ok task_id -> task_id
+        | Error msg -> fail msg
+      in
+      set_task_status_by_title
+        config
+        ~title:"Sticky current"
+        ~task_status:
+          (Masc_domain.InProgress
+             { assignee = base_meta.agent_name
+             ; started_at = "2026-05-01T00:01:00Z"
+             });
+      set_task_status_by_title
+        config
+        ~title:"Competing current"
+        ~task_status:
+          (Masc_domain.Claimed
+             { assignee = base_meta.agent_name
+             ; claimed_at = "2026-05-02T00:01:00Z"
+             });
+      let meta = { base_meta with current_task_id = Some sticky_task_id } in
+      (match Keeper_types.write_meta config meta with
+       | Ok () -> ()
+       | Error msg -> fail msg);
+      let synced =
+        Keeper_agent_tool_surface.sync_current_task_id_from_backlog ~config meta
+      in
+      check
+        (option string)
+        "existing active current task preserved"
+        (Some sticky.id)
+        (current_task_id_string synced)))
 ;;
 
 let test_heartbeat_current_task_id_reconciles_terminal_backlog () =
@@ -2135,6 +2254,14 @@ let () =
             "run context uses reconciled current_task_id"
             `Quick
             test_run_context_uses_reconciled_current_task_id
+        ; test_case
+            "multiple active tasks select deterministic current_task_id"
+            `Quick
+            test_multiple_active_tasks_selects_deterministic_current_task
+        ; test_case
+            "multiple active tasks preserve existing current_task_id"
+            `Quick
+            test_multiple_active_tasks_preserves_existing_current_task
         ; test_case
             "heartbeat current_task_id reconciles terminal backlog"
             `Quick


### PR DESCRIPTION
## Summary
- choose a deterministic current_task_id when a keeper owns multiple active tasks
- preserve an existing active current_task_id before falling back to status, priority, created_at, and task id
- add regression coverage for multi-owned active task reconciliation

## HTML alignment
- Implements the P1 reducer slice: task_ownership_ambiguity_current_task_unset
- This targets the repeated "has N active owned tasks; leaving current_task_id unset" warning loop
- It does not claim the P2/P3/P4/P5/P6 rows are complete

## Verification
- ocamlformat --check lib/keeper/keeper_current_task_reconcile.ml lib/keeper/keeper_current_task_reconcile.mli test/test_keeper_task_dispatch.ml
- git diff --check origin/main..HEAD
- scripts/dune-local.sh build ./test/test_keeper_task_dispatch.exe
- ./_build/default/test/test_keeper_task_dispatch.exe (52 tests)
