### PR TITLE
refactor: split keeper bash safe-read fallback

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -141,6 +141,7 @@
    keeper_shell_bash_task_state
    keeper_shell_bash_shape_messages
    keeper_shell_bash_shape_ir
+   keeper_shell_bash_safe_read
    keeper_shell_bash
    keeper_shell_ops
    keeper_exec_shell

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -1,6 +1,7 @@
 open Keeper_types
 open Keeper_exec_shared
 open Keeper_shell_bash_redirects
+open Keeper_shell_bash_safe_read
 open Keeper_shell_bash_shape_ir
 open Keeper_shell_bash_shape_messages
 open Keeper_shell_bash_task_state
@@ -241,141 +242,6 @@ let keeper_bash_shape_block cmd =
   | Masc_exec.Parsed.Parse_aborted _
   | Masc_exec.Parsed.Too_complex _ ->
     raw_keeper_bash_shape_block cmd
-
-type safe_read_fallback = {
-  primary_cmd : string;
-}
-
-let safe_read_primary_rewrite primary_cmd =
-  match keeper_bash_shape_block primary_cmd with
-  | Some _ -> None
-  | None ->
-    if Worker_dev_tools.is_write_operation primary_cmd
-    then None
-    else (
-      match
-        Worker_dev_tools.validate_command_coding_with_allowlist
-          ~allow_pipes:false
-          ~allowed_commands:Worker_dev_tools.dev_allowed_commands
-          primary_cmd
-      with
-      | Ok () -> Some { primary_cmd }
-      | Error _ -> None)
-
-let find_unquoted_logic_or cmd =
-  let len = String.length cmd in
-  let rec loop quote_state escaped i =
-    if i + 1 >= len
-    then None
-    else if escaped
-    then loop quote_state false (i + 1)
-    else (
-      match quote_state, cmd.[i] with
-      | Single_quote, '\'' -> loop No_quote false (i + 1)
-      | Single_quote, _ -> loop Single_quote false (i + 1)
-      | Double_quote, '"' -> loop No_quote false (i + 1)
-      | Double_quote, '\\' -> loop Double_quote true (i + 1)
-      | Double_quote, _ -> loop Double_quote false (i + 1)
-      | No_quote, '\'' -> loop Single_quote false (i + 1)
-      | No_quote, '"' -> loop Double_quote false (i + 1)
-      | No_quote, '\\' -> loop No_quote true (i + 1)
-      | No_quote, '|' when Char.equal cmd.[i + 1] '|' -> Some i
-      | No_quote, _ -> loop No_quote false (i + 1))
-  in
-  loop No_quote false 0
-
-let strip_suffix_ci text suffix =
-  let text_len = String.length text in
-  let suffix_len = String.length suffix in
-  if suffix_len > text_len
-  then None
-  else (
-    let tail = String.sub text (text_len - suffix_len) suffix_len in
-    if String.equal (String.lowercase_ascii tail) suffix
-    then Some (String.sub text 0 (text_len - suffix_len) |> String.trim)
-    else None)
-
-let strip_trailing_dev_null_redirect cmd =
-  let cmd = String.trim cmd in
-  [
-    "2>/dev/null";
-    "1>/dev/null";
-    ">/dev/null";
-    "2>>/dev/null";
-    "1>>/dev/null";
-    ">>/dev/null";
-    "2> /dev/null";
-    "1> /dev/null";
-    "> /dev/null";
-    "2>> /dev/null";
-    "1>> /dev/null";
-    ">> /dev/null";
-  ]
-  |> List.find_map (strip_suffix_ci cmd)
-  |> function
-  | Some primary when not (String.equal primary "") -> Some primary
-  | Some _ | None -> None
-
-let literal_echo_is_safe text =
-  match Masc_exec_bash_parser.Bash.parse_string text with
-  | Masc_exec.Parsed.Parsed (Masc_exec.Shell_ir.Simple simple)
-    when simple.env = []
-         && simple.redirects = []
-         && Option.is_none simple.cwd
-         && String.equal (Masc_exec.Bin.to_string simple.bin) "echo" ->
-    let rec literal_arg_text = function
-      | Masc_exec.Shell_ir.Lit arg -> Some arg
-      | Masc_exec.Shell_ir.Concat parts ->
-        let rec loop acc = function
-          | [] -> Some (String.concat "" (List.rev acc))
-          | part :: rest ->
-            (match literal_arg_text part with
-             | Some text -> loop (text :: acc) rest
-             | None -> None)
-        in
-        loop [] parts
-      | Masc_exec.Shell_ir.Var _ -> None
-    in
-    let rec loop = function
-      | [] -> true
-      | arg :: rest ->
-        (match literal_arg_text arg with
-         | Some text -> (not (String.starts_with ~prefix:"-" text)) && loop rest
-         | None -> false)
-    in
-    loop simple.args
-  | _ -> false
-
-let safe_read_or_echo_fallback_of_command cmd =
-  match find_unquoted_logic_or cmd with
-  | None -> None
-  | Some split ->
-    let left = String.sub cmd 0 split in
-    let right =
-      String.sub cmd (split + 2) (String.length cmd - split - 2) |> String.trim
-    in
-    if not (literal_echo_is_safe right)
-    then None
-    else
-      let primary_cmd =
-        match strip_trailing_dev_null_redirect left with
-        | Some primary -> Some primary
-        | None ->
-          let primary = String.trim left in
-          if String.equal primary "" then None else Some primary
-      in
-      Option.bind primary_cmd safe_read_primary_rewrite
-
-let safe_read_fallback_of_command ~write_enabled:_ ~stderr_dev_null_stripped cmd =
-  match safe_read_or_echo_fallback_of_command cmd with
-  | Some _ as rewrite -> rewrite
-  | None ->
-    (match strip_trailing_dev_null_redirect cmd with
-     | Some primary_cmd -> safe_read_primary_rewrite primary_cmd
-     | None ->
-       if stderr_dev_null_stripped
-       then safe_read_primary_rewrite cmd
-       else None)
 
 let shape_block_allowed_by_active_validator ~write_enabled cmd = function
   | Pipe_or_redirect when write_enabled ->
@@ -930,7 +796,9 @@ let handle_keeper_bash
       Masc_exec.Risk_classifier.(is_cacheable (classify cmd))
     in
     let safe_read_fallback =
-      safe_read_fallback_of_command ~write_enabled
+      Keeper_shell_bash_safe_read.of_command
+        ~shape_block_of_command:keeper_bash_shape_block
+        ~write_enabled
         ~stderr_dev_null_stripped:stripped_stderr_dev_null cmd
     in
     let validation_cmd =

--- a/lib/keeper/keeper_shell_bash_safe_read.ml
+++ b/lib/keeper/keeper_shell_bash_safe_read.ml
@@ -1,0 +1,136 @@
+open Keeper_shell_bash_words
+
+type t = {
+  primary_cmd : string;
+}
+
+let primary_rewrite ~shape_block_of_command primary_cmd =
+  match shape_block_of_command primary_cmd with
+  | Some _ -> None
+  | None ->
+    if Worker_dev_tools.is_write_operation primary_cmd
+    then None
+    else (
+      match
+        Worker_dev_tools.validate_command_coding_with_allowlist
+          ~allow_pipes:false
+          ~allowed_commands:Worker_dev_tools.dev_allowed_commands
+          primary_cmd
+      with
+      | Ok () -> Some { primary_cmd }
+      | Error _ -> None)
+
+let find_unquoted_logic_or cmd =
+  let len = String.length cmd in
+  let rec loop quote_state escaped i =
+    if i + 1 >= len
+    then None
+    else if escaped
+    then loop quote_state false (i + 1)
+    else (
+      match quote_state, cmd.[i] with
+      | Single_quote, '\'' -> loop No_quote false (i + 1)
+      | Single_quote, _ -> loop Single_quote false (i + 1)
+      | Double_quote, '"' -> loop No_quote false (i + 1)
+      | Double_quote, '\\' -> loop Double_quote true (i + 1)
+      | Double_quote, _ -> loop Double_quote false (i + 1)
+      | No_quote, '\'' -> loop Single_quote false (i + 1)
+      | No_quote, '"' -> loop Double_quote false (i + 1)
+      | No_quote, '\\' -> loop No_quote true (i + 1)
+      | No_quote, '|' when Char.equal cmd.[i + 1] '|' -> Some i
+      | No_quote, _ -> loop No_quote false (i + 1))
+  in
+  loop No_quote false 0
+
+let strip_suffix_ci text suffix =
+  let text_len = String.length text in
+  let suffix_len = String.length suffix in
+  if suffix_len > text_len
+  then None
+  else (
+    let tail = String.sub text (text_len - suffix_len) suffix_len in
+    if String.equal (String.lowercase_ascii tail) suffix
+    then Some (String.sub text 0 (text_len - suffix_len) |> String.trim)
+    else None)
+
+let strip_trailing_dev_null_redirect cmd =
+  let cmd = String.trim cmd in
+  [
+    "2>/dev/null";
+    "1>/dev/null";
+    ">/dev/null";
+    "2>>/dev/null";
+    "1>>/dev/null";
+    ">>/dev/null";
+    "2> /dev/null";
+    "1> /dev/null";
+    "> /dev/null";
+    "2>> /dev/null";
+    "1>> /dev/null";
+    ">> /dev/null";
+  ]
+  |> List.find_map (strip_suffix_ci cmd)
+  |> function
+  | Some primary when not (String.equal primary "") -> Some primary
+  | Some _ | None -> None
+
+let literal_echo_is_safe text =
+  match Masc_exec_bash_parser.Bash.parse_string text with
+  | Masc_exec.Parsed.Parsed (Masc_exec.Shell_ir.Simple simple)
+    when simple.env = []
+         && simple.redirects = []
+         && Option.is_none simple.cwd
+         && String.equal (Masc_exec.Bin.to_string simple.bin) "echo" ->
+    let rec literal_arg_text = function
+      | Masc_exec.Shell_ir.Lit arg -> Some arg
+      | Masc_exec.Shell_ir.Concat parts ->
+        let rec loop acc = function
+          | [] -> Some (String.concat "" (List.rev acc))
+          | part :: rest ->
+            (match literal_arg_text part with
+             | Some text -> loop (text :: acc) rest
+             | None -> None)
+        in
+        loop [] parts
+      | Masc_exec.Shell_ir.Var _ -> None
+    in
+    let rec loop = function
+      | [] -> true
+      | arg :: rest ->
+        (match literal_arg_text arg with
+         | Some text -> (not (String.starts_with ~prefix:"-" text)) && loop rest
+         | None -> false)
+    in
+    loop simple.args
+  | _ -> false
+
+let or_echo_fallback_of_command ~shape_block_of_command cmd =
+  match find_unquoted_logic_or cmd with
+  | None -> None
+  | Some split ->
+    let left = String.sub cmd 0 split in
+    let right =
+      String.sub cmd (split + 2) (String.length cmd - split - 2) |> String.trim
+    in
+    if not (literal_echo_is_safe right)
+    then None
+    else
+      let primary_cmd =
+        match strip_trailing_dev_null_redirect left with
+        | Some primary -> Some primary
+        | None ->
+          let primary = String.trim left in
+          if String.equal primary "" then None else Some primary
+      in
+      Option.bind primary_cmd (primary_rewrite ~shape_block_of_command)
+
+let of_command ~shape_block_of_command ~write_enabled:_ ~stderr_dev_null_stripped cmd =
+  match or_echo_fallback_of_command ~shape_block_of_command cmd with
+  | Some _ as rewrite -> rewrite
+  | None ->
+    (match strip_trailing_dev_null_redirect cmd with
+     | Some primary_cmd -> primary_rewrite ~shape_block_of_command primary_cmd
+     | None ->
+       if stderr_dev_null_stripped
+       then primary_rewrite ~shape_block_of_command cmd
+       else None)

--- a/lib/keeper/keeper_shell_bash_safe_read.mli
+++ b/lib/keeper/keeper_shell_bash_safe_read.mli
@@ -1,0 +1,10 @@
+type t = {
+  primary_cmd : string;
+}
+
+val of_command :
+  shape_block_of_command:(string -> 'block option) ->
+  write_enabled:bool ->
+  stderr_dev_null_stripped:bool ->
+  string ->
+  t option


### PR DESCRIPTION
## Summary
- stack on #16310 / codex/godfile-zero-55-bash-shell-ir-classifier
- split safe-read compatibility fallback handling into Keeper_shell_bash_safe_read
- keep shape classification injected as a callback, avoiding a module cycle with the Shell IR classifier path
- reduce lib/keeper/keeper_shell_bash.ml from 1620 to 1488 LOC

## Shell IR note
This separates the legacy raw fallback path from the Shell IR classifier seam added in #16310. The remaining keeper_bash flow can now distinguish IR-first classification from compatibility rewrites more clearly.

## Verification
- ocamlformat --check lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_shell_bash_safe_read.ml lib/keeper/keeper_shell_bash_safe_read.mli and the existing split keeper_bash helper modules
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh

Focused Dune verification was attempted with scripts/dune-local.sh build lib/masc_mcp.cmxa, but the wrapper waited behind another @check lock; I stopped only this wait to avoid slowing the stacked PR flow.