### PR TITLE
fix(keeper): coalesce livelock operator broadcasts

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -816,22 +816,27 @@ let to_json (receipt : t) =
      PauseHuman / StaleRunning  -> [needs_operator_broadcast]
                                   returns [true] for "pause_human",
                                   "alert_exhausted", "unknown".
-     OperatorBroadcast event    -> [emit_operator_broadcast]
-                                  emits "keeper.operator_broadcast_required.v1"
-                                  with structured payload.
-     Eventually-emit liveness   -> [append] calls the emit
-                                  unconditionally when
-                                  [needs_operator_broadcast] is true,
-                                  inside a [try] so a single failure
-                                  does not cascade — the spec's clean
-                                  model.
+     OperatorBroadcast event    -> [append] emits
+                                  "keeper.operator_broadcast_required.v1"
+                                  with structured payload. Repeated
+                                  turn-livelock receipts for the same
+                                  keeper/turn/reason are coalesced after
+                                  the first event; the receipt itself is
+                                  still persisted.
+     Eventually-emit liveness   -> [append] calls the emit when
+                                  [needs_operator_broadcast] is true and
+                                  the receipt is not a duplicate livelock
+                                  notification, inside a [try] so a single
+                                  failure does not cascade — the spec's
+                                  clean model.
 
-   Bug model (would be violated if a future refactor wrapped emit
-   in a conditional that could silently skip): an OperatorBroadcast
-   path that requires manual operator dispatch instead of automatic
-   emit would re-create the original #fleet-stall bug.  Sibling
-   anchor in [keeper_supervisor.ml] (StaleRunning watchdog +
-   emit_stale_keeper_broadcast) is deferred to a separate cycle. *)
+   Bug model (would be violated if a future refactor dropped the first
+   emit for a broadcast-worthy state, or skipped without the suppression
+   metric): an OperatorBroadcast path that requires manual operator
+   dispatch instead of automatic emit would re-create the original
+   #fleet-stall bug.  Sibling anchor in [keeper_supervisor.ml]
+   (StaleRunning watchdog + emit_stale_keeper_broadcast) is deferred to
+   a separate cycle. *)
 let needs_operator_broadcast = function
   | Disp_pause_human | Disp_alert_exhausted | Disp_unknown -> true
   | Disp_pass
@@ -839,6 +844,48 @@ let needs_operator_broadcast = function
   | Disp_pass_next_model
   | Disp_user_cancelled
   | Disp_skipped -> false
+;;
+
+let operator_broadcast_dedupe_mu = Eio.Mutex.create ()
+let operator_broadcast_dedupe_by_keeper : (string, string) Hashtbl.t =
+  Hashtbl.create 16
+;;
+
+let operator_broadcast_key_part = function
+  | Some value -> value
+  | None -> "-"
+;;
+
+let operator_broadcast_turn_key = function
+  | Some value -> string_of_int value
+  | None -> "-"
+;;
+
+let operator_broadcast_dedupe_key receipt ~disposition ~reason =
+  String.concat
+    "\000"
+    [ receipt.keeper_name
+    ; receipt.agent_name
+    ; string_of_int receipt.generation
+    ; operator_broadcast_turn_key receipt.turn_count
+    ; operator_broadcast_key_part receipt.current_task_id
+    ; operator_disposition_kind_to_string disposition
+    ; operator_disposition_reason_to_string reason
+    ; receipt.terminal_reason_code
+    ]
+;;
+
+let should_emit_operator_broadcast receipt ~disposition ~reason =
+  match reason with
+  | Reason_turn_livelock_blocked ->
+    let key = operator_broadcast_dedupe_key receipt ~disposition ~reason in
+    Eio.Mutex.use_rw ~protect:true operator_broadcast_dedupe_mu (fun () ->
+      match Hashtbl.find_opt operator_broadcast_dedupe_by_keeper receipt.keeper_name with
+      | Some previous_key when String.equal previous_key key -> false
+      | _ ->
+        Hashtbl.replace operator_broadcast_dedupe_by_keeper receipt.keeper_name key;
+        true)
+  | _ -> true
 ;;
 
 let operator_broadcast_payload (receipt : t) ~disposition ~reason =
@@ -967,22 +1014,37 @@ let append (config : Coord.config) (receipt : t) =
   let disposition, reason = operator_disposition receipt in
   if needs_operator_broadcast disposition
   then (
-    try emit_operator_broadcast config receipt ~disposition ~reason with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
-      (* fail-closed: log loud, do not silently swallow. The append itself
-         has already persisted the receipt; the broadcast failure is its
-         own diagnostic that watchdogs/log alerts will pick up. *)
+    let disposition_s = operator_disposition_kind_to_string disposition in
+    let reason_s = operator_disposition_reason_to_string reason in
+    if should_emit_operator_broadcast receipt ~disposition ~reason
+    then (
+      try emit_operator_broadcast config receipt ~disposition ~reason with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        (* fail-closed: log loud, do not silently swallow. The append itself
+           has already persisted the receipt; the broadcast failure is its
+           own diagnostic that watchdogs/log alerts will pick up. *)
+        Prometheus.inc_counter
+          Keeper_metrics.metric_keeper_execution_receipt_failures
+          ~labels:[ "keeper", receipt.keeper_name; "site", Keeper_execution_receipt_failure_site.(to_label Emit_failed) ]
+          ();
+        Log.Keeper.error
+          "%s: operator_broadcast_required EMIT FAILED disposition=%s reason=%s exn=%s"
+          receipt.keeper_name
+          disposition_s
+          reason_s
+          (Printexc.to_string exn))
+    else (
       Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_execution_receipt_failures
-        ~labels:[ "keeper", receipt.keeper_name; "site", Keeper_execution_receipt_failure_site.(to_label Emit_failed) ]
+        Keeper_metrics.metric_keeper_operator_broadcast_suppressed
+        ~labels:[ "keeper", receipt.keeper_name; "reason", reason_s ]
         ();
-      Log.Keeper.error
-        "%s: operator_broadcast_required EMIT FAILED disposition=%s reason=%s exn=%s"
+      Log.Keeper.info
+        "%s: operator_broadcast_required suppressed duplicate disposition=%s reason=%s turn=%s"
         receipt.keeper_name
-        (operator_disposition_kind_to_string disposition)
-        (operator_disposition_reason_to_string reason)
-        (Printexc.to_string exn))
+        disposition_s
+        reason_s
+        (operator_broadcast_turn_key receipt.turn_count)))
 ;;
 
 (* Watchdog-driven broadcast (#fleet-stall 2026-04-26 Step 3): emitted by a

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -94,6 +94,7 @@ type t =
   | TraceEmitFailures
   | TransitionAuditFailures
   | ExecutionReceiptFailures
+  | OperatorBroadcastSuppressed
   | LlmBridgeFailures
   | SessionCleanupFailures
   | ShellBashFailures
@@ -298,6 +299,7 @@ let to_string = function
   | TraceEmitFailures -> "masc_keeper_trace_emit_failures_total"
   | TransitionAuditFailures -> "masc_keeper_transition_audit_failures_total"
   | ExecutionReceiptFailures -> "masc_keeper_execution_receipt_failures_total"
+  | OperatorBroadcastSuppressed -> "masc_keeper_operator_broadcast_suppressed_total"
   | LlmBridgeFailures -> "masc_keeper_llm_bridge_failures_total"
   | SessionCleanupFailures -> "masc_keeper_session_cleanup_failures_total"
   | ShellBashFailures -> "masc_keeper_shell_bash_failures_total"
@@ -622,6 +624,10 @@ let metric_keeper_transition_audit_failures =
 
 let metric_keeper_execution_receipt_failures =
   "masc_keeper_execution_receipt_failures_total"
+;;
+
+let metric_keeper_operator_broadcast_suppressed =
+  "masc_keeper_operator_broadcast_suppressed_total"
 ;;
 
 let metric_keeper_llm_bridge_failures = "masc_keeper_llm_bridge_failures_total"

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -86,6 +86,7 @@ type t =
   | TraceEmitFailures
   | TransitionAuditFailures
   | ExecutionReceiptFailures
+  | OperatorBroadcastSuppressed
   | LlmBridgeFailures
   | SessionCleanupFailures
   | ShellBashFailures
@@ -367,6 +368,7 @@ val metric_keeper_tag_dispatch_failures : string
 val metric_keeper_trace_emit_failures : string
 val metric_keeper_transition_audit_failures : string
 val metric_keeper_execution_receipt_failures : string
+val metric_keeper_operator_broadcast_suppressed : string
 val metric_keeper_llm_bridge_failures : string
 val metric_keeper_shell_bash_failures : string
 val metric_keeper_rollover_failures : string

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -441,6 +441,37 @@ let string_list_member name json =
   json |> U.member name |> U.to_list |> List.map U.to_string
 ;;
 
+let temp_dir prefix =
+  let dir = Filename.temp_file (prefix ^ "-") "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+;;
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path
+    then
+      if Sys.is_directory path
+      then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try rm dir with
+  | _ -> ()
+;;
+
+let operator_broadcast_event_count config =
+  Activity_graph.list_events
+    config
+    ~kinds:[ "keeper.operator_broadcast_required" ]
+    ~after_seq:0
+    ~limit:20
+    ()
+  |> List.length
+;;
+
 let test_receipt_json_redacts_provider_model_identity () =
   let receipt =
     { (mk_receipt ())
@@ -466,6 +497,61 @@ let test_receipt_json_redacts_provider_model_identity () =
     "runtime contract model redacted"
     true
     (json |> U.member "runtime_contract" |> U.member "model" = `Null)
+;;
+
+let test_turn_livelock_broadcast_suppresses_duplicate_turn () =
+  Eio_main.run
+  @@ fun _env ->
+  let base_dir = temp_dir "masc-test-livelock-broadcast-dedupe" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "test-operator"));
+       let keeper_name = "test-livelock-broadcast-dedupe-keeper" in
+       let suppression_before =
+         Masc_mcp.Prometheus.metric_value_or_zero
+           Masc_mcp.Keeper_metrics.metric_keeper_operator_broadcast_suppressed
+           ~labels:[ "keeper", keeper_name; "reason", "turn_livelock_blocked" ]
+           ()
+       in
+       let receipt =
+         { (mk_receipt
+              ~terminal_reason_code:
+                "turn_livelock:attempts_exhausted attempts=3 max_attempts=3"
+              ~tool_contract_result:Contract_satisfied_completion
+              ~tools_used:[ "keeper_task_submit_for_verification" ]
+              ~error_kind:(Some (R.error_kind_of_string "turn_livelock_blocked"))
+              ())
+           with
+           keeper_name
+         ; agent_name = "test-livelock-broadcast-dedupe-agent"
+         ; trace_id = "trace-livelock-dedupe-1"
+         ; generation = 7
+         ; turn_count = Some 605
+         ; current_task_id = Some "task-livelock-dedupe"
+         }
+       in
+       R.append config receipt;
+       check int "first livelock receipt emits" 1 (operator_broadcast_event_count config);
+       R.append config { receipt with trace_id = "trace-livelock-dedupe-2" };
+       check
+         int
+         "duplicate livelock receipt is suppressed"
+         1
+         (operator_broadcast_event_count config);
+       check
+         (float 0.0001)
+         "suppression metric increments"
+         (suppression_before +. 1.0)
+         (Masc_mcp.Prometheus.metric_value_or_zero
+            Masc_mcp.Keeper_metrics.metric_keeper_operator_broadcast_suppressed
+            ~labels:[ "keeper", keeper_name; "reason", "turn_livelock_blocked" ]
+            ());
+       R.append
+         config
+         { receipt with trace_id = "trace-livelock-dedupe-3"; turn_count = Some 606 };
+       check int "new turn emits again" 2 (operator_broadcast_event_count config))
 ;;
 
 let test_broadcast_payload_carries_turn_diagnostics () =
@@ -793,6 +879,10 @@ let () =
             "all 3 broadcast paths reachable"
             `Quick
             test_each_broadcast_disp_is_reachable
+        ; test_case
+            "turn livelock duplicate broadcast is coalesced"
+            `Quick
+            test_turn_livelock_broadcast_suppresses_duplicate_turn
         ; test_case
             "receipt JSON redacts provider/model identity"
             `Quick


### PR DESCRIPTION
## Summary

- Coalesces duplicate `keeper.operator_broadcast_required` events for the same keeper/generation/turn/task/reason when the pause reason is `turn_livelock_blocked`.
- Keeps the first operator broadcast and still persists every execution receipt.
- Adds `masc_keeper_operator_broadcast_suppressed_total` so suppressed repeats remain visible without flooding the activity graph.
- Covers the duplicate livelock path in `test_keeper_pause_broadcast`.

## Product impact

- User-visible change: repeated livelock turns still surface once to operators, but no longer flood activity/dashboard streams every retry cycle.

## Evidence

- Live issue evidence: #16204 reports repeated `operator_broadcast_required disposition=pause_human reason=turn_livelock_blocked` for the same stuck keeper turn.
- `opam exec -- ocamlformat --check lib/keeper/keeper_execution_receipt.ml lib/keeper/keeper_metrics.ml lib/keeper/keeper_metrics.mli test/test_keeper_pause_broadcast.ml`
- `git diff --check`
- `python3 scripts/ci/check-fun-protect-finally-guard.py --base origin/main --head HEAD`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_pause_broadcast.exe`
- `./_build/default/test/test_keeper_pause_broadcast.exe`

## GOAL LOOP ACT checklist

- [x] Observe — #16204 contains the repeated live-log pattern.
- [x] Orient — mapped to `Keeper_execution_receipt.append` emitting every `turn_livelock_blocked` receipt.
- [x] Decide — bounded rate reduction is lower risk than changing keeper release/retry semantics in this PR.
- [x] Act — first broadcast remains automatic; only exact duplicate livelock broadcasts are coalesced and counted.
- [x] Verify — focused local build/test passed.
- [x] Loop — no new follow-up for this PR scope; broader keeper auto-release behavior remains outside this change.

## Review evidence

- Local deterministic review only. Cross-model review not run because this is a narrow receipt emission/test change.

## Linked issue

- Closes #16204
- Relates #16165

## Variant addition checklist

- [x] **OCaml** — added `OperatorBroadcastSuppressed` in `.ml`/`.mli` and updated exhaustive `to_string`.
- [ ] **TypeScript** — N/A: internal Prometheus metric variant only; no dashboard union change.
- [ ] **TLA+ spec** — N/A: no new state-machine literal; liveness still emits the first broadcast.
- [ ] **Event / JSON schema** — N/A: event payload schema unchanged; added a Prometheus counter only.
- [ ] **`make check-variants` passes** — not run locally; focused OCaml build/test passed for the touched receipt path.
