### PR TITLE
refactor: split prometheus runtime metric names

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -37,6 +37,7 @@
  prometheus_core_metric_names
  prometheus_cascade_metric_names
  prometheus_oas_metric_names
+ prometheus_runtime_metric_names
  dashboard_http_keeper_metrics
  dashboard_http_keeper_detail
  dashboard_http_tool_quality

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -256,25 +256,9 @@ include Prometheus_oas_metric_names
 
 include Prometheus_cascade_metric_names
 
-(* MCP tool schema budget (set once at boot from mcp_server_eio.ml
-   via [set_tool_schema_stats]). *)
-let metric_mcp_tool_schema_count = "masc_mcp_tool_schema_count"
-let metric_mcp_tool_schema_tokens_approx = "masc_mcp_tool_schema_tokens_approx"
+include Prometheus_runtime_metric_names
 
 include Prometheus_transport_metric_names
-
-(* Admission queue metrics — used in admission_queue_metrics.ml. *)
-let metric_inference_queue_depth = "masc_inference_queue_depth"
-let metric_inference_queue_inflight = "masc_inference_queue_inflight"
-let metric_inference_queue_acquired = "masc_inference_queue_acquired_total"
-let metric_inference_queue_wait = "masc_inference_queue_wait_seconds"
-let metric_inference_queue_cancelled = "masc_inference_queue_cancelled_total"
-let metric_inference_queue_rejected = "masc_inference_queue_rejected_total"
-let metric_inference_queue_max_concurrent = "masc_inference_queue_max_concurrent"
-
-(* Agent health metrics — used in transport_metrics.ml. *)
-let metric_agent_heartbeat_age_seconds = "masc_agent_heartbeat_age_seconds"
-let metric_agent_stale_total = "masc_agent_stale_total"
 
 (* Process-level FD gauges — used in init() and update_fd_gauges. *)
 let metric_open_fds = "masc_process_open_fds"
@@ -290,21 +274,6 @@ let metric_pool_inflight_total = Pool_metrics.metric_inflight_total
 let metric_pool_reuse_total = Pool_metrics.metric_reuse_total
 let metric_pool_evict_total = Pool_metrics.metric_evict_total
 let metric_pool_create_total = Pool_metrics.metric_create_total
-
-(* PR-0.2.D: OCaml GC quick_stat sampler gauges.  Populated by
-   [Gc_sampler.run] from the runtime [Gc.quick_stat ()] once per
-   sampling interval.  Names follow the [masc_gc_*_words] /
-   [masc_gc_*] convention so PromQL queries can group on the
-   [masc_gc_] prefix.  Cumulative counters are exposed as Gauge
-   because they are read as point-in-time runtime snapshots; PromQL
-   [rate()] still works on monotonic-by-construction gauges. *)
-let metric_gc_minor_words = "masc_gc_minor_words"
-let metric_gc_major_words = "masc_gc_major_words"
-let metric_gc_heap_words = "masc_gc_heap_words"
-let metric_gc_live_words = "masc_gc_live_words"
-let metric_gc_compactions = "masc_gc_compactions"
-let metric_gc_promoted_words = "masc_gc_promoted_words"
-let metric_memory_usage_bytes = "masc_memory_usage_bytes"
 
 (* Domain-specific counters not yet constant-ised. *)
 let metric_anti_rationalization_fallback = "masc_anti_rationalization_fallback_total"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -114,8 +114,7 @@ val metric_coord_claim_post_provision_failures : string
 
 include module type of Prometheus_oas_metric_names
 
-val metric_mcp_tool_schema_count : string
-val metric_mcp_tool_schema_tokens_approx : string
+include module type of Prometheus_runtime_metric_names
 
 (** {1 Core counters / gauges} *)
 
@@ -516,60 +515,6 @@ val metric_governance_lenient_json_fallback_hit : string
 (** {1 Transport metrics} *)
 
 include module type of Prometheus_transport_metric_names
-
-(** {1 Admission queue metrics} *)
-
-val metric_inference_queue_depth : string
-val metric_inference_queue_inflight : string
-val metric_inference_queue_acquired : string
-val metric_inference_queue_wait : string
-val metric_inference_queue_cancelled : string
-
-(** Total admission requests rejected before execution. Labels:
-    [surface=with_permit|try_with_permit] and
-    [reason=host_resource_saturated]. *)
-val metric_inference_queue_rejected : string
-
-(** Total admission requests rejected before execution. Labels:
-    [surface=with_permit|try_with_permit] and
-    [reason=host_resource_saturated]. *)
-val metric_inference_queue_max_concurrent : string
-
-(** {1 Agent health metrics} *)
-
-val metric_agent_heartbeat_age_seconds : string
-val metric_agent_stale_total : string
-
-(** {1 OCaml GC sampler gauges (PR-0.2.D)}
-
-    Populated by {!module:Gc_sampler} once per sampling interval from
-    [Gc.quick_stat]. The cumulative word counters are exposed as
-    [Gauge] (not [Counter]) because they are read from the OCaml
-    runtime as point-in-time snapshots; PromQL [rate()] still works on
-    monotonic-by-construction gauges. [heap_words] and [live_words]
-    are point-in-time heap structure values, naturally a gauge. *)
-
-(** Cumulative words allocated in the minor heap since program start. *)
-val metric_gc_minor_words : string
-
-(** Cumulative words allocated in the major heap since program start. *)
-val metric_gc_major_words : string
-
-(** Current size of the major heap, in words. *)
-val metric_gc_heap_words : string
-
-(** Number of live words in the major heap at last sample. *)
-val metric_gc_live_words : string
-
-(** Number of major-heap compactions since program start. *)
-val metric_gc_compactions : string
-
-(** Cumulative words promoted from minor to major heap since program start. *)
-val metric_gc_promoted_words : string
-
-(** Approximate live OCaml heap memory usage in bytes, derived from
-    [Gc.quick_stat.live_words] and [Sys.word_size]. *)
-val metric_memory_usage_bytes : string
 
 (** [masc_keeper_oas_run_timeout_total] counter incremented in the
     cascade FSM each time an [Agent.run] / [run_stream] returns

--- a/lib/prometheus_runtime_metric_names.ml
+++ b/lib/prometheus_runtime_metric_names.ml
@@ -1,0 +1,24 @@
+(** Runtime schema, admission queue, agent-health, and GC sampler
+    metric-name constants.
+
+    Included by {!Prometheus} so existing callers keep using
+    [Prometheus.metric_*] bindings unchanged. *)
+
+let metric_mcp_tool_schema_count = "masc_mcp_tool_schema_count"
+let metric_mcp_tool_schema_tokens_approx = "masc_mcp_tool_schema_tokens_approx"
+let metric_inference_queue_depth = "masc_inference_queue_depth"
+let metric_inference_queue_inflight = "masc_inference_queue_inflight"
+let metric_inference_queue_acquired = "masc_inference_queue_acquired_total"
+let metric_inference_queue_wait = "masc_inference_queue_wait_seconds"
+let metric_inference_queue_cancelled = "masc_inference_queue_cancelled_total"
+let metric_inference_queue_rejected = "masc_inference_queue_rejected_total"
+let metric_inference_queue_max_concurrent = "masc_inference_queue_max_concurrent"
+let metric_agent_heartbeat_age_seconds = "masc_agent_heartbeat_age_seconds"
+let metric_agent_stale_total = "masc_agent_stale_total"
+let metric_gc_minor_words = "masc_gc_minor_words"
+let metric_gc_major_words = "masc_gc_major_words"
+let metric_gc_heap_words = "masc_gc_heap_words"
+let metric_gc_live_words = "masc_gc_live_words"
+let metric_gc_compactions = "masc_gc_compactions"
+let metric_gc_promoted_words = "masc_gc_promoted_words"
+let metric_memory_usage_bytes = "masc_memory_usage_bytes"

--- a/lib/prometheus_runtime_metric_names.mli
+++ b/lib/prometheus_runtime_metric_names.mli
@@ -1,0 +1,61 @@
+(** Runtime schema, admission queue, agent-health, and GC sampler
+    metric-name constants.
+
+    Included by {!Prometheus} so existing callers keep using
+    [Prometheus.metric_*] bindings unchanged. *)
+
+(** MCP tool schema budget gauges, set once at boot from [mcp_server_eio.ml]
+    via [set_tool_schema_stats]. *)
+val metric_mcp_tool_schema_count : string
+
+val metric_mcp_tool_schema_tokens_approx : string
+
+(** {1 Admission queue metrics} *)
+
+val metric_inference_queue_depth : string
+val metric_inference_queue_inflight : string
+val metric_inference_queue_acquired : string
+val metric_inference_queue_wait : string
+val metric_inference_queue_cancelled : string
+
+(** Total admission requests rejected before execution. Labels:
+    [surface=with_permit|try_with_permit] and
+    [reason=host_resource_saturated]. *)
+val metric_inference_queue_rejected : string
+
+(** Maximum configured concurrent inference permits. *)
+val metric_inference_queue_max_concurrent : string
+
+(** {1 Agent health metrics} *)
+
+val metric_agent_heartbeat_age_seconds : string
+val metric_agent_stale_total : string
+
+(** {1 OCaml GC sampler gauges}
+
+    Populated by {!module:Gc_sampler} once per sampling interval from
+    [Gc.quick_stat]. The cumulative word counters are exposed as [Gauge]
+    because they are read from the OCaml runtime as point-in-time snapshots;
+    PromQL [rate()] still works on monotonic-by-construction gauges. *)
+
+(** Cumulative words allocated in the minor heap since program start. *)
+val metric_gc_minor_words : string
+
+(** Cumulative words allocated in the major heap since program start. *)
+val metric_gc_major_words : string
+
+(** Current size of the major heap, in words. *)
+val metric_gc_heap_words : string
+
+(** Number of live words in the major heap at last sample. *)
+val metric_gc_live_words : string
+
+(** Number of major-heap compactions since program start. *)
+val metric_gc_compactions : string
+
+(** Cumulative words promoted from minor to major heap since program start. *)
+val metric_gc_promoted_words : string
+
+(** Approximate live OCaml heap memory usage in bytes, derived from
+    [Gc.quick_stat.live_words] and [Sys.word_size]. *)
+val metric_memory_usage_bytes : string


### PR DESCRIPTION
Re-opened from #16200 (auto-closed after base branch deletion). Splits prometheus_runtime metric names. Supersedes #16200.