### PR TITLE
test(config): pin deleted cwd resolution

### DIFF
--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -206,6 +206,33 @@ let test_inputs_from_env_honors_base_path_override_opt_in () =
   check string "root source" "local_masc"
     (Config_dir_resolver.source_to_string resolution.config_root.source)
 
+let test_inputs_from_env_survives_deleted_cwd () =
+  with_temp_dir "config-dir-deleted-cwd" @@ fun root ->
+  let parent = Filename.concat root "parent" in
+  let doomed = Filename.concat parent "doomed" in
+  let base = Filename.concat root "base" in
+  Unix.mkdir parent 0o755;
+  Unix.mkdir doomed 0o755;
+  let _config = make_config_root (Filename.concat base Common.masc_dirname) in
+  with_env "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE" (Some "true") @@ fun () ->
+  with_env "MASC_CONFIG_DIR" None @@ fun () ->
+  with_env "MASC_PERSONAS_DIR" None @@ fun () ->
+  with_env "MASC_BASE_PATH" (Some base) @@ fun () ->
+  with_env "MASC_BASE_PATH_INPUT" (Some base) @@ fun () ->
+  let saved_cwd = Sys.getcwd () in
+  Unix.chdir doomed;
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.chdir saved_cwd;
+      Config_dir_resolver.reset ())
+    (fun () ->
+      Unix.rmdir doomed;
+      let inputs = Config_dir_resolver.inputs_from_env () in
+      check string "deleted cwd falls back to base path" base inputs.cwd;
+      let resolution = Config_dir_resolver.resolve_with inputs in
+      check string "root source" "local_masc"
+        (Config_dir_resolver.source_to_string resolution.config_root.source))
+
 let test_normalize_masc_base_path_input_canonicalizes_explicit_path () =
   let actual =
     Env_config_core.normalize_masc_base_path_input
@@ -561,6 +588,8 @@ let () =
             test_inputs_from_env_honors_config_path_override_opt_in;
           test_case "inputs_from_env honors base-path override opt-in" `Quick
             test_inputs_from_env_honors_base_path_override_opt_in;
+          test_case "inputs_from_env survives deleted cwd" `Quick
+            test_inputs_from_env_survives_deleted_cwd;
           test_case "canonicalizes explicit base path" `Quick
             test_normalize_masc_base_path_input_canonicalizes_explicit_path;
         ] );


### PR DESCRIPTION
## Summary
- Replaces closed/unmerged #16225 as the current-main carrier for deleted-cwd config resolver coverage.
- Adds a regression test proving inputs_from_env survives when the process cwd is deleted and falls back to the configured base path.
- Keeps the implementation already present on main from #16197; this PR is now the missing proof/coverage slice.

## Verification
- PASS: opam exec -- ocamlformat --check test/test_config_dir_resolver.ml
- PASS: git diff --check origin/main...HEAD
- PASS before latest rebase: scripts/dune-local.sh build ./test/test_config_dir_resolver.exe
- PASS before latest rebase: scripts/dune-local.sh exec ./test/test_config_dir_resolver.exe (38 tests)
- NOTE: post-rebase focused Dune rerun was blocked by concurrent bare dune processes from other worktrees; CI is the current integration verifier.

## Context
- Old PR #16225 is closed without merge.
- Latest main implementation already catches deleted cwd via current_working_dir; this PR pins the behavior so it cannot silently regress.