### PR TITLE
Require concrete progress for owned keeper tasks

### DIFF
--- a/lib/coord/coord_worktree.mli
+++ b/lib/coord/coord_worktree.mli
@@ -125,6 +125,9 @@ val same_realpath : String.t -> String.t -> bool
 val is_usable_git_worktree : String.t -> bool
 (** [true] when [path] is a linked git worktree whose checkout is intact. *)
 
+val current_worktree_branch : String.t -> String.t option
+(** Current branch of [path], or [None] when it cannot be resolved. *)
+
 val run_git_in_clone :
   string -> string list -> Unix.process_status * string
 (** Run [git <args>] inside the clone at [path] (no [-C] when path is the

--- a/lib/coord/coord_worktree_lifecycle.ml
+++ b/lib/coord/coord_worktree_lifecycle.ml
@@ -165,21 +165,45 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
                  keeper_path branch_name repo_name race_note link_note
                  (Coord_worktree_paths.worktree_next_step keeper_path))
           in
-
-          (* Create .worktrees directory if not exists *)
-          Fs_compat.mkdir_p worktrees_dir;
-
-          (* Check if worktree already exists *)
-          if Coord_worktree_paths.safe_file_exists worktree_path then begin
-            if Coord_worktree_paths.is_usable_git_worktree worktree_path then
-              existing_worktree_ok ()
-            else
+          let existing_worktree_branch_conflict ?actual_branch () =
+            let actual =
+              match actual_branch with
+              | Some branch -> branch
+              | None -> "(unresolved)"
+            in
+            Error
+              (System (System_error.IoError
+                 (Printf.sprintf
+                    "worktree_path_conflict: %s already exists as a git \
+                     worktree on branch %s, but task %s expects branch %s. \
+                     Use the matching task/branch worktree or remove/repair \
+                     this path before retrying."
+                    worktree_path actual task_id branch_name)))
+          in
+          let existing_worktree_result ?(created_concurrently=false) () =
+            if not (Coord_worktree_paths.is_usable_git_worktree worktree_path)
+            then
               Error
                 (System (System_error.IoError
                    (Printf.sprintf
                       "worktree_path_conflict: %s already exists but is not a \
                        usable git worktree. Remove or repair it before retrying."
                       worktree_path)))
+            else
+              match Coord_worktree_paths.current_worktree_branch worktree_path with
+              | Some actual_branch when String.equal actual_branch branch_name ->
+                existing_worktree_ok ~created_concurrently ()
+              | Some actual_branch ->
+                existing_worktree_branch_conflict ~actual_branch ()
+              | None -> existing_worktree_branch_conflict ()
+          in
+
+          (* Create .worktrees directory if not exists *)
+          Fs_compat.mkdir_p worktrees_dir;
+
+          (* Check if worktree already exists *)
+          if Coord_worktree_paths.safe_file_exists worktree_path then begin
+            existing_worktree_result ()
           end else begin
             (* Fetch origin first; stale remotes must be explicit, not hidden.
                Use the longer git_fetch_timeout_sec budget — the default
@@ -271,7 +295,7 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
                 end
                 else if Coord_worktree_paths.is_usable_git_worktree worktree_path
                 then
-                  existing_worktree_ok ~created_concurrently:true ()
+                  existing_worktree_result ~created_concurrently:true ()
                 else begin
                   Coord_worktree_destructive_ops.rm_rf worktree_path;
                   let detail = String.trim git_output in

--- a/lib/coord/coord_worktree_paths.ml
+++ b/lib/coord/coord_worktree_paths.ml
@@ -124,6 +124,14 @@ let is_usable_git_worktree path =
       | None -> false)
   | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _ -> false
 
+let current_worktree_branch path =
+  match
+    Coord_worktree_exec.run_argv_with_status
+      [ "git"; "-C"; path; "rev-parse"; "--abbrev-ref"; "HEAD" ]
+  with
+  | Unix.WEXITED 0, output -> Coord_worktree_exec.first_nonempty_line output
+  | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _ -> None
+
 let run_git_in_clone clone_path args =
   Coord_worktree_exec.run_argv_with_status
     ([ "git"; "-C"; clone_path; "--no-optional-locks" ] @ args)

--- a/lib/coord/coord_worktree_paths.mli
+++ b/lib/coord/coord_worktree_paths.mli
@@ -34,6 +34,7 @@ val is_git_clone : string -> bool
 val has_git_marker : string -> bool
 val same_realpath : String.t -> String.t -> bool
 val is_usable_git_worktree : String.t -> bool
+val current_worktree_branch : String.t -> String.t option
 val run_git_in_clone :
   string -> string list -> Unix.process_status * string
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -117,11 +117,54 @@ let cdal_task_id_for_verdict ~(current_task_id : string option)
       tool_calls
 ;;
 
+let keeper_tool_names_for_outcome
+      ~(allowed_tool_names : string list)
+      ~(tool_calls : tool_call_detail list)
+      ~(outcome : string)
+  : string list
+  =
+  let observed_tool_names =
+    tool_calls
+    |> List.rev
+    |> List.filter_map (fun (detail : tool_call_detail) ->
+      if String.equal detail.outcome outcome then Some detail.tool_name else None)
+  in
+  Keeper_tool_disclosure.final_keeper_tool_names
+    ~reported_tool_names:[]
+    ~observed_tool_names
+    ~allowed_tool_names
+;;
+
+let progress_keeper_tool_names_for_contract
+      ~(allowed_tool_names : string list)
+      ~(actual_keeper_tool_names : string list)
+      ~(tool_calls : tool_call_detail list)
+  : string list
+  =
+  match tool_calls with
+  | [] -> actual_keeper_tool_names
+  | _ :: _ -> keeper_tool_names_for_outcome ~allowed_tool_names ~tool_calls ~outcome:"ok"
+;;
+
+let no_progress_success_tool_names_for_contract
+      ~(allowed_tool_names : string list)
+      ~(tool_calls : tool_call_detail list)
+  : string list
+  =
+  keeper_tool_names_for_outcome ~allowed_tool_names ~tool_calls ~outcome:"ok_no_progress"
+;;
+
 module For_testing = struct
   let sse_event_progress_kind = sse_event_progress_kind
   let registry_progress_on_event = registry_progress_on_event
   let select_cdal_proof = select_cdal_proof
   let cdal_task_id_for_verdict = cdal_task_id_for_verdict
+  let progress_keeper_tool_names_for_contract =
+    progress_keeper_tool_names_for_contract
+  ;;
+  let no_progress_success_tool_names_for_contract =
+    no_progress_success_tool_names_for_contract
+  ;;
 end
 ;;
 
@@ -1126,6 +1169,17 @@ let run_turn
                        ~allowed_tool_names:acc.requested_tool_names_seen
                    in
                    actual_keeper_tool_names_ref := actual_keeper_tool_names;
+                   let progress_keeper_tool_names =
+                     progress_keeper_tool_names_for_contract
+                       ~allowed_tool_names:acc.requested_tool_names_seen
+                       ~actual_keeper_tool_names
+                       ~tool_calls:acc.tool_calls
+                   in
+                   let no_progress_success_tool_names =
+                     no_progress_success_tool_names_for_contract
+                       ~allowed_tool_names:acc.requested_tool_names_seen
+                       ~tool_calls:acc.tool_calls
+                   in
                    let usage = Keeper_exec_context.usage_of_response result.response in
                    let ctx_composition =
                      build_ctx_composition_metrics
@@ -1160,10 +1214,22 @@ let run_turn
                      || Keeper_contract_classifier.is_actionable actionable_signal_kind
                    in
                    let actionable_tool_contract_violation_reason =
-                     Keeper_tool_disclosure.actionable_tool_contract_violation_reason
-                       ~claim_context_allowed:(not had_owned_active_task_at_turn_start)
-                       ~actionable_signal_context
-                       ~tool_names:actual_keeper_tool_names
+                     if
+                       actionable_signal_context
+                       && progress_keeper_tool_names = []
+                       && no_progress_success_tool_names <> []
+                     then
+                       Some
+                         (Printf.sprintf
+                            "actionable keeper signal was present, but the model only \
+                             used idempotent setup tools that made no execution \
+                             progress: %s"
+                            (String.concat ", " no_progress_success_tool_names))
+                     else
+                       Keeper_tool_disclosure.actionable_tool_contract_violation_reason
+                         ~claim_context_allowed:(not had_owned_active_task_at_turn_start)
+                         ~actionable_signal_context
+                         ~tool_names:progress_keeper_tool_names
                    in
                    let contract_violation_error reason =
                      Agent_sdk.Error.Agent
@@ -1179,7 +1245,7 @@ let run_turn
                        ~missing_visible_required:
                          acc.tool_surface.missing_required_tool_names
                        ~had_owned_active_task_at_turn_start
-                       ~actual_keeper_tool_names
+                       ~actual_keeper_tool_names:progress_keeper_tool_names
                    in
                    (* Required-tool turns are filtered onto providers that declare
             tool support plus tool_choice support. If a text-only response
@@ -1201,6 +1267,8 @@ let run_turn
                            : Keeper_execution_receipt.tool_contract_result =
                          if actual_keeper_tool_names = []
                          then Contract_missing_required_tool_use
+                         else if progress_keeper_tool_names = []
+                         then Contract_needs_execution_progress
                          else tool_contract_status ()
                        in
                        acc.receipt_tool_contract_result <- contract_status;

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -259,6 +259,20 @@ module For_testing : sig
     -> tool_calls:tool_call_detail list
     -> string option
   (** Selects the task scope used for keeper-side CDAL verdict persistence. *)
+
+  val progress_keeper_tool_names_for_contract
+    :  allowed_tool_names:string list
+    -> actual_keeper_tool_names:string list
+    -> tool_calls:tool_call_detail list
+    -> string list
+  (** Tool names that may satisfy keeper execution-progress contracts. *)
+
+  val no_progress_success_tool_names_for_contract
+    :  allowed_tool_names:string list
+    -> tool_calls:tool_call_detail list
+    -> string list
+  (** Successful tool calls that were intentionally classified as
+      idempotent/no-progress. *)
 end
 
 (** {1 Turn execution} *)

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -1384,6 +1384,16 @@ let prepare_agent_setup
               ~input
               ~output_text
           in
+          let outcome =
+            if not success
+            then "error"
+            else if
+              Keeper_tool_disclosure.tool_result_has_material_progress
+                ~tool_name
+                ~output_text
+            then "ok"
+            else "ok_no_progress"
+          in
           let task_id = task_id_scope_of_tool_input ~tool_name input in
           (match Keeper_registry.get ~base_path:config.base_path meta.name with
            | Some entry ->
@@ -1393,7 +1403,7 @@ let prepare_agent_setup
           acc.tool_calls
           <- { tool_name
              ; provider
-             ; outcome = (if success then "ok" else "error")
+             ; outcome
              ; latency_ms = duration_ms
              ; task_id
              ; route_evidence

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -516,13 +516,34 @@ let classify_tool_progress name =
   else Passive_status
 ;;
 
+let is_owned_task_coordination_progress_tool_name name =
+  let name = canonical_tool_name name in
+  match Tool_name.of_string name with
+  | Some (Tool_name.Keeper Tool_name.Keeper.Handoff)
+  | Some (Tool_name.Keeper Tool_name.Keeper.Pr_create)
+  | Some (Tool_name.Keeper Tool_name.Keeper.Pr_review_comment)
+  | Some (Tool_name.Keeper Tool_name.Keeper.Pr_review_reply) -> true
+  | _ -> false
+;;
+
 let is_owned_task_progress_tool_name name =
   if is_stay_silent_tool_name name
   then false
-  else (
-    match classify_tool_progress name with
-    | Execution | Completion -> true
-    | Passive_status | Claim_context -> false)
+  else
+    let name = canonical_tool_name name in
+    if is_completion_tool_name name || is_owned_task_coordination_progress_tool_name name
+    then true
+    else (
+      match Tool_catalog.effect_domain name with
+      | Some (Tool_catalog.Playground_write | Tool_catalog.Main_worktree_write) ->
+        true
+      | Some Tool_catalog.Masc_coordination
+      | Some Tool_catalog.Read_only
+      | None -> false)
+;;
+
+let is_actionable_signal_progress_tool_name name =
+  (not (is_stay_silent_tool_name name)) && tool_name_can_satisfy_required_contract name
 ;;
 
 let is_passive_status_tool_name name =
@@ -574,7 +595,12 @@ let actionable_tool_contract_violation_reason
     match tool_names with
     | [] ->
       Some "actionable keeper signal was present, but the model called no keeper tools"
-    | names when List.exists is_owned_task_progress_tool_name names -> None
+    | names
+      when List.exists
+             (if claim_context_allowed
+              then is_actionable_signal_progress_tool_name
+              else is_owned_task_progress_tool_name)
+             names -> None
     | names
       when (not claim_context_allowed)
            && not (List.exists is_owned_task_progress_tool_name names) ->

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -172,6 +172,22 @@ let final_keeper_tool_names
   |> List.filter (fun tool_name -> Hashtbl.mem allowed tool_name)
 ;;
 
+let result_text_for_progress_check output_text =
+  match Tool_output.decode_from_oas output_text with
+  | Tool_output.Stored { preview; _ } -> preview
+  | Tool_output.Inline value -> value
+;;
+
+let tool_result_has_material_progress ~(tool_name : string) ~(output_text : string)
+  : bool
+  =
+  let tool_name = canonical_name tool_name in
+  let output_text = result_text_for_progress_check output_text |> String.trim in
+  not
+    (String.equal tool_name "masc_worktree_create"
+     && String.starts_with ~prefix:"Worktree already exists:" output_text)
+;;
+
 let unexpected_tool_names ~(allowed_tool_names : string list) ~(tool_names : string list)
   : string list
   =

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -49,6 +49,15 @@ val final_keeper_tool_names
   -> allowed_tool_names:string list
   -> string list
 
+(** [true] when a successful tool result should count as material keeper
+    progress. Idempotent setup confirmations such as an already-existing task
+    worktree remain successful tool calls, but they do not satisfy execution
+    progress contracts by themselves. *)
+val tool_result_has_material_progress
+  :  tool_name:string
+  -> output_text:string
+  -> bool
+
 (** Names called by the model that are NOT on the keeper's allowed
     surface (deduped, order preserving). [allowed_tool_names] is
     canonicalized before comparison so runtime-reported internal

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -9503,6 +9503,43 @@ let test_actionable_tool_contract_allows_execution_tools () =
        ~tool_names:[ "keeper_bash"; "masc_status" ]);
   check
     (option string)
+    "board coordination can satisfy non-owned board signal"
+    None
+    (KTD.actionable_tool_contract_violation_reason
+       ~claim_context_allowed:true
+       ~actionable_signal_context:true
+       ~tool_names:[ "keeper_board_comment" ]);
+  (match
+     KTD.actionable_tool_contract_violation_reason
+       ~claim_context_allowed:false
+       ~actionable_signal_context:true
+       ~tool_names:[ "keeper_board_post"; "keeper_tasks_list" ]
+   with
+   | Some reason ->
+     check
+       bool
+       "owned task board-only turn requires execution progress"
+       true
+       (contains_substring reason "without execution progress")
+   | None -> fail "expected owned task board-only turn to violate contract");
+  check
+    (option string)
+    "worktree creation satisfies owned task progress"
+    None
+    (KTD.actionable_tool_contract_violation_reason
+       ~claim_context_allowed:false
+       ~actionable_signal_context:true
+       ~tool_names:[ "masc_worktree_create" ]);
+  check
+    (option string)
+    "PR creation satisfies owned task progress"
+    None
+    (KTD.actionable_tool_contract_violation_reason
+       ~claim_context_allowed:false
+       ~actionable_signal_context:true
+       ~tool_names:[ "keeper_pr_create" ]);
+  check
+    (option string)
     "non-actionable no-op remains allowed"
     None
     (KTD.actionable_tool_contract_violation_reason

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -9492,6 +9492,49 @@ let test_claim_contract_result_counts_initial_claim_as_execution () =
     (result ~required:[ "keeper_task_done" ] [ "keeper_task_claim" ])
 ;;
 
+let tool_call_detail ?(outcome = "ok") tool_name : KAR.tool_call_detail =
+  { tool_name
+  ; provider = "test"
+  ; outcome
+  ; latency_ms = 1.0
+  ; task_id = None
+  ; route_evidence = None
+  }
+;;
+
+let test_contract_progress_filters_no_progress_tool_results () =
+  let allowed_tool_names = [ "masc_worktree_create"; "keeper_bash" ] in
+  let no_progress_only =
+    [ tool_call_detail ~outcome:"ok_no_progress" "masc_worktree_create" ]
+  in
+  check
+    (list string)
+    "already-existing worktree is not contract progress"
+    []
+    (KAR.For_testing.progress_keeper_tool_names_for_contract
+       ~allowed_tool_names
+       ~actual_keeper_tool_names:[ "masc_worktree_create" ]
+       ~tool_calls:no_progress_only);
+  check
+    (list string)
+    "already-existing worktree remains visible as no-progress success"
+    [ "masc_worktree_create" ]
+    (KAR.For_testing.no_progress_success_tool_names_for_contract
+       ~allowed_tool_names
+       ~tool_calls:no_progress_only);
+  check
+    (list string)
+    "follow-up shell keeps the turn as progress"
+    [ "keeper_bash" ]
+    (KAR.For_testing.progress_keeper_tool_names_for_contract
+       ~allowed_tool_names
+       ~actual_keeper_tool_names:[ "masc_worktree_create"; "keeper_bash" ]
+       ~tool_calls:
+         [ tool_call_detail ~outcome:"ok_no_progress" "masc_worktree_create"
+         ; tool_call_detail "keeper_bash"
+         ])
+;;
+
 let test_actionable_tool_contract_allows_execution_tools () =
   check
     (option string)
@@ -9767,7 +9810,21 @@ let test_required_tool_satisfaction_accepts_mutating_tools () =
     true
     (satisfies_required_tool
        "keeper_shell"
-       (`Assoc [ "op", `String "gh"; "cmd", `String "pr comment 123 --body ok" ]))
+       (`Assoc [ "op", `String "gh"; "cmd", `String "pr comment 123 --body ok" ]));
+  check
+    bool
+    "fresh worktree create result is material progress"
+    true
+    (KTD.tool_result_has_material_progress
+       ~tool_name:"masc_worktree_create"
+       ~output_text:"Worktree created:\n  Path: /tmp/wt");
+  check
+    bool
+    "already-existing worktree result is idempotent no-progress"
+    false
+    (KTD.tool_result_has_material_progress
+       ~tool_name:"masc_worktree_create"
+       ~output_text:"Worktree already exists:\n  Path: /tmp/wt")
 ;;
 
 let test_explicit_required_tool_satisfaction_accepts_named_passive_tool () =
@@ -11583,6 +11640,15 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
        ~satisfied_tool_names:
          (Surface.satisfied_required_tool_names_of_outcomes
             [ "keeper_pr_review_comment", "ok" ]));
+  check
+    (list string)
+    "idempotent no-progress success stays outstanding"
+    [ "masc_worktree_create" ]
+    (Surface.outstanding_required_tool_names
+       ~required_tool_names:[ "masc_worktree_create" ]
+       ~satisfied_tool_names:
+         (Surface.satisfied_required_tool_names_of_outcomes
+            [ "masc_worktree_create", "ok_no_progress" ]));
   (match
      Surface.preferred_tool_choice_for_required_tool_names
        ~required_tool_names:[ "keeper_board_post" ]
@@ -12693,6 +12759,10 @@ let () =
             "initial claim counts as contract progress"
             `Quick
             test_claim_contract_result_counts_initial_claim_as_execution
+        ; test_case
+            "contract progress filters no-progress tool results"
+            `Quick
+            test_contract_progress_filters_no_progress_tool_results
         ; test_case
             "actionable signal allows execution tools"
             `Quick

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -832,6 +832,61 @@ let test_worktree_create_rejects_existing_non_git_worktree_path () =
       check bool "plain directory conflict was preserved" true
         (Sys.file_exists worktree_path)
 
+let test_worktree_create_rejects_existing_wrong_branch_worktree () =
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  init_process_eio env;
+  run_ok ~cwd:base_path "git init -q -b main";
+  let source_repo =
+    setup_nested_repo_with_remote ~base_path
+      ~repo_rel:"workspace/yousleepwhen/masc-mcp"
+  in
+  let sandbox_repos =
+    Filename.concat base_path ".masc/playground/test-agent/repos"
+  in
+  ensure_dir sandbox_repos;
+  let sandbox_clone = Filename.concat sandbox_repos "masc-mcp" in
+  run_ok ~cwd:base_path
+    (Printf.sprintf "git clone -q %s %s"
+       (Filename.quote source_repo) (Filename.quote sandbox_clone));
+  let config = Masc_mcp.Coord.default_config base_path in
+  ignore (Masc_mcp.Coord.init config ~agent_name:(Some "test-agent"));
+  let ctx : Tool_worktree.context = { config; agent_name = "test-agent" } in
+  let task_id = "task-branch-conflict" in
+  let worktree_path =
+    Filename.concat sandbox_clone
+      (Filename.concat ".worktrees"
+         (Playground_paths.worktree_dir_name "test-agent" task_id))
+  in
+  ensure_dir (Filename.dirname worktree_path);
+  run_ok ~cwd:sandbox_clone
+    (Printf.sprintf "git worktree add -q %s -b stale-existing-worktree origin/main"
+       (Filename.quote worktree_path));
+  let args =
+    `Assoc
+      [ ("task_id", `String task_id)
+      ; ("repo_name", `String "masc-mcp")
+      ; ("base_branch", `String "main")
+      ]
+  in
+  match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
+  | None -> fail "dispatch returned None for masc_worktree_create"
+  | Some result when result.success ->
+    fail
+      (Printf.sprintf
+         "expected wrong-branch worktree conflict, got success: %s"
+         result.legacy_message)
+  | Some result ->
+    let msg = result.legacy_message in
+    check_contains "message mentions worktree path conflict"
+      "worktree_path_conflict" msg;
+    check_contains "message mentions actual stale branch"
+      "stale-existing-worktree" msg;
+    check_contains "message mentions expected task branch"
+      "test-agent/task-branch-conflict" msg
+
 let test_worktree_create_concurrent_same_name_converges () =
   let base_path = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
@@ -948,6 +1003,8 @@ let () =
         test_worktree_path_rejects_traversal_name;
       test_case "existing non-git worktree path is rejected" `Quick
         test_worktree_create_rejects_existing_non_git_worktree_path;
+      test_case "existing wrong-branch worktree path is rejected" `Quick
+        test_worktree_create_rejects_existing_wrong_branch_worktree;
       test_case "concurrent same-name worktree create converges" `Quick
         test_worktree_create_concurrent_same_name_converges;
     ];


### PR DESCRIPTION
## Summary
- Tighten owned-task actionable progress classification so board posts/comments alone no longer count as execution progress for a keeper that already owns a task.
- Treat `masc_worktree_create` returning `Worktree already exists:` as an idempotent success, but not as material keeper progress or required-tool satisfaction.
- Reject pre-existing task worktree paths when the git worktree is on a different branch than the task expects.
- Keep non-owned board signals valid, and keep real worktree creation, code/worktree writes, bash/shell, PR creation, handoff, and completion tools as valid owned-task progress.

## Product impact
After a keeper claims a task, progress spam to the board or a repeated "worktree already exists" setup call no longer satisfies the runtime contract. The keeper must continue with cwd-based shell/code/test/push/PR/completion action, which matches the expected claim -> worktree -> edit/test -> push/PR flow.

## Evidence
- `scripts/dune-local.sh build test/test_tool_worktree_coverage.exe test/test_keeper_unified.exe`
- `./_build/default/test/test_tool_worktree_coverage.exe test agent_name_spoof 17,18` - 2 targeted tests passed
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 56,57,61` - 3 targeted tests passed
- `./_build/default/test/test_keeper_unified.exe test tool_classification 4` - 1 targeted test passed
- `git diff --check` - clean

## Review evidence
Live `/Users/dancer/me/.masc` tool-call evidence showed many owned-task turns using Bash/read/search and board posts while producing no git commit, push, or PR. The follow-up worktree review found the second loophole: an existing worktree was returned as OK for idempotence, then that OK was counted as keeper progress. This PR now preserves idempotent success while preventing it from closing the progress contract.

## Linked issue
- Follow-up from keeper autonomy/runtime investigation, no GitHub issue linked.
