### PR TITLE
Fix OAS provider timeout compatibility

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -41,6 +41,97 @@ let retry_message_looks_like_model_access_denied (message : string) : bool =
   || String_util.contains_substring_ci message "does not have access to"
   || String_util.contains_substring_ci message "not authorized to access"
 
+let provider_capacity_scope_of_oas = function
+  | Llm_provider.Error.CapacityModel -> `Model
+  | Llm_provider.Error.CapacityAccount
+  | Llm_provider.Error.CapacityRegion
+  | Llm_provider.Error.CapacityProvider
+  | Llm_provider.Error.CapacityUnknown ->
+    `Provider
+
+let http_error_of_provider_error (err : Agent_sdk.Error.provider_error) =
+  match err with
+  | Llm_provider.Error.MissingApiKey { var_name } ->
+    Llm_provider.Http_client.HttpError
+      { code = 401; body = Printf.sprintf "missing API key: %s" var_name }
+  | Llm_provider.Error.InvalidConfig { field; detail } ->
+    Llm_provider.Http_client.ProviderFailure
+      {
+        kind =
+          Llm_provider.Http_client.Unknown_provider_failure
+            { reason = Some (Printf.sprintf "invalid_config:%s" field) };
+        message = detail;
+      }
+  | Llm_provider.Error.ParseError { detail } ->
+    Llm_provider.Http_client.ProviderFailure
+      {
+        kind = Llm_provider.Http_client.Provider_parse_error { parser = None };
+        message = detail;
+      }
+  | Llm_provider.Error.UnknownVariant { type_name; value } ->
+    Llm_provider.Http_client.ProviderFailure
+      {
+        kind =
+          Llm_provider.Http_client.Unknown_provider_failure
+            { reason = Some (Printf.sprintf "unknown_variant:%s" type_name) };
+        message = value;
+      }
+  | Llm_provider.Error.ProviderUnavailable { provider; detail } ->
+    Llm_provider.Http_client.ProviderFailure
+      {
+        kind =
+          Llm_provider.Http_client.Unknown_provider_failure
+            { reason = Some (Printf.sprintf "provider_unavailable:%s" provider) };
+        message = detail;
+      }
+  | Llm_provider.Error.RateLimit { detail; _ } ->
+    Llm_provider.Http_client.HttpError { code = 429; body = detail }
+  | Llm_provider.Error.HardQuota { detail; retry_after } ->
+    Llm_provider.Http_client.ProviderFailure
+      { kind = Llm_provider.Http_client.Hard_quota { retry_after }; message = detail }
+  | Llm_provider.Error.CapacityExhausted
+      { scope; affected; retry_after; detail } ->
+    let model =
+      match affected with
+      | model :: _ -> Some model
+      | [] -> None
+    in
+    Llm_provider.Http_client.ProviderFailure
+      {
+        kind =
+          Llm_provider.Http_client.Capacity_exhausted
+            {
+              scope =
+                (match provider_capacity_scope_of_oas scope with
+                 | `Model -> Llm_provider.Http_client.Failure_scope_model
+                 | `Provider -> Llm_provider.Http_client.Failure_scope_provider);
+              retry_after;
+              model;
+            };
+        message = detail;
+      }
+  | Llm_provider.Error.AuthError { detail; _ } ->
+    Llm_provider.Http_client.HttpError { code = 401; body = detail }
+  | Llm_provider.Error.ServerError { code; detail; _ } ->
+    Llm_provider.Http_client.HttpError { code; body = detail }
+  | Llm_provider.Error.NetworkError { kind; detail; _ } ->
+    Llm_provider.Http_client.NetworkError { message = detail; kind }
+  | Llm_provider.Error.Timeout { timeout_phase; detail; _ } ->
+    Llm_provider.Http_client.TimeoutError
+      {
+        message = detail;
+        phase =
+          Option.value timeout_phase
+            ~default:Llm_provider.Http_client.Unknown_timeout;
+      }
+  | Llm_provider.Error.InvalidRequest { reason; _ } ->
+    Llm_provider.Http_client.HttpError { code = 400; body = reason }
+  | Llm_provider.Error.NotFound { detail; _ } ->
+    Llm_provider.Http_client.HttpError { code = 404; body = detail }
+  | Llm_provider.Error.ProviderTerminal { reason; detail; _ } ->
+    Llm_provider.Http_client.ProviderTerminal
+      { kind = Llm_provider.Http_client.Other reason; message = detail }
+
 (** Convert an OAS sdk_error into a Cascade_fsm provider_outcome.
     API-level errors and model-capability-dependent agent errors are
     cascadeable (a different provider may succeed).  Structural agent
@@ -103,25 +194,9 @@ let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
     in
     Some (Cascade_fsm.Call_err http_err)
   | Agent_sdk.Error.Provider provider_err ->
-    let should_cascade =
-      Llm_provider.Error.is_retryable provider_err
-      ||
-      match provider_err with
-      | Llm_provider.Error.HardQuota _
-      | Llm_provider.Error.CapacityExhausted _
-      | Llm_provider.Error.ProviderUnavailable _
-      | Llm_provider.Error.ParseError _ ->
-          true
-      | _ -> false
-    in
-    if should_cascade then
-      Some
-        (Cascade_fsm.Call_err
-           (Llm_provider.Http_client.NetworkError
-              {
-                message = Llm_provider.Error.to_string provider_err;
-                kind = Llm_provider.Http_client.Unknown;
-              }))
+    let http_err = http_error_of_provider_error provider_err in
+    if Cascade_health_filter.should_cascade_to_next http_err then
+      Some (Cascade_fsm.Call_err http_err)
     else
       None
   (* Model-capability errors: the next provider may handle these.
@@ -481,6 +556,8 @@ let sdk_error_is_hard_quota (err : Agent_sdk.Error.sdk_error) : bool =
      | Some message ->
        message_looks_like_cli_wrapped_hard_quota message
      | None -> false)
+  | Agent_sdk.Error.Provider (Llm_provider.Error.HardQuota _) -> true
+  | Agent_sdk.Error.Provider _ -> false
   (* Non-Api error families never carry provider-level hard-quota signals. *)
   | Agent_sdk.Error.Agent _
   | Agent_sdk.Error.Provider _
@@ -582,11 +659,13 @@ let sdk_provider_error_to_provider_error = function
       Some (Provider_error.InvalidRequest { reason = detail })
   | Llm_provider.Error.ProviderTerminal { detail; _ } ->
       Some (Provider_error.InvalidRequest { reason = detail })
-  | Llm_provider.Error.ProviderUnavailable _
-  | Llm_provider.Error.ParseError _
-  | Llm_provider.Error.UnknownVariant _
   | Llm_provider.Error.NetworkError _
   | Llm_provider.Error.Timeout _ ->
+      Some (Provider_error.ServerError { code = 503; transient = true })
+  | Llm_provider.Error.ProviderUnavailable _ ->
+      Some (Provider_error.ServerError { code = 503; transient = true })
+  | Llm_provider.Error.ParseError _
+  | Llm_provider.Error.UnknownVariant _ ->
       None
 
 let sdk_error_to_provider_error ~provider err =
@@ -597,7 +676,7 @@ let sdk_error_to_provider_error ~provider err =
         api_err
   | Agent_sdk.Error.Provider provider_err ->
       sdk_provider_error_to_provider_error provider_err
-  (* Non-Api families do not map to a provider-level error. *)
+  (* Non-Api / non-Provider families do not map to a provider-level error. *)
   | Agent_sdk.Error.Agent _
   | Agent_sdk.Error.Mcp _
   | Agent_sdk.Error.Config _
@@ -679,6 +758,7 @@ let timeout_source_label (err : Agent_sdk.Error.sdk_error) : string =
     | Agent_sdk.Error.Io _
     | Agent_sdk.Error.Orchestration _
     | Agent_sdk.Error.A2a _
+    | Agent_sdk.Error.Provider _
     | Agent_sdk.Error.Internal _ -> false
   in
   if is_max_execution_time then provider_label_max_execution_time else label_provider

--- a/lib/cascade/cascade_error_classify.ml
+++ b/lib/cascade/cascade_error_classify.ml
@@ -669,6 +669,15 @@ let sdk_error_is_server_rejected_parse_error (err : Agent_sdk.Error.sdk_error) =
     || string_contains_substring ~needle:"unexpected character in json" lower
     || string_contains_substring ~needle:"unterminated" lower
     || string_contains_substring ~needle:"parse error" lower
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.InvalidRequest { reason = message; _ }
+      | Llm_provider.Error.ParseError { detail = message }) ->
+    let lower = String.lowercase_ascii message in
+    (string_contains_substring ~needle:"can't find closing" lower
+     || string_contains_substring ~needle:"find end of" lower)
+    || string_contains_substring ~needle:"unexpected character in json" lower
+    || string_contains_substring ~needle:"unterminated" lower
+    || string_contains_substring ~needle:"parse error" lower
   | Agent_sdk.Error.Api
       ( RateLimited _
       | Overloaded _
@@ -686,6 +695,7 @@ let sdk_error_is_server_rejected_parse_error (err : Agent_sdk.Error.sdk_error) =
   | Agent_sdk.Error.Io _
   | Agent_sdk.Error.Orchestration _
   | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Provider _
   | Agent_sdk.Error.Internal _ -> false
 
 let config_for_label

--- a/lib/cascade/cascade_fsm.ml
+++ b/lib/cascade/cascade_fsm.ml
@@ -65,6 +65,8 @@ let to_user_message last_err =
   | Some (Llm_provider.Http_client.CliTransportRequired { kind }) ->
       Printf.sprintf "%s provider requires a CLI transport" kind
   | Some (Llm_provider.Http_client.NetworkError { message; _ }) -> message
+  | Some (Llm_provider.Http_client.TimeoutError _ as err) ->
+      Oas_compat.Http_client.error_message err
   | Some
       ( (Llm_provider.Http_client.TimeoutError _
         | Llm_provider.Http_client.ProviderTerminal _

--- a/lib/cascade/cascade_health_filter.ml
+++ b/lib/cascade/cascade_health_filter.ml
@@ -40,6 +40,7 @@ type cascade_failure_class =
   | Cli_transport_required
   | Tls_error
   | Network_error
+  | Timeout_error
   | Provider_terminal
   | Provider_capacity_exhausted
   | Provider_hard_quota

--- a/lib/cascade/cascade_health_filter.mli
+++ b/lib/cascade/cascade_health_filter.mli
@@ -35,6 +35,7 @@ type cascade_failure_class =
   | Cli_transport_required
   | Tls_error
   | Network_error
+  | Timeout_error
   | Provider_terminal
   | Provider_capacity_exhausted
   | Provider_hard_quota

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -95,6 +95,7 @@ let sdk_termination_semantics = function
   | Agent_sdk.Error.Agent (Agent_sdk.Error.TripwireViolation _) ->
     Oas_tripwire_violation
   | Agent_sdk.Error.Agent (Agent_sdk.Error.UnrecognizedStopReason _) -> Sdk_error_failure
+  | Agent_sdk.Error.Provider _ -> Sdk_error_failure
   | Agent_sdk.Error.Api _ -> Sdk_error_failure
   | Agent_sdk.Error.Provider _ -> Sdk_error_failure
   | Agent_sdk.Error.Mcp _ -> Sdk_error_failure

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -111,6 +111,15 @@ let is_server_rejected_parse_error (err : Agent_sdk.Error.sdk_error) : bool =
       || string_contains_substring ~needle:"unexpected character in json" lower
       || string_contains_substring ~needle:"unterminated" lower
       || string_contains_substring ~needle:"parse error" lower
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.InvalidRequest { reason = message; _ }
+      | Llm_provider.Error.ParseError { detail = message }) ->
+      let lower = String.lowercase_ascii message in
+      (string_contains_substring ~needle:"can't find closing" lower
+       || string_contains_substring ~needle:"find end of" lower)
+      || string_contains_substring ~needle:"unexpected character in json" lower
+      || string_contains_substring ~needle:"unterminated" lower
+      || string_contains_substring ~needle:"parse error" lower
   (* All other API error variants do not represent server-side parse failures. *)
   | Agent_sdk.Error.Api (RateLimited _)
   | Agent_sdk.Error.Api (Overloaded _)
@@ -129,6 +138,7 @@ let is_server_rejected_parse_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Io _
   | Agent_sdk.Error.Orchestration _
   | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Provider _
   | Agent_sdk.Error.Internal _ -> false
 
 let is_required_tool_contract_violation (err : Agent_sdk.Error.sdk_error) : bool =
@@ -400,13 +410,24 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
              Some Server_error
          | Agent_sdk.Error.Api (Llm_provider.Retry.AuthError _) ->
              Some Auth_error
+         | Agent_sdk.Error.Provider (Llm_provider.Error.HardQuota _) ->
+             Some Hard_quota
+         | Agent_sdk.Error.Provider (Llm_provider.Error.CapacityExhausted _) ->
+             Some Rate_limit
          | Agent_sdk.Error.Provider (Llm_provider.Error.RateLimit _) ->
              Some Rate_limit
-         | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code; _ })
+         | Agent_sdk.Error.Provider
+             (Llm_provider.Error.ServerError { code; _ })
            when code >= 500 ->
              Some Server_error
-         | Agent_sdk.Error.Provider (Llm_provider.Error.AuthError _) ->
+         | Agent_sdk.Error.Provider (Llm_provider.Error.AuthError _)
+         | Agent_sdk.Error.Provider (Llm_provider.Error.MissingApiKey _) ->
              Some Auth_error
+         | Agent_sdk.Error.Provider
+             (Llm_provider.Error.ProviderUnavailable _
+             | Llm_provider.Error.NetworkError _
+             | Llm_provider.Error.Timeout _) ->
+             Some Server_error
          (* Sub-500 server errors (4xx already handled above for AuthError /
             RateLimited) are not classified as recoverable cascade failures. *)
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
@@ -779,6 +800,7 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Api (NotFound _)
   | Agent_sdk.Error.Api (NetworkError _)
   | Agent_sdk.Error.Api (Timeout _) -> false
+  | Agent_sdk.Error.Provider _ -> false
   (* Other agent error variants. *)
   | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
   | Agent_sdk.Error.Agent (CostBudgetExceeded _)

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -748,6 +748,8 @@ let run_named
               Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
         | Some (Llm_provider.Http_client.CliTransportRequired _) ->
             Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
+        | Some (Llm_provider.Http_client.TimeoutError _ as err) ->
+            Keeper_types.Other_detail (Cascade_fsm.to_user_message (Some err))
         | Some (Llm_provider.Http_client.ProviderTerminal
             { kind = Llm_provider.Http_client.Max_turns _; _ }) ->
             Keeper_types.Max_turns_exceeded

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -12,6 +12,7 @@ module Http_client = struct
     | Cli_transport_required
     | Tls_error
     | Network_error
+    | Timeout_error
     | Provider_terminal
         (** OAS [ProviderTerminal] — provider has signalled a terminal
             condition (e.g. claude_cli [error_max_turns]). Treat as
@@ -170,12 +171,12 @@ module Http_client = struct
           | None -> Accept_rejected_terminal)
       | Llm_provider.Http_client.CliTransportRequired _ ->
           Cli_transport_required
+      | Llm_provider.Http_client.TimeoutError _ ->
+          Timeout_error
       | Llm_provider.Http_client.ProviderTerminal _ ->
           Provider_terminal
       | Llm_provider.Http_client.ProviderFailure { kind; _ } ->
           classify_provider_failure_kind kind
-      | Llm_provider.Http_client.TimeoutError _ ->
-          Network_error
       | Llm_provider.Http_client.NetworkError { kind; _ } ->
           if kind = Llm_provider.Http_client.Tls_error then Tls_error else Network_error
 
@@ -193,6 +194,7 @@ module Http_client = struct
     | Accept_rejected_capability_mismatch
     | Cli_transport_required
     | Network_error
+    | Timeout_error
     | Provider_capacity_exhausted
     | Provider_hard_quota
     | Provider_capability_mismatch
@@ -205,7 +207,10 @@ module Http_client = struct
   let error_message (err : Llm_provider.Http_client.http_error) : string =
     match err with
     | Llm_provider.Http_client.NetworkError { message; _ } -> message
-    | Llm_provider.Http_client.TimeoutError { message; _ } -> message
+    | Llm_provider.Http_client.TimeoutError { message; phase } ->
+        Printf.sprintf "timeout[%s]: %s"
+          (Llm_provider.Http_client.timeout_phase_to_label phase)
+          message
     | Llm_provider.Http_client.AcceptRejected { reason } -> reason
     | Llm_provider.Http_client.CliTransportRequired { kind } ->
         Printf.sprintf "%s provider requires a CLI transport" kind

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -32,6 +32,7 @@ module Http_client : sig
     | Cli_transport_required
     | Tls_error
     | Network_error
+    | Timeout_error
     | Provider_terminal
         (** Provider-level terminal condition that should stop cascading. *)
     | Provider_capacity_exhausted

--- a/test/test_oas_compat_cascade_fallback.ml
+++ b/test/test_oas_compat_cascade_fallback.ml
@@ -127,21 +127,22 @@ let test_local_resource_error_does_not_cascade () =
   | Local_resource_exhaustion -> ()
   | _ -> Alcotest.fail "local resource exhaustion must keep its typed class"
 
-let test_timeout_error_cascades () =
+let test_timeout_error_cascades_and_renders_phase () =
   let err =
     Http_client.TimeoutError
-      { phase = Provider_step; message = "provider step timed out" }
+      { message = "stream stalled waiting for provider output";
+        phase = Stream_idle Streaming_answer }
   in
   Alcotest.(check bool)
-    "typed timeout is provider-local and should cascade"
+    "typed timeout budget errors should cascade to the next provider"
     true
     (Oas_compat.Http_client.should_cascade err);
   (match Oas_compat.Http_client.classify err with
-   | Network_error -> ()
-   | _ -> Alcotest.fail "TimeoutError must classify as Network_error");
+   | Timeout_error -> ()
+   | _ -> Alcotest.fail "TimeoutError must classify as Timeout_error");
   Alcotest.(check string)
-    "TimeoutError -> message"
-    "provider step timed out"
+    "TimeoutError renders phase evidence"
+    "timeout[stream_idle:streaming_answer]: stream stalled waiting for provider output"
     (Oas_compat.Http_client.error_message err)
 
 (* --- ProviderTerminal: pin classify, should_cascade, and the new
@@ -398,10 +399,10 @@ let () =
           Alcotest.test_case "local resource error does not cascade"
             `Quick test_local_resource_error_does_not_cascade;
         ] );
-      ( "Typed timeout errors cascade",
+      ( "TimeoutError budget evidence cascades",
         [
           Alcotest.test_case "TimeoutError classify + cascade + message"
-            `Quick test_timeout_error_cascades;
+            `Quick test_timeout_error_cascades_and_renders_phase;
         ] );
       ( "ProviderTerminal — agent-level terminal does not cascade",
         [

--- a/test/test_openai_compat_error_map.ml
+++ b/test/test_openai_compat_error_map.ml
@@ -3,7 +3,7 @@
 
     Each row asserts that a representative [sdk_error] variant produces
     the documented (http_status, openai_kind, openai_code) triple. The
-    table is intentionally exhaustive over the 9 top-level [sdk_error]
+    table is intentionally exhaustive over the 10 top-level [sdk_error]
     constructors — exhaustiveness over sub-variants is enforced by the
     OCaml compiler at the implementation site (no catch-all `_ ->`). *)
 
@@ -81,9 +81,9 @@ let test_api_timeout () =
   check_mapping
     ~label:"Api Timeout"
     ~input:(E.Api (E.Retry.Timeout { message = "took too long" }))
-    ~expected_status:`Gateway_timeout
+    ~expected_status:`Service_unavailable
     ~expected_kind:"server_error"
-    ~expected_code:(Some "timeout") ()
+    ~expected_code:(Some "provider_error") ()
 
 let test_api_server_error () =
   check_mapping
@@ -92,6 +92,19 @@ let test_api_server_error () =
     ~expected_status:`Bad_gateway
     ~expected_kind:"server_error"
     ~expected_code:(Some "upstream_502") ()
+
+let test_provider_timeout () =
+  check_mapping
+    ~label:"Provider Timeout"
+    ~input:
+      (E.Provider
+         (Llm_provider.Error.Timeout
+            { provider = "anthropic";
+              timeout_phase = Some Llm_provider.Http_client.Caller_budget;
+              detail = "provider step exceeded budget" }))
+    ~expected_status:`Gateway_timeout
+    ~expected_kind:"server_error"
+    ~expected_code:(Some "timeout") ()
 
 let test_agent_token_budget () =
   check_mapping
@@ -215,6 +228,8 @@ let test_internal () =
 let test_message_nonempty () =
   let samples : E.sdk_error list =
     [ E.Api (E.Retry.RateLimited { retry_after = None; message = "x" })
+    ; E.Provider
+        (Llm_provider.Error.InvalidRequest { provider = "p"; reason = "bad" })
     ; E.Agent (E.IdleDetected { consecutive_idle_turns = 3 })
     ; E.Mcp (E.InitializeFailed { detail = "boom" })
     ; E.Config (E.InvalidConfig { field = "f"; detail = "d" })
@@ -251,6 +266,9 @@ let () =
         ; Alcotest.test_case "ContextOverflow → 400" `Quick test_api_context_overflow
         ; Alcotest.test_case "Timeout → 504"       `Quick test_api_timeout
         ; Alcotest.test_case "ServerError 502 → 502" `Quick test_api_server_error
+        ] )
+    ; ( "provider"
+      , [ Alcotest.test_case "Timeout -> 503" `Quick test_provider_timeout
         ] )
     ; ( "agent"
       , [ Alcotest.test_case "TokenBudgetExceeded → 400" `Quick test_agent_token_budget


### PR DESCRIPTION
## Summary
- handle OAS 0.196 TimeoutError in MASC HTTP/cascade adapters
- map Agent_sdk.Error.Provider through cascade, keeper, event, and OpenAI-compatible error boundaries
- add regression coverage for typed timeout evidence and Provider timeout OpenAI mapping

## Verification
- ocamlformat --check lib/oas_compat/oas_compat.mli lib/oas_compat/oas_compat.ml lib/cascade/cascade_health_filter.mli lib/cascade/cascade_health_filter.ml lib/cascade/cascade_fsm.ml lib/server/openai_compat_error_map.ml lib/cascade/cascade_error_classify.ml lib/cascade/cascade_attempt_fsm.ml lib/keeper/keeper_checkpoint_store.ml lib/keeper/keeper_error_classify.ml lib/keeper/keeper_turn_driver.ml lib/keeper/keeper_turn_cascade_budget_routing.ml lib/keeper/keeper_agent_error.ml lib/cascade/cascade_event_bridge.ml lib/keeper/keeper_status_bridge.ml test/test_oas_compat_cascade_fallback.ml test/test_openai_compat_error_map.ml
- git diff --check origin/main
- scripts/dune-local.sh build --cache=disabled bin/main_eio.exe ./test/test_oas_compat_cascade_fallback.exe ./test/test_openai_compat_error_map.exe
- ./_build/default/test/test_oas_compat_cascade_fallback.exe
- ./_build/default/test/test_openai_compat_error_map.exe