### PR TITLE
feat(rfc-0127-pr-1): provenance threading — typed carrier for Fiber_terminated + Provider_runtime_error

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -628,7 +628,7 @@ let record_keeper_crashed
     Keeper_registry.dispatch_event_unit
       ~base_path
       keeper_name
-      (Keeper_state_machine.Fiber_terminated { outcome });
+      (Keeper_state_machine.Fiber_terminated { outcome; provider_id = None; http_status = None });
     Keeper_registry.record_crash ~base_path keeper_name (Time_compat.now ()) reason;
     Keeper_registry.record_error ~base_path keeper_name reason;
     publish_keeper_phase_lifecycle

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -85,6 +85,8 @@ type failure_reason =
   | Provider_runtime_error of
       { code : string
       ; detail : string
+      ; provider_id : string option
+      ; http_status : int option
       }
   | Tool_required_unsatisfied of
       { code : string

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -113,8 +113,16 @@ let failure_reason_to_string = function
     Printf.sprintf "stale_fleet_batch(distinct_count=%d)" distinct_count
   | Oas_timeout_budget_loop { count } ->
     Printf.sprintf "oas_timeout_budget_loop(count=%d)" count
-  | Provider_runtime_error { code; detail } ->
-    Printf.sprintf "provider_runtime_error(%s:%s)" code detail
+  | Provider_runtime_error { code; detail; provider_id; http_status } ->
+    let prov =
+      Option.fold provider_id ~none:""
+        ~some:(Printf.sprintf " provider=%s")
+    in
+    let http =
+      Option.fold http_status ~none:""
+        ~some:(Printf.sprintf " http=%d")
+    in
+    Printf.sprintf "provider_runtime_error(%s:%s%s%s)" code detail prov http
   | Tool_required_unsatisfied { code; detail } ->
     Printf.sprintf "tool_required_unsatisfied(%s:%s)" code detail
   | Ambiguous_partial_commit { kind; detail } ->

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -84,7 +84,12 @@ type failure_reason =
           consecutive cycles. This is a provider/cascade/runtime throughput
           failure, so the supervisor pauses instead of restarting into the
           same slow model and burning another multi-minute budget. *)
-  | Provider_runtime_error of { code : string; detail : string }
+  | Provider_runtime_error of
+      { code : string
+      ; detail : string
+      ; provider_id : string option
+      ; http_status : int option
+      }
       (** Latched from the keeper turn terminal reason when the provider,
           adapter, or cascade fails before useful keeper progress. A later
           idle watchdog should preserve this root cause instead of recasting

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -219,7 +219,18 @@ let event_to_string = function
   | Stop_requested -> "stop_requested"
   | Drain_complete -> "drain_complete"
   | Fiber_started -> "fiber_started"
-  | Fiber_terminated r -> Printf.sprintf "fiber_terminated(%s)" r.outcome
+  | Fiber_terminated { outcome; provider_id = None; http_status = None } ->
+    Printf.sprintf "fiber_terminated(%s)" outcome
+  | Fiber_terminated { outcome; provider_id; http_status } ->
+    let prov =
+      Option.fold provider_id ~none:""
+        ~some:(Printf.sprintf " provider=%s")
+    in
+    let http =
+      Option.fold http_status ~none:""
+        ~some:(Printf.sprintf " http=%d")
+    in
+    Printf.sprintf "fiber_terminated(%s%s%s)" outcome prov http
   | Supervisor_restart_attempt r ->
     Printf.sprintf "supervisor_restart_attempt(%d)" r.attempt
   | Restart_budget_exhausted -> "restart_budget_exhausted"
@@ -1274,7 +1285,19 @@ let event_to_json (ev : event) : Yojson.Safe.t =
   | Stop_requested -> obj "stop_requested" []
   | Drain_complete -> obj "drain_complete" []
   | Fiber_started -> obj "fiber_started" []
-  | Fiber_terminated r -> obj "fiber_terminated" [ "outcome", `String r.outcome ]
+  | Fiber_terminated r ->
+    let base = [ "outcome", `String r.outcome ] in
+    let with_prov =
+      match r.provider_id with
+      | None -> base
+      | Some p -> base @ [ "provider_id", `String p ]
+    in
+    let with_http =
+      match r.http_status with
+      | None -> with_prov
+      | Some s -> with_prov @ [ "http_status", `Int s ]
+    in
+    obj "fiber_terminated" with_http
   | Supervisor_restart_attempt r ->
     obj "supervisor_restart_attempt" [ "attempt", `Int r.attempt ]
   | Restart_budget_exhausted -> obj "restart_budget_exhausted" []

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -162,7 +162,11 @@ type event =
   | Stop_requested
   | Drain_complete
   | Fiber_started
-  | Fiber_terminated of { outcome : string }
+  | Fiber_terminated of
+      { outcome : string
+      ; provider_id : string option
+      ; http_status : int option
+      }
   | Supervisor_restart_attempt of { attempt : int }
   | Restart_budget_exhausted
   | Credential_archived

--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -190,7 +190,11 @@ type event =
   | Stop_requested
   | Drain_complete
   | Fiber_started
-  | Fiber_terminated of { outcome : string }
+  | Fiber_terminated of
+      { outcome : string
+      ; provider_id : string option
+      ; http_status : int option
+      }
   | Supervisor_restart_attempt of { attempt : int }
   | Restart_budget_exhausted
   | Credential_archived

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -328,7 +328,7 @@ let launch_supervised_fiber
 	                  Keeper_registry.dispatch_event
 	                    ~base_path
 	                    meta.name
-	                    (Keeper_state_machine.Fiber_terminated { outcome })
+	                    (Keeper_state_machine.Fiber_terminated { outcome; provider_id = None; http_status = None })
 	                with
                 | Ok _ -> ()
                 | Error e ->
@@ -415,7 +415,7 @@ let launch_supervised_fiber
 	                Keeper_registry.dispatch_event
 	                  ~base_path
 	                  meta.name
-	                  (Keeper_state_machine.Fiber_terminated { outcome })
+	                  (Keeper_state_machine.Fiber_terminated { outcome; provider_id = None; http_status = None })
 	              with
               | Ok _ -> ()
               | Error e ->
@@ -546,7 +546,7 @@ let launch_supervised_fiber
 	                Keeper_registry.dispatch_event_unit
 	                  ~base_path
 	                  meta.name
-	                  (Keeper_state_machine.Fiber_terminated { outcome });
+	                  (Keeper_state_machine.Fiber_terminated { outcome; provider_id = None; http_status = None });
                 if resolve_done (`Crashed reason)
                 then
                   publish_phase_lifecycle
@@ -1658,7 +1658,7 @@ let sweep_and_recover (ctx : _ context) =
 	        (Keeper_registry.dispatch_event_and_log
 	           ~base_path
 	           entry.name
-	           (Keeper_state_machine.Fiber_terminated { outcome }));
+	           (Keeper_state_machine.Fiber_terminated { outcome; provider_id = None; http_status = None }));
       let ts = Time_compat.now () in
       Keeper_registry.record_crash ~base_path entry.name ts msg;
       Keeper_registry.record_error ~base_path entry.name msg;

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -658,7 +658,9 @@ let make_post_turn_resilience_executor
     let detail = short_resilience_detail detail in
     let latest_meta = current_keeper_meta ~config ~fallback_meta:meta in
     Keeper_registry.set_failure_reason ~base_path:config.base_path meta.name
-      (Some (Keeper_registry.Provider_runtime_error { code; detail }));
+      (Some
+         (Keeper_registry.Provider_runtime_error
+            { code; detail; provider_id = None; http_status = None }));
     match sync_keeper_paused_state ~config ~meta:latest_meta ~paused:true with
     | Ok paused_meta ->
         on_paused paused_meta;

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -117,7 +117,11 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
   | Some (Cascade_error_classify.Cascade_exhausted { reason; _ }) ->
     Some
       (Keeper_registry.Provider_runtime_error
-         { code = cascade_exhaustion_reason_code reason; detail })
+         { code = cascade_exhaustion_reason_code reason
+         ; detail
+         ; provider_id = None
+         ; http_status = None
+         })
   | Some
       ( Cascade_error_classify.Resumable_cli_session _
       | Cascade_error_classify.No_tool_capable_provider _
@@ -160,7 +164,11 @@ let registry_failure_reason_of_terminal_reason
   | Keeper_turn_disposition.Provider_error c ->
     Some
       (Keeper_registry.Provider_runtime_error
-         { code = Keeper_turn_terminal_code.to_wire c; detail })
+         { code = Keeper_turn_terminal_code.to_wire c
+         ; detail
+         ; provider_id = None
+         ; http_status = None
+         })
   | Keeper_turn_disposition.Success
   | Keeper_turn_disposition.External_cancel
   | Keeper_turn_disposition.Turn_wall_clock_timeout

--- a/test/dune
+++ b/test/dune
@@ -157,6 +157,7 @@
   test_keeper_deliberation
   test_cascade_attempt_provenance
   test_keeper_registry
+  test_keeper_registry_provenance
   test_keeper_fd_pressure_fleet
   test_docker_spawn_throttle
   test_keeper_supervisor
@@ -451,6 +452,7 @@
   test_keeper_deliberation
   test_cascade_attempt_provenance
   test_keeper_registry
+  test_keeper_registry_provenance
   test_keeper_fd_pressure_fleet
   test_docker_spawn_throttle
   test_keeper_supervisor

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -78,7 +78,7 @@ let test_crash_heartbeat_failure () =
   let reason_str = R.failure_reason_to_string reason in
   R.set_failure_reason ~base_path:bp "hb-crash" (Some reason);
   ignore (R.dispatch_event ~base_path:bp "hb-crash"
-    (KSM.Fiber_terminated { outcome = "heartbeat_failure" }));
+    (KSM.Fiber_terminated { outcome = "heartbeat_failure"; provider_id = None; http_status = None }));
   R.record_crash ~base_path:bp "hb-crash" 1000.0 reason_str;
   R.record_error ~base_path:bp "hb-crash" reason_str;
   Eio.Promise.resolve reg.done_r (`Crashed reason_str);
@@ -110,7 +110,7 @@ let test_crash_generic_exception () =
   let reason_str = R.failure_reason_to_string fr in
   R.set_failure_reason ~base_path:bp "exn-crash" (Some fr);
   ignore (R.dispatch_event ~base_path:bp "exn-crash"
-    (KSM.Fiber_terminated { outcome = "exception" }));
+    (KSM.Fiber_terminated { outcome = "exception"; provider_id = None; http_status = None }));
   R.record_crash ~base_path:bp "exn-crash" 1001.0 reason_str;
   R.record_error ~base_path:bp "exn-crash" reason_str;
   Eio.Promise.resolve reg.done_r (`Crashed reason_str);
@@ -135,7 +135,7 @@ let test_crash_fiber_unresolved () =
   R.record_crash ~base_path:bp "unresolved" 1002.0 reason_str;
   R.record_error ~base_path:bp "unresolved" reason_str;
   ignore (R.dispatch_event ~base_path:bp "unresolved"
-    (KSM.Fiber_terminated { outcome = "unresolved" }));
+    (KSM.Fiber_terminated { outcome = "unresolved"; provider_id = None; http_status = None }));
   Eio.Promise.resolve reg.done_r (`Crashed reason_str);
   match R.get ~base_path:bp "unresolved" with
   | None -> fail "expected unresolved"
@@ -161,7 +161,7 @@ let test_dead_tombstone_full_lifecycle () =
   (* Crash *)
   Eio.Promise.resolve reg.done_r (`Crashed "test");
   ignore (R.dispatch_event ~base_path:bp "mortal"
-    (KSM.Fiber_terminated { outcome = "test" }));
+    (KSM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }));
   (* Simulate budget exhaustion *)
   let max_restarts = Cfg.KeeperSupervisor.max_restarts in
   R.restore_supervisor_state ~base_path:bp "mortal"
@@ -183,7 +183,7 @@ let test_dead_tombstone_full_lifecycle () =
    | None -> fail "expected mortal");
   (* Dead → Crashed blocked *)
   ignore (R.dispatch_event ~base_path:bp "mortal"
-    (KSM.Fiber_terminated { outcome = "test" }));
+    (KSM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }));
   (match R.get ~base_path:bp "mortal" with
    | Some e -> check string "still dead after Crashed attempt" "dead"
        (KSM.phase_to_string e.phase)
@@ -207,7 +207,7 @@ let test_self_preservation_suppresses_dominant () =
   let entries = List.map (fun name ->
     let _reg = R.register ~base_path:bp name (make_meta name) in
     ignore (R.dispatch_event ~base_path:bp name
-      (KSM.Fiber_terminated { outcome = "test" }));
+      (KSM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }));
     let reason = if String.length name > 4 && String.sub name 3 2 = "hb"
       then Some (R.Heartbeat_consecutive_failures 5)
       else Some (R.Exception "timeout") in
@@ -237,7 +237,7 @@ let test_self_preservation_below_threshold () =
   R.clear ();
   let _reg = R.register ~base_path:bp "lone" (make_meta "lone") in
   ignore (R.dispatch_event ~base_path:bp "lone"
-    (KSM.Fiber_terminated { outcome = "test" }));
+    (KSM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }));
   R.set_failure_reason ~base_path:bp "lone"
     (Some (R.Heartbeat_consecutive_failures 3));
   let entry = match R.get ~base_path:bp "lone" with
@@ -252,7 +252,7 @@ let test_self_preservation_min_candidates_not_met () =
   R.clear ();
   let _reg = R.register ~base_path:bp "solo" (make_meta "solo") in
   ignore (R.dispatch_event ~base_path:bp "solo"
-    (KSM.Fiber_terminated { outcome = "test" }));
+    (KSM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }));
   R.set_failure_reason ~base_path:bp "solo"
     (Some (R.Heartbeat_consecutive_failures 3));
   let entry = match R.get ~base_path:bp "solo" with
@@ -283,7 +283,7 @@ let test_reconcile_predicate_sweep_owned () =
    | None -> fail "expected r1");
   (* Crashed = sweep-owned *)
   ignore (R.dispatch_event ~base_path:bp "r1"
-    (KSM.Fiber_terminated { outcome = "test" }));
+    (KSM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }));
   (match R.get ~base_path:bp "r1" with
    | Some e -> check bool "crashed is sweep-owned" true
        (e.phase = KSM.Crashed)
@@ -351,7 +351,7 @@ let test_restart_state_preservation () =
   let reg1 = R.register ~base_path:bp "restartable" meta in
   Eio.Promise.resolve reg1.done_r (`Crashed "first crash");
   ignore (R.dispatch_event ~base_path:bp "restartable"
-    (KSM.Fiber_terminated { outcome = "first crash" }));
+    (KSM.Fiber_terminated { outcome = "first crash"; provider_id = None; http_status = None }));
   R.record_crash ~base_path:bp "restartable" 100.0 "first crash";
   (* Simulate sweep restart: re-register then restore state *)
   let _reg2 = R.register ~base_path:bp "restartable" meta in
@@ -385,7 +385,7 @@ let test_crash_turn_failures () =
   let reason_str = R.failure_reason_to_string reason in
   R.set_failure_reason ~base_path:bp "turn-crash" (Some reason);
   ignore (R.dispatch_event ~base_path:bp "turn-crash"
-    (KSM.Fiber_terminated { outcome = "turn failure" }));
+    (KSM.Fiber_terminated { outcome = "turn failure"; provider_id = None; http_status = None }));
   R.record_crash ~base_path:bp "turn-crash" 2000.0 reason_str;
   R.record_error ~base_path:bp "turn-crash" reason_str;
   Eio.Promise.resolve reg.done_r (`Crashed reason_str);
@@ -562,7 +562,7 @@ let test_stop_keepalive_preserves_existing_crash_outcome () =
   let reg = R.register ~base_path:bp keeper_name (make_meta keeper_name) in
   let reason = "already crashed" in
   ignore (R.dispatch_event ~base_path:bp keeper_name
-    (KSM.Fiber_terminated { outcome = "already crashed" }));
+    (KSM.Fiber_terminated { outcome = "already crashed"; provider_id = None; http_status = None }));
   Eio.Promise.resolve reg.done_r (`Crashed reason);
   Masc_mcp.Keeper_keepalive.stop_keepalive keeper_name;
   match R.get ~base_path:bp keeper_name with
@@ -628,7 +628,7 @@ let test_pipeline_stage_unregistered_is_offline () =
    | None -> fail "registered keeper must have a phase");
   (* Crash the keeper and verify phase + stage update *)
   ignore (R.dispatch_event ~base_path:bp "alive"
-    (KSM.Fiber_terminated { outcome = "test" }));
+    (KSM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }));
   (match R.get_phase ~base_path:bp "alive" with
    | Some phase ->
      let stage = ES.pipeline_stage_of_phase phase in

--- a/test/test_keeper_lifecycle_chaos.ml
+++ b/test/test_keeper_lifecycle_chaos.ml
@@ -78,7 +78,7 @@ let setup name =
 let crash_keeper name =
   let tr = dispatch name (KSM.Heartbeat_failed { consecutive = 5; max_allowed = 5 }) in
   check phase_t "failing" KSM.Failing tr.new_phase;
-  let tr = dispatch name (KSM.Fiber_terminated { outcome = "crash" }) in
+  let tr = dispatch name (KSM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None }) in
   check phase_t "crashed" KSM.Crashed tr.new_phase
 
 let restart_keeper name ~attempt =
@@ -103,7 +103,7 @@ let test_heartbeat_failure_cascade () =
   check phase_t "2nd failure → failing" KSM.Failing tr.new_phase;
 
   let tr = dispatch "hb-fail"
-    (KSM.Fiber_terminated { outcome = "heartbeat exceeded max" }) in
+    (KSM.Fiber_terminated { outcome = "heartbeat exceeded max"; provider_id = None; http_status = None }) in
   check phase_t "fiber death → crashed" KSM.Crashed tr.new_phase
 
 let test_supervisor_restart_cycle () =
@@ -140,7 +140,7 @@ let test_compaction_crash_recovery () =
   check phase_t "2nd compact → running" KSM.Running tr.new_phase;
 
   let tr = dispatch "compact"
-    (KSM.Fiber_terminated { outcome = "cascading OOM" }) in
+    (KSM.Fiber_terminated { outcome = "cascading OOM"; provider_id = None; http_status = None }) in
   check phase_t "fiber death → crashed" KSM.Crashed tr.new_phase;
   restart_keeper "compact" ~attempt:1
 
@@ -197,7 +197,7 @@ let test_full_chaos_sequence () =
     (KSM.Handoff_completed { new_trace_id = "trace-fail"; generation = 1 }) in
   check phase_t "handoff complete → running" KSM.Running tr.new_phase;
   let tr = dispatch "chaos"
-    (KSM.Fiber_terminated { outcome = "handoff target unreachable" }) in
+    (KSM.Fiber_terminated { outcome = "handoff target unreachable"; provider_id = None; http_status = None }) in
   check phase_t "post-handoff crash" KSM.Crashed tr.new_phase;
 
   restart_keeper "chaos" ~attempt:1;

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -591,7 +591,8 @@ let test_stale_broadcast_payload_uses_low_cardinality_stale_reason () =
 let test_stale_broadcast_payload_preserves_provider_failure_reason () =
   let failure_reason =
     Masc_mcp.Keeper_registry.Provider_runtime_error
-      { code = "api_error_timeout"; detail = "Timeout after 300.0s" }
+      { code = "api_error_timeout"; detail = "Timeout after 300.0s"
+      ; provider_id = None; http_status = None }
   in
   let payload =
     R.stale_broadcast_payload

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -927,7 +927,7 @@ let test_extended_states () =
   R.clear ();
   let _entry = R.register ~base_path:bp "k4x" (make_meta "k4x") in
   ignore (R.dispatch_event ~base_path:bp "k4x"
-    (KSM.Fiber_terminated { outcome = "test" }));
+    (KSM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }));
   (match R.get ~base_path:bp "k4x" with
    | None -> fail "expected k4x"
    | Some e -> check string "crashed string" "crashed" (KSM.phase_to_string e.phase));
@@ -1272,7 +1272,7 @@ let test_fiber_health_crashed_state_without_done_signal () =
   R.clear ();
   let _entry = R.register ~base_path:bp "fh3-state" (make_meta "fh3-state") in
   ignore (R.dispatch_event ~base_path:bp "fh3-state"
-    (KSM.Fiber_terminated { outcome = "test" }));
+    (KSM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }));
   match R.fiber_health_of ~base_path:bp "fh3-state" with
   | Keeper_types.Fiber_zombie -> ()
   | _ -> fail "expected Fiber_zombie for explicit crashed state"

--- a/test/test_keeper_registry_provenance.ml
+++ b/test/test_keeper_registry_provenance.ml
@@ -1,0 +1,162 @@
+(** RFC-0127 PR-1 — provenance carrier tests.
+
+    PR-1 widens [Keeper_state_machine.Fiber_terminated] and
+    [Keeper_registry.Provider_runtime_error] with optional
+    [provider_id : string option] and [http_status : int option] fields.
+    These tests verify:
+
+    - the carrier preserves values across construction
+    - [event_to_string] and [failure_reason_to_string] surface the fields
+      with [provider=X http=N] suffix when set
+    - the [None / None] forms remain byte-identical to pre-PR-1 output
+    - JSON serializer round-trips the optional fields
+
+    Data flow (cascade [Provider_error.ServerError] → these fields) is
+    PR-2 scope; PR-1 only ships the typed carrier. *)
+
+open Alcotest
+
+module KSM = Masc_mcp.Keeper_state_machine
+module R = Masc_mcp.Keeper_registry
+
+let test_fiber_terminated_carrier_none () =
+  let ev =
+    KSM.Fiber_terminated
+      { outcome = "fiber_unresolved"
+      ; provider_id = None
+      ; http_status = None
+      }
+  in
+  (check string)
+    "event_to_string: None/None is byte-identical to pre-PR-1"
+    "fiber_terminated(fiber_unresolved)"
+    (KSM.event_to_string ev)
+
+let test_fiber_terminated_carrier_some () =
+  let ev =
+    KSM.Fiber_terminated
+      { outcome = "fiber_unresolved"
+      ; provider_id = Some "runpod_mtp"
+      ; http_status = Some 502
+      }
+  in
+  let s = KSM.event_to_string ev in
+  (check bool)
+    "event_to_string contains provider=runpod_mtp"
+    true
+    (Astring.String.is_infix ~affix:"provider=runpod_mtp" s);
+  (check bool)
+    "event_to_string contains http=502"
+    true
+    (Astring.String.is_infix ~affix:"http=502" s)
+
+let test_fiber_terminated_carrier_partial () =
+  let ev =
+    KSM.Fiber_terminated
+      { outcome = "crash"
+      ; provider_id = Some "glm_coding"
+      ; http_status = None
+      }
+  in
+  let s = KSM.event_to_string ev in
+  (check bool)
+    "event_to_string contains provider=glm_coding"
+    true
+    (Astring.String.is_infix ~affix:"provider=glm_coding" s);
+  (check bool)
+    "event_to_string does not contain http= when http_status = None"
+    false
+    (Astring.String.is_infix ~affix:"http=" s)
+
+let test_provider_runtime_error_carrier_none () =
+  let r =
+    R.Provider_runtime_error
+      { code = "provider_error"
+      ; detail = "kimi unicode crash"
+      ; provider_id = None
+      ; http_status = None
+      }
+  in
+  (check string)
+    "failure_reason_to_string: None/None is byte-identical to pre-PR-1"
+    "provider_runtime_error(provider_error:kimi unicode crash)"
+    (R.failure_reason_to_string r)
+
+let test_provider_runtime_error_carrier_some () =
+  let r =
+    R.Provider_runtime_error
+      { code = "api_error_timeout"
+      ; detail = "Timeout after 300.0s"
+      ; provider_id = Some "runpod_mtp"
+      ; http_status = Some 502
+      }
+  in
+  let s = R.failure_reason_to_string r in
+  (check bool)
+    "failure_reason_to_string contains provider=runpod_mtp"
+    true
+    (Astring.String.is_infix ~affix:"provider=runpod_mtp" s);
+  (check bool)
+    "failure_reason_to_string contains http=502"
+    true
+    (Astring.String.is_infix ~affix:"http=502" s)
+
+let test_json_serializer_none () =
+  let ev =
+    KSM.Fiber_terminated
+      { outcome = "fiber_unresolved"
+      ; provider_id = None
+      ; http_status = None
+      }
+  in
+  let json = KSM.event_to_json ev in
+  let s = Yojson.Safe.to_string json in
+  (check bool)
+    "JSON does not include provider_id when None"
+    false
+    (Astring.String.is_infix ~affix:"provider_id" s);
+  (check bool)
+    "JSON does not include http_status when None"
+    false
+    (Astring.String.is_infix ~affix:"http_status" s)
+
+let test_json_serializer_some () =
+  let ev =
+    KSM.Fiber_terminated
+      { outcome = "fiber_unresolved"
+      ; provider_id = Some "runpod_mtp"
+      ; http_status = Some 502
+      }
+  in
+  let json = KSM.event_to_json ev in
+  let s = Yojson.Safe.to_string json in
+  (check bool)
+    "JSON includes provider_id when Some"
+    true
+    (Astring.String.is_infix ~affix:"\"provider_id\":\"runpod_mtp\"" s);
+  (check bool)
+    "JSON includes http_status when Some"
+    true
+    (Astring.String.is_infix ~affix:"\"http_status\":502" s)
+
+let () =
+  run "keeper_registry_provenance"
+    [ ( "fiber_terminated_carrier"
+      , [ test_case "none/none byte-identical" `Quick
+            test_fiber_terminated_carrier_none
+        ; test_case "some/some surfaces both" `Quick
+            test_fiber_terminated_carrier_some
+        ; test_case "partial (provider only)" `Quick
+            test_fiber_terminated_carrier_partial
+        ] )
+    ; ( "provider_runtime_error_carrier"
+      , [ test_case "none/none byte-identical" `Quick
+            test_provider_runtime_error_carrier_none
+        ; test_case "some/some surfaces both" `Quick
+            test_provider_runtime_error_carrier_some
+        ] )
+    ; ( "json_serializer"
+      , [ test_case "none omits fields" `Quick test_json_serializer_none
+        ; test_case "some emits fields" `Quick test_json_serializer_some
+        ] )
+    ]

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -288,7 +288,7 @@ let test_apply_drain_fiber_death () =
     apply_ok
       ~current_phase:SM.Draining
       ~conditions:draining_conds
-      ~event:(SM.Fiber_terminated { outcome = "exception during drain" })
+      ~event:(SM.Fiber_terminated { outcome = "exception during drain"; provider_id = None; http_status = None })
   in
   check phase_t "Draining + fiber death -> Crashed" SM.Crashed tr.new_phase
 ;;
@@ -302,7 +302,7 @@ let test_apply_drain_complete_then_fiber_exit () =
     apply_ok
       ~current_phase:SM.Draining
       ~conditions:drain_done_conds
-      ~event:(SM.Fiber_terminated { outcome = "clean exit" })
+      ~event:(SM.Fiber_terminated { outcome = "clean exit"; provider_id = None; http_status = None })
   in
   check phase_t "drain complete + fiber exit -> Stopped" SM.Stopped tr.new_phase
 ;;
@@ -314,7 +314,7 @@ let test_apply_failing_to_crashed () =
     apply_ok
       ~current_phase:SM.Failing
       ~conditions:failing_conds
-      ~event:(SM.Fiber_terminated { outcome = "fatal" })
+      ~event:(SM.Fiber_terminated { outcome = "fatal"; provider_id = None; http_status = None })
   in
   check phase_t "Failing + fiber death -> Crashed" SM.Crashed tr.new_phase
 ;;
@@ -336,7 +336,7 @@ let test_apply_fiber_terminated_crash () =
     apply_ok
       ~current_phase:SM.Running
       ~conditions:running_conditions
-      ~event:(SM.Fiber_terminated { outcome = "exception" })
+      ~event:(SM.Fiber_terminated { outcome = "exception"; provider_id = None; http_status = None })
   in
   (* fiber_alive=false + budget_remaining=true + backoff not elapsed = Crashed *)
   check phase_t "-> Crashed" SM.Crashed tr.new_phase;
@@ -412,7 +412,7 @@ let test_apply_compacting_to_crashed () =
     apply_ok
       ~current_phase:SM.Compacting
       ~conditions:compacting_conds
-      ~event:(SM.Fiber_terminated { outcome = "crash during compaction" })
+      ~event:(SM.Fiber_terminated { outcome = "crash during compaction"; provider_id = None; http_status = None })
   in
   check phase_t "Compacting + fiber death -> Crashed" SM.Crashed tr.new_phase
 ;;
@@ -424,7 +424,7 @@ let test_apply_handingoff_to_crashed () =
     apply_ok
       ~current_phase:SM.HandingOff
       ~conditions:handoff_conds
-      ~event:(SM.Fiber_terminated { outcome = "crash during handoff" })
+      ~event:(SM.Fiber_terminated { outcome = "crash during handoff"; provider_id = None; http_status = None })
   in
   check phase_t "HandingOff + fiber death -> Crashed" SM.Crashed tr.new_phase
 ;;
@@ -451,7 +451,7 @@ let test_apply_restarting_to_crashed () =
     apply_ok
       ~current_phase:SM.Restarting
       ~conditions:restarting_conds
-      ~event:(SM.Fiber_terminated { outcome = "restart failed" })
+      ~event:(SM.Fiber_terminated { outcome = "restart failed"; provider_id = None; http_status = None })
   in
   check phase_t "Restarting + fiber death -> Crashed" SM.Crashed tr.new_phase
 ;;
@@ -1076,7 +1076,7 @@ let test_chain_crash_recovery () =
       ~init_conditions:running_conditions
       [ SM.Heartbeat_failed { consecutive = 3; max_allowed = 5 }, SM.Failing
       ; SM.Heartbeat_failed { consecutive = 5; max_allowed = 5 }, SM.Failing
-      ; SM.Fiber_terminated { outcome = "hb threshold exceeded" }, SM.Crashed
+      ; SM.Fiber_terminated { outcome = "hb threshold exceeded"; provider_id = None; http_status = None }, SM.Crashed
       ; SM.Supervisor_restart_attempt { attempt = 1 }, SM.Restarting
       ; SM.Fiber_started, SM.Running
       ; SM.Heartbeat_ok, SM.Running
@@ -1093,13 +1093,13 @@ let test_chain_death_spiral () =
     chain_apply
       ~init_phase:SM.Running
       ~init_conditions:running_conditions
-      [ SM.Fiber_terminated { outcome = "OOM" }, SM.Crashed
+      [ SM.Fiber_terminated { outcome = "OOM"; provider_id = None; http_status = None }, SM.Crashed
       ; SM.Supervisor_restart_attempt { attempt = 1 }, SM.Restarting
       ; SM.Fiber_started, SM.Running
-      ; SM.Fiber_terminated { outcome = "OOM again" }, SM.Crashed
+      ; SM.Fiber_terminated { outcome = "OOM again"; provider_id = None; http_status = None }, SM.Crashed
       ; SM.Supervisor_restart_attempt { attempt = 2 }, SM.Restarting
       ; SM.Fiber_started, SM.Running
-      ; SM.Fiber_terminated { outcome = "OOM third time" }, SM.Crashed
+      ; SM.Fiber_terminated { outcome = "OOM third time"; provider_id = None; http_status = None }, SM.Crashed
       ; SM.Restart_budget_exhausted, SM.Dead
       ]
   in
@@ -1223,7 +1223,7 @@ let test_chain_crash_during_compaction_recovery () =
       ~init_phase:SM.Running
       ~init_conditions:running_conditions
       [ SM.Compaction_started, SM.Compacting
-      ; SM.Fiber_terminated { outcome = "segfault in compactor" }, SM.Crashed
+      ; SM.Fiber_terminated { outcome = "segfault in compactor"; provider_id = None; http_status = None }, SM.Crashed
       ; SM.Supervisor_restart_attempt { attempt = 1 }, SM.Restarting
       ; SM.Fiber_started, SM.Running
       ; SM.Heartbeat_ok, SM.Running
@@ -1324,7 +1324,7 @@ let test_chain_restart_inherits_paused () =
       ~init_phase:SM.Running
       ~init_conditions:running_conditions
       [ SM.Operator_pause, SM.Paused
-      ; SM.Fiber_terminated { outcome = "OOM while paused" }, SM.Crashed
+      ; SM.Fiber_terminated { outcome = "OOM while paused"; provider_id = None; http_status = None }, SM.Crashed
       ; SM.Supervisor_restart_attempt { attempt = 1 }, SM.Restarting
       ; SM.Fiber_started, SM.Paused
       ]
@@ -1348,7 +1348,7 @@ let test_chain_restart_clears_stop () =
       ~init_phase:SM.Running
       ~init_conditions:running_conditions
       [ SM.Stop_requested, SM.Draining
-      ; SM.Fiber_terminated { outcome = "crash during drain" }, SM.Crashed
+      ; SM.Fiber_terminated { outcome = "crash during drain"; provider_id = None; http_status = None }, SM.Crashed
       ; SM.Supervisor_restart_attempt { attempt = 1 }, SM.Restarting
       ; (* Fiber starts: stop_requested is reset → Running, not Draining *)
         SM.Fiber_started, SM.Running
@@ -1472,7 +1472,7 @@ let test_chain_no_phoenix () =
     chain_apply
       ~init_phase:SM.Running
       ~init_conditions:running_conditions
-      [ SM.Fiber_terminated { outcome = "fatal" }, SM.Crashed
+      [ SM.Fiber_terminated { outcome = "fatal"; provider_id = None; http_status = None }, SM.Crashed
       ; SM.Restart_budget_exhausted, SM.Dead
       ]
   in
@@ -1508,7 +1508,7 @@ let test_chain_no_phoenix () =
     ; SM.Stop_requested
     ; SM.Drain_complete
     ; SM.Fiber_started
-    ; SM.Fiber_terminated { outcome = "test" }
+    ; SM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }
     ; SM.Supervisor_restart_attempt { attempt = 99 }
     ; SM.Restart_budget_exhausted
     ; SM.Guardrail_stop { reason = "test" }
@@ -1548,15 +1548,15 @@ let test_chain_triple_restart_survives () =
       ~init_phase:SM.Running
       ~init_conditions:running_conditions
       [ (* Crash 1 *)
-        SM.Fiber_terminated { outcome = "crash 1" }, SM.Crashed
+        SM.Fiber_terminated { outcome = "crash 1"; provider_id = None; http_status = None }, SM.Crashed
       ; SM.Supervisor_restart_attempt { attempt = 1 }, SM.Restarting
       ; SM.Fiber_started, SM.Running
       ; (* Crash 2 *)
-        SM.Fiber_terminated { outcome = "crash 2" }, SM.Crashed
+        SM.Fiber_terminated { outcome = "crash 2"; provider_id = None; http_status = None }, SM.Crashed
       ; SM.Supervisor_restart_attempt { attempt = 2 }, SM.Restarting
       ; SM.Fiber_started, SM.Running
       ; (* Crash 3 *)
-        SM.Fiber_terminated { outcome = "crash 3" }, SM.Crashed
+        SM.Fiber_terminated { outcome = "crash 3"; provider_id = None; http_status = None }, SM.Crashed
       ; SM.Supervisor_restart_attempt { attempt = 3 }, SM.Restarting
       ; SM.Fiber_started, SM.Running
       ; (* Finally stabilizes *)
@@ -1644,7 +1644,7 @@ let test_chain_condition_snapshot_audit () =
     apply_ok
       ~current_phase:SM.Running
       ~conditions:tr1.updated_conditions
-      ~event:(SM.Fiber_terminated { outcome = "crash" })
+      ~event:(SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None })
   in
   check phase_t "step 2" SM.Crashed tr2.new_phase;
   check bool "fiber dead" false tr2.updated_conditions.fiber_alive;
@@ -1855,7 +1855,7 @@ let test_invariant_no_cross_life_hb_leakage () =
     apply_ok
       ~current_phase:SM.Failing
       ~conditions:life1_conds
-      ~event:(SM.Fiber_terminated { outcome = "too many hb failures" })
+      ~event:(SM.Fiber_terminated { outcome = "too many hb failures"; provider_id = None; http_status = None })
   in
   check
     bool
@@ -1893,7 +1893,7 @@ let test_invariant_no_cross_life_backoff_leakage () =
     chain_apply
       ~init_phase:SM.Running
       ~init_conditions:running_conditions
-      [ SM.Fiber_terminated { outcome = "crash 1" }, SM.Crashed
+      [ SM.Fiber_terminated { outcome = "crash 1"; provider_id = None; http_status = None }, SM.Crashed
       ; SM.Supervisor_restart_attempt { attempt = 1 }, SM.Restarting
       ; SM.Fiber_started, SM.Running
       ]
@@ -1905,7 +1905,7 @@ let test_invariant_no_cross_life_backoff_leakage () =
     apply_ok
       ~current_phase:SM.Running
       ~conditions:post_restart
-      ~event:(SM.Fiber_terminated { outcome = "crash 2" })
+      ~event:(SM.Fiber_terminated { outcome = "crash 2"; provider_id = None; http_status = None })
   in
   check phase_t "second crash -> Crashed (not Restarting)" SM.Crashed tr.new_phase;
   check bool "backoff_elapsed still false" false tr.updated_conditions.backoff_elapsed
@@ -1919,7 +1919,7 @@ let test_invariant_no_cross_life_buffer_leakage () =
       ~init_phase:SM.Running
       ~init_conditions:running_conditions
       [ SM.Compaction_started, SM.Compacting
-      ; SM.Fiber_terminated { outcome = "crash during compaction" }, SM.Crashed
+      ; SM.Fiber_terminated { outcome = "crash during compaction"; provider_id = None; http_status = None }, SM.Crashed
       ; SM.Supervisor_restart_attempt { attempt = 1 }, SM.Restarting
       ; SM.Fiber_started, SM.Running
       ]
@@ -1949,7 +1949,7 @@ let test_invariant_stop_requested_monotonic () =
     ; SM.Operator_resume
     ; SM.Guardrail_stop { reason = "test" }
     ; (* Fiber_started intentionally OMITTED — it resets stop *)
-      SM.Fiber_terminated { outcome = "test" }
+      SM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }
     ; SM.Supervisor_restart_attempt { attempt = 1 }
     ; SM.Drain_complete
     ; SM.Context_measured
@@ -2083,7 +2083,7 @@ let test_invariant_derive_matches_matrix () =
     ; SM.Stop_requested
     ; SM.Drain_complete
     ; SM.Fiber_started
-    ; SM.Fiber_terminated { outcome = "test" }
+    ; SM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }
     ; SM.Supervisor_restart_attempt { attempt = 1 }
     ; SM.Restart_budget_exhausted
     ; SM.Credential_archived
@@ -2458,7 +2458,7 @@ let test_setclear_coverage () =
     ; "Stop_requested", SM.Stop_requested
     ; "Drain_complete", SM.Drain_complete
     ; "Fiber_started", SM.Fiber_started
-    ; "Fiber_terminated", SM.Fiber_terminated { outcome = "test" }
+    ; "Fiber_terminated", SM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }
     ; "Supervisor_restart_attempt", SM.Supervisor_restart_attempt { attempt = 1 }
     ; "Restart_budget_exhausted", SM.Restart_budget_exhausted
     ; "Credential_archived", SM.Credential_archived

--- a/test/test_keeper_state_machine_correspondence.ml
+++ b/test/test_keeper_state_machine_correspondence.ml
@@ -288,7 +288,7 @@ let canonical_events : (string * SM.event) list =
     ("OperatorStop", SM.Operator_stop { remove_meta = false });
     ("DrainCompleteEv", SM.Drain_complete);
     ("FiberStarted", SM.Fiber_started);
-    ("FiberTerminated", SM.Fiber_terminated { outcome = "test" });
+    ("FiberTerminated", SM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None });
     ("SupervisorRestartAttempt", SM.Supervisor_restart_attempt { attempt = 1 });
     ("RestartBudgetExhausted", SM.Restart_budget_exhausted);
     ("GuardrailStop", SM.Guardrail_stop { reason = "test" });

--- a/test/test_keeper_state_machine_pbt.ml
+++ b/test/test_keeper_state_machine_pbt.ml
@@ -49,7 +49,7 @@ let gen_event_chaos : SM.event QCheck.Gen.t =
     return SM.Stop_requested;
     return SM.Drain_complete;
     return SM.Fiber_started;
-    return (SM.Fiber_terminated { outcome = "pbt_test" });
+    return (SM.Fiber_terminated { outcome = "pbt_test"; provider_id = None; http_status = None });
     (let* attempt = int_range 1 5 in
      return (SM.Supervisor_restart_attempt { attempt }));
     return SM.Restart_budget_exhausted;
@@ -75,7 +75,7 @@ let valid_events_for_phase (phase : SM.phase) (c : SM.conditions) : SM.event lis
         SM.Operator_pause;
         SM.Stop_requested;
         SM.Operator_stop { remove_meta = false };
-        SM.Fiber_terminated { outcome = "crash" };
+        SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };
         SM.Guardrail_stop { reason = "test" };
         SM.Context_overflow_detected
           { source = `Prompt_rejected;
@@ -84,7 +84,7 @@ let valid_events_for_phase (phase : SM.phase) (c : SM.conditions) : SM.event lis
       ]
     | SM.Failing ->
       [ SM.Heartbeat_ok; SM.Turn_succeeded;
-        SM.Fiber_terminated { outcome = "crash" };
+        SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };
         SM.Stop_requested; SM.Operator_pause;
         SM.Context_overflow_detected
           { source = `Prompt_rejected;
@@ -96,32 +96,32 @@ let valid_events_for_phase (phase : SM.phase) (c : SM.conditions) : SM.event lis
         SM.Operator_compact_requested;
         SM.Operator_clear_requested { preserve_system = true; reason = "pbt" };
         SM.Stop_requested;
-        SM.Fiber_terminated { outcome = "crash" };
+        SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };
       ]
     | SM.Compacting ->
       [ SM.Compaction_completed { before_tokens = 100; after_tokens = 50 };
         SM.Compaction_failed { reason = "test" };
         SM.Heartbeat_failed { consecutive = 1; max_allowed = 5 };
-        SM.Fiber_terminated { outcome = "crash" };
+        SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };
         SM.Stop_requested;
       ]
     | SM.HandingOff ->
       [ SM.Handoff_completed { new_trace_id = "t"; generation = 1 };
         SM.Handoff_failed { reason = "test" };
         SM.Heartbeat_failed { consecutive = 1; max_allowed = 5 };
-        SM.Fiber_terminated { outcome = "crash" };
+        SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };
         SM.Stop_requested;
       ]
     | SM.Draining ->
       [ SM.Drain_complete;
-        SM.Fiber_terminated { outcome = "crash" };
+        SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };
       ]
     | SM.Paused ->
       [ SM.Operator_resume;
         SM.Operator_compact_requested;
         SM.Operator_clear_requested { preserve_system = true; reason = "pbt" };
         SM.Stop_requested; SM.Operator_stop { remove_meta = false };
-        SM.Fiber_terminated { outcome = "crash" };
+        SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };
       ]
     | SM.Crashed ->
       [ SM.Supervisor_restart_attempt { attempt = 1 };
@@ -129,7 +129,7 @@ let valid_events_for_phase (phase : SM.phase) (c : SM.conditions) : SM.event lis
       ]
     | SM.Restarting ->
       [ SM.Fiber_started;
-        SM.Fiber_terminated { outcome = "fail" };
+        SM.Fiber_terminated { outcome = "fail"; provider_id = None; http_status = None };
         SM.Restart_budget_exhausted;
       ]
     | SM.Stopped | SM.Dead | SM.Zombie -> []

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -496,7 +496,7 @@ let test_self_preservation_subset () =
   let entries = List.map (fun name ->
     let _reg = Reg.register ~base_path:bp name (make_meta name) in
     ignore (Reg.dispatch_event ~base_path:bp name
-      (Masc_mcp.Keeper_state_machine.Fiber_terminated { outcome = "test" }));
+      (Masc_mcp.Keeper_state_machine.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }));
     Reg.set_failure_reason ~base_path:bp name
       (Some (Reg.Heartbeat_consecutive_failures 3));
     match Reg.get ~base_path:bp name with

--- a/test/test_keeper_turn_terminal_code_byte_compat.ml
+++ b/test/test_keeper_turn_terminal_code_byte_compat.ml
@@ -60,7 +60,8 @@ let cases : (string * R.failure_reason option) list = [
     Some (R.Oas_timeout_budget_loop { count = 2 });
   "Provider_runtime_error",
     Some (R.Provider_runtime_error
-      { code = "provider_http_500"; detail = "upstream 500" });
+      { code = "provider_http_500"; detail = "upstream 500"
+      ; provider_id = None; http_status = None });
   "Tool_required_unsatisfied",
     Some (R.Tool_required_unsatisfied
       { code = "tool_unsat_no_call"; detail = "no tool" });

--- a/test/test_phase2_self_preservation.ml
+++ b/test/test_phase2_self_preservation.ml
@@ -31,7 +31,7 @@ let test_state_to_string_crashed () =
   R.clear ();
   let _entry = R.register ~base_path:bp "k1" (make_meta "k1") in
   ignore (R.dispatch_event ~base_path:bp "k1"
-    (KSM.Fiber_terminated { outcome = "test" }));
+    (KSM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }));
   match R.get ~base_path:bp "k1" with
   | None -> fail "expected k1"
   | Some e ->
@@ -52,7 +52,7 @@ let test_running_count_crashed () =
   let _e2 = R.register ~base_path:bp "b" (make_meta "b") in
   check int "2 running" 2 (R.count_running ());
   ignore (R.dispatch_event ~base_path:bp "a"
-    (KSM.Fiber_terminated { outcome = "test" }));
+    (KSM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }));
   check int "1 running after crash" 1 (R.count_running ());
   R.mark_dead ~base_path:bp "b" ~at:(Unix.gettimeofday ());
   check int "0 running after dead" 0 (R.count_running ())
@@ -68,7 +68,7 @@ let test_is_registered_crashed () =
   R.clear ();
   let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
   ignore (R.dispatch_event ~base_path:bp "k1"
-    (KSM.Fiber_terminated { outcome = "test" }));
+    (KSM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }));
   check bool "crashed → still registered" true (R.is_registered ~base_path:bp "k1")
 
 let test_is_registered_dead () =
@@ -143,7 +143,7 @@ let test_state_transition_running_crashed_running () =
   let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
   check int "1 running" 1 (R.count_running ());
   ignore (R.dispatch_event ~base_path:bp "k1"
-    (KSM.Fiber_terminated { outcome = "test" }));
+    (KSM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }));
   check int "0 running" 0 (R.count_running ());
   check bool "is_running false" false (R.is_running ~base_path:bp "k1");
   check bool "is_registered true" true (R.is_registered ~base_path:bp "k1");
@@ -228,7 +228,7 @@ let test_dead_tombstone_is_registered () =
   R.clear ();
   let _e = R.register ~base_path:bp "k1" (make_meta "k1") in
   ignore (R.dispatch_event ~base_path:bp "k1"
-    (KSM.Fiber_terminated { outcome = "test" }));
+    (KSM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }));
   R.mark_dead ~base_path:bp "k1" ~at:(Unix.gettimeofday ());
   (* Dead keeper is still registered — reconcile must skip *)
   check bool "Dead is registered" true (R.is_registered ~base_path:bp "k1");

--- a/test/test_stale_kill_class.ml
+++ b/test/test_stale_kill_class.ml
@@ -89,7 +89,8 @@ let test_failure_reason_to_string_provider_runtime_error () =
     "provider_runtime_error(provider_error:kimi unicode crash)"
     (failure_reason_to_string
        (Provider_runtime_error
-          { code = "provider_error"; detail = "kimi unicode crash" }))
+          { code = "provider_error"; detail = "kimi unicode crash"
+          ; provider_id = None; http_status = None }))
 
 let test_failure_reason_to_string_tool_required_unsatisfied () =
   r "Tool_required_unsatisfied includes terminal code"
@@ -167,7 +168,8 @@ let test_terminal_failure_cohort_keys () =
     (failure_reason_cohort_key
        (Some
           (Provider_runtime_error
-             { code = "provider_error"; detail = "x" })));
+             { code = "provider_error"; detail = "x"
+             ; provider_id = None; http_status = None })));
   r "Tool_required_unsatisfied cohort_key" "tool_required_unsatisfied"
     (failure_reason_cohort_key
        (Some
@@ -176,7 +178,8 @@ let test_terminal_failure_cohort_keys () =
 
 let test_stale_watchdog_preserves_terminal_failure_reason () =
   let prior =
-    Provider_runtime_error { code = "provider_error"; detail = "kimi" }
+    Provider_runtime_error { code = "provider_error"; detail = "kimi"
+                           ; provider_id = None; http_status = None }
   in
   let kill_class = Idle_turn { stall_seconds = 305.0 } in
   match stale_watchdog_failure_reason ~prior:(Some prior) ~kill_class with
@@ -291,7 +294,8 @@ let test_batch_root_cause_provider_auth () =
     (root_cause_label
        [
          Provider_runtime_error
-           { code = "auth_error"; detail = "bad key rejected" };
+           { code = "auth_error"; detail = "bad key rejected"
+           ; provider_id = None; http_status = None };
        ])
 
 let test_batch_root_cause_fd_exhaustion () =
@@ -307,7 +311,8 @@ let test_batch_root_cause_mixed () =
     (root_cause_label
        [
          Provider_runtime_error
-           { code = "auth_error"; detail = "bad key rejected" };
+           { code = "auth_error"; detail = "bad key rejected"
+           ; provider_id = None; http_status = None };
          Exception "too many open files";
        ])
 


### PR DESCRIPTION
## Summary

**RFC-0127 PR-1** — provenance threading (Gap B): typed carrier extension for `Keeper_state_machine.Fiber_terminated` and `Keeper_registry.Provider_runtime_error` with `provider_id : string option` and `http_status : int option`.

Purely additive — all existing constructor sites receive `provider_id = None; http_status = None`. Display surfaces (`event_to_string`, `event_to_json`, `failure_reason_to_string`) remain byte-identical when both fields are `None`; when set, suffix becomes `provider=X http=N`.

**Scope**: typed carrier only. Data flow from cascade `Provider_error.ServerError` into these fields is PR-2 scope.

## Commit chain

- `212199b` site (1) widen `Fiber_terminated` + ~43 caller propagation (lib/keeper + 8 test files)
- `5eb1594` site (2) widen `Provider_runtime_error` + 8 caller propagation
- `7951667` site (4) `event_to_string` + JSON serializer + `failure_reason_to_string` surface optional fields
- `d61cc8f` test/test_keeper_registry_provenance.ml (7 cases: carrier preservation + None/None byte-identical + partial Some)

## Test plan

- [ ] `dune build --root . lib/` (silent local pass on chunks 1-3)
- [ ] CI Build and Test runs `test_keeper_registry_provenance.exe`
- [ ] CI verifies pre-PR-1 byte-compat (test_stale_kill_class string assertions unchanged)

## Out of scope

- **site (3)** cascade-attempt `Provider_error.ServerError` extraction — RFC-0127 PR-2 (provider_health probe loop)
- **site (5)** prometheus label emit — PR-2 reuses PR-1 carrier when feeding `record_attempt_result`

Refs: RFC-0127 §3.2 (5 edit sites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
