### PR TITLE
refactor(task): extract lifecycle transition executor

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -16,19 +16,6 @@ include Coord_task_classify
 include Coord_task_create
 include Coord_task_claim
 
-let action_persists_handoff_context = function
-  | Masc_domain.Release
-  | Masc_domain.Done_action
-  | Masc_domain.Submit_for_verification
-  | Masc_domain.Submit_pr_evidence ->
-    true
-  | Masc_domain.Claim
-  | Masc_domain.Start
-  | Masc_domain.Cancel
-  | Masc_domain.Approve_verification
-  | Masc_domain.Reject_verification ->
-    false
-
 let flatten_lock_result = function
   | Ok result -> result
   | Error e -> Error e
@@ -534,60 +521,15 @@ let transition_task_r
                task_id
                (task_status_to_string task.task_status))
         else (
-          let new_tasks =
-            List.map
-              (fun (t : task) ->
-                 if t.id = task_id
-                 then (
-                   let t =
-                     match action with
-                     | Masc_domain.Claim ->
-                       t
-                       |> clear_soft_do_not_reclaim_reason
-                       |> clear_stale_worktree_binding
-                     | Masc_domain.Release -> clear_stale_worktree_binding t
-                     | Masc_domain.Start
-                     | Masc_domain.Done_action
-                     | Masc_domain.Cancel
-                     | Masc_domain.Submit_for_verification
-                     | Masc_domain.Submit_pr_evidence
-                     | Masc_domain.Approve_verification
-                     | Masc_domain.Reject_verification -> t
-                   in
-                   let cycle_count, do_not_reclaim_reason =
-                     match action with
-                     | Masc_domain.Release ->
-                       ( t.cycle_count + 1
-                       , derive_release_do_not_reclaim_reason t handoff_context )
-                     | Masc_domain.Claim
-                     | Masc_domain.Start
-                     | Masc_domain.Done_action
-                     | Masc_domain.Cancel
-                     | Masc_domain.Submit_for_verification
-                     | Masc_domain.Submit_pr_evidence
-                     | Masc_domain.Approve_verification
-                     | Masc_domain.Reject_verification ->
-                       t.cycle_count, t.do_not_reclaim_reason
-                   in
-                   { t with
-                     task_status = new_status
-                   ; handoff_context =
-                       (if action_persists_handoff_context action
-                        then handoff_context
-                        else None)
-                   ; cycle_count
-                   ; do_not_reclaim_reason
-                   })
-                 else t)
-              backlog.tasks
+          let backlog_update =
+            Coord_task_transition_executor.build_backlog_update
+              ~backlog
+              ~task_id
+              ~action
+              ~new_status
+              ~handoff_context
           in
-          let new_backlog =
-            { tasks = new_tasks
-            ; last_updated = now_iso ()
-            ; version = backlog.version + 1
-            }
-          in
-          write_backlog config new_backlog;
+          write_backlog config backlog_update.backlog;
           update_local_agent_state config ~agent_name (fun agent ->
             match set_current with
             | Some _ -> { agent with status = Busy; current_task = Some task_id }
@@ -607,10 +549,7 @@ let transition_task_r
                ~forced:force
                ?notes:(trim_opt (Some notes))
                ?reason:(trim_opt (Some reason))
-               ?handoff_context:
-                 (if action_persists_handoff_context action
-                  then handoff_context
-                  else None)
+               ?handoff_context:backlog_update.persisted_handoff_context
                ());
           (match action with
            | Masc_domain.Claim ->

--- a/lib/coord/coord_task_transition_executor.ml
+++ b/lib/coord/coord_task_transition_executor.ml
@@ -1,0 +1,90 @@
+(** Build the persisted task/backlog shape for task lifecycle transitions. *)
+
+open Masc_domain
+
+type transition_backlog_update =
+  { backlog : Masc_domain.backlog
+  ; persisted_handoff_context : Masc_domain.task_handoff_context option
+  }
+
+let action_persists_handoff_context = function
+  | Masc_domain.Release
+  | Masc_domain.Done_action
+  | Masc_domain.Submit_for_verification
+  | Masc_domain.Submit_pr_evidence ->
+    true
+  | Masc_domain.Claim
+  | Masc_domain.Start
+  | Masc_domain.Cancel
+  | Masc_domain.Approve_verification
+  | Masc_domain.Reject_verification ->
+    false
+;;
+
+let normalize_task_before_status ~action task =
+  match action with
+  | Masc_domain.Claim ->
+    task
+    |> Coord_task_claim.clear_soft_do_not_reclaim_reason
+    |> Coord_task_claim.clear_stale_worktree_binding
+  | Masc_domain.Release -> Coord_task_claim.clear_stale_worktree_binding task
+  | Masc_domain.Start
+  | Masc_domain.Done_action
+  | Masc_domain.Cancel
+  | Masc_domain.Submit_for_verification
+  | Masc_domain.Submit_pr_evidence
+  | Masc_domain.Approve_verification
+  | Masc_domain.Reject_verification ->
+    task
+;;
+
+let release_counters ~action task handoff_context =
+  match action with
+  | Masc_domain.Release ->
+    ( task.cycle_count + 1
+    , Coord_task_claim.derive_release_do_not_reclaim_reason task handoff_context )
+  | Masc_domain.Claim
+  | Masc_domain.Start
+  | Masc_domain.Done_action
+  | Masc_domain.Cancel
+  | Masc_domain.Submit_for_verification
+  | Masc_domain.Submit_pr_evidence
+  | Masc_domain.Approve_verification
+  | Masc_domain.Reject_verification ->
+    task.cycle_count, task.do_not_reclaim_reason
+;;
+
+let update_task_for_transition ~action ~new_status ~handoff_context task =
+  let task = normalize_task_before_status ~action task in
+  let cycle_count, do_not_reclaim_reason =
+    release_counters ~action task handoff_context
+  in
+  { task with
+    task_status = new_status
+  ; handoff_context =
+      (if action_persists_handoff_context action then handoff_context else None)
+  ; cycle_count
+  ; do_not_reclaim_reason
+  }
+;;
+
+let build_backlog_update ~backlog ~task_id ~action ~new_status ~handoff_context =
+  let tasks =
+    List.map
+      (fun (task : task) ->
+         if String.equal task.id task_id
+         then update_task_for_transition ~action ~new_status ~handoff_context task
+         else task)
+      backlog.tasks
+  in
+  let persisted_handoff_context =
+    if action_persists_handoff_context action then handoff_context else None
+  in
+  { backlog =
+      { tasks
+      ; last_updated = now_iso ()
+      ; version = backlog.version + 1
+      }
+  ; persisted_handoff_context
+  }
+;;

--- a/lib/coord/coord_task_transition_executor.mli
+++ b/lib/coord/coord_task_transition_executor.mli
@@ -1,0 +1,18 @@
+(** Build the persisted task/backlog shape for task lifecycle transitions.
+
+    This module owns the mutation plan that sits between
+    {!Coord_task_lifecycle.decide} and the storage/event side effects in
+    {!Coord_task.transition_task_r}. *)
+
+type transition_backlog_update =
+  { backlog : Masc_domain.backlog
+  ; persisted_handoff_context : Masc_domain.task_handoff_context option
+  }
+
+val build_backlog_update
+  :  backlog:Masc_domain.backlog
+  -> task_id:string
+  -> action:Masc_domain.task_action
+  -> new_status:Masc_domain.task_status
+  -> handoff_context:Masc_domain.task_handoff_context option
+  -> transition_backlog_update

--- a/lib/coord/dune
+++ b/lib/coord/dune
@@ -34,6 +34,7 @@
   coord_task_lifecycle
   coord_task_receipts
   coord_task_schedule
+  coord_task_transition_executor
   coord_verification_store
   event_kind
   coord_git


### PR DESCRIPTION
## Summary
- Extracted task lifecycle backlog mutation into Coord_task_transition_executor.
- Kept storage writes, local agent state updates, receipts, and event emission in Coord_task.transition_task_r.
- Preserved existing handoff context persistence, release cycle count, stale worktree binding, and soft do-not-reclaim behavior.

## Verification
- ocamlformat --check lib/coord/coord_task.ml lib/coord/coord_task_transition_executor.ml lib/coord/coord_task_transition_executor.mli
- git diff --check
- rg -n "Stdlib\.Lazy\.(force|from_val)|Fun\.protect|Mutex\.(lock|unlock)|failwith|assert false|Eio\.traceln|Sys\.(readdir|command)|Option\.value" lib/coord/coord_task.ml lib/coord/coord_task_transition_executor.ml lib/coord/coord_task_transition_executor.mli
- scripts/dune-local.sh build test/test_verification_fsm.exe test/test_keeper_task_dispatch.exe
- ./_build/default/test/test_keeper_task_dispatch.exe test done --show-errors
- ./_build/default/test/test_keeper_task_dispatch.exe test claim --show-errors
- ./_build/default/test/test_verification_fsm.exe --show-errors

Refs #16078