### PR TITLE
test(ide): pin lsp handshake scope

### DIFF
--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -148,28 +148,87 @@ let pct_decode s =
   done;
   Buffer.contents buf
 
+let strip_trailing_slash path =
+  let len = String.length path in
+  if len > 1 && String.get path (len - 1) = '/'
+  then String.sub path 0 (len - 1)
+  else path
+;;
+
+let path_of_file_uri uri =
+  let prefix = "file://" in
+  if String.starts_with ~prefix uri
+  then (
+    let raw =
+      String.sub uri (String.length prefix) (String.length uri - String.length prefix)
+    in
+    pct_decode raw)
+  else uri
+;;
+
+let path_within ~base path =
+  let base = strip_trailing_slash base in
+  let path = strip_trailing_slash path in
+  let base_len = String.length base in
+  String.equal path base
+  || (String.starts_with ~prefix:base path
+      && String.length path > base_len
+      && Char.equal (String.get path base_len) '/')
+;;
+
+let workspace_root_for_initialize ~base_path root_uri =
+  let candidate = root_uri |> path_of_file_uri |> strip_trailing_slash in
+  let base = strip_trailing_slash base_path in
+  if path_within ~base candidate then candidate else base
+;;
+
 (** Resolve file:// URI to relative path from base.
     Strips trailing slash from base and checks directory boundary. *)
 let resolve_relative ~base uri =
-  let prefix = "file://" in
-  if not (String.starts_with ~prefix uri) then Some uri
-  else
-    let raw = String.sub uri (String.length prefix) (String.length uri - String.length prefix) in
-    let full = pct_decode raw in
-    let base =
-      let len = String.length base in
-      if len > 1 && String.get base (len - 1) = '/'
-      then String.sub base 0 (len - 1)
-      else base
-    in
+  if not (String.starts_with ~prefix:"file://" uri)
+  then Some uri
+  else (
+    let full = path_of_file_uri uri |> strip_trailing_slash in
+    let base = strip_trailing_slash base in
     let base_len = String.length base in
     let full_len = String.length full in
-    if not (String.starts_with ~prefix:base full) then Some full
-    else if base_len = full_len then Some ""
-    else if full_len > base_len && String.get full base_len = '/' then
-      Some (String.sub full (base_len + 1) (full_len - base_len - 1))
-    else
-      Some full
+    if not (path_within ~base full)
+    then None
+    else if base_len = full_len
+    then Some ""
+    else Some (String.sub full (base_len + 1) (full_len - base_len - 1)))
+;;
+
+let initialize_capabilities_json () =
+  `Assoc
+    [ "textDocumentSync", `Int 2
+    ; "completionProvider", `Assoc [ "resolveProvider", `Bool true ]
+    ; "hoverProvider", `Bool true
+    ; "definitionProvider", `Bool true
+    ; "referencesProvider", `Bool true
+    ; "documentHighlightProvider", `Bool true
+    ; "documentSymbolProvider", `Bool true
+    ; "foldingRangeProvider", `Bool true
+    ; "selectionRangeProvider", `Bool true
+    ; "documentLinkProvider", `Bool true
+    ; "codeLensProvider", `Assoc [ "resolveProvider", `Bool false ]
+    ; "inlayHintProvider", `Bool true
+    ; ( "diagnosticProvider"
+      , `Assoc [ "interFileDependencies", `Bool false; "workspaceDiagnostics", `Bool false ]
+      )
+    ]
+;;
+
+let initialize_result_json () =
+  `Assoc [ "capabilities", initialize_capabilities_json () ]
+;;
+
+type route_admission =
+  | Upgrade_websocket
+  | Missing_process_manager
+
+let route_admission ~has_proc_mgr =
+  if has_proc_mgr then Upgrade_websocket else Missing_process_manager
 ;;
 
 (** Extract client request ID from JSON-RPC message fields. *)
@@ -458,33 +517,9 @@ let dispatch_message cs msg =
               | _ -> cs.base_path)
            | _ -> cs.base_path
          in
-         let root =
-           if String.starts_with ~prefix:"file://" root_uri
-           then String.sub root_uri 7 (String.length root_uri - 7)
-           else root_uri
-         in
+         let root = workspace_root_for_initialize ~base_path:cs.base_path root_uri in
          cs.workspace_root := root;
-         send_response
-           cs
-           n
-           (`Assoc
-               [ ( "capabilities"
-                 , `Assoc
-                     [ "textDocumentSync", `Int 2
-                     ; "completionProvider", `Assoc [ "resolveProvider", `Bool true ]
-                     ; "hoverProvider", `Bool true
-                     ; "definitionProvider", `Bool true
-                     ; "referencesProvider", `Bool true
-                     ; "documentHighlightProvider", `Bool true
-                     ; "documentSymbolProvider", `Bool true
-                     ; "foldingRangeProvider", `Bool true
-                     ; "selectionRangeProvider", `Bool true
-                     ; "documentLinkProvider", `Bool true
-                     ; "codeLensProvider", `Assoc [ "resolveProvider", `Bool false ]
-                     ; "inlayHintProvider", `Bool true
-                     ; "diagnosticProvider", `Assoc [ "interFileDependencies", `Bool false; "workspaceDiagnostics", `Bool false ]
-                     ] )
-               ])
+         send_response cs n (initialize_result_json ())
        | Some "initialized", _ -> ()
        | Some "shutdown", Some n -> send_response cs n `Null
        | Some "exit", _ -> disconnect cs
@@ -554,9 +589,11 @@ let add_routes ~sw ~clock router =
                 | Some o -> o
                 | None -> "localhost"
               in
-              (match state.Mcp_server.proc_mgr with
-               | None -> Log.Server.warn "LSP WebSocket: no proc_mgr available"
-               | Some proc_mgr ->
+              (match route_admission ~has_proc_mgr:(Option.is_some state.Mcp_server.proc_mgr) with
+               | Missing_process_manager ->
+                 Log.Server.warn "LSP WebSocket: no proc_mgr available"
+               | Upgrade_websocket ->
+               let proc_mgr = Option.get state.Mcp_server.proc_mgr in
                Ws.Handshake.respond_with_upgrade ~sha1 reqd (fun () ->
                  Eio.Switch.run (fun conn_sw ->
                    let done_promise, done_resolver = Eio.Promise.create () in
@@ -615,3 +652,15 @@ let add_routes ~sw ~clock router =
   in
   router
 ;;
+
+module For_testing = struct
+  type nonrec route_admission =
+    route_admission =
+    | Upgrade_websocket
+    | Missing_process_manager
+
+  let resolve_relative = resolve_relative
+  let workspace_root_for_initialize = workspace_root_for_initialize
+  let initialize_result_json = initialize_result_json
+  let route_admission = route_admission
+end

--- a/lib/server/server_ide_lsp_proxy.mli
+++ b/lib/server/server_ide_lsp_proxy.mli
@@ -7,3 +7,15 @@ val add_routes :
   sw:Eio.Switch.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->
   Http_server_eio.Router.t -> Http_server_eio.Router.t
+
+module For_testing : sig
+  val resolve_relative : base:string -> string -> string option
+  val workspace_root_for_initialize : base_path:string -> string -> string
+  val initialize_result_json : unit -> Yojson.Safe.t
+
+  type route_admission =
+    | Upgrade_websocket
+    | Missing_process_manager
+
+  val route_admission : has_proc_mgr:bool -> route_admission
+end

--- a/test/dune
+++ b/test/dune
@@ -133,6 +133,7 @@
   test_keeper_chat_store
   test_keeper_runtime_trust_snapshot
   test_ide_annotations
+  test_server_ide_lsp_proxy
   test_ide_paths
   test_ide_canonical_url_join
   test_ide_migration
@@ -425,6 +426,7 @@
   test_keeper_chat_store
   test_keeper_runtime_trust_snapshot
   test_ide_annotations
+  test_server_ide_lsp_proxy
   test_ide_paths
   test_ide_canonical_url_join
   test_ide_migration

--- a/test/test_server_ide_lsp_proxy.ml
+++ b/test/test_server_ide_lsp_proxy.ml
@@ -1,0 +1,111 @@
+open Alcotest
+
+module Lsp = Masc_mcp.Server_ide_lsp_proxy.For_testing
+
+let member key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+;;
+
+let test_initialize_handshake_is_read_only () =
+  let result = Lsp.initialize_result_json () in
+  let capabilities =
+    match member "capabilities" result with
+    | Some (`Assoc fields) -> fields
+    | _ -> fail "initialize result must expose capabilities"
+  in
+  check bool "hover supported" true (List.mem_assoc "hoverProvider" capabilities);
+  check
+    bool
+    "references supported"
+    true
+    (List.mem_assoc "referencesProvider" capabilities);
+  check
+    bool
+    "execute command provider is not advertised"
+    false
+    (List.mem_assoc "executeCommandProvider" capabilities);
+  check
+    bool
+    "workspace edit/applyEdit is not advertised"
+    false
+    (List.mem_assoc "workspace" capabilities)
+;;
+
+let test_workspace_root_initialize_stays_in_base () =
+  let base_path = "/workspace/masc-mcp" in
+  check
+    string
+    "inside root accepted"
+    "/workspace/masc-mcp/subdir"
+    (Lsp.workspace_root_for_initialize
+       ~base_path
+       "file:///workspace/masc-mcp/subdir/");
+  check
+    string
+    "sibling root rejected"
+    base_path
+    (Lsp.workspace_root_for_initialize ~base_path "file:///workspace/masc-mcp-other");
+  check
+    string
+    "outside root rejected"
+    base_path
+    (Lsp.workspace_root_for_initialize ~base_path "file:///tmp/outside")
+;;
+
+let test_file_uri_resolution_is_workspace_scoped () =
+  let base = "/workspace/masc-mcp" in
+  check
+    (option string)
+    "inside file becomes relative"
+    (Some "lib/server.ml")
+    (Lsp.resolve_relative ~base "file:///workspace/masc-mcp/lib/server.ml");
+  check
+    (option string)
+    "encoded inside file decodes"
+    (Some "docs/with space.md")
+    (Lsp.resolve_relative ~base "file:///workspace/masc-mcp/docs/with%20space.md");
+  check
+    (option string)
+    "sibling prefix is rejected"
+    None
+    (Lsp.resolve_relative ~base "file:///workspace/masc-mcp-other/lib/server.ml");
+  check
+    (option string)
+    "outside file is rejected"
+    None
+    (Lsp.resolve_relative ~base "file:///tmp/outside.ml")
+;;
+
+let test_missing_proc_mgr_does_not_upgrade () =
+  check
+    bool
+    "missing process manager blocks websocket upgrade"
+    true
+    (match Lsp.route_admission ~has_proc_mgr:false with
+     | Lsp.Missing_process_manager -> true
+     | Lsp.Upgrade_websocket -> false);
+  check
+    bool
+    "process manager allows websocket upgrade"
+    true
+    (match Lsp.route_admission ~has_proc_mgr:true with
+     | Lsp.Upgrade_websocket -> true
+     | Lsp.Missing_process_manager -> false)
+;;
+
+let () =
+  run
+    "server_ide_lsp_proxy"
+    [ ( "lsp_proxy"
+      , [ test_case "initialize handshake is read-only" `Quick
+            test_initialize_handshake_is_read_only
+        ; test_case "initialize root stays inside workspace" `Quick
+            test_workspace_root_initialize_stays_in_base
+        ; test_case "file uri resolution is workspace scoped" `Quick
+            test_file_uri_resolution_is_workspace_scoped
+        ; test_case "missing proc_mgr blocks websocket upgrade" `Quick
+            test_missing_proc_mgr_does_not_upgrade
+        ] )
+    ]
+;;


### PR DESCRIPTION
Refs #16083

## Summary
- add focused LSP proxy tests for initialize handshake capabilities, workspace root confinement, file URI scoping, and missing proc_mgr admission
- keep the initialize handshake read-only by asserting no executeCommand/workspace edit capability is advertised
- confine initialize rootUri and file:// textDocument paths to the server base path
- keep existing IDE LSP behavior for in-workspace files

## Verification
- ocamlformat --check lib/server/server_ide_lsp_proxy.ml lib/server/server_ide_lsp_proxy.mli test/test_server_ide_lsp_proxy.ml
- git diff --check HEAD~1..HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build --cache=disabled test/test_server_ide_lsp_proxy.exe
- ./_build/default/test/test_server_ide_lsp_proxy.exe --show-errors