### PR TITLE
[codex] Expose keeper cascade attempt facts

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -659,17 +659,48 @@ let runtime_blocker_surface_opt (config : Coord_utils.config) (meta : keeper_met
   derived
 ;;
 
+let cascade_attempt_outcome_json = function
+  | `Success -> `Assoc [ "kind", `String "success"; "detail", `Null ]
+  | `Failure detail ->
+    `Assoc [ "kind", `String "failure"; "detail", `String detail ]
+;;
+
+let cascade_attempt_record_json (attempt : cascade_attempt_record) =
+  `Assoc
+    [ "provider_id", `String attempt.provider_id
+    ; "http_status", Json_util.int_opt_to_json attempt.http_status
+    ; "outcome", cascade_attempt_outcome_json attempt.outcome
+    ; "timestamp_unix", `Float attempt.timestamp
+    ]
+;;
+
+let last_cascade_attempt_json (meta : keeper_meta) =
+  match meta.runtime.last_cascade_attempt with
+  | None -> `Null
+  | Some attempt -> cascade_attempt_record_json attempt
+;;
+
+let runtime_blocker_facts_json (meta : keeper_meta) =
+  `Assoc
+    [ "source", `String "keeper_runtime.last_cascade_attempt"
+    ; "cascade_name", `String (cascade_name_of_meta meta)
+    ; "last_cascade_attempt", last_cascade_attempt_json meta
+    ]
+;;
+
 let runtime_blocker_fields_json (config : Coord_utils.config) (meta : keeper_meta) =
   match runtime_blocker_surface_opt config meta with
   | Some blocker ->
     [ "runtime_blocker_class", `String blocker.blocker_class
     ; "runtime_blocker_summary", `String blocker.summary
     ; "runtime_blocker_continue_gate", `Bool blocker.continue_gate
+    ; "runtime_blocker_facts", runtime_blocker_facts_json meta
     ]
   | None ->
     [ "runtime_blocker_class", `Null
     ; "runtime_blocker_summary", `Null
     ; "runtime_blocker_continue_gate", `Bool false
+    ; "runtime_blocker_facts", `Null
     ]
 ;;
 
@@ -846,6 +877,7 @@ let runtime_surface_json config (meta : keeper_meta) =
          | Some p -> `String p
          | None -> `Null )
      ; "fiber_health", `String (Keeper_exec_status.string_of_fiber_health fiber_health)
+     ; "last_cascade_attempt", last_cascade_attempt_json meta
      ]
      @ social_runtime_fields_json meta
      @ runtime_state_fields_json config meta

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -936,6 +936,52 @@ let test_runtime_surface_maps_registry_failure_reason_blockers () =
          (runtime |> member "needs_attention" |> to_bool))
     cases
 
+let test_runtime_surface_exposes_cascade_attempt_facts () =
+  KR.clear ();
+  let attempt : KT.cascade_attempt_record =
+    { provider_id = "runpod_mtp.qwen36-35b-a3b-mtp.keeper"
+    ; http_status = Some 524
+    ; outcome = `Failure "connection closed by peer"
+    ; timestamp = 1_768_600_000.25
+    }
+  in
+  let base =
+    make_meta ~name:"runtime-cascade-attempt-facts-test" ()
+    |> KT.set_cascade_name "tier-group.strict_tool_candidates"
+  in
+  let meta =
+    { base with
+      runtime = { base.runtime with last_cascade_attempt = Some attempt }
+    }
+  in
+  let config =
+    Coord.default_config "/tmp/test-keeper-exec-status-cascade-attempt-facts"
+  in
+  ignore (KR.register ~base_path:config.base_path meta.name meta);
+  KR.set_failure_reason ~base_path:config.base_path meta.name
+    (Some (KR.Turn_consecutive_failures 2));
+  let runtime = KSB.runtime_surface_json config meta in
+  let open Yojson.Safe.Util in
+  let facts = runtime |> member "runtime_blocker_facts" in
+  check string "facts source" "keeper_runtime.last_cascade_attempt"
+    (facts |> member "source" |> to_string);
+  check string "facts cascade" "tier-group.strict_tool_candidates"
+    (facts |> member "cascade_name" |> to_string);
+  let last_attempt = facts |> member "last_cascade_attempt" in
+  check string "attempt provider_id" attempt.provider_id
+    (last_attempt |> member "provider_id" |> to_string);
+  check int "attempt http_status" 524
+    (last_attempt |> member "http_status" |> to_int);
+  check string "attempt outcome kind" "failure"
+    (last_attempt |> member "outcome" |> member "kind" |> to_string);
+  check string "attempt outcome detail" "connection closed by peer"
+    (last_attempt |> member "outcome" |> member "detail" |> to_string);
+  check (float 0.000001) "attempt timestamp" attempt.timestamp
+    (last_attempt |> member "timestamp_unix" |> to_float);
+  let runtime_last_attempt = runtime |> member "last_cascade_attempt" in
+  check string "runtime carries same provider_id" attempt.provider_id
+    (runtime_last_attempt |> member "provider_id" |> to_string)
+
 let test_runtime_surface_classifies_progress_narrative_blockers () =
   let cases =
     [
@@ -1230,6 +1276,8 @@ let () =
             test_runtime_surface_maps_heartbeat_failure_reason;
           test_case "runtime surface maps registry failure blockers" `Quick
             test_runtime_surface_maps_registry_failure_reason_blockers;
+          test_case "runtime surface exposes cascade attempt facts" `Quick
+            test_runtime_surface_exposes_cascade_attempt_facts;
           test_case "runtime surface classifies progress narrative blockers"
             `Quick
             test_runtime_surface_classifies_progress_narrative_blockers;


### PR DESCRIPTION
## Summary
- expose the keeper runtime `last_cascade_attempt` as structured runtime facts
- add `runtime_blocker_facts` without provider-name heuristics or RunPod-specific classification
- cover the runtime JSON shape with a focused status-surface test

## Validation
- `ocamlformat --check lib/keeper/keeper_status_bridge.ml test/test_keeper_exec_status.ml`
- `git diff --check HEAD~1 HEAD`
- `scripts/dune-local.sh build test/test_keeper_exec_status.exe` was not completed locally because `/tmp/me-dune-local.lock` was held by other worktrees

## Notes
This keeps provider identity as producer-side evidence from `keeper_runtime.last_cascade_attempt`; the status layer does not infer RunPod-only mode from labels.