### PR TITLE
feat(keeper): separate body_timeout from max_execution wire

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -491,6 +491,31 @@ module KeeperKeepalive = struct
       (Float.min 600.0 (get_float ~default:120.0 "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC"))
   ;;
 
+  (** Total HTTP body-consumption deadline for one OAS streaming call.
+      Wraps the body callback in [Eio.Time.with_timeout_exn] in agent_sdk;
+      on expiry [Retry.Timeout] surfaces and cascade falls forward to the
+      next provider at the attempt boundary. Complements
+      [stream_idle_timeout_sec] (which only caps inter-line silence):
+      this catches the case where a single bulk read hangs without
+      producing line breaks.
+
+      Opt-in: unset env leaves [None] so {!Cascade_agent_context} skips
+      the builder wiring. Set to a value strictly less than the per-call
+      turn cap (e.g. 240–540s when [oas_timeout_sec] is 300–600s) for
+      attempt-level fall-forward; set [<= stream_idle_timeout_sec] for a
+      strict overall cap.
+
+      Env: [MASC_KEEPER_BODY_TIMEOUT_SEC]. Default: unset → [None].
+      Range when set: [10, 600]. *)
+  let body_timeout_sec_override =
+    match Env_config_core.raw_value_opt "MASC_KEEPER_BODY_TIMEOUT_SEC" with
+    | Some raw ->
+      (match Float.of_string_opt (String.trim raw) with
+       | Some v -> Some (Float.max 10.0 (Float.min 600.0 v))
+       | None -> None)
+    | None -> None
+  ;;
+
   (** Stdout-idle timeout for CLI subprocess transports (Kimi CLI today;
       Claude Code / Gemini CLI / Codex CLI need an OAS upstream change to
       expose [stdout_idle_timeout_s] in their transport configs).

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -185,6 +185,17 @@ module KeeperKeepalive : sig
   val oas_timeout_for_estimated_input_tokens : estimated_input_tokens:int -> float
   val oas_timeout_sec : float
   val stream_idle_timeout_sec : float
+
+  val body_timeout_sec_override : float option
+  (** Total HTTP body-consumption deadline for one OAS streaming call.
+      [None] (env unset) leaves the cascade builder wire untouched.
+      [Some s] forwards to [Builder.with_body_timeout]; on expiry
+      [Retry.Timeout] surfaces at the attempt boundary so cascade falls
+      forward to the next provider. Complements {!stream_idle_timeout_sec}
+      (inter-line silence cap) and [max_execution_time_s] (turn-total cap).
+
+      Env: [MASC_KEEPER_BODY_TIMEOUT_SEC]. Clamp range: [10, 600] s. *)
+
   val idle_skip_threshold : int
 end
 

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -19,6 +19,7 @@ type t = {
   admission_wait_timeout_sec : float field;
   oas_timeout_override_sec : float option field;
   stream_idle_timeout_sec : float field;
+  body_timeout_override_sec : float option field;
   oas_timeout_per_1k : float field;
   oas_timeout_per_turn : float field;
 }
@@ -118,6 +119,19 @@ let oas_timeout_override_sec_live ~turn_timeout_sec =
                  (Float.of_string_opt (String.trim raw)))))
   | None -> None
 
+(* SSOT: Env_config_keeper.KeeperKeepalive.body_timeout_sec_override
+   (same env var, same clamp [10, 600]). Mirrors the
+   [oas_timeout_override_sec_live] / [stream_idle_timeout_sec_live]
+   idiom: read raw env, clamp, return option. Opt-in: unset → None
+   → cascade falls back to the per-attempt max_execution_time. *)
+let body_timeout_override_sec_live () =
+  match Env_config_core.raw_value_opt "MASC_KEEPER_BODY_TIMEOUT_SEC" with
+  | Some raw ->
+      (match Float.of_string_opt (String.trim raw) with
+       | Some v -> Some (Float.max 10.0 (Float.min 600.0 v))
+       | None -> None)
+  | None -> None
+
 let freeze_from_current () =
   let source_field name value =
     { value;
@@ -178,6 +192,14 @@ let freeze_from_current () =
       "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC"
       (stream_idle_timeout_sec_live ())
   in
+  let body_timeout_override_sec =
+    {
+      value = body_timeout_override_sec_live ();
+      source =
+        Option.value ~default:Default
+          (source_of_env_name "MASC_KEEPER_BODY_TIMEOUT_SEC");
+    }
+  in
   let oas_timeout_per_1k =
     source_field
       "MASC_KEEPER_OAS_TIMEOUT_PER_1K"
@@ -198,6 +220,7 @@ let freeze_from_current () =
     admission_wait_timeout_sec;
     oas_timeout_override_sec;
     stream_idle_timeout_sec;
+    body_timeout_override_sec;
     oas_timeout_per_1k;
     oas_timeout_per_turn;
   }
@@ -240,6 +263,7 @@ let to_yojson (runtime : t) =
       ("admission_wait_timeout_sec", field_to_yojson (fun value -> `Float value) runtime.admission_wait_timeout_sec);
       ("oas_timeout_override_sec", field_to_yojson option_float_to_yojson runtime.oas_timeout_override_sec);
       ("stream_idle_timeout_sec", field_to_yojson (fun value -> `Float value) runtime.stream_idle_timeout_sec);
+      ("body_timeout_override_sec", field_to_yojson option_float_to_yojson runtime.body_timeout_override_sec);
       ("oas_timeout_per_1k", field_to_yojson (fun value -> `Float value) runtime.oas_timeout_per_1k);
       ("oas_timeout_per_turn", field_to_yojson (fun value -> `Float value) runtime.oas_timeout_per_turn);
     ]
@@ -270,6 +294,9 @@ let stream_idle_timeout_sec () =
 
 let stream_idle_timeout_for_total_timeout ~(total_timeout_s : float) =
   Float.min total_timeout_s (stream_idle_timeout_sec ())
+
+let body_timeout_override_sec () =
+  (current ()).body_timeout_override_sec.value
 
 let oas_timeout_for_estimated_input_tokens_with_turn_budget
     ~(estimated_input_tokens : int) ~(max_turns : int) : float =

--- a/lib/keeper/keeper_runtime_resolved.mli
+++ b/lib/keeper/keeper_runtime_resolved.mli
@@ -28,6 +28,7 @@ type t = {
   admission_wait_timeout_sec : float field;
   oas_timeout_override_sec : float option field;
   stream_idle_timeout_sec : float field;
+  body_timeout_override_sec : float option field;
   oas_timeout_per_1k : float field;
   oas_timeout_per_turn : float field;
 }
@@ -51,6 +52,16 @@ val turn_timeout_sec : unit -> float
 val admission_wait_timeout_sec : unit -> float
 val stream_idle_timeout_sec : unit -> float
 val stream_idle_timeout_for_total_timeout : total_timeout_s:float -> float
+
+(** Total HTTP body-consumption deadline override.
+    [None] (env unset) lets the cascade attempt fall back to the per-
+    attempt [max_execution_time]. [Some s] is forwarded to
+    [Cascade_agent_context.body_timeout_s] -> [Builder.with_body_timeout],
+    surfacing [Retry.Timeout] before the turn cap so cascade falls
+    forward at the attempt boundary.
+
+    SSOT: {!Env_config_keeper.KeeperKeepalive.body_timeout_sec_override}. *)
+val body_timeout_override_sec : unit -> float option
 
 (** CLI subprocess stdout-idle timeout, read fresh per turn from
     [MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC] and clamped to [10, 600].

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -285,7 +285,16 @@ let run_try_provider
           ; max_execution_time_s =
               max_execution_time_for_attempt ?per_provider_timeout_s ()
           ; body_timeout_s =
-              max_execution_time_for_attempt ?per_provider_timeout_s ()
+              (* SSOT: Keeper_runtime_resolved.body_timeout_override_sec
+                 (driven by MASC_KEEPER_BODY_TIMEOUT_SEC). When unset
+                 (default), fall back to the per-attempt
+                 max_execution_time so this wire matches the PR #16071
+                 baseline. When set, the body-callback wall-clock fires
+                 before the turn cap, surfacing Retry.Timeout so cascade
+                 falls forward at the attempt boundary. *)
+              (match Keeper_runtime_resolved.body_timeout_override_sec () with
+               | Some _ as s -> s
+               | None -> max_execution_time_for_attempt ?per_provider_timeout_s ())
           ; temperature = ctx.temperature
           ; max_idle_turns = ctx.max_idle_turns
           ; guardrails = ctx.guardrails


### PR DESCRIPTION
## Summary

PR #16071 (`caf1c0d674`, MERGED 2026-05-18) 가 `keeper_turn_driver_try_provider.ml:287-288` 에서 `body_timeout_s` 를 wire 했으나 **degenerate**:

```ocaml
; max_execution_time_s = max_execution_time_for_attempt ?per_provider_timeout_s ()
; body_timeout_s       = max_execution_time_for_attempt ?per_provider_timeout_s ()  (* 같은 값 *)
```

`with_max_execution_time` 가 먼저 fire 하므로 `with_body_timeout` 는 실효 dead code. 본 PR 은 axis 분리를 복원한다.

## Three-layer stack

| Layer | PR | 역할 |
|---|---|---|
| Env | **#16190** | `MASC_KEEPER_BODY_TIMEOUT_SEC` → `Env_config_keeper.KeeperKeepalive.body_timeout_sec_override : float option` |
| Resolved | **본 PR** | `Env_config` → `Keeper_runtime_resolved.body_timeout_override_sec` (live + freeze + accessor + yojson + source) |
| Consumption | **본 PR** | `Keeper_runtime_resolved` → `Cascade_agent_context.body_timeout_s` → `Agent_sdk.Builder.with_body_timeout` |

PR #16190 base 위 stack. #16190 머지 후 rebase.

## Behaviour

| 상태 | `body_timeout_s` |
|---|---|
| `MASC_KEEPER_BODY_TIMEOUT_SEC` unset | `Some (max_execution_time_for_attempt ())` — PR #16071 baseline 그대로 |
| `MASC_KEEPER_BODY_TIMEOUT_SEC=240` (예) | `Some 240.0` — turn cap (보통 300-600s) 보다 *먼저* fire |

후자에서 hung HTTP body 가 `Retry.Timeout` 으로 surface → cascade 가 *attempt* 경계에서 다음 provider 로 fall-forward. turn 통째 죽지 않음.

## Changes

- `lib/keeper/keeper_runtime_resolved.mli` (+11)
  - `t` 에 `body_timeout_override_sec : float option field`
  - `val body_timeout_override_sec : unit -> float option` + doc
- `lib/keeper/keeper_runtime_resolved.ml` (+27)
  - `body_timeout_override_sec_live` (existing idiom 복제)
  - `freeze_from_current` 에 source tracking 포함 capture
  - `to_yojson` entry (`/keeper/<id>/runtime` dump 에 노출)
  - accessor
- `lib/keeper/keeper_turn_driver_try_provider.ml` (+10 -1)
  - line 287-288 의 degenerate wire 를 `match Keeper_runtime_resolved.body_timeout_override_sec () with | Some _ as s -> s | None -> max_execution_time_for_attempt ?per_provider_timeout_s ()` 로 교체. 주석으로 의도 명시.

## SSOT consistency

`MASC_KEEPER_BODY_TIMEOUT_SEC` 가 두 layer 에서 *각자* read 되지만 (Env_config + Runtime_resolved), 둘 다 같은 `Env_config_core.raw_value_opt` 직접 read 패턴. 기존 `oas_timeout_sec_override` / `stream_idle_timeout_sec` 가 같은 idiom 으로 동일하게 dual-read. clamp range `[10, 600]` 가 양측 동일.

## RFC waiver

cascade / keeper_runtime / try_provider 는 RFC 게이트 5 subsystem (credential / repo_manager / operator_control / keeper_sandbox / dashboard credential / .claude hooks / instructions/workflow) 어디에도 해당 안 됨. 일반 lib 변경.

## Stack metadata

| PR | Base | Status |
|---|---|---|
| **#16190** | `main` | Draft pushed |
| **this PR** | `feat/env-config-body-timeout-sec-20260518` (#16190) | Draft pushed |

#16190 squash-merge 후 본 branch 가 cherry-pick chain 깨질 수 있음 (`memory/feedback_stacked_pr_sha_cascade_on_amend.md` 패턴). #16190 머지 직후 `git rebase origin/main` + `git push --force-with-lease=<branch>:<sha>` 필요. 또는 #16190 머지 대기 후 force-rebase.

## Test plan

- [x] `dune build --root . lib/keeper lib/config` clean
- [ ] PR #16190 + 본 PR 양쪽 머지 후, env unset 상태에서 PR #16071 baseline 회귀 없음 verify (production canary)
- [ ] `MASC_KEEPER_BODY_TIMEOUT_SEC=240` 로 set 후 hung HTTP body 시 cascade 가 attempt 경계에서 fall-forward 하는지 production 관찰

## Known unrelated regression

main 의 `cascade_event_bridge.ml` + `keeper_status_bridge.ml` 가 `Agent_sdk.Error.Provider _` 미처리 → `@check` partial-match warning 8. 본 PR 무관 (Agent_sdk 0.195.0 catch-up gap, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
