### PR TITLE
refactor: split prometheus render helpers

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -33,6 +33,7 @@
  prometheus_format
  prometheus_key
  prometheus_store
+ prometheus_render
  prometheus_process
  prometheus_builtin_metric_names
  prometheus_builtin_metrics_part1

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -301,14 +301,8 @@ let set_tool_schema_stats ~count ~approx_tokens =
   set_gauge metric_mcp_tool_schema_tokens_approx (float_of_int approx_tokens)
 ;;
 
-let text_metric_type = function
-  | Counter -> Prometheus_text.Counter
-  | Gauge -> Prometheus_text.Gauge
-  | Histogram -> Prometheus_text.Histogram
-;;
-
-let type_to_string metric_type = Prometheus_text.type_to_string (text_metric_type metric_type)
-let labels_to_string = Prometheus_format.labels_to_string
+let type_to_string = Prometheus_render.type_to_string
+let labels_to_string = Prometheus_render.labels_to_string
 
 (* Track host labels seen in previous scrapes so we can zero out gauges
    for hosts that disappeared from the pool. Without this, an evicted
@@ -356,15 +350,7 @@ let to_prometheus_text () =
   update_fd_gauges ();
   update_fd_accountant_gauges ();
   update_pool_metrics_gauges ();
-  Prometheus_store.snapshot ()
-  |> List.map (fun (m : metric) ->
-    Prometheus_text.metric
-      ~name:m.name
-      ~help:m.help
-      ~metric_type:(text_metric_type m.metric_type)
-      ~value:m.value
-      ~labels:m.labels)
-  |> Prometheus_text.render
+  Prometheus_store.snapshot () |> Prometheus_render.render_snapshot
 ;;
 
 (** {1 Convenience Functions} *)

--- a/lib/prometheus_render.ml
+++ b/lib/prometheus_render.ml
@@ -1,0 +1,22 @@
+(** Prometheus text render helpers over store snapshots. *)
+
+let text_metric_type = function
+  | Prometheus_store.Counter -> Prometheus_text.Counter
+  | Prometheus_store.Gauge -> Prometheus_text.Gauge
+  | Prometheus_store.Histogram -> Prometheus_text.Histogram
+;;
+
+let type_to_string metric_type = Prometheus_text.type_to_string (text_metric_type metric_type)
+let labels_to_string = Prometheus_format.labels_to_string
+
+let render_snapshot snapshot =
+  snapshot
+  |> List.map (fun (m : Prometheus_store.metric) ->
+    Prometheus_text.metric
+      ~name:m.name
+      ~help:m.help
+      ~metric_type:(text_metric_type m.metric_type)
+      ~value:m.value
+      ~labels:m.labels)
+  |> Prometheus_text.render
+;;

--- a/lib/prometheus_render.mli
+++ b/lib/prometheus_render.mli
@@ -1,0 +1,5 @@
+(** Prometheus text render helpers over store snapshots. *)
+
+val type_to_string : Prometheus_store.metric_type -> string
+val labels_to_string : Prometheus_store.label list -> string
+val render_snapshot : Prometheus_store.metric list -> string


### PR DESCRIPTION
## Summary
- add Prometheus_render for text metric type conversion, label formatting, and snapshot rendering
- keep Prometheus facade functions type_to_string, labels_to_string, and to_prometheus_text stable
- leave scrape-time gauge refresh in Prometheus before rendering the store snapshot

## Verification
- ocamlformat --check lib/prometheus_render.ml lib/prometheus_render.mli lib/prometheus.ml
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_prometheus_coverage.exe test/test_eio_mutex_concurrency.exe was attempted but blocked by a live bare Dune process in another worktree