### PR TITLE
fix(cdal): scope verifier verdicts to task tool targets

### DIFF
--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -8,6 +8,7 @@ type tool_call_detail =
   ; provider : string
   ; outcome : string
   ; latency_ms : float
+  ; task_id : string option
   ; route_evidence : Yojson.Safe.t option
   }
 
@@ -17,6 +18,11 @@ let tool_call_detail_to_json (detail : tool_call_detail) =
     | Some evidence -> [ ("route_evidence", evidence) ]
     | None -> []
   in
+  let task_id_field =
+    match detail.task_id with
+    | Some task_id -> [ ("task_id", `String task_id) ]
+    | None -> []
+  in
   `Assoc
     ([
        ("tool_name", `String detail.tool_name);
@@ -24,6 +30,7 @@ let tool_call_detail_to_json (detail : tool_call_detail) =
        ("outcome", `String detail.outcome);
        ("latency_ms", `Float detail.latency_ms);
      ]
+     @ task_id_field
      @ route_evidence_field)
 
 (** Result of a single Agent.run() keeper turn. *)

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -5,6 +5,7 @@ type tool_call_detail =
   ; provider : string
   ; outcome : string
   ; latency_ms : float
+  ; task_id : string option
   ; route_evidence : Yojson.Safe.t option
   }
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -104,10 +104,24 @@ let select_cdal_proof ~result_proof ~captured_proof =
   | None -> captured_proof
 ;;
 
+let cdal_task_id_for_verdict ~(current_task_id : string option)
+    ~(tool_calls : tool_call_detail list) =
+  match current_task_id with
+  | Some task_id -> Some task_id
+  | None ->
+    List.find_map
+      (fun (detail : tool_call_detail) ->
+         match detail.task_id with
+         | Some task_id when String.trim task_id <> "" -> Some task_id
+         | _ -> None)
+      tool_calls
+;;
+
 module For_testing = struct
   let sse_event_progress_kind = sse_event_progress_kind
   let registry_progress_on_event = registry_progress_on_event
   let select_cdal_proof = select_cdal_proof
+  let cdal_task_id_for_verdict = cdal_task_id_for_verdict
 end
 ;;
 
@@ -1510,14 +1524,21 @@ let run_turn
                           let store = Masc_mcp_cdal_runtime.Proof_store.default_config in
                           let outcome = Cdal_eval_v1.evaluate ~store p in
                           let verdict = Cdal_eval_v1.verdict_of_outcome outcome in
+                          let current_task_id =
+                            Option.map
+                              Keeper_id.Task_id.to_string
+                              acc.meta.current_task_id
+                          in
+                          let task_id =
+                            cdal_task_id_for_verdict
+                              ~current_task_id
+                              ~tool_calls:acc.tool_calls
+                          in
                           let task_subject =
                             Option.map
                               (fun task_id ->
-                                 Coord_hooks.
-                                   { kind = "task"
-                                   ; id = Keeper_id.Task_id.to_string task_id
-                                   })
-                              acc.meta.current_task_id
+                                 Coord_hooks.{ kind = "task"; id = task_id })
+                              task_id
                           in
                           let emit_keeper_activity ~kind ~payload ~tags =
                             try
@@ -1542,11 +1563,6 @@ let run_turn
                                 meta.name
                                 kind
                                 (Printexc.to_string exn)
-                          in
-                          let task_id =
-                            Option.map
-                              Keeper_id.Task_id.to_string
-                              acc.meta.current_task_id
                           in
                           Cdal_eval_v1.persist ?task_id verdict;
                           Keeper_turn_telemetry.log_keeper_contract_verdict

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -72,6 +72,7 @@ type tool_call_detail =
   ; provider : string
   ; outcome : string
   ; latency_ms : float
+  ; task_id : string option
   ; route_evidence : Yojson.Safe.t option
   }
 
@@ -252,6 +253,12 @@ module For_testing : sig
     -> captured_proof:Masc_mcp_cdal_runtime.Cdal_proof.t option
     -> Masc_mcp_cdal_runtime.Cdal_proof.t option
   (** Selects the proof used for keeper-side CDAL verdict persistence. *)
+
+  val cdal_task_id_for_verdict
+    :  current_task_id:string option
+    -> tool_calls:tool_call_detail list
+    -> string option
+  (** Selects the task scope used for keeper-side CDAL verdict persistence. *)
 end
 
 (** {1 Turn execution} *)

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -71,6 +71,33 @@ let record_requested_tool_names (acc : hook_accumulator) requested =
     merge_requested_tool_names_seen ~seen:acc.requested_tool_names_seen requested
 ;;
 
+let task_scope_tool_names =
+  [ "masc_transition"
+  ; "masc_claim_task"
+  ; "masc_complete_task"
+  ; "masc_release_task"
+  ; "masc_cancel_task"
+  ; "keeper_task_done"
+  ; "keeper_task_submit_for_verification"
+  ; "keeper_task_force_done"
+  ; "keeper_task_force_release"
+  ]
+;;
+
+let json_string_opt name = function
+  | `Assoc fields ->
+    (match List.assoc_opt name fields with
+     | Some (`String value) when String.trim value <> "" -> Some (String.trim value)
+     | _ -> None)
+  | _ -> None
+;;
+
+let task_id_scope_of_tool_input ~tool_name input =
+  if List.mem tool_name task_scope_tool_names
+  then json_string_opt "task_id" input
+  else None
+;;
+
 type tool_search_hit_partition =
   { visible_core_hits : (string * float) list
   ; discoverable_hits : (string * float) list
@@ -1357,6 +1384,7 @@ let prepare_agent_setup
               ~input
               ~output_text
           in
+          let task_id = task_id_scope_of_tool_input ~tool_name input in
           (match Keeper_registry.get ~base_path:config.base_path meta.name with
            | Some entry ->
              acc.meta <- entry.meta;
@@ -1367,6 +1395,7 @@ let prepare_agent_setup
              ; provider
              ; outcome = (if success then "ok" else "error")
              ; latency_ms = duration_ms
+             ; task_id
              ; route_evidence
              }
              :: acc.tool_calls)

--- a/test/test_keeper_cdal_contract.ml
+++ b/test/test_keeper_cdal_contract.ml
@@ -143,6 +143,41 @@ let test_select_cdal_proof_falls_back_to_captured_proof () =
   |> check_selected_proof_run_id "selected proof" "captured-proof"
 ;;
 
+let tool_call ?task_id tool_name : Keeper_agent_run.tool_call_detail =
+  { tool_name
+  ; provider = "runtime"
+  ; outcome = "ok"
+  ; latency_ms = 1.0
+  ; task_id
+  ; route_evidence = None
+  }
+;;
+
+let test_cdal_task_id_prefers_current_task () =
+  let selected =
+    Keeper_agent_run.For_testing.cdal_task_id_for_verdict
+      ~current_task_id:(Some "task-current")
+      ~tool_calls:[ tool_call ~task_id:"task-tool" "masc_transition" ]
+  in
+  check (option string) "selected task id" (Some "task-current") selected
+;;
+
+let test_cdal_task_id_falls_back_to_tool_target () =
+  let selected =
+    Keeper_agent_run.For_testing.cdal_task_id_for_verdict
+      ~current_task_id:None
+      ~tool_calls:
+        [ tool_call "keeper_status"
+        ; tool_call ~task_id:"task-approve-target" "masc_transition"
+        ]
+  in
+  check
+    (option string)
+    "selected task id"
+    (Some "task-approve-target")
+    selected
+;;
+
 let () =
   Alcotest.run
     "keeper_cdal_contract"
@@ -165,6 +200,14 @@ let () =
             "falls back to captured proof"
             `Quick
             test_select_cdal_proof_falls_back_to_captured_proof
+        ; test_case
+            "prefers current task id for verdict scope"
+            `Quick
+            test_cdal_task_id_prefers_current_task
+        ; test_case
+            "falls back to lifecycle tool target for verdict scope"
+            `Quick
+            test_cdal_task_id_falls_back_to_tool_target
         ] )
     ]
 ;;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5065,6 +5065,7 @@ let test_append_decision_record_persists_tool_calls () =
            ; provider = "codex_cli"
            ; outcome = "ok"
            ; latency_ms = 12.5
+           ; task_id = None
            ; route_evidence =
                Some
                  (`Assoc
@@ -5081,6 +5082,7 @@ let test_append_decision_record_persists_tool_calls () =
            ; provider = "codex_cli"
            ; outcome = "error"
            ; latency_ms = 3.0
+           ; task_id = None
            ; route_evidence = None
            }
          ]


### PR DESCRIPTION
## Summary
- Persist keeper CDAL verdicts with the active current_task_id when present, as before.
- When current_task_id is absent, fall back to the task_id from task lifecycle tool calls such as masc_transition, keeper_task_done, and keeper_task_submit_for_verification.
- Preserve task_id in keeper tool-call details so verifier/approver turns can produce task-scoped CDAL verdict rows.

## Why
PR #16265 fixed the misleading advisory missing-verdict warning after task-348, but it landed before this deeper scope fallback was pushed. The remaining root case is verifier-style turns: they may call masc_transition(action=approve, task_id=...) without owning current_task_id, so Cdal_eval_v1.persist wrote an unscoped verdict. This follow-up makes that proof task-scoped.

## Validation
- ocamlformat --check lib/keeper/keeper_agent_result.ml lib/keeper/keeper_agent_result.mli lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run.mli lib/keeper/keeper_run_tools.ml test/test_keeper_cdal_contract.ml test/test_keeper_unified.ml
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build ./test/test_keeper_cdal_contract.exe ./test/test_keeper_unified.exe
- ./_build/default/test/test_keeper_cdal_contract.exe

## Related
- Follow-up to #16265
- Live evidence: task-348 approval turn had task_id in masc_transition input but runtime current_task_id was null, producing unscoped CDAL rows.