### PR TITLE
docs: design lsp symbol graph exporter and seed snapshot

### DIFF
--- a/docs/design/lsp-symbol-graph-exporter.md
+++ b/docs/design/lsp-symbol-graph-exporter.md
@@ -120,7 +120,7 @@ docs/generated/reverse-engineering/symbol-graph.v1.json
 
 `docs/reverse-engineering-design.html` should link to the artifact and render only the curated summary. The exporter must not rewrite the HTML automatically; HTML updates stay in normal PR review.
 
-The first snapshot in this PR is a schema-compatible static seed. It records WBS lanes, source owners, guard tests, and curated flow edges, and it explicitly records `live_lsp_not_invoked_in_this_pr` in `omissions[]`. A later implementation PR should replace static ranges with live `documentSymbol` and `references` responses.
+The first snapshot in this PR is a schema-compatible static seed. It records WBS lanes, source owners, guard tests, and curated flow edges, and it explicitly records `live_lsp_not_invoked_in_this_pr` in `omissions[]`. Its `display_range` rows are bound to the JSON `base_commit`, so they are evidence for that commit only and must not be treated as current-main coordinates after main advances. A later implementation PR should replace static ranges with live `documentSymbol` and `references` responses.
 
 ## JSON Schema
 

--- a/docs/design/lsp-symbol-graph-exporter.md
+++ b/docs/design/lsp-symbol-graph-exporter.md
@@ -1,0 +1,242 @@
+---
+status: design
+last_verified: 2026-05-18
+issue: https://github.com/jeong-sik/masc-mcp/issues/16083
+masc_goal: goal-refactor-lsp-atlas-20260518
+masc_task: task-386
+code_refs:
+  - lib/server/server_ide_lsp_proxy.ml
+  - lib/server/lsp_process_manager.ml
+  - lib/server/lsp_message_router.ml
+  - dashboard/src/components/ide/ide-lsp-client.ts
+---
+
+# LSP Symbol Graph Exporter
+
+This is the task-386 design contract for turning the existing dashboard LSP lane into a read-only reverse-engineering atlas.
+
+## Goal
+
+Produce a deterministic symbol graph that can update `docs/reverse-engineering-design.html` with code-level flow evidence before large refactors begin.
+
+The graph must answer:
+
+- Which file defines each important symbol?
+- Which ranges participate in a documented flow?
+- Which references and call edges cross module boundaries?
+- Which tests own each flow contract?
+- Which WBS task is allowed to move that code?
+
+## Non-Goals
+
+- No code editing through this lane.
+- No LSP rename, formatting, code action, or command execution.
+- No keeper claim, task transition, git mutation, or dashboard mutation from the exporter.
+- No hidden broad workspace scan without a file manifest and limits.
+
+## Existing Surface
+
+The repo already has a dashboard LSP WebSocket route:
+
+| Surface | Current owner | Relevant behavior |
+|---|---|---|
+| `/api/v1/ide/lsp` | `server_ide_lsp_proxy.ml` | WebSocket JSON-RPC lane registered with public-read auth boundary. |
+| LSP process manager | `lsp_process_manager.ml` | Spawns a language server process under an `Eio.Switch` and tears it down with the connection. |
+| Message router | `lsp_message_router.ml` | Maps client IDs to server IDs and resolves pending request promises. |
+| Dashboard client | `ide-lsp-client.ts` | Connects to the WebSocket, initializes JSON-RPC, and requests IDE annotations. |
+
+Current main advertises read and write-adjacent LSP capabilities in the generic IDE handshake, so the symbol graph exporter must apply its own stricter method allowlist even if the shared IDE lane remains broader.
+
+## Exporter Shape
+
+Implement the exporter as a separate read-only component, not as another branch inside editor hydration:
+
+| Layer | Responsibility | Write permission |
+|---|---|---|
+| `Ide_symbol_graph_manifest` | Static manifest of files, WBS lanes, expected tests, and maximum ranges. | none |
+| `Ide_symbol_graph_client` | Sends allowlisted LSP requests and normalizes responses. | none |
+| `Ide_symbol_graph_builder` | Builds file/symbol/reference/test-owner graph JSON. | none |
+| `scripts/ide/export-symbol-graph` or equivalent CLI | Runs the exporter and writes the artifact only when invoked by a developer PR. | repo write by operator command only |
+| Optional dashboard `GET` route | Returns graph JSON for a requested file/range without persisting it. | none |
+
+The runtime endpoint, if added, must be `GET` only and must not write cache files. Persistent artifacts are produced by an explicit script during a documentation PR.
+
+## Method Allowlist
+
+Allowed LSP methods:
+
+- `initialize`
+- `initialized`
+- `shutdown`
+- `exit`
+- `textDocument/documentSymbol`
+- `textDocument/references`
+- `textDocument/definition`
+- `textDocument/typeDefinition`
+- `textDocument/implementation`
+- `textDocument/hover`
+
+Rejected methods:
+
+- `textDocument/didChange`
+- `textDocument/didSave`
+- `workspace/applyEdit`
+- `workspace/executeCommand`
+- `textDocument/rename`
+- `textDocument/formatting`
+- `textDocument/rangeFormatting`
+- `textDocument/codeAction`
+- every `workspace/*` method except passive capability discovery.
+
+If a language server returns a capability that implies mutation, the exporter records it in `omissions[]` and does not call that method.
+
+## Scope And Budgets
+
+Default limits for task-387:
+
+| Limit | Default | Failure mode |
+|---|---:|---|
+| files per run | 80 | emit `limit_exceeded` omission |
+| bytes per file | 512 KiB | skip file, keep manifest row |
+| symbols per file | 1,500 | truncate with omission |
+| references per symbol | 200 | truncate with omission |
+| LSP request timeout | 3 s | mark method timeout and continue |
+| run timeout | 180 s | fail the exporter command |
+
+Workspace confinement:
+
+- Manifest paths are repo-relative.
+- `file://` URIs must resolve inside the configured workspace root.
+- Symlinks must be resolved before request dispatch.
+- Paths outside the workspace are omitted, not normalized into absolute paths.
+
+## Artifact Path
+
+Task-387 should generate:
+
+```text
+docs/generated/reverse-engineering/symbol-graph.v1.json
+```
+
+`docs/reverse-engineering-design.html` should link to the artifact and render only the curated summary. The exporter must not rewrite the HTML automatically; HTML updates stay in normal PR review.
+
+The first snapshot in this PR is a schema-compatible static seed. It records WBS lanes, source owners, guard tests, and curated flow edges, and it explicitly records `live_lsp_not_invoked_in_this_pr` in `omissions[]`. A later implementation PR should replace static ranges with live `documentSymbol` and `references` responses.
+
+## JSON Schema
+
+The first artifact uses `masc.symbol_graph.v1`:
+
+```json
+{
+  "schema_version": "masc.symbol_graph.v1",
+  "repo": "masc-mcp",
+  "base_commit": "7dda94cd4f",
+  "generated_at": "2026-05-18T00:00:00Z",
+  "source": {
+    "lsp_route": "/api/v1/ide/lsp",
+    "methods": ["textDocument/documentSymbol", "textDocument/references"],
+    "manifest": "docs/design/lsp-symbol-graph-exporter.md"
+  },
+  "limits": {
+    "max_files": 80,
+    "max_bytes_per_file": 524288,
+    "request_timeout_ms": 3000
+  },
+  "files": [
+    {
+      "path": "lib/server/server_ide_lsp_proxy.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:server_ide_lsp_proxy:add_routes",
+          "name": "add_routes",
+          "kind": "function",
+          "display_range": {"start_line": 580, "end_line": 654},
+          "lsp_range": {
+            "start": {"line": 579, "character": 0},
+            "end": {"line": 654, "character": 0}
+          },
+          "wbs": {"issue": 16083, "task": "task-385"},
+          "tests": ["test/test_server_ide_lsp_proxy.ml"]
+        }
+      ],
+      "test_owners": [
+        {
+          "test_path": "test/test_server_ide_lsp_proxy.ml",
+          "contract": "LSP handshake and workspace scope"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "kind": "defines",
+      "from": "file:lib/server/server_ide_lsp_proxy.ml",
+      "to": "sym:server_ide_lsp_proxy:add_routes"
+    }
+  ],
+  "omissions": []
+}
+```
+
+Range rules:
+
+- `display_range` is one-based and inclusive for documentation links.
+- `lsp_range` is zero-based and half-open, matching LSP.
+- Every symbol ID is stable across regenerated artifacts unless the symbol path changes.
+
+## Test Ownership Metadata
+
+The exporter should not infer ownership from references alone. It should combine:
+
+1. Explicit manifest rows: WBS issue/task -> files -> expected tests.
+2. `dune` test stanza membership where available.
+3. `rg` evidence from test files for exported symbol or route names.
+4. Manual overrides for cross-cutting flows such as dashboard HTTP/WS/SSE parity.
+
+Each exported WBS slice must include at least one guard test or an omission explaining why no guard exists yet.
+
+## Keeper Work Breakdown
+
+### Small Goal: `task-386`
+
+Design a read-only symbol graph exporter.
+
+Ultra-mini tasks:
+
+1. Name the artifact path and schema version.
+2. Define the LSP method allowlist and mutation denylist.
+3. Define workspace path confinement rules.
+4. Define runtime budgets and omission rows.
+5. Define test-owner metadata and WBS links.
+6. Link the design from `docs/reverse-engineering-design.html`.
+
+Done evidence:
+
+- This document exists.
+- The HTML design artifact links the contract.
+- GitHub issue #16083 has a PR evidence comment.
+
+### Small Goal: `task-387`
+
+Generate the first reverse-engineering symbol graph snapshot.
+
+Ultra-mini tasks:
+
+1. Build a manifest for the six refactor lanes in #16077.
+2. Export at least these current owners: MCP request context, keeper turn, task/goal lifecycle, dashboard read model, JSONL writer, LSP route.
+3. Emit `docs/generated/reverse-engineering/symbol-graph.v1.json`.
+4. Add a small HTML summary that links the JSON artifact.
+5. Record omissions for symbols or references that LSP cannot resolve.
+
+Done evidence:
+
+- Generated JSON validates against the schema fields above.
+- HTML contains the artifact link and generation commit.
+- The run command and omission count are posted to #16083.
+
+## Acceptance Checks
+
+- `rg "lsp-symbol-graph-exporter" docs/reverse-engineering-design.html docs/design/lsp-symbol-graph-exporter.md`
+- `rg "masc.symbol_graph.v1|task-386|task-387" docs/design/lsp-symbol-graph-exporter.md`
+- `xmllint --html --noout docs/reverse-engineering-design.html`

--- a/docs/generated/reverse-engineering/symbol-graph.v1.json
+++ b/docs/generated/reverse-engineering/symbol-graph.v1.json
@@ -12,7 +12,7 @@
     ],
     "manifest": "docs/design/lsp-symbol-graph-exporter.md",
     "live_lsp_invoked": false,
-    "notes": "Initial task-387 snapshot seeded from current source line inventory. Later exporter PRs should replace static ranges with live LSP responses."
+    "notes": "Initial task-387 snapshot is a base-commit-bound static seed from base_commit. display_range values are not current-main coordinates. Later exporter PRs should replace static ranges with live LSP responses."
   },
   "limits": {
     "max_files": 80,
@@ -691,6 +691,11 @@
       "code": "live_lsp_not_invoked_in_this_pr",
       "reason": "The task-387 artifact is the first schema-compatible seed. It records current owners and guard tests, but does not yet invoke ocamllsp/typescript-language-server through /api/v1/ide/lsp.",
       "follow_up": "Replace static display ranges with live LSP documentSymbol/references responses in the exporter implementation PR."
+    },
+    {
+      "code": "base_commit_bound_static_ranges",
+      "reason": "Static display ranges are valid only for base_commit 22f3665e5218 and may drift as main changes; they must not be treated as current-main coordinates.",
+      "follow_up": "Refresh the artifact through the read-only exporter before using line ranges for refactor execution."
     },
     {
       "code": "call_edges_curated",

--- a/docs/generated/reverse-engineering/symbol-graph.v1.json
+++ b/docs/generated/reverse-engineering/symbol-graph.v1.json
@@ -1,0 +1,701 @@
+{
+  "schema_version": "masc.symbol_graph.v1",
+  "repo": "masc-mcp",
+  "base_commit": "22f3665e5218",
+  "generated_at": "2026-05-18T14:01:20Z",
+  "collection_mode": "static_manifest_seed",
+  "source": {
+    "lsp_route": "/api/v1/ide/lsp",
+    "methods": [
+      "textDocument/documentSymbol",
+      "textDocument/references"
+    ],
+    "manifest": "docs/design/lsp-symbol-graph-exporter.md",
+    "live_lsp_invoked": false,
+    "notes": "Initial task-387 snapshot seeded from current source line inventory. Later exporter PRs should replace static ranges with live LSP responses."
+  },
+  "limits": {
+    "max_files": 80,
+    "max_bytes_per_file": 524288,
+    "max_symbols_per_file": 1500,
+    "max_references_per_symbol": 200,
+    "request_timeout_ms": 3000,
+    "run_timeout_ms": 180000
+  },
+  "lanes": [
+    {
+      "name": "MCP request admission",
+      "issue": 16080,
+      "goal": "goal-refactor-mcp-context-20260518",
+      "tasks": ["task-364", "task-365", "task-366", "task-367"],
+      "primary_files": [
+        "lib/server/server_mcp_transport_http.ml",
+        "lib/server/server_h2_gateway.ml",
+        "lib/mcp_server_eio_protocol.ml",
+        "lib/mcp_server_eio_execute.ml"
+      ],
+      "guard_tests": [
+        "test/test_mcp_h1_h2_admission_parity.ml",
+        "test/test_mcp_session_id_header.ml",
+        "test/test_mcp_server_eio.ml",
+        "dashboard/src/api/mcp.test.ts"
+      ]
+    },
+    {
+      "name": "Keeper turn pipeline",
+      "issue": 16079,
+      "goal": "goal-refactor-keeper-turn-20260518",
+      "tasks": ["task-368", "task-369", "task-370", "task-371", "task-372"],
+      "primary_files": [
+        "lib/keeper/keeper_keepalive.ml",
+        "lib/keeper/keeper_heartbeat_loop.ml",
+        "lib/keeper/keeper_unified_turn.ml",
+        "lib/keeper/keeper_agent_run.ml",
+        "lib/keeper/keeper_execution_receipt.ml"
+      ],
+      "guard_tests": [
+        "test/test_keeper_unified.ml",
+        "test/test_keeper_unified_tool_event_order_source.ml"
+      ]
+    },
+    {
+      "name": "Task and Goal lifecycle",
+      "issue": 16078,
+      "goal": "goal-refactor-task-goal-20260518",
+      "tasks": ["task-373", "task-374", "task-375", "task-376"],
+      "primary_files": [
+        "lib/tool_task.ml",
+        "lib/coord/coord_task.ml",
+        "lib/coord/coord_task_lifecycle.ml",
+        "lib/coord_goals.ml",
+        "lib/goal/goal_verification.ml"
+      ],
+      "guard_tests": [
+        "test/test_verification_fsm.ml",
+        "test/test_goal_tools.ml",
+        "test/test_keeper_task_dispatch.ml"
+      ]
+    },
+    {
+      "name": "Dashboard read model and transport parity",
+      "issue": 16081,
+      "goal": "goal-refactor-dashboard-readmodel-20260518",
+      "tasks": ["task-377", "task-378", "task-379", "task-380"],
+      "primary_files": [
+        "dashboard/src/api/dashboard.ts",
+        "dashboard/src/api/dashboard-hot.ts",
+        "dashboard/src/dashboard-ws.ts",
+        "dashboard/src/sse.ts",
+        "lib/server/server_dashboard_http_execution_surfaces.ml"
+      ],
+      "guard_tests": [
+        "dashboard/src/api/dashboard.test.ts",
+        "dashboard/src/dashboard-ws.test.ts",
+        "dashboard/src/sse-store.test.ts",
+        "test/test_dashboard_keeper_routes.ml"
+      ]
+    },
+    {
+      "name": "JSONL writer contract",
+      "issue": 16082,
+      "goal": "goal-refactor-jsonl-substrate-20260518",
+      "tasks": ["task-381", "task-382", "task-383", "task-384"],
+      "primary_files": [
+        "lib/dated_jsonl/dated_jsonl.ml",
+        "lib/fs_compat/fs_compat.ml",
+        "lib/audit_log.ml",
+        "lib/keeper/keeper_execution_receipt.ml"
+      ],
+      "guard_tests": [
+        "test/test_dated_jsonl.ml",
+        "test/test_dated_jsonl_mutex_registry_10372.ml",
+        "test/test_fs_compat.ml",
+        "test/test_fs_compat_append_jsonl_atomicity.ml"
+      ]
+    },
+    {
+      "name": "LSP-backed reverse engineering atlas",
+      "issue": 16083,
+      "goal": "goal-refactor-lsp-atlas-20260518",
+      "tasks": ["task-385", "task-386", "task-387"],
+      "primary_files": [
+        "lib/server/server_ide_lsp_proxy.ml",
+        "lib/server/lsp_process_manager.ml",
+        "lib/server/lsp_message_router.ml",
+        "dashboard/src/components/ide/ide-lsp-client.ts"
+      ],
+      "guard_tests": [
+        "test/test_server_ide_lsp_proxy.ml",
+        "test/test_ide_annotations.ml",
+        "dashboard/src/components/ide/ide-context-lens.test.ts",
+        "dashboard/src/components/ide/ide-editor.test.ts"
+      ]
+    }
+  ],
+  "files": [
+    {
+      "path": "lib/server/server_mcp_transport_http.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:server_mcp_transport_http:should_stream_post_tools_call",
+          "name": "should_stream_post_tools_call",
+          "kind": "function",
+          "display_range": {"start_line": 176, "end_line": 198},
+          "wbs": {"issue": 16080, "task": "task-364"},
+          "tests": ["test/test_mcp_h1_h2_admission_parity.ml", "test/test_mcp_post_sse_e2e.ml"]
+        },
+        {
+          "id": "sym:server_mcp_transport_http:body_with_canonical_http_actor",
+          "name": "body_with_canonical_http_actor",
+          "kind": "function",
+          "display_range": {"start_line": 199, "end_line": 202},
+          "wbs": {"issue": 16080, "task": "task-366"},
+          "tests": ["test/test_mcp_h1_h2_admission_parity.ml"]
+        },
+        {
+          "id": "sym:server_mcp_transport_http:handle_post_mcp",
+          "name": "handle_post_mcp",
+          "kind": "function",
+          "display_range": {"start_line": 203, "end_line": 525},
+          "wbs": {"issue": 16080, "task": "task-365"},
+          "tests": ["test/test_mcp_session_id_header.ml", "dashboard/src/api/mcp.test.ts"]
+        },
+        {
+          "id": "sym:server_mcp_transport_http:handle_delete_mcp",
+          "name": "handle_delete_mcp",
+          "kind": "function",
+          "display_range": {"start_line": 784, "end_line": 870},
+          "wbs": {"issue": 16080, "task": "task-364"},
+          "tests": ["test/test_mcp_session_id_header.ml"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_mcp_h1_h2_admission_parity.ml", "contract": "H1/H2 admission parity"},
+        {"test_path": "test/test_mcp_session_id_header.ml", "contract": "session id and protocol continuity"}
+      ]
+    },
+    {
+      "path": "lib/mcp_server_eio_protocol.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:mcp_server_eio_protocol:handle_request",
+          "name": "handle_request",
+          "kind": "function",
+          "display_range": {"start_line": 572, "end_line": 819},
+          "wbs": {"issue": 16080, "task": "task-367"},
+          "tests": ["test/test_mcp_server_eio.ml", "test/test_mcp_protocol_coverage.ml"]
+        },
+        {
+          "id": "sym:mcp_server_eio_protocol:handle_dashboard_hello_eio",
+          "name": "handle_dashboard_hello_eio",
+          "kind": "function",
+          "display_range": {"start_line": 437, "end_line": 451},
+          "wbs": {"issue": 16081, "task": "task-379"},
+          "tests": ["dashboard/src/dashboard-ws.test.ts"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_mcp_server_eio.ml", "contract": "JSON-RPC request dispatch"},
+        {"test_path": "dashboard/src/dashboard-ws.test.ts", "contract": "dashboard WS hello and slice auth"}
+      ]
+    },
+    {
+      "path": "lib/mcp_server_eio_execute.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:mcp_server_eio_execute:caller_identity_resolution",
+          "name": "caller_identity_resolution",
+          "kind": "flow",
+          "display_range": {"start_line": 203, "end_line": 216},
+          "wbs": {"issue": 16080, "task": "task-367"},
+          "tests": ["test/test_mcp_server_eio_call_tool.ml"]
+        },
+        {
+          "id": "sym:mcp_server_eio_execute:authorize_tool",
+          "name": "Auth.authorize_tool_v2 callsite",
+          "kind": "callsite",
+          "display_range": {"start_line": 272, "end_line": 293},
+          "wbs": {"issue": 16080, "task": "task-367"},
+          "tests": ["test/test_mcp_server_eio_call_tool.ml"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_mcp_server_eio_call_tool.ml", "contract": "tool caller identity and authorization"}
+      ]
+    },
+    {
+      "path": "lib/keeper/keeper_keepalive.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:keeper_keepalive:start_keepalive",
+          "name": "start_keepalive",
+          "kind": "function",
+          "display_range": {"start_line": 643, "end_line": 764},
+          "wbs": {"issue": 16079, "task": "task-368"},
+          "tests": ["test/test_keeper_unified.ml"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_keeper_unified.ml", "contract": "keeper spawn and turn lifecycle"}
+      ]
+    },
+    {
+      "path": "lib/keeper/keeper_heartbeat_loop.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:keeper_heartbeat_loop:run_keeper_cycle_with_slot",
+          "name": "run_keeper_cycle_with_slot",
+          "kind": "function",
+          "display_range": {"start_line": 583, "end_line": 607},
+          "wbs": {"issue": 16079, "task": "task-371"},
+          "tests": ["test/test_keeper_unified.ml"]
+        },
+        {
+          "id": "sym:keeper_heartbeat_loop:run_heartbeat_loop",
+          "name": "run_heartbeat_loop",
+          "kind": "function",
+          "display_range": {"start_line": 1646, "end_line": 1831},
+          "wbs": {"issue": 16079, "task": "task-371"},
+          "tests": ["test/test_keeper_unified.ml"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_keeper_unified.ml", "contract": "heartbeat loop and unified turn dispatch"}
+      ]
+    },
+    {
+      "path": "lib/keeper/keeper_unified_turn.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:keeper_unified_turn:run_keeper_cycle",
+          "name": "run_keeper_cycle",
+          "kind": "function",
+          "display_range": {"start_line": 122, "end_line": 2886},
+          "wbs": {"issue": 16079, "task": "task-372"},
+          "tests": ["test/test_keeper_unified.ml", "test/test_keeper_unified_tool_event_order_source.ml"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_keeper_unified.ml", "contract": "keeper turn result and post-turn lifecycle"},
+        {"test_path": "test/test_keeper_unified_tool_event_order_source.ml", "contract": "tool event ordering source"}
+      ]
+    },
+    {
+      "path": "lib/keeper/keeper_agent_run.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:keeper_agent_run:append_receipt_manifest",
+          "name": "append_receipt_manifest",
+          "kind": "local_function",
+          "display_range": {"start_line": 2002, "end_line": 2045},
+          "wbs": {"issue": 16079, "task": "task-370"},
+          "tests": ["test/test_keeper_unified_tool_event_order_source.ml"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_keeper_unified_tool_event_order_source.ml", "contract": "receipt before turn finished event"}
+      ]
+    },
+    {
+      "path": "lib/tool_task.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:tool_task:transition_dispatch",
+          "name": "transition dispatch",
+          "kind": "flow",
+          "display_range": {"start_line": 1020, "end_line": 1332},
+          "wbs": {"issue": 16078, "task": "task-375"},
+          "tests": ["test/test_verification_fsm.ml", "test/test_keeper_task_dispatch.ml"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_verification_fsm.ml", "contract": "task verification transition legality"},
+        {"test_path": "test/test_keeper_task_dispatch.ml", "contract": "keeper task dispatch tool path"}
+      ]
+    },
+    {
+      "path": "lib/coord/coord_task.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:coord_task:transition_task_r",
+          "name": "transition_task_r",
+          "kind": "function",
+          "display_range": {"start_line": 49, "end_line": 245},
+          "wbs": {"issue": 16078, "task": "task-375"},
+          "tests": ["test/test_verification_fsm.ml"]
+        },
+        {
+          "id": "sym:coord_task:verification_side_effects",
+          "name": "verification side effects",
+          "kind": "flow",
+          "display_range": {"start_line": 279, "end_line": 411},
+          "wbs": {"issue": 16078, "task": "task-374"},
+          "tests": ["test/test_verification_fsm.ml"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_verification_fsm.ml", "contract": "task verification state machine"}
+      ]
+    },
+    {
+      "path": "lib/coord_goals.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:coord_goals:request_complete_flow",
+          "name": "request complete flow",
+          "kind": "flow",
+          "display_range": {"start_line": 573, "end_line": 710},
+          "wbs": {"issue": 16078, "task": "task-376"},
+          "tests": ["test/test_goal_tools.ml"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_goal_tools.ml", "contract": "goal transition and verification request behavior"}
+      ]
+    },
+    {
+      "path": "lib/goal/goal_verification.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:goal_verification:evaluate_quorum",
+          "name": "evaluate_quorum",
+          "kind": "function",
+          "display_range": {"start_line": 609, "end_line": 674},
+          "wbs": {"issue": 16078, "task": "task-376"},
+          "tests": ["test/test_goal_tools.ml"]
+        },
+        {
+          "id": "sym:goal_verification:vote_and_evaluate",
+          "name": "vote and evaluate quorum",
+          "kind": "flow",
+          "display_range": {"start_line": 675, "end_line": 700},
+          "wbs": {"issue": 16078, "task": "task-376"},
+          "tests": ["test/test_goal_tools.ml"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_goal_tools.ml", "contract": "goal quorum and reject semantics"}
+      ]
+    },
+    {
+      "path": "dashboard/src/api/dashboard.ts",
+      "language": "typescript",
+      "symbols": [
+        {
+          "id": "sym:dashboard_api:fetchDashboardShell",
+          "name": "fetchDashboardShell",
+          "kind": "function",
+          "display_range": {"start_line": 158, "end_line": 161},
+          "wbs": {"issue": 16081, "task": "task-378"},
+          "tests": ["dashboard/src/api/dashboard.test.ts"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "dashboard/src/api/dashboard.test.ts", "contract": "dashboard API shell and execution trust contracts"}
+      ]
+    },
+    {
+      "path": "dashboard/src/dashboard-ws.ts",
+      "language": "typescript",
+      "symbols": [
+        {
+          "id": "sym:dashboard_ws:dashboard_hello",
+          "name": "dashboard/hello send",
+          "kind": "callsite",
+          "display_range": {"start_line": 680, "end_line": 701},
+          "wbs": {"issue": 16081, "task": "task-377"},
+          "tests": ["dashboard/src/dashboard-ws.test.ts"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "dashboard/src/dashboard-ws.test.ts", "contract": "WebSocket auth material and slice mapping"}
+      ]
+    },
+    {
+      "path": "dashboard/src/sse.ts",
+      "language": "typescript",
+      "symbols": [
+        {
+          "id": "sym:sse:observer_query_token",
+          "name": "observer query token",
+          "kind": "flow",
+          "display_range": {"start_line": 196, "end_line": 209},
+          "wbs": {"issue": 16081, "task": "task-377"},
+          "tests": ["dashboard/src/sse-store.test.ts"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "dashboard/src/sse-store.test.ts", "contract": "SSE store replay and token transport"}
+      ]
+    },
+    {
+      "path": "lib/server/server_dashboard_http_execution_surfaces.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:server_dashboard_http_execution_surfaces:with_cached_dashboard_surface_metadata",
+          "name": "with_cached_dashboard_surface_metadata",
+          "kind": "function",
+          "display_range": {"start_line": 237, "end_line": 284},
+          "wbs": {"issue": 16081, "task": "task-380"},
+          "tests": ["test/test_dashboard_keeper_routes.ml", "dashboard/src/api/dashboard.test.ts"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_dashboard_keeper_routes.ml", "contract": "backend dashboard route envelope"},
+        {"test_path": "dashboard/src/api/dashboard.test.ts", "contract": "frontend dashboard envelope decoding"}
+      ]
+    },
+    {
+      "path": "lib/dated_jsonl/dated_jsonl.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:dated_jsonl:append",
+          "name": "append",
+          "kind": "function",
+          "display_range": {"start_line": 244, "end_line": 252},
+          "wbs": {"issue": 16082, "task": "task-383"},
+          "tests": ["test/test_dated_jsonl.ml", "test/test_dated_jsonl_mutex_registry_10372.ml"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_dated_jsonl.ml", "contract": "dated JSONL append/read behavior"},
+        {"test_path": "test/test_dated_jsonl_mutex_registry_10372.ml", "contract": "single mutex per dated store path"}
+      ]
+    },
+    {
+      "path": "lib/fs_compat/fs_compat.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:fs_compat:append_file_unix",
+          "name": "append_file_unix",
+          "kind": "function",
+          "display_range": {"start_line": 184, "end_line": 391},
+          "wbs": {"issue": 16082, "task": "task-382"},
+          "tests": ["test/test_fs_compat.ml"]
+        },
+        {
+          "id": "sym:fs_compat:append_jsonl",
+          "name": "append_jsonl",
+          "kind": "function",
+          "display_range": {"start_line": 605, "end_line": 610},
+          "wbs": {"issue": 16082, "task": "task-382"},
+          "tests": ["test/test_fs_compat_append_jsonl_atomicity.ml"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_fs_compat.ml", "contract": "filesystem compatibility helpers"},
+        {"test_path": "test/test_fs_compat_append_jsonl_atomicity.ml", "contract": "append_jsonl atomicity"}
+      ]
+    },
+    {
+      "path": "lib/audit_log.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:audit_log:get_audit_store",
+          "name": "get_audit_store",
+          "kind": "function",
+          "display_range": {"start_line": 237, "end_line": 252},
+          "wbs": {"issue": 16082, "task": "task-384"},
+          "tests": ["test/test_dashboard_keeper_routes.ml"]
+        },
+        {
+          "id": "sym:audit_log:append_entry",
+          "name": "append entry",
+          "kind": "flow",
+          "display_range": {"start_line": 304, "end_line": 307},
+          "wbs": {"issue": 16082, "task": "task-384"},
+          "tests": ["test/test_dashboard_keeper_routes.ml"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_dashboard_keeper_routes.ml", "contract": "dashboard audit/read model filters"}
+      ]
+    },
+    {
+      "path": "lib/server/server_ide_lsp_proxy.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:server_ide_lsp_proxy:resolve_relative",
+          "name": "resolve_relative",
+          "kind": "function",
+          "display_range": {"start_line": 187, "end_line": 200},
+          "wbs": {"issue": 16083, "task": "task-385"},
+          "tests": ["test/test_server_ide_lsp_proxy.ml"]
+        },
+        {
+          "id": "sym:server_ide_lsp_proxy:dispatch_message",
+          "name": "dispatch_message",
+          "kind": "function",
+          "display_range": {"start_line": 497, "end_line": 577},
+          "wbs": {"issue": 16083, "task": "task-385"},
+          "tests": ["test/test_server_ide_lsp_proxy.ml"]
+        },
+        {
+          "id": "sym:server_ide_lsp_proxy:add_routes",
+          "name": "add_routes",
+          "kind": "function",
+          "display_range": {"start_line": 580, "end_line": 654},
+          "wbs": {"issue": 16083, "task": "task-385"},
+          "tests": ["test/test_server_ide_lsp_proxy.ml", "dashboard/src/components/ide/ide-editor.test.ts"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_server_ide_lsp_proxy.ml", "contract": "LSP handshake, workspace scoping, and route admission"},
+        {"test_path": "test/test_ide_annotations.ml", "contract": "LSP overlay and annotation context"},
+        {"test_path": "dashboard/src/components/ide/ide-editor.test.ts", "contract": "IDE editor LSP signal rendering"}
+      ]
+    },
+    {
+      "path": "lib/server/lsp_process_manager.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:lsp_process_manager:spawn",
+          "name": "spawn",
+          "kind": "function",
+          "display_range": {"start_line": 164, "end_line": 220},
+          "wbs": {"issue": 16083, "task": "task-387"},
+          "tests": ["test/test_server_ide_lsp_proxy.ml"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_server_ide_lsp_proxy.ml", "contract": "missing process manager and LSP route admission"}
+      ]
+    },
+    {
+      "path": "lib/server/lsp_message_router.ml",
+      "language": "ocaml",
+      "symbols": [
+        {
+          "id": "sym:lsp_message_router:send_request",
+          "name": "send_request",
+          "kind": "function",
+          "display_range": {"start_line": 45, "end_line": 59},
+          "wbs": {"issue": 16083, "task": "task-387"},
+          "tests": ["test/test_server_ide_lsp_proxy.ml"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "test/test_server_ide_lsp_proxy.ml", "contract": "LSP request/response path smoke"}
+      ]
+    },
+    {
+      "path": "dashboard/src/components/ide/ide-lsp-client.ts",
+      "language": "typescript",
+      "symbols": [
+        {
+          "id": "sym:ide_lsp_client:LspConnection",
+          "name": "LspConnection",
+          "kind": "class",
+          "display_range": {"start_line": 362, "end_line": 778},
+          "wbs": {"issue": 16083, "task": "task-387"},
+          "tests": ["dashboard/src/components/ide/ide-editor.test.ts"]
+        },
+        {
+          "id": "sym:ide_lsp_client:connect",
+          "name": "connect",
+          "kind": "method",
+          "display_range": {"start_line": 374, "end_line": 408},
+          "wbs": {"issue": 16083, "task": "task-387"},
+          "tests": ["dashboard/src/components/ide/ide-editor.test.ts"]
+        },
+        {
+          "id": "sym:ide_lsp_client:initialize",
+          "name": "initialize",
+          "kind": "method",
+          "display_range": {"start_line": 455, "end_line": 478},
+          "wbs": {"issue": 16083, "task": "task-387"},
+          "tests": ["dashboard/src/components/ide/ide-editor.test.ts"]
+        }
+      ],
+      "test_owners": [
+        {"test_path": "dashboard/src/components/ide/ide-editor.test.ts", "contract": "IDE editor LSP integration"}
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "kind": "dispatches_to",
+      "from": "sym:server_mcp_transport_http:handle_post_mcp",
+      "to": "sym:mcp_server_eio_protocol:handle_request"
+    },
+    {
+      "kind": "authorizes",
+      "from": "sym:mcp_server_eio_protocol:handle_request",
+      "to": "sym:mcp_server_eio_execute:authorize_tool"
+    },
+    {
+      "kind": "calls",
+      "from": "sym:keeper_heartbeat_loop:run_keeper_cycle_with_slot",
+      "to": "sym:keeper_unified_turn:run_keeper_cycle"
+    },
+    {
+      "kind": "emits_receipt",
+      "from": "sym:keeper_unified_turn:run_keeper_cycle",
+      "to": "sym:keeper_agent_run:append_receipt_manifest"
+    },
+    {
+      "kind": "persists_via",
+      "from": "sym:keeper_agent_run:append_receipt_manifest",
+      "to": "sym:dated_jsonl:append"
+    },
+    {
+      "kind": "delegates_append",
+      "from": "sym:dated_jsonl:append",
+      "to": "sym:fs_compat:append_jsonl"
+    },
+    {
+      "kind": "decides_transition",
+      "from": "sym:tool_task:transition_dispatch",
+      "to": "sym:coord_task:transition_task_r"
+    },
+    {
+      "kind": "evaluates_quorum",
+      "from": "sym:coord_goals:request_complete_flow",
+      "to": "sym:goal_verification:evaluate_quorum"
+    },
+    {
+      "kind": "connects_to",
+      "from": "sym:ide_lsp_client:connect",
+      "to": "sym:server_ide_lsp_proxy:add_routes"
+    },
+    {
+      "kind": "routes_lsp_request",
+      "from": "sym:server_ide_lsp_proxy:dispatch_message",
+      "to": "sym:lsp_message_router:send_request"
+    },
+    {
+      "kind": "spawns_lsp_process",
+      "from": "sym:server_ide_lsp_proxy:dispatch_message",
+      "to": "sym:lsp_process_manager:spawn"
+    }
+  ],
+  "omissions": [
+    {
+      "code": "live_lsp_not_invoked_in_this_pr",
+      "reason": "The task-387 artifact is the first schema-compatible seed. It records current owners and guard tests, but does not yet invoke ocamllsp/typescript-language-server through /api/v1/ide/lsp.",
+      "follow_up": "Replace static display ranges with live LSP documentSymbol/references responses in the exporter implementation PR."
+    },
+    {
+      "code": "call_edges_curated",
+      "reason": "Edges are selected from documented flow ownership and rg/nl source evidence, not complete call graph traversal.",
+      "follow_up": "Add per-language reference expansion and omission counts for unresolved references."
+    }
+  ]
+}

--- a/docs/reverse-engineering-design.html
+++ b/docs/reverse-engineering-design.html
@@ -1384,7 +1384,7 @@
               <td><code>task-387</code> first snapshot</td>
               <td>Six WBS lanes from #16077 and explicit file manifest</td>
               <td><a href="generated/reverse-engineering/symbol-graph.v1.json"><code>docs/generated/reverse-engineering/symbol-graph.v1.json</code></a></td>
-              <td>Every WBS slice names at least one guard test or an omission row. Current snapshot is a static seed; live LSP invocation is recorded as an omission.</td>
+              <td>Every WBS slice names at least one guard test or an omission row. Current snapshot is a static seed; live LSP invocation is recorded as an omission. Snapshot ranges are bound to the JSON <code>base_commit</code>, not live current-main coordinates.</td>
             </tr>
           </tbody>
         </table>

--- a/docs/reverse-engineering-design.html
+++ b/docs/reverse-engineering-design.html
@@ -1216,7 +1216,7 @@
               <li>
                 <strong>LSP route already exists as a dashboard WebSocket lane</strong>
                 <span>Server registers <code>/api/v1/ide/lsp</code>; dashboard IDE client connects via WebSocket and initializes JSON-RPC.</span>
-                <code>lib/server/server_ide_lsp_proxy.ml:544-575, dashboard/src/components/ide/ide-lsp-client.ts:362-385</code>
+                <code>lib/server/server_ide_lsp_proxy.ml:580-654, dashboard/src/components/ide/ide-lsp-client.ts:362-385</code>
               </li>
             </ol>
             <div class="cutline">
@@ -1305,7 +1305,8 @@
             <ul>
               <li>현재 존재: <code>/api/v1/ide/lsp</code> WS proxy와 dashboard IDE LSP client</li>
               <li>추가 목표: symbol graph, call graph, test owner를 추출해 이 HTML의 순서도를 자동 갱신</li>
-              <li>첫 구현: read-only endpoint로 file -> symbol overview -> selected range -> references를 JSON으로 반환</li>
+              <li>설계 contract: <a href="design/lsp-symbol-graph-exporter.md"><code>docs/design/lsp-symbol-graph-exporter.md</code></a></li>
+              <li>첫 구현: read-only exporter로 file -> symbol overview -> selected range -> references -> test owner를 JSON으로 반환</li>
               <li>보호 테스트: proxy handshake, workspace root scoping, no write capability, large-file timeout.</li>
             </ul>
           </div>
@@ -1367,7 +1368,26 @@
 
         <div class="callout">
           <strong>LSP note:</strong> LSP 연결 자체는 제품 코드 안에 이미 있습니다. 다음 단계는 이 문서를 수작업 산출물로 끝내지 않고, LSP symbol graph와 test ownership metadata를 붙여 "리팩토링 전 자동 영향도 지도"로 승격하는 것입니다.
+          Exporter contract는 <a href="design/lsp-symbol-graph-exporter.md"><code>docs/design/lsp-symbol-graph-exporter.md</code></a>에 고정합니다.
         </div>
+
+        <table>
+          <thead><tr><th>LSP atlas step</th><th>Input</th><th>Output</th><th>Guardrail</th></tr></thead>
+          <tbody>
+            <tr>
+              <td><code>task-386</code> exporter design</td>
+              <td>#16083, existing <code>/api/v1/ide/lsp</code>, RFC-0059 LSP modules</td>
+              <td>Read-only schema, method allowlist, workspace limits, artifact path</td>
+              <td>No mutation methods, no automatic HTML rewrite, bounded file/range scan</td>
+            </tr>
+            <tr>
+              <td><code>task-387</code> first snapshot</td>
+              <td>Six WBS lanes from #16077 and explicit file manifest</td>
+              <td><a href="generated/reverse-engineering/symbol-graph.v1.json"><code>docs/generated/reverse-engineering/symbol-graph.v1.json</code></a></td>
+              <td>Every WBS slice names at least one guard test or an omission row. Current snapshot is a static seed; live LSP invocation is recorded as an omission.</td>
+            </tr>
+          </tbody>
+        </table>
       </section>
 
       <section id="keeper-wbs">
@@ -1422,7 +1442,7 @@
               <td>LSP 기반 역공학 lane을 만들어 다음 설계도 갱신을 자동화한다.</td>
               <td><code>goal-refactor-lsp-atlas-20260518</code><br><a href="https://github.com/jeong-sik/masc-mcp/issues/16083">GitHub #16083</a></td>
               <td><code>task-385</code> LSP handshake<br><code>task-386</code> symbol graph design<br><code>task-387</code> first graph snapshot</td>
-              <td>기존 <code>/api/v1/ide/lsp</code>를 read-only 분석 lane으로 제한하고 file/symbol/range/reference/test-owner JSON을 만든다.</td>
+              <td>기존 <code>/api/v1/ide/lsp</code> 위에 read-only exporter contract를 두고 file/symbol/range/reference/test-owner JSON을 만든다. 설계 SSOT: <a href="design/lsp-symbol-graph-exporter.md">LSP Symbol Graph Exporter</a>.</td>
             </tr>
           </tbody>
         </table>
@@ -1447,7 +1467,7 @@
           </div>
           <div class="step">
             <strong>PR 4: LSP atlas automation</strong>
-            <span><code>task-386</code>, <code>task-387</code>. refactor graph 생성은 read-only lane으로 제한하고, HTML에는 생성 산출물 링크만 붙인다.</span>
+            <span><code>task-386</code>, <code>task-387</code>. refactor graph 생성은 read-only lane으로 제한하고, HTML에는 <a href="generated/reverse-engineering/symbol-graph.v1.json"><code>docs/generated/reverse-engineering/symbol-graph.v1.json</code></a> 링크와 curated summary만 붙인다.</span>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add docs/design/lsp-symbol-graph-exporter.md for task-386
- define read-only LSP symbol graph schema, method allowlist, workspace limits, artifact path, test-owner metadata, and task-387 handoff
- add the first schema-compatible seed snapshot at docs/generated/reverse-engineering/symbol-graph.v1.json
- link the exporter contract and generated snapshot from docs/reverse-engineering-design.html WBS and improvement plan

## Snapshot scope
- collection_mode: static_manifest_seed
- rebased on origin/main 22f3665e5218 after #16246 landed
- lanes: 6 WBS lanes from #16077
- source files: 22 existing files
- guard tests: 24 existing test files
- omissions include live_lsp_not_invoked_in_this_pr, base_commit_bound_static_ranges, and call_edges_curated
- test/test_server_ide_lsp_proxy.ml now owns the server-side LSP route guard; lsp_server_route_guard_pending was removed

## Verification
- jq schema/count check for masc.symbol_graph.v1
- jq lane/test-owner/omission coverage check
- python3 path/range check for all referenced source files, guard tests, symbol tests, and display ranges
- rg "symbol-graph.v1.json|live_lsp_not_invoked_in_this_pr|base_commit_bound_static_ranges|masc.symbol_graph.v1|task-387|test_server_ide_lsp_proxy" docs/reverse-engineering-design.html docs/design/lsp-symbol-graph-exporter.md docs/generated/reverse-engineering/symbol-graph.v1.json
- git diff --check
- xmllint --html --noout docs/reverse-engineering-design.html (exit 0; existing HTML5 tag vocabulary warnings)

Issue: #16083
MASC: task-386, task-387
