### PR TITLE
[codex] Fix required-tool cascade fallback order

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -763,6 +763,7 @@ fallback = true
 tiers = ["tier_medium", "primary", "__safe_lane"]
 strategy = "priority_tier"
 fallback = true
+keeper-assignable = false
 
 [tier-group.provider_benchmark]
 # Sweep lane for full provider inventory performance measurement

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -587,6 +587,11 @@ let degraded_rotation_candidates
   let candidates =
     match fallback_hint_candidate with
     | None -> raw_candidates
+    (* Required-tool retries must try the configured tool-required lane before
+       declarative fallback hints; otherwise a broad recovery chain can bypass
+       the runtime-MCP-capable lane and immediately land on a passive provider. *)
+    | Some hint when tool_requirement = Required ->
+        dedupe_keep_order (raw_candidates @ [ hint ])
     | Some hint -> dedupe_keep_order (hint :: raw_candidates)
   in
   candidates

--- a/test/test_cascade_config_validity.ml
+++ b/test/test_cascade_config_validity.ml
@@ -105,6 +105,53 @@ let test_cascade_json_absent () =
   check bool "config/cascade.json absent" false (Sys.file_exists (config_path "cascade.json"))
 ;;
 
+let find_tier_group cfg name =
+  cfg.Types.tier_groups
+  |> List.find_opt (fun (group : Types.cascade_tier_group) ->
+    String.equal group.name name)
+;;
+
+let index_of value values =
+  let rec loop index = function
+    | [] -> None
+    | candidate :: rest ->
+      if String.equal candidate value then Some index else loop (index + 1) rest
+  in
+  loop 0 values
+;;
+
+let test_ollama_cloud_stable_is_system_only () =
+  let cfg = load_checked_in_cascade_toml () in
+  match find_tier_group cfg "ollama_cloud_stable" with
+  | None -> fail "missing tier-group.ollama_cloud_stable"
+  | Some group ->
+    check
+      (option bool)
+      "ollama_cloud_stable keeper-assignable"
+      (Some false)
+      group.keeper_assignable
+;;
+
+let test_strict_tool_group_does_not_bypass_glm_before_ollama_cloud () =
+  let cfg = load_checked_in_cascade_toml () in
+  match find_tier_group cfg "strict_tool_candidates" with
+  | None -> fail "missing tier-group.strict_tool_candidates"
+  | Some group ->
+    (match index_of "ollama_cloud_stable" group.tiers with
+     | None -> ()
+     | Some cloud_index ->
+       (match index_of "glm-coding-with-spark" group.tiers with
+        | Some glm_index when glm_index < cloud_index -> ()
+        | Some _ ->
+          fail
+            "strict_tool_candidates must try glm-coding-with-spark before \
+             ollama_cloud_stable"
+        | None ->
+          fail
+            "strict_tool_candidates must not include ollama_cloud_stable without \
+             glm-coding-with-spark ahead of it"))
+;;
+
 let check_qwen_thinking_control cfg model_id =
   match Types.model_capabilities_for_id cfg model_id with
   | Some c ->
@@ -133,6 +180,14 @@ let () =
             `Quick
             test_cascade_toml_runtime_validates_without_rejected_profiles
         ; test_case "cascade.json is not a checked-in source" `Quick test_cascade_json_absent
+        ; test_case
+            "ollama_cloud_stable is system-only"
+            `Quick
+            test_ollama_cloud_stable_is_system_only
+        ; test_case
+            "strict tool group does not bypass GLM before Ollama Cloud"
+            `Quick
+            test_strict_tool_group_does_not_bypass_glm_before_ollama_cloud
         ; test_case
             "qwen models use chat_template_kwargs thinking control"
             `Quick

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -169,7 +169,7 @@ let test_rotation_skips_direct_tier_after_attempted_tier_group () =
       retry.next_cascade
   | None -> fail "Expected rotation to skip duplicate direct tier candidate"
 
-let test_required_tool_rotation_uses_explicit_fallback_hint () =
+let test_required_tool_rotation_prioritizes_tool_route_before_fallback_hint () =
   let err =
     Owne.sdk_error_of_masc_internal_error
       (Owne.Resumable_cli_session
@@ -185,18 +185,47 @@ let test_required_tool_rotation_uses_explicit_fallback_hint () =
     KEC.degraded_rotation_after_recoverable_error
       ~rotation_cascades:[ "glm-coding-with-spark"; "strict_tool_candidates" ]
       ~fallback_hint:"ollama_cloud_stable"
-      ~base_cascade:"glm-coding-with-spark"
+      ~base_cascade:"strict_tool_candidates"
+      ~effective_cascade:"strict_tool_candidates"
+      ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Required
+      ~attempted_cascades:[ "strict_tool_candidates" ]
+      err
+  with
+  | Some retry ->
+    check string "tool-required route wins" "glm-coding-with-spark"
+      retry.next_cascade;
+    check string "reason is resumable_cli_session" "resumable_cli_session"
+      (KEC.degraded_retry_reason_to_string retry.fallback_reason)
+  | None -> fail "Required-tool resumable session should use tool route"
+
+let test_required_tool_rotation_uses_fallback_hint_after_tool_route_attempted () =
+  let err =
+    Owne.sdk_error_of_masc_internal_error
+      (Owne.Resumable_cli_session
+         {
+           cascade_name = cascade_name "strict_tool_candidates";
+           detail =
+             "CLI JSON-stream transport reported a resumable session (exit 75). \
+              Resumable session available via -r.";
+           exit_code = Some 75;
+         })
+  in
+  match
+    KEC.degraded_rotation_after_recoverable_error
+      ~rotation_cascades:[ "glm-coding-with-spark"; "strict_tool_candidates" ]
+      ~fallback_hint:"ollama_cloud_stable"
+      ~base_cascade:"strict_tool_candidates"
       ~effective_cascade:"strict_tool_candidates"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Required
       ~attempted_cascades:[ "strict_tool_candidates"; "glm-coding-with-spark" ]
       err
   with
   | Some retry ->
-    check string "explicit fallback hint wins" "ollama_cloud_stable"
-      retry.next_cascade;
+    check string "explicit fallback hint remains terminal fallback"
+      "ollama_cloud_stable" retry.next_cascade;
     check string "reason is resumable_cli_session" "resumable_cli_session"
       (KEC.degraded_retry_reason_to_string retry.fallback_reason)
-  | None -> fail "Required-tool resumable session should use explicit fallback"
+  | None -> fail "Required-tool resumable session should use terminal fallback"
 
 (* ---- Status-code-aware rotation tests ----------------------------------- *)
 
@@ -391,8 +420,10 @@ let () =
             test_catalog_rotation_preserves_order_without_base_injection;
           test_case "skips direct tier after attempted tier-group" `Quick
             test_rotation_skips_direct_tier_after_attempted_tier_group;
-          test_case "required-tool rotation honors explicit fallback hint" `Quick
-            test_required_tool_rotation_uses_explicit_fallback_hint;
+          test_case "required-tool rotation prefers tool route before fallback hint" `Quick
+            test_required_tool_rotation_prioritizes_tool_route_before_fallback_hint;
+          test_case "required-tool rotation keeps fallback hint after tool route" `Quick
+            test_required_tool_rotation_uses_fallback_hint_after_tool_route_attempted;
           test_case "soft rate-limit rotates to next cascade" `Quick
             test_rotation_finds_next_cascade_for_rate_limit;
           test_case "auth error rotates to next cascade" `Quick


### PR DESCRIPTION
## Summary

- Keep required-tool degraded retries on the configured tool-required route before applying declarative fallback hints.
- Mark `tier-group.ollama_cloud_stable` as non-keeper-assignable in the checked-in cascade seed.
- Add regression checks for the Ollama Cloud recovery group and strict-tool fallback ordering.

## Root Cause

Required-tool retries prepended `fallback_cascade` hints ahead of the configured tool-required rotation route. A broad fallback chain could therefore bypass the runtime-MCP-capable recovery lane and immediately land on an Ollama Cloud recovery target, where required-tool turns are more likely to fail with contract violations.

## Validation

- `ocamlformat -i lib/keeper/keeper_error_classify.ml test/test_keeper_error_classify_recoverable.ml test/test_cascade_config_validity.ml`
- `git diff --check`
- Attempted focused local build:
  `MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_keeper_error_classify_recoverable.exe test/test_cascade_config_validity.exe`
  This was stopped after more than 8 minutes with no compiler result because the host already had multiple concurrent Dune builds, including `@check`, running in other sessions.
