### PR TITLE
docs(keeper): failure policy layer plan

### DIFF
--- a/docs/design/keeper-failure-policy-layer-plan.html
+++ b/docs/design/keeper-failure-policy-layer-plan.html
@@ -1,0 +1,657 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Keeper Failure Policy Layer Plan</title>
+  <style>
+    :root {
+      --bg: #f6f7f7;
+      --surface: #ffffff;
+      --ink: #172026;
+      --muted: #5e6a73;
+      --line: #d8dde2;
+      --code: #eef1f3;
+      --blue: #1d5d8f;
+      --green: #1f7a4d;
+      --amber: #a15c07;
+      --red: #b42318;
+      --violet: #6043a6;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans KR", sans-serif;
+      line-height: 1.55;
+    }
+
+    header {
+      background: var(--surface);
+      border-bottom: 1px solid var(--line);
+      padding: 38px 32px 26px;
+    }
+
+    main {
+      max-width: 1280px;
+      margin: 0 auto;
+      padding: 26px 24px 72px;
+    }
+
+    h1, h2, h3 {
+      margin: 0;
+      line-height: 1.2;
+      letter-spacing: 0;
+    }
+
+    h1 { font-size: 34px; }
+    h2 { margin-top: 34px; font-size: 23px; }
+    h3 { margin-top: 18px; font-size: 17px; }
+
+    p { margin: 10px 0; }
+
+    a {
+      color: var(--blue);
+      text-decoration: none;
+    }
+
+    a:hover { text-decoration: underline; }
+
+    code {
+      padding: 2px 5px;
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      background: var(--code);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.92em;
+    }
+
+    pre {
+      overflow-x: auto;
+      margin: 12px 0 0;
+      padding: 14px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #111820;
+      color: #e8edf2;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 13px;
+      line-height: 1.45;
+    }
+
+    table {
+      width: 100%;
+      margin-top: 12px;
+      border-collapse: collapse;
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    th, td {
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--line);
+      text-align: left;
+      vertical-align: top;
+      font-size: 14px;
+    }
+
+    th {
+      background: #eef2f5;
+      font-size: 12px;
+      color: #34424d;
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+    }
+
+    tr:last-child td { border-bottom: 0; }
+
+    ul {
+      margin: 10px 0 0;
+      padding-left: 20px;
+    }
+
+    li { margin: 5px 0; }
+
+    .lede {
+      max-width: 940px;
+      color: var(--muted);
+      font-size: 16px;
+    }
+
+    .meta {
+      margin-top: 12px;
+      color: var(--muted);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 12px;
+    }
+
+    .grid {
+      display: grid;
+      gap: 12px;
+    }
+
+    .snapshot {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      margin-top: 18px;
+    }
+
+    .two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+
+    .tile, .panel {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--surface);
+    }
+
+    .tile { padding: 15px; }
+    .panel { margin-top: 14px; padding: 18px; }
+
+    .tile strong {
+      display: block;
+      font-size: 28px;
+      line-height: 1.1;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .tile span {
+      display: block;
+      margin-top: 4px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .badge {
+      display: inline-block;
+      margin: 2px 4px 2px 0;
+      padding: 2px 7px;
+      border-radius: 999px;
+      background: #e8ecef;
+      color: #2d3942;
+      font-size: 12px;
+      white-space: nowrap;
+    }
+
+    .ok { color: var(--green); font-weight: 700; }
+    .warn { color: var(--amber); font-weight: 700; }
+    .bad { color: var(--red); font-weight: 700; }
+    .info { color: var(--blue); font-weight: 700; }
+    .p0 { color: var(--red); font-weight: 700; }
+    .p1 { color: var(--amber); font-weight: 700; }
+    .p2 { color: var(--violet); font-weight: 700; }
+    .p3 { color: var(--blue); font-weight: 700; }
+
+    .callout {
+      margin-top: 14px;
+      padding: 14px 16px;
+      border-left: 4px solid var(--blue);
+      background: #edf4fa;
+    }
+
+    .callout.warning {
+      border-left-color: var(--amber);
+      background: #fff6e8;
+    }
+
+    .callout.danger {
+      border-left-color: var(--red);
+      background: #fff0ee;
+    }
+
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 10px;
+      margin-top: 12px;
+    }
+
+    .step {
+      min-height: 122px;
+      padding: 14px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--surface);
+    }
+
+    .step strong {
+      display: block;
+      margin-bottom: 6px;
+    }
+
+    .status {
+      font-weight: 700;
+      white-space: nowrap;
+    }
+
+    .todo { color: var(--violet); }
+    .doing { color: var(--amber); }
+    .done { color: var(--green); }
+    .blocked { color: var(--red); }
+
+    @media (max-width: 900px) {
+      header { padding: 28px 20px 22px; }
+      main { padding: 22px 16px 56px; }
+      .snapshot, .two, .three, .flow { grid-template-columns: 1fr; }
+      h1 { font-size: 28px; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Keeper Failure Policy Layer Plan</h1>
+    <p class="lede">
+      Keeper를 죽일 실패와 턴만 실패시킬 실패를 한 계층에서 판정하도록 만드는 실행 계획서.
+      목표는 임시 예외처리나 문자열 기반 우회가 아니라, failure taxonomy, lifecycle disposition,
+      operator visibility를 하나의 typed decision으로 연결하는 것이다.
+    </p>
+    <div class="meta">
+      Status: living plan · Created: 2026-05-18 · Owner surface: keeper runtime / supervisor / dashboard · Update rule: every implementation PR updates this page
+    </div>
+  </header>
+
+  <main>
+    <section class="grid snapshot">
+      <div class="tile">
+        <strong>P0</strong>
+        <span>keeper 생명주기 정책을 callsite별 ad hoc 판단에서 제거</span>
+      </div>
+      <div class="tile">
+        <strong>1</strong>
+        <span>single typed policy layer: failure -> disposition</span>
+      </div>
+      <div class="tile">
+        <strong>4</strong>
+        <span>분리할 scope: provider, turn, keeper, fleet</span>
+      </div>
+      <div class="tile">
+        <strong>0</strong>
+        <span>timeout만으로 keeper death를 결정하는 경로</span>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Executive Goal</h2>
+      <p>
+        현재 문제는 keeper 실패가 여러 callsite에서 서로 다른 언어로 해석된다는 점이다.
+        <code>keeper_bash</code> workflow rejection, <code>oas_timeout_budget</code>, stale watchdog,
+        supervisor auto-pause, dashboard blocked count가 서로 다른 정책 계층처럼 동작하면서
+        operator에게는 모두 "keeper가 막힘/죽음"으로 보인다.
+      </p>
+      <p>
+        최종 상태는 모든 실패가 먼저 <code>Keeper_failure_policy.classify</code>를 거쳐
+        <code>disposition</code>을 받고, heartbeat/supervisor/watchdog/dashboard는 그 결과만 소비하는 구조다.
+      </p>
+      <pre>failure evidence
+  -> Keeper_failure_policy.classify
+  -> { failure_class; scope; disposition; lifecycle_effect; operator_action; evidence }
+  -> runtime action + metrics/logs + dashboard status</pre>
+    </section>
+
+    <section>
+      <h2>Current Problem Statement</h2>
+      <div class="grid two">
+        <div class="panel">
+          <h3>Observed Confusion</h3>
+          <ul>
+            <li><code>Paused</code>, <code>Blocked</code>, <code>Backoff</code>, <code>Provider cooldown</code>이 UI/로그에서 섞인다.</li>
+            <li><code>blocked_count</code>가 실제 blocked task 수가 아니라 fleet capacity shortfall로 보인다.</li>
+            <li><code>Oas_timeout_budget_loop</code>가 provider/turn 증상인데 keeper lifecycle event로 승격된다.</li>
+            <li>stale watchdog은 root cause를 보존하려다 lifecycle action까지 과하게 이어질 수 있다.</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h3>Immediate Mitigations In Flight</h3>
+          <ul>
+            <li><span class="done">Done / PR</span> <code>#16154</code>: deterministic <code>keeper_bash</code> guard rejection을 <code>workflow_rejection</code>으로 분류해 circuit breaker에서 제외.</li>
+            <li><span class="done">Done / PR</span> <code>#16159</code>: repeated <code>oas_timeout_budget</code> strike가 <code>Keeper_fiber_crash</code>로 승격되는 직접 경로 제거.</li>
+            <li><span class="warn">Remaining</span>: watchdog/supervisor/dashboard가 같은 policy vocabulary를 쓰도록 통합 필요.</li>
+          </ul>
+        </div>
+      </div>
+      <div class="callout warning">
+        <strong>Important:</strong>
+        <code>oas_timeout_budget</code>는 원인이 아니라 증상이다. 단일 timeout error kind만 보고 "recoverable" 또는 "hopeless"를 결정하면 안 된다.
+        provider/cascade 상태, fallback 가능성, terminal fingerprint, slot/process liveness, repeated stale evidence를 함께 봐야 한다.
+      </div>
+    </section>
+
+    <section>
+      <h2>Policy Model</h2>
+      <div class="flow">
+        <div class="step">
+          <strong>1. Evidence</strong>
+          typed error, provider health, skip reasons, watchdog class, tool result, committed tools, slot holder age
+        </div>
+        <div class="step">
+          <strong>2. Scope</strong>
+          provider/call, turn, keeper fiber, durable keeper, fleet/system
+        </div>
+        <div class="step">
+          <strong>3. Disposition</strong>
+          feedback, retry, soft_backoff, route_away, restart, pause, dead, operator_required
+        </div>
+        <div class="step">
+          <strong>4. Visibility</strong>
+          metric labels, structured log, dashboard status, next operator action
+        </div>
+      </div>
+
+      <h3>Proposed Decision Type</h3>
+      <pre>type failure_scope =
+  | Provider_call
+  | Keeper_turn
+  | Keeper_fiber
+  | Keeper_durable_state
+  | Fleet_system
+
+type lifecycle_effect =
+  | No_lifecycle_effect
+  | Turn_soft_fail
+  | Provider_cooldown
+  | Keeper_restart
+  | Keeper_auto_pause
+  | Keeper_operator_pause_required
+  | Keeper_dead
+
+type operator_action =
+  | No_action
+  | Inspect_timeout_budget
+  | Inspect_provider_health
+  | Fix_cascade_config
+  | Fix_tool_contract
+  | Fix_runtime_environment
+  | Resume_after_backoff
+
+type decision = {
+  failure_class : string;
+  scope : failure_scope;
+  disposition : string;
+  lifecycle_effect : lifecycle_effect;
+  operator_action : operator_action;
+  breaker_applicable : bool;
+  auto_resume : bool;
+  evidence : Yojson.Safe.t;
+}</pre>
+    </section>
+
+    <section>
+      <h2>Failure Taxonomy</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Failure class</th>
+            <th>Default scope</th>
+            <th>Lifecycle effect</th>
+            <th>Escalates only when</th>
+            <th>Operator wording</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>workflow_rejection</code></td>
+            <td>turn/tool feedback</td>
+            <td><span class="ok">none</span></td>
+            <td>never to keeper death; repeated misuse may nudge instructions</td>
+            <td>Command rejected by workflow guard. Rewrite tool usage.</td>
+          </tr>
+          <tr>
+            <td><code>provider_timeout</code> / <code>oas_timeout_budget</code></td>
+            <td>provider call or keeper turn</td>
+            <td><span class="ok">turn soft fail</span></td>
+            <td>only with separate liveness evidence such as wedged child process or leaked slot</td>
+            <td>Provider or turn budget exhausted. Inspect timeout budget and provider health.</td>
+          </tr>
+          <tr>
+            <td><code>transient_network</code> / <code>overload</code></td>
+            <td>provider call</td>
+            <td><span class="ok">retry/backoff</span></td>
+            <td>sustained provider-wide failure fingerprints across cooldown windows</td>
+            <td>Transient upstream issue. Route away or retry after backoff.</td>
+          </tr>
+          <tr>
+            <td><code>cascade_config_exhausted</code></td>
+            <td>cascade policy</td>
+            <td><span class="warn">operator-visible pause possible</span></td>
+            <td>all configured candidates missing auth, unavailable, or filtered with no fallback</td>
+            <td>Cascade has no callable providers. Fix config or credentials.</td>
+          </tr>
+          <tr>
+            <td><code>required_tool_contract</code></td>
+            <td>turn/tool contract</td>
+            <td><span class="warn">pause current work possible</span></td>
+            <td>required tool is impossible for the active keeper/provider surface</td>
+            <td>Required tool contract cannot be satisfied. Adjust provider/tool policy.</td>
+          </tr>
+          <tr>
+            <td><code>fatal_environment</code></td>
+            <td>keeper fiber/runtime</td>
+            <td><span class="bad">restart or pause</span></td>
+            <td>environment invariant broken: missing Eio context, sandbox corruption, FD exhaustion</td>
+            <td>Runtime environment is unhealthy. Fix host/runtime before resuming.</td>
+          </tr>
+          <tr>
+            <td><code>stale_in_turn_hung</code></td>
+            <td>keeper fiber</td>
+            <td><span class="bad">force-release + restart</span></td>
+            <td>active turn exceeds hard liveness budget or no-progress threshold</td>
+            <td>Keeper turn is hung. Restart fiber and preserve turn evidence.</td>
+          </tr>
+          <tr>
+            <td><code>stale_storm</code></td>
+            <td>fleet/system</td>
+            <td><span class="bad">durable pause possible</span></td>
+            <td>same keeper or cohort repeatedly restarts into stale termination</td>
+            <td>Repeated liveness storm. Stop churn and require operator inspection.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>OAS Timeout vs Hopeless</h2>
+      <div class="grid two">
+        <div class="panel">
+          <h3>Timeout, but not hopeless</h3>
+          <ul>
+            <li>single provider timed out while fallback providers remain callable</li>
+            <li>provider health has recent success or short cooldown only</li>
+            <li>prompt/context was unusually large for this turn</li>
+            <li>outer keeper turn remains cancellable and slots are released</li>
+            <li>no hard quota, auth, model-not-found, or required-tool terminal fingerprint</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h3>Potentially hopeless without operator action</h3>
+          <ul>
+            <li>all cascade candidates are missing credentials, hard-quotaed, or model-not-found</li>
+            <li>required tool contract cannot be satisfied by any selected provider</li>
+            <li>same terminal fingerprint repeats after cooldown windows</li>
+            <li>active child process or slot is wedged and force-release evidence exists</li>
+            <li>the same keeper enters a stale termination storm after restart</li>
+          </ul>
+        </div>
+      </div>
+      <div class="callout">
+        <strong>Policy rule:</strong>
+        <code>oas_timeout_budget</code> alone may set <code>Turn_soft_fail</code> or <code>Provider_cooldown</code>.
+        It may not set <code>Keeper_auto_pause</code> or <code>Keeper_dead</code> unless a second typed evidence source proves keeper/runtime liveness is broken.
+      </div>
+    </section>
+
+    <section>
+      <h2>Work Packages</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>PR</th>
+            <th>Status</th>
+            <th>Goal</th>
+            <th>Primary files</th>
+            <th>Acceptance test</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>P0-A</td>
+            <td><span class="status doing">in flight</span></td>
+            <td>Existing noisy paths stop killing keepers directly.</td>
+            <td><code>keeper_shell_bash.ml</code>, <code>keeper_heartbeat_loop.ml</code>, <code>keeper_turn_slot.ml</code></td>
+            <td>workflow rejection skips breaker; OAS timeout strike limit soft-backoffs without crash.</td>
+          </tr>
+          <tr>
+            <td>P0-B</td>
+            <td><span class="status todo">next</span></td>
+            <td>Add <code>Keeper_failure_policy</code> pure module and decision type.</td>
+            <td><code>lib/keeper/keeper_failure_policy.ml</code>, <code>.mli</code>, unit tests</td>
+            <td>matrix test covers workflow, timeout, cascade exhausted, fatal env, stale classes.</td>
+          </tr>
+          <tr>
+            <td>P0-C</td>
+            <td><span class="status todo">next</span></td>
+            <td>Migrate heartbeat OAS timeout and transient error paths to policy decisions.</td>
+            <td><code>keeper_heartbeat_loop.ml</code>, <code>keeper_error_classify.ml</code></td>
+            <td><code>oas_timeout_budget</code> cannot raise <code>Keeper_fiber_crash</code> without liveness evidence.</td>
+          </tr>
+          <tr>
+            <td>P0-D</td>
+            <td><span class="status todo">next</span></td>
+            <td>Migrate stale watchdog and supervisor crash/auto-pause paths.</td>
+            <td><code>keeper_stale_watchdog.ml</code>, <code>keeper_supervisor.ml</code></td>
+            <td>watchdog preserves root cause for visibility but lifecycle action comes from policy.</td>
+          </tr>
+          <tr>
+            <td>P1-E</td>
+            <td><span class="status todo">planned</span></td>
+            <td>Dashboard/status vocabulary cleanup.</td>
+            <td><code>keeper_status_bridge.ml</code>, dashboard API/components</td>
+            <td>capacity shortfall, operator pause, auto backoff, provider cooldown render as separate states.</td>
+          </tr>
+          <tr>
+            <td>P1-F</td>
+            <td><span class="status todo">planned</span></td>
+            <td>Metrics/log/event envelope standardization.</td>
+            <td><code>keeper_metrics.ml</code>, lifecycle events, runtime trust snapshot</td>
+            <td>all failure decisions emit <code>failure_class</code>, <code>disposition</code>, <code>lifecycle_effect</code>.</td>
+          </tr>
+          <tr>
+            <td>P2-G</td>
+            <td><span class="status todo">planned</span></td>
+            <td>Update docs and runbooks to remove old timeout auto-pause wording.</td>
+            <td><code>docs/TIMEOUT-MATRIX.md</code>, dashboard/operator runbooks</td>
+            <td>docs distinguish timeout symptom, terminal provider failure, and keeper liveness failure.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Implementation Sequence</h2>
+      <div class="grid three">
+        <div class="panel">
+          <h3>Phase 1: Pure Classification</h3>
+          <ul>
+            <li>Create closed decision vocabulary.</li>
+            <li>Map existing typed errors into decisions without side effects.</li>
+            <li>Add table-driven tests before callsite migration.</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h3>Phase 2: Runtime Migration</h3>
+          <ul>
+            <li>Replace direct <code>raise Keeper_fiber_crash</code> where failure is not fatal.</li>
+            <li>Replace supervisor auto-pause case splits with policy decisions.</li>
+            <li>Keep fatal environment and true stale-hung restart paths strict.</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h3>Phase 3: Operator Clarity</h3>
+          <ul>
+            <li>Rename capacity surfaces away from ambiguous blocked wording.</li>
+            <li>Expose next action and lifecycle effect in dashboard/runtime trust.</li>
+            <li>Backfill docs and runbooks with new vocabulary.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Code Migration Targets</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Target</th>
+            <th>Current responsibility</th>
+            <th>Desired dependency direction</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="../../lib/keeper/keeper_heartbeat_loop.ml">keeper_heartbeat_loop.ml</a></td>
+            <td>Detects OAS timeout and currently owns parts of strike handling.</td>
+            <td>Build evidence, call policy, apply returned turn/lifecycle action.</td>
+          </tr>
+          <tr>
+            <td><a href="../../lib/keeper/keeper_supervisor.ml">keeper_supervisor.ml</a></td>
+            <td>Maps crash reasons to restart, pause, dead, and auto-resume.</td>
+            <td>Consume <code>lifecycle_effect</code>; stop duplicating failure taxonomy.</td>
+          </tr>
+          <tr>
+            <td><a href="../../lib/keeper/keeper_stale_watchdog.ml">keeper_stale_watchdog.ml</a></td>
+            <td>Classifies stale kills and preserves some prior failure reasons.</td>
+            <td>Produce liveness evidence; policy decides whether prior cause affects lifecycle.</td>
+          </tr>
+          <tr>
+            <td><a href="../../lib/keeper/keeper_error_classify.ml">keeper_error_classify.ml</a></td>
+            <td>Classifies recoverability and retry semantics.</td>
+            <td>Remain error-level classifier; policy composes it with liveness and provider evidence.</td>
+          </tr>
+          <tr>
+            <td><a href="../../lib/keeper/keeper_status_bridge.ml">keeper_status_bridge.ml</a></td>
+            <td>Projects runtime blockers into dashboard status.</td>
+            <td>Render policy decisions and next action without conflating pause/block/backoff.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Acceptance Criteria</h2>
+      <div class="panel">
+        <ul>
+          <li><span class="ok">A1</span> A provider/turn timeout cannot directly kill or durable-pause a keeper.</li>
+          <li><span class="ok">A2</span> Fatal runtime failures still trip restart/circuit breaker paths.</li>
+          <li><span class="ok">A3</span> Dashboard separates <code>operator_paused</code>, <code>auto_backoff</code>, <code>provider_cooldown</code>, <code>capacity_shortfall</code>, and true task blocked state.</li>
+          <li><span class="ok">A4</span> Every failure decision has a structured log/metric with <code>failure_class</code>, <code>scope</code>, <code>disposition</code>, and <code>lifecycle_effect</code>.</li>
+          <li><span class="ok">A5</span> Regression tests prove the negative cases: workflow rejection does not break keeper; OAS timeout does not break keeper; fatal environment still breaks keeper.</li>
+          <li><span class="ok">A6</span> Runbooks no longer describe repeated OAS timeout as keeper auto-pause by default.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section>
+      <h2>Update Log</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Change</th>
+            <th>Evidence</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>2026-05-18</td>
+            <td>Initial living plan created.</td>
+            <td>Live keeper investigation, <code>#16154</code>, <code>#16159</code>, and current timeout/supervisor code paths.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/design/keeper-failure-policy-layer-plan.html
+++ b/docs/design/keeper-failure-policy-layer-plan.html
@@ -309,6 +309,7 @@
           <ul>
             <li><span class="done">Done / PR</span> <code>#16154</code>: deterministic <code>keeper_bash</code> guard rejection을 <code>workflow_rejection</code>으로 분류해 circuit breaker에서 제외.</li>
             <li><span class="done">Done / PR</span> <code>#16159</code>: repeated <code>oas_timeout_budget</code> strike가 <code>Keeper_fiber_crash</code>로 승격되는 직접 경로 제거.</li>
+            <li><span class="doing">Started / OAS PR</span> <code>oas#1632</code>: provider timeout을 <code>stream_idle:streaming_thinking</code>, <code>stream_body</code>, <code>provider_step</code> 같은 typed evidence로 보존.</li>
             <li><span class="warn">Remaining</span>: watchdog/supervisor/dashboard가 같은 policy vocabulary를 쓰도록 통합 필요.</li>
           </ul>
         </div>
@@ -459,6 +460,7 @@ type decision = {
           <h3>Timeout, but not hopeless</h3>
           <ul>
             <li>single provider timed out while fallback providers remain callable</li>
+            <li>timeout phase is <code>stream_idle</code> with answer/thinking/tool-call progress already observed</li>
             <li>provider health has recent success or short cooldown only</li>
             <li>prompt/context was unusually large for this turn</li>
             <li>outer keeper turn remains cancellable and slots are released</li>
@@ -470,6 +472,7 @@ type decision = {
           <ul>
             <li>all cascade candidates are missing credentials, hard-quotaed, or model-not-found</li>
             <li>required tool contract cannot be satisfied by any selected provider</li>
+            <li>timeout phase is <code>provider_step</code> and all fallback candidates are exhausted or disabled</li>
             <li>same terminal fingerprint repeats after cooldown windows</li>
             <li>active child process or slot is wedged and force-release evidence exists</li>
             <li>the same keeper enters a stale termination storm after restart</li>
@@ -496,6 +499,13 @@ type decision = {
           </tr>
         </thead>
         <tbody>
+          <tr>
+            <td>P0-OAS</td>
+            <td><span class="status doing">draft PR</span></td>
+            <td>Expose generic provider timeout/failure evidence before MASC policy consumes it.</td>
+            <td><code>oas#1632</code>: <code>Http_client.TimeoutError</code>, <code>Error.Provider</code>, stream idle state</td>
+            <td>MASC can distinguish <code>stream_idle:streaming_thinking</code>, <code>stream_body</code>, <code>provider_step</code>, hard quota, capacity, and provider terminal without string parsing.</td>
+          </tr>
           <tr>
             <td>P0-A</td>
             <td><span class="status doing">in flight</span></td>

--- a/docs/design/keeper-failure-policy-layer-plan.html
+++ b/docs/design/keeper-failure-policy-layer-plan.html
@@ -310,8 +310,8 @@
             <li><span class="done">Done / PR</span> <code>#16154</code>: deterministic <code>keeper_bash</code> guard rejection을 <code>workflow_rejection</code>으로 분류해 circuit breaker에서 제외.</li>
             <li><span class="done">Done / PR</span> <code>#16159</code>: repeated <code>oas_timeout_budget</code> strike가 <code>Keeper_fiber_crash</code>로 승격되는 직접 경로 제거.</li>
             <li><span class="done">Done / OAS PR</span> <code>oas#1632</code>: provider timeout을 <code>stream_idle:streaming_thinking</code>, <code>stream_body</code>, <code>provider_step</code> 같은 typed evidence로 보존.</li>
-            <li><span class="doing">Started / MASC PR</span> <code>#16191</code>: downstream OAS pin을 <code>main@308152ee</code> (<code>v0.196.1</code>)로 올리고 API surface fingerprint를 갱신.</li>
-            <li><span class="doing">Started / MASC PR</span> <code>#16178</code>: <code>Keeper_failure_policy.decide</code> pure matrix로 Streaming/Thinking timeout과 keeper liveness 결정을 분리.</li>
+            <li><span class="done">Done / MASC PR</span> <code>#16191</code>: downstream OAS pin을 <code>main@308152ee</code> (<code>v0.196.1</code>)로 올리고 API surface fingerprint를 갱신.</li>
+            <li><span class="doing">Started / MASC PR</span> <code>#16178</code>: <code>Keeper_failure_policy.decide</code> pure matrix와 heartbeat OAS timeout strike callsite를 policy decision으로 연결.</li>
             <li><span class="warn">Remaining</span>: watchdog/supervisor/dashboard가 같은 policy vocabulary를 쓰도록 통합 필요.</li>
           </ul>
         </div>
@@ -510,14 +510,14 @@ type decision = {
           </tr>
           <tr>
             <td>P0-PIN</td>
-            <td><span class="status doing">draft PR</span></td>
+            <td><span class="status done">merged</span></td>
             <td>Consume the OAS provider-timeout evidence release in MASC's downstream dependency pin.</td>
             <td><code>#16191</code>: <code>scripts/oas-agent-sdk-pin.sh</code>, <code>dune-project</code>, <code>masc_mcp.opam</code>, generated docs and fingerprint</td>
             <td><code>check-oas-pin</code>, <code>oas-drift-check</code>, and generated doc checks pass against OAS <code>main@308152ee</code> (<code>v0.196.1</code>).</td>
           </tr>
           <tr>
             <td>P0-A</td>
-            <td><span class="status doing">in flight</span></td>
+            <td><span class="status done">merged</span></td>
             <td>Existing noisy paths stop killing keepers directly.</td>
             <td><code>keeper_shell_bash.ml</code>, <code>keeper_heartbeat_loop.ml</code>, <code>keeper_turn_slot.ml</code></td>
             <td>workflow rejection skips breaker; OAS timeout strike limit soft-backoffs without crash.</td>
@@ -531,10 +531,10 @@ type decision = {
           </tr>
           <tr>
             <td>P0-C</td>
-            <td><span class="status todo">next</span></td>
+            <td><span class="status doing">draft PR</span></td>
             <td>Migrate heartbeat OAS timeout and transient error paths to policy decisions.</td>
-            <td><code>keeper_heartbeat_loop.ml</code>, <code>keeper_error_classify.ml</code></td>
-            <td><code>oas_timeout_budget</code> cannot raise <code>Keeper_fiber_crash</code> without liveness evidence.</td>
+            <td><code>#16178</code>: <code>keeper_heartbeat_loop.ml</code>, <code>keeper_failure_policy.ml</code>, strike tests</td>
+            <td><code>oas_timeout_budget</code> strike limit routes through policy; <code>stream_idle:streaming_thinking</code> is preserved and cannot allow keeper death without liveness evidence.</td>
           </tr>
           <tr>
             <td>P0-D</td>
@@ -665,7 +665,12 @@ type decision = {
         <tbody>
           <tr>
             <td>2026-05-18</td>
-            <td>Recorded OAS merge and downstream MASC pin draft.</td>
+            <td>Added heartbeat OAS timeout callsite migration status.</td>
+            <td><code>#16178</code>: <code>keeper_heartbeat_loop</code> routes timeout strikes through <code>Keeper_failure_policy</code> and preserves <code>stream_idle:streaming_thinking</code> as non-death evidence.</td>
+          </tr>
+          <tr>
+            <td>2026-05-18</td>
+            <td>Recorded OAS merge and downstream MASC pin merge.</td>
             <td><code>oas#1632</code> merged; <code>#16191</code> bumps <code>agent_sdk</code> to <code>v0.196.1</code> and refreshes timeout evidence fingerprint.</td>
           </tr>
           <tr>

--- a/docs/design/keeper-failure-policy-layer-plan.html
+++ b/docs/design/keeper-failure-policy-layer-plan.html
@@ -265,8 +265,8 @@
         <span>single typed policy layer: failure -> disposition</span>
       </div>
       <div class="tile">
-        <strong>4</strong>
-        <span>분리할 scope: provider, turn, keeper, fleet</span>
+        <strong>5</strong>
+        <span>분리할 scope: invocation, provider, turn, keeper, fleet</span>
       </div>
       <div class="tile">
         <strong>0</strong>
@@ -283,11 +283,11 @@
         operator에게는 모두 "keeper가 막힘/죽음"으로 보인다.
       </p>
       <p>
-        최종 상태는 모든 실패가 먼저 <code>Keeper_failure_policy.classify</code>를 거쳐
+        최종 상태는 모든 실패가 먼저 <code>Keeper_failure_policy.decide</code>를 거쳐
         <code>disposition</code>을 받고, heartbeat/supervisor/watchdog/dashboard는 그 결과만 소비하는 구조다.
       </p>
       <pre>failure evidence
-  -> Keeper_failure_policy.classify
+  -> Keeper_failure_policy.decide
   -> { failure_class; scope; disposition; lifecycle_effect; operator_action; evidence }
   -> runtime action + metrics/logs + dashboard status</pre>
     </section>
@@ -310,6 +310,7 @@
             <li><span class="done">Done / PR</span> <code>#16154</code>: deterministic <code>keeper_bash</code> guard rejection을 <code>workflow_rejection</code>으로 분류해 circuit breaker에서 제외.</li>
             <li><span class="done">Done / PR</span> <code>#16159</code>: repeated <code>oas_timeout_budget</code> strike가 <code>Keeper_fiber_crash</code>로 승격되는 직접 경로 제거.</li>
             <li><span class="doing">Started / OAS PR</span> <code>oas#1632</code>: provider timeout을 <code>stream_idle:streaming_thinking</code>, <code>stream_body</code>, <code>provider_step</code> 같은 typed evidence로 보존.</li>
+            <li><span class="doing">Started / MASC PR</span> <code>#16178</code>: <code>Keeper_failure_policy.decide</code> pure matrix로 Streaming/Thinking timeout과 keeper liveness 결정을 분리.</li>
             <li><span class="warn">Remaining</span>: watchdog/supervisor/dashboard가 같은 policy vocabulary를 쓰도록 통합 필요.</li>
           </ul>
         </div>
@@ -515,10 +516,10 @@ type decision = {
           </tr>
           <tr>
             <td>P0-B</td>
-            <td><span class="status todo">next</span></td>
+            <td><span class="status doing">draft PR</span></td>
             <td>Add <code>Keeper_failure_policy</code> pure module and decision type.</td>
-            <td><code>lib/keeper/keeper_failure_policy.ml</code>, <code>.mli</code>, unit tests</td>
-            <td>matrix test covers workflow, timeout, cascade exhausted, fatal env, stale classes.</td>
+            <td><code>#16178</code>: <code>lib/keeper/keeper_failure_policy.ml</code>, <code>.mli</code>, unit tests</td>
+            <td>matrix test covers <code>stream_idle:streaming_thinking</code>, workflow rejection, OAS budget loop liveness, fatal env, and stale classes.</td>
           </tr>
           <tr>
             <td>P0-C</td>
@@ -654,6 +655,11 @@ type decision = {
           </tr>
         </thead>
         <tbody>
+          <tr>
+            <td>2026-05-18</td>
+            <td>Added P0-B implementation draft.</td>
+            <td><code>#16178</code>: pure <code>Keeper_failure_policy</code> matrix and focused tests for Streaming/Thinking timeout separation.</td>
+          </tr>
           <tr>
             <td>2026-05-18</td>
             <td>Initial living plan created.</td>

--- a/docs/design/keeper-failure-policy-layer-plan.html
+++ b/docs/design/keeper-failure-policy-layer-plan.html
@@ -309,7 +309,8 @@
           <ul>
             <li><span class="done">Done / PR</span> <code>#16154</code>: deterministic <code>keeper_bash</code> guard rejection을 <code>workflow_rejection</code>으로 분류해 circuit breaker에서 제외.</li>
             <li><span class="done">Done / PR</span> <code>#16159</code>: repeated <code>oas_timeout_budget</code> strike가 <code>Keeper_fiber_crash</code>로 승격되는 직접 경로 제거.</li>
-            <li><span class="doing">Started / OAS PR</span> <code>oas#1632</code>: provider timeout을 <code>stream_idle:streaming_thinking</code>, <code>stream_body</code>, <code>provider_step</code> 같은 typed evidence로 보존.</li>
+            <li><span class="done">Done / OAS PR</span> <code>oas#1632</code>: provider timeout을 <code>stream_idle:streaming_thinking</code>, <code>stream_body</code>, <code>provider_step</code> 같은 typed evidence로 보존.</li>
+            <li><span class="doing">Started / MASC PR</span> <code>#16191</code>: downstream OAS pin을 <code>main@308152ee</code> (<code>v0.196.1</code>)로 올리고 API surface fingerprint를 갱신.</li>
             <li><span class="doing">Started / MASC PR</span> <code>#16178</code>: <code>Keeper_failure_policy.decide</code> pure matrix로 Streaming/Thinking timeout과 keeper liveness 결정을 분리.</li>
             <li><span class="warn">Remaining</span>: watchdog/supervisor/dashboard가 같은 policy vocabulary를 쓰도록 통합 필요.</li>
           </ul>
@@ -502,10 +503,17 @@ type decision = {
         <tbody>
           <tr>
             <td>P0-OAS</td>
-            <td><span class="status doing">draft PR</span></td>
+            <td><span class="status done">merged</span></td>
             <td>Expose generic provider timeout/failure evidence before MASC policy consumes it.</td>
             <td><code>oas#1632</code>: <code>Http_client.TimeoutError</code>, <code>Error.Provider</code>, stream idle state</td>
             <td>MASC can distinguish <code>stream_idle:streaming_thinking</code>, <code>stream_body</code>, <code>provider_step</code>, hard quota, capacity, and provider terminal without string parsing.</td>
+          </tr>
+          <tr>
+            <td>P0-PIN</td>
+            <td><span class="status doing">draft PR</span></td>
+            <td>Consume the OAS provider-timeout evidence release in MASC's downstream dependency pin.</td>
+            <td><code>#16191</code>: <code>scripts/oas-agent-sdk-pin.sh</code>, <code>dune-project</code>, <code>masc_mcp.opam</code>, generated docs and fingerprint</td>
+            <td><code>check-oas-pin</code>, <code>oas-drift-check</code>, and generated doc checks pass against OAS <code>main@308152ee</code> (<code>v0.196.1</code>).</td>
           </tr>
           <tr>
             <td>P0-A</td>
@@ -655,6 +663,11 @@ type decision = {
           </tr>
         </thead>
         <tbody>
+          <tr>
+            <td>2026-05-18</td>
+            <td>Recorded OAS merge and downstream MASC pin draft.</td>
+            <td><code>oas#1632</code> merged; <code>#16191</code> bumps <code>agent_sdk</code> to <code>v0.196.1</code> and refreshes timeout evidence fingerprint.</td>
+          </tr>
           <tr>
             <td>2026-05-18</td>
             <td>Added P0-B implementation draft.</td>


### PR DESCRIPTION
## Summary
- add a living HTML plan for the keeper failure policy layer
- define the target failure -> disposition model and taxonomy
- break the implementation into PR-sized work packages with acceptance criteria

## Verification
- git diff --check