### PR TITLE
refactor: split prometheus oas metric names

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -36,6 +36,7 @@
  prometheus_transport_metric_names
  prometheus_core_metric_names
  prometheus_cascade_metric_names
+ prometheus_oas_metric_names
  dashboard_http_keeper_metrics
  dashboard_http_keeper_detail
  dashboard_http_tool_quality

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -252,37 +252,9 @@ let metric_coord_claim_post_provision_failures =
    [auto_responder] / [dashboard_provider_runs] no longer
    silently masquerade as the same class of event as
    intentional 120s/180s budgets in autoresearch / deep_review. *)
-let metric_oas_bridge_timeout = "masc_oas_bridge_timeout_total"
-
-(* #10942 mirror for masc_oas_bridge cancel branch.  Same bucket
-   semantics as [masc_keeper_oas_cancel_total] (fast/short_tail/
-   mid_tail/long_mid/long_tail) so PromQL can union the two
-   sources by [bucket] for a fleet-wide bimodal view of cancels.
-   [caller] preserves the timeout-counter pairing so each caller's
-   timeout vs cancel populations stay separable. *)
-let metric_oas_bridge_cancel = "masc_oas_bridge_cancel_total"
-
-(* OAS event relay (oas_event_bridge.ml).  Metric strings keep the
-   historical [oas_sse_*] prefix for Grafana/alert continuity; renaming
-   the operational contract is deferred to a separate PR with a
-   dashboard migration plan. *)
-let metric_oas_sse_relay_retries = "masc_oas_sse_relay_retries_total"
-let metric_oas_sse_relay_drops = "masc_oas_sse_relay_drops_total"
-let metric_oas_sse_relay_queue_depth = "masc_oas_sse_relay_queue_depth"
-let metric_oas_inference_telemetry_tokens = "masc_oas_inference_telemetry_tokens"
-let metric_oas_inference_prompt_tok_per_sec = "masc_oas_inference_prompt_tok_per_sec"
-let metric_oas_inference_decode_tok_per_sec = "masc_oas_inference_decode_tok_per_sec"
-let metric_oas_inference_cost_usd = "masc_oas_inference_cost_usd"
+include Prometheus_oas_metric_names
 
 include Prometheus_cascade_metric_names
-
-(* Context overflow ratio — set each time ContextOverflowImminent fires.
-   Ratio is estimated_tokens / limit_tokens in [0.0, 1.0+]. *)
-let metric_oas_context_overflow_ratio = "masc_oas_context_overflow_ratio"
-
-(* OAS-level context compaction counter — incremented each time
-   ContextCompactStarted fires from the event bus. *)
-let metric_oas_context_compaction_total = "masc_oas_context_compaction_total"
 
 (* MCP tool schema budget (set once at boot from mcp_server_eio.ml
    via [set_tool_schema_stats]). *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -112,53 +112,7 @@ val metric_coord_claim_post_provision_failures : string
 (** Total best-effort claim post-provision hook failures. Labels: [site]
     and [agent_name]. *)
 
-(** #10094: labelled [caller, timeout_s] so operators can
-    distinguish fantasy 60s budgets from intentional 120/180s
-    budgets when both fire timeouts in the same session. *)
-val metric_oas_bridge_timeout : string
-
-(** #10094: labelled [caller, timeout_s] so operators can
-    distinguish fantasy 60s budgets from intentional 120/180s
-    budgets when both fire timeouts in the same session. *)
-val metric_oas_bridge_cancel : string
-(** #10942 mirror for [masc_oas_bridge].  Labelled [caller, bucket]
-    where bucket is wall-class (fast<60s, short_tail<300s,
-    mid_tail<600s, long_mid<1800s, long_tail>=1800s) — identical
-    boundaries to [masc_keeper_oas_cancel_total] so PromQL can
-    union the two sources for a fleet-wide bimodal view. *)
-
-(** #10942 mirror for [masc_oas_bridge].  Labelled [caller, bucket]
-    where bucket is wall-class (fast<60s, short_tail<300s,
-    mid_tail<600s, long_mid<1800s, long_tail>=1800s) — identical
-    boundaries to [masc_keeper_oas_cancel_total] so PromQL can
-    union the two sources for a fleet-wide bimodal view. *)
-val metric_oas_sse_relay_retries : string
-
-val metric_oas_sse_relay_drops : string
-
-(** Histogram populated from OAS [InferenceTelemetry] events that are
-    intentionally not relayed over SSE. Labels: [model_bucket], [phase],
-    and [token_bucket]. Cardinality bound: 8 model buckets * 2 phases *
-    5 token buckets = 80 labelled series. *)
-val metric_oas_sse_relay_queue_depth : string
-
-(** Histogram populated from OAS [InferenceTelemetry] events that are
-    intentionally not relayed over SSE. Labels: [model_bucket], [phase],
-    and [token_bucket]. Cardinality bound: 8 model buckets * 2 phases *
-    5 token buckets = 80 labelled series. *)
-val metric_oas_inference_telemetry_tokens : string
-
-(** Histogram populated from OAS [InferenceTelemetry.prompt_ms] and
-    [prompt_tokens]. Labels: [model_bucket] only. *)
-val metric_oas_inference_prompt_tok_per_sec : string
-
-(** Histogram populated from OAS [InferenceTelemetry.decode_tok_s] or
-    [decode_ms] plus [completion_tokens]. Labels: [model_bucket] only. *)
-val metric_oas_inference_decode_tok_per_sec : string
-
-(** Histogram populated from [AgentCompleted] [usage.cost_usd].
-    Labels: [provider] and [model_bucket]. *)
-val metric_oas_inference_cost_usd : string
+include module type of Prometheus_oas_metric_names
 
 val metric_mcp_tool_schema_count : string
 val metric_mcp_tool_schema_tokens_approx : string
@@ -192,14 +146,6 @@ val metric_anti_rationalization_excuse_pattern : string
     excuse substring detector.  Decision label is
     [advisory_to_llm | terminal_reject | advisory_safety_net_reject]. *)
 include module type of Prometheus_cascade_metric_names
-
-(** Gauge: context overflow ratio [estimated_tokens / limit_tokens] when
-    [ContextOverflowImminent] fires.  Labels: [agent_name]. *)
-val metric_oas_context_overflow_ratio : string
-
-(** Counter: total context compaction actions from OAS event bus.
-    Labels: [agent_name, trigger]. *)
-val metric_oas_context_compaction_total : string
 
 (** PR-I: cross-FSM edge transition counter. Labels: [edge] with values
     drawn from the static coupling graph documented in

--- a/lib/prometheus_oas_metric_names.ml
+++ b/lib/prometheus_oas_metric_names.ml
@@ -1,0 +1,16 @@
+(** OAS bridge, relay, inference, and context metric-name constants.
+
+    Included by {!Prometheus} so existing callers keep using
+    [Prometheus.metric_*] bindings unchanged. *)
+
+let metric_oas_bridge_timeout = "masc_oas_bridge_timeout_total"
+let metric_oas_bridge_cancel = "masc_oas_bridge_cancel_total"
+let metric_oas_sse_relay_retries = "masc_oas_sse_relay_retries_total"
+let metric_oas_sse_relay_drops = "masc_oas_sse_relay_drops_total"
+let metric_oas_sse_relay_queue_depth = "masc_oas_sse_relay_queue_depth"
+let metric_oas_inference_telemetry_tokens = "masc_oas_inference_telemetry_tokens"
+let metric_oas_inference_prompt_tok_per_sec = "masc_oas_inference_prompt_tok_per_sec"
+let metric_oas_inference_decode_tok_per_sec = "masc_oas_inference_decode_tok_per_sec"
+let metric_oas_inference_cost_usd = "masc_oas_inference_cost_usd"
+let metric_oas_context_overflow_ratio = "masc_oas_context_overflow_ratio"
+let metric_oas_context_compaction_total = "masc_oas_context_compaction_total"

--- a/lib/prometheus_oas_metric_names.mli
+++ b/lib/prometheus_oas_metric_names.mli
@@ -1,0 +1,49 @@
+(** OAS bridge, relay, inference, and context metric-name constants.
+
+    Included by {!Prometheus} so existing callers keep using
+    [Prometheus.metric_*] bindings unchanged. *)
+
+(** Labelled [caller, timeout_s] so operators can distinguish short budgets
+    from intentional 120/180s budgets when both fire timeouts in the same
+    session. *)
+val metric_oas_bridge_timeout : string
+
+(** Labelled [caller, bucket] where bucket is a wall-clock class shared with
+    [masc_keeper_oas_cancel_total], allowing PromQL to union the two sources
+    for a fleet-wide bimodal view. *)
+val metric_oas_bridge_cancel : string
+
+val metric_oas_sse_relay_retries : string
+val metric_oas_sse_relay_drops : string
+
+(** Histogram populated from OAS [InferenceTelemetry] events that are
+    intentionally not relayed over SSE. Labels: [model_bucket], [phase], and
+    [token_bucket]. Cardinality bound: 8 model buckets * 2 phases * 5 token
+    buckets = 80 labelled series. *)
+val metric_oas_sse_relay_queue_depth : string
+
+(** Histogram populated from OAS [InferenceTelemetry] events that are
+    intentionally not relayed over SSE. Labels: [model_bucket], [phase], and
+    [token_bucket]. Cardinality bound: 8 model buckets * 2 phases * 5 token
+    buckets = 80 labelled series. *)
+val metric_oas_inference_telemetry_tokens : string
+
+(** Histogram populated from OAS [InferenceTelemetry.prompt_ms] and
+    [prompt_tokens]. Labels: [model_bucket] only. *)
+val metric_oas_inference_prompt_tok_per_sec : string
+
+(** Histogram populated from OAS [InferenceTelemetry.decode_tok_s] or
+    [decode_ms] plus [completion_tokens]. Labels: [model_bucket] only. *)
+val metric_oas_inference_decode_tok_per_sec : string
+
+(** Histogram populated from [AgentCompleted] [usage.cost_usd].
+    Labels: [provider] and [model_bucket]. *)
+val metric_oas_inference_cost_usd : string
+
+(** Gauge: context overflow ratio [estimated_tokens / limit_tokens] when
+    [ContextOverflowImminent] fires. Labels: [agent_name]. *)
+val metric_oas_context_overflow_ratio : string
+
+(** Counter: total context compaction actions from OAS event bus.
+    Labels: [agent_name, trigger]. *)
+val metric_oas_context_compaction_total : string


### PR DESCRIPTION
## Summary
- extract OAS bridge, relay, inference, and context metric-name constants into `Prometheus_oas_metric_names`
- keep existing `Prometheus.metric_*` public bindings via `include` in both `.ml` and `.mli`
- register the new module as a private library module

## Size impact
- `lib/prometheus.ml`: 2741 -> 2713 lines
- `lib/prometheus.mli`: 587 -> 533 lines
- new files: `prometheus_oas_metric_names.ml` 16 lines, `.mli` 49 lines

## Validation
- `ocamlformat --check lib/prometheus.ml lib/prometheus.mli lib/prometheus_oas_metric_names.ml lib/prometheus_oas_metric_names.mli`
- `git diff --check`
- `bash scripts/lint/godfile-size-regression.sh`
- `scripts/ocaml-structure-ratchet.sh --print`
- `ocamlc -c -o /tmp/prometheus_oas_metric_names.cmi lib/prometheus_oas_metric_names.mli && ocamlc -I /tmp -c -o /tmp/prometheus_oas_metric_names.cmo lib/prometheus_oas_metric_names.ml`

## Local Dune note
- Focused Dune build is not a reliable local proof on this host right now: the shared opam switch is ahead of the branch pin and emits unrelated warning-as-error exhaustiveness failures in existing `agent_sdk` error matches (`TimeoutError` / `Provider` variants) outside this PR. CI remains the exact branch verifier.