### PR TITLE
fix(keeper): preserve workflow rejections for verification submits

### DIFF
--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -8,13 +8,31 @@ let keeper_task_result_json = function
       (`Assoc [ "ok", `Bool false; "error", `String (Masc_domain.masc_error_to_string e) ])
 ;;
 
-let keeper_tool_result_json ~(ok : bool) ~(message : string) =
+let workflow_rejection_error_json message =
+  error_json
+    ~fields:[ "failure_class", `String "workflow_rejection" ]
+    message
+;;
+
+let keeper_tool_result_json ~failure_class ~(ok : bool) ~(message : string) =
+  let failure_class_fields =
+    match failure_class with
+    | Some cls when not ok ->
+      [
+        ( "failure_class"
+        , `String (Tool_result.tool_failure_class_to_string cls) );
+      ]
+    | Some _
+    | None ->
+      []
+  in
   Yojson.Safe.to_string
     (`Assoc
-       [
+       ([
          "ok", `Bool ok;
          ((if ok then "result" else "error"), `String message);
-       ])
+       ]
+        @ failure_class_fields))
 ;;
 
 let validate_goal_id config goal_id =
@@ -425,7 +443,9 @@ let handle_keeper_task_tool
     let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
     let result_text = Safe_ops.json_string ~default:"" "result" args |> String.trim in
     if task_id = ""
-    then error_json "task_id is required. Use the task_id you got from keeper_task_claim."
+    then
+      workflow_rejection_error_json
+        "task_id is required. Use the task_id you got from keeper_task_claim."
     else if result_text = ""
     then
       (* Schema (tool_shard_types.ml:1447) declares [result] as a
@@ -438,7 +458,7 @@ let handle_keeper_task_tool
          "handoff_context.summary is required" message instead of a
          keeper-vocabulary error). Enforce the schema here so the
          error names the field the keeper actually sent. *)
-      error_json
+      workflow_rejection_error_json
         "result is required. Audit trail: describe what you completed. \
          Example: result='Refactored module X, all tests green, no flake'."
     else (
@@ -466,17 +486,26 @@ let handle_keeper_task_tool
           }
           (`Assoc args_for_transition)
       in
-      keeper_tool_result_json ~ok:transition_result.Tool_result.success ~message:transition_result.Tool_result.legacy_message)
+      keeper_tool_result_json
+        ~failure_class:(Tool_result.failure_class transition_result)
+        ~ok:transition_result.Tool_result.success
+        ~message:transition_result.Tool_result.legacy_message)
   | "keeper_task_submit_for_verification" ->
     let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
     let notes = Safe_ops.json_string ~default:"" "notes" args |> String.trim in
     let pr_url = Safe_ops.json_string ~default:"" "pr_url" args |> String.trim in
     if task_id = ""
-    then error_json "task_id is required. Use the task_id you got from keeper_task_claim."
+    then
+      workflow_rejection_error_json
+        "task_id is required. Use the task_id you got from keeper_task_claim."
     else if notes = ""
-    then error_json "notes is required. Include verification evidence and test summary."
+    then
+      workflow_rejection_error_json
+        "notes is required. Include verification evidence and test summary."
     else if pr_url = ""
-    then error_json "pr_url is required. Include the PR opened for this task."
+    then
+      workflow_rejection_error_json
+        "pr_url is required. Include the PR opened for this task."
     else (
       (* Map keeper vocabulary (notes + pr_url) onto MASC domain typed
          handoff_context fields: notes -> summary, [pr_url] ->
@@ -506,6 +535,9 @@ let handle_keeper_task_tool
                "handoff_context", handoff_context;
              ])
       in
-      keeper_tool_result_json ~ok:transition_result.Tool_result.success ~message:transition_result.Tool_result.legacy_message)
+      keeper_tool_result_json
+        ~failure_class:(Tool_result.failure_class transition_result)
+        ~ok:transition_result.Tool_result.success
+        ~message:transition_result.Tool_result.legacy_message)
   | other -> error_json ~fields:[ "tool", `String other ] "unknown_task_tool"
 ;;

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -147,8 +147,18 @@ let normalize_tool_result ~(success : bool) (raw : string) : string =
                    "tool returned error status"
                  | _ -> "tool call failed")))
       in
+      let preserved_fields =
+        [ "failure_class"; "recoverable"; "error_class" ]
+        |> List.filter_map (fun key ->
+          match Yojson.Safe.Util.member key json with
+          | `String _ as value -> Some (key, value)
+          | `Bool _ as value -> Some (key, value)
+          | _ -> None)
+      in
       Yojson.Safe.to_string
-        (`Assoc [ "ok", `Bool false; "error", `String error_msg; "detail", json ]))
+        (`Assoc
+          ([ "ok", `Bool false; "error", `String error_msg; "detail", json ]
+           @ preserved_fields)))
   with
   | Yojson.Json_error _ ->
     (* Raw is not JSON (e.g. plain text from keeper_tasks_list).
@@ -158,6 +168,16 @@ let normalize_tool_result ~(success : bool) (raw : string) : string =
     else
       Yojson.Safe.to_string
         (`Assoc [ "ok", `Bool false; "error", `String raw; "detail", `Null ])
+;;
+
+let tool_failure_class_of_wire_string = function
+  | Some "transient_error" -> Some Tool_result.Transient_error
+  | Some "policy_rejection" -> Some Tool_result.Policy_rejection
+  | Some "runtime_failure" -> Some Tool_result.Runtime_failure
+  | Some "workflow_rejection" -> Some Tool_result.Workflow_rejection
+  | Some _
+  | None ->
+    None
 ;;
 
 let transient_mutex_contention_error_class = "transient_mutex_contention"
@@ -181,6 +201,7 @@ let transient_mutex_contention_tool_error
         [ "ok", `Bool false
         ; "error", `String message
         ; "error_class", `String transient_mutex_contention_error_class
+        ; "failure_class", `String "transient_error"
         ; "recoverable", `Bool true
         ; "transient", `Bool true
         ; "retry_recommended", `Bool true
@@ -550,7 +571,22 @@ let make_keeper_tool_handler
           in
           if is_failure
           then (
-            let count = failure_count_record_failure failure_counts key in
+            let failure_class =
+              Keeper_exec_tools.failure_class_of_tool_result_payload raw_result
+              |> tool_failure_class_of_wire_string
+            in
+            let is_workflow_rejection =
+              match failure_class with
+              | Some Tool_result.Workflow_rejection -> true
+              | Some (Tool_result.Transient_error | Tool_result.Policy_rejection | Tool_result.Runtime_failure)
+              | None ->
+                false
+            in
+            let count =
+              if is_workflow_rejection
+              then 0
+              else failure_count_record_failure failure_counts key
+            in
             Keeper_registry.record_tool_use
               ~base_path:config.base_path
               meta.name
@@ -567,12 +603,9 @@ let make_keeper_tool_handler
                  ; duration_ms = Float.of_int duration_ms
                  ; data = `Null
                  ; legacy_message = raw_result
-                 ; (* The keeper-internal tool returned a non-throwing
-                      error result; classify as Runtime_failure so the
-                      dispatch metric label and downstream observers
-                      can distinguish it from transient / policy / workflow
-                      rejections. *)
-                   failure_class = Some Tool_result.Runtime_failure
+                 ; failure_class =
+                     Some
+                       (Option.value ~default:Tool_result.Runtime_failure failure_class)
                  }
              in
              (* RFC-0084 PR-I-3 — typed observers replace
@@ -601,12 +634,19 @@ let make_keeper_tool_handler
               Keeper_metrics.metric_keeper_tools_oas_failures
               ~labels:[ "tool", name; "site", "error_result" ]
               ();
-            Log.Keeper.error
-              "tool %s returned error result (%d/%d): %s"
-              name
-              count
-              max_consecutive_failures
-              detail;
+            if is_workflow_rejection
+            then
+              Log.Keeper.warn
+                "tool %s returned workflow rejection: %s"
+                name
+                detail
+            else
+              Log.Keeper.error
+                "tool %s returned error result (%d/%d): %s"
+                name
+                count
+                max_consecutive_failures
+                detail;
             let normalized_error = normalize_tool_result ~success:false raw_result in
             append_tool_exec_decision_log
               ~config

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -49,8 +49,9 @@ val create_failure_counts : unit -> failure_counts
 
 (** Normalize a raw tool result string into the canonical JSON
     envelope. Success → [{"ok":true,"result":...}]; failure →
-    [{"ok":false,"error":...,"detail":...}]. Plain text is wrapped
-    as a string under [result] / [error]. *)
+    [{"ok":false,"error":...,"detail":...}], preserving structured
+    [failure_class]/[recoverable]/[error_class] fields when present.
+    Plain text is wrapped as a string under [result] / [error]. *)
 val normalize_tool_result : success:bool -> string -> string
 
 (** Build the structured, recoverable envelope used when a keeper tool

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -146,6 +146,14 @@ let to_oas_tool_result ?(recoverable = false) (success, msg)
     let recoverable = recoverable || json_recoverable in
     make_tool_error ~recoverable ?error_class (maybe_externalize msg)
 
+let oas_error_class_of_tool_failure_class = function
+  | Tool_result.Transient_error -> Some Agent_sdk.Types.Transient
+  | Tool_result.Policy_rejection
+  | Tool_result.Workflow_rejection ->
+    Some Agent_sdk.Types.Deterministic
+  | Tool_result.Runtime_failure -> Some Agent_sdk.Types.Unknown
+;;
+
 let of_oas_tool_result : Agent_sdk.Types.tool_result -> bool * string = function
   | Ok { content } -> (true, content)
   | Error { message; _ } -> (false, message)
@@ -264,7 +272,20 @@ let oas_descriptor_of_masc_tool name =
   Option.map descriptor_of_permission (oas_permission_of_masc_tool name)
 
 let to_oas_typed_result (tr : Tool_result.t) : Agent_sdk.Types.tool_result =
-  to_oas_tool_result (tr.success, Tool_result.message tr)
+  if tr.success
+  then Ok { Agent_sdk.Types.content = maybe_externalize (Tool_result.message tr) }
+  else (
+    let msg = Tool_result.message tr in
+    let json_recoverable, json_error_class =
+      tool_error_metadata_from_json_message msg
+    in
+    let recoverable, error_class =
+      match Tool_result.failure_class tr with
+      | Some cls ->
+        (Tool_result.is_retryable cls, oas_error_class_of_tool_failure_class cls)
+      | None -> json_recoverable, json_error_class
+    in
+    make_tool_error ~recoverable ?error_class (maybe_externalize msg))
 
 (** Create an OAS [Tool.t] from a MASC tool schema and a typed handler.
 

--- a/lib/tool_bridge.mli
+++ b/lib/tool_bridge.mli
@@ -45,7 +45,8 @@ val to_oas_tool_result :
 
 val to_oas_typed_result : Tool_result.t -> Agent_sdk.Types.tool_result
 (** Convert a {!Tool_result.t} to OAS [tool_result].
-    Preserves the structured payload and applies externalization. *)
+    Preserves the structured payload, maps [failure_class] to OAS
+    [recoverable]/[error_class], and applies externalization. *)
 
 val of_oas_tool_result : Agent_sdk.Types.tool_result -> bool * string
 (** Convert OAS [tool_result] back to MASC [(success, message)]. *)

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -673,6 +673,19 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
   match handoff_context with
   | Error error -> Tool_result.error ~tool_name ~start_time error
   | Ok handoff_context ->
+  let submit_evidence_error =
+    match requested_action with
+    | Masc_domain.Submit_for_verification | Masc_domain.Submit_pr_evidence ->
+      verification_submission_evidence_error ~notes ~handoff_context
+    | Masc_domain.Claim
+    | Masc_domain.Start
+    | Masc_domain.Done_action
+    | Masc_domain.Cancel
+    | Masc_domain.Release
+    | Masc_domain.Approve_verification
+    | Masc_domain.Reject_verification ->
+      None
+  in
   if (=) action Masc_domain.Release && strict_release_requires_handoff task_opt
      && Option.is_none handoff_context
   then
@@ -763,19 +776,19 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
       | None -> action
     else action
   in
-  let submit_evidence_error =
-    match requested_action with
-    | Masc_domain.Submit_for_verification | Masc_domain.Submit_pr_evidence ->
-      verification_submission_evidence_error ~notes ~handoff_context
-    | Masc_domain.Claim
-    | Masc_domain.Start
-    | Masc_domain.Done_action
-    | Masc_domain.Cancel
-    | Masc_domain.Release
-    | Masc_domain.Approve_verification
-    | Masc_domain.Reject_verification ->
-      None
+  let action =
+    match requested_action, task_opt, submit_evidence_error with
+    | ( Masc_domain.Submit_for_verification
+      , Some ({ task_status = Masc_domain.Todo; _ } : Masc_domain.task)
+      , None ) ->
+      Log.Task.info
+        "[verification-alias] treating todo submit_for_verification with evidence as submit_pr_evidence task=%s agent=%s"
+        task_id
+        ctx.agent_name;
+      Masc_domain.Submit_pr_evidence
+    | _ -> action
   in
+  let action_s = Masc_domain.task_action_to_string action in
   let default_time = Time_compat.now () -. 60.0 in
   let (started_at_actual, collaborators_from_task) = match task_opt with
     | Some t -> (match t.task_status with

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -224,7 +224,8 @@ After masc_add_task or masc_claim_next; pair with masc_deliver before action='do
 Use submit_for_verification to request cross-agent review; approve/reject for verifier actions. \
 Use submit_pr_evidence to submit a merged PR as evidence for a todo task that requires tools \
 unavailable to you — this transitions the task directly to awaiting_verification so a keeper \
-with the required tools can verify and close it. \
+with the required tools can verify and close it. For compatibility, \
+submit_for_verification with evidence on a todo task is treated as submit_pr_evidence. \
 Tasks created through masc_add_task normally route action='done' into awaiting_verification rather than final done.";
     input_schema = `Assoc [
       ("type", `String "object");

--- a/lib/tool_types/tool_result.ml
+++ b/lib/tool_types/tool_result.ml
@@ -30,6 +30,14 @@ let tool_failure_class_to_string = function
   | Workflow_rejection -> "workflow_rejection"
 ;;
 
+let tool_failure_class_of_string = function
+  | "transient_error" -> Some Transient_error
+  | "policy_rejection" -> Some Policy_rejection
+  | "runtime_failure" -> Some Runtime_failure
+  | "workflow_rejection" -> Some Workflow_rejection
+  | _ -> None
+;;
+
 let is_retryable = function
   | Transient_error -> true
   | Policy_rejection | Runtime_failure | Workflow_rejection -> false
@@ -114,6 +122,18 @@ let classify_from_dispatch_failure (message : string) : tool_failure_class =
     || contains_casefold message "503"
   then Transient_error
   else Runtime_failure
+;;
+
+let classify_from_structured_failure_message message =
+  try
+    match Yojson.Safe.from_string message with
+    | `Assoc fields ->
+      (match List.assoc_opt "failure_class" fields with
+       | Some (`String value) -> tool_failure_class_of_string value
+       | _ -> None)
+    | _ -> None
+  with
+  | Yojson.Json_error _ -> None
 ;;
 
 type t =
@@ -210,7 +230,11 @@ let error ?(failure_class = None) ~tool_name ~start_time message =
   let failure_class =
     match failure_class with
     | Some _ -> failure_class
-    | None -> Some (classify_from_dispatch_failure message)
+    | None ->
+      Some
+        (match classify_from_structured_failure_message message with
+         | Some cls -> cls
+         | None -> classify_from_dispatch_failure message)
   in
   { success = false
   ; data

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -1893,7 +1893,13 @@ let test_submit_for_verification_requires_pr_url () =
     in
     let json = parse_json result in
     match Yojson.Safe.Util.member "error" json with
-    | `String msg -> check bool "mentions pr_url" true (contains_substring msg "pr_url")
+    | `String msg ->
+      check bool "mentions pr_url" true (contains_substring msg "pr_url");
+      check
+        string
+        "failure class"
+        "workflow_rejection"
+        Yojson.Safe.Util.(member "failure_class" json |> to_string)
     | _ -> fail "expected error for empty pr_url")
 ;;
 

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1095,6 +1095,26 @@ let test_normalize_failure_ok_false () =
   check string "error extracted" "command_blocked" (json_string "error" json)
 ;;
 
+let test_normalize_failure_preserves_failure_class () =
+  let raw =
+    {|{"ok":false,"error":"[TaskError] Invalid task state","failure_class":"workflow_rejection","error_class":"deterministic","recoverable":false}|}
+  in
+  let normalized = Keeper_tools_oas.normalize_tool_result ~success:false raw in
+  let json = parse normalized in
+  check bool "ok is false" false (json_bool "ok" json);
+  check
+    string
+    "failure class preserved"
+    "workflow_rejection"
+    (json_string "failure_class" json);
+  check
+    string
+    "error class preserved"
+    "deterministic"
+    (json_string "error_class" json);
+  check bool "recoverable preserved" false (json_bool "recoverable" json)
+;;
+
 let test_normalize_failure_plain_text () =
   let raw = "tool keeper_bash failed (3/5): Unix_error(ENOENT)" in
   let normalized = Keeper_tools_oas.normalize_tool_result ~success:false raw in
@@ -1119,6 +1139,11 @@ let test_transient_mutex_contention_envelope () =
     "error_class"
     "transient_mutex_contention"
     Yojson.Safe.Util.(member "error_class" json |> to_string);
+  check
+    string
+    "failure_class"
+    "transient_error"
+    Yojson.Safe.Util.(member "failure_class" json |> to_string);
   check
     bool
     "retry recommended"
@@ -1348,6 +1373,10 @@ let () =
             "failure handles ok:false hybrid"
             `Quick
             test_normalize_failure_ok_false
+        ; test_case
+            "failure preserves failure_class"
+            `Quick
+            test_normalize_failure_preserves_failure_class
         ; test_case
             "failure plain text wraps as error"
             `Quick

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -119,6 +119,40 @@ let test_to_oas_error_uses_json_recoverable_flag () =
        | Some Agent_sdk.Types.Transient -> ()
        | _ -> Alcotest.fail "expected transient error_class from JSON")
 
+let test_to_oas_typed_result_preserves_workflow_rejection () =
+  Unix.putenv "MASC_TOOL_EXTERNALIZE" "0";
+  let tr =
+    Tool_result.error
+      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~tool_name:"masc_transition"
+      ~start_time:0.0
+      "Invalid task state: submit_for_verification requires verification evidence"
+  in
+  match B.to_oas_typed_result tr with
+  | Ok _ -> Alcotest.fail "expected Error"
+  | Error { recoverable; error_class; _ } ->
+    Alcotest.(check bool) "workflow rejection is non-recoverable" false recoverable;
+    (match error_class with
+     | Some Agent_sdk.Types.Deterministic -> ()
+     | _ -> Alcotest.fail "expected deterministic error_class")
+
+let test_to_oas_typed_result_preserves_transient_failure_class () =
+  Unix.putenv "MASC_TOOL_EXTERNALIZE" "0";
+  let tr =
+    Tool_result.error
+      ~failure_class:(Some Tool_result.Transient_error)
+      ~tool_name:"keeper_shell"
+      ~start_time:0.0
+      {|{"ok":false,"error":"mutex contention","failure_class":"transient_error","recoverable":true,"error_class":"transient_mutex_contention"}|}
+  in
+  match B.to_oas_typed_result tr with
+  | Ok _ -> Alcotest.fail "expected Error"
+  | Error { recoverable; error_class; _ } ->
+    Alcotest.(check bool) "transient remains recoverable" true recoverable;
+    (match error_class with
+     | Some Agent_sdk.Types.Transient -> ()
+     | _ -> Alcotest.fail "expected transient error_class")
+
 (* --- Externalize round-trip needs an isolated test process due to the
        lazy singleton. We exercise it via the env-aware path. --- *)
 
@@ -181,6 +215,10 @@ let () =
           Alcotest.test_case "error inlined" `Quick test_to_oas_error_inlined;
           Alcotest.test_case "error recoverable from JSON" `Quick
             test_to_oas_error_uses_json_recoverable_flag;
+          Alcotest.test_case "typed workflow rejection is deterministic" `Quick
+            test_to_oas_typed_result_preserves_workflow_rejection;
+          Alcotest.test_case "typed transient remains recoverable" `Quick
+            test_to_oas_typed_result_preserves_transient_failure_class;
           Alcotest.test_case "round-trip through OAS" `Quick
             test_round_trip_through_oas;
         ] );

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -74,6 +74,22 @@ let test_distributed_lock_exception_is_transient () =
      | None -> "none")
 ;;
 
+let test_error_uses_structured_failure_class () =
+  let r =
+    Tool_result.error
+      ~tool_name:"keeper_task_submit_for_verification"
+      ~start_time:0.0
+      {|{"ok":false,"error":"pr_url is required","failure_class":"workflow_rejection"}|}
+  in
+  Alcotest.(check bool) "failure" false r.success;
+  Alcotest.(check string)
+    "failure class"
+    "workflow_rejection"
+    (match Tool_result.failure_class r with
+     | Some cls -> Tool_result.tool_failure_class_to_string cls
+     | None -> "none")
+;;
+
 let test_ok_prefixed_json_response () =
   let start = 1000.0 in
   let r =
@@ -168,6 +184,10 @@ let () =
             "distributed lock exception is transient"
             `Quick
             test_distributed_lock_exception_is_transient
+        ; Alcotest.test_case
+            "structured failure_class is honored"
+            `Quick
+            test_error_uses_structured_failure_class
         ; Alcotest.test_case
             "prefixed json response"
             `Quick

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1666,7 +1666,34 @@ let () = test "transition_submit_for_verification_requires_evidence_ref" (fun ()
     assert_task_claimed_by ctx ctx.agent_name)
 )
 
-let () = test "transition_submit_for_verification_rejects_todo_pr_evidence" (fun () ->
+let () = test "transition_submit_for_verification_aliases_todo_pr_evidence" (fun () ->
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
+    let ctx = make_test_ctx_with_agent "codex-mcp-client" in
+    let pr_url = "https://github.com/jeong-sik/masc-mcp/pull/13169" in
+    add_task_requiring_tools ctx ~title:"Codex CLI approval follow-up" [ "keeper_bash" ];
+    let result =
+      Tool_task.handle_transition
+        ~agent_tool_names:[ "masc_status"; "masc_transition" ]
+        ~tool_name:"test_tool" ~start_time:0.0
+        ctx
+        (`Assoc
+          [
+            ("task_id", `String "task-001");
+            ("action", `String "submit_for_verification");
+            ("pr_url", `String pr_url);
+            ( "notes",
+              `String
+                "Implementation is already merged; submit PR evidence for independent verification." );
+          ])
+    in
+    if not result.Tool_result.success then failwith result.Tool_result.legacy_message;
+    assert_task_awaiting_verification_by ctx "codex-mcp-client";
+    match (only_task ctx).handoff_context with
+    | Some hc -> assert (List.mem pr_url hc.evidence_refs)
+    | None -> failwith "expected handoff_context to receive pr_url evidence")
+)
+
+let () = test "transition_submit_for_verification_todo_still_requires_evidence" (fun () ->
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
     let ctx = make_test_ctx_with_agent "codex-mcp-client" in
     add_task_requiring_tools ctx ~title:"Codex CLI approval follow-up" [ "keeper_bash" ];
@@ -1679,14 +1706,11 @@ let () = test "transition_submit_for_verification_rejects_todo_pr_evidence" (fun
           [
             ("task_id", `String "task-001");
             ("action", `String "submit_for_verification");
-            ("pr_url", `String "https://github.com/jeong-sik/masc-mcp/pull/13169");
-            ( "notes",
-              `String
-                "Implementation is already merged; submit PR evidence for independent verification." );
+            ("notes", `String "Implementation is complete.");
           ])
     in
     assert (not result.Tool_result.success);
-    assert (str_contains result.Tool_result.legacy_message "Invalid transition: todo -> submit_for_verification");
+    assert (str_contains result.Tool_result.legacy_message "requires verification evidence");
     assert_task_todo ctx)
 )
 

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1661,6 +1661,8 @@ let () = test "transition_submit_for_verification_requires_evidence_ref" (fun ()
     in
     assert (not submit_result.Tool_result.success);
     assert
+      (Tool_result.failure_class submit_result = Some Tool_result.Workflow_rejection);
+    assert
       (str_contains submit_result.Tool_result.legacy_message
          "requires verification evidence");
     assert_task_claimed_by ctx ctx.agent_name)
@@ -1710,6 +1712,7 @@ let () = test "transition_submit_for_verification_todo_still_requires_evidence" 
           ])
     in
     assert (not result.Tool_result.success);
+    assert (Tool_result.failure_class result = Some Tool_result.Workflow_rejection);
     assert (str_contains result.Tool_result.legacy_message "requires verification evidence");
     assert_task_todo ctx)
 )


### PR DESCRIPTION
## Summary
- preserve task workflow rejection failure_class through keeper task wrappers and normalized OAS tool results
- map typed Tool_result failure_class into Agent SDK recoverable/error_class so missing verification evidence is deterministic/non-retryable
- keep todo submit_for_verification with PR evidence alias from the existing branch and add regression coverage for evidence-required paths

Fixes #16167

## Verification
- ocamlformat --check lib/tool_bridge.ml lib/tool_bridge.mli lib/tool_types/tool_result.ml lib/keeper/keeper_tools_oas.ml lib/keeper/keeper_tools_oas.mli lib/keeper/keeper_exec_task.ml test/test_tool_bridge_externalize.ml test/test_tool_result.ml test/test_keeper_tools_oas.ml test/test_keeper_task_dispatch.ml test/test_tool_task_coverage.ml
- git diff --check
- focused Dune test attempted, blocked by existing root scripts/dune-local.sh build holding /tmp/me-dune-local.lock