### PR TITLE
refactor(keeper): extract turn pipeline records

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -65,6 +65,52 @@ let provider_attempt_provenance_fields p =
   | Some source_cascade ->
       ("provider_source_cascade", `String source_cascade) :: base
 
+type provider_attempt_started_record =
+  { started_provenance : provider_attempt_provenance
+  ; started_is_last : bool
+  ; started_per_provider_timeout_s : float option
+  }
+
+type provider_attempt_finished_record =
+  { finished_provenance : provider_attempt_provenance
+  ; finished_status : string
+  ; finished_latency_ms : float
+  ; finished_checkpoint_after_present : bool
+  ; finished_error : Yojson.Safe.t
+  ; finished_exception_kind : string option
+  }
+
+let provider_attempt_started_decision record =
+  `Assoc
+    (provider_attempt_provenance_fields record.started_provenance
+     @ [
+         ("is_last", `Bool record.started_is_last);
+         ( "per_provider_timeout_s",
+           match record.started_per_provider_timeout_s with
+           | None -> `Null
+           | Some timeout -> `Float timeout );
+       ])
+;;
+
+let provider_attempt_finished_decision record =
+  let decision_fields =
+    [
+      ("latency_ms", `Float record.finished_latency_ms);
+      ("checkpoint_after_present", `Bool record.finished_checkpoint_after_present);
+      ("error", record.finished_error);
+    ]
+  in
+  let decision_fields =
+    provider_attempt_provenance_fields record.finished_provenance @ decision_fields
+  in
+  let decision_fields =
+    match record.finished_exception_kind with
+    | None -> decision_fields
+    | Some kind -> ("exception_kind", `String kind) :: decision_fields
+  in
+  `Assoc decision_fields
+;;
+
 let success_selected_model_raw candidate =
   Some (Cascade_runtime_candidate.model_health_key candidate)
 
@@ -839,19 +885,15 @@ let run_named
           candidate
       in
       let attempt_started_at = Unix.gettimeofday () in
-      let started_decision_fields =
-        provider_attempt_provenance_fields provider_attempt_provenance
-        @ [
-            ("is_last", `Bool is_last);
-            ( "per_provider_timeout_s",
-              match pp_timeout with
-              | None -> `Null
-              | Some timeout -> `Float timeout );
-          ]
+      let started_record =
+        { started_provenance = provider_attempt_provenance
+        ; started_is_last = is_last
+        ; started_per_provider_timeout_s = pp_timeout
+        }
       in
       emit_runtime_manifest
         ~status:"started"
-        ~decision:(`Assoc started_decision_fields)
+        ~decision:(provider_attempt_started_decision started_record)
         Keeper_runtime_manifest.Provider_attempt_started;
       let provider_attempt_finished_emitted = ref false in
       let emit_provider_attempt_finished_once
@@ -865,26 +907,19 @@ let run_named
         =
         if not !provider_attempt_finished_emitted then (
           provider_attempt_finished_emitted := true;
-          let decision_fields =
-            [
-              ("latency_ms", `Float attempt_latency_ms);
-              ("checkpoint_after_present", `Bool checkpoint_after_present);
-              ("error", error);
-            ]
-          in
-          let decision_fields =
-            provider_attempt_provenance_fields provider_attempt_provenance
-            @ decision_fields
-          in
-          let decision_fields =
-            match exception_kind with
-            | None -> decision_fields
-            | Some kind -> ("exception_kind", `String kind) :: decision_fields
+          let finished_record =
+            { finished_provenance = provider_attempt_provenance
+            ; finished_status = status
+            ; finished_latency_ms = attempt_latency_ms
+            ; finished_checkpoint_after_present = checkpoint_after_present
+            ; finished_error = error
+            ; finished_exception_kind = exception_kind
+            }
           in
           emit_runtime_manifest
             ~status
             ?oas_turn_count
-            ~decision:(`Assoc decision_fields)
+            ~decision:(provider_attempt_finished_decision finished_record)
             Keeper_runtime_manifest.Provider_attempt_finished)
       in
       let record_attempt_terminal ~error attempt_latency_ms =

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -140,6 +140,37 @@ val sdk_error_cascade_fallback_class :
     stream. *)
 val apply_stream_idle_timeout_default : float option -> float option
 
+(** {1 Turn pipeline records} *)
+
+type provider_attempt_provenance =
+  { model_source : string
+  ; resolved_model_source : string
+  ; capability_source : string
+  ; fallback_authority : string
+  ; provider_source_cascade : string option
+  }
+
+type provider_attempt_started_record =
+  { started_provenance : provider_attempt_provenance
+  ; started_is_last : bool
+  ; started_per_provider_timeout_s : float option
+  }
+
+type provider_attempt_finished_record =
+  { finished_provenance : provider_attempt_provenance
+  ; finished_status : string
+  ; finished_latency_ms : float
+  ; finished_checkpoint_after_present : bool
+  ; finished_error : Yojson.Safe.t
+  ; finished_exception_kind : string option
+  }
+
+val provider_attempt_started_decision :
+  provider_attempt_started_record -> Yojson.Safe.t
+
+val provider_attempt_finished_decision :
+  provider_attempt_finished_record -> Yojson.Safe.t
+
 (** {1 Named cascade execution} *)
 
 val run_named :

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -17,6 +17,90 @@ include Keeper_unified_turn_types
 
 let runtime_lane_label = "runtime"
 
+type turn_plan_status =
+  | Turn_plan_dispatch
+  | Turn_plan_skipped
+  | Turn_plan_cancelled
+  | Turn_plan_error
+
+type turn_plan =
+  { turn_plan_keeper_turn_id : int
+  ; turn_plan_phase : string option
+  ; turn_plan_status : turn_plan_status
+  ; turn_plan_executable : bool
+  ; turn_plan_reason : string
+  ; turn_plan_terminal_reason_code : string option
+  }
+
+let decide_turn_plan_at_phase_gate
+      ~keeper_turn_id
+      ~supervisor_stop_at_entry
+      phase_opt
+  =
+  if supervisor_stop_at_entry
+  then
+    { turn_plan_keeper_turn_id = keeper_turn_id
+    ; turn_plan_phase = Option.map Keeper_state_machine.phase_to_string phase_opt
+    ; turn_plan_status = Turn_plan_cancelled
+    ; turn_plan_executable = false
+    ; turn_plan_reason = "supervisor_stop"
+    ; turn_plan_terminal_reason_code = Some "supervisor_stop"
+    }
+  else
+    match phase_opt with
+    | None ->
+      { turn_plan_keeper_turn_id = keeper_turn_id
+      ; turn_plan_phase = None
+      ; turn_plan_status = Turn_plan_error
+      ; turn_plan_executable = false
+      ; turn_plan_reason = "registry_phase_missing"
+      ; turn_plan_terminal_reason_code = Some "registry_phase_missing"
+      }
+    | Some phase ->
+      let phase_string = Keeper_state_machine.phase_to_string phase in
+      if Keeper_state_machine.can_execute_turn phase
+      then
+        { turn_plan_keeper_turn_id = keeper_turn_id
+        ; turn_plan_phase = Some phase_string
+        ; turn_plan_status = Turn_plan_dispatch
+        ; turn_plan_executable = true
+        ; turn_plan_reason = "executable_phase"
+        ; turn_plan_terminal_reason_code = None
+        }
+      else
+        { turn_plan_keeper_turn_id = keeper_turn_id
+        ; turn_plan_phase = Some phase_string
+        ; turn_plan_status = Turn_plan_skipped
+        ; turn_plan_executable = false
+        ; turn_plan_reason = "non_executable_phase"
+        ; turn_plan_terminal_reason_code =
+            Some (Printf.sprintf "non_executable_phase:%s" phase_string)
+        }
+;;
+
+let turn_plan_manifest_status plan =
+  match plan.turn_plan_status with
+  | Turn_plan_dispatch -> "ok"
+  | Turn_plan_skipped -> "skipped"
+  | Turn_plan_cancelled -> "cancelled"
+  | Turn_plan_error -> "error"
+;;
+
+let turn_plan_manifest_decision plan =
+  let phase_fields =
+    match plan.turn_plan_phase, plan.turn_plan_status with
+    | Some phase, _ -> [ ("phase", `String phase) ]
+    | None, Turn_plan_error -> [ ("phase", `Null) ]
+    | None, _ -> []
+  in
+  `Assoc
+    (phase_fields
+     @ [
+         ("reason", `String plan.turn_plan_reason);
+         ("executable", `Bool plan.turn_plan_executable);
+       ])
+;;
+
 let stay_silent_recovery_stimulus ~now ~keeper_name ~streak ~threshold =
   let payload =
     `Assoc
@@ -200,6 +284,12 @@ let run_keeper_cycle
       ?cascade_name ?status ?decision ()
     |> Keeper_runtime_manifest.append_best_effort ~site config
   in
+  let append_phase_gate_decision turn_plan =
+    append_manifest ~site:"phase_gate_decided"
+      ~status:(turn_plan_manifest_status turn_plan)
+      ~decision:(turn_plan_manifest_decision turn_plan)
+      Keeper_runtime_manifest.Phase_gate_decided
+  in
   append_manifest ~site:"turn_started"
     ~decision:
       (`Assoc
@@ -227,15 +317,11 @@ let run_keeper_cycle
   in
   if supervisor_stop_at_entry
   then (
-    append_manifest ~site:"phase_gate_decided"
-      ~status:"cancelled"
-      ~decision:
-        (`Assoc
-          [
-            ("reason", `String "supervisor_stop");
-            ("executable", `Bool false);
-          ])
-      Keeper_runtime_manifest.Phase_gate_decided;
+    let turn_plan =
+      decide_turn_plan_at_phase_gate ~keeper_turn_id
+        ~supervisor_stop_at_entry:true None
+    in
+    append_phase_gate_decision turn_plan;
     Log.Keeper.info
       ~keeper_name:meta.name
       ~turn_id:keeper_turn_id
@@ -269,17 +355,12 @@ let run_keeper_cycle
   else (
     match Keeper_registry.get_phase ~base_path:registry_base_path meta.name with
     | Some phase when not (Keeper_state_machine.can_execute_turn phase) ->
+      let turn_plan =
+        decide_turn_plan_at_phase_gate ~keeper_turn_id
+          ~supervisor_stop_at_entry:false (Some phase)
+      in
       let phase_string = Keeper_state_machine.phase_to_string phase in
-      append_manifest ~site:"phase_gate_decided"
-        ~status:"skipped"
-        ~decision:
-          (`Assoc
-            [
-              ("phase", `String phase_string);
-              ("reason", `String "non_executable_phase");
-              ("executable", `Bool false);
-            ])
-        Keeper_runtime_manifest.Phase_gate_decided;
+      append_phase_gate_decision turn_plan;
       Log.Keeper.info
         ~keeper_name:meta.name
         ~turn_id:keeper_turn_id
@@ -306,22 +387,17 @@ let run_keeper_cycle
         Keeper_turn_fsm.Done;
       Ok meta
     | None ->
+      let turn_plan =
+        decide_turn_plan_at_phase_gate ~keeper_turn_id
+          ~supervisor_stop_at_entry:false None
+      in
       let terminal_reason_code = "registry_phase_missing" in
       let error_message =
         Printf.sprintf
           "%s: keeper registry phase lookup returned None before dispatch"
           meta.name
       in
-      append_manifest ~site:"phase_gate_decided"
-        ~status:"error"
-        ~decision:
-          (`Assoc
-            [
-              ("phase", `Null);
-              ("reason", `String terminal_reason_code);
-              ("executable", `Bool false);
-            ])
-        Keeper_runtime_manifest.Phase_gate_decided;
+      append_phase_gate_decision turn_plan;
       Log.Keeper.error
         ~keeper_name:meta.name
         ~turn_id:keeper_turn_id
@@ -351,20 +427,11 @@ let run_keeper_cycle
     | phase_opt ->
       (* State-aware cascade routing (TLA+ KeeperCoreTriad.SelectCascade).
          At this point [phase] is executable; blocked phases returned above. *)
-      append_manifest ~site:"phase_gate_decided"
-        ~status:"ok"
-        ~decision:
-          (`Assoc
-            [
-              ( "phase",
-                `String
-                  (match phase_opt with
-                   | Some phase -> Keeper_state_machine.phase_to_string phase
-                   | None -> "missing_registry_phase_unreachable") );
-              ("reason", `String "executable_phase");
-              ("executable", `Bool true);
-            ])
-        Keeper_runtime_manifest.Phase_gate_decided;
+      let turn_plan =
+        decide_turn_plan_at_phase_gate ~keeper_turn_id
+          ~supervisor_stop_at_entry:false phase_opt
+      in
+      append_phase_gate_decision turn_plan;
       Keeper_turn_fsm.emit_transition
         ~keeper_name:meta.name
         ~turn_id:keeper_turn_id

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -215,6 +215,34 @@ val fail_open_rotation_cascades_from_catalog
   -> unit
   -> string list option
 
+(** Typed phase-gate output for the first turn pipeline boundary.
+    [run_keeper_cycle] converts this record into the manifest
+    [Phase_gate_decided] row and then dispatches the matching terminal or
+    cascade-routing branch. *)
+type turn_plan_status =
+  | Turn_plan_dispatch
+  | Turn_plan_skipped
+  | Turn_plan_cancelled
+  | Turn_plan_error
+
+type turn_plan =
+  { turn_plan_keeper_turn_id : int
+  ; turn_plan_phase : string option
+  ; turn_plan_status : turn_plan_status
+  ; turn_plan_executable : bool
+  ; turn_plan_reason : string
+  ; turn_plan_terminal_reason_code : string option
+  }
+
+val decide_turn_plan_at_phase_gate
+  :  keeper_turn_id:int
+  -> supervisor_stop_at_entry:bool
+  -> Keeper_state_machine.phase option
+  -> turn_plan
+
+val turn_plan_manifest_status : turn_plan -> string
+val turn_plan_manifest_decision : turn_plan -> Yojson.Safe.t
+
 (** Resolve the next cascade to try after an auto-recoverable failure.
     Uses the current effective cascade, the turn tool requirement, and
     optionally a runtime/catalog-owned rotation order, then suppresses

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -7,6 +7,7 @@ module EC = Masc_mcp.Keeper_error_classify
 module UM = Masc_mcp.Keeper_unified_metrics
 module KR = Masc_mcp.Keeper_registry
 module KAR = Masc_mcp.Keeper_agent_run
+module KRun = Masc_mcp.Keeper_turn_driver
 module KCC = Masc_mcp.Keeper_contract_classifier
 module KTCL = Masc_mcp.Keeper_tool_call_log
 module KTD = Masc_mcp.Keeper_tool_disclosure
@@ -5393,6 +5394,152 @@ let test_append_decision_record_preserves_no_result_skipped_outcome () =
          "ollama_saturated"
          (json |> member "terminal_reason_code" |> to_string);
        check int "duration alias persisted" 11 (json |> member "duration_ms" |> to_int))
+;;
+
+let test_turn_plan_phase_gate_records_typed_contract () =
+  let open Yojson.Safe.Util in
+  let running =
+    UT.decide_turn_plan_at_phase_gate ~keeper_turn_id:17
+      ~supervisor_stop_at_entry:false (Some KP.Running)
+  in
+  check int "turn plan keeps turn id" 17 running.turn_plan_keeper_turn_id;
+  check string "running manifest status" "ok" (UT.turn_plan_manifest_status running);
+  check bool "running executable" true running.turn_plan_executable;
+  check
+    (option string)
+    "running terminal reason absent"
+    None
+    running.turn_plan_terminal_reason_code;
+  let running_decision = UT.turn_plan_manifest_decision running in
+  check string "running phase" "running" (running_decision |> member "phase" |> to_string);
+  check
+    string
+    "running reason"
+    "executable_phase"
+    (running_decision |> member "reason" |> to_string);
+  check
+    bool
+    "running decision executable"
+    true
+    (running_decision |> member "executable" |> to_bool);
+  let paused =
+    UT.decide_turn_plan_at_phase_gate ~keeper_turn_id:18
+      ~supervisor_stop_at_entry:false (Some KP.Paused)
+  in
+  check string "paused manifest status" "skipped" (UT.turn_plan_manifest_status paused);
+  check
+    (option string)
+    "paused terminal reason"
+    (Some "non_executable_phase:paused")
+    paused.turn_plan_terminal_reason_code;
+  let paused_decision = UT.turn_plan_manifest_decision paused in
+  check string "paused phase" "paused" (paused_decision |> member "phase" |> to_string);
+  check
+    string
+    "paused reason"
+    "non_executable_phase"
+    (paused_decision |> member "reason" |> to_string);
+  let missing =
+    UT.decide_turn_plan_at_phase_gate ~keeper_turn_id:19
+      ~supervisor_stop_at_entry:false None
+  in
+  check string "missing manifest status" "error" (UT.turn_plan_manifest_status missing);
+  check
+    (option string)
+    "missing terminal reason"
+    (Some "registry_phase_missing")
+    missing.turn_plan_terminal_reason_code;
+  let missing_decision = UT.turn_plan_manifest_decision missing in
+  check bool "missing phase is null" true (missing_decision |> member "phase" = `Null);
+  check
+    string
+    "missing reason"
+    "registry_phase_missing"
+    (missing_decision |> member "reason" |> to_string);
+  let stopped =
+    UT.decide_turn_plan_at_phase_gate ~keeper_turn_id:20
+      ~supervisor_stop_at_entry:true None
+  in
+  check
+    string
+    "supervisor stop manifest status"
+    "cancelled"
+    (UT.turn_plan_manifest_status stopped);
+  check
+    (option string)
+    "supervisor stop terminal reason"
+    (Some "supervisor_stop")
+    stopped.turn_plan_terminal_reason_code
+;;
+
+let test_provider_attempt_records_manifest_decision_contract () =
+  let provenance : KRun.provider_attempt_provenance =
+    { model_source = "named_cascade"
+    ; resolved_model_source = "cascade_catalog_binding"
+    ; capability_source = "provider_config_from_cascade_catalog"
+    ; fallback_authority = "declared_cascade"
+    ; provider_source_cascade = Some "phase_buffer"
+    }
+  in
+  let open Yojson.Safe.Util in
+  let started =
+    KRun.provider_attempt_started_decision
+      { started_provenance = provenance
+      ; started_is_last = false
+      ; started_per_provider_timeout_s = Some 12.5
+      }
+  in
+  check
+    string
+    "started model source"
+    "named_cascade"
+    (started |> member "model_source" |> to_string);
+  check
+    string
+    "started provider source cascade"
+    "phase_buffer"
+    (started |> member "provider_source_cascade" |> to_string);
+  check bool "started is not last" false (started |> member "is_last" |> to_bool);
+  check
+    (float 0.0)
+    "started timeout"
+    12.5
+    (started |> member "per_provider_timeout_s" |> to_float);
+  let finished =
+    KRun.provider_attempt_finished_decision
+      { finished_provenance = provenance
+      ; finished_status = "timeout"
+      ; finished_latency_ms = 250.0
+      ; finished_checkpoint_after_present = false
+      ; finished_error = `String "Eio.Time.Timeout"
+      ; finished_exception_kind = Some "outer_oas_timeout"
+      }
+  in
+  check
+    string
+    "finished exception kind"
+    "outer_oas_timeout"
+    (finished |> member "exception_kind" |> to_string);
+  check
+    string
+    "finished resolved model source"
+    "cascade_catalog_binding"
+    (finished |> member "resolved_model_source" |> to_string);
+  check
+    (float 0.0)
+    "finished latency"
+    250.0
+    (finished |> member "latency_ms" |> to_float);
+  check
+    bool
+    "finished checkpoint absent"
+    false
+    (finished |> member "checkpoint_after_present" |> to_bool);
+  check
+    string
+    "finished error"
+    "Eio.Time.Timeout"
+    (finished |> member "error" |> to_string)
 ;;
 
 let test_run_keeper_cycle_skips_non_executable_phase () =
@@ -12952,6 +13099,16 @@ let () =
             "context_overflow_event falls back without event bus signal"
             `Quick
             test_context_overflow_event_falls_back_without_event_bus_signal
+        ] )
+    ; ( "turn_pipeline_records"
+      , [ test_case
+            "phase gate emits typed turn plan records"
+            `Quick
+            test_turn_plan_phase_gate_records_typed_contract
+        ; test_case
+            "provider attempt emits typed manifest records"
+            `Quick
+            test_provider_attempt_records_manifest_decision_contract
         ] )
 	    ; ( "phase_gate"
 	      , [ test_case


### PR DESCRIPTION
## Summary
- extract typed phase-gate turn_plan records from run_keeper_cycle and reuse them for Phase_gate_decided manifest rows
- extract provider attempt started/finished records from keeper_turn_driver runtime manifest payload assembly
- add focused tests for turn pipeline record contracts and preserve existing phase gate behavior

Refs #16079
MASC task: task-372

## Verification
- ocamlformat --check lib/keeper/keeper_turn_driver.ml lib/keeper/keeper_turn_driver.mli lib/keeper/keeper_unified_turn.ml lib/keeper/keeper_unified_turn.mli test/test_keeper_unified.ml
- git diff --check
- scripts/dune-local.sh build test/test_keeper_unified.exe
- ./_build/default/test/test_keeper_unified.exe test turn_pipeline_records --show-errors
- ./_build/default/test/test_keeper_unified.exe test phase_gate --show-errors