### PR TITLE
test(dashboard): pin push slice parity

### DIFF
--- a/dashboard/src/dashboard-slices.ts
+++ b/dashboard/src/dashboard-slices.ts
@@ -1,0 +1,21 @@
+// Dashboard push slice vocabulary shared by WS subscriptions and hydrators.
+// Keep in sync with Server_mcp_transport_ws.valid_dashboard_slice.
+
+export const DASHBOARD_PUSH_SLICES = [
+  'shell',
+  'namespace',
+  'transport',
+  'execution',
+  'goals',
+  'board',
+  'composite',
+  'operator',
+] as const
+
+export type DashboardPushSlice = typeof DASHBOARD_PUSH_SLICES[number]
+
+export const GLOBAL_DASHBOARD_PUSH_SLICES = [
+  'shell',
+  'namespace',
+  'transport',
+] as const satisfies readonly DashboardPushSlice[]

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -20,6 +20,7 @@ import {
   DASHBOARD_WS_HEARTBEAT_INTERVAL_MS,
   DASHBOARD_WS_RPC_TIMEOUT_MS,
 } from './config/constants'
+import { DASHBOARD_PUSH_SLICES } from './dashboard-slices'
 import {
   dashboardWsConnected,
   dashboardWsLastError,
@@ -198,6 +199,24 @@ afterEach(() => {
 })
 
 describe('dashboardSlicesForRoute', () => {
+  it('only subscribes slices from the shared push vocabulary', () => {
+    const routes = [
+      { tab: 'overview', params: {} },
+      { tab: 'workspace', params: { section: 'planning' } },
+      { tab: 'workspace', params: { section: 'board' } },
+      { tab: 'monitoring', params: { section: 'agents' } },
+      { tab: 'monitoring', params: { section: 'cognition' } },
+      { tab: 'monitoring', params: { section: 'fleet-health', view: 'comparison' } },
+      { tab: 'command', params: {} },
+    ] as const
+
+    for (const route of routes) {
+      for (const slice of dashboardSlicesForRoute(route)) {
+        expect(DASHBOARD_PUSH_SLICES).toContain(slice)
+      }
+    }
+  })
+
   it('keeps global shell namespace and transport slices on every route', () => {
     expect(dashboardSlicesForRoute({ tab: 'overview', params: {} })).toEqual([
       'execution',

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -4,6 +4,10 @@ import { hydrateDashboardSlice, routeServerPushEvent } from './sse-store'
 import { batch } from '@preact/signals'
 import { parseWebSocketSseFrames as parseWebSocketSseFramesImpl } from './dashboard-ws-parse'
 import {
+  GLOBAL_DASHBOARD_PUSH_SLICES,
+  type DashboardPushSlice,
+} from './dashboard-slices'
+import {
   DASHBOARD_WS_HEARTBEAT_INTERVAL_MS,
   DASHBOARD_WS_RPC_TIMEOUT_MS,
   RECONNECT_JITTER_MS,
@@ -254,7 +258,7 @@ function routeKey(routeState: DashboardRouteState): string {
 }
 
 export function dashboardSlicesForRoute(routeState: DashboardRouteState): string[] {
-  const slices = new Set(['shell', 'namespace', 'transport'])
+  const slices = new Set<DashboardPushSlice>(GLOBAL_DASHBOARD_PUSH_SLICES)
 
   // Overview tab needs execution slice for World Visualizer keeper fleet data.
   if (routeState.tab === 'overview') {

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -1,6 +1,10 @@
 import { signal } from '@preact/signals'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BoardPost, BoardSortMode, RouteState } from './types'
+import {
+  DASHBOARD_PUSH_SLICES,
+  type DashboardPushSlice,
+} from './dashboard-slices'
 
 void vi
 
@@ -470,6 +474,35 @@ describe('setupSSEReaction reconnect hydration', () => {
       count: 0,
       snapshots: [],
     })
+  })
+
+  it('handles every dashboard push slice advertised to route subscriptions', async () => {
+    const { sseStore } = await loadSseStore()
+    const payloads: Record<DashboardPushSlice, unknown> = {
+      shell: { counts: { agents: 1, tasks: 2, keepers: 3 } },
+      namespace: { root: { status: { project: 'default' } } },
+      transport: { transports: [] },
+      execution: { agents: [], tasks: [], messages: [], keepers: [] },
+      goals: {
+        planning: { goals: [], generated_at: 'now' },
+        tree: { tree: [], summary: { total_goals: 0 } },
+      },
+      board: { posts: [], generated_at: 'now' },
+      composite: { generated_at: 1, count: 0, snapshots: [] },
+      operator: { snapshot: { keepers: [] }, digest: { target_type: 'namespace' } },
+    }
+
+    for (const slice of DASHBOARD_PUSH_SLICES) {
+      expect(() => sseStore.hydrateDashboardSlice(slice, payloads[slice])).not.toThrow()
+    }
+
+    expect(hydrateShellSnapshot).toHaveBeenCalledWith(
+      payloads.shell,
+      { light: true },
+    )
+    expect(hydrateExecutionSnapshot).toHaveBeenCalledWith(payloads.execution)
+    expect(hydrateBoardSnapshot).toHaveBeenCalledWith(payloads.board)
+    expect(hydrateFleetCompositeSnapshot).toHaveBeenCalledWith(payloads.composite)
   })
 
   it('routes websocket dashboard delta event types without treating payloads as snapshots', async () => {

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -44,7 +44,15 @@ let test_dashboard_route_scoped_slices_are_valid () =
         (Printf.sprintf "%s is accepted" slice)
         true
         (Ws.valid_dashboard_slice slice))
-    [ "board"; "goals"; "composite" ]
+    [ "shell"
+    ; "namespace"
+    ; "transport"
+    ; "execution"
+    ; "goals"
+    ; "board"
+    ; "composite"
+    ; "operator"
+    ]
 
 (* ====== Parse cache for broadcast amplification ====== *)
 


### PR DESCRIPTION
Refs #16081

## Summary
- introduce a shared TypeScript dashboard push slice vocabulary for route subscriptions and hydrators
- route global subscriptions through shared constants instead of raw string literals
- pin frontend hydrator coverage for every advertised push slice
- expand backend websocket slice acceptance coverage to the same 8-slice vocabulary

## Verification
- cd dashboard && pnpm install --frozen-lockfile
- cd dashboard && pnpm exec vitest run src/dashboard-ws.test.ts src/sse-store.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- cd dashboard && pnpm run typecheck
- cd dashboard && pnpm run lint (passes with pre-existing virtual-list eslint-disable warning)
- ocamlformat --check test/test_ws_transport.ml
- scripts/dune-local.sh build test/test_ws_transport.exe
- ./_build/default/test/test_ws_transport.exe --show-errors