### PR TITLE
refactor: split prometheus cascade metric names

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -35,6 +35,7 @@
  prometheus_process
  prometheus_transport_metric_names
  prometheus_core_metric_names
+ prometheus_cascade_metric_names
  dashboard_http_keeper_metrics
  dashboard_http_keeper_detail
  dashboard_http_tool_quality

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -274,10 +274,7 @@ let metric_oas_inference_prompt_tok_per_sec = "masc_oas_inference_prompt_tok_per
 let metric_oas_inference_decode_tok_per_sec = "masc_oas_inference_decode_tok_per_sec"
 let metric_oas_inference_cost_usd = "masc_oas_inference_cost_usd"
 
-(* Cascade provider health score — composite of success_rate * speed_score *
-   cost_score.  Set (not observed) because it is a point-in-time snapshot,
-   not a distribution. *)
-let metric_cascade_provider_health_score = "masc_cascade_provider_health_score"
+include Prometheus_cascade_metric_names
 
 (* Context overflow ratio — set each time ContextOverflowImminent fires.
    Ratio is estimated_tokens / limit_tokens in [0.0, 1.0+]. *)
@@ -303,17 +300,6 @@ let metric_inference_queue_cancelled = "masc_inference_queue_cancelled_total"
 let metric_inference_queue_rejected = "masc_inference_queue_rejected_total"
 let metric_inference_queue_max_concurrent = "masc_inference_queue_max_concurrent"
 
-(* Cascade metrics — used in cascade_metrics.ml.
-   Labels: decision=accept|accept_on_exhaustion|try_next|exhausted *)
-let metric_cascade_decisions = "masc_cascade_decisions_total"
-
-(* Labels: reason=call_err|slot_full|accept_rejected|health_filter *)
-let metric_cascade_fallbacks = "masc_cascade_fallbacks_total"
-let metric_cascade_providers_exhausted = "masc_cascade_providers_exhausted_total"
-
-(* Labels: phase=<keeper_phase>, from_cascade=<name>, to_cascade=<name> *)
-let metric_cascade_routing_phase_overrides = "masc_cascade_routing_phase_overrides_total"
-
 (* Agent health metrics — used in transport_metrics.ml. *)
 let metric_agent_heartbeat_age_seconds = "masc_agent_heartbeat_age_seconds"
 let metric_agent_stale_total = "masc_agent_stale_total"
@@ -332,13 +318,6 @@ let metric_pool_inflight_total = Pool_metrics.metric_inflight_total
 let metric_pool_reuse_total = Pool_metrics.metric_reuse_total
 let metric_pool_evict_total = Pool_metrics.metric_evict_total
 let metric_pool_create_total = Pool_metrics.metric_create_total
-
-(* Cascade attempt-liveness streaming histograms.
-   Filled by cascade_attempt_liveness_observer via the recorder injected
-   into L.step.  TTFT = time from request start to first non-Done chunk;
-   TBT = inter-chunk gap during streaming. *)
-let metric_cascade_ttfb_seconds = "masc_cascade_ttfb_seconds"
-let metric_cascade_inter_chunk_seconds = "masc_cascade_inter_chunk_seconds"
 
 (* PR-0.2.D: OCaml GC quick_stat sampler gauges.  Populated by
    [Gc_sampler.run] from the runtime [Gc.quick_stat ()] once per
@@ -390,21 +369,6 @@ let metric_board_truncated_posts = "masc_board_truncated_posts_total"
    useful counter increment. *)
 let metric_board_dispatch_flusher_start_outcomes =
   "masc_board_dispatch_flusher_start_outcomes_total"
-let metric_cascade_strategy_decisions = "masc_cascade_strategy_decisions_total"
-let metric_cascade_capacity_events = "masc_cascade_capacity_events_total"
-
-(* RFC-0022 §9 attempt-liveness gate.  Counts would-be (Observe) and
-   actual (Enforce) liveness kills broken down by failure class.
-   Labels: [kind, mode, provider].
-
-   [observed_total] is the per-attempt finalizer counter regardless of
-   outcome (success | kill | wire_error). Useful for the kill-rate
-   ratio kill / observed. *)
-let metric_cascade_attempt_liveness_kill = "masc_cascade_attempt_liveness_kill_total"
-
-let metric_cascade_attempt_liveness_observed =
-  "masc_cascade_attempt_liveness_observed_total"
-;;
 
 let metric_fsm_guard_violation = "masc_fsm_guard_violation_total"
 let metric_memory_pipeline_flushes = "masc_memory_pipeline_flushes_total"
@@ -456,33 +420,6 @@ let metric_memory_pipeline_flush_duration_seconds =
    result by outcome label (started | not_running | meta_missing |
    meta_read_failed | meta_write_failed). Labels: keeper (for
    attempts) and keeper+outcome (for outcomes). *)
-(* #12797: Cascade server-error score decay — provider deprioritised
-   after recent 5xx events.  Increments each time a provider's server-
-   error score drops the effective weight below the skip threshold.
-   Labels: provider_key. *)
-let metric_cascade_server_error_skip_total = "masc_cascade_server_error_skip_total"
-
-(* 2026-05-05 fleet-stuck diagnosis: cascade A → B → A circular fallback
-   creates a silent 600s timeout chain when every model in both
-   cascades depends on the same provider that has stalled.  This
-   counter increments once per [load_catalog] call when any
-   fallback_cascade chain forms a cycle.  Labels: cascade (the entry
-   point of the cycle).  Operators alert on this counter; cycle
-   participants are listed in the WARN log. *)
-let metric_cascade_fallback_cycle_detected_total =
-  "masc_cascade_fallback_cycle_detected_total"
-;;
-
-let metric_provider_health_probe_skipped = "masc_provider_health_probe_skipped_total"
-let metric_provider_actual_health_status = "masc_provider_actual_health_status"
-
-(* Counter complement to [metric_provider_actual_health_status]: the
-   gauge only shows the LAST observed status, so a flapping or
-   sustained probe failure rate is invisible to operators.  This
-   counter ticks once per [Probe_error _] observation in
-   [Cascade_catalog_runtime.record_probe_metrics] so a [rate()] query
-   can quantify provider liveness churn over time. *)
-let metric_provider_health_probe_error = "masc_provider_health_probe_error_total"
 (* #12799: Passive loop detector — keeper emitting only read-only tool
    calls for N consecutive turns.  Labels: keeper. *)
 

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -191,59 +191,7 @@ val metric_anti_rationalization_excuse_pattern : string
 (** #10113: per-pattern + per-decision counter for the gate 2
     excuse substring detector.  Decision label is
     [advisory_to_llm | terminal_reject | advisory_safety_net_reject]. *)
-val metric_cascade_strategy_decisions : string
-
-val metric_cascade_capacity_events : string
-
-(** RFC-0022 §9 — would-be ([mode=observe]) and actual ([mode=enforce])
-    in-attempt liveness kills, broken down by failure class.
-
-    Labels: [kind, mode, provider] where:
-    - [kind] ∈ [no_first_token | inter_chunk_idle | wall_exceeded | provider_error]
-    - [mode] ∈ [observe | enforce]
-    - [provider] is the cascade label that produced the attempt
-
-    Use the {b observe}-mode counter to calibrate bootstrap and
-    observed-success budgets against [scripts/diag-keeper-cycle.sh]
-    before flipping attempt liveness to {b enforce}. *)
-val metric_cascade_attempt_liveness_kill : string
-
-(** RFC-0022 PR-2 §3 — per-attempt finalizer counter regardless of
-    outcome. Labels: [cascade], [provider], [outcome] ∈ {success |
-    kill | wire_error}. The kill-rate is
-    [kill_total / observed_total]. *)
-val metric_cascade_attempt_liveness_observed : string
-
-(** Histogram: time from cascade attempt start to first non-Done chunk (TTFT).
-    Labels: [cascade], [provider] where [provider] is a bounded public
-    provider bucket. *)
-val metric_cascade_ttfb_seconds : string
-
-(** Histogram: inter-chunk gap during streaming (TBT).
-    Labels: [cascade], [provider] where [provider] is a bounded public
-    provider bucket. *)
-val metric_cascade_inter_chunk_seconds : string
-
-(** Gauge: composite health score per cascade provider.
-    [success_rate * speed_score * cost_score] in [0.0, 1.0].
-    Labels: [provider_key]. *)
-val metric_cascade_provider_health_score : string
-
-(** Counter: cascade routing decisions emitted by [Cascade_fsm.decide].
-    Labels: [decision] in [accept|accept_on_exhaustion|try_next|exhausted]. *)
-val metric_cascade_decisions : string
-
-(** Counter: cascade fallback transitions ([Try_next] outcomes).
-    Labels: [reason] in [call_err|slot_full|accept_rejected|health_filter]. *)
-val metric_cascade_fallbacks : string
-
-(** Counter: terminal exhaustion events emitted when a cascade has no
-    further provider candidates. *)
-val metric_cascade_providers_exhausted : string
-
-(** Counter: cascade routing phase overrides applied during decision.
-    Labels: [phase], [from_cascade], [to_cascade]. *)
-val metric_cascade_routing_phase_overrides : string
+include module type of Prometheus_cascade_metric_names
 
 (** Gauge: context overflow ratio [estimated_tokens / limit_tokens] when
     [ContextOverflowImminent] fires.  Labels: [agent_name]. *)
@@ -252,32 +200,6 @@ val metric_oas_context_overflow_ratio : string
 (** Counter: total context compaction actions from OAS event bus.
     Labels: [agent_name, trigger]. *)
 val metric_oas_context_compaction_total : string
-
-(** #12797 Total cascade label-ranking skips triggered by recent server-error
-    (5xx) score decay for a provider.  Labels: [provider_key]. *)
-val metric_cascade_server_error_skip_total : string
-
-(** Total cascade fallback_cascade cycles detected during [load_catalog].
-    A cycle means a provider stall propagates through every cascade in
-    the loop silently for 600s+ without escaping.  Labels: [cascade]
-    (the entry point of the detected cycle). *)
-val metric_cascade_fallback_cycle_detected_total : string
-
-(** Total bootstrap/runtime-catalog provider health probes intentionally
-    skipped as advisory. Labels: [provider_name, profile_name]. *)
-val metric_provider_health_probe_skipped : string
-
-(** Last advisory provider health status observed by runtime catalog
-    validation. Values: 0=unknown/skipped, 1=healthy, 3=unhealthy.
-    Labels: [provider_name, profile_name, model_id]. *)
-val metric_provider_actual_health_status : string
-
-(** Total provider health probe errors observed during runtime catalog
-    validation. Counter complement to
-    [metric_provider_actual_health_status] — the gauge only shows the
-    last observed status, so a sustained probe failure rate is
-    otherwise invisible. Labels: [provider_name, profile_name]. *)
-val metric_provider_health_probe_error : string
 
 (** PR-I: cross-FSM edge transition counter. Labels: [edge] with values
     drawn from the static coupling graph documented in

--- a/lib/prometheus_cascade_metric_names.ml
+++ b/lib/prometheus_cascade_metric_names.ml
@@ -1,0 +1,29 @@
+(** Cascade routing, liveness, and provider-health metric-name constants.
+
+    Included by {!Prometheus} so existing callers keep using
+    [Prometheus.metric_*] bindings unchanged. *)
+
+let metric_cascade_strategy_decisions = "masc_cascade_strategy_decisions_total"
+let metric_cascade_capacity_events = "masc_cascade_capacity_events_total"
+let metric_cascade_attempt_liveness_kill = "masc_cascade_attempt_liveness_kill_total"
+
+let metric_cascade_attempt_liveness_observed =
+  "masc_cascade_attempt_liveness_observed_total"
+;;
+
+let metric_cascade_ttfb_seconds = "masc_cascade_ttfb_seconds"
+let metric_cascade_inter_chunk_seconds = "masc_cascade_inter_chunk_seconds"
+let metric_cascade_provider_health_score = "masc_cascade_provider_health_score"
+let metric_cascade_decisions = "masc_cascade_decisions_total"
+let metric_cascade_fallbacks = "masc_cascade_fallbacks_total"
+let metric_cascade_providers_exhausted = "masc_cascade_providers_exhausted_total"
+let metric_cascade_routing_phase_overrides = "masc_cascade_routing_phase_overrides_total"
+let metric_cascade_server_error_skip_total = "masc_cascade_server_error_skip_total"
+
+let metric_cascade_fallback_cycle_detected_total =
+  "masc_cascade_fallback_cycle_detected_total"
+;;
+
+let metric_provider_health_probe_skipped = "masc_provider_health_probe_skipped_total"
+let metric_provider_actual_health_status = "masc_provider_actual_health_status"
+let metric_provider_health_probe_error = "masc_provider_health_probe_error_total"

--- a/lib/prometheus_cascade_metric_names.mli
+++ b/lib/prometheus_cascade_metric_names.mli
@@ -1,0 +1,82 @@
+(** Cascade routing, liveness, and provider-health metric-name constants.
+
+    Included by {!Prometheus} so existing callers keep using
+    [Prometheus.metric_*] bindings unchanged. *)
+
+(** Counter: cascade strategy decisions emitted by the strategy layer. *)
+val metric_cascade_strategy_decisions : string
+
+val metric_cascade_capacity_events : string
+
+(** RFC-0022 section 9 - would-be ([mode=observe]) and actual
+    ([mode=enforce]) in-attempt liveness kills, broken down by failure class.
+
+    Labels: [kind, mode, provider] where:
+    - [kind] is [no_first_token | inter_chunk_idle | wall_exceeded | provider_error]
+    - [mode] is [observe | enforce]
+    - [provider] is the cascade label that produced the attempt
+
+    Use the observe-mode counter to calibrate bootstrap and observed-success
+    budgets against [scripts/diag-keeper-cycle.sh] before flipping attempt
+    liveness to enforce. *)
+val metric_cascade_attempt_liveness_kill : string
+
+(** RFC-0022 PR-2 section 3 - per-attempt finalizer counter regardless of
+    outcome. Labels: [cascade], [provider], [outcome] in {success | kill |
+    wire_error}. The kill-rate is [kill_total / observed_total]. *)
+val metric_cascade_attempt_liveness_observed : string
+
+(** Histogram: time from cascade attempt start to first non-Done chunk (TTFT).
+    Labels: [cascade], [provider] where [provider] is a bounded public
+    provider bucket. *)
+val metric_cascade_ttfb_seconds : string
+
+(** Histogram: inter-chunk gap during streaming (TBT). Labels: [cascade],
+    [provider] where [provider] is a bounded public provider bucket. *)
+val metric_cascade_inter_chunk_seconds : string
+
+(** Gauge: composite health score per cascade provider.
+    [success_rate * speed_score * cost_score] in [0.0, 1.0].
+    Labels: [provider_key]. *)
+val metric_cascade_provider_health_score : string
+
+(** Counter: cascade routing decisions emitted by [Cascade_fsm.decide].
+    Labels: [decision] in [accept|accept_on_exhaustion|try_next|exhausted]. *)
+val metric_cascade_decisions : string
+
+(** Counter: cascade fallback transitions ([Try_next] outcomes).
+    Labels: [reason] in [call_err|slot_full|accept_rejected|health_filter]. *)
+val metric_cascade_fallbacks : string
+
+(** Counter: terminal exhaustion events emitted when a cascade has no further
+    provider candidates. *)
+val metric_cascade_providers_exhausted : string
+
+(** Counter: cascade routing phase overrides applied during decision.
+    Labels: [phase], [from_cascade], [to_cascade]. *)
+val metric_cascade_routing_phase_overrides : string
+
+(** Total cascade label-ranking skips triggered by recent server-error (5xx)
+    score decay for a provider. Labels: [provider_key]. *)
+val metric_cascade_server_error_skip_total : string
+
+(** Total cascade fallback_cascade cycles detected during [load_catalog].
+    A cycle means a provider stall propagates through every cascade in the loop
+    silently for 600s+ without escaping. Labels: [cascade] (the entry point of
+    the detected cycle). *)
+val metric_cascade_fallback_cycle_detected_total : string
+
+(** Total bootstrap/runtime-catalog provider health probes intentionally
+    skipped as advisory. Labels: [provider_name, profile_name]. *)
+val metric_provider_health_probe_skipped : string
+
+(** Last advisory provider health status observed by runtime catalog
+    validation. Values: 0=unknown/skipped, 1=healthy, 3=unhealthy.
+    Labels: [provider_name, profile_name, model_id]. *)
+val metric_provider_actual_health_status : string
+
+(** Total provider health probe errors observed during runtime catalog
+    validation. Counter complement to [metric_provider_actual_health_status]:
+    the gauge only shows the last observed status, so a sustained probe failure
+    rate is otherwise invisible. Labels: [provider_name, profile_name]. *)
+val metric_provider_health_probe_error : string


### PR DESCRIPTION
## Summary
- extract cascade routing, liveness, and provider-health metric-name constants into `Prometheus_cascade_metric_names`
- keep existing `Prometheus.metric_*` public bindings via `include` in both `.ml` and `.mli`
- register the new module as a private library module

## Size impact
- `lib/prometheus.ml`: 2804 -> 2741 lines
- `lib/prometheus.mli`: 665 -> 587 lines
- new files: `prometheus_cascade_metric_names.ml` 29 lines, `.mli` 82 lines

## Validation
- `ocamlformat --check lib/prometheus.ml lib/prometheus.mli lib/prometheus_cascade_metric_names.ml lib/prometheus_cascade_metric_names.mli`
- `git diff --check`
- `bash scripts/lint/godfile-size-regression.sh`
- `scripts/ocaml-structure-ratchet.sh --print`
- `ocamlc -c -o /tmp/prometheus_cascade_metric_names.cmi lib/prometheus_cascade_metric_names.mli && ocamlc -I /tmp -c -o /tmp/prometheus_cascade_metric_names.cmo lib/prometheus_cascade_metric_names.ml`

## Local Dune note
- Focused Dune build is not a reliable local proof on this host right now: the shared opam switch is ahead of the branch pin and emits unrelated warning-as-error exhaustiveness failures in existing `agent_sdk` error matches (`TimeoutError` / `Provider` variants) outside this PR. CI remains the exact branch verifier.