### PR TITLE
refactor: split keeper bash Shell IR classifier

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -145,6 +145,7 @@
    keeper_shell_bash_task_probe
    keeper_shell_bash_task_state
    keeper_shell_bash_shape_messages
+   keeper_shell_bash_shape_ir
    keeper_shell_bash
    keeper_shell_ops
    keeper_exec_shell

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -1,6 +1,7 @@
 open Keeper_types
 open Keeper_exec_shared
 open Keeper_shell_bash_redirects
+open Keeper_shell_bash_shape_ir
 open Keeper_shell_bash_shape_messages
 open Keeper_shell_bash_task_state
 open Keeper_shell_bash_words
@@ -226,27 +227,6 @@ let raw_keeper_bash_shape_block cmd =
     string_contains_substring scan_text "$(" || string_contains_char scan_text '`'
   then Some Substitution
   else None
-
-let arg_text = function
-  | Masc_exec.Shell_ir.Lit text -> Some (String.lowercase_ascii text)
-  | Masc_exec.Shell_ir.Var _ | Masc_exec.Shell_ir.Concat _ -> None
-
-let simple_is_gh_pr_checks (simple : Masc_exec.Shell_ir.simple) =
-  match Masc_exec.Bin.known simple.bin, simple.args with
-  | Some Masc_exec.Bin.Gh, arg_pr :: arg_checks :: _ ->
-    (match arg_text arg_pr, arg_text arg_checks with
-     | Some "pr", Some "checks" -> true
-     | _ -> false)
-  | _ -> false
-
-let rec parsed_keeper_bash_shape_block = function
-  | Masc_exec.Shell_ir.Pipeline _ -> Some Pipe_or_redirect
-  | Masc_exec.Shell_ir.Simple simple ->
-    if simple.redirects <> []
-    then Some Pipe_or_redirect
-    else if simple_is_gh_pr_checks simple
-    then Some Gh_pr_checks
-    else None
 
 let keeper_bash_shape_block cmd =
   let cmd, _ = strip_stderr_dev_null_redirects cmd in

--- a/lib/keeper/keeper_shell_bash_shape_ir.ml
+++ b/lib/keeper/keeper_shell_bash_shape_ir.ml
@@ -1,0 +1,22 @@
+open Keeper_shell_bash_shape_messages
+
+let arg_text = function
+  | Masc_exec.Shell_ir.Lit text -> Some (String.lowercase_ascii text)
+  | Masc_exec.Shell_ir.Var _ | Masc_exec.Shell_ir.Concat _ -> None
+
+let simple_is_gh_pr_checks (simple : Masc_exec.Shell_ir.simple) =
+  match Masc_exec.Bin.known simple.bin, simple.args with
+  | Some Masc_exec.Bin.Gh, arg_pr :: arg_checks :: _ ->
+    (match arg_text arg_pr, arg_text arg_checks with
+     | Some "pr", Some "checks" -> true
+     | _ -> false)
+  | _ -> false
+
+let rec parsed_keeper_bash_shape_block = function
+  | Masc_exec.Shell_ir.Pipeline _ -> Some Pipe_or_redirect
+  | Masc_exec.Shell_ir.Simple simple ->
+    if simple.redirects <> []
+    then Some Pipe_or_redirect
+    else if simple_is_gh_pr_checks simple
+    then Some Gh_pr_checks
+    else None

--- a/lib/keeper/keeper_shell_bash_shape_ir.mli
+++ b/lib/keeper/keeper_shell_bash_shape_ir.mli
@@ -1,0 +1,3 @@
+val parsed_keeper_bash_shape_block :
+  Masc_exec.Shell_ir.t ->
+  Keeper_shell_bash_shape_messages.bash_shape_block option


### PR DESCRIPTION
## Summary
- stack on #16308 / codex/godfile-zero-54-bash-shape-messages
- split Masc_exec.Shell_ir based shape classification into Keeper_shell_bash_shape_ir
- keep raw string fallback in keeper_shell_bash for now, but make the IR classifier an explicit seam for the next advanced slice
- reduce lib/keeper/keeper_shell_bash.ml from 1640 to 1620 LOC

## Why Shell IR
The keeper_bash shape block already uses Shell IR for parsed commands. This PR moves that logic behind a named classifier boundary so future work can make IR-first decisions without mixing them into legacy string scanning.

## Verification
- ocamlformat --check lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_shell_bash_shape_ir.ml lib/keeper/keeper_shell_bash_shape_ir.mli lib/keeper/keeper_shell_bash_shape_messages.ml lib/keeper/keeper_shell_bash_shape_messages.mli lib/keeper/keeper_shell_bash_task_state.ml lib/keeper/keeper_shell_bash_task_state.mli lib/keeper/keeper_shell_bash_redirects.ml lib/keeper/keeper_shell_bash_redirects.mli lib/keeper/keeper_shell_bash_words.ml lib/keeper/keeper_shell_bash_words.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh

Focused Dune verification was attempted with scripts/dune-local.sh build lib/masc_mcp.cmxa, but the wrapper refused to run because a live bare Dune test build was bypassing the shared lock.