### PR TITLE
fix(cascade): damp provider health probe timeout logs

### DIFF
--- a/lib/cascade/provider_health.ml
+++ b/lib/cascade/provider_health.ml
@@ -19,6 +19,10 @@ type provider =
 
 type t = { providers : (string, provider) Hashtbl.t }
 
+type probe_failure_log_level =
+  | Probe_failure_warn
+  | Probe_failure_info
+
 let active_ref : t option Atomic.t = Atomic.make None
 let set_active t = Atomic.set active_ref (Some t)
 let active () = Atomic.get active_ref
@@ -126,8 +130,9 @@ let find_provider t provider_id =
   |> List.find_map (fun key -> Hashtbl.find_opt t.providers key)
 ;;
 
-let transition provider ~success =
+let transition_with_state provider ~success =
   Eio.Mutex.use_rw ~protect:true provider.mu (fun () ->
+    let before = provider.state in
     if success then begin
       provider.consecutive_failures <- 0;
       provider.consecutive_successes <- provider.consecutive_successes + 1;
@@ -157,9 +162,20 @@ let transition provider ~success =
         in
         provider.state
         <- Unhealthy
-             { since; consecutive_failures = provider.consecutive_failures }
+          { since; consecutive_failures = provider.consecutive_failures }
       end
-    end)
+    end;
+    before, provider.state)
+;;
+
+let transition provider ~success =
+  ignore (transition_with_state provider ~success : health_state * health_state)
+;;
+
+let probe_failure_log_level ~before ~after =
+  match before, after with
+  | Healthy, Unhealthy _ -> Probe_failure_warn
+  | _ -> Probe_failure_info
 ;;
 
 let is_healthy t ~provider_id =
@@ -217,12 +233,22 @@ let probe_once ~clock ~net:_ provider =
        transition provider ~success:(response.Masc_http_client.status >= 200
                                      && response.status < 300)
      | Error message ->
-       Log.Cascade.warn
-         "[provider-health] probe failed provider=%s endpoint=%s error=%s"
-         provider.provider_id
-         endpoint
-         message;
-       transition provider ~success:false)
+       let before, after = transition_with_state provider ~success:false in
+       (match probe_failure_log_level ~before ~after with
+        | Probe_failure_warn ->
+          Log.Cascade.warn
+            "[provider-health] provider marked unhealthy provider=%s endpoint=%s \
+             error=%s"
+            provider.provider_id
+            endpoint
+            message
+        | Probe_failure_info ->
+          Log.Cascade.info
+            "[provider-health] probe failed while unhealthy provider=%s endpoint=%s \
+             error=%s"
+            provider.provider_id
+            endpoint
+            message))
 ;;
 
 let start_probe_fiber ~sw ~env t =
@@ -277,6 +303,12 @@ module For_testing = struct
       }
     in
     providers |> List.map make_for_test |> create_from_providers
+  ;;
+
+  let probe_failure_should_warn ~before ~after =
+    match probe_failure_log_level ~before ~after with
+    | Probe_failure_warn -> true
+    | Probe_failure_info -> false
   ;;
 
   let clear_active () = Atomic.set active_ref None

--- a/lib/cascade/provider_health.mli
+++ b/lib/cascade/provider_health.mli
@@ -38,5 +38,6 @@ module For_testing : sig
     }
 
   val create : provider list -> t
+  val probe_failure_should_warn : before:health_state -> after:health_state -> bool
   val clear_active : unit -> unit
 end

--- a/test/test_provider_health.ml
+++ b/test/test_provider_health.ml
@@ -134,6 +134,26 @@ let test_filter_healthy_skips_unhealthy_candidate () =
   check (list string) "unhealthy A removed" [ "B"; "C" ] filtered
 ;;
 
+let test_probe_failure_warns_only_on_unhealthy_transition () =
+  let unhealthy =
+    Provider_health.Unhealthy { since = 1.0; consecutive_failures = 1 }
+  in
+  check bool "healthy to unhealthy warns" true
+    (Provider_health.For_testing.probe_failure_should_warn
+       ~before:Provider_health.Healthy
+       ~after:unhealthy);
+  check bool "repeated unhealthy probe does not warn" false
+    (Provider_health.For_testing.probe_failure_should_warn
+       ~before:unhealthy
+       ~after:
+         (Provider_health.Unhealthy
+            { since = 1.0; consecutive_failures = 2 }));
+  check bool "below-threshold healthy failure does not warn" false
+    (Provider_health.For_testing.probe_failure_should_warn
+       ~before:Provider_health.Healthy
+       ~after:Provider_health.Healthy)
+;;
+
 let test_parser_clamps_probe_interval_to_minimum () =
   let toml =
     {|
@@ -180,6 +200,8 @@ let () =
             test_in_band_recovery_threshold_marks_healthy
         ; test_case "candidate filter skips unhealthy provider" `Quick
             test_filter_healthy_skips_unhealthy_candidate
+        ; test_case "probe failure warning only on unhealthy transition" `Quick
+            test_probe_failure_warns_only_on_unhealthy_transition
         ; test_case "parser clamps probe interval" `Quick
             test_parser_clamps_probe_interval_to_minimum
         ] )


### PR DESCRIPTION
Closes #16228.\n\n## Summary\n- log provider-health probe failures as WARN only when a provider transitions from Healthy to Unhealthy\n- keep repeated failures while already Unhealthy at INFO so timeout loops do not dominate live error/warning audits\n- expose a scoped For_testing predicate and cover Healthy->Unhealthy, Unhealthy->Unhealthy, and below-threshold Healthy cases\n\n## Verification\n- opam exec -- ocamlformat --check lib/cascade/provider_health.ml lib/cascade/provider_health.mli test/test_provider_health.ml\n- git diff --check\n- scripts/dune-local.sh build test/test_provider_health.exe\n- ./_build/default/test/test_provider_health.exe