### PR TITLE
fix(keeper): preflight sandbox image before docker run

### DIFF
--- a/lib/keeper/keeper_docker_client_real.ml
+++ b/lib/keeper/keeper_docker_client_real.ml
@@ -267,7 +267,9 @@ let run plan =
      so caller-passed [cmd] strings work identically across both
      functions. *)
   let argv =
-    [ "docker"; "run"; "--rm"; "--name"; container_name; image; "sh"; "-lc"; command ]
+    [ "docker"; "run"; "--rm"; "--name"; container_name ]
+    @ Keeper_sandbox_runtime.docker_run_pull_never_args ()
+    @ [ image; "sh"; "-lc"; command ]
   in
   map_status_to_exec_result
     (gated_argv_with_status_split ~timeout_sec ~summary:"keeper docker run (oneshot)" argv)
@@ -395,6 +397,7 @@ let run_detached_argv
   in
   Keeper_sandbox_runtime.docker_command_argv ()
   @ [ "run"; "-d"; "--rm"; "--name"; Keeper_container_name.to_string (P.container_name plan) ]
+  @ Keeper_sandbox_runtime.docker_run_pull_never_args ()
   @ List.concat_map label_arg (P.labels plan @ edge_labels)
   @ user_args (P.user plan)
   @ List.concat_map env_arg (P.env_overrides plan)
@@ -438,6 +441,9 @@ let run_detached (plan : Keeper_sandbox_session_plan.t) =
   | Ok () ->
     let ensure_timeout = session_preflight_timeout_sec () in
     let start_timeout = session_start_timeout_sec () in
+    (match image_present ~image:(Keeper_sandbox_session_plan.image plan) with
+     | Error _ as err -> err
+     | Ok () ->
     (match Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec:ensure_timeout with
      | Error _ ->
        (* docker runtime could not be ensured — daemon-level. *)
@@ -465,5 +471,5 @@ let run_detached (plan : Keeper_sandbox_session_plan.t) =
              class); a future RFC could distinguish. *)
           Error Keeper_docker_client.Daemon_unreachable
         | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _, _ ->
-          Error Keeper_docker_client.Daemon_unreachable))
+          Error Keeper_docker_client.Daemon_unreachable)))
 ;;

--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -69,6 +69,7 @@ let build_docker_argv ~image ~container_name ~base_path ~host_root ~croot
       "--user";
       Printf.sprintf "%d:%d" uid gid;
     ]
+  @ Keeper_sandbox_runtime.docker_run_pull_never_args ()
   @ Keeper_sandbox_runtime.docker_sandbox_env_args
       ~base_path
       ~container_root:croot
@@ -125,11 +126,22 @@ let run_command_in_container_with_status ?turn_sandbox_factory
   else if command_argv = [] then
     Error "run_command_in_container_with_status: command_argv is empty"
   else
+    let head_program =
+      match command_argv with prog :: _ -> prog | [] -> "?"
+    in
     match runtime_opt with
     | Some runtime ->
       Keeper_turn_sandbox_runtime.run_command_with_status
         ~ok_exit_codes runtime ~cwd ~command_argv ~max_bytes ~timeout_sec ()
     | None ->
+      match Keeper_sandbox_runtime.ensure_keeper_sandbox_image_present ~image ~timeout_sec with
+      | Error err ->
+        Error
+          (Printf.sprintf
+             "docker_%s_failed: sandbox_image_missing: %s"
+             head_program
+             err)
+      | Ok () ->
       match Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec with
       | Error err -> Error err
       | Ok seccomp_args ->
@@ -150,9 +162,6 @@ let run_command_in_container_with_status ?turn_sandbox_factory
                 ~summary:"keeper docker read sandboxed command"
                 ~env:(Unix.environment ())
                 ~cwd:(Sys.getcwd ()) ~timeout_sec argv)
-        in
-        let head_program =
-          match command_argv with prog :: _ -> prog | [] -> "?"
         in
         (match st with
          | Unix.WEXITED code

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -126,6 +126,17 @@ let start_managed_container
             if String.trim image = "" then
               Error "keeper sandbox docker image is not configured"
             else
+              match
+                Keeper_sandbox_runtime.ensure_keeper_sandbox_image_present
+                  ~image
+                  ~timeout_sec
+              with
+              | Error err ->
+                  Error
+                    (Printf.sprintf
+                       "docker_container_start_failed: sandbox_image_missing: %s"
+                       err)
+              | Ok () ->
               let _cleanup =
                 Keeper_sandbox_runtime.maybe_cleanup_stale_containers
                   ~base_path:config.base_path
@@ -161,6 +172,7 @@ let start_managed_container
                         "--name";
                         container_name;
                       ]
+                    @ Keeper_sandbox_runtime.docker_run_pull_never_args ()
                     @ Keeper_sandbox_runtime.docker_label_args
                         ~ttl_sec
                         ~base_path:config.base_path

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -34,6 +34,12 @@ let docker_command_argv () =
   | _ -> [ docker_command () ]
 ;;
 
+let docker_run_pull_never_args () = [ "--pull"; "never" ]
+
+let docker_image_missing_next_action =
+  "Run scripts/build-keeper-sandbox-image.sh to build the default keeper sandbox image."
+;;
+
 (* RFC-0107 Phase E step 2 — branch on MASC_DOCKER_TRANSPORT env flag here.
    When set to "api", route through [Sandbox.Docker_api] (UDS HTTP) instead
    of forking a [docker] subprocess; the subprocess path stays as the
@@ -1100,6 +1106,17 @@ let docker_image_present ~image ~timeout_sec =
            (Worker_dev_tools.truncate_for_log out)))
 ;;
 
+let ensure_keeper_sandbox_image_present ~image ~timeout_sec =
+  match docker_image_present ~image ~timeout_sec with
+  | Ok () -> Ok ()
+  | Error message ->
+    Error
+      (Printf.sprintf
+         "%s. Next: %s"
+         message
+         docker_image_missing_next_action)
+;;
+
 let docker_image_required_commands ~image ~timeout_sec =
   let script =
     let quoted = List.map Filename.quote required_commands |> String.concat " " in
@@ -1110,7 +1127,9 @@ let docker_image_required_commands ~image ~timeout_sec =
   in
   let argv =
     docker_command_argv ()
-    @ [ "run"; "--rm"; "--network"; "none"; "--entrypoint"; "sh"; image; "-lc"; script ]
+    @ [ "run"; "--rm" ]
+    @ docker_run_pull_never_args ()
+    @ [ "--network"; "none"; "--entrypoint"; "sh"; image; "-lc"; script ]
   in
   let st, out =
     run_docker_argv_with_status
@@ -1283,10 +1302,7 @@ let docker_preflight ~timeout_sec () =
            Some "Ensure Docker is installed and the daemon is reachable from this shell."
          else None)
       ; (if (not image_present) || missing_commands <> []
-         then
-           Some
-             "Run scripts/build-keeper-sandbox-image.sh to build the default keeper \
-              sandbox image."
+         then Some docker_image_missing_next_action
          else None)
       ; (if not hardening_ok
          then
@@ -1347,14 +1363,12 @@ let ensure_keeper_startup_preflight ~timeout_sec ~sandbox_profile =
         Error
           (Printf.sprintf "Docker sandbox startup preflight failed: %s" message)
       | Ok _ ->
-        (match docker_image_present ~image ~timeout_sec with
+        (match ensure_keeper_sandbox_image_present ~image ~timeout_sec with
          | Ok () -> Ok ()
          | Error message ->
            Error
              (Printf.sprintf
-                "Docker sandbox startup preflight failed: %s. Next: Run \
-                 scripts/build-keeper-sandbox-image.sh to build the default keeper \
-                 sandbox image."
+                "Docker sandbox startup preflight failed: %s"
                 message)))
 ;;
 

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -69,6 +69,14 @@ val docker_command : unit -> string
     handling. *)
 val docker_command_argv : unit -> string list
 
+(** Docker [run] flag fragment that prevents implicit registry pulls. Keeper
+    sandbox images are a local runtime prerequisite and must be built before
+    execution. *)
+val docker_run_pull_never_args : unit -> string list
+
+(** Canonical operator action for a missing keeper sandbox image. *)
+val docker_image_missing_next_action : string
+
 (** Docker [--label] argv fragment for containers owned by the keeper
     sandbox runtime. *)
 val docker_label_args
@@ -310,6 +318,15 @@ val docker_preflight_failure_message : docker_preflight -> string
 val ensure_keeper_startup_preflight
   :  timeout_sec:float
   -> sandbox_profile:Keeper_types.sandbox_profile
+  -> (unit, string) result
+
+(** Lightweight image-presence gate for per-command execution paths. The
+    startup preflight can pass and the image can later be pruned, so docker
+    execution paths call this before [docker run] to fail locally rather than
+    falling through to a registry pull. *)
+val ensure_keeper_sandbox_image_present
+  :  image:string
+  -> timeout_sec:float
   -> (unit, string) result
 
 (** Returns the [--security-opt seccomp=...] argv fragment when the

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -160,15 +160,18 @@ let start_container (t : t) ~(timeout_sec : float) =
   if String.trim image = ""
   then Error "keeper sandbox docker image is not configured"
   else (
-    let _cleanup =
-      Keeper_sandbox_runtime.maybe_cleanup_stale_containers
-        ~base_path:t.config.base_path
-        ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Turn_sandbox ())
-        ()
-    in
-    match Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec with
-    | Error _ as err -> err
-    | Ok seccomp_args ->
+    match Keeper_sandbox_runtime.ensure_keeper_sandbox_image_present ~image ~timeout_sec with
+    | Error err -> Error (Printf.sprintf "docker_container_start_failed: sandbox_image_missing: %s" err)
+    | Ok () ->
+      let _cleanup =
+        Keeper_sandbox_runtime.maybe_cleanup_stale_containers
+          ~base_path:t.config.base_path
+          ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Turn_sandbox ())
+          ()
+      in
+      match Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec with
+      | Error _ as err -> err
+      | Ok seccomp_args ->
       let container_name = container_name_of t in
       let network_args, network_label =
         Keeper_sandbox_runtime.docker_network_args t.network_mode
@@ -184,6 +187,7 @@ let start_container (t : t) ~(timeout_sec : float) =
          let argv =
            Keeper_sandbox_runtime.docker_command_argv ()
            @ [ "run"; "-d"; "--rm"; "--name"; container_name ]
+           @ Keeper_sandbox_runtime.docker_run_pull_never_args ()
            @ Keeper_sandbox_runtime.docker_label_args
                ~base_path:t.config.base_path
                ~keeper_name:t.meta.name

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -404,6 +404,8 @@ let test_run_detached_argv_shape () =
     | [] -> false
   in
   check bool "argv has `run -d --rm --name <derived>`" true (has_run_prefix argv);
+  check bool "argv disables implicit image pulls" true
+    (List.mem "--pull" argv && List.mem "never" argv);
   check bool "owner_pid label = passed pid" true
     (List.mem "masc.mcp.owner_pid=424242" argv);
   check bool "started_at label = %.3f of passed clock" true
@@ -436,12 +438,12 @@ let test_run_detached_returns_typed () =
   match Keeper_docker_client_real.run_detached (sample_session_plan ()) with
   | Ok _ -> () (* daemon present + identity files written + spawn ok *)
   | Error Keeper_docker_client.Daemon_unreachable -> () (* identity-write failure / no daemon / spawn failure *)
-  | Error Keeper_docker_client.Image_pull_failed
+  | Error Keeper_docker_client.Image_pull_failed -> () (* image absent locally *)
   | Error Keeper_docker_client.Container_oom
   | Error Keeper_docker_client.Exec_timeout
   | Error Keeper_docker_client.Probe_format_drift
   | Error Keeper_docker_client.Cleanup_failed ->
-    fail "run_detached should only surface Ok <name> | Daemon_unreachable"
+    fail "run_detached should only surface Ok <name> | Daemon_unreachable | Image_pull_failed"
 ;;
 
 (* ── Functor instantiation works with Real ───────────────────── *)

--- a/test/test_keeper_github_pr.ml
+++ b/test/test_keeper_github_pr.ml
@@ -120,12 +120,16 @@ let fake_docker_echo_script =
    if [ -n \"$log_file\" ]; then\n\
    \  printf '%s\\n' \"$*\" >> \"$log_file\"\n\
    fi\n\
-   if [ \"$1\" = \"info\" ]; then\n\
-   \  printf '[]\\n'\n\
-   \  exit 0\n\
-   fi\n\
-   if [ \"$1\" != \"run\" ]; then\n\
-   \  printf 'unexpected docker invocation: %s\\n' \"$1\" >&2\n\
+	   if [ \"$1\" = \"info\" ]; then\n\
+	   \  printf '[]\\n'\n\
+	   \  exit 0\n\
+	   fi\n\
+	   if [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ] && [ \"$3\" = \"alpine:test\" ]; then\n\
+	   \  printf '[]\\n'\n\
+	   \  exit 0\n\
+	   fi\n\
+	   if [ \"$1\" != \"run\" ]; then\n\
+	   \  printf 'unexpected docker invocation: %s\\n' \"$1\" >&2\n\
    \  exit 2\n\
    fi\n\
    shift\n\

--- a/test/test_keeper_pr_review.ml
+++ b/test/test_keeper_pr_review.ml
@@ -133,6 +133,10 @@ if [ \"$1\" = \"info\" ]; then\n\
   printf '[]\\n'\n\
   exit 0\n\
 fi\n\
+if [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ] && [ \"$3\" = \"alpine:test\" ]; then\n\
+  printf '[]\\n'\n\
+  exit 0\n\
+fi\n\
 if [ \"$1\" != \"run\" ]; then\n\
   printf 'unexpected docker invocation: %s\\n' \"$1\" >&2\n\
   exit 2\n\

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -158,12 +158,20 @@ fi\n\
 cmd=$1\n\
 shift\n\
 case \"$cmd\" in\n\
-  info)\n\
-    printf '[]\\n'\n\
-    exit 0\n\
-    ;;\n\
-  ps)\n\
-    want_kind=''\n\
+	  info)\n\
+	    printf '[]\\n'\n\
+	    exit 0\n\
+	    ;;\n\
+	  image)\n\
+	    if [ \"$1\" = \"inspect\" ] && [ \"$2\" = \"alpine:test\" ]; then\n\
+	      printf '[]\\n'\n\
+	      exit 0\n\
+	    fi\n\
+	    printf 'missing image\\n' >&2\n\
+	    exit 1\n\
+	    ;;\n\
+	  ps)\n\
+	    want_kind=''\n\
     while [ \"$#\" -gt 0 ]; do\n\
       case \"$1\" in\n\
         --filter)\n\
@@ -208,9 +216,9 @@ case \"$cmd\" in\n\
           esac\n\
           shift 2\n\
           ;;\n\
-        --user|--tmpfs|-v|--workdir|--pids-limit|--memory|--network|--security-opt)\n\
-          shift 2\n\
-          ;;\n\
+	        --user|--tmpfs|-v|--workdir|--pids-limit|--memory|--network|--security-opt|--pull)\n\
+	          shift 2\n\
+	          ;;\n\
         -d|--rm|--read-only|--cap-drop=ALL)\n\
           shift\n\
           ;;\n\


### PR DESCRIPTION

## Summary

Fixes #16160.

This makes the keeper Docker sandbox fail before `docker run` when `masc-keeper-sandbox:local` is missing, instead of letting Docker attempt an implicit registry pull and returning the noisy pull-denied failure.

Changes:
- add a shared keeper sandbox image preflight with an explicit next action
- pass `--pull never` on keeper Docker run paths
- apply the preflight to one-shot shell, read fallback, turn runtime, managed sandbox, and direct Docker client paths
- extend fake Docker tests so missing-image behavior is covered without a real daemon

Runtime remediation already applied on this host:
- rebuilt `masc-keeper-sandbox:local`
- verified image inspect reports `sha256:2b13ee36402b064c44302b4ca73b58184f7a03630aa9d02a0cf0a4329aaf48b9`
- `scripts/keeper-sandbox-smoke.sh` passed
- recent keeper logs stopped showing the missing-image / pull-denied signature after rebuild

## Validation

- `opam exec -- ocamlformat --check ...`
- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build test/test_keeper_shell_docker_route.exe test/test_keeper_docker_read.exe test/test_docker_client_real.exe test/test_keeper_pr_review.exe test/test_keeper_github_pr.exe`
- `./_build/default/test/test_keeper_shell_docker_route.exe` (36 tests)
- `./_build/default/test/test_keeper_docker_read.exe` (33 tests)
- `./_build/default/test/test_docker_client_real.exe` (31 tests)
- `./_build/default/test/test_keeper_pr_review.exe` (11 tests)
- `./_build/default/test/test_keeper_github_pr.exe` (13 tests)
- earlier before rebase: `./_build/default/test/test_operator_control.exe` (66 tests, 1082s)
