### PR TITLE
fix(keeper): avoid failure class accessor shadowing

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -571,12 +571,12 @@ let make_keeper_tool_handler
           in
           if is_failure
           then (
-            let failure_class =
+            let failure_class_opt =
               Keeper_exec_tools.failure_class_of_tool_result_payload raw_result
               |> tool_failure_class_of_wire_string
             in
             let is_workflow_rejection =
-              match failure_class with
+              match failure_class_opt with
               | Some Tool_result.Workflow_rejection -> true
               | Some (Tool_result.Transient_error | Tool_result.Policy_rejection | Tool_result.Runtime_failure)
               | None ->
@@ -605,7 +605,7 @@ let make_keeper_tool_handler
                  ; legacy_message = raw_result
                  ; failure_class =
                      Some
-                       (Option.value ~default:Tool_result.Runtime_failure failure_class)
+                       (Option.value ~default:Tool_result.Runtime_failure failure_class_opt)
                  }
              in
              (* RFC-0084 PR-I-3 — typed observers replace


### PR DESCRIPTION
## Summary
- fix keeper_tools_oas failure_class local variable shadowing Tool_result.failure_class accessor
- restores compilation for workflow-rejection preservation path after #16258 merged

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_tools_oas.ml
- git diff --check origin/main...HEAD
- earlier focused build on #16258 caught the error and passed after the same patch before this current-main cherry-pick; current local Dune proof is queued behind other machine-wide Dune jobs