### PR TITLE
Add keeper failure policy matrix

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -41,6 +41,82 @@ let retry_message_looks_like_model_access_denied (message : string) : bool =
   || String_util.contains_substring_ci message "does not have access to"
   || String_util.contains_substring_ci message "not authorized to access"
 
+let provider_capacity_scope_to_http = function
+  | Llm_provider.Error.CapacityModel -> Llm_provider.Http_client.Failure_scope_model
+  | Llm_provider.Error.CapacityAccount ->
+    Llm_provider.Http_client.Failure_scope_account
+  | Llm_provider.Error.CapacityRegion ->
+    Llm_provider.Http_client.Failure_scope_region
+  | Llm_provider.Error.CapacityProvider ->
+    Llm_provider.Http_client.Failure_scope_provider
+  | Llm_provider.Error.CapacityUnknown ->
+    Llm_provider.Http_client.Failure_scope_unknown
+
+let provider_error_to_http_error (err : Agent_sdk.Error.provider_error)
+  : Llm_provider.Http_client.http_error =
+  let module E = Llm_provider.Error in
+  let message = E.to_string err in
+  match err with
+  | E.MissingApiKey _ | E.InvalidConfig _ ->
+    Llm_provider.Http_client.AcceptRejected { reason = message }
+  | E.ParseError { detail } ->
+    Llm_provider.Http_client.ProviderFailure
+      { kind = Llm_provider.Http_client.Provider_parse_error { parser = None }
+      ; message = detail
+      }
+  | E.UnknownVariant { type_name; value } ->
+    Llm_provider.Http_client.ProviderFailure
+      { kind =
+          Llm_provider.Http_client.Unknown_provider_failure
+            { reason = Some (Printf.sprintf "%s:%s" type_name value) }
+      ; message
+      }
+  | E.ProviderUnavailable { detail; _ } ->
+    Llm_provider.Http_client.HttpError { code = 503; body = detail }
+  | E.RateLimit { detail; _ } ->
+    Llm_provider.Http_client.HttpError { code = 429; body = detail }
+  | E.HardQuota { retry_after; detail; _ } ->
+    Llm_provider.Http_client.ProviderFailure
+      { kind = Llm_provider.Http_client.Hard_quota { retry_after }
+      ; message = detail
+      }
+  | E.CapacityExhausted { scope; affected; retry_after; detail } ->
+    Llm_provider.Http_client.ProviderFailure
+      { kind =
+          Llm_provider.Http_client.Capacity_exhausted
+            { scope = provider_capacity_scope_to_http scope
+            ; retry_after
+            ; model = List.find_opt (fun value -> String.trim value <> "") affected
+            }
+      ; message = detail
+      }
+  | E.AuthError { detail; _ } ->
+    Llm_provider.Http_client.HttpError { code = 401; body = detail }
+  | E.ServerError { code; detail; _ } ->
+    Llm_provider.Http_client.HttpError { code; body = detail }
+  | E.NetworkError { timeout_phase = Some phase; detail; _ } ->
+    Llm_provider.Http_client.TimeoutError { message = detail; phase }
+  | E.NetworkError { kind; timeout_phase = None; detail; _ } ->
+    Llm_provider.Http_client.NetworkError { message = detail; kind }
+  | E.Timeout { timeout_phase; detail; _ } ->
+    let phase =
+      match timeout_phase with
+      | Some phase -> phase
+      | None ->
+        (* DET-OK: OAS provider omitted timeout_phase; Unknown_timeout is an
+           explicit typed sentinel, not a permissive branch heuristic. *)
+        Llm_provider.Http_client.Unknown_timeout
+    in
+    Llm_provider.Http_client.TimeoutError
+      { message = detail; phase }
+  | E.InvalidRequest { reason; _ } ->
+    Llm_provider.Http_client.HttpError { code = 400; body = reason }
+  | E.NotFound { detail; _ } ->
+    Llm_provider.Http_client.HttpError { code = 404; body = detail }
+  | E.ProviderTerminal { reason; detail; _ } ->
+    Llm_provider.Http_client.ProviderTerminal
+      { kind = Llm_provider.Http_client.Other reason; message = detail }
+
 (** Convert an OAS sdk_error into a Cascade_fsm provider_outcome.
     API-level errors and model-capability-dependent agent errors are
     cascadeable (a different provider may succeed).  Structural agent
@@ -103,27 +179,7 @@ let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
     in
     Some (Cascade_fsm.Call_err http_err)
   | Agent_sdk.Error.Provider provider_err ->
-    let should_cascade =
-      Llm_provider.Error.is_retryable provider_err
-      ||
-      match provider_err with
-      | Llm_provider.Error.HardQuota _
-      | Llm_provider.Error.CapacityExhausted _
-      | Llm_provider.Error.ProviderUnavailable _
-      | Llm_provider.Error.ParseError _ ->
-          true
-      | _ -> false
-    in
-    if should_cascade then
-      Some
-        (Cascade_fsm.Call_err
-           (Llm_provider.Http_client.NetworkError
-              {
-                message = Llm_provider.Error.to_string provider_err;
-                kind = Llm_provider.Http_client.Unknown;
-              }))
-    else
-      None
+    Some (Cascade_fsm.Call_err (provider_error_to_http_error provider_err))
   (* Model-capability errors: the next provider may handle these.
      CompletionContractViolation: model returned text when tool_use was
      required — a different model with better tool calling may succeed.
@@ -482,8 +538,8 @@ let sdk_error_is_hard_quota (err : Agent_sdk.Error.sdk_error) : bool =
        message_looks_like_cli_wrapped_hard_quota message
      | None -> false)
   (* Non-Api error families never carry provider-level hard-quota signals. *)
-  | Agent_sdk.Error.Agent _
   | Agent_sdk.Error.Provider _
+  | Agent_sdk.Error.Agent _
   | Agent_sdk.Error.Mcp _
   | Agent_sdk.Error.Config _
   | Agent_sdk.Error.Serialization _
@@ -588,7 +644,6 @@ let sdk_provider_error_to_provider_error = function
   | Llm_provider.Error.NetworkError _
   | Llm_provider.Error.Timeout _ ->
       None
-
 let sdk_error_to_provider_error ~provider err =
   match err with
   | Agent_sdk.Error.Api api_err ->
@@ -663,6 +718,9 @@ let timeout_source_label (err : Agent_sdk.Error.sdk_error) : string =
         String_util.contains_substring_ci message "max_execution_time_s"
     | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout { detail; _ }) ->
         String_util.contains_substring_ci detail "max_execution_time_s"
+    | Agent_sdk.Error.Provider
+        (Llm_provider.Error.NetworkError { timeout_phase = Some _; _ }) ->
+        false
     | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _)
     | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _)
     | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
@@ -681,7 +739,16 @@ let timeout_source_label (err : Agent_sdk.Error.sdk_error) : string =
     | Agent_sdk.Error.A2a _
     | Agent_sdk.Error.Internal _ -> false
   in
-  if is_max_execution_time then provider_label_max_execution_time else label_provider
+  if is_max_execution_time
+  then provider_label_max_execution_time
+  else
+    match err with
+    | Agent_sdk.Error.Provider
+        (Llm_provider.Error.Timeout { timeout_phase = Some phase; _ })
+    | Agent_sdk.Error.Provider
+        (Llm_provider.Error.NetworkError { timeout_phase = Some phase; _ }) ->
+        Llm_provider.Http_client.timeout_phase_to_label phase
+    | _ -> label_provider
 
 let emit_oas_run_timeout_metric ~cascade_name ~provider:_ err =
   match err with
@@ -695,7 +762,9 @@ let emit_oas_run_timeout_metric ~cascade_name ~provider:_ err =
             (label_source, timeout_source_label err);
           ]
         ()
-  | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _) ->
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.Timeout _
+      | Llm_provider.Error.NetworkError { timeout_phase = Some _; _ }) ->
       let cascade_name = provider_label (cascade_name_to_string cascade_name) in
       Prometheus.inc_counter Keeper_metrics.metric_keeper_oas_run_timeout
         ~labels:

--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -366,15 +366,101 @@ let sdk_a2a_error_fields = function
   | Agent_sdk.Error.StoreCapacityExceeded { current; max } ->
     [ "variant", `String "store_capacity_exceeded"
     ; "current", `Int current
-    ; "max", `Int max
+      ; "max", `Int max
+      ]
+;;
+
+let timeout_phase_json = function
+  | Some phase -> `String (Llm_provider.Http_client.timeout_phase_to_label phase)
+  | None -> `Null
+;;
+
+let sdk_provider_error_fields = function
+  | Llm_provider.Error.MissingApiKey { var_name } ->
+    [ "variant", `String "missing_api_key"; "var_name", `String var_name ]
+  | Llm_provider.Error.InvalidConfig { field; detail } ->
+    [ "variant", `String "invalid_config"
+    ; "field", `String field
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.ParseError { detail } ->
+    [ "variant", `String "parse_error"; "detail", `String detail ]
+  | Llm_provider.Error.UnknownVariant { type_name; value } ->
+    [ "variant", `String "unknown_variant"
+    ; "type_name", `String type_name
+    ; "value", `String value
+    ]
+  | Llm_provider.Error.ProviderUnavailable { provider; detail } ->
+    [ "variant", `String "provider_unavailable"
+    ; "provider", `String provider
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.RateLimit { provider; retry_after; detail } ->
+    [ "variant", `String "rate_limit"
+    ; "provider", `String provider
+    ; "retry_after_s", json_float_opt retry_after
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.HardQuota { provider; retry_after; detail } ->
+    [ "variant", `String "hard_quota"
+    ; "provider", `String provider
+    ; "retry_after_s", json_float_opt retry_after
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.CapacityExhausted { scope; affected; retry_after; detail } ->
+    [ "variant", `String "capacity_exhausted"
+    ; "capacity_scope", `String (Llm_provider.Error.capacity_scope_to_string scope)
+    ; "affected", `List (List.map (fun value -> `String value) affected)
+    ; "retry_after_s", json_float_opt retry_after
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.AuthError { provider; detail } ->
+    [ "variant", `String "auth_error"
+    ; "provider", `String provider
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.ServerError { provider; code; transient; detail } ->
+    [ "variant", `String "server_error"
+    ; "provider", `String provider
+    ; "status", `Int code
+    ; "transient", `Bool transient
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.NetworkError { provider; kind; timeout_phase; detail } ->
+    [ "variant", `String "network_error"
+    ; "provider", `String provider
+    ; "network_kind", `String (network_error_kind_to_wire kind)
+    ; "timeout_phase", timeout_phase_json timeout_phase
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.Timeout { provider; timeout_phase; detail } ->
+    [ "variant", `String "timeout"
+    ; "provider", `String provider
+    ; "timeout_phase", timeout_phase_json timeout_phase
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.InvalidRequest { provider; reason } ->
+    [ "variant", `String "invalid_request"
+    ; "provider", `String provider
+    ; "reason", `String reason
+    ]
+  | Llm_provider.Error.NotFound { provider; detail } ->
+    [ "variant", `String "not_found"
+    ; "provider", `String provider
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.ProviderTerminal { provider; reason; detail } ->
+    [ "variant", `String "provider_terminal"
+    ; "provider", `String provider
+    ; "reason", `String reason
+    ; "detail", `String detail
     ]
 ;;
 
 let sdk_error_detail_fields (error : Agent_sdk.Error.sdk_error) =
   match error with
   | Agent_sdk.Error.Api error -> sdk_api_error_fields error
-  | Agent_sdk.Error.Provider error ->
-    [ "variant", `String "provider"; "message", `String (Llm_provider.Error.to_string error) ]
+  | Agent_sdk.Error.Provider error -> sdk_provider_error_fields error
   | Agent_sdk.Error.Agent error -> sdk_agent_error_fields error
   | Agent_sdk.Error.Mcp error -> sdk_mcp_error_fields error
   | Agent_sdk.Error.Config error -> sdk_config_error_fields error

--- a/lib/cascade/cascade_health_filter.ml
+++ b/lib/cascade/cascade_health_filter.ml
@@ -40,6 +40,7 @@ type cascade_failure_class =
   | Cli_transport_required
   | Tls_error
   | Network_error
+  | Provider_timeout
   | Provider_terminal
   | Provider_capacity_exhausted
   | Provider_hard_quota

--- a/lib/cascade/cascade_health_filter.mli
+++ b/lib/cascade/cascade_health_filter.mli
@@ -35,6 +35,7 @@ type cascade_failure_class =
   | Cli_transport_required
   | Tls_error
   | Network_error
+  | Provider_timeout
   | Provider_terminal
   | Provider_capacity_exhausted
   | Provider_hard_quota

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -72,7 +72,9 @@ type sdk_termination_semantics =
 
 let sdk_termination_semantics = function
   | Agent_sdk.Error.Api (Agent_sdk.Retry.Timeout _) -> Provider_wall_clock_timeout
-  | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _) ->
+  | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _)
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.NetworkError { timeout_phase = Some _; _ }) ->
     Provider_wall_clock_timeout
   | Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded _) ->
     Oas_turn_budget_exhausted
@@ -182,10 +184,56 @@ let agent_error_terminal_reason_code = function
     Printf.sprintf "agent_error_tripwire_violation:tripwire=%s" tripwire
 ;;
 
+let network_error_kind_to_wire = function
+  | Llm_provider.Http_client.Connection_refused -> "connection_refused"
+  | Llm_provider.Http_client.Dns_failure -> "dns_failure"
+  | Llm_provider.Http_client.Tls_error -> "tls_error"
+  | Llm_provider.Http_client.Timeout -> "timeout"
+  | Llm_provider.Http_client.Local_resource_exhaustion -> "local_resource_exhaustion"
+  | Llm_provider.Http_client.End_of_file -> "end_of_file"
+  | Llm_provider.Http_client.Unknown -> "unknown"
+;;
+
+let provider_timeout_suffix = function
+  | None -> ""
+  | Some phase ->
+    ":" ^ Llm_provider.Http_client.timeout_phase_to_label phase
+;;
+
+let provider_error_terminal_reason_code = function
+  | Llm_provider.Error.MissingApiKey _ -> "provider_error_missing_api_key"
+  | Llm_provider.Error.InvalidConfig { field; _ } ->
+    Printf.sprintf "provider_error_invalid_config:%s" field
+  | Llm_provider.Error.ParseError _ -> "provider_error_parse"
+  | Llm_provider.Error.UnknownVariant { type_name; _ } ->
+    Printf.sprintf "provider_error_unknown_variant:%s" type_name
+  | Llm_provider.Error.ProviderUnavailable _ -> "provider_error_unavailable"
+  | Llm_provider.Error.RateLimit _ -> "provider_error_rate_limited"
+  | Llm_provider.Error.HardQuota _ -> "provider_error_hard_quota"
+  | Llm_provider.Error.CapacityExhausted { scope; _ } ->
+    Printf.sprintf
+      "provider_error_capacity_exhausted:%s"
+      (Llm_provider.Error.capacity_scope_to_string scope)
+  | Llm_provider.Error.AuthError _ -> "provider_error_auth"
+  | Llm_provider.Error.ServerError { code; _ } ->
+    Printf.sprintf "provider_error_server:%d" code
+  | Llm_provider.Error.NetworkError { kind; timeout_phase; _ } ->
+    Printf.sprintf
+      "provider_error_network:%s%s"
+      (network_error_kind_to_wire kind)
+      (provider_timeout_suffix timeout_phase)
+  | Llm_provider.Error.Timeout { timeout_phase; _ } ->
+    "provider_error_timeout" ^ provider_timeout_suffix timeout_phase
+  | Llm_provider.Error.InvalidRequest _ -> "provider_error_invalid_request"
+  | Llm_provider.Error.NotFound _ -> "provider_error_not_found"
+  | Llm_provider.Error.ProviderTerminal { reason; _ } ->
+    Printf.sprintf "provider_error_terminal:%s" reason
+;;
+
 let terminal_reason_code_of_sdk_error = function
   | Agent_sdk.Error.Agent err -> agent_error_terminal_reason_code err
   | Agent_sdk.Error.Api err -> api_error_terminal_reason_code err
-  | Agent_sdk.Error.Provider _ -> "provider_error"
+  | Agent_sdk.Error.Provider err -> provider_error_terminal_reason_code err
   | Agent_sdk.Error.Mcp _ -> "mcp_error"
   | Agent_sdk.Error.Config _ -> "config_error"
   | Agent_sdk.Error.Serialization _ -> "serialization_error"

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -71,6 +71,8 @@ let is_transient_network_error (err : Agent_sdk.Error.sdk_error) : bool =
       not (is_structural_oas_timeout_message detail)
   | Agent_sdk.Error.Api (Overloaded _) -> true
   | Agent_sdk.Error.Api (ServerError { status = 503; _ }) -> true
+  | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { transient; _ }) ->
+      transient
   (* Non-transient API errors. *)
   | Agent_sdk.Error.Api (ServerError _)
   | Agent_sdk.Error.Api (RateLimited _)
@@ -402,10 +404,11 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
              Some Auth_error
          | Agent_sdk.Error.Provider (Llm_provider.Error.RateLimit _) ->
              Some Rate_limit
-         | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code; _ })
-           when code >= 500 ->
+         | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code; transient; _ })
+           when transient || code >= 500 ->
              Some Server_error
-         | Agent_sdk.Error.Provider (Llm_provider.Error.AuthError _) ->
+         | Agent_sdk.Error.Provider
+             (Llm_provider.Error.AuthError _ | Llm_provider.Error.MissingApiKey _) ->
              Some Auth_error
          (* Sub-500 server errors (4xx already handled above for AuthError /
             RateLimited) are not classified as recoverable cascade failures. *)
@@ -655,7 +658,10 @@ let reclassify_error_after_side_effect
     let is_timeout =
       match err with
       | Agent_sdk.Error.Api (Timeout _) -> true
-      | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _) -> true
+      | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _)
+      | Agent_sdk.Error.Provider
+          (Llm_provider.Error.NetworkError { timeout_phase = Some _; _ }) ->
+          true
       | Agent_sdk.Error.Api (RateLimited _)
       | Agent_sdk.Error.Api (Overloaded _)
       | Agent_sdk.Error.Api (ServerError _)
@@ -681,7 +687,9 @@ let reclassify_error_after_side_effect
 let post_commit_failure_kind_of_error (err : Agent_sdk.Error.sdk_error) =
   match err with
   | Agent_sdk.Error.Api (Timeout _) -> Keeper_registry.Post_commit_timeout
-  | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _) ->
+  | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _)
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.NetworkError { timeout_phase = Some _; _ }) ->
       Keeper_registry.Post_commit_timeout
   (* All non-Timeout failures classify as generic post-commit failure. *)
   | Agent_sdk.Error.Api (RateLimited _)

--- a/lib/keeper/keeper_failure_policy.ml
+++ b/lib/keeper/keeper_failure_policy.ml
@@ -1,0 +1,370 @@
+type stream_idle_state =
+  | Awaiting_first_event
+  | Awaiting_first_delta
+  | Streaming_answer
+  | Streaming_thinking
+  | Streaming_tool_call
+  | Streaming_heartbeat
+  | Streaming_substrate
+  | Streaming_done
+  | Streaming_unknown
+
+let stream_idle_state_to_label = function
+  | Awaiting_first_event -> "awaiting_first_event"
+  | Awaiting_first_delta -> "awaiting_first_delta"
+  | Streaming_answer -> "streaming_answer"
+  | Streaming_thinking -> "streaming_thinking"
+  | Streaming_tool_call -> "streaming_tool_call"
+  | Streaming_heartbeat -> "streaming_heartbeat"
+  | Streaming_substrate -> "streaming_substrate"
+  | Streaming_done -> "streaming_done"
+  | Streaming_unknown -> "streaming_unknown"
+;;
+
+let stream_idle_state_of_label = function
+  | "awaiting_first_event" -> Some Awaiting_first_event
+  | "awaiting_first_delta" -> Some Awaiting_first_delta
+  | "streaming_answer" -> Some Streaming_answer
+  | "streaming_thinking" -> Some Streaming_thinking
+  | "streaming_tool_call" -> Some Streaming_tool_call
+  | "streaming_heartbeat" -> Some Streaming_heartbeat
+  | "streaming_substrate" -> Some Streaming_substrate
+  | "streaming_done" -> Some Streaming_done
+  | "streaming_unknown" -> Some Streaming_unknown
+  | _ -> None
+;;
+
+let stream_idle_state_is_activity = function
+  | Streaming_answer
+  | Streaming_thinking
+  | Streaming_tool_call
+  | Streaming_heartbeat
+  | Streaming_substrate -> true
+  | Awaiting_first_event
+  | Awaiting_first_delta
+  | Streaming_done
+  | Streaming_unknown -> false
+;;
+
+type timeout_phase =
+  | Http_operation
+  | Non_streaming_body
+  | Stream_body
+  | Stream_idle of stream_idle_state
+  | Provider_step
+  | Cli_stdout_idle
+  | Caller_budget
+  | Unknown_timeout
+
+let timeout_phase_to_label = function
+  | Http_operation -> "http_operation"
+  | Non_streaming_body -> "non_streaming_body"
+  | Stream_body -> "stream_body"
+  | Stream_idle state -> "stream_idle:" ^ stream_idle_state_to_label state
+  | Provider_step -> "provider_step"
+  | Cli_stdout_idle -> "cli_stdout_idle"
+  | Caller_budget -> "caller_budget"
+  | Unknown_timeout -> "unknown_timeout"
+;;
+
+let timeout_phase_of_label label =
+  let label = String.trim label in
+  let stream_idle_prefix = "stream_idle:" in
+  if String.starts_with ~prefix:stream_idle_prefix label
+  then
+    let prefix_len = String.length stream_idle_prefix in
+    String.sub label prefix_len (String.length label - prefix_len)
+    |> stream_idle_state_of_label
+    |> Option.map (fun state -> Stream_idle state)
+  else
+    match label with
+    | "http_operation" -> Some Http_operation
+    | "non_streaming_body" -> Some Non_streaming_body
+    | "stream_body" -> Some Stream_body
+    | "provider_step" -> Some Provider_step
+    | "cli_stdout_idle" -> Some Cli_stdout_idle
+    | "caller_budget" -> Some Caller_budget
+    | "unknown_timeout" -> Some Unknown_timeout
+    | _ -> None
+;;
+
+let timeout_phase_is_streaming_activity = function
+  | Stream_idle state -> stream_idle_state_is_activity state
+  | Http_operation
+  | Non_streaming_body
+  | Stream_body
+  | Provider_step
+  | Cli_stdout_idle
+  | Caller_budget
+  | Unknown_timeout -> false
+;;
+
+type liveness_evidence =
+  | Recent_heartbeat
+  | In_turn_progress
+  | Watchdog_stale
+  | No_recent_heartbeat
+  | Unknown_liveness
+
+type failure =
+  | Workflow_rejection of { rule_id : string option }
+  | Provider_timeout of
+      { phase : timeout_phase option
+      ; liveness : liveness_evidence
+      }
+  | Oas_timeout_budget of
+      { phase : timeout_phase option
+      ; strikes : int option
+      ; liveness : liveness_evidence
+      }
+  | Transient_provider_failure
+  | Cascade_exhausted of { retryable : bool }
+  | Required_tool_contract_violation
+  | Fatal_environment of { detail : string option }
+  | Stale_turn of { progress_seen : bool }
+  | Stale_termination_storm of { count : int }
+  | Ambiguous_partial_commit
+
+type failure_scope =
+  | Invocation_scope
+  | Provider_scope
+  | Turn_scope
+  | Keeper_liveness_scope
+  | Fleet_scope
+
+type lifecycle_effect =
+  | Keep_running
+  | Soft_fail_turn
+  | Pause_current_work
+  | Force_release_turn
+  | Pause_keeper
+  | Restart_keeper
+
+type circuit_effect =
+  | Skip_circuit
+  | Count_for_circuit
+  | Provider_cooldown
+  | Operator_breaker
+
+type operator_action =
+  | No_operator_action
+  | Fix_invocation
+  | Inspect_provider_stream
+  | Inspect_timeout_budget
+  | Reroute_or_tune_provider
+  | Inspect_required_tool_contract
+  | Reconcile_partial_commit
+  | Inspect_keeper_liveness
+  | Fix_runtime_environment
+
+type decision =
+  { failure_scope : failure_scope
+  ; lifecycle_effect : lifecycle_effect
+  ; circuit_effect : circuit_effect
+  ; operator_action : operator_action
+  ; keeper_death_allowed : bool
+  ; reason : string
+  }
+
+let failure_scope_to_label = function
+  | Invocation_scope -> "invocation"
+  | Provider_scope -> "provider"
+  | Turn_scope -> "turn"
+  | Keeper_liveness_scope -> "keeper_liveness"
+  | Fleet_scope -> "fleet"
+;;
+
+let lifecycle_effect_to_label = function
+  | Keep_running -> "keep_running"
+  | Soft_fail_turn -> "soft_fail_turn"
+  | Pause_current_work -> "pause_current_work"
+  | Force_release_turn -> "force_release_turn"
+  | Pause_keeper -> "pause_keeper"
+  | Restart_keeper -> "restart_keeper"
+;;
+
+let circuit_effect_to_label = function
+  | Skip_circuit -> "skip_circuit"
+  | Count_for_circuit -> "count_for_circuit"
+  | Provider_cooldown -> "provider_cooldown"
+  | Operator_breaker -> "operator_breaker"
+;;
+
+let operator_action_to_label = function
+  | No_operator_action -> "none"
+  | Fix_invocation -> "fix_invocation"
+  | Inspect_provider_stream -> "inspect_provider_stream"
+  | Inspect_timeout_budget -> "inspect_timeout_budget"
+  | Reroute_or_tune_provider -> "reroute_or_tune_provider"
+  | Inspect_required_tool_contract -> "inspect_required_tool_contract"
+  | Reconcile_partial_commit -> "reconcile_partial_commit"
+  | Inspect_keeper_liveness -> "inspect_keeper_liveness"
+  | Fix_runtime_environment -> "fix_runtime_environment"
+;;
+
+let make_decision
+      ~failure_scope
+      ~lifecycle_effect
+      ~circuit_effect
+      ~operator_action
+      ~keeper_death_allowed
+      ~reason
+  =
+  { failure_scope
+  ; lifecycle_effect
+  ; circuit_effect
+  ; operator_action
+  ; keeper_death_allowed
+  ; reason
+  }
+;;
+
+let liveness_is_lost = function
+  | Watchdog_stale | No_recent_heartbeat -> true
+  | Recent_heartbeat | In_turn_progress | Unknown_liveness -> false
+;;
+
+let oas_budget_loop_effect ~strikes ~liveness =
+  match strikes with
+  | Some n when n >= 3 && liveness_is_lost liveness ->
+    Pause_keeper, Operator_breaker, Inspect_keeper_liveness, "oas_timeout_budget_liveness_lost"
+  | Some n when n >= 3 ->
+    Pause_current_work, Provider_cooldown, Reroute_or_tune_provider, "oas_timeout_budget_loop"
+  | _ -> Soft_fail_turn, Provider_cooldown, Inspect_timeout_budget, "oas_timeout_budget"
+;;
+
+let decide = function
+  | Workflow_rejection { rule_id } ->
+    let reason =
+      match rule_id with
+      | Some rule_id -> "workflow_rejection:" ^ rule_id
+      | None -> "workflow_rejection"
+    in
+    make_decision
+      ~failure_scope:Invocation_scope
+      ~lifecycle_effect:Keep_running
+      ~circuit_effect:Skip_circuit
+      ~operator_action:Fix_invocation
+      ~keeper_death_allowed:false
+      ~reason
+  | Provider_timeout { phase = Some (Stream_idle state); liveness = _ } ->
+    let has_activity = stream_idle_state_is_activity state in
+    make_decision
+      ~failure_scope:Provider_scope
+      ~lifecycle_effect:Soft_fail_turn
+      ~circuit_effect:Provider_cooldown
+      ~operator_action:Inspect_provider_stream
+      ~keeper_death_allowed:false
+      ~reason:
+        (if has_activity
+         then "provider_stream_idle_active:" ^ stream_idle_state_to_label state
+         else "provider_stream_idle:" ^ stream_idle_state_to_label state)
+  | Provider_timeout { phase; liveness = _ } ->
+    let reason =
+      match phase with
+      | Some phase -> "provider_timeout:" ^ timeout_phase_to_label phase
+      | None -> "provider_timeout"
+    in
+    make_decision
+      ~failure_scope:Provider_scope
+      ~lifecycle_effect:Soft_fail_turn
+      ~circuit_effect:Provider_cooldown
+      ~operator_action:Inspect_timeout_budget
+      ~keeper_death_allowed:false
+      ~reason
+  | Oas_timeout_budget { phase; strikes; liveness } ->
+    let lifecycle_effect, circuit_effect, operator_action, reason =
+      oas_budget_loop_effect ~strikes ~liveness
+    in
+    let reason =
+      match phase with
+      | Some phase -> reason ^ ":" ^ timeout_phase_to_label phase
+      | None -> reason
+    in
+    make_decision
+      ~failure_scope:Turn_scope
+      ~lifecycle_effect
+      ~circuit_effect
+      ~operator_action
+      ~keeper_death_allowed:false
+      ~reason
+  | Transient_provider_failure ->
+    make_decision
+      ~failure_scope:Provider_scope
+      ~lifecycle_effect:Soft_fail_turn
+      ~circuit_effect:Provider_cooldown
+      ~operator_action:Reroute_or_tune_provider
+      ~keeper_death_allowed:false
+      ~reason:"transient_provider_failure"
+  | Cascade_exhausted { retryable = true } ->
+    make_decision
+      ~failure_scope:Provider_scope
+      ~lifecycle_effect:Soft_fail_turn
+      ~circuit_effect:Provider_cooldown
+      ~operator_action:Reroute_or_tune_provider
+      ~keeper_death_allowed:false
+      ~reason:"cascade_exhausted_retryable"
+  | Cascade_exhausted { retryable = false } ->
+    make_decision
+      ~failure_scope:Turn_scope
+      ~lifecycle_effect:Pause_current_work
+      ~circuit_effect:Operator_breaker
+      ~operator_action:Reroute_or_tune_provider
+      ~keeper_death_allowed:false
+      ~reason:"cascade_exhausted_terminal"
+  | Required_tool_contract_violation ->
+    make_decision
+      ~failure_scope:Turn_scope
+      ~lifecycle_effect:Pause_current_work
+      ~circuit_effect:Skip_circuit
+      ~operator_action:Inspect_required_tool_contract
+      ~keeper_death_allowed:false
+      ~reason:"required_tool_contract_violation"
+  | Fatal_environment { detail } ->
+    let reason =
+      match detail with
+      | Some detail -> "fatal_environment:" ^ detail
+      | None -> "fatal_environment"
+    in
+    make_decision
+      ~failure_scope:Keeper_liveness_scope
+      ~lifecycle_effect:Restart_keeper
+      ~circuit_effect:Operator_breaker
+      ~operator_action:Fix_runtime_environment
+      ~keeper_death_allowed:true
+      ~reason
+  | Stale_turn { progress_seen = true } ->
+    make_decision
+      ~failure_scope:Turn_scope
+      ~lifecycle_effect:Force_release_turn
+      ~circuit_effect:Operator_breaker
+      ~operator_action:Inspect_timeout_budget
+      ~keeper_death_allowed:false
+      ~reason:"stale_turn_with_progress"
+  | Stale_turn { progress_seen = false } ->
+    make_decision
+      ~failure_scope:Keeper_liveness_scope
+      ~lifecycle_effect:Restart_keeper
+      ~circuit_effect:Operator_breaker
+      ~operator_action:Inspect_keeper_liveness
+      ~keeper_death_allowed:true
+      ~reason:"stale_turn_no_progress"
+  | Stale_termination_storm { count } ->
+    make_decision
+      ~failure_scope:Fleet_scope
+      ~lifecycle_effect:Pause_keeper
+      ~circuit_effect:Operator_breaker
+      ~operator_action:Inspect_keeper_liveness
+      ~keeper_death_allowed:false
+      ~reason:("stale_termination_storm:" ^ string_of_int count)
+  | Ambiguous_partial_commit ->
+    make_decision
+      ~failure_scope:Turn_scope
+      ~lifecycle_effect:Pause_current_work
+      ~circuit_effect:Operator_breaker
+      ~operator_action:Reconcile_partial_commit
+      ~keeper_death_allowed:false
+      ~reason:"ambiguous_partial_commit"
+;;
+
+let should_kill_keeper decision = decision.keeper_death_allowed

--- a/lib/keeper/keeper_failure_policy.mli
+++ b/lib/keeper/keeper_failure_policy.mli
@@ -1,0 +1,111 @@
+(** Keeper_failure_policy -- pure keeper failure ownership matrix.
+
+    This module answers one question before any supervisor side effect:
+    "does this failure belong to a tool invocation, provider call, turn,
+    keeper liveness, or the fleet?"  It deliberately keeps provider and
+    OAS timeout evidence separate from keeper lifecycle decisions so a
+    streaming/thinking timeout cannot be treated as a dead keeper. *)
+
+type stream_idle_state =
+  | Awaiting_first_event
+  | Awaiting_first_delta
+  | Streaming_answer
+  | Streaming_thinking
+  | Streaming_tool_call
+  | Streaming_heartbeat
+  | Streaming_substrate
+  | Streaming_done
+  | Streaming_unknown
+
+val stream_idle_state_to_label : stream_idle_state -> string
+val stream_idle_state_of_label : string -> stream_idle_state option
+val stream_idle_state_is_activity : stream_idle_state -> bool
+
+type timeout_phase =
+  | Http_operation
+  | Non_streaming_body
+  | Stream_body
+  | Stream_idle of stream_idle_state
+  | Provider_step
+  | Cli_stdout_idle
+  | Caller_budget
+  | Unknown_timeout
+
+val timeout_phase_to_label : timeout_phase -> string
+val timeout_phase_of_label : string -> timeout_phase option
+val timeout_phase_is_streaming_activity : timeout_phase -> bool
+
+type liveness_evidence =
+  | Recent_heartbeat
+  | In_turn_progress
+  | Watchdog_stale
+  | No_recent_heartbeat
+  | Unknown_liveness
+
+type failure =
+  | Workflow_rejection of { rule_id : string option }
+  | Provider_timeout of
+      { phase : timeout_phase option
+      ; liveness : liveness_evidence
+      }
+  | Oas_timeout_budget of
+      { phase : timeout_phase option
+      ; strikes : int option
+      ; liveness : liveness_evidence
+      }
+  | Transient_provider_failure
+  | Cascade_exhausted of { retryable : bool }
+  | Required_tool_contract_violation
+  | Fatal_environment of { detail : string option }
+  | Stale_turn of { progress_seen : bool }
+  | Stale_termination_storm of { count : int }
+  | Ambiguous_partial_commit
+
+type failure_scope =
+  | Invocation_scope
+  | Provider_scope
+  | Turn_scope
+  | Keeper_liveness_scope
+  | Fleet_scope
+
+type lifecycle_effect =
+  | Keep_running
+  | Soft_fail_turn
+  | Pause_current_work
+  | Force_release_turn
+  | Pause_keeper
+  | Restart_keeper
+
+type circuit_effect =
+  | Skip_circuit
+  | Count_for_circuit
+  | Provider_cooldown
+  | Operator_breaker
+
+type operator_action =
+  | No_operator_action
+  | Fix_invocation
+  | Inspect_provider_stream
+  | Inspect_timeout_budget
+  | Reroute_or_tune_provider
+  | Inspect_required_tool_contract
+  | Reconcile_partial_commit
+  | Inspect_keeper_liveness
+  | Fix_runtime_environment
+
+type decision =
+  { failure_scope : failure_scope
+  ; lifecycle_effect : lifecycle_effect
+  ; circuit_effect : circuit_effect
+  ; operator_action : operator_action
+  ; keeper_death_allowed : bool
+  ; reason : string
+  }
+
+val decide : failure -> decision
+val should_kill_keeper : decision -> bool
+
+val failure_scope_to_label : failure_scope -> string
+val lifecycle_effect_to_label : lifecycle_effect -> string
+val circuit_effect_to_label : circuit_effect -> string
+val operator_action_to_label : operator_action -> string

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -746,7 +746,7 @@ let run_keeper_cycle_with_slot
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_oas_timeout_budget_strike
           ~labels:[ "keeper", keeper_name; "outcome", metric_outcome ]
-          ());
+          ()));
     (match read_meta ctx.config meta_after_cursor_persist.name with
      | Ok (Some latest) -> latest
      | Ok None ->

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -539,6 +539,57 @@ let is_oas_timeout_budget_error (err : Agent_sdk.Error.sdk_error) =
     false
 ;;
 
+let timeout_phase_of_oas_timeout_budget_phase phase =
+  let phase = String.trim phase in
+  if String.equal phase ""
+  then None
+  else (
+    match Keeper_failure_policy.timeout_phase_of_label phase with
+    | Some phase -> Some phase
+    | None -> Some Keeper_failure_policy.Unknown_timeout)
+;;
+
+let oas_timeout_budget_policy_decision
+      ~(strikes : int)
+      (err : Agent_sdk.Error.sdk_error)
+  : Keeper_failure_policy.decision option
+  =
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some (Keeper_turn_driver.Oas_timeout_budget { phase; _ }) ->
+    Some
+      (Keeper_failure_policy.decide
+         (Keeper_failure_policy.Oas_timeout_budget
+            { phase = timeout_phase_of_oas_timeout_budget_phase phase
+            ; strikes = Some strikes
+            ; liveness = Keeper_failure_policy.Recent_heartbeat
+            }))
+  | Some
+      ( Keeper_turn_driver.Cascade_exhausted _
+      | Keeper_turn_driver.Resumable_cli_session _
+      | Keeper_turn_driver.No_tool_capable_provider _
+      | Keeper_turn_driver.Accept_rejected _
+      | Keeper_turn_driver.Admission_queue_timeout _
+      | Keeper_turn_driver.Admission_queue_rejected _
+      | Keeper_turn_driver.Turn_timeout _
+      | Keeper_turn_driver.Max_tokens_ceiling_violation _
+      | Keeper_turn_driver.Ambiguous_post_commit _ )
+  | None ->
+    None
+;;
+
+let oas_timeout_budget_metric_outcome
+      (decision : Keeper_failure_policy.decision)
+  =
+  match decision.lifecycle_effect with
+  | Keeper_failure_policy.Keep_running
+  | Keeper_failure_policy.Soft_fail_turn -> "warn"
+  | Keeper_failure_policy.Pause_current_work -> "soft_backoff"
+  | Keeper_failure_policy.Force_release_turn -> "force_release"
+  | Keeper_failure_policy.Pause_keeper -> "pause"
+  | Keeper_failure_policy.Restart_keeper ->
+    if Keeper_failure_policy.should_kill_keeper decision then "promote" else "restart"
+;;
+
 let persist_message_cursor_updates ~config (meta : keeper_meta) updates =
   let updated = Keeper_world_observation.apply_message_cursor_updates meta updates in
   if updates = []
@@ -641,28 +692,60 @@ let run_keeper_cycle_with_slot
         keeper_name
         (Some (Keeper_registry.Oas_timeout_budget_loop { count = strikes }));
       record_oas_timeout_budget_observation ~base_path:ctx.config.base_path ~keeper_name;
-      match Keeper_turn_slot.classify_oas_timeout_budget_strike ~strikes with
-      | Keeper_turn_slot.Oas_timeout_budget_soft_backoff ->
-        Log.Keeper.warn
-          "%s: %d consecutive oas_timeout_budget strikes (>= %d) -- keeping keeper \
-           fiber alive; provider/cascade cooldown and retry backoff remain active"
+      let decision =
+        match oas_timeout_budget_policy_decision ~strikes err with
+        | Some decision -> decision
+        | None ->
+          Keeper_failure_policy.decide
+            (Keeper_failure_policy.Oas_timeout_budget
+               { phase = None
+               ; strikes = Some strikes
+               ; liveness = Keeper_failure_policy.Recent_heartbeat
+               })
+      in
+      let metric_outcome = oas_timeout_budget_metric_outcome decision in
+      if Keeper_failure_policy.should_kill_keeper decision
+      then (
+        Log.Keeper.error
+          "%s: %d consecutive oas_timeout_budget strikes -- policy allows keeper \
+           death (lifecycle=%s circuit=%s reason=%s)"
           keeper_name
           strikes
-          Keeper_turn_slot.oas_timeout_budget_strike_limit;
+          (Keeper_failure_policy.lifecycle_effect_to_label decision.lifecycle_effect)
+          (Keeper_failure_policy.circuit_effect_to_label decision.circuit_effect)
+          decision.reason;
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_oas_timeout_budget_strike
-          ~labels:[ "keeper", keeper_name; "outcome", "soft_backoff" ]
-          ()
-      | Keeper_turn_slot.Oas_timeout_budget_warn ->
+          ~labels:[ "keeper", keeper_name; "outcome", metric_outcome ]
+          ();
+        Keeper_turn_slot.reset_budget_exhaustion ~keeper_name;
+        raise Keeper_registry.Keeper_fiber_crash)
+      else if strikes >= Keeper_turn_slot.oas_timeout_budget_strike_limit
+      then (
         Log.Keeper.warn
-          "%s: oas_timeout_budget strike %d/%d (keeper stays alive; repeated strikes \
-           escalate only to soft backoff)"
+          "%s: %d consecutive oas_timeout_budget strikes (>= %d) -- policy=%s \
+           lifecycle=%s circuit=%s; keeping keeper alive"
           keeper_name
           strikes
-          Keeper_turn_slot.oas_timeout_budget_strike_limit;
+          Keeper_turn_slot.oas_timeout_budget_strike_limit
+          decision.reason
+          (Keeper_failure_policy.lifecycle_effect_to_label decision.lifecycle_effect)
+          (Keeper_failure_policy.circuit_effect_to_label decision.circuit_effect);
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_oas_timeout_budget_strike
-          ~labels:[ "keeper", keeper_name; "outcome", "warn" ]
+          ~labels:[ "keeper", keeper_name; "outcome", metric_outcome ]
+          ())
+      else (
+        Log.Keeper.warn
+          "%s: oas_timeout_budget strike %d/%d (policy=%s lifecycle=%s)"
+          keeper_name
+          strikes
+          Keeper_turn_slot.oas_timeout_budget_strike_limit
+          decision.reason
+          (Keeper_failure_policy.lifecycle_effect_to_label decision.lifecycle_effect);
+        Prometheus.inc_counter
+          Keeper_metrics.metric_keeper_oas_timeout_budget_strike
+          ~labels:[ "keeper", keeper_name; "outcome", metric_outcome ]
           ());
     (match read_meta ctx.config meta_after_cursor_persist.name with
      | Ok (Some latest) -> latest

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -99,6 +99,12 @@ val oas_timeout_budget_observation_reasons : string list
 val record_oas_timeout_budget_observation :
   base_path:string -> keeper_name:string -> unit
 
+val oas_timeout_budget_policy_decision :
+  strikes:int -> Agent_sdk.Error.sdk_error -> Keeper_failure_policy.decision option
+(** Return the policy decision for a structured [Oas_timeout_budget] error.
+    This heartbeat-loop path is reached after the keeper turn returned, so
+    timeout evidence is not liveness loss by itself. *)
+
 val persist_message_cursor_updates :
   config:Coord.config -> keeper_meta -> (string * int) list -> keeper_meta
 (** Persist room-message cursor updates immediately after observation.

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -197,13 +197,13 @@ val set_after_acquire_flag_hook_for_test :
   (label:string -> keeper_name:string -> unit) option -> unit
 
 (** PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
-    per keeper. Crossing [oas_timeout_budget_strike_limit] emits a
-    soft-backoff signal and must not kill the keeper fiber; reset on any
-    successful turn.
+    per keeper. The heartbeat loop routes the count through
+    [Keeper_failure_policy] instead of treating the limit as keeper death.
+    Reset on any successful turn.
     The in-process CAS map survives within a server lifetime. After
     restart, callers may hydrate the first bump from persisted
     [Oas_timeout_budget_loop] state so multi-process loops still reach
-    the same soft-backoff signal. *)
+    the policy gate. *)
 val oas_timeout_budget_strike_limit : int
 
 type oas_timeout_budget_strike_outcome =

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1433,6 +1433,46 @@ let handle_oas_timeout_budget_pause
          count)
 ;;
 
+let failure_reason_policy_decision
+      (reason : Keeper_registry.failure_reason option)
+  : Keeper_failure_policy.decision option
+  =
+  match reason with
+  | Some (Keeper_registry.Oas_timeout_budget_loop { count }) ->
+    Some
+      (Keeper_failure_policy.decide
+         (Keeper_failure_policy.Oas_timeout_budget
+            { phase = None
+            ; strikes = Some count
+            ; liveness = Keeper_failure_policy.Watchdog_stale
+            }))
+  | Some (Keeper_registry.Stale_termination_storm { count }) ->
+    Some
+      (Keeper_failure_policy.decide
+         (Keeper_failure_policy.Stale_termination_storm { count }))
+  | Some (Keeper_registry.Stale_turn_timeout _) ->
+    Some
+      (Keeper_failure_policy.decide
+         (Keeper_failure_policy.Stale_turn { progress_seen = false }))
+  | Some (Keeper_registry.Tool_required_unsatisfied _) ->
+    Some
+      (Keeper_failure_policy.decide
+         Keeper_failure_policy.Required_tool_contract_violation)
+  | Some (Keeper_registry.Ambiguous_partial_commit _) ->
+    Some (Keeper_failure_policy.decide Keeper_failure_policy.Ambiguous_partial_commit)
+  | Some
+      ( Keeper_registry.Heartbeat_consecutive_failures _
+      | Keeper_registry.Turn_consecutive_failures _
+      | Keeper_registry.Stale_fleet_batch _
+      | Keeper_registry.Provider_runtime_error _
+      | Keeper_registry.Fiber_unresolved
+      | Keeper_registry.Exception _ )
+  | None ->
+    None
+;;
+
+let failure_reason_policy_decision_for_test = failure_reason_policy_decision
+
 let sweep_and_recover (ctx : _ context) =
   let now = Time_compat.now () in
   let max_restarts =
@@ -1485,46 +1525,56 @@ let sweep_and_recover (ctx : _ context) =
   let to_mark_dead = ref [] in
   let to_cleanup_dead = ref [] in
   let queue_crashed_entry (entry : Keeper_registry.registry_entry) msg =
-    match entry.last_failure_reason with
-    | Some (Keeper_registry.Stale_termination_storm { count }) ->
-      (* #10765 Phase 2: skip [to_restart] AND in-memory unregister.
-           The watchdog detected a termination storm (>= escalation_
-           threshold within the 6h window).  [handle_stale_storm_pause]
-           persists [meta.paused = true] so reconcile + future sweeps
-           honor the pause across server restarts; we then add the
-           entry to [to_unregister] so the in-memory registry slot is
-           cleared and subsequent sweep ticks within the same server
-           do NOT re-fire the storm-pause path (counter must increment
-           once per storm, not once per sweep tick). *)
-      handle_stale_storm_pause ctx entry ~count;
-      to_unregister := entry :: !to_unregister
-    | Some (Keeper_registry.Oas_timeout_budget_loop { count }) ->
-      (* Repeated OAS budget exhaustion means the active
-           cascade/model is not producing within the turn budget.
-           Restarting the same keeper preserves that bad routing and
-           burns another multi-minute budget, so pause instead. *)
-      handle_oas_timeout_budget_pause ctx entry ~count;
-      to_unregister := entry :: !to_unregister
-    (* All other failure reasons (and missing reason) fall through to the
-       standard restart-budget path: restart up to [max_restarts], then mark
-       Dead.  Any new [failure_reason] variant that warrants pause-instead-of-
-       restart must be added explicitly; the compiler will enforce it. *)
-    | Some (Keeper_registry.Heartbeat_consecutive_failures _)
-    | Some (Keeper_registry.Turn_consecutive_failures _)
-    | Some (Keeper_registry.Stale_turn_timeout _)
-    | Some (Keeper_registry.Stale_fleet_batch _)
-    | Some (Keeper_registry.Provider_runtime_error _)
-    | Some (Keeper_registry.Tool_required_unsatisfied _)
-    | Some (Keeper_registry.Ambiguous_partial_commit _)
-    | Some Keeper_registry.Fiber_unresolved
-    | Some (Keeper_registry.Exception _)
-    | None ->
+    let queue_standard_restart () =
       if entry.restart_count >= max_restarts
       then to_mark_dead := (entry, msg) :: !to_mark_dead
       else (
         let delay = backoff_delay entry.restart_count in
         if now -. entry.last_restart_ts >= delay
         then to_restart := (entry, msg) :: !to_restart)
+    in
+    match failure_reason_policy_decision entry.last_failure_reason with
+    | Some
+        { Keeper_failure_policy.lifecycle_effect = Keeper_failure_policy.Pause_keeper
+        ; _
+        } ->
+      (match entry.last_failure_reason with
+       | Some (Keeper_registry.Stale_termination_storm { count }) ->
+         (* #10765 Phase 2: policy owns the pause-vs-restart lifecycle
+            decision; this branch only applies the stale-storm pause side
+            effect and clears the in-memory registry slot so the counter
+            increments once per storm. *)
+         handle_stale_storm_pause ctx entry ~count;
+         to_unregister := entry :: !to_unregister
+       | Some (Keeper_registry.Oas_timeout_budget_loop { count }) ->
+         (* Watchdog-preserved OAS budget loops include liveness evidence,
+            so policy allows keeper pause without treating timeout alone as
+            keeper death. *)
+         handle_oas_timeout_budget_pause ctx entry ~count;
+         to_unregister := entry :: !to_unregister
+       | Some
+           ( Keeper_registry.Heartbeat_consecutive_failures _
+           | Keeper_registry.Turn_consecutive_failures _
+           | Keeper_registry.Stale_turn_timeout _
+           | Keeper_registry.Stale_fleet_batch _
+           | Keeper_registry.Provider_runtime_error _
+           | Keeper_registry.Tool_required_unsatisfied _
+           | Keeper_registry.Ambiguous_partial_commit _
+           | Keeper_registry.Fiber_unresolved
+           | Keeper_registry.Exception _ )
+       | None ->
+         queue_standard_restart ())
+    | Some
+        { Keeper_failure_policy.lifecycle_effect =
+            ( Keeper_failure_policy.Keep_running
+            | Keeper_failure_policy.Soft_fail_turn
+            | Keeper_failure_policy.Pause_current_work
+            | Keeper_failure_policy.Force_release_turn
+            | Keeper_failure_policy.Restart_keeper )
+        ; _
+        }
+    | None ->
+      queue_standard_restart ()
   in
   let watchdog_stop_pending (entry : Keeper_registry.registry_entry) =
     Atomic.get entry.fiber_stop

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -72,6 +72,12 @@ include module type of Keeper_supervisor_types
 val cohort_key_of_reason : Keeper_registry.failure_reason option -> string
 (** Map a structured failure_reason to a cohort key for self-preservation grouping. *)
 
+val failure_reason_policy_decision_for_test :
+  Keeper_registry.failure_reason option -> Keeper_failure_policy.decision option
+(** Pure supervisor-side bridge from registry failure reasons into the
+    keeper failure policy matrix. Exposed for regression tests so pause-vs-restart
+    lifecycle ownership remains pinned to [Keeper_failure_policy]. *)
+
 val apply_self_preservation :
   keepers_dir:string ->
   total_keepers:int ->

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -872,8 +872,9 @@ let reset_autonomous_completion_for_test () : unit =
    Re-running on the same fiber gives the same context and the same
    shape of failure repeats, but provider/cascade budget pressure is not
    keeper fiber corruption. Crossing [oas_timeout_budget_strike_limit]
-   is therefore a soft-backoff signal, not a [Keeper_fiber_crash]
-   promotion: the keeper stays alive while provider cooldown, cascade
+   is therefore routed through [Keeper_failure_policy] before any
+   lifecycle effect is applied. Without independent keeper-liveness
+   loss, the keeper stays alive while provider cooldown, cascade
    backpressure, and turn retry policy do the actual throttling.
 
    Counter is in-memory for the common same-server case and is reset on

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -181,8 +181,8 @@ val set_after_acquire_flag_hook_for_test :
   (label:string -> keeper_name:string -> unit) option -> unit
 
 (** PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
-    per keeper. Crossing this limit is a soft-backoff signal; it must not
-    promote to [Keeper_fiber_crash].
+    per keeper. The heartbeat loop feeds this count into
+    [Keeper_failure_policy] before choosing any lifecycle effect.
 
     Counts are stored in an in-process CAS map and can be seeded from the
     persisted [Oas_timeout_budget_loop] failure reason on the first bump after

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -12,6 +12,7 @@ module Http_client = struct
     | Cli_transport_required
     | Tls_error
     | Network_error
+    | Provider_timeout
     | Provider_terminal
         (** OAS [ProviderTerminal] — provider has signalled a terminal
             condition (e.g. claude_cli [error_max_turns]). Treat as
@@ -174,8 +175,7 @@ module Http_client = struct
           Provider_terminal
       | Llm_provider.Http_client.ProviderFailure { kind; _ } ->
           classify_provider_failure_kind kind
-      | Llm_provider.Http_client.TimeoutError _ ->
-          Network_error
+      | Llm_provider.Http_client.TimeoutError _ -> Provider_timeout
       | Llm_provider.Http_client.NetworkError { kind; _ } ->
           if kind = Llm_provider.Http_client.Tls_error then Tls_error else Network_error
 
@@ -193,6 +193,7 @@ module Http_client = struct
     | Accept_rejected_capability_mismatch
     | Cli_transport_required
     | Network_error
+    | Provider_timeout
     | Provider_capacity_exhausted
     | Provider_hard_quota
     | Provider_capability_mismatch
@@ -205,7 +206,10 @@ module Http_client = struct
   let error_message (err : Llm_provider.Http_client.http_error) : string =
     match err with
     | Llm_provider.Http_client.NetworkError { message; _ } -> message
-    | Llm_provider.Http_client.TimeoutError { message; _ } -> message
+    | Llm_provider.Http_client.TimeoutError { message; phase } ->
+        Printf.sprintf "provider timeout: %s: %s"
+          (Llm_provider.Http_client.timeout_phase_to_label phase)
+          message
     | Llm_provider.Http_client.AcceptRejected { reason } -> reason
     | Llm_provider.Http_client.CliTransportRequired { kind } ->
         Printf.sprintf "%s provider requires a CLI transport" kind

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -32,6 +32,7 @@ module Http_client : sig
     | Cli_transport_required
     | Tls_error
     | Network_error
+    | Provider_timeout
     | Provider_terminal
         (** Provider-level terminal condition that should stop cascading. *)
     | Provider_capacity_exhausted

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -647,11 +647,10 @@ let metric_provider_health_probe_error = "masc_provider_health_probe_error_total
    can see "alive but unproductive" keepers in Grafana before the
    detection latch fires.  Labels: keeper. *)
 (* PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
-   per keeper. Counter increments on each strike; a strike at
-   [outcome=promote] means [Keeper_fiber_crash] was raised so
-   [Keeper_supervisor.sweep_and_recover] will respawn the fiber. Without
-   the strike→crash promotion these failures repeated silently for
-   hours (4h+ zombie keepers observed 2026-04-26). *)
+   per keeper. Counter increments on each strike. At the limit, the
+   heartbeat loop records [outcome=soft_backoff] unless
+   [Keeper_failure_policy] sees separate keeper-liveness loss and returns
+   a death-allowed decision. *)
 let metric_oas_bus_subscriber_stream_depth = "masc_oas_bus_subscriber_stream_depth"
 let metric_oas_bus_publish_block_seconds = "masc_oas_bus_publish_block_seconds_total"
 let metric_oas_bus_publish = "masc_oas_bus_publish_total"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -550,7 +550,9 @@ val metric_memory_pipeline_flush_duration_seconds : string
       cycle continues.
     - [outcome=soft_backoff]: strike at or above limit; keeper fiber
       remains alive while provider/cascade cooldown and retry backoff
-      throttle later turns. Counter reset on any successful turn. *)
+      throttle later turns.
+    - [outcome=promote]: policy allowed keeper death because separate
+      liveness evidence exists. Counter reset on any successful turn. *)
 
 val metric_oas_bus_subscriber_stream_depth : string
 val metric_oas_bus_publish_block_seconds : string

--- a/lib/server/openai_compat_error_map.ml
+++ b/lib/server/openai_compat_error_map.ml
@@ -78,6 +78,101 @@ let of_api_error (e : Agent_sdk.Error.Retry.api_error) : t =
     ; openai_code = Some "timeout"
     ; message }
 
+let provider_timeout_code = function
+  | None -> "provider_timeout"
+  | Some phase ->
+    Printf.sprintf
+      "provider_timeout:%s"
+      (Llm_provider.Http_client.timeout_phase_to_label phase)
+
+let provider_network_code = function
+  | None -> "provider_network"
+  | Some phase -> provider_timeout_code (Some phase)
+
+let of_provider_error (e : Agent_sdk.Error.provider_error) : t =
+  let message = Agent_sdk.Error.to_string (Agent_sdk.Error.Provider e) in
+  match e with
+  | Llm_provider.Error.MissingApiKey _ ->
+    { http_status = `Internal_server_error
+    ; openai_kind = kind_server
+    ; openai_code = Some "provider_missing_api_key"
+    ; message }
+  | InvalidConfig _ ->
+    { http_status = `Internal_server_error
+    ; openai_kind = kind_server
+    ; openai_code = Some "provider_invalid_config"
+    ; message }
+  | ParseError _ ->
+    { http_status = `Bad_gateway
+    ; openai_kind = kind_server
+    ; openai_code = Some "provider_parse_error"
+    ; message }
+  | UnknownVariant _ ->
+    { http_status = `Bad_gateway
+    ; openai_kind = kind_server
+    ; openai_code = Some "provider_unknown_variant"
+    ; message }
+  | ProviderUnavailable _ ->
+    { http_status = `Service_unavailable
+    ; openai_kind = kind_server
+    ; openai_code = Some "provider_unavailable"
+    ; message }
+  | RateLimit _ ->
+    { http_status = `Too_many_requests
+    ; openai_kind = kind_rate_limit
+    ; openai_code = Some "provider_rate_limited"
+    ; message }
+  | HardQuota _ ->
+    { http_status = `Too_many_requests
+    ; openai_kind = kind_rate_limit
+    ; openai_code = Some "provider_hard_quota"
+    ; message }
+  | CapacityExhausted r ->
+    { http_status = `Service_unavailable
+    ; openai_kind = kind_server
+    ; openai_code =
+        Some
+          (Printf.sprintf
+             "provider_capacity_exhausted:%s"
+             (Llm_provider.Error.capacity_scope_to_string r.scope))
+    ; message }
+  | AuthError _ ->
+    { http_status = `Unauthorized
+    ; openai_kind = kind_authentication
+    ; openai_code = Some "provider_auth"
+    ; message }
+  | ServerError r ->
+    { http_status =
+        (if r.transient then `Bad_gateway else `Internal_server_error)
+    ; openai_kind = kind_server
+    ; openai_code = Some (Printf.sprintf "provider_server:%d" r.code)
+    ; message }
+  | NetworkError r ->
+    { http_status = `Bad_gateway
+    ; openai_kind = kind_server
+    ; openai_code = Some (provider_network_code r.timeout_phase)
+    ; message }
+  | Timeout r ->
+    { http_status = `Gateway_timeout
+    ; openai_kind = kind_server
+    ; openai_code = Some (provider_timeout_code r.timeout_phase)
+    ; message }
+  | InvalidRequest _ ->
+    { http_status = `Bad_request
+    ; openai_kind = kind_invalid_request
+    ; openai_code = Some "provider_invalid_request"
+    ; message }
+  | NotFound _ ->
+    { http_status = `Not_found
+    ; openai_kind = kind_not_found
+    ; openai_code = Some "provider_not_found"
+    ; message }
+  | ProviderTerminal _ ->
+    { http_status = `Bad_gateway
+    ; openai_kind = kind_server
+    ; openai_code = Some "provider_terminal"
+    ; message }
+
 let of_agent_error (e : Agent_sdk.Error.agent_error) : t =
   let message = Agent_sdk.Error.to_string (Agent_sdk.Error.Agent e) in
   match e with
@@ -272,12 +367,7 @@ let of_a2a_error (e : Agent_sdk.Error.a2a_error) : t =
 let of_sdk_error (e : Agent_sdk.Error.sdk_error) : t =
   match e with
   | Agent_sdk.Error.Api ae -> of_api_error ae
-  | Provider pe ->
-    { http_status =
-        (if Llm_provider.Error.is_retryable pe then `Service_unavailable else `Bad_gateway)
-    ; openai_kind = kind_server
-    ; openai_code = Some "provider_error"
-    ; message = Llm_provider.Error.to_string pe }
+  | Provider pe -> of_provider_error pe
   | Agent ae -> of_agent_error ae
   | Mcp me -> of_mcp_error me
   | Config ce -> of_config_error ce

--- a/test/dune
+++ b/test/dune
@@ -1549,6 +1549,8 @@
 
 (include stanzas/test_keeper_error_classify_recoverable.inc)
 
+(include stanzas/test_keeper_failure_policy.inc)
+
 (include stanzas/test_keeper_exec_shell_cwd_response.inc)
 
 (include stanzas/test_keeper_exec_tools.inc)

--- a/test/stanzas/test_keeper_failure_policy.inc
+++ b/test/stanzas/test_keeper_failure_policy.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_failure_policy)
+ (modules test_keeper_failure_policy)
+ (libraries masc_test_deps))

--- a/test/test_keeper_failure_policy.ml
+++ b/test/test_keeper_failure_policy.ml
@@ -1,0 +1,160 @@
+open Alcotest
+
+module Policy = Masc_mcp.Keeper_failure_policy
+
+let check_lifecycle label expected actual =
+  check string label expected (Policy.lifecycle_effect_to_label actual)
+;;
+
+let check_circuit label expected actual =
+  check string label expected (Policy.circuit_effect_to_label actual)
+;;
+
+let check_scope label expected actual =
+  check string label expected (Policy.failure_scope_to_label actual)
+;;
+
+let check_action label expected actual =
+  check string label expected (Policy.operator_action_to_label actual)
+;;
+
+let test_stream_idle_thinking_label_round_trips () =
+  let phase = Policy.Stream_idle Policy.Streaming_thinking in
+  check string
+    "thinking timeout label"
+    "stream_idle:streaming_thinking"
+    (Policy.timeout_phase_to_label phase);
+  match Policy.timeout_phase_of_label "stream_idle:streaming_thinking" with
+  | Some parsed ->
+    check bool "thinking phase round-trips" true (parsed = phase);
+    check bool
+      "thinking is streaming activity"
+      true
+      (Policy.timeout_phase_is_streaming_activity parsed)
+  | None -> fail "stream_idle:streaming_thinking did not parse"
+;;
+
+let test_stream_idle_awaiting_delta_is_not_activity () =
+  let phase = Policy.Stream_idle Policy.Awaiting_first_delta in
+  check bool
+    "awaiting first delta is not streaming activity"
+    false
+    (Policy.timeout_phase_is_streaming_activity phase)
+;;
+
+let test_provider_streaming_thinking_timeout_does_not_kill_keeper () =
+  let decision =
+    Policy.decide
+      (Policy.Provider_timeout
+         {
+           phase = Some (Policy.Stream_idle Policy.Streaming_thinking);
+           liveness = Policy.In_turn_progress;
+         })
+  in
+  check_scope "scope" "provider" decision.failure_scope;
+  check_lifecycle "lifecycle" "soft_fail_turn" decision.lifecycle_effect;
+  check_circuit "circuit" "provider_cooldown" decision.circuit_effect;
+  check_action "action" "inspect_provider_stream" decision.operator_action;
+  check bool "keeper death not allowed" false (Policy.should_kill_keeper decision);
+  check string
+    "reason"
+    "provider_stream_idle_active:streaming_thinking"
+    decision.reason
+;;
+
+let test_oas_budget_loop_with_live_keeper_pauses_work_not_keeper () =
+  let decision =
+    Policy.decide
+      (Policy.Oas_timeout_budget
+         {
+           phase = Some Policy.Caller_budget;
+           strikes = Some 6;
+           liveness = Policy.Recent_heartbeat;
+         })
+  in
+  check_scope "scope" "turn" decision.failure_scope;
+  check_lifecycle "lifecycle" "pause_current_work" decision.lifecycle_effect;
+  check_circuit "circuit" "provider_cooldown" decision.circuit_effect;
+  check_action "action" "reroute_or_tune_provider" decision.operator_action;
+  check bool "keeper death not allowed" false (Policy.should_kill_keeper decision)
+;;
+
+let test_oas_budget_loop_with_lost_liveness_pauses_keeper_without_death () =
+  let decision =
+    Policy.decide
+      (Policy.Oas_timeout_budget
+         {
+           phase = Some (Policy.Stream_idle Policy.Awaiting_first_event);
+           strikes = Some 3;
+           liveness = Policy.Watchdog_stale;
+         })
+  in
+  check_lifecycle "lifecycle" "pause_keeper" decision.lifecycle_effect;
+  check_circuit "circuit" "operator_breaker" decision.circuit_effect;
+  check_action "action" "inspect_keeper_liveness" decision.operator_action;
+  check bool "keeper death not allowed" false (Policy.should_kill_keeper decision)
+;;
+
+let test_workflow_rejection_skips_keeper_circuit () =
+  let decision =
+    Policy.decide
+      (Policy.Workflow_rejection { rule_id = Some "command_chaining_blocked" })
+  in
+  check_scope "scope" "invocation" decision.failure_scope;
+  check_lifecycle "lifecycle" "keep_running" decision.lifecycle_effect;
+  check_circuit "circuit" "skip_circuit" decision.circuit_effect;
+  check_action "action" "fix_invocation" decision.operator_action;
+  check bool "keeper death not allowed" false (Policy.should_kill_keeper decision)
+;;
+
+let test_only_liveness_failures_allow_keeper_death () =
+  let non_liveness_failures =
+    [
+      Policy.Transient_provider_failure;
+      Policy.Cascade_exhausted { retryable = false };
+      Policy.Required_tool_contract_violation;
+      Policy.Stale_turn { progress_seen = true };
+      Policy.Stale_termination_storm { count = 6 };
+      Policy.Ambiguous_partial_commit;
+    ]
+  in
+  List.iter
+    (fun failure ->
+       let decision = Policy.decide failure in
+       check bool
+         ("keeper death blocked for " ^ decision.reason)
+         false
+         (Policy.should_kill_keeper decision))
+    non_liveness_failures;
+  let fatal =
+    Policy.decide (Policy.Fatal_environment { detail = Some "missing_eio_switch" })
+  in
+  check bool "fatal env can restart keeper" true (Policy.should_kill_keeper fatal);
+  let stale = Policy.decide (Policy.Stale_turn { progress_seen = false }) in
+  check bool "stale no progress can restart keeper" true (Policy.should_kill_keeper stale)
+;;
+
+let () =
+  run "keeper_failure_policy"
+    [
+      ( "timeout_phase",
+        [
+          test_case "stream_idle:streaming_thinking parses as activity" `Quick
+            test_stream_idle_thinking_label_round_trips;
+          test_case "awaiting first delta is not activity" `Quick
+            test_stream_idle_awaiting_delta_is_not_activity;
+        ] );
+      ( "decision_matrix",
+        [
+          test_case "provider streaming thinking timeout stays provider-scoped" `Quick
+            test_provider_streaming_thinking_timeout_does_not_kill_keeper;
+          test_case "live OAS budget loop pauses work, not keeper" `Quick
+            test_oas_budget_loop_with_live_keeper_pauses_work_not_keeper;
+          test_case "lost-liveness OAS budget loop pauses keeper without death" `Quick
+            test_oas_budget_loop_with_lost_liveness_pauses_keeper_without_death;
+          test_case "workflow rejection skips keeper circuit" `Quick
+            test_workflow_rejection_skips_keeper_circuit;
+          test_case "keeper death is liveness-only" `Quick
+            test_only_liveness_failures_allow_keeper_death;
+        ] );
+    ]

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -12,6 +12,7 @@ module KSM = Masc_mcp.Keeper_state_machine
 module KLH = Masc_mcp.Keeper_lifecycle_hooks
 module FD = Masc_mcp.Keeper_fd_pressure
 module KA = Masc_mcp.Keeper_keepalive
+module KFP = Masc_mcp.Keeper_failure_policy
 
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_supervisor_" "" in
@@ -79,6 +80,11 @@ goal = "test keeper"
 let with_restart_launch_noop f =
   Sup.with_restart_launch_noop_for_test f
 
+let policy_decision_exn reason =
+  match Sup.failure_reason_policy_decision_for_test reason with
+  | Some decision -> decision
+  | None -> fail "expected supervisor policy decision"
+
 (* ── Pure tests: backoff_delay ──────────────────────────── *)
 
 let test_backoff_delay_attempt_0 () =
@@ -116,6 +122,41 @@ let test_auto_resume_disabled () =
   in
   check (option (float 0.1)) "initial <= 0 disables auto-resume"
     None delay
+
+let test_supervisor_policy_pauses_watchdog_oas_budget_loop () =
+  let decision =
+    policy_decision_exn (Some (Reg.Oas_timeout_budget_loop { count = 3 }))
+  in
+  check string "scope" "turn" (KFP.failure_scope_to_label decision.failure_scope);
+  check string "lifecycle" "pause_keeper"
+    (KFP.lifecycle_effect_to_label decision.lifecycle_effect);
+  check string "circuit" "operator_breaker"
+    (KFP.circuit_effect_to_label decision.circuit_effect);
+  check bool "keeper death denied" false decision.keeper_death_allowed;
+  check string "reason" "oas_timeout_budget_liveness_lost" decision.reason
+
+let test_supervisor_policy_pauses_stale_storm () =
+  let decision =
+    policy_decision_exn (Some (Reg.Stale_termination_storm { count = 5 }))
+  in
+  check string "scope" "fleet" (KFP.failure_scope_to_label decision.failure_scope);
+  check string "lifecycle" "pause_keeper"
+    (KFP.lifecycle_effect_to_label decision.lifecycle_effect);
+  check bool "keeper death denied" false decision.keeper_death_allowed;
+  check string "reason" "stale_termination_storm:5" decision.reason
+
+let test_supervisor_policy_restarts_stale_turn () =
+  let decision =
+    policy_decision_exn
+      (Some
+         (Reg.Stale_turn_timeout
+            (Reg.In_turn_hung { active_seconds = 60.0; timeout_threshold = 30.0 })))
+  in
+  check string "scope" "keeper_liveness"
+    (KFP.failure_scope_to_label decision.failure_scope);
+  check string "lifecycle" "restart_keeper"
+    (KFP.lifecycle_effect_to_label decision.lifecycle_effect);
+  check bool "keeper death allowed" true decision.keeper_death_allowed
 
 (* ── Pure tests: keep_last_n ────────────────────────────── *)
 
@@ -1695,6 +1736,14 @@ let () =
     "backoff_properties", [
       test_case "monotonic until cap" `Quick test_backoff_monotonic_until_cap;
       test_case "never negative" `Quick test_backoff_never_negative;
+    ];
+    "failure_policy_bridge", [
+      test_case "watchdog OAS budget loop pauses via policy" `Quick
+        test_supervisor_policy_pauses_watchdog_oas_budget_loop;
+      test_case "stale storm pauses via policy" `Quick
+        test_supervisor_policy_pauses_stale_storm;
+      test_case "stale turn restarts via policy" `Quick
+        test_supervisor_policy_restarts_stale_turn;
     ];
     "keep_last_n_properties", [
       test_case "never exceeds limit" `Quick test_keep_last_n_never_exceeds;

--- a/test/test_oas_compat_cascade_fallback.ml
+++ b/test/test_oas_compat_cascade_fallback.ml
@@ -137,12 +137,14 @@ let test_timeout_error_cascades () =
     true
     (Oas_compat.Http_client.should_cascade err);
   (match Oas_compat.Http_client.classify err with
-   | Network_error -> ()
-   | _ -> Alcotest.fail "TimeoutError must classify as Network_error");
-  Alcotest.(check string)
-    "TimeoutError -> message"
-    "provider step timed out"
-    (Oas_compat.Http_client.error_message err)
+   | Provider_timeout -> ()
+   | _ -> Alcotest.fail "TimeoutError must classify as Provider_timeout");
+  let rendered = Oas_compat.Http_client.error_message err in
+  Alcotest.(check bool)
+    "TimeoutError -> message preserves phase"
+    true
+    (Astring.String.is_infix ~affix:"provider_step" rendered
+     && Astring.String.is_infix ~affix:"provider step timed out" rendered)
 
 (* --- ProviderTerminal: pin classify, should_cascade, and the new
        error_message helper. The variant arrived in agent_sdk without
@@ -255,6 +257,28 @@ let test_provider_failure_capability_mismatch_cascades () =
    | _ ->
        Alcotest.fail
          "Capability_mismatch must classify as Provider_capability_mismatch")
+
+let test_timeout_error_cascades_with_phase_evidence () =
+  let err =
+    Http_client.TimeoutError
+      {
+        message = "stream idle after thinking";
+        phase = Stream_idle Streaming_thinking;
+      }
+  in
+  Alcotest.(check bool)
+    "TimeoutError cascades as provider-local timeout evidence"
+    true
+    (Oas_compat.Http_client.should_cascade err);
+  (match Oas_compat.Http_client.classify err with
+   | Provider_timeout -> ()
+   | _ -> Alcotest.fail "TimeoutError must classify as Provider_timeout");
+  let rendered = Oas_compat.Http_client.error_message err in
+  Alcotest.(check bool)
+    "error_message preserves timeout phase"
+    true
+    (Astring.String.is_infix ~affix:"stream_idle:streaming_thinking" rendered
+     && Astring.String.is_infix ~affix:"stream idle after thinking" rendered)
 
 let test_error_message_baseline () =
   (* Smoke check that the new helper preserves existing semantics for
@@ -418,6 +442,11 @@ let () =
             `Quick test_provider_failure_hard_quota_cascades;
           Alcotest.test_case "Capability_mismatch classify + cascade"
             `Quick test_provider_failure_capability_mismatch_cascades;
+        ] );
+      ( "TimeoutError — typed timeout phase cascades",
+        [
+          Alcotest.test_case "TimeoutError classify + cascade + message"
+            `Quick test_timeout_error_cascades_with_phase_evidence;
         ] );
       ( "error_message helper baseline",
         [

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -1,6 +1,9 @@
 open Masc_mcp
 
+module KH = Keeper_heartbeat_loop
+module KFP = Keeper_failure_policy
 module KK = Keeper_keepalive
+module KTD = Keeper_turn_driver
 
 let with_reset keeper f =
   KK.reset_budget_exhaustion ~keeper_name:keeper;
@@ -54,6 +57,41 @@ let test_strike_limit_is_soft_backoff () =
    | KK.Oas_timeout_budget_warn ->
      failwith "strike limit should soft-backoff, not crash")
 
+let oas_timeout_budget_error ~phase =
+  KTD.sdk_error_of_masc_internal_error
+    (KTD.Oas_timeout_budget
+       { budget_sec = 90.0
+       ; keeper_turn_timeout_sec = 1200.0
+       ; estimated_input_tokens = 10_000
+       ; source = "test"
+       ; remaining_turn_budget_sec = Some 42.0
+       ; min_required_sec = 15.0
+       ; phase
+       })
+
+let test_strike_limit_routes_through_policy_without_keeper_death () =
+  let err = oas_timeout_budget_error ~phase:"stream_idle:streaming_thinking" in
+  match
+    KH.oas_timeout_budget_policy_decision
+      ~strikes:KK.oas_timeout_budget_strike_limit
+      err
+  with
+  | None -> Alcotest.fail "expected OAS timeout budget policy decision"
+  | Some decision ->
+    Alcotest.(check bool) "keeper death denied" false decision.keeper_death_allowed;
+    Alcotest.(check string)
+      "lifecycle"
+      "pause_current_work"
+      (KFP.lifecycle_effect_to_label decision.lifecycle_effect);
+    Alcotest.(check string)
+      "circuit"
+      "provider_cooldown"
+      (KFP.circuit_effect_to_label decision.circuit_effect);
+    Alcotest.(check string)
+      "reason preserves streaming thinking"
+      "oas_timeout_budget_loop:stream_idle:streaming_thinking"
+      decision.reason
+
 let test_concurrent_bumps_do_not_lose_updates () =
   let keeper = "parallel-bumps" in
   with_reset keeper (fun () ->
@@ -85,6 +123,8 @@ let () =
         Alcotest.test_case "reset clears" `Quick test_reset_clears;
         Alcotest.test_case "strike limit soft-backoffs without crash" `Quick
           test_strike_limit_is_soft_backoff;
+        Alcotest.test_case "strike limit uses policy, not keeper death" `Quick
+          test_strike_limit_routes_through_policy_without_keeper_death;
         Alcotest.test_case "concurrent bumps do not lose updates" `Quick
           test_concurrent_bumps_do_not_lose_updates;
       ] );


### PR DESCRIPTION
## Summary
- Add a pure `Keeper_failure_policy` matrix that separates invocation/provider/turn/keeper/fleet failures before lifecycle side effects.
- Preserve typed OAS/provider timeout phase labels including `stream_idle:streaming_thinking`, so Streaming/Thinking evidence stays provider/turn-scoped instead of keeper-death scoped.
- Bridge `Agent_sdk.Error.Provider` variants into structured cascade/runtime evidence: `TimeoutError` now keeps phase, provider capacity/quota/auth/server cases keep typed classifications, and status/error surfaces expose the same reason codes.
- Route heartbeat and supervisor failure handling through the same policy decision before lifecycle action; OAS timeout budget loops only pause through the policy path, and stale turn/liveness-only cases remain restart-scoped.
- Add regression coverage for workflow rejection circuit skipping, OAS budget-loop policy decisions, provider timeout phase rendering, supervisor policy bridging, terminal reason mapping, and OpenAI-compatible error mapping.

## Verification
- `git diff --check`
- `opam exec -- ocamlformat --check lib/cascade/cascade_attempt_fsm.ml lib/cascade/cascade_error_classify.ml lib/keeper/keeper_error_classify.ml lib/keeper/keeper_turn_driver.ml lib/oas_compat/oas_compat.ml test/test_oas_compat_cascade_fallback.ml`
- `bash scripts/ci/check-determinism-contract.sh`
- `./scripts/dune-local.sh build test/test_oas_timeout_budget_strike.exe test/test_keeper_failure_policy.exe test/test_keeper_supervisor.exe test/test_oas_compat_cascade_fallback.exe test/test_openai_compat_error_map.exe test/test_keeper_terminal_reason.exe`
- `./scripts/dune-local.sh build ./test/test_cascade_attempt_fsm_response_pins.exe`
- `./_build/default/test/test_oas_timeout_budget_strike.exe` passed 7 tests
- `./_build/default/test/test_keeper_failure_policy.exe` passed 7 tests
- `./_build/default/test/test_keeper_supervisor.exe` passed 76 tests
- `./_build/default/test/test_oas_compat_cascade_fallback.exe` passed 24 tests
- `./_build/default/test/test_openai_compat_error_map.exe` passed 21 tests
- `./_build/default/test/test_keeper_terminal_reason.exe` passed 36 tests
- `./_build/default/test/test_cascade_attempt_fsm_response_pins.exe` passed 3 tests

Note: `test_keeper_supervisor.exe` was rerun alone after a parallel Alcotest log-directory internal error; the solo run passed.