### PR TITLE
fix(audit-path-ssot): refresh allowlist pins drifted out of sync

### DIFF
--- a/.ci/path-ssot-allowlist.txt
+++ b/.ci/path-ssot-allowlist.txt
@@ -25,12 +25,15 @@ lib/keeper/keeper_egress_audit.ml:54
 
 # default_local_path / repositories.toml local_path TOML default value
 # is cwd/base-path-relative by on-disk design (RFC-0121 §6 deferred).
-lib/repo_manager/repo_store.ml:11
-lib/server/server_routes_http_routes_repositories.ml:195
+lib/repo_manager/repo_store.ml:17
+lib/server/server_routes_http_routes_repositories.ml:197
 
 # Self-reference inside the audit script and RFC text.
 scripts/audit-path-ssot.sh
 docs/rfc/RFC-0121-config-dir-resolution-single-active-root.md
+# Self-reference inside the layout-SSOT module documentation comments.
+lib/config_dir_resolver/config_dir_resolver.mli:93
+lib/config_dir_resolver/config_dir_resolver.ml:478
 
 # ============================================================
 # (B) Transitional baseline (in-flight RFC-0121 PRs)


### PR DESCRIPTION
## Summary

`audit-path-ssot` 가 main 자체에서 fail 중. allowlist 의 line-pin entry 들이 코드 이동으로 drift:

| Entry | Was | Now |
|-------|-----|-----|
| `repo_store.ml` | `:11` | `:17` |
| `server_routes_http_routes_repositories.ml` | `:195` | `:197` |
| `config_dir_resolver.mli` self-ref | (missing) | `:93` |
| `config_dir_resolver.ml` self-ref | (missing) | `:478` |

원래 audit script + RFC doc 만 self-reference 면제됐는데, `config_dir_resolver.{mli,ml}` 의 module documentation 안에 `Filename.concat base_path ".masc/..."` 가 string-literal 로 들어 있어 scan 에 걸림.

## Impact

머지 후 in-flight Draft PR `#16166`, `#16178` (그리고 동일 baseline 의 다른 PR) 의 `audit-path-ssot` fail 해소.

## Test plan

- [x] `bash scripts/audit-path-ssot.sh` → `OK (0 violations)`
- [x] line-pin substring 갱신 (drift 따라가는 임시 처방. line-shape-pin → file-pin migration 은 RFC-0121 follow-up 후보로 분리)

RFC-WAIVED: audit gate 자체 SSOT 정상화. config_dir_resolver subsystem touch 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
