### PR TITLE
fix(dashboard): match wire format casing for snapshot.phase compares

### DIFF
--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -462,8 +462,10 @@ function blockingNextStep(snapshot: KeeperCompositeSnapshot): string {
 
 function staleCause(snapshot: KeeperCompositeSnapshot, ageText: string): string {
   const receiptReason = snapshot.execution?.operator_disposition_reason
-  const base = snapshot.phase === 'Running'
-    ? 'KSM=Running이지만 live turn 없음'
+  // `snapshot.phase` wire format is lowercase (phase_to_string in
+  // keeper_state_machine.ml:21-35); the prior PascalCase compare was dead.
+  const base = snapshot.phase === 'running'
+    ? 'KSM=running이지만 live turn 없음'
     : `live turn 없음 · KSM=${snapshot.phase}`
   const receipt = receiptReason ? ` · last receipt: ${receiptReason}` : ''
   return `${base} · latest ${ageText}${receipt}`
@@ -473,7 +475,7 @@ function staleNextStep(snapshot: KeeperCompositeSnapshot, latest: number | null)
   if (latest == null) {
     return 'turn 시작/keepalive 이벤트가 composite로 들어오는지 확인'
   }
-  if (snapshot.phase === 'Running') {
+  if (snapshot.phase === 'running') {
     return 'keeper keepalive와 turn 시작 이벤트 경로 확인'
   }
   return `phase=${snapshot.phase} 전환 또는 재시작 경로 확인`

--- a/dashboard/src/components/fsm-hub-invariant-analysis.test.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.test.ts
@@ -8,7 +8,7 @@ function makeSnapshot(overrides: Partial<KeeperCompositeSnapshot> = {}): KeeperC
     correlation_id: 'corr-1',
     run_id: 'run-1',
     ts: 1000000,
-    phase: 'Running',
+    phase: 'running',
     turn_phase: 'idle',
     decision: { stage: 'undecided' },
     cascade: { state: 'idle' },
@@ -78,7 +78,7 @@ describe('invariantRows', () => {
 
   it('shows drift detail for broken compaction_atomicity', () => {
     const rows = invariantRows(makeSnapshot({
-      phase: 'Running',
+      phase: 'running',
       invariants: {
         phase_turn_alignment: true,
         no_cascade_before_measurement: true,
@@ -89,7 +89,7 @@ describe('invariantRows', () => {
     }))
     const row = rows.find(r => r.key === 'compaction_atomicity')!
     expect(row.ok).toBe(false)
-    expect(row.detail).toContain('KSM=Running')
+    expect(row.detail).toContain('KSM=running')
   })
 
   it('shows OK detail for valid phase_turn_alignment', () => {
@@ -129,7 +129,7 @@ describe('deriveOperationalInsight', () => {
   it('reports error when Failing and cascade exhausted', () => {
     const insight = deriveOperationalInsight(
       makeSnapshot({
-        phase: 'Failing',
+        phase: 'failing',
         cascade: { state: 'exhausted' },
       }),
       noObservations,
@@ -175,7 +175,7 @@ describe('deriveOperationalInsight', () => {
   it('reports info when Compacting', () => {
     const insight = deriveOperationalInsight(
       makeSnapshot({
-        phase: 'Compacting',
+        phase: 'compacting',
         compaction: { stage: 'compacting' },
       }),
       noObservations,
@@ -188,19 +188,19 @@ describe('deriveOperationalInsight', () => {
   it('reports warn for Overflowed phase', () => {
     const insight = deriveOperationalInsight(
       makeSnapshot({
-        phase: 'Overflowed',
+        phase: 'overflowed',
       }),
       noObservations,
       now,
     )
     expect(insight.tone).toBe('warn')
-    expect(insight.headline).toContain('Overflowed')
+    expect(insight.headline).toContain('overflowed')
   })
 
   it('reports warn for HandingOff phase', () => {
     const insight = deriveOperationalInsight(
       makeSnapshot({
-        phase: 'HandingOff',
+        phase: 'handing_off',
       }),
       noObservations,
       now,
@@ -211,7 +211,7 @@ describe('deriveOperationalInsight', () => {
   it('reports warn for Draining phase', () => {
     const insight = deriveOperationalInsight(
       makeSnapshot({
-        phase: 'Draining',
+        phase: 'draining',
       }),
       noObservations,
       now,
@@ -219,23 +219,16 @@ describe('deriveOperationalInsight', () => {
     expect(insight.tone).toBe('warn')
   })
 
-  it('reports warn for Stable phase', () => {
-    const insight = deriveOperationalInsight(
-      makeSnapshot({
-        phase: 'Stable',
-        is_live: false,
-      }),
-      noObservations,
-      now,
-    )
-    // Stable falls into the overflow/handoff/draining/stable block
-    expect(insight.tone).toBe('warn')
-  })
+  // Backend wire format (keeper_state_machine.ml:21-35) emits the 13 raw KSM
+  // phases lowercase. A 7-phase composite projection with a 'Stable' carrier
+  // is specced (KeeperCompositeLifecycle.tla:143) but not currently emitted,
+  // so the dashboard surfaces `collapsed_from` directly whenever the backend
+  // sets it — see deriveOperationalInsight + nextExpectedStep.
 
-  it('reports raw stable source in detail and evidence when collapsed_from is present', () => {
+  it('reports raw collapsed_from source in detail, evidence, and nextStep', () => {
     const insight = deriveOperationalInsight(
       makeSnapshot({
-        phase: 'Stable',
+        phase: 'overflowed',
         collapsed_from: 'paused',
       }),
       noObservations,
@@ -369,7 +362,7 @@ describe('deriveOperationalInsight', () => {
 
   it('gives correct nextStep for Failing+exhausted', () => {
     const insight = deriveOperationalInsight(
-      makeSnapshot({ phase: 'Failing', cascade: { state: 'exhausted' } }),
+      makeSnapshot({ phase: 'failing', cascade: { state: 'exhausted' } }),
       noObservations,
       now,
     )

--- a/dashboard/src/components/fsm-hub-invariant-analysis.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.ts
@@ -52,32 +52,39 @@ function invariantDetail(
   }
 }
 
+// Backend (lib/keeper/keeper_state_machine.ml:21-35) emits phase strings
+// via `phase_to_string` in lowercase + snake_case: 'running', 'failing',
+// 'handing_off' etc. The composite observer (keeper_composite_observer.ml:628)
+// passes the same wire format through `snapshot.phase`. Compare against
+// those exact tokens — PascalCase comparisons are dead branches in production.
 function nextExpectedStep(snapshot: KeeperCompositeSnapshot): string {
-  const collapsedFrom = snapshot.phase === 'Stable' ? snapshot.collapsed_from : null
   if (!snapshot.is_live) {
     return snapshot.last_outcome
       ? '다음 live turn 이 idle placeholder 로부터 KTC/KDP/KCL 을 repopulate 해야 함.'
       : '아직 완료된 턴 없음 — first live turn 이 observer 를 채워야 함.'
   }
-  if (snapshot.phase === 'Failing' && snapshot.cascade.state === 'exhausted') {
-    return '정상 provider path 또는 명시적 recovery clearance 가 Failing 을 해제해야 Running 재개 가능.'
+  // `collapsed_from` carries the raw KSM phase when the composite has folded
+  // it under a parent projection. When present it is the operator-actionable
+  // signal — surface it before the surface-phase arms, since the surface
+  // phase is just the carrier label. See file header comment for the
+  // casing-SSOT background.
+  if (snapshot.collapsed_from) {
+    return `lifecycle 가 raw phase ${snapshot.collapsed_from} 에서 carrier phase 로 collapse 됨; 다음 meaningful edge 가 turn activity 재개 전에 그 underlying condition 을 clear 해야 함.`
   }
-  if (snapshot.phase === 'Overflowed') {
+  if (snapshot.phase === 'failing' && snapshot.cascade.state === 'exhausted') {
+    return '정상 provider path 또는 명시적 recovery clearance 가 failing 을 해제해야 running 재개 가능.'
+  }
+  if (snapshot.phase === 'overflowed') {
     return 'context overflow 은 compaction 또는 명시적 operator clearance 로 해소되어야 lifecycle 이 정착 가능.'
   }
-  if (snapshot.phase === 'Compacting' || snapshot.compaction.stage === 'compacting') {
-    return 'KMC 가 done 에 도달한 뒤 KSM 이 Running 으로 control 을 반환해야 함.'
+  if (snapshot.phase === 'compacting' || snapshot.compaction.stage === 'compacting') {
+    return 'KMC 가 done 에 도달한 뒤 KSM 이 running 으로 control 을 반환해야 함.'
   }
-  if (snapshot.phase === 'HandingOff') {
+  if (snapshot.phase === 'handing_off') {
     return 'handoff completion 이 관측되면 현재 keeper 는 stop 해야 함.'
   }
-  if (snapshot.phase === 'Draining') {
-    return 'lifecycle 가 Stopped 로 정착되기 전에 Draining 이 완료되어야 함.'
-  }
-  if (snapshot.phase === 'Stable') {
-    return collapsedFrom
-      ? `lifecycle 가 raw phase ${collapsedFrom} 에서 Stable 로 collapse 됨; 다음 meaningful edge 가 turn activity 재개 전에 그 underlying condition 을 clear 해야 함.`
-      : 'lifecycle 가 active turn cycle 밖에 있음; 다음 meaningful edge 는 새 live turn 또는 operator action 에서 시작되어야 함.'
+  if (snapshot.phase === 'draining') {
+    return 'lifecycle 가 stopped 로 정착되기 전에 draining 이 완료되어야 함.'
   }
   if (snapshot.decision.stage === 'gate_rejected') {
     return 'blocked turn 은 cascade/tool execution 진입 없이 idle 로 finalize 되어야 함.'
@@ -126,7 +133,7 @@ export function deriveOperationalInsight(
 
   const lanes = precomputedLanes ?? deriveObservedLaneSummaries(snapshot, observations, now)
   const stalledLane = lanes.find(lane => lane.stalled)
-  if (snapshot.phase === 'Failing' && snapshot.cascade.state === 'exhausted') {
+  if (snapshot.phase === 'failing' && snapshot.cascade.state === 'exhausted') {
     return {
       tone: 'error',
       headline: 'cascade exhaustion 후 실패',
@@ -164,7 +171,7 @@ export function deriveOperationalInsight(
       ],
     }
   }
-  if (snapshot.phase === 'Compacting' || snapshot.compaction.stage === 'compacting') {
+  if (snapshot.phase === 'compacting' || snapshot.compaction.stage === 'compacting') {
     return {
       tone: 'info',
       headline: 'Compaction 가 현재 턴 소유',
@@ -176,8 +183,8 @@ export function deriveOperationalInsight(
       ],
     }
   }
-  if (snapshot.phase === 'Overflowed' || snapshot.phase === 'HandingOff' || snapshot.phase === 'Draining' || snapshot.phase === 'Stable') {
-    const collapsedDetail = snapshot.phase === 'Stable' && snapshot.collapsed_from
+  if (snapshot.phase === 'overflowed' || snapshot.phase === 'handing_off' || snapshot.phase === 'draining') {
+    const collapsedDetail = snapshot.collapsed_from
       ? ` raw keeper phase is ${snapshot.collapsed_from} — 이건 단순한 idleness 가 아님.`
       : ''
     return {

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -222,7 +222,10 @@ function PhaseSparkline({
 }
 
 /** Human-readable descriptions for sub-FSM states.
-    Shown as native title tooltips on hover. */
+ *  Keys match the wire format from `keeper_composite_observer.ml` exactly:
+ *    KSM phase via `phase_to_string` (lib/keeper/keeper_state_machine.ml:21-35) — lowercase + snake_case.
+ *    KTC/KDP/KCL/KMC via the per-axis to_string fns (lib/keeper/keeper_composite_observer.ml:141-201) — lowercase.
+ *  Shown as native title tooltips on hover. */
 const STATE_DESCRIPTIONS: Record<string, string> = {
   // KTC (Turn Cycle)
   idle: '다음 heartbeat cycle 까지 턴 시작 대기 중',
@@ -242,25 +245,20 @@ const STATE_DESCRIPTIONS: Record<string, string> = {
   exhausted: 'cascade 의 모든 provider 실패',
   // KMC (Compaction)
   accumulating: '메시지 수집 중; 컨텍스트 아직 가득 차지 않음',
-  // KSM (Phase) — used in Hero
-  Running: '키퍼가 활성 상태로 턴 실행 중',
-  Overflowed: '프롬프트가 provider 컨텍스트 윈도우 초과; 복구 대기',
-  Compacting: '토큰 예산 회수를 위해 컨텍스트 압축 중',
-  HandingOff: '다음 generation 으로 상태 이관 중',
-  Failing: '에러 발생, 재시도 또는 복구 진행',
-  Draining: '종료 전 현재 작업 마무리 중',
-  Stable: '활성 턴 사이클 밖; idle terminal 또는 비활성 parent phase 가 여기로 collapse',
-  running: '원시 키퍼 phase: runtime 이 활성 상태로 턴 실행 중',
-  failing: '원시 키퍼 phase: 복구 / 재시도 처리 중',
-  overflowed: '원시 키퍼 phase: provider 컨텍스트 overflow 압축 또는 clear 필요',
-  handing_off: '원시 키퍼 phase: 상태 handoff 진행 중',
-  draining: '원시 키퍼 phase: 종료 진행 중',
-  offline: '원시 키퍼 phase: 키퍼가 아직 시작되지 않음',
-  paused: '원시 키퍼 phase: 운영자 pause 또는 재시도 한계',
-  stopped: '원시 키퍼 phase: clean terminal stop',
-  crashed: '원시 키퍼 phase: crash, 재시작 또는 조사 필요',
-  restarting: '원시 키퍼 phase: supervisor 재시작 흐름 활성',
-  dead: '원시 키퍼 phase: 재시작 예산 소진',
+  // KSM (Phase) — wire format is lowercase per phase_to_string.
+  // 13-state set matches `Keeper_state_machine.phase` ctors.
+  offline: '키퍼가 아직 시작되지 않음',
+  running: '키퍼가 활성 상태로 턴 실행 중',
+  failing: '에러 발생, 재시도 또는 복구 진행',
+  overflowed: '프롬프트가 provider 컨텍스트 윈도우 초과; 복구 대기',
+  handing_off: '다음 generation 으로 상태 이관 중',
+  draining: '종료 전 현재 작업 마무리 중',
+  paused: '운영자 pause 또는 재시도 한계',
+  stopped: 'clean terminal stop',
+  crashed: 'crash 후 재시작 또는 조사 필요',
+  restarting: 'supervisor 재시작 흐름 활성',
+  dead: '재시작 예산 소진',
+  zombie: 'terminal failure latched — 운영자 개입 필요',
 }
 
 export function HeroPhase({
@@ -287,17 +285,33 @@ export function HeroPhase({
     return undefined
   }, [snapshot.phase])
 
+  // Wire format is lowercase (phase_to_string in keeper_state_machine.ml).
+  // 12 emitted phases get an explicit tone; unmapped falls through to neutral accent.
   const phaseColor: Record<string, string> = {
-    Running: 'text-[var(--color-status-ok)]',
-    Overflowed: 'text-[var(--color-status-warn)]',
-    Compacting: 'text-[var(--color-status-warn)]',
-    HandingOff: 'text-[var(--color-accent-fg)]',
-    Failing: 'text-[var(--bad-light)]',
-    Stable: 'text-[var(--color-fg-disabled)]',
+    running: 'text-[var(--color-status-ok)]',
+    offline: 'text-[var(--color-fg-disabled)]',
+    stopped: 'text-[var(--color-fg-disabled)]',
+    overflowed: 'text-[var(--color-status-warn)]',
+    compacting: 'text-[var(--color-status-warn)]',
+    handing_off: 'text-[var(--color-accent-fg)]',
+    failing: 'text-[var(--bad-light)]',
+    crashed: 'text-[var(--bad-light)]',
+    dead: 'text-[var(--bad-light)]',
+    zombie: 'text-[var(--bad-light)]',
+    draining: 'text-[var(--color-status-warn)]',
+    paused: 'text-[var(--color-status-warn)]',
+    restarting: 'text-[var(--color-status-warn)]',
   }
   const color = phaseColor[snapshot.phase] ?? 'text-[var(--color-accent-fg)]'
   const heldFor = phaseSince != null ? fmtDuration(Math.max(0, now - phaseSince)) : null
-  const collapsedSource = snapshot.phase === 'Stable' ? snapshot.collapsed_from : null
+  // `collapsed_from` is set by the backend only when phase has collapsed onto
+  // a parent projection (e.g. a 7-phase composite Stable). The backend
+  // currently emits the raw 13-state phase via `phase_to_string` and does
+  // not emit a 'Stable' carrier (see KeeperCompositeLifecycle.tla:143 spec
+  // vs lib/keeper/keeper_composite_observer.ml:628 emit). Surface
+  // `collapsed_from` whenever it is present rather than gating on a phase
+  // string that the backend never produces.
+  const collapsedSource = snapshot.collapsed_from ?? null
   const collapsedSourceLabel = collapsedSource
     ? `${displayState(collapsedSource)} (${collapsedSource})`
     : null


### PR DESCRIPTION
## 요약

`snapshot.phase` 11개 PascalCase 비교가 production에서 silently false였습니다 — backend(`phase_to_string` lib/keeper/keeper_state_machine.ml:21-35)는 lowercase + snake_case를 emit하지만, dashboard 3개 컴포넌트는 PascalCase 리터럴과 비교했습니다. UI 분기(invariant analysis next-step, KSM hero color/description, fleet stale-cause)가 keeper의 실제 phase와 무관하게 항상 neutral default로 fallthrough되어 사용자에게 잘못된 정보를 보여주고 있었습니다.

## 측정된 근거

- Backend KSM emit: `lib/keeper/keeper_state_machine.ml:21-35` `phase_to_string` 13-state lowercase
  (`offline | running | failing | overflowed | compacting | handing_off | draining | paused | stopped | crashed | restarting | dead | zombie`).
- Composite 통과 경로: `lib/keeper/keeper_composite_observer.ml:628`
- Witness 코멘트: `dashboard/src/components/keeper-phase-strip.ts:15` — `Server sends lowercase (e.g. "running", "handing_off"); PHASE_STYLES uses PascalCase.`
- 'Stable' 7-phase projection: TLA spec(`KeeperCompositeLifecycle.tla:143`)에 선언, 그러나 OCaml emit 0건 (`rg '"Stable"' lib/` → 0 hits). 본 PR은 `collapsed_from` 존재 여부를 신호로 사용하도록 재구성.

## 변경

| 파일 | 변경 |
|------|------|
| `dashboard/src/components/fsm-hub-invariant-analysis.ts` | 11개 PascalCase compare → lowercase. `collapsed_from`을 carrier 신호로 재구성하여 phase-specific arms보다 우선 평가. Dead 'Stable' arms 제거. |
| `dashboard/src/components/fsm-hub-pipeline-panels.ts` | `STATE_DESCRIPTIONS` 13개 lowercase 키로 통합 (이전: PascalCase + lowercase 'fallback' 이중 코딩). `phaseColor` map lowercase 키. `collapsedSource`는 `snapshot.collapsed_from` 직접 읽음. |
| `dashboard/src/components/fleet-fsm-matrix.ts` | `staleCause` / `staleNextStep` PascalCase 비교 → lowercase. |
| `*.test.ts` | fixture를 backend wire format으로 정렬, mock↔mock 순환검증 패턴 해소. |

## 검증

- `pnpm typecheck` ✅ clean
- `pnpm vitest run src/components/fsm-hub-invariant-analysis.test.ts src/components/fsm-hub-pipeline-panels.test.ts src/components/fleet-fsm-matrix.test.ts` ✅ 88/88
- `rg "snapshot.phase.*'(Stable|Failing|Running|Compacting|HandingOff|Draining|Overflowed)'" dashboard/src/components/` → 0 hits

## 안티패턴 회피 (RFC-0088)

- ❌ case-insensitive comparator helper 추가 (workaround #2 string classifier)
- ❌ parse-time normalizer 추가 (§Symptom 억제 #4 Repair)
- ✅ wire format에 코드를 맞춤. Test fixture도 wire format으로 정렬해 mock↔mock loophole 닫음.

## Scope 외 (별도 RFC 후보)

1. **4중 normalizer 통합** — `keeper.phase` (flat field)는 `keeper-store-normalize.ts`, `monitoring-runtime.ts`, `keeper-state-diagram.ts`, `keeper-phase-strip.ts` 4곳에서 lowercase→PascalCase 정규화가 반복됨. RFC-0088 §Symptom 억제 #4 Repair 패턴의 4중 누적.
2. **`KeeperCompositePhaseSchema` closed-sum 강제** — 현재 `string()` raw. RFC-0042 closed-sum 적용 시 schema 단위에서 unknown phase가 컴파일 타임 에러로 surface.
3. **7-phase composite projection 결정** — backend가 Stable 발행하도록 구현 OR dashboard에서 `collapsed_from` 의미 제거.

## Related

- RFC-0046 §7 OOS (dashboard-side casing unification 영역)
- RFC-0088 (counter-as-fix avoidance, Repair 패턴 거부)
- RFC-0042 (closed-sum at boundary)
- Memory: `Test Mock: mock↔mock 순환검증` (production 불일치 못 잡는 mock 검증 패턴)

🤖 Generated with [Claude Code](https://claude.com/claude-code)