### PR TITLE
fix(config): tolerate deleted cwd during resolution

### DIFF
--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -135,14 +135,21 @@ let current_env_personas_dir_opt () =
     ~initial:initial_env_personas_dir
     ~current:((Host_config.from_env ()).personas_dir)
 
+let absolute_dir_opt path =
+  let path = Env_config_core.normalize_masc_base_path_input path in
+  if path = "" || Filename.is_relative path then None else Some path
+
 let fallback_cwd_from_env () =
   let host = Host_config.from_env () in
-  match host.base_path with
-  | Some base_path when not (Filename.is_relative base_path) -> base_path
+  match Option.bind host.base_path absolute_dir_opt with
+  | Some base_path -> base_path
   | _ ->
-    (match host.home with
-     | Some home when not (Filename.is_relative home) -> home
-     | _ -> Filename.get_temp_dir_name ())
+    (match Option.bind host.home absolute_dir_opt with
+     | Some home -> home
+     | _ ->
+       let exe = Sys.executable_name in
+       if Filename.is_relative exe then Filename.get_temp_dir_name ()
+       else Filename.dirname exe)
 
 let current_working_dir () =
   try Sys.getcwd () with

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -206,6 +206,33 @@ let test_inputs_from_env_honors_base_path_override_opt_in () =
   check string "root source" "local_masc"
     (Config_dir_resolver.source_to_string resolution.config_root.source)
 
+let test_inputs_from_env_survives_deleted_cwd () =
+  with_temp_dir "config-dir-deleted-cwd" @@ fun root ->
+  let parent = Filename.concat root "parent" in
+  let doomed = Filename.concat parent "doomed" in
+  let base = Filename.concat root "base" in
+  Unix.mkdir parent 0o755;
+  Unix.mkdir doomed 0o755;
+  let _config = make_config_root (Filename.concat base Common.masc_dirname) in
+  with_env "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE" (Some "true") @@ fun () ->
+  with_env "MASC_CONFIG_DIR" None @@ fun () ->
+  with_env "MASC_PERSONAS_DIR" None @@ fun () ->
+  with_env "MASC_BASE_PATH" (Some base) @@ fun () ->
+  with_env "MASC_BASE_PATH_INPUT" (Some base) @@ fun () ->
+  let saved_cwd = Sys.getcwd () in
+  Unix.chdir doomed;
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.chdir saved_cwd;
+      Config_dir_resolver.reset ())
+    (fun () ->
+      Unix.rmdir doomed;
+      let inputs = Config_dir_resolver.inputs_from_env () in
+      check string "deleted cwd falls back to base path" base inputs.cwd;
+      let resolution = Config_dir_resolver.resolve_with inputs in
+      check string "root source" "local_masc"
+        (Config_dir_resolver.source_to_string resolution.config_root.source))
+
 let test_normalize_masc_base_path_input_canonicalizes_explicit_path () =
   let actual =
     Env_config_core.normalize_masc_base_path_input
@@ -561,6 +588,8 @@ let () =
             test_inputs_from_env_honors_config_path_override_opt_in;
           test_case "inputs_from_env honors base-path override opt-in" `Quick
             test_inputs_from_env_honors_base_path_override_opt_in;
+          test_case "inputs_from_env survives deleted cwd" `Quick
+            test_inputs_from_env_survives_deleted_cwd;
           test_case "canonicalizes explicit base path" `Quick
             test_normalize_masc_base_path_input_canonicalizes_explicit_path;
         ] );


### PR DESCRIPTION
## Summary
- make Config_dir_resolver fall back when Sys.getcwd fails because the process cwd was deleted
- prefer absolute MASC_BASE_PATH, then HOME, then executable dir/temp dir as the resolver cwd fallback
- add a regression test that removes the current directory before calling inputs_from_env

## Verification
- opam exec -- ocamlformat --check lib/config_dir_resolver/config_dir_resolver.ml test/test_config_dir_resolver.ml
- git diff --check
- scripts/dune-local.sh build test/test_config_dir_resolver.exe
- ./_build/default/test/test_config_dir_resolver.exe

Refs #16208