### PR TITLE
[codex] Fix dashboard stale execution receipt state

### DIFF
--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -122,6 +122,13 @@ const KeeperLastOutcomeSchema = object({
   selected_model: nullable(string()),
 })
 
+const KeeperLiveTurnSchema = object({
+  turn_id: number(),
+  started_at: number(),
+  last_progress_at: number(),
+  last_progress_kind: nullable(string()),
+})
+
 const KeeperCompositeExecutionSchema = object({
   latest_receipt_present: boolean(),
   recorded_at: nullable(string()),
@@ -181,6 +188,10 @@ const KeeperRuntimeAttentionSchema = object({
   raw_phase: nullable(string()),
   is_live: boolean(),
   source: string(),
+  execution_current: optional(boolean()),
+  stale_execution_receipt: optional(boolean()),
+  live_turn_started_at: optional(nullable(number())),
+  live_turn_last_progress_at: optional(nullable(number())),
 })
 
 const OperatorRecommendedActionSchema = object({
@@ -227,6 +238,7 @@ export const KeeperCompositeSnapshotSchema = object({
   fsm_guard_violations: number(),
   phase_diagnosis: optional(KeeperPhaseDiagnosisSchema),
   is_live: boolean(),
+  live_turn: optional(nullable(KeeperLiveTurnSchema)),
   last_outcome: nullable(KeeperLastOutcomeSchema),
   idle_seconds: optional(number()),
   last_turn_ts: optional(number()),

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -305,6 +305,56 @@ describe('runtimeAttentionForSnapshot', () => {
     expect(attention.reason).toContain('healthy idle')
   })
 
+  it('does not revive a previous terminal receipt while a live turn is running', () => {
+    const snap = snapshot({
+      is_live: true,
+      turn_phase: 'executing',
+      decision: { stage: 'tool_policy_selected' },
+      cascade: { state: 'trying' },
+      live_turn: {
+        turn_id: 42,
+        started_at: generatedAt - 30,
+        last_progress_at: generatedAt - 5,
+        last_progress_kind: 'provider_attempt_started',
+      },
+      execution: execution({
+        recorded_at: '2026-04-25T07:30:00Z',
+        outcome: 'receipt_failed',
+        terminal_reason_code: 'cascade_exhausted',
+        operator_disposition: 'alert_exhausted',
+        operator_disposition_reason: 'cascade_exhausted',
+        tool_contract_result: 'unknown',
+        error: {
+          kind: 'internal',
+          message_preview: 'cascade exhausted',
+          message_truncated: false,
+        },
+      }),
+      runtime_attention: {
+        state: 'ok',
+        needs_attention: false,
+        blocked: false,
+        fiber_stop_requested: false,
+        reason: null,
+        raw_phase: 'running',
+        is_live: true,
+        source: 'live_turn',
+        execution_current: false,
+        stale_execution_receipt: true,
+        live_turn_started_at: generatedAt - 30,
+        live_turn_last_progress_at: generatedAt - 5,
+      },
+    })
+
+    expect(latestRuntimeActivityEpoch(snap)).toBe(generatedAt - 5)
+    const attention = runtimeAttentionForSnapshot(snap, generatedAt)
+    expect(attention.level).toBe('ok')
+    expect(attention.label).toBe('live')
+    expect(attention.cause).toContain('live turn 관측 중')
+    expect(attention.title).toContain('receipt=previous_turn')
+    expect(attention.title).toContain('previous_terminal=cascade_exhausted')
+  })
+
   it('keeps raw lifecycle separate by flagging stale liveness without changing phase', () => {
     const snap = snapshot({
       is_live: false,

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -227,6 +227,11 @@ function parseEpochSeconds(value: string | null | undefined): number | null {
 
 export function latestRuntimeActivityEpoch(snapshot: KeeperCompositeSnapshot): number | null {
   const candidates: number[] = []
+  if (snapshot.live_turn?.last_progress_at != null) {
+    candidates.push(snapshot.live_turn.last_progress_at)
+  } else if (snapshot.live_turn?.started_at != null) {
+    candidates.push(snapshot.live_turn.started_at)
+  }
   if (snapshot.last_outcome?.ended_at != null) {
     candidates.push(snapshot.last_outcome.ended_at)
   }
@@ -236,6 +241,11 @@ export function latestRuntimeActivityEpoch(snapshot: KeeperCompositeSnapshot): n
   }
   if (candidates.length === 0) return null
   return Math.max(...candidates)
+}
+
+function hasPreviousTurnExecutionReceipt(snapshot: KeeperCompositeSnapshot): boolean {
+  return snapshot.runtime_attention?.stale_execution_receipt === true
+    || snapshot.runtime_attention?.execution_current === false
 }
 
 function formatAge(seconds: number | null): string {
@@ -260,18 +270,20 @@ function executionEvidence(snapshot: KeeperCompositeSnapshot): string[] {
   const execution = snapshot.execution
   const surface = execution?.tool_surface
   const parts: string[] = []
+  const previousReceipt = hasPreviousTurnExecutionReceipt(snapshot)
   if (!snapshot.is_live) parts.push('is_live=false')
+  if (previousReceipt) parts.push('receipt=previous_turn')
   if (execution?.operator_disposition) {
-    parts.push(`operator=${execution.operator_disposition}`)
+    parts.push(`${previousReceipt ? 'previous_' : ''}operator=${execution.operator_disposition}`)
   }
   if (execution?.operator_disposition_reason) {
-    parts.push(`reason=${execution.operator_disposition_reason}`)
+    parts.push(`${previousReceipt ? 'previous_' : ''}reason=${execution.operator_disposition_reason}`)
   }
   if (execution?.terminal_reason_code) {
-    parts.push(`terminal=${execution.terminal_reason_code}`)
+    parts.push(`${previousReceipt ? 'previous_' : ''}terminal=${execution.terminal_reason_code}`)
   }
   if (execution?.tool_contract_result) {
-    parts.push(`tool=${execution.tool_contract_result}`)
+    parts.push(`${previousReceipt ? 'previous_' : ''}tool=${execution.tool_contract_result}`)
   }
   if (surface?.tool_requirement) {
     parts.push(`tool_requirement=${surface.tool_requirement}`)
@@ -300,6 +312,7 @@ function executionEvidence(snapshot: KeeperCompositeSnapshot): string[] {
 function hasBlockingExecutionEvidence(snapshot: KeeperCompositeSnapshot): boolean {
   const execution = snapshot.execution
   if (!execution) return false
+  if (hasPreviousTurnExecutionReceipt(snapshot)) return false
   if (execution.operator_disposition === 'pause_human') return true
   if (execution.outcome === 'error') return true
   if (execution.terminal_reason_code && execution.terminal_reason_code !== 'completed') return true

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -762,6 +762,48 @@ describe('RuntimeLensSection', () => {
     expect(summary.rows.find(row => row.label === '차단')?.detail).toContain('needs_execution_progress')
   })
 
+  it('keeps previous receipt blockers out of the current live-turn summary', () => {
+    const summary = deriveKeeperLiveTruth({
+      keeper: {
+        name: 'sangsu',
+        status: 'active',
+        keepalive_running: true,
+        runtime_blocker_class: 'cascade_exhausted',
+        runtime_blocker_summary: 'previous turn exhausted cascade',
+      },
+      compositeSnapshot: compositeFixture({
+        is_live: true,
+        turn_phase: 'executing',
+        live_turn: {
+          turn_id: 8,
+          started_at: 1_778_688_690,
+          last_progress_at: 1_778_688_699,
+          last_progress_kind: 'provider_attempt_started',
+        },
+        runtime_attention: {
+          state: 'ok',
+          needs_attention: false,
+          blocked: false,
+          fiber_stop_requested: false,
+          reason: null,
+          raw_phase: 'running',
+          is_live: true,
+          source: 'live_turn',
+          execution_current: false,
+          stale_execution_receipt: true,
+          live_turn_started_at: 1_778_688_690,
+          live_turn_last_progress_at: 1_778_688_699,
+        },
+      }),
+      runtimeTrace: runtimeTraceFixture(),
+      runtimeResolution: null,
+    })
+
+    expect(summary.headline).toBe('턴 진행 중')
+    expect(summary.tone).toBe('ok')
+    expect(summary.rows.find(row => row.label === '차단')?.value).toBe('none')
+  })
+
   it('surfaces runtime resolution warnings in the live-truth summary', () => {
     const summary = deriveKeeperLiveTruth({
       keeper: {

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -185,10 +185,13 @@ export function deriveKeeperLiveTruth({
     ?? keeper.presence_keepalive
     ?? (linkedState !== 'offline')
   const activeTurn = compositeSnapshot?.is_live === true || !isIdleTurnPhase(compositeSnapshot?.turn_phase)
+  const previousExecutionReceipt =
+    compositeSnapshot?.runtime_attention?.stale_execution_receipt === true
+    || compositeSnapshot?.runtime_attention?.execution_current === false
   const blocked =
     compositeSnapshot?.runtime_attention?.blocked === true
     || compositeSnapshot?.runtime_attention?.needs_attention === true
-    || Boolean(keeper.runtime_blocker_class)
+    || (!previousExecutionReceipt && Boolean(keeper.runtime_blocker_class))
   const stopRequested =
     compositeSnapshot?.runtime_attention?.fiber_stop_requested === true
     || compositeSnapshot?.phase_diagnosis?.conditions.stop_requested === true

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -114,6 +114,13 @@ type last_outcome = {
   selected_model : string option;
 }
 
+type live_turn = {
+  turn_id : int;
+  started_at : float;
+  last_progress_at : float;
+  last_progress_kind : string option;
+}
+
 type snapshot = {
   keeper_name : string;
   correlation_id : string;
@@ -129,6 +136,7 @@ type snapshot = {
   invariants : invariants_check;
   conditions : Keeper_state_machine.conditions;
   is_live : bool;
+  live_turn : live_turn option;
   last_outcome : last_outcome option;
   fiber_stop_flag : bool;
   fiber_wakeup_flag : bool;
@@ -466,6 +474,17 @@ let observe
     invariants;
     conditions = entry.conditions;
     is_live;
+    live_turn =
+      (match entry.current_turn_observation with
+       | Some obs ->
+         Some
+           {
+             turn_id = obs.turn_id;
+             started_at = obs.started_at;
+             last_progress_at = obs.last_progress_at;
+             last_progress_kind = obs.last_progress_kind;
+           }
+       | None -> None);
     last_outcome =
       (match entry.last_completed_turn with
        | Some lc ->
@@ -654,6 +673,18 @@ let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
     "phase_diagnosis", phase_diagnosis_to_json
       ~current_phase:s.phase s.conditions;
     "is_live", `Bool s.is_live;
+    "live_turn", (match s.live_turn with
+      | Some live ->
+        `Assoc [
+          "turn_id", `Int live.turn_id;
+          "started_at", `Float live.started_at;
+          "last_progress_at", `Float live.last_progress_at;
+          "last_progress_kind",
+            (match live.last_progress_kind with
+             | Some kind -> `String kind
+             | None -> `Null);
+        ]
+      | None -> `Null);
     "last_outcome", (match s.last_outcome with
       | Some lo -> `Assoc [
           "turn_id", `Int lo.turn_id;

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -166,6 +166,20 @@ type last_outcome = {
   selected_model : string option;
 }
 
+(** Live turn timing, surfaced separately from [last_outcome] so dashboard
+    enrichers can tell whether a terminal receipt belongs to the current
+    turn or to a previous one. *)
+type live_turn = {
+  turn_id : int;
+  started_at : float;
+      (** Unix timestamp when the current turn observation was installed. *)
+  last_progress_at : float;
+      (** Unix timestamp of the most recent in-turn progress signal. *)
+  last_progress_kind : string option;
+      (** Low-cardinality label for the signal that refreshed
+          [last_progress_at]. *)
+}
+
 type snapshot = {
   keeper_name : string;
       (** Canonical keeper identity from the registry entry. This is separate
@@ -200,6 +214,10 @@ type snapshot = {
           actively executing and the live sub-FSM fields reflect its
           state. [false] indicates an idle keeper; sub-FSM fields
           revert to [Idle]/[Undecided]. *)
+  live_turn : live_turn option;
+      (** Current live turn timing. [Some _] iff [is_live = true]. This is
+          the causality boundary used by dashboard enrichers before treating
+          the latest terminal receipt as a current blocker. *)
   last_outcome : last_outcome option;
       (** Most recent completed turn, surfaced separately from live
           state so operators can see "what just finished" without

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -1065,6 +1065,11 @@ let json_string_eq key json expected =
 ;;
 
 let composite_latest_activity_epoch snapshot execution =
+  let live_turn_progress_epoch =
+    match json_member "live_turn" snapshot with
+    | `Assoc _ as live_turn -> json_number "last_progress_at" live_turn
+    | _ -> None
+  in
   let last_outcome_epoch =
     match json_member "last_outcome" snapshot with
     | `Assoc _ as last_outcome -> json_number "ended_at" last_outcome
@@ -1075,10 +1080,11 @@ let composite_latest_activity_epoch snapshot execution =
     | Some raw -> Masc_domain.parse_iso8601_opt raw
     | None -> None
   in
-  match last_outcome_epoch, receipt_epoch with
-  | Some a, Some b -> Some (max a b)
-  | Some value, None | None, Some value -> Some value
-  | None, None -> None
+  [ live_turn_progress_epoch; last_outcome_epoch; receipt_epoch ]
+  |> List.filter_map Fun.id
+  |> function
+  | [] -> None
+  | first :: rest -> Some (List.fold_left max first rest)
 ;;
 
 let composite_snapshot_is_idle snapshot =
@@ -1246,12 +1252,54 @@ let composite_execution_blocked execution =
   | _ -> false
 ;;
 
+let composite_execution_receipt_present execution =
+  Option.value ~default:false (json_bool "latest_receipt_present" execution)
+;;
+
+let composite_execution_receipt_epoch execution =
+  match json_string "recorded_at" execution with
+  | Some raw -> Masc_domain.parse_iso8601_opt raw
+  | None -> None
+;;
+
+let composite_live_turn_started_epoch snapshot =
+  match json_member "live_turn" snapshot with
+  | `Assoc _ as live_turn -> json_number "started_at" live_turn
+  | _ -> None
+;;
+
+let composite_live_turn_last_progress_epoch snapshot =
+  match json_member "live_turn" snapshot with
+  | `Assoc _ as live_turn -> json_number "last_progress_at" live_turn
+  | _ -> None
+;;
+
+let composite_execution_current_for_runtime_state ~snapshot ~execution =
+  if not (composite_execution_receipt_present execution)
+  then true
+  else (
+    let is_live = Option.value ~default:false (json_bool "is_live" snapshot) in
+    if not is_live
+    then true
+    else
+      match
+        ( composite_live_turn_started_epoch snapshot,
+          composite_execution_receipt_epoch execution )
+      with
+      | Some live_started_at, Some receipt_at -> receipt_at >= live_started_at
+      | _ -> false)
+;;
+
 type composite_runtime_attention =
   { cra_is_live : bool
   ; cra_fiber_stop_requested : bool
   ; cra_stale_long_enough : bool
   ; cra_idle_attention : bool
   ; cra_blocked : bool
+  ; cra_execution_current : bool
+  ; cra_stale_execution_receipt : bool
+  ; cra_live_turn_started_at : float option
+  ; cra_live_turn_last_progress_at : float option
   ; cra_stale_without_live_turn : bool
   ; cra_needs_attention : bool
   ; cra_reason : string option
@@ -1273,26 +1321,39 @@ let composite_runtime_attention ~snapshot ~execution =
   let idle_attention =
     is_live && composite_snapshot_is_idle snapshot && stale_long_enough
   in
-  let blocked = composite_execution_blocked execution in
+  let execution_current =
+    composite_execution_current_for_runtime_state ~snapshot ~execution
+  in
+  let stale_execution_receipt =
+    composite_execution_receipt_present execution && not execution_current
+  in
+  let blocked = execution_current && composite_execution_blocked execution in
   let stale_without_live_turn = (not is_live) && stale_long_enough in
   let needs_attention =
     blocked || fiber_stop_requested || stale_without_live_turn || idle_attention
   in
-  let reason =
-    if composite_execution_claim_no_eligible execution
+  let execution_reason =
+    if not execution_current
+    then None
+    else if composite_execution_claim_no_eligible execution
     then Some "claim_scope_no_eligible"
     else match json_string "operator_disposition_reason" execution with
     | Some value when String.trim value <> "" -> Some value
     | _ ->
       (match json_string "terminal_reason_code" execution with
        | Some value when String.trim value <> "" -> Some value
-       | _ when fiber_stop_requested -> Some "fiber_stop_requested"
-       | _ when idle_attention -> Some "idle_composite"
-       | _ when stale_without_live_turn -> Some "not_live"
        | _ when needs_attention && composite_execution_config_drift execution ->
          Some "keeper_cascade_override_drift"
        | _ when blocked -> Some "runtime_blocked"
        | _ -> None)
+  in
+  let reason =
+    match execution_reason with
+    | Some _ as reason -> reason
+    | None when fiber_stop_requested -> Some "fiber_stop_requested"
+    | None when idle_attention -> Some "idle_composite"
+    | None when stale_without_live_turn -> Some "not_live"
+    | None -> None
   in
   let state =
     if blocked
@@ -1310,6 +1371,10 @@ let composite_runtime_attention ~snapshot ~execution =
   ; cra_stale_long_enough = stale_long_enough
   ; cra_idle_attention = idle_attention
   ; cra_blocked = blocked
+  ; cra_execution_current = execution_current
+  ; cra_stale_execution_receipt = stale_execution_receipt
+  ; cra_live_turn_started_at = composite_live_turn_started_epoch snapshot
+  ; cra_live_turn_last_progress_at = composite_live_turn_last_progress_epoch snapshot
   ; cra_stale_without_live_turn = stale_without_live_turn
   ; cra_needs_attention = needs_attention
   ; cra_reason = reason
@@ -1326,10 +1391,18 @@ let composite_runtime_attention_json attention ~snapshot =
     ; "reason", Json_util.string_opt_to_json attention.cra_reason
     ; "raw_phase", Json_util.string_opt_to_json (json_string "phase" snapshot)
     ; "is_live", `Bool attention.cra_is_live
+    ; "execution_current", `Bool attention.cra_execution_current
+    ; "stale_execution_receipt", `Bool attention.cra_stale_execution_receipt
+    ; "live_turn_started_at",
+      Json_util.float_opt_to_json attention.cra_live_turn_started_at
+    ; "live_turn_last_progress_at",
+      Json_util.float_opt_to_json attention.cra_live_turn_last_progress_at
     ; ( "source"
       , `String
           (if attention.cra_blocked
            then "execution_receipt"
+           else if attention.cra_stale_execution_receipt
+           then "live_turn"
            else if attention.cra_fiber_stop_requested
            then "registry_fiber_stop"
            else "composite_snapshot") )

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -742,6 +742,8 @@ let append_execution_receipt
       Some Masc_mcp.Keeper_config.local_recovery_cascade_name)
     ?(fallback_reason = Some Masc_mcp.Keeper_error_classify.Turn_timeout)
     ?(required_tool_candidates = [])
+    ?started_at
+    ?ended_at
     config ~keeper_name =
   let meta =
     match Masc_mcp.Keeper_types.read_meta config keeper_name with
@@ -750,10 +752,14 @@ let append_execution_receipt
     | Error err -> fail ("read_meta failed for receipt: " ^ err)
   in
   let started_at =
-    iso_of_unix (Unix.gettimeofday () +. 2.0)
+    match started_at with
+    | Some value -> value
+    | None -> iso_of_unix (Unix.gettimeofday () +. 2.0)
   in
   let ended_at =
-    iso_of_unix (Unix.gettimeofday () +. 3.0)
+    match ended_at with
+    | Some value -> value
+    | None -> iso_of_unix (Unix.gettimeofday () +. 3.0)
   in
   let receipt : Masc_mcp.Keeper_execution_receipt.t =
     {
@@ -1782,6 +1788,79 @@ let test_composite_runtime_attention_surfaces_fiber_stop () =
            actions))
 ;;
 
+let test_composite_runtime_attention_ignores_previous_receipt_during_live_turn () =
+  let base_path = Filename.temp_file "dashboard-keeper-live-turn-receipt-" "" in
+  (try Sys.remove base_path with
+   | _ -> ());
+  Unix.mkdir base_path 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_registry.clear ();
+      rm_rf base_path)
+    (fun () ->
+      let keeper_name = "live_turn_previous_receipt_demo" in
+      let config = Masc_mcp.Coord.default_config base_path in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "bootstrap-admin"));
+      Fs_compat.mkdir_p (Masc_mcp.Keeper_types.keeper_dir config);
+      write_file
+        (Masc_mcp.Keeper_types.keeper_meta_path config keeper_name)
+        (make_keeper_meta_json ~name:keeper_name ~paused:false ());
+      let meta =
+        match Masc_mcp.Keeper_types.read_meta config keeper_name with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "keeper meta missing for live-turn receipt test"
+        | Error err -> fail ("read_meta failed: " ^ err)
+      in
+      ignore
+        (Masc_mcp.Keeper_registry.register
+           ~base_path:config.base_path keeper_name meta);
+      let receipt_started_at = iso_of_unix (Unix.gettimeofday () -. 120.0) in
+      let receipt_ended_at = iso_of_unix (Unix.gettimeofday () -. 60.0) in
+      append_execution_receipt
+        ~tool_contract_result:Contract_missing_required_tool_use
+        ~tools_used:[]
+        ~started_at:receipt_started_at
+        ~ended_at:receipt_ended_at
+        config
+        ~keeper_name;
+      Masc_mcp.Keeper_registry.mark_turn_started ~base_path:config.base_path
+        keeper_name;
+      Masc_mcp.Keeper_registry.mark_turn_provider_attempt_started
+        ~base_path:config.base_path keeper_name;
+      let entry =
+        match Masc_mcp.Keeper_registry.get ~base_path:config.base_path keeper_name with
+        | Some entry -> entry
+        | None -> fail "keeper registry entry missing after live turn start"
+      in
+      let open Yojson.Safe.Util in
+      let json =
+        Masc_mcp.Server_dashboard_http.dashboard_keeper_composite_json
+          ~config entry
+      in
+      check bool "live-turn fixture is live" true (json |> member "is_live" |> to_bool);
+      (match json |> member "live_turn" with
+       | `Assoc _ -> ()
+       | other ->
+         Alcotest.failf
+           "expected live_turn object, got %s"
+           (Yojson.Safe.to_string other));
+      let runtime_attention = json |> member "runtime_attention" in
+      check string "previous receipt does not block current turn" "ok"
+        (runtime_attention |> member "state" |> to_string);
+      check bool "previous receipt ignored for blocker" false
+        (runtime_attention |> member "blocked" |> to_bool);
+      check bool "previous receipt needs no action" false
+        (runtime_attention |> member "needs_attention" |> to_bool);
+      check bool "receipt is not current live-turn evidence" false
+        (runtime_attention |> member "execution_current" |> to_bool);
+      check bool "stale execution receipt surfaced" true
+        (runtime_attention |> member "stale_execution_receipt" |> to_bool);
+      check string "runtime source follows live turn" "live_turn"
+        (runtime_attention |> member "source" |> to_string);
+      check int "previous receipt creates no runtime actions" 0
+        (json |> member "recommended_actions" |> to_list |> List.length))
+;;
+
 let with_fleet_work_discovery_fixture f =
   let base_path = Filename.temp_file "dashboard-fleet-work-discovery-" "" in
   (try Sys.remove base_path with
@@ -2185,6 +2264,10 @@ let () =
             "composite runtime attention surfaces fiber stop"
             `Quick
             test_composite_runtime_attention_surfaces_fiber_stop
+        ; test_case
+            "composite runtime attention ignores previous receipt during live turn"
+            `Quick
+            test_composite_runtime_attention_ignores_previous_receipt_during_live_turn
         ; test_case
             "fleet composite surfaces no work-discovery keeper"
             `Quick


### PR DESCRIPTION
## Summary
- expose live-turn timing in keeper composite snapshots
- classify execution receipts as current vs stale relative to the active live turn
- prevent dashboard fallback code from showing previous-turn terminal receipts as current blockers

## Root Cause
Agent Observatory mixed two different truth horizons: the current live turn could report `running` while the latest persisted execution receipt still carried a previous-turn terminal state such as `cascade_exhausted`. The backend runtime attention path treated that receipt as current without a live-turn causality boundary, and frontend fallbacks could re-block from the same stale receipt.

## Validation
- `git diff --check`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/fleet-fsm-matrix.test.ts src/components/keeper-detail-runtime.test.ts src/api/schemas/keeper-composite.test.ts`

## Not Run
- `scripts/dune-local.sh build test/test_dashboard_keeper_routes.exe` could not complete because `/tmp/me-dune-local.lock` was held by another live Dune wrapper process from `fix-bash-alias-cwd-recovery-20260519`. I did not bypass the guard or kill the external process.