### PR TITLE
docs: add symbol graph seed export gate

### DIFF
--- a/docs/design/lsp-symbol-graph-exporter.md
+++ b/docs/design/lsp-symbol-graph-exporter.md
@@ -122,6 +122,35 @@ docs/generated/reverse-engineering/symbol-graph.v1.json
 
 The first snapshot in this PR is a schema-compatible static seed. It records WBS lanes, source owners, guard tests, and curated flow edges, and it explicitly records `live_lsp_not_invoked_in_this_pr` in `omissions[]`. Its `display_range` rows are bound to the JSON `base_commit`, so they are evidence for that commit only and must not be treated as current-main coordinates after main advances. A later implementation PR should replace static ranges with live `documentSymbol` and `references` responses.
 
+## Seed Export Command
+
+Current task-411 command:
+
+```bash
+scripts/ide/export-symbol-graph --check
+```
+
+This validates the checked-in seed deterministically: schema version, read-only
+method allowlist, absence of live LSP invocation, workspace-confined paths,
+guard test existence, and `display_range` bounds for the artifact's current
+worktree when the artifact `base_commit` matches `HEAD`. If `base_commit` is
+older than the current checkout, the command switches to `base_commit_bound`
+range mode: it still checks range shape and all file/test paths, but does not
+pretend stale static line numbers are current-main coordinates. It does not
+call `/api/v1/ide/lsp`, does not add a runtime route, and does not mutate task,
+keeper, git, dashboard, or cache state.
+
+To reproduce the seed payload as canonical JSON during a documentation PR:
+
+```bash
+scripts/ide/export-symbol-graph --emit > docs/generated/reverse-engineering/symbol-graph.v1.json
+```
+
+That write is an explicit operator shell redirection, not a runtime capability.
+Until the live LSP exporter lands, this command is a static seed reproducer and
+drift gate; it intentionally fails or emits omission rows instead of silently
+inventing refreshed symbol ranges.
+
 ## JSON Schema
 
 The first artifact uses `masc.symbol_graph.v1`:
@@ -135,7 +164,9 @@ The first artifact uses `masc.symbol_graph.v1`:
   "source": {
     "lsp_route": "/api/v1/ide/lsp",
     "methods": ["textDocument/documentSymbol", "textDocument/references"],
-    "manifest": "docs/design/lsp-symbol-graph-exporter.md"
+    "manifest": "docs/design/lsp-symbol-graph-exporter.md",
+    "check_command": "scripts/ide/export-symbol-graph --check",
+    "emit_command": "scripts/ide/export-symbol-graph --emit > docs/generated/reverse-engineering/symbol-graph.v1.json"
   },
   "limits": {
     "max_files": 80,
@@ -234,9 +265,11 @@ Done evidence:
 - Generated JSON validates against the schema fields above.
 - HTML contains the artifact link and generation commit.
 - The run command and omission count are posted to #16083.
+- `scripts/ide/export-symbol-graph --check` passes without introducing runtime write capability.
 
 ## Acceptance Checks
 
+- `scripts/ide/export-symbol-graph --check`
 - `rg "lsp-symbol-graph-exporter" docs/reverse-engineering-design.html docs/design/lsp-symbol-graph-exporter.md`
 - `rg "masc.symbol_graph.v1|task-386|task-387" docs/design/lsp-symbol-graph-exporter.md`
 - `xmllint --html --noout docs/reverse-engineering-design.html`

--- a/docs/generated/reverse-engineering/symbol-graph.v1.json
+++ b/docs/generated/reverse-engineering/symbol-graph.v1.json
@@ -11,6 +11,8 @@
       "textDocument/references"
     ],
     "manifest": "docs/design/lsp-symbol-graph-exporter.md",
+    "check_command": "scripts/ide/export-symbol-graph --check",
+    "emit_command": "scripts/ide/export-symbol-graph --emit > docs/generated/reverse-engineering/symbol-graph.v1.json",
     "live_lsp_invoked": false,
     "notes": "Initial task-387 snapshot is a base-commit-bound static seed from base_commit. display_range values are not current-main coordinates. Later exporter PRs should replace static ranges with live LSP responses."
   },

--- a/docs/reverse-engineering-design.html
+++ b/docs/reverse-engineering-design.html
@@ -1387,6 +1387,12 @@
               <td><a href="generated/reverse-engineering/symbol-graph.v1.json"><code>docs/generated/reverse-engineering/symbol-graph.v1.json</code></a></td>
               <td>Every WBS slice names at least one guard test or an omission row. Current snapshot is a static seed; live LSP invocation is recorded as an omission. Snapshot ranges are bound to the JSON <code>base_commit</code>, not live current-main coordinates.</td>
             </tr>
+            <tr>
+              <td><code>task-411</code> landing gate</td>
+              <td>PR #16251, generated snapshot, and current repo files/tests</td>
+              <td><code>scripts/ide/export-symbol-graph --check</code></td>
+              <td>Classifies merge/readiness blockers and proves the atlas path is operator-only: no runtime write route, no cache write, no keeper/task/git mutation.</td>
+            </tr>
           </tbody>
         </table>
       </section>

--- a/scripts/ide/export-symbol-graph
+++ b/scripts/ide/export-symbol-graph
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Validate or reproduce the checked-in reverse-engineering symbol graph.
+
+This is the static seed exporter for task-411. It intentionally does not talk
+to the live LSP WebSocket and does not mutate runtime state. The only write
+mode is an explicit operator command that rewrites the checked-in artifact
+from its already-versioned JSON payload.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+
+DEFAULT_ARTIFACT = pathlib.Path("docs/generated/reverse-engineering/symbol-graph.v1.json")
+SCHEMA_VERSION = "masc.symbol_graph.v1"
+ALLOWED_METHODS = {
+    "initialize",
+    "initialized",
+    "shutdown",
+    "exit",
+    "textDocument/documentSymbol",
+    "textDocument/references",
+    "textDocument/definition",
+    "textDocument/typeDefinition",
+    "textDocument/implementation",
+    "textDocument/hover",
+}
+DENIED_METHODS = {
+    "textDocument/didChange",
+    "textDocument/didSave",
+    "workspace/applyEdit",
+    "workspace/executeCommand",
+    "textDocument/rename",
+    "textDocument/formatting",
+    "textDocument/rangeFormatting",
+    "textDocument/codeAction",
+}
+
+
+def repo_root() -> pathlib.Path:
+    root = subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip()
+    return pathlib.Path(root)
+
+
+def git_short_head(root: pathlib.Path) -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "--short=12", "HEAD"],
+        cwd=root,
+        text=True,
+    ).strip()
+
+
+def load_json(path: pathlib.Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("artifact root must be a JSON object")
+    return data
+
+
+def repo_relative_path(value: str) -> pathlib.Path:
+    path = pathlib.PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"path is not confined to repo root: {value}")
+    return pathlib.Path(*path.parts)
+
+
+def collect_tests(data: dict[str, Any]) -> set[str]:
+    tests: set[str] = set()
+    for lane in data.get("lanes", []):
+        tests.update(lane.get("guard_tests", []))
+    for file_row in data.get("files", []):
+        for owner in file_row.get("test_owners", []):
+            tests.add(owner["test_path"])
+        for symbol in file_row.get("symbols", []):
+            tests.update(symbol.get("tests", []))
+    return tests
+
+
+def validate(data: dict[str, Any], root: pathlib.Path, *, check_current_ranges: bool) -> list[str]:
+    errors: list[str] = []
+    if data.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    if data.get("repo") != "masc-mcp":
+        errors.append("repo must be masc-mcp")
+
+    source = data.get("source", {})
+    if not isinstance(source, dict):
+        errors.append("source must be an object")
+        source = {}
+    methods = source.get("methods", [])
+    for method in methods:
+        if method not in ALLOWED_METHODS:
+            errors.append(f"method is not allowlisted: {method}")
+        if method in DENIED_METHODS or (method.startswith("workspace/") and method not in ALLOWED_METHODS):
+            errors.append(f"mutation-capable method is forbidden: {method}")
+    if source.get("live_lsp_invoked") is not False:
+        errors.append("static seed must set source.live_lsp_invoked=false")
+
+    omissions = data.get("omissions", [])
+    omission_codes = {
+        row.get("code")
+        for row in omissions
+        if isinstance(row, dict)
+    }
+    if "live_lsp_not_invoked_in_this_pr" not in omission_codes:
+        errors.append("static seed must record live_lsp_not_invoked_in_this_pr")
+    if "base_commit_bound_static_ranges" not in omission_codes:
+        errors.append("static seed must record base_commit_bound_static_ranges")
+
+    lanes = data.get("lanes", [])
+    if not lanes:
+        errors.append("lanes must not be empty")
+    for lane in lanes:
+        if not lane.get("guard_tests"):
+            errors.append(f"lane has no guard_tests: {lane.get('name', '<unnamed>')}")
+
+    file_paths = [row.get("path") for row in data.get("files", [])]
+    for value in file_paths:
+        if not isinstance(value, str):
+            errors.append(f"file path must be a string: {value!r}")
+            continue
+        path = root / repo_relative_path(value)
+        if not path.exists():
+            errors.append(f"missing source file: {value}")
+
+    for test_path in sorted(collect_tests(data)):
+        path = root / repo_relative_path(test_path)
+        if not path.exists():
+            errors.append(f"missing guard test: {test_path}")
+
+    for file_row in data.get("files", []):
+        value = file_row.get("path")
+        if not isinstance(value, str):
+            continue
+        path = root / repo_relative_path(value)
+        if not path.exists():
+            continue
+        line_count = sum(1 for _ in path.open(encoding="utf-8", errors="replace"))
+        if not file_row.get("test_owners"):
+            errors.append(f"file row has no test_owners: {value}")
+        for symbol in file_row.get("symbols", []):
+            display_range = symbol.get("display_range", {})
+            start = display_range.get("start_line")
+            end = display_range.get("end_line")
+            if not isinstance(start, int) or not isinstance(end, int):
+                errors.append(f"symbol has invalid display_range: {symbol.get('id')}")
+            elif not (1 <= start <= end):
+                errors.append(f"symbol has invalid display_range order: {symbol.get('id')}")
+            elif check_current_ranges and end > line_count:
+                errors.append(
+                    f"symbol range outside file: {symbol.get('id')} {value}:{start}-{end} "
+                    f"(file has {line_count} lines)"
+                )
+            if not symbol.get("tests"):
+                errors.append(f"symbol has no tests: {symbol.get('id')}")
+
+    return errors
+
+
+def dump_canonical(data: dict[str, Any]) -> str:
+    return json.dumps(data, indent=2, ensure_ascii=False, sort_keys=False) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=pathlib.Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--check", action="store_true", help="validate the artifact; default action")
+    parser.add_argument("--emit", action="store_true", help="validate and print canonical JSON to stdout")
+    parser.add_argument("--write", action="store_true", help="validate and rewrite the artifact canonically")
+    parser.add_argument(
+        "--strict-ranges",
+        action="store_true",
+        help="require display_range rows to fit the current checkout even when base_commit differs",
+    )
+    parser.add_argument("--base-commit", help="override base_commit when used with --emit or --write")
+    parser.add_argument("--generated-at", help="override generated_at when used with --emit or --write")
+    args = parser.parse_args()
+
+    root = repo_root()
+    artifact = args.artifact if args.artifact.is_absolute() else root / args.artifact
+    data = load_json(artifact)
+    if args.base_commit:
+        data["base_commit"] = args.base_commit
+    if args.generated_at:
+        data["generated_at"] = args.generated_at
+
+    current_head = git_short_head(root)
+    base_commit = str(data.get("base_commit", ""))
+    check_current_ranges = args.strict_ranges or base_commit == current_head
+    errors = validate(data, root, check_current_ranges=check_current_ranges)
+    if errors:
+        for error in errors:
+            print(f"symbol graph error: {error}", file=sys.stderr)
+        return 1
+
+    if args.emit:
+        sys.stdout.write(dump_canonical(data))
+    elif args.write:
+        artifact.write_text(dump_canonical(data), encoding="utf-8")
+    else:
+        source = data.get("source", {})
+        print(
+            "symbol graph ok: "
+            f"schema={data.get('schema_version')} "
+            f"base_commit={data.get('base_commit')} "
+            f"collection_mode={data.get('collection_mode')} "
+            f"live_lsp_invoked={source.get('live_lsp_invoked')} "
+            f"range_mode={'current_checkout' if check_current_ranges else 'base_commit_bound'} "
+            f"lanes={len(data.get('lanes', []))} "
+            f"files={len(data.get('files', []))} "
+            f"tests={len(collect_tests(data))} "
+            f"omissions={len(data.get('omissions', []))}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add operator-only `scripts/ide/export-symbol-graph` for task-411
- record the check/emit commands in `docs/generated/reverse-engineering/symbol-graph.v1.json`
- update the LSP exporter design and reverse-engineering HTML with the task-411 landing gate

## Relationship to #16251
- #16251 merged the task-386/task-387 design and static seed snapshot.
- This is a delta PR on top of current `origin/main` (`44cfe970b1`) because the task-411 export gate commit landed after #16251 merged.
- The script does not call `/api/v1/ide/lsp`, does not add a runtime route, and does not write cache/dashboard/keeper/task/git state.

## Verification
- `scripts/ide/export-symbol-graph --check`
  - `schema=masc.symbol_graph.v1`
  - `base_commit=22f3665e5218`
  - `collection_mode=static_manifest_seed`
  - `live_lsp_invoked=False`
  - `range_mode=base_commit_bound`
  - `lanes=6 files=22 tests=24 omissions=3`
- `jq -e '.schema_version == "masc.symbol_graph.v1" and (.source.check_command == "scripts/ide/export-symbol-graph --check") and (.source.emit_command | contains("scripts/ide/export-symbol-graph --emit")) and (.omissions | length == 3)' docs/generated/reverse-engineering/symbol-graph.v1.json`
- `git diff --check origin/main..HEAD`
- `python3 -m py_compile scripts/ide/export-symbol-graph`
- `xmllint --html --noout docs/reverse-engineering-design.html` (exit 0; existing HTML5 tag vocabulary warnings)

## Blocker classification
- #16251 is already merged.
- Current static snapshot ranges are base-commit-bound. `--strict-ranges` intentionally catches current-main line drift, so the default check does not pretend old line ranges are current coordinates.
- Merge readiness for this PR is normal draft-agent policy: `agent-pr` stays draft until a human adds `human-approved-ready`.
- CI restarted after the rebase/push to head `54e6f66dd3`.

Issue: #16083
MASC: task-411
