### PR TITLE
feat(keeper): lower typed bash pipelines to Shell IR

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -20,7 +20,7 @@ LLM-native tool names map to keeper tools: Bash means keeper_bash, Read means ke
 NEVER type MASC tool names as shell commands. `keeper_board_list`, `keeper_task_claim`, `masc_worktree_create`, `keeper_pr_create`, and other keeper_* / masc_* names are JSON tools, not programs in Bash.
 Do NOT use masc_code_shell from a Docker keeper. It resolves a different host playground root in this live runtime. Use Bash/keeper_bash with sandbox-relative `cwd` instead.
 Do NOT use `gh pr checks` as a success/failure gate inside keeper_bash. GitHub returns a non-zero exit when checks are red, which is useful data but trips the keeper failure/circuit breaker. Prefer `keeper_pr_status` when it is available. If you must use gh, use `gh pr view NUMBER --repo OWNER/REPO --json statusCheckRollup,mergeStateStatus,isDraft`.
-Do NOT use shell redirects at all. `2>&1`, `2&1`, `>/dev/null`, `| head`, and `|| true` are blocked or misparsed in keeper_bash.
+Do NOT use shell redirects or chaining. Pipelines are validator-specific: prefer structured keeper_shell ops, and only use a keeper_bash pipeline when the active validator accepts every stage.
 Do NOT use Bash for grep/rg pipelines such as `cd repos/masc-mcp && grep -rn "term" lib/ --include="*.ml" | head -40`. Use `keeper_shell op=rg pattern="term" path=lib glob=*.ml` with `cwd` set to the repo/worktree when needed.
 Do NOT run repo-wide Bash scans such as `rg "term" repos/ ...` or `git log --all --grep="term" 2>/dev/null | head -5`. Use `keeper_shell op=rg path=repos/<REPO>/lib` or `keeper_shell op=git_log cwd=repos/<REPO> count=5 grep="term"`.
 ## Tool error grammar (how to read a failed tool result)
@@ -41,7 +41,7 @@ When a tool call fails:
 Short form: hint → fix args → retry once → if still stuck, judgment request. Do NOT end a turn on a silent tool error.
 
 keeper_bash examples:
-  BAD:  cmd="git log --oneline | head -5"          (pipe blocked)
+  BAD:  cmd="git log --oneline | head -5"          (use keeper_shell op=git_log count=5 unless the active validator explicitly accepts the pipeline)
   GOOD: keeper_shell op=git_log count=5              (use dedicated op)
   BAD:  cmd="cd repos && ls"                         (chaining blocked)
   GOOD: keeper_shell op=ls path={sandbox_repos}       (single op with path from keeper_context_status)

--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -33,6 +33,7 @@ type validation_error =
     }
   | Cwd_not_absolute of string
   | Pipeline_empty
+  | Pipeline_too_short
   | Env_key_invalid of string
 
 let is_allowed ~mode name =
@@ -104,6 +105,7 @@ let validate ~mode = function
   | Exec { executable; argv; cwd; env } ->
     check_exec ~mode ~executable ~argv ~cwd ~env
   | Pipeline { stages = []; _ } -> Error Pipeline_empty
+  | Pipeline { stages = [ _ ]; _ } -> Error Pipeline_too_short
   | Pipeline { stages; cwd; env } ->
     let ( let* ) = Result.bind in
     let* () = check_cwd cwd in
@@ -115,6 +117,58 @@ let validate ~mode = function
         each rest
     in
     each stages
+;;
+
+let shell_arg text = Masc_exec.Shell_ir.Lit text
+
+let shell_env env =
+  List.map (fun (key, value) -> key, shell_arg value) env
+;;
+
+let shell_cwd = function
+  | None -> None
+  | Some cwd -> Some (Masc_exec.Path_scope.classify ~raw:cwd ~cwd)
+;;
+
+let shell_bin ~mode executable =
+  match Masc_exec.Bin.of_string executable with
+  | Ok bin -> Ok bin
+  | Error (`Unknown name) ->
+    Error (Executable_not_allowlisted { name; mode })
+;;
+
+let shell_simple ~mode ?cwd ?(env = []) { executable; argv } =
+  let ( let* ) = Result.bind in
+  let* bin = shell_bin ~mode executable in
+  Ok
+    { Masc_exec.Shell_ir.bin
+    ; args = List.map shell_arg argv
+    ; env = shell_env env
+    ; cwd = shell_cwd cwd
+    ; redirects = []
+    ; sandbox = Masc_exec.Sandbox_target.host ()
+    }
+;;
+
+let to_shell_ir ~mode input =
+  let ( let* ) = Result.bind in
+  let* () = validate ~mode input in
+  match input with
+  | Exec { executable; argv; cwd; env } ->
+    let stage = { executable; argv } in
+    let* simple = shell_simple ~mode ?cwd ~env stage in
+    Ok (Masc_exec.Shell_ir.Simple simple)
+  | Pipeline { stages; cwd; env } ->
+    let* simples =
+      let rec loop acc = function
+        | [] -> Ok (List.rev acc)
+        | stage :: rest ->
+          let* simple = shell_simple ~mode ?cwd ~env stage in
+          loop (Masc_exec.Shell_ir.Simple simple :: acc) rest
+      in
+      loop [] stages
+    in
+    Ok (Masc_exec.Shell_ir.Pipeline simples)
 ;;
 
 let pp_mode ppf = function
@@ -138,6 +192,8 @@ let pp_validation_error ppf = function
   | Cwd_not_absolute path ->
     Format.fprintf ppf "cwd %S is not absolute" path
   | Pipeline_empty -> Format.pp_print_string ppf "Pipeline.stages is empty"
+  | Pipeline_too_short ->
+    Format.pp_print_string ppf "Pipeline.stages requires at least two stages"
   | Env_key_invalid k ->
     Format.fprintf ppf "env key %S is not [A-Za-z0-9_]+" k
 ;;

--- a/lib/keeper/keeper_tool_bash_input.mli
+++ b/lib/keeper/keeper_tool_bash_input.mli
@@ -69,12 +69,19 @@ type validation_error =
     }
   | Cwd_not_absolute of string
   | Pipeline_empty
+  | Pipeline_too_short
   | Env_key_invalid of string
 
 val validate : mode:allowlist_mode -> bash_input -> (unit, validation_error) result
 (** Run all structural checks against [input].  Returns [Ok ()] on
     success, or the first {!validation_error} encountered.  No side
     effects, no exceptions. *)
+
+val to_shell_ir :
+  mode:allowlist_mode -> bash_input -> (Masc_exec.Shell_ir.t, validation_error) result
+(** Validate and lower [input] into {!Masc_exec.Shell_ir.t}.  [Pipeline]
+    inputs become an explicit {!Masc_exec.Shell_ir.Pipeline}; literal ["|"]
+    argv tokens remain ordinary argument data and never create a pipeline. *)
 
 val pp_validation_error : Format.formatter -> validation_error -> unit
 (** Human-readable formatter for {!validation_error}.  Stable across

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -126,6 +126,20 @@ let test_pipeline_empty () =
     (typed_ok input)
 ;;
 
+let test_pipeline_single_stage_rejected () =
+  let input =
+    Bash_input.Pipeline
+      { stages = [ { executable = "rg"; argv = [ "pattern" ] } ]
+      ; cwd = None
+      ; env = []
+      }
+  in
+  Alcotest.(check bool)
+    "pipeline with one stage is rejected"
+    false
+    (typed_ok input)
+;;
+
 let test_pipeline_stage_executable_check () =
   let input =
     Bash_input.Pipeline
@@ -141,6 +155,80 @@ let test_pipeline_stage_executable_check () =
     "pipeline: non-allowlisted stage executable is rejected"
     false
     (typed_ok input)
+;;
+
+let shell_arg_string = function
+  | Masc_exec.Shell_ir.Lit s -> s
+  | Masc_exec.Shell_ir.Var name -> "$" ^ name
+  | Masc_exec.Shell_ir.Concat _ -> "<concat>"
+;;
+
+let shell_simple_tuple (simple : Masc_exec.Shell_ir.simple) =
+  ( Masc_exec.Bin.to_string simple.bin
+  , List.map shell_arg_string simple.args )
+;;
+
+let to_shell_ir_exn input =
+  match Bash_input.to_shell_ir ~mode:Bash_input.Dev_full input with
+  | Ok ir -> ir
+  | Error error ->
+    Alcotest.failf
+      "to_shell_ir failed: %a"
+      Bash_input.pp_validation_error
+      error
+;;
+
+let test_pipeline_lowers_to_shell_ir_pipeline () =
+  let input =
+    Bash_input.Pipeline
+      { stages =
+          [ { executable = "echo"; argv = [ "hello world" ] }
+          ; { executable = "tr"; argv = [ "a-z"; "A-Z" ] }
+          ]
+      ; cwd = Some "/tmp"
+      ; env = [ "LC_ALL", "C" ]
+      }
+  in
+  match to_shell_ir_exn input with
+  | Masc_exec.Shell_ir.Pipeline
+      [ Masc_exec.Shell_ir.Simple first; Masc_exec.Shell_ir.Simple second ] ->
+    Alcotest.(check (pair string (list string)))
+      "first stage"
+      ("echo", [ "hello world" ])
+      (shell_simple_tuple first);
+    Alcotest.(check (pair string (list string)))
+      "second stage"
+      ("tr", [ "a-z"; "A-Z" ])
+      (shell_simple_tuple second);
+    Alcotest.(check (option string))
+      "cwd copied to every stage"
+      (Some "/tmp")
+      (Option.map Masc_exec.Path_scope.raw second.cwd);
+    Alcotest.(check (list (pair string string)))
+      "env copied to every stage"
+      [ "LC_ALL", "C" ]
+      (List.map (fun (key, value) -> key, shell_arg_string value) second.env)
+  | other ->
+    Alcotest.failf "expected Shell_ir.Pipeline, got %a" Masc_exec.Shell_ir.pp other
+;;
+
+let test_pipe_character_in_exec_argv_is_literal () =
+  let input =
+    Bash_input.Exec
+      { executable = "echo"
+      ; argv = [ "foo|bar" ]
+      ; cwd = None
+      ; env = []
+      }
+  in
+  match to_shell_ir_exn input with
+  | Masc_exec.Shell_ir.Simple simple ->
+    Alcotest.(check (pair string (list string)))
+      "pipe char remains argv data"
+      ("echo", [ "foo|bar" ])
+      (shell_simple_tuple simple)
+  | Masc_exec.Shell_ir.Pipeline _ ->
+    Alcotest.fail "literal pipe argv token must not create Shell_ir.Pipeline"
 ;;
 
 let test_cwd_not_absolute () =
@@ -173,12 +261,24 @@ let suite =
   ("RFC-0091 PR-1 differential",
     List.map
       (fun c -> Alcotest.test_case c.name `Quick (test_case c))
-      cases
+    cases
     @ [ Alcotest.test_case "pipeline_empty" `Quick test_pipeline_empty
+      ; Alcotest.test_case
+          "pipeline_single_stage_rejected"
+          `Quick
+          test_pipeline_single_stage_rejected
       ; Alcotest.test_case
           "pipeline_stage_executable_check"
           `Quick
           test_pipeline_stage_executable_check
+      ; Alcotest.test_case
+          "pipeline_lowers_to_shell_ir_pipeline"
+          `Quick
+          test_pipeline_lowers_to_shell_ir_pipeline
+      ; Alcotest.test_case
+          "pipe_character_in_exec_argv_is_literal"
+          `Quick
+          test_pipe_character_in_exec_argv_is_literal
       ; Alcotest.test_case "cwd_not_absolute" `Quick test_cwd_not_absolute
       ; Alcotest.test_case "env_key_invalid" `Quick test_env_key_invalid
       ])


### PR DESCRIPTION
Stacked on #16145.

## Summary
- Add Keeper_tool_bash_input.to_shell_ir so typed Exec/Pipeline inputs lower into Shell_ir.
- Reject one-stage typed Pipeline values so Shell_ir.Pipeline keeps its length >= 2 invariant.
- Update keeper capability guidance so pipelines are validator-specific, not universally blocked.

## Verification
- ocamlformat --check lib/keeper/keeper_tool_bash_input.ml lib/keeper/keeper_tool_bash_input.mli test/test_keeper_bash_typed_input.ml
- git diff --check
- scripts/dune-local.sh build ./test/test_keeper_bash_typed_input.exe
- ./_build/default/test/test_keeper_bash_typed_input.exe