### PR TITLE
feat(keeper): enable typed Docker Shell IR dispatch

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -1075,12 +1075,44 @@ let typed_input_command_text = function
       typed_stage_command_text ~executable:stage.executable ~argv:stage.argv)
     |> String.concat " | "
 
+let typed_input_has_env = function
+  | Keeper_tool_bash_input.Exec { env; _ }
+  | Keeper_tool_bash_input.Pipeline { env; _ } ->
+    env <> []
+
 let typed_validation_error_text error =
   Format.asprintf "%a" Keeper_tool_bash_input.pp_validation_error error
 
 let normalize_path_for_keeper_bash_containment path =
   Keeper_alerting_path.normalize_path_for_check path
   |> Keeper_alerting_path.strip_trailing_slashes
+
+let typed_docker_image (meta : keeper_meta) =
+  match meta.sandbox_image with
+  | Some img when String.trim img <> "" -> img
+  | _ -> Env_config_keeper.KeeperSandbox.docker_image ()
+
+let typed_docker_sandbox_target ~turn_sandbox_factory ~meta ~cwd =
+  match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
+  | None ->
+    Error
+      "typed keeper_bash Docker Shell IR dispatch requires a turn sandbox factory"
+  | Some runtime ->
+    let image = typed_docker_image meta in
+    let runner ~stdin_content ~argv ~env:_ ~cwd:stage_cwd ~timeout_sec =
+      let cwd = Option.value stage_cwd ~default:cwd in
+      match
+        Keeper_turn_sandbox_runtime.run_exec_with_status
+          ?stdin_content
+          runtime
+          ~timeout_sec
+          ~cwd
+          ~command_argv:argv
+      with
+      | Ok (status, output) -> status, output, ""
+      | Error err -> Unix.WEXITED 1, "", err
+    in
+    Ok (Masc_exec.Sandbox_target.docker ~image ~runner)
 
 let handle_keeper_bash_typed
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
@@ -1092,18 +1124,12 @@ let handle_keeper_bash_typed
       ~write_enabled
       ()
   =
-  ignore turn_sandbox_factory;
   let root = Keeper_alerting_path.project_root_of_config config in
   if run_in_background
   then
     error_json
       ~fields:[ "typed", `Bool true ]
       "typed keeper_bash does not support run_in_background yet; use legacy cmd or foreground typed exec"
-  else if meta.sandbox_profile = Docker
-  then
-    error_json
-      ~fields:[ "typed", `Bool true ]
-      "typed keeper_bash Shell IR dispatch for Docker is not enabled yet; use legacy cmd until the Docker runner carries stdin/cwd through pipeline stages"
   else
     match Keeper_shell_shared.resolve_keeper_shell_write_cwd ~config ~meta ~args with
     | Error e -> error_json e
@@ -1139,12 +1165,21 @@ let handle_keeper_bash_typed
         let sandbox_profile, _sandbox_network_mode =
           Keeper_shell_shared.effective_sandbox_profile ~meta ~in_playground
         in
-        if sandbox_profile = Docker
-        then
-          error_json
-            ~fields:[ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]
-            "typed keeper_bash Shell IR dispatch for Docker is not enabled yet; use legacy cmd until the Docker runner carries stdin/cwd through pipeline stages"
-        else if Worker_dev_tools.is_destructive_bash_operation cmd
+        let dispatch_sandbox =
+          match sandbox_profile with
+          | Local -> Ok (Masc_exec.Sandbox_target.host ())
+          | Docker ->
+            if typed_input_has_env input
+            then Error "typed keeper_bash Docker Shell IR dispatch does not support env yet"
+            else typed_docker_sandbox_target ~turn_sandbox_factory ~meta ~cwd
+        in
+        (match dispatch_sandbox with
+         | Error e ->
+           error_json
+             ~fields:[ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]
+             e
+         | Ok dispatch_sandbox ->
+        if Worker_dev_tools.is_destructive_bash_operation cmd
         then
           Yojson.Safe.to_string
             (Exec_core.blocked_result_json
@@ -1172,7 +1207,7 @@ let handle_keeper_bash_typed
                ~extra:[ "cmd", `String cmd_for_log; "typed", `Bool true; "execution_time_ms", `Int 0 ]
                ())
         else
-          match Keeper_tool_bash_input.to_shell_ir ~mode input with
+          match Keeper_tool_bash_input.to_shell_ir ~mode ~sandbox:dispatch_sandbox input with
           | Error e ->
             error_json
               ~fields:[ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]
@@ -1225,7 +1260,7 @@ let handle_keeper_bash_typed
                     ~status:result.status
                     ~output
                     ~env_snapshot:env_snap
-                    ()))
+                    ())))
 
 let handle_keeper_bash
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)

--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -293,7 +293,7 @@ let shell_bin ~mode executable =
     Error (Executable_not_allowlisted { name; mode })
 ;;
 
-let shell_simple ~mode ?cwd ?(env = []) { executable; argv } =
+let shell_simple ~mode ?(sandbox = Masc_exec.Sandbox_target.host ()) ?cwd ?(env = []) { executable; argv } =
   let ( let* ) = Result.bind in
   let* bin = shell_bin ~mode executable in
   Ok
@@ -302,24 +302,24 @@ let shell_simple ~mode ?cwd ?(env = []) { executable; argv } =
     ; env = shell_env env
     ; cwd = shell_cwd cwd
     ; redirects = []
-    ; sandbox = Masc_exec.Sandbox_target.host ()
+    ; sandbox
     }
 ;;
 
-let to_shell_ir ~mode input =
+let to_shell_ir ?(sandbox = Masc_exec.Sandbox_target.host ()) ~mode input =
   let ( let* ) = Result.bind in
   let* () = validate ~mode input in
   match input with
   | Exec { executable; argv; cwd; env } ->
     let stage = { executable; argv } in
-    let* simple = shell_simple ~mode ?cwd ~env stage in
+    let* simple = shell_simple ~mode ~sandbox ?cwd ~env stage in
     Ok (Masc_exec.Shell_ir.Simple simple)
   | Pipeline { stages; cwd; env } ->
     let* simples =
       let rec loop acc = function
         | [] -> Ok (List.rev acc)
         | stage :: rest ->
-          let* simple = shell_simple ~mode ?cwd ~env stage in
+          let* simple = shell_simple ~mode ~sandbox ?cwd ~env stage in
           loop (Masc_exec.Shell_ir.Simple simple :: acc) rest
       in
       loop [] stages

--- a/lib/keeper/keeper_tool_bash_input.mli
+++ b/lib/keeper/keeper_tool_bash_input.mli
@@ -85,10 +85,15 @@ val validate : mode:allowlist_mode -> bash_input -> (unit, validation_error) res
     effects, no exceptions. *)
 
 val to_shell_ir :
-  mode:allowlist_mode -> bash_input -> (Masc_exec.Shell_ir.t, validation_error) result
+  ?sandbox:Masc_exec.Sandbox_target.t ->
+  mode:allowlist_mode ->
+  bash_input ->
+  (Masc_exec.Shell_ir.t, validation_error) result
 (** Validate and lower [input] into {!Masc_exec.Shell_ir.t}.  [Pipeline]
     inputs become an explicit {!Masc_exec.Shell_ir.Pipeline}; literal ["|"]
-    argv tokens remain ordinary argument data and never create a pipeline. *)
+    argv tokens remain ordinary argument data and never create a pipeline.
+    [sandbox] defaults to host execution; keeper callers may provide Docker
+    runtime targets after sandbox/profile resolution. *)
 
 val pp_validation_error : Format.formatter -> validation_error -> unit
 (** Human-readable formatter for {!validation_error}.  Stable across

--- a/lib/keeper/keeper_turn_sandbox_runtime.mli
+++ b/lib/keeper/keeper_turn_sandbox_runtime.mli
@@ -36,6 +36,17 @@ val run_command_with_status :
   unit ->
   (Unix.process_status * string, string) result
 
+val run_exec_with_status :
+  ?stdin_content:string ->
+  t ->
+  timeout_sec:float ->
+  cwd:string ->
+  command_argv:string list ->
+  (Unix.process_status * string, string) result
+(** Execute [command_argv] inside the turn-scoped container and return the raw
+    process status and merged output without applying success-code policy.
+    This is the argv-level entrypoint used by Shell IR dispatch. *)
+
 val run_command :
   ?ok_exit_codes:int list ->
   t ->

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -950,13 +950,13 @@ let test_keeper_bash_typed_pipeline_runs_via_shell_ir () =
      |> Json.to_string
      |> fun output -> String_util.contains_substring output "5")
 
-let test_keeper_bash_typed_docker_is_fail_closed () =
+let test_keeper_bash_typed_docker_requires_factory () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
   Keeper_registry.clear ();
   let meta = make_docker_meta "typed-docker" in
-  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir playground;
   let raw =
     Keeper_exec_shell.handle_keeper_bash
@@ -975,9 +975,9 @@ let test_keeper_bash_typed_docker_is_fail_closed () =
   in
   match parse_error_field raw with
   | Some err ->
-    Alcotest.(check bool) "docker typed path is explicit" true
-      (String_util.contains_substring err "Docker is not enabled yet")
-  | None -> Alcotest.fail ("expected typed docker fail-closed error, got: " ^ raw)
+    if not (String_util.contains_substring err "turn sandbox factory")
+    then Alcotest.fail ("unexpected typed docker error: " ^ err)
+  | None -> Alcotest.fail ("expected typed docker factory error, got: " ^ raw)
 
 let test_keeper_bash_safe_dev_null_echo_fallback_executes_primary () =
   with_eio_fs @@ fun () ->
@@ -1779,8 +1779,8 @@ let () =
         test_keeper_bash_typed_exec_runs_via_shell_ir;
       Alcotest.test_case "typed pipeline runs via Shell IR" `Quick
         test_keeper_bash_typed_pipeline_runs_via_shell_ir;
-      Alcotest.test_case "typed docker dispatch fails closed" `Quick
-        test_keeper_bash_typed_docker_is_fail_closed;
+      Alcotest.test_case "typed docker dispatch requires factory" `Quick
+        test_keeper_bash_typed_docker_requires_factory;
     ]);
     ("readonly_hints", [
       Alcotest.test_case "safe dev-null echo fallback executes primary" `Quick

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -334,6 +334,50 @@ let test_pipeline_lowers_to_shell_ir_pipeline () =
     Alcotest.failf "expected Shell_ir.Pipeline, got %a" Masc_exec.Shell_ir.pp other
 ;;
 
+let docker_test_sandbox () =
+  Masc_exec.Sandbox_target.docker
+    ~image:"typed-docker"
+    ~runner:(fun ~stdin_content:_ ~argv:_ ~env:_ ~cwd:_ ~timeout_sec:_ ->
+      Unix.WEXITED 0, "", "")
+;;
+
+let check_docker_sandbox label simple =
+  match simple.Masc_exec.Shell_ir.sandbox with
+  | Masc_exec.Sandbox_target.Host -> Alcotest.fail (label ^ ": expected Docker sandbox")
+  | Docker { image; _ } -> Alcotest.(check string) (label ^ " image") "typed-docker" image
+;;
+
+let test_pipeline_lowers_with_injected_docker_sandbox () =
+  let input =
+    Bash_input.Pipeline
+      { stages =
+          [ { executable = "echo"; argv = [ "hello" ] }
+          ; { executable = "wc"; argv = [ "-c" ] }
+          ]
+      ; cwd = Some "/tmp"
+      ; env = []
+      }
+  in
+  match
+    Bash_input.to_shell_ir
+      ~mode:Bash_input.Dev_full
+      ~sandbox:(docker_test_sandbox ())
+      input
+  with
+  | Ok
+      (Masc_exec.Shell_ir.Pipeline
+        [ Masc_exec.Shell_ir.Simple first; Masc_exec.Shell_ir.Simple second ]) ->
+    check_docker_sandbox "first stage" first;
+    check_docker_sandbox "second stage" second
+  | Ok other ->
+    Alcotest.failf "expected Shell_ir.Pipeline, got %a" Masc_exec.Shell_ir.pp other
+  | Error error ->
+    Alcotest.failf
+      "to_shell_ir failed: %a"
+      Bash_input.pp_validation_error
+      error
+;;
+
 let test_pipe_character_in_exec_argv_is_literal () =
   let input =
     Bash_input.Exec
@@ -419,6 +463,10 @@ let suite =
           "pipeline_lowers_to_shell_ir_pipeline"
           `Quick
           test_pipeline_lowers_to_shell_ir_pipeline
+      ; Alcotest.test_case
+          "pipeline_lowers_with_injected_docker_sandbox"
+          `Quick
+          test_pipeline_lowers_with_injected_docker_sandbox
       ; Alcotest.test_case
           "pipe_character_in_exec_argv_is_literal"
           `Quick


### PR DESCRIPTION
## Summary
Enables typed Docker Shell IR dispatch for the typed `keeper_bash` input. Threads a `?sandbox` parameter through `Keeper_tool_bash_input.shell_simple` / `to_shell_ir` so the bash tool can dispatch to either host or docker sandbox targets without bypassing the typed pipeline.

Picked up from the stale branch `fix/keeper-bash-typed-docker-ir-20260518` after #16235, #16238, #16256 landed the prerequisite typed JSON / Shell IR groundwork on `main`. Three of the original seven commits were already subsumed by those merges; the remaining novel work is this single commit (parse-json content is identical in main via #16238; legacy-cmd reject was already hoisted up earlier in `of_json`; diagnostics test already on main).

## Changes
- `lib/keeper/keeper_shell_bash.ml`: dispatch typed bash through Shell IR using injected sandbox target (+47/-16)
- `lib/keeper/keeper_tool_bash_input.ml/.mli`: add optional `?sandbox` to `shell_simple` and `to_shell_ir`
- `lib/keeper/keeper_turn_sandbox_runtime.mli`: surface sandbox target for typed dispatch (+11)
- `test/test_keeper_bash_safety.ml`: adapt to new signature
- `test/test_keeper_bash_typed_input.ml`: cover typed Docker dispatch (+48)

Total: 6 files, +127 / -28.

## Verification
- `opam exec -- ocamlformat --check` on all 6 files: PASS
- `git diff --check`: PASS
- `dune build --root . lib/keeper -j 4` (isolated `/private/tmp/masc-mcp-typed-bash-ir`): PASS
- Full test binary link is currently blocked by an unrelated `lib/prometheus.ml` regression on `origin/main` (`Unbound value metric_key` at line 262) — being fixed by in-flight Draft PR #16289 (`fix: expose prometheus store snapshot`). Once #16289 lands, the typed-bash test suite will be re-run on this PR.

## Notes
- Recovered from `origin/fix/keeper-bash-typed-docker-ir-20260518`, which had 7 commits with no PR; rebased to single-commit equivalent here.
- No file pattern matches the RFC-required keeper subsystems (`credential_*`, `keeper_gh_*`, `host_config_*`). No new external surface; sandbox-target plumbing only.
- RFC-WAIVED: file-scope outside mandatory list; sandbox dispatch wiring follows existing Shell IR API.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
