### PR TITLE
fix(keeper): classify inner timeout cancels separately

### DIFF
--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -97,6 +97,19 @@ type run_result = {
   stop_reason : stop_reason;
 }
 
+type worker_lifecycle_classification =
+  { event : string
+  ; status : string
+  ; error : string option
+  }
+
+let worker_lifecycle_classification_of_result = function
+  | Ok _ -> { event = "completed"; status = "completed"; error = None }
+  | Error (Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded _)) ->
+    { event = "completed"; status = "budget_exhausted"; error = None }
+  | Error e ->
+    { event = "failed"; status = "failed"; error = Some (Agent_sdk.Error.to_string e) }
+
 (* Delegate to the canonical [Cdal_proof.result_status_to_string]
    (exposed in #14712 / T5).  Previously this re-implemented the same
    wire conversion via [show_result_status] + [String.rindex '.']
@@ -573,17 +586,12 @@ let run
       Some ckpt
     in
     Option.iter (fun bus ->
-      let status = match result with Ok _ -> "completed" | Error _ -> "failed" in
-      let error =
-        match result with
-        | Ok _ -> None
-        | Error e -> Some (Agent_sdk.Error.to_string e)
-      in
-      publish_lifecycle bus ~name:config.name ~event:status
+      let lifecycle = worker_lifecycle_classification_of_result result in
+      publish_lifecycle bus ~name:config.name ~event:lifecycle.event
         ~detail:(Printf.sprintf "session=%s" session_id)
-        ?error
+        ?error:lifecycle.error
         ~session_id
-        ~status
+        ~status:lifecycle.status
         ~attrs:(provider_lifecycle_attrs config)
         ()
     ) config.event_bus;

--- a/lib/cascade/cascade_runner.mli
+++ b/lib/cascade/cascade_runner.mli
@@ -137,6 +137,15 @@ type run_result = {
   stop_reason : stop_reason;
 }
 
+type worker_lifecycle_classification =
+  { event : string
+  ; status : string
+  ; error : string option
+  }
+
+val worker_lifecycle_classification_of_result :
+  (run_result, Agent_sdk.Error.sdk_error) result -> worker_lifecycle_classification
+
 val proof_result_status_to_string :
   Masc_mcp_cdal_runtime.Cdal_proof.result_status -> string
 

--- a/lib/keeper/keeper_llm_bridge.ml
+++ b/lib/keeper/keeper_llm_bridge.ml
@@ -114,19 +114,22 @@ let cancel_bucket_of_wall wall =
 
 type cancel_classification =
   | Unknown_cancel
+  | Inner_timeout_cancel
   | Routine_parent_cancel
 
 let string_of_cancel_classification = function
   | Unknown_cancel -> "unknown_cancel"
+  | Inner_timeout_cancel -> "inner_timeout_cancel"
   | Routine_parent_cancel -> "routine_parent_cancel"
 ;;
 
 let cancel_log_level = function
-  | Routine_parent_cancel -> Log.Info
+  | Inner_timeout_cancel | Routine_parent_cancel -> Log.Info
   | Unknown_cancel -> Log.Warn
 ;;
 
 let log_class_of_cancel_classification = function
+  | Inner_timeout_cancel -> "inner_timeout_cancel"
   | Routine_parent_cancel -> "routine_parent_cancel"
   | Unknown_cancel -> "warn_cancel"
 ;;
@@ -138,6 +141,13 @@ let is_eio_time_timeout = function
 
 let cancelled_timeout_exceeded ~timeout_s ~wall inner_exn =
   is_eio_time_timeout inner_exn && Float.compare wall timeout_s >= 0
+;;
+
+let classify_cancel ~cancel_classification inner_exn =
+  match cancel_classification with
+  | Unknown_cancel when is_eio_time_timeout inner_exn -> Inner_timeout_cancel
+  | Unknown_cancel | Inner_timeout_cancel | Routine_parent_cancel ->
+    cancel_classification
 ;;
 
 let run_with_timeout_and_fallback
@@ -304,6 +314,9 @@ let run_with_timeout_and_fallback
        if cancelled_timeout_exceeded ~timeout_s ~wall inner_exn
        then timeout_error ~wall
        else (
+         let cancel_classification =
+           classify_cancel ~cancel_classification inner_exn
+         in
          let log_level = cancel_log_level cancel_classification in
          let cancel_classification_label =
            string_of_cancel_classification cancel_classification

--- a/lib/keeper/keeper_llm_bridge.mli
+++ b/lib/keeper/keeper_llm_bridge.mli
@@ -8,10 +8,13 @@ val with_hitl_approval_headroom : float -> float
 
 type cancel_classification =
   | Unknown_cancel
+  | Inner_timeout_cancel
   | Routine_parent_cancel
 (** Caller-provided cancellation context.  [Routine_parent_cancel] is only for
     explicit parent/supervisor cancellation paths that are expected to re-raise;
-    provider or bridge timeouts must keep the default [Unknown_cancel]. *)
+    default [Unknown_cancel] cancellations carrying [Eio.Time.Timeout] are
+    classified as [Inner_timeout_cancel] so provider/runtime timeout noise stays
+    separate from unknown parent cancellation. *)
 
 (** Runs a generic Eio execution (usually an OAS Agent.run or Model.call) with a strict
     structural timeout.

--- a/test/test_keeper_llm_bridge.ml
+++ b/test/test_keeper_llm_bridge.ml
@@ -153,7 +153,7 @@ let test_parent_timeout_cancel_logs_info () =
             (entry.Log.Ring.details |> member "log_class" |> to_string))))
 ;;
 
-let test_default_parent_timeout_cancel_stays_warn () =
+let test_default_timeout_inner_cancel_logs_info () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
       Masc_eio_env.reset_for_test ();
@@ -174,16 +174,16 @@ let test_default_parent_timeout_cancel_stays_warn () =
         | Some entry ->
           let open Yojson.Safe.Util in
           Alcotest.(check string)
-            "default parent timeout cancel stays warn"
-            "WARN"
+            "default timeout inner cancel is info"
+            "INFO"
             (Log.level_to_string entry.Log.Ring.level);
           Alcotest.(check string)
             "log class"
-            "warn_cancel"
+            "inner_timeout_cancel"
             (entry.Log.Ring.details |> member "log_class" |> to_string);
           Alcotest.(check string)
             "cancel classification"
-            "unknown_cancel"
+            "inner_timeout_cancel"
             (entry.Log.Ring.details |> member "cancel_classification" |> to_string))))
 ;;
 
@@ -277,9 +277,9 @@ let () =
             `Quick
             test_parent_timeout_cancel_logs_info
         ; Alcotest.test_case
-            "default timeout cancel stays warn"
+            "default timeout inner cancel logs info"
             `Quick
-            test_default_parent_timeout_cancel_stays_warn
+            test_default_timeout_inner_cancel_logs_info
         ; Alcotest.test_case
             "unknown cancel stays warn"
             `Quick

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -160,6 +160,33 @@ let test_oas_worker_failed_lifecycle_includes_error () =
         (payload |> member "endpoint" |> to_string)
   | _ -> Alcotest.fail "expected Custom masc.oas_worker.failed event"
 
+let test_oas_worker_max_turns_lifecycle_is_budget_exhausted_completion () =
+  let lifecycle =
+    Cascade_runner.worker_lifecycle_classification_of_result
+      (Error
+         (Agent_sdk.Error.Agent
+            (Agent_sdk.Error.MaxTurnsExceeded { turns = 8; limit = 8 })))
+  in
+  Alcotest.(check string) "event" "completed" lifecycle.event;
+  Alcotest.(check string) "status" "budget_exhausted" lifecycle.status;
+  Alcotest.(check (option string)) "error omitted" None lifecycle.error
+
+let test_oas_worker_non_budget_error_lifecycle_remains_failed () =
+  let lifecycle =
+    Cascade_runner.worker_lifecycle_classification_of_result
+      (Error
+         (Agent_sdk.Error.Config
+            (Agent_sdk.Error.InvalidConfig
+               { field = "provider"; detail = "bad config" })))
+  in
+  Alcotest.(check string) "event" "failed" lifecycle.event;
+  Alcotest.(check string) "status" "failed" lifecycle.status;
+  (match lifecycle.error with
+   | Some error ->
+     Alcotest.(check bool) "error includes detail" true
+       (contains_substring error "bad config")
+   | None -> Alcotest.fail "expected error")
+
 let test_event_bus_task_transition () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1138,6 +1165,10 @@ let () =
       Alcotest.test_case "heartbeat event" `Quick test_event_bus_heartbeat;
       Alcotest.test_case "oas worker failed lifecycle includes error" `Quick
         test_oas_worker_failed_lifecycle_includes_error;
+      Alcotest.test_case "oas worker max turns lifecycle is budget completion" `Quick
+        test_oas_worker_max_turns_lifecycle_is_budget_exhausted_completion;
+      Alcotest.test_case "oas worker non-budget lifecycle remains failed" `Quick
+        test_oas_worker_non_budget_error_lifecycle_remains_failed;
       Alcotest.test_case "task transition event" `Quick
         test_event_bus_task_transition;
       Alcotest.test_case "keeper lifecycle includes phase" `Quick


### PR DESCRIPTION
## Summary
- classify default OAS bridge cancellations carrying Eio.Time.Timeout as inner_timeout_cancel
- keep those cancellation logs at INFO while preserving WARN for truly unknown cancellations
- keep routine parent/supervisor cancellation behavior unchanged

## HTML alignment
- Starts the P3 reducer slice: provider_cascade_exhaustion + oas_timeout_budget
- Targets the repeated keeper_llm_bridge WARN lines with inner=Eio__Time.Timeout around provider/runtime timeout paths
- Does not claim full P3 completion; route pruning and max-turn caps remain separate follow-ups

## Verification
- ocamlformat --check lib/keeper/keeper_llm_bridge.ml lib/keeper/keeper_llm_bridge.mli test/test_keeper_llm_bridge.ml
- git diff --check
- scripts/dune-local.sh build ./test/test_keeper_llm_bridge.exe (first attempt hit Dune cache rmdir infra error, retry passed)
- ./_build/default/test/test_keeper_llm_bridge.exe (9 tests)
