### PR TITLE
refactor: extract MCP caller identity resolution

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -85,6 +85,7 @@
  server_mcp_transport_http_types
  server_mcp_transport_http_session
  server_mcp_transport_http_headers
+ server_mcp_request_context
  server_mcp_transport_http_sse
  server_mcp_transport_http_conn
  server_mcp_transport_http_respond

--- a/lib/dune
+++ b/lib/dune
@@ -86,6 +86,7 @@
  server_mcp_transport_http_session
  server_mcp_transport_http_headers
  server_mcp_request_context
+ server_mcp_actor_injection
  server_mcp_transport_http_sse
  server_mcp_transport_http_conn
  server_mcp_transport_http_respond

--- a/lib/mcp_server_eio_caller_identity.ml
+++ b/lib/mcp_server_eio_caller_identity.ml
@@ -1,0 +1,268 @@
+type owner_keeper_identity = string * string option
+
+type t = {
+  agent_name : string;
+  token : string option;
+  has_explicit_agent_name : bool;
+  verified_internal_keeper_runtime : bool;
+  internal_keeper_runtime_tool : bool;
+  owner_keeper_identity : owner_keeper_identity option;
+  mode_gate_error : string option;
+}
+
+let silent_auth_token_error_kind err =
+  Auth_error_kind.to_string (Auth_error_kind.classify err)
+
+let should_read_legacy_persisted_agent_name ~has_explicit_agent_name ~agent_name =
+  (not has_explicit_agent_name) && Agent_name_kind.is_ephemeral agent_name
+
+let caller_agent_name_from_arguments arguments =
+  let nonempty_nonunknown key =
+    match Safe_ops.json_string_opt key arguments with
+    | Some value ->
+        let value = String.trim value in
+        if value <> "" && value <> "unknown" then
+          Some value
+        else
+          None
+    | None -> None
+  in
+  match nonempty_nonunknown "_agent_name" with
+  | Some _ as value -> value
+  | None -> nonempty_nonunknown "agent_name"
+
+let direct_call_block_message name =
+  if Tool_catalog.is_on_surface Tool_catalog.Keeper_internal name then (
+    let replacement_hint =
+      match (Tool_catalog.metadata name).Tool_catalog.replacement with
+      | Some replacement -> Printf.sprintf " Try `%s` instead." replacement
+      | None -> ""
+    in
+    Printf.sprintf
+      "Tool '%s' is keeper-internal and not callable from external MCP clients.%s"
+      name replacement_hint)
+  else
+    Printf.sprintf
+      "Tool '%s' is hidden from the default tool surface and not callable directly."
+      name
+
+let resolve_owner_keeper_identity config owner_name =
+  let candidates =
+    [
+      Keeper_types.canonical_keeper_name owner_name;
+      Keeper_types.canonical_keeper_name_from_agent_name owner_name;
+    ]
+    |> List.filter_map (function
+         | Some value ->
+             let trimmed = String.trim value in
+             if trimmed <> "" then
+               Some trimmed
+             else
+               None
+         | None -> None)
+    |> List.sort_uniq String.compare
+  in
+  let rec loop = function
+    | [] -> None
+    | candidate :: rest -> (
+        match Keeper_types.read_meta_resolved config candidate with
+        | Ok (Some (resolved_name, meta)) ->
+            Some
+              (resolved_name, Option.map Keeper_id.Uid.to_string meta.Keeper_types.keeper_id)
+        | Ok None -> loop rest
+        | Error _ -> loop rest)
+  in
+  loop candidates
+
+let resolve_initial_agent_name ~identity ~cached_resolved_agent ~mcp_session_id
+    ~explicit_agent_name ~read_mcp_session_agent ~read_term_session_agent =
+  let identity_session_prefix =
+    let len = min 8 (String.length identity.Agent_identity.session_key) in
+    if len = 0 then
+      "anon"
+    else
+      String.sub identity.session_key 0 len
+  in
+  let generated_fallback_agent_name =
+    Printf.sprintf "agent-%s" identity_session_prefix
+  in
+  match explicit_agent_name with
+  | Some agent_name -> agent_name
+  | None -> (
+      match cached_resolved_agent with
+      | Some cached -> cached
+      | None ->
+          if identity.Agent_identity.agent_name <> "" then
+            identity.Agent_identity.agent_name
+          else (
+            match read_mcp_session_agent () with
+            | Some name -> name
+            | None ->
+                if Option.is_some mcp_session_id then
+                  generated_fallback_agent_name
+                else (
+                  match read_term_session_agent () with
+                  | Some name ->
+                      Log.Mcp.warn
+                        "[deprecated] agent name resolved via /tmp TERM file — migrate to \
+                         Agent_identity";
+                      name
+                  | None -> generated_fallback_agent_name)))
+
+let resolve_auth_fallback_agent_name
+    ~(config : Coord_utils_backend_setup.config)
+    ~token ~has_explicit_agent_name
+    agent_name =
+  match token with
+  | Some t
+    when (not has_explicit_agent_name) && Agent_name_kind.is_transient agent_name
+    -> (
+      match Auth.resolve_agent_from_token config.base_path ~token:t with
+      | Ok resolved -> resolved
+      | Error err ->
+          let error_kind = silent_auth_token_error_kind err in
+          Log.Auth.warn
+            "[silent:auth_token_resolve_error] agent=%s error_kind=%s - token resolve \
+             failed, keeping caller alias"
+            agent_name error_kind;
+          Prometheus.inc_counter
+            Prometheus.metric_silent_auth_token_resolve_error
+            ~labels:[ "error_kind", error_kind; "agent", agent_name ]
+            ();
+          let mode = Auth_strict_mode.current () in
+          let mode_label = Auth_strict_mode.to_label mode in
+          (match mode with
+          | Auth_strict_mode.Off -> ()
+          | Auth_strict_mode.Dry_run | Auth_strict_mode.Strict ->
+              Log.Auth.warn
+                "[would_reject:auth_token_resolve_error] mode=%s agent=%s error_kind=%s \
+                 - Phase B PR-2 will reject this request"
+                mode_label agent_name error_kind;
+              Prometheus.inc_counter
+                Prometheus.metric_auth_strict_would_reject
+                ~labels:
+                  [ "mode", mode_label; "error_kind", error_kind; "agent", agent_name ]
+                ());
+          agent_name)
+  | _ -> agent_name
+
+let resolve_explicit_joined_alias ~config ~room_initialized ~log_mcp_exn
+    ~has_explicit_agent_name agent_name =
+  if has_explicit_agent_name && not (Nickname.is_generated_nickname agent_name)
+  then (
+    let resolved = Coord.resolve_agent_name config agent_name in
+    if resolved <> agent_name then (
+      try
+        if room_initialized () then (
+          try
+            if Coord.is_agent_joined config ~agent_name:resolved then
+              resolved
+            else
+              agent_name
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+              log_mcp_exn ~label:"is_agent_joined" exn;
+              agent_name)
+        else
+          agent_name
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+          log_mcp_exn ~label:"resolve_explicit_joined_alias" exn;
+          agent_name)
+    else
+      agent_name)
+  else
+    agent_name
+
+let resolve ~(config : Coord_utils_backend_setup.config) ~tool_name ~arguments ~identity ~cached_resolved_agent
+    ~mcp_session_id ~auth_token ~internal_keeper_runtime ~room_initialized
+    ~read_mcp_session_agent ~read_term_session_agent ~log_mcp_exn =
+  let arg_get_string_opt key =
+    match Safe_ops.json_string_opt key arguments with
+    | Some "" -> None
+    | other -> other
+  in
+  let explicit_agent_name = caller_agent_name_from_arguments arguments in
+  let has_explicit_agent_name = Option.is_some explicit_agent_name in
+  let agent_name =
+    resolve_initial_agent_name ~identity ~cached_resolved_agent ~mcp_session_id
+      ~explicit_agent_name ~read_mcp_session_agent ~read_term_session_agent
+  in
+  let token =
+    match auth_token with
+    | Some _ as token -> token
+    | None -> arg_get_string_opt "token"
+  in
+  let verified_internal_keeper_runtime =
+    internal_keeper_runtime
+    &&
+    match token with
+    | Some raw -> Auth.verify_internal_keeper_token config.base_path ~token:raw
+    | None -> false
+  in
+  let internal_keeper_runtime_tool =
+    verified_internal_keeper_runtime
+    && Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool_name
+  in
+  let owner_keeper_identity =
+    match token with
+    | None -> None
+    | Some raw -> (
+        match Auth.resolve_agent_from_token config.base_path ~token:raw with
+        | Ok owner_name -> resolve_owner_keeper_identity config owner_name
+        | Error msg ->
+            Log.Auth.routine
+              "owner_keeper_identity: token resolve failed: %s"
+              (Masc_domain.masc_error_to_string msg);
+            None)
+  in
+  let mode_gate_error =
+    if
+      (not internal_keeper_runtime_tool)
+      && not (Tool_catalog.allow_direct_call tool_name)
+    then
+      Some (direct_call_block_message tool_name)
+    else
+      None
+  in
+  let persisted_agent_name () =
+    if should_read_legacy_persisted_agent_name ~has_explicit_agent_name ~agent_name
+    then
+      match read_mcp_session_agent () with
+      | Some n -> Some n
+      | None ->
+          if Option.is_some mcp_session_id then
+            None
+          else
+            read_term_session_agent ()
+    else
+      None
+  in
+  let agent_name =
+    match persisted_agent_name () with
+    | Some persisted
+      when Nickname.is_generated_nickname persisted
+           && (not has_explicit_agent_name)
+           && not (Nickname.is_generated_nickname agent_name) ->
+        persisted
+    | _ -> agent_name
+  in
+  let agent_name =
+    resolve_auth_fallback_agent_name ~config ~token ~has_explicit_agent_name
+      agent_name
+  in
+  let agent_name =
+    resolve_explicit_joined_alias ~config ~room_initialized ~log_mcp_exn
+      ~has_explicit_agent_name agent_name
+  in
+  {
+    agent_name;
+    token;
+    has_explicit_agent_name;
+    verified_internal_keeper_runtime;
+    internal_keeper_runtime_tool;
+    owner_keeper_identity;
+    mode_gate_error;
+  }

--- a/lib/mcp_server_eio_caller_identity.mli
+++ b/lib/mcp_server_eio_caller_identity.mli
@@ -1,0 +1,31 @@
+type owner_keeper_identity = string * string option
+
+type t = {
+  agent_name : string;
+  token : string option;
+  has_explicit_agent_name : bool;
+  verified_internal_keeper_runtime : bool;
+  internal_keeper_runtime_tool : bool;
+  owner_keeper_identity : owner_keeper_identity option;
+  mode_gate_error : string option;
+}
+
+val should_read_legacy_persisted_agent_name :
+  has_explicit_agent_name:bool -> agent_name:string -> bool
+
+val caller_agent_name_from_arguments : Yojson.Safe.t -> string option
+
+val resolve :
+  config:Coord_utils_backend_setup.config ->
+  tool_name:string ->
+  arguments:Yojson.Safe.t ->
+  identity:Agent_identity.t ->
+  cached_resolved_agent:string option ->
+  mcp_session_id:string option ->
+  auth_token:string option ->
+  internal_keeper_runtime:bool ->
+  room_initialized:(unit -> bool) ->
+  read_mcp_session_agent:(unit -> string option) ->
+  read_term_session_agent:(unit -> string option) ->
+  log_mcp_exn:(label:string -> exn -> unit) ->
+  t

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -83,43 +83,13 @@ let resolve_join_state ~room_initialized ~join_required ~agent_name ~base_path ~
 ;;
 
 
-let silent_auth_token_error_kind err =
-  Auth_error_kind.to_string (Auth_error_kind.classify err)
-;;
-
 let should_read_legacy_persisted_agent_name ~has_explicit_agent_name ~agent_name =
-  (not has_explicit_agent_name) && Agent_name_kind.is_ephemeral agent_name
+  Mcp_server_eio_caller_identity.should_read_legacy_persisted_agent_name
+    ~has_explicit_agent_name ~agent_name
 ;;
 
 let caller_agent_name_from_arguments arguments =
-  let nonempty_nonunknown key =
-    match Safe_ops.json_string_opt key arguments with
-    | Some value ->
-      let value = String.trim value in
-      if value <> "" && value <> "unknown" then Some value else None
-    | None -> None
-  in
-  match nonempty_nonunknown "_agent_name" with
-  | Some _ as value -> value
-  | None -> nonempty_nonunknown "agent_name"
-;;
-
-let direct_call_block_message name =
-  if Tool_catalog.is_on_surface Tool_catalog.Keeper_internal name
-  then (
-    let replacement_hint =
-      match (Tool_catalog.metadata name).Tool_catalog.replacement with
-      | Some replacement -> Printf.sprintf " Try `%s` instead." replacement
-      | None -> ""
-    in
-    Printf.sprintf
-      "Tool '%s' is keeper-internal and not callable from external MCP clients.%s"
-      name
-      replacement_hint)
-  else
-    Printf.sprintf
-      "Tool '%s' is hidden from the default tool surface and not callable directly."
-      name
+  Mcp_server_eio_caller_identity.caller_agent_name_from_arguments arguments
 ;;
 
 let cleanup_internal_keeper_runtime_resource ~during_exception ~label cleanup =
@@ -216,114 +186,6 @@ let execute_tool_eio
        | Eio.Io _ as exn ->
          Log.Misc.warn "write_mcp_session_agent: %s" (Printexc.to_string exn))
   in
-  (* Helper to get values from JSON arguments - delegates to Safe_ops *)
-  let arg_get_string_opt key =
-    match Safe_ops.json_string_opt key arguments with
-    | Some "" -> None
-    | other -> other
-  in
-  (* Resolve caller identity.  HTTP auth injects [_agent_name] from the
-     bearer-token owner; legacy [agent_name] is still accepted for direct
-     callers and for older MCP clients that have not moved to the internal
-     marker yet. *)
-  let explicit_agent_name = caller_agent_name_from_arguments arguments in
-  let has_explicit_agent_name = Option.is_some explicit_agent_name in
-  let identity_session_prefix =
-    let len = min 8 (String.length identity.session_key) in
-    if len = 0 then "anon" else String.sub identity.session_key 0 len
-  in
-  let generated_fallback_agent_name = Printf.sprintf "agent-%s" identity_session_prefix in
-  let agent_name =
-    (* Fix 4: Use cached resolved name to skip legacy /tmp file reads *)
-    match explicit_agent_name with
-    | Some agent_name -> agent_name
-    | None ->
-      (match cached_resolved_agent with
-       | Some cached -> cached
-       | None ->
-         if identity.Agent_identity.agent_name <> ""
-         then identity.Agent_identity.agent_name
-         else (
-           match read_mcp_session_agent () with
-           | Some name -> name
-           | None ->
-             if Option.is_some mcp_session_id
-             then generated_fallback_agent_name
-             else (
-               let term_session_id =
-                 Option.value ~default:"" (Sys.getenv_opt "TERM_SESSION_ID")
-               in
-               let term_file = Filename.concat agent_runtime_root (Printf.sprintf ".masc_agent_%s" term_session_id) in
-               match
-                 Safe_ops.protect ~default:None (fun () ->
-                   let name = Fs_compat.load_file term_file |> String.trim in
-                   if name <> "" then Some name else None)
-               with
-               | Some name ->
-                 Log.Mcp.warn
-                   "[deprecated] agent name resolved via /tmp TERM file — migrate to \
-                    Agent_identity";
-                 name
-               | None -> generated_fallback_agent_name)))
-  in
-  let token =
-    match auth_token with
-    | Some _ as token -> token
-    | None -> arg_get_string_opt "token"
-  in
-  let verified_internal_keeper_runtime =
-    internal_keeper_runtime
-    &&
-    match token with
-    | Some raw -> Auth.verify_internal_keeper_token config.base_path ~token:raw
-    | None -> false
-  in
-  let internal_keeper_runtime_tool =
-    verified_internal_keeper_runtime
-    && Tool_catalog.is_on_surface Tool_catalog.Keeper_internal name
-  in
-  let resolve_owner_keeper_identity owner_name =
-    let candidates =
-      [ Keeper_types.canonical_keeper_name owner_name
-      ; Keeper_types.canonical_keeper_name_from_agent_name owner_name
-      ]
-      |> List.filter_map (function
-        | Some value ->
-          let trimmed = String.trim value in
-          if trimmed <> "" then Some trimmed else None
-        | None -> None)
-      |> List.sort_uniq String.compare
-    in
-    let rec loop = function
-      | [] -> None
-      | candidate :: rest ->
-        (match Keeper_types.read_meta_resolved config candidate with
-         | Ok (Some (resolved_name, meta)) ->
-           Some
-             ( resolved_name
-             , Option.map Keeper_id.Uid.to_string meta.Keeper_types.keeper_id )
-         | Ok None -> loop rest
-         | Error _ -> loop rest)
-    in
-    loop candidates
-  in
-  let owner_keeper_identity =
-    match token with
-    | None -> None
-    | Some raw ->
-      (match Auth.resolve_agent_from_token config.base_path ~token:raw with
-       | Ok owner_name -> resolve_owner_keeper_identity owner_name
-       | Error msg ->
-         Log.Auth.routine
-           "owner_keeper_identity: token resolve failed: %s"
-           (Masc_domain.masc_error_to_string msg);
-         None)
-  in
-  let mode_gate_error =
-    if (not internal_keeper_runtime_tool) && not (Tool_catalog.allow_direct_call name)
-    then Some (direct_call_block_message name)
-    else None
-  in
   let read_term_session_agent () =
     if Option.is_some mcp_session_id
     then None
@@ -338,101 +200,20 @@ let execute_tool_eio
          with
          | Sys_error _ -> None))
   in
-  let persisted_agent_name () =
-    if should_read_legacy_persisted_agent_name ~has_explicit_agent_name ~agent_name
-    then (
-      match read_mcp_session_agent () with
-      | Some n -> Some n
-      | None -> if Option.is_some mcp_session_id then None else read_term_session_agent ())
-    else None
+  let caller_identity =
+    Mcp_server_eio_caller_identity.resolve ~config ~tool_name:name ~arguments
+      ~identity ~cached_resolved_agent ~mcp_session_id ~auth_token
+      ~internal_keeper_runtime
+      ~room_initialized:(fun () -> !room_init_cached)
+      ~read_mcp_session_agent ~read_term_session_agent ~log_mcp_exn
   in
-  let agent_name =
-    match persisted_agent_name () with
-    | Some persisted
-      when Nickname.is_generated_nickname persisted
-           && (not has_explicit_agent_name)
-           && not (Nickname.is_generated_nickname agent_name) -> persisted
-    | _ -> agent_name
+  let agent_name = caller_identity.agent_name in
+  let token = caller_identity.token in
+  let internal_keeper_runtime_tool =
+    caller_identity.internal_keeper_runtime_tool
   in
-  let agent_name =
-    match token with
-    (* Explicit agent_name is the caller's SSOT for this request.
-       Rewriting an explicit generated alias to the bearer-token owner
-       makes mutation paths operate under a different identity than the
-       one shown in join/status/debug output, which is exactly the
-       #8892 joined/debug/credential-route drift. Keep the explicit
-       alias and let auth preflight reject it if the token does not
-       authorize that identity. We only fall back to token ownership
-       when the request did not explicitly name an agent. *)
-    | Some t when (not has_explicit_agent_name) && Agent_name_kind.is_transient agent_name ->
-      (match Auth.resolve_agent_from_token config.base_path ~token:t with
-       | Ok resolved -> resolved
-       | Error err ->
-         (* PR-I: surface the silent fallback. The pre-#9786 branch silently
-                kept the caller-supplied alias when the bearer token did not
-                resolve to any credential, masking identity drift in production.
-                Emit a warn + counter so operators can grep [silent:auth_token]. *)
-         let error_kind = silent_auth_token_error_kind err in
-         Log.Auth.warn
-           "[silent:auth_token_resolve_error] agent=%s error_kind=%s - token resolve \
-            failed, keeping caller alias"
-           agent_name
-           error_kind;
-         Prometheus.inc_counter
-           Prometheus.metric_silent_auth_token_resolve_error
-           ~labels:[ "error_kind", error_kind; "agent", agent_name ]
-           ();
-         (* Phase A F2 (2026-04-27): pair the silent counter with a
-                [would_reject] emission so operators can measure how many of
-                these fall-throughs would be rejected under MASC_AUTH_STRICT.
-                Behavior is unchanged: this PR only adds telemetry + a flag
-                surface so Phase B PR-2 can flip [Strict] safely. *)
-         let mode = Auth_strict_mode.current () in
-         let mode_label = Auth_strict_mode.to_label mode in
-         (match mode with
-          | Auth_strict_mode.Off -> ()
-          | Auth_strict_mode.Dry_run | Auth_strict_mode.Strict ->
-            Log.Auth.warn
-              "[would_reject:auth_token_resolve_error] mode=%s agent=%s error_kind=%s - \
-               Phase B PR-2 will reject this request"
-              mode_label
-              agent_name
-              error_kind;
-            Prometheus.inc_counter
-              Prometheus.metric_auth_strict_would_reject
-              ~labels:
-                [ "mode", mode_label; "error_kind", error_kind; "agent", agent_name ]
-              ());
-         agent_name)
-    | _ -> agent_name
-  in
-  let agent_name =
-    if has_explicit_agent_name && not (Nickname.is_generated_nickname agent_name)
-    then (
-      let resolved = Coord.resolve_agent_name config agent_name in
-      if resolved <> agent_name
-      then (
-        try
-          if !room_init_cached
-          then (
-            try
-              if Coord.is_agent_joined config ~agent_name:resolved
-              then resolved
-              else agent_name
-            with
-            | Eio.Cancel.Cancelled _ as e -> raise e
-            | exn ->
-              log_mcp_exn ~label:"is_agent_joined" exn;
-              agent_name)
-          else agent_name
-        with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | exn ->
-          log_mcp_exn ~label:__FUNCTION__ exn;
-          agent_name)
-      else agent_name)
-    else agent_name
-  in
+  let owner_keeper_identity = caller_identity.owner_keeper_identity in
+  let mode_gate_error = caller_identity.mode_gate_error in
   (* Cache resolved agent_name for this session (Fix 4) *)
   (match mcp_session_id with
    | Some sid -> Agent_registry_eio.set_resolved_name sid agent_name

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -448,6 +448,25 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                      @ mcp_headers session_id
                                          protocol_version)
                              | Ok () ->
+                             let is_known =
+                               session_was_provided
+                               && Server_mcp_transport_http.is_known_session
+                                    session_id
+                             in
+                             (match
+                                Server_mcp_transport_http.validate_session_known
+                                  ~session_was_provided ~is_known body_str
+                              with
+                              | Error msg ->
+                                  let new_session_id = Mcp_session.generate () in
+                                  let body = json_rpc_error (-32600) msg in
+                                  h2_respond_json h2_reqd body
+                                    ~status:`Not_found
+                                    ~extra_headers:
+                                      (cors
+                                      @ mcp_headers new_session_id
+                                          protocol_version)
+                              | Ok () ->
                              let accept_mode =
                                Server_mcp_transport_http_headers
                                .classify_mcp_accept_for_body httpun_request body_str
@@ -504,7 +523,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                          ~extra_headers:mcp_hdrs
                                    | json ->
                                        let body = Yojson.Safe.to_string json in
-                                       h2_respond_json h2_reqd body ~extra_headers:mcp_hdrs)))))
+                                       h2_respond_json h2_reqd body ~extra_headers:mcp_hdrs))))))
 
       | `DELETE, "/mcp/operator" ->
           h2_respond_removed_surface h2_reqd ~surface:"operator_remote" ~extra_headers:cors

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -390,13 +390,10 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           h2_respond_removed_surface h2_reqd ~surface:"operator_remote" ~extra_headers:cors
 
       | `POST, "/mcp" | `POST, "/" | `POST, "/mcp/managed" ->
-          let session_was_provided = Option.is_some session_id_opt in
           let session_id = match session_id_opt with
             | Some id -> id
             | None -> Mcp_session.generate ()
           in
-          let auth_token = auth_token_from_request httpun_request in
-          let protocol_version = get_protocol_version_for_session ~session_id httpun_request in
           let profile =
             if String.equal path "/mcp/managed"
             then Server_mcp_transport_http.Managed_agent
@@ -407,6 +404,17 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             | Some s -> s.Mcp_server.room_config.base_path
             | None -> default_base_path ()
           in
+          let context =
+            Server_mcp_request_context.make ~session_id_opt
+              ~generated_session_id:session_id
+              ~auth_token:(auth_token_from_request httpun_request)
+              ~protocol_version:
+                (get_protocol_version_for_session ~session_id httpun_request)
+              ~origin ~base_path
+          in
+          let session_id = context.session_id in
+          let auth_token = context.auth_token in
+          let protocol_version = context.protocol_version in
           let auth_result =
             match profile with
             | Server_mcp_transport_http.Full
@@ -435,11 +443,16 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                      | Ok _cred_opt ->
                          h2_read_body h2_reqd (fun body_str ->
                              match
-                               Server_mcp_transport_http
-                               .validate_session_requirement
-                                 ~session_was_provided body_str
+                               Server_mcp_request_context.decide_post_body
+                                 ~request:httpun_request ~context
+                                 ~session_is_known:
+                                   (Server_mcp_transport_http.is_known_session
+                                      session_id)
+                                 body_str
                              with
-                             | Error msg ->
+                             | Error
+                                 (Server_mcp_request_context.Session_required msg)
+                               ->
                                  let body = json_rpc_error (-32600) msg in
                                  h2_respond_json h2_reqd body
                                    ~status:`Bad_request
@@ -447,17 +460,9 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                      (cors
                                      @ mcp_headers session_id
                                          protocol_version)
-                             | Ok () ->
-                             let is_known =
-                               session_was_provided
-                               && Server_mcp_transport_http.is_known_session
-                                    session_id
-                             in
-                             (match
-                                Server_mcp_transport_http.validate_session_known
-                                  ~session_was_provided ~is_known body_str
-                              with
-                              | Error msg ->
+                             | Error
+                                 (Server_mcp_request_context.Unknown_session msg)
+                               ->
                                   let new_session_id = Mcp_session.generate () in
                                   let body = json_rpc_error (-32600) msg in
                                   h2_respond_json h2_reqd body
@@ -466,23 +471,15 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                       (cors
                                       @ mcp_headers new_session_id
                                           protocol_version)
-                              | Ok () ->
-                             let accept_mode =
-                               Server_mcp_transport_http_headers
-                               .classify_mcp_accept_for_body httpun_request body_str
-                             in
-                             match accept_mode with
-                             | Http_negotiation.Rejected ->
-                                 let body =
-                                   json_rpc_error (-32600)
-                                     "Invalid Accept header: must include application/json and text/event-stream. \
-                                      Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility."
-                                 in
+                             | Error
+                                 (Server_mcp_request_context.Invalid_accept msg)
+                               ->
+                                 let body = json_rpc_error (-32600) msg in
                                  h2_respond_json h2_reqd body ~status:`Bad_request
                                    ~extra_headers:(cors @ mcp_headers session_id protocol_version)
-                             | accept_mode ->
+                             | Ok post_context ->
                                  let accept_warn_headers =
-                                   legacy_accept_warning_headers accept_mode
+                                   post_context.accept_warn_headers
                                  in
                                  with_server_state h2_reqd (fun state ->
                                    let profile =
@@ -490,7 +487,8 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                    in
                                    let body_with_agent =
                                      Server_mcp_transport_http.body_with_canonical_http_actor
-                                       ~base_path ~auth_token httpun_request body_str
+                                       ~base_path ~auth_token httpun_request
+                                       post_context.body_str
                                    in
                                    let internal_keeper_runtime =
                                      Server_auth.is_verified_internal_keeper_request
@@ -502,7 +500,10 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                        ~internal_keeper_runtime state
                                        body_with_agent
                                    in
-                                   (match protocol_version_from_body body_str with
+                                   (match
+                                      protocol_version_from_body
+                                        post_context.body_str
+                                    with
                                    | Some v -> remember_protocol_version session_id v
                                    | None -> ());
                                    let protocol_version =
@@ -523,7 +524,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                          ~extra_headers:mcp_hdrs
                                    | json ->
                                        let body = Yojson.Safe.to_string json in
-                                       h2_respond_json h2_reqd body ~extra_headers:mcp_hdrs))))))
+                                       h2_respond_json h2_reqd body ~extra_headers:mcp_hdrs)))))
 
       | `DELETE, "/mcp/operator" ->
           h2_respond_removed_surface h2_reqd ~surface:"operator_remote" ~extra_headers:cors

--- a/lib/server/server_mcp_actor_injection.ml
+++ b/lib/server/server_mcp_actor_injection.ml
@@ -1,0 +1,108 @@
+(** Inject or replace [_agent_name] in MCP [tools/call] arguments.
+    For authenticated dashboard sessions, the HTTP-layer token owner is the
+    canonical caller identity, so a stale browser-supplied [_agent_name]
+    must be overwritten. The legacy argument-scoped [token] is also removed
+    when HTTP auth is present so stale MCP bodies cannot override the
+    transport token. Legacy [agent_name] is left untouched because some tools
+    use it as a domain argument rather than caller identity. *)
+let inject_agent_name_into_body ?(rewrite_existing = false) ?(strip_token = false)
+    ~agent_name body_str =
+  try
+    let json = Yojson.Safe.from_string body_str in
+    let open Yojson.Safe.Util in
+    let method_name = member "method" json |> to_string_option in
+    match method_name with
+    | Some "tools/call" ->
+        let params = member "params" json in
+        let args = member "arguments" params in
+        let existing_agent =
+          Option.bind
+            (member "_agent_name" args |> to_string_option)
+            (fun value ->
+              let trimmed = String.trim value in
+              if String.equal trimmed "" then
+                None
+              else
+                Some trimmed)
+        in
+        let existing_legacy_agent =
+          Option.bind
+            (member "agent_name" args |> to_string_option)
+            (fun value ->
+              let trimmed = String.trim value in
+              if String.equal trimmed "" then
+                None
+              else
+                Some trimmed)
+        in
+        let new_args =
+          match args with
+          | `Assoc fields ->
+              let normalized_fields =
+                let fields =
+                  if rewrite_existing then
+                    List.filter
+                      (fun (key, _) -> not (String.equal key "_agent_name"))
+                      fields
+                  else
+                    fields
+                in
+                if strip_token then
+                  List.filter (fun (key, _) -> not (String.equal key "token")) fields
+                else
+                  fields
+              in
+              let should_inject =
+                rewrite_existing
+                || (Option.is_none existing_agent
+                   && Option.is_none existing_legacy_agent)
+              in
+              if should_inject then
+                `Assoc (("_agent_name", `String agent_name) :: normalized_fields)
+              else
+                args
+          | _ -> args
+        in
+        if new_args = args then
+          body_str
+        else
+          let new_params =
+            match params with
+            | `Assoc fields ->
+                `Assoc
+                  (List.map
+                     (fun (k, v) ->
+                       if k = "arguments" then
+                         (k, new_args)
+                       else
+                         (k, v))
+                     fields)
+            | _ -> params
+          in
+          let new_json =
+            match json with
+            | `Assoc fields ->
+                `Assoc
+                  (List.map
+                     (fun (k, v) ->
+                       if k = "params" then
+                         (k, new_params)
+                       else
+                         (k, v))
+                     fields)
+            | _ -> json
+          in
+          Yojson.Safe.to_string new_json
+    | _ -> body_str
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> body_str
+
+let reduce ~actor ~auth_token body_str =
+  match actor with
+  | None -> body_str
+  | Some agent ->
+      inject_agent_name_into_body
+        ~rewrite_existing:(Option.is_some auth_token)
+        ~strip_token:(Option.is_some auth_token)
+        ~agent_name:agent body_str

--- a/lib/server/server_mcp_actor_injection.mli
+++ b/lib/server/server_mcp_actor_injection.mli
@@ -1,0 +1,8 @@
+val inject_agent_name_into_body :
+  ?rewrite_existing:bool ->
+  ?strip_token:bool ->
+  agent_name:string ->
+  string ->
+  string
+
+val reduce : actor:string option -> auth_token:string option -> string -> string

--- a/lib/server/server_mcp_request_context.ml
+++ b/lib/server/server_mcp_request_context.ml
@@ -10,6 +10,8 @@ type t = {
 let make ~session_id_opt ~generated_session_id ~auth_token ~protocol_version
     ~origin ~base_path =
   let session_was_provided = Option.is_some session_id_opt in
+  (* NDT-OK: HTTP ingress supplies [generated_session_id] only when the client
+     omitted Mcp-Session-Id; persisted state still records the resolved value. *)
   let session_id = Option.value ~default:generated_session_id session_id_opt in
   { session_id; session_was_provided; auth_token; protocol_version; origin; base_path }
 

--- a/lib/server/server_mcp_request_context.ml
+++ b/lib/server/server_mcp_request_context.ml
@@ -1,0 +1,56 @@
+type t = {
+  session_id : string;
+  session_was_provided : bool;
+  auth_token : string option;
+  protocol_version : string;
+  origin : string;
+  base_path : string;
+}
+
+let make ~session_id_opt ~generated_session_id ~auth_token ~protocol_version
+    ~origin ~base_path =
+  let session_was_provided = Option.is_some session_id_opt in
+  let session_id = Option.value ~default:generated_session_id session_id_opt in
+  { session_id; session_was_provided; auth_token; protocol_version; origin; base_path }
+
+type post_body_decision = {
+  body_str : string;
+  accept_mode : Mcp_transport_protocol.Http_negotiation.accept_mode;
+  accept_warn_headers : (string * string) list;
+}
+
+type post_body_rejection =
+  | Session_required of string
+  | Unknown_session of string
+  | Invalid_accept of string
+
+let invalid_accept_message =
+  "Invalid Accept header: must include application/json and text/event-stream. \
+   Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility."
+
+let decide_post_body ~request ~context ~session_is_known body_str =
+  match
+    Server_mcp_transport_http_protocol.validate_session_requirement
+      ~session_was_provided:context.session_was_provided body_str
+  with
+  | Error msg -> Error (Session_required msg)
+  | Ok () -> (
+      let is_known = context.session_was_provided && session_is_known in
+      match
+        Server_mcp_transport_http_protocol.validate_session_known
+          ~session_was_provided:context.session_was_provided ~is_known body_str
+      with
+      | Error msg -> Error (Unknown_session msg)
+      | Ok () -> (
+          match
+            Server_mcp_transport_http_headers.classify_mcp_accept_for_body request
+              body_str
+          with
+          | Mcp_transport_protocol.Http_negotiation.Rejected ->
+              Error (Invalid_accept invalid_accept_message)
+          | accept_mode ->
+              let accept_warn_headers =
+                Server_mcp_transport_http_headers.legacy_accept_warning_headers
+                  accept_mode
+              in
+              Ok { body_str; accept_mode; accept_warn_headers }))

--- a/lib/server/server_mcp_request_context.mli
+++ b/lib/server/server_mcp_request_context.mli
@@ -1,0 +1,37 @@
+type t = {
+  session_id : string;
+  session_was_provided : bool;
+  auth_token : string option;
+  protocol_version : string;
+  origin : string;
+  base_path : string;
+}
+
+val make :
+  session_id_opt:string option ->
+  generated_session_id:string ->
+  auth_token:string option ->
+  protocol_version:string ->
+  origin:string ->
+  base_path:string ->
+  t
+
+type post_body_decision = {
+  body_str : string;
+  accept_mode : Mcp_transport_protocol.Http_negotiation.accept_mode;
+  accept_warn_headers : (string * string) list;
+}
+
+type post_body_rejection =
+  | Session_required of string
+  | Unknown_session of string
+  | Invalid_accept of string
+
+val invalid_accept_message : string
+
+val decide_post_body :
+  request:Httpun.Request.t ->
+  context:t ->
+  session_is_known:bool ->
+  string ->
+  (post_body_decision, post_body_rejection) result

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -283,16 +283,23 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
     respond_not_ready ~deps request reqd
   else
   let session_id_opt = get_session_id_any request in
-  let session_was_provided = Option.is_some session_id_opt in
   let session_id =
     match session_id_opt with
     | Some sid -> sid
     | None -> Mcp_session.generate ()
   in
-  let auth_token = deps.auth_token_from_request request in
-  let protocol_version = get_protocol_version_for_session ~session_id request in
-  let origin = deps.get_origin request in
-  let base_path = deps.get_base_path () in
+  let context =
+    Server_mcp_request_context.make ~session_id_opt
+      ~generated_session_id:session_id
+      ~auth_token:(deps.auth_token_from_request request)
+      ~protocol_version:(get_protocol_version_for_session ~session_id request)
+      ~origin:(deps.get_origin request) ~base_path:(deps.get_base_path ())
+  in
+  let session_id = context.session_id in
+  let auth_token = context.auth_token in
+  let protocol_version = context.protocol_version in
+  let origin = context.origin in
+  let base_path = context.base_path in
   let auth_result =
     match profile with
     | Full | Managed_agent ->
@@ -349,12 +356,14 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
     in
     Ok (Http.Request.read_body_async reqd (fun body_str ->
       ignore (
-        let* () =
+      let* post_context =
         match
-          validate_session_requirement ~session_was_provided body_str
+          Server_mcp_request_context.decide_post_body ~request ~context
+            ~session_is_known:(is_known_session session_id)
+            body_str
         with
-        | Ok () -> Ok ()
-        | Error msg ->
+        | Ok decision -> Ok decision
+        | Error (Server_mcp_request_context.Session_required msg) ->
             let body =
               Printf.sprintf
                 {|{"jsonrpc":"2.0","error":{"code":-32600,"message":%s},"id":null}|}
@@ -370,25 +379,7 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
               (Httpun.Response.create ~headers `Bad_request)
               body;
             Error ()
-      in
-      let* () =
-        (* RFC-0100 PR-3 — Q3 default. If the client echoed an
-           [Mcp-Session-Id] the server has no protocol-version state
-           for, respond [404 Not Found] with a freshly minted
-           [Mcp-Session-Id] header so the client re-handshakes via
-           [initialize] instead of silently riding on a phantom
-           session. The handshake methods are exempt: [initialize]
-           legitimately mints the state we are about to check for,
-           and [ping] / [notifications/initialized] are allowed
-           without a known session per the existing contract. *)
-        let is_known =
-          session_was_provided && is_known_session session_id
-        in
-        match
-          validate_session_known ~session_was_provided ~is_known body_str
-        with
-        | Ok () -> Ok ()
-        | Error msg ->
+        | Error (Server_mcp_request_context.Unknown_session msg) ->
             let new_session_id = Mcp_session.generate () in
             let body =
               Printf.sprintf
@@ -405,14 +396,7 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
               (Httpun.Response.create ~headers `Not_found)
               body;
             Error ()
-      in
-      let accept_mode =
-        Server_mcp_transport_http_headers.classify_mcp_accept_for_body
-          request body_str
-      in
-      let* accept_mode =
-        match accept_mode with
-        | Http_negotiation.Rejected ->
+        | Error (Server_mcp_request_context.Invalid_accept msg) ->
             let body =
               Yojson.Safe.to_string
                 (`Assoc
@@ -422,9 +406,7 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
                       `Assoc
                         [
                           ("code", `Int (-32600));
-                          ( "message",
-                            `String
-                              "Invalid Accept header: must include application/json and text/event-stream. Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility." );
+                          ("message", `String msg);
                         ] );
                   ])
             in
@@ -436,11 +418,9 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
             let response = Httpun.Response.create ~headers `Bad_request in
             safe_respond_with_string reqd response body;
             Error ()
-        | _ -> Ok accept_mode
       in
-      let accept_warn_headers =
-        legacy_accept_warning_headers accept_mode
-      in
+      let accept_mode = post_context.accept_mode in
+      let accept_warn_headers = post_context.accept_warn_headers in
       let* runtime =
         match request_runtime_result deps with
         | Ok r -> Ok r

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -191,91 +191,14 @@ let should_stream_post_tools_call request body_str accept_mode =
       | None -> false)
   | _ -> false
 
-(** Inject or replace [_agent_name] in MCP [tools/call] arguments.
-    For authenticated dashboard sessions, the HTTP-layer token owner is the
-    canonical caller identity, so a stale browser-supplied [_agent_name]
-    must be overwritten. The legacy argument-scoped [token] is also removed
-    when HTTP auth is present so stale MCP bodies cannot override the
-    transport token. Legacy [agent_name] is left untouched because some tools
-    use it as a domain argument rather than caller identity. *)
 let inject_agent_name_into_body ?(rewrite_existing = false) ?(strip_token = false)
     ~agent_name body_str =
-  try
-    let json = Yojson.Safe.from_string body_str in
-    let open Yojson.Safe.Util in
-    let method_name = member "method" json |> to_string_option in
-    match method_name with
-    | Some "tools/call" ->
-        let params = member "params" json in
-        let args = member "arguments" params in
-        let existing_agent =
-          Option.bind
-            (member "_agent_name" args |> to_string_option)
-            (fun value ->
-               let trimmed = String.trim value in
-               if String.equal trimmed "" then None else Some trimmed)
-        in
-        let existing_legacy_agent =
-          Option.bind
-            (member "agent_name" args |> to_string_option)
-            (fun value ->
-               let trimmed = String.trim value in
-               if String.equal trimmed "" then None else Some trimmed)
-        in
-        let new_args =
-          match args with
-          | `Assoc fields ->
-              let normalized_fields =
-                let fields =
-                  if rewrite_existing then
-                    List.filter
-                      (fun (key, _) -> not (String.equal key "_agent_name"))
-                      fields
-                  else
-                    fields
-                in
-                if strip_token then
-                  List.filter (fun (key, _) -> not (String.equal key "token"))
-                    fields
-                else
-                  fields
-              in
-              let should_inject =
-                rewrite_existing
-                || (Option.is_none existing_agent
-                    && Option.is_none existing_legacy_agent)
-              in
-              if should_inject then
-                `Assoc (("_agent_name", `String agent_name) :: normalized_fields)
-              else
-                args
-          | _ -> args
-        in
-        if new_args = args then body_str else
-          let new_params = match params with
-            | `Assoc fields ->
-                `Assoc (List.map (fun (k, v) ->
-                  if k = "arguments" then (k, new_args) else (k, v)) fields)
-            | _ -> params
-          in
-          let new_json = match json with
-            | `Assoc fields ->
-                `Assoc (List.map (fun (k, v) ->
-                  if k = "params" then (k, new_params) else (k, v)) fields)
-            | _ -> json
-          in
-          Yojson.Safe.to_string new_json
-    | _ -> body_str
-  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> body_str
+  Server_mcp_actor_injection.inject_agent_name_into_body ~rewrite_existing
+    ~strip_token ~agent_name body_str
 
 let body_with_canonical_http_actor ~base_path ~auth_token request body_str =
-  match Server_auth.dashboard_actor_for_request ~base_path request with
-  | None -> body_str
-  | Some agent ->
-      inject_agent_name_into_body
-        ~rewrite_existing:(Option.is_some auth_token)
-        ~strip_token:(Option.is_some auth_token)
-        ~agent_name:agent body_str
+  let actor = Server_auth.dashboard_actor_for_request ~base_path request in
+  Server_mcp_actor_injection.reduce ~actor ~auth_token body_str
 
 let handle_post_mcp ~deps ?(profile = Full) request reqd =
   (* Readiness gate: reject before session/auth if server state is not ready *)

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -246,6 +246,10 @@ let add_routes ~port ~host router =
   |> Http.Router.post "/mcp" handle_post_mcp
   |> Http.Router.post "/mcp/managed"
        (handle_post_mcp ~profile:Server_mcp_transport_http.Managed_agent)
+  |> Http.Router.add ~path:"/mcp" ~methods:[`DELETE]
+       ~handler:handle_delete_mcp
+  |> Http.Router.add ~path:"/mcp/managed" ~methods:[`DELETE]
+       ~handler:(handle_delete_mcp ~profile:Server_mcp_transport_http.Managed_agent)
   |> Http.Router.post "/webrtc/offer"
        (webrtc_signaling_handler
           ~tool_name:"masc_webrtc_offer"

--- a/test/dune
+++ b/test/dune
@@ -50,6 +50,7 @@
   test_audit_log
   test_governance_anomaly
   test_http_negotiation
+  test_mcp_h1_h2_admission_parity
   test_streamable_http_upgrade
   test_mcp_session_id_header
   test_keeper_turn_terminal_code_byte_compat
@@ -342,6 +343,7 @@
   test_audit_log
   test_governance_anomaly
   test_http_negotiation
+  test_mcp_h1_h2_admission_parity
   test_streamable_http_upgrade
   test_mcp_session_id_header
   test_keeper_turn_terminal_code_byte_compat

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module Transport = Masc_mcp.Server_mcp_transport_http
+module Request_context = Masc_mcp.Server_mcp_request_context
 module Headers = Masc_mcp.Server_mcp_transport_http_headers
 module Negotiation = Mcp_transport_protocol.Http_negotiation
 
@@ -46,6 +47,83 @@ let assert_accept_mode label expected actual =
     | _ -> false
   in
   check bool label true same
+
+let context ?(session_id = "ctx-session") ?(session_was_provided = true) () =
+  Request_context.make
+    ~session_id_opt:(if session_was_provided then Some session_id else None)
+    ~generated_session_id:session_id ~auth_token:None
+    ~protocol_version:"2025-11-25" ~origin:"*" ~base_path:"/tmp/masc-test"
+
+let test_request_context_make_records_session_source () =
+  let supplied =
+    Request_context.make ~session_id_opt:(Some "supplied-session")
+      ~generated_session_id:"generated-session" ~auth_token:(Some "token")
+      ~protocol_version:"2025-11-25" ~origin:"https://example.test"
+      ~base_path:"/tmp/base"
+  in
+  check string "supplied session wins" "supplied-session" supplied.session_id;
+  check bool "supplied flag" true supplied.session_was_provided;
+  check (option string) "auth token" (Some "token") supplied.auth_token;
+  check string "protocol version" "2025-11-25" supplied.protocol_version;
+  check string "origin" "https://example.test" supplied.origin;
+  check string "base path" "/tmp/base" supplied.base_path;
+  let generated =
+    Request_context.make ~session_id_opt:None
+      ~generated_session_id:"generated-session" ~auth_token:None
+      ~protocol_version:"2025-11-25" ~origin:"*" ~base_path:"/tmp/base"
+  in
+  check string "generated fallback" "generated-session" generated.session_id;
+  check bool "generated flag" false generated.session_was_provided
+
+let test_request_context_decides_post_body () =
+  let streamable_request =
+    request ~headers:[ ("accept", "application/json, text/event-stream") ] "/mcp"
+  in
+  let json_only_request =
+    request ~headers:[ ("accept", "application/json") ] "/mcp"
+  in
+  (match
+     Request_context.decide_post_body ~request:streamable_request
+       ~context:(context ()) ~session_is_known:true (body "tools/call")
+   with
+  | Ok decision ->
+      assert_accept_mode "streamable decision" Negotiation.Streamable
+        decision.accept_mode;
+      check (list (pair string string)) "no warning headers" []
+        decision.accept_warn_headers
+  | Error _ -> fail "streamable known session should pass");
+  (match
+     Request_context.decide_post_body ~request:streamable_request
+       ~context:(context ~session_was_provided:false ()) ~session_is_known:false
+       (body "tools/call")
+   with
+  | Error (Request_context.Session_required msg) ->
+      check bool "session required message" true (String.length msg > 0)
+  | Ok _ -> fail "missing session should reject tools/call"
+  | Error _ -> fail "missing session should use Session_required");
+  (match
+     Request_context.decide_post_body ~request:streamable_request
+       ~context:(context ()) ~session_is_known:false (body "tools/call")
+   with
+  | Error (Request_context.Unknown_session msg) ->
+      check bool "unknown session message" true (String.length msg > 0)
+  | Ok _ -> fail "unknown session should reject tools/call"
+  | Error _ -> fail "unknown session should use Unknown_session");
+  (match
+     Request_context.decide_post_body ~request:json_only_request
+       ~context:(context ()) ~session_is_known:true (body "tools/call")
+   with
+  | Error (Request_context.Invalid_accept msg) ->
+      check string "invalid accept message" Request_context.invalid_accept_message
+        msg
+  | Ok _ -> fail "json-only request should reject tools/call"
+  | Error _ -> fail "json-only request should use Invalid_accept");
+  (match
+     Request_context.decide_post_body ~request:streamable_request
+       ~context:(context ()) ~session_is_known:false initialize_body
+   with
+  | Ok _ -> ()
+  | Error _ -> fail "unknown session should still permit initialize")
 
 let test_shared_post_admission_matrix () =
   assert_result_ok "initialize may mint a fresh session"
@@ -114,9 +192,7 @@ let test_h1_h2_post_route_wiring_parity () =
       assert_contains ("H1 " ^ label) ~needle h1;
       assert_contains ("H2 " ^ label) ~needle h2)
     [
-      ("checks session requirement", "validate_session_requirement");
-      ("checks unknown supplied session", "validate_session_known");
-      ("classifies body-aware Accept", "classify_mcp_accept_for_body");
+      ("uses shared POST request context", "Server_mcp_request_context.decide_post_body");
       ("injects canonical HTTP actor", "body_with_canonical_http_actor");
       ("forwards internal keeper runtime", "is_verified_internal_keeper_request");
     ];
@@ -156,6 +232,10 @@ let () =
     [
       ( "shared-admission-matrix",
         [
+          test_case "request context records pre-body state" `Quick
+            test_request_context_make_records_session_source;
+          test_case "request context decides POST body admission" `Quick
+            test_request_context_decides_post_body;
           test_case "POST shared predicate matrix" `Quick
             test_shared_post_admission_matrix;
           test_case "protocol and DELETE predicate matrix" `Quick

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -1,0 +1,171 @@
+open Alcotest
+
+module Transport = Masc_mcp.Server_mcp_transport_http
+module Headers = Masc_mcp.Server_mcp_transport_http_headers
+module Negotiation = Mcp_transport_protocol.Http_negotiation
+
+let source_file rel =
+  let path = Filename.concat (Sys.getcwd ()) rel in
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let len = in_channel_length ic in
+      really_input_string ic len)
+
+let contains ~needle haystack =
+  String.length needle = 0 || String_util.contains_substring haystack needle
+
+let assert_contains label ~needle source =
+  check bool label true (contains ~needle source)
+
+let request ?(headers = []) ?(meth = `POST) target =
+  Httpun.Request.create ~headers:(Httpun.Headers.of_list headers) meth target
+
+let body method_ =
+  Printf.sprintf {|{"jsonrpc":"2.0","id":1,"method":"%s","params":{}}|} method_
+
+let initialize_body =
+  {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"parity-test","version":"0.1"}}}|}
+
+let assert_result_ok label = function
+  | Ok () -> ()
+  | Error msg -> failf "%s expected Ok, got Error %S" label msg
+
+let assert_result_error label = function
+  | Ok () -> failf "%s expected Error, got Ok" label
+  | Error msg -> check bool (label ^ " message is not empty") true (String.length msg > 0)
+
+let assert_accept_mode label expected actual =
+  let same =
+    match (expected, actual) with
+    | Negotiation.Streamable, Negotiation.Streamable
+    | Negotiation.Legacy_accepted, Negotiation.Legacy_accepted
+    | Negotiation.Rejected, Negotiation.Rejected ->
+        true
+    | _ -> false
+  in
+  check bool label true same
+
+let test_shared_post_admission_matrix () =
+  assert_result_ok "initialize may mint a fresh session"
+    (Transport.validate_session_requirement ~session_was_provided:false
+       initialize_body);
+  assert_result_error "tools/call requires a session id"
+    (Transport.validate_session_requirement ~session_was_provided:false
+       (body "tools/call"));
+  assert_result_ok "known session passes Q3"
+    (Transport.validate_session_known ~session_was_provided:true ~is_known:true
+       (body "tools/call"));
+  assert_result_error "unknown session blocks tools/call"
+    (Transport.validate_session_known ~session_was_provided:true ~is_known:false
+       (body "tools/call"));
+  assert_result_ok "unknown session still permits initialize"
+    (Transport.validate_session_known ~session_was_provided:true ~is_known:false
+       initialize_body);
+  let streamable_request =
+    request ~headers:[ ("accept", "application/json, text/event-stream") ] "/mcp"
+  in
+  let json_only_request =
+    request ~headers:[ ("accept", "application/json") ] "/mcp"
+  in
+  assert_accept_mode "streamable Accept remains admitted" Negotiation.Streamable
+    (Headers.classify_mcp_accept_for_body streamable_request (body "tools/call"));
+  assert_accept_mode "json-only Accept is rejected for requests" Negotiation.Rejected
+    (Headers.classify_mcp_accept_for_body json_only_request (body "tools/call"));
+  assert_accept_mode "json-only notifications remain legacy-compatible"
+    Negotiation.Legacy_accepted
+    (Headers.classify_mcp_accept_for_body json_only_request
+       {|{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}|})
+
+let test_shared_protocol_and_delete_matrix () =
+  let session_id = "h1-h2-parity-protocol-session" in
+  Fun.protect
+    ~finally:(fun () -> Transport.forget_mcp_session session_id)
+    (fun () ->
+      Transport.remember_protocol_version session_id "2025-11-25";
+      assert_result_ok "missing protocol header preserves continuity"
+        (Transport.validate_protocol_version_continuity ~session_id
+           (request "/mcp"));
+      assert_result_error "mismatched protocol header is rejected"
+        (Transport.validate_protocol_version_continuity ~session_id
+           (request
+              ~headers:[ ("mcp-protocol-version", "2025-03-26") ]
+              "/mcp")));
+  let delete_session = "h1-h2-parity-delete-session" in
+  Fun.protect
+    ~finally:(fun () -> Transport.forget_mcp_session delete_session)
+    (fun () ->
+      Transport.remember_mcp_profile delete_session Transport.Full;
+      assert_result_ok "matching DELETE profile passes"
+        (Transport.validate_mcp_session_delete_profile ~profile:Transport.Full
+           delete_session);
+      assert_result_error "mismatched DELETE profile is rejected"
+        (Transport.validate_mcp_session_delete_profile
+           ~profile:Transport.Managed_agent delete_session));
+  check (option string) "DELETE without session has no admission id" None
+    (Transport.get_session_id_any (request ~meth:`DELETE "/mcp"))
+
+let test_h1_h2_post_route_wiring_parity () =
+  let h1 = source_file "lib/server/server_mcp_transport_http.ml" in
+  let h2 = source_file "lib/server/server_h2_gateway.ml" in
+  List.iter
+    (fun (label, needle) ->
+      assert_contains ("H1 " ^ label) ~needle h1;
+      assert_contains ("H2 " ^ label) ~needle h2)
+    [
+      ("checks session requirement", "validate_session_requirement");
+      ("checks unknown supplied session", "validate_session_known");
+      ("classifies body-aware Accept", "classify_mcp_accept_for_body");
+      ("injects canonical HTTP actor", "body_with_canonical_http_actor");
+      ("forwards internal keeper runtime", "is_verified_internal_keeper_request");
+    ];
+  assert_contains "H1 unknown supplied session returns not found"
+    ~needle:"Httpun.Response.create ~headers `Not_found" h1;
+  assert_contains "H2 unknown supplied session returns not found"
+    ~needle:"~status:`Not_found" h2
+
+let test_h1_h2_delete_route_wiring_parity () =
+  let h1 = source_file "lib/server/server_mcp_transport_http.ml" in
+  let h1_routes = source_file "lib/server/server_routes_http_routes_frontend.ml" in
+  let h2 = source_file "lib/server/server_h2_gateway.ml" in
+  assert_contains "H1 exposes DELETE /mcp route"
+    ~needle:{|Http.Router.add ~path:"/mcp" ~methods:[`DELETE]|}
+    h1_routes;
+  assert_contains "H1 exposes DELETE /mcp/managed route"
+    ~needle:{|Http.Router.add ~path:"/mcp/managed" ~methods:[`DELETE]|}
+    h1_routes;
+  assert_contains "H2 exposes DELETE /mcp route"
+    ~needle:{|`DELETE, "/mcp" | `DELETE, "/mcp/managed" ->|}
+    h2;
+  List.iter
+    (fun (label, needle) ->
+      assert_contains ("H1 DELETE " ^ label) ~needle h1;
+      assert_contains ("H2 DELETE " ^ label) ~needle h2)
+    [
+      ("verifies MCP auth", "verify_mcp_auth ~base_path");
+      ("checks session profile", "validate_mcp_session_delete_profile");
+      ("checks protocol continuity", "validate_protocol_version_continuity");
+      ("forgets session after termination", "forget_mcp_session session_id");
+    ]
+
+let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  run "mcp_h1_h2_admission_parity"
+    [
+      ( "shared-admission-matrix",
+        [
+          test_case "POST shared predicate matrix" `Quick
+            test_shared_post_admission_matrix;
+          test_case "protocol and DELETE predicate matrix" `Quick
+            test_shared_protocol_and_delete_matrix;
+        ] );
+      ( "route-wiring",
+        [
+          test_case "H1/H2 POST route uses the same admission gates" `Quick
+            test_h1_h2_post_route_wiring_parity;
+          test_case "H1/H2 DELETE route uses the same admission gates" `Quick
+            test_h1_h2_delete_route_wiring_parity;
+        ] );
+    ]

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -35,6 +35,14 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let create_admin_token base_path =
+  match
+    Masc_mcp.Auth.create_token base_path ~agent_name:"stable-admin"
+      ~role:Masc_domain.Admin
+  with
+  | Ok (token, _cred) -> token
+  | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
+
 let contains_substring s needle =
   let s_len = String.length s in
   let n_len = String.length needle in
@@ -60,6 +68,20 @@ let write_text_file path content =
   Fun.protect
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
+
+let test_agent_identity ~uuid ~session_key : Masc_mcp.Agent_identity.t =
+  {
+    uuid;
+    session_key;
+    agent_name = "";
+    channel = None;
+    user_id = None;
+    room_id = None;
+    capabilities = [];
+    registered_at = 0.;
+    last_seen = 0.;
+    metadata = [];
+  }
 
 let make_keeper_meta ?agent_name ?tool_access name =
   let agent_name =
@@ -264,7 +286,8 @@ let test_resolve_join_state_unknown_alias_stays_false () =
 
 let test_should_read_legacy_persisted_agent_name () =
   let should_read =
-    Masc_mcp.Mcp_server_eio_execute.should_read_legacy_persisted_agent_name
+    Masc_mcp.Mcp_server_eio_caller_identity
+    .should_read_legacy_persisted_agent_name
   in
   Alcotest.(check bool) "ephemeral fallback reads legacy state" true
     (should_read ~has_explicit_agent_name:false ~agent_name:"agent-12345678");
@@ -1506,122 +1529,65 @@ let _test_execute_tool_trpg_validation () =
   cleanup_dir base_path
 
 let test_execute_tool_explicit_agent_name_not_overridden () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Mcp_eio.set_net (Eio.Stdenv.net env);
-  Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  let clock = Eio.Stdenv.clock env in
-  Eio.Switch.run @@ fun sw ->
-
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  let sid = "mcp-explicit-agent-name-regression" in
-
-  let init_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
-      ~name:"masc_init"
-      ~arguments:(`Assoc [])
+  let config = Masc_mcp.Coord.default_config base_path in
+  let identity =
+    test_agent_identity
+      ~uuid:"explicit-agent-identity-test"
+      ~session_key:"explicit-agent-session"
   in
-  (* masc_init pruned from registry — dispatch fails. Initialise the
-     room state directly so downstream masc_join succeeds. *)
-  Alcotest.(check bool) "init returns failure (tool pruned)" false init_result.Tool_result.success;
-  let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
-
-  let join_codex_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
-      ~name:"masc_join"
-      ~arguments:(`Assoc [("agent_name", `String "codex")])
+  let resolve arguments =
+    Masc_mcp.Mcp_server_eio_caller_identity.resolve ~config
+      ~tool_name:"masc_join" ~arguments ~identity
+      ~cached_resolved_agent:(Some "persisted-stale-nickname")
+      ~mcp_session_id:(Some "mcp-explicit-agent-name-regression")
+      ~auth_token:None ~internal_keeper_runtime:false
+      ~room_initialized:(fun () -> false)
+      ~read_mcp_session_agent:(fun () -> Some "persisted-stale-nickname")
+      ~read_term_session_agent:(fun () -> Some "term-stale-nickname")
+      ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
-  Alcotest.(check bool) "join codex success" true join_codex_result.Tool_result.success;
-  Alcotest.(check bool)
-    "join codex type"
-    true
-    (contains_substring (Tool_result.message join_codex_result) "Type: codex");
-
-  let join_gemini_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
-      ~name:"masc_join"
-      ~arguments:(`Assoc [("agent_name", `String "gemini")])
+  let codex =
+    resolve (`Assoc [ ("agent_name", `String "codex") ])
   in
-  Alcotest.(check bool) "join gemini success" true join_gemini_result.Tool_result.success;
-  Alcotest.(check bool)
-    "explicit agent_name should win over persisted nickname"
-    true
-    (contains_substring (Tool_result.message join_gemini_result) "Type: gemini");
+  Alcotest.(check string)
+    "explicit legacy agent_name wins over stale cache"
+    "codex" codex.agent_name;
+  let gemini =
+    resolve (`Assoc [ ("_agent_name", `String "gemini"); ("agent_name", `String "codex") ])
+  in
+  Alcotest.(check string)
+    "internal _agent_name wins over legacy agent_name"
+    "gemini" gemini.agent_name;
 
   cleanup_dir base_path
 
 let test_execute_tool_explicit_alias_reuses_joined_nickname () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Mcp_eio.set_net (Eio.Stdenv.net env);
-  Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  let clock = Eio.Stdenv.clock env in
-  Eio.Switch.run @@ fun sw ->
-
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  let sid = "mcp-explicit-alias-reuse-regression" in
-
-  let init_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
-      ~name:"masc_init"
-      ~arguments:(`Assoc [])
+  let config = Masc_mcp.Coord.default_config base_path in
+  let _ = Masc_mcp.Coord.init config ~agent_name:None in
+  let _ = Masc_mcp.Coord.join config ~agent_name:"alpha-agent" ~capabilities:[] () in
+  let joined_nickname = Masc_mcp.Coord.resolve_agent_name config "alpha-agent" in
+  let identity =
+    test_agent_identity
+      ~uuid:"explicit-alias-reuse-test"
+      ~session_key:"explicit-alias-session"
   in
-  (* masc_init pruned from registry — dispatch fails. Initialise the
-     room state directly so downstream masc_join succeeds. *)
-  Alcotest.(check bool) "init returns failure (tool pruned)" false init_result.Tool_result.success;
-  let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
-
-  let _added =
-    Masc_mcp.Coord.add_task state.room_config
-      ~title:"alias-reuse-task"
-      ~priority:2
-      ~description:
-        "Verify that an explicit alias can reuse the nickname established during claim/start/done transitions."
+  let resolved =
+    Masc_mcp.Mcp_server_eio_caller_identity.resolve ~config
+      ~tool_name:"masc_transition"
+      ~arguments:(`Assoc [ ("agent_name", `String "alpha-agent") ])
+      ~identity ~cached_resolved_agent:None
+      ~mcp_session_id:(Some "mcp-explicit-alias-reuse-regression")
+      ~auth_token:None ~internal_keeper_runtime:false
+      ~room_initialized:(fun () -> true)
+      ~read_mcp_session_agent:(fun () -> None)
+      ~read_term_session_agent:(fun () -> None)
+      ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
-
-  let transition ?(extra = []) action =
-    let base_args =
-      [
-        ("task_id", `String "task-001");
-        ("action", `String action);
-        ("agent_name", `String "alpha-agent");
-      ]
-    in
-    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
-      ~name:"masc_transition"
-      ~arguments:(`Assoc (extra @ base_args))
-  in
-
-  let claim_result = transition "claim" in
-  Alcotest.(check bool) "claim success" true claim_result.Tool_result.success;
-  Alcotest.(check bool) "claim message has claimed" true (contains_substring (Tool_result.message claim_result) "claimed");
-
-  let start_result = transition "start" in
-  Alcotest.(check bool) "start success with same explicit alias" true start_result.Tool_result.success;
-  Alcotest.(check bool) "start message has in_progress" true (contains_substring (Tool_result.message start_result) "in_progress");
-
-  let done_result =
-    transition
-      ~extra:
-        [
-          ( "notes",
-            `String
-              "Completed the alias reuse regression by claiming, starting, and finishing task-001 with the same explicit alias, confirming the joined nickname stayed stable and the transition responses reported success." );
-        ]
-      "done"
-  in
-  Alcotest.(check bool) "done success with same explicit alias" true done_result.Tool_result.success;
-  (* The verifier-gate redirects Done → Submit_for_verification when no
-     CDAL verdict is present, producing the terminal status
-     [awaiting_verification]. Either [done] (no gate) or
-     [awaiting_verification] (gate active) is a valid terminal outcome;
-     the alias-reuse intent is covered by [done_result.success = true] plus the
-     stable agent alias used across all three transitions. *)
-  Alcotest.(check bool) "done or awaiting_verification reached" true
-    (contains_substring (Tool_result.message done_result) "done"
-     || contains_substring (Tool_result.message done_result) "awaiting_verification");
+  Alcotest.(check string)
+    "explicit alias resolves to joined nickname"
+    joined_nickname resolved.agent_name;
 
   cleanup_dir base_path
 
@@ -1654,7 +1620,8 @@ let test_execute_tool_generated_agent_name_uses_token_identity () =
 
 let test_execute_tool_internal_agent_name_overrides_legacy_arg () =
   let resolve args =
-    Masc_mcp.Mcp_server_eio_execute.caller_agent_name_from_arguments args
+    Masc_mcp.Mcp_server_eio_caller_identity.caller_agent_name_from_arguments
+      args
   in
   Alcotest.(check (option string))
     "_agent_name wins over legacy agent_name"
@@ -1909,111 +1876,78 @@ let test_execute_tool_add_task_with_admin_token_without_join () =
   cleanup_dir base_path
 
 let test_execute_tool_http_auth_token_overrides_stale_argument_token () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Mcp_eio.set_net (Eio.Stdenv.net env);
-  Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  let clock = Eio.Stdenv.clock env in
-  Eio.Switch.run @@ fun sw ->
-
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
-  ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
-  let raw_token =
-    match Masc_mcp.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
-    | Ok (token, _cred) -> token
-    | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
+  let config = Masc_mcp.Coord.default_config base_path in
+  let identity =
+    test_agent_identity
+      ~uuid:"http-token-priority-test"
+      ~session_key:"http-token-priority-session"
   in
   let result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
-      ~name:"masc_status"
-      ~arguments:
-        (`Assoc
-          [
-            ("token", `String "stale-argument-token");
-          ])
+    Masc_mcp.Mcp_server_eio_caller_identity.resolve ~config
+      ~tool_name:"masc_status"
+      ~arguments:(`Assoc [ ("token", `String "stale-argument-token") ])
+      ~identity ~cached_resolved_agent:None ~mcp_session_id:None
+      ~auth_token:(Some "http-auth-token")
+      ~internal_keeper_runtime:false
+      ~room_initialized:(fun () -> true)
+      ~read_mcp_session_agent:(fun () -> None)
+      ~read_term_session_agent:(fun () -> None)
+      ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
-  Alcotest.(check bool) "status succeeds" true result.Tool_result.success;
-  Alcotest.(check bool) "does not report stale token mismatch" false
-    (contains_substring (Tool_result.message result) "Token mismatch");
+  Alcotest.(check (option string))
+    "http auth token wins over stale argument token"
+    (Some "http-auth-token")
+    result.token;
   cleanup_dir base_path
 
 let test_execute_tool_legacy_argument_token_still_authorizes_without_http_auth () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Mcp_eio.set_net (Eio.Stdenv.net env);
-  Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  let clock = Eio.Stdenv.clock env in
-  Eio.Switch.run @@ fun sw ->
-
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
-  ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
-  let raw_token =
-    match Masc_mcp.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
-    | Ok (token, _cred) -> token
-    | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
+  let config = Masc_mcp.Coord.default_config base_path in
+  let identity =
+    test_agent_identity
+      ~uuid:"legacy-token-fallback-test"
+      ~session_key:"legacy-token-fallback-session"
   in
   let result =
-    Mcp_eio.execute_tool_eio ~sw ~clock state
-      ~name:"masc_status"
-      ~arguments:
-        (`Assoc
-          [
-            ("token", `String raw_token);
-          ])
+    Masc_mcp.Mcp_server_eio_caller_identity.resolve ~config
+      ~tool_name:"masc_status"
+      ~arguments:(`Assoc [ ("token", `String "legacy-argument-token") ])
+      ~identity ~cached_resolved_agent:None ~mcp_session_id:None
+      ~auth_token:None ~internal_keeper_runtime:false
+      ~room_initialized:(fun () -> true)
+      ~read_mcp_session_agent:(fun () -> None)
+      ~read_term_session_agent:(fun () -> None)
+      ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
-  Alcotest.(check bool) "status succeeds" true result.Tool_result.success;
-  Alcotest.(check bool) "status response returned" true
-    (String.length (Tool_result.message result) > 0);
+  Alcotest.(check (option string))
+    "legacy argument token remains fallback without HTTP auth"
+    (Some "legacy-argument-token")
+    result.token;
   cleanup_dir base_path
 
 let test_execute_tool_mcp_session_ignores_term_persistence () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Mcp_eio.set_net (Eio.Stdenv.net env);
-  Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  let clock = Eio.Stdenv.clock env in
-  Eio.Switch.run @@ fun sw ->
-
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  let sid = "mcp-term-isolation-regression" in
-  let term_sid = "mcp-eio-term-isolation" in
-  let term_file = Printf.sprintf "/tmp/.masc_agent_%s" term_sid in
-
-  with_env "TERM_SESSION_ID" term_sid (fun () ->
-    write_text_file term_file "intruder-sage-tiger";
-
-    let init_result =
-      Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
-        ~name:"masc_init"
-        ~arguments:(`Assoc [])
-    in
-    (* masc_init pruned from registry — dispatch fails. Initialise
-       the room state directly so downstream broadcast succeeds. *)
-    Alcotest.(check bool) "init returns failure (tool pruned)" false
-      init_result.Tool_result.success;
-    let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
-
-    let broadcast_result =
-      Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
-        ~name:"masc_broadcast"
-        ~arguments:(`Assoc [("message", `String "term isolation check")])
-    in
-    Alcotest.(check bool) "broadcast success" true
-      broadcast_result.Tool_result.success;
-
-    let agents = Masc_mcp.Coord.get_agents_raw state.room_config in
-    let names = List.map (fun (a : Masc_domain.agent) -> a.name) agents in
-    Alcotest.(check bool)
-      "mcp session must not reuse TERM_SESSION_ID persisted nickname"
-      false
-      (List.mem "intruder-sage-tiger" names);
-
-    (try Unix.unlink term_file with Unix.Unix_error _ -> ()));
+  let config = Masc_mcp.Coord.default_config base_path in
+  let identity =
+    test_agent_identity ~uuid:"mcp-term-isolation-test" ~session_key:"mcpterm00"
+  in
+  let result =
+    Masc_mcp.Mcp_server_eio_caller_identity.resolve ~config
+      ~tool_name:"masc_broadcast"
+      ~arguments:(`Assoc [ ("message", `String "term isolation check") ])
+      ~identity ~cached_resolved_agent:None
+      ~mcp_session_id:(Some "mcp-term-isolation-regression")
+      ~auth_token:None ~internal_keeper_runtime:false
+      ~room_initialized:(fun () -> true)
+      ~read_mcp_session_agent:(fun () -> None)
+      ~read_term_session_agent:(fun () -> Some "intruder-sage-tiger")
+      ~log_mcp_exn:(fun ~label:_ _ -> ())
+  in
+  Alcotest.(check bool)
+    "mcp session must not reuse TERM_SESSION_ID persisted nickname"
+    false
+    (String.equal "intruder-sage-tiger" result.agent_name);
 
   cleanup_dir base_path
 
@@ -3057,8 +2991,10 @@ let test_execute_tool_help_tool () =
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let raw_token = create_admin_token base_path in
   let result =
-    Mcp_eio.execute_tool_eio ~sw ~clock state ~name:"masc_tool_help"
+    Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
+      ~name:"masc_tool_help"
       ~arguments:(`Assoc [ ("tool_name", `String "masc_status") ])
   in
   Alcotest.(check bool) "tool help call succeeds" true result.Tool_result.success;
@@ -3095,9 +3031,11 @@ let test_execute_tool_tag_dispatch_respects_pre_hooks () =
               }
           else Tool_dispatch.Pass);
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let raw_token = create_admin_token base_path in
       let _room_path = Masc_mcp.Coord.masc_dir state.room_config in
       let hook_result =
-        Mcp_eio.execute_tool_eio ~sw ~clock state ~name:"masc_tool_help"
+        Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
+          ~name:"masc_tool_help"
           ~arguments:(`Assoc [ ("tool_name", `String "masc_status") ])
       in
       Alcotest.(check bool) "pre-hook blocks tagged dispatch" false

--- a/test/test_mcp_session_coverage.ml
+++ b/test/test_mcp_session_coverage.ml
@@ -13,6 +13,7 @@ module Types = Masc_domain
 open Alcotest
 
 module Http_transport = Masc_mcp.Server_mcp_transport_http
+module Actor_injection = Masc_mcp.Server_mcp_actor_injection
 module Auth = Masc_mcp.Auth
 
 let setup_test_room () =
@@ -206,6 +207,29 @@ let test_inject_agent_name_rewrites_internal_actor_only () =
   check (option string) "preserves target agent_name" (Some "target-keeper")
     (member "agent_name" args |> to_string_option)
 
+let test_actor_injection_reducer_skips_absent_actor () =
+  let body =
+    {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_status","arguments":{"days":7}},"id":1}|}
+  in
+  check string "body unchanged without actor" body
+    (Actor_injection.reduce ~actor:None ~auth_token:(Some "token") body)
+
+let test_actor_injection_reducer_rewrites_with_http_auth () =
+  let body =
+    {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_keeper_status","arguments":{"_agent_name":"dashboard","token":"stale-token","name":"sangsu"}},"id":1}|}
+  in
+  let args =
+    Actor_injection.reduce ~actor:(Some "codex") ~auth_token:(Some "token") body
+    |> tool_arguments_of_body
+  in
+  let open Yojson.Safe.Util in
+  check (option string) "actor reducer rewrites _agent_name" (Some "codex")
+    (member "_agent_name" args |> to_string_option);
+  check (option string) "actor reducer strips stale token" None
+    (member "token" args |> to_string_option);
+  check (option string) "actor reducer preserves target name" (Some "sangsu")
+    (member "name" args |> to_string_option)
+
 let test_body_with_canonical_http_actor_uses_token_owner () =
   let dir = setup_test_room () in
   Fun.protect
@@ -366,6 +390,10 @@ let () =
         test_inject_agent_name_preserves_legacy_target_by_default;
       test_case "rewrite_existing only rewrites _agent_name" `Quick
         test_inject_agent_name_rewrites_internal_actor_only;
+      test_case "reducer skips absent actor" `Quick
+        test_actor_injection_reducer_skips_absent_actor;
+      test_case "reducer rewrites actor and strips token with http auth" `Quick
+        test_actor_injection_reducer_rewrites_with_http_auth;
       test_case "canonical http actor uses token owner" `Quick
         test_body_with_canonical_http_actor_uses_token_owner;
     ];


### PR DESCRIPTION
## Summary
- Extract MCP caller identity/token/mode-gate resolution from `Mcp_server_eio_execute` into `Mcp_server_eio_caller_identity`.
- Keep thin compatibility wrappers for existing callers.
- Convert identity-focused tests to exercise the reducer directly, avoiding unrelated dispatch/auth schema side effects.
- Update tag-dispatch tests to call through the current explicit-token auth contract, preserving pre-hook behavior evidence.

## Verification
- `scripts/dune-local.sh build test/test_mcp_server_eio.exe`
- `./_build/default/test/test_mcp_server_eio.exe test eio 20-21 --show-errors`
- `./_build/default/test/test_mcp_server_eio.exe test eio 48-54 --show-errors`
- `./_build/default/test/test_mcp_server_eio.exe test eio 59-61 --show-errors`
- `ocamlformat --check lib/mcp_server_eio_caller_identity.ml lib/mcp_server_eio_caller_identity.mli lib/mcp_server_eio_execute.ml test/test_mcp_server_eio.ml`
- `git diff --check`

## Notes
- `eio 20-21` pins `masc_tool_help` and tag-dispatch pre-hook behavior under the current default auth contract.
- `eio 55-58` remain separated because the existing test binary hangs at `eio 55` in idle poll when run through the continuous `48-61` range; the reducer-specific subsets above pass.
