### PR TITLE
fix(ci): restore draft-auto-merge guard

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -30,7 +30,6 @@ jobs:
   draft-automerge-guard:
     name: Draft Auto-Merge Guard
     runs-on: ubuntu-latest
-    if: ${{ false }}  # TEMP: disabled for batch PR ready conversion
     # Skip when the PR is already closed/merged. labeled/unlabeled
     # events on pull_request_target can fire after merge (post-merge
     # automation removing labels), causing wasted runs.


### PR DESCRIPTION
## Summary
- Reverts the temporary `if: ${{ false }}` disable from #16248
- Draft Auto-Merge Guard is now active again for all PR events

## Context
Guard was temporarily disabled to batch-convert ~30 PRs to Ready with `human-approved-ready` labels.
Batch processing is complete; restoring normal operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>