### PR TITLE
fix(oas): handle provider sdk errors

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -638,7 +638,8 @@ let sdk_provider_error_to_provider_error = function
       Some (Provider_error.InvalidRequest { reason = detail })
   | Llm_provider.Error.ProviderTerminal { detail; _ } ->
       Some (Provider_error.InvalidRequest { reason = detail })
-  | Llm_provider.Error.ProviderUnavailable _
+  | Llm_provider.Error.ProviderUnavailable _ ->
+      Some (Provider_error.ServerError { code = 503; transient = false })
   | Llm_provider.Error.ParseError _
   | Llm_provider.Error.UnknownVariant _
   | Llm_provider.Error.NetworkError _
@@ -862,6 +863,11 @@ let sdk_error_is_max_turns_exceeded (err : Agent_sdk.Error.sdk_error) : bool =
           | Llm_provider.Retry.NotFound _
           | Llm_provider.Retry.ContextOverflow _) ->
           false
+      | Agent_sdk.Error.Provider
+          (Llm_provider.Error.ProviderTerminal { reason; detail; _ }) ->
+          message_looks_like_cli_wrapped_max_turns reason
+          || message_looks_like_cli_wrapped_max_turns detail
+      | Agent_sdk.Error.Provider _ -> false
       | Agent_sdk.Error.Internal message ->
           message_looks_like_cli_wrapped_max_turns message
       | _ -> false)

--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -457,6 +457,120 @@ let sdk_provider_error_fields = function
     ]
 ;;
 
+let json_string_list values = `List (List.map (fun value -> `String value) values)
+;;
+
+let sdk_provider_error_fields error =
+  let message = Llm_provider.Error.to_string error in
+  match error with
+  | Llm_provider.Error.MissingApiKey { var_name } ->
+    [ "variant", `String "missing_api_key"
+    ; "message", `String message
+    ; "var_name", `String var_name
+    ]
+  | Llm_provider.Error.InvalidConfig { field; detail } ->
+    [ "variant", `String "invalid_config"
+    ; "message", `String message
+    ; "field", `String field
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.ParseError { detail } ->
+    [ "variant", `String "parse_error"
+    ; "message", `String message
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.UnknownVariant { type_name; value } ->
+    [ "variant", `String "unknown_variant"
+    ; "message", `String message
+    ; "type_name", `String type_name
+    ; "value", `String value
+    ]
+  | Llm_provider.Error.ProviderUnavailable { provider; detail } ->
+    [ "variant", `String "provider_unavailable"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.RateLimit { provider; retry_after; detail } ->
+    [ "variant", `String "rate_limited"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "retry_after_s", json_float_opt retry_after
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.HardQuota { provider; retry_after; detail } ->
+    [ "variant", `String "hard_quota"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "retry_after_s", json_float_opt retry_after
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.CapacityExhausted
+      { scope; affected; retry_after; detail } ->
+    [ "variant", `String "capacity_exhausted"
+    ; "message", `String message
+    ; "capacity_scope", `String (Llm_provider.Error.capacity_scope_to_string scope)
+    ; "affected", json_string_list affected
+    ; "retry_after_s", json_float_opt retry_after
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.AuthError { provider; detail } ->
+    [ "variant", `String "auth_error"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.ServerError { provider; code; transient; detail } ->
+    [ "variant", `String "server_error"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "status", `Int code
+    ; "transient", `Bool transient
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.NetworkError
+      { provider; kind; timeout_phase; detail } ->
+    [ "variant", `String "network_error"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "network_kind", `String (network_error_kind_to_wire kind)
+    ; ( "timeout_phase"
+      , match timeout_phase with
+        | Some phase -> `String (Llm_provider.Http_client.timeout_phase_to_label phase)
+        | None -> `Null )
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.Timeout { provider; timeout_phase; detail } ->
+    [ "variant", `String "timeout"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; ( "timeout_phase"
+      , match timeout_phase with
+        | Some phase -> `String (Llm_provider.Http_client.timeout_phase_to_label phase)
+        | None -> `Null )
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.InvalidRequest { provider; reason } ->
+    [ "variant", `String "invalid_request"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "reason", `String reason
+    ]
+  | Llm_provider.Error.NotFound { provider; detail } ->
+    [ "variant", `String "not_found"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.ProviderTerminal { provider; reason; detail } ->
+    [ "variant", `String "provider_terminal"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "reason", `String reason
+    ; "detail", `String detail
+    ]
+;;
+
 let sdk_error_detail_fields (error : Agent_sdk.Error.sdk_error) =
   match error with
   | Agent_sdk.Error.Api error -> sdk_api_error_fields error

--- a/lib/cascade/cascade_fsm.ml
+++ b/lib/cascade/cascade_fsm.ml
@@ -65,9 +65,9 @@ let to_user_message last_err =
   | Some (Llm_provider.Http_client.CliTransportRequired { kind }) ->
       Printf.sprintf "%s provider requires a CLI transport" kind
   | Some (Llm_provider.Http_client.NetworkError { message; _ }) -> message
+  | Some (Llm_provider.Http_client.TimeoutError { message; _ }) -> message
   | Some
-      ( (Llm_provider.Http_client.TimeoutError _
-        | Llm_provider.Http_client.ProviderTerminal _
+      ( (Llm_provider.Http_client.ProviderTerminal _
         | Llm_provider.Http_client.ProviderFailure _) as err ) ->
       (* Mirror the rendering shape used elsewhere on main HEAD
          (tool_local_runtime_bench / verify): "provider terminal:
@@ -82,6 +82,7 @@ let format_exhausted_error last_err =
   let network_error_kind =
     match last_err with
     | Some (Llm_provider.Http_client.NetworkError { kind; _ }) -> kind
+    | Some (Llm_provider.Http_client.TimeoutError _) -> Timeout
     | _ -> Unknown
   in
   match last_err with

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -97,8 +97,8 @@ let sdk_termination_semantics = function
   | Agent_sdk.Error.Agent (Agent_sdk.Error.TripwireViolation _) ->
     Oas_tripwire_violation
   | Agent_sdk.Error.Agent (Agent_sdk.Error.UnrecognizedStopReason _) -> Sdk_error_failure
-  | Agent_sdk.Error.Api _ -> Sdk_error_failure
   | Agent_sdk.Error.Provider _ -> Sdk_error_failure
+  | Agent_sdk.Error.Api _ -> Sdk_error_failure
   | Agent_sdk.Error.Mcp _ -> Sdk_error_failure
   | Agent_sdk.Error.Config _ -> Sdk_error_failure
   | Agent_sdk.Error.Serialization _ -> Sdk_error_failure
@@ -141,6 +141,54 @@ let api_error_terminal_reason_code (err : Agent_sdk.Error.api_error) : string =
   | Agent_sdk.Retry.ContextOverflow _ -> "api_error_context_overflow"
   | Agent_sdk.Retry.NetworkError _ -> "api_error_network"
   | Agent_sdk.Retry.Timeout _ -> "api_error_timeout"
+;;
+
+let provider_error_terminal_reason_code
+    (err : Agent_sdk.Error.provider_error)
+  : string
+  =
+  match err with
+  | Llm_provider.Error.MissingApiKey _ -> "provider_error_missing_api_key"
+  | Llm_provider.Error.InvalidConfig { field; _ } ->
+    Printf.sprintf "provider_error_invalid_config:%s" field
+  | Llm_provider.Error.ParseError _ -> "provider_error_parse"
+  | Llm_provider.Error.UnknownVariant { type_name; value } ->
+    Printf.sprintf "provider_error_unknown_variant:%s:%s" type_name value
+  | Llm_provider.Error.ProviderUnavailable { provider; _ } ->
+    Printf.sprintf "provider_error_unavailable:%s" provider
+  | Llm_provider.Error.RateLimit { provider; _ } ->
+    Printf.sprintf "provider_error_rate_limited:%s" provider
+  | Llm_provider.Error.HardQuota { provider; _ } ->
+    Printf.sprintf "provider_error_hard_quota:%s" provider
+  | Llm_provider.Error.CapacityExhausted { scope; _ } ->
+    Printf.sprintf
+      "provider_error_capacity_exhausted:%s"
+      (Llm_provider.Error.capacity_scope_to_string scope)
+  | Llm_provider.Error.AuthError { provider; _ } ->
+    Printf.sprintf "provider_error_auth:%s" provider
+  | Llm_provider.Error.ServerError { provider; code; _ } ->
+    Printf.sprintf "provider_error_server:%s:%d" provider code
+  | Llm_provider.Error.NetworkError { provider; kind; _ } ->
+    Printf.sprintf
+      "provider_error_network:%s:%s"
+      provider
+      (match kind with
+       | Llm_provider.Http_client.Connection_refused -> "connection_refused"
+       | Llm_provider.Http_client.Dns_failure -> "dns_failure"
+       | Llm_provider.Http_client.Tls_error -> "tls_error"
+       | Llm_provider.Http_client.Timeout -> "timeout"
+       | Llm_provider.Http_client.Local_resource_exhaustion ->
+         "local_resource_exhaustion"
+       | Llm_provider.Http_client.End_of_file -> "end_of_file"
+       | Llm_provider.Http_client.Unknown -> "unknown")
+  | Llm_provider.Error.Timeout { provider; _ } ->
+    Printf.sprintf "provider_error_timeout:%s" provider
+  | Llm_provider.Error.InvalidRequest { provider; _ } ->
+    Printf.sprintf "provider_error_invalid_request:%s" provider
+  | Llm_provider.Error.NotFound { provider; _ } ->
+    Printf.sprintf "provider_error_not_found:%s" provider
+  | Llm_provider.Error.ProviderTerminal { provider; reason; _ } ->
+    Printf.sprintf "provider_error_terminal:%s:%s" provider reason
 ;;
 
 (* Per-variant terminal_reason_code for Agent_sdk.Error.Agent.

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -113,6 +113,14 @@ let is_server_rejected_parse_error (err : Agent_sdk.Error.sdk_error) : bool =
       || string_contains_substring ~needle:"unexpected character in json" lower
       || string_contains_substring ~needle:"unterminated" lower
       || string_contains_substring ~needle:"parse error" lower
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.InvalidRequest { reason; _ }) ->
+      let lower = String.lowercase_ascii reason in
+      (string_contains_substring ~needle:"can't find closing" lower
+       || string_contains_substring ~needle:"find end of" lower)
+      || string_contains_substring ~needle:"unexpected character in json" lower
+      || string_contains_substring ~needle:"unterminated" lower
+      || string_contains_substring ~needle:"parse error" lower
   (* All other API error variants do not represent server-side parse failures. *)
   | Agent_sdk.Error.Api (RateLimited _)
   | Agent_sdk.Error.Api (Overloaded _)
@@ -402,14 +410,31 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
              Some Server_error
          | Agent_sdk.Error.Api (Llm_provider.Retry.AuthError _) ->
              Some Auth_error
-         | Agent_sdk.Error.Provider (Llm_provider.Error.RateLimit _) ->
+         | Agent_sdk.Error.Provider
+             (Llm_provider.Error.RateLimit _
+             | Llm_provider.Error.CapacityExhausted _) ->
              Some Rate_limit
+         | Agent_sdk.Error.Provider (Llm_provider.Error.HardQuota _) ->
+             Some Hard_quota
          | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code; transient; _ })
            when transient || code >= 500 ->
+             Some Server_error
+         | Agent_sdk.Error.Provider (Llm_provider.Error.ProviderUnavailable _) ->
              Some Server_error
          | Agent_sdk.Error.Provider
              (Llm_provider.Error.AuthError _ | Llm_provider.Error.MissingApiKey _) ->
              Some Auth_error
+         | Agent_sdk.Error.Provider
+             (Llm_provider.Error.ServerError _
+             | Llm_provider.Error.InvalidConfig _
+             | Llm_provider.Error.InvalidRequest _
+             | Llm_provider.Error.NotFound _
+             | Llm_provider.Error.NetworkError _
+             | Llm_provider.Error.Timeout _
+             | Llm_provider.Error.ParseError _
+             | Llm_provider.Error.UnknownVariant _
+             | Llm_provider.Error.ProviderTerminal _) ->
+             None
          (* Sub-500 server errors (4xx already handled above for AuthError /
             RateLimited) are not classified as recoverable cascade failures. *)
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
@@ -418,8 +443,7 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
          | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.ContextOverflow _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.NetworkError _)
-         | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _)
-         | Agent_sdk.Error.Provider _ -> None
+         | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _) -> None
          (* Non-API error families have no rotation reason here: structured
             MASC internal errors are handled by [classify_masc_internal_error]
             above; agent / mcp / config / etc. are not provider-level rotations. *)
@@ -787,6 +811,7 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Api (NotFound _)
   | Agent_sdk.Error.Api (NetworkError _)
   | Agent_sdk.Error.Api (Timeout _) -> false
+  | Agent_sdk.Error.Provider _ -> false
   (* Other agent error variants. *)
   | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
   | Agent_sdk.Error.Agent (CostBudgetExceeded _)
@@ -799,7 +824,6 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Agent (TripwireViolation _)
   | Agent_sdk.Error.Agent (ExitConditionMet _) -> false
   (* Non-API / non-Agent error families. *)
-  | Agent_sdk.Error.Provider _
   | Agent_sdk.Error.Mcp _
   | Agent_sdk.Error.Config _
   | Agent_sdk.Error.Serialization _

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -20,10 +20,13 @@ include Keeper_turn_driver_helpers
 let provider_attempt_status_of_result = function
   | Ok _ -> "provider_returned"
   | Error (Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _)) -> "timeout"
+  | Error (Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _)) -> "timeout"
   | Error _ -> "error"
 
 let provider_attempt_exception_kind_of_result = function
   | Error (Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _)) ->
+    Some "outer_oas_timeout"
+  | Error (Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _)) ->
     Some "outer_oas_timeout"
   | Ok _ | Error _ -> None
 

--- a/lib/server/openai_compat_error_map.ml
+++ b/lib/server/openai_compat_error_map.ml
@@ -367,7 +367,7 @@ let of_a2a_error (e : Agent_sdk.Error.a2a_error) : t =
 let of_sdk_error (e : Agent_sdk.Error.sdk_error) : t =
   match e with
   | Agent_sdk.Error.Api ae -> of_api_error ae
-  | Provider pe -> of_provider_error pe
+  | Agent_sdk.Error.Provider pe -> of_provider_error pe
   | Agent ae -> of_agent_error ae
   | Mcp me -> of_mcp_error me
   | Config ce -> of_config_error ce

--- a/test/test_oas_compat_cascade_fallback.ml
+++ b/test/test_oas_compat_cascade_fallback.ml
@@ -101,6 +101,23 @@ let test_http_429_cascades () =
     true
     (Oas_compat.Http_client.should_cascade err)
 
+let test_timeout_error_cascades () =
+  let err =
+    Http_client.TimeoutError
+      { phase = Http_client.Http_operation; message = "provider request timed out" }
+  in
+  Alcotest.(check bool)
+    "TimeoutError remains a provider-hop failure and should cascade"
+    true
+    (Oas_compat.Http_client.should_cascade err);
+  (match Oas_compat.Http_client.classify err with
+   | Network_error -> ()
+   | _ -> Alcotest.fail "TimeoutError must classify with network retry policy");
+  Alcotest.(check string)
+    "TimeoutError message is preserved"
+    "provider request timed out"
+    (Oas_compat.Http_client.error_message err)
+
 let test_tls_error_does_not_cascade () =
   let err =
     Http_client.NetworkError
@@ -414,6 +431,8 @@ let () =
       ( "Baseline: HTTP errors unaffected",
         [
           Alcotest.test_case "HTTP 429 cascades" `Quick test_http_429_cascades;
+          Alcotest.test_case "TimeoutError cascades"
+            `Quick test_timeout_error_cascades;
         ] );
       ( "Network terminal errors do not cascade",
         [

--- a/test/test_openai_compat_error_map.ml
+++ b/test/test_openai_compat_error_map.ml
@@ -3,7 +3,7 @@
 
     Each row asserts that a representative [sdk_error] variant produces
     the documented (http_status, openai_kind, openai_code) triple. The
-    table is intentionally exhaustive over the 9 top-level [sdk_error]
+    table is intentionally exhaustive over the 10 top-level [sdk_error]
     constructors — exhaustiveness over sub-variants is enforced by the
     OCaml compiler at the implementation site (no catch-all `_ ->`). *)
 
@@ -103,6 +103,30 @@ let test_provider_timeout () =
     ~expected_status:`Gateway_timeout
     ~expected_kind:"server_error"
     ~expected_code:(Some "provider_timeout")
+    ()
+
+let test_provider_hard_quota () =
+  check_mapping
+    ~label:"Provider HardQuota"
+    ~input:
+      (E.Provider
+         (Llm_provider.Error.HardQuota
+            { provider = "claude"; retry_after = None; detail = "quota exhausted" }))
+    ~expected_status:`Too_many_requests
+    ~expected_kind:"rate_limit_error"
+    ~expected_code:(Some "provider_hard_quota")
+    ()
+
+let test_provider_invalid_request () =
+  check_mapping
+    ~label:"Provider InvalidRequest"
+    ~input:
+      (E.Provider
+         (Llm_provider.Error.InvalidRequest
+            { provider = "claude"; reason = "bad request" }))
+    ~expected_status:`Bad_request
+    ~expected_kind:"invalid_request_error"
+    ~expected_code:(Some "provider_invalid_request")
     ()
 
 let test_agent_token_budget () =
@@ -273,7 +297,9 @@ let () =
         ; Alcotest.test_case "GuardrailViolation → 400"  `Quick test_agent_guardrail
         ] )
     ; ( "provider"
-      , [ Alcotest.test_case "Provider Timeout → 504" `Quick test_provider_timeout
+      , [ Alcotest.test_case "Timeout → 504" `Quick test_provider_timeout
+        ; Alcotest.test_case "HardQuota → 429" `Quick test_provider_hard_quota
+        ; Alcotest.test_case "InvalidRequest → 400" `Quick test_provider_invalid_request
         ] )
     ; ( "mcp"
       , [ Alcotest.test_case "ServerStartFailed → 503" `Quick test_mcp_server_start


### PR DESCRIPTION
## Summary
- map Agent_sdk.Error.Provider variants into cascade HTTP outcomes instead of leaving OAS/provider failures disconnected
- carry provider errors through SSE detail, terminal reason codes, OpenAI-compatible errors, retry/fallback classification, and timeout/provider metrics
- add regression coverage for TimeoutError cascading and provider OpenAI-compatible mappings

## Verification
- scripts/dune-local.sh build ./test/test_tool_task_coverage.exe test/test_oas_compat_cascade_fallback.exe test/test_openai_compat_error_map.exe bin/main_eio.exe
- ./_build/default/test/test_tool_task_coverage.exe (94 tests)
- ./_build/default/test/test_oas_compat_cascade_fallback.exe (24 tests)
- ./_build/default/test/test_openai_compat_error_map.exe (24 tests)