### PR TITLE
feat(keeper): classify Cloudflare 522/524 as transient network errors

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -71,9 +71,11 @@ let is_transient_network_error (err : Agent_sdk.Error.sdk_error) : bool =
       not (is_structural_oas_timeout_message detail)
   | Agent_sdk.Error.Api (Overloaded _) -> true
   | Agent_sdk.Error.Api (ServerError { status = 503; _ }) -> true
-  (* Cloudflare 524 "A timeout occurred" — origin server did not respond
-     in time.  Functionally identical to a gateway timeout: the LLM never
-     processed the request, so no side effects were committed. *)
+  (* Cloudflare 52x timeout family — origin server unreachable or
+     slow to respond.  No LLM request was processed, so safe to retry.
+     522 = Connection timed out (TCP handshake failed).
+     524 = A timeout occurred (origin responded too slowly). *)
+  | Agent_sdk.Error.Api (ServerError { status = 522; _ }) -> true
   | Agent_sdk.Error.Api (ServerError { status = 524; _ }) -> true
   | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { transient; _ }) ->
       transient

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -71,6 +71,10 @@ let is_transient_network_error (err : Agent_sdk.Error.sdk_error) : bool =
       not (is_structural_oas_timeout_message detail)
   | Agent_sdk.Error.Api (Overloaded _) -> true
   | Agent_sdk.Error.Api (ServerError { status = 503; _ }) -> true
+  (* Cloudflare 524 "A timeout occurred" — origin server did not respond
+     in time.  Functionally identical to a gateway timeout: the LLM never
+     processed the request, so no side effects were committed. *)
+  | Agent_sdk.Error.Api (ServerError { status = 524; _ }) -> true
   | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { transient; _ }) ->
       transient
   (* Non-transient API errors. *)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -12985,6 +12985,18 @@ let () =
               (EC.is_transient_network_error
                  (Agent_sdk.Error.Api
                     (ServerError { status = 503; message = "Service Unavailable" }))))
+        ; test_case "ServerError 524 (Cloudflare gateway timeout) detected" `Quick
+          (fun () ->
+            check
+              bool
+              "524 cloudflare timeout is transient"
+              true
+              (EC.is_transient_network_error
+                 (Agent_sdk.Error.Api
+                    (ServerError
+                       { status = 524
+                       ; message = "A timeout occurred"
+                       }))))
         ; test_case "ServerError 500 not transient" `Quick (fun () ->
             check
               bool

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -12985,6 +12985,18 @@ let () =
               (EC.is_transient_network_error
                  (Agent_sdk.Error.Api
                     (ServerError { status = 503; message = "Service Unavailable" }))))
+        ; test_case "ServerError 522 (Cloudflare connection timeout) detected" `Quick
+          (fun () ->
+            check
+              bool
+              "522 cloudflare connection timeout is transient"
+              true
+              (EC.is_transient_network_error
+                 (Agent_sdk.Error.Api
+                    (ServerError
+                       { status = 522
+                       ; message = "Connection timed out"
+                       }))))
         ; test_case "ServerError 524 (Cloudflare gateway timeout) detected" `Quick
           (fun () ->
             check


### PR DESCRIPTION
## Summary
Classifies Cloudflare 52x family timeouts (522 connection timed out, 524 origin responded too slowly) as transient network errors eligible for short-backoff retry. Salvaged from the abandoned autonomous-agent branch `keeper-analyst-agent/task-273` (no PR, 149 commits behind main).

These are functionally equivalent to existing 503 Service Unavailable handling: the LLM request never reached the origin server (522) or the origin failed to respond in time (524), so no side effects were committed and retry is safe.

## Changes
- `lib/keeper/keeper_error_classify.ml`: add `Api (ServerError { status = 522 })` and `{ status = 524 }` arms to `is_transient_network_error`, with comment explaining the Cloudflare 52x family
- `test/test_keeper_unified.ml`: cover the 524 transient classification (+12 lines)

## Verification
- `ocamlformat --check` on both files: PASS
- `git diff --check`: PASS
- Branch rebased onto current `origin/main`; conflict in `keeper_error_classify.ml` resolved by keeping both main's new `Provider ServerError { transient; _ }` arm and the 52x additions
- Full link-stage build is currently blocked by the same `lib/prometheus.ml` regression that #16289 is fixing (`Unbound value metric_key`) — pattern-matching audit on the affected function was done by inspection

## Origin
- Source: `origin/keeper-analyst-agent/task-273` (autonomous agent branch from 2026-05-18)
- 2 commits cherry-picked / rebased; identical fix-set, applied to current main

RFC-WAIVED: `lib/keeper/keeper_error_classify.ml` is not in the RFC-mandatory keeper subsystems (`credential_*`, `keeper_gh_*`, `host_config_*`). Pure error-classification predicate addition; no behavior change for non-52x errors.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
