### PR TITLE
refactor(dashboard): use shell fetcher SSOT

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -20,6 +20,7 @@ import {
   fetchTlcResults,
   fetchToolQuality,
 } from './dashboard'
+import { fetchDashboardShell as fetchDashboardShellHot } from './dashboard-hot'
 import { keeperRuntimeBlockerLabel } from '../lib/keeper-runtime-display'
 
 afterEach(() => {
@@ -72,6 +73,10 @@ function makeRawGoalNode(overrides: Record<string, unknown> = {}) {
 }
 
 describe('fetchDashboardShell', () => {
+  it('uses the hot-path shell fetcher as the API SSOT', () => {
+    expect(fetchDashboardShell).toBe(fetchDashboardShellHot)
+  })
+
   it('uses the light shell query when requested', async () => {
     const rawResponse = {
       status: { project: 'default' },

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -62,7 +62,6 @@ import type {
   GoalVerificationSummary,
   GoalVerificationVote,
   DashboardNamespaceTruthResponse,
-  DashboardShellResponse,
   BoardSortMode,
   GovernanceCaseBundle,
   GovernanceDecisionItem,
@@ -121,7 +120,7 @@ export type {
   CascadeValidationStatus,
 } from './dashboard-cascade'
 export { reportToolHostFailure } from './tool-host-failure'
-export { fetchDashboardBootstrap } from './dashboard-hot'
+export { fetchDashboardBootstrap, fetchDashboardShell } from './dashboard-hot'
 
 // --- Dashboard projections ---
 
@@ -149,15 +148,6 @@ function decodeDashboardFeedMetadata(raw: Record<string, unknown>): DashboardFee
     source: asString(raw.source),
     retention: isRecord(raw.retention) ? raw.retention : undefined,
   }
-}
-
-type DashboardShellRequestOptions = AbortableRequestOptions & {
-  light?: boolean
-}
-
-export function fetchDashboardShell(opts?: DashboardShellRequestOptions): Promise<DashboardShellResponse> {
-  const qs = opts?.light ? '?light=true' : ''
-  return get(`/api/v1/dashboard/shell${qs}`, { signal: opts?.signal })
 }
 
 // --- System logs ---


### PR DESCRIPTION
## Summary
- Removed the duplicate fetchDashboardShell implementation from dashboard/src/api/dashboard.ts.
- Re-exported the hot-path fetchDashboardShell from dashboard/src/api/dashboard-hot.ts so existing imports keep working.
- Added a regression assertion that the public dashboard API surface uses the hot-path shell fetcher as the SSOT.

## Verification
- pnpm install --frozen-lockfile
- pnpm exec vitest run src/api/dashboard.test.ts src/store-dashboard-bootstrap.test.ts src/store-shell-auth.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm run typecheck
- pnpm run lint (passes with pre-existing virtual-list unused eslint-disable warning)
- git diff --check

Refs #16081