### PR TITLE
fix(coord): repair legacy agent last_seen reads

### DIFF
--- a/lib/coord/coord_query.ml
+++ b/lib/coord/coord_query.ml
@@ -88,8 +88,7 @@ let load_agents_from_dir config dir ~include_inactive =
   |> List.filter_map (fun name ->
          safe_yield ();
          let path = Filename.concat dir name in
-         let json = read_json config path in
-         match agent_of_yojson json with
+         match read_agent_with_repair config path with
          | Ok agent when include_inactive || agent.status <> Masc_domain.Inactive ->
              Some agent
          | Ok _ | Error _ -> None)

--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -398,8 +398,9 @@ let read_json_opt config path =
 let agent_json_needs_repair = function
   | `Assoc fields -> (
       match List.assoc_opt "last_seen" fields with
-      | Some (`Int _ | `Float _) -> true
-      | _ -> false)
+      | Some (`String _) -> false
+      | Some (`Int _ | `Float _ | `Null) | None -> true
+      | Some _ -> false)
   | _ -> false
 
 let is_fd_pressure_text detail =

--- a/lib/coord/coord_worktree_lifecycle.ml
+++ b/lib/coord/coord_worktree_lifecycle.ml
@@ -124,8 +124,7 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
 
           let update_agent_current_task () =
             let agent_file = Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json") in
-            let json = read_json config agent_file in
-            match agent_of_yojson json with
+            match read_agent_with_repair config agent_file with
             | Ok agent ->
                 let updated_agent = { agent with current_task = Some worktree_name } in
                 write_json config agent_file (agent_to_yojson updated_agent)

--- a/test/test_room_state_recovery.ml
+++ b/test/test_room_state_recovery.ml
@@ -232,6 +232,47 @@ let test_agent_of_yojson_missing_last_seen_falls_back_to_now () =
   | Error msg ->
       fail ("missing last_seen+joined_at should fall back, not error: " ^ msg)
 
+let test_read_agent_with_repair_rewrites_missing_last_seen () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:None);
+      let legacy_agent_json =
+        `Assoc
+          [
+            ("name", `String "keeper-orphan");
+            ("agent_type", `String "keeper");
+            ("status", `String "active");
+            ("capabilities", `List []);
+            ("current_task", `Null);
+            ("joined_at", `String "2026-03-26T00:00:00Z");
+          ]
+      in
+      write_text_file (agent_path config "keeper-orphan")
+        (Yojson.Safe.to_string legacy_agent_json);
+
+      match Coord.read_agent_with_repair config (agent_path config "keeper-orphan") with
+      | Error msg -> fail ("missing last_seen should repair: " ^ msg)
+      | Ok agent ->
+          check string "last_seen bootstrapped from joined_at"
+            "2026-03-26T00:00:00Z" agent.last_seen;
+          let repaired_json =
+            match Safe_ops.read_file_safe (agent_path config "keeper-orphan") with
+            | Error error -> fail error
+            | Ok raw ->
+                raw
+                |> Backend.Compression.decompress_auto
+                |> Yojson.Safe.from_string
+          in
+          check bool "last_seen rewritten as canonical string" true
+            (match Yojson.Safe.Util.member "last_seen" repaired_json with
+             | `String "2026-03-26T00:00:00Z" -> true
+             | _ -> false))
+
 let test_heartbeat_repairs_legacy_agent_last_seen () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -290,6 +331,8 @@ let () =
             test_agent_of_yojson_annotates_invalid_last_seen;
           test_case "agent parser falls back when both last_seen and joined_at missing (#9751)" `Quick
             test_agent_of_yojson_missing_last_seen_falls_back_to_now;
+          test_case "read_agent_with_repair rewrites missing last_seen" `Quick
+            test_read_agent_with_repair_rewrites_missing_last_seen;
           test_case "heartbeat repairs legacy agent last_seen" `Quick
             test_heartbeat_repairs_legacy_agent_last_seen;
         ] );


### PR DESCRIPTION
## Summary
- route agent listing/worktree updates through repair-aware agent reads
- rewrite legacy agent JSON when last_seen is missing/null/numeric so later readers see canonical state
- add regression coverage for missing last_seen repair rewrite

## Tests
- ocamlformat --check lib/coord/coord_utils_ops.ml lib/coord/coord_query.ml lib/coord/coord_worktree_lifecycle.ml test/test_room_state_recovery.ml
- git diff --check origin/main..HEAD
- env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build ./test/test_room_state_recovery.exe
- ./_build/default/test/test_room_state_recovery.exe