### PR TITLE
fix(keeper): hide worker tools from verifier

### DIFF
--- a/config/keepers/verifier.toml
+++ b/config/keepers/verifier.toml
@@ -7,7 +7,22 @@ proactive_idle_sec = 120
 proactive_cooldown_sec = 240
 per_provider_timeout = 120.0
 work_discovery_sources = ["awaiting_verification_tasks"]
-tool_denylist = ["keeper_task_claim", "masc_claim_next", "masc_claim_task"]
+tool_denylist = [
+  "keeper_task_claim",
+  "keeper_task_create",
+  "keeper_task_done",
+  "keeper_task_force_done",
+  "keeper_task_force_release",
+  "keeper_task_submit_for_verification",
+  "masc_add_task",
+  "masc_batch_add_tasks",
+  "masc_cancel_task",
+  "masc_claim_next",
+  "masc_claim_task",
+  "masc_complete_task",
+  "masc_deliver",
+  "masc_release_task",
+]
 github_identity = "reviewer-keepers-nonoperator-0506b"
 git_identity_mode = "github_identity"
 
@@ -16,6 +31,8 @@ instructions = """
 
 중요한 금지:
 - awaiting_verification task는 이미 제출된 작업이다. 절대로 keeper_task_claim을 호출하지 마라.
+- verifier는 worker-flow 도구를 호출하지 않는다. keeper_task_done, keeper_task_submit_for_verification, keeper_task_create, force/release 계열, masc_claim_next/claim_task/complete/release/cancel/deliver/add_task/batch_add_tasks는 모두 잘못된 도구다.
+- verifier가 task lifecycle을 바꾸는 유일한 방법은 masc_transition action="approve" 또는 action="reject" 두 가지뿐이다.
 - completion notes만 보고 approve/reject 하지 마라.
 - MASC tool 이름을 Bash 명령으로 입력하지 마라.
 - Bash에서 shell quote, glob, brace expansion을 쓰지 마라. 경로 인자는 plain path로만 쓴다.

--- a/config/personas/verifier/profile.json
+++ b/config/personas/verifier/profile.json
@@ -10,7 +10,23 @@
     "will": "agent의 completion notes를 신뢰하지 않는다. 도구로 직접 확인한다.",
     "needs": "task contract, completion notes, workspace 접근 (keeper_bash, file read)",
     "desires": "정량 기준의 100% 실측 검증. 정성 기준의 artifact 기반 판단.",
-    "instructions": "너는 task completion 검증자다. AwaitingVerification 상태의 task를 발견하면 다음 절차를 따른다. 중요한 금지: awaiting_verification task는 이미 제출된 작업이므로 keeper_task_claim을 호출하지 마라. completion notes만 보고 approve/reject 하지 마라. MASC tool 이름을 Bash 명령으로 입력하지 마라. Bash에서 shell quote, glob, brace expansion을 쓰지 마라. 경로 인자는 plain path로만 쓴다. 코드/문서 탐색은 가능하면 masc_code_search 또는 masc_code_read를 먼저 쓴다. 검증 절차: 1) keeper_tasks_list 또는 masc_tasks로 awaiting_verification task를 조회한다. 2) task의 completion_contract, required_evidence, completion notes, 관련 PR/파일/명령을 확인한다. 3) 수치/명령 기준은 masc_code_search, masc_code_read, keeper_bash 순서로 직접 실측한다. 4) 충족이면 masc_transition을 task_id와 action=\"approve\"로 호출한다. 5) 미충족이면 masc_transition을 task_id와 action=\"reject\"로 호출하고 reason에 미충족 항목과 실측값을 넣는다. 6) 검증 불가면 keeper_board_comment 또는 keeper_board_curation_submit으로 blocker를 남기고 status는 바꾸지 않는다. actionable signal 처리: board_activity, broadcast, direct mention은 모두 actionable signal이다. 신호 수신 -> keeper_tasks_list 또는 masc_tasks 1회 호출 -> approve/reject 또는 blocker/no-work 기록 순서로 처리한다. passive read만 하고 끝내지 마라. 단, 검증 불가 blocker 기록은 유효한 active action이다. awaiting_verification task가 0개면 free-text로 끝내지 마라. board/broadcast 신호가 있으면 keeper_board_curation_submit으로 no awaiting verification tasks를 기록한다. 이 active tool call은 require_tool_use 계약을 만족하기 위해 필수다. 순수 idle/no-work 턴에서만 keeper_stay_silent를 사용한다.",
+    "instructions": "너는 task completion 검증자다. AwaitingVerification 상태의 task를 발견하면 다음 절차를 따른다. 중요한 금지: awaiting_verification task는 이미 제출된 작업이므로 keeper_task_claim을 호출하지 마라. verifier는 worker-flow 도구를 호출하지 않는다. keeper_task_done, keeper_task_submit_for_verification, keeper_task_create, force/release 계열, masc_claim_next/claim_task/complete/release/cancel/deliver/add_task/batch_add_tasks는 모두 잘못된 도구다. verifier가 task lifecycle을 바꾸는 유일한 방법은 masc_transition action=\"approve\" 또는 action=\"reject\" 두 가지뿐이다. completion notes만 보고 approve/reject 하지 마라. MASC tool 이름을 Bash 명령으로 입력하지 마라. Bash에서 shell quote, glob, brace expansion을 쓰지 마라. 경로 인자는 plain path로만 쓴다. 코드/문서 탐색은 가능하면 masc_code_search 또는 masc_code_read를 먼저 쓴다. 검증 절차: 1) keeper_tasks_list 또는 masc_tasks로 awaiting_verification task를 조회한다. 2) task의 completion_contract, required_evidence, completion notes, 관련 PR/파일/명령을 확인한다. 3) 수치/명령 기준은 masc_code_search, masc_code_read, keeper_bash 순서로 직접 실측한다. 4) 충족이면 masc_transition을 task_id와 action=\"approve\"로 호출한다. 5) 미충족이면 masc_transition을 task_id와 action=\"reject\"로 호출하고 reason에 미충족 항목과 실측값을 넣는다. 6) 검증 불가면 keeper_board_comment 또는 keeper_board_curation_submit으로 blocker를 남기고 status는 바꾸지 않는다. actionable signal 처리: board_activity, broadcast, direct mention은 모두 actionable signal이다. 신호 수신 -> keeper_tasks_list 또는 masc_tasks 1회 호출 -> approve/reject 또는 blocker/no-work 기록 순서로 처리한다. passive read만 하고 끝내지 마라. 단, 검증 불가 blocker 기록은 유효한 active action이다. awaiting_verification task가 0개면 free-text로 끝내지 마라. board/broadcast 신호가 있으면 keeper_board_curation_submit으로 no awaiting verification tasks를 기록한다. 이 active tool call은 require_tool_use 계약을 만족하기 위해 필수다. 순수 idle/no-work 턴에서만 keeper_stay_silent를 사용한다.",
+    "tool_denylist": [
+      "keeper_task_claim",
+      "keeper_task_create",
+      "keeper_task_done",
+      "keeper_task_force_done",
+      "keeper_task_force_release",
+      "keeper_task_submit_for_verification",
+      "masc_add_task",
+      "masc_batch_add_tasks",
+      "masc_cancel_task",
+      "masc_claim_next",
+      "masc_claim_task",
+      "masc_complete_task",
+      "masc_deliver",
+      "masc_release_task"
+    ],
     "mention_targets": [
       "verifier",
       "검증자"

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -144,6 +144,81 @@ let test_committed_keepers_are_pr_work_capable () =
              (KPR.pr_review_event_to_gh_flag KPR.Approve))
     files
 
+let test_verifier_config_hides_worker_lifecycle_tools () =
+  let project_root = Masc_test_deps.find_project_root () in
+  Masc_test_deps.init_keeper_tool_registry ();
+  (match KPolicy.init_policy_config ~base_path:project_root with
+   | Ok () -> ()
+   | Error e -> fail (Printf.sprintf "init_policy_config: %s" e));
+  let path = Filename.concat project_root "config/keepers/verifier.toml" in
+  match KTP.load_keeper_toml path with
+  | Error e -> fail (Printf.sprintf "verifier.toml: %s" e)
+  | Ok (_loaded_name, defaults) ->
+      let preset =
+        match defaults.tool_preset with
+        | Some raw -> (
+            match KT.tool_preset_of_string raw with
+            | Some preset -> preset
+            | None -> fail (Printf.sprintf "unknown verifier preset %S" raw))
+        | None -> fail "verifier tool_access.preset is required"
+      in
+      let also_allow = Option.value ~default:[] defaults.tool_also_allow in
+      let denylist = Option.value ~default:[] defaults.tool_denylist in
+      let meta =
+        match
+          Masc_test_deps.meta_of_json_fixture
+            (`Assoc
+               [
+                 ("name", `String "verifier");
+                 ("agent_name", `String "keeper-verifier-agent");
+                 ("trace_id", `String "verifier-tool-surface-test");
+                 ( "tool_access",
+                   `Assoc
+                     [
+                       ("kind", `String "preset");
+                       ("preset", `String (KT.tool_preset_to_string preset));
+                       ( "also_allow",
+                         `List (List.map (fun value -> `String value) also_allow) );
+                     ] );
+                 ( "tool_denylist",
+                   `List (List.map (fun value -> `String value) denylist) );
+               ])
+        with
+        | Ok meta -> meta
+        | Error e -> fail (Printf.sprintf "verifier meta fixture: %s" e)
+      in
+      let lookup = KPolicy.tool_access_lookup_of_meta meta in
+      List.iter
+        (fun tool_name ->
+          check bool ("verifier keeps " ^ tool_name) true
+            (KPolicy.can_execute ~lookup tool_name))
+        [
+          "keeper_tasks_list";
+          "masc_tasks";
+          "masc_task_history";
+          "masc_transition";
+        ];
+      List.iter
+        (fun tool_name ->
+          check bool ("verifier hides " ^ tool_name) false
+            (KPolicy.can_execute ~lookup tool_name))
+        [
+          "keeper_task_claim";
+          "keeper_task_create";
+          "keeper_task_done";
+          "keeper_task_force_done";
+          "keeper_task_force_release";
+          "keeper_task_submit_for_verification";
+          "masc_add_task";
+          "masc_batch_add_tasks";
+          "masc_cancel_task";
+          "masc_claim_next";
+          "masc_claim_task";
+          "masc_complete_task";
+          "masc_deliver";
+          "masc_release_task";
+        ]
+
 (** Write a temporary TOML file, run load_keeper_toml, clean up. *)
 let with_temp_toml content f =
   let path = Filename.temp_file "keeper_test_" ".toml" in
@@ -898,6 +973,10 @@ let () =
           test_case "committed keepers can do PR work" `Quick
             (fun () ->
               with_repo_config_dir test_committed_keepers_are_pr_work_capable);
+          test_case "verifier hides worker lifecycle tools" `Quick
+            (fun () ->
+              with_repo_config_dir
+                test_verifier_config_hides_worker_lifecycle_tools);
         ] );
       ( "cascade_name validation",
         [

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1018,7 +1018,7 @@ let () = test "handle_transition_verifier_blocks_non_verdict_actions" (fun () ->
         (Tool_result.failure_class result = Some Tool_result.Workflow_rejection);
       assert (str_contains result.Tool_result.legacy_message "Verifier action guard");
       assert (str_contains result.Tool_result.legacy_message "approve|reject"))
-    [ "claim"; "done" ];
+    [ "claim"; "done"; "submit_for_verification" ];
   assert_task_todo ctx;
   assert (Planning_eio.get_current_task ctx.config = None))
 


### PR DESCRIPTION
## Summary

- Hide worker-flow lifecycle tools from the committed `verifier` keeper config and verifier persona fallback.
- Keep verifier task-state mutation scoped to `masc_transition(action=approve|reject)`.
- Add config regression coverage that loads `config/keepers/verifier.toml` and asserts worker lifecycle tools are not executable for verifier while read/verdict tools remain available.
- Extend the existing verifier action-guard regression to cover `masc_transition(action=submit_for_verification)`, matching the 2026-05-18 keeper log failure wave.

## Goal Link

- `goal-keeper-error-improvement-20260518`
- HTML section: P1-C Verifier Tool Surface

## Product impact

Addresses #16181 by removing `keeper_task_submit_for_verification`, `keeper_task_done`, claim/create/release/cancel/deliver tools from the verifier tool surface instead of relying only on the runtime action guard after a bad call.

## Evidence

- Live issue evidence showed `keeper-verifier-agent` repeatedly attempting submit-for-verification-like lifecycle actions, which then hit `Verifier action guard` and circuit breaker retries.
- Live runtime config was also updated under `/Users/dancer/me/.masc` so verifier persisted denylist now includes the worker-flow tools immediately.

## Review evidence

- `jq empty config/personas/verifier/profile.json`
- `jq empty /Users/dancer/me/.masc/keepers/verifier.json`
- `ocamlformat --check test/test_keeper_toml_config_validation.ml test/test_tool_task_coverage.ml`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- Attempted `scripts/dune-local.sh build ./test/test_keeper_toml_config_validation.exe ./test/test_tool_task_coverage.exe`; local Dune was blocked behind the shared `/tmp/me-dune-local.lock` queue and the duplicate queued validation was stopped. Draft CI is the remaining verification surface.

## Linked issue

Fixes #16181.
