### PR TITLE
fix(dashboard): share bearer token reader across transports

### DIFF
--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -5,6 +5,7 @@ import {
   clearStoredToken,
   confirmOperatorAction,
   currentDashboardActor,
+  dashboardBearerToken,
   defaultBoardVoter,
   extractApiError,
   get,
@@ -59,6 +60,13 @@ describe('stored token metadata', () => {
 
     expect(getStoredToken()).toBeNull()
     expect(getStoredTokenMeta()).toBeNull()
+  })
+
+  it('normalizes blank raw storage for shared transport auth', () => {
+    sessionStorage.setItem('masc_bearer_token', '   ')
+
+    expect(dashboardBearerToken()).toBeNull()
+    expect(authHeaders()).not.toHaveProperty('Authorization')
   })
 })
 

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -74,6 +74,10 @@ export function getStoredToken(): string | null {
   }
 }
 
+export function dashboardBearerToken(): string | null {
+  return getStoredToken()
+}
+
 export function getStoredTokenMeta(): StoredTokenMeta | null {
   try {
     const raw = sessionStorage.getItem(TOKEN_META_STORAGE_KEY)
@@ -134,7 +138,7 @@ type HeaderOptions = {
 
 export function authHeaders(options: HeaderOptions = {}): Record<string, string> {
   const headers: Record<string, string> = {}
-  const token = getStoredToken()
+  const token = dashboardBearerToken()
   const agent = options.actorName !== undefined
     ? sanitizeDashboardActorName(options.actorName)
     : currentDashboardActor()

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -16,6 +16,7 @@ import {
   parseWebSocketSseFrames,
   subscribeDashboardRoute,
 } from './dashboard-ws'
+import { clearStoredToken, setStoredToken } from './api/core'
 import {
   DASHBOARD_WS_HEARTBEAT_INTERVAL_MS,
   DASHBOARD_WS_RPC_TIMEOUT_MS,
@@ -190,6 +191,7 @@ afterEach(() => {
   dashboardWsLastPongLatencyMs.value = null
   dashboardWsLastSeq.value = 0
   dashboardWsReady.value = false
+  clearStoredToken()
   vi.useRealTimers()
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
@@ -257,6 +259,32 @@ describe('parseWebSocketSseFrames', () => {
 })
 
 describe('dashboard websocket route subscriptions', () => {
+  it('sends hello token from the shared dashboard auth reader', async () => {
+    installWebSocketMocks()
+    setStoredToken('  ws-token  ')
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+
+    const hello = parseRpc(socket, 0)
+    expect(hello.method).toBe('dashboard/hello')
+    expect(hello.params.token).toBe('ws-token')
+  })
+
+  it('omits blank raw stored tokens from websocket hello', async () => {
+    installWebSocketMocks()
+    sessionStorage.setItem('masc_bearer_token', '   ')
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+
+    const hello = parseRpc(socket, 0)
+    expect(hello.method).toBe('dashboard/hello')
+    expect(hello.params).not.toHaveProperty('token')
+  })
+
   it('does not open a socket when discovery resolves after disconnect', async () => {
     const discoveries = installControlledDiscovery()
 

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -2,6 +2,7 @@ import type { RouteState, SSEEvent } from './types'
 import { parseSSEMessage } from './schemas/sse'
 import { hydrateDashboardSlice, routeServerPushEvent } from './sse-store'
 import { batch } from '@preact/signals'
+import { dashboardBearerToken } from './api/core'
 import { parseWebSocketSseFrames as parseWebSocketSseFramesImpl } from './dashboard-ws-parse'
 import {
   DASHBOARD_WS_HEARTBEAT_INTERVAL_MS,
@@ -676,7 +677,7 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     if (socket !== ws) return
     dashboardWsConnected.value = true
     reconnectAttempts = 0
-    const token = sessionStorage.getItem('masc_bearer_token')
+    const token = dashboardBearerToken()
     void sendRpc('dashboard/hello', {
       protocol: 'dashboard-ws.v1',
       token: token ?? undefined,

--- a/dashboard/src/sse.test.ts
+++ b/dashboard/src/sse.test.ts
@@ -1,16 +1,25 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { buildDashboardSseUrl, normalizeSSEDispatchType } from './sse'
+import { clearStoredToken, setStoredToken } from './api/core'
 
 describe('buildDashboardSseUrl', () => {
   afterEach(() => {
-    sessionStorage.removeItem('masc_bearer_token')
+    clearStoredToken()
   })
 
   it('includes token from sessionStorage and agent from query params', () => {
-    sessionStorage.setItem('masc_bearer_token', 'secret')
+    setStoredToken('secret')
     expect(
       buildDashboardSseUrl('dash_test', '?agent=keeper-a'),
     ).toBe('/mcp?agent=keeper-a&token=secret&session_id=dash_test&sse_kind=observer')
+  })
+
+  it('omits blank raw stored tokens through the shared auth reader', () => {
+    sessionStorage.setItem('masc_bearer_token', '   ')
+
+    expect(buildDashboardSseUrl('dash_test', '?agent=keeper-a')).toBe(
+      '/mcp?agent=keeper-a&session_id=dash_test&sse_kind=observer',
+    )
   })
 
   it('omits token when sessionStorage is empty', () => {

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -15,6 +15,7 @@ import {
 } from './journal-entry'
 import { appendLiveToolCall } from './components/session-trace/session-trace-live-store'
 import { appendAuditEntry } from './live-store'
+import { dashboardBearerToken } from './api/core'
 import { parseSSEMessage } from './schemas/sse'
 import { RingBuffer } from './lib/ring-buffer'
 import { createSseTransport } from './transports/sse-transport'
@@ -200,7 +201,7 @@ export function buildDashboardSseUrl(sessionId: string, locationSearch = window.
   // Token from sessionStorage (moved from URL on init) — EventSource does not
   // support custom headers, so query param is the only option.  The token is
   // no longer visible in the browser address bar or shareable links.
-  const token = sessionStorage.getItem('masc_bearer_token')
+  const token = dashboardBearerToken()
   if (agent) sseParams.set('agent', agent)
   if (token) sseParams.set('token', token)
   sseParams.set('session_id', sessionId)


### PR DESCRIPTION
## Summary
- Added a shared dashboardBearerToken reader on the dashboard API core path.
- Switched HTTP auth headers, observer SSE URL construction, and dashboard WS hello to the same normalized bearer token material.
- Added regression coverage so blank raw sessionStorage tokens are omitted across HTTP, SSE, and WS.

## Verification
- pnpm install --frozen-lockfile
- pnpm exec vitest run src/api/core.test.ts src/sse.test.ts src/dashboard-ws.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm run typecheck
- pnpm run lint (passes with pre-existing virtual-list unused eslint-disable warning)
- git diff --check

Refs #16081