### PR TITLE
fix(keeper): classify workflow rejections as self-correcting

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -636,6 +636,50 @@ let prompt_for_facts facts_json =
   | Ok value -> value
   | Error _ -> Prompt_registry.get_prompt "dashboard.governance_judge"
 
+let rec json_has_material_value = function
+  | `Null -> false
+  | `Bool value -> value
+  | `Int value -> value <> 0
+  | `Intlit value -> String.trim value <> "" && value <> "0"
+  | `Float value -> value <> 0.0
+  | `String value -> String.trim value <> ""
+  | `List values -> List.exists json_has_material_value values
+  | `Assoc fields -> List.exists (fun (_, value) -> json_has_material_value value) fields
+
+let list_field_nonempty name json =
+  match json |> member name with
+  | `List (_ :: _) -> true
+  | _ -> false
+
+let agents_facts_nonempty = function
+  | `Assoc fields ->
+      let count_nonzero =
+        match List.assoc_opt "count" fields with
+        | Some (`Int value) -> value > 0
+        | Some (`Intlit value) -> (
+            match int_of_string_opt value with
+            | Some parsed -> parsed > 0
+            | None -> false)
+        | _ -> false
+      in
+      count_nonzero || list_field_nonempty "agents" (`Assoc fields)
+  | `List (_ :: _) -> true
+  | _ -> false
+
+let governance_facts_need_judgment facts_json =
+  match facts_json with
+  | `Assoc fields ->
+      list_field_nonempty "items" facts_json
+      || list_field_nonempty "activity" facts_json
+      || agents_facts_nonempty (facts_json |> member "agents")
+      || List.exists
+           (fun (name, value) ->
+             (not
+                (List.mem name [ "generated_at"; "items"; "activity"; "agents" ]))
+             && json_has_material_value value)
+           fields
+  | _ -> json_has_material_value facts_json
+
 let compute_judgments
     ~(masc_tools : Masc_domain.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> Tool_result.t)
@@ -654,16 +698,33 @@ let compute_judgments
     Masc_oas_bridge.run_with_caller
       ~caller:Env_config_oas_bridge.Governance_judge (fun () ->
       let factual_json = build_facts () in
-      let prompt = prompt_for_facts factual_json in
-      Keeper_turn_driver_wrappers.run_named_with_masc_tools ~cascade_name
-        ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
-        ~accept:Keeper_tool_disclosure.response_has_text_or_tool_progress
-        ~approval:Approval_callbacks.auto_approve
-        ()
+      if not (governance_facts_need_judgment factual_json) then
+        Ok `No_governance_facts
+      else
+        let prompt = prompt_for_facts factual_json in
+        match
+          Keeper_turn_driver_wrappers.run_named_with_masc_tools
+            ~cascade_name
+            ~goal:prompt
+            ~masc_tools
+            ~dispatch
+            ~max_turns:3
+            ~accept:Keeper_tool_disclosure.response_has_text_or_tool_progress
+            ~approval:Approval_callbacks.auto_approve
+            ()
+        with
+        | Ok result -> Ok (`Judge_response result)
+        | Error err -> Error err
     )
   with
   | Error err -> Error (Agent_sdk.Error.to_string err)
-  | Ok result -> (
+  | Ok `No_governance_facts ->
+      let generated_at = now_iso () in
+      let expires_at = iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in
+      Log.Governance.routine
+        "compute_judgments: no governance facts; skipping judge call";
+      Ok ("not_applicable", generated_at, expires_at, [])
+  | Ok (`Judge_response result) -> (
       let response = result.Cascade_runner.response in
       try
         let raw_text = Agent_sdk_response.text_of_response response in

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -500,17 +500,17 @@ let find_matching_rule
 
 (* ── Persistent audit log ────────────────────────────────── *)
 
-(* Stdlib.Mutex: the store registry critical section only mutates an in-memory
-   hashtable and creates a Dated_jsonl handle. It is also used by synchronous
-   tests outside an Eio context, so an Eio mutex would either raise Get_context
-   or poison the registry after a recoverable store-creation failure. *)
+(* Eio.Mutex: approval audit writes run from approval-flow Eio fibers. Using a
+   Stdlib.Mutex here can turn cooperative fiber contention on the same system
+   thread into EDEADLK. [Eio_guard] keeps pre-runtime synchronous callers
+   working by running the critical section directly until Eio is enabled. *)
 (** Dated JSONL audit trail for approval events.
     Stored at [<base_path>/.masc/audit-approvals/YYYY-MM/DD.jsonl].
     Dashboard and room-scoped keeper runs pass [base_path] explicitly so approval
     history stays with the room that made the decision. *)
-let audit_stores_mu = Stdlib.Mutex.create ()
+let audit_stores_mu = Eio.Mutex.create ()
 
-let audit_io_mu = Stdlib.Mutex.create ()
+let audit_io_mu = Eio.Mutex.create ()
 let audit_stores : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
 
 let keeper_audit_metric_label = function
@@ -550,7 +550,7 @@ let get_audit_store ?base_path () =
       | None -> Env_config_core.base_path ()
     in
     match
-      Stdlib.Mutex.protect audit_stores_mu (fun () ->
+      Eio_guard.with_mutex audit_stores_mu (fun () ->
         try
           Ok
             (match Hashtbl.find_opt audit_stores base with
@@ -633,7 +633,7 @@ let audit_approval_event
          | Some value -> [ "auto_approved", `Bool value ]
          | None -> [])
     in
-    Stdlib.Mutex.protect audit_io_mu (fun () ->
+    Eio_guard.with_mutex audit_io_mu (fun () ->
       try Fs_compat.append_jsonl (audit_today_path (Dated_jsonl.base_dir store)) json with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn -> record_queue_failure ~keeper_name ~site:"audit_append" ~id ~event_type exn)
@@ -697,7 +697,7 @@ let read_recent_audit ?base_path ?keeper_name ?(n = 20) () : Yojson.Safe.t list 
 
 module For_testing = struct
   let reset_audit_store () =
-    Stdlib.Mutex.protect audit_stores_mu (fun () -> Hashtbl.clear audit_stores)
+    Eio_guard.with_mutex audit_stores_mu (fun () -> Hashtbl.clear audit_stores)
   ;;
 end
 

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -77,6 +77,21 @@ let idle_decision_to_label = function
   | Agent_sdk.Hooks.AdjustParams _ -> "adjust_params"
   | Agent_sdk.Hooks.ElicitInput _ -> "elicit_input"
 
+let tool_error_is_workflow_rejection error =
+  try
+    let json = Yojson.Safe.from_string error in
+    let direct = Safe_ops.json_string_opt "failure_class" json in
+    let nested =
+      match Yojson.Safe.Util.member "detail" json with
+      | `Assoc _ as detail -> Safe_ops.json_string_opt "failure_class" detail
+      | _ -> None
+    in
+    match Option.value direct ~default:(Option.value nested ~default:"") with
+    | "workflow_rejection" -> true
+    | _ -> false
+  with
+  | _ -> false
+
 module Gate_attempt = Keeper_hooks_oas_gate_attempt
 
 let render_pre_tool_gate_output = Gate_attempt.render_pre_tool_gate_output
@@ -713,12 +728,17 @@ let make_hooks
 
     on_tool_error = Some (function
       | Agent_sdk.Hooks.OnToolError { tool_name; error } ->
-        Prometheus.inc_counter
-          Keeper_metrics.metric_keeper_lifecycle_callback_failures
-          ~labels:[(label_keeper, (!meta_ref).name); (label_callback, callback_label_on_tool_error)]
-          ();
-        Log.Keeper.error "keeper:%s tool_error: %s — %s"
-          (!meta_ref).name tool_name error;
+        if tool_error_is_workflow_rejection error
+        then
+          Log.Keeper.warn "keeper:%s tool_workflow_rejection: %s — %s"
+            (!meta_ref).name tool_name error
+        else (
+          Prometheus.inc_counter
+            Keeper_metrics.metric_keeper_lifecycle_callback_failures
+            ~labels:[(label_keeper, (!meta_ref).name); (label_callback, callback_label_on_tool_error)]
+            ();
+          Log.Keeper.error "keeper:%s tool_error: %s — %s"
+            (!meta_ref).name tool_name error);
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);
 

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -77,23 +77,44 @@ let idle_decision_to_label = function
   | Agent_sdk.Hooks.AdjustParams _ -> "adjust_params"
   | Agent_sdk.Hooks.ElicitInput _ -> "elicit_input"
 
-let tool_error_failure_class error =
+let failure_class_of_tool_error_json json =
+  let direct = Safe_ops.json_string_opt "failure_class" json in
+  let nested =
+    match Yojson.Safe.Util.member "detail" json with
+    | `Assoc _ as detail -> Safe_ops.json_string_opt "failure_class" detail
+    | _ -> None
+  in
+  match direct with
+  | Some _ -> direct
+  | None -> nested
+
+let failure_class_of_tool_error_text error =
   try
     let json = Yojson.Safe.from_string error in
-    let direct = Safe_ops.json_string_opt "failure_class" json in
-    let nested =
-      match Yojson.Safe.Util.member "detail" json with
-      | `Assoc _ as detail -> Safe_ops.json_string_opt "failure_class" detail
-      | _ -> None
-    in
-    match direct with
-    | Some _ -> direct
-    | None -> nested
+    failure_class_of_tool_error_json json
   with
   | _ -> None
 
-let tool_error_is_self_correcting_rejection error =
-  match tool_error_failure_class error with
+let tool_error_failure_class ?base_path error =
+  match Tool_output.decode_from_oas error with
+  | Tool_output.Inline inline -> failure_class_of_tool_error_text inline
+  | Tool_output.Stored { sha256; preview; _ } ->
+    let from_store =
+      match base_path with
+      | None -> None
+      | Some base_path ->
+        Safe_ops.protect ~default:None (fun () ->
+            let store = Tool_blob_store.create ~base_path in
+            match Tool_blob_store.fetch store ~sha256 with
+            | Some payload -> failure_class_of_tool_error_text payload
+            | None -> None)
+    in
+    (match from_store with
+     | Some _ -> from_store
+     | None -> failure_class_of_tool_error_text preview)
+
+let tool_error_is_self_correcting_rejection ?base_path error =
+  match tool_error_failure_class ?base_path error with
   | Some ("workflow_rejection" | "policy_rejection") -> true
   | _ -> false
 
@@ -733,10 +754,12 @@ let make_hooks
 
     on_tool_error = Some (function
       | Agent_sdk.Hooks.OnToolError { tool_name; error } ->
-        if tool_error_is_self_correcting_rejection error
+        if tool_error_is_self_correcting_rejection ~base_path:config.base_path error
         then
           let failure_class =
-            Option.value (tool_error_failure_class error) ~default:"tool_rejection"
+            Option.value
+              (tool_error_failure_class ~base_path:config.base_path error)
+              ~default:"tool_rejection"
           in
           Log.Keeper.warn "keeper:%s tool_%s: %s — %s"
             (!meta_ref).name failure_class tool_name error

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -77,7 +77,7 @@ let idle_decision_to_label = function
   | Agent_sdk.Hooks.AdjustParams _ -> "adjust_params"
   | Agent_sdk.Hooks.ElicitInput _ -> "elicit_input"
 
-let tool_error_is_workflow_rejection error =
+let tool_error_failure_class error =
   try
     let json = Yojson.Safe.from_string error in
     let direct = Safe_ops.json_string_opt "failure_class" json in
@@ -86,10 +86,15 @@ let tool_error_is_workflow_rejection error =
       | `Assoc _ as detail -> Safe_ops.json_string_opt "failure_class" detail
       | _ -> None
     in
-    match Option.value direct ~default:(Option.value nested ~default:"") with
-    | "workflow_rejection" -> true
-    | _ -> false
+    match direct with
+    | Some _ -> direct
+    | None -> nested
   with
+  | _ -> None
+
+let tool_error_is_self_correcting_rejection error =
+  match tool_error_failure_class error with
+  | Some ("workflow_rejection" | "policy_rejection") -> true
   | _ -> false
 
 module Gate_attempt = Keeper_hooks_oas_gate_attempt
@@ -728,10 +733,13 @@ let make_hooks
 
     on_tool_error = Some (function
       | Agent_sdk.Hooks.OnToolError { tool_name; error } ->
-        if tool_error_is_workflow_rejection error
+        if tool_error_is_self_correcting_rejection error
         then
-          Log.Keeper.warn "keeper:%s tool_workflow_rejection: %s — %s"
-            (!meta_ref).name tool_name error
+          let failure_class =
+            Option.value (tool_error_failure_class error) ~default:"tool_rejection"
+          in
+          Log.Keeper.warn "keeper:%s tool_%s: %s — %s"
+            (!meta_ref).name failure_class tool_name error
         else (
           Prometheus.inc_counter
             Keeper_metrics.metric_keeper_lifecycle_callback_failures

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -1339,7 +1339,11 @@ let handle_keeper_bash
               ; rewrite = Some task_state_shell_hint
               ; tool_suggestion = Some "keeper_tasks_list"
               })
-         ~extra:[ "cmd", `String cmd_for_log; "execution_time_ms", `Int 0 ]
+         ~extra:
+           [ workflow_rejection_field
+           ; "cmd", `String cmd_for_log
+           ; "execution_time_ms", `Int 0
+           ]
          ())
   in
   let task_state_file_probe_block () =
@@ -1362,7 +1366,11 @@ let handle_keeper_bash
               ; rewrite = Some task_state_shell_hint
               ; tool_suggestion = Some "keeper_tasks_list"
               })
-         ~extra:[ "cmd", `String cmd_for_log; "execution_time_ms", `Int 0 ]
+         ~extra:
+           [ workflow_rejection_field
+           ; "cmd", `String cmd_for_log
+           ; "execution_time_ms", `Int 0
+           ]
          ())
   in
   if Env_config_keeper.KeeperSandbox.hard_mode ()

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -280,13 +280,32 @@ let gh_effective_cmd (input : Yojson.Safe.t) : string =
   | _ -> ""
 ;;
 
-(** Check if keeper_shell input has op="gh". *)
-let is_shell_gh_op (input : Yojson.Safe.t) : bool =
+let normalize_keeper_shell_op raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "git status" | "status" -> "git_status"
+  | "git log" -> "git_log"
+  | "git diff" -> "git_diff"
+  | "git worktree" | "worktree" -> "git_worktree"
+  | "git clone" | "clone" -> "git_clone"
+  | "read" | "file" | "type" -> "cat"
+  | "grep" | "search" -> "rg"
+  | "dir" | "list" -> "ls"
+  | op -> op
+;;
+
+let keeper_shell_op_of_input (input : Yojson.Safe.t) : string =
   match input with
   | `Assoc fields ->
     (match List.assoc_opt "op" fields with
-     | Some (`String s) -> String.trim s = "gh"
-     | _ -> false)
+     | Some (`String s) -> normalize_keeper_shell_op s
+     | _ -> "")
+  | _ -> ""
+;;
+
+(** Check if keeper_shell input has op="gh". *)
+let is_shell_gh_op (input : Yojson.Safe.t) : bool =
+  match input with
+  | `Assoc _ -> keeper_shell_op_of_input input = "gh"
   | _ -> false
 ;;
 
@@ -303,19 +322,33 @@ let git_action_of_input (input : Yojson.Safe.t) : string =
 
 let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : bool =
   match Tool_name.of_string tool_name with
-  | Some (Keeper Shell) when is_shell_gh_op input ->
-    (* keeper_shell with op=gh is input-aware: gh commands can mutate state
-       even though the tool itself is marked read-only by default. *)
-    let cmd = gh_effective_cmd input in
-    let cmd_lower = String.lowercase_ascii cmd in
-    if cmd_lower = ""
-    then false
-    else if String.starts_with cmd_lower ~prefix:"api"
-    then is_gh_api_read_only cmd_lower
-    else
-      List.exists
-        (fun prefix -> String.starts_with cmd_lower ~prefix)
-        gh_read_only_prefixes
+  | Some (Keeper Shell) ->
+    (match keeper_shell_op_of_input input with
+     | "gh" ->
+       (* keeper_shell with op=gh is input-aware: gh commands can mutate state
+          even though the tool itself is marked read-only by default. *)
+       let cmd = gh_effective_cmd input in
+       let cmd_lower = String.lowercase_ascii cmd in
+       if cmd_lower = ""
+       then false
+       else if String.starts_with cmd_lower ~prefix:"api"
+       then is_gh_api_read_only cmd_lower
+       else
+         List.exists
+           (fun prefix -> String.starts_with cmd_lower ~prefix)
+           gh_read_only_prefixes
+     | "git_clone" -> false
+     | "git_worktree" ->
+       let action =
+         match input with
+         | `Assoc fields ->
+           (match List.assoc_opt "action" fields with
+            | Some (`String s) -> String.lowercase_ascii (String.trim s)
+            | _ -> "list")
+         | _ -> "list"
+       in
+       action <> "add"
+     | _ -> is_effectively_read_only_tool tool_name)
   | Some (Masc Code_git) ->
     if is_effectively_read_only_tool tool_name
     then true

--- a/lib/keeper/keeper_tool_registry.mli
+++ b/lib/keeper/keeper_tool_registry.mli
@@ -86,9 +86,11 @@ val git_read_only_actions : string list
     lowercased ([""] when missing). *)
 val git_action_of_input : Yojson.Safe.t -> string
 
-(** Input-aware read-only check: [keeper_shell op=gh] and
-    [masc_code_git] mix read-only and mutating subcommands within
-    one tool name; the input JSON disambiguates. *)
+(** Input-aware read-only check: [keeper_shell] and [masc_code_git] mix
+    read-only and mutating subcommands within one tool name; the input JSON
+    disambiguates. For [keeper_shell], [op=gh] is command-aware,
+    [op=git_clone] mutates sandbox repo state, and [op=git_worktree] mutates
+    only when [action=add]. *)
 val is_read_only_with_input :
   tool_name:string -> input:Yojson.Safe.t -> bool
 

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -597,8 +597,17 @@ let make_keeper_tool_handler
             let is_workflow_rejection =
               match failure_class_opt with
               | Some Tool_result.Workflow_rejection -> true
-              | Some (Tool_result.Transient_error | Tool_result.Policy_rejection | Tool_result.Runtime_failure)
+              | Some
+                  ( Tool_result.Transient_error
+                  | Tool_result.Policy_rejection
+                  | Tool_result.Runtime_failure )
               | None ->
+                false
+            in
+            let is_self_correcting_rejection =
+              match failure_class_opt with
+              | Some (Tool_result.Workflow_rejection | Tool_result.Policy_rejection) -> true
+              | Some (Tool_result.Transient_error | Tool_result.Runtime_failure) | None ->
                 false
             in
             let workflow_rejection_recovery_fields =
@@ -613,7 +622,7 @@ let make_keeper_tool_handler
               else []
             in
             let count =
-              if is_workflow_rejection
+              if is_self_correcting_rejection
               then 0
               else failure_count_record_failure failure_counts key
             in
@@ -664,19 +673,24 @@ let make_keeper_tool_handler
               Keeper_metrics.metric_keeper_tools_oas_failures
               ~labels:[ "tool", name; "site", "error_result" ]
               ();
-            if is_workflow_rejection
-            then
-              Log.Keeper.warn
-                "tool %s returned workflow rejection: %s"
-                name
-                detail
-            else
-              Log.Keeper.error
-                "tool %s returned error result (%d/%d): %s"
-                name
-                count
-                max_consecutive_failures
-                detail;
+            (match failure_class_opt with
+             | Some Tool_result.Workflow_rejection ->
+               Log.Keeper.warn
+                 "tool %s returned workflow rejection: %s"
+                 name
+                 detail
+             | Some Tool_result.Policy_rejection ->
+               Log.Keeper.warn
+                 "tool %s returned policy rejection: %s"
+                 name
+                 detail
+             | Some Tool_result.Transient_error | Some Tool_result.Runtime_failure | None ->
+               Log.Keeper.error
+                 "tool %s returned error result (%d/%d): %s"
+                 name
+                 count
+                 max_consecutive_failures
+                 detail);
             let normalized_error =
               normalize_tool_result
                 ~workflow_rejection_recovery_fields

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -250,19 +250,13 @@ let metric_mention_dedup_decisions_total = "masc_mention_dedup_decisions_total"
 (** {1 Built-in Metrics} *)
 
 let init () =
-  (* Module-level init runs before Eio context exists.
-     Single-threaded at load time — bypass mutex. *)
+  (* Module-level init runs before Eio context exists; the store lock is a
+     Stdlib.Mutex and is safe to use here. *)
   let add name help metric_kind =
-    let metric_type =
-      match metric_kind with
-      | `Counter -> Counter
-      | `Gauge -> Gauge
-      | `Histogram -> Histogram
-    in
-    let key = metric_key name [] in
-    if not (Hashtbl.mem metrics key)
-    then
-      Hashtbl.add metrics key { name; help; metric_type; value = 0.0; labels = [] }
+    match metric_kind with
+    | `Counter -> register_counter ~name ~help ()
+    | `Gauge -> register_gauge ~name ~help ()
+    | `Histogram -> register_histogram ~name ~help ()
   in
   Prometheus_builtin_metrics.register
     ~add
@@ -369,18 +363,14 @@ let to_prometheus_text () =
      are still updating [metrics].  [m.value] is mutable so we copy it
      here rather than holding the lock for the full render. *)
   let snapshot =
-    with_lock (fun () ->
-      Hashtbl.fold
-        (fun _ (m : metric) acc ->
-           Prometheus_text.metric
-             ~name:m.name
-             ~help:m.help
-             ~metric_type:(text_metric_type m.metric_type)
-             ~value:m.value
-             ~labels:m.labels
-           :: acc)
-        metrics
-        [])
+    snapshot_metrics ()
+    |> List.map (fun (m : metric) ->
+      Prometheus_text.metric
+        ~name:m.name
+        ~help:m.help
+        ~metric_type:(text_metric_type m.metric_type)
+        ~value:m.value
+        ~labels:m.labels)
   in
   Prometheus_text.render snapshot
 ;;

--- a/lib/prometheus_store.ml
+++ b/lib/prometheus_store.ml
@@ -118,6 +118,11 @@ let metric_total name =
       0.0)
 ;;
 
+let snapshot_metrics () =
+  with_lock (fun () ->
+    Hashtbl.fold (fun _ (m : metric) acc -> { m with value = m.value } :: acc) metrics [])
+;;
+
 let observe_histogram name ?(labels = []) value =
   let key = metric_key name labels in
   let count_key = metric_key (name ^ "_count") labels in

--- a/lib/prometheus_store.mli
+++ b/lib/prometheus_store.mli
@@ -30,6 +30,7 @@ val observe_histogram : string -> ?labels:label list -> float -> unit
 val get_metric_value : string -> ?labels:label list -> unit -> float option
 val metric_value_or_zero : string -> ?labels:label list -> unit -> float
 val metric_total : string -> float
+val snapshot_metrics : unit -> metric list
 
 (** The most recent EDEADLK backtrace captured by the store lock. [None]
     until the first re-entrant lock failure. *)

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -229,6 +229,29 @@ let missing_cwd_error_json ctx ~cwd ~resolved_cwd ?command ?action () =
   in
   error_response_with (List.rev fields)
 
+let code_shell_cwd_rejection_json ctx ~cwd ?command reason =
+  let hint =
+    "masc_code_shell cwd must resolve inside an allowed worktree or this \
+     keeper's own playground. Docker keepers should prefer keeper_bash/Bash \
+     with sandbox-relative cwd, or call masc_worktree_create before retrying."
+  in
+  let fields =
+    [
+      ("error", `String "code_shell_cwd_rejected");
+      ("reason", `String reason);
+      ("cwd", `String cwd);
+      ("agent", `String ctx.agent_name);
+      ("failure_class", `String "policy_rejection");
+      ("hint", `String hint);
+    ]
+  in
+  let fields =
+    match command with
+    | Some command -> ("command", `String command) :: fields
+    | None -> fields
+  in
+  error_response_with (List.rev fields)
+
 (* Issue #8522: Variant SSOT for git action.  Adding a constructor
    forces compilation in [git_action_to_string] AND extends
    [valid_git_action_strings]; the schema enum below derives from
@@ -557,7 +580,13 @@ let handle_code_shell ~tool_name ~start_time ctx args =
             | Error e -> Error e
         in
         (match cwd_result with
-         | Error e -> Tool_result.error ~tool_name ~start_time (Masc_domain.masc_error_to_string e)
+         | Error e ->
+             let reason = Masc_domain.masc_error_to_string e in
+             Tool_result.error
+               ~failure_class:(Some Tool_result.Policy_rejection)
+               ~tool_name
+               ~start_time
+               (code_shell_cwd_rejection_json ctx ~cwd ~command reason)
          | Ok (Some dir) when not (path_is_directory dir) ->
              Tool_result.error ~tool_name ~start_time
                (missing_cwd_error_json ctx ~cwd ~resolved_cwd:dir

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -252,6 +252,23 @@ let code_shell_cwd_rejection_json ctx ~cwd ?command reason =
   in
   error_response_with (List.rev fields)
 
+let code_shell_command_rejection_json ctx ~command reason =
+  let hint =
+    "masc_code_shell only accepts allowlisted coding commands. Use an \
+     allowlisted command or a structured tool such as keeper_fs_read or \
+     keeper_fs_edit, and split shell pipelines into complete allowlisted \
+     command stages."
+  in
+  error_response_with
+    [
+      ("error", `String "code_shell_command_rejected");
+      ("reason", `String reason);
+      ("command", `String command);
+      ("agent", `String ctx.agent_name);
+      ("failure_class", `String "policy_rejection");
+      ("hint", `String hint);
+    ]
+
 (* Issue #8522: Variant SSOT for git action.  Adding a constructor
    forces compilation in [git_action_to_string] AND extends
    [valid_git_action_strings]; the schema enum below derives from
@@ -569,7 +586,12 @@ let handle_code_shell ~tool_name ~start_time ctx args =
   if String.equal command "" then Tool_result.error ~tool_name ~start_time "command parameter required"
   else
     match validate_code_shell_command command with
-    | Error reason -> Tool_result.error ~tool_name ~start_time reason
+    | Error reason ->
+        Tool_result.error
+          ~failure_class:(Some Tool_result.Policy_rejection)
+          ~tool_name
+          ~start_time
+          (code_shell_command_rejection_json ctx ~command reason)
     | Ok () ->
         (* Validate cwd if provided *)
         let cwd_result =

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,7 +31,7 @@ lib/process/process_eio.ml:493
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1941 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:1816 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
 # Eio.Switch.run at the call boundary.
-lib/worker_dev_tools.ml:1941
+lib/worker_dev_tools.ml:1816

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -685,6 +685,53 @@ let test_refresh_once_skips_fresh_cached_result () =
       check string "runtime status is online" "online" status.status;
       check (option string) "last_error stays clear" None status.last_error)
 
+let test_refresh_once_skips_empty_governance_facts () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      with_test_fs env @@ fun () ->
+      let build_called = ref false in
+      let dispatch_called = ref false in
+      Eio.Switch.run @@ fun sw ->
+      Lib.Dashboard_governance_judge.refresh_once ~sw
+        ~net:(Eio.Stdenv.net env)
+        ~masc_tools:[]
+        ~dispatch:(fun ~name ~args:_ ->
+          dispatch_called := true;
+          {
+            Tool_result.success = false;
+            data = `String "unused";
+            legacy_message = "unused";
+            tool_name = name;
+            duration_ms = 0.0;
+            failure_class = None;
+          })
+        ~base_path:dir
+        ~build_facts:(fun () ->
+          build_called := true;
+          `Assoc
+            [ ("generated_at", `String (Masc_domain.now_iso ()))
+            ; ("items", `List [])
+            ; ("activity", `List [])
+            ; ( "agents"
+              , `Assoc [ ("agents", `List []); ("count", `Int 0) ] )
+            ]);
+      check bool "empty facts still build facts" true !build_called;
+      check bool "empty facts skip judge dispatch" false !dispatch_called;
+      let status =
+        Lib.Dashboard_governance_judge.runtime_status_at
+          ~now_ts:(Unix.gettimeofday ()) dir
+      in
+      check bool "empty facts judge is healthy" true status.judge_online;
+      check string "empty facts status online" "online" status.status;
+      check (option string) "empty facts last_error clear" None status.last_error;
+      check (option string) "empty facts compute outcome ok" (Some "ok")
+        status.last_compute_outcome;
+      check (option string) "empty facts compute reason ok" (Some "ok")
+        status.last_compute_reason)
+
 let test_backoff_runtime_status_is_structured () =
   let dir = test_dir () in
   Fun.protect
@@ -1001,6 +1048,8 @@ let () =
             test_refresh_failure_marks_invalid_json_as_judge_output_invalid;
           test_case "refresh_once skips fresh cached result" `Quick
             test_refresh_once_skips_fresh_cached_result;
+          test_case "refresh_once skips empty governance facts" `Quick
+            test_refresh_once_skips_empty_governance_facts;
           test_case "backoff runtime status is structured" `Quick
             test_backoff_runtime_status_is_structured;
           test_case "monitoring uses live runtime" `Quick

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -545,7 +545,7 @@ let test_keeper_bash_shape_rejection_skips_circuit_breaker () =
       let input =
         `Assoc
           [ ( "cmd"
-            , `String "cat .masc/state/backlog.json 2>/dev/null | head -5" )
+            , `String "rg \"search-term\" repos/ --type ml -l" )
           ]
       in
       let run () =
@@ -565,6 +565,22 @@ let test_keeper_bash_shape_rejection_skips_circuit_breaker () =
         (KET.should_apply_circuit_breaker_to_failure_payload raw);
       check bool "no circuit breaker enrichment after repeated shape blocks" true
         Yojson.Safe.Util.(member "circuit_breaker" json = `Null))
+
+let test_keeper_bash_task_state_probe_is_workflow_rejection () =
+  with_exec_fixture "keeper_bash_task_state_probe_no_cb"
+    (fun ~config ~meta ~ctx_work ->
+      let input = `Assoc [ "cmd", `String "cat .masc/state/backlog.json" ] in
+      let raw =
+        KET.execute_keeper_tool_call
+          ~config ~meta ~ctx_work ~exec_cache:None ~name:"keeper_bash" ~input ()
+      in
+      let json = Yojson.Safe.from_string raw in
+      check string "task-state probe error" "task_state_file_probe_blocked"
+        Yojson.Safe.Util.(member "error" json |> to_string);
+      check string "failure class" "workflow_rejection"
+        Yojson.Safe.Util.(member "failure_class" json |> to_string);
+      check bool "workflow rejection skips circuit breaker accounting" false
+        (KET.should_apply_circuit_breaker_to_failure_payload raw))
 
 let registered_dispatch_probe_tool = "test_keeper_registered_dispatch_probe"
 
@@ -810,6 +826,8 @@ let () =
         test_workflow_rejection_payload_skips_circuit_breaker;
       test_case "keeper_bash shape rejection skips circuit breaker" `Quick
         test_keeper_bash_shape_rejection_skips_circuit_breaker;
+      test_case "keeper_bash task-state probe is workflow rejection" `Quick
+        test_keeper_bash_task_state_probe_is_workflow_rejection;
       test_case "registered dispatch does not require masc_ prefix" `Quick
         test_registered_tool_dispatch_without_masc_prefix;
       test_case "registered dispatch preserves workflow failure class" `Quick

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -21,7 +21,7 @@ let cleanup_dir path =
   in
   try rm path with _ -> ()
 
-let make_meta ?(name = "keeper-exec-tools") ?tool_access () =
+let make_meta ?(name = "keeper-exec-tools") ?(policy_voice_enabled = false) ?tool_access () =
   let tool_access =
     match tool_access with
     | Some value -> value
@@ -37,6 +37,7 @@ let make_meta ?(name = "keeper-exec-tools") ?tool_access () =
           ("agent_name", `String name);
           ("trace_id", `String "keeper-exec-tools-trace");
           ("allowed_paths", `List [ `String "*" ]);
+          ("policy_voice_enabled", `Bool policy_voice_enabled);
           ( "tool_access",
             Masc_mcp.Keeper_types.tool_access_to_json tool_access );
         ])
@@ -257,6 +258,7 @@ let test_tool_not_allowed_reason_label_is_bounded () =
 let test_keeper_tools_list_json_uses_typed_groups () =
   let meta =
     make_meta
+      ~policy_voice_enabled:true
       ~tool_access:
         (Masc_mcp.Keeper_types.Custom
            [ "keeper_board_post";
@@ -584,10 +586,24 @@ let test_keeper_bash_task_state_probe_is_workflow_rejection () =
 
 let registered_dispatch_probe_tool = "test_keeper_registered_dispatch_probe"
 
+let register_test_schema tool_name =
+  let schema : Masc_domain.tool_schema =
+    {
+      name = tool_name;
+      description = "test tool " ^ tool_name;
+      input_schema =
+        `Assoc
+          [ ("type", `String "object")
+          ; ("properties", `Assoc [])
+          ];
+    }
+  in
+  Masc_mcp.Tool_dispatch.register_module_tag
+    ~schemas:[ schema ]
+    ~tag:Masc_mcp.Tool_dispatch.Mod_misc
+
 let register_registered_dispatch_probe () =
-  Masc_mcp.Tool_dispatch.register_name_tag
-    ~tool_name:registered_dispatch_probe_tool
-    ~tag:Masc_mcp.Tool_dispatch.Mod_misc;
+  register_test_schema registered_dispatch_probe_tool;
   Masc_mcp.Tool_dispatch.register
     ~tool_name:registered_dispatch_probe_tool
     ~handler:(fun ~name ~args:_ ->
@@ -603,9 +619,7 @@ let register_registered_dispatch_probe () =
 let workflow_rejection_probe_tool = "test_keeper_workflow_rejection_probe"
 
 let register_workflow_rejection_probe () =
-  Masc_mcp.Tool_dispatch.register_name_tag
-    ~tool_name:workflow_rejection_probe_tool
-    ~tag:Masc_mcp.Tool_dispatch.Mod_misc;
+  register_test_schema workflow_rejection_probe_tool;
   Masc_mcp.Tool_dispatch.register
     ~tool_name:workflow_rejection_probe_tool
     ~handler:(fun ~name ~args:_ ->

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -26,6 +26,9 @@ let is_boundary_exempt ~tool_name ~input =
 let mk_cmd cmd =
   `Assoc [ ("op", `String "gh"); ("cmd", `String cmd) ]
 
+let mk_shell_op op fields =
+  `Assoc (("op", `String op) :: fields)
+
 (* Legacy helpers for backward compat with older tests (not exercised;
    keeper_shell op=gh only accepts cmd, not args). *)
 let mk_args args =
@@ -178,7 +181,18 @@ let with_repo_context_test_env f =
   let base = temp_dir () in
   let config = Coord.default_config base in
   ensure_dir (Filename.concat base Common.masc_dirname);
-  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  Keeper_tool_policy.reset_policy_config_for_test ();
+  (match
+     Keeper_tool_policy.init_policy_config
+       ~base_path:(Masc_test_deps.find_project_root ())
+   with
+   | Ok () -> ()
+   | Error err -> Alcotest.fail err);
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_tool_policy.reset_policy_config_for_test ();
+      cleanup_dir base)
+  @@ fun () ->
   ignore (Coord.init config ~agent_name:None);
   let repo_dir = Filename.concat base "repo" in
   ensure_dir repo_dir;
@@ -416,6 +430,22 @@ let test_input_aware_mutation_detection () =
   Alcotest.(check bool) "keeper_shell op=gh merge cmd is mutating"
     true
     (has_side_effect ~tool_name:"keeper_shell" ~input:(mk_cmd "pr merge 123"));
+  Alcotest.(check bool) "keeper_shell rg remains read-only"
+    true
+    (is_ro ~tool_name:"keeper_shell"
+       ~input:(mk_shell_op "rg" [ ("pattern", `String "TODO") ]));
+  Alcotest.(check bool) "keeper_shell git_clone mutates sandbox repos"
+    true
+    (has_side_effect ~tool_name:"keeper_shell"
+       ~input:(mk_shell_op "git_clone" [ ("url", `String "https://github.com/jeong-sik/masc-mcp") ]));
+  Alcotest.(check bool) "keeper_shell git_worktree list is read-only"
+    true
+    (is_ro ~tool_name:"keeper_shell"
+       ~input:(mk_shell_op "git_worktree" [ ("action", `String "list") ]));
+  Alcotest.(check bool) "keeper_shell git_worktree add mutates"
+    true
+    (has_side_effect ~tool_name:"keeper_shell"
+       ~input:(mk_shell_op "git_worktree" [ ("action", `String "add"); ("branch", `String "fix/test") ]));
   Alcotest.(check bool) "masc_code_git status is not mutating"
     false
     (has_side_effect ~tool_name:"masc_code_git" ~input:(mk_action "status"));

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -1087,6 +1087,22 @@ let test_on_tool_error_workflow_rejection_does_not_count_callback_failure () =
     (after -. before)
 ;;
 
+let test_on_tool_error_policy_rejection_does_not_count_callback_failure () =
+  let keeper = "callback-on-tool-policy-rejection-keeper" in
+  let hooks = make_test_hooks keeper in
+  let hook = require_hook "on_tool_error" hooks.on_tool_error in
+  let before = lifecycle_callback_failure_count ~keeper ~callback:"on_tool_error" in
+  let error =
+    {|{"ok":false,"error":"code_shell_cwd_rejected","detail":{"failure_class":"policy_rejection"}}|}
+  in
+  check_continue
+    "on_tool_error policy rejection"
+    (hook (Agent_sdk.Hooks.OnToolError { tool_name = "masc_code_shell"; error }));
+  let after = lifecycle_callback_failure_count ~keeper ~callback:"on_tool_error" in
+  check (float 0.001) "policy rejection counter does not increment" 0.0
+    (after -. before)
+;;
+
 let test_on_stop_hook_records_stop_reason_metric () =
   let keeper = "callback-on-stop-keeper" in
   let hooks = make_test_hooks keeper in
@@ -1710,6 +1726,10 @@ let () =
             "on_tool_error workflow rejection is not callback failure"
             `Quick
             test_on_tool_error_workflow_rejection_does_not_count_callback_failure
+        ; test_case
+            "on_tool_error policy rejection is not callback failure"
+            `Quick
+            test_on_tool_error_policy_rejection_does_not_count_callback_failure
         ; test_case
             "on_stop records stop reason metric"
             `Quick

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -80,6 +80,12 @@ let make_test_hooks keeper_name =
   Hooks.make_hooks ~config ~meta_ref ~generation:1 ()
 ;;
 
+let make_test_hooks_at_root keeper_name root =
+  let config = Masc_mcp.Coord.default_config root in
+  let meta_ref = ref (make_meta keeper_name) in
+  Hooks.make_hooks ~config ~meta_ref ~generation:1 ()
+;;
+
 let lifecycle_callback_failure_count ~keeper ~callback =
   Masc_mcp.Prometheus.metric_value_or_zero
     Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
@@ -1087,6 +1093,29 @@ let test_on_tool_error_workflow_rejection_does_not_count_callback_failure () =
     (after -. before)
 ;;
 
+let test_on_tool_error_blob_workflow_rejection_does_not_count_callback_failure () =
+  let keeper = "callback-on-tool-blob-workflow-rejection-keeper" in
+  let root = temp_dir () in
+  let hooks = make_test_hooks_at_root keeper root in
+  let hook = require_hook "on_tool_error" hooks.on_tool_error in
+  let before = lifecycle_callback_failure_count ~keeper ~callback:"on_tool_error" in
+  let payload =
+    {|{"ok":false,"error":"task_state_file_probe_blocked","detail":{"ok":false,"error":"task_state_file_probe_blocked","reason":"Task state is owned by the MASC task tools, not guessed files."},"failure_class":"workflow_rejection"}|}
+  in
+  let store = Tool_blob_store.create ~base_path:root in
+  let error = Tool_blob_store.put store ~bytes:payload ~mime:"text/plain" in
+  let error = Tool_output.encode_for_oas error in
+  check_continue
+    "on_tool_error blob workflow rejection"
+    (hook (Agent_sdk.Hooks.OnToolError { tool_name = "Bash"; error }));
+  let after = lifecycle_callback_failure_count ~keeper ~callback:"on_tool_error" in
+  check
+    (float 0.001)
+    "blob workflow rejection counter does not increment"
+    0.0
+    (after -. before)
+;;
+
 let test_on_tool_error_policy_rejection_does_not_count_callback_failure () =
   let keeper = "callback-on-tool-policy-rejection-keeper" in
   let hooks = make_test_hooks keeper in
@@ -1726,6 +1755,10 @@ let () =
             "on_tool_error workflow rejection is not callback failure"
             `Quick
             test_on_tool_error_workflow_rejection_does_not_count_callback_failure
+        ; test_case
+            "on_tool_error blob workflow rejection is not callback failure"
+            `Quick
+            test_on_tool_error_blob_workflow_rejection_does_not_count_callback_failure
         ; test_case
             "on_tool_error policy rejection is not callback failure"
             `Quick

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -1071,6 +1071,22 @@ let test_on_tool_error_hook_records_callback_failure_metric () =
   check (float 0.001) "on_tool_error counter increments" 1.0 (after -. before)
 ;;
 
+let test_on_tool_error_workflow_rejection_does_not_count_callback_failure () =
+  let keeper = "callback-on-tool-workflow-rejection-keeper" in
+  let hooks = make_test_hooks keeper in
+  let hook = require_hook "on_tool_error" hooks.on_tool_error in
+  let before = lifecycle_callback_failure_count ~keeper ~callback:"on_tool_error" in
+  let error =
+    {|{"ok":false,"error":"keeper_bash_command_shape_blocked","failure_class":"workflow_rejection"}|}
+  in
+  check_continue
+    "on_tool_error workflow rejection"
+    (hook (Agent_sdk.Hooks.OnToolError { tool_name = "keeper_bash"; error }));
+  let after = lifecycle_callback_failure_count ~keeper ~callback:"on_tool_error" in
+  check (float 0.001) "workflow rejection counter does not increment" 0.0
+    (after -. before)
+;;
+
 let test_on_stop_hook_records_stop_reason_metric () =
   let keeper = "callback-on-stop-keeper" in
   let hooks = make_test_hooks keeper in
@@ -1690,6 +1706,10 @@ let () =
             "on_tool_error records callback metric"
             `Quick
             test_on_tool_error_hook_records_callback_failure_metric
+        ; test_case
+            "on_tool_error workflow rejection is not callback failure"
+            `Quick
+            test_on_tool_error_workflow_rejection_does_not_count_callback_failure
         ; test_case
             "on_stop records stop reason metric"
             `Quick

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -645,6 +645,48 @@ let test_error_result_logs_at_error_level () =
            (Mlog.level_to_string entry.level))
 ;;
 
+let test_policy_rejection_logs_at_warn_level () =
+  let meta =
+    make_test_meta ~name:"test-keeper-policy-log-level" ~allowed_paths:[ "repos" ] ()
+  in
+  let ctx_snapshot = make_test_ctx () in
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_tools_policy_log_level_%d" (Random.int 100000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      try
+        Sys.readdir dir |> Array.iter (fun f -> Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir
+      with
+      | _ -> ())
+    (fun () ->
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       let tools = make_registered_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_tool "masc_code_shell" tools in
+       let baseline = latest_log_seq () in
+       (match Tool.execute tool (`Assoc [ "command", `String "python3 --version" ]) with
+        | Error _ -> ()
+        | Ok _ -> fail "disallowed code shell command should be rejected");
+       let entry =
+         Mlog.Ring.recent ~limit:50 ~module_filter:"Keeper" ~since_seq:baseline ()
+         |> List.find_opt (fun (entry : Mlog.Ring.entry) ->
+           string_contains ~sub:"returned policy rejection" entry.message)
+       in
+       match entry with
+       | None -> fail "expected keeper warn log for policy rejection"
+       | Some (entry : Mlog.Ring.entry) ->
+         check string "policy rejection logs at WARN" "WARN"
+           (Mlog.level_to_string entry.level))
+;;
+
 let test_missing_file_error_redacts_directory_suggestions () =
   let meta =
     make_test_meta ~name:"test-keeper-suggestions" ~allowed_paths:[ "repos" ] ()
@@ -1370,6 +1412,10 @@ let () =
             "error result logs at error level"
             `Quick
             test_error_result_logs_at_error_level
+        ; test_case
+            "policy rejection logs at warn level"
+            `Quick
+            test_policy_rejection_logs_at_warn_level
         ; test_case
             "missing file error redacts suggestions"
             `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -9795,6 +9795,14 @@ let test_required_tool_satisfaction_rejects_passive_tools () =
     (satisfies_required_tool
        "keeper_shell"
        (`Assoc [ "op", `String "gh"; "cmd", `String "pr view 123" ]))
+  ;
+  check
+    bool
+    "read-only keeper_shell git_worktree list is passive"
+    false
+    (satisfies_required_tool
+       "keeper_shell"
+       (`Assoc [ "op", `String "git_worktree"; "action", `String "list" ]))
 ;;
 
 let test_required_tool_satisfaction_accepts_mutating_tools () =
@@ -9811,6 +9819,27 @@ let test_required_tool_satisfaction_accepts_mutating_tools () =
     (satisfies_required_tool
        "keeper_shell"
        (`Assoc [ "op", `String "gh"; "cmd", `String "pr comment 123 --body ok" ]));
+  check
+    bool
+    "keeper_shell git_clone satisfies as sandbox mutation"
+    true
+    (satisfies_required_tool
+       "keeper_shell"
+       (`Assoc
+          [ "op", `String "git_clone"
+          ; "url", `String "https://github.com/jeong-sik/masc-mcp"
+          ]));
+  check
+    bool
+    "keeper_shell git_worktree add satisfies as sandbox mutation"
+    true
+    (satisfies_required_tool
+       "keeper_shell"
+       (`Assoc
+          [ "op", `String "git_worktree"
+          ; "action", `String "add"
+          ; "branch", `String "fix/test"
+          ]));
   check
     bool
     "fresh worktree create result is material progress"

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -624,6 +624,24 @@ let test_code_shell_cwd_boundary_is_policy_rejection () =
   check bool "error preserves traversal reason" true
     (contains "Path traversal detected" msg)
 
+let test_code_shell_command_rejection_is_policy_rejection () =
+  let ctx = make_ctx () in
+  let args =
+    `Assoc
+      [
+        ("command", `String "sed -n '1,10p' lib/tool_code_write.ml");
+        ("timeout", `Int 5);
+      ]
+  in
+  let ok, msg = dispatch_exn ctx ~name:"masc_code_shell" ~args in
+  check bool "disallowed command rejected before shell execution" false ok;
+  check string "policy failure class" "policy_rejection"
+    (json_string_field "failure_class" msg);
+  check string "command rejection error" "code_shell_command_rejected"
+    (json_string_field "error" msg);
+  check bool "error preserves allowlist reason" true
+    (msg_contains ~needle:"Allowed commands for this tool" msg)
+
 let test_code_shell_rg_exit_one_no_matches_is_success () =
   with_temp_dir "tool-code-shell-rg" @@ fun dir ->
   let fixture = Filename.concat dir "sample.ml" in
@@ -951,6 +969,8 @@ let () =
         test_code_shell_missing_docker_cwd_reports_worktree_hint;
       test_case "cwd boundary is policy rejection" `Quick
         test_code_shell_cwd_boundary_is_policy_rejection;
+      test_case "command rejection is policy rejection" `Quick
+        test_code_shell_command_rejection_is_policy_rejection;
       test_case "rg exit 1 no-match is success" `Quick
         test_code_shell_rg_exit_one_no_matches_is_success;
       test_case "rg quoted regex pipe no-match is success" `Quick

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -599,6 +599,31 @@ let test_code_shell_missing_docker_cwd_reports_worktree_hint () =
   check bool "error suggests worktree creation" true
     (contains "masc_worktree_create" msg)
 
+let test_code_shell_cwd_boundary_is_policy_rejection () =
+  let base_path = fresh_base_path () in
+  let config = make_config base_path in
+  let ctx =
+    { Tool_code_write.config;
+      agent_name = "keeper-sangsu-agent";
+    }
+  in
+  let args =
+    `Assoc
+      [
+        ("command", `String "ls");
+        ("cwd", `String "/etc");
+        ("timeout", `Int 5);
+      ]
+  in
+  let ok, msg = dispatch_exn ctx ~name:"masc_code_shell" ~args in
+  check bool "outside cwd rejected before shell execution" false ok;
+  check string "policy failure class" "policy_rejection"
+    (json_string_field "failure_class" msg);
+  check string "cwd rejection error" "code_shell_cwd_rejected"
+    (json_string_field "error" msg);
+  check bool "error preserves traversal reason" true
+    (contains "Path traversal detected" msg)
+
 let test_code_shell_rg_exit_one_no_matches_is_success () =
   with_temp_dir "tool-code-shell-rg" @@ fun dir ->
   let fixture = Filename.concat dir "sample.ml" in
@@ -924,6 +949,8 @@ let () =
         test_validate_code_shell_command_rejects_semicolon;
       test_case "missing docker cwd reports worktree hint" `Quick
         test_code_shell_missing_docker_cwd_reports_worktree_hint;
+      test_case "cwd boundary is policy rejection" `Quick
+        test_code_shell_cwd_boundary_is_policy_rejection;
       test_case "rg exit 1 no-match is success" `Quick
         test_code_shell_rg_exit_one_no_matches_is_success;
       test_case "rg quoted regex pipe no-match is success" `Quick


### PR DESCRIPTION
## Summary
- classify keeper workflow/policy rejections as self-correcting control-flow outcomes instead of lifecycle tool errors
- classify blob-externalized tool errors by hydrating `[masc:blob ...]` payloads before deciding `on_tool_error` severity
- keep task-state probe blocks, shell/cwd validation blocks, registered workflow rejections, and policy rejections at WARN with structured recovery hints
- preserve keeper/OAS telemetry by routing workflow_rejection and policy_rejection through rejected/self-correcting paths instead of callback failure metrics
- repair Prometheus facade/store split fallout by using public store registration and snapshot APIs
- skip empty dashboard governance judge refreshes so smoke runtimes do not spend cascade/quota on no-op facts
- replace approval-queue audit Stdlib.Mutex usage with Eio.Mutex to avoid EDEADLK in Eio tests/runtime
- align dynamic dispatch probe tests with the schema guard and voice-policy tool exposure rules

## Verification
- ocamlformat --check lib/keeper/keeper_hooks_oas.ml lib/keeper/keeper_tools_oas.ml test/test_keeper_hooks_oas_telemetry.ml test/test_keeper_tools_oas.ml
- git diff --check
- scripts/dune-local.sh build ./test/test_keeper_hooks_oas_telemetry.exe
- ./_build/default/test/test_keeper_hooks_oas_telemetry.exe test hook_introspection 3-5
- scripts/dune-local.sh build ./test/test_keeper_tools_oas.exe
- ./_build/default/test/test_keeper_tools_oas.exe test make_tools 5-6
- scripts/dune-local.sh build ./bin/main_eio.exe
- live 8935 runtime restarted from PR worktree via tmux session `masc-pr16304-8935`
- live health: commit 52b5629f44, executable path under `.worktrees/fix-keeper-workflow-rejection-severity-20260519`, HTTP/gRPC/WebSocket listening, CDAL writer active
- live log proof after restart: blob workflow rejections now log as WARN `tool_workflow_rejection`; policy rejections now log as WARN `tool_policy_rejection` / `returned policy rejection`
- previous verification retained: dashboard governance tests, keeper exec tests, targeted keeper task/approval/CDAL tests, and local smoke on 18935 from earlier PR updates

## CDAL Sweep
- env DUNE_CACHE=disabled MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build ./test/test_cdal_mode_enforcer.exe ./test/test_keeper_cdal_contract.exe ./test/test_cdal_loader.exe ./test/test_cdal_friction_projection.exe ./test/test_cdal_proof.exe ./test/test_cdal_ledger_health_10115.exe ./test/test_cdal_tool_id.exe ./test/test_cdal_judge.exe ./test/test_cdal_risk_contract.exe ./test/test_cdal_verdict_gate.exe ./test/test_cdal_types.exe ./test/test_cdal_conformance.exe ./test/test_cdal_eval_v1.exe ./test/test_cdal_runtime_health_15748.exe ./test/test_cdal_verifiable_markers.exe ./test/test_cdal_mode_resolver.exe
- ./_build/default/test/test_cdal_types.exe
- ./_build/default/test/test_cdal_conformance.exe
- ./_build/default/test/test_cdal_judge.exe
- ./_build/default/test/test_cdal_loader.exe
- ./_build/default/test/test_cdal_proof.exe
- ./_build/default/test/test_cdal_eval_v1.exe
- ./_build/default/test/test_cdal_friction_projection.exe
- ./_build/default/test/test_cdal_verdict_gate.exe
- ./_build/default/test/test_cdal_runtime_health_15748.exe
- ./_build/default/test/test_cdal_ledger_health_10115.exe
- ./_build/default/test/test_cdal_mode_enforcer.exe
- ./_build/default/test/test_cdal_mode_resolver.exe
- ./_build/default/test/test_keeper_cdal_contract.exe
- ./_build/default/test/test_cdal_tool_id.exe
- ./_build/default/test/test_cdal_risk_contract.exe
- ./_build/default/test/test_cdal_verifiable_markers.exe

## Status
- Draft PR by policy; labels: do-not-merge, agent-pr
- Draft Auto-Merge Guard is expected to fail while do-not-merge is present and human-approved-ready is absent
- autoMergeRequest is null and the PR is still draft
- Head is 52b5629f44; new GitHub checks are running
- Remaining live ERRORs after this patch are separate real runtime/cwd/task-edit failures, not workflow/policy rejection severity regressions
- Follow-up issue recorded for sandbox-root repo-relative Bash cwd recovery: #16372
