### PR TITLE
feat(dashboard): add surface envelope metadata

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -100,6 +100,26 @@ describe('fetchDashboardExecutionTrust', () => {
       producer: 'keeper_agent_run.execution_receipt',
       durable_store: '.masc/keepers/*/execution-receipts',
       dashboard_surface: '/api/v1/dashboard/execution-trust',
+      dashboard_surface_envelope: {
+        schema: 'masc.dashboard_surface.v1',
+        schema_version: 1,
+        surface: '/api/v1/dashboard/execution-trust',
+        source: 'execution_receipt',
+        generated_at_iso: '2026-05-14T00:00:00Z',
+        cache: {
+          state: 'request_cache',
+          key: 'execution-trust:default',
+          ttl_s: 15,
+          stale: true,
+          stale_reason: 'execution_receipt_append_failed',
+          latest_age_s: null,
+          health: 'coverage_gap',
+        },
+        migration: {
+          body_shape: 'root_fields_preserved',
+          rule: 'additive envelope first',
+        },
+      },
       freshness_slo_s: 900,
       entry_count: 0,
       total: 0,
@@ -133,6 +153,17 @@ describe('fetchDashboardExecutionTrust', () => {
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/execution-trust')
     expect(result.coverage_gap_count).toBe(1)
+    expect(result.dashboard_surface_envelope).toMatchObject({
+      schema: 'masc.dashboard_surface.v1',
+      surface: '/api/v1/dashboard/execution-trust',
+      source: 'execution_receipt',
+      cache: {
+        state: 'request_cache',
+        key: 'execution-trust:default',
+        stale_reason: 'execution_receipt_append_failed',
+      },
+      migration: { body_shape: 'root_fields_preserved' },
+    })
     expect(result.coverage_gaps?.[0]).toMatchObject({
       producer: 'keeper_agent_run.execution_receipt',
       durable_store: '.masc/keepers/*/execution-receipts',

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2469,6 +2469,7 @@ export type TelemetryFreshnessMetadata = {
   producer?: string
   durable_store?: string
   dashboard_surface?: string
+  dashboard_surface_envelope?: DashboardSurfaceEnvelope | null
   freshness_slo_s?: number | null
   latest_ts_unix?: number | null
   latest_ts_iso?: string | null
@@ -2479,6 +2480,27 @@ export type TelemetryFreshnessMetadata = {
   exists?: boolean
   coverage_gaps?: TelemetryCoverageGap[]
   coverage_gap_count?: number
+}
+
+export type DashboardSurfaceEnvelope = {
+  schema?: string
+  schema_version?: number
+  surface?: string
+  source?: string
+  generated_at_iso?: string
+  cache?: {
+    state?: string
+    key?: string | null
+    ttl_s?: number | null
+    stale?: boolean
+    stale_reason?: string | null
+    latest_age_s?: number | null
+    health?: string | null
+  }
+  migration?: {
+    body_shape?: string
+    rule?: string
+  }
 }
 
 export type TelemetryCoverageGap = {
@@ -2493,6 +2515,36 @@ export type TelemetryCoverageGap = {
   keeper_name?: string | null
   trace_id?: string | null
   error?: string | null
+}
+
+function decodeDashboardSurfaceEnvelope(raw: unknown): DashboardSurfaceEnvelope | null {
+  if (!isRecord(raw)) return null
+  const cache = isRecord(raw.cache)
+    ? {
+        state: asString(raw.cache.state),
+        key: asNullableString(raw.cache.key),
+        ttl_s: asNumber(raw.cache.ttl_s),
+        stale: asBoolean(raw.cache.stale),
+        stale_reason: asNullableString(raw.cache.stale_reason),
+        latest_age_s: asNumber(raw.cache.latest_age_s),
+        health: asNullableString(raw.cache.health),
+      }
+    : undefined
+  const migration = isRecord(raw.migration)
+    ? {
+        body_shape: asString(raw.migration.body_shape),
+        rule: asString(raw.migration.rule),
+      }
+    : undefined
+  return {
+    schema: asString(raw.schema),
+    schema_version: asNumber(raw.schema_version),
+    surface: asString(raw.surface),
+    source: asString(raw.source),
+    generated_at_iso: asString(raw.generated_at_iso),
+    cache,
+    migration,
+  }
 }
 
 function decodeTelemetryCoverageGap(raw: unknown): TelemetryCoverageGap | null {
@@ -2521,6 +2573,7 @@ function decodeTelemetryFreshnessMetadata(raw: Record<string, unknown>): Telemet
     producer: asString(raw.producer),
     durable_store: asString(raw.durable_store),
     dashboard_surface: asString(raw.dashboard_surface),
+    dashboard_surface_envelope: decodeDashboardSurfaceEnvelope(raw.dashboard_surface_envelope),
     freshness_slo_s: asNumber(raw.freshness_slo_s),
     latest_ts_unix: asNumber(raw.latest_ts_unix),
     latest_ts_iso: asNullableString(raw.latest_ts_iso),

--- a/docs/reverse-engineering-design.html
+++ b/docs/reverse-engineering-design.html
@@ -1288,6 +1288,7 @@
               <li>Shell, keeper, execution, OAS telemetry, config, LSP를 projection module로 분리</li>
               <li>목표: router module은 route wiring만 하고 JSON projection은 domain read model이 소유.</li>
               <li>추가 contract: <code>DashboardSurface</code> envelope로 cache state, stale fallback, source, broadcast hook을 통일.</li>
+              <li>Migration rule: 기존 root JSON field는 유지하고 <code>dashboard_surface_envelope</code>를 먼저 붙인다. 프론트가 envelope를 읽도록 옮긴 뒤에만 endpoint versioning 또는 root metadata 제거를 검토한다.</li>
               <li>보호 테스트: current endpoint JSON snapshots, frontend API contract tests, bootstrap initializing envelope, WS/SSE slice mapping parity.</li>
             </ul>
           </div>
@@ -1410,7 +1411,7 @@
               <td>Dashboard runtime truth를 read-model modules로 분리하고 transport parity를 고정한다.</td>
               <td><code>goal-refactor-dashboard-readmodel-20260518</code><br><a href="https://github.com/jeong-sik/masc-mcp/issues/16081">GitHub #16081</a></td>
               <td><code>task-377</code> auth material parity<br><code>task-378</code> shell fetch SSOT<br><code>task-379</code> WS/SSE slice parity<br><code>task-380</code> DashboardSurface</td>
-              <td>HTTP/SSE/WS token material, shell fetch duplication, backend slice와 frontend hydrator mapping을 고정한 뒤 surface envelope를 도입한다.</td>
+              <td>HTTP/SSE/WS token material, shell fetch duplication, backend slice와 frontend hydrator mapping을 고정한 뒤 기존 root JSON field를 보존하는 additive <code>dashboard_surface_envelope</code>부터 도입한다.</td>
             </tr>
             <tr>
               <td>JSONL writer contract를 하나로 수렴하되 파일 경로와 row schema는 보존한다.</td>

--- a/lib/dune
+++ b/lib/dune
@@ -65,6 +65,7 @@
  keeper_meta_store
 
  server_dashboard_http_cache
+ server_dashboard_surface
  server_dashboard_http_perf
  dashboard_http_helpers
  dashboard_http_monitoring

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -746,6 +746,14 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
 ;;
 
 let dashboard_execution_trust_http_json ~state ~sw ~clock _request =
+  let attach_surface_envelope json =
+    Server_dashboard_surface.attach
+      ~surface:"/api/v1/dashboard/execution-trust"
+      ~source:"execution_receipt"
+      ~cache_key:"execution-trust:default"
+      ~ttl_s:15.0
+      json
+  in
   let compute () =
     let started_at = Unix.gettimeofday () in
     run_dashboard_compute
@@ -759,7 +767,7 @@ let dashboard_execution_trust_http_json ~state ~sw ~clock _request =
          Dashboard_http_keeper.execution_trust_dashboard_json config
          |> with_projection_diagnostics ~surface:"execution_trust" ~started_at ~extra:[])
   in
-  match state.Mcp_server.clock with
+  (match state.Mcp_server.clock with
   | Some clock ->
     Dashboard_cache.get_or_compute_with_timeout
       "execution-trust:default"
@@ -767,7 +775,8 @@ let dashboard_execution_trust_http_json ~state ~sw ~clock _request =
       ~clock
       ~timeout_sec:Env_config_runtime.Dashboard.execution_trust_timeout_sec
       compute
-  | None -> Dashboard_cache.get_or_compute "execution-trust:default" ~ttl:15.0 compute
+  | None -> Dashboard_cache.get_or_compute "execution-trust:default" ~ttl:15.0 compute)
+  |> attach_surface_envelope
 ;;
 
 let transport_health_cache_diagnostics () =

--- a/lib/server/server_dashboard_surface.ml
+++ b/lib/server/server_dashboard_surface.ml
@@ -66,6 +66,7 @@ let generated_at_iso json =
     ; string_field "generated_at" json
     ; string_field "generated_at" diagnostics
     ]
+  (* NDT-OK: response metadata fallback only; source projections remain deterministic. *)
   |> Option.value ~default:(Masc_domain.now_iso ())
 ;;
 

--- a/lib/server/server_dashboard_surface.ml
+++ b/lib/server/server_dashboard_surface.ml
@@ -1,0 +1,150 @@
+(** Shared additive envelope for dashboard read models. *)
+
+type cache_metadata = {
+  state : string;
+  key : string option;
+  ttl_s : float option;
+  stale : bool;
+  stale_reason : string option;
+  latest_age_s : float option;
+  health : string option;
+}
+
+type t = {
+  schema : string;
+  schema_version : int;
+  surface : string;
+  source : string;
+  generated_at_iso : string;
+  cache : cache_metadata;
+}
+
+let schema = "masc.dashboard_surface.v1"
+
+let json_string_opt = function
+  | Some value -> `String value
+  | None -> `Null
+;;
+
+let json_float_opt = function
+  | Some value -> `Float value
+  | None -> `Null
+;;
+
+let assoc_field key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+;;
+
+let string_field key json =
+  match assoc_field key json with
+  | Some (`String value) when String.trim value <> "" -> Some value
+  | _ -> None
+;;
+
+let float_field key json =
+  match assoc_field key json with
+  | Some (`Float value) -> Some value
+  | Some (`Int value) -> Some (float_of_int value)
+  | _ -> None
+;;
+
+let projection_diagnostics json =
+  match assoc_field "projection_diagnostics" json with
+  | Some (`Assoc fields) -> `Assoc fields
+  | _ -> `Assoc []
+;;
+
+let first_some values =
+  List.find_map Fun.id values
+;;
+
+let generated_at_iso json =
+  let diagnostics = projection_diagnostics json in
+  first_some
+    [ string_field "generated_at_iso" json
+    ; string_field "generated_at" json
+    ; string_field "generated_at" diagnostics
+    ]
+  |> Option.value ~default:(Masc_domain.now_iso ())
+;;
+
+let stale_reason json =
+  let diagnostics = projection_diagnostics json in
+  first_some
+    [ string_field "stale_reason" json
+    ; string_field "stale_reason" diagnostics
+    ]
+;;
+
+let cache_state_of_json ~default json =
+  match string_field "cache_state" (projection_diagnostics json) with
+  | Some value -> value
+  | None -> default
+;;
+
+let make
+      ?cache_key
+      ?ttl_s
+      ?(cache_state = "request_cache")
+      ~surface
+      ~source
+      json
+  =
+  let stale_reason = stale_reason json in
+  {
+    schema;
+    schema_version = 1;
+    surface;
+    source;
+    generated_at_iso = generated_at_iso json;
+    cache =
+      {
+        state = cache_state_of_json ~default:cache_state json;
+        key = cache_key;
+        ttl_s;
+        stale = Option.is_some stale_reason;
+        stale_reason;
+        latest_age_s = float_field "latest_age_s" json;
+        health = string_field "health" json;
+      };
+  }
+;;
+
+let to_json envelope =
+  `Assoc
+    [ "schema", `String envelope.schema
+    ; "schema_version", `Int envelope.schema_version
+    ; "surface", `String envelope.surface
+    ; "source", `String envelope.source
+    ; "generated_at_iso", `String envelope.generated_at_iso
+    ; ( "cache"
+      , `Assoc
+          [ "state", `String envelope.cache.state
+          ; "key", json_string_opt envelope.cache.key
+          ; "ttl_s", json_float_opt envelope.cache.ttl_s
+          ; "stale", `Bool envelope.cache.stale
+          ; "stale_reason", json_string_opt envelope.cache.stale_reason
+          ; "latest_age_s", json_float_opt envelope.cache.latest_age_s
+          ; "health", json_string_opt envelope.cache.health
+          ] )
+    ; ( "migration"
+      , `Assoc
+          [ "body_shape", `String "root_fields_preserved"
+          ; ( "rule"
+            , `String
+                "New dashboard read models add this envelope before versioning or removing existing root fields."
+            )
+          ] )
+    ]
+;;
+
+let attach ?cache_key ?ttl_s ?cache_state ~surface ~source json =
+  match json with
+  | `Assoc fields ->
+    let envelope = make ?cache_key ?ttl_s ?cache_state ~surface ~source json in
+    `Assoc
+      (("dashboard_surface_envelope", to_json envelope)
+       :: List.remove_assoc "dashboard_surface_envelope" fields)
+  | other -> other
+;;

--- a/lib/server/server_dashboard_surface.mli
+++ b/lib/server/server_dashboard_surface.mli
@@ -1,0 +1,37 @@
+(** Shared DashboardSurface envelope helpers.
+
+    The envelope is additive: callers keep their current JSON body and attach
+    [dashboard_surface_envelope] so frontend/read-model migrations can consume a
+    stable metadata shape before any endpoint body is versioned. *)
+
+type cache_metadata = {
+  state : string;
+  key : string option;
+  ttl_s : float option;
+  stale : bool;
+  stale_reason : string option;
+  latest_age_s : float option;
+  health : string option;
+}
+
+type t = {
+  schema : string;
+  schema_version : int;
+  surface : string;
+  source : string;
+  generated_at_iso : string;
+  cache : cache_metadata;
+}
+
+val to_json : t -> Yojson.Safe.t
+
+val attach :
+  ?cache_key:string ->
+  ?ttl_s:float ->
+  ?cache_state:string ->
+  surface:string ->
+  source:string ->
+  Yojson.Safe.t ->
+  Yojson.Safe.t
+(** [attach json] returns [json] with a [dashboard_surface_envelope] field when
+    [json] is an object. Existing root fields are preserved. *)

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -1512,6 +1512,25 @@ let test_execution_trust_route_surfaces_trust_summary_fields () =
   check string "route surfaces execution trust dashboard surface"
     "/api/v1/dashboard/execution-trust"
     (json |> member "dashboard_surface" |> to_string);
+  let envelope = json |> member "dashboard_surface_envelope" in
+  check string "route attaches DashboardSurface schema"
+    "masc.dashboard_surface.v1"
+    (envelope |> member "schema" |> to_string);
+  check string "envelope preserves surface identity"
+    "/api/v1/dashboard/execution-trust"
+    (envelope |> member "surface" |> to_string);
+  check string "envelope preserves source identity"
+    "execution_receipt"
+    (envelope |> member "source" |> to_string);
+  check string "envelope marks request cache state"
+    "request_cache"
+    (envelope |> member "cache" |> member "state" |> to_string);
+  check string "envelope cache key names the surface cache"
+    "execution-trust:default"
+    (envelope |> member "cache" |> member "key" |> to_string);
+  check string "envelope migration keeps root fields"
+    "root_fields_preserved"
+    (envelope |> member "migration" |> member "body_shape" |> to_string);
   let row =
     match json |> member "keepers" |> to_list with
     | keeper :: _ -> keeper


### PR DESCRIPTION
Refs #16081

## Summary
- add a shared OCaml DashboardSurface envelope helper for additive read-model metadata
- attach dashboard_surface_envelope to the execution-trust surface while preserving existing root JSON fields
- add frontend typing/API coverage for the envelope
- document the migration rule in the reverse-engineering WBS HTML

## Verification
- ocamlformat --check lib/server/server_dashboard_surface.mli lib/server/server_dashboard_surface.ml lib/server/server_dashboard_http_execution_surfaces.ml test/test_dashboard_keeper_routes.ml
- cd dashboard && pnpm install --frozen-lockfile
- cd dashboard && pnpm exec vitest run src/api/dashboard.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- cd dashboard && pnpm run typecheck
- cd dashboard && pnpm run lint (passes with pre-existing virtual-list eslint-disable warning)
- scripts/dune-local.sh build test/test_dashboard_keeper_routes.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build --cache=disabled bin/main_eio.exe test/test_dashboard_keeper_routes.exe
- env MASC_MAIN_EIO_EXE=./_build/default/bin/main_eio.exe ./_build/default/test/test_dashboard_keeper_routes.exe test --show-errors dashboard_keeper_routes 9