### PR TITLE
fix(cdal): distinguish advisory missing verdicts

### DIFF
--- a/lib/cdal_verdict_gate.ml
+++ b/lib/cdal_verdict_gate.ml
@@ -86,7 +86,20 @@ let scan_for_task_id ~task_id recent =
     | _ -> acc
   ) None recent
 
+let verdict_scope_counts recent =
+  List.fold_left
+    (fun (task_scoped, unscoped) json ->
+       match json with
+       | `Assoc fields ->
+         (match List.assoc_opt "_task_id" fields with
+          | Some (`String _) -> task_scoped + 1, unscoped
+          | _ -> task_scoped, unscoped + 1)
+       | _ -> task_scoped, unscoped)
+    (0, 0)
+    recent
+
 let lookup_latest_verdict ?base_dir
+    ?(warn_on_missing = true)
     ?(limit = Env_config_runtime.Cdal.verdict_lookup_limit ())
     ~task_id () : Cdal_types.contract_verdict option =
   let base_dir =
@@ -109,10 +122,12 @@ let lookup_latest_verdict ?base_dir
     | Some _ -> result, recent, limit
     | None when List.length recent >= limit && auto_widen_factor > 1 ->
       let widened = limit * auto_widen_factor in
-      Log.Task.info
-        "[cdal-gate] task_id=%s: starting window saturated (%d entries) \
-         without match; widening to %d and re-scanning"
-        task_id limit widened;
+      if warn_on_missing
+      then
+        Log.Task.info
+          "[cdal-gate] task_id=%s: starting window saturated (%d entries) \
+           without match; widening to %d and re-scanning"
+          task_id limit widened;
       let recent2 = Dated_jsonl.read_recent store widened in
       let result2 = scan_for_task_id ~task_id recent2 in
       result2, recent2, widened
@@ -124,32 +139,37 @@ let lookup_latest_verdict ?base_dir
        - scanned everything available, no match (verdict was never written)
        - saturated even at the widened ceiling (unusually large ledger or
          very old verdict — operator may need to raise the env knob).  *)
-  (match result, recent with
-   | Some _, _ -> ()
-   | None, [] ->
-     Log.Task.warn
-       "[cdal-gate] task_id=%s: cdal_verdicts ledger is EMPTY at %s. \
-        Writer pipeline likely dormant — check that OAS Agent.run \
-        emits result.proof and Cdal_eval_v1.persist is reached. (#10115)"
-       task_id base_dir
-   | None, _ when List.length recent >= used_limit ->
-     if not (Hashtbl.mem saturation_warn_emitted task_id) then begin
-       Hashtbl.add saturation_warn_emitted task_id ();
+  if warn_on_missing
+  then (
+    let task_scoped, unscoped = verdict_scope_counts recent in
+    match result, recent with
+    | Some _, _ -> ()
+    | None, [] ->
        Log.Task.warn
-         "[cdal-gate] task_id=%s: scanned newest %d entries (auto-widened \
-          %dx from MASC_CDAL_VERDICT_LOOKUP_LIMIT=%d) without match; older \
-          verdicts beyond this ceiling are silently skipped. Raise \
-          MASC_CDAL_VERDICT_LOOKUP_LIMIT only if the verdict is known to \
-          exist farther back. (#10115 #10731)"
-         task_id used_limit auto_widen_factor limit
-     end
-   | None, _ ->
-     Log.Task.warn
-       "[cdal-gate] task_id=%s: no verdict in current ledger window \
-        (%d entries scanned, below limit=%d).  Either the task has \
-        never been verified, or the writer pipeline is dormant — \
-        bumping MASC_CDAL_VERDICT_LOOKUP_LIMIT will not help. (#10115)"
-       task_id (List.length recent) used_limit);
+         "[cdal-gate] task_id=%s: cdal_verdicts ledger is EMPTY at %s. \
+          Writer pipeline likely dormant — check that OAS Agent.run \
+          emits result.proof and Cdal_eval_v1.persist is reached. (#10115)"
+         task_id base_dir
+    | None, _ when List.length recent >= used_limit ->
+      if not (Hashtbl.mem saturation_warn_emitted task_id) then begin
+        Hashtbl.add saturation_warn_emitted task_id ();
+        Log.Task.warn
+          "[cdal-gate] task_id=%s: scanned newest %d entries (auto-widened \
+           %dx from MASC_CDAL_VERDICT_LOOKUP_LIMIT=%d) without match \
+           (task_scoped=%d unscoped=%d). Older verdicts beyond this ceiling \
+           are silently skipped. Raise MASC_CDAL_VERDICT_LOOKUP_LIMIT only \
+           if the verdict is known to exist farther back. (#10115 #10731)"
+          task_id used_limit auto_widen_factor limit task_scoped unscoped
+      end
+    | None, _ ->
+      Log.Task.warn
+        "[cdal-gate] task_id=%s: no task-scoped verdict in current ledger \
+         window (%d entries scanned, task_scoped=%d, unscoped=%d, below \
+         limit=%d). CDAL writer is active; this task either has never \
+         produced a scoped verifier proof, or the verifier turn persisted \
+         proof without task_id/current_task_id. Bumping \
+         MASC_CDAL_VERDICT_LOOKUP_LIMIT will not help. (#10115)"
+        task_id (List.length recent) task_scoped unscoped used_limit);
   result
 
 (* #10115: ledger health introspection.  Walks [base_dir/YYYY-MM/]
@@ -287,8 +307,10 @@ let attribution_for_missing_verdict ?(gate_label = strict_gate_label)
          task_id)
 
 let gate_check ?base_dir
-    ?(gate_label = strict_gate_label) ~task_id () : string option =
-  match lookup_latest_verdict ?base_dir ~task_id () with
+    ?(gate_label = strict_gate_label)
+    ?(warn_on_missing = true)
+    ~task_id () : string option =
+  match lookup_latest_verdict ?base_dir ~warn_on_missing ~task_id () with
   | None ->
     Dashboard_attribution.record
       (attribution_for_missing_verdict ~gate_label ~task_id ());

--- a/lib/cdal_verdict_gate.mli
+++ b/lib/cdal_verdict_gate.mli
@@ -39,7 +39,7 @@ val advisory_gate_label : string
 
 (** {1 Task completion gate} *)
 
-(** [gate_check ?base_dir ?gate_label ~task_id ()] looks up the latest
+(** [gate_check ?base_dir ?gate_label ?warn_on_missing ~task_id ()] looks up the latest
     verdict for [task_id] under [base_dir] (default: CDAL verdict
     directory resolved from MASC base path) and returns:
 
@@ -50,15 +50,21 @@ val advisory_gate_label : string
     {!strict_gate_label}). Callers operating on advisory contracts
     should pass [~gate_label:advisory_gate_label] so the dashboard can
     distinguish the two buckets. The return value is unaffected by
-    the label. *)
+    the label.
+
+    [warn_on_missing] controls operator-visible missing-verdict WARNs.
+    Strict gates should keep the default [true]. Advisory or
+    attribution-only callers may pass [false] to record attribution
+    without repeating a non-blocking warning. *)
 val gate_check :
   ?base_dir:string ->
   ?gate_label:string ->
+  ?warn_on_missing:bool ->
   task_id:string ->
   unit ->
   string option
 
-(** [lookup_latest_verdict ?base_dir ?limit ~task_id ()] — the
+(** [lookup_latest_verdict ?base_dir ?warn_on_missing ?limit ~task_id ()] — the
     primitive that {!gate_check} composes with attribution recording.
     Exposed so diagnostic tools and tests can call it without
     importing the attribution side effect.
@@ -69,6 +75,7 @@ val gate_check :
     cases (#10731). *)
 val lookup_latest_verdict :
   ?base_dir:string ->
+  ?warn_on_missing:bool ->
   ?limit:int ->
   task_id:string ->
   unit ->

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -942,6 +942,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
             ignore
               (Cdal_verdict_gate.gate_check
                  ~gate_label:(cdal_gate_label_for_task task_opt)
+                 ~warn_on_missing:false
                  ~task_id ())
         | Masc_domain.Reject_verification ->
           let reason = if not (String.equal notes "") then notes else reason in
@@ -952,6 +953,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
             ignore
               (Cdal_verdict_gate.gate_check
                  ~gate_label:(cdal_gate_label_for_task task_opt)
+                 ~warn_on_missing:false
                  ~task_id ())
         | Masc_domain.Claim | Masc_domain.Start | Masc_domain.Done_action | Masc_domain.Cancel | Masc_domain.Release -> ())
    | Error err ->

--- a/lib/tool_task_contract_gate.ml
+++ b/lib/tool_task_contract_gate.ml
@@ -93,7 +93,11 @@ let persisted_contract_rejection ~(agent_name : string)
           "[cdal-gate] checking verdict for task=%s agent=%s strict=%b gate=%s"
           task.id agent_name contract.strict gate_label;
         let rejection =
-          Cdal_verdict_gate.gate_check ~gate_label ~task_id:task.id ()
+          Cdal_verdict_gate.gate_check
+            ~gate_label
+            ~warn_on_missing:contract.strict
+            ~task_id:task.id
+            ()
         in
         if contract.strict then rejection
         else begin

--- a/test/test_cdal_verdict_gate.ml
+++ b/test/test_cdal_verdict_gate.ml
@@ -198,6 +198,22 @@ let test_gate_different_task_id_not_found () =
     | None ->
       Alcotest.fail "Different task_id should not match")
 
+let test_gate_missing_can_suppress_operator_warning () =
+  with_temp_dir (fun base_dir ->
+    let verdict = make_verdict ~status:CT.Satisfied () in
+    write_verdict_jsonl ~base_dir verdict;
+    match
+      CVG.gate_check ~base_dir ~warn_on_missing:false
+        ~task_id:"task-missing" ()
+    with
+    | Some msg ->
+      Alcotest.(check bool)
+        "still returns rejection reason"
+        true
+        (Astring.String.is_infix ~affix:"task-missing" msg)
+    | None ->
+      Alcotest.fail "No scoped verdict should still reject")
+
 let test_gate_latest_verdict_wins () =
   with_temp_dir (fun base_dir ->
     let v1 = make_verdict ~run_id:"run-old" ~status:CT.Violated () in
@@ -398,6 +414,8 @@ let () =
       Alcotest.test_case "satisfied verdict allows" `Quick test_gate_satisfied_verdict_allows;
       Alcotest.test_case "violated verdict rejects" `Quick test_gate_violated_verdict_rejects;
       Alcotest.test_case "different task_id not found" `Quick test_gate_different_task_id_not_found;
+      Alcotest.test_case "missing verdict warning can be suppressed" `Quick
+        test_gate_missing_can_suppress_operator_warning;
       Alcotest.test_case "latest verdict wins" `Quick test_gate_latest_verdict_wins;
       Alcotest.test_case "auto-widens past starting limit (#10731)" `Quick
         test_lookup_auto_widens_past_starting_limit;


### PR DESCRIPTION
## Summary
- Add a warn_on_missing switch to CDAL verdict lookup/gating so strict gates still warn while advisory and attribution-only callers can stay quiet.
- Improve missing-verdict diagnostics by separating empty ledger, saturated window, task-scoped verdicts, and unscoped verdicts.
- Suppress repeated non-blocking WARN noise from post-approve/post-reject attribution and advisory contracts while preserving attribution and rejection return values.

## Why
Live task-348 showed the CDAL writer was active, but the relevant verifier/approval proofs were persisted without a task scope. The previous message said the writer pipeline might be dormant even when the ledger contained recent entries. That made advisory paths look like runtime failure rather than a scoped-verdict attribution gap.

Observed evidence:
- /Users/dancer/me/data/cdal_verdicts/2026-05/18.jsonl had recent entries.
- task-348 had no task-scoped verdict.
- Nearby run ids cdal-1779113992962-9ed649 and cdal-1779114342020-5fce8e were unscoped.

## Validation
- ocamlformat --check lib/cdal_verdict_gate.ml lib/cdal_verdict_gate.mli lib/tool_task_contract_gate.ml lib/tool_task.ml test/test_cdal_verdict_gate.ml
- git diff --check
- scripts/dune-local.sh build ./test/test_cdal_verdict_gate.exe
- ./_build/default/test/test_cdal_verdict_gate.exe

## Notes
This reduces false operator warnings and makes the diagnosis accurate. It does not fully solve the deeper task-scope propagation gap where verifier/approval turns can persist proofs without current_task_id/task_id; that should be handled as a separate scoped-runtime fix.