### PR TITLE
fix(exec): preserve sandbox pipeline stdin

### DIFF
--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -44,7 +44,7 @@ let resolve_env env_bindings =
    [Exec_gate] (no behavior change for non-keeper callers); the Docker
    case is wired up by [lib/keeper] using a closure over
    [Keeper_turn_sandbox_runtime]. *)
-let dispatch_simple (s : Shell_ir.simple) =
+let dispatch_simple ?stdin_content (s : Shell_ir.simple) =
   let bin = Bin.to_string s.bin in
   let argv = bin :: List.map resolve_arg s.args in
   let env = resolve_env s.env in
@@ -58,11 +58,19 @@ let dispatch_simple (s : Shell_ir.simple) =
   | Host ->
       let raw_source = String.concat " " argv in
       (match
-         Exec_gate.run_argv_with_status_split
-           ~actor:`Tool_local_runtime
-           ~raw_source
-           ~summary:"exec dispatch simple"
-           ~timeout_sec ~env ?cwd argv
+         match stdin_content with
+         | None ->
+           Exec_gate.run_argv_with_status_split
+             ~actor:`Tool_local_runtime
+             ~raw_source
+             ~summary:"exec dispatch simple"
+             ~timeout_sec ~env ?cwd argv
+         | Some stdin_content ->
+           Exec_gate.run_argv_with_stdin_and_status_split
+             ~actor:`Tool_local_runtime
+             ~raw_source
+             ~summary:"exec dispatch simple stdin"
+             ~timeout_sec ~env ?cwd ~stdin_content argv
        with
        | exception exn ->
            { status = Unix.WEXITED 1;
@@ -71,7 +79,7 @@ let dispatch_simple (s : Shell_ir.simple) =
        | (status, stdout, stderr) ->
            { status; stdout; stderr })
   | Docker { runner; _ } ->
-      (match runner ~argv ~env ~cwd ~timeout_sec with
+      (match runner ~stdin_content ~argv ~env ~cwd ~timeout_sec with
        | exception exn ->
            { status = Unix.WEXITED 1;
              stdout = "";
@@ -90,52 +98,17 @@ let rec dispatch_pipeline stages =
       let rec chain prev_stdout = function
         | [] ->
             { status = Unix.WEXITED 0; stdout = prev_stdout; stderr = "" }
-        | [ Shell_ir.Simple s ] ->
-            let bin = Bin.to_string s.bin in
-            let argv = bin :: List.map resolve_arg s.args in
-            let env = resolve_env s.env in
-            (match
-               let raw_source = String.concat " " argv in
-               Exec_gate.run_argv_with_stdin_and_status_split
-                 ~actor:`Tool_local_runtime
-                 ~raw_source
-                 ~summary:"exec dispatch pipeline stage"
-                 ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Dispatch ()) ~env
-                 ~stdin_content:prev_stdout argv
-             with
-            | exception exn ->
-                { status = Unix.WEXITED 1;
-                  stdout = "";
-                  stderr = Printexc.to_string exn }
-            | (status, stdout, stderr) ->
-                { status; stdout; stderr })
+        | [ Shell_ir.Simple s ] -> dispatch_simple ~stdin_content:prev_stdout s
         | Shell_ir.Simple s :: rest ->
-            let bin = Bin.to_string s.bin in
-            let argv = bin :: List.map resolve_arg s.args in
-            let env = resolve_env s.env in
-            (match
-               let raw_source = String.concat " " argv in
-               Exec_gate.run_argv_with_stdin_and_status_split
-                 ~actor:`Tool_local_runtime
-                 ~raw_source
-                 ~summary:"exec dispatch pipeline stage"
-                 ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Dispatch ()) ~env
-                 ~stdin_content:prev_stdout argv
-             with
-            | exception exn ->
-                { status = Unix.WEXITED 1;
-                  stdout = "";
-                  stderr = Printexc.to_string exn }
-            | (status, stdout, stderr) ->
-                let last_status = status in
-                let result = chain stdout rest in
-                let final_status =
-                  match last_status with
-                  | Unix.WEXITED 0 -> result.status
-                  | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
-                      last_status
-                in
-                { result with status = final_status })
+            let stage_result = dispatch_simple ~stdin_content:prev_stdout s in
+            let result = chain stage_result.stdout rest in
+            let final_status =
+              match stage_result.status with
+              | Unix.WEXITED 0 -> result.status
+              | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
+                  stage_result.status
+            in
+            { result with status = final_status }
         | Pipeline _ :: _ ->
             { status = Unix.WEXITED 1;
               stdout = "";

--- a/lib/exec/exec_dispatch.mli
+++ b/lib/exec/exec_dispatch.mli
@@ -12,8 +12,11 @@ val dispatch : Shell_ir.t -> dispatch_result
     going through /bin/bash.  Simple commands use argv-based spawn;
     pipelines chain stdout to stdin across stages. *)
 
-val dispatch_simple : Shell_ir.simple -> dispatch_result
-(** Execute a simple command via argv-based spawn. *)
+val dispatch_simple :
+  ?stdin_content:string -> Shell_ir.simple -> dispatch_result
+(** Execute a simple command via argv-based spawn.  [stdin_content] is
+    used by pipeline dispatch when a previous stage's stdout must be
+    forwarded without dropping the stage's sandbox target. *)
 
 val native_dispatch_enabled : unit -> bool
 (** Check [MASC_BASH_NATIVE_DISPATCH] env var.

--- a/lib/exec/sandbox_target.ml
+++ b/lib/exec/sandbox_target.ml
@@ -31,6 +31,7 @@
    [runner]. *)
 
 type runner =
+  stdin_content:string option ->
   argv:string list ->
   env:string array ->
   cwd:string option ->

--- a/lib/exec/sandbox_target.mli
+++ b/lib/exec/sandbox_target.mli
@@ -15,6 +15,7 @@
     Exceptions are propagated; callers in [Exec_dispatch] catch and
     translate them into structured dispatch results. *)
 type runner =
+  stdin_content:string option ->
   argv:string list ->
   env:string array ->
   cwd:string option ->

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -1034,6 +1034,199 @@ let bash_shape_block_result ~cmd ~cmd_for_log ~env_snapshot block =
        ~env_snapshot
        ())
 
+let has_typed_bash_input_key = function
+  | `Assoc fields ->
+    List.exists
+      (fun (key, _) ->
+         String.equal key "executable"
+         || String.equal key "pipeline"
+         || String.equal key "stages")
+      fields
+  | _ -> false
+
+let assoc_upsert key value = function
+  | `Assoc fields ->
+    `Assoc ((key, value) :: List.filter (fun (k, _) -> not (String.equal k key)) fields)
+  | other -> other
+
+let shell_quote_for_policy token =
+  let safe_char = function
+    | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '-' | '.' | '/' | ':' | '=' | ',' ->
+      true
+    | _ -> false
+  in
+  if String.length token > 0 && String.for_all safe_char token
+  then token
+  else
+    let parts = String.split_on_char '\'' token in
+    "'" ^ String.concat "'\\''" parts ^ "'"
+
+let typed_stage_command_text ~executable ~argv =
+  executable :: argv
+  |> List.map shell_quote_for_policy
+  |> String.concat " "
+
+let typed_input_command_text = function
+  | Keeper_tool_bash_input.Exec { executable; argv; _ } ->
+    typed_stage_command_text ~executable ~argv
+  | Keeper_tool_bash_input.Pipeline { stages; _ } ->
+    stages
+    |> List.map (fun (stage : Keeper_tool_bash_input.exec_stage) ->
+      typed_stage_command_text ~executable:stage.executable ~argv:stage.argv)
+    |> String.concat " | "
+
+let typed_validation_error_text error =
+  Format.asprintf "%a" Keeper_tool_bash_input.pp_validation_error error
+
+let normalize_path_for_keeper_bash_containment path =
+  Keeper_alerting_path.normalize_path_for_check path
+  |> Keeper_alerting_path.strip_trailing_slashes
+
+let handle_keeper_bash_typed
+      ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t)
+      ~timeout_sec
+      ~run_in_background
+      ~write_enabled
+      ()
+  =
+  ignore turn_sandbox_factory;
+  let root = Keeper_alerting_path.project_root_of_config config in
+  if run_in_background
+  then
+    error_json
+      ~fields:[ "typed", `Bool true ]
+      "typed keeper_bash does not support run_in_background yet; use legacy cmd or foreground typed exec"
+  else if meta.sandbox_profile = Docker
+  then
+    error_json
+      ~fields:[ "typed", `Bool true ]
+      "typed keeper_bash Shell IR dispatch for Docker is not enabled yet; use legacy cmd until the Docker runner carries stdin/cwd through pipeline stages"
+  else
+    match Keeper_shell_shared.resolve_keeper_shell_write_cwd ~config ~meta ~args with
+    | Error e -> error_json e
+    | Ok cwd ->
+      let typed_args = assoc_upsert "cwd" (`String cwd) args in
+      match Keeper_tool_bash_input.of_json typed_args with
+      | Error e ->
+        error_json
+          ~fields:[ "typed", `Bool true; "cwd", `String cwd ]
+          e
+      | Ok input ->
+        let cmd = typed_input_command_text input in
+        let cmd_for_log =
+          cmd
+          |> Worker_dev_tools.sanitize_command_for_log
+          |> Worker_dev_tools.truncate_for_log
+        in
+        let mode =
+          if write_enabled
+          then Keeper_tool_bash_input.Dev_full
+          else Keeper_tool_bash_input.Readonly
+        in
+        let in_playground =
+          let cwd_canonical = normalize_path_for_keeper_bash_containment cwd in
+          let playground_rel = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
+          let playground_abs =
+            normalize_path_for_keeper_bash_containment
+              (Filename.concat root playground_rel)
+          in
+          String.starts_with ~prefix:(playground_abs ^ "/") (cwd_canonical ^ "/")
+          || String.equal playground_abs cwd_canonical
+        in
+        let sandbox_profile, _sandbox_network_mode =
+          Keeper_shell_shared.effective_sandbox_profile ~meta ~in_playground
+        in
+        if sandbox_profile = Docker
+        then
+          error_json
+            ~fields:[ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]
+            "typed keeper_bash Shell IR dispatch for Docker is not enabled yet; use legacy cmd until the Docker runner carries stdin/cwd through pipeline stages"
+        else if Worker_dev_tools.is_destructive_bash_operation cmd
+        then
+          Yojson.Safe.to_string
+            (Exec_core.blocked_result_json
+               ~cmd
+               ~error:"destructive_operation_blocked"
+               ~reason:
+                 "This typed command is destructive and is blocked for all presets."
+               ~alternatives:[ "Use a non-destructive command or a dedicated structured tool." ]
+               ~retryability:Exec_core.Operator_required
+               ~extra:[ "cmd", `String cmd_for_log; "typed", `Bool true; "execution_time_ms", `Int 0 ]
+               ())
+        else if (not write_enabled) && Worker_dev_tools.is_write_operation cmd
+        then
+          Yojson.Safe.to_string
+            (Exec_core.blocked_result_json
+               ~cmd
+               ~error:"write_operation_gated"
+               ~reason:
+                 "This typed command modifies state. A write-enabled preset is required."
+               ~alternatives:
+                 [ "Use read-only commands such as rg, cat, ls, git status, or git log."
+                 ; "Ask the operator for a write-enabled preset."
+                 ]
+               ~retryability:Exec_core.Operator_required
+               ~extra:[ "cmd", `String cmd_for_log; "typed", `Bool true; "execution_time_ms", `Int 0 ]
+               ())
+        else
+          match Keeper_tool_bash_input.to_shell_ir ~mode input with
+          | Error e ->
+            error_json
+              ~fields:[ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]
+              (typed_validation_error_text e)
+          | Ok ir ->
+            let path_validation =
+              match
+                Keeper_task_worktree_lazy.ensure_command_existing_dirs
+                  ~config ~meta ~cwd ~cmd
+              with
+              | Error e -> Error e
+              | Ok () ->
+                Worker_dev_tools.validate_command_paths
+                  ~keeper_id:meta.name
+                  ~base_path:root
+                  ~workdir:cwd
+                  cmd
+            in
+            (match path_validation with
+             | Error e -> error_json ~fields:[ "blocked_cmd", `String cmd_for_log ] e
+             | Ok () ->
+               let env_snap =
+                 Cancel_safe.protect
+                   ~on_exn:(fun _ -> None)
+                   (fun () -> Some (Exec_core.snapshot_env ~cwd))
+               in
+               let t0 = Unix.gettimeofday () in
+               let result = Masc_exec.Exec_dispatch.dispatch ir in
+               let elapsed_ms =
+                 elapsed_duration_ms
+                   ~start_time:t0
+                   ~end_time:(Unix.gettimeofday ())
+               in
+               let output =
+                 if String.equal result.stderr ""
+                 then result.stdout
+                 else result.stdout ^ result.stderr
+               in
+               Yojson.Safe.to_string
+                 (Exec_core.process_result_json
+                    ~base_path:root
+                    ~keeper_name:meta.name
+                    ~cmd
+                    ~extra:
+                      [ "cwd", `String cwd
+                      ; "typed", `Bool true
+                      ; "execution_time_ms", `Int elapsed_ms
+                      ; "timeout_sec", `Float timeout_sec
+                      ]
+                    ~status:result.status
+                    ~output
+                    ~env_snapshot:env_snap
+                    ()))
+
 let handle_keeper_bash
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(turn_sandbox_factory_git : Keeper_sandbox_factory.t option)
@@ -1172,13 +1365,24 @@ let handle_keeper_bash
          ~extra:[ "cmd", `String cmd_for_log; "execution_time_ms", `Int 0 ]
          ())
   in
-  if cmd = ""
-  then error_json "cmd is required. Good: cmd='ls -la lib/'. Bad: cmd=''."
-  else if Env_config_keeper.KeeperSandbox.hard_mode ()
-          && meta.sandbox_profile <> Docker
+  if Env_config_keeper.KeeperSandbox.hard_mode ()
+     && meta.sandbox_profile <> Docker
   then
     error_json
       "MASC_KEEPER_SANDBOX_HARD_MODE requires sandbox_profile=docker"
+  else if cmd = "" && has_typed_bash_input_key args
+  then
+    handle_keeper_bash_typed
+      ~turn_sandbox_factory
+      ~config
+      ~meta
+      ~args
+      ~timeout_sec
+      ~run_in_background
+      ~write_enabled
+      ()
+  else if cmd = ""
+  then error_json "cmd is required. Good: cmd='ls -la lib/'. Bad: cmd=''."
   else (
     match direct_tool_command_name ~meta cmd with
     | Some (tool_name, tool_policy_visible) ->

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -1334,7 +1334,7 @@ let run_docker_shell_command_with_status_internal
                                   "docker_shell_failed: unix_error: %s: %s(%s)"
                                   (Unix.error_message code)
                                   fn
-                                  arg)))))))))
+                                  arg))))))))
 ;;
 
 let run_docker_shell_command_with_status =

--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -138,9 +138,9 @@ let optional_env ~path fields =
       (json_type_name value)
 ;;
 
-let parse_stage ~index (value : Yojson.Safe.t) =
+let parse_stage ~path_prefix ~index (value : Yojson.Safe.t) =
   let ( let* ) = Result.bind in
-  let path = Printf.sprintf "$.pipeline[%d]" index in
+  let path = Printf.sprintf "%s[%d]" path_prefix index in
   let* fields = assoc_fields ~path value in
   let* executable = required_string ~path fields "executable" in
   let* argv = optional_string_list ~path fields "argv" in
@@ -154,7 +154,7 @@ let parse_pipeline ~path (json : Yojson.Safe.t) =
     let rec loop index acc = function
       | [] -> Ok (List.rev acc)
       | value :: rest ->
-        let* stage = parse_stage ~index value in
+        let* stage = parse_stage ~path_prefix:path ~index value in
         loop (index + 1) (stage :: acc) rest
     in
     loop 0 [] values
@@ -193,7 +193,7 @@ let of_json (json : Yojson.Safe.t) =
       Error
         "legacy cmd string is not a typed keeper_bash input; provide \
          executable/argv or pipeline stages"
-    else Error "$.executable or $.pipeline is required"
+    else Error "$.executable or $.pipeline/$.stages is required"
 ;;
 
 (* Execve-style: argv tokens pass verbatim to the child process, so

--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -165,6 +165,14 @@ let parse_pipeline ~path (json : Yojson.Safe.t) =
 let of_json (json : Yojson.Safe.t) =
   let ( let* ) = Result.bind in
   let* fields = assoc_fields ~path:"$" json in
+  let* () =
+    if Option.is_some (member fields "cmd")
+    then
+      Error
+        "legacy cmd string is not a typed keeper_bash input; provide \
+         executable/argv or pipeline stages"
+    else Ok ()
+  in
   let executable_present = Option.is_some (member fields "executable") in
   let pipeline_value =
     match member fields "pipeline", member fields "stages" with
@@ -187,13 +195,7 @@ let of_json (json : Yojson.Safe.t) =
   | false, Some (path, value) ->
     let* stages = parse_pipeline ~path value in
     Ok (Pipeline { stages; cwd; env })
-  | false, None ->
-    if Option.is_some (member fields "cmd")
-    then
-      Error
-        "legacy cmd string is not a typed keeper_bash input; provide \
-         executable/argv or pipeline stages"
-    else Error "$.executable or $.pipeline/$.stages is required"
+  | false, None -> Error "$.executable or $.pipeline/$.stages is required"
 ;;
 
 (* Execve-style: argv tokens pass verbatim to the child process, so

--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -42,6 +42,160 @@ let is_allowed ~mode name =
   | Readonly -> Dev_exec_allowlist.is_readonly_allowed name
 ;;
 
+let json_type_name (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc _ -> "object"
+  | `Bool _ -> "boolean"
+  | `Float _ -> "number"
+  | `Int _ -> "integer"
+  | `Intlit _ -> "integer"
+  | `List _ -> "array"
+  | `Null -> "null"
+  | `String _ -> "string"
+;;
+
+let result_errorf fmt = Printf.ksprintf (fun msg -> Error msg) fmt
+
+let assoc_fields ~path (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields -> Ok fields
+  | value ->
+    result_errorf
+      "%s must be object, got %s"
+      path
+      (json_type_name value)
+;;
+
+let member fields key = List.assoc_opt key fields
+
+let required_string ~path fields key =
+  match member fields key with
+  | Some (`String value) -> Ok value
+  | Some value ->
+    result_errorf
+      "%s.%s must be string, got %s"
+      path
+      key
+      (json_type_name value)
+  | None -> result_errorf "%s.%s is required" path key
+;;
+
+let optional_string ~path fields key =
+  match member fields key with
+  | None | Some `Null -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some value ->
+    result_errorf
+      "%s.%s must be string, got %s"
+      path
+      key
+      (json_type_name value)
+;;
+
+let optional_string_list ~path fields key =
+  match member fields key with
+  | None | Some `Null -> Ok []
+  | Some (`List values) ->
+    let rec loop index acc = function
+      | [] -> Ok (List.rev acc)
+      | `String value :: rest -> loop (index + 1) (value :: acc) rest
+      | value :: _ ->
+        result_errorf
+          "%s.%s[%d] must be string, got %s"
+          path
+          key
+          index
+          (json_type_name value)
+    in
+    loop 0 [] values
+  | Some value ->
+    result_errorf
+      "%s.%s must be array, got %s"
+      path
+      key
+      (json_type_name value)
+;;
+
+let optional_env ~path fields =
+  match member fields "env" with
+  | None | Some `Null -> Ok []
+  | Some (`Assoc bindings) ->
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | (key, `String value) :: rest -> loop ((key, value) :: acc) rest
+      | (key, value) :: _ ->
+        result_errorf
+          "%s.env.%s must be string, got %s"
+          path
+          key
+          (json_type_name value)
+    in
+    loop [] bindings
+  | Some value ->
+    result_errorf
+      "%s.env must be object, got %s"
+      path
+      (json_type_name value)
+;;
+
+let parse_stage ~index (value : Yojson.Safe.t) =
+  let ( let* ) = Result.bind in
+  let path = Printf.sprintf "$.pipeline[%d]" index in
+  let* fields = assoc_fields ~path value in
+  let* executable = required_string ~path fields "executable" in
+  let* argv = optional_string_list ~path fields "argv" in
+  Ok { executable; argv }
+;;
+
+let parse_pipeline ~path (json : Yojson.Safe.t) =
+  match json with
+  | `List values ->
+    let ( let* ) = Result.bind in
+    let rec loop index acc = function
+      | [] -> Ok (List.rev acc)
+      | value :: rest ->
+        let* stage = parse_stage ~index value in
+        loop (index + 1) (stage :: acc) rest
+    in
+    loop 0 [] values
+  | value ->
+    result_errorf "%s must be array, got %s" path (json_type_name value)
+;;
+
+let of_json (json : Yojson.Safe.t) =
+  let ( let* ) = Result.bind in
+  let* fields = assoc_fields ~path:"$" json in
+  let executable_present = Option.is_some (member fields "executable") in
+  let pipeline_value =
+    match member fields "pipeline", member fields "stages" with
+    | Some _, Some _ ->
+      Error "$ must not provide both pipeline and stages"
+    | Some value, None -> Ok (Some ("$.pipeline", value))
+    | None, Some value -> Ok (Some ("$.stages", value))
+    | None, None -> Ok None
+  in
+  let* pipeline_value = pipeline_value in
+  let* cwd = optional_string ~path:"$" fields "cwd" in
+  let* env = optional_env ~path:"$" fields in
+  match executable_present, pipeline_value with
+  | true, Some _ ->
+    Error "$ must provide either executable or pipeline/stages, not both"
+  | true, None ->
+    let* executable = required_string ~path:"$" fields "executable" in
+    let* argv = optional_string_list ~path:"$" fields "argv" in
+    Ok (Exec { executable; argv; cwd; env })
+  | false, Some (path, value) ->
+    let* stages = parse_pipeline ~path value in
+    Ok (Pipeline { stages; cwd; env })
+  | false, None ->
+    if Option.is_some (member fields "cmd")
+    then
+      Error
+        "legacy cmd string is not a typed keeper_bash input; provide \
+         executable/argv or pipeline stages"
+    else Error "$.executable or $.pipeline is required"
+;;
+
 (* Execve-style: argv tokens pass verbatim to the child process, so
    shell metacharacters ([;|&><`$*?]) are literal data, not operators.
    Only control characters that cannot survive process-boundary

--- a/lib/keeper/keeper_tool_bash_input.mli
+++ b/lib/keeper/keeper_tool_bash_input.mli
@@ -72,6 +72,12 @@ type validation_error =
   | Pipeline_too_short
   | Env_key_invalid of string
 
+val of_json : Yojson.Safe.t -> (bash_input, string) result
+(** Parse the typed keeper_bash JSON boundary.  Accepts either
+    [{executable, argv?, cwd?, env?}] for [Exec] or
+    [{pipeline = [{executable, argv?}, ...], cwd?, env?}] for [Pipeline].
+    Legacy [{cmd: string}] input is intentionally rejected here. *)
+
 val validate : mode:allowlist_mode -> bash_input -> (unit, validation_error) result
 (** Run all structural checks against [input].  Returns [Ok ()] on
     success, or the first {!validation_error} encountered.  No side

--- a/lib/keeper/keeper_tool_bash_input.mli
+++ b/lib/keeper/keeper_tool_bash_input.mli
@@ -76,6 +76,7 @@ val of_json : Yojson.Safe.t -> (bash_input, string) result
 (** Parse the typed keeper_bash JSON boundary.  Accepts either
     [{executable, argv?, cwd?, env?}] for [Exec] or
     [{pipeline = [{executable, argv?}, ...], cwd?, env?}] for [Pipeline].
+    [{stages = ...}] is accepted as an equivalent structured pipeline key.
     Legacy [{cmd: string}] input is intentionally rejected here. *)
 
 val validate : mode:allowlist_mode -> bash_input -> (unit, validation_error) result

--- a/lib/tool_shard_types_schemas_bash.ml
+++ b/lib/tool_shard_types_schemas_bash.ml
@@ -1,14 +1,41 @@
 (** Tool_shard_types_schemas_bash — [coding_keeper_bridge_tools] keeper_bash + keeper_bash_output + keeper_bash_kill schemas. *)
 
+let keeper_bash_exec_stage_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; ( "properties"
+      , `Assoc
+          [ ( "executable"
+            , `Assoc
+                [ "type", `String "string"
+                ; ( "description"
+                  , `String "Allowlisted executable name, e.g. rg, sed, sort, head." )
+                ] )
+          ; ( "argv"
+            , `Assoc
+                [ "type", `String "array"
+                ; "items", `Assoc [ "type", `String "string" ]
+                ; ( "description"
+                  , `String
+                      "Arguments passed verbatim to executable. Shell metacharacters \
+                       are data; use pipeline/stages for pipes." )
+                ] )
+          ] )
+    ; "required", `List [ `String "executable" ]
+    ]
+;;
+
 let coding_keeper_bridge_tools : Masc_domain.tool_schema list =
   [ { name = "keeper_bash"
     ; description =
-        "Execute ONE shell command through the keeper_bash safety gates. No \
+        "Execute one command through the keeper_bash safety gates. Legacy cmd remains \
+         accepted during the typed-argv migration; prefer executable/argv for one \
+         process or pipeline/stages for explicit Shell IR pipelines. No \
          chaining/control syntax (&&, ||, ;), command substitution, background \
-         operators, or file redirects. Pipelines and fd-only redirects are accepted only \
-         when the active preset validator allows every segment. Good: cmd='scripts/dune-local.sh build', \
-         cmd='ls -la lib/'. Bad: cmd='cd x && dune build', cmd='echo hi > out.txt'. Runs \
-         in the keeper sandbox by default; use cwd to target an explicit allowed \
+         operators, or file redirects. Good: cmd='scripts/dune-local.sh build', \
+         executable='rg' argv=['pattern','lib/'], pipeline=[{executable='rg',...}, \
+         {executable='head',...}]. Bad: cmd='cd x && dune build', cmd='echo hi > \
+         out.txt'. Runs in the keeper sandbox by default; use cwd to target an explicit allowed \
          directory. Paths resolve automatically — never include host storage prefixes \
          such as '.masc/playground/your-name/' in cwd. Use 'repos/X' instead. Sandbox \
          root is NOT a git repository: git/gh calls require cwd='repos/<REPO_NAME>' (or \
@@ -29,6 +56,50 @@ let coding_keeper_bridge_tools : Masc_domain.tool_schema list =
                         , `String
                             "Single command only. No chaining/control syntax or file \
                              redirects. Example: 'scripts/dune-local.sh build', 'rg pattern lib/'" )
+                      ] )
+                ; ( "executable"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Typed argv form: allowlisted executable name. Provide argv \
+                             separately; do not combine shell syntax into this field." )
+                      ] )
+                ; ( "argv"
+                  , `Assoc
+                      [ "type", `String "array"
+                      ; "items", `Assoc [ "type", `String "string" ]
+                      ; ( "description"
+                        , `String
+                            "Typed argv form: arguments passed verbatim to executable. \
+                             A literal '|' token is data, not a pipe." )
+                      ] )
+                ; ( "pipeline"
+                  , `Assoc
+                      [ "type", `String "array"
+                      ; "items", keeper_bash_exec_stage_schema
+                      ; ( "description"
+                        , `String
+                            "Typed pipeline form: ordered exec stages. Use this instead \
+                             of putting '|' in argv or cmd." )
+                      ] )
+                ; ( "stages"
+                  , `Assoc
+                      [ "type", `String "array"
+                      ; "items", keeper_bash_exec_stage_schema
+                      ; ( "description"
+                        , `String
+                            "Alias for pipeline. Each stage has executable and optional \
+                             argv." )
+                      ] )
+                ; ( "env"
+                  , `Assoc
+                      [ "type", `String "object"
+                      ; "additionalProperties", `Assoc [ "type", `String "string" ]
+                      ; ( "description"
+                        , `String
+                            "Optional typed environment bindings. Keys must be \
+                             [A-Za-z0-9_]+ and values are strings." )
                       ] )
                 ; ( "cwd"
                   , `Assoc
@@ -56,7 +127,13 @@ let coding_keeper_bridge_tools : Masc_domain.tool_schema list =
                              stop via keeper_bash_kill." )
                       ] )
                 ] )
-          ; "required", `List [ `String "cmd" ]
+          ; ( "oneOf"
+            , `List
+                [ `Assoc [ "required", `List [ `String "cmd" ] ]
+                ; `Assoc [ "required", `List [ `String "executable" ] ]
+                ; `Assoc [ "required", `List [ `String "pipeline" ] ]
+                ; `Assoc [ "required", `List [ `String "stages" ] ]
+                ] )
           ]
     }
   ; { name = "keeper_bash_output"

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -135,7 +135,7 @@ let () =
   let runner_argv = ref [] in
   let runner_env = ref [||] in
   let runner_cwd = ref (Some "should_be_none") in
-  let mock_runner ~argv ~env ~cwd ~timeout_sec:_ =
+  let mock_runner ~stdin_content:_ ~argv ~env ~cwd ~timeout_sec:_ =
     runner_called := true;
     runner_argv := argv;
     runner_env := env;
@@ -169,13 +169,64 @@ let () =
    | Masc_exec.Sandbox_target.Docker { image; _ } ->
        assert (image = "test-image"))
 
+(* --- dispatch_pipeline propagates stdin and sandbox runner --- *)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let printf_bin = Masc_exec.Bin.of_string "printf" |> Result.get_ok in
+  let wc_bin = Masc_exec.Bin.of_string "wc" |> Result.get_ok in
+  let runner_calls = ref [] in
+  let mock_runner ~stdin_content ~argv ~env:_ ~cwd ~timeout_sec:_ =
+    runner_calls := (argv, cwd, stdin_content) :: !runner_calls;
+    match argv, stdin_content with
+    | [ "printf"; "typed" ], None -> Unix.WEXITED 0, "typed", ""
+    | [ "wc"; "-c" ], Some "typed" -> Unix.WEXITED 0, "5\n", ""
+    | _ -> Unix.WEXITED 2, "", "unexpected mock runner call"
+  in
+  let docker_sandbox =
+    Masc_exec.Sandbox_target.docker ~image:"pipeline-image" ~runner:mock_runner
+  in
+  let cwd = Some (Masc_exec.Path_scope.classify ~raw:"/tmp/pipeline" ~cwd:"/tmp/pipeline") in
+  let stages =
+    [
+      Simple
+        {
+          bin = printf_bin;
+          args = [ Lit "typed" ];
+          env = [];
+          cwd;
+          redirects = [];
+          sandbox = docker_sandbox;
+        };
+      Simple
+        {
+          bin = wc_bin;
+          args = [ Lit "-c" ];
+          env = [];
+          cwd;
+          redirects = [];
+          sandbox = docker_sandbox;
+        };
+    ]
+  in
+  let result = Masc_exec.Exec_dispatch.dispatch (Pipeline stages) in
+  assert (result.status = Unix.WEXITED 0);
+  assert (String.trim result.stdout = "5");
+  match List.rev !runner_calls with
+  | [ ([ "printf"; "typed" ], Some first_cwd, None)
+    ; ([ "wc"; "-c" ], Some second_cwd, Some "typed") ] ->
+      assert (first_cwd = "/tmp/pipeline");
+      assert (second_cwd = "/tmp/pipeline")
+  | _ -> assert false
+
 (* --- dispatch_simple exception from runner is caught --- *)
 
 let () =
   with_eio @@ fun () ->
   let open Masc_exec.Shell_ir in
   let bin = Masc_exec.Bin.of_string "echo" |> Result.get_ok in
-  let mock_runner ~argv:_ ~env:_ ~cwd:_ ~timeout_sec:_ =
+  let mock_runner ~stdin_content:_ ~argv:_ ~env:_ ~cwd:_ ~timeout_sec:_ =
     failwith "mock docker failure"
   in
   let docker_sandbox =

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -873,6 +873,112 @@ let parse_error_field raw =
   |> Json.member "error"
   |> Json.to_string_option
 
+let test_keeper_bash_typed_exec_runs_via_shell_ir () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_readonly_meta "typed-exec" in
+  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  ensure_dir playground;
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "printf"
+           ; "argv", `List [ `String "typed-ok" ]
+           ; "cwd", `String playground
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) "typed exec succeeds" true
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check bool) "typed flag" true
+    (json |> Json.member "typed" |> Json.to_bool);
+  Alcotest.(check bool) "output from native argv" true
+    (json
+     |> Json.member "output"
+     |> Json.to_string
+     |> fun output -> String_util.contains_substring output "typed-ok")
+
+let test_keeper_bash_typed_pipeline_runs_via_shell_ir () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_readonly_meta "typed-pipeline" in
+  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  ensure_dir playground;
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ ( "pipeline"
+             , `List
+                 [ `Assoc
+                     [ "executable", `String "printf"
+                     ; "argv", `List [ `String "typed" ]
+                     ]
+                 ; `Assoc
+                     [ "executable", `String "wc"
+                     ; "argv", `List [ `String "-c" ]
+                     ]
+                 ] )
+           ; "cwd", `String playground
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) "typed pipeline succeeds" true
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check bool) "typed flag" true
+    (json |> Json.member "typed" |> Json.to_bool);
+  Alcotest.(check bool) "wc sees piped stdin" true
+    (json
+     |> Json.member "output"
+     |> Json.to_string
+     |> fun output -> String_util.contains_substring output "5")
+
+let test_keeper_bash_typed_docker_is_fail_closed () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_docker_meta "typed-docker" in
+  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  ensure_dir playground;
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "printf"
+           ; "argv", `List [ `String "typed-docker" ]
+           ; "cwd", `String playground
+           ])
+      ()
+  in
+  match parse_error_field raw with
+  | Some err ->
+    Alcotest.(check bool) "docker typed path is explicit" true
+      (String_util.contains_substring err "Docker is not enabled yet")
+  | None -> Alcotest.fail ("expected typed docker fail-closed error, got: " ^ raw)
+
 let test_keeper_bash_safe_dev_null_echo_fallback_executes_primary () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
@@ -1667,6 +1773,14 @@ let () =
         test_docker_allows_gh_pr_create_prose;
       Alcotest.test_case "docker missing seccomp fails closed" `Quick
         test_docker_missing_seccomp_profile_fails_closed;
+    ]);
+    ("typed_shell_ir", [
+      Alcotest.test_case "typed exec runs via Shell IR" `Quick
+        test_keeper_bash_typed_exec_runs_via_shell_ir;
+      Alcotest.test_case "typed pipeline runs via Shell IR" `Quick
+        test_keeper_bash_typed_pipeline_runs_via_shell_ir;
+      Alcotest.test_case "typed docker dispatch fails closed" `Quick
+        test_keeper_bash_typed_docker_is_fail_closed;
     ]);
     ("readonly_hints", [
       Alcotest.test_case "safe dev-null echo fallback executes primary" `Quick

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -257,6 +257,17 @@ let test_of_json_rejects_mixed_exec_and_pipeline () =
     (String_util.contains_substring_ci msg "either executable or pipeline")
 ;;
 
+let test_of_json_stages_alias_reports_stages_path () =
+  let msg =
+    parse_json_error
+      (`Assoc [ "stages", `List [ `Assoc [ "argv", `List [] ] ] ])
+  in
+  Alcotest.(check bool)
+    "error mentions stages path"
+    true
+    (String_util.contains_substring_ci msg "$.stages[0].executable")
+;;
+
 let shell_arg_string = function
   | Masc_exec.Shell_ir.Lit s -> s
   | Masc_exec.Shell_ir.Var name -> "$" ^ name
@@ -385,6 +396,10 @@ let suite =
           "of_json_rejects_mixed_exec_and_pipeline"
           `Quick
           test_of_json_rejects_mixed_exec_and_pipeline
+      ; Alcotest.test_case
+          "of_json_stages_alias_reports_stages_path"
+          `Quick
+          test_of_json_stages_alias_reports_stages_path
       ; Alcotest.test_case
           "pipeline_lowers_to_shell_ir_pipeline"
           `Quick

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -231,6 +231,17 @@ let test_of_json_rejects_legacy_cmd_only () =
     (String_util.contains_substring_ci msg "typed keeper_bash input")
 ;;
 
+let test_of_json_rejects_legacy_cmd_with_exec () =
+  let msg =
+    parse_json_error
+      (`Assoc [ "cmd", `String "rg pattern lib/"; "executable", `String "rg" ])
+  in
+  Alcotest.(check bool)
+    "error mentions typed input"
+    true
+    (String_util.contains_substring_ci msg "typed keeper_bash input")
+;;
+
 let test_of_json_rejects_non_string_argv () =
   let msg =
     parse_json_error
@@ -388,6 +399,10 @@ let suite =
           "of_json_rejects_legacy_cmd_only"
           `Quick
           test_of_json_rejects_legacy_cmd_only
+      ; Alcotest.test_case
+          "of_json_rejects_legacy_cmd_with_exec"
+          `Quick
+          test_of_json_rejects_legacy_cmd_with_exec
       ; Alcotest.test_case
           "of_json_rejects_non_string_argv"
           `Quick

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -36,6 +36,18 @@ let mk_exec executable argv =
   Bash_input.Exec { executable; argv; cwd = None; env = [] }
 ;;
 
+let parse_json_exn json =
+  match Bash_input.of_json json with
+  | Ok input -> input
+  | Error msg -> Alcotest.failf "of_json failed: %s" msg
+;;
+
+let parse_json_error json =
+  match Bash_input.of_json json with
+  | Ok _ -> Alcotest.fail "of_json unexpectedly succeeded"
+  | Error msg -> msg
+;;
+
 type case = {
   name : string;
   legacy_cmd : string;
@@ -157,6 +169,94 @@ let test_pipeline_stage_executable_check () =
     (typed_ok input)
 ;;
 
+let test_of_json_exec () =
+  let input =
+    parse_json_exn
+      (`Assoc
+          [ "executable", `String "rg"
+          ; "argv", `List [ `String "pattern"; `String "lib/" ]
+          ; "cwd", `String "/tmp"
+          ; "env", `Assoc [ "LC_ALL", `String "C" ]
+          ])
+  in
+  match input with
+  | Bash_input.Exec { executable; argv; cwd; env } ->
+    Alcotest.(check string) "executable" "rg" executable;
+    Alcotest.(check (list string)) "argv" [ "pattern"; "lib/" ] argv;
+    Alcotest.(check (option string)) "cwd" (Some "/tmp") cwd;
+    Alcotest.(check (list (pair string string))) "env" [ "LC_ALL", "C" ] env
+  | Bash_input.Pipeline _ -> Alcotest.fail "expected Exec"
+;;
+
+let test_of_json_pipeline () =
+  let input =
+    parse_json_exn
+      (`Assoc
+          [ ( "pipeline"
+            , `List
+                [ `Assoc
+                    [ "executable", `String "printf"
+                    ; "argv", `List [ `String "hello" ]
+                    ]
+                ; `Assoc
+                    [ "executable", `String "wc"
+                    ; "argv", `List [ `String "-c" ]
+                    ]
+                ] )
+          ; "cwd", `String "/tmp"
+          ])
+  in
+  match input with
+  | Bash_input.Pipeline { stages; cwd; env } ->
+    Alcotest.(check int) "stage count" 2 (List.length stages);
+    Alcotest.(check (option string)) "cwd" (Some "/tmp") cwd;
+    Alcotest.(check (list (pair string string))) "env" [] env;
+    (match stages with
+     | [ first; second ] ->
+       Alcotest.(check string) "first executable" "printf" first.executable;
+       Alcotest.(check (list string)) "first argv" [ "hello" ] first.argv;
+       Alcotest.(check string) "second executable" "wc" second.executable;
+       Alcotest.(check (list string)) "second argv" [ "-c" ] second.argv
+     | _ -> Alcotest.fail "expected exactly two stages")
+  | Bash_input.Exec _ -> Alcotest.fail "expected Pipeline"
+;;
+
+let test_of_json_rejects_legacy_cmd_only () =
+  let msg =
+    parse_json_error (`Assoc [ "cmd", `String "rg pattern lib/" ])
+  in
+  Alcotest.(check bool)
+    "error mentions typed input"
+    true
+    (String_util.contains_substring_ci msg "typed keeper_bash input")
+;;
+
+let test_of_json_rejects_non_string_argv () =
+  let msg =
+    parse_json_error
+      (`Assoc
+          [ "executable", `String "echo"; "argv", `List [ `Int 1 ] ])
+  in
+  Alcotest.(check bool)
+    "error mentions argv[0]"
+    true
+    (String_util.contains_substring_ci msg "$.argv[0]")
+;;
+
+let test_of_json_rejects_mixed_exec_and_pipeline () =
+  let msg =
+    parse_json_error
+      (`Assoc
+          [ "executable", `String "echo"
+          ; "pipeline", `List [ `Assoc [ "executable", `String "wc" ] ]
+          ])
+  in
+  Alcotest.(check bool)
+    "error mentions either executable or pipeline"
+    true
+    (String_util.contains_substring_ci msg "either executable or pipeline")
+;;
+
 let shell_arg_string = function
   | Masc_exec.Shell_ir.Lit s -> s
   | Masc_exec.Shell_ir.Var name -> "$" ^ name
@@ -271,6 +371,20 @@ let suite =
           "pipeline_stage_executable_check"
           `Quick
           test_pipeline_stage_executable_check
+      ; Alcotest.test_case "of_json_exec" `Quick test_of_json_exec
+      ; Alcotest.test_case "of_json_pipeline" `Quick test_of_json_pipeline
+      ; Alcotest.test_case
+          "of_json_rejects_legacy_cmd_only"
+          `Quick
+          test_of_json_rejects_legacy_cmd_only
+      ; Alcotest.test_case
+          "of_json_rejects_non_string_argv"
+          `Quick
+          test_of_json_rejects_non_string_argv
+      ; Alcotest.test_case
+          "of_json_rejects_mixed_exec_and_pipeline"
+          `Quick
+          test_of_json_rejects_mixed_exec_and_pipeline
       ; Alcotest.test_case
           "pipeline_lowers_to_shell_ir_pipeline"
           `Quick

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -452,6 +452,9 @@ let keeper_fs_edit_schema =
 let keeper_board_post_schema =
   find_schema_exn "keeper_board_post" Config.raw_all_tool_schemas
 
+let keeper_bash_schema =
+  find_schema_exn "keeper_bash" Config.raw_all_tool_schemas
+
 let assoc_string key json =
   match Yojson.Safe.Util.member key json with
   | `String value -> value
@@ -530,6 +533,128 @@ let test_registered_hook_keeper_board_post_accepts_sources_array () =
   in
   Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
   check_keeper_board_post_sources_preserved forwarded
+
+let param_by_name name params =
+  List.find_opt
+    (fun (param : Agent_sdk.Types.tool_param) -> String.equal param.name name)
+    params
+
+let check_param_type name expected params =
+  match param_by_name name params with
+  | Some (param : Agent_sdk.Types.tool_param) ->
+    Alcotest.(check bool)
+      (name ^ " is optional at OAS boundary")
+      false
+      param.required;
+    Alcotest.(check string)
+      (name ^ " param type")
+      expected
+      (match param.param_type with
+       | Agent_sdk.Types.String -> "string"
+       | Integer -> "integer"
+       | Number -> "number"
+       | Boolean -> "boolean"
+       | Array -> "array"
+       | Object -> "object")
+  | None -> Alcotest.failf "missing param: %s" name
+
+let test_keeper_bash_schema_exposes_typed_boundary () =
+  let params = Tool_bridge.params_of_json_schema keeper_bash_schema in
+  check_param_type "cmd" "string" params;
+  check_param_type "executable" "string" params;
+  check_param_type "argv" "array" params;
+  check_param_type "pipeline" "array" params;
+  check_param_type "stages" "array" params;
+  check_param_type "env" "object" params
+
+let test_validate_args_keeper_bash_accepts_legacy_cmd () =
+  let args = `Assoc [ "cmd", `String "pwd" ] in
+  match
+    Tool_input_validation.validate_args
+      ~schema:keeper_bash_schema
+      ~name:"keeper_bash"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check bool) "args unchanged" true (Yojson.Safe.equal args forwarded)
+  | Error result ->
+    Alcotest.failf
+      "expected legacy keeper_bash cmd to pass validation, got %s"
+      (Yojson.Safe.to_string result.Tool_result.data)
+
+let test_validate_args_keeper_bash_accepts_typed_exec () =
+  let args =
+    `Assoc
+      [ "executable", `String "rg"
+      ; "argv", `List [ `String "--files"; `String "lib" ]
+      ; "cwd", `String "/tmp"
+      ; "env", `Assoc [ "NO_COLOR", `String "1" ]
+      ]
+  in
+  match
+    Tool_input_validation.validate_args
+      ~schema:keeper_bash_schema
+      ~name:"keeper_bash"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check bool) "args unchanged" true (Yojson.Safe.equal args forwarded)
+  | Error result ->
+    Alcotest.failf
+      "expected typed keeper_bash exec to pass validation, got %s"
+      (Yojson.Safe.to_string result.Tool_result.data)
+
+let test_validate_args_keeper_bash_accepts_typed_pipeline () =
+  let args =
+    `Assoc
+      [ ( "pipeline"
+        , `List
+            [ `Assoc
+                [ "executable", `String "rg"
+                ; "argv", `List [ `String "--files"; `String "lib" ]
+                ]
+            ; `Assoc
+                [ "executable", `String "head"
+                ; "argv", `List [ `String "-20" ]
+                ]
+            ] )
+      ; "cwd", `String "/tmp"
+      ]
+  in
+  match
+    Tool_input_validation.validate_args
+      ~schema:keeper_bash_schema
+      ~name:"keeper_bash"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check bool) "pipeline preserved" true (Yojson.Safe.equal args forwarded)
+  | Error result ->
+    Alcotest.failf
+      "expected typed keeper_bash pipeline to pass validation, got %s"
+      (Yojson.Safe.to_string result.Tool_result.data)
+
+let test_validate_args_keeper_bash_rejects_bad_argv_type () =
+  let args =
+    `Assoc [ "executable", `String "rg"; "argv", `String "--files lib" ]
+  in
+  match
+    Tool_input_validation.validate_args
+      ~schema:keeper_bash_schema
+      ~name:"keeper_bash"
+      ~args
+      ()
+  with
+  | Error result ->
+    let msg = Yojson.Safe.to_string result.Tool_result.data in
+    Alcotest.(check bool) "mentions argv" true (string_contains msg "argv")
+  | Ok forwarded ->
+    Alcotest.failf
+      "expected typed keeper_bash argv string to fail, got %s"
+      (Yojson.Safe.to_string forwarded)
 
 let validation_labels ~tool ~result ~reason =
   [ "tool", tool; "result", result; "reason", reason ]
@@ -920,6 +1045,16 @@ let () =
         test_registered_hook_keeper_fs_edit_patch_args;
       Alcotest.test_case "keeper_board_post accepts sources array" `Quick
         test_registered_hook_keeper_board_post_accepts_sources_array;
+      Alcotest.test_case "keeper_bash exposes typed boundary" `Quick
+        test_keeper_bash_schema_exposes_typed_boundary;
+      Alcotest.test_case "keeper_bash accepts legacy cmd" `Quick
+        test_validate_args_keeper_bash_accepts_legacy_cmd;
+      Alcotest.test_case "keeper_bash accepts typed exec" `Quick
+        test_validate_args_keeper_bash_accepts_typed_exec;
+      Alcotest.test_case "keeper_bash accepts typed pipeline" `Quick
+        test_validate_args_keeper_bash_accepts_typed_pipeline;
+      Alcotest.test_case "keeper_bash rejects bad typed argv" `Quick
+        test_validate_args_keeper_bash_rejects_bad_argv_type;
       Alcotest.test_case "direct validation uses explicit schema" `Quick
         test_validate_args_uses_explicit_schema_without_registry;
       Alcotest.test_case "direct keeper_board_post accepts sources array" `Quick


### PR DESCRIPTION
Stacked on #16256.

What:
- Extends Sandbox_target.runner with explicit stdin_content support.
- Routes Shell IR pipeline stages through dispatch_simple so Host and Docker sandbox targets share the same stdin/cwd path.
- Adds a regression test proving Docker runner stages receive stdin and cwd in explicit pipelines.

Why:
- This is the substrate needed before enabling typed keeper_bash pipelines for Docker. Previously pipeline stages after the first went through the host stdin path and dropped the stage sandbox target.

Verification:
- ocamlformat --check lib/exec/sandbox_target.ml lib/exec/sandbox_target.mli lib/exec/exec_dispatch.ml lib/exec/exec_dispatch.mli test/test_exec_dispatch.ml
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build ./test/test_exec_dispatch.exe
- ./_build/default/test/test_exec_dispatch.exe