### PR TITLE
feat(keeper): parse typed bash input JSON

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -1334,7 +1334,7 @@ let run_docker_shell_command_with_status_internal
                                   "docker_shell_failed: unix_error: %s: %s(%s)"
                                   (Unix.error_message code)
                                   fn
-                                  arg)))))))))
+                                  arg))))))))
 ;;
 
 let run_docker_shell_command_with_status =

--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -138,9 +138,9 @@ let optional_env ~path fields =
       (json_type_name value)
 ;;
 
-let parse_stage ~index (value : Yojson.Safe.t) =
+let parse_stage ~path_prefix ~index (value : Yojson.Safe.t) =
   let ( let* ) = Result.bind in
-  let path = Printf.sprintf "$.pipeline[%d]" index in
+  let path = Printf.sprintf "%s[%d]" path_prefix index in
   let* fields = assoc_fields ~path value in
   let* executable = required_string ~path fields "executable" in
   let* argv = optional_string_list ~path fields "argv" in
@@ -154,7 +154,7 @@ let parse_pipeline ~path (json : Yojson.Safe.t) =
     let rec loop index acc = function
       | [] -> Ok (List.rev acc)
       | value :: rest ->
-        let* stage = parse_stage ~index value in
+        let* stage = parse_stage ~path_prefix:path ~index value in
         loop (index + 1) (stage :: acc) rest
     in
     loop 0 [] values
@@ -193,7 +193,7 @@ let of_json (json : Yojson.Safe.t) =
       Error
         "legacy cmd string is not a typed keeper_bash input; provide \
          executable/argv or pipeline stages"
-    else Error "$.executable or $.pipeline is required"
+    else Error "$.executable or $.pipeline/$.stages is required"
 ;;
 
 (* Execve-style: argv tokens pass verbatim to the child process, so

--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -165,6 +165,14 @@ let parse_pipeline ~path (json : Yojson.Safe.t) =
 let of_json (json : Yojson.Safe.t) =
   let ( let* ) = Result.bind in
   let* fields = assoc_fields ~path:"$" json in
+  let* () =
+    if Option.is_some (member fields "cmd")
+    then
+      Error
+        "legacy cmd string is not a typed keeper_bash input; provide \
+         executable/argv or pipeline stages"
+    else Ok ()
+  in
   let executable_present = Option.is_some (member fields "executable") in
   let pipeline_value =
     match member fields "pipeline", member fields "stages" with
@@ -187,13 +195,7 @@ let of_json (json : Yojson.Safe.t) =
   | false, Some (path, value) ->
     let* stages = parse_pipeline ~path value in
     Ok (Pipeline { stages; cwd; env })
-  | false, None ->
-    if Option.is_some (member fields "cmd")
-    then
-      Error
-        "legacy cmd string is not a typed keeper_bash input; provide \
-         executable/argv or pipeline stages"
-    else Error "$.executable or $.pipeline/$.stages is required"
+  | false, None -> Error "$.executable or $.pipeline/$.stages is required"
 ;;
 
 (* Execve-style: argv tokens pass verbatim to the child process, so

--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -42,6 +42,160 @@ let is_allowed ~mode name =
   | Readonly -> Dev_exec_allowlist.is_readonly_allowed name
 ;;
 
+let json_type_name (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc _ -> "object"
+  | `Bool _ -> "boolean"
+  | `Float _ -> "number"
+  | `Int _ -> "integer"
+  | `Intlit _ -> "integer"
+  | `List _ -> "array"
+  | `Null -> "null"
+  | `String _ -> "string"
+;;
+
+let result_errorf fmt = Printf.ksprintf (fun msg -> Error msg) fmt
+
+let assoc_fields ~path (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields -> Ok fields
+  | value ->
+    result_errorf
+      "%s must be object, got %s"
+      path
+      (json_type_name value)
+;;
+
+let member fields key = List.assoc_opt key fields
+
+let required_string ~path fields key =
+  match member fields key with
+  | Some (`String value) -> Ok value
+  | Some value ->
+    result_errorf
+      "%s.%s must be string, got %s"
+      path
+      key
+      (json_type_name value)
+  | None -> result_errorf "%s.%s is required" path key
+;;
+
+let optional_string ~path fields key =
+  match member fields key with
+  | None | Some `Null -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some value ->
+    result_errorf
+      "%s.%s must be string, got %s"
+      path
+      key
+      (json_type_name value)
+;;
+
+let optional_string_list ~path fields key =
+  match member fields key with
+  | None | Some `Null -> Ok []
+  | Some (`List values) ->
+    let rec loop index acc = function
+      | [] -> Ok (List.rev acc)
+      | `String value :: rest -> loop (index + 1) (value :: acc) rest
+      | value :: _ ->
+        result_errorf
+          "%s.%s[%d] must be string, got %s"
+          path
+          key
+          index
+          (json_type_name value)
+    in
+    loop 0 [] values
+  | Some value ->
+    result_errorf
+      "%s.%s must be array, got %s"
+      path
+      key
+      (json_type_name value)
+;;
+
+let optional_env ~path fields =
+  match member fields "env" with
+  | None | Some `Null -> Ok []
+  | Some (`Assoc bindings) ->
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | (key, `String value) :: rest -> loop ((key, value) :: acc) rest
+      | (key, value) :: _ ->
+        result_errorf
+          "%s.env.%s must be string, got %s"
+          path
+          key
+          (json_type_name value)
+    in
+    loop [] bindings
+  | Some value ->
+    result_errorf
+      "%s.env must be object, got %s"
+      path
+      (json_type_name value)
+;;
+
+let parse_stage ~index (value : Yojson.Safe.t) =
+  let ( let* ) = Result.bind in
+  let path = Printf.sprintf "$.pipeline[%d]" index in
+  let* fields = assoc_fields ~path value in
+  let* executable = required_string ~path fields "executable" in
+  let* argv = optional_string_list ~path fields "argv" in
+  Ok { executable; argv }
+;;
+
+let parse_pipeline ~path (json : Yojson.Safe.t) =
+  match json with
+  | `List values ->
+    let ( let* ) = Result.bind in
+    let rec loop index acc = function
+      | [] -> Ok (List.rev acc)
+      | value :: rest ->
+        let* stage = parse_stage ~index value in
+        loop (index + 1) (stage :: acc) rest
+    in
+    loop 0 [] values
+  | value ->
+    result_errorf "%s must be array, got %s" path (json_type_name value)
+;;
+
+let of_json (json : Yojson.Safe.t) =
+  let ( let* ) = Result.bind in
+  let* fields = assoc_fields ~path:"$" json in
+  let executable_present = Option.is_some (member fields "executable") in
+  let pipeline_value =
+    match member fields "pipeline", member fields "stages" with
+    | Some _, Some _ ->
+      Error "$ must not provide both pipeline and stages"
+    | Some value, None -> Ok (Some ("$.pipeline", value))
+    | None, Some value -> Ok (Some ("$.stages", value))
+    | None, None -> Ok None
+  in
+  let* pipeline_value = pipeline_value in
+  let* cwd = optional_string ~path:"$" fields "cwd" in
+  let* env = optional_env ~path:"$" fields in
+  match executable_present, pipeline_value with
+  | true, Some _ ->
+    Error "$ must provide either executable or pipeline/stages, not both"
+  | true, None ->
+    let* executable = required_string ~path:"$" fields "executable" in
+    let* argv = optional_string_list ~path:"$" fields "argv" in
+    Ok (Exec { executable; argv; cwd; env })
+  | false, Some (path, value) ->
+    let* stages = parse_pipeline ~path value in
+    Ok (Pipeline { stages; cwd; env })
+  | false, None ->
+    if Option.is_some (member fields "cmd")
+    then
+      Error
+        "legacy cmd string is not a typed keeper_bash input; provide \
+         executable/argv or pipeline stages"
+    else Error "$.executable or $.pipeline is required"
+;;
+
 (* Execve-style: argv tokens pass verbatim to the child process, so
    shell metacharacters ([;|&><`$*?]) are literal data, not operators.
    Only control characters that cannot survive process-boundary

--- a/lib/keeper/keeper_tool_bash_input.mli
+++ b/lib/keeper/keeper_tool_bash_input.mli
@@ -72,6 +72,12 @@ type validation_error =
   | Pipeline_too_short
   | Env_key_invalid of string
 
+val of_json : Yojson.Safe.t -> (bash_input, string) result
+(** Parse the typed keeper_bash JSON boundary.  Accepts either
+    [{executable, argv?, cwd?, env?}] for [Exec] or
+    [{pipeline = [{executable, argv?}, ...], cwd?, env?}] for [Pipeline].
+    Legacy [{cmd: string}] input is intentionally rejected here. *)
+
 val validate : mode:allowlist_mode -> bash_input -> (unit, validation_error) result
 (** Run all structural checks against [input].  Returns [Ok ()] on
     success, or the first {!validation_error} encountered.  No side

--- a/lib/keeper/keeper_tool_bash_input.mli
+++ b/lib/keeper/keeper_tool_bash_input.mli
@@ -76,6 +76,7 @@ val of_json : Yojson.Safe.t -> (bash_input, string) result
 (** Parse the typed keeper_bash JSON boundary.  Accepts either
     [{executable, argv?, cwd?, env?}] for [Exec] or
     [{pipeline = [{executable, argv?}, ...], cwd?, env?}] for [Pipeline].
+    [{stages = ...}] is accepted as an equivalent structured pipeline key.
     Legacy [{cmd: string}] input is intentionally rejected here. *)
 
 val validate : mode:allowlist_mode -> bash_input -> (unit, validation_error) result

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -257,6 +257,17 @@ let test_of_json_rejects_mixed_exec_and_pipeline () =
     (String_util.contains_substring_ci msg "either executable or pipeline")
 ;;
 
+let test_of_json_stages_alias_reports_stages_path () =
+  let msg =
+    parse_json_error
+      (`Assoc [ "stages", `List [ `Assoc [ "argv", `List [] ] ] ])
+  in
+  Alcotest.(check bool)
+    "error mentions stages path"
+    true
+    (String_util.contains_substring_ci msg "$.stages[0].executable")
+;;
+
 let shell_arg_string = function
   | Masc_exec.Shell_ir.Lit s -> s
   | Masc_exec.Shell_ir.Var name -> "$" ^ name
@@ -385,6 +396,10 @@ let suite =
           "of_json_rejects_mixed_exec_and_pipeline"
           `Quick
           test_of_json_rejects_mixed_exec_and_pipeline
+      ; Alcotest.test_case
+          "of_json_stages_alias_reports_stages_path"
+          `Quick
+          test_of_json_stages_alias_reports_stages_path
       ; Alcotest.test_case
           "pipeline_lowers_to_shell_ir_pipeline"
           `Quick

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -231,6 +231,17 @@ let test_of_json_rejects_legacy_cmd_only () =
     (String_util.contains_substring_ci msg "typed keeper_bash input")
 ;;
 
+let test_of_json_rejects_legacy_cmd_with_exec () =
+  let msg =
+    parse_json_error
+      (`Assoc [ "cmd", `String "rg pattern lib/"; "executable", `String "rg" ])
+  in
+  Alcotest.(check bool)
+    "error mentions typed input"
+    true
+    (String_util.contains_substring_ci msg "typed keeper_bash input")
+;;
+
 let test_of_json_rejects_non_string_argv () =
   let msg =
     parse_json_error
@@ -388,6 +399,10 @@ let suite =
           "of_json_rejects_legacy_cmd_only"
           `Quick
           test_of_json_rejects_legacy_cmd_only
+      ; Alcotest.test_case
+          "of_json_rejects_legacy_cmd_with_exec"
+          `Quick
+          test_of_json_rejects_legacy_cmd_with_exec
       ; Alcotest.test_case
           "of_json_rejects_non_string_argv"
           `Quick

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -36,6 +36,18 @@ let mk_exec executable argv =
   Bash_input.Exec { executable; argv; cwd = None; env = [] }
 ;;
 
+let parse_json_exn json =
+  match Bash_input.of_json json with
+  | Ok input -> input
+  | Error msg -> Alcotest.failf "of_json failed: %s" msg
+;;
+
+let parse_json_error json =
+  match Bash_input.of_json json with
+  | Ok _ -> Alcotest.fail "of_json unexpectedly succeeded"
+  | Error msg -> msg
+;;
+
 type case = {
   name : string;
   legacy_cmd : string;
@@ -157,6 +169,94 @@ let test_pipeline_stage_executable_check () =
     (typed_ok input)
 ;;
 
+let test_of_json_exec () =
+  let input =
+    parse_json_exn
+      (`Assoc
+          [ "executable", `String "rg"
+          ; "argv", `List [ `String "pattern"; `String "lib/" ]
+          ; "cwd", `String "/tmp"
+          ; "env", `Assoc [ "LC_ALL", `String "C" ]
+          ])
+  in
+  match input with
+  | Bash_input.Exec { executable; argv; cwd; env } ->
+    Alcotest.(check string) "executable" "rg" executable;
+    Alcotest.(check (list string)) "argv" [ "pattern"; "lib/" ] argv;
+    Alcotest.(check (option string)) "cwd" (Some "/tmp") cwd;
+    Alcotest.(check (list (pair string string))) "env" [ "LC_ALL", "C" ] env
+  | Bash_input.Pipeline _ -> Alcotest.fail "expected Exec"
+;;
+
+let test_of_json_pipeline () =
+  let input =
+    parse_json_exn
+      (`Assoc
+          [ ( "pipeline"
+            , `List
+                [ `Assoc
+                    [ "executable", `String "printf"
+                    ; "argv", `List [ `String "hello" ]
+                    ]
+                ; `Assoc
+                    [ "executable", `String "wc"
+                    ; "argv", `List [ `String "-c" ]
+                    ]
+                ] )
+          ; "cwd", `String "/tmp"
+          ])
+  in
+  match input with
+  | Bash_input.Pipeline { stages; cwd; env } ->
+    Alcotest.(check int) "stage count" 2 (List.length stages);
+    Alcotest.(check (option string)) "cwd" (Some "/tmp") cwd;
+    Alcotest.(check (list (pair string string))) "env" [] env;
+    (match stages with
+     | [ first; second ] ->
+       Alcotest.(check string) "first executable" "printf" first.executable;
+       Alcotest.(check (list string)) "first argv" [ "hello" ] first.argv;
+       Alcotest.(check string) "second executable" "wc" second.executable;
+       Alcotest.(check (list string)) "second argv" [ "-c" ] second.argv
+     | _ -> Alcotest.fail "expected exactly two stages")
+  | Bash_input.Exec _ -> Alcotest.fail "expected Pipeline"
+;;
+
+let test_of_json_rejects_legacy_cmd_only () =
+  let msg =
+    parse_json_error (`Assoc [ "cmd", `String "rg pattern lib/" ])
+  in
+  Alcotest.(check bool)
+    "error mentions typed input"
+    true
+    (String_util.contains_substring_ci msg "typed keeper_bash input")
+;;
+
+let test_of_json_rejects_non_string_argv () =
+  let msg =
+    parse_json_error
+      (`Assoc
+          [ "executable", `String "echo"; "argv", `List [ `Int 1 ] ])
+  in
+  Alcotest.(check bool)
+    "error mentions argv[0]"
+    true
+    (String_util.contains_substring_ci msg "$.argv[0]")
+;;
+
+let test_of_json_rejects_mixed_exec_and_pipeline () =
+  let msg =
+    parse_json_error
+      (`Assoc
+          [ "executable", `String "echo"
+          ; "pipeline", `List [ `Assoc [ "executable", `String "wc" ] ]
+          ])
+  in
+  Alcotest.(check bool)
+    "error mentions either executable or pipeline"
+    true
+    (String_util.contains_substring_ci msg "either executable or pipeline")
+;;
+
 let shell_arg_string = function
   | Masc_exec.Shell_ir.Lit s -> s
   | Masc_exec.Shell_ir.Var name -> "$" ^ name
@@ -271,6 +371,20 @@ let suite =
           "pipeline_stage_executable_check"
           `Quick
           test_pipeline_stage_executable_check
+      ; Alcotest.test_case "of_json_exec" `Quick test_of_json_exec
+      ; Alcotest.test_case "of_json_pipeline" `Quick test_of_json_pipeline
+      ; Alcotest.test_case
+          "of_json_rejects_legacy_cmd_only"
+          `Quick
+          test_of_json_rejects_legacy_cmd_only
+      ; Alcotest.test_case
+          "of_json_rejects_non_string_argv"
+          `Quick
+          test_of_json_rejects_non_string_argv
+      ; Alcotest.test_case
+          "of_json_rejects_mixed_exec_and_pipeline"
+          `Quick
+          test_of_json_rejects_mixed_exec_and_pipeline
       ; Alcotest.test_case
           "pipeline_lowers_to_shell_ir_pipeline"
           `Quick


### PR DESCRIPTION
Stacked on #16235.

## Summary
- Add Keeper_tool_bash_input.of_json for the typed keeper_bash boundary.
- Accept typed Exec JSON ({executable, argv, cwd, env}) and typed Pipeline JSON ({pipeline:[...], cwd, env}).
- Intentionally reject legacy {cmd:string} at this typed boundary so the next handler/schema migration does not reintroduce string-as-protocol parsing.

## Verification
- ocamlformat --check lib/keeper/keeper_tool_bash_input.ml lib/keeper/keeper_tool_bash_input.mli test/test_keeper_bash_typed_input.ml
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build ./test/test_keeper_bash_typed_input.exe
- ./_build/default/test/test_keeper_bash_typed_input.exe