### PR TITLE
fix(keeper): repair docker shell syntax

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -1334,7 +1334,7 @@ let run_docker_shell_command_with_status_internal
                                   "docker_shell_failed: unix_error: %s: %s(%s)"
                                   (Unix.error_message code)
                                   fn
-                                  arg)))))))))
+                                  arg))))))))
 ;;
 
 let run_docker_shell_command_with_status =


### PR DESCRIPTION
## Summary
- remove the extra closing paren in keeper_shell_docker introduced around the docker shell error path
- restores parsing for lib/keeper/keeper_shell_docker.ml on current main

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_shell_docker.ml
- git diff --check HEAD~1..HEAD
- scripts/dune-local.sh build lib/keeper/keeper_shell_docker.cmx is queued behind an existing local Dune lock