### PR TITLE
refactor: split keeper bash shape messages

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -144,6 +144,7 @@
    keeper_shell_bash_redirects
    keeper_shell_bash_task_probe
    keeper_shell_bash_task_state
+   keeper_shell_bash_shape_messages
    keeper_shell_bash
    keeper_shell_ops
    keeper_exec_shell

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -1,6 +1,7 @@
 open Keeper_types
 open Keeper_exec_shared
 open Keeper_shell_bash_redirects
+open Keeper_shell_bash_shape_messages
 open Keeper_shell_bash_task_state
 open Keeper_shell_bash_words
 module Task_probe = Keeper_shell_bash_task_probe
@@ -18,13 +19,6 @@ let elapsed_duration_ms ~start_time ~end_time =
   | _ when elapsed_ms <= 0. -> 0
   | _ when elapsed_ms < 1. -> 1
   | _ -> int_of_float elapsed_ms
-
-type bash_shape_block =
-  | Gh_pr_checks
-  | Pipe_or_redirect
-  | Chaining
-  | Substitution
-  | Repo_wide_scan
 
 let string_contains_char s ch = String.exists (Char.equal ch) s
 let string_contains_substring s needle = String_util.contains_substring s needle
@@ -558,138 +552,6 @@ let shape_block_allowed_by_active_validator ~write_enabled cmd = function
      | Error _ -> false)
   | Gh_pr_checks | Chaining | Substitution | Repo_wide_scan | Pipe_or_redirect ->
     false
-
-let bash_shape_block_tag = function
-  | Gh_pr_checks -> "gh_pr_checks"
-  | Pipe_or_redirect -> "pipe_or_redirect"
-  | Chaining -> "chaining"
-  | Substitution -> "substitution"
-  | Repo_wide_scan -> "repo_wide_scan"
-
-let bash_shape_block_reason = function
-  | Gh_pr_checks ->
-    "gh pr checks exits non-zero when checks are red. That is useful status \
-     data, but it trips keeper shell failure and circuit-breaker accounting."
-  | Pipe_or_redirect ->
-    "keeper_bash accepts one direct command. Pipes and redirects such as |, \
-     2>&1, 2&1, >/dev/null, <, and | head are blocked before execution."
-  | Chaining ->
-    "keeper_bash accepts one command per call. Chaining with &&, ||, ;, or \
-     newlines is blocked before execution."
-  | Substitution ->
-    "Command substitution is blocked before execution. Compute values in a \
-     separate tool call and pass literal arguments."
-  | Repo_wide_scan ->
-    "Repo-wide recursive scans are blocked in raw keeper_bash. Under long \
-     running Keeper fleets they can stampede Docker bind mounts and exhaust \
-     host file descriptors."
-
-let bash_shape_block_hint ~cmd = function
-  | _ when Task_probe.looks_like_discovery cmd -> Task_probe.hint
-  | Gh_pr_checks ->
-    "Use keeper_pr_status. If raw gh is the only visible status path, use gh \
-     pr view NUMBER --repo OWNER/REPO --json \
-     statusCheckRollup,mergeStateStatus,isDraft."
-  | Pipe_or_redirect when command_looks_like_search_pipeline cmd ->
-    "Do not pipe grep/rg through keeper_bash. Use keeper_shell op=rg with a \
-     scoped path and pattern instead; if the command starts with cd, pass that \
-     directory as cwd instead of using cd &&."
-  | Pipe_or_redirect when
-      command_looks_like_find_pipeline cmd || lowercase_contains cmd "find " ->
-    "Do not pipe find through keeper_bash. Use keeper_shell op=find with path, \
-     pattern, and limit instead of | head; if the command needs multiple -name \
-     globs, run one keeper_shell op=find call per pattern."
-  | Pipe_or_redirect ->
-    "Remove the pipe or redirect. Run the primary command once and summarize \
-     the returned output; use keeper_shell op=head/tail for file slices."
-  | Chaining when command_looks_like_cd_chained_search cmd ->
-    "Do not prepend cd ... && to search commands. Pass the target repo or \
-     worktree as cwd and use keeper_shell op=rg with a scoped path."
-  | Chaining ->
-    "Split the work into separate keeper_bash calls and use the cwd argument \
-     instead of cd chaining."
-  | Substitution ->
-    "Run the discovery command first, then use its literal result in a second \
-     keeper_bash call."
-  | Repo_wide_scan ->
-    if command_looks_like_repo_wide_git_log_grep cmd then
-      "Do not use raw Bash for repo-wide git history grep. Use keeper_shell \
-       op=git_log with cwd set to the repo/worktree, count=5, and grep=<term>."
-    else if command_looks_like_repo_wide_rg cmd then
-      "Do not scan repos/ from raw keeper_bash. Use keeper_shell op=rg with a \
-       scoped path such as repos/masc-mcp/lib or repos/oas/src, plus type/glob \
-       filters."
-    else
-    "Use keeper_shell op=rg/find with a scoped path such as lib/, test/, or a \
-     specific repos/REPO subdirectory; avoid scanning . or repos/ from raw \
-     bash."
-
-let bash_shape_block_alternatives ~cmd = function
-  | _ when Task_probe.looks_like_discovery cmd -> Task_probe.alternatives
-  | Gh_pr_checks ->
-    [
-      "keeper_pr_status";
-      "gh pr view NUMBER --repo OWNER/REPO --json \
-       statusCheckRollup,mergeStateStatus,isDraft";
-    ]
-  | Pipe_or_redirect ->
-    if command_looks_like_search_pipeline cmd
-    then
-      [
-        "keeper_shell op=rg pattern=search-term path=lib glob=*.ml";
-        "keeper_shell op=rg pattern=search-term path=repos/REPO/lib glob=*.ml";
-        "keeper_bash cmd='git status' cwd='repos/REPO'";
-      ]
-    else if command_looks_like_find_pipeline cmd || lowercase_contains cmd "find "
-    then
-      [
-        "keeper_shell op=find path=repos/REPO/.worktrees/TASK pattern='*.ml' limit=30";
-        "keeper_shell op=find path=repos/REPO/.worktrees/TASK pattern='*.mli' limit=30";
-        "keeper_shell op=find path=lib pattern='*.ml' limit=30";
-      ]
-    else
-      [
-        "keeper_bash cmd='ls lib/'";
-        "keeper_shell op=head path=file/path lines=20";
-        "keeper_shell op=rg pattern=search-term path=dir/path";
-      ]
-  | Chaining ->
-    if command_looks_like_cd_chained_search cmd
-    then
-      [
-        "keeper_shell op=rg pattern=search-term path=lib glob=*.ml";
-        "keeper_bash cmd='git status' cwd='repos/REPO'";
-      ]
-    else
-      [
-        "keeper_bash cmd='git status' cwd='repos/REPO'";
-        "keeper_bash cmd='git log -1' cwd='repos/REPO'";
-      ]
-  | Substitution ->
-    [
-      "keeper_bash cmd='rg --files lib'";
-      "keeper_bash cmd='cat path/from/previous-step'";
-    ]
-  | Repo_wide_scan ->
-    if command_looks_like_repo_wide_git_log_grep cmd
-    then
-      [
-        "keeper_shell op=git_log cwd=repos/REPO count=5 grep=search-term";
-        "keeper_shell op=git_log cwd=repos/REPO/.worktrees/TASK count=5 grep=search-term";
-      ]
-    else if command_looks_like_repo_wide_rg cmd
-    then
-      [
-        "keeper_shell op=rg pattern=search-term path=repos/masc-mcp/lib glob=*.ml";
-        "keeper_shell op=rg pattern=search-term path=repos/oas/src glob=*.ml";
-        "keeper_shell op=find path=repos/REPO/lib pattern='*.ml'";
-      ]
-    else
-      [
-        "keeper_shell op=rg pattern=search-term path=lib";
-        "keeper_shell op=find path=lib pattern='*.ml'";
-        "keeper_bash cmd='git log --oneline -20'";
-      ]
 
 module For_testing = struct
   let elapsed_duration_ms = elapsed_duration_ms

--- a/lib/keeper/keeper_shell_bash_shape_messages.ml
+++ b/lib/keeper/keeper_shell_bash_shape_messages.ml
@@ -1,0 +1,140 @@
+open Keeper_shell_bash_task_state
+
+type bash_shape_block =
+  | Gh_pr_checks
+  | Pipe_or_redirect
+  | Chaining
+  | Substitution
+  | Repo_wide_scan
+
+let bash_shape_block_tag = function
+  | Gh_pr_checks -> "gh_pr_checks"
+  | Pipe_or_redirect -> "pipe_or_redirect"
+  | Chaining -> "chaining"
+  | Substitution -> "substitution"
+  | Repo_wide_scan -> "repo_wide_scan"
+
+let bash_shape_block_reason = function
+  | Gh_pr_checks ->
+    "gh pr checks exits non-zero when checks are red. That is useful status \
+     data, but it trips keeper shell failure and circuit-breaker accounting."
+  | Pipe_or_redirect ->
+    "keeper_bash accepts one direct command. Pipes and redirects such as |, \
+     2>&1, 2&1, >/dev/null, <, and | head are blocked before execution."
+  | Chaining ->
+    "keeper_bash accepts one command per call. Chaining with &&, ||, ;, or \
+     newlines is blocked before execution."
+  | Substitution ->
+    "Command substitution is blocked before execution. Compute values in a \
+     separate tool call and pass literal arguments."
+  | Repo_wide_scan ->
+    "Repo-wide recursive scans are blocked in raw keeper_bash. Under long \
+     running Keeper fleets they can stampede Docker bind mounts and exhaust \
+     host file descriptors."
+
+let bash_shape_block_hint ~cmd = function
+  | _ when command_looks_like_task_state_discovery cmd -> task_state_shell_hint
+  | Gh_pr_checks ->
+    "Use keeper_pr_status. If raw gh is the only visible status path, use gh \
+     pr view NUMBER --repo OWNER/REPO --json \
+     statusCheckRollup,mergeStateStatus,isDraft."
+  | Pipe_or_redirect when command_looks_like_search_pipeline cmd ->
+    "Do not pipe grep/rg through keeper_bash. Use keeper_shell op=rg with a \
+     scoped path and pattern instead; if the command starts with cd, pass that \
+     directory as cwd instead of using cd &&."
+  | Pipe_or_redirect when
+      command_looks_like_find_pipeline cmd || lowercase_contains cmd "find " ->
+    "Do not pipe find through keeper_bash. Use keeper_shell op=find with path, \
+     pattern, and limit instead of | head; if the command needs multiple -name \
+     globs, run one keeper_shell op=find call per pattern."
+  | Pipe_or_redirect ->
+    "Remove the pipe or redirect. Run the primary command once and summarize \
+     the returned output; use keeper_shell op=head/tail for file slices."
+  | Chaining when command_looks_like_cd_chained_search cmd ->
+    "Do not prepend cd ... && to search commands. Pass the target repo or \
+     worktree as cwd and use keeper_shell op=rg with a scoped path."
+  | Chaining ->
+    "Split the work into separate keeper_bash calls and use the cwd argument \
+     instead of cd chaining."
+  | Substitution ->
+    "Run the discovery command first, then use its literal result in a second \
+     keeper_bash call."
+  | Repo_wide_scan ->
+    if command_looks_like_repo_wide_git_log_grep cmd then
+      "Do not use raw Bash for repo-wide git history grep. Use keeper_shell \
+       op=git_log with cwd set to the repo/worktree, count=5, and grep=<term>."
+    else if command_looks_like_repo_wide_rg cmd then
+      "Do not scan repos/ from raw keeper_bash. Use keeper_shell op=rg with a \
+       scoped path such as repos/masc-mcp/lib or repos/oas/src, plus type/glob \
+       filters."
+    else
+      "Use keeper_shell op=rg/find with a scoped path such as lib/, test/, or a \
+       specific repos/REPO subdirectory; avoid scanning . or repos/ from raw \
+       bash."
+
+let bash_shape_block_alternatives ~cmd = function
+  | _ when command_looks_like_task_state_discovery cmd -> task_state_shell_alternatives
+  | Gh_pr_checks ->
+    [
+      "keeper_pr_status";
+      "gh pr view NUMBER --repo OWNER/REPO --json \
+       statusCheckRollup,mergeStateStatus,isDraft";
+    ]
+  | Pipe_or_redirect ->
+    if command_looks_like_search_pipeline cmd
+    then
+      [
+        "keeper_shell op=rg pattern=search-term path=lib glob=*.ml";
+        "keeper_shell op=rg pattern=search-term path=repos/REPO/lib glob=*.ml";
+        "keeper_bash cmd='git status' cwd='repos/REPO'";
+      ]
+    else if command_looks_like_find_pipeline cmd || lowercase_contains cmd "find "
+    then
+      [
+        "keeper_shell op=find path=repos/REPO/.worktrees/TASK pattern='*.ml' limit=30";
+        "keeper_shell op=find path=repos/REPO/.worktrees/TASK pattern='*.mli' limit=30";
+        "keeper_shell op=find path=lib pattern='*.ml' limit=30";
+      ]
+    else
+      [
+        "keeper_bash cmd='ls lib/'";
+        "keeper_shell op=head path=file/path lines=20";
+        "keeper_shell op=rg pattern=search-term path=dir/path";
+      ]
+  | Chaining ->
+    if command_looks_like_cd_chained_search cmd
+    then
+      [
+        "keeper_shell op=rg pattern=search-term path=lib glob=*.ml";
+        "keeper_bash cmd='git status' cwd='repos/REPO'";
+      ]
+    else
+      [
+        "keeper_bash cmd='git status' cwd='repos/REPO'";
+        "keeper_bash cmd='git log -1' cwd='repos/REPO'";
+      ]
+  | Substitution ->
+    [
+      "keeper_bash cmd='rg --files lib'";
+      "keeper_bash cmd='cat path/from/previous-step'";
+    ]
+  | Repo_wide_scan ->
+    if command_looks_like_repo_wide_git_log_grep cmd
+    then
+      [
+        "keeper_shell op=git_log cwd=repos/REPO count=5 grep=search-term";
+        "keeper_shell op=git_log cwd=repos/REPO/.worktrees/TASK count=5 grep=search-term";
+      ]
+    else if command_looks_like_repo_wide_rg cmd
+    then
+      [
+        "keeper_shell op=rg pattern=search-term path=repos/masc-mcp/lib glob=*.ml";
+        "keeper_shell op=rg pattern=search-term path=repos/oas/src glob=*.ml";
+        "keeper_shell op=find path=repos/REPO/lib pattern='*.ml'";
+      ]
+    else
+      [
+        "keeper_shell op=rg pattern=search-term path=lib";
+        "keeper_shell op=find path=lib pattern='*.ml'";
+        "keeper_bash cmd='git log --oneline -20'";
+      ]

--- a/lib/keeper/keeper_shell_bash_shape_messages.mli
+++ b/lib/keeper/keeper_shell_bash_shape_messages.mli
@@ -1,0 +1,11 @@
+type bash_shape_block =
+  | Gh_pr_checks
+  | Pipe_or_redirect
+  | Chaining
+  | Substitution
+  | Repo_wide_scan
+
+val bash_shape_block_tag : bash_shape_block -> string
+val bash_shape_block_reason : bash_shape_block -> string
+val bash_shape_block_hint : cmd:string -> bash_shape_block -> string
+val bash_shape_block_alternatives : cmd:string -> bash_shape_block -> string list


### PR DESCRIPTION
## Summary
- stack on #16303 / codex/godfile-zero-53-bash-task-state
- split bash shape block type/tag/reason/hint/alternative messages into Keeper_shell_bash_shape_messages
- reduce lib/keeper/keeper_shell_bash.ml from 1778 to 1640 LOC

## Shell IR note
This preserves the existing Shell IR parsing path in keeper_bash shape detection. The next advanced slice should extract the IR classifier boundary itself so raw string fallback becomes a narrower legacy path.

## Verification
- ocamlformat --check lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_shell_bash_shape_messages.ml lib/keeper/keeper_shell_bash_shape_messages.mli lib/keeper/keeper_shell_bash_task_state.ml lib/keeper/keeper_shell_bash_task_state.mli lib/keeper/keeper_shell_bash_redirects.ml lib/keeper/keeper_shell_bash_redirects.mli lib/keeper/keeper_shell_bash_words.ml lib/keeper/keeper_shell_bash_words.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh

Focused Dune verification was attempted with scripts/dune-local.sh build lib/masc_mcp.cmxa, but the wrapper refused to run because live bare Dune builds were bypassing the shared lock.