### PR TITLE
Gate keeper verification on concrete evidence

### DIFF
--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -506,6 +506,11 @@ let handle_keeper_task_tool
     then
       workflow_rejection_error_json
         "pr_url is required. Include the PR opened for this task."
+    else if not (Tool_task_completion_review.pr_url_has_pull_ref pr_url)
+    then
+      workflow_rejection_error_json
+        "pr_url must be a GitHub pull request URL or PR # reference. \
+         Do not submit placeholders like 'draft', 'none', or 'pending'."
     else (
       (* Map keeper vocabulary (notes + pr_url) onto MASC domain typed
          handoff_context fields: notes -> summary, [pr_url] ->

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -673,19 +673,6 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
   match handoff_context with
   | Error error -> Tool_result.error ~tool_name ~start_time error
   | Ok handoff_context ->
-  let submit_evidence_error =
-    match requested_action with
-    | Masc_domain.Submit_for_verification | Masc_domain.Submit_pr_evidence ->
-      verification_submission_evidence_error ~notes ~handoff_context
-    | Masc_domain.Claim
-    | Masc_domain.Start
-    | Masc_domain.Done_action
-    | Masc_domain.Cancel
-    | Masc_domain.Release
-    | Masc_domain.Approve_verification
-    | Masc_domain.Reject_verification ->
-      None
-  in
   if (=) action Masc_domain.Release && strict_release_requires_handoff task_opt
      && Option.is_none handoff_context
   then
@@ -775,6 +762,21 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
          | _ -> action)
       | None -> action
     else action
+  in
+  let submit_evidence_error =
+    match requested_action with
+    | Masc_domain.Submit_for_verification | Masc_domain.Submit_pr_evidence ->
+      verification_submission_evidence_error ~notes ~handoff_context
+    | Masc_domain.Done_action when done_redirects_to_verification ->
+      verification_submission_evidence_error ~notes ~handoff_context
+    | Masc_domain.Claim
+    | Masc_domain.Start
+    | Masc_domain.Done_action
+    | Masc_domain.Cancel
+    | Masc_domain.Release
+    | Masc_domain.Approve_verification
+    | Masc_domain.Reject_verification ->
+      None
   in
   let action =
     match requested_action, task_opt, submit_evidence_error with

--- a/lib/tool_task_completion_review.ml
+++ b/lib/tool_task_completion_review.ml
@@ -65,23 +65,61 @@ let contains_substring_ci text needle =
   in
   loop 0
 
-let notes_have_verification_artifact_ref notes =
-  let notes = String.trim notes in
+let placeholder_evidence_refs =
+  [ "-"; "draft"; "n/a"; "na"; "none"; "null"; "pending"; "tbd"; "todo"; "unknown" ]
+
+let is_placeholder_evidence_ref value =
+  let value = value |> String.trim |> String.lowercase_ascii in
+  value = "" || List.mem value placeholder_evidence_refs
+
+let text_has_verification_artifact_ref text =
+  let text = String.trim text in
   let has_github_pull =
-    contains_substring_ci notes "github.com/"
-    && contains_substring_ci notes "/pull/"
+    contains_substring_ci text "github.com/"
+    && contains_substring_ci text "/pull/"
   in
   let has_pr_shorthand =
-    contains_substring_ci notes "#"
-    && (contains_substring_ci notes "pr "
-        || contains_substring_ci notes "pr:"
-        || contains_substring_ci notes "pull request")
+    contains_substring_ci text "#"
+    && (contains_substring_ci text "pr "
+        || contains_substring_ci text "pr:"
+        || contains_substring_ci text "pull request")
   in
   let has_explicit_artifact =
     [ "artifact:"; "artifact://"; "file:"; "path:"; "commit:"; "branch:" ]
-    |> List.exists (contains_substring_ci notes)
+    |> List.exists (contains_substring_ci text)
   in
   has_github_pull || has_pr_shorthand || has_explicit_artifact
+
+let pr_url_has_pull_ref pr_url =
+  let pr_url = String.trim pr_url in
+  (not (is_placeholder_evidence_ref pr_url))
+  && ((contains_substring_ci pr_url "github.com/"
+       && contains_substring_ci pr_url "/pull/")
+      || (contains_substring_ci pr_url "#"
+          && (contains_substring_ci pr_url "pr "
+              || contains_substring_ci pr_url "pr:"
+              || contains_substring_ci pr_url "pull request")))
+
+let artifact_like_ref value =
+  let value = String.trim value in
+  contains_substring_ci value "artifact://"
+  || contains_substring_ci value "file:"
+  || contains_substring_ci value "path:"
+  || contains_substring_ci value "commit:"
+  || contains_substring_ci value "branch:"
+  || contains_substring_ci value "github.com/"
+  || String.contains value '/'
+  || String.contains value '.'
+
+let evidence_ref_has_verification_artifact_ref value =
+  let value = String.trim value in
+  (not (is_placeholder_evidence_ref value))
+  && (text_has_verification_artifact_ref value || artifact_like_ref value)
+
+let notes_have_verification_artifact_ref notes =
+  let notes = String.trim notes in
+  (not (is_placeholder_evidence_ref notes))
+  && text_has_verification_artifact_ref notes
 
 let non_empty_trimmed_strings values =
   values
@@ -93,7 +131,7 @@ let non_empty_trimmed_strings values =
 let handoff_context_has_verification_artifact_ref = function
   | Some (handoff_context : Masc_domain.task_handoff_context) ->
       handoff_context.evidence_refs |> non_empty_trimmed_strings |> fun refs ->
-      refs <> []
+      List.exists evidence_ref_has_verification_artifact_ref refs
   | None -> false
 
 let verification_submission_evidence_error ~notes ~handoff_context =

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -1780,7 +1780,10 @@ let test_done_respects_persisted_cdal_gate () =
           config
           meta
           "keeper_task_done"
-          (`Assoc [ "task_id", `String task_id; "result", `String "tests pass" ])
+          (`Assoc
+             [ "task_id", `String task_id
+             ; "result", `String "tests pass; artifact:output.json"
+             ])
       in
       let json = parse_json result in
       match Yojson.Safe.Util.member "ok" json with
@@ -1816,7 +1819,10 @@ let test_done_redirects_to_verification_fsm () =
             config
             meta
             "keeper_task_done"
-            (`Assoc [ "task_id", `String task_id; "result", `String "tests pass" ])
+            (`Assoc
+               [ "task_id", `String task_id;
+                 "result", `String "tests pass; artifact:output.json";
+               ])
         in
         let json = parse_json result in
         match Yojson.Safe.Util.member "ok" json with
@@ -1866,9 +1872,9 @@ let test_done_redirects_default_contract_task_to_verification_fsm () =
           meta
           "keeper_task_done"
           (`Assoc
-              [ "task_id", `String task_id
-              ; "result", `String "Implemented change and ran focused checks."
-              ])
+             [ "task_id", `String task_id
+             ; "result", `String "Implemented change and ran focused checks. commit:abc123"
+             ])
       in
       let json = parse_json result in
       match Yojson.Safe.Util.member "ok" json with
@@ -1900,6 +1906,48 @@ let test_done_redirects_default_contract_task_to_verification_fsm () =
       | _ -> fail "expected keeper_task_done to redirect into verification FSM"))
 ;;
 
+let test_done_redirect_rejects_missing_verification_evidence () =
+  ensure_rng ();
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
+    with_room (fun config ->
+      let meta = make_test_meta () in
+      let _ =
+        Coord.add_task
+          config
+          ~title:"Default verification task without evidence"
+          ~priority:1
+          ~description:"done redirect must carry concrete evidence"
+      in
+      let task_id = (only_task config).id in
+      ignore (call_tool config meta "keeper_task_claim" (`Assoc []));
+      let result =
+        call_tool
+          config
+          meta
+          "keeper_task_done"
+          (`Assoc
+              [ "task_id", `String task_id
+              ; "result", `String "Implemented change and ran focused checks."
+              ])
+      in
+      let json = parse_json result in
+      match Yojson.Safe.Util.member "error" json with
+      | `String msg ->
+        check
+          bool
+          "requires evidence"
+          true
+          (contains_substring msg "requires verification evidence");
+        (match (only_task config).task_status with
+         | Masc_domain.InProgress _ | Masc_domain.Claimed _ -> ()
+         | status ->
+           fail
+             (Printf.sprintf
+                "expected task to stay owned, got %s"
+                (Masc_domain.string_of_task_status status)))
+      | _ -> fail "expected keeper_task_done to reject missing evidence"))
+;;
+
 let test_submit_for_verification_requires_pr_url () =
   with_room (fun config ->
     let meta = make_test_meta () in
@@ -1924,6 +1972,38 @@ let test_submit_for_verification_requires_pr_url () =
         "workflow_rejection"
         Yojson.Safe.Util.(member "failure_class" json |> to_string)
     | _ -> fail "expected error for empty pr_url")
+;;
+
+let test_submit_for_verification_rejects_placeholder_pr_url () =
+  ensure_rng ();
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
+    with_room (fun config ->
+      let meta = make_test_meta () in
+      let _ =
+        Coord.add_task
+          config
+          ~title:"Reject placeholder PR"
+          ~priority:1
+          ~description:"submit should require real PR evidence"
+      in
+      let task_id = (only_task config).id in
+      ignore (call_tool config meta "keeper_task_claim" (`Assoc []));
+      let result =
+        call_tool
+          config
+          meta
+          "keeper_task_submit_for_verification"
+          (`Assoc
+              [ "task_id", `String task_id
+              ; "notes", `String "work not actually submitted"
+              ; "pr_url", `String "draft"
+              ])
+      in
+      let json = parse_json result in
+      match Yojson.Safe.Util.member "error" json with
+      | `String msg ->
+        check bool "rejects placeholder" true (contains_substring msg "GitHub pull request")
+      | _ -> fail "expected error for placeholder pr_url"))
 ;;
 
 let test_submit_for_verification_transitions_task () =
@@ -2005,9 +2085,9 @@ let test_done_maps_result_to_typed_handoff_summary () =
         meta
         "keeper_task_done"
         (`Assoc
-            [ "task_id", `String task_id
-            ; "result", `String "refactored module, all tests green"
-            ])
+           [ "task_id", `String task_id
+           ; "result", `String "refactored module, all tests green, commit:abc123"
+           ])
     in
     let json = parse_json result in
     match Yojson.Safe.Util.member "ok" json with
@@ -2018,7 +2098,7 @@ let test_done_maps_result_to_typed_handoff_summary () =
          check
            string
            "result mapped to typed handoff_context.summary"
-           "refactored module, all tests green"
+           "refactored module, all tests green, commit:abc123"
            hc.summary
        | None ->
          fail "expected handoff_context to be populated after keeper_task_done")
@@ -2391,12 +2471,20 @@ let () =
             `Quick
             test_done_redirects_default_contract_task_to_verification_fsm
         ; test_case
+            "redirect requires concrete verification evidence"
+            `Quick
+            test_done_redirect_rejects_missing_verification_evidence
+        ; test_case
             "result maps to typed handoff_context.summary"
             `Quick
             test_done_maps_result_to_typed_handoff_summary
         ] )
     ; ( "submit_for_verification"
       , [ test_case "requires pr_url" `Quick test_submit_for_verification_requires_pr_url
+        ; test_case
+            "rejects placeholder pr_url"
+            `Quick
+            test_submit_for_verification_rejects_placeholder_pr_url
         ; test_case
             "transitions task"
             `Quick

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -304,7 +304,7 @@ let () = test "handle_done_records_approved_calibration_verdict" (fun () ->
   let result = Tool_task.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx
     (`Assoc [
       ("task_id", `String "task-001");
-      ("notes", `String "Implemented the calibration coverage path, verified the JSONL verdict store, and completed the task cleanly.")
+      ("notes", `String "Implemented the calibration coverage path, verified the JSONL verdict store, and completed the task cleanly. commit:abc123")
     ]) in
   if not result.Tool_result.success then failwith result.Tool_result.legacy_message;
   let store = Eval_calibration.get_store () in
@@ -506,7 +506,7 @@ let () = test "handle_done_redirects_to_verification_before_cdal_gate" (fun () -
                 ("task_id", `String "task-001");
                 ( "notes",
                   `String
-                    "Implemented deliverable-ready output and captured run_deliverable evidence." );
+                    "Implemented deliverable-ready output and captured artifact:run_deliverable evidence." );
               ])
         in
         if not result_done.Tool_result.success then
@@ -1666,7 +1666,42 @@ let () = test "transition_submit_for_verification_requires_evidence_ref" (fun ()
       (str_contains submit_result.Tool_result.legacy_message
          "requires verification evidence");
     assert_task_claimed_by ctx ctx.agent_name)
-)
+  )
+
+let () = test "transition_submit_for_verification_rejects_placeholder_evidence_ref" (fun () ->
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
+    let ctx = make_test_ctx () in
+    let add_result =
+      Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+        (`Assoc [ ("title", `String "Reject placeholder evidence") ])
+    in
+    if not add_result.Tool_result.success then failwith add_result.Tool_result.legacy_message;
+    let claim_result =
+      Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+        (`Assoc [ ("task_id", `String "task-001"); ("action", `String "claim") ])
+    in
+    if not claim_result.Tool_result.success then failwith claim_result.Tool_result.legacy_message;
+    let submit_result =
+      Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+        (`Assoc
+          [
+            ("task_id", `String "task-001");
+            ("action", `String "submit_for_verification");
+            ("notes", `String "Implementation complete.");
+            ( "handoff_context",
+              `Assoc
+                [
+                  ("summary", `String "Implementation complete.");
+                  ("evidence_refs", `List [ `String "none" ]);
+                ] );
+          ])
+    in
+    assert (not submit_result.Tool_result.success);
+    assert
+      (str_contains submit_result.Tool_result.legacy_message
+         "requires verification evidence");
+    assert_task_claimed_by ctx ctx.agent_name)
+  )
 
 let () = test "transition_submit_for_verification_aliases_todo_pr_evidence" (fun () ->
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
@@ -1928,7 +1963,7 @@ let () = test "transition_done_redirects_to_verification_and_clears_planning_cur
         [
           ("task_id", `String "task-001");
           ("action", `String "done");
-          ("notes", `String "Implemented the transport parity checks and verified the result.");
+          ("notes", `String "Implemented the transport parity checks and verified the result. commit:abc123");
         ])
   in
   assert done_result.Tool_result.success;


### PR DESCRIPTION
## Summary
- Tighten keeper verification submission so placeholder PR/evidence values like `draft` and `none` are rejected.
- Apply the same concrete-evidence gate when `keeper_task_done` redirects into the verification FSM.
- Preserve latest `main` todo `submit_for_verification` alias behavior while adding regression coverage for rejected placeholder evidence.

## Product impact
Keepers can still claim tasks and create worktrees, but they cannot mark PR/evidence-bearing work as awaiting verification with only progress notes. The task stays owned until the keeper provides a real PR, commit, branch, file, path, or artifact reference.

## Evidence
- `scripts/dune-local.sh build test/test_keeper_task_dispatch.exe test/test_tool_task_coverage.exe`
- `./_build/default/test/test_keeper_task_dispatch.exe` - 54 tests passed
- `./_build/default/test/test_tool_task_coverage.exe` - 96 tests passed
- `git diff --check` - clean

## Review evidence
Live runtime inspection on `/Users/dancer/me/.masc` showed recent keepers submitting placeholders such as `pr_url="draft"` / `pr_url="none"` and `keeper_task_done` results like "Ready to implement" into `awaiting_verification`. This PR blocks those paths at the tool/FSM boundary.

## Linked issue
- Follow-up from keeper autonomy/runtime investigation, no GitHub issue linked.
