### PR TITLE
fix(keeper): classify bash guard blocks as workflow rejections

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -532,6 +532,8 @@ let bash_shape_block_alternatives = function
       "keeper_bash cmd='git log --oneline -20'";
     ]
 
+let workflow_rejection_field = "failure_class", `String "workflow_rejection"
+
 let bash_shape_block_result ~cmd ~cmd_for_log ~env_snapshot block =
   Yojson.Safe.to_string
     (Exec_core.blocked_result_json
@@ -556,6 +558,7 @@ let bash_shape_block_result ~cmd ~cmd_for_log ~env_snapshot block =
             })
        ~extra:
          [
+           workflow_rejection_field;
            "cmd", `String cmd_for_log;
            "shape_block", `String (bash_shape_block_tag block);
            "execution_time_ms", `Int 0;
@@ -602,6 +605,7 @@ let handle_keeper_bash
       (`Assoc
          [ "ok", `Bool false
          ; "error", `String "gh_pr_create_requires_keeper_pr_create"
+         ; workflow_rejection_field
          ; "reason", `String
              "keeper_bash cannot bypass the PR creation approval and audit policy"
          ; "hint", `String
@@ -621,6 +625,7 @@ let handle_keeper_bash
       (`Assoc
          [ "ok", `Bool false
          ; "error", `String "tool_invoked_as_shell_command"
+         ; workflow_rejection_field
          ; "tool", `String tool_name
          ; "cmd", `String cmd_for_log
          ; "hint",

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -991,6 +991,10 @@ let test_bash_blocks_direct_masc_tool_command () =
     (Some "tool_invoked_as_shell_command")
     (Json.member "error" json |> Json.to_string_option);
   Alcotest.(check (option string))
+    "failure class"
+    (Some "workflow_rejection")
+    (Json.member "failure_class" json |> Json.to_string_option);
+  Alcotest.(check (option string))
     "suggested tool"
     (Some "keeper_tasks_list")
     (Json.member "suggested_tool" json |> Json.to_string_option);

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -539,6 +539,33 @@ let test_workflow_rejection_payload_skips_circuit_breaker () =
   check bool "runtime failure still trips circuit breaker" true
     (KET.should_apply_circuit_breaker_to_failure_payload runtime_payload)
 
+let test_keeper_bash_shape_rejection_skips_circuit_breaker () =
+  with_exec_fixture "keeper_bash_shape_rejection_no_cb"
+    (fun ~config ~meta ~ctx_work ->
+      let input =
+        `Assoc
+          [ ( "cmd"
+            , `String "cat .masc/state/backlog.json 2>/dev/null | head -5" )
+          ]
+      in
+      let run () =
+        KET.execute_keeper_tool_call
+          ~config ~meta ~ctx_work ~exec_cache:None
+          ~name:"keeper_bash" ~input ()
+      in
+      ignore (run ());
+      ignore (run ());
+      let raw = run () in
+      let json = Yojson.Safe.from_string raw in
+      check string "shape error" "keeper_bash_command_shape_blocked"
+        Yojson.Safe.Util.(member "error" json |> to_string);
+      check string "failure class" "workflow_rejection"
+        Yojson.Safe.Util.(member "failure_class" json |> to_string);
+      check bool "workflow rejection skips circuit breaker accounting" false
+        (KET.should_apply_circuit_breaker_to_failure_payload raw);
+      check bool "no circuit breaker enrichment after repeated shape blocks" true
+        Yojson.Safe.Util.(member "circuit_breaker" json = `Null))
+
 let registered_dispatch_probe_tool = "test_keeper_registered_dispatch_probe"
 
 let register_registered_dispatch_probe () =
@@ -781,6 +808,8 @@ let () =
         test_tool_result_or_error_preserves_failure_class;
       test_case "workflow rejection skips circuit breaker" `Quick
         test_workflow_rejection_payload_skips_circuit_breaker;
+      test_case "keeper_bash shape rejection skips circuit breaker" `Quick
+        test_keeper_bash_shape_rejection_skips_circuit_breaker;
       test_case "registered dispatch does not require masc_ prefix" `Quick
         test_registered_tool_dispatch_without_masc_prefix;
       test_case "registered dispatch preserves workflow failure class" `Quick


### PR DESCRIPTION
## Summary
- mark deterministic keeper_bash guard blocks as workflow_rejection payloads
- apply the same class to raw gh-pr-create and MASC-tool-as-shell rejections
- add regression coverage that repeated shape blocks do not trigger circuit breaker enrichment

## Verification
- scripts/dune-local.sh build test/test_keeper_exec_tools.exe test/test_keeper_bash_safety.exe
- ./_build/default/test/test_keeper_exec_tools.exe test execute_keeper_tool_call_with_outcome 12
- ./_build/default/test/test_keeper_bash_safety.exe

Note: full ./_build/default/test/test_keeper_exec_tools.exe still has unrelated existing registered-dispatch/schema failures after the new regression passes.