### PR TITLE
refactor: split keeper runtime lens swimlanes

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -78,6 +78,7 @@
  dashboard_http_keeper
  server_dashboard_http_keeper_runtime_manifest_scan
  server_dashboard_http_keeper_runtime_lens_proof
+ server_dashboard_http_keeper_runtime_lens_swimlane
  dashboard_goal_loop
  dashboard_http_autoresearch
  dashboard_harness_health

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -380,12 +380,7 @@ let memory_summary_json scan =
       ("procedures_flushed", `Int scan.procedures_flushed);
     ]
 
-type runtime_lens_gap =
-  { code : string
-  ; severity : string
-  ; lane : string
-  ; detail : string option
-  }
+include Server_dashboard_http_keeper_runtime_lens_swimlane
 
 let max_int_list_opt values =
   List.fold_left
@@ -615,15 +610,6 @@ let runtime_lens_tool_surface_parts scan =
   , materialized_tools
   , missing_required_tools )
 
-let runtime_lens_gap_json gap =
-  `Assoc
-    [
-      ("code", `String gap.code);
-      ("severity", `String gap.severity);
-      ("lane", `String gap.lane);
-      ("detail", json_string_opt gap.detail);
-    ]
-
 let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
   let ( _
       , _
@@ -799,80 +785,6 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
            gaps
        else gaps)
   |> List.rev
-
-let runtime_lens_gap_codes_for_lane gaps lane =
-  gaps
-  |> List.filter_map (fun gap ->
-       if String.equal gap.lane lane then Some gap.code else None)
-  |> Json_util.dedupe_keep_order
-
-let runtime_lens_event_count scan event =
-  runtime_manifest_scan_event_count scan event
-
-let runtime_lens_events_json scan events =
-  events
-  |> List.filter_map (fun event ->
-       let count = runtime_lens_event_count scan event in
-       if count = 0 then None
-       else
-         Some
-           (`Assoc
-             [
-               ( "event",
-                 `String (Keeper_runtime_manifest.event_kind_to_string event) );
-               ("count", `Int count);
-             ]))
-  |> fun events -> `List events
-
-let runtime_lens_swimlane_json scan gaps ~lane ~label ~events ~terminal_status =
-  let gap_codes = runtime_lens_gap_codes_for_lane gaps lane in
-  let event_count =
-    events
-    |> List.fold_left
-         (fun total event -> total + runtime_lens_event_count scan event)
-         0
-  in
-  `Assoc
-    [
-      ("lane", `String lane);
-      ("label", `String label);
-      ("event_count", `Int event_count);
-      ("terminal_status", `String terminal_status);
-      ("gap_codes", json_string_list gap_codes);
-      ( "gap_badge",
-        match gap_codes with
-        | code :: _ -> `String code
-        | [] -> `Null );
-      ("events", runtime_lens_events_json scan events);
-    ]
-
-let runtime_lens_keeper_terminal_status ~terminal_event_present scan =
-  if terminal_event_present then "finished"
-  else if
-    runtime_lens_event_count scan Keeper_runtime_manifest.Pre_dispatch_blocked
-    > 0
-  then "blocked"
-  else if scan.total_rows = 0 then "empty"
-  else "open"
-
-let runtime_lens_provider_terminal_status scan =
-  match scan.provider_terminal_row with
-  | Some row -> row.Keeper_runtime_manifest.status
-  | None when scan.provider_started_count > scan.provider_finished_count ->
-    "unfinished"
-  | None when scan.provider_started_count = 0 -> "not_started"
-  | None -> "unknown"
-
-let runtime_lens_memory_terminal_status scan =
-  if scan.memory_flush_error_count > 0 then "memory_error"
-  else if scan.memory_flush_success_count > 0 then "flushed"
-  else if scan.memory_injected_count > 0 then "injected"
-  else if
-    scan.context_injected_count > 0
-    || scan.context_compacted_event_count > 0
-    || scan.event_bus_count > 0
-  then "context"
-  else "empty"
 
 (* Runtime-lens proof accumulator moved to
    Server_dashboard_http_keeper_runtime_lens_proof (intra-library file split,

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
@@ -1,0 +1,99 @@
+(** Runtime-lens gap rendering and swimlane helpers.
+
+    Split from {!Server_dashboard_http_keeper_api}; gap construction stays in
+    the facade while repeated JSON rendering helpers live here. *)
+
+open Server_dashboard_http_keeper_api_types
+open Server_dashboard_http_keeper_runtime_manifest_scan
+
+type runtime_lens_gap =
+  { code : string
+  ; severity : string
+  ; lane : string
+  ; detail : string option
+  }
+
+let json_string_list values = `List (List.map (fun value -> `String value) values)
+
+let runtime_lens_gap_json gap =
+  `Assoc
+    [
+      ("code", `String gap.code);
+      ("severity", `String gap.severity);
+      ("lane", `String gap.lane);
+      ("detail", json_string_opt gap.detail);
+    ]
+
+let runtime_lens_gap_codes_for_lane gaps lane =
+  gaps
+  |> List.filter_map (fun gap ->
+       if String.equal gap.lane lane then Some gap.code else None)
+  |> Json_util.dedupe_keep_order
+
+let runtime_lens_event_count scan event =
+  runtime_manifest_scan_event_count scan event
+
+let runtime_lens_events_json scan events =
+  events
+  |> List.filter_map (fun event ->
+       let count = runtime_lens_event_count scan event in
+       if count = 0 then None
+       else
+         Some
+           (`Assoc
+             [
+               ( "event",
+                 `String (Keeper_runtime_manifest.event_kind_to_string event) );
+               ("count", `Int count);
+             ]))
+  |> fun events -> `List events
+
+let runtime_lens_swimlane_json scan gaps ~lane ~label ~events ~terminal_status =
+  let gap_codes = runtime_lens_gap_codes_for_lane gaps lane in
+  let event_count =
+    events
+    |> List.fold_left
+         (fun total event -> total + runtime_lens_event_count scan event)
+         0
+  in
+  `Assoc
+    [
+      ("lane", `String lane);
+      ("label", `String label);
+      ("event_count", `Int event_count);
+      ("terminal_status", `String terminal_status);
+      ("gap_codes", json_string_list gap_codes);
+      ( "gap_badge",
+        match gap_codes with
+        | code :: _ -> `String code
+        | [] -> `Null );
+      ("events", runtime_lens_events_json scan events);
+    ]
+
+let runtime_lens_keeper_terminal_status ~terminal_event_present scan =
+  if terminal_event_present then "finished"
+  else if
+    runtime_lens_event_count scan Keeper_runtime_manifest.Pre_dispatch_blocked
+    > 0
+  then "blocked"
+  else if scan.total_rows = 0 then "empty"
+  else "open"
+
+let runtime_lens_provider_terminal_status scan =
+  match scan.provider_terminal_row with
+  | Some row -> row.Keeper_runtime_manifest.status
+  | None when scan.provider_started_count > scan.provider_finished_count ->
+    "unfinished"
+  | None when scan.provider_started_count = 0 -> "not_started"
+  | None -> "unknown"
+
+let runtime_lens_memory_terminal_status scan =
+  if scan.memory_flush_error_count > 0 then "memory_error"
+  else if scan.memory_flush_success_count > 0 then "flushed"
+  else if scan.memory_injected_count > 0 then "injected"
+  else if
+    scan.context_injected_count > 0
+    || scan.context_compacted_event_count > 0
+    || scan.event_bus_count > 0
+  then "context"
+  else "empty"

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.mli
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.mli
@@ -1,0 +1,43 @@
+(** Runtime-lens gap rendering and swimlane helpers. *)
+
+type runtime_lens_gap =
+  { code : string
+  ; severity : string
+  ; lane : string
+  ; detail : string option
+  }
+
+val runtime_lens_gap_json : runtime_lens_gap -> Yojson.Safe.t
+
+val runtime_lens_gap_codes_for_lane :
+  runtime_lens_gap list -> string -> string list
+
+val runtime_lens_event_count :
+  Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan ->
+  Keeper_runtime_manifest.event_kind ->
+  int
+
+val runtime_lens_events_json :
+  Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan ->
+  Keeper_runtime_manifest.event_kind list ->
+  Yojson.Safe.t
+
+val runtime_lens_swimlane_json :
+  Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan ->
+  runtime_lens_gap list ->
+  lane:string ->
+  label:string ->
+  events:Keeper_runtime_manifest.event_kind list ->
+  terminal_status:string ->
+  Yojson.Safe.t
+
+val runtime_lens_keeper_terminal_status :
+  terminal_event_present:bool ->
+  Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan ->
+  string
+
+val runtime_lens_provider_terminal_status :
+  Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan -> string
+
+val runtime_lens_memory_terminal_status :
+  Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan -> string


### PR DESCRIPTION
## Summary
- split runtime lens gap rendering and swimlane helpers into a private server module
- keep gap construction and keeper runtime trace response shape unchanged
- reduce server_dashboard_http_keeper_api.ml from 2636 to 2548 lines

## Validation
- ocamlformat --check lib/server/server_dashboard_http_keeper_api.ml lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.mli
- git diff --check
- bash scripts/lint/godfile-size-regression.sh
- scripts/ocaml-structure-ratchet.sh --print

## Not Run
- scripts/dune-local.sh build lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.cmo lib/server/server_dashboard_http_keeper_api.cmo (local Dune lock was held by another worktree test run; cancelled before compile)