### PR TITLE
fix(prometheus): use store API during init

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -250,19 +250,13 @@ let metric_mention_dedup_decisions_total = "masc_mention_dedup_decisions_total"
 (** {1 Built-in Metrics} *)
 
 let init () =
-  (* Module-level init runs before Eio context exists.
-     Single-threaded at load time — bypass mutex. *)
+  (* Module-level init runs before Eio context exists; the store uses
+     Stdlib.Mutex and is safe to call during module initialization. *)
   let add name help metric_kind =
-    let metric_type =
-      match metric_kind with
-      | `Counter -> Counter
-      | `Gauge -> Gauge
-      | `Histogram -> Histogram
-    in
-    let key = metric_key name [] in
-    if not (Hashtbl.mem metrics key)
-    then
-      Hashtbl.add metrics key { name; help; metric_type; value = 0.0; labels = [] }
+    match metric_kind with
+    | `Counter -> register_counter ~name ~help ()
+    | `Gauge -> register_gauge ~name ~help ()
+    | `Histogram -> register_histogram ~name ~help ()
   in
   Prometheus_builtin_metrics.register
     ~add
@@ -364,23 +358,17 @@ let to_prometheus_text () =
   update_fd_gauges ();
   update_fd_accountant_gauges ();
   update_pool_metrics_gauges ();
-  (* Snapshot (name, help, metric_type, value, labels) under the mutex so
-     the render phase sees a consistent view even when concurrent fibers
-     are still updating [metrics].  [m.value] is mutable so we copy it
-     here rather than holding the lock for the full render. *)
+  (* Snapshot under the store mutex so the render phase sees a consistent
+     view without holding the lock for text formatting. *)
   let snapshot =
-    with_lock (fun () ->
-      Hashtbl.fold
-        (fun _ (m : metric) acc ->
-           Prometheus_text.metric
-             ~name:m.name
-             ~help:m.help
-             ~metric_type:(text_metric_type m.metric_type)
-             ~value:m.value
-             ~labels:m.labels
-           :: acc)
-        metrics
-        [])
+    Prometheus_store.snapshot ()
+    |> List.map (fun (m : metric) ->
+      Prometheus_text.metric
+        ~name:m.name
+        ~help:m.help
+        ~metric_type:(text_metric_type m.metric_type)
+        ~value:m.value
+        ~labels:m.labels)
   in
   Prometheus_text.render snapshot
 ;;

--- a/lib/prometheus_store.ml
+++ b/lib/prometheus_store.ml
@@ -118,6 +118,10 @@ let metric_total name =
       0.0)
 ;;
 
+let snapshot () =
+  with_lock (fun () -> Hashtbl.fold (fun _ (m : metric) acc -> { m with value = m.value } :: acc) metrics [])
+;;
+
 let observe_histogram name ?(labels = []) value =
   let key = metric_key name labels in
   let count_key = metric_key (name ^ "_count") labels in

--- a/lib/prometheus_store.mli
+++ b/lib/prometheus_store.mli
@@ -30,6 +30,7 @@ val observe_histogram : string -> ?labels:label list -> float -> unit
 val get_metric_value : string -> ?labels:label list -> unit -> float option
 val metric_value_or_zero : string -> ?labels:label list -> unit -> float
 val metric_total : string -> float
+val snapshot : unit -> metric list
 
 (** The most recent EDEADLK backtrace captured by the store lock. [None]
     until the first re-entrant lock failure. *)


### PR DESCRIPTION
## Summary
- Fixes the latest main build break after the Prometheus store/built-in metric split.
- Stops `Prometheus.init` and text rendering from reaching into store internals that are hidden by `prometheus_store.mli`.
- Adds a public `Prometheus_store.snapshot` API for rendering without exposing the mutable table or lock.

## Root Cause
- main `@check` failed on `lib/prometheus.ml:256` with `Unbound value metric_key`.
- After the first fix, the next hidden-internal access failed in `to_prometheus_text` with `Unbound value with_lock`.
- Both were stale godfile-internal references left behind after #16281 and the later built-in metric split.

## Verification
- PASS: `opam exec -- ocamlformat --check lib/prometheus.ml lib/prometheus_store.ml lib/prometheus_store.mli`
- PASS: `git diff --check origin/main...HEAD`
- PASS: `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build @check`
