### PR TITLE
fix(ci): add missing split-module interfaces

### DIFF
--- a/lib/dashboard/dashboard_goals_types_accessor.mli
+++ b/lib/dashboard/dashboard_goals_types_accessor.mli
@@ -1,0 +1,81 @@
+(** Accessor layer for dashboard goal-tree projections. *)
+
+type tree_node = {
+  goal : Goal_store.goal;
+  children : tree_node list;
+  tasks : (Masc_domain.task * string) list;
+  convergence : float;
+  health : string;
+  badges : string list;
+  last_activity_at : string;
+  stagnation_seconds : int;
+  linked_keeper_names : string list;
+  pending_approval_count : int;
+  infra_risk_count : int;
+  linkage_source : string;
+  linkage_warning_count : int;
+  status_reason : string;
+  blocking_source : string;
+  blocking_reason : string;
+  latest_keeper_ref : string option;
+  latest_turn_ref : int option;
+  stalled_since : string option;
+  activity_observation : string;
+  stagnation_status : string;
+}
+
+type goal_detail_keeper = {
+  meta : Keeper_types.keeper_meta;
+  latest_receipt : Yojson.Safe.t option;
+  runtime_trust : Yojson.Safe.t;
+}
+
+type attainment_unit =
+  | Percent
+  | Count
+  | Unknown
+
+val task_is_linked_to_goal : Masc_domain.task -> string -> bool
+val task_linkage_source_opt : Masc_domain.task -> string -> string option
+val task_assignee : Masc_domain.task -> string option
+val task_status_label : Masc_domain.task -> string
+val task_is_terminal : Masc_domain.task -> bool
+val task_is_done : Masc_domain.task -> bool
+val task_updated_at : Masc_domain.task -> string
+
+val dedupe_sort : string list -> string list
+val link_source_of_values : string list -> string
+
+val receipt_error_kind : Yojson.Safe.t -> string option
+val receipt_error_message : Yojson.Safe.t -> string option
+val receipt_sandbox_kind : Yojson.Safe.t -> string option
+val receipt_approval_profile : Yojson.Safe.t -> string option
+val receipt_cascade_name : Yojson.Safe.t -> string option
+val receipt_cascade_outcome : Yojson.Safe.t -> string option
+val receipt_cascade_fallback_applied : Yojson.Safe.t -> bool
+val receipt_outcome : Yojson.Safe.t -> string option
+val receipt_started_at : Yojson.Safe.t -> string option
+val receipt_ended_at : Yojson.Safe.t -> string option
+val receipt_turn_count : Yojson.Safe.t -> int option
+
+val trust_disposition : Yojson.Safe.t -> string option
+val trust_disposition_reason : Yojson.Safe.t -> string option
+val trust_attention_reason : Yojson.Safe.t -> string option
+val trust_needs_attention : Yojson.Safe.t -> bool
+val trust_snapshot_unavailable : Yojson.Safe.t -> bool
+val trust_turn_id : Yojson.Safe.t -> int option
+val trust_latest_event : Yojson.Safe.t -> Yojson.Safe.t option
+val trust_latest_event_ts : Yojson.Safe.t -> string option
+val trust_latest_event_ts_unix : Yojson.Safe.t -> float option
+val trust_sandbox_risk : Yojson.Safe.t -> bool
+val trust_cascade_risk : Yojson.Safe.t -> bool
+
+val receipt_has_error : Yojson.Safe.t -> bool
+val receipt_has_sandbox_risk : Yojson.Safe.t -> bool
+val receipt_has_cascade_risk : Yojson.Safe.t -> bool
+
+val iso_max : string -> string -> string
+val latest_iso : ?fallback:string -> string list -> string option
+
+val stagnation_threshold_seconds : Goal_store.horizon -> int
+val human_duration : int -> string

--- a/lib/dashboard/dashboard_goals_types_attainment.mli
+++ b/lib/dashboard/dashboard_goals_types_attainment.mli
@@ -1,0 +1,47 @@
+(** Goal attainment metric parsing and JSON projection helpers. *)
+
+open Dashboard_goals_types_accessor
+
+val clamp_float : float -> float -> float -> float
+val pct_of_float : float -> int
+
+val json_float_opt : float option -> Yojson.Safe.t
+val json_int_opt : int option -> Yojson.Safe.t
+val attainment_unit_to_string : attainment_unit -> string
+
+val contains_ci : string -> string -> bool
+
+val metric_word_tokens : string -> string list
+val metric_word_implies_percent : string -> bool
+val metric_implies_percent : string option -> bool
+
+val metric_count_token : string -> bool
+val metric_has_pull_request_phrase : string list -> bool
+val metric_supports_count_target : string option -> bool
+
+val target_value_implies_percent : string -> bool
+
+val strip_number_group_separators : string -> string
+val parse_first_float : string -> float option
+
+val parsed_target_unit : string option -> string -> attainment_unit
+
+val build_attainment_json :
+  state:string ->
+  basis:string ->
+  task_done_count:int ->
+  task_count:int ->
+  target_parse_status:string ->
+  unit:attainment_unit ->
+  observed_value:float option ->
+  target_numeric:float option ->
+  attainment_pct:int option ->
+  note:string ->
+  Goal_store.goal ->
+  Yojson.Safe.t
+
+val goal_attainment_pct_help : string
+val goal_attainment_measured_help : string
+
+val goal_attainment_to_json :
+  Goal_store.goal -> tree_node -> Yojson.Safe.t

--- a/lib/dashboard/dashboard_goals_types_builder.mli
+++ b/lib/dashboard/dashboard_goals_types_builder.mli
@@ -1,0 +1,34 @@
+(** Recursive goal-tree builder and runtime trust projection helpers. *)
+
+open Dashboard_goals_types_accessor
+
+val compute_convergence :
+  Goal_store.goal ->
+  (Masc_domain.task * string) list ->
+  tree_node list ->
+  float
+
+val goal_policy_nodes :
+  Goal_store.goal list -> Goal_verification.goal_policy_node list
+
+val runtime_blocker_event_from_meta :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  Yojson.Safe.t option
+
+val runtime_trust_from_receipt_fallback :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  Yojson.Safe.t ->
+  Yojson.Safe.t
+
+type build_context = {
+  now_ts : float;
+  all_tasks : Masc_domain.task list;
+  pending_approvals : Yojson.Safe.t list;
+  keeper_metas : Keeper_types.keeper_meta list;
+  latest_receipts : (string * Yojson.Safe.t) list;
+  latest_runtime_trusts : (string * Yojson.Safe.t) list;
+}
+
+val build_tree : build_context -> Goal_store.goal list -> Goal_store.goal -> tree_node

--- a/lib/dashboard/dashboard_goals_types_health.mli
+++ b/lib/dashboard/dashboard_goals_types_health.mli
@@ -1,0 +1,61 @@
+(** Goal phase health, FSM, and disposition projections. *)
+
+open Dashboard_goals_types_accessor
+
+val goal_phase_to_health : Goal_phase.t -> string option
+
+val goal_health_reason :
+  goal_phase:Goal_phase.t ->
+  blocked_by_receipt:bool ->
+  child_blocked:bool ->
+  pending_approvals:int ->
+  sandbox_risk:bool ->
+  cascade_risk:bool ->
+  fsm_risk:bool ->
+  stalled:bool ->
+  stagnation_seconds:int ->
+  child_at_risk:bool ->
+  linkage_warning_reason:string option ->
+  activity_observation:string ->
+  stagnation_status:string ->
+  string
+
+val tree_health :
+  goal_phase:Goal_phase.t ->
+  blocked_by_receipt:bool ->
+  child_blocked:bool ->
+  at_risk:bool ->
+  string
+
+val tree_badges :
+  pending_approvals:int ->
+  sandbox_risk:bool ->
+  cascade_risk:bool ->
+  fsm_risk:bool ->
+  stalled:bool ->
+  activity_unobserved:bool ->
+  string list
+
+val approval_matches_goal : string -> Yojson.Safe.t -> bool
+
+val keeper_name_matches_meta : Keeper_types.keeper_meta list -> string -> bool
+
+val keeper_name_of_assignee :
+  Keeper_types.keeper_meta list -> string -> string option
+
+val goal_fsm_state_kind : Goal_phase.t -> string
+
+val goal_fsm_next_actions :
+  goal_phase:Goal_phase.t ->
+  has_effective_verifier_policy:bool ->
+  require_completion_approval:bool ->
+  string list
+
+val goal_fsm_to_json :
+  effective_policy:'a option ->
+  Goal_store.goal ->
+  tree_node ->
+  Yojson.Safe.t
+
+val display_disposition_of_receipt_json :
+  Yojson.Safe.t -> string * string * string * string

--- a/lib/dashboard/dashboard_goals_types_timeline.mli
+++ b/lib/dashboard/dashboard_goals_types_timeline.mli
@@ -1,0 +1,32 @@
+(** Goal tree color, keeper detail, and timeline JSON projections. *)
+
+open Dashboard_goals_types_accessor
+
+val goal_status_color : Goal_store.goal_status -> string
+val goal_phase_color : Goal_phase.t -> string
+val goal_health_color : string -> string
+val task_status_color : string -> string
+
+val task_to_tree_json : Masc_domain.task * string -> Yojson.Safe.t
+
+val flatten_tree : tree_node list -> tree_node list -> tree_node list
+val goal_detail_keeper_json : goal_detail_keeper -> Yojson.Safe.t
+
+val timeline_event_json :
+  ts:string ->
+  kind:string ->
+  lane:string ->
+  title:string ->
+  summary:string ->
+  severity:string ->
+  Yojson.Safe.t
+
+val json_member_or_null : string -> Yojson.Safe.t -> Yojson.Safe.t
+val goal_event_timeline_json : Yojson.Safe.t -> Yojson.Safe.t
+
+val build_goal_timeline :
+  tree_node ->
+  goal_detail_keeper list ->
+  Yojson.Safe.t list ->
+  Yojson.Safe.t list ->
+  Yojson.Safe.t list

--- a/lib/repo_manager/repo_store_lookup.mli
+++ b/lib/repo_manager/repo_store_lookup.mli
@@ -1,0 +1,22 @@
+(** Repository lookup helpers factored out of [Repo_store]. *)
+
+open Repo_manager_types
+
+module type Store = sig
+  val load_all : base_path:string -> (repository list, string) result
+  val local_path : base_path:string -> repository -> string
+end
+
+val strip_trailing_slash : string -> string
+val is_path_prefix : prefix:string -> string -> bool
+val rel_under_path : prefix:string -> string -> string
+
+val longest_local_path :
+  ('repo * string * 'rel) list -> ('repo * string * 'rel) option
+
+module Make (Store : Store) : sig
+  val find_url_by_id : base_path:string -> repository_id -> string option
+
+  val find_repo_by_path_prefix :
+    base_path:string -> string -> (repository * string) option
+end


### PR DESCRIPTION
## Summary
- add .mli interfaces for dashboard_goals_types split modules
- add .mli interface for repo_store_lookup
- restore ocaml structure ratchet after current-main split work

## Verification
- ocamlformat --inplace lib/dashboard/dashboard_goals_types_accessor.mli lib/dashboard/dashboard_goals_types_attainment.mli lib/dashboard/dashboard_goals_types_health.mli lib/dashboard/dashboard_goals_types_timeline.mli lib/dashboard/dashboard_goals_types_builder.mli lib/repo_manager/repo_store_lookup.mli
- scripts/ocaml-structure-ratchet.sh
- git diff --check
- scripts/dune-local.sh build lib/masc_mcp.cmxa